### PR TITLE
fix(ci): add debug variable for e2e web job

### DIFF
--- a/ci/packages/suite-web.yml
+++ b/ci/packages/suite-web.yml
@@ -122,6 +122,8 @@ suite-web deploy dev:
     # when debugging or developing tests it does not make sense to have retries,
     # in other cases retries are useful to avoid occasional failures due to flaky tests
     ALLOW_RETRY: 1
+    CI_DEBUG_TRACE: "true"
+    # verbose output for debugging jobs, should display same output as on the runners
   script:
     - yarn install --pure-lockfile --cache-folder .yarn --prefer-offline
     - docker-compose pull


### PR DESCRIPTION
This should enable more verbose output in the job logs.