### PR TITLE
fix(send): set "isDirty" also on FeeLevel change

### DIFF
--- a/packages/suite/src/hooks/wallet/useSendFormCompose.ts
+++ b/packages/suite/src/hooks/wallet/useSendFormCompose.ts
@@ -230,9 +230,10 @@ export const useSendFormCompose = ({
                 updateComposedValues(currentLevel);
             }
         }
+        updateContext({ isDirty: true });
         setDraftSaveRequest(true);
         selectedFeeRef.current = selectedFee;
-    }, [composedLevels, selectedFee, updateComposedValues]);
+    }, [composedLevels, selectedFee, updateComposedValues, updateContext]);
 
     // TODO: useEffect on props (check: account change: key||balance, fee change, fiat change)
     // useEffect(() => {


### PR DESCRIPTION
Fixes issue where "clear all" button is not visible when switching FeeLevel without interaction with any other send element