### PR TITLE
Fix/3913 onboarding animation inconsistencies

### DIFF
--- a/packages/suite/package.json
+++ b/packages/suite/package.json
@@ -21,7 +21,6 @@
         "@trezor/suite-data": "21.7.0",
         "@trezor/suite-storage": "21.7.0",
         "bignumber.js": "^9.0.1",
-        "compare-versions": "^3.6.0",
         "date-fns": "^2.16.1",
         "date-fns-tz": "^1.0.12",
         "dropbox": "5.1.0",

--- a/packages/suite/src/components/firmware/FirmwareInitial.tsx
+++ b/packages/suite/src/components/firmware/FirmwareInitial.tsx
@@ -51,7 +51,6 @@ const FirmwareInitial = ({ cachedDevice, setCachedDevice, standaloneFwUpdate }: 
 
     // User is following instructions for disconnecting/reconnecting a device in bootloader mode; We'll use cached version of the device
     const device = status === 'waiting-for-bootloader' ? cachedDevice : liveDevice;
-    const expectedModel = device?.features?.major_version || 2;
 
     let content;
 
@@ -136,10 +135,7 @@ const FirmwareInitial = ({ cachedDevice, setCachedDevice, standaloneFwUpdate }: 
             <>
                 {/* Modal above a fw update offer. Instructs user to reconnect the device in bootloader */}
                 {status === 'waiting-for-bootloader' && (
-                    <ReconnectDevicePrompt
-                        deviceVersion={expectedModel}
-                        requestedMode="bootloader"
-                    />
+                    <ReconnectDevicePrompt expectedDevice={device} requestedMode="bootloader" />
                 )}
 
                 <OnboardingStepBox

--- a/packages/suite/src/components/firmware/FirmwareInstallation.tsx
+++ b/packages/suite/src/components/firmware/FirmwareInstallation.tsx
@@ -59,10 +59,7 @@ const FirmwareInstallation = ({ cachedDevice, standaloneFwUpdate }: Props) => {
         <>
             {(status === 'unplug' || status === 'reconnect-in-normal') && (
                 // Modal to instruct user to disconnect the device and reconnect in normal mode
-                <ReconnectDevicePrompt
-                    deviceVersion={cachedDevice?.features?.major_version || 2}
-                    requestedMode="normal"
-                />
+                <ReconnectDevicePrompt expectedDevice={cachedDevice} requestedMode="normal" />
             )}
             <OnboardingStepBox
                 image="FIRMWARE"

--- a/packages/suite/src/components/firmware/ReconnectDevicePrompt.tsx
+++ b/packages/suite/src/components/firmware/ReconnectDevicePrompt.tsx
@@ -4,7 +4,7 @@ import * as semver from 'semver';
 
 import { H1, Button, variables } from '@trezor/components';
 import { Translation, WebusbButton } from '@suite-components';
-import { DeviceAnimation, DeviceAnimationType } from '@onboarding-components';
+import { DeviceAnimation } from '@onboarding-components';
 import { useDevice, useFirmware } from '@suite-hooks';
 import { isDesktop, isMacOs } from '@suite-utils/env';
 import { DESKTOP_WRAPPER_BORDER_WIDTH } from '@suite-constants/layout';
@@ -200,25 +200,13 @@ const ReconnectDevicePrompt = ({ expectedDevice, requestedMode }: Props) => {
             </Button>
         ) : undefined;
 
-    // T1 bootloader before firmware version 1.8.0 can only be invoked by holding both buttons
-    const deviceFwVersion = device?.features ? getFwVersion(device) : '';
-    const deviceModel = device?.features ? getDeviceModel(device) : 'T';
-    let animationType: DeviceAnimationType = 'BOOTLOADER';
-    if (
-        deviceModel === '1' &&
-        semver.valid(deviceFwVersion) &&
-        semver.satisfies(deviceFwVersion, '<1.8.0')
-    ) {
-        animationType = 'BOOTLOADER_TWO_BUTTONS';
-    }
-
     return (
         <Overlay
             desktopBorder={isDesktop() && !isMacOs() ? DESKTOP_WRAPPER_BORDER_WIDTH : undefined}
         >
             <Wrapper data-test={`@firmware/reconnect-device/${requestedMode}`}>
                 <StyledDeviceAnimation
-                    type={animationType}
+                    type="BOOTLOADER"
                     size={200}
                     shape="ROUNDED"
                     device={expectedDevice}

--- a/packages/suite/src/components/firmware/ReconnectDevicePrompt.tsx
+++ b/packages/suite/src/components/firmware/ReconnectDevicePrompt.tsx
@@ -1,12 +1,14 @@
 import React, { useState, useEffect } from 'react';
 import styled, { css } from 'styled-components';
-import compareVersions from 'compare-versions';
+import * as semver from 'semver';
+
 import { H1, Button, variables } from '@trezor/components';
 import { Translation, WebusbButton } from '@suite-components';
 import { DeviceAnimation, DeviceAnimationType } from '@onboarding-components';
 import { useDevice, useFirmware } from '@suite-hooks';
 import { isDesktop, isMacOs } from '@suite-utils/env';
 import { DESKTOP_WRAPPER_BORDER_WIDTH } from '@suite-constants/layout';
+import { getDeviceModel, getFwVersion } from '@suite/utils/suite/device';
 
 const Wrapper = styled.div`
     display: flex;
@@ -187,13 +189,12 @@ const ReconnectDevicePrompt = ({ deviceVersion, requestedMode }: Props) => {
         ) : undefined;
 
     // T1 bootloader before firmware version 1.8.0 can only be invoked by holding both buttons
-    const animationVersion = deviceVersion === 1 ? '1' : 'T';
-    const firmwareSemver = `${device?.features?.major_version}.${device?.features?.minor_version}.${device?.features?.patch_version}`;
+    const firmwareVersion = device?.features ? getFwVersion(device) : '';
     let animationType: DeviceAnimationType = 'BOOTLOADER';
     if (
         animationVersion === '1' &&
-        compareVersions.validate(firmwareSemver) &&
-        compareVersions.compare(firmwareSemver, '1.8.0', '<')
+        semver.valid(firmwareVersion) &&
+        semver.satisfies(firmwareVersion, '<1.8.0')
     ) {
         animationType = 'BOOTLOADER_TWO_BUTTONS';
     }

--- a/packages/suite/src/components/firmware/ReconnectDevicePrompt.tsx
+++ b/packages/suite/src/components/firmware/ReconnectDevicePrompt.tsx
@@ -10,6 +10,8 @@ import { isDesktop, isMacOs } from '@suite-utils/env';
 import { DESKTOP_WRAPPER_BORDER_WIDTH } from '@suite-constants/layout';
 import { getDeviceModel, getFwVersion } from '@suite/utils/suite/device';
 
+import type { TrezorDevice } from '@suite/types/suite';
+
 const Wrapper = styled.div`
     display: flex;
     flex: 1;
@@ -147,11 +149,11 @@ const getTextForMode = (requestedMode: 'bootloader' | 'normal', deviceVersion: n
     return text[requestedMode];
 };
 interface Props {
-    deviceVersion: number;
+    expectedDevice?: TrezorDevice;
     requestedMode: 'bootloader' | 'normal';
 }
 
-const ReconnectDevicePrompt = ({ deviceVersion, requestedMode }: Props) => {
+const ReconnectDevicePrompt = ({ expectedDevice, requestedMode }: Props) => {
     const { device } = useDevice();
     const { firmwareUpdate, isWebUSB } = useFirmware();
     // local state to track if the user actually unplugged the device. Otherwise if the device is
@@ -189,12 +191,13 @@ const ReconnectDevicePrompt = ({ deviceVersion, requestedMode }: Props) => {
         ) : undefined;
 
     // T1 bootloader before firmware version 1.8.0 can only be invoked by holding both buttons
-    const firmwareVersion = device?.features ? getFwVersion(device) : '';
+    const deviceFwVersion = device?.features ? getFwVersion(device) : '';
+    const deviceModel = device?.features ? getDeviceModel(device) : 'T';
     let animationType: DeviceAnimationType = 'BOOTLOADER';
     if (
-        animationVersion === '1' &&
-        semver.valid(firmwareVersion) &&
-        semver.satisfies(firmwareVersion, '<1.8.0')
+        deviceModel === '1' &&
+        semver.valid(deviceFwVersion) &&
+        semver.satisfies(deviceFwVersion, '<1.8.0')
     ) {
         animationType = 'BOOTLOADER_TWO_BUTTONS';
     }
@@ -208,7 +211,7 @@ const ReconnectDevicePrompt = ({ deviceVersion, requestedMode }: Props) => {
                     type={animationType}
                     size={200}
                     shape="ROUNDED"
-                    version={animationVersion}
+                    device={expectedDevice}
                     loop
                 />
                 <Content>

--- a/packages/suite/src/components/onboarding/ConnectDevicePrompt/index.tsx
+++ b/packages/suite/src/components/onboarding/ConnectDevicePrompt/index.tsx
@@ -1,10 +1,11 @@
 import React from 'react';
 import { useSpring, config, animated } from 'react-spring';
+import styled from 'styled-components';
+
 import { variables, Icon } from '@trezor/components';
 import { DeviceAnimation } from '@onboarding-components';
 import { Translation } from '@suite-components';
-import { useTheme, useDevice } from '@suite-hooks';
-import styled from 'styled-components';
+import { useDevice, useTheme } from '@suite-hooks';
 
 const Wrapper = styled(animated.div)`
     display: flex;
@@ -71,7 +72,7 @@ const ConnectDevicePrompt = ({ children, connected, showWarning }: Props) => {
             <ImageWrapper>
                 <DeviceAnimation
                     type="CONNECT"
-                    version={device?.features?.model}
+                    device={device}
                     loop={!connected}
                     shape="CIRCLE"
                     size={100}

--- a/packages/suite/src/components/onboarding/DeviceAnimation/index.tsx
+++ b/packages/suite/src/components/onboarding/DeviceAnimation/index.tsx
@@ -1,12 +1,13 @@
 import styled, { css } from 'styled-components';
 import React, { useRef } from 'react';
 import Lottie from 'lottie-react';
+import * as semver from 'semver';
 
 import { resolveStaticPath } from '@suite-utils/nextjs';
 import { useTheme } from '@suite-hooks';
 import LottieT1Connect from './lottie/t1_connect.json';
 import LottieTTConnect from './lottie/tt_connect.json';
-import { getDeviceModel } from '@suite-utils/device';
+import { getDeviceModel, getFwVersion } from '@suite-utils/device';
 
 import type { TrezorDevice } from '@suite/types/suite';
 
@@ -71,42 +72,54 @@ type Props = {
 
 const DeviceAnimation = ({ size, type, loop = false, shape, device, ...props }: Props) => {
     const { themeVariant } = useTheme();
-
     const hologramRef = useRef<HTMLVideoElement>(null);
 
     // if device features are not available, use T model animations
     const deviceModel = device?.features ? getDeviceModel(device) : 'T';
-    const animationType = type.toLowerCase();
+
+    // T1 bootloader before firmware version 1.8.0 can only be invoked by holding both buttons
+    const deviceFwVersion = device?.features ? getFwVersion(device) : '';
+    let animationType = type;
+    if (
+        type === 'BOOTLOADER' &&
+        deviceModel === '1' &&
+        semver.valid(deviceFwVersion) &&
+        semver.satisfies(deviceFwVersion, '<1.8.0')
+    ) {
+        animationType = 'BOOTLOADER_TWO_BUTTONS';
+    }
+
+    const animationFileName = animationType.toLowerCase();
 
     return (
         <Wrapper size={size} shape={shape} {...props}>
-            {type === 'CONNECT' && (
+            {animationType === 'CONNECT' && (
                 <StyledLottie
                     animationData={deviceModel === '1' ? LottieT1Connect : LottieTTConnect}
                     loop={loop}
                 />
             )}
-            {type === 'BOOTLOADER' && (
+            {animationType === 'BOOTLOADER' && (
                 <StyledVideo loop={loop} autoPlay muted width={size} height={size}>
                     <source
                         src={resolveStaticPath(
-                            `videos/onboarding/t${deviceModel}_${animationType}_${themeVariant}.mp4`,
+                            `videos/onboarding/t${deviceModel}_${animationFileName}_${themeVariant}.mp4`,
                         )}
                         type="video/mp4"
                     />
                 </StyledVideo>
             )}
-            {type === 'BOOTLOADER_TWO_BUTTONS' && (
+            {animationType === 'BOOTLOADER_TWO_BUTTONS' && (
                 <StyledVideo loop={loop} autoPlay muted width={size} height={size}>
                     <source
                         src={resolveStaticPath(
-                            `videos/onboarding/t1_${animationType}_${themeVariant}.mp4`,
+                            `videos/onboarding/t1_${animationFileName}_${themeVariant}.mp4`,
                         )}
                         type="video/mp4"
                     />
                 </StyledVideo>
             )}
-            {type === 'HOLOGRAM' && (
+            {animationType === 'HOLOGRAM' && (
                 <StyledVideo
                     loop={loop}
                     autoPlay
@@ -120,17 +133,17 @@ const DeviceAnimation = ({ size, type, loop = false, shape, device, ...props }: 
                 >
                     <source
                         src={resolveStaticPath(
-                            `videos/onboarding/t${deviceModel}_${animationType}.webm`,
+                            `videos/onboarding/t${deviceModel}_${animationFileName}.webm`,
                         )}
                         type="video/webm"
                     />
                 </StyledVideo>
             )}
-            {type === 'SUCCESS' && (
+            {animationType === 'SUCCESS' && (
                 <StyledVideo loop={loop} autoPlay muted width={size} height={size}>
                     <source
                         src={resolveStaticPath(
-                            `videos/onboarding/t${deviceModel}_${animationType}_${themeVariant}.webm`,
+                            `videos/onboarding/t${deviceModel}_${animationFileName}_${themeVariant}.webm`,
                         )}
                         type="video/webm"
                     />

--- a/packages/suite/src/components/onboarding/DeviceAnimation/index.tsx
+++ b/packages/suite/src/components/onboarding/DeviceAnimation/index.tsx
@@ -1,11 +1,14 @@
-/* eslint-disable jsx-a11y/media-has-caption */
 import styled, { css } from 'styled-components';
 import React, { useRef } from 'react';
 import Lottie from 'lottie-react';
+
 import { resolveStaticPath } from '@suite-utils/nextjs';
 import { useTheme } from '@suite-hooks';
 import LottieT1Connect from './lottie/t1_connect.json';
 import LottieTTConnect from './lottie/tt_connect.json';
+import { getDeviceModel } from '@suite-utils/device';
+
+import type { TrezorDevice } from '@suite/types/suite';
 
 const Wrapper = styled.div<{ size?: number; shape?: Shape }>`
     width: 100%;
@@ -60,23 +63,26 @@ type Shape = 'CIRCLE' | 'ROUNDED' | 'ROUNDED-SMALL';
 
 type Props = {
     size?: number;
+    device?: TrezorDevice;
     type: DeviceAnimationType;
-    version?: string;
     loop?: boolean;
     shape?: Shape;
 };
 
-const DeviceAnimation = ({ size, type, version, loop = false, shape, ...props }: Props) => {
+const DeviceAnimation = ({ size, type, loop = false, shape, device, ...props }: Props) => {
     const { themeVariant } = useTheme();
+
     const hologramRef = useRef<HTMLVideoElement>(null);
-    const trezorVersion = version === '1' ? version : 't';
+
+    // if device features are not available, use T model animations
+    const deviceModel = device?.features ? getDeviceModel(device) : 'T';
     const animationType = type.toLowerCase();
 
     return (
         <Wrapper size={size} shape={shape} {...props}>
             {type === 'CONNECT' && (
                 <StyledLottie
-                    animationData={trezorVersion === '1' ? LottieT1Connect : LottieTTConnect}
+                    animationData={deviceModel === '1' ? LottieT1Connect : LottieTTConnect}
                     loop={loop}
                 />
             )}
@@ -84,7 +90,7 @@ const DeviceAnimation = ({ size, type, version, loop = false, shape, ...props }:
                 <StyledVideo loop={loop} autoPlay muted width={size} height={size}>
                     <source
                         src={resolveStaticPath(
-                            `videos/onboarding/t${trezorVersion}_${animationType}_${themeVariant}.mp4`,
+                            `videos/onboarding/t${deviceModel}_${animationType}_${themeVariant}.mp4`,
                         )}
                         type="video/mp4"
                     />
@@ -114,7 +120,7 @@ const DeviceAnimation = ({ size, type, version, loop = false, shape, ...props }:
                 >
                     <source
                         src={resolveStaticPath(
-                            `videos/onboarding/t${trezorVersion}_${animationType}.webm`,
+                            `videos/onboarding/t${deviceModel}_${animationType}.webm`,
                         )}
                         type="video/webm"
                     />
@@ -124,7 +130,7 @@ const DeviceAnimation = ({ size, type, version, loop = false, shape, ...props }:
                 <StyledVideo loop={loop} autoPlay muted width={size} height={size}>
                     <source
                         src={resolveStaticPath(
-                            `videos/onboarding/t${trezorVersion}_${animationType}_${themeVariant}.webm`,
+                            `videos/onboarding/t${deviceModel}_${animationType}_${themeVariant}.webm`,
                         )}
                         type="video/webm"
                     />

--- a/packages/suite/src/components/onboarding/Hologram/index.tsx
+++ b/packages/suite/src/components/onboarding/Hologram/index.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import styled from 'styled-components';
+
 import { variables } from '@trezor/components';
 import { DeviceAnimation } from '@onboarding-components';
 import { Translation, TrezorLink } from '@suite/components/suite';
@@ -8,6 +9,8 @@ import {
     TREZOR_RESELLERS_URL,
     SUPPORT_URL,
 } from '@suite/constants/suite/urls';
+
+import type { TrezorDevice } from '@suite/types/suite';
 
 const Wrapper = styled.div`
     display: flex;
@@ -41,10 +44,11 @@ const Warning = styled.div`
     background: ${props => props.theme.BG_LIGHT_GREY};
 `;
 
-interface Props {
-    trezorModel?: string;
+interface HologramProps {
+    device?: TrezorDevice;
 }
-const Hologram = ({ trezorModel }: Props) => (
+
+const Hologram = ({ device }: HologramProps) => (
     <Wrapper>
         <HologramHeading>
             <Translation id="TR_HOLOGRAM_STEP_HEADING" />
@@ -55,7 +59,7 @@ const Hologram = ({ trezorModel }: Props) => (
         </HologramSubHeading>
 
         <AnimationWrapper>
-            <DeviceAnimation type="HOLOGRAM" version={trezorModel} shape="ROUNDED-SMALL" loop />
+            <DeviceAnimation type="HOLOGRAM" shape="ROUNDED-SMALL" loop device={device} />
         </AnimationWrapper>
 
         <Warning>

--- a/packages/suite/src/services/github.ts
+++ b/packages/suite/src/services/github.ts
@@ -1,4 +1,4 @@
-import { getFwVersion, isBitcoinOnly, getVersion } from '@suite-utils/device';
+import { getFwVersion, isBitcoinOnly, getDeviceModel } from '@suite-utils/device';
 import { isDesktop, getUserAgent, getScreenWidth, getScreenHeight } from '@suite-utils/env';
 
 import type { ReleaseInfo } from '@suite-types/github';
@@ -27,7 +27,7 @@ const getDeviceInfo = (device?: TrezorDevice) => {
     if (!device?.features) {
         return '';
     }
-    return `model ${getVersion(device)} ${getFwVersion(device)} ${
+    return `model ${getDeviceModel(device)} ${getFwVersion(device)} ${
         isBitcoinOnly(device) ? 'Bitcoin only' : 'regular'
     }`;
 };

--- a/packages/suite/src/support/messages.ts
+++ b/packages/suite/src/support/messages.ts
@@ -4629,9 +4629,13 @@ const definedMessages = defineMessages({
         id: 'TR_LANDING_CONTINUE',
         defaultMessage: 'Continue in browser',
     },
+    TR_HOLD_BOTH_BUTTONS: {
+        id: 'TR_HOLD_BOTH_BUTTONS',
+        defaultMessage: 'Hold both buttons while connecting device',
+    },
     TR_HOLD_LEFT_BUTTON: {
         id: 'TR_HOLD_LEFT_BUTTON',
-        defaultMessage: 'Hold left or both buttons while connecting device',
+        defaultMessage: 'Hold left button while connecting device',
     },
     BACKUP_BACKUP_ALREADY_FINISHED_HEADING: {
         id: 'BACKUP_BACKUP_ALREADY_FINISHED',

--- a/packages/suite/src/utils/suite/__fixtures__/device.ts
+++ b/packages/suite/src/utils/suite/__fixtures__/device.ts
@@ -172,12 +172,12 @@ const getVersion = [
     {
         description: `model One`,
         device: getSuiteDevice(undefined, { major_version: 1 }),
-        result: 'One',
+        result: '1',
     },
     {
         description: `model One (no features)`,
         device: getSuiteDevice({ type: 'unacquired' }),
-        result: 'One',
+        result: '1',
     },
 ];
 

--- a/packages/suite/src/utils/suite/__tests__/device.test.ts
+++ b/packages/suite/src/utils/suite/__tests__/device.test.ts
@@ -41,7 +41,7 @@ describe('isSelectedInstance', () => {
 describe('getVersion', () => {
     fixtures.getVersion.forEach(f => {
         it(f.description, () => {
-            const instance = utils.getVersion(f.device);
+            const instance = utils.getDeviceModel(f.device);
             expect(instance).toEqual(f.result);
         });
     });

--- a/packages/suite/src/utils/suite/device.ts
+++ b/packages/suite/src/utils/suite/device.ts
@@ -131,9 +131,9 @@ export const isSelectedDevice = (selected?: TrezorDevice | Device, device?: Trez
     return selected.id === device.id;
 };
 
-export const getVersion = (device: TrezorDevice) => {
+export const getDeviceModel = (device: TrezorDevice) => {
     const { features } = device;
-    return features && features.major_version > 1 ? 'T' : 'One';
+    return features && features.major_version > 1 ? 'T' : '1';
 };
 
 export const getFwVersion = (device: KnownDevice) => {

--- a/packages/suite/src/views/onboarding/steps/Final/index.tsx
+++ b/packages/suite/src/views/onboarding/steps/Final/index.tsx
@@ -145,7 +145,7 @@ const FinalStep = () => {
         >
             <Wrapper>
                 <DeviceImageWrapper>
-                    <DeviceAnimation type="SUCCESS" version={device?.features?.model} size={400} />
+                    <DeviceAnimation type="SUCCESS" size={400} device={device} />
                 </DeviceImageWrapper>
                 <Content>
                     <Heading>

--- a/packages/suite/src/views/onboarding/steps/Welcome/components/PreOnboardingSetup/SecurityCheck.tsx
+++ b/packages/suite/src/views/onboarding/steps/Welcome/components/PreOnboardingSetup/SecurityCheck.tsx
@@ -89,10 +89,7 @@ const SecurityCheck = () => {
                     id="TR_ONBOARDING_DEVICE_CHECK_1"
                     values={{
                         strong: chunks => (
-                            <StyledTooltip
-                                rich
-                                content={<Hologram trezorModel={device?.features?.model} />}
-                            >
+                            <StyledTooltip rich content={<Hologram device={device} />}>
                                 <Underline>{chunks}</Underline>
                             </StyledTooltip>
                         ),

--- a/yarn.lock
+++ b/yarn.lock
@@ -8821,11 +8821,6 @@ compare-func@^2.0.0:
     array-ify "^1.0.0"
     dot-prop "^5.1.0"
 
-compare-versions@^3.6.0:
-  version "3.6.0"
-  resolved "https://registry.yarnpkg.com/compare-versions/-/compare-versions-3.6.0.tgz#1a5689913685e5a87637b8d3ffca75514ec41d62"
-  integrity sha512-W6Af2Iw1z4CB7q4uU4hv646dW9GQuBM+YpC0UvUCWSD8w90SJjp+ujJuXaEMtAXBtSqGfMPuFOVn4/+FlaqfBA==
-
 component-emitter@^1.2.1, component-emitter@~1.3.0:
   version "1.3.0"
   resolved "https://registry.yarnpkg.com/component-emitter/-/component-emitter-1.3.0.tgz#16e4070fba8ae29b679f2215853ee181ab2eabc0"


### PR DESCRIPTION
closes #3913, #3938

1. Commit (c5cb738263d782866af707d49411f00672050964)
- device.features.model returns `'T' | '1'`
- our helper function which determines the model based on fw version returned `'T' | 'One'`
- I made it consistent. So now both return `'T' | '1'`

2. Commit (0d374da176bdca90d1b7abdd2f762fa7aff4b566)
- removing compare-versions library which do the same as semver lib which is already in the project

3. Commit (db0311681d392f22f2d54ba246731360208cb748)
- DeviceAnimation now accept device prop and shows animation type based on fw version instead of feature.model (because feature.model is not available in older devices)
- If device is not available, it fallbacks to `T` model. The only case when user sees T model animation is when device is not connected
![Screenshot 2021-06-22 at 15 39 34](https://user-images.githubusercontent.com/33235762/122934707-0e9e8600-d370-11eb-8c10-51937e529308.png)

4. Commit (28da3d5f19998c84a84545f5d9182a255b364f6f)
- Fix incorrect bootloader text which says different instruction than animation
<img width="586" alt="Screenshot 2021-06-24 at 11 55 56" src="https://user-images.githubusercontent.com/33235762/123243281-28140f00-d4e3-11eb-8352-ecd2325aa2f8.png">

5. Commit (110703535b1c6ca508408b57d3817c6404cfdff7)
- I moved T1 bootloader animation logic to the animation component to avoid possible future bugs if this animation is required somewhere else.