### PR TITLE
feat(invity): coinmarket UI loading state improvement

### DIFF
--- a/packages/suite/src/views/wallet/coinmarket/buy/components/BuyForm/Footer/index.tsx
+++ b/packages/suite/src/views/wallet/coinmarket/buy/components/BuyForm/Footer/index.tsx
@@ -1,23 +1,13 @@
 import React from 'react';
+import { Controller } from 'react-hook-form';
+import styled from 'styled-components';
 import { Button, Select, variables, Flag } from '@trezor/components';
 import regional from '@wallet-constants/coinmarket/regional';
 import { useCoinmarketBuyFormContext } from '@wallet-hooks/useCoinmarketBuyForm';
 import { getCountryLabelParts } from '@wallet-utils/coinmarket/coinmarketUtils';
 import { CountryOption } from '@wallet-types/coinmarketCommonTypes';
 import { Translation } from '@suite-components';
-import { Controller } from 'react-hook-form';
-import styled from 'styled-components';
-
-const Wrapper = styled.div`
-    display: flex;
-    align-items: center;
-    padding-top: 30px;
-    border-top: 1px solid ${props => props.theme.STROKE_GREY};
-
-    @media screen and (max-width: ${variables.SCREEN_SIZE.SM}) {
-        flex-direction: column;
-    }
-`;
+import { FooterWrapper, Left, Right } from '@wallet-views/coinmarket';
 
 const OptionLabel = styled.div`
     display: flex;
@@ -34,16 +24,7 @@ const LabelText = styled.div`
     color: ${props => props.theme.TYPE_DARK_GREY};
 `;
 
-const Left = styled.div`
-    display: flex;
-    flex: 1;
-`;
-
-const Right = styled.div`
-    display: flex;
-    flex: 1;
-    justify-content: flex-end;
-
+const StyledRight = styled(Right)`
     @media screen and (max-width: ${variables.SCREEN_SIZE.SM}) {
         justify-content: flex-start;
     }
@@ -61,11 +42,9 @@ const Label = styled.div`
 const StyledButton = styled(Button)`
     display: flex;
     min-width: 200px;
-    margin-left: 20px;
-
-    @media screen and (max-width: ${variables.SCREEN_SIZE.SM}) {
+    margin-top: 0;
+    @media screen and (max-width: ${variables.SCREEN_SIZE.MD}) {
         margin-top: 20px;
-        margin-left: 0;
         width: 100%;
     }
 `;
@@ -84,7 +63,7 @@ const Footer = () => {
     const formIsValid = Object.keys(errors).length === 0;
 
     return (
-        <Wrapper>
+        <FooterWrapper>
             <Left>
                 <Label>
                     <Translation id="TR_BUY_OFFERS_FOR" />
@@ -127,7 +106,7 @@ const Footer = () => {
                     )}
                 />
             </Left>
-            <Right>
+            <StyledRight>
                 <StyledButton
                     isDisabled={!(formIsValid && hasValues) || formState.isSubmitting}
                     isLoading={formState.isSubmitting}
@@ -135,8 +114,8 @@ const Footer = () => {
                 >
                     <Translation id="TR_BUY_SHOW_OFFERS" />
                 </StyledButton>
-            </Right>
-        </Wrapper>
+            </StyledRight>
+        </FooterWrapper>
     );
 };
 

--- a/packages/suite/src/views/wallet/coinmarket/buy/components/BuyForm/Inputs/index.tsx
+++ b/packages/suite/src/views/wallet/coinmarket/buy/components/BuyForm/Inputs/index.tsx
@@ -1,55 +1,17 @@
-import { FIAT } from '@suite-config';
-import { Translation } from '@suite-components';
-import { getCryptoOptions } from '@wallet-utils/coinmarket/buyUtils';
-import { Select, Icon, Input, variables } from '@trezor/components';
-import { buildOption } from '@wallet-utils/coinmarket/coinmarketUtils';
 import React, { useEffect, useState } from 'react';
 import Bignumber from 'bignumber.js';
 import { Controller } from 'react-hook-form';
+import { FIAT } from '@suite-config';
+import { Translation } from '@suite-components';
+import { getCryptoOptions } from '@wallet-utils/coinmarket/buyUtils';
+import { Select, Input } from '@trezor/components';
+import { buildOption } from '@wallet-utils/coinmarket/coinmarketUtils';
 import { useCoinmarketBuyFormContext } from '@wallet-hooks/useCoinmarketBuyForm';
