### PR TITLE
fix(account-navigation): post-merge fixes

### DIFF
--- a/packages/suite/src/components/settings/SettingsMenu/index.tsx
+++ b/packages/suite/src/components/settings/SettingsMenu/index.tsx
@@ -45,7 +45,7 @@ const SettingsMenu = () => {
                 <AppNavigation
                     items={[
                         {
-                            id: 'general',
+                            id: 'settings-index',
                             title: <Translation id="TR_GENERAL" />,
                             position: 'primary',
                             'data-test': '@settings/menu/general',
@@ -55,7 +55,7 @@ const SettingsMenu = () => {
                             },
                         },
                         {
-                            id: 'device',
+                            id: 'settings-device',
                             title: <Translation id="TR_DEVICE" />,
                             position: 'primary',
                             'data-test': '@settings/menu/device',
@@ -65,7 +65,7 @@ const SettingsMenu = () => {
                             },
                         },
                         {
-                            id: 'coins',
+                            id: 'settings-coins',
                             title: <Translation id="TR_COINS" />,
                             position: 'primary',
                             'data-test': '@settings/menu/wallet',

--- a/packages/suite/src/components/suite/AppNavigation/index.tsx
+++ b/packages/suite/src/components/suite/AppNavigation/index.tsx
@@ -16,6 +16,7 @@ const Wrapper = styled.div`
     scrollbar-width: none; /* Firefox */
     justify-content: space-between;
     position: relative;
+    height: 68px;
 
     &::-webkit-scrollbar {
         /* WebKit */
@@ -68,7 +69,7 @@ const StyledNavLink = styled.div<{ active?: boolean }>`
     font-weight: ${FONT_WEIGHT.MEDIUM};
     display: flex;
     align-items: center;
-    padding: 23px 0;
+    padding: 23px 10px;
     white-space: nowrap;
     border-bottom: 2px solid
         ${props => (props.active ? props => props.theme.TYPE_DARK_GREY : 'transparent')};

--- a/packages/suite/src/components/suite/modals/ReviewTransaction/components/Output.tsx
+++ b/packages/suite/src/components/suite/modals/ReviewTransaction/components/Output.tsx
@@ -75,10 +75,12 @@ const Output = ({ type, state, label, value, value2, symbol, token }: Props) => 
     if (type === 'fee-replace' && value2) {
         outputLines = [
             {
+                id: 'increase-fee-by',
                 label: <Translation id="TR_INCREASE_FEE_BY" />,
                 value: formatNetworkAmount(value, symbol),
             },
             {
+                id: 'increased-fee',
                 label: <Translation id="TR_INCREASED_FEE" />,
                 value: formatNetworkAmount(value2, symbol),
             },
@@ -88,6 +90,7 @@ const Output = ({ type, state, label, value, value2, symbol, token }: Props) => 
     } else {
         outputLines = [
             {
+                id: 'default',
                 label: outputLabel,
                 value: outputValue,
             },

--- a/packages/suite/src/components/suite/modals/ReviewTransaction/components/OutputElement.tsx
+++ b/packages/suite/src/components/suite/modals/ReviewTransaction/components/OutputElement.tsx
@@ -100,6 +100,7 @@ const DotSeparator = styled.div`
 `;
 
 export type OutputElementLine = {
+    id: string;
     label: React.ReactNode;
     value: string;
 };
@@ -142,7 +143,7 @@ const OutputLine = ({
             </OutputLeft>
             <OutputRight>
                 {lines.map(line => (
-                    <OutputRightLine>
+                    <OutputRightLine key={line.id}>
                         <OutputHeadline>
                             <Truncate>{line.label}</Truncate>
                         </OutputHeadline>

--- a/packages/suite/src/components/suite/modals/ReviewTransaction/components/OutputList.tsx
+++ b/packages/suite/src/components/suite/modals/ReviewTransaction/components/OutputList.tsx
@@ -140,6 +140,7 @@ const OutputList = ({
                             <OutputElement
                                 lines={[
                                     {
+                                        id: 'total',
                                         label: <Translation id="TR_TOTAL" />,
                                         value: formatNetworkAmount(
                                             precomposedTx.totalSpent,

--- a/packages/suite/src/hooks/wallet/__fixtures__/useSendForm.ts
+++ b/packages/suite/src/hooks/wallet/__fixtures__/useSendForm.ts
@@ -1077,6 +1077,9 @@ export const signAndPush = [
                     type: '@notification/toast',
                     payload: { type: 'tx-sent', formattedAmount: '1 ETH' }, // BUG ?
                 },
+                {
+                    type: 'mock-redirect',
+                },
             ],
         },
     },
@@ -1127,6 +1130,9 @@ export const signAndPush = [
                 {
                     type: '@notification/toast',
                     payload: { type: 'tx-sent', formattedAmount: '1 XRP' },
+                },
+                {
+                    type: 'mock-redirect',
                 },
             ],
         },
@@ -1297,6 +1303,9 @@ export const signAndPush = [
                             { txid: 'utxoE', amount: '6250000000' },
                         ],
                     },
+                },
+                {
+                    type: 'mock-redirect',
                 },
             ],
         },

--- a/packages/suite/src/hooks/wallet/__tests__/useSendForm.test.tsx
+++ b/packages/suite/src/hooks/wallet/__tests__/useSendForm.test.tsx
@@ -17,6 +17,12 @@ import { SendContextValues } from '@wallet-types/sendForm';
 import SendIndex from '@wallet-views/send';
 import { useSendFormContext } from '../useSendForm';
 
+jest.mock('@suite-actions/routerActions', () => ({
+    goto: () => {
+        return { type: 'mock-redirect' };
+    },
+}));
+
 jest.mock('react-svg', () => {
     return { ReactSVG: () => 'SVG' };
 });

--- a/packages/suite/src/hooks/wallet/useSendForm.ts
+++ b/packages/suite/src/hooks/wallet/useSendForm.ts
@@ -3,6 +3,7 @@ import { useForm, useFieldArray } from 'react-hook-form';
 import { useActions } from '@suite-hooks';
 import * as sendFormActions from '@wallet-actions/sendFormActions';
 import * as walletSettingsActions from '@settings-actions/walletSettingsActions';
+import * as routerActions from '@suite-actions/routerActions';
 import { DEFAULT_PAYMENT, DEFAULT_VALUES } from '@wallet-constants/sendForm';
 import {
     UseSendFormProps,
@@ -81,6 +82,7 @@ export const useSendForm = (props: UseSendFormProps): SendContextValues => {
         getLastUsedFeeLevel,
         setLastUsedFeeLevel,
         signTransaction,
+        goto,
     } = useActions({
         getDraft: sendFormActions.getDraft,
         saveDraft: sendFormActions.saveDraft,
@@ -88,6 +90,7 @@ export const useSendForm = (props: UseSendFormProps): SendContextValues => {
         getLastUsedFeeLevel: walletSettingsActions.getLastUsedFeeLevel,
         setLastUsedFeeLevel: walletSettingsActions.setLastUsedFeeLevel,
         signTransaction: sendFormActions.signTransaction,
+        goto: routerActions.goto,
     });
 
     const { localCurrencyOption } = state;
@@ -223,9 +226,10 @@ export const useSendForm = (props: UseSendFormProps): SendContextValues => {
             updateContext({ isLoading: false });
             if (result) {
                 resetContext();
+                goto('wallet-index', undefined, true);
             }
         }
-    }, [getValues, composedLevels, signTransaction, resetContext, updateContext]);
+    }, [getValues, composedLevels, signTransaction, resetContext, updateContext, goto]);
 
     const typedRegister = useCallback(<T>(rules?: T) => register(rules), [register]);
 

--- a/packages/suite/src/views/wallet/details/index.tsx
+++ b/packages/suite/src/views/wallet/details/index.tsx
@@ -79,7 +79,7 @@ const Details = () => {
 
     return (
         <WalletLayout title="TR_ACCOUNT_DETAILS_HEADER" account={selectedAccount}>
-            <StyledCard title={<Translation id="TR_ACCOUNT_DETAILS_HEADER" />} largePadding>
+            <StyledCard largePadding>
                 <StyledRow>
                     <TextColumn
                         title={<Translation id="TR_ACCOUNT_DETAILS_TYPE_HEADER" />}


### PR DESCRIPTION
fixes #3607

1. Back button is visible in Settings for a short time after coming from Send/Receive etc. - **I was not able to reproduce this**
2. User is redirected to Overview after signing the transaction
3. Header in detail is not duplicated anymore
4. Active tab states in settings fixed
5. Padding added to tab content
6. Tabs vs Back button height fixed