### PR TITLE
fix(rollout): fix integration test after 1.10.1 FW release

### DIFF
--- a/ci/packages/rollout.yml
+++ b/ci/packages/rollout.yml
@@ -1,11 +1,19 @@
 # This test should exist only until trezor-connect is in monorepo.
 # It checks whether rollout works with currently released webwallet data
-rollout test integration:
-  only:
-    refs:
-      - develop
-      - schedules
+
+.rollout_test_integration: &rollout_test_integration
   stage: integration testing
   script:
     - yarn install --frozen-lockfile --cache-folder .yarn --prefer-offline
     - yarn workspace @trezor/rollout test:integration
+
+rollout test integration:
+  <<: *rollout_test_integration
+  only:
+    refs:
+      - develop
+      - schedules
+
+rollout test integration manual:
+  <<: *rollout_test_integration
+  when: manual

--- a/packages/integration-tests/projects/suite-web/tests/firmware/firmware.test.ts
+++ b/packages/integration-tests/projects/suite-web/tests/firmware/firmware.test.ts
@@ -6,49 +6,52 @@ describe('Firmware', () => {
         cy.viewport(1024, 768).resetDb();
     });
 
-    it('Firmware outdated notification banner should open firmware update modal', () => {
-        cy.task('startEmu', { wipe: true, version: '2.3.0' });
-        cy.task('setupEmu');
-        cy.task('startBridge');
-        cy.prefixedVisit('/');
-        cy.passThroughInitialRun();
-        cy.matchImageSnapshot('outdated notification banner');
-        cy.getTestElement('@notification/update-firmware/button').click();
+    ['1.9.4', '2.3.0'].forEach(fw => {
+        it(`Firmware ${fw} outdated notification banner should open firmware update modal`, () => {
+            cy.task('startEmu', { wipe: true, version: fw });
+            cy.task('setupEmu');
+            cy.task('startBridge');
+            cy.prefixedVisit('/');
+            cy.passThroughInitialRun();
+            cy.matchImageSnapshot('outdated notification banner');
+            cy.getTestElement('@notification/update-firmware/button').click();
 
-        // // initial screen
-        cy.getTestElement('@firmware/get-ready-button').click();
+            // // initial screen
+            cy.getTestElement('@firmware/get-ready-button').click();
 
-        // check seed screen
-        cy.getTestElement('@modal/close-button').should('be.visible'); // modal is cancellable at this moment
-        cy.wait(1000); // wait for animation to finish before taking a screenshot
-        cy.getTestElement('@firmware').matchImageSnapshot('check-seed');
-        cy.getTestElement('@firmware/confirm-seed-checkbox').click();
-        cy.getTestElement('@firmware/confirm-seed-button').click();
+            // check seed screen
+            cy.getTestElement('@modal/close-button').should('be.visible'); // modal is cancellable at this moment
+            cy.wait(1000); // wait for animation to finish before taking a screenshot
+            cy.getTestElement('@firmware').matchImageSnapshot('check-seed');
+            cy.getTestElement('@firmware/confirm-seed-checkbox').click();
+            cy.getTestElement('@firmware/confirm-seed-button').click();
 
-        // reconnect in bootloader screen (disconnect)
-        cy.getTestElement('@firmware/disconnect-message');
-        cy.task('stopEmu');
+            // reconnect in bootloader screen (disconnect)
+            cy.getTestElement('@firmware/disconnect-message');
+            cy.task('stopEmu');
 
-        // reconnect in bootloader screen (connect in bootloader)
-        cy.getTestElement('@firmware/connect-in-bootloader-message', { timeout: 20000 });
-        cy.log(
-            'And this is the end my friends. Emulator does not support bootloader, so we can not proceed with actual fw install',
-        );
+            // reconnect in bootloader screen (connect in bootloader)
+            cy.getTestElement('@firmware/connect-in-bootloader-message', { timeout: 20000 });
+            cy.log(
+                'And this is the end my friends. Emulator does not support bootloader, so we can not proceed with actual fw install',
+            );
+        });
     });
 
-    it.skip('For latest firmware, update button in device settings should display "Up to date" but still be clickable', () => {
-        cy.reload();
-        cy.task('startEmu', { wipe: true });
-        cy.task('setupEmu');
-        cy.task('startBridge');
-        cy.prefixedVisit('/');
-        cy.passThroughInitialRun();
-        cy.getTestElement('@suite/menu/settings').click();
-        cy.getTestElement('@suite/menu/settings-index').click();
-        cy.getTestElement('@settings/menu/device').click();
-        cy.getTestElement('@settings/device/update-button')
-            .should('contain.text', 'Up to date')
-            .click();
-        cy.getTestElement('@modal/close-button').click();
+    ['1-master', '2-master'].forEach(fw => {
+        it(`For latest firmware ${fw}, update button in device settings should display "Up to date" but still be clickable`, () => {
+            cy.task('startEmu', { wipe: true, version: fw });
+            cy.task('setupEmu');
+            cy.task('startBridge');
+            cy.prefixedVisit('/');
+            cy.passThroughInitialRun();
+            cy.getTestElement('@suite/menu/settings').click();
+            cy.getTestElement('@suite/menu/settings-index').click();
+            cy.getTestElement('@settings/menu/device').click();
+            cy.getTestElement('@settings/device/update-button')
+                .should('contain.text', 'Up to date')
+                .click();
+            cy.getTestElement('@modal/close-button').click();
+        });
     });
 });

--- a/packages/rollout/integration/fresh-devices.ts
+++ b/packages/rollout/integration/fresh-devices.ts
@@ -48,7 +48,7 @@ describe('Find firmware info for: ', () => {
 
     it('bootloader 1.5.1 -> firmware version 1.10.0', async () => {
         // currently, this is expected to fail after there is new firmware update, since the last version is hardcoded
-        const targetVersion = [1, 10, 0] as VersionArray;
+        const targetVersion = [1, 10, 1] as VersionArray;
         const info = getInfo({
             features: getDeviceFeatures({
                 bootloader_mode: true,


### PR DESCRIPTION
as mentioned in test:
 `is expected to fail after there is new firmware update, since the last version is hardcoded`
 
 additionally enable suite e2e test for both T1 and TT, it was skipped [here](https://github.com/trezor/trezor-suite/commit/4f7997e33e4646edc7275f0b1aec5599d5ec6e61#diff-f00cddf17e303985f841542d41020013c72bb734ed967b9f53e5bfb92614e861)