### PR TITLE
feat(suite-desktop): add context menu for editable elements (input, t…

### DIFF
--- a/packages/suite-desktop/src-electron/libs/menu.ts
+++ b/packages/suite-desktop/src-electron/libs/menu.ts
@@ -3,7 +3,7 @@ import { app, shell, Menu, MenuItem } from 'electron';
 const isMac = process.platform === 'darwin';
 
 // @ts-ignore should be fine https://www.electronjs.org/docs/api/menu#main-process
-const menuTemplate: MenuItem[] = [
+const mainMenuTemplate: MenuItem[] = [
     // { role: 'appMenu' }
     ...(isMac
         ? [
@@ -96,4 +96,22 @@ const menuTemplate: MenuItem[] = [
     },
 ];
 
-export const buildMainMenu = () => Menu.buildFromTemplate(menuTemplate);
+// for those wondering why is this a function, it is because otherwise app.name used in the template has incorrect value @trezor/suite-desktop instead of "Trezor Suite"
+export const buildMainMenu = () => Menu.buildFromTemplate(mainMenuTemplate);
+
+export const inputMenu = Menu.buildFromTemplate([
+    { role: 'undo' },
+    { role: 'redo' },
+    { type: 'separator' },
+    { role: 'cut' },
+    { role: 'copy' },
+    { role: 'paste' },
+    { type: 'separator' },
+    { role: 'selectAll' },
+]);
+
+export const selectionMenu = Menu.buildFromTemplate([
+    { role: 'copy' },
+    { type: 'separator' },
+    { role: 'selectAll' },
+]);

--- a/packages/suite-desktop/src-electron/modules/menu.ts
+++ b/packages/suite-desktop/src-electron/modules/menu.ts
@@ -1,10 +1,20 @@
 import { BrowserWindow, Menu } from 'electron';
 
-import { buildMainMenu } from '@lib/menu';
+import { buildMainMenu, inputMenu, selectionMenu } from '@lib/menu';
 
 const init = (window: BrowserWindow) => {
     Menu.setApplicationMenu(buildMainMenu());
     window.setMenuBarVisibility(false);
+
+    window.webContents.on('context-menu', (_e, props) => {
+        if (props.isEditable) {
+            // right click on the input/textarea should open a context menu with text editing options (copy, cut, paste,...)
+            inputMenu.popup();
+        } else if (props.selectionText && props.selectionText.trim() !== '') {
+            // right click with active text selection should open context menu with a copy option
+            selectionMenu.popup();
+        }
+    });
 };
 
 export default init;


### PR DESCRIPTION
…extarea) with text editing options

- adds context menu in inputs, textareas...
- I also realized there is no way to copy selected text (eg. error message) in the desktop app via a mouse so I added another small context menu with "copy" option if user has selected some text

close https://github.com/trezor/trezor-suite/issues/3200

<img width="656" alt="Screenshot 2021-01-06 at 14 03 15" src="https://user-images.githubusercontent.com/6961901/103771529-34d1a300-5028-11eb-80d8-c57a9d418306.png">
<img width="926" alt="Screenshot 2021-01-06 at 14 03 22" src="https://user-images.githubusercontent.com/6961901/103771532-3602d000-5028-11eb-9206-bd4984fe5e26.png">
