### PR TITLE
fix(e2e): skip user-env websocket connection if already connected

### DIFF
--- a/packages/integration-tests/projects/suite-web/plugins/websocket-client.js
+++ b/packages/integration-tests/projects/suite-web/plugins/websocket-client.js
@@ -141,6 +141,7 @@ class Controller extends EventEmitter {
     }
 
     connect() {
+        if (this.isConnected()) return Promise.resolve();
         // url validation
         let { url } = this.options;
         if (typeof url !== 'string') {


### PR DESCRIPTION
i just found it the same bug in [trezor-connect](https://github.com/trezor/connect/pull/846/commits/a3a263c8cfcc6515a3b7672ff4b7f43cb04b6c4f)

`controller.connect()` is called from pre-setup functions like `startBridge` or `setupEmu` so it creates another `WebSocket` instance every time while previous websockets is still running (and receiving messages?) 