### PR TITLE
trezor/components: Generate declaration maps on build

### DIFF
--- a/packages/components/tsconfig.json
+++ b/packages/components/tsconfig.json
@@ -15,7 +15,7 @@
         "declaration": true,
         // Only emit ‘.d.ts’ declaration files.
         "emitDeclarationOnly": true,
-        "declarationMap": false,
+        "declarationMap": true,
         "noImplicitReturns": true,
         "noImplicitThis": true,
         "noImplicitAny": true,


### PR DESCRIPTION
`cmd+click` on a declaration of a component will redirect to the source code  (eg `/src/Button.tsx`) instead of types declaration (eg `/lib/Button.d.ts`).
![Screen Recording 2019-09-02 at 15 13 01](https://user-images.githubusercontent.com/6961901/64117296-1654fb00-cd95-11e9-8787-0c1eb1b54b76.gif)
