### PR TITLE
fix: await async dispatch calls

### DIFF
--- a/packages/suite/src/actions/firmware/firmwareActions.ts
+++ b/packages/suite/src/actions/firmware/firmwareActions.ts
@@ -89,7 +89,7 @@ export const firmwareUpdate = () => async (dispatch: Dispatch, getState: GetStat
 
     const updateResponse = await TrezorConnect.firmwareUpdate(payload);
 
-    dispatch(
+    await dispatch(
         analyticsActions.report({
             type: 'device-update-firmware',
             payload: {

--- a/packages/suite/src/actions/recovery/recoveryActions.ts
+++ b/packages/suite/src/actions/recovery/recoveryActions.ts
@@ -128,12 +128,12 @@ const rerun = () => async (dispatch: Dispatch, getState: GetState) => {
     if (!features.initialized) {
         dispatch(onboardingActions.goToStep('recovery'));
         dispatch(onboardingActions.addPath('recovery'));
-        dispatch(recoverDevice());
+        await dispatch(recoverDevice());
     }
 
     if (features.initialized) {
-        dispatch(routerActions.goto('recovery-index'));
-        dispatch(checkSeed());
+        await dispatch(routerActions.goto('recovery-index'));
+        await dispatch(checkSeed());
     }
 };
 

--- a/packages/suite/src/actions/wallet/accountActions.ts
+++ b/packages/suite/src/actions/wallet/accountActions.ts
@@ -126,10 +126,10 @@ export const fetchAndUpdateAccount = (account: Account) => async (
 
         const analyze = analyzeTransactions(payload.history.transactions || [], accountTxs);
         if (analyze.remove.length > 0) {
-            dispatch(transactionActions.remove(account, analyze.remove));
+            await dispatch(transactionActions.remove(account, analyze.remove));
         }
         if (analyze.add.length > 0) {
-            dispatch(transactionActions.add(analyze.add.reverse(), account));
+            await dispatch(transactionActions.add(analyze.add.reverse(), account));
         }
 
         const accountDevice = accountUtils.findAccountDevice(account, getState().devices);

--- a/packages/suite/src/actions/wallet/blockchainActions.ts
+++ b/packages/suite/src/actions/wallet/blockchainActions.ts
@@ -220,7 +220,7 @@ export const onConnect = (symbol: string) => async (dispatch: Dispatch, getState
     }
     await dispatch(subscribe(network.symbol));
     await dispatch(updateFeeInfo(network.symbol));
-    dispatch(fiatRatesActions.initRates());
+    await dispatch(fiatRatesActions.initRates());
 };
 
 export const onBlockMined = (block: BlockchainBlock) => async (
@@ -274,14 +274,14 @@ export const onNotification = (payload: BlockchainNotification) => async (
     // TODO: investigate more how to keep ripple pending tx until they are confirmed/rejected
     // ripple-lib doesn't send "pending" txs in history
     if (account.networkType !== 'ripple') {
-        dispatch(accountActions.fetchAndUpdateAccount(account));
+        await dispatch(accountActions.fetchAndUpdateAccount(account));
         // tmp workaround for BB not sending multiple notifications, fix in progress
         if (account.networkType === 'bitcoin') {
             networkAccounts.forEach(account => {
                 dispatch(accountActions.fetchAndUpdateAccount(account));
             });
         } else {
-            dispatch(accountActions.fetchAndUpdateAccount(account));
+            await dispatch(accountActions.fetchAndUpdateAccount(account));
         }
     }
 };

--- a/packages/suite/src/actions/wallet/sendFormActions.ts
+++ b/packages/suite/src/actions/wallet/sendFormActions.ts
@@ -159,7 +159,7 @@ const pushTransaction = () => async (dispatch: Dispatch, getState: GetState) => 
             }),
         );
 
-        dispatch(accountActions.fetchAndUpdateAccount(account));
+        await dispatch(accountActions.fetchAndUpdateAccount(account));
     } else {
         dispatch(
             notificationActions.addToast({ type: 'sign-tx-error', error: sentTx.payload.error }),
@@ -249,7 +249,7 @@ export const pushRawTransaction = (tx: string, coin: Account['symbol']) => async
         // but try to update selectedAccount just to be sure
         const { account } = getState().wallet.selectedAccount;
         if (account) {
-            dispatch(accountActions.fetchAndUpdateAccount(account));
+            await dispatch(accountActions.fetchAndUpdateAccount(account));
         }
     } else {
         dispatch(


### PR DESCRIPTION
Someone should go and review those dispatch calls. I didn't try to study details of those actions but in general dispatches of async actions should be awaited or there should be a big fat comment block explaining why a particular dispatch should really be fired independently.

Missing await may be harmless but it could also lead to hard-to-debug subtle timing bugs. Because following code or caller could rely on effects of the action being fully realized. Also it could be harmless today but in future someone could write code relying on that. I believe issue #2660 could be a manifestation of such bug.