### PR TITLE
fix(storage): Check if IDB is supported before db operation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ### Changed
 
 ### Fixed
+- Check if IDB is supported before each operation (no idb support in FF incognito/tor browser)
 
 ## 21.2.1 [10th February 2021]
 

--- a/packages/suite-storage/src/native/index.ts
+++ b/packages/suite-storage/src/native/index.ts
@@ -23,6 +23,7 @@ class CommonDB<TDBStructure> {
     broadcastChannel!: any;
     onUpgrade!: OnUpgradeFunc<TDBStructure>;
     onDowngrade!: () => any;
+    supported!: boolean | undefined;
 
     constructor(
         dbName: string,
@@ -38,7 +39,7 @@ class CommonDB<TDBStructure> {
         this.version = version;
         this.onUpgrade = onUpgrade.bind(this);
         this.onDowngrade = onDowngrade.bind(this);
-
+        this.supported = false;
         // @ts-ignore
         this.db = null;
         // create global instance of broadcast channel
@@ -70,6 +71,11 @@ class CommonDB<TDBStructure> {
         //         }
         //     }
         // });
+    };
+
+    isSupported = (): Promise<boolean> => {
+        this.supported = false;
+        return Promise.resolve(false);
     };
 
     notify = (_store: StoreNames<TDBStructure>, _keys: any[]) => {};

--- a/packages/suite/src/actions/suite/__tests__/storageActions.test.ts
+++ b/packages/suite/src/actions/suite/__tests__/storageActions.test.ts
@@ -21,8 +21,6 @@ import fiatRatesReducer from '@wallet-reducers/fiatRatesReducer';
 import storageMiddleware from '@wallet-middlewares/storageMiddleware';
 import { getAccountTransactions, getAccountIdentifier } from '@wallet-utils/accountUtils';
 import { AppState } from '@suite-types';
-// in-memory implementation of indexedDB
-import 'fake-indexeddb/auto';
 import { SETTINGS } from '@suite/config/suite';
 
 const { getSuiteDevice, getWalletAccount, getWalletTransaction } = global.JestMocks;

--- a/packages/suite/src/actions/suite/storageActions.ts
+++ b/packages/suite/src/actions/suite/storageActions.ts
@@ -1,5 +1,4 @@
 import { db } from '@suite/storage';
-import SuiteDB from '@trezor/suite-storage';
 import { STORAGE } from './constants';
 import { Dispatch, GetState, AppState, TrezorDevice } from '@suite-types';
 import { Account } from '@wallet-types';
@@ -20,16 +19,19 @@ export type StorageAction =
 
 // send form drafts start
 
-export const saveDraft = (formState: FormState, accountKey: string) => {
+export const saveDraft = async (formState: FormState, accountKey: string) => {
+    if (!(await db.isSupported())) return;
     return db.addItem('sendFormDrafts', formState, accountKey, true);
 };
 
-export const removeDraft = (accountKey: string) => {
+export const removeDraft = async (accountKey: string) => {
+    if (!(await db.isSupported())) return;
     return db.removeItemByPK('sendFormDrafts', accountKey);
 };
 
 // eslint-disable-next-line require-await
 export const saveAccountDraft = (account: Account) => async (_: Dispatch, getState: GetState) => {
+    if (!(await db.isSupported())) return;
     const { drafts } = getState().wallet.send;
     const draft = drafts[account.key];
     if (draft) {
@@ -37,22 +39,26 @@ export const saveAccountDraft = (account: Account) => async (_: Dispatch, getSta
     }
 };
 
-export const removeAccountDraft = (account: Account) => {
+export const removeAccountDraft = async (account: Account) => {
+    if (!(await db.isSupported())) return Promise.resolve();
     return db.removeItemByPK('sendFormDrafts', account.key);
 };
 
 // send form drafts end
 
-export const saveDevice = (device: TrezorDevice, forceRemember?: true) => {
+export const saveDevice = async (device: TrezorDevice, forceRemember?: true) => {
+    if (!(await db.isSupported())) return;
     if (!device || !device.features || !device.state) return;
     return db.addItem('devices', serializeDevice(device, forceRemember), device.state, true);
 };
 
-export const removeAccount = (account: Account) => {
+export const removeAccount = async (account: Account) => {
+    if (!(await db.isSupported())) return;
     return db.removeItemByPK('accounts', [account.descriptor, account.symbol, account.deviceState]);
 };
 
 export const removeAccountTransactions = async (account: Account) => {
+    if (!(await db.isSupported())) return;
     await db.removeItemByIndex('txs', 'accountKey', [
         account.descriptor,
         account.symbol,
@@ -61,6 +67,7 @@ export const removeAccountTransactions = async (account: Account) => {
 };
 
 export const forgetDevice = (device: TrezorDevice) => async (_: Dispatch, getState: GetState) => {
+    if (!(await db.isSupported())) return;
     if (!device.state) return;
     const accounts = getState().wallet.accounts.filter(a => a.deviceState === device.state);
     const accountPromises = accounts.reduce((promises, account) => {
@@ -77,7 +84,8 @@ export const forgetDevice = (device: TrezorDevice) => async (_: Dispatch, getSta
     return promises;
 };
 
-export const saveAccounts = (accounts: Account[]) => {
+export const saveAccounts = async (accounts: Account[]) => {
+    if (!(await db.isSupported())) return;
     return db.addItems('accounts', accounts, true);
 };
 
@@ -88,7 +96,8 @@ interface AccountPart {
     descriptor: Account['descriptor'];
 }
 
-export const saveBuyTrade = (buyTrade: BuyTrade, account: AccountPart, date: string) => {
+export const saveBuyTrade = async (buyTrade: BuyTrade, account: AccountPart, date: string) => {
+    if (!(await db.isSupported())) return;
     return db.addItem(
         'coinmarketTrades',
         {
@@ -108,11 +117,12 @@ export const saveBuyTrade = (buyTrade: BuyTrade, account: AccountPart, date: str
     );
 };
 
-export const saveExchangeTrade = (
+export const saveExchangeTrade = async (
     exchangeTrade: ExchangeTrade,
     account: AccountPart,
     date: string,
 ) => {
+    if (!(await db.isSupported())) return;
     return db.addItem(
         'coinmarketTrades',
         {
@@ -132,18 +142,21 @@ export const saveExchangeTrade = (
     );
 };
 
-export const saveDiscovery = (discoveries: Discovery[]) => {
+export const saveDiscovery = async (discoveries: Discovery[]) => {
+    if (!(await db.isSupported())) return;
     return db.addItems('discovery', discoveries, true);
 };
 
-export const saveGraph = (graphData: GraphData[]) => {
+export const saveGraph = async (graphData: GraphData[]) => {
+    if (!(await db.isSupported())) return;
     return db.addItems('graph', graphData, true);
 };
 
-export const saveAccountTransactions = (account: Account) => (
+export const saveAccountTransactions = (account: Account) => async (
     _dispatch: Dispatch,
     getState: GetState,
 ) => {
+    if (!(await db.isSupported())) return Promise.resolve();
     const allTxs = getState().wallet.transactions.transactions;
     const accTxs = allTxs[account.key] || [];
 
@@ -157,7 +170,8 @@ export const saveAccountTransactions = (account: Account) => (
     return db.addItems('txs', orderedTxs, true);
 };
 
-export const removeAccountGraph = (account: Account) => {
+export const removeAccountGraph = async (account: Account) => {
+    if (!(await db.isSupported())) return;
     return db.removeItemByIndex('graph', 'accountKey', [
         account.descriptor,
         account.symbol,
@@ -170,6 +184,7 @@ export const rememberDevice = (
     remember: boolean,
     forcedRemember?: true,
 ) => async (dispatch: Dispatch, getState: GetState) => {
+    if (!(await db.isSupported())) return;
     if (!device || !device.features || !device.state) return;
     if (!remember) {
         return dispatch(forgetDevice(device));
@@ -203,6 +218,7 @@ export const rememberDevice = (
 };
 
 export const saveWalletSettings = () => async (_dispatch: Dispatch, getState: GetState) => {
+    if (!(await db.isSupported())) return;
     await db.addItem(
         'walletSettings',
         {
@@ -213,17 +229,23 @@ export const saveWalletSettings = () => async (_dispatch: Dispatch, getState: Ge
     );
 };
 
-export const removeFiatRate = (symbol: string) => (_dispatch: Dispatch, _getState: GetState) => {
+export const removeFiatRate = (symbol: string) => async (
+    _dispatch: Dispatch,
+    _getState: GetState,
+) => {
+    if (!(await db.isSupported())) return;
     // TODO: just to be safe store and delete by compound index [symbol, mainNetworkSymbol]
     // check if it's fine to have mainNetworkSymbol undefined
     return db.removeItemByPK('fiatRates', symbol);
 };
 
-export const saveFiatRates = () => (_dispatch: Dispatch, getState: GetState) => {
+export const saveFiatRates = () => async (_dispatch: Dispatch, getState: GetState) => {
+    if (!(await db.isSupported())) return;
     return db.addItems('fiatRates', getState().wallet.fiat.coins, true);
 };
 
-export const saveSuiteSettings = () => (_dispatch: Dispatch, getState: GetState) => {
+export const saveSuiteSettings = () => async (_dispatch: Dispatch, getState: GetState) => {
+    if (!(await db.isSupported())) return;
     const { suite } = getState();
     db.addItem(
         'suiteSettings',
@@ -243,7 +265,9 @@ export const saveSuiteSettings = () => (_dispatch: Dispatch, getState: GetState)
     );
 };
 
-export const saveAnalytics = () => (_dispatch: Dispatch, getState: GetState) => {
+export const saveAnalytics = () => async (_dispatch: Dispatch, getState: GetState) => {
+    if (!(await db.isSupported())) return;
+
     const { analytics } = getState();
     db.addItem(
         'analytics',
@@ -259,7 +283,9 @@ export const saveAnalytics = () => (_dispatch: Dispatch, getState: GetState) => 
 /**
  * save general metadata settings
  */
-export const saveMetadata = () => (_dispatch: Dispatch, getState: GetState) => {
+export const saveMetadata = () => async (_dispatch: Dispatch, getState: GetState) => {
+    if (!(await db.isSupported())) return;
+
     const { metadata } = getState();
     db.addItem(
         'metadata',
@@ -270,6 +296,8 @@ export const saveMetadata = () => (_dispatch: Dispatch, getState: GetState) => {
 };
 
 export const removeDatabase = () => async (dispatch: Dispatch, getState: GetState) => {
+    if (!(await db.isSupported())) return;
+
     const rememberedDevices = getState().devices.filter(d => d.remember);
     // forget all remembered devices
     rememberedDevices.forEach(d => {
@@ -283,12 +311,13 @@ export const removeDatabase = () => async (dispatch: Dispatch, getState: GetStat
     );
 };
 
-export const loadSuiteSettings = () => {
+export const loadSuiteSettings = async () => {
+    if (!(await db.isSupported())) return;
     return db.getItemByPK('suiteSettings', 'suite');
 };
 
 export const loadStorage = () => async (dispatch: Dispatch, getState: GetState) => {
-    const isDBAvailable = await SuiteDB.isDBAvailable();
+    const isDBAvailable = await db.isSupported();
 
     if (!isDBAvailable) {
         // console.warn('IndexedDB not supported');

--- a/packages/suite/src/support/tests/setupJest.ts
+++ b/packages/suite/src/support/tests/setupJest.ts
@@ -5,7 +5,8 @@
 import { Device, Features } from 'trezor-connect';
 import { TrezorDevice } from '@suite-types';
 import { Account, WalletAccountTransaction } from '@wallet-types';
-
+// in-memory implementation of indexedDB
+import 'fake-indexeddb/auto';
 /**
  * Generate wallet account
  * @param {Partial<Account>} [account]


### PR DESCRIPTION
IDB is not supported in firefox incognito mode/tor browser. It doesn't affect the user (no one expects that remembered device will be persisted in incognito), but outputs tons of errors in console/sentry.

Fun fact, there is a bug report about this somewhere in mozilla repo for years now. They are planning to allow idb in incognito (cause otherwise shady websites can easily detect that you are using incognito). I've never assumed it would take so long that we'll manage to release public version of suite before it.

With this PR, before each action in storage actions we first check if idb is supported, if not then we are not even trying.