### PR TITLE
Fix/amount currency select

### DIFF
--- a/packages/components/src/components/form/Select/index.tsx
+++ b/packages/components/src/components/form/Select/index.tsx
@@ -281,8 +281,8 @@ const Select = ({
             // Save current timestamp to lastKeyPressTime variable
             lastKeyPressTimestamp.current = currentTimestamp;
 
-            // If user didn't type anything for 0.5 seconds, set searchedValue to just pressed key, otherwise add the new value to the old one
-            if (timeSincePreviousKeyPress > 500) {
+            // If user didn't type anything for 0.8 seconds, set searchedValue to just pressed key, otherwise add the new value to the old one
+            if (timeSincePreviousKeyPress > 800) {
                 searchedTerm.current = charValue;
             } else {
                 searchedTerm.current += charValue;
@@ -320,9 +320,6 @@ const Select = ({
                         optionsToSearchThrough,
                         searchedTerm.current
                     );
-
-                    // If no option to focus on was found, clear the searchedValue
-                    if (!optionToFocusOn) searchedTerm.current = '';
 
                     // Also get the last option, so I can scroll to it later
                     const lastOption = optionsToSearchThrough[optionsToSearchThrough.length - 1];

--- a/packages/suite/src/views/wallet/send/components/Outputs/components/Amount/components/TokenSelect/index.tsx
+++ b/packages/suite/src/views/wallet/send/components/Outputs/components/Amount/components/TokenSelect/index.tsx
@@ -78,6 +78,7 @@ const TokenSelect = ({ output, outputId }: Props) => {
                     <Select
                         options={options}
                         isSearchable
+                        isDisabled={options.length === 1} // disable when account has no tokens to choose from
                         hideTextCursor
                         value={options.find(o => o.value === tokenValue)}
                         isClearable={false}


### PR DESCRIPTION
close https://github.com/trezor/trezor-suite/issues/3235

- disabled crypto currency select if there are no tokens to choose from (basically send form for non-tokens networks won't have a dropdown next to the crypto currency that is being sent)
- plus unrelated change on QA's request, slightly more intuitive search behaviour 
  - allowed longer delay between key presses 
  - removed clearing of current search string if there are no matches. reasoning: if user made a typo error he doesn't know about the mistake anyway resulting in search string being completely different than user expects. Then the search behaviour feels even more broken than it really is.