### PR TITLE
update account in IndexedDB onAccountvisibilityChange

### DIFF
--- a/packages/suite/src/actions/wallet/accountActions.ts
+++ b/packages/suite/src/actions/wallet/accountActions.ts
@@ -91,9 +91,12 @@ export const disableAccounts = () => (dispatch: Dispatch, getState: GetState) =>
     });
 };
 
-export const changeAccountVisibility = (payload: Account) => ({
+export const changeAccountVisibility = (payload: Account, visible = true) => ({
     type: ACCOUNT.CHANGE_VISIBILITY,
-    payload,
+    payload: {
+        ...payload,
+        visible,
+    },
 });
 
 export const fetchAndUpdateAccount = (account: Account) => async (

--- a/packages/suite/src/middlewares/wallet/storageMiddleware.ts
+++ b/packages/suite/src/middlewares/wallet/storageMiddleware.ts
@@ -35,6 +35,7 @@ const storageMiddleware = (api: MiddlewareAPI<Dispatch, AppState>) => (next: Dis
             break;
 
         case ACCOUNT.CREATE:
+        case ACCOUNT.CHANGE_VISIBILITY:
         case ACCOUNT.UPDATE: {
             const device = accountUtils.findAccountDevice(action.payload, api.getState().devices);
             // update only transactions for remembered device

--- a/packages/suite/src/reducers/wallet/accountsReducer.ts
+++ b/packages/suite/src/reducers/wallet/accountsReducer.ts
@@ -59,19 +59,6 @@ const create = (draft: Account[], account: Account) => {
     draft.push(account);
 };
 
-const changeVisibility = (draft: Account[], account: Account) => {
-    // TODO: extract the find filter condition to separate function
-    const index = draft.findIndex(
-        a =>
-            a.deviceState === account.deviceState &&
-            a.symbol === account.symbol &&
-            a.descriptor === account.descriptor,
-    );
-    if (draft[index]) {
-        draft[index].visible = true;
-    }
-};
-
 const remove = (draft: Account[], accounts: Account[]) => {
     accounts.forEach(a => {
         const index = draft.findIndex(
@@ -124,7 +111,7 @@ export default (state: Account[] = initialState, action: WalletAction | SuiteAct
                 update(draft, action.payload);
                 break;
             case ACCOUNT.CHANGE_VISIBILITY:
-                changeVisibility(draft, action.payload);
+                update(draft, action.payload);
                 break;
             case ACCOUNT.REMOVE:
                 remove(draft, action.payload);


### PR DESCRIPTION
Fix for unreported bug.

Steps to reproduce:
- discovery
- "remember device"
- add new account (any possible account type)
- wait to load
- refresh page

Result: account is not visible

