### PR TITLE
fix(suite,landing): fix resolution of static path

### DIFF
--- a/packages/suite/src/utils/suite/__tests__/build.test.ts
+++ b/packages/suite/src/utils/suite/__tests__/build.test.ts
@@ -64,9 +64,16 @@ describe('build', () => {
             expect(resolveStaticPath('mypath')).toBe('/static/mypath');
         });
 
+        it('should return static path even if ASSET_PREFIX is undefined', () => {
+            process.env.ASSET_PREFIX = undefined;
+            expect(resolveStaticPath('mypath')).toBe('/static/mypath');
+            expect(resolveStaticPath('/mypath')).toBe('/static/mypath');
+        });
+
         it('should return static path prefixed with ASSET_PREFIX', () => {
             process.env.ASSET_PREFIX = 'brachName';
             expect(resolveStaticPath('mypath')).toBe('brachName/static/mypath');
+            expect(resolveStaticPath('/mypath')).toBe('brachName/static/mypath');
         });
     });
 });

--- a/packages/suite/src/utils/suite/build.ts
+++ b/packages/suite/src/utils/suite/build.ts
@@ -6,4 +6,5 @@ export const normalizeVersion = (version: string) =>
     // remove any zeros that are not preceded by Latin letters, decimal digits, underscores
     version.replace(/\b0+(\d)/g, '$1');
 
-export const resolveStaticPath = (path: string) => `${process.env.ASSET_PREFIX}/static/${path}`;
+export const resolveStaticPath = (path: string) =>
+    `${process.env.ASSET_PREFIX || ''}/static/${path.replace(/^\/+/, '')}`;


### PR DESCRIPTION
fix #4207 

- allow undefined ASSET_PREFIX
- handle also "static" paths (begining with a slash)