### PR TITLE
feat: #3968 Add /start page to suite landing website

### DIFF
--- a/packages/suite-web-landing/components/LandingPage/index.tsx
+++ b/packages/suite-web-landing/components/LandingPage/index.tsx
@@ -1,0 +1,95 @@
+import styled from 'styled-components';
+import { H1, P, variables, colors } from '@trezor/components';
+
+export const Wrapper = styled.div`
+    display: flex;
+    flex-direction: column;
+    font-size: ${variables.FONT_SIZE.NORMAL};
+`;
+
+export const StyledHeroCta = styled.header`
+    text-align: center;
+    z-index: 2;
+`;
+
+export const StyledCta = styled.div`
+    text-align: center;
+    justify-content: center;
+    margin: 168px 0 140px;
+`;
+
+export const DownloadWrapper = styled.div`
+    display: flex;
+    justify-content: center;
+`;
+
+export const FeaturesWrapper = styled.div`
+    margin: 80px 0 0 0;
+    & > section {
+        margin-bottom: 50px;
+
+        &:last-child {
+            margin-bottom: 0;
+        }
+    }
+`;
+
+export const StyledH1 = styled(H1)`
+    font-size: 28px;
+    line-height: 36px;
+    font-weight: ${variables.FONT_WEIGHT.DEMI_BOLD};
+
+    @media only screen and (min-width: ${variables.SCREEN_SIZE.MD}) {
+        font-size: 44px;
+        line-height: 55px;
+        white-space: pre-wrap;
+    }
+`;
+
+export const StyledHeadline = styled(H1)<{ size?: number }>`
+    font-size: 40px;
+    font-weight: ${variables.FONT_WEIGHT.DEMI_BOLD};
+    line-height: 1.3;
+    margin-bottom: 18px;
+    em {
+        font-style: normal;
+        color: ${colors.TYPE_GREEN};
+    }
+
+    @media only screen and (min-width: ${variables.SCREEN_SIZE.MD}) {
+        font-size: ${props => (props.size !== undefined ? `${props.size}px` : '64px')};
+    }
+`;
+
+export const StyledSubheadline = styled(P)`
+    font-size: 20px;
+    font-weight: ${variables.FONT_WEIGHT.MEDIUM};
+    color: ${colors.TYPE_LIGHT_GREY} !important;
+    margin-bottom: 65px;
+`;
+
+export const StyledP = styled(P)`
+    && {
+        font-size: 20px;
+        line-height: 34px;
+        font-weight: ${variables.FONT_WEIGHT.MEDIUM};
+        color: ${colors.TYPE_LIGHT_GREY};
+    }
+`;
+
+export const StyledSoon = styled.div`
+    font-size: 16px;
+    line-height: 24px;
+    text-transform: uppercase;
+    font-weight: ${variables.FONT_WEIGHT.BOLD};
+    color: ${colors.TYPE_ORANGE};
+`;
+
+export const TranslationModeTrigger = styled.div`
+    position: fixed;
+    width: 20px;
+    height: 20px;
+    left: 0px;
+    bottom: 0px;
+    /* background: red; */
+`;

