### PR TITLE
Deploy signed binaries to staging

### DIFF
--- a/ci/packages/suite-web.yml
+++ b/ci/packages/suite-web.yml
@@ -207,3 +207,28 @@ suite-web deploy staging-suite:
     - ./scripts/s3sync.sh staging-suite
   tags:
     - deploy
+
+suite-desktop codesign deploy staging-suite:
+  stage: deploy to staging
+  needs:
+    - suite-desktop build mac codesign
+    - suite-desktop build linux codesign
+    - suite-desktop build windows codesign
+  environment:
+    name: ${CI_BUILD_REF_NAME}-staging-suite
+    url: ${STAGING_SUITE_SERVER_URL}
+  before_script: []
+  only:
+    refs:
+      - codesign
+  when: manual
+  script:
+    - source ${STAGING_SUITE_DEPLOY_KEYFILE}
+    - mkdir -p packages/suite-web/build/static/desktop
+    - 'rsync --delete -va "${DESKTOP_APP_NAME}"-*.AppImage ./packages/suite-web/build/static/desktop || :'
+    - 'rsync --delete -va "${DESKTOP_APP_NAME}"-*.dmg ./packages/suite-web/build/static/desktop || :'
+    - 'rsync --delete -va "${DESKTOP_APP_NAME}"-*.exe ./packages/suite-web/build/static/desktop || :'
+    - cd packages/suite-web
+    - ./scripts/s3sync.sh staging-suite
+  tags:
+    - deploy


### PR DESCRIPTION
The idea is that first we would run the regular deploy job from the release branch and then we would run this one overriding the binaries. We could definitely do better but it seems fine for now. I have not tested yet, I want to check if there isn't something i am not aware of? cc @prusnak 