### PR TITLE
fix(suite): blockchainActions subscriptions

### DIFF
--- a/packages/suite/src/actions/wallet/__fixtures__/blockchainActions.ts
+++ b/packages/suite/src/actions/wallet/__fixtures__/blockchainActions.ts
@@ -1,4 +1,5 @@
-import { TRANSACTION, ACCOUNT } from '@wallet-actions/constants';
+import { NOTIFICATION } from '@suite-actions/constants';
+import { TRANSACTION, ACCOUNT, BLOCKCHAIN } from '@wallet-actions/constants';
 import { analyzeTransactions } from '@wallet-utils/__fixtures__/transactionUtils';
 
 const DEFAULT_ACCOUNT = {
@@ -261,3 +262,275 @@ export const onBlock = analyzeTransactions
             },
         },
     ] as any);
+
+export const init = [
+    {
+        description: 'no accounts',
+        actions: [{ type: BLOCKCHAIN.UPDATE_FEE }, { type: BLOCKCHAIN.READY }],
+        blockchainUnsubscribeFiatRates: 0,
+    },
+    {
+        description: 'one coin is present',
+        initialState: {
+            accounts: [{ symbol: 'btc' }],
+        },
+        actions: [{ type: BLOCKCHAIN.UPDATE_FEE }, { type: BLOCKCHAIN.READY }],
+        blockchainUnsubscribeFiatRates: 1,
+    },
+    {
+        description: 'multiple coins and custom backends are present',
+        initialState: {
+            accounts: [
+                { symbol: 'btc' },
+                { symbol: 'btc' },
+                { symbol: 'ltc' },
+                { symbol: 'ltc' },
+                { symbol: 'eth' },
+            ],
+        },
+        actions: [{ type: BLOCKCHAIN.UPDATE_FEE }, { type: BLOCKCHAIN.READY }],
+        blockchainUnsubscribeFiatRates: 3,
+    },
+];
+
+export const onConnect = [
+    {
+        description: 'unknown coin',
+        symbol: 'btc-invalid',
+        actions: [],
+        blockchainEstimateFee: 0,
+        blockchainSubscribeFiatRates: 0,
+        blockchainSubscribe: 0,
+    },
+    {
+        description: 'successful, no accounts, no subscriptions',
+        symbol: 'btc',
+        actions: [{ type: BLOCKCHAIN.UPDATE_FEE }, { type: BLOCKCHAIN.CONNECTED }],
+        blockchainEstimateFee: 1,
+        blockchainSubscribeFiatRates: 1,
+        blockchainSubscribe: 0,
+    },
+    {
+        description: 'successful, different coin accounts, no subscriptions',
+        initialState: {
+            accounts: [{ symbol: 'ltc' }],
+        },
+        symbol: 'btc',
+        actions: [{ type: BLOCKCHAIN.UPDATE_FEE }, { type: BLOCKCHAIN.CONNECTED }],
+        blockchainEstimateFee: 1,
+        blockchainSubscribeFiatRates: 1,
+        blockchainSubscribe: 0,
+    },
+    {
+        description: 'successful with subscription',
+        initialState: {
+            accounts: [{ symbol: 'btc' }],
+            blockchain: {
+                btc: {
+                    reconnection: { id: 1 },
+                },
+            },
+        },
+        symbol: 'btc',
+        actions: [{ type: BLOCKCHAIN.UPDATE_FEE }, { type: BLOCKCHAIN.CONNECTED }],
+        blockchainEstimateFee: 1,
+        blockchainSubscribeFiatRates: 1,
+        blockchainSubscribe: 1,
+    },
+    {
+        description: 'successful, subscribeFiatRates failed, fee levels sorted',
+        initialState: {
+            accounts: [{ symbol: 'btc' }],
+        },
+        // order: subscribeFiatRates > estimateFee
+        connect: [
+            { success: false },
+            { payload: { levels: [{ label: 'normal' }, { label: 'high' }, { label: 'low' }] } },
+        ],
+        symbol: 'btc',
+        actions: [{ type: BLOCKCHAIN.UPDATE_FEE }, { type: BLOCKCHAIN.CONNECTED }],
+        blockchainEstimateFee: 1,
+        blockchainSubscribeFiatRates: 1,
+        blockchainSubscribe: 0,
+    },
+    {
+        description: 'successful, blockchainEstimateFee failed',
+        initialState: {
+            accounts: [{ symbol: 'eth' }],
+        },
+        // order: subscribeFiatRates > subscribe > estimateFee
+        connect: [undefined, undefined, { success: false }],
+        symbol: 'eth',
+        actions: [{ type: BLOCKCHAIN.CONNECTED }],
+        blockchainEstimateFee: 1,
+        blockchainSubscribeFiatRates: 1,
+        blockchainSubscribe: 1,
+    },
+];
+
+export const onDisconnect = [
+    {
+        description: 'unknown coin',
+        symbol: 'btc-invalid',
+        actions: [],
+    },
+    {
+        description: 'without accounts, not reconnection',
+        symbol: 'btc',
+        actions: [],
+    },
+    {
+        description: 'with accounts, reconnection started',
+        initialState: {
+            accounts: [{ symbol: 'btc' }],
+        },
+        symbol: 'btc',
+        actions: [{ type: BLOCKCHAIN.RECONNECT_TIMEOUT_START }],
+    },
+    {
+        description: 'with accounts, with reconnection, reconnection restarted',
+        initialState: {
+            accounts: [{ symbol: 'btc' }],
+            blockchain: {
+                btc: {
+                    reconnection: {
+                        id: 1,
+                        count: 1,
+                    },
+                },
+            },
+        },
+        symbol: 'btc',
+        actions: [{ type: BLOCKCHAIN.RECONNECT_TIMEOUT_START }],
+    },
+];
+
+export const onNotification = [
+    {
+        description: 'no accounts',
+        initialState: {
+            accounts: [{ symbol: 'eth' }],
+        },
+        params: {
+            notification: { descriptor: 'xpub', tx: { type: 'recv' } },
+            coin: { shortcut: 'btc' },
+        },
+        actions: [],
+        getAccountInfo: 0,
+    },
+    {
+        description: 'pending btc tx, multiple accounts update',
+        initialState: {
+            accounts: [
+                DEFAULT_ACCOUNT,
+                { ...DEFAULT_ACCOUNT, descriptor: 'xpub2' },
+                { ...DEFAULT_ACCOUNT, descriptor: 'xpub3' },
+            ],
+        },
+        params: {
+            notification: { descriptor: 'xpub', tx: { type: 'recv', amount: '100000' } },
+            coin: { shortcut: 'btc' },
+        },
+        actions: [{ type: NOTIFICATION.EVENT, payload: { formattedAmount: '0.001 BTC' } }],
+        getAccountInfo: 3,
+    },
+    {
+        description: 'pending token tx, one account update',
+        initialState: {
+            accounts: [
+                { ...DEFAULT_ACCOUNT, symbol: 'eth', networkType: 'ethereum' },
+                { ...DEFAULT_ACCOUNT, descriptor: 'xpub2', symbol: 'eth', networkType: 'ethereum' },
+            ],
+        },
+        params: {
+            notification: {
+                descriptor: 'xpub',
+                tx: { type: 'recv', tokens: [{ amount: '1', decimals: 3, symbol: 'erc20' }] },
+            },
+            coin: { shortcut: 'eth' },
+        },
+        actions: [{ type: NOTIFICATION.EVENT, payload: { formattedAmount: '0.001 ERC20' } }],
+        getAccountInfo: 1,
+    },
+    {
+        description: 'sent btc, multiple accounts update',
+        initialState: {
+            accounts: [
+                DEFAULT_ACCOUNT,
+                { ...DEFAULT_ACCOUNT, descriptor: 'xpub2' },
+                { ...DEFAULT_ACCOUNT, descriptor: 'xpub3' },
+            ],
+        },
+        params: {
+            notification: { descriptor: 'xpub', tx: {} },
+            coin: { shortcut: 'btc' },
+        },
+        actions: [],
+        getAccountInfo: 3,
+    },
+    {
+        description: 'sent eth, one account update',
+        initialState: {
+            accounts: [
+                { ...DEFAULT_ACCOUNT, symbol: 'eth', networkType: 'ethereum' },
+                { ...DEFAULT_ACCOUNT, descriptor: 'xpub2', symbol: 'eth', networkType: 'ethereum' },
+            ],
+        },
+        params: {
+            notification: { descriptor: 'xpub', tx: {} },
+            coin: { shortcut: 'eth' },
+        },
+        actions: [],
+        getAccountInfo: 1,
+    },
+    {
+        description: 'sent ripple, no account update',
+        initialState: {
+            accounts: [{ ...DEFAULT_ACCOUNT, symbol: 'xrp', networkType: 'ripple' }],
+        },
+        params: {
+            notification: { descriptor: 'xpub', tx: {} },
+            coin: { shortcut: 'xrp' },
+        },
+        actions: [],
+        getAccountInfo: 0,
+    },
+];
+
+export const customBacked = [
+    {
+        description: 'no backends',
+        initialState: [],
+        blockchainSetCustomBackend: 0,
+    },
+    {
+        description: 'with one backend',
+        initialState: [{ coin: 'btc' }, { coin: 'btc' }],
+        blockchainSetCustomBackend: 1,
+    },
+    {
+        description: 'with multiple backends',
+        initialState: [
+            { coin: 'btc' },
+            { coin: 'btc' },
+            { coin: 'ltc' },
+            { coin: 'ltc' },
+            { coin: 'ltc' },
+            { coin: 'eth' },
+        ],
+        blockchainSetCustomBackend: 3,
+    },
+    {
+        description: 'enable one, with multiple backends',
+        initialState: [
+            { coin: 'btc' },
+            { coin: 'btc' },
+            { coin: 'ltc' },
+            { coin: 'ltc' },
+            { coin: 'ltc' },
+            { coin: 'eth' },
+        ],
+        symbol: 'btc',
+        blockchainSetCustomBackend: 1,
+    },
+];

