### PR TITLE
fix(suite-desktop): ignore error display while auto-updater is checking

### DIFF
--- a/packages/suite/src/actions/suite/desktopUpdateActions.ts
+++ b/packages/suite/src/actions/suite/desktopUpdateActions.ts
@@ -44,7 +44,11 @@ export const error = (err: Error) => (dispatch: Dispatch, getState: GetState) =>
     console.error('auto-updater', err);
 
     const { state } = getState().desktopUpdate;
-    dispatch(addToast({ type: 'auto-updater-error', state }));
+
+    // Ignore displaying errors while checking
+    if (state !== 'checking') {
+        dispatch(addToast({ type: 'auto-updater-error', state }));
+    }
 
     dispatch({
         type: DESKTOP_UPDATE.NOT_AVAILABLE,


### PR DESCRIPTION
Fixes #2968 