### PR TITLE
fix(landing): use absolute URLs for og:image and twitter:image meta tags

### DIFF
--- a/packages/suite-web-landing/pages/_document.tsx
+++ b/packages/suite-web-landing/pages/_document.tsx
@@ -4,6 +4,7 @@ import { resolveStaticPath } from '@suite-utils/nextjs';
 import { ServerStyleSheet } from 'styled-components';
 import globalStyles from '../support/styles';
 import { isEnabled } from '@suite-utils/features';
+import { URLS } from '@suite-constants';
 
 const isOnionLocation = isEnabled('ONION_LOCATION_META');
 
@@ -50,7 +51,7 @@ export default class MyDocument extends Document {
 
                     {/* Open Graph / Facebook */}
                     <meta property="og:type" content="website" />
-                    <meta property="og:url" content="https://suite.trezor.io/" />
+                    <meta property="og:url" content={URLS.SUITE_URL} />
                     <meta property="og:title" content="Trezor Suite" />
                     <meta
                         property="og:description"
@@ -58,12 +59,14 @@ export default class MyDocument extends Document {
                     />
                     <meta
                         property="og:image"
-                        content={resolveStaticPath('images/suite-web-landing/meta.png')}
+                        content={`${URLS.SUITE_URL}${resolveStaticPath(
+                            'images/suite-web-landing/meta.png',
+                        )}`}
                     />
 
                     {/* Twitter */}
                     <meta property="twitter:card" content="summary_large_image" />
-                    <meta property="twitter:url" content="https://suite.trezor.io/" />
+                    <meta property="twitter:url" content={URLS.SUITE_URL} />
                     <meta property="twitter:title" content="Trezor Suite" />
                     <meta
                         property="twitter:description"
@@ -71,7 +74,9 @@ export default class MyDocument extends Document {
                     />
                     <meta
                         property="twitter:image"
-                        content={resolveStaticPath('images/suite-web-landing/meta.png')}
+                        content={`${URLS.SUITE_URL}${resolveStaticPath(
+                            'images/suite-web-landing/meta.png',
+                        )}`}
                     />
 
                     <meta charSet="utf-8" />

--- a/packages/suite/src/constants/suite/urls.ts
+++ b/packages/suite/src/constants/suite/urls.ts
@@ -7,6 +7,7 @@ export const SUPPORT_URL = 'https://trezor.io/support/';
 export const WIKI_URL = 'https://wiki.trezor.io/';
 export const BLOG_URL = 'https://blog.trezor.io/';
 export const SHOP_URL = 'https://shop.trezor.io/';
+export const SUITE_URL = 'https://suite.trezor.io/';
 export const TREZOR_DATA_URL = 'https://wallet.trezor.io/data/';
 export const PIN_MANUAL_URL = 'https://wiki.trezor.io/User_manual:Entering_PIN';
 export const DRY_RUN_URL = 'https://wiki.trezor.io/User_manual:Dry-run_recovery';


### PR DESCRIPTION
We need to use absolute URLs for `og:image` and `twitter:image` meta tags. This PR hopefully fixes this.