### PR TITLE
ci: --frozen-lockfile

### DIFF
--- a/.git-hooks/post-merge
+++ b/.git-hooks/post-merge
@@ -1,0 +1,23 @@
+#!/bin/bash
+
+# check whether there was a change to libs that need to be built
+
+for path in "packages/components" "packages/rollout" "packages/blockchain-link" "packages/suite-storage" "packages/translations-manager"
+do
+    diff="$(git diff HEAD^ --name-only --diff-filter=ACMR "$path")"
+    if [ ! -z "$diff" ]
+    then
+        yarn build:libs
+    fi
+done
+
+# check whether yarn.lock changed and if yes call yarn install
+
+for path in "yarn.lock"
+do
+    diff="$(git diff HEAD^ --name-only --diff-filter=ACMR "$path")"
+    if [ ! -z "$diff" ]
+    then
+        yarn
+    fi
+done

--- a/ci/environment.yml
+++ b/ci/environment.yml
@@ -14,3 +14,8 @@ build & push image:
     - docker build --no-cache --tag $CONTAINER_NAME:$CI_COMMIT_SHA --tag $CONTAINER_NAME:latest ./ci/docker/base
     - docker push $CONTAINER_NAME:$CI_COMMIT_SHA
     - docker push $CONTAINER_NAME:latest
+
+install:
+  stage: setup environment
+  script:
+    - ci/scripts/check_lockfile.sh

--- a/ci/packages/components.yml
+++ b/ci/packages/components.yml
@@ -15,7 +15,7 @@
 .build_common: &build_common
   stage: build
   script:
-    - yarn install --pure-lockfile --cache-folder .yarn --prefer-offline
+    - yarn install --frozen-lockfile --cache-folder .yarn --prefer-offline
     - yarn workspace @trezor/components storybook-build
   artifacts:
     name: components-build-storybook-files

--- a/ci/packages/landing-page.yml
+++ b/ci/packages/landing-page.yml
@@ -10,8 +10,8 @@
 landing-page build dev:
   stage: build
   script:
-    - yarn install --pure-lockfile --cache-folder .yarn --prefer-offline
     - yarn install --frozen-lockfile --cache-folder .yarn --prefer-offline
+    - yarn build:libs
     - assetPrefix=/landing-page/${CI_BUILD_REF_NAME} yarn workspace @trezor/landing-page build
   artifacts:
     expire_in: 7 days
@@ -24,6 +24,7 @@ landing-page build beta:
     <<: *run_everything_rules
   script:
     - yarn install --frozen-lockfile --cache-folder .yarn --prefer-offline
+    - yarn build:libs
     - yarn workspace @trezor/landing-page build
   artifacts:
     expire_in: 7 days

--- a/ci/packages/landing-page.yml
+++ b/ci/packages/landing-page.yml
@@ -11,6 +11,7 @@ landing-page build dev:
   stage: build
   script:
     - yarn install --pure-lockfile --cache-folder .yarn --prefer-offline
+    - yarn install --frozen-lockfile --cache-folder .yarn --prefer-offline
     - assetPrefix=/landing-page/${CI_BUILD_REF_NAME} yarn workspace @trezor/landing-page build
   artifacts:
     expire_in: 7 days
@@ -22,7 +23,7 @@ landing-page build beta:
   only:
     <<: *run_everything_rules
   script:
-    - yarn install --pure-lockfile --cache-folder .yarn --prefer-offline
+    - yarn install --frozen-lockfile --cache-folder .yarn --prefer-offline
     - yarn workspace @trezor/landing-page build
   artifacts:
     expire_in: 7 days

--- a/ci/packages/rollout.yml
+++ b/ci/packages/rollout.yml
@@ -7,5 +7,5 @@ rollout test integration:
       - schedules
   stage: integration testing
   script:
-    - yarn install --pure-lockfile --cache-folder .yarn --prefer-offline
+    - yarn install --frozen-lockfile --cache-folder .yarn --prefer-offline
     - yarn workspace @trezor/rollout test:integration

--- a/ci/packages/suite-desktop.yml
+++ b/ci/packages/suite-desktop.yml
@@ -2,6 +2,7 @@
   stage: build
   script:
     - yarn install --frozen-lockfile --cache-folder .yarn --prefer-offline
+    - yarn build:libs
     - yarn workspace @trezor/suite-data copy-static-files
     - yarn workspace @trezor/suite-desktop build:${platform}
     - ls -la packages/suite-desktop/build-electron
@@ -16,6 +17,7 @@
 .build_nix: &build_nix
   script: # override build script to use nix-shell instead
     - nix-shell --run "yarn install --frozen-lockfile --cache-folder .yarn --prefer-offline"
