### PR TITLE
count number of updated packages and notify in ci job

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -18,6 +18,7 @@ stages:
     - deploy to dev servers
     - integration testing
     - build desktop apps
+    - misc
 
 include:
     - ci/environment.yml

--- a/ci/packages/suite.yml
+++ b/ci/packages/suite.yml
@@ -37,3 +37,11 @@ suite test integration:
         - yarn workspace @trezor/suite test-health
     dependencies:
         - install and build
+
+suite check outdated:
+    stage: misc
+    allow_failure: true
+    script:
+        - ./ci/scripts/outdated.sh
+    dependencies:
+        - install and build

--- a/ci/scripts/outdated.sh
+++ b/ci/scripts/outdated.sh
@@ -1,0 +1,15 @@
+#!/bin/bash
+treshold=180
+
+number=$(yarn outdated | wc -l)
+
+echo outdated packages treshold $treshold
+
+if [ $number -gt $treshold ]
+then
+    echo number of outdated packages [$number] is over treshold [$treshold]. consider updating.
+    exit 1
+fi
+
+echo number of outdated packages [$number] is below treshold [$treshold]
+exit 0


### PR DESCRIPTION
was thinking how to maintain high discipline at updating packages. 
Maybe add a script to CI that will count outdated packages and compare the resulting number with arbitrary treshold? 
![image](https://user-images.githubusercontent.com/30367552/69654054-73024200-1074-11ea-96be-1a971f7af448.png)

if added to CI, and set to allow_failure: true, it might be useful that we will see that we probably should update some of the packages. 

I set treshold to 180, as after #820 will be merged, we are going to have something like 174 outdated packages.