### PR TITLE
Fix/tx details inconsistency

### DIFF
--- a/packages/suite/src/utils/wallet/transactionUtils.ts
+++ b/packages/suite/src/utils/wallet/transactionUtils.ts
@@ -380,6 +380,13 @@ export const enhanceTransaction = (
     tx: AccountTransaction,
     account: Account,
 ): WalletAccountTransaction => {
+    const network = getNetwork(account.symbol);
+    // subtract fee from sent transaction amount (looks like only btc-like txs amounts are including fee, ethereum tx.amount does not include a fee)
+    const amount =
+        tx.type === 'sent' && network!.networkType === 'bitcoin'
+            ? new BigNumber(tx.amount).minus(tx.fee).toString()
+            : tx.amount;
+
     return {
         descriptor: account.descriptor,
         deviceState: account.deviceState,
@@ -396,7 +403,7 @@ export const enhanceTransaction = (
                 amount: formatAmount(tok.amount, tok.decimals),
             };
         }),
-        amount: formatNetworkAmount(tx.amount, account.symbol),
+        amount: formatNetworkAmount(amount, account.symbol),
         fee: formatNetworkAmount(tx.fee, account.symbol),
         targets: tx.targets.map(tr => {
             if (typeof tr.amount === 'string') {


### PR DESCRIPTION
close https://github.com/trezor/trezor-suite/issues/3366 (subtract tx.fee from tx.amount in case of 'sent' btc-like txs)
I am not completely sure about this one, is it legit that tx.amount includes fee in case of sent btc-like txs? Should it be fixed somewhere higher or there is a valid reason for handling it this way?
cc @szymonlesisz 