### PR TITLE
device invalid states modals

### DIFF
--- a/packages/suite/src/actions/firmware/firmwareActions.ts
+++ b/packages/suite/src/actions/firmware/firmwareActions.ts
@@ -64,7 +64,8 @@ export const firmwareUpdate = () => async (dispatch: Dispatch, getState: GetStat
             path: device.path,
         },
         btcOnly,
-        version: targetRelease?.release?.version,
+        // for update (in firmware modal) target release is set. otherwise use device.firmwareRelease
+        version: targetRelease?.release?.version || device.firmwareRelease.release.version,
         baseUrl: 'https://wallet.trezor.io',
     };
 

--- a/packages/suite/src/actions/suite/trezorConnectActions.ts
+++ b/packages/suite/src/actions/suite/trezorConnectActions.ts
@@ -62,7 +62,7 @@ export const init = () => async (dispatch: Dispatch, getState: GetState) => {
             process.env.SUITE_TYPE === 'desktop'
                 ? resolveStaticPath('connect/')
                 : // : 'https://connect.trezor.io/8/';
-                  //   'https://localhost:8088/';
+                  // 'https://localhost:8088/';
                   'https://connect.corp.sldev.cz/develop/';
 
         await TrezorConnect.init({

--- a/packages/suite/src/components/suite/DeviceInvalidModeLayout/index.tsx
+++ b/packages/suite/src/components/suite/DeviceInvalidModeLayout/index.tsx
@@ -1,0 +1,99 @@
+import React from 'react';
+import { connect } from 'react-redux';
+import { bindActionCreators } from 'redux';
+import styled from 'styled-components';
+
+import { Button, variables } from '@trezor/components';
+import { Image as Img } from '@suite-components';
+import * as routerActions from '@suite-actions/routerActions';
+import { AppState, Dispatch } from '@suite-types';
+
+const { SCREEN_SIZE } = variables;
+const Wrapper = styled.div`
+    max-width: 80vw;
+    @media (min-width: ${SCREEN_SIZE.SM}) {
+        max-width: 60vw;
+    }
+    @media (min-width: ${SCREEN_SIZE.LG}) {
+        max-width: 40vw;
+    }
+`;
+
+const Title = styled.div`
+    font-size: ${variables.FONT_SIZE.H2};
+    margin-bottom: 4px;
+`;
+
+const Text = styled.div``;
+
+const Image = styled(Img)`
+    flex: 1;
+    margin: 20px 0;
+`;
+
+const Buttons = styled.div`
+    display: flex;
+    justify-content: space-around;
+`;
+
+const StyledButton = styled(Button)`
+    // margin: 20px;
+`;
+
+/**
+ * DeviceInvalidMode is subset of ApplicationState, see Preloader component. It shows that device is not in state
+ * application can work with and user must take one of the following actions:
+ *
+ *   1. trigger switch device menu (only available if multiple devices are connected)
+ *   2. click resolve button which takes user to a view where he may resolve issue with current device
+ *
+ * This is a layout component which indicates that it is supposed to unify layout of all DeviceInvalidMode
+ * like views listed in suite/views
+ */
+
+const mapDispatchToProps = (dispatch: Dispatch) => ({
+    goto: bindActionCreators(routerActions.goto, dispatch),
+});
+
+const mapStateToProps = (state: AppState) => ({
+    devices: state.devices,
+});
+
+type Props = {
+    title: React.ReactNode;
+    text?: React.ReactNode;
+    image?: React.ComponentProps<typeof Img>['image'];
+    allowSwitchDevice?: boolean;
+    resolveButton?: React.ReactNode;
+} & ReturnType<typeof mapStateToProps> &
+    ReturnType<typeof mapDispatchToProps>;
+
+const DeviceInvalidModeLayout = (props: Props) => {
+    const {
+        title,
+        text,
+        image = 'UNI_WARNING',
+        allowSwitchDevice,
+        devices,
+        resolveButton,
+        goto,
+    } = props;
+    return (
+        <Wrapper>
+            <Title>{title}</Title>
+            {text && <Text>{text}</Text>}
+            <Image image={image} />
+            <Buttons>
+                {resolveButton && resolveButton}
+                {/* todo: filter only physical devices */}
+                {allowSwitchDevice && devices.length > 1 && (
+                    <StyledButton onClick={() => goto('suite-switch-device', { cancelable: true })}>
+                        Switch device
+                    </StyledButton>
+                )}
+            </Buttons>
+        </Wrapper>
+    );
+};
+
+export default connect(mapStateToProps, mapDispatchToProps)(DeviceInvalidModeLayout);

--- a/packages/suite/src/components/suite/DeviceInvalidModeLayout/index.tsx
+++ b/packages/suite/src/components/suite/DeviceInvalidModeLayout/index.tsx
@@ -36,10 +36,6 @@ const Buttons = styled.div`
     justify-content: space-around;
 `;
 
-const StyledButton = styled(Button)`
-    // margin: 20px;
-`;
-
 /**
  * DeviceInvalidMode is subset of ApplicationState, see Preloader component. It shows that device is not in state
  * application can work with and user must take one of the following actions:
@@ -85,11 +81,11 @@ const DeviceInvalidModeLayout = (props: Props) => {
             <Image image={image} />
             <Buttons>
                 {resolveButton && resolveButton}
-                {/* todo: filter only physical devices */}
+                {/* todo: filter only physical devices ?? hm not sure. I still may want to browse wallet under this bl device */}
                 {allowSwitchDevice && devices.length > 1 && (
-                    <StyledButton onClick={() => goto('suite-switch-device', { cancelable: true })}>
-                        Switch device
-                    </StyledButton>
+                    <Button onClick={() => goto('suite-switch-device', { cancelable: true })}>
+                        <Translation id="TR_SWITCH_DEVICE" />
+                    </Button>
                 )}
             </Buttons>
         </Wrapper>

--- a/packages/suite/src/components/suite/index.tsx
+++ b/packages/suite/src/components/suite/index.tsx
@@ -21,7 +21,7 @@ import WebusbButton from './WebusbButton';
 import HiddenPlaceholder from './HiddenPlaceholder/Container';
 import QrCode from './QrCode';
 import QuestionTooltip from './QuestionTooltip';
-
+import DeviceInvalidModeLayout from './DeviceInvalidModeLayout';
 import { Translation } from './Translation';
 import { AccountLabeling, AddressLabeling, WalletLabeling } from './Labeling';
 
@@ -29,6 +29,7 @@ export {
     Backdrop,
     DeviceIcon,
     CheckItem,
+    DeviceInvalidModeLayout,
     ExternalLink,
     Preloader,
     FormattedNumber,

--- a/packages/suite/src/support/messages.ts
+++ b/packages/suite/src/support/messages.ts
@@ -2880,6 +2880,62 @@ const definedMessages = defineMessages({
         defaultMessage: 'Success',
         description: 'Just a general "success" if we do not know what else to use',
     },
+    TR_RESOLVE: {
+        id: 'TR_RESOLVE',
+        defaultMessage: 'resolve',
+    },
+    TR_DEVICE_NOT_INITIALIZED: {
+        id: 'TR_DEVICE_NOT_INITIALIZED',
+        defaultMessage: 'Device not initialized',
+        description:
+            'Device not initialized means that it has no cryptographic secret lives in it and it must be either recovered from seed or newly generated.',
+    },
+    TR_DEVICE_NOT_INITIALIZED_TEXT: {
+        id: 'TR_DEVICE_NOT_INITIALIZED_TEXT',
+        defaultMessage:
+            'You will need to go through initialization process to put your device into work',
+    },
+    TR_GO_TO_ONBOARDING: {
+        id: 'TR_GO_TO_ONBOARDING',
+        defaultMessage: 'Go to onboarding',
+    },
+    TR_NO_FIRMWARE: {
+        id: 'TR_NO_FIRMWARE',
+        defaultMessage: 'No firmware',
+    },
+    TR_NO_FIRMWARE_EXPLAINED: {
+        id: 'TR_NO_FIRMWARE_EXPLAINED',
+        defaultMessage: 'Device has no firmware installed.',
+    },
+    TR_SEEDLESS_MODE: {
+        id: 'TR_SEEDLESS_MODE',
+        defaultMessage: 'Seedless mode',
+        description:
+            'Seedless is a term. It means that device has cryptographic secret inside but has never given out recovery seed',
+    },
+    TR_SEEDLESS_MODE_EXPLAINED: {
+        id: 'TR_SEEDLESS_MODE_EXPLAINED',
+        defaultMessage:
+            'Seedless mode means that device has cryptographic secret inside but no corresponding recovery seed exists. Such devices are not allowed to be used with this wallet.',
+    },
+    TR_UNKNOWN_DEVICE: {
+        id: 'TR_UNKNOWN_DEVICE',
+        defaultMessage: 'Unknown device',
+    },
+    TR_UNREADABLE_EXPLAINED: {
+        id: 'TR_UNREADABLE_EXPLAINED',
+        defaultMessage:
+            'We cant see details about your device. It might be Trezor with old firmware or possibly any USB device. To make communication possible, you will need to install Trezor Bridge.',
+    },
+    TR_SEE_DETAILS: {
+        id: 'TR_SEE_DETAILS',
+        defaultMessage: 'See details',
+    },
+    TR_FIRMWARE_UPDATE_REQUIRED_EXPLAINED: {
+        id: 'TR_FIRMWARE_UPDATE_REQUIRED_EXPLAINED',
+        defaultMessage:
+            'Your device has firmware that is no longer supported. You will need to update it.',
+    },
 } as const);
 
 export default definedMessages;

--- a/packages/suite/src/support/messages.ts
+++ b/packages/suite/src/support/messages.ts
@@ -2936,6 +2936,15 @@ const definedMessages = defineMessages({
         defaultMessage:
             'Your device has firmware that is no longer supported. You will need to update it.',
     },
+    TR_DEVICE_IN_BOOTLOADER: {
+        id: 'TR_DEVICE_IN_BOOTLOADER',
+        defaultMessage: 'Device in bootloader',
+    },
+    TR_DEVICE_IN_BOOTLOADER_EXPLAINED: {
+        id: 'TR_DEVICE_IN_BOOTLOADER_EXPLAINED',
+        defaultMessage:
+            'In bootloader mode, device is ready to receive firmware updates but it also means that nothing else might be done with it. To get back into normal mode simply reconnect it.',
+    },
 } as const);
 
 export default definedMessages;

--- a/packages/suite/src/utils/suite/device.ts
+++ b/packages/suite/src/utils/suite/device.ts
@@ -82,7 +82,7 @@ export const isSelectedInstance = (selected?: TrezorDevice, device?: TrezorDevic
 export const isSelectedDevice = (selected?: TrezorDevice | Device, device?: TrezorDevice) => {
     if (!selected || !device) return false;
     if (!selected.features && !device.features) return selected.path === device.path;
-    if (selected.features && selected.mode === 'bootloader') return selected.path === device.path
+    if (selected.features && selected.mode === 'bootloader') return selected.path === device.path;
     return !!(
         selected.features &&
         selected.id &&

--- a/packages/suite/src/utils/suite/device.ts
+++ b/packages/suite/src/utils/suite/device.ts
@@ -82,6 +82,7 @@ export const isSelectedInstance = (selected?: TrezorDevice, device?: TrezorDevic
 export const isSelectedDevice = (selected?: TrezorDevice | Device, device?: TrezorDevice) => {
     if (!selected || !device) return false;
     if (!selected.features && !device.features) return selected.path === device.path;
+    if (selected.features && selected.mode === 'bootloader') return selected.path === device.path
     return !!(
         selected.features &&
         selected.id &&

--- a/packages/suite/src/utils/suite/device.ts
+++ b/packages/suite/src/utils/suite/device.ts
@@ -81,15 +81,8 @@ export const isSelectedInstance = (selected?: TrezorDevice, device?: TrezorDevic
 
 export const isSelectedDevice = (selected?: TrezorDevice | Device, device?: TrezorDevice) => {
     if (!selected || !device) return false;
-    if (!selected.features && !device.features) return selected.path === device.path;
-    if (selected.features && selected.mode === 'bootloader') return selected.path === device.path;
-    return !!(
-        selected.features &&
-        selected.id &&
-        device.features &&
-        device.id &&
-        selected.id === device.id
-    );
+    if (!selected.id || selected.mode === 'bootloader') return selected.path === device.path;
+    return selected.id === device.id;
 };
 
 export const getVersion = (device: TrezorDevice) => {

--- a/packages/suite/src/views/suite/device-acquire/index.tsx
+++ b/packages/suite/src/views/suite/device-acquire/index.tsx
@@ -1,46 +1,25 @@
-import { SUITE } from '@suite-actions/constants';
-import styled from 'styled-components';
-
-import { H2, P, Button } from '@trezor/components';
-import { Translation, Image } from '@suite-components';
 import React from 'react';
 
+import { SUITE } from '@suite-actions/constants';
+import { Button } from '@trezor/components';
+import { Translation, DeviceInvalidModeLayout } from '@suite-components';
+
 import { Props } from './Container';
-
-const Wrapper = styled.div`
-    display: flex;
-    padding: 100px 120px;
-    justify-content: center;
-    align-items: center;
-    flex-direction: column;
-`;
-
-const ImageWrapper = styled.div`
-    width: 360px;
-`;
-
-const StyledP = styled(P)`
-    max-width: 500px;
-`;
 
 const Acquire = ({ device, locks, acquireDevice }: Props) => {
     if (!device) return null;
     const locked = locks.includes(SUITE.LOCK_TYPE.DEVICE) || locks.includes(SUITE.LOCK_TYPE.UI);
     return (
-        <Wrapper>
-            <H2>
-                <Translation id="TR_ACQUIRE_DEVICE_TITLE" />
-            </H2>
-            <StyledP>
-                <Translation id="TR_ACQUIRE_DEVICE_DESCRIPTION" />
-            </StyledP>
-            <ImageWrapper>
-                <Image image="DEVICE_ANOTHER_SESSION" />
-            </ImageWrapper>
-            <Button isLoading={locked} onClick={() => acquireDevice()}>
-                <Translation id="TR_ACQUIRE_DEVICE" />
-            </Button>
-        </Wrapper>
+        <DeviceInvalidModeLayout
+            title={<Translation id="TR_ACQUIRE_DEVICE_TITLE" />}
+            text={<Translation id="TR_ACQUIRE_DEVICE_DESCRIPTION" />}
+            image="DEVICE_ANOTHER_SESSION"
+            resolveButton={
+                <Button isLoading={locked} onClick={() => acquireDevice()}>
+                    <Translation id="TR_ACQUIRE_DEVICE" />
+                </Button>
+            }
+        />
     );
 };
 

--- a/packages/suite/src/views/suite/device-bootloader/index.tsx
+++ b/packages/suite/src/views/suite/device-bootloader/index.tsx
@@ -1,21 +1,20 @@
 import React from 'react';
-import { connect } from 'react-redux';
-import { bindActionCreators } from 'redux';
-import * as routerActions from '@suite-actions/routerActions';
-import { Button, P } from '@trezor/components';
-import { Dispatch } from '@suite-types';
+import { P } from '@trezor/components';
+import { DeviceInvalidModeLayout } from '@suite-components';
 
-const mapDispatchToProps = (dispatch: Dispatch) => ({
-    goto: bindActionCreators(routerActions.goto, dispatch),
-});
-
-type Props = ReturnType<typeof mapDispatchToProps>;
-
-const Index = (props: Props) => (
-    <>
-        <P data-test="initialize-message">Device is in bootloader mode. Reconnect it.</P>
-        <Button onClick={() => props.goto('firmware-index')}>Or go to setup wizard</Button>
-    </>
+const Index = () => (
+    <DeviceInvalidModeLayout
+        title="Device is in bootloader mode"
+        text={
+            <P data-test="initialize-message">
+                In bootloader mode, device is ready to receive firmware updates but it also means
+                that nothing else might be done with it. To get back into normal mode simply
+                reconnect it.
+            </P>
+        }
+        // no resolve button here. I believe that we don't want to send user anywhere who might have accidentally connected
+        // device in bootloader mode
+    />
 );
 
-export default connect(null, mapDispatchToProps)(Index);
+export default Index;

--- a/packages/suite/src/views/suite/device-bootloader/index.tsx
+++ b/packages/suite/src/views/suite/device-bootloader/index.tsx
@@ -1,17 +1,11 @@
 import React from 'react';
-import { P } from '@trezor/components';
-import { DeviceInvalidModeLayout } from '@suite-components';
+import { DeviceInvalidModeLayout, Translation } from '@suite-components';
 
 const Index = () => (
     <DeviceInvalidModeLayout
-        title="Device is in bootloader mode"
-        text={
-            <P data-test="initialize-message">
-                In bootloader mode, device is ready to receive firmware updates but it also means
-                that nothing else might be done with it. To get back into normal mode simply
-                reconnect it.
-            </P>
-        }
+        title={<Translation id="TR_DEVICE_IN_BOOTLOADER" />}
+        text={<Translation id="TR_DEVICE_IN_BOOTLOADER_EXPLAINED" />}
+        allowSwitchDevice
         // no resolve button here. I believe that we don't want to send user anywhere who might have accidentally connected
         // device in bootloader mode
     />

--- a/packages/suite/src/views/suite/device-initialize/index.tsx
+++ b/packages/suite/src/views/suite/device-initialize/index.tsx
@@ -2,8 +2,9 @@ import React from 'react';
 import { connect } from 'react-redux';
 import { bindActionCreators } from 'redux';
 import * as routerActions from '@suite-actions/routerActions';
-import { Button, P } from '@trezor/components';
+import { Button } from '@trezor/components';
 import { Dispatch } from '@suite-types';
+import { DeviceInvalidModeLayout, Translation } from '@suite-components';
 
 const mapDispatchToProps = (dispatch: Dispatch) => ({
     goto: bindActionCreators(routerActions.goto, dispatch),
@@ -12,12 +13,18 @@ const mapDispatchToProps = (dispatch: Dispatch) => ({
 type Props = ReturnType<typeof mapDispatchToProps>;
 
 const Index = (props: Props) => (
-    <>
-        <P data-test="initialize-message">Device is not set up.</P>
-        <Button data-test="@button/go-to-onboarding" onClick={() => props.goto('onboarding-index')}>
-            Go to setup wizard
-        </Button>
-    </>
+    <DeviceInvalidModeLayout
+        title={<Translation id="TR_DEVICE_NOT_INITIALIZED" />}
+        text={<Translation id="TR_DEVICE_NOT_INITIALIZED_TEXT" />}
+        resolveButton={
+            <Button
+                data-test="@button/go-to-onboarding"
+                onClick={() => props.goto('onboarding-index')}
+            >
+                <Translation id="TR_GO_TO_ONBOARDING" />
+            </Button>
+        }
+    />
 );
 
 export default connect(null, mapDispatchToProps)(Index);

--- a/packages/suite/src/views/suite/device-no-firmware/index.tsx
+++ b/packages/suite/src/views/suite/device-no-firmware/index.tsx
@@ -2,8 +2,9 @@ import React from 'react';
 import { connect } from 'react-redux';
 import { bindActionCreators } from 'redux';
 import * as routerActions from '@suite-actions/routerActions';
-import { Button, P } from '@trezor/components';
+import { Button } from '@trezor/components';
 import { Dispatch } from '@suite-types';
+import { DeviceInvalidModeLayout, Translation } from '@suite-components';
 
 const mapDispatchToProps = (dispatch: Dispatch) => ({
     goto: bindActionCreators(routerActions.goto, dispatch),
@@ -12,10 +13,16 @@ const mapDispatchToProps = (dispatch: Dispatch) => ({
 type Props = ReturnType<typeof mapDispatchToProps>;
 
 const Index = (props: Props) => (
-    <>
-        <P data-test="no-firmware-message">Device has no firmware installed.</P>
-        <Button onClick={() => props.goto('onboarding-index')}>Go to setup wizard</Button>
-    </>
+    <DeviceInvalidModeLayout
+        title={<Translation id="TR_NO_FIRMWARE" />}
+        text={<Translation id="TR_NO_FIRMWARE_EXPLAINED" />}
+        resolveButton={
+            <Button onClick={() => props.goto('onboarding-index')}>
+                <Translation id="TR_GO_TO_ONBOARDING" />
+            </Button>
+        }
+        allowSwitchDevice
+    />
 );
 
 export default connect(null, mapDispatchToProps)(Index);

--- a/packages/suite/src/views/suite/device-seedless/index.tsx
+++ b/packages/suite/src/views/suite/device-seedless/index.tsx
@@ -1,10 +1,10 @@
 import React from 'react';
-import { P } from '@trezor/components';
+import { DeviceInvalidModeLayout, Translation } from '@suite-components';
 
 export default () => (
-    <>
-        <P data-test="seedless-message">
-            Your device is in seedless mode and is not allowed to be used with this wallet.
-        </P>
-    </>
+    <DeviceInvalidModeLayout
+        title={<Translation id="TR_SEEDLESS_MODE" />}
+        text={<Translation id="TR_SEEDLESS_MODE_EXPLAINED" />}
+        allowSwitchDevice
+    />
 );

--- a/packages/suite/src/views/suite/device-unknown/index.tsx
+++ b/packages/suite/src/views/suite/device-unknown/index.tsx
@@ -1,8 +1,6 @@
 import React from 'react';
-import { P } from '@trezor/components';
+import { DeviceInvalidModeLayout, Translation } from '@suite-components';
 
 export default () => (
-    <>
-        <P>Unknown device.</P>
-    </>
+    <DeviceInvalidModeLayout title={<Translation id="TR_UNKNOWN_DEVICE" />} allowSwitchDevice />
 );

--- a/packages/suite/src/views/suite/device-unreadable/index.tsx
+++ b/packages/suite/src/views/suite/device-unreadable/index.tsx
@@ -2,8 +2,9 @@ import React from 'react';
 import { connect } from 'react-redux';
 import { bindActionCreators } from 'redux';
 import * as routerActions from '@suite-actions/routerActions';
-import { Button, P } from '@trezor/components';
+import { Button } from '@trezor/components';
 import { Dispatch } from '@suite-types';
+import { DeviceInvalidModeLayout, Translation } from '@suite-components';
 
 const mapDispatchToProps = (dispatch: Dispatch) => ({
     goto: bindActionCreators(routerActions.goto, dispatch),
@@ -12,13 +13,16 @@ const mapDispatchToProps = (dispatch: Dispatch) => ({
 type Props = ReturnType<typeof mapDispatchToProps>;
 
 const Index = (props: Props) => (
-    <>
-        <P data-test="unreadable-device-message">
-            We cant see details about your device. It might be Trezor with old firmware or possibly
-            any USB device. To make communication possible, you will need to install Trezor Bridge.
-        </P>
-        <Button onClick={() => props.goto('suite-bridge')}>See details</Button>
-    </>
+    <DeviceInvalidModeLayout
+        title={<Translation id="TR_UNREADABLE" />}
+        text={<Translation id="TR_UNREADABLE_EXPLAINED" />}
+        resolveButton={
+            <Button onClick={() => props.goto('suite-bridge')}>
+                <Translation id="TR_SEE_DETAILS" />
+            </Button>
+        }
+        allowSwitchDevice
+    />
 );
 
 export default connect(null, mapDispatchToProps)(Index);

--- a/packages/suite/src/views/suite/device-update-required/index.tsx
+++ b/packages/suite/src/views/suite/device-update-required/index.tsx
@@ -2,8 +2,9 @@ import React from 'react';
 import { connect } from 'react-redux';
 import { bindActionCreators } from 'redux';
 import * as routerActions from '@suite-actions/routerActions';
-import { Button, P } from '@trezor/components';
+import { Button } from '@trezor/components';
 import { Dispatch } from '@suite-types';
+import { DeviceInvalidModeLayout, Translation } from '@suite-components';
 
 const mapDispatchToProps = (dispatch: Dispatch) => ({
     goto: bindActionCreators(routerActions.goto, dispatch),
@@ -12,12 +13,16 @@ const mapDispatchToProps = (dispatch: Dispatch) => ({
 type Props = ReturnType<typeof mapDispatchToProps>;
 
 const Index = (props: Props) => (
-    <>
-        <P data-test="firmware-required-message">
-            Your device has firmware that is no longer supported. You will need to update it.
-        </P>
-        <Button onClick={() => props.goto('firmware-index')}>See details</Button>
-    </>
+    <DeviceInvalidModeLayout
+        title={<Translation id="FW_CAPABILITY_UPDATE_REQUIRED" />}
+        text={<Translation id="TR_FIRMWARE_UPDATE_REQUIRED_EXPLAINED" />}
+        allowSwitchDevice
+        resolveButton={
+            <Button onClick={() => props.goto('firmware-index')}>
+                <Translation id="TR_SEE_DETAILS" />
+            </Button>
+        }
+    />
 );
 
 export default connect(null, mapDispatchToProps)(Index);


### PR DESCRIPTION
So, what I am trying to do here: 
- [ ]  invalid device state modals (unreadable, seedless) should share styles and layout, so I have introduced new component `DeviceInvalidModeLayout`
- [ ] add translations
- [ ] each modal may or may not provide up to two buttons to resolve A] resolve button B] switch device button

___ 
close #1494 
close #1511