### PR TITLE
fix: display appropriate value when tx sent to self

### DIFF
--- a/packages/suite/src/components/suite/modals/TransactionDetail/components/AmountDetails/index.tsx
+++ b/packages/suite/src/components/suite/modals/TransactionDetail/components/AmountDetails/index.tsx
@@ -102,13 +102,18 @@ const AmountDetails = ({ tx, txDetails, isTestnet }: Props) => {
     let amountSentToSelf = '';
 
     if (txSentToSelf && network && totalOutput && !totalOutput.isNaN()) {
-        // convert float value of fees back to the absolute value in basic network units in order to prevent possible errors coming from summing up float numbers
-        const feesAbsolute = Number(tx.fee) * 10 ** network.decimals;
-        if (feesAbsolute) {
-            amountSentToSelf = formatNetworkAmount(
-                (Number(totalOutput) + feesAbsolute).toFixed(),
-                tx.symbol,
-            );
+        if (tokenTransfer) {
+            // in case of token transfer, the displayed amount will be just the token amount, not token + fee (in ETH for example)
+            amountSentToSelf = tokenTransfer.amount;
+        } else {
+            // convert float value of fees back to the absolute value in basic network units in order to prevent possible errors coming from summing up float numbers
+            const feesAbsolute = Number(tx.fee) * 10 ** network.decimals;
+            if (feesAbsolute) {
+                amountSentToSelf = formatNetworkAmount(
+                    (Number(totalOutput) + feesAbsolute).toFixed(),
+                    tx.symbol,
+                );
+            }
         }
     }
 


### PR DESCRIPTION
fix: https://github.com/trezor/trezor-suite/issues/1856

I changed the **Amount** value we show to the user when he sends a transaction to himself. In this PR we show _"the actual value user sent + fee"_, not just the fee (even though the user lost from his wallet portfolio just the fee). 

This value could be equal to the `totalInput` value (right?), but I encountered a problem that `totalInput` is not defined for _Ethereum_ network. Is that a bug or a valid behavior? If it's a bug, it should be fixed and this issue could be solved in a cleaner way as well. 

For the above-mentioned reasons, I solved this from the other side: `amountSentToSelf = totalOutput + tx.fee`. 
You can see the numbers I computed on the provided screenshots, which capture "**Send ETH to myself**" transaction.


![image](https://user-images.githubusercontent.com/44506010/101629123-24c2a580-3a21-11eb-912e-5e1eb9e4e960.png)

![image](https://user-images.githubusercontent.com/44506010/101629164-34da8500-3a21-11eb-91f4-b75e0266e774.png)

However, because `tx.fee` is a string, I had to convert it to a float and then to an integer first, in order to prevent issues with summing up float number (is this an ok approach?).

_Note:_
I didn't try to solve the situation when the user sends some funds to himself and some funds to somebody else. If somebody thinks that the way how we show this information should be changed, let me know.

