### PR TITLE
Fix: Desktop Updater

### DIFF
--- a/ci/packages/suite-desktop.yml
+++ b/ci/packages/suite-desktop.yml
@@ -99,8 +99,8 @@ suite-desktop deploy dev:
         DEPLOY_DIRECTORY: ${DEPLOY_BASE_DIR}/suite-desktop/${CI_BUILD_REF_NAME}
     script:
         - mkdir -p ${DEPLOY_DIRECTORY}
-        - rsync --delete -va "${DESKTOP_APP_NAME}"-*.zip "${DEPLOY_DIRECTORY}/"
         - rsync --delete -va "${DESKTOP_APP_NAME}"-*.AppImage "${DEPLOY_DIRECTORY}/"
+        - rsync --delete -va "${DESKTOP_APP_NAME}"-*.dmg "${DEPLOY_DIRECTORY}/"
         - rsync --delete -va "${DESKTOP_APP_NAME}"-*.exe "${DEPLOY_DIRECTORY}/"
     tags:
         - deploy

--- a/ci/packages/suite-web.yml
+++ b/ci/packages/suite-web.yml
@@ -164,7 +164,7 @@ suite-web deploy staging-wallet:
         - source ${STAGING_WALLET_DEPLOY_KEYFILE}
         - mkdir -p packages/suite-web/build/static/desktop
         - rsync --delete -va "${DESKTOP_APP_NAME}"-*.AppImage ./packages/suite-web/build/static/desktop
-        - rsync --delete -va "${DESKTOP_APP_NAME}"-*.zip ./packages/suite-web/build/static/desktop
+        - rsync --delete -va "${DESKTOP_APP_NAME}"-*.dmg ./packages/suite-web/build/static/desktop
         - rsync --delete -va "${DESKTOP_APP_NAME}"-*.exe ./packages/suite-web/build/static/desktop
         - cd packages/suite-web
         - ./scripts/s3sync.sh staging-wallet
@@ -190,7 +190,7 @@ suite-web deploy staging-suite:
         - source ${STAGING_SUITE_DEPLOY_KEYFILE}
         - mkdir -p packages/suite-web/build/static/desktop
         - rsync --delete -va "${DESKTOP_APP_NAME}"-*.AppImage ./packages/suite-web/build/static/desktop
-        - rsync --delete -va "${DESKTOP_APP_NAME}"-*.zip ./packages/suite-web/build/static/desktop
+        - rsync --delete -va "${DESKTOP_APP_NAME}"-*.dmg ./packages/suite-web/build/static/desktop
         - rsync --delete -va "${DESKTOP_APP_NAME}"-*.exe ./packages/suite-web/build/static/desktop
         - cd packages/suite-web
         - ./scripts/s3sync.sh staging-suite

--- a/docs/SUMMARY.md
+++ b/docs/SUMMARY.md
@@ -3,6 +3,8 @@
 - [Introduction](index.md)
 - [Deployment](deployment/index.md)
   - [Web](deployment/web.md)
+- [Packages](packages/index.md)
+  - [Suite Desktop](packages/desktop.md)
 - [Features](features/index.md)
   - [Metadata](features/metadata.md)
 - [Miscellaneous](misc/index.md)

--- a/docs/packages/index.md
+++ b/docs/packages/index.md
@@ -1,0 +1,3 @@
+# Packages
+
+This directory contains description of various Trezor Suite packages.

--- a/docs/packages/suite-desktop.md
+++ b/docs/packages/suite-desktop.md
@@ -1,0 +1,12 @@
+# Suite Desktop
+
+## Shortcuts
+_TODO_
+
+## Runtime flags
+Runtime flags can be used when running the Suite Desktop executable, enabling or disabling certain features. For example: `./Trezor-Suite-20.10.1.AppImage --disable-csp` will run with this flag turned on, which will result in the Content Security Policy being disabled. 
+
+Available flags:
+| name | description |
+| --- | --- |
+| `--disable-csp` | Disables the Content Security Policy. Necessary for using DevTools in a production build. |

