### PR TITLE
fix(onboarding): huge icon when backup fails

### DIFF
--- a/packages/suite/src/views/onboarding/steps/Backup/index.tsx
+++ b/packages/suite/src/views/onboarding/steps/Backup/index.tsx
@@ -139,7 +139,7 @@ const BackupStep = () => {
                         </OnboardingButtonCta>
                     }
                 >
-                    <OptionsWrapper>
+                    <OptionsWrapper fullWidth={false}>
                         <StyledImage image="UNI_ERROR" />
                     </OptionsWrapper>
                 </OnboardingStepBox>


### PR DESCRIPTION
closes #3910

![Screenshot 2021-06-22 at 8 52 35](https://user-images.githubusercontent.com/33235762/122877753-3a514a00-d337-11eb-934d-485f5e2ae501.png)
