### PR TITLE
feat(metadata): display address label as a fallback in tx lists if tx…

### DIFF
--- a/packages/suite/src/views/wallet/transactions/components/TransactionList/components/TransactionItem/components/Target/index.tsx
+++ b/packages/suite/src/views/wallet/transactions/components/TransactionList/components/TransactionItem/components/Target/index.tsx
@@ -12,6 +12,7 @@ import TokenTransferAddressLabel from '../TokenTransferAddressLabel';
 import TargetAddressLabel from '../TargetAddressLabel';
 import BaseTargetLayout from '../BaseTargetLayout';
 import { copyToClipboard } from '@suite-utils/dom';
+import { AccountMetadata } from '@suite-types/metadata';
 
 const StyledHiddenPlaceholder = styled(HiddenPlaceholder)`
     /* padding: 8px 0px; row padding */
@@ -61,19 +62,20 @@ interface TargetProps {
     isFirst?: boolean;
     isLast?: boolean;
     accountKey: string;
-    targetMetadata?: string;
+    accountMetadata?: AccountMetadata;
 }
 
 export const Target = ({
     target,
     transaction,
-    targetMetadata,
+    accountMetadata,
     accountKey,
     ...baseLayoutProps
 }: TargetProps) => {
     const targetAmount = getTargetAmount(target, transaction);
     const operation = getTxOperation(transaction);
     const { addNotification } = useActions({ addNotification: notificationActions.addToast });
+    const targetMetadata = accountMetadata?.outputLabels?.[transaction.txid]?.[target.n];
 
     return (
         <BaseTargetLayout
@@ -81,7 +83,11 @@ export const Target = ({
             addressLabel={
                 <MetadataLabeling
                     defaultVisibleValue={
-                        <TargetAddressLabel target={target} type={transaction.type} />
+                        <TargetAddressLabel
+                            accountMetadata={accountMetadata}
+                            target={target}
+                            type={transaction.type}
+                        />
                     }
                     dropdownOptions={[
                         {

--- a/packages/suite/src/views/wallet/transactions/components/TransactionList/components/TransactionItem/components/TargetAddressLabel/index.tsx
+++ b/packages/suite/src/views/wallet/transactions/components/TransactionList/components/TransactionItem/components/TargetAddressLabel/index.tsx
@@ -3,6 +3,7 @@ import styled from 'styled-components';
 import { WalletAccountTransaction } from '@wallet-types';
 import { ArrayElement } from '@suite/types/utils';
 import { Translation, AddressLabeling } from '@suite-components';
+import { AccountMetadata } from '@suite-types/metadata';
 
 const TruncatedSpan = styled.span`
     overflow: hidden;
