### PR TITLE
feat/analytics 1.9

### DIFF
--- a/docs/misc/analytics.md
+++ b/docs/misc/analytics.md
@@ -49,6 +49,54 @@ Breaking change should bump major version. Any other change bumps minor version.
 
 ## Changelog
 
+### 1.9
+Changed:
+- use `stable.log` for codesign builds and `develop.log` otherwise
+- `suite-ready` is now also tracked on initial run
+
+Added:
+- suite-ready
+  - platformLanguages: string
+- device-connect
+  - language: string
+  - model: string
+- settings/device/goto/background
+  - custom: boolean
+- settings/device/background  
+  - image: string | undefined (gallery image)
+  - format: string | undefined (custom image)
+  - size: number | undefined (custom image)
+  - resolutionWidth: number | undefined (custom image)
+  - resolutionHeight: number | undefined (custom image)
+- add-token
+  - token: string
+- transaction-created
+  - action: 'sent' | 'copied' | 'downloaded' | 'replace'
+  - symbol: string
+  - tokens: string
+  - outputsCount: number
+  - broadcast: boolean
+  - bitcoinRbf: boolean
+  - bitcoinLockTime: boolean
+  - ethereumData: boolean
+  - rippleDestinationTag: boolean
+  - ethereumNonce: boolean
+  - selectedFee: string
+- menu/notifications/toggle
+  - value: boolean
+- menu/settings/toggle
+  - value: boolean
+- menu/settings/dropdown
+  - option: 'all' | 'general' | 'device' | 'coins'
+- menu/goto/tor
+- accounts/empty-account/receive
+
+Fixed:
+- device-update-firmware
+  - toBtcOnly
+- accounts/empty-account/buy
+  - symbol (lowercase instead of uppercase)
+
 ### 1.8
 Added: 
 - settings/device/update-auto-lock
@@ -72,8 +120,10 @@ Fixed:
 - analytics/dispose
 
 Removed:
- - menu/goto/exchange-index
+- menu/goto/exchange-index
  
+Changed:
+- `desktop` build is now tracked to `stable.log` instead of `beta.log`
 ### 1.7
 Added:
 - send-raw-transaction

--- a/packages/suite-native/src/utils/suite/env.ts
+++ b/packages/suite-native/src/utils/suite/env.ts
@@ -23,6 +23,8 @@ export const getPlatform = () => 'todo react-native';
 
 export const getPlatformLanguage = () => 'en';
 
+export const getPlatformLanguages = () => ['en'];
+
 export const getLocationOrigin = () => 'implementation of getLocationOrigin in native';
 
 export const getLocationHostname = () =>

--- a/packages/suite/src/actions/firmware/__tests__/firmwareActions.test.ts
+++ b/packages/suite/src/actions/firmware/__tests__/firmwareActions.test.ts
@@ -69,6 +69,7 @@ export const getInitialState = (override?: InitialState): any => {
                 },
             },
             locks: [],
+            flags: {},
             ...suite,
         },
         firmware: firmwareReducer(undefined, { type: 'foo' } as any),

--- a/packages/suite/src/actions/recovery/__tests__/recoveryActions.test.ts
+++ b/packages/suite/src/actions/recovery/__tests__/recoveryActions.test.ts
@@ -25,14 +25,18 @@ export const getInitialState = (custom?: any): any => ({
         device: {
             features: {
                 // eslint-disable-next-line
-                    major_version: 2,
+                major_version: 2,
             },
         },
+        flags: {},
         locks: [],
     },
     recovery: {
         ...recoveryReducer(undefined, {} as Action),
         ...custom,
+    },
+    analytics: {
+        enabled: false,
     },
 });
 

