### PR TITLE
fix(suite): prevent error Cannot read property blockHeight of undefined

### DIFF
--- a/packages/suite/src/utils/wallet/transactionUtils.ts
+++ b/packages/suite/src/utils/wallet/transactionUtils.ts
@@ -102,7 +102,7 @@ export const parseKey = (key: string) => {
 };
 
 export const isPending = (tx: WalletAccountTransaction | AccountTransaction) =>
-    !tx.blockHeight || tx.blockHeight < 0;
+    !!tx && (!tx.blockHeight || tx.blockHeight < 0);
 
 export const findTransaction = (txid: string, transactions: WalletAccountTransaction[]) =>
     transactions.find(t => t && t.txid === txid);


### PR DESCRIPTION
fix #3926 

- Very common in Sentry.
- Sourcemaps helped a lot: https://sentry.io/organizations/satoshilabs/issues/2228342311/events/31549c6f9083425db927959173c1b263/?environment=web&project=5193825