### PR TITLE
Feat/import tx

### DIFF
--- a/packages/suite/src/actions/suite/modalActions.ts
+++ b/packages/suite/src/actions/suite/modalActions.ts
@@ -2,7 +2,6 @@ import TrezorConnect, { UI } from 'trezor-connect';
 import { MODAL, SUITE } from '@suite-actions/constants';
 import { Action, Dispatch, GetState, TrezorDevice } from '@suite-types';
 import { Account, WalletAccountTransaction } from '@wallet-types';
-import { PartialFormState } from '@wallet-types/sendForm';
 import { createDeferred, Deferred, DeferredResponse } from '@suite-utils/deferred';
 
 export type UserContextPayload =
@@ -62,7 +61,7 @@ export type UserContextPayload =
       }
     | {
           type: 'import-transaction';
-          decision: Deferred<PartialFormState>;
+          decision: Deferred<{ [key: string]: string }[]>;
       }
     | {
           type: 'coinmarket-buy-terms';

--- a/packages/suite/src/components/suite/DropZone/index.tsx
+++ b/packages/suite/src/components/suite/DropZone/index.tsx
@@ -1,0 +1,163 @@
+import React, { useRef, useCallback, useMemo, useState } from 'react';
+import styled from 'styled-components';
+import { P, Icon, colors } from '@trezor/components';
+import { Translation } from '@suite-components';
+
+interface Props {
+    accept: 'text/csv' | 'image/*';
+    onSuccess: (data: string) => void;
+}
+
+export const useDropZone = ({ accept, onSuccess }: Props) => {
+    const available = useRef(window.File && window.FileReader && window.FileList && window.Blob);
+    const wrapperRef = useRef<HTMLDivElement | null>(null);
+    const inputRef = useRef<HTMLInputElement | null>(null);
+    const [error, setError] = useState<string | undefined>(undefined);
+
+    const readFileContent = useCallback(
+        (file: File) => {
+            if (!file || file.type !== accept) {
+                setError('file-type');
+                return;
+            }
+            const reader = new FileReader();
+            reader.onload = () => {
+                if (typeof reader.result !== 'string') {
+                    setError('empty');
+                    return;
+                }
+                onSuccess(reader.result);
+            };
+            reader.onerror = () => {
+                setError(reader.error!.message);
+                reader.abort();
+            };
+            if (accept === 'text/csv') {
+                reader.readAsText(file);
+            } else {
+                reader.readAsDataURL(file);
+            }
+        },
+        [accept, onSuccess],
+    );
+
+    const onClick = useCallback(() => {
+        if (inputRef.current) {
+            inputRef.current.value = '';
+            inputRef.current.click();
+        }
+    }, [inputRef]);
+
+    const prevent = useCallback(event => {
+        event.preventDefault();
+    }, []);
+
+    const onDrop = useCallback(
+        async (event: React.DragEvent) => {
+            event.preventDefault();
+            if (event.dataTransfer) {
+                readFileContent(event.dataTransfer.files[0]);
+            } else {
+                setError('empty');
+            }
+        },
+        [readFileContent],
+    );
+
+    const onInputChange = useCallback(
+        (event: React.ChangeEvent<HTMLInputElement>) => {
+            event.stopPropagation();
+            if (event.target?.value && event.target.files) {
+                readFileContent(event.target.files[0]);
+            } else {
+                setError('empty');
+            }
+        },
+        [readFileContent],
+    );
+
+    const onInputClick = useCallback(event => {
+        event.stopPropagation();
+    }, []);
+
+    const getWrapperProps = useMemo(
+        () => () => ({
+            onClick,
+            onDragEnter: prevent,
+            onDragOver: prevent,
+            onDragLeave: prevent,
+            onDrop,
+            ref: wrapperRef,
+        }),
+        [onClick, prevent, onDrop],
+    );
+
+    const getInputProps = useMemo(
+        () => () => ({
+            type: 'file',
+            multiple: false,
+            accept,
+            autoComplete: 'off',
+            tabIndex: -1,
+            onChange: onInputChange,
+            onClick: onInputClick,
+            ref: inputRef,
+        }),
+        [accept, onInputChange, onInputClick],
+    );
+
+    return {
+        available: available.current,
+        error,
+        getWrapperProps,
+        getInputProps,
+    };
+};
+
+const Wrapper = styled.div`
+    padding: 16px;
+    display: flex;
+    flex-direction: column;
+    justify-content: center;
+    align-items: center;
+    border: 2px dashed ${colors.NEUE_STROKE_GREY};
+    border-radius: 6px;
+    cursor: pointer;
+    min-height: 300px;
+    transition: background-color 0.3s;
+    &:hover {
+        background: ${colors.NEUE_BG_GRAY};
+    }
+`;
+
+const StyledInput = styled.input`
+    display: none;
+`;
+
+const StyledIcon = styled(Icon)`
+    margin-right: 8px;
+`;
+
+const Label = styled.div`
+    display: flex;
+    align-items: center;
+`;
+
+export const DropZone = (props: Props) => {
+    const { getWrapperProps, getInputProps, error } = useDropZone(props);
+
+    return (
+        <Wrapper {...getWrapperProps()}>
+            <StyledInput {...getInputProps()} />
+            <Label>
+                <StyledIcon icon="CSV" />
+                <Translation id="TR_DROPZONE" />
+            </Label>
+            {error && (
+                <P>
+                    <Translation id="TR_DROPZONE_ERROR" values={{ error }} />
+                </P>
+            )}
+        </Wrapper>
+    );
+};

--- a/packages/suite/src/components/suite/modals/ImportTransaction/components/DelimiterForm.tsx
+++ b/packages/suite/src/components/suite/modals/ImportTransaction/components/DelimiterForm.tsx
@@ -1,0 +1,69 @@
+import React, { useState, useRef, useEffect } from 'react';
+import styled from 'styled-components';
+import { Switch, Input, P } from '@trezor/components';
+import { Translation } from '@suite-components';
+
+const Wrapper = styled.div`
+    display: flex;
+    align-items: center;
+    min-height: 32px; /* Input height */
+    margin-top: 16px;
+`;
+
+const Label = styled(P)`
+    padding: 0px 8px;
+`;
+
+interface Props {
+    value?: string;
+    onChange: (value?: string) => void;
+}
+
+export const DelimiterForm = ({ value, onChange }: Props) => {
+    const [custom, setCustom] = useState(false);
+    const inputRef = useRef<HTMLInputElement | null>(null);
+
+    // handle `custom` change and focus the input
+    useEffect(() => {
+        if (inputRef.current) {
+            inputRef.current.focus();
+        }
+    }, [custom]);
+
+    return (
+        <Wrapper>
+            <Switch
+                onChange={() => {
+                    if (custom) {
+                        // reset delimiter value in parent component
+                        onChange(undefined);
+                    }
+                    setCustom(!custom);
+                }}
+                checked={!custom}
+            />
+            <Label>
+                <Translation
+                    id={
+                        custom
+                            ? 'TR_IMPORT_CSV_MODAL_DELIMITER_CUSTOM'
+                            : 'TR_IMPORT_CSV_MODAL_DELIMITER_DEFAULT'
+                    }
+                />
+            </Label>
+            {custom && (
+                <Input
+                    noTopLabel
+                    noError
+                    variant="small"
+                    monospace
+                    width={120}
+                    wrapperProps={{ width: 120 }}
+                    onChange={({ target }) => onChange(target.value)}
+                    defaultValue={value}
+                    innerRef={inputRef}
+                />
+            )}
+        </Wrapper>
+    );
+};

--- a/packages/suite/src/components/suite/modals/ImportTransaction/components/ExampleCSV.tsx
+++ b/packages/suite/src/components/suite/modals/ImportTransaction/components/ExampleCSV.tsx
@@ -1,0 +1,77 @@
+import React, { useState } from 'react';
+import styled from 'styled-components';
+import { motion, AnimatePresence } from 'framer-motion';
+import { P, Icon, colors, variables } from '@trezor/components';
+import { Translation } from '@suite-components';
+import { useSelector } from '@suite-hooks';
+import { ANIMATION } from '@suite-config';
+
+const Wrapper = styled.div`
+    display: flex;
+    flex-direction: column;
+    align-items: start;
+    padding-bottom: 16px;
+`;
+
+const ExpandWrapper = styled(motion.div)`
+    width: 100%;
+    background: #f4f4f4;
+    border-radius: 6px;
+    overflow: hidden;
+    padding: 12px;
+    text-align: left;
+`;
+
+const ExpandButton = styled.div`
+    display: flex;
+    cursor: pointer;
+    color: ${colors.NEUE_TYPE_LIGHT_GREY};
+    font-size: ${variables.FONT_SIZE.SMALL};
+    font-weight: 500;
+    justify-content: space-between;
+`;
+
+export const ExampleCSV = () => {
+    const [isExpanded, setExpanded] = useState(false);
+    const { account } = useSelector(state => state.wallet.selectedAccount);
+    if (!account) return null;
+
+    // for BTC get first two unused addresses
+    // for ETH and XRP descriptor get twice (used in two examples)
+    const addresses = account.addresses?.unused.slice(0, 2).map(a => a.address) || [
+        account.descriptor,
+        account.descriptor,
+    ];
+    return (
+        <Wrapper>
+            <ExpandButton
+                onClick={e => {
+                    e.preventDefault();
+                    e.stopPropagation();
+                    setExpanded(!isExpanded);
+                }}
+            >
+                <Translation
+                    id={
+                        isExpanded
+                            ? 'TR_IMPORT_CSV_MODAL_HIDE_EXAMPLE'
+                            : 'TR_IMPORT_CSV_MODAL_SHOW_EXAMPLE'
+                    }
+                />
+                <Icon size={16} icon={!isExpanded ? 'ARROW_DOWN' : 'ARROW_UP'} />
+            </ExpandButton>
+            <AnimatePresence initial={false}>
+                {isExpanded && (
+                    <ExpandWrapper {...ANIMATION.EXPAND}>
+                        {/* CSV keys shouldn't be translated */}
+                        <P size="small">address,amount,currency</P>
+                        <P size="small">
+                            {addresses[0]},0.31337,{account.symbol.toUpperCase()}
+                        </P>
+                        <P size="small">{addresses[1]},0.1,USD</P>
+                    </ExpandWrapper>
+                )}
+            </AnimatePresence>
+        </Wrapper>
+    );
+};

--- a/packages/suite/src/components/suite/modals/ImportTransaction/index.tsx
+++ b/packages/suite/src/components/suite/modals/ImportTransaction/index.tsx
@@ -1,20 +1,11 @@
-import React from 'react';
-import styled from 'styled-components';
-import { Modal, Button } from '@trezor/components';
-// import { Translation } from '@suite-components';
+import React, { useState } from 'react';
+import { Modal } from '@trezor/components';
+import { Translation } from '@suite-components';
+import { DropZone } from '@suite-components/DropZone';
 import { UserContextPayload } from '@suite-actions/modalActions';
-// import { DEFAULT_PAYMENT, DEFAULT_OPRETURN } from '@wallet-constants/sendForm';
-
-const Description = styled.div`
-    display: flex;
-    flex-direction: column;
-    align-items: center;
-`;
-
-const Actions = styled.div`
-    display: flex;
-    justify-content: center;
-`;
+import { DelimiterForm } from './components/DelimiterForm';
+import { ExampleCSV } from './components/ExampleCSV';
+import { parseCSV } from '@wallet-utils/csvParser';
 
 type Props = {
     onCancel: () => any;
@@ -22,65 +13,24 @@ type Props = {
 };
 
 const ImportTransaction = ({ onCancel, decision }: Props) => {
-    // TODO:
-    // - views and Translations
-    // - delimiter (default ,)
-    // - upload button
-    // - upload drag&drop area
-    // - parse uploaded file with error handler, similar to QRCode reader
+    // const [mode, setMode] = useState<'upload' | 'form'>('upload'); // TODO: upload or textarea form? (fallback for upload)
+    const [delimiter, setDelimiter] = useState<string | undefined>(undefined);
 
-    // result from uploaded file
-    const validData = {
-        outputs: [
-            {
-                type: 'payment',
-                address: '0x7de62F23453E9230cC038390901A9A0130105A3c',
-                amount: '0.1',
-            } as const,
-            // { ...DEFAULT_PAYMENT, address: 'address' },
-            // { ...DEFAULT_PAYMENT, amount: '1' },
-            // // { label: 'label' },
-            // // { fiat: '1' },
-            // { ...DEFAULT_OPRETURN },
-        ],
-    };
-    const invalidData = {
-        outputs: [
-            {
-                type: 'payment',
-                address: '0x7de62F23453E9230cC038390901A9A0130105A3c',
-                amount: '',
-            } as const,
-        ],
+    const onUploadSuccess = (data: string) => {
+        const parsed = parseCSV(data, ['address', 'amount', 'currency', 'label'], delimiter);
+        decision.resolve(parsed);
+        onCancel();
     };
 
     return (
         <Modal
             cancelable
             onCancel={onCancel}
-            heading="upload file"
-            description={<Description>File format description</Description>}
+            heading={<Translation id="TR_IMPORT_CSV_MODAL_TITLE" />}
         >
-            <Actions>
-                <Button
-                    variant="secondary"
-                    onClick={() => {
-                        decision.resolve(validData);
-                        onCancel();
-                    }}
-                >
-                    UPLOAD VALID
-                </Button>
-                <Button
-                    variant="secondary"
-                    onClick={() => {
-                        decision.resolve(invalidData);
-                        onCancel();
-                    }}
-                >
-                    UPLOAD INVALID
-                </Button>
-            </Actions>
+            <ExampleCSV />
+            <DropZone accept="text/csv" onSuccess={onUploadSuccess} />
+            <DelimiterForm value={delimiter} onChange={setDelimiter} />
         </Modal>
     );
 };

--- a/packages/suite/src/hooks/wallet/useSendFormImport.ts
+++ b/packages/suite/src/hooks/wallet/useSendFormImport.ts
@@ -1,37 +1,92 @@
-import { FormState, PartialFormState, UseSendFormState } from '@wallet-types/sendForm';
+import * as sendFormActions from '@wallet-actions/sendFormActions';
+import { useActions } from '@suite-hooks';
+import { DEFAULT_PAYMENT } from '@wallet-constants/sendForm';
+import { FIAT } from '@suite-config';
+import { fromFiatCurrency, toFiatCurrency } from '@wallet-utils/fiatConverterUtils';
+import { UseSendFormState, Output } from '@wallet-types/sendForm';
 
 type Props = {
+    network: UseSendFormState['network'];
+    tokens: UseSendFormState['account']['tokens'];
     fiatRates: UseSendFormState['fiatRates'];
-    getLoadedValues: (loadedState?: Partial<FormState>) => FormState;
+    localCurrencyOption: UseSendFormState['localCurrencyOption'];
 };
 
 // This hook should be used only as a sub-hook of `useSendForm`
 
-export const useSendFormImport = ({ getLoadedValues, fiatRates }: Props) => {
-    // state loaded from ImportTransaction modal
-    const importTransaction = (loadedState: PartialFormState) => {
-        const defaultState = getLoadedValues();
+export const useSendFormImport = ({ network, tokens, localCurrencyOption, fiatRates }: Props) => {
+    const { importRequest } = useActions({
+        importRequest: sendFormActions.importRequest,
+    });
 
-        console.warn('loadedState', loadedState, defaultState, fiatRates);
+    const importTransaction = async () => {
+        // open ImportTransaction modal and get parsed csv
+        const result = await importRequest();
+        if (!result) return; // cancelled
 
-        if (loadedState.outputs) {
-            loadedState.outputs = loadedState.outputs.map(output => {
-                if (output.type === 'opreturn') {
-                    return output;
+        const outputs = result.map(item => {
+            // create default Output with address from csv
+            const output: Output = {
+                ...DEFAULT_PAYMENT,
+                currency: localCurrencyOption,
+                address: item.address || '',
+            };
+
+            // currency is specified in csv
+            if (item.currency) {
+                // sanitize csv data
+                const currency = item.currency.toLowerCase();
+
+                if (currency === network.symbol) {
+                    // csv amount in crypto currency
+                    output.amount = item.amount || '';
+                    // calculate Fiat from Amount
+                    if (fiatRates && fiatRates.current) {
+                        output.fiat =
+                            toFiatCurrency(
+                                output.amount,
+                                output.currency.value,
+                                fiatRates.current.rates,
+                            ) || '';
+                    }
+                } else if (
+                    FIAT.currencies.find(c => c === currency) &&
+                    fiatRates &&
+                    fiatRates.current &&
+                    Object.keys(fiatRates.current.rates).includes(currency)
+                ) {
+                    // csv amount in fiat currency
+                    output.currency = { value: currency, label: currency.toUpperCase() };
+                    output.fiat = item.amount || '';
+                    // calculate Amount from Fiat
+                    output.amount =
+                        fromFiatCurrency(
+                            output.fiat,
+                            currency,
+                            fiatRates.current.rates,
+                            network.decimals,
+                        ) || '';
+                } else if (tokens) {
+                    // csv amount in ERC20 currency
+                    const token = tokens.find(t => t.symbol === currency);
+                    if (token) {
+                        output.token = token.address;
+                        output.amount = item.amount || '';
+                    }
                 }
-                if (output.amount) {
-                    // TODO: calculateFiat
-                } else if (output.fiat) {
-                    // TODO: calculate amount
-                }
-                return { ...defaultState.outputs[0], ...output };
-            });
-        }
 
-        return {
-            ...defaultState,
-            ...loadedState,
-        };
+                if (!output.amount || !output.fiat) {
+                    // TODO: display Toast notification with invalid currency error?
+                    // what if there will be multiple errors? Toast spamming...
+                    console.warn('import error', currency, output);
+                }
+            }
+            return output;
+        });
+
+        // only one output allowed for ETH and XRP
+        // TODO: create queue of transactions to sign to allow multiple outputs for ETH/XRP (overkill?)
+        return network.networkType === 'bitcoin' ? outputs : [outputs[0]];
     };
 
     return {

--- a/packages/suite/src/support/messages.ts
+++ b/packages/suite/src/support/messages.ts
@@ -3885,7 +3885,8 @@ const definedMessages = defineMessages({
     },
     OP_RETURN_ADD: {
         id: 'OP_RETURN_ADD',
-        defaultMessage: 'ADD OP RETURN',
+        description: 'item in dropdown menu',
+        defaultMessage: 'Add OP Return',
     },
     RBF: {
         id: 'RBF',
@@ -4033,6 +4034,11 @@ const definedMessages = defineMessages({
         description: 'Sign and send button used in send form',
         defaultMessage: 'Review & Send',
     },
+    SEND_RAW: {
+        id: 'SEND_RAW',
+        description: 'item in dropdown menu',
+        defaultMessage: 'Send RAW',
+    },
     SEND_RAW_TRANSACTION: {
         id: 'SEND_RAW_TRANSACTION',
         description: 'Send raw form header',
@@ -4086,6 +4092,11 @@ const definedMessages = defineMessages({
     BROADCAST: {
         id: 'BROADCAST',
         defaultMessage: 'Broadcast',
+    },
+    IMPORT_CSV: {
+        id: 'IMPORT_CSV',
+        description: 'item in dropdown menu',
+        defaultMessage: 'Import',
     },
     // Send form end
 

--- a/packages/suite/src/support/messages.ts
+++ b/packages/suite/src/support/messages.ts
@@ -515,6 +515,34 @@ const definedMessages = defineMessages({
         id: 'TR_XPUB_MODAL_TITLE_METADATA',
         description: 'accountLabel is user defined name of account, might be pretty much anything.',
     },
+    TR_IMPORT_CSV_MODAL_TITLE: {
+        defaultMessage: 'Import addresses from CSV',
+        id: 'TR_IMPORT_CSV_MODAL_TITLE',
+    },
+    TR_IMPORT_CSV_MODAL_SHOW_EXAMPLE: {
+        defaultMessage: 'Show CSV example',
+        id: 'TR_IMPORT_CSV_MODAL_SHOW_EXAMPLE',
+    },
+    TR_IMPORT_CSV_MODAL_HIDE_EXAMPLE: {
+        defaultMessage: 'Hide example',
+        id: 'TR_IMPORT_CSV_MODAL_HIDE_EXAMPLE',
+    },
+    TR_IMPORT_CSV_MODAL_DELIMITER_DEFAULT: {
+        defaultMessage: 'Auto detect delimiter',
+        id: 'TR_IMPORT_CSV_MODAL_DELIMITER_DEFAULT',
+    },
+    TR_IMPORT_CSV_MODAL_DELIMITER_CUSTOM: {
+        defaultMessage: 'Custom delimiter',
+        id: 'TR_IMPORT_CSV_MODAL_DELIMITER_CUSTOM',
+    },
+    TR_DROPZONE: {
+        defaultMessage: 'Drag and drop file here or click to select from files',
+        id: 'TR_DROPZONE',
+    },
+    TR_DROPZONE_ERROR: {
+        defaultMessage: 'Import failed {error}',
+        id: 'TR_DROPZONE_ERROR',
+    },
     TR_ADVANCED_RECOVERY: {
         defaultMessage: 'advanced recovery',
         description: 'Enter words via obfuscated pin matrix, recovery takes about 5 minutes.',

--- a/packages/suite/src/types/wallet/sendForm.ts
+++ b/packages/suite/src/types/wallet/sendForm.ts
@@ -1,4 +1,4 @@
-import { UseFormMethods, FieldError, DeepPartial } from 'react-hook-form';
+import { UseFormMethods, FieldError } from 'react-hook-form';
 import { Account, Network, CoinFiatRates } from '@wallet-types';
 import {
     FeeLevel,
@@ -48,8 +48,6 @@ export type FormState = {
     ethereumDataHex?: string;
     rippleDestinationTag?: string;
 };
-
-export type PartialFormState = DeepPartial<FormState>;
 
 export interface FeeInfo {
     blockHeight: number; // when fee info was updated; 0 = never

--- a/packages/suite/src/utils/wallet/__tests__/csvParser.test.ts
+++ b/packages/suite/src/utils/wallet/__tests__/csvParser.test.ts
@@ -1,0 +1,59 @@
+import { parseCSV } from '../csvParser';
+
+const FIXTURES = [
+    {
+        description: 'csv without header',
+        csv: `bcAddRe5,0.2,usd\r"bcAddRe5",0.1,"CZK"`,
+        columns: ['address', 'amount', 'currency'],
+        result: [
+            { address: 'bcAddRe5', amount: '0.2', currency: 'usd' },
+            { address: 'bcAddRe5', amount: '0.1', currency: 'CZK' },
+        ],
+    },
+    {
+        description: 'csv with header and empty lines',
+        csv: `address,amount,currency\n\n\r\nbcAddRe5,0.2,usd\r"bcAddRe5",0.1,"CZK"`,
+        columns: ['address', 'amount', 'currency'],
+        result: [
+            { address: 'bcAddRe5', amount: '0.2', currency: 'usd' },
+            { address: 'bcAddRe5', amount: '0.1', currency: 'CZK' },
+        ],
+    },
+    {
+        description: 'csv without specified columns',
+        csv: `bcAddRe5,0.2,usd\r"bcAddRe5",0.1,"CZK"`,
+        result: [
+            { '0': 'bcAddRe5', '1': '0.2', '2': 'usd' },
+            { '0': 'bcAddRe5', '1': '0.1', '2': 'CZK' },
+        ],
+    },
+    {
+        description: 'csv without specified delimiter',
+        csv: `bcAddRe5`,
+        result: [{ '0': 'bcAddRe5' }],
+    },
+    {
+        description: 'csv with mixed delimiters (first used)',
+        csv: `1,2;3|4\t5^6`,
+        result: [{ '0': '1', '1': '2;3|4\t5^6' }],
+    },
+    {
+        description: 'csv with mixed delimiters (special char detected)',
+        csv: `1,2;3|4\t5^6|123`,
+        result: [{ '0': '1,2;3', '1': '4\t5^6', '2': '123' }],
+    },
+    {
+        description: 'csv with defined delimiter',
+        csv: `a#b#c`,
+        delimiter: '#',
+        result: [{ '0': 'a', '1': 'b', '2': 'c' }],
+    },
+];
+
+describe('csvParser.parseCSV', () => {
+    FIXTURES.forEach(f => {
+        it(f.description, () => {
+            expect(parseCSV(f.csv, f.columns, f.delimiter)).toEqual(f.result);
+        });
+    });
+});

--- a/packages/suite/src/utils/wallet/csvParser.ts
+++ b/packages/suite/src/utils/wallet/csvParser.ts
@@ -1,0 +1,67 @@
+const CELL_DELIMITERS = [',', ';', '\t', '|', '^'];
+// const LINE_DELIMITERS = ['\r\n', '\r', '\n'];
+
+type Result = { [key: string]: string };
+
+const occurrences = (text: string, delimiter: string) => {
+    // special chars needs to be escaped in RegExp
+    const specialChars = '!@#$^&%*()+=-[]/{}|:<>?,.';
+    const escape = specialChars.indexOf(delimiter) >= 0 ? '\\' : '';
+    const regExp = new RegExp(escape + delimiter, 'g');
+    return (text.match(regExp) || []).length;
+};
+
+const detectDelimiter = (text: string, delimiters: string[]) => {
+    let index = 0;
+    let frequency = 0;
+    delimiters
+        .map(d => occurrences(text, d)) // calculate occurrences
+        .forEach((f, i) => {
+            // find greatest occurrence
+            if (f > frequency) {
+                index = i;
+                frequency = f;
+            }
+        });
+    return delimiters[index];
+};
+
+const parseLine = (line: string, delimiter: string, columns: string[]) => {
+    // skip empty lines
+    if (!line.length) return {};
+    // split string to cells using delimiter
+    const cells = line.split(delimiter);
+    const output: Result = {};
+    cells.forEach((value, index) => {
+        const key = columns[index];
+        // strip double quotes and whitespace
+        const cleanValue = value.replace(/^"|"$/g, '').trim();
+        if (typeof key === 'string') {
+            // skip csv header (value is one of column keys)
+            if (!columns.includes(cleanValue.toLowerCase())) {
+                output[key] = cleanValue;
+            }
+        } else {
+            // use index as a key
+            output[index] = cleanValue;
+        }
+    });
+    return output;
+};
+
+export const parseCSV = (text: string, columns: string[] = [], delimiter?: string) => {
+    // detect delimiter
+    const d = delimiter || detectDelimiter(text, CELL_DELIMITERS);
+    // normalize new line delimiter and split into lines
+    const lines = text.replace(/(?:\r|\r\n|\n\n)/g, '\n').split('\n');
+
+    const result: Result[] = [];
+    lines.forEach(line => {
+        const output = parseLine(line, d, columns);
+        if (Object.keys(output).length) {
+            // use only valid lines
+            result.push(output);
+        }
+    });
+    return result;
+};

--- a/packages/suite/src/views/wallet/send/components/Header/index.tsx
+++ b/packages/suite/src/views/wallet/send/components/Header/index.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import styled from 'styled-components';
 import { variables, colors, Dropdown } from '@trezor/components';
+import { Translation } from '@suite-components';
 import { useActions } from '@suite-hooks';
 import { useSendFormContext } from '@wallet-hooks';
 import * as sendFormActions from '@wallet-actions/sendFormActions';
@@ -45,7 +46,7 @@ const Header = () => {
         {
             key: 'opreturn',
             callback: addOpReturn,
-            label: 'Add OP Return',
+            label: <Translation id="OP_RETURN_ADD" />,
             isDisabled: !!opreturnOutput,
             isHidden: networkType !== 'bitcoin',
         },
@@ -55,8 +56,8 @@ const Header = () => {
                 loadTransaction();
                 return true;
             },
-            label: 'Import',
-            isDisabled: true,
+            label: <Translation id="IMPORT_CSV" />,
+            isHidden: networkType !== 'bitcoin',
         },
         {
             key: 'raw',
@@ -64,8 +65,7 @@ const Header = () => {
                 sendRaw(true);
                 return true;
             },
-            label: 'Send RAW',
-            // isDisabled: true,
+            label: <Translation id="SEND_RAW" />,
         },
     ];
 


### PR DESCRIPTION
import transaction from csv for bitcoin-like coins only.
it's prepared to work with ETH/Erc20/XRP but it doesn't make sense there because you can have only 1 output - requires future work to sign multiple transactions one after another.

should automatically detect csv header (column name) and delimiter (one of: `, | ; ^ \t`)

quick test scenario:
- save as csv file
```
address,amount,currency
bc1q6hr68ewf72l6r7cj6ut286x0xkwg5706jq450u,0.31337,BTC
bc1q7zql632newlfv9rt269jyxdn30370rh4kp23pd,0.1,USD
```
- drag and drop or click to upload file
- modify data in csv (invalid currency, invalid fiat, invalid address etc)

![Screenshot 2020-10-29 at 20 26 19](https://user-images.githubusercontent.com/3435913/97622894-329a0980-1a25-11eb-9116-bc69756d4065.png)
![Screenshot 2020-10-29 at 20 28 19](https://user-images.githubusercontent.com/3435913/97622998-52313200-1a25-11eb-8b7e-f256c412005f.png)