--- a/packages/suite/src/actions/suite/__tests__/analyticsActions.test.ts
+++ b/packages/suite/src/actions/suite/__tests__/analyticsActions.test.ts
@@ -60,12 +60,9 @@ describe('Analytics Actions', () => {
         };
     });
     beforeEach(() => {
-        const mockSuccessResponse = {};
-        const mockJsonPromise = Promise.resolve(mockSuccessResponse);
         const mockFetchPromise = Promise.resolve({
-            json: () => mockJsonPromise,
+            json: () => Promise.resolve({}),
         });
-        // @ts-ignore
         global.fetch = jest.fn().mockImplementation(() => mockFetchPromise);
         // @ts-ignore
         jest.spyOn(global, 'fetch').mockImplementation(() => mockFetchPromise);
@@ -84,10 +81,9 @@ describe('Analytics Actions', () => {
         });
         const store = initStore(state);
         store.dispatch(analyticsActions.report({ type: 'switch-device/eject' }));
-        // @ts-ignore
         expect(global.fetch).toHaveBeenNthCalledWith(
             1,
-            `https://data.trezor.io/suite/log/desktop/stable.log?c_v=${analyticsActions.version}&c_type=switch-device%2Feject&c_instance_id=1&c_session_id=very-random`,
+            `https://data.trezor.io/suite/log/desktop/develop.log?c_v=${analyticsActions.version}&c_type=switch-device%2Feject&c_instance_id=1&c_session_id=very-random`,
             { method: 'GET' },
         );
         process.env.SUITE_TYPE = env;
@@ -101,7 +97,6 @@ describe('Analytics Actions', () => {
         });
         const store = initStore(state);
         store.dispatch(analyticsActions.report({ type: 'switch-device/eject' }));
-        // @ts-ignore
         expect(global.fetch).toHaveBeenNthCalledWith(
             1,
             `https://data.trezor.io/suite/log/web/develop.log?c_v=${analyticsActions.version}&c_type=switch-device%2Feject&c_instance_id=1&c_session_id=very-random`,
@@ -116,7 +111,6 @@ describe('Analytics Actions', () => {
         });
         const store = initStore(state);
         store.dispatch(analyticsActions.report({ type: 'switch-device/eject' }));
-        // @ts-ignore
         expect(global.fetch).toHaveBeenCalledTimes(0);
     });
 
@@ -128,7 +122,6 @@ describe('Analytics Actions', () => {
         });
         const store = initStore(state);
         store.dispatch(analyticsActions.report({ type: 'switch-device/eject' }));
-        // @ts-ignore
         expect(global.fetch).toHaveBeenCalledTimes(0);
         process.env.SUITE_TYPE = env;
     });

