### PR TITLE
feat/msg system banner on top

### DIFF
--- a/packages/suite-data/src/message-system/config/config.v1.json
+++ b/packages/suite-data/src/message-system/config/config.v1.json
@@ -1,6 +1,51 @@
 {
     "version": 1,
-    "timestamp": "2021-05-01T00:00:00+00:00",
-    "sequence": 1,
-    "actions": []
+    "timestamp": "2021-06-09T12:00:00+00:00",
+    "sequence": 2,
+    "actions": [
+        {
+            "conditions": [
+                {
+                    "os": {
+                        "macos": "*",
+                        "linux": "!",
+                        "windows": "!",
+                        "android": "!",
+                        "ios": "!"
+                    },
+                    "environment": {
+                        "desktop": "!",
+                        "mobile": "!",
+                        "web": "*"
+                    },
+                    "browser": {
+                        "firefox": "!",
+                        "chrome": "91",
+                        "chromium": "91"
+                    },
+                    "transport": {
+                        "bridge": "!",
+                        "webusbplugin": "*"
+                    }
+                }
+            ],
+            "message": {
+                "id": "0f3ec64d-c3e4-4787-8106-162f3ac14c34",
+                "priority": 91,
+                "dismissible": true,
+                "variant": "critical",
+                "category": "banner",
+                "content": {
+                    "en-GB": "To be able to use the application in the current version of your browser, please install Trezor Bridge."
+                },
+                "cta": {
+                    "action": "internal-link",
+                    "link": "suite-bridge",
+                    "label": {
+                        "en-GB": "Install now"
+                    }
+                }
+            }
+        }
+    ]
 }

--- a/packages/suite/src/components/suite/Banners/index.tsx
+++ b/packages/suite/src/components/suite/Banners/index.tsx
@@ -13,8 +13,8 @@ import SafetyChecksBanner from './SafetyChecks';
 
 import type { Message } from '@suite-types/messageSystem';
 
-const Wrapper = styled.div`
-    z-index: 3;
+const Wrapper = styled.div<{ onTop?: boolean }>`
+    z-index: ${props => (props.onTop ? '10001' : '3')};
     background: ${props => props.theme.BG_WHITE};
 `;
 
@@ -90,16 +90,23 @@ const Banners = () => {
         priority = 10;
     }
 
-    if (messageSystemBanner && messageSystemBanner.priority >= priority) {
-        banner = <MessageSystemBanner message={messageSystemBanner} />;
-    }
+    // message system banners should always be visible in the app even if app body is blurred
+    const useMessageSystemBanner = messageSystemBanner && messageSystemBanner.priority >= priority;
 
     return (
-        <Wrapper>
-            <OnlineStatus isOnline={online} />
-            {banner}
-            {/* TODO: add Pin not set */}
-        </Wrapper>
+        <>
+            {useMessageSystemBanner && (
+                <Wrapper onTop>
+                    {/* @ts-ignore - fix ts which thinks that "messageSystemBanner" can be null */}
+                    <MessageSystemBanner message={messageSystemBanner} />
+                </Wrapper>
+            )}
+            <Wrapper>
+                <OnlineStatus isOnline={online} />
+                {!useMessageSystemBanner && banner}
+                {/* TODO: add Pin not set */}
+            </Wrapper>
+        </>
     );
 };
 


### PR DESCRIPTION
On macOS in Google Chrome 91, users are not able to use the web version of Trezor Suite without Bridge as WebUSB API is broken.

Tasks:
- [x] config addressing those users
- [x] make banners to be visible when modal windows are open and the body of the app is blurred
- [x] Update develop config (s3 @tsusanka, after merging to develop)
- [x] Update stable config (s3 @tsusanka, before release)

The solution makes all message system banners visible even if the app is blurred. The possibility to configure if the banner should be visible in the blurred app was added to follow-up task #3693. 

This change only affects users who have the app set up. Users in onboarding will not see this banner. The idea is that new users will install the Bridge anyway because they did not know that it worked for them before. However, old users should be informed, because they were able to use the app without Bridge before.

![Screenshot 2021-06-09 at 13 26 45](https://user-images.githubusercontent.com/33235762/121346621-a474f280-c926-11eb-92ef-045c7af009c9.png)