### PR TITLE
recovery fixes

### DIFF
--- a/packages/suite/src/actions/recovery/recoveryActions.ts
+++ b/packages/suite/src/actions/recovery/recoveryActions.ts
@@ -52,7 +52,7 @@ const checkSeed = () => async (dispatch: Dispatch, getState: GetState) => {
     const { advancedRecovery, wordsCount } = getState().recovery;
     const { device } = getState().suite;
     if (!device || !device.features) return;
-
+    dispatch(setError(''));
     dispatch(setStatus('in-progress'));
 
     const response = await TrezorConnect.recoveryDevice({
@@ -63,6 +63,8 @@ const checkSeed = () => async (dispatch: Dispatch, getState: GetState) => {
             path: device.path,
         },
     });
+
+    console.log('response', response);
 
     if (!response.success) {
         dispatch(setError(response.payload.error));
@@ -83,7 +85,7 @@ const recoverDevice = () => async (dispatch: Dispatch, getState: GetState) => {
     const { advancedRecovery, wordsCount } = getState().recovery;
     const { device } = getState().suite;
     if (!device || !device.features) return;
-
+    dispatch(setError(''));
     dispatch(setStatus('in-progress'));
 
     const response = await TrezorConnect.recoveryDevice({
@@ -93,6 +95,7 @@ const recoverDevice = () => async (dispatch: Dispatch, getState: GetState) => {
             path: device.path,
         },
     });
+    console.log('response', response);
 
     if (!response.success) {
         dispatch(setError(response.payload.error));

--- a/packages/suite/src/actions/recovery/recoveryActions.ts
+++ b/packages/suite/src/actions/recovery/recoveryActions.ts
@@ -93,6 +93,9 @@ const recoverDevice = () => async (dispatch: Dispatch, getState: GetState) => {
     dispatch(setStatus('finished'));
 };
 
+// Recovery mode is persistent on model T. This means that device stays in recovery mode even after reconnecting.
+// In such case, we need to call again the call that brought device into recovery mode (either proper recovery
+// or seed check). This way, communication is renewed and host starts receiving messages from device again.
 const rerun = () => async (dispatch: Dispatch, getState: GetState) => {
     const { device } = getState().suite;
 

--- a/packages/suite/src/actions/recovery/recoveryActions.ts
+++ b/packages/suite/src/actions/recovery/recoveryActions.ts
@@ -95,7 +95,6 @@ const recoverDevice = () => async (dispatch: Dispatch, getState: GetState) => {
             path: device.path,
         },
     });
-    console.log('response', response);
 
     if (!response.success) {
         dispatch(setError(response.payload.error));

--- a/packages/suite/src/actions/recovery/recoveryActions.ts
+++ b/packages/suite/src/actions/recovery/recoveryActions.ts
@@ -64,21 +64,10 @@ const checkSeed = () => async (dispatch: Dispatch, getState: GetState) => {
         },
     });
 
-    console.log('response', response);
-
     if (!response.success) {
         dispatch(setError(response.payload.error));
     }
 
-    // todo: does it make sense here? probably not
-    // if (device.features.recovery_mode) {
-    //     TrezorConnect.getFeatures({
-    //         device: {
-    //             path: device.path,
-    //         },
-    //     });
-    // }
-    dispatch(setError(''));
     dispatch(setStatus('finished'));
 };
 
@@ -88,7 +77,6 @@ const recoverDevice = () => async (dispatch: Dispatch, getState: GetState) => {
     if (!device || !device.features) return;
     dispatch(setError(''));
     dispatch(setStatus('in-progress'));
-    dispatch(setError(''));
 
     const response = await TrezorConnect.recoveryDevice({
         type: advancedRecovery ? 1 : 0,
@@ -102,14 +90,6 @@ const recoverDevice = () => async (dispatch: Dispatch, getState: GetState) => {
         dispatch(setError(response.payload.error));
     }
 
-    // todo: does it make sense here? probably not
-    // if (device.features.recovery_mode) {
-    //     TrezorConnect.getFeatures({
-    //         device: {
-    //             path: device.path,
-    //         },
-    //     });
-    // }
     dispatch(setStatus('finished'));
 };
 

--- a/packages/suite/src/components/recovery/Error.tsx
+++ b/packages/suite/src/components/recovery/Error.tsx
@@ -1,8 +1,12 @@
 import React from 'react';
-
+import styled from 'styled-components';
 import { P } from '@trezor/components';
 
 import { Translation, Image } from '@suite-components';
+
+const StyledImage = styled(Image)`
+    flex: 1;
+`;
 
 interface Props {
     error?: string;
@@ -13,7 +17,7 @@ const Error = ({ error }: Props) => (
         <P size="small">
             <Translation id="TR_RECOVERY_ERROR" values={{ error }} />
         </P>
-        <Image image="UNI_ERROR" />
+        <StyledImage image="UNI_ERROR" />
     </>
 );
 

--- a/packages/suite/src/components/suite/Prompts/components/ConnectPrompt.tsx
+++ b/packages/suite/src/components/suite/Prompts/components/ConnectPrompt.tsx
@@ -1,7 +1,11 @@
 /* eslint-disable jsx-a11y/media-has-caption */
 import React from 'react';
-
+import styled from 'styled-components';
 import { resolveStaticPath } from '@suite-utils/nextjs';
+
+const StyledVideo = styled.video`
+    flex: 1;
+`;
 
 interface Props {
     model: number;
@@ -15,14 +19,14 @@ const ConnectPrompt = ({ model, height = 200, loop = false }: Props) => {
         <>
             {/* just a hack to switch loop from true to false without need to forward ref to the video */}
             {loop && (
-                <video height={height} autoPlay loop={loop}>
+                <StyledVideo height={height} autoPlay loop={loop}>
                     <source src={resolveStaticPath(path)} type="video/mp4" />
-                </video>
+                </StyledVideo>
             )}
             {!loop && (
-                <video height={height} autoPlay loop={loop}>
+                <StyledVideo height={height} autoPlay loop={loop}>
                     <source src={resolveStaticPath(path)} type="video/mp4" />
-                </video>
+                </StyledVideo>
             )}
         </>
     );

--- a/packages/suite/src/config/onboarding/steps.ts
+++ b/packages/suite/src/config/onboarding/steps.ts
@@ -98,7 +98,8 @@ const steps: Step[] = [
             STEP.DISALLOWED_DEVICE_IS_NOT_CONNECTED,
             STEP.DISALLOWED_DEVICE_IS_IN_BOOTLOADER,
             STEP.DISALLOWED_DEVICE_IS_NOT_USED_HERE,
-            STEP.DISALLOWED_IS_NOT_SAME_DEVICE,
+            // watch out: cannot be used here! recovery is changing device_id
+            // STEP.DISALLOWED_IS_NOT_SAME_DEVICE
         ],
         path: [STEP.PATH_RECOVERY, STEP.PATH_NEW, STEP.PATH_USED],
         buy: false,

--- a/packages/suite/src/constants/suite/routes.ts
+++ b/packages/suite/src/constants/suite/routes.ts
@@ -100,12 +100,14 @@ const routes = [
         pattern: 'recovery',
         app: 'recovery',
         isModal: true,
+        params: modalAppParams,
     },
     {
         name: 'backup-index',
         pattern: 'backup',
         app: 'backup',
         isModal: true,
+        params: modalAppParams,
     },
     {
         name: 'firmware-index',

--- a/packages/suite/src/middlewares/recovery/recoveryMiddleware.ts
+++ b/packages/suite/src/middlewares/recovery/recoveryMiddleware.ts
@@ -1,6 +1,8 @@
 import { MiddlewareAPI } from 'redux';
 import { SUITE } from '@suite-actions/constants';
 import * as recoveryActions from '@recovery-actions/recoveryActions';
+import * as onboardingActions from '@onboarding-actions/onboardingActions';
+
 import { AppState, Action, Dispatch } from '@suite-types';
 
 const recovery = (api: MiddlewareAPI<Dispatch, AppState>) => (next: Dispatch) => (
@@ -15,6 +17,25 @@ const recovery = (api: MiddlewareAPI<Dispatch, AppState>) => (next: Dispatch) =>
 
     // pass action
     next(action);
+    // this applies to recovery when device is not initialized yet -> it means in oboarding.
+    // user might lose connection with device and/or reload suite. but the device is still
+    // in recovery mode and without any seed so we must act. the way out this is to reinitialize
+    // recoveryDevice call and move user to the onboarding step where it should be solved.
+    if (action.type === SUITE.SELECT_DEVICE && action.payload?.features?.recovery_mode) {
+        if (!action.payload.features.initialized) {
+            // enter appropriate onboarding step
+            api.dispatch(onboardingActions.goToNextStep('recovery'));
+            // also add users selection of 'recovery' path artificially. thats because user
+            // might click back and we need to make sure that he will through steps in correct order.
+            api.dispatch(onboardingActions.addPath('recovery'));
+            // reinitialize recoveryDevice call.
+            api.dispatch(recoveryActions.recoverDevice());
+        }
+        if (action.payload.features.initialized) {
+            // if device is initialized then user got interrupted in dry_drun
+            api.dispatch(recoveryActions.checkSeed());
+        }
+    }
 
     return action;
 };

--- a/packages/suite/src/middlewares/recovery/recoveryMiddleware.ts
+++ b/packages/suite/src/middlewares/recovery/recoveryMiddleware.ts
@@ -1,7 +1,6 @@
 import { MiddlewareAPI } from 'redux';
 import { SUITE } from '@suite-actions/constants';
 import * as recoveryActions from '@recovery-actions/recoveryActions';
-import * as onboardingActions from '@onboarding-actions/onboardingActions';
 
 import { AppState, Action, Dispatch } from '@suite-types';
 
@@ -17,25 +16,6 @@ const recovery = (api: MiddlewareAPI<Dispatch, AppState>) => (next: Dispatch) =>
 
     // pass action
     next(action);
-    // this applies to recovery when device is not initialized yet -> it means in oboarding.
-    // user might lose connection with device and/or reload suite. but the device is still
-    // in recovery mode and without any seed so we must act. the way out this is to reinitialize
-    // recoveryDevice call and move user to the onboarding step where it should be solved.
-    if (action.type === SUITE.SELECT_DEVICE && action.payload?.features?.recovery_mode) {
-        if (!action.payload.features.initialized) {
-            // enter appropriate onboarding step
-            api.dispatch(onboardingActions.goToNextStep('recovery'));
-            // also add users selection of 'recovery' path artificially. thats because user
-            // might click back and we need to make sure that he will through steps in correct order.
-            api.dispatch(onboardingActions.addPath('recovery'));
-            // reinitialize recoveryDevice call.
-            api.dispatch(recoveryActions.recoverDevice());
-        }
-        if (action.payload.features.initialized) {
-            // if device is initialized then user got interrupted in dry_drun
-            api.dispatch(recoveryActions.checkSeed());
-        }
-    }
 
     return action;
 };

--- a/packages/suite/src/views/onboarding/index.tsx
+++ b/packages/suite/src/views/onboarding/index.tsx
@@ -121,7 +121,7 @@ const Onboarding = (props: Props) => {
 
     const StepComponent = getStepComponent();
     const stepsInPath = steps.filter(s => s.progress && isStepInPath(s, path));
-    console.log(modal);
+
     return (
         <Wrapper>
             <Head>

--- a/packages/suite/src/views/onboarding/index.tsx
+++ b/packages/suite/src/views/onboarding/index.tsx
@@ -121,6 +121,7 @@ const Onboarding = (props: Props) => {
 
     const StepComponent = getStepComponent();
     const stepsInPath = steps.filter(s => s.progress && isStepInPath(s, path));
+    console.log(modal);
     return (
         <Wrapper>
             <Head>
@@ -134,7 +135,7 @@ const Onboarding = (props: Props) => {
                 showHelp={getStep().help}
                 hidden={!getStep().progress}
             />
-
+            {/* { modal && modal } */}
             <UnexpectedState>
                 {modal && (
                     <ActionModalWrapper data-test="@onboading/confirm-action-on-device">

--- a/packages/suite/src/views/onboarding/index.tsx
+++ b/packages/suite/src/views/onboarding/index.tsx
@@ -135,7 +135,6 @@ const Onboarding = (props: Props) => {
                 showHelp={getStep().help}
                 hidden={!getStep().progress}
             />
-            {/* { modal && modal } */}
             <UnexpectedState>
                 {modal && (
                     <ActionModalWrapper data-test="@onboading/confirm-action-on-device">

--- a/packages/suite/src/views/onboarding/index.tsx
+++ b/packages/suite/src/views/onboarding/index.tsx
@@ -9,6 +9,7 @@ import { Step } from '@onboarding-types/steps';
 import * as onboardingActions from '@onboarding-actions/onboardingActions';
 import * as STEP from '@onboarding-constants/steps';
 import steps from '@onboarding-config/steps';
+import { isStepInPath } from '@onboarding-utils/steps';
 
 import WelcomeStep from '@onboarding-views/steps/Welcome/Container';
 import SkipStep from '@onboarding-views/steps/Skip/Container';
@@ -72,7 +73,7 @@ type Props = ReturnType<typeof mapStateToProps> &
     InjectedModalApplicationProps;
 
 const Onboarding = (props: Props) => {
-    const { activeStepId, modal } = props;
+    const { activeStepId, modal, path } = props;
 
     const getStep = () => {
         const lookup = steps.find((step: Step) => step.id === activeStepId);
@@ -119,7 +120,7 @@ const Onboarding = (props: Props) => {
     };
 
     const StepComponent = getStepComponent();
-
+    const stepsInPath = steps.filter(s => s.progress && isStepInPath(s, path));
     return (
         <Wrapper>
             <Head>
@@ -127,8 +128,8 @@ const Onboarding = (props: Props) => {
             </Head>
 
             <ProgressBar
-                total={steps.filter(s => s.progress).length}
-                current={steps.findIndex(step => activeStepId === step.id)}
+                total={stepsInPath.length}
+                current={stepsInPath.findIndex(step => activeStepId === step.id)}
                 showBuy={getStep().buy}
                 showHelp={getStep().help}
                 hidden={!getStep().progress}

--- a/packages/suite/src/views/onboarding/steps/Final/index.tsx
+++ b/packages/suite/src/views/onboarding/steps/Final/index.tsx
@@ -1,9 +1,14 @@
 import React from 'react';
+import styled from 'styled-components';
 
-import { OnboardingButton, Wrapper } from '@onboarding-components';
+import { OnboardingButton, Wrapper, Text } from '@onboarding-components';
 import { Translation, Image } from '@suite-components';
 
 import { Props } from './Container';
+
+const StyledImage = styled(Image)`
+    flex: 1;
+`;
 
 const FinalStep = ({ closeModalApp }: Props) => (
     <Wrapper.Step data-test="@onboarding/final">
@@ -11,8 +16,10 @@ const FinalStep = ({ closeModalApp }: Props) => (
             <Translation id="TR_FINAL_HEADING" />
         </Wrapper.StepHeading>
         <Wrapper.StepBody>
-            <Translation id="TR_FINAL_SUBHEADING" />
-            <Image image="ALL_DONE" />
+            <Text>
+                <Translation id="TR_FINAL_SUBHEADING" />
+            </Text>
+            <StyledImage image="ALL_DONE" />
         </Wrapper.StepBody>
         <Wrapper.Controls>
             <OnboardingButton.Cta

--- a/packages/suite/src/views/onboarding/steps/Recovery/Container.ts
+++ b/packages/suite/src/views/onboarding/steps/Recovery/Container.ts
@@ -19,7 +19,7 @@ const mapDispatchToProps = (dispatch: Dispatch) => ({
     setAdvancedRecovery: bindActionCreators(recoveryActions.setAdvancedRecovery, dispatch),
     recoverDevice: bindActionCreators(recoveryActions.recoverDevice, dispatch),
     setStatus: bindActionCreators(recoveryActions.setStatus, dispatch),
-    resetReducer: bindActionCreators(recoveryActions.resetReducer, dispatch),
+    rerun: bindActionCreators(recoveryActions.rerun, dispatch),
 });
 
 export type Props = ReturnType<typeof mapStateToProps> & ReturnType<typeof mapDispatchToProps>;

--- a/packages/suite/src/views/onboarding/steps/Recovery/index.tsx
+++ b/packages/suite/src/views/onboarding/steps/Recovery/index.tsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import styled from 'styled-components';
 
 import { OnboardingButton, Text, Wrapper } from '@onboarding-components';
 import { SelectWordCount, SelectRecoveryType, Error } from '@recovery-components';
@@ -6,6 +7,9 @@ import { Translation, Loading, Image } from '@suite-components';
 
 import { Props } from './Container';
 
+const StyledImage = styled(Image)`
+    flex: 1;
+`;
 const RecoveryStep = (props: Props) => {
     const {
         goToNextStep,
@@ -84,17 +88,11 @@ const RecoveryStep = (props: Props) => {
                     </>
                 )}
 
-                {recovery.status === 'in-progress' && (
-                    // <>
-                    //     {!modal && <Loading />}
-                    //     {modal && modal}
-                    // </>
-                    <Loading />
-                )}
+                {recovery.status === 'in-progress' && <Loading />}
 
                 {recovery.status === 'finished' && !recovery.error && (
                     <>
-                        <Image image="UNI_SUCCESS" />
+                        <StyledImage image="UNI_SUCCESS" />
                         <Wrapper.Controls>
                             <OnboardingButton.Cta
                                 data-test="@onboarding/recovery/continue-button"

--- a/packages/suite/src/views/onboarding/steps/Recovery/index.tsx
+++ b/packages/suite/src/views/onboarding/steps/Recovery/index.tsx
@@ -21,8 +21,7 @@ const RecoveryStep = (props: Props) => {
         recoverDevice,
         recovery,
         device,
-        // modal,
-        resetReducer,
+        rerun,
     } = props;
 
     if (!device || !device.features) {
@@ -91,6 +90,7 @@ const RecoveryStep = (props: Props) => {
 
                 {recovery.status === 'in-progress' && <Loading />}
 
+                {/* {device.features.initialized && ( */}
                 {recovery.status === 'finished' && !recovery.error && (
                     <>
                         <StyledImage image="UNI_SUCCESS" />
@@ -110,7 +110,9 @@ const RecoveryStep = (props: Props) => {
                         <Wrapper.Controls>
                             <OnboardingButton.Cta
                                 onClick={() => {
-                                    resetReducer();
+                                    // resetReducer();
+                                    // recoverDevice();
+                                    rerun();
                                 }}
                             >
                                 <Translation id="TR_RETRY" />
@@ -121,7 +123,7 @@ const RecoveryStep = (props: Props) => {
             </Wrapper.StepBody>
 
             <Wrapper.StepFooter>
-                {recovery.status !== 'in-progress' && (
+                {recovery.status === 'initial' && (
                     <OnboardingButton.Back onClick={() => goToPreviousStep()}>
                         <Translation id="TR_BACK" />
                     </OnboardingButton.Back>

--- a/packages/suite/src/views/onboarding/steps/Recovery/index.tsx
+++ b/packages/suite/src/views/onboarding/steps/Recovery/index.tsx
@@ -4,7 +4,6 @@ import styled from 'styled-components';
 import { OnboardingButton, Text, Wrapper } from '@onboarding-components';
 import { SelectWordCount, SelectRecoveryType, Error } from '@recovery-components';
 import { Translation, Loading, Image } from '@suite-components';
-
 import { Props } from './Container';
 
 const StyledImage = styled(Image)`
@@ -21,7 +20,6 @@ const RecoveryStep = (props: Props) => {
         recoverDevice,
         recovery,
         device,
-        rerun,
     } = props;
 
     if (!device || !device.features) {
@@ -29,6 +27,26 @@ const RecoveryStep = (props: Props) => {
     }
 
     const model = device.features.major_version;
+    const handleBack = () => {
+        if (recovery.status === 'select-recovery-type') {
+            return setStatus('initial');
+        }
+        // allow to change recovery settings for T1 in case of error
+        if (recovery.status === 'finished' && recovery.error && model === 1) {
+            return setStatus('initial');
+        }
+        return goToPreviousStep();
+    };
+
+    const isBackButtonVisible = () => {
+        if (recovery.status === 'finished' && recovery.error && model === 1) {
+            return true;
+        }
+        if (recovery.status !== 'finished' && recovery.status !== 'in-progress') {
+            return true;
+        }
+        return false;
+    };
 
     return (
         <Wrapper.Step>
@@ -40,14 +58,12 @@ const RecoveryStep = (props: Props) => {
             </Wrapper.StepHeading>
             <Wrapper.StepBody>
                 {recovery.status === 'initial' && model === 1 && (
-                    <>
-                        <SelectWordCount
-                            onSelect={number => {
-                                setWordsCount(number);
-                                setStatus('select-recovery-type');
-                            }}
-                        />
-                    </>
+                    <SelectWordCount
+                        onSelect={number => {
+                            setWordsCount(number);
+                            setStatus('select-recovery-type');
+                        }}
+                    />
                 )}
 
                 {recovery.status === 'initial' && model === 2 && (
@@ -75,16 +91,6 @@ const RecoveryStep = (props: Props) => {
                                 recoverDevice();
                             }}
                         />
-
-                        <Wrapper.Controls>
-                            <OnboardingButton.Alt
-                                onClick={() => {
-                                    setStatus('initial');
-                                }}
-                            >
-                                <Translation id="TR_BACK" />
-                            </OnboardingButton.Alt>
-                        </Wrapper.Controls>
                     </>
                 )}
 
@@ -109,7 +115,7 @@ const RecoveryStep = (props: Props) => {
                         <Wrapper.Controls>
                             <OnboardingButton.Cta
                                 onClick={() => {
-                                    rerun();
+                                    recoverDevice();
                                 }}
                             >
                                 <Translation id="TR_RETRY" />
@@ -120,8 +126,8 @@ const RecoveryStep = (props: Props) => {
             </Wrapper.StepBody>
 
             <Wrapper.StepFooter>
-                {recovery.status === 'initial' && (
-                    <OnboardingButton.Back onClick={() => goToPreviousStep()}>
+                {isBackButtonVisible() && (
+                    <OnboardingButton.Back onClick={() => handleBack()}>
                         <Translation id="TR_BACK" />
                     </OnboardingButton.Back>
                 )}

--- a/packages/suite/src/views/onboarding/steps/Recovery/index.tsx
+++ b/packages/suite/src/views/onboarding/steps/Recovery/index.tsx
@@ -90,7 +90,6 @@ const RecoveryStep = (props: Props) => {
 
                 {recovery.status === 'in-progress' && <Loading />}
 
-                {/* {device.features.initialized && ( */}
                 {recovery.status === 'finished' && !recovery.error && (
                     <>
                         <StyledImage image="UNI_SUCCESS" />
@@ -110,8 +109,6 @@ const RecoveryStep = (props: Props) => {
                         <Wrapper.Controls>
                             <OnboardingButton.Cta
                                 onClick={() => {
-                                    // resetReducer();
-                                    // recoverDevice();
                                     rerun();
                                 }}
                             >

--- a/packages/suite/src/views/onboarding/steps/Recovery/index.tsx
+++ b/packages/suite/src/views/onboarding/steps/Recovery/index.tsx
@@ -10,6 +10,7 @@ import { Props } from './Container';
 const StyledImage = styled(Image)`
     flex: 1;
 `;
+
 const RecoveryStep = (props: Props) => {
     const {
         goToNextStep,
@@ -98,7 +99,7 @@ const RecoveryStep = (props: Props) => {
                                 data-test="@onboarding/recovery/continue-button"
                                 onClick={() => goToNextStep('set-pin')}
                             >
-                                Continue
+                                <Translation id="TR_CONTINUE" />
                             </OnboardingButton.Cta>
                         </Wrapper.Controls>
                     </>
@@ -122,7 +123,7 @@ const RecoveryStep = (props: Props) => {
             <Wrapper.StepFooter>
                 {recovery.status !== 'in-progress' && (
                     <OnboardingButton.Back onClick={() => goToPreviousStep()}>
-                        Back
+                        <Translation id="TR_BACK" />
                     </OnboardingButton.Back>
                 )}
             </Wrapper.StepFooter>

--- a/packages/suite/src/views/onboarding/unexpected-states/index.tsx
+++ b/packages/suite/src/views/onboarding/unexpected-states/index.tsx
@@ -28,6 +28,7 @@ const IsInBootloader = () => (
 const mapStateToProps = (state: AppState) => ({
     onboarding: state.onboarding,
     suite: state.suite,
+    recovery: state.recovery,
 });
 
 type Props = ReturnType<typeof mapStateToProps> & {
@@ -41,16 +42,19 @@ const UnexpectedState = ({ onboarding, suite, children }: Props) => {
     const activeStep = steps.find(s => s.id === activeStepId);
 
     const isNotSameDevice = () => {
-        const prevDeviceId = prevDevice && prevDevice.features && prevDevice.id;
-        // if no device was connected before, assume it is same device
-        if (!prevDeviceId) {
-            return false;
-        }
-        const deviceId = device && device.features && device.id;
-        if (!deviceId) {
-            return null;
-        }
-        return deviceId !== prevDeviceId;
+        // temporarily disabled, there is the thing with changing id in resetDevice
+        return false;
+
+        // const prevDeviceId = prevDevice && prevDevice.features && prevDevice.id;
+        // // if no device was connected before, assume it is same device
+        // if (!prevDeviceId) {
+        //     return false;
+        // }
+        // const deviceId = device && device.features && device.id;
+        // if (!deviceId) {
+        //     return null;
+        // }
+        // return deviceId !== prevDeviceId;
     };
 
     const isNotNewDevice = () => {
@@ -75,7 +79,6 @@ const UnexpectedState = ({ onboarding, suite, children }: Props) => {
             case STEP.DISALLOWED_DEVICE_IS_NOT_USED_HERE:
                 return device?.type === 'unacquired';
             case STEP.DISALLOWED_DEVICE_IS_NOT_NEW_DEVICE:
-                // todo check
                 return isNotNewDevice();
             case STEP.DISALLOWED_DEVICE_IS_IN_RECOVERY_MODE:
                 return device?.features?.recovery_mode;

--- a/packages/suite/src/views/onboarding/unexpected-states/index.tsx
+++ b/packages/suite/src/views/onboarding/unexpected-states/index.tsx
@@ -42,19 +42,16 @@ const UnexpectedState = ({ onboarding, suite, children }: Props) => {
     const activeStep = steps.find(s => s.id === activeStepId);
 
     const isNotSameDevice = () => {
-        // temporarily disabled, there is the thing with changing id in resetDevice
-        return false;
-
-        // const prevDeviceId = prevDevice && prevDevice.features && prevDevice.id;
-        // // if no device was connected before, assume it is same device
-        // if (!prevDeviceId) {
-        //     return false;
-        // }
-        // const deviceId = device && device.features && device.id;
-        // if (!deviceId) {
-        //     return null;
-        // }
-        // return deviceId !== prevDeviceId;
+        const prevDeviceId = prevDevice && prevDevice.features && prevDevice.id;
+        // if no device was connected before, assume it is same device
+        if (!prevDeviceId) {
+            return false;
+        }
+        const deviceId = device && device.features && device.id;
+        if (!deviceId) {
+            return null;
+        }
+        return deviceId !== prevDeviceId;
     };
 
     const isNotNewDevice = () => {

--- a/packages/suite/src/views/recovery/index.tsx
+++ b/packages/suite/src/views/recovery/index.tsx
@@ -85,6 +85,9 @@ const StyledP = styled(P)`
     color: ${colors.BLACK50};
 `;
 
+const StyledImage = styled(Image)`
+    flex: 1;
+`;
 const mapStateToProps = (state: AppState) => ({
     recovery: state.recovery,
     locks: state.suite.locks,
@@ -295,7 +298,7 @@ const Recovery = ({
                     <StyledP>
                         <Translation id="TR_SEED_CHECK_SUCCESS_DESC" />
                     </StyledP>
-                    <Image image="UNI_SUCCESS" />
+                    <StyledImage image="UNI_SUCCESS" />
                     <Buttons>
                         <StyledButton onClick={() => closeModalApp()}>
                             <Translation id="TR_CLOSE" />

--- a/packages/suite/src/views/recovery/index.tsx
+++ b/packages/suite/src/views/recovery/index.tsx
@@ -181,6 +181,7 @@ const Recovery = ({
                     <StyledP>
                         <Translation id="TR_CHECK_RECOVERY_SEED_DESC_T2" />
                     </StyledP>
+                    <div style={{ flex: 1, alignItems: 'center'}}>
 
                     <InfoBox>
                         <Number>1</Number>
@@ -205,6 +206,8 @@ const Recovery = ({
                             </InfoBoxDescription>
                         </InfoBoxText>
                     </InfoBox>
+                    </div>
+
                 </>
             )}
 

--- a/packages/suite/src/views/recovery/index.tsx
+++ b/packages/suite/src/views/recovery/index.tsx
@@ -181,7 +181,6 @@ const Recovery = ({
                     <StyledP>
                         <Translation id="TR_CHECK_RECOVERY_SEED_DESC_T2" />
                     </StyledP>
-                    <div style={{ flex: 1, alignItems: 'center'}}>
 
                     <InfoBox>
                         <Number>1</Number>
@@ -206,8 +205,6 @@ const Recovery = ({
                             </InfoBoxDescription>
                         </InfoBoxText>
                     </InfoBox>
-                    </div>
-
                 </>
             )}
 

--- a/packages/suite/src/views/recovery/index.tsx
+++ b/packages/suite/src/views/recovery/index.tsx
@@ -18,7 +18,7 @@ import ModalWrapper from '@suite-components/ModalWrapper';
 import * as recoveryActions from '@recovery-actions/recoveryActions';
 import { InjectedModalApplicationProps, AppState, Dispatch } from '@suite-types';
 import { WordCount } from '@recovery-types';
-
+import { useDeviceActionLocks } from '@suite-utils/hooks';
 import { URLS } from '@suite-constants';
 
 const Wrapper = styled(ModalWrapper)`
@@ -38,12 +38,12 @@ const Row = styled.div`
 const Buttons = styled(Row)`
     justify-content: center;
     margin-top: auto;
+    flex-direction: column;
 `;
 
 const StyledButton = styled(Button)`
     min-width: 224px;
     margin-bottom: 16px;
-    margin-top: 28px;
 `;
 
 const InfoBox = styled.div`
@@ -117,7 +117,7 @@ const Recovery = ({
 }: Props) => {
     const model = device?.features?.major_version;
     const [understood, setUnderstood] = useState(false);
-
+    const [actionEnabled] = useDeviceActionLocks();
     const onSetWordsCount = (count: WordCount) => {
         setWordsCount(count);
         setStatus('select-recovery-type');
@@ -222,13 +222,15 @@ const Recovery = ({
                         onClick={() => setUnderstood(!understood)}
                     />
 
-                    <StyledButton
-                        onClick={() => (model === 1 ? setStatus('select-word-count') : checkSeed())}
-                        isDisabled={!understood}
-                    >
-                        <Translation id="TR_START" />
-                    </StyledButton>
                     <Buttons>
+                        <StyledButton
+                            onClick={() =>
+                                model === 1 ? setStatus('select-word-count') : checkSeed()
+                            }
+                            isDisabled={!understood || !actionEnabled}
+                        >
+                            <Translation id="TR_START" />
+                        </StyledButton>
                         <StyledButton
                             icon="CROSS"
                             variant="tertiary"

--- a/packages/suite/src/views/settings/device/index.tsx
+++ b/packages/suite/src/views/settings/device/index.tsx
@@ -143,9 +143,7 @@ const Settings = ({ device, applySettings, changePin, openModal, goto }: Props) 
                         <ActionColumn>
                             <ActionButton
                                 data-test="@settings/device/check-seed-button"
-                                onClick={() => {
-                                    goto('recovery-index', { cancelable: true });
-                                }}
+                                onClick={() => goto('recovery-index', { cancelable: true })}
                                 isDisabled={
                                     !actionEnabled ||
                                     features.needs_backup ||

--- a/packages/suite/src/views/suite/device-recovery-mode/Container.ts
+++ b/packages/suite/src/views/suite/device-recovery-mode/Container.ts
@@ -12,11 +12,11 @@ const mapStateToProps = (state: AppState) => ({
 });
 
 const mapDispatchToProps = (dispatch: Dispatch) => ({
-    // todo: check if not dry_run
     addPath: bindActionCreators(onboardingActions.addPath, dispatch),
     goToStep: bindActionCreators(onboardingActions.goToStep, dispatch),
-    recoverDevice: bindActionCreators(recoveryActions.recoverDevice, dispatch),
-    checkSeed: bindActionCreators(recoveryActions.checkSeed, dispatch),
+    // recoverDevice: bindActionCreators(recoveryActions.recoverDevice, dispatch),
+    // checkSeed: bindActionCreators(recoveryActions.checkSeed, dispatch),
+    rerun: bindActionCreators(recoveryActions.rerun, dispatch),
 });
 
 export type Props = ReturnType<typeof mapStateToProps> &

--- a/packages/suite/src/views/suite/device-recovery-mode/Container.ts
+++ b/packages/suite/src/views/suite/device-recovery-mode/Container.ts
@@ -14,8 +14,6 @@ const mapStateToProps = (state: AppState) => ({
 const mapDispatchToProps = (dispatch: Dispatch) => ({
     addPath: bindActionCreators(onboardingActions.addPath, dispatch),
     goToStep: bindActionCreators(onboardingActions.goToStep, dispatch),
-    // recoverDevice: bindActionCreators(recoveryActions.recoverDevice, dispatch),
-    // checkSeed: bindActionCreators(recoveryActions.checkSeed, dispatch),
     rerun: bindActionCreators(recoveryActions.rerun, dispatch),
 });
 

--- a/packages/suite/src/views/suite/device-recovery-mode/index.tsx
+++ b/packages/suite/src/views/suite/device-recovery-mode/index.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import styled from 'styled-components';
-import { H2 } from '@trezor/components';
-import { Translation, Image } from '@suite-components';
+import { H2, Button } from '@trezor/components';
+import { Loading, Translation, Image } from '@suite-components';
 
 import { Props } from './Container';
 
@@ -11,49 +11,47 @@ const Wrapper = styled.div`
     flex-direction: column;
 `;
 
-// const Buttons = styled.div`
-//     display: flex;
-//     flex-direction: row;
-//     justify-content: center;
-//     margin: 20px;
-// `;
+const Buttons = styled.div`
+    display: flex;
+    flex-direction: row;
+    justify-content: center;
+    margin: 20px;
+`;
 
 const StyledImage = styled(Image)`
     flex: 1;
 `;
 
-const Index = ({ device }: Props) => {
-    const image = device?.features?.major_version === 2 ? 'FIRMWARE_INIT_2' : 'FIRMWARE_INIT_1';
-    return (
-        <Wrapper>
-            <H2>
-                <Translation id="TR_DEVICE_IN_RECOVERY_MODE" />
-            </H2>
-            <StyledImage image={image} />
-            {/* 
-            todo: still thinking about this but I'd say that it does not have sense to have button here. it is probably 
-            better to re-init recoveryDevice call from recoveryMiddleware.
-            */}
-            {/* <Buttons>
-                {!device?.features?.initialized && (
-                    <Button
-                        onClick={() => {
-                            recoverDevice();
-                            goToStep('recovery');
-                            addPath('recovery');
-                        }}
-                    >
-                        <Translation id="TR_CONTINUE" />
-                    </Button>
-                )}
-                {device?.features?.initialized && (
-                    <Button onClick={() => checkSeed()}>
-                        <Translation id="TR_CONTINUE" />
-                    </Button>
-                )}
-            </Buttons> */}
-        </Wrapper>
-    );
-};
+const Index = ({ recovery, device, rerun, goToStep, addPath }: Props) => (
+    <Wrapper>
+        {recovery.status === 'in-progress' && <Loading />}
+        {recovery.status !== 'in-progress' && (
+            <>
+                <H2>
+                    <Translation id="TR_DEVICE_IN_RECOVERY_MODE" />
+                </H2>
+                <StyledImage image="FIRMWARE_INIT_2" />
+                <Buttons>
+                    {!device?.features?.initialized && (
+                        <Button
+                            onClick={async () => {
+                                await rerun();
+                                goToStep('recovery');
+                                addPath('recovery');
+                            }}
+                        >
+                            <Translation id="TR_CONTINUE" />
+                        </Button>
+                    )}
+                    {device?.features?.initialized && (
+                        <Button onClick={() => rerun()}>
+                            <Translation id="TR_CONTINUE" />
+                        </Button>
+                    )}
+                </Buttons>
+            </>
+        )}
+    </Wrapper>
+);
 
 export default Index;

--- a/packages/suite/src/views/suite/device-recovery-mode/index.tsx
+++ b/packages/suite/src/views/suite/device-recovery-mode/index.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import styled from 'styled-components';
-import { H2, Button } from '@trezor/components';
-import { Loading, Translation, Image } from '@suite-components';
+import { H2 } from '@trezor/components';
+import { Translation, Image } from '@suite-components';
 
 import { Props } from './Container';
 
@@ -11,50 +11,49 @@ const Wrapper = styled.div`
     flex-direction: column;
 `;
 
-const Buttons = styled.div`
-    display: flex;
-    flex-direction: row;
-    justify-content: center;
-    margin: 20px;
-`;
+// const Buttons = styled.div`
+//     display: flex;
+//     flex-direction: row;
+//     justify-content: center;
+//     margin: 20px;
+// `;
 
 const StyledImage = styled(Image)`
     flex: 1;
 `;
 
-const Index = ({ recovery, device, checkSeed, recoverDevice, goToStep, addPath }: Props) => { 
+const Index = ({ device }: Props) => {
     const image = device?.features?.major_version === 2 ? 'FIRMWARE_INIT_2' : 'FIRMWARE_INIT_1';
-
-    <Wrapper>
-        {recovery.status === 'in-progress' && <Loading />}
-        {recovery.status !== 'in-progress' && (
-            <>
-                <H2>
-                    <Translation id="TR_DEVICE_IN_RECOVERY_MODE" />
-                </H2>
-                <StyledImage image={image} />
-                <Buttons>
-                    {!device?.features?.initialized && (
-                        <Button
-                            onClick={() => {
-                                recoverDevice();
-                                goToStep('recovery');
-                                addPath('recovery');
-                            }}
-                        >
-                            <Translation id="TR_CONTINUE" />
-                        </Button>
-                    )}
-                    {device?.features?.initialized && (
-                        <Button onClick={() => checkSeed()}>
-                            <Translation id="TR_CONTINUE" />
-                        </Button>
-                    )}
-                </Buttons>
-            </>
-        )}
-    </Wrapper>
-    )
+    return (
+        <Wrapper>
+            <H2>
+                <Translation id="TR_DEVICE_IN_RECOVERY_MODE" />
+            </H2>
+            <StyledImage image={image} />
+            {/* 
+            todo: still thinking about this but I'd say that it does not have sense to have button here. it is probably 
+            better to re-init recoveryDevice call from recoveryMiddleware.
+            */}
+            {/* <Buttons>
+                {!device?.features?.initialized && (
+                    <Button
+                        onClick={() => {
+                            recoverDevice();
+                            goToStep('recovery');
+                            addPath('recovery');
+                        }}
+                    >
+                        <Translation id="TR_CONTINUE" />
+                    </Button>
+                )}
+                {device?.features?.initialized && (
+                    <Button onClick={() => checkSeed()}>
+                        <Translation id="TR_CONTINUE" />
+                    </Button>
+                )}
+            </Buttons> */}
+        </Wrapper>
+    );
 };
 
 export default Index;

--- a/packages/suite/src/views/suite/device-recovery-mode/index.tsx
+++ b/packages/suite/src/views/suite/device-recovery-mode/index.tsx
@@ -34,8 +34,8 @@ const Index = ({ recovery, device, rerun, goToStep, addPath }: Props) => (
                 <Buttons>
                     {!device?.features?.initialized && (
                         <Button
-                            onClick={async () => {
-                                await rerun();
+                            onClick={() => {
+                                rerun();
                                 goToStep('recovery');
                                 addPath('recovery');
                             }}

--- a/packages/suite/src/views/suite/device-recovery-mode/index.tsx
+++ b/packages/suite/src/views/suite/device-recovery-mode/index.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import styled from 'styled-components';
 import { H2, Button } from '@trezor/components';
-import { Loading, Translation } from '@suite-components';
+import { Loading, Translation, Image } from '@suite-components';
 
 import { Props } from './Container';
 
@@ -18,14 +18,21 @@ const Buttons = styled.div`
     margin: 20px;
 `;
 
-const Index = ({ recovery, device, checkSeed, recoverDevice, goToStep, addPath }: Props) => (
+const StyledImage = styled(Image)`
+    flex: 1;
+`;
+
+const Index = ({ recovery, device, checkSeed, recoverDevice, goToStep, addPath }: Props) => { 
+    const image = device?.features?.major_version === 2 ? 'FIRMWARE_INIT_2' : 'FIRMWARE_INIT_1';
+
     <Wrapper>
         {recovery.status === 'in-progress' && <Loading />}
-        {recovery.status === 'initial' && (
+        {recovery.status !== 'in-progress' && (
             <>
                 <H2>
                     <Translation id="TR_DEVICE_IN_RECOVERY_MODE" />
                 </H2>
+                <StyledImage image={image} />
                 <Buttons>
                     {!device?.features?.initialized && (
                         <Button
@@ -47,6 +54,7 @@ const Index = ({ recovery, device, checkSeed, recoverDevice, goToStep, addPath }
             </>
         )}
     </Wrapper>
-);
+    )
+};
 
 export default Index;


### PR DESCRIPTION
- [x] change padding around success and error image in recovery 
- [x] add illustration to recovery mode modal
- [x] fix progress bar (https://github.com/trezor/trezor-suite/pull/1447/commits/43b0794f065b79e7d9aa57be65e94243d768eb1f)
- [x] prevent stuck in recovery in onboarding bug (go to onboarding, select recovery, start recovery, disconnect, reconnect, finish recovery on device without touching UI, get stuck io recovery step in onboarding)

##  edge cases that should be handled now: 

### Initialized device
common steps: check seed -> start -> confirm  on device:

- [x] reload window -> click continue -> finish on device
- [x] reload window -> finish on device without clicking continue -> click continue

Here comes a little unhappy case I can not do much about. Maybe close seed check modal, but where do I display error? In application state modal indicating that device is in recovery mode? @matejzak 

- [ ] reconnect device -> error state appears -> finish on device with success -> error state still visible -> click close -> see device-is-in-recovery mode -> click continue.

 
### No seed device
common steps: onboarding -> recovery -> start -> confirm on device 
- [x] reload window -> click continue -> finish on device
- [x] reload window -> finish on device without clicking continue -> click on continue
- [x] reconnect -> error appears -> click retry -> finish on device
- [x] reconnect -> error appears -> finish without clicking retry -> ??? 

___

resolves #1329