### PR TITLE
Fix static files in ci build

### DIFF
--- a/ci/packages/suite-desktop.yml
+++ b/ci/packages/suite-desktop.yml
@@ -16,6 +16,7 @@ suite-desktop build:
     stage: build
     when: manual
     script:
+        - yarn workspace @trezor/suite-data copy-static-files
         - yarn workspace @trezor/suite-desktop build:linux
     artifacts:
         expire_in: 1 day


### PR DESCRIPTION
currently there is a bug in suite-desktop build. It does not include static files. Id say it is because copy-files task does not run or maybe it runs but its result does not persists between steps?. 

Debugging in CI.