### PR TITLE
fix(ci): separate yarn cache folder for nix and docker container installs

### DIFF
--- a/ci/environment.yml
+++ b/ci/environment.yml
@@ -25,4 +25,4 @@ clear_cache:
   stage: setup environment
   when: manual
   script:
-    - rm -rf .yarn node_modules packages/**/node_modules packages/*/lib packages/*/build packages/*/dist
+    - rm -rf .yarn .yarn-nix node_modules packages/**/node_modules packages/*/lib packages/*/build packages/*/dist

--- a/ci/packages/suite-data.yml
+++ b/ci/packages/suite-data.yml
@@ -24,7 +24,7 @@ msg-system config sign stable:
     IS_CODESIGN_BUILD: "true"
   script:
     - nix-shell --run "git lfs pull"
-    - nix-shell --run "yarn install --frozen-lockfile --cache-folder .yarn --prefer-offline"
+    - nix-shell --run "yarn install --frozen-lockfile --cache-folder .yarn-nix --prefer-offline"
     - nix-shell --run "yarn workspace @trezor/suite-data msg-system-sign-config"
     # - aws s3 cp packages/suite-data/files/message-system/config.v1.jws s3://data.trezor.io/config/stable/config.v1.jws
   artifacts:

--- a/ci/packages/suite-desktop.yml
+++ b/ci/packages/suite-desktop.yml
@@ -25,7 +25,7 @@
 .build_nix: &build_nix
   script: # override build script to use nix-shell instead
     - nix-shell --run "git lfs pull"
-    - nix-shell --run "yarn install --frozen-lockfile --cache-folder .yarn --prefer-offline"
+    - nix-shell --run "yarn install --frozen-lockfile --cache-folder .yarn-nix --prefer-offline"
     - nix-shell --run "yarn build:libs"
     - nix-shell --run "yarn workspace @trezor/suite-data copy-static-files"
     - nix-shell --run "yarn workspace @trezor/suite-desktop build:${platform}"

--- a/ci/packages/suite-web.yml
+++ b/ci/packages/suite-web.yml
@@ -75,7 +75,7 @@ suite-web build stable codesign:
     IS_CODESIGN_BUILD: "true"
   script:
     - nix-shell --run "git lfs pull"
-    - nix-shell --run "yarn install --frozen-lockfile --cache-folder .yarn --prefer-offline"
+    - nix-shell --run "yarn install --frozen-lockfile --cache-folder .yarn-nix --prefer-offline"
     - nix-shell --run "yarn build:libs"
     - nix-shell --run "assetPrefix=/web yarn workspace @trezor/suite-web build"
   artifacts:


### PR DESCRIPTION
This will create two separate folders for .yarn cached files. I also modified the clear_runner cache job that will also remove the new .yarn-nix cache folder.
This is because we suspect the unit test fails could be related to nix and docker container building into the same cache folder and overwriting each other with perhaps different packages.