### PR TITLE
Feat/source maps auto uploading sentry

### DIFF
--- a/packages/suite-build/configs/base.webpack.config.ts
+++ b/packages/suite-build/configs/base.webpack.config.ts
@@ -1,13 +1,24 @@
+import path from 'path';
 import webpack from 'webpack';
 import { BundleAnalyzerPlugin } from 'webpack-bundle-analyzer';
+import SentryWebpackPlugin from '@sentry/webpack-plugin';
 
 import alias from '../utils/alias';
-import { assetPrefix, project, isDev, isAnalyzing, isCodesignBuild } from '../utils/env';
+import {
+    assetPrefix,
+    project,
+    isDev,
+    isAnalyzing,
+    isCodesignBuild,
+    sentryAuthToken,
+} from '../utils/env';
 import { getRevision } from '../utils/git';
 import JWS_PUBLIC_KEY from '../utils/codesign';
+import { getPathForProject } from '../utils/path';
 import { version } from '../../suite-desktop/package.json';
 
 const gitRevision = getRevision();
+const sentryRelease = `${version}.${project}${isCodesignBuild ? '.codesign' : ''}.${gitRevision}`;
 
 const config: webpack.Configuration = {
     mode: 'production',
@@ -134,6 +145,7 @@ const config: webpack.Configuration = {
             'process.env.ASSET_PREFIX': JSON.stringify(assetPrefix),
             'process.env.PUBLIC_KEY': JSON.stringify(JWS_PUBLIC_KEY),
             'process.env.CODESIGN_BUILD': isCodesignBuild,
+            'process.env.SENTRY_RELEASE': JSON.stringify(sentryRelease),
         }),
         new webpack.ProvidePlugin({
             Buffer: ['buffer', 'Buffer'],
@@ -143,6 +155,16 @@ const config: webpack.Configuration = {
             new BundleAnalyzerPlugin({
                 openAnalyzer: true,
                 analyzerMode: isDev ? 'server' : 'static',
+            }),
+        !isDev &&
+            new SentryWebpackPlugin({
+                authToken: sentryAuthToken,
+                org: 'satoshilabs',
+                project: 'trezor-suite',
+                release: sentryRelease,
+                include: path.join(getPathForProject(project), 'build'),
+                ignore: ['static/connect'], // connect does not contain source maps for now
+                cleanArtifacts: true,
             }),
     ].filter(Boolean),
 };

--- a/packages/suite-build/configs/base.webpack.config.ts
+++ b/packages/suite-build/configs/base.webpack.config.ts
@@ -12,7 +12,7 @@ const gitRevision = getRevision();
 const config: webpack.Configuration = {
     mode: 'production',
     target: 'browserslist',
-    devtool: false,
+    devtool: 'source-map',
     output: {
         publicPath: `${assetPrefix}/`,
         filename: 'js/[name].[contenthash:8].js',

--- a/packages/suite-build/package.json
+++ b/packages/suite-build/package.json
@@ -47,6 +47,7 @@
         "worker-loader": "^3.0.8"
     },
     "devDependencies": {
+        "@sentry/webpack-plugin": "^1.16.0",
         "@types/copy-webpack-plugin": "^6.4.1",
         "@types/webpack": "^5.0.0",
         "@types/webpack-bundle-analyzer": "^3.9.2",

--- a/packages/suite-build/utils/env.ts
+++ b/packages/suite-build/utils/env.ts
@@ -7,6 +7,7 @@ const {
     LAUNCH_ELECTRON,
     ASSET_PREFIX,
     IS_CODESIGN_BUILD,
+    SENTRY_AUTH_TOKEN,
 } = process.env;
 
 const project = PROJECT as Project;
@@ -16,5 +17,15 @@ const isAnalyzing = ANALYZE === 'true';
 const isCodesignBuild = IS_CODESIGN_BUILD === 'true';
 const launchElectron = LAUNCH_ELECTRON === 'true';
 const assetPrefix = ASSET_PREFIX || '';
+const sentryAuthToken = SENTRY_AUTH_TOKEN;
 
-export { environment, isAnalyzing, isCodesignBuild, isDev, launchElectron, assetPrefix, project };
+export {
+    environment,
+    isAnalyzing,
+    isCodesignBuild,
+    isDev,
+    launchElectron,
+    assetPrefix,
+    project,
+    sentryAuthToken,
+};

--- a/packages/suite-data/browser-detection.webpack.js
+++ b/packages/suite-data/browser-detection.webpack.js
@@ -8,6 +8,7 @@ module.exports = {
         path: path.resolve(__dirname, 'files/browser-detection'),
         filename: 'index.js',
     },
+    devtool: 'source-map',
     module: {
         rules: [
             {

--- a/packages/suite/src/config/suite/sentry.ts
+++ b/packages/suite/src/config/suite/sentry.ts
@@ -10,6 +10,6 @@ export default {
             levels: ['error'],
         }),
     ],
-    release: process.env.COMMITHASH,
+    release: process.env.SENTRY_RELEASE,
     environment: process.env.SUITE_TYPE,
 } as BrowserOptions;

--- a/yarn.lock
+++ b/yarn.lock
@@ -4503,6 +4503,18 @@
     "@sentry/utils" "5.30.0"
     tslib "^1.9.3"
 
+"@sentry/cli@^1.67.1":
+  version "1.67.2"
+  resolved "https://registry.yarnpkg.com/@sentry/cli/-/cli-1.67.2.tgz#dbb5631cb3637e10298f67915013592cb22f04ff"
+  integrity sha512-lPn0Sffbjg2UmCkHl2iw8pKlqpPhy85mW0za5kz3LEqC9JGUXHo9eSyyCkiRktlemMXKk+DeS/nyFy/LTRUG2Q==
+  dependencies:
+    https-proxy-agent "^5.0.0"
+    mkdirp "^0.5.5"
+    node-fetch "^2.6.0"
+    npmlog "^4.1.2"
+    progress "^2.0.3"
+    proxy-from-env "^1.1.0"
+
 "@sentry/core@5.30.0":
   version "5.30.0"
   resolved "https://registry.yarnpkg.com/@sentry/core/-/core-5.30.0.tgz#6b203664f69e75106ee8b5a2fe1d717379b331f3"
@@ -4554,6 +4566,13 @@
   dependencies:
     "@sentry/types" "5.30.0"
     tslib "^1.9.3"
+
+"@sentry/webpack-plugin@^1.16.0":
+  version "1.16.0"
+  resolved "https://registry.yarnpkg.com/@sentry/webpack-plugin/-/webpack-plugin-1.16.0.tgz#f9b15b5bb485995e776729b71bcf2d9fad7dca7a"
+  integrity sha512-Ax0QZ3a+LFYU876Si2HElPYSj+mX3vinvzH+o9F1g/5T2Z3HqITnX6gg+zVfLFsE819PN9KeLpmoHtO352dlmQ==
+  dependencies:
+    "@sentry/cli" "^1.67.1"
 
 "@sideway/address@^4.1.0":
   version "4.1.0"
@@ -21020,6 +21039,11 @@ proxy-addr@~2.0.5:
   dependencies:
     forwarded "~0.1.2"
     ipaddr.js "1.9.1"
+
+proxy-from-env@^1.1.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/proxy-from-env/-/proxy-from-env-1.1.0.tgz#e102f16ca355424865755d2c9e8ea4f24d58c3e2"
+  integrity sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg==
 
 prr@~1.0.1:
   version "1.0.1"


### PR DESCRIPTION
closes #3927
closes #3445
closes https://github.com/satoshilabs/devops/issues/25

- build source maps during project build (suite and browser detection)
- upload source maps to sentry on project build by webpack plugin automatically

BEWARE that it will be available in develop after feat/tschuss-next is merged