### PR TITLE
Fix account menu - inconsistent parameters

### DIFF
--- a/packages/suite/src/components/suite/AppNavigation/index.tsx
+++ b/packages/suite/src/components/suite/AppNavigation/index.tsx
@@ -58,9 +58,21 @@ interface Props {
 
 const AppNavigation = ({ items }: Props) => {
     const routeName = useSelector(state => state.router.route?.name);
+    const routerParams = useSelector(state => state.router.params);
+    const account = useSelector(state => state.wallet.selectedAccount.account);
     const { goto } = useActions({
         goto: routerActions.goto,
     });
+
+    if (!account) return null;
+
+    const params = !routerParams
+        ? {
+              symbol: account.symbol,
+              accountIndex: account.index,
+              accountType: account.accountType,
+          }
+        : undefined;
 
     return (
         <Wrapper>
@@ -71,7 +83,7 @@ const AppNavigation = ({ items }: Props) => {
                     <StyledNavLink
                         key={route}
                         active={active}
-                        onClick={() => goto(route, undefined, true)}
+                        onClick={() => goto(route, params, true)}
                         {...restItemProps}
                     >
                         <IconWrapper>

--- a/packages/suite/src/components/suite/AppNavigation/index.tsx
+++ b/packages/suite/src/components/suite/AppNavigation/index.tsx
@@ -63,15 +63,7 @@ const AppNavigation = ({ items }: Props) => {
         goto: routerActions.goto,
     });
 
-    if (selectedAccount.status !== 'loaded') return null;
-    const params = !router.params
-        ? {
-              symbol: selectedAccount.params.symbol,
-              accountIndex: selectedAccount.params.accountIndex,
-              accountType: selectedAccount.params.accountType,
-          }
-        : undefined;
-
+    const { params } = selectedAccount;
     return (
         <Wrapper>
             {items.map(item => {
@@ -81,7 +73,9 @@ const AppNavigation = ({ items }: Props) => {
                     <StyledNavLink
                         key={route}
                         active={active}
-                        onClick={() => goto(route, params, true)}
+                        onClick={() =>
+                            params ? goto(route, params) : goto(route, undefined, true)
+                        }
                         {...restItemProps}
                     >
                         <IconWrapper>

--- a/packages/suite/src/components/suite/AppNavigation/index.tsx
+++ b/packages/suite/src/components/suite/AppNavigation/index.tsx
@@ -57,25 +57,22 @@ interface Props {
 }
 
 const AppNavigation = ({ items }: Props) => {
-    const router = useSelector(state => state.router);
-    const selectedAccount = useSelector(state => state.wallet.selectedAccount);
+    const routeName = useSelector(state => state.router.route?.name);
+    const { params } = useSelector(state => state.wallet.selectedAccount);
     const { goto } = useActions({
         goto: routerActions.goto,
     });
 
-    const { params } = selectedAccount;
     return (
         <Wrapper>
             {items.map(item => {
                 const { route, title, icon, ...restItemProps } = item;
-                const active = router.route?.name === route;
+                const active = routeName === route;
                 return (
                     <StyledNavLink
                         key={route}
                         active={active}
-                        onClick={() =>
-                            params ? goto(route, params) : goto(route, undefined, true)
-                        }
+                        onClick={() => goto(route, params, !params)}
                         {...restItemProps}
                     >
                         <IconWrapper>

--- a/packages/suite/src/components/suite/AppNavigation/index.tsx
+++ b/packages/suite/src/components/suite/AppNavigation/index.tsx
@@ -59,18 +59,17 @@ interface Props {
 const AppNavigation = ({ items }: Props) => {
     const routeName = useSelector(state => state.router.route?.name);
     const routerParams = useSelector(state => state.router.params);
-    const account = useSelector(state => state.wallet.selectedAccount.account);
+    const selectedAccount = useSelector(state => state.wallet.selectedAccount);
     const { goto } = useActions({
         goto: routerActions.goto,
     });
 
-    if (!account) return null;
-
+    if (selectedAccount.status !== 'loaded') return null;
     const params = !routerParams
         ? {
-              symbol: account.symbol,
-              accountIndex: account.index,
-              accountType: account.accountType,
+              symbol: selectedAccount.params.symbol,
+              accountIndex: selectedAccount.params.accountIndex,
+              accountType: selectedAccount.params.accountType,
           }
         : undefined;
 

--- a/packages/suite/src/components/suite/AppNavigation/index.tsx
+++ b/packages/suite/src/components/suite/AppNavigation/index.tsx
@@ -57,15 +57,14 @@ interface Props {
 }
 
 const AppNavigation = ({ items }: Props) => {
-    const routeName = useSelector(state => state.router.route?.name);
-    const routerParams = useSelector(state => state.router.params);
+    const router = useSelector(state => state.router);
     const selectedAccount = useSelector(state => state.wallet.selectedAccount);
     const { goto } = useActions({
         goto: routerActions.goto,
     });
 
     if (selectedAccount.status !== 'loaded') return null;
-    const params = !routerParams
+    const params = !router.params
         ? {
               symbol: selectedAccount.params.symbol,
               accountIndex: selectedAccount.params.accountIndex,
@@ -77,7 +76,7 @@ const AppNavigation = ({ items }: Props) => {
         <Wrapper>
             {items.map(item => {
                 const { route, title, icon, ...restItemProps } = item;
-                const active = routeName === route;
+                const active = router.route?.name === route;
                 return (
                     <StyledNavLink
                         key={route}


### PR DESCRIPTION
This change fixes a little inconsistency in the account menu. When you click on "Accounts" and "Send" you have the first account selected but the hash is missing in the URL (screenshot 1). This causes unnecessary `dispose` event when you switch on the same account but with the hash (/#/btc/0)

![image](https://user-images.githubusercontent.com/3112191/94563012-62a78e80-0266-11eb-82f0-8dafd2bdf7a6.png)

The state after clicking on Account 1 (Menu)

![image](https://user-images.githubusercontent.com/3112191/94563390-f1b4a680-0266-11eb-957d-18741e9723c7.png)

