### PR TITLE
Conventional commits (kick off)

### DIFF
--- a/COMMITS.md
+++ b/COMMITS.md
@@ -1,0 +1,29 @@
+# Commits
+
+Using [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) is strongly recommended and might be enforced in future.
+
+### Examples
+
+```
+docs: correct spelling of CHANGELOG
+feat: allow provided config object to extend other configs
+feat(lang): added polish language
+```
+
+### Git hook
+
+Use this git hook to auto-check your commit messages. Save the following snippet into `.git/hooks/commit-msg`
+
+```
+#!/bin/sh
+if ! grep -qE "^(build|ci|docs|feat|fix|perf|refactor|style|test|chore|revert)(\((blockchain-link|components|components-storybook|integration-tests|landing-page|news-api|rollout|suite|suite-data|suite-desktop|suite-native|suite-onboarding|suite-storage|suite-web|translations-manager)\))?: " "$1" ; then
+  echo "Conventional Commits validation failed"
+  exit 1
+fi
+```
+
+If you want to bypass commit-msg hook check, you may always use
+
+```
+git commit -m "foobar" --no-verify
+```

--- a/README.md
+++ b/README.md
@@ -33,6 +33,8 @@ Run a dev build:
 
 Inspired by [GitLab Contributing Guide](https://docs.gitlab.com/ee/development/contributing/)
 
+Using [Conventional Commits](COMMITS.md) is strongly recommended and might be enforced in future.
+
 ## Security vulnerability disclosure
 
 Please report suspected security vulnerabilities in private to [security@satoshilabs.com](mailto:security@satoshilabs.com), also see [the disclosure section on the Trezor.io website](https://trezor.io/security/). Please do NOT create publicly viewable issues for suspected security vulnerabilities.


### PR DESCRIPTION
This is a proposal and discussion kickoff. 

I believe that we should adapt some commit message convention, which would help us in two ways: easier to read version history and easier to create changelog. see files for details

Also there are more complex tools that may be considered:
- https://github.com/talos-systems/conform this one contains spell check
- https://marketplace.visualstudio.com/items?itemName=vivaxy.vscode-conventional-commits plugin for vscode 
- https://github.com/xotahal/fastlane-plugin-semantic_release for creating conventional changelog from conventional commits