### PR TITLE
feat(suite-data): override keys for msg-system via files

### DIFF
--- a/ci/packages/suite-data.yml
+++ b/ci/packages/suite-data.yml
@@ -13,11 +13,13 @@ msg-system config sign dev:
     paths:
       - packages/suite-data/files/message-system/config.v1.jws
 
-msg-system config sign:
+msg-system config sign stable:
   stage: prebuild
   only:
     refs:
       - codesign
+  variables:
+    IS_CODESIGN_BUILD: "true"
   script:
     - yarn workspace @trezor/suite-data msg-system-sign-config
     # - aws s3 cp packages/suite-data/files/message-system/config.v1.jws s3://data.trezor.io/config/stable/config.v1.jws

--- a/ci/packages/suite-data.yml
+++ b/ci/packages/suite-data.yml
@@ -18,10 +18,14 @@ msg-system config sign stable:
   only:
     refs:
       - codesign
+  tags:
+    - darwin
   variables:
     IS_CODESIGN_BUILD: "true"
   script:
-    - yarn workspace @trezor/suite-data msg-system-sign-config
+    - nix-shell --run "git lfs pull"
+    - nix-shell --run "yarn install --frozen-lockfile --cache-folder .yarn --prefer-offline"
+    - nix-shell --run "yarn workspace @trezor/suite-data msg-system-sign-config"
     # - aws s3 cp packages/suite-data/files/message-system/config.v1.jws s3://data.trezor.io/config/stable/config.v1.jws
   artifacts:
     expire_in: 7 days

--- a/ci/packages/suite-desktop.yml
+++ b/ci/packages/suite-desktop.yml
@@ -64,6 +64,7 @@ suite-desktop build mac codesign:
   tags:
     - darwin
   variables:
+    IS_CODESIGN_BUILD: "true"
     artifact: ${DESKTOP_APP_NAME}*
     platform: mac
   <<: *build
@@ -98,6 +99,7 @@ suite-desktop build linux codesign:
   tags:
     - darwin
   variables:
+    IS_CODESIGN_BUILD: "true"
     artifact: ${DESKTOP_APP_NAME}*
     platform: linux
   <<: *build
@@ -135,6 +137,7 @@ suite-desktop build windows codesign:
     - darwin
   image: electronuserland/builder:wine
   variables:
+    IS_CODESIGN_BUILD: "true"
     artifact: ${DESKTOP_APP_NAME}*
     platform: win
   <<: *build

--- a/ci/packages/suite-desktop.yml
+++ b/ci/packages/suite-desktop.yml
@@ -1,3 +1,11 @@
+.config_sign_dev: &config_sign_dev
+  needs:
+    - msg-system config sign dev
+
+.config_sign_stable: &config_sign_stable
+  needs:
+    - msg-system config sign stable
+
 .build: &build
   stage: build
   script:
@@ -35,6 +43,7 @@
     - /^run\//
 
 suite-desktop build mac:
+  <<: *config_sign_dev
   only:
     <<: *run_everything_rules
   tags:
@@ -46,6 +55,7 @@ suite-desktop build mac:
   <<: *build_nix
 
 suite-desktop build mac manual:
+  <<: *config_sign_dev
   when: manual
   except:
     <<: *run_everything_rules
@@ -58,6 +68,7 @@ suite-desktop build mac manual:
   <<: *build_nix
 
 suite-desktop build mac codesign:
+  <<: *config_sign_stable
   only:
     refs:
       - codesign
@@ -76,6 +87,7 @@ suite-desktop build mac codesign:
     expire_in: 7 days
 
 suite-desktop build linux:
+  <<: *config_sign_dev
   only:
     <<: *run_everything_rules
   variables:
@@ -84,6 +96,7 @@ suite-desktop build linux:
   <<: *build
 
 suite-desktop build linux manual:
+  <<: *config_sign_dev
   when: manual
   except:
     <<: *run_everything_rules
@@ -93,6 +106,7 @@ suite-desktop build linux manual:
   <<: *build
 
 suite-desktop build linux codesign:
+  <<: *config_sign_stable
   only:
     refs:
       - codesign
@@ -111,6 +125,7 @@ suite-desktop build linux codesign:
     expire_in: 7 days
 
 suite-desktop build windows:
+  <<: *config_sign_dev
   only:
     <<: *run_everything_rules
   image: electronuserland/builder:wine
