### PR TITLE
Feature/safety checks warning

### DIFF
--- a/packages/integration-tests/projects/suite-web/tests/suite/safety-checks-warning.test.ts
+++ b/packages/integration-tests/projects/suite-web/tests/suite/safety-checks-warning.test.ts
@@ -1,0 +1,85 @@
+// @group:suite
+// @retry=2
+
+// TODO: enable this test once https://github.com/trezor/trezor-user-env/issues/54
+// is resolved
+// describe('safety_checks Warning For PromptAlways', () => {
+//     beforeEach(() => {
+//         cy.task('startEmu', { wipe: true });
+//         cy.task('setupEmu');
+//         cy.task('startBridge');
+//         cy.viewport(1024, 768).resetDb();
+//         cy.prefixedVisit('/settings/device/');
+//         cy.passThroughInitialRun();
+//         // TODO: set safety_checks to `PromptAlways`
+//     });
+
+//     it('Non-dismissible warning appears', () => {
+//         cy.getTestElement('@banner/safety-checks/button');
+//         cy.getTestElement('@banner/safety-checks/dismiss').should('not.exist');
+//     });
+// })
+
+describe('safety_checks Warning For PromptTemporarily', () => {
+    beforeEach(() => {
+        cy.task('startEmu', { wipe: true });
+        cy.task('setupEmu');
+        cy.task('startBridge');
+        cy.viewport(1024, 768).resetDb();
+        // Start in the device settings to easily open safety_checks setting modal.
+        cy.prefixedVisit('/settings/device/');
+        cy.passThroughInitialRun();
+        // Set safety_checks to `PromptTemporarily'.
+        // TODO: do this via the `applySetting` task once https://github.com/trezor/trezor-user-env/issues/54
+        // is resolved.
+        cy.getTestElement('@settings/device/safety-checks-button').click();
+        cy.get(`[data-test="@radio-button"][value="PromptTemporarily"]`).click();
+        cy.getTestElement('@safety-checks-apply').click();
+        cy.task('pressYes');
+    });
+
+    it('Dismissible warning appears', () => {
+        cy.getTestElement('@banner/safety-checks/button');
+        cy.getTestElement('@banner/safety-checks/dismiss');
+    });
+
+    it('CTA button opens device settings', () => {
+        cy.getTestElement('@banner/safety-checks/button').click();
+        // In CI the path is prefixed with a branch name. Test only against the end of the path.
+        cy.location('pathname').should('match', /\/settings\/device\/$/)
+    });
+
+    it('Dismiss button hides the warning', () => {
+        cy.getTestElement('@banner/safety-checks/dismiss').click();
+        cy.getTestElement('@banner/safety-checks/button').should('not.exist');
+    });
+
+    it('Warning disappears when safety_checks are set to strict', () => {
+        // Open the safety_checks setting modal and change safety_checks to Strict.
+        cy.getTestElement('@settings/device/safety-checks-button').click();
+        cy.get('[data-test="@radio-button"][value="Strict"]').click();
+        cy.getTestElement('@safety-checks-apply').click();
+        cy.task('pressYes');
+        // Assert the warning is gone.
+        cy.getTestElement('@banner/safety-checks/button').should('not.exist');
+    });
+
+    it('Dismissed warning re-appears when safety_checks are set to strict and then to Prompt again.', () => {
+        // Dismiss the warning.
+        cy.getTestElement('@banner/safety-checks/dismiss').click();
+        // Open the safety_checks setting modal and change safety_checks to Strict.
+        cy.getTestElement('@settings/device/safety-checks-button').click();
+        cy.get('[data-test="@radio-button"][value="Strict"]').click();
+        cy.getTestElement('@safety-checks-apply').click();
+        cy.task('pressYes');
+        // Assert the warning is gone.
+        cy.getTestElement('@banner/safety-checks/button').should('not.exist');
+        // Set safety_checks back to PromptTemporarily
+        cy.getTestElement('@settings/device/safety-checks-button').click();
+        cy.get(`[data-test="@radio-button"][value="PromptTemporarily"]`).click();
+        cy.getTestElement('@safety-checks-apply').click();
+        cy.task('pressYes');
+        // Assert the warning appear again.
+        cy.getTestElement('@banner/safety-checks/button');
+    });
+});

--- a/packages/suite/src/components/suite/Banners/SafetyChecks.tsx
+++ b/packages/suite/src/components/suite/Banners/SafetyChecks.tsx
@@ -1,0 +1,37 @@
+import React from 'react';
+import { Translation } from '@suite-components';
+import { useActions } from '@suite-hooks';
+import Wrapper from './components/Wrapper';
+import * as routerActions from '@suite/actions/suite/routerActions';
+
+interface Props {
+    onDismiss?: () => void;
+}
+
+const SafetyChecksBanner = (props: Props) => {
+    const { goto } = useActions({
+        goto: routerActions.goto,
+    });
+
+    return (
+        <Wrapper
+            variant="warning"
+            body={<Translation id="TR_SAFETY_CHECKS_DISABLED_WARNING" />}
+            action={{
+                label: <Translation id="TR_SAFETY_CHECKS_BANNER_CHANGE" />,
+                // TODO: Use anchor to bring the user to the appropriate section of settings.
+                onClick: () => goto('settings-device'),
+                'data-test': '@banner/safety-checks/button',
+            }}
+            dismissal={
+                (props.onDismiss !== undefined && {
+                    onClick: props.onDismiss,
+                    'data-test': '@banner/safety-checks/dismiss',
+                }) ||
+                undefined
+            }
+        />
+    );
+};
+
+export default SafetyChecksBanner;

--- a/packages/suite/src/support/messages.ts
+++ b/packages/suite/src/support/messages.ts
@@ -1610,6 +1610,14 @@ const definedMessages = defineMessages({
             'Allow potentially unsafe actions, such as mismatching coin keys or extreme fees by manually approving them on your Trezor.',
         id: 'TR_SAFETY_CHECKS_PROMPT_LEVEL_DESC',
     },
+    TR_SAFETY_CHECKS_DISABLED_WARNING: {
+        defaultMessage: 'Safety Checks are disabled.',
+        id: 'TR_SAFETY_CHECKS_DISABLED_WARNING',
+    },
+    TR_SAFETY_CHECKS_BANNER_CHANGE: {
+        defaultMessage: 'Change',
+        id: 'TR_SAFETY_CHECKS_BANNER_CHANGE',
+    },
     TR_DEVICE_SETTINGS_PASSPHRASE_TITLE: {
         defaultMessage: 'Passphrase',
         id: 'TR_DEVICE_SETTINGS_PASSPHRASE_TITLE',


### PR DESCRIPTION
This PR adds a warning banner that appears when safety checks are not `Strict`. It's an essential complement to the already merged [safety checks setting](https://github.com/trezor/trezor-suite/pull/3590) and hence needs to be merged before the next freeze.