### PR TITLE
fix: change default window size behavior

### DIFF
--- a/packages/suite-desktop/src-electron/store.ts
+++ b/packages/suite-desktop/src-electron/store.ts
@@ -1,14 +1,47 @@
 import Store from 'electron-store';
-import { BrowserWindow } from 'electron';
+import { BrowserWindow, screen } from 'electron';
 
 // creates config.json inside appData folder https://electronjs.org/docs/api/app#appgetpathname
 const store = new Store();
 
 export const MIN_WIDTH = 720;
 export const MIN_HEIGHT = 700;
+export const MAX_WIDTH = 1920;
+export const MAX_HEIGHT = 1080;
+export const BUFFER = 0.2;
+
+const getInitialWindowSize = () => {
+    const { bounds } = screen.getPrimaryDisplay();
+    const buffer = {
+        width: bounds.width * BUFFER,
+        height: bounds.height * BUFFER,
+    };
+
+    let width = bounds.width - buffer.width;
+    if (width <= MIN_WIDTH) {
+        width = MIN_WIDTH;
+    } else if (width >= MAX_WIDTH) {
+        width = MAX_WIDTH;
+    }
+
+    let height = bounds.height - buffer.height;
+    if (height <= MIN_HEIGHT) {
+        height = MIN_HEIGHT;
+    } else if (height >= MAX_HEIGHT) {
+        height = MAX_HEIGHT;
+    }
+
+    return {
+        width,
+        height,
+    };
+};
+
+//
 
 export const getWinBounds = () => {
-    const winBounds = store.get('winBounds', { width: 980, height: MIN_HEIGHT });
+    const { width, height } = getInitialWindowSize();
+    const winBounds = store.get('winBounds', { width, height });
     return winBounds;
 };
 


### PR DESCRIPTION
This changed the behavior of the default window size. It will try to set the window at the primary screen size - 20% buffer. If the window is too small, it will set a minimum height and/or width. If it's too big, there's also a maximum height and/or width.

Fixes #2582