### PR TITLE
Add Changelog check to CI

### DIFF
--- a/.github/workflows/changelog.yml
+++ b/.github/workflows/changelog.yml
@@ -1,0 +1,15 @@
+name: "Pull Request Workflow"
+on:
+  pull_request:
+    types: [opened, synchronize, reopened, ready_for_review, labeled, unlabeled]
+
+jobs:
+  # Enforces the update of a changelog file on every pull request
+  changelog:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: dangoslen/changelog-enforcer@v2
+        with:
+          changeLogPath: 'CHANGELOG.md'
+          skipLabels: 'no Changelog'

--- a/docs/SUMMARY.md
+++ b/docs/SUMMARY.md
@@ -13,6 +13,7 @@
   - [Suite-web e2e](tests/e2e-web.md)
 - [Miscellaneous](misc/index.md)
   - [Analytics](misc/analytics.md)
+  - [Changelog](misc/changelog.md)
   - [Desktop Updates](misc/desktop_updates.md)
   - [Desktop Logger](misc/desktop_logger.md)
   - [Feature Flags](misc/feature_flags.md)

--- a/docs/misc/changelog.md
+++ b/docs/misc/changelog.md
@@ -1,0 +1,9 @@
+# Changelog
+
+All important project changes must be added into the CHANGELOG.md file in the project's root directory. The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
+
+## CI check
+
+We have a Github Actions job which runs for every PR that checks if CHANGELOG.md has been modified. If not, the job fails.
+
+In the unlikely event of a PR not needing a Changelog entry, you can apply the "no Changelog" label and the job passes then.


### PR DESCRIPTION
This adds a [Changelog Enforcer](https://github.com/marketplace/actions/changelog-enforcer) into Github Actions which checks if CHANGELOG.md has been modified in the PR. If not the job fails. In case you wish not to add anything to Changelog (which should not be often) you can add the "no Changelog" label and the job passes then.

Examples:
- Success: https://github.com/tsusanka/trezor-suite/pull/3
- Fail: https://github.com/tsusanka/trezor-suite/pull/4
- Success thanks to label: https://github.com/tsusanka/trezor-suite/pull/5

Closes https://github.com/trezor/trezor-suite/issues/3390.