### PR TITLE
feat(invity): coinmarket input validity state improvement

### DIFF
--- a/packages/components/src/components/form/Select/index.tsx
+++ b/packages/components/src/components/form/Select/index.tsx
@@ -7,8 +7,8 @@ import ReactSelect, {
 } from 'react-select';
 import styled, { css } from 'styled-components';
 import { variables } from '../../../config';
-import { useTheme } from '../../../utils';
-import { InputVariant, SuiteThemeColors } from '../../../support/types';
+import { getStateColor, useTheme } from '../../../utils';
+import { InputVariant, InputState, SuiteThemeColors } from '../../../support/types';
 
 const selectStyle = (
     isSearchable: boolean,
@@ -19,7 +19,8 @@ const selectStyle = (
     minWidth: string,
     borderRadius: number,
     borderWidth: number,
-    theme: SuiteThemeColors
+    theme: SuiteThemeColors,
+    selectState?: InputState
 ) => ({
     singleValue: (base: Record<string, any>) => ({
         ...base,
@@ -42,6 +43,7 @@ const selectStyle = (
         { isDisabled, isFocused }: { isDisabled: boolean; isFocused: boolean }
     ) => {
         let height = variant === 'small' ? '36px' : '48px';
+        const borderColor = selectState ? getStateColor(selectState, theme) : theme.STROKE_GREY;
         if (isClean) height = '22px';
         return {
             ...base,
@@ -51,7 +53,7 @@ const selectStyle = (
             height,
             borderRadius: `${borderRadius}px`,
             borderWidth: `${borderWidth}px`,
-            borderColor: theme.STROKE_GREY,
+            borderColor,
             borderStyle: isClean ? 'none' : 'solid',
             backgroundColor: 'transparent',
             boxShadow: 'none',
@@ -59,7 +61,7 @@ const selectStyle = (
                 cursor: 'pointer',
                 borderRadius: `${borderRadius}px`,
                 borderWidth: `${borderWidth}px`,
-                borderColor: theme.STROKE_GREY,
+                borderColor,
             },
         };
     },
@@ -190,6 +192,7 @@ interface CommonProps extends Omit<SelectProps, 'components' | 'isSearchable'> {
     minWidth?: string;
     borderWidth?: number;
     borderRadius?: number;
+    state?: InputState;
 }
 
 // Make sure isSearchable can't be defined if useKeyPressScroll===true
@@ -215,6 +218,7 @@ const Select = ({
     minWidth = 'initial',
     borderWidth = 2,
     borderRadius = 4,
+    state,
     ...props
 }: Props) => {
     const selectRef: React.RefObject<ReactSelect<Option>> | null | undefined = useRef(null);
@@ -384,7 +388,8 @@ const Select = ({
                     minWidth,
                     borderRadius,
                     borderWidth,
-                    theme
+                    theme,
+                    state
                 )}
                 isSearchable={isSearchable}
                 {...props}

--- a/packages/suite/src/hooks/wallet/useCoinmarketSellForm.ts
+++ b/packages/suite/src/hooks/wallet/useCoinmarketSellForm.ts
@@ -86,7 +86,9 @@ export const useCoinmarketSellForm = (props: Props): SellFormContextValues => {
     const localCurrencyOption = { value: localCurrency, label: localCurrency.toUpperCase() };
 
     const [state, setState] = useState<ReturnType<typeof useSellState>>(undefined);
-
+    const [activeInput, setActiveInput] = useState<typeof FIAT_INPUT | typeof CRYPTO_INPUT>(
+        FIAT_INPUT,
+    );
     const { accounts, sellInfo } = useSelector(state => ({
         accounts: state.wallet.accounts,
         sellInfo: state.wallet.coinmarket.sell.sellInfo,
@@ -238,13 +240,11 @@ export const useCoinmarketSellForm = (props: Props): SellFormContextValues => {
         const composed = composedLevels[selectedFeeLevel];
         if (!composed) return;
 
-        if (composed.type === 'error') {
-            if (composed.errorMessage) {
-                setError(CRYPTO_INPUT, {
-                    type: 'compose',
-                    message: composed.errorMessage as any,
-                });
-            }
+        if (composed.type === 'error' && composed.errorMessage && activeInput === CRYPTO_INPUT) {
+            setError(CRYPTO_INPUT, {
+                type: 'compose',
+                message: composed.errorMessage as any,
+            });
         }
         // set calculated and formatted "max" value to `Amount` input
         else if (composed.type === 'final') {
@@ -263,6 +263,7 @@ export const useCoinmarketSellForm = (props: Props): SellFormContextValues => {
         setError,
         setValue,
         selectedFee,
+        activeInput,
     ]);
 
     const onSubmit = async () => {
@@ -333,6 +334,8 @@ export const useCoinmarketSellForm = (props: Props): SellFormContextValues => {
         handleClearFormButtonClick,
         formState,
         isDraft,
+        activeInput,
+        setActiveInput,
     };
 };
 

--- a/packages/suite/src/types/wallet/coinmarketSellForm.ts
+++ b/packages/suite/src/types/wallet/coinmarketSellForm.ts
@@ -76,4 +76,6 @@ export type SellFormContextValues = Omit<UseFormMethods<SellFormState>, 'registe
     handleClearFormButtonClick: () => void;
     formState: ReactHookFormState<FormState>;
     isDraft: boolean;
+    activeInput: 'fiatInput' | 'cryptoInput';
+    setActiveInput: React.Dispatch<React.SetStateAction<SellFormContextValues['activeInput']>>;
 };

--- a/packages/suite/src/views/wallet/coinmarket/buy/components/BuyForm/Inputs/index.tsx
+++ b/packages/suite/src/views/wallet/coinmarket/buy/components/BuyForm/Inputs/index.tsx
@@ -11,6 +11,7 @@ import styled from 'styled-components';
 import { isDecimalsValid } from '@wallet-utils/validation';
 import { InputError } from '@wallet-components';
 import { MAX_LENGTH } from '@suite-constants/inputs';
+import { getInputState } from '@wallet-utils/sendFormUtils';
 
 const Wrapper = styled.div`
     display: flex;
@@ -66,6 +67,7 @@ const Inputs = () => {
         setAmountLimits,
         defaultCurrency,
         cryptoInputValue,
+        getValues,
     } = useCoinmarketBuyFormContext();
     const { symbol } = account;
     const uppercaseSymbol = symbol.toUpperCase();
@@ -82,6 +84,8 @@ const Inputs = () => {
     useEffect(() => {
         trigger([activeInput]);
     }, [activeInput, amountLimits, trigger]);
+
+    const fiatInputValue = getValues('fiatInput');
 
     return (
         <Wrapper>
@@ -152,7 +156,7 @@ const Inputs = () => {
                         setValue(cryptoInput, '');
                         clearErrors(cryptoInput);
                     }}
-                    state={errors[fiatInput] ? 'error' : undefined}
+                    state={getInputState(errors.fiatInput, fiatInputValue)}
                     name={fiatInput}
                     maxLength={MAX_LENGTH.AMOUNT}
                     bottomText={<InputError error={errors[fiatInput]} />}
@@ -194,7 +198,7 @@ const Inputs = () => {
                         setValue(fiatInput, '');
                         clearErrors(fiatInput);
                     }}
-                    state={errors[cryptoInput] ? 'error' : undefined}
+                    state={getInputState(errors.cryptoInput, cryptoInputValue)}
                     name={cryptoInput}
                     noTopLabel
                     maxLength={MAX_LENGTH.AMOUNT}

--- a/packages/suite/src/views/wallet/coinmarket/exchange/components/ExchangeForm/Inputs/FiatInput/index.tsx
+++ b/packages/suite/src/views/wallet/coinmarket/exchange/components/ExchangeForm/Inputs/FiatInput/index.tsx
@@ -9,6 +9,7 @@ import FiatSelect from './FiatSelect';
 import BigNumber from 'bignumber.js';
 import { MAX_LENGTH } from '@suite-constants/inputs';
 import { CRYPTO_INPUT, FIAT_INPUT } from '@suite/types/wallet/coinmarketExchangeForm';
+import { getInputState } from '@suite/utils/wallet/sendFormUtils';
 
 const StyledInput = styled(Input)`
     border-left: 0;
@@ -17,11 +18,22 @@ const StyledInput = styled(Input)`
 `;
 
 const FiatInput = () => {
-    const { register, network, clearErrors, errors, trigger, updateSendCryptoValue, setValue } =
-        useCoinmarketExchangeFormContext();
+    const {
+        register,
+        network,
+        clearErrors,
+        errors,
+        trigger,
+        updateSendCryptoValue,
+        setValue,
+        getValues,
+    } = useCoinmarketExchangeFormContext();
 
-    const error = errors.outputs && errors.outputs[0] ? errors.outputs[0].fiat : undefined;
+    const amountError = errors.outputs?.[0]?.amount;
+    const fiatError = errors.outputs?.[0]?.fiat;
 
+    const { outputs } = getValues();
+    const fiat = outputs?.[0]?.fiat;
     return (
         <StyledInput
             onFocus={() => {
@@ -29,14 +41,14 @@ const FiatInput = () => {
             }}
             onChange={event => {
                 setValue('setMaxOutputId', undefined);
-                if (error) {
+                if (fiatError) {
                     setValue(CRYPTO_INPUT, '');
                 } else {
                     updateSendCryptoValue(event.target.value, network.decimals);
                     clearErrors(FIAT_INPUT);
                 }
             }}
-            state={error ? 'error' : undefined}
+            state={getInputState(fiatError || amountError, fiat)}
             name={FIAT_INPUT}
             noTopLabel
             maxLength={MAX_LENGTH.AMOUNT}
@@ -63,7 +75,7 @@ const FiatInput = () => {
                     }
                 },
             })}
-            bottomText={<InputError error={error} />}
+            bottomText={<InputError error={fiatError} />}
             innerAddon={<FiatSelect />}
         />
     );

--- a/packages/suite/src/views/wallet/coinmarket/exchange/components/ExchangeForm/Inputs/ReceiveCryptoSelect/index.tsx
+++ b/packages/suite/src/views/wallet/coinmarket/exchange/components/ExchangeForm/Inputs/ReceiveCryptoSelect/index.tsx
@@ -8,8 +8,8 @@ import { useCoinmarketExchangeFormContext } from '@wallet-hooks/useCoinmarketExc
 import { Translation } from '@suite-components';
 import { Account } from '@wallet-types';
 import invityAPI from '@suite-services/invityAPI';
-import { CRYPTO_TOKEN } from '@wallet-types/coinmarketExchangeForm';
 import { symbolToInvityApiSymbol } from '@suite/utils/wallet/coinmarket/coinmarketUtils';
+import { getInputState } from '@suite/utils/wallet/sendFormUtils';
 
 const Wrapper = styled.div`
     display: flex;
@@ -108,7 +108,7 @@ const buildOptions = (
 };
 
 const ReceiveCryptoSelect = () => {
-    const { control, setAmountLimits, exchangeInfo, exchangeCoinInfo, account, getValues } =
+    const { control, setAmountLimits, exchangeInfo, exchangeCoinInfo, account, getValues, errors } =
         useCoinmarketExchangeFormContext();
 
     const customSearch = (
@@ -124,9 +124,9 @@ const ReceiveCryptoSelect = () => {
         return false;
     };
 
-    const tokenAddress = getValues(CRYPTO_TOKEN);
-    const tokenData = account.tokens?.find(t => t.address === tokenAddress);
-
+    const { outputs, receiveCryptoSelect } = getValues();
+    const token = outputs?.[0]?.token;
+    const tokenData = account.tokens?.find(t => t.address === token);
     return (
         <Wrapper>
             <Controller
@@ -134,6 +134,10 @@ const ReceiveCryptoSelect = () => {
                 name="receiveCryptoSelect"
                 render={({ onChange, value }) => (
                     <Select
+                        state={getInputState(
+                            errors.receiveCryptoSelect,
+                            receiveCryptoSelect?.value,
+                        )}
                         onChange={(selected: any) => {
                             onChange(selected);
                             setAmountLimits(undefined);

--- a/packages/suite/src/views/wallet/coinmarket/sell/components/SellForm/Inputs/CryptoInput/index.tsx
+++ b/packages/suite/src/views/wallet/coinmarket/sell/components/SellForm/Inputs/CryptoInput/index.tsx
@@ -13,6 +13,7 @@ import {
     CRYPTO_INPUT,
     FIAT_INPUT,
 } from '@suite/types/wallet/coinmarketSellForm';
+import { getInputState } from '@suite/utils/wallet/sendFormUtils';
 
 interface Props {
     activeInput: typeof FIAT_INPUT | typeof CRYPTO_INPUT;
@@ -38,6 +39,7 @@ const CryptoInput = ({ activeInput, setActiveInput }: Props) => {
         formState,
         amountLimits,
         onCryptoAmountChange,
+        getValues,
     } = useCoinmarketSellFormContext();
 
     const uppercaseSymbol = account.symbol.toUpperCase();
@@ -45,6 +47,8 @@ const CryptoInput = ({ activeInput, setActiveInput }: Props) => {
         value: uppercaseSymbol,
         label: uppercaseSymbol,
     };
+
+    const cryptoInputValue = getValues(CRYPTO_INPUT);
 
     return (
         <Input
@@ -56,7 +60,7 @@ const CryptoInput = ({ activeInput, setActiveInput }: Props) => {
                 onCryptoAmountChange(event.target.value);
             }}
             defaultValue=""
-            state={errors[CRYPTO_INPUT] ? 'error' : undefined}
+            state={getInputState(errors.cryptoInput, cryptoInputValue)}
             name={CRYPTO_INPUT}
             noTopLabel
             maxLength={MAX_LENGTH.AMOUNT}

--- a/packages/suite/src/views/wallet/coinmarket/sell/components/SellForm/Inputs/FiatInput/index.tsx
+++ b/packages/suite/src/views/wallet/coinmarket/sell/components/SellForm/Inputs/FiatInput/index.tsx
@@ -14,6 +14,7 @@ import {
     FIAT_CURRENCY_SELECT,
     FIAT_INPUT,
 } from '@suite/types/wallet/coinmarketSellForm';
+import { getInputState } from '@suite/utils/wallet/sendFormUtils';
 
 interface Props {
     activeInput: typeof FIAT_INPUT | typeof CRYPTO_INPUT;
@@ -32,7 +33,10 @@ const FiatInput = ({ activeInput, setActiveInput }: Props) => {
         defaultCurrency,
         quotesRequest,
         onFiatAmountChange,
+        getValues,
     } = useCoinmarketSellFormContext();
+
+    const fiatInputValue = getValues(FIAT_INPUT);
 
     return (
         <Input
@@ -101,7 +105,7 @@ const FiatInput = ({ activeInput, setActiveInput }: Props) => {
                 setActiveInput(FIAT_INPUT);
                 onFiatAmountChange(event.target.value);
             }}
-            state={errors[FIAT_INPUT] ? 'error' : undefined}
+            state={getInputState(errors.fiatInput, fiatInputValue)}
             name={FIAT_INPUT}
             maxLength={MAX_LENGTH.AMOUNT}
             bottomText={<InputError error={errors[FIAT_INPUT]} />}

--- a/packages/suite/src/views/wallet/coinmarket/sell/components/SellForm/Inputs/index.tsx
+++ b/packages/suite/src/views/wallet/coinmarket/sell/components/SellForm/Inputs/index.tsx
@@ -1,5 +1,5 @@
 import { Icon, variables } from '@trezor/components';
-import React, { useCallback, useEffect, useState } from 'react';
+import React, { useCallback, useEffect } from 'react';
 import { useCoinmarketSellFormContext } from '@wallet-hooks/useCoinmarketSellForm';
 import styled from 'styled-components';
 import FiatInput from './FiatInput';
@@ -68,10 +68,9 @@ const Inputs = () => {
         setValue,
         clearErrors,
         onCryptoAmountChange,
+        activeInput,
+        setActiveInput,
     } = useCoinmarketSellFormContext();
-    const [activeInput, setActiveInput] = useState<typeof FIAT_INPUT | typeof CRYPTO_INPUT>(
-        FIAT_INPUT,
-    );
 
     // if FIAT_INPUT has a valid value, set it as the activeInput
     if (watch(FIAT_INPUT) && !errors[FIAT_INPUT] && activeInput === CRYPTO_INPUT) {
@@ -96,7 +95,14 @@ const Inputs = () => {
             setActiveInput(CRYPTO_INPUT);
             onCryptoAmountChange(amount);
         },
-        [account.formattedBalance, clearErrors, network.decimals, onCryptoAmountChange, setValue],
+        [
+            account.formattedBalance,
+            clearErrors,
+            network.decimals,
+            onCryptoAmountChange,
+            setActiveInput,
+            setValue,
+        ],
     );
 
     const setAllAmount = useCallback(() => {
@@ -106,7 +112,7 @@ const Inputs = () => {
         clearErrors([FIAT_INPUT, CRYPTO_INPUT]);
         setActiveInput(CRYPTO_INPUT);
         composeRequest(CRYPTO_INPUT);
-    }, [clearErrors, composeRequest, setValue]);
+    }, [clearErrors, composeRequest, setActiveInput, setValue]);
 
     const isBalanceZero = new BigNumber(account.formattedBalance).isZero();
 


### PR DESCRIPTION
**User story**
> As a user, I want to be informed whether my input into any coin market form (buy, sell, exchange) is valid or not, so I can continue in trade or input valid values.

Invalid input fields are already rendered with a red border and error message. This commit adds rendering valid input fields with a green appearance.

Please be aware of change in `packages/components/src/components/form/Select/index.tsx` especially. I have been told that the `Select` component should be reviewed by someone who is responsible for the general components in Suite. The suggestion was @matejkriz. Please Matěj, could you review the Select component or recommend/assign someone else?