+    - nix-shell --run "yarn build:libs"
     - nix-shell --run "yarn workspace @trezor/suite-data copy-static-files"
     - nix-shell --run "yarn workspace @trezor/suite-desktop build:${platform}"
     - ls -la packages/suite-desktop/build-electron

--- a/ci/packages/suite-desktop.yml
+++ b/ci/packages/suite-desktop.yml
@@ -1,7 +1,7 @@
 .build: &build
   stage: build
   script:
-    - yarn install --pure-lockfile --cache-folder .yarn --prefer-offline
+    - yarn install --frozen-lockfile --cache-folder .yarn --prefer-offline
     - yarn workspace @trezor/suite-data copy-static-files
     - yarn workspace @trezor/suite-desktop build:${platform}
     - ls -la packages/suite-desktop/build-electron
@@ -15,7 +15,7 @@
 
 .build_nix: &build_nix
   script: # override build script to use nix-shell instead
-    - nix-shell --run "yarn install --pure-lockfile --cache-folder .yarn --prefer-offline"
+    - nix-shell --run "yarn install --frozen-lockfile --cache-folder .yarn --prefer-offline"
     - nix-shell --run "yarn workspace @trezor/suite-data copy-static-files"
     - nix-shell --run "yarn workspace @trezor/suite-desktop build:${platform}"
     - ls -la packages/suite-desktop/build-electron

--- a/ci/packages/suite-native.yml
+++ b/ci/packages/suite-native.yml
@@ -6,7 +6,7 @@ suite-native build android:
       - develop
       - schedules
   script:
-    - yarn install --pure-lockfile --cache-folder .yarn --prefer-offline
+    - yarn install --frozen-lockfile --cache-folder .yarn --prefer-offline
     - yarn build:libs
     - yarn workspace @trezor/suite-data copy-static-files
     - yarn workspace @trezor/suite-native build:android

--- a/ci/packages/suite-web-landing.yml
+++ b/ci/packages/suite-web-landing.yml
@@ -8,7 +8,7 @@
 suite-web-landing build dev:
   stage: build
   script:
-    - yarn install --pure-lockfile --cache-folder .yarn --prefer-offline
+    - yarn install --frozen-lockfile --cache-folder .yarn --prefer-offline
     - assetPrefix=/suite-web-landing/${CI_BUILD_REF_NAME} yarn workspace @trezor/suite-web-landing build
   artifacts:
     expire_in: 7 days
@@ -20,7 +20,7 @@ suite-web-landing build stable:
   only:
     <<: *run_everything_rules
   script:
-    - yarn install --pure-lockfile --cache-folder .yarn --prefer-offline
+    - yarn install --frozen-lockfile --cache-folder .yarn --prefer-offline
     - yarn workspace @trezor/suite-web-landing build
   artifacts:
     expire_in: 7 days

--- a/ci/packages/suite-web-landing.yml
+++ b/ci/packages/suite-web-landing.yml
@@ -9,6 +9,7 @@ suite-web-landing build dev:
   stage: build
   script:
     - yarn install --frozen-lockfile --cache-folder .yarn --prefer-offline
+    - yarn build:libs
     - assetPrefix=/suite-web-landing/${CI_BUILD_REF_NAME} yarn workspace @trezor/suite-web-landing build
   artifacts:
     expire_in: 7 days
@@ -21,6 +22,7 @@ suite-web-landing build stable:
     <<: *run_everything_rules
   script:
     - yarn install --frozen-lockfile --cache-folder .yarn --prefer-offline
+    - yarn build:libs
     - yarn workspace @trezor/suite-web-landing build
   artifacts:
     expire_in: 7 days

--- a/ci/packages/suite-web.yml
+++ b/ci/packages/suite-web.yml
@@ -14,6 +14,7 @@ suite-web build dev:
   stage: build
   script:
     - yarn install --frozen-lockfile --cache-folder .yarn --prefer-offline
+    - yarn build:libs
     - assetPrefix=/suite-web/${CI_BUILD_REF_NAME}/web yarn workspace @trezor/suite-web build
   artifacts:
     expire_in: 7 days
@@ -26,6 +27,7 @@ suite-web build beta:
     <<: *run_everything_rules
   script:
     - yarn install --frozen-lockfile --cache-folder .yarn --prefer-offline
+    - yarn build:libs
     - assetPrefix=/wallet/web yarn workspace @trezor/suite-web build
   artifacts:
     expire_in: 7 days
