### PR TITLE
feat: Showing device status as animated text in device selector 

### DIFF
--- a/packages/suite/src/components/suite/NavigationBar/components/DeviceSelector/components/DeviceStatus/index.tsx
+++ b/packages/suite/src/components/suite/NavigationBar/components/DeviceSelector/components/DeviceStatus/index.tsx
@@ -30,13 +30,20 @@ const getStatusForDevice = (device: TrezorDevice) => {
 };
 
 const StatusText = styled.div<{ show: boolean; status: Status }>`
-    /* display: ${props => (props.show ? 'flex' : 'none')}; */
     position: absolute;
     text-transform: uppercase;
     font-weight: ${variables.FONT_WEIGHT.DEMI_BOLD};
     font-size: ${variables.FONT_SIZE.TINY};
     top: 14px;
     color: ${props => getStatusColor(props.status)};
+    background: linear-gradient(
+        90deg,
+        ${`${colors.NEUE_BG_LIGHT_GREY}00`} 0%,
+        ${colors.NEUE_BG_LIGHT_GREY} 20px,
+        ${colors.NEUE_BG_LIGHT_GREY} 100%
+    );
+
+    padding-left: 24px;
     opacity: ${props => (props.show ? 1 : 0)};
     right: ${props => (props.show ? '12px' : '4px')};
     transition: opacity 0.5s ease, right 0.5s ease;

--- a/packages/suite/src/components/suite/NavigationBar/components/DeviceSelector/components/DeviceStatus/index.tsx
+++ b/packages/suite/src/components/suite/NavigationBar/components/DeviceSelector/components/DeviceStatus/index.tsx
@@ -1,12 +1,12 @@
 import React from 'react';
-import { Icon, colors } from '@trezor/components';
+import { Icon, colors, variables } from '@trezor/components';
 import styled from 'styled-components';
 import * as deviceUtils from '@suite-utils/device';
 import { TrezorDevice } from '@suite-types';
 
 type Status = 'connected' | 'disconnected' | 'warning';
 
-const getDotColor = (status: Status) => {
+const getStatusColor = (status: Status) => {
     const statusColors = {
         connected: colors.NEUE_TYPE_GREEN,
         disconnected: colors.NEUE_TYPE_RED,
@@ -29,6 +29,19 @@ const getStatusForDevice = (device: TrezorDevice) => {
     return 'connected';
 };
 
+const StatusText = styled.div<{ show: boolean; status: Status }>`
+    /* display: ${props => (props.show ? 'flex' : 'none')}; */
+    position: absolute;
+    text-transform: uppercase;
+    font-weight: ${variables.FONT_WEIGHT.DEMI_BOLD};
+    font-size: ${variables.FONT_SIZE.TINY};
+    top: 14px;
+    color: ${props => getStatusColor(props.status)};
+    opacity: ${props => (props.show ? 1 : 0)};
+    right: ${props => (props.show ? '12px' : '4px')};
+    transition: opacity 0.5s ease, right 0.5s ease;
+`;
+
 const IconWrapper = styled.div`
     display: flex;
     align-self: flex-start;
@@ -38,32 +51,42 @@ const IconWrapper = styled.div`
 const StyledIcon = styled(Icon)`
     cursor: pointer;
 `;
-const OuterCircle = styled.div<{ status: Status }>`
-    position: absolute;
-    top: 12px;
-    right: 12px;
+
+const OuterCircle = styled.div<{ show: boolean; status: Status }>`
     display: flex;
     justify-content: center;
     align-items: center;
+    position: absolute;
+    top: 12px;
     width: 18px;
     height: 18px;
     border-radius: 50%;
     background: ${props => (props.status === 'connected' ? colors.NEUE_BG_LIGHT_GREEN : '#F6E2E2')};
+    opacity: ${props => (props.show ? 1 : 0)};
+    right: ${props => (props.show ? '12px' : '48px')};
+    transition: opacity 0.5s ease, right 0.5s ease;
 `;
 
 const InnerCircle = styled.div<{ status: Status }>`
     width: 6px;
     height: 6px;
     border-radius: 50%;
-    background: ${props => getDotColor(props.status)};
+    background: ${props => getStatusColor(props.status)};
 `;
 
 interface Props {
     device: TrezorDevice;
     onRefreshClick?: () => void;
+    showIconStatus?: boolean;
+    showTextStatus?: boolean;
 }
 
-const DeviceStatus = ({ device, onRefreshClick }: Props) => {
+const DeviceStatus = ({
+    device,
+    onRefreshClick,
+    showIconStatus = true,
+    showTextStatus = false,
+}: Props) => {
     const status = getStatusForDevice(device);
 
     // if device needs attention and CTA func was passed show refresh button
@@ -71,13 +94,13 @@ const DeviceStatus = ({ device, onRefreshClick }: Props) => {
         return (
             <IconWrapper>
                 <StyledIcon
-                    onClick={e => {
+                    onClick={(e: any) => {
                         e.stopPropagation();
                         onRefreshClick();
                     }}
                     icon="REFRESH"
                     size={16}
-                    color={getDotColor(status)}
+                    color={getStatusColor(status)}
                 />
             </IconWrapper>
         );
@@ -85,9 +108,14 @@ const DeviceStatus = ({ device, onRefreshClick }: Props) => {
 
     // otherwise show dot icon (green/orange/red)
     return (
-        <OuterCircle status={status}>
-            <InnerCircle status={status} />
-        </OuterCircle>
+        <>
+            <StatusText status={status} show={showTextStatus}>
+                {status}
+            </StatusText>
+            <OuterCircle status={status} show={showIconStatus}>
+                <InnerCircle status={status} />
+            </OuterCircle>
+        </>
     );
 };
 

--- a/packages/suite/src/components/suite/NavigationBar/components/DeviceSelector/index.tsx
+++ b/packages/suite/src/components/suite/NavigationBar/components/DeviceSelector/index.tsx
@@ -93,6 +93,7 @@ const DeviceSelector = (props: React.HTMLAttributes<HTMLDivElement>) => {
 
     const [localCount, setLocalCount] = useState<number | null>(null);
     const [triggerAnim, setTriggerAnim] = useState(false);
+    const [isHovered, setIsHovered] = useState(false);
 
     const countChanged = localCount && localCount !== deviceCount;
     const timerRef = useRef<number | undefined>(undefined);
@@ -127,6 +128,8 @@ const DeviceSelector = (props: React.HTMLAttributes<HTMLDivElement>) => {
 
     return (
         <Wrapper
+            onMouseEnter={() => setIsHovered(true)}
+            onMouseLeave={() => setIsHovered(false)}
             data-test="@menu/switch-device"
             onClick={() =>
                 goto('suite-switch-device', {
@@ -156,6 +159,8 @@ const DeviceSelector = (props: React.HTMLAttributes<HTMLDivElement>) => {
                         </WalletNameWrapper>
                     </DeviceDetail>
                     <DeviceStatus
+                        showTextStatus={isHovered}
+                        showIconStatus={!isHovered}
                         device={selectedDevice}
                         onRefreshClick={
                             deviceNeedsRefresh


### PR DESCRIPTION
fix part of https://github.com/trezor/trezor-suite/issues/2558

For now the animation appears when the user hovers over the device selector. 

**TODO:** show animation when device status changes (I will do that in another PR)