### PR TITLE
feat(suite/invity): Form draft

### DIFF
--- a/packages/suite/src/actions/wallet/__tests__/formDraftActions.test.ts
+++ b/packages/suite/src/actions/wallet/__tests__/formDraftActions.test.ts
@@ -1,0 +1,56 @@
+import configureStore from 'redux-mock-store';
+import thunk from 'redux-thunk';
+import formDraftReducer, { FormDraftState } from '@wallet-reducers/formDraftReducer';
+import * as formDraftActions from '../formDraftActions';
+
+export const getInitialState = (state?: FormDraftState) => ({
+    wallet: {
+        formDrafts: formDraftReducer(state, { type: 'foo' } as any),
+    },
+});
+
+type State = ReturnType<typeof getInitialState>;
+const mockStore = configureStore<State, any>([thunk]);
+
+const initStore = (state: State) => {
+    const store = mockStore(state);
+    store.subscribe(() => {
+        const action = store.getActions().pop();
+        const { formDrafts } = store.getState().wallet;
+        store.getState().wallet.formDrafts = formDraftReducer(formDrafts, action);
+        store.getActions().push(action);
+    });
+    return store;
+};
+
+describe('Form draft actions', () => {
+    it('saves draft', () => {
+        const initialState = getInitialState();
+        const store = initStore(initialState);
+        const expectedFormDraftState = {
+            'coinmarket-buy/form': { input: 'value' },
+        };
+
+        store.dispatch(formDraftActions.saveDraft('coinmarket-buy')('form', { input: 'value' }));
+        const formDraftState = store.getState().wallet.formDrafts;
+        expect(formDraftState).toEqual(expectedFormDraftState);
+    });
+
+    it('gets draft', () => {
+        const initialState = getInitialState({ 'coinmarket-buy/form': { input: 'value' } });
+        const store = initStore(initialState);
+        const expectedDraft = { input: 'value' };
+
+        const draft = store.dispatch(formDraftActions.getDraft('coinmarket-buy')('form'));
+        expect(draft).toEqual(expectedDraft);
+    });
+
+    it('removes draft', () => {
+        const initialState = getInitialState({ 'coinmarket-buy/form': { input: 'value' } });
+        const store = initStore(initialState);
+        const expectedDraft = {};
+
+        store.dispatch(formDraftActions.removeDraft('coinmarket-buy')('form'));
+        expect(store.getState().wallet.formDrafts).toEqual(expectedDraft);
+    });
+});

--- a/packages/suite/src/actions/wallet/constants/formDraftConstants.ts
+++ b/packages/suite/src/actions/wallet/constants/formDraftConstants.ts
@@ -1,0 +1,2 @@
+export const STORE_DRAFT = '@formDraft/store-draft';
+export const REMOVE_DRAFT = '@formDraft/remove-draft';

--- a/packages/suite/src/actions/wallet/constants/index.ts
+++ b/packages/suite/src/actions/wallet/constants/index.ts
@@ -13,6 +13,7 @@ import * as COINMARKET_EXCHANGE from './coinmarketExchangeConstants';
 import * as COINMARKET_SELL from './coinmarketSellConstants';
 import * as COINMARKET_COMMON from './coinmarketCommonConstants';
 import * as ACCOUNT_SEARCH from './accountSearch';
