### PR TITLE
Fix/discovery loops

### DIFF
--- a/packages/suite/src/actions/wallet/discoveryActions.ts
+++ b/packages/suite/src/actions/wallet/discoveryActions.ts
@@ -424,9 +424,28 @@ export const start = () => async (dispatch: Dispatch, getState: GetState): Promi
             }
         }
 
+        if (result.payload.error && device.connected) {
+            // call getFeatures to release device session
+            await TrezorConnect.getFeatures({
+                device,
+                keepSession: false,
+                useEmptyPassphrase: device.useEmptyPassphrase,
+            });
+        }
+
         const error =
             result.payload.error !== 'discovery_interrupted' ? result.payload.error : undefined;
-        dispatch(update({ deviceState, status: DISCOVERY.STATUS.STOPPED, error }, DISCOVERY.STOP));
+        dispatch(
+            update(
+                {
+                    deviceState,
+                    status: DISCOVERY.STATUS.STOPPED,
+                    error,
+                    errorCode: result.payload.code,
+                },
+                DISCOVERY.STOP,
+            ),
+        );
 
         if (error) {
             dispatch(addToast({ type: 'discovery-error', error }));

--- a/packages/suite/src/actions/wallet/selectedAccountActions.ts
+++ b/packages/suite/src/actions/wallet/selectedAccountActions.ts
@@ -37,7 +37,7 @@ const getAccountStateWithMode = (selectedAccount?: State) => (
     if (selectedAccount && selectedAccount.status === 'loaded') {
         const { account, discovery, network } = selectedAccount;
         // Account does exists and it's visible but shouldn't be active
-        if (account && discovery && discovery.status !== DISCOVERY.STATUS.COMPLETED) {
+        if (account && discovery && discovery.status < DISCOVERY.STATUS.STOPPING) {
             mode.push('account-loading-others');
         }
 
@@ -164,6 +164,17 @@ const getAccountState = () => (dispatch: Dispatch, getState: GetState): State =>
 
     // account doesn't exist (yet?) checking why...
     // discovery is still running
+    if (discovery.error) {
+        return {
+            status: 'exception',
+            loader: 'discovery-error',
+            network,
+            discovery,
+            params,
+            mode,
+        };
+    }
+
     if (discovery.status !== DISCOVERY.STATUS.COMPLETED) {
         return {
             status: 'loading',

--- a/packages/suite/src/components/dashboard/PortfolioCard/components/Exception/index.tsx
+++ b/packages/suite/src/components/dashboard/PortfolioCard/components/Exception/index.tsx
@@ -5,10 +5,12 @@ import { Image, Translation } from '@suite-components';
 import { useDeviceActionLocks, useDevice } from '@suite-hooks';
 import { useDispatch } from 'react-redux';
 import * as discoveryActions from '@wallet-actions/discoveryActions';
+import * as deviceSettingsActions from '@settings-actions/deviceSettingsActions';
 import * as suiteActions from '@suite-actions/suiteActions';
 import * as modalActions from '@suite-actions/modalActions';
 import * as routerActions from '@suite-actions/routerActions';
 import * as accountUtils from '@wallet-utils/accountUtils';
+import { Dispatch } from '@suite-types';
 import { Discovery, DiscoveryStatus } from '@wallet-types';
 
 const Wrapper = styled.div`
@@ -112,7 +114,7 @@ const discoveryFailedMessage = (discovery?: Discovery) => {
 };
 
 export default ({ exception, discovery }: Props) => {
-    const dispatch = useDispatch();
+    const dispatch = useDispatch<Dispatch>();
     const { device } = useDevice();
     switch (exception.type) {
         case 'auth-failed':
@@ -169,6 +171,31 @@ export default ({ exception, discovery }: Props) => {
                         />
                     }
                     cta={{ action: () => dispatch(discoveryActions.restart()) }}
+                />
+            );
+        case 'device-unavailable':
+            return (
+                <Container
+                    title="TR_DASHBOARD_DISCOVERY_ERROR"
+                    description={
+                        <Translation
+                            id="TR_ACCOUNT_PASSPHRASE_DISABLED"
+                            values={{ details: discoveryFailedMessage(discovery) }}
+                        />
+                    }
+                    cta={{
+                        action: async () => {
+                            // enable passphrase
+                            const result = await dispatch(
+                                // eslint-disable-next-line @typescript-eslint/camelcase
+                                deviceSettingsActions.applySettings({ use_passphrase: true }),
+                            );
+                            if (!result || !result.success) return;
+                            // restart discovery
+                            dispatch(discoveryActions.restart());
+                        },
+                        label: 'TR_ACCOUNT_ENABLE_PASSPHRASE',
+                    }}
                 />
             );
         default:

--- a/packages/suite/src/components/wallet/AccountException/DiscoveryFailed.tsx
+++ b/packages/suite/src/components/wallet/AccountException/DiscoveryFailed.tsx
@@ -1,18 +1,30 @@
 import React from 'react';
+import { Button } from '@trezor/components';
 import { Image, Translation } from '@suite-components';
-
+import { useDiscovery, useActions } from '@suite-hooks';
 import Wrapper from './components/Wrapper';
+import * as discoveryActions from '@wallet-actions/discoveryActions';
 
 /**
  * Handler for discovery "hard" error (other than bundle-error)
  * see: @wallet-actions/selectedAccountActions
  */
 const DiscoveryFailed = () => {
+    const { discovery } = useDiscovery();
+    const { restart } = useActions({
+        restart: discoveryActions.restart,
+    });
+
     return (
         <Wrapper
             title={<Translation id="TR_ACCOUNT_EXCEPTION_DISCOVERY_ERROR" />}
+            description={discovery && discovery.error ? discovery.error : undefined}
             image={<Image image="UNI_ERROR" />}
-        />
+        >
+            <Button variant="primary" icon="PLUS" onClick={restart}>
+                <Translation id="TR_RETRY" />
+            </Button>
+        </Wrapper>
     );
 };
 

--- a/packages/suite/src/hooks/suite/useDiscovery.ts
+++ b/packages/suite/src/hooks/suite/useDiscovery.ts
@@ -58,6 +58,21 @@ export const useDiscovery = () => {
                     type: 'discovery-empty',
                 };
             }
+            // TODO: ugly, ugly, ugly. Error code needed from trezor-connect :(
+            // since trezor-connect@8.1.6 code: 'Failure_PassphraseState'
+            if (discovery.error === 'Passphrase is incorrect' && !device.available) {
+                return {
+                    status: 'exception',
+                    type: 'device-unavailable',
+                };
+            }
+
+            if (discovery.error || discovery.failed.length > 0) {
+                return {
+                    status: 'exception',
+                    type: 'discovery-failed',
+                };
+            }
             if (discovery.error || discovery.failed.length > 0) {
                 return {
                     status: 'exception',

--- a/packages/suite/src/reducers/wallet/discoveryReducer.ts
+++ b/packages/suite/src/reducers/wallet/discoveryReducer.ts
@@ -25,6 +25,7 @@ export interface Discovery {
     networks: Network['symbol'][];
     running?: Deferred<void>;
     error?: string;
+    errorCode?: string | number;
 }
 
 export type PartialDiscovery = { deviceState: string } & Partial<Discovery>;

--- a/packages/suite/src/reducers/wallet/selectedAccountReducer.ts
+++ b/packages/suite/src/reducers/wallet/selectedAccountReducer.ts
@@ -31,15 +31,12 @@ export interface AccountLoading {
 export type AccountException =
     | {
           status: 'exception';
-          loader:
-              | 'auth-failed'
-              | 'discovery-error' // TODO: Discovery failed on something different than expected "bundle exception"
-              | 'discovery-empty'; // No network enabled in settings
+          loader: 'auth-failed' | 'discovery-error' | 'discovery-empty'; // No network enabled in settings
           mode?: AccountWatchOnlyMode[];
           account?: undefined;
           network?: Network;
           discovery?: Discovery;
-          params?: undefined;
+          params?: WalletParams;
       }
     | {
           status: 'exception';

--- a/packages/suite/src/types/wallet/index.ts
+++ b/packages/suite/src/types/wallet/index.ts
@@ -44,7 +44,12 @@ export type DiscoveryStatus =
       }
     | {
           status: 'exception';
-          type: 'auth-failed' | 'auth-confirm-failed' | 'discovery-empty' | 'discovery-failed';
+          type:
+              | 'auth-failed'
+              | 'auth-confirm-failed'
+              | 'discovery-empty'
+              | 'discovery-failed'
+              | 'device-unavailable';
       };
 export type WalletParams = WalletParams$;
 export type WalletAccountTransaction = WalletAccountTransaction$;


### PR DESCRIPTION
- add "Enable passphrase" view to Dashboard, fix #1827
Steps to reproduce:
1. discover accounts with passphrase
2. goto settings/device
3. disable passphrase
4. goto settings/wallet
5. add new coin
6. goto Dashboard

- add "DiscoveryError" view to Account, fix #1763
Steps to reproduce:
1. discover accounts with passphrase
2. save device
3. refresh webpage
4. add another coin from /wallet (Add account)
5. enter invalid passphrase