### PR TITLE
fix: use buy crypto payment method icons tailored for Suite, improve design

### DIFF
--- a/packages/suite/src/components/wallet/CoinmarketBuyOfferInfo/index.tsx
+++ b/packages/suite/src/components/wallet/CoinmarketBuyOfferInfo/index.tsx
@@ -66,6 +66,7 @@ const LeftColumn = styled.div`
     text-transform: uppercase;
     font-weight: ${variables.FONT_WEIGHT.MEDIUM};
     color: ${colors.NEUE_TYPE_LIGHT_GREY};
+    align-self: center;
 `;
 
 const RightColumn = styled.div`

--- a/packages/suite/src/components/wallet/CoinmarketBuyProviderInfo/index.tsx
+++ b/packages/suite/src/components/wallet/CoinmarketBuyProviderInfo/index.tsx
@@ -9,7 +9,16 @@ const Wrapper = styled.div`
     align-items: center;
 `;
 
-const Icon = styled.img``;
+const IconWrapper = styled.div`
+    display: flex;
+    align-items: center;
+    padding-left: 4px;
+    padding-right: 8px;
+`;
+
+const Icon = styled.img`
+    border-radius: 2px;
+`;
 
 const Text = styled.div`
     display: flex;
@@ -35,10 +44,12 @@ const CoinmarketBuyProviderInfo = ({ exchange, providers }: Props) => {
             {!provider && exchange}
             {provider && (
                 <>
-                    <Icon
-                        width="16px"
-                        src={`${invityApi.server}/images/exchange/${provider.logo}`}
-                    />
+                    <IconWrapper>
+                        <Icon
+                            width="16px"
+                            src={`${invityApi.server}/images/exchange/${provider.logo}`}
+                        />
+                    </IconWrapper>
                     <Text>{provider.companyName}</Text>
                 </>
             )}

--- a/packages/suite/src/components/wallet/CoinmarketPaymentType/index.tsx
+++ b/packages/suite/src/components/wallet/CoinmarketPaymentType/index.tsx
@@ -3,6 +3,7 @@ import styled from 'styled-components';
 import { colors, variables } from '@trezor/components';
 import invityApi from '@suite-services/invityAPI';
 import { BuyCryptoPaymentMethod } from 'invity-api';
+import { Translation } from '@suite-components';
 
 const Wrapper = styled.div`
     display: flex;
@@ -12,7 +13,7 @@ const Wrapper = styled.div`
 const IconWrapper = styled.div`
     display: flex;
     align-items: center;
-    padding-right: 8px;
+    padding-right: 9px;
 `;
 
 const Icon = styled.img``;
@@ -30,14 +31,22 @@ interface Props {
 
 const CoinmarketPaymentType = ({ method }: Props) => (
     <Wrapper>
-        {!method && <Text>Unknown payment method</Text>}
+        {!method && (
+            <Text>
+                <Translation id="TR_PAYMENT_METHOD_UNKOWN" />
+            </Text>
+        )}
         {method && (
-            <IconWrapper>
-                <Icon
-                    width="40px"
-                    src={`${invityApi.server}/images/paymentMethods/${method}.svg`}
-                />
-            </IconWrapper>
+            <>
+                <IconWrapper>
+                    <Icon
+                        width="24px"
+                        src={`${invityApi.server}/images/paymentMethods/suite/${method}.svg`}
+                    />
+                </IconWrapper>
+                {/* temporary solution - payment mehtod name will be returned by API server to be independent on translations */}
+                <Translation id={`TR_PAYMENT_METHOD_${method.toUpperCase()}` as any} />
+            </>
         )}
     </Wrapper>
 );

--- a/packages/suite/src/support/messages.ts
+++ b/packages/suite/src/support/messages.ts
@@ -3024,13 +3024,45 @@ const definedMessages = defineMessages({
         id: 'TR_COINMARKET_EXCHANGES',
         defaultMessage: 'exchanges',
     },
-    TR_PAYMENT_METHOD_CARD: {
-        id: 'TR_PAYMENT_METHOD_CARD',
+    TR_PAYMENT_METHOD_CREDITCARD: {
+        id: 'TR_PAYMENT_METHOD_CREDITCARD',
         defaultMessage: 'Credit Card',
     },
-    TR_PAYMENT_METHOD_BANK_TRANSFER: {
-        id: 'TR_PAYMENT_METHOD_BANK_TRANSFER',
-        defaultMessage: 'Bank transfer',
+    TR_PAYMENT_METHOD_BANKTRANSFER: {
+        id: 'TR_PAYMENT_METHOD_BANKTRANSFER',
+        defaultMessage: 'Bank Transfer',
+    },
+    TR_PAYMENT_METHOD_BANCONTACT: {
+        id: 'TR_PAYMENT_METHOD_BANCONTACT',
+        defaultMessage: 'Bancontact',
+    },
+    TR_PAYMENT_METHOD_SOFORT: {
+        id: 'TR_PAYMENT_METHOD_SOFORT',
+        defaultMessage: 'Sofort',
+    },
+    TR_PAYMENT_METHOD_IDEAL: {
+        id: 'TR_PAYMENT_METHOD_IDEAL',
+        defaultMessage: 'iDEAL',
+    },
+    TR_PAYMENT_METHOD_SEPA: {
+        id: 'TR_PAYMENT_METHOD_SEPA',
+        defaultMessage: 'SEPA',
+    },
+    TR_PAYMENT_METHOD_GIROPAY: {
+        id: 'TR_PAYMENT_METHOD_CREDITCARD',
+        defaultMessage: 'giropay',
+    },
+    TR_PAYMENT_METHOD_EPS: {
+        id: 'TR_PAYMENT_METHOD_EPS',
+        defaultMessage: 'eps',
+    },
+    TR_PAYMENT_METHOD_APPLEPAY: {
+        id: 'TR_PAYMENT_METHOD_APPLEPAY',
+        defaultMessage: 'Apple Pay',
+    },
+    TR_PAYMENT_METHOD_UNKOWN: {
+        id: 'TR_PAYMENT_METHOD_UNKOWN',
+        defaultMessage: 'Unknown',
     },
     TR_OFFER_FEE_INFO: {
         id: 'TR_OFFER_FEE_INFO',

--- a/packages/suite/src/views/wallet/coinmarket/buy/detail/Detail/index.tsx
+++ b/packages/suite/src/views/wallet/coinmarket/buy/detail/Detail/index.tsx
@@ -82,6 +82,7 @@ const CoinmarketDetail = () => {
                         account={account}
                         selectedQuote={trade.data}
                         transactionId={trade.key}
+                        providers={buyInfo?.providerInfos}
                     />
                 </>
             )}

--- a/packages/suite/src/views/wallet/coinmarket/buy/offers/Offers/SelectedOffer/index.tsx
+++ b/packages/suite/src/views/wallet/coinmarket/buy/offers/Offers/SelectedOffer/index.tsx
@@ -20,7 +20,7 @@ const StyledCard = styled(Card)`
 `;
 
 const SelectedOffer = () => {
-    const { account, selectedQuote } = useCoinmarketBuyOffersContext();
+    const { account, selectedQuote, providersInfo } = useCoinmarketBuyOffersContext();
     if (!selectedQuote) return null;
 
     return (
@@ -28,7 +28,11 @@ const SelectedOffer = () => {
             <StyledCard>
                 <VerifyAddress />
             </StyledCard>
-            <CoinmarketBuyOfferInfo selectedQuote={selectedQuote} account={account} />
+            <CoinmarketBuyOfferInfo
+                selectedQuote={selectedQuote}
+                account={account}
+                providers={providersInfo}
+            />
         </Wrapper>
     );
 };


### PR DESCRIPTION
This change does minor visual improvements to the buy process:
1) use payment method icons tailored for Suite
2) add name of the payment method next to the icon
3) fix size and alignment of payment method and provider icons
4) show partner business name instead of partner key in the selected offer