### PR TITLE
ci(suite-web): reorganize build and deploy tasks

### DIFF
--- a/ci/packages/components.yml
+++ b/ci/packages/components.yml
@@ -20,11 +20,8 @@ components storybook deploy dev:
     url: $BASE_REVIEW_URL/${CI_BUILD_REF_NAME}
   before_script: []
   script:
-    - cd packages/components
-    - echo "Deploy to dev servers"
-    - mkdir -p ${DEPLOY_BASE_DIR}/components
-    - mkdir -p ${DEPLOY_DIRECTORY} # create build folder
-    - rsync --delete -va .build-storybook/ "${DEPLOY_DIRECTORY}/"
+    - mkdir -p ${DEPLOY_DIRECTORY}
+    - rsync --delete -va packages/components/.build-storybook/ "${DEPLOY_DIRECTORY}/"
   tags:
     - deploy
 

--- a/ci/packages/landing-page.yml
+++ b/ci/packages/landing-page.yml
@@ -4,7 +4,7 @@
     - releases
     - schedules
 
-landing-page build:
+landing-page build dev:
   stage: build
   script:
     - assetPrefix=/suite-web/${CI_BUILD_REF_NAME} yarn workspace @trezor/landing-page build
@@ -13,32 +13,49 @@ landing-page build:
     paths:
       - packages/landing-page/build
 
-landing-page build-staging:
+landing-page build beta:
   stage: build
   only:
     <<: *auto_run_branches
   script:
-    - yarn workspace @trezor/landing-page build
+    - assetPrefix=/wallet yarn workspace @trezor/landing-page build
   artifacts:
     expire_in: 7 days
     paths:
       - packages/landing-page/scripts/s3sync.sh
       - packages/landing-page/build
 
-landing-page deploy-staging:
+landing-page deploy staging-wallet:
   stage: deploy to staging
   only:
     <<: *auto_run_branches
   dependencies:
-    - landing-page build-staging
+    - landing-page build beta
   environment:
     name: ${CI_BUILD_REF_NAME}-staging
-    url: ${STAGING_SERVER_URL}
+    url: ${STAGING_WALLET_SERVER_URL}
   before_script: []
   when: manual
   script:
-    - source ${STAGING_DEPLOY_KEYFILE}
+    - source ${STAGING_WALLET_DEPLOY_KEYFILE}
     - cd packages/landing-page
-    - ./scripts/s3sync.sh stage beta
+    - ./scripts/s3sync.sh staging-wallet
+  tags:
+    - deploy
+
+landing-page deploy dev:
+  stage: deploy to dev servers
+  variables:
+    DEPLOY_DIRECTORY: ${DEPLOY_BASE_DIR}/landing-page/${CI_BUILD_REF_NAME}
+  dependencies:
+    - install and build
+    - landing-page build dev
+  environment:
+    name: ${CI_BUILD_REF_NAME}
+    url: $BASE_REVIEW_URL/${CI_BUILD_REF_NAME}
+  before_script: []
+  script:
+    - mkdir -p ${DEPLOY_DIRECTORY}
+    - rsync --delete -va packages/landing-page/build/ "${DEPLOY_DIRECTORY}/"
   tags:
     - deploy

--- a/ci/packages/suite-native.yml
+++ b/ci/packages/suite-native.yml
@@ -16,7 +16,7 @@ suite-native build android:
         paths:
             - app-release.apk
 
-suite-native deploy:
+suite-native deploy dev:
     stage: deploy to dev
     only:
         refs:

--- a/ci/packages/suite-web-landing.yml
+++ b/ci/packages/suite-web-landing.yml
@@ -4,7 +4,7 @@
     - releases
     - schedules
 
-suite-web-landing build:
+suite-web-landing build dev:
   stage: build
   script:
     - assetPrefix=/suite-web-landing/${CI_BUILD_REF_NAME} yarn workspace @trezor/suite-web-landing build
@@ -13,35 +13,35 @@ suite-web-landing build:
     paths:
       - packages/suite-web-landing/build
 
