### PR TITLE
@trezor/rollout 1.1.0

### DIFF
--- a/packages/rollout/.npmignore
+++ b/packages/rollout/.npmignore
@@ -3,9 +3,6 @@ coverage
 tests
 __tests__
 __mocks__
-e2e
-setupJest.d.ts
-start-e2e.d.ts
 jest*
 .rpt2_cache
 .eslintignore
@@ -14,21 +11,15 @@ jest*
 .gilab-ci.yml
 .prettierignore
 .prettierrc
-babel.config.js
 jest.config.integration.js
-jest.config.unit.js
-tsconfig.workers.json
 tsconfig.lib.json
 tsconfig.json
 setupJest.ts
-start-e2e.ts
-setupJest.js
-start-e2e.js
+start-integration.ts
 
 # Source files
 src
-webpack
-scripts
+integration
 docs
 
 # Editors

--- a/packages/rollout/CHANGELOG.md
+++ b/packages/rollout/CHANGELOG.md
@@ -1,3 +1,5 @@
+# 1.1.0
+- always provide latest release together with safe release
 # 1.0.8
 - bump intermediary fw
 # 1.0.7

--- a/packages/rollout/package.json
+++ b/packages/rollout/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@trezor/rollout",
-    "version": "1.0.8",
+    "version": "1.1.0",
     "author": "Trezor <info@trezor.io>",
     "homepage": "https://github.com/trezor/trezor-suite/packages/rollout",
     "keywords": [

--- a/packages/rollout/src/__tests__/getInfo.rollout.test.ts
+++ b/packages/rollout/src/__tests__/getInfo.rollout.test.ts
@@ -60,7 +60,7 @@ const fixtures = [
             release: {
                 version: [2, 0, 0],
             },
-            isLatest: false,
+            isLatest: true,
         },
     },
     {

--- a/packages/rollout/src/index.ts
+++ b/packages/rollout/src/index.ts
@@ -93,7 +93,7 @@ const isRequired = (changelog: ReturnType<typeof getChangelog>) => {
     return changelog.some(item => item.required);
 };
 
-const isLatest = (release: Release, latest: Release) =>
+const isEqual = (release: Release, latest: Release) =>
     versionUtils.isEqual(release.version, latest.version);
 
 interface GetInfoProps {
@@ -125,7 +125,6 @@ export const getInfo = ({ features, releases }: GetInfoProps) => {
         fw_minor,
         fw_patch,
     } = parsedFeatures;
-    const latest = parsedReleases[0];
 
     if (score) {
         parsedReleases = parsedReleases.filter(item => {
@@ -133,6 +132,8 @@ export const getInfo = ({ features, releases }: GetInfoProps) => {
             return item.rollout >= score;
         });
     }
+
+    const latest = parsedReleases[0];
 
     if (major_version === 2 && bootloader_mode) {
         // sorry for this if, I did not figure out how to narrow types properly
@@ -171,12 +172,14 @@ export const getInfo = ({ features, releases }: GetInfoProps) => {
         return null;
     }
 
+    const isLatest = isEqual(parsedReleases[0], latest);
     const changelog = getChangelog(parsedReleases, parsedFeatures);
 
     return {
         changelog,
         release: parsedReleases[0],
-        isLatest: isLatest(parsedReleases[0], latest),
+        isLatest,
+        latest,
         isRequired: isRequired(changelog),
         isNewer: isNewer(parsedReleases[0], parsedFeatures),
     };

--- a/yarn.lock
+++ b/yarn.lock
@@ -4753,6 +4753,14 @@
   dependencies:
     tippy.js "^6.3.1"
 
+"@trezor/rollout@1.0.8":
+  version "1.0.8"
+  resolved "https://registry.yarnpkg.com/@trezor/rollout/-/rollout-1.0.8.tgz#9e4440a4c907c1280899f4fdf9657ef39f72cdf3"
+  integrity sha512-nEXzvGOHfXRI89rbvfeAHLRj5mN0EcF/I7HcZaZiQ2xWEjXhjUEyhTyw5PU8oruPUtyRnVVYwpKvzk0xB5I0Mw==
+  dependencies:
+    cross-fetch "^3.0.6"
+    runtypes "^5.0.1"
+
 "@trezor/utxo-lib@0.1.2", "@trezor/utxo-lib@^0.1.2":
   version "0.1.2"
   resolved "https://registry.yarnpkg.com/@trezor/utxo-lib/-/utxo-lib-0.1.2.tgz#19319a424b0d0c648b0df456f1849eb08697fb44"


### PR DESCRIPTION
fix(rollout): provide latest release together with safe release
- get latest release with rollout score in mind to prevent providing of intermediary FW for safe release just because of rollout mechanism