### PR TITLE
chore(suite-desktop): update electron to 11

### DIFF
--- a/packages/suite-desktop/package.json
+++ b/packages/suite-desktop/package.json
@@ -28,7 +28,7 @@
         "productName": "Trezor Suite",
         "copyright": "Copyright © ${author}",
         "asar": true,
-        "electronVersion": "10.1.0",
+        "electronVersion": "11.0.1",
         "directories": {
             "output": "build-electron"
         },
@@ -154,7 +154,7 @@
         "@types/react-redux": "^7.1.7",
         "@zeit/next-workers": "^1.0.0",
         "babel-plugin-styled-components": "1.11.1",
-        "electron": "^10.1.0",
+        "electron": "^11.0.1",
         "electron-builder": "^22.7.0",
         "electron-notarize": "^1.0.0",
         "git-revision-webpack-plugin": "^3.0.6",

--- a/yarn.lock
+++ b/yarn.lock
@@ -13449,10 +13449,10 @@ electron@*:
     "@types/node" "^12.0.12"
     extract-zip "^1.0.3"
 
-electron@^10.1.0:
-  version "10.1.0"
-  resolved "https://registry.yarnpkg.com/electron/-/electron-10.1.0.tgz#3559182545dc76e20d9764d183d555415d55c250"
-  integrity sha512-DyS6WhQ59+ZXQsI1EkpsYkOXFt0Xbp+mbxPTJS9A7O21r3JDzaTC+1Jxz7g6J+Sbi9Y7UFdRs0tn/vqhHJx2gA==
+electron@^11.0.1:
+  version "11.0.1"
+  resolved "https://registry.yarnpkg.com/electron/-/electron-11.0.1.tgz#e71195ff9abfbcfa0f4bf49ec9064e5e0f3f928c"
+  integrity sha512-UefDvxeyTREL1FpC0BcXwzLjcYiQICFSZONbwarpoqTXQU5rzEguIegHPqg5AqwYH4FVYfEuigj/Vm94rtZOzg==
   dependencies:
     "@electron/get" "^1.0.1"
     "@types/node" "^12.0.12"


### PR DESCRIPTION
close https://github.com/trezor/trezor-suite/issues/2999

I haven't tested it much. macOS/linux (x86_64) builds are launching fine, bundled bridge is correctly spawned (at least on nixOS), but someone should probably test things around auto updater just to be sure. (on the other hand we had never experienced any problems regarding upgrading electron so I am gonna say it will be fine 😁 )