### PR TITLE
fix: add missing 404 page to suite-web and suite-desktop

### DIFF
--- a/packages/suite-desktop/pages/404.tsx
+++ b/packages/suite-desktop/pages/404.tsx
@@ -1,0 +1,3 @@
+import ErrorPage from '@suite-views/error';
+
+export default ErrorPage;

--- a/packages/suite-web/pages/404.tsx
+++ b/packages/suite-web/pages/404.tsx
@@ -1,0 +1,3 @@
+import ErrorPage from '@suite-views/error';
+
+export default ErrorPage;


### PR DESCRIPTION
for some reason we didn't have 404 page exported properly, it throws warning during compilation:
![Screenshot 2020-10-13 at 13 46 09](https://user-images.githubusercontent.com/3435913/95856672-afa55d80-0d5a-11eb-93d0-b2121adeee54.png)
https://github.com/vercel/next.js/blob/master/errors/custom-error-no-custom-404.md

it may solve https://github.com/trezor/trezor-suite/issues/2485