### PR TITLE
fix(suite): discreet mode menu border-top outside mobile view

### DIFF
--- a/packages/suite/src/components/suite/NavigationBar/components/NavigationActions/components/ActionItem/index.tsx
+++ b/packages/suite/src/components/suite/NavigationBar/components/NavigationActions/components/ActionItem/index.tsx
@@ -61,6 +61,12 @@ const AlertDot = styled.div`
     background: ${colors.NEUE_TYPE_RED};
 `;
 
+// The Icon can be switched dynamically (e.g. Discreet mode icon) and without fixed size the whole row of NavigationActions jumps on the first switch
+const StyledIcon = styled(Icon)`
+    width: 24px;
+    height: 24px;
+`;
+
 interface CommonProps extends Pick<React.HTMLAttributes<HTMLDivElement>, 'onClick'> {
     label: React.ReactNode;
     isActive?: boolean;
@@ -81,7 +87,7 @@ type Props = CustomIconComponentProps | IconComponentProps;
 
 const ActionItem = (props: Props) => {
     const iconComponent = props.icon ? (
-        <Icon
+        <StyledIcon
             color={props.isActive ? colors.NEUE_TYPE_DARK_GREY : colors.NEUE_TYPE_LIGHT_GREY}
             size={24}
             icon={props.icon}

--- a/packages/suite/src/components/suite/NavigationBar/components/NavigationActions/index.tsx
+++ b/packages/suite/src/components/suite/NavigationBar/components/NavigationActions/index.tsx
@@ -31,6 +31,7 @@ const ActionsContainer = styled.div<{ desktop: boolean; mobileLayout?: boolean }
         `display: flex;
         align-items: center;
         margin-left: 28px;
+        border-top: 0;
     `}
     ${props =>
         props.desktop &&


### PR DESCRIPTION
- there was a missing style for non-mobile view (border-top should be visible only in mobile view)
- the discreet mode icon is loaded dynamically on the first load, I fixed the jumping by setting fixed size to the Icon instance wrapper 

Maybe it would be better to have an option to preload the icon for cases like discreet mode or set the fixed size on the Icon component level, not just this instance. But I'd rather do that in an another PR so I don't block the release causing more issues