### PR TITLE
fix(suite): update of btc-only fw to btc-only fw

### DIFF
--- a/packages/suite/src/actions/firmware/constants/firmware.ts
+++ b/packages/suite/src/actions/firmware/constants/firmware.ts
@@ -4,3 +4,4 @@ export const ENABLE_REDUCER = '@firmware/enable-reducer';
 export const RESET_REDUCER = '@firmware/reset-reducer';
 export const SET_ERROR = '@firmware/set-error';
 export const TOGGLE_HAS_SEED = '@firmware/toggle-has-seed';
+export const REMEMBER_PREVIOUS_DEVICE = '@firmware/remember-previous-device';

--- a/packages/suite/src/reducers/firmware/firmwareReducer.ts
+++ b/packages/suite/src/reducers/firmware/firmwareReducer.ts
@@ -1,8 +1,10 @@
 import produce from 'immer';
-import { UI, DEVICE, Device } from 'trezor-connect';
+import { UI, Device } from 'trezor-connect';
+
 import { FIRMWARE } from '@firmware-actions/constants';
 import { SUITE } from '@suite-actions/constants';
-import { Action, AcquiredDevice } from '@suite-types';
+
+import type { Action, AcquiredDevice } from '@suite-types';
 
 type FirmwareUpdateCommon = {
     installingProgress?: number;
@@ -65,7 +67,6 @@ const firmwareUpdate = (state: FirmwareUpdateState = initialState, action: Actio
             case FIRMWARE.TOGGLE_HAS_SEED:
                 draft.hasSeed = !state.hasSeed;
                 break;
-
             case SUITE.ADD_BUTTON_REQUEST:
                 if (action.payload === 'ButtonRequest_FirmwareUpdate') {
                     draft.status = 'waiting-for-confirmation';
@@ -75,11 +76,11 @@ const firmwareUpdate = (state: FirmwareUpdateState = initialState, action: Actio
                 draft.installingProgress = action.payload.progress;
                 draft.status = 'installing';
                 break;
-            case FIRMWARE.RESET_REDUCER:
-                return initialState;
-            case DEVICE.DISCONNECT:
+            case FIRMWARE.REMEMBER_PREVIOUS_DEVICE:
                 draft.prevDevice = action.payload;
                 break;
+            case FIRMWARE.RESET_REDUCER:
+                return initialState;
             default:
 
             // no default


### PR DESCRIPTION
Right now, if you update device with btc-only fw. It is updated to device with regular fw.

Problem is that we cannot detect if device fw is btc-only or not, if device is in bootloader mode. For this reason, we have to store data about previously connected device in non-bootloader mode. Moreover, we want to store data about previous device only in firmware update modal.
