### PR TITLE
feat: do not 'disconnect' metadata provider when disabling metadata

### DIFF
--- a/packages/integration-tests/projects/suite-web/tests/metadata/remembered-device.test.ts
+++ b/packages/integration-tests/projects/suite-web/tests/metadata/remembered-device.test.ts
@@ -64,6 +64,7 @@ On disable, it throws away all metadata related records from memory.`, () => {
             cy.getTestElement('@settings/metadata-switch').click({ force: true });
             cy.passThroughInitMetadata(f.provider);
 
+
             cy.log(
                 'Now metadata is enabled, go to accounts and see what we got loaded from provider',
             );
@@ -110,9 +111,10 @@ On disable, it throws away all metadata related records from memory.`, () => {
                 force: true,
             });
             cy.log(
-                'disabling metadata removed also all keys, so metadata init flow takes all steps now',
+                'disabling metadata removed also all keys, so metadata init flow takes all steps now expect for providers, these stay connected',
             );
-            cy.passThroughInitMetadata(f.provider);
+            cy.getConfirmActionOnDeviceModal();
+            cy.task('pressYes');
 
             // device saved, disconnect provider
             cy.getTestElement('@menu/switch-device').click();

--- a/packages/suite/src/reducers/suite/metadataReducer.ts
+++ b/packages/suite/src/reducers/suite/metadataReducer.ts
@@ -19,7 +19,6 @@ const metadataReducer = (state = initialState, action: Action): MetadataState =>
                 break;
             case METADATA.DISABLE:
                 draft.enabled = false;
-                draft.provider = undefined;
                 break;
             case METADATA.SET_PROVIDER:
                 draft.provider = action.payload;


### PR DESCRIPTION
In retrospect, it wasn't the most "bulltetproof" implemenation of provider disconnecting. 

But please don't merge yet. Could you @tsusanka please whitelist new localhost urls with dropbox and google? We now need `http://localhost:8000` instead of `http://localhost:3000` which is whitelisted at the moment.

___ 

resolve #3669