### PR TITLE
fix parsing date key for grouped transactions

### DIFF
--- a/packages/suite/src/utils/suite/__tests__/date.test.ts
+++ b/packages/suite/src/utils/suite/__tests__/date.test.ts
@@ -18,14 +18,10 @@ describe('Date utils', () => {
 
     test('get date with timezone', () => {
         const dateInMs = 1565797979000;
-        const dateInIso = '2014-06-25T10:00:00.000Z';
 
         expect(utils.getDateWithTimeZone(dateInMs, 'Asia/Tokyo')).toEqual(
             new Date('2019-08-15T00:52:59.000Z'),
         );
         expect(utils.getDateWithTimeZone(dateInMs)).toEqual(new Date('2019-08-14T15:52:59.000Z'));
-        expect(utils.getDateWithTimeZone(dateInIso, 'America/New_York')).toEqual(
-            new Date('2014-06-25T06:00:00.000Z'),
-        );
     });
 });

--- a/packages/suite/src/utils/suite/date.ts
+++ b/packages/suite/src/utils/suite/date.ts
@@ -5,12 +5,7 @@ export const formatDuration = (seconds: number) =>
     formatDistance(0, seconds * 1000, { includeSeconds: true });
 
 export const getDateWithTimeZone = (date: number, timeZone?: string) => {
-    try {
-        const unixDate = fromUnixTime(date / 1000);
-        const tz = timeZone || Intl.DateTimeFormat().resolvedOptions().timeZone;
-        return utcToZonedTime(unixDate, tz);
-    } catch (err) {
-        console.error(err);
-        return null;
-    }
+    const unixDate = fromUnixTime(date / 1000);
+    const tz = timeZone || Intl.DateTimeFormat().resolvedOptions().timeZone;
+    return utcToZonedTime(unixDate, tz);
 };

--- a/packages/suite/src/utils/suite/date.ts
+++ b/packages/suite/src/utils/suite/date.ts
@@ -1,12 +1,16 @@
-import { formatDistance } from 'date-fns';
+import { formatDistance, fromUnixTime } from 'date-fns';
 import { utcToZonedTime } from 'date-fns-tz';
 
 export const formatDuration = (seconds: number) =>
     formatDistance(0, seconds * 1000, { includeSeconds: true });
 
-export const getDateWithTimeZone = (date: number | string, timeZone?: string): Date => {
-    const isoDate = new Date(date).toISOString();
-    const tz = timeZone || Intl.DateTimeFormat().resolvedOptions().timeZone;
-
-    return utcToZonedTime(isoDate, tz);
+export const getDateWithTimeZone = (date: number, timeZone?: string) => {
+    try {
+        const unixDate = fromUnixTime(date / 1000);
+        const tz = timeZone || Intl.DateTimeFormat().resolvedOptions().timeZone;
+        return utcToZonedTime(unixDate, tz);
+    } catch (err) {
+        console.error(err);
+        return null;
+    }
 };

--- a/packages/suite/src/utils/wallet/transactionUtils.ts
+++ b/packages/suite/src/utils/wallet/transactionUtils.ts
@@ -54,8 +54,7 @@ export const sumTransactions = (transactions: WalletAccountTransaction[]) => {
  */
 export const parseKey = (key: string) => {
     const parts = key.split('-');
-    const d = new Date(Number(parts[0]), Number(parts[1]) - 1, Number(parts[2])).getTime();
-
+    const d = new Date(Number(parts[0]), Number(parts[1]) - 1, Number(parts[2]));
     return d;
 };
 

--- a/packages/suite/src/utils/wallet/transactionUtils.ts
+++ b/packages/suite/src/utils/wallet/transactionUtils.ts
@@ -54,9 +54,8 @@ export const sumTransactions = (transactions: WalletAccountTransaction[]) => {
  */
 export const parseKey = (key: string) => {
     const parts = key.split('-');
-    const d = getDateWithTimeZone(
-        new Date(Number(parts[0]), Number(parts[1]) - 1, Number(parts[2])).getTime(),
-    );
+    const d = new Date(Number(parts[0]), Number(parts[1]) - 1, Number(parts[2])).getTime();
+
     return d;
 };
 


### PR DESCRIPTION
fix https://github.com/trezor/trezor-suite/issues/1274

tldr; transactions grouped by day are indexed by string in format 'yy-mm-dd', which is already converted to local timezone. there is no reason to apply timezone conversion again when creating date object from this string. (most significant https://github.com/trezor/trezor-suite/pull/1278/files#diff-aac9a2bd6364ccb34b81f191595436fcR57)