### PR TITLE
fix(suite): fix intermediary FW installation loop

### DIFF
--- a/packages/suite/src/reducers/firmware/firmwareReducer.ts
+++ b/packages/suite/src/reducers/firmware/firmwareReducer.ts
@@ -80,6 +80,11 @@ const firmwareUpdate = (state: FirmwareUpdateState = initialState, action: Actio
                 break;
             case FIRMWARE.SET_INTERMEDIARY_INSTALLED:
                 draft.intermediaryInstalled = action.payload;
+                if (draft.targetRelease) {
+                    // intermediary is already installed so latest release has to be used as new target release
+                    draft.targetRelease.release = draft.targetRelease.latest;
+                    draft.targetRelease.isLatest = true;
+                }
                 break;
 
             case SUITE.ADD_BUTTON_REQUEST:


### PR DESCRIPTION
fixi #4129 

- Setting latest FW as next targetRelease once intermediary is installed.
- After instalation of intermediary FW on already initialized devices the status is not going to 'waiting-for-bootloader' so the targetRelease is not reset (see firmwareMiddleware.ts)