### PR TITLE
Send: cached utxo + balance/utxo change handler

### DIFF
--- a/packages/suite/src/actions/wallet/accountActions.ts
+++ b/packages/suite/src/actions/wallet/accountActions.ts
@@ -75,6 +75,11 @@ export const update = (account: Account, accountInfo: AccountInfo): AccountActio
     },
 });
 
+export const updateAccount = (payload: Account): AccountAction => ({
+    type: ACCOUNT.UPDATE,
+    payload,
+});
+
 export const disableAccounts = () => (dispatch: Dispatch, getState: GetState) => {
     const { enabledNetworks } = getState().wallet.settings;
     // find disabled networks

--- a/packages/suite/src/actions/wallet/selectedAccountActions.ts
+++ b/packages/suite/src/actions/wallet/selectedAccountActions.ts
@@ -224,7 +224,15 @@ export const getStateForAction = (action: Action) => (dispatch: Dispatch, getSta
 
     // find differences
     const stateChanged = comparisonUtils.isChanged(state.wallet.selectedAccount, newState, {
-        account: ['descriptor', 'availableBalance', 'misc', 'tokens', 'metadata', 'addresses'],
+        account: [
+            'descriptor',
+            'availableBalance',
+            'misc',
+            'tokens',
+            'metadata',
+            'addresses',
+            'utxo',
+        ],
         discovery: [
             'status',
             'index',

--- a/packages/suite/src/hooks/wallet/useSendForm.ts
+++ b/packages/suite/src/hooks/wallet/useSendForm.ts
@@ -152,6 +152,7 @@ export const useSendForm = (props: UseSendFormProps): SendContextValues => {
     } = useSendFormCompose({
         ...useFormMethods,
         state,
+        account: props.selectedAccount.account,
         updateContext,
         setAmount: sendFormUtils.setAmount,
     });
@@ -201,12 +202,14 @@ export const useSendForm = (props: UseSendFormProps): SendContextValues => {
         if (composedTx && composedTx.type === 'final') {
             // sign workflow in Actions:
             // signTransaction > sign[COIN]Transaction > requestPushTransaction (modal with promise decision)
+            updateContext({ isLoading: true });
             const result = await signTransaction(values, composedTx);
+            updateContext({ isLoading: false });
             if (result) {
                 resetContext();
             }
         }
-    }, [getValues, composedLevels, signTransaction, resetContext]);
+    }, [getValues, composedLevels, signTransaction, resetContext, updateContext]);
 
     const typedRegister = useCallback(<T>(rules?: T) => register(rules), [register]);
 

--- a/packages/suite/src/hooks/wallet/useSendFormCompose.ts
+++ b/packages/suite/src/hooks/wallet/useSendFormCompose.ts
@@ -13,8 +13,9 @@ import { findComposeErrors } from '@wallet-utils/sendFormUtils';
 
 type Props = UseFormMethods<FormState> & {
     state: UseSendFormState;
+    account: UseSendFormState['account']; // account from the component props !== state.account
     updateContext: SendContextValues['updateContext'];
-    setAmount: any;
+    setAmount: (index: number, amount: string) => void;
 };
 
 // This hook should be used only as a sub-hook of `useSendForm`
@@ -26,6 +27,7 @@ export const useSendFormCompose = ({
     errors,
     clearErrors,
     state,
+    account,
     updateContext,
     setAmount,
 }: Props) => {
@@ -158,7 +160,7 @@ export const useSendFormCompose = ({
 
             const { setMaxOutputId } = values;
             // set calculated and formatted "max" value to `Amount` input
-            if (typeof setMaxOutputId === 'number') {
+            if (typeof setMaxOutputId === 'number' && composed.max) {
                 setAmount(setMaxOutputId, composed.max);
                 setDraftSaveRequest(true);
             }
@@ -234,10 +236,31 @@ export const useSendFormCompose = ({
         selectedFeeRef.current = selectedFee;
     }, [composedLevels, selectedFee, updateComposedValues, updateContext]);
 
-    // TODO: useEffect on props (check: account change: key||balance, fee change, fiat change)
-    // useEffect(() => {
-    //     console.warn('SET BALANCE', account.balance);
-    // }, [account.balance]);
+    // handle props.account change:
+    // - update context state (state.account)
+    // - compose transaction with new data
+    useEffect(() => {
+        if (state.account === account) return; // account didn't change
+        if (!state.isDirty) {
+            // there was no interaction with the form, just update state.account
+            updateContext({ account });
+            return;
+        }
+
+        // reset precomposed transactions
+        setComposedLevels(undefined);
+        // set ref for later use in useEffect which handle composedLevels change
+        composeRequestRef.current = 'outputs[0].amount';
+        // set ref for later use in processComposeRequest function
+        composeRequestID.current++;
+        // clear errors from compose process
+        const composeErrors = findComposeErrors(errors);
+        if (composeErrors.length > 0) {
+            clearErrors(composeErrors);
+        }
+        // start composing
+        updateContext({ account, isLoading: true });
+    }, [state.account, state.isDirty, account, clearErrors, errors, updateContext]);
 
     return {
         composeDraft,

--- a/packages/suite/src/middlewares/suite/suiteMiddleware.ts
+++ b/packages/suite/src/middlewares/suite/suiteMiddleware.ts
@@ -13,6 +13,7 @@ import * as trezorConnectActions from '@suite-actions/trezorConnectActions';
 import { getApp } from '@suite-utils/router';
 import { AppState, Action, Dispatch } from '@suite-types';
 import { isWeb } from '@suite-utils/env';
+import { sortByTimestamp } from '@suite-utils/device';
 
 const suite = (api: MiddlewareAPI<Dispatch, AppState>) => (next: Dispatch) => async (
     action: Action,
@@ -44,10 +45,11 @@ const suite = (api: MiddlewareAPI<Dispatch, AppState>) => (next: Dispatch) => as
                 forcedDevices.forEach(d => {
                     api.dispatch(suiteActions.rememberDevice(d));
                 });
-                // possible improvement - if there are no forcedDevices, try to pick the connected device instead of the first device
                 api.dispatch(
                     suiteActions.selectDevice(
-                        forcedDevices.length ? forcedDevices[0] : action.payload.devices[0],
+                        forcedDevices.length
+                            ? forcedDevices[0]
+                            : sortByTimestamp([...action.payload.devices])[0],
                     ),
                 );
             }

--- a/packages/suite/src/support/tests/hooksHelper.tsx
+++ b/packages/suite/src/support/tests/hooksHelper.tsx
@@ -48,7 +48,7 @@ export type UserAction<R = any> = {
 
 export const actionSequence = async <A extends UserAction[]>(
     actions: A,
-    callback: (action: A[number]) => void,
+    callback?: (action: A[number]) => void,
 ) => {
     for (let i = 0; i < actions.length; i++) {
         const action = actions[i];
@@ -79,6 +79,6 @@ export const actionSequence = async <A extends UserAction[]>(
         await waitForLoader();
 
         // action complete. run test
-        callback(action);
+        if (callback) callback(action);
     }
 };

--- a/packages/suite/src/support/tests/setupJest.ts
+++ b/packages/suite/src/support/tests/setupJest.ts
@@ -223,12 +223,17 @@ const getTrezorConnect = <M>(methods?: M) => {
                 return { success: false, ...getFixture(), _params };
             }),
             composeTransaction: jest.fn(async _params => {
-                const f = getFixture();
-                if (!f) return { success: false, payload: { error: 'error' }, _params };
-                if (typeof f.delay === 'number') {
-                    await new Promise(resolve => setTimeout(resolve, f.delay));
+                const fixture = getFixture();
+                if (fixture && typeof fixture.delay === 'number') {
+                    await new Promise(resolve => setTimeout(resolve, fixture.delay));
                 }
-                return f.response;
+                return { success: false, payload: { error: 'error' }, ...fixture, _params };
+            }),
+            signTransaction: jest.fn(async _params => {
+                return { success: false, payload: { error: 'error' }, ...getFixture(), _params };
+            }),
+            pushTransaction: jest.fn(async _params => {
+                return { success: true, payload: { txid: 'txid' }, ...getFixture(), _params };
             }),
             changePin: () => {
                 return {

--- a/packages/suite/src/views/wallet/send/components/ReviewButton/index.tsx
+++ b/packages/suite/src/views/wallet/send/components/ReviewButton/index.tsx
@@ -53,7 +53,11 @@ const ReviewButton = () => {
     return (
         <Wrapper>
             <Row>
-                <ButtonReview isDisabled={isDisabled || isLoading} onClick={signTransaction}>
+                <ButtonReview
+                    data-test="@send/review-button"
+                    isDisabled={isDisabled || isLoading}
+                    onClick={signTransaction}
+                >
                     {broadcastEnabled ? (
                         <Translation id="REVIEW_AND_SEND_TRANSACTION" />
                     ) : (


### PR DESCRIPTION
- handle selected account balance/utxo change and recompose transaction if needed
Sendform should react on account changes and will use new values.

- temporary calculate selected account balance and utxo before valid "account update" process.
There is possible race condition right after pushing tx to the network. Notification from blockbook may be delayed for few sec. therefore account is not properly updated yet. fix #2858

- device selected after loading from storage is a recently used device (sort using `device.ts` timestamp)


-----
Its ready to review but waiting for QA test result