### PR TITLE
Desktop: Disable auto updater if APPIMAGE is not set

### DIFF
--- a/docs/packages/suite-desktop.md
+++ b/docs/packages/suite-desktop.md
@@ -28,3 +28,5 @@ Available flags:
 | `--log-no-print` | Disable the log priting in the console. |
 | `--log-file=FILENAME` | Name of the output file (defaults to `log-%ts.txt`) |
 | `--log-path=PATHNAME` | Path for the output file (defaults to home or current working directory) |
+| `--enable-updater` | Enables the auto updater (if disabled in feature flags) |
+| `--disable-updater` | Disables the auto updater (if enabled in feature flags) |

--- a/packages/suite-desktop/src-electron/__tests__/logger.test.ts
+++ b/packages/suite-desktop/src-electron/__tests__/logger.test.ts
@@ -8,7 +8,7 @@ const testOptions: Options = {
     outputFile: 'test-log.txt',
     outputPath: __dirname,
 };
-const output = path.join(testOptions.outputPath, testOptions.outputFile);
+const output = path.join(testOptions.outputPath ?? '', testOptions.outputFile ?? '');
 
 describe('logger', () => {
     let spy: any;

--- a/packages/suite-desktop/src-electron/app.ts
+++ b/packages/suite-desktop/src-electron/app.ts
@@ -3,12 +3,12 @@ import url from 'url';
 import { app, BrowserWindow, ipcMain } from 'electron';
 import isDev from 'electron-is-dev';
 
-import { PROTOCOL } from '@lib/constants';
-import * as store from '@lib/store';
-import { MIN_HEIGHT, MIN_WIDTH } from '@lib/screen';
-import Logger, { LogLevel, defaultOptions as loggerDefaults } from '@lib/logger';
-import { buildInfo, computerInfo } from '@lib/info';
-import modules from '@lib/modules';
+import { PROTOCOL } from '@desktop-electron/libs/constants';
+import * as store from '@desktop-electron/libs/store';
+import { MIN_HEIGHT, MIN_WIDTH } from '@desktop-electron/libs/screen';
+import Logger, { LogLevel, defaultOptions as loggerDefaults } from '@desktop-electron/libs/logger';
+import { buildInfo, computerInfo } from '@desktop-electron/libs/info';
+import modules from '@desktop-electron/libs/modules';
 
 let mainWindow: BrowserWindow;
 const APP_NAME = 'Trezor Suite';

--- a/packages/suite-desktop/src-electron/config.ts
+++ b/packages/suite-desktop/src-electron/config.ts
@@ -1,4 +1,4 @@
-import { TOR_DOMAIN } from '@suite/constants/suite/urls';
+import { TOR_DOMAIN } from '@suite-constants/urls';
 
 export const onionDomain = TOR_DOMAIN;
 

--- a/packages/suite-desktop/src-electron/index.d.ts
+++ b/packages/suite-desktop/src-electron/index.d.ts
@@ -43,9 +43,9 @@ declare interface ILogger {
 
 // Dependencies
 declare type Dependencies = {
-    mainWindow?: Electron.BrowserWindow;
-    store?: LocalStore;
-    src?: string;
+    mainWindow: Electron.BrowserWindow;
+    store: LocalStore;
+    src: string;
 };
 
 // Store

--- a/packages/suite-desktop/src-electron/libs/constants.ts
+++ b/packages/suite-desktop/src-electron/libs/constants.ts
@@ -1,25 +1,26 @@
 export const PROTOCOL = 'file';
 
+// General modules (both dev & prod)
 export const MODULES = [
     // Event Logging
-    { name: 'event-logging/process', dependencies: [] },
-    { name: 'event-logging/app', dependencies: [] },
-    { name: 'event-logging/contents', dependencies: ['mainWindow'] },
+    'event-logging/process',
+    'event-logging/app',
+    'event-logging/contents',
     // Standard modules
-    { name: 'menu', dependencies: ['mainWindow'] },
-    { name: 'shortcuts', dependencies: ['mainWindow', 'src'] },
-    { name: 'request-filter', dependencies: ['mainWindow'] },
-    { name: 'external-links', dependencies: ['mainWindow', 'store'] },
-    { name: 'window-controls', dependencies: ['mainWindow', 'store'] },
-    { name: 'http-receiver', dependencies: ['mainWindow', 'src'] },
-    { name: 'metadata', dependencies: [] },
-    { name: 'bridge', dependencies: [] },
-    { name: 'tor', dependencies: ['mainWindow', 'store'] },
-    { name: 'analytics', dependencies: [] },
-    // Prod Only
-    { name: 'csp', dependencies: ['mainWindow'], isDev: false },
-    { name: 'file-protocol', dependencies: ['mainWindow', 'src'], isDev: false },
-    { name: 'auto-updater', dependencies: ['mainWindow', 'store'], isDev: false },
-    // Dev Only
-    { name: 'dev-tools', dependencies: ['mainWindow'], isDev: true },
+    'menu',
+    'shortcuts',
+    'request-filter',
+    'external-links',
+    'window-controls',
+    'http-receiver',
+    'metadata',
+    'bridge',
+    'tor',
+    'analytics',
 ];
+
+// Modules only used in prod mode
+export const MODULES_PROD = ['csp', 'file-protocol', 'auto-updater'];
+
+// Modules only used in dev mode
+export const MODULES_DEV = ['dev-tools'];

--- a/packages/suite-desktop/src-electron/libs/http-receiver.ts
+++ b/packages/suite-desktop/src-electron/libs/http-receiver.ts
@@ -245,8 +245,8 @@ export class HttpReceiver extends EventEmitter {
     private spendHandleMessage = (request: Request, response: http.ServerResponse) => {
         const { query } = url.parse(request.url, true);
         this.emit('spend/message', {
-            data: query.data,
-            origin: query.origin,
+            data: query.data ?? '',
+            origin: query.origin ?? '',
         });
 
         const template = this.applyTemplate('You may now close this window.');

--- a/packages/suite-desktop/src-electron/libs/info.ts
+++ b/packages/suite-desktop/src-electron/libs/info.ts
@@ -2,8 +2,8 @@ import { app } from 'electron';
 import isDev from 'electron-is-dev';
 import si from 'systeminformation';
 
-import { b2t } from '@lib/utils';
-import { toHumanReadable } from '@suite/utils/suite/file';
+import { b2t } from '@desktop-electron/libs/utils';
+import { toHumanReadable } from '@suite-utils/file';
 
 export const buildInfo = () => {
     global.logger.info('build', [

--- a/packages/suite-desktop/src-electron/libs/processes/BaseProcess.ts
+++ b/packages/suite-desktop/src-electron/libs/processes/BaseProcess.ts
@@ -1,7 +1,7 @@
 import path from 'path';
 import { spawn, ChildProcess } from 'child_process';
 import isDev from 'electron-is-dev';
-import { b2t } from '@lib/utils';
+import { b2t } from '@desktop-electron/libs/utils';
 
 export type Status = {
     service: boolean;

--- a/packages/suite-desktop/src-electron/modules/analytics.ts
+++ b/packages/suite-desktop/src-electron/modules/analytics.ts
@@ -1,5 +1,5 @@
 import { ipcMain } from 'electron';
-import { getOSVersion } from '@lib/user-data';
+import { getOSVersion } from '@desktop-electron/libs/user-data';
 
 export const init = () => {
     const { logger } = global;

--- a/packages/suite-desktop/src-electron/modules/auto-updater.ts
+++ b/packages/suite-desktop/src-electron/modules/auto-updater.ts
@@ -13,6 +13,11 @@ const preReleaseFlag = app.commandLine.hasSwitch('pre-release');
 const init = ({ mainWindow, store }: Dependencies) => {
     const { logger } = global;
 
+    if (process.platform === 'linux' && process.env.APPIMAGE === undefined) {
+        logger.warn('auto-updater', 'APPIMAGE is not defined, skipping auto updater');
+        return;
+    }
+
     let isManualCheck = false;
     let latestVersion = {};
     let updateCancellationToken: CancellationToken;

--- a/packages/suite-desktop/src-electron/modules/bridge.ts
+++ b/packages/suite-desktop/src-electron/modules/bridge.ts
@@ -2,8 +2,8 @@
  * Bridge runner
  */
 import { app, session } from 'electron';
-import BridgeProcess from '@lib/processes/BridgeProcess';
-import { b2t } from '@lib/utils';
+import BridgeProcess from '@desktop-electron/libs/processes/BridgeProcess';
+import { b2t } from '@desktop-electron/libs/utils';
 
 const filter = {
     urls: ['http://127.0.0.1:21325/*'],

--- a/packages/suite-desktop/src-electron/modules/event-logging/process.ts
+++ b/packages/suite-desktop/src-electron/modules/event-logging/process.ts
@@ -6,7 +6,9 @@ const init = () => {
     });
 
     process.on('unhandledRejection', e => {
-        logger.warn('rejection', `Unhandled Rejection: ${e.toString()}`);
+        if (e) {
+            logger.warn('rejection', `Unhandled Rejection: ${e.toString()}`);
+        }
     });
 };
 

--- a/packages/suite-desktop/src-electron/modules/file-protocol.ts
+++ b/packages/suite-desktop/src-electron/modules/file-protocol.ts
@@ -4,7 +4,7 @@
 import path from 'path';
 import { session } from 'electron';
 
-import { PROTOCOL } from '@lib/constants';
+import { PROTOCOL } from '@desktop-electron/libs/constants';
 
 const init = ({ mainWindow, src }: Dependencies) => {
     // Point to the right directory for file protocol requests

--- a/packages/suite-desktop/src-electron/modules/http-receiver.ts
+++ b/packages/suite-desktop/src-electron/modules/http-receiver.ts
@@ -3,8 +3,8 @@
  */
 import { app, ipcMain } from 'electron';
 
-import { buyRedirectHandler } from '@lib/buy';
-import { HttpReceiver } from '@lib/http-receiver';
+import { buyRedirectHandler } from '@desktop-electron/libs/buy';
+import { HttpReceiver } from '@desktop-electron/libs/http-receiver';
 
 // External request handler
 const httpReceiver = new HttpReceiver();

--- a/packages/suite-desktop/src-electron/modules/menu.ts
+++ b/packages/suite-desktop/src-electron/modules/menu.ts
@@ -1,7 +1,7 @@
 import { Menu } from 'electron';
 
-import { buildMainMenu, inputMenu, selectionMenu } from '@lib/menu';
-import { b2t } from '@lib/utils';
+import { buildMainMenu, inputMenu, selectionMenu } from '@desktop-electron/libs/menu';
+import { b2t } from '@desktop-electron/libs/utils';
 
 const init = ({ mainWindow }: Dependencies) => {
     const { logger } = global;
@@ -10,7 +10,7 @@ const init = ({ mainWindow }: Dependencies) => {
     mainWindow.setMenuBarVisibility(false);
 
     mainWindow.webContents.on('context-menu', (_, props) => {
-        const isTextSelected = props.selectionText && props.selectionText.trim() !== '';
+        const isTextSelected = Boolean(props.selectionText) && props.selectionText.trim() !== '';
         logger.debug('menu', [
             'Context menu:',
             `- Editable: ${b2t(props.isEditable)}`,

--- a/packages/suite-desktop/src-electron/modules/metadata.ts
+++ b/packages/suite-desktop/src-electron/modules/metadata.ts
@@ -2,7 +2,7 @@
  * Metadata feature (save/load metadata locally)
  */
 import { ipcMain } from 'electron';
-import { save, read } from '@lib/user-data';
+import { save, read } from '@desktop-electron/libs/user-data';
 
 const DATA_DIR = '/metadata';
 

--- a/packages/suite-desktop/src-electron/modules/tor.ts
+++ b/packages/suite-desktop/src-electron/modules/tor.ts
@@ -3,8 +3,8 @@
  */
 import { app, session, ipcMain, IpcMainEvent } from 'electron';
 
-import TorProcess from '@lib/processes/TorProcess';
-import { b2t } from '@lib/utils';
+import TorProcess from '@desktop-electron/libs/processes/TorProcess';
+import { b2t } from '@desktop-electron/libs/utils';
 
 import { onionDomain } from '../config';
 

--- a/packages/suite-desktop/src-electron/preload.ts
+++ b/packages/suite-desktop/src-electron/preload.ts
@@ -13,6 +13,7 @@ const validChannels = [
     'oauth/response',
 
     // Update events
+    'update/enable',
     'update/checking',
     'update/available',
     'update/not-available',

--- a/packages/suite-desktop/src-electron/tsconfig.json
+++ b/packages/suite-desktop/src-electron/tsconfig.json
@@ -1,4 +1,5 @@
 {
+    "extends": "../../../tsconfig.json",
     "compilerOptions": {
         "watch": false,
         "preserveWatchOutput": true,
@@ -21,18 +22,12 @@
         "skipLibCheck": true,
         "noUnusedLocals": true,
         "noUnusedParameters": true,
-        "noImplicitAny": true,
-        "baseUrl": ".",
-        "paths": {
-            "@lib/*": ["./libs/*"],
-            "@module/*": ["./modules/*"],
-            "@suite/*": ["../../suite/src/*"]
-        }
+        "noImplicitAny": true
     },
     "include": [
         "**/*.ts"
     ],
     "exclude": [
-        "**/*.js",
+        "**/*.js"
     ]
 }

--- a/packages/suite-desktop/src/support/DesktopUpdater.tsx
+++ b/packages/suite-desktop/src/support/DesktopUpdater.tsx
@@ -1,6 +1,5 @@
 import React, { useCallback, useEffect, useMemo } from 'react';
 import { useActions, useSelector } from '@suite-hooks';
-import { isDev } from '@suite-utils/build';
 import * as desktopUpdateActions from '@suite-actions/desktopUpdateActions';
 
 import Available from './DesktopUpdater/Available';
@@ -13,6 +12,7 @@ interface Props {
 
 const DesktopUpdater = ({ setIsUpdateVisible }: Props) => {
     const {
+        enable,
         checking,
         available,
         notAvailable,
@@ -22,6 +22,7 @@ const DesktopUpdater = ({ setIsUpdateVisible }: Props) => {
         error,
         setUpdateWindow,
     } = useActions({
+        enable: desktopUpdateActions.enable,
         checking: desktopUpdateActions.checking,
         available: desktopUpdateActions.available,
         notAvailable: desktopUpdateActions.notAvailable,
@@ -34,8 +35,8 @@ const DesktopUpdater = ({ setIsUpdateVisible }: Props) => {
     const desktopUpdate = useSelector(state => state.desktopUpdate);
 
     useEffect(() => {
-        // Don't run in dev builds (no updates to fetch, triggers errors)
-        if (isDev()) {
+        if (!desktopUpdate.enabled) {
+            window.desktopApi!.on('update/enable', enable);
             return;
         }
 
@@ -51,7 +52,17 @@ const DesktopUpdater = ({ setIsUpdateVisible }: Props) => {
         window.desktopApi!.checkForUpdates();
         // Check for updates every hour
         setInterval(() => window.desktopApi!.checkForUpdates(), 60 * 60 * 1000);
-    }, [available, checking, downloading, notAvailable, ready, skip, error]);
+    }, [
+        available,
+        checking,
+        downloading,
+        notAvailable,
+        ready,
+        skip,
+        error,
+        desktopUpdate.enabled,
+        enable,
+    ]);
 
     const hideWindow = useCallback(() => setUpdateWindow('hidden'), [setUpdateWindow]);
     /* Not used for now

--- a/packages/suite/src/actions/suite/constants/desktopUpdateConstants.ts
+++ b/packages/suite/src/actions/suite/constants/desktopUpdateConstants.ts
@@ -1,3 +1,4 @@
+export const ENABLE = '@desktop-update/enable';
 export const CHECKING = '@desktop-update/checking';
 export const AVAILABLE = '@desktop-update/available';
 export const NOT_AVAILABLE = '@desktop-update/not-available';

--- a/packages/suite/src/actions/suite/desktopUpdateActions.ts
+++ b/packages/suite/src/actions/suite/desktopUpdateActions.ts
@@ -4,6 +4,7 @@ import { Dispatch, GetState } from '@suite-types';
 import { UpdateInfo, UpdateProgress, UpdateWindow } from '@suite-types/desktop';
 
 export type DesktopUpdateAction =
+    | { type: typeof DESKTOP_UPDATE.ENABLE }
     | { type: typeof DESKTOP_UPDATE.CHECKING }
     | { type: typeof DESKTOP_UPDATE.AVAILABLE; payload: UpdateInfo }
     | { type: typeof DESKTOP_UPDATE.NOT_AVAILABLE; payload?: UpdateInfo }
@@ -11,6 +12,8 @@ export type DesktopUpdateAction =
     | { type: typeof DESKTOP_UPDATE.READY; payload: UpdateInfo }
     | { type: typeof DESKTOP_UPDATE.SKIP; payload: string }
     | { type: typeof DESKTOP_UPDATE.WINDOW; payload: UpdateWindow };
+
+export const enable = (): DesktopUpdateAction => ({ type: DESKTOP_UPDATE.ENABLE });
 
 export const checking = (): DesktopUpdateAction => ({ type: DESKTOP_UPDATE.CHECKING });
 

--- a/packages/suite/src/config/suite/features.ts
+++ b/packages/suite/src/config/suite/features.ts
@@ -11,6 +11,7 @@ export const FLAGS = {
     ONION_LOCATION_META: true, // Show TOR onion-location meta tag in page head
     EXPORT_TRANSACTIONS: true, // Display export option on transactions
     SEARCH_TRANSACTIONS: true, // Display search option on transactions
+    DESKTOP_AUTO_UPDATER: true, // Runs auto updater code on desktop
 } as const;
 
 // Web specific flags

--- a/packages/suite/src/reducers/suite/desktopUpdateReducer.ts
+++ b/packages/suite/src/reducers/suite/desktopUpdateReducer.ts
@@ -19,6 +19,7 @@ import { UpdateInfo, UpdateProgress, UpdateWindow } from '@suite-types/desktop';
  * - hidden: Hidden
  */
 export interface State {
+    enabled: boolean;
     state: 'checking' | 'available' | 'not-available' | 'downloading' | 'ready';
     skip?: string;
     progress?: UpdateProgress;
@@ -27,6 +28,7 @@ export interface State {
 }
 
 const initialState: State = {
+    enabled: false,
     state: 'not-available',
     window: 'maximized',
 };
@@ -34,6 +36,9 @@ const initialState: State = {
 const desktopUpdateReducer = (state: State = initialState, action: Action): State => {
     return produce(state, draft => {
         switch (action.type) {
+            case DESKTOP_UPDATE.ENABLE:
+                draft.enabled = true;
+                break;
             case DESKTOP_UPDATE.CHECKING:
                 draft.state = 'checking';
                 break;

--- a/packages/suite/src/views/settings/index.tsx
+++ b/packages/suite/src/views/settings/index.tsx
@@ -389,7 +389,7 @@ const Settings = ({
                             </Version>
                         }
                     />
-                    {isDesktop() && (
+                    {desktopUpdate.enabled && (
                         <ActionColumn>
                             {desktopUpdate.state === 'checking' && (
                                 <ActionButton isDisabled variant="secondary">

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -292,7 +292,8 @@
             "*/workers/graph.worker": ["./packages/suite/src/workers/graph.worker"],
             // other
             "@native/*": ["./packages/suite-native/src/*"],
-            "@desktop/*": ["./packages/suite-desktop/src/*"]
+            "@desktop/*": ["./packages/suite-desktop/src/*"],
+            "@desktop-electron/*": ["./packages/suite-desktop/src-electron/*"]
         },
         "jsx": "react-native",
         "module": "esnext",


### PR DESCRIPTION
resolves #2962

As @prusnak suggestion on #3113, this change skips the auto updater if the `APPIMAGE` environment variable is not set on Linux. It will display a warning (if that log level is enabled). It will also disable the UI for the auto-updater if the auto-updater is not loaded (not supported by platform or not fulfilling all requirements (ie APPIMAGE env var on Linux)).

This also extends the tsconfig paths from the base config for the electron source. It also add command line parameters to force enable/disable the auto-updater as well as a feature flag to control this feature. Only if the feature is enabled and supported, it will be shown on the front-end.

And there are also some changes with how modules are loaded. I simplified it a bit. Each modules gets all dependencies and it's now using an array of strings rather than object.