### PR TITLE
design: Unify heading and description styles in Onboarding

### DIFF
--- a/packages/suite/src/views/onboarding/steps/ResetDevice/index.tsx
+++ b/packages/suite/src/views/onboarding/steps/ResetDevice/index.tsx
@@ -1,9 +1,9 @@
 import React from 'react';
-import { Link, P, H2 } from '@trezor/components';
+import { Link } from '@trezor/components';
 import * as STEP from '@onboarding-constants/steps';
 import { Wrapper, Text, Option, OnboardingButton } from '@onboarding-components';
 import { Translation } from '@suite-components';
-import { SuccessImg } from '@firmware-components';
+import { SuccessImg, H2, P } from '@firmware-components';
 import { TOS_URL } from '@suite-constants/urls';
 import { Props } from './Container';
 
@@ -40,7 +40,7 @@ const ResetDeviceStep = (props: Props) => {
                     </Text>
                 )}
 
-                <P size="tiny">
+                <P>
                     <Translation
                         id="TR_BY_CREATING_WALLET"
                         values={{


### PR DESCRIPTION
fix https://github.com/trezor/trezor-suite/issues/2599

The previous design used components from two different folders. 
I used` <P> ` and `<H2>` components from _@firmware-components_ in both steps. The new design looks like follows:

![ezgif com-gif-maker](https://user-images.githubusercontent.com/44506010/96572463-25667780-12cd-11eb-9b0c-73ca50d9d835.gif)
