### PR TITLE
Suite Guide improvements

### DIFF
--- a/packages/components/src/components/form/Select/index.tsx
+++ b/packages/components/src/components/form/Select/index.tsx
@@ -141,6 +141,12 @@ const selectStyle = (
             textShadow: hideTextCursor ? `0 0 0 ${theme.TYPE_DARK_GREY} !important` : 'none',
         },
     }),
+    placeholder: (base: Record<string, any>) => ({
+        ...base,
+        fontWeight: variables.FONT_WEIGHT.MEDIUM,
+        fontSize: variables.NEUE_FONT_SIZE.SMALL,
+        padding: '0 6px',
+    }),
 });
 
 const Wrapper = styled.div<Props>`

--- a/packages/components/src/components/form/Textarea/index.tsx
+++ b/packages/components/src/components/form/Textarea/index.tsx
@@ -24,7 +24,7 @@ interface StyledTextareaProps extends BaseTextareaProps {
 
 const StyledTextarea = styled.textarea<StyledTextareaProps>`
     width: ${props => (props.width ? `${props.width}px` : '100%')};
-    padding: 10px;
+    padding: 14px 16px;
     box-sizing: border-box;
     border: solid ${props => props.borderWidth}px
         ${props =>

--- a/packages/components/src/config/variables.ts
+++ b/packages/components/src/config/variables.ts
@@ -9,6 +9,7 @@ export const SCREEN_SIZE = {
 } as const;
 
 export const LAYOUT_SIZE = {
+    MENU_SECONDARY_WIDTH: '300px',
     GUIDE_PANEL_WIDTH: '350px',
 } as const;
 

--- a/packages/suite/src/components/suite/MenuSecondary/index.tsx
+++ b/packages/suite/src/components/suite/MenuSecondary/index.tsx
@@ -1,3 +1,4 @@
+import { variables } from '@trezor/components';
 import React from 'react';
 import styled from 'styled-components';
 
@@ -6,7 +7,7 @@ interface Props {
 }
 
 const AbsoluteWrapper = styled.aside`
-    width: 300px;
+    width: ${variables.LAYOUT_SIZE.MENU_SECONDARY_WIDTH};
     flex: 0 0 auto;
     background: ${props => props.theme.BG_WHITE};
     border-right: 1px solid ${props => props.theme.STROKE_GREY};

--- a/packages/suite/src/components/suite/SuiteLayout/index.tsx
+++ b/packages/suite/src/components/suite/SuiteLayout/index.tsx
@@ -1,5 +1,5 @@
 import React, { useState, createContext } from 'react';
-import styled from 'styled-components';
+import styled, { css } from 'styled-components';
 import { connect } from 'react-redux';
 import { useHotkeys } from 'react-hotkeys-hook';
 
@@ -29,15 +29,24 @@ const Body = styled.div`
     display: flex;
     flex-direction: column;
     flex: 1;
-    overflow: auto;
+    overflow-y: hidden;
+    overflow-x: hidden;
 `;
 
 // AppWrapper and MenuSecondary creates own scrollbars independently
-const Columns = styled.div`
+const Columns = styled.div<{ guideOpen?: boolean }>`
     display: flex;
     flex-direction: row;
     flex: 1 0 100%;
     overflow: auto;
+    padding: 0;
+    transition: all 0.3s ease;
+
+    ${props =>
+        props.guideOpen &&
+        css`
+            padding: 0 ${variables.LAYOUT_SIZE.GUIDE_PANEL_WIDTH} 0 0;
+        `}
 `;
 
 const AppWrapper = styled.div`
@@ -77,11 +86,22 @@ const DefaultPaddings = styled.div`
     }
 `;
 
-const StyledGuidePanel = styled(GuidePanel)`
+const StyledGuidePanel = styled(GuidePanel)<{ open?: boolean }>`
     height: 100%;
     width: ${variables.LAYOUT_SIZE.GUIDE_PANEL_WIDTH};
     flex: 0 0 ${variables.LAYOUT_SIZE.GUIDE_PANEL_WIDTH};
     z-index: ${variables.Z_INDEX.GUIDE_PANEL};
+    border-left: 1px solid ${props => props.theme.STROKE_GREY};
+    position: absolute;
+    right: 0;
+    transform: translateX(100%);
+    transition: all 0.3s ease;
+
+    ${props =>
+        props.open &&
+        css`
+            transform: translateX(0);
+        `}
 `;
 
 const mapStateToProps = (state: AppState) => ({
@@ -136,7 +156,7 @@ const ScrollAppWrapper = ({ url, children }: ScrollAppWrapperProps) => {
 
 const BodyNormal = ({ url, menu, appMenu, children, guideOpen, isMenuInline }: NormalBodyProps) => (
     <Body>
-        <Columns>
+        <Columns guideOpen={guideOpen}>
             {!isMenuInline && menu && <MenuSecondary>{menu}</MenuSecondary>}
             <ScrollAppWrapper url={url}>
                 {isMenuInline && menu}
@@ -145,7 +165,7 @@ const BodyNormal = ({ url, menu, appMenu, children, guideOpen, isMenuInline }: N
                     <MaxWidthWrapper>{children}</MaxWidthWrapper>
                 </DefaultPaddings>
             </ScrollAppWrapper>
-            {guideOpen && <StyledGuidePanel />}
+            <StyledGuidePanel open={guideOpen} />
         </Columns>
     </Body>
 );

--- a/packages/suite/src/components/suite/SuiteLayout/index.tsx
+++ b/packages/suite/src/components/suite/SuiteLayout/index.tsx
@@ -1,6 +1,8 @@
 import React, { useState, createContext } from 'react';
 import styled from 'styled-components';
 import { connect } from 'react-redux';
+import { useHotkeys } from 'react-hotkeys-hook';
+
 import { variables, scrollbarStyles } from '@trezor/components';
 import SuiteBanners from '@suite-components/Banners';
 import { AppState } from '@suite-types';
@@ -169,9 +171,24 @@ const SuiteLayout = (props: SuiteLayoutProps) => {
     const { guideOpen } = useSelector(state => ({
         guideOpen: state.guide.open,
     }));
-    const { openGuide } = useActions({
+    const { openGuide, closeGuide } = useActions({
         openGuide: guideActions.open,
+        closeGuide: guideActions.close,
     });
+    useHotkeys(
+        'f1,esc',
+        e => {
+            e.preventDefault();
+            if (guideOpen) {
+                closeGuide();
+            }
+            if (!guideOpen && e.key.toLowerCase() === 'f1') {
+                openGuide();
+            }
+        },
+        [guideOpen, closeGuide, openGuide],
+    );
+
     const [title, setTitle] = useState<string | undefined>(undefined);
     const [menu, setMenu] = useState<any>(undefined);
     // There are three layout configurations WRT the guide and menu:

--- a/packages/suite/src/support/messages.ts
+++ b/packages/suite/src/support/messages.ts
@@ -5402,6 +5402,38 @@ const definedMessages = defineMessages({
         id: 'TR_FEEDBACK_ANALYTICS_ITEM_APP',
         defaultMessage: 'Suite version',
     },
+    TR_FEEDBACK_CATEGORY_SELECT_PLACEHOLDER: {
+        id: 'TR_FEEDBACK_CATEGORY_SELECT_PLACEHOLDER',
+        defaultMessage: 'Select category...',
+    },
+    TR_FEEDBACK_CATEGORY_DASHBOARD: {
+        id: 'TR_FEEDBACK_CATEGORY_DASHBOARD',
+        defaultMessage: 'Dashboard',
+    },
+    TR_FEEDBACK_CATEGORY_ACCOUNT: {
+        id: 'TR_FEEDBACK_CATEGORY_ACCOUNT',
+        defaultMessage: 'Account',
+    },
+    TR_FEEDBACK_CATEGORY_SETTINGS: {
+        id: 'TR_FEEDBACK_CATEGORY_SETTINGS',
+        defaultMessage: 'Settings',
+    },
+    TR_FEEDBACK_CATEGORY_SEND: {
+        id: 'TR_FEEDBACK_CATEGORY_SEND',
+        defaultMessage: 'Send',
+    },
+    TR_FEEDBACK_CATEGORY_RECEIVE: {
+        id: 'TR_FEEDBACK_CATEGORY_RECEIVE',
+        defaultMessage: 'Receive',
+    },
+    TR_FEEDBACK_CATEGORY_TRADE: {
+        id: 'TR_FEEDBACK_CATEGORY_TRADE',
+        defaultMessage: 'Trade',
+    },
+    TR_FEEDBACK_CATEGORY_OTHER: {
+        id: 'TR_FEEDBACK_CATEGORY_OTHER',
+        defaultMessage: 'Other',
+    },
     FIRMWARE_USER_HAS_SEED_CHECKBOX_DESC: {
         id: 'FIRMWARE_USER_HAS_SEED_CHECKBOX_DESC',
         defaultMessage: 'Yes, I do!',

--- a/packages/suite/src/views/guide/GuideDefault.tsx
+++ b/packages/suite/src/views/guide/GuideDefault.tsx
@@ -92,6 +92,7 @@ const ArticleLabel = styled.div`
     color: ${props => props.theme.TYPE_DARK_GREY};
 `;
 
+// TODO: if something has to be fetched on render of this component, make sure that it is fetched after guide is opened by a user
 const GuideDefault = (props: any) => {
     const analytics = useAnalytics();
     const theme = useTheme();

--- a/packages/suite/src/views/wallet/send/components/Outputs/components/Amount/index.tsx
+++ b/packages/suite/src/views/wallet/send/components/Outputs/components/Amount/index.tsx
@@ -41,7 +41,6 @@ const Left = styled.div`
     position: relative; /* for TokenBalance positioning */
     display: flex;
     flex: 1;
-    min-width: 260px;
 `;
 
 const TokenBalance = styled.div`
@@ -72,7 +71,6 @@ const TransferIconWrapper = styled.div`
 const Right = styled.div`
     display: flex;
     flex: 1;
-    min-width: 260px;
     align-items: flex-start;
 `;
 


### PR DESCRIPTION
task #3817

- [x] preselect category according to the current route when reporting a bug (5c6f08315cf0d1054a408c673b46e81294924aea)
- [x] animations of opening and closing of guide (5c6f08315cf0d1054a408c673b46e81294924aea)
- [x] F1 hotkey to toggle the visibility of the Guide (5c6f08315cf0d1054a408c673b46e81294924aea)
- [x] unify padding of select and textarea component (16339010866a6778afbcfba9478133fde00e9278)
- [x] fix input in send form outside of window (16339010866a6778afbcfba9478133fde00e9278)
![Screenshot 2021-06-25 at 17 20 54](https://user-images.githubusercontent.com/33235762/123448240-fc745000-d5da-11eb-9e27-dbbf14c5437a.png)
