### PR TITLE
Fix custom tor address setting

### DIFF
--- a/packages/suite-desktop/src-electron/index.d.ts
+++ b/packages/suite-desktop/src-electron/index.d.ts
@@ -69,6 +69,16 @@ declare type UpdateSettings = {
 };
 
 declare type TorSettings = {
+    /**
+     * True when tor should be enabled.
+     * Doesn't necessarily mean that the bundled tor is running
+     * as that depends on the address as well.
+     */
     running: boolean;
+    /**
+     * Address of the tor process through which traffic is routed.
+     * If it's anything other than the default one assume user
+     * wants to use their own tor instance and don't run the bundled one.
+     */
     address: string;
 };

--- a/packages/suite-desktop/src-electron/libs/processes/TorProcess.ts
+++ b/packages/suite-desktop/src-electron/libs/processes/TorProcess.ts
@@ -2,27 +2,18 @@ import fetch from 'node-fetch';
 
 import BaseProcess, { Status } from './BaseProcess';
 
-const defaultTorAddress = '127.0.0.1:9050';
+// 9050 is the default port of the tor process.
+export const DEFAULT_ADDRESS = '127.0.0.1:9050';
 
 class TorProcess extends BaseProcess {
-    adr = defaultTorAddress;
-
     constructor() {
         super('tor', 'tor');
-    }
-
-    get address() {
-        return this.adr;
-    }
-
-    set address(value: string) {
-        this.adr = value;
     }
 
     async status(): Promise<Status> {
         // service
         try {
-            const resp = await fetch(`http://${this.adr}/`);
+            const resp = await fetch(`http://${DEFAULT_ADDRESS}/`);
             if (resp.status === 501 && resp.statusText.startsWith('Tor')) {
                 return {
                     service: true,
@@ -41,11 +32,7 @@ class TorProcess extends BaseProcess {
     }
 
     async start(): Promise<void> {
-        // Only try to start the process if it's the default Tor address.
-        // Otherwise the user might be pointing to a different instance.
-        if (this.adr === defaultTorAddress) {
-            await super.start(['-f', 'torrc']);
-        }
+        await super.start(['-f', 'torrc']);
     }
 }
 

--- a/packages/suite-desktop/src-electron/modules/tor.ts
+++ b/packages/suite-desktop/src-electron/modules/tor.ts
@@ -1,8 +1,7 @@
 /**
  * Tor feature (toggle, configure)
  */
-import { app, session, ipcMain, IpcMainEvent } from 'electron';
-
+import { app, session, ipcMain } from 'electron';
 import TorProcess, { DEFAULT_ADDRESS } from '@desktop-electron/libs/processes/TorProcess';
 import { b2t } from '@desktop-electron/libs/utils';
 
@@ -59,7 +58,7 @@ const init = async ({ mainWindow, store }: Dependencies) => {
         await toggleTor(start);
     });
 
-    ipcMain.on('tor/set-address', () => async (_: IpcMainEvent, address: string) => {
+    ipcMain.on('tor/set-address', async (_, address: string) => {
         if (torSettings.address !== address) {
             logger.debug('tor', [
                 'Updating address:',

--- a/packages/suite-desktop/src-electron/modules/tor.ts
+++ b/packages/suite-desktop/src-electron/modules/tor.ts
@@ -3,93 +3,85 @@
  */
 import { app, session, ipcMain } from 'electron';
 import TorProcess, { DEFAULT_ADDRESS } from '@desktop-electron/libs/processes/TorProcess';
-import { b2t } from '@desktop-electron/libs/utils';
-
 import { onionDomain } from '../config';
-
-const torFlag = app.commandLine.hasSwitch('tor');
 
 const init = async ({ mainWindow, store }: Dependencies) => {
     const { logger } = global;
     const tor = new TorProcess();
-    const torSettings = store.getTorSettings();
 
-    const toggleTor = async (start: boolean) => {
-        // Only start/stop the process if address is the default one.
+    /**
+     * Merges given TorSettings with settings already present in the store,
+     * persists the result and returns it.
+     */
+    const persistSettings = (options: Partial<TorSettings>): TorSettings => {
+        const newSettings = { ...store.getTorSettings(), ...options };
+        store.setTorSettings(newSettings);
+        return newSettings;
+    };
+
+    const setProxy = (rule: string) => {
+        logger.info('tor', `Setting proxy rules to "${rule}"`);
+        session.defaultSession.setProxy({
+            proxyRules: rule,
+        });
+    };
+
+    const setupTor = async (settings: TorSettings) => {
+        // Start (or stop) the bundled tor only if address is the default one.
         // Otherwise the user must run the process themselves.
-        if(torSettings.address === DEFAULT_ADDRESS) {
-            if (start) {
-                if (torSettings.running) {
-                    logger.info('tor', 'Restarting');
-                    await tor.restart();
-                } else {
-                    logger.info('tor', 'Starting');
-                    await tor.start();
-                }
+        const shouldRunBundledTor = settings.running && settings.address === DEFAULT_ADDRESS;
+        if (shouldRunBundledTor !== (await tor.status()).process) {
+            if (shouldRunBundledTor === true) {
+                await tor.start();
             } else {
-                logger.info('tor', 'Stopping');
                 await tor.stop();
             }
         }
 
-        torSettings.running = start;
-        store.setTorSettings(torSettings);
+        // Start (or stop) routing all communication through tor.
+        if (settings.running) {
+            setProxy(`socks5://${settings.address}`);
+        } else {
+            setProxy('');
+        }
 
-        mainWindow.webContents.send('tor/status', start);
-
-        const proxy = start ? `socks5://${torSettings.address}` : '';
-        logger.info('tor', `Setting proxy to "${proxy}"`);
-        session.defaultSession.setProxy({
-            proxyRules: proxy,
-        });
+        // Notify the renderer.
+        mainWindow.webContents.send('tor/status', settings.running);
     };
-
-    if (torFlag || torSettings.running) {
-        logger.info('tor', [
-            'Auto starting:',
-            `- Running with flag: ${b2t(torFlag)}`,
-            `- Running with settings: ${b2t(torSettings.running)}`,
-        ]);
-        await toggleTor(true);
-    }
 
     ipcMain.on('tor/toggle', async (_, start: boolean) => {
         logger.info('tor', `Toggling ${start ? 'ON' : 'OFF'}`);
-        await toggleTor(start);
+        const settings = persistSettings({ running: start });
+        await setupTor(settings);
     });
 
     ipcMain.on('tor/set-address', async (_, address: string) => {
-        if (torSettings.address !== address) {
-            logger.debug('tor', [
-                'Updating address:',
-                `- From: ${torSettings.address}`,
-                `- To: ${address}`,
-            ]);
-
-            torSettings.address = address;
-            store.setTorSettings(torSettings);
-
-            if (torSettings.running) {
-                await toggleTor(true);
-            }
+        if (store.getTorSettings().address !== address) {
+            logger.debug('tor', `Changed address to ${address}`);
+            const settings = persistSettings({ address });
+            await setupTor(settings);
         }
     });
 
     ipcMain.on('tor/get-status', () => {
-        logger.debug('tor', `Getting status (${torSettings.running ? 'ON' : 'OFF'})`);
-        mainWindow.webContents.send('tor/status', torSettings.running);
+        logger.debug('tor', `Getting status (${store.getTorSettings().running ? 'ON' : 'OFF'})`);
+        mainWindow.webContents.send('tor/status', store.getTorSettings().running);
     });
 
     ipcMain.handle('tor/get-address', () => {
-        logger.debug('tor', `Getting address (${torSettings.address})`);
-        return torSettings.address;
+        logger.debug('tor', `Getting address (${store.getTorSettings().address})`);
+        return store.getTorSettings().address;
     });
 
     session.defaultSession.webRequest.onBeforeRequest({ urls: ['*://*/*'] }, (details, cb) => {
         const { hostname, protocol } = new URL(details.url);
 
         // Redirect outgoing trezor.io requests to .onion domain
-        if (torSettings.running && hostname.endsWith('trezor.io') && protocol === 'https:') {
+        if (
+            store.getTorSettings().running &&
+            hostname.endsWith('trezor.io') &&
+            protocol === 'https:'
+        ) {
             logger.info('tor', `Rewriting ${details.url} to .onion URL`);
             cb({
                 redirectURL: details.url.replace(
@@ -107,6 +99,13 @@ const init = async ({ mainWindow, store }: Dependencies) => {
         logger.info('tor', 'Stopping (app quit)');
         tor.stop();
     });
+
+    if (app.commandLine.hasSwitch('tor')) {
+        logger.info('tor', 'Tor enabled by command line option.');
+        persistSettings({ running: true });
+    }
+
+    await setupTor(store.getTorSettings());
 };
 
 export default init;

--- a/packages/suite-desktop/src-electron/modules/tor.ts
+++ b/packages/suite-desktop/src-electron/modules/tor.ts
@@ -3,7 +3,7 @@
  */
 import { app, session, ipcMain, IpcMainEvent } from 'electron';
 
-import TorProcess from '@desktop-electron/libs/processes/TorProcess';
+import TorProcess, { DEFAULT_ADDRESS } from '@desktop-electron/libs/processes/TorProcess';
 import { b2t } from '@desktop-electron/libs/utils';
 
 import { onionDomain } from '../config';
@@ -16,17 +16,21 @@ const init = async ({ mainWindow, store }: Dependencies) => {
     const torSettings = store.getTorSettings();
 
     const toggleTor = async (start: boolean) => {
-        if (start) {
-            if (torSettings.running) {
-                logger.info('tor', 'Restarting');
-                await tor.restart();
+        // Only start/stop the process if address is the default one.
+        // Otherwise the user must run the process themselves.
+        if(torSettings.address === DEFAULT_ADDRESS) {
+            if (start) {
+                if (torSettings.running) {
+                    logger.info('tor', 'Restarting');
+                    await tor.restart();
+                } else {
+                    logger.info('tor', 'Starting');
+                    await tor.start();
+                }
             } else {
-                logger.info('tor', 'Starting');
-                await tor.start();
+                logger.info('tor', 'Stopping');
+                await tor.stop();
             }
-        } else {
-            logger.info('tor', 'Stopping');
-            await tor.stop();
         }
 
         torSettings.running = start;

--- a/packages/suite/src/views/settings/index.tsx
+++ b/packages/suite/src/views/settings/index.tsx
@@ -91,6 +91,9 @@ const Settings = () => {
     });
 
     // Tor
+    // Default address of the bundled tor process.
+    // Keep in sync with DEFAULT_ADDRESS in suite-desktop's TorProcess.
+    const DEFAULT_ADDRESS = '127.0.0.1:9050';
     const [torAddress, setTorAddress] = useState('');
     useEffect(() => {
         window.desktopApi?.getTorAddress().then(address => setTorAddress(address));
@@ -98,7 +101,10 @@ const Settings = () => {
 
     const saveTorAddress = useCallback(() => {
         // TODO: Validation
-        window.desktopApi!.setTorAddress(torAddress);
+        // Let the user go back to default by clearing the input.
+        // Indicate this to the user by using DEFAULT_ADDRESS as placeholder in the input below.
+        const address = torAddress.length > 0 ? torAddress : DEFAULT_ADDRESS;
+        window.desktopApi!.setTorAddress(address);
     }, [torAddress]);
 
     // Auto Updater
@@ -291,7 +297,7 @@ const Settings = () => {
                                         }
                                         onBlur={saveTorAddress}
                                         data-test="@settings/general/tor-address"
-                                        placeholder="127.0.0.1:9050"
+                                        placeholder={DEFAULT_ADDRESS}
                                     />
                                 </ActionColumn>
                             </SectionItem>


### PR DESCRIPTION
@keraf [I noticed](https://github.com/trezor/trezor-suite/issues/3709) that the custom tor address won't get persisted in the Suite settings and spent hours debugging it only to find out that it takes removing mere 7 characters from a single line to fix it. In that effort I refactored the tor module because I just couldn't understand it well enough and thought the bug is hidden somewhere inside (and also because the code had some functional issues, see the commit messages.)

Please give this both eyes -- it's not covered with tests. (yet)

Closes https://github.com/trezor/trezor-suite/issues/3709.