### PR TITLE
fix(send): setmax with multiple outputs

### DIFF
--- a/packages/suite/src/hooks/wallet/useSendFormFields.ts
+++ b/packages/suite/src/hooks/wallet/useSendFormFields.ts
@@ -5,7 +5,6 @@ import * as walletSettingsActions from '@settings-actions/walletSettingsActions'
 import { useActions } from '@suite-hooks';
 import { toFiatCurrency } from '@wallet-utils/fiatConverterUtils';
 import {
-    Output,
     FormState,
     FormOptions,
     UseSendFormState,
@@ -32,10 +31,11 @@ export const useSendFormFields = ({
     });
     const calculateFiat = useCallback(
         (outputIndex: number, amount?: string) => {
-            const output = getValues(`outputs[${outputIndex}]`) as Output;
+            const { outputs } = getValues();
+            const output = outputs ? outputs[outputIndex] : undefined;
             if (!output || output.type !== 'payment') return;
             const { fiat, currency } = output;
-            if (typeof fiat !== 'string') return; // fiat input not registered (testnet? fiat not available?)
+            if (typeof fiat !== 'string') return; // fiat input not registered (testnet or fiat not available)
             const inputName = `outputs[${outputIndex}].fiat`;
             if (!amount) {
                 // reset fiat value (Amount field has error)


### PR DESCRIPTION
Hopefully ultimate fix #2414 :)
note:
`react-hook-form` returns different (sometimes incomplete) values with different usage:

- `getValues()` <- ~~this one returns partial `Output`~~ (already [fixed](https://github.com/trezor/trezor-suite/commit/1d28c1574f7fd06fa1f155e543f51be10313c093) once by following usage)
- `getValues('outputs[x]')` <- this one also returns partial `Output` object (currency is missing, reported [here](https://github.com/trezor/trezor-suite/issues/2414))
- `getValues('outputs')[x]` <- this one also returns partial `Output` and looks ugly :)

EDIT:
i've ended up reverting the fix from usage 1 since i couldn't replicate the issue (compose draft without Amount set)
fingers crossed