@@ -120,6 +135,7 @@ suite-desktop build windows:
   <<: *build
 
 suite-desktop build windows manual:
+  <<: *config_sign_dev
   when: manual
   except:
     <<: *run_everything_rules
@@ -130,6 +146,7 @@ suite-desktop build windows manual:
   <<: *build
 
 suite-desktop build windows codesign:
+  <<: *config_sign_stable
   only:
     refs:
       - codesign

--- a/ci/packages/suite-web.yml
+++ b/ci/packages/suite-web.yml
@@ -1,7 +1,3 @@
-.config_sign_stable: &config_sign_stable
-  needs:
-    - msg-system config sign
-
 .run_everything_rules: &run_everything_rules
   refs:
     - develop
@@ -57,10 +53,11 @@ suite-web build stable:
 
 suite-web build stable codesign:
   stage: build
-  <<: *config_sign_stable
   only:
     refs:
       - codesign
+  variables:
+    IS_CODESIGN_BUILD: "true"
   script:
     - yarn install --frozen-lockfile --cache-folder .yarn --prefer-offline
     - yarn build:libs

--- a/ci/packages/suite-web.yml
+++ b/ci/packages/suite-web.yml
@@ -1,3 +1,11 @@
+.config_sign_stable: &config_sign_stable
+  needs:
+    - msg-system config sign stable
+
+.config_sign_dev: &config_sign_dev
+  needs:
+    - msg-system config sign dev
+
 .run_everything_rules: &run_everything_rules
   refs:
     - develop
@@ -9,6 +17,7 @@
 
 suite-web build dev:
   stage: build
+  <<: *config_sign_dev
   script:
     - yarn install --frozen-lockfile --cache-folder .yarn --prefer-offline
     - yarn build:libs
@@ -21,6 +30,7 @@ suite-web build dev:
 # to be removed after beta-wallet is officially killed
 suite-web build beta:
   stage: build
+  <<: *config_sign_dev
   only:
     <<: *run_everything_rules
   script:
@@ -35,6 +45,7 @@ suite-web build beta:
 
 suite-web build stable:
   stage: build
+  <<: *config_sign_dev
   only:
     refs:
       - develop
@@ -53,15 +64,19 @@ suite-web build stable:
 
 suite-web build stable codesign:
   stage: build
+  <<: *config_sign_stable
   only:
     refs:
       - codesign
+  tags:
+    - darwin
   variables:
     IS_CODESIGN_BUILD: "true"
   script:
-    - yarn install --frozen-lockfile --cache-folder .yarn --prefer-offline
-    - yarn build:libs
-    - assetPrefix=/web yarn workspace @trezor/suite-web build
+    - nix-shell --run "git lfs pull"
+    - nix-shell --run "yarn install --frozen-lockfile --cache-folder .yarn --prefer-offline"
+    - nix-shell --run "yarn build:libs"
+    - nix-shell --run "assetPrefix=/web yarn workspace @trezor/suite-web build"
   artifacts:
     expire_in: 7 days
     paths:

--- a/packages/suite-data/src/message-system/constants/index.ts
+++ b/packages/suite-data/src/message-system/constants/index.ts
@@ -1,3 +1,4 @@
+import * as fs from 'fs-extra';
 import { join, resolve } from 'path';
 
 /*
@@ -20,15 +21,3 @@ export const PACKAGES_ROOT = resolve(PROJECT_ROOT, '../../..');
 
 export const SCHEMA_PATH = join(PROJECT_ROOT, 'schema', SCHEMA_FILENAME);
 export const CONFIG_PATH = join(PROJECT_ROOT, 'config', CONFIG_FILENAME);
-
-const DEV_JWS_PRIVATE_KEY = `-----BEGIN EC PRIVATE KEY-----
-MHQCAQEEINi7lfZE3Y5U9srS58A+AN7Ul7HeBXsHEfzVzijColOkoAcGBSuBBAAKoUQDQgAEbSUHJlr17+NywPS/w+xMkp3dSD8eWXSuAfFKwonZPe5fL63kISipJC+eJP7Mad0WxgyJoiMsZCV6BZPK2jIFdg==
------END EC PRIVATE KEY-----`;
-
-const PROD_JWS_PRIVATE_KEY =
-    process.env.JWS_PRIVATE_KEY &&
-    `-----BEGIN EC PRIVATE KEY-----
-${process.env.JWS_PRIVATE_KEY}
------END EC PRIVATE KEY-----`;
-
-export const JWS_PRIVATE_KEY = PROD_JWS_PRIVATE_KEY || DEV_JWS_PRIVATE_KEY;

--- a/packages/suite-desktop/next.config.js
+++ b/packages/suite-desktop/next.config.js
@@ -1,4 +1,5 @@
 /* eslint-disable @typescript-eslint/no-var-requires */
