### PR TITLE
add backup page and nothing more

### DIFF
--- a/packages/components/src/components/Notification/index.tsx
+++ b/packages/components/src/components/Notification/index.tsx
@@ -92,7 +92,7 @@ const ButtonNotification = styled(Button)`
 `;
 
 interface CtaShape {
-    label: React.ReactNode;
+    label: React.ReactNode | string;
     callback: () => any;
 }
 
@@ -181,7 +181,7 @@ Notification.propTypes = {
     isActionInProgress: PropTypes.bool,
     actions: PropTypes.arrayOf(
         PropTypes.shape({
-            label: PropTypes.string,
+            label: PropTypes.oneOfType([PropTypes.string, PropTypes.node]),
             callback: PropTypes.func,
         })
     ),

--- a/packages/suite-web/pages/backup/index.tsx
+++ b/packages/suite-web/pages/backup/index.tsx
@@ -1,0 +1,3 @@
+import Backup from '@suite-views/backup';
+
+export default Backup;

--- a/packages/suite/src/components/suite/Notifications/components/NoBackup/index.tsx
+++ b/packages/suite/src/components/suite/Notifications/components/NoBackup/index.tsx
@@ -23,10 +23,10 @@ export default ({ device, pathname }: Props) => {
             message={<FormattedMessage {...l10nCommonMessages.TR_IF_YOUR_DEVICE_IS_EVER_LOST} />}
             actions={[
                 {
-                    // label: (
-                    //     <FormattedMessage {...l10nCommonMessages.TR_CREATE_BACKUP_IN_3_MINUTES} />
-                    // ),
-                    label: 'Create backup in 3 minutes',
+                    label: (
+                        <FormattedMessage {...l10nCommonMessages.TR_CREATE_BACKUP_IN_3_MINUTES} />
+                    ),
+                    // label: 'Create backup in 3 minutes',
                     callback: () => goto(getRoute('suite-device-backup')),
                 },
             ]}

--- a/packages/suite/src/components/suite/Notifications/components/NoBackup/index.tsx
+++ b/packages/suite/src/components/suite/Notifications/components/NoBackup/index.tsx
@@ -2,31 +2,34 @@ import React from 'react';
 import { Notification } from '@trezor/components';
 import { FormattedMessage } from 'react-intl';
 import l10nCommonMessages from '@suite-views/index.messages';
-// import { goto } from '@suite-actions/routerActions';
-// import { getRoute } from '@suite-utils/router';
+import { goto } from '@suite-actions/routerActions';
+import { getRoute } from '@suite-utils/router';
 import { AppState } from '@suite-types';
 
 interface Props {
     device: AppState['suite']['device'];
+    pathname: string;
 }
 
-export default ({ device }: Props) => {
+export default ({ device, pathname }: Props) => {
     const needsBackup = device && device.features && device.features.needs_backup;
     if (!needsBackup) return null;
+    if (pathname === getRoute('suite-device-backup')) return null;
     return (
         <Notification
             key="no-backup"
             variant="warning"
             title={<FormattedMessage {...l10nCommonMessages.TR_YOUR_TREZOR_IS_NOT_BACKED_UP} />}
             message={<FormattedMessage {...l10nCommonMessages.TR_IF_YOUR_DEVICE_IS_EVER_LOST} />}
-            // actions={[
-            //     {
-            //         label: (
-            //             <FormattedMessage {...l10nCommonMessages.TR_CREATE_BACKUP_IN_3_MINUTES} />
-            //         ),
-            //         callback: goto(getRoute('wallet-no-backup')),
-            //     },
-            // ]}
+            actions={[
+                {
+                    // label: (
+                    //     <FormattedMessage {...l10nCommonMessages.TR_CREATE_BACKUP_IN_3_MINUTES} />
+                    // ),
+                    label: 'Create backup in 3 minutes',
+                    callback: () => goto(getRoute('suite-device-backup')),
+                },
+            ]}
         />
     );
 };

--- a/packages/suite/src/components/suite/Notifications/index.tsx
+++ b/packages/suite/src/components/suite/Notifications/index.tsx
@@ -18,7 +18,7 @@ const Notifications = (props: Props & InjectedIntlProps) => (
         <OnlineStatus isOnline={props.suite.online} />
         <UpdateBridge transport={props.suite.transport} />
         <UpdateFirmware device={props.suite.device} pathname={props.router.pathname} />
-        <NoBackup device={props.suite.device} />
+        <NoBackup device={props.suite.device} pathname={props.router.pathname} />
     </React.Fragment>
 );
 

--- a/packages/suite/src/constants/suite/routes.ts
+++ b/packages/suite/src/constants/suite/routes.ts
@@ -42,6 +42,11 @@ export const routes = [
         isStatic: false,
     },
     {
+        name: 'suite-device-backup',
+        pattern: '/backup',
+        isStatic: false,
+    },
+    {
         name: 'wallet-settings',
         pattern: '/wallet/settings',
         isStatic: false,

--- a/packages/suite/src/views/suite/backup/index.tsx
+++ b/packages/suite/src/views/suite/backup/index.tsx
@@ -1,0 +1,10 @@
+import React from 'react';
+// import styled from 'styled-components';
+// import { InjectedIntlProps } from 'react-intl';
+// import { AppState } from '@suite-types';
+
+const Backup = () => {
+    return <div>Backup</div>;
+};
+
+export default Backup;


### PR DESCRIPTION
This is very small. 

In the course of following days, I am going to refactor onboarding backup parts to make them available for users not going through onboarding. This means users doing backup after they see notification "your device is not backed up"

This PR just adds `/backup` route. Lets discuss if we are ok with this structure. `/firwmare` route is already in develop, so adding `/backup` would be consistent. We still have time to make decisions now though, so any ideas welcome.  