### PR TITLE
fix(suite): hide empty account group in accounts menu

### DIFF
--- a/packages/suite/src/components/wallet/AccountsMenu/components/AccountGroup/index.tsx
+++ b/packages/suite/src/components/wallet/AccountsMenu/components/AccountGroup/index.tsx
@@ -60,8 +60,6 @@ export default forwardRef((props: Props, _ref: React.Ref<HTMLDivElement>) => {
         }
     }, [props.keepOpened, props.hasBalance]);
 
-    if (!props.children || React.Children.count(props.children) === 0) return null;
-
     const onClick = () => {
         setExpanded(!expanded);
         setAnimatedIcon(true);

--- a/packages/suite/src/components/wallet/AccountsMenu/index.tsx
+++ b/packages/suite/src/components/wallet/AccountsMenu/index.tsx
@@ -193,6 +193,12 @@ const AccountsMenu = ({ device, accounts, selectedAccount }: Props) => {
 
     const buildGroup = (type: Account['accountType'], accounts: Account[]) => {
         const groupHasBalance = accounts.find(a => a.availableBalance !== '0');
+
+        if (!accounts.length) {
+            // show skeleton in 'normal' group while we wait for a discovery of first account
+            return <>{discoveryInProgress && type === 'normal' && <SkeletonAccountItem />}</>;
+        }
+
         return (
             <AccountGroup
                 key={type}


### PR DESCRIPTION
fix https://github.com/trezor/trezor-suite/issues/3173

account groups like segwit and legacy were shown even if only non bitcoin like coins (eg. eth) were enabled because of added rendering of loading skeleton 