### PR TITLE
Instruct git to automerge conflicts in CHANGELOG.md via union

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,3 +1,4 @@
+# lfs files
 packages/suite-data/files/bin/bridge/linux-*/trezord filter=lfs diff=lfs merge=lfs -text
 packages/suite-data/files/bin/bridge/mac-*/trezord filter=lfs diff=lfs merge=lfs -text
 packages/suite-data/files/bin/bridge/win-*/trezord.exe filter=lfs diff=lfs merge=lfs -text
@@ -8,3 +9,6 @@ packages/suite-data/files/bin/tor/mac-*/tor filter=lfs diff=lfs merge=lfs -text
 packages/suite-data/files/bin/tor/win-*/*.dll filter=lfs diff=lfs merge=lfs -text
 packages/suite-data/files/bin/tor/win-*/tor.exe filter=lfs diff=lfs merge=lfs -text
 packages/integration-tests/projects/suite-web/snapshots/** filter=lfs diff=lfs merge=lfs -text
+
+# Changelog to be merged via union always.
+CHANGELOG.md merge=union


### PR DESCRIPTION
https://github.com/trezor/trezor-firmware/pull/1475 for Suite. Github does not support it, so it will still render Changelog conflicts in  Github PRs but at least when you are rebasing locally you do not have to worry about Changelog. 