### PR TITLE
Fix/data persistence

### DIFF
--- a/packages/suite/src/actions/suite/__fixtures__/suiteActions.ts
+++ b/packages/suite/src/actions/suite/__fixtures__/suiteActions.ts
@@ -623,6 +623,71 @@ const handleDeviceDisconnect = [
     },
 ];
 
+const forgetDisconnectedDevices = [
+    {
+        description: `no affected devices (unacquired)`,
+        state: {
+            suite: {
+                device: SUITE_DEVICE_UNACQUIRED,
+            },
+            devices: [SUITE_DEVICE_UNACQUIRED],
+        },
+        device: getConnectDevice({
+            path: '2',
+        }),
+        result: [],
+    },
+    {
+        description: `no remembered devices, all affected`,
+        state: {
+            suite: {
+                device: SUITE_DEVICE,
+            },
+            devices: [
+                SUITE_DEVICE,
+                getSuiteDevice({
+                    path: '1',
+                    instance: 1,
+                }),
+            ],
+        },
+        device: CONNECT_DEVICE,
+        result: [
+            { path: '1', instance: undefined },
+            { path: '1', instance: 1 },
+        ],
+    },
+    {
+        description: `mix of affected and unaffected devices`,
+        state: {
+            suite: {
+                device: SUITE_DEVICE,
+            },
+            devices: [
+                SUITE_DEVICE,
+                getSuiteDevice({
+                    path: '1',
+                    instance: 1,
+                }),
+                getSuiteDevice({
+                    path: '1',
+                    instance: 2,
+                    remember: true,
+                }),
+                getSuiteDevice({
+                    path: '2',
+                    id: 'device-id-2',
+                }),
+            ],
+        },
+        device: CONNECT_DEVICE,
+        result: [
+            { path: '1', instance: undefined },
+            { path: '1', instance: 1 },
+        ],
+    },
+];
+
 const observeSelectedDevice = [
     {
         description: `ignored action`,
@@ -1024,6 +1089,7 @@ export default {
     selectDevice,
     handleDeviceConnect,
     handleDeviceDisconnect,
+    forgetDisconnectedDevices,
     observeSelectedDevice,
     acquireDevice,
     authorizeDevice,

--- a/packages/suite/src/actions/suite/__tests__/suiteActions.test.ts
+++ b/packages/suite/src/actions/suite/__tests__/suiteActions.test.ts
@@ -185,6 +185,19 @@ describe('Suite Actions', () => {
         });
     });
 
+    fixtures.forgetDisconnectedDevices.forEach(f => {
+        it(`forgetDisconnectedDevices: ${f.description}`, () => {
+            const state = getInitialState(f.state.suite, f.state.devices);
+            const store = initStore(state);
+            store.dispatch(suiteActions.forgetDisconnectedDevices(f.device));
+            const actions = store.getActions();
+            expect(actions.length).toEqual(f.result.length);
+            actions.forEach((a, i) => {
+                expect(a.payload).toMatchObject(f.result[i]);
+            });
+        });
+    });
+
     fixtures.observeSelectedDevice.forEach(f => {
         it(`observeSelectedDevice: ${f.description}`, () => {
             const state = getInitialState(f.state.suite, f.state.devices);

--- a/packages/suite/src/actions/suite/__tests__/suiteActions.test.ts
+++ b/packages/suite/src/actions/suite/__tests__/suiteActions.test.ts
@@ -292,7 +292,7 @@ describe('Suite Actions', () => {
     // just for coverage
     it('misc', () => {
         const SUITE_DEVICE = getSuiteDevice({ path: '1' });
-        expect(suiteActions.rememberDevice(SUITE_DEVICE)).toMatchObject({
+        expect(suiteActions.toggleRememberDevice(SUITE_DEVICE)).toMatchObject({
             type: SUITE.REMEMBER_DEVICE,
         });
         expect(suiteActions.forgetDevice(SUITE_DEVICE)).toMatchObject({

--- a/packages/suite/src/actions/suite/constants/storageConstants.ts
+++ b/packages/suite/src/actions/suite/constants/storageConstants.ts
@@ -1,4 +1,2 @@
 export const LOAD = '@storage/load';
 export const LOADED = '@storage/loaded';
-export const ERROR = '@storage/error';
-export const SAVE = '@storage/save';

--- a/packages/suite/src/actions/suite/storageActions.ts
+++ b/packages/suite/src/actions/suite/storageActions.ts
@@ -15,8 +15,7 @@ import type { Trade, TradeType } from '@wallet-types/coinmarketCommonTypes';
 
 export type StorageAction =
     | { type: typeof STORAGE.LOAD }
-    | { type: typeof STORAGE.LOADED; payload: AppState }
-    | { type: typeof STORAGE.ERROR; error: any };
+    | { type: typeof STORAGE.LOADED; payload: AppState };
 
 const isDBAccessible = async () => {
     const isSupported = await db.isSupported();
@@ -78,7 +77,7 @@ export const forgetDevice = (device: TrezorDevice) => async (_: Dispatch, getSta
     const accounts = getState().wallet.accounts.filter(a => a.deviceState === device.state);
     const accountPromises = accounts.reduce(
         (promises, account) => promises.concat([removeAccountDraft(account)]),
-        [] as Promise<any>[],
+        [] as Promise<void>[],
     );
     const promises = await Promise.all([
         db.removeItemByPK('devices', device.state),
@@ -191,7 +190,7 @@ export const rememberDevice = (
                 dispatch(saveAccountTransactions(account)),
                 dispatch(saveAccountDraft(account)),
             ]),
-        [] as Promise<any>[],
+        [] as Promise<void | string | undefined>[],
     );
 
     try {

--- a/packages/suite/src/actions/suite/suiteActions.ts
+++ b/packages/suite/src/actions/suite/suiteActions.ts
@@ -357,6 +357,23 @@ export const handleDeviceDisconnect = (device: Device) => (
 };
 
 /**
+ * Triggered by `trezor-connect DEVICE_EVENT` via suiteMiddleware
+ * Remove all data related to all instances of disconnected device if they are not remembered
+ * @param {Device} device
+ */
+export const forgetDisconnectedDevices = (device: Device) => (
+    dispatch: Dispatch,
+    getState: GetState,
+) => {
+    const deviceInstances = getState().devices.filter(d => d.id === device.id);
+    deviceInstances.forEach(d => {
+        if (d.features && !d.remember) {
+            dispatch(forgetDevice(d));
+        }
+    });
+};
+
+/**
  * list of actions which has influence on `device` field inside `suite` reducer
  * all other actions should be ignored
  */

--- a/packages/suite/src/actions/suite/suiteActions.ts
+++ b/packages/suite/src/actions/suite/suiteActions.ts
@@ -242,7 +242,7 @@ export const selectDevice = (device?: Device | TrezorDevice) => (
  *
  * Use `forgetDevice` to forget a device regardless if its current state.
  */
-export const rememberDevice = (payload: TrezorDevice, forceRemember?: true): SuiteAction => ({
+export const toggleRememberDevice = (payload: TrezorDevice, forceRemember?: true): SuiteAction => ({
     type: SUITE.REMEMBER_DEVICE,
     payload,
     remember: !payload.remember || !!forceRemember,

--- a/packages/suite/src/actions/wallet/coinmarket/coinmarketCommonActions.ts
+++ b/packages/suite/src/actions/wallet/coinmarket/coinmarketCommonActions.ts
@@ -129,7 +129,7 @@ export const submitRequestForm = (form?: {
 }) => (dispatch: Dispatch, getState: GetState) => {
     const { device } = getState().suite;
     if (device && !device.remember && !isDesktop()) {
-        dispatch(suiteActions.rememberDevice(device, true));
+        dispatch(suiteActions.toggleRememberDevice(device, true));
     }
     if (form) {
         envSubmitRequestForm(form.formMethod, form.formAction, form.fields);

--- a/packages/suite/src/components/suite/SwitchDevice/components/WalletInstance/index.tsx
+++ b/packages/suite/src/components/suite/SwitchDevice/components/WalletInstance/index.tsx
@@ -84,8 +84,8 @@ const WalletInstance = ({
     index,
     ...rest
 }: Props) => {
-    const { rememberDevice, forgetDevice, getDiscovery } = useActions({
-        rememberDevice: suiteActions.rememberDevice,
+    const { toggleRememberDevice, forgetDevice, getDiscovery } = useActions({
+        toggleRememberDevice: suiteActions.toggleRememberDevice,
         forgetDevice: suiteActions.forgetDevice,
         getDiscovery: discoveryActions.getDiscovery,
     });
@@ -169,7 +169,7 @@ const WalletInstance = ({
                         <Switch
                             checked={!!instance.remember}
                             onChange={() => {
-                                rememberDevice(instance);
+                                toggleRememberDevice(instance);
                                 analytics.report({
                                     type: instance.remember
                                         ? 'switch-device/forget'

--- a/packages/suite/src/middlewares/firmware/firmwareMiddleware.ts
+++ b/packages/suite/src/middlewares/firmware/firmwareMiddleware.ts
@@ -40,7 +40,7 @@ const firmware = (api: MiddlewareAPI<Dispatch, AppState>) => (next: Dispatch) =>
                 // This would save us from huge headache with hacky solutions like trying to remember a device before the update process
                 // in exchange for just a slightly worse UX for users which have multiple connected devices (there will not be many of them)
                 if (!device.remember) {
-                    api.dispatch(suiteActions.rememberDevice(device, true));
+                    api.dispatch(suiteActions.toggleRememberDevice(device, true));
                 }
             }
 

--- a/packages/suite/src/middlewares/suite/eventsMiddleware.ts
+++ b/packages/suite/src/middlewares/suite/eventsMiddleware.ts
@@ -62,11 +62,16 @@ const eventsMiddleware = (api: MiddlewareAPI<Dispatch, AppState>) => (next: Disp
         }
     }
 
-    if (action.type === DEVICE.DISCONNECT) {
+    if (action.type === DEVICE.DISCONNECT || action.type === SUITE.FORGET_DEVICE) {
         // remove notifications associated with disconnected device
         // api.dispatch(addEvent({ type: 'disconnected-device' }));
         const { notifications } = api.getState();
-        const affectedDevices = prevState.devices.filter(d => d.path === action.payload.path);
+        const affectedDevices =
+            action.type === SUITE.FORGET_DEVICE
+                ? prevState.devices.filter(
+                      d => d.path === action.payload.path && d.instance === action.payload.instance,
+                  )
+                : prevState.devices.filter(d => d.path === action.payload.path);
         affectedDevices.forEach(d => {
             if (!d.remember) {
                 const toRemove = notifications.filter(n =>

--- a/packages/suite/src/middlewares/suite/suiteMiddleware.ts
+++ b/packages/suite/src/middlewares/suite/suiteMiddleware.ts
@@ -23,6 +23,12 @@ const suite = (api: MiddlewareAPI<Dispatch, AppState>) => (next: Dispatch) => as
         api.dispatch({ type: SUITE.APP_CHANGED, payload: getApp(action.url) });
     }
 
+    // this action needs to be processed before propagation to deviceReducer
+    // otherwise device will not be accessible and related data will not be removed (accounts, txs...)
+    if (action.type === DEVICE.DISCONNECT) {
+        api.dispatch(suiteActions.forgetDisconnectedDevices(action.payload));
+    }
+
     // pass action to reducers
     next(action);
 

--- a/packages/suite/src/middlewares/suite/suiteMiddleware.ts
+++ b/packages/suite/src/middlewares/suite/suiteMiddleware.ts
@@ -45,7 +45,7 @@ const suite = (api: MiddlewareAPI<Dispatch, AppState>) => (next: Dispatch) => as
                     d => d.forceRemember && d.remember,
                 );
                 forcedDevices.forEach(d => {
-                    api.dispatch(suiteActions.rememberDevice(d));
+                    api.dispatch(suiteActions.toggleRememberDevice(d));
                 });
                 api.dispatch(
                     suiteActions.selectDevice(

--- a/packages/suite/src/middlewares/wallet/storageMiddleware.ts
+++ b/packages/suite/src/middlewares/wallet/storageMiddleware.ts
@@ -37,10 +37,6 @@ const storageMiddleware = (api: MiddlewareAPI<Dispatch, AppState>) => (next: Dis
             );
             break;
 
-        case SUITE.FORGET_DEVICE:
-            api.dispatch(storageActions.forgetDevice(action.payload));
-            break;
-
         case ACCOUNT.CREATE:
         case ACCOUNT.CHANGE_VISIBILITY:
         case ACCOUNT.UPDATE: {
@@ -54,9 +50,10 @@ const storageMiddleware = (api: MiddlewareAPI<Dispatch, AppState>) => (next: Dis
 
         case ACCOUNT.REMOVE: {
             action.payload.forEach(account => {
-                storageActions.removeAccount(account);
+                storageActions.removeAccountDraft(account);
                 storageActions.removeAccountTransactions(account);
                 storageActions.removeAccountGraph(account);
+                storageActions.removeAccount(account);
             });
             break;
         }

--- a/packages/suite/src/middlewares/wallet/walletMiddleware.ts
+++ b/packages/suite/src/middlewares/wallet/walletMiddleware.ts
@@ -78,6 +78,14 @@ const walletMiddleware = (api: MiddlewareAPI<Dispatch, AppState>) => (next: Disp
         }
     }
 
+    if (
+        action.type === SUITE.FORGET_DEVICE &&
+        prevState.wallet.selectedAccount.account?.deviceState === action.payload.state
+    ) {
+        // if currently selected account is related to forgotten device
+        resetReducers = true;
+    }
+
     if (prevRouter.app === 'wallet' && action.type === ROUTER.LOCATION_CHANGE) {
         // leaving wallet app or switching between accounts
         resetReducers =

--- a/packages/suite/src/reducers/wallet/sendFormReducer.ts
+++ b/packages/suite/src/reducers/wallet/sendFormReducer.ts
@@ -1,6 +1,6 @@
 import produce from 'immer';
 import { STORAGE } from '@suite-actions/constants';
-import { SEND } from '@wallet-actions/constants';
+import { ACCOUNT, SEND } from '@wallet-actions/constants';
 import { Action } from '@suite-types';
 import { FormState, PrecomposedTransactionFinal } from '@wallet-types/sendForm';
 
@@ -30,6 +30,11 @@ const sendFormReducer = (state: SendState = initialState, action: Action): SendS
                 break;
             case SEND.REMOVE_DRAFT:
                 delete draft.drafts[action.key];
+                break;
+            case ACCOUNT.REMOVE:
+                action.payload.forEach(account => {
+                    delete draft.drafts[account.key];
+                });
                 break;
             case SEND.REQUEST_SIGN_TRANSACTION:
                 if (action.payload) {


### PR DESCRIPTION
This PR solves multiple issues regarding data persistence.

49ef5d6 - just a cleanup of dead/unused code
 
bb48491 - solve and close #3933, @LukasRada 

f49e3f5 - rename confusing function name to self descriptive

83b99f7  - fixing unreported issue. DEVICE.DISCONNECT action didn't remove related data from reducers (accounts, transactions etc)

30b671b - tests for 83b99f7 

084da9f - fixing unreported issue. When device was removed (eject button) wallet reducers was not disposed. Result: account was still visible on the background of "select device" modal.
![Screenshot from 2021-06-23 14-43-33](https://user-images.githubusercontent.com/3435913/123098467-779a0280-d431-11eb-929d-bdd15ed53fc5.png)

