### PR TITLE
coins settings wallet app?

### DIFF
--- a/packages/suite/src/constants/suite/routes.ts
+++ b/packages/suite/src/constants/suite/routes.ts
@@ -68,7 +68,7 @@ const routes = [
     {
         name: 'settings-coins',
         pattern: '/settings/coins',
-        app: 'deviceManagement',
+        app: 'wallet',
     },
     {
         name: 'suite-device-firmware',


### PR DESCRIPTION
if `settings-coins` route is defined as belonging to "deviceManagement" app (which does not make sense anyway), discovery does not get updated automatically after coin setting is changed. 