--- a/packages/landing-page/pages/wallet/start/index.tsx
+++ b/packages/landing-page/pages/wallet/start/index.tsx
@@ -50,7 +50,7 @@ const getAppUrl = (appName: App) => {
         case 'win':
             return encodeURI(`../web/static/desktop/Trezor Suite-${version}.exe`);
         case 'macos':
-            return encodeURI(`../web/static/desktop/Trezor Suite-${version}.zip`);
+            return encodeURI(`../web/static/desktop/Trezor Suite-${version}.dmg`);
         case 'linux':
             return encodeURI(`../web/static/desktop/Trezor Suite-${version}.AppImage`);
         // no default

--- a/packages/suite-desktop/package.json
+++ b/packages/suite-desktop/package.json
@@ -84,7 +84,7 @@
             "entitlements": "entitlements.mac.inherit.plist",
             "entitlementsInherit": "entitlements.mac.inherit.plist",
             "target": [
-                "zip"
+                "dmg"
             ]
         },
         "win": {

--- a/packages/suite-desktop/package.json
+++ b/packages/suite-desktop/package.json
@@ -134,7 +134,6 @@
     "dependencies": {
         "electron-is-dev": "^1.2.0",
         "electron-localshortcut": "^3.2.1",
-        "electron-log": "^4.2.4",
         "electron-next": "^3.1.5",
         "electron-store": "^5.1.1",
         "electron-updater": "^4.3.5",

--- a/packages/suite-desktop/package.json
+++ b/packages/suite-desktop/package.json
@@ -84,6 +84,7 @@
             "entitlements": "entitlements.mac.inherit.plist",
             "entitlementsInherit": "entitlements.mac.inherit.plist",
             "target": [
+                "zip",
                 "dmg"
             ]
         },
@@ -100,8 +101,7 @@
             "icon": "build/static/images/icons/512x512.ico",
             "artifactName": "${productName}-${version}.${ext}",
             "target": [
-                "nsis",
-                "zip"
+                "nsis"
             ]
         },
         "linux": {
@@ -126,8 +126,7 @@
             "executableName": "trezor-suite",
             "category": "Utility",
             "target": [
-                "AppImage",
-                "tar.gz"
+                "AppImage"
             ]
         }
     },

--- a/packages/suite-desktop/src-electron/electron.ts
+++ b/packages/suite-desktop/src-electron/electron.ts
@@ -2,7 +2,6 @@ import { app, session, BrowserWindow, ipcMain, shell, Menu, dialog } from 'elect
 import isDev from 'electron-is-dev';
 import prepareNext from 'electron-next';
 import { autoUpdater, CancellationToken } from 'electron-updater';
-import electronLogger from 'electron-log';
 import * as path from 'path';
 import * as url from 'url';
 import * as electronLocalshortcut from 'electron-localshortcut';
