### PR TITLE
chore(electron): invoke/handle

### DIFF
--- a/packages/suite-desktop/src-electron/electron.ts
+++ b/packages/suite-desktop/src-electron/electron.ts
@@ -372,9 +372,9 @@ httpReceiver.on('server/listening', () => {
     });
 
     // when httpReceiver was asked to provide current address for given pathname
-    ipcMain.on('server/request-address', (_event, pathname) => {
-        mainWindow.webContents.send('server/address', httpReceiver.getRouteAddress(pathname));
-    });
+    ipcMain.handle('server/request-address', (_event, pathname) =>
+        httpReceiver.getRouteAddress(pathname),
+    );
 });
 
 metadata.init();

--- a/packages/suite-desktop/src-electron/preload.ts
+++ b/packages/suite-desktop/src-electron/preload.ts
@@ -68,4 +68,7 @@ contextBridge.exposeInMainWorld('desktopApi', {
     metadataRead: (options: { file: string }) => ipcRenderer.invoke('metadata/read', options),
     metadataWrite: (options: { file: string; content: string }) =>
         ipcRenderer.invoke('metadata/write', options),
+
+    // HttpReceiver
+    getHttpReceiverAddress: (route: string) => ipcRenderer.invoke('server/request-address', route),
 });

--- a/packages/suite/global.d.ts
+++ b/packages/suite/global.d.ts
@@ -26,6 +26,8 @@ export interface DesktopApi {
     metadataRead: (options: {
         file: string;
     }) => Promise<{ success: true; payload: string } | { success: false; error: string }>;
+    // HttpReceiver
+    getHttpReceiverAddress: (route: string) => Promise<string>;
 }
 
 declare global {

--- a/packages/suite/src/utils/suite/oauth.ts
+++ b/packages/suite/src/utils/suite/oauth.ts
@@ -12,20 +12,7 @@ export const getOauthReceiverUrl = () => {
         return `${window.location.origin}${getPrefixedURL('/static/oauth/oauth_receiver.html')}`;
     }
 
-    // for desktop
-    // start oauth-receiver http service and wait for address
-    return new Promise<string>((resolve, reject) => {
-        const onGetServerAddress = (message: string) => {
-            window.desktopApi!.off('server/address', onGetServerAddress);
-            if (message) {
-                return resolve(message);
-            }
-            return reject(new Error('no response'));
-        };
-
-        window.desktopApi!.on('server/address', onGetServerAddress);
-        window.desktopApi!.send('server/request-address', '/oauth');
-    });
+    return window.desktopApi!.getHttpReceiverAddress('/oauth');
 };
 
 /**


### PR DESCRIPTION
`handle` - `invoke` electron api seems to be something we want to use instead of `send` - `on`/`off`. It is easier to read and you don't run into the problem of forgetting to deregister event listener using `off`.

