### PR TITLE
Onion link inconsistencies and warning for all links on suite-desktop when using Tor

### DIFF
--- a/packages/suite-desktop/src-electron/electron.ts
+++ b/packages/suite-desktop/src-electron/electron.ts
@@ -42,6 +42,10 @@ const httpReceiver = new HttpReceiver();
 const bridge = new BridgeProcess();
 const tor = new TorProcess();
 
+// Settings
+const updateSettings = store.getUpdateSettings();
+const torSettings = store.getTorSettings();
+
 const registerShortcuts = (window: BrowserWindow) => {
     // internally uses before-input-event, which should be safer than adding globalShortcut and removing it on blur event
     // https://github.com/electron/electron/issues/8491#issuecomment-274790124
@@ -150,7 +154,7 @@ const init = async () => {
         // TODO? url.startsWith('http:') || url.startsWith('https:');
         if (url !== mainWindow.webContents.getURL()) {
             event.preventDefault();
-            if (!config.allowedExternalUrls.some(u => url.startsWith(u))) {
+            if (torSettings.running || !config.allowedExternalUrls.some(u => url.startsWith(u))) {
                 // TODO: Replace with in-app modal
                 const result = dialog.showMessageBoxSync(mainWindow, {
                     type: 'warning',
@@ -212,7 +216,6 @@ const init = async () => {
     mainWindow.loadURL(src);
 
     // TOR
-    const torSettings = store.getTorSettings();
     const sess = mainWindow.webContents.session;
     const toggleTor = async (start: boolean) => {
         if (start) {
@@ -355,7 +358,6 @@ const init = async () => {
     httpReceiver.start();
 
     // Updates (move in separate file)
-    const updateSettings = store.getUpdateSettings();
     let latestVersion = {};
 
     autoUpdater.autoDownload = false;

--- a/packages/suite/src/actions/suite/analyticsActions.ts
+++ b/packages/suite/src/actions/suite/analyticsActions.ts
@@ -163,6 +163,12 @@ export type AnalyticsEvent =
           };
       }
     | {
+          type: 'menu/toggle-onion-links';
+          payload: {
+              value: boolean;
+          };
+      }
+    | {
           type: 'wallet/add-account';
           payload: {
               /** normal, segwit, legacy */

--- a/packages/suite/src/actions/suite/constants/suiteConstants.ts
+++ b/packages/suite/src/actions/suite/constants/suiteConstants.ts
@@ -18,6 +18,7 @@ export const SET_DEBUG_MODE = '@suite/set-debug-mode';
 export const SET_FLAG = '@suite/set-flag';
 export const ONLINE_STATUS = '@suite/online-status';
 export const TOR_STATUS = '@suite/tor-status';
+export const ONION_LINKS = '@suite/onion-links';
 export const APP_CHANGED = '@suite/app-changed';
 export const ADD_BUTTON_REQUEST = '@suite/add-button-request';
 export const SET_PROCESS_MODE = '@suite/set-process-mode';

--- a/packages/suite/src/actions/suite/suiteActions.ts
+++ b/packages/suite/src/actions/suite/suiteActions.ts
@@ -41,6 +41,7 @@ export type SuiteAction =
     | { type: typeof SUITE.SET_DEBUG_MODE; payload: Partial<DebugModeOptions> }
     | { type: typeof SUITE.ONLINE_STATUS; payload: boolean }
     | { type: typeof SUITE.TOR_STATUS; payload: boolean }
+    | { type: typeof SUITE.ONION_LINKS; payload: boolean }
     | { type: typeof SUITE.LOCK_UI; payload: boolean }
     | { type: typeof SUITE.LOCK_DEVICE; payload: boolean }
     | { type: typeof SUITE.LOCK_ROUTER; payload: boolean }
@@ -101,6 +102,11 @@ export const updateOnlineStatus = (payload: boolean): SuiteAction => ({
  */
 export const updateTorStatus = (payload: boolean) => ({
     type: SUITE.TOR_STATUS,
+    payload,
+});
+
+export const setOnionLinks = (payload: boolean) => ({
+    type: SUITE.ONION_LINKS,
     payload,
 });
 

--- a/packages/suite/src/components/suite/BetaBadge/index.tsx
+++ b/packages/suite/src/components/suite/BetaBadge/index.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
-import { Dropdown, Icon, Link, colors, variables } from '@trezor/components';
-import { Translation } from '@suite-components';
+import { Dropdown, Icon, colors, variables } from '@trezor/components';
+import { Translation, TrezorLink } from '@suite-components';
 import styled from 'styled-components';
 import { useSelector } from '@suite-hooks';
 import { FEEDBACK_FORM, SUPPORT_URL } from '@suite-constants/urls';
@@ -35,7 +35,7 @@ const Version = styled.div`
     font-weight: ${variables.FONT_WEIGHT.MEDIUM};
 `;
 
-const StyledLink = styled(Link)`
+const StyledLink = styled(TrezorLink)`
     padding: 10px 16px;
     width: 100%;
 `;

--- a/packages/suite/src/components/suite/ExternalLink/index.tsx
+++ b/packages/suite/src/components/suite/ExternalLink/index.tsx
@@ -1,11 +1,12 @@
 import React from 'react';
-import { Link, LinkProps } from '@trezor/components';
+import { TrezorLink } from '@suite-components';
+import { LinkProps } from '@trezor/components';
 
 const ExternalLink = ({ children, target = '_blank', ...rest }: LinkProps) => {
     return (
-        <Link icon="EXTERNAL_LINK" target={target} {...rest}>
+        <TrezorLink icon="EXTERNAL_LINK" target={target} {...rest}>
             {children}
-        </Link>
+        </TrezorLink>
     );
 };
 

--- a/packages/suite/src/components/suite/ReadMoreLink/index.tsx
+++ b/packages/suite/src/components/suite/ReadMoreLink/index.tsx
@@ -1,6 +1,5 @@
 import React from 'react';
-import { Link } from '@trezor/components';
-import { Translation } from '@suite-components';
+import { Translation, TrezorLink } from '@suite-components';
 import { URLS } from '@suite-constants';
 import { ExtendedMessageDescriptor } from '@suite-types';
 
@@ -18,15 +17,15 @@ export const ReadMoreLink = ({ url, message, linkLabel }: Props) => {
             id={message}
             values={{
                 TR_LEARN_MORE: (
-                    <Link variant="nostyle" href={URLS[url]}>
+                    <TrezorLink variant="nostyle" href={URLS[url]}>
                         <Translation id={linkLabel || 'TR_LEARN_MORE'} />
-                    </Link>
+                    </TrezorLink>
                 ),
             }}
         />
     ) : (
-        <Link href={URLS[url]}>
+        <TrezorLink href={URLS[url]}>
             <Translation id={linkLabel || 'TR_LEARN_MORE'} />
-        </Link>
+        </TrezorLink>
     );
 };

--- a/packages/suite/src/components/suite/TrezorLink/index.tsx
+++ b/packages/suite/src/components/suite/TrezorLink/index.tsx
@@ -4,14 +4,18 @@ import { useSelector } from '@suite-hooks';
 import { toTorUrl } from '@suite-utils/tor';
 
 const TrezorLink = (props: LinkProps) => {
-    const isTor = useSelector(state => state.suite.tor);
+    const { tor, torOnionLinks } = useSelector(state => ({
+        tor: state.suite.tor,
+        torOnionLinks: state.suite.settings.torOnionLinks,
+    }));
+
     const url = useMemo(() => {
-        if (!props.href || !isTor) {
-            return props.href;
+        if (props.href && tor && torOnionLinks) {
+            return toTorUrl(props.href);
         }
 
-        return toTorUrl(props.href);
-    }, [isTor, props.href]);
+        return props.href;
+    }, [tor, torOnionLinks, props.href]);
 
     return <Link {...props} href={url} />;
 };

--- a/packages/suite/src/components/suite/modals/TransactionDetail/components/BasicDetails/index.tsx
+++ b/packages/suite/src/components/suite/modals/TransactionDetail/components/BasicDetails/index.tsx
@@ -1,8 +1,8 @@
 import React from 'react';
 import styled from 'styled-components';
 import { FormattedDate } from 'react-intl';
-import { Icon, colors, variables, Link, Loader } from '@trezor/components';
-import { Translation, HiddenPlaceholder } from '@suite-components';
+import { Icon, colors, variables, Loader } from '@trezor/components';
+import { Translation, HiddenPlaceholder, TrezorLink } from '@suite-components';
 import { getDateWithTimeZone } from '@suite-utils/date';
 import { WalletAccountTransaction } from '@wallet-types';
 
@@ -32,7 +32,7 @@ const TransactionId = styled(props => <HiddenPlaceholder {...props} />)`
     font-variant-numeric: slashed-zero tabular-nums;
 `;
 
-const ExplorerLink = styled(Link)`
+const ExplorerLink = styled(props => <TrezorLink {...props} />)`
     font-size: ${variables.NEUE_FONT_SIZE.TINY};
     width: 100%; /* makes text overflow ellipsis work */
 `;

--- a/packages/suite/src/middlewares/wallet/storageMiddleware.ts
+++ b/packages/suite/src/middlewares/wallet/storageMiddleware.ts
@@ -115,6 +115,7 @@ const storageMiddleware = (api: MiddlewareAPI<Dispatch, AppState>) => (next: Dis
         case SUITE.SET_LANGUAGE:
         case SUITE.SET_FLAG:
         case SUITE.SET_DEBUG_MODE:
+        case SUITE.ONION_LINKS:
             api.dispatch(storageActions.saveSuiteSettings());
             break;
 

--- a/packages/suite/src/reducers/suite/suiteReducer.ts
+++ b/packages/suite/src/reducers/suite/suiteReducer.ts
@@ -25,6 +25,7 @@ interface Flags {
 
 interface SuiteSettings {
     language: typeof LANGUAGES[number]['code'];
+    torOnionLinks: boolean;
     debug: DebugModeOptions;
 }
 
@@ -60,6 +61,7 @@ const initialState: SuiteState = {
     },
     settings: {
         language: 'en',
+        torOnionLinks: isWeb(),
         debug: {
             invityAPIUrl: undefined,
             showDebugMenu: false,
@@ -139,6 +141,10 @@ const suiteReducer = (state: SuiteState = initialState, action: Action): SuiteSt
 
             case SUITE.TOR_STATUS:
                 draft.tor = action.payload;
+                break;
+
+            case SUITE.ONION_LINKS:
+                draft.settings.torOnionLinks = action.payload;
                 break;
 
             case SUITE.LOCK_UI:

--- a/packages/suite/src/support/messages.ts
+++ b/packages/suite/src/support/messages.ts
@@ -2594,6 +2594,15 @@ const definedMessages = defineMessages({
         defaultMessage:
             "Enabling this will route all of Suite's traffic through the Tor network.{lineBreak}All requests to Trezor infrastructure will be pointed to our Tor services, increasing your privacy and security.",
     },
+    TR_ONION_LINKS_TITLE: {
+        id: 'TR_ONION_LINKS_TITLE',
+        defaultMessage: 'Open trezor.io links as .onion links',
+    },
+    TR_ONION_LINKS_DESCRIPTION: {
+        id: 'TR_ONION_LINKS_DESCRIPTION',
+        defaultMessage:
+            'With this setting enabled, all trezor.io links will be opened as .onion links.',
+    },
     TR_TOR_PARAM_TITLE: {
         id: 'TR_TOR_PARAM_TITLE',
         defaultMessage: 'Tor address and port',


### PR DESCRIPTION
This PR addresses #2892 

- Inconsistencies with .onion links has been solved. All trezor.io links should be correctly converted to .onion links (if the setting is enabled).
- Added a new setting for switching on/off .onion links when using Tor. This is enabled by default on web and disabled by default on desktop. This is visible on desktop and web if on .onion domain.
- Opening links on desktop will show a warning when using Tor before opening them in the default browser.