### PR TITLE
fix(invity): coinmarket load invity data if doesn't exist

### DIFF
--- a/packages/suite/src/hooks/wallet/useCoinmarketBuyForm.ts
+++ b/packages/suite/src/hooks/wallet/useCoinmarketBuyForm.ts
@@ -32,7 +32,10 @@ export const useCoinmarketBuyForm = (props: Props): BuyFormContextValues => {
             loadInvityData: coinmarketCommonActions.loadInvityData,
         });
 
-    loadInvityData();
+    useEffect(() => {
+        loadInvityData();
+    }, [loadInvityData]);
+
     const { selectedAccount } = props;
     const { account, network } = selectedAccount;
     const [amountLimits, setAmountLimits] = useState<AmountLimits | undefined>(undefined);

--- a/packages/suite/src/hooks/wallet/useCoinmarketExchangeForm.ts
+++ b/packages/suite/src/hooks/wallet/useCoinmarketExchangeForm.ts
@@ -67,7 +67,9 @@ export const useCoinmarketExchangeForm = (props: Props): ExchangeFormContextValu
         loadInvityData: coinmarketCommonActions.loadInvityData,
     });
 
-    loadInvityData();
+    useEffect(() => {
+        loadInvityData();
+    }, [loadInvityData]);
 
     const { selectedAccount, quotesRequest, fees, fiat, localCurrency, exchangeCoinInfo, device } =
         props;

--- a/packages/suite/src/hooks/wallet/useCoinmarketSellForm.ts
+++ b/packages/suite/src/hooks/wallet/useCoinmarketSellForm.ts
@@ -71,7 +71,9 @@ export const useCoinmarketSellForm = (props: Props): SellFormContextValues => {
         loadInvityData: coinmarketCommonActions.loadInvityData,
     });
 
-    loadInvityData();
+    useEffect(() => {
+        loadInvityData();
+    }, [loadInvityData]);
 
     const { selectedAccount, quotesRequest, fees, fiat, localCurrency, exchangeCoinInfo, device } =
         props;

--- a/packages/suite/src/hooks/wallet/useCoinmarketSpend.ts
+++ b/packages/suite/src/hooks/wallet/useCoinmarketSpend.ts
@@ -7,6 +7,7 @@ import { useActions, useSelector } from '@suite-hooks';
 import { useTranslation } from '@suite-hooks/useTranslation';
 import * as coinmarketSellActions from '@wallet-actions/coinmarketSellActions';
 import * as coinmarketSpendActions from '@wallet-actions/coinmarketSpendActions';
+import * as coinmarketCommonActions from '@wallet-actions/coinmarket/coinmarketCommonActions';
 import * as notificationActions from '@suite-actions/notificationActions';
 import { FormState } from '@wallet-types/sendForm';
 import { getFeeLevels } from '@wallet-utils/sendFormUtils';
@@ -42,11 +43,17 @@ const useSpendState = ({ selectedAccount, fees }: Props, currentState: boolean) 
 export const useCoinmarketSpend = (props: Props): SpendContextValues => {
     const [voucherSiteUrl, setVoucherSiteUrl] = useState<string | undefined>('error');
 
-    const { addNotification, setShowLeaveModal, saveTrade } = useActions({
+    const { addNotification, setShowLeaveModal, saveTrade, loadInvityData } = useActions({
         addNotification: notificationActions.addToast,
         setShowLeaveModal: coinmarketSellActions.setShowLeaveModal,
         saveTrade: coinmarketSpendActions.saveTrade,
+        loadInvityData: coinmarketCommonActions.loadInvityData,
     });
+
+    useEffect(() => {
+        loadInvityData();
+    }, [loadInvityData]);
+
     const { translationString } = useTranslation();
 
     const { selectedAccount, language } = props;


### PR DESCRIPTION
Bug repro steps:

1. In coin market Spend tab refresh page.
2. Page stucks in loading state.

Fix:
Just load the data from Invity server in the hook.