### PR TITLE
Feat/bundle fw

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -9,6 +9,7 @@ packages/suite-data/files/bin/tor/mac-*/tor filter=lfs diff=lfs merge=lfs -text
 packages/suite-data/files/bin/tor/win-*/*.dll filter=lfs diff=lfs merge=lfs -text
 packages/suite-data/files/bin/tor/win-*/tor.exe filter=lfs diff=lfs merge=lfs -text
 packages/integration-tests/projects/suite-web/snapshots/** filter=lfs diff=lfs merge=lfs -text
-
+packages/connect-common/files/firmware/1/*.bin filter=lfs diff=lfs merge=lfs -text
+packages/connect-common/files/firmware/2/*.bin filter=lfs diff=lfs merge=lfs -text
 # Changelog to be merged via union always.
 CHANGELOG.md merge=union

--- a/docs/releases/adding-new-firmwares.md
+++ b/docs/releases/adding-new-firmwares.md
@@ -1,25 +1,23 @@
 # Adding New Firmwares
 
-In case we are about to release both Suite and firmwares we want to add the signed firmwares during the Freeze so QA has the whole thing to test.
+In case we are about to release both Suite and firmwares we want to add the signed binaries during the Freeze so QA has the whole thing to test.
+
+Binaries and release definitions are stored in `packages/connect-common/files/firmware/*` in the same data structure as they were in the past (data.trezor.io). They are used by `suite-web` and `suite-desktop` builds.
+
+Package `@trezor/connect-common` is a public NPM package used as dependency of `trezor-connect`.
 
 ## Add firmwares
 
 1. Complete the firmware release process including firmware signing.
-2. Add firmwares to [webwallet-data](https://github.com/trezor/webwallet-data/) and modify its `releases.json` file. See e.g. [a1831647](https://github.com/trezor/webwallet-data/commit/f8ed15a8999689e7692b8fc4c00b7aaef25d8011) for an example.
-3. Deploy them to data.trezor.io. _This is currently done manually and should be automated._
-4. Modify `releases.json` in Connect. See [5350f7ee](https://github.com/trezor/connect/commit/5350f7eef30a2137127636e8d8c42238ddc0d14c) for example.
-
-## Publish Connect to NPM and bump in Suite
-
-5. Publish Connect as beta. See [Connect: Updating NPM to beta](https://github.com/trezor/connect/blob/db7139e2cd22dd0d9ea9dc3f0725dbd13a57f691/docs/deployment/index.md#beta) on how to do that.
-6. Bump Connect in Suite. See [connect/bump.md](../packages/connect/bump.md).
+1. Add firmwares to `packages/connect-common/files/firmware/*` and modify its `releases.json` file. See e.g. [a1831647](https://github.com/trezor/webwallet-data/commit/f8ed15a8999689e7692b8fc4c00b7aaef25d8011) for an example.
+1. `git lfs push --all origin [YOUR-BRANCH-NAME]`
+1. Optionally if you want to test it locally run `yarn workspace @trezor/connect-iframe build:lib` to rebuild connect files and `yarn workspace @trezor/suite-web dev` to use/copy them.
 
 ## Freeze & Release
 
-7. Freeze Suite. At this moment you are all good to _Freeze_ and forward to QA. They should be able to test Suite in its wholeness along with the new firmwares. [1]
-8. If QA gives a go-ahead we release.
-9. Publish Connect to production.
-	1. To connect.trezor.io, see [Connect: Updating NPM to production](https://github.com/trezor/connect/blob/db7139e2cd22dd0d9ea9dc3f0725dbd13a57f691/docs/deployment/index.md#production).
-	2. To NPM, see [this](https://github.com/trezor/connect/blob/db7139e2cd22dd0d9ea9dc3f0725dbd13a57f691/docs/deployment/index.md#production).
+1. Freeze Suite. At this moment you are all good to _Freeze_ and forward to QA. They should be able to test Suite in its wholeness along with the new firmwares.
+1. If QA gives a go-ahead we release. From suite point of view there is nothing else to do, it may be released as it is.
+1. If we want to offer new releases to the users of 3rd-party applications (using connect popup) we need to publish `@trezor/connect-common` to npm registry and use new releases in `trezor-connect`.
+	1. Update dependency of `trezor-connect`
+	1. Follow instructions [how to deploy connect to production](https://github.com/trezor/connect/blob/83af30f73f4cfa7c099c55b2b0f8a103abc299c8/docs/deployment/index.md).
 
-[1] Note that at this moment you have a `-beta` version of Connect bundled in Suite. This however does not pose any problem. We simply release Suite with this `-beta` version and publish Connect production version later.

--- a/packages/connect-common/.npmignore
+++ b/packages/connect-common/.npmignore
@@ -13,6 +13,7 @@ tsconfig.lib.json
 src
 scripts
 docs
+*.bin
 
 # Editors
 .editorconfig

--- a/packages/connect-common/files/firmware/1/trezor-1.10.2-bitcoinonly.bin
+++ b/packages/connect-common/files/firmware/1/trezor-1.10.2-bitcoinonly.bin
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:81e71710e289728aafcff2a2508d7882e14961a8b1ae8afd263af953a415a6f5
+size 439196

--- a/packages/connect-common/files/firmware/1/trezor-1.10.2.bin
+++ b/packages/connect-common/files/firmware/1/trezor-1.10.2.bin
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:7ed716b2813f8b81983700e6d286f6ff17a17e830cb85954fe31e9a7ec9388b8
+size 595684

--- a/packages/connect-common/files/firmware/1/trezor-inter-1.10.0.bin
+++ b/packages/connect-common/files/firmware/1/trezor-inter-1.10.0.bin
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:7c3d63d6fc8e7d378256e9ac487a76031921e7075619aa34102e3f53fef07d1b
+size 46008

--- a/packages/connect-common/files/firmware/2/trezor-2.4.1-bitcoinonly.bin
+++ b/packages/connect-common/files/firmware/2/trezor-2.4.1-bitcoinonly.bin
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:bd201becc85122c9cfdd1bc88cc0ac02fd9c4bafb48840250d1462fe28e826ec
+size 1104384

--- a/packages/connect-common/files/firmware/2/trezor-2.4.1.bin
+++ b/packages/connect-common/files/firmware/2/trezor-2.4.1.bin
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:b8925f4fcfd34f3b8cfdcbcf68183565953f14f00448e437f68b8cd8c6abb6e0
+size 1504768

--- a/packages/suite/src/actions/firmware/firmwareActions.ts
+++ b/packages/suite/src/actions/firmware/firmwareActions.ts
@@ -5,6 +5,7 @@ import TrezorConnect, { Device } from 'trezor-connect';
 import { FIRMWARE } from '@firmware-actions/constants';
 import { report, AnalyticsEvent } from '@suite-actions/analyticsActions';
 import { getFwVersion, isBitcoinOnly } from '@suite-utils/device';
+import { resolveStaticPath } from '@suite-utils/build';
 
 import type { Dispatch, GetState, AppState, AcquiredDevice } from '@suite-types';
 import { addToast } from '@suite-actions/notificationActions';
@@ -117,6 +118,8 @@ const firmwareInstall =
                 device: {
                     path: device.path,
                 },
+                // FW binaries are stored in "*/static/connect/data/firmware/*/*.bin". see "connect-common" package
+                baseUrl: resolveStaticPath('connect/data'),
                 btcOnly: isBtcOnlyFirmware,
                 version: toRelease.release.version,
                 // if we detect latest firmware may not be used right away, we should use intermediary instead


### PR DESCRIPTION
General idea is to have firmware binaries bundled with application files (same as bridge or tor)
Firmware update/onboarding should be available even without internet connection (only in desktop app of course)
Binaries are stored in suite build files structure from where they are downloaded.
data.trezor.io is no longer used by suite.

fix https://github.com/trezor/trezor-suite/issues/3738