### PR TITLE
Fix/fiat rates api limits

### DIFF
--- a/packages/suite/src/actions/suite/storageActions.ts
+++ b/packages/suite/src/actions/suite/storageActions.ts
@@ -146,7 +146,7 @@ export const removeFiatRate = (symbol: string) => (_dispatch: Dispatch, _getStat
 };
 
 export const saveFiatRates = () => (_dispatch: Dispatch, getState: GetState) => {
-    return db.addItems('fiatRates', getState().wallet.fiat, true);
+    return db.addItems('fiatRates', getState().wallet.fiat.coins, true);
 };
 
 export const saveSuiteSettings = () => (_dispatch: Dispatch, getState: GetState) => {
@@ -254,7 +254,7 @@ export const loadStorage = () => async (dispatch: Dispatch, getState: GetState) 
                         ...initialState.wallet.transactions,
                         transactions: mappedTxs,
                     },
-                    fiat: fiatRates || [],
+                    fiat: { ...initialState.wallet.fiat, coins: fiatRates || [] },
                     graph: {
                         ...initialState.wallet.graph,
                         data: walletGraphData || [],

--- a/packages/suite/src/actions/wallet/constants/fiatRatesConstants.ts
+++ b/packages/suite/src/actions/wallet/constants/fiatRatesConstants.ts
@@ -2,3 +2,7 @@ export const RATE_UPDATE = '@rate/update';
 export const RATE_REMOVE = '@rate/remove';
 export const LAST_WEEK_RATES_UPDATE = '@rate/last-week-rate-update';
 export const TX_FIAT_RATE_UPDATE = '@rate/tx-fiat-rate-update';
+
+export const FETCH_COIN_LIST_START = '@rate/fetch-coin-list-start';
+export const FETCH_COIN_LIST_SUCCESS = '@rate/fetch-coin-list-success';
+export const FETCH_COIN_LIST_FAIL = '@rate/fetch-coin-list-fail';

--- a/packages/suite/src/actions/wallet/fiatRatesActions.ts
+++ b/packages/suite/src/actions/wallet/fiatRatesActions.ts
@@ -97,7 +97,7 @@ export const updateCurrentRates = (ticker: FiatTicker, maxAge = MAX_AGE) => asyn
 
         // don't fetch if rates is fresh enough
         if (existingRates) {
-            if (differenceInSeconds(new Date(), fromUnixTime(existingRates.ts)) < maxAge) {
+            if (differenceInSeconds(new Date(), new Date(existingRates.ts)) < maxAge) {
                 return;
             }
         }

--- a/packages/suite/src/actions/wallet/fiatRatesActions.ts
+++ b/packages/suite/src/actions/wallet/fiatRatesActions.ts
@@ -4,6 +4,7 @@ import {
     fetchCurrentFiatRates,
     getFiatRatesForTimestamps,
     fetchLastWeekRates,
+    fetchCoinList,
 } from '@suite/services/coingecko';
 import { isTestnet } from '@wallet-utils/accountUtils';
 import { splitTimestampsByInterval, getBlockbookSafeTime } from '@suite-utils/date';
@@ -14,6 +15,9 @@ import {
     LAST_WEEK_RATES_UPDATE,
     TX_FIAT_RATE_UPDATE,
     RATE_REMOVE,
+    FETCH_COIN_LIST_START,
+    FETCH_COIN_LIST_SUCCESS,
+    FETCH_COIN_LIST_FAIL,
 } from './constants/fiatRatesConstants';
 import {
     Network,
@@ -22,10 +26,21 @@ import {
     WalletAccountTransaction,
     FiatTicker,
 } from '@wallet-types';
+import { CoinListItem } from '@wallet-types/fiatRates';
 
 type FiatRatesPayload = NonNullable<CoinFiatRates['current']>;
 
 export type FiatRatesActions =
+    | {
+          type: typeof FETCH_COIN_LIST_START;
+      }
+    | {
+          type: typeof FETCH_COIN_LIST_SUCCESS;
+          payload: CoinListItem[];
+      }
+    | {
+          type: typeof FETCH_COIN_LIST_FAIL;
+      }
     | {
           type: typeof RATE_UPDATE;
           payload: FiatRatesPayload;
@@ -71,13 +86,38 @@ export const remove = (symbol: string, mainNetworkSymbol?: string) => (dispatch:
 
 export const removeRatesForDisabledNetworks = () => (dispatch: Dispatch, getState: GetState) => {
     const { enabledNetworks } = getState().wallet.settings;
-    const { fiat } = getState().wallet;
+    const fiat = getState().wallet.fiat.coins;
     fiat.forEach(f => {
         const rateNetwork = (f.mainNetworkSymbol ?? f.symbol) as Network['symbol'];
         if (!enabledNetworks.includes(rateNetwork)) {
             dispatch(remove(f.symbol, f.mainNetworkSymbol));
         }
     });
+};
+
+export const getCoinData = (symbol: string) => async (_dispatch: Dispatch, getState: GetState) => {
+    const { coinList } = getState().wallet.fiat;
+    const coinData = coinList?.find(d => d.symbol === symbol.toLowerCase());
+    return coinData;
+};
+
+export const updateCoinList = () => async (dispatch: Dispatch, getState: GetState) => {
+    if (getState().wallet.fiat.coinList) return;
+    dispatch({
+        type: FETCH_COIN_LIST_START,
+    });
+    try {
+        const list = await fetchCoinList();
+        dispatch({
+            type: FETCH_COIN_LIST_SUCCESS,
+            payload: list,
+        });
+    } catch (error) {
+        console.error(error);
+        dispatch({
+            type: FETCH_COIN_LIST_FAIL,
+        });
+    }
 };
 
 /**
@@ -91,7 +131,7 @@ export const updateCurrentRates = (ticker: FiatTicker, maxAge = MAX_AGE) => asyn
     getState: GetState,
 ) => {
     if (maxAge > 0) {
-        const existingRates = getState().wallet.fiat.find(
+        const existingRates = getState().wallet.fiat.coins.find(
             t => t.symbol === ticker.symbol && t.mainNetworkSymbol === ticker.mainNetworkSymbol,
         )?.current;
 
@@ -105,7 +145,12 @@ export const updateCurrentRates = (ticker: FiatTicker, maxAge = MAX_AGE) => asyn
 
     const response = await TrezorConnect.blockchainGetCurrentFiatRates({ coin: ticker.symbol });
     try {
-        const results = response.success ? response.payload : await fetchCurrentFiatRates(ticker);
+        const results = response.success
+            ? response.payload
+            : await fetchCurrentFiatRates({
+                  ...ticker,
+                  coinData: await dispatch(getCoinData(ticker.symbol)),
+              });
 
         if (results && results.rates) {
             // dispatch only if rates are not null/undefined
@@ -144,8 +189,9 @@ const getStaleTickers = (
     interval: number,
     includeTokens?: boolean,
 ) => (_dispatch: Dispatch, getState: GetState): FiatTicker[] => {
-    const { fiat } = getState().wallet;
+    const fiat = getState().wallet.fiat.coins;
     const { enabledNetworks } = getState().wallet.settings;
+    // TODO: FIAT.tickers is useless now
     const watchedCoinTickers = FIAT.tickers.filter(t => enabledNetworks.includes(t.symbol));
     const tokenTickers = fiat.filter(t => !!t.mainNetworkSymbol);
 
@@ -207,7 +253,7 @@ export const updateLastWeekRates = () => async (dispatch: Dispatch, getState: Ge
 
     const lastWeekStaleFn = (coinRates: CoinFiatRates) => {
         if (coinRates.lastWeek?.tickers[0]?.rates[localCurrency]) {
-            // if there is a rate for localCurrency then decided based on timestamp
+            // if there is a rate for localCurrency then decide based on timestamp
             return coinRates.lastWeek?.ts;
         }
         // no rates for localCurrency
@@ -224,7 +270,10 @@ export const updateLastWeekRates = () => async (dispatch: Dispatch, getState: Ge
         try {
             const results = response.success
                 ? response.payload
-                : await fetchLastWeekRates(ticker, localCurrency);
+                : await fetchLastWeekRates(
+                      { ...ticker, coinData: await dispatch(getCoinData(ticker.symbol)) },
+                      localCurrency,
+                  );
 
             if (results?.tickers) {
                 dispatch({
@@ -263,7 +312,10 @@ export const updateTxsRates = (account: Account, txs: AccountTransaction[]) => a
     try {
         const results = response.success
             ? response.payload
-            : await getFiatRatesForTimestamps({ symbol: account.symbol }, timestamps);
+            : await getFiatRatesForTimestamps(
+                  { symbol: account.symbol, coinData: await dispatch(getCoinData(account.symbol)) },
+                  timestamps,
+              );
 
         if (results?.tickers) {
             txs.forEach((tx, i) => {
@@ -301,7 +353,8 @@ let lastWeekTimeout: ReturnType<typeof setInterval>;
  * Called from blockchainActions.onConnect
  *
  */
-export const initRates = () => (dispatch: Dispatch) => {
+export const initRates = () => async (dispatch: Dispatch) => {
+    await dispatch(updateCoinList());
     dispatch(updateStaleRates());
     dispatch(updateLastWeekRates());
 

--- a/packages/suite/src/actions/wallet/fiatRatesActions.ts
+++ b/packages/suite/src/actions/wallet/fiatRatesActions.ts
@@ -1,5 +1,5 @@
 import TrezorConnect, { AccountTransaction, BlockchainFiatRatesUpdate } from 'trezor-connect';
-import { getUnixTime, differenceInSeconds, fromUnixTime } from 'date-fns';
+import { getUnixTime, differenceInSeconds } from 'date-fns';
 import {
     fetchCurrentFiatRates,
     getFiatRatesForTimestamps,

--- a/packages/suite/src/actions/wallet/send/sendFormActions.ts
+++ b/packages/suite/src/actions/wallet/send/sendFormActions.ts
@@ -171,7 +171,8 @@ export const handleAmountChange = (outputId: number, amount: string) => (
     dispatch: Dispatch,
     getState: GetState,
 ) => {
-    const { send, fiat, selectedAccount } = getState().wallet;
+    const { send, selectedAccount } = getState().wallet;
+    const fiat = getState().wallet.fiat.coins;
     if (!send || !fiat || selectedAccount.status !== 'loaded') return null;
     const { account, network } = selectedAccount;
 
@@ -207,7 +208,8 @@ export const handleFiatSelectChange = (
     localCurrency: Output['localCurrency']['value'],
     outputId: number,
 ) => (dispatch: Dispatch, getState: GetState) => {
-    const { fiat, send, selectedAccount } = getState().wallet;
+    const { send, selectedAccount } = getState().wallet;
+    const fiat = getState().wallet.fiat.coins;
     if (!fiat || !send || selectedAccount.status !== 'loaded') return null;
     const { account } = selectedAccount;
 
@@ -249,7 +251,8 @@ export const handleFiatInputChange = (outputId: number, fiatValue: string) => (
     dispatch: Dispatch,
     getState: GetState,
 ) => {
-    const { fiat, send, selectedAccount } = getState().wallet;
+    const { send, selectedAccount } = getState().wallet;
+    const fiat = getState().wallet.fiat.coins;
     if (!fiat || !send || selectedAccount.status !== 'loaded') return null;
     const { network } = selectedAccount;
     const output = getOutput(send.outputs, outputId);
@@ -275,7 +278,8 @@ export const handleFiatInputChange = (outputId: number, fiatValue: string) => (
     Click on "set max"
  */
 export const setMax = (outputIdIn?: number) => async (dispatch: Dispatch, getState: GetState) => {
-    const { fiat, send, selectedAccount } = getState().wallet;
+    const { send, selectedAccount } = getState().wallet;
+    const fiat = getState().wallet.fiat.coins;
 
     if (!fiat || !send || selectedAccount.status !== 'loaded') return null;
     const { account } = selectedAccount;

--- a/packages/suite/src/components/dashboard/AssetsCard/components/Asset/index.tsx
+++ b/packages/suite/src/components/dashboard/AssetsCard/components/Asset/index.tsx
@@ -151,7 +151,7 @@ const Asset = React.memo(({ network, failed, cryptoValue, isFirstRow }: Props) =
 
     // get graph data only for mainnet and not failed accounts
     const lastWeekData =
-        !testnet && !failed ? fiat.find(r => r.symbol === symbol)?.lastWeek?.tickers : [];
+        !testnet && !failed ? fiat.coins.find(r => r.symbol === symbol)?.lastWeek?.tickers : [];
 
     // display one of view:
     // - failed

--- a/packages/suite/src/components/dashboard/AssetsCard/components/LastWeekGraph/index.tsx
+++ b/packages/suite/src/components/dashboard/AssetsCard/components/LastWeekGraph/index.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { Network } from '@wallet-types';
 import { AreaChart, Area, ResponsiveContainer, YAxis } from 'recharts';
-import { LastWeekRates } from '@wallet-reducers/fiatRatesReducer';
+import { LastWeekRates } from '@wallet-types/fiatRates';
 
 const greenArea = '#D6F3CC';
 const greenStroke = '#30c100';

--- a/packages/suite/src/components/dashboard/PortfolioCard/index.tsx
+++ b/packages/suite/src/components/dashboard/PortfolioCard/index.tsx
@@ -32,7 +32,7 @@ const PortfolioCard = React.memo(() => {
 
     const isDeviceEmpty = useMemo(() => accounts.every(a => a.empty), [accounts]);
     const portfolioValue = accountUtils
-        .getTotalFiatBalance(accounts, localCurrency, fiat)
+        .getTotalFiatBalance(accounts, localCurrency, fiat.coins)
         .toString();
 
     const discoveryStatus = getDiscoveryStatus();

--- a/packages/suite/src/components/suite/FiatValue/Container.ts
+++ b/packages/suite/src/components/suite/FiatValue/Container.ts
@@ -2,7 +2,7 @@ import Component from './index';
 import { AppState } from '@suite-types';
 import { Network } from '@wallet-types';
 import { connect } from 'react-redux';
-import { TimestampedRates } from '@wallet-reducers/fiatRatesReducer';
+import { TimestampedRates } from '@wallet-types/fiatRates';
 
 const mapStateToProps = (state: AppState) => ({
     fiat: state.wallet.fiat,

--- a/packages/suite/src/components/suite/FiatValue/index.tsx
+++ b/packages/suite/src/components/suite/FiatValue/index.tsx
@@ -17,7 +17,7 @@ import FormattedNumber from '../FormattedNumber';
  */
 const FiatValue = ({ amount, symbol, fiatCurrency, source, useCustomSource, ...props }: Props) => {
     const targetCurrency = fiatCurrency ?? props.settings.localCurrency;
-    const currentFiatRates = props.fiat.find(f => f.symbol === symbol)?.current;
+    const currentFiatRates = props.fiat.coins.find(f => f.symbol === symbol)?.current;
     const ratesSource = useCustomSource ? source : currentFiatRates?.rates;
     const fiat = ratesSource ? toFiatCurrency(amount, targetCurrency, ratesSource) : null;
     if (fiat) {

--- a/packages/suite/src/components/suite/SwitchDevice/components/WalletInstance/index.tsx
+++ b/packages/suite/src/components/suite/SwitchDevice/components/WalletInstance/index.tsx
@@ -87,7 +87,11 @@ const WalletInstance = ({
     const discoveryProcess = instance.state ? getDiscovery(instance.state) : null;
     const deviceAccounts = accountUtils.getAllAccounts(instance.state, accounts);
     const accountsCount = deviceAccounts.length;
-    const instanceBalance = accountUtils.getTotalFiatBalance(deviceAccounts, localCurrency, fiat);
+    const instanceBalance = accountUtils.getTotalFiatBalance(
+        deviceAccounts,
+        localCurrency,
+        fiat.coins,
+    );
     const analytics = useAnalytics();
 
     const getDataTestBase = () => {

--- a/packages/suite/src/components/suite/modals/ReviewTransaction/index.tsx
+++ b/packages/suite/src/components/suite/modals/ReviewTransaction/index.tsx
@@ -92,7 +92,7 @@ export default ({
     const transactionInfo = getTransactionInfo(account.networkType, send);
     if (!transactionInfo || transactionInfo.type === 'error') return null;
     const upperCaseSymbol = account.symbol.toUpperCase();
-    const fiatVal = fiat.find(fiatItem => fiatItem.symbol === account.symbol);
+    const fiatVal = fiat.coins.find(fiatItem => fiatItem.symbol === account.symbol);
     const outputSymbol = token ? token.symbol!.toUpperCase() : account.symbol.toUpperCase();
     const [isEnabled] = useDeviceActionLocks();
     const fee = getFeeValue(transactionInfo, networkType, account.symbol);

--- a/packages/suite/src/components/wallet/Menu/components/AccountItem/index.tsx
+++ b/packages/suite/src/components/wallet/Menu/components/AccountItem/index.tsx
@@ -85,7 +85,7 @@ const StyledBadge = styled(Badge)`
 const AccountItem = forwardRef((props: Props, ref: React.Ref<HTMLDivElement>) => {
     const { account, selected } = props;
 
-    const fiatBalance = getAccountFiatBalance(account, props.localCurrency, props.fiat);
+    const fiatBalance = getAccountFiatBalance(account, props.localCurrency, props.fiat.coins);
     const accountLabel = props.labeling[`account:${account.descriptor}`] ? (
         <span>{props.labeling[`account:${account.descriptor}`]}</span>
     ) : (

--- a/packages/suite/src/middlewares/wallet/fiatRatesMiddleware.ts
+++ b/packages/suite/src/middlewares/wallet/fiatRatesMiddleware.ts
@@ -48,14 +48,18 @@ const fiatRatesMiddleware = (api: MiddlewareAPI<Dispatch, AppState>) => (next: D
             // fetch current rates for account's tokens
             const account = action.payload;
             if (account.tokens) {
-                account.tokens.forEach(t => {
+                account.tokens.forEach((t, i) => {
                     if (t.symbol) {
-                        api.dispatch(
-                            fiatRatesActions.updateCurrentRates({
-                                symbol: t.symbol,
-                                mainNetworkSymbol: account.symbol,
-                            }),
-                        );
+                        const s = t.symbol;
+                        // wait 1 sec before firing next fetch
+                        setTimeout(() => {
+                            api.dispatch(
+                                fiatRatesActions.updateCurrentRates({
+                                    symbol: s,
+                                    mainNetworkSymbol: account.symbol,
+                                }),
+                            );
+                        }, i * 1000);
                     }
                 });
             }

--- a/packages/suite/src/middlewares/wallet/fiatRatesMiddleware.ts
+++ b/packages/suite/src/middlewares/wallet/fiatRatesMiddleware.ts
@@ -51,7 +51,7 @@ const fiatRatesMiddleware = (api: MiddlewareAPI<Dispatch, AppState>) => (next: D
                 account.tokens.forEach((t, i) => {
                     if (t.symbol) {
                         const s = t.symbol;
-                        // wait 1 sec before firing next fetch
+                        // wait 500ms before firing next fetch
                         setTimeout(() => {
                             api.dispatch(
                                 fiatRatesActions.updateCurrentRates({
@@ -59,7 +59,7 @@ const fiatRatesMiddleware = (api: MiddlewareAPI<Dispatch, AppState>) => (next: D
                                     mainNetworkSymbol: account.symbol,
                                 }),
                             );
-                        }, i * 1000);
+                        }, i * 500);
                     }
                 });
             }

--- a/packages/suite/src/reducers/wallet/fiatRatesReducer.ts
+++ b/packages/suite/src/reducers/wallet/fiatRatesReducer.ts
@@ -4,34 +4,27 @@ import {
     RATE_UPDATE,
     LAST_WEEK_RATES_UPDATE,
     RATE_REMOVE,
+    FETCH_COIN_LIST_START,
+    FETCH_COIN_LIST_SUCCESS,
+    FETCH_COIN_LIST_FAIL,
 } from '@wallet-actions/constants/fiatRatesConstants';
 import { STORAGE } from '@suite-actions/constants';
+import {
+    CoinListItem,
+    CoinFiatRates,
+    CurrentFiatRates,
+    LastWeekRates,
+} from '@wallet-types/fiatRates';
 
-export interface CurrentFiatRates {
-    symbol: string;
-    rates: { [key: string]: number | undefined };
-    ts: number;
+export interface State {
+    coins: CoinFiatRates[];
+    coinList: CoinListItem[] | null;
 }
 
-export interface TimestampedRates {
-    rates: { [key: string]: number | undefined };
-    ts: number;
-}
-
-export interface LastWeekRates {
-    symbol: string;
-    tickers: TimestampedRates[];
-    ts: number;
-}
-
-export interface CoinFiatRates {
-    current?: CurrentFiatRates;
-    lastWeek?: LastWeekRates;
-    symbol: string;
-    mainNetworkSymbol?: string;
-}
-
-export const initialState: CoinFiatRates[] = [];
+export const initialState: State = {
+    coins: [],
+    coinList: null,
+};
 
 const remove = (state: CoinFiatRates[], symbol: string, mainNetworkSymbol?: string) => {
     const index = state.findIndex(
@@ -76,17 +69,26 @@ const updateLastWeekRates = (state: CoinFiatRates[], payload: LastWeekRates) => 
     }
 };
 
-export default (state: CoinFiatRates[] = initialState, action: Action): CoinFiatRates[] => {
+export default (state: State = initialState, action: Action): State => {
     return produce(state, draft => {
         switch (action.type) {
             case RATE_REMOVE:
-                remove(draft, action.symbol, action.mainNetworkSymbol);
+                remove(draft.coins, action.symbol, action.mainNetworkSymbol);
                 break;
             case RATE_UPDATE:
-                updateCurrentRates(draft, action.payload, action.mainNetworkSymbol);
+                updateCurrentRates(draft.coins, action.payload, action.mainNetworkSymbol);
                 break;
             case LAST_WEEK_RATES_UPDATE:
-                updateLastWeekRates(draft, action.payload);
+                updateLastWeekRates(draft.coins, action.payload);
+                break;
+            case FETCH_COIN_LIST_START:
+                draft.coinList = null;
+                break;
+            case FETCH_COIN_LIST_SUCCESS:
+                draft.coinList = action.payload;
+                break;
+            case FETCH_COIN_LIST_FAIL:
+                draft.coinList = null;
                 break;
             case STORAGE.LOADED:
                 return action.payload.wallet.fiat;

--- a/packages/suite/src/reducers/wallet/transactionReducer.ts
+++ b/packages/suite/src/reducers/wallet/transactionReducer.ts
@@ -7,7 +7,7 @@ import { SETTINGS } from '@suite-config';
 import { Account, WalletAction, Network } from '@wallet-types';
 import { Action } from '@suite-types';
 import { STORAGE } from '@suite-actions/constants';
-import { TimestampedRates } from './fiatRatesReducer';
+import { TimestampedRates } from '@wallet-types/fiatRates';
 
 export interface WalletAccountTransaction extends AccountTransaction {
     id?: number;

--- a/packages/suite/src/services/coingecko.ts
+++ b/packages/suite/src/services/coingecko.ts
@@ -1,5 +1,4 @@
-import { LastWeekRates } from '@wallet-reducers/fiatRatesReducer';
-import { FiatTicker } from '@wallet-types';
+import { LastWeekRates, FiatTicker } from '@wallet-types/fiatRates';
 
 const COINGECKO_BASE_URL = 'https://api.coingecko.com/';
 
@@ -21,7 +20,7 @@ export const fetchCoinList = async (): Promise<any> => {
 };
 
 /**
- * Build coinUrl from the `ticker.url` if available.
+ * Build coinUrl from the `ticker.coinData` if available.
  * Otherwise fetch coin ID from CoinGecko and use that.
  *
  * @param {FiatTicker} ticker
@@ -29,14 +28,9 @@ export const fetchCoinList = async (): Promise<any> => {
  */
 const buildCoinUrl = async (ticker: FiatTicker) => {
     let coinUrl: string | null = null;
-    const { symbol } = ticker;
-    if (ticker.url) {
-        coinUrl = ticker.url;
-    } else if (symbol) {
+    const { coinData } = ticker;
+    if (coinData) {
         // fetch coin id from coingecko and use it to build URL for fetching rates
-        const coinList = await fetchCoinList();
-        const coinData = coinList.find((t: any) => t.symbol === symbol.toLowerCase());
-        if (!coinData) return null;
         coinUrl = `${COINGECKO_BASE_URL}/api/v3/coins/${coinData.id}`;
     }
     return coinUrl;

--- a/packages/suite/src/storage/migrations/index.ts
+++ b/packages/suite/src/storage/migrations/index.ts
@@ -1,10 +1,11 @@
 import { OnUpgradeFunc } from '@trezor/suite-storage';
+import { SuiteDBSchema } from '..';
 
-export const migrate = async <TDBType>(
-    db: any,
-    oldVersion: Parameters<OnUpgradeFunc<TDBType>>['1'],
-    newVersion: Parameters<OnUpgradeFunc<TDBType>>['2'],
-    _transaction: Parameters<OnUpgradeFunc<TDBType>>['3'],
+export const migrate = async (
+    db: Parameters<OnUpgradeFunc<SuiteDBSchema>>['0'],
+    oldVersion: Parameters<OnUpgradeFunc<SuiteDBSchema>>['1'],
+    newVersion: Parameters<OnUpgradeFunc<SuiteDBSchema>>['2'],
+    _transaction: Parameters<OnUpgradeFunc<SuiteDBSchema>>['3'],
 ) => {
     console.log(`Migrating database from version ${oldVersion} to ${newVersion}`);
 

--- a/packages/suite/src/types/wallet/fiatRates.ts
+++ b/packages/suite/src/types/wallet/fiatRates.ts
@@ -1,7 +1,37 @@
+export interface CoinListItem {
+    id: string;
+    symbol: string;
+    name: string;
+}
+
 export interface FiatTicker {
     symbol: string;
-    url?: string;
+    coinData?: CoinListItem; // coingecko metadata including identifier used for request
     mainNetworkSymbol?: string; // symbol of thee main network. (used for tokens)
+}
+
+export interface CurrentFiatRates {
+    symbol: string;
+    rates: { [key: string]: number | undefined };
+    ts: number;
+}
+
+export interface TimestampedRates {
+    rates: { [key: string]: number | undefined };
+    ts: number;
+}
+
+export interface LastWeekRates {
+    symbol: string;
+    tickers: TimestampedRates[];
+    ts: number;
+}
+
+export interface CoinFiatRates {
+    current?: CurrentFiatRates;
+    lastWeek?: LastWeekRates;
+    symbol: string;
+    mainNetworkSymbol?: string;
 }
 
 export type GraphRange =

--- a/packages/suite/src/types/wallet/index.ts
+++ b/packages/suite/src/types/wallet/index.ts
@@ -8,12 +8,14 @@ import {
     SendFormXrpActions,
     SendFormEthActions,
 } from '@wallet-types/sendForm';
-import { FiatTicker as FiatTicker$ } from '@wallet-types/fiatRates';
+import {
+    FiatTicker as FiatTicker$,
+    CoinFiatRates as CoinFiatRates$,
+} from '@wallet-types/fiatRates';
 import { DiscoveryActions } from '@wallet-actions/discoveryActions';
 import { AccountActions } from '@wallet-actions/accountActions';
 import { Discovery as Discovery$ } from '@wallet-reducers/discoveryReducer';
 import { Account as Account$ } from '@wallet-reducers/accountsReducer';
-import { CoinFiatRates as CoinFiatRates$ } from '@wallet-reducers/fiatRatesReducer';
 import { WalletAccountTransaction as WalletAccountTransaction$ } from '@wallet-reducers/transactionReducer';
 import { ReceiveInfo as ReceiveInfo$ } from '@wallet-reducers/receiveReducer';
 

--- a/packages/suite/src/views/wallet/send/components/AdvancedForm/components/Fee/index.tsx
+++ b/packages/suite/src/views/wallet/send/components/AdvancedForm/components/Fee/index.tsx
@@ -135,7 +135,7 @@ export default ({ sendFormActions, send, account, settings, fiat }: Props) => {
     const feeLevels = feeInfo.levels;
     const { localCurrency } = settings;
     const { networkType, symbol } = account;
-    const fiatVal = fiat.find(fiatItem => fiatItem.symbol === symbol);
+    const fiatVal = fiat.coins.find(fiatItem => fiatItem.symbol === symbol);
     return (
         <Wrapper>
             <Row>

--- a/packages/suite/src/views/wallet/transactions/components/PricePanel/index.tsx
+++ b/packages/suite/src/views/wallet/transactions/components/PricePanel/index.tsx
@@ -118,7 +118,7 @@ export default ({ settings, selectedAccount, fiat }: Props) => {
 
     const { account } = selectedAccount;
     const { symbol, formattedBalance } = account;
-    const fiatBalance = getAccountFiatBalance(account, localCurrency, fiat);
+    const fiatBalance = getAccountFiatBalance(account, localCurrency, fiat.coins);
     const MAX_AGE = 5; // after 5 minutes the ticker will show tooltip with info about last update instead of blinking LIVE text
     const rateAge = (timestamp: number) => differenceInMinutes(new Date(), new Date(timestamp));
 


### PR DESCRIPTION
- slow down fetching rates for tokens account.create (500ms between every token rate fetch)
- don't fetch already downloaded rates on account.create/update (check for already downloaded was present only during updating the rates)
- download coingecko's coinList only once and store it in fiat reducer (that required edits in multiple files to reflect new reducer schema)

resolves case when user has too many tokens and coingecko limits fetch request rate 😬 
https://sentry.io/organizations/satoshilabs/issues/1680018913/?project=5193825&query=is%3Aunresolved
https://sentry.io/organizations/satoshilabs/issues/1692648876/?project=5193825&query=is%3Aunresolved