### PR TITLE
Add support for .crypto resolution

### DIFF
--- a/packages/suite/package.json
+++ b/packages/suite/package.json
@@ -17,6 +17,7 @@
         "test-health": "jest -c jest.config.health.js"
     },
     "dependencies": {
+        "@ethersproject/abi": "^5.0.5",
         "@formatjs/intl-pluralrules": "^1.5.3",
         "@formatjs/intl-relativetimeformat": "^4.5.10",
         "@trezor/components": "^1.0.0",

--- a/packages/suite/src/config/wallet/networks.ts
+++ b/packages/suite/src/config/wallet/networks.ts
@@ -75,6 +75,7 @@ const networks = [
         bip44: "m/44'/60'/0'/0/i",
         hasSignVerify: true,
         decimals: 18,
+        web3: ['wss://eth2.trezor.io/geth'],
         explorer: {
             tx: 'https://eth1.trezor.io/tx/',
             account: 'https://eth1.trezor.io/address/',
@@ -315,6 +316,7 @@ type Network = {
     isHidden?: boolean;
     chainId?: number;
     hasSignVerify?: boolean;
+    web3?: string[];
 } & ArrayElement<typeof networks>;
 
 export default [...networks] as Network[];

--- a/packages/suite/src/utils/wallet/ethUtils.ts
+++ b/packages/suite/src/utils/wallet/ethUtils.ts
@@ -1,5 +1,7 @@
 import * as EthereumjsUtil from 'ethereumjs-util';
 import BigNumber from 'bignumber.js';
+import { Interface } from '@ethersproject/abi';
+import { getNetwork } from './accountUtils';
 
 export const decimalToHex = (dec: number): string => new BigNumber(dec).toString(16);
 
@@ -40,4 +42,100 @@ export const validateAddress = (address: string): string | null => {
 export const isHex = (str: string): boolean => {
     const regExp = /^(0x|0X)?[0-9A-Fa-f]+$/g;
     return regExp.test(str);
+};
+
+export const namehash = (domain: string): string => {
+    if (!domain) {
+        return '0x0000000000000000000000000000000000000000000000000000000000000000';
+    }
+    const [label, ...remainder] = domain.split('.');
+    return `0x${EthereumjsUtil.keccak256(
+        namehash(remainder.join('.')) + EthereumjsUtil.keccak256(label).toString('hex'),
+    ).toString('hex')}`;
+};
+
+export const resolveDomain = async (domain: string, ticker: string): Promise<string> => {
+    const tokenId = namehash(domain);
+    const coder = new Interface([
+        {
+            constant: true,
+            inputs: [
+                {
+                    name: 'keys',
+                    type: 'string[]',
+                },
+                {
+                    name: 'tokenId',
+                    type: 'uint256',
+                },
+            ],
+            name: 'getData',
+            outputs: [
+                {
+                    name: 'resolver',
+                    type: 'address',
+                },
+                {
+                    name: 'owner',
+                    type: 'address',
+                },
+                {
+                    name: 'values',
+                    type: 'string[]',
+                },
+            ],
+            payable: false,
+            stateMutability: 'view',
+            type: 'function',
+        },
+        {
+            constant: true,
+            inputs: [
+                { name: 'key', type: 'string' },
+                { name: 'tokenId', type: 'uint256' },
+            ],
+            name: 'get',
+            outputs: [{ name: '', type: 'string' }],
+            payable: false,
+            stateMutability: 'view',
+            type: 'function',
+        },
+    ]);
+    const inputParam = coder.encodeFunctionData('getData', [
+        [`crypto.${ticker.toUpperCase()}.address`],
+        tokenId,
+    ]);
+    const params = [
+        {
+            data: inputParam,
+            to: '0x7ea9Ee21077F84339eDa9C80048ec6db678642B1',
+        },
+        'latest',
+    ];
+    const request = {
+        jsonrpc: '2.0',
+        method: 'eth_call',
+        params,
+        id: 1,
+    };
+    const network = getNetwork('eth');
+    if (!network || !network.web3 || !network.web3.length) {
+        return '';
+    }
+    const socket = new WebSocket(network.web3[0]);
+    socket.onopen = () => {
+        socket.send(JSON.stringify(request));
+    };
+    return new Promise(resolve => {
+        socket.onmessage = e => {
+            try {
+                const data = JSON.parse(e.data);
+                const decoded = coder.decodeFunctionResult('getData', data.result);
+                resolve(decoded[2][0]);
+            } catch (e) {
+                resolve('');
+            }
+        };
+        socket.onerror = () => resolve('');
+    });
 };

--- a/packages/suite/src/utils/wallet/sendFormUtils.ts
+++ b/packages/suite/src/utils/wallet/sendFormUtils.ts
@@ -13,6 +13,7 @@ import {
 } from '@wallet-utils/accountUtils';
 import { Network, Account, CoinFiatRates } from '@wallet-types';
 import { FormState, FeeInfo, EthTransactionData, ExternalOutput } from '@wallet-types/sendForm';
+import { isValidAddress } from 'ethereumjs-util';
 
 export const calculateTotal = (amount: string, fee: string): string => {
     try {
@@ -162,11 +163,18 @@ export const getFeeLevels = (
     return networkType === 'ethereum' ? convertedEthLevels : initialLevels;
 };
 
-export const getInputState = (error?: FieldError, value?: string) => {
-    if (error) {
+export const getInputState = (
+    error?: FieldError,
+    value?: string,
+    resolvingDomain?: boolean,
+    resolvedDomain?: string,
+) => {
+    if (error || (resolvedDomain && value && !isValidAddress(value))) {
         return 'error';
     }
-
+    if (resolvingDomain) {
+        return 'warning';
+    }
     if (value && value.length > 0 && !error) {
         return 'success';
     }

--- a/yarn.lock
+++ b/yarn.lock
@@ -4647,6 +4647,103 @@
   resolved "https://registry.npmjs.org/@emotion/weak-memoize/-/weak-memoize-0.2.5.tgz#8eed982e2ee6f7f4e44c253e12962980791efd46"
   integrity sha512-6U71C2Wp7r5XtFtQzYrW5iKFT67OixrSxjI4MptCHzdSVlgabczzqLe0ZSgnub/5Kp4hSbpDB1tMytZY9pwxxA==
 
+"@ethersproject/abi@^5.0.5":
+  version "5.0.5"
+  resolved "https://registry.yarnpkg.com/@ethersproject/abi/-/abi-5.0.5.tgz#6e7bbf9d014791334233ba18da85331327354aa1"
+  integrity sha512-FNx6UMm0LnmCMFzN3urohFwZpjbUHPvc/O60h4qkF4yiJxLJ/G7QOSPjkHQ/q/QibagR4S7OKQawRy0NcvWa9w==
+  dependencies:
+    "@ethersproject/address" "^5.0.4"
+    "@ethersproject/bignumber" "^5.0.7"
+    "@ethersproject/bytes" "^5.0.4"
+    "@ethersproject/constants" "^5.0.4"
+    "@ethersproject/hash" "^5.0.4"
+    "@ethersproject/keccak256" "^5.0.3"
+    "@ethersproject/logger" "^5.0.5"
+    "@ethersproject/properties" "^5.0.3"
+    "@ethersproject/strings" "^5.0.4"
+
+"@ethersproject/address@^5.0.4":
+  version "5.0.4"
+  resolved "https://registry.yarnpkg.com/@ethersproject/address/-/address-5.0.4.tgz#8669bcbd02f4b64f4cede0a10e84df6d964ec9d3"
+  integrity sha512-CIjAeG6zNehbpJTi0sgwUvaH2ZICiAV9XkCBaFy5tjuEVFpQNeqd6f+B7RowcNO7Eut+QbhcQ5CVLkmP5zhL9A==
+  dependencies:
+    "@ethersproject/bignumber" "^5.0.7"
+    "@ethersproject/bytes" "^5.0.4"
+    "@ethersproject/keccak256" "^5.0.3"
+    "@ethersproject/logger" "^5.0.5"
+    "@ethersproject/rlp" "^5.0.3"
+    bn.js "^4.4.0"
+
+"@ethersproject/bignumber@^5.0.7":
+  version "5.0.7"
+  resolved "https://registry.yarnpkg.com/@ethersproject/bignumber/-/bignumber-5.0.7.tgz#720b3e3df3e125a99669ee869478106d0afe7b76"
+  integrity sha512-wwKgDJ+KA7IpgJwc8Fc0AjKIRuDskKA2cque29/+SgII9/1K/38JpqVNPKIovkLwTC2DDofIyzHcxeaKpMFouQ==
+  dependencies:
+    "@ethersproject/bytes" "^5.0.4"
+    "@ethersproject/logger" "^5.0.5"
+    bn.js "^4.4.0"
+
+"@ethersproject/bytes@^5.0.4":
+  version "5.0.4"
+  resolved "https://registry.yarnpkg.com/@ethersproject/bytes/-/bytes-5.0.4.tgz#328d9d929a3e970964ecf5d62e12568a187189f1"
+  integrity sha512-9R6A6l9JN8x1U4s1dJCR+9h3MZTT3xQofr/Xx8wbDvj6NnY4CbBB0o8ZgHXvR74yV90pY2EzCekpkMBJnRzkSw==
+  dependencies:
+    "@ethersproject/logger" "^5.0.5"
+
+"@ethersproject/constants@^5.0.4":
+  version "5.0.4"
+  resolved "https://registry.yarnpkg.com/@ethersproject/constants/-/constants-5.0.4.tgz#9ddaa5f3c738a94e5adc4b3f71b36206fa5cdf88"
+  integrity sha512-Df32lcXDHPgZRPgp1dgmByNbNe4Ki1QoXR+wU61on5nggQGTqWR1Bb7pp9VtI5Go9kyE/JflFc4Te6o9MvYt8A==
+  dependencies:
+    "@ethersproject/bignumber" "^5.0.7"
+
+"@ethersproject/hash@^5.0.4":
+  version "5.0.4"
+  resolved "https://registry.yarnpkg.com/@ethersproject/hash/-/hash-5.0.4.tgz#385642786405d236f3d2f1acdfaf250ab519cdac"
+  integrity sha512-VCs/bFBU8AQFhHcT1cQH6x7a4zjulR6fJmAOcPxUgrN7bxOQ7QkpBKF+YCDJhFtkLdaljIsr/r831TuWU4Ysfg==
+  dependencies:
+    "@ethersproject/bytes" "^5.0.4"
+    "@ethersproject/keccak256" "^5.0.3"
+    "@ethersproject/logger" "^5.0.5"
+    "@ethersproject/strings" "^5.0.4"
+
+"@ethersproject/keccak256@^5.0.3":
+  version "5.0.3"
+  resolved "https://registry.yarnpkg.com/@ethersproject/keccak256/-/keccak256-5.0.3.tgz#f094a8fca3bb913c044593c4f382be424292e588"
+  integrity sha512-VhW3mgZMBZlETV6AyOmjNeNG+Pg68igiKkPpat8/FZl0CKnfgQ+KZQZ/ee1vT+X0IUM8/djqnei6btmtbA27Ug==
+  dependencies:
+    "@ethersproject/bytes" "^5.0.4"
+    js-sha3 "0.5.7"
+
+"@ethersproject/logger@^5.0.5":
+  version "5.0.5"
+  resolved "https://registry.yarnpkg.com/@ethersproject/logger/-/logger-5.0.5.tgz#e3ba3d0bcf9f5be4da5f043b1e328eb98b80002f"
+  integrity sha512-gJj72WGzQhUtCk6kfvI8elTaPOQyMvrMghp/nbz0ivTo39fZ7IjypFh/ySDeUSdBNplAwhzWKKejQhdpyefg/w==
+
+"@ethersproject/properties@^5.0.3":
+  version "5.0.3"
+  resolved "https://registry.yarnpkg.com/@ethersproject/properties/-/properties-5.0.3.tgz#991aef39a5f87d4645cee76cec4df868bfb08be6"
+  integrity sha512-wLCSrbywkQgTO6tIF9ZdKsH9AIxPEqAJF/z5xcPkz1DK4mMAZgAXRNw1MrKYhyb+7CqNHbj3vxenNKFavGY/IA==
+  dependencies:
+    "@ethersproject/logger" "^5.0.5"
+
+"@ethersproject/rlp@^5.0.3":
+  version "5.0.3"
+  resolved "https://registry.yarnpkg.com/@ethersproject/rlp/-/rlp-5.0.3.tgz#841a5edfdf725f92155fe74424f5510c9043c13a"
+  integrity sha512-Hz4yyA/ilGafASAqtTlLWkA/YqwhQmhbDAq2LSIp1AJNx+wtbKWFAKSckpeZ+WG/xZmT+fw5OFKK7a5IZ4DR5g==
+  dependencies:
+    "@ethersproject/bytes" "^5.0.4"
+    "@ethersproject/logger" "^5.0.5"
+
+"@ethersproject/strings@^5.0.4":
+  version "5.0.4"
+  resolved "https://registry.yarnpkg.com/@ethersproject/strings/-/strings-5.0.4.tgz#67cda604eee3ffcc004cb9f3bd03516e1c7b09a0"
+  integrity sha512-azXFHaNkDXzefhr4LVVzzDMFwj3kH9EOKlATu51HjxabQafuUyVLPFgmxRFmCynnAi0Bmmp7nr+qK1pVDgRDLQ==
+  dependencies:
+    "@ethersproject/bytes" "^5.0.4"
+    "@ethersproject/constants" "^5.0.4"
+    "@ethersproject/logger" "^5.0.5"
+
 "@evocateur/libnpmaccess@^3.1.2":
   version "3.1.2"
   resolved "https://registry.yarnpkg.com/@evocateur/libnpmaccess/-/libnpmaccess-3.1.2.tgz#ecf7f6ce6b004e9f942b098d92200be4a4b1c845"
@@ -17902,6 +17999,11 @@ js-library-detector@^5.5.0:
   version "5.8.0"
   resolved "https://registry.yarnpkg.com/js-library-detector/-/js-library-detector-5.8.0.tgz#28a72d81e7acf4992b8f932b3a80c34cd197959d"
   integrity sha512-7H10W+oukLGvs5gT5SeMjqYX03rglIQt3ggXzRiQxveUkVupHhbrd2mGPTKQ87bxSvMzlnAMdExfCDnquUi93Q==
+
+js-sha3@0.5.7:
+  version "0.5.7"
+  resolved "https://registry.yarnpkg.com/js-sha3/-/js-sha3-0.5.7.tgz#0d4ffd8002d5333aabaf4a23eed2f6374c9f28e7"
+  integrity sha1-DU/9gALVMzqrr0oj7tL2N0yfKOc=
 
 js-sha3@0.8.0, js-sha3@^0.8.0:
   version "0.8.0"


### PR DESCRIPTION
I’m submitting a pull request to add support for sending crypto via blockchain domains in Trezor Wallet. Trezor Wallet is consistently one of the most requested integrations by our users. You can find a list of wallets that currently support this functionality on our website - https://unstoppabledomains.com/. We have registered over 300,000 .crypto and .zil domains since last March. We are also happy to provide your team with a grant to compensate for any time you spend on this PR.

To test, enter brad.crypto into the address field when sending from Ethereum Wallet

This PR adds a single dependency for ABI encoding/decoding - @ethersproject/abi