### PR TITLE
suite-storage: add upsert param to addItem

### DIFF
--- a/packages/suite-storage/src/native/index.ts
+++ b/packages/suite-storage/src/native/index.ts
@@ -88,6 +88,7 @@ class CommonDB<TDBStructure> {
     >(
         _store: TStoreName,
         _item: TItem,
+        _key?: TKey,
         _upsert?: boolean
     ): Promise<StoreKey<TDBStructure, TStoreName>> => {
         // @ts-ignore

--- a/packages/suite-storage/src/native/index.ts
+++ b/packages/suite-storage/src/native/index.ts
@@ -88,7 +88,7 @@ class CommonDB<TDBStructure> {
     >(
         _store: TStoreName,
         _item: TItem,
-        _key?: TKey
+        _upsert?: boolean
     ): Promise<StoreKey<TDBStructure, TStoreName>> => {
         // @ts-ignore
         return Promise.resolve();

--- a/packages/suite-storage/src/web/index.ts
+++ b/packages/suite-storage/src/web/index.ts
@@ -145,7 +145,7 @@ class CommonDB<TDBStructure> {
 
         const p = new Promise<StoreKey<TDBStructure, TStoreName>>((resolve, reject) => {
             const tx = db.transaction(storeName, 'readwrite');
-            const params: [TItem, TKey | undefined] = key? [item, key] : [item, undefined]
+            const params: [TItem, TKey | undefined] = key ? [item, key] : [item, undefined];
             const req: IDBRequest = upsert
                 ? tx.objectStore(storeName).put(...params)
                 : tx.objectStore(storeName).add(...params);

--- a/packages/suite-storage/src/web/index.ts
+++ b/packages/suite-storage/src/web/index.ts
@@ -132,6 +132,7 @@ class CommonDB<TDBStructure> {
     >(
         store: TStoreName,
         item: TItem,
+        key?: TKey,
         upsert?: boolean
     ): Promise<StoreKey<TDBStructure, TStoreName>> => {
         // TODO: When using idb wrapper something throws 'Uncaught (in promise) null'
@@ -144,9 +145,10 @@ class CommonDB<TDBStructure> {
 
         const p = new Promise<StoreKey<TDBStructure, TStoreName>>((resolve, reject) => {
             const tx = db.transaction(storeName, 'readwrite');
+            const params: [TItem, TKey | undefined] = key? [item, key] : [item, undefined]
             const req: IDBRequest = upsert
-                ? tx.objectStore(storeName).put(item)
-                : tx.objectStore(storeName).add(item);
+                ? tx.objectStore(storeName).put(...params)
+                : tx.objectStore(storeName).add(...params);
             req.onerror = _event => {
                 reject(req.error);
             };

--- a/packages/suite-storage/src/web/index.ts
+++ b/packages/suite-storage/src/web/index.ts
@@ -132,7 +132,7 @@ class CommonDB<TDBStructure> {
     >(
         store: TStoreName,
         item: TItem,
-        key?: TKey
+        upsert?: boolean
     ): Promise<StoreKey<TDBStructure, TStoreName>> => {
         // TODO: When using idb wrapper something throws 'Uncaught (in promise) null'
         // and I couldn't figure out how to catch it. Maybe a bug in idb?
@@ -144,8 +144,8 @@ class CommonDB<TDBStructure> {
 
         const p = new Promise<StoreKey<TDBStructure, TStoreName>>((resolve, reject) => {
             const tx = db.transaction(storeName, 'readwrite');
-            const req: IDBRequest = key
-                ? tx.objectStore(storeName).put(item, key)
+            const req: IDBRequest = upsert
+                ? tx.objectStore(storeName).put(item)
                 : tx.objectStore(storeName).add(item);
             req.onerror = _event => {
                 reject(req.error);

--- a/packages/suite/src/actions/suite/storageActions.ts
+++ b/packages/suite/src/actions/suite/storageActions.ts
@@ -22,7 +22,7 @@ export type StorageActions =
 // send form drafts start
 
 export const saveDraft = (formState: FormState, accountKey: string) => {
-    return db.addItem('sendFormDrafts', formState, accountKey);
+    return db.addItem('sendFormDrafts', formState, accountKey, true);
 };
 
 export const removeDraft = (accountKey: string) => {
@@ -33,7 +33,7 @@ export const saveAccountDraft = (account: Account) => async (_: Dispatch, getSta
     const { drafts } = getState().wallet.send;
     const draft = drafts[account.key];
     if (draft) {
-        return db.addItem('sendFormDrafts', draft, account.key);
+        return db.addItem('sendFormDrafts', draft, account.key, true);
     }
 };
 
@@ -45,7 +45,7 @@ export const removeAccountDraft = (account: Account) => {
 
 export const saveDevice = async (device: TrezorDevice) => {
     if (!device || !device.features || !device.state) return;
-    return db.addItem('devices', serializeDevice(device), device.state);
+    return db.addItem('devices', serializeDevice(device), device.state, true);
 };
 
 export const removeAccount = async (account: Account) => {
@@ -157,6 +157,7 @@ export const saveWalletSettings = () => async (_dispatch: Dispatch, getState: Ge
             ...getState().wallet.settings,
         },
         'wallet',
+        true,
     );
 };
 
@@ -184,6 +185,7 @@ export const saveSuiteSettings = () => (_dispatch: Dispatch, getState: GetState)
             },
         },
         'suite',
+        true,
     );
 };
 
@@ -196,12 +198,18 @@ export const saveAnalytics = () => (_dispatch: Dispatch, getState: GetState) => 
             instanceId: analytics.instanceId,
         },
         'suite',
+        true,
     );
 };
 
 export const saveMetadataProvider = () => (_dispatch: Dispatch, getState: GetState) => {
     const { metadata } = getState();
-    db.addItem('metadata', { provider: metadata.provider, enabled: metadata.enabled }, 'state');
+    db.addItem(
+        'metadata',
+        { provider: metadata.provider, enabled: metadata.enabled },
+        'state',
+        true,
+    );
 };
 
 export const removeDatabase = () => async (dispatch: Dispatch, getState: GetState) => {


### PR DESCRIPTION
Folks from Invity have found an issue.

problem:  `key` param in `addItem` acted like an upsert. Without specifying the param (eg in cases where key is auto generated using keyPath) the method would fail on adding entry with the same key. What's worse, IDB doesn't even allow to add item with passed `key` prop if object store was created with keyPath definition. Thus there was no way to force an upsert if you created object store with keyPath definition.

solution:  this PR adds separate `upsert` param to `addItem`, which is more in line with usage of `getItems` method