### PR TITLE
fix(invity): switch name of exchange inputs

### DIFF
--- a/packages/suite/src/hooks/wallet/useCoinmarketExchangeForm.ts
+++ b/packages/suite/src/hooks/wallet/useCoinmarketExchangeForm.ts
@@ -51,7 +51,7 @@ export const useCoinmarketExchangeForm = (props: Props): ExchangeFormContextValu
         defaultValues: { selectedFee: 'normal', feePerUnit: '', feeLimit: '' },
     });
     const { register, setValue, getValues, setError, clearErrors } = methods;
-    const [token, setToken] = useState<string | undefined>(getValues('receiveCryptoSelect')?.value);
+    const [token, setToken] = useState<string | undefined>(getValues('sendCryptoSelect')?.value);
     const [amountLimits, setAmountLimits] = useState<AmountLimits | undefined>(undefined);
     const [isMax, setIsMax] = useState<boolean | undefined>(undefined);
     const [isComposing, setIsComposing] = useState<boolean>(false);
@@ -127,7 +127,7 @@ export const useCoinmarketExchangeForm = (props: Props): ExchangeFormContextValu
         setIsComposing(true);
         const formValues = getValues();
         const token =
-            data && data.token ? data.token : formValues.receiveCryptoSelect.value || undefined;
+            data && data.token ? data.token : formValues.sendCryptoSelect.value || undefined;
         const feeLevel = feeInfo.levels.find(level => level.label === data.feeLevelLabel);
         const selectedFeeLevel =
             feeLevel || feeInfo.levels.find(level => level.label === formValues.selectedFee);
@@ -146,7 +146,7 @@ export const useCoinmarketExchangeForm = (props: Props): ExchangeFormContextValu
 
         const result = await composeTransaction({
             account,
-            amount: data && data.amount ? data.amount : formValues.receiveCryptoInput || '0',
+            amount: data && data.amount ? data.amount : formValues.sendCryptoInput || '0',
             feeInfo,
             feePerUnit,
             feeLimit: data && data.feeLimit ? data.feeLimit : formValues.feeLimit || '0',
@@ -172,17 +172,17 @@ export const useCoinmarketExchangeForm = (props: Props): ExchangeFormContextValu
                         .decimalPlaces(decimals)
                         .toFixed();
                 }
-                setValue('receiveCryptoInput', amountToFill, { shouldValidate: true });
+                setValue('sendCryptoInput', amountToFill, { shouldValidate: true });
                 updateFiatValue(amountToFill);
             }
             saveComposedTransaction(transactionInfo);
