### PR TITLE
feat(ci): github-cli automatic release to github

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -1,5 +1,5 @@
 # ! DO NOT set latest here USE custom hash !
-image: registry.gitlab.com/satoshilabs/trezor/trezor-suite/base@sha256:a11083e6fddc1b10f878b7c23bc282b9545d6d0951e8ecad6ffeecc902aa2766
+image: registry.gitlab.com/satoshilabs/trezor/trezor-suite/base@sha256:cfc62bc28946f0789a10dde4ecd3990ee7502e92de3dc2fa4d4ca84a329f7d21
 
 variables:
   DEV_SERVER_URL: "https://suite.corp.sldev.cz"

--- a/ci/docker/base/Dockerfile
+++ b/ci/docker/base/Dockerfile
@@ -44,6 +44,7 @@ RUN apt-get update && apt-get install -y \
     libsdl2-image-dev \
     # why not
     zip \
+    jq \
     rsync
 
 
@@ -65,6 +66,12 @@ RUN \
     apt-get update && \
     apt-get install -y dbus-x11 google-chrome-stable google-chrome-beta && \
     rm -rf /var/lib/apt/lists/*
+
+# install GitHub-cli
+RUN \
+    wget -q https://github.com/cli/cli/releases/download/v1.10.2/gh_1.10.2_linux_amd64.deb && \
+    dpkg -i gh_1.10.2_linux_amd64.deb && \
+    rm gh_1.10.2_linux_amd64.deb 
 
 # "fake" dbus address to prevent errors
 # https://github.com/SeleniumHQ/docker-selenium/issues/87

--- a/ci/releases.yml
+++ b/ci/releases.yml
@@ -32,6 +32,29 @@ suite codesign deploy staging-suite:
   tags:
     - deploy
 
+# Create a GitHub release and append signed binaries
+suite-desktop github release:
+  stage: deploy to production
+  needs:
+    - suite-desktop build mac codesign
+    - suite-desktop build linux codesign
+    - suite-desktop build windows codesign
+  environment:
+    name: ${CI_BUILD_REF_NAME}-staging-suite
+    url: ${STAGING_SUITE_SERVER_URL}
+  before_script: []
+  only:
+    refs:
+      - codesign
+  when: manual
+  script:
+    - gh config set prompt disabled
+    - echo $GITHUB_CLI_RELEASE_TOKEN | gh auth login --with-token
+    - VERSION=$(jq -r .version packages/suite-desktop/package.json)
+    - gh release create --repo trezor/trezor-suite --draft v${VERSION}  --title "v${VERSION}" ./Trezor-Suite* latest*
+  tags:
+    - deploy
+
 release commit messages:
   stage: deploy to staging
   only:


### PR DESCRIPTION
Together with @ondrejsika we created github-cli script which will create a draft release and upload all artefacts to GitHub release page. The tag will be created base on the version from package.json file in suite-desktop. For this, to work we had to modify the base docker image and add the necessary tools.  We should wait for pr #3779 before we merge this.