### PR TITLE
change texts

### DIFF
--- a/packages/suite/src/components/suite/modals/AddAccount/components/AccountSelect.tsx
+++ b/packages/suite/src/components/suite/modals/AddAccount/components/AccountSelect.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { FormattedMessage } from 'react-intl';
 import styled from 'styled-components';
-import { P, Button, variables, colors } from '@trezor/components';
+import { Button, variables, colors } from '@trezor/components';
 import { Network, ExternalNetwork, Account } from '@wallet-types';
 import { NETWORKS } from '@wallet-config';
 import l10nMessages from '../messages';
@@ -18,9 +18,10 @@ const StyledButton = styled(Button)`
     margin: 4px 0px;
 `;
 
-const StyledP = styled(P)`
-    margin: 20px 0;
-`;
+// keeping it here in case we want to add some texts
+// const StyledP = styled(P)`
+//     margin: 20px 0;
+// `;
 
 const AccountNameWrapper = styled.div`
     display: flex;
@@ -42,12 +43,6 @@ const EnableNetwork = (props: {
     onEnableNetwork: Props['onEnableNetwork'];
 }) => (
     <>
-        <StyledP>
-            <FormattedMessage
-                {...l10nMessages.TR_ENABLE_NETWORK}
-                values={{ networkName: props.selectedNetwork.name }}
-            />
-        </StyledP>
         <StyledButton fullWidth onClick={() => props.onEnableNetwork(props.selectedNetwork.symbol)}>
             <FormattedMessage
                 {...l10nMessages.TR_ENABLE_NETWORK_BUTTON}

--- a/packages/suite/src/components/suite/modals/AddAccount/messages.ts
+++ b/packages/suite/src/components/suite/modals/AddAccount/messages.ts
@@ -5,11 +5,6 @@ const definedMessages = defineMessages({
         id: 'TR_ADD_NEW_ACCOUNT',
         defaultMessage: 'Add new account',
     },
-    TR_ENABLE_NETWORK: {
-        id: 'TR_ENABLE_NETWORK',
-        defaultMessage:
-            '{networkName} is disabled.\nTODO: add more text about enabling networks in wallet settings',
-    },
     TR_ENABLE_NETWORK_BUTTON: {
         id: 'TR_ENABLE_NETWORK_BUTTON',
         defaultMessage: 'Find my {networkName} accounts',


### PR DESCRIPTION
prev state 
![image](https://user-images.githubusercontent.com/30367552/66033988-ab6c2080-e508-11e9-90f4-77487121af5c.png)

new state 
![image](https://user-images.githubusercontent.com/30367552/66033921-88417100-e508-11e9-949f-fd15e0f2d48b.png)

imho no text is needed here, on button click, first normal account is added and network is enabled in settings automatically. 
