### PR TITLE
docs: generate docs screenshots from tests

### DIFF
--- a/packages/integration-tests/projects/suite-web/support/commands.ts
+++ b/packages/integration-tests/projects/suite-web/support/commands.ts
@@ -9,6 +9,7 @@ import { connectBootloaderDevice, connectDevice, changeDevice } from './utils/de
 import { getTestElement, getConfirmActionOnDeviceModal } from './utils/selectors';
 import { resetDb, setState } from './utils/test-env';
 import { toggleDeviceMenu, goToOnboarding, passThroughInitialRun, passThroughBackup, passThroughInitMetadata } from './utils/shortcuts';
+import { captureDocScreenshot } from './utils/docs';
 
 const command = require('cypress-image-snapshot/command');
 
@@ -43,6 +44,7 @@ declare global {
             passThroughBackup: () => Chainable<Subject>;
             passThroughInitMetadata: () => Chainable<Subject>;
             goToOnboarding: () => Chainable<Subject>;
+            captureDocScreenshot: typeof captureDocScreenshot;
         }
     }
 }
@@ -83,3 +85,5 @@ Cypress.Commands.add('goToOnboarding', goToOnboarding);
 Cypress.Commands.add('passThroughInitialRun', passThroughInitialRun);
 Cypress.Commands.add('passThroughBackup', passThroughBackup);
 Cypress.Commands.add('passThroughInitMetadata', passThroughInitMetadata);
+// docs
+Cypress.Commands.add('captureDocScreenshot', captureDocScreenshot);

--- a/packages/integration-tests/projects/suite-web/support/utils/docs.ts
+++ b/packages/integration-tests/projects/suite-web/support/utils/docs.ts
@@ -1,0 +1,12 @@
+/**
+ * utility command used to create screenshot with area defined by dataTest param highlighted
+ */
+export const captureDocScreenshot = (dataTest: string, screenshotOptions?: Cypress.ScreenshotOptions) => {
+    cy.getTestElement(dataTest).then(($el) => {
+        const origBorder = $el.css('border'); 
+        $el.css('border', '4px solid red');
+        cy.screenshot(screenshotOptions || {}).then(() => {
+            $el.css('border', origBorder);
+        });
+    })
+}


### PR DESCRIPTION
I started to write some documentation on metadata and got an idea how to automate proces of creating screenshots for it. But as it is out of the scope of work there, I am creating this standalone PR for later.

![image](https://user-images.githubusercontent.com/30367552/93510565-ad99db80-f921-11ea-8143-9faca8936ee1.png)
