### PR TITLE
fix: applied word-break to modal heading

### DIFF
--- a/packages/components/src/components/Modal/index.tsx
+++ b/packages/components/src/components/Modal/index.tsx
@@ -177,7 +177,7 @@ const Heading = styled(H1)<{
 }>`
     display: flex;
     align-items: flex-start;
-    word-break: break-all;
+    word-break: break-word;
     padding: 28px 32px 22px 32px;
     margin-bottom: ${props => (props.showProgressBar ? 0 : '20px')};
 

--- a/packages/components/src/components/Modal/index.tsx
+++ b/packages/components/src/components/Modal/index.tsx
@@ -177,6 +177,7 @@ const Heading = styled(H1)<{
 }>`
     display: flex;
     align-items: flex-start;
+    word-break: break-all;
     padding: 28px 32px 22px 32px;
     margin-bottom: ${props => (props.showProgressBar ? 0 : '20px')};
 

--- a/packages/suite/src/components/suite/modals/confirm/Xpub/index.tsx
+++ b/packages/suite/src/components/suite/modals/confirm/Xpub/index.tsx
@@ -14,7 +14,7 @@ const Address = styled.div`
     word-break: break-all;
     font-size: 20px;
     padding: 20px;
-    margin-bottom: 40px;
+    margin: 20px 0 40px 0;
 `;
 
 const Row = styled.div`


### PR DESCRIPTION
fix https://github.com/trezor/trezor-suite/issues/2631

The new design looks like this 
![Account-details fix](https://user-images.githubusercontent.com/44506010/96559624-93a33e00-12bd-11eb-8c72-303282c733b4.png)
