### PR TITLE
fix(labeling): incorrectly shortened labels in Firefox

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ### Fixed
 - Discreet mode fixed in Wallet modal and chart hover tooltip
 - Long account labels in transaction review form
+- Labels incorrectly shortened in Firefox
 
 ## 21.3.1 [10th March 2021]
 

--- a/packages/suite/src/components/suite/Labeling/components/Metadata/index.tsx
+++ b/packages/suite/src/components/suite/Labeling/components/Metadata/index.tsx
@@ -14,7 +14,9 @@ import { withDropdown } from './withDropdown';
 const LabelDefaultValue = styled.div`
     width: 0;
     display: inline-block;
-    transition: all 0.6s;
+    transition: width 0.6s, visibility 0.3s, opacity 0.3s;
+    visibility: hidden;
+    opacity: 0;
 
     &::before {
         content: ': ';
@@ -75,6 +77,8 @@ const LabelContainer = styled.div`
 
         ${LabelDefaultValue} {
             width: 200px;
+            visibility: visible;
+            opacity: 1;
         }
     }
 `;


### PR DESCRIPTION
fix: #3549

Note: 
Firefox doesn't handle text ellipsis well in our case (zero width element inside label which has overflow hidden + text ellipsis property) so I tried to hack it somehow via `visibility` and `opacity` properties and I tried to improve hover animations as well. It's still not perfect but it's definitely better now I guess.