### PR TITLE
fix for SUITE.UPDATE_PASSPHRASE_MODE

### DIFF
--- a/packages/suite/src/actions/suite/modalActions.ts
+++ b/packages/suite/src/actions/suite/modalActions.ts
@@ -75,14 +75,23 @@ export const onPinSubmit = (payload: string) => () => {
  * Sends passphrase to `trezor-connect`
  * @param {string} passphrase
  */
-export const onPassphraseSubmit = (value: string, passphraseOnDevice?: boolean) => async (
-    dispatch: Dispatch,
-    getState: GetState,
-) => {
+export const onPassphraseSubmit = (
+    value: string,
+    passphraseOnDevice: boolean,
+    hasEmptyPassphraseWallet: boolean,
+) => async (dispatch: Dispatch, getState: GetState) => {
     const { device } = getState().suite;
     if (!device) return;
 
-    if (!passphraseOnDevice && value === '' && !device.authConfirm && !device.state) {
+    // update wallet type only on certain conditions
+    const update =
+        !hasEmptyPassphraseWallet &&
+        !passphraseOnDevice &&
+        !device.authConfirm &&
+        !device.state &&
+        value === '';
+
+    if (update) {
         // set standard wallet type if passphrase is blank
         dispatch({
             type: SUITE.UPDATE_PASSPHRASE_MODE,

--- a/packages/suite/src/components/suite/modals/Passphrase/index.tsx
+++ b/packages/suite/src/components/suite/modals/Passphrase/index.tsx
@@ -74,7 +74,7 @@ const Passphrase = (props: Props) => {
 
     const onSubmit = (value: string, passphraseOnDevice?: boolean) => {
         setSubmitted(true);
-        props.onPassphraseSubmit(value, passphraseOnDevice);
+        props.onPassphraseSubmit(value, !!passphraseOnDevice, !!hasEmptyPassphraseWallet);
     };
 
     const onRecreate = async () => {


### PR DESCRIPTION
Use case:
1. create standart wallet
2. create hidden wallet
3. enter empty passphrase (should not switch device to "no passphrase" mode)