### PR TITLE
feat(suite-web-landing): add links to signatures

### DIFF
--- a/packages/landing-page/pages/wallet/start/index.tsx
+++ b/packages/landing-page/pages/wallet/start/index.tsx
@@ -2,7 +2,8 @@ import React, { useState } from 'react';
 import styled from 'styled-components';
 import Layout from '@landing-components/StartLayout';
 import { normalizeVersion } from '@suite-utils/build';
-import { H2, Button, P, Select, Link, variables } from '@trezor/components';
+import { SL_SIGNING_KEY } from '@suite-constants/urls';
+import { H2, Button, P, Select, Link, colors, variables } from '@trezor/components';
 
 const Wrapper = styled.div`
     display: flex;
@@ -42,6 +43,24 @@ const ButtonDownload = styled(Button)`
     }
 `;
 
+const StyledLink = styled(Link)`
+    font-weight: 400;
+    font-size: ${variables.FONT_SIZE.TINY};
+    color: ${colors.TYPE_LIGHT_GREY};
+    text-decoration: underline;
+
+    & + & {
+        margin-left: 8px;
+    }
+`;
+
+const Signatures = styled.div`
+    display: flex;
+    height: 16px;
+    color: ${colors.TYPE_LIGHT_GREY};
+    margin: 8px 4px;
+`;
+
 type Platform = 'win' | 'mac' | 'linux-x86_64' | 'linux-arm64';
 
 const getAppUrl = (platform: Platform) => {
@@ -55,6 +74,11 @@ const getAppUrl = (platform: Platform) => {
         ext = 'exe';
     }
     return encodeURI(`../web/static/desktop/Trezor-Suite-${version}-${platform}.${ext}`);
+};
+
+const getAppSignatureUrl = (platform: Platform) => {
+    const installer = getAppUrl(platform);
+    return encodeURI(`${installer}.asc`);
 };
 
 const Start = () => {
@@ -100,6 +124,14 @@ const Start = () => {
                         )}
                     </Item>
                 </Row>
+                <Signatures>
+                    {platform && (
+                        <>
+                            <StyledLink href={SL_SIGNING_KEY}>Signing key</StyledLink>
+                            <StyledLink href={getAppSignatureUrl(platform)}>Signature</StyledLink>
+                        </>
+                    )}
+                </Signatures>
                 <Item>
                     <Link href="../web" variant="nostyle" target="_self">
                         <ButtonContinue

--- a/packages/suite-web-landing/components/Download/index.tsx
+++ b/packages/suite-web-landing/components/Download/index.tsx
@@ -5,6 +5,7 @@ import { IconType } from '@trezor/components/src/support/types';
 import Translation from '../Translation';
 import { Platform, getPlatform } from '../../utils/navigator';
 import { normalizeVersion } from '@suite-utils/build';
+import { SL_SIGNING_KEY } from '@suite-constants/urls';
 
 const StyledDropdown = styled(Dropdown)`
     & ul {
@@ -53,9 +54,23 @@ const ButtonWrapper = styled.div`
 `;
 
 const VersionInfo = styled.div`
+    display: flex;
     margin-top: 12px;
     color: ${colors.TYPE_LIGHTER_GREY};
     font-size: ${variables.NEUE_FONT_SIZE.TINY};
+`;
+
+const Item = styled.div`
+    display: flex;
+    & + & {
+        margin-left: 8px;
+    }
+`;
+
+const StyledLink = styled(Link)`
+    color: ${colors.TYPE_LIGHTER_GREY};
+    text-decoration: underline;
+    font-weight: 400;
 `;
 
 type DropdownItem = {
@@ -102,6 +117,11 @@ const getInstallerURI = (platform: Platform, version: string) => {
     return encodeURI(`./web/static/desktop/Trezor-Suite-${version}-${platform}.${extension}`);
 };
 
+const getInstallerSignatureURI = (platform: Platform, version: string) => {
+    const installerURI = getInstallerURI(platform, version);
+    return encodeURI(`${installerURI}.asc`);
+};
+
 const Index = () => {
     const version: string = process.env.VERSION ? normalizeVersion(process.env.VERSION) : '';
     const [platform, setPlatform] = useState<Platform>('linux-x86_64');
@@ -142,7 +162,22 @@ const Index = () => {
                 </StyledDownloadButton>
             </ButtonWrapper>
             <VersionInfo>
-                <Translation id="TR_SUITE_WEB_LANDING_VERSION" values={{ version }} />
+                <Item>
+                    <Translation id="TR_SUITE_WEB_LANDING_VERSION" values={{ version }} />
+                </Item>
+                <Item>
+                    <StyledLink variant="nostyle" href={SL_SIGNING_KEY}>
+                        <Translation id="TR_SUITE_WEB_LANDING_SIGNING_KEY" />
+                    </StyledLink>
+                </Item>
+                <Item>
+                    <StyledLink
+                        variant="nostyle"
+                        href={getInstallerSignatureURI(platform, version)}
+                    >
+                        <Translation id="TR_SUITE_WEB_LANDING_SIGNATURE" />
+                    </StyledLink>
+                </Item>
             </VersionInfo>
         </div>
     );

--- a/packages/suite/src/constants/suite/urls.ts
+++ b/packages/suite/src/constants/suite/urls.ts
@@ -54,3 +54,5 @@ export const BCH_FORK_BLOG_POST =
 
 // Tor domain
 export const TOR_DOMAIN = 'trezoriovpjcahpzkrewelclulmszwbqpzmzgub37gbcjlvluxtruqad.onion';
+
+export const SL_SIGNING_KEY = 'https://trezor.io/security/satoshilabs-2020-signing-key.asc';

--- a/packages/suite/src/support/messages.ts
+++ b/packages/suite/src/support/messages.ts
@@ -5009,6 +5009,14 @@ const definedMessages = defineMessages({
         id: 'TR_SUITE_WEB_LANDING_MACOS_LABEL',
         defaultMessage: 'for MacOS',
     },
+    TR_SUITE_WEB_LANDING_SIGNING_KEY: {
+        id: 'TR_SUITE_WEB_LANDING_SIGNING_KEY',
+        defaultMessage: 'Signing key',
+    },
+    TR_SUITE_WEB_LANDING_SIGNATURE: {
+        id: 'TR_SUITE_WEB_LANDING_SIGNATURE',
+        defaultMessage: 'Signature',
+    },
     TR_DARK_MODE: {
         id: 'TR_DARK_MODE',
         defaultMessage: 'Dark mode',


### PR DESCRIPTION
close https://github.com/trezor/trezor-suite/issues/2699

added links to signing key and signatures for both landing pages (public beta/closed beta)

.asc files will be added manually before the release