### PR TITLE
e2e tests: a small step towards arm and docs tweaks

### DIFF
--- a/docker/suite/Dockerfile
+++ b/docker/suite/Dockerfile
@@ -9,8 +9,9 @@ RUN apt-get update && apt-get -y --no-install-recommends install \
     ca-certificates \
     curl
 
-RUN curl -o /usr/local/bin/gosu -SL "https://github.com/tianon/gosu/releases/download/1.4/gosu-$(dpkg --print-architecture)" \
-    && curl -o /usr/local/bin/gosu.asc -SL "https://github.com/tianon/gosu/releases/download/1.4/gosu-$(dpkg --print-architecture).asc" \
+# TODO: for M1 doesn't work
+RUN curl -o /usr/local/bin/gosu -SL "https://github.com/tianon/gosu/releases/download/1.12/gosu-$(dpkg --print-architecture)" \
+    && curl -o /usr/local/bin/gosu.asc -SL "https://github.com/tianon/gosu/releases/download/1.12/gosu-$(dpkg --print-architecture).asc" \
     && chmod +x /usr/local/bin/gosu
 
 COPY ./suite/entrypoint.sh /usr/local/bin/entrypoint.sh

--- a/docker/test-runner/Dockerfile
+++ b/docker/test-runner/Dockerfile
@@ -4,8 +4,8 @@ RUN apt-get update && apt-get -y --no-install-recommends install \
     ca-certificates \
     curl
 
-RUN curl -o /usr/local/bin/gosu -SL "https://github.com/tianon/gosu/releases/download/1.4/gosu-$(dpkg --print-architecture)" \
-    && curl -o /usr/local/bin/gosu.asc -SL "https://github.com/tianon/gosu/releases/download/1.4/gosu-$(dpkg --print-architecture).asc" \
+RUN curl -o /usr/local/bin/gosu -SL "https://github.com/tianon/gosu/releases/download/1.12/gosu-$(dpkg --print-architecture)" \
+    && curl -o /usr/local/bin/gosu.asc -SL "https://github.com/tianon/gosu/releases/download/1.12/gosu-$(dpkg --print-architecture).asc" \
     && chmod +x /usr/local/bin/gosu
 
 COPY ./suite/entrypoint.sh /usr/local/bin/entrypoint.sh

