### PR TITLE
fix: move root definition inclusion

### DIFF
--- a/packages/suite-desktop/tsconfig.json
+++ b/packages/suite-desktop/tsconfig.json
@@ -15,6 +15,7 @@
         "isolatedModules": true
     },
     "include": [
+        "../../index.d.ts",
         "next-env.d.ts",
         "**/*.ts",
         "**/*.tsx"

--- a/packages/suite-web/tsconfig.json
+++ b/packages/suite-web/tsconfig.json
@@ -10,6 +10,11 @@
         "resolveJsonModule": true,
         "isolatedModules": true
     },
-    "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx"],
+    "include": [
+        "../../index.d.ts",
+        "next-env.d.ts",
+        "**/*.ts",
+        "**/*.tsx",
+    ],
     "exclude": ["test/**/*.*"]
 }

--- a/packages/suite/tsconfig.json
+++ b/packages/suite/tsconfig.json
@@ -16,5 +16,10 @@
         "resolveJsonModule": true,
         "isolatedModules": true
     },
-    "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx"]
+    "include": [
+        "../../index.d.ts",
+        "next-env.d.ts",
+        "**/*.ts",
+        "**/*.tsx",
+    ]
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -281,9 +281,6 @@
         "target": "ES2020",
         "noErrorTruncation": true,
     },
-    "files": [
-        "./index.d.ts"
-    ],
     "exclude": [
         "node_modules",
         "**/node_modules",


### PR DESCRIPTION
I'm not a huge fan of referencing the definitions in each file and by traveling back in directories. I couldn't get it to work from the root tsconfig file, it seems to override the `includes` property rather than merging it. 

If there's a better way to do this, please let me know.