### PR TITLE
wip tests mac gui

### DIFF
--- a/docker/docker-suite-test-mac.sh
+++ b/docker/docker-suite-test-mac.sh
@@ -1,0 +1,5 @@
+#!/bin/sh
+
+export LOCAL_USER_ID=`id -u $USER`
+
+docker-compose -f ./docker/docker-compose.suite-test.yml up --build --abort-on-container-exit trezor-user-env-mac suite-dev test-open

--- a/docker/docker-suite-test.sh
+++ b/docker/docker-suite-test.sh
@@ -6,4 +6,4 @@
 xhost +
 export LOCAL_USER_ID=`id -u $USER`
 
-docker-compose -f ./docker/docker-compose.suite-test.yml up --build --abort-on-container-exit
+docker-compose -f ./docker/docker-compose.suite-test.yml up --build --abort-on-container-exit trezor-user-env-unix suite-dev test-open


### PR DESCRIPTION
running (debugging) tests locally in docker with GUI on mac should be simple now. We just need to use proper service from trezor-user-env and probably adjust some env vars on cypress service. 