### PR TITLE
Fix/metadata passphrase flow

### DIFF
--- a/packages/integration-tests/projects/suite-web/tests/metadata/account-metadata.test.ts
+++ b/packages/integration-tests/projects/suite-web/tests/metadata/account-metadata.test.ts
@@ -6,7 +6,7 @@ describe('Metadata', () => {
     beforeEach(() => {
         cy.viewport(1024, 768).resetDb();
     });
-    
+
     after(() => {
         cy.task('stopGoogle');
     });
@@ -15,57 +15,73 @@ describe('Metadata', () => {
         Metadata is by default disabled, this means, that application does not try to generate master key and connect to cloud.
         Hovering on some fields that may be labeled shows "add label" button upon which is clicked, Suite initiates metadata flow
         `, () => {
-            // prepare test
-            cy.task('startEmu', { wipe: true });
-            cy.task('setupEmu');
-            cy.task('startGoogle');
+        // prepare test
+        cy.task('startEmu', { wipe: true });
+        cy.task('setupEmu');
+        cy.task('startGoogle');
 
-            cy.prefixedVisit('/accounts', { onBeforeLoad: (win: Window) => {
+        cy.prefixedVisit('/accounts', {
+            onBeforeLoad: (win: Window) => {
                 cy.stub(win, 'open', stubOpen(win));
-                cy.stub(win, 'fetch', stubFetch)
+                cy.stub(win, 'fetch', stubFetch);
+            },
+        });
 
-            }});
-    
-            cy.passThroughInitialRun();
-            
-            // todo: better waiting for discovery (mock it!)
-            cy.getTestElement('@wallet/loading-other-accounts', { timeout: 30000 });
-            cy.getTestElement('@wallet/loading-other-accounts', { timeout: 30000 }).should('not.be.visible');
-    
-            cy.log('Default label is "Bitcoin #1". Clicking it in accounts menu is not possible. User can click on label in accounts sections. This triggers metadata flow');
-            cy.getTestElement('@account-menu/btc/normal/0/label').should('contain', 'Bitcoin');  
+        cy.passThroughInitialRun();
 
-            cy.getTestElement("@metadata/accountLabel/m/84'/0'/0'/add-label-button").click({ force: true });
-            cy.passThroughInitMetadata();
+        // todo: better waiting for discovery (mock it!)
+        cy.getTestElement('@wallet/loading-other-accounts', { timeout: 30000 });
+        cy.getTestElement('@wallet/loading-other-accounts', { timeout: 30000 }).should(
+            'not.be.visible',
+        );
 
-    
-            cy.log('Edit and submit changes by pressing enter key');
-            cy.getTestElement('@metadata/input').type('{backspace}{backspace}{backspace}{backspace}{backspace}cool new label{enter}');
-            cy.getTestElement('@account-menu/btc/normal/0/label').should('contain', 'cool new label');
+        cy.log(
+            'Default label is "Bitcoin #1". Clicking it in accounts menu is not possible. User can click on label in accounts sections. This triggers metadata flow',
+        );
+        cy.getTestElement('@account-menu/btc/normal/0/label').should('contain', 'Bitcoin');
 
-            cy.log('Now edit and submit by clicking on submit button');
-            cy.getTestElement("@metadata/accountLabel/m/84'/0'/0'").click();
-            cy.getTestElement('@metadata/edit-button').click();
-            cy.getTestElement('@metadata/input').type(' even cooler');
-            cy.getTestElement('@metadata/submit').click();
-            cy.getTestElement('@account-menu/btc/normal/0/label').should('contain', 'cool new label even cooler');
+        cy.getTestElement("@metadata/accountLabel/m/84'/0'/0'/add-label-button").click({
+            force: true,
+        });
+        cy.passThroughInitMetadata();
 
-            cy.log('Now edit and press escape, should not save');
-            cy.getTestElement("@metadata/accountLabel/m/84'/0'/0'").click();
-            cy.getTestElement('@metadata/edit-button').click();
-            cy.getTestElement('@metadata/input').clear().type('bcash is true bitcoin{esc}', {timeout: 20 });
-            cy.getTestElement('@account-menu/btc/normal/0/label').should('contain', 'cool new label even cooler');
+        cy.log('Edit and submit changes by pressing enter key');
+        cy.getTestElement('@metadata/input').type(
+            '{backspace}{backspace}{backspace}{backspace}{backspace}cool new label{enter}',
+        );
+        cy.getTestElement('@account-menu/btc/normal/0/label').should('contain', 'cool new label');
 
-            cy.log('Check that accounts search reflects also metadata');
-            cy.getTestElement('@account-menu/search-input').click().type('cool new label');
-            cy.getTestElement('@account-menu/btc/normal/0').should('be.visible');
-            cy.getTestElement('@account-menu/search-input').click().type('something retarded');
-            cy.getTestElement('@account-menu/btc/normal/0').should('not.be.visible');
-            cy.getTestElement('@account-menu/search-input').click().clear();
+        cy.log('Now edit and submit by clicking on submit button');
+        cy.getTestElement("@metadata/accountLabel/m/84'/0'/0'").click();
+        cy.getTestElement('@metadata/edit-button').click();
+        cy.getTestElement('@metadata/input').type(' even cooler');
+        cy.getTestElement('@metadata/submit').click();
+        cy.getTestElement('@account-menu/btc/normal/0/label').should(
+            'contain',
+            'cool new label even cooler',
+        );
 
-            cy.log('We can also remove label from dropdown menu')
-            cy.getTestElement("@metadata/accountLabel/m/84'/0'/0'").click();
-            cy.getTestElement('@metadata/remove-button').click();
-            cy.getTestElement('@account-menu/btc/normal/0/label').should('contain', 'Bitcoin');
+        cy.log('Now edit and press escape, should not save');
+        cy.getTestElement("@metadata/accountLabel/m/84'/0'/0'").click();
+        cy.getTestElement('@metadata/edit-button').click();
+        cy.getTestElement('@metadata/input')
+            .clear()
+            .type('bcash is true bitcoin{esc}', { timeout: 20 });
+        cy.getTestElement('@account-menu/btc/normal/0/label').should(
+            'contain',
+            'cool new label even cooler',
+        );
+
+        cy.log('Check that accounts search reflects also metadata');
+        cy.getTestElement('@account-menu/search-input').click().type('cool new label');
+        cy.getTestElement('@account-menu/btc/normal/0').should('be.visible');
+        cy.getTestElement('@account-menu/search-input').click().type('something retarded');
+        cy.getTestElement('@account-menu/btc/normal/0').should('not.be.visible');
+        cy.getTestElement('@account-menu/search-input').click().clear();
+
+        cy.log('We can also remove label from dropdown menu');
+        cy.getTestElement("@metadata/accountLabel/m/84'/0'/0'").click();
+        cy.getTestElement('@metadata/remove-button').click();
+        cy.getTestElement('@account-menu/btc/normal/0/label').should('contain', 'Bitcoin');
     });
 });

--- a/packages/integration-tests/projects/suite-web/tests/metadata/address-metadata.test.ts
+++ b/packages/integration-tests/projects/suite-web/tests/metadata/address-metadata.test.ts
@@ -13,9 +13,7 @@ describe('Metadata', () => {
         cy.task('stopGoogle');
     });
 
-    it(`
-        Address labeling
-        `, () => {
+    it('Address labeling', () => {
         // prepare test
         cy.task('startEmu', { wipe: true });
         cy.task('setupEmu');

--- a/packages/integration-tests/projects/suite-web/tests/metadata/interval-fetching.test.ts
+++ b/packages/integration-tests/projects/suite-web/tests/metadata/interval-fetching.test.ts
@@ -11,9 +11,7 @@ describe('Metadata', () => {
         cy.task('stopGoogle');
     });
 
-    it(`
-        suite is watching cloud provider and syncs periodically
-    `, () => {
+    it('suite is watching cloud provider and syncs periodically', () => {
         // prepare test
         cy.task('startEmu', { wipe: true });
         cy.task('setupEmu');
@@ -63,15 +61,21 @@ describe('Metadata', () => {
 
         // and this does the time travel to trigger fetch
         cy.tick(METADATA.FETCH_INTERVAL);
-        cy.getTestElement('@metadata/outputLabel/9f472739fa7034dfb9736fa4d98915f2e8ddf70a86ee5e0a9ac0634f8c1d0007-0').should('contain', 'label from another window');
+        cy.getTestElement(
+            '@metadata/outputLabel/9f472739fa7034dfb9736fa4d98915f2e8ddf70a86ee5e0a9ac0634f8c1d0007-0',
+        ).should('contain', 'label from another window');
 
-        cy.log('See what happens if user wipes his data from Google Drive interface (out of suite)');
+        cy.log(
+            'See what happens if user wipes his data from Google Drive interface (out of suite)',
+        );
         cy.log('Next command simulates that user wiped his Google Drive');
-        cy.task('setupGoogle', { prop: 'files', value: []});
+        cy.task('setupGoogle', { prop: 'files', value: [] });
         cy.tick(METADATA.FETCH_INTERVAL);
 
         // in this edge case, all metadata are disposed.
-        cy.getTestElement('@metadata/outputLabel/9f472739fa7034dfb9736fa4d98915f2e8ddf70a86ee5e0a9ac0634f8c1d0007-0').should('not.contain', 'label from another window');
+        cy.getTestElement(
+            '@metadata/outputLabel/9f472739fa7034dfb9736fa4d98915f2e8ddf70a86ee5e0a9ac0634f8c1d0007-0',
+        ).should('not.contain', 'label from another window');
 
         // cy.getTestElement("@metadata/accountLabel/m/84'/0'/0'").click();
         // cy.log('Remove is not available when provider is not connected. With remove (unlike with edit) there is not intermediate step where user can find out if he is changing a label that already exists');

--- a/packages/integration-tests/projects/suite-web/tests/metadata/output-labeling.test.ts
+++ b/packages/integration-tests/projects/suite-web/tests/metadata/output-labeling.test.ts
@@ -6,47 +6,58 @@ describe('Metadata', () => {
     beforeEach(() => {
         cy.viewport(1024, 768).resetDb();
     });
-    
+
     after(() => {
         cy.task('stopGoogle');
     });
 
-    it(`
-        Output labeling
-        `, () => {
-            const targetEl1 = '@metadata/outputLabel/9f472739fa7034dfb9736fa4d98915f2e8ddf70a86ee5e0a9ac0634f8c1d0007-0/add-label-button';
-            // prepare test
-            cy.task('startEmu', { wipe: true });
-            cy.task('setupEmu');
-            cy.task('startGoogle');
+    it('Output labeling', () => {
+        const targetEl1 =
+            '@metadata/outputLabel/9f472739fa7034dfb9736fa4d98915f2e8ddf70a86ee5e0a9ac0634f8c1d0007-0/add-label-button';
+        // prepare test
+        cy.task('startEmu', { wipe: true });
+        cy.task('setupEmu');
+        cy.task('startGoogle');
 
-            cy.prefixedVisit('/accounts', { onBeforeLoad: (win: Window) => {
+        cy.prefixedVisit('/accounts', {
+            onBeforeLoad: (win: Window) => {
                 cy.stub(win, 'open', stubOpen(win));
-                cy.stub(win, 'fetch', stubFetch)
-            }});
-    
-            cy.passThroughInitialRun();
-            
-            // todo: better waiting for discovery (mock it!)
-            cy.getTestElement('@wallet/loading-other-accounts', { timeout: 30000 });
-            cy.getTestElement('@wallet/loading-other-accounts', { timeout: 30000 }).should('not.be.visible');
+                cy.stub(win, 'fetch', stubFetch);
+            },
+        });
 
-            cy.getTestElement(targetEl1).click({force: true});
-            cy.passThroughInitMetadata();
-            cy.getTestElement('@metadata/input').type('mnau cool label{enter}');
+        cy.passThroughInitialRun();
 
-            cy.log('go to legacy account 6, it has txs with multiple outputs');
-            cy.getTestElement('@account-menu/legacy').click();
-            cy.getTestElement('@account-menu/btc/legacy/5/label').click();
-            cy.getTestElement('@metadata/outputLabel/b649a09e6d5d02b3cb4648a42511177efb6abf44366f30a51c1b202d52335d18-0/add-label-button').click({ force: true });
-            cy.getTestElement('@metadata/outputLabel/b649a09e6d5d02b3cb4648a42511177efb6abf44366f30a51c1b202d52335d18-1/add-label-button').click({ force: true });
-            cy.getTestElement('@metadata/submit').should('have.length', 1);
-            cy.getTestElement('@metadata/outputLabel/b649a09e6d5d02b3cb4648a42511177efb6abf44366f30a51c1b202d52335d18-2/add-label-button').click({force: true});
-            cy.getTestElement('@metadata/input').type('output 3{enter}');
+        // todo: better waiting for discovery (mock it!)
+        cy.getTestElement('@wallet/loading-other-accounts', { timeout: 30000 });
+        cy.getTestElement('@wallet/loading-other-accounts', { timeout: 30000 }).should(
+            'not.be.visible',
+        );
 
-            cy.log('label "send to myself tx"')
-            cy.getTestElement('@account-menu/btc/legacy/9/label').click();
-            cy.getTestElement('@metadata/outputLabel/40242836cc07b635569688d12d63041935b86feb2db3fe575be80f2c44e5b4cb-0/add-label-button').click({force: true});
-            cy.getTestElement('@metadata/input').type('really to myself{enter}');
+        cy.getTestElement(targetEl1).click({ force: true });
+        cy.passThroughInitMetadata();
+        cy.getTestElement('@metadata/input').type('mnau cool label{enter}');
+
+        cy.log('go to legacy account 6, it has txs with multiple outputs');
+        cy.getTestElement('@account-menu/legacy').click();
+        cy.getTestElement('@account-menu/btc/legacy/5/label').click();
+        cy.getTestElement(
+            '@metadata/outputLabel/b649a09e6d5d02b3cb4648a42511177efb6abf44366f30a51c1b202d52335d18-0/add-label-button',
+        ).click({ force: true });
+        cy.getTestElement(
+            '@metadata/outputLabel/b649a09e6d5d02b3cb4648a42511177efb6abf44366f30a51c1b202d52335d18-1/add-label-button',
+        ).click({ force: true });
+        cy.getTestElement('@metadata/submit').should('have.length', 1);
+        cy.getTestElement(
+            '@metadata/outputLabel/b649a09e6d5d02b3cb4648a42511177efb6abf44366f30a51c1b202d52335d18-2/add-label-button',
+        ).click({ force: true });
+        cy.getTestElement('@metadata/input').type('output 3{enter}');
+
+        cy.log('label "send to myself tx"');
+        cy.getTestElement('@account-menu/btc/legacy/9/label').click();
+        cy.getTestElement(
+            '@metadata/outputLabel/40242836cc07b635569688d12d63041935b86feb2db3fe575be80f2c44e5b4cb-0/add-label-button',
+        ).click({ force: true });
+        cy.getTestElement('@metadata/input').type('really to myself{enter}');
     });
 });

--- a/packages/integration-tests/projects/suite-web/tests/metadata/token-expires.test.ts
+++ b/packages/integration-tests/projects/suite-web/tests/metadata/token-expires.test.ts
@@ -38,14 +38,16 @@ describe('Metadata', () => {
         cy.getTestElement('@suite/menu/wallet-index').click();
 
         cy.getTestElement("@metadata/accountLabel/m/84'/0'/0'").click({ force: true });
-        cy.getTestElement("@metadata/edit-button").click({ force: true });
+        cy.getTestElement('@metadata/edit-button').click({ force: true });
 
         cy.log('at this moment, oauth token expires');
         cy.task('setupGoogle', { prop: 'user', value: null });
 
         cy.getTestElement('@metadata/input').type('Kvooo{enter}');
 
-        cy.getTestElement('@toast').should('contain.text', 'Failed to sync labeling data with cloud provider');
+        cy.getTestElement('@toast').should(
+            'contain.text',
+            'Failed to sync labeling data with cloud provider',
+        );
     });
 });
-

--- a/packages/integration-tests/projects/suite-web/tests/metadata/wallet-metadata.test.ts
+++ b/packages/integration-tests/projects/suite-web/tests/metadata/wallet-metadata.test.ts
@@ -6,61 +6,73 @@ describe('Metadata', () => {
     beforeEach(() => {
         cy.viewport(1024, 768).resetDb();
     });
-    
+
     after(() => {
         cy.task('stopGoogle');
     });
 
-    it(`
-        Wallet labeling
-        `, () => {
-            // prepare test
-            cy.task('startEmu', { wipe: true });
-            cy.task('setupEmu');
-            cy.task('startGoogle');
+    it('Wallet labeling', () => {
+        // prepare test
+        cy.task('startEmu', { wipe: true });
+        cy.task('setupEmu');
+        cy.task('startGoogle');
 
-            cy.prefixedVisit('/accounts', { onBeforeLoad: (win: Window) => {
+        cy.prefixedVisit('/accounts', {
+            onBeforeLoad: (win: Window) => {
                 cy.stub(win, 'open', stubOpen(win));
-                cy.stub(win, 'fetch', stubFetch)
-            }});
-    
-            cy.passThroughInitialRun();
-            
-            // todo: better waiting for discovery (mock it!)
-            cy.getTestElement('@wallet/loading-other-accounts', { timeout: 30000 });
-            cy.getTestElement('@wallet/loading-other-accounts', { timeout: 30000 }).should('not.be.visible');
+                cy.stub(win, 'fetch', stubFetch);
+            },
+        });
 
-            cy.getTestElement('@menu/switch-device').click();
-            cy.getTestElement('@metadata/walletLabel/standard-wallet/add-label-button').click({force: true });
-            cy.passThroughInitMetadata();
+        cy.passThroughInitialRun();
 
-            cy.getTestElement('@metadata/input').type('label for standard wallet{enter}');
-            cy.getTestElement('@metadata/walletLabel/standard-wallet').click();
-            cy.getTestElement('@metadata/edit-button').click();
-            cy.getTestElement('@metadata/input').clear().type('wallet for drugs{enter}');
+        // todo: better waiting for discovery (mock it!)
+        cy.getTestElement('@wallet/loading-other-accounts', { timeout: 30000 });
+        cy.getTestElement('@wallet/loading-other-accounts', { timeout: 30000 }).should(
+            'not.be.visible',
+        );
 
-            cy.getTestElement('@switch-device/add-wallet-button').click();
-            cy.getConfirmActionOnDeviceModal();
-            cy.task('pressYes');
-            cy.getTestElement('@passphrase/input').type('abc');
-            cy.getTestElement('@passphrase/hidden/submit-button').click();
-            
-            cy.log('discovering new passphrase -> new deviceState -> we need new metadata master key');
-            cy.getConfirmActionOnDeviceModal();
-            cy.task('pressYes');
+        cy.getTestElement('@menu/switch-device').click();
+        cy.getTestElement('@metadata/walletLabel/standard-wallet/add-label-button').click({
+            force: true,
+        });
+        cy.passThroughInitMetadata();
 
-            cy.getTestElement('@passphrase/input', { timeout: 30000 }).type('abc');
+        cy.getTestElement('@metadata/input').type('label for standard wallet{enter}');
+        cy.getTestElement('@metadata/walletLabel/standard-wallet').click();
+        cy.getTestElement('@metadata/edit-button').click();
+        cy.getTestElement('@metadata/input').clear().type('wallet for drugs{enter}');
 
-            cy.getTestElement('@passphrase/confirm-checkbox').click();
-            cy.getTestElement('@passphrase/hidden/submit-button').click();
+        cy.getTestElement('@switch-device/add-wallet-button').click();
+        cy.getConfirmActionOnDeviceModal();
+        cy.task('pressYes');
+        cy.getTestElement('@passphrase/input').type('abc');
+        cy.getTestElement('@passphrase/hidden/submit-button').click();
 
-            cy.getTestElement('@suite/loading').should('not.be.visible');
-            cy.getTestElement('@menu/switch-device').click({ force: true });
-            cy.getTestElement('@metadata/walletLabel/standard-wallet').should('contain', 'wallet for drugs');
+        cy.getTestElement('@passphrase/input', { timeout: 30000 }).type('abc');
 
-            // focus lock? :(
-            cy.getTestElement('@metadata/walletLabel/hidden-wallet-1/add-label-button').click({force: true });
-            cy.getTestElement('@metadata/input').type('wallet not for drugs{enter}');
-            cy.getTestElement('@metadata/walletLabel/hidden-wallet-1').should('contain', 'wallet not for drugs');
+        cy.getTestElement('@passphrase/confirm-checkbox').click();
+        cy.getTestElement('@passphrase/hidden/submit-button').click();
+
+        cy.getTestElement('@suite/loading').should('not.be.visible');
+
+        cy.log('discovering new passphrase -> new deviceState -> we need new metadata master key');
+        cy.getConfirmActionOnDeviceModal();
+        cy.task('pressYes');
+        cy.getTestElement('@menu/switch-device').click();
+        cy.getTestElement('@metadata/walletLabel/standard-wallet').should(
+            'contain',
+            'wallet for drugs',
+        );
+
+        // focus lock? :(
+        cy.getTestElement('@metadata/walletLabel/hidden-wallet-1/add-label-button').click({
+            force: true,
+        });
+        cy.getTestElement('@metadata/input').type('wallet not for drugs{enter}');
+        cy.getTestElement('@metadata/walletLabel/hidden-wallet-1').should(
+            'contain',
+            'wallet not for drugs',
+        );
     });
 });

--- a/packages/integration-tests/projects/suite-web/tests/onboarding/create-wallet-t1.test.ts
+++ b/packages/integration-tests/projects/suite-web/tests/onboarding/create-wallet-t1.test.ts
@@ -1,7 +1,7 @@
 /* eslint-disable @typescript-eslint/camelcase */
 
 // @stable/device-management
-// retry=2
+// @retry=2
 
 describe('Onboarding - create wallet', () => {
     beforeEach(() => {

--- a/packages/suite/docs/METADATA.md
+++ b/packages/suite/docs/METADATA.md
@@ -101,7 +101,7 @@ Account has metadata property which is an object of following shape:
 ```
 
 ## User stories
-First time user:
+### First time user:
 1. User opens App for the first time. Metadata is disabled. "Add label" buttons are present on mouse hover over labelable data.
 1. User clicks "Add label" button.
 1. Device metadata key is generated.
@@ -110,7 +110,14 @@ First time user:
 1. Fetch data from metadata provider and set interval for fetching data.
 1. Activate editable input.
 
-How to turn metadata off
+### Metadata enabled during discovery process:
+Controlled by `discoveryActions`
+1. If passphrase is not used device metadata key is generated before discovery process start. `discoveryActions`
+1. If passphrase is used metadata key is generated either:
+    * in the middle of the discovery process after successful receiving first bundle of accounts and at least one the account is not empty. `discoveryActions`
+    * after passphrase confirmation process. `metadataMiddleware`
+
+## How to turn metadata off
 - controls for common metadata related actions are located in general settings under the labeling section
 - there is a switch which: 
     1. sets metadata.enabled bool value

--- a/packages/suite/src/middlewares/suite/metadataMiddleware.ts
+++ b/packages/suite/src/middlewares/suite/metadataMiddleware.ts
@@ -2,7 +2,7 @@ import { MiddlewareAPI } from 'redux';
 import * as metadataActions from '@suite-actions/metadataActions';
 import { ACCOUNT, DISCOVERY } from '@wallet-actions/constants';
 import { AppState, Action, Dispatch } from '@suite-types';
-import { ROUTER } from '@suite-actions/constants';
+import { ROUTER, SUITE } from '@suite-actions/constants';
 
 const metadata = (api: MiddlewareAPI<Dispatch, AppState>) => (next: Dispatch) => (
     action: Action,
@@ -18,6 +18,15 @@ const metadata = (api: MiddlewareAPI<Dispatch, AppState>) => (next: Dispatch) =>
         case DISCOVERY.COMPLETE:
             if (api.getState().metadata.enabled) {
                 api.dispatch(metadataActions.fetchMetadata(action.payload.deviceState));
+            }
+            break;
+        case SUITE.RECEIVE_AUTH_CONFIRM:
+            if (
+                action.success &&
+                api.getState().metadata.enabled &&
+                action.payload.metadata.status === 'disabled'
+            ) {
+                api.dispatch(metadataActions.init());
             }
             break;
         case ROUTER.LOCATION_CHANGE:


### PR DESCRIPTION
Fix #2308

Device metadata keys are generated in 3 places during discovery:
1. Before discovery if passphrase is not used
2. During discovery if passphrase is used and there are used accounts
3. After passphrase confirmations if there are no used accounts

+ eslint in integration tests files