### PR TITLE
fix(onboarding): fix recovery persistence

### DIFF
--- a/packages/integration-tests/projects/suite-web/tests/onboarding/t2-recovery-persistence.test.ts
+++ b/packages/integration-tests/projects/suite-web/tests/onboarding/t2-recovery-persistence.test.ts
@@ -77,6 +77,8 @@ describe('Onboarding - T2 in recovery mode', () => {
 
         // now suite has reloaded. database is wiped.
         cy.task('startEmu', { version: Cypress.env('emuVersionT2'), wipe: false });
+        // analytics opt-out again
+        cy.getTestElement('@onboarding/continue-button').click();
         // recovery device persisted reload
         cy.getTestElement('@onboarding/confirm-on-device');
         cy.wait(1000);

--- a/packages/suite/src/actions/suite/__tests__/analyticsActions.test.ts
+++ b/packages/suite/src/actions/suite/__tests__/analyticsActions.test.ts
@@ -175,11 +175,11 @@ describe('Analytics Actions', () => {
         const store = initStore(state);
         store.dispatch(analyticsActions.enable());
         expect(store.getState()).toMatchObject({
-            analytics: { enabled: true },
+            analytics: { enabled: true, confirmed: true },
         });
         store.dispatch(analyticsActions.dispose());
         expect(store.getState()).toMatchObject({
-            analytics: { enabled: false },
+            analytics: { enabled: false, confirmed: true },
         });
     });
 });

--- a/packages/suite/src/actions/suite/storageActions.ts
+++ b/packages/suite/src/actions/suite/storageActions.ts
@@ -300,6 +300,7 @@ export const saveAnalytics = () => async (_dispatch: Dispatch, getState: GetStat
         {
             enabled: analytics.enabled,
             instanceId: analytics.instanceId,
+            confirmed: analytics.confirmed,
         },
         'suite',
         true,

--- a/packages/suite/src/reducers/suite/analyticsReducer.ts
+++ b/packages/suite/src/reducers/suite/analyticsReducer.ts
@@ -8,6 +8,7 @@ export interface State {
     instanceId?: string;
     enabled?: boolean;
     sessionStart?: number;
+    confirmed?: boolean; // Has the user confirmed the choice for analytics?
 }
 
 export const initialState: State = {
@@ -15,6 +16,7 @@ export const initialState: State = {
     instanceId: undefined,
     enabled: undefined,
     sessionStart: undefined,
+    confirmed: false,
 };
 
 const analyticsReducer = (state: State = initialState, action: Action): State =>
@@ -28,9 +30,11 @@ const analyticsReducer = (state: State = initialState, action: Action): State =>
                 break;
             case ANALYTICS.ENABLE:
                 draft.enabled = true;
+                draft.confirmed = true;
                 break;
             case ANALYTICS.DISPOSE:
                 draft.enabled = false;
+                draft.confirmed = true;
                 break;
             // no default
         }


### PR DESCRIPTION
- handle the analytics optout screen in test for fresh suite and device in recovery mode
- introduce new analytics.confirmed state to check if user already went through that screen
- confirm selection on analytics optout screen only on Confirm button not on toggle change
- use that confirmation state to prevent interruption of shamir recovery