### PR TITLE
feat(ci): introduce release commit messages check

### DIFF
--- a/ci/packages/suite-misc.yml
+++ b/ci/packages/suite-misc.yml
@@ -17,3 +17,11 @@ suite misc:
         # find unused messages. these don't have right to exist as they pose additional budget on translators
         # todo: make it work with messages.ts
         # - yarn workspace @trezor/suite translations:unused
+
+release commit messages:
+    stage: misc
+    only:
+        refs:
+            - /^release\//
+    script:
+        - ci/scripts/check_release_commit_messages.sh

--- a/ci/scripts/check_release_commit_messages.sh
+++ b/ci/scripts/check_release_commit_messages.sh
@@ -1,0 +1,34 @@
+#!/usr/bin/env bash
+
+fail=0
+
+git fetch origin develop
+
+# list all commits between HEAD and develop
+for commit in $(git rev-list origin/develop..)
+do
+    message=$(git log -n1 --format=%B $commit)
+    echo "Checking $commit"
+
+    # The commit message must contain either
+    # 1. "cherry-picked from [some commit in develop]"
+    if [[ $message =~ "(cherry picked from commit" ]]; then
+      # remove last ")" and extract commit hash
+      develop_commit=$(echo ${message:0:-1} | tr ' ' '\n' | tail -1)
+      # check if develop really contains this commit hash
+      if [[ $(git branch -a --contains $develop_commit | grep --only-matching "remotes/origin/develop") == "remotes/origin/develop" ]]; then
+        continue
+      fi
+    fi
+
+    # 2. [RELEASE ONLY] substring
+    if [[ $message =~ "[RELEASE ONLY]" ]]; then
+      continue
+    fi
+
+    fail=1
+    echo "FAILURE! Neither 'cherry picked from..' nor '[RELEASE ONLY]' substring found in this commit message."
+done
+
+echo "ALL OK"
+exit $fail


### PR DESCRIPTION
Introduces a simple check to see if all commits in a release branch are either cherry-picked (with `-x`) or contain `[RELEASE ONLY]` indicating that they do not belong to _develop_. This way we'll make sure that everything that is in release branch is also in _develop_.

Note that this correctly fails on `release/2020-11` because 11ef2d377f2131ca74ddc6c7979e013082b9b061 does not adhere to this convention (it is missing `[RELEASE ONLY]`), so we will not cherry-pick this there. We will use this next release.

Might conflict with #2893.