### PR TITLE
fix(suite-desktop): move request headers to work with dev builds (required by new Bridge)

### DIFF
--- a/packages/suite-desktop/src-electron/electron.ts
+++ b/packages/suite-desktop/src-electron/electron.ts
@@ -184,18 +184,18 @@ const init = async () => {
         evt.preventDefault();
     });
 
-    if (!isDev) {
-        const filter = {
-            urls: ['http://127.0.0.1:21325/*'],
-        };
+    const filter = {
+        urls: ['http://127.0.0.1:21325/*'],
+    };
 
-        if (session.defaultSession) {
-            session.defaultSession.webRequest.onBeforeSendHeaders(filter, (details, callback) => {
-                // @ts-ignore electron declares requestHeaders as an empty interface
-                details.requestHeaders.Origin = 'https://electron.trezor.io';
-                callback({ cancel: false, requestHeaders: details.requestHeaders });
-            });
+    if (session.defaultSession) {
+        session.defaultSession.webRequest.onBeforeSendHeaders(filter, (details, callback) => {
+            // @ts-ignore electron declares requestHeaders as an empty interface
+            details.requestHeaders.Origin = 'https://electron.trezor.io';
+            callback({ cancel: false, requestHeaders: details.requestHeaders });
+        });
 
+        if (!isDev) {
             if (!disableCspFlag) {
                 session.defaultSession.webRequest.onHeadersReceived((details, callback) => {
                     callback({
@@ -214,9 +214,9 @@ const init = async () => {
                 callback(url);
             });
         }
-
-        registerShortcuts(mainWindow);
     }
+
+    registerShortcuts(mainWindow);
 
     mainWindow.loadURL(src);
 


### PR DESCRIPTION
Correct origin wasn't set in dev builds which breaks the Bridge after the latest update. 