-# suite-web-landing build-staging:
-#   stage: build
-#   only:
-#     <<: *auto_run_branches
-#   script:
-#     - yarn workspace @trezor/suite-web-landing build
-#   artifacts:
-#     expire_in: 7 days
-#     paths:
-#       - packages/suite-web-landing/scripts/s3sync.sh
-#       - packages/suite-web-landing/build
+suite-web-landing build stable:
+  stage: build
+  only:
+    <<: *auto_run_branches
+  script:
+    - yarn workspace @trezor/suite-web-landing build
+  artifacts:
+    expire_in: 7 days
+    paths:
+      - packages/suite-web-landing/scripts/s3sync.sh
+      - packages/suite-web-landing/build
 
-# suite-web-landing deploy-staging:
-#   stage: deploy to staging
-#   only:
-#     <<: *auto_run_branches
-#   dependencies:
-#     - suite-web-landing build-staging
-#   environment:
-#     name: ${CI_BUILD_REF_NAME}-staging
-#     url: ${STAGING_SERVER_URL}
-#   before_script: []
-#   when: manual
-#   script:
-#     - source ${STAGING_DEPLOY_KEYFILE}
-#     - cd packages/suite-web-landing
-#     - ./scripts/s3sync.sh stage beta
-#   tags:
-#     - deploy
+suite-web-landing deploy staging-suite:
+  stage: deploy to staging
+  only:
+    <<: *auto_run_branches
+  dependencies:
+    - suite-web-landing build stable
+  environment:
+    name: ${CI_BUILD_REF_NAME}-staging
+    url: ${STAGING_SUITE_SERVER_URL}
+  before_script: []
+  when: manual
+  script:
+    - source ${STAGING_SUITE_DEPLOY_KEYFILE}
+    - cd packages/suite-web-landing
+    - ./scripts/s3sync.sh staging-suite
+  tags:
+    - deploy
 
 suite-web-landing deploy dev:
   stage: deploy to dev servers
@@ -49,17 +49,13 @@ suite-web-landing deploy dev:
     DEPLOY_DIRECTORY: ${DEPLOY_BASE_DIR}/suite-web-landing/${CI_BUILD_REF_NAME}
   dependencies:
     - install and build
-    - suite-web-landing build
+    - suite-web-landing build dev
   environment:
     name: ${CI_BUILD_REF_NAME}
     url: $BASE_REVIEW_URL/${CI_BUILD_REF_NAME}
   before_script: []
   script:
-    - cd packages/suite-web-landing
-    - echo "Deploy to dev servers"
-    - mkdir -p ${DEPLOY_BASE_DIR}/suite-web-landing
-    - mkdir -p ${DEPLOY_DIRECTORY} # create build folder
-    - rsync --delete -va build/ "${DEPLOY_DIRECTORY}/"
-
+    - mkdir -p ${DEPLOY_DIRECTORY}
+    - rsync --delete -va packages/suite-web-landing/build/ "${DEPLOY_DIRECTORY}/"
   tags:
     - deploy

--- a/ci/packages/suite-web.yml
+++ b/ci/packages/suite-web.yml
@@ -17,38 +17,37 @@ variables:
 
 .e2e_script_common: &e2e_script_common
     - npx cypress install
-    - export CYPRESS_ASSET_PREFIX=/wallet
+    - export CYPRESS_ASSET_PREFIX=/web
     - export CYPRESS_baseUrl=${DEV_SERVER_URL}/suite-web/${CI_BUILD_REF_NAME}
     - export TRACK_SUITE_URL=https://track-suite.herokuapp.com
 
-suite-web build:
+suite-web build dev:
     stage: build
     script:
-        - assetPrefix=/suite-web/${CI_BUILD_REF_NAME}/wallet yarn workspace @trezor/suite-web build
+        - assetPrefix=/suite-web/${CI_BUILD_REF_NAME}/web yarn workspace @trezor/suite-web build
     artifacts:
         expire_in: 7 days
         paths:
             - packages/suite-web/build
 
-suite-web build-staging:
+suite-web build beta:
     stage: build
     only:
         <<: *auto_run_branches
     script:
