### PR TITLE
Feature/discovery with unavailable capabilities

### DIFF
--- a/packages/suite/src/actions/wallet/__fixtures__/discoveryActions.ts
+++ b/packages/suite/src/actions/wallet/__fixtures__/discoveryActions.ts
@@ -135,6 +135,41 @@ export const fixtures = [
                 code: undefined,
             },
         },
+        // this device is used only to cover missing unavailableCapabilities case
+        device: global.JestMocks.getSuiteDevice({
+            state: 'device-state',
+            type: 'unacquired',
+        }),
+    },
+    {
+        description: 'UnavailableCapability: XRP, discovery empty',
+        connect: {
+            success: true,
+        },
+        device: global.JestMocks.getSuiteDevice({
+            state: 'device-state',
+            connected: true,
+            unavailableCapabilities: { xrp: 'no-capability' },
+        }),
+        enabledNetworks: ['xrp'],
+        result: {
+            failed: [],
+        },
+    },
+    {
+        description: 'UnavailableCapability: XRP, discovery not empty',
+        connect: {
+            success: true,
+        },
+        device: global.JestMocks.getSuiteDevice({
+            state: 'device-state',
+            connected: true,
+            unavailableCapabilities: { xrp: 'no-capability' },
+        }),
+        enabledNetworks: ['btc', 'xrp'],
+        result: {
+            failed: [],
+        },
     },
 ];
 
@@ -243,5 +278,38 @@ export const changeNetworksFixtures = [
                 networks: ['btc', 'ltc'],
             },
         ],
+    },
+];
+
+export const unavailableCapabilities = [
+    {
+        description: 'UnavailableCapability: Enable XRP',
+        device: global.JestMocks.getSuiteDevice({
+            state: 'device-state',
+            connected: true,
+            unavailableCapabilities: { xrp: 'no-capability' },
+        }),
+        networks: ['btc', 'xrp'],
+        discoveryNetworks: ['btc', 'btc', 'btc'],
+    },
+    {
+        description: 'UnavailableCapability: Only LTC',
+        device: global.JestMocks.getSuiteDevice({
+            state: 'device-state',
+            connected: true,
+            unavailableCapabilities: { ltc: 'no-capability' },
+        }),
+        networks: ['ltc'],
+        discoveryNetworks: [],
+    },
+    {
+        description: 'UnavailableCapability: Device without features',
+        // this device is used only to cover missing unavailableCapabilities case
+        device: global.JestMocks.getSuiteDevice({
+            state: 'device-state',
+            type: 'unacquired',
+        }),
+        networks: ['xrp'],
+        discoveryNetworks: ['xrp'],
     },
 ];

--- a/packages/suite/src/middlewares/wallet/discoveryMiddleware.ts
+++ b/packages/suite/src/middlewares/wallet/discoveryMiddleware.ts
@@ -98,7 +98,7 @@ const discoveryMiddleware = (api: MiddlewareAPI<Dispatch, AppState>) => (next: D
 
     // 4. device state received
     if (action.type === SUITE.AUTH_DEVICE) {
-        api.dispatch(discoveryActions.create(action.state, device!.useEmptyPassphrase));
+        api.dispatch(discoveryActions.create(action.state, action.payload));
     }
 
     // 5. device state confirmation received

--- a/packages/suite/src/middlewares/wallet/discoveryMiddleware.ts
+++ b/packages/suite/src/middlewares/wallet/discoveryMiddleware.ts
@@ -98,7 +98,9 @@ const discoveryMiddleware = (api: MiddlewareAPI<Dispatch, AppState>) => (next: D
 
     // 4. device state received
     if (action.type === SUITE.AUTH_DEVICE) {
-        api.dispatch(discoveryActions.create(action.state, action.payload));
+        // `device` is always present here
+        // to avoid typescript conditioning use device from action as a fallback (never used)
+        api.dispatch(discoveryActions.create(action.state, device || action.payload));
     }
 
     // 5. device state confirmation received

--- a/packages/suite/src/support/tests/setupJest.ts
+++ b/packages/suite/src/support/tests/setupJest.ts
@@ -85,9 +85,9 @@ export const getConnectDevice = (dev?: Partial<Device>, feat?: Partial<Features>
         mode: 'normal',
         state: undefined,
         features,
+        unavailableCapabilities: {},
         ...dev,
         type: 'acquired',
-        unavailableCapabilities: {},
     };
 };
 


### PR DESCRIPTION
Do not perform discovery on unavailable coins.

Example:
- connect TT
- go to settings/coins
- disable all networks, enable XRP
- go back to wallet
- connect T1

