### PR TITLE
feat(ci): gitlab dependency proxy for docker images

### DIFF
--- a/ci/docker/base/Dockerfile
+++ b/ci/docker/base/Dockerfile
@@ -1,5 +1,7 @@
 # Base
-FROM debian:buster-slim as base
+## Use a proxy or fallback to no proxy at all (direct access to Docker Hub).
+ARG CI_DOCKER_PROXY=""
+FROM ${CI_DOCKER_PROXY}debian:buster-slim as base
 
 RUN apt-get update && \
     apt-get install -y --no-install-recommends \
@@ -26,7 +28,7 @@ RUN curl -L https://github.com/docker/compose/releases/download/$DOCKER_COMPOSE_
 
 # Final image
 # buster is for debian 10. the same version as firmware team has in its Dockerfile.
-FROM node:14-buster
+FROM ${CI_DOCKER_PROXY}node:14-buster
 
 RUN apt-get update && apt-get install -y \
     build-essential \
@@ -71,7 +73,7 @@ RUN \
 RUN \
     wget -q https://github.com/cli/cli/releases/download/v1.10.2/gh_1.10.2_linux_amd64.deb && \
     dpkg -i gh_1.10.2_linux_amd64.deb && \
-    rm gh_1.10.2_linux_amd64.deb 
+    rm gh_1.10.2_linux_amd64.deb
 
 # "fake" dbus address to prevent errors
 # https://github.com/SeleniumHQ/docker-selenium/issues/87

--- a/ci/environment.yml
+++ b/ci/environment.yml
@@ -19,9 +19,3 @@ install:
   stage: setup environment
   script:
     - ci/scripts/check_lockfile.sh
