### PR TITLE
fix(send): validate ERC20 balance when using "set-max" option

### DIFF
--- a/packages/suite/src/actions/wallet/send/sendFormEthereumActions.ts
+++ b/packages/suite/src/actions/wallet/send/sendFormEthereumActions.ts
@@ -54,7 +54,11 @@ const calculate = (
         return { type: 'error', error, errorMessage: { id: error } } as const;
     }
 
-    if (availableTokenBalance && new BigNumber(amount).gt(availableTokenBalance)) {
+    // validate if token balance is not 0 or lower than amount
+    if (
+        availableTokenBalance &&
+        (availableTokenBalance === '0' || new BigNumber(amount).gt(availableTokenBalance))
+    ) {
         return {
             type: 'error',
             error: 'AMOUNT_IS_NOT_ENOUGH',


### PR DESCRIPTION
validate ERC20 balance (could be 0) when using "set-max" option
fix: #2593