### PR TITLE
fix(suite): hidden wallet number

### DIFF
--- a/packages/suite/src/actions/settings/__fixtures__/deviceSettings.ts
+++ b/packages/suite/src/actions/settings/__fixtures__/deviceSettings.ts
@@ -1,20 +1,83 @@
-import * as deviceSettingsActions from '@suite/actions/settings/deviceSettingsActions';
+import * as deviceSettingsActions from '../deviceSettingsActions';
 import { NOTIFICATION, SUITE } from '@suite-actions/constants';
+
+const { getSuiteDevice } = global.JestMocks;
 
 export default [
     {
         description: 'Wipe device',
         action: () => deviceSettingsActions.wipeDevice(),
-        mocks: { success: true, payload: { message: 'huraa' } },
+        mocks: { success: true, payload: { message: 'Success' } },
+        deviceChange: getSuiteDevice({ path: '1' }, { device_id: 'new-device-id' }),
         result: {
             actions: [
-                { type: SUITE.FORGET_DEVICE },
+                { type: 'device-changed' },
+                { type: '@suite/update-selected-device' },
+                { type: SUITE.FORGET_DEVICE, payload: { features: { device_id: 'device-id' } } },
+                {
+                    type: SUITE.FORGET_DEVICE,
+                    payload: { features: { device_id: 'new-device-id' } },
+                },
                 { type: NOTIFICATION.TOAST, payload: { type: 'device-wiped' } },
             ],
         },
     },
     {
-        description: 'Wipe device',
+        description: 'Wipe device with multiple device instances',
+        initialState: {
+            devices: [
+                getSuiteDevice({
+                    path: '1',
+                    connected: true,
+                }),
+                getSuiteDevice({
+                    path: '1',
+                    connected: true,
+                    instance: 1,
+                    state: '1',
+                }),
+                getSuiteDevice({
+                    path: '1',
+                    connected: true,
+                    instance: 2,
+                    state: '2',
+                }),
+            ],
+        },
+        action: () => deviceSettingsActions.wipeDevice(),
+        mocks: { success: true, payload: { message: 'Success' } },
+        deviceChange: getSuiteDevice({ path: '1' }, { device_id: 'new-device-id' }),
+        result: {
+            actions: [
+                { type: 'device-changed' },
+                { type: '@suite/update-selected-device' },
+                { type: SUITE.FORGET_DEVICE, payload: { features: { device_id: 'device-id' } } },
+                {
+                    type: SUITE.FORGET_DEVICE,
+                    payload: { instance: 1, features: { device_id: 'device-id' } },
+                },
+                {
+                    type: SUITE.FORGET_DEVICE,
+                    payload: { instance: 2, features: { device_id: 'device-id' } },
+                },
+                {
+                    type: SUITE.FORGET_DEVICE,
+                    payload: { features: { device_id: 'new-device-id' } },
+                },
+                {
+                    type: SUITE.FORGET_DEVICE,
+                    payload: { instance: 1, features: { device_id: 'new-device-id' } },
+                },
+                {
+                    type: SUITE.FORGET_DEVICE,
+                    payload: { instance: 2, features: { device_id: 'new-device-id' } },
+                },
+                { type: NOTIFICATION.TOAST, payload: { type: 'device-wiped' } },
+            ],
+        },
+    },
+    {
+        description: 'Wipe device failed',
         action: () => deviceSettingsActions.wipeDevice(),
         mocks: { success: false, payload: { error: 'fuuu' } },
         result: {

--- a/packages/suite/src/actions/suite/modalActions.ts
+++ b/packages/suite/src/actions/suite/modalActions.ts
@@ -144,39 +144,21 @@ export const onPinCancel = () => {
  * @param {boolean} passphraseOnDevice
  * @param {boolean} hasEmptyPassphraseWallet
  */
-export const onPassphraseSubmit = (
-    value: string,
-    passphraseOnDevice: boolean,
-    hasEmptyPassphraseWallet: boolean,
-) => (dispatch: Dispatch, getState: GetState) => {
+export const onPassphraseSubmit = (value: string, passphraseOnDevice: boolean) => (
+    dispatch: Dispatch,
+    getState: GetState,
+) => {
     const { device } = getState().suite;
     if (!device) return;
 
-    // update wallet type only on certain conditions
-    const update =
-        !hasEmptyPassphraseWallet &&
-        !passphraseOnDevice &&
-        !device.authConfirm &&
-        !device.state &&
-        value === '';
-
-    if (update) {
-        // set standard wallet type if passphrase is blank
-        dispatch({
-            type: SUITE.UPDATE_PASSPHRASE_MODE,
-            payload: device,
-            hidden: false,
-        });
-    }
-
-    if (passphraseOnDevice) {
-        dispatch({
-            type: SUITE.UPDATE_PASSPHRASE_MODE,
-            payload: device,
-            hidden: true,
-            alwaysOnDevice: true,
-        });
-    }
+    const hidden = passphraseOnDevice || value;
+    // call SUITE.UPDATE_PASSPHRASE_MODE action to set or remove walletNumber
+    dispatch({
+        type: SUITE.UPDATE_PASSPHRASE_MODE,
+        payload: device,
+        hidden,
+        alwaysOnDevice: passphraseOnDevice,
+    });
 
     TrezorConnect.uiResponse({
         type: UI.RECEIVE_PASSPHRASE,

--- a/packages/suite/src/actions/suite/suiteActions.ts
+++ b/packages/suite/src/actions/suite/suiteActions.ts
@@ -286,7 +286,6 @@ export const createDeviceInstance = (device: TrezorDevice, useEmptyPassphrase = 
             ...device,
             useEmptyPassphrase,
             instance: deviceUtils.getNewInstanceNumber(getState().devices, device),
-            walletNumber: deviceUtils.getNewWalletNumber(getState().devices, device),
         },
     });
 };

--- a/packages/suite/src/components/suite/modals/Passphrase/index.tsx
+++ b/packages/suite/src/components/suite/modals/Passphrase/index.tsx
@@ -69,7 +69,7 @@ const Passphrase = (props: Props) => {
 
     const onSubmit = (value: string, passphraseOnDevice?: boolean) => {
         setSubmitted(true);
-        props.onPassphraseSubmit(value, !!passphraseOnDevice, !!hasEmptyPassphraseWallet);
+        props.onPassphraseSubmit(value, !!passphraseOnDevice);
     };
 
     const onRecreate = () => {

--- a/packages/suite/src/middlewares/wallet/storageMiddleware.ts
+++ b/packages/suite/src/middlewares/wallet/storageMiddleware.ts
@@ -37,6 +37,10 @@ const storageMiddleware = (api: MiddlewareAPI<Dispatch, AppState>) => (next: Dis
             );
             break;
 
+        case SUITE.FORGET_DEVICE:
+            api.dispatch(storageActions.forgetDevice(action.payload));
+            break;
+
         case ACCOUNT.CREATE:
         case ACCOUNT.CHANGE_VISIBILITY:
         case ACCOUNT.UPDATE: {

--- a/packages/suite/src/reducers/suite/deviceReducer.ts
+++ b/packages/suite/src/reducers/suite/deviceReducer.ts
@@ -226,8 +226,13 @@ const changePassphraseMode = (
     // update fields
     draft[index].useEmptyPassphrase = !hidden;
     draft[index].passphraseOnDevice = alwaysOnDevice;
-    // draft[index].instance = undefined;
     draft[index].ts = new Date().getTime();
+    if (hidden && typeof draft[index].walletNumber !== 'number') {
+        draft[index].walletNumber = deviceUtils.getNewWalletNumber(draft, draft[index]);
+    }
+    if (!hidden && typeof draft[index].walletNumber === 'number') {
+        delete draft[index].walletNumber;
+    }
 };
 
 /**
@@ -276,10 +281,6 @@ const authConfirm = (draft: State, device: TrezorDevice, success: boolean) => {
     // update state
     draft[index].authConfirm = !success;
     draft[index].available = success;
-
-    if (!draft[index].walletNumber) {
-        draft[index].walletNumber = deviceUtils.getNewWalletNumber(draft, draft[index]);
-    }
 };
 
 /**
@@ -296,6 +297,7 @@ const createInstance = (draft: State, device: TrezorDevice) => {
         passphraseOnDevice: false,
         remember: false,
         state: undefined,
+        walletNumber: undefined,
         authConfirm: false,
         ts: new Date().getTime(),
         buttonRequests: [],
@@ -339,6 +341,7 @@ const forget = (draft: State, device: TrezorDevice) => {
     if (device.connected && others.length < 1) {
         // do not forget the last instance, just reset state
         draft[index].state = undefined;
+        draft[index].walletNumber = undefined;
         draft[index].useEmptyPassphrase = !device.features.passphrase_protection;
         draft[index].passphraseOnDevice = false;
         // set remember to false to make it disappear after device is disconnected


### PR DESCRIPTION
Wallet number is generated only in two cases when SUITE.UPDATE_PASSPHRASE_MODE is called

Refactored onPassphraseSubmit action:
always call SUITE.UPDATE_PASSPHRASE_MODE to set or remove `walletNumber `field from the device

fix: #3277