### PR TITLE
fix(news-api): convert limit param to integer

### DIFF
--- a/packages/news-api/src/index.ts
+++ b/packages/news-api/src/index.ts
@@ -39,8 +39,8 @@ const getPosts = (data: any, limit = 5) => {
 };
 
 const fetcher = (
-    limit: number,
     callback: (statusCode: number, data: string | null, errMessage?: string) => void,
+    limit?: number,
 ) => {
     axios
         .get(MEDIUM_FEED_URL, { headers: { 'User-Agent': USER_AGENT } })


### PR DESCRIPTION
typescript got smarter, and our news-api got forgotten

Build was failing since forever because of TS issue (query param `limit` could be string | QueryString.ParsedQs | string[] | QueryString.ParsedQs[] | undefined, BUT never a number), but no one noticed  as we don't deploy it on regular basis (and looks like there is not even CI job). 