### PR TITLE
feat(suite-desktop): add renderer crash recovery system

### DIFF
--- a/packages/suite-desktop/src-electron/libs/constants.ts
+++ b/packages/suite-desktop/src-electron/libs/constants.ts
@@ -7,6 +7,7 @@ export const MODULES = [
     'event-logging/app',
     'event-logging/contents',
     // Standard modules
+    'crash-recover',
     'menu',
     'shortcuts',
     'request-filter',

--- a/packages/suite-desktop/src-electron/modules/crash-recover.ts
+++ b/packages/suite-desktop/src-electron/modules/crash-recover.ts
@@ -1,0 +1,31 @@
+import { app, dialog } from 'electron';
+
+// Reasons for prompting a restart
+const unexpectedReasons = [
+    'crashed', // Process crashed
+    'oom', // Out of memory
+    'launch-failure', // Process couldn't launch
+];
+
+const init = ({ mainWindow }: Dependencies) => {
+    // Check if the renderer process got unexpectedly terminated
+    mainWindow.webContents.on('render-process-gone', (_, { reason }) => {
+        if (unexpectedReasons.includes(reason)) {
+            // Note: No need to log this, the event logger already takes care of that
+            const result = dialog.showMessageBoxSync(mainWindow, {
+                type: 'error',
+                message: `Render process terminated unexpectedly (reason: ${reason}).`,
+                buttons: ['Quit', 'Restart'],
+            });
+
+            // Restart
+            if (result === 1) {
+                app.relaunch();
+            }
+
+            app.exit();
+        }
+    });
+};
+
+export default init;

--- a/packages/suite-desktop/src-electron/modules/event-logging/contents.ts
+++ b/packages/suite-desktop/src-electron/modules/event-logging/contents.ts
@@ -13,7 +13,7 @@ const init = ({ mainWindow }: Dependencies) => {
     });
 
     mainWindow.webContents.on('render-process-gone', (_, { reason }) => {
-        logger.error('content', `Render process gone (reason: ${reason}`);
+        logger.error('content', `Render process gone (reason: ${reason})`);
     });
 
     let unresponsiveStart = 0;


### PR DESCRIPTION
Mitigates #3534 by not leaving the user in a state where the app cannot be used at all.

When the renderer process unexpectedly quits, an error dialog is shown prompting the user to either quit the app or restart it.