### PR TITLE
fix(metadata): optimize loading

### DIFF
--- a/packages/integration-tests/projects/suite-web/tests/metadata/account-metadata.test.ts
+++ b/packages/integration-tests/projects/suite-web/tests/metadata/account-metadata.test.ts
@@ -5,8 +5,8 @@ import { rerouteMetadataToMockProvider, stubOpen } from '../../stubs/metadata';
 
 // fixture contains number of request that given provider needs go through this test scenario
 const fixtures = [
-    { provider: 'dropbox', numberOfRequests: [24, 43] },
-    { provider: 'google', numberOfRequests: [10, 16] },
+    { provider: 'dropbox', numberOfRequests: [24, 25] },
+    { provider: 'google', numberOfRequests: [10, 12] },
 ] as const;
 
 describe(`Metadata is by default disabled, this means, that application does not try to generate master key and connect to cloud.

--- a/packages/suite/src/actions/suite/metadataActions.ts
+++ b/packages/suite/src/actions/suite/metadataActions.ts
@@ -224,7 +224,7 @@ export const fetchMetadata = (deviceState: string) => async (
     dispatch: Dispatch,
     getState: GetState,
 ) => {
-    const provider = await dispatch(getProvider());
+    const provider = dispatch(getProvider());
     if (!provider) {
         return;
     }

--- a/packages/suite/src/actions/wallet/discoveryActions.ts
+++ b/packages/suite/src/actions/wallet/discoveryActions.ts
@@ -345,6 +345,9 @@ export const start = () => async (dispatch: Dispatch, getState: GetState): Promi
                 dispatch({ type: SUITE.REQUEST_AUTH_CONFIRM });
             }
         }
+        
+        // if status prevDiscovery === running, something changed, try
+
         dispatch(
             update(
                 {

--- a/packages/suite/src/actions/wallet/discoveryActions.ts
+++ b/packages/suite/src/actions/wallet/discoveryActions.ts
@@ -345,8 +345,12 @@ export const start = () => async (dispatch: Dispatch, getState: GetState): Promi
                 dispatch({ type: SUITE.REQUEST_AUTH_CONFIRM });
             }
         }
-        
-        // if status prevDiscovery === running, something changed, try
+
+        // if previous discovery status was running (typically after application start or when user added a new account)
+        // trigger fetch metadata
+        if (discovery.status === DISCOVERY.STATUS.RUNNING) {
+            dispatch(metadataActions.fetchMetadata(deviceState));
+        }
 
         dispatch(
             update(

--- a/packages/suite/src/middlewares/suite/metadataMiddleware.ts
+++ b/packages/suite/src/middlewares/suite/metadataMiddleware.ts
@@ -1,6 +1,6 @@
 import { MiddlewareAPI } from 'redux';
 import * as metadataActions from '@suite-actions/metadataActions';
-import { ACCOUNT, DISCOVERY } from '@wallet-actions/constants';
+import { ACCOUNT } from '@wallet-actions/constants';
 import { AppState, Action, Dispatch } from '@suite-types';
 import { ROUTER, SUITE } from '@suite-actions/constants';
 
@@ -15,20 +15,6 @@ const metadata = (api: MiddlewareAPI<Dispatch, AppState>) => (next: Dispatch) =>
     next(action);
 
     switch (action.type) {
-        case DISCOVERY.UPDATE: {
-            const { total, loaded } = action.payload;
-            if (
-                api.getState().metadata.enabled &&
-                // todo: does loaded include failed count?
-                // todo: wouldn't it be better to change discovery complete action to dispatch some final 'stats'?
-                total &&
-                loaded &&
-                total === loaded
-            ) {
-                api.dispatch(metadataActions.fetchMetadata(action.payload.deviceState));
-            }
-            break;
-        }
         case SUITE.RECEIVE_AUTH_CONFIRM:
             if (
                 action.success &&

--- a/packages/suite/src/middlewares/suite/metadataMiddleware.ts
+++ b/packages/suite/src/middlewares/suite/metadataMiddleware.ts
@@ -15,11 +15,20 @@ const metadata = (api: MiddlewareAPI<Dispatch, AppState>) => (next: Dispatch) =>
     next(action);
 
     switch (action.type) {
-        case DISCOVERY.COMPLETE:
-            if (api.getState().metadata.enabled) {
+        case DISCOVERY.UPDATE: {
+            const { total, loaded } = action.payload;
+            if (
+                api.getState().metadata.enabled &&
+                // todo: does loaded include failed count?
+                // todo: wouldn't it be better to change discovery complete action to dispatch some final 'stats'?
+                total &&
+                loaded &&
+                total === loaded
+            ) {
                 api.dispatch(metadataActions.fetchMetadata(action.payload.deviceState));
             }
             break;
+        }
         case SUITE.RECEIVE_AUTH_CONFIRM:
             if (
                 action.success &&


### PR DESCRIPTION
Idea to optimize excessive http requests for metadata and close #2671
The first commit (3bec66805c55b95c0ee37e2c9a67893bc656f815) contains some tests documenting how many requests were fired. The other one (e0f405455ee4a2362f03b8f1f4ac381a081729a9) contains fix.

Intentionally left one todo in there to initiate discussion :] 
