### PR TITLE
Feat/settings modals design update

### DIFF
--- a/packages/components/src/components/Modal/index.tsx
+++ b/packages/components/src/components/Modal/index.tsx
@@ -250,12 +250,13 @@ const Description = styled(SidePaddingWrapper)`
     text-align: center;
 `;
 
-const Content = styled(SidePaddingWrapper)`
+const Content = styled(SidePaddingWrapper)<{ centerContent: boolean }>`
     display: flex;
     flex-direction: column;
     width: 100%;
     height: 100%;
     overflow-y: auto;
+
     ::-webkit-scrollbar {
         background-color: #fff;
         width: 10px;
@@ -275,6 +276,14 @@ const Content = styled(SidePaddingWrapper)`
     ::-webkit-scrollbar-button {
         display: none;
     }
+
+    /* center the content if props.centerContent selected. For example useful for centering nested modals */
+    ${props =>
+        props.centerContent &&
+        css`
+            justify-content: center;
+            align-items: center;
+        `}
 `;
 
 const BottomBar = styled(SidePaddingWrapper)`
@@ -371,6 +380,7 @@ interface Props extends React.HTMLAttributes<HTMLDivElement> {
     hiddenProgressBar?: boolean;
     totalProgressBarSteps?: number;
     currentProgressBarStep?: number;
+    centerContent?: boolean;
 }
 
 const Modal = ({
@@ -397,6 +407,7 @@ const Modal = ({
     hiddenProgressBar = false, // reserves the space for progress bar (4px under the heading), but not showing the green bar
     totalProgressBarSteps,
     currentProgressBarStep,
+    centerContent = false,
     ...rest
 }: Props) => {
     const escPressed = useKeyPress('Escape');
@@ -462,7 +473,9 @@ const Modal = ({
             {description && (
                 <Description sidePadding={contentPaddingSide}>{description}</Description>
             )}
-            <Content sidePadding={contentPaddingSide}>{children}</Content>
+            <Content sidePadding={contentPaddingSide} centerContent={centerContent}>
+                {children}
+            </Content>
             {bottomBar && <BottomBar sidePadding={contentPaddingSide}>{bottomBar}</BottomBar>}
         </ModalWindow>
     );

--- a/packages/suite/src/views/recovery/index.tsx
+++ b/packages/suite/src/views/recovery/index.tsx
@@ -6,14 +6,7 @@ import { bindActionCreators } from 'redux';
 import { Button, ButtonProps, H2, P, colors, Modal, variables } from '@trezor/components';
 
 import { SelectWordCount, SelectRecoveryType, Error } from '@recovery-components';
-import {
-    ProgressBar,
-    Loading,
-    Translation,
-    CheckItem,
-    ExternalLink,
-    Image,
-} from '@suite-components';
+import { Loading, Translation, CheckItem, ExternalLink, Image } from '@suite-components';
 import * as recoveryActions from '@recovery-actions/recoveryActions';
 import { InjectedModalApplicationProps, AppState, Dispatch } from '@suite-types';
 import { WordCount } from '@recovery-types';

--- a/packages/suite/src/views/recovery/index.tsx
+++ b/packages/suite/src/views/recovery/index.tsx
@@ -159,18 +159,15 @@ const Recovery = ({
     }
 
     return (
-        <Modal useFixedHeight>
+        <Modal
+            useFixedHeight
+            heading={<Translation id="TR_CHECK_RECOVERY_SEED" />}
+            totalProgressBarSteps={statesInProgressBar.length}
+            currentProgressBarStep={statesInProgressBar.findIndex(s => s === recovery.status) + 1}
+        >
             <Wrapper>
-                <ProgressBar
-                    total={statesInProgressBar.length}
-                    current={statesInProgressBar.findIndex(s => s === recovery.status) + 1}
-                />
-
                 {recovery.status === 'initial' && model === 1 && (
                     <>
-                        <H2>
-                            <Translation id="TR_CHECK_RECOVERY_SEED" />
-                        </H2>
                         <StyledP>
                             <Translation id="TR_CHECK_RECOVERY_SEED_DESC_T1" />
                         </StyledP>
@@ -201,9 +198,6 @@ const Recovery = ({
 
                 {recovery.status === 'initial' && model === 2 && (
                     <>
-                        <H2>
-                            <Translation id="TR_CHECK_RECOVERY_SEED" />
-                        </H2>
                         <StyledP>
                             <Translation id="TR_CHECK_RECOVERY_SEED_DESC_T2" />
                         </StyledP>


### PR DESCRIPTION
Updated standalone modals in setting

- **Seed check modal**: I updated the design of progress bar and modal heading
- **Backup modal**: I updated the design of progress bar  and modal heading. I also centered nested ("_Confirm on Device_") modal. I solved this by adding a new **centerContent** prop to the general Modal component.  