### PR TITLE
fix(invity): allow only 2 decimals in fiat input

### DIFF
--- a/packages/suite/src/views/wallet/coinmarket/exchange/components/ExchangeForm/Inputs/FiatInput/index.tsx
+++ b/packages/suite/src/views/wallet/coinmarket/exchange/components/ExchangeForm/Inputs/FiatInput/index.tsx
@@ -50,12 +50,17 @@ const FiatInput = () => {
                             return 'AMOUNT_IS_NOT_NUMBER';
                         }
 
-                        if (amountBig.lte(0)) {
-                            return 'AMOUNT_IS_TOO_LOW';
+                        if (!isDecimalsValid(value, 2)) {
+                            return (
+                                <Translation
+                                    id="AMOUNT_IS_NOT_IN_RANGE_DECIMALS"
+                                    values={{ decimals: 2 }}
+                                />
+                            );
                         }
 
-                        if (!isDecimalsValid(value, 18)) {
-                            return <Translation id="TR_EXCHANGE_VALIDATION_ERROR_NOT_NUMBER" />;
+                        if (amountBig.lte(0)) {
+                            return 'AMOUNT_IS_TOO_LOW';
                         }
                     }
                 },


### PR DESCRIPTION
resolves: https://github.com/trezor/trezor-suite/issues/3003
![image](https://user-images.githubusercontent.com/3112191/99547999-78a91400-29b8-11eb-96d2-023dab20297f.png)
