### PR TITLE
fix: use greater z-index than one in NavigationBar

### DIFF
--- a/packages/suite/src/components/wallet/DiscoveryProgress/index.tsx
+++ b/packages/suite/src/components/wallet/DiscoveryProgress/index.tsx
@@ -9,7 +9,7 @@ const Wrapper = styled.div`
     top: 0;
     width: 100%;
     height: 2px;
-    z-index: 3;
+    z-index: 4;
     background: ${colors.WHITE};
     overflow: hidden;
 `;


### PR DESCRIPTION
Progress bar for account discovery wasn't visible as NavigationBar has greater z-index. 🎉 