### PR TITLE
Grdddj/replacing old firmwares in e2e tests

### DIFF
--- a/packages/integration-tests/projects/suite-web/cypress.json
+++ b/packages/integration-tests/projects/suite-web/cypress.json
@@ -9,5 +9,9 @@
     "video": true,
     "trashAssetsBeforeRuns": true,
     "chromeWebSecurity": false,
-    "experimentalFetchPolyfill": true
+    "experimentalFetchPolyfill": true,
+    "env": {
+        "emuVersionT1": "1-master",
+        "emuVersionT2": "2-master"
+    }
 }

--- a/packages/integration-tests/projects/suite-web/plugins/index.js
+++ b/packages/integration-tests/projects/suite-web/plugins/index.js
@@ -173,6 +173,12 @@ module.exports = on => {
             controller.disconnect();
             return null;
         },
+        clickEmu: async options => {
+            await controller.connect();
+            await controller.send({ type: 'emulator-click', ...options });
+            controller.disconnect();
+            return null;
+        },
         resetDevice: async options => {
             await controller.connect();
             await controller.send({ type: 'emulator-reset-device', ...options });
@@ -192,13 +198,9 @@ module.exports = on => {
             return null;
         },
         applySettings: async options => {
-            const defaults = {
-                passphrase_always_on_device: false,
-            };
             await controller.connect();
             await controller.send({
                 type: 'emulator-apply-settings',
-                ...defaults,
                 ...options,
             });
             controller.disconnect();

--- a/packages/integration-tests/projects/suite-web/run_tests.js
+++ b/packages/integration-tests/projects/suite-web/run_tests.js
@@ -122,6 +122,10 @@ async function runTests() {
             chromeWebSecurity: false,
             trashAssetsBeforeRuns: false,
             defaultCommandTimeout: 15000,
+            env: {
+                emuVersionT1: '1-master',
+                emuVersionT2: '2-master'
+            }
         };
 
         if (userAgent) {
@@ -214,7 +218,7 @@ async function runTests() {
             if [ $diff_pre -gt 0 ]
             then
               echo "You have unstaged changes."
-              exit 1 
+              exit 1
             fi
             mkdir tmp
             cd tmp
@@ -228,12 +232,12 @@ async function runTests() {
             if [ $diff_after -eq 0 ]
             then
               echo "There are no new snapshots."
-              exit 0 
+              exit 0
             fi
             git add .
             git commit -m "e2e${stage ? `(${stage}):` : ':'} update snapshots"
             git log -n 2
-            echo "You may now push your changes."  
+            echo "You may now push your changes."
         `;
 
         console.log('Generated script to update files locally');
@@ -242,9 +246,9 @@ async function runTests() {
         console.log(`
         EXECUTE ^^ SCRIPT TO UPDATE SNAPSHOTS THAT CHANGED LOCALLY
         *******************************************************************
-                                                                           
-        curl ${CI_JOB_URL}/artifacts/raw/download-snapshots.sh | bash  
-                                                                           
+
+        curl ${CI_JOB_URL}/artifacts/raw/download-snapshots.sh | bash
+
         *******************************************************************
         `);
 

--- a/packages/integration-tests/projects/suite-web/support/utils/shortcuts.ts
+++ b/packages/integration-tests/projects/suite-web/support/utils/shortcuts.ts
@@ -13,7 +13,7 @@ export const goToOnboarding = () => {
     //     .click();
 
     // todo: no no no
-    cy.task('startEmu', { version: '2.1.4', wipe: true });
+    cy.task('startEmu', { version: Cypress.env('emuVersionT2'), wipe: true });
     cy.getTestElement('@onboarding/continue-button').click();
     cy.getTestElement('@onboarding/continue-button').click();
 

--- a/packages/integration-tests/projects/suite-web/tests/backup/t2-fail.test.ts
+++ b/packages/integration-tests/projects/suite-web/tests/backup/t2-fail.test.ts
@@ -3,7 +3,7 @@
 
 describe('Backup', () => {
     beforeEach(() => {
-        cy.task('startEmu', { wipe: true });
+        cy.task('startEmu', { version: Cypress.env('emuVersionT2'), wipe: true });
         cy.task('setupEmu', { needs_backup: true });
         cy.task('startBridge');
         cy.viewport(1024, 768).resetDb();

--- a/packages/integration-tests/projects/suite-web/tests/backup/t2-misc.test.ts
+++ b/packages/integration-tests/projects/suite-web/tests/backup/t2-misc.test.ts
@@ -3,7 +3,7 @@
 
 describe('Backup', () => {
     beforeEach(() => {
-        cy.task('startEmu', { wipe: true });
+        cy.task('startEmu', { version: Cypress.env('emuVersionT2'), wipe: true });
         cy.task('setupEmu', { needs_backup: true });
         cy.task('startBridge');
 
@@ -39,7 +39,7 @@ describe('Backup', () => {
         cy.getTestElement('@backup/no-device', { timeout: 20000 });
         cy.task('stopBridge');
         // latest (2.3.1 at the time of writing this) has default behavior needs_backup false
-        cy.task('startEmu', { wipe: true });
+        cy.task('startEmu', { version: Cypress.env('emuVersionT2'), wipe: true });
         cy.task('setupEmu');
         // noticed that it failed here times: 1
         cy.getTestElement('@backup/already-finished-message');

--- a/packages/integration-tests/projects/suite-web/tests/backup/t2-success.test.ts
+++ b/packages/integration-tests/projects/suite-web/tests/backup/t2-success.test.ts
@@ -2,7 +2,7 @@
 
 describe('Backup', () => {
     beforeEach(() => {
-        cy.task('startEmu', { wipe: true });
+        cy.task('startEmu', { version: Cypress.env('emuVersionT2'), wipe: true });
         cy.task('setupEmu', {
             needs_backup: true,
             mnemonic: 'all all all all all all all all all all all all',

--- a/packages/integration-tests/projects/suite-web/tests/dashboard/dashboard.test.ts
+++ b/packages/integration-tests/projects/suite-web/tests/dashboard/dashboard.test.ts
@@ -3,13 +3,11 @@
 
 describe('Dashboard', () => {
     beforeEach(() => {
-        cy.task('startEmu', { version: '2.3.1', wipe: true });
+        cy.task('startEmu', { version: Cypress.env('emuVersionT2'), wipe: true });
         cy.task('setupEmu', {
             needs_backup: true,
             mnemonic: 'all all all all all all all all all all all all',
         });
-
-        cy.task('applySettings', { passphrase_always_on_device: false });
         cy.task('startBridge');
 
         cy.viewport(1024, 768).resetDb();

--- a/packages/integration-tests/projects/suite-web/tests/metadata/account-metadata.test.ts
+++ b/packages/integration-tests/projects/suite-web/tests/metadata/account-metadata.test.ts
@@ -18,7 +18,7 @@ Hovering over fields that may be labeled shows "add label" button upon which is 
     fixtures.forEach(f => {
         it(f.provider, () => {
             // prepare test
-            cy.task('startEmu', { wipe: true });
+            cy.task('startEmu', { version: Cypress.env('emuVersionT2'), wipe: true });
             cy.task('setupEmu', {
                 mnemonic: 'all all all all all all all all all all all all',
             });
@@ -37,7 +37,7 @@ Hovering over fields that may be labeled shows "add label" button upon which is 
             cy.discoveryShouldFinish();
 
             cy.getTestElement('@suite/menu/wallet-index').click();
-            
+
             cy.log(
                 'Default label is "Bitcoin #1". Clicking it in accounts menu is not possible. User can click on label in accounts sections. This triggers metadata flow',
             );

--- a/packages/integration-tests/projects/suite-web/tests/metadata/address-metadata.test.ts
+++ b/packages/integration-tests/projects/suite-web/tests/metadata/address-metadata.test.ts
@@ -15,7 +15,7 @@ describe('Metadata - address labeling', () => {
     providers.forEach(provider => {
         it(provider, () => {
             // prepare test
-            cy.task('startEmu', { wipe: true });
+            cy.task('startEmu', { version: Cypress.env('emuVersionT2'), wipe: true });
             cy.task('setupEmu', {
                 mnemonic: 'all all all all all all all all all all all all',
             });

--- a/packages/integration-tests/projects/suite-web/tests/metadata/dropbox-api-errors.test.ts
+++ b/packages/integration-tests/projects/suite-web/tests/metadata/dropbox-api-errors.test.ts
@@ -9,7 +9,7 @@ describe('Dropbox api errors', () => {
     });
 
     it('Malformed token', () => {
-        cy.task('startEmu', { wipe: true });
+        cy.task('startEmu', { version: Cypress.env('emuVersionT2'), wipe: true });
         cy.task('setupEmu', {
             mnemonic: 'all all all all all all all all all all all all',
         });

--- a/packages/integration-tests/projects/suite-web/tests/metadata/google-api-errors.test.ts
+++ b/packages/integration-tests/projects/suite-web/tests/metadata/google-api-errors.test.ts
@@ -8,7 +8,7 @@ const provider = 'google';
 describe('Google api errors', () => {
     beforeEach(() => {
         cy.viewport(1024, 768).resetDb();
-        cy.task('startEmu', { wipe: true });
+        cy.task('startEmu', { version: Cypress.env('emuVersionT2'), wipe: true });
         cy.task('setupEmu', {
             mnemonic: 'all all all all all all all all all all all all',
         });

--- a/packages/integration-tests/projects/suite-web/tests/metadata/interval-fetching.test.ts
+++ b/packages/integration-tests/projects/suite-web/tests/metadata/interval-fetching.test.ts
@@ -27,7 +27,7 @@ describe('Metadata - suite is watching cloud provider and syncs periodically', (
     fixtures.forEach(f => {
         it(`${f.provider}-${f.desc}`, () => {
             // prepare test
-            cy.task('startEmu', { wipe: true });
+            cy.task('startEmu', { version: Cypress.env('emuVersionT2'), wipe: true });
             cy.task('setupEmu', {
                 mnemonic: 'all all all all all all all all all all all all',
             });

--- a/packages/integration-tests/projects/suite-web/tests/metadata/output-labeling.test.ts
+++ b/packages/integration-tests/projects/suite-web/tests/metadata/output-labeling.test.ts
@@ -15,7 +15,7 @@ describe('Metadata - Output labeling', () => {
             const targetEl1 =
                 '@metadata/outputLabel/9f472739fa7034dfb9736fa4d98915f2e8ddf70a86ee5e0a9ac0634f8c1d0007-0/add-label-button';
             // prepare test
-            cy.task('startEmu', { wipe: true });
+            cy.task('startEmu', { version: Cypress.env('emuVersionT2'), wipe: true });
             cy.task('setupEmu', {
                 mnemonic: 'all all all all all all all all all all all all',
             });

--- a/packages/integration-tests/projects/suite-web/tests/metadata/remembered-device.test.ts
+++ b/packages/integration-tests/projects/suite-web/tests/metadata/remembered-device.test.ts
@@ -24,7 +24,7 @@ On disable, it throws away all metadata related records from memory.`, () => {
         it(f.provider, () => {
             // prepare test
             cy.task('stopBridge');
-            cy.task('startEmu', { wipe: true });
+            cy.task('startEmu', { version: Cypress.env('emuVersionT2'), wipe: true });
             cy.task('setupEmu', {
                 mnemonic: 'all all all all all all all all all all all all',
             });

--- a/packages/integration-tests/projects/suite-web/tests/metadata/switching-providers.test.ts
+++ b/packages/integration-tests/projects/suite-web/tests/metadata/switching-providers.test.ts
@@ -10,7 +10,7 @@ describe(`Metadata - switching between cloud providers`, () => {
 
     it('Start with one and switch to another', () => {
         // prepare test
-        cy.task('startEmu', { wipe: true });
+        cy.task('startEmu', { version: Cypress.env('emuVersionT2'), wipe: true });
         cy.task('setupEmu', {
             mnemonic: 'all all all all all all all all all all all all',
         });

--- a/packages/integration-tests/projects/suite-web/tests/metadata/wallet-metadata.test.ts
+++ b/packages/integration-tests/projects/suite-web/tests/metadata/wallet-metadata.test.ts
@@ -19,7 +19,7 @@ describe('Metadata - wallet labeling', () => {
     providers.forEach(provider => {
         it(provider, () => {
             // prepare test
-            cy.task('startEmu', { wipe: true, version: '2.3.1' });
+            cy.task('startEmu', { wipe: true, version: Cypress.env('emuVersionT2') });
             cy.task('setupEmu', {
                 mnemonic,
             });
@@ -57,8 +57,12 @@ describe('Metadata - wallet labeling', () => {
             cy.getTestElement('@passphrase/input').type('abc');
             cy.getTestElement('@passphrase/hidden/submit-button').click();
             cy.getTestElement('@passphrase/input').should('not.exist');
+            cy.task('pressYes');
+            cy.task('pressYes');
 
             cy.getTestElement('@passphrase/input', { timeout: 30000 }).type('abc');
+            cy.task('pressYes');
+            cy.task('pressYes');
 
             cy.getTestElement('@passphrase/confirm-checkbox').click();
             cy.getTestElement('@passphrase/hidden/submit-button').click();
@@ -71,6 +75,7 @@ describe('Metadata - wallet labeling', () => {
             cy.getConfirmActionOnDeviceModal();
             cy.task('pressYes');
             cy.getTestElement('@menu/switch-device').click();
+            cy.task('pressYes');
             cy.getTestElement(`@metadata/walletLabel/${standardWalletState}`).should(
                 'contain',
                 'wallet for drugs',

--- a/packages/integration-tests/projects/suite-web/tests/onboarding/firmware-update.test.ts
+++ b/packages/integration-tests/projects/suite-web/tests/onboarding/firmware-update.test.ts
@@ -11,7 +11,7 @@ describe('Onboarding - firmware update', () => {
     });
 
     it('firmware update error', () => {
-        cy.task('startEmu', { version: '2.1.4', wipe: true });
+        cy.task('startEmu', { version: '2.4.0', wipe: true });
         cy.getTestElement('@onboarding/continue-button').click();
         cy.getTestElement('@onboarding/continue-button').click();
 

--- a/packages/integration-tests/projects/suite-web/tests/onboarding/t1-create-wallet.test.ts
+++ b/packages/integration-tests/projects/suite-web/tests/onboarding/t1-create-wallet.test.ts
@@ -9,17 +9,17 @@ describe('Onboarding - create wallet', () => {
     });
 
     it('Success (basic)', () => {
-        cy.task('startEmu', { version: '1.9.0', wipe: true });
+        cy.task('startEmu', { version: Cypress.env('emuVersionT1'), wipe: true });
         cy.getTestElement('@onboarding/continue-button').click();
         cy.getTestElement('@onboarding/continue-button').click();
-        cy.getTestElement('@firmware/skip-button').click();
+        cy.getTestElement('@firmware/continue-button').click();
 
         cy.getTestElement('@onboarding/path-create-button').click();
         cy.getTestElement('@onboarding/only-backup-option-button').click();
 
         // todo: this sometimes fails with "device disconnected during action";
         // todo: adding huge wait here and see if it does something
-        cy.wait(5000);
+        cy.wait(1000);
 
         cy.task('pressYes');
 
@@ -46,6 +46,7 @@ describe('Onboarding - create wallet', () => {
 
         cy.log('Lets set PIN');
         cy.getTestElement('@onboarding/set-pin-button').click();
+        cy.wait(1000);
         cy.task('pressYes');
 
         cy.log('PIN mismatch for now will be enough');

--- a/packages/integration-tests/projects/suite-web/tests/onboarding/t1-recovery-advanced.test.ts
+++ b/packages/integration-tests/projects/suite-web/tests/onboarding/t1-recovery-advanced.test.ts
@@ -5,10 +5,7 @@
 
 describe('Onboarding - recover wallet T1', () => {
     beforeEach(() => {
-        // wipe: true does not work in trezor-user-env with model 1 at the moment
-        cy.task('startEmu', { version: '1.9.0' });
-        cy.task('wipeEmu');
-        cy.task('stopEmu');
+        cy.task('startEmu', { version: Cypress.env('emuVersionT1'), wipe: true });
         cy.task('startBridge');
 
         cy.viewport(1024, 768).resetDb();
@@ -16,15 +13,13 @@ describe('Onboarding - recover wallet T1', () => {
     });
 
     it('Incomplete run of advanced recovery', () => {
-        cy.task('startEmu', { version: '1.9.0' });
-
         cy.getTestElement('@onboarding/continue-button').click();
         cy.getTestElement('@onboarding/continue-button').click();
-        cy.getTestElement("@firmware/skip-button").click();
+        cy.getTestElement("@firmware/continue-button").click();
         cy.getTestElement('@onboarding/path-recovery-button').click();
 
         // cy.getTestElement('@onboarding/button-continue').click();
-        // cy.getTestElement('@firmware/skip-button').click();
+        // cy.getTestElement('@firmware/continue-button').click();
         cy.getTestElement('@recover/select-count/24').click();
         cy.getTestElement('@recover/select-type/advanced').click();
         cy.task('pressYes');
@@ -39,7 +34,7 @@ describe('Onboarding - recover wallet T1', () => {
         cy.wait(501);
         cy.task('stopEmu');
         cy.getTestElement('@connect-device-prompt', { timeout: 20000 });
-        cy.task('startEmu', { version: '1.9.0' });
+        cy.task('startEmu', { version: Cypress.env('emuVersionT1') });
 
         cy.getTestElement('@onboarding/recovery/retry-button').click();
         cy.getTestElement('@recover/select-count/12').click();
@@ -47,7 +42,7 @@ describe('Onboarding - recover wallet T1', () => {
 
         cy.task('pressYes');
         cy.getTestElement('@word-input-select/input');
-        
+
         // todo: finish reading from device. needs support in trezor-user-env
     });
 });

--- a/packages/integration-tests/projects/suite-web/tests/onboarding/t1-recovery-basic.test.ts
+++ b/packages/integration-tests/projects/suite-web/tests/onboarding/t1-recovery-basic.test.ts
@@ -6,10 +6,7 @@
 // todo: this started to fail mysteriously after merging new base image. Skipping it for now and will investigate.
 describe.skip('Onboarding - recover wallet T1', () => {
     before(() => {
-        // wipe: true does not work in trezor-user-env with model 1 at the moment
-        cy.task('startEmu', { version: '1.9.0' });
-        cy.task('wipeEmu');
-        cy.task('stopEmu');
+        cy.task('startEmu', { version: Cypress.env('emuVersionT1'), wipe: true });
         cy.task('startBridge');
 
         cy.viewport(1024, 768).resetDb();
@@ -24,9 +21,8 @@ describe.skip('Onboarding - recover wallet T1', () => {
     });
 
     it('Incomplete run of basic recovery', () => {
-        cy.task('startEmu', { version: '1.9.0' });
         cy.getTestElement('@onboarding/button-continue').click();
-        cy.getTestElement('@firmware/skip-button').click();
+        cy.getTestElement('@firmware/continue-button').click();
         cy.getTestElement('@recover/select-count/24').click();
         cy.getTestElement('@recover/select-type/basic').click();
 

--- a/packages/integration-tests/projects/suite-web/tests/onboarding/t2-create-wallet.test.ts
+++ b/packages/integration-tests/projects/suite-web/tests/onboarding/t2-create-wallet.test.ts
@@ -11,44 +11,14 @@ describe('Onboarding - create wallet', () => {
 
     });
 
-    it('Success (no shamir capability)', () => {
-
-        cy.task('startEmu', { version: '2.1.4', wipe: true });
-        cy.getTestElement('@onboarding/continue-button').click();
-        cy.getTestElement('@onboarding/continue-button').click();
-        cy.getTestElement("@firmware/skip-button").click();
-        cy.getTestElement('@onboarding/path-create-button').click();
-        cy.log(
-            'Note that this firmware does not have Shamir capability so we show only single backup option button',
-        );
-        cy.getTestElement('@onboarding/only-backup-option-button');
-        cy.getTestElement('@onboarding/shamir-backup-option-button').should('not.exist');
-        cy.getTestElement('@onboarding/only-backup-option-button').click();
-        cy.getTestElement('@onboarding/confirm-on-device').should('be.visible');
-        cy.task('pressYes');
-
-        cy.getTestElement('@onboarding/create-backup-button').click();
-
-        cy.passThroughBackup();
-
-        cy.getTestElement('@onboarding/set-pin-button').click();
-        cy.getTestElement('@onboarding/confirm-on-device');
-        cy.task('pressYes');
-        cy.task('inputEmu', '1');
-        cy.task('inputEmu', '1');
-        cy.getTestElement('@onboarding/pin/continue-button').click();
-    });
-
     it('Success (Shamir capability)', () => {
-        cy.task('startEmu', { version: '2.3.4', wipe: true });
+        cy.task('startEmu', { version: Cypress.env('emuVersionT2'), wipe: true });
         cy.getTestElement('@onboarding/continue-button').click();
         cy.getTestElement('@onboarding/continue-button').click();
-        cy.getTestElement("@firmware/skip-button").click();
+        cy.getTestElement("@firmware/continue-button").click();
         cy.getTestElement('@onboarding/path-create-button').click();
 
-        cy.log(
-            'Note that this firmware does not have Shamir capability so we show only single backup option button',
-        );
+        cy.log('Performing standard backup',);
         cy.getTestElement('@onboarding/button-standard-backup').click();
         cy.getTestElement('@onboarding/confirm-on-device').should('be.visible');
         cy.task('pressYes');

--- a/packages/integration-tests/projects/suite-web/tests/onboarding/t2-recovery-fail.test.ts
+++ b/packages/integration-tests/projects/suite-web/tests/onboarding/t2-recovery-fail.test.ts
@@ -8,11 +8,11 @@ describe('Onboarding - recover wallet T2', () => {
         cy.task('startBridge');
         cy.viewport(1024, 768).resetDb();
         cy.prefixedVisit('/');
-        cy.task('startEmu', { version: '2.1.4', wipe: true });
+        cy.task('startEmu', { version: Cypress.env('emuVersionT2'), wipe: true });
 
         cy.getTestElement('@onboarding/continue-button').click();
         cy.getTestElement('@onboarding/continue-button').click();
-        cy.getTestElement('@firmware/skip-button').click();
+        cy.getTestElement('@firmware/continue-button').click();
         cy.getTestElement('@onboarding/path-recovery-button').click();
     });
 
@@ -22,7 +22,7 @@ describe('Onboarding - recover wallet T2', () => {
         cy.wait(501);
         cy.task('stopEmu');
         cy.getTestElement('@connect-device-prompt', { timeout: 20000 });
-        cy.task('startEmu', { version: '2.1.4', wipe: false });
+        cy.task('startEmu', { version: Cypress.env('emuVersionT2'), wipe: false });
         cy.log(
             'If device disconnected during call, error page with retry button should appear. Also note, that unlike with T1, retry button initiates recoveryDevice call immediately',
         );

--- a/packages/integration-tests/projects/suite-web/tests/onboarding/t2-recovery-persistence.test.ts
+++ b/packages/integration-tests/projects/suite-web/tests/onboarding/t2-recovery-persistence.test.ts
@@ -51,18 +51,18 @@ const shareTwoOfThree = [
 describe('Onboarding - T2 in recovery mode', () => {
     beforeEach(() => {
         cy.task('startBridge');
-        cy.task('startEmu', { version: '2.3.1', wipe: true });
+        cy.task('startEmu', { version: Cypress.env('emuVersionT2'), wipe: true });
         cy.resetDb();
         cy.viewport(1024, 768);
         cy.prefixedVisit('/');
         cy.getTestElement('@onboarding/continue-button').click();
         cy.getTestElement('@onboarding/continue-button').click();
-        cy.getTestElement('@firmware/skip-button').click();
+        cy.getTestElement('@firmware/continue-button').click();
         cy.getTestElement('@onboarding/path-recovery-button').click();
     });
 
     it('Initial run with device that is already in recovery mode', () => {
-        // start recovery with some device 
+        // start recovery with some device
         cy.getTestElement('@onboarding/recovery/start-button').click();
         cy.getTestElement('@onboarding/confirm-on-device');
         cy.task('pressYes');
@@ -76,7 +76,7 @@ describe('Onboarding - T2 in recovery mode', () => {
         cy.reload();
 
         // now suite has reloaded. database is wiped.
-        cy.task('startEmu', { version: '2.3.1', wipe: false });
+        cy.task('startEmu', { version: Cypress.env('emuVersionT2'), wipe: false });
         // recovery device persisted reload
         cy.getTestElement('@onboarding/confirm-on-device');
         cy.wait(1000);
@@ -93,7 +93,7 @@ describe('Onboarding - T2 in recovery mode', () => {
         4. enter second shamir share
         5. recovery is finished
     `, () => {
-        
+
         cy.getTestElement('@onboarding/recovery/start-button').click();
         cy.getTestElement('@onboarding/confirm-on-device');
         cy.task('pressYes');
@@ -111,7 +111,7 @@ describe('Onboarding - T2 in recovery mode', () => {
         cy.task('stopEmu');
         cy.wait(1000);
         cy.getTestElement('@connect-device-prompt', { timeout: 30000 });
-        cy.task('startEmu', { version: '2.3.1', wipe: false });
+        cy.task('startEmu', { version: Cypress.env('emuVersionT2'), wipe: false });
         cy.getTestElement('@onboarding/confirm-on-device');
         cy.wait(1000);
         cy.task('pressYes');

--- a/packages/integration-tests/projects/suite-web/tests/onboarding/t2-recovery-success.test.ts
+++ b/packages/integration-tests/projects/suite-web/tests/onboarding/t2-recovery-success.test.ts
@@ -9,12 +9,10 @@ describe('Onboarding - recover wallet T2', () => {
         cy.viewport(1024, 768).resetDb();
         cy.prefixedVisit('/');
 
-        // using 2.1.4 firmware here. I don't know how to click on final screen after
-        // recovery is finished on 2.3.1 atm
-        cy.task('startEmu', { version: '2.1.4', wipe: true });
+        cy.task('startEmu', { version: Cypress.env('emuVersionT2'), wipe: true });
         cy.getTestElement('@onboarding/continue-button').click();
         cy.getTestElement('@onboarding/continue-button').click();
-        cy.getTestElement('@firmware/skip-button').click();
+        cy.getTestElement('@firmware/continue-button').click();
         cy.getTestElement('@onboarding/path-recovery-button').click();
     });
 
@@ -30,11 +28,12 @@ describe('Onboarding - recover wallet T2', () => {
         cy.task('pressYes');
         cy.wait(1000);
 
-        for (let i = 0; i <= 12; i++) {
+        for (let i = 0; i < 12; i++) {
             cy.task('inputEmu', 'all');
         }
 
-        // this does nothing with 2.3.1
+        // pressing the final Continue button
+        cy.wait(1000);
         cy.task('pressYes');
 
         // pin is tested in create path, so here we test 'skipping' path instead

--- a/packages/integration-tests/projects/suite-web/tests/recovery/t1-dry-run.test.ts
+++ b/packages/integration-tests/projects/suite-web/tests/recovery/t1-dry-run.test.ts
@@ -4,7 +4,7 @@
 
 describe.skip('Recovery - dry run', () => {
     beforeEach(() => {
-        cy.task('startEmu', { version: '1.9.0', wipe: true });
+        cy.task('startEmu', { version: Cypress.env('emuVersionT1'), wipe: true });
         cy.wait(2000);
         cy.task('setupEmu', { needs_backup: false });
         cy.task('startBridge');

--- a/packages/integration-tests/projects/suite-web/tests/recovery/t2-dry-run-persistence.test.ts
+++ b/packages/integration-tests/projects/suite-web/tests/recovery/t2-dry-run-persistence.test.ts
@@ -5,7 +5,7 @@
 
 describe('Recovery - dry run', () => {
     beforeEach(() => {
-        cy.task('startEmu', { wipe: true, version: '2.3.1' });
+        cy.task('startEmu', { wipe: true, version: Cypress.env('emuVersionT2') });
         cy.task('setupEmu', {
             mnemonic: 'all all all all all all all all all all all all',
         });
@@ -13,7 +13,9 @@ describe('Recovery - dry run', () => {
         cy.viewport(1024, 768).resetDb();
     });
 
-    it('Communication between device and application is automatically established whenever app detects device in recovery mode', () => {
+    // Test case skipped because it was unstable
+    // See the issue for more details - https://github.com/trezor/trezor-suite/issues/4128
+    it.skip('Communication between device and application is automatically established whenever app detects device in recovery mode', () => {
         cy.prefixedVisit('/');
         cy.passThroughInitialRun();
         cy.getTestElement('@suite/menu/settings').click();
@@ -34,7 +36,7 @@ describe('Recovery - dry run', () => {
         cy.task('stopEmu');
         cy.getTestElement('@recovery/close-button', { timeout: 30000 }).click();
         cy.getTestElement('@connect-device-prompt');
-        cy.task('startEmu', { wipe: false, version: '2.3.1' });
+        cy.task('startEmu', { wipe: false, version: Cypress.env('emuVersionT2') });
         cy.getTestElement('@suite/modal/confirm-action-on-device', { timeout: 20000 });
         cy.task('pressYes');
         cy.log('At this moment, communication with device should be re-established');
@@ -54,18 +56,9 @@ describe('Recovery - dry run', () => {
         cy.task('pressYes');
         cy.log('Communication established, now finish the seed check process');
 
-        cy.task('inputEmu', 'all');
-        cy.task('inputEmu', 'all');
-        cy.task('inputEmu', 'all');
-        cy.task('inputEmu', 'all');
-        cy.task('inputEmu', 'all');
-        cy.task('inputEmu', 'all');
-        cy.task('inputEmu', 'all');
-        cy.task('inputEmu', 'all');
-        cy.task('inputEmu', 'all');
-        cy.task('inputEmu', 'all');
-        cy.task('inputEmu', 'all');
-        cy.task('inputEmu', 'all');
+        for (let i = 0; i < 12; i++) {
+            cy.task('inputEmu', 'all');
+        }
         cy.task('pressYes');
 
         cy.getTestElement('@recovery/success-title');

--- a/packages/integration-tests/projects/suite-web/tests/settings/general.test.ts
+++ b/packages/integration-tests/projects/suite-web/tests/settings/general.test.ts
@@ -3,7 +3,7 @@
 
 describe('General settings', () => {
     beforeEach(() => {
-        cy.task('startEmu', { wipe: true });
+        cy.task('startEmu', { version: Cypress.env('emuVersionT2'), wipe: true });
         cy.task('setupEmu', { needs_backup: false });
         cy.task('startBridge');
         cy.viewport(1024, 768).resetDb();

--- a/packages/integration-tests/projects/suite-web/tests/settings/log.test.ts
+++ b/packages/integration-tests/projects/suite-web/tests/settings/log.test.ts
@@ -3,7 +3,7 @@
 
 describe('Log', () => {
     beforeEach(() => {
-        cy.task('startEmu', { wipe: true });
+        cy.task('startEmu', { version: Cypress.env('emuVersionT2'), wipe: true });
         cy.task('setupEmu');
         cy.task('startBridge');
         cy.viewport(1024, 768).resetDb();

--- a/packages/integration-tests/projects/suite-web/tests/settings/safety-checks.test.ts
+++ b/packages/integration-tests/projects/suite-web/tests/settings/safety-checks.test.ts
@@ -3,7 +3,7 @@
 
 describe('Safety Checks Settings', () => {
     beforeEach(() => {
-        cy.task('startEmu', { wipe: true });
+        cy.task('startEmu', { version: Cypress.env('emuVersionT2'), wipe: true });
         cy.task('setupEmu');
         cy.task('startBridge');
         cy.viewport(1024, 768).resetDb();

--- a/packages/integration-tests/projects/suite-web/tests/settings/t1-device-settings.test.ts
+++ b/packages/integration-tests/projects/suite-web/tests/settings/t1-device-settings.test.ts
@@ -3,7 +3,7 @@
 
 describe('T1 - Device settings', () => {
     it('pin mismatch', () => {
-        cy.task('startEmu', { version: '1.9.4', wipe: true });
+        cy.task('startEmu', { version: Cypress.env('emuVersionT1'), wipe: true });
         cy.task('setupEmu', { needs_backup: false });
         cy.task('startBridge');
         cy.viewport(1024, 768).resetDb();

--- a/packages/integration-tests/projects/suite-web/tests/settings/t2-device-settings.test.ts
+++ b/packages/integration-tests/projects/suite-web/tests/settings/t2-device-settings.test.ts
@@ -3,7 +3,7 @@
 
 describe('T2 - Device settings', () => {
     it('change all possible device settings', () => {
-        cy.task('startEmu', { wipe: true, version: '2.1.4' });
+        cy.task('startEmu', { wipe: true, version: Cypress.env('emuVersionT2') });
         cy.task('setupEmu');
         cy.task('startBridge');
 
@@ -53,7 +53,7 @@ describe('T2 - Device settings', () => {
     });
 
     it('backup in settings', () => {
-        cy.task('startEmu', { wipe: true });
+        cy.task('startEmu', { version: Cypress.env('emuVersionT2'), wipe: true });
         cy.task('setupEmu', { needs_backup: true });
 
         cy.viewport(1024, 768).resetDb();
@@ -80,7 +80,7 @@ describe('T2 - Device settings', () => {
     });
 
     it('wipe device', () => {
-        cy.task('startEmu', { wipe: true });
+        cy.task('startEmu', { version: Cypress.env('emuVersionT2'), wipe: true });
         cy.task('setupEmu');
 
         cy.viewport(1024, 768).resetDb();

--- a/packages/integration-tests/projects/suite-web/tests/suite/analytics.test.ts
+++ b/packages/integration-tests/projects/suite-web/tests/suite/analytics.test.ts
@@ -10,7 +10,7 @@ const timestamp = new RegExp(/^[0-9]{13,16}$/);
 
 describe('Analytics', () => {
     beforeEach(() => {
-        cy.task('startEmu', { wipe: true });
+        cy.task('startEmu', { version: Cypress.env('emuVersionT2'), wipe: true });
         cy.task('setupEmu');
         cy.task('startBridge');
         cy.viewport(1024, 768).resetDb();

--- a/packages/integration-tests/projects/suite-web/tests/suite/initial-run.test.ts
+++ b/packages/integration-tests/projects/suite-web/tests/suite/initial-run.test.ts
@@ -4,7 +4,7 @@
 describe('Suite initial run', () => {
     beforeEach(() => {
         cy.viewport(1024, 768).resetDb();
-        cy.task('startEmu', { wipe: true });
+        cy.task('startEmu', { version: Cypress.env('emuVersionT2'), wipe: true });
         cy.task('setupEmu');
         cy.task('startBridge');
     });

--- a/packages/integration-tests/projects/suite-web/tests/suite/passhprase-duplicate.test.ts
+++ b/packages/integration-tests/projects/suite-web/tests/suite/passhprase-duplicate.test.ts
@@ -3,7 +3,7 @@
 
 describe('Passphrase', () => {
     beforeEach(() => {
-        cy.task('startEmu', { wipe: true, version: '2.3.1' });
+        cy.task('startEmu', { wipe: true, version: Cypress.env('emuVersionT2') });
         cy.task('setupEmu', { passphrase_protection: true });
         cy.task('startBridge');
 
@@ -16,6 +16,8 @@ describe('Passphrase', () => {
     });
 
     it('passphrase duplicate', () => {
+        const passphraseToType = 'taxation is theft{enter}';
+
         // cy.getTestElement('@menu/switch-device').click();
         cy.getTestElement('@passphrase-type/standard').click();
         cy.getTestElement('@dashboard/loading', { timeout: 30000 });
@@ -24,16 +26,28 @@ describe('Passphrase', () => {
         // enter passphrase A for the first time
         cy.getTestElement('@menu/switch-device').click();
         cy.getTestElement('@switch-device/add-hidden-wallet-button').click();
-        cy.getTestElement('@passphrase/input').type('taxation is theft{enter}');
-        cy.getTestElement('@passphrase/input', { timeout: 10000 }).type('taxation is theft{enter}');
+        cy.getTestElement('@passphrase/input').type(passphraseToType);
+
+        cy.task('pressYes');
+        cy.task('pressYes');
+
+        cy.getTestElement('@passphrase/input', { timeout: 10000 }).type(passphraseToType);
         cy.getTestElement('@passphrase/confirm-checkbox').click();
         cy.getTestElement('@passphrase/hidden/submit-button').click();
+
+        cy.task('pressYes');
+        cy.task('pressYes');
+
         cy.getTestElement('@dashboard/loading').should('not.exist');
 
         // try to add another wallet with the same passphrase
         cy.getTestElement('@menu/switch-device').click();
         cy.getTestElement('@switch-device/add-hidden-wallet-button').click();
-        cy.getTestElement('@passphrase/input', { timeout: 10000 }).type('taxation is theft{enter}');
+
+        cy.task('pressYes');
+        cy.task('pressYes');
+
+        cy.getTestElement('@passphrase/input', { timeout: 10000 }).type(passphraseToType);
 
         // duplicate passphrase modal appears;
         cy.getTestElement('@passphrase-duplicate');

--- a/packages/integration-tests/projects/suite-web/tests/suite/passhprase-numbering.test.ts
+++ b/packages/integration-tests/projects/suite-web/tests/suite/passhprase-numbering.test.ts
@@ -3,7 +3,7 @@
 
 describe('Passphrase', () => {
     beforeEach(() => {
-        cy.task('startEmu', { wipe: true, version: '2.3.1' });
+        cy.task('startEmu', { wipe: true, version: Cypress.env('emuVersionT2') });
         cy.task('setupEmu', { passphrase_protection: true });
         cy.task('startBridge');
         // eslint-disable-next-line @typescript-eslint/naming-convention
@@ -15,6 +15,10 @@ describe('Passphrase', () => {
     });
 
     it('hidden wallet numbering', () => {
+        const passphraseOne = 'taxation is theft{enter}';
+        const passphraseTwo = 'meow{enter}';
+        const passphraseThree = 'abc{enter}';
+
         cy.getTestElement('@passphrase-type/standard').click();
         cy.getTestElement('@dashboard/loading', { timeout: 30000 });
         cy.getTestElement('@dashboard/loading', { timeout: 30000 }).should('not.exist');
@@ -22,16 +26,32 @@ describe('Passphrase', () => {
         // create standard and two hidden wallets
         cy.getTestElement('@menu/switch-device').click();
         cy.getTestElement('@switch-device/add-hidden-wallet-button').click();
-        cy.getTestElement('@passphrase/input').type('taxation is theft{enter}');
+        cy.getTestElement('@passphrase/input').type(passphraseOne);
+
+        cy.task('pressYes');
+        cy.task('pressYes');
+
         cy.getTestElement('@passphrase/input', { timeout: 10000 }).type('taxation is theft');
         cy.getTestElement('@passphrase/confirm-checkbox').click();
         cy.getTestElement('@passphrase/hidden/submit-button').click();
+
+        cy.task('pressYes');
+        cy.task('pressYes');
+
         cy.getTestElement('@dashboard/loading').should('not.exist');
         cy.getTestElement('@menu/switch-device').click();
         cy.getTestElement('@switch-device/add-hidden-wallet-button').click();
-        cy.getTestElement('@passphrase/input').type('meow{enter}');
+        cy.getTestElement('@passphrase/input').type(passphraseTwo);
+
+        cy.task('pressYes');
+        cy.task('pressYes');
+
         cy.getTestElement('@passphrase/confirm-checkbox').click();
-        cy.getTestElement('@passphrase/input').type('meow{enter}');
+        cy.getTestElement('@passphrase/input').type(passphraseTwo);
+
+        cy.task('pressYes');
+        cy.task('pressYes');
+
         cy.getTestElement('@dashboard/loading').should('not.exist');
 
         // assert that wallet labels are correct
@@ -51,9 +71,17 @@ describe('Passphrase', () => {
         cy.getTestElement('@dashboard/loading', { timeout: 30000 }).should('not.exist');
         cy.getTestElement('@menu/switch-device').click();
         cy.getTestElement('@switch-device/add-hidden-wallet-button').click();
-        cy.getTestElement('@passphrase/input').type('abc{enter}');
+        cy.getTestElement('@passphrase/input').type(passphraseThree);
+
+        cy.task('pressYes');
+        cy.task('pressYes');
+
         cy.getTestElement('@passphrase/confirm-checkbox', { timeout: 10000 }).click();
-        cy.getTestElement('@passphrase/input').type('abc{enter}');
+        cy.getTestElement('@passphrase/input').type(passphraseThree);
+
+        cy.task('pressYes');
+        cy.task('pressYes');
+
         cy.getTestElement('@dashboard/loading').should('not.exist');
 
         // assert that wallet labels are correct
@@ -65,12 +93,22 @@ describe('Passphrase', () => {
 
     // https://github.com/trezor/trezor-suite/issues/3133
     it('when user adds hidden wallet first (no pre-existing standard wallet)', () => {
+        const passphrase = 'abc{enter}';
+
         cy.getTestElement('@passphrase-type/hidden').click();
-        cy.getTestElement('@passphrase/input').type('abc{enter}');
+        cy.getTestElement('@passphrase/input').type(passphrase);
+
+        cy.task('pressYes');
+        cy.task('pressYes');
+
         cy.getTestElement('@modal');
-        cy.getTestElement('@passphrase/input', { timeout: 10000 }).type('abc');
+        cy.getTestElement('@passphrase/input', { timeout: 10000 }).type(passphrase);
         cy.getTestElement('@passphrase/confirm-checkbox').click();
         cy.getTestElement('@passphrase/hidden/submit-button').click();
+
+        cy.task('pressYes');
+        cy.task('pressYes');
+
         cy.getTestElement('@modal').should('not.exist');
         cy.getTestElement('@menu/switch-device').should('contain', 'Hidden wallet #1');
     });

--- a/packages/integration-tests/projects/suite-web/tests/suite/passphrase-disabled.test.ts
+++ b/packages/integration-tests/projects/suite-web/tests/suite/passphrase-disabled.test.ts
@@ -11,9 +11,8 @@ describe('Suite switch wallet modal', () => {
     });
 
     it('passphrase_protection: false', () => {
-        cy.task('startEmu', { wipe: true, version: '2.3.1' });
+        cy.task('startEmu', { wipe: true, version: Cypress.env('emuVersionT2') });
         cy.task('setupEmu', { passphrase_protection: false });
-        cy.task('applySettings', { passphrase_always_on_device: false });
 
         cy.prefixedVisit('/');
 
@@ -41,11 +40,20 @@ describe('Suite switch wallet modal', () => {
         cy.getTestElement('@suite/modal/confirm-action-on-device');
         cy.task('pressYes');
 
-        cy.getTestElement('@passphrase/input').type('taxation is theft{enter}');
+        const passphaseToType = 'taxation is theft{enter}';
+        cy.getTestElement('@passphrase/input').type(passphaseToType);
+
+        cy.task('pressYes');
+        cy.task('pressYes');
+
         cy.getTestElement('@modal');
-        cy.getTestElement('@passphrase/input', { timeout: 10000 }).type('taxation is theft{enter}');
+        cy.getTestElement('@passphrase/input', { timeout: 10000 }).type(passphaseToType);
         cy.getTestElement('@passphrase/confirm-checkbox').click();
         cy.getTestElement('@passphrase/hidden/submit-button').click();
+
+        cy.task('pressYes');
+        cy.task('pressYes');
+
         cy.getTestElement('@modal').should('not.exist');
 
         cy.getTestElement('@menu/switch-device').should(

--- a/packages/integration-tests/projects/suite-web/tests/suite/passphrase.test.ts
+++ b/packages/integration-tests/projects/suite-web/tests/suite/passphrase.test.ts
@@ -8,12 +8,9 @@ describe('Passphrase', () => {
     beforeEach(() => {
         // note that versions before 2.3.1 don't have passphrase caching, this means that returning
         // back to passphrase that was used before in the session would require to type the passphrase again
-        cy.task('startEmu', { wipe: true, version: '2.3.1' });
+        cy.task('startEmu', { wipe: true, version: Cypress.env('emuVersionT2') });
         cy.task('setupEmu', { mnemonic: 'all all all all all all all all all all all all' });
         cy.task('startBridge');
-
-        // eslint-disable-next-line @typescript-eslint/naming-convention
-        cy.task('applySettings', { passphrase_always_on_device: false });
 
         cy.viewport(1024, 768).resetDb();
         cy.prefixedVisit('/');
@@ -77,9 +74,17 @@ describe('Passphrase', () => {
         // first input
         cy.getTestElement('@passphrase/input').type('abc');
         cy.getTestElement('@passphrase/hidden/submit-button').click();
+
+        cy.task('pressYes');
+        cy.task('pressYes');
+
         // confirm - input wrong passphrase
         cy.getTestElement('@passphrase/confirm-checkbox', { timeout: 10000 }).click();
         cy.getTestElement('@passphrase/input').type('cba');
+
+        cy.task('pressYes');
+        cy.task('pressYes');
+
         cy.getTestElement('@passphrase/hidden/submit-button').click();
         cy.getTestElement('@toast/auth-confirm-error/close').click();
         // retry
@@ -88,6 +93,10 @@ describe('Passphrase', () => {
         cy.getTestElement('@passphrase/confirm-checkbox', { timeout: 10000 }).click();
         cy.getTestElement('@passphrase/input').type('abc');
         cy.getTestElement('@passphrase/hidden/submit-button').click();
+
+        cy.task('pressYes');
+        cy.task('pressYes');
+
         cy.getTestElement('@dashboard/wallet-ready');
         // go to wallet
         cy.getTestElement('@suite/menu/wallet-index').click();
@@ -105,10 +114,18 @@ describe('Passphrase', () => {
         cy.getTestElement('@menu/switch-device').click();
         cy.getTestElement('@switch-device/add-hidden-wallet-button').click();
         cy.getTestElement('@passphrase/input').type('def');
+
+        cy.task('pressYes');
+        cy.task('pressYes');
+
         cy.getTestElement('@passphrase/hidden/submit-button').click();
         // confirm
         cy.getTestElement('@passphrase/confirm-checkbox', { timeout: 10000 }).click();
         cy.getTestElement('@passphrase/input').type('def');
+
+        cy.task('pressYes');
+        cy.task('pressYes');
+
         cy.getTestElement('@passphrase/hidden/submit-button').click();
         cy.getTestElement('@modal').should('not.exist');
         // go to receive

--- a/packages/integration-tests/projects/suite-web/tests/suite/remembering-devices.test.ts
+++ b/packages/integration-tests/projects/suite-web/tests/suite/remembering-devices.test.ts
@@ -5,7 +5,7 @@
 
 describe('Stories of device remembering', () => {
     beforeEach(() => {
-        cy.task('startEmu', { wipe: true });
+        cy.task('startEmu', { version: Cypress.env('emuVersionT2'), wipe: true });
         cy.task('setupEmu');
         cy.task('startBridge');
         cy.viewport(1024, 768).resetDb();

--- a/packages/integration-tests/projects/suite-web/tests/suite/safety-checks-warning.test.ts
+++ b/packages/integration-tests/projects/suite-web/tests/suite/safety-checks-warning.test.ts
@@ -5,7 +5,7 @@
 // is resolved
 // describe('safety_checks Warning For PromptAlways', () => {
 //     beforeEach(() => {
-//         cy.task('startEmu', { wipe: true });
+//         cy.task('startEmu', { version: Cypress.env('emuVersionT2'), wipe: true });
 //         cy.task('setupEmu');
 //         cy.task('startBridge');
 //         cy.viewport(1024, 768).resetDb();
@@ -22,7 +22,7 @@
 
 describe('safety_checks Warning For PromptTemporarily', () => {
     beforeEach(() => {
-        cy.task('startEmu', { wipe: true });
+        cy.task('startEmu', { version: Cypress.env('emuVersionT2'), wipe: true });
         cy.task('setupEmu');
         cy.task('startBridge');
         cy.viewport(1024, 768).resetDb();

--- a/packages/integration-tests/projects/suite-web/tests/wallet/discovery.test.ts
+++ b/packages/integration-tests/projects/suite-web/tests/wallet/discovery.test.ts
@@ -7,7 +7,7 @@ const DISCOVERY_LIMIT = 1000 * 60 * 2;
 // todo: discovery does not run to end, is it only in tests?
 describe.skip('Discovery', () => {
     beforeEach(() => {
-        cy.task('startEmu', { wipe: true });
+        cy.task('startEmu', { version: Cypress.env('emuVersionT2'), wipe: true });
         cy.task('setupEmu');
         cy.task('startBridge');
         cy.viewport(1024, 768).resetDb();


### PR DESCRIPTION
Putting latest version of TT emulator (T1 may be done as well) - `2-master` wherever possible into e2e tests
Notes/issues/ideas:
- created new `clickEmu` Cypress task, even though it is not being used currently (resolved in [firmware issue](https://github.com/trezor/trezor-firmware/issues/1734)) - in that test, we were sending the "all" mnemonic 13 times instead of 12 times, so it meant the `pressYes` was not working after that
- changed the clicked firmware button - `continue-button` instead of `skip-button` - as we are always using the latest version
- lot of new emulator changes were adding confirmation on device, a lot of times it was two confirmation in a row (we can add a Cypress task `pressYesMultipleTimes(n)`)
- I have issues with some passphrase tests, where updating emulator to the latest one causes emulator initialization error: `TrezorFailure - DataError: Passphrase is not enabled`. Tried to play with arguments to `setupEmu` and `applySettings`, but could not make it work. Currently, these tests have 2.3.1 version with `TODO` above them to point out this issue
- most probably, the current commits would need to be squashed into one or two, to form a good PR, they are not good now