### PR TITLE
feat: dropdown menu design update

### DIFF
--- a/packages/components/src/components/form/CleanSelect/index.tsx
+++ b/packages/components/src/components/form/CleanSelect/index.tsx
@@ -33,6 +33,8 @@ const getDropdownVisibility = (isDisabled: boolean, isFocused: boolean, isHovere
 const selectStyle = (
     isDropdownVisible: boolean,
     isHovered: boolean,
+    hideTextCursor: boolean,
+    isSearchable: boolean,
     minWidth = '50px',
     theme: SuiteThemeColors
 ) => ({
@@ -43,6 +45,9 @@ const selectStyle = (
         display: 'flex',
         width: '100%',
         justifyContent: 'flex-end',
+        '&:hover': {
+            cursor: hideTextCursor || !isSearchable ? 'pointer' : 'text',
+        },
     }),
     container: (base: Record<string, any>) => ({
         ...base,
@@ -86,6 +91,7 @@ const selectStyle = (
             padding: 0,
             margin: 0,
             border: '0',
+            cursor: 'pointer',
             display: isDropdownVisible
                 ? 'flex'
                 : getDropdownVisibility(isDisabled, isFocused, isHovered),
@@ -113,6 +119,14 @@ const selectStyle = (
             background: theme.BG_GREY,
         },
     }),
+    input: (base: Record<string, any>) => ({
+        ...base,
+        fontSize: variables.NEUE_FONT_SIZE.NORMAL,
+        color: hideTextCursor ? 'transparent' : theme.TYPE_DARK_GREY,
+        '& input': {
+            textShadow: hideTextCursor ? `0 0 0 ${theme.TYPE_DARK_GREY} !important` : 'none',
+        },
+    }),
 });
 
 interface Props extends Omit<SelectProps, 'components'> {
@@ -137,6 +151,7 @@ const CleanSelect = ({
     minWidth,
     options,
     maxSearchLength,
+    hideTextCursor,
     ...props
 }: Props) => {
     const theme = useTheme();
@@ -146,7 +161,14 @@ const CleanSelect = ({
     return (
         <Wrapper onMouseEnter={() => setIsHovered(true)} onMouseLeave={() => setIsHovered(false)}>
             <ReactSelect
-                styles={selectStyle(isDropdownVisible, isHovered, minWidth, theme)}
+                styles={selectStyle(
+                    isDropdownVisible,
+                    isHovered,
+                    hideTextCursor,
+                    isSearchable,
+                    minWidth,
+                    theme
+                )}
                 classNamePrefix="react-select"
                 isSearchable={isSearchable}
                 isDisabled={optionsLength <= 1}

--- a/packages/components/src/components/form/Select/index.tsx
+++ b/packages/components/src/components/form/Select/index.tsx
@@ -111,11 +111,6 @@ const Label = styled.span`
     min-height: 32px;
 `;
 
-interface Option {
-    value: string;
-    label: string;
-}
-
 interface Props extends Omit<SelectProps, 'components'> {
     withDropdownIndicator?: boolean;
     isClean?: boolean;

--- a/packages/components/src/components/form/Select/index.tsx
+++ b/packages/components/src/components/form/Select/index.tsx
@@ -10,6 +10,7 @@ const selectStyle = (
     isSearchable: boolean,
     withDropdownIndicator = true,
     variant: InputVariant,
+    hideTextCursor: boolean,
     isClean: boolean,
     theme: SuiteThemeColors
 ) => ({
@@ -19,8 +20,9 @@ const selectStyle = (
         alignItems: 'center',
         width: '100%',
         color: theme.TYPE_DARK_GREY,
+        fontSize: variables.NEUE_FONT_SIZE.NORMAL,
         '&:hover': {
-            cursor: isSearchable ? 'text' : 'pointer',
+            cursor: hideTextCursor || !isSearchable ? 'pointer' : 'text',
         },
     }),
     control: (
@@ -55,6 +57,7 @@ const selectStyle = (
         display: !withDropdownIndicator || isDisabled ? 'none' : 'flex',
         alignItems: 'center',
         color: theme.TYPE_LIGHT_GREY,
+        cursor: 'pointer',
         path: '',
         '&:hover': {
             color: theme.TYPE_DARK_GREY,
@@ -78,8 +81,17 @@ const selectStyle = (
         color: theme.TYPE_DARK_GREY,
         background: isFocused ? theme.BG_WHITE_ALT_HOVER : theme.BG_WHITE_ALT,
         borderRadius: 0,
+        fontSize: variables.NEUE_FONT_SIZE.NORMAL,
         '&:hover': {
             cursor: 'pointer',
+        },
+    }),
+    input: (base: Record<string, any>) => ({
+        ...base,
+        fontSize: variables.NEUE_FONT_SIZE.NORMAL,
+        color: hideTextCursor ? 'transparent' : theme.TYPE_DARK_GREY,
+        '& input': {
+            textShadow: hideTextCursor ? `0 0 0 ${theme.TYPE_DARK_GREY} !important` : 'none',
         },
     }),
 });
@@ -99,6 +111,11 @@ const Label = styled.span`
     min-height: 32px;
 `;
 
+interface Option {
+    value: string;
+    label: string;
+}
+
 interface Props extends Omit<SelectProps, 'components'> {
     withDropdownIndicator?: boolean;
     isClean?: boolean;
@@ -106,10 +123,12 @@ interface Props extends Omit<SelectProps, 'components'> {
     wrapperProps?: Record<string, any>;
     variant?: InputVariant;
     noTopLabel?: boolean;
+    hideTextCursor?: boolean; // this prop hides blinking text cursor
 }
 
 const Select = ({
     isSearchable = true,
+    hideTextCursor = false,
     withDropdownIndicator = true,
     className,
     wrapperProps,
@@ -152,7 +171,14 @@ const Select = ({
             {!noTopLabel && <Label>{label}</Label>}
             <ReactSelect
                 classNamePrefix="react-select"
-                styles={selectStyle(isSearchable, withDropdownIndicator, variant, isClean, theme)}
+                styles={selectStyle(
+                    isSearchable,
+                    withDropdownIndicator,
+                    variant,
+                    hideTextCursor,
+                    isClean,
+                    theme
+                )}
                 isSearchable={isSearchable}
                 {...props}
                 components={{ Control, Option, ...props.components }}

--- a/packages/suite/src/components/suite/Settings/components/Analytics.tsx
+++ b/packages/suite/src/components/suite/Settings/components/Analytics.tsx
@@ -6,7 +6,7 @@ import { SectionItem, ActionColumn, TextColumn } from '@suite-components/Setting
 import { useAnalytics } from '@suite-hooks';
 
 const PositionedSwitch = styled.div`
-    align-self: flex-end;
+    align-self: center;
 `;
 
 const Analytics = () => {

--- a/packages/suite/src/components/suite/Settings/components/TextColumn.tsx
+++ b/packages/suite/src/components/suite/Settings/components/TextColumn.tsx
@@ -20,6 +20,7 @@ const Wrapper = styled.div`
 const Description = styled.div`
     color: ${props => props.theme.TYPE_LIGHT_GREY};
     margin-bottom: 12px;
+    margin-top: 12px;
     font-size: ${variables.FONT_SIZE.TINY};
 
     &:last-child {
@@ -29,7 +30,6 @@ const Description = styled.div`
 
 const Title = styled.div`
     font-weight: ${variables.FONT_WEIGHT.REGULAR};
-    margin-bottom: 12px;
 `;
 
 const TextColumn = ({ title, description, learnMore }: TextColumnProps) => {

--- a/packages/suite/src/components/suite/modals/AddAccount/components/NetworkSelect.tsx
+++ b/packages/suite/src/components/suite/modals/AddAccount/components/NetworkSelect.tsx
@@ -58,6 +58,7 @@ interface Props {
 const NetworkSelect = ({ network, internalNetworks, setSelectedNetwork, isDisabled }: Props) => (
     <Select
         isSearchable
+        hideTextCursor
         width={250}
         maxMenuHeight={220}
         isClearable={false}

--- a/packages/suite/src/components/suite/modals/AddAccount/components/Wrapper.tsx
+++ b/packages/suite/src/components/suite/modals/AddAccount/components/Wrapper.tsx
@@ -8,7 +8,7 @@ import AccountTypeSelect from './AccountTypeSelect';
 import { TREZOR_COINS_URL } from '@suite-constants/urls';
 
 const StyledModal = styled(Modal)`
-    min-height: 540px;
+    min-height: 550px;
 `;
 
 const Actions = styled.div`

--- a/packages/suite/src/views/settings/index.tsx
+++ b/packages/suite/src/views/settings/index.tsx
@@ -93,7 +93,7 @@ const Settings = ({
                     <TextColumn title={<Translation id="TR_LANGUAGE" />} />
                     <ActionColumn>
                         <ActionSelect
-                            variant="small"
+                            hideTextCursor
                             noTopLabel
                             value={{
                                 value: language,
@@ -122,7 +122,7 @@ const Settings = ({
                     <ActionColumn>
                         <ActionSelect
                             noTopLabel
-                            variant="small"
+                            hideTextCursor
                             onChange={(option: { value: string; label: string }) => {
                                 setLocalCurrency(option.value);
                                 analytics.report({

--- a/packages/suite/src/views/wallet/send/components/Outputs/components/Amount/components/Fiat/index.tsx
+++ b/packages/suite/src/views/wallet/send/components/Outputs/components/Amount/components/Fiat/index.tsx
@@ -144,9 +144,10 @@ const Fiat = ({ output, outputId }: Props) => {
                             return (
                                 <CleanSelect
                                     options={buildCurrencyOptions()}
-                                    isSearchable
                                     value={value}
                                     isClearable={false}
+                                    isSearchable
+                                    hideTextCursor
                                     minWidth="45px"
                                     data-test={currencyInputName}
                                     onChange={(selected: CurrencyOption) => {

--- a/packages/suite/src/views/wallet/send/components/Outputs/components/Amount/components/TokenSelect/index.tsx
+++ b/packages/suite/src/views/wallet/send/components/Outputs/components/Amount/components/TokenSelect/index.tsx
@@ -78,6 +78,7 @@ const TokenSelect = ({ output, outputId }: Props) => {
                     <CleanSelect
                         options={options}
                         isSearchable
+                        hideTextCursor
                         value={options.find(o => o.value === tokenValue)}
                         isClearable={false}
                         minWidth="45px"


### PR DESCRIPTION
Fix part of https://github.com/trezor/trezor-suite/issues/2480

The goal here is to be able to hide the blinking cursor in a searchable (=user can type in values) dropdown menu.

I solved this by adding  `hideTextCursor` prop to the **Select** and **CleanSelect** component.


You can check the new design in _Settings_ -> _Fiat currency_ dropdown (the blinking cursor is gone, but user can still filter options by typing in values).
 

 
I also made some visual changes:

-  using the _TT Hoves_ font for both selected value and options list

- Increased the height of dropdowns in settings 
