### PR TITLE
backup: better handling of already failed, already finished edge case

### DIFF
--- a/packages/integration-tests/projects/suite-web/tests/backup/misc-t2.test.ts
+++ b/packages/integration-tests/projects/suite-web/tests/backup/misc-t2.test.ts
@@ -11,7 +11,7 @@ describe('Backup', () => {
         cy.passThroughInitialRun();
     });
 
-    it('Backup failed', () => {
+    it('Backup failed - device disconnected during action', () => {
         cy.getTestElement('@notification/no-backup/button').click();
         cy.getTestElement('@backup/check-item/understands-what-seed-is').click();
         cy.getTestElement('@backup/check-item/has-enough-time').click();
@@ -23,6 +23,14 @@ describe('Backup', () => {
         cy.getTestElement('@backup/no-device', { timeout: 20000 });
         cy.task('startEmu');
         cy.getTestElement('@backup/error-message');
+
+        cy.log('Now go to dashboard and see if security card and notification reflects backup failed state correctly');
+        cy.getTestElement('@backup/close-button').click();
+        cy.getTestElement('@notification/failed-backup/learn-more-link').should('be.visible');
+
+        cy.getTestElement('@dashboard/security-card/backup/button', { timeout: 20000 }).click();
+        cy.getTestElement('@backup/already-failed-message');
+
     });
 
     it('Backup should reset if modal is closed', () => {
@@ -34,12 +42,11 @@ describe('Backup', () => {
         cy.getTestElement('@backup/check-item/understands-what-seed-is').should('not.be.checked');
     });
 
-    // seems to always fail
-    it.skip('User is doing backup with device A -> disconnects device A -> connects device B with backup already finished', () => {
+    it('User is doing backup with device A -> disconnects device A -> connects device B with backup already finished', () => {
         cy.getTestElement('@notification/no-backup/button').click();
         cy.getTestElement('@backup/check-item/has-enough-time').click();
         cy.task('stopEmu');
-        cy.getTestElement('@backup/no-device');
+        cy.getTestElement('@backup/no-device', { timeout: 20000 });
         cy.task('stopBridge');
         // latest (2.3.0 at the time of writing this) has default behavior needs_backup false
         cy.task('startEmu', { wipe: true });

--- a/packages/suite/src/components/suite/Notifications/FailedBackup.tsx
+++ b/packages/suite/src/components/suite/Notifications/FailedBackup.tsx
@@ -15,7 +15,11 @@ export default ({ device }: Props) => {
     return (
         <Wrapper variant="warning">
             <Translation id="TR_FAILED_BACKUP" />
-            <Link variant="nostyle" href={URLS.FAILED_BACKUP_URL}>
+            <Link
+                variant="nostyle"
+                href={URLS.FAILED_BACKUP_URL}
+                data-test="@notification/failed-backup/learn-more-link"
+            >
                 <Translation id="TR_WHAT_TO_DO_NOW" />
             </Link>
         </Wrapper>

--- a/packages/suite/src/support/messages.ts
+++ b/packages/suite/src/support/messages.ts
@@ -3459,6 +3459,24 @@ const definedMessages = defineMessages({
         id: 'TR_INCLUDING_FEE',
         defaultMessage: 'Including fee',
     },
+    BACKUP_BACKUP_ALREADY_FINISHED_HEADING: {
+        id: 'BACKUP_BACKUP_ALREADY_FINISHED',
+        defaultMessage: 'Backup already finished',
+    },
+    BACKUP_BACKUP_ALREADY_FINISHED_DESCRIPTION: {
+        id: 'BACKUP_BACKUP_ALREADY_FINISHED_DESCRIPTION',
+        defaultMessage:
+            'Connected device as backup already finished. You should have a recovery seed written down and hidden in a safe place.',
+    },
+    BACKUP_BACKUP_ALREADY_FAILED_HEADING: {
+        id: 'BACKUP_BACKUP_ALREADY_FAILED_HEADING',
+        defaultMessage: 'Backup failed',
+    },
+    BACKUP_BACKUP_ALREADY_FAILED_DESCRIPTION: {
+        id: 'BACKUP_BACKUP_ALREADY_FAILED_DESCRIPTION',
+        defaultMessage:
+            'A previous attempt to backup this device failed. Device backup may be done only once.',
+    },
 } as const);
 
 export default definedMessages;

--- a/packages/suite/src/views/backup/index.tsx
+++ b/packages/suite/src/views/backup/index.tsx
@@ -6,9 +6,10 @@ import { H2, P, Button, ButtonProps, colors, Modal } from '@trezor/components';
 import * as backupActions from '@backup-actions/backupActions';
 import * as deviceSettingsActions from '@settings-actions/deviceSettingsActions';
 import { Dispatch, AppState, InjectedModalApplicationProps } from '@suite-types';
-import { ProgressBar, Loading, Image, Translation } from '@suite-components';
+import { ProgressBar, Loading, Image, Translation, ExternalLink } from '@suite-components';
 import { PreBackupCheckboxes, AfterBackupCheckboxes } from '@backup-components';
 import { canStart, canContinue } from '@backup-utils';
+import { FAILED_BACKUP_URL } from '@suite-constants/urls';
 
 const Row = styled.div`
     display: flex;
@@ -96,7 +97,7 @@ const Backup = (props: Props) => {
     }
 
     /*
-        Edge case, user disconnected device he was doing backup initially with and connected another device 
+        Edge case, user disconnected the device he was doing backup initially with and connected another device 
         with backup finished or failed. Either way, there is no way.
     */
     if (backup.status !== 'finished' && !backup.error && device.features.needs_backup === false) {
@@ -104,16 +105,25 @@ const Backup = (props: Props) => {
             <Modal useFixedHeight cancelable onCancel={props.onCancel}>
                 {!device.features.unfinished_backup && (
                     <>
+                        <H2>
+                            <Translation id="BACKUP_BACKUP_ALREADY_FINISHED_HEADING" />
+                        </H2>
                         <StyledP data-test="@backup/already-finished-message">
-                            This device has backup already finished
+                            <Translation id="BACKUP_BACKUP_ALREADY_FINISHED_DESCRIPTION" />
                         </StyledP>
                         <StyledImage image="UNI_SUCCESS" />
                     </>
                 )}
                 {device.features.unfinished_backup && (
                     <>
+                        <H2>
+                            <Translation id="BACKUP_BACKUP_ALREADY_FAILED_HEADING" />
+                        </H2>
                         <StyledP data-test="@backup/already-failed-message">
-                            This device is in failed backup state
+                            <Translation id="BACKUP_BACKUP_ALREADY_FAILED_DESCRIPTION" />
+                            <ExternalLink href={FAILED_BACKUP_URL}>
+                                <Translation id="TR_LEARN_MORE" />
+                            </ExternalLink>
                         </StyledP>
                         <StyledImage image="UNI_ERROR" />
                     </>


### PR DESCRIPTION
- better handling of already failed / already backup edge case. this may happen if user connects another device during backup, or when user opens backup modal from dashboard security card and the selected device is in backup failed state, resolve https://github.com/trezor/trezor-suite/issues/1787
- tests covering both cases here https://gitlab.com/satoshilabs/trezor/trezor-suite/-/jobs/585631789/artifacts/file/packages/integration-tests/projects/suite-web/videos/backup/misc-t2.test.ts.mp4 (as part of the first one and the last one)
