### PR TITLE
Add zindex to dayheading so it'll get pushed above tx-type icon with …

### DIFF
--- a/packages/suite/src/views/wallet/transactions/components/TransactionList/components/DayHeader/index.tsx
+++ b/packages/suite/src/views/wallet/transactions/components/TransactionList/components/DayHeader/index.tsx
@@ -16,6 +16,7 @@ import { Network } from '@wallet-types';
 const Wrapper = styled.div`
     display: flex;
     position: sticky;
+    z-index: 1;
     background: ${colors.NEUE_BG_GRAY};
     top: 0;
     align-items: center;


### PR DESCRIPTION
…position relative

I am remembering we once discussed this zindex with @mroz22 as it was causing some issues, but now I can't really remember what was the exact issue. 
So @mroz22 when you are available ping me.

fix https://github.com/trezor/trezor-suite/issues/2270