### PR TITLE
Improve readme for integration-tests package

### DIFF
--- a/packages/integration-tests/README.md
+++ b/packages/integration-tests/README.md
@@ -1,4 +1,13 @@
-### Components library + storybook v2
+# Integration tests
+
+This package contains Suite web end-to-end tests and components library tests.
+
+## Suite web tests
+Suite uses [Cypress](https://docs.cypress.io/guides/overview/why-cypress.html) to run e2e tests. It also uses [trezor-user-env](https://github.com/trezor/trezor-user-env) which is [daily built](https://gitlab.com/satoshilabs/trezor/trezor-user-env/-/pipelines) into a docker image providing all the necessary instrumentation required to run tests (bridge and emulators).
+
+See how to run them [here](../../docs/tests/e2e-web.md).
+
+## Components library + storybook v2
 
 `docker build -t tests-components-storybook -f packages/integration-tests/projects/components-storybook/Dockerfile .`
 


### PR DESCRIPTION
I have a small preference for pushing small docs improvements directly into `develop` but it feels a bit intrusive as I am not a Suite dev per-se. Any opinions on that?