--- a/packages/suite/src/actions/suite/analyticsActions.ts
+++ b/packages/suite/src/actions/suite/analyticsActions.ts
@@ -45,11 +45,11 @@ export const version = '1.8';
 export type AnalyticsEvent =
     | {
           /**
-        suite-ready
-        Triggers on application start. Logs part of suite setup that might have been loaded from storage
-        but it might also be suite default setup that is loaded when suite starts for the first time.
-        IMPORTANT: skipped if user opens suite for the first time. In such case, the first log will be 'initial-run-completed'
-        */
+         suite-ready
+         Triggers on application start. Logs part of suite setup that might have been loaded from storage
+         but it might also be suite default setup that is loaded when suite starts for the first time.
+         IMPORTANT: skipped if user opens suite for the first time. In such case, the first log will be 'initial-run-completed'
+         */
           type: 'suite-ready';
           payload: {
               language: AppState['suite']['settings']['language'];
@@ -82,10 +82,10 @@ export type AnalyticsEvent =
     | { type: 'transport-type'; payload: { type: string; version: string } }
     | {
           /**
-      device-connect
-      is logged when user connects device
-      - if device is not in bootloader, some of its features are logged 
-      */
+         device-connect
+         is logged when user connects device
+         - if device is not in bootloader, some of its features are logged
+         */
           type: 'device-connect';
           payload: {
               mode?: DeviceMode;
@@ -110,9 +110,9 @@ export type AnalyticsEvent =
       }
     | {
           /**
-        device-update-firmware
-        is log after firmware update call to device is finished. 
-        */
+         device-update-firmware
+         is log after firmware update call to device is finished.
+         */
           type: 'device-update-firmware';
           payload: {
               /** version of bootloader before update started. */
@@ -129,10 +129,10 @@ export type AnalyticsEvent =
       }
     | {
           /**
-        initial-run-completed
-        when new installation of trezor suite starts it is in initial-run mode which means that some additional screens appear (welcome, analytics, onboarding)
-        it is completed either by going trough onboarding or skipping it. once completed event is registered, we log some data connected up to this point     
-         */
+         initial-run-completed
+         when new installation of trezor suite starts it is in initial-run mode which means that some additional screens appear (welcome, analytics, onboarding)
+         it is completed either by going trough onboarding or skipping it. once completed event is registered, we log some data connected up to this point
+          */
           type: 'initial-run-completed';
           payload: {
               analytics: false;
@@ -153,10 +153,10 @@ export type AnalyticsEvent =
       }
     | {
           /**
-        account-create
-        logged either automatically upon each suite start as default switched on accounts are loaded
-        or when user adds account manually 
-        */
+         account-create
+         logged either automatically upon each suite start as default switched on accounts are loaded
+         or when user adds account manually
+         */
           type: 'account-create';
           payload: {
               /** normal, segwit, legacy */
@@ -391,11 +391,13 @@ export const report = (data: AnalyticsEvent, force = false) => (
     if (initialRun) {
         return;
     }
-    // the only case we want to override users 'do not log' choice is when we
-    // want to log that user did not give consent to logging.
+
+    // The only case we want to override users 'do not log' choice is
+    // when we want to log that user did not give consent to logging.
     if (!enabled && !force) {
         return;
     }
+
     const qs = encodeDataToQueryString(data, { sessionId, instanceId, version });
 
     try {
@@ -403,7 +405,7 @@ export const report = (data: AnalyticsEvent, force = false) => (
             method: 'GET',
         });
     } catch (err) {
-        // do nothing, just log error for sentry
+        // do nothing, just log error to sentry
         console.error('failed to log analytics', err);
     }
 };

--- a/packages/suite/src/actions/suite/analyticsActions.ts
+++ b/packages/suite/src/actions/suite/analyticsActions.ts
@@ -33,14 +33,9 @@ export type AnalyticsAction =
           };
       };
 
-/**
-simple semver for data-analytics part.
-<breaking-change>.<analytics-extended>
-
-Don't forget to update docs with changelog!
-*/
-
-export const version = '1.8';
+// Don't forget to update docs with changelog!
+// <breaking-change>.<analytics-extended>
+export const version = '1.9';
 
 export type AnalyticsEvent =
     | {
@@ -77,6 +72,8 @@ export type AnalyticsEvent =
               osVersion: string;
               windowWidth: number;
               windowHeight: number;
+              // added in 1.9
+              platformLanguages: string;
           };
       }
     | { type: 'transport-type'; payload: { type: string; version: string } }
@@ -98,6 +95,9 @@ export type AnalyticsEvent =
               isBitcoinOnly: boolean;
               // added in 1.7
               totalDevices: number;
+              // added in 1.9
+              language: string | null;
+              model: string;
           };
       }
     | {
@@ -175,6 +175,12 @@ export type AnalyticsEvent =
               symbol: string;
           };
       }
+    | {
+          type: 'accounts/empty-account/receive';
+          payload: {
+              symbol: string;
+          };
+      }
     | { type: 'dashboard/security-card/create-backup' }
     | { type: 'dashboard/security-card/seed-link' }
     | { type: 'dashboard/security-card/set-pin' }
@@ -192,12 +198,31 @@ export type AnalyticsEvent =
     | { type: 'menu/goto/suite-index' }
     | { type: 'menu/goto/wallet-index' }
     | { type: 'menu/goto/notifications-index' }
