### PR TITLE
feat: bump minimal browser version supporting .flat()

### DIFF
--- a/packages/suite-data/files/browser-detection/index.js
+++ b/packages/suite-data/files/browser-detection/index.js
@@ -34,17 +34,17 @@ window.onload = function() {
     var supportedBrowsers = [
         {
             name: "Chrome",
-            version: 59,
+            version: 69,
             mobile: true,
         },
         {
             name: "Chromium",
-            version: 59,
+            version: 69,
             mobile: true,
         },
         {
             name: "Firefox",
-            version: 54,
+            version: 62,
             mobile: false, // no webusb support
         }
     ];


### PR DESCRIPTION
chrome < 69 (pre sept 2018), firefox < 62 (pre jun 2018) do not support array.flat() https://sentry.io/organizations/satoshilabs/issues/1729617291