### PR TITLE
wipe device with webusb [need help]

### DIFF
--- a/packages/suite/src/actions/suite/modalActions.ts
+++ b/packages/suite/src/actions/suite/modalActions.ts
@@ -61,6 +61,9 @@ export type UserContextPayload =
       }
     | {
           type: 'wipe-device';
+      }
+    | {
+          type: 'disconnect-device';
       };
 
 export type ModalActions =

--- a/packages/suite/src/components/suite/modals/DisconnectDevice/index.tsx
+++ b/packages/suite/src/components/suite/modals/DisconnectDevice/index.tsx
@@ -1,0 +1,27 @@
+import React from 'react';
+import styled from 'styled-components';
+import { Modal } from '@trezor/components';
+import { Image } from '@suite-components';
+
+const StyledImage = styled(Image)`
+    flex: 1;
+`;
+
+// todo: add translations
+
+const DisconnectDevice = () => {
+    return (
+        <Modal
+            cancelable={false}
+            size="tiny"
+            // heading={<Translation id="TR_PIN_MISMATCH_HEADING" />}
+            // description={<Translation id="TR_PIN_MISMATCH_TEXT" />}
+            heading="Disconnect your device"
+            description="Your device was wiped. Disconnect it now."
+        >
+            <StyledImage image="UNI_SUCCESS" />
+        </Modal>
+    );
+};
+
+export default DisconnectDevice;

--- a/packages/suite/src/components/suite/modals/WipeDevice/index.tsx
+++ b/packages/suite/src/components/suite/modals/WipeDevice/index.tsx
@@ -5,8 +5,8 @@ import { bindActionCreators } from 'redux';
 import { Modal, Button } from '@trezor/components';
 import { Translation, CheckItem, Image } from '@suite-components';
 import * as deviceSettingsActions from '@settings-actions/deviceSettingsActions';
-import { Dispatch, AppState } from '@suite-types';
-import { SUITE } from '@suite-actions/constants';
+import { Dispatch } from '@suite-types';
+import { useDeviceActionLocks } from '@suite-hooks';
 
 const Row = styled.div`
     display: flex;
@@ -33,19 +33,15 @@ const mapDispatchToProps = (dispatch: Dispatch) => ({
     wipeDevice: bindActionCreators(deviceSettingsActions.wipeDevice, dispatch),
 });
 
-const mapStateToProps = (state: AppState) => ({
-    locks: state.suite.locks,
-});
+type Props = ReturnType<typeof mapDispatchToProps> & {
+    onCancel: () => void;
+};
 
-type Props = ReturnType<typeof mapDispatchToProps> &
-    ReturnType<typeof mapStateToProps> & {
-        onCancel: () => void;
-    };
-
-const WipeDevice = ({ locks, wipeDevice, onCancel }: Props) => {
+const WipeDevice = ({ wipeDevice, onCancel }: Props) => {
     const [checkbox1, setCheckbox1] = useState(false);
     const [checkbox2, setCheckbox2] = useState(false);
-    const uiLocked = locks.includes(SUITE.LOCK_TYPE.DEVICE) || locks.includes(SUITE.LOCK_TYPE.UI);
+
+    const [actionEnabled] = useDeviceActionLocks();
 
     return (
         <Modal
@@ -60,7 +56,7 @@ const WipeDevice = ({ locks, wipeDevice, onCancel }: Props) => {
                         <Button
                             variant="danger"
                             onClick={() => wipeDevice()}
-                            isDisabled={uiLocked || !checkbox1 || !checkbox2}
+                            isDisabled={!actionEnabled || !checkbox1 || !checkbox2}
                             data-test="@wipe/wipe-button"
                         >
                             <Translation id="TR_DEVICE_SETTINGS_BUTTON_WIPE_DEVICE" />
@@ -92,4 +88,4 @@ const WipeDevice = ({ locks, wipeDevice, onCancel }: Props) => {
     );
 };
 
-export default connect(mapStateToProps, mapDispatchToProps)(WipeDevice);
+export default connect(null, mapDispatchToProps)(WipeDevice);

--- a/packages/suite/src/components/suite/modals/index.tsx
+++ b/packages/suite/src/components/suite/modals/index.tsx
@@ -30,6 +30,7 @@ import BackgroundGallery from './BackgroundGallery';
 import TransactionDetail from './TransactionDetail';
 import Log from './Log';
 import WipeDevice from './WipeDevice';
+import DisconnectDevice from './DisconnectDevice';
 
 const mapStateToProps = (state: AppState) => ({
     modal: state.modal,
@@ -162,6 +163,8 @@ const getUserContextModal = (props: Props) => {
             return <ReviewTransaction />;
         case 'pin-mismatch':
             return <PinMismatch onCancel={modalActions.onCancel} />;
+        case 'disconnect-device':
+            return <DisconnectDevice />;
         case 'log':
             return <Log onCancel={modalActions.onCancel} />;
         default:


### PR DESCRIPTION
this does fix https://github.com/trezor/trezor-suite/issues/1064 and closes #1504
but I also found few more problems. Please check it @matejzak 

### with nothing remembered

before wipe
![image](https://user-images.githubusercontent.com/30367552/81499761-2468fd00-92ce-11ea-8511-a7c30728ce2d.png)

after wipe. not possible to cancel. after disconnect or reload device is not paired. works fine.
![image](https://user-images.githubusercontent.com/30367552/81499858-b7a23280-92ce-11ea-9eff-346a75b945b6.png)

### with remembered wallets

state of affairs right before wipe

![image](https://user-images.githubusercontent.com/30367552/81499653-5af24800-92cd-11ea-9241-a00e97a2fa43.png)

after wipe

![image](https://user-images.githubusercontent.com/30367552/81499858-b7a23280-92ce-11ea-9eff-346a75b945b6.png)

after disconnecting device switch-device modal still looks like this. that is expected 

![image](https://user-images.githubusercontent.com/30367552/81499653-5af24800-92cd-11ea-9241-a00e97a2fa43.png)

what happens when I connect the device again? lets see. right after it is connected nothing happens. it is not paired yet.

In switch-device modal I may click on "Find Trezor" button 

![image](https://user-images.githubusercontent.com/30367552/81500028-b291b300-92cf-11ea-94ed-023ad7863065.png)

After I do so and pair device: 

![image](https://user-images.githubusercontent.com/30367552/81500052-cf2deb00-92cf-11ea-87f6-7a2dff38a250.png)

- [ ] question: here I would expect another device to appear alongside with the device previously saved and already wiped. 
- [ ] question: also, shouldnt wipe wipe everything? Or is it expected usecase that user wipes device but wants to keep it saved in read only mode? 

then I click on the solve issue button and get this:

![image](https://user-images.githubusercontent.com/30367552/81499675-78bfad00-92cd-11ea-9001-f392b21a61b4.png)

- [ ] question: should swith device button here be either shown only if there are multiple physical devices or kept as it is and reworded to "switch wallet"? 

So, I pass through onboarding and switch device modal looks like this again

![image](https://user-images.githubusercontent.com/30367552/81499653-5af24800-92cd-11ea-9241-a00e97a2fa43.png)

but of course saved addresses and maybe transactions are no longer valid. this does not happen only with webusb but also with bridge transport