### PR TITLE
fix(components): dropdown proper positioning

### DIFF
--- a/packages/components/src/components/Dropdown/index.tsx
+++ b/packages/components/src/components/Dropdown/index.tsx
@@ -222,7 +222,7 @@ const Dropdown = ({
                       e.preventDefault();
                       if (children.props.onClick) children.props.onClick(e);
                       setToggled(!toggled);
-                      setAdjustedCoords([e.clientX, e.clientY]);
+                      setAdjustedCoords([e.pageX, e.pageY]);
                   }
                 : undefined,
         })
@@ -236,7 +236,7 @@ const Dropdown = ({
                 !isDisabled
                     ? e => {
                           setToggled(!toggled);
-                          setAdjustedCoords([e.clientX, e.clientY]);
+                          setAdjustedCoords([e.pageX, e.pageY]);
                       }
                     : undefined
             }


### PR DESCRIPTION
In attempt to fix #2904
According to the docs on https://developer.mozilla.org/

> The clientX read-only property of the MouseEvent interface provides the horizontal coordinate within the application's viewport at which the event occurred (as opposed to the coordinate within the page).

> The pageX read-only property of the MouseEvent interface returns the X (horizontal) coordinate (in pixels) at which the mouse was clicked, relative to the left edge of the entire document. **This includes any portion of the document not currently visible.**

Using pageX pageY instead of clientX clientY in this case feels like exactly what we want. Still I must admit that I don't understand why it actually did work in Chrome correctly.

Not sure if this should go to the release? #2904 is high proprioty (Or I'd say @matejzak feels it like that)
