### PR TITLE
retry for integration tests

### DIFF
--- a/ci/packages/suite-web.yml
+++ b/ci/packages/suite-web.yml
@@ -41,8 +41,8 @@ suite-web test integration google-chrome:
             - /builds/satoshilabs/trezor/trezor-suite/packages/integration-tests/projects/suite-web/snapshots
             - /builds/satoshilabs/trezor/trezor-suite/packages/integration-tests/projects/suite-web/screenshots
     dependencies: []
-
-
+    retry:
+        max: 2
 
 suite-web test integration google-chrome-beta:
     only:
@@ -60,6 +60,8 @@ suite-web test integration google-chrome-beta:
             - /builds/satoshilabs/trezor/trezor-suite/packages/integration-tests/projects/suite-web/snapshots
             - /builds/satoshilabs/trezor/trezor-suite/packages/integration-tests/projects/suite-web/screenshots
     dependencies: []
+    retry:
+        max: 2
 
 suite-web test security:
     stage: deploy artifacts, others


### PR DESCRIPTION
Integration tests fail aprox in 10% (maybe less) of cases on some low level emulator not found problem. I definitely feel obliged to fix this but for this moment I believe that we may afford making this little step to hell and avoid rerunning our jobs manually.