### PR TITLE
fix(onboarding): add webusb pairing option after device is restarted …

### DIFF
--- a/packages/suite/src/components/firmware/FirmwareProgress.tsx
+++ b/packages/suite/src/components/firmware/FirmwareProgress.tsx
@@ -1,16 +1,28 @@
 import React from 'react';
+import styled from 'styled-components';
 import { getTextForStatus, getDescriptionForStatus } from '@firmware-utils';
-import { Translation } from '@suite-components';
+import { Translation, WebusbButton } from '@suite-components';
+import { Button } from '@trezor/components';
 import { Loaders } from '@onboarding-components';
-import { useDevice, useFirmware } from '@suite-hooks';
+import { useDevice, useFirmware, useSelector } from '@suite-hooks';
 import { InitImg, P, H2 } from '@firmware-components';
+import { isWebUSB } from '@suite-utils/transport';
+
+const ButtonWrapper = styled.div`
+    margin-top: 16px;
+`;
 
 const Body = () => {
     const { device } = useDevice();
     const { status, prevDevice } = useFirmware();
+    const { transport } = useSelector(state => ({
+        transport: state.suite.transport,
+    }));
+    const webUsbTransport = isWebUSB(transport);
 
     const statusText = getTextForStatus(status);
-    const statusDescription = getDescriptionForStatus(status);
+    const statusDescription = getDescriptionForStatus(status, webUsbTransport);
+
     return (
         <>
             <InitImg
@@ -27,6 +39,19 @@ const Body = () => {
                         <P>
                             <Translation id={statusDescription} />
                         </P>
+                    )}
+                    {status === 'wait-for-reboot' && webUsbTransport && (
+                        // Device needs to be paired twice when using web usb transport
+                        // Once in bootloader mode and once in normal mode. Without 2nd pairing step would get stuck at waiting for reboot,
+                        // because Suite won't detect restarted device till it is paired again.
+                        // That's why after restarting the device we need to allow user to pair it again.
+                        <ButtonWrapper>
+                            <WebusbButton ready>
+                                <Button icon="SEARCH" variant="primary">
+                                    <Translation id="TR_CHECK_FOR_DEVICES" />
+                                </Button>
+                            </WebusbButton>
+                        </ButtonWrapper>
                     )}
                 </>
             )}

--- a/packages/suite/src/support/messages.ts
+++ b/packages/suite/src/support/messages.ts
@@ -5462,6 +5462,10 @@ const definedMessages = defineMessages({
         defaultMessage:
             'It seems you are running multiple instances of the app. If you are using Suite in other window or tab, close it and refresh the app.',
     },
+    TR_WAIT_FOR_REBOOT_WEBUSB_DESCRIPTION: {
+        id: 'TR_WAIT_FOR_REBOOT_WEBUSB_DESCRIPTION',
+        defaultMessage: 'Please wait for Trezor to reboot and pair the device again.',
+    },
 } as const);
 
 export default definedMessages;

--- a/packages/suite/src/utils/firmware/index.ts
+++ b/packages/suite/src/utils/firmware/index.ts
@@ -26,12 +26,16 @@ export const getTextForStatus = (status: AppState['firmware']['status']) => {
             return null;
     }
 };
-export const getDescriptionForStatus = (status: AppState['firmware']['status']) => {
+export const getDescriptionForStatus = (
+    status: AppState['firmware']['status'],
+    webUSB?: boolean,
+) => {
     switch (status) {
         case 'started':
         case 'installing':
-        case 'wait-for-reboot':
             return 'TR_DO_NOT_DISCONNECT';
+        case 'wait-for-reboot':
+            return webUSB ? 'TR_WAIT_FOR_REBOOT_WEBUSB_DESCRIPTION' : 'TR_DO_NOT_DISCONNECT';
         default:
             return null;
     }


### PR DESCRIPTION
…after fw instalation

fix https://github.com/trezor/trezor-suite/issues/3575 
You can follow steps for reproduction there to test this PR, remove all devices from `chrome://settings/content/usbDevices` before.

webusb transport & waiting for reboot:
<img width="742" alt="Screenshot 2021-04-06 at 16 15 20" src="https://user-images.githubusercontent.com/6961901/113726849-de423680-96f4-11eb-91f0-42ba930a1e0c.png">
