### PR TITLE
fix(send): check network features while toggling options

### DIFF
--- a/packages/suite/src/hooks/wallet/useSendForm.ts
+++ b/packages/suite/src/hooks/wallet/useSendForm.ts
@@ -142,6 +142,7 @@ export const useSendForm = (props: UseSendFormProps): SendContextValues => {
     const sendFormUtils = useSendFormFields({
         ...useFormMethods,
         fiatRates: state.fiatRates,
+        network: state.network,
     });
 
     // declare sendFormCompose, sub-hook of useSendForm

--- a/packages/suite/src/hooks/wallet/useSendFormFields.ts
+++ b/packages/suite/src/hooks/wallet/useSendFormFields.ts
@@ -11,6 +11,7 @@ import { isEnabled as isFeatureEnabled } from '@suite-utils/features';
 
 type Props = UseFormMethods<FormState> & {
     fiatRates: UseSendFormState['fiatRates'];
+    network: UseSendFormState['network'];
 };
 
 // This hook should be used only as a sub-hook of `useSendForm`
@@ -21,6 +22,7 @@ export const useSendFormFields = ({
     setValue,
     clearErrors,
     fiatRates,
+    network,
 }: Props) => {
     const calculateFiat = useCallback(
         (outputIndex: number, amount?: string) => {
@@ -102,7 +104,10 @@ export const useSendFormFields = ({
     };
 
     const toggleOption = (option: FormOptions) => {
-        if (!isFeatureEnabled('RBF') && option === 'bitcoinRBF') {
+        if (
+            option === 'bitcoinRBF' &&
+            (!isFeatureEnabled('RBF') || !network.features?.includes('rbf'))
+        ) {
             // do not use RBF if disabled
             return;
         }


### PR DESCRIPTION
it ~~is~~ was possible to enable rbf in currently not supported networks because of missing check.
RBF can be enabled as a general feature but it doesnt mean that it is available in current network

fix: https://github.com/trezor/trezor-suite/issues/3539