### PR TITLE
fix(dropbox): fix metadata files location for scoped app

### DIFF
--- a/packages/suite/src/actions/suite/metadataActions.ts
+++ b/packages/suite/src/actions/suite/metadataActions.ts
@@ -260,12 +260,15 @@ export const fetchMetadata = (deviceState: string) => async (
                 return reject(result);
             }
 
-            let json = { walletLabel: '' };
+            const json = { walletLabel: '' };
             if (result.payload) {
                 try {
-                    json = metadataUtils.decrypt(
-                        metadataUtils.arrayBufferToBuffer(result.payload),
-                        device.metadata.aesKey,
+                    Object.assign(
+                        json,
+                        metadataUtils.decrypt(
+                            metadataUtils.arrayBufferToBuffer(result.payload),
+                            device.metadata.aesKey,
+                        ),
                     );
                 } catch (err) {
                     const error = provider.error('OTHER_ERROR', err.message);
@@ -297,15 +300,18 @@ export const fetchMetadata = (deviceState: string) => async (
             throw new Error(response.error);
         }
 
-        let json = { accountLabel: '', outputLabels: {}, addressLabels: {} };
+        const json = { accountLabel: '', outputLabels: {}, addressLabels: {} };
 
         if (response.payload) {
             try {
                 // we found associated metadata file for given account, decrypt it
                 // and save its metadata into reducer;
-                json = metadataUtils.decrypt(
-                    metadataUtils.arrayBufferToBuffer(response.payload),
-                    account.metadata.aesKey,
+                Object.assign(
+                    json,
+                    metadataUtils.decrypt(
+                        metadataUtils.arrayBufferToBuffer(response.payload),
+                        account.metadata.aesKey,
+                    ),
                 );
                 // if (json.version === '1.0.0') {
                 //     TODO: migration

--- a/packages/suite/src/services/metadata/DropboxProvider.ts
+++ b/packages/suite/src/services/metadata/DropboxProvider.ts
@@ -92,6 +92,8 @@ class DropboxProvider extends AbstractMetadataProvider {
                 let match = exists.matches.find(m => m.metadata.path_lower === `/${file}.mtdt`);
 
                 // ... or in the legacy folder
+                // tldr: in the initial releases, files were saved into wrong location
+                // see more here: https://github.com/trezor/trezor-suite/pull/2642
                 const matchLegacy = exists.matches.find(
                     m => m.metadata.path_lower === `/apps/trezor/${file}.mtdt`,
                 );


### PR DESCRIPTION
Hopefully fixes https://github.com/trezor/trezor-suite/issues/2636

The error is caused by scoped vs unscoped Dropbox app

@mroz22 this is the idea for the fix I described:
* we look for the files both in in the `/` and `/Apps/TREZOR` folders while reading
* if it is in the first one => good, let's use this location
* if it's in the second one => ok, let's use this location
* if not found in any location =>  fail
* we always write to the `/` location, so eventually all files will be migrated from `/Apps/TREZOR` back to `/`

**This is completely untested, just sharing the draft with you - please comment, review and test. Thanks!**