+    | {
+          type: 'menu/notifications/toggle';
+          payload: {
+              value: boolean;
+          };
+      }
     | { type: 'menu/goto/settings-index' }
+    | {
+          type: 'menu/settings/toggle';
+          payload: {
+              value: boolean;
+          };
+      }
+    | {
+          type: 'menu/settings/dropdown';
+          payload: { option: 'all' | 'general' | 'device' | 'coins' };
+      }
     | {
           type: 'menu/toggle-discreet';
           payload: {
               value: boolean;
           };
+      }
+    | {
+          type: 'menu/goto/tor';
       }
     | {
           type: 'menu/toggle-tor';
@@ -246,7 +271,24 @@ export type AnalyticsEvent =
               value: number;
           };
       }
-    | { type: 'settings/device/goto/background' }
+    | {
+          type: 'settings/device/goto/background';
+          payload: {
+              // added in 1.9
+              custom: boolean;
+          };
+      }
+    | {
+          type: 'settings/device/background';
+          payload: {
+              // added in 1.9
+              image?: string;
+              format?: string;
+              size?: number;
+              resolutionWidth?: number;
+              resolutionHeight?: number;
+          };
+      }
     | {
           type: 'settings/device/change-orientation';
           payload: {
@@ -321,14 +363,18 @@ export type AnalyticsEvent =
     | {
           type: 'transaction-created';
           payload: {
-              action: 'sent' | 'copied' | 'downloaded';
+              // added in 1.9
+              action: 'sent' | 'copied' | 'downloaded' | 'replaced';
               symbol: Account['symbol'];
-              broadcast: boolean;
+              tokens: string;
               outputsCount: number;
+              broadcast: boolean;
               bitcoinRbf: boolean;
               bitcoinLockTime: boolean;
               ethereumData: boolean;
-              tokenSent: boolean;
+              ethereumNonce: boolean;
+              rippleDestinationTag: boolean;
+              selectedFee: string;
           };
       }
     | {
@@ -336,6 +382,8 @@ export type AnalyticsEvent =
           payload: {
               networkSymbol: Account['symbol'];
               addedNth: number; // if the user added 1st, 2nd,... token in his account
+              // added in 1.9
+              token: string;
           };
       }
     | {

--- a/packages/suite/src/components/suite/NavigationBar/components/NavigationActions/components/NotificationsDropdown/index.tsx
+++ b/packages/suite/src/components/suite/NavigationBar/components/NavigationActions/components/NotificationsDropdown/index.tsx
@@ -3,7 +3,7 @@ import { Dropdown, DropdownRef, variables } from '@trezor/components';
 import React, { useRef, useCallback, useState } from 'react';
 import styled from 'styled-components';
 import ActionItem from '../ActionItem';
-import { useActions } from '@suite-hooks';
+import { useActions, useAnalytics } from '@suite-hooks';
 import * as notificationActions from '@suite-actions/notificationActions';
 
 const Wrapper = styled.div<Pick<Props, 'marginLeft' | 'marginRight'>>`
@@ -33,6 +33,8 @@ const NotificationsDropdown = ({
     marginLeft = '0px',
     marginRight = '0px',
 }: Props) => {
+    const analytics = useAnalytics();
+
     // use "opened" state to decide if "active" styles on ActionItem should be applied
     const [open, setOpen] = useState(false);
     const dropdownRef = useRef<DropdownRef>();
@@ -50,8 +52,15 @@ const NotificationsDropdown = ({
                 resetUnseen();
                 setOpen(false);
             }
+
+            analytics.report({
+                type: 'menu/notifications/toggle',
+                payload: {
+                    value: isToggled,
+                },
+            });
         },
-        [resetUnseen],
+        [resetUnseen, analytics],
     );
 
     return (

--- a/packages/suite/src/components/suite/NavigationBar/components/NavigationActions/components/SettingsDropdown/index.tsx
+++ b/packages/suite/src/components/suite/NavigationBar/components/NavigationActions/components/SettingsDropdown/index.tsx
@@ -3,7 +3,7 @@ import { Dropdown, DropdownRef } from '@trezor/components';
 import React, { useRef, useState } from 'react';
 import styled from 'styled-components';
 import ActionItem from '../ActionItem';
-import { useActions } from '@suite-hooks';
+import { useActions, useAnalytics } from '@suite-hooks';
 import * as routerActions from '@suite-actions/routerActions';
 
 const Wrapper = styled.div<Pick<Props, 'marginLeft'>>`
@@ -17,6 +17,16 @@ interface Props {
 }
 
 const SettingsDropdown = (props: Props) => {
+    const analytics = useAnalytics();
+    const reportDropdownEvent = (option: 'all' | 'general' | 'device' | 'coins') => {
+        analytics.report({
+            type: 'menu/settings/dropdown',
+            payload: {
+                option,
+            },
+        });
+    };
+
     const [open, setOpen] = useState(false);
     const dropdownRef = useRef<DropdownRef>();
 
@@ -27,7 +37,13 @@ const SettingsDropdown = (props: Props) => {
     return (
         <Wrapper {...props}>
             <Dropdown
-                onToggle={() => setOpen(!open)}
+                onToggle={() => {
+                    setOpen(!open);
+                    analytics.report({
+                        type: 'menu/settings/toggle',
+                        payload: { value: !open },
+                    });
+                }}
                 ref={dropdownRef}
                 alignMenu="right"
                 offset={34}
@@ -35,7 +51,10 @@ const SettingsDropdown = (props: Props) => {
                 topPadding={0}
                 minWidth={230}
                 masterLink={{
-                    callback: () => goto('settings-index'),
+                    callback: () => {
+                        goto('settings-index');
+                        reportDropdownEvent('all');
+                    },
                     label: <Translation id="TR_ALL" />,
                     icon: 'ARROW_RIGHT_LONG',
                 }}
@@ -50,6 +69,7 @@ const SettingsDropdown = (props: Props) => {
                                 icon: 'APP',
                                 callback: () => {
                                     goto('settings-index');
+                                    reportDropdownEvent('general');
                                 },
                                 isRounded: true,
                                 'data-test': '@suite/menu/settings-index',
@@ -60,6 +80,7 @@ const SettingsDropdown = (props: Props) => {
                                 icon: 'DEVICE',
                                 callback: () => {
                                     goto('settings-device');
+                                    reportDropdownEvent('device');
                                 },
                                 isRounded: true,
                                 'data-test': '@suite/menu/settings-device',
@@ -70,6 +91,7 @@ const SettingsDropdown = (props: Props) => {
                                 icon: 'COINS',
                                 callback: () => {
                                     goto('settings-coins');
+                                    reportDropdownEvent('coins');
                                 },
                                 isRounded: true,
                                 'data-test': '@suite/menu/settings-coins',

--- a/packages/suite/src/components/suite/NavigationBar/components/NavigationActions/components/TorDropdown/index.tsx
+++ b/packages/suite/src/components/suite/NavigationBar/components/NavigationActions/components/TorDropdown/index.tsx
@@ -3,7 +3,7 @@ import { Dropdown, DropdownRef, Icon, useTheme, variables } from '@trezor/compon
 import React, { useEffect, useRef, useState } from 'react';
 import styled from 'styled-components';
 import ActionItem from '../ActionItem';
-import { useActions } from '@suite-hooks';
+import { useActions, useAnalytics } from '@suite-hooks';
 import { transparentize } from 'polished';
 import * as routerActions from '@suite-actions/routerActions';
 
@@ -81,6 +81,8 @@ interface Props {
 }
 
 const TorDropdown = (props: Props) => {
+    const analytics = useAnalytics();
+
     const [open, setOpen] = useState(false);
     const [torAddress, setTorAddress] = useState('');
     const dropdownRef = useRef<DropdownRef>();
@@ -95,7 +97,15 @@ const TorDropdown = (props: Props) => {
     return (
         <Wrapper {...props}>
             <Dropdown
-                onToggle={() => setOpen(!open)}
+                onToggle={() => {
+                    setOpen(!open);
+                    analytics.report({
+                        type: 'menu/toggle-tor',
+                        payload: {
+                            value: !open,
+                        },
+                    });
+                }}
                 ref={dropdownRef}
                 alignMenu="right"
                 offset={34}
@@ -110,7 +120,12 @@ const TorDropdown = (props: Props) => {
                             {
                                 key: 'torStatus',
                                 label: (
-                                    <TorStatus onClick={() => goto('settings-index')}>
+                                    <TorStatus
+                                        onClick={() => {
+                                            goto('settings-index');
+                                            analytics.report({ type: 'menu/goto/tor' });
+                                        }}
+                                    >
                                         <Indicator isActive={props.isActive} />
                                         <Details>
                                             <Label>

--- a/packages/suite/src/components/suite/NavigationBar/components/NavigationActions/index.tsx
+++ b/packages/suite/src/components/suite/NavigationBar/components/NavigationActions/index.tsx
@@ -61,6 +61,7 @@ const NavigationActions = (props: Props) => {
 
     const WrapperComponent = props.isMobileLayout ? MobileWrapper : Wrapper;
 
+    // used only in mobile layout
     const gotoWithReport = (routeName: Route) => {
         if (routeName === 'notifications-index') {
             analytics.report({ type: 'menu/goto/notifications-index' });

--- a/packages/suite/src/components/suite/modals/AddToken/index.tsx
+++ b/packages/suite/src/components/suite/modals/AddToken/index.tsx
@@ -131,11 +131,13 @@ const AddToken = (props: Props) => {
                         if (tokenInfo) {
                             addToken(account, tokenInfo);
                             props.onCancel();
+
                             analytics.report({
                                 type: 'add-token',
                                 payload: {
                                     networkSymbol: account.symbol,
                                     addedNth: account.tokens ? account.tokens.length + 1 : 0,
+                                    token: tokenInfo[0]?.symbol?.toLowerCase() || '',
                                 },
                             });
                         }

--- a/packages/suite/src/components/suite/modals/BackgroundGallery/index.tsx
+++ b/packages/suite/src/components/suite/modals/BackgroundGallery/index.tsx
@@ -7,7 +7,7 @@ import { resolveStaticPath } from '@suite-utils/nextjs';
 import * as deviceSettingsActions from '@settings-actions/deviceSettingsActions';
 import { elementToHomescreen } from '@suite-utils/homescreen';
 import { AcquiredDevice } from '@suite-types';
-import { useActions } from '@suite-hooks';
+import { useActions, useAnalytics } from '@suite-hooks';
 
 type AnyImageName = typeof homescreensT1[number] | typeof homescreensT2[number];
 
@@ -39,6 +39,7 @@ type Props = {
 
 const BackgroundGallery = ({ device, onCancel }: Props) => {
     const { applySettings } = useActions({ applySettings: deviceSettingsActions.applySettings });
+    const analytics = useAnalytics();
 
     const setHomescreen = (image: AnyImageName) => {
         const element = document.getElementById(image);
@@ -61,7 +62,16 @@ const BackgroundGallery = ({ device, onCancel }: Props) => {
                         <BackgroundImageT1
                             key={image}
                             id={image}
-                            onClick={() => setHomescreen(image)}
+                            onClick={() => {
+                                setHomescreen(image);
+
+                                analytics.report({
+                                    type: 'settings/device/background',
+                                    payload: {
+                                        image,
+                                    },
+                                });
+                            }}
                             src={resolveStaticPath(`images/png/homescreens/t1/${image}.png`)}
                         />
                     ))}
@@ -74,7 +84,16 @@ const BackgroundGallery = ({ device, onCancel }: Props) => {
                             data-test={`@modal/gallery/t2/${image}`}
                             key={image}
                             id={image}
-                            onClick={() => setHomescreen(image)}
+                            onClick={() => {
+                                setHomescreen(image);
+
+                                analytics.report({
+                                    type: 'settings/device/background',
+                                    payload: {
+                                        image,
+                                    },
+                                });
+                            }}
                             src={resolveStaticPath(`images/png/homescreens/t2/${image}.png`)}
                         />
                     ))}

--- a/packages/suite/src/middlewares/suite/__tests__/redirectMiddleware.test.ts
+++ b/packages/suite/src/middlewares/suite/__tests__/redirectMiddleware.test.ts
@@ -50,6 +50,7 @@ export const getInitialState = (
         ...modalReducer(undefined, { type: 'foo' } as any),
         ...modal,
     },
+    messageSystem: {},
 });
 
 type State = ReturnType<typeof getInitialState>;

--- a/packages/suite/src/middlewares/suite/analyticsMiddleware.ts
+++ b/packages/suite/src/middlewares/suite/analyticsMiddleware.ts
@@ -18,6 +18,7 @@ import {
     getOsVersion,
     getWindowWidth,
     getWindowHeight,
+    getPlatformLanguages,
 } from '@suite-utils/env';
 import { isBitcoinOnly, getPhysicalDeviceCount } from '@suite-utils/device';
 import { setSentryUser, unsetSentryUser } from '@suite/utils/suite/sentry';
@@ -34,6 +35,7 @@ const reportSuiteReadyAction = (state: AppState) =>
             screenHeight: getScreenHeight(),
             platform: getPlatform(),
             platformLanguage: getPlatformLanguage(),
+            platformLanguages: getPlatformLanguages().join(','),
             tor: state.suite.tor,
             rememberedStandardWallets: state.devices.filter(d => d.remember && d.useEmptyPassphrase)
                 .length,
@@ -96,9 +98,11 @@ const analytics = (api: MiddlewareAPI<Dispatch, AppState>) => (next: Dispatch) =
                             backup_type: features.backup_type || 'Bip39',
                             pin_protection: features.pin_protection,
                             passphrase_protection: features.passphrase_protection,
-                            totalInstances: api.getState().devices.length,
+                            totalInstances: state.devices.length,
                             isBitcoinOnly: isBtcOnly,
-                            totalDevices: getPhysicalDeviceCount(api.getState().devices),
+                            totalDevices: getPhysicalDeviceCount(state.devices),
+                            language: features.language,
+                            model: features.model,
                         },
                     }),
                 );

--- a/packages/suite/src/utils/suite/device.ts
+++ b/packages/suite/src/utils/suite/device.ts
@@ -1,4 +1,4 @@
-import { Device } from 'trezor-connect';
+import { Device, KnownDevice } from 'trezor-connect';
 import { TrezorDevice, AcquiredDevice } from '@suite-types';
 
 export const getStatus = (device: TrezorDevice): string => {
@@ -116,7 +116,7 @@ export const getVersion = (device: TrezorDevice) => {
     return features && features.major_version > 1 ? 'T' : 'One';
 };
 
-export const getFwVersion = (device: AcquiredDevice) => {
+export const getFwVersion = (device: KnownDevice) => {
     const { features } = device;
     return `${features.major_version}.${features.minor_version}.${features.patch_version}`;
 };

--- a/packages/suite/src/utils/suite/env.ts
+++ b/packages/suite/src/utils/suite/env.ts
@@ -9,6 +9,8 @@ export const getPlatform = () => window.navigator.platform;
 
 export const getPlatformLanguage = () => window.navigator.language;
 
+export const getPlatformLanguages = () => window.navigator.languages;
+
 export const getAppVersion = () => window.navigator.appVersion;
 
 export const getScreenWidth = () => window.screen.width;

--- a/packages/suite/src/utils/suite/homescreen.ts
+++ b/packages/suite/src/utils/suite/homescreen.ts
@@ -256,3 +256,14 @@ export const elementToHomescreen = (
     removeCanvas();
     return hex;
 };
+
+export const getImageResolution = (url: string): Promise<{ width: number; height: number }> =>
+    new Promise(resolve => {
+        const img = new Image();
+        img.src = url;
+        img.onload = () =>
+            resolve({
+                width: img.width,
+                height: img.height,
+            });
+    });

--- a/packages/suite/src/utils/suite/sentry.ts
+++ b/packages/suite/src/utils/suite/sentry.ts
@@ -5,3 +5,9 @@ export const setSentryUser = (instanceId: string) => {
         scope.setUser({ id: instanceId });
     });
 };
+
+export const unsetSentryUser = () => {
+    Sentry.configureScope(scope => {
+        scope.setUser(null);
+    });
+};

--- a/packages/suite/src/views/settings/device/index.tsx
+++ b/packages/suite/src/views/settings/device/index.tsx
@@ -123,8 +123,21 @@ const Settings = () => {
 
     const onUploadHomescreen = async (files: FileList | null) => {
         if (!files || !files.length) return;
-        const dataUrl = await homescreen.fileToDataUrl(files[0]);
+        const image = files[0];
+        const dataUrl = await homescreen.fileToDataUrl(image);
+
         setCustomHomescreen(dataUrl);
+
+        const imageResolution = await homescreen.getImageResolution(dataUrl);
+        analytics.report({
+            type: 'settings/device/background',
+            payload: {
+                format: image.type,
+                size: image.size,
+                resolutionWidth: imageResolution.width,
+                resolutionHeight: imageResolution.height,
+            },
+        });
     };
 
     const onSelectCustomHomescreen = async () => {
@@ -434,6 +447,10 @@ const Settings = () => {
                                 onClick={() => {
                                     if (fileInputElement.current) {
                                         fileInputElement.current.click();
+                                        analytics.report({
+                                            type: 'settings/device/goto/background',
+                                            payload: { custom: true },
+                                        });
                                     }
                                 }}
                                 isDisabled={isDeviceLocked}
@@ -451,6 +468,7 @@ const Settings = () => {
                                 });
                                 analytics.report({
                                     type: 'settings/device/goto/background',
+                                    payload: { custom: false },
                                 });
                             }}
                             isDisabled={isDeviceLocked}

--- a/packages/suite/src/views/wallet/transactions/components/AccountEmpty/index.tsx
+++ b/packages/suite/src/views/wallet/transactions/components/AccountEmpty/index.tsx
@@ -102,6 +102,12 @@ const AccountEmpty = (props: Props) => {
                         variant="secondary"
                         onClick={() => {
                             goto('wallet-receive', undefined, true);
+                            analytics.report({
+                                type: 'accounts/empty-account/receive',
+                                payload: {
+                                    symbol: networkSymbol.toLowerCase(),
+                                },
+                            });
                         }}
                     >
                         <Translation id="TR_RECEIVE_NETWORK" values={{ network: networkSymbol }} />
@@ -113,7 +119,7 @@ const AccountEmpty = (props: Props) => {
                             analytics.report({
                                 type: 'accounts/empty-account/buy',
                                 payload: {
-                                    symbol: networkSymbol,
+                                    symbol: networkSymbol.toLowerCase(),
                                 },
                             });
                         }}


### PR DESCRIPTION
closes #3717 

- updated docs
- `suite-ready` event tracked on initial run
- added new events and extensions of old ones
- fixed `transaction-created` event which was not sent at all
- only events from codesign branch build are tracked to `stable.log`, other ones to `develop.log`

[Notion info](https://www.notion.so/satoshilabs/Analytics-overview-3b49d66235e044928b79954d3a4ac8ff)
