### PR TITLE
fix(dark-mode): dont reset theme on db error

### DIFF
--- a/packages/suite/src/support/suite/ThemeProvider.tsx
+++ b/packages/suite/src/support/suite/ThemeProvider.tsx
@@ -29,6 +29,7 @@ const ThemeProvider: React.FC = ({ children }) => {
     const [storedTheme, setStoredTheme] = useState<
         AppState['suite']['settings']['theme'] | null | undefined
     >(); // null represents no theme is stored in db, while undefined means reading from db was not completed yet
+    const [error, setError] = useState(false);
 
     const { setTheme } = useActions({
         setTheme: suiteActions.setTheme,
@@ -44,6 +45,7 @@ const ThemeProvider: React.FC = ({ children }) => {
                 setStoredTheme(savedTheme ?? null);
             } catch {
                 setStoredTheme(null);
+                setError(true);
             }
         };
 
@@ -52,13 +54,13 @@ const ThemeProvider: React.FC = ({ children }) => {
         }
 
         // set active theme OS based theme only if there are no saved settings
-        if (storedTheme === null) {
+        if (storedTheme === null && !error) {
             const osTheme = getOSTheme();
             if (osTheme !== theme.variant) {
                 setTheme(osTheme);
             }
         }
-    }, [theme, setTheme, storedTheme, setStoredTheme]);
+    }, [theme, setTheme, storedTheme, setStoredTheme, error]);
 
     return <SCThemeProvider theme={getThemeColors(theme)}>{children}</SCThemeProvider>;
 };


### PR DESCRIPTION
close https://github.com/trezor/trezor-suite/issues/2738#issuecomment-729516722

tested by our dear QA

I think for the next release I am gonna move the logic for auto selecting the correct theme from ThemeProvider to one time action triggered on inital run or something. Should be less complex to deal with.