### PR TITLE
chore: make json files strictly compliant

### DIFF
--- a/packages/suite-desktop/src-electron/tsconfig.json
+++ b/packages/suite-desktop/src-electron/tsconfig.json
@@ -18,11 +18,11 @@
     "esModuleInterop": true,
     "resolveJsonModule": true,
     "isolatedModules": true,
-    "skipLibCheck": true,
+    "skipLibCheck": true
   },
   "include": [
     "**/*.ts",
-    "**/*.tsx",
+    "**/*.tsx"
   ],
   "exclude": [
     "**/*.js",

--- a/packages/suite-native/tsconfig.json
+++ b/packages/suite-native/tsconfig.json
@@ -24,7 +24,7 @@
             ],
             "@suite": [
                 "./src/index",
-                "../../packages/suite/src/index",
+                "../../packages/suite/src/index"
             ],
             // suite 
             "@suite-components/*": ["./src/components/suite/*", "../../packages/suite/src/components/suite/*"],
@@ -261,17 +261,17 @@
             "@recovery-middlewares/*": ["./src/middlewares/recovery/*", "../../packages/suite/src/middlewares/recovery/*"],
             "@recovery-middlewares": ["./src/middlewares/recovery/index", "../../packages/suite/src/middlewares/recovery/index"],
             "@recovery-hooks/*": ["./src/hooks/recovery/*", "../../packages/suite/src/hooks/recovery/*"],
-            "@recovery-hooks": ["./src/hooks/recovery/index", "../../packages/suite/src/hooks/recovery/index"],
+            "@recovery-hooks": ["./src/hooks/recovery/index", "../../packages/suite/src/hooks/recovery/index"]
         },
         "module": "esnext",
         "noUnusedParameters": true,
         "sourceMap": true,
-        "strict": true,
+        "strict": true
     },
     "include": [
         "./src/App.tsx",
         "./index.d.ts",
-        "./src/utils/suite/oauth.ts", // todo: remove when used somewhere, otherwise eslint complaints
+        "./src/utils/suite/oauth.ts" // todo: remove when used somewhere, otherwise eslint complaints
     ],
     "exclude": ["node_modules", "babel.config.js", "metro.config.js", "jest.config.js"]
 }

--- a/packages/suite/.stylelintrc
+++ b/packages/suite/.stylelintrc
@@ -17,7 +17,7 @@
             }
         ],
         "at-rule-no-unknown": [ true, {
-            ignoreAtRules: ["each"]
+            "ignoreAtRules": ["each"]
         }]
     }
 }


### PR DESCRIPTION
WebStorm complains about those files to be not compliant with the JSON standard. I understand that all is probably working just fine because tsconfig and linter use relaxed JSON parsers. But why not make it compliant to silence WebStorm concerns.