### PR TITLE
fix(suite): fiat rates error handling

### DIFF
--- a/packages/suite/src/config/suite/sentry.ts
+++ b/packages/suite/src/config/suite/sentry.ts
@@ -1,4 +1,6 @@
 import { CaptureConsole } from '@sentry/integrations';
+import { BrowserOptions } from '@sentry/browser';
+import { TOR_DOMAIN } from '@suite-constants/urls';
 
 export default {
     dsn: 'https://6d91ca6e6a5d4de7b47989455858b5f6@o117836.ingest.sentry.io/5193825',
@@ -10,4 +12,13 @@ export default {
     ],
     release: process.env.COMMITHASH,
     environment: process.env.SUITE_TYPE,
-};
+    beforeSend(event, hint) {
+        const error = hint?.syntheticException;
+        const re = new RegExp(`FiatRatesFetchError.*${TOR_DOMAIN}`, 'gmi');
+        if (error?.message?.match(re)) {
+            // discard failed fiat rate fetch on TOR
+            event.fingerprint = ['FiatRatesFetchError'];
+            return null;
+        }
+    },
+} as BrowserOptions;


### PR DESCRIPTION
- custom error for failed fiat rate fetch
- throw an error on non-2xx status codes.
- disabled sentry reporting for failed fiat rates fetches on TOR (there are around 200k of them for the past 90days, mostly due to not working tor/onion links)