### PR TITLE
fix(tests): updating expected message in new account e2e test

### DIFF
--- a/packages/integration-tests/projects/suite-web/tests/suite/new-account-message.test.ts
+++ b/packages/integration-tests/projects/suite-web/tests/suite/new-account-message.test.ts
@@ -2,24 +2,24 @@
 // @retry=2
 
 describe('New accounts', () => {
-        beforeEach(() => {
-             // Launches Trezor emulator
-            cy.task('startEmu', { wipe: true });
-            // Initializes Trezor (random seed)
-            cy.task('setupEmu', { needs_backup: false });
-            cy.task('startBridge');
-            cy.viewport(1024, 768).resetDb();
-            cy.prefixedVisit('/');
-            cy.passThroughInitialRun();
-            cy.discoveryShouldFinish();
-        });
-    
+    beforeEach(() => {
+        // Launches Trezor emulator
+        cy.task('startEmu', { wipe: true });
+        // Initializes Trezor (random seed)
+        cy.task('setupEmu', { needs_backup: false });
+        cy.task('startBridge');
+        cy.viewport(1024, 768).resetDb();
+        cy.prefixedVisit('/');
+        cy.passThroughInitialRun();
+        cy.discoveryShouldFinish();
+    });
 
-    it('Goes to accounts and verifies that the "New default Accounts natively.." is displayed:', () => {
+    const expectedAccountMessage = 'New to Trezor Suite: BTC Bech32 accounts!';
+    it(`Goes to accounts and verifies that the "${expectedAccountMessage}" is displayed:`, () => {
         cy.getTestElement('@suite/menu/wallet-index').click();
         cy.getTestElement('@accounts/empty-account/receive');
         cy.getTestElement('@accounts/empty-account/default-native-account/close');
-        cy.contains('New default Accounts natively in Trezor Suite!');
+        cy.contains(expectedAccountMessage);
         // Clicks on Got it!
         cy.getTestElement('@accounts/empty-account/default-native-account/close').click({
             scrollBehavior: 'bottom',
@@ -28,13 +28,13 @@ describe('New accounts', () => {
         cy.getTestElement('@accounts/empty-account/receive');
         cy.getTestElement('@accounts/empty-account/buy');
         cy.getTestElement('@accounts/empty-account/default-native-account/close').should('not.exist');
-        cy.contains('New default Accounts natively in Trezor Suite!').should('not.exist');
+        cy.contains(expectedAccountMessage).should('not.exist');
         // Reload page.
         cy.reload();
         // Makes sure it is still gone.
         cy.getTestElement('@accounts/empty-account/receive');
         cy.getTestElement('@accounts/empty-account/buy');
         cy.getTestElement('@accounts/empty-account/default-native-account/close').should('not.exist');
-        cy.contains('New default Accounts natively in Trezor Suite!').should('not.exist');
+        cy.contains(expectedAccountMessage).should('not.exist');
     });
 });


### PR DESCRIPTION
Addressing issue discussed in https://github.com/trezor/trezor-suite/pull/4079:
- changing expected message shown when new accounts are displayed (old message was no longer valid)