### PR TITLE
Refactor Preloader component

### DIFF
--- a/packages/suite/src/components/suite/SwitchDevice/components/DeviceItem/components/AddWalletButton/index.tsx
+++ b/packages/suite/src/components/suite/SwitchDevice/components/DeviceItem/components/AddWalletButton/index.tsx
@@ -39,7 +39,6 @@ interface Props {
 
 const AddWalletButton = ({ device, instances, addDeviceInstance, selectDeviceInstance }: Props) => {
     const hasAtLeastOneWallet = instances.find(d => d.state);
-    const tooltipMsg = <Translation id="TR_TO_ACCESS_OTHER_WALLETS" />;
     const locks = useSelector(state => state.suite.locks);
 
     // opportunity to bring useDeviceLocks back (extract it from useDevice hook)?
@@ -54,7 +53,11 @@ const AddWalletButton = ({ device, instances, addDeviceInstance, selectDeviceIns
     const analytics = useAnalytics();
     return (
         <AddWallet>
-            <StyledTooltip enabled={!device.connected} placement="top" content={tooltipMsg}>
+            <StyledTooltip
+                enabled={!device.connected}
+                placement="top"
+                content={<Translation id="TR_TO_ACCESS_OTHER_WALLETS" />}
+            >
                 <StyledButton
                     data-test="@switch-device/add-wallet-button"
                     variant="tertiary"

--- a/packages/suite/src/views/dashboard/components/PortfolioCard/components/Exception/index.tsx
+++ b/packages/suite/src/views/dashboard/components/PortfolioCard/components/Exception/index.tsx
@@ -75,7 +75,7 @@ const Container = ({ title, description, cta }: ContainerProps) => {
             <Actions>
                 {actions.map(a => (
                     <Button
-                        key={a.label}
+                        key={a.label || 'TR_RETRY'}
                         variant={a.variant || 'primary'}
                         icon={a.icon || 'PLUS'}
                         isLoading={isLocked()}


### PR DESCRIPTION
refactor `Preloader` component from redux-connected to hooks, it's solving "unused prop" [issue after typescript4.0 update](https://github.com/trezor/trezor-suite/blob/develop/packages/suite/src/components/suite/Preloader/index.tsx#L49)
This change doesn't have effect on `Preloader` component rendering (renders exact same amount of times as connected component)

plus also two minor fixes found by accident while passing by :)
