### PR TITLE
feat(invity): successful sell trade fixed rate message

### DIFF
--- a/packages/suite/src/support/messages.ts
+++ b/packages/suite/src/support/messages.ts
@@ -731,6 +731,14 @@ const definedMessages = defineMessages({
         defaultMessage: 'Back to Account',
         id: 'TR_SELL_DETAIL_SUCCESS_BUTTON',
     },
+    TR_SELL_DETAIL_SUCCESS_FIXED_RATE_HEADER: {
+        defaultMessage: '✓ This rate is locked in',
+        id: 'TR_SELL_DETAIL_SUCCESS_FIXED_RATE_HEADER',
+    },
+    TR_SELL_DETAIL_SUCCESS_FIXED_RATE_MESSAGE: {
+        defaultMessage: "Your payment is still processing, but what you see is what you'll get.",
+        id: 'TR_SELL_DETAIL_SUCCESS_FIXED_RATE_MESSAGE',
+    },
     TR_SELL_DETAIL_ERROR_TITLE: {
         defaultMessage: 'The transaction failed',
         id: 'TR_SELL_DETAIL_ERROR_TITLE',

--- a/packages/suite/src/views/wallet/coinmarket/sell/detail/components/PaymentSuccessful/index.tsx
+++ b/packages/suite/src/views/wallet/coinmarket/sell/detail/components/PaymentSuccessful/index.tsx
@@ -33,6 +33,21 @@ const Description = styled.div`
     text-align: center;
 `;
 
+const FixedRate = styled.div`
+    display: flex;
+    flex-direction: column;
+    background-color: ${props => props.theme.BG_GREY};
+    padding: 14px 18px;
+    border-radius: 8px;
+    margin-bottom: 30px;
+`;
+const FixedRateHeader = styled.div`
+    font-weight: ${variables.FONT_WEIGHT.DEMI_BOLD};
+    font-size: ${variables.FONT_SIZE.SMALL};
+`;
+const FixedRateMessage = styled.div`
+    color: ${props => props.theme.TYPE_LIGHT_GREY};
+`;
 interface Props {
     account: Account;
 }
@@ -50,6 +65,14 @@ const PaymentSuccessful = ({ account }: Props) => {
             <Description>
                 <Translation id="TR_SELL_DETAIL_SUCCESS_TEXT" />
             </Description>
+            <FixedRate>
+                <FixedRateHeader>
+                    <Translation id="TR_SELL_DETAIL_SUCCESS_FIXED_RATE_HEADER" />
+                </FixedRateHeader>
+                <FixedRateMessage>
+                    <Translation id="TR_SELL_DETAIL_SUCCESS_FIXED_RATE_MESSAGE" />
+                </FixedRateMessage>
+            </FixedRate>
             <Button
                 onClick={() =>
                     goto('wallet-coinmarket-sell', {


### PR DESCRIPTION
At the final (successful) step of sell trade, a user should be informed about the fixed rate. That means a message should appear to inform the user.
![image](https://user-images.githubusercontent.com/7394177/131513019-a05124ef-16d3-43f8-b377-677fe443a1e4.png)
The message is right above the "Back to Account" button.
The message is different from the one in the picture.
The correct message is already in `messages.ts`