### PR TITLE
Chore/fw update

### DIFF
--- a/packages/rollout/integration/fresh-devices.ts
+++ b/packages/rollout/integration/fresh-devices.ts
@@ -7,6 +7,7 @@
 
 import { getInfo, getBinary } from '../src';
 import { Release, VersionArray } from '../src/utils/parse';
+import { isNewerOrEqual } from '../src/utils/version';
 
 const { getDeviceFeatures } = global.JestMocks;
 
@@ -46,9 +47,7 @@ describe('Find firmware info for: ', () => {
         expect(withBinary).toMatchObject({ release: { version: [1, 6, 3] } });
     });
 
-    it('bootloader 1.5.1 -> firmware version 1.10.0', async () => {
-        // currently, this is expected to fail after there is new firmware update, since the last version is hardcoded
-        const targetVersion = [1, 10, 1] as VersionArray;
+    it('bootloader 1.5.1 -> firmware version 1.10.0+', async () => {
         const info = getInfo({
             features: getDeviceFeatures({
                 bootloader_mode: true,
@@ -59,7 +58,9 @@ describe('Find firmware info for: ', () => {
             }),
             releases: RELEASES_T1,
         });
-        expect(info).toMatchObject({ release: { version: targetVersion } });
+
+        const targetVersion = info!.release.version;
+        expect(isNewerOrEqual(targetVersion, [1, 10, 0])).toBe(true);
 
         // validate that with binary returns the same firmware
         const withBinary = await getBinary({

--- a/packages/suite-data/files/connect/data/firmware/1/releases.json
+++ b/packages/suite-data/files/connect/data/firmware/1/releases.json
@@ -1,6 +1,20 @@
 [
 	{
 		"required": false,
+		"version": [1, 10, 2],
+		"bootloader_version": [1, 10, 0],
+		"min_bridge_version": [2, 0, 25],
+		"min_firmware_version": [1, 6, 2],
+		"min_bootloader_version": [1, 5, 0],
+		"url": "data/firmware/1/trezor-1.10.2.bin",
+		"url_bitcoinonly": "data/firmware/1/trezor-1.10.2-bitcoinonly.bin",
+		"fingerprint": "99707b90a504f7e402f26c3d59cbbdacbc52754cebcce79cc47be528fc889338",
+		"fingerprint_bitcoinonly": "e597b6aef5a2e817f532d27b8501f99f189e432a887877bdd3498cd3a0afc431",
+		"notes": "https://blog.trezor.io/trezor-suite-launches-8958c1d37d33",
+		"changelog": "* Security improvements."
+	},
+	{
+		"required": false,
 		"version": [1, 10, 1],
 		"bootloader_version": [1, 10, 0],
 		"min_bridge_version": [2, 0, 25],

--- a/packages/suite-data/files/connect/data/firmware/2/releases.json
+++ b/packages/suite-data/files/connect/data/firmware/2/releases.json
@@ -1,6 +1,19 @@
 [
 	{
 		"required": false,
+		"version": [2, 4, 1],
+		"min_bridge_version": [2, 0, 7],
+		"min_firmware_version": [2, 0, 8],
+		"min_bootloader_version": [2, 0, 0],
+		"url": "data/firmware/2/trezor-2.4.1.bin",
+		"url_bitcoinonly": "data/firmware/2/trezor-2.4.1-bitcoinonly.bin",
+		"fingerprint": "84bc47bb197b3ae7bfb096f03d4a528ccf6c9ef4dfee0aac4022971e4ec91d68",
+		"fingerprint_bitcoinonly": "fce4503fcadb68dc72144a562ec0a59e7c8d083e403e01bfc4c584161d79f596",
+		"notes": "https://blog.trezor.io/trezor-suite-launches-8958c1d37d33",
+		"changelog": "* Security and major perfomance improvements.\n* Cardano fixes.\n* Fix red screen on shutdown."
+	},
+	{
+		"required": false,
 		"version": [2, 4, 0],
 		"min_bridge_version": [2, 0, 7],
 		"min_firmware_version": [2, 0, 8],


### PR DESCRIPTION
FW release commit was cherry-picked from the release branch:
https://github.com/trezor/trezor-suite/commits/release/21.07

corresponding PR in connect:
https://github.com/trezor/connect/pull/849

fixing rollout test, which was failing after every FW release, now it's checking if FW is >= 1.10.0