### PR TITLE
style(components): lighter color for scrollbar thumb

### DIFF
--- a/packages/components/src/config/colors.ts
+++ b/packages/components/src/config/colors.ts
@@ -25,7 +25,7 @@ export const THEME = {
         TYPE_LIGHTER_GREY: '#bdbdbd',
         TYPE_WHITE: '#ffffff',
 
-        SCROLLBAR_THUMB: '#babac0',
+        SCROLLBAR_THUMB: '#dcdcdc',
         STROKE_GREY: '#e8e8e8',
         STROKE_LIGHT_GREY: '#f4f4f4',
 


### PR DESCRIPTION
super heavy fix as part of https://github.com/trezor/trezor-suite/issues/2997
(mainly useful for firefox on some linux platforms as they use pretty wide scrollbars which were attracting too much attention being so dark)

@bosomt approved!