### PR TITLE
Invity - skip passphrase entry after redirect from Buy payment gateway

### DIFF
--- a/packages/suite/src/actions/suite/__tests__/storageActions.test.ts
+++ b/packages/suite/src/actions/suite/__tests__/storageActions.test.ts
@@ -60,6 +60,11 @@ const dev2Instance1 = getSuiteDevice({
     instance: 2,
     remember: true, // normally it would be set by SUITE.REMEMBER_DEVICE dispatched from modalActions.onRememberDevice()
 });
+const devNotRemembered = getSuiteDevice({
+    state: 'state1',
+    path: '1',
+    instance: 1,
+});
 
 const acc1 = getWalletAccount({
     deviceState: dev1.state,
@@ -460,5 +465,20 @@ describe('Storage actions', () => {
         await store.dispatch(storageActions.loadStorage());
         expect(store.getState().wallet.graph.data.length).toBe(1);
         expect(store.getState().wallet.graph.data[0].account.symbol).toBe('ltc');
+    });
+
+    it('remember device with forceRemember', async () => {
+        const store = mockStore(
+            getInitialState({
+                devices: [devNotRemembered],
+            }),
+        );
+        updateStore(store);
+
+        // store in db
+        await store.dispatch(storageActions.rememberDevice(devNotRemembered, true, true));
+        await store.dispatch(storageActions.loadStorage());
+        expect(store.getState().devices[0].remember).toBe(true);
+        expect(store.getState().devices[0].forceRemember).toBe(true);
     });
 });

