### PR TITLE
Feat: ETH rbf transactions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - OpenGraph meta tags for Suite (web version)
 - Option to hide dashboard graph
 - Instructions for verifying linux binary (landing page)
+- Ethereum replace-by-fee feature
 
 ### Changed
 - Don't allow to run multiple instances of Suite desktop app

--- a/packages/suite/src/actions/wallet/send/sendFormEthereumActions.ts
+++ b/packages/suite/src/actions/wallet/send/sendFormEthereumActions.ts
@@ -243,10 +243,14 @@ export const signTransaction = (
         return Math.max(value, tx.ethereumSpecific.nonce + 1);
     }, 0);
     const pendingNonceBig = new BigNumber(pendingNonce);
-    const nonce =
+    let nonce =
         pendingNonceBig.gt(0) && pendingNonceBig.gt(account.misc.nonce)
             ? pendingNonceBig.toString()
             : account.misc.nonce;
+
+    if (formValues.rbfParams && typeof formValues.rbfParams.ethereumNonce === 'number') {
+        nonce = formValues.rbfParams.ethereumNonce.toString();
+    }
 
     // transform to TrezorConnect.ethereumSignTransaction params
     const transaction = prepareEthereumTransaction({

--- a/packages/suite/src/components/suite/modals/TransactionDetail/components/BasicDetails/index.tsx
+++ b/packages/suite/src/components/suite/modals/TransactionDetail/components/BasicDetails/index.tsx
@@ -9,7 +9,12 @@ import {
 } from '@suite-components';
 import { getDateWithTimeZone } from '@suite-utils/date';
 import { WalletAccountTransaction, Network } from '@wallet-types';
-import { getFeeRate, getBlockExplorerUrl, isTxFinal } from '@wallet-utils/transactionUtils';
+import {
+    getFeeRate,
+    getBlockExplorerUrl,
+    isTxFinal,
+    getTxIcon,
+} from '@wallet-utils/transactionUtils';
 import { getFeeUnits } from '@wallet-utils/sendFormUtils';
 
 const Wrapper = styled.div`
@@ -200,14 +205,20 @@ const BasicDetails = ({ tx, confirmations, network }: Props) => {
                     <NestedIconWrapper>
                         <Icon
                             size={14}
-                            color={theme.TYPE_DARK_GREY}
-                            icon={tx.type === 'recv' ? 'RECEIVE' : 'SEND'}
+                            color={tx.type === 'failed' ? theme.TYPE_RED : theme.TYPE_DARK_GREY}
+                            icon={getTxIcon(tx.type)}
                         />
                     </NestedIconWrapper>
                 </MainIconWrapper>
                 <TxStatus>
                     <TxSentStatus>
-                        {transactionStatus} {assetSymbol}
+                        {tx.type === 'failed' ? (
+                            <Translation id="TR_FAILED_TRANSACTION" />
+                        ) : (
+                            <>
+                                {transactionStatus} {assetSymbol}
+                            </>
+                        )}
                     </TxSentStatus>
                 </TxStatus>
 

--- a/packages/suite/src/components/suite/modals/TransactionDetail/components/BasicDetails/index.tsx
+++ b/packages/suite/src/components/suite/modals/TransactionDetail/components/BasicDetails/index.tsx
@@ -154,6 +154,10 @@ const Timestamp = styled.span`
 const StyledIcon = styled(Icon)`
     margin-right: 6px;
 `;
+const IconPlaceholder = styled.span`
+    min-width: 10px;
+    margin-right: 6px;
+`;
 const LinkIcon = styled(Icon)`
     margin-left: 6px;
 `;
@@ -290,6 +294,40 @@ const BasicDetails = ({ tx, confirmations, network }: Props) => {
                                 />
                             </ConfirmationStatus>
                         </Value>
+                    </>
+                )}
+
+                {/* Ethereum */}
+                {tx.ethereumSpecific && (
+                    <>
+                        <Title>
+                            <StyledIcon icon="GAS" size={10} />
+                            <Translation id="TR_GAS_LIMIT" />
+                        </Title>
+                        <Value>{tx.ethereumSpecific.gasLimit}</Value>
+                        <Title>
+                            <StyledIcon icon="GAS" size={10} />
+                            <Translation id="TR_GAS_USED" />
+                        </Title>
+                        <Value>
+                            {tx.ethereumSpecific.gasUsed ? (
+                                tx.ethereumSpecific.gasUsed
+                            ) : (
+                                <Translation id="TR_BUY_STATUS_PENDING" />
+                            )}
+                        </Value>
+                        <Title>
+                            <StyledIcon icon="GAS" size={10} />
+                            <Translation id="TR_GAS_PRICE" />
+                        </Title>
+                        <Value>{`${tx.ethereumSpecific.gasPrice} ${getFeeUnits(
+                            'ethereum',
+                        )}`}</Value>
+                        <Title>
+                            <IconPlaceholder>#</IconPlaceholder>
+                            <Translation id="TR_NONCE" />
+                        </Title>
+                        <Value>{tx.ethereumSpecific.nonce}</Value>
                     </>
                 )}
             </Grid>

--- a/packages/suite/src/components/suite/modals/TransactionDetail/components/ChangeFee/index.tsx
+++ b/packages/suite/src/components/suite/modals/TransactionDetail/components/ChangeFee/index.tsx
@@ -101,7 +101,10 @@ const ChangeFee = (props: Props & { showChained: () => void }) => {
     const contextValues = useRbf(props);
     if (!contextValues.account) return null; // context without account, should never happen
     const { tx } = props;
-    const hasChangeAddress = tx.rbfParams?.changeAddress;
+    const { networkType } = contextValues.account;
+    const feeRate =
+        networkType === 'bitcoin' ? `${tx.rbfParams?.feeRate} ${getFeeUnits(networkType)}` : null;
+    const hasChangeAddress = tx.rbfParams?.changeAddress || networkType !== 'bitcoin';
 
     return (
         <RbfContext.Provider value={contextValues}>
@@ -114,9 +117,7 @@ const ChangeFee = (props: Props & { showChained: () => void }) => {
                             </Title>
                             <Content>
                                 <RateWrapper>
-                                    <Rate>
-                                        {tx.rbfParams?.feeRate} {getFeeUnits('bitcoin')}
-                                    </Rate>
+                                    <Rate>{feeRate}</Rate>
                                     <Amount>
                                         <StyledCryptoAmount>
                                             <FormattedCryptoAmount
@@ -144,7 +145,6 @@ const ChangeFee = (props: Props & { showChained: () => void }) => {
                         {contextValues.chainedTxs.length > 0 && (
                             <AffectedTransactions showChained={props.showChained} />
                         )}
-                        {!tx.rbfParams?.changeAddress && <NoChange />}
                     </Box>
                 ) : (
                     <Box>

--- a/packages/suite/src/components/suite/modals/TransactionDetail/index.tsx
+++ b/packages/suite/src/components/suite/modals/TransactionDetail/index.tsx
@@ -132,16 +132,19 @@ const TransactionDetail = (props: Props) => {
                                         >
                                             <Translation id="TR_BUMP_FEE" />
                                         </Button>
-                                        <Button
-                                            variant="tertiary"
-                                            onClick={() => {
-                                                setFinalize(true);
-                                                setSection('CHANGE_FEE');
-                                                setTab(undefined);
-                                            }}
-                                        >
-                                            <Translation id="TR_FINALIZE_TX" />
-                                        </Button>
+                                        {network?.networkType === 'bitcoin' && (
+                                            // finalize button only possible in BTC rbf
+                                            <Button
+                                                variant="tertiary"
+                                                onClick={() => {
+                                                    setFinalize(true);
+                                                    setSection('CHANGE_FEE');
+                                                    setTab(undefined);
+                                                }}
+                                            >
+                                                <Translation id="TR_FINALIZE_TX" />
+                                            </Button>
+                                        )}
                                     </>
                                 )}
                             </Right>

--- a/packages/suite/src/components/wallet/TransactionItem/components/TransactionHeading/index.tsx
+++ b/packages/suite/src/components/wallet/TransactionItem/components/TransactionHeading/index.tsx
@@ -92,6 +92,17 @@ const TransactionHeading = ({
         );
     }
 
+    if (transaction.type === 'failed') {
+        amount = (
+            <CryptoAmount>
+                <StyledHiddenPlaceholder>
+                    <Sign value="neg" />
+                    {transaction.fee} {symbol}
+                </StyledHiddenPlaceholder>
+            </CryptoAmount>
+        );
+    }
+
     // TODO: intl once the structure and all combinations are decided
     let heading = null;
     // const symbol = transaction.symbol.toUpperCase();
@@ -104,6 +115,8 @@ const TransactionHeading = ({
         heading = isPending ? `Receiving ${symbol}` : `Received ${symbol}`;
     } else if (transaction.type === 'self') {
         heading = isPending ? `Sending ${symbol} to myself` : `Sent ${symbol} to myself`;
+    } else if (transaction.type === 'failed') {
+        heading = <Translation id="TR_FAILED_TRANSACTION" />;
     } else {
         heading = <Translation id="TR_UNKNOWN_TRANSACTION" />;
     }

--- a/packages/suite/src/components/wallet/TransactionItem/components/TransactionTypeIcon/index.tsx
+++ b/packages/suite/src/components/wallet/TransactionItem/components/TransactionTypeIcon/index.tsx
@@ -2,6 +2,7 @@ import React from 'react';
 import styled from 'styled-components';
 import { WalletAccountTransaction } from '@wallet-types';
 import { Icon, useTheme, IconProps } from '@trezor/components';
+import { getTxIcon } from '@wallet-utils/transactionUtils';
 
 const IconsWrapper = styled.div`
     position: relative;
@@ -20,14 +21,14 @@ interface Props extends Omit<IconProps, 'icon'> {
 
 const TransactionTypeIcon = ({ type, isPending, ...rest }: Props) => {
     const theme = useTheme();
-    let icon = null;
-    if (type === 'sent' || type === 'self') {
-        icon = <Icon icon="SEND" color={theme.TYPE_LIGHT_GREY} size={24} {...rest} />;
-    } else if (type === 'recv') {
-        icon = <Icon icon="RECEIVE" color={theme.TYPE_LIGHT_GREY} size={24} {...rest} />;
-    } else {
-        icon = <Icon icon="QUESTION" color={theme.TYPE_LIGHT_GREY} size={24} {...rest} />;
-    }
+    const icon = (
+        <Icon
+            icon={getTxIcon(type)}
+            color={type === 'failed' ? theme.TYPE_RED : theme.TYPE_LIGHT_GREY}
+            size={24}
+            {...rest}
+        />
+    );
 
     if (isPending) {
         return (

--- a/packages/suite/src/components/wallet/TransactionItem/index.tsx
+++ b/packages/suite/src/components/wallet/TransactionItem/index.tsx
@@ -162,7 +162,7 @@ const TransactionItem = React.memo((props: Props) => {
                 onMouseLeave={() => setNestedItemIsHovered(false)}
                 onClick={() => openTxDetailsModal()}
             >
-                <TransactionTypeIcon type={transaction.type} isPending={props.isPending} />
+                <TransactionTypeIcon type={type} isPending={props.isPending} />
             </TxTypeIconWrapper>
 
             <Content>
@@ -185,7 +185,7 @@ const TransactionItem = React.memo((props: Props) => {
                         <TransactionTimestamp transaction={transaction} />
                     </TimestampWrapper>
                     <TargetsWrapper>
-                        {!isUnknown && !isTokenTransaction && (
+                        {!isUnknown && type !== 'failed' && !isTokenTransaction && (
                             <>
                                 {previewTargets.map((t, i) => (
                                     // render first n targets, n = DEFAULT_LIMIT

--- a/packages/suite/src/hooks/wallet/__fixtures__/useSendForm.ts
+++ b/packages/suite/src/hooks/wallet/__fixtures__/useSendForm.ts
@@ -901,13 +901,13 @@ export const setMax = [
             composedLevels: {
                 normal: {
                     type: 'final',
-                    fee: '69300000000000',
+                    fee: '63000000000000',
                     totalSpent: '10000000000000000000',
                 },
                 custom: undefined,
             },
             formValues: {
-                outputs: [{ amount: '9.9999307', fiat: '10.00' }],
+                outputs: [{ amount: '9.999937', fiat: '10.00' }],
             },
         },
     },
@@ -933,7 +933,7 @@ export const setMax = [
             composedLevels: {
                 normal: {
                     type: 'final',
-                    fee: '69300000000000',
+                    fee: '63000000000000',
                     totalSpent: '1000', // tokens
                 },
                 custom: undefined,
@@ -1568,7 +1568,7 @@ export const feeChange = [
                     estimateFeeCalls: 1,
                     formValues: {
                         selectedFee: 'custom' as const,
-                        feePerUnit: '3.3',
+                        feePerUnit: '3',
                         feeLimit: '21000', // default
                         estimatedFeeLimit: undefined,
                     },
@@ -1582,7 +1582,7 @@ export const feeChange = [
                     estimateFeeCalls: 2,
                     formValues: {
                         outputs: [{ amount: '1.1' }],
-                        feePerUnit: '3.3',
+                        feePerUnit: '3',
                         feeLimit: '21000',
                         estimatedFeeLimit: '41000',
                     },
@@ -1602,7 +1602,7 @@ export const feeChange = [
                     formValues: {
                         outputs: [{ amount: '1.1' }],
                         selectedFee: 'custom' as const,
-                        feePerUnit: '3.3',
+                        feePerUnit: '3',
                         feeLimit: '210001',
                         estimatedFeeLimit: '21009',
                     },
@@ -1660,7 +1660,7 @@ export const feeChange = [
                 result: {
                     formValues: {
                         selectedFee: 'custom' as const,
-                        feePerUnit: '3.3',
+                        feePerUnit: '3',
                         feeLimit: '21a',
                         estimatedFeeLimit: '21009',
                     },
@@ -1692,8 +1692,8 @@ export const feeChange = [
                     composedLevels: {
                         normal: {
                             type: 'final',
-                            fee: '69300000000000',
-                            feePerByte: '3.3',
+                            fee: '63000000000000',
+                            feePerByte: '3',
                             feeLimit: '21000', // default
                         },
                         custom: undefined, // no custom level build

--- a/packages/suite/src/hooks/wallet/__fixtures__/useSendForm.ts
+++ b/packages/suite/src/hooks/wallet/__fixtures__/useSendForm.ts
@@ -1583,7 +1583,22 @@ export const feeChange = [
                     formValues: {
                         outputs: [{ amount: '1.1' }],
                         feePerUnit: '3',
-                        feeLimit: '21000',
+                        feeLimit: '41000', // feeLimit is switched automatically
+                        estimatedFeeLimit: '41000',
+                    },
+                },
+            },
+            // trigger "gas limit below recommended" error
+            {
+                type: 'input',
+                element: 'feeLimit',
+                value: '{backspace}',
+                result: {
+                    estimateFeeCalls: 2,
+                    formValues: {
+                        outputs: [{ amount: '1.1' }],
+                        feePerUnit: '3',
+                        feeLimit: '4100',
                         estimatedFeeLimit: '41000',
                     },
                     errors: {
@@ -1596,14 +1611,14 @@ export const feeChange = [
             {
                 type: 'input',
                 element: 'feeLimit',
-                value: '1',
+                value: '0',
                 result: {
                     estimateFeeCalls: 3,
                     formValues: {
                         outputs: [{ amount: '1.1' }],
                         selectedFee: 'custom' as const,
                         feePerUnit: '3',
-                        feeLimit: '210001',
+                        feeLimit: '21009', // feeLimit is switched automatically again
                         estimatedFeeLimit: '21009',
                     },
                     composedLevels: {
@@ -1614,7 +1629,7 @@ export const feeChange = [
                         },
                         custom: {
                             type: 'final',
-                            feeLimit: '210001', // custom composed tx with higher level
+                            feeLimit: '41000', // custom composed tx with higher level (as requested)
                             estimatedFeeLimit: '21009',
                         },
                     },

--- a/packages/suite/src/hooks/wallet/form/useFees.ts
+++ b/packages/suite/src/hooks/wallet/form/useFees.ts
@@ -109,11 +109,10 @@ export const useFees = ({
             estimatedFeeLimitRef.current = estimatedFeeLimit;
             if (estimatedFeeLimit) {
                 // re validate feeLimit
-                setValue('feeLimit', feeLimitRef.current, { shouldValidate: true });
-                // TODO: switch only if current limit is lower
-                // feeLimitRef.current = estimatedFeeLimit;
-
-                // setValue('feeLimit', estimatedFeeLimit);
+                // setValue('feeLimit', feeLimitRef.current, { shouldValidate: true });
+                // switch to recommended fee limit
+                feeLimitRef.current = estimatedFeeLimit;
+                setValue('feeLimit', estimatedFeeLimit, { shouldValidate: true });
             }
         }
     }, [estimatedFeeLimit, setValue]);

--- a/packages/suite/src/reducers/wallet/transactionReducer.ts
+++ b/packages/suite/src/reducers/wallet/transactionReducer.ts
@@ -17,10 +17,13 @@ export interface RbfTransactionParams {
         address: string;
         amount: string;
         formattedAmount: string;
+        token?: string;
     }[];
     changeAddress?: AccountAddress; // original change address
     feeRate: string; // original fee rate
     baseFee: number; // original fee
+    ethereumNonce?: number;
+    ethereumData?: string;
 }
 
 export interface WalletAccountTransaction extends AccountTransaction {

--- a/packages/suite/src/support/messages.ts
+++ b/packages/suite/src/support/messages.ts
@@ -2728,6 +2728,14 @@ const definedMessages = defineMessages({
         id: 'TR_GAS_LIMIT',
         defaultMessage: 'Gas limit',
     },
+    TR_GAS_USED: {
+        id: 'TR_GAS_USED',
+        defaultMessage: 'Gas used',
+    },
+    TR_NONCE: {
+        id: 'TR_NONCE',
+        defaultMessage: 'Nonce',
+    },
     TR_SEND_GAS_LIMIT_TOOLTIP: {
         id: 'TR_SEND_GAS_LIMIT_TOOLTIP',
         defaultMessage:

--- a/packages/suite/src/support/messages.ts
+++ b/packages/suite/src/support/messages.ts
@@ -2508,6 +2508,10 @@ const definedMessages = defineMessages({
         defaultMessage: 'Unknown transaction',
         id: 'TR_UNKNOWN_TRANSACTION',
     },
+    TR_FAILED_TRANSACTION: {
+        defaultMessage: 'Failed transaction',
+        id: 'TR_FAILED_TRANSACTION',
+    },
     TR_UNKNOWN_ERROR_SEE_CONSOLE: {
         defaultMessage: 'Unknown error. See console logs for details.',
         id: 'TR_UNKNOWN_ERROR_SEE_CONSOLE',

--- a/packages/suite/src/utils/wallet/sendFormUtils.ts
+++ b/packages/suite/src/utils/wallet/sendFormUtils.ts
@@ -5,7 +5,7 @@ import Common from 'ethereumjs-common';
 import { Transaction, TxData } from 'ethereumjs-tx';
 import { fromWei, padLeft, toHex, toWei } from 'web3-utils';
 import { ERC20_TRANSFER } from '@wallet-constants/sendForm';
-import { amountToSatoshi, networkAmountToSatoshi } from '@wallet-utils/accountUtils';
+import { amountToSatoshi, networkAmountToSatoshi, formatAmount } from '@wallet-utils/accountUtils';
 import { Network, Account, CoinFiatRates } from '@wallet-types';
 import { FormState, FeeInfo, EthTransactionData, ExternalOutput } from '@wallet-types/sendForm';
 
@@ -76,6 +76,9 @@ const getSerializedErc20Transfer = (token: TokenInfo, to: string, amount: string
     return `0x${ERC20_TRANSFER}${erc20recipient}${erc20amount}`;
 };
 
+// TrezorConnect.blockchainEstimateFee for ethereum
+// NOTE:
+// - amount cannot be "0" (send max calculation), use at least 1 unit.
 export const getEthereumEstimateFeeParams = (
     to: string,
     token?: TokenInfo,
@@ -86,7 +89,11 @@ export const getEthereumEstimateFeeParams = (
         return {
             to: token.address,
             value: '0x0',
-            data: getSerializedErc20Transfer(token, to, amount || '0'),
+            data: getSerializedErc20Transfer(
+                token,
+                to,
+                amount || formatAmount('1', token.decimals), // use at least 1 smallest unit of token (satoshi)
+            ),
         };
     }
     return {

--- a/packages/suite/src/utils/wallet/sendFormUtils.ts
+++ b/packages/suite/src/utils/wallet/sendFormUtils.ts
@@ -163,9 +163,12 @@ export const getFeeLevels = (networkType: Network['networkType'], feeInfo: FeeIn
     });
 
     if (networkType === 'ethereum') {
+        // convert wei to gwei and floor value to avoid decimals
         return levels.map(level => ({
             ...level,
-            feePerUnit: fromWei(level.feePerUnit, 'gwei'),
+            feePerUnit: new BigNumber(fromWei(level.feePerUnit, 'gwei'))
+                .integerValue(BigNumber.ROUND_FLOOR)
+                .toString(),
             feeLimit: level.feeLimit,
         }));
     }


### PR DESCRIPTION
part https://github.com/trezor/trezor-suite/issues/3268
fix https://github.com/trezor/trezor-suite/issues/3331

## QA scenarios
https://suite.corp.sldev.cz/suite-web/feat/rbf-eth/web/accounts/#/trop/0
It should work in the same way as RBF in bitcoin with two exceptions:
1. every pending transaction is replaceable (every tx is rbf)
2. there is no possibility to "finalize" transaction, ETH transactions are not final by design

### What to test
- Ropsten, ETH, ETC
- send normal (eth) tx, try to bump it
- send erc20 tx, try to bump it
- send eth tx with data, try to bump it
- watch gas limit, gas price
- watch replaced transactions in blockbook explorer (open it from TxDetail before and after bump)
- on Ropsten you have to be quick, blocks are mined quite often
- check for Bitcoin RBF implementation regresion (there should not be any, yet just to be sure, Testnet check should be enough)




### TODO:
- [x] update trezor-connect (fixed eth pending fee value)
- [x] gasLimit/gasUsed/nonce icons in TxDetail modal @matejzak
- [x] failed transaction in account overview @matejzak 
![Screenshot from 2021-02-17 20-13-13](https://user-images.githubusercontent.com/3435913/108325410-572f1280-71c9-11eb-96d9-d5c6dc79d625.png)

- [x] failed transaction in tx detail modal
![Screenshot from 2021-02-18 09-04-37](https://user-images.githubusercontent.com/3435913/108325362-4aaaba00-71c9-11eb-9ee3-04f6b816b7bb.png)