@@ -39,6 +41,7 @@ suite-web build stable:
     <<: *run_everything_rules
   script:
     - yarn install --frozen-lockfile --cache-folder .yarn --prefer-offline
+    - yarn build:libs
     - assetPrefix=/web yarn workspace @trezor/suite-web build
   artifacts:
     expire_in: 7 days

--- a/ci/packages/suite-web.yml
+++ b/ci/packages/suite-web.yml
@@ -13,7 +13,7 @@ variables:
 suite-web build dev:
   stage: build
   script:
-    - yarn install --pure-lockfile --cache-folder .yarn --prefer-offline
+    - yarn install --frozen-lockfile --cache-folder .yarn --prefer-offline
     - assetPrefix=/suite-web/${CI_BUILD_REF_NAME}/web yarn workspace @trezor/suite-web build
   artifacts:
     expire_in: 7 days
@@ -25,7 +25,7 @@ suite-web build beta:
   only:
     <<: *run_everything_rules
   script:
-    - yarn install --pure-lockfile --cache-folder .yarn --prefer-offline
+    - yarn install --frozen-lockfile --cache-folder .yarn --prefer-offline
     - assetPrefix=/wallet/web yarn workspace @trezor/suite-web build
   artifacts:
     expire_in: 7 days
@@ -38,7 +38,7 @@ suite-web build stable:
   only:
     <<: *run_everything_rules
   script:
-    - yarn install --pure-lockfile --cache-folder .yarn --prefer-offline
+    - yarn install --frozen-lockfile --cache-folder .yarn --prefer-offline
     - assetPrefix=/web yarn workspace @trezor/suite-web build
   artifacts:
     expire_in: 7 days

--- a/ci/prebuild.yml
+++ b/ci/prebuild.yml
@@ -1,19 +1,19 @@
 lint:
   stage: prebuild
   script:
-    - yarn install --pure-lockfile --cache-folder .yarn --prefer-offline
+    - yarn install --frozen-lockfile --cache-folder .yarn --prefer-offline
     - lerna run lint
 
 typescript:
   stage: prebuild
   script:
-    - yarn install --pure-lockfile --cache-folder .yarn --prefer-offline
+    - yarn install --frozen-lockfile --cache-folder .yarn --prefer-offline
     - lerna run type-check
 
 unit tests:
   stage: prebuild
   script:
-    - yarn install --pure-lockfile --cache-folder .yarn --prefer-offline
+    - yarn install --frozen-lockfile --cache-folder .yarn --prefer-offline
     - lerna run --stream test:unit -- --passWithNoTests
 
 yaml lint:

--- a/ci/scripts/check_lockfile.sh
+++ b/ci/scripts/check_lockfile.sh
@@ -1,0 +1,16 @@
+#!/usr/bin/env bash
+
+# This file exists because as of yarn@1.12.3, --frozen-lockfile is completely
+# broken when combined with Yarn workspaces. See https://github.com/yarnpkg/yarn/issues/6291
+
+CKSUM_BEFORE=$(cksum yarn.lock)
+echo "checksum before $CKSUM_BEFORE"
+yarn install --cache-folder .yarn --prefer-offline
+CKSUM_AFTER=$(cksum yarn.lock)
+echo "checksum after $CKSUM_AFTER"
+
+
+if [[ $CKSUM_BEFORE != $CKSUM_AFTER ]]; then
+  echo "check-lockfile.sh: yarn.lock was modified unexpectedly - terminating"
+  exit 1
+fi

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     },
     "scripts": {
         "bootstrap": "lerna bootstrap",
-        "postinstall": "yarn patch-package && lerna run build:lib",
+        "postinstall": "yarn patch-package",
         "build:libs": "lerna run build:lib",
         "build:connect": "rimraf packages/suite-data/files/connect && yarn webpack --config packages/suite-data/trezor-connect.webpack.js",
         "deps": "rimraf 'node_modules' '*/**/node_modules' && yarn",


### PR DESCRIPTION
### Problem 
accidentally commiting changes to packge.json without commiting yarn.lock

### Solution 
[--frozen-lockfile flag](https://classic.yarnpkg.com/en/docs/cli/install#toc-yarn-install-frozen-lockfile), but it does not work with monorepos, so I have added a custom script for this

### Problem
calling `yarn build:libs` in every postinstall. Not only that it slows down CI quite a bit and is failing with current develop (at least on my machine) but I would also argue that it does not belong there.

### Solution
Or maybe it does but still I believe that having a post-merge git hook for this is a better way to go. It can be actually used for more things, for example if yarn.lock has changed - it may trigger `yarn`. Of course my bash kung-fu is not very strong so I will be happy for review comments.