### PR TITLE
fix(suite): distinguish Unreadable device in PrerequisitesGuide

### DIFF
--- a/packages/suite/src/components/suite/Preloader/__tests__/Preloader.test.tsx
+++ b/packages/suite/src/components/suite/Preloader/__tests__/Preloader.test.tsx
@@ -197,19 +197,53 @@ describe('Preloader component', () => {
         unmount();
     });
 
-    it('Unreadable device', () => {
+    it('Unreadable device: webusb HID', () => {
         const store = initStore(
             getInitialState({
                 suite: {
-                    transport: { type: 'bridge' },
-                    device: { type: 'unreadable' },
+                    transport: { type: 'WebUsbPlugin' },
+                    device: { type: 'unreadable', error: 'LIBUSB_ERROR_ACCESS' },
                 },
             }),
         );
         const { unmount } = renderWithProviders(store, <Index app={store.getState().router.app} />);
 
         expect(findByTestId('@connect-device-prompt')).not.toBeNull();
-        expect(findByTestId(/TR_YOUR_DEVICE_IS_CONNECTED_BUT_UNREADABLE/)).not.toBeNull();
+        expect(findByTestId('@connect-device-prompt/unreadable-hid')).not.toBeNull();
+
+        unmount();
+    });
+
+    it('Unreadable device: missing udev', () => {
+        const store = initStore(
+            getInitialState({
+                suite: {
+                    transport: { type: 'bridge' },
+                    device: { type: 'unreadable', error: 'LIBUSB_ERROR_ACCESS' },
+                },
+            }),
+        );
+        const { unmount } = renderWithProviders(store, <Index app={store.getState().router.app} />);
+
+        expect(findByTestId('@connect-device-prompt')).not.toBeNull();
+        expect(findByTestId('@connect-device-prompt/unreadable-udev')).not.toBeNull();
+
+        unmount();
+    });
+
+    it('Unreadable device: unknown error', () => {
+        const store = initStore(
+            getInitialState({
+                suite: {
+                    transport: { type: 'bridge' },
+                    device: { type: 'unreadable', error: 'Unexpected error' },
+                },
+            }),
+        );
+        const { unmount } = renderWithProviders(store, <Index app={store.getState().router.app} />);
+
+        expect(findByTestId('@connect-device-prompt')).not.toBeNull();
+        expect(findByTestId('@connect-device-prompt/unreadable-unknown')).not.toBeNull();
 
         unmount();
     });

--- a/packages/suite/src/components/suite/PrerequisitesGuide/components/DeviceConnect.tsx
+++ b/packages/suite/src/components/suite/PrerequisitesGuide/components/DeviceConnect.tsx
@@ -18,10 +18,10 @@ const Wrapper = styled(animated.div)`
 `;
 
 interface Props {
-    offerWebUsb: boolean;
+    webusb: boolean;
 }
 
-const DeviceConnect = ({ offerWebUsb }: Props) => {
+const DeviceConnect = ({ webusb }: Props) => {
     const fadeStyles = useSpring({
         config: { ...config.default },
         delay: 1000,
@@ -29,7 +29,7 @@ const DeviceConnect = ({ offerWebUsb }: Props) => {
         to: { opacity: 1 },
     });
 
-    const items = offerWebUsb
+    const items = webusb
         ? [
               TROUBLESHOOTING_TIP_UDEV,
               TROUBLESHOOTING_TIP_CABLE,
@@ -49,8 +49,8 @@ const DeviceConnect = ({ offerWebUsb }: Props) => {
             <TroubleshootingTips
                 label={<Translation id="TR_STILL_DONT_SEE_YOUR_TREZOR" />}
                 items={items}
-                offerWebUsb={offerWebUsb}
-                cta={offerWebUsb ? <WebusbButton icon="SEARCH" /> : undefined}
+                offerWebUsb={webusb}
+                cta={webusb ? <WebusbButton icon="SEARCH" /> : undefined}
             />
         </Wrapper>
     );

--- a/packages/suite/src/components/suite/PrerequisitesGuide/components/DeviceUnreadable.tsx
+++ b/packages/suite/src/components/suite/PrerequisitesGuide/components/DeviceUnreadable.tsx
@@ -1,25 +1,72 @@
 import React from 'react';
 import styled from 'styled-components';
+import { isLinux } from '@suite-utils/env';
 import { Translation, TroubleshootingTips } from '@suite-components';
 import {
     TROUBLESHOOTING_TIP_BRIDGE_STATUS,
     TROUBLESHOOTING_TIP_BRIDGE_INSTALL,
+    TROUBLESHOOTING_TIP_UDEV,
+    TROUBLESHOOTING_TIP_CABLE,
+    TROUBLESHOOTING_TIP_USB,
+    TROUBLESHOOTING_TIP_DIFFERENT_COMPUTER,
 } from '@suite-components/TroubleshootingTips/tips';
+import type { TrezorDevice } from '@suite-types';
 
 const Wrapper = styled.div`
     display: flex;
     flex-direction: column;
 `;
 
+interface Props {
+    device?: TrezorDevice; // this should be actually UnreadableDevice, but it is not worth type casting
+    webusb: boolean;
+}
+
 // We don't really know what happened, show some generic help and provide link to contact a support
-const DeviceUnreadable = () => (
-    <Wrapper>
-        <TroubleshootingTips
-            label={<Translation id="TR_YOUR_DEVICE_IS_CONNECTED_BUT_UNREADABLE" />}
-            items={[TROUBLESHOOTING_TIP_BRIDGE_STATUS, TROUBLESHOOTING_TIP_BRIDGE_INSTALL]}
-            offerWebUsb
-        />
-    </Wrapper>
-);
+const DeviceUnreadable = ({ device, webusb }: Props) => {
+    if (webusb) {
+        // only install bridge will help (webusb + HID device)
+        return (
+            <Wrapper data-test="@connect-device-prompt/unreadable-hid">
+                <TroubleshootingTips
+                    label={<Translation id="TR_TROUBLESHOOTING_UNREADABLE_WEBUSB" />}
+                    items={[TROUBLESHOOTING_TIP_BRIDGE_STATUS, TROUBLESHOOTING_TIP_BRIDGE_INSTALL]}
+                    offerWebUsb
+                />
+            </Wrapper>
+        );
+    }
+    // this error is dispatched by trezord when udev rules are missing
+    if (isLinux() && device?.error === 'LIBUSB_ERROR_ACCESS') {
+        // missing udev rules
+        return (
+            <Wrapper data-test="@connect-device-prompt/unreadable-udev">
+                <TroubleshootingTips
+                    label={<Translation id="TR_TROUBLESHOOTING_UNREADABLE_UDEV" />}
+                    items={[TROUBLESHOOTING_TIP_UDEV]}
+                />
+            </Wrapper>
+        );
+    }
+
+    return (
+        <Wrapper data-test="@connect-device-prompt/unreadable-unknown">
+            <TroubleshootingTips
+                label={
+                    <Translation
+                        id="TR_TROUBLESHOOTING_UNREADABLE_UNKNOWN"
+                        values={{ error: device?.error }}
+                    />
+                }
+                items={[
+                    TROUBLESHOOTING_TIP_CABLE,
+                    TROUBLESHOOTING_TIP_USB,
+                    TROUBLESHOOTING_TIP_DIFFERENT_COMPUTER,
+                ]}
+                offerWebUsb={webusb}
+            />
+        </Wrapper>
+    );
+};
 
 export default DeviceUnreadable;

--- a/packages/suite/src/components/suite/PrerequisitesGuide/index.tsx
+++ b/packages/suite/src/components/suite/PrerequisitesGuide/index.tsx
@@ -50,6 +50,7 @@ const PrerequisitesGuide = ({ prerequisite, padded, allowSwitchDevice }: Props) 
         devices: state.devices.length,
         transport: state.suite.transport,
     }));
+    const webusb = isWebUSB(transport);
 
     return (
         <Wrapper padded={padded}>
@@ -67,11 +68,11 @@ const PrerequisitesGuide = ({ prerequisite, padded, allowSwitchDevice }: Props) 
                     case 'transport-bridge':
                         return <Transport />;
                     case 'device-disconnected':
-                        return <DeviceConnect offerWebUsb={isWebUSB(transport)} />;
+                        return <DeviceConnect webusb={webusb} />;
                     case 'device-unacquired':
                         return <DeviceAcquire />;
                     case 'device-unreadable':
-                        return <DeviceUnreadable />;
+                        return <DeviceUnreadable device={device} webusb={webusb} />;
                     case 'device-unknown':
                         return <DeviceUnknown />;
                     case 'device-seedless':

--- a/packages/suite/src/support/messages.ts
+++ b/packages/suite/src/support/messages.ts
@@ -6330,6 +6330,19 @@ const definedMessages = defineMessages({
         id: 'TR_TROUBLESHOOTING_TIP_RESTART_COMPUTER_DESCRIPTION',
         defaultMessage: 'Just in case',
     },
+    TR_TROUBLESHOOTING_UNREADABLE_WEBUSB: {
+        id: 'TR_TROUBLESHOOTING_UNREADABLE_WEBUSB',
+        defaultMessage:
+            'Your device is connected properly, but your internet browser can not communicate with it at the moment. You will need to install Trezor Bridge.',
+    },
+    TR_TROUBLESHOOTING_UNREADABLE_UDEV: {
+        id: 'TR_TROUBLESHOOTING_UNREADABLE_UDEV',
+        defaultMessage: 'Missing udev rules',
+    },
+    TR_TROUBLESHOOTING_UNREADABLE_UNKNOWN: {
+        id: 'TR_TROUBLESHOOTING_UNREADABLE_UNKNOWN',
+        defaultMessage: 'Unexpected state: {error}',
+    },
     TR_SEEDLESS_SETUP_IS_NOT_SUPPORTED_TITLE: {
         id: 'TR_SEEDLESS_SETUP_IS_NOT_SUPPORTED_TITLE',
         defaultMessage: 'Seedless setup is not supported by Trezor Suite',


### PR DESCRIPTION
implementation of https://github.com/trezor/connect/commit/18edd1664fa4397a2b580ba4f84ce3d8ae4a4583

distinguish Unreadable device in PrerequisitesGuide
- unreadable webusb device (HID)
- unreadable device (LIBUSB_ERROR) - linux missing udev rules
- other

should fix: https://github.com/trezor/trezor-suite/issues/2977


![Screenshot from 2021-07-01 15-05-40](https://user-images.githubusercontent.com/3435913/124156509-ff1dec00-da97-11eb-9a22-da0c5d2f54ab.png)
![Screenshot from 2021-07-01 15-05-07](https://user-images.githubusercontent.com/3435913/124156527-03e2a000-da98-11eb-8ce2-28a165051150.png)
![Screenshot from 2021-07-01 15-04-32](https://user-images.githubusercontent.com/3435913/124156533-05ac6380-da98-11eb-83c5-df6c5880b5db.png)


