### PR TITLE
test(e2e): add export transactions test

### DIFF
--- a/packages/integration-tests/projects/suite-web/cypress.json
+++ b/packages/integration-tests/projects/suite-web/cypress.json
@@ -1,6 +1,7 @@
 {
     "integrationFolder": "./tests",
     "fixturesFolder": "./fixtures",
+    "downloadsFolder": "./downloads",
     "pluginsFile": "./plugins/index.js",
     "supportFile": "./support/index.ts",
     "defaultCommandTimeout": 10000,

--- a/packages/integration-tests/projects/suite-web/plugins/index.js
+++ b/packages/integration-tests/projects/suite-web/plugins/index.js
@@ -5,11 +5,14 @@
 // https://github.com/bahmutov/add-typescript-to-cypress/tree/master/e2e/cypress
 
 import CDP from 'chrome-remote-interface';
+import fs from 'fs';
+import path from 'path';
 import { addMatchImageSnapshotPlugin } from 'cypress-image-snapshot/plugin';
 import { Controller } from './websocket-client';
 import googleMock from './google';
 import dropboxMock from './dropbox';
 import * as metadataUtils from '../../../../suite/src/utils/suite/metadata';
+import config from '../cypress.json';
 
 const webpackPreprocessor = require('@cypress/webpack-preprocessor');
 
@@ -287,6 +290,20 @@ module.exports = on => {
                 nodeId,
                 forcedPseudoClasses: ['hover'],
             });
+        },
+
+        readDir: dir => fs.readdirSync(dir, { encoding: 'utf-8' }),
+        rmDir: opts => {
+            const { dir, force, recursive } = opts;
+            // just a security check so that we do accidentally wipe something we don't want
+            const restrictedPath = path.join(__dirname, '..', config.downloadsFolder);
+            if (!dir.startsWith(restrictedPath)) {
+                console.warn('trying to rmDir ', dir);
+                throw new Error(`'it is not allowed to rm outside ${restrictedPath}`);
+            }
+
+            fs.rmdirSync(dir, { force, recursive });
+            return null;
         },
     });
 };

--- a/packages/integration-tests/projects/suite-web/run_tests.js
+++ b/packages/integration-tests/projects/suite-web/run_tests.js
@@ -118,6 +118,7 @@ async function runTests() {
             screenshotsFolder: `${__dirname}/screenshots`,
             integrationFolder: `${__dirname}/tests`,
             videosFolder: `${__dirname}/videos`,
+            downloadsFolder: `${__dirname}/downloads`,
             video: true,
             chromeWebSecurity: false,
             trashAssetsBeforeRuns: false,

--- a/packages/integration-tests/projects/suite-web/tests/wallet/export-transactions.test.ts
+++ b/packages/integration-tests/projects/suite-web/tests/wallet/export-transactions.test.ts
@@ -1,0 +1,63 @@
+// @group:suite
+// @retry=2
+
+const downloadsFolder = Cypress.config('downloadsFolder');
+
+describe('Export transactions', () => {
+    beforeEach(() => {
+        cy.task('rmDir', { dir: downloadsFolder, recursive: true, force: true });
+        cy.task('startEmu', { version: Cypress.env('emuVersionT2'), wipe: true });
+        cy.task('setupEmu', {
+            mnemonic: 'all all all all all all all all all all all all',
+        });
+        cy.task('startBridge');
+        cy.viewport(1024, 768).resetDb();
+        cy.prefixedVisit('/');
+        cy.passThroughInitialRun();
+        cy.discoveryShouldFinish();
+    });
+
+    afterEach(() => {
+        cy.task('rmDir', { dir: downloadsFolder, recursive: true, force: true });
+    });
+
+    it('Go to account and try to export all possible variants (pdf, csv, json)', () => {
+        // go to wallet (account)
+        cy.getTestElement('@suite/menu/wallet-index').click();
+
+        // scroll down so that dropdown appears on screen
+        cy.getTestElement('@wallet/accounts/export-transactions/dropdown').scrollIntoView({
+            offset: { top: -150, left: 0 },
+        });
+
+        // export pdf
+        cy.getTestElement('@wallet/accounts/export-transactions/dropdown').click({
+            scrollBehavior: false,
+        });
+        cy.getTestElement('@wallet/accounts/export-transactions/pdf').click({
+            scrollBehavior: false,
+        });
+
+        // export csv
+        cy.getTestElement('@wallet/accounts/export-transactions/dropdown').click({
+            scrollBehavior: false,
+        });
+        cy.getTestElement('@wallet/accounts/export-transactions/csv').click({
+            scrollBehavior: false,
+        });
+
+        // export json
+        cy.getTestElement('@wallet/accounts/export-transactions/dropdown').click({
+            scrollBehavior: false,
+        });
+        cy.getTestElement('@wallet/accounts/export-transactions/json').click({
+            scrollBehavior: false,
+        });
+
+        // assert that downloads folder contains 3 files
+        cy.wait(500);
+        cy.task('readDir', downloadsFolder).then(dir => {
+            cy.wrap(dir).should('have.length', 3);
+        });
+    });
+});

--- a/packages/suite/src/views/wallet/transactions/components/TransactionList/components/Actions/components/ExportAction/index.tsx
+++ b/packages/suite/src/views/wallet/transactions/components/TransactionList/components/Actions/components/ExportAction/index.tsx
@@ -62,6 +62,8 @@ const ExportAction = ({ account }: Props) => {
         return null;
     }
 
+    const dataTest = '@wallet/accounts/export-transactions';
+
     if (isExportRunning) {
         return <Loader size={18} />;
     }
@@ -77,20 +79,24 @@ const ExportAction = ({ account }: Props) => {
                             key: 'export-csv',
                             label: <Translation id="TR_EXPORT_AS" values={{ as: 'CSV' }} />,
                             callback: () => runExport('csv'),
+                            'data-test': `${dataTest}/csv`,
                         },
                         {
                             key: 'export-pdf',
                             label: <Translation id="TR_EXPORT_AS" values={{ as: 'PDF' }} />,
                             callback: () => runExport('pdf'),
+                            'data-test': `${dataTest}/pdf`,
                         },
                         {
                             key: 'export-json',
                             label: <Translation id="TR_EXPORT_AS" values={{ as: 'JSON' }} />,
                             callback: () => runExport('json'),
+                            'data-test': `${dataTest}/json`,
                         },
                     ],
                 },
             ]}
+            data-test={`${dataTest}/dropdown`}
         />
     );
 };


### PR DESCRIPTION
in preparation for #4236 I am adding some end-to-end testing for exp#4259  orting transactions. in fact, it is not a difficult thing to do as we can do everything node.js can do from tests including access to hosts filesystem. 

this is likely to conflict with #4259 but it doesn't matter, I ll rebase once either of them is merged