### PR TITLE
Remove old versions of db for which migrations were not implemented

### DIFF
--- a/packages/suite/src/storage/index.ts
+++ b/packages/suite/src/storage/index.ts
@@ -86,7 +86,17 @@ export type SuiteStorageUpdateMessage = StorageUpdateMessage<SuiteDBSchema>;
  *  Otherwise runs a migration function that transform the data to new scheme version if necessary
  */
 const onUpgrade: OnUpgradeFunc<SuiteDBSchema> = async (db, oldVersion, newVersion, transaction) => {
-    const shouldInitDB = oldVersion === 0;
+    let shouldInitDB = oldVersion === 0;
+    if (oldVersion > 0 && oldVersion < 13) {
+        // just delete whole db as migrations from version older than 13 (internal releases) are not implemented
+        try {
+            await SuiteDB.removeStores(db);
+            shouldInitDB = true;
+        } catch (err) {
+            console.error('Storage: Error during removing all stores', err);
+        }
+    }
+
     if (shouldInitDB) {
         // init db
         // object store for wallet transactions


### PR DESCRIPTION
When upgrading db from old versions ( from 1 to 12) delete old db and create a new one. 
It'll help folks at SL that used the storage in ancient versions of the app for which we did not implement proper migration.