### PR TITLE
fix: ethereum gasPrice and estimated gasLimit

### DIFF
--- a/packages/suite/src/utils/wallet/sendFormUtils.ts
+++ b/packages/suite/src/utils/wallet/sendFormUtils.ts
@@ -5,7 +5,7 @@ import Common from 'ethereumjs-common';
 import { Transaction, TxData } from 'ethereumjs-tx';
 import { fromWei, padLeft, toHex, toWei } from 'web3-utils';
 import { ERC20_TRANSFER } from '@wallet-constants/sendForm';
-import { amountToSatoshi, networkAmountToSatoshi, formatAmount } from '@wallet-utils/accountUtils';
+import { amountToSatoshi, networkAmountToSatoshi } from '@wallet-utils/accountUtils';
 import { Network, Account, CoinFiatRates } from '@wallet-types';
 import { FormState, FeeInfo, EthTransactionData, ExternalOutput } from '@wallet-types/sendForm';
 
@@ -90,16 +90,12 @@ export const getEthereumEstimateFeeParams = (
         return {
             to: token.address,
             value: '0x0',
-            data: getSerializedErc20Transfer(
-                token,
-                to,
-                amount || formatAmount('1', token.decimals), // use at least 1 smallest unit of token (satoshi)
-            ),
+            data: getSerializedErc20Transfer(token, to, amount || token.balance!), // if amount is not set (set-max case) use whole token balance
         };
     }
     return {
         to,
-        value: amount ? getSerializedAmount(amount) : toHex('1'), // use at least 1 wei (satoshi)
+        value: amount ? getSerializedAmount(amount) : toHex('1'), // if amount is not set (set-max case) use at least 1 wei
         data: data || '',
     };
 };


### PR DESCRIPTION
should fix #3846

as explained in the issue, blockbook/geth occasionally returns 0 in "gasPrice" (feePerUnit). [this commit](5277e17560f96d1fbb307f0c555f671f4cc5444c) should fallback to minimum fee in this case.

another issue with ERC20 token is that the `gasLimit` calculation is related to amount used in `estimateGasLimit` method. turns out it has much bigger influence on the result than previously thought.
If amount is not specified yet (set-max use case) `estimateGasLimit` should be called using whole available token balance