### PR TITLE
fix(transactions): add length limit on search

### DIFF
--- a/packages/suite/src/views/wallet/transactions/components/TransactionList/components/Actions/components/SearchAction/index.tsx
+++ b/packages/suite/src/views/wallet/transactions/components/TransactionList/components/Actions/components/SearchAction/index.tsx
@@ -145,6 +145,7 @@ const SearchAction = ({ account, search, setSearch, setSelectedPage }: Props) =>
                     value={search}
                     addonAlign="left"
                     textIndent={[16, 14]}
+                    maxLength={512}
                     noError
                     noTopLabel
                     clearButton


### PR DESCRIPTION
Fixes #3428 

Not the fix initially discussed (checking how many search terms are inserted rather than length) as I guess it's a bit overkill to do it that way. Limit is 512 which hopefully should cover the more extreme cases too. Any feedback on this limit?