### PR TITLE
Fix/webpack5 missing parts

### DIFF
--- a/ci/build.yml
+++ b/ci/build.yml
@@ -273,3 +273,21 @@ suite-native build android:
     expire_in: 1 day
     paths:
       - app-release.apk
+
+suite-native build android manual:
+  stage: build
+  <<: *config_sign_dev
+  when: manual
+  except:
+    <<: *run_everything_rules
+  image: $CI_DEPENDENCY_PROXY_DIRECT_GROUP_IMAGE_PREFIX/reactnativecommunity/react-native-android
+  script:
+    - yarn install --frozen-lockfile --cache-folder .yarn --prefer-offline
+    - yarn build:libs
+    - yarn workspace @trezor/suite-data copy-static-files
+    - yarn workspace @trezor/suite-native build:android
+    - mv packages/suite-native/android/app/build/outputs/apk/release/app-release.apk .
+  artifacts:
+    expire_in: 1 day
+    paths:
+      - app-release.apk

--- a/package.json
+++ b/package.json
@@ -61,6 +61,7 @@
         "@typescript-eslint/parser": "^4.29.1",
         "babel-jest": "^26.6.3",
         "babel-plugin-module-resolver": "^4.0.0",
+        "bufferutil": "^4.0.1",
         "concurrently": "^5.1.0",
         "eslint": "^7.32.0",
         "eslint-config-airbnb": "^18.2.1",
@@ -83,6 +84,7 @@
         "ts-jest": "^26.5.4",
         "ts-node": "^9.1.1",
         "tsconfig-paths": "^3.9.0",
-        "typescript": "4.3.5"
+        "typescript": "4.3.5",
+        "utf-8-validate": "^5.0.2"
     }
 }

