### PR TITLE
fix: enable generation of source maps

### DIFF
--- a/packages/suite-desktop/next.config.js
+++ b/packages/suite-desktop/next.config.js
@@ -36,9 +36,7 @@ module.exports = withBundleAnalyzer(
                     name: 'static/[hash].worker.js',
                     publicPath: '/_next/',
                 },
-                experimental: {
-                    productionBrowserSourceMaps: true,
-                },
+                productionBrowserSourceMaps: true,
                 webpack: config => {
                     config.plugins.push(
                         new webpack.DefinePlugin({

--- a/packages/suite-web/next.config.js
+++ b/packages/suite-web/next.config.js
@@ -31,9 +31,7 @@ module.exports = withOptimizedImages(
                     name: 'static/[hash].worker.js',
                     publicPath: '/_next/',
                 },
-                experimental: {
-                    productionBrowserSourceMaps: true,
-                },
+                productionBrowserSourceMaps: true,
                 webpack: (config, options) => {
                     config.plugins.push(
                         new webpack.DefinePlugin({


### PR DESCRIPTION
close https://github.com/trezor/trezor-suite/issues/3316

flag no longer experimental and that's why it stopped working! 🤦 

if everything goes well, with this fix released we should get working source maps in Sentry again!