### PR TITLE
run check-outdated job only on develop branch

### DIFF
--- a/ci/packages/suite.yml
+++ b/ci/packages/suite.yml
@@ -9,6 +9,9 @@ suite test integration:
 
 suite check outdated:
     stage: misc
+    only:
+        refs:
+            - develop
     allow_failure: true
     script:
         - ./ci/scripts/outdated.sh


### PR DESCRIPTION
running this job for each commit gives us nothing.
The job is just a measure that should trigger ours OCD (by not being green) in case we get many outdated packages. It is perfectly fine to run it only on develop branch.