### PR TITLE
add basic working backup for model T

### DIFF
--- a/packages/suite/jest.config.js
+++ b/packages/suite/jest.config.js
@@ -41,10 +41,10 @@ module.exports = {
     ],
     coverageThreshold: {
         global: {
-            statements: 49.23,
-            branches: 54.39,
-            functions: 46,
-            lines: 50.62,
+            statements: 49.41,
+            branches: 54.48,
+            functions: 46.22,
+            lines: 50.79,
         },
     },
     modulePathIgnorePatterns: ['node_modules', '<rootDir>/src/utils/suite/hooks'],

--- a/packages/suite/src/actions/suite/__tests__/backupActions.test.ts
+++ b/packages/suite/src/actions/suite/__tests__/backupActions.test.ts
@@ -1,0 +1,100 @@
+/* eslint-disable @typescript-eslint/camelcase */
+/* eslint-disable global-require */
+
+import configureStore from 'redux-mock-store';
+import thunk from 'redux-thunk';
+import { mergeObj } from '@suite-utils/mergeObj';
+import { init } from '@suite-actions/trezorConnectActions';
+
+import * as backupActions from '../backupActions';
+
+jest.mock('trezor-connect', () => {
+    let fixture: any;
+
+    const backupDevice = async () => {
+        return fixture;
+    };
+    const callbacks: { [key: string]: Function } = {};
+
+    return {
+        __esModule: true, // this property makes it work
+        default: {
+            init: () => {
+                return true;
+            },
+            on: (event: string, cb: Function) => {
+                callbacks[event] = cb;
+            },
+            getFeatures: () => {},
+            backupDevice,
+        },
+        DEVICE: {},
+        TRANSPORT: {},
+        setTestFixtures: (f: any) => {
+            fixture = f;
+        },
+    };
+});
+
+export const getInitialState = (override: any) => {
+    const defaults = {
+        suite: {
+            device: {
+                connected: true,
+                type: 'acquired',
+                features: {
+                    major_version: 2,
+                },
+            },
+            uiLocked: false,
+        },
+        // doesnt affect anything, just needed for TrezorConnect.init action
+        devices: [],
+    };
+    if (override) {
+        return mergeObj(defaults, override);
+    }
+    return defaults;
+};
+
+const mockStore = configureStore<ReturnType<typeof getInitialState>, any>([thunk]);
+
+describe('Backup Actions', () => {
+    it('it should trigger actions in order: uiLock:true, addNotification:success, uiLock: false', async () => {
+        require('trezor-connect').setTestFixtures({ success: true });
+
+        const state = getInitialState({});
+        const store = mockStore(state);
+        await store.dispatch(init());
+
+        await store.dispatch(backupActions.backupDevice({ device: store.getState().suite.device }));
+        // discard @suite/trezor-connect-initialized action we dont care about it in this test
+        store.getActions().shift();
+
+        expect(store.getActions().shift()).toEqual({ type: '@suite/lock-ui', payload: true });
+        expect(store.getActions().shift()).toEqual({ type: '@suite/lock-ui', payload: false });
+        expect(store.getActions().shift()).toMatchObject({
+            type: '@notification/add',
+            payload: { variant: 'success' },
+        });
+    });
+
+    it('it should trigger actions in order: uiLock:true, addNotification:error, uiLock: false', async () => {
+        require('trezor-connect').setTestFixtures({ success: false });
+
+        const state = getInitialState({});
+        const store = mockStore(state);
+        await store.dispatch(init());
+
+        await store.dispatch(backupActions.backupDevice({ device: store.getState().suite.device }));
+        // discard @suite/trezor-connect-initialized action we dont care about it in this test
+        store.getActions().shift();
+
+        expect(store.getActions().shift()).toEqual({ type: '@suite/lock-ui', payload: true });
+        expect(store.getActions().shift()).toEqual({ type: '@suite/lock-ui', payload: false });
+        expect(store.getActions().shift()).toMatchObject({
+            type: '@notification/add',
+            payload: { variant: 'error' },
+        });
+    });
+});

--- a/packages/suite/src/actions/suite/backupActions.ts
+++ b/packages/suite/src/actions/suite/backupActions.ts
@@ -1,12 +1,24 @@
 import TrezorConnect, { BackupDeviceParams } from 'trezor-connect';
