### PR TITLE
test(e2e): speed up discovery using empty seed

### DIFF
--- a/packages/integration-tests/projects/suite-web/plugins/index.js
+++ b/packages/integration-tests/projects/suite-web/plugins/index.js
@@ -100,7 +100,8 @@ module.exports = on => {
         },
         setupEmu: async options => {
             const defaults = {
-                mnemonic: 'all all all all all all all all all all all all',
+                // some random empty seed. most of the test don't need any account history so it is better not to slow them down with all all seed
+                mnemonic: 'alcohol woman abuse must during monitor noble actual mixed trade anger aisle',
                 pin: '',
                 passphrase_protection: false,
                 label: 'My Trevor',

--- a/packages/integration-tests/projects/suite-web/tests/backup/t2-success.test.ts
+++ b/packages/integration-tests/projects/suite-web/tests/backup/t2-success.test.ts
@@ -3,7 +3,10 @@
 describe('Backup', () => {
     beforeEach(() => {
         cy.task('startEmu', { wipe: true });
-        cy.task('setupEmu', { needs_backup: true });
+        cy.task('setupEmu', {
+            needs_backup: true,
+            mnemonic: 'all all all all all all all all all all all all',
+        });
         cy.task('startBridge');
 
         cy.viewport(1024, 768).resetDb();
@@ -15,8 +18,8 @@ describe('Backup', () => {
         // access from notification
         cy.getTestElement('@notification/no-backup/button').click();
 
-        cy.getTestElement('@backup').matchImageSnapshot('backup-confirm-security-screen')
-        
+        cy.getTestElement('@backup').matchImageSnapshot('backup-confirm-security-screen');
+
         cy.getTestElement('@backup/check-item/understands-what-seed-is').click();
         cy.getTestElement('@backup/check-item/has-enough-time').click();
         cy.getTestElement('@backup/check-item/is-in-private').click();
@@ -24,7 +27,7 @@ describe('Backup', () => {
         cy.log('Create backup on device');
         cy.getTestElement('@backup/start-button').click();
         cy.getConfirmActionOnDeviceModal();
-        
+
         cy.task('pressYes');
         cy.task('swipeEmu', 'up');
         cy.task('swipeEmu', 'up');

--- a/packages/integration-tests/projects/suite-web/tests/dashboard/dashboard.test.ts
+++ b/packages/integration-tests/projects/suite-web/tests/dashboard/dashboard.test.ts
@@ -4,7 +4,11 @@
 describe('Dashboard', () => {
     beforeEach(() => {
         cy.task('startEmu', { version: '2.3.1', wipe: true });
-        cy.task('setupEmu', { needs_backup: true });
+        cy.task('setupEmu', {
+            needs_backup: true,
+            mnemonic: 'all all all all all all all all all all all all',
+        });
+
         cy.task('applySettings', { passphrase_always_on_device: false });
         cy.task('startBridge');
 
@@ -61,4 +65,5 @@ describe('Dashboard', () => {
     });
 
     // QA todo: test for graph
+    // QA todo: dashboard appearance for seed with tx history vs seed without tx history
 });

--- a/packages/integration-tests/projects/suite-web/tests/metadata/account-metadata.test.ts
+++ b/packages/integration-tests/projects/suite-web/tests/metadata/account-metadata.test.ts
@@ -19,7 +19,9 @@ Hovering over fields that may be labeled shows "add label" button upon which is 
         it(f.provider, () => {
             // prepare test
             cy.task('startEmu', { wipe: true });
-            cy.task('setupEmu');
+            cy.task('setupEmu', {
+                mnemonic: 'all all all all all all all all all all all all',
+            });
             cy.task(`metadataStartProvider`, f.provider);
             cy.task('startBridge');
 
@@ -62,9 +64,7 @@ Hovering over fields that may be labeled shows "add label" button upon which is 
             cy.getTestElement('@metadata/submit').click();
             cy.getTestElement('@account-menu/btc/normal/0/label').should('contain', 'even cooler');
             cy.getTestElement("@metadata/accountLabel/m/84'/0'/0'/success").should('be.visible');
-            cy.getTestElement("@metadata/accountLabel/m/84'/0'/0'/success").should(
-                'not.exist',
-            );
+            cy.getTestElement("@metadata/accountLabel/m/84'/0'/0'/success").should('not.exist');
 
             cy.log('Now edit and press escape, should not save');
             cy.getTestElement("@metadata/accountLabel/m/84'/0'/0'").click();
@@ -110,12 +110,8 @@ Hovering over fields that may be labeled shows "add label" button upon which is 
             cy.getTestElement('@metadata/input').type('typing into one input{enter}');
             cy.getTestElement("@metadata/accountLabel/m/49'/0'/0'/success").should('be.visible');
             cy.getTestElement('@account-menu/btc/segwit/1').click();
-            cy.getTestElement("@metadata/accountLabel/m/49'/0'/1'/success").should(
-                'not.exist',
-            );
-            cy.getTestElement("@metadata/accountLabel/m/49'/0'/0'/success").should(
-                'not.exist',
-            );
+            cy.getTestElement("@metadata/accountLabel/m/49'/0'/1'/success").should('not.exist');
+            cy.getTestElement("@metadata/accountLabel/m/49'/0'/0'/success").should('not.exist');
 
             // go to another route that triggers discovery and check whether there are any requests to metadata providers
             cy.getTestElement('@suite/menu/suite-index').click();

--- a/packages/integration-tests/projects/suite-web/tests/metadata/address-metadata.test.ts
+++ b/packages/integration-tests/projects/suite-web/tests/metadata/address-metadata.test.ts
@@ -16,7 +16,9 @@ describe('Metadata - address labeling', () => {
         it(provider, () => {
             // prepare test
             cy.task('startEmu', { wipe: true });
-            cy.task('setupEmu');
+            cy.task('setupEmu', {
+                mnemonic: 'all all all all all all all all all all all all',
+            });
             cy.task('startBridge');
             cy.task('metadataStartProvider', provider);
             cy.prefixedVisit('/accounts', {

--- a/packages/integration-tests/projects/suite-web/tests/metadata/dropbox-api-errors.test.ts
+++ b/packages/integration-tests/projects/suite-web/tests/metadata/dropbox-api-errors.test.ts
@@ -10,7 +10,9 @@ describe('Dropbox api errors', () => {
 
     it('Malformed token', () => {
         cy.task('startEmu', { wipe: true });
-        cy.task('setupEmu');
+        cy.task('setupEmu', {
+            mnemonic: 'all all all all all all all all all all all all',
+        });
         cy.task('startBridge');
         cy.task('metadataStartProvider', 'dropbox');
         // prepare some initial files

--- a/packages/integration-tests/projects/suite-web/tests/metadata/google-api-errors.test.ts
+++ b/packages/integration-tests/projects/suite-web/tests/metadata/google-api-errors.test.ts
@@ -9,7 +9,9 @@ describe('Google api errors', () => {
     beforeEach(() => {
         cy.viewport(1024, 768).resetDb();
         cy.task('startEmu', { wipe: true });
-        cy.task('setupEmu');
+        cy.task('setupEmu', {
+            mnemonic: 'all all all all all all all all all all all all',
+        });
         cy.task('startBridge');
         cy.task('metadataStartProvider', 'dropbox');
         cy.prefixedVisit('/accounts', {

--- a/packages/integration-tests/projects/suite-web/tests/metadata/interval-fetching.test.ts
+++ b/packages/integration-tests/projects/suite-web/tests/metadata/interval-fetching.test.ts
@@ -28,7 +28,9 @@ describe('Metadata - suite is watching cloud provider and syncs periodically', (
         it(`${f.provider}-${f.desc}`, () => {
             // prepare test
             cy.task('startEmu', { wipe: true });
-            cy.task('setupEmu');
+            cy.task('setupEmu', {
+                mnemonic: 'all all all all all all all all all all all all',
+            });
             cy.task('startBridge');
             cy.task('metadataStartProvider', f.provider);
             cy.clock();
@@ -57,7 +59,7 @@ describe('Metadata - suite is watching cloud provider and syncs periodically', (
                 'Wait for discovery to finish. There is "add label" button, but no actual metadata appeared',
             );
             cy.discoveryShouldFinish();
-            
+
             cy.getTestElement("@metadata/accountLabel/m/84'/0'/0'/add-label-button").click({
                 force: true,
             });

--- a/packages/integration-tests/projects/suite-web/tests/metadata/output-labeling.test.ts
+++ b/packages/integration-tests/projects/suite-web/tests/metadata/output-labeling.test.ts
@@ -16,7 +16,9 @@ describe('Metadata - Output labeling', () => {
                 '@metadata/outputLabel/9f472739fa7034dfb9736fa4d98915f2e8ddf70a86ee5e0a9ac0634f8c1d0007-0/add-label-button';
             // prepare test
             cy.task('startEmu', { wipe: true });
-            cy.task('setupEmu');
+            cy.task('setupEmu', {
+                mnemonic: 'all all all all all all all all all all all all',
+            });
             cy.task('startBridge');
             cy.task('metadataStartProvider', provider);
 

--- a/packages/integration-tests/projects/suite-web/tests/metadata/remembered-device.test.ts
+++ b/packages/integration-tests/projects/suite-web/tests/metadata/remembered-device.test.ts
@@ -25,7 +25,9 @@ On disable, it throws away all metadata related records from memory.`, () => {
             // prepare test
             cy.task('stopBridge');
             cy.task('startEmu', { wipe: true });
-            cy.task('setupEmu');
+            cy.task('setupEmu', {
+                mnemonic: 'all all all all all all all all all all all all',
+            });
             cy.task('startBridge');
             cy.task('metadataStartProvider', f.provider);
             cy.task('metadataSetFileContent', {
@@ -52,9 +54,9 @@ On disable, it throws away all metadata related records from memory.`, () => {
             cy.log(
                 'Wait for discovery to finish. There is "add label" button, but no actual metadata appeared',
             );
-           
+
             cy.discoveryShouldFinish();
-            
+
             cy.getTestElement('@account-menu/btc/normal/0/label').should('contain', 'Bitcoin');
 
             cy.log('Go to settings and enable metadata');

--- a/packages/integration-tests/projects/suite-web/tests/metadata/switching-providers.test.ts
+++ b/packages/integration-tests/projects/suite-web/tests/metadata/switching-providers.test.ts
@@ -11,7 +11,9 @@ describe(`Metadata - switching between cloud providers`, () => {
     it('Start with one and switch to another', () => {
         // prepare test
         cy.task('startEmu', { wipe: true });
-        cy.task('setupEmu');
+        cy.task('setupEmu', {
+            mnemonic: 'all all all all all all all all all all all all',
+        });
         cy.task('startBridge');
         cy.task(`metadataStartProvider`, 'dropbox');
         cy.task(`metadataStartProvider`, 'google');

--- a/packages/integration-tests/projects/suite-web/tests/metadata/wallet-metadata.test.ts
+++ b/packages/integration-tests/projects/suite-web/tests/metadata/wallet-metadata.test.ts
@@ -14,7 +14,9 @@ describe('Metadata - wallet labeling', () => {
         it(provider, () => {
             // prepare test
             cy.task('startEmu', { wipe: true, version: '2.3.1' });
-            cy.task('setupEmu');
+            cy.task('setupEmu', {
+                mnemonic: 'all all all all all all all all all all all all',
+            });
             cy.task('startBridge');
             cy.task('metadataStartProvider', provider);
 

--- a/packages/integration-tests/projects/suite-web/tests/recovery/t2-dry-run-persistence.test.ts
+++ b/packages/integration-tests/projects/suite-web/tests/recovery/t2-dry-run-persistence.test.ts
@@ -6,7 +6,9 @@
 describe('Recovery - dry run', () => {
     beforeEach(() => {
         cy.task('startEmu', { wipe: true, version: '2.3.1' });
-        cy.task('setupEmu');
+        cy.task('setupEmu', {
+            mnemonic: 'all all all all all all all all all all all all',
+        });
         cy.task('startBridge');
         cy.viewport(1024, 768).resetDb();
     });

--- a/packages/integration-tests/projects/suite-web/tests/suite/passphrase.test.ts
+++ b/packages/integration-tests/projects/suite-web/tests/suite/passphrase.test.ts
@@ -9,7 +9,7 @@ describe('Passphrase', () => {
         // note that versions before 2.3.1 don't have passphrase caching, this means that returning
         // back to passphrase that was used before in the session would require to type the passphrase again
         cy.task('startEmu', { wipe: true, version: '2.3.1' });
-        cy.task('setupEmu');
+        cy.task('setupEmu', { mnemonic: 'all all all all all all all all all all all all' });
         cy.task('startBridge');
 
         // eslint-disable-next-line @typescript-eslint/naming-convention


### PR DESCRIPTION
use seed with only one account to speed up e2e tests. proper fix (mocking entire discovery) shall follow   later. 