### PR TITLE
feat(tests): logging of test details into tenv log

### DIFF
--- a/packages/integration-tests/projects/suite-web/support/commands.ts
+++ b/packages/integration-tests/projects/suite-web/support/commands.ts
@@ -31,6 +31,10 @@ const prefixedVisit = (route: string, options?: Partial<Cypress.VisitOptions>) =
 };
 
 beforeEach(() => {
+    const suiteName = (Cypress as any).mocha.getRunner().suite.ctx.currentTest.parent.title;
+    const testName = (Cypress as any).mocha.getRunner().suite.ctx.currentTest.title;
+    cy.task('logTestDetails', `New test case: ${suiteName} - ${testName}`);
+
     cy.intercept('POST', 'http://127.0.0.1:21325/', req => {
         req.url = req.url.replace('21325', '21326');
     });


### PR DESCRIPTION
Including logs of all test cases' details into `trezor-user-env`'s `debugging.log`, so we can more easily troubleshoot specific failing tests.

Notes:
- created new specific Cypress task `logNewTestCase`, same as `logTestDetails`, just includes a prefix string (I was not able to call `logTestDetails` from `logNewTestCase`)
  - `logTestDetails` is therefore still not being used, we can send details from the middle of the tests (same info as in `cy.log`)
- my editor (VS Code) is complaining about the `const description = ...` line in all test modules that it `Cannot redeclare block-scoped variable 'description' ` - which is strange, looks as it sees all the files combined (which is maybe happening on the background, but there seems to be no error when running the tests)
- apart from the logging, some small updates to the testing code were made, where it looked appropriate (maybe it deserves its own commit)