### PR TITLE
fix(news-api): return proper error statusCode, change user agent

### DIFF
--- a/packages/news-api/src/config.ts
+++ b/packages/news-api/src/config.ts
@@ -1,3 +1,4 @@
 export const MEDIUM_FEED_URL = 'https://cdn.trezor.io/dynamic/medium/feed/trezor-security-blog';
 export const MEDIUM_CDN_BASE = 'https://cdn-images-1.medium.com';
 export const TREZOR_CDN_BASE = 'https://cdn.trezor.io/static/medium/images';
+export const USER_AGENT = 'trezor/news-api';

--- a/packages/news-api/src/index.ts
+++ b/packages/news-api/src/index.ts
@@ -1,7 +1,7 @@
 import axios from 'axios';
 import { Post } from './types';
 import parser from 'fast-xml-parser';
-import { MEDIUM_FEED_URL, MEDIUM_CDN_BASE, TREZOR_CDN_BASE } from './config';
+import { MEDIUM_FEED_URL, MEDIUM_CDN_BASE, TREZOR_CDN_BASE, USER_AGENT } from './config';
 import cheerio from 'cheerio';
 
 const replaceCDNLink = (trezorLink?: string) => {
@@ -43,7 +43,7 @@ const fetcher = (
     callback: (statusCode: number, data: string | null, errMessage?: string) => void,
 ) => {
     axios
-        .get(MEDIUM_FEED_URL)
+        .get(MEDIUM_FEED_URL, { headers: { 'User-Agent': USER_AGENT } })
         .then(response => {
             try {
                 const data = parser.parse(response.data, {}, true);
@@ -53,7 +53,7 @@ const fetcher = (
                 callback(500, null, err.message);
             }
         })
-        .catch(error => callback(500, null, error.message));
+        .catch(error => callback(error?.response?.status ?? 500, null, error.message));
 };
 
 export default fetcher;

--- a/packages/news-api/src/server.ts
+++ b/packages/news-api/src/server.ts
@@ -22,6 +22,7 @@ app.get('/posts', (req, res) => {
     fetcher(limit, (statusCode, data: string | null, errorMsg) => {
         res.setHeader('Content-Type', 'application/json');
         if (statusCode !== 200) {
+            res.statusCode = statusCode;
             res.end(JSON.stringify({ status: 'error', errorMsg }));
         } else {
             res.end(data);


### PR DESCRIPTION
close https://github.com/trezor/trezor-suite/issues/3622

- changed user agent used by news-api so we can stop banning our infrastructure
- also fixes return code on error responses (it always returned 200) so we can monitor it
- pass real error status code that proxy got from its request to medium instead of always returning 500 so we can monitor it even better