### PR TITLE
fix: account name overflow in accounts menu

### DIFF
--- a/packages/suite/src/components/wallet/AccountsMenu/components/AccountItem/index.tsx
+++ b/packages/suite/src/components/wallet/AccountsMenu/components/AccountItem/index.tsx
@@ -38,6 +38,7 @@ const Right = styled.div`
     display: flex;
     flex-direction: column;
     margin-left: 8px;
+    overflow: hidden;
 `;
 
 const Row = styled.div`


### PR DESCRIPTION
part of https://github.com/trezor/trezor-suite/issues/2283
<img width="369" alt="Screenshot 2020-09-23 at 16 18 01" src="https://user-images.githubusercontent.com/6961901/94025441-c8a09b80-fdb8-11ea-82f0-48bccd4976d9.png">