--- a/packages/suite-web-landing/pages/start.tsx
+++ b/packages/suite-web-landing/pages/start.tsx
@@ -26,24 +26,24 @@ import {
 const features = [
     {
         id: 1,
-        headline: <Translation id="TR_SUITE_WEB_LANDING_FEATURES_1_HEADLINE" />,
-        text: <Translation id="TR_SUITE_WEB_LANDING_FEATURES_1_TEXT" />,
+        headline: <Translation id="TR_SUITE_WEB_LANDING_START_FEATURES_1_HEADLINE" />,
+        text: <Translation id="TR_SUITE_WEB_LANDING_START_FEATURES_1_TEXT" />,
         backgroundPosition: 'bottom right',
         backgroundSize: '616px auto',
         soon: false,
     },
     {
         id: 2,
-        headline: <Translation id="TR_SUITE_WEB_LANDING_FEATURES_2_HEADLINE" />,
-        text: <Translation id="TR_SUITE_WEB_LANDING_FEATURES_2_TEXT" />,
+        headline: <Translation id="TR_SUITE_WEB_LANDING_START_FEATURES_2_HEADLINE" />,
+        text: <Translation id="TR_SUITE_WEB_LANDING_START_FEATURES_2_TEXT" />,
         backgroundPosition: 'center left',
         backgroundSize: '489px auto',
         soon: false,
     },
     {
         id: 3,
-        headline: <Translation id="TR_SUITE_WEB_LANDING_FEATURES_3_HEADLINE" />,
-        text: <Translation id="TR_SUITE_WEB_LANDING_FEATURES_3_TEXT" />,
+        headline: <Translation id="TR_SUITE_WEB_LANDING_START_FEATURES_3_HEADLINE" />,
+        text: <Translation id="TR_SUITE_WEB_LANDING_START_FEATURES_3_TEXT" />,
         backgroundSize: '500px auto',
         soon: false,
     },
@@ -66,7 +66,7 @@ const Index = () => {
                             <Fade direction="up" delay={500} triggerOnce>
                                 <StyledHeadline>
                                     <Translation
-                                        id="TR_SUITE_WEB_LANDING_HEADLINE"
+                                        id="TR_SUITE_WEB_LANDING_START_HEADLINE"
                                         values={{
                                             em: chunks => <em>{chunks}</em>,
                                             lineBreak: <br />,
@@ -76,7 +76,7 @@ const Index = () => {
                             </Fade>
                             <Fade delay={1500} triggerOnce>
                                 <StyledSubheadline>
-                                    <Translation id="TR_SUITE_WEB_LANDING_SUB_HEADLINE" />
+                                    <Translation id="TR_SUITE_WEB_LANDING_START_SUB_HEADLINE" />
                                 </StyledSubheadline>
                             </Fade>
                             <DownloadWrapper>
@@ -102,7 +102,7 @@ const Index = () => {
                                 >
                                     {item.soon && (
                                         <StyledSoon>
-                                            <Translation id="TR_SUITE_WEB_LANDING_SUB_SOON" />
+                                            <Translation id="TR_SUITE_WEB_LANDING_START_SUB_SOON" />
                                         </StyledSoon>
                                     )}
                                     <StyledH1>{item.headline}</StyledH1>
@@ -113,7 +113,7 @@ const Index = () => {
                         <StyledCta>
                             <StyledHeadline size={44}>
                                 <Translation
-                                    id="TR_SUITE_WEB_LANDING_BOTTOM_HEADLINE"
+                                    id="TR_SUITE_WEB_LANDING_START_BOTTOM_HEADLINE"
                                     values={{
                                         em: chunks => <em>{chunks}</em>,
                                         lineBreak: <br />,

--- a/packages/suite/src/support/messages.ts
+++ b/packages/suite/src/support/messages.ts
@@ -5793,6 +5793,49 @@ const definedMessages = defineMessages({
         id: 'TR_SUITE_WEB_LANDING_HOW_TO_VERIFY',
         defaultMessage: 'How to verify and run on Linux',
     },
+    TR_SUITE_WEB_LANDING_START_FEATURES_1_HEADLINE: {
+        id: 'TR_SUITE_WEB_LANDING_START_FEATURES_1_HEADLINE',
+        defaultMessage: 'Desktop app',
+    },
+    TR_SUITE_WEB_LANDING_START_FEATURES_1_TEXT: {
+        id: 'TR_SUITE_WEB_LANDING_START_FEATURES_1_TEXT',
+        defaultMessage:
+            'Enhanced security and privacy, new design and improved performance, all in one software suite.',
+    },
+    TR_SUITE_WEB_LANDING_START_FEATURES_2_HEADLINE: {
+        id: 'TR_SUITE_WEB_LANDING_START_FEATURES_2_HEADLINE',
+        defaultMessage: 'Buy and exchange crypto',
+    },
+    TR_SUITE_WEB_LANDING_START_FEATURES_2_TEXT: {
+        id: 'TR_SUITE_WEB_LANDING_START_FEATURES_2_TEXT',
+        defaultMessage:
+            "Compare competitive rates, buy and exchange coins within Trezor's secure environment. Powered by +Invity.",
+    },
+    TR_SUITE_WEB_LANDING_START_FEATURES_3_HEADLINE: {
+        id: 'TR_SUITE_WEB_LANDING_START_FEATURES_3_HEADLINE',
+        defaultMessage: 'Native altcoin support',
+    },
+    TR_SUITE_WEB_LANDING_START_FEATURES_3_TEXT: {
+        id: 'TR_SUITE_WEB_LANDING_START_FEATURES_3_TEXT',
+        defaultMessage: 'ETH, XRP, ETC and more now supported \ndirectly through the app.',
+    },
+    TR_SUITE_WEB_LANDING_START_HEADLINE: {
+        id: 'TR_SUITE_WEB_LANDING_START_HEADLINE',
+        defaultMessage: 'Managing crypto just got{lineBreak}<em>safer and easier</em>',
+    },
+    TR_SUITE_WEB_LANDING_START_SUB_HEADLINE: {
+        id: 'TR_SUITE_WEB_LANDING_START_SUB_HEADLINE',
+        defaultMessage: 'Take control of your Trezor with our desktop & browser app.',
+    },
+    TR_SUITE_WEB_LANDING_START_SUB_SOON: {
+        id: 'TR_SUITE_WEB_LANDING_START_SUB_SOON',
+        defaultMessage: 'Soon',
+    },
+    TR_SUITE_WEB_LANDING_START_BOTTOM_HEADLINE: {
+        id: 'TR_SUITE_WEB_LANDING_START_BOTTOM_HEADLINE',
+        defaultMessage:
+            'Dozens of <em>brand-new features</em> to discover.{lineBreak}Try Suite now.',
+    },
     TR_DARK_MODE: {
         id: 'TR_DARK_MODE',
         defaultMessage: 'Dark mode',


### PR DESCRIPTION
Add a /start page that is a complete design duplicate of the index (/)
page but has different translation IDs allowing us to alter the copy
individually later via Crowdin.

Deduplicate only the basic building blocks as differentiation of both
pages is anticipated soon.