### PR TITLE
fix: incorrect device features unlocked type

### DIFF
--- a/packages/suite/src/reducers/suite/deviceReducer.ts
+++ b/packages/suite/src/reducers/suite/deviceReducer.ts
@@ -35,7 +35,7 @@ const merge = (device: AcquiredDevice, upcoming: Partial<AcquiredDevice>): Trezo
             ? upcoming.features
             : device.features),
         // ...except for `unlocked` which should reflect the actual state of the device.
-        unlocked: !!upcoming.features?.unlocked,
+        unlocked: upcoming.features ? upcoming.features.unlocked : null,
     },
 });
 

--- a/patches/trezor-connect+8.1.28-beta.1.patch
+++ b/patches/trezor-connect+8.1.28-beta.1.patch
@@ -1,0 +1,26 @@
+diff --git a/node_modules/trezor-connect/lib/types/trezor/protobuf.js.flow b/node_modules/trezor-connect/lib/types/trezor/protobuf.js.flow
+index 0c64934..bc18dfc 100644
+--- a/node_modules/trezor-connect/lib/types/trezor/protobuf.js.flow
++++ b/node_modules/trezor-connect/lib/types/trezor/protobuf.js.flow
+@@ -1367,7 +1367,7 @@ export type Features = {
+     revision: string | null,
+     bootloader_hash: string | null,
+     imported: boolean | null,
+-    unlocked: boolean,
++    unlocked: boolean | null,
+     firmware_present: boolean | null,
+     needs_backup: boolean | null,
+     flags: number | null,
+diff --git a/node_modules/trezor-connect/lib/typescript/trezor/protobuf.d.ts b/node_modules/trezor-connect/lib/typescript/trezor/protobuf.d.ts
+index 41bc045..e341ce6 100644
+--- a/node_modules/trezor-connect/lib/typescript/trezor/protobuf.d.ts
++++ b/node_modules/trezor-connect/lib/typescript/trezor/protobuf.d.ts
+@@ -1345,7 +1345,7 @@ export type Features = {
+     revision: string | null;
+     bootloader_hash: string | null;
+     imported: boolean | null;
+-    unlocked: boolean;
++    unlocked: boolean | null;
+     firmware_present: boolean | null;
+     needs_backup: boolean | null;
+     flags: number | null;


### PR DESCRIPTION
Fixing forgotten change of unlocked attribute in device features.

As `unlocked` can be either `boolean` or `null`, fixed logic in `deviceReducer.ts` after merging [#3774](https://github.com/trezor/trezor-suite/pull/3774) incorrectly set `false` to `unlocked` attribute even when `unlocked` was `null`.

Corresponding fix in connect [connect #824](https://github.com/trezor/connect/pull/824)