### PR TITLE
fix(suite): fix incorrect time format

### DIFF
--- a/packages/suite/src/components/suite/FormattedDate/index.tsx
+++ b/packages/suite/src/components/suite/FormattedDate/index.tsx
@@ -31,8 +31,8 @@ const defaultDateFormat = {
 const defaultTimeFormat = {
     hour: 'numeric',
     minute: 'numeric',
-    hour12: false,
-};
+    hourCycle: 'h23',
+} as const;
 
 const FormattedDate = (props: Props) => {
     return (


### PR DESCRIPTION
close https://github.com/trezor/trezor-suite/issues/3531

oh boy, looks like chrome starting with version 80 has h24 hourCycle as default. https://support.google.com/chrome/thread/29828561?hl=en
