### PR TITLE
fix(sentry): return event in beforeSend hook

### DIFF
--- a/packages/suite/src/config/suite/sentry.ts
+++ b/packages/suite/src/config/suite/sentry.ts
@@ -14,12 +14,13 @@ export default {
     ],
     release: process.env.COMMITHASH,
     environment: process.env.SUITE_TYPE,
-    beforeSend(event, hint) {
+    beforeSend: (event, hint) => {
         const error = hint?.syntheticException;
         if (error?.message?.match(fiatRatesRe)) {
             // discard failed fiat rate fetch on TOR
             event.fingerprint = ['FiatRatesFetchError'];
             return null;
         }
+        return event;
     },
 } as BrowserOptions;


### PR DESCRIPTION
I noticed a lack of error reporting from latest released version so I investigated and found out that I forgot to return event in sentry's before-send hook resulting in filtering out all reports.

Weird that typescript haven't caught that,  the function is properly typed and should return either Event or null 🤷‍♂️ 