+import * as FORM_DRAFT from './formDraftConstants';
 
 export {
     BLOCKCHAIN,
@@ -30,4 +31,5 @@ export {
     COINMARKET_SELL,
     COINMARKET_COMMON,
     ACCOUNT_SEARCH,
+    FORM_DRAFT,
 };

--- a/packages/suite/src/actions/wallet/formDraftActions.ts
+++ b/packages/suite/src/actions/wallet/formDraftActions.ts
@@ -1,0 +1,55 @@
+import { Dispatch, GetState } from '@suite-types';
+import { getFormDraftKey } from '@wallet-utils/formDraftUtils';
+import { FORM_DRAFT } from './constants';
+
+import type { FormDraftKeyPrefix, FormDraft } from '@wallet-types/form';
+
+export type FormDraftAction =
+    | {
+          type: typeof FORM_DRAFT.STORE_DRAFT;
+          key: string;
+          formDraft: FormDraft;
+      }
+    | {
+          type: typeof FORM_DRAFT.REMOVE_DRAFT;
+          key: string;
+      };
+
+export const saveDraft = <T extends FormDraft>(prefix: FormDraftKeyPrefix) => (
+    key: string,
+    formDraft: T,
+) => (dispatch: Dispatch) => {
+    dispatch({
+        type: FORM_DRAFT.STORE_DRAFT,
+        key: getFormDraftKey(prefix, key),
+        formDraft,
+    });
+};
+
+export const getDraft = <T extends FormDraft>(prefix: FormDraftKeyPrefix) => (key: string) => (
+    _dispatch: Dispatch,
+    getState: GetState,
+) => {
+    const { formDrafts } = getState().wallet;
+    const formDraftKey = getFormDraftKey(prefix, key);
+    const draft = formDrafts[formDraftKey];
+
+    if (draft) {
+        // draft is a read-only redux object. make a copy to be able to modify values
+        return JSON.parse(JSON.stringify(draft)) as T;
+    }
+};
+
+export const removeDraft = (prefix: FormDraftKeyPrefix) => (key: string) => (
+    dispatch: Dispatch,
+    getState: GetState,
+) => {
+    const { formDrafts } = getState().wallet;
+    const formDraftKey = getFormDraftKey(prefix, key);
+    if (formDrafts[formDraftKey]) {
+        dispatch({
+            type: FORM_DRAFT.REMOVE_DRAFT,
+            key: formDraftKey,
+        });
+    }
+};

--- a/packages/suite/src/components/wallet/CoinmarketLayout/index.tsx
+++ b/packages/suite/src/components/wallet/CoinmarketLayout/index.tsx
@@ -1,5 +1,5 @@
 import { WalletLayout, CoinmarketFooter } from '@wallet-components';
-import { variables, Card } from '@trezor/components';
+import { variables, Card, Button } from '@trezor/components';
 import { useSelector } from '@suite-hooks';
 import React, { ReactNode } from 'react';
 import styled from 'styled-components';
@@ -24,21 +24,44 @@ const LayoutNavWrap = styled.div`
     margin-bottom: 32px;
 `;
 
+const HeaderLeft = styled.div`
+    display: flex;
+    flex: 1;
+    align-items: center;
+`;
+
+const HeaderRight = styled.div`
+    display: flex;
+    flex: 1;
+    align-items: center;
+    justify-content: flex-end;
+`;
+
 const BottomContent = styled.div``;
 
 interface Props {
     children: ReactNode;
+    onClearFormButtonClick?: () => void;
 }
 
-const CoinmarketLayout = ({ children }: Props) => {
+const CoinmarketLayout = ({ children, onClearFormButtonClick }: Props) => {
     const selectedAccount = useSelector(state => state.wallet.selectedAccount);
     return (
         <WalletLayout title="TR_NAV_TRADE" account={selectedAccount}>
             <LayoutNavWrap>
-                <StyledTitle>
-                    <Translation id="TR_NAV_TRADE" />
-                </StyledTitle>
-                <AccountFormCloseButton />
+                <HeaderLeft>
+                    <StyledTitle>
+                        <Translation id="TR_NAV_TRADE" />
+                    </StyledTitle>
+                </HeaderLeft>
+                <HeaderRight>
+                    {onClearFormButtonClick && (
+                        <Button type="button" variant="tertiary" onClick={onClearFormButtonClick}>
+                            <Translation id="TR_CLEAR_ALL" />
+                        </Button>
+                    )}
+                    <AccountFormCloseButton />
+                </HeaderRight>
             </LayoutNavWrap>
             <Card noPadding>
                 <Navigation />

--- a/packages/suite/src/constants/wallet/formDraft.ts
+++ b/packages/suite/src/constants/wallet/formDraft.ts
@@ -1,0 +1,5 @@
+export const FormDraftPrefixKeyValues = [
+    'coinmarket-buy',
+    'coinmarket-sell',
+    'coinmarket-exchange',
+] as const;

--- a/packages/suite/src/hooks/wallet/useCoinmarket.ts
+++ b/packages/suite/src/hooks/wallet/useCoinmarket.ts
@@ -9,6 +9,7 @@ import * as coinmarketExchangeActions from '@wallet-actions/coinmarketExchangeAc
 import * as coinmarketSellActions from '@wallet-actions/coinmarketSellActions';
 import { Account } from '@wallet-types';
 import { TradeBuy, TradeSell, TradeExchange } from '@wallet-types/coinmarketCommonTypes';
+import { useFormDraft } from '@wallet-hooks/useFormDraft';
 
 const BuyTradeFinalStatuses: BuyTradeStatus[] = ['SUCCESS', 'ERROR', 'BLOCKED'];
 
@@ -30,6 +31,8 @@ export const useWatchBuyTrade = (account: Account, trade: TradeBuy) => {
         cancelRefresh();
     });
 
+    const { removeDraft } = useFormDraft('coinmarket-buy');
+
     useEffect(() => {
         if (trade && shouldRefreshBuyTrade(trade)) {
             cancelRefresh();
@@ -44,10 +47,13 @@ export const useWatchBuyTrade = (account: Account, trade: TradeBuy) => {
                     };
                     saveTrade(tradeData, account, newDate);
                 }
+                if (response.status && BuyTradeFinalStatuses.includes(response.status)) {
+                    removeDraft(account.key);
+                }
             });
             resetRefresh();
         }
-    }, [account, cancelRefresh, refreshCount, resetRefresh, saveTrade, trade]);
+    }, [account, cancelRefresh, refreshCount, removeDraft, resetRefresh, saveTrade, trade]);
 };
 
 export const ExchangeTradeFinalStatuses: ExchangeTradeStatus[] = ['SUCCESS', 'ERROR', 'KYC'];
@@ -70,6 +76,8 @@ export const useWatchExchangeTrade = (account: Account, trade: TradeExchange) =>
         cancelRefresh();
     });
 
+    const { removeDraft } = useFormDraft('coinmarket-exchange');
+
     useEffect(() => {
         if (trade && shouldRefreshExchangeTrade(trade)) {
             cancelRefresh();
@@ -84,10 +92,13 @@ export const useWatchExchangeTrade = (account: Account, trade: TradeExchange) =>
                     };
                     saveTrade(tradeData, account, newDate);
                 }
+                if (response.status && ExchangeTradeFinalStatuses.includes(response.status)) {
+                    removeDraft(account.key);
+                }
             });
             resetRefresh();
         }
-    }, [account, cancelRefresh, refreshCount, resetRefresh, saveTrade, trade]);
+    }, [account, cancelRefresh, refreshCount, removeDraft, resetRefresh, saveTrade, trade]);
 };
 
 export const SellFiatTradeFinalStatuses: SellTradeStatus[] = [
@@ -116,6 +127,8 @@ export const useWatchSellTrade = (account: Account, trade: TradeSell) => {
         cancelRefresh();
     });
 
+    const { removeDraft } = useFormDraft('coinmarket-sell');
+
     useEffect(() => {
         if (trade && shouldRefreshSellTrade(trade)) {
             cancelRefresh();
@@ -129,9 +142,12 @@ export const useWatchSellTrade = (account: Account, trade: TradeSell) => {
                         error: response.error,
                     };
                     saveTrade(tradeData, account, newDate);
+                    if (response.status && SellFiatTradeFinalStatuses.includes(response.status)) {
+                        removeDraft(account.key);
+                    }
                 }
             });
             resetRefresh();
         }
-    }, [account, cancelRefresh, refreshCount, resetRefresh, saveTrade, trade]);
+    }, [account, cancelRefresh, refreshCount, removeDraft, resetRefresh, saveTrade, trade]);
 };

--- a/packages/suite/src/hooks/wallet/useCoinmarketBuyForm.ts
+++ b/packages/suite/src/hooks/wallet/useCoinmarketBuyForm.ts
@@ -1,10 +1,10 @@
-import { createContext, useContext, useCallback, useState } from 'react';
-import { useForm } from 'react-hook-form';
-import * as coinmarketCommonActions from '@wallet-actions/coinmarket/coinmarketCommonActions';
+import { createContext, useContext, useCallback, useState, useEffect } from 'react';
+import { useForm, useWatch } from 'react-hook-form';
+import { isChanged } from '@suite-utils/comparisonUtils';
+import useDebounce from 'react-use/lib/useDebounce';
 import * as coinmarketBuyActions from '@wallet-actions/coinmarketBuyActions';
 import { useActions, useSelector } from '@suite-hooks';
-import { buildOption } from '@wallet-utils/coinmarket/coinmarketUtils';
-import regional from '@wallet-constants/coinmarket/regional';
+import * as coinmarketCommonActions from '@wallet-actions/coinmarket/coinmarketCommonActions';
 import { BuyTradeQuoteRequest } from 'invity-api';
 import invityAPI from '@suite-services/invityAPI';
 import * as routerActions from '@suite-actions/routerActions';
