### PR TITLE
fix(suite): remove crazy re-exports in types

### DIFF
--- a/packages/suite/src/types/firmware/index.ts
+++ b/packages/suite/src/types/firmware/index.ts
@@ -1,3 +1,1 @@
-import { FirmwareActions as FirmwareActions$ } from '@firmware-actions/firmwareActions';
-
-export type FirmwareActions = FirmwareActions$;
+export type { FirmwareActions } from '@firmware-actions/firmwareActions';

--- a/packages/suite/src/types/onboarding/index.ts
+++ b/packages/suite/src/types/onboarding/index.ts
@@ -1,6 +1,4 @@
-import { OnboardingActionTypes } from '@onboarding-actions/onboardingActions';
-
-export type OnboardingActions = OnboardingActionTypes;
+export type { OnboardingActionTypes as OnboardingActions } from '@onboarding-actions/onboardingActions';
 
 export interface Checkbox {
     value: boolean;

--- a/packages/suite/src/types/settings/index.ts
+++ b/packages/suite/src/types/settings/index.ts
@@ -1,3 +1,1 @@
-import { WalletSettingsActions } from '@settings-actions/walletSettingsActions';
-
-export type SettingsActions = WalletSettingsActions;
+export type { WalletSettingsActions as SettingsActions } from '@settings-actions/walletSettingsActions';

--- a/packages/suite/src/types/suite/index.ts
+++ b/packages/suite/src/types/suite/index.ts
@@ -9,8 +9,8 @@ import {
     UnknownDevice as UnknownDeviceBase,
 } from 'trezor-connect';
 import { RouterActions } from '@suite-actions/routerActions';
-import { Route as Route$ } from '@suite-constants/routes';
-import { AppState as AppState$ } from '@suite/reducers/store';
+import { Route } from '@suite-constants/routes';
+import { AppState } from '@suite/reducers/store';
 import { StorageActions } from '@suite-actions/storageActions';
 import { SuiteActions } from '@suite-actions/suiteActions';
 import { ResizeActions } from '@suite-actions/resizeActions';
@@ -24,7 +24,6 @@ import { DeviceMetadata } from '@suite-types/metadata';
 import { OnboardingActions } from '@onboarding-types';
 import { SettingsActions } from '@settings-types';
 import { FirmwareActions } from '@firmware-types';
-import { ExtendedMessageDescriptor as ExtendedMessageDescriptor$ } from '@suite-components/Translation/components/BaseTranslation';
 import { WalletAction } from '@wallet-types';
 import { BackupActions } from '@backup-actions/backupActions';
 import { RecoveryActions } from '@recovery-actions/recoveryActions';
@@ -32,14 +31,12 @@ import { ObjectValues } from '@suite/types/utils';
 import { SUITE } from '@suite-actions/constants';
 import { PROCESS_MODE } from '@suite-middlewares/actionBlockerMiddleware';
 
-// this weird export is because of --isolatedModules and next.js 9
-export type ExtendedMessageDescriptor = ExtendedMessageDescriptor$;
+// reexport
+export type { ExtendedMessageDescriptor } from '@suite-components/Translation/components/BaseTranslation';
+export type { AppState } from '@suite/reducers/store';
+export type { Route } from '@suite-constants/routes';
 
 type TrezorConnectEvents = TransportEvent | UiEvent | DeviceEvent | BlockchainEvent;
-
-export type AppState = AppState$;
-
-export type Route = Route$;
 
 // all actions from all apps used to properly type Dispatch.
 export type Action =
@@ -99,7 +96,7 @@ export type InjectedModalApplicationProps = {
     cancelable: boolean;
     onCancel: () => void;
     closeModalApp: (preserveParams?: boolean) => void;
-    getBackgroundRoute: () => Route$ | typeof undefined;
+    getBackgroundRoute: () => Route | typeof undefined;
 };
 
 export type ToastNotificationVariant = 'success' | 'info' | 'warning' | 'error';

--- a/packages/suite/src/types/wallet/index.ts
+++ b/packages/suite/src/types/wallet/index.ts
@@ -2,18 +2,8 @@ import { ReceiveActions } from '@wallet-actions/receiveActions';
 import { SignVerifyActions } from '@wallet-actions/signVerifyActions';
 import { CoinmarketBuyActions } from '@wallet-actions/coinmarketBuyActions';
 import { CoinmarketExchangeActions } from '@wallet-actions/coinmarketExchangeActions';
-
-import {
-    FiatTicker as FiatTicker$,
-    CoinFiatRates as CoinFiatRates$,
-} from '@wallet-types/fiatRates';
 import { DiscoveryActions } from '@wallet-actions/discoveryActions';
 import { AccountActions } from '@wallet-actions/accountActions';
-import { Discovery as Discovery$ } from '@wallet-reducers/discoveryReducer';
-import { Account as Account$ } from '@wallet-reducers/accountsReducer';
-import { WalletAccountTransaction as WalletAccountTransaction$ } from '@wallet-reducers/transactionReducer';
-import { ReceiveInfo as ReceiveInfo$ } from '@wallet-reducers/receiveReducer';
-
 import { FiatRatesActions } from '@wallet-actions/fiatRatesActions';
 import { GraphActions } from '@wallet-actions/graphActions';
 import { BlockchainActions } from '@wallet-actions/blockchainActions';
@@ -22,18 +12,15 @@ import { AccountSearchActions } from '@wallet-actions/accountSearchActions';
 import { TransactionAction } from '@wallet-actions/transactionActions';
 import { SelectedAccountActions } from '@wallet-actions/selectedAccountActions';
 import { NETWORKS } from '@wallet-config';
-import { Icon as Icon$ } from './iconTypes';
-import { NetworkToken as NetworkToken$, Token as Token$ } from './tokenTypes';
-import { WalletParams as WalletParams$ } from '@suite-utils/router';
 import { ArrayElement } from '../utils';
 
 export type Network = ArrayElement<typeof NETWORKS>;
-export type NetworkToken = NetworkToken$;
-export type Token = Token$;
-export type Account = Account$;
-export type Icon = Icon$;
-export type CoinFiatRates = CoinFiatRates$;
-export type Discovery = Discovery$;
+// reexport
+export type { NetworkToken, Token } from './tokenTypes';
+export type { Icon } from './iconTypes';
+export type { Account } from '@wallet-reducers/accountsReducer';
+export type { CoinFiatRates, FiatTicker } from '@wallet-types/fiatRates';
+export type { Discovery } from '@wallet-reducers/discoveryReducer';
 export type DiscoveryStatus =
     | {
           status: 'loading';
@@ -48,10 +35,9 @@ export type DiscoveryStatus =
               | 'discovery-failed'
               | 'device-unavailable';
       };
-export type WalletParams = WalletParams$;
-export type WalletAccountTransaction = WalletAccountTransaction$;
-export type FiatTicker = FiatTicker$;
-export type ReceiveInfo = ReceiveInfo$;
+export type { WalletParams } from '@suite-utils/router';
+export type { WalletAccountTransaction } from '@wallet-reducers/transactionReducer';
+export type { ReceiveInfo } from '@wallet-reducers/receiveReducer';
 
 export type WalletAction =
     | BlockchainActions


### PR DESCRIPTION
looks like it's finally possible to reexport types from index