### PR TITLE
ci: manual desktop builds on feature branches

### DIFF
--- a/ci/packages/suite-desktop.yml
+++ b/ci/packages/suite-desktop.yml
@@ -43,6 +43,18 @@ suite-desktop build mac:
   <<: *build
   <<: *build_nix
 
+suite-desktop build mac manual:
+  when: manual
+  except:
+    <<: *run_everything_rules
+  tags:
+    - darwin
+  variables:
+    artifact: ${DESKTOP_APP_NAME}*
+    platform: mac
+  <<: *build
+  <<: *build_nix
+
 suite-desktop build mac codesign:
   only:
     refs:
@@ -64,6 +76,15 @@ suite-desktop build linux:
     platform: linux
   <<: *build
 
+suite-desktop build linux manual:
+  when: manual
+  except:
+    <<: *run_everything_rules
+  variables:
+    artifact: ${DESKTOP_APP_NAME}*
+    platform: linux
+  <<: *build
+
 suite-desktop build linux codesign:
   only:
     refs:
@@ -79,6 +100,16 @@ suite-desktop build linux codesign:
 
 suite-desktop build windows:
   only:
+    <<: *run_everything_rules
+  image: electronuserland/builder:wine
+  variables:
+    artifact: ${DESKTOP_APP_NAME}*
+    platform: win
+  <<: *build
+
+suite-desktop build windows manual:
+  when: manual
+  except:
     <<: *run_everything_rules
   image: electronuserland/builder:wine
   variables:


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/30367552/100996964-0446a700-355a-11eb-89a6-a62b593f2488.png)

It does not cost much (few lines in yml) and helps when:
- I want to test a feature branch
- I want to test something on another computer (possibly windows) and don't want to setup entire environment there

@prusnak removed these in one of the commits regarding codesing builds so I am wondering if there was any case against this or it was just an unintended side effect