### PR TITLE
style: txs search box design

### DIFF
--- a/packages/components/src/components/form/Input/index.tsx
+++ b/packages/components/src/components/form/Input/index.tsx
@@ -57,6 +57,7 @@ const StyledInput = styled.input<InputProps>`
     /* TODO: padding for left input addon */
     ${props =>
         props.inputAddonWidth &&
+        !props.textIndent &&
         css`
             padding-right: ${props.inputAddonWidth}px;
         `};
@@ -177,7 +178,6 @@ interface Props extends React.InputHTMLAttributes<HTMLInputElement> {
     autoCorrect?: string;
     autoCapitalize?: string;
     spellCheck?: boolean;
-    isLoading?: boolean;
     dataTest?: string;
     isPartiallyHidden?: boolean;
     wrapperProps?: Record<string, any>;
@@ -214,7 +214,6 @@ const Input = ({
     monospace,
     wrapperProps,
     labelAddonIsVisible,
-    isLoading,
     dataTest,
     isPartiallyHidden,
     clearButton,

--- a/packages/suite/src/support/messages.ts
+++ b/packages/suite/src/support/messages.ts
@@ -5102,6 +5102,10 @@ const definedMessages = defineMessages({
         id: 'TR_NEW_FEE',
         defaultMessage: 'New',
     },
+    TR_SEARCH_TRANSACTIONS: {
+        id: 'TR_SEARCH_TRANSACTIONS',
+        defaultMessage: 'Seach transactions',
+    },
 } as const);
 
 export default definedMessages;

--- a/packages/suite/src/views/wallet/transactions/components/TransactionList/components/Actions/index.tsx
+++ b/packages/suite/src/views/wallet/transactions/components/TransactionList/components/Actions/index.tsx
@@ -1,13 +1,18 @@
 import React from 'react';
-
+import styled from 'styled-components';
 import SearchAction, { Props as SearchProps } from './components/SearchAction';
 import ExportAction, { Props as ExportProps } from './components/ExportAction';
+
+const Wrapper = styled.div`
+    display: flex;
+    align-items: center;
+`;
 
 interface Props extends SearchProps, ExportProps {}
 
 const Actions = ({ account, search, setSearch, setSelectedPage }: Props) => {
     return (
-        <>
+        <Wrapper>
             <SearchAction
                 account={account}
                 search={search}
@@ -15,7 +20,7 @@ const Actions = ({ account, search, setSearch, setSelectedPage }: Props) => {
                 setSelectedPage={setSelectedPage}
             />
             <ExportAction account={account} />
-        </>
+        </Wrapper>
     );
 };
 

--- a/packages/suite/src/views/wallet/transactions/components/TransactionList/index.tsx
+++ b/packages/suite/src/views/wallet/transactions/components/TransactionList/index.tsx
@@ -117,6 +117,7 @@ const TransactionList = ({ transactions, isLoading, account, ...props }: Props) 
                 />
             }
         >
+            {/* TODO: show this skeleton also while searching in txs */}
             {isLoading ? (
                 <Stack col childMargin="0px 0px 16px 0px">
                     <SkeletonTransactionItem />


### PR DESCRIPTION
to be merged into https://github.com/trezor/trezor-suite/pull/3145
https://app.zeplin.io/project/5ee87c00f6af719a645d14c3/screen/5f5208531549bf4b24ebdb88

@keraf I mostly styled only search input (with its super hacky animation) as I don't think it is worth to implement everything from the design. For example I don't see a good reason to implement a loading state into the input when there is already another one in transaction list. I used that space for clear button which I find more handy (basically it's the same as in account search box)

Oh, regarding the loading states ("loading transactions" spinner/checkmark with "all transactions loaded"). Let's just put there the same skeleton that we already use for ehm, loading purposes (left a todo there as I didn't want to mess with the logic too much). I think these design were created long before we came up with loading skeletons so they are a bit obsolete in this regard 😁 