### PR TITLE
NoSSR component that prevents server-side rendering of its children

### DIFF
--- a/packages/suite/src/components/suite/Layout/index.tsx
+++ b/packages/suite/src/components/suite/Layout/index.tsx
@@ -18,6 +18,7 @@ import SuiteNotifications from '@suite-components/Notifications';
 import { AppState } from '@suite-types/index';
 import { TREZOR_URL, SUPPORT_URL, WIKI_URL, BLOG_URL } from '@suite/constants/urls';
 
+import NoSSR from '@suite/support/suite/NoSSR';
 import l10nMessages from './index.messages';
 
 const PageWrapper = styled.div<Pick<Props, 'isLanding'>>`
@@ -76,13 +77,15 @@ const Layout = (props: Props & InjectedIntlProps) => (
             togglerCloseText={<FormattedMessage {...l10nMessages.TR_MENU_CLOSE} />}
             sidebarEnabled={!props.isLanding}
             rightAddon={
-                <LanguagePicker
-                    language={props.suite.language}
-                    languages={suiteConfig.languages}
-                    onChange={option => {
-                        props.fetchLocale(option.value);
-                    }}
-                />
+                <NoSSR>
+                    <LanguagePicker
+                        language={props.suite.language}
+                        languages={suiteConfig.languages}
+                        onChange={option => {
+                            props.fetchLocale(option.value);
+                        }}
+                    />
+                </NoSSR>
             }
             links={[
                 {

--- a/packages/suite/src/support/suite/NoSSR.tsx
+++ b/packages/suite/src/support/suite/NoSSR.tsx
@@ -1,0 +1,19 @@
+import React, { useState, useEffect } from 'react';
+
+interface Props {
+    children: React.ReactNode;
+    fallbackComponent?: any;
+}
+
+const NoSSR = ({ children, fallbackComponent = null }: Props) => {
+    const [shouldRender, setShouldRender] = useState(false);
+
+    useEffect(() => {
+        // should fire on equivalent of componentDidMount
+        setShouldRender(true);
+    }, []);
+
+    return shouldRender ? children : fallbackComponent;
+};
+
+export default NoSSR;

--- a/packages/suite/src/support/suite/NoSSR.tsx
+++ b/packages/suite/src/support/suite/NoSSR.tsx
@@ -9,7 +9,7 @@ const NoSSR = ({ children, fallbackComponent = null }: Props) => {
     const [shouldRender, setShouldRender] = useState(false);
 
     useEffect(() => {
-        // should fire on equivalent of componentDidMount
+        // should fired on equivalent of componentDidMount
         setShouldRender(true);
     }, []);
 


### PR DESCRIPTION
Wrapper component that renders its children only after the component is mounted, basically only on the client side. Returns `null` on server-side rendering.

- wrapped around language picker fixes https://github.com/trezor/trezor-suite/issues/319 and fixes https://github.com/trezor/trezor-suite/issues/290 (could be even better with some custom placeholder (passed as `fallbackComponent` prop) that looks the same as the rendered component)

**before:**
![Screen Recording 2019-07-30 at 11 53 09](https://user-images.githubusercontent.com/6961901/62126846-ecf60a80-b2d0-11e9-95bb-41c25b6a8b1d.gif)

**after:**
![Screen Recording 2019-07-30 at 13 43 13](https://user-images.githubusercontent.com/6961901/62126603-5e818900-b2d0-11e9-88f6-e0ae2843f11a.gif)
