### PR TITLE
feat(suite-desktop): add VS Code debugging configuration

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@ _old
 build
 build-electron
 .build-storybook
+*.cpuprofile
 
 # Dependency directory
 node_modules
@@ -15,7 +16,6 @@ node_modules
 .idea
 *.sublime-project
 *.sublime-workspace
-.vscode
 
 # Logs
 logs

--- a/.gitignore
+++ b/.gitignore
@@ -16,6 +16,9 @@ node_modules
 .idea
 *.sublime-project
 *.sublime-workspace
+.vscode/**/*
+!.vscode/launch.json
+!.vscode/tasks.json
 
 # Logs
 logs

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,26 @@
+{
+    "version": "0.2.0",
+    "configurations": [
+        {
+            "name": "Suite-Desktop: App",
+            "type": "node",
+            "request": "launch",
+            "program": "${workspaceRoot}/packages/suite-desktop/src-electron/app.ts",
+            "stopOnEntry": false,
+            "args": [],
+            "cwd": "${workspaceRoot}/packages/suite-desktop/dist",
+            "runtimeExecutable": "${workspaceRoot}/node_modules/.bin/electron",
+            "runtimeArgs": [
+                "--enable-logging",
+                "--remote-debugging-port=9223"
+            ],
+            "env": {},
+            "sourceMaps": true,
+            "outFiles": [
+                "${workspaceRoot}/packages/suite-desktop/dist/**/*.js"
+            ],
+            "preLaunchTask": "desktop:dev",
+            "postDebugTask": "end-tasks"
+        }
+    ]
+}

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -1,0 +1,54 @@
+{
+	"version": "2.0.0",
+	"tasks": [
+		{
+			"label": "end-tasks",
+			"command": "echo ${input:terminate}",
+			"type": "shell",
+			"problemMatcher": []
+		},
+		{
+			"label": "desktop:dev",
+			"dependsOn": [ "desktop:dev:prepare", "desktop:dev:local" ]
+		},
+		{
+			"label": "desktop:dev:prepare",
+			"type": "npm",
+			"script": "dev:prepare",
+			"path": "packages/suite-desktop/",
+			"problemMatcher": []
+		},
+		{
+			"label": "desktop:dev:local",
+			"type": "npm",
+			"script": "dev:local",
+			"path": "packages/suite-desktop/",
+			"isBackground": true,
+			"problemMatcher": {
+				"owner": "node",
+				"fileLocation": "relative",
+				"pattern": {
+					"regexp": "^(err|warn|info)  - (.*)$",
+					"file": 1,
+					"location": 2,
+					"severity": 3,
+					"code": 4,
+					"message": 5
+				},
+				"background": {
+					"activeOnStart": true,
+					"beginsPattern": "warn  - You have enabled experimental feature(s).",
+					"endsPattern": "event - compiled successfully"
+				},
+			}
+		}
+	],
+	"inputs": [
+		{
+			"id": "terminate",
+			"type": "command",
+			"command": "workbench.action.tasks.terminate",
+			"args": "terminateAll"
+		}
+	]
+}

--- a/docs/packages/suite-desktop.md
+++ b/docs/packages/suite-desktop.md
@@ -1,5 +1,10 @@
 # Suite Desktop
 
+## Debugging (VS Code)
+Using VS Code configuration files (inside `.vscode`), Suite Desktop can be built and run with a debugger attached to it. Running the `Suite-Desktop: App` task (F5) will execute all required scripts (NextJS server + Electron build) and launch the Electron app. VS Code will be set in debugging mode, allowing you, for example, to set breakpoints and inspect variables inside the `electron-src` folder (as well as other dependencies). For more on Debugging, please refer to [the VS Code documentation](https://code.visualstudio.com/docs/editor/debugging).
+
+Known issue: The devtools might blank out at launch. If this happens, simply close and re-open the devtools (CTRL + SHIFT + I).
+
 ## Shortcuts
 _TODO_
 

--- a/packages/suite-desktop/src-electron/modules/dev-tools.ts
+++ b/packages/suite-desktop/src-electron/modules/dev-tools.ts
@@ -4,7 +4,9 @@
 import { BrowserWindow } from 'electron';
 
 const init = (window: BrowserWindow) => {
-    window.webContents.openDevTools();
+    window.webContents.once('dom-ready', () => {
+        window.webContents.openDevTools();
+    });
 };
 
 export default init;


### PR DESCRIPTION
Adds debugger support for the desktop app. Makes debugging issues a whole lot easier and faster with VS Code. As most people use VS Code in the company, I think it would be quite useful to have VS Code workspace configuration files in the project (for other packages as well).