### PR TITLE
Fix/send form default fee

### DIFF
--- a/packages/suite/package.json
+++ b/packages/suite/package.json
@@ -39,7 +39,7 @@
         "react-dom": "16.9.0",
         "react-text-truncate": "0.16.0",
         "react-focus-lock": "^2.0.5",
-        "react-hook-form": "6.6.0",
+        "react-hook-form": "6.7.1",
         "react-hotkeys-hook": "^1.5.4",
         "react-intl": "^3.9.2",
         "react-native-web": "^0.11.2",

--- a/packages/suite/src/actions/settings/walletSettingsActions.ts
+++ b/packages/suite/src/actions/settings/walletSettingsActions.ts
@@ -14,8 +14,8 @@ export type WalletSettingsActions =
     | { type: typeof WALLET_SETTINGS.SET_HIDE_BALANCE; toggled: boolean }
     | {
           type: typeof WALLET_SETTINGS.SET_LAST_USED_FEE_LEVEL;
-          feeLevel: FeeLevel;
           symbol: Network['symbol'];
+          feeLevel?: FeeLevel;
       };
 
 export const setLocalCurrency = (localCurrency: string) => ({
@@ -56,7 +56,7 @@ export const changeNetworks = (payload: Network['symbol'][]) => ({
     payload,
 });
 
-export const setLastUsedFeeLevel = (feeLevel: FeeLevel) => (
+export const setLastUsedFeeLevel = (feeLevel?: FeeLevel) => (
     dispatch: Dispatch,
     getState: GetState,
 ) => {
@@ -64,8 +64,8 @@ export const setLastUsedFeeLevel = (feeLevel: FeeLevel) => (
     if (selectedAccount.status !== 'loaded') return;
     dispatch({
         type: WALLET_SETTINGS.SET_LAST_USED_FEE_LEVEL,
-        feeLevel,
         symbol: selectedAccount.account.symbol,
+        feeLevel,
     });
 };
 

--- a/packages/suite/src/actions/wallet/sendFormActions.ts
+++ b/packages/suite/src/actions/wallet/sendFormActions.ts
@@ -64,7 +64,11 @@ export const getDraft = () => (_dispatch: Dispatch, getState: GetState) => {
     const { selectedAccount, send } = getState().wallet;
     if (selectedAccount.status !== 'loaded') return;
 
-    return send.drafts[selectedAccount.account.key];
+    const draft = send.drafts[selectedAccount.account.key];
+    if (draft) {
+        // draft is a read-only redux object. make a copy to be able to modify values
+        return JSON.parse(JSON.stringify(draft));
+    }
 };
 
 export const removeDraft = () => (dispatch: Dispatch, getState: GetState) => {

--- a/packages/suite/src/hooks/wallet/useSendForm.ts
+++ b/packages/suite/src/hooks/wallet/useSendForm.ts
@@ -69,6 +69,7 @@ export const useSendForm = (props: UseSendFormProps): SendContextValues => {
         saveDraft,
         removeDraft,
         getLastUsedFeeLevel,
+        setLastUsedFeeLevel,
         signTransaction,
         importRequest,
     } = useActions({
@@ -76,6 +77,7 @@ export const useSendForm = (props: UseSendFormProps): SendContextValues => {
         saveDraft: sendFormActions.saveDraft,
         removeDraft: sendFormActions.removeDraft,
         getLastUsedFeeLevel: walletSettingsActions.getLastUsedFeeLevel,
+        setLastUsedFeeLevel: walletSettingsActions.setLastUsedFeeLevel,
         signTransaction: sendFormActions.signTransaction,
         importRequest: sendFormActions.importRequest,
     });
@@ -83,7 +85,7 @@ export const useSendForm = (props: UseSendFormProps): SendContextValues => {
     const { localCurrencyOption } = state;
 
     // register `react-hook-form`, defaultValues are set later in "loadDraft" useEffect block
-    const useFormMethods = useForm<FormState>({ mode: 'onChange' });
+    const useFormMethods = useForm<FormState>({ mode: 'onChange', shouldUnregister: false });
 
     const { control, reset, register, getValues } = useFormMethods;
 
@@ -124,7 +126,6 @@ export const useSendForm = (props: UseSendFormProps): SendContextValues => {
                 ...state,
                 ...value,
             });
-            console.warn('updateContext', value, state);
         },
         [state],
     );
@@ -160,9 +161,10 @@ export const useSendForm = (props: UseSendFormProps): SendContextValues => {
 
     const resetContext = useCallback(() => {
         setComposedLevels(undefined);
-        removeDraft();
+        removeDraft(); // reset draft
+        setLastUsedFeeLevel(); // reset last known FeeLevel
         setState(getStateFromProps(props)); // resetting state will trigger "loadDraft" useEffect block, which will reset FormState to default
-    }, [props, removeDraft, setComposedLevels]);
+    }, [props, removeDraft, setLastUsedFeeLevel, setComposedLevels]);
 
     // declare useSendFormImport, sub-hook of useSendForm
     const { importTransaction } = useSendFormImport({

--- a/packages/suite/src/reducers/wallet/settingsReducer.ts
+++ b/packages/suite/src/reducers/wallet/settingsReducer.ts
@@ -47,7 +47,11 @@ export default (state: State = initialState, action: Action): State => {
                 break;
 
             case WALLET_SETTINGS.SET_LAST_USED_FEE_LEVEL:
-                draft.lastUsedFeeLevel[action.symbol] = action.feeLevel;
+                if (action.feeLevel) {
+                    draft.lastUsedFeeLevel[action.symbol] = action.feeLevel;
+                } else {
+                    delete draft.lastUsedFeeLevel[action.symbol];
+                }
                 break;
             // no default
         }

--- a/yarn.lock
+++ b/yarn.lock
@@ -22828,10 +22828,10 @@ react-helmet-async@^1.0.2:
     react-fast-compare "2.0.4"
     shallowequal "1.1.0"
 
-react-hook-form@6.6.0:
-  version "6.6.0"
-  resolved "https://registry.yarnpkg.com/react-hook-form/-/react-hook-form-6.6.0.tgz#bda76fc50a916096afe18119f6f57f2b3911cdb7"
-  integrity sha512-5UKx2SBMaWuwy614H730Vv2QmoGdsdYpN96MnWXYzC8cHIUi9N2hYwtI86TEIcBHJ6FvEewh3onfA7P243RM1g==
+react-hook-form@6.7.1:
+  version "6.7.1"
+  resolved "https://registry.yarnpkg.com/react-hook-form/-/react-hook-form-6.7.1.tgz#58f1ce3ba6b0f3cb05b665a4cc268d0623ea9e1a"
+  integrity sha512-0I6NUPxdCVWIAbDhhmChusikDD70uUN9mXwtF4qClne8ECwlfhWZ4CBLMyPKjS1B5SmPAVMDWH8zhA3jTpzz+Q==
 
 react-hotkeys-hook@^1.5.4:
   version "1.5.4"


### PR DESCRIPTION
- update react-hook-form@6.7.1
- draft from reducer should be converted from read-only object
- lastUsedFeeLevel is cleared on "clear form" action