### PR TITLE
design: limit number of rendered medium posts

### DIFF
--- a/packages/suite/src/views/dashboard/components/NewsFeed/index.tsx
+++ b/packages/suite/src/views/dashboard/components/NewsFeed/index.tsx
@@ -77,7 +77,14 @@ const ReadMore = styled.div`
 
 const MediumLink = styled.a``;
 
-const NewsFeed = () => {
+interface Props {
+    maxVisibleCount?: number;
+}
+
+// Medium API allows you to fetch maximum of 10 latest articles. In dashboard we show 3 posts in a row.
+// It means that the last (10th) posts will be alone in a row. We don't want that.
+// For that reason, limit maximum posts shown to 9.
+const NewsFeed = ({ maxVisibleCount = 9 }: Props) => {
     const [visibleCount, incrementVisibleCount] = useState(3);
     const { posts, isError, fetchCount, incrementFetchCount } = useFetchNews();
     const theme = useTheme();
@@ -130,7 +137,8 @@ const NewsFeed = () => {
                     </Post>
                 ))}
             </Posts>
-            {posts.length > visibleCount && (
+            {/* display "Show older news" button only if there are more posts to load and I won't exceed maxVisibleCount by fetching another articles */}
+            {posts.length > visibleCount && visibleCount + 3 <= maxVisibleCount && (
                 <BottomAction>
                     <Button
                         variant="tertiary"


### PR DESCRIPTION
fix https://github.com/trezor/trezor-suite/issues/3195

Medium allows you to fetch a maximum of 10 latest articles. So I set a limit to show a maximum of 9 articles in the dashboard. 

![medium-posts](https://user-images.githubusercontent.com/44506010/103781289-6baeb580-5036-11eb-9693-47e02d33156c.png)