@@ -174,6 +173,7 @@ const init = async () => {
 
     // Updates (move in separate file)
     const updateSettings = store.getUpdateSettings();
+    let latestVersion = {};
 
     autoUpdater.autoDownload = false;
     autoUpdater.autoInstallOnAppQuit = true;
@@ -187,15 +187,17 @@ const init = async () => {
     });
 
     autoUpdater.on('update-available', ({ version, releaseDate }) => {
+        latestVersion = { version, releaseDate };
         if (updateSettings.skipVersion === version) {
             return;
         }
 
-        mainWindow.webContents.send('update/available', { version, releaseDate });
+        mainWindow.webContents.send('update/available', latestVersion);
     });
 
     autoUpdater.on('update-not-available', ({ version, releaseDate }) => {
-        mainWindow.webContents.send('update/not-available', { version, releaseDate });
+        latestVersion = { version, releaseDate };
+        mainWindow.webContents.send('update/not-available', latestVersion);
     });
 
     autoUpdater.on('error', err => {
@@ -221,72 +223,14 @@ const init = async () => {
         autoUpdater.downloadUpdate(updateCancellationToken);
     });
     ipcMain.on('update/install', () => autoUpdater.quitAndInstall());
-    ipcMain.on('update/cancel', () => updateCancellationToken.cancel());
+    ipcMain.on('update/cancel', () => {
+        mainWindow.webContents.send('update/available', latestVersion);
+        updateCancellationToken.cancel();
+    });
     ipcMain.on('update/skip', (_, version) => {
         mainWindow.webContents.send('update/skip', version);
         updateSettings.skipVersion = version;
         store.setUpdateSettings(updateSettings);
-    });
-
-    // Differential updater hack (https://gist.github.com/the3moon/0e9325228f6334dabac6dadd7a3fc0b9)
-    autoUpdater.logger = electronLogger;
-
-    let diffDown = {
-        percent: 0,
-        bytesPerSecond: 0,
-        total: 0,
-        transferred: 0,
-    };
-    let diffDownHelper = {
-        startTime: 0,
-        lastTime: 0,
-        lastSize: 0,
-    };
-
-    electronLogger.hooks.push((msg, transport) => {
-        if (transport !== electronLogger.transports.console) {
-            return msg;
-        }
-
-        let match = /Full: ([\d,.]+) ([GMKB]+), To download: ([\d,.]+) ([GMKB]+)/.exec(msg.data[0]);
-        if (match) {
-            let multiplier = 1;
-            if (match[4] === 'KB') multiplier *= 1024;
-            if (match[4] === 'MB') multiplier *= 1024 * 1024;
-            if (match[4] === 'GB') multiplier *= 1024 * 1024 * 1024;
-
-            diffDown = {
-                percent: 0,
-                bytesPerSecond: 0,
-                total: Number(match[3].split(',').join('')) * multiplier,
-                transferred: 0,
-            };
-            diffDownHelper = {
-                startTime: Date.now(),
-                lastTime: Date.now(),
-                lastSize: 0,
-            };
-
-            return msg;
-        }
-
-        match = /download range: bytes=(\d+)-(\d+)/.exec(msg.data[0]);
-        if (match) {
-            const currentSize = Number(match[2]) - Number(match[1]);
-            const currentTime = Date.now();
-            const deltaTime = currentTime - diffDownHelper.startTime;
-
-            diffDown.transferred += diffDownHelper.lastSize;
-            diffDown.bytesPerSecond = Math.floor((diffDown.transferred * 1000) / deltaTime);
-            diffDown.percent = (diffDown.transferred * 100) / diffDown.total;
-
-            diffDownHelper.lastSize = currentSize;
-            diffDownHelper.lastTime = currentTime;
-            mainWindow.webContents.send('update/downloading', { ...diffDown });
-            return msg;
-        }
-
-        return msg;
     });
 };
 

