### PR TITLE
fix(suite-desktop,autoupdater):  fix NODE_ENV param propagation to build script for electron

### DIFF
--- a/packages/suite-desktop/package.json
+++ b/packages/suite-desktop/package.json
@@ -14,7 +14,7 @@
         "clean": "rimraf ./build-electron && rimraf ./build && rimraf ./dist",
         "copy-files": "yarn workspace @trezor/suite-data copy-static-files",
         "build:ui": "rimraf ./build && yarn workspace @trezor/suite-build run build:desktop",
-        "build:app": "cross-env NODE_ENV=production rimraf ./dist && node scripts/build.js && yarn build:app:electron",
+        "build:app": "rimraf ./dist && cross-env NODE_ENV=production node scripts/build.js && yarn build:app:electron",
         "build:app:electron": "electron-builder --c.extraMetadata.version=$(node -p \"require('../suite/package').suiteVersion\")",
         "build:app:linux": "yarn build:app  --publish never --linux --x64 --arm64",
         "build:app:mac": "yarn build:app  --publish never --mac --x64 --arm64",


### PR DESCRIPTION

- electron-updater was mocked because of that so it can't work at all