### PR TITLE
fix electron shortcuts

### DIFF
--- a/packages/suite-desktop/package.json
+++ b/packages/suite-desktop/package.json
@@ -63,6 +63,7 @@
     },
     "dependencies": {
         "electron-is-dev": "^1.1.0",
+        "electron-localshortcut": "^3.1.0",
         "electron-next": "^3.1.5",
         "os": "^0.1.1",
         "ps-list": "6.3.0"

--- a/packages/suite-desktop/src/electron.js
+++ b/packages/suite-desktop/src/electron.js
@@ -4,6 +4,7 @@ const isDev = require('electron-is-dev');
 const prepareNext = require('electron-next');
 const path = require('path');
 const url = require('url');
+const electronLocalshortcut = require('electron-localshortcut');
 const { isBridgeRunning, runBridgeProcess } = require('./bridge');
 
 let mainWindow;
@@ -72,19 +73,15 @@ const init = async () => {
             callback({ path: url });
         });
 
-        // TODO: For more complex shortcuts we should just use mousetrap
-        // https://electronjs.org/docs/tutorial/keyboard-shortcuts#shortcuts-within-a-browserwindow
-        mainWindow.addEventListener(
-            'keyup',
-            e => {
-                console.log('triggered');
-                if (e.keyCode === 82 || e.keyCode === 116) {
-                    // cmd + r or f5
-                    mainWindow.loadURL(src);
-                }
-            },
-            true,
-        );
+        electronLocalshortcut.register(mainWindow, 'R', () => {
+            mainWindow.loadURL(src);
+        });
+
+        electronLocalshortcut.register(mainWindow, 'F5', () => {
+            mainWindow.loadURL(src);
+        });
+
+        electronLocalshortcut.unregisterAll(mainWindow);
     }
 
     mainWindow.loadURL(src);

--- a/packages/suite-desktop/src/electron.js
+++ b/packages/suite-desktop/src/electron.js
@@ -9,6 +9,23 @@ const { isBridgeRunning, runBridgeProcess } = require('./bridge');
 
 let mainWindow;
 
+const registerShortcuts = window => {
+    // internally uses before-input-event, which should be safer than adding globalShortcut and removing it on blur event
+    // https://github.com/electron/electron/issues/8491#issuecomment-274790124
+    // https://github.com/electron/electron/issues/1334#issuecomment-310920998
+    electronLocalshortcut.register(window, 'F5', () => {
+        window.loadURL(src);
+    });
+
+    electronLocalshortcut.register(window, 'CommandOrControl+R', () => {
+        window.loadURL(src);
+    });
+
+    electronLocalshortcut.register(window, 'CommandOrControl+Alt+I', () => {
+        window.webContents.openDevTools();
+    });
+};
+
 const init = async () => {
     try {
         const isBridgeProcessRunning = await isBridgeRunning();
@@ -73,15 +90,7 @@ const init = async () => {
             callback({ path: url });
         });
 
-        electronLocalshortcut.register(mainWindow, 'R', () => {
-            mainWindow.loadURL(src);
-        });
-
-        electronLocalshortcut.register(mainWindow, 'F5', () => {
-            mainWindow.loadURL(src);
-        });
-
-        electronLocalshortcut.unregisterAll(mainWindow);
+        registerShortcuts(mainWindow);
     }
 
     mainWindow.loadURL(src);
@@ -95,6 +104,15 @@ app.on('window-all-closed', () => {
     // to stay active until the user quits explicitly with Cmd + Q
     if (process.platform !== 'darwin') {
         app.quit();
+    }
+});
+
+app.on('will-quit', () => {
+    // try to unregister shortcuts
+    try {
+        electronLocalshortcut.unregisterAll(mainWindow);
+    } catch (error) {
+        // do nothing
     }
 });
 

--- a/packages/suite-desktop/src/electron.js
+++ b/packages/suite-desktop/src/electron.js
@@ -1,13 +1,5 @@
 /* eslint-disable @typescript-eslint/no-var-requires */
-const {
-    app,
-    session,
-    BrowserWindow,
-    ipcMain,
-    globalShortcut,
-    protocol,
-    shell,
-} = require('electron');
+const { app, session, BrowserWindow, ipcMain, protocol, shell } = require('electron');
 const isDev = require('electron-is-dev');
 const prepareNext = require('electron-next');
 const path = require('path');
