### PR TITLE
chore(suite): react-hook-form update

### DIFF
--- a/packages/suite/package.json
+++ b/packages/suite/package.json
@@ -37,7 +37,7 @@
         "react": "17.0.1",
         "react-dom": "17.0.1",
         "react-focus-lock": "^2.5.0",
-        "react-hook-form": "6.14.1",
+        "react-hook-form": "6.15.7",
         "react-hotkeys-hook": "^3.0.3",
         "react-intersection-observer": "^8.31.0",
         "react-intl": "^5.10.19",

--- a/yarn.lock
+++ b/yarn.lock
@@ -19693,10 +19693,10 @@ react-helmet-async@^1.0.2:
     react-fast-compare "^3.2.0"
     shallowequal "^1.1.0"
 
-react-hook-form@6.14.1:
-  version "6.14.1"
-  resolved "https://registry.yarnpkg.com/react-hook-form/-/react-hook-form-6.14.1.tgz#c15f03fe8a7df76232bd4ac07b87317acab0cbd8"
-  integrity sha512-Bf2fWcL2F34hUUqrx1rpgZ8ZErQ4/DvrPs6Je+lUYL59km8PXIQqyCTz/NbggC1RQUj7rChSmTx6eFap+mCttw==
+react-hook-form@6.15.7:
+  version "6.15.7"
+  resolved "https://registry.yarnpkg.com/react-hook-form/-/react-hook-form-6.15.7.tgz#e5ad7a9f73b0311ee770c56951276a3b85b06656"
+  integrity sha512-cfJoBCF/hEjrgfto+70pLDi/F5IBWr5hQhYDFklxb+zyttQORVs+y70OaY4Z4V3IZFeY5oN3ECzEwBaiO1tT1A==
 
 react-hotkeys-hook@^3.0.3:
   version "3.0.3"


### PR DESCRIPTION
The latest version includes `useWatch` that isolates re-rendering at the component level and potentially results in better performance than using `watch`.

I'd like to use `useWatch` in coin market forms.