### PR TITLE
Fix/pending tx unused addr

### DIFF
--- a/packages/suite/src/actions/wallet/selectedAccountActions.ts
+++ b/packages/suite/src/actions/wallet/selectedAccountActions.ts
@@ -224,7 +224,7 @@ export const getStateForAction = (action: Action) => (dispatch: Dispatch, getSta
 
     // find differences
     const stateChanged = comparisonUtils.isChanged(state.wallet.selectedAccount, newState, {
-        account: ['descriptor', 'availableBalance', 'misc', 'tokens', 'metadata'],
+        account: ['descriptor', 'availableBalance', 'misc', 'tokens', 'metadata', 'addresses'],
         discovery: [
             'status',
             'index',

--- a/packages/suite/src/utils/wallet/transactionUtils.ts
+++ b/packages/suite/src/utils/wallet/transactionUtils.ts
@@ -244,3 +244,7 @@ export const isTxUnknown = (transaction: WalletAccountTransaction) => {
         transaction.type === 'unknown'
     );
 };
+
+export const isTxPending = (transaction: WalletAccountTransaction | AccountTransaction) => {
+    return !transaction.blockHeight || transaction.blockHeight < 0;
+};

--- a/packages/suite/src/views/wallet/receive/Container.ts
+++ b/packages/suite/src/views/wallet/receive/Container.ts
@@ -34,6 +34,7 @@ export interface ChildProps {
     showAddress: Props['showAddress'];
     disabled: boolean;
     locked: boolean;
+    pendingAddresses: string[];
 }
 
 export default injectIntl(connect(mapStateToProps, mapDispatchToProps)(SendIndex));

--- a/packages/suite/src/views/wallet/receive/components/FreshAddress/index.tsx
+++ b/packages/suite/src/views/wallet/receive/components/FreshAddress/index.tsx
@@ -97,6 +97,7 @@ const FreshAddress = ({
     addresses,
     showAddress,
     disabled,
+    pendingAddresses,
     locked,
     intl,
 }: Props & WrappedComponentProps) => {
@@ -110,7 +111,11 @@ const FreshAddress = ({
                   transfers: account.history.total,
               },
           ];
-    const unrevealed = unused.filter(a => !addresses.find(r => r.path === a.path));
+
+    const unrevealed = unused.filter(
+        a =>
+            !addresses.find(r => r.path === a.path) && !pendingAddresses.find(p => p === a.address),
+    );
     // const addressLabel = isBitcoin ? 'RECEIVE_ADDRESS_FRESH' : 'RECEIVE_ADDRESS';
     // NOTE: unrevealed[0] can be undefined (limit exceeded)
     const firstFreshAddress = isBitcoin ? unrevealed[0] : unused[0];

--- a/packages/suite/src/views/wallet/receive/components/UsedAddresses/index.tsx
+++ b/packages/suite/src/views/wallet/receive/components/UsedAddresses/index.tsx
@@ -170,15 +170,18 @@ const Item = ({ addr, symbol, onClick, metadataPayload, index }: ItemProps) => {
     );
 };
 
-const UsedAddresses = ({ account, addresses, showAddress, locked }: Props) => {
+const UsedAddresses = ({ account, addresses, pendingAddresses, showAddress, locked }: Props) => {
     const [limit, setLimit] = useState(DEFAULT_LIMIT);
+
     if (account.networkType !== 'bitcoin' || !account.addresses) return null;
     const { used, unused } = account.addresses;
     const { addressLabels } = account.metadata;
     // find revealed addresses in `unused` list
-    const revealed = addresses.reduce((result, addr) => {
-        const x = unused.find(u => u.path === addr.path);
-        return x ? result.concat(x) : result;
+    const revealed = unused.reduce((result, addr) => {
+        const r = addresses.find(u => u.path === addr.path);
+        const p = pendingAddresses.find(u => u === addr.address);
+        const f = r || p;
+        return f ? result.concat(addr) : result;
     }, [] as typeof unused);
     // TODO: add skipped addresses?
     // add revealed addresses to `used` list

--- a/packages/suite/src/views/wallet/receive/index.tsx
+++ b/packages/suite/src/views/wallet/receive/index.tsx
@@ -3,17 +3,28 @@ import { WalletLayout } from '@wallet-components';
 import { useDevice } from '@suite-hooks';
 import FreshAddress from './components/FreshAddress';
 import UsedAddresses from './components/UsedAddresses';
+import { useSelector } from '@suite/hooks/suite';
+import { isTxPending } from '@wallet-utils/transactionUtils';
+import { getAccountTransactions } from '@wallet-utils/accountUtils';
 import { Props } from './Container';
 
 const Receive = ({ selectedAccount, receive, device, showAddress }: Props) => {
     const { isLocked } = useDevice();
     const isDeviceLocked = isLocked(true);
+    const transactions = useSelector(state => state.wallet.transactions.transactions);
+
     if (!device || selectedAccount.status !== 'loaded') {
         return <WalletLayout title="TR_NAV_RECEIVE" account={selectedAccount} />;
     }
 
     const { account } = selectedAccount;
     const disabled = !!device.authConfirm;
+
+    const pendingTxs = getAccountTransactions(transactions, account).filter(isTxPending);
+    const pendingAddresses: string[] = [];
+    pendingTxs.forEach(t =>
+        t.targets.forEach(target => target.addresses?.forEach(a => pendingAddresses.unshift(a))),
+    );
 
     return (
         <WalletLayout title="TR_NAV_RECEIVE" account={selectedAccount}>
@@ -23,6 +34,7 @@ const Receive = ({ selectedAccount, receive, device, showAddress }: Props) => {
                 showAddress={showAddress}
                 disabled={disabled}
                 locked={isDeviceLocked}
+                pendingAddresses={pendingAddresses}
             />
             <UsedAddresses
                 account={account}
@@ -30,6 +42,7 @@ const Receive = ({ selectedAccount, receive, device, showAddress }: Props) => {
                 showAddress={showAddress}
                 disabled={disabled}
                 locked={isDeviceLocked}
+                pendingAddresses={pendingAddresses}
             />
         </WalletLayout>
     );


### PR DESCRIPTION
1. commit solves obvious bug, when transaction to the account address got confirmed the account's list of unused address will get updated (removing now used address from the list), but `selectedAccount` still had the stale data, thus you would still find old fresh address in receive tab (till you hit refresh in the browser)

2. commit solves https://github.com/trezor/trezor-suite/issues/2652