### PR TITLE
Add Changelog check to CI

### DIFF
--- a/.github/workflows/changelog.yml
+++ b/.github/workflows/changelog.yml
@@ -1,0 +1,15 @@
+name: "Pull Request Workflow"
+on:
+  pull_request:
+      types: [opened, synchronize, reopened, ready_for_review, labeled, unlabeled]
+
+jobs:
+  # Enforces the update of a changelog file on every pull request
+  changelog:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+    - uses: dangoslen/changelog-enforcer@v2
+      with:
+        changeLogPath: 'CHANGELOG.md'
+        skipLabels: 'no Changelog'


### PR DESCRIPTION
This adds a [changelog reminder](https://github.com/marketplace/actions/changelog-reminder) into Github Actions which checks if CHANGELOG.md has been modified in the PR. If not the job fails. In case you wish not to add anything to Changelog (which should not be often) you can add the "no Changelog" label and the job passes then.

Examples:
- Success: https://github.com/tsusanka/trezor-suite/pull/3
- Fail: https://github.com/tsusanka/trezor-suite/pull/4
- Success thanks to label: https://github.com/tsusanka/trezor-suite/pull/5