### PR TITLE
Fixes and enables automatic reboot. Fixes bitcoin-only fw update

### DIFF
--- a/packages/components/src/components/Modal/index.tsx
+++ b/packages/components/src/components/Modal/index.tsx
@@ -290,8 +290,8 @@ const getFixedWidth = (size: SIZE) => {
 };
 
 // returns the value of padding-left/right for Heading, Description, Content and BottomBar
-const getContentPaddingSide = (size: SIZE, noPadding: boolean) => {
-    if (noPadding) {
+const getContentPaddingSide = (size: SIZE, noPadding: boolean, noSidePadding: boolean) => {
+    if (noPadding || noSidePadding) {
         return ZERO_PADDING;
     }
 
@@ -358,6 +358,7 @@ interface Props extends React.HTMLAttributes<HTMLDivElement> {
     contentPaddingSide?: [string, string, string, string]; // [SM, MD, LG, XL]
     noPadding?: boolean;
     noHeadingPadding?: boolean;
+    noSidePadding?: boolean;
     noBackground?: boolean;
     onCancel?: () => void;
     showHeaderBorder?: boolean;
@@ -386,11 +387,12 @@ const Modal = ({
     fixedHeight = FIXED_HEIGHT,
     noPadding = false,
     noHeadingPadding = false,
+    noSidePadding = false,
     // TODO: get rid of all these padding props bellow. Usage should be simple: Either use default paddings provided by modal, or use noPadding and then do all necessary work in components which will be passed as heading, description, children/content. We cannot keep handling whole universe here for few stupid custom components
     modalPaddingTop = getModalPaddingTop(size, heading, noPadding),
     modalPaddingBottom = getModalPaddingBottom(size, noPadding),
     modalPaddingSide = ZERO_PADDING, // default value is zero padding on sides for Modal container
-    contentPaddingSide = getContentPaddingSide(size, noPadding),
+    contentPaddingSide = getContentPaddingSide(size, noPadding, noSidePadding),
     showHeaderBorder = true,
     hiddenProgressBar = false, // reserves the space for progress bar (4px under the heading), but not showing the green bar
     totalProgressBarSteps,

--- a/packages/suite/src/actions/suite/suiteActions.ts
+++ b/packages/suite/src/actions/suite/suiteActions.ts
@@ -237,7 +237,7 @@ export const selectDevice =
 /**
  * Toggles remembering the given device. I.e. if given device is not remembered it will become remembered
  * and if it is remembered it will be forgotten.
- * @param forceRemember can be set to `true` to remember given device regardless if its current state.
+ * @param forceRemember can be set to `true` to remember given device regardless of its current state.
  *
  * Use `forgetDevice` to forget a device regardless if its current state.
  */
@@ -321,14 +321,13 @@ export const handleDeviceDisconnect =
         if (!selectedDevice) return;
         if (selectedDevice.path !== device.path) return;
 
-        const { devices, firmware, router } = getState();
+        const { devices, router } = getState();
 
-        if (
-            ['wait-for-reboot', 'unplug'].includes(firmware.status) ||
-            router.app === 'onboarding'
-        ) {
-            // Suite tried to switch selected device to a remembered (and disconnected) device or another connected device while being in Onboarding process.
-            // We never want to switch to some different remembered device when currently used device disconnects because of loose cable or in order to complete firmware installation
+        /**
+         * Under normal circumstances, after device is disconnected we want suite to select another existing device (either remembered or physically connected)
+         * This is not the case in firmware update and onboarding; In this case we simply wan't suite.device to be empty until user reconnects a device again
+         */
+        if (['onboarding', 'firmware'].includes(router.app)) {
             dispatch({ type: SUITE.SELECT_DEVICE, payload: undefined });
             return;
         }

--- a/packages/suite/src/components/firmware/FirmwareInitial.tsx
+++ b/packages/suite/src/components/firmware/FirmwareInitial.tsx
@@ -74,7 +74,7 @@ const FirmwareInitial = ({
         return <ConnectDevicePromptManager device={device} />;
     }
 
-    if (device.firmware === 'none') {
+    if (['none', 'unknown'].includes(device.firmware)) {
         // No firmware installed
         // Device without firmware is already in bootloader mode even if it doesn't report it
         content = {

--- a/packages/suite/src/components/firmware/FirmwareOffer.tsx
+++ b/packages/suite/src/components/firmware/FirmwareOffer.tsx
@@ -2,7 +2,12 @@ import React from 'react';
 import styled from 'styled-components';
 import { Button, Icon, Tooltip, variables } from '@trezor/components';
 import { Translation, TrezorLink } from '@suite-components';
-import { getFwUpdateVersion, getFwVersion, parseFirmwareChangelog } from '@suite-utils/device';
+import {
+    getFwUpdateVersion,
+    getFwVersion,
+    isBitcoinOnly,
+    parseFirmwareChangelog,
+} from '@suite-utils/device';
 import { AcquiredDevice } from '@suite-types';
 import { CHANGELOG_URL } from '@suite-constants/urls';
 
@@ -87,12 +92,15 @@ interface Props {
 
 const FirmwareOffer = ({ device, customFirmware }: Props) => {
     const currentVersion = device.firmware !== 'none' ? getFwVersion(device) : undefined;
+
     const newVersion = customFirmware ? (
         <Translation id="TR_CUSTOM_FIRMWARE_VERSION" />
     ) : (
         getFwUpdateVersion(device)
     );
     const parsedChangelog = !customFirmware && parseFirmwareChangelog(device.firmwareRelease);
+    const bitcoinOnlyVersion = isBitcoinOnly(device) && ' (bitcoin-only)';
+
     return (
         <FwVersionWrapper>
             {currentVersion && (
@@ -101,7 +109,12 @@ const FirmwareOffer = ({ device, customFirmware }: Props) => {
                         <Label>
                             <Translation id="TR_ONBOARDING_CURRENT_VERSION" />
                         </Label>
-                        <Version>{currentVersion}</Version>
+                        <VersionWrapper>
+                            <Version>
+                                {currentVersion}
+                                {bitcoinOnlyVersion}
+                            </Version>
+                        </VersionWrapper>
                     </FwVersion>
                     <IconWrapper>
                         <Icon icon="ARROW_RIGHT_LONG" size={16} />
@@ -154,10 +167,16 @@ const FirmwareOffer = ({ device, customFirmware }: Props) => {
                             }
                             placement="top"
                         >
-                            <Version new>{newVersion}</Version>
+                            <Version new>
+                                {newVersion}
+                                {bitcoinOnlyVersion}
+                            </Version>
                         </Tooltip>
                     ) : (
-                        <Version new>{newVersion}</Version>
+                        <Version new>
+                            {newVersion}
+                            {!customFirmware && bitcoinOnlyVersion}
+                        </Version>
                     )}
                 </VersionWrapper>
             </FwVersion>

--- a/packages/suite/src/hooks/firmware/useRebootRequest.ts
+++ b/packages/suite/src/hooks/firmware/useRebootRequest.ts
@@ -28,7 +28,7 @@ export const useRebootRequest = (
         return requestedMode === 'bootloader' &&
             valid(deviceFwVersion) &&
             satisfies(deviceFwVersion, '>=1.10.0 <2.0.0')
-            ? 'manual' // TODO: replace with 'automatic' mode when #4233 solved
+            ? 'automatic'
             : 'manual';
     });
 

--- a/packages/suite/src/middlewares/firmware/firmwareMiddleware.ts
+++ b/packages/suite/src/middlewares/firmware/firmwareMiddleware.ts
@@ -1,5 +1,5 @@
 import { MiddlewareAPI } from 'redux';
-import TrezorConnect, { DEVICE } from 'trezor-connect';
+import TrezorConnect from 'trezor-connect';
 
 import { SUITE } from '@suite-actions/constants';
 import * as firmwareActions from '@firmware-actions/firmwareActions';
@@ -25,6 +25,9 @@ const firmware =
                 // device is not connected.
                 if (['waiting-for-bootloader', 'check-seed'].includes(action.payload) && device) {
                     api.dispatch(firmwareActions.setTargetRelease(device.firmwareRelease));
+
+                    // remember previous device for firmware type check (regular/bitcoin-only) and analytics
+                    api.dispatch(firmwareActions.rememberPreviousDevice(device));
                 }
 
                 break;
@@ -103,20 +106,6 @@ const firmware =
                     api.dispatch(firmwareActions.resetReducer());
                 }
 
-                break;
-            case DEVICE.DISCONNECT:
-                // we want to store data about previous device only in firmware update modal which is located in "firmware" and "onboarding" apps
-                // we need to do this because device in bootloader mode misses some features attributes required for updating logic
-                // if user disconnects device to connect it in bootloader mode, it opens "device disconnected" modal
-                // so prevApp is equal to "firmware" in case the update process started in settings or "onboarding" in case of onboarding
-                // moreover we do not want to do it if device was already in bootloader
-                // as this can happen only if user disconnected the device again after already being in bootloader mode
-                if (
-                    (prevApp === 'firmware' || prevApp === 'onboarding') &&
-                    action.payload.mode !== 'bootloader'
-                ) {
-                    api.dispatch(firmwareActions.rememberPreviousDevice(action.payload));
-                }
                 break;
             default:
         }

--- a/packages/suite/src/middlewares/firmware/firmwareMiddleware.ts
+++ b/packages/suite/src/middlewares/firmware/firmwareMiddleware.ts
@@ -3,7 +3,6 @@ import TrezorConnect, { DEVICE } from 'trezor-connect';
 
 import { SUITE } from '@suite-actions/constants';
 import * as firmwareActions from '@firmware-actions/firmwareActions';
-import * as suiteActions from '@suite-actions/suiteActions';
 
 import { AppState, Action, Dispatch } from '@suite-types';
 import { FIRMWARE } from '@suite/actions/firmware/constants';
@@ -26,23 +25,6 @@ const firmware =
                 // device is not connected.
                 if (['waiting-for-bootloader', 'check-seed'].includes(action.payload) && device) {
                     api.dispatch(firmwareActions.setTargetRelease(device.firmwareRelease));
-
-                    // in case device is not remembered, force remember here. this is needed to handle device update correctly
-                    // when multiple devices are connected.
-                    // WARNING: This has never worked in case of fresh unpacked device without fw installed (or just used device with wiped fw).
-                    // Such device can't be remembered because it is always in bootloader mode and has no state
-                    // (rememberDevice functionality supports only devices in normal mode with defined state as it is used to remember wallets).
-                    // This may cause problems in combination with
-                    // a) remembered wallet - basically after fw installation, device is restarted and suite will select whatever available remembered device (wallet) as active device.
-                    // b) multiple physical devices connected
-                    // To mitigate this I would do following:
-                    // a) (done) make sure Suite won't select disconnected (remembered) device as active device (done in suiteActions.handleDeviceDisconnect)
-                    // b) (TODO) disallow going through onboarding/fw update with multiple physical devices connected at the same time (and if currently selected device has no fw installed)
-                    // This would save us from huge headache with hacky solutions like trying to remember a device before the update process
-                    // in exchange for just a slightly worse UX for users which have multiple connected devices (there will not be many of them)
-                    if (!device.remember) {
-                        api.dispatch(suiteActions.toggleRememberDevice(device, true));
-                    }
                 }
 
                 break;
@@ -114,18 +96,8 @@ const firmware =
             case SUITE.APP_CHANGED:
                 // leaving firmware update context
                 if (prevApp === 'firmware' || prevApp === 'onboarding') {
-                    const { device } = api.getState().suite;
-
                     api.dispatch(firmwareActions.resetReducer());
-
-                    // clean up force remembered device if applicable
-                    if (device?.features && device.forceRemember) {
-                        api.dispatch(suiteActions.forgetDevice(device));
-                    }
                 }
-
-                // entering firmware update context is not handled here. In onboarding device may not be connected
-                // in the beginning, so remember happens after firmware.status is changed to check-seed or waiting-for-bootloader, see^^
 
                 break;
             case DEVICE.DISCONNECT:

--- a/packages/suite/src/middlewares/firmware/firmwareMiddleware.ts
+++ b/packages/suite/src/middlewares/firmware/firmwareMiddleware.ts
@@ -86,7 +86,11 @@ const firmware =
                         keepSession: false,
                     });
 
-                    if (action.payload.firmware === 'valid') {
+                    // last version of firmware or custom firmware version was installed
+                    if (
+                        action.payload.firmware === 'valid' ||
+                        (action.payload.firmware === 'outdated' && prevApp === 'firmware-custom')
+                    ) {
                         api.dispatch(firmwareActions.setStatus('done'));
                     } else if (['outdated', 'required'].includes(action.payload.firmware)) {
                         api.dispatch(firmwareActions.setStatus('partially-done'));

--- a/packages/suite/src/middlewares/suite/__tests__/suiteMiddleware.test.ts
+++ b/packages/suite/src/middlewares/suite/__tests__/suiteMiddleware.test.ts
@@ -30,6 +30,9 @@ export const getInitialState = (router?: RouterState, suite?: Partial<SuiteState
         type: ANALYTICS.INIT,
         payload: { instanceId: '1', sessionId: '2', enabled: false, sessionStart: 1 },
     }),
+    messageSystem: {
+        timestamp: Date.now() + 10000,
+    },
 });
 
 type State = ReturnType<typeof getInitialState>;

--- a/packages/suite/src/views/firmware/FirmwareCustom.tsx
+++ b/packages/suite/src/views/firmware/FirmwareCustom.tsx
@@ -76,6 +76,7 @@ const FirmwareCustom = () => {
         <Modal
             cancelable={isCancelable}
             onCancel={onClose}
+            noSidePadding={status !== 'initial'} // TODO: redesign custom fw modal to match fw update modal
             heading={<Translation id="TR_DEVICE_SETTINGS_CUSTOM_FIRMWARE_TITLE" />}
             header={
                 status === 'waiting-for-confirmation' && (


### PR DESCRIPTION
1. fix: deselected device after onboarding (9041b5a)
    - fixes a problem that it was not possible to update device after it was aborted once
2. fix(suite): indicate bitcoin-only fw type in fw update modal (3090a27)
3. chore(suite): enable automatic reboot request (25e485d)
    -  we disabled it before release but it should be fixed when @szymonlesisz releases new version of `connect`
4. fix(suite): do not show fw partially updated when custom fw is installed (53bdb03)
    - when user installs custom fw, it is not a partial update
5. fix(suite): install correct fw type (regular/bitcoin-only) (8d0632e)
    - device is not always disconnected on automatic reboot requests, cache device the same time as `targetRelease`
