### PR TITLE
feat: progress-bar natively in Modal component

### DIFF
--- a/packages/components/src/components/Modal/index.stories.tsx
+++ b/packages/components/src/components/Modal/index.stories.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 import styled from 'styled-components';
 import { storiesOf } from '@storybook/react';
 import { ConfirmOnDevice, Modal } from '../../index';
-import { text, boolean } from '@storybook/addon-knobs';
+import { text, boolean, number } from '@storybook/addon-knobs';
 
 const Wrapper = styled.div`
     background: black;
@@ -26,6 +26,9 @@ storiesOf('Modals', module)
             const useFixedHeight = boolean('useFixedHeight', false);
             const showHeaderBorder = boolean('showHeaderBorder', true);
             const noPadding = boolean('noPadding', false);
+            const hiddenProgressBar = boolean('hiddenProgressBar', false);
+            const totalProgressBarSteps = number('totalProgressBarSteps', 0);
+            const currentProgressBarStep = number('currentProgressBarStep', 0);
 
             return (
                 <Wrapper>
@@ -39,6 +42,9 @@ storiesOf('Modals', module)
                         useFixedHeight={useFixedHeight}
                         showHeaderBorder={showHeaderBorder}
                         noPadding={noPadding}
+                        hiddenProgressBar={hiddenProgressBar}
+                        totalProgressBarSteps={totalProgressBarSteps}
+                        currentProgressBarStep={currentProgressBarStep}
                     >
                         {children}
                     </Modal>

--- a/packages/components/src/components/Modal/index.tsx
+++ b/packages/components/src/components/Modal/index.tsx
@@ -219,8 +219,7 @@ const ProgressBarPlaceholder = styled.div<{ hiddenProgressBar: boolean }>`
 const GreenBar = styled.div<{ width: number }>`
     height: 4px;
     position: relative;
-    background-color: ${colors.GREEN};
-    z-index: 3;
+    background-color: ${colors.NEUE_BG_GREEN};
     transition: all 0.5s;
     width: ${props => `${props.width}%`};
 `;
@@ -407,11 +406,11 @@ const Modal = ({
         hiddenProgressBar ||
         (totalProgressBarSteps !== undefined && currentProgressBarStep !== undefined);
 
+    console.log('showProgressBarPlaceholder', showProgressBarPlaceholder);
     // compute progress bar width if all data is available and hiddenProgressBar is not selected
     let progressBarWidth = null;
     if (!hiddenProgressBar && totalProgressBarSteps && currentProgressBarStep) {
-        const progress = (100 / totalProgressBarSteps) * currentProgressBarStep;
-        progressBarWidth = Math.min(Math.max(progress - 5, 0), 100);
+        progressBarWidth = (100 / totalProgressBarSteps) * currentProgressBarStep;
     }
 
     if (cancelable && onCancel && escPressed) {


### PR DESCRIPTION
Fix part of https://github.com/trezor/trezor-suite/issues/2326

Modal component has three more props that allow it to display progress bar natively. 

1.     hiddenProgressBar: boolean;
2.     totalProgressBarSteps: number;
3.     currentProgressBarStep: number;

`hiddenProgressBar` prop is useful in a situation when we don't want the modal to change it's height once the progress bar is not present any more. `hiddenProgressBar` takes the same vertical space as regular progress bar, but the bar is not shown.