### PR TITLE
Add option to restrict search input length in CleanSelect

### DIFF
--- a/packages/components/src/components/form/CleanSelect/index.tsx
+++ b/packages/components/src/components/form/CleanSelect/index.tsx
@@ -109,6 +109,7 @@ interface Props extends Omit<SelectProps, 'components'> {
     wrapperProps?: Record<string, any>;
     variant?: InputVariant;
     minWidth?: string;
+    maxSearchLength?: number;
 }
 
 const CleanSelect = ({
@@ -122,6 +123,7 @@ const CleanSelect = ({
     label,
     minWidth,
     options,
+    maxSearchLength,
     ...props
 }: Props) => {
     const [isHovered, setIsHovered] = React.useState(isHoveredByDefault);
@@ -136,6 +138,15 @@ const CleanSelect = ({
                 isDisabled={optionsLength <= 1}
                 options={options}
                 {...props}
+                onInputChange={
+                    maxSearchLength
+                        ? (inputValue: string) => {
+                              return inputValue.length <= maxSearchLength
+                                  ? inputValue
+                                  : inputValue.substr(0, maxSearchLength);
+                          }
+                        : undefined
+                }
             />
         </Wrapper>
     );


### PR DESCRIPTION
After feedback from QA that it is possible to enter unlimited text to react-select search field, which breaks the form visually, I searched a way how to restrict it.

It is not directly supported by react-select as a prop so but there are multiple ways to do it to be found on the Internet. I picked one of them.