### PR TITLE
fix: disabled dashboard button when backup failed

### DIFF
--- a/packages/integration-tests/projects/suite-web/tests/backup/t2-fail.test.ts
+++ b/packages/integration-tests/projects/suite-web/tests/backup/t2-fail.test.ts
@@ -32,9 +32,7 @@ describe('Backup', () => {
         cy.getTestElement('@notification/failed-backup/cta').should('be.visible');
 
         cy.getTestElement('@dashboard/security-card/backup/button', { timeout: 30000 }).should(
-            'not.be.disabled',
+            'be.disabled',
         );
-        cy.getTestElement('@dashboard/security-card/backup/button').click();
-        cy.getTestElement('@backup/already-failed-message');
     });
 });

--- a/packages/suite/src/views/dashboard/components/SecurityFeatures/index.tsx
+++ b/packages/suite/src/views/dashboard/components/SecurityFeatures/index.tsx
@@ -36,13 +36,14 @@ const SecurityFeatures = ({
     const isDeviceLocked = isLocked();
     const { getDiscoveryStatus } = useDiscovery();
     const discoveryStatus = getDiscoveryStatus();
-    const isDisabled = discoveryStatus && discoveryStatus.status === 'loading';
+    const isDisabledGlobal = discoveryStatus && discoveryStatus.status === 'loading';
     const analytics = useAnalytics();
 
     const { discreetModeCompleted } = flags;
     let needsBackup;
     let pinEnabled;
     let hiddenWalletCreated;
+    let backupFailed;
 
     if (device && device.features) {
         // TODO: add "error - backup failed" instead of needsBackup
@@ -50,6 +51,7 @@ const SecurityFeatures = ({
         needsBackup = device.features.needs_backup || device.features.unfinished_backup;
         pinEnabled = device.features.pin_protection;
         hiddenWalletCreated = device.features.passphrase_protection;
+        backupFailed = device.features.unfinished_backup;
     }
 
     const featuresCompleted =
@@ -73,6 +75,7 @@ const SecurityFeatures = ({
                           type: 'dashboard/security-card/create-backup',
                       });
                   },
+                  isDisabled: !!backupFailed,
               },
           }
         : {
@@ -233,9 +236,12 @@ const SecurityFeatures = ({
             <Content>
                 {!isHidden &&
                     cards.map((card, i) => {
-                        const ctaObject = card.cta
-                            ? { ...card.cta, isDisabled: !!isDisabled }
-                            : undefined;
+                        const ctaObject = card.cta ? { ...card.cta } : undefined;
+
+                        if (ctaObject) {
+                            // re-check if card button is disabled based on the global state as well
+                            ctaObject.isDisabled = !!isDisabledGlobal || ctaObject.isDisabled;
+                        }
 
                         return (
                             <SecurityCard

--- a/packages/suite/src/views/dashboard/components/SecurityFeatures/index.tsx
+++ b/packages/suite/src/views/dashboard/components/SecurityFeatures/index.tsx
@@ -236,12 +236,10 @@ const SecurityFeatures = ({
             <Content>
                 {!isHidden &&
                     cards.map((card, i) => {
-                        const ctaObject = card.cta ? { ...card.cta } : undefined;
-
-                        if (ctaObject) {
-                            // re-check if card button is disabled based on the global state as well
-                            ctaObject.isDisabled = !!isDisabledGlobal || ctaObject.isDisabled;
-                        }
+                        // re-check if the card button should be disabled (taking the global loading state into account)
+                        const ctaObject = card.cta
+                            ? { ...card.cta, isDisabled: !!isDisabledGlobal || card.cta.isDisabled }
+                            : undefined;
 
                         return (
                             <SecurityCard


### PR DESCRIPTION
fix: https://github.com/trezor/trezor-suite/issues/3194

I also fixed another bug related to `isDisabled` of particular buttons. The `isDisabled` prop for a particular button was always overwritten by the global loading state (all buttons disabled or all button enabled). 

![fix-backup](https://user-images.githubusercontent.com/44506010/102608492-3e9f6f00-412a-11eb-8926-25bc05fb6b41.png)
