### PR TITLE
refactor(suite): remove unnecessary async from actions

### DIFF
--- a/packages/suite-native/src/actions/suite/routerActions.ts
+++ b/packages/suite-native/src/actions/suite/routerActions.ts
@@ -30,7 +30,7 @@ interface LocationChange {
     url: string;
 }
 
-export type RouterActions = LocationChange;
+export type RouterAction = LocationChange;
 
 /**
  * Dispatch initial url

--- a/packages/suite/src/actions/backup/backupActions.ts
+++ b/packages/suite/src/actions/backup/backupActions.ts
@@ -13,38 +13,30 @@ export type ConfirmKey =
     | 'will-hide-seed';
 
 export type BackupStatus = 'initial' | 'in-progress' | 'finished';
-export type BackupActions =
+export type BackupAction =
     | { type: typeof BACKUP.RESET_REDUCER }
     | { type: typeof BACKUP.TOGGLE_CHECKBOX_BY_KEY; payload: ConfirmKey }
     | { type: typeof BACKUP.SET_STATUS; payload: BackupStatus }
     | { type: typeof BACKUP.SET_ERROR; payload: string };
 
-export const toggleCheckboxByKey = (key: ConfirmKey) => (dispatch: Dispatch) => {
-    return dispatch({
-        type: BACKUP.TOGGLE_CHECKBOX_BY_KEY,
-        payload: key,
-    });
-};
+export const toggleCheckboxByKey = (key: ConfirmKey): BackupAction => ({
+    type: BACKUP.TOGGLE_CHECKBOX_BY_KEY,
+    payload: key,
+});
 
-export const setStatus = (status: BackupStatus) => (dispatch: Dispatch) => {
-    return dispatch({
-        type: BACKUP.SET_STATUS,
-        payload: status,
-    });
-};
+export const setStatus = (status: BackupStatus): BackupAction => ({
+    type: BACKUP.SET_STATUS,
+    payload: status,
+});
 
-export const setError = (error: string) => (dispatch: Dispatch) => {
-    return dispatch({
-        type: BACKUP.SET_ERROR,
-        payload: error,
-    });
-};
+export const setError = (error: string): BackupAction => ({
+    type: BACKUP.SET_ERROR,
+    payload: error,
+});
 
-export const resetReducer = () => (dispatch: Dispatch) => {
-    return dispatch({
-        type: BACKUP.RESET_REDUCER,
-    });
-};
+export const resetReducer = (): BackupAction => ({
+    type: BACKUP.RESET_REDUCER,
+});
 
 export const backupDevice = (params: CommonParams = {}) => async (
     dispatch: Dispatch,

--- a/packages/suite/src/actions/firmware/firmwareActions.ts
+++ b/packages/suite/src/actions/firmware/firmwareActions.ts
@@ -1,10 +1,10 @@
 import TrezorConnect from 'trezor-connect';
 import { FIRMWARE } from '@firmware-actions/constants';
-import { Dispatch, GetState, AppState, Action, AcquiredDevice } from '@suite-types';
+import { Dispatch, GetState, AppState, AcquiredDevice } from '@suite-types';
 import * as analyticsActions from '@suite-actions/analyticsActions';
 import { isBitcoinOnly } from '@suite-utils/device';
 
-export type FirmwareActions =
+export type FirmwareAction =
     | {
           type: typeof FIRMWARE.SET_UPDATE_STATUS;
           payload: ReturnType<GetState>['firmware']['status'];
@@ -15,25 +15,19 @@ export type FirmwareActions =
     | { type: typeof FIRMWARE.SET_ERROR; payload?: string }
     | { type: typeof FIRMWARE.TOGGLE_HAS_SEED };
 
-export const resetReducer = () => (dispatch: Dispatch) => {
-    dispatch({
-        type: FIRMWARE.RESET_REDUCER,
-    });
-};
+export const resetReducer = (): FirmwareAction => ({
+    type: FIRMWARE.RESET_REDUCER,
+});
 
-export const setStatus = (payload: AppState['firmware']['status']): Action => ({
+export const setStatus = (payload: AppState['firmware']['status']): FirmwareAction => ({
     type: FIRMWARE.SET_UPDATE_STATUS,
     payload,
 });
 
-export const setTargetRelease = (payload: AcquiredDevice['firmwareRelease']) => (
-    dispatch: Dispatch,
-) => {
-    dispatch({
-        type: FIRMWARE.SET_TARGET_RELEASE,
-        payload,
-    });
-};
+export const setTargetRelease = (payload: AcquiredDevice['firmwareRelease']): FirmwareAction => ({
+    type: FIRMWARE.SET_TARGET_RELEASE,
+    payload,
+});
 
 export const firmwareUpdate = () => async (dispatch: Dispatch, getState: GetState) => {
     const { device } = getState().suite;
@@ -120,6 +114,6 @@ export const firmwareUpdate = () => async (dispatch: Dispatch, getState: GetStat
     dispatch(setStatus(model === 1 ? 'unplug' : 'wait-for-reboot'));
 };
 
-export const toggleHasSeed = (): Action => ({
+export const toggleHasSeed = (): FirmwareAction => ({
     type: FIRMWARE.TOGGLE_HAS_SEED,
 });

--- a/packages/suite/src/actions/onboarding/onboardingActions.ts
+++ b/packages/suite/src/actions/onboarding/onboardingActions.ts
@@ -4,9 +4,9 @@ import { AnyStepId, AnyPath } from '@onboarding-types/steps';
 import steps from '@onboarding-config/steps';
 import { findNextStep, findPrevStep, isStepInPath } from '@onboarding-utils/steps';
 
-import { GetState, Dispatch, Action } from '@suite-types';
+import { GetState, Dispatch } from '@suite-types';
 
-export type OnboardingActionTypes =
+export type OnboardingAction =
     | {
           type: typeof ONBOARDING.ENABLE_ONBOARDING_REDUCER;
           payload: boolean;
@@ -39,38 +39,30 @@ export type OnboardingActionTypes =
           stepId: AnyStepId;
       };
 
-const goToStep = (stepId: AnyStepId) => (dispatch: Dispatch) => {
-    dispatch({
-        type: ONBOARDING.SET_STEP_ACTIVE,
-        stepId,
-    });
-};
+const goToStep = (stepId: AnyStepId): OnboardingAction => ({
+    type: ONBOARDING.SET_STEP_ACTIVE,
+    stepId,
+});
 
-const goToSubStep = (subStepId: string | null) => (dispatch: Dispatch) => {
-    dispatch({
-        type: ONBOARDING.GO_TO_SUBSTEP,
-        subStepId,
-    });
-};
+const goToSubStep = (subStepId: string | null): OnboardingAction => ({
+    type: ONBOARDING.GO_TO_SUBSTEP,
+    subStepId,
+});
 
-const selectTrezorModel = (model: number) => ({
+const selectTrezorModel = (model: 1 | 2): OnboardingAction => ({
     type: ONBOARDING.SELECT_TREZOR_MODEL,
     model,
 });
 
-const addPath = (payload: AnyPath) => (dispatch: Dispatch) => {
-    dispatch({
-        type: ONBOARDING.ADD_PATH,
-        payload,
-    });
-};
+const addPath = (payload: AnyPath): OnboardingAction => ({
+    type: ONBOARDING.ADD_PATH,
+    payload,
+});
 
-const removePath = (payload: AnyPath[]) => (dispatch: Dispatch) => {
-    dispatch({
-        type: ONBOARDING.REMOVE_PATH,
-        payload,
-    });
-};
+const removePath = (payload: AnyPath[]): OnboardingAction => ({
+    type: ONBOARDING.REMOVE_PATH,
+    payload,
+});
 
 const goToNextStep = (stepId?: AnyStepId) => (dispatch: Dispatch, getState: GetState) => {
     if (stepId) {
@@ -108,18 +100,16 @@ const goToPreviousStep = (stepId?: AnyStepId) => (dispatch: Dispatch, getState: 
 /**
  * Set onboarding reducer to initial state.
  */
-const resetOnboarding = () => (dispatch: Dispatch) => {
-    dispatch({
-        type: ONBOARDING.RESET_ONBOARDING,
-    });
-};
+const resetOnboarding = (): OnboardingAction => ({
+    type: ONBOARDING.RESET_ONBOARDING,
+});
 
 /**
  * Make onboarding reducer listen to actions.
  * @param payload,
  */
 
