### PR TITLE
ci: only build suite-native in develop and schedules

### DIFF
--- a/ci/packages/suite-native.yml
+++ b/ci/packages/suite-native.yml
@@ -1,6 +1,10 @@
 suite-native build android:
     image: reactnativecommunity/react-native-android
     stage: build
+    only:
+        refs:
+            - develop
+            - schedules
     script:
         - yarn cache clean
         - yarn build:libs


### PR DESCRIPTION
I suggest that we limit suite-native/build job only for develop and scheduled jobs. Reasons:
- there is little to no chance that suite-native/build job could fail. 
- there is no active development on native at the moment, so the only thing we could break is typescript and typescript is covered by another job
- I have never seen this job to fail before

so this seems like a reasonable optimization now. once native will become actively develop, we may build it in every pipeline.