### PR TITLE
fw update improvements

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -21,7 +21,7 @@ stages:
 
 include:
   - ci/environment.yml
-  - ci/prebuild.yml
+  # - ci/prebuild.yml
   - ci/packages/components.yml
   - ci/packages/suite.yml
   - ci/packages/suite-web.yml

--- a/packages/suite/src/components/firmware/CheckSeed.tsx
+++ b/packages/suite/src/components/firmware/CheckSeed.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 import styled from 'styled-components';
 
 import { Button, Checkbox } from '@trezor/components';
-import { useDevice, useFirmware } from '@suite-hooks';
+import { useFirmware } from '@suite-hooks';
 import { Translation } from '@suite-components';
 import { P, H2, WarningImg, SeedImg, ReconnectInNormalStep } from '@firmware-components';
 
@@ -17,8 +17,7 @@ const CheckboxRow = styled.div`
 `;
 
 const Body = () => {
-    const { device } = useDevice();
-    const { toggleHasSeed, hasSeed } = useFirmware();
+    const { toggleHasSeed, hasSeed, device } = useFirmware();
 
     // unacquired device handled on higher level
     if (!device?.features) return null;
@@ -81,14 +80,14 @@ const Body = () => {
 };
 
 const BottomBar = () => {
-    const { device } = useDevice();
-    const { hasSeed, setStatus } = useFirmware();
+    // const { device } = useDevice();
+    const { hasSeed, setStatus, device } = useFirmware();
 
     return (
         <Button
             onClick={() => setStatus('waiting-for-bootloader')}
             data-test="@firmware/confirm-seed-button"
-            isDisabled={!device?.connected || device.mode === 'bootloader' || !hasSeed}
+            isDisabled={!device || device.mode === 'bootloader' || !hasSeed}
         >
             <Translation id="TR_CONTINUE" />
         </Button>

--- a/packages/suite/src/components/firmware/FirmwareProgress.tsx
+++ b/packages/suite/src/components/firmware/FirmwareProgress.tsx
@@ -2,12 +2,11 @@ import React from 'react';
 import { getTextForStatus, getDescriptionForStatus } from '@firmware-utils';
 import { Translation } from '@suite-components';
 import { Loaders } from '@onboarding-components';
-import { useDevice, useFirmware } from '@suite-hooks';
+import { useFirmware } from '@suite-hooks';
 import { InitImg, P, H2 } from '@firmware-components';
 
 const Body = () => {
-    const { device } = useDevice();
-    const { status, prevDevice } = useFirmware();
+    const { status, prevDevice, device } = useFirmware();
 
     const statusText = getTextForStatus(status);
     const statusDescription = getDescriptionForStatus(status);

--- a/packages/suite/src/components/firmware/Initial.tsx
+++ b/packages/suite/src/components/firmware/Initial.tsx
@@ -5,7 +5,7 @@ import { Icon, Button, variables } from '@trezor/components';
 import { CHANGELOG_URL } from '@suite-constants/urls';
 import { Translation, ExternalLink, TrezorLink } from '@suite-components';
 import { getFwVersion } from '@suite-utils/device';
-import { useDevice, useFirmware } from '@suite-hooks';
+import { useFirmware } from '@suite-hooks';
 import { ReconnectInNormalStep, NoNewFirmware, ContinueButton, P, H2 } from '@firmware-components';
 
 const { FONT_SIZE, FONT_WEIGHT } = variables;
@@ -58,7 +58,7 @@ const BottomRow = styled.div`
 `;
 
 const Heading = () => {
-    const { device } = useDevice();
+    const { device } = useFirmware();
     if (device?.mode === 'normal') {
         return (
             <HeadingWrapper>
@@ -76,7 +76,7 @@ const Heading = () => {
 };
 
 const Body = () => {
-    const { device } = useDevice();
+    const { device } = useFirmware();
 
     // ensure that device is connected in requested mode
     if (device?.mode !== 'normal') return <ReconnectInNormalStep.Body />;
@@ -163,9 +163,9 @@ const HowLong = styled.div`
 
 const BottomBar = () => {
     const { setStatus } = useFirmware();
-    const { device } = useDevice();
+    const { device } = useFirmware();
 
-    if (!device?.connected || !device?.features || device.mode !== 'normal') {
+    if (!device || !device?.features || device.mode !== 'normal') {
         return null;
     }
 

--- a/packages/suite/src/components/firmware/NoNewFirmware.tsx
+++ b/packages/suite/src/components/firmware/NoNewFirmware.tsx
@@ -2,14 +2,14 @@ import React from 'react';
 
 import { CHANGELOG_URL } from '@suite-constants/urls';
 import { getFwVersion } from '@suite-utils/device';
-import { useDevice } from '@suite-hooks';
+import { useFirmware } from '@suite-hooks';
 import { P, H2, SuccessImg } from '@firmware-components';
 import { Translation, ExternalLink } from '@suite-components';
 
 const Heading = () => <Translation id="TR_FIRMWARE_UPDATE" />;
 
 const Body = () => {
-    const { device } = useDevice();
+    const { device } = useFirmware();
 
     if (!device?.features) return null;
 

--- a/packages/suite/src/components/firmware/OnboardingInitial.tsx
+++ b/packages/suite/src/components/firmware/OnboardingInitial.tsx
@@ -3,7 +3,7 @@ import { Button } from '@trezor/components';
 
 import { Translation } from '@suite-components';
 import { getFwVersion } from '@suite-utils/device';
-import { useDevice, useFirmware, useActions } from '@suite-hooks';
+import { useFirmware, useActions } from '@suite-hooks';
 import {
     P,
     H2,
@@ -15,9 +15,9 @@ import {
 import * as onboardingActions from '@onboarding-actions/onboardingActions';
 
 const Body = () => {
-    const { device } = useDevice();
+    const { device } = useFirmware();
 
-    if (!device?.connected || !device?.features)
+    if (!device || !device?.features)
         return (
             <>
                 <ConnectInNormalImg />
@@ -92,13 +92,13 @@ const Body = () => {
 };
 
 const BottomBar = () => {
-    const { setStatus, firmwareUpdate } = useFirmware();
-    const { device } = useDevice();
+    const { setStatus, firmwareUpdate, device } = useFirmware();
+    // const { device } = useDevice();
     const { goToNextStep } = useActions({
         goToNextStep: onboardingActions.goToNextStep,
     });
 
-    if (!device?.connected || !device.features) return null;
+    if (!device || !device.features) return null;
 
     if (device.firmware === 'none') {
         return <InstallButton onClick={firmwareUpdate} />;

--- a/packages/suite/src/components/firmware/PartiallyDone.tsx
+++ b/packages/suite/src/components/firmware/PartiallyDone.tsx
@@ -2,10 +2,11 @@ import React from 'react';
 
 import { SuccessImg, P, H2 } from '@firmware-components';
 import { Translation } from '@suite-components';
-import { useDevice } from '@suite-hooks/useDevice';
+import { useFirmware } from '@suite-hooks';
 
 const Body = () => {
-    const { device } = useDevice();
+    const { device } = useFirmware();
+
     return (
         <>
             <H2>

--- a/packages/suite/src/components/firmware/ReconnectInBootloader.tsx
+++ b/packages/suite/src/components/firmware/ReconnectInBootloader.tsx
@@ -11,14 +11,13 @@ import {
     InstallButton,
 } from '@firmware-components';
 import { Translation, WebusbButton } from '@suite-components';
-import { useDevice, useFirmware, useSelector } from '@suite-hooks';
+import { useFirmware, useSelector } from '@suite-hooks';
 
 const Body = () => {
-    const { device } = useDevice();
-    const { prevDevice } = useFirmware();
+    const { prevDevice, device } = useFirmware();
     const expectedModel = prevDevice?.features?.major_version || 2;
 
-    if (!device?.connected) {
+    if (!device) {
         return (
             <>
                 <ConnectInBootloaderImg model={expectedModel} />
@@ -60,15 +59,15 @@ const Body = () => {
 };
 
 const BottomBar = () => {
-    const { device } = useDevice();
-    const { firmwareUpdate } = useFirmware();
+    // const { device } = useDevice();
+    const { firmwareUpdate, device } = useFirmware();
     const transport = useSelector(state => state.suite.transport);
 
     if (device?.mode === 'bootloader') {
         return <InstallButton onClick={firmwareUpdate} />;
     }
 
-    if (!device?.connected && isWebUSB(transport)) {
+    if (!device && isWebUSB(transport)) {
         return (
             <WebusbButton ready>
                 <Button icon="PLUS" variant="tertiary">

--- a/packages/suite/src/components/firmware/ReconnectInNormal.tsx
+++ b/packages/suite/src/components/firmware/ReconnectInNormal.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 import { DisconnectImg, ConnectInNormalImg, P, H2 } from '@firmware-components';
 
 import { Button } from '@trezor/components';
-import { useDevice, useFirmware, useSelector } from '@suite-hooks';
+import { useFirmware, useSelector } from '@suite-hooks';
 import { Translation, WebusbButton } from '@suite-components';
 import { isWebUSB } from '@suite-utils/transport';
 
@@ -11,11 +11,11 @@ const Heading = () => {
 };
 
 const Body = () => {
-    const { device } = useDevice();
-    const { prevDevice } = useFirmware();
+    // const { device } = useDevice();
+    const { prevDevice, device } = useFirmware();
     const expectedModel = prevDevice?.features?.major_version;
 
-    if (!device?.connected) {
+    if (!device) {
         return (
             <>
                 <ConnectInNormalImg />

--- a/packages/suite/src/middlewares/firmware/firmwareMiddleware.ts
+++ b/packages/suite/src/middlewares/firmware/firmwareMiddleware.ts
@@ -29,14 +29,16 @@ const firmware = (api: MiddlewareAPI<Dispatch, AppState>) => (next: Dispatch) =>
 
         case DEVICE.DISCONNECT:
             console.log(action.payload);
-            if (status === 'unplug' && (!action.payload || !action.payload?.connected)) {
+            // todo: hmm ?
+            if (status === 'unplug') {
                 api.dispatch(firmwareActions.setStatus('reconnect-in-normal'));
             }
             break;
         case DEVICE.CONNECT:
-        // case SUITE.UPDATE_SELECTED_DEVICE: // UPDATE_SELECTED_DEVICE is needed to handle if device is unacquired in SELECT_DEVICE
+        case DEVICE.CONNECT_UNACQUIRED:
+            // case SUITE.UPDATE_SELECTED_DEVICE: // UPDATE_SELECTED_DEVICE is needed to handle if device is unacquired in SELECT_DEVICE
             // both saved and unsaved device
-            
+
             console.log(action.payload);
 
             if (

--- a/packages/suite/src/middlewares/firmware/firmwareMiddleware.ts
+++ b/packages/suite/src/middlewares/firmware/firmwareMiddleware.ts
@@ -1,4 +1,4 @@
-import TrezorConnect from 'trezor-connect';
+import TrezorConnect, { DEVICE } from 'trezor-connect';
 import { MiddlewareAPI } from 'redux';
 
 import { SUITE } from '@suite-actions/constants';
@@ -26,12 +26,18 @@ const firmware = (api: MiddlewareAPI<Dispatch, AppState>) => (next: Dispatch) =>
             }
             break;
         }
-        case SUITE.SELECT_DEVICE:
-        case SUITE.UPDATE_SELECTED_DEVICE: // UPDATE_SELECTED_DEVICE is needed to handle if device is unacquired in SELECT_DEVICE
-            // both saved and unsaved device
+
+        case DEVICE.DISCONNECT:
+            console.log(action.payload);
             if (status === 'unplug' && (!action.payload || !action.payload?.connected)) {
                 api.dispatch(firmwareActions.setStatus('reconnect-in-normal'));
             }
+            break;
+        case DEVICE.CONNECT:
+        // case SUITE.UPDATE_SELECTED_DEVICE: // UPDATE_SELECTED_DEVICE is needed to handle if device is unacquired in SELECT_DEVICE
+            // both saved and unsaved device
+            
+            console.log(action.payload);
 
             if (
                 action.payload &&

--- a/packages/suite/src/reducers/firmware/firmwareReducer.ts
+++ b/packages/suite/src/reducers/firmware/firmwareReducer.ts
@@ -10,6 +10,7 @@ type FirmwareUpdateCommon = {
     hasSeed: boolean;
     targetRelease: AcquiredDevice['firmwareRelease'];
     prevDevice?: Device;
+    device?: Device;
 };
 
 export type FirmwareUpdateState =
@@ -43,6 +44,7 @@ const initialState: FirmwareUpdateState = {
     targetRelease: undefined,
     hasSeed: false,
     prevDevice: undefined,
+    device: undefined,
 };
 
 const firmwareUpdate = (state: FirmwareUpdateState = initialState, action: Action) => {
@@ -80,6 +82,12 @@ const firmwareUpdate = (state: FirmwareUpdateState = initialState, action: Actio
                 return initialState;
             case DEVICE.DISCONNECT:
                 draft.prevDevice = action.payload;
+                draft.device = undefined;
+                break;
+            case DEVICE.CONNECT:
+            case DEVICE.CONNECT_UNACQUIRED:
+            case DEVICE.CHANGED:
+                draft.device = action.payload;
                 break;
             default:
 

--- a/packages/suite/src/utils/suite/device.ts
+++ b/packages/suite/src/utils/suite/device.ts
@@ -1,4 +1,4 @@
-import { Device } from 'trezor-connect';
+import { Device, KnownDevice, UnknownDevice } from 'trezor-connect';
 import { TrezorDevice, AcquiredDevice } from '@suite-types';
 
 export const getStatus = (device: TrezorDevice): string => {
@@ -116,7 +116,8 @@ export const getVersion = (device: TrezorDevice) => {
     return features && features.major_version > 1 ? 'T' : 'One';
 };
 
-export const getFwVersion = (device: AcquiredDevice) => {
+export const getFwVersion = (device: KnownDevice | UnknownDevice) => {
+    if (!device.features) return;
     const { features } = device;
     return `${features.major_version}.${features.minor_version}.${features.patch_version}`;
 };


### PR DESCRIPTION
Heavy wip. This  is going to be controversial.

### Multiple devices (#2813)
Problem:
1. Connect device A
1. Connect device B
1. Start firwmare update for device B, in the course of the process, user is prompted to disconnect device
1. Device A gets selected automatically 

**Solution A**
Handle device events from connect in different way than they are handled using deviceReducer and suiteReducer. Create a device field in firmwareReducer that gets populated on every DEVICE.CONNECT and erased on DEVICE.DISCONECT. This way I can ensure that UI always represents corect values for the device that user actively works with and not another device that got accidentaly selected.

**Solution B**
Do not allow to proceed with firmware update if there is more then one device conected. This does not cover cases when user connects another unrelated device anytime later during the progress.

**Solution C** 
Somehow hook into general deviceReducer suiteReducer logic by adding something like if app === firmware && device.disconnect => do not select another already connected device.

**Solution D**
force remember device https://github.com/trezor/trezor-suite/pull/2791/files

### TODO: Consider
- maybe implement (#2338), I am starting to think that client-side implementation won't be that bad maybe
- consider #2814 
