### PR TITLE
fix(suite): do not offer intermediary FW for Model T

### DIFF
--- a/packages/rollout/src/index.ts
+++ b/packages/rollout/src/index.ts
@@ -214,20 +214,18 @@ export const getBinary = async ({
     intermediary = false,
 }: GetBinaryProps) => {
     const parsedFeatures = parseFeatures(features);
-    const infoByBootloader = getInfo({ features, releases });
 
-    let releaseByFirmware;
-
-    if (!intermediary) {
-        // we get info here again, but only as a sanity check.
-        releaseByFirmware = releases.find(r => versionUtils.isEqual(r.version, version!));
-
-        if (!infoByBootloader || !releaseByFirmware) {
-            throw new Error('no firmware found for this device');
-        }
-    } else {
+    if (intermediary && parsedFeatures.major_version !== 2) {
         const fw = await fetchFirmware(`${baseUrl}/firmware/1/trezor-inter-1.10.0.bin`);
         return { binary: modifyFirmware({ fw, features: parsedFeatures }) };
+    }
+
+    // we get info here again, but only as a sanity check.
+    const infoByBootloader = getInfo({ features, releases });
+    const releaseByFirmware = releases.find(r => versionUtils.isEqual(r.version, version!));
+
+    if (!infoByBootloader || !releaseByFirmware) {
+        throw new Error('no firmware found for this device');
     }
 
     if (btcOnly && !releaseByFirmware.url_bitcoinonly) {

--- a/packages/suite/src/actions/firmware/firmwareActions.ts
+++ b/packages/suite/src/actions/firmware/firmwareActions.ts
@@ -97,7 +97,7 @@ const firmwareInstall =
             // update to same variant as is currently installed or to the regular one if device does not have any fw (new/wiped device)
             const isBtcOnlyFirmware = !prevDevice ? false : isBitcoinOnly(prevDevice);
 
-            const intermediary = !toRelease.isLatest;
+            const intermediary = model === 1 && !toRelease.isLatest;
             if (intermediary) {
                 console.warn(
                     'Cannot install latest firmware. Will install intermediary fw instead.',

--- a/packages/suite/src/utils/suite/device.ts
+++ b/packages/suite/src/utils/suite/device.ts
@@ -142,8 +142,9 @@ export const getFwVersion = (device: KnownDevice) => {
 };
 
 export const getFwUpdateVersion = (device: AcquiredDevice) => {
-    // thanks to intermediary FW we are always able to upgrade to the latest version
-    const version = device.firmwareRelease?.latest?.version;
+    // Thanks to intermediary FW we are always able to upgrade to the latest version on Model one.
+    const supportIntermediary = device.features.major_version === 1;
+    const version = device.firmwareRelease?.[supportIntermediary ? 'latest' : 'release']?.version;
     return version?.join('.') || null;
 };
 


### PR DESCRIPTION
fix #4135 

- It's an issue for T devices with FW older than 2.0.8 only, newer FW could install the latest FW so far.