### PR TITLE
Fix/do not use hidden placeholders in send 

### DIFF
--- a/packages/suite/src/components/suite/FiatValue/Container.ts
+++ b/packages/suite/src/components/suite/FiatValue/Container.ts
@@ -22,6 +22,7 @@ interface CommonOwnProps {
     children?: (props: Params) => React.ReactElement | null;
     badge?: { color: 'blue' | 'gray'; size?: 'small' };
     showApproximationIndicator?: boolean;
+    disableHiddenPlaceholder?: boolean;
 }
 
 interface DefaultSourceProps extends CommonOwnProps {

--- a/packages/suite/src/components/suite/FiatValue/index.tsx
+++ b/packages/suite/src/components/suite/FiatValue/index.tsx
@@ -33,27 +33,29 @@ const FiatValue = ({
     useCustomSource,
     badge,
     showApproximationIndicator,
+    disableHiddenPlaceholder,
     ...props
 }: Props) => {
     const targetCurrency = fiatCurrency ?? props.settings.localCurrency;
     const currentFiatRates = props.fiat.coins.find(f => f.symbol === symbol)?.current;
     const ratesSource = useCustomSource ? source : currentFiatRates?.rates;
     const fiat = ratesSource ? toFiatCurrency(amount, targetCurrency, ratesSource) : null;
+    const WrapperComponent = disableHiddenPlaceholder ? SameWidthNums : StyledHiddenPlaceholder;
     if (fiat) {
         let fiatValueComponent = (
-            <StyledHiddenPlaceholder>
+            <WrapperComponent>
                 {showApproximationIndicator && <>≈ </>}
                 <FormattedNumber currency={targetCurrency} value={fiat} />
-            </StyledHiddenPlaceholder>
+            </WrapperComponent>
         );
 
         if (badge) {
             fiatValueComponent = (
-                <StyledHiddenPlaceholder>
+                <WrapperComponent>
                     <Badge isGray={badge.color === 'gray'} isSmall={badge.size === 'small'}>
                         <FormattedNumber currency={targetCurrency} value={fiat} />
                     </Badge>
-                </StyledHiddenPlaceholder>
+                </WrapperComponent>
             );
         }
 

--- a/packages/suite/src/components/suite/FormattedCryptoAmount/index.tsx
+++ b/packages/suite/src/components/suite/FormattedCryptoAmount/index.tsx
@@ -5,7 +5,10 @@ import { HiddenPlaceholder } from '@suite-components';
 const Value = styled.span`
     font-variant-numeric: tabular-nums;
 `;
-const Symbol = styled.span``;
+
+const Symbol = styled.span`
+    text-transform: uppercase;
+`;
 
 interface Props {
     value: React.ReactNode;
@@ -18,7 +21,7 @@ const FormattedCryptoAmount = ({ value, symbol, disableHiddenPlaceholder, classN
     const content = (
         <>
             <Value>{value}</Value>
-            {symbol && <Symbol>{` ${symbol.toUpperCase()}`}</Symbol>}
+            {symbol && <Symbol>{` ${symbol}`}</Symbol>}
         </>
     );
 

--- a/packages/suite/src/components/suite/modals/ReviewTransaction/components/Output.tsx
+++ b/packages/suite/src/components/suite/modals/ReviewTransaction/components/Output.tsx
@@ -236,7 +236,11 @@ const Output = ({ type, state, label, value, symbol, token }: Props) => {
                         </Coin>
                         <Fiat>
                             {outputSymbol && (
-                                <FiatValue amount={outputValue} symbol={outputSymbol} />
+                                <FiatValue
+                                    disableHiddenPlaceholder
+                                    amount={outputValue}
+                                    symbol={outputSymbol}
+                                />
                             )}
                         </Fiat>
                     </Amounts>

--- a/packages/suite/src/components/suite/modals/ReviewTransaction/index.tsx
+++ b/packages/suite/src/components/suite/modals/ReviewTransaction/index.tsx
@@ -158,6 +158,7 @@ const ReviewTransaction = ({ selectedAccount, send, decision }: Props) => {
                                     </Coin>
                                     <TotalFiat>
                                         <FiatValue
+                                            disableHiddenPlaceholder
                                             amount={formatNetworkAmount(
                                                 precomposedTx.totalSpent,
                                                 symbol,

--- a/packages/suite/src/views/wallet/send/components/Fees/index.tsx
+++ b/packages/suite/src/views/wallet/send/components/Fees/index.tsx
@@ -136,12 +136,14 @@ const Fees = () => {
             <FeeAmount>
                 <CoinAmount>
                     <FormattedCryptoAmount
+                        disableHiddenPlaceholder
                         value={formatNetworkAmount(transactionInfo.fee, symbol)}
                         symbol={symbol}
                     />
                 </CoinAmount>
                 <FiatAmount>
                     <FiatValue
+                        disableHiddenPlaceholder
                         amount={formatNetworkAmount(transactionInfo.fee, symbol)}
                         symbol={symbol}
                     />

--- a/packages/suite/src/views/wallet/send/components/TotalSent/index.tsx
+++ b/packages/suite/src/views/wallet/send/components/TotalSent/index.tsx
@@ -3,7 +3,7 @@ import styled from 'styled-components';
 import { variables, colors } from '@trezor/components';
 import { useSendFormContext } from '@wallet-hooks';
 import { formatNetworkAmount, formatAmount } from '@wallet-utils/accountUtils';
-import { Card, Translation, FiatValue } from '@suite-components';
+import { Card, Translation, FiatValue, FormattedCryptoAmount } from '@suite-components';
 
 const StyledCard = styled(Card)`
     display: flex;
@@ -49,11 +49,6 @@ const TotalSentCoin = styled.div`
     padding-bottom: 6px;
 `;
 
-const Symbol = styled.div`
-    text-transform: uppercase;
-    padding-left: 4px;
-`;
-
 const TotalSentFiat = styled.div`
     display: flex;
     font-weight: ${variables.FONT_WEIGHT.MEDIUM};
@@ -89,20 +84,29 @@ const TotalSent = () => {
             {transactionInfo && transactionInfo.type !== 'error' && (
                 <Right>
                     <TotalSentCoin>
-                        {tokenInfo
-                            ? formatAmount(transactionInfo.totalSpent, tokenInfo.decimals)
-                            : formatNetworkAmount(transactionInfo.totalSpent, symbol)}
-                        <Symbol>{tokenInfo ? tokenInfo.symbol : symbol}</Symbol>
+                        <FormattedCryptoAmount
+                            disableHiddenPlaceholder
+                            value={
+                                tokenInfo
+                                    ? formatAmount(transactionInfo.totalSpent, tokenInfo.decimals)
+                                    : formatNetworkAmount(transactionInfo.totalSpent, symbol)
+                            }
+                            symbol={tokenInfo ? tokenInfo.symbol : symbol}
+                        />
                     </TotalSentCoin>
                     <TotalSentFiat>
                         {tokenInfo ? (
                             <>
                                 <Translation id="FEE" />
-                                <Symbol>{formatNetworkAmount(transactionInfo.fee, symbol)}</Symbol>
-                                <Symbol>{symbol}</Symbol>
+                                <FormattedCryptoAmount
+                                    disableHiddenPlaceholder
+                                    value={formatNetworkAmount(transactionInfo.fee, symbol)}
+                                    symbol={symbol}
+                                />
                             </>
                         ) : (
                             <FiatValue
+                                disableHiddenPlaceholder
                                 amount={formatNetworkAmount(transactionInfo.totalSpent, symbol)}
                                 symbol={symbol}
                             />


### PR DESCRIPTION
- added new prop to FiatValue component
- refactored FormattedCryptoAmount component (use css instead of js)
- removed hidden placeholders from send form context (TotalSent, Fee, ReviewTransaction modal) https://github.com/trezor/trezor-suite/issues/2617