### PR TITLE
[question]: isnt it better to have references manual?

### DIFF
--- a/ci/packages/components-storybook.yml
+++ b/ci/packages/components-storybook.yml
@@ -82,6 +82,7 @@ components-storybook test snapshots:
 components-storybook make snapshot references:
   image: cypress/base:10
   stage: integration testing
+  when: manual
   script:
     - npx cypress install
     - CYPRESS_baseUrl=${DEV_SERVER_URL}/components-storybook/${CI_BUILD_REF_NAME} yarn workspace @trezor/components-storybook ci:test:snapshots:references


### PR DESCRIPTION
components are quite stable and in 99% of cases I dont need `make references` job. Wouldnt it be better to run it on manual action?