### PR TITLE
chore(connect-common): set initial version for npm 0.0.1

### DIFF
--- a/packages/connect-common/package.json
+++ b/packages/connect-common/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@trezor/connect-common",
-    "version": "9.0.0-beta.1",
+    "version": "0.0.1",
     "author": "Trezor <info@trezor.io>",
     "homepage": "https://github.com/trezor/trezor-suite/packages/connect-common",
     "keywords": [


### PR DESCRIPTION
- we are not sure if we will want to synchronise the version with connect, but from 0.0.1 we could jump in future to any version if needed