### PR TITLE
fix(analytics): don't report until user was given chance to opt-out

### DIFF
--- a/packages/suite/src/actions/suite/__tests__/analyticsActions.test.ts
+++ b/packages/suite/src/actions/suite/__tests__/analyticsActions.test.ts
@@ -20,6 +20,9 @@ jest.mock('@suite-utils/random', () => {
 export const getInitialState = (state: InitialState | undefined) => {
     const analytics = state ? state.analytics : undefined;
     return {
+        suite: {
+            flags: { initialRun: false },
+        },
         analytics: {
             ...analyticsReducer(undefined, { type: 'foo' } as any),
             ...analytics,

--- a/packages/suite/src/actions/suite/analyticsActions.ts
+++ b/packages/suite/src/actions/suite/analyticsActions.ts
@@ -36,6 +36,7 @@ export type AnalyticsEvent =
         suite-ready
         Triggers on application start. Logs part of suite setup that might have been loaded from storage
         but it might also be suite default setup that is loaded when suite starts for the first time.
+        IMPORTANT: skipped if user opens suite for the first time. In such case, the first log will be 'initial-run-completed'
         */
           type: 'suite-ready';
           payload: {
@@ -263,7 +264,12 @@ export const report = (data: AnalyticsEvent, force = false) => async (
     }
 
     const { enabled, sessionId, instanceId } = getState().analytics;
+    const { initialRun } = getState().suite.flags;
 
+    // don't report until user had chance to optout
+    if (initialRun) {
+        return;
+    }
     // the only case we want to override users 'do not log' choice is when we
     // want to log that user did not give consent to logging.
     if (!enabled && !force) {


### PR DESCRIPTION
Hah, this is fixing a bug introduced few days ago. No big deal, just that at the moment `transport-type` event gets reported before user has chance to optout. It slipped through tests because this connect event is not emitted right away and tests run fast under automation. 