### PR TITLE
fix: align rotation buttons

### DIFF
--- a/packages/suite/src/views/settings/device/index.tsx
+++ b/packages/suite/src/views/settings/device/index.tsx
@@ -32,7 +32,6 @@ import { formatDurationStrict } from '@suite/utils/suite/date';
 
 const RotationButton = styled(ActionButton)`
     min-width: 81px;
-    margin: 4px;
     flex-basis: 45%;
 
     @media screen and (min-width: ${variables.SCREEN_SIZE.MD}) {


### PR DESCRIPTION
kinda OCD PR. rotation buttons were not aligned with vertical line.

before: 

![rot-margin](https://user-images.githubusercontent.com/30367552/133047828-328a365a-6ea7-41b5-9cc9-591eccdddac2.png)

after

![rot-no-margin](https://user-images.githubusercontent.com/30367552/133047848-7c41bee0-0b62-43c5-b601-b831bf58e173.png)
