### PR TITLE
Coin filter bug fixes and improvements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,18 @@
 # Changelog
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/). [YY.MM.MICRO]
 
+## [Unreleased]
+
+### Added
+
+
+### Changed
+
+
+### Fixed
+- Account search bug fixes and various small improvements
+
+
 ## [20.10.1]
 
 ### Added

--- a/packages/suite/src/actions/wallet/accountSearchActions.ts
+++ b/packages/suite/src/actions/wallet/accountSearchActions.ts
@@ -4,19 +4,19 @@ import { ACCOUNT_SEARCH } from '@wallet-actions/constants';
 export type AccountSearchActions =
     | {
           type: typeof ACCOUNT_SEARCH.SET_COIN_FILTER;
-          payload: Account['symbol'] | undefined;
+          payload?: Account['symbol'];
       }
     | {
           type: typeof ACCOUNT_SEARCH.SET_SEARCH_STRING;
-          payload: string | undefined;
+          payload?: string;
       };
 
-export const setCoinFilter = (payload: Account['symbol'] | undefined) => ({
+export const setCoinFilter = (payload?: Account['symbol']) => ({
     type: ACCOUNT_SEARCH.SET_COIN_FILTER,
     payload,
 });
 
-export const setSearchString = (payload: string | undefined) => ({
+export const setSearchString = (payload?: string) => ({
     type: ACCOUNT_SEARCH.SET_SEARCH_STRING,
     payload,
 });

--- a/packages/suite/src/actions/wallet/accountSearchActions.ts
+++ b/packages/suite/src/actions/wallet/accountSearchActions.ts
@@ -1,12 +1,22 @@
 import { Account } from '@wallet-types';
 import { ACCOUNT_SEARCH } from '@wallet-actions/constants';
 
-export type AccountSearchActions = {
-    type: typeof ACCOUNT_SEARCH.SET_COIN_FILTER;
-    payload: Account['symbol'] | undefined;
-};
+export type AccountSearchActions =
+    | {
+          type: typeof ACCOUNT_SEARCH.SET_COIN_FILTER;
+          payload: Account['symbol'] | undefined;
+      }
+    | {
+          type: typeof ACCOUNT_SEARCH.SET_SEARCH_STRING;
+          payload: string | undefined;
+      };
 
 export const setCoinFilter = (payload: Account['symbol'] | undefined) => ({
     type: ACCOUNT_SEARCH.SET_COIN_FILTER,
+    payload,
+});
+
+export const setSearchString = (payload: string | undefined) => ({
+    type: ACCOUNT_SEARCH.SET_SEARCH_STRING,
     payload,
 });

--- a/packages/suite/src/actions/wallet/accountSearchActions.ts
+++ b/packages/suite/src/actions/wallet/accountSearchActions.ts
@@ -1,0 +1,12 @@
+import { Account } from '@wallet-types';
+import { ACCOUNT_SEARCH } from '@wallet-actions/constants';
+
+export type AccountSearchActions = {
+    type: typeof ACCOUNT_SEARCH.SET_COIN_FILTER;
+    payload: Account['symbol'] | undefined;
+};
+
+export const setCoinFilter = (payload: Account['symbol'] | undefined) => ({
+    type: ACCOUNT_SEARCH.SET_COIN_FILTER,
+    payload,
+});

--- a/packages/suite/src/actions/wallet/constants/accountSearch.ts
+++ b/packages/suite/src/actions/wallet/constants/accountSearch.ts
@@ -1,0 +1,1 @@
+export const SET_COIN_FILTER = '@account-search/set-coin-filter';

--- a/packages/suite/src/actions/wallet/constants/accountSearch.ts
+++ b/packages/suite/src/actions/wallet/constants/accountSearch.ts
@@ -1,1 +1,2 @@
 export const SET_COIN_FILTER = '@account-search/set-coin-filter';
+export const SET_SEARCH_STRING = '@account-search/set-search-string';

--- a/packages/suite/src/actions/wallet/constants/index.ts
+++ b/packages/suite/src/actions/wallet/constants/index.ts
@@ -11,6 +11,7 @@ import * as FIAT_RATES from './fiatRatesConstants';
 import * as GRAPH from './graphConstants';
 import * as COINMARKET_BUY from './coinmarketBuyConstants';
 import * as COINMARKET_EXCHANGE from './coinmarketExchangeConstants';
+import * as ACCOUNT_SEARCH from './accountSearch';
 
 export {
     BLOCKCHAIN,
@@ -26,4 +27,5 @@ export {
     GRAPH,
     COINMARKET_BUY,
     COINMARKET_EXCHANGE,
+    ACCOUNT_SEARCH,
 };

--- a/packages/suite/src/components/suite/SuiteLayout/index.tsx
+++ b/packages/suite/src/components/suite/SuiteLayout/index.tsx
@@ -10,8 +10,7 @@ import MenuSecondary from '@suite-components/MenuSecondary';
 import { MAX_WIDTH } from '@suite-constants/layout';
 import { DiscoveryProgress } from '@wallet-components';
 import NavigationBar from '../NavigationBar';
-import { useLayoutSize, useAccountSearch } from '@suite-hooks';
-import { CoinFilterContext } from '@suite-hooks/useAccountSearch';
+import { useLayoutSize } from '@suite-hooks';
 
 const PageWrapper = styled.div`
     display: flex;
@@ -139,7 +138,6 @@ const BodyNarrow = ({ url, menu, appMenu, children }: BodyProps) => (
 
 const SuiteLayout = (props: Props) => {
     // TODO: if (props.layoutSize === 'UNAVAILABLE') return <SmallLayout />;
-    const { coinFilter, setCoinFilter } = useAccountSearch();
     const { isMobileLayout } = useLayoutSize();
     const [title, setTitle] = useState<string | undefined>(undefined);
     const [menu, setMenu] = useState<any>(undefined);
@@ -161,20 +159,18 @@ const SuiteLayout = (props: Props) => {
             <SuiteNotifications />
             <DiscoveryProgress />
             <NavigationBar />
-            <CoinFilterContext.Provider value={{ coinFilter, setCoinFilter }}>
-                <LayoutContext.Provider value={{ title, menu, setLayout }}>
-                    {!isMobileLayout && (
-                        <BodyWide menu={menu} appMenu={appMenu} url={props.router.url}>
-                            {props.children}
-                        </BodyWide>
-                    )}
-                    {isMobileLayout && (
-                        <BodyNarrow menu={menu} appMenu={appMenu} url={props.router.url}>
-                            {props.children}
-                        </BodyNarrow>
-                    )}
-                </LayoutContext.Provider>
-            </CoinFilterContext.Provider>
+            <LayoutContext.Provider value={{ title, menu, setLayout }}>
+                {!isMobileLayout && (
+                    <BodyWide menu={menu} appMenu={appMenu} url={props.router.url}>
+                        {props.children}
+                    </BodyWide>
+                )}
+                {isMobileLayout && (
+                    <BodyNarrow menu={menu} appMenu={appMenu} url={props.router.url}>
+                        {props.children}
+                    </BodyNarrow>
+                )}
+            </LayoutContext.Provider>
             <BetaBadge />
         </PageWrapper>
     );

--- a/packages/suite/src/components/suite/modals/AddAccount/components/AddAccountButton.tsx
+++ b/packages/suite/src/components/suite/modals/AddAccount/components/AddAccountButton.tsx
@@ -3,7 +3,7 @@ import { Button, Tooltip } from '@trezor/components';
 import { Account, Network } from '@wallet-types';
 import { Translation } from '@suite-components';
 import messages from '@suite/support/messages';
-import { useAnalytics } from '@suite-hooks';
+import { useAnalytics, useAccountSearch } from '@suite-hooks';
 
 interface Props {
     network: Network;
@@ -13,6 +13,7 @@ interface Props {
 
 const AddAccountButton = (props: Props) => {
     const analytics = useAnalytics();
+    const { setCoinFilter, setSearchString } = useAccountSearch();
 
     if (props.accounts.length === 0) return null;
     const account = props.accounts[props.accounts.length - 1];
@@ -36,6 +37,9 @@ const AddAccountButton = (props: Props) => {
             isDisabled={!!tooltip}
             onClick={() => {
                 props.onEnableAccount(account);
+                // reset coin filter
+                setSearchString(undefined);
+                setCoinFilter(undefined);
                 // just to log that account was added manually.
                 analytics.report({
                     type: 'wallet/add-account',

--- a/packages/suite/src/components/wallet/AccountsMenu/components/AccountSearchBox/index.tsx
+++ b/packages/suite/src/components/wallet/AccountsMenu/components/AccountSearchBox/index.tsx
@@ -97,31 +97,33 @@ const AccountSearchBox = (props: Props) => {
                 onClear={onClear}
                 data-test="@account-menu/search-input"
             />
-            <CoinsFilter
-                onClick={() => {
-                    setCoinFilter(undefined);
-                }}
-            >
-                {supportedNetworks.map(n => (
-                    <OuterCircle
-                        key={n}
-                        isMobile={props.isMobile}
-                        isSelected={coinFilter === n}
-                        onClick={e => {
-                            e.stopPropagation();
-                            // select the coin or deactivate if it's already selected
-                            setCoinFilter(coinFilter === n ? undefined : n);
-                        }}
-                    >
-                        <StyledCoinLogo
-                            symbol={n}
-                            size={props.isMobile ? 24 : 16}
-                            filterActivated={!!coinFilter}
+            {supportedNetworks.length > 1 && (
+                <CoinsFilter
+                    onClick={() => {
+                        setCoinFilter(undefined);
+                    }}
+                >
+                    {supportedNetworks.map(n => (
+                        <OuterCircle
+                            key={n}
+                            isMobile={props.isMobile}
                             isSelected={coinFilter === n}
-                        />
-                    </OuterCircle>
-                ))}
-            </CoinsFilter>
+                            onClick={e => {
+                                e.stopPropagation();
+                                // select the coin or deactivate if it's already selected
+                                setCoinFilter(coinFilter === n ? undefined : n);
+                            }}
+                        >
+                            <StyledCoinLogo
+                                symbol={n}
+                                size={props.isMobile ? 24 : 16}
+                                filterActivated={!!coinFilter}
+                                isSelected={coinFilter === n}
+                            />
+                        </OuterCircle>
+                    ))}
+                </CoinsFilter>
+            )}
         </Wrapper>
     );
 };

--- a/packages/suite/src/components/wallet/AccountsMenu/components/AccountSearchBox/index.tsx
+++ b/packages/suite/src/components/wallet/AccountsMenu/components/AccountSearchBox/index.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import React from 'react';
 import styled, { css } from 'styled-components';
 import { colors, Icon, Input, CoinLogo } from '@trezor/components';
 import { useSelector, useAccountSearch } from '@suite-hooks';
@@ -51,36 +51,28 @@ const StyledCoinLogo = styled(CoinLogo)<{
 const SearchIconWrapper = styled.div``;
 
 interface Props {
-    onChange: (value: string) => void;
     isMobile?: boolean;
 }
 
 const AccountSearchBox = (props: Props) => {
-    const [value, setValue] = useState('');
-    const { coinFilter, setCoinFilter } = useAccountSearch();
-
+    const { coinFilter, setCoinFilter, searchString, setSearchString } = useAccountSearch();
     const enabledNetworks = useSelector(state => state.wallet.settings.enabledNetworks);
     const device = useSelector(state => state.suite.device);
 
     const unavailableCapabilities = device?.unavailableCapabilities ?? {};
     const supportedNetworks = enabledNetworks.filter(symbol => !unavailableCapabilities[symbol]);
 
-    const onChange = (value: string) => {
-        setValue(value);
-        props.onChange(value);
-    };
-
     const onClear = () => {
-        onChange('');
+        setSearchString(undefined);
         setCoinFilter(undefined);
     };
 
     return (
         <Wrapper>
             <StyledInput
-                value={value}
+                value={searchString ?? ''}
                 onChange={e => {
-                    onChange(e.target.value);
+                    setSearchString(e.target.value);
                 }}
                 innerAddon={
                     <SearchIconWrapper>

--- a/packages/suite/src/components/wallet/AccountsMenu/components/AccountSearchBox/index.tsx
+++ b/packages/suite/src/components/wallet/AccountsMenu/components/AccountSearchBox/index.tsx
@@ -1,8 +1,7 @@
-import React, { useState, useContext } from 'react';
+import React, { useState } from 'react';
 import styled, { css } from 'styled-components';
 import { colors, Icon, Input, CoinLogo } from '@trezor/components';
-import { CoinFilterContext } from '@suite-hooks/useAccountSearch';
-import { useSelector } from '@suite-hooks';
+import { useSelector, useAccountSearch } from '@suite-hooks';
 
 const Wrapper = styled.div`
     background: ${colors.NEUE_BG_WHITE};
@@ -58,7 +57,7 @@ interface Props {
 
 const AccountSearchBox = (props: Props) => {
     const [value, setValue] = useState('');
-    const { coinFilter, setCoinFilter } = useContext(CoinFilterContext);
+    const { coinFilter, setCoinFilter } = useAccountSearch();
 
     const enabledNetworks = useSelector(state => state.wallet.settings.enabledNetworks);
     const device = useSelector(state => state.suite.device);
@@ -82,9 +81,6 @@ const AccountSearchBox = (props: Props) => {
                 value={value}
                 onChange={e => {
                     onChange(e.target.value);
-                    // if (coinFilter) {
-                    //     setCoinFilter(undefined);
-                    // }
                 }}
                 innerAddon={
                     <SearchIconWrapper>

--- a/packages/suite/src/components/wallet/AccountsMenu/components/AccountSearchBox/index.tsx
+++ b/packages/suite/src/components/wallet/AccountsMenu/components/AccountSearchBox/index.tsx
@@ -6,7 +6,7 @@ import { useSelector, useAccountSearch } from '@suite-hooks';
 const Wrapper = styled.div`
     background: ${colors.NEUE_BG_WHITE};
     width: 100%;
-    margin-top: 10px;
+    margin-top: 16px;
 `;
 
 const CoinsFilter = styled.div`
@@ -28,6 +28,17 @@ const OuterCircle = styled.div<{ isSelected?: boolean; isMobile?: boolean }>`
 
     margin-bottom: 8px;
     margin-right: ${props => (props.isMobile ? '12px' : '4px')};
+`;
+
+const InputWrapper = styled.div<{ showCoinFilter: boolean }>`
+    ${props =>
+        !props.showCoinFilter &&
+        css`
+            /* additional space under input if we are not showing coin filter */
+            /* one could think why not to remove a margin from coin filter so it can be here regardless of whether coin filter is shown */
+            /* but hold your horses, it is actually essential there is top PADDING on coin filter as a click to the area triggers deactivating the filter */
+            margin-bottom: 12px;
+        `}
 `;
 
 const StyledInput = styled(Input)`
@@ -62,6 +73,8 @@ const AccountSearchBox = (props: Props) => {
     const unavailableCapabilities = device?.unavailableCapabilities ?? {};
     const supportedNetworks = enabledNetworks.filter(symbol => !unavailableCapabilities[symbol]);
 
+    const showCoinFilter = supportedNetworks.length > 1;
+
     const onClear = () => {
         setSearchString(undefined);
         setCoinFilter(undefined);
@@ -69,27 +82,29 @@ const AccountSearchBox = (props: Props) => {
 
     return (
         <Wrapper>
-            <StyledInput
-                value={searchString ?? ''}
-                onChange={e => {
-                    setSearchString(e.target.value);
-                }}
-                innerAddon={
-                    <SearchIconWrapper>
-                        <Icon icon="SEARCH" size={16} color={colors.NEUE_TYPE_DARK_GREY} />
-                    </SearchIconWrapper>
-                }
-                addonAlign="left"
-                textIndent={[16, 12]}
-                variant="small"
-                placeholder="Search"
-                noTopLabel
-                noError
-                clearButton
-                onClear={onClear}
-                data-test="@account-menu/search-input"
-            />
-            {supportedNetworks.length > 1 && (
+            <InputWrapper showCoinFilter={showCoinFilter}>
+                <StyledInput
+                    value={searchString ?? ''}
+                    onChange={e => {
+                        setSearchString(e.target.value);
+                    }}
+                    innerAddon={
+                        <SearchIconWrapper>
+                            <Icon icon="SEARCH" size={16} color={colors.NEUE_TYPE_DARK_GREY} />
+                        </SearchIconWrapper>
+                    }
+                    addonAlign="left"
+                    textIndent={[16, 12]}
+                    variant="small"
+                    placeholder="Search"
+                    noTopLabel
+                    noError
+                    clearButton
+                    onClear={onClear}
+                    data-test="@account-menu/search-input"
+                />
+            </InputWrapper>
+            {showCoinFilter && (
                 <CoinsFilter
                     onClick={() => {
                         setCoinFilter(undefined);

--- a/packages/suite/src/components/wallet/AccountsMenu/index.tsx
+++ b/packages/suite/src/components/wallet/AccountsMenu/index.tsx
@@ -1,9 +1,9 @@
-import React, { useCallback, useState, useContext } from 'react';
+import React, { useCallback, useState } from 'react';
 import styled, { css } from 'styled-components';
 import { connect } from 'react-redux';
 import { H2, variables, colors, Icon } from '@trezor/components';
 import { Translation, AddAccountButton } from '@suite-components';
-import { useDiscovery, useLayoutSize } from '@suite-hooks';
+import { useDiscovery, useLayoutSize, useAccountSearch } from '@suite-hooks';
 import { sortByCoin, getFailedAccounts, accountSearchFn } from '@wallet-utils/accountUtils';
 import { AppState } from '@suite-types';
 import { Account } from '@wallet-types';
@@ -11,7 +11,6 @@ import { Account } from '@wallet-types';
 import AccountSearchBox from './components/AccountSearchBox';
 import AccountGroup from './components/AccountGroup';
 import AccountItem from './components/AccountItem/Container';
-import { CoinFilterContext } from '@suite-hooks/useAccountSearch';
 
 const Wrapper = styled.div<{ isMobileLayout?: boolean }>`
     display: flex;
@@ -151,8 +150,8 @@ const AccountsMenu = ({ device, accounts, selectedAccount }: Props) => {
     const { isMobileLayout } = useLayoutSize();
     const [isExpanded, setIsExpanded] = useState(false);
     const [animatedIcon, setAnimatedIcon] = useState(false);
-    const [searchString, setSearchString] = useState('');
-    const { coinFilter } = useContext(CoinFilterContext);
+    const [searchString, setSearchString] = useState<string | undefined>();
+    const { coinFilter } = useAccountSearch();
 
     const selectedItemRef = useCallback((_item: HTMLDivElement | null) => {
         // TODO: scroll to selected item

--- a/packages/suite/src/components/wallet/AccountsMenu/index.tsx
+++ b/packages/suite/src/components/wallet/AccountsMenu/index.tsx
@@ -160,8 +160,7 @@ const AccountsMenu = ({ device, accounts, selectedAccount }: Props) => {
     const { isMobileLayout } = useLayoutSize();
     const [isExpanded, setIsExpanded] = useState(false);
     const [animatedIcon, setAnimatedIcon] = useState(false);
-    const [searchString, setSearchString] = useState<string | undefined>();
-    const { coinFilter } = useAccountSearch();
+    const { coinFilter, searchString } = useAccountSearch();
 
     const selectedItemRef = useCallback((_item: HTMLDivElement | null) => {
         // TODO: scroll to selected item
@@ -285,10 +284,7 @@ const AccountsMenu = ({ device, accounts, selectedAccount }: Props) => {
                     <MenuItemsWrapper>
                         <ExpandedMobileWrapper>
                             <Search>
-                                <AccountSearchBox
-                                    isMobile
-                                    onChange={(value: string) => setSearchString(value)}
-                                />
+                                <AccountSearchBox isMobile />
                                 <AddAccountButtonWrapper>
                                     <AddAccountButton
                                         device={device}
@@ -315,7 +311,7 @@ const AccountsMenu = ({ device, accounts, selectedAccount }: Props) => {
                         </Heading>
                         <AddAccountButton device={device} noButtonLabel />
                     </Row>
-                    <AccountSearchBox onChange={(value: string) => setSearchString(value)} />
+                    <AccountSearchBox />
                 </MenuHeader>
 
                 {accountsComponent}

--- a/packages/suite/src/components/wallet/AccountsMenu/index.tsx
+++ b/packages/suite/src/components/wallet/AccountsMenu/index.tsx
@@ -136,6 +136,16 @@ const Scroll = styled.div`
     }
 `;
 
+const NoResults = styled.div`
+    display: flex;
+    font-size: ${variables.FONT_SIZE.SMALL};
+    font-weight: ${variables.FONT_WEIGHT.MEDIUM};
+    color: ${colors.NEUE_TYPE_LIGHT_GREY};
+    justify-content: center;
+    text-align: center;
+    margin: 36px 0px;
+`;
+
 const mapStateToProps = (state: AppState) => ({
     device: state.suite.device,
     accounts: state.wallet.accounts,
@@ -224,6 +234,22 @@ const AccountsMenu = ({ device, accounts, selectedAccount }: Props) => {
         );
     };
 
+    const listedAccountsLength =
+        normalAccounts.length + segwitAccounts.length + legacyAccounts.length;
+
+    const accountsComponent =
+        listedAccountsLength > 0 || !searchString ? (
+            <>
+                {buildGroup('normal', normalAccounts)}
+                {buildGroup('segwit', segwitAccounts)}
+                {buildGroup('legacy', legacyAccounts)}
+            </>
+        ) : (
+            <NoResults>
+                <Translation id="TR_ACCOUNT_SEARCH_NO_RESULTS" />
+            </NoResults>
+        );
+
     if (isMobileLayout) {
         return (
             <>
@@ -271,9 +297,7 @@ const AccountsMenu = ({ device, accounts, selectedAccount }: Props) => {
                                     />
                                 </AddAccountButtonWrapper>
                             </Search>
-                            {buildGroup('normal', normalAccounts)}
-                            {buildGroup('segwit', segwitAccounts)}
-                            {buildGroup('legacy', legacyAccounts)}
+                            {accountsComponent}
                         </ExpandedMobileWrapper>
                     </MenuItemsWrapper>
                 )}
@@ -294,9 +318,7 @@ const AccountsMenu = ({ device, accounts, selectedAccount }: Props) => {
                     <AccountSearchBox onChange={(value: string) => setSearchString(value)} />
                 </MenuHeader>
 
-                {buildGroup('normal', normalAccounts)}
-                {buildGroup('segwit', segwitAccounts)}
-                {buildGroup('legacy', legacyAccounts)}
+                {accountsComponent}
             </Scroll>
         </Wrapper>
     );

--- a/packages/suite/src/hooks/suite/useAccountSearch.ts
+++ b/packages/suite/src/hooks/suite/useAccountSearch.ts
@@ -2,13 +2,16 @@ import * as accountSearchActions from '@wallet-actions/accountSearchActions';
 import { useSelector, useActions } from '@suite-hooks';
 
 export const useAccountSearch = () => {
-    const { coinFilter } = useSelector(state => state.wallet.accountSearch);
-    const { setCoinFilter } = useActions({
+    const { coinFilter, searchString } = useSelector(state => state.wallet.accountSearch);
+    const { setCoinFilter, setSearchString } = useActions({
         setCoinFilter: accountSearchActions.setCoinFilter,
+        setSearchString: accountSearchActions.setSearchString,
     });
 
     return {
         coinFilter,
         setCoinFilter,
+        searchString,
+        setSearchString,
     };
 };

--- a/packages/suite/src/hooks/suite/useAccountSearch.ts
+++ b/packages/suite/src/hooks/suite/useAccountSearch.ts
@@ -1,18 +1,11 @@
-import React, { useState } from 'react';
-import { Account } from '@wallet-types';
-
-interface AccountSearchContext {
-    coinFilter: Account['symbol'] | undefined;
-    setCoinFilter: (v: Account['symbol'] | undefined) => void;
-}
-
-export const CoinFilterContext = React.createContext<AccountSearchContext>({
-    coinFilter: undefined,
-    setCoinFilter: () => {},
-});
+import * as accountSearchActions from '@wallet-actions/accountSearchActions';
+import { useSelector, useActions } from '@suite-hooks';
 
 export const useAccountSearch = () => {
-    const [coinFilter, setCoinFilter] = useState<Account['symbol'] | undefined>(undefined);
+    const { coinFilter } = useSelector(state => state.wallet.accountSearch);
+    const { setCoinFilter } = useActions({
+        setCoinFilter: accountSearchActions.setCoinFilter,
+    });
 
     return {
         coinFilter,

--- a/packages/suite/src/reducers/wallet/accountSearchReducer.ts
+++ b/packages/suite/src/reducers/wallet/accountSearchReducer.ts
@@ -1,32 +1,37 @@
 import produce from 'immer';
 import { SUITE } from '@suite-actions/constants';
-import { ACCOUNT_SEARCH, ACCOUNT } from '@wallet-actions/constants';
+import { ACCOUNT_SEARCH } from '@wallet-actions/constants';
 import { WALLET_SETTINGS } from '@settings-actions/constants';
 import { Action } from '@suite-types';
 import { Account as AccountType } from '@wallet-types';
 
 export interface State {
     coinFilter: AccountType['symbol'] | undefined;
+    searchString: string | undefined;
 }
 
 export const initialState: State = {
     coinFilter: undefined,
+    searchString: undefined,
 };
 
 const accountSearchReducer = (state: State = initialState, action: Action): State => {
     return produce(state, draft => {
         switch (action.type) {
+            case ACCOUNT_SEARCH.SET_SEARCH_STRING:
+                draft.searchString = action.payload;
+                break;
             case ACCOUNT_SEARCH.SET_COIN_FILTER:
                 draft.coinFilter = action.payload;
                 break;
             // reset coin filter on:
             // 1) disabling/enabling coins
             // 2) switching to another device/wallet
-            // 3) adding a new account (this also causes resetting during initial discovery, but imo it's a feature enabling users to actually see new accounts being added to the list)
+            // * 3) adding a new account is handled directly in add account modal, reacting on ACCOUNT.CREATE would cause resetting during initial accounts discovery
             case WALLET_SETTINGS.CHANGE_NETWORKS:
             case SUITE.SELECT_DEVICE:
-            case ACCOUNT.CREATE:
                 draft.coinFilter = undefined;
+                draft.searchString = undefined;
                 break;
 
             // no default

--- a/packages/suite/src/reducers/wallet/accountSearchReducer.ts
+++ b/packages/suite/src/reducers/wallet/accountSearchReducer.ts
@@ -1,0 +1,37 @@
+import produce from 'immer';
+import { SUITE } from '@suite-actions/constants';
+import { ACCOUNT_SEARCH, ACCOUNT } from '@wallet-actions/constants';
+import { WALLET_SETTINGS } from '@settings-actions/constants';
+import { Action } from '@suite-types';
+import { Account as AccountType } from '@wallet-types';
+
+export interface State {
+    coinFilter: AccountType['symbol'] | undefined;
+}
+
+export const initialState: State = {
+    coinFilter: undefined,
+};
+
+const accountSearchReducer = (state: State = initialState, action: Action): State => {
+    return produce(state, draft => {
+        switch (action.type) {
+            case ACCOUNT_SEARCH.SET_COIN_FILTER:
+                draft.coinFilter = action.payload;
+                break;
+            // reset coin filter on:
+            // 1) disabling/enabling coins
+            // 2) switching to another device/wallet
+            // 3) adding a new account (this also causes resetting during initial discovery, but imo it's a feature enabling users to actually see new accounts being added to the list)
+            case WALLET_SETTINGS.CHANGE_NETWORKS:
+            case SUITE.SELECT_DEVICE:
+            case ACCOUNT.CREATE:
+                draft.coinFilter = undefined;
+                break;
+
+            // no default
+        }
+    });
+};
+
+export default accountSearchReducer;

--- a/packages/suite/src/reducers/wallet/index.ts
+++ b/packages/suite/src/reducers/wallet/index.ts
@@ -12,6 +12,7 @@ import feesReducer from './feesReducer';
 import blockchainReducer from './blockchainReducer';
 import coinmarketReducer from './coinmarketReducer';
 import sendFormReducer from './sendFormReducer';
+import accountSearchReducer from './accountSearchReducer';
 
 const WalletReducers = combineReducers({
     signVerify: signVerifyReducer,
@@ -27,6 +28,7 @@ const WalletReducers = combineReducers({
     blockchain: blockchainReducer,
     coinmarket: coinmarketReducer,
     send: sendFormReducer,
+    accountSearch: accountSearchReducer,
 });
 
 export default WalletReducers;

--- a/packages/suite/src/support/messages.ts
+++ b/packages/suite/src/support/messages.ts
@@ -4453,6 +4453,10 @@ const definedMessages = defineMessages({
         id: 'TR_ONBOARDING',
         defaultMessage: 'Onboarding',
     },
+    TR_ACCOUNT_SEARCH_NO_RESULTS: {
+        id: 'TR_ACCOUNT_SEARCH_NO_RESULTS',
+        defaultMessage: 'No results',
+    },
 } as const);
 
 export default definedMessages;

--- a/packages/suite/src/types/wallet/index.ts
+++ b/packages/suite/src/types/wallet/index.ts
@@ -18,6 +18,7 @@ import { FiatRatesActions } from '@wallet-actions/fiatRatesActions';
 import { GraphActions } from '@wallet-actions/graphActions';
 import { BlockchainActions } from '@wallet-actions/blockchainActions';
 import { SendFormActions } from '@wallet-actions/sendFormActions';
+import { AccountSearchActions } from '@wallet-actions/accountSearchActions';
 import { TransactionAction } from '@wallet-actions/transactionActions';
 import { SelectedAccountActions } from '@wallet-actions/selectedAccountActions';
 import { NETWORKS } from '@wallet-config';
@@ -64,4 +65,5 @@ export type WalletAction =
     | SelectedAccountActions
     | CoinmarketExchangeActions
     | CoinmarketBuyActions
-    | SendFormActions;
+    | SendFormActions
+    | AccountSearchActions;

--- a/packages/suite/src/utils/wallet/accountUtils.ts
+++ b/packages/suite/src/utils/wallet/accountUtils.ts
@@ -462,7 +462,7 @@ export const getAccountIdentifier = (account: Account) => {
 
 export const accountSearchFn = (
     account: Account,
-    rawSearchString: string | undefined,
+    rawSearchString?: string,
     coinFilter?: Account['symbol'],
 ) => {
     // if coin filter is active and account symbol doesn't match return false and don't continue the search
@@ -470,7 +470,7 @@ export const accountSearchFn = (
     if (!coinFilterMatch) return false;
 
     const searchString = rawSearchString?.trim().toLowerCase();
-    if (!searchString || searchString.length === 0) return true; // no search string
+    if (!searchString) return true; // no search string
 
     // helper func for searching in account's addresses
     const matchAddressFn = (u: NonNullable<Account['addresses']>['used'][number]) =>

--- a/packages/suite/src/utils/wallet/accountUtils.ts
+++ b/packages/suite/src/utils/wallet/accountUtils.ts
@@ -462,15 +462,15 @@ export const getAccountIdentifier = (account: Account) => {
 
 export const accountSearchFn = (
     account: Account,
-    rawSearchString: string,
+    rawSearchString: string | undefined,
     coinFilter?: Account['symbol'],
 ) => {
     // if coin filter is active and account symbol doesn't match return false and don't continue the search
     const coinFilterMatch = coinFilter ? account.symbol === coinFilter : true;
     if (!coinFilterMatch) return false;
 
-    const searchString = rawSearchString.trim().toLowerCase();
-    if (searchString.length === 0) return true; // no search string
+    const searchString = rawSearchString?.trim().toLowerCase();
+    if (!searchString || searchString.length === 0) return true; // no search string
 
     // helper func for searching in account's addresses
     const matchAddressFn = (u: NonNullable<Account['addresses']>['used'][number]) =>

--- a/packages/suite/src/views/dashboard/components/AssetsCard/components/Asset/index.tsx
+++ b/packages/suite/src/views/dashboard/components/AssetsCard/components/Asset/index.tsx
@@ -103,7 +103,7 @@ interface Props {
 
 const Asset = React.memo(({ network, failed, cryptoValue, isLastRow }: Props) => {
     const { symbol, name } = network;
-    const { setCoinFilter } = useAccountSearch();
+    const { setCoinFilter, setSearchString } = useAccountSearch();
 
     const { goto } = useActions({ goto: routerActions.goto });
     return (
@@ -116,7 +116,9 @@ const Asset = React.memo(({ network, failed, cryptoValue, isLastRow }: Props) =>
                         accountIndex: 0,
                         accountType: 'normal',
                     });
+                    // activate coin filter and reset account search string
                     setCoinFilter(symbol);
+                    setSearchString(undefined);
                 }}
             >
                 <LogoWrapper>

--- a/packages/suite/src/views/dashboard/components/AssetsCard/components/Asset/index.tsx
+++ b/packages/suite/src/views/dashboard/components/AssetsCard/components/Asset/index.tsx
@@ -1,4 +1,4 @@
-import React, { useContext } from 'react';
+import React from 'react';
 import styled, { css } from 'styled-components';
 import { Network } from '@wallet-types';
 import { CoinLogo, Icon, variables, colors } from '@trezor/components';
@@ -6,8 +6,7 @@ import { FiatValue, Ticker, Translation } from '@suite-components';
 import { CoinBalance } from '@wallet-components';
 import { isTestnet } from '@wallet-utils/accountUtils';
 import * as routerActions from '@suite-actions/routerActions';
-import { useActions } from '@suite-hooks';
-import { CoinFilterContext } from '@suite-hooks/useAccountSearch';
+import { useActions, useAccountSearch } from '@suite-hooks';
 
 const LogoWrapper = styled.div`
     padding-right: 12px;
@@ -104,7 +103,7 @@ interface Props {
 
 const Asset = React.memo(({ network, failed, cryptoValue, isLastRow }: Props) => {
     const { symbol, name } = network;
-    const { setCoinFilter } = useContext(CoinFilterContext);
+    const { setCoinFilter } = useAccountSearch();
 
     const { goto } = useActions({ goto: routerActions.goto });
     return (


### PR DESCRIPTION
At first, the idea to use react context instead of full-blown redux looked really promising till I needed to fix some bugs where it was necessary to react to redux actions from bunch of places 🤕 I took it as an opportunity to rewrite it with state stored in redux.

New stuff (close https://github.com/trezor/trezor-suite/issues/2556):
- "No results" msg if there are, well... no results
- hide coin filter if only one coin is enabled

Coin filter and search string now resets on (fix https://github.com/trezor/trezor-suite/issues/2083 and fix https://github.com/trezor/trezor-suite/issues/2319): 
- disabling/enabling coins
- switching to another device/wallet
- adding a new account (handled directly in add-account modal as reacting to account.create would cause annoying resets during initial discovery)
- search string is reseted when coming from a click on a coin asset in the dashboard

First two are handled in accountSearch reducer. Another option would be to put it inside a middleware, but I didn't really want to create a whole new middleware just for this and adding it to existing wallet middleware seems to me confusing as well)

