### PR TITLE
Add document titles

### DIFF
--- a/packages/suite-desktop/src/electron.js
+++ b/packages/suite-desktop/src/electron.js
@@ -31,8 +31,8 @@ const init = async () => {
     }
 
     mainWindow = new BrowserWindow({
-        width: 800,
-        height: 600,
+        width: 980,
+        height: 660,
         webPreferences: {
             webSecurity: !isDev,
             allowRunningInsecureContent: isDev,

--- a/packages/suite-desktop/src/electron.js
+++ b/packages/suite-desktop/src/electron.js
@@ -32,7 +32,7 @@ const init = async () => {
 
     mainWindow = new BrowserWindow({
         width: 980,
-        height: 660,
+        height: 680,
         webPreferences: {
             webSecurity: !isDev,
             allowRunningInsecureContent: isDev,

--- a/packages/suite/src/components/suite/SettingsLayout/index.tsx
+++ b/packages/suite/src/components/suite/SettingsLayout/index.tsx
@@ -4,6 +4,7 @@ import WalletNotifications from '@wallet-components/Notifications';
 import { SuiteLayout } from '@suite-components';
 
 interface Props {
+    title: string;
     children?: React.ReactNode;
 }
 
@@ -27,7 +28,7 @@ const Layout = styled.div`
 
 const SettingsLayout = (props: Props) => {
     return (
-        <SuiteLayout showSuiteHeader disableSidebar title="Settings | Trezor Suite">
+        <SuiteLayout showSuiteHeader disableSidebar title={props.title}>
             <Layout>
                 <WalletNotifications />
                 <Wrapper>{props.children}</Wrapper>

--- a/packages/suite/src/components/suite/SettingsLayout/index.tsx
+++ b/packages/suite/src/components/suite/SettingsLayout/index.tsx
@@ -27,7 +27,7 @@ const Layout = styled.div`
 
 const SettingsLayout = (props: Props) => {
     return (
-        <SuiteLayout showSuiteHeader disableSidebar>
+        <SuiteLayout showSuiteHeader disableSidebar title="Settings | Trezor Suite">
             <Layout>
                 <WalletNotifications />
                 <Wrapper>{props.children}</Wrapper>

--- a/packages/suite/src/components/suite/SuiteLayout/index.tsx
+++ b/packages/suite/src/components/suite/SuiteLayout/index.tsx
@@ -12,6 +12,7 @@ import { Header as CommonHeader, LanguagePicker, colors } from '@trezor/componen
 import ErrorBoundary from '@suite-support/ErrorBoundary';
 import SuiteNotifications from '@suite-components/Notifications';
 import NoSSR from '@suite/support/suite/NoSSR';
+import Head from 'next/head';
 import { URLS } from '@suite-constants';
 
 import l10nMessages from './index.messages';
@@ -61,6 +62,7 @@ interface Props {
     isLanding?: boolean;
     showSuiteHeader?: boolean;
     fullscreenMode?: boolean;
+    title?: string;
     children: React.ReactNode;
     footer?: React.ReactNode;
     additionalDeviceMenuItems?: React.ReactNode;
@@ -71,6 +73,9 @@ interface Props {
 
 const SuiteLayout = (props: Props & InjectedIntlProps) => (
     <PageWrapper isLanding={props.isLanding}>
+        <Head>
+            <title>{props.title || 'Trezor Suite'}</title>
+        </Head>
         <CommonHeader
             sidebarOpened={props.suite.showSidebar}
             toggleSidebar={props.toggleSidebar}

--- a/packages/suite/src/components/suite/SuiteLayout/index.tsx
+++ b/packages/suite/src/components/suite/SuiteLayout/index.tsx
@@ -74,7 +74,7 @@ interface Props {
 const SuiteLayout = (props: Props & InjectedIntlProps) => (
     <PageWrapper isLanding={props.isLanding}>
         <Head>
-            <title>{props.title || 'Trezor Suite'}</title>
+            <title>{props.title ? `${props.title} | Trezor Suite` : 'Trezor Suite'}</title>
         </Head>
         <CommonHeader
             sidebarOpened={props.suite.showSidebar}

--- a/packages/suite/src/components/wallet/LayoutAccount/index.tsx
+++ b/packages/suite/src/components/wallet/LayoutAccount/index.tsx
@@ -8,10 +8,12 @@ import l10nMessages from './index.messages';
 
 interface Props {
     children: React.ReactNode;
+    title: string;
 }
 
 const LayoutAccount = (props: Props) => (
     <WalletLayout
+        title={props.title}
         topNavigationComponent={
             <TopNavigation
                 items={[

--- a/packages/suite/src/components/wallet/WalletLayout/index.tsx
+++ b/packages/suite/src/components/wallet/WalletLayout/index.tsx
@@ -20,6 +20,7 @@ const mapStateToProps = (state: AppState) => ({
 
 type Props = {
     topNavigationComponent?: React.ReactNode;
+    title: string;
     children?: React.ReactNode;
 } & ReturnType<typeof mapStateToProps>;
 
@@ -54,6 +55,7 @@ const WalletLayout = (props: Props) => {
             showSuiteHeader
             footer={<Footer />}
             additionalDeviceMenuItems={<WalletMenuItems />}
+            title={props.title}
         >
             <Wrapper>
                 <ProgressBar />

--- a/packages/suite/src/views/onboarding/index.tsx
+++ b/packages/suite/src/views/onboarding/index.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import styled, { keyframes } from 'styled-components';
+import Head from 'next/head';
 import { Link, P, Prompt, variables } from '@trezor/components';
 import { connect } from 'react-redux';
 import { bindActionCreators } from 'redux';
@@ -260,148 +261,153 @@ const Onboarding = (props: Props) => {
     const activeStep = getStep(activeStepId);
 
     return (
-        <Preloader loaded={loaded}>
-            <WrapperOutside>
-                <WrapperInside isGlobalInteraction={isGlobalInteraction()}>
-                    {errorState && (
-                        <UnexpectedStateOverlay>
-                            <UnexpectedState
-                                caseType={errorState}
-                                prevModel={
-                                    (prevDevice &&
-                                        prevDevice.features &&
-                                        prevDevice.features.major_version) ||
-                                    2
-                                }
-                                uiInteraction={uiInteraction}
-                            />
-                        </UnexpectedStateOverlay>
-                    )}
-                    <ProgressStepsSlot>
-                        <ProgressSteps
-                            hiddenOnSteps={[
-                                STEP.ID_WELCOME_STEP,
-                                STEP.ID_SECURITY_STEP,
-                                STEP.ID_FINAL_STEP,
-                            ]}
-                            steps={steps}
-                            activeStep={activeStep}
-                            isDisabled={deviceCall.isProgress}
-                        />
-                    </ProgressStepsSlot>
-                    <ComponentWrapper>
-                        {uiInteraction.name && isGlobalInteraction() && (
-                            <TrezorAction model={model} event={uiInteraction.name} />
+        <>
+            <Head>
+                <title>Onboarding | Trezor Suite</title>
+            </Head>
+            <Preloader loaded={loaded}>
+                <WrapperOutside>
+                    <WrapperInside isGlobalInteraction={isGlobalInteraction()}>
+                        {errorState && (
+                            <UnexpectedStateOverlay>
+                                <UnexpectedState
+                                    caseType={errorState}
+                                    prevModel={
+                                        (prevDevice &&
+                                            prevDevice.features &&
+                                            prevDevice.features.major_version) ||
+                                        2
+                                    }
+                                    uiInteraction={uiInteraction}
+                                />
+                            </UnexpectedStateOverlay>
                         )}
+                        <ProgressStepsSlot>
+                            <ProgressSteps
+                                hiddenOnSteps={[
+                                    STEP.ID_WELCOME_STEP,
+                                    STEP.ID_SECURITY_STEP,
+                                    STEP.ID_FINAL_STEP,
+                                ]}
+                                steps={steps}
+                                activeStep={activeStep}
+                                isDisabled={deviceCall.isProgress}
+                            />
+                        </ProgressStepsSlot>
+                        <ComponentWrapper>
+                            {uiInteraction.name && isGlobalInteraction() && (
+                                <TrezorAction model={model} event={uiInteraction.name} />
+                            )}
 
-                        <CSSTransition
-                            in={activeStepId === STEP.ID_WELCOME_STEP}
-                            {...TRANSITION_PROPS}
-                        >
-                            <WelcomeStep />
-                        </CSSTransition>
+                            <CSSTransition
+                                in={activeStepId === STEP.ID_WELCOME_STEP}
+                                {...TRANSITION_PROPS}
+                            >
+                                <WelcomeStep />
+                            </CSSTransition>
 
-                        <CSSTransition
-                            in={activeStepId === STEP.ID_NEW_OR_USED}
-                            {...TRANSITION_PROPS}
-                        >
-                            <NewOrUsedStep />
-                        </CSSTransition>
+                            <CSSTransition
+                                in={activeStepId === STEP.ID_NEW_OR_USED}
+                                {...TRANSITION_PROPS}
+                            >
+                                <NewOrUsedStep />
+                            </CSSTransition>
 
-                        <CSSTransition
-                            in={activeStepId === STEP.ID_SELECT_DEVICE_STEP}
-                            {...TRANSITION_PROPS}
-                        >
-                            <SelectDeviceStep />
-                        </CSSTransition>
+                            <CSSTransition
+                                in={activeStepId === STEP.ID_SELECT_DEVICE_STEP}
+                                {...TRANSITION_PROPS}
+                            >
+                                <SelectDeviceStep />
+                            </CSSTransition>
 
-                        <CSSTransition
-                            in={activeStepId === STEP.ID_UNBOXING_STEP}
-                            {...TRANSITION_PROPS}
-                        >
-                            <HologramStep />
-                        </CSSTransition>
+                            <CSSTransition
+                                in={activeStepId === STEP.ID_UNBOXING_STEP}
+                                {...TRANSITION_PROPS}
+                            >
+                                <HologramStep />
+                            </CSSTransition>
 
-                        <CSSTransition
-                            in={activeStepId === STEP.ID_PAIR_DEVICE_STEP}
-                            {...TRANSITION_PROPS}
-                        >
-                            <PairStep />
-                        </CSSTransition>
+                            <CSSTransition
+                                in={activeStepId === STEP.ID_PAIR_DEVICE_STEP}
+                                {...TRANSITION_PROPS}
+                            >
+                                <PairStep />
+                            </CSSTransition>
 
-                        <CSSTransition
-                            in={activeStepId === STEP.ID_FIRMWARE_STEP}
-                            {...TRANSITION_PROPS}
-                        >
-                            <FirmwareStep />
-                        </CSSTransition>
+                            <CSSTransition
+                                in={activeStepId === STEP.ID_FIRMWARE_STEP}
+                                {...TRANSITION_PROPS}
+                            >
+                                <FirmwareStep />
+                            </CSSTransition>
 
-                        <CSSTransition
-                            in={activeStepId === STEP.ID_SHAMIR_STEP}
-                            {...TRANSITION_PROPS}
-                        >
-                            <ShamirStep />
-                        </CSSTransition>
+                            <CSSTransition
+                                in={activeStepId === STEP.ID_SHAMIR_STEP}
+                                {...TRANSITION_PROPS}
+                            >
+                                <ShamirStep />
+                            </CSSTransition>
 
-                        <CSSTransition
-                            in={activeStepId === STEP.ID_RECOVERY_STEP}
-                            {...TRANSITION_PROPS}
-                        >
-                            <RecoveryStep />
-                        </CSSTransition>
+                            <CSSTransition
+                                in={activeStepId === STEP.ID_RECOVERY_STEP}
+                                {...TRANSITION_PROPS}
+                            >
+                                <RecoveryStep />
+                            </CSSTransition>
 
-                        <CSSTransition
-                            in={activeStepId === STEP.ID_SECURITY_STEP}
-                            {...TRANSITION_PROPS}
-                        >
-                            <SecurityStep />
-                        </CSSTransition>
+                            <CSSTransition
+                                in={activeStepId === STEP.ID_SECURITY_STEP}
+                                {...TRANSITION_PROPS}
+                            >
+                                <SecurityStep />
+                            </CSSTransition>
 
-                        <CSSTransition
-                            in={activeStepId === STEP.ID_BACKUP_STEP}
-                            {...TRANSITION_PROPS}
-                        >
-                            <BackupStep />
-                        </CSSTransition>
+                            <CSSTransition
+                                in={activeStepId === STEP.ID_BACKUP_STEP}
+                                {...TRANSITION_PROPS}
+                            >
+                                <BackupStep />
+                            </CSSTransition>
 
-                        <CSSTransition
-                            in={activeStepId === STEP.ID_SET_PIN_STEP}
-                            {...TRANSITION_PROPS}
-                        >
-                            <SetPinStep />
-                        </CSSTransition>
+                            <CSSTransition
+                                in={activeStepId === STEP.ID_SET_PIN_STEP}
+                                {...TRANSITION_PROPS}
+                            >
+                                <SetPinStep />
+                            </CSSTransition>
 
-                        <CSSTransition
-                            in={activeStepId === STEP.ID_NAME_STEP}
-                            {...TRANSITION_PROPS}
-                        >
-                            <NameStep />
-                        </CSSTransition>
+                            <CSSTransition
+                                in={activeStepId === STEP.ID_NAME_STEP}
+                                {...TRANSITION_PROPS}
+                            >
+                                <NameStep />
+                            </CSSTransition>
 
-                        <CSSTransition
-                            in={activeStepId === STEP.ID_NEWSLETTER_STEP}
-                            {...TRANSITION_PROPS}
-                        >
-                            <NewsletterStep />
-                        </CSSTransition>
+                            <CSSTransition
+                                in={activeStepId === STEP.ID_NEWSLETTER_STEP}
+                                {...TRANSITION_PROPS}
+                            >
+                                <NewsletterStep />
+                            </CSSTransition>
 
-                        <CSSTransition
-                            in={activeStepId === STEP.ID_BOOKMARK_STEP}
-                            {...TRANSITION_PROPS}
-                        >
-                            <BookmarkStep />
-                        </CSSTransition>
+                            <CSSTransition
+                                in={activeStepId === STEP.ID_BOOKMARK_STEP}
+                                {...TRANSITION_PROPS}
+                            >
+                                <BookmarkStep />
+                            </CSSTransition>
 
-                        <CSSTransition
-                            in={activeStepId === STEP.ID_FINAL_STEP}
-                            {...TRANSITION_PROPS}
-                        >
-                            <FinalStep />
-                        </CSSTransition>
-                    </ComponentWrapper>
-                </WrapperInside>
-            </WrapperOutside>
-        </Preloader>
+                            <CSSTransition
+                                in={activeStepId === STEP.ID_FINAL_STEP}
+                                {...TRANSITION_PROPS}
+                            >
+                                <FinalStep />
+                            </CSSTransition>
+                        </ComponentWrapper>
+                    </WrapperInside>
+                </WrapperOutside>
+            </Preloader>
+        </>
     );
 };
 

--- a/packages/suite/src/views/suite/settings/index.tsx
+++ b/packages/suite/src/views/suite/settings/index.tsx
@@ -130,7 +130,7 @@ const Settings = ({ device, locks, applySettings, changePin, wipeDevice, goto }:
     ] as const;
 
     return (
-        <SettingsLayout>
+        <SettingsLayout title="Settings">
             <Row>
                 <Title>{tr('TR_DEVICE_SETTINGS_TITLE')}</Title>
                 <CloseButton onClick={() => goto('wallet-index')} isTransparent>

--- a/packages/suite/src/views/wallet/account/receive/index.tsx
+++ b/packages/suite/src/views/wallet/account/receive/index.tsx
@@ -36,7 +36,7 @@ const AccountReceive = (props: Props) => {
     if (!device || !account || !discovery || !network || !shouldRender) {
         const { loader, exceptionPage } = props.selectedAccount;
         return (
-            <LayoutAccount>
+            <LayoutAccount title="Receive | Trezor Suite">
                 <Content loader={loader} exceptionPage={exceptionPage} isLoading />
             </LayoutAccount>
         );
@@ -67,7 +67,7 @@ const AccountReceive = (props: Props) => {
         props.locks.includes(SUITE.LOCK_TYPE.DEVICE) || props.locks.includes(SUITE.LOCK_TYPE.UI);
 
     return (
-        <LayoutAccount>
+        <LayoutAccount title="Receive | Trezor Suite">
             <ReceiveForm
                 showButtonDisabled={showButtonDisabled}
                 account={account}

--- a/packages/suite/src/views/wallet/account/receive/index.tsx
+++ b/packages/suite/src/views/wallet/account/receive/index.tsx
@@ -36,7 +36,7 @@ const AccountReceive = (props: Props) => {
     if (!device || !account || !discovery || !network || !shouldRender) {
         const { loader, exceptionPage } = props.selectedAccount;
         return (
-            <LayoutAccount title="Receive | Trezor Suite">
+            <LayoutAccount title="Receive">
                 <Content loader={loader} exceptionPage={exceptionPage} isLoading />
             </LayoutAccount>
         );
@@ -67,7 +67,7 @@ const AccountReceive = (props: Props) => {
         props.locks.includes(SUITE.LOCK_TYPE.DEVICE) || props.locks.includes(SUITE.LOCK_TYPE.UI);
 
     return (
-        <LayoutAccount title="Receive | Trezor Suite">
+        <LayoutAccount title="Receive">
             <ReceiveForm
                 showButtonDisabled={showButtonDisabled}
                 account={account}

--- a/packages/suite/src/views/wallet/account/send/index.tsx
+++ b/packages/suite/src/views/wallet/account/send/index.tsx
@@ -6,7 +6,7 @@ import { Output } from '@wallet-types/sendForm';
 
 import { getTitleForNetwork, getTypeForNetwork } from '@wallet-utils/accountUtils';
 import { StateProps, DispatchProps } from './Container';
-import { Content, Title, LayoutAccount as Layout } from '@wallet-components';
+import { Content, Title, LayoutAccount } from '@wallet-components';
 import {
     Address,
     Amount,
@@ -75,16 +75,16 @@ const Send = (props: { intl: InjectedIntl } & StateProps & DispatchProps) => {
     if (!device || !send || !account || !discovery || !network || !fees || !shouldRender) {
         const { loader, exceptionPage } = props.selectedAccount;
         return (
-            <Layout>
+            <LayoutAccount title="Send | Trezor Suite">
                 <Content loader={loader} exceptionPage={exceptionPage} isLoading />
-            </Layout>
+            </LayoutAccount>
         );
     }
 
     const accountType = getTypeForNetwork(account.accountType, props.intl);
 
     return (
-        <Layout>
+        <LayoutAccount title="Send | Trezor Suite">
             <StyledTitle>
                 <StyledCoinLogo size={24} symbol={account.symbol} />
                 Send {getTitleForNetwork(network.symbol, props.intl)}
@@ -155,7 +155,7 @@ const Send = (props: { intl: InjectedIntl } & StateProps & DispatchProps) => {
                     sendFormActionsRipple={sendFormActionsRipple}
                 />
             </Row>
-        </Layout>
+        </LayoutAccount>
     );
 };
 

--- a/packages/suite/src/views/wallet/account/send/index.tsx
+++ b/packages/suite/src/views/wallet/account/send/index.tsx
@@ -75,7 +75,7 @@ const Send = (props: { intl: InjectedIntl } & StateProps & DispatchProps) => {
     if (!device || !send || !account || !discovery || !network || !fees || !shouldRender) {
         const { loader, exceptionPage } = props.selectedAccount;
         return (
-            <LayoutAccount title="Send | Trezor Suite">
+            <LayoutAccount title="Send">
                 <Content loader={loader} exceptionPage={exceptionPage} isLoading />
             </LayoutAccount>
         );
@@ -84,7 +84,7 @@ const Send = (props: { intl: InjectedIntl } & StateProps & DispatchProps) => {
     const accountType = getTypeForNetwork(account.accountType, props.intl);
 
     return (
-        <LayoutAccount title="Send | Trezor Suite">
+        <LayoutAccount title="Send">
             <StyledTitle>
                 <StyledCoinLogo size={24} symbol={account.symbol} />
                 Send {getTitleForNetwork(network.symbol, props.intl)}

--- a/packages/suite/src/views/wallet/account/sign-verify/index.tsx
+++ b/packages/suite/src/views/wallet/account/sign-verify/index.tsx
@@ -113,7 +113,7 @@ class SignVerify extends Component<Props> {
 
         const verifyAddressError = this.getError('verifyAddress');
         return (
-            <LayoutAccount>
+            <LayoutAccount title="SIgn & Verify | Trezor Suite">
                 <Wrapper>
                     <Sign>
                         <Title>

--- a/packages/suite/src/views/wallet/account/sign-verify/index.tsx
+++ b/packages/suite/src/views/wallet/account/sign-verify/index.tsx
@@ -113,7 +113,7 @@ class SignVerify extends Component<Props> {
 
         const verifyAddressError = this.getError('verifyAddress');
         return (
-            <LayoutAccount title="SIgn & Verify | Trezor Suite">
+            <LayoutAccount title="SIgn & Verify">
                 <Wrapper>
                     <Sign>
                         <Title>

--- a/packages/suite/src/views/wallet/account/summary/index.tsx
+++ b/packages/suite/src/views/wallet/account/summary/index.tsx
@@ -11,14 +11,14 @@ const AccountSummary = (props: Props) => {
     if (!device || !account || !network || !shouldRender) {
         const { loader, exceptionPage } = props.wallet.selectedAccount;
         return (
-            <LayoutAccount>
+            <LayoutAccount title="Summary | Trezor Suite">
                 <Content loader={loader} exceptionPage={exceptionPage} isLoading />
             </LayoutAccount>
         );
     }
 
     return (
-        <LayoutAccount>
+        <LayoutAccount title="Summary | Trezor Suite">
             <AccountHeader
                 account={account}
                 network={network}

--- a/packages/suite/src/views/wallet/account/summary/index.tsx
+++ b/packages/suite/src/views/wallet/account/summary/index.tsx
@@ -11,14 +11,14 @@ const AccountSummary = (props: Props) => {
     if (!device || !account || !network || !shouldRender) {
         const { loader, exceptionPage } = props.wallet.selectedAccount;
         return (
-            <LayoutAccount title="Summary | Trezor Suite">
+            <LayoutAccount title="Summary">
                 <Content loader={loader} exceptionPage={exceptionPage} isLoading />
             </LayoutAccount>
         );
     }
 
     return (
-        <LayoutAccount title="Summary | Trezor Suite">
+        <LayoutAccount title="Summary">
             <AccountHeader
                 account={account}
                 network={network}

--- a/packages/suite/src/views/wallet/account/transactions/index.tsx
+++ b/packages/suite/src/views/wallet/account/transactions/index.tsx
@@ -36,7 +36,7 @@ const Transactions = (props: Props) => {
     if (!selectedAccount.account) {
         const { loader, exceptionPage } = selectedAccount;
         return (
-            <LayoutAccount>
+            <LayoutAccount title="Transactions | Trezor Suite">
                 <Content loader={loader} exceptionPage={exceptionPage} isLoading />
             </LayoutAccount>
         );
@@ -56,7 +56,7 @@ const Transactions = (props: Props) => {
     };
 
     return (
-        <LayoutAccount>
+        <LayoutAccount title="Transactions | Trezor Suite">
             <Title>
                 <FormattedMessage {...l10nMessages.TR_TRANSACTIONS} />
             </Title>

--- a/packages/suite/src/views/wallet/account/transactions/index.tsx
+++ b/packages/suite/src/views/wallet/account/transactions/index.tsx
@@ -36,7 +36,7 @@ const Transactions = (props: Props) => {
     if (!selectedAccount.account) {
         const { loader, exceptionPage } = selectedAccount;
         return (
-            <LayoutAccount title="Transactions | Trezor Suite">
+            <LayoutAccount title="Transactions">
                 <Content loader={loader} exceptionPage={exceptionPage} isLoading />
             </LayoutAccount>
         );
@@ -56,7 +56,7 @@ const Transactions = (props: Props) => {
     };
 
     return (
-        <LayoutAccount title="Transactions | Trezor Suite">
+        <LayoutAccount title="Transactions">
             <Title>
                 <FormattedMessage {...l10nMessages.TR_TRANSACTIONS} />
             </Title>

--- a/packages/suite/src/views/wallet/dashboard/index.tsx
+++ b/packages/suite/src/views/wallet/dashboard/index.tsx
@@ -132,7 +132,7 @@ const Dashboard = (props: Props) => {
     });
 
     return (
-        <WalletLayout title="Dashboard | Trezor Suite">
+        <WalletLayout title="Dashboard">
             <Content data-test="Dashboard__page__content">
                 <H4>Dashboard</H4>
                 <CardsWrapper>

--- a/packages/suite/src/views/wallet/dashboard/index.tsx
+++ b/packages/suite/src/views/wallet/dashboard/index.tsx
@@ -132,7 +132,7 @@ const Dashboard = (props: Props) => {
     });
 
     return (
-        <WalletLayout>
+        <WalletLayout title="Dashboard | Trezor Suite">
             <Content data-test="Dashboard__page__content">
                 <H4>Dashboard</H4>
                 <CardsWrapper>

--- a/packages/suite/src/views/wallet/settings/index.tsx
+++ b/packages/suite/src/views/wallet/settings/index.tsx
@@ -77,7 +77,7 @@ const buildCurrencyOption = (currency: string) => {
 };
 
 const WalletSettings = (props: Props & InjectedIntlProps) => (
-    <WalletLayout title="Settings | Trezor Suite">
+    <WalletLayout title="Settings">
         <CloseWrapper>
             <Button onClick={() => props.goto('wallet-index')} isTransparent>
                 <Icon icon="CLOSE" size={14} />

--- a/packages/suite/src/views/wallet/settings/index.tsx
+++ b/packages/suite/src/views/wallet/settings/index.tsx
@@ -77,7 +77,7 @@ const buildCurrencyOption = (currency: string) => {
 };
 
 const WalletSettings = (props: Props & InjectedIntlProps) => (
-    <WalletLayout>
+    <WalletLayout title="Settings | Trezor Suite">
         <CloseWrapper>
             <Button onClick={() => props.goto('wallet-index')} isTransparent>
                 <Icon icon="CLOSE" size={14} />


### PR DESCRIPTION
close https://github.com/trezor/trezor-suite/issues/633
- Layouts components have new `title` prop
- all static pages uses the same instance of SuiteLayout so for now if you need to override the title use `Head` component from `next/head` (used for the onboarding).
- changed default width and height of an electron window to prevent showing a scrollbar on first launch inside the onboarding.

<img width="304" alt="Screenshot 2019-10-15 at 11 39 29" src="https://user-images.githubusercontent.com/6961901/66820180-7c11d680-ef40-11e9-8d95-a764723d51ac.png">

works in electron too! (screen with default dimensions)
<img width="1093" alt="Screenshot 2019-10-15 at 11 52 43" src="https://user-images.githubusercontent.com/6961901/66821215-58e82680-ef42-11e9-9fca-8f05432c04b4.png">

I would add intl later when we settle on what to show in the title (display currently selected account?, or just Trezor Suite everywhere?,...)