### PR TITLE
fix(suite): show specific error message when pkexec returns 126

### DIFF
--- a/packages/suite-desktop/src-electron/modules/udev-install.ts
+++ b/packages/suite-desktop/src-electron/modules/udev-install.ts
@@ -63,6 +63,8 @@ const init = () => {
                 logger.debug('udev', `pkexec exit with code ${code}`);
                 if (code === 0) {
                     resolve({ success: true });
+                } else if (code === 126) {
+                    resolve({ success: false, error: `pkexec authentication dialog dismissed` });
                 } else {
                     resolve({ success: false, error: `pkexec exit with code ${code}` });
                 }


### PR DESCRIPTION
From the documentation: https://www.freedesktop.org/software/polkit/docs/latest/pkexec.1.html#pkexec-return-value

> Upon successful completion, the return value is the return value of PROGRAM. If the calling process is not authorized or an authorization could not be obtained through authentication or an error occured, pkexec exits with a return value of 127. If the authorization could not be obtained because the user dismissed the authentication dialog, pkexec exits with a return value of 126.


Fixes https://github.com/trezor/trezor-suite/issues/4183