@@ -15,6 +15,8 @@ import {
     AmountLimits,
     BuyFormContextValues,
 } from '@wallet-types/coinmarketBuyForm';
+import { useFormDraft } from '@wallet-hooks/useFormDraft';
+import { useCoinmarketBuyFormDefaultValues } from './useCoinmarketBuyFormDefaultValues';
 
 export const BuyFormContext = createContext<BuyFormContextValues | null>(null);
 BuyFormContext.displayName = 'CoinmarketBuyContext';
@@ -37,14 +39,52 @@ export const useCoinmarketBuyForm = (props: Props): BuyFormContextValues => {
     });
 
     loadInvityData();
-
-    const { selectedAccount, cachedAccountInfo, quotesRequest } = props;
-    const { buyInfo } = useSelector(state => ({ buyInfo: state.wallet.coinmarket.buy.buyInfo }));
+    const { selectedAccount } = props;
     const { account, network } = selectedAccount;
     const [amountLimits, setAmountLimits] = useState<AmountLimits | undefined>(undefined);
-    const methods = useForm<FormState>({ mode: 'onChange' });
+    const { saveDraft, getDraft, removeDraft } = useFormDraft<FormState>('coinmarket-buy');
+    const draft = getDraft(account.key);
+    const isDraft = !!draft;
 
-    const { register } = methods;
+    const { buyInfo } = useSelector(state => ({ buyInfo: state.wallet.coinmarket.buy.buyInfo }));
+    const { defaultValues, defaultCountry, defaultCurrency } = useCoinmarketBuyFormDefaultValues(
+        account.symbol,
+        buyInfo,
+    );
+    const methods = useForm<FormState>({
+        mode: 'onChange',
+        defaultValues: isDraft ? draft : defaultValues,
+    });
+
+    const { register, control, formState, errors, reset } = methods;
+    const values = useWatch<FormState>({ control });
+
+    useEffect(() => {
+        // when draft doesn't exist, we need to bind actual default values - that happens when we've got buyInfo from Invity API server
+        if (!isDraft && defaultValues) {
+            reset(defaultValues);
+        }
+    }, [reset, defaultValues, isDraft]);
+
+    const resetForm = useCallback(() => {
+        reset({});
+        removeDraft(account.key);
+    }, [account.key, removeDraft, reset]);
+
+    useDebounce(
+        () => {
+            if (formState.isDirty && !formState.isValidating && Object.keys(errors).length === 0) {
+                saveDraft(account.key, values as FormState);
+            }
+        },
+        200,
+        [errors, saveDraft, account.key, values, formState],
+    );
+    useEffect(() => {
+        if (!isChanged(defaultValues, values)) {
+            removeDraft(account.key);
+        }
+    }, [defaultValues, values, removeDraft, account.key]);
 
     const onSubmit = async () => {
         const formValues = methods.getValues();
@@ -77,21 +117,6 @@ export const useCoinmarketBuyForm = (props: Props): BuyFormContextValues => {
         }
     };
 
-    const country = buyInfo?.buyInfo?.country || regional.unknownCountry;
-    const defaultCountry = {
-        label: regional.countriesMap.get(country),
-        value: country,
-    };
-    const defaultCurrencyInfo = buyInfo?.buyInfo?.suggestedFiatCurrency;
-    const defaultCurrency = defaultCurrencyInfo
-        ? buildOption(defaultCurrencyInfo)
-        : { label: 'USD', value: 'usd' };
-
-    const accountHasCachedRequest =
-        account.symbol === cachedAccountInfo.symbol &&
-        account.index === cachedAccountInfo.index &&
-        account.accountType === cachedAccountInfo.accountType;
-
     const typedRegister = useCallback(<T>(rules?: T) => register(rules), [register]);
     const isLoading = !buyInfo || !buyInfo?.buyInfo;
     const noProviders =
@@ -107,18 +132,18 @@ export const useCoinmarketBuyForm = (props: Props): BuyFormContextValues => {
         defaultCurrency,
         register: typedRegister,
         buyInfo,
-        accountHasCachedRequest,
-        cachedAccountInfo,
-        saveQuoteRequest,
         saveQuotes,
-        quotesRequest,
-        saveCachedAccountInfo,
         saveTrade,
         amountLimits,
         setAmountLimits,
         isLoading,
         noProviders,
         network,
+        cryptoInputValue: values.cryptoInput,
+        removeDraft,
+        formState,
+        isDraft,
+        handleClearFormButtonClick: resetForm,
     };
 };
 

--- a/packages/suite/src/hooks/wallet/useCoinmarketBuyFormDefaultValues.ts
+++ b/packages/suite/src/hooks/wallet/useCoinmarketBuyFormDefaultValues.ts
@@ -1,0 +1,46 @@
+import { BuyInfo } from '@wallet-actions/coinmarketBuyActions';
+import { useMemo } from 'react';
+import regional from '@wallet-constants/coinmarket/regional';
+import { Account } from '@wallet-types';
+import { buildOption } from '@wallet-utils/coinmarket/coinmarketUtils';
+
+export const useCoinmarketBuyFormDefaultValues = (
+    accountSymbol: Account['symbol'],
+    buyInfo?: BuyInfo,
+) => {
+    const country = buyInfo?.buyInfo?.country || regional.unknownCountry;
+    const defaultCountry = useMemo(
+        () => ({
+            label: regional.countriesMap.get(country),
+            value: country,
+        }),
+        [country],
+    );
+    const defaultCurrencyInfo = buyInfo?.buyInfo?.suggestedFiatCurrency;
+    const defaultCurrency = useMemo(
+        () =>
+            defaultCurrencyInfo ? buildOption(defaultCurrencyInfo) : { label: 'USD', value: 'usd' },
+        [defaultCurrencyInfo],
+    );
+    const defaultCrypto = useMemo(
+        () => ({
+            value: accountSymbol.toUpperCase(),
+            label: accountSymbol.toUpperCase(),
+        }),
+        [accountSymbol],
+    );
+    const defaultValues = useMemo(
+        () =>
+            buyInfo
+                ? {
+                      fiatInput: '',
+                      cryptoInput: '',
+                      currencySelect: defaultCurrency,
+                      cryptoSelect: defaultCrypto,
+                      countrySelect: defaultCountry,
+                  }
+                : undefined,
+        [buyInfo, defaultCountry, defaultCrypto, defaultCurrency],
+    );
+    return { defaultValues, defaultCountry, defaultCurrency };
+};

