### PR TITLE
Assign index as notification's action button key

### DIFF
--- a/packages/components/src/components/Notification/index.tsx
+++ b/packages/components/src/components/Notification/index.tsx
@@ -144,9 +144,11 @@ const Notification = ({
                     <AdditionalContent>
                         {actions && actions.length > 0 && (
                             <ActionContent>
-                                {actions.map((action: CtaShape) => (
+                                {actions.map((action: CtaShape, i) => (
                                     <ButtonNotification
                                         isInverse
+                                        // eslint-disable-next-line react/no-array-index-key
+                                        key={i}
                                         variant={variant}
                                         isLoading={isActionInProgress}
                                         onClick={() => {


### PR DESCRIPTION
- assign index as notification's action button key

imo valid use case. notification's actions are static (we don't manipulate with an array of actions) and they don't have anything that can be used as a unique id. We used `label` before, but it is not always string now, but a react component which can't be used as key.

fixes: 
<img width="730" alt="Screenshot 2019-07-30 at 15 54 32" src="https://user-images.githubusercontent.com/6961901/62136751-10c34b80-b2e5-11e9-94b3-030400761d37.png">

