### PR TITLE
fix(suite): show target's amount for each "sent to self" target

### DIFF
--- a/packages/suite/src/utils/wallet/transactionUtils.ts
+++ b/packages/suite/src/utils/wallet/transactionUtils.ts
@@ -218,21 +218,9 @@ export const getTxOperation = (transaction: WalletAccountTransaction) => {
     return null;
 };
 
-export const getTargetAmount = (
-    target: WalletAccountTransaction['targets'][number],
-    transaction: WalletAccountTransaction,
-) => {
-    const isLocalTarget =
-        (transaction.type === 'sent' || transaction.type === 'self') && target.isAccountTarget;
-    const hasAmount = !isLocalTarget && typeof target.amount === 'string' && target.amount !== '0';
-    const targetAmount =
-        (hasAmount ? target.amount : null) ||
-        (target === transaction.targets[0] &&
-        typeof transaction.amount === 'string' &&
-        transaction.amount !== '0'
-            ? transaction.amount
-            : null);
-    return targetAmount;
+export const getTargetAmount = (target: WalletAccountTransaction['targets'][number]) => {
+    const hasAmount = typeof target.amount === 'string' && target.amount !== '0';
+    return hasAmount ? target.amount : null;
 };
 
 export const isTxUnknown = (transaction: WalletAccountTransaction) => {

--- a/packages/suite/src/views/wallet/transactions/components/TransactionList/components/TransactionItem/components/Target/index.tsx
+++ b/packages/suite/src/views/wallet/transactions/components/TransactionList/components/TransactionItem/components/Target/index.tsx
@@ -72,7 +72,7 @@ export const Target = ({
     accountKey,
     ...baseLayoutProps
 }: TargetProps) => {
-    const targetAmount = getTargetAmount(target, transaction);
+    const targetAmount = getTargetAmount(target);
     const operation = getTxOperation(transaction);
     const { addNotification } = useActions({ addNotification: notificationActions.addToast });
     const targetMetadata = accountMetadata?.outputLabels?.[transaction.txid]?.[target.n];

--- a/packages/suite/src/views/wallet/transactions/components/TransactionList/components/TransactionItem/components/TransactionHeading/index.tsx
+++ b/packages/suite/src/views/wallet/transactions/components/TransactionList/components/TransactionItem/components/TransactionHeading/index.tsx
@@ -76,9 +76,7 @@ const TransactionHeading = ({
     const [headingIsHovered, setHeadingIsHovered] = useState(false);
 
     if (useSingleRowLayout) {
-        const targetAmount = !isTokenTransaction
-            ? getTargetAmount(target, transaction)
-            : transfer.amount;
+        const targetAmount = !isTokenTransaction ? getTargetAmount(target) : transfer.amount;
         const operation = getTxOperation(transaction);
         amount = (
             <CryptoAmount>


### PR DESCRIPTION
close https://github.com/trezor/trezor-suite/issues/2809

looks like it was some kind of business that we didn't show amount for each "sent to self" target instead we've shown ~aggregated sum for all these targets~ actually, it's the amount that was sent away to different acc + fee, next to the first "sent to self" target.
After consulting @matejzak we've come to decision to remove this

edit: ohh, I think I see what is going on there 😬 It is not aggregated sum of "self" targets, but the amount that was sent away to different acc + fee
nevermind, this needs another solution

⚠️ ⚠️ ⚠️ 
**I have an idea tho, we could always show all self outputs as a one with aggregated sum next to it and that would solve the problem.**
⚠️ ⚠️ ⚠️ 

before:
<img width="906" alt="Screenshot 2020-11-03 at 14 44 04" src="https://user-images.githubusercontent.com/6961901/97992861-9769b100-1de3-11eb-8a89-f1e2144f56ed.png">

after:
??