### PR TITLE
feat(tests): docker image containing everything for e2e tests

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -26,6 +26,7 @@ include:
   - ci/prebuild.yml
   - ci/components.yml
   - ci/build.yml
+  - ci/build-e2e.yml
   - ci/deploy.yml
   - ci/test.yml
   - ci/releases.yml

--- a/ci/build-e2e.yml
+++ b/ci/build-e2e.yml
@@ -1,0 +1,20 @@
+.build: &build
+  image: docker
+  variables:
+    CONTAINER_NAME: "$CI_REGISTRY/satoshilabs/trezor/trezor-suite/trezor-suite-e2e"
+  services:
+    - docker:dind
+  before_script:
+    - docker login $CI_REGISTRY -u $CI_REGISTRY_USER -p $CI_REGISTRY_PASSWORD
+
+build and push image:
+  stage: build
+  <<: *build
+  only:
+    - schedules  # nightly build
+    - master
+    - /^run\//
+  script:
+    - docker build --tag $CONTAINER_NAME:$CI_COMMIT_SHA --tag $CONTAINER_NAME:latest -f docker/e2e-tests/Dockerfile .
+    - docker push $CONTAINER_NAME:$CI_COMMIT_SHA
+    - docker push $CONTAINER_NAME:latest

--- a/docker/e2e-tests/.dockerignore
+++ b/docker/e2e-tests/.dockerignore
@@ -1,0 +1,2 @@
+node_modules
+.git

--- a/docker/e2e-tests/Dockerfile
+++ b/docker/e2e-tests/Dockerfile
@@ -1,0 +1,9 @@
+FROM cypress/included:6.4.0
+
+RUN mkdir /trezor-suite
+
+WORKDIR /trezor-suite
+
+COPY . /trezor-suite
+
+RUN yarn


### PR DESCRIPTION
Trying to create a standalone docker image for e2e test, that could be used elsewhere without any access to Suite code.

Use case:
- firmware CI pulling this image and running e2e tests against a freshly-build emulator (https://github.com/trezor/trezor-user-env/issues/49)