### PR TITLE
fix(suite): switchDuplicatedDevice race condition

### DIFF
--- a/packages/suite/src/actions/suite/suiteActions.ts
+++ b/packages/suite/src/actions/suite/suiteActions.ts
@@ -542,7 +542,9 @@ export const switchDuplicatedDevice = (device: TrezorDevice, duplicate: TrezorDe
     });
 
     // switch to existing wallet
-    dispatch(selectDevice(duplicate));
+    // NOTE: await is important. otherwise `forgetDevice` action will be resolved first leading to race condition:
+    // forgetDevice > suiteMiddleware > handleDeviceDisconnect > selectDevice (first available)
+    await dispatch(selectDevice(duplicate));
     // remove stateless instance
     dispatch(forgetDevice(device));
 };


### PR DESCRIPTION
fix https://github.com/trezor/trezor-suite/issues/3517

even if `selectDevice` action is not an async it needs to be resolved before `forgetDevice` action
`selectDevice` is in fact post processed by `suiteMiddleware` and `UPDATE_SELECTED_DEVICE` is not called before `FORGET`

it leads to post-processing `FORGET` action which decides that first available device should be selected because currently selected is forgotten
