### PR TITLE
Fix overflow in notification title/message

### DIFF
--- a/packages/components/src/components/Notification/index.tsx
+++ b/packages/components/src/components/Notification/index.tsx
@@ -42,12 +42,14 @@ const Body = styled.div`
 
 const Message = styled.div`
     font-size: ${FONT_SIZE.SMALL};
+    word-break: break-word;
 `;
 
 const Title = styled.div`
     padding-bottom: 5px;
     padding-top: 1px;
     font-weight: ${FONT_WEIGHT.MEDIUM};
+    word-break: break-word;
 `;
 
 const CloseClick = styled.div`


### PR DESCRIPTION
**before:**
<img width="483" alt="Screenshot 2019-10-02 at 16 21 11" src="https://user-images.githubusercontent.com/6961901/66052506-fdc13780-e530-11e9-892b-638eaf8f5678.png">

**after:**
<img width="465" alt="Screenshot 2019-10-02 at 16 20 53" src="https://user-images.githubusercontent.com/6961901/66052505-fd28a100-e530-11e9-860c-106f2ec5ffe6.png">