-import { lockUI } from '@suite-actions/suiteActions';
+import * as notificationActions from '@suite-actions/notificationActions';
 import { Dispatch } from '@suite-types';
-
 //  TODO: should be reworked to deviceManagementActions
 
 export const backupDevice = (params: BackupDeviceParams) => async (dispatch: Dispatch) => {
-    dispatch(lockUI(true));
-    await TrezorConnect.backupDevice(params);
-    dispatch(lockUI(false));
-    // todo: dispatch result notification;
+    const result = await TrezorConnect.backupDevice(params);
+    if (result.success) {
+        return dispatch(
+            notificationActions.add({
+                variant: 'success',
+                title: 'backup successful',
+                cancelable: true,
+            }),
+        );
+    }
+    dispatch(
+        notificationActions.add({
+            variant: 'error',
+            title: 'backup failed',
+            cancelable: true,
+        }),
+    );
 };

--- a/packages/suite/src/actions/suite/backupActions.ts
+++ b/packages/suite/src/actions/suite/backupActions.ts
@@ -1,0 +1,12 @@
+import TrezorConnect, { BackupDeviceParams } from 'trezor-connect';
+import { lockUI } from '@suite-actions/suiteActions';
+import { Dispatch } from '@suite-types';
+
+//  TODO: should be reworked to deviceManagementActions
+
+export const backupDevice = (params: BackupDeviceParams) => async (dispatch: Dispatch) => {
+    dispatch(lockUI(true));
+    await TrezorConnect.backupDevice(params);
+    dispatch(lockUI(false));
+    // todo: dispatch result notification;
+};

--- a/packages/suite/src/actions/suite/deviceSettingsActions.ts
+++ b/packages/suite/src/actions/suite/deviceSettingsActions.ts
@@ -1,6 +1,8 @@
 import TrezorConnect, { ApplySettingsParams, ChangePinParams } from 'trezor-connect';
 import { Dispatch, GetState } from '@suite-types';
 
+//  TODO: should be reworked to deviceManagementActions
+
 export const applySettings = (params: ApplySettingsParams) => async (
     _dispatch: Dispatch,
     getState: GetState,

--- a/packages/suite/src/actions/suite/firmwareActions.ts
+++ b/packages/suite/src/actions/suite/firmwareActions.ts
@@ -3,6 +3,8 @@ import Rollout from '@trezor/rollout';
 
 import { lockUI } from '@suite-actions/suiteActions';
 
+//  TODO: should be reworked to deviceManagementActions
+
 // todo: refactor to suite
 // import * as notificationActions from '@wallet-actions/notificationActions';
 import { SET_UPDATE_STATUS } from '@suite-actions/constants/firmware';

--- a/packages/suite/src/actions/suite/trezorConnectActions.ts
+++ b/packages/suite/src/actions/suite/trezorConnectActions.ts
@@ -35,7 +35,13 @@ export const init = () => async (dispatch: Dispatch, getState: GetState) => {
         dispatch(event);
     });
 
