### PR TITLE
Fix translate crash by wrapping all intl msgs in span

### DIFF
--- a/packages/suite-web/pages/_document.tsx
+++ b/packages/suite-web/pages/_document.tsx
@@ -37,7 +37,10 @@ export default class MyDocument extends Document {
 
     render() {
         return (
-            <html lang="en">
+            // prevents chrome from auto offering page translation https://github.com/trezor/trezor-suite/issues/1806
+            // remove 'translate' attr after release to test if fix in Translation component was enough to prevent the issue
+            // @ts-ignore TODO: should be fixed in newer React
+            <html lang="en" translate="no">
                 <Head>
                     <meta charSet="utf-8" />
                     <script

--- a/packages/suite/src/components/suite/Translation/index.tsx
+++ b/packages/suite/src/components/suite/Translation/index.tsx
@@ -4,7 +4,8 @@ import { ExtendedMessageDescriptor } from '@suite-types';
 import HelperTooltip from './components/HelperTooltip';
 import messages from '@suite/support/messages';
 
-type MsgType = ExtendedMessageDescriptor;
+type FormattedMessageProps = { tagName?: React.ElementType<any> };
+type MsgType = FormattedMessageProps & ExtendedMessageDescriptor;
 
 export const isMsgType = (props: MsgType | React.ReactNode): props is MsgType => {
     return typeof props === 'object' && props !== null && (props as MsgType).id !== undefined;
@@ -19,7 +20,11 @@ const Translation = (props: MsgType) => {
         // Iterates through all values. The entry may also contain a MessageDescriptor.
         // If so, Renders MessageDescriptor by passing it to `Translation` component
         const maybeMsg = props.values![key];
-        values[key] = isMsgType(maybeMsg) ? <Translation {...maybeMsg} /> : maybeMsg;
+        values[key] = isMsgType(maybeMsg) ? (
+            <Translation {...maybeMsg} tagName={undefined} />
+        ) : (
+            maybeMsg
+        );
     });
 
     // pass undefined to a 'values' prop in case of an empty values object

--- a/packages/suite/src/components/suite/Translation/index.tsx
+++ b/packages/suite/src/components/suite/Translation/index.tsx
@@ -27,6 +27,7 @@ const Translation = (props: MsgType) => {
         <HelperTooltip messageId={props.id}>
             <FormattedMessage
                 id={props.id}
+                tagName="span"
                 {...messages[props.id]}
                 {...props}
                 values={Object.keys(values).length === 0 ? undefined : values}

--- a/packages/suite/src/components/suite/__tests__/__snapshots__/Translation.test.tsx.snap
+++ b/packages/suite/src/components/suite/__tests__/__snapshots__/Translation.test.tsx.snap
@@ -19,9 +19,7 @@ exports[`Translation component with message that holds another in values (passed
 exports[`Translation component with message that holds another message object in values (passed via props) 1`] = `
 <span>
   Hello 
-  <span>
-    Name: John
-  </span>
+  Name: John
   , 100
 </span>
 `;

--- a/packages/suite/src/components/suite/__tests__/__snapshots__/Translation.test.tsx.snap
+++ b/packages/suite/src/components/suite/__tests__/__snapshots__/Translation.test.tsx.snap
@@ -1,21 +1,33 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`Translation component with id, defaultMessage props 1`] = `"Cancel"`;
+exports[`Translation component with id, defaultMessage props 1`] = `
+<span>
+  Cancel
+</span>
+`;
 
 exports[`Translation component with message that holds another in values (passed via props) 1`] = `
-Array [
-  "Hello ",
-  "Name: John",
-  ", 100",
-]
+<span>
+  Hello 
+  <span>
+    Name: John
+  </span>
+  , 100
+</span>
 `;
 
 exports[`Translation component with message that holds another message object in values (passed via props) 1`] = `
-Array [
-  "Hello ",
-  "Name: John",
-  ", 100",
-]
+<span>
+  Hello 
+  <span>
+    Name: John
+  </span>
+  , 100
+</span>
 `;
 
-exports[`Translation component with message that holds string in value (passed via props) 1`] = `"Name: John"`;
+exports[`Translation component with message that holds string in value (passed via props) 1`] = `
+<span>
+  Name: John
+</span>
+`;


### PR DESCRIPTION
close https://github.com/trezor/trezor-suite/issues/1806
there could still be problems outside of Translation component, but I haven't find any doing a quick search 🤞 

edit: it seems chrome ignores translate attr, but idk... it should't crash anymore thanks to the workaround in `Translation` cmpnent