### PR TITLE
Add fixup check to Github Actions

### DIFF
--- a/.github/workflows/fixup_check.yml
+++ b/.github/workflows/fixup_check.yml
@@ -1,0 +1,11 @@
+name: Git Checks
+
+on: [pull_request]
+
+jobs:
+  block-fixup:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2.0.0
+      - name: Block Fixup Commit Merge
+        uses: 13rac1/block-fixup-merge-action@v2.0.0


### PR DESCRIPTION
This Github action checks whether given PR contains fixup or squash commits and fails if so. This should prevent any accidental merges of fixup! commits such has happened in https://github.com/trezor/trezor-suite/pull/3398 for example.

Note that this means that the CI might fail during a code review (but not Gitlab, that's why it is a Github action) when the author is adding some (fixup) commits. I find it okay, but feel free to close this PR if you find that distracting.

Taken from [Github Actions marketplace](https://github.com/marketplace/actions/block-fixup-commit-merge). Example: https://github.com/tsusanka/trezor-firmware/pull/6
