### PR TITLE
chore(ci): optimize

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -49,10 +49,12 @@ include:
     - ci/install-and-build.yml
     - ci/prebuild.yml
     - ci/packages/components.yml
-    - ci/packages/suite-misc.yml
+    - ci/packages/suite.yml
     - ci/packages/suite-web.yml
     - ci/packages/suite-desktop.yml
-#    - ci/packages/suite-native.yml
+    # - ci/packages/suite-native.yml
     - ci/packages/rollout.yml
     - ci/packages/landing-page.yml
     - ci/packages/suite-web-landing.yml
+    # to be run only on scheduled pipelines
+    - ci/schedules.yml

--- a/ci/packages/components.yml
+++ b/ci/packages/components.yml
@@ -1,4 +1,18 @@
-components build-storybook:
+.run_all_rules: &run_all_rules
+    refs:
+      - develop
+      - releases
+      - schedules
+      - /^release\//
+      - /^run\//
+    changes:
+      - packages/components
+      - packages/components-storybook
+      - yarn.lock
+
+# Build
+
+.build_common: &build_common
   stage: build
   script:
     - yarn workspace @trezor/components storybook-build
@@ -8,13 +22,23 @@ components build-storybook:
     paths:
       - packages/components/.build-storybook
 
-components storybook deploy dev:
+components build-storybook:
+  <<: *build_common
+  only:
+    <<: *run_all_rules
+
+components build-storybook:
+  <<: *build_common
+  when: manual
+  except:
+      <<: *run_all_rules
+
+# Deploy 
+
+.deploy_common: &deploy_common
   stage: deploy to dev
   variables:
     DEPLOY_DIRECTORY: ${DEPLOY_BASE_DIR}/components/${CI_BUILD_REF_NAME}
-  needs:
-    - install and build
-    - components build-storybook
   environment:
     name: ${CI_BUILD_REF_NAME}
     url: $BASE_REVIEW_URL/${CI_BUILD_REF_NAME}
@@ -25,6 +49,18 @@ components storybook deploy dev:
   tags:
     - deploy
 
+# Currently two jobs needed, it seems not to be possible to have a job depending on manual job
+# https://gitlab.com/gitlab-org/gitlab/-/issues/31264
+components storybook deploy dev:
+  <<: *deploy_common
+  only:
+    <<: *run_all_rules
+
+components storybook deploy dev:
+  <<: *deploy_common
+  when: manual
+  except:
+      <<: *run_all_rules
 
 # components-storybook test snapshots:
 #   stage: integration testing

--- a/ci/packages/components.yml
+++ b/ci/packages/components.yml
@@ -1,4 +1,4 @@
-.run_all_rules: &run_all_rules
+.run_everything_rules: &run_everything_rules
     refs:
       - develop
       - releases
@@ -25,13 +25,13 @@
 components build-storybook:
   <<: *build_common
   only:
-    <<: *run_all_rules
+    <<: *run_everything_rules
 
 components build-storybook:
   <<: *build_common
   when: manual
   except:
-      <<: *run_all_rules
+      <<: *run_everything_rules
 
 # Deploy 
 
@@ -54,13 +54,13 @@ components build-storybook:
 components storybook deploy dev:
   <<: *deploy_common
   only:
-    <<: *run_all_rules
+    <<: *run_everything_rules
 
 components storybook deploy dev:
   <<: *deploy_common
   when: manual
   except:
-      <<: *run_all_rules
+      <<: *run_everything_rules
 
 # components-storybook test snapshots:
 #   stage: integration testing

--- a/ci/packages/landing-page.yml
+++ b/ci/packages/landing-page.yml
@@ -1,4 +1,4 @@
-.run_all_rules: &run_all_rules
+.run_everything_rules: &run_everything_rules
   refs:
     - develop
     - releases
@@ -19,7 +19,7 @@ landing-page build dev:
 landing-page build beta:
   stage: build
   only:
-    <<: *run_all_rules
+    <<: *run_everything_rules
   script:
     - yarn workspace @trezor/landing-page build
   artifacts:
@@ -49,7 +49,7 @@ landing-page deploy dev:
 landing-page deploy staging-wallet:
   stage: deploy to staging
   only:
-    <<: *run_all_rules
+    <<: *run_everything_rules
   needs:
     - landing-page build beta
   environment:

--- a/ci/packages/landing-page.yml
+++ b/ci/packages/landing-page.yml
@@ -1,9 +1,11 @@
-.auto_run_branches: &auto_run_branches
+.run_all_rules: &run_all_rules
   refs:
     - develop
     - releases
     - schedules
     - /^release\//
