### PR TITLE
fix: forget all devices on app reset

### DIFF
--- a/packages/suite/src/actions/suite/storageActions.ts
+++ b/packages/suite/src/actions/suite/storageActions.ts
@@ -314,7 +314,7 @@ export const removeDatabase = () => async (dispatch: Dispatch, getState: GetStat
     const rememberedDevices = getState().devices.filter(d => d.remember);
     // forget all remembered devices
     rememberedDevices.forEach(d => {
-        suiteActions.rememberDevice(d);
+        dispatch(suiteActions.forgetDevice(d));
     });
     await db.removeDatabase();
     dispatch(

--- a/packages/suite/src/actions/suite/suiteActions.ts
+++ b/packages/suite/src/actions/suite/suiteActions.ts
@@ -224,6 +224,13 @@ export const selectDevice = (device?: Device | TrezorDevice) => (
     });
 };
 
+/**
+ * Toggles remembering the given device. I.e. if given device is not remembered it will become remembered
+ * and if it is remembered it will be forgotten.
+ * @param forceRemember can be set to `true` to remember given device regardless if its current state.
+ *
+ * Use `forgetDevice` to forget a device regardless if its current state.
+ */
 export const rememberDevice = (payload: TrezorDevice, forceRemember?: true): SuiteAction => ({
     type: SUITE.REMEMBER_DEVICE,
     payload,


### PR DESCRIPTION
Just a small improvement I stumpled upon when working on something else.

- Add (probably forgotten) dispatch call to *actually* forget all
remembered devices.
- Use explicit `forgetDevice` instead of confusing `rememberDevice` to
forget the devices.
- Document the confusingly named `rememberDevice` method.

