### PR TITLE
fix: auth only if device is not locked

### DIFF
--- a/packages/suite/src/middlewares/wallet/discoveryMiddleware.ts
+++ b/packages/suite/src/middlewares/wallet/discoveryMiddleware.ts
@@ -71,12 +71,13 @@ const discoveryMiddleware = (api: MiddlewareAPI<Dispatch, AppState>) => (next: D
     if (nextState.router.app !== 'wallet' && nextState.router.app !== 'dashboard') return action;
 
     let authorizationIntent = false;
-    const { device } = nextState.suite;
+    const { device, locks } = nextState.suite;
     // 1. selected device is acquired but doesn't have a state
     if (
         device &&
         device.features &&
         !device.state &&
+        !locks.includes(SUITE.LOCK_TYPE.DEVICE) &&
         (action.type === SUITE.SELECT_DEVICE || action.type === SUITE.APP_CHANGED)
     ) {
         authorizationIntent = true;


### PR DESCRIPTION
fix #3347

the problem is that SELECT_DEVICE and APP_CHANGE actions being called almost at the same time (from SelectDevice modal)
first action will trigger `auth` proccess, second action will interrupt it (first action will throw an error)

solution:
do not auth if device is already locked (auth in progress)