### PR TITLE
fix(bridge): do not log error when bridge is not running

### DIFF
--- a/packages/suite-desktop/src-electron/libs/processes/BridgeProcess.ts
+++ b/packages/suite-desktop/src-electron/libs/processes/BridgeProcess.ts
@@ -29,7 +29,7 @@ class BridgeProcess extends BaseProcess {
                 }
             }
         } catch (err) {
-            this.logger.error(this.logTopic, `Status error: ${err.message}`);
+            this.logger.debug(this.logTopic, `Status error: ${err.message}`);
         }
 
         // process


### PR DESCRIPTION
I am not sure whether this approach is okay or whether it has some consequences. Is it indeed only a distinguishment of the level or does it also behave differently when changed? I mean I could imagine ERRORs being sent to Sentry for example but that is not the case right?

---

Also note that we omit the logging with Tor completely. But I think logging is always helpful so I kept it and just lowered the logging level.

https://github.com/trezor/trezor-suite/blob/ec5258b933efa6fac4ee139eec679a8455286fd8/packages/suite-desktop/src-electron/libs/processes/TorProcess.ts#L23-L25

---

Closes #3350.