### PR TITLE
Coin selection in dashboard, Fixed routes/links

### DIFF
--- a/packages/suite/src/actions/suite/routerActions.ts
+++ b/packages/suite/src/actions/suite/routerActions.ts
@@ -5,7 +5,7 @@
 
 import Router from 'next/router';
 import { Dispatch, GetState } from '@suite-types/index';
-import { getPrefixedURL } from '@suite-utils/nextjs';
+import { getPrefixedURL } from '@suite-utils/router';
 
 export const LOCATION_CHANGE = '@router/location-change';
 export const UPDATE = '@router/update';

--- a/packages/suite/src/components/suite/Link/index.tsx
+++ b/packages/suite/src/components/suite/Link/index.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import NextLink, { LinkProps } from 'next/link';
 import { Link as TLink } from '@trezor/components';
-import { getPrefixedURL, isInternalRoute } from '@suite-utils/nextjs';
+import { getPrefixedURL, isInternalRoute } from '@suite-utils/router';
 
 interface Props extends LinkProps {
     className?: string;

--- a/packages/suite/src/components/suite/Link/index.tsx
+++ b/packages/suite/src/components/suite/Link/index.tsx
@@ -1,9 +1,14 @@
 import React from 'react';
 import NextLink, { LinkProps } from 'next/link';
+import { Link as TLink } from '@trezor/components';
 import { routes } from '@suite-utils/router';
 import { getPrefixedURL } from '@suite-utils/nextjs';
 
-const Link = ({ children, href, ...rest }: LinkProps) => {
+interface Props extends LinkProps {
+    className?: string;
+}
+
+const Link = ({ children, href, className, ...rest }: Props) => {
     // if href prop refers to internal url puts assetPrefix in front and
     // pass the prefixed value in 'as' prop to prevent refreshing the page
     const isInternalLink = routes.find(r => r.pattern === href) || false;
@@ -12,8 +17,10 @@ const Link = ({ children, href, ...rest }: LinkProps) => {
     };
 
     return (
-        <NextLink href={href} {...overrideAsProp} {...rest}>
-            {children}
+        <NextLink href={href} passHref {...overrideAsProp} {...rest}>
+            <TLink target="_self" {...rest} className={className}>
+                {children}
+            </TLink>
         </NextLink>
     );
 };

--- a/packages/suite/src/components/suite/Link/index.tsx
+++ b/packages/suite/src/components/suite/Link/index.tsx
@@ -6,9 +6,12 @@ import { getPrefixedURL } from '@suite-utils/nextjs';
 
 interface Props extends LinkProps {
     className?: string;
+    isGray?: boolean;
+    isGreen?: boolean;
+    target?: string;
 }
 
-const Link = ({ children, href, className, ...rest }: Props) => {
+const Link = ({ children, href, className, target = '_self', ...rest }: Props) => {
     // if href prop refers to internal url puts assetPrefix in front and
     // pass the prefixed value in 'as' prop to prevent refreshing the page
     const isInternalLink = routes.find(r => r.pattern === href) || false;
@@ -16,9 +19,19 @@ const Link = ({ children, href, className, ...rest }: Props) => {
         ...(isInternalLink && typeof href === 'string' ? { as: getPrefixedURL(href) } : {}),
     };
 
+    const { prefetch, shallow, scroll, replace, onError, ...linkProps } = rest;
+
     return (
-        <NextLink href={href} passHref {...overrideAsProp} {...rest}>
-            <TLink target="_self" {...rest} className={className}>
+        <NextLink
+            href={href}
+            prefetch={prefetch}
+            scroll={scroll}
+            shallow={shallow}
+            replace={replace}
+            passHref
+            {...overrideAsProp}
+        >
+            <TLink target={target} {...linkProps} className={className}>
                 {children}
             </TLink>
         </NextLink>

--- a/packages/suite/src/components/suite/Link/index.tsx
+++ b/packages/suite/src/components/suite/Link/index.tsx
@@ -11,9 +11,11 @@ interface Props extends LinkProps {
 }
 
 const Link = ({ children, href, className, target = '_self', ...rest }: Props) => {
-    // if href prop refers to internal url puts assetPrefix in front and
-    // pass the prefixed value in 'as' prop to prevent refreshing the page
-    // TODO: handle UrlObject, Url type of href
+    /*  
+        if href prop refers to internal url puts assetPrefix in front and
+        pass the prefixed value in 'as' prop to prevent refreshing the page
+        TODO: handle UrlObject, Url type of href
+    */
     const isInternalLink = typeof href === 'string' ? isInternalRoute(href) : false;
     const overrideAsProp = {
         ...(isInternalLink && typeof href === 'string' ? { as: getPrefixedURL(href) } : {}),

--- a/packages/suite/src/components/suite/Link/index.tsx
+++ b/packages/suite/src/components/suite/Link/index.tsx
@@ -1,8 +1,7 @@
 import React from 'react';
 import NextLink, { LinkProps } from 'next/link';
 import { Link as TLink } from '@trezor/components';
-import { routes } from '@suite-utils/router';
-import { getPrefixedURL } from '@suite-utils/nextjs';
+import { getPrefixedURL, isInternalRoute } from '@suite-utils/nextjs';
 
 interface Props extends LinkProps {
     className?: string;
@@ -14,7 +13,8 @@ interface Props extends LinkProps {
 const Link = ({ children, href, className, target = '_self', ...rest }: Props) => {
     // if href prop refers to internal url puts assetPrefix in front and
     // pass the prefixed value in 'as' prop to prevent refreshing the page
-    const isInternalLink = routes.find(r => r.pattern === href) || false;
+    // TODO: handle UrlObject, Url type of href
+    const isInternalLink = typeof href === 'string' ? isInternalRoute(href) : false;
     const overrideAsProp = {
         ...(isInternalLink && typeof href === 'string' ? { as: getPrefixedURL(href) } : {}),
     };

--- a/packages/suite/src/components/wallet/CoinMenu/index.tsx
+++ b/packages/suite/src/components/wallet/CoinMenu/index.tsx
@@ -139,7 +139,10 @@ class CoinMenu extends PureComponent<Props> {
                     .map(item => (
                         <StyledLink
                             key={item.shortcut}
-                            href={`/wallet/account/#/${item.shortcut}/0`}
+                            href={getRoute('wallet-account', {
+                                coin: item.shortcut,
+                                accountId: '0',
+                            })}
                         >
                             <RowCoin
                                 network={{

--- a/packages/suite/src/components/wallet/CoinMenu/index.tsx
+++ b/packages/suite/src/components/wallet/CoinMenu/index.tsx
@@ -8,7 +8,6 @@ import { FormattedMessage } from 'react-intl';
 import l10nCommonMessages from '@suite-views/index.messages';
 import networks from '@suite-config/networks';
 import externalCoins from '@suite-config/externalCoins';
-import { goto } from '@suite/actions/suite/routerActions';
 import { getRoute } from '@suite/utils/suite/router';
 import Divider from '../Divider';
 import RowCoin from '../RowCoin';

--- a/packages/suite/src/components/wallet/CoinMenu/index.tsx
+++ b/packages/suite/src/components/wallet/CoinMenu/index.tsx
@@ -2,12 +2,14 @@ import React, { PureComponent } from 'react';
 import { connect } from 'react-redux';
 import styled from 'styled-components';
 import { State } from '@suite-types/index';
-import { Link, colors, icons as ICONS } from '@trezor/components';
+import { colors, icons as ICONS } from '@trezor/components';
+import Link from '@suite-components/Link';
 import { FormattedMessage } from 'react-intl';
 import l10nCommonMessages from '@suite-views/index.messages';
 import networks from '@suite-config/networks';
 import externalCoins from '@suite-config/externalCoins';
 import { goto } from '@suite/actions/suite/routerActions';
+import { getRoute } from '@suite/utils/suite/router';
 import Divider from '../Divider';
 import RowCoin from '../RowCoin';
 import l10nMessages from './index.messages';
@@ -31,10 +33,6 @@ const Empty = styled.span`
     justify-content: center;
     align-items: center;
     min-height: 50px;
-`;
-
-const StyledLinkEmpty = styled(Link)`
-    padding: 0;
 `;
 
 const Gray = styled.span`
@@ -93,11 +91,11 @@ class CoinMenu extends PureComponent<Props> {
                         {...l10nMessages.TR_SELECT_COINS}
                         values={{
                             TR_SELECT_COINS_LINK: (
-                                <StyledLinkEmpty to="/settings">
+                                <Link href={getRoute('wallet-settings')}>
                                     <FormattedMessage
                                         {...l10nCommonMessages.TR_SELECT_COINS_LINK}
                                     />
-                                </StyledLinkEmpty>
+                                </Link>
                             ),
                         }}
                     />{' '}
@@ -142,7 +140,7 @@ class CoinMenu extends PureComponent<Props> {
                     .map(item => (
                         <StyledLink
                             key={item.shortcut}
-                            onClick={() => goto(`/wallet/account#/${item.shortcut}/0`)}
+                            href={`/wallet/account#/${item.shortcut}/0`}
                         >
                             <RowCoin
                                 network={{

--- a/packages/suite/src/components/wallet/CoinMenu/index.tsx
+++ b/packages/suite/src/components/wallet/CoinMenu/index.tsx
@@ -139,7 +139,7 @@ class CoinMenu extends PureComponent<Props> {
                     .map(item => (
                         <StyledLink
                             key={item.shortcut}
-                            href={`/wallet/account#/${item.shortcut}/0`}
+                            href={`/wallet/account/#/${item.shortcut}/0`}
                         >
                             <RowCoin
                                 network={{

--- a/packages/suite/src/components/wallet/TopNavigation/index.tsx
+++ b/packages/suite/src/components/wallet/TopNavigation/index.tsx
@@ -4,7 +4,7 @@ import styled from 'styled-components';
 import { colors, variables } from '@trezor/components';
 import { State } from '@suite-types/index';
 import { goto } from '@suite-actions/routerActions';
-import { getPrefixedURL } from '@suite-utils/nextjs';
+import { getPrefixedURL } from '@suite-utils/router';
 
 const { FONT_WEIGHT, FONT_SIZE, SCREEN_SIZE } = variables;
 

--- a/packages/suite/src/components/wallet/TopNavigation/index.tsx
+++ b/packages/suite/src/components/wallet/TopNavigation/index.tsx
@@ -84,10 +84,7 @@ interface Props {
 
 const TopNavigation = (props: Props) => {
     const { pathname, params } = props.router;
-    const currentPath =
-        pathname[pathname.length - 1] === '/'
-            ? pathname.substring(0, pathname.length - 1)
-            : pathname;
+    const currentPath = pathname;
 
     return (
         <Wrapper>

--- a/packages/suite/src/utils/suite/nextjs.ts
+++ b/packages/suite/src/utils/suite/nextjs.ts
@@ -1,5 +1,4 @@
 import { join } from 'path';
-import { routes } from '@suite-utils/router';
 
 export const resolveStaticPath = (path: string) => {
     const staticPath = join('/static', path);
@@ -9,27 +8,4 @@ export const resolveStaticPath = (path: string) => {
     }
 
     return staticPath;
-};
-
-export const getPrefixedURL = (url: string) => {
-    const urlPrefix = process.env.assetPrefix || '';
-    return urlPrefix + url;
-};
-
-export const toInternalRoute = (url: string) => {
-    try {
-        // chars before # belong to the first group, # and chars after to the optional second group
-        // eg. https://suite.corp.sldev.cz/wallet/account/#/eth/0 will be splitted to
-        // 'https://suite.corp.sldev.cz/wallet/account/' and '#/eth/0'
-        const tokens = url.match(/([^#]*)(#.*)?/);
-        const group1 = tokens ? tokens[1] : url;
-        return group1;
-    } catch (error) {
-        console.error(error);
-        return url;
-    }
-};
-
-export const isInternalRoute = (url: string) => {
-    return routes.find(r => r.pattern === toInternalRoute(url)) || false;
 };

--- a/packages/suite/src/utils/suite/nextjs.ts
+++ b/packages/suite/src/utils/suite/nextjs.ts
@@ -23,10 +23,7 @@ export const toInternalRoute = (url: string) => {
         // 'https://suite.corp.sldev.cz/wallet/account/' and '#/eth/0'
         const tokens = url.match(/([^#]*)(#.*)?/);
         const group1 = tokens ? tokens[1] : url;
-        // strip trailing slash
-        const lastCharPos = group1.length - 1;
-        const stripped = group1[lastCharPos] === '/' ? group1.substring(0, lastCharPos) : group1;
-        return stripped;
+        return group1;
     } catch (error) {
         console.error(error);
         return url;

--- a/packages/suite/src/utils/suite/nextjs.ts
+++ b/packages/suite/src/utils/suite/nextjs.ts
@@ -1,4 +1,5 @@
 import { join } from 'path';
+import { routes } from '@suite-utils/router';
 
 export const resolveStaticPath = (path: string) => {
     const staticPath = join('/static', path);
@@ -13,4 +14,25 @@ export const resolveStaticPath = (path: string) => {
 export const getPrefixedURL = (url: string) => {
     const urlPrefix = process.env.assetPrefix || '';
     return urlPrefix + url;
+};
+
+export const toInternalRoute = (url: string) => {
+    try {
+        // chars before # belong to the first group, # and chars after to the optional second group
+        // eg. https://suite.corp.sldev.cz/wallet/account/#/eth/0 will be splitted to
+        // 'https://suite.corp.sldev.cz/wallet/account/' and '#/eth/0'
+        const tokens = url.match(/([^#]*)(#.*)?/);
+        const group1 = tokens ? tokens[1] : url;
+        // strip trailing slash
+        const lastCharPos = group1.length - 1;
+        const stripped = group1[lastCharPos] === '/' ? group1.substring(0, lastCharPos) : group1;
+        return stripped;
+    } catch (error) {
+        console.error(error);
+        return url;
+    }
+};
+
+export const isInternalRoute = (url: string) => {
+    return routes.find(r => r.pattern === toInternalRoute(url)) || false;
 };

--- a/packages/suite/src/utils/suite/router.ts
+++ b/packages/suite/src/utils/suite/router.ts
@@ -47,6 +47,8 @@ export const routes: Route[] = [
     },
 ];
 
+const PARAMS = ['coin', 'accountId'];
+
 export const getApp = (url: string) => {
     if (url === '/' || url.indexOf('/wallet') === 0) return 'wallet';
     if (url.indexOf('/onboarding') === 0) return 'onboarding';
@@ -60,18 +62,27 @@ export const getParams = (url: string) => {
     const parts = split[1].substr(1, split[1].length).split('/');
 
     const params: { [key: string]: string } = {};
-    ['coin', 'accountId'].forEach((key, index) => {
+    PARAMS.forEach((key, index) => {
         params[key] = parts[index];
     });
     return params;
 };
 
-export const getRoute = (name: string): string => {
+export const getRoute = (name: string, params?: { [key: string]: string }) => {
     const entry = routes.find(r => r.name === name);
     if (!entry) {
         // eslint-disable-next-line no-console
         console.error(`Route for ${name} not found`);
         return '/';
+    }
+
+    // attach params
+    if (params && params !== {}) {
+        let paramsString = '';
+        PARAMS.forEach(key => {
+            paramsString = `${paramsString}/${params[key]}`;
+        });
+        return `${entry.pattern}#${paramsString}`;
     }
     return entry.pattern;
 };
@@ -84,17 +95,17 @@ export const getPrefixedURL = (url: string) => {
 };
 
 // Strips params delimited by a hashtag from the URL
-export const toInternalRoute = (url: string) => {
+export const toInternalRoute = (route: string) => {
     // chars before # belong to the first group, # and chars after to the optional second group
     // eg. https://suite.corp.sldev.cz/wallet/account/#/eth/0 will be splitted to
     // 'https://suite.corp.sldev.cz/wallet/account/' and '#/eth/0'
     try {
-        const tokens = url.match(/([^#]*)(#.*)?/);
-        const group1 = tokens ? tokens[1] : url;
+        const tokens = route.match(/([^#]*)(#.*)?/);
+        const group1 = tokens ? tokens[1] : route;
         return group1;
     } catch (error) {
         console.error(error);
-        return url;
+        return route;
     }
 };
 

--- a/packages/suite/src/utils/suite/router.ts
+++ b/packages/suite/src/utils/suite/router.ts
@@ -30,39 +30,39 @@ export const routes: Route[] = [
     },
     {
         name: 'wallet-index',
-        pattern: '/wallet',
+        pattern: '/wallet/',
     },
     {
         name: 'suite-device-settings',
-        pattern: '/settings',
+        pattern: '/settings/',
     },
     {
         name: 'wallet-settings',
-        pattern: '/wallet/settings',
+        pattern: '/wallet/settings/',
     },
     {
         name: 'wallet-account',
-        pattern: '/wallet/account',
+        pattern: '/wallet/account/',
     },
     {
         name: 'wallet-account-summary',
-        pattern: '/wallet/account',
+        pattern: '/wallet/account/',
     },
     {
         name: 'wallet-account-transactions',
-        pattern: '/wallet/account/transactions',
+        pattern: '/wallet/account/transactions/',
     },
     {
         name: 'wallet-account-send',
-        pattern: '/wallet/account/send',
+        pattern: '/wallet/account/send/',
     },
     {
         name: 'wallet-account-receive',
-        pattern: '/wallet/account/receive',
+        pattern: '/wallet/account/receive/',
     },
     {
         name: 'wallet-account-sign-verify',
-        pattern: '/wallet/account/sign-verify',
+        pattern: '/wallet/account/sign-verify/',
     },
 ];
 

--- a/packages/suite/src/utils/suite/router.ts
+++ b/packages/suite/src/utils/suite/router.ts
@@ -1,22 +1,3 @@
-export const getApp = (url: string) => {
-    if (url === '/' || url.indexOf('/wallet') === 0) return 'wallet';
-    if (url.indexOf('/onboarding') === 0) return 'onboarding';
-
-    return 'unknown';
-};
-
-export const getParams = (url: string) => {
-    const split = url.split('#');
-    if (!split[1]) return {};
-    const parts = split[1].substr(1, split[1].length).split('/');
-
-    const params: { [key: string]: string } = {};
-    ['coin', 'accountId'].forEach((key, index) => {
-        params[key] = parts[index];
-    });
-    return params;
-};
-
 export interface Route {
     name: string;
     pattern: string;
@@ -66,6 +47,25 @@ export const routes: Route[] = [
     },
 ];
 
+export const getApp = (url: string) => {
+    if (url === '/' || url.indexOf('/wallet') === 0) return 'wallet';
+    if (url.indexOf('/onboarding') === 0) return 'onboarding';
+
+    return 'unknown';
+};
+
+export const getParams = (url: string) => {
+    const split = url.split('#');
+    if (!split[1]) return {};
+    const parts = split[1].substr(1, split[1].length).split('/');
+
+    const params: { [key: string]: string } = {};
+    ['coin', 'accountId'].forEach((key, index) => {
+        params[key] = parts[index];
+    });
+    return params;
+};
+
 export const getRoute = (name: string): string => {
     const entry = routes.find(r => r.name === name);
     if (!entry) {
@@ -74,4 +74,31 @@ export const getRoute = (name: string): string => {
         return '/';
     }
     return entry.pattern;
+};
+
+// Prefix a url with assetPrefix (eg. name of the branch in CI)
+// Useful with NextJS's Router.push() that accepts
+export const getPrefixedURL = (url: string) => {
+    const urlPrefix = process.env.assetPrefix || '';
+    return urlPrefix + url;
+};
+
+// Strips params delimited by a hashtag from the URL
+export const toInternalRoute = (url: string) => {
+    // chars before # belong to the first group, # and chars after to the optional second group
+    // eg. https://suite.corp.sldev.cz/wallet/account/#/eth/0 will be splitted to
+    // 'https://suite.corp.sldev.cz/wallet/account/' and '#/eth/0'
+    try {
+        const tokens = url.match(/([^#]*)(#.*)?/);
+        const group1 = tokens ? tokens[1] : url;
+        return group1;
+    } catch (error) {
+        console.error(error);
+        return url;
+    }
+};
+
+// Check if the URL/route points to an in-app page
+export const isInternalRoute = (route: string) => {
+    return routes.find(r => r.pattern === toInternalRoute(route));
 };

--- a/packages/suite/src/views/wallet/dashboard/index.tsx
+++ b/packages/suite/src/views/wallet/dashboard/index.tsx
@@ -101,7 +101,10 @@ const Dashboard = (props: Props) => {
                                 // TODO: build network account url in router utils
                                 <Link
                                     key={network.shortcut}
-                                    href={`/wallet/account/#/${network.shortcut}/0`}
+                                    href={getRoute('wallet-account', {
+                                        coin: network.shortcut,
+                                        accountId: '0',
+                                    })}
                                 >
                                     <StyledCoinLogo network={network.shortcut} height={32} />
                                 </Link>

--- a/packages/suite/src/views/wallet/dashboard/index.tsx
+++ b/packages/suite/src/views/wallet/dashboard/index.tsx
@@ -53,6 +53,14 @@ const StyledH4 = styled(H4)`
     text-align: center;
 `;
 
+const StyledLink = styled(Link)`
+    margin-right: 10px;
+
+    &:last-child {
+        margin-right: 0;
+    }
+`;
+
 interface Props {
     settings: State['wallet']['settings'];
 }
@@ -99,7 +107,7 @@ const Dashboard = (props: Props) => {
                             .filter(item => !props.settings.hiddenCoins.includes(item.shortcut))
                             .map(network => (
                                 // TODO: build network account url in router utils
-                                <Link
+                                <StyledLink
                                     key={network.shortcut}
                                     href={getRoute('wallet-account', {
                                         coin: network.shortcut,
@@ -107,7 +115,7 @@ const Dashboard = (props: Props) => {
                                     })}
                                 >
                                     <StyledCoinLogo network={network.shortcut} height={32} />
-                                </Link>
+                                </StyledLink>
                             ))}
                     </Coins>
                 </Row>

--- a/packages/suite/src/views/wallet/dashboard/index.tsx
+++ b/packages/suite/src/views/wallet/dashboard/index.tsx
@@ -101,7 +101,7 @@ const Dashboard = (props: Props) => {
                                 // TODO: build network account url in router utils
                                 <Link
                                     key={network.shortcut}
-                                    href={`/wallet/account#/${network.shortcut}/0`}
+                                    href={`/wallet/account/#/${network.shortcut}/0`}
                                 >
                                     <StyledCoinLogo network={network.shortcut} height={32} />
                                 </Link>

--- a/packages/suite/src/views/wallet/dashboard/index.tsx
+++ b/packages/suite/src/views/wallet/dashboard/index.tsx
@@ -1,10 +1,16 @@
 import React from 'react';
 import styled from 'styled-components';
+import { connect } from 'react-redux';
+import { State } from '@suite-types/index';
 // import Content from '@wallet-components/Content';
-import { H4, P } from '@trezor/components';
+import { H4, P, CoinLogo } from '@trezor/components';
+import Link from '@suite-components/Link';
 import Layout from '@wallet-components/Layout';
 import { FormattedMessage } from 'react-intl';
-// import l10nCommonMessages from '@wallet-views/messages';
+import l10nCommonMessages from '@wallet-views/messages';
+import NETWORKS from '@suite-config/networks';
+import EXTERNAL_COINS from '@suite-config/externalCoins';
+import { getRoute } from '@suite/utils/suite/router';
 import l10nMessages from './index.messages';
 
 const Wrapper = styled.div`
@@ -28,52 +34,40 @@ const StyledP = styled(P)`
     }
 `;
 
-// const Coins = styled.div`
-//     display: flex;
-//     flex-wrap: wrap;
-// `;
+const Coins = styled.div`
+    display: flex;
+    flex-wrap: wrap;
+`;
 
-// const StyledLinkEmpty = styled(Link)`
-//     padding: 0;
-// `;
+const StyledCoinLogo = styled(CoinLogo)`
+    opacity: 0.7;
+    transition: opacity 0.2s ease-in-out;
+    cursor: pointer;
 
-// const StyledCoinLogo = styled(CoinLogo)`
-//     opacity: 0.7;
-//     transition: opacity 0.2s ease-in-out;
-
-//     &:hover {
-//         opacity: 1;
-//     }
-// `;
+    &:hover {
+        opacity: 1;
+    }
+`;
 
 const StyledH4 = styled(H4)`
     text-align: center;
 `;
 
-const getBaseUrl = device => {
-    let baseUrl = '';
-    if (device && device.features) {
-        baseUrl = `/device/${device.features.device_id}`;
-        if (device.instance) {
-            baseUrl += `:${device.instance}`;
-        }
-    }
+interface Props {
+    settings: State['wallet']['settings'];
+}
 
-    return baseUrl;
-};
+const Dashboard = (props: Props) => {
+    const isEmpty = () => {
+        const numberOfVisibleNetworks = NETWORKS.filter(item => !item.isHidden) // hide coins globally in config
+            .filter(item => !props.settings.hiddenCoins.includes(item.shortcut));
+        const { hiddenCoinsExternal } = props.settings;
+        const numberOfVisibleNetworksExternal = EXTERNAL_COINS.filter(
+            item => !item.isHidden,
+        ).filter(item => !hiddenCoinsExternal.includes(item.id));
 
-const Dashboard = () => {
-    // const isEmpty = () => {
-    //     const numberOfVisibleNetworks = props.localStorage.config.networks
-    //         .filter(item => !item.isHidden) // hide coins globally in config
-    //         .filter(item => !props.wallet.hiddenCoins.includes(item.shortcut));
-    //     const { hiddenCoinsExternal } = props.wallet;
-    //     const numberOfVisibleNetworksExternal = coins
-    //         .filter(item => !item.isHidden)
-    //         .filter(item => !hiddenCoinsExternal.includes(item.id));
-
-    //     return numberOfVisibleNetworks.length <= 0 && numberOfVisibleNetworksExternal.length <= 0;
-    // };
+        return numberOfVisibleNetworks.length <= 0 && numberOfVisibleNetworksExternal.length <= 0;
+    };
 
     return (
         // <Content>
@@ -81,43 +75,38 @@ const Dashboard = () => {
             <Wrapper>
                 <Row data-test="Dashboard__page__content">
                     <StyledH4>
-                        <FormattedMessage {...l10nMessages.TR_PLEASE_SELECT_YOUR} />
+                        {isEmpty() && (
+                            <FormattedMessage
+                                {...l10nMessages.TR_PLEASE_SELECT_YOUR_EMPTY}
+                                values={{
+                                    TR_SELECT_COINS_LINK: (
+                                        <Link href={getRoute('wallet-settings')}>
+                                            <FormattedMessage
+                                                {...l10nCommonMessages.TR_SELECT_COINS_LINK}
+                                            />
+                                        </Link>
+                                    ),
+                                }}
+                            />
+                        )}
+                        {!isEmpty() && <FormattedMessage {...l10nMessages.TR_PLEASE_SELECT_YOUR} />}
                     </StyledH4>
-                    {/* <StyledH4>
-                    {isEmpty() && (
-                        <FormattedMessage
-                            {...l10nMessages.TR_PLEASE_SELECT_YOUR_EMPTY}
-                            values={{
-                                TR_SELECT_COINS_LINK: (
-                                    <StyledLinkEmpty to="/settings">
-                                        <FormattedMessage
-                                            {...l10nCommonMessages.TR_SELECT_COINS_LINK}
-                                        />
-                                    </StyledLinkEmpty>
-                                ),
-                            }}
-                        />
-                    )}
-                    {!isEmpty() && <FormattedMessage {...l10nMessages.TR_PLEASE_SELECT_YOUR} />}
-                </StyledH4> */}
                     <StyledP>
                         <FormattedMessage {...l10nMessages.TR_YOU_WILL_GAIN_ACCESS} />
                     </StyledP>
-                    {/* <Coins>
-                    {props.localStorage.config.networks
-                        .filter(item => !item.isHidden)
-                        .filter(item => !props.wallet.hiddenCoins.includes(item.shortcut))
-                        .map(network => (
-                            <StyledNavLink
-                                key={network.shortcut}
-                                to={`${getBaseUrl(props.wallet.selectedDevice)}/network/${
-                                    network.shortcut
-                                }/account/0`}
-                            >
-                                <StyledCoinLogo network={network.shortcut} height={32} />
-                            </StyledNavLink>
-                        ))}
-                </Coins> */}
+                    <Coins>
+                        {NETWORKS.filter(item => !item.isHidden)
+                            .filter(item => !props.settings.hiddenCoins.includes(item.shortcut))
+                            .map(network => (
+                                // TODO: build network account url in router utils
+                                <Link
+                                    key={network.shortcut}
+                                    href={`/wallet/account#/${network.shortcut}/0`}
+                                >
+                                    <StyledCoinLogo network={network.shortcut} height={32} />
+                                </Link>
+                            ))}
+                    </Coins>
                 </Row>
             </Wrapper>
         </Layout>
@@ -125,4 +114,8 @@ const Dashboard = () => {
     );
 };
 
-export default Dashboard;
+const mapStateToProps = (state: State) => ({
+    settings: state.wallet.settings,
+});
+
+export default connect(mapStateToProps)(Dashboard);

--- a/packages/suite/src/views/wallet/settings/index.tsx
+++ b/packages/suite/src/views/wallet/settings/index.tsx
@@ -24,19 +24,7 @@ import { getRoute } from '@suite/utils/suite/router';
 import Coins from './components/Coins';
 import l10nMessages from './index.messages';
 
-const { FONT_SIZE, SCREEN_SIZE } = variables;
-
-const StyledContent = styled.div`
-    max-width: 800px;
-    display: flex;
-    flex: 1;
-    flex-direction: column;
-    padding: 40px 35px 40px 35px;
-
-    @media screen and (max-width: ${SCREEN_SIZE.SM}) {
-        padding: 20px 35px;
-    }
-`;
+const { FONT_SIZE } = variables;
 
 const CurrencySelect = styled(Select)`
     min-width: 77px;


### PR DESCRIPTION
- Custom `Link` component that prefixes routes with name of the branch. It is a wrapper around trezor/components Link. It is now used in CoinMenu (user can see the link on hover)
- `getRoute()` accepts params (`{coin: ..., accountId: ...}`)that can be added to the url as second arg
- Changed all routes so they end with '/' to be consistent between local dev server and exported build
- Linked coins on Dashboard page 
