### PR TITLE
Set max select height in Download Bridge page to prevent expanding modal

### DIFF
--- a/packages/suite/src/views/suite/bridge/index.tsx
+++ b/packages/suite/src/views/suite/bridge/index.tsx
@@ -175,6 +175,7 @@ const InstallBridge = (props: Props) => {
                             value={target}
                             onChange={setSelectedTarget}
                             options={installers}
+                            maxMenuHeight={160}
                         />
 
                         <Link variant="nostyle" href={`${data.uri}${target.value}`}>


### PR DESCRIPTION
addressing https://github.com/trezor/trezor-suite/issues/1117#issuecomment-612761645