### PR TITLE
build(nix): build node binary modules from source

### DIFF
--- a/nixos-fix-binaries.sh
+++ b/nixos-fix-binaries.sh
@@ -5,14 +5,19 @@ if [ -f /etc/NIXOS ] ; then
     echo "You need to run this script in a nix-shell. Aborting"
     exit 1
   fi
+
   # replace bundled binaries in node_modules with symlinks
+
   ln -sf "$(which 7za)" "$CURDIR"/node_modules/7zip-bin/linux/x64/7za || :
+
   # replace bundled binaries in .cache/electron-builder with symlinks
+
   ln -sf "$(which desktop-file-validate)" "$ELECTRON_BUILDER_CACHE"/appimage/appimage-12.0.1/linux-x64/desktop-file-validate || :
   ln -sf "$(which opj_decompress)" "$ELECTRON_BUILDER_CACHE"/appimage/appimage-12.0.1/linux-x64/opj_decompress || :
   ln -sf "$(which mksquashfs)" "$ELECTRON_BUILDER_CACHE"/appimage/appimage-12.0.1/linux-x64/mksquashfs || :
   ln -sf "$(which makensis)" "$ELECTRON_BUILDER_CACHE"/nsis/nsis-3.0.4.1/linux/makensis || :
   ln -sf "$(which osslsigncode)" "$ELECTRON_BUILDER_CACHE"/winCodeSign/winCodeSign-2.6.0/linux/osslsigncode || :
+
 else
   echo "This is not NixOS. Aborting"
   exit 1

--- a/shell.nix
+++ b/shell.nix
@@ -25,12 +25,11 @@ in
       yarn
       SuitePython
     ] ++ lib.optionals stdenv.isLinux [
-      appimagekit
-      nsis
-      openjpeg
-      osslsigncode
-      p7zip
-      squashfsTools
+      pkg-config
+      python2                                                     # older node-gyp still requires python2.x
+      p7zip                                                       # binaries used by node_module: 7zip-bin
+      appimagekit nsis openjpeg osslsigncode p7zip squashfsTools  # binaries used by node_module: electron-builder
+      cairo giflib libjpeg libpng librsvg pango                   # build dependencies for node-canvas
       # winePackages.minimal
     ] ++ lib.optionals stdenv.isDarwin (with darwin.apple_sdk.frameworks; [
       Cocoa
@@ -40,5 +39,7 @@ in
       export CURDIR="$(pwd)"
       export PATH="$PATH:$CURDIR/node_modules/.bin"
       export ELECTRON_BUILDER_CACHE="$CURDIR/.cache/electron-builder"
+    '' + lib.optionalString stdenv.isLinux ''
+      export npm_config_build_from_source=true  # tell yarn to not download binaries, but build from source
     '';
   }


### PR DESCRIPTION
This PR tells yarn to build binary modules from source instead of downloading the prebuilt binaries.

`npm_config_build_from_source=true` for yarn is the same like calling `npm install --build-from-source`

This tackles mainly the `node-canvas` module and we had to add canvas dependencies to shell.nix (among with `pkg-config` and `python2` to enable the build via node-gyp).

This is done only for the Linux build. macOS build still downloads the prebuilt binaries