### PR TITLE
Fix/fiat rates 1234

### DIFF
--- a/docs/SUMMARY.md
+++ b/docs/SUMMARY.md
@@ -20,6 +20,7 @@
 - [Miscellaneous](misc/index.md)
   - [Analytics](misc/analytics.md)
   - [Desktop Logger](misc/desktop_logger.md)
+  - [Fiat Rates](misc/fiat_rates.md)
   - [Feature Flags](misc/feature_flags.md)
   - [Localization](misc/localization.md)
   - [Review Process](misc/review.md)

--- a/docs/misc/fiat_rates.md
+++ b/docs/misc/fiat_rates.md
@@ -1,0 +1,99 @@
+# Fiat rates
+
+Suite provides several types of fiat rates:
+- Current fiat rate: Used on Dashboard, next to the account balance, for converting a crypto amount in send form to a fiat currency, etc...
+- Weekly rates: In addition to current rate we also fetch 7 days old rate and based on the difference we either show green or red arrow next to an exchange rate (can be seen in assets table on Dashboard).
+- Historical fiat rate: Exchange rate at the time of facilitating a transaction. Used in list of transactions to calculate daily deltas and in transaction detail modal. Not supported for ERC20 tokens.
+
+## Providers
+- Blockbook: For all main networks (BTC, LTC, ETH) except XRP and ERC20 tokens
+- Blockbook "live" updates: Apart from using Blockbook to manually fetch fiat rates, it also provides us with "live" fiat rate updates (basically push notifications via websocket) for all blockbook-supported coins (see above).
+- CoinGecko: Used for XRP, ERC20 tokens and as a fallback for failed requests to blockbook.
+
+## First fetch
+### Current fiat rates
+For main networks: On app launch for enabled networks and then immediately after enabling new coin/network
+#### Current fiat rates for ERC20 tokens
+ERC20 tokens: On `ACCOUNT.CREATE` which is triggered during account discovery (if account were not remembered), on `ACCOUNT.UPDATE` when `account.tokens` has some new items.
+### Weekly fiat rates
+Weekly rates are downloaded on app launch and on enabling new network.
+
+### Historical fiat rates (for transactions)
+Historical rates for transactions: On `TRANSACTION.ADD` action, which means after a new transaction is added, stored within the tx object, 
+
+## Update intervals
+### Current fiat rates
+Every rate stored in `wallet.fiat` reducer is checked in 2-minute interval. If the rate is older then 10 minutes then it is refetched. Although this shouldn't really be necessary thanks to live updates from Blockbook, the same logic is also used for ERC20 tokens and XRP where we don't have a comfort of receiving these updates and we are relying on manual checks.
+
+#### Current fiat rates for ERC20 tokens
+List of tokens is part of the account object (`account.tokens`).
+Fiat rates for ERC20 tokens are fetched on `ACCOUNT.CREATE` (fired during account discovery) and `ACCOUNT.UPDATE` (new token can appear after receiving a token transaction). These actions are intercepted in `fiatRatesMiddleware`.
+
+### Weekly fiat rates
+Check for deciding if a weekly rate for a coin needs to be updated runs every hour. Fetched rates are cached also for 1 hour. Eg. If user opens app and there are already weekly fiat rates, no older than 1 hour, stored in persistent storage then Suite won't fire new fetch. If, after one hour, fetch fails then next one will be fired after another hour.
+
+### Historical fiat rates (for transactions)
+They are stored as part of the transaction. They don't need to be periodically updated as the exchange rate in the past cannot change anymore. If fetch fails for some reason we will retry on next `BLOCKCHAIN.CONNECTED`.
+
+## Usage
+To make your life easier use [FiatValue](https://github.com/trezor/trezor-suite/blob/develop/packages/suite/src/components/suite/FiatValue/index.tsx) component.
+
+Most straightforward usage is to just pass `amount` and `symbol`, if you need to work with tokens also add `tokenAddress` property:
+```jsx
+ <FiatValue
+    amount={amount}
+    symbol={assetSymbol}
+    tokenAddress={tokenTransfer?.address}
+/>
+```
+
+For converting to fiat amount using rates from custom source use `useCustomSource` in combination with `source` property:
+```jsx
+<FiatValue
+    amount={targetAmount}
+    symbol={transaction.symbol}
+    source={transaction.rates}
+    useCustomSource
+/>
+```
+
+To support more complex use-cases we are leveraging render props.
+When passing function as a children it will get called with one parameter, object with `value`, `rate` and `timestamp`. This allows us to handle cases where fiat rates are missing (all fiels in the object are set `null`) or show not only fiat amount, but also used exchange rate.
+
+```jsx
+<FiatValue amount="1" symbol={symbol}>
+    {({ _value, rate, timestamp }) =>
+        rate && timestamp ? (
+            // we got rates!
+            // show the exchange rate and provide information about last update in tooltip
+            <Tooltip
+                content={
+                    <LastUpdate>
+                        <Translation
+                            id="TR_LAST_UPDATE"
+                            values={{
+                                value: (
+                                    <FormattedRelativeTime
+                                        value={rateAge(timestamp) * 60}
+                                        numeric="auto"
+                                        updateIntervalInSeconds={10}
+                                    />
+                                ),
+                            }}
+                        />
+                    </LastUpdate>
+                }
+            >
+                <FiatRateWrapper>
+                    {rate}
+                </FiatRateWrapper>
+            </Tooltip>
+        ) : (
+            // no rates available!
+            <NoRatesTooltip />
+        )
+    }
+</FiatValue>
+```
+
+There are other handy props like `showApproximationIndicator` (self explanatory) and `disableHiddenPlaceholder` which disables blurred overlay used when discreet-mode is activated.

--- a/packages/suite/src/actions/wallet/blockchainActions.ts
+++ b/packages/suite/src/actions/wallet/blockchainActions.ts
@@ -22,7 +22,11 @@ import { BLOCKCHAIN } from './constants';
 
 export type BlockchainAction =
     | {
-          type: typeof BLOCKCHAIN.READY | typeof BLOCKCHAIN.CONNECTED;
+          type: typeof BLOCKCHAIN.READY;
+      }
+    | {
+          type: typeof BLOCKCHAIN.CONNECTED;
+          payload: Network['symbol'];
       }
     | {
           type: typeof BLOCKCHAIN.RECONNECT_TIMEOUT_START;
@@ -271,7 +275,7 @@ export const onConnect = (symbol: string) => async (dispatch: Dispatch, getState
         const promises = accounts.map(a => dispatch(accountActions.fetchAndUpdateAccount(a)));
         await Promise.all(promises);
     }
-    dispatch({ type: BLOCKCHAIN.CONNECTED });
+    dispatch({ type: BLOCKCHAIN.CONNECTED, payload: symbol });
 };
 
 export const onBlockMined = (block: BlockchainBlock) => (

--- a/packages/suite/src/actions/wallet/fiatRatesActions.ts
+++ b/packages/suite/src/actions/wallet/fiatRatesActions.ts
@@ -280,7 +280,7 @@ export const updateTxsRates = (account: Account, txs: AccountTransaction[]) => a
 ) => {
     if (txs?.length === 0 || isTestnet(account.symbol)) return;
 
-    const timestamps = txs.map(tx => tx.blockTime ?? getBlockbookSafeTime());
+    const timestamps = txs.map(tx => getBlockbookSafeTime(tx.blockTime));
     const response = await TrezorConnect.blockchainGetFiatRatesForTimestamps({
         coin: account.symbol,
         timestamps,

--- a/packages/suite/src/middlewares/wallet/fiatRatesMiddleware.ts
+++ b/packages/suite/src/middlewares/wallet/fiatRatesMiddleware.ts
@@ -13,7 +13,7 @@ const fiatRatesMiddleware = (api: MiddlewareAPI<Dispatch, AppState>) => (next: D
 
     switch (action.type) {
         case BLOCKCHAIN.CONNECTED:
-            api.dispatch(fiatRatesActions.initRates());
+            api.dispatch(fiatRatesActions.initRates(action.payload));
             break;
         case BLOCKCHAIN.FIAT_RATES_UPDATE:
             api.dispatch(fiatRatesActions.onUpdateRate(action.payload));

--- a/packages/suite/src/middlewares/wallet/fiatRatesMiddleware.ts
+++ b/packages/suite/src/middlewares/wallet/fiatRatesMiddleware.ts
@@ -31,16 +31,17 @@ const fiatRatesMiddleware = (api: MiddlewareAPI<Dispatch, AppState>) => (next: D
 
             if (account.tokens) {
                 const difference = account.tokens.filter(
-                    t => !prevAccount?.tokens?.find(prevT => prevT.symbol === t.symbol),
+                    token =>
+                        !prevAccount?.tokens?.find(prevToken => prevToken.symbol === token.symbol),
                 );
 
-                difference.forEach(t => {
-                    if (t.symbol) {
+                difference.forEach(token => {
+                    if (token.symbol) {
                         api.dispatch(
                             fiatRatesActions.updateCurrentRates({
-                                symbol: t.symbol,
+                                symbol: token.symbol,
                                 mainNetworkSymbol: account.symbol,
-                                tokenAddress: t.address,
+                                tokenAddress: token.address,
                             }),
                         );
                     }
@@ -51,23 +52,19 @@ const fiatRatesMiddleware = (api: MiddlewareAPI<Dispatch, AppState>) => (next: D
         case ACCOUNT.CREATE: {
             // fetch current rates for account's tokens
             const account = action.payload;
-            if (account.tokens) {
-                account.tokens.forEach((t, i) => {
-                    if (t.symbol) {
-                        const s = t.symbol;
-                        // wait 500ms before firing next fetch
-                        setTimeout(() => {
-                            api.dispatch(
-                                fiatRatesActions.updateCurrentRates({
-                                    symbol: s,
-                                    mainNetworkSymbol: account.symbol,
-                                    tokenAddress: t.address,
-                                }),
-                            );
-                        }, i * 500);
-                    }
-                });
-            }
+            account.tokens?.forEach(token => {
+                if (!token.symbol) {
+                    return;
+                }
+                api.dispatch(
+                    fiatRatesActions.updateCurrentRates({
+                        symbol: token.symbol,
+                        mainNetworkSymbol: account.symbol,
+                        tokenAddress: token.address,
+                    }),
+                );
+            });
+
             break;
         }
         case WALLET_SETTINGS.CHANGE_NETWORKS:

--- a/packages/suite/src/services/coingecko.ts
+++ b/packages/suite/src/services/coingecko.ts
@@ -1,11 +1,55 @@
+/* eslint-disable max-classes-per-file */
 import { LastWeekRates, TickerId } from '@wallet-types/fiatRates';
 import FIAT_CONFIG from '@suite-config/fiat';
+import { differenceInMilliseconds } from 'date-fns';
 
+// a proxy for https://api.coingecko.com/api/v3
 const COINGECKO_API_BASE_URL = 'https://cdn.trezor.io/dynamic/coingecko/api/v3';
 
 interface HistoricalResponse extends LastWeekRates {
     symbol: string;
 }
+
+class RateLimiter {
+    // Poor man's coingecko rate limiter
+    // Slows down requests so there is `delayMs` gap between them
+    private delayMs: number; // gap between each request
+    private lastFetchTimestamp: number;
+    private queued: number; // how many requests are waiting to be fired
+    private totalDelay: number; // by how much time are we gonna slown down next request
+
+    constructor(delayMs: number) {
+        this.delayMs = delayMs;
+
+        this.lastFetchTimestamp = 0;
+        this.queued = 0;
+        this.totalDelay = 0;
+    }
+
+    async limit<T>(fn: () => Promise<T>): Promise<T> {
+        const msSinceLastFetch = differenceInMilliseconds(
+            new Date().getTime(),
+            this.lastFetchTimestamp,
+        );
+        if (msSinceLastFetch < this.delayMs) {
+            this.queued += 1;
+            this.totalDelay += this.delayMs;
+            // dummy wait for this.totalDelay before we fire next request
+            await new Promise(resolve => setTimeout(resolve, this.totalDelay)); // slow down firing next request
+        }
+
+        this.lastFetchTimestamp = new Date().getTime();
+        const results = await fn();
+        this.queued -= 1;
+        if (this.queued === 0) {
+            // if all queued requests were fired, we need to reset totalDelay to properly delay next batch of requests
+            this.totalDelay = 0;
+        }
+        return results;
+    }
+}
+
+const rateLimiter = new RateLimiter(1000);
 
 class FiatRatesFetchError extends Error {
     constructor(message: string) {
@@ -20,7 +64,7 @@ class FiatRatesFetchError extends Error {
 
 const fetchCoinGecko = async (url: string) => {
     try {
-        const res = await fetch(url);
+        const res = await rateLimiter.limit(() => fetch(url));
         if (!res.ok) {
             throw new FiatRatesFetchError(`${res.status}: ${url}`);
         }

--- a/packages/suite/src/utils/suite/date.ts
+++ b/packages/suite/src/utils/suite/date.ts
@@ -10,6 +10,7 @@ import {
     eachQuarterOfInterval,
     eachMonthOfInterval,
     eachDayOfInterval,
+    differenceInMinutes,
 } from 'date-fns';
 import { utcToZonedTime } from 'date-fns-tz';
 
@@ -84,14 +85,20 @@ export const calcTicksFromData = (data: { time: number }[]) => {
 };
 
 /**
- * Returns Blockbook-safe current unix timestamp (current time - 3 mins).
- * Little workaround for Blockbook as it doesn't return rates data for too recent timestamps.
+ * Little workaround for Blockbook API for fetching fiat rates for given timestamps (getFiatRatesForTimestamps)
+ * which doesn't return proper response if the timestamp is too recent.
+ * If passed timestamp is older than 3 minutes it is returned without any adjustments.
+ * Otherwise timestamp of 3 minutes ago is returned.
  *
  * @returns
  */
-export const getBlockbookSafeTime = () => {
-    const timestamp = getUnixTime(new Date());
-    return timestamp - 180; // current time - 3 mins
+export const getBlockbookSafeTime = (timestamp?: number) => {
+    const currentTimestamp = getUnixTime(new Date());
+    if (timestamp && differenceInMinutes(currentTimestamp * 1000, timestamp * 1000) > 3) {
+        // timestamp is older than 3 mins, no adjustment needed
+        return timestamp;
+    }
+    return currentTimestamp - 180;
 };
 
 /**


### PR DESCRIPTION
close https://github.com/trezor/trezor-suite/issues/3459
close https://github.com/trezor/trezor-suite/issues/3662
close https://github.com/trezor/trezor-suite/issues/1772
close https://github.com/trezor/trezor-suite/issues/3365

I think the biggest problem was that after sending and/or receiving new tx fiat rates were not downloaded properly because Blockbook won't return any rates for too recent timestamps, it was already work-arounded long time ago I just failed to use the workaround properly. (1st commit)

As a bonus I added global limiter (more like slowdown-ner) for all request to coingecko as I realised since all fiat rates are periodically updated Suite would probably fire requests for all tokens at the same time next time the update is needed. However, this still won't resolve the problem that our own proxy is getting rate limited (this fix won't prevent 1000 users firing 1 request at the same time) and if the proxy is implemented correctly this shouldn't even help with anything. (2nd commit)

And for rare cases when some user has stored transactions in idb without historical rates attached to them I added refetch logic that is triggered after connecting to blockchain (basically happens after app is launched and data from storage are loaded). (3rd commit).

plus I added some docs https://github.com/trezor/trezor-suite/blob/06469fdddf61e539a38ceecbac5d8626256633f6/docs/misc/fiat_rates.md