--- a/packages/suite/src/actions/wallet/accountActions.ts
+++ b/packages/suite/src/actions/wallet/accountActions.ts
@@ -85,10 +85,13 @@ export const disableAccounts = () => (dispatch: Dispatch, getState: GetState) =>
     const accountsToRemove = getState().wallet.accounts.filter(a =>
         disabledNetworks.includes(a.symbol),
     );
-    dispatch({
-        type: ACCOUNT.REMOVE,
-        payload: accountsToRemove,
-    });
+
+    if (accountsToRemove.length) {
+        dispatch({
+            type: ACCOUNT.REMOVE,
+            payload: accountsToRemove,
+        });
+    }
 };
 
 export const changeAccountVisibility = (payload: Account, visible = true) => ({

--- a/packages/suite/src/actions/wallet/blockchainActions.ts
+++ b/packages/suite/src/actions/wallet/blockchainActions.ts
@@ -7,7 +7,6 @@ import TrezorConnect, {
 } from 'trezor-connect';
 import * as accountUtils from '@wallet-utils/accountUtils';
 import * as accountActions from '@wallet-actions/accountActions';
-import * as fiatRatesActions from '@wallet-actions/fiatRatesActions';
 import { getNetwork } from '@wallet-utils/accountUtils';
 import * as notificationActions from '@suite-actions/notificationActions';
 import { State as FeeState } from '@wallet-reducers/feesReducer';
@@ -23,7 +22,7 @@ import { BLOCKCHAIN } from './constants';
 
 export type BlockchainActions =
     | {
-          type: typeof BLOCKCHAIN.READY;
+          type: typeof BLOCKCHAIN.READY | typeof BLOCKCHAIN.CONNECTED;
       }
     | {
           type: typeof BLOCKCHAIN.RECONNECT_TIMEOUT_START;
@@ -239,7 +238,7 @@ export const onConnect = (symbol: string) => async (dispatch: Dispatch, getState
     }
     await dispatch(subscribe(network.symbol, true));
     await dispatch(updateFeeInfo(network.symbol));
-    dispatch(fiatRatesActions.initRates());
+    dispatch({ type: BLOCKCHAIN.CONNECTED });
 };
 
 export const onBlockMined = (block: BlockchainBlock) => async (

--- a/packages/suite/src/actions/wallet/blockchainActions.ts
+++ b/packages/suite/src/actions/wallet/blockchainActions.ts
@@ -179,35 +179,54 @@ export const init = () => async (dispatch: Dispatch, getState: GetState) => {
     });
 };
 
-export const subscribe = (symbol?: Network['symbol']) => async (
-    _dispatch: Dispatch,
+// called from WalletMiddleware after ACCOUNT.ADD/UPDATE action
+// or after BLOCKCHAIN.CONNECT event (blockchainActions.onConnect)
+export const subscribe = (symbol: Network['symbol'], fiatRates = false) => async (
+    _: Dispatch,
     getState: GetState,
 ) => {
+    // fiat rates should be subscribed only once, after onConnect event
+    if (fiatRates) {
+        const { success } = await TrezorConnect.blockchainSubscribeFiatRates({ coin: symbol });
+        // if first subscription fails, do not run the second one
+        if (!success) return;
+    }
+
+    // do NOT subscribe if there are no accounts
+    // it leads to websocket disconnection
     const { accounts } = getState().wallet;
-    if (accounts.length <= 0) return;
+    if (!accounts.length) return;
+    const accountsToSubscribe = accounts.filter(a => a.symbol === symbol);
+    if (!accountsToSubscribe.length) return;
+    return TrezorConnect.blockchainSubscribe({
+        accounts: accountsToSubscribe,
+        coin: symbol,
+    });
+};
 
-    const sortedAccounts: { [key: string]: Account[] } = {};
-    const accountsToSubscribe = symbol ? accounts.filter(a => a.symbol === symbol) : accounts;
-    accountsToSubscribe.forEach(a => {
-        if (!sortedAccounts[a.symbol]) {
-            sortedAccounts[a.symbol] = [];
+// called from WalletMiddleware after ACCOUNT.REMOVE action
+export const unsubscribe = (removedAccounts: Account[]) => (_: Dispatch, getState: GetState) => {
+    // collect unique symbols
+    const symbols = removedAccounts.reduce((arr, account) => {
+        if (arr.indexOf(account.symbol) < 0) return arr.concat([account.symbol]);
+        return arr;
+    }, [] as string[]);
+
+    const { accounts } = getState().wallet;
+    const promises = symbols.map(symbol => {
+        const accountsToSubscribe = accounts.filter(a => a.symbol === symbol);
+        if (accountsToSubscribe.length) {
+            // there are some accounts left, update subscription
+            return TrezorConnect.blockchainSubscribe({
+                accounts: accountsToSubscribe,
+                coin: symbol,
+            });
         }
-        sortedAccounts[a.symbol].push(a);
+        // there are no accounts left for this coin, disconnect backend
+        return TrezorConnect.blockchainDisconnect({ coin: symbol });
     });
 
-    const promises = Object.keys(sortedAccounts).map(coin => {
-        return [
-            TrezorConnect.blockchainSubscribe({
-                accounts: sortedAccounts[coin],
-                coin,
-            }),
-            TrezorConnect.blockchainSubscribeFiatRates({
-                coin,
-            }),
-        ];
-    });
-
-    return Promise.all(promises.flat());
+    return Promise.all(promises as Promise<any>[]);
 };
 
 export const onConnect = (symbol: string) => async (dispatch: Dispatch, getState: GetState) => {
@@ -218,7 +237,7 @@ export const onConnect = (symbol: string) => async (dispatch: Dispatch, getState
         // reset previous timeout
         clearTimeout(blockchain.reconnection.id);
     }
-    await dispatch(subscribe(network.symbol));
+    await dispatch(subscribe(network.symbol, true));
     await dispatch(updateFeeInfo(network.symbol));
     dispatch(fiatRatesActions.initRates());
 };

--- a/packages/suite/src/actions/wallet/blockchainActions.ts
+++ b/packages/suite/src/actions/wallet/blockchainActions.ts
@@ -134,7 +134,7 @@ export const updateFeeInfo = (symbol: string) => async (dispatch: Dispatch, getS
 };
 
 // call TrezorConnect.unsubscribe, it doesn't cost anything and should emit BLOCKCHAIN.CONNECT or BLOCKCHAIN.ERROR event
-export const reconnect = (coin: Network['symbol']) => async (_dispatch: Dispatch) => {
+export const reconnect = (coin: Network['symbol']) => (_dispatch: Dispatch) => {
     return TrezorConnect.blockchainUnsubscribeFiatRates({ coin });
 };
 
@@ -292,7 +292,6 @@ export const onNotification = (payload: BlockchainNotification) => async (
               )} ${token.symbol.toUpperCase()}`
             : accountUtils.formatNetworkAmount(tx.amount, account.symbol, true);
 
-        console.warn('RECV', tx, token, formattedAmount);
         dispatch(
             notificationActions.addEvent({
                 type: 'tx-received',
@@ -309,11 +308,10 @@ export const onNotification = (payload: BlockchainNotification) => async (
     // TODO: investigate more how to keep ripple pending tx until they are confirmed/rejected
     // ripple-lib doesn't send "pending" txs in history
     if (account.networkType !== 'ripple') {
-        dispatch(accountActions.fetchAndUpdateAccount(account));
         // tmp workaround for BB not sending multiple notifications, fix in progress
         if (account.networkType === 'bitcoin') {
-            networkAccounts.forEach(account => {
-                dispatch(accountActions.fetchAndUpdateAccount(account));
+            networkAccounts.forEach(a => {
+                dispatch(accountActions.fetchAndUpdateAccount(a));
             });
         } else {
             dispatch(accountActions.fetchAndUpdateAccount(account));

--- a/packages/suite/src/actions/wallet/constants/blockchainConstants.ts
+++ b/packages/suite/src/actions/wallet/constants/blockchainConstants.ts
@@ -2,8 +2,7 @@ import { BLOCKCHAIN } from 'trezor-connect';
 
 export const READY = '@blockchain/ready';
 export const RECONNECT_TIMEOUT_START = '@blockchain/reconnect-timeout-start';
-export const START_SUBSCRIBE = '@blockchain/start-subscribe';
-export const FAIL_SUBSCRIBE = '@blockchain/fail-subscribe';
+export const CONNECTED = '@blockchain/connected';
 export const UPDATE_FEE = '@blockchain/update-fee';
 
 // reexport from trezor-connect

--- a/packages/suite/src/middlewares/wallet/__fixtures__/walletMiddleware.ts
+++ b/packages/suite/src/middlewares/wallet/__fixtures__/walletMiddleware.ts
@@ -1,0 +1,90 @@
+import { ACCOUNT } from '@wallet-actions/constants';
+
+export const blockchainSubscription = [
+    {
+        description: 'create account, only one subscribed',
+        initialAccounts: [{ descriptor: '1', symbol: 'ltc' }],
+        actions: [
+            {
+                type: ACCOUNT.CREATE,
+                payload: { descriptor: '1', symbol: 'btc' },
+            },
+        ],
+        result: {
+            subscribe: {
+                called: 1,
+                accounts: [{ descriptor: '1', symbol: 'btc' }],
+                coin: 'btc',
+            },
+        },
+    },
+    {
+        description: 'remove account, one subscription remain',
+        initialAccounts: [{ descriptor: '1' }, { descriptor: '2' }],
+        actions: [
+            {
+                type: ACCOUNT.REMOVE,
+                payload: [{ descriptor: '1' }],
+            },
+        ],
+        result: {
+            subscribe: {
+                called: 1,
+                accounts: [{ descriptor: '2' }],
+                coin: 'eth',
+            },
+            disconnect: {
+                called: 0,
+            },
+        },
+    },
+    {
+        description: 'remove account and disconnect backend',
+        initialAccounts: [{ descriptor: '1' }, { descriptor: '2' }],
+        actions: [
+            {
+                type: ACCOUNT.REMOVE,
+                payload: [{ descriptor: '1' }, { descriptor: '2' }],
+            },
+        ],
+        result: {
+            subscribe: {
+                called: 0,
+            },
+            disconnect: {
+                called: 1,
+                coin: 'eth',
+            },
+        },
+    },
+    {
+        description: 'disconnect LTC backend, subscribe one account on BTC backend',
+        initialAccounts: [
+            { descriptor: '1btc', symbol: 'btc' },
+            { descriptor: '2btc', symbol: 'btc' },
+            { descriptor: '1ltc', symbol: 'ltc' },
+            { descriptor: '2ltc', symbol: 'ltc' },
+        ],
+        actions: [
+            {
+                type: ACCOUNT.REMOVE,
+                payload: [
+                    { descriptor: '1btc', symbol: 'btc' },
+                    { descriptor: '1ltc', symbol: 'ltc' },
+                    { descriptor: '2ltc', symbol: 'ltc' },
+                ],
+            },
+        ],
+        result: {
+            subscribe: {
+                called: 1,
+                accounts: [{ descriptor: '2btc', symbol: 'btc' }],
+                coin: 'btc',
+            },
+            disconnect: {
+                called: 1,
+                coin: 'ltc',
+            },
+        },
+    },
+];

--- a/packages/suite/src/middlewares/wallet/__tests__/walletMiddleware.test.ts
+++ b/packages/suite/src/middlewares/wallet/__tests__/walletMiddleware.test.ts
@@ -1,0 +1,143 @@
+/* eslint-disable global-require */
+import configureStore from 'redux-mock-store';
+import thunk from 'redux-thunk';
+
+import accountsReducer from '@wallet-reducers/accountsReducer';
+import walletSettingsReducer from '@wallet-reducers/settingsReducer';
+import blockchainReducer from '@wallet-reducers/blockchainReducer';
+import walletMiddleware from '@wallet-middlewares/walletMiddleware';
+import blockchainMiddleware from '@wallet-middlewares/blockchainMiddleware';
+
+import { Action } from '@suite-types';
+import * as fixtures from '../__fixtures__/walletMiddleware';
+
+const { getWalletAccount } = global.JestMocks;
+
+jest.mock('trezor-connect', () => {
+    let fixture: any;
+    return {
+        __esModule: true, // this property makes it work
+        default: {
+            blockchainSubscribe: jest.fn(async _params => {
+                return { success: true, ...fixture };
+            }),
+            blockchainSubscribeFiatRates: jest.fn(async _params => {
+                return { success: true };
+            }),
+            blockchainUnsubscribeFiatRates: jest.fn(async _params => {
+                return { success: true };
+            }),
+            blockchainDisconnect: jest.fn(async _params => {
+                return { success: true };
+            }),
+            blockchainEstimateFee: jest.fn(async _params => {
+                return { success: true };
+            }),
+        },
+        setTestFixtures: (f: any) => {
+            fixture = f;
+        },
+        DEVICE: {},
+        BLOCKCHAIN: {
+            CONNECT: 'bl-connect',
+            BLOCK: 'bl-block',
+            NOTIFICATION: 'notif',
+            ERROR: 'err',
+        },
+    };
+});
+
+type AccountsState = ReturnType<typeof accountsReducer>;
+type SettingsState = ReturnType<typeof walletSettingsReducer>;
+interface Args {
+    accounts?: AccountsState;
+    settings?: Partial<SettingsState>;
+}
+
+export const getInitialState = ({ accounts, settings }: Args = {}) => ({
+    router: {
+        app: 'wallet',
+    },
+    suite: {
+        device: true, // device is irrelevant in this test
+    },
+    wallet: {
+        accounts: accounts || accountsReducer(undefined, { type: 'foo' } as any),
+        blockchain: blockchainReducer(undefined, { type: 'foo' } as any),
+        settings: {
+            ...walletSettingsReducer(undefined, { type: 'foo' } as any),
+            ...settings,
+        },
+    },
+});
+
+type State = ReturnType<typeof getInitialState>;
+
+const mockStore = configureStore<State, Action>([thunk, walletMiddleware, blockchainMiddleware]);
+
+const initStore = (state: State) => {
+    const store = mockStore(state);
+    store.subscribe(() => {
+        const action = store.getActions().pop();
+        const { accounts, blockchain, settings } = store.getState().wallet;
+        store.getState().wallet = {
+            accounts: accountsReducer(accounts, action),
+            blockchain: blockchainReducer(blockchain, action),
+            settings: walletSettingsReducer(settings, action),
+        };
+        // add action back to stack
+        store.getActions().push(action);
+    });
+    return store;
+};
+
+// testing walletMiddleware, blockchainActions (subscribe/unsubscribe)
+describe('walletMiddleware', () => {
+    afterEach(() => {
+        jest.clearAllMocks();
+    });
+
+    // TODO: this is failing on fiatRatesActions (missing reducer)
+    // it('connect', () => {
+    //     const store = initStore(getInitialState());
+    //     store.dispatch({ type: BLOCKCHAIN.CONNECT, payload: { coin: { shortcut: 'btc' } } });
+    // });
+
+    fixtures.blockchainSubscription.forEach(f => {
+        it(f.description, () => {
+            // @ts-ignore
+            const initialAccounts = f.initialAccounts.map((a: any) => getWalletAccount(a));
+            const store = initStore(
+                getInitialState({
+                    accounts: initialAccounts,
+                }),
+            );
+
+            f.actions.forEach((action: any) => {
+                const payload = Array.isArray(action.payload)
+                    ? // @ts-ignore
+                      action.payload.map(a => getWalletAccount(a))
+                    : getWalletAccount(action.payload);
+                store.dispatch({ ...action, payload });
+            });
+
+            const { blockchainSubscribe, blockchainDisconnect } = require('trezor-connect').default;
+            const { subscribe, disconnect } = f.result;
+            if (subscribe) {
+                expect(blockchainSubscribe).toBeCalledTimes(subscribe.called);
+                if (subscribe.called) {
+                    // @ts-ignore
+                    const accounts = subscribe.accounts?.map(a => getWalletAccount(a));
+                    expect(blockchainSubscribe).toHaveBeenLastCalledWith({
+                        accounts,
+                        coin: subscribe.coin,
+                    });
+                }
+            }
+
+            if (disconnect) {
+                expect(blockchainDisconnect).toBeCalledTimes(disconnect.called);
+            }
+        });
+    });
+});

--- a/packages/suite/src/middlewares/wallet/blockchainMiddleware.ts
+++ b/packages/suite/src/middlewares/wallet/blockchainMiddleware.ts
@@ -3,7 +3,7 @@ import { BLOCKCHAIN } from 'trezor-connect';
 import * as blockchainActions from '@wallet-actions/blockchainActions';
 import { AppState, Action, Dispatch } from '@suite-types';
 
-const walletMiddleware = (api: MiddlewareAPI<Dispatch, AppState>) => (next: Dispatch) => (
+const blockchainMiddleware = (api: MiddlewareAPI<Dispatch, AppState>) => (next: Dispatch) => (
     action: Action,
 ): Action => {
     // propagate action to reducers
@@ -21,7 +21,7 @@ const walletMiddleware = (api: MiddlewareAPI<Dispatch, AppState>) => (next: Disp
             api.dispatch(blockchainActions.onNotification(action.payload));
             break;
         case BLOCKCHAIN.ERROR:
-            api.dispatch(blockchainActions.setReconnectionTimeout(action.payload));
+            api.dispatch(blockchainActions.onDisconnect(action.payload));
             break;
         default:
             break;
@@ -30,4 +30,4 @@ const walletMiddleware = (api: MiddlewareAPI<Dispatch, AppState>) => (next: Disp
     return action;
 };
 
-export default walletMiddleware;
+export default blockchainMiddleware;

--- a/packages/suite/src/middlewares/wallet/fiatRatesMiddleware.ts
+++ b/packages/suite/src/middlewares/wallet/fiatRatesMiddleware.ts
@@ -12,6 +12,9 @@ const fiatRatesMiddleware = (api: MiddlewareAPI<Dispatch, AppState>) => (next: D
     next(action);
 
     switch (action.type) {
+        case BLOCKCHAIN.CONNECTED:
+            api.dispatch(fiatRatesActions.initRates());
+            break;
         case BLOCKCHAIN.FIAT_RATES_UPDATE:
             api.dispatch(fiatRatesActions.onUpdateRate(action.payload));
             break;

--- a/packages/suite/src/middlewares/wallet/walletMiddleware.ts
+++ b/packages/suite/src/middlewares/wallet/walletMiddleware.ts
@@ -35,12 +35,12 @@ const walletMiddleware = (api: MiddlewareAPI<Dispatch, AppState>) => (next: Disp
     // propagate action to reducers
     next(action);
 
-    if (
-        action.type === ACCOUNT.CREATE ||
-        action.type === ACCOUNT.UPDATE ||
-        action.type === ACCOUNT.REMOVE
-    ) {
-        api.dispatch(blockchainActions.subscribe());
+    if (action.type === ACCOUNT.CREATE || action.type === ACCOUNT.UPDATE) {
+        api.dispatch(blockchainActions.subscribe(action.payload.symbol));
+    }
+
+    if (action.type === ACCOUNT.REMOVE) {
+        api.dispatch(blockchainActions.unsubscribe(action.payload));
     }
 
     // Update custom backends

--- a/packages/suite/src/middlewares/wallet/walletMiddleware.ts
+++ b/packages/suite/src/middlewares/wallet/walletMiddleware.ts
@@ -1,4 +1,3 @@
-import TrezorConnect from 'trezor-connect';
 import { MiddlewareAPI } from 'redux';
 import { SUITE, ROUTER } from '@suite-actions/constants';
 import { ACCOUNT } from '@wallet-actions/constants';
@@ -15,7 +14,6 @@ const walletMiddleware = (api: MiddlewareAPI<Dispatch, AppState>) => (next: Disp
     action: Action,
 ): Action => {
     const prevState = api.getState();
-    const prevRouter = prevState.router;
 
     if (action.type === SUITE.FORGET_DEVICE) {
         const deviceState = action.payload.state;
@@ -48,20 +46,11 @@ const walletMiddleware = (api: MiddlewareAPI<Dispatch, AppState>) => (next: Disp
         action.type === WALLET_SETTINGS.ADD_BLOCKBOOK_URL ||
         action.type === WALLET_SETTINGS.REMOVE_BLOCKBOOK_URL
     ) {
-        const { coin } = action.payload;
-        const { blockbookUrls } = api.getState().wallet.settings;
-
-        TrezorConnect.blockchainSetCustomBackend({
-            coin: action.payload.coin,
-            blockchainLink: {
-                type: 'blockbook',
-                url: blockbookUrls.filter(b => b.coin === coin).map(b => b.url),
-            },
-        });
+        api.dispatch(blockchainActions.setCustomBackend(action.payload.coin));
     }
 
+    const prevRouter = prevState.router;
     const nextRouter = api.getState().router;
-
     let resetReducers = action.type === SUITE.SELECT_DEVICE;
     if (prevRouter.app === 'wallet' && action.type === ROUTER.LOCATION_CHANGE) {
         // leaving wallet app or switching between accounts


### PR DESCRIPTION
This PR actually solves few things:
- `unsubscribe` disconnects websocket if all accounts for particular network are removed, fix #2667
- `subscribe` prevents calling `TrezorConnect.subscribeFiatRates` too many times (was called on every account.create/update)
- `subscribe` prevents calling `TrezorConnect.subscribe` with empty accounts param, fix #2660
- prevent calling "updateFiatRates" on disconnected backends (unexpectedly fired up by fiatRatesActions ticker)
- separate fiatRatesActions from blockchainActions
- fix setCustomBackend called multiple times for 1 coin
- refactor `blockchainActions` (setCustomBackend, onDisconnect)
- added tests for blockchainActions (100%!!!!) global coverage increase ~4%!!!
- create shareable TrezorConnect mock for unit tests

browsing thru commits recommended :)