### PR TITLE
add platform to reducer

### DIFF
--- a/packages/suite/src/reducers/suite/suite.ts
+++ b/packages/suite/src/reducers/suite/suite.ts
@@ -12,6 +12,7 @@ interface SuiteState {
     messages: { [key: string]: any };
     deviceMenuOpened: boolean;
     showSidebar?: boolean;
+    platform?: Platform;
 }
 
 interface Transport {
@@ -23,6 +24,14 @@ interface Transport {
         packages: [];
         changelog: [];
     };
+}
+
+interface Platform {
+    mobile: boolean | undefined; // todo: there is maybe a bug in connect, mobile shouldnt be undefined imho
+    name: string;
+    osname: string;
+    outdated: boolean;
+    supported: boolean;
 }
 
 const initialState: SuiteState = {
@@ -87,6 +96,11 @@ export default (state: SuiteState = initialState, action: Action): SuiteState =>
             return {
                 ...state,
                 showSidebar: !state.showSidebar,
+            };
+        case 'iframe-loaded':
+            return {
+                ...state,
+                platform: action.payload.browser,
             };
         default:
             return state;


### PR DESCRIPTION
We are going to need information about clients platform in suite.
Good thing is, it is already provided by connect, so I have just added it to the suite reducer for now.

