### PR TITLE
fix(send): DOGE fees

### DIFF
--- a/packages/suite/docs/SEND.md
+++ b/packages/suite/docs/SEND.md
@@ -40,6 +40,7 @@
 - AMOUNT_IS_NOT_SET (empty field)
 - AMOUNT_IS_NOT_NUMBER (not valid number)
 - AMOUNT_IS_TOO_LOW (lower/equal than zero + ETH exception: 0 amount is possible ONLY for tx with DATA)
+- AMOUNT_IS_BELOW_DUST lower than network dust limit
 - AMOUNT_IS_NOT_ENOUGH (not enough funds on account)
 - AMOUNT_NOT_ENOUGH_CURRENCY_FEE (ETH only: trying to send TOKEN without enough ETH to cover TX fee)
 - AMOUNT_IS_MORE_THAN_RESERVE (XRP only: trying to spend the reserve)

--- a/packages/suite/src/support/messages.ts
+++ b/packages/suite/src/support/messages.ts
@@ -4240,6 +4240,10 @@ const definedMessages = defineMessages({
         defaultMessage: 'Amount is too low',
         id: 'AMOUNT_IS_TOO_LOW',
     },
+    AMOUNT_IS_BELOW_DUST: {
+        defaultMessage: 'Amount is below the dust limit ({dust})',
+        id: 'AMOUNT_IS_BELOW_DUST',
+    },
     AMOUNT_IS_MORE_THAN_RESERVE: {
         defaultMessage: 'Amount is above the required unspendable reserve ({reserve} XRP)',
         id: 'AMOUNT_IS_MORE_THAN_RESERVE',

--- a/packages/suite/src/types/wallet/sendForm.ts
+++ b/packages/suite/src/types/wallet/sendForm.ts
@@ -54,6 +54,7 @@ export interface FeeInfo {
     blockTime: number; // how often block is mined
     minFee: number;
     maxFee: number;
+    dustLimit?: number; // coin dust limit
     feeLimit?: number; // eth gas limit
     levels: FeeLevel[]; // fee levels are predefined in trezor-connect > trezor-firmware/common
 }

--- a/packages/suite/src/views/wallet/send/components/Outputs/components/Amount/index.tsx
+++ b/packages/suite/src/views/wallet/send/components/Outputs/components/Amount/index.tsx
@@ -84,6 +84,7 @@ const Amount = ({ output, outputId }: Props) => {
     const {
         account,
         network,
+        feeInfo,
         localCurrencyOption,
         register,
         getDefaultValue,
@@ -188,6 +189,20 @@ const Amount = ({ output, outputId }: Props) => {
                             // allow 0 amount ONLY for ethereum transaction with data
                             if (amountBig.eq(0) && !getDefaultValue('ethereumDataHex')) {
                                 return 'AMOUNT_IS_TOO_LOW';
+                            }
+
+                            // amounts below dust are not allowed
+                            const dust =
+                                feeInfo.dustLimit &&
+                                formatNetworkAmount(feeInfo.dustLimit.toString(), symbol);
+                            if (dust && amountBig.lte(dust)) {
+                                return (
+                                    <Translation
+                                        key="AMOUNT_IS_BELOW_DUST"
+                                        id="AMOUNT_IS_BELOW_DUST"
+                                        values={{ dust: `${dust} ${symbol.toUpperCase()}` }}
+                                    />
+                                );
                             }
 
                             if (amountBig.gt(formattedAvailableBalance)) {


### PR DESCRIPTION
~~depends on: https://github.com/trezor/connect/pull/712 and https://github.com/trezor/hd-wallet/pull/51~~

new DOGE fee rules are:
- 1 DOGE base fee (for every regular tx lower than 1000 bytes)
- 1 DOGE for every next started 1000b (tx with size 1100 b = 2 DOGE)
- dust is 1 DOGE, so for example if you have 2.5 DOGE and send 1 DOGE away you will pay 1.5 DOGE fee (1 base + 0.5 dust)
- amounts lower than 1 doge are not allowed (dust validation)
- custom fee lower than 100000 sat/b is not allowed

new feature:
all BTC-like coins have new validation rule for amounts

![Screenshot 2020-11-20 at 10 09 32](https://user-images.githubusercontent.com/3435913/99782939-1536f780-2b1a-11eb-8ce4-9ac08a7016ac.png)
![Screenshot 2020-11-20 at 10 07 42](https://user-images.githubusercontent.com/3435913/99782963-1a944200-2b1a-11eb-9841-edb27f6bc33f.png)