--- a/packages/suite-desktop/src-electron/preload.ts
+++ b/packages/suite-desktop/src-electron/preload.ts
@@ -26,6 +26,9 @@ const validChannels = [
 ];
 
 contextBridge.exposeInMainWorld('desktopApi', {
+    /**
+     * @deprecated Use dedicated methods instead of send
+     */
     send: (channel: string, data?: any) => {
         if (validChannels.includes(channel)) {
             ipcRenderer.send(channel, data);
@@ -41,8 +44,6 @@ contextBridge.exposeInMainWorld('desktopApi', {
             ipcRenderer.off(channel, (_, ...args) => func(...args));
         }
     },
-    // App ready
-    ready: () => ipcRenderer.send('ready'),
     // Updater
     checkForUpdates: () => ipcRenderer.send('update/check'),
     downloadUpdate: () => ipcRenderer.send('update/download'),

--- a/packages/suite-desktop/src/support/DesktopUpdater.tsx
+++ b/packages/suite-desktop/src/support/DesktopUpdater.tsx
@@ -8,6 +8,7 @@ import { Translation } from '@suite-components';
 import { UpdateInfo, UpdateProgress } from '@suite-types/desktop';
 import { useActions, useSelector } from '@suite-hooks';
 
+import { isDev } from '@suite-utils/build';
 import { getReleaseNotes, getReleaseUrl } from '@suite/services/github';
 
 import * as file from '@suite-utils/file';
@@ -177,16 +178,17 @@ const DesktopUpdater = () => {
     });
 
     useEffect(() => {
-        if (!window.desktopApi) {
+        // Don't run in dev builds (no updates to fetch, triggers errors)
+        if (isDev()) {
             return;
         }
 
-        window.desktopApi.on('update/checking', () => checking());
-        window.desktopApi.on('update/available', (info: UpdateInfo) => available(info));
-        window.desktopApi.on('update/not-available', (info: UpdateInfo) => notAvailable(info));
-        window.desktopApi.on('update/skip', (version: string) => skip(version));
-        window.desktopApi.on('update/downloaded', (info: UpdateInfo) => ready(info));
-        window.desktopApi.on('update/downloading', (progress: UpdateProgress) =>
+        window.desktopApi!.on('update/checking', () => checking());
+        window.desktopApi!.on('update/available', (info: UpdateInfo) => available(info));
+        window.desktopApi!.on('update/not-available', (info: UpdateInfo) => notAvailable(info));
+        window.desktopApi!.on('update/skip', (version: string) => skip(version));
+        window.desktopApi!.on('update/downloaded', (info: UpdateInfo) => ready(info));
+        window.desktopApi!.on('update/downloading', (progress: UpdateProgress) =>
             downloading(progress),
         );
 

--- a/packages/suite-desktop/src/support/DesktopUpdater.tsx
+++ b/packages/suite-desktop/src/support/DesktopUpdater.tsx
@@ -193,7 +193,7 @@ const DesktopUpdater = () => {
         );
 
         // Initial check for updates
-        window.desktopApi.checkForUpdates();
+        window.desktopApi!.checkForUpdates();
         // Check for updates every hour
         setInterval(() => window.desktopApi!.checkForUpdates(), 60 * 60 * 1000);
 

--- a/packages/suite-web-landing/components/Download/index.tsx
+++ b/packages/suite-web-landing/components/Download/index.tsx
@@ -69,7 +69,7 @@ const dropdownItemsData: DropdownItem[] = [
         platform: 'mac',
         label: 'for MacOS',
         icon: 'OS_MAC',
-        installerExtension: 'zip',
+        installerExtension: 'dmg',
     },
     {
         platform: 'windows',

--- a/packages/suite/src/views/settings/index.tsx
+++ b/packages/suite/src/views/settings/index.tsx
@@ -13,10 +13,11 @@ import {
 } from '@suite-components/Settings';
 import { FIAT, LANGUAGES } from '@suite-config';
 import { useAnalytics, useDevice } from '@suite-hooks';
-import { Switch } from '@trezor/components';
+import { Button, Tooltip, Switch } from '@trezor/components';
 import { capitalizeFirstLetter } from '@suite-utils/string';
 
 import { Props } from './Container';
+import { getReleaseUrl } from '@suite/services/github';
 
 const buildCurrencyOption = (currency: string) => ({
     value: currency,
@@ -27,6 +28,12 @@ const Version = styled.div`
     display: flex;
     align-items: center;
 `;
+
+const VersionButton = styled(Button)`
+    padding-left: 1ch;
+`;
+
+const VersionLink = styled.a``;
 
 const Settings = ({
     language,
@@ -208,14 +215,50 @@ const Settings = ({
                             <Version>
                                 <Translation
                                     id="TR_YOUR_CURRENT_VERSION"
-                                    values={{ version: process.env.VERSION }}
+                                    values={{
+                                        version: (
+                                            <Tooltip content={process.env.COMMITHASH || ''}>
+                                                <VersionLink
+                                                    target="_blank"
+                                                    href={`https://github.com/trezor/trezor-suite/commit/${process.env.COMMITHASH}`}
+                                                >
+                                                    <VersionButton
+                                                        variant="tertiary"
+                                                        icon="EXTERNAL_LINK"
+                                                        alignIcon="right"
+                                                    >
+                                                        {process.env.VERSION}
+                                                    </VersionButton>
+                                                </VersionLink>
+                                            </Tooltip>
+                                        ),
+                                    }}
                                 />
-                                {!['checking', 'not-available'].includes(desktopUpdate.state) && (
+                                {!['', 'checking', 'not-available'].includes(
+                                    desktopUpdate.state,
+                                ) && (
                                     <>
                                         &nbsp;
                                         <Translation
                                             id="TR_YOUR_NEW_VERSION"
-                                            values={{ version: desktopUpdate.latest?.version }}
+                                            values={{
+                                                version: (
+                                                    <VersionLink
+                                                        target="_blank"
+                                                        href={getReleaseUrl(
+                                                            desktopUpdate.latest!.version,
+                                                        )}
+                                                    >
+                                                        <VersionButton
+                                                            variant="tertiary"
+                                                            icon="EXTERNAL_LINK"
+                                                            alignIcon="right"
+                                                        >
+                                                            {desktopUpdate.latest!.version}
+                                                        </VersionButton>
+                                                    </VersionLink>
+                                                ),
+                                            }}
                                         />
                                     </>
                                 )}

--- a/packages/suite/src/views/settings/index.tsx
+++ b/packages/suite/src/views/settings/index.tsx
@@ -25,12 +25,19 @@ const buildCurrencyOption = (currency: string) => ({
 });
 
 const Version = styled.div`
-    display: flex;
-    align-items: center;
+    span {
+        display: flex;
+        align-items: center;
+    }
 `;
 
 const VersionButton = styled(Button)`
     padding-left: 1ch;
+`;
+
+const VersionTooltip = styled(Tooltip)`
+    display: inline-flex;
+    margin: 0 2px;
 `;
 
 const VersionLink = styled.a``;
@@ -217,7 +224,7 @@ const Settings = ({
                                     id="TR_YOUR_CURRENT_VERSION"
                                     values={{
                                         version: (
-                                            <Tooltip content={process.env.COMMITHASH || ''}>
+                                            <VersionTooltip content={process.env.COMMITHASH || ''}>
                                                 <VersionLink
                                                     target="_blank"
                                                     href={`https://github.com/trezor/trezor-suite/commit/${process.env.COMMITHASH}`}
@@ -230,7 +237,7 @@ const Settings = ({
                                                         {process.env.VERSION}
                                                     </VersionButton>
                                                 </VersionLink>
-                                            </Tooltip>
+                                            </VersionTooltip>
                                         ),
                                     }}
                                 />

--- a/patches/electron-updater+4.3.5.patch
+++ b/patches/electron-updater+4.3.5.patch
@@ -1,0 +1,23 @@
+diff --git a/node_modules/electron-updater/out/AppImageUpdater.js b/node_modules/electron-updater/out/AppImageUpdater.js
+index baf53e5..ebe5d13 100644
+--- a/node_modules/electron-updater/out/AppImageUpdater.js
++++ b/node_modules/electron-updater/out/AppImageUpdater.js
+@@ -108,8 +108,8 @@ class AppImageUpdater extends _BaseUpdater().BaseUpdater {
+           throw (0, _builderUtilRuntime().newError)("APPIMAGE env is not defined", "ERR_UPDATER_OLD_FILE_NOT_FOUND");
+         }
+
+-        let isDownloadFull = false;
+-
++        let isDownloadFull = true;
++        /*
+         try {
+           await new (_FileWithEmbeddedBlockMapDifferentialDownloader().FileWithEmbeddedBlockMapDifferentialDownloader)(fileInfo.info, this.httpExecutor, {
+             newUrl: fileInfo.url,
+@@ -125,6 +125,7 @@ class AppImageUpdater extends _BaseUpdater().BaseUpdater {
+
+           isDownloadFull = process.platform === "linux";
+         }
++        */
+
+         if (isDownloadFull) {
+           await this.httpExecutor.download(fileInfo.url, updateFile, downloadOptions);

--- a/yarn.lock
+++ b/yarn.lock
@@ -12609,11 +12609,6 @@ electron-localshortcut@^3.2.1:
     keyboardevent-from-electron-accelerator "^2.0.0"
     keyboardevents-areequal "^0.2.1"
 
-electron-log@^4.2.4:
-  version "4.2.4"
-  resolved "https://registry.yarnpkg.com/electron-log/-/electron-log-4.2.4.tgz#a13e42a9fc42ca2cc7d2603c3746352efa82112e"
-  integrity sha512-CXbDU+Iwi+TjKzugKZmTRIORIPe3uQRqgChUl19fkW/reFUn5WP7dt+cNGT3bkLV8xfPilpkPFv33HgtmLLewQ==
-
 electron-next@^3.1.5:
   version "3.1.5"
   resolved "https://registry.yarnpkg.com/electron-next/-/electron-next-3.1.5.tgz#6d7df1ffe9bdc300f79b33a1eea43c6767085f57"


### PR DESCRIPTION
This PR contains
- Added back missing version button and commit hash tooltip on the settings page #2525 
- Added new version button that sends the user to the release page of the latest release.
- Disabled update checking on dev builds.
- Removed `tar.gz` target for Linux builds and `zip` for Windows builds. Added `dmg` to Mac builds. Fixes #2550 
- Updating landing page and CI to reflect target updates.
- Added runtime flag to disable CSP `--disable-csp`. 
- Disabled differential downloads (caused issues with download progress and cancellation).
- Fixed issue with download cancellation not resetting view (back to download available page). 