### PR TITLE
fix(suite): make scrollbar visible on every page under SuiteLayout

### DIFF
--- a/packages/suite/src/components/suite/SuiteLayout/index.tsx
+++ b/packages/suite/src/components/suite/SuiteLayout/index.tsx
@@ -42,7 +42,8 @@ const AppWrapper = styled.div`
     color: ${props => props.theme.TYPE_DARK_GREY};
     background: ${props => props.theme.BG_GREY};
     flex-direction: column;
-    overflow: auto;
+    overflow-x: auto;
+    overflow-y: scroll;
     width: 100%;
     align-items: center;
 


### PR DESCRIPTION
resolves content jump when switching between tabs that has scrollbar visible due to large content height (overview, send) and tabs with very little content (eg receive without long list of used addresses) leaving a visible empty area in place where scrollbar should be.