### PR TITLE
fix(ci) remove gh cli from base image and use variable for release job

### DIFF
--- a/ci/docker/base/Dockerfile
+++ b/ci/docker/base/Dockerfile
@@ -69,12 +69,6 @@ RUN \
     apt-get install -y dbus-x11 google-chrome-stable google-chrome-beta && \
     rm -rf /var/lib/apt/lists/*
 
-# install GitHub-cli
-RUN \
-    wget -q https://github.com/cli/cli/releases/download/v1.10.2/gh_1.10.2_linux_amd64.deb && \
-    dpkg -i gh_1.10.2_linux_amd64.deb && \
-    rm gh_1.10.2_linux_amd64.deb
-
 # "fake" dbus address to prevent errors
 # https://github.com/SeleniumHQ/docker-selenium/issues/87
 ENV DBUS_SESSION_BUS_ADDRESS=/dev/null

--- a/ci/releases.yml
+++ b/ci/releases.yml
@@ -49,7 +49,6 @@ suite-desktop github release:
   when: manual
   script:
     - gh config set prompt disabled
-    - echo $GITHUB_CLI_RELEASE_TOKEN | gh auth login --with-token
     - VERSION=$(jq -r .version packages/suite-desktop/package.json)
     - gh release create --repo trezor/trezor-suite --draft v${VERSION}  --title "v${VERSION}" ./Trezor-Suite* latest*
   tags:


### PR DESCRIPTION
Remove GitHub Cli from docker image as we're using it on runner directly via nix. Also removed the line where we log into the docker cli with personal token and instead it now uses token from GitLab environment variable and there is no need to pass it like before. 