### PR TITLE
fix(fw-update): webusb button was missing

### DIFF
--- a/packages/suite/src/components/firmware/ReconnectInBootloader.tsx
+++ b/packages/suite/src/components/firmware/ReconnectInBootloader.tsx
@@ -2,9 +2,9 @@ import React from 'react';
 import { InitImg, ConnectInBootloaderImg, DisconnectImg, P, H2 } from '@firmware-components';
 
 import { Button } from '@trezor/components';
-
-import { Translation } from '@suite-components';
-import { useDevice, useFirmware } from '@suite-hooks';
+import { Translation, WebusbButton } from '@suite-components';
+import { useDevice, useFirmware, useSelector } from '@suite-hooks';
+import { isWebUSB } from '@suite-utils/transport';
 
 const Body = () => {
     const { device } = useDevice();
@@ -55,12 +55,23 @@ const Body = () => {
 const BottomBar = () => {
     const { device } = useDevice();
     const { firmwareUpdate } = useFirmware();
+    const transport = useSelector(state => state.suite.transport);
 
     if (device?.mode === 'bootloader') {
         return (
             <Button onClick={firmwareUpdate}>
                 <Translation id="TR_START" />
             </Button>
+        );
+    }
+
+    if (!device?.connected && isWebUSB(transport)) {
+        return (
+            <WebusbButton ready>
+                <Button icon="PLUS" variant="tertiary">
+                    <Translation id="TR_CHECK_FOR_DEVICES" />
+                </Button>
+            </WebusbButton>
         );
     }
 


### PR DESCRIPTION
Ok, this bug was affecting only web and only if using webusb transport.

If you are doing firmware update, and don't have paired device in bootloader (thats why we got it just now when trying it on new domain) you got stuck and could not proceed. So we must render webusb button in right place and time. 

It used to be implemented correctly some time ago but I somehow missed it when reworking fw update to the new design.