### PR TITLE
fix(suie): reload the app right after removing db

### DIFF
--- a/packages/suite/src/support/suite/ErrorBoundary.tsx
+++ b/packages/suite/src/support/suite/ErrorBoundary.tsx
@@ -140,8 +140,8 @@ class ErrorBoundary extends React.Component<Props, StateProps> {
                         <StyledButton
                             icon="REFRESH"
                             variant="tertiary"
-                            onClick={async () => {
-                                await db.removeDatabase();
+                            onClick={() => {
+                                db.removeDatabase();
                                 refresh();
                             }}
                         >


### PR DESCRIPTION
awaiting removeDB operation was not good idea since it won't resolve untill app is reloaded 😁 
`This instance is blocking the IDB upgrade to new version.`

When we were only clearing existing stores it worked fine, but it got broken when we started dropping whole DB.

close https://github.com/trezor/trezor-suite/issues/2839