### PR TITLE
Add 1.10.2 and 2.4.1

### DIFF
--- a/packages/suite-data/files/connect/data/firmware/1/releases.json
+++ b/packages/suite-data/files/connect/data/firmware/1/releases.json
@@ -1,6 +1,20 @@
 [
 	{
 		"required": false,
+		"version": [1, 10, 2],
+		"bootloader_version": [1, 10, 0],
+		"min_bridge_version": [2, 0, 25],
+		"min_firmware_version": [1, 6, 2],
+		"min_bootloader_version": [1, 5, 0],
+		"url": "data/firmware/1/trezor-1.10.2.bin",
+		"url_bitcoinonly": "data/firmware/1/trezor-1.10.2-bitcoinonly.bin",
+		"fingerprint": "f8ebf48ae37968651489ef3d530161e5a4649d5a87dced94bc4c59040fdeb728",
+		"fingerprint_bitcoinonly": "1502e694ab519ed573e8770c69bfac042b4d2b56f81e9dcf0482de9fda88d527",
+		"notes": "https://blog.trezor.io/trezor-suite-launches-8958c1d37d33",
+		"changelog": "* Security improvements."
+	},
+	{
+		"required": false,
 		"version": [1, 10, 1],
 		"bootloader_version": [1, 10, 0],
 		"min_bridge_version": [2, 0, 25],

--- a/packages/suite-data/files/connect/data/firmware/2/releases.json
+++ b/packages/suite-data/files/connect/data/firmware/2/releases.json
@@ -1,6 +1,19 @@
 [
 	{
 		"required": false,
+		"version": [2, 4, 1],
+		"min_bridge_version": [2, 0, 7],
+		"min_firmware_version": [2, 0, 8],
+		"min_bootloader_version": [2, 0, 0],
+		"url": "data/firmware/2/trezor-2.4.1.bin",
+		"url_bitcoinonly": "data/firmware/2/trezor-2.4.1-bitcoinonly.bin",
+		"fingerprint": "89870915191afbb037ed3e1a1d2a216b6c5d931677a23a0f19a722006ed8f18c",
+		"fingerprint_bitcoinonly": "5f57586629b44906b02135b3d9012dd85ea16b508fc828bd5ffd26865aa99b7b",
+		"notes": "https://blog.trezor.io/trezor-suite-launches-8958c1d37d33",
+		"changelog": "* Security and major perfomance improvements.\n* Cardano fixes.\n* Fix red screen on shutdown."
+	},
+	{
+		"required": false,
 		"version": [2, 4, 0],
 		"min_bridge_version": [2, 0, 7],
 		"min_firmware_version": [2, 0, 8],


### PR DESCRIPTION
Adds new firmwares to the release branch only, we will add them to develop via Connect update.

This will now fail in Suite as the firmwares are not deployed to data.trezor.io as we do not want to them public yet. This is expected. We will add them on Monday. #3738 will solve this in future.