### PR TITLE
design: unified margins in account tab layouts

### DIFF
--- a/packages/suite/src/components/wallet/CoinmarketLayout/index.tsx
+++ b/packages/suite/src/components/wallet/CoinmarketLayout/index.tsx
@@ -19,7 +19,7 @@ interface Props {
 const CoinmarketLayout = ({ children }: Props) => {
     const selectedAccount = useSelector(state => state.wallet.selectedAccount);
     return (
-        <WalletLayout title="TR_NAV_TRADE" account={selectedAccount}>
+        <WalletLayout title="TR_NAV_TRADE" account={selectedAccount} showEmptyHeaderPlaceholder>
             <Card noPadding>
                 <Navigation />
                 <Content>{children}</Content>

--- a/packages/suite/src/components/wallet/WalletLayout/index.tsx
+++ b/packages/suite/src/components/wallet/WalletLayout/index.tsx
@@ -20,21 +20,29 @@ const Wrapper = styled.div`
     height: 100%;
 `;
 
+// This placeholder makes the "Receive" and "Trade" tabs look aligned with other tabs in "Accounts" view,
+// which implement some kind of toolbar.
+// Height computation: 24px toolbarHeight + 20px marginBottom = 44px;
+const EmptyHeaderPlaceholder = styled.div`
+    width: 100%;
+    height: 44px;
+`;
+
 type Props = {
     title: ExtendedMessageDescriptor['id'];
     children?: React.ReactNode;
     account: AppState['wallet']['selectedAccount'];
+    showEmptyHeaderPlaceholder?: boolean;
 };
 
-const WalletLayout = (props: Props) => {
+const WalletLayout = ({ showEmptyHeaderPlaceholder = false, title, children, account }: Props) => {
     const { setLayout } = React.useContext(LayoutContext);
     const { translationString } = useTranslation();
-    const l10nTitle = translationString(props.title);
+    const l10nTitle = translationString(title);
 
     React.useEffect(() => {
         if (setLayout) setLayout(l10nTitle, <AccountsMenu />, <AccountTopPanel />);
     }, [l10nTitle, setLayout]);
-    const { account } = props;
 
     if (account.status === 'loading') {
         return (
@@ -63,7 +71,8 @@ const WalletLayout = (props: Props) => {
             <AccountMode mode={account.mode} />
             <AccountAnnouncement selectedAccount={account} />
             {/* <WalletNotifications /> */}
-            {props.children}
+            {showEmptyHeaderPlaceholder && <EmptyHeaderPlaceholder />}
+            {children}
         </Wrapper>
     );
 };

--- a/packages/suite/src/views/wallet/receive/index.tsx
+++ b/packages/suite/src/views/wallet/receive/index.tsx
@@ -27,7 +27,7 @@ const Receive = ({ selectedAccount, receive, device, showAddress }: Props) => {
     );
 
     return (
-        <WalletLayout title="TR_NAV_RECEIVE" account={selectedAccount}>
+        <WalletLayout title="TR_NAV_RECEIVE" account={selectedAccount} showEmptyHeaderPlaceholder>
             <FreshAddress
                 account={account}
                 addresses={receive}


### PR DESCRIPTION
fix https://github.com/trezor/trezor-suite/issues/2810

I added an empty `<div>` with calculated height to layouts which don't implement any toolbar (_Receive_ and _Trade_).  This is not a very generalized approach, but it also didn't require many changes to the existing layouts. 
If anybody thinks it would be better to do this in a more generalized way, I will do that. 

Example: _Receive_ and _Send_ tabs have the same distance from the header even though the _Receive_ layout doesn't implement any kind of toolbar.

![account-tab-layout-fix](https://user-images.githubusercontent.com/44506010/100240718-2b3a2300-2f33-11eb-8176-6f79d4da9873.png)

