### PR TITLE
fix(suite): redact Toast notification error

### DIFF
--- a/packages/suite-data/files/translations/en.json
+++ b/packages/suite-data/files/translations/en.json
@@ -172,7 +172,7 @@
 	"TOAST_ACQUIRE_ERROR": "Acquire error {error}",
 	"TOAST_AUTH_CONFIRM_ERROR": "Passphrase confirmation error: {error}",
 	"TOAST_AUTH_CONFIRM_ERROR_DEFAULT": "Invalid passphrase",
-	"TOAST_AUTH_FAILED": "Authorization error: {error}",
+	"TOAST_AUTH_FAILED": "Authorization error {error}",
 	"TOAST_AUTO_UPDATER_ERROR": "Auto updater error ({state})",
 	"TOAST_AUTO_UPDATER_NO_NEW": "No new updates available.",
 	"TOAST_BACKUP_FAILED": "Backup failed",

--- a/packages/suite/src/middlewares/suite/toastMiddleware.ts
+++ b/packages/suite/src/middlewares/suite/toastMiddleware.ts
@@ -25,7 +25,13 @@ const toastMiddleware = (api: MiddlewareAPI<Dispatch, AppState>) => (next: Dispa
 
     if (action.type === NOTIFICATION.TOAST) {
         // TODO: set custom timeout
-        const { payload } = action;
+        const payload = { ...action.payload };
+        // assetType error is returned by trezor-connect
+        // we don't want to show this generic message in toast however the whole message is useful for logging
+        // redact error message to empty string
+        if (payload.error && payload.error.indexOf('assetType:') >= 0) {
+            payload.error = '';
+        }
         toast(hocNotification(payload, ToastNotification), {
             toastId: payload.id,
             onClose: () => api.dispatch(close(payload.id)),

--- a/packages/suite/src/reducers/suite/notificationReducer.ts
+++ b/packages/suite/src/reducers/suite/notificationReducer.ts
@@ -84,6 +84,7 @@ interface Common {
     id: number; // programmer provided, might be used to find and close notification programmatically
     device?: TrezorDevice; // used to close notifications for device
     closed?: boolean;
+    error?: string;
 }
 
 export type EventPayload = (

--- a/packages/suite/src/support/messages.ts
+++ b/packages/suite/src/support/messages.ts
@@ -3210,7 +3210,7 @@ const definedMessages = defineMessages({
     },
     TOAST_AUTH_FAILED: {
         id: 'TOAST_AUTH_FAILED',
-        defaultMessage: 'Authorization error: {error}',
+        defaultMessage: 'Authorization error {error}',
     },
     TOAST_AUTH_CONFIRM_ERROR: {
         id: 'TOAST_AUTH_CONFIRM_ERROR',


### PR DESCRIPTION
generic error "assertType" should not be visible in Toast but detailed message should be visible in log

fix: #3807

![Peek 2021-07-01 21-06](https://user-images.githubusercontent.com/3435913/124177987-44024c80-dab1-11eb-8aef-d81bcdfb45ab.gif)
