### PR TITLE
fix(suite): allow to exit Crowdin if not logged

### DIFF
--- a/packages/suite-web/src/static/index.html
+++ b/packages/suite-web/src/static/index.html
@@ -26,6 +26,10 @@
                 console.warn("INJECTING CROWDIN IN-CONTEXT");
                 var _jipt = [];
                 _jipt.push(['project', 'trezor-suite']);
+                _jipt.push(['escape', function() {
+                    localStorage.removeItem('translation_mode');
+                    window.location.reload();
+                }]);
                 var script = document.createElement('script');
                 script.setAttribute('src','//cdn.crowdin.com/jipt/jipt.js');
                 document.head.prepend(script);


### PR DESCRIPTION
Should be cherrypicked into release in order to allow to turn off translation mode if the user is not logged into Crowdin or even doesn't have an account. Otherwise he is stuck on Crowdin login popup and has to manually delete `translation_mode` flag from localStorage.