### PR TITLE
fix(suite-desktop): save window dimension on window close

### DIFF
--- a/packages/suite-desktop/src-electron/electron.ts
+++ b/packages/suite-desktop/src-electron/electron.ts
@@ -315,7 +315,8 @@ const init = async () => {
         if (mainWindow.webContents.isDevToolsOpened()) {
             mainWindow.webContents.closeDevTools();
         }
-
+        // store window bounds on close btn click
+        store.setWinBounds(mainWindow);
         mainWindow.close();
     });
     ipcMain.on('window/minimize', () => {
@@ -451,7 +452,7 @@ app.on('before-quit', () => {
         // do nothing
     }
 
-    // store window bounds
+    // store window bounds on cmd/ctrl+q
     store.setWinBounds(mainWindow);
 
     // stop services

--- a/packages/suite-desktop/src-electron/store.ts
+++ b/packages/suite-desktop/src-electron/store.ts
@@ -47,12 +47,10 @@ export const getWinBounds = () => {
 
 export const setWinBounds = (window: BrowserWindow) => {
     const bounds = window.getBounds();
-    // don't allow saving window dimensions smaller than  MIN_WIDTHxMIN_HEIGHT
-    store.set('winBounds', {
-        ...bounds,
-        width: bounds.width > MIN_WIDTH ? bounds.width : MIN_WIDTH,
-        height: bounds.height > MIN_HEIGHT ? bounds.height : MIN_HEIGHT,
-    });
+    // save only non zero dimensions
+    if (bounds.width > 0 && bounds.height > 0) {
+        store.set('winBounds', bounds);
+    }
 };
 
 export const getUpdateSettings = () => {


### PR DESCRIPTION
close https://github.com/trezor/trezor-suite/issues/2938

tested on:
- [x] macOS
- [x] Ubuntu
- [x] Windows (yuge thanks to @wendys-cats)