### PR TITLE
fix(suite): discreet effect cut off

### DIFF
--- a/packages/suite/src/views/wallet/transactions/components/TransactionList/components/TransactionItem/components/BaseTargetLayout/index.tsx
+++ b/packages/suite/src/views/wallet/transactions/components/TransactionList/components/TransactionItem/components/BaseTargetLayout/index.tsx
@@ -59,6 +59,8 @@ const TargetAddress = styled(motion.div)`
     text-overflow: ellipsis;
     font-variant-numeric: tabular-nums slashed-zero;
     margin-right: 4px;
+    padding-left: 10px;
+    margin-left: -10px;
 `;
 
 const TimelineDotWrapper = styled.div`

--- a/packages/suite/src/views/wallet/transactions/components/TransactionList/components/TransactionItem/index.tsx
+++ b/packages/suite/src/views/wallet/transactions/components/TransactionList/components/TransactionItem/index.tsx
@@ -39,6 +39,8 @@ const Content = styled.div`
     display: flex;
     flex: 1;
     overflow: hidden;
+    padding: 10px;
+    margin: -10px;
     flex-direction: column;
     font-variant-numeric: tabular-nums;
 `;
@@ -65,6 +67,8 @@ const TargetsWrapper = styled.div`
     flex-direction: column;
     flex: 1;
     overflow: hidden;
+    padding-right: 10px;
+    margin-right: -10px;
 `;
 
 const ExpandButton = styled(Button)`


### PR DESCRIPTION
Fixing discreet mode blur cut offs in Accounts/Transactions section.

I tried a couple of obscure solutions using backdrop filters and absolute positioning of blurred elements and I also tried to disable `overflow: hidden` in Transations section but finally I came up with this rather elegant solution without any obscure hacks.

Hopefully it will work in all browsers.