@@ -80,12 +72,19 @@ const init = async () => {
             callback({ path: url });
         });
 
-        globalShortcut.register('f5', () => {
-            mainWindow.loadURL(src);
-        });
-        globalShortcut.register('CommandOrControl+R', () => {
-            mainWindow.loadURL(src);
-        });
+        // TODO: For more complex shortcuts we should just use mousetrap
+        // https://electronjs.org/docs/tutorial/keyboard-shortcuts#shortcuts-within-a-browserwindow
+        mainWindow.addEventListener(
+            'keyup',
+            e => {
+                console.log('triggered');
+                if (e.keyCode === 82 || e.keyCode === 116) {
+                    // cmd + r or f5
+                    mainWindow.loadURL(src);
+                }
+            },
+            true,
+        );
     }
 
     mainWindow.loadURL(src);

--- a/yarn.lock
+++ b/yarn.lock
@@ -7998,10 +7998,25 @@ electron-download@^4.1.0:
     semver "^5.4.1"
     sumchecker "^2.0.2"
 
+electron-is-accelerator@^0.1.0:
+  version "0.1.2"
+  resolved "https://registry.yarnpkg.com/electron-is-accelerator/-/electron-is-accelerator-0.1.2.tgz#509e510c26a56b55e17f863a4b04e111846ab27b"
+  integrity sha1-UJ5RDCala1Xhf4Y6SwThEYRqsns=
+
 electron-is-dev@>=0.3.0, electron-is-dev@^1.1.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/electron-is-dev/-/electron-is-dev-1.1.0.tgz#b15a2a600bdc48a51a857d460e05f15b19a2522c"
   integrity sha512-Z1qA/1oHNowGtSBIcWk0pcLEqYT/j+13xUw/MYOrBUOL4X7VN0i0KCTf5SqyvMPmW5pSPKbo28wkxMxzZ20YnQ==
+
+electron-localshortcut@^3.1.0:
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/electron-localshortcut/-/electron-localshortcut-3.1.0.tgz#10c1ffd537b8d39170aaf6e1551341f7780dd2ce"
+  integrity sha512-MgL/j5jdjW7iA0R6cI7S045B0GlKXWM1FjjujVPjlrmyXRa6yH0bGSaIAfxXAF9tpJm3pLEiQzerYHkRh9JG/A==
+  dependencies:
+    debug "^2.6.8"
+    electron-is-accelerator "^0.1.0"
+    keyboardevent-from-electron-accelerator "^1.1.0"
+    keyboardevents-areequal "^0.2.1"
 
 electron-next@^3.1.5:
   version "3.1.5"
@@ -12160,6 +12175,16 @@ keccak@^2.0.0:
     inherits "^2.0.3"
     nan "^2.2.1"
     safe-buffer "^5.1.0"
+
+keyboardevent-from-electron-accelerator@^1.1.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/keyboardevent-from-electron-accelerator/-/keyboardevent-from-electron-accelerator-1.1.0.tgz#324614f6e33490c37ffc5be5876b3e85fe223c84"
+  integrity sha512-VDC4vKWGrR3VgIKCE4CsXnvObGgP8C2idnTKEMUkuEuvDGE1GEBX9FtNdJzrD00iQlhI3xFxRaeItsUmlERVng==
+
+keyboardevents-areequal@^0.2.1:
+  version "0.2.2"
+  resolved "https://registry.yarnpkg.com/keyboardevents-areequal/-/keyboardevents-areequal-0.2.2.tgz#88191ec738ce9f7591c25e9056de928b40277194"
+  integrity sha512-Nv+Kr33T0mEjxR500q+I6IWisOQ0lK1GGOncV0kWE6n4KFmpcu7RUX5/2B0EUtX51Cb0HjZ9VJsSY3u4cBa0kw==
 
 keyv@^3.0.0:
   version "3.1.0"


### PR DESCRIPTION
fix https://github.com/trezor/trezor-suite/issues/634

tldr: `GlobalShorcuts` are really global, meaning Suite was capturing the cmd+R/F5 shortcuts even in case where Suite window was not focused (minimized, hidden under other windows, etc). I ended up using https://github.com/beakerbrowser/electron-localshortcut