### PR TITLE
fix(fw-update): multiple fixes

### DIFF
--- a/packages/integration-tests/projects/suite-web/tests/onboarding/firmware-update.test.ts
+++ b/packages/integration-tests/projects/suite-web/tests/onboarding/firmware-update.test.ts
@@ -1,0 +1,45 @@
+// @stable/device-management
+// @retry=2
+
+describe('Onboarding - firmware update', () => {
+    beforeEach(() => {
+        cy.task('stopEmu');
+        cy.viewport(1024, 768).resetDb();
+        cy.prefixedVisit('/');
+        cy.goToOnboarding();
+        cy.onboardingShouldLoad();
+    });
+
+    it('firmware update error', () => {
+        cy.getTestElement('@onboarding/begin-button').click();
+        cy.getTestElement('@onboarding/path-create-button').click();
+        cy.getTestElement('@onboarding/path-used-button').click();
+        cy.getTestElement('@onboarding/pair-device-step');
+        cy.task('startEmu', { version: '2.1.4', wipe: true });
+        cy.getTestElement('@onboarding/button-continue').click();
+        cy.getTestElement('@firmware/get-ready-button').click();
+        cy.task('stopEmu');
+        cy.getTestElement('@firmware/connect-in-bootloader-message');
+
+        cy.connectBootloaderDevice('1');
+        cy.getTestElement('@firmware/install-button').click();
+        // error from connect
+        cy.getTestElement('@firmware/error-message').should('contain', 'Device not found');
+
+        // this simulates that device lost its firmware
+        cy.changeDevice(
+            '1',
+            {
+                firmware: 'none',
+                mode: 'bootloader',
+            },
+            { bootloader_mode: true },
+        );
+
+        // now there is retry button which should retry firmware update right away
+
+        // and back button which reset state of firmware update and brings user back to initial screen
+        cy.getTestElement('@onboarding/back-button').click();
+        cy.getTestElement('@firmware/install-button');
+    });
+});

