### PR TITLE
fix(onboarding): fix failing desktop builds

### DIFF
--- a/packages/suite-desktop/pages/onboarding/index.tsx
+++ b/packages/suite-desktop/pages/onboarding/index.tsx
@@ -1,3 +1,3 @@
-import Onboarding from '@onboarding-views';
-
+// This route will be displayed by Preloader
+const Onboarding = () => null;
 export default Onboarding;

--- a/packages/suite-desktop/pages/recovery/index.tsx
+++ b/packages/suite-desktop/pages/recovery/index.tsx
@@ -1,3 +1,3 @@
-import Page from '@recovery-views';
-
-export default Page;
+// This route will be displayed by Preloader
+const Recovery = () => null;
+export default Recovery;


### PR DESCRIPTION
Nextjs optimization step was failing on onboarding and recovery pages, but only on linux runner 🤷‍♂️
Luckily "fix" was easy since we can just return null in these pages because the corresponding components are rendered via Preloader component anyway (it's the same thing as in in suite-web, where we indeed return null in these pages)