### PR TITLE
Add intl support for notifications/redux

### DIFF
--- a/packages/suite/src/actions/wallet/receiveActions.ts
+++ b/packages/suite/src/actions/wallet/receiveActions.ts
@@ -103,12 +103,12 @@ export const showAddress = (path: string) => async (
             type: NOTIFICATION.ADD,
             payload: {
                 variant: 'error',
-                title: l10nMessages.TR_VERIFYING_ADDRESS_ERROR.defaultMessage, // TODO intl support for Notification without the need to pass FormattedMessage
+                title: l10nMessages.TR_VERIFYING_ADDRESS_ERROR,
                 message: response.payload.error,
                 cancelable: true,
                 actions: [
                     {
-                        label: l10nCommonMessages.TR_TRY_AGAIN.defaultMessage,
+                        label: l10nCommonMessages.TR_TRY_AGAIN,
                         callback: () => {
                             dispatch(showAddress(path));
                         },

--- a/packages/suite/src/actions/wallet/selectedAccountActions.ts
+++ b/packages/suite/src/actions/wallet/selectedAccountActions.ts
@@ -17,6 +17,9 @@ import {
 } from '@wallet-reducers/selectedAccountReducer';
 
 import { DISCOVERY_STATUS } from '@suite/reducers/wallet/discoveryReducer';
+import l10nNotificationMessages from '@wallet-components/Notifications/components/Account/index.messages';
+import l10nLoaderMessages from '@wallet-components/Content/index.messages';
+import l10nFwUnsupportedMessages from '@wallet-components/Content/components/FirmwareUnsupported/index.messages';
 import { NETWORKS } from '@wallet-config';
 import { Action, GetState, Dispatch, AppState } from '@suite-types';
 import { DISCOVERY } from './constants';
@@ -53,8 +56,14 @@ const getExceptionPage = (
     if (discovery.fwNotSupported) {
         return {
             type: 'fwNotSupported',
-            title: `${network.name} is not supported with Trezor ${getVersion(device)}`,
-            message: 'Find more information on Trezor Wiki.',
+            title: {
+                ...l10nFwUnsupportedMessages.TR_NETWORK_IS_NOT_SUPPORTED_BY_TREZOR,
+                values: {
+                    networkName: network.name,
+                    deviceVersion: getVersion(device),
+                },
+            },
+            message: l10nFwUnsupportedMessages.TR_FIND_MORE_INFORMATION_ON_TREZOR_WIKI,
             symbol: network.symbol,
         };
     }
@@ -73,7 +82,7 @@ const getAccountLoader = (
     if (!device || !device.state) {
         return {
             type: 'progress',
-            title: 'Loading device...',
+            title: l10nLoaderMessages.TR_LOADING_DEVICE_DOT_DOT_DOT,
         };
     }
 
@@ -81,7 +90,7 @@ const getAccountLoader = (
     if (!network) {
         return {
             type: 'progress',
-            title: 'Loading account',
+            title: l10nLoaderMessages.TR_LOADING_ACCOUNT,
         };
     }
 
@@ -95,23 +104,29 @@ const getAccountLoader = (
             if (device.available) {
                 return {
                     type: 'progress',
-                    title: 'Authenticating device...',
+                    title: l10nLoaderMessages.TR_AUTHENTICATING_DEVICE,
                 };
             }
             // case 2: device is unavailable (created with different passphrase settings) account cannot be accessed
             // this is related to device instance in url, it's not used for now (device clones are disabled)
             return {
                 type: 'info',
-                title: `Device ${device.instanceLabel || device.label} is unavailable`,
-                message: 'Change passphrase settings to use this device',
+                title: {
+                    ...l10nNotificationMessages.TR_DEVICE_LABEL_IS_UNAVAILABLE,
+                    values: { deviceLabel: device.instanceLabel || device.label },
+                },
+                message: l10nNotificationMessages.TR_CHANGE_PASSPHRASE_SETTINGS_TO_USE,
             };
         }
 
         // case 3: device is disconnected
         return {
             type: 'info',
-            title: `Device ${device.instanceLabel} is disconnected`,
-            message: 'Connect device to load accounts',
+            title: {
+                ...l10nNotificationMessages.TR_DEVICE_LABEL_IS_DISCONNECTED,
+                values: { deviceLabel: device.instanceLabel },
+            },
+            message: l10nLoaderMessages.TR_CONNECT_DEVICE_TO_LOAD_ACCOUNT,
         };
     }
 
@@ -119,14 +134,14 @@ const getAccountLoader = (
         // case 4: account not found and discovery is completed
         return {
             type: 'info',
-            title: 'Account does not exist',
+            title: l10nLoaderMessages.TR_ACCOUNT_DOES_NOT_EXIST,
         };
     }
 
     // case default: account information isn't loaded yet
     return {
         type: 'progress',
-        title: 'Loading account',
+        title: l10nLoaderMessages.TR_LOADING_ACCOUNT,
     };
 };
 
@@ -158,7 +173,7 @@ const getAccountNotification = (state: AppState, selectedAccount: SelectedAccoun
         return {
             type: 'info',
             variant: 'info',
-            title: 'Loading other accounts...',
+            title: l10nNotificationMessages.TR_LOADING_OTHER_ACCOUNTS,
             shouldRender: true,
         };
     }
@@ -168,7 +183,10 @@ const getAccountNotification = (state: AppState, selectedAccount: SelectedAccoun
         return {
             type: 'info',
             variant: 'info',
-            title: `Device ${device.instanceLabel} is disconnected`,
+            title: {
+                ...l10nNotificationMessages.TR_DEVICE_LABEL_IS_DISCONNECTED,
+                values: { deviceLabel: device.instanceLabel },
+            },
             shouldRender: true,
         };
     }
@@ -179,8 +197,11 @@ const getAccountNotification = (state: AppState, selectedAccount: SelectedAccoun
         return {
             type: 'info',
             variant: 'info',
-            title: `Device ${device.instanceLabel} is unavailable`,
-            message: 'Change passphrase settings to use this device',
+            title: {
+                ...l10nNotificationMessages.TR_DEVICE_LABEL_IS_UNAVAILABLE,
+                values: { deviceLabel: device.instanceLabel },
+            },
+            message: l10nNotificationMessages.TR_CHANGE_PASSPHRASE_SETTINGS_TO_USE,
             shouldRender: true,
         };
     }

--- a/packages/suite/src/components/suite/IntlMessageExtractor/index.tsx
+++ b/packages/suite/src/components/suite/IntlMessageExtractor/index.tsx
@@ -1,0 +1,47 @@
+import React from 'react';
+import { FormattedMessage } from 'react-intl';
+import { ExtendedMessageDescriptor } from '@suite-types';
+
+export const isMessageDescriptor = (
+    message: React.ReactNode | ExtendedMessageDescriptor,
+): message is ExtendedMessageDescriptor => {
+    return (
+        typeof message === 'object' &&
+        message !== null &&
+        (message as ExtendedMessageDescriptor).defaultMessage !== undefined
+    );
+};
+
+interface Props {
+    children: React.ReactNode | ExtendedMessageDescriptor;
+}
+
+/**
+ * Util component that helps with rendering react-intl messages.
+ * If children prop is an object, it assumes that it is ExtendedMessageDescriptor
+ * and renders FormattedMessage instead of originally passed prop.
+ */
+const IntlMessageExtractor = ({ children }: Props) => {
+    if (isMessageDescriptor(children)) {
+        const values: FormattedMessage.Props['values'] = {};
+        if (children.values) {
+            // Message with variables passed via 'values' prop.
+            // Value entry can also contain a MessageDescriptor.
+            // Copy values and extract necessary messages to a new 'values' object
+            Object.keys(children.values).forEach(key => {
+                values[key] = <IntlMessageExtractor>{children.values![key]}</IntlMessageExtractor>;
+            });
+        }
+
+        // pass undefined to a 'values' prop in case of an empty values object
+        return (
+            <FormattedMessage
+                {...children}
+                values={Object.keys(values).length === 0 ? undefined : values}
+            />
+        );
+    }
+    return <>{children}</>;
+};
+
+export default IntlMessageExtractor;

--- a/packages/suite/src/components/suite/Notification/index.tsx
+++ b/packages/suite/src/components/suite/Notification/index.tsx
@@ -5,9 +5,7 @@ import { Notification, NotificationProps } from '@trezor/components';
 // Add MessageDescriptor type to values entry
 interface ExtendedMessageDescriptor extends FormattedMessage.MessageDescriptor {
     values?: {
-        [key: string]:
-            | React.ReactNode // Original values type
-            | FormattedMessage.MessageDescriptor;
+        [key: string]: React.ReactNode | FormattedMessage.MessageDescriptor;
     };
 }
 

--- a/packages/suite/src/components/suite/Notification/index.tsx
+++ b/packages/suite/src/components/suite/Notification/index.tsx
@@ -5,7 +5,7 @@ import { Notification, NotificationProps } from '@trezor/components';
 // Add MessageDescriptor type to values entry
 interface ExtendedMessageDescriptor extends FormattedMessage.MessageDescriptor {
     values?: {
-        [key: string]: React.ReactNode | FormattedMessage.MessageDescriptor;
+        [key: string]: React.ReactElement | FormattedMessage.MessageDescriptor;
     };
 }
 
@@ -23,7 +23,7 @@ interface Props extends NotificationProps {
 const getFormattedMessage = (message: React.ReactNode | ExtendedMessageDescriptor) => {
     // assume message type is ExtendedMessageDescriptor
     if (typeof message === 'object' && message !== null) {
-        const values: Required<ExtendedMessageDescriptor>['values'] = {};
+        const values: FormattedMessage.Props['values'] = {};
         if ('values' in message && message.values) {
             // Message with variables passed via 'values' prop.
             // Value entry can also contain a MessageDescriptor.
@@ -39,15 +39,11 @@ const getFormattedMessage = (message: React.ReactNode | ExtendedMessageDescripto
         return (
             <FormattedMessage
                 {...(message as ExtendedMessageDescriptor)}
-                values={
-                    Object.keys(values).length === 0
-                        ? undefined
-                        : (values as FormattedMessage.Props['values'])
-                }
+                values={Object.keys(values).length === 0 ? undefined : values}
             />
         );
     }
-    return message;
+    return <>{message}</>;
 };
 
 /**

--- a/packages/suite/src/components/suite/Notification/index.tsx
+++ b/packages/suite/src/components/suite/Notification/index.tsx
@@ -30,14 +30,14 @@ const NotificationWithIntl = (props: Props) => {
             {...props}
             title={getFormattedMessage(props.title)}
             message={getFormattedMessage(props.message)}
-            {...(props.actions
-                ? {
-                      actions: props.actions.map(a => ({
+            actions={
+                props.actions
+                    ? props.actions.map(a => ({
                           ...a,
                           label: getFormattedMessage(a.label),
-                      })),
-                  }
-                : {})}
+                      }))
+                    : undefined
+            }
         />
     );
 };

--- a/packages/suite/src/components/suite/Notification/index.tsx
+++ b/packages/suite/src/components/suite/Notification/index.tsx
@@ -1,0 +1,46 @@
+import React from 'react';
+import { FormattedMessage } from 'react-intl';
+import { Notification, NotificationProps } from '@trezor/components';
+
+// add additional type 'MessageDescriptor' to label to CTA object
+type CTAShape = Required<NotificationProps>['actions'][number] & {
+    label: React.ReactNode | FormattedMessage.MessageDescriptor;
+};
+
+interface Props extends NotificationProps {
+    title: NotificationProps['title'] | FormattedMessage.MessageDescriptor;
+    message?: NotificationProps['message'] | FormattedMessage.MessageDescriptor;
+    callback?: CTAShape[];
+}
+
+const getFormattedMessage = (message: React.ReactNode | FormattedMessage.MessageDescriptor) => {
+    if (typeof message === 'object' && message !== null) {
+        return <FormattedMessage {...(message as FormattedMessage.MessageDescriptor)} />;
+    }
+    return message;
+};
+/**
+ * Wrapper around @trezor/component Notification with support for react-intl messages.
+ * If title, message or callback's label prop is an object, it assumes that it is MessageDescriptor
+ * and renders FormattedMessage instead of originally passed prop.
+ */
+const NotificationWithIntl = (props: Props) => {
+    return (
+        <Notification
+            className={props.className}
+            {...props}
+            title={getFormattedMessage(props.title)}
+            message={getFormattedMessage(props.message)}
+            {...(props.actions
+                ? {
+                      actions: props.actions.map(a => ({
+                          ...a,
+                          label: getFormattedMessage(a.label),
+                      })),
+                  }
+                : {})}
+        />
+    );
+};
+
+export default NotificationWithIntl;

--- a/packages/suite/src/components/suite/Notification/index.tsx
+++ b/packages/suite/src/components/suite/Notification/index.tsx
@@ -20,15 +20,15 @@ interface Props extends NotificationProps {
     actions?: CTAShape[];
 }
 
-function isMessageDescriptor(
+const isMessageDescriptor = (
     message: React.ReactNode | ExtendedMessageDescriptor,
-): message is ExtendedMessageDescriptor {
+): message is ExtendedMessageDescriptor => {
     return (
         typeof message === 'object' &&
         message !== null &&
         (message as ExtendedMessageDescriptor).defaultMessage !== undefined
     );
-}
+};
 
 const getFormattedMessage = (message: React.ReactNode | ExtendedMessageDescriptor) => {
     if (isMessageDescriptor(message)) {

--- a/packages/suite/src/components/suite/Notification/index.tsx
+++ b/packages/suite/src/components/suite/Notification/index.tsx
@@ -20,11 +20,21 @@ interface Props extends NotificationProps {
     actions?: CTAShape[];
 }
 
+function isMessageDescriptor(
+    message: React.ReactNode | ExtendedMessageDescriptor,
+): message is ExtendedMessageDescriptor {
+    return (
+        typeof message === 'object' &&
+        message !== null &&
+        (message as ExtendedMessageDescriptor).defaultMessage !== undefined
+    );
+}
+
 const getFormattedMessage = (message: React.ReactNode | ExtendedMessageDescriptor) => {
     // assume message type is ExtendedMessageDescriptor
-    if (typeof message === 'object' && message !== null && 'defaultMessage' in message) {
+    if (isMessageDescriptor(message)) {
         const values: FormattedMessage.Props['values'] = {};
-        if ('values' in message && message.values) {
+        if (message.values) {
             // Message with variables passed via 'values' prop.
             // Value entry can also contain a MessageDescriptor.
             // Copy values and extract necessary messages to a new 'values' object

--- a/packages/suite/src/components/suite/Notification/index.tsx
+++ b/packages/suite/src/components/suite/Notification/index.tsx
@@ -27,7 +27,6 @@ const getFormattedMessage = (message: React.ReactNode | FormattedMessage.Message
 const NotificationWithIntl = (props: Props) => {
     return (
         <Notification
-            className={props.className}
             {...props}
             title={getFormattedMessage(props.title)}
             message={getFormattedMessage(props.message)}

--- a/packages/suite/src/components/suite/Notification/index.tsx
+++ b/packages/suite/src/components/suite/Notification/index.tsx
@@ -31,7 +31,6 @@ function isMessageDescriptor(
 }
 
 const getFormattedMessage = (message: React.ReactNode | ExtendedMessageDescriptor) => {
-    // assume message type is ExtendedMessageDescriptor
     if (isMessageDescriptor(message)) {
         const values: FormattedMessage.Props['values'] = {};
         if (message.values) {

--- a/packages/suite/src/components/suite/Notification/index.tsx
+++ b/packages/suite/src/components/suite/Notification/index.tsx
@@ -2,26 +2,59 @@ import React from 'react';
 import { FormattedMessage } from 'react-intl';
 import { Notification, NotificationProps } from '@trezor/components';
 
+// Add MessageDescriptor type to values entry
+interface ExtendedMessageDescriptor extends FormattedMessage.MessageDescriptor {
+    values?: {
+        [key: string]:
+            | React.ReactNode // Original values type
+            | FormattedMessage.MessageDescriptor;
+    };
+}
+
 // add additional type 'MessageDescriptor' to label to CTA object
 type CTAShape = Required<NotificationProps>['actions'][number] & {
-    label: React.ReactNode | FormattedMessage.MessageDescriptor;
+    label: React.ReactNode | ExtendedMessageDescriptor;
 };
 
 interface Props extends NotificationProps {
-    title: NotificationProps['title'] | FormattedMessage.MessageDescriptor;
-    message?: NotificationProps['message'] | FormattedMessage.MessageDescriptor;
-    callback?: CTAShape[];
+    title: React.ReactNode | ExtendedMessageDescriptor;
+    message?: React.ReactNode | ExtendedMessageDescriptor;
+    actions?: CTAShape[];
 }
 
-const getFormattedMessage = (message: React.ReactNode | FormattedMessage.MessageDescriptor) => {
+const getFormattedMessage = (message: React.ReactNode | ExtendedMessageDescriptor) => {
+    // assume message type is ExtendedMessageDescriptor
     if (typeof message === 'object' && message !== null) {
-        return <FormattedMessage {...(message as FormattedMessage.MessageDescriptor)} />;
+        const values: Required<ExtendedMessageDescriptor>['values'] = {};
+        if ('values' in message && message.values) {
+            // Message with variables passed via 'values' prop.
+            // Value entry can also contain a MessageDescriptor.
+            // Copy values and extract necessary messages to a new 'values' object
+            Object.keys(message.values).forEach(key => {
+                values[key] = getFormattedMessage(
+                    (message as ExtendedMessageDescriptor).values![key],
+                );
+            });
+        }
+
+        // pass undefined to a 'values' prop in case of an empty values object
+        return (
+            <FormattedMessage
+                {...(message as ExtendedMessageDescriptor)}
+                values={
+                    Object.keys(values).length === 0
+                        ? undefined
+                        : (values as FormattedMessage.Props['values'])
+                }
+            />
+        );
     }
     return message;
 };
+
 /**
  * Wrapper around @trezor/component Notification with support for react-intl messages.
- * If title, message or callback's label prop is an object, it assumes that it is MessageDescriptor
+ * If title, message or callback's label prop is an object, it assumes that it is ExtendedMessageDescriptor
  * and renders FormattedMessage instead of originally passed prop.
  */
 const NotificationWithIntl = (props: Props) => {

--- a/packages/suite/src/components/suite/Notification/index.tsx
+++ b/packages/suite/src/components/suite/Notification/index.tsx
@@ -22,23 +22,21 @@ interface Props extends NotificationProps {
 
 const getFormattedMessage = (message: React.ReactNode | ExtendedMessageDescriptor) => {
     // assume message type is ExtendedMessageDescriptor
-    if (typeof message === 'object' && message !== null) {
+    if (typeof message === 'object' && message !== null && 'defaultMessage' in message) {
         const values: FormattedMessage.Props['values'] = {};
         if ('values' in message && message.values) {
             // Message with variables passed via 'values' prop.
             // Value entry can also contain a MessageDescriptor.
             // Copy values and extract necessary messages to a new 'values' object
             Object.keys(message.values).forEach(key => {
-                values[key] = getFormattedMessage(
-                    (message as ExtendedMessageDescriptor).values![key],
-                );
+                values[key] = getFormattedMessage(message.values![key]);
             });
         }
 
         // pass undefined to a 'values' prop in case of an empty values object
         return (
             <FormattedMessage
-                {...(message as ExtendedMessageDescriptor)}
+                {...message}
                 values={Object.keys(values).length === 0 ? undefined : values}
             />
         );

--- a/packages/suite/src/components/suite/Notification/index.tsx
+++ b/packages/suite/src/components/suite/Notification/index.tsx
@@ -1,57 +1,18 @@
 import React from 'react';
-import { FormattedMessage } from 'react-intl';
 import { Notification, NotificationProps } from '@trezor/components';
-
-// Add MessageDescriptor type to values entry
-interface ExtendedMessageDescriptor extends FormattedMessage.MessageDescriptor {
-    values?: {
-        [key: string]: React.ReactElement | FormattedMessage.MessageDescriptor;
-    };
-}
+import { ExtendedMessageDescriptor } from '@suite-types';
+import IntlMessageExtractor from '../IntlMessageExtractor';
 
 // add additional type 'MessageDescriptor' to label to CTA object
 type CTAShape = Required<NotificationProps>['actions'][number] & {
     label: React.ReactNode | ExtendedMessageDescriptor;
 };
 
-interface Props extends NotificationProps {
+export interface Props extends NotificationProps {
     title: React.ReactNode | ExtendedMessageDescriptor;
     message?: React.ReactNode | ExtendedMessageDescriptor;
     actions?: CTAShape[];
 }
-
-const isMessageDescriptor = (
-    message: React.ReactNode | ExtendedMessageDescriptor,
-): message is ExtendedMessageDescriptor => {
-    return (
-        typeof message === 'object' &&
-        message !== null &&
-        (message as ExtendedMessageDescriptor).defaultMessage !== undefined
-    );
-};
-
-const getFormattedMessage = (message: React.ReactNode | ExtendedMessageDescriptor) => {
-    if (isMessageDescriptor(message)) {
-        const values: FormattedMessage.Props['values'] = {};
-        if (message.values) {
-            // Message with variables passed via 'values' prop.
-            // Value entry can also contain a MessageDescriptor.
-            // Copy values and extract necessary messages to a new 'values' object
-            Object.keys(message.values).forEach(key => {
-                values[key] = getFormattedMessage(message.values![key]);
-            });
-        }
-
-        // pass undefined to a 'values' prop in case of an empty values object
-        return (
-            <FormattedMessage
-                {...message}
-                values={Object.keys(values).length === 0 ? undefined : values}
-            />
-        );
-    }
-    return <>{message}</>;
-};
 
 /**
  * Wrapper around @trezor/component Notification with support for react-intl messages.
@@ -62,13 +23,13 @@ const NotificationWithIntl = (props: Props) => {
     return (
         <Notification
             {...props}
-            title={getFormattedMessage(props.title)}
-            message={getFormattedMessage(props.message)}
+            title={<IntlMessageExtractor>{props.title}</IntlMessageExtractor>}
+            message={<IntlMessageExtractor>{props.message}</IntlMessageExtractor>}
             actions={
                 props.actions
                     ? props.actions.map(a => ({
                           ...a,
-                          label: getFormattedMessage(a.label),
+                          label: <IntlMessageExtractor>{a.label}</IntlMessageExtractor>,
                       }))
                     : undefined
             }

--- a/packages/suite/src/components/suite/index.tsx
+++ b/packages/suite/src/components/suite/index.tsx
@@ -12,6 +12,7 @@ import Header from './Header';
 import FormattedNumber from './FormattedNumber';
 import SuiteLayout from './SuiteLayout';
 import SettingsLayout from './SettingsLayout';
+import Notification from './Notification';
 
 export {
     AcquireDevice,
@@ -28,4 +29,5 @@ export {
     FormattedNumber,
     SuiteLayout,
     SettingsLayout,
+    Notification,
 };

--- a/packages/suite/src/components/wallet/Content/components/FirmwareUnsupported/index.messages.ts
+++ b/packages/suite/src/components/wallet/Content/components/FirmwareUnsupported/index.messages.ts
@@ -5,9 +5,13 @@ const definedMessages = defineMessages({
         id: 'TR_FIND_OUT_MORE_INFO',
         defaultMessage: 'Find out more info',
     },
-    TR_MODEL_DOES_NOT_SUPPORT_COIN: {
-        id: 'TR_MODEL_DOES_NOT_SUPPORT_COIN',
-        defaultMessage: 'The coin {coin} is not supported by your Trezor model.',
+    TR_NETWORK_IS_NOT_SUPPORTED_BY_TREZOR: {
+        id: 'TR_NETWORK_IS_NOT_SUPPORTED_BY_TREZOR',
+        defaultMessage: '{networkName} is not supported by Trezor {deviceVersion}',
+    },
+    TR_FIND_MORE_INFORMATION_ON_TREZOR_WIKI: {
+        id: 'TR_FIND_MORE_INFORMATION_ON_TREZOR_WIKI',
+        defaultMessage: 'Find more information on Trezor Wiki.',
     },
 });
 

--- a/packages/suite/src/components/wallet/Content/components/FirmwareUnsupported/index.tsx
+++ b/packages/suite/src/components/wallet/Content/components/FirmwareUnsupported/index.tsx
@@ -4,12 +4,14 @@ import styled from 'styled-components';
 import { CoinLogo, H4, P, Button, Link, colors } from '@trezor/components';
 
 import { FormattedMessage } from 'react-intl';
+import IntlMessageExtractor from '@suite/components/suite/IntlMessageExtractor';
+import { ExtendedMessageDescriptor } from '@suite/types/suite';
 import l10nMessages from './index.messages';
 
 interface Props {
     symbol?: string | null;
-    title?: string;
-    message?: string;
+    title?: string | ExtendedMessageDescriptor;
+    message?: string | ExtendedMessageDescriptor;
 }
 
 const getInfoUrl = (symbol?: Props['symbol']) => {
@@ -62,7 +64,6 @@ const Message = styled(P)`
 `;
 
 const FirmwareUnsupported = (props: Props) => (
-    // TODO: localization
     <Wrapper>
         <Row>
             {props.symbol && (
@@ -70,8 +71,12 @@ const FirmwareUnsupported = (props: Props) => (
                     <StyledCoinLogo symbol={props.symbol} />
                 </CoinLogoWrapper>
             )}
-            <H4>{props.title}</H4>
-            <Message>{props.message}</Message>
+            <H4>
+                <IntlMessageExtractor>{props.title}</IntlMessageExtractor>
+            </H4>
+            <Message>
+                <IntlMessageExtractor>{props.message}</IntlMessageExtractor>
+            </Message>
             <Link href={getInfoUrl(props.symbol)}>
                 <Button>
                     <FormattedMessage {...l10nMessages.TR_FIND_OUT_MORE_INFO} />

--- a/packages/suite/src/components/wallet/Content/index.messages.ts
+++ b/packages/suite/src/components/wallet/Content/index.messages.ts
@@ -5,6 +5,26 @@ const definedMessages = defineMessages({
         id: 'TR_INITIALIZING_ACCOUNTS',
         defaultMessage: 'Initializing accounts',
     },
+    TR_LOADING_DEVICE_DOT_DOT_DOT: {
+        id: 'TR_LOADING_DEVICE_DOT_DOT_DOT',
+        defaultMessage: 'Loading device...',
+    },
+    TR_LOADING_ACCOUNT: {
+        id: 'TR_LOADING_ACCOUNT',
+        defaultMessage: 'Loading account',
+    },
+    TR_AUTHENTICATING_DEVICE: {
+        id: 'TR_AUTHENTICATING_DEVICE',
+        defaultMessage: 'Authenticating device...',
+    },
+    TR_CONNECT_DEVICE_TO_LOAD_ACCOUNT: {
+        id: 'TR_CONNECT_DEVICE_TO_LOAD_ACCOUNT',
+        defaultMessage: 'Connect device to load accounts',
+    },
+    TR_ACCOUNT_DOES_NOT_EXIST: {
+        id: 'TR_ACCOUNT_DOES_NOT_EXIST',
+        defaultMessage: 'Account does not exist',
+    },
 });
 
 export default definedMessages;

--- a/packages/suite/src/components/wallet/Content/index.tsx
+++ b/packages/suite/src/components/wallet/Content/index.tsx
@@ -3,6 +3,7 @@ import styled from 'styled-components';
 import { FormattedMessage } from 'react-intl';
 import { P, H4, Loader, colors, variables } from '@trezor/components';
 import { ExceptionPage, Loader as LoaderInterface } from '@wallet-reducers/selectedAccountReducer';
+import IntlMessageExtractor from '@suite-components/IntlMessageExtractor';
 import FirmwareUnsupported from './components/FirmwareUnsupported';
 
 import l10nMessages from './index.messages';
@@ -82,12 +83,16 @@ const Content = ({ className, children, isLoading = false, loader, exceptionPage
                         </LoaderWrapper>
                     )}
                     <Title type={loader.type}>
-                        {loader.title || (
+                        {<IntlMessageExtractor>{loader.title}</IntlMessageExtractor> || (
                             <FormattedMessage {...l10nMessages.TR_INITIALIZING_ACCOUNTS} />
                         )}
                     </Title>
                 </Row>
-                {loader.message && <Message>{loader.message}</Message>}
+                {loader.message && (
+                    <Message>
+                        <IntlMessageExtractor>{loader.message}</IntlMessageExtractor>
+                    </Message>
+                )}
             </Loading>
         )}
     </Wrapper>

--- a/packages/suite/src/components/wallet/Notifications/components/Account/index.messages.ts
+++ b/packages/suite/src/components/wallet/Notifications/components/Account/index.messages.ts
@@ -5,6 +5,22 @@ const definedMessages = defineMessages({
         id: 'TR_CONNECT_TO_BACKEND',
         defaultMessage: 'Connect',
     },
+    TR_LOADING_OTHER_ACCOUNTS: {
+        id: 'TR_LOADING_OTHER_ACCOUNTS',
+        defaultMessage: 'Loading other accounts...',
+    },
+    TR_DEVICE_LABEL_IS_DISCONNECTED: {
+        id: 'TR_DEVICE_LABEL_IS_DISCONNECTED',
+        defaultMessage: 'Device {deviceLabel} is disconnected',
+    },
+    TR_DEVICE_LABEL_IS_UNAVAILABLE: {
+        id: 'TR_DEVICE_LABEL_IS_UNAVAILABLE',
+        defaultMessage: 'Device {deviceLabel} is unavailable',
+    },
+    TR_CHANGE_PASSPHRASE_SETTINGS_TO_USE: {
+        id: 'TR_DEVICE_LABEL_IS_UNAVAILABLE',
+        defaultMessage: 'Change passphrase settings to use this device',
+    },
 });
 
 export default definedMessages;

--- a/packages/suite/src/components/wallet/Notifications/components/Account/index.tsx
+++ b/packages/suite/src/components/wallet/Notifications/components/Account/index.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react';
 import { injectIntl, InjectedIntlProps } from 'react-intl';
-import { Notification } from '@trezor/components';
-import { AppState } from '@suite/types/suite';
+import { Notification } from '@suite-components';
+import { AppState } from '@suite-types';
 import l10nMessages from './index.messages';
 // TODO
 interface Props extends InjectedIntlProps {

--- a/packages/suite/src/components/wallet/Notifications/components/Action/components/NotificationsGroups/components/Group/index.tsx
+++ b/packages/suite/src/components/wallet/Notifications/components/Action/components/NotificationsGroups/components/Group/index.tsx
@@ -1,8 +1,10 @@
 import React, { PureComponent } from 'react';
 import styled from 'styled-components';
-import { colors, Notification, Icon, utils } from '@trezor/components';
+import { colors, Icon, utils } from '@trezor/components';
+
 import { NotificationEntry } from '@suite-reducers/notificationReducer';
 import { close } from '@suite-actions/notificationActions';
+import Notification from '@suite-components/Notification';
 
 const { getPrimaryColor } = utils.colors;
 const { getStateIcon } = utils.icons;

--- a/packages/suite/src/reducers/wallet/selectedAccountReducer.ts
+++ b/packages/suite/src/reducers/wallet/selectedAccountReducer.ts
@@ -10,12 +10,6 @@ export interface Loader {
     message?: string | ExtendedMessageDescriptor;
 }
 
-export interface Notification {
-    variant: NotificationProps['variant'];
-    title: NotificationProps['title'];
-    message?: NotificationProps['message'];
-}
-
 export interface ExceptionPage {
     type?: string;
     title?: string | ExtendedMessageDescriptor;
@@ -23,7 +17,7 @@ export interface ExceptionPage {
     symbol: string;
 }
 
-interface AccountNotification extends Notification {
+interface AccountNotification extends NotificationProps {
     type: 'info' | 'backend';
 }
 export interface State {

--- a/packages/suite/src/reducers/wallet/selectedAccountReducer.ts
+++ b/packages/suite/src/reducers/wallet/selectedAccountReducer.ts
@@ -1,24 +1,25 @@
 import produce from 'immer';
 import { ACCOUNT } from '@wallet-actions/constants';
-import { Action } from '@suite-types';
+import { Props as NotificationProps } from '@suite-components/Notification';
+import { Action, ExtendedMessageDescriptor } from '@suite-types';
 import { Network, Account, Discovery } from '@wallet-types';
 
 export interface Loader {
     type: string;
-    title: string;
-    message?: string;
+    title: string | ExtendedMessageDescriptor;
+    message?: string | ExtendedMessageDescriptor;
 }
 
 export interface Notification {
-    variant: 'info' | 'success' | 'warning' | 'error';
-    title: string;
-    message?: string;
+    variant: NotificationProps['variant'];
+    title: NotificationProps['title'];
+    message?: NotificationProps['message'];
 }
 
 export interface ExceptionPage {
     type?: string;
-    title?: string;
-    message?: string;
+    title?: string | ExtendedMessageDescriptor;
+    message?: string | ExtendedMessageDescriptor;
     symbol: string;
 }
 

--- a/packages/suite/src/support/suite/ConnectedIntlProvider.tsx
+++ b/packages/suite/src/support/suite/ConnectedIntlProvider.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { IntlProvider, addLocaleData } from 'react-intl';
+import { IntlProvider, addLocaleData, FormattedMessage } from 'react-intl';
 import { connect } from 'react-redux';
 
 import en from 'react-intl/locale-data/en';
@@ -20,18 +20,15 @@ import uk from 'react-intl/locale-data/uk';
 import zh from 'react-intl/locale-data/zh';
 import { AppState } from '@suite-types';
 
-export interface MessageDescriptor {
-    // A unique, stable identifier for the message
-    id: string;
-    // The default message (probably in English)
-    defaultMessage: string;
-    // Context for the translator about how it's used in the UI
-    description?: string;
-    values?: { [key: string]: any };
+// Add MessageDescriptor type to values entry
+export interface ExtendedMessageDescriptor extends FormattedMessage.MessageDescriptor {
+    values?: {
+        [key: string]: string | React.ReactElement | FormattedMessage.MessageDescriptor;
+    };
 }
 
 export interface Messages {
-    [key: string]: MessageDescriptor;
+    [key: string]: FormattedMessage.MessageDescriptor;
 }
 
 addLocaleData([

--- a/packages/suite/src/types/suite/index.ts
+++ b/packages/suite/src/types/suite/index.ts
@@ -19,15 +19,11 @@ import { ModalActions } from '@suite-actions/modalActions';
 import { LogActions } from '@suite-actions/logActions';
 import { NotificationActions } from '@suite-actions/notificationActions';
 import OnboardingActions from '@onboarding-types/actions';
-import {
-    MessageDescriptor as MessageDescriptor$,
-    Messages as Messages$,
-} from '@suite-support/ConnectedIntlProvider';
+import { ExtendedMessageDescriptor as ExtendedMessageDescriptor$ } from '@suite-support/ConnectedIntlProvider';
 import { WalletAction } from '@wallet-types';
 
 // this weird export is because of --isolatedModules and next.js 9
-export type MessageDescriptor = MessageDescriptor$;
-export type Messages = Messages$;
+export type ExtendedMessageDescriptor = ExtendedMessageDescriptor$;
 
 type TrezorConnectEvents =
     | Omit<TransportEvent, 'event'>


### PR DESCRIPTION
- new helper component `IntlMessageExtractor` that takes care of rendering intl message when needed
- new component `suite/Notification` that wraps @trezor/component `Notification` and correctly handles rendering of intl message passed to title, message or actions' label prop (via `IntlMessageExtractor`)
- all dynamic notifications (created from redux action) now support intl messages
- refactored selectedAccountActions to dispatch intl messages instead of pure strings.