-const enableOnboardingReducer = (payload: boolean): Action => ({
+const enableOnboardingReducer = (payload: boolean): OnboardingAction => ({
     type: ONBOARDING.ENABLE_ONBOARDING_REDUCER,
     payload,
 });

--- a/packages/suite/src/actions/recovery/recoveryActions.ts
+++ b/packages/suite/src/actions/recovery/recoveryActions.ts
@@ -3,7 +3,7 @@ import TrezorConnect, { UI } from 'trezor-connect';
 import { RECOVERY } from '@recovery-actions/constants';
 import * as onboardingActions from '@onboarding-actions/onboardingActions';
 import * as routerActions from '@suite-actions/routerActions';
-import { Dispatch, GetState, Action } from '@suite-types';
+import { Dispatch, GetState } from '@suite-types';
 import { WordCount } from '@recovery-types';
 import { DEVICE } from '@suite-constants';
 
@@ -14,38 +14,38 @@ export type SeedInputStatus =
     | 'in-progress'
     | 'finished';
 
-export type RecoveryActions =
+export type RecoveryAction =
     | { type: typeof RECOVERY.SET_WORDS_COUNT; payload: WordCount }
     | { type: typeof RECOVERY.SET_ADVANCED_RECOVERY; payload: boolean }
     | { type: typeof RECOVERY.SET_ERROR; payload: string }
     | { type: typeof RECOVERY.SET_STATUS; payload: SeedInputStatus }
     | { type: typeof RECOVERY.RESET_REDUCER };
 
-const setWordsCount = (count: WordCount) => ({
+const setWordsCount = (count: WordCount): RecoveryAction => ({
     type: RECOVERY.SET_WORDS_COUNT,
     payload: count,
 });
 
-const setAdvancedRecovery = (value: boolean) => ({
+const setAdvancedRecovery = (value: boolean): RecoveryAction => ({
     type: RECOVERY.SET_ADVANCED_RECOVERY,
     payload: value,
 });
 
-const setError = (payload: string): Action => ({
+const setError = (payload: string): RecoveryAction => ({
     type: RECOVERY.SET_ERROR,
     payload,
 });
 
-const resetReducer = (): Action => ({
+const resetReducer = (): RecoveryAction => ({
     type: RECOVERY.RESET_REDUCER,
 });
 
-const setStatus = (status: SeedInputStatus): Action => ({
+const setStatus = (status: SeedInputStatus): RecoveryAction => ({
     type: RECOVERY.SET_STATUS,
     payload: status,
 });
 
-const submit = (word: string) => async () => {
+const submit = (word: string) => () => {
     TrezorConnect.uiResponse({ type: UI.RECEIVE_WORD, payload: word });
 };
 

--- a/packages/suite/src/actions/settings/walletSettingsActions.ts
+++ b/packages/suite/src/actions/settings/walletSettingsActions.ts
@@ -7,7 +7,7 @@ import { BlockbookUrl } from '@wallet-types/blockbook';
 import { NETWORKS } from '@wallet-config';
 import { toTorUrl } from '@suite-utils/tor';
 
-export type WalletSettingsActions =
+export type WalletSettingsAction =
     | { type: typeof WALLET_SETTINGS.CHANGE_NETWORKS; payload: Network['symbol'][] }
     | { type: typeof WALLET_SETTINGS.SET_LOCAL_CURRENCY; localCurrency: string }
     | { type: typeof WALLET_SETTINGS.SET_HIDE_BALANCE; toggled: boolean }
@@ -54,7 +54,7 @@ export const changeCoinVisibility = (symbol: Network['symbol'], shouldBeVisible:
     });
 };
 
-export const changeNetworks = (payload: Network['symbol'][]) => ({
+export const changeNetworks = (payload: Network['symbol'][]): WalletSettingsAction => ({
     type: WALLET_SETTINGS.CHANGE_NETWORKS,
     payload,
 });
@@ -78,12 +78,12 @@ export const getLastUsedFeeLevel = () => (_: Dispatch, getState: GetState) => {
     return settings.lastUsedFeeLevel[selectedAccount.account.symbol];
 };
 
-export const addBlockbookUrl = (payload: BlockbookUrl) => ({
+export const addBlockbookUrl = (payload: BlockbookUrl): WalletSettingsAction => ({
     type: WALLET_SETTINGS.ADD_BLOCKBOOK_URL,
     payload,
 });
 
-export const removeBlockbookUrl = (payload: BlockbookUrl) => ({
+export const removeBlockbookUrl = (payload: BlockbookUrl): WalletSettingsAction => ({
     type: WALLET_SETTINGS.REMOVE_BLOCKBOOK_URL,
     payload,
 });

--- a/packages/suite/src/actions/suite/analyticsActions.ts
+++ b/packages/suite/src/actions/suite/analyticsActions.ts
@@ -13,7 +13,7 @@ import { encodeDataToQueryString } from '@suite-utils/analytics';
 import { Account } from '@wallet-types';
 import { isDesktop, isWeb } from '@suite-utils/env';
 
-export type AnalyticsActions =
+export type AnalyticsAction =
     | { type: typeof ANALYTICS.DISPOSE }
     | { type: typeof ANALYTICS.INIT; payload: { instanceId: string } };
 
@@ -301,6 +301,6 @@ export const init = () => async (dispatch: Dispatch, getState: GetState) => {
     });
 };
 
-export const dispose = () => ({
+export const dispose = (): AnalyticsAction => ({
     type: ANALYTICS.DISPOSE,
 });

--- a/packages/suite/src/actions/suite/desktopUpdateActions.ts
+++ b/packages/suite/src/actions/suite/desktopUpdateActions.ts
@@ -3,7 +3,7 @@ import { addToast } from '@suite-actions/notificationActions';
 import { Dispatch, GetState } from '@suite-types';
 import { UpdateInfo, UpdateProgress, UpdateWindow } from '@suite-types/desktop';
 
-export type DesktopUpdateActions =
+export type DesktopUpdateAction =
     | { type: typeof DESKTOP_UPDATE.CHECKING }
     | { type: typeof DESKTOP_UPDATE.AVAILABLE; payload: UpdateInfo }
     | { type: typeof DESKTOP_UPDATE.NOT_AVAILABLE; payload?: UpdateInfo }
@@ -12,39 +12,32 @@ export type DesktopUpdateActions =
     | { type: typeof DESKTOP_UPDATE.SKIP; payload: string }
     | { type: typeof DESKTOP_UPDATE.WINDOW; payload: UpdateWindow };
 
-export const checking = () => async (dispatch: Dispatch) =>
-    dispatch({ type: DESKTOP_UPDATE.CHECKING });
+export const checking = (): DesktopUpdateAction => ({ type: DESKTOP_UPDATE.CHECKING });
 
-export const available = (info: UpdateInfo) => async (dispatch: Dispatch) =>
-    dispatch({
-        type: DESKTOP_UPDATE.AVAILABLE,
-        payload: info,
-    });
+export const available = (info: UpdateInfo): DesktopUpdateAction => ({
+    type: DESKTOP_UPDATE.AVAILABLE,
+    payload: info,
+});
 
-export const notAvailable = (info: UpdateInfo) => async (dispatch: Dispatch) =>
-    dispatch({
-        type: DESKTOP_UPDATE.NOT_AVAILABLE,
-        payload: info,
-    });
+export const notAvailable = (info: UpdateInfo): DesktopUpdateAction => ({
+    type: DESKTOP_UPDATE.NOT_AVAILABLE,
+    payload: info,
+});
 
-export const downloading = (progress: UpdateProgress) => async (dispatch: Dispatch) =>
-    dispatch({
-        type: DESKTOP_UPDATE.DOWNLOADING,
-        payload: progress,
-        autoClose: false,
-    });
+export const downloading = (progress: UpdateProgress): DesktopUpdateAction => ({
+    type: DESKTOP_UPDATE.DOWNLOADING,
+    payload: progress,
+});
 
-export const ready = (info: UpdateInfo) => async (dispatch: Dispatch) =>
-    dispatch({
-        type: DESKTOP_UPDATE.READY,
-        payload: info,
-    });
+export const ready = (info: UpdateInfo): DesktopUpdateAction => ({
+    type: DESKTOP_UPDATE.READY,
+    payload: info,
+});
 
-export const skip = (version: string) => async (dispatch: Dispatch) =>
-    dispatch({
-        type: DESKTOP_UPDATE.SKIP,
-        payload: version,
-    });
+export const skip = (version: string): DesktopUpdateAction => ({
+    type: DESKTOP_UPDATE.SKIP,
+    payload: version,
+});
 
 export const error = (err: Error) => async (dispatch: Dispatch, getState: GetState) => {
     // TODO: Properly display error
@@ -58,8 +51,7 @@ export const error = (err: Error) => async (dispatch: Dispatch, getState: GetSta
     });
 };
 
-export const setUpdateWindow = (win: UpdateWindow) => async (dispatch: Dispatch) =>
-    dispatch({
-        type: DESKTOP_UPDATE.WINDOW,
-        payload: win,
-    });
+export const setUpdateWindow = (win: UpdateWindow): DesktopUpdateAction => ({
+    type: DESKTOP_UPDATE.WINDOW,
+    payload: win,
+});

--- a/packages/suite/src/actions/suite/logActions.ts
+++ b/packages/suite/src/actions/suite/logActions.ts
@@ -12,19 +12,17 @@ export type LogAction =
 export const addCustom = (
     action: Action,
     payload: Record<string, unknown> | undefined,
-): LogAction => {
-    return {
-        type: LOG.ADD,
-        payload: {
-            time: new Date().getTime(),
-            custom: true,
-            action: {
-                type: action.type,
-                payload,
-            },
+): LogAction => ({
+    type: LOG.ADD,
+    payload: {
+        time: new Date().getTime(),
+        custom: true,
+        action: {
+            type: action.type,
+            payload,
         },
-    };
-};
+    },
+});
 
 export const addAction = (action: Action, options?: { stripPayload: true }): LogAction => {
     const stripPayload = !!options?.stripPayload;

--- a/packages/suite/src/actions/suite/logActions.ts
+++ b/packages/suite/src/actions/suite/logActions.ts
@@ -5,11 +5,14 @@ import * as Sentry from '@sentry/browser';
 import { LOG } from './constants';
 import { redactDevice, redactCustom, redactAction } from '@suite/utils/suite/logUtils';
 
-export type LogActions =
+export type LogAction =
     | { type: typeof LOG.ADD; payload: LogEntry }
     | { type: typeof LOG.TOGGLE_EXCLUDE_BALANCE_RELATED };
 
-export const addCustom = (action: Action, payload: Record<string, unknown> | undefined): Action => {
+export const addCustom = (
+    action: Action,
+    payload: Record<string, unknown> | undefined,
+): LogAction => {
     return {
         type: LOG.ADD,
         payload: {
@@ -23,7 +26,7 @@ export const addCustom = (action: Action, payload: Record<string, unknown> | und
     };
 };
 
-export const addAction = (action: Action, options?: { stripPayload: true }): Action => {
+export const addAction = (action: Action, options?: { stripPayload: true }): LogAction => {
     const stripPayload = !!options?.stripPayload;
 
     if (stripPayload) {
@@ -49,7 +52,7 @@ export const addAction = (action: Action, options?: { stripPayload: true }): Act
     };
 };
 
-export const toggleExcludeBalanceRelated = () => ({
+export const toggleExcludeBalanceRelated = (): LogAction => ({
     type: LOG.TOGGLE_EXCLUDE_BALANCE_RELATED,
 });
 

--- a/packages/suite/src/actions/suite/metadataActions.ts
+++ b/packages/suite/src/actions/suite/metadataActions.ts
@@ -18,7 +18,7 @@ import DropboxProvider from '@suite-services/metadata/DropboxProvider';
 import GoogleProvider from '@suite-services/metadata/GoogleProvider';
 import FileSystemProvider from '@suite-services/metadata/FileSystemProvider';
 
-export type MetadataActions =
+export type MetadataAction =
     | { type: typeof METADATA.ENABLE }
     | { type: typeof METADATA.DISABLE }
     | { type: typeof METADATA.SET_EDITING; payload: string | undefined }
@@ -200,11 +200,9 @@ const getProvider = () => async (_dispatch: Dispatch, getState: GetState) => {
     return providerInstance;
 };
 
-export const enableMetadata = () => (dispatch: Dispatch) => {
-    dispatch({
-        type: METADATA.ENABLE,
-    });
-};
+export const enableMetadata = (): MetadataAction => ({
+    type: METADATA.ENABLE,
+});
 
 export const disableMetadata = () => (dispatch: Dispatch) => {
     dispatch({
@@ -680,9 +678,7 @@ export const init = (force = false) => async (dispatch: Dispatch, getState: GetS
     return true;
 };
 
-export const setEditing = (payload: string | undefined) => (dispatch: Dispatch) => {
-    dispatch({
-        type: METADATA.SET_EDITING,
-        payload,
-    });
-};
+export const setEditing = (payload: string | undefined): MetadataAction => ({
+    type: METADATA.SET_EDITING,
+    payload,
+});

--- a/packages/suite/src/actions/suite/modalActions.ts
+++ b/packages/suite/src/actions/suite/modalActions.ts
@@ -1,6 +1,6 @@
 import TrezorConnect, { UI } from 'trezor-connect';
 import { MODAL, SUITE } from '@suite-actions/constants';
-import { Action, Dispatch, GetState, TrezorDevice } from '@suite-types';
+import { Dispatch, GetState, TrezorDevice } from '@suite-types';
 import { Account, WalletAccountTransaction } from '@wallet-types';
 import { createDeferred, Deferred, DeferredResponse } from '@suite-utils/deferred';
 
@@ -89,7 +89,7 @@ export type UserContextPayload =
           coin: Account['symbol'];
       };
 
-export type ModalActions =
+export type ModalAction =
     | {
           type: typeof MODAL.CLOSE;
       }
@@ -98,7 +98,7 @@ export type ModalActions =
           payload: UserContextPayload;
       };
 
-export const onCancel = (): Action => ({
+export const onCancel = (): ModalAction => ({
     type: MODAL.CLOSE,
 });
 
@@ -174,7 +174,7 @@ export const onReceiveConfirmation = (confirmation: boolean) => async (dispatch:
     dispatch(onCancel());
 };
 
-export const openModal = (payload: UserContextPayload): Action => ({
+export const openModal = (payload: UserContextPayload): ModalAction => ({
     type: MODAL.OPEN_USER_CONTEXT,
     payload,
 });

--- a/packages/suite/src/actions/suite/notificationActions.ts
+++ b/packages/suite/src/actions/suite/notificationActions.ts
@@ -9,7 +9,7 @@ import {
 } from '@suite-reducers/notificationReducer';
 import * as notificationUtils from '@suite-utils/notification';
 
-export type NotificationActions =
+export type NotificationAction =
     | {
           type: typeof NOTIFICATION.TOAST;
           payload: ToastNotification;
@@ -56,17 +56,17 @@ export const addEvent = (payload: EventPayload) => (dispatch: Dispatch, getState
     });
 };
 
-export const close = (id: number): NotificationActions => ({
+export const close = (id: number): NotificationAction => ({
     type: NOTIFICATION.CLOSE,
     payload: id,
 });
 
-export const resetUnseen = (payload?: NotificationEntry[]): NotificationActions => ({
+export const resetUnseen = (payload?: NotificationEntry[]): NotificationAction => ({
     type: NOTIFICATION.RESET_UNSEEN,
     payload,
 });
 
-export const remove = (payload: NotificationEntry[] | NotificationEntry): NotificationActions => ({
+export const remove = (payload: NotificationEntry[] | NotificationEntry): NotificationAction => ({
     type: NOTIFICATION.REMOVE,
     payload,
 });

--- a/packages/suite/src/actions/suite/resizeActions.ts
+++ b/packages/suite/src/actions/suite/resizeActions.ts
@@ -1,18 +1,13 @@
 import { RESIZE } from './constants';
-import { Dispatch } from '@suite-types';
 
-export interface ResizeActions {
+export interface ResizeAction {
     type: typeof RESIZE.UPDATE_WINDOW_SIZE;
     screenWidth: number | null;
     screenHeight: number | null;
 }
 
-export const updateWindowSize = (screenWidth: number, screenHeight: number) => (
-    dispatch: Dispatch,
-) => {
-    dispatch({
-        type: RESIZE.UPDATE_WINDOW_SIZE,
-        screenWidth,
-        screenHeight,
-    });
-};
+export const updateWindowSize = (screenWidth: number, screenHeight: number): ResizeAction => ({
+    type: RESIZE.UPDATE_WINDOW_SIZE,
+    screenWidth,
+    screenHeight,
+});

--- a/packages/suite/src/actions/suite/routerActions.ts
+++ b/packages/suite/src/actions/suite/routerActions.ts
@@ -19,7 +19,7 @@ interface LocationChange {
     url: string;
 }
 
-export type RouterActions = LocationChange;
+export type RouterAction = LocationChange;
 
 /**
  * Dispatch initial url

--- a/packages/suite/src/actions/suite/storageActions.ts
+++ b/packages/suite/src/actions/suite/storageActions.ts
@@ -15,7 +15,7 @@ import { getAnalyticsRandomId } from '@suite-utils/random';
 import { BuyTrade, ExchangeTrade } from 'invity-api';
 import { setSentryUser } from '@suite-utils/sentry';
 
-export type StorageActions =
+export type StorageAction =
     | { type: typeof STORAGE.LOAD }
     | { type: typeof STORAGE.LOADED; payload: AppState }
     | { type: typeof STORAGE.ERROR; error: any };

--- a/packages/suite/src/actions/suite/suiteActions.ts
+++ b/packages/suite/src/actions/suite/suiteActions.ts
@@ -8,7 +8,7 @@ import { LANGUAGES } from '@suite-config';
 import { Action, Dispatch, GetState, TrezorDevice, AppState } from '@suite-types';
 import { DebugModeOptions } from '@suite-reducers/suiteReducer';
 
-export type SuiteActions =
+export type SuiteAction =
     | { type: typeof SUITE.INIT }
     | { type: typeof SUITE.READY }
     | { type: typeof SUITE.ERROR; error: string }
@@ -64,13 +64,13 @@ export type SuiteActions =
 export const setProcessMode = (
     device: TrezorDevice,
     processMode: TrezorDevice['processMode'],
-): Action => ({
+): SuiteAction => ({
     type: SUITE.SET_PROCESS_MODE,
     device,
     payload: processMode,
 });
 
-export const setFlag = (key: keyof AppState['suite']['flags'], value: boolean): Action => ({
+export const setFlag = (key: keyof AppState['suite']['flags'], value: boolean): SuiteAction => ({
     type: SUITE.SET_FLAG,
     key,
     value,
@@ -86,9 +86,9 @@ export const initialRunCompleted = () => (dispatch: Dispatch, getState: GetState
  * Triggered by `@suite-support/OnlineStatus` or `@suite-native/support/OnlineStatus`
  * Set `online` status in suite reducer
  * @param {boolean} payload
- * @returns {Action}
+ * @returns {SuiteAction}
  */
-export const updateOnlineStatus = (payload: boolean) => ({
+export const updateOnlineStatus = (payload: boolean): SuiteAction => ({
     type: SUITE.ONLINE_STATUS,
     payload,
 });
@@ -107,9 +107,9 @@ export const updateTorStatus = (payload: boolean) => ({
 /**
  * Called from `suiteMiddleware`
  * Set `loaded` field in suite reducer
- * @returns {Action}
+ * @returns {SuiteAction}
  */
-export const onSuiteReady = (): Action => ({
+export const onSuiteReady = (): SuiteAction => ({
     type: SUITE.READY,
 });
 
@@ -118,9 +118,9 @@ export const onSuiteReady = (): Action => ({
  * - Debug Settings
  * Set `debug` object in suite reducer
  * @param {boolean} payload
- * @returns {Action}
+ * @returns {SuiteAction}
  */
-export const setDebugMode = (payload: Partial<DebugModeOptions>): Action => ({
+export const setDebugMode = (payload: Partial<DebugModeOptions>): SuiteAction => ({
     type: SUITE.SET_DEBUG_MODE,
     payload,
 });
@@ -129,9 +129,9 @@ export const setDebugMode = (payload: Partial<DebugModeOptions>): Action => ({
  * Called from multiple places before and after TrezorConnect call
  * Prevent from mad clicking
  * Set `lock` field in suite reducer
- * @returns {Action}
+ * @returns {SuiteAction}
  */
-export const lockUI = (payload: boolean): Action => ({
+export const lockUI = (payload: boolean): SuiteAction => ({
     type: SUITE.LOCK_UI,
     payload,
 });
@@ -140,9 +140,9 @@ export const lockUI = (payload: boolean): Action => ({
  * Prevent TrezorConnect multiple calls
  * Called before and after specific process, like onboarding
  * Set `lock` field in suite reducer
- * @returns {Action}
+ * @returns {SuiteAction}
  */
-export const lockDevice = (payload: boolean): Action => ({
+export const lockDevice = (payload: boolean): SuiteAction => ({
     type: SUITE.LOCK_DEVICE,
     payload,
 });
@@ -151,9 +151,9 @@ export const lockDevice = (payload: boolean): Action => ({
  * Prevent route change and rendering
  * Called before and after specific process, like onboarding
  * Set `lock` field in suite reducer
- * @returns {Action}
+ * @returns {SuiteAction}
  */
-export const lockRouter = (payload: boolean): Action => ({
+export const lockRouter = (payload: boolean): SuiteAction => ({
     type: SUITE.LOCK_ROUTER,
     payload,
 });
@@ -191,7 +191,7 @@ export const selectDevice = (device?: Device | TrezorDevice) => async (
     });
 };
 
-export const rememberDevice = (payload: TrezorDevice, forceRemember?: true): Action => ({
+export const rememberDevice = (payload: TrezorDevice, forceRemember?: true): SuiteAction => ({
     type: SUITE.REMEMBER_DEVICE,
     payload,
     remember: !payload.remember || !!forceRemember,
@@ -199,7 +199,7 @@ export const rememberDevice = (payload: TrezorDevice, forceRemember?: true): Act
     forceRemember: payload.remember ? undefined : forceRemember,
 });
 
-export const forgetDevice = (payload: TrezorDevice): Action => ({
+export const forgetDevice = (payload: TrezorDevice): SuiteAction => ({
     type: SUITE.FORGET_DEVICE,
     payload,
 });
@@ -374,7 +374,7 @@ export const acquireDevice = (requestedDevice?: TrezorDevice) => async (
 /**
  * Inner action used in `authorizeDevice`
  */
-const updatePassphraseMode = (device: TrezorDevice, hidden: boolean): Action => ({
+const updatePassphraseMode = (device: TrezorDevice, hidden: boolean): SuiteAction => ({
     type: SUITE.UPDATE_PASSPHRASE_MODE,
     payload: device,
     hidden,
@@ -444,7 +444,7 @@ export const authorizeDevice = () => async (
 /**
  * Inner action used in `authConfirm`
  */
-const receiveAuthConfirm = (device: TrezorDevice, success: boolean): Action => ({
+const receiveAuthConfirm = (device: TrezorDevice, success: boolean): SuiteAction => ({
     type: SUITE.RECEIVE_AUTH_CONFIRM,
     payload: device,
     success,

--- a/packages/suite/src/actions/wallet/accountActions.ts
+++ b/packages/suite/src/actions/wallet/accountActions.ts
@@ -10,7 +10,7 @@ import { Account } from '@wallet-types';
 import { Dispatch, GetState } from '@suite-types';
 import { SETTINGS } from '@suite-config';
 
-export type AccountActions =
+export type AccountAction =
     | { type: typeof ACCOUNT.CREATE; payload: Account }
     | { type: typeof ACCOUNT.REMOVE; payload: Account[] }
     | { type: typeof ACCOUNT.CHANGE_VISIBILITY; payload: Account }
@@ -20,7 +20,7 @@ export const create = (
     deviceState: string,
     discoveryItem: DiscoveryItem,
     accountInfo: AccountInfo,
-): AccountActions => ({
+): AccountAction => ({
     type: ACCOUNT.CREATE,
     payload: {
         deviceState,
@@ -58,7 +58,7 @@ export const create = (
     },
 });
 
-export const update = (account: Account, accountInfo: AccountInfo): AccountActions => ({
+export const update = (account: Account, accountInfo: AccountInfo): AccountAction => ({
     type: ACCOUNT.UPDATE,
     payload: {
         ...account,
@@ -94,7 +94,7 @@ export const disableAccounts = () => (dispatch: Dispatch, getState: GetState) =>
     }
 };
 
-export const changeAccountVisibility = (payload: Account, visible = true) => ({
+export const changeAccountVisibility = (payload: Account, visible = true): AccountAction => ({
     type: ACCOUNT.CHANGE_VISIBILITY,
     payload: {
         ...payload,

--- a/packages/suite/src/actions/wallet/accountSearchActions.ts
+++ b/packages/suite/src/actions/wallet/accountSearchActions.ts
@@ -1,7 +1,7 @@
 import { Account } from '@wallet-types';
 import { ACCOUNT_SEARCH } from '@wallet-actions/constants';
 
-export type AccountSearchActions =
+export type AccountSearchAction =
     | {
           type: typeof ACCOUNT_SEARCH.SET_COIN_FILTER;
           payload?: Account['symbol'];
@@ -11,12 +11,12 @@ export type AccountSearchActions =
           payload?: string;
       };
 
-export const setCoinFilter = (payload?: Account['symbol']) => ({
+export const setCoinFilter = (payload?: Account['symbol']): AccountSearchAction => ({
     type: ACCOUNT_SEARCH.SET_COIN_FILTER,
     payload,
 });
 
-export const setSearchString = (payload?: string) => ({
+export const setSearchString = (payload?: string): AccountSearchAction => ({
     type: ACCOUNT_SEARCH.SET_SEARCH_STRING,
     payload,
 });

--- a/packages/suite/src/actions/wallet/blockchainActions.ts
+++ b/packages/suite/src/actions/wallet/blockchainActions.ts
@@ -20,7 +20,7 @@ import { BLOCKCHAIN } from './constants';
 // checks if there are discovery processes loaded from LocalStorage
 // if so starts subscription to proper networks
 
-export type BlockchainActions =
+export type BlockchainAction =
     | {
           type: typeof BLOCKCHAIN.READY | typeof BLOCKCHAIN.CONNECTED;
       }

--- a/packages/suite/src/actions/wallet/coinmarketBuyActions.ts
+++ b/packages/suite/src/actions/wallet/coinmarketBuyActions.ts
@@ -13,10 +13,10 @@ export interface BuyInfo {
     supportedCryptoCurrencies: Set<string>;
 }
 
-export type CoinmarketBuyActions =
+export type CoinmarketBuyAction =
     | { type: typeof COINMARKET_BUY.SAVE_BUY_INFO; buyInfo: BuyInfo }
     | { type: typeof COINMARKET_BUY.DISPOSE }
-    | { type: typeof COINMARKET_BUY.SET_IS_FROM_REDIRECT; isFromRedirect: true }
+    | { type: typeof COINMARKET_BUY.SET_IS_FROM_REDIRECT; isFromRedirect: boolean }
     | { type: typeof COINMARKET_BUY.SAVE_TRANSACTION_DETAIL_ID; transactionId: string }
     | { type: typeof COINMARKET_BUY.SAVE_QUOTE_REQUEST; request: BuyTradeQuoteRequest }
     | { type: typeof COINMARKET_BUY.VERIFY_ADDRESS; addressVerified: boolean }
@@ -46,7 +46,7 @@ export type CoinmarketBuyActions =
           };
       };
 
-export async function loadBuyInfo(): Promise<BuyInfo> {
+export const loadBuyInfo = async (): Promise<BuyInfo> => {
     let buyInfo = await invityAPI.getBuyList();
 
     if (!buyInfo) {
@@ -76,25 +76,21 @@ export async function loadBuyInfo(): Promise<BuyInfo> {
         supportedFiatCurrencies,
         supportedCryptoCurrencies,
     };
-}
-
-export const saveBuyInfo = (buyInfo: BuyInfo) => async (dispatch: Dispatch) => {
-    dispatch({
-        type: COINMARKET_BUY.SAVE_BUY_INFO,
-        buyInfo,
-    });
 };
 
-export const dispose = () => ({
+export const saveBuyInfo = (buyInfo: BuyInfo): CoinmarketBuyAction => ({
+    type: COINMARKET_BUY.SAVE_BUY_INFO,
+    buyInfo,
+});
+
+export const dispose = (): CoinmarketBuyAction => ({
     type: COINMARKET_BUY.DISPOSE,
 });
 
-export const setIsFromRedirect = (isFromRedirect: boolean) => async (dispatch: Dispatch) => {
-    dispatch({
-        type: COINMARKET_BUY.SET_IS_FROM_REDIRECT,
-        isFromRedirect,
-    });
-};
+export const setIsFromRedirect = (isFromRedirect: boolean): CoinmarketBuyAction => ({
+    type: COINMARKET_BUY.SET_IS_FROM_REDIRECT,
+    isFromRedirect,
+});
 
 // this is only a wrapper for `openDeferredModal` since it doesn't work with `bindActionCreators`
 // used in useCoinmarketBuyOffers
@@ -102,59 +98,52 @@ export const openCoinmarketBuyConfirmModal = (provider?: string) => (dispatch: D
     return dispatch(modalActions.openDeferredModal({ type: 'coinmarket-buy-terms', provider }));
 };
 
-export const saveTrade = (buyTrade: BuyTrade, account: Account, date: string) => async (
-    dispatch: Dispatch,
-) => {
-    dispatch({
-        type: COINMARKET_BUY.SAVE_TRADE,
-        tradeType: 'buy',
-        key: buyTrade.paymentId,
-        date,
-        data: buyTrade,
-        account: {
-            descriptor: account.descriptor,
-            symbol: account.symbol,
-            accountType: account.accountType,
-            accountIndex: account.index,
-        },
-    });
-};
+export const saveTrade = (
+    buyTrade: BuyTrade,
+    account: Account,
+    date: string,
+): CoinmarketBuyAction => ({
+    type: COINMARKET_BUY.SAVE_TRADE,
+    tradeType: 'buy',
+    key: buyTrade.paymentId,
+    date,
+    data: buyTrade,
+    account: {
+        descriptor: account.descriptor,
+        symbol: account.symbol,
+        accountType: account.accountType,
+        accountIndex: account.index,
+    },
+});
 
-export const saveQuoteRequest = (request: BuyTradeQuoteRequest) => async (dispatch: Dispatch) => {
-    dispatch({
-        type: COINMARKET_BUY.SAVE_QUOTE_REQUEST,
-        request,
-    });
-};
+export const saveQuoteRequest = (request: BuyTradeQuoteRequest): CoinmarketBuyAction => ({
+    type: COINMARKET_BUY.SAVE_QUOTE_REQUEST,
+    request,
+});
 
-export const saveTransactionDetailId = (transactionId: string) => async (dispatch: Dispatch) => {
-    dispatch({
-        type: COINMARKET_BUY.SAVE_TRANSACTION_DETAIL_ID,
-        transactionId,
-    });
-};
+export const saveTransactionDetailId = (transactionId: string): CoinmarketBuyAction => ({
+    type: COINMARKET_BUY.SAVE_TRANSACTION_DETAIL_ID,
+    transactionId,
+});
 
 export const saveCachedAccountInfo = (
     symbol: Account['symbol'],
     index: number,
     accountType: Account['accountType'],
     shouldSubmit = false,
-) => async (dispatch: Dispatch) => {
-    dispatch({
-        type: COINMARKET_BUY.SAVE_CACHED_ACCOUNT_INFO,
-        symbol,
-        index,
-        accountType,
-        shouldSubmit,
-    });
-};
+): CoinmarketBuyAction => ({
+    type: COINMARKET_BUY.SAVE_CACHED_ACCOUNT_INFO,
+    symbol,
+    index,
+    accountType,
+    shouldSubmit,
+});
 
-export const saveQuotes = (quotes: BuyTrade[], alternativeQuotes: BuyTrade[] | undefined) => async (
-    dispatch: Dispatch,
-) => {
-    dispatch({
-        type: COINMARKET_BUY.SAVE_QUOTES,
-        quotes,
-        alternativeQuotes,
-    });
-};
+export const saveQuotes = (
+    quotes: BuyTrade[],
+    alternativeQuotes: BuyTrade[] | undefined,
+): CoinmarketBuyAction => ({
+    type: COINMARKET_BUY.SAVE_QUOTES,
+    quotes,
+    alternativeQuotes,
+});

--- a/packages/suite/src/actions/wallet/coinmarketCommonActions.ts
+++ b/packages/suite/src/actions/wallet/coinmarketCommonActions.ts
@@ -96,7 +96,7 @@ export const verifyAddress = (path: string, address: string) => async (
     }
 };
 
-export const submitRequestForm = (tradeForm: BuyTradeFormResponse) => async (
+export const submitRequestForm = (tradeForm: BuyTradeFormResponse) => (
     dispatch: Dispatch,
     getState: GetState,
 ) => {

--- a/packages/suite/src/actions/wallet/coinmarketExchangeActions.ts
+++ b/packages/suite/src/actions/wallet/coinmarketExchangeActions.ts
@@ -7,7 +7,6 @@ import {
 } from 'invity-api';
 import invityAPI from '@suite-services/invityAPI';
 import { COINMARKET_EXCHANGE } from './constants';
-import { Dispatch } from '@suite-types';
 
 export interface ExchangeInfo {
     exchangeList?: ExchangeListResponse;
@@ -16,7 +15,7 @@ export interface ExchangeInfo {
     sellSymbols: Set<string>;
 }
 
-export type CoinmarketExchangeActions =
+export type CoinmarketExchangeAction =
     | { type: typeof COINMARKET_EXCHANGE.SAVE_EXCHANGE_INFO; exchangeInfo: ExchangeInfo }
     | { type: typeof COINMARKET_EXCHANGE.SAVE_QUOTE_REQUEST; request: ExchangeTradeQuoteRequest }
     | { type: typeof COINMARKET_EXCHANGE.SAVE_TRANSACTION_ID; transactionId: string }
@@ -33,14 +32,14 @@ export type CoinmarketExchangeActions =
           tradeType: 'exchange';
           data: ExchangeTrade;
           account: {
+              descriptor: string;
               symbol: Account['symbol'];
               accountIndex: Account['index'];
               accountType: Account['accountType'];
-              deviceState: Account['deviceState'];
           };
       };
 
-export async function loadExchangeInfo(): Promise<ExchangeInfo> {
+export const loadExchangeInfo = async (): Promise<ExchangeInfo> => {
     const exchangeList = await invityAPI.getExchangeList();
 
     if (!exchangeList || exchangeList.length === 0) {
@@ -67,55 +66,46 @@ export async function loadExchangeInfo(): Promise<ExchangeInfo> {
         buySymbols: new Set(buySymbols),
         sellSymbols: new Set(sellSymbols),
     };
-}
-
-export const saveExchangeInfo = (exchangeInfo: ExchangeInfo) => async (dispatch: Dispatch) => {
-    dispatch({
-        type: COINMARKET_EXCHANGE.SAVE_EXCHANGE_INFO,
-        exchangeInfo,
-    });
 };
 
-export const saveTrade = (exchangeTrade: ExchangeTrade, account: Account, date: string) => async (
-    dispatch: Dispatch,
-) => {
-    dispatch({
-        type: COINMARKET_EXCHANGE.SAVE_TRADE,
-        tradeType: 'exchange',
-        key: exchangeTrade.orderId,
-        date,
-        data: exchangeTrade,
-        account: {
-            descriptor: account.descriptor,
-            symbol: account.symbol,
-            accountType: account.accountType,
-            accountIndex: account.index,
-        },
-    });
-};
+export const saveExchangeInfo = (exchangeInfo: ExchangeInfo): CoinmarketExchangeAction => ({
+    type: COINMARKET_EXCHANGE.SAVE_EXCHANGE_INFO,
+    exchangeInfo,
+});
 
-export const saveQuoteRequest = (request: ExchangeTradeQuoteRequest) => async (
-    dispatch: Dispatch,
-) => {
-    dispatch({
-        type: COINMARKET_EXCHANGE.SAVE_QUOTE_REQUEST,
-        request,
-    });
-};
+export const saveTrade = (
+    exchangeTrade: ExchangeTrade,
+    account: Account,
+    date: string,
+): CoinmarketExchangeAction => ({
+    type: COINMARKET_EXCHANGE.SAVE_TRADE,
+    tradeType: 'exchange',
+    key: exchangeTrade.orderId,
+    date,
+    data: exchangeTrade,
+    account: {
+        descriptor: account.descriptor,
+        symbol: account.symbol,
+        accountType: account.accountType,
+        accountIndex: account.index,
+    },
+});
 
-export const saveTransactionId = (transactionId: string) => async (dispatch: Dispatch) => {
-    dispatch({
-        type: COINMARKET_EXCHANGE.SAVE_TRANSACTION_ID,
-        transactionId,
-    });
-};
+export const saveQuoteRequest = (request: ExchangeTradeQuoteRequest): CoinmarketExchangeAction => ({
+    type: COINMARKET_EXCHANGE.SAVE_QUOTE_REQUEST,
+    request,
+});
 
-export const saveQuotes = (fixedQuotes: ExchangeTrade[], floatQuotes: ExchangeTrade[]) => async (
-    dispatch: Dispatch,
-) => {
-    dispatch({
-        type: COINMARKET_EXCHANGE.SAVE_QUOTES,
-        fixedQuotes,
-        floatQuotes,
-    });
-};
+export const saveTransactionId = (transactionId: string): CoinmarketExchangeAction => ({
+    type: COINMARKET_EXCHANGE.SAVE_TRANSACTION_ID,
+    transactionId,
+});
+
+export const saveQuotes = (
+    fixedQuotes: ExchangeTrade[],
+    floatQuotes: ExchangeTrade[],
+): CoinmarketExchangeAction => ({
+    type: COINMARKET_EXCHANGE.SAVE_QUOTES,
+    fixedQuotes,
+    floatQuotes,
+});

--- a/packages/suite/src/actions/wallet/discoveryActions.ts
+++ b/packages/suite/src/actions/wallet/discoveryActions.ts
@@ -490,7 +490,7 @@ export const start = () => async (dispatch: Dispatch, getState: GetState): Promi
     }
 };
 
-export const stop = () => async (dispatch: Dispatch) => {
+export const stop = () => (dispatch: Dispatch) => {
     const discovery = dispatch(getDiscoveryForDevice());
     if (discovery && discovery.running) {
         dispatch(

--- a/packages/suite/src/actions/wallet/discoveryActions.ts
+++ b/packages/suite/src/actions/wallet/discoveryActions.ts
@@ -10,7 +10,7 @@ import { NETWORKS } from '@wallet-config';
 import { Dispatch, GetState, TrezorDevice } from '@suite-types';
 import { Account } from '@wallet-types';
 
-export type DiscoveryActions =
+export type DiscoveryAction =
     | { type: typeof DISCOVERY.CREATE; payload: Discovery }
     | { type: typeof DISCOVERY.START; payload: Discovery }
     | { type: typeof DISCOVERY.UPDATE; payload: PartialDiscovery }
@@ -81,7 +81,7 @@ export const getDiscoveryAuthConfirmationStatus = () => (
 export const update = (
     payload: PartialDiscovery,
     type: UpdateActionType = DISCOVERY.UPDATE,
-): DiscoveryActions => ({
+): DiscoveryAction => ({
     type,
     payload,
 });
@@ -281,7 +281,7 @@ export const create = (deviceState: string, device: TrezorDevice) => (
     });
 };
 
-export const remove = (deviceState: string): DiscoveryActions => ({
+export const remove = (deviceState: string): DiscoveryAction => ({
     type: DISCOVERY.REMOVE,
     payload: {
         deviceState,
@@ -490,7 +490,7 @@ export const start = () => async (dispatch: Dispatch, getState: GetState): Promi
     }
 };
 
-export const stop = () => async (dispatch: Dispatch): Promise<void> => {
+export const stop = () => async (dispatch: Dispatch) => {
     const discovery = dispatch(getDiscoveryForDevice());
     if (discovery && discovery.running) {
         dispatch(

--- a/packages/suite/src/actions/wallet/fiatRatesActions.ts
+++ b/packages/suite/src/actions/wallet/fiatRatesActions.ts
@@ -30,7 +30,7 @@ import { CoinListItem } from '@wallet-types/fiatRates';
 
 type FiatRatesPayload = NonNullable<CoinFiatRates['current']>;
 
-export type FiatRatesActions =
+export type FiatRatesAction =
     | {
           type: typeof FETCH_COIN_LIST_START;
       }
@@ -76,13 +76,11 @@ const INTERVAL_LAST_WEEK = 1000 * 60 * 60 * 1; // 1 hour
 const MAX_AGE = 1000 * 60 * 10; // 10 mins
 const MAX_AGE_LAST_WEEK = 1000 * 60 * 60 * 1; // 1 hour
 
-export const remove = (symbol: string, mainNetworkSymbol?: string) => (dispatch: Dispatch) => {
-    dispatch({
-        type: RATE_REMOVE,
-        symbol,
-        mainNetworkSymbol,
-    });
-};
+export const remove = (symbol: string, mainNetworkSymbol?: string): FiatRatesAction => ({
+    type: RATE_REMOVE,
+    symbol,
+    mainNetworkSymbol,
+});
 
 export const removeRatesForDisabledNetworks = () => (dispatch: Dispatch, getState: GetState) => {
     const { enabledNetworks } = getState().wallet.settings;

--- a/packages/suite/src/actions/wallet/graphActions.ts
+++ b/packages/suite/src/actions/wallet/graphActions.ts
@@ -18,7 +18,7 @@ import {
     enhanceBlockchainAccountHistory,
 } from '@wallet-utils/graphUtils';
 
-export type GraphActions =
+export type GraphAction =
     | {
           type: typeof ACCOUNT_GRAPH_SUCCESS;
           payload: GraphData;
@@ -46,12 +46,12 @@ export type GraphActions =
           payload: GraphScale;
       };
 
-export const setSelectedRange = (range: GraphRange) => ({
+export const setSelectedRange = (range: GraphRange): GraphAction => ({
     type: SET_SELECTED_RANGE,
     payload: range,
 });
 
-export const setSelectedView = (view: GraphScale) => ({
+export const setSelectedView = (view: GraphScale): GraphAction => ({
     type: SET_SELECTED_VIEW,
     payload: view,
 });

--- a/packages/suite/src/actions/wallet/receiveActions.ts
+++ b/packages/suite/src/actions/wallet/receiveActions.ts
@@ -5,12 +5,12 @@ import * as modalActions from '@suite-actions/modalActions';
 import * as notificationActions from '@suite-actions/notificationActions';
 import { GetState, Dispatch } from '@suite-types';
 
-export type ReceiveActions =
+export type ReceiveAction =
     | { type: typeof RECEIVE.DISPOSE }
     | { type: typeof RECEIVE.SHOW_ADDRESS; path: string; address: string }
     | { type: typeof RECEIVE.SHOW_UNVERIFIED_ADDRESS; path: string; address: string };
 
-export const dispose = (): ReceiveActions => ({
+export const dispose = (): ReceiveAction => ({
     type: RECEIVE.DISPOSE,
 });
 

--- a/packages/suite/src/actions/wallet/selectedAccountActions.ts
+++ b/packages/suite/src/actions/wallet/selectedAccountActions.ts
@@ -9,15 +9,15 @@ import * as accountUtils from '@wallet-utils/accountUtils';
 import { Action, Dispatch, GetState } from '@suite-types';
 import { State, AccountWatchOnlyMode } from '@wallet-reducers/selectedAccountReducer';
 
-export type SelectedAccountActions =
+export type SelectedAccountAction =
     | { type: typeof ACCOUNT.DISPOSE }
     | { type: typeof ACCOUNT.UPDATE_SELECTED_ACCOUNT; payload: State };
 
-export const dispose = (): Action => ({
+export const dispose = (): SelectedAccountAction => ({
     type: ACCOUNT.DISPOSE,
 });
 
-export const update = (payload: State): Action => ({
+export const update = (payload: State): SelectedAccountAction => ({
     type: ACCOUNT.UPDATE_SELECTED_ACCOUNT,
     payload,
 });
@@ -26,7 +26,7 @@ export const update = (payload: State): Action => ({
 const getAccountStateWithMode = (selectedAccount?: State) => (
     _dispatch: Dispatch,
     getState: GetState,
-): AccountWatchOnlyMode[] | undefined => {
+) => {
     const state = getState();
     const { device, loaded } = state.suite;
     if (!device || !loaded) return;
@@ -63,7 +63,7 @@ const getAccountStateWithMode = (selectedAccount?: State) => (
     return mode.length > 0 ? mode : undefined;
 };
 
-const getAccountState = () => (dispatch: Dispatch, getState: GetState): State => {
+const getAccountState = () => (dispatch: Dispatch, getState: GetState) => {
     const state = getState();
 
     const { device } = state.suite;

--- a/packages/suite/src/actions/wallet/sendFormActions.ts
+++ b/packages/suite/src/actions/wallet/sendFormActions.ts
@@ -14,7 +14,7 @@ import * as sendFormBitcoinActions from './send/sendFormBitcoinActions';
 import * as sendFormEthereumActions from './send/sendFormEthereumActions';
 import * as sendFormRippleActions from './send/sendFormRippleActions';
 
-export type SendFormActions =
+export type SendFormAction =
     | {
           type: typeof SEND.STORE_DRAFT;
           key: string;
@@ -84,7 +84,7 @@ export const removeDraft = () => (dispatch: Dispatch, getState: GetState) => {
     }
 };
 
-export const composeTransaction = (formValues: FormState, formState: UseSendFormState) => async (
+export const composeTransaction = (formValues: FormState, formState: UseSendFormState) => (
     dispatch: Dispatch,
 ) => {
     const { account } = formState;
@@ -224,7 +224,7 @@ export const signTransaction = (
     }
 };
 
-export const sendRaw = (payload?: boolean) => ({
+export const sendRaw = (payload?: boolean): SendFormAction => ({
     type: SEND.SEND_RAW,
     payload,
 });
@@ -261,6 +261,6 @@ export const pushRawTransaction = (tx: string, coin: Account['symbol']) => async
     return sentTx.success;
 };
 
-export const dispose = () => ({
+export const dispose = (): SendFormAction => ({
     type: SEND.DISPOSE,
 });

--- a/packages/suite/src/actions/wallet/signVerifyActions.ts
+++ b/packages/suite/src/actions/wallet/signVerifyActions.ts
@@ -12,7 +12,7 @@ export type inputNameType =
     | 'verifyMessage'
     | 'verifySignature';
 
-export type SignVerifyActions =
+export type SignVerifyAction =
     | { type: typeof SIGN_VERIFY.SIGN_SUCCESS; signSignature: string }
     | { type: typeof SIGN_VERIFY.CLEAR_SIGN }
     | { type: typeof SIGN_VERIFY.CLEAR_VERIFY }
@@ -124,10 +124,10 @@ export const inputChange = (inputName: inputNameType, value: string) => (dispatc
     }
 };
 
-export const clearSign = (): SignVerifyActions => ({
+export const clearSign = (): SignVerifyAction => ({
     type: SIGN_VERIFY.CLEAR_SIGN,
 });
 
-export const clearVerify = (): SignVerifyActions => ({
+export const clearVerify = (): SignVerifyAction => ({
     type: SIGN_VERIFY.CLEAR_VERIFY,
 });

--- a/packages/suite/src/actions/wallet/transactionActions.ts
+++ b/packages/suite/src/actions/wallet/transactionActions.ts
@@ -22,43 +22,37 @@ export type TransactionAction =
       }
     | { type: typeof TRANSACTION.FETCH_ERROR; error: string };
 
-export const add = (transactions: AccountTransaction[], account: Account, page?: number) => async (
-    dispatch: Dispatch,
-) => {
-    dispatch({
-        type: TRANSACTION.ADD,
-        transactions,
-        account,
-        page,
-    });
-};
+export const add = (
+    transactions: AccountTransaction[],
+    account: Account,
+    page?: number,
+): TransactionAction => ({
+    type: TRANSACTION.ADD,
+    transactions,
+    account,
+    page,
+});
 
 /**
  * Remove all transactions for a given account
  *
  * @param {Account} account
  */
-export const reset = (account: Account) => async (dispatch: Dispatch) => {
-    dispatch({
-        type: TRANSACTION.RESET,
-        account,
-    });
-};
+export const reset = (account: Account): TransactionAction => ({
+    type: TRANSACTION.RESET,
+    account,
+});
 
 /**
  * Remove certain transactions for a given account
  *
  * @param {Account} account
  */
-export const remove = (account: Account, txs: WalletAccountTransaction[]) => async (
-    dispatch: Dispatch,
-) => {
-    dispatch({
-        type: TRANSACTION.REMOVE,
-        account,
-        txs,
-    });
-};
+export const remove = (account: Account, txs: WalletAccountTransaction[]): TransactionAction => ({
+    type: TRANSACTION.REMOVE,
+    account,
+    txs,
+});
 
 // export const update = (txId: string) => async (dispatch: Dispatch) => {
 //     const updatedTimestamp = Date.now();

--- a/packages/suite/src/types/firmware/index.ts
+++ b/packages/suite/src/types/firmware/index.ts
@@ -1,1 +1,0 @@
-export type { FirmwareActions } from '@firmware-actions/firmwareActions';

--- a/packages/suite/src/types/onboarding/index.ts
+++ b/packages/suite/src/types/onboarding/index.ts
@@ -1,6 +1,0 @@
-export type { OnboardingActionTypes as OnboardingActions } from '@onboarding-actions/onboardingActions';
-
-export interface Checkbox {
-    value: boolean;
-    label: string;
-}

--- a/packages/suite/src/types/settings/index.ts
+++ b/packages/suite/src/types/settings/index.ts
@@ -1,1 +1,0 @@
-export type { WalletSettingsActions as SettingsActions } from '@settings-actions/walletSettingsActions';

--- a/packages/suite/src/types/suite/index.ts
+++ b/packages/suite/src/types/suite/index.ts
@@ -16,7 +16,7 @@ import { SuiteActions } from '@suite-actions/suiteActions';
 import { ResizeActions } from '@suite-actions/resizeActions';
 import { ModalAction } from '@suite-actions/modalActions';
 import { LogAction } from '@suite-actions/logActions';
-import { NotificationActions } from '@suite-actions/notificationActions';
+import { NotificationAction } from '@suite-actions/notificationActions';
 import { AnalyticsAction } from '@suite-actions/analyticsActions';
 import { MetadataAction } from '@suite-actions/metadataActions';
 import { DesktopUpdateAction } from '@suite-actions/desktopUpdateActions';
@@ -47,7 +47,7 @@ export type Action =
     | SuiteActions
     | LogAction
     | ModalAction
-    | NotificationActions
+    | NotificationAction
     | AnalyticsAction
     | MetadataAction
     | WalletAction

--- a/packages/suite/src/types/suite/index.ts
+++ b/packages/suite/src/types/suite/index.ts
@@ -8,12 +8,12 @@ import {
     KnownDevice,
     UnknownDevice as UnknownDeviceBase,
 } from 'trezor-connect';
-import { RouterActions } from '@suite-actions/routerActions';
+import { RouterAction } from '@suite-actions/routerActions';
 import { Route } from '@suite-constants/routes';
 import { AppState } from '@suite/reducers/store';
 import { StorageActions } from '@suite-actions/storageActions';
 import { SuiteActions } from '@suite-actions/suiteActions';
-import { ResizeActions } from '@suite-actions/resizeActions';
+import { ResizeAction } from '@suite-actions/resizeActions';
 import { ModalAction } from '@suite-actions/modalActions';
 import { LogAction } from '@suite-actions/logActions';
 import { NotificationAction } from '@suite-actions/notificationActions';
@@ -41,8 +41,8 @@ type TrezorConnectEvents = TransportEvent | UiEvent | DeviceEvent | BlockchainEv
 // all actions from all apps used to properly type Dispatch.
 export type Action =
     | TrezorConnectEvents
-    | RouterActions
-    | ResizeActions
+    | RouterAction
+    | ResizeAction
     | StorageActions
     | SuiteActions
     | LogAction

--- a/packages/suite/src/types/suite/index.ts
+++ b/packages/suite/src/types/suite/index.ts
@@ -20,13 +20,13 @@ import { NotificationActions } from '@suite-actions/notificationActions';
 import { AnalyticsActions } from '@suite-actions/analyticsActions';
 import { MetadataActions } from '@suite-actions/metadataActions';
 import { DesktopUpdateActions } from '@suite-actions/desktopUpdateActions';
-import { DeviceMetadata } from '@suite-types/metadata';
-import { OnboardingActions } from '@onboarding-types';
+import { OnboardingAction } from '@onboarding-actions/onboardingActions';
 import { SettingsActions } from '@settings-types';
-import { FirmwareActions } from '@firmware-types';
+import { FirmwareAction } from '@firmware-actions/firmwareActions';
 import { WalletAction } from '@wallet-types';
-import { BackupActions } from '@backup-actions/backupActions';
-import { RecoveryActions } from '@recovery-actions/recoveryActions';
+import { BackupAction } from '@backup-actions/backupActions';
+import { RecoveryAction } from '@recovery-actions/recoveryActions';
+import { DeviceMetadata } from '@suite-types/metadata';
 import { ObjectValues } from '@suite/types/utils';
 import { SUITE } from '@suite-actions/constants';
 import { PROCESS_MODE } from '@suite-middlewares/actionBlockerMiddleware';
@@ -51,10 +51,10 @@ export type Action =
     | AnalyticsActions
     | MetadataActions
     | WalletAction
-    | OnboardingActions
-    | FirmwareActions
-    | BackupActions
-    | RecoveryActions
+    | OnboardingAction
+    | FirmwareAction
+    | BackupAction
+    | RecoveryAction
     | SettingsActions
     | DesktopUpdateActions;
 

--- a/packages/suite/src/types/suite/index.ts
+++ b/packages/suite/src/types/suite/index.ts
@@ -21,7 +21,7 @@ import { AnalyticsActions } from '@suite-actions/analyticsActions';
 import { MetadataActions } from '@suite-actions/metadataActions';
 import { DesktopUpdateActions } from '@suite-actions/desktopUpdateActions';
 import { OnboardingAction } from '@onboarding-actions/onboardingActions';
-import { SettingsActions } from '@settings-types';
+import { WalletSettingsAction } from '@settings-actions/walletSettingsActions';
 import { FirmwareAction } from '@firmware-actions/firmwareActions';
 import { WalletAction } from '@wallet-types';
 import { BackupAction } from '@backup-actions/backupActions';
@@ -55,7 +55,7 @@ export type Action =
     | FirmwareAction
     | BackupAction
     | RecoveryAction
-    | SettingsActions
+    | WalletSettingsAction
     | DesktopUpdateActions;
 
 // export type Dispatch = ReduxDispatch<Action>;

--- a/packages/suite/src/types/suite/index.ts
+++ b/packages/suite/src/types/suite/index.ts
@@ -19,7 +19,7 @@ import { LogActions } from '@suite-actions/logActions';
 import { NotificationActions } from '@suite-actions/notificationActions';
 import { AnalyticsActions } from '@suite-actions/analyticsActions';
 import { MetadataActions } from '@suite-actions/metadataActions';
-import { DesktopUpdateActions } from '@suite-actions/desktopUpdateActions';
+import { DesktopUpdateAction } from '@suite-actions/desktopUpdateActions';
 import { OnboardingAction } from '@onboarding-actions/onboardingActions';
 import { WalletSettingsAction } from '@settings-actions/walletSettingsActions';
 import { FirmwareAction } from '@firmware-actions/firmwareActions';
@@ -56,7 +56,7 @@ export type Action =
     | BackupAction
     | RecoveryAction
     | WalletSettingsAction
-    | DesktopUpdateActions;
+    | DesktopUpdateAction;
 
 // export type Dispatch = ReduxDispatch<Action>;
 // export type Dispatch = ThunkDispatch<AppState, any, Action>;

--- a/packages/suite/src/types/suite/index.ts
+++ b/packages/suite/src/types/suite/index.ts
@@ -11,8 +11,8 @@ import {
 import { RouterAction } from '@suite-actions/routerActions';
 import { Route } from '@suite-constants/routes';
 import { AppState } from '@suite/reducers/store';
-import { StorageActions } from '@suite-actions/storageActions';
-import { SuiteActions } from '@suite-actions/suiteActions';
+import { StorageAction } from '@suite-actions/storageActions';
+import { SuiteAction } from '@suite-actions/suiteActions';
 import { ResizeAction } from '@suite-actions/resizeActions';
 import { ModalAction } from '@suite-actions/modalActions';
 import { LogAction } from '@suite-actions/logActions';
@@ -43,8 +43,8 @@ export type Action =
     | TrezorConnectEvents
     | RouterAction
     | ResizeAction
-    | StorageActions
-    | SuiteActions
+    | StorageAction
+    | SuiteAction
     | LogAction
     | ModalAction
     | NotificationAction

--- a/packages/suite/src/types/suite/index.ts
+++ b/packages/suite/src/types/suite/index.ts
@@ -17,7 +17,7 @@ import { ResizeActions } from '@suite-actions/resizeActions';
 import { ModalActions } from '@suite-actions/modalActions';
 import { LogActions } from '@suite-actions/logActions';
 import { NotificationActions } from '@suite-actions/notificationActions';
-import { AnalyticsActions } from '@suite-actions/analyticsActions';
+import { AnalyticsAction } from '@suite-actions/analyticsActions';
 import { MetadataActions } from '@suite-actions/metadataActions';
 import { DesktopUpdateAction } from '@suite-actions/desktopUpdateActions';
 import { OnboardingAction } from '@onboarding-actions/onboardingActions';
@@ -48,7 +48,7 @@ export type Action =
     | LogActions
     | ModalActions
     | NotificationActions
-    | AnalyticsActions
+    | AnalyticsAction
     | MetadataActions
     | WalletAction
     | OnboardingAction

--- a/packages/suite/src/types/suite/index.ts
+++ b/packages/suite/src/types/suite/index.ts
@@ -18,7 +18,7 @@ import { ModalActions } from '@suite-actions/modalActions';
 import { LogAction } from '@suite-actions/logActions';
 import { NotificationActions } from '@suite-actions/notificationActions';
 import { AnalyticsAction } from '@suite-actions/analyticsActions';
-import { MetadataActions } from '@suite-actions/metadataActions';
+import { MetadataAction } from '@suite-actions/metadataActions';
 import { DesktopUpdateAction } from '@suite-actions/desktopUpdateActions';
 import { OnboardingAction } from '@onboarding-actions/onboardingActions';
 import { WalletSettingsAction } from '@settings-actions/walletSettingsActions';
@@ -49,7 +49,7 @@ export type Action =
     | ModalActions
     | NotificationActions
     | AnalyticsAction
-    | MetadataActions
+    | MetadataAction
     | WalletAction
     | OnboardingAction
     | FirmwareAction

--- a/packages/suite/src/types/suite/index.ts
+++ b/packages/suite/src/types/suite/index.ts
@@ -14,7 +14,7 @@ import { AppState } from '@suite/reducers/store';
 import { StorageActions } from '@suite-actions/storageActions';
 import { SuiteActions } from '@suite-actions/suiteActions';
 import { ResizeActions } from '@suite-actions/resizeActions';
-import { ModalActions } from '@suite-actions/modalActions';
+import { ModalAction } from '@suite-actions/modalActions';
 import { LogAction } from '@suite-actions/logActions';
 import { NotificationActions } from '@suite-actions/notificationActions';
 import { AnalyticsAction } from '@suite-actions/analyticsActions';
@@ -46,7 +46,7 @@ export type Action =
     | StorageActions
     | SuiteActions
     | LogAction
-    | ModalActions
+    | ModalAction
     | NotificationActions
     | AnalyticsAction
     | MetadataAction

--- a/packages/suite/src/types/suite/index.ts
+++ b/packages/suite/src/types/suite/index.ts
@@ -15,7 +15,7 @@ import { StorageActions } from '@suite-actions/storageActions';
 import { SuiteActions } from '@suite-actions/suiteActions';
 import { ResizeActions } from '@suite-actions/resizeActions';
 import { ModalActions } from '@suite-actions/modalActions';
-import { LogActions } from '@suite-actions/logActions';
+import { LogAction } from '@suite-actions/logActions';
 import { NotificationActions } from '@suite-actions/notificationActions';
 import { AnalyticsAction } from '@suite-actions/analyticsActions';
 import { MetadataActions } from '@suite-actions/metadataActions';
@@ -45,7 +45,7 @@ export type Action =
     | ResizeActions
     | StorageActions
     | SuiteActions
-    | LogActions
+    | LogAction
     | ModalActions
     | NotificationActions
     | AnalyticsAction

--- a/packages/suite/src/types/wallet/coinmarketBuyForm.ts
+++ b/packages/suite/src/types/wallet/coinmarketBuyForm.ts
@@ -1,7 +1,12 @@
 import { AppState } from '@suite-types';
 import { Account, Network } from '@wallet-types';
-import { BuyTradeQuoteRequest, BuyTrade } from 'invity-api';
-import { BuyInfo } from '@wallet-actions/coinmarketBuyActions';
+import {
+    BuyInfo,
+    saveQuoteRequest,
+    saveQuotes,
+    saveTrade,
+    saveCachedAccountInfo,
+} from '@wallet-actions/coinmarketBuyActions';
 import { UseFormMethods } from 'react-hook-form';
 import { TypedValidationRules } from './form';
 
@@ -41,14 +46,10 @@ export type BuyFormContextValues = Omit<UseFormMethods<FormState>, 'register'> &
     defaultCountry: defaultCountryOption;
     defaultCurrency: Option;
     buyInfo?: BuyInfo;
-    saveQuoteRequest: (request: BuyTradeQuoteRequest) => Promise<void>;
-    saveQuotes: (quotes: BuyTrade[], alternativeQuotes: BuyTrade[] | undefined) => Promise<void>;
-    saveCachedAccountInfo: (
-        symbol: Account['symbol'],
-        index: number,
-        accountType: Account['accountType'],
-    ) => Promise<void>;
-    saveTrade: (buyTrade: BuyTrade, account: Account, date: string) => Promise<void>;
+    saveQuoteRequest: typeof saveQuoteRequest;
+    saveQuotes: typeof saveQuotes;
+    saveCachedAccountInfo: typeof saveCachedAccountInfo;
+    saveTrade: typeof saveTrade;
     amountLimits?: AmountLimits;
     setAmountLimits: (limits?: AmountLimits) => void;
     accountHasCachedRequest: boolean;

--- a/packages/suite/src/types/wallet/index.ts
+++ b/packages/suite/src/types/wallet/index.ts
@@ -1,7 +1,7 @@
 import { ReceiveActions } from '@wallet-actions/receiveActions';
 import { SignVerifyActions } from '@wallet-actions/signVerifyActions';
 import { CoinmarketBuyAction } from '@wallet-actions/coinmarketBuyActions';
-import { CoinmarketExchangeActions } from '@wallet-actions/coinmarketExchangeActions';
+import { CoinmarketExchangeAction } from '@wallet-actions/coinmarketExchangeActions';
 import { DiscoveryActions } from '@wallet-actions/discoveryActions';
 import { AccountAction } from '@wallet-actions/accountActions';
 import { FiatRatesActions } from '@wallet-actions/fiatRatesActions';
@@ -49,7 +49,7 @@ export type WalletAction =
     | DiscoveryActions
     | AccountAction
     | SelectedAccountActions
-    | CoinmarketExchangeActions
+    | CoinmarketExchangeAction
     | CoinmarketBuyAction
     | SendFormActions
     | AccountSearchAction;

--- a/packages/suite/src/types/wallet/index.ts
+++ b/packages/suite/src/types/wallet/index.ts
@@ -8,7 +8,7 @@ import { FiatRatesActions } from '@wallet-actions/fiatRatesActions';
 import { GraphActions } from '@wallet-actions/graphActions';
 import { BlockchainActions } from '@wallet-actions/blockchainActions';
 import { SendFormActions } from '@wallet-actions/sendFormActions';
-import { AccountSearchActions } from '@wallet-actions/accountSearchActions';
+import { AccountSearchAction } from '@wallet-actions/accountSearchActions';
 import { TransactionAction } from '@wallet-actions/transactionActions';
 import { SelectedAccountActions } from '@wallet-actions/selectedAccountActions';
 import { NETWORKS } from '@wallet-config';
@@ -52,4 +52,4 @@ export type WalletAction =
     | CoinmarketExchangeActions
     | CoinmarketBuyActions
     | SendFormActions
-    | AccountSearchActions;
+    | AccountSearchAction;

--- a/packages/suite/src/types/wallet/index.ts
+++ b/packages/suite/src/types/wallet/index.ts
@@ -1,6 +1,6 @@
 import { ReceiveActions } from '@wallet-actions/receiveActions';
 import { SignVerifyActions } from '@wallet-actions/signVerifyActions';
-import { CoinmarketBuyActions } from '@wallet-actions/coinmarketBuyActions';
+import { CoinmarketBuyAction } from '@wallet-actions/coinmarketBuyActions';
 import { CoinmarketExchangeActions } from '@wallet-actions/coinmarketExchangeActions';
 import { DiscoveryActions } from '@wallet-actions/discoveryActions';
 import { AccountAction } from '@wallet-actions/accountActions';
@@ -50,6 +50,6 @@ export type WalletAction =
     | AccountAction
     | SelectedAccountActions
     | CoinmarketExchangeActions
-    | CoinmarketBuyActions
+    | CoinmarketBuyAction
     | SendFormActions
     | AccountSearchAction;

--- a/packages/suite/src/types/wallet/index.ts
+++ b/packages/suite/src/types/wallet/index.ts
@@ -6,7 +6,7 @@ import { DiscoveryActions } from '@wallet-actions/discoveryActions';
 import { AccountAction } from '@wallet-actions/accountActions';
 import { FiatRatesActions } from '@wallet-actions/fiatRatesActions';
 import { GraphActions } from '@wallet-actions/graphActions';
-import { BlockchainActions } from '@wallet-actions/blockchainActions';
+import { BlockchainAction } from '@wallet-actions/blockchainActions';
 import { SendFormActions } from '@wallet-actions/sendFormActions';
 import { AccountSearchAction } from '@wallet-actions/accountSearchActions';
 import { TransactionAction } from '@wallet-actions/transactionActions';
@@ -40,7 +40,7 @@ export type { WalletAccountTransaction } from '@wallet-reducers/transactionReduc
 export type { ReceiveInfo } from '@wallet-reducers/receiveReducer';
 
 export type WalletAction =
-    | BlockchainActions
+    | BlockchainAction
     | ReceiveActions
     | SignVerifyActions
     | TransactionAction

--- a/packages/suite/src/types/wallet/index.ts
+++ b/packages/suite/src/types/wallet/index.ts
@@ -4,7 +4,7 @@ import { CoinmarketBuyAction } from '@wallet-actions/coinmarketBuyActions';
 import { CoinmarketExchangeAction } from '@wallet-actions/coinmarketExchangeActions';
 import { DiscoveryAction } from '@wallet-actions/discoveryActions';
 import { AccountAction } from '@wallet-actions/accountActions';
-import { FiatRatesActions } from '@wallet-actions/fiatRatesActions';
+import { FiatRatesAction } from '@wallet-actions/fiatRatesActions';
 import { GraphActions } from '@wallet-actions/graphActions';
 import { BlockchainAction } from '@wallet-actions/blockchainActions';
 import { SendFormActions } from '@wallet-actions/sendFormActions';
@@ -44,7 +44,7 @@ export type WalletAction =
     | ReceiveActions
     | SignVerifyActions
     | TransactionAction
-    | FiatRatesActions
+    | FiatRatesAction
     | GraphActions
     | DiscoveryAction
     | AccountAction

--- a/packages/suite/src/types/wallet/index.ts
+++ b/packages/suite/src/types/wallet/index.ts
@@ -3,7 +3,7 @@ import { SignVerifyActions } from '@wallet-actions/signVerifyActions';
 import { CoinmarketBuyActions } from '@wallet-actions/coinmarketBuyActions';
 import { CoinmarketExchangeActions } from '@wallet-actions/coinmarketExchangeActions';
 import { DiscoveryActions } from '@wallet-actions/discoveryActions';
-import { AccountActions } from '@wallet-actions/accountActions';
+import { AccountAction } from '@wallet-actions/accountActions';
 import { FiatRatesActions } from '@wallet-actions/fiatRatesActions';
 import { GraphActions } from '@wallet-actions/graphActions';
 import { BlockchainActions } from '@wallet-actions/blockchainActions';
@@ -47,7 +47,7 @@ export type WalletAction =
     | FiatRatesActions
     | GraphActions
     | DiscoveryActions
-    | AccountActions
+    | AccountAction
     | SelectedAccountActions
     | CoinmarketExchangeActions
     | CoinmarketBuyActions

--- a/packages/suite/src/types/wallet/index.ts
+++ b/packages/suite/src/types/wallet/index.ts
@@ -7,7 +7,7 @@ import { AccountAction } from '@wallet-actions/accountActions';
 import { FiatRatesAction } from '@wallet-actions/fiatRatesActions';
 import { GraphAction } from '@wallet-actions/graphActions';
 import { BlockchainAction } from '@wallet-actions/blockchainActions';
-import { SendFormActions } from '@wallet-actions/sendFormActions';
+import { SendFormAction } from '@wallet-actions/sendFormActions';
 import { AccountSearchAction } from '@wallet-actions/accountSearchActions';
 import { TransactionAction } from '@wallet-actions/transactionActions';
 import { SelectedAccountAction } from '@wallet-actions/selectedAccountActions';
@@ -51,5 +51,5 @@ export type WalletAction =
     | SelectedAccountAction
     | CoinmarketExchangeAction
     | CoinmarketBuyAction
-    | SendFormActions
+    | SendFormAction
     | AccountSearchAction;

--- a/packages/suite/src/types/wallet/index.ts
+++ b/packages/suite/src/types/wallet/index.ts
@@ -1,5 +1,5 @@
 import { ReceiveAction } from '@wallet-actions/receiveActions';
-import { SignVerifyActions } from '@wallet-actions/signVerifyActions';
+import { SignVerifyAction } from '@wallet-actions/signVerifyActions';
 import { CoinmarketBuyAction } from '@wallet-actions/coinmarketBuyActions';
 import { CoinmarketExchangeAction } from '@wallet-actions/coinmarketExchangeActions';
 import { DiscoveryAction } from '@wallet-actions/discoveryActions';
@@ -42,7 +42,7 @@ export type { ReceiveInfo } from '@wallet-reducers/receiveReducer';
 export type WalletAction =
     | BlockchainAction
     | ReceiveAction
-    | SignVerifyActions
+    | SignVerifyAction
     | TransactionAction
     | FiatRatesAction
     | GraphAction

--- a/packages/suite/src/types/wallet/index.ts
+++ b/packages/suite/src/types/wallet/index.ts
@@ -10,7 +10,7 @@ import { BlockchainAction } from '@wallet-actions/blockchainActions';
 import { SendFormActions } from '@wallet-actions/sendFormActions';
 import { AccountSearchAction } from '@wallet-actions/accountSearchActions';
 import { TransactionAction } from '@wallet-actions/transactionActions';
-import { SelectedAccountActions } from '@wallet-actions/selectedAccountActions';
+import { SelectedAccountAction } from '@wallet-actions/selectedAccountActions';
 import { NETWORKS } from '@wallet-config';
 import { ArrayElement } from '../utils';
 
@@ -48,7 +48,7 @@ export type WalletAction =
     | GraphAction
     | DiscoveryAction
     | AccountAction
-    | SelectedAccountActions
+    | SelectedAccountAction
     | CoinmarketExchangeAction
     | CoinmarketBuyAction
     | SendFormActions

--- a/packages/suite/src/types/wallet/index.ts
+++ b/packages/suite/src/types/wallet/index.ts
@@ -2,7 +2,7 @@ import { ReceiveActions } from '@wallet-actions/receiveActions';
 import { SignVerifyActions } from '@wallet-actions/signVerifyActions';
 import { CoinmarketBuyAction } from '@wallet-actions/coinmarketBuyActions';
 import { CoinmarketExchangeAction } from '@wallet-actions/coinmarketExchangeActions';
-import { DiscoveryActions } from '@wallet-actions/discoveryActions';
+import { DiscoveryAction } from '@wallet-actions/discoveryActions';
 import { AccountAction } from '@wallet-actions/accountActions';
 import { FiatRatesActions } from '@wallet-actions/fiatRatesActions';
 import { GraphActions } from '@wallet-actions/graphActions';
@@ -46,7 +46,7 @@ export type WalletAction =
     | TransactionAction
     | FiatRatesActions
     | GraphActions
-    | DiscoveryActions
+    | DiscoveryAction
     | AccountAction
     | SelectedAccountActions
     | CoinmarketExchangeAction

--- a/packages/suite/src/types/wallet/index.ts
+++ b/packages/suite/src/types/wallet/index.ts
@@ -5,7 +5,7 @@ import { CoinmarketExchangeAction } from '@wallet-actions/coinmarketExchangeActi
 import { DiscoveryAction } from '@wallet-actions/discoveryActions';
 import { AccountAction } from '@wallet-actions/accountActions';
 import { FiatRatesAction } from '@wallet-actions/fiatRatesActions';
-import { GraphActions } from '@wallet-actions/graphActions';
+import { GraphAction } from '@wallet-actions/graphActions';
 import { BlockchainAction } from '@wallet-actions/blockchainActions';
 import { SendFormActions } from '@wallet-actions/sendFormActions';
 import { AccountSearchAction } from '@wallet-actions/accountSearchActions';
@@ -45,7 +45,7 @@ export type WalletAction =
     | SignVerifyActions
     | TransactionAction
     | FiatRatesAction
-    | GraphActions
+    | GraphAction
     | DiscoveryAction
     | AccountAction
     | SelectedAccountActions

--- a/packages/suite/src/types/wallet/index.ts
+++ b/packages/suite/src/types/wallet/index.ts
@@ -1,4 +1,4 @@
-import { ReceiveActions } from '@wallet-actions/receiveActions';
+import { ReceiveAction } from '@wallet-actions/receiveActions';
 import { SignVerifyActions } from '@wallet-actions/signVerifyActions';
 import { CoinmarketBuyAction } from '@wallet-actions/coinmarketBuyActions';
 import { CoinmarketExchangeAction } from '@wallet-actions/coinmarketExchangeActions';
@@ -41,7 +41,7 @@ export type { ReceiveInfo } from '@wallet-reducers/receiveReducer';
 
 export type WalletAction =
     | BlockchainAction
-    | ReceiveActions
+    | ReceiveAction
     | SignVerifyActions
     | TransactionAction
     | FiatRatesAction


### PR DESCRIPTION
## This PR should be squashed
I did multiple commits to be easy to read, but they should be squashed into one during merge

- unified action names (ScopeAction instead of ScopeActions)
- removed unnecessary redux-thunk or async actions (replaced by regular redux action)
- removed unnecessary types/index files (walletSettings/firmware/onboarding)
