### PR TITLE
chore: mark redundant type checks

### DIFF
--- a/packages/suite/src/actions/suite/suiteActions.ts
+++ b/packages/suite/src/actions/suite/suiteActions.ts
@@ -155,6 +155,7 @@ export const selectDevice = (device?: Device | TrezorDevice) => async (
     if (device) {
         // "ts" is one of the field which distinguish Device from TrezorDevice
         const { ts } = device as TrezorDevice;
+        // noinspection SuspiciousTypeOfGuard
         if (typeof ts === 'number') {
             // requested device is a @suite TrezorDevice type. get exact instance from reducer
             payload = deviceUtils.getSelectedDevice(device as TrezorDevice, getState().devices);
@@ -275,6 +276,7 @@ export const handleDeviceDisconnect = (device: Device) => (
     dispatch({ type: SUITE.SELECT_DEVICE, payload: available[0] });
 };
 
+// noinspection SuspiciousTypeOfGuard
 /**
  * list of actions which has influence on `device` field inside `suite` reducer
  * all other actions should be ignored

--- a/packages/suite/src/actions/wallet/selectedAccountActions.ts
+++ b/packages/suite/src/actions/wallet/selectedAccountActions.ts
@@ -194,6 +194,7 @@ const getAccountState = () => (dispatch: Dispatch, getState: GetState): State =>
 
 // list of all actions which has influence on "selectedAccount" reducer
 // other actions will be ignored
+// noinspection SuspiciousTypeOfGuard
 const actions = [
     ROUTER.LOCATION_CHANGE,
     SUITE.SELECT_DEVICE,

--- a/packages/suite/src/actions/wallet/send/sendFormBitcoinActions.ts
+++ b/packages/suite/src/actions/wallet/send/sendFormBitcoinActions.ts
@@ -118,6 +118,7 @@ export const composeTransaction = (formValues: FormState, formState: UseSendForm
             tx.feePerByte = new BigNumber(tx.feePerByte)
                 .integerValue(BigNumber.ROUND_FLOOR)
                 .toString();
+            // noinspection SuspiciousTypeOfGuard
             if (typeof tx.max === 'string') {
                 tx.max = formatNetworkAmount(tx.max, account.symbol);
             }

--- a/packages/suite/src/hooks/wallet/useSendFormFields.ts
+++ b/packages/suite/src/hooks/wallet/useSendFormFields.ts
@@ -36,6 +36,7 @@ export const useSendFormFields = ({
             const output = outputs ? outputs[outputIndex] : undefined;
             if (!output || output.type !== 'payment') return;
             const { fiat, currency } = output;
+            // noinspection SuspiciousTypeOfGuard
             if (typeof fiat !== 'string') return; // fiat input not registered (testnet or fiat not available)
             const inputName = `outputs[${outputIndex}].fiat`;
             if (!amount) {

--- a/packages/suite/src/services/metadata/DropboxProvider.ts
+++ b/packages/suite/src/services/metadata/DropboxProvider.ts
@@ -157,6 +157,7 @@ class DropboxProvider extends AbstractMetadataProvider {
             err?.error ||
             err?.message; // if standard error
 
+        // noinspection SuspiciousTypeOfGuard
         if (typeof message !== 'string') {
             // this should never happen
             message = 'unknown error';

--- a/packages/suite/src/support/suite/Router.tsx
+++ b/packages/suite/src/support/suite/Router.tsx
@@ -37,6 +37,7 @@ const RouterComponent: FunctionComponent<Props> = (props: Props) => {
         // handle browser back button
         Router.beforePopState(() => {
             const locked = props.onBeforePopState();
+            // noinspection SuspiciousTypeOfGuard
             return typeof locked === 'boolean' ? locked : true;
         });
 

--- a/packages/suite/src/support/tests/setupJest.ts
+++ b/packages/suite/src/support/tests/setupJest.ts
@@ -98,6 +98,7 @@ export const getDeviceFeatures = (feat?: Partial<Features>): Features => ({
  * @returns {Device}
  */
 export const getConnectDevice = (dev?: Partial<Device>, feat?: Partial<Features>): Device => {
+    // noinspection SuspiciousTypeOfGuard
     if (dev && typeof dev.type === 'string' && dev.type !== 'acquired') {
         return {
             type: dev.type,

--- a/packages/suite/src/utils/suite/mergeObj.ts
+++ b/packages/suite/src/utils/suite/mergeObj.ts
@@ -3,6 +3,7 @@ export const mergeObj = (
     source: Record<string, any> | string | boolean | number,
 ) => {
     Object.keys(source).forEach(key => {
+        // noinspection SuspiciousTypeOfGuard
         if (source instanceof Object && source[key] instanceof Object) {
             Object.assign(source[key], mergeObj(target[key], source[key]));
         }

--- a/packages/suite/src/utils/suite/router.ts
+++ b/packages/suite/src/utils/suite/router.ts
@@ -13,6 +13,7 @@ export const getPrefixedURL = (url: string) => {
 export const stripPrefixedURL = (url: string) => {
     // do not use object destructuring https://github.com/webpack/webpack/issues/5392
     const prefix = process.env.assetPrefix;
+    // noinspection SuspiciousTypeOfGuard
     if (typeof prefix === 'string' && url.indexOf(prefix) === 0) {
         url = url.slice(prefix.length);
     }
@@ -133,6 +134,7 @@ export const getRoute = (name: Route['name'], params?: RouteParams) => {
 
 // Used in @suite-native routerActions
 export const getTopLevelRoute = (url: string) => {
+    // noinspection SuspiciousTypeOfGuard
     if (typeof url !== 'string') return;
     const clean = stripPrefixedPathname(url);
     const split = clean.split('/');

--- a/packages/suite/src/utils/wallet/accountUtils.ts
+++ b/packages/suite/src/utils/wallet/accountUtils.ts
@@ -106,6 +106,7 @@ export const getTypeForNetwork = (accountType: Account['accountType']) => {
 };
 
 export const getBip43Shortcut = (path: string) => {
+    // noinspection SuspiciousTypeOfGuard
     if (typeof path !== 'string') return 'unknown';
     // https://github.com/bitcoin/bips/blob/master/bip-0043.mediawiki
     const bip43 = path.split('/')[1];

--- a/packages/suite/src/utils/wallet/fiatConverterUtils.ts
+++ b/packages/suite/src/utils/wallet/fiatConverterUtils.ts
@@ -17,6 +17,7 @@ export const toFiatCurrency = (
     }
 
     let formattedAmount = amount;
+    // noinspection SuspiciousTypeOfGuard
     if (typeof amount === 'string') {
         formattedAmount = amount.replace(',', '.');
     }
@@ -41,6 +42,7 @@ export const fromFiatCurrency = (
     }
 
     let formattedLocalAmount = localAmount;
+    // noinspection SuspiciousTypeOfGuard
     if (typeof localAmount === 'string') {
         formattedLocalAmount = localAmount.replace(',', '.');
     }

--- a/packages/suite/src/utils/wallet/transactionUtils.ts
+++ b/packages/suite/src/utils/wallet/transactionUtils.ts
@@ -225,6 +225,7 @@ export const getTargetAmount = (
     const isLocalTarget =
         (transaction.type === 'sent' || transaction.type === 'self') && target.isAccountTarget;
     const hasAmount = !isLocalTarget && typeof target.amount === 'string' && target.amount !== '0';
+    // noinspection SuspiciousTypeOfGuard
     const targetAmount =
         (hasAmount ? target.amount : null) ||
         (target === transaction.targets[0] &&


### PR DESCRIPTION
This silences warnings for WebStorm IDE users.

I just marked them for future review. I would recommend going over those and removing them eventually.