### PR TITLE
feat: add intl support for suite-web-landing

### DIFF
--- a/packages/suite-web-landing/components/Download/index.tsx
+++ b/packages/suite-web-landing/components/Download/index.tsx
@@ -2,6 +2,7 @@ import React, { useState, useEffect } from 'react';
 import styled from 'styled-components';
 import { Button, Dropdown, Icon, colors, variables, Link } from '@trezor/components';
 import { IconType } from '@trezor/components/src/support/types';
+import Translation from '../Translation';
 import { Platform, getPlatform } from '../../utils/navigator';
 import { normalizeVersion } from '@suite-utils/build';
 
@@ -59,7 +60,7 @@ const VersionInfo = styled.div`
 
 type DropdownItem = {
     platform: Platform;
-    label: string;
+    label: React.ReactNode;
     icon: IconType;
     installerExtension: string;
 };
@@ -67,19 +68,19 @@ type DropdownItem = {
 const dropdownItemsData: DropdownItem[] = [
     {
         platform: 'mac',
-        label: 'for MacOS',
+        label: <Translation id="TR_SUITE_WEB_LANDING_MACOS_LABEL" />,
         icon: 'OS_MAC',
         installerExtension: 'dmg',
     },
     {
         platform: 'win',
-        label: 'for Windows 8+',
+        label: <Translation id="TR_SUITE_WEB_LANDING_WINDOWS_LABEL" />,
         icon: 'OS_WINDOWS',
         installerExtension: 'exe',
     },
     {
         platform: 'linux',
-        label: 'for Linux',
+        label: <Translation id="TR_SUITE_WEB_LANDING_LINUX_LABEL" />,
         icon: 'OS_LINUX',
         installerExtension: 'AppImage',
     },
@@ -130,11 +131,13 @@ const Index = () => {
                 </StyledDropdown>
                 <StyledDownloadButton>
                     <Link variant="nostyle" href={getInstallerURI(platform, version)}>
-                        Get desktop app
+                        <Translation id="TR_SUITE_WEB_LANDING_DOWNLOAD_DESKTOP" />
                     </Link>
                 </StyledDownloadButton>
             </ButtonWrapper>
-            <VersionInfo>Version: {version}</VersionInfo>
+            <VersionInfo>
+                <Translation id="TR_SUITE_WEB_LANDING_VERSION" values={{ version }} />
+            </VersionInfo>
         </div>
     );
 };

--- a/packages/suite-web-landing/components/Layout/index.tsx
+++ b/packages/suite-web-landing/components/Layout/index.tsx
@@ -1,5 +1,6 @@
 import React, { ReactNode } from 'react';
 import styled from 'styled-components';
+import Translation from '../Translation';
 import { TrezorLogo, Button, colors, variables, Link } from '@trezor/components';
 
 const Layout = styled.div`