-
-clear_cache:
-  stage: setup environment
-  when: manual
-  script:
-    - rm -rf .yarn node_modules packages/**/node_modules packages/*/lib packages/*/build packages/*/dist

--- a/ci/environment.yml
+++ b/ci/environment.yml
@@ -2,16 +2,17 @@ build & push image:
   stage: setup environment
   when: manual
   before_script:
+    - docker login $CI_DEPENDENCY_PROXY_SERVER -u $CI_DEPENDENCY_PROXY_USER -p $CI_DEPENDENCY_PROXY_PASSWORD
     - docker login $CI_REGISTRY -u $CI_REGISTRY_USER -p $CI_REGISTRY_PASSWORD
   variables:
     DOCKER_TLS_CERTDIR: ''
     CONTAINER_NAME: "$CI_REGISTRY/satoshilabs/trezor/trezor-suite/base"
-  image: docker
+  image: $CI_DEPENDENCY_PROXY_GROUP_IMAGE_PREFIX/docker
   services:
     - docker:dind
   script:
     - docker pull $CONTAINER_NAME:latest || true
-    - docker build --no-cache --tag $CONTAINER_NAME:$CI_COMMIT_SHA --tag $CONTAINER_NAME:latest ./ci/docker/base
+    - docker build --build-arg CI_DOCKER_PROXY="$CI_DEPENDENCY_PROXY_GROUP_IMAGE_PREFIX/" --no-cache --tag $CONTAINER_NAME:$CI_COMMIT_SHA --tag $CONTAINER_NAME:latest ./ci/docker/base
     - docker push $CONTAINER_NAME:$CI_COMMIT_SHA
     - docker push $CONTAINER_NAME:latest
 

--- a/ci/packages/suite-desktop.yml
+++ b/ci/packages/suite-desktop.yml
@@ -128,7 +128,7 @@ suite-desktop build windows:
   <<: *config_sign_dev
   only:
     <<: *run_everything_rules
-  image: electronuserland/builder:wine
+  image: $CI_DEPENDENCY_PROXY_GROUP_IMAGE_PREFIX/electronuserland/builder:wine
   variables:
     artifact: ${DESKTOP_APP_NAME}*
     platform: win
@@ -139,7 +139,7 @@ suite-desktop build windows manual:
   when: manual
   except:
     <<: *run_everything_rules
-  image: electronuserland/builder:wine
+  image: $CI_DEPENDENCY_PROXY_GROUP_IMAGE_PREFIX/electronuserland/builder:wine
   variables:
     artifact: ${DESKTOP_APP_NAME}*
     platform: win
@@ -152,7 +152,7 @@ suite-desktop build windows codesign:
       - codesign
   tags:
     - darwin
-  image: electronuserland/builder:wine
+  image: $CI_DEPENDENCY_PROXY_GROUP_IMAGE_PREFIX/electronuserland/builder:wine
   variables:
     IS_CODESIGN_BUILD: "true"
     artifact: ${DESKTOP_APP_NAME}*

--- a/ci/packages/suite-native.yml
+++ b/ci/packages/suite-native.yml
@@ -1,5 +1,5 @@
 suite-native build android:
-  image: reactnativecommunity/react-native-android
+  image: $CI_DEPENDENCY_PROXY_GROUP_IMAGE_PREFIX/reactnativecommunity/react-native-android
   stage: build
   script:
     - yarn install --frozen-lockfile --cache-folder .yarn --prefer-offline

--- a/ci/packages/suite-web.yml
+++ b/ci/packages/suite-web.yml
@@ -28,6 +28,7 @@ suite-web build dev:
       - packages/suite-web/build
 
 # to be removed after beta-wallet is officially killed
+
 suite-web build beta:
   stage: build
   <<: *config_sign_dev
@@ -122,6 +123,8 @@ suite-web deploy dev:
     # when debugging or developing tests it does not make sense to have retries,
     # in other cases retries are useful to avoid occasional failures due to flaky tests
     ALLOW_RETRY: 1
+  before_script:
+    - docker login $CI_DEPENDENCY_PROXY_SERVER -u $CI_DEPENDENCY_PROXY_USER -p $CI_DEPENDENCY_PROXY_PASSWORD
   script:
     - yarn install --pure-lockfile --cache-folder .yarn --prefer-offline
     - docker-compose pull

--- a/docker/docker-compose.suite-ci.yml
+++ b/docker/docker-compose.suite-ci.yml
@@ -7,7 +7,7 @@ services:
       - XDG_RUNTIME_DIR=/var/tmp
     network_mode: bridge # this makes docker reuse existing networks
   test-run:
-    image: cypress/included:6.4.0
+    image: $CI_DEPENDENCY_PROXY_GROUP_IMAGE_PREFIX/cypress/included:6.4.0
     entrypoint: []
     environment:
       - CYPRESS_SNAPSHOT=$CYPRESS_SNAPSHOT

--- a/docker/suite/Dockerfile
+++ b/docker/suite/Dockerfile
@@ -2,8 +2,9 @@
 # dependencies on host (yarn, node). But all source files remain on host. We must ensure that permissions 
 # of newly created files in docker (entire monorepo is mounted volume) match users default.
 # Otherwise user would run into permission denied problem when trying to rebuild project outside docker.
-
-FROM node:14
+## Use a proxy or fallback to no proxy at all (direct access to Docker Hub).
+ARG CI_DOCKER_PROXY=""
+FROM ${CI_DOCKER_PROXY}node:14
   
 RUN apt-get update && apt-get -y --no-install-recommends install \
     ca-certificates \

--- a/docker/test-runner/Dockerfile
+++ b/docker/test-runner/Dockerfile
@@ -1,4 +1,6 @@
-FROM cypress/included:6.4.0
+## Use a proxy or fallback to no proxy at all (direct access to Docker Hub).
+ARG CI_DOCKER_PROXY=""
+FROM ${CI_DOCKER_PROXY}cypress/included:6.4.0
 
 RUN apt-get update && apt-get -y --no-install-recommends install \
     ca-certificates \


### PR DESCRIPTION
Added GitLab dependency proxy for all docker images used in GitLab CI, so we are not limited by Docker hub pull rate limiting. This pr also contains commit where I removed unnecessary and unused job in GitLab CI.