### PR TITLE
fix(discreet): discreet effect cut out in accounts menu

### DIFF
--- a/packages/suite/src/components/wallet/AccountsMenu/components/AccountItem/index.tsx
+++ b/packages/suite/src/components/wallet/AccountsMenu/components/AccountItem/index.tsx
@@ -37,7 +37,7 @@ const Left = styled.div`
 const Right = styled.div`
     display: flex;
     flex-direction: column;
-    margin-left: 8px;
+    padding-left: 8px;
     overflow: hidden;
 `;
 


### PR DESCRIPTION
super tiny fix
before:
<img width="281" alt="Screenshot 2020-10-19 at 16 34 26" src="https://user-images.githubusercontent.com/6961901/96465473-4d040400-1229-11eb-94b7-3c8395f3b852.png">

after:
<img width="286" alt="Screenshot 2020-10-19 at 16 34 43" src="https://user-images.githubusercontent.com/6961901/96465460-49707d00-1229-11eb-8ebc-e41fa10cc738.png">
