### PR TITLE
Settings - elements not interactive without device

### DIFF
--- a/packages/suite/src/views/settings/device/Container.ts
+++ b/packages/suite/src/views/settings/device/Container.ts
@@ -11,7 +11,6 @@ import DeviceSettings from './index';
 
 const mapStateToProps = (state: AppState) => ({
     device: state.suite.device,
-    locks: state.suite.locks,
 });
 
 const mapDispatchToProps = (dispatch: Dispatch) => ({

--- a/packages/suite/src/views/settings/device/index.tsx
+++ b/packages/suite/src/views/settings/device/index.tsx
@@ -4,8 +4,6 @@ import React, { useEffect, useState, createRef } from 'react';
 import styled from 'styled-components';
 import { P, Switch, Link, colors } from '@trezor/components';
 
-import { SUITE } from '@suite-actions/constants';
-
 import { Translation } from '@suite-components';
 import { SettingsLayout } from '@settings-components';
 import { getFwVersion, isBitcoinOnly } from '@suite-utils/device';
@@ -16,6 +14,7 @@ import {
     FAILED_BACKUP_URL,
 } from '@suite-constants/urls';
 import * as homescreen from '@suite-utils/homescreen';
+import { useDeviceActionLocks } from '@suite-utils/hooks';
 
 import { Props } from './Container';
 
@@ -49,11 +48,11 @@ const Col = styled.div`
     flex-direction: column;
 `;
 
-const Settings = ({ device, locks, applySettings, changePin, openModal, goto }: Props) => {
-    const uiLocked = locks.includes(SUITE.LOCK_TYPE.DEVICE) || locks.includes(SUITE.LOCK_TYPE.UI);
+const Settings = ({ device, applySettings, changePin, openModal, goto }: Props) => {
     const [label, setLabel] = useState('');
     const [customHomescreen, setCustomHomescreen] = useState('');
     const fileInputElement = createRef<HTMLInputElement>();
+    const [ actionEnabled ] = useDeviceActionLocks();
 
     useEffect(() => {
         if (!device) {
@@ -111,7 +110,7 @@ const Settings = ({ device, locks, applySettings, changePin, openModal, goto }: 
                             data-test="@settings/device/create-backup-button"
                             onClick={() => goto('backup-index', { cancelable: true })}
                             isDisabled={
-                                uiLocked || !features.needs_backup || features.unfinished_backup
+                                !actionEnabled || !features.needs_backup || features.unfinished_backup
                             }
                         >
                             {features.needs_backup && <Translation id="TR_CREATE_BACKUP" />}
@@ -150,7 +149,7 @@ const Settings = ({ device, locks, applySettings, changePin, openModal, goto }: 
                                     goto('recovery-index', { cancelable: true });
                                 }}
                                 isDisabled={
-                                    uiLocked || features.needs_backup || features.unfinished_backup
+                                    !actionEnabled || features.needs_backup || features.unfinished_backup
                                 }
                                 variant="secondary"
                             >
@@ -180,7 +179,7 @@ const Settings = ({ device, locks, applySettings, changePin, openModal, goto }: 
                             variant="secondary"
                             onClick={() => goto('firmware-index', { cancelable: true })}
                             data-test="@settings/device/update-button"
-                            isDisabled={uiLocked}
+                            isDisabled={!actionEnabled}
                         >
                             {device &&
                                 ['required', 'outdated'].includes(device.firmware) &&
@@ -200,7 +199,7 @@ const Settings = ({ device, locks, applySettings, changePin, openModal, goto }: 
                         <Switch
                             checked={!!features.pin_protection}
                             onChange={() => changePin({ remove: features.pin_protection })}
-                            // isDisabled={uiLocked}
+                            isDisabled={!actionEnabled}
                         />
                     </ActionColumn>
                 </Row>
@@ -214,7 +213,7 @@ const Settings = ({ device, locks, applySettings, changePin, openModal, goto }: 
                         <ActionColumn>
                             <ActionButton
                                 onClick={() => changePin({ remove: false })}
-                                // isDisabled={uiLocked}
+                                isDisabled={!actionEnabled}
                                 variant="secondary"
                                 data-test="@settings/device/update-button"
                             >
@@ -244,7 +243,7 @@ const Settings = ({ device, locks, applySettings, changePin, openModal, goto }: 
                                 })
                             }
                             data-test="@settings/device/passphrase-switch"
-                            // isDisabled={uiLocked}
+                            isDisabled={!actionEnabled}
                         />
                     </ActionColumn>
                 </Row>
@@ -261,10 +260,11 @@ const Settings = ({ device, locks, applySettings, changePin, openModal, goto }: 
                                 setLabel(event.currentTarget.value)
                             }
                             data-test="@settings/device/label-input"
+                            readOnly={!actionEnabled}
                         />
                         <ActionButton
                             onClick={() => applySettings({ label })}
-                            isDisabled={uiLocked}
+                            isDisabled={!actionEnabled}
                             data-test="@settings/device/label-submit"
                         >
                             <Translation id="TR_DEVICE_SETTINGS_DEVICE_EDIT_LABEL" />
@@ -296,7 +296,7 @@ const Settings = ({ device, locks, applySettings, changePin, openModal, goto }: 
                                         fileInputElement.current.click();
                                     }
                                 }}
-                                isDisabled={uiLocked}
+                                isDisabled={!actionEnabled}
                                 variant="secondary"
                             >
                                 <Translation id="TR_DEVICE_SETTINGS_HOMESCREEN_UPLOAD_IMAGE" />
@@ -310,7 +310,7 @@ const Settings = ({ device, locks, applySettings, changePin, openModal, goto }: 
                                     device,
                                 })
                             }
-                            isDisabled={uiLocked}
+                            isDisabled={!actionEnabled}
                             data-test="@settings/device/select-from-gallery"
                             variant="secondary"
                         >
@@ -337,6 +337,7 @@ const Settings = ({ device, locks, applySettings, changePin, openModal, goto }: 
                             <ActionButton
                                 variant="secondary"
                                 onClick={() => setCustomHomescreen('')}
+                                isDisabled={!actionEnabled}
                             >
                                 Drop image
                             </ActionButton>
@@ -360,7 +361,7 @@ const Settings = ({ device, locks, applySettings, changePin, openModal, goto }: 
                                         })
                                     }
                                     data-test={`@settings/device/rotation-button/${variant.value}`}
-                                    isDisabled={uiLocked}
+                                    isDisabled={!actionEnabled}
                                 >
                                     {variant.label}
                                 </RotationButton>
@@ -384,7 +385,7 @@ const Settings = ({ device, locks, applySettings, changePin, openModal, goto }: 
                                 })
                             }
                             variant="danger"
-                            isDisabled={uiLocked}
+                            isDisabled={!actionEnabled}
                             data-test="@settings/device/open-wipe-modal-button"
                         >
                             <Translation id="TR_DEVICE_SETTINGS_BUTTON_WIPE_DEVICE" />

--- a/packages/suite/src/views/settings/device/index.tsx
+++ b/packages/suite/src/views/settings/device/index.tsx
@@ -52,7 +52,7 @@ const Settings = ({ device, applySettings, changePin, openModal, goto }: Props) 
     const [label, setLabel] = useState('');
     const [customHomescreen, setCustomHomescreen] = useState('');
     const fileInputElement = createRef<HTMLInputElement>();
-    const [ actionEnabled ] = useDeviceActionLocks();
+    const [actionEnabled] = useDeviceActionLocks();
 
     useEffect(() => {
         if (!device) {
@@ -110,7 +110,9 @@ const Settings = ({ device, applySettings, changePin, openModal, goto }: Props) 
                             data-test="@settings/device/create-backup-button"
                             onClick={() => goto('backup-index', { cancelable: true })}
                             isDisabled={
-                                !actionEnabled || !features.needs_backup || features.unfinished_backup
+                                !actionEnabled ||
+                                !features.needs_backup ||
+                                features.unfinished_backup
                             }
                         >
                             {features.needs_backup && <Translation id="TR_CREATE_BACKUP" />}
@@ -149,7 +151,9 @@ const Settings = ({ device, applySettings, changePin, openModal, goto }: Props) 
                                     goto('recovery-index', { cancelable: true });
                                 }}
                                 isDisabled={
-                                    !actionEnabled || features.needs_backup || features.unfinished_backup
+                                    !actionEnabled ||
+                                    features.needs_backup ||
+                                    features.unfinished_backup
                                 }
                                 variant="secondary"
                             >

--- a/packages/suite/src/views/settings/wallet/index.tsx
+++ b/packages/suite/src/views/settings/wallet/index.tsx
@@ -99,6 +99,7 @@ interface CoinsGroupProps {
     enabledNetworks: Network['symbol'][];
     type: 'mainnet' | 'testnet'; // used in tests
     unavailableCapabilities: { [key: string]: UnavailableCapability };
+    controlsDisabled: boolean;
 }
 
 const Unavailable = ({ type }: { type: UnavailableCapability }) => {
@@ -124,6 +125,7 @@ const CoinsGroup = ({
     filterFn,
     enabledNetworks,
     unavailableCapabilities,
+    controlsDisabled,
     ...props
 }: CoinsGroupProps) => (
     <CoinsGroupWrapper data-test="@settings/wallet/coins-group">
@@ -134,7 +136,7 @@ const CoinsGroup = ({
             </HeaderLeft>
             <ToggleButtons>
                 <Button
-                    isDisabled={NETWORKS.filter(filterFn).length === enabledNetworks.length}
+                    isDisabled={controlsDisabled || NETWORKS.filter(filterFn).length === enabledNetworks.length}
                     variant="tertiary"
                     size="small"
                     icon="CHECK"
@@ -144,7 +146,7 @@ const CoinsGroup = ({
                     <Translation id="TR_ACTIVATE_ALL" />
                 </Button>
                 <Button
-                    isDisabled={enabledNetworks.length === 0}
+                    isDisabled={controlsDisabled || enabledNetworks.length === 0}
                     variant="tertiary"
                     size="small"
                     icon="CROSS"
@@ -161,16 +163,18 @@ const CoinsGroup = ({
                 <CoinRow key={n.symbol}>
                     <Coin network={n} />
                     <ActionColumn>
-                        <AdvancedSettings>
+                        {/* todo: hidden until implmented */}
+                        {/* <AdvancedSettings>
                             <SettingsIcon icon="SETTINGS" size={12} color={colors.BLACK25} />
                             <Translation id="TR_ADVANCED_SETTINGS" />
-                        </AdvancedSettings>
+                        </AdvancedSettings> */}
                         {!unavailableCapabilities[n.symbol] && (
                             <Switch
                                 data-test={`@settings/wallet/network/${n.symbol}`}
                                 onChange={(visible: boolean) => {
                                     onToggleOneFn(n.symbol, visible);
                                 }}
+                                disabled={controlsDisabled}
                                 checked={enabledNetworks.includes(n.symbol)}
                             />
                         )}
@@ -190,7 +194,7 @@ const Settings = (props: Props) => {
     const { enabledNetworks } = props.wallet.settings;
     const unavailableCapabilities =
         props.device && props.device.features ? props.device.unavailableCapabilities : {};
-
+    const controlsDisabled = !props.device || !props.device.connected;
     const mainnetNetworksFilterFn = (n: Network) => !n.accountType && !n.testnet;
 
     const testnetNetworksFilterFn = (n: Network) =>
@@ -233,6 +237,7 @@ const Settings = (props: Props) => {
                 onDeactivateAll={() => props.changeNetworks(enabledTestnetNetworks)}
                 type="mainnet"
                 unavailableCapabilities={unavailableCapabilities}
+                controlsDisabled={controlsDisabled}
             />
 
             <CoinsGroup
@@ -252,6 +257,7 @@ const Settings = (props: Props) => {
                 onDeactivateAll={() => props.changeNetworks(enabledMainnetNetworks)}
                 type="testnet"
                 unavailableCapabilities={unavailableCapabilities}
+                controlsDisabled={controlsDisabled}
             />
 
             <SectionHeader>

--- a/packages/suite/src/views/settings/wallet/index.tsx
+++ b/packages/suite/src/views/settings/wallet/index.tsx
@@ -127,69 +127,73 @@ const CoinsGroup = ({
     unavailableCapabilities,
     ...props
 }: CoinsGroupProps) => {
-    const [ actionEnabled ] = useDeviceActionLocks();
+    const [actionEnabled] = useDeviceActionLocks();
     return (
-    <CoinsGroupWrapper data-test="@settings/wallet/coins-group">
-        <Header>
-            <HeaderLeft>
-                <SectionHeader>{label}</SectionHeader>
-                {description && <P size="tiny">{description}</P>}
-            </HeaderLeft>
-            <ToggleButtons>
-                <Button
-                    isDisabled={!actionEnabled || NETWORKS.filter(filterFn).length === enabledNetworks.length}
-                    variant="tertiary"
-                    size="small"
-                    icon="CHECK"
-                    onClick={() => onActivateAll()}
-                    data-test={`@settings/wallet/coins-group/${props.type}/activate-all`}
-                >
-                    <Translation id="TR_ACTIVATE_ALL" />
-                </Button>
-                <Button
-                    isDisabled={!actionEnabled || enabledNetworks.length === 0}
-                    variant="tertiary"
-                    size="small"
-                    icon="CROSS"
-                    onClick={() => onDeactivateAll()}
-                    data-test={`@settings/wallet/coins-group/${props.type}/deactivate-all`}
-                >
-                    <Translation id="TR_DEACTIVATE_ALL" />
-                </Button>
-            </ToggleButtons>
-        </Header>
+        <CoinsGroupWrapper data-test="@settings/wallet/coins-group">
+            <Header>
+                <HeaderLeft>
+                    <SectionHeader>{label}</SectionHeader>
+                    {description && <P size="tiny">{description}</P>}
+                </HeaderLeft>
+                <ToggleButtons>
+                    <Button
+                        isDisabled={
+                            !actionEnabled ||
+                            NETWORKS.filter(filterFn).length === enabledNetworks.length
+                        }
+                        variant="tertiary"
+                        size="small"
+                        icon="CHECK"
+                        onClick={() => onActivateAll()}
+                        data-test={`@settings/wallet/coins-group/${props.type}/activate-all`}
+                    >
+                        <Translation id="TR_ACTIVATE_ALL" />
+                    </Button>
+                    <Button
+                        isDisabled={!actionEnabled || enabledNetworks.length === 0}
+                        variant="tertiary"
+                        size="small"
+                        icon="CROSS"
+                        onClick={() => onDeactivateAll()}
+                        data-test={`@settings/wallet/coins-group/${props.type}/deactivate-all`}
+                    >
+                        <Translation id="TR_DEACTIVATE_ALL" />
+                    </Button>
+                </ToggleButtons>
+            </Header>
 
-        <Section>
-            {NETWORKS.filter(filterFn).map(n => (
-                <CoinRow key={n.symbol}>
-                    <Coin network={n} />
-                    <ActionColumn>
-                        {/* hidden with display 'none' until implemented */}
-                        <AdvancedSettings style={{ display: 'none' }}>
-                            <SettingsIcon icon="SETTINGS" size={12} color={colors.BLACK25} />
-                            <Translation id="TR_ADVANCED_SETTINGS" />
-                        </AdvancedSettings>
-                        {!unavailableCapabilities[n.symbol] && (
-                            <Switch
-                                data-test={`@settings/wallet/network/${n.symbol}`}
-                                onChange={(visible: boolean) => {
-                                    onToggleOneFn(n.symbol, visible);
-                                }}
-                                checked={enabledNetworks.includes(n.symbol)}
-                                disabled={!actionEnabled}
-                            />
-                        )}
-                        {unavailableCapabilities[n.symbol] && (
-                            <UnavailableLabel>
-                                <Unavailable type={unavailableCapabilities[n.symbol]} />
-                            </UnavailableLabel>
-                        )}
-                    </ActionColumn>
-                </CoinRow>
-            ))}
-        </Section>
-    </CoinsGroupWrapper>
-)};
+            <Section>
+                {NETWORKS.filter(filterFn).map(n => (
+                    <CoinRow key={n.symbol}>
+                        <Coin network={n} />
+                        <ActionColumn>
+                            {/* hidden with display 'none' until implemented */}
+                            <AdvancedSettings style={{ display: 'none' }}>
+                                <SettingsIcon icon="SETTINGS" size={12} color={colors.BLACK25} />
+                                <Translation id="TR_ADVANCED_SETTINGS" />
+                            </AdvancedSettings>
+                            {!unavailableCapabilities[n.symbol] && (
+                                <Switch
+                                    data-test={`@settings/wallet/network/${n.symbol}`}
+                                    onChange={(visible: boolean) => {
+                                        onToggleOneFn(n.symbol, visible);
+                                    }}
+                                    checked={enabledNetworks.includes(n.symbol)}
+                                    disabled={!actionEnabled}
+                                />
+                            )}
+                            {unavailableCapabilities[n.symbol] && (
+                                <UnavailableLabel>
+                                    <Unavailable type={unavailableCapabilities[n.symbol]} />
+                                </UnavailableLabel>
+                            )}
+                        </ActionColumn>
+                    </CoinRow>
+                ))}
+            </Section>
+        </CoinsGroupWrapper>
+    );
+};
 
 const Settings = (props: Props) => {
     const { enabledNetworks } = props.wallet.settings;


### PR DESCRIPTION
- Make controls in settings not interactive when device is not available.
- Hide advanced settings button
___ 
resolve #1453
resolve https://github.com/trezor/trezor-suite/issues/846