### PR TITLE
fix(suite-desktop): close devtools before closing the window

### DIFF
--- a/packages/suite-desktop/src-electron/electron.ts
+++ b/packages/suite-desktop/src-electron/electron.ts
@@ -303,6 +303,11 @@ const init = async () => {
 
     // Window controls
     ipcMain.on('window/close', () => {
+        // Keeping the devtools open might prevent the app from closing
+        if (mainWindow.webContents.isDevToolsOpened()) {
+            mainWindow.webContents.closeDevTools();
+        }
+
         mainWindow.close();
     });
     ipcMain.on('window/minimize', () => {


### PR DESCRIPTION
Devtools prevent the app from being closed on Windows. Doing it regardless of the platform, there's no point keeping the devtools open if the app is being closed 🙂 