--- a/packages/blockchain-link/webpack/workers.module.babel.js
+++ b/packages/blockchain-link/webpack/workers.module.babel.js
@@ -2,7 +2,7 @@ import webpack from 'webpack';
 import { SRC, BUILD } from './constants';
 
 module.exports = {
-    target: 'node',
+    target: 'web',
     mode: 'production',
     entry: {
         'blockbook-worker': `${SRC}workers/blockbook/index.ts`,
@@ -38,6 +38,13 @@ module.exports = {
     resolve: {
         modules: [SRC, 'node_modules'],
         extensions: ['.ts', '.js'],
+        alias: {
+            'ws-browser': `${SRC}/utils/ws.js`,
+        },
+        fallback: {
+            crypto: require.resolve('crypto-browserify'),
+            stream: require.resolve('stream-browserify'),
+        },
     },
     resolveLoader: {
         modules: ['node_modules'],
@@ -48,9 +55,7 @@ module.exports = {
     performance: {
         hints: false,
     },
-    // ignore those modules, otherwise webpack throws warning about missing (ws dependency)
-    externals: ['utf-8-validate', 'bufferutil'],
-
+    plugins: [new webpack.NormalModuleReplacementPlugin(/^ws$/, 'ws-browser')],
     optimization: {
         minimize: false,
     },

--- a/packages/blockchain-link/webpack/workers.node.babel.js
+++ b/packages/blockchain-link/webpack/workers.node.babel.js
@@ -35,6 +35,4 @@ module.exports = {
     performance: {
         hints: false,
     },
-    // ignore those modules, otherwise webpack throws warning about missing (ws dependency)
-    externals: ['utf-8-validate', 'bufferutil'],
 };

--- a/packages/components/.storybook/main.js
+++ b/packages/components/.storybook/main.js
@@ -1,7 +1,15 @@
+const path = require('path');
+
 module.exports = {
     stories: ['../src/**/*.stories.*'],
     logLevel: 'debug',
     webpackFinal: async config => {
+        // for typescript use ts-loader@8.3.0 compatible with webpack@4 (storybook dependency)
+        // probably may be removed after storybook@6.4.0 with webpack@5 support
+        config.module.rules.unshift({
+            test: /\.tsx?$/,
+            loader: path.resolve('./node_modules/ts-loader/index.js'),
+        })
         return config;
     },
     addons: [

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -64,6 +64,7 @@
         "stylelint-config-styled-components": "^0.1.1",
         "stylelint-custom-processor-loader": "^0.6.0",
         "stylelint-processor-styled-components": "^1.10.0",
+        "ts-loader": "^8.3.0",
         "typescript-styled-plugin": "^0.15.0"
     },
     "peerDependencies": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -25187,6 +25187,17 @@ ts-jest@^26.5.4:
     semver "7.x"
     yargs-parser "20.x"
 
+ts-loader@^8.3.0:
+  version "8.3.0"
+  resolved "https://registry.yarnpkg.com/ts-loader/-/ts-loader-8.3.0.tgz#83360496d6f8004fab35825279132c93412edf33"
+  integrity sha512-MgGly4I6cStsJy27ViE32UoqxPTN9Xly4anxxVyaIWR+9BGxboV4EyJBGfR3RePV7Ksjj3rHmPZJeIt+7o4Vag==
+  dependencies:
+    chalk "^4.1.0"
+    enhanced-resolve "^4.0.0"
+    loader-utils "^2.0.0"
+    micromatch "^4.0.0"
+    semver "^7.3.4"
+
 ts-loader@^9.2.5:
   version "9.2.6"
   resolved "https://registry.yarnpkg.com/ts-loader/-/ts-loader-9.2.6.tgz#9937c4dd0a1e3dbbb5e433f8102a6601c6615d74"

--- a/yarn.lock
+++ b/yarn.lock
@@ -8964,6 +8964,13 @@ buffer@^6.0.3:
     base64-js "^1.3.1"
     ieee754 "^1.2.1"
 
+bufferutil@^4.0.1:
+  version "4.0.4"
+  resolved "https://registry.yarnpkg.com/bufferutil/-/bufferutil-4.0.4.tgz#ab81373d313a6ead0d734e98c448c722734ae7bb"
+  integrity sha512-VNxjXUCrF3LvbLgwfkTb5LsFvk6pGIn7OBb9x+3o+iJ6mKw0JTUp4chBFc88hi1aspeZGeZG9jAIbpFYPQSLZw==
+  dependencies:
+    node-gyp-build "^4.2.0"
+
 bufferview@~1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/bufferview/-/bufferview-1.0.1.tgz#7afd74a45f937fa422a1d338c08bbfdc76cd725d"
@@ -25917,6 +25924,13 @@ use@^3.1.0:
   version "3.1.1"
   resolved "https://registry.yarnpkg.com/use/-/use-3.1.1.tgz#d50c8cac79a19fbc20f2911f56eb973f4e10070f"
   integrity sha512-cwESVXlO3url9YWlFW/TA9cshCEhtu7IKJ/p5soJ/gGpj7vbvFrAY/eIioQ6Dw23KjZhYgiIo8HOs1nQ2vr/oQ==
+
+utf-8-validate@^5.0.2:
+  version "5.0.6"
+  resolved "https://registry.yarnpkg.com/utf-8-validate/-/utf-8-validate-5.0.6.tgz#e1b3e0a5cc8648a3b44c1799fbb170d1aaaffe80"
+  integrity sha512-hoY0gOf9EkCw+nimK21FVKHUIG1BMqSiRwxB/q3A9yKZOrOI99PP77BxmarDqWz6rG3vVYiBWfhG8z2Tl+7fZA==
+  dependencies:
+    node-gyp-build "^4.2.0"
 
 utf8-byte-length@^1.0.1:
   version "1.0.4"


### PR DESCRIPTION
Should fix failing CI jobs on develop

- add missing modules (pair dependencies of `ws` lib) in `@trezor/blockchain-link` builds
- `@trezor/blockchain-link` "module" build as web target
- use lower version of `ts-loader` in `@trezor/components` storybook builds (compatible with webpack4)
- add manual CI job for `@trezor/suite-native` builds on any branch