### PR TITLE
ci: adding NixOS support to Gitlab artifacts

### DIFF
--- a/ci/packages/suite-desktop.yml
+++ b/ci/packages/suite-desktop.yml
@@ -17,9 +17,12 @@ suite-desktop build:
     script:
         - yarn workspace @trezor/suite-data copy-static-files
         - yarn workspace @trezor/suite-desktop build:linux
+        - sed -i "s/unstable-head/$CI_JOB_ID/g" trezor-suite.nix
     artifacts:
         expire_in: 1 day
         paths:
             - $PACKAGE_PATH_SUITE_DESKTOP/build-electron
+            - default.nix
+            - trezor-suite.nix
     dependencies:
         - install and build

--- a/default.nix
+++ b/default.nix
@@ -1,0 +1,1 @@
+ (import <nixpkgs> {}).callPackage ./trezor-suite.nix {}

--- a/trezor-suite.nix
+++ b/trezor-suite.nix
@@ -1,0 +1,83 @@
+{ stdenv
+, alsaLib
+, xorg
+, at-spi2-atk
+, at-spi2-core
+, atk
+, cairo
+, cups
+, dbus
+, expat
+, gdk_pixbuf
+, gtk3-x11
+, gtk3
+, glib
+, glibc
+, gnome2
+, libuuid
+, libogg
+, libpulseaudio
+, nss
+, nspr
+, systemd
+, patchelf
+, vivaldi-ffmpeg-codecs
+}:
+
+stdenv.mkDerivation rec {
+  pname = "trezor-suite";
+  version = "unstable-head";
+
+  src = ./packages/suite-desktop/build-electron/linux-unpacked;
+
+  phases = [ "installPhase" "fixupPhase" ];
+
+  installPhase = ''
+    mkdir -p $out/bin
+    cp -r $src/* $out/bin
+    chmod +w $out/bin/TrezorSuite
+   '';
+
+  fixupPhase = let
+   libPath = stdenv.lib.makeLibraryPath [
+    alsaLib
+    at-spi2-atk
+    at-spi2-core
+    atk
+    cairo
+    cups
+    dbus
+    expat
+    gdk_pixbuf
+    gtk3-x11
+    gtk3
+    glib
+    gnome2.pango
+    libuuid
+    libogg
+    libpulseaudio
+    nss
+    nspr
+    systemd
+    vivaldi-ffmpeg-codecs
+    xorg.libXtst
+    xorg.libXScrnSaver
+    xorg.libX11
+    xorg.libXcomposite
+    xorg.libXrender
+    xorg.libxcb
+    xorg.libXcursor
+    xorg.libXdamage
+    xorg.libXfixes
+    xorg.libXi
+    xorg.libXext
+    xorg.libXrandr
+   ];
+  in ''
+    patchelf \
+      --set-interpreter "$(cat $NIX_CC/nix-support/dynamic-linker)" \
+      --set-rpath "${libPath}" \
+      $out/bin/TrezorSuite
+  '';
+}
+


### PR DESCRIPTION
This changes adds the NixOS files that are required to build the desktop suite on NixOS.

It also replaces the version of the suite by the CI's job id.

Sadly, gitlab.com provides the artifacts only using the .zip format, thefero we need to execute it as follows (on NixOS):

```wget https://gitlab.com/satoshilabs/trezor/trezor-suite/-/jobs/323709561/artifacts/download && unzip download && nix-env -f . -i trezor-suite```

And then run the ```TrezorSuite``` binary.