### PR TITLE
fix(tor): custom backed not clearing properly when tor is switched off

### DIFF
--- a/packages/suite/src/actions/wallet/blockchainActions.ts
+++ b/packages/suite/src/actions/wallet/blockchainActions.ts
@@ -164,6 +164,20 @@ export const setCustomBackend = (symbol?: string) => async (_: Dispatch, getStat
     return Promise.all(promises);
 };
 
+export const clearCustomBackend = (symbol: string | string[]) => async () => {
+    const coins = typeof symbol === 'string' ? [symbol] : [...new Set(symbol)];
+    const promises = coins.map(coin => {
+        return TrezorConnect.blockchainSetCustomBackend({
+            coin,
+            blockchainLink: {
+                type: 'blockbook',
+                url: [],
+            },
+        });
+    });
+    return Promise.all(promises);
+};
+
 export const init = () => async (dispatch: Dispatch, getState: GetState) => {
     await dispatch(preloadFeeInfo());
 

--- a/packages/suite/src/middlewares/wallet/walletMiddleware.ts
+++ b/packages/suite/src/middlewares/wallet/walletMiddleware.ts
@@ -30,6 +30,14 @@ const walletMiddleware = (api: MiddlewareAPI<Dispatch, AppState>) => (next: Disp
         api.dispatch(transactionActions.add(account.history.transactions || [], account, 1));
     }
 
+    if (action.type === WALLET_SETTINGS.CLEAR_TOR_BLOCKBOOK_URLS) {
+        const torCoins = api
+            .getState()
+            .wallet.settings.blockbookUrls.filter(b => b.tor)
+            .map(b => b.coin);
+        api.dispatch(blockchainActions.clearCustomBackend(torCoins));
+    }
+
     // propagate action to reducers
     next(action);
 
@@ -49,10 +57,7 @@ const walletMiddleware = (api: MiddlewareAPI<Dispatch, AppState>) => (next: Disp
         api.dispatch(blockchainActions.setCustomBackend(action.payload.coin));
     }
 
-    if (
-        action.type === WALLET_SETTINGS.SET_BLOCKBOOK_URLS ||
-        action.type === WALLET_SETTINGS.CLEAR_TOR_BLOCKBOOK_URLS
-    ) {
+    if (action.type === WALLET_SETTINGS.SET_BLOCKBOOK_URLS) {
         api.dispatch(blockchainActions.setCustomBackend());
     }
 


### PR DESCRIPTION
Custom backends were not cleared properly when Tor was switched off. That would result in the backends still pointing to the .onion domains without using Tor.