### PR TITLE
fix(static notification): update should not appear if missing backup

### DIFF
--- a/packages/integration-tests/projects/suite-web/tests/firmware/firmware.test.ts
+++ b/packages/integration-tests/projects/suite-web/tests/firmware/firmware.test.ts
@@ -8,7 +8,7 @@ describe('Firmware', () => {
     });
 
     it('Firmware outdated static notification should open firmware update modal', () => {
-        cy.task('startEmu', { version: '2.1.4', wipe: true });
+        cy.task('startEmu', { wipe: true });
         cy.task('setupEmu');
         cy.prefixedVisit('/');
         cy.passThroughInitialRun();

--- a/packages/suite/src/components/suite/Notifications/UpdateFirmware.tsx
+++ b/packages/suite/src/components/suite/Notifications/UpdateFirmware.tsx
@@ -18,7 +18,7 @@ const UpdateFirmware = ({ device, goto }: Props) => {
     if (device.mode === 'bootloader') return null;
 
     // backup is more important than firmware
-    if (device.features.unfinished_backup || device.features.no_backup) return null;
+    if (device.features.unfinished_backup || device.features.needs_backup) return null;
 
     const outdated = ['outdated'].includes(device.firmware);
     if (!outdated) return null;


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/30367552/98289724-e6147800-1fa8-11eb-9237-bff308da80e5.png)


this is not nice (no talking about the darkmode, darkmode is superb). no_backup means seedless so this was a bug, these two notifications should not appear at one moment.