-        - assetPrefix=/wallet yarn workspace @trezor/suite-web build
+        - assetPrefix=/wallet/web yarn workspace @trezor/suite-web build
     artifacts:
         expire_in: 7 days
         paths:
             - packages/suite-web/scripts/s3sync.sh
             - packages/suite-web/build
 
-suite-web build-staging manual:
+suite-web build stable:
     stage: build
-    when: manual
-    except:
+    only:
         <<: *auto_run_branches
     script:
-        - assetPrefix=/wallet yarn workspace @trezor/suite-web build
+        - assetPrefix=/web yarn workspace @trezor/suite-web build
     artifacts:
         expire_in: 7 days
         paths:
@@ -56,26 +55,23 @@ suite-web build-staging manual:
             - packages/suite-web/build
 
 suite-web deploy dev:
-    stage: deploy to dev servers
-    variables:
-        DEPLOY_DIRECTORY: ${DEPLOY_BASE_DIR}/suite-web/${CI_BUILD_REF_NAME}/wallet
-    dependencies:
-        - suite-web build
-        - landing-page build
-    environment:
-        name: ${CI_BUILD_REF_NAME}
-        url: $BASE_REVIEW_URL/${CI_BUILD_REF_NAME}
-    before_script: []
-    script:
-        - cd packages/suite-web
-        - echo "Deploy to dev servers"
-        - mkdir -p ${DEPLOY_BASE_DIR}/suite-web
-        - mkdir -p ${DEPLOY_DIRECTORY} # create build folder
-        - rsync --delete -va build/ "${DEPLOY_DIRECTORY}/"
-        - cd ../landing-page
-        - rsync -abviuzP -va build/ "${DEPLOY_BASE_DIR}/suite-web/${CI_BUILD_REF_NAME}/"
-    tags:
-        - deploy
+  stage: deploy to dev servers
+  variables:
+    DEPLOY_DIRECTORY: ${DEPLOY_BASE_DIR}/suite-web/${CI_BUILD_REF_NAME}
+  dependencies:
+    - install and build
+    - suite-web-landing build dev
+    - suite-web build dev
+  environment:
+    name: ${CI_BUILD_REF_NAME}
+    url: $BASE_REVIEW_URL/${CI_BUILD_REF_NAME}
+  before_script: []
+  script:
+    - mkdir -p ${DEPLOY_DIRECTORY}/web
+    - rsync --delete -va packages/suite-web-landing/build/ "${DEPLOY_DIRECTORY}/"
+    - rsync --delete -va packages/suite-web/build/ "${DEPLOY_DIRECTORY}/web/"
+  tags:
+    - deploy
 
 suite-web e2e chrome stage=stable/suite:
     stage: integration testing
@@ -150,28 +146,53 @@ suite-web e2e chrome-beta stage=stable:
         <<: *e2e_artifacts
     dependencies: []
 
-suite-web deploy staging:
+suite-web deploy staging-wallet:
     stage: deploy to staging
     dependencies:
-        - suite-web build-staging
+        - suite-web build beta
         - suite-desktop build mac
         - suite-desktop build linux
         - suite-desktop build windows
     environment:
         name: ${CI_BUILD_REF_NAME}-staging
-        url: ${STAGING_SERVER_URL}
+        url: ${STAGING_WALLET_SERVER_URL}
     before_script: []
     only:
         <<: *auto_run_branches
     when: manual
     script:
-        - source ${STAGING_DEPLOY_KEYFILE}
+        - source ${STAGING_WALLET_DEPLOY_KEYFILE}
         - mkdir -p packages/suite-web/build/static/desktop
         - rsync --delete -va "${DESKTOP_APP_NAME}"-*.AppImage ./packages/suite-web/build/static/desktop
         - rsync --delete -va "${DESKTOP_APP_NAME}"-*.zip ./packages/suite-web/build/static/desktop
         - rsync --delete -va "${DESKTOP_APP_NAME}"-*.exe ./packages/suite-web/build/static/desktop
         - cd packages/suite-web