+const fs = require('fs');
 const path = require('path');
 const withBundleAnalyzer = require('@next/bundle-analyzer')({
     enabled: process.env.ANALYZE === 'true',
@@ -18,17 +19,28 @@ const packageJson = require('./package.json');
 
 const gitRevisionPlugin = new GitRevisionPlugin();
 
-// TODO: After Raf's tschuss-next is merged, move keys to some constants file to avoid duplication in suite-web and suite-desktop package
-// TODO: Do not forget to move process.env.PUBLIC_KEY and process.env.STABLE_CONFIG to new webpack files
-const productionJwsPublicKey =
-    process.env.JWS_PUBLIC_KEY &&
-    `-----BEGIN PUBLIC KEY-----
-${process.env.JWS_PUBLIC_KEY}
------END PUBLIC KEY-----`;
+/* TODO:
+ * After feat/tschuss-next is merged, move development key to constants file or its own file
+ * to avoid duplication in suite-web and suite-desktop package.
+ * Do not forget to move process.env.PUBLIC_KEY and process.env.CODESIGN_BUILD to new webpack files.
+ */
 
-const developmentJwsPublicKey = `-----BEGIN PUBLIC KEY-----
+/* Only CI jobs flagged with "codesign", sign message system config by production private key.
+ * All other branches use development key. */
+const isCodesignBuild = process.env.IS_CODESIGN_BUILD === 'true';
+let JWS_PUBLIC_KEY;
+
+if (isCodesignBuild) {
+    console.log('Bundling production JWS public key.');
+
+    JWS_PUBLIC_KEY = fs.readFileSync(process.env.JWS_PUBLIC_KEY_FILE, 'utf-8');
+} else {
+    console.log('Bundling develop JWS public key.');
+
+    JWS_PUBLIC_KEY = `-----BEGIN PUBLIC KEY-----
 MFYwEAYHKoZIzj0CAQYFK4EEAAoDQgAEbSUHJlr17+NywPS/w+xMkp3dSD8eWXSuAfFKwonZPe5fL63kISipJC+eJP7Mad0WxgyJoiMsZCV6BZPK2jIFdg==
 -----END PUBLIC KEY-----`;
+}
 
 module.exports = withBundleAnalyzer(
     withOptimizedImages(
@@ -57,10 +69,8 @@ module.exports = withBundleAnalyzer(
                             'process.env.COMMITHASH': JSON.stringify(
                                 gitRevisionPlugin.commithash(),
                             ),
-                            'process.env.PUBLIC_KEY': JSON.stringify(
-                                productionJwsPublicKey || developmentJwsPublicKey,
-                            ),
-                            'process.env.STABLE_CONFIG': !!productionJwsPublicKey,
+                            'process.env.PUBLIC_KEY': JSON.stringify(JWS_PUBLIC_KEY),
+                            'process.env.CODESIGN_BUILD': isCodesignBuild,
                         }),
                     );
                     // google-auth-library dependency does not have out-of-the-box browser support (is primarily aimed at nodejs)

--- a/packages/suite/src/actions/suite/constants/messageSystemConstants.ts
+++ b/packages/suite/src/actions/suite/constants/messageSystemConstants.ts
@@ -22,7 +22,7 @@ export const FETCH_CHECK_INTERVAL = 3600000; // 1 hour in milliseconds
  */
 export const VERSION = 1;
 
-export const CONFIG_URL_REMOTE = process.env.STABLE_CONFIG
+export const CONFIG_URL_REMOTE = process.env.CODESIGN_BUILD
     ? `https://data.trezor.io/config/stable/config.v${VERSION}.jws`
     : `https://data.trezor.io/config/develop/config.v${VERSION}.jws`;
 


### PR DESCRIPTION
I'd like to propose the attached change - I need to override the JWS signing keys via file stored on a filesystem, not via an ENV variable.

I have not tested the change, so please pay special attention to review.

Thanks!