### PR TITLE
visual nitpicks

### DIFF
--- a/packages/suite/src/components/suite/Settings/components/TextColumn.tsx
+++ b/packages/suite/src/components/suite/Settings/components/TextColumn.tsx
@@ -19,7 +19,7 @@ const Wrapper = styled.div`
 
 const Description = styled.div`
     color: ${colors.BLACK50};
-    margin: 12px 0;
+    margin-bottom: 12px;
     font-size: ${variables.FONT_SIZE.TINY};
 
     &:last-child {
@@ -29,12 +29,13 @@ const Description = styled.div`
 
 const Title = styled.div`
     font-weight: ${variables.FONT_WEIGHT.REGULAR};
+    margin-bottom: 12px;
 `;
 
 const TextColumn = ({ title, description, learnMore }: TextColumnProps) => {
     return (
         <Wrapper>
-            <Title>{title}</Title>
+            {title && <Title>{title}</Title>}
             {description && <Description>{description}</Description>}
             {learnMore && (
                 <ExternalLink href={learnMore} size="tiny">

--- a/packages/suite/src/components/suite/Settings/components/TextColumn.tsx
+++ b/packages/suite/src/components/suite/Settings/components/TextColumn.tsx
@@ -4,7 +4,7 @@ import { colors, variables } from '@trezor/components';
 import { Translation, ExternalLink } from '@suite-components';
 
 interface TextColumnProps {
-    title: React.ReactNode;
+    title?: React.ReactNode;
     description?: React.ReactNode;
     learnMore?: string;
 }

--- a/packages/suite/src/components/suite/modals/Passphrase/components/PassphraseTypeCard/index.tsx
+++ b/packages/suite/src/components/suite/modals/Passphrase/components/PassphraseTypeCard/index.tsx
@@ -55,6 +55,7 @@ const Content = styled.div`
 
 const InputWrapper = styled(Content)`
     width: 100%;
+    margin-top: 32px;
 `;
 
 const PassphraseInput = styled(Input)`

--- a/packages/suite/src/views/settings/device/index.tsx
+++ b/packages/suite/src/views/settings/device/index.tsx
@@ -18,7 +18,7 @@ import {
 import { getFwVersion, isBitcoinOnly } from '@suite-utils/device';
 import * as homescreen from '@suite-utils/homescreen';
 import { useDeviceActionLocks, useAnalytics } from '@suite-hooks';
-import { variables, Link, P, Switch } from '@trezor/components';
+import { variables, P, Switch, Link } from '@trezor/components';
 import React, { createRef, useEffect, useState } from 'react';
 import styled from 'styled-components';
 
@@ -32,11 +32,6 @@ const RotationButton = styled(ActionButton)`
     @media screen and (min-width: ${variables.SCREEN_SIZE.MD}) {
         flex-basis: auto;
     }
-`;
-
-const BackupFailedLink = styled(Link)`
-    min-width: 120px;
-    margin-left: 40px;
 `;
 
 const HiddenInput = styled.input`
@@ -130,15 +125,20 @@ const Settings = ({ device, applySettings, changePin, openModal, goto }: Props) 
                         </ActionButton>
                     </ActionColumn>
                 </SectionItem>
-                {features.unfinished_backup && (
+                {!features.unfinished_backup && (
                     <SectionItem data-test="@settings/device/failed-backup-row">
-                        <P size="tiny">
-                            <Translation id="TR_BACKUP_FAILED" />
-                        </P>
+                        <TextColumn description={<Translation id="TR_BACKUP_FAILED" />} />
                         <ActionColumn>
-                            <BackupFailedLink href={FAILED_BACKUP_URL}>
-                                <Translation id="TR_WHAT_TO_DO_NOW" />
-                            </BackupFailedLink>
+                            <Link variant="nostyle" href={FAILED_BACKUP_URL}>
+                                <ActionButton
+                                    onClick={() => {}}
+                                    variant="secondary"
+                                    icon="EXTERNAL_LINK"
+                                    alignIcon="right"
+                                >
+                                    <Translation id="TR_WHAT_TO_DO_NOW" />
+                                </ActionButton>
+                            </Link>
                         </ActionColumn>
                     </SectionItem>
                 )}

--- a/packages/suite/src/views/settings/device/index.tsx
+++ b/packages/suite/src/views/settings/device/index.tsx
@@ -125,7 +125,7 @@ const Settings = ({ device, applySettings, changePin, openModal, goto }: Props) 
                         </ActionButton>
                     </ActionColumn>
                 </SectionItem>
-                {!features.unfinished_backup && (
+                {features.unfinished_backup && (
                     <SectionItem data-test="@settings/device/failed-backup-row">
                         <TextColumn description={<Translation id="TR_BACKUP_FAILED" />} />
                         <ActionColumn>

--- a/packages/suite/src/views/settings/device/index.tsx
+++ b/packages/suite/src/views/settings/device/index.tsx
@@ -18,7 +18,7 @@ import {
 import { getFwVersion, isBitcoinOnly } from '@suite-utils/device';
 import * as homescreen from '@suite-utils/homescreen';
 import { useDeviceActionLocks, useAnalytics } from '@suite-hooks';
-import { variables, P, Switch, Link } from '@trezor/components';
+import { variables, Switch, Link } from '@trezor/components';
 import React, { createRef, useEffect, useState } from 'react';
 import styled from 'styled-components';
 


### PR DESCRIPTION

- add margin top to the passphrase input
<img width="843" alt="Screenshot 2020-05-05 at 08 22 02" src="https://user-images.githubusercontent.com/6961901/81039512-8af2b300-8ea9-11ea-88ab-ceaf66555a81.png">

- close https://github.com/trezor/trezor-suite/issues/1629 ("what to do now" link in device settings is now secondary btn)
