### PR TITLE
proptypes / typescript

### DIFF
--- a/packages/components/src/components/buttons/Button/index.tsx
+++ b/packages/components/src/components/buttons/Button/index.tsx
@@ -198,7 +198,7 @@ const IconWrapper = styled.div`
 // TODO: Error messages are not helpful. Find a better way to extend html button props.
 interface Props extends React.ButtonHTMLAttributes<HTMLButtonElement> {
     additionalClassName?: string;
-    variant: 'success' | 'info' | 'warning' | 'error';
+    variant?: 'success' | 'info' | 'warning' | 'error';
     isDisabled?: boolean;
     isInverse?: boolean;
     isWhite?: boolean;


### PR DESCRIPTION
I have just started consuming typed version of components in onboarding project. There are probably some inconsistencies between proptypes and typescript. For example variant is required by typescript, but is not required by proptypes. How to solve it?