### PR TITLE
chore(libs): update systeminformation to latest

### DIFF
--- a/packages/suite-desktop/package.json
+++ b/packages/suite-desktop/package.json
@@ -151,7 +151,7 @@
         "electron-store": "^5.1.1",
         "electron-updater": "^4.3.5",
         "node-fetch": "^2.6.1",
-        "systeminformation": "^4.34.7"
+        "systeminformation": "^5.4.0"
     },
     "devDependencies": {
         "@sentry/browser": "^5.29.2",
@@ -159,7 +159,7 @@
         "@types/electron-localshortcut": "^3.1.0",
         "@types/next-redux-wrapper": "^3.0.0",
         "@types/node-fetch": "^2.5.7",
-        "@types/react": "^17.0.0",        
+        "@types/react": "^17.0.0",
         "@types/react-dom": "^17.0.0",
         "@types/react-redux": "^7.1.7",
         "@zeit/next-workers": "^1.0.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -21126,10 +21126,10 @@ symbol.prototype.description@^1.0.0:
     has-symbols "^1.0.1"
     object.getownpropertydescriptors "^2.1.0"
 
-systeminformation@^4.34.7:
-  version "4.34.7"
-  resolved "https://registry.yarnpkg.com/systeminformation/-/systeminformation-4.34.7.tgz#8b4a00c44781349905881c95dded8bafe7aae47f"
-  integrity sha512-cS3FiSZasFgVNjO9CP3aZmTO2VHwXKG+JN6Z85nWRyOzxRMNbZe7Xzwrewp42hj+OPMC3hk7MrAFyu/qLM65Mw==
+systeminformation@^5.4.0:
+  version "5.5.0"
+  resolved "https://registry.yarnpkg.com/systeminformation/-/systeminformation-5.5.0.tgz#58b65a862074c15dfda087ff786bd9416625b080"
+  integrity sha512-xFOCgmvbV2aUXpEheFKNKt5y40XeJZvxUkm8qfVWu3RsW9F4eb/CEW3zjY6t4RKl2wAPXywXpKvLmjuQu06+Rg==
 
 table@^6.0.3, table@^6.0.4:
   version "6.0.7"


### PR DESCRIPTION
Reported by dependabot. I have no idea if it will not break anything (tests pass though).

After freeze I will also connect Snyk, because it seems dependabot can't open PRs automatically, so let's see if Snyk can.
