### PR TITLE
chore: make TR_PENDING_TX_HEADING key more flexible

### DIFF
--- a/packages/suite/src/support/messages.ts
+++ b/packages/suite/src/support/messages.ts
@@ -2365,7 +2365,7 @@ const definedMessages = defineMessages({
         id: 'TR_PASSPHRASE_WALLET',
     },
     TR_PENDING_TX_HEADING: {
-        defaultMessage: 'Pending {count, plural, one {transaction} other {transactions}}',
+        defaultMessage: '{count, plural, one {Pending transaction} other {Pending transactions}}',
         description: 'Heading for the list of pending transactions',
         id: 'TR_PENDING_TX_HEADING',
     },


### PR DESCRIPTION
Changing source string to allow more flexible pluralisation of adjective also.


```
new IntlMessageFormat(
  `{count, plural, one {Pending transaction} other {Pending transactions}}`,
  'en-US'
).format({count: 2})
``` 
--> Pending transactions

```
new IntlMessageFormat(
  `{count, plural, one {Pending transaction} other {Pending transactions}}`,
  'en-US'
).format({count: 1})
``` 
--> Pending transaction

https://formatjs.io/docs/intl-messageformat

I guess spanish people need something like "2 transactions pendiges" vs. "1 transaction pending" :D 

Close #4059