### PR TITLE
Feat/messages

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,7 @@ Before you start make sure you have downloaded and installed [Node.js LTS](https
 
 -   `git clone git@github.com:trezor/trezor-suite.git`
 -   `yarn`
+-   `yarn build:libs`
 
 _To set up your dev environment for a native platform (iOS/Android) follow [these additional steps](https://github.com/trezor/trezor-suite/tree/develop/packages/suite-native#development)._
 

--- a/packages/suite/src/components/suite/Announcements/Announcement.tsx
+++ b/packages/suite/src/components/suite/Announcements/Announcement.tsx
@@ -1,15 +1,29 @@
 import styled from 'styled-components';
 import React from 'react';
+import {Button} from '@trezor/components';
 
 const Wrapper = styled.div`
     background-color: #AC61D0;
+    display: flex;
+    justify-content: space-between;
     width: 100%;
     padding: 1em;
     color: #fff;
 `;
 
-const Announcement = (props: {message: string}) => {
-    return <Wrapper>{props.message}</Wrapper>;
+interface Props {
+    message: string,
+    isDismissible?: boolean,
+    onDismiss?: (event: React.MouseEvent<HTMLButtonElement, MouseEvent>) => void
+}
+
+const Announcement = ({message, isDismissible = false, onDismiss = undefined }: Props) => {
+    return (
+        <Wrapper>
+            {message}
+            {isDismissible && <Button variant='tertiary' onClick={onDismiss}>Dismiss</Button>}
+        </Wrapper>
+    );
 };
 
 export default Announcement;

--- a/packages/suite/src/components/suite/Announcements/Announcement.tsx
+++ b/packages/suite/src/components/suite/Announcements/Announcement.tsx
@@ -1,0 +1,15 @@
+import styled from 'styled-components';
+import React from 'react';
+
+const Wrapper = styled.div`
+    background-color: #AC61D0;
+    width: 100%;
+    padding: 1em;
+    color: #fff;
+`;
+
+const Announcement = (props: {message: string}) => {
+    return <Wrapper>{props.message}</Wrapper>;
+};
+
+export default Announcement;

--- a/packages/suite/src/components/suite/Announcements/UseFetchAnnouncements.ts
+++ b/packages/suite/src/components/suite/Announcements/UseFetchAnnouncements.ts
@@ -1,0 +1,21 @@
+import { useState, useEffect } from 'react';
+
+const ANNOUNCEMENTS_API_URL = 'https://gist.githubusercontent.com/goodhoko/fb87ac361a3e13b752e240324dd367df/raw/1099148ee6299cc5500f635882fa5451796fbb79/trezor_announcements_v1.json';
+
+export function useFetchAnnouncements() {
+    const [announcements, setAnnouncements] = useState<string[]>([]);
+
+    useEffect(() => {
+        fetch(ANNOUNCEMENTS_API_URL)
+            .then(response => response.json())
+            .catch(err => {
+                console.error('Could not fetch announcements.', err);
+                return [];
+            })
+            .then(announcements => {
+                setAnnouncements(announcements)
+            })
+    }, []);
+
+    return announcements;
+}

--- a/packages/suite/src/components/suite/Announcements/UseFetchAnnouncements.ts
+++ b/packages/suite/src/components/suite/Announcements/UseFetchAnnouncements.ts
@@ -5,7 +5,7 @@ const ANNOUNCEMENTS_API_URL = 'https://gist.githubusercontent.com/goodhoko/fb87a
 export function useFetchAnnouncements() {
     const [announcements, setAnnouncements] = useState<string[]>([]);
 
-    useEffect(() => {
+    const fetchAnnouncements = () => {
         fetch(ANNOUNCEMENTS_API_URL)
             .then(response => response.json())
             .catch(err => {
@@ -15,6 +15,17 @@ export function useFetchAnnouncements() {
             .then(announcements => {
                 setAnnouncements(announcements)
             })
+    }
+
+    useEffect(() => {
+        // Fetch on mount.
+        fetchAnnouncements();
+        // Re-fetch every 10 minutes.
+        const interval = setInterval(fetchAnnouncements, 1000 * 60 * 10)
+        return () => {
+            // Clear the interval on unmount.
+            clearInterval(interval)
+        }
     }, []);
 
     return announcements;

--- a/packages/suite/src/components/suite/Announcements/UseFetchAnnouncements.ts
+++ b/packages/suite/src/components/suite/Announcements/UseFetchAnnouncements.ts
@@ -1,9 +1,14 @@
 import { useState, useEffect } from 'react';
 
-const ANNOUNCEMENTS_API_URL = 'https://gist.githubusercontent.com/goodhoko/fb87ac361a3e13b752e240324dd367df/raw/1099148ee6299cc5500f635882fa5451796fbb79/trezor_announcements_v1.json';
+const ANNOUNCEMENTS_API_URL = 'https://gist.githubusercontent.com/goodhoko/fb87ac361a3e13b752e240324dd367df/raw/a8c011271dd2ed598132afb89aaa0814e38ed5a1/trezor_announcements_v1.json';
+
+interface AnnouncementDTO {
+    message: string,
+    isDismissible: boolean,
+}
 
 export function useFetchAnnouncements() {
-    const [announcements, setAnnouncements] = useState<string[]>([]);
+    const [announcements, setAnnouncements] = useState<AnnouncementDTO[]>([]);
 
     const fetchAnnouncements = () => {
         fetch(ANNOUNCEMENTS_API_URL)
@@ -12,8 +17,8 @@ export function useFetchAnnouncements() {
                 console.error('Could not fetch announcements.', err);
                 return [];
             })
-            .then(announcements => {
-                setAnnouncements(announcements)
+            .then(response => {
+                setAnnouncements(response.announcements)
             })
     }
 

--- a/packages/suite/src/components/suite/Announcements/index.tsx
+++ b/packages/suite/src/components/suite/Announcements/index.tsx
@@ -1,11 +1,24 @@
-import React from 'react';
+import React, { useState } from 'react';
 import Announcement from './Announcement';
 import { useFetchAnnouncements } from './UseFetchAnnouncements';
 
 const Announcements = () => {
     const announcements = useFetchAnnouncements();
+    const [dismissedMessages, setDismissedMessages] = useState<string[]>([])
+
     return <>{
-        announcements.map(a => <Announcement key={a} message={a} />)
+        announcements
+        .filter(a => !dismissedMessages.includes(a.message))
+        .map(a => {
+            if (!a.isDismissible) {
+                return <Announcement key={a.message} message={a.message} />
+            }
+
+            const dismiss = () => {
+                setDismissedMessages((dismissedMessages) => [...dismissedMessages, a.message])
+            }
+            return <Announcement key={a.message} message={a.message} isDismissible={true} onDismiss = {dismiss} />
+        })
     }</>
 };
 

--- a/packages/suite/src/components/suite/Announcements/index.tsx
+++ b/packages/suite/src/components/suite/Announcements/index.tsx
@@ -2,9 +2,24 @@ import React, { useState } from 'react';
 import Announcement from './Announcement';
 import { useFetchAnnouncements } from './UseFetchAnnouncements';
 
+const KEY = 'trezor:announcements';
+
+const getDismissedMessages: () => string[] = () => {
+    const json = window.localStorage.getItem(KEY);
+    if (json === null) {
+        return []
+    }
+    return JSON.parse(json)
+}
+
+const persistDismissedMessage = (hash: string) => {
+    const messages = [...getDismissedMessages(), hash]
+    window.localStorage.setItem(KEY, JSON.stringify(messages))
+}
+
 const Announcements = () => {
     const announcements = useFetchAnnouncements();
-    const [dismissedMessages, setDismissedMessages] = useState<string[]>([])
+    const [dismissedMessages, setDismissedMessages] = useState(getDismissedMessages())
 
     return <>{
         announcements
@@ -15,6 +30,7 @@ const Announcements = () => {
             }
 
             const dismiss = () => {
+                persistDismissedMessage(a.message)
                 setDismissedMessages((dismissedMessages) => [...dismissedMessages, a.message])
             }
             return <Announcement key={a.message} message={a.message} isDismissible={true} onDismiss = {dismiss} />

--- a/packages/suite/src/components/suite/Announcements/index.tsx
+++ b/packages/suite/src/components/suite/Announcements/index.tsx
@@ -1,0 +1,10 @@
+import React from 'react';
+import Announcement from './Announcement';
+
+const Announcements = (props: {announcements: string[]}) => {
+    return <>{
+        props.announcements.map(a => <Announcement key={a} message={a} />)
+    }</>
+};
+
+export default Announcements;

--- a/packages/suite/src/components/suite/Announcements/index.tsx
+++ b/packages/suite/src/components/suite/Announcements/index.tsx
@@ -1,9 +1,11 @@
 import React from 'react';
 import Announcement from './Announcement';
+import { useFetchAnnouncements } from './UseFetchAnnouncements';
 
-const Announcements = (props: {announcements: string[]}) => {
+const Announcements = () => {
+    const announcements = useFetchAnnouncements();
     return <>{
-        props.announcements.map(a => <Announcement key={a} message={a} />)
+        announcements.map(a => <Announcement key={a} message={a} />)
     }</>
 };
 

--- a/packages/suite/src/components/suite/SuiteLayout/index.tsx
+++ b/packages/suite/src/components/suite/SuiteLayout/index.tsx
@@ -165,7 +165,7 @@ const SuiteLayout = (props: SuiteLayoutProps) => {
             <SuiteBanners />
             <DiscoveryProgress />
             <NavigationBar />
-            <Announcements announcements={['Jen Tak would like to work here.', 'We run out of bitcoins!']} />
+            <Announcements />
             <LayoutContext.Provider value={{ title, menu, setLayout }}>
                 {!isMobileLayout && (
                     <BodyWide menu={menu} appMenu={appMenu} url={props.router.url}>

--- a/packages/suite/src/components/suite/SuiteLayout/index.tsx
+++ b/packages/suite/src/components/suite/SuiteLayout/index.tsx
@@ -12,6 +12,7 @@ import { DiscoveryProgress } from '@wallet-components';
 import NavigationBar from '../NavigationBar';
 import { useLayoutSize } from '@suite-hooks';
 import { isDesktop } from '@suite-utils/env';
+import Announcements from '../Announcements';
 
 const PageWrapper = styled.div`
     display: flex;
@@ -164,6 +165,7 @@ const SuiteLayout = (props: SuiteLayoutProps) => {
             <SuiteBanners />
             <DiscoveryProgress />
             <NavigationBar />
+            <Announcements announcements={['Jen Tak would like to work here.', 'We run out of bitcoins!']} />
             <LayoutContext.Provider value={{ title, menu, setLayout }}>
                 {!isMobileLayout && (
                     <BodyWide menu={menu} appMenu={appMenu} url={props.router.url}>


### PR DESCRIPTION
# Announcements Feature
This is a proof of concept based on [the task](https://gist.github.com/tsusanka/dc8bc8a7f44e31e063e828c586d69a03) given to me during the interview process. It implements a basic message[1] delivery feature into Suite. I recommend reviewing by individual commits and reading the commit messages.

## User story
The task goes as:
> We need to display messages to users for important announcements. For example, if there are changes with a coin that will affect how the application is used, the user should be notified.

Which I extended by:
- An announcement should be visible all the time until it expires or is dismissed by user.
- Some announcements can be dismissed by the user by clicking a button which will hide the announcement and will prevent it from appearing again.

## UI
The UI is directly inspired by the Trezor's [support website](https://trezor.io/support/). 
<img width="1033" alt="image" src="https://user-images.githubusercontent.com/16712262/104843513-599d0480-58cb-11eb-8148-2eb473aba028.png">

It still needs some more polish to be aesthetically pleasing.

## Assumptions
When deciding how to implement this I had to make some assumptions. Of course they might be wrong. Listing them explicitly should help explain why I implemented the feature in this particular way.
- **TLS provides authenticity and integrity**: The task requires to check the message's integrity. I argue that, as long as it's fetched over https and we believe clients properly validate certificates, the integrity is guaranteed.
- **The App is always online**: by its nature a bitcoin wallet must be connected to the internet to provide the core functionality hence we can simply fetch the announcements 'on demand' without complicated local persistence.
- **The API always provides current announcements**: The task hints that each announcement has a period during which it should be shown to the user. I'd instead propose to move this logic to the backend and let the API decide when to show an announcement. This makes my task a bit easier although my implementation can by easily build upon to satisfy the original setup.

## Design
This feature will be implemented as a react module which will be mounted in `SuiteLayout`. After mount the module will fetch announcements from JSON API over https and display them. The fetch will be repeated every few minutes to ensure announcements are delivered to long-running instances of the app.

Once announcements are fetched they're displayed to the user. If the announcement is marked `isDismissible` by the API, there will be a button next to the message. On click, this button will hide the given announcement and will persist it in local storage. Only not yet dismissed and hence not yet persisted announcements are displayed to the user. The announcements are identified (and compared) by their message content.

## Limitations and future work
1. Because the announcement's sole message is used as its identifier if user dismisses a message it can never be shown the same message again. There might be use cases when we'll need to repeat the same announcement - for example announcing planned maintenance. The API would have to expose some additional identifier of the announcements. This could be a regular ID or possibly a time interval during which the announcement should be shown. This interval could be then hashed together with the message to yield an UID.
2. The used local storage will slowly grow with time because it's never pruned of old announcements. This could be optimized away by a) using a fixed-length hash as identifier b) setting up TTL mechanism for the persisted announcements.
3. There's no support for localization. It can be easily added by extending the API with more languages.
4. The announcements are plain strings. Shall we need more glare we could allow for eg. markdown in the messages.
5. I used browser's local storage as my knowledge of the Suite stack is limited. I'd expect there's a storage library that could be used instead and would work on all platforms including native.
6. There are no tests at the moment.
7. `array.includes()` is used to look up if a message was already dismissed. Complexity of filtering the announcements is `O(m * n)` where `m` is the count of current announcements from the API and `n` is the count of dismissed announcements in the storage. I assume both counts will be so small that performance gains by using faster data structure will be negligible. Although, we should keep an eye on this especially with regard to 2.

---

[1] The task talks about "messages". I dared to use "announcements" instead as that IMO better fits the intended feature.