### PR TITLE
fix(metadata): fix rerender of address metadata

### DIFF
--- a/packages/suite/src/components/suite/Labeling/components/Metadata/index.tsx
+++ b/packages/suite/src/components/suite/Labeling/components/Metadata/index.tsx
@@ -132,7 +132,7 @@ const ButtonLikeLabel = (props: ExtendedProps) => {
 };
 
 const TextLikeLabel = (props: ExtendedProps) => {
-    const EditableLabel = withEditable(Label);
+    const EditableLabel = useMemo(() => withEditable(Label), []);
 
     if (props.editActive) {
         return (


### PR DESCRIPTION
This PR shall fix #2632 issue. It works in practice but I don't like it very much. According to react docs:
 
> You may rely on useMemo as a performance optimization, not as a semantic guarantee. In the future, React may choose to “forget” some previously memoized values and recalculate them on next render, e.g. to free memory for offscreen components. Write your code so that it still works without useMemo — and then add it to optimize performance.

I'd say it would be better to fix it by ditching using `useState` for `isHovered` and replace it with css hover instead. 
There are always 3 grid elements, so something like this could work:
1st element on hover -> set 2nd sibling child to visible
2nd element on hover -> set 1st sibling child to visible
3rd element on hover -> set own child to visible. 

what do you think @slowbackspace 