### PR TITLE
Fix/ui 21415

### DIFF
--- a/packages/components/src/components/form/CleanSelect/index.tsx
+++ b/packages/components/src/components/form/CleanSelect/index.tsx
@@ -99,6 +99,7 @@ const selectStyle = (
     },
     menu: (base: Record<string, any>) => ({
         ...base,
+        background: theme.BG_WHITE_ALT,
         minWidth: '85px',
         color: theme.TYPE_LIGHT_GREY,
         boxShadow: '0 4px 10px 0 rgba(0, 0, 0, 0.15)',

--- a/packages/components/src/components/form/Select/index.tsx
+++ b/packages/components/src/components/form/Select/index.tsx
@@ -65,6 +65,7 @@ const selectStyle = (
     }),
     menu: (base: Record<string, any>) => ({
         ...base,
+        background: theme.BG_WHITE_ALT,
         margin: '5px 0',
         boxShadow: `box-shadow: 0 4px 10px 0 ${theme.BOX_SHADOW_BLACK_20}`,
         zIndex: 9,

--- a/packages/components/src/config/colors.ts
+++ b/packages/components/src/config/colors.ts
@@ -41,6 +41,7 @@ export const THEME = {
         GRADIENT_RED_START: '#d15b5b',
         GRADIENT_RED_END: '#e75f5f',
 
+        BOX_SHADOW_BLACK_5: 'rgba(0, 0, 0, 0.05)',
         BOX_SHADOW_BLACK_15: 'rgba(0, 0, 0, 0.15)',
         BOX_SHADOW_BLACK_20: 'rgba(0, 0, 0, 0.2)',
         BOX_SHADOW_MODAL: 'rgba(77, 77, 77, 0.2)',
@@ -85,6 +86,7 @@ export const THEME = {
         GRADIENT_RED_START: '#d15b5b', // same as in light theme
         GRADIENT_RED_END: '#e75f5f', // same as in light theme
 
+        BOX_SHADOW_BLACK_5: 'rgba(255, 255, 255, 0.05)',
         BOX_SHADOW_BLACK_15: 'rgba(0, 0, 0, 0.2)',
         BOX_SHADOW_BLACK_20: 'rgba(0, 0, 0, 0.2)', // shadow around dropdown
         BOX_SHADOW_MODAL: 'rgba(0, 0, 0, 0.5)', // shadow around modal
@@ -131,6 +133,7 @@ export const THEME = {
         GRADIENT_RED_START: '#d15b5b', // same as in light theme
         GRADIENT_RED_END: '#e75f5f', // same as in light theme
 
+        BOX_SHADOW_BLACK_5: 'rgba(255, 255, 255, 0.05)',
         BOX_SHADOW_BLACK_15: 'rgba(0, 0, 0, 0.2)',
         BOX_SHADOW_BLACK_20: 'rgba(255, 255, 255, 0.1)', // shadow around dropdown
         BOX_SHADOW_MODAL: 'rgba(0, 0, 0, 0.5)', // shadow around modal

--- a/packages/suite/src/components/firmware/Error.tsx
+++ b/packages/suite/src/components/firmware/Error.tsx
@@ -12,7 +12,7 @@ const Body = () => {
         <>
             <ErrorImg />
             <H2>
-                <Translation id="TR_OOPS_SOMETHING_WENT_WRONG" />
+                <Translation id="TR_FW_INSTALLATION_FAILED" />
             </H2>
             {/* yeah I know we shouldn't use something called TOAST_ here.. but it is so beautifully generic.. */}
             <P data-test="@firmware/error-message">

--- a/packages/suite/src/components/onboarding/Option/index.tsx
+++ b/packages/suite/src/components/onboarding/Option/index.tsx
@@ -21,7 +21,7 @@ const Wrapper = styled.div<WrapperProps>`
     flex-direction: column;
 
     &:hover {
-        box-shadow: 0px 0px 6px 2px rgba(0, 0, 0, 0.05);
+        box-shadow: 0px 0px 6px 2px ${props => props.theme.BOX_SHADOW_BLACK_5};
     }
 `;
 

--- a/packages/suite/src/components/suite/DeviceInvalidModeLayout/index.tsx
+++ b/packages/suite/src/components/suite/DeviceInvalidModeLayout/index.tsx
@@ -14,7 +14,7 @@ const Image = styled(Img)`
     ${props =>
         props.image === 'UNI_WARNING' &&
         css`
-            height: 64px;
+            max-height: 160px;
             flex: 0 0 auto;
         `}
 `;

--- a/packages/suite/src/components/suite/modals/PinMismatch/index.tsx
+++ b/packages/suite/src/components/suite/modals/PinMismatch/index.tsx
@@ -6,7 +6,8 @@ import * as deviceSettingsActions from '@settings-actions/deviceSettingsActions'
 import { useActions } from '@suite-hooks';
 
 const StyledImage = styled(Image)`
-    flex: 1;
+    margin: 12px 0px;
+    max-height: 160px;
 `;
 
 const PinMismatch = (props: ModalProps) => {

--- a/packages/suite/src/components/suite/modals/QrScanner/index.tsx
+++ b/packages/suite/src/components/suite/modals/QrScanner/index.tsx
@@ -31,7 +31,7 @@ const CameraPlaceholder = styled.div`
     padding: 40px;
     height: 320px;
     border-radius: 3px;
-    background: #ebebeb;
+    background: ${props => props.theme.BG_GREY};
 `;
 
 const Error = styled.div`
@@ -136,7 +136,7 @@ const QrScanner = ({ onCancel, decision }: Props) => {
                     <CameraPlaceholder>
                         <Error>
                             <ErrorTitle>
-                                <Translation id="TR_OOPS_SOMETHING_WENT_WRONG" />
+                                <Translation id="TR_GENERIC_ERROR_TITLE" />
                             </ErrorTitle>
                             <ErrorMessage>{error}</ErrorMessage>
                         </Error>

--- a/packages/suite/src/support/messages.ts
+++ b/packages/suite/src/support/messages.ts
@@ -1879,9 +1879,14 @@ const definedMessages = defineMessages({
         defaultMessage: 'Online',
         id: 'TR_ONLINE',
     },
-    TR_OOPS_SOMETHING_WENT_WRONG: {
+    TR_GENERIC_ERROR_TITLE: {
         defaultMessage: 'Oops! Something went wrong!',
-        id: 'TR_OOPS_SOMETHING_WENT_WRONG',
+        description: 'Generic error message title',
+        id: 'TR_GENERIC_ERROR_TITLE',
+    },
+    TR_FW_INSTALLATION_FAILED: {
+        defaultMessage: 'Installation failed',
+        id: 'TR_FW_INSTALLATION_FAILED',
     },
     TR_OPEN_IN_BLOCK_EXPLORER: {
         defaultMessage: 'Open in Block Explorer',


### PR DESCRIPTION
part of https://github.com/trezor/trezor-suite/issues/3048 (2. and 3. screenshot)
part of https://github.com/trezor/trezor-suite/issues/2997 (send form: qr scanner placeholder bg color)

- dark mode: better box shadow for hover effect on Option component in onboarding
- dark mode: fix missing background in Select and CleanSelect (eg. it was visible on "no options" screen)
- dark mode: bg color for qr scanner placeholder box
- some intl cleanup
- adjust max height of the error icon in case of pin mismatch during pin setup in onboarding (the image was so huge in firefox that it was causing overflow in the modal). I also used the same size for warning img so there is at least a little consitency.
