### PR TITLE
Open a github issue directly from Suite

### DIFF
--- a/nixos-fix-binaries.sh
+++ b/nixos-fix-binaries.sh
@@ -1,3 +1,5 @@
+#!/usr/bin/env bash
+
 if [ -f /etc/NIXOS ] ; then
   if [ -z "$IN_NIX_SHELL" ] ; then
     echo "You need to run this script in a nix-shell. Aborting"

--- a/packages/suite/src/services/github.ts
+++ b/packages/suite/src/services/github.ts
@@ -1,3 +1,7 @@
+import { getFwVersion, isBitcoinOnly, getVersion } from '@suite-utils/device';
+import { isDesktop, getUserAgent, getScreenWidth, getScreenHeight } from '@suite-utils/env';
+import { TrezorDevice } from '@suite-types';
+
 const REPO_INFO = {
     owner: 'trezor',
     repo: 'trezor-suite',
@@ -15,6 +19,56 @@ export const getReleaseNotes = async (version?: string) => {
     const release = response.json();
 
     return release;
+};
+
+const getDeviceInfo = (device?: TrezorDevice) => {
+    if (!device?.features) {
+        return '';
+    }
+    return `model ${getVersion(device)} ${getFwVersion(device)} ${
+        isBitcoinOnly(device) ? 'Bitcoin only' : 'regular'
+    }`;
+};
+
+const getSuiteInfo = () => {
+    return `${isDesktop() ? 'desktop' : 'web'} ${process.env.VERSION} (${process.env.COMMITHASH})`;
+};
+
+export const openGithubIssue = (device?: TrezorDevice) => {
+    const url = new URL(`${RELEASE_URL}/issues/new`);
+
+    const body = `
+**Describe the bug**
+A clear and concise description of what the bug is.
+
+**Steps to reproduce:**
+1. a
+2. b
+3. c
+
+**Info:**
+ - Suite version: ${getSuiteInfo()}
+ - Browser: ${getUserAgent()}
+ - OS: ${navigator.platform}
+ - Screen: ${getScreenWidth()}x${getScreenHeight()}
+ - Device: ${getDeviceInfo(device)}
+
+**Expected result:**
+A clear and concise description of what you expected to happen.
+
+**Actual result:**
+A clear and concise description of what actually happens.
+
+**Screenshots:**
+Insert here.
+
+**Note(s):**
+Add any other context about the problem here.
+`;
+
+    url.searchParams.set('body', body);
+
+    window.open(url.toString());
 };
 
 export const getReleaseUrl = (version: string) => `${RELEASE_URL}/releases/tag/v${version}`;

--- a/packages/suite/src/views/settings/debug/index.tsx
+++ b/packages/suite/src/views/settings/debug/index.tsx
@@ -4,7 +4,8 @@ import { Button, Switch, Select, THEME, SuiteThemeColors } from '@trezor/compone
 import { SettingsLayout } from '@settings-components';
 import { ActionColumn, Row, Section, TextColumn } from '@suite-components/Settings';
 import * as suiteActions from '@suite-actions/suiteActions';
-import { useSelector, useActions } from '@suite-hooks';
+import { useDevice, useSelector, useActions } from '@suite-hooks';
+import { openGithubIssue } from '@suite/services/github';
 
 import { Props } from './Container';
 import invityAPI from '@suite-services/invityAPI';
@@ -35,6 +36,7 @@ const DebugSettings = (props: Props) => {
     ];
     const selectedInvityApiServer =
         invityApiServerOptions.find(s => s.value === invityAPIUrl) || invityApiServerOptions[0];
+    const { device } = useDevice();
     return (
         <SettingsLayout>
             <Section title="Localization">
@@ -54,6 +56,8 @@ const DebugSettings = (props: Props) => {
                         />
                     </ActionColumn>
                 </Row>
+            </Section>
+            <Section title="Debug">
                 <Row>
                     <TextColumn
                         title="Trezor Bridge dev mode (desktop)"
@@ -68,6 +72,21 @@ const DebugSettings = (props: Props) => {
                                 });
                             }}
                         />
+                    </ActionColumn>
+                </Row>
+                <Row>
+                    <TextColumn
+                        title="Open issue on Github"
+                        description="Open issue on Github with pre-filled details. Do not use with sensitive data!"
+                    />
+                    <ActionColumn>
+                        <Button
+                            onClick={() => {
+                                openGithubIssue(device);
+                            }}
+                        >
+                            Open issue
+                        </Button>
                     </ActionColumn>
                 </Row>
             </Section>


### PR DESCRIPTION
I hope @keraf won't mind that I took this, I wanted to give it a go to explore Suite a bit :). There are few things left to do:

- Insert firmware details. I just could not figure out how to retrieve that properly.
- Insert more details/log into the details section. This will be hidden under a collapsible button so I would paste there anything that might be helpful. What do you think? Example below.
- I am not sure if retrieving the data in `github.ts` is OK.

<details>Hi</details>

Closes #2994.

