### PR TITLE
refactor useDiscovery and usage of useSelector  hooks

### DIFF
--- a/packages/suite/jest.config.js
+++ b/packages/suite/jest.config.js
@@ -39,6 +39,7 @@ module.exports = {
         '<rootDir>/src/utils/**',
         '<rootDir>/src/actions/**',
         '<rootDir>/src/middlewares/**',
+        '<rootDir>/src/hooks/suite/useDiscovery.ts',
         '<rootDir>/src/hooks/suite/useDebounce.ts',
         '<rootDir>/src/hooks/wallet/useSendForm.ts',
         '<rootDir>/src/hooks/wallet/useSendFormCompose.ts',
@@ -53,10 +54,10 @@ module.exports = {
     ],
     coverageThreshold: {
         global: {
-            statements: 63,
-            branches: 55,
-            functions: 63,
-            lines: 63,
+            statements: 65,
+            branches: 58,
+            functions: 66,
+            lines: 65,
         },
     },
     modulePathIgnorePatterns: [

--- a/packages/suite/package.json
+++ b/packages/suite/package.json
@@ -61,9 +61,10 @@
     "devDependencies": {
         "@babel/plugin-syntax-dynamic-import": "^7.8.3",
         "@next/bundle-analyzer": "^9.2.1",
-        "@testing-library/dom": "^7.24.2",
-        "@testing-library/react": "^11.0.4",
-        "@testing-library/user-event": "^12.1.5",
+        "@testing-library/dom": "^7.26.3",
+        "@testing-library/react": "^11.1.0",
+        "@testing-library/react-hooks": "^3.4.2",
+        "@testing-library/user-event": "^12.1.10",
         "@trezor/translations-manager": "^1.0.0",
         "@types/invity-api": "^1.0.0",
         "@types/node-fetch": "^2.5.5",

--- a/packages/suite/src/components/suite/AppNavigation/index.tsx
+++ b/packages/suite/src/components/suite/AppNavigation/index.tsx
@@ -72,8 +72,10 @@ interface Props {
 }
 
 const AppNavigation = ({ items }: Props) => {
-    const routeName = useSelector(state => state.router.route?.name);
-    const { params } = useSelector(state => state.wallet.selectedAccount);
+    const { routeName, params } = useSelector(state => ({
+        routeName: state.router.route?.name,
+        params: state.wallet.selectedAccount.params,
+    }));
     const { goto } = useActions({
         goto: routerActions.goto,
     });

--- a/packages/suite/src/components/suite/NavigationBar/components/DeviceSelector/index.tsx
+++ b/packages/suite/src/components/suite/NavigationBar/components/DeviceSelector/index.tsx
@@ -84,8 +84,10 @@ const needsRefresh = (device?: TrezorDevice) => {
 };
 
 const DeviceSelector = (props: React.HTMLAttributes<HTMLDivElement>) => {
-    const selectedDevice = useSelector(state => state.suite.device);
-    const deviceCount = useSelector(state => state.devices).length;
+    const { selectedDevice, deviceCount } = useSelector(state => ({
+        selectedDevice: state.suite.device,
+        deviceCount: state.devices.length,
+    }));
     const { goto, acquireDevice } = useActions({
         goto: routerActions.goto,
         acquireDevice: suiteActions.acquireDevice,

--- a/packages/suite/src/components/suite/NavigationBar/components/NavigationActions/index.tsx
+++ b/packages/suite/src/components/suite/NavigationBar/components/NavigationActions/index.tsx
@@ -28,9 +28,11 @@ interface Props {
 
 const NavigationActions = (props: Props) => {
     const analytics = useAnalytics();
-    const activeApp = useSelector(state => state.router.app);
-    const notifications = useSelector(state => state.notifications);
-    const discreetMode = useSelector(state => state.wallet.settings.discreetMode);
+    const { activeApp, notifications, discreetMode } = useSelector(state => ({
+        activeApp: state.router.app,
+        notifications: state.notifications,
+        discreetMode: state.wallet.settings.discreetMode,
+    }));
     const { goto, setDiscreetMode } = useActions({
         goto: routerActions.goto,
         setDiscreetMode: walletSettingsActions.setDiscreetMode,

--- a/packages/suite/src/components/suite/Ticker/index.tsx
+++ b/packages/suite/src/components/suite/Ticker/index.tsx
@@ -25,10 +25,10 @@ interface Props {
 }
 const Ticker = ({ symbol, tooltipPos = 'top' }: Props) => {
     const rateAge = (timestamp: number) => differenceInMinutes(new Date(timestamp), new Date());
-    const lastWeekRates = useSelector(state => state.wallet.fiat.coins).find(
-        r => r.symbol === symbol,
-    )?.lastWeek;
-    const localCurrency = useSelector(state => state.wallet.settings.localCurrency);
+    const { lastWeekRates, localCurrency } = useSelector(state => ({
+        lastWeekRates: state.wallet.fiat.coins.find(r => r.symbol === symbol)?.lastWeek,
+        localCurrency: state.wallet.settings.localCurrency,
+    }));
     const lastWeekData = lastWeekRates?.tickers ?? [];
 
     let rateGoingUp = false;

--- a/packages/suite/src/components/wallet/AccountsMenu/components/AccountSearchBox/index.tsx
+++ b/packages/suite/src/components/wallet/AccountsMenu/components/AccountSearchBox/index.tsx
@@ -67,8 +67,10 @@ interface Props {
 
 const AccountSearchBox = (props: Props) => {
     const { coinFilter, setCoinFilter, searchString, setSearchString } = useAccountSearch();
-    const enabledNetworks = useSelector(state => state.wallet.settings.enabledNetworks);
-    const device = useSelector(state => state.suite.device);
+    const { enabledNetworks, device } = useSelector(state => ({
+        enabledNetworks: state.wallet.settings.enabledNetworks,
+        device: state.suite.device,
+    }));
 
     const unavailableCapabilities = device?.unavailableCapabilities ?? {};
     const supportedNetworks = enabledNetworks.filter(symbol => !unavailableCapabilities[symbol]);

--- a/packages/suite/src/components/wallet/CoinmarketLayout/components/AccountTransactions/index.tsx
+++ b/packages/suite/src/components/wallet/CoinmarketLayout/components/AccountTransactions/index.tsx
@@ -39,9 +39,11 @@ const TransactionCount = styled.div`
 `;
 
 const AccountTransactions = () => {
-    const allTransactions = useSelector(state => state.wallet.coinmarket.trades);
-    const selectedAccount = useSelector(state => state.wallet.selectedAccount);
-    const providers = useSelector(state => state.wallet.coinmarket.buy.buyInfo?.providerInfos);
+    const { selectedAccount, allTransactions, providers } = useSelector(state => ({
+        selectedAccount: state.wallet.selectedAccount,
+        allTransactions: state.wallet.coinmarket.trades,
+        providers: state.wallet.coinmarket.buy.buyInfo?.providerInfos,
+    }));
 
     if (selectedAccount.status !== 'loaded') {
         return null;

--- a/packages/suite/src/hooks/suite/__fixtures__/useDiscovery.ts
+++ b/packages/suite/src/hooks/suite/__fixtures__/useDiscovery.ts
@@ -1,0 +1,209 @@
+import { SUITE } from '@suite-actions/constants';
+import { DISCOVERY } from '@wallet-actions/constants';
+
+const { getSuiteDevice } = global.JestMocks;
+const DEV = getSuiteDevice();
+
+export const actions = [
+    {
+        action: {
+            type: SUITE.SELECT_DEVICE,
+            payload: undefined,
+        },
+        renders: 1,
+        result: {
+            running: undefined,
+            status: { type: 'waiting-for-device' },
+        },
+    },
+    {
+        action: {
+            type: SUITE.SELECT_DEVICE,
+            payload: DEV,
+        },
+        renders: 2,
+        result: {
+            running: undefined,
+            status: { type: 'auth' },
+        },
+    },
+    {
+        action: {
+            type: SUITE.UPDATE_SELECTED_DEVICE,
+            payload: DEV,
+        },
+        renders: 2, // update of exact same device shouldn't cause render
+        result: {
+            running: undefined,
+            status: { type: 'auth' },
+        },
+    },
+    {
+        action: {
+            type: SUITE.UPDATE_SELECTED_DEVICE,
+            payload: getSuiteDevice({ state: 'deviceState' }),
+        },
+        renders: 3,
+        result: {
+            running: undefined,
+            status: undefined, // normally DISCOVERY.CREATE is called before SUITE.UPDATE_SELECTED_DEVICE, this is here only for coverage
+        },
+    },
+    {
+        action: {
+            type: DISCOVERY.CREATE,
+            payload: {
+                deviceState: 'deviceState',
+                authConfirm: true,
+                status: DISCOVERY.STATUS.IDLE,
+                total: 10,
+                loaded: 0,
+                networks: [],
+                failed: [],
+            },
+        },
+        renders: 4,
+        result: {
+            status: { type: 'auth-confirm' },
+        },
+    },
+    {
+        action: {
+            type: DISCOVERY.UPDATE,
+            payload: { deviceState: 'deviceState', status: DISCOVERY.STATUS.RUNNING, loaded: 2 },
+        },
+        renders: 5,
+        result: {
+            running: true,
+            status: { type: 'auth-confirm' },
+            progress: 20,
+        },
+    },
+    {
+        action: {
+            type: DISCOVERY.UPDATE,
+            payload: { deviceState: 'deviceState', authConfirm: false },
+        },
+        renders: 6,
+        result: {
+            running: true,
+            status: { type: 'discovery' },
+            progress: 20,
+        },
+    },
+    {
+        action: {
+            type: DISCOVERY.UPDATE,
+            payload: {
+                deviceState: 'deviceState',
+                status: DISCOVERY.STATUS.COMPLETED,
+                authConfirm: true,
+            },
+        },
+        renders: 7,
+        result: {
+            running: false,
+            status: { type: 'auth-confirm' },
+        },
+    },
+    {
+        action: {
+            type: SUITE.UPDATE_SELECTED_DEVICE,
+            payload: getSuiteDevice({ authFailed: true }),
+        },
+        renders: 8,
+        result: {
+            running: undefined,
+            status: { type: 'auth-failed' },
+        },
+    },
+    {
+        action: {
+            type: SUITE.UPDATE_SELECTED_DEVICE,
+            payload: getSuiteDevice({ authConfirm: true }),
+        },
+        renders: 9,
+        result: {
+            running: undefined,
+            status: { type: 'auth-confirm-failed' },
+        },
+    },
+    {
+        action: {
+            type: SUITE.UPDATE_SELECTED_DEVICE,
+            payload: getSuiteDevice({ state: 'deviceState', available: false }), // available is used in one test case
+        },
+        renders: 10,
+        result: {},
+    },
+    {
+        action: {
+            type: DISCOVERY.UPDATE,
+            payload: { deviceState: 'deviceState', authConfirm: false },
+        },
+        renders: 11,
+        result: {
+            running: false,
+            status: { type: 'discovery-empty' },
+        },
+    },
+    {
+        action: {
+            type: DISCOVERY.UPDATE,
+            payload: {
+                deviceState: 'deviceState',
+                networks: ['btc'],
+                failed: ['btc'],
+            },
+        },
+        renders: 12,
+        result: {
+            running: false,
+            status: { type: 'discovery-failed' },
+        },
+    },
+    {
+        action: {
+            type: DISCOVERY.UPDATE,
+            payload: {
+                deviceState: 'deviceState',
+                failed: [],
+                error: 'some error',
+            },
+        },
+        renders: 13,
+        result: {
+            running: false,
+            status: { type: 'discovery-failed' },
+        },
+    },
+    {
+        action: {
+            type: DISCOVERY.UPDATE,
+            payload: {
+                deviceState: 'deviceState',
+                networks: ['btc'],
+                errorCode: 'Device_InvalidState',
+            },
+        },
+        renders: 14,
+        result: {
+            running: false,
+            status: { type: 'device-unavailable' },
+        },
+    },
+    {
+        action: {
+            type: DISCOVERY.UPDATE,
+            payload: {
+                deviceState: 'deviceState',
+                errorCode: undefined,
+            },
+        },
+        renders: 15,
+        result: {
+            running: false,
+            status: undefined, // this should never happen, only for coverage
+        },
+    },
+];

--- a/packages/suite/src/hooks/suite/__tests__/useDiscovery.test.tsx
+++ b/packages/suite/src/hooks/suite/__tests__/useDiscovery.test.tsx
@@ -1,0 +1,73 @@
+import React from 'react';
+import configureStore from 'redux-mock-store';
+import thunk from 'redux-thunk';
+import { renderWithProviders } from '@suite/support/tests/hooksHelper';
+
+import discoveryReducer from '@wallet-reducers/discoveryReducer';
+import suiteReducer from '@suite-reducers/suiteReducer';
+import { useDiscovery } from '../useDiscovery';
+import { actions } from '../__fixtures__/useDiscovery';
+
+export const getInitialState = (action: any = { type: 'initial' }) => {
+    return {
+        wallet: {
+            discovery: discoveryReducer(undefined, action),
+        },
+        suite: suiteReducer(undefined, action),
+    };
+};
+
+type State = ReturnType<typeof getInitialState>;
+const mockStore = configureStore<State, any>([thunk]);
+
+const initStore = (state: State) => {
+    const store = mockStore(state);
+    store.subscribe(() => {
+        const actions = store.getActions();
+        const action = actions[actions.length - 1];
+        const state = store.getState();
+        const { wallet } = state;
+        store.getState().wallet = {
+            ...wallet,
+            discovery: discoveryReducer(wallet.discovery, action),
+        };
+        store.getState().suite = suiteReducer(state.suite, action);
+    });
+    return store;
+};
+
+type Result = {
+    running?: boolean;
+    status?: { type: string };
+    progress: number;
+};
+
+type Callback = (r: Result) => void;
+
+const Component = ({ callback }: { callback: Callback }) => {
+    const { isDiscoveryRunning, getDiscoveryStatus, calculateProgress } = useDiscovery();
+    callback({
+        running: isDiscoveryRunning,
+        status: getDiscoveryStatus(),
+        progress: calculateProgress(),
+    });
+    return null;
+};
+
+test('useDiscovery', () => {
+    const store = initStore(getInitialState());
+
+    const renders: Result[] = [];
+    const callback: Callback = r => renders.push(r);
+
+    const { unmount } = renderWithProviders(store, <Component callback={callback} />);
+
+    actions.forEach(a => {
+        store.dispatch(a.action);
+        const len = renders.length;
+        expect(len).toEqual(a.renders); // validate render numbers
+        expect(renders[len - 1]).toMatchObject(a.result); // validate hook values
+    });
+
+    unmount();
+});

--- a/packages/suite/src/hooks/suite/useAnalytics.ts
+++ b/packages/suite/src/hooks/suite/useAnalytics.ts
@@ -1,10 +1,8 @@
-import { useSelector } from 'react-redux';
 import * as analyticsActions from '@suite-actions/analyticsActions';
-import { AppState } from '@suite-types';
-import { useActions } from '@suite-hooks';
+import { useActions, useSelector } from '@suite-hooks';
 
 export const useAnalytics = () => {
-    const analytics = useSelector<AppState, AppState['analytics']>(state => state.analytics);
+    const analytics = useSelector(state => state.analytics);
 
     const actions = useActions({
         report: analyticsActions.report,

--- a/packages/suite/src/hooks/suite/useDevice.ts
+++ b/packages/suite/src/hooks/suite/useDevice.ts
@@ -1,12 +1,12 @@
 import { useCallback } from 'react';
-import { useSelector } from 'react-redux';
+import { useSelector } from './useSelector';
 import { SUITE } from '@suite-actions/constants';
-import { AppState } from '@suite-types';
 
 export const useDevice = () => {
-    const device = useSelector<AppState, AppState['suite']['device']>(state => state.suite.device);
-    const locks = useSelector<AppState, AppState['suite']['locks']>(state => state.suite.locks);
-
+    const { device, locks } = useSelector(state => ({
+        device: state.suite.device,
+        locks: state.suite.locks,
+    }));
     const isLocked = useCallback(
         (ignoreDisconnectedDevice = false) => {
             if (!device?.connected && !ignoreDisconnectedDevice) return true;

--- a/packages/suite/src/hooks/suite/useFirmware.ts
+++ b/packages/suite/src/hooks/suite/useFirmware.ts
@@ -1,10 +1,8 @@
-import { useSelector } from 'react-redux';
 import * as firmwareActions from '@firmware-actions/firmwareActions';
-import { AppState } from '@suite-types';
-import { useActions } from '@suite-hooks';
+import { useActions, useSelector } from '@suite-hooks';
 
 export const useFirmware = () => {
-    const firmware = useSelector<AppState, AppState['firmware']>(state => state.firmware);
+    const firmware = useSelector(state => state.firmware);
 
     const actions = useActions({
         toggleHasSeed: firmwareActions.toggleHasSeed,

--- a/packages/suite/src/hooks/suite/useGraph.ts
+++ b/packages/suite/src/hooks/suite/useGraph.ts
@@ -2,8 +2,10 @@ import { useSelector, useActions } from '@suite-hooks';
 import * as graphActions from '@wallet-actions/graphActions';
 
 export const useGraph = () => {
-    const selectedRange = useSelector(state => state.wallet.graph.selectedRange);
-    const selectedView = useSelector(state => state.wallet.graph.selectedView);
+    const { selectedRange, selectedView } = useSelector(state => ({
+        selectedRange: state.wallet.graph.selectedRange,
+        selectedView: state.wallet.graph.selectedView,
+    }));
 
     const actions = useActions({
         setSelectedRange: graphActions.setSelectedRange,

--- a/packages/suite/src/hooks/wallet/useAccounts.ts
+++ b/packages/suite/src/hooks/wallet/useAccounts.ts
@@ -1,16 +1,15 @@
 import { useState, useEffect, useMemo } from 'react';
-import { useSelector } from 'react-redux';
-import { AppState } from '@suite-types';
+import { useSelector } from '@suite-hooks';
 import { Account, Discovery } from '@wallet-types';
 import * as accountUtils from '@wallet-utils/accountUtils';
 
 export const useAccounts = (discovery?: Discovery) => {
     const [accounts, setAccounts] = useState<Account[]>([]);
 
-    const device = useSelector<AppState, AppState['suite']['device']>(state => state.suite.device);
-    const accountsState = useSelector<AppState, AppState['wallet']['accounts']>(
-        state => state.wallet.accounts,
-    );
+    const { device, accountsState } = useSelector(state => ({
+        device: state.suite.device,
+        accountsState: state.wallet.accounts,
+    }));
 
     useEffect(() => {
         if (device) {
@@ -27,10 +26,10 @@ export const useAccounts = (discovery?: Discovery) => {
 };
 
 export const useFastAccounts = () => {
-    const device = useSelector<AppState, AppState['suite']['device']>(state => state.suite.device);
-    const accounts = useSelector<AppState, AppState['wallet']['accounts']>(
-        state => state.wallet.accounts,
-    );
+    const { device, accounts } = useSelector(state => ({
+        device: state.suite.device,
+        accounts: state.wallet.accounts,
+    }));
     const deviceAccounts = useMemo(
         () => (device ? accountUtils.getAllAccounts(device.state, accounts) : []),
         [accounts, device],

--- a/packages/suite/src/hooks/wallet/useCoinmarket.ts
+++ b/packages/suite/src/hooks/wallet/useCoinmarket.ts
@@ -1,38 +1,24 @@
-import { useSelector } from 'react-redux';
 import { useEffect, useState } from 'react';
 import { BuyTradeStatus } from 'invity-api';
 import useUnmount from 'react-use/lib/useUnmount';
 import useTimeoutFn from 'react-use/lib/useTimeoutFn';
+import { useSelector, useActions } from '@suite-hooks';
 import invityAPI from '@suite-services/invityAPI';
 import * as coinmarketBuyActions from '@wallet-actions/coinmarketBuyActions';
-import { Account } from '@wallet-types';
-import { useActions } from '@suite-hooks';
-import { TradeBuy } from '@wallet-reducers/coinmarketReducer';
-import { AppState } from '@suite-types';
-import { loadBuyInfo } from '@wallet-actions/coinmarketBuyActions';
 import * as coinmarketExchangeActions from '@wallet-actions/coinmarketExchangeActions';
+import { Account } from '@wallet-types';
+import { TradeBuy } from '@wallet-reducers/coinmarketReducer';
 
 export const useInvityAPI = () => {
-    const selectedAccount = useSelector<AppState, AppState['wallet']['selectedAccount']>(
-        state => state.wallet.selectedAccount,
-    );
+    const { selectedAccount, buyInfo, exchangeInfo, invityAPIUrl } = useSelector(state => ({
+        selectedAccount: state.wallet.selectedAccount,
+        buyInfo: state.wallet.coinmarket.buy.buyInfo,
+        exchangeInfo: state.wallet.coinmarket.exchange.exchangeInfo,
+        invityAPIUrl: state.suite.settings.debug.invityAPIUrl,
+    }));
 
-    const buyInfo = useSelector<AppState, AppState['wallet']['coinmarket']['buy']['buyInfo']>(
-        state => state.wallet.coinmarket.buy.buyInfo,
-    );
-
-    const exchangeInfo = useSelector<
-        AppState,
-        AppState['wallet']['coinmarket']['exchange']['exchangeInfo']
-    >(state => state.wallet.coinmarket.exchange.exchangeInfo);
-
-    const invityAPIUrl = useSelector<
-        AppState,
-        AppState['suite']['settings']['debug']['invityAPIUrl']
-    >(state => state.suite.settings.debug.invityAPIUrl);
-
-    const { saveBuyInfo } = useActions({ saveBuyInfo: coinmarketBuyActions.saveBuyInfo });
-    const { saveExchangeInfo } = useActions({
+    const { saveBuyInfo, saveExchangeInfo } = useActions({
+        saveBuyInfo: coinmarketBuyActions.saveBuyInfo,
         saveExchangeInfo: coinmarketExchangeActions.saveExchangeInfo,
     });
 
@@ -44,7 +30,7 @@ export const useInvityAPI = () => {
         invityAPI.createInvityAPIKey(selectedAccount.account?.descriptor);
 
         if (!buyInfo?.buyInfo) {
-            loadBuyInfo().then(buyInfo => {
+            coinmarketBuyActions.loadBuyInfo().then(buyInfo => {
                 saveBuyInfo(buyInfo);
             });
         }

--- a/packages/suite/src/hooks/wallet/useCoinmarketBuyDetail.ts
+++ b/packages/suite/src/hooks/wallet/useCoinmarketBuyDetail.ts
@@ -1,8 +1,7 @@
 import { createContext, useContext } from 'react';
 import { Props, ContextValues } from '@wallet-types/coinmarketBuyDetail';
 import { useWatchBuyTrade } from '@wallet-hooks/useCoinmarket';
-import { useSelector } from 'react-redux';
-import { AppState } from '@suite-types';
+import { useSelector } from '@suite-hooks';
 import invityAPI from '@suite-services/invityAPI';
 import { TradeBuy } from '@wallet-reducers/coinmarketReducer';
 
@@ -14,16 +13,13 @@ export const useCoinmarketBuyDetail = (props: Props) => {
             (trade.key === transactionId || trade.data?.originalPaymentId === transactionId),
     );
     const { account } = selectedAccount;
-    const invityAPIUrl = useSelector<
-        AppState,
-        AppState['suite']['settings']['debug']['invityAPIUrl']
-    >(state => state.suite.settings.debug.invityAPIUrl);
+    const { invityAPIUrl, buyInfo } = useSelector(state => ({
+        invityAPIUrl: state.suite.settings.debug.invityAPIUrl,
+        buyInfo: state.wallet.coinmarket.buy.buyInfo,
+    }));
     if (invityAPIUrl) {
         invityAPI.setInvityAPIServer(invityAPIUrl);
     }
-    const buyInfo = useSelector<AppState, AppState['wallet']['coinmarket']['buy']['buyInfo']>(
-        state => state.wallet.coinmarket.buy.buyInfo,
-    );
 
     useWatchBuyTrade(account, buyTrade as TradeBuy);
 

--- a/packages/suite/src/hooks/wallet/useCoinmarketBuyForm.ts
+++ b/packages/suite/src/hooks/wallet/useCoinmarketBuyForm.ts
@@ -26,14 +26,11 @@ export const useCoinmarketBuyForm = (props: Props): BuyFormContextValues => {
     const [amountLimits, setAmountLimits] = useState<AmountLimits | undefined>(undefined);
     const methods = useForm<FormState>({ mode: 'onChange' });
 
-    const { saveQuoteRequest, saveQuotes, saveCachedAccountInfo, saveTrade } = useActions({
+    const { saveQuoteRequest, saveQuotes, saveCachedAccountInfo, saveTrade, goto } = useActions({
         saveQuoteRequest: coinmarketBuyActions.saveQuoteRequest,
         saveQuotes: coinmarketBuyActions.saveQuotes,
         saveCachedAccountInfo: coinmarketBuyActions.saveCachedAccountInfo,
         saveTrade: coinmarketBuyActions.saveTrade,
-    });
-
-    const { goto } = useActions({
         goto: routerActions.goto,
     });
 

--- a/packages/suite/src/hooks/wallet/useCoinmarketBuyOffers.ts
+++ b/packages/suite/src/hooks/wallet/useCoinmarketBuyOffers.ts
@@ -35,20 +35,22 @@ export const useOffers = (props: Props) => {
         alternativeQuotes,
     );
     const [lastFetchDate, setLastFetchDate] = useState(new Date());
-    const { goto } = useActions({ goto: routerActions.goto });
-    const { verifyAddress } = useActions({ verifyAddress: coinmarketCommonActions.verifyAddress });
     const {
         saveTrade,
         setIsFromRedirect,
         openCoinmarketBuyConfirmModal,
         addNotification,
         saveTransactionDetailId,
+        verifyAddress,
+        goto,
     } = useActions({
         saveTrade: coinmarketBuyActions.saveTrade,
         setIsFromRedirect: coinmarketBuyActions.setIsFromRedirect,
         openCoinmarketBuyConfirmModal: coinmarketBuyActions.openCoinmarketBuyConfirmModal,
         addNotification: notificationActions.addToast,
         saveTransactionDetailId: coinmarketBuyActions.saveTransactionDetailId,
+        verifyAddress: coinmarketCommonActions.verifyAddress,
+        goto: routerActions.goto,
     });
 
     const invityAPIUrl = useSelector(state => state.suite.settings.debug.invityAPIUrl);

--- a/packages/suite/src/hooks/wallet/useCoinmarketRedirect.ts
+++ b/packages/suite/src/hooks/wallet/useCoinmarketRedirect.ts
@@ -5,11 +5,11 @@ import * as routerActions from '@suite-actions/routerActions';
 import * as coinmarketBuyActions from '@wallet-actions/coinmarketBuyActions';
 
 export const useCoinmarketRedirect = () => {
-    const { goto } = useActions({ goto: routerActions.goto });
-    const { saveQuoteRequest, setIsFromRedirect, saveTransactionDetailId } = useActions({
+    const { saveQuoteRequest, setIsFromRedirect, saveTransactionDetailId, goto } = useActions({
         saveQuoteRequest: coinmarketBuyActions.saveQuoteRequest,
         setIsFromRedirect: coinmarketBuyActions.setIsFromRedirect,
         saveTransactionDetailId: coinmarketBuyActions.saveTransactionDetailId,
+        goto: routerActions.goto,
     });
 
     interface OfferRedirectParams {

--- a/packages/suite/src/hooks/wallet/useFiatValue.ts
+++ b/packages/suite/src/hooks/wallet/useFiatValue.ts
@@ -1,13 +1,11 @@
-import { useSelector } from 'react-redux';
-import { AppState } from '@suite-types';
+import { useSelector } from '@suite-hooks';
 
 // TODO: do the calculation here
 export const useFiatValue = () => {
-    const fiat = useSelector<AppState, AppState['wallet']['fiat']>(state => state.wallet.fiat);
-    const localCurrency = useSelector<AppState, string>(
-        state => state.wallet.settings.localCurrency,
-    );
-
+    const { fiat, localCurrency } = useSelector(state => ({
+        fiat: state.wallet.fiat,
+        localCurrency: state.wallet.settings.localCurrency,
+    }));
     return {
         fiat,
         localCurrency,

--- a/packages/suite/src/support/tests/hooksHelper.tsx
+++ b/packages/suite/src/support/tests/hooksHelper.tsx
@@ -1,0 +1,24 @@
+import React from 'react';
+import { Provider } from 'react-redux';
+import { IntlProvider } from 'react-intl';
+import { render } from '@testing-library/react';
+
+// do not render svg files
+jest.mock('react-svg', () => {
+    return { ReactSVG: () => 'SVG' };
+});
+
+// render only Translation['id']
+jest.mock('@suite-components/Translation', () => {
+    return { Translation: ({ id }: any) => id };
+});
+
+// used in hooks tests
+export const renderWithProviders = (store: any, children: React.ReactNode) => {
+    const renderMethods = render(
+        <Provider store={store}>
+            <IntlProvider locale="en">{children}</IntlProvider>
+        </Provider>,
+    );
+    return renderMethods;
+};

--- a/packages/suite/src/types/wallet/index.ts
+++ b/packages/suite/src/types/wallet/index.ts
@@ -37,7 +37,7 @@ export type Discovery = Discovery$;
 export type DiscoveryStatus =
     | {
           status: 'loading';
-          type: 'waiting-for-device' | 'auth' | 'discovery';
+          type: 'waiting-for-device' | 'auth' | 'auth-confirm' | 'discovery';
       }
     | {
           status: 'exception';

--- a/yarn.lock
+++ b/yarn.lock
@@ -4092,7 +4092,7 @@
   dependencies:
     regenerator-runtime "^0.13.4"
 
-"@babel/runtime@^7.12.0", "@babel/runtime@^7.12.1":
+"@babel/runtime@^7.12.0", "@babel/runtime@^7.12.1", "@babel/runtime@^7.5.4":
   version "7.12.1"
   resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.12.1.tgz#b4116a6b6711d010b2dad3b7b6e43bf1b9954740"
   integrity sha512-J5AIf3vPj3UwXaAzb5j1xM4WAQDX3EMgemF8rjCP3SoW09LfRKAXQKt6CoVYl230P6iWdRcBbnLDDdnqWxZSCA==
@@ -6930,10 +6930,10 @@
   dependencies:
     "@babel/runtime" "^7.9.6"
 
-"@testing-library/dom@^7.24.2":
-  version "7.24.2"
-  resolved "https://registry.yarnpkg.com/@testing-library/dom/-/dom-7.24.2.tgz#6d2b7dd21efbd5358b98c2777fc47c252f3ae55e"
-  integrity sha512-ERxcZSoHx0EcN4HfshySEWmEf5Kkmgi+J7O79yCJ3xggzVlBJ2w/QjJUC+EBkJJ2OeSw48i3IoePN4w8JlVUIA==
+"@testing-library/dom@^7.26.0", "@testing-library/dom@^7.26.3":
+  version "7.26.3"
+  resolved "https://registry.yarnpkg.com/@testing-library/dom/-/dom-7.26.3.tgz#5554ee985f712d621bd676104b879f85d9a7a0ef"
+  integrity sha512-/1P6taENE/H12TofJaS3L1J28HnXx8ZFhc338+XPR5y1E3g5ttOgu86DsGnV9/n2iPrfJQVUZ8eiGYZGSxculw==
   dependencies:
     "@babel/code-frame" "^7.10.4"
     "@babel/runtime" "^7.10.3"
@@ -6941,20 +6941,29 @@
     aria-query "^4.2.2"
     chalk "^4.1.0"
     dom-accessibility-api "^0.5.1"
+    lz-string "^1.4.4"
     pretty-format "^26.4.2"
 
-"@testing-library/react@^11.0.4":
-  version "11.0.4"
-  resolved "https://registry.yarnpkg.com/@testing-library/react/-/react-11.0.4.tgz#c84082bfe1593d8fcd475d46baee024452f31dee"
-  integrity sha512-U0fZO2zxm7M0CB5h1+lh31lbAwMSmDMEMGpMT3BUPJwIjDEKYWOV4dx7lb3x2Ue0Pyt77gmz/VropuJnSz/Iew==
+"@testing-library/react-hooks@^3.4.2":
+  version "3.4.2"
+  resolved "https://registry.yarnpkg.com/@testing-library/react-hooks/-/react-hooks-3.4.2.tgz#8deb94f7684e0d896edd84a4c90e5b79a0810bc2"
+  integrity sha512-RfPG0ckOzUIVeIqlOc1YztKgFW+ON8Y5xaSPbiBkfj9nMkkiLhLeBXT5icfPX65oJV/zCZu4z8EVnUc6GY9C5A==
+  dependencies:
+    "@babel/runtime" "^7.5.4"
+    "@types/testing-library__react-hooks" "^3.4.0"
+
+"@testing-library/react@^11.1.0":
+  version "11.1.0"
+  resolved "https://registry.yarnpkg.com/@testing-library/react/-/react-11.1.0.tgz#dfb4b3177d05a8ccf156b5fd14a5550e91d7ebe4"
+  integrity sha512-Nfz58jGzW0tgg3irmTB7sa02JLkLnCk+QN3XG6WiaGQYb0Qc4Ok00aujgjdxlIQWZHbb4Zj5ZOIeE9yKFSs4sA==
   dependencies:
     "@babel/runtime" "^7.11.2"
-    "@testing-library/dom" "^7.24.2"
+    "@testing-library/dom" "^7.26.0"
 
-"@testing-library/user-event@^12.1.5":
-  version "12.1.5"
-  resolved "https://registry.yarnpkg.com/@testing-library/user-event/-/user-event-12.1.5.tgz#b2a94b8b3c1a908cc1c425623b11de63b20bb837"
-  integrity sha512-FzTnKvb0KC4T84G6uTx971ja8OOqLlsprzWbeRyd8f1MDwbcLIFgx0Hyr56izY9m9y2KwHGVKeVEkTPslw32lw==
+"@testing-library/user-event@^12.1.10":
+  version "12.1.10"
+  resolved "https://registry.yarnpkg.com/@testing-library/user-event/-/user-event-12.1.10.tgz#e043ef5aa10e4b3e56b434e383d2fbfef1fcfb7f"
+  integrity sha512-StlNdKHp2Rpb7yrny/5/CGpz8bR3jLa1Ge59ODGU6TmAhkrxSpvR6tCD1gaMFkkjEUWkmmye8BaXsZPcaiJ6Ug==
   dependencies:
     "@babel/runtime" "^7.10.2"
 
@@ -7477,6 +7486,13 @@
   dependencies:
     "@types/react" "*"
 
+"@types/react-test-renderer@*":
+  version "16.9.3"
+  resolved "https://registry.yarnpkg.com/@types/react-test-renderer/-/react-test-renderer-16.9.3.tgz#96bab1860904366f4e848b739ba0e2f67bcae87e"
+  integrity sha512-wJ7IlN5NI82XMLOyHSa+cNN4Z0I+8/YaLl04uDgcZ+W+ExWCmCiVTLT/7fRNqzy4OhStZcUwIqLNF7q+AdW43Q==
+  dependencies:
+    "@types/react" "*"
+
 "@types/react-test-renderer@^16.9.1":
   version "16.9.1"
   resolved "https://registry.yarnpkg.com/@types/react-test-renderer/-/react-test-renderer-16.9.1.tgz#9d432c46c515ebe50c45fa92c6fb5acdc22e39c4"
@@ -7623,6 +7639,13 @@
   version "1.0.5"
   resolved "https://registry.yarnpkg.com/@types/tapable/-/tapable-1.0.5.tgz#9adbc12950582aa65ead76bffdf39fe0c27a3c02"
   integrity sha512-/gG2M/Imw7cQFp8PGvz/SwocNrmKFjFsm5Pb8HdbHkZ1K8pmuPzOX4VeVoiEecFCVf4CsN1r3/BRvx+6sNqwtQ==
+
+"@types/testing-library__react-hooks@^3.4.0":
+  version "3.4.1"
+  resolved "https://registry.yarnpkg.com/@types/testing-library__react-hooks/-/testing-library__react-hooks-3.4.1.tgz#b8d7311c6c1f7db3103e94095fe901f8fef6e433"
+  integrity sha512-G4JdzEcq61fUyV6wVW9ebHWEiLK2iQvaBuCHHn9eMSbZzVh4Z4wHnUGIvQOYCCYeu5DnUtFyNYuAAgbSaO/43Q==
+  dependencies:
+    "@types/react-test-renderer" "*"
 
 "@types/tough-cookie@*":
   version "2.3.5"
@@ -19376,6 +19399,11 @@ lru-cache@^4.0.0, lru-cache@^4.0.1:
   dependencies:
     pseudomap "^1.0.2"
     yallist "^2.1.2"
+
+lz-string@^1.4.4:
+  version "1.4.4"
+  resolved "https://registry.yarnpkg.com/lz-string/-/lz-string-1.4.4.tgz#c0d8eaf36059f705796e1e344811cf4c498d3a26"
+  integrity sha1-wNjq82BZ9wV5bh40SBHPTEmNOiY=
 
 macos-release@^2.2.0:
   version "2.3.0"


### PR DESCRIPTION
- refactored `useDiscovery` hook, turns out it causes double-render in every component where used (because of wrong useState usage)
- added tests for `useDiscovery` hook (render counts on redux-store change)
- refactored/unified usage of `useSelector` hook (and few useActions in invity files)
- update testing-library dependencies

