### PR TITLE
feat(tests): Shamir backup walkthrough function and test

### DIFF
--- a/packages/integration-tests/projects/suite-web/plugins/index.js
+++ b/packages/integration-tests/projects/suite-web/plugins/index.js
@@ -185,6 +185,12 @@ module.exports = on => {
             controller.disconnect();
             return null;
         },
+        readAndConfirmShamirMnemonicEmu: async options => {
+            await controller.connect();
+            await controller.send({ type: 'emulator-read-and-confirm-shamir-mnemonic', ...options});
+            controller.disconnect();
+            return null;
+        },
         applySettings: async options => {
             const defaults = {
                 passphrase_always_on_device: false,

--- a/packages/integration-tests/projects/suite-web/plugins/websocket-client.js
+++ b/packages/integration-tests/projects/suite-web/plugins/websocket-client.js
@@ -21,7 +21,10 @@ const createDeferred = id => {
     };
 };
 
-const DEFAULT_TIMEOUT = 20 * 1000;
+// Making the timeout high because the controller in trezor-user-env
+// must synchronously run actions on emulator and they may take a long time
+// (for example in case of Shamir backup)
+const DEFAULT_TIMEOUT = 5 * 60 * 1000;
 const DEFAULT_PING_TIMEOUT = 50 * 1000;
 
 class Controller extends EventEmitter {

--- a/packages/integration-tests/projects/suite-web/support/commands.ts
+++ b/packages/integration-tests/projects/suite-web/support/commands.ts
@@ -17,6 +17,7 @@ import {
     goToOnboarding,
     passThroughInitialRun,
     passThroughBackup,
+    passThroughBackupShamir,
     passThroughInitMetadata,
     passThroughSetPin,
 } from './utils/shortcuts';
@@ -65,6 +66,7 @@ declare global {
             toggleDeviceMenu: () => Chainable<Subject>;
             passThroughInitialRun: () => Chainable<Subject>;
             passThroughBackup: () => Chainable<Subject>;
+            passThroughBackupShamir: (shares: number, threshold: number) => Chainable<Subject>;
             passThroughSetPin: () => Chainable<Subject>;
             passThroughInitMetadata: (provider: 'dropbox' | 'google') => Chainable<Subject>;
             goToOnboarding: () => Chainable<Subject>;
@@ -107,6 +109,7 @@ Cypress.Commands.add('toggleDeviceMenu', toggleDeviceMenu);
 Cypress.Commands.add('goToOnboarding', goToOnboarding);
 Cypress.Commands.add('passThroughInitialRun', passThroughInitialRun);
 Cypress.Commands.add('passThroughBackup', passThroughBackup);
+Cypress.Commands.add('passThroughBackupShamir', passThroughBackupShamir);
 Cypress.Commands.add('passThroughInitMetadata', passThroughInitMetadata);
 Cypress.Commands.add('passThroughSetPin', passThroughSetPin);
 // redux

--- a/packages/integration-tests/projects/suite-web/support/utils/shortcuts.ts
+++ b/packages/integration-tests/projects/suite-web/support/utils/shortcuts.ts
@@ -11,7 +11,7 @@ export const goToOnboarding = () => {
     //     .click()
     //     .getTestElement('@analytics/go-to-onboarding-button')
     //     .click();
-    
+
     // todo: no no no
     cy.task('startEmu', { version: '2.1.4', wipe: true });
     cy.getTestElement('@onboarding/continue-button').click();
@@ -54,6 +54,22 @@ export const passThroughBackup = () => {
     // cy.getTestElement('@backup/check-item/wrote-seed-properly').click();
     // cy.getTestElement('@backup/check-item/made-no-digital-copy').click();
     // cy.getTestElement('@backup/check-item/will-hide-seed').click();
+    cy.getTestElement('@backup/close-button').click();
+};
+
+export const passThroughBackupShamir = (shares: number, threshold: number) => {
+    cy.log('Backup button should be disabled until all checkboxes are checked');
+    cy.getTestElement('@backup/start-button').should('be.disabled');
+
+    cy.getTestElement('@backup/check-item/wrote-seed-properly').click();
+    cy.getTestElement('@backup/check-item/made-no-digital-copy').click();
+    cy.getTestElement('@backup/check-item/will-hide-seed').click();
+
+    cy.log('Create Shamir backup on device');
+    cy.getTestElement('@backup/start-button').click();
+    cy.getTestElement('@onboarding/confirm-on-device');
+    cy.task('readAndConfirmShamirMnemonicEmu', { shares, threshold });
+
     cy.getTestElement('@backup/close-button').click();
 };
 

--- a/packages/integration-tests/projects/suite-web/tests/onboarding/t2-create-wallet.test.ts
+++ b/packages/integration-tests/projects/suite-web/tests/onboarding/t2-create-wallet.test.ts
@@ -63,4 +63,29 @@ describe('Onboarding - create wallet', () => {
         cy.task('inputEmu', '1');
         cy.task('inputEmu', '1');
     });
+
+    it('Success (Shamir backup)', () => {
+        cy.task('startEmu', { version: '2.3.4', wipe: true });
+        cy.getTestElement('@onboarding/continue-button').click();
+        cy.getTestElement('@onboarding/continue-button').click();
+        cy.getTestElement("@firmware/skip-button").click();
+        cy.getTestElement('@onboarding/path-create-button').click();
+
+        cy.log('Will be clicking on Shamir backup button',);
+        cy.getTestElement('@onboarding/shamir-backup-option-button').click();
+        cy.getTestElement('@onboarding/confirm-on-device').should('be.visible');
+        cy.task('pressYes');
+
+        cy.getTestElement('@onboarding/create-backup-button').click();
+
+        const shares = 3;
+        const threshold = 2;
+        cy.passThroughBackupShamir(shares, threshold);
+        cy.getTestElement('@onboarding/set-pin-button').click();
+        cy.getTestElement('@onboarding/confirm-on-device');
+
+        cy.task('pressYes');
+        cy.task('inputEmu', '12');
+        cy.task('inputEmu', '12');
+    });
 });


### PR DESCRIPTION
Supported Shamir backup functionality for Suite tests
- connected with [trezor-user-env PV](https://github.com/trezor/trezor-user-env/pull/89)

NOTE: When running this "2 out of 3" Shamir, at the end the `websocket_timeout` was encountered