### PR TITLE
test(e2e): fix permissions of in tests generated files

### DIFF
--- a/docker/docker-compose.suite-test.yml
+++ b/docker/docker-compose.suite-test.yml
@@ -10,7 +10,9 @@ services:
       service: suite-dev
   test-open:
     # the Docker image to use from https://github.com/cypress-io/cypress-docker-images
-    image: cypress/included:4.7.0
+    build:
+      context: .
+      dockerfile: ./test-runner/Dockerfile
     container_name: test-runner
     ipc: host
     depends_on:
@@ -23,10 +25,11 @@ services:
       - CYPRESS_defaultCommandTimeout=60000 # on dev server, due to on-demand compilation nature of next.js, we need much longer timeout
       - DISPLAY=$DISPLAY
       - QT_X11_NO_MITSHM=1
+      - LOCAL_USER_ID=$LOCAL_USER_ID
     working_dir: /e2e
-    entrypoint: bash -c "yarn && cypress open --project /e2e/packages/integration-tests/projects/suite-web"
-    # todo: if you want to debug run_tests.js (which runs tests in CI) locally
-    # entrypoint: bash -c "node ./packages/integration-tests/projects/suite-web/run_tests.js"
+    command: bash -c "cypress open --project /e2e/packages/integration-tests/projects/suite-web"
+    # if you want to debug run_tests.js (which runs tests in CI) locally
+    # command: bash -c "node ./packages/integration-tests/projects/suite-web/run_tests.js"
     volumes:
       - ../:/e2e
       - /tmp/.X11-unix:/tmp/.X11-unix:rw

--- a/docker/test-runner/Dockerfile
+++ b/docker/test-runner/Dockerfile
@@ -1,0 +1,14 @@
+FROM cypress/included:4.7.0
+  
+RUN apt-get update && apt-get -y --no-install-recommends install \
+    ca-certificates \
+    curl
+
+RUN curl -o /usr/local/bin/gosu -SL "https://github.com/tianon/gosu/releases/download/1.4/gosu-$(dpkg --print-architecture)" \
+    && curl -o /usr/local/bin/gosu.asc -SL "https://github.com/tianon/gosu/releases/download/1.4/gosu-$(dpkg --print-architecture).asc" \
+    && chmod +x /usr/local/bin/gosu
+
+COPY ./suite/entrypoint.sh /usr/local/bin/entrypoint.sh
+RUN chmod +x /usr/local/bin/entrypoint.sh
+
+ENTRYPOINT ["/usr/local/bin/entrypoint.sh"]


### PR DESCRIPTION
Until now, files generated while running tests locally had wrong permissions