### PR TITLE
fix(suite): unify icon width and height based on passed size

### DIFF
--- a/packages/components/src/components/Dropdown/index.tsx
+++ b/packages/components/src/components/Dropdown/index.tsx
@@ -94,10 +94,6 @@ const MenuItem = styled.li<MenuItemProps>`
         `}
 `;
 
-const DefaultTogglerIcon = styled(Icon)<Pick<Props, 'isDisabled'>>`
-    cursor: ${props => (!props.isDisabled ? 'pointer' : 'default')};
-`;
-
 const IconWrapper = styled.div`
     margin-right: 16px;
 `;
@@ -231,7 +227,7 @@ const Dropdown = ({
                 : undefined,
         })
     ) : (
-        <DefaultTogglerIcon
+        <Icon
             ref={toggleRef}
             size={24}
             icon="MORE"
@@ -244,7 +240,6 @@ const Dropdown = ({
                       }
                     : undefined
             }
-            isDisabled={isDisabled}
             {...rest}
         />
     );

--- a/packages/components/src/components/Icon/index.tsx
+++ b/packages/components/src/components/Icon/index.tsx
@@ -114,7 +114,7 @@ const Icon = React.forwardRef(
                 isActive={isActive}
                 size={size}
                 ref={ref}
-                useCursorPointer={useCursorPointer}
+                useCursorPointer={onClick !== undefined || useCursorPointer}
                 {...rest}
             >
                 <ReactSVG

--- a/packages/components/src/components/Icon/index.tsx
+++ b/packages/components/src/components/Icon/index.tsx
@@ -40,6 +40,7 @@ const SvgWrapper = styled.div<WrapperProps>`
     align-items: center;
     justify-content: center;
     height: ${props => props.size}px;
+    width: ${props => props.size}px;
     animation: ${props => chooseIconAnimationType(props.canAnimate, props.isActive)} 0.2s linear 1
         forwards;
 

--- a/packages/suite/src/components/suite/NavigationBar/components/DeviceSelector/components/DeviceStatus/index.tsx
+++ b/packages/suite/src/components/suite/NavigationBar/components/DeviceSelector/components/DeviceStatus/index.tsx
@@ -55,10 +55,6 @@ const IconWrapper = styled.div`
     margin-top: 4px;
 `;
 
-const StyledIcon = styled(Icon)`
-    cursor: pointer;
-`;
-
 const OuterCircle = styled.div<{ show: boolean; status: Status }>`
     display: flex;
     justify-content: center;
@@ -100,7 +96,7 @@ const DeviceStatus = ({
     if (status === 'warning' && onRefreshClick) {
         return (
             <IconWrapper>
-                <StyledIcon
+                <Icon
                     onClick={(e: any) => {
                         e.stopPropagation();
                         onRefreshClick();

--- a/packages/suite/src/components/suite/NavigationBar/components/NavigationActions/components/ActionItem/index.tsx
+++ b/packages/suite/src/components/suite/NavigationBar/components/NavigationActions/components/ActionItem/index.tsx
@@ -61,12 +61,6 @@ const AlertDot = styled.div`
     background: ${colors.NEUE_TYPE_RED};
 `;
 
-// The Icon can be switched dynamically (e.g. Discreet mode icon) and without fixed size the whole row of NavigationActions jumps on the first switch
-const StyledIcon = styled(Icon)`
-    width: 24px;
-    height: 24px;
-`;
-
 interface CommonProps extends Pick<React.HTMLAttributes<HTMLDivElement>, 'onClick'> {
     label: React.ReactNode;
     isActive?: boolean;
@@ -87,7 +81,7 @@ type Props = CustomIconComponentProps | IconComponentProps;
 
 const ActionItem = (props: Props) => {
     const iconComponent = props.icon ? (
-        <StyledIcon
+        <Icon
             color={props.isActive ? colors.NEUE_TYPE_DARK_GREY : colors.NEUE_TYPE_LIGHT_GREY}
             size={24}
             icon={props.icon}

--- a/packages/suite/src/components/suite/NavigationBar/index.tsx
+++ b/packages/suite/src/components/suite/NavigationBar/index.tsx
@@ -48,10 +48,6 @@ const ExpandedMobileNavigation = styled.div`
     height: 100%;
 `;
 
-const HamburgerIcon = styled(Icon)`
-    cursor: pointer;
-`;
-
 const NavigationBar = () => {
     const [opened, setOpened] = useState(false);
     const { isMobileLayout } = useLayoutSize();
@@ -66,7 +62,7 @@ const NavigationBar = () => {
                 <StyledNavigationBar isMobileLayout={isMobileLayout}>
                     <StyledDeviceSelector />
                     <HamburgerWrapper>
-                        <HamburgerIcon
+                        <Icon
                             onClick={() => setOpened(!opened)}
                             icon={opened ? 'CROSS' : 'MENU'}
                             size={24}

--- a/packages/suite/src/components/suite/NoRatesTooltip/index.tsx
+++ b/packages/suite/src/components/suite/NoRatesTooltip/index.tsx
@@ -3,11 +3,6 @@ import { Translation } from '@suite-components';
 import styled from 'styled-components';
 import { Icon, Tooltip, colors, variables } from '@trezor/components';
 
-const StyledIcon = styled(Icon)`
-    cursor: pointer;
-    align-items: center;
-`;
-
 const NoRatesMessage = styled.div`
     display: flex;
     align-items: center;
