### PR TITLE
ci(suite): don't try to reach onion domain during test

### DIFF
--- a/packages/suite/test/health/urls.test.ts
+++ b/packages/suite/test/health/urls.test.ts
@@ -8,6 +8,8 @@ const excluded = [
     URLS.TREZOR_DATA_URL,
     // TODO: it works locally but CI times out, probably cant handle the redirect or something..
     URLS.TOS_URL,
+    // Trezor onion domain is unreachable without Tor
+    URLS.TOR_DOMAIN,
 ];
 
 const getUrls = () => {


### PR DESCRIPTION
This should fix the following CI error:

```
    ✕ HTTP GET request to trezoriovpjcahpzkrewelclulmszwbqpzmzgub37gbcjlvluxtruqad.onion should respond with range >= 200 && < 400 (1 ms)
```