### PR TITLE
fix(suite): edit settings layout

### DIFF
--- a/packages/suite/src/components/settings/SettingsLayout/index.tsx
+++ b/packages/suite/src/components/settings/SettingsLayout/index.tsx
@@ -2,11 +2,13 @@ import React from 'react';
 import styled from 'styled-components';
 import { LayoutContext } from '@suite-components';
 import { SettingsMenu } from '@settings-components';
+import { variables } from '@trezor/components';
 
 const Wrapper = styled.div`
     display: flex;
     flex: 1;
     flex-direction: column;
+    max-width: ${variables.SCREEN_SIZE.MD};
 `;
 
 type Props = {

--- a/packages/suite/src/components/settings/SettingsMenu/index.tsx
+++ b/packages/suite/src/components/settings/SettingsMenu/index.tsx
@@ -7,6 +7,7 @@ import * as modalActions from '@suite-actions/modalActions';
 import * as suiteActions from '@suite-actions/suiteActions';
 import * as routerActions from '@suite-actions/routerActions';
 import { SUPPORT_URL } from '@suite-constants/urls';
+import { variables } from '@trezor/components';
 
 const StyledLink = styled(ExternalLink)`
     padding: 10px 16px;
@@ -26,7 +27,7 @@ const SettingsMenu = () => {
 
     return (
         <AppNavigationPanel
-            maxWidth="default"
+            maxWidth={variables.SCREEN_SIZE.MD}
             title={
                 <span
                     aria-hidden="true"

--- a/packages/suite/src/components/suite/Settings/components/TextColumn.tsx
+++ b/packages/suite/src/components/suite/Settings/components/TextColumn.tsx
@@ -1,7 +1,8 @@
 import React from 'react';
 import styled from 'styled-components';
 import { variables } from '@trezor/components';
-import { Translation, ExternalLink } from '@suite-components';
+import { Translation, TrezorLink } from '@suite-components';
+import { Button } from '@trezor/components';
 
 interface TextColumnProps {
     title?: React.ReactNode;
@@ -15,6 +16,11 @@ const Wrapper = styled.div`
     flex-direction: column;
     text-align: left;
     margin-right: 16px;
+    max-width: 500px;
+`;
+
+const LearnMoreButton = styled(Button)`
+    max-width: fit-content;
 `;
 
 const Description = styled.div`
@@ -37,9 +43,11 @@ const TextColumn = ({ title, description, learnMore }: TextColumnProps) => (
         {title && <Title>{title}</Title>}
         {description && <Description>{description}</Description>}
         {learnMore && (
-            <ExternalLink href={learnMore} size="tiny">
-                <Translation id="TR_LEARN_MORE" />
-            </ExternalLink>
+            <TrezorLink href={learnMore}>
+                <LearnMoreButton variant="tertiary">
+                    <Translation id="TR_LEARN_MORE" />
+                </LearnMoreButton>
+            </TrezorLink>
         )}
     </Wrapper>
 );


### PR DESCRIPTION
Design: [Zeplin](https://app.zeplin.io/project/5ee87c00f6af719a645d14c3/screen/5faaa48ab6e7968540370da5)

- Edit settings layout max-width to 768px
- Change settings button type to terciary on 'Learn more' buttons
- Add settings description max-width 500px