@@ -12,19 +13,35 @@ const TruncatedSpan = styled.span`
 interface Props {
     target: ArrayElement<WalletAccountTransaction['targets']>;
     type: WalletAccountTransaction['type'];
+    accountMetadata?: AccountMetadata;
 }
-const TargetAddressLabel = ({ target, type }: Props) => {
+const TargetAddressLabel = ({ target, type, accountMetadata }: Props) => {
     const isLocalTarget = (type === 'sent' || type === 'self') && target.isAccountTarget;
-    const addressLabel = isLocalTarget ? (
-        <Translation id="TR_SENT_TO_SELF" />
-    ) : (
-        target.addresses?.map((a, i) =>
-            // Using index as a key is safe as the array doesn't change (no filter/reordering, pushing new items)
-            // eslint-disable-next-line react/no-array-index-key
-            type === 'sent' ? <AddressLabeling key={i} address={a} /> : <span key={i}>{a}</span>,
-        )
+
+    if (isLocalTarget) {
+        return (
+            <TruncatedSpan>
+                <Translation id="TR_SENT_TO_SELF" />
+            </TruncatedSpan>
+        );
+    }
+
+    return (
+        <TruncatedSpan>
+            {target.addresses?.map((a, i) =>
+                // either it may be AddressLabeling - sent to another account associated with this device, e.g: "Bitcoin #2"
+                // or it may show address metadata label added from receive tab e.g "My address for illegal things"
+                type === 'sent' ? (
+                    // Using index as a key is safe as the array doesn't change (no filter/reordering, pushing new items)
+                    // eslint-disable-next-line react/no-array-index-key
+                    <AddressLabeling key={i} address={a} />
+                ) : (
+                    // eslint-disable-next-line react/no-array-index-key
+                    <span key={i}>{accountMetadata?.addressLabels[a] || a}</span>
+                ),
+            )}
+        </TruncatedSpan>
     );
-    return <TruncatedSpan>{addressLabel}</TruncatedSpan>;
 };
 
 export default TargetAddressLabel;

--- a/packages/suite/src/views/wallet/transactions/components/TransactionList/components/TransactionItem/index.tsx
+++ b/packages/suite/src/views/wallet/transactions/components/TransactionList/components/TransactionItem/index.tsx
@@ -85,12 +85,12 @@ const DEFAULT_LIMIT = 3;
 interface Props {
     transaction: WalletAccountTransaction;
     isPending: boolean;
-    txMetadata?: AccountMetadata['outputLabels'][keyof AccountMetadata['outputLabels']];
+    accountMetadata?: AccountMetadata;
     accountKey: string;
 }
 
 const TransactionItem = React.memo((props: Props) => {
-    const { transaction, txMetadata, accountKey } = props;
+    const { transaction, accountKey, accountMetadata } = props;
     const { type, targets, tokens } = transaction;
     const [limit, setLimit] = useState(0);
     const isTokenTransaction = tokens.length > 0;
@@ -170,7 +170,7 @@ const TransactionItem = React.memo((props: Props) => {
                                         singleRowLayout={hasSingleTargetOrTransfer}
                                         isFirst={i === 0}
                                         isLast={limit > 0 ? false : i === previewTargets.length - 1} // if list of targets is expanded we won't get last item here
-                                        targetMetadata={txMetadata && txMetadata[t.n]}
+                                        accountMetadata={accountMetadata}
                                         accountKey={accountKey}
                                     />
                                 ))}
@@ -192,7 +192,7 @@ const TransactionItem = React.memo((props: Props) => {
                                                             : i ===
                                                               targets.length - DEFAULT_LIMIT - 1
                                                     }
-                                                    targetMetadata={txMetadata && txMetadata[t.n]}
+                                                    accountMetadata={accountMetadata}
                                                     accountKey={accountKey}
                                                 />
                                             ))}

--- a/packages/suite/src/views/wallet/transactions/components/TransactionList/index.tsx
+++ b/packages/suite/src/views/wallet/transactions/components/TransactionList/index.tsx
@@ -118,7 +118,7 @@ const TransactionList = ({
                                         key={tx.txid}
                                         transaction={tx}
                                         isPending={isPending}
-                                        txMetadata={account.metadata.outputLabels[tx.txid]}
+                                        accountMetadata={account.metadata}
                                         accountKey={account.key}
                                     />
                                 ))}


### PR DESCRIPTION
… label does not exist yet

We should revisit labeling terminlogy and architecture, it starts being somewhat convoluted.

### "built in internal labeling" 
![image](https://user-images.githubusercontent.com/30367552/97304861-9d4c1900-185c-11eb-964c-992007ecd618.png)

### "metadata fallback labeling"
you may label address
![image](https://user-images.githubusercontent.com/30367552/97305001-d1bfd500-185c-11eb-99cd-fdcb2e3d0f20.png)

and see it in tx list (added in this PR)
![image](https://user-images.githubusercontent.com/30367552/97305071-eac88600-185c-11eb-9826-5d11537b29c9.png)
btw this should probably apply also for account (see bitcoin 2 in "built in internal labelling"), if there is a metadata label for this account, it should display instead of internal default label?

### and user defined metadata direct labeling 
![image](https://user-images.githubusercontent.com/30367552/97305239-21060580-185d-11eb-99c4-bd064c4a0f84.png)


As for this PR, I changed behaviour of items in tx list to show address metadata label if there is no tx label yet but address metadata label already exists, this should resolve #2648

