### PR TITLE
fix(suite-desktop): use binary dir as current dir + library dir

### DIFF
--- a/packages/suite-desktop/src-electron/processes/TorProcess.ts
+++ b/packages/suite-desktop/src-electron/processes/TorProcess.ts
@@ -44,7 +44,7 @@ class TorProcess extends BaseProcess {
         // Only try to start the process if it's the default Tor address.
         // Otherwise the user might be pointing to a different instance.
         if (this.adr === defaultTorAddress) {
-            await super.start();
+            await super.start(['-f', 'torrc']);
         }
     }
 }


### PR DESCRIPTION
This fixes launching of Tor on NixOS (and other Linuxes which do not have libcrypto/libevent/libssl in standard locations) by specifying that we should look for dynamic libraries also in the directory of the binary.

Also this changes the launched process' working directory to the binary directory and we also load the provided config for the bundled Tor.

I think this issue also affects macOS, so I fixed that as well (by using the same `LD_LIBRARY_PATH` trick but with `DYLD_LIBRARY_PATH`).