### PR TITLE
fix: P2PKH was misspelled as P2PHK in a handful of areas

### DIFF
--- a/packages/suite/src/components/suite/modals/AddAccount/components/NetworkInternal.tsx
+++ b/packages/suite/src/components/suite/modals/AddAccount/components/NetworkInternal.tsx
@@ -3,7 +3,7 @@ import styled from 'styled-components';
 import { P } from '@trezor/components';
 import { Network } from '@wallet-types';
 import { Translation, ExternalLink } from '@suite-components';
-import { WIKI_BECH32_URL, WIKI_P2SH_URL, WIKI_P2PHK_URL } from '@suite-constants/urls';
+import { WIKI_BECH32_URL, WIKI_P2SH_URL, WIKI_P2PKH_URL } from '@suite-constants/urls';
 import { getBip43Shortcut } from '@wallet-utils/accountUtils';
 import { ExtendedMessageDescriptor } from '@suite-types';
 
@@ -21,7 +21,7 @@ const NetworkInternal = ({ network, accountTypes }: Props) => {
     if (!accountTypes || accountTypes.length <= 1) return null;
     const bip43 = getBip43Shortcut(network.bip44);
     let accountTypeDesc: ExtendedMessageDescriptor['id'] = 'TR_ACCOUNT_DETAILS_TYPE_P2PKH';
-    let accountTypeUrl = WIKI_P2PHK_URL;
+    let accountTypeUrl = WIKI_P2PKH_URL;
     if (bip43 === 'bech32') {
         accountTypeDesc = 'TR_ACCOUNT_DETAILS_TYPE_BECH32';
         accountTypeUrl = WIKI_BECH32_URL;

--- a/packages/suite/src/constants/suite/urls.ts
+++ b/packages/suite/src/constants/suite/urls.ts
@@ -45,7 +45,7 @@ export const WIKI_XPUB_URL =
     'https://wiki.trezor.io/User_manual:Displaying_account_public_key_(XPUB)';
 export const WIKI_BECH32_URL = 'https://wiki.trezor.io/Bech32';
 export const WIKI_P2SH_URL = 'https://wiki.trezor.io/P2SH';
-export const WIKI_P2PHK_URL = 'https://wiki.trezor.io/P2PHK_address';
+export const WIKI_P2PKH_URL = 'https://wiki.trezor.io/P2PKH';
 export const WIKI_ADVANCED_RECOVERY = 'https://wiki.trezor.io/User_manual:Advanced_recovery';
 export const WIKI_UDEV_RULES = 'https://wiki.trezor.io/Udev_rules';
 export const WIKI_TOR = 'https://wiki.trezor.io/Glossary:Tor';

--- a/packages/suite/src/utils/wallet/__fixtures__/accountUtils.ts
+++ b/packages/suite/src/utils/wallet/__fixtures__/accountUtils.ts
@@ -415,9 +415,9 @@ export const getBip43Shortcut = [
         result: 'p2sh',
     },
     {
-        description: 'p2phk',
+        description: 'p2pkh',
         path: "m/44'/0'/0'",
-        result: 'p2phk',
+        result: 'p2pkh',
     },
     {
         description: 'unknown',

--- a/packages/suite/src/utils/wallet/accountUtils.ts
+++ b/packages/suite/src/utils/wallet/accountUtils.ts
@@ -98,7 +98,7 @@ export const getBip43Shortcut = (path: string) => {
         case `49'`:
             return 'p2sh';
         case `44'`:
-            return 'p2phk';
+            return 'p2pkh';
         default:
             return 'unknown';
     }

--- a/packages/suite/src/views/wallet/details/index.tsx
+++ b/packages/suite/src/views/wallet/details/index.tsx
@@ -12,7 +12,7 @@ import {
     WIKI_XPUB_URL,
     WIKI_BECH32_URL,
     WIKI_P2SH_URL,
-    WIKI_P2PHK_URL,
+    WIKI_P2PKH_URL,
 } from '@suite-constants/urls';
 import { CARD_PADDING_SIZE } from '@suite-constants/layout';
 
@@ -55,7 +55,7 @@ const Details = () => {
     const bip43 = getBip43Shortcut(account.path);
     let accountTypeDesc: ExtendedMessageDescriptor['id'] = 'TR_ACCOUNT_DETAILS_TYPE_P2PKH';
     let accountTypeShortcut: ExtendedMessageDescriptor['id'] = 'TR_ACCOUNT_TYPE_P2PKH';
-    let accountTypeUrl = WIKI_P2PHK_URL;
+    let accountTypeUrl = WIKI_P2PKH_URL;
     if (bip43 === 'bech32') {
         accountTypeDesc = 'TR_ACCOUNT_DETAILS_TYPE_BECH32';
         accountTypeShortcut = 'TR_ACCOUNT_TYPE_BECH32';


### PR DESCRIPTION
This updates a handful of misspellings of the P2PKH acronym in the code base.
I recursively grepped this repo. I think I got them all.
There remains one instance of the misspelling on the https://wiki.trezor.io/P2PKH page. I couldn't find a quick way to make that update.