### PR TITLE
Desktop: Auto Updater fixes

### DIFF
--- a/packages/suite-desktop/src-electron/modules/auto-updater.ts
+++ b/packages/suite-desktop/src-electron/modules/auto-updater.ts
@@ -8,11 +8,10 @@ import { autoUpdater, CancellationToken } from 'electron-updater';
 // Runtime flags
 const preReleaseFlag = app.commandLine.hasSwitch('pre-release');
 
-const updateCancellationToken = new CancellationToken();
-
 const init = (window: BrowserWindow, store: LocalStore) => {
     let isManualCheck = false;
     let latestVersion = {};
+    let updateCancellationToken: CancellationToken;
     const updateSettings = store.getUpdateSettings();
 
     autoUpdater.autoDownload = false;
@@ -73,7 +72,8 @@ const init = (window: BrowserWindow, store: LocalStore) => {
             total: 0,
             transferred: 0,
         });
-        autoUpdater.downloadUpdate(updateCancellationToken);
+        updateCancellationToken = new CancellationToken();
+        autoUpdater.downloadUpdate(updateCancellationToken).catch(() => null); // Suppress error in console
     });
     ipcMain.on('update/install', () => {
         // This will force the closing of the window to quit the app on Mac

--- a/packages/suite-desktop/src-electron/preload.ts
+++ b/packages/suite-desktop/src-electron/preload.ts
@@ -58,7 +58,7 @@ contextBridge.exposeInMainWorld('desktopApi', {
     },
 
     // Updater
-    checkForUpdates: () => ipcRenderer.send('update/check'),
+    checkForUpdates: (isManual?: boolean) => ipcRenderer.send('update/check', isManual),
     downloadUpdate: () => ipcRenderer.send('update/download'),
     installUpdate: () => ipcRenderer.send('update/install'),
     cancelUpdate: () => ipcRenderer.send('update/cancel'),

--- a/packages/suite/global.d.ts
+++ b/packages/suite/global.d.ts
@@ -7,7 +7,7 @@ export interface DesktopApi {
     // App Ready
     ready: () => void;
     // Auto Updater
-    checkForUpdates: () => void;
+    checkForUpdates: (isManual?: boolean) => void;
     downloadUpdate: () => void;
     installUpdate: () => void;
     cancelUpdate: () => void;

--- a/packages/suite/src/actions/suite/desktopUpdateActions.ts
+++ b/packages/suite/src/actions/suite/desktopUpdateActions.ts
@@ -19,10 +19,16 @@ export const available = (info: UpdateInfo): DesktopUpdateAction => ({
     payload: info,
 });
 
-export const notAvailable = (info: UpdateInfo): DesktopUpdateAction => ({
-    type: DESKTOP_UPDATE.NOT_AVAILABLE,
-    payload: info,
-});
+export const notAvailable = (info: UpdateInfo) => (dispatch: Dispatch) => {
+    if (info.isManualCheck) {
+        dispatch(addToast({ type: 'auto-updater-no-new' }));
+    }
+
+    dispatch({
+        type: DESKTOP_UPDATE.NOT_AVAILABLE,
+        payload: info,
+    });
+};
 
 export const downloading = (progress: UpdateProgress): DesktopUpdateAction => ({
     type: DESKTOP_UPDATE.DOWNLOADING,

--- a/packages/suite/src/components/suite/hocNotification/index.tsx
+++ b/packages/suite/src/components/suite/hocNotification/index.tsx
@@ -294,6 +294,13 @@ const hocNotification = (notification: NotificationEntry, View: React.ComponentT
                 },
             });
 
+        case 'auto-updater-no-new':
+            return simple(View, {
+                notification,
+                variant: 'info',
+                message: 'TOAST_AUTO_UPDATER_NO_NEW',
+            });
+
         // Events:
         case DEVICE.CONNECT:
             return withAction(View, {

--- a/packages/suite/src/reducers/suite/notificationReducer.ts
+++ b/packages/suite/src/reducers/suite/notificationReducer.ts
@@ -68,6 +68,9 @@ export type ToastPayload = (
           type: 'auto-updater-error';
           state: string;
       }
+    | {
+          type: 'auto-updater-no-new';
+      }
 ) &
     Options;
 

--- a/packages/suite/src/support/messages.ts
+++ b/packages/suite/src/support/messages.ts
@@ -2856,6 +2856,10 @@ const definedMessages = defineMessages({
         id: 'TOAST_AUTO_UPDATER_ERROR',
         defaultMessage: 'Auto updater error ({state})',
     },
+    TOAST_AUTO_UPDATER_NO_NEW: {
+        id: 'TOAST_AUTO_UPDATER_NO_NEW',
+        defaultMessage: 'No new updates available.',
+    },
     TOAST_GENERIC_ERROR: {
         id: 'TOAST_GENERIC_ERROR',
         defaultMessage: 'Error: {error}',

--- a/packages/suite/src/types/suite/desktop.ts
+++ b/packages/suite/src/types/suite/desktop.ts
@@ -1,6 +1,7 @@
 export type UpdateInfo = {
     version: string;
     releaseDate: string;
+    isManualCheck?: boolean;
     downloadedFile?: string;
 };
 

--- a/packages/suite/src/views/settings/index.tsx
+++ b/packages/suite/src/views/settings/index.tsx
@@ -82,7 +82,7 @@ const Settings = ({
     }, [torAddress]);
 
     // Auto Updater
-    const checkForUpdates = useCallback(() => window.desktopApi?.checkForUpdates(), []);
+    const checkForUpdates = useCallback(() => window.desktopApi?.checkForUpdates(true), []);
     const downloadUpdate = useCallback(() => window.desktopApi?.downloadUpdate(), []);
     const installRestart = useCallback(() => window.desktopApi?.installUpdate(), []);
 

--- a/packages/suite/src/views/settings/index.tsx
+++ b/packages/suite/src/views/settings/index.tsx
@@ -18,6 +18,7 @@ import { useAnalytics, useDevice, useSelector, useActions } from '@suite-hooks';
 import { Button, Tooltip, Switch } from '@trezor/components';
 import { capitalizeFirstLetter } from '@suite-utils/string';
 import * as suiteActions from '@suite-actions/suiteActions';
+import * as desktopUpdateActions from '@suite-actions/desktopUpdateActions';
 
 import { Props } from './Container';
 import { getReleaseUrl } from '@suite/services/github';
@@ -82,9 +83,12 @@ const Settings = ({
     }, [torAddress]);
 
     // Auto Updater
+    const { setUpdateWindow } = useActions({
+        setUpdateWindow: desktopUpdateActions.setUpdateWindow,
+    });
     const checkForUpdates = useCallback(() => window.desktopApi?.checkForUpdates(true), []);
-    const downloadUpdate = useCallback(() => window.desktopApi?.downloadUpdate(), []);
     const installRestart = useCallback(() => window.desktopApi?.installUpdate(), []);
+    const maximizeUpdater = useCallback(() => setUpdateWindow('maximized'), [setUpdateWindow]);
 
     return (
         <SettingsLayout data-test="@settings/index">
@@ -397,12 +401,12 @@ const Settings = ({
                                 </ActionButton>
                             )}
                             {desktopUpdate.state === 'available' && (
-                                <ActionButton onClick={downloadUpdate} variant="secondary">
+                                <ActionButton onClick={maximizeUpdater} variant="secondary">
                                     <Translation id="SETTINGS_UPDATE_AVAILABLE" />
                                 </ActionButton>
                             )}
                             {desktopUpdate.state === 'downloading' && (
-                                <ActionButton isDisabled variant="secondary">
+                                <ActionButton onClick={maximizeUpdater} variant="secondary">
                                     <Translation id="SETTINGS_UPDATE_DOWNLOADING" />
                                 </ActionButton>
                             )}


### PR DESCRIPTION
- [x] Add 'no new version available' toast when manually checking for updates when no newer version is available.
- [x] Display modal when clicking the update button on an available update on the settings page.
- [x] Fix cancellation of updates.