+
+# build 
 
 landing-page build dev:
   stage: build
@@ -17,7 +19,7 @@ landing-page build dev:
 landing-page build beta:
   stage: build
   only:
-    <<: *auto_run_branches
+    <<: *run_all_rules
   script:
     - yarn workspace @trezor/landing-page build
   artifacts:
@@ -26,10 +28,28 @@ landing-page build beta:
       - packages/landing-page/scripts/s3sync.sh
       - packages/landing-page/build
 
+# deploy 
+
+landing-page deploy dev:
+  stage: deploy to dev
+  variables:
+    DEPLOY_DIRECTORY: ${DEPLOY_BASE_DIR}/landing-page/${CI_BUILD_REF_NAME}
+  needs:
+    - landing-page build dev
+  environment:
+    name: ${CI_BUILD_REF_NAME}
+    url: $BASE_REVIEW_URL/${CI_BUILD_REF_NAME}
+  before_script: []
+  script:
+    - mkdir -p ${DEPLOY_DIRECTORY}
+    - rsync --delete -va packages/landing-page/build/ "${DEPLOY_DIRECTORY}/"
+  tags:
+    - deploy
+
 landing-page deploy staging-wallet:
   stage: deploy to staging
   only:
-    <<: *auto_run_branches
+    <<: *run_all_rules
   needs:
     - landing-page build beta
   environment:
@@ -44,19 +64,3 @@ landing-page deploy staging-wallet:
   tags:
     - deploy
 
-landing-page deploy dev:
-  stage: deploy to dev
-  variables:
-    DEPLOY_DIRECTORY: ${DEPLOY_BASE_DIR}/landing-page/${CI_BUILD_REF_NAME}
-  needs:
-    - install and build
-    - landing-page build dev
-  environment:
-    name: ${CI_BUILD_REF_NAME}
-    url: $BASE_REVIEW_URL/${CI_BUILD_REF_NAME}
-  before_script: []
-  script:
-    - mkdir -p ${DEPLOY_DIRECTORY}
-    - rsync --delete -va packages/landing-page/build/ "${DEPLOY_DIRECTORY}/"
-  tags:
-    - deploy

--- a/ci/packages/suite-desktop.yml
+++ b/ci/packages/suite-desktop.yml
@@ -1,7 +1,5 @@
 .build: &build
     stage: build
-    needs:
-        - install and build
     script:
         - yarn cache clean
         - yarn workspace @trezor/suite-data copy-static-files
