### PR TITLE
feat(invity): coinmarket: sort fraction buttons by ascending value

### DIFF
--- a/packages/suite/src/components/wallet/CoinMarketFractionButtons/index.tsx
+++ b/packages/suite/src/components/wallet/CoinMarketFractionButtons/index.tsx
@@ -31,14 +31,14 @@ interface Props {
 const FractionButtons = ({ disabled, onFractionClick, onAllClick }: Props) => (
     <Wrapper>
         <Left>
-            <SmallButton isDisabled={disabled} onClick={() => onFractionClick(2)}>
-                1/2
+            <SmallButton isDisabled={disabled} onClick={() => onFractionClick(4)}>
+                1/4
             </SmallButton>
             <SmallButton isDisabled={disabled} onClick={() => onFractionClick(3)}>
                 1/3
             </SmallButton>
-            <SmallButton isDisabled={disabled} onClick={() => onFractionClick(4)}>
-                1/4
+            <SmallButton isDisabled={disabled} onClick={() => onFractionClick(2)}>
+                1/2
             </SmallButton>
             <SmallButton isDisabled={disabled} onClick={() => onAllClick()}>
                 <Translation id="TR_FRACTION_BUTTONS_ALL" />


### PR DESCRIPTION
Current order of fraction buttons is:
![image](https://user-images.githubusercontent.com/7394177/132659392-36ff7937-fda6-4797-8a5d-2a85e79519ec.png)

Improvement is to sort the buttons in ascending order:
![image](https://user-images.githubusercontent.com/7394177/132659649-d07eff48-e84f-422c-bbdb-6bf47585d689.png)

(This applies to the Sell and the Exchange section.)