### PR TITLE
blockchain-link@1.0.16

### DIFF
--- a/packages/blockchain-link/CHANGELOG.md
+++ b/packages/blockchain-link/CHANGELOG.md
@@ -1,7 +1,9 @@
-# Unreleased
+# 1.0.16
 
 #### changes
 - Fixed an issue where account with non-zero balance could be marked as empty (eth)
+- Pending ETH transaction fee calculated from `ethereumSpecific` field
+- Added missing types (data) to `ethereumSpecific` field
 
 # 1.0.15
 

--- a/packages/blockchain-link/package.json
+++ b/packages/blockchain-link/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@trezor/blockchain-link",
-    "version": "1.0.15",
+    "version": "1.0.16",
     "author": "Trezor <info@trezor.io>",
     "homepage": "https://github.com/trezor/trezor-suite/packages/blockchain-link",
     "description": "High-level javascript interface for blockchain communication",

--- a/packages/blockchain-link/src/types/blockbook.ts
+++ b/packages/blockchain-link/src/types/blockbook.ts
@@ -106,6 +106,7 @@ export interface Transaction {
     ethereumSpecific?: {
         status: number;
         nonce: number;
+        data?: string;
         gasLimit: number;
         gasUsed?: number;
         gasPrice: string;

--- a/packages/blockchain-link/src/types/common.ts
+++ b/packages/blockchain-link/src/types/common.ts
@@ -67,13 +67,7 @@ export interface Transaction {
     targets: Target[];
     tokens: TokenTransfer[];
     rbf?: boolean;
-    ethereumSpecific?: {
-        status: number;
-        nonce: number;
-        gasLimit: number;
-        gasUsed?: number;
-        gasPrice: string;
-    };
+    ethereumSpecific?: BlockbookTransaction['ethereumSpecific'];
     details: TransactionDetail;
 }
 

--- a/packages/blockchain-link/src/workers/blockbook/utils.ts
+++ b/packages/blockchain-link/src/workers/blockbook/utils.ts
@@ -201,6 +201,13 @@ export const transformTransaction = (
         });
     }
 
+    let fee = tx.fees;
+    if (tx.ethereumSpecific && !tx.ethereumSpecific.gasUsed) {
+        fee = new BigNumber(tx.ethereumSpecific.gasPrice)
+            .times(tx.ethereumSpecific.gasLimit)
+            .toString();
+    }
+
     return {
         type,
 
@@ -210,7 +217,7 @@ export const transformTransaction = (
         blockHash: tx.blockHash,
 
         amount,
-        fee: tx.fees,
+        fee,
 
         targets: targets.filter(t => typeof t === 'object').map(t => transformTarget(t, incoming)),
         tokens,

--- a/packages/blockchain-link/tests/unit/fixtures/utils.ts
+++ b/packages/blockchain-link/tests/unit/fixtures/utils.ts
@@ -699,7 +699,7 @@ export default {
         },
 
         {
-            description: 'ETH: sent',
+            description: 'ETH: sent with final fee',
             descriptor: 'A',
             tx: {
                 vin: [
@@ -714,12 +714,47 @@ export default {
                 ],
                 ethereumSpecific: {
                     status: 1,
+                    gasLimit: 21000,
+                    gasUsed: 21000,
+                    gasPrice: 3,
                 },
                 ...FEES,
             },
             parsed: {
                 type: 'sent',
                 amount: '90',
+                fee: '10', // fee from blockbook, not calculated from ethereumSpecific
+                targets: [
+                    {
+                        addresses: ['B'],
+                    },
+                ],
+            },
+        },
+        {
+            description: 'ETH: pending with not final fee',
+            descriptor: 'A',
+            tx: {
+                vin: [
+                    {
+                        addresses: ['A'],
+                    },
+                ],
+                vout: [
+                    {
+                        addresses: ['B'],
+                    },
+                ],
+                ethereumSpecific: {
+                    status: 1,
+                    gasLimit: 21000,
+                    gasPrice: '3',
+                },
+                ...FEES,
+            },
+            parsed: {
+                type: 'sent',
+                fee: '63000', // fee calculated from ethereumSpecific
                 targets: [
                     {
                         addresses: ['B'],


### PR DESCRIPTION
blockbook returns `fee: 0` for pending ETH transactions
calculate it manually from `ethereumSpecific` data

plus added missing type in `ethereumSpecific` object