### PR TITLE
cypress - add babel-loader, connect mocks

### DIFF
--- a/packages/suite-web/pages/_app.tsx
+++ b/packages/suite-web/pages/_app.tsx
@@ -14,9 +14,18 @@ import CypressExportStore from '@suite-support/CypressExportStore';
 import Router from '@suite-support/Router';
 import l10nCommonMessages from '@suite-views/index.messages';
 import { isDev } from '@suite-utils/build';
+import TrezorConnect from 'trezor-connect';
 import { SENTRY } from '@suite-config';
 import { Store } from '@suite-types';
 import ImagesPreloader from '../support/ImagesPreloader';
+
+declare global {
+    interface Window {
+        store: Store;
+        Cypress: any;
+        TrezorConnect: typeof TrezorConnect;
+    }
+}
 
 interface Props {
     store: Store;
@@ -32,6 +41,10 @@ class TrezorSuiteApp extends App<Props> {
     componentDidMount() {
         if (!window.Cypress && !isDev()) {
             Sentry.init({ dsn: SENTRY });
+        }
+        if (window.Cypress) {
+            // exposing ref to TrezorConnect allows us to mock its methods in cypress tests
+            window.TrezorConnect = TrezorConnect;
         }
     }
 
@@ -62,7 +75,6 @@ class TrezorSuiteApp extends App<Props> {
                             <Preloader isStatic={isStaticRoute}>
                                 <Component {...pageProps} />
                             </Preloader>
-                            <CypressExportStore store={store} />
                         </>
                     </IntlProvider>
                 </ReduxProvider>

--- a/packages/suite-web/support/CypressExportStore.tsx
+++ b/packages/suite-web/support/CypressExportStore.tsx
@@ -1,21 +1,11 @@
 /* eslint-disable @typescript-eslint/no-namespace */
-
 import { useEffect } from 'react';
+
 import { Store } from '@suite-types';
 
 interface Props {
     store?: Store;
 }
-declare global {
-    interface Window {
-        store: Store;
-        // todo: Cypress property is added by test runner automatically. I just need it to decide
-        // if store should be exposed on window object.
-        Cypress: any;
-    }
-}
-
-// todo: expose TrezorConnect on window to make its interface adjustable for tests;
 
 /**
  * Utility for running tests in Cypress.

--- a/packages/suite-web/test/integration/onboarding-create-new-wallet.test.ts
+++ b/packages/suite-web/test/integration/onboarding-create-new-wallet.test.ts
@@ -78,7 +78,7 @@ describe('Onboarding', () => {
             // mocked trezor-connect or @onboarding-actions/connectActions module. To be able to mock
             // such module, I need to setup entire typescript to understand our custom import paths.
             // currently, we have paths specified in babel config, typescript has different syntax
-            // IT WOULD BE BEST to figure out, how to make next-config work with cypress tests 
+            // IT WOULD BE BEST to figure out, how to make next-config work with cypress tests
             // .getTestElement('button-standard-backup')
             // .click();
 

--- a/packages/suite-web/test/integration/onboarding-create-new-wallet.test.ts
+++ b/packages/suite-web/test/integration/onboarding-create-new-wallet.test.ts
@@ -7,105 +7,83 @@ import { DEVICE } from 'trezor-connect';
 // declaration for support files is not present in babel.config (and probably shouldnt be)
 import { getConnectDevice, getDeviceFeatures } from '../../../suite/src/support/tests/setupJest';
 
-describe('Onboarding', () => {
+describe('Onboarding happy paths', () => {
     beforeEach(() => {
         cy.viewport(1024, 768).resetDb();
     });
 
-    // todo: not finished yet, now I can control everything that happens in the app
-    // through dispatching mocked actions, but I want to interact as close
-    // to UI as possible, so I will need to mock trezor-connect that
-    // is invoked on user clicks
-    it(`create new wallet happy path`, () => {
-        cy.visit('/')
-            .get('html')
-            .should('contain', 'Welcome to Trezor')
-            .getTestElement('button-path-create')
-            .click()
-            // todo: add snapshots in distance future when everything is stable
-            // .matchImageSnapshot()
-            .get('html')
-            .should('contain', 'New device')
-            .getTestElement('button-new-path')
-            .click()
-            .get('html')
-            .should('contain', 'Select your device')
-            .getTestElement('option-model-t-path')
-            .click()
-            .get('html')
-            .should('contain', 'Hologram check')
-            .getTestElement('button-continue')
-            .click()
-            .get('html')
-            .should('contain', 'Pair device')
-            .window()
-            .its('store')
-            .invoke('dispatch', {
-                type: DEVICE.CONNECT,
-                payload: getConnectDevice({
-                    mode: 'initialize',
-                    firmware: 'none',
-                    features: getDeviceFeatures({
-                        firmware_present: false,
-                        bootloader_mode: true,
-                        initialized: false,
-                    }),
-                }),
-            })
-            .getTestElement('button-continue')
-            .click()
-            .get('html')
-            .should('contain', 'Pair device')
-            .window()
-            .its('store')
-            .invoke('dispatch', {
-                type: DEVICE.CHANGED,
-                payload: getConnectDevice({
-                    mode: 'initialize',
-                    firmware: 'valid',
-                    features: getDeviceFeatures({
-                        firmware_present: true,
-                        bootloader_mode: false,
-                        initialized: false,
-                    }),
-                }),
-            })
-            .getTestElement('button-continue')
-            .click()
-            .get('html')
-            .should('contain', 'Seed type')
-            // todo: here it would be nice to click. but to be able to do that, I would need to have
-            // mocked trezor-connect or @onboarding-actions/connectActions module. To be able to mock
-            // such module, I need to setup entire typescript to understand our custom import paths.
-            // currently, we have paths specified in babel config, typescript has different syntax
-            // IT WOULD BE BEST to figure out, how to make next-config work with cypress tests
-            // .getTestElement('button-standard-backup')
-            // .click();
-
-            // todo: so heree I just simulate button click by dispatching actions it would trigger in the end.
-            // this is not the way I would like to go.
-            .window()
-            .its('store')
-            .invoke('dispatch', {
-                type: DEVICE.CHANGED,
-                payload: getConnectDevice({
-                    mode: 'normal',
-                    firmware: 'valid',
-                    features: getDeviceFeatures({
-                        initialized: true,
-                        needs_backup: true,
-                    }),
-                }),
-            })
-            .window()
-            .its('store')
-            .invoke('dispatch', {
-                type: '@onboarding/set-step-active',
-                stepId: 'security',
-            })
-            .get('html')
-            .should('contain', 'Take me to security')
-            .getTestElement('button-exit-app')
-            .click();
+    it(`create new wallet - skip security - appear in wallet`, () => {
+        cy.visit('/');
+        cy.window()
+            .its('TrezorConnect')
+            .should('exist')
+            .then(TrezorConnect => {
+                cy.stub(TrezorConnect, 'resetDevice', () => {
+                    console.warn('sthubbed shit');
+                    return Promise.resolve({ success: true });
+                });
+                cy.get('html')
+                    .should('contain', 'Welcome to Trezor')
+                    .getTestElement('button-path-create')
+                    .click()
+                    // todo: add snapshots in distance future when everything is stable
+                    // .matchImageSnapshot()
+                    .get('html')
+                    .should('contain', 'New device')
+                    .getTestElement('button-new-path')
+                    .click()
+                    .get('html')
+                    .should('contain', 'Select your device')
+                    .getTestElement('option-model-t-path')
+                    .click()
+                    .get('html')
+                    .should('contain', 'Hologram check')
+                    .getTestElement('button-continue')
+                    .click()
+                    .get('html')
+                    .should('contain', 'Pair device')
+                    .window()
+                    .its('store')
+                    .invoke('dispatch', {
+                        type: DEVICE.CONNECT,
+                        payload: getConnectDevice({
+                            mode: 'initialize',
+                            firmware: 'none',
+                            features: getDeviceFeatures({
+                                firmware_present: false,
+                                bootloader_mode: true,
+                                initialized: false,
+                            }),
+                        }),
+                    })
+                    .getTestElement('button-continue')
+                    .click()
+                    .get('html')
+                    .should('contain', 'Pair device')
+                    .window()
+                    .its('store')
+                    .invoke('dispatch', {
+                        type: DEVICE.CHANGED,
+                        payload: getConnectDevice({
+                            mode: 'initialize',
+                            firmware: 'valid',
+                            features: getDeviceFeatures({
+                                firmware_present: true,
+                                bootloader_mode: false,
+                                initialized: false,
+                            }),
+                        }),
+                    })
+                    .getTestElement('button-continue')
+                    .click()
+                    .get('html')
+                    .should('contain', 'Seed type')
+                    .getTestElement('button-standard-backup')
+                    .click()
+                    .get('html')
+                    .should('contain', 'Take me to security')
+                    .getTestElement('button-exit-app')
+                    .click();
+            });
     });
 });

--- a/packages/suite-web/test/integration/onboarding-create-new-wallet.test.ts
+++ b/packages/suite-web/test/integration/onboarding-create-new-wallet.test.ts
@@ -1,5 +1,10 @@
 /* eslint-disable @typescript-eslint/camelcase */
 import { DEVICE } from 'trezor-connect';
+
+// todo: importing like this works now.
+// import * as connectActions from '@onboarding-actions/connectActions';
+
+// declaration for support files is not present in babel.config (and probably shouldnt be)
 import { getConnectDevice, getDeviceFeatures } from '../../../suite/src/support/tests/setupJest';
 
 describe('Onboarding', () => {
@@ -68,9 +73,39 @@ describe('Onboarding', () => {
             .getTestElement('button-continue')
             .click()
             .get('html')
-            .should('contain', 'Seed type');
-        // todo: mock connect to make this work.
-        // .getTestElement('button-standard-backup')
-        // .click()
+            .should('contain', 'Seed type')
+            // todo: here it would be nice to click. but to be able to do that, I would need to have
+            // mocked trezor-connect or @onboarding-actions/connectActions module. To be able to mock
+            // such module, I need to setup entire typescript to understand our custom import paths.
+            // currently, we have paths specified in babel config, typescript has different syntax
+            // IT WOULD BE BEST to figure out, how to make next-config work with cypress tests 
+            // .getTestElement('button-standard-backup')
+            // .click();
+
+            // todo: so heree I just simulate button click by dispatching actions it would trigger in the end.
+            // this is not the way I would like to go.
+            .window()
+            .its('store')
+            .invoke('dispatch', {
+                type: DEVICE.CHANGED,
+                payload: getConnectDevice({
+                    mode: 'normal',
+                    firmware: 'valid',
+                    features: getDeviceFeatures({
+                        initialized: true,
+                        needs_backup: true,
+                    }),
+                }),
+            })
+            .window()
+            .its('store')
+            .invoke('dispatch', {
+                type: '@onboarding/set-step-active',
+                stepId: 'security',
+            })
+            .get('html')
+            .should('contain', 'Take me to security')
+            .getTestElement('button-exit-app')
+            .click();
     });
 });

--- a/packages/suite-web/test/integration/onboarding/onboarding-create-new-wallet.test.ts
+++ b/packages/suite-web/test/integration/onboarding/onboarding-create-new-wallet.test.ts
@@ -5,7 +5,7 @@ import { DEVICE } from 'trezor-connect';
 // import * as connectActions from '@onboarding-actions/connectActions';
 
 // declaration for support files is not present in babel.config (and probably shouldnt be)
-import { getConnectDevice, getDeviceFeatures } from '../../../suite/src/support/tests/setupJest';
+import { getConnectDevice, getDeviceFeatures } from '../../../../suite/src/support/tests/setupJest';
 
 describe('Onboarding happy paths', () => {
     beforeEach(() => {
@@ -19,7 +19,6 @@ describe('Onboarding happy paths', () => {
             .should('exist')
             .then(TrezorConnect => {
                 cy.stub(TrezorConnect, 'resetDevice', () => {
-                    console.warn('sthubbed shit');
                     return Promise.resolve({ success: true });
                 });
                 cy.get('html')

--- a/packages/suite-web/test/plugins/ts-preprocessor.js
+++ b/packages/suite-web/test/plugins/ts-preprocessor.js
@@ -13,8 +13,7 @@ const webpackOptions = {
     module: {
         rules: [
             {
-                // test: /\.ts$/,
-                test: /\.ts(x?)$/,
+                test: /\.ts$/,
                 exclude: [/node_modules/],
                 use: [
                     {
@@ -24,7 +23,7 @@ const webpackOptions = {
                     {
                         loader: 'ts-loader',
                         options: {
-                            configFile: '../tsconfig.json',
+                            configFile: 'packages/suite-web/test/tsconfig.json',
                         },
                     },
                 ],

--- a/packages/suite-web/test/plugins/ts-preprocessor.js
+++ b/packages/suite-web/test/plugins/ts-preprocessor.js
@@ -1,6 +1,10 @@
 /* eslint-disable @typescript-eslint/no-var-requires */
 
 const wp = require('@cypress/webpack-preprocessor');
+const babel = require('../../babel.config');
+
+// hackinsh smackish way how to make it work, I didnt want to touch app config at all
+const babelOptions = babel({ cache: () => {} });
 
 const webpackOptions = {
     resolve: {
@@ -9,9 +13,14 @@ const webpackOptions = {
     module: {
         rules: [
             {
-                test: /\.ts$/,
+                // test: /\.ts$/,
+                test: /\.ts(x?)$/,
                 exclude: [/node_modules/],
                 use: [
+                    {
+                        loader: 'babel-loader',
+                        options: babelOptions,
+                    },
                     {
                         loader: 'ts-loader',
                         options: {

--- a/packages/suite-web/test/support/commands.ts
+++ b/packages/suite-web/test/support/commands.ts
@@ -1,7 +1,8 @@
 /* eslint-disable @typescript-eslint/no-namespace */
 /* eslint-disable @typescript-eslint/no-var-requires */
-
+import TrezorConnect from 'trezor-connect';
 import { Store } from '@suite-types';
+
 // import { getConnectDevice } from '../../../suite/src/support/tests/setupJest';
 // import { DEVICE } from 'trezor-connect';
 
@@ -21,6 +22,7 @@ declare global {
 declare global {
     interface Window {
         store: Store;
+        TrezorConnect: typeof TrezorConnect;
     }
 }
 

--- a/packages/suite/src/views/onboarding/steps/Security/index.tsx
+++ b/packages/suite/src/views/onboarding/steps/Security/index.tsx
@@ -17,6 +17,7 @@ const SecurityStep = (props: Props) => (
             </Text>
             <Wrapper.Controls>
                 <OnboardingButton.Alt
+                    data-test="button-exit-app"
                     onClick={() => {
                         props.exitApp(CONFIG.APP.EXIT_APP_ROUTE);
                     }}


### PR DESCRIPTION
- until now, it was not possible to import files from suite package as ts preprocessor could not resolve path aliases. so I added babel-loader using suite-web/babel.config.js to cypress test.

- found a way how to mock trezorConnect methods