### PR TITLE
Fix/initial theme

### DIFF
--- a/packages/components/src/components/Scrollbar/index.tsx
+++ b/packages/components/src/components/Scrollbar/index.tsx
@@ -24,6 +24,9 @@ const scrollbarStyles = css`
     ::-webkit-scrollbar-button {
         display: none;
     }
+    ::-webkit-scrollbar-corner {
+        background: transparent;
+    }
 
     /* firefox, first one is thumb, second color is track */
     scrollbar-color: ${props => props.theme.SCROLLBAR_THUMB} transparent;

--- a/packages/suite-native/src/utils/suite/env.ts
+++ b/packages/suite-native/src/utils/suite/env.ts
@@ -1,4 +1,5 @@
 import { Platform } from 'react-native';
+import { SuiteThemeVariant } from '@suite-types';
 
 /**
  * override for suite/utils/env - getUserAgent
@@ -62,4 +63,9 @@ export const submitRequestForm = (
  */
 export const setOnBeforeUnloadListener = (_callback: () => void) => {
     // todo:
+};
+
+export const getOSTheme = (): SuiteThemeVariant => {
+    // todo
+    return 'light';
 };

--- a/packages/suite/src/actions/suite/storageActions.ts
+++ b/packages/suite/src/actions/suite/storageActions.ts
@@ -283,6 +283,10 @@ export const removeDatabase = () => async (dispatch: Dispatch, getState: GetStat
     );
 };
 
+export const loadSuiteSettings = () => {
+    return db.getItemByPK('suiteSettings', 'suite');
+};
+
 export const loadStorage = () => async (dispatch: Dispatch, getState: GetState) => {
     const isDBAvailable = await SuiteDB.isDBAvailable();
 
@@ -297,7 +301,7 @@ export const loadStorage = () => async (dispatch: Dispatch, getState: GetState) 
         });
     } else {
         //  load state from database
-        const suite = await db.getItemByPK('suiteSettings', 'suite');
+        const suite = await loadSuiteSettings();
         const devices = await db.getItemsExtended('devices');
         const accounts = await db.getItemsExtended('accounts');
         const discovery = await db.getItemsExtended('discovery');

--- a/packages/suite/src/actions/suite/suiteActions.ts
+++ b/packages/suite/src/actions/suite/suiteActions.ts
@@ -3,6 +3,8 @@ import * as comparisonUtils from '@suite-utils/comparisonUtils';
 import * as deviceUtils from '@suite-utils/device';
 import { addToast } from '@suite-actions/notificationActions';
 import * as modalActions from '@suite-actions/modalActions';
+import * as storageActions from '@suite-actions/storageActions';
+import { getOSTheme } from '@suite-utils/env';
 import { SUITE, METADATA } from './constants';
 import { LANGUAGES } from '@suite-config';
 import {
@@ -536,4 +538,27 @@ export const switchDuplicatedDevice = (device: TrezorDevice, duplicate: TrezorDe
     dispatch(selectDevice(duplicate));
     // remove stateless instance
     dispatch(forgetDevice(device));
+};
+
+export const setInitialTheme = () => async (dispatch: Dispatch, getState: GetState) => {
+    try {
+        const storedSettings = await storageActions.loadSuiteSettings();
+        const isInitialRun = storedSettings?.flags.initialRun;
+        const savedTheme = storedSettings?.settings.theme;
+        const currentThemeVariant = getState().suite.settings.theme.variant;
+
+        if (isInitialRun || !storedSettings) {
+            // Initial run
+            // set initial theme (light/dark) based on OS settings
+            const osThemeVariant = getOSTheme();
+            if (osThemeVariant !== currentThemeVariant) {
+                dispatch(setTheme(osThemeVariant, undefined));
+            }
+        } else if (savedTheme && savedTheme.variant !== currentThemeVariant) {
+            // set correct theme from the db (this will be a bit quicker than waiting for STORAGE.LOADED)
+            dispatch(setTheme(savedTheme?.variant, savedTheme?.colors));
+        }
+    } catch (error) {
+        console.log(error); // just simple log to skip sentry as we probably don't care that much about failed initial theme
+    }
 };

--- a/packages/suite/src/middlewares/suite/suiteMiddleware.ts
+++ b/packages/suite/src/middlewares/suite/suiteMiddleware.ts
@@ -28,6 +28,7 @@ const suite = (api: MiddlewareAPI<Dispatch, AppState>) => (next: Dispatch) => as
 
     switch (action.type) {
         case SUITE.INIT:
+            api.dispatch(suiteActions.setInitialTheme());
             // load storage
             api.dispatch(loadStorage());
             break;

--- a/packages/suite/src/support/suite/ThemeProvider.tsx
+++ b/packages/suite/src/support/suite/ThemeProvider.tsx
@@ -1,10 +1,7 @@
-import React, { useEffect, useState } from 'react';
+import React from 'react';
 import { ThemeProvider as SCThemeProvider } from 'styled-components';
 import { THEME } from '@trezor/components';
-import * as suiteActions from '@suite-actions/suiteActions';
-import { useSelector, useActions } from '@suite-hooks';
-import { getOSTheme } from '@suite-utils/dom';
-import { db } from '@suite/storage';
+import { useSelector } from '@suite-hooks';
 import { AppState } from '@suite-types';
 
 const getThemeColors = (theme: AppState['suite']['settings']['theme']) => {
@@ -26,42 +23,6 @@ const getThemeColors = (theme: AppState['suite']['settings']['theme']) => {
 
 const ThemeProvider: React.FC = ({ children }) => {
     const theme = useSelector(state => state.suite.settings.theme);
-    const [storedTheme, setStoredTheme] = useState<
-        AppState['suite']['settings']['theme'] | null | undefined
-    >(); // null represents no theme is stored in db, while undefined means reading from db was not completed yet
-    const [error, setError] = useState(false);
-
-    const { setTheme } = useActions({
-        setTheme: suiteActions.setTheme,
-    });
-
-    useEffect(() => {
-        // effect for automatically choosing theme based on OS settings
-        const loadStoredTheme = async () => {
-            // load saved theme from db (we don't want to way for SUITE.STORAGE_LOADED, as it is fired way later)
-            try {
-                const suiteSettings = await db.getItemByPK('suiteSettings', 'suite');
-                const savedTheme = suiteSettings?.settings.theme;
-                setStoredTheme(savedTheme ?? null);
-            } catch {
-                setStoredTheme(null);
-                setError(true);
-            }
-        };
-
-        if (!storedTheme) {
-            loadStoredTheme();
-        }
-
-        // set active theme OS based theme only if there are no saved settings
-        if (storedTheme === null && !error) {
-            const osTheme = getOSTheme();
-            if (osTheme !== theme.variant) {
-                setTheme(osTheme);
-            }
-        }
-    }, [theme, setTheme, storedTheme, setStoredTheme, error]);
-
     return <SCThemeProvider theme={getThemeColors(theme)}>{children}</SCThemeProvider>;
 };
 

--- a/packages/suite/src/utils/suite/dom.ts
+++ b/packages/suite/src/utils/suite/dom.ts
@@ -1,5 +1,4 @@
 import { useState, useEffect } from 'react';
-import { SuiteThemeVariant } from '@suite-types';
 
 export const selectText = (element: HTMLElement) => {
     const doc = document;
@@ -150,13 +149,4 @@ export const setCaretPosition = (el: HTMLInputElement, pos: number) => {
         el.focus();
         el.setSelectionRange(pos, pos);
     }
-};
-
-export const getOSTheme = (): SuiteThemeVariant => {
-    if (typeof window === 'undefined') return 'light'; // in SSR, where window object is not defined, just return light theme
-    // retrieving os color scheme is supported in Chrome 76+, Firefox 67+
-    if (window.matchMedia && window.matchMedia('(prefers-color-scheme: dark)').matches) {
-        return 'dark';
-    }
-    return 'light';
 };

--- a/packages/suite/src/utils/suite/env.ts
+++ b/packages/suite/src/utils/suite/env.ts
@@ -1,3 +1,5 @@
+import { SuiteThemeVariant } from '@suite-types';
+
 /**
  * method does not do much, but still it is useful as we do not
  * have navigator.userAgent in native. This way we may define
@@ -103,4 +105,13 @@ export const submitRequestForm = async (
  */
 export const setOnBeforeUnloadListener = (callback: () => void) => {
     window.addEventListener('beforeunload', callback);
+};
+
+export const getOSTheme = (): SuiteThemeVariant => {
+    if (typeof window === 'undefined') return 'light'; // in SSR, where window object is not defined, just return light theme
+    // retrieving os color scheme is supported in Chrome 76+, Firefox 67+
+    if (window.matchMedia && window.matchMedia('(prefers-color-scheme: dark)').matches) {
+        return 'dark';
+    }
+    return 'light';
 };


### PR DESCRIPTION
fixing an issue where, after clearing a storage, toggling a dark mode switch triggered `setTheme` twice

- moved setting of initial theme from ThemeProvider to action triggered on SUITE.INIT as useEffect inside ThemeProvider was getting too complicated and was buggy anyway (making it easier to reuse in react native as a side effect 🎉 )

- fixed small scrollbar visual issue (https://github.com/trezor/trezor-suite/issues/2997#issuecomment-739823386)