### PR TITLE
fix(suite): add wallet number to every device instance

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ### Changed
 
 ### Fixed
+- Wallet numbering
 
 ## 21.3.1 [to be released 10th March 2021]
 

--- a/packages/suite/src/actions/suite/suiteActions.ts
+++ b/packages/suite/src/actions/suite/suiteActions.ts
@@ -32,7 +32,7 @@ export type SuiteAction =
           hidden: boolean;
           alwaysOnDevice?: boolean;
       }
-    | { type: typeof SUITE.AUTH_DEVICE; payload: TrezorDevice; state: string }
+    | { type: typeof SUITE.AUTH_DEVICE; payload: TrezorDevice; state: string; walletNumber: number }
     | { type: typeof SUITE.AUTH_FAILED; payload: TrezorDevice }
     | { type: typeof SUITE.REQUEST_AUTH_CONFIRM }
     | { type: typeof SUITE.RECEIVE_AUTH_CONFIRM; payload: TrezorDevice; success: boolean }
@@ -268,7 +268,6 @@ export const createDeviceInstance = (device: TrezorDevice, useEmptyPassphrase = 
             ...device,
             useEmptyPassphrase,
             instance: deviceUtils.getNewInstanceNumber(getState().devices, device),
-            walletNumber: deviceUtils.getNewWalletNumber(getState().devices, device),
         },
     });
 };
@@ -470,6 +469,7 @@ export const authorizeDevice = () => async (
             type: SUITE.AUTH_DEVICE,
             payload: device,
             state,
+            walletNumber: deviceUtils.getNewWalletNumber(getState().devices, device),
         });
         return true;
     }

--- a/packages/suite/src/reducers/suite/deviceReducer.ts
+++ b/packages/suite/src/reducers/suite/deviceReducer.ts
@@ -253,13 +253,15 @@ const changePassphraseMode = (
  * @param {string} state
  * @returns
  */
-const authDevice = (draft: State, device: TrezorDevice, state: string) => {
+const authDevice = (draft: State, device: TrezorDevice, state: string, walletNumber: number) => {
     // only acquired devices
     if (!device || !device.features) return;
     const index = deviceUtils.findInstanceIndex(draft, device);
     if (!draft[index]) return;
     // update state
     draft[index].state = state;
+    draft[index].walletNumber = walletNumber;
+
     delete draft[index].authFailed;
 };
 
@@ -292,10 +294,6 @@ const authConfirm = (draft: State, device: TrezorDevice, success: boolean) => {
     // update state
     draft[index].authConfirm = !success;
     draft[index].available = success;
-
-    if (!draft[index].walletNumber) {
-        draft[index].walletNumber = deviceUtils.getNewWalletNumber(draft, draft[index]);
-    }
 };
 
 /**
@@ -431,7 +429,7 @@ const deviceReducer = (state: State = initialState, action: Action): State => {
                 changePassphraseMode(draft, action.payload, action.hidden, action.alwaysOnDevice);
                 break;
             case SUITE.AUTH_DEVICE:
-                authDevice(draft, action.payload, action.state);
+                authDevice(draft, action.payload, action.state, action.walletNumber);
                 break;
             case SUITE.AUTH_FAILED:
                 authFailed(draft, action.payload);


### PR DESCRIPTION
close https://github.com/trezor/trezor-suite/issues/3277
I feel it would be cleaner if I created new action and case in device reducer to set walletNumber field, instead hacking it into the auth process. But it was already hacky before, so you decide 😁 

tl;dr of problem and fix:
- before: walletNumber was set only in case of adding another instance, it wasn't triggered for first wallet instance. Then there was a fallback in reducer ( on `RECEIVE_AUTH_CONFIRM`), that I guess should solve "first instance" problem. But this action is triggered only when accessing empty passphrase (and confirming that user indeed wants to use an empty passphrase. Still it doesn't feel right to generate some dynamic value inside the reducer (there is something about it in redux docs).

- after: set walletNumber in AUTH_DEVICE (action for setting wallet passphrase/state), which is triggered ofc on both, first wallet and also additional wallet instances. walletNumber is set also for standard wallet, and in this case the number is incorrect, but right now it doesn't matter since we are not using the number at all in standard wallet

todo: fix e2e which is searching for correct element using now changed `walletNumber` 😩 