### PR TITLE
fix(metadata): dropbox token renewal

### DIFF
--- a/packages/integration-tests/projects/suite-web/plugins/dropbox.js
+++ b/packages/integration-tests/projects/suite-web/plugins/dropbox.js
@@ -10,12 +10,16 @@ class DropboxMock {
     constructor() {
         this.files = {};
         this.nextResponse = null;
+        // store requests for assertions in tests
+        this.requests = [];
 
         const app = express();
 
         app.use(bodyParser.json());
 
-        app.use((_req, res, next) => {
+        app.use((req, res, next) => {
+            this.requests.push(req.url);
+
             if (this.nextResponse) {
                 console.log('[dropboxMock]', this.nextResponse);
                 res.writeHeader(this.nextResponse.status, this.nextResponse.headers);
@@ -190,6 +194,7 @@ class DropboxMock {
         console.log('[mockDropbox]: reset');
         this.files = {};
         this.nextResponse = null;
+        this.requests = [];
     }
 }
 

--- a/packages/integration-tests/projects/suite-web/plugins/index.js
+++ b/packages/integration-tests/projects/suite-web/plugins/index.js
@@ -83,6 +83,13 @@ module.exports = on => {
             }
             return null;
         },
+        getRequests: ({ provider}) => {
+            switch(provider){ 
+                case 'dropbox':
+                    return dropboxMock.requests;
+                    // todo:
+            }
+        },
         startBridge: async version => {
             await controller.connect();
             await controller.send({ type: 'bridge-start', version });

--- a/packages/integration-tests/projects/suite-web/tests/metadata/account-metadata.test.ts
+++ b/packages/integration-tests/projects/suite-web/tests/metadata/account-metadata.test.ts
@@ -88,6 +88,16 @@ describe('Metadata', () => {
             force: true,
         });
         cy.getTestElement('@metadata/input').clear().type('{enter}');
+
+        // check number of requests that were sent to dropbox in the course of this scenario
+        // - note if it fails:  data is not mocked, so it may fail if somebody adds an account to all seed
+        //                      in future there should be mocked discovery
+        //                      if it shoots somebody in leg, just remove this assertion...
+        // - why asserting it:  just to make sure that metadata don't send unnecessary amount of request
+        cy.task('getRequests', { provider: 'dropbox' }).then(requests => {
+            expect(requests).to.have.length(24);
+        });
+
         cy.getTestElement('@account-menu/btc/normal/0/label').should('contain', 'Bitcoin');
     });
 });

--- a/packages/suite/src/actions/suite/metadataActions.ts
+++ b/packages/suite/src/actions/suite/metadataActions.ts
@@ -239,6 +239,11 @@ export const fetchMetadata = (deviceState: string) => async (
         return;
     }
 
+    // this triggers renewal of access token if needed. Otherwise multiple requests
+    // to renew access token are issued by every provider.getFileContent
+    const response = await provider.getCredentials();
+    if (!response.success) return;
+
     const deviceFileContentP = new Promise((resolve, reject) => {
         if (device?.metadata?.status !== 'enabled') {
             return reject(new Error('metadata not enabled for this device'));


### PR DESCRIPTION
There is a problem  with refreshing access token at the moment. Resulting in losing connection to dropbox after some time (around 8 hours)

When dropbox lib find out that token is expired. it issues a preflight request to renew it. see here 
https://github.com/dropbox/dropbox-sdk-js/blob/aac3fee5c0440fd7dc64b1dd064cb783bbf1381c/src/dropbox.js#L82.

Suite watches dropbox for metadata changes by firing tens of requests in parallel every 3 minutes. Each of these requests (when token is expired) triggers network call to renew token. This is unfortunate as it makes dropbox to issue and invalidate number of tokens in quick succession ultimately leading to failing one of subsequent requests due to invalid token.

Fix is super easy. Just prepend each fetchMetadata action by single call to provider API that ensures that this preflight request is fired only once. 

