### PR TITLE
distinctive visual style for non generic error message

### DIFF
--- a/packages/suite/src/support/suite/ErrorBoundary.tsx
+++ b/packages/suite/src/support/suite/ErrorBoundary.tsx
@@ -50,6 +50,18 @@ const StyledButton = styled(Button)`
     margin: 6px 12px;
 `;
 
+const GenericMessage = styled(P)`
+    margin-bottom: 10px;
+`;
+
+const ErrorMessage = styled.span`
+    text-align: center;
+    max-width: 600px;
+    font-family: Consolas, Menlo, Courier, monospace;
+    font-size: ${variables.FONT_SIZE.TINY};
+    color: ${colors.NEUE_TYPE_DARK_GREY};
+`;
+
 const refresh = () => {
     // @ts-ignore global.ipcRenderer is declared in @desktop/preloader.js
     const { ipcRenderer } = global;
@@ -104,10 +116,10 @@ class ErrorBoundary extends React.Component<Props, StateProps> {
             return (
                 <Wrapper>
                     <H1>Error occurred</H1>
-                    <P textAlign="center">
+                    <GenericMessage textAlign="center">
                         It appears something is broken. You might let us know by sending report
-                    </P>
-                    <P>{this.state.error.message}</P>
+                    </GenericMessage>
+                    <ErrorMessage>{this.state.error.message}</ErrorMessage>
                     {/* <P>{this.state.error.stack}</P> */}
 
                     <SendReportButton variant="primary" onClick={() => Sentry.showReportDialog()}>


### PR DESCRIPTION
close https://github.com/trezor/trezor-suite/issues/2018

AFTER
<img width="922" alt="Screenshot 2020-07-08 at 12 08 37" src="https://user-images.githubusercontent.com/6961901/86906546-007e3800-c114-11ea-9dcc-8e0d265db228.png">

BEFORE
<img width="1019" alt="Screenshot 2020-07-08 at 12 13 07" src="https://user-images.githubusercontent.com/6961901/86906844-6f5b9100-c114-11ea-9a44-741b726ce3d7.png">

