### PR TITLE
fix(suite): btc-only fw update in onboarding; btc-only tag in fw modals

### DIFF
--- a/packages/suite/src/components/firmware/NoNewFirmware.tsx
+++ b/packages/suite/src/components/firmware/NoNewFirmware.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 
 import { CHANGELOG_URL } from '@suite-constants/urls';
-import { getFwVersion } from '@suite-utils/device';
+import { getFwVersion, isBitcoinOnly } from '@suite-utils/device';
 import { useDevice } from '@suite-hooks';
 import { P, H2, SuccessImg } from '@firmware-components';
 import { Translation, ExternalLink } from '@suite-components';
@@ -22,7 +22,11 @@ const Body = () => {
             <P>
                 <Translation
                     id="TR_FIRMWARE_INSTALLED_TEXT"
-                    values={{ version: getFwVersion(device) }}
+                    values={{
+                        version: `${getFwVersion(device)}${
+                            isBitcoinOnly(device) ? ' (bitcoin-only)' : ''
+                        }`,
+                    }}
                 />{' '}
                 <ExternalLink size="small" href={CHANGELOG_URL}>
                     <Translation id="TR_WHATS_NEW_FIRMWARE" />

--- a/packages/suite/src/components/firmware/OnboardingInitial.tsx
+++ b/packages/suite/src/components/firmware/OnboardingInitial.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 import { Button } from '@trezor/components';
 
 import { Translation } from '@suite-components';
-import { getFwVersion } from '@suite-utils/device';
+import { getFwVersion, isBitcoinOnly } from '@suite-utils/device';
 import { useDevice, useFirmware, useActions } from '@suite-hooks';
 import {
     P,
@@ -55,7 +55,9 @@ const Body = () => {
                     <Translation
                         id="TR_FIRMWARE_INSTALLED_TEXT"
                         values={{
-                            version: getFwVersion(device),
+                            version: `${getFwVersion(device)}${
+                                isBitcoinOnly(device) ? ' (bitcoin-only)' : ''
+                            }`,
                         }}
                     />
                 </P>
@@ -75,7 +77,9 @@ const Body = () => {
                     <Translation
                         id="TR_FIRMWARE_INSTALLED_TEXT"
                         values={{
-                            version: getFwVersion(device),
+                            version: `${getFwVersion(device)}${
+                                isBitcoinOnly(device) ? ' (bitcoin-only)' : ''
+                            }`,
                         }}
                     />
                 </P>

--- a/packages/suite/src/middlewares/firmware/firmwareMiddleware.ts
+++ b/packages/suite/src/middlewares/firmware/firmwareMiddleware.ts
@@ -89,12 +89,16 @@ const firmware = (api: MiddlewareAPI<Dispatch, AppState>) => (next: Dispatch) =>
 
             break;
         case DEVICE.DISCONNECT:
-            // we want to store data about previous device only in firmware update modal
+            // we want to store data about previous device only in firmware update modal which is located in "firmware" and "onboarding" apps
             // we need to do this because device in bootloader mode misses some features attributes required for updating logic
             // if user disconnects device to connect it in bootloader mode, it opens "device disconnected" modal
-            // so prevApp is equal to firmware, moreover we do not want to do it if device was already in bootloader
+            // so prevApp is equal to "firmware" in case the update process started in settings or "onboarding" in case of onboarding
+            // moreover we do not want to do it if device was already in bootloader
             // as this can happen only if user disconnected the device again after already being in bootloader mode
-            if (prevApp === 'firmware' && action.payload.mode !== 'bootloader') {
+            if (
+                (prevApp === 'firmware' || prevApp === 'onboarding') &&
+                action.payload.mode !== 'bootloader'
+            ) {
                 api.dispatch(firmwareActions.rememberPreviousDevice(action.payload));
             }
             break;


### PR DESCRIPTION
**These changes are going to current release, so please merge it ASAP.**
Fixes  #bug found in  #3790 by @bosomt. These changes are already tested by QA and it is working correctly.

- Updating of btc-only fw was not handled correctly in onboarding.
- User was not correctly informed about his current version of fw in fw update modals (btc-only / regular)

