### PR TITLE
fix(suite-web): disallow Google Chrome to offer the page translation

### DIFF
--- a/packages/suite-web/pages/_document.tsx
+++ b/packages/suite-web/pages/_document.tsx
@@ -37,6 +37,7 @@ export default class MyDocument extends Document {
             // @ts-ignore TODO: should be fixed in newer React
             <Html lang="en" translate="no">
                 <Head>
+                    <meta name="google" content="notranslate" />
                     <meta charSet="utf-8" />
                     <script
                         type="text/javascript"


### PR DESCRIPTION
- trying to disallow Google Chrome to offer the page translation that can manipulate DOM (I believe manipulating DOM of the webpage can be a security risk)

should fix #3434, but I am not able to simulate it and test it properly