### PR TITLE
fix(suite): missing space between the device name and an account name when sending tx

### DIFF
--- a/packages/suite/src/components/suite/Labeling/components/Account/index.tsx
+++ b/packages/suite/src/components/suite/Labeling/components/Account/index.tsx
@@ -60,13 +60,13 @@ const Account = ({ account }: Props) => {
         const accountDevice = accountUtils.findAccountDevice(accounts[0], devices);
         if (accountDevice) {
             return (
-                <>
+                <span>
                     <WalletLabeling
                         device={accountDevice}
                         useDeviceLabel={!deviceUtils.isSelectedDevice(device, accountDevice)}
                     />{' '}
                     <TabularNums>{accountLabel}</TabularNums>
-                </>
+                </span>
             );
         }
     }


### PR DESCRIPTION
fixes #3530