### PR TITLE
chore: autoupdate finetuning

### DIFF
--- a/packages/suite-desktop/src-electron/index.d.ts
+++ b/packages/suite-desktop/src-electron/index.d.ts
@@ -69,6 +69,7 @@ declare type WinBounds = {
 
 declare type UpdateSettings = {
     skipVersion: string;
+    preUpdateVersion?: string;
 };
 
 declare type TorSettings = {

--- a/packages/suite-desktop/src-electron/modules/auto-updater.ts
+++ b/packages/suite-desktop/src-electron/modules/auto-updater.ts
@@ -4,7 +4,12 @@
 
 import { unlinkSync } from 'fs';
 import { app, ipcMain } from 'electron';
-import { autoUpdater, CancellationToken, UpdateInfo } from 'electron-updater';
+import {
+    autoUpdater,
+    CancellationToken,
+    UpdateInfo,
+    UpdateDownloadedEvent,
+} from 'electron-updater';
 import isDev from 'electron-is-dev';
 
 import { b2t } from '@desktop-electron/libs/utils';
@@ -44,12 +49,27 @@ const init = ({ mainWindow, store }: Dependencies) => {
     let isManualCheck = false;
     let latestVersion: Partial<UpdateInfo> = {};
     let updateCancellationToken: CancellationToken;
-    const updateSettings = store.getUpdateSettings();
+    let shouldInstallUpdateOnQuit = false;
 
+    const updateSettings = store.getUpdateSettings();
+    // Prevent downloading an update unless user explicitly asks for it.
     autoUpdater.autoDownload = false;
-    autoUpdater.autoInstallOnAppQuit = true;
+    // Manually force install based on `shouldInstallUpdateOnQuit` var instead to have more control over the process.
+    // This is useful for cases when we want to cancel update after it has started. It seems to work in the current version
+    // of electron-updater only until update-downloaded event is emitted.
+    autoUpdater.autoInstallOnAppQuit = false;
+
     autoUpdater.allowPrerelease = preReleaseFlag;
     autoUpdater.logger = null;
+
+    const quitAndInstall = () => {
+        // Removing listeners & closing window (https://github.com/electron-userland/electron-builder/issues/1604)
+        app.removeAllListeners('window-all-closed');
+        mainWindow.removeAllListeners('close');
+        mainWindow.close();
+
+        autoUpdater.quitAndInstall();
+    };
 
     logger.info('auto-updater', `Is looking for pre-releases? (${b2t(preReleaseFlag)})`);
 
@@ -127,7 +147,7 @@ const init = ({ mainWindow, store }: Dependencies) => {
         mainWindow.webContents.send('update/downloading', { ...progressObj });
     });
 
-    autoUpdater.on('update-downloaded', (info: any) => {
+    autoUpdater.on('update-downloaded', (info: UpdateDownloadedEvent) => {
         const { version, releaseDate, downloadedFile } = info;
 
         logger.info('auto-updater', [
@@ -148,15 +168,37 @@ const init = ({ mainWindow, store }: Dependencies) => {
                     releaseDate,
                     downloadedFile,
                 });
+
+                shouldInstallUpdateOnQuit = true;
             })
             .catch(err => {
                 logger.error('auto-updater', `Signature check failed: ${err.message}`);
 
                 mainWindow.webContents.send('update/error', err);
 
+                logger.info('auto-updater', `Unlink downloaded file ${downloadedFile}`);
+
                 // Delete file so we are sure it's not accidentally installed
                 unlinkSync(downloadedFile);
+
+                shouldInstallUpdateOnQuit = false;
+            })
+            .finally(() => {
+                logger.info(
+                    'auto-updater',
+                    `Is configured to auto update after app quit ${shouldInstallUpdateOnQuit}`,
+                );
+
+                // save current app version so that after app is relaunched we can show info about transition to the new version
+                store.setUpdateSettings({
+                    ...store.getUpdateSettings(),
+                    preUpdateVersion: app.getVersion(),
+                });
             });
+    });
+
+    autoUpdater.on('before-quit-for-update', () => {
+        logger.info('auto-updater', 'before-quit-for-update event');
     });
 
     ipcMain.on('update/check', (_, isManual?: boolean) => {
@@ -183,18 +225,15 @@ const init = ({ mainWindow, store }: Dependencies) => {
         autoUpdater
             .downloadUpdate(updateCancellationToken)
             .then(() => logger.info('auto-updater', 'Update downloaded'))
-            .catch(() => logger.info('auto-updater', 'Update cancelled'));
+            .catch(() => {
+                logger.info('auto-updater', 'Update cancelled');
+            });
     });
 
     ipcMain.on('update/install', () => {
         logger.info('auto-updater', 'Installation request');
 
-        // Removing listeners & closing window (https://github.com/electron-userland/electron-builder/issues/1604)
-        app.removeAllListeners('window-all-closed');
-        mainWindow.removeAllListeners('close');
-        mainWindow.close();
-
-        autoUpdater.quitAndInstall();
+        quitAndInstall();
     });
 
     ipcMain.on('update/cancel', () => {
@@ -207,6 +246,12 @@ const init = ({ mainWindow, store }: Dependencies) => {
         logger.info('auto-updater', `Skip version (${version}) request`);
         mainWindow.webContents.send('update/skip', version);
         setSkipVersion(version);
+    });
+
+    app.on('before-quit', () => {
+        if (shouldInstallUpdateOnQuit) {
+            quitAndInstall();
+        }
     });
 };
 

--- a/packages/suite-desktop/src-electron/preload.ts
+++ b/packages/suite-desktop/src-electron/preload.ts
@@ -21,6 +21,7 @@ const validChannels = [
     'update/downloading',
     'update/downloaded',
     'update/skip',
+    'update/new-version-first-run',
 
     // invity
     'buy-receiver',

--- a/packages/suite-desktop/src/support/DesktopUpdater.tsx
+++ b/packages/suite-desktop/src/support/DesktopUpdater.tsx
@@ -20,6 +20,7 @@ const DesktopUpdater = ({ setIsUpdateVisible }: Props) => {
         ready,
         skip,
         error,
+        newVersionFirstRun,
         setUpdateWindow,
     } = useActions({
         enable: desktopUpdateActions.enable,
@@ -31,6 +32,7 @@ const DesktopUpdater = ({ setIsUpdateVisible }: Props) => {
         skip: desktopUpdateActions.skip,
         error: desktopUpdateActions.error,
         setUpdateWindow: desktopUpdateActions.setUpdateWindow,
+        newVersionFirstRun: desktopUpdateActions.newVersionFirstRun,
     });
     const desktopUpdate = useSelector(state => state.desktopUpdate);
 
@@ -39,7 +41,6 @@ const DesktopUpdater = ({ setIsUpdateVisible }: Props) => {
             window.desktopApi!.on('update/enable', enable);
             return;
         }
-
         window.desktopApi!.on('update/checking', checking);
         window.desktopApi!.on('update/available', available);
         window.desktopApi!.on('update/not-available', notAvailable);
@@ -47,6 +48,7 @@ const DesktopUpdater = ({ setIsUpdateVisible }: Props) => {
         window.desktopApi!.on('update/downloaded', ready);
         window.desktopApi!.on('update/downloading', downloading);
         window.desktopApi!.on('update/error', error);
+        window.desktopApi!.on('update/new-version-first-run', newVersionFirstRun);
 
         // Initial check for updates
         window.desktopApi!.checkForUpdates();
@@ -60,8 +62,9 @@ const DesktopUpdater = ({ setIsUpdateVisible }: Props) => {
         ready,
         skip,
         error,
-        desktopUpdate.enabled,
         enable,
+        newVersionFirstRun,
+        desktopUpdate.enabled,
     ]);
 
     const hideWindow = useCallback(() => setUpdateWindow('hidden'), [setUpdateWindow]);

--- a/packages/suite/src/actions/suite/desktopUpdateActions.ts
+++ b/packages/suite/src/actions/suite/desktopUpdateActions.ts
@@ -68,3 +68,7 @@ export const setUpdateWindow = (win: UpdateWindow): DesktopUpdateAction => ({
     type: DESKTOP_UPDATE.WINDOW,
     payload: win,
 });
+
+export const newVersionFirstRun = (version: string) => (dispatch: Dispatch) => {
+    dispatch(addToast({ type: 'auto-updater-new-version-first-run', version }));
+};

--- a/packages/suite/src/components/suite/hocNotification/index.tsx
+++ b/packages/suite/src/components/suite/hocNotification/index.tsx
@@ -286,6 +286,18 @@ const hocNotification = (notification: NotificationEntry, View: React.ComponentT
                 message: 'TOAST_AUTO_UPDATER_NO_NEW',
             });
 
+        case 'auto-updater-new-version-first-run':
+            return simple(View, {
+                notification,
+                variant: 'info',
+                message: {
+                    id: 'TOAST_AUTO_UPDATER_NEW_VERSION_FIRST_RUN',
+                    values: {
+                        version: notification.version,
+                    },
+                },
+            });
+
         case 'add-token-success':
             return simple(View, {
                 notification,

--- a/packages/suite/src/reducers/suite/notificationReducer.ts
+++ b/packages/suite/src/reducers/suite/notificationReducer.ts
@@ -75,6 +75,10 @@ export type ToastPayload = (
           type: 'auto-updater-no-new';
       }
     | {
+          type: 'auto-updater-new-version-first-run';
+          version: string;
+      }
+    | {
           type: 'user-feedback-send-success' | 'user-feedback-send-error';
       }
 ) &

--- a/packages/suite/src/support/messages.ts
+++ b/packages/suite/src/support/messages.ts
@@ -3292,6 +3292,10 @@ const definedMessages = defineMessages({
         id: 'TOAST_AUTO_UPDATER_NO_NEW',
         defaultMessage: 'No new updates available.',
     },
+    TOAST_AUTO_UPDATER_NEW_VERSION_FIRST_RUN: {
+        id: 'TOAST_AUTO_UPDATER_NEW_VERSION_FIRST_RUN',
+        defaultMessage: 'New version ({version}) installed successfully.',
+    },
     TOAST_GENERIC_ERROR: {
         id: 'TOAST_GENERIC_ERROR',
         defaultMessage: 'Error: {error}',


### PR DESCRIPTION
Commits: 
- abd3af182d65d262ed6546af34ea40520c4eeb38 finetuning of updating process as per @tsusanka request
- ~~3785b3433f0a851a36b08ef599bb36ba2b2cc624 this just downgrades app version so that abd3af182d65d262ed6546af34ea40520c4eeb38 can be easily tested with builds downloaded from CI as code changes in abd3af182d65d262ed6546af34ea40520c4eeb38 affect only PRE update behaviour of the app. This commit should be dropped eventually.~~ dropped
- 50cc06b7de6dbf6866a1268c2efe7f024f92a273 This should resolve #3308. I haven't tested it within full update scenario yet though. This will require doing some release draft and updating to it as the code changes affect POST update behaviour of the app. 

