### PR TITLE
Fix/receive modals

### DIFF
--- a/packages/suite/src/actions/settings/deviceSettingsActions.ts
+++ b/packages/suite/src/actions/settings/deviceSettingsActions.ts
@@ -29,6 +29,8 @@ export const applySettings = (params: ApplySettings) => async (
     } else {
         dispatch(addToast({ type: 'error', error: result.payload.error }));
     }
+
+    return result;
 };
 
 export const changePin = (params: ChangePin = {}) => async (

--- a/packages/suite/src/components/suite/modals/confirm/NoBackup/index.tsx
+++ b/packages/suite/src/components/suite/modals/confirm/NoBackup/index.tsx
@@ -1,5 +1,5 @@
 import { Translation, Image } from '@suite-components';
-import { Button, H2, P, Icon, colors } from '@trezor/components';
+import { Button, H2, P } from '@trezor/components';
 import React from 'react';
 import styled from 'styled-components';
 

--- a/packages/suite/src/components/suite/modals/confirm/NoBackup/index.tsx
+++ b/packages/suite/src/components/suite/modals/confirm/NoBackup/index.tsx
@@ -1,28 +1,21 @@
-import { Translation } from '@suite-components/Translation';
-
+import { Translation, Image } from '@suite-components';
 import { Button, H2, P, Icon, colors } from '@trezor/components';
 import React from 'react';
 import styled from 'styled-components';
 
 const Wrapper = styled.div`
-    max-width: 370px;
-    padding: 30px 48px;
+    max-width: 600px;
+    padding: 40px;
 `;
 
-const BackupButton = styled(Button)`
-    margin-bottom: 10px;
+const ImageWrapper = styled.div`
+    padding: 60px 0px;
 `;
 
-const StyledP = styled(P)`
-    /* boost-specificity hack to override P base styling */
-    && {
-        padding-bottom: 20px;
-    }
-`;
-
-const Row = styled.div`
+const Actions = styled.div`
     display: flex;
-    flex-direction: column;
+    flex-direction: row;
+    justify-content: space-between;
 `;
 
 interface Props {
@@ -35,28 +28,29 @@ const ConfirmNoBackup = ({ onReceiveConfirmation, onCreateBackup }: Props) => (
         <H2>
             <Translation id="TR_YOUR_TREZOR_IS_NOT_BACKED_UP" />
         </H2>
-        <Icon size={32} color={colors.YELLOW} icon="WARNING" />
-        <StyledP size="small">
+        <P size="small">
             <Translation id="TR_IF_YOUR_DEVICE_IS_EVER_LOST" />
-        </StyledP>
-        <Row>
-            <BackupButton
-                onClick={() => {
-                    onReceiveConfirmation(false);
-                    onCreateBackup();
-                }}
-                fullWidth
-            >
-                <Translation id="TR_CREATE_BACKUP_IN_3_MINUTES" />
-            </BackupButton>
+        </P>
+        <ImageWrapper>
+            <Image image="UNI_ERROR" />
+        </ImageWrapper>
+        <Actions>
             <Button
                 variant="secondary"
                 onClick={() => onReceiveConfirmation(true)}
                 data-test="@no-backup/take-risk-button"
             >
-                <Translation id="TR_SHOW_ADDRESS_I_WILL_TAKE_THE_RISK" />
+                <Translation id="TR_SHOW_ADDRESS_ANYWAY" />
             </Button>
-        </Row>
+            <Button
+                onClick={() => {
+                    onReceiveConfirmation(false);
+                    onCreateBackup();
+                }}
+            >
+                <Translation id="TR_CREATE_BACKUP" />
+            </Button>
+        </Actions>
     </Wrapper>
 );
 

--- a/packages/suite/src/components/suite/modals/confirm/UnverifiedAddress/index.tsx
+++ b/packages/suite/src/components/suite/modals/confirm/UnverifiedAddress/index.tsx
@@ -1,47 +1,38 @@
-import React, { FunctionComponent } from 'react';
+import React from 'react';
 import { connect } from 'react-redux';
 import { bindActionCreators } from 'redux';
 import styled from 'styled-components';
+import { SUITE } from '@suite-actions/constants';
 import * as receiveActions from '@wallet-actions/receiveActions';
-import { Translation } from '@suite-components/Translation';
-import { Button, P, H2, Link, colors } from '@trezor/components';
-import { useKeyPress } from '@suite-utils/dom';
-import { TrezorDevice, Dispatch } from '@suite-types';
+import * as deviceSettingsActions from '@settings-actions/deviceSettingsActions';
+import { Translation, Image } from '@suite-components';
+import { Button, P, H2 } from '@trezor/components';
+import { TrezorDevice, AppState, Dispatch, ExtendedMessageDescriptor } from '@suite-types';
 
 const Wrapper = styled.div`
-    max-width: 370px;
-    padding: 30px 0px;
+    max-width: 600px;
+    padding: 40px;
 `;
 
-const Content = styled.div`
-    padding: 0px 48px;
+const ImageWrapper = styled.div`
+    padding: 60px 0px;
 `;
 
-const StyledP = styled(P)`
-    && {
-        padding-bottom: 20px;
-    }
-`;
-
-const Divider = styled.div`
-    width: 100%;
-    height: 1px;
-    background: ${colors.BLACK92};
-    margin: 20px 0px;
-`;
-
-const Row = styled.div`
+const Actions = styled.div`
     display: flex;
-    flex-direction: column;
-
-    button + button {
-        margin-top: 10px;
-    }
+    flex-direction: row;
+    justify-content: space-between;
 `;
+
+const mapStateToProps = (state: AppState) => ({
+    locks: state.suite.locks,
+});
 
 const mapDispatchToProps = (dispatch: Dispatch) => ({
     showAddress: bindActionCreators(receiveActions.showAddress, dispatch),
     showUnverifiedAddress: bindActionCreators(receiveActions.showUnverifiedAddress, dispatch),
+    // eslint-disable-next-line @typescript-eslint/camelcase
+    applySettings: () => dispatch(deviceSettingsActions.applySettings({ use_passphrase: true })),
 });
 
 type Props = {
@@ -49,17 +40,25 @@ type Props = {
     address: string;
     addressPath: string;
     onCancel: () => void;
-} & ReturnType<typeof mapDispatchToProps>;
+} & ReturnType<typeof mapStateToProps> &
+    ReturnType<typeof mapDispatchToProps>;
 
-const ConfirmUnverifiedAddress: FunctionComponent<Props> = ({
+const ConfirmUnverifiedAddress = ({
+    locks,
     device,
     address,
     addressPath,
     showAddress,
     showUnverifiedAddress,
+    applySettings,
     onCancel,
-}) => {
-    const verifyAddress = () => {
+}: Props) => {
+    const progress = locks.includes(SUITE.LOCK_TYPE.DEVICE) || locks.includes(SUITE.LOCK_TYPE.UI);
+    const verifyAddress = async () => {
+        if (!device.available) {
+            const result = await applySettings();
+            if (!result || !result.success) return;
+        }
         onCancel();
         showAddress(addressPath, address);
     };
@@ -69,86 +68,49 @@ const ConfirmUnverifiedAddress: FunctionComponent<Props> = ({
         showUnverifiedAddress(addressPath, address);
     };
 
-    const enterPressed = useKeyPress('Enter');
-
-    if (enterPressed) {
-        verifyAddress();
-    }
-
-    let deviceStatus;
-    let claim;
+    let deviceStatus: ExtendedMessageDescriptor['id'];
+    let claim: ExtendedMessageDescriptor['id'];
+    let actionLabel: ExtendedMessageDescriptor['id'];
 
     if (!device.connected) {
-        deviceStatus = (
-            <Translation
-                id="TR_DEVICE_LABEL_IS_NOT_CONNECTED"
-                values={{ deviceLabel: device.label }}
-            />
-        );
-        claim = <Translation id="TR_PLEASE_CONNECT_YOUR_DEVICE" />;
+        deviceStatus = 'TR_DEVICE_LABEL_IS_NOT_CONNECTED';
+        claim = 'TR_PLEASE_CONNECT_YOUR_DEVICE';
+        actionLabel = 'TR_TRY_AGAIN';
     } else {
-        // corner-case where device is connected but it is unavailable because it was created with different "passphrase_protection" settings
-        const enable = !!(device.features && device.features.passphrase_protection);
-        deviceStatus = (
-            <Translation
-                id="TR_DEVICE_LABEL_IS_UNAVAILABLE"
-                values={{ deviceLabel: device.label }}
-            />
-        );
-        claim = enable ? (
-            <Translation id="TR_PLEASE_ENABLE_PASSPHRASE" />
-        ) : (
-            <Translation id="TR_PLEASE_DISABLE_PASSPHRASE" />
-        );
+        // case where device is connected but it is unavailable because it was created with different "passphrase_protection" settings
+        deviceStatus = 'TR_DEVICE_LABEL_IS_UNAVAILABLE';
+        claim = 'TR_PLEASE_ENABLE_PASSPHRASE';
+        actionLabel = 'TR_ACCOUNT_ENABLE_PASSPHRASE';
     }
-
-    const needsBackup = device.features && device.features.needs_backup;
 
     return (
         <Wrapper>
-            <Content>
-                <H2>{deviceStatus}</H2>
-                <StyledP size="small">
-                    <Translation id="TR_TO_PREVENT_PHISHING_ATTACKS_COMMA" values={{ claim }} />
-                </StyledP>
-            </Content>
-            <Content>
-                <Row>
-                    <Button onClick={() => verifyAddress()}>
-                        <Translation id="TR_TRY_AGAIN" />
-                    </Button>
-                    <Button variant="danger" onClick={() => unverifiedAddress()}>
-                        <Translation id="TR_SHOW_UNVERIFIED_ADDRESS" />
-                    </Button>
-                </Row>
-            </Content>
-            {needsBackup && <Divider />}
-            {needsBackup && (
-                <>
-                    <Content>
-                        <H2>
-                            <Translation
-                                id="TR_DEVICE_LABEL_IS_NOT_BACKED_UP"
-                                values={{ deviceLabel: device.label }}
-                            />
-                        </H2>
-                        <StyledP size="small">
-                            <Translation id="TR_IF_YOUR_DEVICE_IS_EVER_LOST" />
-                        </StyledP>
-                    </Content>
-                    <Content>
-                        <Row>
-                            <Link href={`/?backup#${device.path}`}>
-                                <Button>
-                                    <Translation id="TR_CREATE_BACKUP_IN_3_MINUTES" />
-                                </Button>
-                            </Link>
-                        </Row>
-                    </Content>
-                </>
-            )}
+            <H2>
+                <Translation id={deviceStatus} values={{ deviceLabel: device.label }} />
+            </H2>
+            <P size="small">
+                <Translation
+                    id="TR_TO_PREVENT_PHISHING_ATTACKS_COMMA"
+                    values={{ claim: <Translation id={claim} /> }}
+                />
+            </P>
+            <ImageWrapper>
+                <Image image="UNI_ERROR" />
+            </ImageWrapper>
+            <Actions>
+                <Button
+                    variant="secondary"
+                    onClick={() => unverifiedAddress()}
+                    isLoading={progress}
+                >
+                    <Translation id="TR_SHOW_UNVERIFIED_ADDRESS" />
+                </Button>
+                <Button variant="primary" onClick={() => verifyAddress()} isLoading={progress}>
+                    <Translation id={actionLabel} />
+                </Button>
+            </Actions>
         </Wrapper>
     );
 };
 
-export default connect(null, mapDispatchToProps)(ConfirmUnverifiedAddress);
+export default connect(mapStateToProps, mapDispatchToProps)(ConfirmUnverifiedAddress);

--- a/packages/suite/src/support/messages.ts
+++ b/packages/suite/src/support/messages.ts
@@ -502,10 +502,6 @@ const definedMessages = defineMessages({
         defaultMessage: 'Create backup',
         id: 'TR_CREATE_BACKUP',
     },
-    TR_CREATE_BACKUP_IN_3_MINUTES: {
-        defaultMessage: 'Create a backup in 3 minutes',
-        id: 'TR_CREATE_BACKUP_IN_3_MINUTES',
-    },
     TR_CURRENCY: {
         defaultMessage: 'Currency',
         id: 'TR_CURRENCY',

--- a/packages/suite/src/support/messages.ts
+++ b/packages/suite/src/support/messages.ts
@@ -1308,11 +1308,6 @@ const definedMessages = defineMessages({
         defaultMessage: 'Please connect your device to continue with the verification process',
         id: 'TR_PLEASE_CONNECT_YOUR_DEVICE',
     },
-    TR_PLEASE_DISABLE_PASSPHRASE: {
-        defaultMessage:
-            'Please disable passphrase settings to continue with the verification process.',
-        id: 'TR_PLEASE_DISABLE_PASSPHRASE',
-    },
     TR_PLEASE_ENABLE_PASSPHRASE: {
         defaultMessage:
             'Please enable passphrase settings to continue with the verification process.',
@@ -1492,9 +1487,9 @@ const definedMessages = defineMessages({
         defaultMessage: 'Settings',
         id: 'TR_SETTINGS',
     },
-    TR_SHOW_ADDRESS_I_WILL_TAKE_THE_RISK: {
-        defaultMessage: 'Show address, I will take the risk',
-        id: 'TR_SHOW_ADDRESS_I_WILL_TAKE_THE_RISK',
+    TR_SHOW_ADDRESS_ANYWAY: {
+        defaultMessage: 'Show address anyway',
+        id: 'TR_SHOW_ADDRESS_ANYWAY',
     },
     TR_SHOW_ADVANCED_OPTIONS: {
         defaultMessage: 'Show advanced options',


### PR DESCRIPTION
Update view of UnverifiedAddress and NoBackup modals.
Add possibility to enable passphrase from UnverifiedAddress in case when device is not available (account is created with passphrase but now passphrase_protection is disabled)

Part of https://github.com/trezor/trezor-suite/issues/1269