### PR TITLE
fix: setLayout called from useEffect instead of useMemo

### DIFF
--- a/packages/suite/src/components/settings/SettingsLayout/index.tsx
+++ b/packages/suite/src/components/settings/SettingsLayout/index.tsx
@@ -18,7 +18,7 @@ type Props = {
 const SettingsLayout = (props: Props) => {
     const { setLayout } = React.useContext(LayoutContext);
 
-    React.useMemo(() => {
+    React.useEffect(() => {
         if (setLayout) setLayout(props.title || 'Settings', null, <SettingsMenu />);
     }, [props.title, setLayout]);
 

--- a/packages/suite/src/components/wallet/WalletLayout/index.tsx
+++ b/packages/suite/src/components/wallet/WalletLayout/index.tsx
@@ -27,7 +27,7 @@ type Props = {
 
 const WalletLayout = (props: Props) => {
     const { setLayout } = React.useContext(LayoutContext);
-    React.useMemo(() => {
+    React.useEffect(() => {
         if (setLayout)
             setLayout(
                 props.title || 'Trezor Suite | Wallet',

--- a/packages/suite/src/views/dashboard/index.tsx
+++ b/packages/suite/src/views/dashboard/index.tsx
@@ -21,7 +21,7 @@ const Dashboard = () => {
     // set SuiteLayout
     const { setLayout } = React.useContext(LayoutContext);
 
-    React.useMemo(() => {
+    React.useEffect(() => {
         if (setLayout) setLayout(undefined, undefined);
     }, [setLayout]);
 

--- a/packages/suite/src/views/passwords/index.tsx
+++ b/packages/suite/src/views/passwords/index.tsx
@@ -15,7 +15,7 @@ const Placeholder = styled.div`
 
 const Passwords = () => {
     const { setLayout } = React.useContext(LayoutContext);
-    React.useMemo(() => {
+    React.useEffect(() => {
         if (setLayout) setLayout('Passwords', undefined);
     }, [setLayout]);
 

--- a/packages/suite/src/views/portfolio/index.tsx
+++ b/packages/suite/src/views/portfolio/index.tsx
@@ -15,7 +15,7 @@ const Placeholder = styled.div`
 
 const Portfolio = () => {
     const { setLayout } = React.useContext(LayoutContext);
-    React.useMemo(() => {
+    React.useEffect(() => {
         if (setLayout) setLayout('Portfolio', undefined);
     }, [setLayout]);
 

--- a/packages/suite/src/views/suite/notifications/index.tsx
+++ b/packages/suite/src/views/suite/notifications/index.tsx
@@ -100,7 +100,7 @@ const Notifications = (props: Props) => {
     const { notifications } = props;
 
     const { setLayout } = React.useContext(LayoutContext);
-    React.useMemo(() => {
+    React.useEffect(() => {
         if (setLayout) setLayout('Notifications', undefined);
     }, [setLayout]);
 


### PR DESCRIPTION
fix for React.render warning introduced by react dependency update

`setLayout` function which sets title, menu and submenu in upper-scope component ([SuiteLayout](https://github.com/trezor/trezor-suite/blob/develop/packages/suite/src/components/suite/SuiteLayout/index.tsx#L144-L151)) was called from lower scope "sub-layouts" components (like [WalletLayout](https://github.com/trezor/trezor-suite/blob/develop/packages/suite/src/components/wallet/WalletLayout/index.tsx#L30-L37)) using `useMemo` (idk why...) instead of `useEffect` hook and causes console warning during first render

![Screenshot 2020-09-23 at 16 39 56](https://user-images.githubusercontent.com/3435913/94028617-45814480-fdbc-11ea-8487-118e08d44e83.png)
