### PR TITLE
chore: update to 2021 signing key

### DIFF
--- a/packages/landing-page/pages/wallet/start/index.tsx
+++ b/packages/landing-page/pages/wallet/start/index.tsx
@@ -127,8 +127,8 @@ const Start = () => {
                 <Signatures>
                     {platform && (
                         <>
-                            <StyledLink href={SL_SIGNING_KEY}>Signing key</StyledLink>
                             <StyledLink href={getAppSignatureUrl(platform)}>Signature</StyledLink>
+                            <StyledLink href={SL_SIGNING_KEY}>Signing key</StyledLink>
                         </>
                     )}
                 </Signatures>

--- a/packages/suite-web-landing/components/Download/index.tsx
+++ b/packages/suite-web-landing/components/Download/index.tsx
@@ -166,16 +166,16 @@ const Index = () => {
                     <Translation id="TR_SUITE_WEB_LANDING_VERSION" values={{ version }} />
                 </Item>
                 <Item>
-                    <StyledLink variant="nostyle" href={SL_SIGNING_KEY}>
-                        <Translation id="TR_SUITE_WEB_LANDING_SIGNING_KEY" />
-                    </StyledLink>
-                </Item>
-                <Item>
                     <StyledLink
                         variant="nostyle"
                         href={getInstallerSignatureURI(platform, version)}
                     >
                         <Translation id="TR_SUITE_WEB_LANDING_SIGNATURE" />
+                    </StyledLink>
+                </Item>
+                <Item>
+                    <StyledLink variant="nostyle" href={SL_SIGNING_KEY}>
+                        <Translation id="TR_SUITE_WEB_LANDING_SIGNING_KEY" />
                     </StyledLink>
                 </Item>
             </VersionInfo>

--- a/packages/suite/src/constants/suite/urls.ts
+++ b/packages/suite/src/constants/suite/urls.ts
@@ -54,4 +54,4 @@ export const FEEDBACK_FORM = 'https://satoshilabs.typeform.com/to/Dqb71wm1';
 // Tor domain
 export const TOR_DOMAIN = 'trezoriovpjcahpzkrewelclulmszwbqpzmzgub37gbcjlvluxtruqad.onion';
 
-export const SL_SIGNING_KEY = 'https://trezor.io/security/satoshilabs-2020-signing-key.asc';
+export const SL_SIGNING_KEY = 'https://trezor.io/security/satoshilabs-2021-signing-key.asc';


### PR DESCRIPTION
1. Update link to 2021 signing key
2. Swap `Signing Key` <-> `Signature` positions in the landing pages