-        - ./scripts/s3sync.sh stage beta
+        - ./scripts/s3sync.sh staging-wallet
     tags:
         - deploy
 # todo: add smoke test job on stage / beta (need basic auth)
+
+suite-web deploy staging-suite:
+    stage: deploy to staging
+    dependencies:
+        - suite-web build stable
+        - suite-desktop build mac
+        - suite-desktop build linux
+        - suite-desktop build windows
+    environment:
+        name: ${CI_BUILD_REF_NAME}-staging
+        url: ${STAGING_SUITE_SERVER_URL}
+    before_script: []
+    only:
+        <<: *auto_run_branches
+    when: manual
+    script:
+        - source ${STAGING_SUITE_DEPLOY_KEYFILE}
+        - mkdir -p packages/suite-web/build/static/desktop
+        - rsync --delete -va "${DESKTOP_APP_NAME}"-*.AppImage ./packages/suite-web/build/static/desktop
+        - rsync --delete -va "${DESKTOP_APP_NAME}"-*.zip ./packages/suite-web/build/static/desktop
+        - rsync --delete -va "${DESKTOP_APP_NAME}"-*.exe ./packages/suite-web/build/static/desktop
+        - cd packages/suite-web
+        - ./scripts/s3sync.sh staging-suite
+    tags:
+        - deploy

--- a/packages/landing-page/scripts/s3sync.sh
+++ b/packages/landing-page/scripts/s3sync.sh
@@ -6,15 +6,9 @@
 # Configure access credentials (aws configure), region is "eu-central-1"
 
 # Usage:
-# ./s3sync.sh DESTINATION SOURCE [clear]
-# @DESTINATION: required, destination server
-# @SOURCE: required, build
-# @CLEAR: optional, delete previous uploads
-# ./s3sync.sh stage beta
-# ./s3sync.sh stage stable
-# ./s3sync.sh stage stable clear
-# ./s3sync.sh beta beta
-# ./s3sync.sh stable stable
+# ./s3sync.sh DESTINATION [-clear]
+#     DESTINATION  required, destination server
+#     -clear       optional, delete previous uploads
 
 function confirm {
     read -r -p "Are you sure? [y/N] " response
@@ -25,45 +19,32 @@ function confirm {
     fi
 }
 
-# Validate params
-if [ "x$1" == "x" ] || [ "x$2" == "x" ]; then
-    echo "Invalid params"
-    echo "./s3sync.sh stage|beta|stable beta|stable [clear]"
-    exit 1
-fi
-
 # Validate destination param
-if [ "x$1" != "xstage" ] && [ "x$1" != "xbeta" ] && [ "x$1" != "xstable" ]; then
+if [ "x$1" != "xstaging-wallet" ] && [ "x$1" != "xstaging-suite" ] && [ "x$1" != "xbeta-wallet" ] && [ "x$1" != "xsuite" ]; then
     echo "Invalid destination: "$1
-    echo "use: stage|beta|stable"
+    echo "use: staging-wallet|staging-suite|beta-wallet|suite"
     exit 1
 fi
 
-# Validate source param
-if [ "x$2" != "xbeta" ] && [ "x$2" != "xstable" ]; then
-    echo "Invalid source: "$2
-    echo "use: beta|stable"
-    exit 1
-fi
-
-# Set source directory
-if [ "x$2" == "xbeta" ]; then
-    SOURCE=../build/
-
-elif [ "x$2" == "xstable" ]; then
-    SOURCE=../build/
-fi
+SOURCE=../build/
 
 # Set destination
-if [ "x$1" == "xstage" ]; then
+if [ "x$1" == "xstaging-wallet" ]; then
     BUCKET=stage.mytrezor.com
-    DISTRIBUTION_ID="E24M0QWO692FQL"
-elif [ "x$1" == "xbeta" ]; then
+    DISTRIBUTION_ID=E24M0QWO692FQL
+    DESTDIR=/wallet
+elif [ "x$1" == "xbeta-wallet" ]; then
     BUCKET=beta.mytrezor.com
-    DISTRIBUTION_ID="E1PONNHWUNCQ9M"
-elif [ "x$1" == "xstable" ]; then
-    BUCKET=wallet.mytrezor.com
-    DISTRIBUTION_ID="EZM01GFTITGVD"
+    DISTRIBUTION_ID=E1PONNHWUNCQ9M
+    DESTDIR=/wallet
+elif [ "x$1" == "xstaging-suite" ]; then
+    BUCKET=staging-suite.trezor.io
+    DISTRIBUTION_ID=E232X8775ST76R
+    DESTDIR=/
+elif [ "x$1" == "xsuite" ]; then
+    BUCKET=suite.trezor.io
+    DISTRIBUTION_ID=E4TDVEWU4P4CY
+    DESTDIR=/
 fi
 
 echo "sync "$SOURCE" with "$BUCKET"/"
@@ -75,12 +56,12 @@ fi
 set -e
 cd `dirname $0`
 
-if [ "x$3" == "x-clear" ]; then
-    aws s3 sync --delete --cache-control 'public, max-age=3600' $SOURCE s3://$BUCKET/
+if [ "x$2" == "x-clear" ]; then
+    aws s3 sync --delete --cache-control 'public, max-age=3600' $SOURCE s3://$BUCKET$DESTDIR
 else
-    aws s3 sync --cache-control 'public, max-age=3600' $SOURCE s3://$BUCKET/
+    aws s3 sync --cache-control 'public, max-age=3600' $SOURCE s3://$BUCKET$DESTDIR
 fi
 
-aws cloudfront create-invalidation --distribution-id $DISTRIBUTION_ID --paths '/*'
+aws cloudfront create-invalidation --distribution-id $DISTRIBUTION_ID --paths "$DESTDIR/*"
 
 echo "DONE"

--- a/packages/suite-web-landing/components/Download/index.tsx
+++ b/packages/suite-web-landing/components/Download/index.tsx
@@ -92,7 +92,7 @@ const getIconForCurrentPlatform = (platform: Platform) => {
 const getInstallerURI = (platform: Platform, version: string) => {
     const extension = dropdownItemsData.find(item => platform === item.platform)!
         .installerExtension;
-    return encodeURI(`/wallet/static/desktop/Trezor Suite-${version}.${extension}`);
+    return encodeURI(`./web/static/desktop/Trezor Suite-${version}.${extension}`);
 };
 
 const Index = () => {

--- a/packages/suite-web-landing/components/Layout/index.tsx
+++ b/packages/suite-web-landing/components/Layout/index.tsx
@@ -116,10 +116,7 @@ const Index = ({ children }: Props) => (
                 alignIcon="right"
                 color={colors.NEUE_TYPE_DARK_GREY}
             >
-                <Link
-                    variant="nostyle"
-                    href={process.env.assetPrefix ? `${process.env.assetPrefix}/web` : '/web'}
-                >
+                <Link variant="nostyle" href="./web">
                     Trezor Suite for web
                 </Link>
             </Button>

--- a/packages/suite-web-landing/scripts/s3sync.sh
+++ b/packages/suite-web-landing/scripts/s3sync.sh
@@ -6,15 +6,9 @@
 # Configure access credentials (aws configure), region is "eu-central-1"
 
 # Usage:
-# ./s3sync.sh DESTINATION SOURCE [clear]
-# @DESTINATION: required, destination server
-# @SOURCE: required, build
-# @CLEAR: optional, delete previous uploads
-# ./s3sync.sh stage beta
-# ./s3sync.sh stage stable
-# ./s3sync.sh stage stable clear
-# ./s3sync.sh beta beta
-# ./s3sync.sh stable stable
+# ./s3sync.sh DESTINATION [-clear]
+#     DESTINATION  required, destination server
+#     -clear       optional, delete previous uploads
 
 function confirm {
     read -r -p "Are you sure? [y/N] " response
@@ -25,45 +19,32 @@ function confirm {
     fi
 }
 
-# Validate params
-if [ "x$1" == "x" ] || [ "x$2" == "x" ]; then
-    echo "Invalid params"
-    echo "./s3sync.sh stage|beta|stable beta|stable [clear]"
-    exit 1
-fi
-
 # Validate destination param
-if [ "x$1" != "xstage" ] && [ "x$1" != "xbeta" ] && [ "x$1" != "xstable" ]; then
+if [ "x$1" != "xstaging-wallet" ] && [ "x$1" != "xstaging-suite" ] && [ "x$1" != "xbeta-wallet" ] && [ "x$1" != "xsuite" ]; then
     echo "Invalid destination: "$1
-    echo "use: stage|beta|stable"
+    echo "use: staging-wallet|staging-suite|beta-wallet|suite"
     exit 1
 fi
 
-# Validate source param
-if [ "x$2" != "xbeta" ] && [ "x$2" != "xstable" ]; then
-    echo "Invalid source: "$2
-    echo "use: beta|stable"
-    exit 1
-fi
-
-# Set source directory
-if [ "x$2" == "xbeta" ]; then
-    SOURCE=../build/
-
-elif [ "x$2" == "xstable" ]; then
-    SOURCE=../build/
-fi
+SOURCE=../build/
 
 # Set destination
-if [ "x$1" == "xstage" ]; then
+if [ "x$1" == "xstaging-wallet" ]; then
     BUCKET=stage.mytrezor.com
-    DISTRIBUTION_ID="E24M0QWO692FQL"
-elif [ "x$1" == "xbeta" ]; then
+    DISTRIBUTION_ID=E24M0QWO692FQL
+    DESTDIR=/wallet
+elif [ "x$1" == "xbeta-wallet" ]; then
     BUCKET=beta.mytrezor.com
-    DISTRIBUTION_ID="E1PONNHWUNCQ9M"
-elif [ "x$1" == "xstable" ]; then
-    BUCKET=wallet.mytrezor.com
-    DISTRIBUTION_ID="EZM01GFTITGVD"
+    DISTRIBUTION_ID=E1PONNHWUNCQ9M
+    DESTDIR=/wallet
+elif [ "x$1" == "xstaging-suite" ]; then
+    BUCKET=staging-suite.trezor.io
+    DISTRIBUTION_ID=E232X8775ST76R
+    DESTDIR=/
+elif [ "x$1" == "xsuite" ]; then
+    BUCKET=suite.trezor.io
+    DISTRIBUTION_ID=E4TDVEWU4P4CY
+    DESTDIR=/
 fi
 
 echo "sync "$SOURCE" with "$BUCKET"/"
@@ -75,12 +56,12 @@ fi
 set -e
 cd `dirname $0`
 
-if [ "x$3" == "x-clear" ]; then
-    aws s3 sync --delete --cache-control 'public, max-age=3600' $SOURCE s3://$BUCKET/
+if [ "x$2" == "x-clear" ]; then
+    aws s3 sync --delete --cache-control 'public, max-age=3600' $SOURCE s3://$BUCKET$DESTDIR
 else
-    aws s3 sync --cache-control 'public, max-age=3600' $SOURCE s3://$BUCKET/
+    aws s3 sync --cache-control 'public, max-age=3600' $SOURCE s3://$BUCKET$DESTDIR
 fi
 
-aws cloudfront create-invalidation --distribution-id $DISTRIBUTION_ID --paths '/*'
+aws cloudfront create-invalidation --distribution-id $DISTRIBUTION_ID --paths "$DESTDIR/*"
 
 echo "DONE"


### PR DESCRIPTION
Fixes https://github.com/trezor/trezor-suite/issues/2416

This PR reworks build and deploy tasks for `landing-page` and `suite-web`.

After the change, there are three builds targets and two deploy targets:

`build dev` - builds with "dev" settings
`build beta` - builds with "beta" settings
`build stable` - builds with "stable" settings

`deploy staging-wallet` - deploys beta build to staging-wallet.trezor.io
`deploy staging-suite` - deploys stable build to staging-suite.trezor.io (the deploy key is not yet in the CI)

The third deploy target will be deployed later:
`deploy suite` - deploys stable build to suite.trezor.io