### PR TITLE
fix(suite): reset coin filter when clicking on "Accounts"

### DIFF
--- a/packages/suite/src/components/suite/NavigationBar/components/MainNavigation/index.tsx
+++ b/packages/suite/src/components/suite/NavigationBar/components/MainNavigation/index.tsx
@@ -4,7 +4,7 @@ import styled, { css } from 'styled-components';
 import { variables } from '@trezor/components';
 import { Translation } from '@suite-components';
 import { MAIN_MENU_ITEMS } from '@suite-constants/menu';
-import { useAnalytics, useActions, useSelector } from '@suite-hooks';
+import { useAnalytics, useActions, useSelector, useAccountSearch } from '@suite-hooks';
 import * as routerActions from '@suite-actions/routerActions';
 
 interface ComponentProps {
@@ -105,6 +105,7 @@ interface Props {
 
 const MainNavigation = (props: Props) => {
     const analytics = useAnalytics();
+    const { setCoinFilter, setSearchString } = useAccountSearch();
     const activeApp = useSelector(state => state.router.app);
     const { goto } = useActions({
         goto: routerActions.goto,
@@ -116,6 +117,8 @@ const MainNavigation = (props: Props) => {
                 analytics.report({ type: 'menu/goto/suite-index' });
                 break;
             case 'wallet-index':
+                setCoinFilter(undefined);
+                setSearchString(undefined);
                 analytics.report({ type: 'menu/goto/wallet-index' });
                 break;
             default:


### PR DESCRIPTION
close https://github.com/trezor/trezor-suite/issues/3266

 - reset coin filter when clicking on "Accounts", preventing the possibility that automatically selected account (most likely BTC if enabled) isn't included in filtered list of accounts

