### PR TITLE
feat(fwUpdate): wait for reboot instead of instructiong to unplug for…

### DIFF
--- a/packages/suite/src/actions/firmware/firmwareActions.ts
+++ b/packages/suite/src/actions/firmware/firmwareActions.ts
@@ -108,10 +108,12 @@ export const firmwareUpdate = () => async (dispatch: Dispatch, getState: GetStat
     }
 
     // model 1
-    // ask user to unplug device (see firmwareMiddleware)
+    // ask user to unplug device if BL < 1.10.0 (see firmwareMiddleware), BL starting with 1.10.0 will automatically restart itself just like on model T
     // model 2 without pin
     // ask user to wait until device reboots
-    dispatch(setStatus(model === 1 ? 'unplug' : 'wait-for-reboot'));
+    dispatch(
+        setStatus(model === 1 && device.features.minor_version < 10 ? 'unplug' : 'wait-for-reboot'),
+    );
 };
 
 export const toggleHasSeed = (): FirmwareAction => ({


### PR DESCRIPTION
… BL >= 1.10.0

BL starting with version 1.10.0 will automatically restart after fw update. So instead of instructing the user to unplug the device we will wait for the restart to complete just like on model T.

close https://github.com/trezor/trezor-suite/issues/3675