@@ -25,7 +23,7 @@
         - mv packages/suite-desktop/build-electron/* .
         - more latest*.yml | cat
 
-.auto_run_branches: &auto_run_branches
+.run_all_rules: &run_all_rules
     refs:
         - develop
         - releases
@@ -35,7 +33,7 @@
 
 suite-desktop build mac:
     only:
-        <<: *auto_run_branches
+        <<: *run_all_rules
     tags:
         - darwin
     variables:
@@ -59,7 +57,7 @@ suite-desktop build mac codesign:
 
 suite-desktop build linux:
     only:
-        <<: *auto_run_branches
+        <<: *run_all_rules
     variables:
         artifact: ${DESKTOP_APP_NAME}*
         platform: linux
@@ -80,7 +78,7 @@ suite-desktop build linux codesign:
 
 suite-desktop build windows:
     only:
-        <<: *auto_run_branches
+        <<: *run_all_rules
     image: electronuserland/builder:wine
     variables:
         artifact: ${DESKTOP_APP_NAME}*
@@ -104,7 +102,7 @@ suite-desktop build windows codesign:
 suite-desktop deploy dev:
     stage: deploy to dev
     only:
-        <<: *auto_run_branches
+        <<: *run_all_rules
     variables:
         DEPLOY_DIRECTORY: ${DEPLOY_BASE_DIR}/suite-desktop/${CI_BUILD_REF_NAME}
     script:

--- a/ci/packages/suite-desktop.yml
+++ b/ci/packages/suite-desktop.yml
@@ -23,7 +23,7 @@
         - mv packages/suite-desktop/build-electron/* .
         - more latest*.yml | cat
 
-.run_all_rules: &run_all_rules
+.run_everything_rules: &run_everything_rules
     refs:
         - develop
         - releases
@@ -33,7 +33,7 @@
 
 suite-desktop build mac:
     only:
-        <<: *run_all_rules
+        <<: *run_everything_rules
     tags:
         - darwin
     variables:
@@ -57,7 +57,7 @@ suite-desktop build mac codesign:
 
 suite-desktop build linux:
     only:
-        <<: *run_all_rules
+        <<: *run_everything_rules
     variables:
         artifact: ${DESKTOP_APP_NAME}*
         platform: linux
@@ -78,7 +78,7 @@ suite-desktop build linux codesign:
 
 suite-desktop build windows:
     only:
-        <<: *run_all_rules
+        <<: *run_everything_rules
     image: electronuserland/builder:wine
     variables:
         artifact: ${DESKTOP_APP_NAME}*
@@ -102,7 +102,7 @@ suite-desktop build windows codesign:
 suite-desktop deploy dev:
     stage: deploy to dev
     only:
-        <<: *run_all_rules
+        <<: *run_everything_rules
     variables:
         DEPLOY_DIRECTORY: ${DEPLOY_BASE_DIR}/suite-desktop/${CI_BUILD_REF_NAME}
     script:

--- a/ci/packages/suite-web-landing.yml
+++ b/ci/packages/suite-web-landing.yml
@@ -1,4 +1,4 @@
-.run_all_rules: &run_all_rules
+.run_everything_rules: &run_everything_rules
   refs:
     - develop
     - releases
@@ -17,7 +17,7 @@ suite-web-landing build dev:
 suite-web-landing build stable:
   stage: build
   only:
-    <<: *run_all_rules
+    <<: *run_everything_rules
   script:
     - yarn workspace @trezor/suite-web-landing build
   artifacts:
@@ -29,7 +29,7 @@ suite-web-landing build stable:
 suite-web-landing deploy staging-suite:
   stage: deploy to staging
   only:
-    <<: *run_all_rules
+    <<: *run_everything_rules
   needs:
     - suite-web-landing build stable
   environment:

--- a/ci/packages/suite-web-landing.yml
+++ b/ci/packages/suite-web-landing.yml
@@ -1,4 +1,4 @@
-.auto_run_branches: &auto_run_branches
+.run_all_rules: &run_all_rules
   refs:
     - develop
     - releases
@@ -17,7 +17,7 @@ suite-web-landing build dev:
 suite-web-landing build stable:
   stage: build
   only:
-    <<: *auto_run_branches
+    <<: *run_all_rules
   script:
     - yarn workspace @trezor/suite-web-landing build
   artifacts:
@@ -29,7 +29,7 @@ suite-web-landing build stable:
 suite-web-landing deploy staging-suite:
   stage: deploy to staging
   only:
-    <<: *auto_run_branches
+    <<: *run_all_rules
   needs:
     - suite-web-landing build stable
   environment:

--- a/ci/packages/suite-web.yml
+++ b/ci/packages/suite-web.yml
@@ -1,12 +1,70 @@
 variables:
     TEST_CMD: 'yarn concurrently --success first --kill-others "cd ./docker/trezor-user-env/controller && python3 ./main.py" "node ./packages/integration-tests/projects/suite-web/run_tests.js --project ./packages/integration-tests/projects/suite-web --stage=$TEST_GROUP"'
 
-.auto_run_branches: &auto_run_branches
+.run_all_rules: &run_all_rules
     refs:
         - develop
         - releases
         - schedules
         - /^release\//
+
+
+# build 
+
+suite-web build dev:
+    stage: build
+    script:
+        - assetPrefix=/suite-web/${CI_BUILD_REF_NAME}/web yarn workspace @trezor/suite-web build
+    artifacts:
+        expire_in: 7 days
+        paths:
+            - packages/suite-web/build
+
+suite-web build beta:
+    stage: build
+    only:
+        <<: *run_all_rules
+    script:
+        - assetPrefix=/wallet/web yarn workspace @trezor/suite-web build
+    artifacts:
+        expire_in: 7 days
+        paths:
+            - packages/suite-web/scripts/s3sync.sh
+            - packages/suite-web/build
+
+suite-web build stable:
+    stage: build
+    only:
+        <<: *run_all_rules
+    script:
+        - assetPrefix=/web yarn workspace @trezor/suite-web build
+    artifacts:
+        expire_in: 7 days
+        paths:
+            - packages/suite-web/scripts/s3sync.sh
+            - packages/suite-web/build
+
+# deploy 
+
+suite-web deploy dev:
+  stage: deploy to dev
+  variables:
+    DEPLOY_DIRECTORY: ${DEPLOY_BASE_DIR}/suite-web/${CI_BUILD_REF_NAME}
+  needs:
+    - suite-web-landing build dev
+    - suite-web build dev
+  environment:
+    name: ${CI_BUILD_REF_NAME}
+    url: $BASE_REVIEW_URL/${CI_BUILD_REF_NAME}
+  before_script: []
+  script:
+    - mkdir -p ${DEPLOY_DIRECTORY}/web
+    - rsync --delete -va packages/suite-web-landing/build/ "${DEPLOY_DIRECTORY}/"
+    - rsync --delete -va packages/suite-web/build/ "${DEPLOY_DIRECTORY}/web/"
+  tags:
+    - deploy
+
+# e2e 
 
 .e2e_artifacts: &e2e_artifacts
     expire_in: 7 days
@@ -21,64 +79,6 @@ variables:
     - export CYPRESS_ASSET_PREFIX=/web
     - export CYPRESS_baseUrl=${DEV_SERVER_URL}/suite-web/${CI_BUILD_REF_NAME}
     - export TRACK_SUITE_URL=https://track-suite.herokuapp.com
-
-suite-web build dev:
-    stage: build
-    needs:
-      - install and build
-    script:
-        - assetPrefix=/suite-web/${CI_BUILD_REF_NAME}/web yarn workspace @trezor/suite-web build
-    artifacts:
-        expire_in: 7 days
-        paths:
-            - packages/suite-web/build
-
-suite-web build beta:
-    stage: build
-    needs:
-      - install and build
-    only:
-        <<: *auto_run_branches
-    script:
-        - assetPrefix=/wallet/web yarn workspace @trezor/suite-web build
-    artifacts:
-        expire_in: 7 days
-        paths:
-            - packages/suite-web/scripts/s3sync.sh
-            - packages/suite-web/build
-
-suite-web build stable:
-    stage: build
-    needs:
-      - install and build
-    only:
-        <<: *auto_run_branches
-    script:
-        - assetPrefix=/web yarn workspace @trezor/suite-web build
-    artifacts:
-        expire_in: 7 days
-        paths:
-            - packages/suite-web/scripts/s3sync.sh
-            - packages/suite-web/build
-
-suite-web deploy dev:
-  stage: deploy to dev
-  variables:
-    DEPLOY_DIRECTORY: ${DEPLOY_BASE_DIR}/suite-web/${CI_BUILD_REF_NAME}
-  needs:
-    - install and build
-    - suite-web-landing build dev
-    - suite-web build dev
-  environment:
-    name: ${CI_BUILD_REF_NAME}
-    url: $BASE_REVIEW_URL/${CI_BUILD_REF_NAME}
-  before_script: []
-  script:
-    - mkdir -p ${DEPLOY_DIRECTORY}/web
-    - rsync --delete -va packages/suite-web-landing/build/ "${DEPLOY_DIRECTORY}/"
-    - rsync --delete -va packages/suite-web/build/ "${DEPLOY_DIRECTORY}/web/"
-  tags:
-    - deploy
 
 suite-web e2e chrome stage=suite:
     stage: integration testing
@@ -136,23 +136,6 @@ suite-web e2e chrome stage=onboarding:
     artifacts:
         <<: *e2e_artifacts
 
-# this job is intended to collect statistics on tests in beta stage (=tests that are possibly unstable)
-# failing test here does not make job fail, run_tests script with --stage='@beta' exits with non-zero
-# code only when there is some runtime error
-.suite-web e2e chrome stage=beta:
-    stage: integration testing
-    variables:
-        TEST_GROUP: "@beta"
-    needs:
-      - suite-web deploy dev
-    script:
-        - *e2e_script_common
-        - export CYPRESS_SNAPSHOT=1
-        - export BROWSER=chrome
-        - "eval $TEST_CMD"
-    artifacts:
-        <<: *e2e_artifacts
-
 # on scheduled job every night, run all stable tests against latest chrome-beta. This is meant to be
 # kind of an early-warning system.
 suite-web e2e chrome-beta stage=stable:
@@ -184,7 +167,7 @@ suite-web deploy staging-wallet:
         url: ${STAGING_WALLET_SERVER_URL}
     before_script: []
     only:
-        <<: *auto_run_branches
+        <<: *run_all_rules
     when: manual
     script:
         - source ${STAGING_WALLET_DEPLOY_KEYFILE}
@@ -196,6 +179,7 @@ suite-web deploy staging-wallet:
         - ./scripts/s3sync.sh staging-wallet
     tags:
         - deploy
+
 # todo: add smoke test job on stage / beta (need basic auth)
 
 suite-web deploy staging-suite:
@@ -210,7 +194,7 @@ suite-web deploy staging-suite:
         url: ${STAGING_SUITE_SERVER_URL}
     before_script: []
     only:
-        <<: *auto_run_branches
+        <<: *run_all_rules
     when: manual
     script:
         - source ${STAGING_SUITE_DEPLOY_KEYFILE}

--- a/ci/packages/suite-web.yml
+++ b/ci/packages/suite-web.yml
@@ -1,7 +1,7 @@
 variables:
     TEST_CMD: 'yarn concurrently --success first --kill-others "cd ./docker/trezor-user-env/controller && python3 ./main.py" "node ./packages/integration-tests/projects/suite-web/run_tests.js --project ./packages/integration-tests/projects/suite-web --stage=$TEST_GROUP"'
 
-.run_all_rules: &run_all_rules
+.run_everything_rules: &run_everything_rules
     refs:
         - develop
         - releases
@@ -23,7 +23,7 @@ suite-web build dev:
 suite-web build beta:
     stage: build
     only:
-        <<: *run_all_rules
+        <<: *run_everything_rules
     script:
         - assetPrefix=/wallet/web yarn workspace @trezor/suite-web build
     artifacts:
@@ -35,7 +35,7 @@ suite-web build beta:
 suite-web build stable:
     stage: build
     only:
-        <<: *run_all_rules
+        <<: *run_everything_rules
     script:
         - assetPrefix=/web yarn workspace @trezor/suite-web build
     artifacts:
@@ -167,7 +167,7 @@ suite-web deploy staging-wallet:
         url: ${STAGING_WALLET_SERVER_URL}
     before_script: []
     only:
-        <<: *run_all_rules
+        <<: *run_everything_rules
     when: manual
     script:
         - source ${STAGING_WALLET_DEPLOY_KEYFILE}
@@ -194,7 +194,7 @@ suite-web deploy staging-suite:
         url: ${STAGING_SUITE_SERVER_URL}
     before_script: []
     only:
-        <<: *run_all_rules
+        <<: *run_everything_rules
     when: manual
     script:
         - source ${STAGING_SUITE_DEPLOY_KEYFILE}

--- a/ci/packages/suite.yml
+++ b/ci/packages/suite.yml
@@ -1,0 +1,7 @@
+release commit messages:
+    stage: misc
+    only:
+        refs:
+            - /^release\//
+    script:
+        - ci/scripts/check_release_commit_messages.sh

--- a/ci/schedules.yml
+++ b/ci/schedules.yml
@@ -1,27 +1,30 @@
-# number of utility scripts that are nice and useful but perfectly ok if they run only once a day :]
-suite misc:
-    # only:
-    #     - schedules
+outdated:
     stage: misc
+    only:
+        - schedules
     allow_failure: true
+    script:
+        # tests whether there are not 'too many' outdated dependencies
+        - ./ci/scripts/outdated.sh
+
+urls_health:
+    stage: misc
+    only:
+        - schedules
     script:
         # tests whether urls in constants return 200 status (shall detect dead links)
         - yarn workspace @trezor/suite test-health
-        # tests whether there are not 'too many' outdated dependencies
-        - ./ci/scripts/outdated.sh
+
+# Few very low priority scripts. 
+misc: 
+    stage: misc
+    only:
+        - schedules
+    script:
         # tests whether we have not included same svgs multiple times (it is hard to see from code)
         - yarn workspace @trezor/suite-data test-same-svgs
         # some random script pretending it checks something (actually it should use part of lighthouse.js for vulnerabilities checking)
         # but it should probably be used in more elaborate way. Or we may use lighthouse directly
         - yarn is-website-vulnerable ${DEV_SERVER_URL}/suite-web/${CI_BUILD_REF_NAME} | node ./ci/scripts/check-vulnerabilities.js
-        # find unused messages. these don't have right to exist as they pose additional budget on translators
         # todo: make it work with messages.ts
         # - yarn workspace @trezor/suite translations:unused
-
-release commit messages:
-    stage: misc
-    only:
-        refs:
-            - /^release\//
-    script:
-        - ci/scripts/check_release_commit_messages.sh


### PR DESCRIPTION
### changes
- jobs in stage won't start before all jobs in preceding stage are completed. Build won't start before prebuild is finished. E2e tests won't start before deploy is finished.
- There may be exceptions to this introduced by using `needs` keyword where it makes sense. For example at the moment deployment jobs don't need to wait for the entire build stage to finish but may deploy as soon as respective build job has finished. 
- components-storybook build and deploy now auto runs only for "auto run branches" (develop, releases, etc). In feature branches it would appear as a manual action. I believe that in feature branches in 95% of cases we don't need this to run.
- suite-misc jobs were moved out of packages folder and renamed to `schedules.yml`. This file shall be run only for scheduled jobs (there is one in the night). This change speeds up CI by additional 4 minuts.
