### PR TITLE
fix(ci): update variable to use direct dependency proxy instead of top level group proxy

### DIFF
--- a/ci/build.yml
+++ b/ci/build.yml
@@ -218,7 +218,7 @@ suite-desktop build windows:
   <<: *config_sign_dev
   only:
     <<: *run_everything_rules
-  image: $CI_DEPENDENCY_PROXY_GROUP_IMAGE_PREFIX/electronuserland/builder:wine
+  image: $CI_DEPENDENCY_PROXY_DIRECT_GROUP_IMAGE_PREFIX/electronuserland/builder:wine
   variables:
     artifact: ${DESKTOP_APP_NAME}*
     platform: win
@@ -229,7 +229,7 @@ suite-desktop build windows manual:
   when: manual
   except:
     <<: *run_everything_rules
-  image: $CI_DEPENDENCY_PROXY_GROUP_IMAGE_PREFIX/electronuserland/builder:wine
+  image: $CI_DEPENDENCY_PROXY_DIRECT_GROUP_IMAGE_PREFIX/electronuserland/builder:wine
   variables:
     artifact: ${DESKTOP_APP_NAME}*
     platform: win
@@ -242,7 +242,7 @@ suite-desktop build windows codesign:
       - codesign
   tags:
     - darwin
-  image: $CI_DEPENDENCY_PROXY_GROUP_IMAGE_PREFIX/electronuserland/builder:wine
+  image: $CI_DEPENDENCY_PROXY_DIRECT_GROUP_IMAGE_PREFIX/electronuserland/builder:wine
   variables:
     IS_CODESIGN_BUILD: "true"
     artifact: ${DESKTOP_APP_NAME}*
@@ -259,7 +259,7 @@ suite-desktop build windows codesign:
 
 ## Suite mobile Android app
 suite-native build android:
-  image: $CI_DEPENDENCY_PROXY_GROUP_IMAGE_PREFIX/reactnativecommunity/react-native-android
+  image: $CI_DEPENDENCY_PROXY_DIRECT_GROUP_IMAGE_PREFIX/reactnativecommunity/react-native-android
   stage: build
   only:
     <<: *run_everything_rules

--- a/ci/environment.yml
+++ b/ci/environment.yml
@@ -7,12 +7,12 @@ build & push image:
   variables:
     DOCKER_TLS_CERTDIR: ''
     CONTAINER_NAME: "$CI_REGISTRY/satoshilabs/trezor/trezor-suite/base"
-  image: $CI_DEPENDENCY_PROXY_GROUP_IMAGE_PREFIX/docker
+  image: $CI_DEPENDENCY_PROXY_DIRECT_GROUP_IMAGE_PREFIX/docker
   services:
     - docker:dind
   script:
     - docker pull $CONTAINER_NAME:latest || true
-    - docker build --build-arg CI_DOCKER_PROXY="$CI_DEPENDENCY_PROXY_GROUP_IMAGE_PREFIX/" --no-cache --tag $CONTAINER_NAME:$CI_COMMIT_SHA --tag $CONTAINER_NAME:latest ./docker/ci-base
+    - docker build --build-arg CI_DOCKER_PROXY="$CI_DEPENDENCY_PROXY_DIRECT_GROUP_IMAGE_PREFIX/" --no-cache --tag $CONTAINER_NAME:$CI_COMMIT_SHA --tag $CONTAINER_NAME:latest ./docker/ci-base
     - docker push $CONTAINER_NAME:$CI_COMMIT_SHA
     - docker push $CONTAINER_NAME:latest
 

--- a/docker/docker-compose.suite-ci.yml
+++ b/docker/docker-compose.suite-ci.yml
@@ -7,7 +7,7 @@ services:
       - XDG_RUNTIME_DIR=/var/tmp
     network_mode: bridge # this makes docker reuse existing networks
   test-run:
-    image: $CI_DEPENDENCY_PROXY_GROUP_IMAGE_PREFIX/cypress/included:6.4.0
+    image: $CI_DEPENDENCY_PROXY_DIRECT_GROUP_IMAGE_PREFIX/cypress/included:6.4.0
     entrypoint: []
     environment:
       - CYPRESS_SNAPSHOT=$CYPRESS_SNAPSHOT


### PR DESCRIPTION
This pr fixes issue with permissions on GitLab when retrying jobs by dev account. This will now use a subgroup dependency proxy and allow for retrying and pulling images for this group.