### PR TITLE
fix(suite-data): update tor binaries

### DIFF
--- a/packages/suite-data/files/bin/tor/linux-x64/tor
+++ b/packages/suite-data/files/bin/tor/linux-x64/tor
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:37c63e1e29651669a54a3d705a3ba848f084a92d99dccfba4c99ce89e99aa8c6
+oid sha256:ed212d0d7dcfd3cd3736333f1c8932698db5a61e9989f1b7fd65ccc9c03ecd31
 size 3539752

--- a/packages/suite-data/files/bin/tor/mac-x64/libevent-2.1.7.dylib
+++ b/packages/suite-data/files/bin/tor/mac-x64/libevent-2.1.7.dylib
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:909d2f0bb70b04487e1410e4381b2b570222ff696da96d5e1e0281f6ec4a2ddf
+oid sha256:decad3a2e40955ddd7d6c41087f5c6136df281d7a06f34c78f854bd3d1227cfd
 size 390080

--- a/packages/suite-data/files/bin/tor/mac-x64/tor
+++ b/packages/suite-data/files/bin/tor/mac-x64/tor
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:0ded454d6ec0c6469fdc821417194a308d890a8544ddcc28b815608c5fb9686c
+oid sha256:5d91f26f547ec7c341bb9fae556c3af2582608f221b085c71a258d806fc2f085
 size 5961760

--- a/packages/suite-data/files/bin/tor/win-x64/tor.exe
+++ b/packages/suite-data/files/bin/tor/win-x64/tor.exe
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:77f32afcea2b43124c7c23eeaae0e0b10bbc79d8a4e8de661196d909fa459d3c
-size 4493312
+oid sha256:886960e5698cd275f81e2ad3b9654275172a30f6e9f16ddf09b6b96ad4b50403
+size 4493824


### PR DESCRIPTION
This might look like this is too late for the party, but actually it's just a small and very required change.

Included are the latest binaries extracted from the latest Tor Browser installers, where the Tor Project fixes the DDoS issue.

Let's get this into the February release. Keeping the old binaries in the release would make Tor feature unusable.

Fixes https://github.com/trezor/trezor-suite/issues/3218
Fixes https://github.com/trezor/trezor-suite/issues/3191

- linux-x64 from https://www.torproject.org/dist/torbrowser/10.0.10/tor-browser-linux64-10.0.10_en-US.tar.xz
- mac-x64   from https://www.torproject.org/dist/torbrowser/10.0.10/TorBrowser-10.0.10-osx64_en-US.dmg
- win-x64   from https://www.torproject.org/dist/torbrowser/10.0.11/torbrowser-install-win64-10.0.11_en-US.exe