### PR TITLE
fix(suite): correct removing from stack in logReducer

### DIFF
--- a/packages/suite/src/reducers/suite/logReducer.ts
+++ b/packages/suite/src/reducers/suite/logReducer.ts
@@ -35,7 +35,7 @@ const MAX_ENTRIES = 200;
 const addToStack = (stack: LogEntry[], entry: LogEntry) => {
     stack.push(entry);
     if (stack.length > MAX_ENTRIES) {
-        stack.pop();
+        stack.shift();
     }
 };
 


### PR DESCRIPTION
remove first item after limit is reached