### PR TITLE
Drop "-beta" from version string

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 # Changelog
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/). [YY.MM.MICRO]
 
-## [20.10.1-beta]
+## [20.10.1]
 
 ### Added
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "trezor-suite",
-    "version": "20.10.1-beta",
+    "version": "20.10.1",
     "private": true,
     "repository": "https://github.com/trezor/trezor-suite.git",
     "license": "SEE LICENSE IN LICENSE.md",

--- a/packages/landing-page/package.json
+++ b/packages/landing-page/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@trezor/landing-page",
-    "version": "20.10.1-beta",
+    "version": "20.10.1",
     "private": true,
     "scripts": {
         "type-check": "tsc --project tsconfig.json",

--- a/packages/suite-data/package.json
+++ b/packages/suite-data/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@trezor/suite-data",
-    "version": "20.10.1-beta",
+    "version": "20.10.1",
     "author": "Trezor <info@trezor.io>",
     "keywords": [
         "Trezor",

--- a/packages/suite-desktop/package.json
+++ b/packages/suite-desktop/package.json
@@ -1,7 +1,7 @@
 {
     "name": "@trezor/suite-desktop",
     "description": "Trezor Suite desktop application",
-    "version": "20.10.1-beta",
+    "version": "20.10.1",
     "private": true,
     "author": "SatoshiLabs <info@satoshilabs.com>",
     "homepage": "https://trezor.io/",

--- a/packages/suite-native/package.json
+++ b/packages/suite-native/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@trezor/suite-native",
-    "version": "20.10.1-beta",
+    "version": "20.10.1",
     "private": true,
     "scripts": {
         "dev:ios": "run-p start run-ios",
@@ -19,7 +19,7 @@
     },
     "dependencies": {
         "@trezor/components": "^1.0.0",
-        "@trezor/suite-storage": "20.10.1-beta",
+        "@trezor/suite-storage": "20.10.1",
         "react": "16.13.1",
         "react-native": "0.63.2",
         "react-native-gesture-handler": "^1.5.2",

--- a/packages/suite-storage/package.json
+++ b/packages/suite-storage/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@trezor/suite-storage",
-    "version": "20.10.1-beta",
+    "version": "20.10.1",
     "author": "Trezor <info@trezor.io>",
     "private": true,
     "keywords": [

--- a/packages/suite-web/package.json
+++ b/packages/suite-web/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@trezor/suite-web",
-    "version": "20.10.1-beta",
+    "version": "20.10.1",
     "private": true,
     "scripts": {
         "type-check": "tsc --project tsconfig.json",
@@ -16,7 +16,7 @@
     "dependencies": {
         "@sentry/browser": "^5.16.0",
         "@sentry/integrations": "^5.16.0",
-        "@trezor/suite": "20.10.1-beta",
+        "@trezor/suite": "20.10.1",
         "@zeit/next-workers": "^1.0.0",
         "next": "^9.5.3",
         "next-redux-wrapper": "^5.0.0",

--- a/packages/suite/package.json
+++ b/packages/suite/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@trezor/suite",
-    "version": "20.10.1-beta",
+    "version": "20.10.1",
     "private": true,
     "scripts": {
         "lint": "yarn lint:styles && yarn lint:js",
@@ -20,8 +20,8 @@
         "@formatjs/intl-pluralrules": "^1.5.3",
         "@formatjs/intl-relativetimeformat": "^4.5.10",
         "@trezor/components": "^1.0.0",
-        "@trezor/suite-data": "20.10.1-beta",
-        "@trezor/suite-storage": "20.10.1-beta",
+        "@trezor/suite-data": "20.10.1",
+        "@trezor/suite-storage": "20.10.1",
         "@types/zxcvbn": "^4.4.0",
         "bignumber.js": "^9.0.0",
         "color-hash": "^1.0.3",


### PR DESCRIPTION
As discussed on Slack, we want to drop the `-beta` from the version string.