### PR TITLE
Fix/account menu selected

### DIFF
--- a/packages/suite/src/actions/wallet/accountActions.ts
+++ b/packages/suite/src/actions/wallet/accountActions.ts
@@ -6,7 +6,7 @@ import * as transactionActions from '@wallet-actions/transactionActions';
 import * as accountUtils from '@wallet-utils/accountUtils';
 import { analyzeTransactions } from '@wallet-utils/transactionUtils';
 import { NETWORKS } from '@wallet-config';
-import { Account, Network } from '@wallet-types';
+import { Account } from '@wallet-types';
 import { Dispatch, GetState } from '@suite-types';
 import { SETTINGS } from '@suite-config';
 
@@ -15,39 +15,6 @@ export type AccountActions =
     | { type: typeof ACCOUNT.REMOVE; payload: Account[] }
     | { type: typeof ACCOUNT.CHANGE_VISIBILITY; payload: Account }
     | { type: typeof ACCOUNT.UPDATE; payload: Account };
-
-const getAccountSpecific = (accountInfo: AccountInfo, networkType: Network['networkType']) => {
-    const { misc } = accountInfo;
-    if (networkType === 'ripple') {
-        return {
-            networkType,
-            misc: {
-                sequence: misc && misc.sequence ? misc.sequence : 0,
-                reserve: misc && misc.reserve ? misc.reserve : '0',
-            },
-            marker: accountInfo.marker,
-            page: undefined,
-        };
-    }
-
-    if (networkType === 'ethereum') {
-        return {
-            networkType,
-            misc: {
-                nonce: misc && misc.nonce ? misc.nonce : '0',
-            },
-            marker: undefined,
-            page: accountInfo.page,
-        };
-    }
-
-    return {
-        networkType,
-        misc: undefined,
-        marker: undefined,
-        page: accountInfo.page,
-    };
-};
 
 export const create = (
     deviceState: string,
@@ -80,7 +47,7 @@ export const create = (
         addresses: accountInfo.addresses,
         utxo: accountInfo.utxo,
         history: accountInfo.history,
-        ...getAccountSpecific(accountInfo, discoveryItem.networkType),
+        ...accountUtils.getAccountSpecific(accountInfo, discoveryItem.networkType),
     },
 });
 
@@ -101,7 +68,7 @@ export const update = (account: Account, accountInfo: AccountInfo): AccountActio
             symbol: t.symbol ? t.symbol.toLowerCase() : t.symbol,
             balance: t.balance ? accountUtils.formatAmount(t.balance, t.decimals) : t.balance,
         })),
-        ...getAccountSpecific(accountInfo, account.networkType),
+        ...accountUtils.getAccountSpecific(accountInfo, account.networkType),
     },
 });
 

--- a/packages/suite/src/actions/wallet/discoveryActions.ts
+++ b/packages/suite/src/actions/wallet/discoveryActions.ts
@@ -396,7 +396,7 @@ export const start = () => async (dispatch: Dispatch, getState: GetState): Promi
                 }
                 const failed: Discovery['failed'] = coins.map(c => ({
                     index: 0,
-                    symbol: c.coin,
+                    symbol: bundle[c.index].coin,
                     accountType: bundle[c.index].accountType,
                     error: c.exception,
                     fwException: c.exception,

--- a/packages/suite/src/actions/wallet/selectedAccountActions.ts
+++ b/packages/suite/src/actions/wallet/selectedAccountActions.ts
@@ -109,10 +109,9 @@ const getAccountState = () => (dispatch: Dispatch, getState: GetState): State =>
         state.router.app === 'wallet' && state.router.params
             ? state.router.params
             : {
-                  paramsType: 'wallet' as const,
                   accountIndex: 0,
                   accountType: 'normal' as const,
-                  symbol: discovery.networks[0] || 'btc',
+                  symbol: discovery.networks[0],
               };
 
     const network = NETWORKS.find(c => c.symbol === params.symbol)!;
@@ -124,6 +123,7 @@ const getAccountState = () => (dispatch: Dispatch, getState: GetState): State =>
             loader: 'account-not-enabled',
             network,
             discovery,
+            params,
             mode,
         };
     }
@@ -136,6 +136,7 @@ const getAccountState = () => (dispatch: Dispatch, getState: GetState): State =>
             loader: 'account-not-loaded',
             network,
             discovery,
+            params,
             mode,
         };
     }
