### PR TITLE
Chore/bump connect

### DIFF
--- a/packages/suite/package.json
+++ b/packages/suite/package.json
@@ -59,7 +59,7 @@
         "semver": "^7.3.5",
         "styled-components": "5.1.1",
         "trezor-address-validator": "^0.3.22",
-        "trezor-connect": "8.1.30-beta.2",
+        "trezor-connect": "8.1.30-beta.7",
         "ua-parser-js": "^0.7.28",
         "uuid": "^8.3.2",
         "web3-utils": "^1.2.6",

--- a/packages/suite/src/components/suite/CoinsGroup/CoinsList.tsx
+++ b/packages/suite/src/components/suite/CoinsGroup/CoinsList.tsx
@@ -1,11 +1,10 @@
 import React from 'react';
 import { TooltipConditional } from '@trezor/components';
 import styled from 'styled-components';
-import { UnavailableCapability } from 'trezor-connect';
 import { Network } from '@wallet-types';
-import { TrezorDevice, ExtendedMessageDescriptor } from '@suite-types';
+import { TrezorDevice } from '@suite-types';
 import { Coin, Translation } from '@suite-components';
-import { getDeviceModel, isBitcoinOnly } from '@suite-utils/device';
+import { getUnavailabilityMessage } from '@suite-utils/device';
 import { useDevice } from '@suite-hooks';
 
 const Wrapper = styled.div`
@@ -13,40 +12,6 @@ const Wrapper = styled.div`
     display: flex;
     flex-flow: wrap;
 `;
-
-interface UnavailableMessageProps {
-    whyDisabled?: UnavailableCapability;
-    device: TrezorDevice;
-}
-const unavailabilityReason = ({ whyDisabled, device }: UnavailableMessageProps) => {
-    const deviceModel = getDeviceModel(device);
-    const isBtcOnly = isBitcoinOnly(device);
-    switch (whyDisabled) {
-        case 'no-capability':
-            return deviceModel === '1' && !isBtcOnly
-                ? // right know it serves only one purpose - in case of XRP on T1 inform user that the capability is available on TT
-                  'FW_CAPABILITY_SUPPORTED_IN_T2'
-                : 'FW_CAPABILITY_NO_CAPABILITY';
-        case 'no-support':
-            return 'FW_CAPABILITY_NO_SUPPORT';
-        case 'update-required':
-            return 'FW_CAPABILITY_UPDATE_REQUIRED';
-        // case 'trezor-connect-outdated':
-        default:
-            return 'FW_CAPABILITY_CONNECT_OUTDATED';
-    }
-};
-
-interface TooltipContentProps {
-    tooltip?: ExtendedMessageDescriptor['id'];
-    device: TrezorDevice;
-    isDisabled: boolean;
-    whyDisabled?: UnavailableCapability;
-}
-const getTooltipContent = ({ tooltip, device, isDisabled, whyDisabled }: TooltipContentProps) => {
-    const contentKey = isDisabled ? unavailabilityReason({ device, whyDisabled }) : tooltip;
-    return contentKey && <Translation id={contentKey} />;
-};
 
 interface Props {
     onToggleFn: (symbol: Network['symbol'], visible: boolean) => void;
@@ -65,19 +30,22 @@ const CoinsList = ({ onToggleFn, networks, selectedNetworks, unavailableCapabili
         <Wrapper>
             {networks.map(({ symbol, accountType, label, tooltip, name }) => {
                 const isSelected = selectedNetworks.includes(symbol);
-                const isDisabled = !!unavailableCapabilities?.[symbol] || isDeviceLocked;
-                const tooltipContent = getTooltipContent({
-                    tooltip,
-                    device,
-                    isDisabled,
-                    whyDisabled: unavailableCapabilities?.[symbol],
-                });
+                const unavailableCapability = unavailableCapabilities?.[symbol];
+                const isDisabled = !!unavailableCapability || isDeviceLocked;
+                const tooltipContent = unavailableCapability && (
+                    <Translation
+                        id={getUnavailabilityMessage(
+                            unavailableCapability,
+                            device.features?.major_version,
+                        )}
+                    />
+                );
 
                 return (
                     <TooltipConditional
                         key={`${symbol}_${accountType}`}
                         placement="top"
-                        content={tooltipContent}
+                        content={tooltipContent || tooltip}
                     >
                         <Coin
                             symbol={symbol}

--- a/packages/suite/src/components/suite/CoinsGroup/CoinsList.tsx
+++ b/packages/suite/src/components/suite/CoinsGroup/CoinsList.tsx
@@ -2,7 +2,6 @@ import React from 'react';
 import { TooltipConditional } from '@trezor/components';
 import styled from 'styled-components';
 import { Network } from '@wallet-types';
-import { TrezorDevice } from '@suite-types';
 import { Coin, Translation } from '@suite-components';
 import { getUnavailabilityMessage } from '@suite-utils/device';
 import { useDevice } from '@suite-hooks';
@@ -17,10 +16,9 @@ interface Props {
     onToggleFn: (symbol: Network['symbol'], visible: boolean) => void;
     networks: Network[];
     selectedNetworks: Network['symbol'][];
-    unavailableCapabilities: TrezorDevice['unavailableCapabilities'];
 }
 
-const CoinsList = ({ onToggleFn, networks, selectedNetworks, unavailableCapabilities }: Props) => {
+const CoinsList = ({ onToggleFn, networks, selectedNetworks }: Props) => {
     const { device, isLocked } = useDevice();
     if (!device) return null;
 
@@ -30,7 +28,7 @@ const CoinsList = ({ onToggleFn, networks, selectedNetworks, unavailableCapabili
         <Wrapper>
             {networks.map(({ symbol, accountType, label, tooltip, name }) => {
                 const isSelected = selectedNetworks.includes(symbol);
-                const unavailableCapability = unavailableCapabilities?.[symbol];
+                const unavailableCapability = device.unavailableCapabilities?.[symbol];
                 const isDisabled = !!unavailableCapability || isDeviceLocked;
                 const tooltipContent = unavailableCapability && (
                     <Translation

--- a/packages/suite/src/components/suite/CoinsGroup/index.tsx
+++ b/packages/suite/src/components/suite/CoinsGroup/index.tsx
@@ -1,7 +1,6 @@
 import React from 'react';
 import styled from 'styled-components';
 import { Network } from '@wallet-types';
-import { TrezorDevice } from '@suite-types';
 import { Translation } from '@suite-components';
 import CoinsCount from './CoinsCount';
 import CoinsList from './CoinsList';
@@ -14,16 +13,9 @@ interface Props {
     networks: Network[];
     enabledNetworks: Network['symbol'][];
     testnet: boolean;
-    unavailableCapabilities: TrezorDevice['unavailableCapabilities'];
 }
 
-const CoinsGroup = ({
-    onToggleFn,
-    networks,
-    enabledNetworks,
-    testnet,
-    unavailableCapabilities,
-}: Props) => (
+const CoinsGroup = ({ onToggleFn, networks, enabledNetworks, testnet }: Props) => (
     <CoinsGroupWrapper>
         <CoinsCount
             networks={networks}
@@ -36,12 +28,7 @@ const CoinsGroup = ({
                 )
             }
         />
-        <CoinsList
-            onToggleFn={onToggleFn}
-            networks={networks}
-            selectedNetworks={enabledNetworks}
-            unavailableCapabilities={unavailableCapabilities}
-        />
+        <CoinsList onToggleFn={onToggleFn} networks={networks} selectedNetworks={enabledNetworks} />
     </CoinsGroupWrapper>
 );
 

--- a/packages/suite/src/components/suite/modals/AddAccount/components/EnableNetwork.tsx
+++ b/packages/suite/src/components/suite/modals/AddAccount/components/EnableNetwork.tsx
@@ -5,7 +5,6 @@ import { Icon, P, useTheme } from '@trezor/components';
 
 import { CoinsList, Translation } from '@suite-components';
 import { Network } from '@wallet-types';
-import { TrezorDevice } from '@suite-types';
 import { ANIMATION } from '@suite-config';
 import { MoreCoins } from './MoreCoins';
 
@@ -52,7 +51,6 @@ type Props = {
     networks: Network[];
     testnetNetworks: Network[];
     selectedNetworks: Network['symbol'][];
-    unavailableCapabilities: TrezorDevice['unavailableCapabilities'];
     handleNetworkSelection: (symbol?: Network['symbol']) => void;
 };
 
@@ -61,7 +59,6 @@ export const EnableNetwork = ({
     testnetNetworks,
     selectedNetworks,
     handleNetworkSelection,
-    unavailableCapabilities,
 }: Props) => {
     const theme = useTheme();
     const [isTestnetVisible, setTestnetVisible] = useState(false);
@@ -73,7 +70,6 @@ export const EnableNetwork = ({
                 onToggleFn={handleNetworkSelection}
                 networks={networks}
                 selectedNetworks={selectedNetworks}
-                unavailableCapabilities={unavailableCapabilities}
             />
             {hasTestnetNetworks && (
                 <>
@@ -108,7 +104,6 @@ export const EnableNetwork = ({
                                     onToggleFn={handleNetworkSelection}
                                     networks={testnetNetworks}
                                     selectedNetworks={selectedNetworks}
-                                    unavailableCapabilities={unavailableCapabilities}
                                 />
                             </TestnetCoinsWrapper>
                         )}

--- a/packages/suite/src/components/suite/modals/AddAccount/components/SelectNetwork.tsx
+++ b/packages/suite/src/components/suite/modals/AddAccount/components/SelectNetwork.tsx
@@ -5,7 +5,6 @@ import { FADE_IN } from '@trezor/components/lib/config/animations';
 
 import { CoinsList, Translation } from '@suite-components';
 import { Network } from '@wallet-types';
-import { TrezorDevice } from '@suite-types';
 
 const Header = styled.div<{ disabled: boolean }>`
     display: flex;