-    const wrappedMethods = ['getFeatures', 'getDeviceState', 'applySettings', 'changePin'] as const;
+    const wrappedMethods = [
+        'getFeatures',
+        'getDeviceState',
+        'applySettings',
+        'changePin',
+        'backupDevice',
+    ] as const;
     wrappedMethods.forEach(key => {
         const original = TrezorConnect[key];
         if (!original) return;

--- a/packages/suite/src/views/suite/backup/index.tsx
+++ b/packages/suite/src/views/suite/backup/index.tsx
@@ -1,10 +1,79 @@
 import React from 'react';
-// import styled from 'styled-components';
+import { connect } from 'react-redux';
+import { bindActionCreators } from 'redux';
+import { Button, P } from '@trezor/components';
+import { backupDevice } from '@suite-actions/backupActions';
+import { goto } from '@suite-actions/routerActions';
+import { getRoute } from '@suite-utils/router';
+import styled from 'styled-components';
 // import { InjectedIntlProps } from 'react-intl';
-// import { AppState } from '@suite-types';
+import { AppState } from '@suite-types';
 
-const Backup = () => {
-    return <div>Backup</div>;
+// note this Wrapper is copypasta from 'firmware' page
+const Wrapper = styled.div`
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    justify-content: center;
+    padding: 60px 24px 30px 24px;
+    flex: 1;
+`;
+
+interface BackupProps {
+    device: AppState['suite']['device'];
+    goto: typeof goto;
+    backupDevice: typeof backupDevice;
+}
+
+const Backup = (props: BackupProps) => {
+    const { device } = props;
+    if (!device || !device.features) return null;
+
+    const getStatus = () => {
+        if (device.features.unfinished_backup) {
+            return 'backup-failed';
+        }
+        if (device.features.needs_backup) {
+            return 'needs-backup';
+        }
+        return 'backup-finished';
+    };
+
+    return (
+        <Wrapper>
+            {getStatus() === 'backup-failed' && (
+                <P>
+                    Backup procedure failed. For security reasons, device will show its seed only
+                    once. You need to wipe device and start over.
+                </P>
+            )}
+            {getStatus() === 'backup-finished' && (
+                <>
+                    <P>
+                        Device is already backed up. You should have your recovery seed. If you dont
+                        have it, you should do something about it now.
+                    </P>
+                    <Button onClick={() => goto(getRoute('wallet-index'))}>Go to wallet</Button>
+                </>
+            )}
+            {getStatus() === 'needs-backup' && (
+                <>
+                    <P>Create backup. Follow instructions on your device</P>
+                    <Button onClick={() => props.backupDevice({ device })}>Start</Button>
+                </>
+            )}
+        </Wrapper>
+    );
 };
 
-export default Backup;
+const mapStateToProps = (state: AppState) => ({
+    device: state.suite.device,
+});
+
+export default connect(
+    mapStateToProps,
+    dispatch => ({
+        backupDevice: bindActionCreators(backupDevice, dispatch),
+        goto: bindActionCreators(goto, dispatch),
+    }),
+)(Backup);

--- a/packages/typescript-typings/types/trezor-connect/index.d.ts
+++ b/packages/typescript-typings/types/trezor-connect/index.d.ts
@@ -282,6 +282,12 @@ declare module 'trezor-connect' {
         message: string;
         coin?: string;
     }
+    export interface FirmwareUpdateParams extends CommonParams {
+        payload: ArrayBuffer;
+        hash?: string;
+        offset?: number;
+        length?: number;  
+    }
 
     export interface BackupDeviceParams extends CommonParams {}
 
@@ -792,9 +798,14 @@ declare module 'trezor-connect' {
          * Asks device to verify a message using the signer address and signature.
          */
         function verifyMessage(params: VerifyMessageParams): Promise<ResponseMessage<Message>>;
-        
-        // todo:
-        function firmwareUpdate(params: any): Promise<ResponseMessage<Message>>;
+
+        /**
+         * Sends FirmwareErase message followed by FirmwareUpdate message
+         */
+        function firmwareUpdate(params: FirmwareUpdateParams): Promise<ResponseMessage<Message>>;
+        /**
+         * Asks device to initiate seed backup procedure
+         */
         function backupDevice(params: BackupDeviceParams): Promise<ResponseMessage<Message>>;
 
         function dispose(): void;

--- a/packages/typescript-typings/types/trezor-connect/index.d.ts
+++ b/packages/typescript-typings/types/trezor-connect/index.d.ts
@@ -283,6 +283,8 @@ declare module 'trezor-connect' {
         coin?: string;
     }
 
+    export interface BackupDeviceParams extends CommonParams {}
+
     export interface SignedMessage {
         address: string; // signer address
         signature: string; // signature in base64 format
@@ -791,8 +793,9 @@ declare module 'trezor-connect' {
          */
         function verifyMessage(params: VerifyMessageParams): Promise<ResponseMessage<Message>>;
         
-        // hmm, does it make sense to type it now?
+        // todo:
         function firmwareUpdate(params: any): Promise<ResponseMessage<Message>>;
+        function backupDevice(params: BackupDeviceParams): Promise<ResponseMessage<Message>>;
 
         function dispose(): void;
 


### PR DESCRIPTION
Again, very small PR.

Adding working backup for model T. And actually it should work for model one as well, just there is no UI for it.

As discussed on slack today, we probably want to have all actions regarding device management in one. So this, firmare update and device setings, everything is going to be refactored. I would do it in another PR, if you dont mind.  