### PR TITLE
Fix/shell nix

### DIFF
--- a/packages/suite-desktop/package.json
+++ b/packages/suite-desktop/package.json
@@ -7,7 +7,7 @@
     "homepage": "https://trezor.io/",
     "main": "dist/app.js",
     "scripts": {
-        "dev": "LAUNCH_ELECTRON=true yarn run dev:local",
+        "dev": "ELECTRON_IS_DEV=1 LAUNCH_ELECTRON=true yarn run dev:local",
         "dev:run": "electron .",
         "dev:prepare": "yarn build:app",
         "dev:local": "rimraf ./build && yarn workspace @trezor/suite-build run dev:desktop",

--- a/packages/suite-desktop/src-electron/modules/shortcuts.ts
+++ b/packages/suite-desktop/src-electron/modules/shortcuts.ts
@@ -4,9 +4,13 @@ import electronLocalshortcut from 'electron-localshortcut';
 const init = ({ mainWindow, src }: Dependencies) => {
     const { logger } = global;
 
-    electronLocalshortcut.register(mainWindow, 'CommandOrControl+Alt+I', () => {
-        logger.info('shortcuts', 'CTRL+ALT+I pressed');
-        mainWindow.webContents.openDevTools();
+    // Register more shortcuts for opening dev tools
+    const openDevToolsShortcuts = ['CommandOrControl+Shift+I', 'CommandOrControl+Alt+I'];
+    openDevToolsShortcuts.forEach(shortcut => {
+        electronLocalshortcut.register(mainWindow, shortcut, () => {
+            logger.info('shortcuts', `${shortcut} pressed`);
+            mainWindow.webContents.openDevTools();
+        });
     });
 
     electronLocalshortcut.register(mainWindow, 'F5', () => {

--- a/shell.nix
+++ b/shell.nix
@@ -35,6 +35,8 @@ in
     ] ++ lib.optionals stdenv.isDarwin (with darwin.apple_sdk.frameworks; [
       Cocoa
       CoreServices
+      p7zip
+      electron
     ]);
     shellHook = ''
       export NODE_OPTIONS=--max_old_space_size=4096
@@ -43,5 +45,7 @@ in
       export ELECTRON_BUILDER_CACHE="$CURDIR/.cache/electron-builder"
     '' + lib.optionalString stdenv.isLinux ''
       export npm_config_build_from_source=true  # tell yarn to not download binaries, but build from source
+      export USE_SYSTEM_7ZA=true
+      export ELECTRON_OVERRIDE_DIST_PATH="${electron}/bin/"
     '';
   }


### PR DESCRIPTION
**enable development build of `suite-desktop` via `shell.nix`**
- use system-wide binaries for `p7zip` and `electron` in build
- explicitly set `ELECTRON_IS_DEV` for build in development  mode
- hot reload
- add multiple shortcuts support for accessing dev tools
