### PR TITLE
Fix/quick theme preload

### DIFF
--- a/packages/suite-desktop/src/index.tsx
+++ b/packages/suite-desktop/src/index.tsx
@@ -20,7 +20,6 @@ import OnlineStatus from '@suite-support/OnlineStatus';
 import ErrorBoundary from '@suite-support/ErrorBoundary';
 import RouterHandler from '@suite-support/Router';
 import ThemeProvider from '@suite-support/ThemeProvider';
-import GlobalStyleProvider from '@suite-support/styles/GlobalStyleProvider';
 import DesktopTitlebarWrapper from './support/DesktopTitlebar';
 import history from '@suite/support/history';
 import AppRouter from './support/Router';
@@ -43,7 +42,6 @@ const Index = () => {
         <ReduxProvider store={store}>
             <ThemeProvider>
                 <RouterProvider history={history}>
-                    <GlobalStyleProvider />
                     <DesktopTitlebarWrapper>
                         <ErrorBoundary>
                             <Autodetect />

--- a/packages/suite-native/src/components/suite/DeviceSelector/index.tsx
+++ b/packages/suite-native/src/components/suite/DeviceSelector/index.tsx
@@ -1,7 +1,8 @@
 import React, { useContext } from 'react';
 import { View, Text, StyleSheet } from 'react-native';
+import { useTheme } from '@trezor/components';
 // import * as suiteActions from '@suite-actions/suiteActions';
-import { useDevice, useTheme } from '@suite-hooks';
+import { useDevice } from '@suite-hooks';
 import { SuiteThemeColors, TrezorDevice } from '@suite-types';
 import * as deviceUtils from '@suite-utils/device';
 import DeviceImage from '@native-components/suite/DeviceImage';
@@ -83,7 +84,7 @@ const statusStyles = (theme: SuiteThemeColors, status: Status) =>
 
 const DeviceSelector = () => {
     const { device } = useDevice();
-    const { theme } = useTheme();
+    const theme = useTheme();
     const status = getStatusForDevice(device);
     // const { acquireDevice } = useActions({
     //     acquireDevice: suiteActions.acquireDevice,

--- a/packages/suite-native/src/components/suite/Drawer/index.tsx
+++ b/packages/suite-native/src/components/suite/Drawer/index.tsx
@@ -19,9 +19,10 @@ const styles = (theme: SuiteThemeColors) =>
 
 const Drawer = (_props: DrawerContentComponentProps) => {
     const { device } = useDevice();
-    const { theme, themeVariant, setTheme } = useTheme();
-    const { goto, acquireDevice } = useActions({
+    const { theme, themeVariant } = useTheme();
+    const { goto, setTheme, acquireDevice } = useActions({
         acquireDevice: suiteActions.acquireDevice,
+        setTheme: suiteActions.setTheme,
         goto: routerActions.goto,
     });
 

--- a/packages/suite-native/src/components/suite/Drawer/index.tsx
+++ b/packages/suite-native/src/components/suite/Drawer/index.tsx
@@ -1,9 +1,9 @@
 import React from 'react';
 import { View, Text, StyleSheet } from 'react-native';
-import { Button } from '@trezor/components';
+import { Button, useTheme } from '@trezor/components';
 import * as routerActions from '@suite-actions/routerActions';
 import * as suiteActions from '@suite-actions/suiteActions';
-import { useDevice, useActions, useTheme } from '@suite-hooks';
+import { useDevice, useActions } from '@suite-hooks';
 import DeviceSelector from '@native-components/suite/DeviceSelector';
 import { DrawerContentComponentProps } from 'react-navigation-drawer';
 import Translation from '@native-components/suite/Translation';
@@ -19,7 +19,7 @@ const styles = (theme: SuiteThemeColors) =>
 
 const Drawer = (_props: DrawerContentComponentProps) => {
     const { device } = useDevice();
-    const { theme, themeVariant } = useTheme();
+    const theme = useTheme();
     const { goto, setTheme, acquireDevice } = useActions({
         acquireDevice: suiteActions.acquireDevice,
         setTheme: suiteActions.setTheme,
@@ -39,7 +39,7 @@ const Drawer = (_props: DrawerContentComponentProps) => {
                 </Button>
                 <Button
                     onClick={() => {
-                        setTheme(themeVariant === 'dark' ? 'light' : 'dark');
+                        setTheme(theme.THEME === 'dark' ? 'light' : 'dark');
                     }}
                 >
                     Change theme

--- a/packages/suite-native/src/components/suite/Layout/index.tsx
+++ b/packages/suite-native/src/components/suite/Layout/index.tsx
@@ -1,9 +1,9 @@
 import React from 'react';
 import { connect } from 'react-redux';
 import { Text, ScrollView, View } from 'react-native';
+import { useTheme } from '@trezor/components';
 import Head from '@native/support/suite/Head';
 import { AppState, SuiteThemeColors } from '@suite-types';
-import { useTheme } from '@suite-hooks';
 
 const styles = (theme: SuiteThemeColors) => ({
     wrapper: { backgroundColor: theme.BG_WHITE },
@@ -25,7 +25,7 @@ const Layout = (props: Props) => {
         suite,
         // router,
     } = props;
-    const { theme } = useTheme();
+    const theme = useTheme();
 
     // connect was initialized, but didn't emit "TRANSPORT" event yet (it could take a while)
     if (!suite.transport) {

--- a/packages/suite-native/src/components/suite/Preloader/index.tsx
+++ b/packages/suite-native/src/components/suite/Preloader/index.tsx
@@ -10,10 +10,9 @@ import { connect } from 'react-redux';
 import { Text, View } from 'react-native';
 import { SafeAreaView } from 'react-navigation';
 import { SUITE } from '@suite-actions/constants';
-// import { H1, P } from '@trezor/components';
+import { useTheme } from '@trezor/components';
 import { AppState, Dispatch } from '@suite-types';
 import styles from '@native/support/suite/styles';
-import { useTheme } from '@suite-hooks';
 
 const mapStateToProps = (state: AppState) => ({
     loading: state.suite.loading,
@@ -28,7 +27,7 @@ type Props = ReturnType<typeof mapStateToProps> & {
 
 const Preloader = (props: Props) => {
     const { loading, loaded, error, dispatch } = props;
-    const { theme } = useTheme();
+    const theme = useTheme();
     useEffect(() => {
         if (!loading && !loaded && !error) {
             dispatch({ type: SUITE.INIT });

--- a/packages/suite-native/src/views/dashboard/index.tsx
+++ b/packages/suite-native/src/views/dashboard/index.tsx
@@ -2,10 +2,9 @@ import React from 'react';
 import { connect } from 'react-redux';
 import { bindActionCreators } from 'redux';
 import { View, Button } from 'react-native';
-import { P as Text } from '@trezor/components';
+import { P as Text, useTheme } from '@trezor/components';
 import * as routerActions from '@suite-actions/routerActions';
 import styles from '@native/support/suite/styles';
-import { useTheme } from '@suite-hooks';
 import Layout from '@native-components/suite/Layout';
 import { Dispatch } from '@suite-types';
 
@@ -16,7 +15,7 @@ const mapDispatchToProps = (dispatch: Dispatch) => ({
 type Props = ReturnType<typeof mapDispatchToProps>;
 
 const Dashboard = (props: Props) => {
-    const { theme } = useTheme();
+    const theme = useTheme();
 
     return (
         <Layout title="Dashboard">

--- a/packages/suite-native/src/views/suite/backup/index.tsx
+++ b/packages/suite-native/src/views/suite/backup/index.tsx
@@ -2,10 +2,10 @@ import React from 'react';
 import { connect } from 'react-redux';
 import { bindActionCreators } from 'redux';
 import { View, Text, Button } from 'react-native';
+import { useTheme } from '@trezor/components';
 
 import * as routerActions from '@suite-actions/routerActions';
 import styles from '@native/support/suite/styles';
-import { useTheme } from '@suite-hooks';
 import { Dispatch } from '@suite-types';
 
 const mapDispatchToProps = (dispatch: Dispatch) => ({
@@ -16,7 +16,7 @@ const mapDispatchToProps = (dispatch: Dispatch) => ({
 type Props = ReturnType<typeof mapDispatchToProps>;
 
 const Backup = (props: Props) => {
-    const { theme } = useTheme();
+    const theme = useTheme();
 
     return (
         <View style={styles(theme).container}>

--- a/packages/suite-native/src/views/suite/firmware/index.tsx
+++ b/packages/suite-native/src/views/suite/firmware/index.tsx
@@ -2,10 +2,10 @@ import React from 'react';
 import { connect } from 'react-redux';
 import { bindActionCreators } from 'redux';
 import { View, Text, Button } from 'react-native';
+import { useTheme } from '@trezor/components';
 
 import * as routerActions from '@suite-actions/routerActions';
 import styles from '@native/support/suite/styles';
-import { useTheme } from '@suite-hooks';
 
 import { Dispatch } from '@suite-types';
 
@@ -17,7 +17,7 @@ const mapDispatchToProps = (dispatch: Dispatch) => ({
 type Props = ReturnType<typeof mapDispatchToProps>;
 
 const Backup = (props: Props) => {
-    const { theme } = useTheme();
+    const theme = useTheme();
     return (
         <View style={styles(theme).container}>
             <Text style={styles(theme).h1}>Firmware update</Text>

--- a/packages/suite-native/src/views/suite/onboarding/components/InitialRun/index.tsx
+++ b/packages/suite-native/src/views/suite/onboarding/components/InitialRun/index.tsx
@@ -2,11 +2,11 @@ import React from 'react';
 import { View, Text, Button } from 'react-native';
 import { bindActionCreators } from 'redux';
 import { connect } from 'react-redux';
+import { useTheme } from '@trezor/components';
 import * as routerActions from '@suite-actions/routerActions';
 import * as suiteActions from '@suite-actions/suiteActions';
 import styles from '@native/support/suite/styles';
 import { Dispatch } from '@suite-types';
-import { useTheme } from '@suite-hooks';
 
 const mapDispatchToProps = (dispatch: Dispatch) => ({
     goto: bindActionCreators(routerActions.goto, dispatch),
@@ -16,7 +16,7 @@ const mapDispatchToProps = (dispatch: Dispatch) => ({
 type Props = ReturnType<typeof mapDispatchToProps>;
 
 const InitialRun = (props: Props) => {
-    const { theme } = useTheme();
+    const theme = useTheme();
     return (
         <View style={styles(theme).container}>
             <Text style={styles(theme).h1}>Initial run</Text>

--- a/packages/suite-native/src/views/suite/onboarding/index.tsx
+++ b/packages/suite-native/src/views/suite/onboarding/index.tsx
@@ -2,12 +2,12 @@ import React from 'react';
 import { connect } from 'react-redux';
 import { bindActionCreators } from 'redux';
 import { View, Text, Button } from 'react-native';
+import { useTheme } from '@trezor/components';
 
 import * as routerActions from '@suite-actions/routerActions';
 import * as suiteActions from '@suite-actions/suiteActions';
 import styles from '@native/support/suite/styles';
 import InitialRun from './components/InitialRun';
-import { useTheme } from '@suite-hooks';
 import { AppState, Dispatch } from '@suite-types';
 
 const mapStateToProps = (state: AppState) => ({
@@ -23,7 +23,7 @@ const mapDispatchToProps = (dispatch: Dispatch) => ({
 type Props = ReturnType<typeof mapStateToProps> & ReturnType<typeof mapDispatchToProps>;
 
 const Onboarding = (props: Props) => {
-    const { theme } = useTheme();
+    const theme = useTheme();
 
     // TODO: "initialRun" view should not depend on props.initialRun
     if (props.initialRun) {

--- a/packages/suite-native/src/views/suite/switch-device/index.tsx
+++ b/packages/suite-native/src/views/suite/switch-device/index.tsx
@@ -2,10 +2,10 @@ import React from 'react';
 import { connect } from 'react-redux';
 import { bindActionCreators } from 'redux';
 import { View, Text, Button } from 'react-native';
+import { useTheme } from '@trezor/components';
 
 import * as routerActions from '@suite-actions/routerActions';
 import styles from '@native/support/suite/styles';
-import { useTheme } from '@suite-hooks';
 import { Dispatch } from '@suite-types';
 
 const mapDispatchToProps = (dispatch: Dispatch) => ({
@@ -15,7 +15,7 @@ const mapDispatchToProps = (dispatch: Dispatch) => ({
 type Props = ReturnType<typeof mapDispatchToProps>;
 
 const SwitchDevice = (props: Props) => {
-    const { theme } = useTheme();
+    const theme = useTheme();
 
     return (
         <View style={styles(theme).container}>

--- a/packages/suite-web/src/Main.tsx
+++ b/packages/suite-web/src/Main.tsx
@@ -24,7 +24,6 @@ import history from '@suite/support/history';
 
 import AppRouter from './support/Router';
 import { CypressExportStore } from './support/CypressExportStore';
-import GlobalStyleProvider from '@suite-support/styles/GlobalStyleProvider';
 
 const Main = () => {
     useEffect(() => {
@@ -46,7 +45,6 @@ const Main = () => {
             <ReduxProvider store={store}>
                 <ThemeProvider>
                     <RouterProvider history={history}>
-                        <GlobalStyleProvider />
                         <ErrorBoundary>
                             <Autodetect />
                             <Resize />

--- a/packages/suite/src/actions/suite/storageActions.ts
+++ b/packages/suite/src/actions/suite/storageActions.ts
@@ -429,6 +429,7 @@ export const loadStorage = () => async (dispatch: Dispatch, getState: GetState) 
                             bridgeDevMode: false, // don't sync bridgeDevMode for now
                         },
                     },
+                    storageLoaded: true,
                 },
                 devices,
                 wallet: {

--- a/packages/suite/src/actions/suite/suiteActions.ts
+++ b/packages/suite/src/actions/suite/suiteActions.ts
@@ -3,8 +3,6 @@ import * as comparisonUtils from '@suite-utils/comparisonUtils';
 import * as deviceUtils from '@suite-utils/device';
 import { addToast } from '@suite-actions/notificationActions';
 import * as modalActions from '@suite-actions/modalActions';
-import * as storageActions from '@suite-actions/storageActions';
-import { getOsTheme } from '@suite-utils/env';
 import { SUITE, METADATA } from './constants';
 import type { Locale } from '@suite-config/languages';
 import type {
@@ -590,26 +588,3 @@ export const switchDuplicatedDevice =
         // remove stateless instance
         dispatch(forgetDevice(device));
     };
-
-export const setInitialTheme = () => async (dispatch: Dispatch, getState: GetState) => {
-    try {
-        const storedSettings = await storageActions.loadSuiteSettings();
-        const isInitialRun = storedSettings?.flags.initialRun;
-        const savedTheme = storedSettings?.settings.theme;
-        const currentThemeVariant = getState().suite.settings.theme.variant;
-
-        if (isInitialRun || !storedSettings) {
-            // Initial run
-            // set initial theme (light/dark) based on OS settings
-            const osThemeVariant = getOsTheme();
-            if (osThemeVariant !== currentThemeVariant) {
-                dispatch(setTheme(osThemeVariant, undefined));
-            }
-        } else if (savedTheme && savedTheme.variant !== currentThemeVariant) {
-            // set correct theme from the db (this will be a bit quicker than waiting for STORAGE.LOADED)
-            dispatch(setTheme(savedTheme?.variant, savedTheme?.colors));
-        }
-    } catch (error) {
-        console.log(error); // just simple log to skip sentry as we probably don't care that much about failed initial theme
-    }
-};

--- a/packages/suite/src/components/backup/BackupSeedCard.tsx
+++ b/packages/suite/src/components/backup/BackupSeedCard.tsx
@@ -1,7 +1,6 @@
 import React from 'react';
 import styled from 'styled-components';
-import { Icon, IconProps, variables } from '@trezor/components';
-import { useTheme } from '@suite/hooks/suite';
+import { Icon, IconProps, variables, useTheme } from '@trezor/components';
 
 const Card = styled.div<{ checked: boolean }>`
     display: flex;
@@ -61,7 +60,7 @@ interface Props extends React.HTMLAttributes<HTMLDivElement> {
 }
 
 const BackupSeedCard = ({ label, icon, isChecked, ...rest }: Props) => {
-    const { theme } = useTheme();
+    const theme = useTheme();
 
     return (
         <Card checked={isChecked} {...rest}>

--- a/packages/suite/src/components/firmware/ProgressBar.tsx
+++ b/packages/suite/src/components/firmware/ProgressBar.tsx
@@ -1,7 +1,6 @@
 import React, { useEffect, useState } from 'react';
-import { Icon, variables } from '@trezor/components';
+import { Icon, variables, useTheme } from '@trezor/components';
 import styled from 'styled-components';
-import { useTheme } from '@suite-hooks';
 
 const Wrapper = styled.div`
     display: flex;
@@ -62,7 +61,7 @@ const ProgressBar = ({
     fakeProgressDuration,
     fakeProgressBarrier = 90,
 }: Props) => {
-    const { theme } = useTheme();
+    const theme = useTheme();
     const [storedProgress, setStoreProgress] = useState(0);
     const progress = (100 / total) * current;
     const fakeIncrement = fakeProgressDuration ? total / fakeProgressDuration : 0;

--- a/packages/suite/src/components/onboarding/Box/Box.tsx
+++ b/packages/suite/src/components/onboarding/Box/Box.tsx
@@ -3,8 +3,7 @@ import styled, { css } from 'styled-components';
 import { animated, useSpring } from 'react-spring';
 import Text from '@onboarding-components/Text';
 import { Image, ImageProps, Translation } from '@suite-components';
-import { H1, variables, Button } from '@trezor/components';
-import { useTheme } from '@suite-hooks';
+import { H1, variables, Button, useTheme } from '@trezor/components';
 import useMeasure from 'react-use/lib/useMeasure';
 
 const BoxWrapper = styled(
@@ -165,7 +164,7 @@ const Box = ({
     onToggle = () => undefined,
     ...rest
 }: Props) => {
-    const { theme } = useTheme();
+    const theme = useTheme();
     const [heightRef, { height }] = useMeasure<HTMLDivElement>();
     const springExpandableBox = useSpring({
         from: { opacity: 0 },

--- a/packages/suite/src/components/onboarding/DeviceAnimation/index.tsx
+++ b/packages/suite/src/components/onboarding/DeviceAnimation/index.tsx
@@ -2,9 +2,9 @@ import styled, { css } from 'styled-components';
 import React, { useRef } from 'react';
 import Lottie from 'lottie-react';
 import * as semver from 'semver';
+import { useTheme } from '@trezor/components';
 
 import { resolveStaticPath } from '@suite-utils/build';
-import { useTheme } from '@suite-hooks';
 import LottieT1Connect from './lottie/t1_connect.json';
 import LottieTTConnect from './lottie/tt_connect.json';
 import { getDeviceModel, getFwVersion } from '@suite-utils/device';
@@ -71,7 +71,7 @@ type Props = {
 };
 
 const DeviceAnimation = ({ size, type, loop = false, shape, device, ...props }: Props) => {
-    const { themeVariant } = useTheme();
+    const { THEME } = useTheme();
     const hologramRef = useRef<HTMLVideoElement>(null);
 
     // if device features are not available, use T model animations
@@ -103,7 +103,7 @@ const DeviceAnimation = ({ size, type, loop = false, shape, device, ...props }: 
                 <StyledVideo loop={loop} autoPlay muted width={size} height={size}>
                     <source
                         src={resolveStaticPath(
-                            `videos/onboarding/t${deviceModel}_${animationFileName}_${themeVariant}.mp4`,
+                            `videos/onboarding/t${deviceModel}_${animationFileName}_${THEME}.mp4`,
                         )}
                         type="video/mp4"
                     />
@@ -113,7 +113,7 @@ const DeviceAnimation = ({ size, type, loop = false, shape, device, ...props }: 
                 <StyledVideo loop={loop} autoPlay muted width={size} height={size}>
                     <source
                         src={resolveStaticPath(
-                            `videos/onboarding/t1_${animationFileName}_${themeVariant}.mp4`,
+                            `videos/onboarding/t1_${animationFileName}_${THEME}.mp4`,
                         )}
                         type="video/mp4"
                     />
@@ -143,7 +143,7 @@ const DeviceAnimation = ({ size, type, loop = false, shape, device, ...props }: 
                 <StyledVideo loop={loop} autoPlay muted width={size} height={size}>
                     <source
                         src={resolveStaticPath(
-                            `videos/onboarding/t${deviceModel}_${animationFileName}_${themeVariant}.webm`,
+                            `videos/onboarding/t${deviceModel}_${animationFileName}_${THEME}.webm`,
                         )}
                         type="video/webm"
                     />

--- a/packages/suite/src/components/onboarding/ProgressBar/index.tsx
+++ b/packages/suite/src/components/onboarding/ProgressBar/index.tsx
@@ -1,7 +1,6 @@
 import React from 'react';
 import styled, { css } from 'styled-components';
-import { Icon, variables } from '@trezor/components';
-import { useTheme } from '@suite-hooks';
+import { Icon, variables, useTheme } from '@trezor/components';
 
 const ProgressBarWrapper = styled.div`
     display: flex;
@@ -92,7 +91,7 @@ interface Props {
 }
 
 const ProgressBar = ({ steps, activeStep, className }: Props) => {
-    const { theme } = useTheme();
+    const theme = useTheme();
     return (
         <ProgressBarWrapper className={className}>
             {steps.map((step, index) => {

--- a/packages/suite/src/components/suite/Coin/index.tsx
+++ b/packages/suite/src/components/suite/Coin/index.tsx
@@ -1,8 +1,7 @@
 import React from 'react';
 import styled, { css } from 'styled-components';
-import { variables, CoinLogo, Icon } from '@trezor/components';
+import { variables, CoinLogo, Icon, useTheme } from '@trezor/components';
 import { Translation } from '@suite-components';
-import { useTheme } from '@suite-hooks';
 import { ExtendedMessageDescriptor } from '@suite-types';
 import { Network } from '@wallet-types';
 
@@ -90,7 +89,7 @@ interface Props extends React.HTMLAttributes<HTMLButtonElement> {
 }
 
 const Coin = ({ symbol, name, label, selected = false, disabled = false, ...props }: Props) => {
-    const { theme } = useTheme();
+    const theme = useTheme();
     return (
         <CoinWrapper selected={selected} disabled={disabled} {...props}>
             <ImageWrapper>

--- a/packages/suite/src/components/suite/ConnectDevicePrompt/index.tsx
+++ b/packages/suite/src/components/suite/ConnectDevicePrompt/index.tsx
@@ -2,10 +2,10 @@ import React from 'react';
 import { useSpring, config, animated } from 'react-spring';
 import styled from 'styled-components';
 
-import { variables, Icon, Button } from '@trezor/components';
+import { variables, Icon, Button, useTheme } from '@trezor/components';
 import { DeviceAnimation } from '@onboarding-components';
 import { Translation } from '@suite-components';
-import { useDevice, useTheme, useActions } from '@suite-hooks';
+import { useDevice, useActions } from '@suite-hooks';
 import * as routerActions from '@suite-actions/routerActions';
 
 const Wrapper = styled(animated.div)`
@@ -61,7 +61,7 @@ const getDefaultMessage = (connected: boolean, showWarning: boolean) => {
     return 'TR_CONNECT_YOUR_DEVICE';
 };
 const ConnectDevicePrompt = ({ children, connected, showWarning, allowSwitchDevice }: Props) => {
-    const { theme } = useTheme();
+    const theme = useTheme();
     const { device } = useDevice();
     const { goto } = useActions({
         goto: routerActions.goto,

--- a/packages/suite/src/components/suite/PinMatrix/index.tsx
+++ b/packages/suite/src/components/suite/PinMatrix/index.tsx
@@ -1,11 +1,11 @@
 import React, { useState, useEffect } from 'react';
 import styled from 'styled-components';
-import { variables } from '@trezor/components';
+import { variables, useTheme } from '@trezor/components';
 import { DeviceMatrixExplanation, PinInput, Translation, TrezorLink } from '@suite-components';
 import { TrezorDevice } from '@suite-types';
 import { URLS } from '@suite-constants';
 import * as modalActions from '@suite-actions/modalActions';
-import { useActions, useTheme } from '@suite-hooks';
+import { useActions } from '@suite-hooks';
 
 const Wrapper = styled.div`
     display: flex;
@@ -32,7 +32,7 @@ interface Props {
 }
 
 const PinMatrix = ({ device, hideExplanation, invalid }: Props) => {
-    const { theme } = useTheme();
+    const theme = useTheme();
     const [submitted, setSubmitted] = useState(false);
     const { onPinSubmit } = useActions({ onPinSubmit: modalActions.onPinSubmit });
     const pinRequestType = device.buttonRequests[device.buttonRequests.length - 1];

--- a/packages/suite/src/components/suite/modals/AddAccount/components/MoreCoins.tsx
+++ b/packages/suite/src/components/suite/modals/AddAccount/components/MoreCoins.tsx
@@ -1,9 +1,8 @@
 import React, { useState } from 'react';
 import { AnimatePresence, motion } from 'framer-motion';
 import styled, { css } from 'styled-components';
-import { Icon, P } from '@trezor/components';
+import { Icon, P, useTheme } from '@trezor/components';
 import { Translation } from '@suite-components';
-import { useTheme } from '@suite-hooks';
 
 const animationDuration = 0.24;
 
@@ -110,7 +109,7 @@ const Header = ({
     isExpanded: boolean;
     setExpanded: React.Dispatch<React.SetStateAction<boolean>>;
 }) => {
-    const { theme } = useTheme();
+    const theme = useTheme();
     return (
         <HeaderWrapper>
             <OpenIconWrapper

--- a/packages/suite/src/hooks/suite/index.ts
+++ b/packages/suite/src/hooks/suite/index.ts
@@ -10,7 +10,7 @@ export { useFirmware } from './useFirmware';
 export { useSelector } from './useSelector';
 export { useLoadingSkeleton } from './useLoadingSkeleton';
 export { useTranslation } from './useTranslation';
-export { useTheme } from './useTheme';
+export { useThemeContext } from './useThemeContext';
 export { useOnboarding } from './useOnboarding';
 export { useRecovery } from './useRecovery';
 export { useGuide } from './useGuide';

--- a/packages/suite/src/hooks/suite/useThemeContext.ts
+++ b/packages/suite/src/hooks/suite/useThemeContext.ts
@@ -5,7 +5,7 @@ import { getThemeColors } from '@suite-utils/theme';
 import { loadSuiteSettings } from '@suite-actions/storageActions';
 import type { SuiteState } from '@suite-reducers/suiteReducer';
 
-export const useTheme = () => {
+export const useThemeContext = () => {
     const [preloadedTheme, setPreloadedTheme] = useState<SuiteState['settings']['theme']>();
     const { theme, storageLoaded } = useSelector(state => ({
         theme: state.suite.settings.theme,
@@ -25,8 +25,5 @@ export const useTheme = () => {
               variant: getOsTheme(),
           };
 
-    return {
-        theme: getThemeColors(resolvedTheme),
-        themeVariant: resolvedTheme.variant,
-    };
+    return getThemeColors(resolvedTheme);
 };

--- a/packages/suite/src/middlewares/suite/suiteMiddleware.ts
+++ b/packages/suite/src/middlewares/suite/suiteMiddleware.ts
@@ -36,7 +36,6 @@ const suite =
         switch (action.type) {
             case SUITE.INIT:
                 await api.dispatch(storageActions.init());
-                api.dispatch(suiteActions.setInitialTheme());
                 // load storage
                 api.dispatch(storageActions.loadStorage());
                 break;

--- a/packages/suite/src/reducers/suite/suiteReducer.ts
+++ b/packages/suite/src/reducers/suite/suiteReducer.ts
@@ -46,6 +46,7 @@ export interface SuiteState {
     online: boolean;
     tor: boolean;
     loading: boolean;
+    storageLoaded: boolean;
     loaded: boolean;
     error?: string; // errors set from connect, should be renamed
     dbError?: 'blocking' | 'blocked' | undefined; // blocked if the instance cannot upgrade due to older version running, blocking in case instance is running older version thus blocking other instance
@@ -61,6 +62,7 @@ const initialState: SuiteState = {
     online: true,
     tor: false,
     loading: false,
+    storageLoaded: false,
     loaded: false,
     messages: {},
     locks: [],
@@ -116,6 +118,7 @@ const suiteReducer = (state: SuiteState = initialState, action: Action): SuiteSt
             case STORAGE.LOADED:
                 draft.flags = action.payload.suite.flags;
                 draft.settings = action.payload.suite.settings;
+                draft.storageLoaded = action.payload.suite.storageLoaded;
                 break;
 
             case SUITE.READY:

--- a/packages/suite/src/support/suite/Autodetect.tsx
+++ b/packages/suite/src/support/suite/Autodetect.tsx
@@ -6,38 +6,38 @@ import { setTheme as setThemeAction } from '@suite-actions/suiteActions';
 import { fetchLocale as fetchLocaleAction } from '@settings-actions/languageActions';
 
 const Autodetect = () => {
-    const { autodetectTheme, autodetectLanguage, currentTheme, currentLanguage } = useSelector(
-        state => ({
+    const { autodetectTheme, autodetectLanguage, currentTheme, currentLanguage, storageLoaded } =
+        useSelector(state => ({
             autodetectTheme: state.suite.settings.autodetect.theme,
             autodetectLanguage: state.suite.settings.autodetect.language,
             currentTheme: state.suite.settings.theme.variant,
             currentLanguage: state.suite.settings.language,
-        }),
-    );
+            storageLoaded: state.suite.storageLoaded,
+        }));
     const { setTheme, fetchLocale } = useActions({
         setTheme: setThemeAction,
         fetchLocale: fetchLocaleAction,
     });
 
     useEffect(() => {
-        if (!autodetectTheme) return;
+        if (!storageLoaded || !autodetectTheme) return;
         const osTheme = getOsTheme();
         if (osTheme !== currentTheme) {
             setTheme(osTheme);
         }
         const unwatch = watchOsTheme(setTheme);
         return () => unwatch();
-    }, [autodetectTheme, currentTheme, setTheme]);
+    }, [storageLoaded, autodetectTheme, currentTheme, setTheme]);
 
     useEffect(() => {
-        if (!autodetectLanguage) return;
+        if (!storageLoaded || !autodetectLanguage) return;
         const osLocale = getOsLocale(currentLanguage);
         if (osLocale !== currentLanguage) {
             fetchLocale(osLocale);
         }
         const unwatch = watchOsLocale(fetchLocale);
         return () => unwatch();
-    }, [autodetectLanguage, currentLanguage, fetchLocale]);
+    }, [storageLoaded, autodetectLanguage, currentLanguage, fetchLocale]);
 
     return null;
 };

--- a/packages/suite/src/support/suite/ThemeProvider.tsx
+++ b/packages/suite/src/support/suite/ThemeProvider.tsx
@@ -1,13 +1,13 @@
 import React from 'react';
 import { ThemeProvider as SCThemeProvider } from 'styled-components';
-import { useTheme } from '@suite-hooks';
+import { useThemeContext } from '@suite-hooks';
 import GlobalStyle from './styles/GlobalStyle';
 
 const ThemeProvider: React.FC = ({ children }) => {
-    const { theme, themeVariant } = useTheme();
+    const theme = useThemeContext();
     return (
         <SCThemeProvider theme={theme}>
-            <GlobalStyle theme={theme} themeVariant={themeVariant} />
+            <GlobalStyle theme={theme} />
             {children}
         </SCThemeProvider>
     );

--- a/packages/suite/src/support/suite/ThemeProvider.tsx
+++ b/packages/suite/src/support/suite/ThemeProvider.tsx
@@ -1,11 +1,16 @@
 import React from 'react';
 import { ThemeProvider as SCThemeProvider } from 'styled-components';
-import { useSelector } from '@suite-hooks';
-import { getThemeColors } from '@suite-utils/theme';
+import { useTheme } from '@suite-hooks';
+import GlobalStyle from './styles/GlobalStyle';
 
 const ThemeProvider: React.FC = ({ children }) => {
-    const theme = useSelector(state => state.suite.settings.theme);
-    return <SCThemeProvider theme={getThemeColors(theme)}>{children}</SCThemeProvider>;
+    const { theme, themeVariant } = useTheme();
+    return (
+        <SCThemeProvider theme={theme}>
+            <GlobalStyle theme={theme} themeVariant={themeVariant} />
+            {children}
+        </SCThemeProvider>
+    );
 };
 
 export default ThemeProvider;

--- a/packages/suite/src/support/suite/styles/GlobalStyle.tsx
+++ b/packages/suite/src/support/suite/styles/GlobalStyle.tsx
@@ -1,11 +1,8 @@
-import * as React from 'react';
-
 import animations from './animations';
 import { notifications } from './notifications';
 import { variables, SuiteThemeColors } from '@trezor/components';
 import { createGlobalStyle } from 'styled-components';
 import { SuiteThemeVariant } from '@suite/types/suite';
-import { useTheme } from '@suite-hooks';
 
 const GlobalStyle = createGlobalStyle<{ theme: SuiteThemeColors; themeVariant: SuiteThemeVariant }>`
     #app {
@@ -55,10 +52,4 @@ const GlobalStyle = createGlobalStyle<{ theme: SuiteThemeColors; themeVariant: S
     ${notifications}
 `;
 
-const GlobalStyleProvider = () => {
-    const { theme, themeVariant } = useTheme();
-
-    return <GlobalStyle theme={theme} themeVariant={themeVariant} />;
-};
-
-export default GlobalStyleProvider;
+export default GlobalStyle;

--- a/packages/suite/src/support/suite/styles/GlobalStyle.tsx
+++ b/packages/suite/src/support/suite/styles/GlobalStyle.tsx
@@ -2,9 +2,8 @@ import animations from './animations';
 import { notifications } from './notifications';
 import { variables, SuiteThemeColors } from '@trezor/components';
 import { createGlobalStyle } from 'styled-components';
-import { SuiteThemeVariant } from '@suite/types/suite';
 
-const GlobalStyle = createGlobalStyle<{ theme: SuiteThemeColors; themeVariant: SuiteThemeVariant }>`
+const GlobalStyle = createGlobalStyle<{ theme: SuiteThemeColors }>`
     #app {
         display: flex;
         flex-direction: column;
@@ -45,7 +44,7 @@ const GlobalStyle = createGlobalStyle<{ theme: SuiteThemeColors; themeVariant: S
     }
 
     :root {
-        color-scheme: ${props => (props.themeVariant === 'light' ? 'light' : 'dark')};
+        color-scheme: ${props => (props.theme.THEME === 'light' ? 'light' : 'dark')};
     }
 
     ${animations}

--- a/packages/suite/src/views/dashboard/components/AssetsCard/components/AssetGrid/index.tsx
+++ b/packages/suite/src/views/dashboard/components/AssetsCard/components/AssetGrid/index.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import styled from 'styled-components';
 import { Network } from '@wallet-types';
-import { CoinLogo, Icon, variables } from '@trezor/components';
+import { CoinLogo, Icon, variables, useTheme } from '@trezor/components';
 import {
     FiatValue,
     SkeletonCircle,
@@ -12,7 +12,7 @@ import {
 import { CoinBalance } from '@wallet-components';
 import { isTestnet } from '@wallet-utils/accountUtils';
 import * as routerActions from '@suite-actions/routerActions';
-import { useActions, useAccountSearch, useTheme, useLoadingSkeleton } from '@suite-hooks';
+import { useActions, useAccountSearch, useLoadingSkeleton } from '@suite-hooks';
 
 const Col = styled.div`
     display: flex;
@@ -93,7 +93,7 @@ interface Props {
 
 const AssetGrid = React.memo(({ network, failed, cryptoValue }: Props) => {
     const { symbol, name } = network;
-    const { theme } = useTheme();
+    const theme = useTheme();
     const { setCoinFilter, setSearchString } = useAccountSearch();
 
     const { goto } = useActions({ goto: routerActions.goto });

--- a/packages/suite/src/views/firmware/index.tsx
+++ b/packages/suite/src/views/firmware/index.tsx
@@ -11,8 +11,8 @@ import {
 import { DeviceAcquire, DeviceUnknown, DeviceUnreadable } from '@suite-views';
 import { Translation, Modal } from '@suite-components';
 import { OnboardingStepBox } from '@onboarding-components';
-import { useActions, useFirmware, useSelector, useTheme } from '@suite-hooks';
-import { ConfirmOnDevice, Icon } from '@trezor/components';
+import { useActions, useFirmware, useSelector } from '@suite-hooks';
+import { ConfirmOnDevice, Icon, useTheme } from '@trezor/components';
 
 const Wrapper = styled.div`
     display: flex;
@@ -35,7 +35,7 @@ const CancelIconWrapper = styled.div`
 `;
 
 const Firmware = () => {
-    const { theme } = useTheme();
+    const theme = useTheme();
     const { resetReducer, status, setStatus, error, firmwareUpdate } = useFirmware();
     const { device } = useSelector(state => ({
         device: state.suite.device,

--- a/packages/suite/src/views/onboarding/steps/BasicSettings/AdvancedSetup.tsx
+++ b/packages/suite/src/views/onboarding/steps/BasicSettings/AdvancedSetup.tsx
@@ -3,8 +3,8 @@ import { Translation } from '@suite-components';
 import { Box } from '@onboarding-components';
 import styled from 'styled-components';
 import { Network } from '@wallet-types';
-import { variables, Icon, Button } from '@trezor/components';
-import { useActions, useSelector, useTheme } from '@suite-hooks';
+import { variables, Icon, Button, useTheme } from '@trezor/components';
+import { useActions, useSelector } from '@suite-hooks';
 import TrezorConnect from 'trezor-connect';
 import { BlockbookUrl } from '@wallet-types/blockbook';
 import * as walletSettingsActions from '@settings-actions/walletSettingsActions';
@@ -75,7 +75,7 @@ const AdvancedSetup = ({ networks, children }: Props) => {
     const [customBackendOpen, setCustomBackendOpen] = useState(false);
     const [torOpen, setTorOpen] = useState(false);
     const [networksWithBlockbook, setNetworksWithBlockbook] = useState<Network[]>([]);
-    const { theme } = useTheme();
+    const theme = useTheme();
 
     const { addBlockbookUrl, removeBlockbookUrl } = useActions({
         addBlockbookUrl: walletSettingsActions.addBlockbookUrl,

--- a/packages/suite/src/views/onboarding/steps/Welcome/components/PreOnboardingSetup/SecurityCheck.tsx
+++ b/packages/suite/src/views/onboarding/steps/Welcome/components/PreOnboardingSetup/SecurityCheck.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import styled from 'styled-components';
-import { Icon, Tooltip, variables } from '@trezor/components';
-import { useOnboarding, useSelector, useTheme } from '@suite-hooks';
+import { Icon, Tooltip, variables, useTheme } from '@trezor/components';
+import { useOnboarding, useSelector } from '@suite-hooks';
 import { Translation, TrezorLink } from '@suite-components';
 import { Box, Hologram, OnboardingButtonCta, OnboardingButtonSkip } from '@onboarding-components';
 import { SUPPORT_URL } from '@suite-constants/urls';
@@ -78,7 +78,7 @@ const SecurityCheck = () => {
     const deviceStatus = getConnectedDeviceStatus(device);
     const initialized = deviceStatus === 'initialized';
     const firmwareNotInstalled = device?.firmware === 'none';
-    const { theme } = useTheme();
+    const theme = useTheme();
 
     const items = [
         {


### PR DESCRIPTION
Fixes bug where theme detection sometimes rewrote settings with initial values on fast devices. Moreover, improves initial theme detection in order to minimize the 'flash' on application start. Nevertheless, there is still room for improvement.