### PR TITLE
feat(suite): search network by its label, symbol and in case of (t)XR…

### DIFF
--- a/packages/suite/src/components/suite/modals/AddAccount/components/NetworkSelect.tsx
+++ b/packages/suite/src/components/suite/modals/AddAccount/components/NetworkSelect.tsx
@@ -48,6 +48,18 @@ const NetworkOption = ({ value, label }: Option) => (
     </OptionWrapper>
 );
 
+const customNetworkFilter = (option: Option, searchText: string) => {
+    const searchString = searchText.toLowerCase();
+
+    const matchLabel = option.label.toLowerCase().includes(searchString);
+    const matchSymbol = option.value.symbol.toLowerCase().includes(searchString);
+    // match XRP/TXRP when user types "Ripple"
+    const matchXRPAlternativeName =
+        option.value.networkType === 'ripple' && 'ripple'.includes(searchString);
+
+    return matchLabel || matchSymbol || matchXRPAlternativeName;
+};
+
 interface Props {
     network: Network;
     internalNetworks: Network[];
@@ -62,6 +74,7 @@ const NetworkSelect = ({ network, internalNetworks, setSelectedNetwork, isDisabl
         width={250}
         maxMenuHeight={220}
         isClearable={false}
+        filterOption={customNetworkFilter}
         value={buildNetworkOption(network)}
         options={buildNetworkOptions(internalNetworks)}
         formatOptionLabel={NetworkOption}

--- a/packages/suite/src/utils/wallet/accountUtils.ts
+++ b/packages/suite/src/utils/wallet/accountUtils.ts
@@ -414,12 +414,14 @@ export const accountSearchFn = (
     const searchString = rawSearchString?.trim().toLowerCase();
     if (!searchString) return true; // no search string
 
+    const network = getNetwork(account.symbol);
+
     // helper func for searching in account's addresses
     const matchAddressFn = (u: NonNullable<Account['addresses']>['used'][number]) =>
         u.address.toLowerCase() === searchString;
 
     const symbolMatch = account.symbol.startsWith(searchString);
-    const networkNameMatch = getNetwork(account.symbol)?.name.toLowerCase().includes(searchString);
+    const networkNameMatch = network?.name.toLowerCase().includes(searchString);
     const accountTypeMatch = account.accountType.startsWith(searchString);
     const descriptorMatch = account.descriptor.toLowerCase() === searchString;
     const addressMatch = account.addresses
@@ -427,6 +429,9 @@ export const accountSearchFn = (
           account.addresses.unused.find(matchAddressFn) ||
           account.addresses.change.find(matchAddressFn)
         : false;
+    // find XRP accounts when users types in 'ripple'
+    const matchXRPAlternativeName =
+        network?.networkType === 'ripple' && 'ripple'.includes(searchString);
 
     const metadataMatch = account.metadata.accountLabel?.toLowerCase().includes(searchString);
 
@@ -436,6 +441,7 @@ export const accountSearchFn = (
         accountTypeMatch ||
         descriptorMatch ||
         addressMatch ||
+        matchXRPAlternativeName ||
         metadataMatch
     );
 };


### PR DESCRIPTION
…P also match "ripple"

- In add-account modal networks are now searchable also by their symbol, XRP also matches "ripple" search string
- added "ripple" matching rule also for account search to get consistent behaviour

close https://github.com/trezor/trezor-suite/issues/3071

<img width="849" alt="Screenshot 2021-01-05 at 16 34 41" src="https://user-images.githubusercontent.com/6961901/103665672-fa0e3300-4f73-11eb-8064-99e51cb21317.png">
