### PR TITLE
design: new way of displaying changelog

### DIFF
--- a/packages/suite/src/components/firmware/Initial.tsx
+++ b/packages/suite/src/components/firmware/Initial.tsx
@@ -72,7 +72,7 @@ const StyledExternalLink = styled(ExternalLink)`
 `;
 
 const BottomRow = styled.div`
-    margin-top: auto;
+    margin-top: 8px;
 `;
 
 const Body = () => {
@@ -85,12 +85,13 @@ const Body = () => {
     if (!device?.features) return null; // ts
 
     const { firmwareRelease } = device;
+    if (!device?.features || !firmwareRelease) return null; // ts
 
     // Create custom object containing changelogs for easier manipulation in render() method.
     // Default changelog format is just a long string where individual changes are separated by "*" symbol.
     const logsCustomObject: any = {};
 
-    if (firmwareRelease.changelog?.length > 0) {
+    if (firmwareRelease.changelog && firmwareRelease.changelog?.length > 0) {
         firmwareRelease.changelog.forEach((log: any) => {
             // get array of individual changes for a given version
             const logsArr = log.changelog.trim().split(/\*/g);
@@ -117,7 +118,7 @@ const Body = () => {
                 <Translation id="FIRMWARE_UPDATE_AVAILABLE_DESC" />
             </P>
 
-            {device.firmwareRelease.changelog?.length > 0 && (
+            {Object.keys(logsCustomObject).length > 0 && (
                 <ChangesSummary>
                     {Object.keys(logsCustomObject).map(version => {
                         const log = logsCustomObject[version];

--- a/packages/suite/src/components/firmware/Initial.tsx
+++ b/packages/suite/src/components/firmware/Initial.tsx
@@ -82,8 +82,6 @@ const Body = () => {
     if (device?.mode !== 'normal') return <ReconnectInNormalStep.Body />;
     if (device?.firmware === 'valid') return <NoNewFirmware.Body />;
 
-    if (!device?.features) return null; // ts
-
     const { firmwareRelease } = device;
     if (!device?.features || !firmwareRelease) return null; // ts
 


### PR DESCRIPTION
Fix https://github.com/trezor/trezor-suite/issues/2323

I changed the design to look like the one in the following picture. This required me to introduce a slightly different way how to preprocess and render the individual changelogs.

_Note:_ It doesn't look exactly like specified in [Zeplin](https://app.zeplin.io/project/5ee87c00f6af719a645d14c3/screen/5f58c34f6c4dfa1ca5a5da68), but since the changes don't have (or do they?) any  "Improvement"  or "Fixes" tag, this is a good intermediate step. 

![new-firmware](https://user-images.githubusercontent.com/44506010/95830847-92f82e00-0d38-11eb-99ff-ec00493fb68b.png)