@@ -117,7 +118,7 @@ const Index = ({ children }: Props) => (
                 color={colors.NEUE_TYPE_DARK_GREY}
             >
                 <Link variant="nostyle" href="./web">
-                    Trezor Suite for web
+                    <Translation id="TR_SUITE_WEB_LANDING_SUITE_ON_WEB" />
                 </Link>
             </Button>
         </Header>
@@ -125,23 +126,34 @@ const Index = ({ children }: Props) => (
         <Footer>
             <FooterLinks>
                 <FooterList>
-                    <FooterHeadline>Improve</FooterHeadline>
+                    <FooterHeadline>
+                        <Translation id="TR_SUITE_WEB_LANDING_FOOTER_HEADLINE_1" />
+                    </FooterHeadline>
                     <FooterLink href="https://satoshilabs.typeform.com/to/Dqb71wm1">
-                        Give feedback
+                        <Translation id="TR_SUITE_WEB_LANDING_FOOTER_FEEDBACK" />
                     </FooterLink>
                     <FooterLink href="https://blog.trezor.io/join-the-trezor-beta-testers-community-b19761f4960a">
-                        Join closed Beta
+                        <Translation id="TR_SUITE_WEB_LANDING_FOOTER_JOIN_CLOSED_BETA" />
                     </FooterLink>
                 </FooterList>
                 <FooterList>
-                    <FooterHeadline>Follow</FooterHeadline>
-                    <FooterLink href="https://blog.trezor.io/">Trezor Blog</FooterLink>
+                    <FooterHeadline>
+                        <Translation id="TR_SUITE_WEB_LANDING_FOOTER_HEADLINE_2" />
+                    </FooterHeadline>
+                    <FooterLink href="https://blog.trezor.io/">
+                        <Translation id="TR_SUITE_WEB_LANDING_FOOTER_BLOG" />
+                    </FooterLink>
                 </FooterList>
             </FooterLinks>
             <FooterCompany>
                 <TrezorLogo type="horizontal" variant="black" width="83px" />
                 <FooterParagraph>
-                    Companion to the <Link href="https://trezor.io/">Trezor hardware wallet</Link>
+                    <Translation
+                        id="TR_SUITE_WEB_LANDING_FOOTER_HEADLINE_PARAGRAPH"
+                        values={{
+                            a: chunks => <Link href="https://trezor.io/">{chunks}</Link>,
+                        }}
+                    />
                 </FooterParagraph>
             </FooterCompany>
         </Footer>

--- a/packages/suite-web-landing/components/Translation/index.tsx
+++ b/packages/suite-web-landing/components/Translation/index.tsx
@@ -1,0 +1,24 @@
+import React, { useContext } from 'react';
+import BaseTranslation from '@suite-components/Translation/components/BaseTranslation';
+import HelperTooltip, {
+    Props as HelperTooltipProps,
+} from '@suite-components/Translation/components/HelperTooltip';
+
+export const TranslationModeContext = React.createContext(false);
+
+const CustomHelperTooltip = (props: HelperTooltipProps) => {
+    const translationMode = useContext(TranslationModeContext);
+
+    return (
+        <HelperTooltip {...props} language="en" translationMode={translationMode}>
+            {props.children}
+        </HelperTooltip>
+    );
+};
+
+type TranslationProps = Omit<React.ComponentProps<typeof BaseTranslation>, 'translationTooltip'>;
+const Translation = (props: TranslationProps) => {
+    return <BaseTranslation {...props} translationTooltip={CustomHelperTooltip} />;
+};
+
+export default Translation;

--- a/packages/suite-web-landing/package.json
+++ b/packages/suite-web-landing/package.json
@@ -17,7 +17,8 @@
         "polished": "^4.0.3",
         "react": "16.13.1",
         "react-awesome-reveal": "^3.3.1",
-        "react-dom": "16.13.1"
+        "react-dom": "16.13.1",
+        "react-intl": "^5.8.5"
     },
     "devDependencies": {
         "@types/next": "^9.0.0",

--- a/packages/suite-web-landing/pages/index.tsx
+++ b/packages/suite-web-landing/pages/index.tsx
@@ -1,11 +1,14 @@
-import React from 'react';
+import React, { useState } from 'react';
 import styled from 'styled-components';
+import { IntlProvider } from 'react-intl';
 import Layout from '@suite-web-landing-components/Layout';
+import Translation, { TranslationModeContext } from '@suite-web-landing-components/Translation';
 import Download from '@suite-web-landing-components/Download';
 import Feature from '@suite-web-landing-components/Feature';
 import { resolveStaticPath } from '@suite-utils/nextjs';
 import { H1, P, variables, colors } from '@trezor/components';
 import { Fade } from 'react-awesome-reveal';
+import enLocale from '@trezor/suite-data/files/translations/en.json';
 
 const Wrapper = styled.div`
     display: flex;
@@ -57,7 +60,7 @@ const StyledHeadline = styled(H1)<{ size?: number }>`
     font-weight: ${variables.FONT_WEIGHT.DEMI_BOLD};
     line-height: 1.3;
     margin-bottom: 18px;
-    & > em {
+    em {
         font-style: normal;
         color: ${colors.NEUE_TYPE_GREEN};
     }
@@ -91,87 +94,117 @@ const StyledSoon = styled.div`
     color: ${colors.NEUE_TYPE_ORANGE};
 `;
 
+const TranslationModeTrigger = styled.div`
+    position: fixed;
+    width: 20px;
+    height: 20px;
+    left: 0px;
+    bottom: 0px;
+    /* background: red; */
+`;
+
 const features = [
     {
         id: 1,
-        headline: 'Desktop app',
-        text:
-            'Enhanced security and privacy, new design and improved performance, all in one software suite.',
+        headline: <Translation id="TR_SUITE_WEB_LANDING_FEATURES_1_HEADLINE" />,
+        text: <Translation id="TR_SUITE_WEB_LANDING_FEATURES_1_TEXT" />,
         backgroundPosition: 'bottom right',
         backgroundSize: '616px auto',
         soon: false,
     },
     {
         id: 2,
-        headline: 'Buy and exchange crypto',
-        text:
-            "Compare competitive rates, buy and exchange coins within Trezor's secure environment. Powered by +Invity.",
+        headline: <Translation id="TR_SUITE_WEB_LANDING_FEATURES_2_HEADLINE" />,
+        text: <Translation id="TR_SUITE_WEB_LANDING_FEATURES_2_TEXT" />,
         backgroundPosition: 'center left',
         backgroundSize: '489px auto',
         soon: true,
     },
     {
         id: 3,
-        headline: 'Native altcoin support',
-        text: 'ETH, XRP, ETC and more now supported \ndirectly through the app.',
+        headline: <Translation id="TR_SUITE_WEB_LANDING_FEATURES_3_HEADLINE" />,
+        text: <Translation id="TR_SUITE_WEB_LANDING_FEATURES_3_TEXT" />,
         backgroundSize: '500px auto',
         soon: false,
     },
 ];
 
-const Index = () => (
-    <Layout>
-        <Wrapper>
-            <StyledHeroCta>
-                <Fade direction="up" delay={500} triggerOnce>
-                    <StyledHeadline>
-                        Managing crypto just got
-                        <br />
-                        <em>safer and easier</em>
-                    </StyledHeadline>
-                </Fade>
-                <Fade delay={1500} triggerOnce>
-                    <StyledSubheadline>
-                        Take control of your Trezor with our desktop & browser app.
-                    </StyledSubheadline>
-                </Fade>
-                <DownloadWrapper>
-                    <Fade delay={2000} triggerOnce>
-                        <Download />
-                    </Fade>
-                </DownloadWrapper>
-            </StyledHeroCta>
-            <FeaturesWrapper>
-                {features.map((item, key) => (
-                    <Feature
-                        image={resolveStaticPath(`images/suite-web-landing/feature${item.id}.png`)}
-                        key={item.id}
-                        flip={key % 2 === 1}
-                        backgroundPosition={
-                            item.backgroundPosition !== undefined
-                                ? item.backgroundPosition
-                                : undefined
-                        }
-                        backgroundSize={item.backgroundSize}
-                    >
-                        {item.soon && <StyledSoon>Soon</StyledSoon>}
-                        <StyledH1>{item.headline}</StyledH1>
-                        <StyledP>{item.text}</StyledP>
-                    </Feature>
-                ))}
-            </FeaturesWrapper>
-            <StyledCta>
-                <StyledHeadline size={44}>
-                    Dozens of <em>brand-new features</em> to discover.
-                    <br />
-                    Try Suite now.
-                </StyledHeadline>
-                <DownloadWrapper>
-                    <Download />
-                </DownloadWrapper>
-            </StyledCta>
-        </Wrapper>
-    </Layout>
-);
+const Index = () => {
+    const [translationMode, setTranslationMode] = useState(false);
+
+    return (
+        <TranslationModeContext.Provider value={translationMode}>
+            <IntlProvider locale="en" messages={enLocale}>
+                <Layout>
+                    <Wrapper>
+                        <StyledHeroCta>
+                            <Fade direction="up" delay={500} triggerOnce>
+                                <StyledHeadline>
+                                    <Translation
+                                        id="TR_SUITE_WEB_LANDING_HEADLINE"
+                                        values={{
+                                            em: chunks => <em>{chunks}</em>,
+                                            lineBreak: <br />,
+                                        }}
+                                    />
+                                </StyledHeadline>
+                            </Fade>
+                            <Fade delay={1500} triggerOnce>
+                                <StyledSubheadline>
+                                    <Translation id="TR_SUITE_WEB_LANDING_SUB_HEADLINE" />
+                                </StyledSubheadline>
+                            </Fade>
+                            <DownloadWrapper>
+                                <Fade delay={2000} triggerOnce>
+                                    <Download />
+                                </Fade>
+                            </DownloadWrapper>
+                        </StyledHeroCta>
+                        <FeaturesWrapper>
+                            {features.map((item, key) => (
+                                <Feature
+                                    image={resolveStaticPath(
+                                        `images/suite-web-landing/feature${item.id}.png`,
+                                    )}
+                                    key={item.id}
+                                    flip={key % 2 === 1}
+                                    backgroundPosition={
+                                        item.backgroundPosition !== undefined
+                                            ? item.backgroundPosition
+                                            : undefined
+                                    }
+                                    backgroundSize={item.backgroundSize}
+                                >
+                                    {item.soon && (
+                                        <StyledSoon>
+                                            <Translation id="TR_SUITE_WEB_LANDING_SUB_SOON" />
+                                        </StyledSoon>
+                                    )}
+                                    <StyledH1>{item.headline}</StyledH1>
+                                    <StyledP>{item.text}</StyledP>
+                                </Feature>
+                            ))}
+                        </FeaturesWrapper>
+                        <StyledCta>
+                            <StyledHeadline size={44}>
+                                <Translation
+                                    id="TR_SUITE_WEB_LANDING_BOTTOM_HEADLINE"
+                                    values={{
+                                        em: chunks => <em>{chunks}</em>,
+                                        lineBreak: <br />,
+                                    }}
+                                />
+                            </StyledHeadline>
+                            <DownloadWrapper>
+                                <Download />
+                            </DownloadWrapper>
+                        </StyledCta>
+                    </Wrapper>
+                </Layout>
+                <TranslationModeTrigger onClick={() => setTranslationMode(prev => !prev)} />
+            </IntlProvider>
+        </TranslationModeContext.Provider>
+    );
+};
 
 export default Index;

--- a/packages/suite-web-landing/support/styles.ts
+++ b/packages/suite-web-landing/support/styles.ts
@@ -1,4 +1,4 @@
-import { variables, colors } from '@trezor/components';
+import { variables, colors, tooltipGlobalStyles } from '@trezor/components';
 
 export default `
     #__next {
@@ -37,5 +37,5 @@ export default `
     *:after {
         box-sizing: border-box;
     }
-
+    ${tooltipGlobalStyles}
 `;

--- a/packages/suite/package.json
+++ b/packages/suite/package.json
@@ -17,8 +17,6 @@
         "test-health": "jest -c jest.config.health.js"
     },
     "dependencies": {
-        "@formatjs/intl-pluralrules": "^1.5.3",
-        "@formatjs/intl-relativetimeformat": "^4.5.10",
         "@trezor/components": "^1.0.0",
         "@trezor/suite-data": "20.10.1",
         "@trezor/suite-storage": "20.10.1",
@@ -38,7 +36,7 @@
         "react-focus-lock": "^2.0.5",
         "react-hook-form": "6.7.1",
         "react-hotkeys-hook": "^1.5.4",
-        "react-intl": "^3.9.2",
+        "react-intl": "^5.8.5",
         "react-markdown": "^4.3.1",
         "react-native-web": "^0.11.2",
         "react-qr-reader": "^2.2.1",
@@ -73,7 +71,6 @@
         "@types/qs": "^6.9.2",
         "@types/react": "^16.7.11",
         "@types/react-dom": "^16.0.11",
-        "@types/react-intl": "^3.0.0",
         "@types/react-qr-reader": "^2.1.2",
         "@types/react-redux": "^7.1.7",
         "@types/react-test-renderer": "^16.9.1",

--- a/packages/suite/src/components/suite/FormattedNumber/index.tsx
+++ b/packages/suite/src/components/suite/FormattedNumber/index.tsx
@@ -5,13 +5,10 @@ import { FormattedNumber as FNumber } from 'react-intl';
 // wrapper for react-intl/FormattedNumber
 // FormattedNumber works with "number" values type also we want to handle Number.MAX_SAFE_INTEGER
 
-interface Props {
-    currency: string;
+type FNProps = React.ComponentProps<typeof FNumber>;
+type Props = {
     value: string | number;
-    minimumFractionDigits?: number;
-    maximumFractionDigits?: number;
-    style?: string;
-}
+} & Omit<FNProps, 'value'>;
 
 const FormattedNumber = (props: Props) => {
     const bn = new BigNumber(props.value);

--- a/packages/suite/src/components/suite/Translation/components/BaseTranslation/index.tsx
+++ b/packages/suite/src/components/suite/Translation/components/BaseTranslation/index.tsx
@@ -1,0 +1,73 @@
+import React from 'react';
+import { FormattedMessage, MessageDescriptor } from 'react-intl';
+import messages from '@suite/support/messages';
+
+interface TooltipProps {
+    isNested?: boolean;
+    messageId: keyof typeof messages;
+    children: any;
+}
+
+type OwnProps = {
+    isNested?: boolean;
+    translationTooltip: React.ComponentType<TooltipProps>;
+};
+
+type PrimitiveType = string | number | boolean | Date | null | undefined;
+
+// Add MessageDescriptor type to values entry
+type FormatXMLElementFn = (...args: any[]) => string | object;
+export interface ExtendedMessageDescriptor extends MessageDescriptor {
+    id: keyof typeof messages;
+    values?: {
+        [key: string]:
+            | PrimitiveType
+            | React.ReactElement
+            | ExtendedMessageDescriptor
+            | FormatXMLElementFn;
+    };
+}
+type MsgType = OwnProps & ExtendedMessageDescriptor;
+
+export const isMsgType = (props: MsgType | React.ReactNode): props is MsgType => {
+    return typeof props === 'object' && props !== null && (props as MsgType).id !== undefined;
+};
+
+const BaseTranslation = (props: MsgType) => {
+    const TooltipComponent = props.translationTooltip;
+    const values: Record<string, PrimitiveType | React.ReactNode | ExtendedMessageDescriptor> = {};
+    // message passed via props (id, defaultMessage, values)
+    Object.keys(props.values || []).forEach(key => {
+        // Iterates through all values. The entry may also contain a MessageDescriptor.
+        // If so, Renders MessageDescriptor by passing it to `Translation` component
+        const maybeMsg = props.values![key];
+        values[key] = isMsgType(maybeMsg) ? (
+            <BaseTranslation {...maybeMsg} translationTooltip={props.translationTooltip} isNested />
+        ) : (
+            maybeMsg
+        );
+    });
+
+    // prevent runtime errors
+    if (
+        !props.defaultMessage &&
+        Object.prototype.hasOwnProperty.call(props, 'id') &&
+        !messages[props.id]
+    ) {
+        return <>{`Unknown translation id: ${props.id}`}</>;
+    }
+
+    return (
+        <TooltipComponent isNested={props.isNested} messageId={props.id}>
+            <FormattedMessage
+                id={props.id}
+                tagName={props.isNested ? undefined : 'span'}
+                defaultMessage={props.defaultMessage || messages[props.id].defaultMessage}
+                // pass undefined to a 'values' prop in case of an empty values object
+                values={Object.keys(values).length === 0 ? undefined : values}
+            />
+        </TooltipComponent>
+    );
+};
+
+export default BaseTranslation;

--- a/packages/suite/src/components/suite/Translation/components/ConnectedHelperTooltip/index.tsx
+++ b/packages/suite/src/components/suite/Translation/components/ConnectedHelperTooltip/index.tsx
@@ -1,0 +1,18 @@
+import React from 'react';
+import { useSelector } from '@suite-hooks';
+import HelperTooltip, { Props } from '../HelperTooltip';
+
+const ConnectedHelperTooltip = (props: Props) => {
+    const { language, debugMode } = useSelector(state => ({
+        language: state.suite.settings.language,
+        debugMode: state.suite.settings.debug.translationMode,
+    }));
+
+    return (
+        <HelperTooltip {...props} language={language} translationMode={debugMode}>
+            {props.children}
+        </HelperTooltip>
+    );
+};
+
+export default ConnectedHelperTooltip;

--- a/packages/suite/src/components/suite/Translation/components/HelperTooltip/index.tsx
+++ b/packages/suite/src/components/suite/Translation/components/HelperTooltip/index.tsx
@@ -1,7 +1,5 @@
 import React from 'react';
 import styled from 'styled-components';
-import { connect } from 'react-redux';
-import { AppState, Dispatch } from '@suite-types';
 import { Tooltip, Link } from '@trezor/components';
 
 const StyledLink = styled(Link)`
@@ -16,20 +14,13 @@ const MessageWrapper = styled.span`
     text-decoration: underline solid red;
 `;
 
-const mapStateToProps = (state: AppState) => ({
-    translationMode: state.suite.settings.debug.translationMode,
-    language: state.suite.settings.language,
-});
-
-const mapDispatchToProps = (_dispatch: Dispatch) => ({});
-
-interface OwnProps {
+export interface Props {
     messageId?: string;
     isNested?: boolean;
+    language?: string;
+    translationMode?: boolean;
     children: any;
 }
-
-type Props = OwnProps & ReturnType<typeof mapStateToProps> & ReturnType<typeof mapDispatchToProps>;
 
 /**
  * When translationMode is enabled wraps a message with a Tooltip and adds styling to provide visual hint for translators
@@ -56,4 +47,4 @@ const HelperTooltip = (props: Props) => {
     );
 };
 
-export default connect(mapStateToProps, mapDispatchToProps)(HelperTooltip);
+export default HelperTooltip;

--- a/packages/suite/src/components/suite/Translation/index.tsx
+++ b/packages/suite/src/components/suite/Translation/index.tsx
@@ -1,47 +1,11 @@
 import React from 'react';
-import { FormattedMessage } from 'react-intl';
-import { ExtendedMessageDescriptor } from '@suite-types';
-import HelperTooltip from './components/HelperTooltip';
-import messages from '@suite/support/messages';
+import ConnectedHelperTooltip from './components/ConnectedHelperTooltip';
+import BaseTranslation from './components/BaseTranslation';
 
-type FormattedMessageProps = { isNested?: boolean };
-type MsgType = FormattedMessageProps & ExtendedMessageDescriptor;
-
-export const isMsgType = (props: MsgType | React.ReactNode): props is MsgType => {
-    return typeof props === 'object' && props !== null && (props as MsgType).id !== undefined;
-};
-
-type PrimitiveType = string | number | boolean | Date | null | undefined;
-
-const Translation = (props: MsgType) => {
-    const values: Record<string, PrimitiveType | React.ReactNode | ExtendedMessageDescriptor> = {};
-    // message passed via props (id, defaultMessage, values)
-    Object.keys(props.values || []).forEach(key => {
-        // Iterates through all values. The entry may also contain a MessageDescriptor.
-        // If so, Renders MessageDescriptor by passing it to `Translation` component
-        const maybeMsg = props.values![key];
-        values[key] = isMsgType(maybeMsg) ? <Translation {...maybeMsg} isNested /> : maybeMsg;
-    });
-
-    // prevent runtime errors
-    if (
-        !props.defaultMessage &&
-        Object.prototype.hasOwnProperty.call(props, 'id') &&
-        !messages[props.id]
-    ) {
-        return <>{`Unknown translation id: ${props.id}`}</>;
-    }
-    // pass undefined to a 'values' prop in case of an empty values object
-    return (
-        <HelperTooltip isNested={props.isNested} messageId={props.id}>
-            <FormattedMessage
-                id={props.id}
-                tagName={props.isNested ? undefined : 'span'}
-                defaultMessage={props.defaultMessage || messages[props.id].defaultMessage}
-                values={Object.keys(values).length === 0 ? undefined : values}
-            />
-        </HelperTooltip>
-    );
+const Translation = (
+    props: Omit<React.ComponentProps<typeof BaseTranslation>, 'translationTooltip'>,
+) => {
+    return <BaseTranslation {...props} translationTooltip={ConnectedHelperTooltip} />;
 };
 
 export { Translation };

--- a/packages/suite/src/support/messages.ts
+++ b/packages/suite/src/support/messages.ts
@@ -4461,6 +4461,98 @@ const definedMessages = defineMessages({
         id: 'TR_ACCOUNT_SEARCH_NO_RESULTS',
         defaultMessage: 'No results',
     },
+    TR_SUITE_WEB_LANDING_HEADLINE: {
+        id: 'TR_SUITE_WEB_LANDING_HEADLINE',
+        defaultMessage: 'Managing crypto just got{lineBreak}<em>safer and easier</em>',
+    },
+    TR_SUITE_WEB_LANDING_SUB_HEADLINE: {
+        id: 'TR_SUITE_WEB_LANDING_SUB_HEADLINE',
+        defaultMessage: 'Take control of your Trezor with our desktop & browser app.',
+    },
+    TR_SUITE_WEB_LANDING_SUB_SOON: {
+        id: 'TR_SUITE_WEB_LANDING_SUB_SOON',
+        defaultMessage: 'Soon',
+    },
+    TR_SUITE_WEB_LANDING_BOTTOM_HEADLINE: {
+        id: 'TR_SUITE_WEB_LANDING_BOTTOM_HEADLINE',
+        defaultMessage:
+            'Dozens of <em>brand-new features</em> to discover.{lineBreak}Try Suite now.',
+    },
+
+    TR_SUITE_WEB_LANDING_FEATURES_1_HEADLINE: {
+        id: 'TR_SUITE_WEB_LANDING_FEATURES_1_HEADLINE',
+        defaultMessage: 'Desktop app',
+    },
+    TR_SUITE_WEB_LANDING_FEATURES_1_TEXT: {
+        id: 'TR_SUITE_WEB_LANDING_FEATURES_1_TEXT',
+        defaultMessage:
+            'Enhanced security and privacy, new design and improved performance, all in one software suite.',
+    },
+    TR_SUITE_WEB_LANDING_FEATURES_2_HEADLINE: {
+        id: 'TR_SUITE_WEB_LANDING_FEATURES_2_HEADLINE',
+        defaultMessage: 'Buy and exchange crypto',
+    },
+    TR_SUITE_WEB_LANDING_FEATURES_2_TEXT: {
+        id: 'TR_SUITE_WEB_LANDING_FEATURES_2_TEXT',
+        defaultMessage:
+            "Compare competitive rates, buy and exchange coins within Trezor's secure environment. Powered by +Invity.",
+    },
+    TR_SUITE_WEB_LANDING_FEATURES_3_HEADLINE: {
+        id: 'TR_SUITE_WEB_LANDING_FEATURES_3_HEADLINE',
+        defaultMessage: 'Native altcoin support',
+    },
+    TR_SUITE_WEB_LANDING_FEATURES_3_TEXT: {
+        id: 'TR_SUITE_WEB_LANDING_FEATURES_3_TEXT',
+        defaultMessage: 'ETH, XRP, ETC and more now supported \ndirectly through the app.',
+    },
+    TR_SUITE_WEB_LANDING_SUITE_ON_WEB: {
+        id: 'TR_SUITE_WEB_LANDING_SUITE_ON_WEB',
+        defaultMessage: 'Trezor Suite for web',
+    },
+    TR_SUITE_WEB_LANDING_FOOTER_HEADLINE_1: {
+        id: 'TR_SUITE_WEB_LANDING_FOOTER_HEADLINE_1',
+        defaultMessage: 'Improve',
+    },
+    TR_SUITE_WEB_LANDING_FOOTER_FEEDBACK: {
+        id: 'TR_SUITE_WEB_LANDING_FOOTER_FEEDBACK',
+        defaultMessage: 'Give feedback',
+    },
+    TR_SUITE_WEB_LANDING_FOOTER_JOIN_CLOSED_BETA: {
+        id: 'TR_SUITE_WEB_LANDING_FOOTER_JOIN_CLOSED_BETA',
+        defaultMessage: 'Join closed Beta',
+    },
+    TR_SUITE_WEB_LANDING_FOOTER_BLOG: {
+        id: 'TR_SUITE_WEB_LANDING_FOOTER_BLOG',
+        defaultMessage: 'Trezor Blog',
+    },
+    TR_SUITE_WEB_LANDING_FOOTER_HEADLINE_2: {
+        id: 'TR_SUITE_WEB_LANDING_FOOTER_HEADLINE_2',
+        defaultMessage: 'Follow',
+    },
+    TR_SUITE_WEB_LANDING_FOOTER_HEADLINE_PARAGRAPH: {
+        id: 'TR_SUITE_WEB_LANDING_FOOTER_HEADLINE_PARAGRAPH',
+        defaultMessage: 'Companion to the <a>Trezor hardware wallet</a>',
+    },
+    TR_SUITE_WEB_LANDING_DOWNLOAD_DESKTOP: {
+        id: 'TR_SUITE_WEB_LANDING_DOWNLOAD_DESKTOP',
+        defaultMessage: 'Get desktop app',
+    },
+    TR_SUITE_WEB_LANDING_VERSION: {
+        id: 'TR_SUITE_WEB_LANDING_VERSION',
+        defaultMessage: 'Version: {version}',
+    },
+    TR_SUITE_WEB_LANDING_LINUX_LABEL: {
+        id: 'TR_SUITE_WEB_LANDING_LINUX_LABEL',
+        defaultMessage: 'for Linux',
+    },
+    TR_SUITE_WEB_LANDING_WINDOWS_LABEL: {
+        id: 'TR_SUITE_WEB_LANDING_WINDOWS_LABEL',
+        defaultMessage: 'for Windows 8+',
+    },
+    TR_SUITE_WEB_LANDING_MACOS_LABEL: {
+        id: 'TR_SUITE_WEB_LANDING_MACOS_LABEL',
+        defaultMessage: 'for MacOS',
+    },
 } as const);
 
 export default definedMessages;

--- a/packages/suite/src/support/suite/ConnectedIntlProvider.tsx
+++ b/packages/suite/src/support/suite/ConnectedIntlProvider.tsx
@@ -1,45 +1,6 @@
-/* eslint-disable global-require */
 import * as React from 'react';
-import { IntlProvider, MessageDescriptor } from 'react-intl';
+import { IntlProvider } from 'react-intl';
 import { useSelector } from '@suite-hooks/useSelector';
-import messages from '@suite/support/messages';
-
-// TODO: removes polyfills as we are not gonna support these browsers anyway
-// polyfill for Intl.PluralRules (e.g IE11 & Safari 12-)
-if (!Intl.PluralRules) {
-    require('@formatjs/intl-pluralrules/polyfill');
-    require('@formatjs/intl-pluralrules/dist/locale-data/ru');
-    require('@formatjs/intl-pluralrules/dist/locale-data/fr');
-    require('@formatjs/intl-pluralrules/dist/locale-data/es');
-    require('@formatjs/intl-pluralrules/dist/locale-data/de');
-    require('@formatjs/intl-pluralrules/dist/locale-data/cs');
-}
-
-// polyfill for Intl.RelativeTimeFormat (e.g IE11, Edge, Safari 13-)
-// TODO: TS types are missing Intl.RelativeTimeFormat
-// @ts-ignore
-if (!Intl.RelativeTimeFormat) {
-    require('@formatjs/intl-relativetimeformat/polyfill');
-    require('@formatjs/intl-relativetimeformat/dist/locale-data/ru');
-    require('@formatjs/intl-relativetimeformat/dist/locale-data/fr');
-    require('@formatjs/intl-relativetimeformat/dist/locale-data/es');
-    require('@formatjs/intl-relativetimeformat/dist/locale-data/de');
-    require('@formatjs/intl-relativetimeformat/dist/locale-data/cs');
-}
-
-type PrimitiveType = string | number | boolean | Date | null | undefined;
-
-// Add MessageDescriptor type to values entry
-export interface ExtendedMessageDescriptor extends MessageDescriptor {
-    id: keyof typeof messages;
-    values?: {
-        [key: string]: PrimitiveType | React.ReactElement | ExtendedMessageDescriptor;
-    };
-}
-
-export interface Messages {
-    [key: string]: MessageDescriptor;
-}
 
 const ConnectedIntlProvider: React.FC = ({ children }) => {
     const { locale, messages } = useSelector(state => ({

--- a/packages/suite/src/types/suite/index.ts
+++ b/packages/suite/src/types/suite/index.ts
@@ -24,7 +24,7 @@ import { DeviceMetadata } from '@suite-types/metadata';
 import { OnboardingActions } from '@onboarding-types';
 import { SettingsActions } from '@settings-types';
 import { FirmwareActions } from '@firmware-types';
-import { ExtendedMessageDescriptor as ExtendedMessageDescriptor$ } from '@suite-support/ConnectedIntlProvider';
+import { ExtendedMessageDescriptor as ExtendedMessageDescriptor$ } from '@suite-components/Translation/components/BaseTranslation';
 import { WalletAction } from '@wallet-types';
 import { BackupActions } from '@backup-actions/backupActions';
 import { RecoveryActions } from '@recovery-actions/recoveryActions';

--- a/yarn.lock
+++ b/yarn.lock
@@ -4080,12 +4080,28 @@
     unique-filename "^1.1.1"
     which "^1.3.1"
 
-"@formatjs/intl-listformat@^1.3.1":
-  version "1.3.1"
-  resolved "https://registry.yarnpkg.com/@formatjs/intl-listformat/-/intl-listformat-1.3.1.tgz#bb75fe8b1caa7c0df765d45ce32030b6123f5311"
-  integrity sha512-ASkGifaQ0icJr4/WWPYLTFnhsEnV1RKorTtS6SAvAud9jIuUc7vMcbKiecxOKoOLS9K62itnbZ89UluTLQ6tgQ==
+"@formatjs/ecma402-abstract@^1.2.4":
+  version "1.2.4"
+  resolved "https://registry.yarnpkg.com/@formatjs/ecma402-abstract/-/ecma402-abstract-1.2.4.tgz#0f11e0309bc885d53ddc823e36d04d520fda7674"
+  integrity sha512-5XEuvm+bImBmSFlhbE9FeRQKXWtpt+WIYRsma96bneoNMnUMeCADHJxNNSA5JSY4TlrjVZFHW3jE4HYm10bLbA==
   dependencies:
-    "@formatjs/intl-utils" "^1.6.0"
+    tslib "^2.0.1"
+
+"@formatjs/intl-displaynames@^3.3.11":
+  version "3.3.11"
+  resolved "https://registry.yarnpkg.com/@formatjs/intl-displaynames/-/intl-displaynames-3.3.11.tgz#433fc8cdc1c5d655b1e016122d33356ef621fa0b"
+  integrity sha512-GwcUOt8XbThNlGG7w8T2rJVCJD/ZgLKV+RbY2QnAw7d2S4Z6b7aRfHjZvs6ZSrHNTazTqkI/rz0yvufQJEkfLQ==
+  dependencies:
+    "@formatjs/ecma402-abstract" "^1.2.4"
+    tslib "^2.0.1"
+
+"@formatjs/intl-listformat@^4.2.9":
+  version "4.2.9"
+  resolved "https://registry.yarnpkg.com/@formatjs/intl-listformat/-/intl-listformat-4.2.9.tgz#94a603d3b84634d555a1f8c72efaa943d36fcb3d"
+  integrity sha512-SNHn3ZA5Un9r+j4EoDjYMeYp0niXb90MeG+GFwpYK0L/mbBiUUlBf7RZul8Jdr9ixrMEIW9ptUMOv03zWDfwAQ==
+  dependencies:
+    "@formatjs/ecma402-abstract" "^1.2.4"
+    tslib "^2.0.1"
 
 "@formatjs/intl-numberformat@^4.2.9":
   version "4.2.9"
@@ -4094,62 +4110,13 @@
   dependencies:
     "@formatjs/intl-utils" "^3.4.1"
 
-"@formatjs/intl-pluralrules@^1.5.3":
-  version "1.5.3"
-  resolved "https://registry.yarnpkg.com/@formatjs/intl-pluralrules/-/intl-pluralrules-1.5.3.tgz#eb7ebea49340a4cc52437a8480b0c284bfa8f20b"
-  integrity sha512-piBxSgQLRcaM754lwEjnNWqtMZfqPTjLGp9qqE1pktNUge46Ub10WToos9qYssKuuxy4RzKUeklvSsxwhcT1ZQ==
+"@formatjs/intl-relativetimeformat@^7.2.9":
+  version "7.2.9"
+  resolved "https://registry.yarnpkg.com/@formatjs/intl-relativetimeformat/-/intl-relativetimeformat-7.2.9.tgz#054c1c49cbd1c4f437763583c916579b1822c03e"
+  integrity sha512-hFVhXeo+/zg2z0t7xcSZRAOQ5oO5NKoDjUNG/pQpJH+yUfqfFxkU1W1KFEV+bnwJaoUf6OQjEeoR6bgN/N1y1w==
   dependencies:
-    "@formatjs/intl-utils" "^2.2.0"
-
-"@formatjs/intl-relativetimeformat@^4.1.1":
-  version "4.2.0"
-  resolved "https://registry.yarnpkg.com/@formatjs/intl-relativetimeformat/-/intl-relativetimeformat-4.2.0.tgz#dc403699eb5755dd19307c93a6541232b14dd721"
-  integrity sha512-0NQnixfRIdwRMagVR0CmqfKaI8xCtT1oZ0tAU7zrsch0k6N2wJFUYBsOtlgSqRR4hz2gAbVc7Rv5tdzkWW5fgg==
-  dependencies:
-    "@formatjs/intl-utils" "^1.4.0"
-
-"@formatjs/intl-relativetimeformat@^4.5.1":
-  version "4.5.1"
-  resolved "https://registry.yarnpkg.com/@formatjs/intl-relativetimeformat/-/intl-relativetimeformat-4.5.1.tgz#167298f3ca61123ac4cc4e45d09e55678dd7d369"
-  integrity sha512-s32xwuxvkozX6NxUVAnEGZU1/k3HA3kSsRXtpCvftnCWsshNAUsUWLS/6GpfHcjLfY1XEGptSKouTasyGLZdsg==
-  dependencies:
-    "@formatjs/intl-utils" "^1.6.0"
-
-"@formatjs/intl-relativetimeformat@^4.5.10":
-  version "4.5.10"
-  resolved "https://registry.yarnpkg.com/@formatjs/intl-relativetimeformat/-/intl-relativetimeformat-4.5.10.tgz#5c23775da4366e8e3763c900270711d42a0f4fb7"
-  integrity sha512-lQXqwywTcWL88VV+6RC1xShZjH0ry4/TEQHKGcTF3ObJp2P61EHIu8UftYgFfDqRDSV9/yQBiyStaBZWbHNlzg==
-  dependencies:
-    "@formatjs/intl-utils" "^2.2.0"
-
-"@formatjs/intl-unified-numberformat@^1.0.0":
-  version "1.0.1"
-  resolved "https://registry.yarnpkg.com/@formatjs/intl-unified-numberformat/-/intl-unified-numberformat-1.0.1.tgz#5c74d5d1a1e2a9451482da83dfb8524f65603665"
-  integrity sha512-nlHCmisXCzCOloy+My1PCGkjfrkFeHwDSq2IVnt8OFwDbljXX+atGg32T+w3nvRpbMWBJ7GsYIEeaZq+UFMomw==
-  dependencies:
-    "@formatjs/intl-utils" "^1.3.0"
-
-"@formatjs/intl-unified-numberformat@^2.2.0":
-  version "2.2.0"
-  resolved "https://registry.yarnpkg.com/@formatjs/intl-unified-numberformat/-/intl-unified-numberformat-2.2.0.tgz#ef82469962d7e66dbfce511409961d7013253ecd"
-  integrity sha512-A9ov4uO04pSHG5Iqcrc457hvsq3lz/oWQ3B0I03zbL1rnBC8ttrZEobw3X3k/tWYPXeNJbRtsSbXqzJo55NeBw==
-  dependencies:
-    "@formatjs/intl-utils" "^1.6.0"
-
-"@formatjs/intl-utils@^1.3.0", "@formatjs/intl-utils@^1.4.0":
-  version "1.4.0"
-  resolved "https://registry.yarnpkg.com/@formatjs/intl-utils/-/intl-utils-1.4.0.tgz#b59fdf78bbae9f99c500a298bf73b1945f5991f1"
-  integrity sha512-z5HyJumGzORM+5SpvkAlp/hu0AHDeZcUNKSmj9NjS7kWxOGZMuAdS3X1K5XiE0j5I8r8s8SIaz0IQOdMA1WFeA==
-
-"@formatjs/intl-utils@^1.6.0":
-  version "1.6.0"
-  resolved "https://registry.yarnpkg.com/@formatjs/intl-utils/-/intl-utils-1.6.0.tgz#43b094232b9ef98b57a270bcecee99168d329e9f"
-  integrity sha512-5D0C4tQgNFJNaJ17BYum0GfAcKNK3oa1VWzgkv/AN7i52fg4r69ZLcpEGpf6tZiX9Qld8CDwTQOeFt6fuOqgVw==
-
-"@formatjs/intl-utils@^2.2.0":
-  version "2.2.0"
-  resolved "https://registry.yarnpkg.com/@formatjs/intl-utils/-/intl-utils-2.2.0.tgz#ba6e12fe64ff7fd160be392007c47d24b7ae5c75"
-  integrity sha512-+Az7tR1av1DHZu9668D8uh9atT6vp+FFmEF8BrEssv0OqzpVjpVBGVmcgPzQP8k2PQjVlm/h2w8cTt0knn132w==
+    "@formatjs/ecma402-abstract" "^1.2.4"
+    tslib "^2.0.1"
 
 "@formatjs/intl-utils@^3.4.1":
   version "3.4.1"
@@ -4158,10 +4125,19 @@
   dependencies:
     emojis-list "^3.0.0"
 
-"@formatjs/macro@^0.2.6":
-  version "0.2.6"
-  resolved "https://registry.yarnpkg.com/@formatjs/macro/-/macro-0.2.6.tgz#eb173658d803416a43210778b2f5c04c5a240bb6"
-  integrity sha512-DfdnLJf8+PwLHzJECZ1Xfa8+sI9akQnUuLN2UdkaExTQmlY0Vs36rMzEP0JoVDBMk+KdQbJNt72rPeZkBNcKWg==
+"@formatjs/intl@^1.3.5":
+  version "1.3.5"
+  resolved "https://registry.yarnpkg.com/@formatjs/intl/-/intl-1.3.5.tgz#c04c6296f8a57d2a540453a3d3305c0fee7f4cf9"
+  integrity sha512-pa0oSm7nJ4RhQzm0CLWJDl7WdyJCAbLoPtEN39gvH8nG4aa3394vZuDwkxz60KxAGHEMi8uAcikEGuoqvUQ21Q==
+  dependencies:
+    "@formatjs/ecma402-abstract" "^1.2.4"
+    "@formatjs/intl-displaynames" "^3.3.11"
+    "@formatjs/intl-listformat" "^4.2.9"
+    "@formatjs/intl-relativetimeformat" "^7.2.9"
+    fast-memoize "^2.5.2"
+    intl-messageformat "^9.3.10"
+    intl-messageformat-parser "^6.0.9"
+    tslib "^2.0.1"
 
 "@hapi/address@2.x.x":
   version "2.1.2"
@@ -6515,11 +6491,6 @@
   resolved "https://registry.yarnpkg.com/@types/html-minifier-terser/-/html-minifier-terser-5.0.0.tgz#7532440c138605ced1b555935c3115ddd20e8bef"
   integrity sha512-q95SP4FdkmF0CwO0F2q0H6ZgudsApaY/yCtAQNRn1gduef5fGpyEphzy0YCq/N0UFvDSnLg5V8jFK/YGXlDiCw==
 
-"@types/invariant@^2.2.30":
-  version "2.2.30"
-  resolved "https://registry.yarnpkg.com/@types/invariant/-/invariant-2.2.30.tgz#20efa342807606ada5483731a8137cb1561e5fe9"
-  integrity sha512-98fB+yo7imSD2F7PF7GIpELNgtLNgo5wjivu0W5V4jx+KVVJxo6p/qN4zdzSTBWy4/sN3pPyXwnhRSD28QX+ag==
-
 "@types/invity-api@^1.0.0":
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/@types/invity-api/-/invity-api-1.0.0.tgz#ac49fe6b05be900acbed5c85c4a51a98e977a3fd"
@@ -6735,13 +6706,6 @@
   integrity sha512-eIRpEW73DCzPIMaNBDP5pPIpK1KXyZwNgfxiVagb5iGiz6da+9A5hslSX6GAQKdO7SayVCS/Fr2kjqprgAvkfA==
   dependencies:
     "@types/react" "*"
-
-"@types/react-intl@^3.0.0":
-  version "3.0.0"
-  resolved "https://registry.yarnpkg.com/@types/react-intl/-/react-intl-3.0.0.tgz#a2cce0024b6cfe403be28ccf67f49d720fa810ec"
-  integrity sha512-k8F3d05XQGEqSWIfK97bBjZe4z9RruXU9Wa7OZ2iUC5pdeIpzuQDZe/9C2J3Xir5//ZtAkhcv08Wfx3n5TBTQg==
-  dependencies:
-    react-intl "*"
 
 "@types/react-native@*":
   version "0.57.65"
@@ -13910,6 +13874,11 @@ fast-levenshtein@~2.0.4, fast-levenshtein@~2.0.6:
   resolved "https://registry.yarnpkg.com/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz#3d8a5c66883a16a30ca8643e851f19baa7797917"
   integrity sha1-PYpcZog6FqMMqGQ+hR8Zuqd5eRc=
 
+fast-memoize@^2.5.2:
+  version "2.5.2"
+  resolved "https://registry.yarnpkg.com/fast-memoize/-/fast-memoize-2.5.2.tgz#79e3bb6a4ec867ea40ba0e7146816f6cdce9b57e"
+  integrity sha512-Ue0LwpDYErFbmNnZSF0UH6eImUwDmogUO1jyE+JbN2gsQz/jICm1Ve7t9QT0rNSsfJt+Hs4/S3GnsDVjL4HVrw==
+
 fast-safe-stringify@^1.0.8, fast-safe-stringify@^1.2.1:
   version "1.2.3"
   resolved "https://registry.npmjs.org/fast-safe-stringify/-/fast-safe-stringify-1.2.3.tgz#9fe22c37fb2f7f86f06b8f004377dbf8f1ee7bc1"
@@ -15437,14 +15406,14 @@ hoist-non-react-statics@^2.3.1:
   resolved "https://registry.yarnpkg.com/hoist-non-react-statics/-/hoist-non-react-statics-2.5.5.tgz#c5903cf409c0dfd908f388e619d86b9c1174cb47"
   integrity sha512-rqcy4pJo55FTTLWt+bU8ukscqHeE/e9KWvsOW2b/a3afxQZhwkQdT1rPPCJ0rYXdj4vNcasY8zHTH+jF/qStxw==
 
-hoist-non-react-statics@^3.0.0:
+hoist-non-react-statics@^3.0.0, hoist-non-react-statics@^3.3.2:
   version "3.3.2"
   resolved "https://registry.npmjs.org/hoist-non-react-statics/-/hoist-non-react-statics-3.3.2.tgz#ece0acaf71d62c2969c2ec59feff42a4b1a85b45"
   integrity sha512-/gGivxi8JPKWNm/W0jSmzcMPpfpPLc3dY/6GxhX2hQ9iGj3aDfklV4ET7NjKpSinLpJ5vafa9iiGIEZg10SfBw==
   dependencies:
     react-is "^16.7.0"
 
-hoist-non-react-statics@^3.0.1, hoist-non-react-statics@^3.3.1:
+hoist-non-react-statics@^3.0.1:
   version "3.3.1"
   resolved "https://registry.yarnpkg.com/hoist-non-react-statics/-/hoist-non-react-statics-3.3.1.tgz#101685d3aff3b23ea213163f6e8e12f4f111e19f"
   integrity sha512-wbg3bpgA/ZqWrZuMOeJi8+SKMhr7X9TesL/rXMjTzh0p0JUBo3II8DHboYbuIXWRlttrUFxwcu/5kygrCw8fJw==
@@ -16107,42 +16076,10 @@ interpret@^2.0.0:
   resolved "https://registry.npmjs.org/interpret/-/interpret-2.0.0.tgz#b783ffac0b8371503e9ab39561df223286aa5433"
   integrity sha512-e0/LknJ8wpMMhTiWcjivB+ESwIuvHnBSlBbmP/pSb8CQJldoj1p2qv7xGZ/+BtbTziYRFSz8OsvdbiX45LtYQA==
 
-intl-format-cache@^4.2.1, intl-format-cache@^4.2.2:
-  version "4.2.2"
-  resolved "https://registry.yarnpkg.com/intl-format-cache/-/intl-format-cache-4.2.2.tgz#4e745d4cda3aa9df2495f0493bed4c6c4ff7093d"
-  integrity sha512-7tY3XadLn8rMHiYVUzH/6NmOe944nJ59LdAWuFm64/m2OfFAEkZTtTHxrEtoxq7HWFddX4aRwDb9P8KB5Z2AvQ==
-
-intl-format-cache@^4.2.13:
-  version "4.2.13"
-  resolved "https://registry.yarnpkg.com/intl-format-cache/-/intl-format-cache-4.2.13.tgz#7f3df3de048dc87353391cd75760b98b596060da"
-  integrity sha512-yIIS4bKrWzBcWcCHArmEYB+VMSlVUWwOGwSlhWVVVWgVcouejAOm+Ivk9UKN0FKBuFzryfmWUMvbCJuMuMXgDw==
-
-intl-locales-supported@^1.5.0:
-  version "1.6.0"
-  resolved "https://registry.yarnpkg.com/intl-locales-supported/-/intl-locales-supported-1.6.0.tgz#6f66501ef23a58c87f242021cfadb1b012770808"
-  integrity sha512-n8J5v2oBjaOu065/HXeDFU3huv76Ehwj6YovPI7IJ3DCf0EvvwL1lncRj/qobmlyDh0LumwxpU+pVhFR34xjEA==
-
-intl-locales-supported@^1.8.4:
-  version "1.8.4"
-  resolved "https://registry.yarnpkg.com/intl-locales-supported/-/intl-locales-supported-1.8.4.tgz#e1d19812afa50dc2e2a2b4741ceb4030522d45b1"
-  integrity sha512-wO0JhDqhshhkq8Pa9CLcstqd1aCXjfMgfMzjD6mDreS3mTSDbjGiMU+07O8BdJGxed7Q0Wf3TFVjGq0W3Y0n1w==
-
 intl-messageformat-parser@^1.8.1:
   version "1.8.1"
   resolved "https://registry.yarnpkg.com/intl-messageformat-parser/-/intl-messageformat-parser-1.8.1.tgz#0eb14c5618333be4c95c409457b66c8c33ddcc01"
   integrity sha512-IMSCKVf0USrM/959vj3xac7s8f87sc+80Y/ipBzdKy4ifBv5Gsj2tZ41EAaURVg01QU71fYr77uA8Meh6kELbg==
-
-intl-messageformat-parser@^3.2.0, intl-messageformat-parser@^3.2.1:
-  version "3.2.1"
-  resolved "https://registry.yarnpkg.com/intl-messageformat-parser/-/intl-messageformat-parser-3.2.1.tgz#598795221267cbbd206f1497c42ffced9b5565b6"
-  integrity sha512-ajCL1k1ha0mUrutlBTo5vcTzyfdH2OoghUu8SmR7tJ1D0uifZh9Hqd3ZC2SYVv/GTfTdW//rgKonMgAhZWmwZg==
-
-intl-messageformat-parser@^3.5.1:
-  version "3.5.1"
-  resolved "https://registry.yarnpkg.com/intl-messageformat-parser/-/intl-messageformat-parser-3.5.1.tgz#523a17bd2ef4a92209956b7cc953a0170bcf5b76"
-  integrity sha512-aCUjbLCZYhWJzC5gJiXKYR+OCE8rIegRBsjm1irJSH0AmeC7dIOp3nzOCc84BcyFX5baoXJfijV6SWqYUrN27w==
-  dependencies:
-    "@formatjs/intl-unified-numberformat" "^2.2.0"
 
 intl-messageformat-parser@^5.1.6:
   version "5.1.6"
@@ -16151,6 +16088,14 @@ intl-messageformat-parser@^5.1.6:
   dependencies:
     "@formatjs/intl-numberformat" "^4.2.9"
 
+intl-messageformat-parser@^6.0.9:
+  version "6.0.9"
+  resolved "https://registry.yarnpkg.com/intl-messageformat-parser/-/intl-messageformat-parser-6.0.9.tgz#323b3631afc8202276243134507c1ee11d206c80"
+  integrity sha512-cWYP9l/3/zgs90wZf8lBPWDxBwJSa86j0QFXVTsvuFUsS0pdPweZhvLx5KV78vXQgN3WOQYzdS6/R87A8mZcVw==
+  dependencies:
+    "@formatjs/ecma402-abstract" "^1.2.4"
+    tslib "^2.0.1"
+
 intl-messageformat@^4.4.0:
   version "4.4.0"
   resolved "https://registry.yarnpkg.com/intl-messageformat/-/intl-messageformat-4.4.0.tgz#aa196a4d04b573f4090bc417f982d81de4f74fad"
@@ -16158,21 +16103,14 @@ intl-messageformat@^4.4.0:
   dependencies:
     intl-messageformat-parser "^1.8.1"
 
-intl-messageformat@^7.3.1:
-  version "7.3.2"
-  resolved "https://registry.yarnpkg.com/intl-messageformat/-/intl-messageformat-7.3.2.tgz#8dcf53237faec86061ace315f36aeffe7edb4c8d"
-  integrity sha512-1hSgNhnpQqNrr09lFiz/oA3jX+REBuSyXh/ePvSncUicMsREtH3j2X1tDTTFHbK5kHjI+9vcwGpDSZpP8CM/uQ==
+intl-messageformat@^9.3.10:
+  version "9.3.10"
+  resolved "https://registry.yarnpkg.com/intl-messageformat/-/intl-messageformat-9.3.10.tgz#bd217a22a756e97b85734cb63de85f61ed673606"
+  integrity sha512-LHkUjt0cDm6a/Rd+bGDPcgHZor7KXQeZA5kM64P9I4Sg7xiNUMnzHPJ9n3ah6/LV/4vTUIJKp00Q9RLs+4nLCQ==
   dependencies:
-    intl-format-cache "^4.2.2"
-    intl-messageformat-parser "^3.2.1"
-
-intl-messageformat@^7.7.2:
-  version "7.7.2"
-  resolved "https://registry.yarnpkg.com/intl-messageformat/-/intl-messageformat-7.7.2.tgz#99839c4fde020523c4a66c10a4cc28060ac2fd3f"
-  integrity sha512-dcZxYh1laXLrv3VVb/Ke4lGee/NJmBcmA5ATPtX51dEL+aePs5GuQXD/MepxTv9M8kKqEt6KauGUwz6+X/tqBQ==
-  dependencies:
-    intl-format-cache "^4.2.13"
-    intl-messageformat-parser "^3.5.1"
+    fast-memoize "^2.5.2"
+    intl-messageformat-parser "^6.0.9"
+    tslib "^2.0.1"
 
 intl-pluralrules@^1.0.3:
   version "1.1.2"
@@ -16186,7 +16124,7 @@ intl@^1.2.5:
   resolved "https://registry.yarnpkg.com/intl/-/intl-1.2.5.tgz#82244a2190c4e419f8371f5aa34daa3420e2abde"
   integrity sha1-giRKIZDE5Bn4Nx9ao02qNCDiq94=
 
-invariant@2.2.4, invariant@^2.1.1, invariant@^2.2.2, invariant@^2.2.3, invariant@^2.2.4:
+invariant@2.2.4, invariant@^2.2.2, invariant@^2.2.3, invariant@^2.2.4:
   version "2.2.4"
   resolved "https://registry.yarnpkg.com/invariant/-/invariant-2.2.4.tgz#610f3c92c9359ce1db616e538008d23ff35158e6"
   integrity sha512-phJfQVBuaJM5raOpJjSfkiD6BpbCE4Ns//LaXl6wGYtUBY83nWS6Rf9tXm2e8VaK60JEjYldbPif/A2B1C2gNA==
@@ -22899,41 +22837,23 @@ react-intersection-observer@^8.28.4:
   resolved "https://registry.yarnpkg.com/react-intersection-observer/-/react-intersection-observer-8.29.0.tgz#8349a6301bfc24329a029036c6bed30f9864f3ad"
   integrity sha512-Bqp7GBa5Aieo8C33Bz0e5WuUnFUKN3WOayKMT/2f0ujfW+YpzOEdNE4MK/TnaHp+cisK7n1At3qcFaNPfhHbqw==
 
-react-intl@*:
-  version "3.3.2"
-  resolved "https://registry.yarnpkg.com/react-intl/-/react-intl-3.3.2.tgz#e60ba59736b612654653be2409be3b9711a646af"
-  integrity sha512-Y2QMrcVxkVSzuTD/3+wkbJOV+vYcu60KsKY5XqJ6IkzseFY68myk7ijJ1UHXOP/xBdJtwiXVOCG10EDwDGj/xQ==
+react-intl@^5.8.5:
+  version "5.8.5"
+  resolved "https://registry.yarnpkg.com/react-intl/-/react-intl-5.8.5.tgz#bc5dfab259049830621e129b8bffb1ac33ef4124"
+  integrity sha512-TJXeFlKfiIWVWmilVlY+0IKkxlnQinnTp9wLpWRk963quR3OtDeaqltxQ6pezRIolG4ItZx9Cpa+h3SOVAeE9g==
   dependencies:
-    "@formatjs/intl-relativetimeformat" "^4.1.1"
-    "@formatjs/intl-unified-numberformat" "^1.0.0"
+    "@formatjs/ecma402-abstract" "^1.2.4"
+    "@formatjs/intl" "^1.3.5"
+    "@formatjs/intl-displaynames" "^3.3.11"
+    "@formatjs/intl-listformat" "^4.2.9"
+    "@formatjs/intl-relativetimeformat" "^7.2.9"
     "@types/hoist-non-react-statics" "^3.3.1"
-    "@types/invariant" "^2.2.30"
-    hoist-non-react-statics "^3.3.0"
-    intl-format-cache "^4.2.1"
-    intl-locales-supported "^1.5.0"
-    intl-messageformat "^7.3.1"
-    intl-messageformat-parser "^3.2.0"
-    invariant "^2.1.1"
-    shallow-equal "^1.1.0"
-
-react-intl@^3.9.2:
-  version "3.9.2"
-  resolved "https://registry.yarnpkg.com/react-intl/-/react-intl-3.9.2.tgz#24d479877e43fb953bc8af494927ae57d6a6421a"
-  integrity sha512-QuiY90qO1mGRJ21Lpe1jL3NxAexmhYBrv/9Rw8dcrytv6M1FfVcGVYsruU8PUFYdFhFvQd2BMcw1uu0nomTIHg==
-  dependencies:
-    "@formatjs/intl-listformat" "^1.3.1"
-    "@formatjs/intl-relativetimeformat" "^4.5.1"
-    "@formatjs/intl-unified-numberformat" "^2.2.0"
-    "@formatjs/macro" "^0.2.6"
-    "@types/hoist-non-react-statics" "^3.3.1"
-    "@types/invariant" "^2.2.30"
-    hoist-non-react-statics "^3.3.1"
-    intl-format-cache "^4.2.13"
-    intl-locales-supported "^1.8.4"
-    intl-messageformat "^7.7.2"
-    intl-messageformat-parser "^3.5.1"
-    invariant "^2.1.1"
+    fast-memoize "^2.5.2"
+    hoist-non-react-statics "^3.3.2"
+    intl-messageformat "^9.3.10"
+    intl-messageformat-parser "^6.0.9"
     shallow-equal "^1.2.1"
+    tslib "^2.0.1"
 
 react-is@16.13.1, react-is@^16.13.1:
   version "16.13.1"
@@ -27186,6 +27106,11 @@ tslib@^2.0.0:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/tslib/-/tslib-2.0.1.tgz#410eb0d113e5b6356490eec749603725b021b43e"
   integrity sha512-SgIkNheinmEBgx1IUNirK0TUD4X9yjjBRTqqjggWCU3pUEqIk3/Uwl3yRixYKT6WjQuGiwDv4NomL3wqRCj+CQ==
+
+tslib@^2.0.1:
+  version "2.0.2"
+  resolved "https://registry.yarnpkg.com/tslib/-/tslib-2.0.2.tgz#462295631185db44b21b1ea3615b63cd1c038242"
+  integrity sha512-wAH28hcEKwna96/UacuWaVspVLkg4x1aDM9JlzqaQTOFczCktkVAb5fmXChgandR1EraDPs2w8P+ozM+oafwxg==
 
 tsutils@^3.17.1:
   version "3.17.1"


### PR DESCRIPTION
close https://github.com/trezor/trezor-suite/issues/2562

- intl for suite-web-landing
- bump react-intl lib
- change to the Translation component that allows to reuse it outside of redux (as landing page doesn't use and need full blown redux support). The main change is separating redux connected container from dummy presentational component for a Tooltip used in Translation component (shows message id on hover when translation mode is enabled). Suite uses redux connected version that checks if a translation mode is enabled in redux state (nothing changed). suite-web-landing uses redux-free version and enables translation mode based on local state.