--- a/docs/tests/e2e-web.md
+++ b/docs/tests/e2e-web.md
@@ -2,18 +2,16 @@
 Suite uses [Cypress](https://docs.cypress.io/guides/overview/why-cypress.html) to run e2e tests. It also uses [trezor-user-env](https://github.com/trezor/trezor-user-env) which is [daily built](https://gitlab.com/satoshilabs/trezor/trezor-user-env/-/pipelines) into a docker image providing all the necessary instrumentation required to run tests (bridge and emulators).
 
 ## Run it locally
+_Note: All paths below are relative to the root of trezor-suite repository._
 
 ### On Linux
-
 #### Prerequisites
-
 - [Docker](https://docs.docker.com/docker-for-mac/install/)
 
 #### Steps
-
 1. Run `xhost +` to add yourself to the X access control list.
-2. Run `./docker/docker-suite-install.sh`.
-3. Run `./docker/docker-suite-test.sh`.
+2. Run `docker/docker-suite-install.sh`.
+3. Run `docker/docker-suite-test.sh`.
     - A Cypress window should open.
     - Wait until the project is built (a warning about "http://localhost:3000/ is not available", should disappear on the retry button click).
 4. Start a test by clicking its name in the Cypress window.
@@ -21,29 +19,24 @@ Suite uses [Cypress](https://docs.cypress.io/guides/overview/why-cypress.html) t
     - If the Suite web app is not loading even after two retries. Stop tests, open a new tab, navigate to http://localhost:3000/, refresh the page until the app is loaded. Close the tab and run tests again.
 
 ### On MacOS
+As of now M1 Macs aren't supported. See [this issue](https://github.com/trezor/trezor-suite/issues/3616) for detailed information.
 
 #### Prerequisites
-
 - [Docker](https://docs.docker.com/docker-for-mac/install/)
 - [XQuartz](https://www.xquartz.org/) (to share your screen with Docker)
 
 #### Steps
-
-1. Run XQuartz. Leave it running on the background. Wait till it is launched.
-2. In XQuartz settings go to Preferences > Security and enable "Allow connections from network clients".
+1. Run XQuartz. Wait till it is launched. Leave it running in the background.
+2. In XQuartz settings go to Preferences -> Security and enable "Allow connections from network clients".
 3. Open a new terminal window (not in XQuartz) and add yourself to the X access control list: 
     - `xhost +127.0.0.1` 
     - You will probably need to logout/login after XQuartz installation to have `xhost` command available.
-4. Run Docker and go to Preferences->Resources->Advanced and increase RAM to at least 4GB. Otherwise, the app during tests does not even load.
-5. In terminal window run `./docker/docker-suite-install.sh`
+4. Run Docker and go to Preferences -> Resources -> Advanced and increase RAM to at least 4GB. Otherwise, the app during tests does not even load.
+5. In terminal window run `docker/docker-suite-install.sh`
 6. In the terminal window, set two environment variables:
-    - ``
-export HOSTNAME=`hostname`
-``
-    - ``
-export DISPLAY=${HOSTNAME}:0
-``
-7. In terminal window run `./docker/docker-suite-test.sh`
+    - `` export HOSTNAME=`hostname\` ``
+    - `export DISPLAY=${HOSTNAME}:0`
+7. In terminal window run `docker/docker-suite-test.sh`
     - A Cypress window should open.
     - Wait until the project is built (a warning about "http://localhost:3000/ is not available", should disappear on the retry button click).
 8. Start a test by clicking its name in the Cypress window.
@@ -54,25 +47,19 @@ export DISPLAY=${HOSTNAME}:0
 - `[...ERROR:browser_main_loop.cc(1434)] Unable to open X display.`
     - Make sure the XQuartz app is launched and you can see its terminal.
     - Check that environment variables are properly set:
-      - ``
-echo $HOSTNAME # e.g. name.local
-``
-      - ``
-echo $DISPLAY # e.g. name.local:0
-``
+        - `echo $HOSTNAME # e.g. name.local`
+        - `echo $DISPLAY # e.g. name.local:0`
     - Do not mix native terminal window with terminal window in your IDE (e.g. Visual Studio Code).
 
 ## Notes
-
 ### Image snapshots
-
 It is possible to run tests with image snapshots to test for visual regressions. To enable snapshots, use env variable:
 
-`CYPRESS_SNAPSHOT=1 ./docker/docker-suite-test.sh`
+`CYPRESS_SNAPSHOT=1 docker/docker-suite-test.sh`
 
 When you need to update image snapshots you have 2 options:
 - use CI job. This will generate new snapshots in artifacts together with a handy script that updates your snapshots locally. Check the log output. 
-- use `./docker/docker-suite-snapshots.sh`. This does the same as `./docker/docker-suite-test.sh`, the only difference is it won't fail on non-matching snapshots but generate new snapshots.
+- use `docker/docker-suite-snapshots.sh`. This does the same as `docker/docker-suite-test.sh`, the only difference is it won't fail on non-matching snapshots but generate new snapshots.
 
 ### run_tests script
 The [run_tests.js script](https://github.com/trezor/trezor-suite/blob/develop/packages/integration-tests/projects/suite-web/run_tests.js)


### PR DESCRIPTION
A few last days I spent trying to run e2e tests on my M1 Mac. This PR brings 1) a small patch that brings us closer to that 2) Some minor docs tweaks.

This alone isn't enough to make the e2e tests run on arm machines, that will need far more work. I decided to not spend time on that now, deffered the effort to [this issue](https://github.com/trezor/trezor-suite/issues/3616) and pushed what I got so far with this PR.

RBC (review by commits) & DNS (do not squash) please .)