### PR TITLE
fix(suite-desktop): use static BuildId for Next.js

### DIFF
--- a/packages/suite-desktop/next.config.js
+++ b/packages/suite-desktop/next.config.js
@@ -60,6 +60,10 @@ module.exports = withBundleAnalyzer(
 
                         return config;
                     },
+                    // use static BuildId so the desktop builds are deterministic
+                    generateBuildId: async () => {
+                        return '0';
+                    },
                 }),
             ),
         ),


### PR DESCRIPTION
We don't need random BuildIds for desktop builds and by having it static we can achieve deterministic builds

Code taken from https://nextjs.org/docs/api-reference/next.config.js/configuring-the-build-id