### PR TITLE
experimenting, add create wallet call to 'go to security' button

### DIFF
--- a/packages/suite/src/actions/onboarding/connectActions.ts
+++ b/packages/suite/src/actions/onboarding/connectActions.ts
@@ -207,15 +207,13 @@ const submitWord = (params: any) => (dispatch: Dispatch) =>
     dispatch(uiResponseCall(UI.RECEIVE_WORD, params));
 
 // todo: maybe rework this function to take concrete call function as argument;
-// todo: not used now.
 const callActionAndGoToNextStep = (
-    name: string,
-    params: any,
+    action: any,
     stepId?: AnyStepId,
     goOnSuccess: boolean = true,
     goOnError: boolean = false,
 ) => (dispatch: Dispatch) => {
-    dispatch(call(name, params)).then((response: any) => {
+    dispatch(action).then((response: any) => {
         if (response.success && goOnSuccess) {
             dispatch(goToNextStep(stepId));
         }

--- a/packages/suite/src/actions/suite/trezorConnectActions.ts
+++ b/packages/suite/src/actions/suite/trezorConnectActions.ts
@@ -46,8 +46,8 @@ export const init = () => async (dispatch: Dispatch) => {
 
     try {
         await TrezorConnect.init({
-            // connectSrc: 'https://sisyfos.sldev.cz/connect-electron/',
-            connectSrc: 'https://localhost:8088/',
+            connectSrc: 'https://sisyfos.sldev.cz/connect-electron/',
+            // connectSrc: 'https://localhost:8088/',
             transportReconnect: true,
             debug: false,
             popup: false,

--- a/packages/suite/src/actions/suite/trezorConnectActions.ts
+++ b/packages/suite/src/actions/suite/trezorConnectActions.ts
@@ -46,8 +46,8 @@ export const init = () => async (dispatch: Dispatch) => {
 
     try {
         await TrezorConnect.init({
-            connectSrc: 'https://sisyfos.sldev.cz/connect-electron/',
-            // connectSrc: 'https://localhost:8088/',
+            // connectSrc: 'https://sisyfos.sldev.cz/connect-electron/',
+            connectSrc: 'https://localhost:8088/',
             transportReconnect: true,
             debug: false,
             popup: false,

--- a/packages/suite/src/components/onboarding/ProgressSteps/index.tsx
+++ b/packages/suite/src/components/onboarding/ProgressSteps/index.tsx
@@ -106,7 +106,6 @@ class ProgressSteps extends React.Component<Props> {
     render() {
         const { isDisabled, onboardingActions, activeStep, hiddenOnSteps = [] } = this.props;
         const steps = this.getStepsWithDots();
-
         return (
             <React.Fragment>
                 <Wrapper>

--- a/packages/suite/src/views/onboarding/index.tsx
+++ b/packages/suite/src/views/onboarding/index.tsx
@@ -305,7 +305,7 @@ class Onboarding extends React.PureComponent<Props> {
                         <ProgressStepsSlot>
                             <ProgressStepsWrapper>
                                 <ProgressSteps
-                                    hiddenOnSteps={[STEP.ID_WELCOME_STEP]}
+                                    hiddenOnSteps={[STEP.ID_WELCOME_STEP, STEP.ID_SECURITY_STEP]}
                                     steps={steps}
                                     activeStep={activeStep}
                                     onboardingActions={onboardingActions}
@@ -324,13 +324,6 @@ class Onboarding extends React.PureComponent<Props> {
                             >
                                 <WelcomeStep />
                             </CSSTransition>
-
-                            {/* <CSSTransition
-                                in={activeStepId === STEP.ID_START_STEP}
-                                {...TRANSITION_PROPS}
-                            >
-                                <StartStep />
-                            </CSSTransition> */}
 
                             <CSSTransition
                                 in={activeStepId === STEP.ID_NEW_OR_USED}

--- a/packages/suite/src/views/onboarding/steps/Backup/index.tsx
+++ b/packages/suite/src/views/onboarding/steps/Backup/index.tsx
@@ -5,8 +5,7 @@ import { FormattedMessage } from 'react-intl';
 
 import colors from '@suite/config/onboarding/colors';
 import { SEED_MANUAL_URL } from '@suite/constants/onboarding/urls';
-import { WIPE_DEVICE, BACKUP_DEVICE } from '@suite/actions/onboarding/constants/calls';
-import * as STEP from '@suite/constants/onboarding/steps';
+import { BACKUP_DEVICE } from '@suite/actions/onboarding/constants/calls';
 import Text from '@suite/components/onboarding/Text';
 import l10nCommonMessages from '@suite-support/Messages';
 
@@ -114,10 +113,6 @@ class BackupStep extends React.Component<BackupProps, BackupState> {
             return BackupStep.INITIAL_STATUS;
         }
         return null;
-    }
-
-    async wipeDeviceAndStartAgain() {
-        this.props.connectActions.callActionAndGoToNextStep(WIPE_DEVICE, null, STEP.ID_BACKUP_STEP);
     }
 
     render() {

--- a/packages/suite/src/views/onboarding/steps/Bookmark/Container.ts
+++ b/packages/suite/src/views/onboarding/steps/Bookmark/Container.ts
@@ -13,6 +13,7 @@ const mapStateToProps = (state: AppState) => ({
 
 const mapDispatchToProps = (dispatch: Dispatch) => ({
     connectActions: {
+        applyFlags: bindActionCreators(connectActions.applyFlags, dispatch),
         callActionAndGoToNextStep: bindActionCreators(
             connectActions.callActionAndGoToNextStep,
             dispatch,

--- a/packages/suite/src/views/onboarding/steps/Bookmark/index.tsx
+++ b/packages/suite/src/views/onboarding/steps/Bookmark/index.tsx
@@ -5,7 +5,6 @@ import { FormattedMessage } from 'react-intl';
 import { Link, Button, P } from '@trezor/components';
 
 import { HAS_BOOKMARK_FLAG, addToFlags } from '@suite-utils/flags';
-import { APPLY_FLAGS } from '@suite/actions/onboarding/constants/calls';
 import l10nCommonMessages from '@suite-support/Messages';
 import { PHISHING_URL } from '@suite/constants/onboarding/urls';
 import Key from '@suite/components/onboarding/Key';
@@ -17,7 +16,7 @@ import {
     ControlsWrapper,
 } from '@suite/components/onboarding/Wrapper';
 import { AppState } from '@suite-types/index';
-import { callActionAndGoToNextStep } from '@onboarding-actions/connectActions';
+import { callActionAndGoToNextStep, applyFlags } from '@onboarding-actions/connectActions';
 
 import l10nMessages from './index.messages';
 
@@ -28,6 +27,7 @@ const Keys = styled.div`
 interface StepProps {
     device: AppState['onboarding']['connect']['device'];
     connectActions: {
+        applyFlags: typeof applyFlags;
         callActionAndGoToNextStep: typeof callActionAndGoToNextStep;
     };
 }
@@ -60,7 +60,7 @@ class BookmarkStep extends React.Component<StepProps, StepState> {
 
     setBookmarkFlagAndContinue() {
         const flags = addToFlags(HAS_BOOKMARK_FLAG, this.props.device.features.flags);
-        this.props.connectActions.callActionAndGoToNextStep(APPLY_FLAGS, { flags });
+        this.props.connectActions.callActionAndGoToNextStep(() => applyFlags({ flags }));
     }
 
     keyboardHandler(e: KeyboardEvent) {

--- a/packages/suite/src/views/onboarding/steps/Newsletter/Container.ts
+++ b/packages/suite/src/views/onboarding/steps/Newsletter/Container.ts
@@ -16,6 +16,7 @@ const mapStateToProps = (state: AppState) => ({
 
 const mapDispatchToProps = (dispatch: Dispatch) => ({
     connectActions: {
+        applyFlags: bindActionCreators(connectActions.applyFlags, dispatch),
         callActionAndGoToNextStep: bindActionCreators(
             connectActions.callActionAndGoToNextStep,
             dispatch,

--- a/packages/suite/src/views/onboarding/steps/Newsletter/index.tsx
+++ b/packages/suite/src/views/onboarding/steps/Newsletter/index.tsx
@@ -13,10 +13,9 @@ import { IconSocial } from '@suite/components/onboarding/Icons';
 import { isEmail } from '@suite-utils/validators';
 import { HAS_EMAIL_FLAG, addToFlags } from '@suite-utils/flags';
 import { SUBMIT_EMAIL } from '@suite/actions/onboarding/constants/fetchCalls';
-import { APPLY_FLAGS } from '@suite/actions/onboarding/constants/calls';
 import Text from '@suite/components/onboarding/Text';
 import l10nCommonMessages from '@suite-support/Messages';
-import { callActionAndGoToNextStep } from '@onboarding-actions/connectActions';
+import { callActionAndGoToNextStep, applyFlags } from '@onboarding-actions/connectActions';
 import {
     setSkipped,
     setEmail,
@@ -64,6 +63,7 @@ interface Props {
     newsletter: AppState['onboarding']['newsletter'];
     device: AppState['onboarding']['connect']['device'];
     connectActions: {
+        applyFlags: typeof applyFlags;
         callActionAndGoToNextStep: typeof callActionAndGoToNextStep;
     };
     newsletterActions: {
@@ -121,9 +121,11 @@ class NewsleterStep extends React.Component<Props & InjectedIntlProps> {
     };
 
     goToNextStep = () => {
-        this.props.connectActions.callActionAndGoToNextStep(APPLY_FLAGS, {
-            flags: addToFlags(HAS_EMAIL_FLAG, this.props.device.features.flags),
-        });
+        this.props.connectActions.callActionAndGoToNextStep(() =>
+            applyFlags({
+                flags: addToFlags(HAS_EMAIL_FLAG, this.props.device.features.flags),
+            }),
+        );
     };
 
     submitEmail = () => {

--- a/packages/suite/src/views/onboarding/steps/Security/Container.ts
+++ b/packages/suite/src/views/onboarding/steps/Security/Container.ts
@@ -3,13 +3,14 @@ import { connect } from 'react-redux';
 
 import { Dispatch } from '@suite-types/index';
 import { goToNextStep } from '@suite/actions/onboarding/onboardingActions';
+import { callActionAndGoToNextStep, resetDevice } from '@suite/actions/onboarding/connectActions';
 
 import Step from './index';
 
 const mapDispatchToProps = (dispatch: Dispatch) => ({
-    onboardingActions: {
-        goToNextStep: bindActionCreators(goToNextStep, dispatch),
-    },
+    goToNextStep: bindActionCreators(goToNextStep, dispatch),
+    callActionAndGoToNextStep: bindActionCreators(callActionAndGoToNextStep, dispatch),
+    resetDevice: bindActionCreators(resetDevice, dispatch),
 });
 
 export default connect(

--- a/packages/suite/src/views/onboarding/steps/Security/index.tsx
+++ b/packages/suite/src/views/onboarding/steps/Security/index.tsx
@@ -3,6 +3,8 @@ import { Button } from '@trezor/components';
 import { FormattedMessage } from 'react-intl';
 
 import { goToNextStep } from '@onboarding-actions/onboardingActions';
+import { callActionAndGoToNextStep, resetDevice } from '@onboarding-actions/connectActions';
+
 import * as STEP from '@suite/constants/onboarding/steps';
 import Text from '@suite/components/onboarding/Text';
 import {
@@ -15,12 +17,12 @@ import {
 import l10nMessages from './index.messages';
 
 interface Props {
-    onboardingActions: {
-        goToNextStep: typeof goToNextStep;
-    };
+    callActionAndGoToNextStep: typeof callActionAndGoToNextStep;
+    goToNextStep: typeof goToNextStep;
+    resetDevice: typeof resetDevice;
 }
 
-const SecurityStep = ({ onboardingActions }: Props) => (
+const SecurityStep = (props: Props) => (
     <StepWrapper>
         <StepHeadingWrapper>
             <FormattedMessage {...l10nMessages.TR_SECURITY_HEADING} />
@@ -30,12 +32,23 @@ const SecurityStep = ({ onboardingActions }: Props) => (
                 <FormattedMessage {...l10nMessages.TR_SECURITY_SUBHEADING} />
             </Text>
             <ControlsWrapper>
-                <Button isWhite onClick={() => onboardingActions.goToNextStep(STEP.ID_FINAL_STEP)}>
+                <Button
+                    isWhite
+                    onClick={() =>
+                        props.callActionAndGoToNextStep(
+                            () => props.resetDevice(),
+                            STEP.ID_FINAL_STEP,
+                        )
+                    }
+                >
                     <FormattedMessage {...l10nMessages.TR_SKIP_SECURITY} />
                 </Button>
                 <Button
                     onClick={() => {
-                        onboardingActions.goToNextStep();
+                        props.callActionAndGoToNextStep(
+                            () => props.resetDevice(),
+                            STEP.ID_BACKUP_STEP,
+                        );
                     }}
                 >
                     <FormattedMessage {...l10nMessages.TR_GO_TO_SECURITY} />

--- a/packages/suite/src/views/onboarding/steps/SelectDevice/index.tsx
+++ b/packages/suite/src/views/onboarding/steps/SelectDevice/index.tsx
@@ -29,9 +29,6 @@ interface Props {
     device: AppState['onboarding']['connect']['device'];
     asNewDevice: AppState['onboarding']['asNewDevice'];
     model: AppState['onboarding']['selectedModel'];
-    // model: any;
-    // device: any;
-    // asNewDevice: any;
 }
 
 const SelectDeviceStep: React.FC<Props> = ({ onboardingActions, model, device, asNewDevice }) => {
@@ -85,7 +82,7 @@ const SelectDeviceStep: React.FC<Props> = ({ onboardingActions, model, device, a
                     onSelect={(value: number) => {
                         onboardingActions.selectTrezorModel(value);
                         onboardingActions.goToNextStep(
-                            asNewDevice ? STEP.ID_UNBOXING_STEP : STEP.ID_CONNECT_STEP,
+                            asNewDevice ? STEP.ID_UNBOXING_STEP : STEP.ID_BRIDGE_STEP,
                         );
                     }}
                 />


### PR DESCRIPTION
Due to the new workflow, I didnt know where to put reset device call. so it was not there at all. Experimenting now with having it on "Security step" which is the step where user decides if he wants to go through security or skip it