### PR TITLE
fix(suite): pass className to tooltip wrapper, unify tooltip styling

### DIFF
--- a/packages/components/src/components/Tooltip/index.tsx
+++ b/packages/components/src/components/Tooltip/index.tsx
@@ -45,26 +45,6 @@ ${tippy}
     .tippy-arrow {
         border-right-color: ${colors.NEUE_BG_TOOLTIP};
     }
-
-
-.tippy-tooltip.dark-grey  {
-    background: ${colors.NEUE_TYPE_DARK_GREY};
-}
-.tippy-tooltip.dark-grey[data-placement^='top'] > .tippy-arrow {
-    border-top-color: ${colors.NEUE_TYPE_DARK_GREY};
-}
-
-.tippy-tooltip.dark-grey[data-placement^='bottom'] > .tippy-arrow {
-    border-bottom-color: ${colors.NEUE_TYPE_DARK_GREY};
-}
-
-.tippy-tooltip.dark-grey[data-placement^='left'] > .tippy-arrow {
-    border-left-color: ${colors.NEUE_TYPE_DARK_GREY};
-}
-
-.tippy-tooltip.dark-grey[data-placement^='right'] > .tippy-arrow {
-    border-right-color: ${colors.NEUE_TYPE_DARK_GREY};
-}
 `;
 
 const Wrapper = styled.div``;
@@ -94,7 +74,7 @@ const Tooltip = ({
     content,
     ...rest
 }: Props) => (
-    <Wrapper>
+    <Wrapper className={className}>
         <Tippy
             zIndex={10070}
             arrow
@@ -113,7 +93,6 @@ const Tooltip = ({
                     )}
                 </>
             }
-            className={className}
             {...rest}
         >
             <Content>{children}</Content>

--- a/packages/suite/src/components/suite/NavigationBar/components/NavigationActions/index.tsx
+++ b/packages/suite/src/components/suite/NavigationBar/components/NavigationActions/index.tsx
@@ -156,7 +156,6 @@ const NavigationActions = (props: Props) => {
                                     action={() => action('settings-index')}
                                 />
                             }
-                            className="dark-grey"
                             {...props}
                         >
                             <>


### PR DESCRIPTION
Small fix for bug introduced in TOR PR (Tooltip's `clasname` prop was passed to different component).
I also unified tooltip design which allowed me to completely remove all additional styles which was basically the only reason `className` prop was moved 

close https://github.com/trezor/trezor-suite/issues/2845