### PR TITLE
feat(suite-desktop): add devtool extensions

### DIFF
--- a/docs/packages/suite-desktop.md
+++ b/docs/packages/suite-desktop.md
@@ -11,3 +11,8 @@ Available flags:
 | --- | --- |
 | `--disable-csp` | Disables the Content Security Policy. Necessary for using DevTools in a production build. |
 | `--pre-release` | Tells the auto-updater to fetch pre-release updates. |
+
+## DevTools
+DevTools are automatically opened on dev builds and can also be used on production builds. For production builds, you need to run Suite Desktop with the `--disable-csp` flag and press CTRL+SHIFT+I, or CMD+SHIFT+I on Mac, to open the DevTools.
+
+For development builds only, additional extensions are loaded, such as Redux DevTools. This is controlled by the `package.json` file inside the `@trezor/suite-desktop` package under the `extensions` property. This property is an array of extension IDs. Adding a new ID will result in the extension being downloaded and extracted using `yarn run build:ext` (which is also run together with `yarn run dev`). Once running, Electron will be loading all extensions specified in the `package.json` file.

--- a/packages/suite-desktop/.gitignore
+++ b/packages/suite-desktop/.gitignore
@@ -2,3 +2,4 @@ public
 build
 lib
 build-electron
+extensions

--- a/packages/suite-desktop/package.json
+++ b/packages/suite-desktop/package.json
@@ -7,9 +7,10 @@
     "homepage": "https://trezor.io/",
     "main": "dist/electron.js",
     "scripts": {
-        "dev": "yarn copy-files && yarn build:lib && electron .",
+        "dev": "yarn copy-files && yarn build:ext && yarn build:lib && electron .",
         "clean": "rimraf ./build-electron && rimraf ./build && rimraf ./dist",
         "copy-files": "yarn workspace @trezor/suite-data copy-static-files",
+        "build:ext": "node ./scripts/extensions.js",
         "build:lib": "tsc --project src-electron/tsconfig.json",
         "build:desktop": "rimraf ./build && next build && next export -o build && yarn build:lib",
         "build:mac": "yarn clean && yarn build:desktop && electron-builder --mac -p never",
@@ -168,6 +169,10 @@
         "react": "16.13.1",
         "react-dom": "16.13.1",
         "styled-components": "5.1.1",
+        "unzip-crx-3": "0.2.0",
         "worker-loader": "^3.0.2"
-    }
+    },
+    "extensions": [
+        "lmhkpmbekcpmknklioeibfkpmmfibljd"
+    ]
 }

--- a/packages/suite-desktop/scripts/extensions.js
+++ b/packages/suite-desktop/scripts/extensions.js
@@ -1,0 +1,39 @@
+// Download extensions
+const pkg = require('../package.json');
+const fs = require('fs');
+const path = require('path');
+const fetch = require('node-fetch');
+const unzip = require('unzip-crx-3');
+const rimraf = require('rimraf');
+
+const extensions = path.join(__dirname, '..', 'extensions');
+
+const downloadExtension = async id => {
+    const directory = path.join(extensions, id);
+    const filename = `${directory}.crx`;
+
+    if (fs.existsSync(directory)) {
+        rimraf.sync(directory);
+    }
+
+    const res = await fetch(`https://clients2.google.com/service/update2/crx?response=redirect&prodversion=64&acceptformat=crx2,crx3&x=id%3D${id}%26uc`);
+    const dest = fs.createWriteStream(filename);
+    res.body.pipe(dest);
+    res.body.on('end', async () => {
+        await unzip(filename);
+        fs.unlinkSync(filename);
+    });
+    dest.on('error', err => {
+        throw new Error(err);
+    });
+};
+
+if (!fs.existsSync(extensions)) {
+    fs.mkdirSync(extensions);
+}
+
+pkg.extensions.forEach(ext => {
+    downloadExtension(ext)
+        .then(() => console.log(ext, 'downloaded successfully'))
+        .catch(err => console.error(ext, err));
+});

