### PR TITLE
fix(suite-desktop): enforce single instance policy

### DIFF
--- a/packages/suite-desktop/src-electron/app.ts
+++ b/packages/suite-desktop/src-electron/app.ts
@@ -77,8 +77,25 @@ const init = async () => {
     });
 };
 
-app.name = APP_NAME; // overrides @trezor/suite-desktop app name in menu
-app.on('ready', init);
+// https://www.electronjs.org/docs/all#apprequestsingleinstancelock
+const singleInstance = app.requestSingleInstanceLock();
+if (!singleInstance) {
+    logger.warn('main', 'Second instance detected, quitting...');
+    app.quit();
+} else {
+    logger.info('main', 'Application starting');
+
+    app.on('second-instance', () => {
+        // Someone tried to run a second instance, we should focus our window.
+        if (mainWindow) {
+            if (mainWindow.isMinimized()) mainWindow.restore();
+            mainWindow.focus();
+        }
+    });
+
+    app.name = APP_NAME; // overrides @trezor/suite-desktop app name in menu
+    app.on('ready', init);
+}
 
 app.on('before-quit', () => {
     if (!mainWindow) return;


### PR DESCRIPTION
should resolve https://github.com/trezor/trezor-suite/issues/3438
and should help with https://github.com/trezor/trezor-suite/issues/3431 (2nd opened instance would timeout on "Loading takes too long")

I basically copy pasted electron docs. @keraf pretty please have a look if I put it at the correct spot (probably not) or if I have broke something because of it 😁 

briefly "tested" (we have not test anything besides opening multiple instances) on macos (by me) and on windows by @sorooris 