-            clearErrors('receiveCryptoInput');
+            clearErrors('sendCryptoInput');
             setValue('estimatedFeeLimit', transactionInfo.estimatedFeeLimit);
             ok = true;
         }
 
         if (transactionInfo?.type === 'error' && transactionInfo.errorMessage) {
-            setError('receiveCryptoInput', {
+            setError('sendCryptoInput', {
                 type: 'compose',
                 message: transactionInfo.errorMessage as any,
             });
@@ -193,7 +193,7 @@ export const useCoinmarketExchangeForm = (props: Props): ExchangeFormContextValu
     };
 
     const updateFiatCurrency = (currency: { label: string; value: string }) => {
-        const amount = getValues('receiveCryptoInput') || '0';
+        const amount = getValues('sendCryptoInput') || '0';
         if (!fiatRates || !fiatRates.current || !currency) return;
         const fiatValue = toFiatCurrency(amount, currency.value, fiatRates.current.rates);
         if (fiatValue) {
@@ -201,7 +201,7 @@ export const useCoinmarketExchangeForm = (props: Props): ExchangeFormContextValu
         }
     };
 
-    const updateReceiveCryptoValue = (amount: string, decimals: number) => {
+    const updateSendCryptoValue = (amount: string, decimals: number) => {
         const currency: { value: string; label: string } | undefined = getValues('fiatSelect');
         if (!fiatRates || !fiatRates.current || !currency) return;
         const cryptoValue = fromFiatCurrency(
@@ -211,7 +211,7 @@ export const useCoinmarketExchangeForm = (props: Props): ExchangeFormContextValu
             decimals,
         );
 
-        setValue('receiveCryptoInput', cryptoValue || '', { shouldValidate: true });
+        setValue('sendCryptoInput', cryptoValue || '', { shouldValidate: true });
     };
 
     const typedRegister = useCallback(<T>(rules?: T) => register(rules), [register]);
@@ -221,9 +221,9 @@ export const useCoinmarketExchangeForm = (props: Props): ExchangeFormContextValu
 
     const onSubmit = async () => {
         const formValues = getValues();
-        const sendStringAmount = formValues.receiveCryptoInput || '';
-        const send = formValues.receiveCryptoSelect.value;
-        const receive = formValues.sendCryptoSelect.value;
+        const sendStringAmount = formValues.sendCryptoInput || '';
+        const send = formValues.sendCryptoSelect.value;
+        const receive = formValues.receiveCryptoSelect.value;
         const request: ExchangeTradeQuoteRequest = {
             receive,
             send,
@@ -307,7 +307,7 @@ export const useCoinmarketExchangeForm = (props: Props): ExchangeFormContextValu
         exchangeCoinInfo,
         updateFiatCurrency,
         token,
-        updateReceiveCryptoValue,
+        updateSendCryptoValue,
         saveTrade,
         feeInfo,
         compose,

--- a/packages/suite/src/types/wallet/coinmarketExchangeForm.ts
+++ b/packages/suite/src/types/wallet/coinmarketExchangeForm.ts
@@ -25,11 +25,11 @@ export interface Props extends ComponentProps {
 }
 
 export type FormState = {
-    receiveCryptoInput?: string;
-    receiveCryptoSelect: Option;
+    sendCryptoInput?: string;
+    sendCryptoSelect: Option;
     fiatInput?: string;
     fiatSelect?: Option;
-    sendCryptoSelect: Option;
+    receiveCryptoSelect: Option;
     selectedFee: FeeLevel['label'];
     feePerUnit: string;
     feeLimit?: string;
@@ -66,7 +66,7 @@ export type ExchangeFormContextValues = Omit<UseFormMethods<FormState>, 'registe
     setMax: (isMax: boolean) => void;
     compose: (data: ComposeData) => void;
     updateFiatCurrency: (selectedCurrency: { value: string; label: string }) => void;
-    updateReceiveCryptoValue: (fiatValue: string, decimals: number) => void;
+    updateSendCryptoValue: (fiatValue: string, decimals: number) => void;
     saveQuoteRequest: (request: ExchangeTradeQuoteRequest) => CoinmarketExchangeAction;
     saveQuotes: (
         fixedQuotes: ExchangeTrade[],

--- a/packages/suite/src/views/wallet/coinmarket/exchange/components/ExchangeForm/Footer/index.tsx
+++ b/packages/suite/src/views/wallet/coinmarket/exchange/components/ExchangeForm/Footer/index.tsx
@@ -23,7 +23,7 @@ const StyledButton = styled(Button)`
 
 const Footer = () => {
     const { formState, watch, errors, isComposing } = useCoinmarketExchangeFormContext();
-    const hasValues = !!watch('receiveCryptoInput') && !!watch('sendCryptoSelect')?.value;
+    const hasValues = !!watch('sendCryptoInput') && !!watch('receiveCryptoSelect')?.value;
     const formIsValid = Object.keys(errors).length === 0;
 
     return (

--- a/packages/suite/src/views/wallet/coinmarket/exchange/components/ExchangeForm/Inputs/Buttons/index.tsx
+++ b/packages/suite/src/views/wallet/coinmarket/exchange/components/ExchangeForm/Inputs/Buttons/index.tsx
@@ -65,7 +65,7 @@ const Bottom = () => {
                   .dividedBy(divisor)
                   .decimalPlaces(network.decimals)
                   .toString();
-        setValue('receiveCryptoInput', amount);
+        setValue('sendCryptoInput', amount);
         updateFiatValue(amount);
     };
 

--- a/packages/suite/src/views/wallet/coinmarket/exchange/components/ExchangeForm/Inputs/FiatInput/index.tsx
+++ b/packages/suite/src/views/wallet/coinmarket/exchange/components/ExchangeForm/Inputs/FiatInput/index.tsx
@@ -22,7 +22,7 @@ const FiatInput = () => {
         clearErrors,
         errors,
         trigger,
-        updateReceiveCryptoValue,
+        updateSendCryptoValue,
         setMax,
         setValue,
     } = useCoinmarketExchangeFormContext();
@@ -36,9 +36,9 @@ const FiatInput = () => {
             onChange={event => {
                 setMax(false);
                 if (errors[fiatInput]) {
-                    setValue('receiveCryptoInput', '');
+                    setValue('sendCryptoInput', '');
                 } else {
-                    updateReceiveCryptoValue(event.target.value, network.decimals);
+                    updateSendCryptoValue(event.target.value, network.decimals);
                     clearErrors(fiatInput);
                 }
             }}

--- a/packages/suite/src/views/wallet/coinmarket/exchange/components/ExchangeForm/Inputs/ReceiveCryptoSelect/index.tsx
+++ b/packages/suite/src/views/wallet/coinmarket/exchange/components/ExchangeForm/Inputs/ReceiveCryptoSelect/index.tsx
@@ -102,7 +102,7 @@ const buildOptions = (
     return [popular, stable, all];
 };
 
-const SendCryptoSelect = () => {
+const ReceiveCryptoSelect = () => {
     const {
         control,
         setAmountLimits,
@@ -129,7 +129,7 @@ const SendCryptoSelect = () => {
             <Controller
                 control={control}
                 defaultValue={false}
-                name="sendCryptoSelect"
+                name="receiveCryptoSelect"
                 render={({ onChange, value }) => {
                     return (
                         <Select
@@ -166,4 +166,4 @@ const SendCryptoSelect = () => {
     );
 };
 
-export default SendCryptoSelect;
+export default ReceiveCryptoSelect;

--- a/packages/suite/src/views/wallet/coinmarket/exchange/components/ExchangeForm/Inputs/SendCryptoInput/SendCryptoSelect/index.tsx
+++ b/packages/suite/src/views/wallet/coinmarket/exchange/components/ExchangeForm/Inputs/SendCryptoInput/SendCryptoSelect/index.tsx
@@ -14,7 +14,7 @@ const Label = styled.div`
     padding-left: 10px;
 `;
 
-const ReceiveCryptoSelect = () => {
+const SendCryptoSelect = () => {
     const {
         control,
         setAmountLimits,
@@ -25,13 +25,13 @@ const ReceiveCryptoSelect = () => {
         setToken,
         compose,
     } = useCoinmarketExchangeFormContext();
-    const receiveCryptoSelect = 'receiveCryptoSelect';
+    const sendCryptoSelect = 'sendCryptoSelect';
     const uppercaseSymbol = account.symbol.toUpperCase();
 
     return (
         <Controller
             control={control}
-            name={receiveCryptoSelect}
+            name={sendCryptoSelect}
             defaultValue={{
                 value: uppercaseSymbol,
                 label: formatLabel(uppercaseSymbol),
@@ -43,7 +43,7 @@ const ReceiveCryptoSelect = () => {
                             setMax(false);
                             onChange(selected);
                             setAmountLimits(undefined);
-                            setValue('receiveCryptoInput', '');
+                            setValue('sendCryptoInput', '');
                             setValue('fiatInput', '');
                             const lowerCaseToken = selected.value.toLowerCase();
                             if (
@@ -81,4 +81,4 @@ const ReceiveCryptoSelect = () => {
     );
 };
 
-export default ReceiveCryptoSelect;
+export default SendCryptoSelect;

--- a/packages/suite/src/views/wallet/coinmarket/exchange/components/ExchangeForm/Inputs/SendCryptoInput/index.tsx
+++ b/packages/suite/src/views/wallet/coinmarket/exchange/components/ExchangeForm/Inputs/SendCryptoInput/index.tsx
@@ -7,7 +7,7 @@ import useDebounce from 'react-use/lib/useDebounce';
 import { isDecimalsValid, isInteger } from '@wallet-utils/validation';
 import { useCoinmarketExchangeFormContext } from '@wallet-hooks/useCoinmarketExchangeForm';
 import { Translation } from '@suite-components';
-import ReceiveCryptoSelect from './ReceiveCryptoSelect';
+import SendCryptoSelect from './SendCryptoSelect';
 import { InputError } from '@wallet-components';
 import Bignumber from 'bignumber.js';
 import { MAX_LENGTH } from '@suite-constants/inputs';
@@ -30,7 +30,7 @@ const StyledInput = styled(Input)`
     border-bottom-right-radius: 0;
 `;
 
-const ReceiveCryptoInput = () => {
+const SendCryptoInput = () => {
     const {
         register,
         errors,
@@ -45,7 +45,7 @@ const ReceiveCryptoInput = () => {
         updateFiatValue,
         getValues,
     } = useCoinmarketExchangeFormContext();
-    const receiveCryptoInput = 'receiveCryptoInput';
+    const sendCryptoInput = 'sendCryptoInput';
     const fiatInput = 'fiatInput';
     const { symbol, tokens } = account;
     const tokenData = tokens?.find(t => t.symbol === invityApiSymbolToSymbol(token));
@@ -57,11 +57,11 @@ const ReceiveCryptoInput = () => {
             ? formatNetworkAmount(account.misc.reserve, account.symbol)
             : undefined;
     const decimals = tokenData ? tokenData.decimals : network.decimals;
-    const amount = getValues(receiveCryptoInput);
+    const amount = getValues(sendCryptoInput);
     useDebounce(
         () => {
             // take value at debounce time, the user may type fast
-            const currentAmount = getValues(receiveCryptoInput);
+            const currentAmount = getValues(sendCryptoInput);
             if (currentAmount && !isMax) {
                 const amountBig = new Bignumber(currentAmount);
                 if (amountBig.gte(0)) {
@@ -83,8 +83,8 @@ const ReceiveCryptoInput = () => {
                 clearErrors(fiatInput);
                 setMax(false);
             }}
-            state={errors[receiveCryptoInput] ? 'error' : undefined}
-            name={receiveCryptoInput}
+            state={errors[sendCryptoInput] ? 'error' : undefined}
+            name={sendCryptoInput}
             noTopLabel
             maxLength={MAX_LENGTH.AMOUNT}
             innerRef={register({
@@ -159,10 +159,10 @@ const ReceiveCryptoInput = () => {
                     }
                 },
             })}
-            bottomText={<InputError error={errors[receiveCryptoInput]} />}
-            innerAddon={<ReceiveCryptoSelect />}
+            bottomText={<InputError error={errors[sendCryptoInput]} />}
+            innerAddon={<SendCryptoSelect />}
         />
     );
 };
 
-export default ReceiveCryptoInput;
+export default SendCryptoInput;

--- a/packages/suite/src/views/wallet/coinmarket/exchange/components/ExchangeForm/Inputs/index.tsx
+++ b/packages/suite/src/views/wallet/coinmarket/exchange/components/ExchangeForm/Inputs/index.tsx
@@ -3,9 +3,9 @@ import React, { useEffect } from 'react';
 import styled from 'styled-components';
 import { invityApiSymbolToSymbol } from '@wallet-utils/coinmarket/coinmarketUtils';
 import { useCoinmarketExchangeFormContext } from '@wallet-hooks/useCoinmarketExchangeForm';
-import ReceiveCryptoInput from './ReceiveCryptoInput';
+import SendCryptoInput from './SendCryptoInput';
 import FiatInput from './FiatInput';
-import SendCryptoSelect from './SendCryptoSelect';
+import ReceiveCryptoSelect from './ReceiveCryptoSelect';
 import Buttons from './Buttons';
 
 const Wrapper = styled.div`
@@ -62,17 +62,17 @@ const Inputs = () => {
     const formattedToken = invityApiSymbolToSymbol(token);
     const tokenData = account.tokens?.find(t => t.symbol === formattedToken);
     useEffect(() => {
-        trigger(['receiveCryptoInput']);
+        trigger(['sendCryptoInput']);
     }, [amountLimits, trigger]);
 
     return (
         <Wrapper>
             <Top>
                 <LeftWrapper>
-                    <ReceiveCryptoInput />
+                    <SendCryptoInput />
                     <Line
                         color={
-                            errors.receiveCryptoInput || errors.fiatInput
+                            errors.sendCryptoInput || errors.fiatInput
                                 ? theme.TYPE_RED
                                 : theme.STROKE_GREY
                         }
@@ -83,7 +83,7 @@ const Inputs = () => {
                     <StyledIcon icon="TRANSFER" size={16} />
                 </MiddleWrapper>
                 <RightWrapper>
-                    <SendCryptoSelect />
+                    <ReceiveCryptoSelect />
                 </RightWrapper>
             </Top>
             <Buttons />


### PR DESCRIPTION
Refactoring because of wrongly named inputs in exchange, changing Send to Receive and vice versa. There is no change in the functionality.