### PR TITLE
Fix/3733 discreet mode nitpicks

### DIFF
--- a/packages/suite/src/components/suite/modals/TransactionDetail/components/AmountDetails/index.tsx
+++ b/packages/suite/src/components/suite/modals/TransactionDetail/components/AmountDetails/index.tsx
@@ -26,12 +26,13 @@ const AmountWrapper = styled.div`
     font-size: ${variables.NEUE_FONT_SIZE.SMALL};
     font-weight: ${variables.FONT_WEIGHT.MEDIUM};
     align-items: center;
-    overflow-x: auto; /* allow x-axis scrolling: useful on small screens when fiat amount is displayed */
+    overflow: visible;
     word-break: break-all;
 
     @media only screen and (max-width: ${variables.SCREEN_SIZE.SM}) {
         /* decrease the width of the first (title) column on small screen */
         grid-template-columns: 90px minmax(110px, auto) minmax(100px, auto) minmax(100px, auto);
+        overflow-x: auto;
     }
 `;
 

--- a/packages/suite/src/components/suite/modals/TransactionDetail/components/BasicDetails/index.tsx
+++ b/packages/suite/src/components/suite/modals/TransactionDetail/components/BasicDetails/index.tsx
@@ -62,14 +62,14 @@ const Grid = styled.div<{ showRbfCols?: boolean }>`
     display: grid;
     border-top: 1px solid ${props => props.theme.STROKE_GREY};
     grid-gap: 12px;
-    grid-template-columns: 100px 2fr 80px 3fr; /* title value title value */
+    grid-template-columns: 100px minmax(0, 2fr) 80px minmax(0, 3fr); /* title value title value */
     font-size: ${variables.NEUE_FONT_SIZE.SMALL};
     font-weight: ${variables.FONT_WEIGHT.MEDIUM};
     padding: 28px 6px 10px 6px;
     text-align: left;
 
     @media only screen and (max-width: ${variables.SCREEN_SIZE.MD}) {
-        grid-template-columns: 110px 1fr;
+        grid-template-columns: 110px minmax(0, 1fr);
     }
 `;
 
@@ -92,6 +92,7 @@ const Value = styled.div`
 
 const TxidValue = styled(Value)`
     padding-right: 32px;
+    overflow: visible;
 `;
 
 const IconWrapper = styled.div`

--- a/packages/suite/src/components/suite/modals/TransactionDetail/components/IODetails/index.tsx
+++ b/packages/suite/src/components/suite/modals/TransactionDetail/components/IODetails/index.tsx
@@ -3,7 +3,7 @@ import styled from 'styled-components';
 import { Icon, useTheme, variables } from '@trezor/components';
 import { WalletAccountTransaction } from '@wallet-reducers/transactionReducer';
 import { getNetwork } from '@wallet-utils/accountUtils';
-import { FormattedCryptoAmount, Translation } from '@suite-components';
+import { FormattedCryptoAmount, HiddenPlaceholder, Translation } from '@suite-components';
 
 const Wrapper = styled.div`
     text-align: left;
@@ -40,7 +40,7 @@ const CryptoAmountWrapper = styled.div`
     flex: 0 0 auto;
 `;
 
-const Address = styled.div`
+const Address = styled(props => <HiddenPlaceholder {...props} />)`
     text-overflow: ellipsis;
     overflow: hidden;
 `;
@@ -78,12 +78,11 @@ const IODetails = ({ tx }: Props) => {
                                         <FormattedCryptoAmount
                                             value={input.value}
                                             symbol={tx.symbol}
-                                            disableHiddenPlaceholder
                                         />
                                         <Circle>&bull;</Circle>
                                     </CryptoAmountWrapper>
                                 )}
-                                <Address>{input.addresses?.map(addr => addr)}</Address>
+                                <Address>{input.addresses}</Address>
                             </IORow>
                         ))}
                     </IOBox>
@@ -105,7 +104,7 @@ const IODetails = ({ tx }: Props) => {
                                     />
                                     <Circle>&bull;</Circle>
                                 </CryptoAmountWrapper>
-                                <Address>{output.addresses?.map(addr => addr)}</Address>
+                                <Address>{output.addresses}</Address>
                             </IORow>
                         ))}
                     </IOBox>

--- a/packages/suite/src/config/suite/animation.ts
+++ b/packages/suite/src/config/suite/animation.ts
@@ -7,6 +7,7 @@ export default {
             },
             visible: {
                 height: 'auto',
+                transitionEnd: { overflow: 'unset' }, // overflow needs to be unset after animation
             },
         },
         initial: 'initial',

--- a/packages/suite/src/views/wallet/send/components/Outputs/index.tsx
+++ b/packages/suite/src/views/wallet/send/components/Outputs/index.tsx
@@ -1,6 +1,6 @@
 import React, { useRef, useEffect, useState } from 'react';
 import styled, { css } from 'styled-components';
-import { AnimatePresence, motion, MotionProps } from 'framer-motion';
+import { AnimatePresence, motion } from 'framer-motion';
 import { useSendFormContext } from '@wallet-hooks';
 import Address from './components/Address';
 import Amount from './components/Amount';
@@ -64,12 +64,7 @@ const Outputs = ({ disableAnim }: Props) => {
         }
     }, [outputs.length, renderedOutputs, setRenderedOutputs]);
 
-    const customAnim: MotionProps = { ...ANIMATION.EXPAND };
-    customAnim.variants!.visible = {
-        height: 'auto',
-        transitionEnd: { overflow: 'unset' }, // overflow needs to be unset after animation (dropdowns inside)
-    };
-    const animation = outputs.length > 1 && !disableAnim ? customAnim : {}; // do not animate if there is only 1 output, prevents animation on clear
+    const animation = outputs.length > 1 && !disableAnim ? ANIMATION.EXPAND : {}; // do not animate if there is only 1 output, prevents animation on clear
 
     return (
         <AnimatePresence initial={false}>


### PR DESCRIPTION
close #3733

- Add discreet mode on Inputs amounts and also on addresses in transaction detail.
- Fix sharp edges on some of the blurred elements. I can't find any global solution keeping the same UI, because the blur is overflowing the element and there is no way to reset the overflow: hidden prop from any of parent elements. One possible global solution could be adding some rounded clip path (`clip-path: inset(0px round 5px);`) but it means turning of the smooth edges completely. I would suggest to replace the blur filter with some skeleton to make it even more private.