@@ -38,7 +37,6 @@ type Props = {
     networkCanChange: boolean;
     selectedNetworks: Network['symbol'][];
     handleNetworkSelection: (symbol?: Network['symbol']) => void;
-    unavailableCapabilities: TrezorDevice['unavailableCapabilities'];
 };
 
 export const SelectNetwork = ({
@@ -46,7 +44,6 @@ export const SelectNetwork = ({
     networkCanChange,
     selectedNetworks,
     handleNetworkSelection,
-    unavailableCapabilities,
 }: Props) => {
     const resetNetworkSelection = () => {
         if (networkCanChange) {
@@ -66,7 +63,6 @@ export const SelectNetwork = ({
                 onToggleFn={handleNetworkSelection}
                 networks={networks}
                 selectedNetworks={selectedNetworks}
-                unavailableCapabilities={unavailableCapabilities}
             />
         </>
     );

--- a/packages/suite/src/components/suite/modals/AddAccount/index.tsx
+++ b/packages/suite/src/components/suite/modals/AddAccount/index.tsx
@@ -57,9 +57,6 @@ const AddAccountModal = ({ device, onCancel, symbol, noRedirect }: Props) => {
     // Collect all Networks without "accountType" (normal)
     const internalNetworks = NETWORKS.filter(n => !n.accountType && !n.isHidden);
 
-    // Collect device unavailable capabilities
-    const unavailableCapabilities = device.features ? device.unavailableCapabilities : {};
-
     // applied only when changing account in coinmarket exchange receive options context so far
     const networkPinned = !!symbol;
     const preselectedNetwork = symbol && internalNetworks.find(n => n.symbol === symbol);
@@ -155,7 +152,6 @@ const AddAccountModal = ({ device, onCancel, symbol, noRedirect }: Props) => {
                 }
                 networkCanChange={!!selectedNetwork && selectedNetworkEnabled && !networkPinned}
                 selectedNetworks={selectedNetworks}
-                unavailableCapabilities={unavailableCapabilities}
                 handleNetworkSelection={handleNetworkSelection}
             />
             {!selectedNetworkEnabled && hasDisabledNetworks && (
@@ -163,7 +159,6 @@ const AddAccountModal = ({ device, onCancel, symbol, noRedirect }: Props) => {
                     networks={disabledMainnetNetworks}
                     testnetNetworks={disabledTestnetNetworks}
                     selectedNetworks={selectedNetworks}
-                    unavailableCapabilities={unavailableCapabilities}
                     handleNetworkSelection={handleNetworkSelection}
                 />
             )}

--- a/packages/suite/src/hooks/wallet/useCoinmarketExchangeOffers.ts
+++ b/packages/suite/src/hooks/wallet/useCoinmarketExchangeOffers.ts
@@ -135,10 +135,7 @@ export const useOffers = (props: Props) => {
 
     useEffect(() => {
         if (selectedQuote && exchangeStep === 'RECEIVING_ADDRESS') {
-            const unavailableCapabilities =
-                device?.features && device?.unavailableCapabilities
-                    ? device.unavailableCapabilities
-                    : {};
+            const unavailableCapabilities = device?.unavailableCapabilities ?? {};
             // is the symbol supported by the suite and the device natively
             const receiveNetworks = networks.filter(
                 n => n.symbol === receiveSymbol && !unavailableCapabilities[n.symbol],

--- a/packages/suite/src/utils/suite/device.ts
+++ b/packages/suite/src/utils/suite/device.ts
@@ -1,4 +1,4 @@
-import { Device, KnownDevice } from 'trezor-connect';
+import { Device, KnownDevice, UnavailableCapability } from 'trezor-connect';
 import { TrezorDevice, AcquiredDevice } from '@suite-types';
 
 /**
@@ -146,6 +146,20 @@ export const getFwUpdateVersion = (device: AcquiredDevice) => {
     const supportIntermediary = device.features.major_version === 1;
     const version = device.firmwareRelease?.[supportIntermediary ? 'latest' : 'release']?.version;
     return version?.join('.') || null;
+};
+
+export const getUnavailabilityMessage = (reason: UnavailableCapability, model?: number) => {
+    switch (reason) {
+        case 'no-capability':
+            return 'FW_CAPABILITY_NO_CAPABILITY';
+        case 'no-support':
+            return model === 1 ? 'FW_CAPABILITY_SUPPORTED_IN_T2' : 'FW_CAPABILITY_NO_SUPPORT';
+        case 'update-required':
+            return 'FW_CAPABILITY_UPDATE_REQUIRED';
+        case 'trezor-connect-outdated':
+            return 'FW_CAPABILITY_CONNECT_OUTDATED';
+        // no default
+    }
 };
 
 /**

--- a/packages/suite/src/views/onboarding/steps/BasicSettings/BasicSettingsStepBox.tsx
+++ b/packages/suite/src/views/onboarding/steps/BasicSettings/BasicSettingsStepBox.tsx
@@ -5,7 +5,6 @@ import { OnboardingStepBox, OnboardingStepBoxProps } from '@onboarding-component
 import { CoinsGroup } from '@suite-components';
 import styled from 'styled-components';
 import { Network } from '@wallet-types';
-import { UnavailableCapability } from 'trezor-connect';
 
 const Separator = styled.hr`
     height: 1px;
@@ -20,7 +19,6 @@ interface Props extends OnboardingStepBoxProps {
     mainnetNetworks: Network[];
     enabledTestnetNetworks: Network['symbol'][];
     enabledMainnetNetworks: Network['symbol'][];
-    unavailableCapabilities: { [key: string]: UnavailableCapability };
 }
 
 const BasicSettingsStepBox = ({
@@ -28,7 +26,6 @@ const BasicSettingsStepBox = ({
     mainnetNetworks,
     enabledTestnetNetworks,
     enabledMainnetNetworks,
-    unavailableCapabilities,
     ...props
 }: Props) => {
     const { changeCoinVisibility } = useActions({
@@ -49,14 +46,12 @@ const BasicSettingsStepBox = ({
                 networks={mainnetNetworks}
                 enabledNetworks={enabledMainnetNetworks}
                 testnet={false}
-                unavailableCapabilities={unavailableCapabilities}
             />
             <CoinsGroup
                 onToggleFn={changeCoinVisibility}
                 networks={testnetNetworks}
                 enabledNetworks={enabledTestnetNetworks}
                 testnet
-                unavailableCapabilities={unavailableCapabilities}
             />
         </OnboardingStepBox>
     );

--- a/packages/suite/src/views/onboarding/steps/BasicSettings/index.tsx
+++ b/packages/suite/src/views/onboarding/steps/BasicSettings/index.tsx
@@ -8,12 +8,9 @@ import BasicSettingsStepBox from './BasicSettingsStepBox';
 import AdvancedSetup from './AdvancedSetup';
 
 const BasicSettings = () => {
-    const { device, enabledNetworks } = useSelector(state => ({
-        device: state.suite.device,
+    const { enabledNetworks } = useSelector(state => ({
         enabledNetworks: state.wallet.settings.enabledNetworks,
     }));
-
-    const unavailableCapabilities = device && device.features ? device.unavailableCapabilities : {};
 
     const enabledMainnetNetworks: Network['symbol'][] = [];
     const enabledTestnetNetworks: Network['symbol'][] = [];
@@ -43,7 +40,6 @@ const BasicSettings = () => {
             testnetNetworks={testnetNetworks}
             enabledMainnetNetworks={enabledMainnetNetworks}
             enabledTestnetNetworks={enabledTestnetNetworks}
-            unavailableCapabilities={unavailableCapabilities}
             heading={<Translation id="TR_ONBOARDING_COINS_STEP" />}
             description={<Translation id="TR_ONBOARDING_COINS_STEP_DESCRIPTION" />}
             outerActions={

--- a/packages/suite/src/views/settings/coins/components/CoinsGroup/index.tsx
+++ b/packages/suite/src/views/settings/coins/components/CoinsGroup/index.tsx
@@ -3,7 +3,6 @@ import styled from 'styled-components';
 import { P, Switch, Icon, variables, Button, useTheme } from '@trezor/components';
 import { Translation } from '@suite-components';
 import { NETWORKS } from '@wallet-config';
-import { UnavailableCapability } from 'trezor-connect';
 import { Network } from '@wallet-types';
 import { Section, ActionColumn, Row } from '@suite-components/Settings';
 import { useDevice, useActions } from '@suite-hooks';
@@ -100,7 +99,6 @@ interface Props {
     filterFn: (n: Network) => boolean;
     enabledNetworks: Network['symbol'][];
     type: 'mainnet' | 'testnet'; // used in tests
-    unavailableCapabilities: { [key: string]: UnavailableCapability };
 }
 
 const CoinsGroup = ({
@@ -111,7 +109,6 @@ const CoinsGroup = ({
     onToggleOneFn,
     filterFn,
     enabledNetworks,
-    unavailableCapabilities,
     ...props
 }: Props) => {
     const { openModal } = useActions({
@@ -122,6 +119,7 @@ const CoinsGroup = ({
     if (!device) return null;
 
     const isDeviceLocked = isLocked();
+    const unavailableCapabilities = device?.unavailableCapabilities ?? {};
     return (
         <Wrapper data-test={`@settings/wallet/coins-group/${props.type}`}>
             <Section
@@ -163,7 +161,7 @@ const CoinsGroup = ({
                     <CoinRow key={network.symbol}>
                         <Coin symbol={network.symbol} name={network.name} />
                         <ActionColumn>
-                            {!unavailableCapabilities[network.symbol] && (
+                            {!unavailableCapabilities[network.symbol] ? (
                                 <>
                                     <AdvancedSettings
                                         onClick={() =>
@@ -193,8 +191,7 @@ const CoinsGroup = ({
                                         isDisabled={isDeviceLocked}
                                     />
                                 </>
-                            )}
-                            {unavailableCapabilities[network.symbol] && (
+                            ) : (
                                 <UnavailableLabel>
                                     <Translation
                                         id={getUnavailabilityMessage(

--- a/packages/suite/src/views/settings/coins/components/CoinsGroup/index.tsx
+++ b/packages/suite/src/views/settings/coins/components/CoinsGroup/index.tsx
@@ -7,7 +7,7 @@ import { UnavailableCapability } from 'trezor-connect';
 import { Network } from '@wallet-types';
 import { Section, ActionColumn, Row } from '@suite-components/Settings';
 import { useDevice, useActions } from '@suite-hooks';
-import { isBitcoinOnly } from '@suite-utils/device';
+import { getUnavailabilityMessage } from '@suite-utils/device';
 import * as modalActions from '@suite-actions/modalActions';
 import Coin from '../Coin';
 
@@ -103,30 +103,6 @@ interface Props {
     unavailableCapabilities: { [key: string]: UnavailableCapability };
 }
 
-interface UnavailableMessageProps {
-    type: UnavailableCapability;
-    deviceVersion: number;
-    isBtcOnly: boolean;
-}
-const UnavailableMessage = ({ type, deviceVersion, isBtcOnly }: UnavailableMessageProps) => {
-    switch (type) {
-        case 'no-capability':
-            return deviceVersion === 1 && !isBtcOnly ? (
-                // right know it serves only one purpose - in case of XRP on T1 inform user that the capability is available on TT
-                <Translation id="FW_CAPABILITY_SUPPORTED_IN_T2" />
-            ) : (
-                <Translation id="FW_CAPABILITY_NO_CAPABILITY" />
-            );
-        case 'no-support':
-            return <Translation id="FW_CAPABILITY_NO_SUPPORT" />;
-        case 'update-required':
-            return <Translation id="FW_CAPABILITY_UPDATE_REQUIRED" />;
-        // case 'trezor-connect-outdated':
-        default:
-            return <Translation id="FW_CAPABILITY_CONNECT_OUTDATED" />;
-    }
-};
-
 const CoinsGroup = ({
     label,
     description,
@@ -146,8 +122,6 @@ const CoinsGroup = ({
     if (!device) return null;
 
     const isDeviceLocked = isLocked();
-    const deviceVersion = device.features?.major_version === 1 ? 1 : 2;
-    const isBtcOnly = isBitcoinOnly(device);
     return (
         <Wrapper data-test={`@settings/wallet/coins-group/${props.type}`}>
             <Section
@@ -222,10 +196,11 @@ const CoinsGroup = ({
                             )}
                             {unavailableCapabilities[network.symbol] && (
                                 <UnavailableLabel>
-                                    <UnavailableMessage
-                                        deviceVersion={deviceVersion}
-                                        isBtcOnly={isBtcOnly}
-                                        type={unavailableCapabilities[network.symbol]}
+                                    <Translation
+                                        id={getUnavailabilityMessage(
+                                            unavailableCapabilities[network.symbol],
+                                            device.features?.major_version,
+                                        )}
                                     />
                                 </UnavailableLabel>
                             )}

--- a/packages/suite/src/views/settings/coins/index.tsx
+++ b/packages/suite/src/views/settings/coins/index.tsx
@@ -17,7 +17,7 @@ const Settings = () => {
         enabledNetworks: state.wallet.settings.enabledNetworks,
     }));
 
-    const unavailableCapabilities = device && device.features ? device.unavailableCapabilities : {};
+    const unavailableCapabilities = device?.unavailableCapabilities ?? {};
 
     const mainnetNetworksFilterFn = (n: Network) => !n.accountType && !n.testnet;
 
@@ -58,7 +58,6 @@ const Settings = () => {
                 }
                 onDeactivateAll={() => changeNetworks(enabledTestnetNetworks)}
                 type="mainnet"
-                unavailableCapabilities={unavailableCapabilities}
             />
 
             <CoinsGroup
@@ -77,7 +76,6 @@ const Settings = () => {
                 }
                 onDeactivateAll={() => changeNetworks(enabledMainnetNetworks)}
                 type="testnet"
-                unavailableCapabilities={unavailableCapabilities}
             />
         </SettingsLayout>
     );

--- a/yarn.lock
+++ b/yarn.lock
@@ -5553,6 +5553,11 @@
   dependencies:
     tippy.js "^6.3.1"
 
+"@trezor/connect-common@^0.0.2":
+  version "0.0.2"
+  resolved "https://registry.yarnpkg.com/@trezor/connect-common/-/connect-common-0.0.2.tgz#d2bb1e90de6be2895b7f44215f09b52db361aaf4"
+  integrity sha512-b0R/HfA10mH2CR0BoPkKUs/2TC5Bf4MSGBFRF+1Q4tluQfSRzongQEZivg09vbBQEZBD1Ora3Oikn74zqsW4Aw==
+
 "@trezor/utxo-lib@0.1.2", "@trezor/utxo-lib@^0.1.2":
   version "0.1.2"
   resolved "https://registry.yarnpkg.com/@trezor/utxo-lib/-/utxo-lib-0.1.2.tgz#19319a424b0d0c648b0df456f1849eb08697fb44"
@@ -9231,6 +9236,11 @@ cbor-js@^0.1.0:
   version "0.1.0"
   resolved "https://registry.yarnpkg.com/cbor-js/-/cbor-js-0.1.0.tgz#c80ce6120f387e8faa74370dfda21d965b8fc7f9"
   integrity sha1-yAzmEg84fo+qdDcN/aIdlluPx/k=
+
+cbor-web@^7.0.6:
+  version "7.0.6"
+  resolved "https://registry.yarnpkg.com/cbor-web/-/cbor-web-7.0.6.tgz#6e23a0c58db4c38e485e395de511b9e2f628961c"
+  integrity sha512-A6ZH12jcDJG9PS7StugO78G+ok23SAjxMugGInPBy4IItiH6hYzybi6HQkGjWw9jBEGQpIBkleB2mizxYZIpLw==
 
 ccount@^1.0.0:
   version "1.1.0"
@@ -25164,18 +25174,20 @@ trezor-address-validator@^0.3.22:
     jssha "2.3.1"
     lodash "^4.17.15"
 
-trezor-connect@8.1.30-beta.2:
-  version "8.1.30-beta.2"
-  resolved "https://registry.yarnpkg.com/trezor-connect/-/trezor-connect-8.1.30-beta.2.tgz#7612ffde876bbf173cafdedf6caddca5e2cc822b"
-  integrity sha512-QxV2yjosvT1E6fCdU3oL+akUluiSr1SmxRUj9XcEse/XVe0S7Z6kAhyjOGr0XO4z+orS2DlYyWdBh6MzaXC5zw==
+trezor-connect@8.1.30-beta.7:
+  version "8.1.30-beta.7"
+  resolved "https://registry.yarnpkg.com/trezor-connect/-/trezor-connect-8.1.30-beta.7.tgz#aa0f7ed62417dd7120d217896b360fa87101f2f4"
+  integrity sha512-sUxzM9vnpGDDXBTdQTf6sG2JKcsieB++kxXQ4O6NTCYc3N6lI5ysoFfoYzPY1dkI/fANh5F+WdUg5PzX7sQOYA==
   dependencies:
     "@babel/runtime" "^7.12.5"
     "@trezor/blockchain-link" "^1.0.17"
+    "@trezor/connect-common" "^0.0.2"
     "@trezor/rollout" "^1.2.0"
     "@trezor/utxo-lib" "^0.1.2"
     bchaddrjs "^0.5.2"
     bignumber.js "^9.0.1"
     bowser "^2.11.0"
+    cbor-web "^7.0.6"
     events "^3.2.0"
     hd-wallet "9.1.2"
     keccak "^3.0.1"


### PR DESCRIPTION
- bump connect

- implement fix of `unavailableCapabilities` https://github.com/trezor/connect/commit/bbf4e365e42a135aac5a0b4607dc6fd54e14d4a6
Example: XRP on T1 'no-capability' is replaced by 'no-support'

- cleanup in components
`unavailableCapabilities` props was passed all the way down thru 4 components but should be obtained by final/last-child component (CoinsList) from the device

T1 and XRP

![Screenshot from 2021-09-09 10-41-07](https://user-images.githubusercontent.com/3435913/132653285-384f9a5c-62eb-40ce-80e2-78073b0c0825.png)
![Screenshot from 2021-09-09 10-37-04](https://user-images.githubusercontent.com/3435913/132653371-da7ed9bd-813a-41ea-aa80-05ac682a4dae.png)

TT bitcoin-only

![Screenshot from 2021-09-09 10-49-14](https://user-images.githubusercontent.com/3435913/132654534-a227cd7b-6d62-4e2e-8836-e4398289bf39.png)