@@ -33,11 +28,12 @@ const NoRatesTooltip = ({ customText, iconOnly, customTooltip, className, ...pro
             content={<Translation id={customTooltip || 'TR_FIAT_RATES_NOT_AVAILABLE_TOOLTIP'} />}
             {...props}
         >
-            <StyledIcon
+            <Icon
                 icon="QUESTION"
                 color={colors.BLACK50}
                 hoverColor={colors.BLACK25}
                 size={14}
+                useCursorPointer
             />
         </Tooltip>
     </NoRatesMessage>

--- a/packages/suite/src/components/suite/PinInput/components/InputPin/index.tsx
+++ b/packages/suite/src/components/suite/PinInput/components/InputPin/index.tsx
@@ -17,10 +17,6 @@ const StyledInput = styled(Input)`
     box-sizing: border-box;
 `;
 
-const StyledIcon = styled(Icon)`
-    cursor: pointer;
-`;
-
 interface Props {
     value: string;
     onDeleteClick: (event?: React.MouseEvent<any>) => void;
@@ -32,7 +28,7 @@ const InputPin = ({ value, onDeleteClick }: Props) => (
         noTopLabel
         noError
         value={value.replace(/[0-9]/g, '●')}
-        innerAddon={<StyledIcon onClick={onDeleteClick} color={colors.BLACK25} icon="BACK" />}
+        innerAddon={<Icon onClick={onDeleteClick} color={colors.BLACK25} icon="BACK" />}
     />
 );
 

--- a/packages/suite/src/components/suite/SwitchDevice/components/DeviceItem/components/ColHeader/index.tsx
+++ b/packages/suite/src/components/suite/SwitchDevice/components/DeviceItem/components/ColHeader/index.tsx
@@ -16,11 +16,6 @@ const Text = styled.span`
     text-transform: uppercase;
 `;
 
-const StyledIcon = styled(Icon)`
-    cursor: pointer;
-    align-items: center;
-`;
-
 interface Props {
     children?: React.ReactNode;
     tooltipContent?: TooltipProps['content'];
@@ -32,7 +27,12 @@ const ColHeader = ({ children, tooltipContent, ...rest }: Props) => {
             <Text>{children}</Text>
             {tooltipContent && (
                 <Tooltip maxWidth={285} placement="top" content={tooltipContent}>
-                    <StyledIcon icon="INFO_ACTIVE" color={colors.NEUE_TYPE_LIGHT_GREY} size={16} />
+                    <Icon
+                        icon="INFO_ACTIVE"
+                        color={colors.NEUE_TYPE_LIGHT_GREY}
+                        size={16}
+                        useCursorPointer
+                    />
                 </Tooltip>
             )}
         </Wrapper>

--- a/packages/suite/src/components/suite/TransactionsGraph/index.tsx
+++ b/packages/suite/src/components/suite/TransactionsGraph/index.tsx
@@ -48,10 +48,6 @@ const Description = styled.div`
     flex: 1;
 `;
 
-const RefreshIcon = styled(Icon)`
-    cursor: pointer;
-`;
-
 interface CommonProps {
     isLoading?: boolean;
     selectedRange: GraphRange;
@@ -115,7 +111,7 @@ const TransactionsGraph = React.memo((props: Props) => {
                 <Toolbar>
                     <RangeSelector />
                     {props.onRefresh && (
-                        <RefreshIcon
+                        <Icon
                             size={14}
                             icon="REFRESH"
                             hoverColor={colors.BLACK0}

--- a/packages/suite/src/components/suite/modals/Passphrase/components/PassphraseTypeCard/index.tsx
+++ b/packages/suite/src/components/suite/modals/Passphrase/components/PassphraseTypeCard/index.tsx
@@ -139,10 +139,6 @@ const OnDeviceActionButton = styled(ActionButton)`
     }
 `;
 
-const StyledIcon = styled(Icon)`
-    cursor: pointer;
-`;
-
 const TooltipIcon = styled(Icon)`
     margin-left: 4px;
 `;
@@ -323,7 +319,7 @@ const PassphraseTypeCard = (props: Props) => {
                             noTopLabel
                             noError
                             innerAddon={
-                                <StyledIcon
+                                <Icon
                                     size={18}
                                     color={colors.NEUE_TYPE_LIGHT_GREY}
                                     icon={showPassword ? 'HIDE' : 'SHOW'}

--- a/packages/suite/src/components/wallet/AccountsMenu/index.tsx
+++ b/packages/suite/src/components/wallet/AccountsMenu/index.tsx
@@ -80,10 +80,6 @@ const Heading = styled(H2)<{ isMobileLayout?: boolean }>`
         `}
 `;
 
-const ExpandIcon = styled(Icon)`
-    cursor: pointer;
-`;
-
 const MenuItemsWrapper = styled.div`
     position: relative;
     width: 100%;
@@ -266,7 +262,7 @@ const AccountsMenu = ({ device, accounts, selectedAccount }: Props) => {
                             <Heading noMargin isMobileLayout={isMobileLayout}>
                                 <Translation id="TR_MY_ACCOUNTS" />
                             </Heading>
-                            <ExpandIcon
+                            <Icon
                                 canAnimate={animatedIcon}
                                 isActive={isExpanded}
                                 size={20}

--- a/packages/suite/src/components/wallet/CoinmarketFooter/index.tsx
+++ b/packages/suite/src/components/wallet/CoinmarketFooter/index.tsx
@@ -77,8 +77,6 @@ const IconWrapper = styled.div`
     margin-left: 10px;
 `;
 
-const StyledIcon = styled(Icon)``;
-
 const Text = styled.div`
     padding-left: 10px;
     color: ${colors.NEUE_TYPE_LIGHT_GREY};
@@ -120,7 +118,7 @@ const CoinmarketFooter = () => {
                                     <Button variant="tertiary">invity.io</Button>
                                 </Link>
                                 <IconWrapper onClick={() => setToggled(false)}>
-                                    <StyledIcon icon="CROSS" size={16} />
+                                    <Icon icon="CROSS" size={16} />
                                 </IconWrapper>
                             </BoxRight>
                         </Header>

--- a/packages/suite/src/views/wallet/send/components/Options/components/BitcoinOptions/components/Locktime/index.tsx
+++ b/packages/suite/src/views/wallet/send/components/Options/components/BitcoinOptions/components/Locktime/index.tsx
@@ -23,10 +23,6 @@ const Text = styled.div`
     margin-left: 8px;
 `;
 
-const StyledIcon = styled(Icon)`
-    cursor: pointer;
-`;
-
 const RbfMessage = styled.div`
     display: flex;
     flex: 1;
@@ -125,7 +121,7 @@ const Locktime = ({ close }: Props) => {
                         </Text>
                     </Label>
                 }
-                labelRight={<StyledIcon size={20} icon="CROSS" onClick={close} />}
+                labelRight={<Icon size={20} icon="CROSS" onClick={close} />}
                 bottomText={<InputError error={error} />}
             />
             {isEnabled('RBF') && (

--- a/packages/suite/src/views/wallet/send/components/Options/components/EthereumOptions/components/Data/index.tsx
+++ b/packages/suite/src/views/wallet/send/components/Options/components/EthereumOptions/components/Data/index.tsx
@@ -21,10 +21,6 @@ const Space = styled.div`
     min-width: 65px;
 `;
 
-const StyledIcon = styled(Icon)`
-    cursor: pointer;
-`;
-
 interface Props {
     close: () => void;
 }
@@ -108,7 +104,7 @@ const Data = ({ close }: Props) => {
                 }}
                 bottomText={<InputError error={hexError} />}
                 labelRight={
-                    <StyledIcon
+                    <Icon
                         size={20}
                         icon="CROSS"
                         onClick={() => {

--- a/packages/suite/src/views/wallet/send/components/Outputs/components/Address/index.tsx
+++ b/packages/suite/src/views/wallet/send/components/Outputs/components/Address/index.tsx
@@ -37,7 +37,6 @@ const Remove = styled.div`
 `;
 
 const StyledIcon = styled(Icon)`
-    cursor: pointer;
     display: flex;
 `;
 
@@ -117,7 +116,12 @@ const Address = ({ output, outputId, outputsCount }: Props) => {
                             composeTransaction();
                         }}
                     >
-                        <StyledIcon size={20} color={colors.BLACK50} icon="CROSS" />
+                        <StyledIcon
+                            size={20}
+                            color={colors.BLACK50}
+                            icon="CROSS"
+                            useCursorPointer
+                        />
                     </Remove>
                 ) : undefined
             }

--- a/packages/suite/src/views/wallet/send/components/Outputs/components/OpReturn/index.tsx
+++ b/packages/suite/src/views/wallet/send/components/Outputs/components/OpReturn/index.tsx
@@ -15,10 +15,6 @@ const Wrapper = styled.div`
     align-items: center;
 `;
 
-const StyledIcon = styled(Icon)`
-    cursor: pointer;
-`;
-
 const Label = styled.div`
     display: flex;
     align-items: center;
@@ -109,7 +105,7 @@ const OpReturn = ({ outputId }: { outputId: number }) => {
                 }}
                 bottomText={<InputError error={hexError} />}
                 labelRight={
-                    <StyledIcon size={20} icon="CROSS" onClick={() => removeOpReturn(outputId)} />
+                    <Icon size={20} icon="CROSS" onClick={() => removeOpReturn(outputId)} />
                 }
             />
         </Wrapper>

--- a/packages/suite/src/views/wallet/send/components/Raw/index.tsx
+++ b/packages/suite/src/views/wallet/send/components/Raw/index.tsx
@@ -34,10 +34,6 @@ const IconWrapper = styled.div`
     justify-content: flex-end;
 `;
 
-const StyledIcon = styled(Icon)`
-    cursor: pointer;
-`;
-
 const ButtonWrapper = styled.div`
     display: flex;
     margin: 25px 0;
@@ -70,7 +66,7 @@ const Raw = ({ network }: { network: Network }) => {
     return (
         <Wrapper>
             <IconWrapper>
-                <StyledIcon size={20} icon="CROSS" onClick={() => sendRaw(false)} />
+                <Icon size={20} icon="CROSS" onClick={() => sendRaw(false)} />
             </IconWrapper>
             <StyledCard>
                 <Textarea


### PR DESCRIPTION
1) I quickly went through all instances of `Icon` component and I also manually checked potentially problematic ones - there are couple of `Icon` instances where the width is overridden with a smaller value than the `size` prop. It is done like this because of a specific art direction and the design is not not broken. But a proper QA check is welcome :)

2) Added small refactoring of Icon component - Icons with onClick event now have `cursor: pointer` by default (can be overridden via prop).