### PR TITLE
fix(suite): pass enhanced txs in TRANSACTION.ADD (fix rates in xrp txs)

### DIFF
--- a/packages/suite/src/actions/wallet/transactionActions.ts
+++ b/packages/suite/src/actions/wallet/transactionActions.ts
@@ -5,7 +5,7 @@ import {
     formatNetworkAmount,
     getRbfPendingAccount,
 } from '@wallet-utils/accountUtils';
-import { findTransactions } from '@wallet-utils/transactionUtils';
+import { enhanceTransaction, findTransactions } from '@wallet-utils/transactionUtils';
 import * as accountActions from '@wallet-actions/accountActions';
 import { TRANSACTION } from '@wallet-actions/constants';
 import { SETTINGS } from '@suite-config';
@@ -16,7 +16,7 @@ import { formatData } from '@wallet-utils/exportTransactions';
 export type TransactionAction =
     | {
           type: typeof TRANSACTION.ADD;
-          transactions: AccountTransaction[];
+          transactions: WalletAccountTransaction[];
           account: Account;
           page?: number;
       }
@@ -40,7 +40,7 @@ export const add = (
     page?: number,
 ): TransactionAction => ({
     type: TRANSACTION.ADD,
-    transactions,
+    transactions: transactions.map(tx => enhanceTransaction(tx, account)),
     account,
     page,
 });
@@ -177,12 +177,7 @@ export const fetchTransactions = (
         dispatch({
             type: TRANSACTION.FETCH_SUCCESS,
         });
-        dispatch({
-            type: TRANSACTION.ADD,
-            account: updatedAccount,
-            transactions,
-            page,
-        });
+        dispatch(add(transactions, updatedAccount, page));
         // updates the marker/page object for the account
         dispatch(accountActions.update(account, result.payload));
 


### PR DESCRIPTION
close https://github.com/trezor/trezor-suite/issues/3528
tx.blockTime for ripple txs is not really unix timestamp until it goes through our enhanceTransaction util func 

https://github.com/trezor/trezor-suite/blob/ea9bdfd26becaa9a31e624ba634b6259692e1485/packages/suite/src/utils/wallet/transactionUtils.ts#L488

(this is probably another thing to refactor into the blockchain-link instead of doing it in suite)
 
Because fetching of historical rates is triggered on `TRANSACTION.ADD` where non-enhanced txs were passed, it resulted in downloading fiat rate for incorrect timestamps. As a fix I moved calling `enhanceTransaction` from reducer to the `TRANSACTION.ADD` action.

hopefully nothing breaks because of it 😁 