@@ -151,6 +152,7 @@ const getAccountState = () => (dispatch: Dispatch, getState: GetState): State =>
             account,
             network,
             discovery,
+            params,
             mode: undefined,
         } as const;
         const loadedMode = dispatch(getAccountStateWithMode(loadedState));
@@ -174,6 +176,7 @@ const getAccountState = () => (dispatch: Dispatch, getState: GetState): State =>
         loader: 'account-not-exists',
         network,
         discovery,
+        params,
         mode,
     };
 };

--- a/packages/suite/src/reducers/wallet/discoveryReducer.ts
+++ b/packages/suite/src/reducers/wallet/discoveryReducer.ts
@@ -16,9 +16,9 @@ export interface Discovery {
     status: ObjectValues<typeof DISCOVERY.STATUS>;
     // coins which failed to load
     failed: {
-        symbol: string;
+        symbol: Network['symbol'];
         index: number;
-        accountType: string;
+        accountType: NonNullable<Network['accountType']>;
         error: string;
         fwException?: string;
     }[];

--- a/packages/suite/src/reducers/wallet/selectedAccountReducer.ts
+++ b/packages/suite/src/reducers/wallet/selectedAccountReducer.ts
@@ -1,6 +1,6 @@
 import { ACCOUNT } from '@wallet-actions/constants';
 import { Action } from '@suite-types';
-import { Network, Account, Discovery } from '@wallet-types';
+import { Network, Account, Discovery, WalletParams } from '@wallet-types';
 
 // Context notifications view
 // Account is in "watch only" mode
@@ -19,7 +19,11 @@ export interface AccountLoading {
         | 'waiting-for-device' // No selectedDevice
         | 'auth' // Waiting for device.state
         | 'account-loading'; // Waiting for account
+    mode?: undefined;
     account?: undefined;
+    network?: Network;
+    discovery?: Discovery;
+    params?: undefined;
 }
 
 // 100% view
@@ -32,41 +36,46 @@ export type AccountException =
               | 'discovery-error' // TODO: Discovery failed on something different than expected "bundle exception"
               | 'discovery-empty'; // No network enabled in settings
           mode?: AccountWatchOnlyMode[];
+          account?: undefined;
           network?: Network;
           discovery?: Discovery;
-          account?: undefined;
+          params?: undefined;
       }
     | {
           status: 'exception';
           loader:
-              | 'discovery-error' // TODO: Discovery failed on something different than expected "bundle exception"
               | 'account-not-loaded' // Account discovery failed
               | 'account-not-enabled' // Requested account network is not enabled in settings
               | 'account-not-exists'; // Requested account network is not listed in NETWORKS
           mode?: AccountWatchOnlyMode[];
+          account?: undefined;
           network: Network;
           discovery: Discovery;
-          account?: undefined;
+          params: WalletParams;
       };
 
 export type State =
     | {
           status: 'loaded';
+          loader?: undefined;
+          mode: AccountWatchOnlyMode[] | undefined;
           account: Account;
           network: Network;
           discovery: Discovery;
-          blockchain?: any; // TODO:
+          params: WalletParams;
+          // blockchain?: any; // TODO:
           // transactions?: any; // TODO:
-          mode: AccountWatchOnlyMode[] | undefined;
-          loader?: undefined;
       }
     | AccountLoading
     | AccountException
     | {
           status: 'none';
-          account?: undefined;
           loader?: undefined;
           mode?: undefined;
+          account?: undefined;
+          network?: undefined;
+          discovery?: undefined;
+          params?: undefined;
       };
 
 export const initialState: State = {


### PR DESCRIPTION
- WalletParams object (from router) available in `selectedAccount` and used in wallet Account Menu (fix for not selected first account when router has no # params)
- Network type group stays opened if contains account with balance (segwit/legacy accounts are visible)