### PR TITLE
feat: allow multiselect in account search using control key

### DIFF
--- a/packages/suite/src/actions/wallet/accountSearchActions.ts
+++ b/packages/suite/src/actions/wallet/accountSearchActions.ts
@@ -4,14 +4,14 @@ import { ACCOUNT_SEARCH } from '@wallet-actions/constants';
 export type AccountSearchAction =
     | {
           type: typeof ACCOUNT_SEARCH.SET_COIN_FILTER;
-          payload?: Account['symbol'];
+          payload: Account['symbol'][];
       }
     | {
           type: typeof ACCOUNT_SEARCH.SET_SEARCH_STRING;
           payload?: string;
       };
 
-export const setCoinFilter = (payload?: Account['symbol']): AccountSearchAction => ({
+export const setCoinFilter = (payload: Account['symbol'][]): AccountSearchAction => ({
     type: ACCOUNT_SEARCH.SET_COIN_FILTER,
     payload,
 });

--- a/packages/suite/src/components/suite/modals/AddAccount/components/AddAccountButton.tsx
+++ b/packages/suite/src/components/suite/modals/AddAccount/components/AddAccountButton.tsx
@@ -38,7 +38,7 @@ const AddAccountButton = (props: Props) => {
                 props.onEnableAccount(account);
                 // reset coin filter
                 setSearchString(undefined);
-                setCoinFilter(undefined);
+                setCoinFilter([]);
                 // just to log that account was added manually.
                 analytics.report({
                     type: 'wallet/add-account',

--- a/packages/suite/src/reducers/wallet/accountSearchReducer.ts
+++ b/packages/suite/src/reducers/wallet/accountSearchReducer.ts
@@ -6,12 +6,12 @@ import { Action } from '@suite-types';
 import { Account as AccountType } from '@wallet-types';
 
 export interface State {
-    coinFilter: AccountType['symbol'] | undefined;
+    coinFilter: AccountType['symbol'][];
     searchString: string | undefined;
 }
 
 export const initialState: State = {
-    coinFilter: undefined,
+    coinFilter: [],
     searchString: undefined,
 };
 
@@ -30,7 +30,7 @@ const accountSearchReducer = (state: State = initialState, action: Action): Stat
             // * 3) adding a new account is handled directly in add account modal, reacting on ACCOUNT.CREATE would cause resetting during initial accounts discovery
             case WALLET_SETTINGS.CHANGE_NETWORKS:
             case SUITE.SELECT_DEVICE:
-                draft.coinFilter = undefined;
+                draft.coinFilter = [];
                 draft.searchString = undefined;
                 break;
 

--- a/packages/suite/src/utils/wallet/__tests__/accountUtils.test.ts
+++ b/packages/suite/src/utils/wallet/__tests__/accountUtils.test.ts
@@ -262,15 +262,15 @@ describe('account utils', () => {
         });
 
         expect(accountUtils.accountSearchFn(btcAcc, 'btc')).toBe(true);
-        expect(accountUtils.accountSearchFn(btcAcc, '', 'btc')).toBe(true);
+        expect(accountUtils.accountSearchFn(btcAcc, '', ['btc'])).toBe(true);
         expect(
             accountUtils.accountSearchFn(
                 btcAcc,
                 'zpub6rszzdAK6RuafeRwyN8z1cgWcXCuKbLmjjfnrW4fWKtcoXQ8787214pNJjnBG5UATyghuNzjn6Lfp5k5xymrLFJnCy46bMYJPyZsbpFGagT',
-                'btc',
+                ['btc'],
             ),
         ).toBe(true);
-        expect(accountUtils.accountSearchFn(btcAcc, '', 'ltc')).toBe(false);
+        expect(accountUtils.accountSearchFn(btcAcc, '', ['ltc'])).toBe(false);
         expect(accountUtils.accountSearchFn(btcAcc, 'bitcoin')).toBe(true);
         expect(accountUtils.accountSearchFn(btcAcc, 'legacy')).toBe(true);
         expect(accountUtils.accountSearchFn(btcAcc, 'bitco')).toBe(true);

--- a/packages/suite/src/utils/wallet/accountUtils.ts
+++ b/packages/suite/src/utils/wallet/accountUtils.ts
@@ -406,10 +406,10 @@ export const getAccountIdentifier = (account: Account) => {
 export const accountSearchFn = (
     account: Account,
     rawSearchString?: string,
-    coinFilter?: Account['symbol'],
+    coinFilter?: Account['symbol'][],
 ) => {
     // if coin filter is active and account symbol doesn't match return false and don't continue the search
-    const coinFilterMatch = coinFilter ? account.symbol === coinFilter : true;
+    const coinFilterMatch = coinFilter?.length ? coinFilter.includes(account.symbol) : true;
     if (!coinFilterMatch) return false;
 
     const searchString = rawSearchString?.trim().toLowerCase();

--- a/packages/suite/src/views/dashboard/components/AssetsCard/components/Asset/index.tsx
+++ b/packages/suite/src/views/dashboard/components/AssetsCard/components/Asset/index.tsx
@@ -118,7 +118,7 @@ const Asset = React.memo(({ network, failed, cryptoValue, isLastRow }: Props) =>
                         accountType: 'normal',
                     });
                     // activate coin filter and reset account search string
-                    setCoinFilter(symbol);
+                    setCoinFilter([symbol]);
                     setSearchString(undefined);
                 }}
             >


### PR DESCRIPTION
Added possibility to select multiple coin filters by holding control key. I am not sure about Mac. Does it have control key? 
![image](https://user-images.githubusercontent.com/30367552/100541555-01d80a80-3245-11eb-8ad8-05ba7ce9b132.png)
