### PR TITLE
fix: align the logged path with the actual path

### DIFF
--- a/packages/suite-data/src/message-system/scripts/sign-config.ts
+++ b/packages/suite-data/src/message-system/scripts/sign-config.ts
@@ -38,11 +38,9 @@ const getConfigJwsSignature = () => {
 };
 
 const saveConfigJwsSignature = jwsConfig => {
-    fs.outputFileSync(
-        join(PACKAGE_ROOT, 'files', 'message-system', JWS_CONFIG_FILENAME),
-        jwsConfig,
-    );
-    console.log(`JWS signature saved to ${join(PROJECT_ROOT, 'config', JWS_CONFIG_FILENAME)}!`);
+    const destination = join(PACKAGE_ROOT, 'files', 'message-system', JWS_CONFIG_FILENAME);
+    fs.outputFileSync(destination, jwsConfig);
+    console.log(`JWS signature saved to ${destination}!`);
 };
 
 const jwsConfig = getConfigJwsSignature();


### PR DESCRIPTION
@tomasklim just a quick fix I stumbled upon. The logged path was different from the path where the signature was actually written.
