### PR TITLE
fix(ci): exit on yarn install fail

### DIFF
--- a/ci/scripts/check_lockfile.sh
+++ b/ci/scripts/check_lockfile.sh
@@ -2,6 +2,7 @@
 
 # This file exists because as of yarn@1.12.3, --frozen-lockfile is completely
 # broken when combined with Yarn workspaces. See https://github.com/yarnpkg/yarn/issues/6291
+set -euxo pipefail
 
 CKSUM_BEFORE=$(cksum yarn.lock)
 echo "checksum before $CKSUM_BEFORE"


### PR DESCRIPTION
I encountered a case where `yarn install` failed, but the job on gitlab was all green because the script returns error code only on checksum mismatch

Don't laugh I haven't touched bash in years 😁 