### PR TITLE
fix: Remove ONG from list of supported tokens for buy crypto

### DIFF
--- a/packages/suite/src/utils/wallet/coinmarket/__tests__/buyUtils.test.ts
+++ b/packages/suite/src/utils/wallet/coinmarket/__tests__/buyUtils.test.ts
@@ -156,10 +156,6 @@ describe('coinmarket/buy utils', () => {
                 value: 'GUSD',
                 label: 'GUSD',
             },
-            {
-                value: 'ONG',
-                label: 'ONG',
-            },
         ]);
     });
 

--- a/packages/suite/src/utils/wallet/coinmarket/buyUtils.ts
+++ b/packages/suite/src/utils/wallet/coinmarket/buyUtils.ts
@@ -178,7 +178,7 @@ export const getCryptoOptions = (
     symbol: Account['symbol'],
     networkType: Account['networkType'],
 ) => {
-    const supportedTokens = ['usdt', 'dai', 'gusd', 'ong'];
+    const supportedTokens = ['usdt', 'dai', 'gusd'];
     const uppercaseSymbol = symbol.toUpperCase();
     const options: { value: string; label: string }[] = [
         { value: uppercaseSymbol, label: uppercaseSymbol },


### PR DESCRIPTION
ONG is not ERC20 token in ETH network (it is an ONT token), cannot be offered to buy in ETH account.

This hardcoded list of tokens is only temporary solution, we are adding to our API server a functionality, which will give us info if a coin is a token and in what network. 
It is not deployed yet, however, therefore this hardcoded list.