### PR TITLE
Make add-account modal usable in invity exchange

### DIFF
--- a/packages/suite/src/actions/suite/modalActions.ts
+++ b/packages/suite/src/actions/suite/modalActions.ts
@@ -45,6 +45,8 @@ export type UserContextPayload =
     | {
           type: 'add-account';
           device: TrezorDevice;
+          symbol?: Account['symbol'];
+          noRedirect?: boolean;
       }
     | {
           type: 'device-background-gallery';

--- a/packages/suite/src/components/suite/modals/AddAccount/Container.tsx
+++ b/packages/suite/src/components/suite/modals/AddAccount/Container.tsx
@@ -5,6 +5,7 @@ import { changeCoinVisibility } from '@settings-actions/walletSettingsActions';
 import * as routerActions from '@suite-actions/routerActions';
 import { AppState, Dispatch, TrezorDevice } from '@suite-types';
 import Index from './index';
+import { Account } from '@wallet-types';
 
 const mapStateToProps = (state: AppState) => ({
     app: state.router.app,
@@ -26,6 +27,8 @@ const mapDispatchToProps = (dispatch: Dispatch) =>
 export type Props = {
     device: TrezorDevice;
     onCancel: () => void;
+    symbol?: Account['symbol'];
+    noRedirect?: boolean;
 } & ReturnType<typeof mapStateToProps> &
     ReturnType<typeof mapDispatchToProps>;
 

--- a/packages/suite/src/components/suite/modals/AddAccount/components/NetworkSelect.tsx
+++ b/packages/suite/src/components/suite/modals/AddAccount/components/NetworkSelect.tsx
@@ -53,10 +53,10 @@ interface Props {
     network: Network;
     internalNetworks: Network[];
     setSelectedNetwork: (n: Network) => void;
-    pinNetwork?: boolean;
+    isDisabled?: boolean;
 }
 
-const NetworkSelect = ({ network, internalNetworks, setSelectedNetwork, pinNetwork }: Props) => (
+const NetworkSelect = ({ network, internalNetworks, setSelectedNetwork, isDisabled }: Props) => (
     <Select
         isSearchable
         width={250}
@@ -67,7 +67,7 @@ const NetworkSelect = ({ network, internalNetworks, setSelectedNetwork, pinNetwo
         formatOptionLabel={NetworkOption}
         onChange={(option: Option) => setSelectedNetwork(option.value)}
         noOptionsMessage={() => <Translation id="TR_COIN_NOT_FOUND" />}
-        isDisabled={pinNetwork}
+        isDisabled={isDisabled}
     />
 );
 

--- a/packages/suite/src/components/suite/modals/AddAccount/components/NetworkSelect.tsx
+++ b/packages/suite/src/components/suite/modals/AddAccount/components/NetworkSelect.tsx
@@ -53,9 +53,10 @@ interface Props {
     network: Network;
     internalNetworks: Network[];
     setSelectedNetwork: (n: Network) => void;
+    pinNetwork?: boolean;
 }
 
-const NetworkSelect = ({ network, internalNetworks, setSelectedNetwork }: Props) => (
+const NetworkSelect = ({ network, internalNetworks, setSelectedNetwork, pinNetwork }: Props) => (
     <Select
         isSearchable
         width={250}
@@ -66,6 +67,7 @@ const NetworkSelect = ({ network, internalNetworks, setSelectedNetwork }: Props)
         formatOptionLabel={NetworkOption}
         onChange={(option: Option) => setSelectedNetwork(option.value)}
         noOptionsMessage={() => <Translation id="TR_COIN_NOT_FOUND" />}
+        isDisabled={pinNetwork}
     />
 );
 

--- a/packages/suite/src/components/suite/modals/AddAccount/components/Wrapper.tsx
+++ b/packages/suite/src/components/suite/modals/AddAccount/components/Wrapper.tsx
@@ -77,7 +77,7 @@ const Wrapper = (props: Props) => (
                 network={props.selectedNetwork}
                 internalNetworks={props.internalNetworks}
                 setSelectedNetwork={props.onSelectNetwork}
-                pinNetwork={props.pinNetwork}
+                isDisabled={props.pinNetwork}
             />
         </Row>
         {props.accountTypes && props.accountTypes.length > 1 && (

--- a/packages/suite/src/components/suite/modals/AddAccount/components/Wrapper.tsx
+++ b/packages/suite/src/components/suite/modals/AddAccount/components/Wrapper.tsx
@@ -48,6 +48,7 @@ type Props = {
     onCancel: () => void;
     children?: JSX.Element;
     actionButton?: JSX.Element;
+    pinNetwork?: boolean;
 };
 
 const Wrapper = (props: Props) => (
@@ -76,6 +77,7 @@ const Wrapper = (props: Props) => (
                 network={props.selectedNetwork}
                 internalNetworks={props.internalNetworks}
                 setSelectedNetwork={props.onSelectNetwork}
+                pinNetwork={props.pinNetwork}
             />
         </Row>
         {props.accountTypes && props.accountTypes.length > 1 && (

--- a/packages/suite/src/components/suite/modals/AddAccount/index.tsx
+++ b/packages/suite/src/components/suite/modals/AddAccount/index.tsx
@@ -19,10 +19,11 @@ const AddAccount = (props: Props) => {
         ? props.device.unavailableCapabilities
         : {};
 
-    // Use component state, default value is currently selected network or first network item on the list (btc)
-    const { account } = props.selectedAccount;
-    const preselectedNetwork = account
-        ? (internalNetworks.find(n => n.symbol === account.symbol) as Network)
+    // if symbol is passed in the props, preselect it and pin it (do not allow the user to change it)
+    // otherwise default value is currently selected network or first network item on the list (btc)
+    const symbol = props.symbol ? props.symbol : props.selectedAccount?.account?.symbol;
+    const preselectedNetwork = symbol
+        ? (internalNetworks.find(n => n.symbol === symbol) as Network)
         : internalNetworks[0];
 
     const [network, setNetwork] = useState<Network>(preselectedNetwork);
@@ -56,7 +57,7 @@ const AddAccount = (props: Props) => {
         const onEnableNetwork = () => {
             props.onCancel();
             props.changeCoinVisibility(network.symbol, true);
-            if (props.app === 'wallet') {
+            if (props.app === 'wallet' && !props.noRedirect) {
                 // redirect to account only if added from "wallet" app
                 props.goto('wallet-index', {
                     symbol: network.symbol,
@@ -77,6 +78,7 @@ const AddAccount = (props: Props) => {
                         />
                     </Button>
                 }
+                pinNetwork={!!props.symbol}
             />
         );
     }
@@ -100,7 +102,7 @@ const AddAccount = (props: Props) => {
     const onEnableAccount = (account: Account) => {
         props.onCancel();
         props.changeAccountVisibility(account);
-        if (props.app === 'wallet') {
+        if (props.app === 'wallet' && !props.noRedirect) {
             // redirect to account only if added from "wallet" app
             props.goto('wallet-index', {
                 symbol: account.symbol,
@@ -123,6 +125,7 @@ const AddAccount = (props: Props) => {
                     onEnableAccount={onEnableAccount}
                 />
             }
+            pinNetwork={!!props.symbol}
         >
             <NetworkInternal network={accountType || network} accountTypes={accountTypes} />
         </Wrapper>

--- a/packages/suite/src/components/suite/modals/AddAccount/index.tsx
+++ b/packages/suite/src/components/suite/modals/AddAccount/index.tsx
@@ -21,7 +21,7 @@ const AddAccount = (props: Props) => {
 
     // if symbol is passed in the props, preselect it and pin it (do not allow the user to change it)
     // otherwise default value is currently selected network or first network item on the list (btc)
-    const symbol = props.symbol ? props.symbol : props.selectedAccount?.account?.symbol;
+    const symbol = props.symbol ? props.symbol : props.selectedAccount.account?.symbol;
     const preselectedNetwork = symbol
         ? (internalNetworks.find(n => n.symbol === symbol) as Network)
         : internalNetworks[0];

--- a/packages/suite/src/components/suite/modals/index.tsx
+++ b/packages/suite/src/components/suite/modals/index.tsx
@@ -136,6 +136,8 @@ const getUserContextModal = (props: Props) => {
             return (
                 <AddAccount
                     device={payload.device as AcquiredDevice}
+                    symbol={payload.symbol}
+                    noRedirect={payload.noRedirect}
                     onCancel={modalActions.onCancel}
                 />
             );


### PR DESCRIPTION
We need have a possibility to add account that is different from the currently selected account - it is the account to which the exchanged coins will be sent. To be able to reuse the functionality of the `add-account` modal, I had to do minor modifications:

- add optional prop `symbol`, which preselect and pins (makes in unchangeable) the symbol of the account which should be added
- add optional prop `noRedirect` to disable redirects implemented in the modal

The default functionality should be unchanged.