### PR TITLE
suite-desktop: remove arm build

### DIFF
--- a/ci/packages/suite-desktop.yml
+++ b/ci/packages/suite-desktop.yml
@@ -70,23 +70,6 @@ suite-desktop build windows manual:
         artifact: ${DESKTOP_APP_NAME}*
     <<: *build
 
-# suite-desktop build arm:
-#     only:
-#         <<: *auto_run_branches
-#     variables:
-#         platform: arm
-#         artifact: ${DESKTOP_APP_NAME}*
-#     <<: *build
-
-# suite-desktop build arm manual:
-#     except:
-#         <<: *auto_run_branches
-#     when: manual
-#     variables:
-#         platform: arm
-#         artifact: ${DESKTOP_APP_NAME}*
-#     <<: *build
-
 suite-desktop deploy dev:
     stage: deploy to dev
     only:

--- a/packages/suite-desktop/package.json
+++ b/packages/suite-desktop/package.json
@@ -13,9 +13,8 @@
         "build:desktop": "rimraf ./build && next build && next export -o build && yarn build:lib",
         "build:mac": "yarn clean && yarn build:desktop && electron-builder --mac",
         "build:linux": "yarn clean && yarn build:desktop && electron-builder --linux",
-        "build:arm": "yarn clean && yarn build:desktop && electron-builder --armv7l",
         "build:win": "yarn clean && yarn build:desktop && electron-builder --win",
-        "publish": "yarn clean && yarn build:desktop && electron-builder --publish always --mac --linux --win --armv7l",
+        "publish": "yarn clean && yarn build:desktop && electron-builder --publish always --mac --linux --win",
         "lint": "eslint '**/*{.ts,.tsx}'",
         "type-check": "tsc --project tsconfig.json"
     },


### PR DESCRIPTION
This is unused and not working properly anyway.

In the future when we'll be supporting ARM, but it will be aarch64 (aka arm64), not armv7.