### PR TITLE
fix(suite): make account visible if it is not empty anymore

### DIFF
--- a/packages/suite/src/actions/wallet/accountActions.ts
+++ b/packages/suite/src/actions/wallet/accountActions.ts
@@ -66,6 +66,7 @@ export const update = (account: Account, accountInfo: AccountInfo): AccountActio
         ...accountInfo,
         path: account.path,
         empty: accountInfo.empty,
+        visible: account.visible || !accountInfo.empty,
         formattedBalance: accountUtils.formatNetworkAmount(
             // xrp `availableBalance` is reduced by reserve, use regular balance
             account.networkType === 'ripple' ? accountInfo.balance : accountInfo.availableBalance,

--- a/packages/suite/src/actions/wallet/selectedAccountActions.ts
+++ b/packages/suite/src/actions/wallet/selectedAccountActions.ts
@@ -231,6 +231,7 @@ export const getStateForAction = (action: Action) => (dispatch: Dispatch, getSta
             'tokens',
             'metadata',
             'addresses',
+            'visible',
             'utxo',
         ],
         discovery: [


### PR DESCRIPTION
tldr; of what happened:
1. when we first create an account (`accountActions.create`) we set its visibility to true only if it is not empty (or it is first account that we always want to show). Otherwise it is set to false.
2. if the account was remembered we don't update its visibility ever again (`accountActions.update` doesn't update this field).

To show account in the accounts menu it is enough if it is set to visible or non empty 
https://github.com/trezor/trezor-suite/blob/b6feaf87bbd0534afbe49e0a18248758b09aaacb/packages/suite/src/components/wallet/AccountsMenu/index.tsx#L190
BUT to be able to select (open) certain account it MUST be set to visible, we are not checking if it is not empty https://github.com/trezor/trezor-suite/blob/c4202dd7e61489a9dbc93c0795451ef12bfcfe17/packages/suite/src/actions/wallet/selectedAccountActions.ts#L148
So you could get a behaviour where you can actually see the account in the menu but after opening it suite tells you it doesn't exist.

This PR adds changing `visible` field inside  account update action that should fix the problem.

fix https://github.com/trezor/trezor-suite/issues/3212