### PR TITLE
fix(suite-desktop): Unify title bar on MacOS

### DIFF
--- a/packages/components/src/components/Icon/icons.ts
+++ b/packages/components/src/components/Icon/icons.ts
@@ -92,5 +92,7 @@ export const ICONS = {
     WINDOW_CLOSE: require('../../images/icons/window_close.svg'),
     WINDOW_MINIMIZE: require('../../images/icons/window_minimize.svg'),
     WINDOW_MAXIMIZE: require('../../images/icons/window_maximize.svg'),
+    WINDOW_MAXIMIZE_MAC: require('../../images/icons/window_maximize_mac.svg'),
     WINDOW_RESTORE: require('../../images/icons/window_restore.svg'),
+    WINDOW_RESTORE_MAC: require('../../images/icons/window_restore_mac.svg'),
 };

--- a/packages/components/src/config/variables.ts
+++ b/packages/components/src/config/variables.ts
@@ -151,5 +151,7 @@ export const ICONS: IconType[] = [
     'WINDOW_CLOSE',
     'WINDOW_MINIMIZE',
     'WINDOW_MAXIMIZE',
+    'WINDOW_MAXIMIZE_MAC',
     'WINDOW_RESTORE',
+    'WINDOW_RESTORE_MAC',
 ];

--- a/packages/components/src/images/icons/window_maximize_mac.svg
+++ b/packages/components/src/images/icons/window_maximize_mac.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" fill-rule="evenodd" stroke-linejoin="round" stroke-miterlimit="2" clip-rule="evenodd" viewBox="0 0 24 24"><path d="M5.015 8.307l10.678 10.678H7.707a2.708 2.708 0 01-2.692-2.693V8.307zm3.292-3.292h7.986a2.708 2.708 0 012.692 2.693v7.985L8.307 5.015z"/></svg>

--- a/packages/components/src/images/icons/window_restore_mac.svg
+++ b/packages/components/src/images/icons/window_restore_mac.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" fill-rule="evenodd" stroke-linejoin="round" stroke-miterlimit="2" clip-rule="evenodd" viewBox="0 0 24 24"><path d="M12.09 1.907L22.093 11.91h-7.48a2.536 2.536 0 01-2.523-2.524v-7.48zM2.087 11.91h7.48a2.536 2.536 0 012.523 2.524v7.48L2.087 11.91z"/></svg>

--- a/packages/suite-desktop/src-electron/electron.ts
+++ b/packages/suite-desktop/src-electron/electron.ts
@@ -72,6 +72,11 @@ const notifyWindowMaximized = (window: BrowserWindow) => {
     );
 };
 
+// notify client with window active state
+const notifyWindowActive = (window: BrowserWindow, state: boolean) => {
+    window.webContents.send('window/is-active', state);
+};
+
 const init = async () => {
     try {
         await bridge.start();
@@ -226,6 +231,12 @@ const init = async () => {
     });
     mainWindow.on('moved', () => {
         notifyWindowMaximized(mainWindow);
+    });
+    mainWindow.on('focus', () => {
+        notifyWindowActive(mainWindow, true);
+    });
+    mainWindow.on('blur', () => {
+        notifyWindowActive(mainWindow, false);
     });
 
     httpReceiver.start();

--- a/packages/suite-desktop/src-electron/preload.ts
+++ b/packages/suite-desktop/src-electron/preload.ts
@@ -26,6 +26,7 @@ const validChannels = [
 
     // window
     'window/is-maximized',
+    'window/is-active',
 ];
 
 contextBridge.exposeInMainWorld('desktopApi', {


### PR DESCRIPTION
- custom MacOS icons for maximize and restore action
- got rid of hover component state, done with CSS instead (there was a problem with maximize icon not being updated after window maximize animation)
- improved MacOS action icons (size, margins, hover states)

It's still not perfect (we might need to align the style for Windows as well and maybe also do touch-ups for Retina screens, but I'd do that in an another iteration)