### PR TITLE
fix: don't focus on element created for copying text to clipboard (pr…

### DIFF
--- a/packages/suite/src/utils/suite/dom.ts
+++ b/packages/suite/src/utils/suite/dom.ts
@@ -63,7 +63,6 @@ export const copyToClipboard = (
         el.style.position = 'absolute';
         el.style.left = '-9999px';
         container.appendChild(el);
-        el.focus();
         el.select();
         el.setSelectionRange(0, 99999); /* For mobile devices */
         const successful = document.execCommand('copy');


### PR DESCRIPTION
…events scrolling to the end of page in ff)

close https://github.com/trezor/trezor-suite/issues/2904#issuecomment-724631219

I am not sure why there we were calling a `focus` method, I checked 2 sources and they didn't use it. I did a quick test and looks like it works fine (latest chrome/firefox), but just to be sure cc-ing @szymonlesisz to take a look if you are okay with this solution.