### PR TITLE
test(e2e): blackout expectedly changing parts of snapshots

### DIFF
--- a/packages/integration-tests/projects/suite-web/support/commands.ts
+++ b/packages/integration-tests/projects/suite-web/support/commands.ts
@@ -44,8 +44,9 @@ declare global {
             prefixedVisit: typeof prefixedVisit;
             getConfirmActionOnDeviceModal: typeof getConfirmActionOnDeviceModal;
             resetDb: typeof resetDb;
-            // todo: better types
-            matchImageSnapshot: (options?: any) => Chainable<any>;
+            // todo: better types, this is not 100% correct as this fn may get more args from 
+            // cypress-image-snapshot lib
+            matchImageSnapshot: typeof cy['screenshot'];
             connectDevice: (
                 device?: Partial<Device>,
                 features?: Partial<Features>,

--- a/packages/integration-tests/projects/suite-web/tests/firmware/firmware.test.ts
+++ b/packages/integration-tests/projects/suite-web/tests/firmware/firmware.test.ts
@@ -16,7 +16,17 @@ describe('Firmware', () => {
         cy.getTestElement('@notification/update-firmware/button').click();
 
         // initial screen
-        // cy.getTestElement('@firmware').matchImageSnapshot('initial'); there is a changelog which should be covered with black rectangle (there is a command for it somewheree)
+        // to make screenshots stable, make changelog fixed height
+        cy.getTestElement('@firmware/initial/changelog').invoke('css', 'height', '300px')
+        cy.getTestElement('@firmware')
+            .matchImageSnapshot('initial', {
+                // to make screenshot test stable we need to blackout all parts that change expectedly
+                blackout: [
+                    '[data-test="@firmware/initial/changelog"]',
+                    '[data-test="@firmware/initial/heading/version"]',
+                    '[data-test="@firmware/initial/subheading/version"]',
+                ]
+            });
         cy.getTestElement('@firmware/continue-button').click();
 
         // check seed screen

--- a/packages/suite/src/components/firmware/Initial.tsx
+++ b/packages/suite/src/components/firmware/Initial.tsx
@@ -63,7 +63,7 @@ const Heading = () => {
         return (
             <HeadingWrapper>
                 <Translation id="TR_UPDATE_AVAILABLE" />
-                <Version>
+                <Version data-test="@firmware/initial/heading/version">
                     <Translation
                         id="TR_DEVICE_FIRMWARE_VERSION"
                         values={{ firmware: getFwVersion(device) }}
@@ -111,13 +111,15 @@ const Body = () => {
 
     return (
         <BodyWrapper>
-            <H2 isGreen>v{firmwareRelease.release.version.join('.')} has been released!</H2>
+            <H2 isGreen data-test="@firmware/initial/subheading/version">
+                v{firmwareRelease.release.version.join('.')} has been released!
+            </H2>
             <P>
                 <Translation id="FIRMWARE_UPDATE_AVAILABLE_DESC" />
             </P>
 
             {Object.keys(logsCustomObject).length > 0 && (
-                <ChangesSummary>
+                <ChangesSummary data-test="@firmware/initial/changelog">
                     {Object.keys(logsCustomObject).map(version => {
                         const log = logsCustomObject[version];
                         return (


### PR DESCRIPTION
contribution to https://github.com/trezor/trezor-suite/issues/3388

things that are expected to change over time should not be screenshot-tested of course. 

In general, one needs to find a balance between when these screenshots actually help and when they are slowing you down. 

You should now regenerate new screenshots. There is a job in CI that does this @wendys-cats 
Please let me know if anything is not clear