### PR TITLE
refactor(invity): compose/sign transaction in exchange and spend crypto

### DIFF
--- a/packages/suite/src/hooks/wallet/useCoinmarketExchangeForm.ts
+++ b/packages/suite/src/hooks/wallet/useCoinmarketExchangeForm.ts
@@ -148,7 +148,9 @@ export const useCoinmarketExchangeForm = (props: Props): ExchangeFormContextValu
 
     // react-hook-form reset, set default values
     useEffect(() => {
-        reset(state?.formValues);
+        if (state) {
+            reset(state?.formValues);
+        }
     }, [reset, state]);
 
     const { isLoading: isComposing, composeRequest, composedLevels, onFeeLevelChange } = useCompose(
@@ -206,7 +208,10 @@ export const useCoinmarketExchangeForm = (props: Props): ExchangeFormContextValu
     };
 
     const typedRegister = useCallback(<T>(rules?: T) => register(rules), [register]);
-    const isLoading = !exchangeInfo?.exchangeList || exchangeInfo?.exchangeList.length === 0;
+    const isLoading =
+        !exchangeInfo?.exchangeList ||
+        exchangeInfo?.exchangeList.length === 0 ||
+        !state?.formValues.outputs[0].address;
     const noProviders =
         exchangeInfo?.exchangeList?.length === 0 || !exchangeInfo?.sellSymbols.has(account.symbol);
 

--- a/packages/suite/src/views/wallet/coinmarket/exchange/components/ExchangeForm/Inputs/Buttons/index.tsx
+++ b/packages/suite/src/views/wallet/coinmarket/exchange/components/ExchangeForm/Inputs/Buttons/index.tsx
@@ -5,7 +5,7 @@ import { Translation } from '@suite-components';
 import styled from 'styled-components';
 import { useCoinmarketExchangeFormContext } from '@wallet-hooks/useCoinmarketExchangeForm';
 import { formatLabel } from '@wallet-utils/coinmarket/exchangeUtils';
-import { CRYPTO_INPUT, CRYPTO_TOKEN } from '@wallet-types/coinmarketExchangeForm';
+import { CRYPTO_INPUT, CRYPTO_TOKEN, FIAT_INPUT } from '@wallet-types/coinmarketExchangeForm';
 
 const Wrapper = styled.div`
     display: flex;
@@ -49,6 +49,7 @@ const Bottom = () => {
         getValues,
         setValue,
         updateFiatValue,
+        clearErrors,
     } = useCoinmarketExchangeFormContext();
     const tokenAddress = getValues(CRYPTO_TOKEN);
     const tokenData = account.tokens?.find(t => t.address === tokenAddress);
@@ -66,6 +67,7 @@ const Bottom = () => {
                   .toString();
         setValue(CRYPTO_INPUT, amount);
         updateFiatValue(amount);
+        clearErrors([FIAT_INPUT, CRYPTO_INPUT]);
         composeRequest();
     };
 
@@ -78,6 +80,7 @@ const Bottom = () => {
                 <Button
                     onClick={() => {
                         setValue('setMaxOutputId', 0);
+                        clearErrors([FIAT_INPUT, CRYPTO_INPUT]);
                         composeRequest();
                     }}
                 >


### PR DESCRIPTION
Fixes #3579.
The fix consist of clearing errors on ratio button press and also a small change in initialization of the form as clicking on the ratio buttons too early after the form was still loading caused amounts to be reset.