### PR TITLE
chore(nix): pin nix revision to a stable commit

### DIFF
--- a/shell.nix
+++ b/shell.nix
@@ -1,8 +1,8 @@
-# the last successful build of nixos-20.09 (stable) as of 2020-10-11
+# the last successful build of nixos-21.05 (stable) as of 2021-08-02
 with import
   (builtins.fetchTarball {
-    url = "https://github.com/NixOS/nixpkgs/archive/0b8799ecaaf0dc6b4c11583a3c96ca5b40fcfdfb.tar.gz";
-    sha256 = "11m4aig6cv0zi3gbq2xn9by29cfvnsxgzf9qsvz67qr0yq29ryyz";
+    url = "https://github.com/NixOS/nixpkgs/archive/16bf3980bfa0d8929639be93fa8491ebad9d61ec.tar.gz";
+    sha256 = "0azsnd2pjg53siv97n5l62j0c8b5whi5bd5a2wqz1sphkirf3cgq";
   })
 { };
 


### PR DESCRIPTION
This updates the shell.nix to the latest stable release of nixos. We mainly want to update it because of unifying node versions ([related issue](https://github.com/satoshilabs/devops/issues/42)) across the different environments where we build the suite.
