### PR TITLE
fix(suite-desktop): don't trigger bridge update dialog for bridge 2.0.27 and newer

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "trezor-suite",
-    "version": "20.11.1",
+    "version": "20.11.2",
     "private": true,
     "repository": "https://github.com/trezor/trezor-suite.git",
     "license": "SEE LICENSE IN LICENSE.md",

--- a/packages/integration-tests/projects/suite-web/tests/backup/t2-misc.test.ts
+++ b/packages/integration-tests/projects/suite-web/tests/backup/t2-misc.test.ts
@@ -18,7 +18,7 @@ describe('Backup', () => {
         cy.getTestElement('@notification/no-backup/button').click();
         cy.getTestElement('@backup/check-item/understands-what-seed-is').click();
         cy.getTestElement('@backup/close-button').click();
-        cy.getTestElement('@notification/no-backup/button').click();
+        cy.getTestElement('@notification/no-backup/button').click({ force: true });
         cy.log('at this moment, after modal was closed and opened again, no checkbox should be checked');
         cy.getTestElement('@backup/check-item/understands-what-seed-is').should('not.be.checked');
     });

--- a/packages/landing-page/package.json
+++ b/packages/landing-page/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@trezor/landing-page",
-    "version": "20.11.1",
+    "version": "20.11.2",
     "private": true,
     "scripts": {
         "type-check": "tsc --project tsconfig.json",

--- a/packages/suite-data/package.json
+++ b/packages/suite-data/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@trezor/suite-data",
-    "version": "20.11.1",
+    "version": "20.11.2",
     "author": "Trezor <info@trezor.io>",
     "keywords": [
         "Trezor",

--- a/packages/suite-desktop/package.json
+++ b/packages/suite-desktop/package.json
@@ -1,7 +1,7 @@
 {
     "name": "@trezor/suite-desktop",
     "description": "Trezor Suite desktop application",
-    "version": "20.11.1",
+    "version": "20.11.2",
     "private": true,
     "author": "SatoshiLabs <info@satoshilabs.com>",
     "homepage": "https://trezor.io/",

--- a/packages/suite-native/package.json
+++ b/packages/suite-native/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@trezor/suite-native",
-    "version": "20.11.1",
+    "version": "20.11.2",
     "private": true,
     "scripts": {
         "dev:ios": "run-p start run-ios",
@@ -19,7 +19,7 @@
     },
     "dependencies": {
         "@trezor/components": "^1.0.0",
-        "@trezor/suite-storage": "20.11.1",
+        "@trezor/suite-storage": "20.11.2",
         "react": "16.13.1",
         "react-native": "0.63.2",
         "react-native-gesture-handler": "^1.5.2",

--- a/packages/suite-storage/package.json
+++ b/packages/suite-storage/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@trezor/suite-storage",
-    "version": "20.11.1",
+    "version": "20.11.2",
     "author": "Trezor <info@trezor.io>",
     "private": true,
     "keywords": [

--- a/packages/suite-web-landing/package.json
+++ b/packages/suite-web-landing/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@trezor/suite-web-landing",
-    "version": "20.11.1",
+    "version": "20.11.2",
     "private": true,
     "scripts": {
         "type-check": "tsc --project tsconfig.json",

--- a/packages/suite-web/package.json
+++ b/packages/suite-web/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@trezor/suite-web",
-    "version": "20.11.1",
+    "version": "20.11.2",
     "private": true,
     "scripts": {
         "type-check": "tsc --project tsconfig.json",
@@ -16,7 +16,7 @@
     "dependencies": {
         "@sentry/browser": "^5.16.0",
         "@sentry/integrations": "^5.16.0",
-        "@trezor/suite": "20.11.1",
+        "@trezor/suite": "20.11.2",
         "@zeit/next-workers": "^1.0.0",
         "next": "^9.5.3",
         "next-redux-wrapper": "^5.0.0",

--- a/packages/suite/package.json
+++ b/packages/suite/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@trezor/suite",
-    "version": "20.11.1",
+    "version": "20.11.2",
     "private": true,
     "scripts": {
         "lint": "yarn lint:styles && yarn lint:js",
@@ -18,8 +18,8 @@
     },
     "dependencies": {
         "@trezor/components": "^1.0.0",
-        "@trezor/suite-data": "20.11.1",
-        "@trezor/suite-storage": "20.11.1",
+        "@trezor/suite-data": "20.11.2",
+        "@trezor/suite-storage": "20.11.2",
         "bignumber.js": "^9.0.0",
         "date-fns": "^2.15.0",
         "date-fns-tz": "^1.0.10",

--- a/packages/suite/src/components/suite/Notifications/UpdateBridge.tsx
+++ b/packages/suite/src/components/suite/Notifications/UpdateBridge.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import { Button, colors } from '@trezor/components';
 import { Translation } from '@suite-components';
+import { isDesktop } from '@suite-utils/env';
 
 import Wrapper from './components/Wrapper';
 import { Props as BaseProps } from './index';
@@ -12,6 +13,11 @@ interface Props {
 
 const UpdateBridge = ({ transport, goto }: Props) => {
     if (!transport || !transport.outdated) return null;
+    if (isDesktop()) {
+        // we can work with these versions of bridge too
+        if (transport.version && ['2.0.27', '2.0.28', '2.0.29'].includes(transport.version))
+            return null;
+    }
     return (
         <Wrapper variant="info">
             <Translation id="TR_NEW_TREZOR_BRIDGE_IS_AVAILABLE" />


### PR DESCRIPTION
This is a quick-fix for yesterday's release.

I think we should not show an update bridge banner in Deskop if there is a bridge installed we can work with with no issues.

It also checks for the acceptable versions.

This is a PR straight to the release branch, so please don't merge yet, only review.

For develop I think we should discuss about fixing this properly (Desktop should probably tell you to uninstall the bridge - so the bundled version is used, but this causes other trouble - let's discuss that later).