### PR TITLE
feat(suite-desktop): add pre-release runtime flag

### DIFF
--- a/docs/packages/suite-desktop.md
+++ b/docs/packages/suite-desktop.md
@@ -10,3 +10,4 @@ Available flags:
 | name | description |
 | --- | --- |
 | `--disable-csp` | Disables the Content Security Policy. Necessary for using DevTools in a production build. |
+| `--pre-release` | Tells the auto-updater to fetch pre-release updates. |

--- a/packages/suite-desktop/package.json
+++ b/packages/suite-desktop/package.json
@@ -44,6 +44,11 @@
                 "to": "images/icons/512x512.png"
             }
         ],
+        "publish": {
+            "provider": "github",
+            "repo": "trezor-suite",
+            "owner": "trezor"
+        },
         "dmg": {
             "contents": [
                 {

--- a/packages/suite-desktop/src-electron/electron.ts
+++ b/packages/suite-desktop/src-electron/electron.ts
@@ -29,6 +29,7 @@ const src = isDev
 
 // Runtime flags
 const disableCspFlag = app.commandLine.hasSwitch('disable-csp');
+const preReleaseFlag = app.commandLine.hasSwitch('pre-release');
 
 // Updater
 const updateCancellationToken = new CancellationToken();
@@ -193,6 +194,7 @@ const init = async () => {
 
     autoUpdater.autoDownload = false;
     autoUpdater.autoInstallOnAppQuit = true;
+    autoUpdater.allowPrerelease = preReleaseFlag;
 
     if (updateSettings.skipVersion) {
         mainWindow.webContents.send('update/skip', updateSettings.skipVersion);


### PR DESCRIPTION
- Adds a pre-release runtime flag for the auto-updater to fetch builds tagged as "pre-release" from GitHub.
- Adds publish configuration to generate `update.yml` files when building.