### PR TITLE
fix(send-form): multiple small fixes

### DIFF
--- a/packages/suite/src/hooks/wallet/useSendFormCompose.ts
+++ b/packages/suite/src/hooks/wallet/useSendFormCompose.ts
@@ -161,8 +161,6 @@ export const useSendFormCompose = ({
         // do nothing if there are no composedLevels
         if (!composedLevels) return;
 
-        console.warn('---post composeTransaction', composedLevels);
-
         const values = getValues();
         const { selectedFee } = values;
         let composed = composedLevels[selectedFee || 'normal'];

--- a/packages/suite/src/hooks/wallet/useSendFormFields.ts
+++ b/packages/suite/src/hooks/wallet/useSendFormFields.ts
@@ -106,8 +106,7 @@ export const useSendFormFields = ({
         [setValue, errors, clearErrors, setLastUsedFeeLevel],
     );
 
-    const changeCustomFeeLevel = (hasError: boolean) => {
-        if (hasError) return;
+    const changeCustomFeeLevel = () => {
         const { feePerUnit, feeLimit } = getValues();
         setLastUsedFeeLevel({ label: 'custom', feePerUnit, feeLimit, blocks: -1 });
     };

--- a/packages/suite/src/types/wallet/sendForm.ts
+++ b/packages/suite/src/types/wallet/sendForm.ts
@@ -170,7 +170,7 @@ export type SendContextValues = Omit<UseFormMethods<FormState>, 'register'> &
         calculateFiat: (outputIndex: number, amount?: string) => void;
         setAmount: (outputIndex: number, amount: string) => void;
         changeFeeLevel: (currentLevel: FeeLevel, newLevel: FeeLevel) => FieldError | void;
-        changeCustomFeeLevel: (fieldHasError: boolean) => void;
+        changeCustomFeeLevel: () => void;
         resetDefaultValue: (field: string) => void;
         setMax: (index: number, active: boolean) => void;
         getDefaultValue: GetDefaultValue;

--- a/packages/suite/src/views/wallet/send/components/Fees/components/CustomFee/index.tsx
+++ b/packages/suite/src/views/wallet/send/components/Fees/components/CustomFee/index.tsx
@@ -50,8 +50,8 @@ export default () => {
                 state={getInputState(feePerUnitError, feePerUnitValue)}
                 innerAddon={<Units>{getFeeUnits(network.networkType)}</Units>}
                 onChange={() => {
-                    changeCustomFeeLevel(!!feePerUnitError);
-                    composeTransaction('feePerUnit', !!feePerUnitError);
+                    changeCustomFeeLevel();
+                    composeTransaction('feePerUnit', false);
                 }}
                 name={inputName}
                 data-test={inputName}
@@ -63,7 +63,10 @@ export default () => {
                             return 'CUSTOM_FEE_IS_NOT_NUMBER';
                         }
                         // allow decimals in ETH since GWEI is not a satoshi
-                        if (network.networkType !== 'ethereum' && !feeBig.isInteger()) {
+                        if (
+                            network.networkType !== 'ethereum' &&
+                            (!feeBig.isInteger() || value.includes('.'))
+                        ) {
                             return 'CUSTOM_FEE_IS_NOT_INTEGER';
                         }
                         if (network.networkType === 'ethereum' && !isDecimalsValid(value, 9)) {

--- a/packages/suite/src/views/wallet/send/components/Outputs/components/Amount/components/Fiat/index.tsx
+++ b/packages/suite/src/views/wallet/send/components/Outputs/components/Amount/components/Fiat/index.tsx
@@ -43,6 +43,7 @@ export default ({ outputId }: { outputId: number }) => {
         setValue,
         localCurrencyOption,
         composeTransaction,
+        watch,
     } = useSendFormContext();
 
     const inputName = `outputs[${outputId}].fiat`;
@@ -55,8 +56,10 @@ export default ({ outputId }: { outputId: number }) => {
     const error = outputError ? outputError.fiat : undefined;
     const fiatValue = getDefaultValue(inputName, outputs[outputId].fiat || '');
     const tokenValue = getDefaultValue(tokenInputName, outputs[outputId].token);
-    const currencyValue =
-        getDefaultValue(currencyInputName, outputs[outputId].currency) || localCurrencyOption;
+    const currencyValue = watch(
+        currencyInputName,
+        getDefaultValue(currencyInputName, outputs[outputId].currency) || localCurrencyOption,
+    );
     const token = findToken(account.tokens, tokenValue);
     const decimals = token ? token.decimals : network.decimals;
 


### PR DESCRIPTION
- Fixed custom fee not updating estimate amount after an error.
- Added validation to reject decimals in custom fees.
- Removed console logging for transaction composing.
- Added watcher for currency switching to fix incorrect fiat amount displayed.

Refs: #2202