### PR TITLE
feat(tests): option to use custom emulator version in local e2e tests

### DIFF
--- a/docker/copy-custom-emulators-into-tenv.sh
+++ b/docker/copy-custom-emulators-into-tenv.sh
@@ -1,0 +1,31 @@
+#!/usr/bin/env bash
+
+echo "Sleeping for 5 seconds for the container to fully initialize before transferring the emulator files"
+sleep 5
+
+T_ONE_EMU=""
+T_T_EMU=""
+
+# Arguments for T1 and TT emulator locations
+while getopts :o:t: option
+    do
+        case $option in
+            o) T_ONE_EMU=$OPTARG;;
+            t) T_T_EMU=$OPTARG;;
+        esac
+    done
+
+
+CONTAINER_ID=$(docker ps | grep 'trezor-user-env-unix' | awk {'print $1'})
+
+if [[ ${T_ONE_EMU} != "" ]]
+then
+    docker cp ${T_ONE_EMU} ${CONTAINER_ID}:/trezor-user-env/src/binaries/firmware/bin/trezor-emu-legacy-v1-master
+    echo "Copying ${T_ONE_EMU} into the container."
+fi
+
+if [[ ${T_T_EMU} != "" ]]
+then
+    docker cp ${T_T_EMU} ${CONTAINER_ID}:/trezor-user-env/src/binaries/firmware/bin/trezor-emu-core-v2-master
+    echo "Copying ${T_T_EMU} into the container."
+fi

--- a/docker/docker-suite-test.sh
+++ b/docker/docker-suite-test.sh
@@ -1,4 +1,9 @@
 #!/usr/bin/env bash
+# Usage for custom emulators: docker/docker-suite-test.sh -o /tmp/1-custom -t /tmp/2-custom
+# -o being for T-One location and -t for T-T location, both arguments being optional
+
+DIR=$(dirname "$0")
+
 set -e
 
 # todo: resolve selective xhost permissions
@@ -6,5 +11,14 @@ set -e
 
 xhost +
 export LOCAL_USER_ID=`id -u $USER`
+
+# When supplied with custom emulator(s), copying them into tenv container
+# Forwarding all script arguments (-o and -t) into the script and running it on
+#   the background to be able to wait until the container is running
+if [[ $# -ne 0 ]]
+then
+    echo "Copying custom emulators into the tenv container"
+    ${DIR}/copy-custom-emulators-into-tenv.sh $@ &
+fi
 
 docker-compose -f ./docker/docker-compose.suite-test.yml up --build --abort-on-container-exit


### PR DESCRIPTION
Addressing https://github.com/trezor/trezor-user-env/issues/49#:
- ability to run Suite e2e tests against a locally-built version of the emulator
- it is certainly open for improvements, it is just a running prototype

Current usage (for @matejcik):
- setting up `Suite` locally ([this](https://github.com/trezor/trezor-suite/#development)  and [this](https://github.com/trezor/trezor-suite/blob/develop/docs/tests/e2e-web.md) guide)
- building emulator version locally
- being in root of the `Suite` repo, running the testing script and giving it the locations of the custom emulator(s) - `docker/docker-suite-test.sh -o /tmp/1-custom -t /tmp/2-custom`