--- a/packages/suite/src/actions/firmware/__fixtures__/firmwareActions.ts
+++ b/packages/suite/src/actions/firmware/__fixtures__/firmwareActions.ts
@@ -25,7 +25,6 @@ export const actions = [
         },
         result: {
             actions: [
-                { type: FIRMWARE.SET_UPDATE_STATUS, payload: 'downloading' },
                 { type: FIRMWARE.SET_UPDATE_STATUS, payload: 'started' },
 
                 // todo: waiting-for-confirmation and installing is not tested
@@ -60,7 +59,6 @@ export const actions = [
         },
         result: {
             actions: [
-                { type: FIRMWARE.SET_UPDATE_STATUS, payload: 'downloading' },
                 { type: FIRMWARE.SET_UPDATE_STATUS, payload: 'started' },
                 { type: FIRMWARE.SET_UPDATE_STATUS, payload: 'unplug' },
             ],
@@ -113,9 +111,33 @@ export const actions = [
         },
         result: {
             actions: [
-                { type: FIRMWARE.SET_UPDATE_STATUS, payload: 'downloading' },
                 { type: FIRMWARE.SET_UPDATE_STATUS, payload: 'started' },
                 { type: FIRMWARE.SET_ERROR, payload: 'foo' },
+            ],
+        },
+    },
+    {
+        description: 'FirmwareUpdate call to connect fails due to cancelling on device',
+        action: () => firmwareActions.firmwareUpdate(),
+        initialState: {
+            suite: {
+                device: bootloaderDevice,
+            },
+            devices: [bootloaderDevice],
+        },
+        mocks: {
+            connect: {
+                success: false,
+                payload: {
+                    // this is temporary workaround for bug somewhere in connect/trezor-link/trezord?
+                    error: "Cannot read property 'code' of null",
+                },
+            },
+        },
+        result: {
+            actions: [
+                { type: FIRMWARE.SET_UPDATE_STATUS, payload: 'started' },
+                { type: FIRMWARE.SET_ERROR, payload: 'Firmware update cancelled' },
             ],
         },
     },

--- a/packages/suite/src/actions/firmware/firmwareActions.ts
+++ b/packages/suite/src/actions/firmware/firmwareActions.ts
@@ -12,7 +12,7 @@ export type FirmwareActions =
     | { type: typeof FIRMWARE.SET_TARGET_RELEASE; payload: AcquiredDevice['firmwareRelease'] }
     | { type: typeof FIRMWARE.RESET_REDUCER }
     | { type: typeof FIRMWARE.ENABLE_REDUCER; payload: boolean }
-    | { type: typeof FIRMWARE.SET_ERROR; payload: string | undefined }
+    | { type: typeof FIRMWARE.SET_ERROR; payload?: string }
     | { type: typeof FIRMWARE.TOGGLE_HAS_SEED };
 
 export const resetReducer = () => (dispatch: Dispatch) => {
@@ -103,6 +103,10 @@ export const firmwareUpdate = () => async (dispatch: Dispatch, getState: GetStat
     );
 
     if (!updateResponse.success) {
+        // todo: temporary workaround, weird connect response, issue here: https://github.com/trezor/trezor-suite/issues/2659
+        if (updateResponse.payload.error === "Cannot read property 'code' of null") {
+            return dispatch({ type: FIRMWARE.SET_ERROR, payload: 'Firmware update cancelled' });
+        }
         return dispatch({ type: FIRMWARE.SET_ERROR, payload: updateResponse.payload.error });
     }
 

--- a/packages/suite/src/actions/firmware/firmwareActions.ts
+++ b/packages/suite/src/actions/firmware/firmwareActions.ts
@@ -12,7 +12,7 @@ export type FirmwareActions =
     | { type: typeof FIRMWARE.SET_TARGET_RELEASE; payload: AcquiredDevice['firmwareRelease'] }
     | { type: typeof FIRMWARE.RESET_REDUCER }
     | { type: typeof FIRMWARE.ENABLE_REDUCER; payload: boolean }
-    | { type: typeof FIRMWARE.SET_ERROR; payload: string }
+    | { type: typeof FIRMWARE.SET_ERROR; payload: string | undefined }
     | { type: typeof FIRMWARE.TOGGLE_HAS_SEED };
 
 export const resetReducer = () => (dispatch: Dispatch) => {
@@ -52,6 +52,8 @@ export const firmwareUpdate = () => async (dispatch: Dispatch, getState: GetStat
         return;
     }
 
+    dispatch(setStatus('started'));
+
     const model = device.features.major_version;
 
     // for update (in firmware modal) target release is set. otherwise use device.firmwareRelease
@@ -72,8 +74,6 @@ export const firmwareUpdate = () => async (dispatch: Dispatch, getState: GetStat
         ].join();
     }
 
-    dispatch(setStatus('downloading'));
-
     // update to same variant as is currently installed
     const toBtcOnly = isBitcoinOnly(device);
 
@@ -86,8 +86,6 @@ export const firmwareUpdate = () => async (dispatch: Dispatch, getState: GetStat
         btcOnly: toBtcOnly,
         version: toFwVersion,
     };
-
-    dispatch(setStatus('started'));
 
     const updateResponse = await TrezorConnect.firmwareUpdate(payload);
 

--- a/packages/suite/src/actions/firmware/firmwareActions.ts
+++ b/packages/suite/src/actions/firmware/firmwareActions.ts
@@ -106,6 +106,17 @@ export const firmwareUpdate = () => async (dispatch: Dispatch, getState: GetStat
         return dispatch({ type: FIRMWARE.SET_ERROR, payload: updateResponse.payload.error });
     }
 
+    // handling case described here: https://github.com/trezor/trezor-suite/issues/2650
+    // firmwareMiddleware handles device-connect event but it never happens for model T
+    // with pin_protection set to true. In this case, we show success screen directly.
+    if (prevDevice?.features?.pin_protection && prevDevice?.features?.major_version === 2) {
+        return dispatch(setStatus('done'));
+    }
+
+    // model 1
+    // ask user to unplug device (see firmwareMiddleware)
+    // model 2 without pin
+    // ask user to wait until device reboots
     dispatch(setStatus(model === 1 ? 'unplug' : 'wait-for-reboot'));
 };
 

--- a/packages/suite/src/components/firmware/Button.tsx
+++ b/packages/suite/src/components/firmware/Button.tsx
@@ -4,7 +4,7 @@ import { Button, ButtonProps } from '@trezor/components';
 import { Translation } from '@suite-components';
 
 export const RetryButton = (props: ButtonProps) => (
-    <Button {...props}>
+    <Button {...props} data-test="@firmware/retry-button">
         <Translation id="TR_RETRY" />
     </Button>
 );
@@ -19,7 +19,7 @@ export const ContinueButton = (props: ButtonProps) => {
 
 export const InstallButton = (props: ButtonProps) => {
     return (
-        <Button {...props}>
+        <Button {...props} data-test="@firmware/install-button">
             <Translation id="TR_INSTALL" />
         </Button>
     );

--- a/packages/suite/src/components/firmware/CheckSeed.tsx
+++ b/packages/suite/src/components/firmware/CheckSeed.tsx
@@ -45,10 +45,11 @@ const Body = () => {
                         isChecked={hasSeed}
                         onClick={toggleHasSeed}
                         data-test="@firmware/confirm-seed-checkbox"
-                    />
-                    <P>
-                        <Translation id="FIRMWARE_USER_TAKES_RESPONSIBILITY_CHECKBOX_DESC" />
-                    </P>
+                    >
+                        <P>
+                            <Translation id="FIRMWARE_USER_TAKES_RESPONSIBILITY_CHECKBOX_DESC" />
+                        </P>
+                    </Checkbox>
                 </CheckboxRow>
             </>
         );
@@ -69,12 +70,11 @@ const Body = () => {
                     isChecked={hasSeed}
                     onClick={toggleHasSeed}
                     data-test="@firmware/confirm-seed-checkbox"
-                />
-                <P>
-                    &nbsp;
-                    <Translation id="FIRMWARE_USER_HAS_SEED_CHECKBOX_DESC" />
-                    &nbsp;
-                </P>
+                >
+                    <P>
+                        <Translation id="FIRMWARE_USER_HAS_SEED_CHECKBOX_DESC" />
+                    </P>
+                </Checkbox>
             </CheckboxRow>
         </>
     );

--- a/packages/suite/src/components/firmware/Error.tsx
+++ b/packages/suite/src/components/firmware/Error.tsx
@@ -15,7 +15,7 @@ const Body = () => {
                 <Translation id="TR_OOPS_SOMETHING_WENT_WRONG" />
             </H2>
             {/* yeah I know we shouldn't use something called TOAST_ here.. but it is so beautifully generic.. */}
-            <P>
+            <P data-test="@firmware/error-message">
                 <Translation id="TOAST_GENERIC_ERROR" values={{ error }} />
             </P>
         </>

--- a/packages/suite/src/components/firmware/FirmwareProgress.tsx
+++ b/packages/suite/src/components/firmware/FirmwareProgress.tsx
@@ -11,18 +11,15 @@ import { Fingerprint, InitImg, P, H2 } from '@firmware-components';
 
 const Body = () => {
     const { device } = useDevice();
-    const { status } = useFirmware();
-
-    // if device is not connected, there must be error which is handled by another component
-    if (!device?.connected || !device?.features || !device?.firmwareRelease) {
-        return null;
-    }
+    const { status, prevDevice } = useFirmware();
 
     const statusText = getTextForStatus(status);
     const statusDescription = getDescriptionForStatus(status);
     return (
         <>
-            <InitImg model={device.features.major_version} />
+            <InitImg
+                model={device?.features?.major_version || prevDevice?.features?.major_version || 2}
+            />
 
             {statusText && (
                 <>
@@ -38,7 +35,7 @@ const Body = () => {
                 </>
             )}
 
-            {status === 'check-fingerprint' && (
+            {status === 'check-fingerprint' && device?.firmwareRelease?.release?.fingerprint && (
                 <Fingerprint>
                     {getFormattedFingerprint(device.firmwareRelease.release.fingerprint)}
                 </Fingerprint>

--- a/packages/suite/src/components/firmware/FirmwareProgress.tsx
+++ b/packages/suite/src/components/firmware/FirmwareProgress.tsx
@@ -38,16 +38,6 @@ const Body = () => {
                 </>
             )}
 
-            {status === 'installing' ? (
-                // TODO: Product wants "Follow progress in you trezor screen" in H2, but that is already used above
-                <P>
-                    <Translation id="TR_DO_NOT_DISCONNECT" />
-                </P>
-            ) : (
-                // empty to avoid jumping
-                <P> </P>
-            )}
-
             {status === 'check-fingerprint' && (
                 <Fingerprint>
                     {getFormattedFingerprint(device.firmwareRelease.release.fingerprint)}

--- a/packages/suite/src/components/firmware/OnboardingInitial.tsx
+++ b/packages/suite/src/components/firmware/OnboardingInitial.tsx
@@ -4,7 +4,14 @@ import { Button } from '@trezor/components';
 import { Translation } from '@suite-components';
 import { getFwVersion } from '@suite-utils/device';
 import { useDevice, useFirmware, useActions } from '@suite-hooks';
-import { P, H2, InitImg, ConnectInNormalImg } from '@firmware-components';
+import {
+    P,
+    H2,
+    InitImg,
+    ConnectInNormalImg,
+    ReconnectInNormalStep,
+    InstallButton,
+} from '@firmware-components';
 import * as onboardingActions from '@onboarding-actions/onboardingActions';
 
 const Body = () => {
@@ -20,10 +27,10 @@ const Body = () => {
             </>
         );
 
-    if (device?.firmware === 'none') {
+    if (device.firmware === 'none') {
         return (
             <>
-                <InitImg model={device.features?.major_version} />
+                <InitImg model={device.features.major_version} />
                 <H2>
                     <Translation id="TR_INSTALL_FIRMWARE" />
                 </H2>
@@ -34,10 +41,13 @@ const Body = () => {
         );
     }
 
+    // after firmware none because such device reports as in bootloader mode
+    if (device?.mode === 'bootloader') return <ReconnectInNormalStep.Body />;
+
     if (device.firmware === 'required') {
         return (
             <>
-                <InitImg model={device.features?.major_version} />
+                <InitImg model={device.features.major_version} />
                 <H2>
                     <Translation id="TR_INSTALL_FIRMWARE" />
                 </H2>
@@ -59,7 +69,7 @@ const Body = () => {
     if (device.firmware === 'outdated') {
         return (
             <>
-                <InitImg model={device.features?.major_version} />
+                <InitImg model={device.features.major_version} />
                 {/* TODO: H2 subheading? */}
                 <P>
                     <Translation
@@ -91,12 +101,10 @@ const BottomBar = () => {
     if (!device?.connected || !device?.features) return null;
 
     if (device?.firmware === 'none') {
-        return (
-            <Button onClick={() => firmwareUpdate()} data-test="@firmware/start-button">
-                <Translation id="TR_INSTALL" />
-            </Button>
-        );
+        return <InstallButton onClick={() => firmwareUpdate()} />;
     }
+
+    if (device?.mode === 'bootloader') return null;
 
     const getPrimaryButtonProps = () => {
         return {

--- a/packages/suite/src/components/firmware/OnboardingInitial.tsx
+++ b/packages/suite/src/components/firmware/OnboardingInitial.tsx
@@ -42,7 +42,7 @@ const Body = () => {
     }
 
     // after firmware none because such device reports as in bootloader mode
-    if (device?.mode === 'bootloader') return <ReconnectInNormalStep.Body />;
+    if (device.mode === 'bootloader') return <ReconnectInNormalStep.Body />;
 
     if (device.firmware === 'required') {
         return (
@@ -98,13 +98,13 @@ const BottomBar = () => {
         goToNextStep: onboardingActions.goToNextStep,
     });
 
-    if (!device?.connected || !device?.features) return null;
+    if (!device?.connected || !device.features) return null;
 
-    if (device?.firmware === 'none') {
-        return <InstallButton onClick={() => firmwareUpdate()} />;
+    if (device.firmware === 'none') {
+        return <InstallButton onClick={firmwareUpdate} />;
     }
 
-    if (device?.mode === 'bootloader') return null;
+    if (device.mode === 'bootloader') return null;
 
     const getPrimaryButtonProps = () => {
         return {

--- a/packages/suite/src/components/firmware/ReconnectInBootloader.tsx
+++ b/packages/suite/src/components/firmware/ReconnectInBootloader.tsx
@@ -1,10 +1,17 @@
 import React from 'react';
-import { InitImg, ConnectInBootloaderImg, DisconnectImg, P, H2 } from '@firmware-components';
 
 import { Button } from '@trezor/components';
+import { isWebUSB } from '@suite-utils/transport';
+import {
+    InitImg,
+    ConnectInBootloaderImg,
+    DisconnectImg,
+    P,
+    H2,
+    InstallButton,
+} from '@firmware-components';
 import { Translation, WebusbButton } from '@suite-components';
 import { useDevice, useFirmware, useSelector } from '@suite-hooks';
-import { isWebUSB } from '@suite-utils/transport';
 
 const Body = () => {
     const { device } = useDevice();
@@ -58,11 +65,7 @@ const BottomBar = () => {
     const transport = useSelector(state => state.suite.transport);
 
     if (device?.mode === 'bootloader') {
-        return (
-            <Button onClick={firmwareUpdate}>
-                <Translation id="TR_START" />
-            </Button>
-        );
+        return <InstallButton onClick={firmwareUpdate} />;
     }
 
     if (!device?.connected && isWebUSB(transport)) {

--- a/packages/suite/src/reducers/firmware/firmwareReducer.ts
+++ b/packages/suite/src/reducers/firmware/firmwareReducer.ts
@@ -19,8 +19,7 @@ export type FirmwareUpdateState =
               | 'initial' // initial state
               | 'check-seed' // ask user, if has seed properly backed up
               | 'waiting-for-bootloader' // navigate user into bootloader mode
-              | 'started' // progress - ??
-              | 'downloading' // progress - firmware is being downloaded
+              | 'started' // progress - firmware update has started, waiting for events from trezor-connect
               | 'waiting-for-confirmation' // progress - device waits for confirmation prior starting to update
               | 'installing' // progress - firmware is being installed
               | 'check-fingerprint' // progress - some old t1 firmwares show screen with fingerprint check
@@ -52,10 +51,15 @@ const firmwareUpdate = (state: FirmwareUpdateState = initialState, action: Actio
         switch (action.type) {
             case FIRMWARE.SET_UPDATE_STATUS:
                 draft.status = action.payload;
+                if (action.payload === 'started') {
+                    draft.error = undefined;
+                }
                 break;
             case FIRMWARE.SET_ERROR:
-                draft.status = 'error';
                 draft.error = action.payload;
+                if (action.payload) {
+                    draft.status = 'error';
+                }
                 break;
             case FIRMWARE.SET_TARGET_RELEASE:
                 draft.targetRelease = action.payload;

--- a/packages/suite/src/utils/firmware/index.ts
+++ b/packages/suite/src/utils/firmware/index.ts
@@ -15,23 +15,23 @@ export const getTextForStatus = (status: AppState['firmware']['status']) => {
     switch (status) {
         case 'waiting-for-confirmation':
             return 'TR_WAITING_FOR_CONFIRMATION';
+        case 'started':
         case 'installing':
             return 'TR_INSTALLING';
-        case 'downloading':
-            return 'TR_DOWNLOADING';
         case 'wait-for-reboot':
             return 'TR_WAIT_FOR_REBOOT';
         case 'unplug':
             return 'TR_DISCONNECT_YOUR_DEVICE';
         case 'check-fingerprint':
             return 'TR_CHECK_FINGERPRINT';
-        // case 'started' is intentionally omitted;
         default:
             return null;
     }
 };
 export const getDescriptionForStatus = (status: AppState['firmware']['status']) => {
     switch (status) {
+        case 'started':
+        case 'installing':
         case 'wait-for-reboot':
             return 'TR_DO_NOT_DISCONNECT';
         default:

--- a/packages/suite/src/views/firmware/index.tsx
+++ b/packages/suite/src/views/firmware/index.tsx
@@ -52,7 +52,6 @@ const Firmware = ({ closeModalApp, resetReducer, firmware, device }: Props) => {
         'check-seed',
         'waiting-for-bootloader',
         'started',
-        'downloading',
         'waiting-for-confirmation',
         'installing',
         ['wait-for-reboot', 'unplug'],
@@ -131,7 +130,6 @@ const Firmware = ({ closeModalApp, resetReducer, firmware, device }: Props) => {
             case 'waiting-for-confirmation':
             case 'installing':
             case 'started':
-            case 'downloading':
             case 'check-fingerprint':
             case 'wait-for-reboot':
             case 'unplug':

--- a/packages/suite/src/views/onboarding/steps/Firmware/Container.ts
+++ b/packages/suite/src/views/onboarding/steps/Firmware/Container.ts
@@ -19,6 +19,7 @@ const mapDispatchToProps = (dispatch: Dispatch) =>
             goToNextStep: onboardingActions.goToNextStep,
             goToPreviousStep: onboardingActions.goToPreviousStep,
             resetReducer: firmwareActions.resetReducer,
+            firmwareUpdate: firmwareActions.firmwareUpdate,
         },
         dispatch,
     );

--- a/packages/suite/src/views/onboarding/steps/Firmware/index.tsx
+++ b/packages/suite/src/views/onboarding/steps/Firmware/index.tsx
@@ -24,13 +24,15 @@ const FirmwareStep = ({
     goToPreviousStep,
     goToNextStep,
     resetReducer,
+    firmwareUpdate,
 }: Props) => {
     const getComponent = () => {
+        console.log(firmware.error, firmware.status);
         // edge case 1 - error
         if (firmware.error) {
             return {
                 Body: <ErrorStep.Body />,
-                BottomBar: <RetryButton onClick={() => resetReducer()} />,
+                BottomBar: <RetryButton onClick={() => firmwareUpdate()} />,
             };
         }
 
@@ -61,7 +63,6 @@ const FirmwareStep = ({
             case 'waiting-for-confirmation':
             case 'installing':
             case 'started':
-            case 'downloading':
             case 'check-fingerprint':
             case 'wait-for-reboot':
             case 'unplug':
@@ -87,7 +88,7 @@ const FirmwareStep = ({
 
             default:
                 // 'ensure' type completeness
-                throw new Error('state is not handled here');
+                throw new Error(`state "${firmware.status}" is not handled here`);
         }
     };
 
@@ -101,8 +102,12 @@ const FirmwareStep = ({
             </Wrapper.StepBody>
 
             <Wrapper.StepFooter>
-                {firmware.status === 'initial' && (
-                    <OnboardingButton.Back onClick={() => goToPreviousStep()}>
+                {['initial', 'error'].includes(firmware.status) && (
+                    <OnboardingButton.Back
+                        onClick={() =>
+                            firmware.status === 'error' ? resetReducer() : goToPreviousStep()
+                        }
+                    >
                         <Translation id="TR_BACK" />
                     </OnboardingButton.Back>
                 )}

--- a/packages/suite/src/views/onboarding/steps/Firmware/index.tsx
+++ b/packages/suite/src/views/onboarding/steps/Firmware/index.tsx
@@ -27,12 +27,11 @@ const FirmwareStep = ({
     firmwareUpdate,
 }: Props) => {
     const getComponent = () => {
-        console.log(firmware.error, firmware.status);
         // edge case 1 - error
         if (firmware.error) {
             return {
                 Body: <ErrorStep.Body />,
-                BottomBar: <RetryButton onClick={() => firmwareUpdate()} />,
+                BottomBar: <RetryButton onClick={firmwareUpdate} />,
             };
         }
 


### PR DESCRIPTION
Changes:
- [x] change how retry button works, now it does not reset firmware update internal state but tries to install firmware directly. If there is error, in onboarding, back button resets internal firmware update state.

Fixes:
- [x] fix #2541 (firmware version vs bootloade version, UI problem)
- [x] fix #2650 by showing success screen without waiting for device to reconnect
- [x] fix #2627 make checkbox text clickable
- [x] [error code "null"](https://user-images.githubusercontent.com/31506317/95347757-8a79a080-08bd-11eb-99b4-306357c994e6.png). After cancellation of fw update on device. As this happens somewhere lower, this PR contains only a workaround and a separate issue is made for this. https://github.com/trezor/trezor-suite/issues/2659

Added: 
- e2e test for retry button behavior 

Not fixing at the moment:
- https://github.com/trezor/trezor-suite/issues/2456 requires broader discussion. luckily edge case

QA:
- [ ] Asana request (will file it after changes resulting from review)
- [ ] approval by QA