### PR TITLE
fix(suite): fetch account info after blockchain connection

### DIFF
--- a/packages/suite/src/actions/wallet/__fixtures__/blockchainActions.ts
+++ b/packages/suite/src/actions/wallet/__fixtures__/blockchainActions.ts
@@ -324,7 +324,7 @@ export const onConnect = [
     {
         description: 'successful with subscription',
         initialState: {
-            accounts: [{ symbol: 'btc' }],
+            accounts: [{ symbol: 'btc', history: {} }],
             blockchain: {
                 btc: {
                     reconnection: { id: 1 },
@@ -340,7 +340,7 @@ export const onConnect = [
     {
         description: 'successful, subscribeFiatRates failed, fee levels sorted',
         initialState: {
-            accounts: [{ symbol: 'btc' }],
+            accounts: [{ symbol: 'btc', history: {} }],
         },
         // order: subscribeFiatRates > estimateFee
         connect: [
@@ -356,7 +356,7 @@ export const onConnect = [
     {
         description: 'successful, blockchainEstimateFee failed',
         initialState: {
-            accounts: [{ symbol: 'eth' }],
+            accounts: [{ symbol: 'eth', history: {} }],
         },
         // order: subscribeFiatRates > subscribe > estimateFee
         connect: [undefined, undefined, { success: false }],

--- a/packages/suite/src/actions/wallet/blockchainActions.ts
+++ b/packages/suite/src/actions/wallet/blockchainActions.ts
@@ -269,6 +269,12 @@ export const onConnect = (symbol: string) => async (dispatch: Dispatch, getState
     }
     await dispatch(subscribe(network.symbol, true));
     await dispatch(updateFeeInfo(network.symbol));
+    // update accounts for connected network
+    const accounts = getState().wallet.accounts.filter(a => a.symbol === network.symbol);
+    if (accounts.length) {
+        const promises = accounts.map(a => dispatch(accountActions.fetchAndUpdateAccount(a)));
+        await Promise.all(promises);
+    }
     dispatch({ type: BLOCKCHAIN.CONNECTED });
 };
 


### PR DESCRIPTION
should fix https://github.com/trezor/trezor-suite/issues/2563
and probably fix for "missing pending tx" issue (reported by @slush0  on slack)

how to test it:
1. open desktop app (or chrome without incognito) discover and "remember" device
2. get receive address from one of the accounts
3. close app (or chrome tab)
4. open suite in different env. (if you used desktop app in prev step - open it in chrome, if you used chrome - open in firefox or incognito mode)
5. send coins from/to the account from step 2. (point here is to change account balance)
6. close suite from step 4.
7. open suite from step 1.

account balances should be updated