--- a/packages/suite/src/hooks/wallet/useCoinmarketExchangeFormDefaultValues.ts
+++ b/packages/suite/src/hooks/wallet/useCoinmarketExchangeFormDefaultValues.ts
@@ -1,0 +1,41 @@
+import { useMemo } from 'react';
+import { ExchangeInfo } from '@wallet-actions/coinmarketExchangeActions';
+import { DEFAULT_PAYMENT, DEFAULT_VALUES } from '@wallet-constants/sendForm';
+import { buildOption } from '@wallet-utils/coinmarket/coinmarketUtils';
+import { Account } from '@wallet-types';
+import { ExchangeFormState } from '@wallet-types/coinmarketExchangeForm';
+
+export const useCoinmarketExchangeFormDefaultValues = (
+    symbol: Account['symbol'],
+    localCurrency: string,
+    exchangeInfo?: ExchangeInfo,
+    defaultAddress?: string,
+) => {
+    const defaultCurrency = useMemo(() => buildOption(localCurrency), [localCurrency]);
+    const defaultValues = useMemo(
+        () =>
+            exchangeInfo
+                ? ({
+                      ...DEFAULT_VALUES,
+                      feePerUnit: '',
+                      feeLimit: '',
+                      estimatedFeeLimit: undefined,
+                      fiatInput: '',
+                      cryptoInput: '',
+                      receiveCryptoSelect: null,
+                      sendCryptoSelect: buildOption(symbol),
+                      options: ['broadcast'],
+                      outputs: [
+                          {
+                              ...DEFAULT_PAYMENT,
+                              address: defaultAddress,
+                              currency: defaultCurrency,
+                          },
+                      ],
+                      // TODO: remove type casting (options string[])
+                  } as ExchangeFormState)
+                : undefined,
+        [exchangeInfo, symbol, defaultAddress, defaultCurrency],
+    );
+    return { defaultCurrency, defaultValues };
+};

--- a/packages/suite/src/hooks/wallet/useCoinmarketSellFormDefaultValues.ts
+++ b/packages/suite/src/hooks/wallet/useCoinmarketSellFormDefaultValues.ts
@@ -1,0 +1,49 @@
+import { useMemo } from 'react';
+import regional from '@wallet-constants/coinmarket/regional';
+import { SellInfo } from '@wallet-actions/coinmarketSellActions';
+import { DEFAULT_PAYMENT, DEFAULT_VALUES } from '@wallet-constants/sendForm';
+import { buildOption } from '@wallet-utils/coinmarket/coinmarketUtils';
+import { Account } from '@wallet-types';
+import { SellFormState } from '@wallet-types/coinmarketSellForm';
+
+export const useCoinmarketSellFormDefaultValues = (
+    symbol: Account['symbol'],
+    sellInfo?: SellInfo,
+    defaultAddress?: string,
+) => {
+    const country = sellInfo?.sellList?.country || regional.unknownCountry;
+    const defaultCountry = useMemo(
+        () => ({
+            label: regional.countriesMap.get(country),
+            value: country,
+        }),
+        [country],
+    );
+    const defaultCurrency = useMemo(() => ({ label: 'EUR', value: 'eur' }), []);
+    const defaultValues = useMemo(
+        () =>
+            sellInfo
+                ? ({
+                      ...DEFAULT_VALUES,
+                      feePerUnit: '',
+                      feeLimit: '',
+                      estimatedFeeLimit: undefined,
+                      fiatInput: '',
+                      fiatCurrencySelect: defaultCurrency,
+                      cryptoInput: '',
+                      cryptoCurrencySelect: buildOption(symbol),
+                      countrySelect: defaultCountry,
+                      options: ['broadcast'],
+                      outputs: [
+                          {
+                              ...DEFAULT_PAYMENT,
+                              address: defaultAddress,
+                          },
+                      ],
+                      // TODO: remove type casting (options string[])
+                  } as SellFormState)
+                : undefined,
+        [symbol, defaultCountry, defaultCurrency, sellInfo, defaultAddress],
+    );
+    return { defaultCountry, defaultCurrency, defaultValues };
+};

--- a/packages/suite/src/hooks/wallet/useFormDraft.ts
+++ b/packages/suite/src/hooks/wallet/useFormDraft.ts
@@ -1,0 +1,10 @@
+import { useActions } from '@suite-hooks';
+import { FormDraft, FormDraftKeyPrefix } from '@wallet-types/form';
+import * as formDraftActions from '@wallet-actions/formDraftActions';
+
+export const useFormDraft = <T extends FormDraft>(keyPrefix: FormDraftKeyPrefix) =>
+    useActions({
+        getDraft: formDraftActions.getDraft<T>(keyPrefix),
+        saveDraft: formDraftActions.saveDraft<T>(keyPrefix),
+        removeDraft: formDraftActions.removeDraft(keyPrefix),
+    });

--- a/packages/suite/src/middlewares/wallet/storageMiddleware.ts
+++ b/packages/suite/src/middlewares/wallet/storageMiddleware.ts
@@ -9,6 +9,7 @@ import {
     GRAPH,
     SEND,
     COINMARKET_COMMON,
+    FORM_DRAFT,
 } from '@wallet-actions/constants';
 import * as storageActions from '@suite-actions/storageActions';
 import * as accountUtils from '@wallet-utils/accountUtils';
@@ -16,6 +17,7 @@ import { SUITE, ANALYTICS, METADATA, MESSAGE_SYSTEM } from '@suite-actions/const
 import { getDiscovery } from '@wallet-actions/discoveryActions';
 import { isDeviceRemembered } from '@suite-utils/device';
 import { serializeDiscovery } from '@suite-utils/storage';
+import { FormDraftPrefixKeyValues } from '@wallet-constants/formDraft';
 
 import type { AppState, Action as SuiteAction, Dispatch } from '@suite-types';
 import type { WalletAction } from '@wallet-types';
