### PR TITLE
feat(suite): btn to dump reducer's data from debug settings

### DIFF
--- a/packages/suite/src/actions/suite/suiteActions.ts
+++ b/packages/suite/src/actions/suite/suiteActions.ts
@@ -1,4 +1,5 @@
 import TrezorConnect, { Device, DEVICE } from 'trezor-connect';
+import { saveAs } from 'file-saver';
 import * as comparisonUtils from '@suite-utils/comparisonUtils';
 import * as deviceUtils from '@suite-utils/device';
 import { addToast } from '@suite-actions/notificationActions';
@@ -77,6 +78,12 @@ export type SuiteAction =
           variant: SuiteThemeVariant;
           colors: SuiteThemeColors;
       };
+
+export const dumpReducers = () => (_dispatch: Dispatch, getState: GetState) => {
+    const b = new Blob([JSON.stringify(getState(), null, 2)], { type: 'text/plain;charset=utf-8' });
+    const timestamp = Math.floor(new Date().getTime() / 1000);
+    saveAs(b, `suite_reducers_${process.env.VERSION}_${timestamp}.json`);
+};
 
 export const setDbError = (payload: AppState['suite']['dbError']) => ({
     type: SUITE.SET_DB_ERROR,

--- a/packages/suite/src/views/settings/debug/index.tsx
+++ b/packages/suite/src/views/settings/debug/index.tsx
@@ -14,8 +14,9 @@ const StyledActionColumn = styled(ActionColumn)`
 `;
 
 const DebugSettings = () => {
-    const { setTheme, setDebugMode } = useActions({
+    const { setTheme, setDebugMode, dumpReducers } = useActions({
         setTheme: suiteActions.setTheme,
+        dumpReducers: suiteActions.dumpReducers,
         setDebugMode: suiteActions.setDebugMode,
     });
     const { debug, theme } = useSelector(state => ({
@@ -89,6 +90,21 @@ const DebugSettings = () => {
                             }}
                         >
                             Open issue
+                        </Button>
+                    </ActionColumn>
+                </Row>
+                <Row>
+                    <TextColumn
+                        title="Dump all data"
+                        description="Exports all data stored in reducers into a file. Contains all sensitive data. Do not send this file to anyone."
+                    />
+                    <ActionColumn>
+                        <Button
+                            onClick={() => {
+                                dumpReducers();
+                            }}
+                        >
+                            Dump data
                         </Button>
                     </ActionColumn>
                 </Row>


### PR DESCRIPTION
close https://github.com/trezor/trezor-suite/issues/3719

no data censoring, just for QA purposes (that's why it is hidden in debug settings).
I would really like to see this as a public facing feature after implementing bulletproof censoring of sensitive data (balances, addresses, txids, xpubs,...).