### PR TITLE
fix(transactions): search optimization and incorrect pagination display for coin

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ### Fixed
 - Check if IDB is supported before each operation (no idb support in FF incognito/tor browser)
+- Pagination on transaction list
+- Freeze when using transaction search while discovery is running
 
 ## 21.2.1 [10th February 2021]
 

--- a/packages/suite/src/views/wallet/transactions/components/TransactionList/index.tsx
+++ b/packages/suite/src/views/wallet/transactions/components/TransactionList/index.tsx
@@ -173,7 +173,7 @@ const TransactionList = ({ transactions, isLoading, account, ...props }: Props) 
             {showPagination && (
                 <PaginationWrapper>
                     <Pagination
-                        hasPages={isRipple}
+                        hasPages={!isRipple}
                         currentPage={currentPage}
                         totalPages={total}
                         isOnLastPage={isOnLastPage}


### PR DESCRIPTION
This addresses #3376 by reworking on the fetch all logic when searching. And it also fixes an issue with the wrong pagination being displayed.