### PR TITLE
fix(send): ReplaceTransaction current fee fiat calculation

### DIFF
--- a/packages/suite/src/components/suite/modals/TransactionDetail/components/ChangeFee/components/DecreasedOutputs/index.tsx
+++ b/packages/suite/src/components/suite/modals/TransactionDetail/components/ChangeFee/components/DecreasedOutputs/index.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 import styled from 'styled-components';
 import { AnimatePresence, motion } from 'framer-motion';
 import { Icon, variables, RadioButton } from '@trezor/components';
-import { Translation, FormattedCryptoAmount } from '@suite-components';
+import { Translation, FormattedCryptoAmount, HiddenPlaceholder } from '@suite-components';
 import { ANIMATION } from '@suite-config';
 import { formatNetworkAmount } from '@wallet-utils/accountUtils';
 import { useRbfContext } from '@wallet-hooks/useRbfForm';
@@ -78,7 +78,6 @@ const DecreasedOutputs = () => {
                 <ReducedAmount>
                     <ArrowIcon icon="ARROW_RIGHT_LONG" />
                     <FormattedCryptoAmount
-                        disableHiddenPlaceholder
                         value={formatNetworkAmount(
                             precomposedTx.transaction.outputs[setMaxOutputId].amount,
                             account.symbol,
@@ -124,7 +123,6 @@ const DecreasedOutputs = () => {
                                                 values={{
                                                     value: (
                                                         <FormattedCryptoAmount
-                                                            disableHiddenPlaceholder
                                                             value={o.amount}
                                                             symbol={account.symbol}
                                                         />
@@ -134,7 +132,7 @@ const DecreasedOutputs = () => {
                                             {isChecked && reducedAmount}
                                         </OutputLabel>
                                         <OutputAddress isChecked={isChecked}>
-                                            {o.address}
+                                            <HiddenPlaceholder>{o.address}</HiddenPlaceholder>
                                         </OutputAddress>
                                     </OutputInner>
                                 </Output>

--- a/packages/suite/src/components/suite/modals/TransactionDetail/components/ChangeFee/index.tsx
+++ b/packages/suite/src/components/suite/modals/TransactionDetail/components/ChangeFee/index.tsx
@@ -118,18 +118,19 @@ const ChangeFee = (props: Props & { showChained: () => void }) => {
                                 <Rate>{feeRate}</Rate>
                                 <Amount>
                                     <StyledCryptoAmount>
-                                        <FormattedCryptoAmount value={tx.fee} symbol={tx.symbol} />
+                                        <FormattedCryptoAmount
+                                            disableHiddenPlaceholder
+                                            value={tx.fee}
+                                            symbol={tx.symbol}
+                                        />
                                     </StyledCryptoAmount>
-                                    {tx.rates && (
-                                        <StyledFiatValue>
-                                            <FiatValue
-                                                amount={tx.amount}
-                                                symbol={tx.symbol}
-                                                source={tx.rates}
-                                                useCustomSource
-                                            />
-                                        </StyledFiatValue>
-                                    )}
+                                    <StyledFiatValue>
+                                        <FiatValue
+                                            disableHiddenPlaceholder
+                                            amount={tx.fee}
+                                            symbol={tx.symbol}
+                                        />
+                                    </StyledFiatValue>
                                 </Amount>
                             </RateWrapper>
                         </Content>


### PR DESCRIPTION
fix for issue mentioned [here](https://github.com/trezor/trezor-suite/pull/3827#issuecomment-862941633)

- current fee should use current fiat rate instead of historical fiat rate
- decreased output amount and address should use HiddenPlaceholders (discret mode)

![Screenshot from 2021-06-17 12-04-59](https://user-images.githubusercontent.com/3435913/122376770-bda02380-cf64-11eb-98b6-fd85cff421d3.png)
