### PR TITLE
chore: bump version for November release

### DIFF
--- a/docs/misc/versioning.md
+++ b/docs/misc/versioning.md
@@ -28,3 +28,9 @@ Beta also has +1 `MM` version when compared to stable indicating this is upcomin
 - `20.11.0` release on Oct 29th 2020 to beta
 - `20.11.0` another release on Nov 5th to beta
 - `20.11.1` public release on Nov 14th to stable
+
+## Develop versioning
+
+We use the same scheme as beta. That is, `develop` branch has always `YY.MM.0` version where `MM` is the upcoming month's release.
+When we fork `develop` to `release/20YY-MM` branch, we bump the release branch version to `YY.MM.1` and
+increase the `develop` version to `YY.(MM+1).0` indicating we are already brewing next release in the `develop`.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "trezor-suite",
-    "version": "20.10.1",
+    "version": "20.11.0",
     "private": true,
     "repository": "https://github.com/trezor/trezor-suite.git",
     "license": "SEE LICENSE IN LICENSE.md",

--- a/packages/landing-page/package.json
+++ b/packages/landing-page/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@trezor/landing-page",
-    "version": "20.10.1",
+    "version": "20.11.0",
     "private": true,
     "scripts": {
         "type-check": "tsc --project tsconfig.json",

--- a/packages/suite-data/package.json
+++ b/packages/suite-data/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@trezor/suite-data",
-    "version": "20.10.1",
+    "version": "20.11.0",
     "author": "Trezor <info@trezor.io>",
     "keywords": [
         "Trezor",

--- a/packages/suite-desktop/package.json
+++ b/packages/suite-desktop/package.json
@@ -1,7 +1,7 @@
 {
     "name": "@trezor/suite-desktop",
     "description": "Trezor Suite desktop application",
-    "version": "20.10.1",
+    "version": "20.11.0",
     "private": true,
     "author": "SatoshiLabs <info@satoshilabs.com>",
     "homepage": "https://trezor.io/",

--- a/packages/suite-native/package.json
+++ b/packages/suite-native/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@trezor/suite-native",
-    "version": "20.10.1",
+    "version": "20.11.0",
     "private": true,
     "scripts": {
         "dev:ios": "run-p start run-ios",
@@ -19,7 +19,7 @@
     },
     "dependencies": {
         "@trezor/components": "^1.0.0",
-        "@trezor/suite-storage": "20.10.1",
+        "@trezor/suite-storage": "20.11.0",
         "react": "16.13.1",
         "react-native": "0.63.2",
         "react-native-gesture-handler": "^1.5.2",

--- a/packages/suite-storage/package.json
+++ b/packages/suite-storage/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@trezor/suite-storage",
-    "version": "20.10.1",
+    "version": "20.11.0",
     "author": "Trezor <info@trezor.io>",
     "private": true,
     "keywords": [

--- a/packages/suite-web-landing/package.json
+++ b/packages/suite-web-landing/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@trezor/suite-web-landing",
-    "version": "20.10.1",
+    "version": "20.11.0",
     "private": true,
     "scripts": {
         "type-check": "tsc --project tsconfig.json",

--- a/packages/suite-web/package.json
+++ b/packages/suite-web/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@trezor/suite-web",
-    "version": "20.10.1",
+    "version": "20.11.0",
     "private": true,
     "scripts": {
         "type-check": "tsc --project tsconfig.json",
@@ -16,7 +16,7 @@
     "dependencies": {
         "@sentry/browser": "^5.16.0",
         "@sentry/integrations": "^5.16.0",
-        "@trezor/suite": "20.10.1",
+        "@trezor/suite": "20.11.0",
         "@zeit/next-workers": "^1.0.0",
         "next": "^9.5.3",
         "next-redux-wrapper": "^5.0.0",

--- a/packages/suite/package.json
+++ b/packages/suite/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@trezor/suite",
-    "version": "20.10.1",
+    "version": "20.11.0",
     "private": true,
     "scripts": {
         "lint": "yarn lint:styles && yarn lint:js",
@@ -18,8 +18,8 @@
     },
     "dependencies": {
         "@trezor/components": "^1.0.0",
-        "@trezor/suite-data": "20.10.1",
-        "@trezor/suite-storage": "20.10.1",
+        "@trezor/suite-data": "20.11.0",
+        "@trezor/suite-storage": "20.11.0",
         "bignumber.js": "^9.0.0",
         "date-fns": "^2.15.0",
         "date-fns-tz": "^1.0.10",


### PR DESCRIPTION
This is something we forgot to do after forking the `release/2020-10` branch from the develop.

We'll always keep the version `YY.MM.0` in develop where `MM` is the upcoming month. More info in the updated `docs/misc/versioning.md` file