### PR TITLE
Add invity.io to allowed domains in destop version

### DIFF
--- a/packages/suite-desktop/src-electron/config.ts
+++ b/packages/suite-desktop/src-electron/config.ts
@@ -9,6 +9,7 @@ export const allowedDomains = [
     'localhost',
     '127.0.0.1',
     'trezor.io',
+    'invity.io',
     'api.github.com',
     'api.dropboxapi.com',
     'content.dropboxapi.com',


### PR DESCRIPTION
It is used for example for Invity API staging server.