### PR TITLE
chore: introduce bounty e2e group

### DIFF
--- a/ci/test.yml
+++ b/ci/test.yml
@@ -65,6 +65,15 @@ e2e web metadata:
   variables:
     TEST_GROUP: '@group:metadata'
 
+# bounty group gathers flaky tests.
+e2e web bounty:
+  extends: .e2e web
+  allow_failure: true
+  variables:
+    TEST_GROUP: '@group:bounty'
+    ALLOW_RETRY: 0
+
+
 ## Update snapshots
 ## You may update snapshots either locally (see readme https://docs.trezor.io/trezor-suite/tests/e2e-web.html)
 ## But as this is quite time consuming you may prefer to do it in CI

--- a/packages/integration-tests/projects/suite-web/tests/onboarding/t1-recovery-advanced.test.ts
+++ b/packages/integration-tests/projects/suite-web/tests/onboarding/t1-recovery-advanced.test.ts
@@ -1,6 +1,6 @@
 /* eslint-disable @typescript-eslint/naming-convention */
 
-// @group:onboarding
+// @group:bounty
 // @retry=2
 
 describe('Onboarding - recover wallet T1', () => {

--- a/packages/integration-tests/projects/suite-web/tests/settings/t1-device-settings.test.ts
+++ b/packages/integration-tests/projects/suite-web/tests/settings/t1-device-settings.test.ts
@@ -1,4 +1,4 @@
-// @group:settings
+// @group:bounty
 // @retry=2
 
 describe('T1 - Device settings', () => {


### PR DESCRIPTION
I suggest running flaky tests in a separate group that is allowed to fail in CI. This will give us both:
- reliable tests
- ability to debug flaky tests in the wild. 