### PR TITLE
Desktop Titlebar - Fixes and improvements (functionality and style)

### DIFF
--- a/packages/suite-desktop/src-electron/electron.ts
+++ b/packages/suite-desktop/src-electron/electron.ts
@@ -208,10 +208,10 @@ const init = async () => {
     ipcMain.on('client/ready', () => {
         notifyWindowMaximized(mainWindow);
     });
-    mainWindow.on('resize', () => {
+    mainWindow.on('maximize', () => {
         notifyWindowMaximized(mainWindow);
     });
-    mainWindow.on('move', () => {
+    mainWindow.on('unmaximize', () => {
         notifyWindowMaximized(mainWindow);
     });
 

--- a/packages/suite-desktop/src-electron/electron.ts
+++ b/packages/suite-desktop/src-electron/electron.ts
@@ -214,6 +214,10 @@ const init = async () => {
     mainWindow.on('unmaximize', () => {
         notifyWindowMaximized(mainWindow);
     });
+    mainWindow.on('moved', () => {
+        console.log('move');
+        notifyWindowMaximized(mainWindow);
+    });
 
     httpReceiver.start();
 

--- a/packages/suite-desktop/src-electron/electron.ts
+++ b/packages/suite-desktop/src-electron/electron.ts
@@ -60,7 +60,10 @@ const registerShortcuts = (window: BrowserWindow) => {
 
 // notify client with window maximization state
 const notifyWindowMaximized = (window: BrowserWindow) => {
-    window.webContents.send('window/is-maximized', mainWindow.isMaximized());
+    window.webContents.send(
+        'window/is-maximized',
+        process.platform === 'darwin' ? mainWindow.isFullScreen() : mainWindow.isMaximized(),
+    );
 };
 
 const init = async () => {
@@ -200,10 +203,18 @@ const init = async () => {
         mainWindow.minimize();
     });
     ipcMain.on('window/maximize', () => {
-        mainWindow.maximize();
+        if (process.platform === 'darwin') {
+            mainWindow.setFullScreen(true);
+        } else {
+            mainWindow.maximize();
+        }
     });
     ipcMain.on('window/unmaximize', () => {
-        mainWindow.unmaximize();
+        if (process.platform === 'darwin') {
+            mainWindow.setFullScreen(false);
+        } else {
+            mainWindow.unmaximize();
+        }
     });
     ipcMain.on('client/ready', () => {
         notifyWindowMaximized(mainWindow);
@@ -212,6 +223,12 @@ const init = async () => {
         notifyWindowMaximized(mainWindow);
     });
     mainWindow.on('unmaximize', () => {
+        notifyWindowMaximized(mainWindow);
+    });
+    mainWindow.on('enter-full-screen', () => {
+        notifyWindowMaximized(mainWindow);
+    });
+    mainWindow.on('leave-full-screen', () => {
         notifyWindowMaximized(mainWindow);
     });
     mainWindow.on('moved', () => {

--- a/packages/suite-desktop/src-electron/electron.ts
+++ b/packages/suite-desktop/src-electron/electron.ts
@@ -215,7 +215,6 @@ const init = async () => {
         notifyWindowMaximized(mainWindow);
     });
     mainWindow.on('moved', () => {
-        console.log('move');
         notifyWindowMaximized(mainWindow);
     });
 

--- a/packages/suite-desktop/src/support/DesktopTitlebar.tsx
+++ b/packages/suite-desktop/src/support/DesktopTitlebar.tsx
@@ -121,6 +121,8 @@ const DesktopTitlebar = () => {
     const isMac = isMacOS();
     const iconSize = isMac ? 10 : 16;
     const iconColor = isMac ? colors.NEUE_TYPE_DARK_GREY : colors.NEUE_TYPE_LIGHT_GREY;
+    const isMacNotHovering = !isMac || hover !== '';
+    const isNotMacHovering = (btn: string) => !isMac && hover === btn;
 
     return (
         <Titlebar>
@@ -133,9 +135,9 @@ const DesktopTitlebar = () => {
                     onMouseEnter={mouseEnter}
                     onMouseLeave={mouseLeave}
                 >
-                    {(!isMac || hover !== '') && (
+                    {isMacNotHovering && (
                         <Icon
-                            color={!isMac && hover === 'close' ? colors.WHITE : iconColor}
+                            color={isNotMacHovering('close') ? colors.WHITE : iconColor}
                             size={iconSize}
                             icon="WINDOW_CLOSE"
                         />
@@ -148,9 +150,9 @@ const DesktopTitlebar = () => {
                     onMouseEnter={mouseEnter}
                     onMouseLeave={mouseLeave}
                 >
-                    {(!isMac || hover !== '') && (
+                    {isMacNotHovering && (
                         <Icon
-                            color={!isMac && hover === 'minimize' ? colors.WHITE : iconColor}
+                            color={isNotMacHovering('minimize') ? colors.WHITE : iconColor}
                             size={iconSize}
                             icon="WINDOW_MINIMIZE"
                         />
@@ -164,9 +166,9 @@ const DesktopTitlebar = () => {
                         onMouseEnter={mouseEnter}
                         onMouseLeave={mouseLeave}
                     >
-                        {(!isMac || hover !== '') && (
+                        {isMacNotHovering && (
                             <Icon
-                                color={!isMac && hover === 'restore' ? colors.WHITE : iconColor}
+                                color={isNotMacHovering('restore') ? colors.WHITE : iconColor}
                                 size={iconSize}
                                 icon="WINDOW_RESTORE"
                             />
@@ -180,9 +182,9 @@ const DesktopTitlebar = () => {
                         onMouseEnter={mouseEnter}
                         onMouseLeave={mouseLeave}
                     >
-                        {(!isMac || hover !== '') && (
+                        {isMacNotHovering && (
                             <Icon
-                                color={!isMac && hover === 'maximize' ? colors.WHITE : iconColor}
+                                color={isNotMacHovering('maximize') ? colors.WHITE : iconColor}
                                 size={iconSize}
                                 icon="WINDOW_MAXIMIZE"
                             />

--- a/packages/suite-desktop/src/support/DesktopTitlebar.tsx
+++ b/packages/suite-desktop/src/support/DesktopTitlebar.tsx
@@ -41,7 +41,7 @@ const Actions = styled.div<{ isMac?: boolean }>`
     margin: ${props => (props.isMac ? '0 10px' : '0')};
 `;
 
-const Action = styled.div<{ isMac?: boolean }>`
+const Action = styled.div<{ isMac?: boolean; isDisabled?: boolean }>`
     width: ${props => (props.isMac ? 14 : TITLEBAR_HEIGHT)}px;
     height: ${props => (props.isMac ? 14 : TITLEBAR_HEIGHT)}px;
     margin: ${props => (props.isMac ? 2 : 0)}px;
@@ -67,12 +67,19 @@ const ActionClose = styled(Action)`
 `;
 
 const ActionMinimize = styled(Action)`
-    background: ${props => (props.isMac ? '#fabe3e' : 'transparent')};
     order: ${props => (props.isMac ? '0' : '1')};
-
-    &:hover {
-        background: ${props => (props.isMac ? '#fabe3e' : colors.NEUE_TYPE_LIGHT_GREY)};
-    }
+    ${props =>
+        props.isDisabled
+            ? `
+                background: ${colors.NEUE_TYPE_LIGHT_GREY};
+                cursor: auto;
+            `
+            : `
+                background: ${props.isMac ? '#fabe3e' : 'transparent'};
+                &:hover {
+                    background: ${props.isMac ? '#fabe3e' : colors.NEUE_TYPE_LIGHT_GREY};
+                }
+            `}
 `;
 
 const ActionMaximize = styled(Action)`
@@ -121,6 +128,7 @@ const DesktopTitlebar = () => {
     const isMac = isMacOS();
     const iconSize = isMac ? 10 : 16;
     const iconColor = isMac ? colors.NEUE_TYPE_DARK_GREY : colors.NEUE_TYPE_LIGHT_GREY;
+    const isMinimizedDisabled = isMac && maximized;
     const isMacNotHovering = !isMac || hover !== '';
     const isNotMacHovering = (btn: string) => !isMac && hover === btn;
 
@@ -145,12 +153,15 @@ const DesktopTitlebar = () => {
                 </ActionClose>
                 <ActionMinimize
                     isMac={isMac}
-                    onClick={() => window.desktopApi!.windowMinimize()}
+                    isDisabled={isMinimizedDisabled}
+                    onClick={
+                        isMinimizedDisabled ? undefined : () => window.desktopApi!.windowMinimize()
+                    }
                     data-button="minimize"
-                    onMouseEnter={mouseEnter}
-                    onMouseLeave={mouseLeave}
+                    onMouseEnter={isMinimizedDisabled ? undefined : mouseEnter}
+                    onMouseLeave={isMinimizedDisabled ? undefined : mouseLeave}
                 >
-                    {isMacNotHovering && (
+                    {isMacNotHovering && !isMinimizedDisabled && (
                         <Icon
                             color={isNotMacHovering('minimize') ? colors.WHITE : iconColor}
                             size={iconSize}


### PR DESCRIPTION
This change addresses the following issues:
- Buttons were not clickable (drag area was overlaying them).
- Maximize/Unmaximize state was properly set.
- Maximize/Unmaximize is now setting the window to fullscreen on Mac (as it's commonly done on this platform).

Also includes visual changes:
- Reduced height of the title bar from 40px to 28px.
- Win/Linux buttons get highlighted on hover and have a background (grey for all buttons except close which has a red background).
- Icons in Mac buttons get displayed on hover (mimic native system behaviour).
- Increased icon size for Mac.

Future improvements (not part of this PR):
- Mac specific icons for maximize/unmaximize buttons.

**Current**
![Win/Linux](https://i.imgur.com/ZoVtrTJ.gif)
![Mac](https://i.imgur.com/rLZysAe.gif)

**New**
![Win/Linux](https://i.imgur.com/4ne2kLC.gif)
![Mac](https://i.imgur.com/vWZYbDg.gif)