--- a/packages/suite/src/actions/suite/storageActions.ts
+++ b/packages/suite/src/actions/suite/storageActions.ts
@@ -44,9 +44,9 @@ export const removeAccountDraft = (account: Account) => {
 
 // send form drafts end
 
-export const saveDevice = async (device: TrezorDevice) => {
+export const saveDevice = async (device: TrezorDevice, forceRemember?: true) => {
     if (!device || !device.features || !device.state) return;
-    return db.addItem('devices', serializeDevice(device), device.state, true);
+    return db.addItem('devices', serializeDevice(device, forceRemember), device.state, true);
 };
 
 export const removeAccount = async (account: Account) => {
@@ -166,10 +166,11 @@ export const removeAccountGraph = async (account: Account) => {
     ]);
 };
 
-export const rememberDevice = (device: TrezorDevice, remember: boolean) => async (
-    dispatch: Dispatch,
-    getState: GetState,
-) => {
+export const rememberDevice = (
+    device: TrezorDevice,
+    remember: boolean,
+    forcedRemember?: true,
+) => async (dispatch: Dispatch, getState: GetState) => {
     if (!device || !device.features || !device.state) return;
     if (!remember) {
         return dispatch(forgetDevice(device));
@@ -191,7 +192,7 @@ export const rememberDevice = (device: TrezorDevice, remember: boolean) => async
 
     try {
         await Promise.all([
-            saveDevice(device),
+            saveDevice(device, forcedRemember),
             saveAccounts(accounts),
             saveGraph(graphData),
             saveDiscovery(discovery),

--- a/packages/suite/src/actions/suite/suiteActions.ts
+++ b/packages/suite/src/actions/suite/suiteActions.ts
@@ -27,7 +27,12 @@ export type SuiteActions =
     | { type: typeof SUITE.RECEIVE_AUTH_CONFIRM; payload: TrezorDevice; success: boolean }
     | { type: typeof SUITE.CREATE_DEVICE_INSTANCE; payload: TrezorDevice }
     | { type: typeof SUITE.FORGET_DEVICE; payload: TrezorDevice }
-    | { type: typeof SUITE.REMEMBER_DEVICE; payload: TrezorDevice; remember: boolean }
+    | {
+          type: typeof SUITE.REMEMBER_DEVICE;
+          payload: TrezorDevice;
+          remember: boolean;
+          forceRemember?: true;
+      }
     | {
           type: typeof SUITE.SET_LANGUAGE;
           locale: typeof LANGUAGES[number]['code'];
@@ -174,10 +179,12 @@ export const selectDevice = (device?: Device | TrezorDevice) => async (
     });
 };
 
-export const rememberDevice = (payload: TrezorDevice): Action => ({
+export const rememberDevice = (payload: TrezorDevice, forceRemember?: true): Action => ({
     type: SUITE.REMEMBER_DEVICE,
     payload,
-    remember: !payload.remember,
+    remember: !payload.remember || !!forceRemember,
+    // if device is already remembered, do not force it, it would remove the remember on return to suite
+    forceRemember: payload.remember ? undefined : forceRemember,
 });
 
 export const forgetDevice = (payload: TrezorDevice): Action => ({

--- a/packages/suite/src/actions/wallet/coinmarketCommonActions.ts
+++ b/packages/suite/src/actions/wallet/coinmarketCommonActions.ts
@@ -1,8 +1,12 @@
 import TrezorConnect, { UI, ButtonRequestMessage } from 'trezor-connect';
 import * as modalActions from '@suite-actions/modalActions';
 import * as notificationActions from '@suite-actions/notificationActions';
+import * as suiteActions from '@suite-actions/suiteActions';
 import { COINMARKET_BUY } from './constants';
 import { Dispatch, GetState } from '@suite-types';
+import { BuyTradeFormResponse } from 'invity-api';
+import { submitRequestForm as utilsSubmitRequestForm } from '@wallet-utils/coinmarket/buyUtils';
+import { isDesktop } from '@suite/utils/suite/env';
 
 export const verifyAddress = (path: string, address: string) => async (
     dispatch: Dispatch,
@@ -90,4 +94,15 @@ export const verifyAddress = (path: string, address: string) => async (
             }),
         );
     }
+};
+
+export const submitRequestForm = (tradeForm: BuyTradeFormResponse) => async (
+    dispatch: Dispatch,
+    getState: GetState,
+) => {
+    const { device } = getState().suite;
+    if (device && !device.remember && !isDesktop()) {
+        dispatch(suiteActions.rememberDevice(device, true));
+    }
+    utilsSubmitRequestForm(tradeForm);
 };

--- a/packages/suite/src/hooks/wallet/useCoinmarketBuyOffers.ts
+++ b/packages/suite/src/hooks/wallet/useCoinmarketBuyOffers.ts
@@ -6,11 +6,7 @@ import { processQuotes } from '@wallet-utils/coinmarket/buyUtils';
 import * as coinmarketCommonActions from '@wallet-actions/coinmarketCommonActions';
 import * as coinmarketBuyActions from '@wallet-actions/coinmarketBuyActions';
 import * as routerActions from '@suite-actions/routerActions';
-import {
-    createQuoteLink,
-    submitRequestForm,
-    createTxLink,
-} from '@suite/utils/wallet/coinmarket/buyUtils';
+import { createQuoteLink, createTxLink } from '@suite/utils/wallet/coinmarket/buyUtils';
 import { Props, ContextValues } from '@wallet-types/coinmarketBuyOffers';
 import * as notificationActions from '@suite-actions/notificationActions';
 import { isDesktop } from '@suite-utils/env';
@@ -42,6 +38,7 @@ export const useOffers = (props: Props) => {
         addNotification,
         saveTransactionDetailId,
         verifyAddress,
+        submitRequestForm,
         goto,
     } = useActions({
         saveTrade: coinmarketBuyActions.saveTrade,
@@ -50,6 +47,7 @@ export const useOffers = (props: Props) => {
         addNotification: notificationActions.addToast,
         saveTransactionDetailId: coinmarketBuyActions.saveTransactionDetailId,
         verifyAddress: coinmarketCommonActions.verifyAddress,
+        submitRequestForm: coinmarketCommonActions.submitRequestForm,
         goto: routerActions.goto,
     });
 
@@ -104,7 +102,7 @@ export const useOffers = (props: Props) => {
                     });
                     if (response) {
                         if (response.trade.status === 'LOGIN_REQUEST' && response.tradeForm) {
-                            submitRequestForm(response.tradeForm);
+                            await submitRequestForm(response.tradeForm);
                         } else {
                             const errorMessage = `[doBuyTrade] ${response.trade.status} ${response.trade.error}`;
                             console.log(errorMessage);
@@ -148,7 +146,7 @@ export const useOffers = (props: Props) => {
         } else {
             await saveTrade(response.trade, account, new Date().toISOString());
             if (response.tradeForm) {
-                submitRequestForm(response.tradeForm);
+                await submitRequestForm(response.tradeForm);
             }
             if (isDesktop()) {
                 await saveTransactionDetailId(response.trade.paymentId);

--- a/packages/suite/src/middlewares/suite/suiteMiddleware.ts
+++ b/packages/suite/src/middlewares/suite/suiteMiddleware.ts
@@ -36,7 +36,19 @@ const suite = (api: MiddlewareAPI<Dispatch, AppState>) => (next: Dispatch) => as
                 action.payload.devices &&
                 action.payload.devices[0]
             ) {
-                api.dispatch(suiteActions.selectDevice(action.payload.devices[0]));
+                // if there are force remember devices, forget them and pick the first one of them as selected device
+                const forcedDevices = action.payload.devices.filter(
+                    d => d.forceRemember && d.remember,
+                );
+                forcedDevices.forEach(d => {
+                    api.dispatch(suiteActions.rememberDevice(d));
+                });
+                // possible improvement - if there are no forcedDevices, try to pick the connected device instead of the first device
+                api.dispatch(
+                    suiteActions.selectDevice(
+                        forcedDevices.length ? forcedDevices[0] : action.payload.devices[0],
+                    ),
+                );
             }
             // right after storage is loaded, we might start:
             // 1. fetching locales

--- a/packages/suite/src/middlewares/wallet/storageMiddleware.ts
+++ b/packages/suite/src/middlewares/wallet/storageMiddleware.ts
@@ -28,7 +28,13 @@ const storageMiddleware = (api: MiddlewareAPI<Dispatch, AppState>) => (next: Dis
 
     switch (action.type) {
         case SUITE.REMEMBER_DEVICE:
-            api.dispatch(storageActions.rememberDevice(action.payload, action.remember));
+            api.dispatch(
+                storageActions.rememberDevice(
+                    action.payload,
+                    action.remember,
+                    action.forceRemember,
+                ),
+            );
             break;
 
         case SUITE.FORGET_DEVICE:

--- a/packages/suite/src/reducers/suite/deviceReducer.ts
+++ b/packages/suite/src/reducers/suite/deviceReducer.ts
@@ -314,12 +314,14 @@ const createInstance = (draft: State, device: TrezorDevice) => {
  * @param {State} draft
  * @param {TrezorDevice} device
  */
-const remember = (draft: State, device: TrezorDevice, remember: boolean) => {
+const remember = (draft: State, device: TrezorDevice, remember: boolean, forceRemember?: true) => {
     // only acquired devices with state
     if (!device || !device.features || !device.state) return;
     draft.forEach(d => {
         if (deviceUtils.isSelectedInstance(device, d)) {
             d.remember = remember;
+            if (forceRemember) d.forceRemember = true;
+            else delete d.forceRemember;
         }
     });
 };
@@ -428,7 +430,7 @@ const deviceReducer = (state: State = initialState, action: Action): State => {
                 createInstance(draft, action.payload);
                 break;
             case SUITE.REMEMBER_DEVICE:
-                remember(draft, action.payload, action.remember);
+                remember(draft, action.payload, action.remember, action.forceRemember);
                 break;
             case SUITE.FORGET_DEVICE:
                 forget(draft, action.payload);

--- a/packages/suite/src/types/suite/index.ts
+++ b/packages/suite/src/types/suite/index.ts
@@ -70,6 +70,7 @@ export interface ExtendedDevice {
     useEmptyPassphrase: boolean;
     passphraseOnDevice?: boolean;
     remember?: boolean; // device should be remembered
+    forceRemember?: true; // device was forced to be remembered
     connected: boolean; // device is connected
     available: boolean; // device cannot be used because of features.passphrase_protection is different then expected
     authConfirm?: boolean; // device cannot be used because passphrase was not confirmed

--- a/packages/suite/src/utils/suite/storage.ts
+++ b/packages/suite/src/utils/suite/storage.ts
@@ -12,10 +12,14 @@ export const serializeDiscovery = (discovery: Discovery) => ({ ...discovery, run
  * Strip fields from Device
  * @param {AcquiredDevice} device
  */
-export const serializeDevice = (device: AcquiredDevice) => ({
-    ...device,
-    path: '',
-    remember: true,
-    connected: false,
-    buttonRequests: [],
-});
+export const serializeDevice = (device: AcquiredDevice, forceRemember?: true) => {
+    const sd = {
+        ...device,
+        path: '',
+        remember: true,
+        connected: false,
+        buttonRequests: [],
+    };
+    if (forceRemember) sd.forceRemember = true;
+    return sd;
+};

--- a/packages/suite/src/views/settings/debug/index.tsx
+++ b/packages/suite/src/views/settings/debug/index.tsx
@@ -6,12 +6,30 @@ import React from 'react';
 
 import { Props } from './Container';
 import invityAPI from '@suite-services/invityAPI';
+import { useSelector } from '@suite-hooks';
 
 const StyledActionColumn = styled(ActionColumn)`
     max-width: 300px;
 `;
 
 const DebugSettings = (props: Props) => {
+    const invityAPIUrl = useSelector(state => state.suite.settings.debug.invityAPIUrl);
+    const invityApiServerOptions = [
+        {
+            label: invityAPI.productionAPIServer,
+            value: invityAPI.productionAPIServer,
+        },
+        {
+            label: invityAPI.stagingAPIServer,
+            value: invityAPI.stagingAPIServer,
+        },
+        {
+            label: invityAPI.localhostAPIServer,
+            value: invityAPI.localhostAPIServer,
+        },
+    ];
+    const selectedInvityApiServer =
+        invityApiServerOptions.find(s => s.value === invityAPIUrl) || invityApiServerOptions[0];
     return (
         <SettingsLayout>
             <Section title="Localization">
@@ -62,24 +80,8 @@ const DebugSettings = (props: Props) => {
                                 });
                                 invityAPI.setInvityAPIServer(item.value);
                             }}
-                            value={{
-                                label: invityAPI.server,
-                                value: invityAPI.server,
-                            }}
-                            options={[
-                                {
-                                    label: invityAPI.localhostAPIServer,
-                                    value: invityAPI.localhostAPIServer,
-                                },
-                                {
-                                    label: invityAPI.stagingAPIServer,
-                                    value: invityAPI.stagingAPIServer,
-                                },
-                                {
-                                    label: invityAPI.productionAPIServer,
-                                    value: invityAPI.productionAPIServer,
-                                },
-                            ]}
+                            value={selectedInvityApiServer}
+                            options={invityApiServerOptions}
                         />
                     </StyledActionColumn>
                 </Row>

--- a/packages/suite/src/views/wallet/coinmarket/buy/detail/components/WaitingForPayment/index.tsx
+++ b/packages/suite/src/views/wallet/coinmarket/buy/detail/components/WaitingForPayment/index.tsx
@@ -7,7 +7,9 @@ import { Translation } from '@suite-components/Translation';
 import { BuyTrade } from 'invity-api';
 import { Account } from '@wallet-types';
 import invityAPI from '@suite-services/invityAPI';
-import { createTxLink, submitRequestForm } from '@wallet-utils/coinmarket/buyUtils';
+import { createTxLink } from '@wallet-utils/coinmarket/buyUtils';
+import * as coinmarketCommonActions from '@wallet-actions/coinmarketCommonActions';
+import { useActions } from '@suite-hooks';
 
 const Wrapper = styled.div`
     display: flex;
@@ -51,6 +53,11 @@ interface Props {
 
 const WaitingForPayment = ({ transactionId, trade, account }: Props) => {
     const [isWorking, setIsWorking] = useState(false);
+
+    const { submitRequestForm } = useActions({
+        submitRequestForm: coinmarketCommonActions.submitRequestForm,
+    });
+
     const goToPayment = () => {
         setIsWorking(true);
         invityAPI


### PR DESCRIPTION
To skip passphrase entry after return from the payment gate, current device is set to remember mode before switching to the payment gate.
To not to change the setting for ever, after return from the payment gate, the remember mode is reset.

Fixes #2691.