### PR TITLE
fix(suite): use noopener/noreferrer for target=_blank

### DIFF
--- a/packages/suite/src/views/dashboard/components/NewsFeed/index.tsx
+++ b/packages/suite/src/views/dashboard/components/NewsFeed/index.tsx
@@ -99,7 +99,11 @@ const NewsFeed = ({ maxVisibleCount = 9 }: Props) => {
         <Section
             heading={<Translation id="TR_WHATS_NEW" />}
             actions={
-                <MediumLink target="_blank" href={isTor ? toTorUrl(BLOG_URL) : BLOG_URL}>
+                <MediumLink
+                    target="_blank"
+                    rel="noopener noreferrer"
+                    href={isTor ? toTorUrl(BLOG_URL) : BLOG_URL}
+                >
                     <Button isWhite variant="tertiary" icon="MEDIUM">
                         <Translation id="TR_OPEN_IN_MEDIUM" />
                     </Button>
@@ -111,6 +115,7 @@ const NewsFeed = ({ maxVisibleCount = 9 }: Props) => {
                     <Post
                         key={item.link}
                         target="_blank"
+                        rel="noopener noreferrer"
                         href={isTor ? toTorUrl(item.link) : item.link}
                         data-test={`@dashboard/news/post/${index}`}
                     >

--- a/packages/suite/src/views/settings/device/index.tsx
+++ b/packages/suite/src/views/settings/device/index.tsx
@@ -240,6 +240,7 @@ const Settings = () => {
                                             <VersionTooltip content={revision} disabled={!revision}>
                                                 <VersionLink
                                                     target="_blank"
+                                                    rel="noopener noreferrer"
                                                     href={FIRMWARE_COMMIT_URL + revision}
                                                 >
                                                     <VersionButton

--- a/packages/suite/src/views/settings/index.tsx
+++ b/packages/suite/src/views/settings/index.tsx
@@ -338,6 +338,7 @@ const Settings = () => {
                                             <VersionTooltip content={process.env.COMMITHASH || ''}>
                                                 <VersionLink
                                                     target="_blank"
+                                                    rel="noopener noreferrer"
                                                     href={`https://github.com/trezor/trezor-suite/commit/${process.env.COMMITHASH}`}
                                                 >
                                                     <VersionButton
@@ -362,6 +363,7 @@ const Settings = () => {
                                                     version: (
                                                         <VersionLink
                                                             target="_blank"
+                                                            rel="noopener noreferrer"
                                                             href={getReleaseUrl(
                                                                 desktopUpdate.latest.version,
                                                             )}


### PR DESCRIPTION
Some components that descend from `Link` already do that.

Others (`MediumLink`/`Post`/`VersionLink`) don't, so let's add it manually. 

I feel this can be refactored into having a common ascendent which takes care of this automatically, but this is out of scope of this PR.