### PR TITLE
fix(suite): do not update passphrase mode on passphrase confirmation

### DIFF
--- a/packages/suite/src/actions/suite/modalActions.ts
+++ b/packages/suite/src/actions/suite/modalActions.ts
@@ -151,14 +151,15 @@ export const onPassphraseSubmit = (value: string, passphraseOnDevice: boolean) =
     const { device } = getState().suite;
     if (!device) return;
 
-    const hidden = passphraseOnDevice || value;
-    // call SUITE.UPDATE_PASSPHRASE_MODE action to set or remove walletNumber
-    dispatch({
-        type: SUITE.UPDATE_PASSPHRASE_MODE,
-        payload: device,
-        hidden,
-        alwaysOnDevice: passphraseOnDevice,
-    });
+    if (!device.state) {
+        // call SUITE.UPDATE_PASSPHRASE_MODE action to set or remove walletNumber
+        dispatch({
+            type: SUITE.UPDATE_PASSPHRASE_MODE,
+            payload: device,
+            hidden: passphraseOnDevice || value,
+            alwaysOnDevice: passphraseOnDevice,
+        });
+    }
 
     TrezorConnect.uiResponse({
         type: UI.RECEIVE_PASSPHRASE,


### PR DESCRIPTION
fix https://github.com/trezor/trezor-suite/issues/4108

call `SUITE.UPDATE_PASSPHRASE_MODE` only if device doesnt have state (if it already does it's a passphrase confirmation)