--- a/packages/suite-desktop/src-electron/electron.ts
+++ b/packages/suite-desktop/src-electron/electron.ts
@@ -156,7 +156,15 @@ const init = async () => {
         evt.preventDefault();
     });
 
-    if (!isDev) {
+    if (isDev) {
+        const pkgPath = path.join(__dirname, '..', 'package.json');
+        // eslint-disable-next-line
+        const { extensions } = require(pkgPath);
+        await extensions.forEach(async (id: string) => {
+            const extPath = path.join(__dirname, '..', 'extensions', id);
+            await session.defaultSession.loadExtension(extPath);
+        });
+    } else {
         const filter = {
             urls: ['http://127.0.0.1:21325/*'],
         };

--- a/yarn.lock
+++ b/yarn.lock
@@ -15799,6 +15799,11 @@ image-ssim@^0.2.0:
   resolved "https://registry.yarnpkg.com/image-ssim/-/image-ssim-0.2.0.tgz#83b42c7a2e6e4b85505477fe6917f5dbc56420e5"
   integrity sha1-g7Qsei5uS4VQVHf+aRf128VkIOU=
 
+immediate@~3.0.5:
+  version "3.0.6"
+  resolved "https://registry.yarnpkg.com/immediate/-/immediate-3.0.6.tgz#9db1dbd0faf8de6fbe0f5dd5e56bb606280de69b"
+  integrity sha1-nbHb0Pr43m++D13V5Wu2BigN5ps=
+
 immer@1.10.0:
   version "1.10.0"
   resolved "https://registry.yarnpkg.com/immer/-/immer-1.10.0.tgz#bad67605ba9c810275d91e1c2a47d4582e98286d"
@@ -17741,6 +17746,16 @@ jsx-ast-utils@^2.2.3:
     array-includes "^3.0.3"
     object.assign "^4.1.0"
 
+jszip@^3.1.0:
+  version "3.5.0"
+  resolved "https://registry.yarnpkg.com/jszip/-/jszip-3.5.0.tgz#b4fd1f368245346658e781fec9675802489e15f6"
+  integrity sha512-WRtu7TPCmYePR1nazfrtuF216cIVon/3GWOvHS9QR5bIwSbnxtdpma6un3jyGGNhHsKCSzn5Ypk+EkDRvTGiFA==
+  dependencies:
+    lie "~3.3.0"
+    pako "~1.0.2"
+    readable-stream "~2.3.6"
+    set-immediate-shim "~1.0.1"
+
 jwa@^1.4.1:
   version "1.4.1"
   resolved "https://registry.yarnpkg.com/jwa/-/jwa-1.4.1.tgz#743c32985cb9e98655530d53641b66c8645b039a"
@@ -17988,6 +18003,13 @@ levn@^0.3.0, levn@~0.3.0:
   dependencies:
     prelude-ls "~1.1.2"
     type-check "~0.3.2"
+
+lie@~3.3.0:
+  version "3.3.0"
+  resolved "https://registry.yarnpkg.com/lie/-/lie-3.3.0.tgz#dcf82dee545f46074daf200c7c1c5a08e0f40f6a"
+  integrity sha512-UaiMJzeWRlEujzAuw5LokY1L5ecNQYZKfmyZ9L7wDHb/p5etKaxXhohBcrw0EYby+G/NA52vRSN4N39dxHAIwQ==
+  dependencies:
+    immediate "~3.0.5"
 
 lighthouse-logger@^1.0.0, lighthouse-logger@^1.2.0:
   version "1.2.0"
@@ -20930,7 +20952,7 @@ package-json@^6.3.0:
     registry-url "^5.0.0"
     semver "^6.1.1"
 
-pako@^1.0.11, pako@~1.0.5:
+pako@^1.0.11, pako@~1.0.2, pako@~1.0.5:
   version "1.0.11"
   resolved "https://registry.yarnpkg.com/pako/-/pako-1.0.11.tgz#6c9599d340d54dfd3946380252a35705a6b992bf"
   integrity sha512-4hLB8Py4zZce5s4yd9XzopqwVv/yGNhV1Bl8NTmCq1763HeK2+EwVTv+leGeL13Dnh2wfbqowVPXCIO0z4taYw==
@@ -24916,6 +24938,11 @@ set-harmonic-interval@^1.0.1:
   resolved "https://registry.yarnpkg.com/set-harmonic-interval/-/set-harmonic-interval-1.0.1.tgz#e1773705539cdfb80ce1c3d99e7f298bb3995249"
   integrity sha512-AhICkFV84tBP1aWqPwLZqFvAwqEoVA9kxNMniGEUvzOlm4vLmOFLiTT3UZ6bziJTy4bOVpzWGTfSCbmaayGx8g==
 
+set-immediate-shim@~1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/set-immediate-shim/-/set-immediate-shim-1.0.1.tgz#4b2b1b27eb808a9f8dcc481a58e5e56f599f3f61"
+  integrity sha1-SysbJ+uAip+NzEgaWOXlb1mfP2E=
+
 set-value@^2.0.0, set-value@^2.0.1:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/set-value/-/set-value-2.0.1.tgz#a18d40530e6f07de4228c7defe4227af8cad005b"
@@ -27567,6 +27594,15 @@ untildify@4.0.0:
   resolved "https://registry.yarnpkg.com/untildify/-/untildify-4.0.0.tgz#2bc947b953652487e4600949fb091e3ae8cd919b"
   integrity sha512-KK8xQ1mkzZeg9inewmFVDNkg3l5LUhoq9kN6iWYB/CC9YMG8HA+c1Q8HwDe6dEX7kErrEVNVBO3fWsVq5iDgtw==
 
+unzip-crx-3@0.2.0:
+  version "0.2.0"
+  resolved "https://registry.yarnpkg.com/unzip-crx-3/-/unzip-crx-3-0.2.0.tgz#d5324147b104a8aed9ae8639c95521f6f7cda292"
+  integrity sha512-0+JiUq/z7faJ6oifVB5nSwt589v1KCduqIJupNVDoWSXZtWDmjDGO3RAEOvwJ07w90aoXoP4enKsR7ecMrJtWQ==
+  dependencies:
+    jszip "^3.1.0"
+    mkdirp "^0.5.1"
+    yaku "^0.16.6"
+
 unzip-response@^2.0.1:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/unzip-response/-/unzip-response-2.0.1.tgz#d2f0f737d16b0615e72a6935ed04214572d56f97"
@@ -28888,6 +28924,11 @@ y18n@^4.0.0:
   version "4.0.0"
   resolved "https://registry.yarnpkg.com/y18n/-/y18n-4.0.0.tgz#95ef94f85ecc81d007c264e190a120f0a3c8566b"
   integrity sha512-r9S/ZyXu/Xu9q1tYlpsLIsa3EeLXXk0VwlxqTcFRfg9EhMW+17kbt9G0NrgCmhGb5vT2hyhJZLfDGx+7+5Uj/w==
+
+yaku@^0.16.6:
+  version "0.16.7"
+  resolved "https://registry.yarnpkg.com/yaku/-/yaku-0.16.7.tgz#1d195c78aa9b5bf8479c895b9504fd4f0847984e"
+  integrity sha1-HRlceKqbW/hHnIlblQT9TwhHmE4=
 
 yallist@^2.1.2:
   version "2.1.2"


### PR DESCRIPTION
This change adds a script that fetches extensions from the Chrome store, unpacks them and loads them in Electron in development builds only. Extensions can be added or removed via the `package.json` file in the `@trezor/suite-desktop` project and the command can either be run separately using `yarn run build:ext` or together with `yarn run dev`. 

Currently on Redux DevTools (which is already super helpful) has been added. React DevTools are currently not working but could be in the future once there's a fix for it in Electron.

![Screenshot from 2020-10-23 00-13-34](https://user-images.githubusercontent.com/30026749/96935934-69bc6800-14c5-11eb-84d6-f85359b35bb2.png)