@@ -54,6 +56,9 @@ const storageMiddleware = (api: MiddlewareAPI<Dispatch, AppState>) => (next: Dis
 
         case ACCOUNT.REMOVE: {
             action.payload.forEach(account => {
+                FormDraftPrefixKeyValues.map(prefix =>
+                    storageActions.removeAccountFormDraft(prefix, account.key),
+                );
                 storageActions.removeAccountDraft(account);
                 storageActions.removeAccountTransactions(account);
                 storageActions.removeAccountGraph(account);
@@ -192,6 +197,18 @@ const storageMiddleware = (api: MiddlewareAPI<Dispatch, AppState>) => (next: Dis
         case MESSAGE_SYSTEM.FETCH_CONFIG_SUCCESS_UPDATE:
         case MESSAGE_SYSTEM.DISMISS_MESSAGE:
             api.dispatch(storageActions.saveMessageSystem());
+            break;
+
+        case FORM_DRAFT.STORE_DRAFT: {
+            const { device } = api.getState().suite;
+            // save drafts for remembered device
+            if (isDeviceRemembered(device)) {
+                storageActions.saveFormDraft(action.key, action.formDraft);
+            }
+            break;
+        }
+        case FORM_DRAFT.REMOVE_DRAFT:
+            storageActions.removeFormDraft(action.key);
             break;
 
         default:

--- a/packages/suite/src/reducers/wallet/formDraftReducer.ts
+++ b/packages/suite/src/reducers/wallet/formDraftReducer.ts
@@ -1,0 +1,27 @@
+import { FORM_DRAFT } from '@wallet-actions/constants';
+import produce from 'immer';
+import { Action } from '@suite-types';
+import { FormDraft } from '@wallet-types/form';
+import { STORAGE } from '@suite/actions/suite/constants';
+
+export interface FormDraftState {
+    [key: string]: FormDraft;
+}
+export const initialState: FormDraftState = {};
+
+const formDraftReducer = (state: FormDraftState = initialState, action: Action): FormDraftState =>
+    produce(state, draft => {
+        switch (action.type) {
+            case STORAGE.LOADED:
+                return action.payload.wallet.formDrafts;
+            case FORM_DRAFT.STORE_DRAFT:
+                draft[action.key] = action.formDraft;
+                break;
+            case FORM_DRAFT.REMOVE_DRAFT:
+                delete draft[action.key];
+                break;
+            // no default
+        }
+    });
+
+export default formDraftReducer;

--- a/packages/suite/src/reducers/wallet/index.ts
+++ b/packages/suite/src/reducers/wallet/index.ts
@@ -13,6 +13,7 @@ import blockchainReducer from './blockchainReducer';
 import coinmarketReducer from './coinmarketReducer';
 import sendFormReducer from './sendFormReducer';
 import accountSearchReducer from './accountSearchReducer';
+import formDraftReducer from './formDraftReducer';
 
 const WalletReducers = combineReducers({
     signVerify: signVerifyReducer,
@@ -29,6 +30,7 @@ const WalletReducers = combineReducers({
     coinmarket: coinmarketReducer,
     send: sendFormReducer,
     accountSearch: accountSearchReducer,
+    formDrafts: formDraftReducer,
 });
 
 export default WalletReducers;

--- a/packages/suite/src/storage/CHANGELOG.md
+++ b/packages/suite/src/storage/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Storage changelog
 
+## 24
+-   added form drafts
+
 ## 22
 -   added LTC bech32 accounts
 

--- a/packages/suite/src/storage/definitions.ts
+++ b/packages/suite/src/storage/definitions.ts
@@ -13,6 +13,7 @@ import type { GraphData } from '@wallet-types/graph';
 import type { TradeType } from '@wallet-types/coinmarketCommonTypes';
 import type { MessageSystem } from '@suite-types/messageSystem';
 import type { MessageState } from '@suite/reducers/suite/messageSystemReducer';
+import type { FormDraft } from '@wallet-types/form';
 
 export interface DBWalletAccountTransaction {
     tx: WalletAccountTransaction;
@@ -105,6 +106,10 @@ export interface SuiteDBSchema extends DBSchema {
                 [key: string]: MessageState;
             };
         };
+    };
+    formDrafts: {
+        key: string;
+        value: FormDraft;
     };
 }
 

--- a/packages/suite/src/storage/index.ts
+++ b/packages/suite/src/storage/index.ts
@@ -3,7 +3,7 @@ import { migrate } from './migrations';
 
 import type { SuiteDBSchema } from './definitions';
 
-const VERSION = 23; // don't forget to add migration and CHANGELOG when changing versions!
+const VERSION = 24; // don't forget to add migration and CHANGELOG when changing versions!
 
 /**
  *  If the object stores don't already exist then creates them.
@@ -75,6 +75,7 @@ const onUpgrade: OnUpgradeFunc<SuiteDBSchema> = async (db, oldVersion, newVersio
         db.createObjectStore('metadata');
 
         db.createObjectStore('messageSystem');
+        db.createObjectStore('formDrafts');
     } else {
         // migrate functions
         await migrate(db, oldVersion, newVersion, transaction);

--- a/packages/suite/src/storage/migrations/index.ts
+++ b/packages/suite/src/storage/migrations/index.ts
@@ -220,4 +220,8 @@ export const migrate = async (
     if (oldVersion < 23) {
         db.createObjectStore('messageSystem');
     }
+
+    if (oldVersion < 24) {
+        db.createObjectStore('formDrafts');
+    }
 };

--- a/packages/suite/src/types/wallet/coinmarketBuyForm.ts
+++ b/packages/suite/src/types/wallet/coinmarketBuyForm.ts
@@ -1,20 +1,12 @@
 import { AppState } from '@suite-types';
 import { Account, Network } from '@wallet-types';
-import {
-    BuyInfo,
-    saveQuoteRequest,
-    saveQuotes,
-    saveTrade,
-    saveCachedAccountInfo,
-} from '@wallet-actions/coinmarketBuyActions';
-import { UseFormMethods } from 'react-hook-form';
+import { BuyInfo, saveQuotes, saveTrade } from '@wallet-actions/coinmarketBuyActions';
+import { UseFormMethods, FormState as ReactHookFormState } from 'react-hook-form';
 import { TypedValidationRules } from './form';
 import { DefaultCountryOption, Option } from './coinmarketCommonTypes';
 
 export interface ComponentProps {
     selectedAccount: AppState['wallet']['selectedAccount'];
-    quotesRequest: AppState['wallet']['coinmarket']['buy']['quotesRequest'];
-    cachedAccountInfo: AppState['wallet']['coinmarket']['buy']['cachedAccountInfo'];
 }
 
 export interface Props extends ComponentProps {
@@ -44,16 +36,16 @@ export type BuyFormContextValues = Omit<UseFormMethods<FormState>, 'register'> &
     defaultCountry: DefaultCountryOption;
     defaultCurrency: Option;
     buyInfo?: BuyInfo;
-    saveQuoteRequest: typeof saveQuoteRequest;
     saveQuotes: typeof saveQuotes;
-    saveCachedAccountInfo: typeof saveCachedAccountInfo;
     saveTrade: typeof saveTrade;
     amountLimits?: AmountLimits;
     setAmountLimits: (limits?: AmountLimits) => void;
-    accountHasCachedRequest: boolean;
-    cachedAccountInfo: AppState['wallet']['coinmarket']['buy']['cachedAccountInfo'];
-    quotesRequest: AppState['wallet']['coinmarket']['buy']['quotesRequest'];
     isLoading: boolean;
     noProviders: boolean;
     network: Network;
+    cryptoInputValue?: string;
+    removeDraft: (key: string) => void;
+    formState: ReactHookFormState<FormState>;
+    isDraft: boolean;
+    handleClearFormButtonClick: () => void;
 };

--- a/packages/suite/src/types/wallet/coinmarketExchangeForm.ts
+++ b/packages/suite/src/types/wallet/coinmarketExchangeForm.ts
@@ -1,5 +1,5 @@
 import { AppState } from '@suite-types';
-import { UseFormMethods } from 'react-hook-form';
+import { UseFormMethods, FormState as ReactHookFormState } from 'react-hook-form';
 import { Account, Network, CoinFiatRates } from '@wallet-types';
 import { FeeLevel } from 'trezor-connect';
 import { ExchangeTrade, ExchangeTradeQuoteRequest, ExchangeCoinInfo } from 'invity-api';
@@ -28,7 +28,8 @@ export interface Props extends ComponentProps {
 }
 
 export type ExchangeFormState = FormState & {
-    receiveCryptoSelect: Option;
+    // NOTE: react-select value type cannot be undefined, but at least null works
+    receiveCryptoSelect: Option | null;
     sendCryptoSelect: Option;
 };
 
@@ -46,7 +47,7 @@ export type ExchangeFormContextValues = Omit<UseFormMethods<ExchangeFormState>, 
     changeFeeLevel: (level: FeeLevel['label']) => void;
     exchangeInfo?: ExchangeInfo;
     exchangeCoinInfo?: ExchangeCoinInfo[];
-    localCurrencyOption: { label: string; value: string };
+    defaultCurrency: Option;
     composeRequest: (field?: string) => void;
     updateFiatCurrency: (selectedCurrency: { value: string; label: string }) => void;
     updateSendCryptoValue: (fiatValue: string, decimals: number) => void;
@@ -70,4 +71,8 @@ export type ExchangeFormContextValues = Omit<UseFormMethods<ExchangeFormState>, 
     noProviders: boolean;
     network: Network;
     feeInfo: FeeInfo;
+    removeDraft: (key: string) => void;
+    formState: ReactHookFormState<ExchangeFormState>;
+    handleClearFormButtonClick: () => void;
+    isDraft: boolean;
 };

--- a/packages/suite/src/types/wallet/coinmarketSellForm.ts
+++ b/packages/suite/src/types/wallet/coinmarketSellForm.ts
@@ -1,5 +1,5 @@
 import { AppState } from '@suite-types';
-import { UseFormMethods } from 'react-hook-form';
+import { UseFormMethods, FormState as ReactHookFormState } from 'react-hook-form';
 import { Account, Network, CoinFiatRates } from '@wallet-types';
 import { FeeLevel } from 'trezor-connect';
 import { SellFiatTrade, SellFiatTradeQuoteRequest, ExchangeCoinInfo } from 'invity-api';
@@ -73,4 +73,7 @@ export type SellFormContextValues = Omit<UseFormMethods<SellFormState>, 'registe
     feeInfo: FeeInfo;
     onCryptoAmountChange: (amount: string) => void;
     onFiatAmountChange: (amount: string) => void;
+    handleClearFormButtonClick: () => void;
+    formState: ReactHookFormState<FormState>;
+    isDraft: boolean;
 };

--- a/packages/suite/src/types/wallet/form.ts
+++ b/packages/suite/src/types/wallet/form.ts
@@ -1,6 +1,7 @@
 import { ReactElement } from 'react';
 import { ExtendedMessageDescriptor } from '@suite-types';
 import { FieldError } from 'react-hook-form';
+import { FormDraftPrefixKeyValues } from '@wallet-constants/formDraft';
 
 // strongly typed UseFormMethods.register
 export interface TypedValidationRules {
@@ -20,3 +21,6 @@ export type TypedFieldError =
           type: string;
           message?: ExtendedMessageDescriptor['id'] | ExtendedMessageDescriptor | ReactElement;
       };
+
+export type FormDraftKeyPrefix = typeof FormDraftPrefixKeyValues[number];
+export type FormDraft = Record<string, any>;

--- a/packages/suite/src/types/wallet/index.ts
+++ b/packages/suite/src/types/wallet/index.ts
@@ -14,6 +14,7 @@ import { SendFormAction } from '@wallet-actions/sendFormActions';
 import { AccountSearchAction } from '@wallet-actions/accountSearchActions';
 import { TransactionAction } from '@wallet-actions/transactionActions';
 import { SelectedAccountAction } from '@wallet-actions/selectedAccountActions';
+import { FormDraftAction } from '@wallet-actions/formDraftActions';
 import { NETWORKS } from '@wallet-config';
 import { ArrayElement } from '../utils';
 
@@ -61,4 +62,5 @@ export type WalletAction =
     | CoinmarketSellAction
     | CoinmarketCommonAction
     | SendFormAction
-    | AccountSearchAction;
+    | AccountSearchAction
+    | FormDraftAction;

--- a/packages/suite/src/utils/wallet/__tests__/formDraftUtils.test.ts
+++ b/packages/suite/src/utils/wallet/__tests__/formDraftUtils.test.ts
@@ -1,0 +1,10 @@
+import { FormDraftPrefixKeyValues } from '@wallet-constants/formDraft';
+import * as formDraftUtils from '../formDraftUtils';
+
+describe('form draft utils', () => {
+    it('getFormDraftKey', () => {
+        FormDraftPrefixKeyValues.forEach(prefix => {
+            expect(formDraftUtils.getFormDraftKey(prefix, 'key')).toEqual(`${prefix}/key`);
+        });
+    });
+});

--- a/packages/suite/src/utils/wallet/formDraftUtils.ts
+++ b/packages/suite/src/utils/wallet/formDraftUtils.ts
@@ -1,0 +1,3 @@
+import type { FormDraftKeyPrefix } from '@wallet-types/form';
+
+export const getFormDraftKey = (prefix: FormDraftKeyPrefix, key: string) => `${prefix}/${key}`;

--- a/packages/suite/src/views/wallet/coinmarket/buy/components/BuyForm/Footer/index.tsx
+++ b/packages/suite/src/views/wallet/coinmarket/buy/components/BuyForm/Footer/index.tsx
@@ -82,8 +82,6 @@ const Footer = () => {
         watch,
         setAmountLimits,
         defaultCountry,
-        accountHasCachedRequest,
-        quotesRequest,
     } = useCoinmarketBuyFormContext();
     const countrySelect = 'countrySelect';
     const hasValues =
@@ -99,14 +97,7 @@ const Footer = () => {
                 </Label>
                 <Controller
                     control={control}
-                    defaultValue={
-                        accountHasCachedRequest && quotesRequest?.country
-                            ? {
-                                  label: regional.countriesMap.get(quotesRequest.country),
-                                  value: quotesRequest.country,
-                              }
-                            : defaultCountry
-                    }
+                    defaultValue={defaultCountry}
                     name={countrySelect}
                     render={({ onChange, value }) => (
                         <StyledSelect

--- a/packages/suite/src/views/wallet/coinmarket/buy/components/BuyForm/Inputs/index.tsx
+++ b/packages/suite/src/views/wallet/coinmarket/buy/components/BuyForm/Inputs/index.tsx
@@ -55,7 +55,6 @@ const Inputs = () => {
         register,
         errors,
         trigger,
-        watch,
         account,
         network,
         control,
@@ -66,8 +65,7 @@ const Inputs = () => {
         buyInfo,
         setAmountLimits,
         defaultCurrency,
-        accountHasCachedRequest,
-        quotesRequest,
+        cryptoInputValue,
     } = useCoinmarketBuyFormContext();
     const { symbol } = account;
     const uppercaseSymbol = symbol.toUpperCase();
@@ -77,7 +75,7 @@ const Inputs = () => {
     const cryptoSelect = 'cryptoSelect';
     const [activeInput, setActiveInput] = useState<'fiatInput' | 'cryptoInput'>(fiatInput);
     // if cryptoInput has a valid value, set it as the activeInput
-    if (watch('cryptoInput') && !errors[cryptoInput] && activeInput === fiatInput) {
+    if (cryptoInputValue && !errors[cryptoInput] && activeInput === fiatInput) {
         setActiveInput(cryptoInput);
     }
 
@@ -90,11 +88,6 @@ const Inputs = () => {
             <Left>
                 <Input
                     noTopLabel
-                    defaultValue={
-                        accountHasCachedRequest && quotesRequest
-                            ? quotesRequest.fiatStringAmount
-                            : ''
-                    }
                     innerRef={register({
                         validate: (value: string) => {
                             if (activeInput === fiatInput) {
@@ -167,14 +160,7 @@ const Inputs = () => {
                         <Controller
                             control={control}
                             name={currencySelect}
-                            defaultValue={
-                                accountHasCachedRequest && quotesRequest?.fiatCurrency
-                                    ? {
-                                          label: quotesRequest.fiatCurrency.toUpperCase(),
-                                          value: quotesRequest.fiatCurrency.toUpperCase(),
-                                      }
-                                    : defaultCurrency
-                            }
+                            defaultValue={defaultCurrency}
                             render={({ onChange, value }) => (
                                 <Select
                                     options={FIAT.currencies
@@ -208,11 +194,6 @@ const Inputs = () => {
                         setValue(fiatInput, '');
                         clearErrors(fiatInput);
                     }}
-                    defaultValue={
-                        accountHasCachedRequest && quotesRequest
-                            ? quotesRequest.cryptoStringAmount
-                            : ''
-                    }
                     state={errors[cryptoInput] ? 'error' : undefined}
                     name={cryptoInput}
                     noTopLabel
@@ -280,17 +261,10 @@ const Inputs = () => {
                         <Controller
                             control={control}
                             name={cryptoSelect}
-                            defaultValue={
-                                accountHasCachedRequest && quotesRequest?.receiveCurrency
-                                    ? {
-                                          label: quotesRequest.receiveCurrency.toUpperCase(),
-                                          value: quotesRequest.receiveCurrency.toUpperCase(),
-                                      }
-                                    : {
-                                          value: uppercaseSymbol,
-                                          label: uppercaseSymbol,
-                                      }
-                            }
+                            defaultValue={{
+                                value: uppercaseSymbol,
+                                label: uppercaseSymbol,
+                            }}
                             render={({ onChange, value }) => (
                                 <Select
                                     onChange={(selected: any) => {

--- a/packages/suite/src/views/wallet/coinmarket/buy/index.tsx
+++ b/packages/suite/src/views/wallet/coinmarket/buy/index.tsx
@@ -8,16 +8,20 @@ import BuyForm from './components/BuyForm';
 
 const mapStateToProps = (state: AppState): ComponentProps => ({
     selectedAccount: state.wallet.selectedAccount,
-    quotesRequest: state.wallet.coinmarket.buy.quotesRequest,
-    cachedAccountInfo: state.wallet.coinmarket.buy.cachedAccountInfo,
 });
 
 const CoinmarketBuyLoaded = (props: Props) => {
     const { selectedAccount } = props;
     const coinmarketBuyContextValues = useCoinmarketBuyForm({ ...props, selectedAccount });
-
+    const {
+        isDraft,
+        formState: { isDirty },
+        handleClearFormButtonClick,
+    } = coinmarketBuyContextValues;
     return (
-        <CoinmarketLayout>
+        <CoinmarketLayout
+            onClearFormButtonClick={isDirty || isDraft ? handleClearFormButtonClick : undefined}
+        >
             <BuyFormContext.Provider value={coinmarketBuyContextValues}>
                 <BuyForm />
             </BuyFormContext.Provider>

--- a/packages/suite/src/views/wallet/coinmarket/exchange/components/ExchangeForm/Inputs/FiatInput/FiatSelect/index.tsx
+++ b/packages/suite/src/views/wallet/coinmarket/exchange/components/ExchangeForm/Inputs/FiatInput/FiatSelect/index.tsx
@@ -20,7 +20,7 @@ const FiatSelect = () => {
         setAmountLimits,
         account,
         updateFiatCurrency,
-        localCurrencyOption,
+        defaultCurrency,
     } = useCoinmarketExchangeFormContext();
     const currencyOptions = buildCurrencyOptions();
 
@@ -28,7 +28,7 @@ const FiatSelect = () => {
         <Controller
             control={control}
             name={FIAT_CURRENCY}
-            defaultValue={localCurrencyOption}
+            defaultValue={defaultCurrency}
             render={({ onChange, value }) => (
                 <Select
                     onChange={(selected: any) => {

--- a/packages/suite/src/views/wallet/coinmarket/exchange/components/ExchangeForm/Inputs/ReceiveCryptoSelect/index.tsx
+++ b/packages/suite/src/views/wallet/coinmarket/exchange/components/ExchangeForm/Inputs/ReceiveCryptoSelect/index.tsx
@@ -137,7 +137,6 @@ const ReceiveCryptoSelect = () => {
         <Wrapper>
             <Controller
                 control={control}
-                defaultValue={false}
                 name="receiveCryptoSelect"
                 render={({ onChange, value }) => (
                     <Select

--- a/packages/suite/src/views/wallet/coinmarket/exchange/components/ExchangeForm/Inputs/SendCryptoInput/index.tsx
+++ b/packages/suite/src/views/wallet/coinmarket/exchange/components/ExchangeForm/Inputs/SendCryptoInput/index.tsx
@@ -66,7 +66,7 @@ const SendCryptoInput = () => {
             onChange={event => {
                 updateFiatValue(event.target.value);
                 clearErrors(FIAT_INPUT);
-                setValue('setMaxOutputId', undefined);
+                setValue('setMaxOutputId', undefined, { shouldDirty: true });
                 composeRequest();
             }}
             state={error ? 'error' : undefined}

--- a/packages/suite/src/views/wallet/coinmarket/exchange/components/ExchangeForm/Inputs/index.tsx
+++ b/packages/suite/src/views/wallet/coinmarket/exchange/components/ExchangeForm/Inputs/index.tsx
@@ -89,7 +89,7 @@ const Inputs = () => {
 
     const setRatioAmount = useCallback(
         (divisor: number) => {
-            setValue('setMaxOutputId', undefined);
+            setValue('setMaxOutputId', undefined, { shouldDirty: true });
             const amount = tokenData
                 ? new BigNumber(tokenData.balance || '0')
                       .dividedBy(divisor)
@@ -99,7 +99,7 @@ const Inputs = () => {
                       .dividedBy(divisor)
                       .decimalPlaces(network.decimals)
                       .toString();
-            setValue(CRYPTO_INPUT, amount);
+            setValue(CRYPTO_INPUT, amount, { shouldDirty: true });
             updateFiatValue(amount);
             clearErrors([FIAT_INPUT, CRYPTO_INPUT]);
             composeRequest();
@@ -116,7 +116,7 @@ const Inputs = () => {
     );
 
     const setAllAmount = useCallback(() => {
-        setValue('setMaxOutputId', 0);
+        setValue('setMaxOutputId', 0, { shouldDirty: true });
         clearErrors([FIAT_INPUT, CRYPTO_INPUT]);
         composeRequest();
     }, [clearErrors, composeRequest, setValue]);

--- a/packages/suite/src/views/wallet/coinmarket/exchange/index.tsx
+++ b/packages/suite/src/views/wallet/coinmarket/exchange/index.tsx
@@ -14,9 +14,15 @@ const CoinmarketExchangeLoaded = (props: Props) => {
         ...props,
         selectedAccount,
     });
-
+    const {
+        isDraft,
+        formState: { isDirty },
+        handleClearFormButtonClick,
+    } = coinmarketExchangeContextValues;
     return (
-        <CoinmarketLayout>
+        <CoinmarketLayout
+            onClearFormButtonClick={isDirty || isDraft ? handleClearFormButtonClick : undefined}
+        >
             <ExchangeFormContext.Provider value={coinmarketExchangeContextValues}>
                 <ExchangeForm />
             </ExchangeFormContext.Provider>

--- a/packages/suite/src/views/wallet/coinmarket/sell/components/SellForm/Inputs/index.tsx
+++ b/packages/suite/src/views/wallet/coinmarket/sell/components/SellForm/Inputs/index.tsx
@@ -91,7 +91,7 @@ const Inputs = () => {
                 .dividedBy(divisor)
                 .decimalPlaces(network.decimals)
                 .toString();
-            setValue(CRYPTO_INPUT, amount);
+            setValue(CRYPTO_INPUT, amount, { shouldDirty: true });
             clearErrors([CRYPTO_INPUT]);
             setActiveInput(CRYPTO_INPUT);
             onCryptoAmountChange(amount);
@@ -100,8 +100,8 @@ const Inputs = () => {
     );
 
     const setAllAmount = useCallback(() => {
-        setValue('setMaxOutputId', 0);
-        setValue(FIAT_INPUT, '');
+        setValue('setMaxOutputId', 0, { shouldDirty: true });
+        setValue(FIAT_INPUT, '', { shouldDirty: true });
         clearErrors([FIAT_INPUT, CRYPTO_INPUT]);
         setActiveInput(CRYPTO_INPUT);
         composeRequest(CRYPTO_INPUT);

--- a/packages/suite/src/views/wallet/coinmarket/sell/index.tsx
+++ b/packages/suite/src/views/wallet/coinmarket/sell/index.tsx
@@ -7,9 +7,15 @@ import { useCoinmarketSellForm, SellFormContext } from '@wallet-hooks/useCoinmar
 
 const CoinmarketSellLoaded = (props: Props) => {
     const coinmarketSellContextValues = useCoinmarketSellForm(props);
-
+    const {
+        isDraft,
+        formState: { isDirty },
+        handleClearFormButtonClick,
+    } = coinmarketSellContextValues;
     return (
-        <CoinmarketLayout>
+        <CoinmarketLayout
+            onClearFormButtonClick={isDirty || isDraft ? handleClearFormButtonClick : undefined}
+        >
             <SellFormContext.Provider value={coinmarketSellContextValues}>
                 <SellForm />
             </SellFormContext.Provider>


### PR DESCRIPTION
**User stories**

> As a user, I want to return back to my trade which is in progress, so I can continue and finish the trade.

When a user fills out any form input on **Buy**, **Sell** or **Exchange** page, a form draft is created and stored with a unique key. On the next page load (or navigation), the form draft is applied to the form if it exists. The form draft key is unique per form name and per optional value (in the trade section it is an account key).

> As a user, I want to clear form with draft applied, so I can quickly start a new trade.

When there is a form draft applied to a form, the "clear form" button appears in the top right corner (similar position as it is in send form). When a user clicks the button, the form resets to its default values and the form draft storage is clear. The button's text is "Clear all" which is the same as it is in the send form. Form draft is also cleared in a final state of trade.

**Impact**
Send form uses its own concrete form draft functionality. I believe It's desired the send form uses the general form draft feature.

**Commits**
b00ee2dc197f63df7a250df70042fc1cfc23954a - General form draft
69db5f3c5ddfcf40c3d962c7b1e2f1f3bc15cb6b - Select extension so we are able to add the clear button also above select (appears in Exchange)
3363f1cea1be44700af77f9ff44c60be56013070 - Application of general form draft in coinmarket

This PR partially fulfills #3012