### PR TITLE
fix(desktop-logger): output file

### DIFF
--- a/docs/misc/desktop_logger.md
+++ b/docs/misc/desktop_logger.md
@@ -22,14 +22,14 @@ Any of the following values:
 - info (3)
 - debug (4)
 
-#### Options
+#### Options (all optional)
 | name | type | default value | description |
 | --- | --- | --- | --- |
 | colors | boolean | `true` | Console output has colors |
 | writeToConsole | boolean | `true` | Output is displayed in the console |
 | writeToDisk | boolean | `false` | Output is written to a file |
 | outputFile | string | `'log-%ts.txt'` | file name for the output |
-| outputPath | string | Electron app log path or CWD | path for the output |
+| outputPath | string | Current working directory | path for the output |
 | logFormat | string | `'%dt - %lvl(%top): %msg'` | Output format of the log |
 
 ### String formatters

--- a/docs/packages/suite-desktop.md
+++ b/docs/packages/suite-desktop.md
@@ -6,7 +6,9 @@ Using VS Code configuration files (inside `.vscode`), Suite Desktop can be built
 Known issue: The devtools might blank out at launch. If this happens, simply close and re-open the devtools (CTRL + SHIFT + I).
 
 ## Logging
-_TODO_
+Logging can be enabled by running Suite with the command line flag `--log-level=LEVEL` (replace _LEVEL_ with _error_, _warn_, _info_ or _debug_ based on the logging you wish to display). Additional command line flags can be found [below](#runtime-flags).
+
+More technical information can be found on the [Desktop Logger page](../misc/desktop_logger.md).
 
 ## Shortcuts
 _TODO_
@@ -24,4 +26,5 @@ Available flags:
 | `--log-level=NAME` | Set the logging level. Available levels are [name (value)]: error (1), warn (2), info(3), debug (4). All logs with a value equal or lower to the selected log level will be displayed. |
 | `--log-write` | Write log to disk |
 | `--log-no-print` | Disable the log priting in the console. |
-| `--log-output=FILENAME` | Name of the output file (default: log-%ts.txt) |
+| `--log-file=FILENAME` | Name of the output file (defaults to `log-%ts.txt`) |
+| `--log-path=FILENAME` | Path for the output file (defaults to current working directory) |

--- a/packages/suite-desktop/package.json
+++ b/packages/suite-desktop/package.json
@@ -11,7 +11,7 @@
         "dev:run": "electron .",
         "dev:prepare": "yarn copy-files && yarn build:electron",
         "dev:local": "node scripts/dev.js",
-        "clean": "rimraf ./build-electron && rimraf ./build && rimraf ./dist",
+        "clean": "rimraf ./build-electron && rimraf ./build && rimraf ./dist && rimraf ./.next",
         "copy-files": "yarn workspace @trezor/suite-data copy-static-files",
         "build:electron": "rimraf ./dist && node scripts/build.js",
         "build:desktop": "rimraf ./build && next build && next export -o build && cross-env NODE_ENV=production yarn build:electron",

--- a/packages/suite-desktop/src-electron/app.ts
+++ b/packages/suite-desktop/src-electron/app.ts
@@ -6,7 +6,7 @@ import isDev from 'electron-is-dev';
 import { PROTOCOL } from '@lib/constants';
 import * as store from '@lib/store';
 import { MIN_HEIGHT, MIN_WIDTH } from '@lib/screen';
-import Logger, { LogLevel } from '@lib/logger';
+import Logger, { LogLevel, defaultOptions as loggerDefaults } from '@lib/logger';
 import { buildInfo, computerInfo } from '@lib/info';
 import modules from '@lib/modules';
 
@@ -25,7 +25,8 @@ const log = {
     level: app.commandLine.getSwitchValue('log-level') || (isDev ? 'debug' : 'error'),
     writeToConsole: !app.commandLine.hasSwitch('log-no-print'),
     writeToDisk: app.commandLine.hasSwitch('log-write'),
-    outputFile: app.commandLine.getSwitchValue('log-output'),
+    outputFile: app.commandLine.getSwitchValue('log-file') || loggerDefaults.outputFile,
+    outputPath: app.commandLine.getSwitchValue('log-path') || loggerDefaults.outputPath,
 };
 
 const logger = new Logger(log.level as LogLevel, { ...log });

--- a/packages/suite-desktop/src-electron/libs/logger.ts
+++ b/packages/suite-desktop/src-electron/libs/logger.ts
@@ -1,7 +1,6 @@
 import fs from 'fs';
 import path from 'path';
 import chalk from 'chalk';
-import { app } from 'electron';
 
 const logLevels = ['mute', 'error', 'warn', 'info', 'debug'] as const;
 export type LogLevel = typeof logLevels[number];
@@ -15,12 +14,12 @@ export type Options = {
     logFormat?: string; // Output format of the log
 };
 
-const defaultOptions: Options = {
+export const defaultOptions: Options = {
     colors: true,
     writeToConsole: true,
     writeToDisk: false,
     outputFile: 'log-%ts.txt',
-    outputPath: app?.getPath('logs') || process.cwd(),
+    outputPath: process.cwd(),
     logFormat: '%dt - %lvl(%top): %msg',
 };
 


### PR DESCRIPTION
- Changes the flag `--log-output` to `--log-file` for setting the file name for the log file and `--log-path` for setting a path to output the log files. 
- Changes the default for the log path. It is now pointing to the current working directory (unless overwritten by `--log-path`).
- Documentation has been updated to reflect these changes.