### PR TITLE
feat(ci): update base docker image and use the new image in ci

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -1,5 +1,5 @@
 # ! DO NOT set latest here USE custom hash !
-image: registry.gitlab.com/satoshilabs/trezor/trezor-suite/base@sha256:cfc62bc28946f0789a10dde4ecd3990ee7502e92de3dc2fa4d4ca84a329f7d21
+image: registry.gitlab.com/satoshilabs/trezor/trezor-suite/base@sha256:32b21e049618d33737786d8b1c52d0d896f979ba305bc7453285209fdf3cdf92
 
 variables:
   DEV_SERVER_URL: "https://suite.corp.sldev.cz"

--- a/docker/ci-base/Dockerfile
+++ b/docker/ci-base/Dockerfile
@@ -32,7 +32,7 @@ FROM ${CI_DOCKER_PROXY}node:14-buster
 
 RUN apt-get update && apt-get install -y \
     build-essential \
-    # required by cypress
+    # required by cypress and node
     xvfb \
     libgtk2.0-0 \
     libnotify-dev \
@@ -40,6 +40,11 @@ RUN apt-get update && apt-get install -y \
     libnss3 \
     libxss1 \
     libasound2 \
+    libcairo2-dev \
+    libpango1.0-dev \
+    libjpeg-dev \
+    libgif-dev \
+    librsvg2-dev \
     # required by core/emulator
     scons \
     libsdl2-dev \
@@ -48,7 +53,6 @@ RUN apt-get update && apt-get install -y \
     zip \
     jq \
     rsync
-
 
 RUN apt-get install -y \
     python3-dev \


### PR DESCRIPTION
I have added dependencies for the node canvas as they were missing and switched the ci to this updated image. I would squash it into 1 commit for the merge.