-import styled from 'styled-components';
 import { isDecimalsValid } from '@wallet-utils/validation';
 import { InputError } from '@wallet-components';
 import { MAX_LENGTH } from '@suite-constants/inputs';
 import { getInputState } from '@wallet-utils/sendFormUtils';
-
-const Wrapper = styled.div`
-    display: flex;
-    flex: 1;
-
-    @media screen and (max-width: ${variables.SCREEN_SIZE.LG}) {
-        flex-direction: column;
-    }
-`;
-
-const Left = styled.div`
-    display: flex;
-    flex: 1;
-`;
-
-const Right = styled.div`
-    display: flex;
-    flex: 1;
-    justify-content: flex-end;
-`;
-
-const Middle = styled.div`
-    display: flex;
-    min-width: 65px;
-    height: 48px;
-    align-items: center;
-    justify-content: center;
-
-    @media screen and (max-width: ${variables.SCREEN_SIZE.LG}) {
-        padding-bottom: 27px;
-    }
-`;
-
-const StyledIcon = styled(Icon)`
-    @media screen and (max-width: ${variables.SCREEN_SIZE.LG}) {
-        transform: rotate(90deg);
-    }
-`;
+import { Wrapper, Left, Middle, Right, StyledIcon } from '@wallet-views/coinmarket';
 
 const Inputs = () => {
     const {
@@ -88,7 +50,7 @@ const Inputs = () => {
     const fiatInputValue = getValues('fiatInput');
 
     return (
-        <Wrapper>
+        <Wrapper responsiveSize="LG">
             <Left>
                 <Input
                     noTopLabel
@@ -186,8 +148,8 @@ const Inputs = () => {
                     }
                 />
             </Left>
-            <Middle>
-                <StyledIcon icon="TRANSFER" size={16} />
+            <Middle responsiveSize="LG">
+                <StyledIcon responsiveSize="LG" icon="TRANSFER" size={16} />
             </Middle>
             <Right>
                 <Input

--- a/packages/suite/src/views/wallet/coinmarket/buy/components/BuyForm/index.tsx
+++ b/packages/suite/src/views/wallet/coinmarket/buy/components/BuyForm/index.tsx
@@ -1,44 +1,22 @@
 import React from 'react';
-import { useCoinmarketBuyFormContext } from '@wallet-hooks/useCoinmarketBuyForm';
 import styled from 'styled-components';
 import { Translation } from '@suite-components';
-import { variables } from '@trezor/components';
+import { useCoinmarketBuyFormContext } from '@wallet-hooks/useCoinmarketBuyForm';
+import { Wrapper, NoProviders } from '@wallet-views/coinmarket';
+import { CoinmarketSkeleton } from '@wallet-views/coinmarket/skeleton';
 
 import Inputs from './Inputs';
 import Footer from './Footer';
 
-const Wrapper = styled.div`
-    display: flex;
-    flex-direction: column;
-    flex: 1;
-
-    @media screen and (max-width: ${variables.SCREEN_SIZE.LG}) {
-        padding: 0;
-    }
-`;
-
-const Form = styled.form``;
-
-const Loading = styled.div`
-    display: flex;
-    font-size: ${variables.FONT_SIZE.BIG};
-`;
-
-const NoProviders = styled.div`
-    display: flex;
-    font-size: ${variables.FONT_SIZE.BIG};
+const Form = styled.form`
+    width: 100%;
 `;
 
 const BuyForm = () => {
     const { onSubmit, handleSubmit, isLoading, noProviders } = useCoinmarketBuyFormContext();
-
     return (
-        <Wrapper>
-            {isLoading && (
-                <Loading>
-                    <Translation id="TR_BUY_LOADING" />
-                </Loading>
-            )}
+        <Wrapper responsiveSize="LG">
+            {isLoading && <CoinmarketSkeleton />}
             {!isLoading && noProviders && (
                 <NoProviders>
                     <Translation id="TR_BUY_NO_PROVIDERS" />

--- a/packages/suite/src/views/wallet/coinmarket/exchange/components/ExchangeForm/Footer/index.tsx
+++ b/packages/suite/src/views/wallet/coinmarket/exchange/components/ExchangeForm/Footer/index.tsx
@@ -1,15 +1,10 @@
 import React from 'react';
+import styled from 'styled-components';
 import { Button } from '@trezor/components';
 import { Translation } from '@suite-components';
-import styled from 'styled-components';
 import { useCoinmarketExchangeFormContext } from '@wallet-hooks/useCoinmarketExchangeForm';
-import { CRYPTO_INPUT } from '@suite/types/wallet/coinmarketExchangeForm';
-
-const Wrapper = styled.div`
-    display: flex;
-    align-items: center;
-    padding-top: 40px;
-`;
+import { CRYPTO_INPUT } from '@wallet-types/coinmarketExchangeForm';
+import { FooterWrapper } from '@wallet-views/coinmarket';
 
 const Center = styled.div`
     display: flex;
@@ -28,7 +23,7 @@ const Footer = () => {
     const formIsValid = Object.keys(errors).length === 0;
 
     return (
-        <Wrapper>
+        <FooterWrapper>
             <Center>
                 <StyledButton
                     isDisabled={!(formIsValid && hasValues) || formState.isSubmitting}
@@ -38,7 +33,7 @@ const Footer = () => {
                     <Translation id="TR_EXCHANGE_SHOW_OFFERS" />
                 </StyledButton>
             </Center>
-        </Wrapper>
+        </FooterWrapper>
     );
 };
 

--- a/packages/suite/src/views/wallet/coinmarket/exchange/components/ExchangeForm/Inputs/index.tsx
+++ b/packages/suite/src/views/wallet/coinmarket/exchange/components/ExchangeForm/Inputs/index.tsx
@@ -1,7 +1,8 @@
-import { Icon, variables, useTheme, SuiteThemeColors } from '@trezor/components';
+import { useTheme, SuiteThemeColors } from '@trezor/components';
 import React, { useCallback, useEffect } from 'react';
 import { DeepMap, FieldError } from 'react-hook-form';
 import styled from 'styled-components';
+import BigNumber from 'bignumber.js';
 import { useCoinmarketExchangeFormContext } from '@wallet-hooks/useCoinmarketExchangeForm';
 import SendCryptoInput from './SendCryptoInput';
 import FiatInput from './FiatInput';
@@ -9,49 +10,14 @@ import ReceiveCryptoSelect from './ReceiveCryptoSelect';
 import FractionButtons from '@wallet-components/CoinMarketFractionButtons';
 import { CRYPTO_INPUT, ExchangeFormState, FIAT_INPUT } from '@wallet-types/coinmarketExchangeForm';
 import { useLayoutSize } from '@suite/hooks/suite';
-import BigNumber from 'bignumber.js';
+import { Wrapper, Left, Middle, Right, StyledIcon } from '@wallet-views/coinmarket';
 
-const Wrapper = styled.div`
-    display: flex;
-    flex: 1;
-    flex-direction: column;
+const StyledLeft = styled(Left)`
+    flex-basis: 50%;
 `;
 
-const Top = styled.div`
-    display: flex;
-    flex: 1;
-
-    @media screen and (max-width: ${variables.SCREEN_SIZE.XL}) {
-        flex-direction: column;
-    }
-`;
-
-const LeftWrapper = styled.div`
-    display: flex;
-    flex: 1;
-`;
-
-const RightWrapper = styled.div`
-    display: flex;
-    justify-content: flex-end;
-`;
-
-const MiddleWrapper = styled.div`
-    display: flex;
+const StyledMiddle = styled(Middle)`
     min-width: 35px;
-    height: 48px;
-    align-items: center;
-    justify-content: center;
-
-    @media screen and (max-width: ${variables.SCREEN_SIZE.XL}) {
-        padding-bottom: 27px;
-    }
-`;
-
-const StyledIcon = styled(Icon)`
-    @media screen and (max-width: ${variables.SCREEN_SIZE.XL}) {
-        transform: rotate(90deg);
-    }
 `;
 
 const Line = styled.div<{ color: string }>`
@@ -150,32 +116,30 @@ const Inputs = () => {
         : new BigNumber(account.formattedBalance).isZero();
 
     return (
-        <Wrapper>
-            <Top>
-                <LeftWrapper>
-                    <SendCryptoInput />
-                    {!tokenData && (
-                        <>
-                            <Line color={getLineDividerColor(theme, errors, amount, fiat)} />
-                            <FiatInput />
-                        </>
-                    )}
-                </LeftWrapper>
-                <MiddleWrapper>
-                    {!isXLargeLayoutSize && (
-                        <FractionButtons
-                            disabled={isBalanceZero}
-                            onFractionClick={setRatioAmount}
-                            onAllClick={setAllAmount}
-                        />
-                    )}
-                    <StyledIcon icon="TRANSFER" size={16} />
-                    {!isXLargeLayoutSize && <EmptyDiv />}
-                </MiddleWrapper>
-                <RightWrapper>
-                    <ReceiveCryptoSelect />
-                </RightWrapper>
-            </Top>
+        <Wrapper responsiveSize="XL">
+            <StyledLeft>
+                <SendCryptoInput />
+                {!tokenData && (
+                    <>
+                        <Line color={getLineDividerColor(theme, errors, amount, fiat)} />
+                        <FiatInput />
+                    </>
+                )}
+            </StyledLeft>
+            <StyledMiddle responsiveSize="XL">
+                {!isXLargeLayoutSize && (
+                    <FractionButtons
+                        disabled={isBalanceZero}
+                        onFractionClick={setRatioAmount}
+                        onAllClick={setAllAmount}
+                    />
+                )}
+                <StyledIcon responsiveSize="XL" icon="TRANSFER" size={16} />
+                {!isXLargeLayoutSize && <EmptyDiv />}
+            </StyledMiddle>
+            <Right>
+                <ReceiveCryptoSelect />
+            </Right>
             {isXLargeLayoutSize && (
                 <FractionButtons
                     disabled={isBalanceZero}

--- a/packages/suite/src/views/wallet/coinmarket/exchange/components/ExchangeForm/index.tsx
+++ b/packages/suite/src/views/wallet/coinmarket/exchange/components/ExchangeForm/index.tsx
@@ -1,64 +1,31 @@
 import React from 'react';
-import styled from 'styled-components';
-import { variables } from '@trezor/components';
 import { Translation } from '@suite-components';
 import { useCoinmarketExchangeFormContext } from '@wallet-hooks/useCoinmarketExchangeForm';
-
+import { Wrapper, FeesWrapper, NoProviders } from '@wallet-views/coinmarket';
+import { CoinmarketSkeleton } from '@wallet-views/coinmarket/skeleton';
 import Inputs from './Inputs';
 import Fees from './Fees';
 import Footer from './Footer';
-
-const Wrapper = styled.div`
-    display: flex;
-    flex-direction: column;
-    flex: 1;
-
-    @media screen and (max-width: ${variables.SCREEN_SIZE.LG}) {
-        padding: 0;
-    }
-`;
-
-const Form = styled.form``;
-
-const FeesWrapper = styled.div`
-    margin: 25px 0;
-    border-top: 1px solid ${props => props.theme.STROKE_GREY};
-    border-bottom: 1px solid ${props => props.theme.STROKE_GREY};
-`;
-
-const Loading = styled.div`
-    display: flex;
-    font-size: ${variables.FONT_SIZE.BIG};
-`;
-
-const NoProviders = styled.div`
-    display: flex;
-    font-size: ${variables.FONT_SIZE.BIG};
-`;
 
 const CoinmarketExchangeForm = () => {
     const { onSubmit, handleSubmit, isLoading, noProviders } = useCoinmarketExchangeFormContext();
 
     return (
-        <Wrapper>
-            {isLoading && (
-                <Loading>
-                    <Translation id="TR_EXCHANGE_LOADING" />
-                </Loading>
-            )}
+        <Wrapper responsiveSize="LG">
+            {isLoading && <CoinmarketSkeleton />}
             {!isLoading && noProviders && (
                 <NoProviders>
                     <Translation id="TR_EXCHANGE_NO_PROVIDERS" />
                 </NoProviders>
             )}
             {!isLoading && !noProviders && (
-                <Form onSubmit={handleSubmit(onSubmit)}>
+                <form onSubmit={handleSubmit(onSubmit)}>
                     <Inputs />
                     <FeesWrapper>
                         <Fees />
                     </FeesWrapper>
                     <Footer />
-                </Form>
+                </form>
             )}
         </Wrapper>
     );

--- a/packages/suite/src/views/wallet/coinmarket/index.tsx
+++ b/packages/suite/src/views/wallet/coinmarket/index.tsx
@@ -1,0 +1,68 @@
+import styled from 'styled-components';
+import { Icon, variables } from '@trezor/components';
+
+interface ResponsiveSize {
+    responsiveSize: keyof typeof variables.SCREEN_SIZE;
+}
+
+export const Wrapper = styled.div<ResponsiveSize>`
+    display: flex;
+    flex: 1;
+
+    @media screen and (min-width: ${props => variables.SCREEN_SIZE[props.responsiveSize]}) {
+        flex-flow: wrap;
+    }
+    @media screen and (max-width: ${props => variables.SCREEN_SIZE[props.responsiveSize]}) {
+        flex-direction: column;
+    }
+`;
+
+export const Left = styled.div`
+    display: flex;
+    flex: 1;
+`;
+
+export const Right = styled.div`
+    display: flex;
+    flex: 1;
+    justify-content: flex-end;
+`;
+
+export const Middle = styled.div<ResponsiveSize>`
+    display: flex;
+    min-width: 65px;
+    height: 48px;
+    align-items: center;
+    justify-content: center;
+
+    @media screen and (max-width: ${props => variables.SCREEN_SIZE[props.responsiveSize]}) {
+        padding-bottom: 27px;
+    }
+`;
+
+export const StyledIcon = styled(Icon)<ResponsiveSize>`
+    @media screen and (max-width: ${props => variables.SCREEN_SIZE[props.responsiveSize]}) {
+        transform: rotate(90deg);
+    }
+`;
+
+export const FeesWrapper = styled.div`
+    margin: 25px 0;
+    border-top: 1px solid ${props => props.theme.STROKE_GREY};
+`;
+
+export const NoProviders = styled.div`
+    display: flex;
+    font-size: ${variables.FONT_SIZE.BIG};
+`;
+
+export const FooterWrapper = styled.div`
+    display: flex;
+    align-items: center;
+    padding-top: 30px;
+    border-top: 1px solid ${props => props.theme.STROKE_GREY};
+
+    @media screen and (max-width: ${variables.SCREEN_SIZE.MD}) {
+        flex-direction: column;
+    }
+`;

--- a/packages/suite/src/views/wallet/coinmarket/sell/components/SellForm/Footer/index.tsx
+++ b/packages/suite/src/views/wallet/coinmarket/sell/components/SellForm/Footer/index.tsx
@@ -1,23 +1,14 @@
 import React from 'react';
+import { Controller } from 'react-hook-form';
+import styled from 'styled-components';
 import { Button, Select, variables, Flag } from '@trezor/components';
 import regional from '@wallet-constants/coinmarket/regional';
 import { useCoinmarketSellFormContext } from '@wallet-hooks/useCoinmarketSellForm';
 import { getCountryLabelParts } from '@wallet-utils/coinmarket/coinmarketUtils';
 import { Translation } from '@suite-components';
-import { Controller } from 'react-hook-form';
-import styled from 'styled-components';
+
 import { CountryOption } from '@wallet-types/coinmarketCommonTypes';
-
-const Wrapper = styled.div`
-    display: flex;
-    align-items: center;
-    padding-top: 30px;
-    border-top: 1px solid ${props => props.theme.STROKE_GREY};
-
-    @media screen and (max-width: ${variables.SCREEN_SIZE.SM}) {
-        flex-direction: column;
-    }
-`;
+import { FooterWrapper, Left, Right } from '@wallet-views/coinmarket';
 
 const OptionLabel = styled.div`
     display: flex;
@@ -34,16 +25,7 @@ const LabelText = styled.div`
     color: ${props => props.theme.TYPE_DARK_GREY};
 `;
 
-const Left = styled.div`
-    display: flex;
-    flex: 1;
-`;
-
-const Right = styled.div`
-    display: flex;
-    flex: 1;
-    justify-content: flex-end;
-
+const StyledRight = styled(Right)`
     @media screen and (max-width: ${variables.SCREEN_SIZE.SM}) {
         justify-content: flex-start;
     }
@@ -92,7 +74,7 @@ const Footer = () => {
     const formIsValid = Object.keys(errors).length === 0;
 
     return (
-        <Wrapper>
+        <FooterWrapper>
             <Left>
                 <Label>
                     <Translation id="TR_SELL_OFFERS_FOR" />
@@ -142,7 +124,7 @@ const Footer = () => {
                     )}
                 />
             </Left>
-            <Right>
+            <StyledRight>
                 <StyledButton
                     isDisabled={!(formIsValid && hasValues) || formState.isSubmitting}
                     isLoading={formState.isSubmitting || isComposing}
@@ -150,8 +132,8 @@ const Footer = () => {
                 >
                     <Translation id="TR_SELL_SHOW_OFFERS" />
                 </StyledButton>
-            </Right>
-        </Wrapper>
+            </StyledRight>
+        </FooterWrapper>
     );
 };
 

--- a/packages/suite/src/views/wallet/coinmarket/sell/components/SellForm/Inputs/index.tsx
+++ b/packages/suite/src/views/wallet/coinmarket/sell/components/SellForm/Inputs/index.tsx
@@ -1,57 +1,13 @@
-import { Icon, variables } from '@trezor/components';
 import React, { useCallback, useEffect } from 'react';
-import { useCoinmarketSellFormContext } from '@wallet-hooks/useCoinmarketSellForm';
+import BigNumber from 'bignumber.js';
 import styled from 'styled-components';
+import { useCoinmarketSellFormContext } from '@wallet-hooks/useCoinmarketSellForm';
 import FiatInput from './FiatInput';
 import { CRYPTO_INPUT, FIAT_INPUT, OUTPUT_AMOUNT } from '@suite/types/wallet/coinmarketSellForm';
 import CryptoInput from './CryptoInput';
 import { useLayoutSize } from '@suite/hooks/suite';
 import FractionButtons from '@suite/components/wallet/CoinMarketFractionButtons';
-import BigNumber from 'bignumber.js';
-
-const Wrapper = styled.div`
-    display: flex;
-    flex: 1;
-    flex-direction: column;
-`;
-
-const Top = styled.div`
-    display: flex;
-    flex: 1;
-
-    @media screen and (max-width: ${variables.SCREEN_SIZE.LG}) {
-        flex-direction: column;
-    }
-`;
-
-const Left = styled.div`
-    display: flex;
-    flex: 1;
-`;
-
-const Right = styled.div`
-    display: flex;
-    flex: 1;
-    justify-content: flex-end;
-`;
-
-const Middle = styled.div`
-    display: flex;
-    min-width: 65px;
-    height: 48px;
-    align-items: center;
-    justify-content: center;
-
-    @media screen and (max-width: ${variables.SCREEN_SIZE.LG}) {
-        padding-bottom: 27px;
-    }
-`;
-
-const StyledIcon = styled(Icon)`
-    @media screen and (max-width: ${variables.SCREEN_SIZE.LG}) {
-        transform: rotate(90deg);
-    }
-`;
+import { Wrapper, Left, Middle, Right, StyledIcon } from '@wallet-views/coinmarket';
 
 const EmptyDiv = styled.div`
     width: 100%;
@@ -117,26 +73,24 @@ const Inputs = () => {
     const isBalanceZero = new BigNumber(account.formattedBalance).isZero();
 
     return (
-        <Wrapper>
-            <Top>
-                <Left>
-                    <CryptoInput activeInput={activeInput} setActiveInput={setActiveInput} />
-                </Left>
-                <Middle>
-                    {!isLargeLayoutSize && (
-                        <FractionButtons
-                            disabled={isBalanceZero}
-                            onFractionClick={setRatioAmount}
-                            onAllClick={setAllAmount}
-                        />
-                    )}
-                    <StyledIcon icon="TRANSFER" size={16} />
-                    {!isLargeLayoutSize && <EmptyDiv />}
-                </Middle>
-                <Right>
-                    <FiatInput activeInput={activeInput} setActiveInput={setActiveInput} />
-                </Right>
-            </Top>
+        <Wrapper responsiveSize="LG">
+            <Left>
+                <CryptoInput activeInput={activeInput} setActiveInput={setActiveInput} />
+            </Left>
+            <Middle responsiveSize="LG">
+                {!isLargeLayoutSize && (
+                    <FractionButtons
+                        disabled={isBalanceZero}
+                        onFractionClick={setRatioAmount}
+                        onAllClick={setAllAmount}
+                    />
+                )}
+                <StyledIcon responsiveSize="LG" icon="TRANSFER" size={16} />
+                {!isLargeLayoutSize && <EmptyDiv />}
+            </Middle>
+            <Right>
+                <FiatInput activeInput={activeInput} setActiveInput={setActiveInput} />
+            </Right>
             {isLargeLayoutSize && (
                 <FractionButtons
                     disabled={isBalanceZero}

--- a/packages/suite/src/views/wallet/coinmarket/sell/components/SellForm/index.tsx
+++ b/packages/suite/src/views/wallet/coinmarket/sell/components/SellForm/index.tsx
@@ -1,63 +1,32 @@
 import React from 'react';
 import { useCoinmarketSellFormContext } from '@wallet-hooks/useCoinmarketSellForm';
-import styled from 'styled-components';
 import { Translation } from '@suite-components';
-import { variables } from '@trezor/components';
+import { Wrapper, FeesWrapper, NoProviders } from '@wallet-views/coinmarket';
+import { CoinmarketSkeleton } from '@wallet-views/coinmarket/skeleton';
 
 import Inputs from './Inputs';
 import Footer from './Footer';
 import Fees from './Fees';
 
-const Wrapper = styled.div`
-    display: flex;
-    flex-direction: column;
-    flex: 1;
-
-    @media screen and (max-width: ${variables.SCREEN_SIZE.LG}) {
-        padding: 0;
-    }
-`;
-
-const Form = styled.form``;
-
-const Loading = styled.div`
-    display: flex;
-    font-size: ${variables.FONT_SIZE.BIG};
-`;
-
-const NoProviders = styled.div`
-    display: flex;
-    font-size: ${variables.FONT_SIZE.BIG};
-`;
-
-const FeesWrapper = styled.div`
-    margin: 25px 0;
-    border-top: 1px solid ${props => props.theme.STROKE_GREY};
-`;
-
 const SellForm = () => {
     const { onSubmit, handleSubmit, isLoading, noProviders } = useCoinmarketSellFormContext();
 
     return (
-        <Wrapper>
-            {isLoading && (
-                <Loading>
-                    <Translation id="TR_SELL_LOADING" />
-                </Loading>
-            )}
+        <Wrapper responsiveSize="LG">
+            {isLoading && <CoinmarketSkeleton />}
             {!isLoading && noProviders && (
                 <NoProviders>
                     <Translation id="TR_SELL_NO_PROVIDERS" />
                 </NoProviders>
             )}
             {!isLoading && !noProviders && (
-                <Form onSubmit={handleSubmit(onSubmit)}>
+                <form onSubmit={handleSubmit(onSubmit)}>
                     <Inputs />
                     <FeesWrapper>
                         <Fees />
                     </FeesWrapper>
                     <Footer />
-                </Form>
+                </form>
             )}
         </Wrapper>
     );

--- a/packages/suite/src/views/wallet/coinmarket/skeleton/index.tsx
+++ b/packages/suite/src/views/wallet/coinmarket/skeleton/index.tsx
@@ -1,0 +1,84 @@
+import React from 'react';
+import styled from 'styled-components';
+import { variables } from '@trezor/components';
+import { useLoadingSkeleton } from '@suite-hooks';
+import { SkeletonRectangle, Spread } from '@suite-components/Skeleton';
+import { Wrapper, Left, Middle, Right, StyledIcon, FooterWrapper } from '@wallet-views/coinmarket';
+
+const SkeletonWrapper = styled.div`
+    display: flex;
+    width: 100%;
+    @media screen and (max-width: ${variables.SCREEN_SIZE.LG}) {
+        flex-direction: column;
+    }
+`;
+
+const FooterSkeletonWrapper = styled(FooterWrapper)`
+    justify-content: space-between;
+    width: 100%;
+`;
+
+const Divider = styled(Wrapper)`
+    display: flex;
+    border-top: 1px solid ${props => props.theme.STROKE_GREY};
+    padding: 0;
+`;
+
+const StyledLeft = styled(Left)`
+    @media screen and (max-width: ${variables.SCREEN_SIZE.LG}) {
+        width: 100%;
+    }
+    @media screen and (max-width: ${variables.SCREEN_SIZE.MD}) {
+        margin-left: 0;
+        justify-content: center;
+    }
+`;
+
+const StyledSkeletonRectangle = styled(SkeletonRectangle)`
+    margin-bottom: 27px;
+`;
+
+const StyledRight = styled(Right)`
+    @media screen and (max-width: ${variables.SCREEN_SIZE.LG}) {
+        margin-left: 0;
+        width: 100%;
+        justify-content: flex-end;
+    }
+    @media screen and (max-width: ${variables.SCREEN_SIZE.MD}) {
+        margin-top: 20px;
+        justify-content: center;
+    }
+`;
+
+export const CoinmarketSkeleton = () => {
+    const { shouldAnimate } = useLoadingSkeleton();
+    return (
+        <Wrapper responsiveSize="LG">
+            <SkeletonWrapper>
+                <Left>
+                    <StyledSkeletonRectangle height="48px" width="100%" animate={shouldAnimate} />
+                </Left>
+                <Middle responsiveSize="LG">
+                    <StyledIcon responsiveSize="LG" icon="TRANSFER" size={16} />
+                </Middle>
+                <Right>
+                    <StyledSkeletonRectangle height="48px" width="100%" animate={shouldAnimate} />
+                </Right>
+            </SkeletonWrapper>
+            <SkeletonWrapper>
+                <Divider responsiveSize="LG" />
+            </SkeletonWrapper>
+            <FooterSkeletonWrapper>
+                <StyledLeft>
+                    <Spread childMargin="0 8px 0 0" alignItems="center">
+                        <SkeletonRectangle height="20px" width="68px" animate={shouldAnimate} />
+                        <SkeletonRectangle height="20px" width="180px" animate={shouldAnimate} />
+                    </Spread>
+                </StyledLeft>
+                <StyledRight>
+                    <SkeletonRectangle height="38px" width="200px" animate={shouldAnimate} />
+                </StyledRight>
+            </FooterSkeletonWrapper>
+        </Wrapper>
+    );
+};

--- a/packages/suite/src/views/wallet/coinmarket/spend/components/Spend/index.tsx
+++ b/packages/suite/src/views/wallet/coinmarket/spend/components/Spend/index.tsx
@@ -1,31 +1,15 @@
 import React from 'react';
 import styled from 'styled-components';
-import { Icon, variables, Button } from '@trezor/components';
+import { Icon, Button } from '@trezor/components';
 import { Translation } from '@suite-components';
 import { isDesktop } from '@suite-utils/env';
 import { useCoinmarketSpendContext } from '@wallet-hooks/useCoinmarketSpend';
+import { NoProviders, Wrapper } from '@wallet-views/coinmarket';
+import { CoinmarketSkeleton } from '@wallet-views/coinmarket/skeleton';
 
-const Wrapper = styled.div`
-    display: flex;
-    flex-direction: column;
-    flex: 1;
-
-    @media screen and (max-width: ${variables.SCREEN_SIZE.LG}) {
-        padding: 0;
-    }
+const Vouchers = styled.div`
+    width: 100%;
 `;
-
-const Loading = styled.div`
-    display: flex;
-    font-size: ${variables.FONT_SIZE.BIG};
-`;
-
-const NoProviders = styled.div`
-    display: flex;
-    font-size: ${variables.FONT_SIZE.BIG};
-`;
-
-const Vouchers = styled.div``;
 
 const ProviderInfo = styled.div`
     display: flex;
@@ -78,12 +62,8 @@ const CoinmarketSpend = () => {
     const showIframe = !isDesktop();
 
     return (
-        <Wrapper>
-            {isLoading && (
-                <Loading>
-                    <Translation id="TR_SPEND_LOADING" />
-                </Loading>
-            )}
+        <Wrapper responsiveSize="LG">
+            {isLoading && <CoinmarketSkeleton />}
             {!isLoading && noProviders && (
                 <NoProviders>
                     <Translation id="TR_SPEND_NO_PROVIDERS" />


### PR DESCRIPTION
We would like to improve the look and feel during the loading state of data from Invity server in coin market.
Then:
![image](https://user-images.githubusercontent.com/7394177/131629389-5be05414-a90d-4259-907d-98067cdaa91e.png)
Now:
![image](https://user-images.githubusercontent.com/7394177/131635387-c4e2056c-95a4-4dc1-9439-add097108cb1.png)

Product and Dev dept at Invity decided that there will be a single skeleton for all four forms (buy, sell, exchange, spend). That means showing skeleton that matches only buy form layout.

(Because of wanted refactoring, the commit includes extraction of some custom-styled components.)