### PR TITLE
fix(blockchain-link): revert adding peer dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -61,7 +61,6 @@
         "@typescript-eslint/parser": "^4.29.1",
         "babel-jest": "^26.6.3",
         "babel-plugin-module-resolver": "^4.0.0",
-        "bufferutil": "^4.0.1",
         "concurrently": "^5.1.0",
         "eslint": "^7.32.0",
         "eslint-config-airbnb": "^18.2.1",
@@ -84,7 +83,6 @@
         "ts-jest": "^26.5.4",
         "ts-node": "^9.1.1",
         "tsconfig-paths": "^3.9.0",
-        "typescript": "4.3.5",
-        "utf-8-validate": "^5.0.2"
+        "typescript": "4.3.5"
     }
 }

--- a/packages/blockchain-link/webpack/workers.node.babel.js
+++ b/packages/blockchain-link/webpack/workers.node.babel.js
@@ -35,4 +35,6 @@ module.exports = {
     performance: {
         hints: false,
     },
+    // ignore optional modules, dependencies of "ws" lib
+    externals: ['utf-8-validate', 'bufferutil'],
 };

--- a/yarn.lock
+++ b/yarn.lock
@@ -8964,13 +8964,6 @@ buffer@^6.0.3:
     base64-js "^1.3.1"
     ieee754 "^1.2.1"
 
-bufferutil@^4.0.1:
-  version "4.0.4"
-  resolved "https://registry.yarnpkg.com/bufferutil/-/bufferutil-4.0.4.tgz#ab81373d313a6ead0d734e98c448c722734ae7bb"
-  integrity sha512-VNxjXUCrF3LvbLgwfkTb5LsFvk6pGIn7OBb9x+3o+iJ6mKw0JTUp4chBFc88hi1aspeZGeZG9jAIbpFYPQSLZw==
-  dependencies:
-    node-gyp-build "^4.2.0"
-
 bufferview@~1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/bufferview/-/bufferview-1.0.1.tgz#7afd74a45f937fa422a1d338c08bbfdc76cd725d"
@@ -25935,13 +25928,6 @@ use@^3.1.0:
   version "3.1.1"
   resolved "https://registry.yarnpkg.com/use/-/use-3.1.1.tgz#d50c8cac79a19fbc20f2911f56eb973f4e10070f"
   integrity sha512-cwESVXlO3url9YWlFW/TA9cshCEhtu7IKJ/p5soJ/gGpj7vbvFrAY/eIioQ6Dw23KjZhYgiIo8HOs1nQ2vr/oQ==
-
-utf-8-validate@^5.0.2:
-  version "5.0.6"
-  resolved "https://registry.yarnpkg.com/utf-8-validate/-/utf-8-validate-5.0.6.tgz#e1b3e0a5cc8648a3b44c1799fbb170d1aaaffe80"
-  integrity sha512-hoY0gOf9EkCw+nimK21FVKHUIG1BMqSiRwxB/q3A9yKZOrOI99PP77BxmarDqWz6rG3vVYiBWfhG8z2Tl+7fZA==
-  dependencies:
-    node-gyp-build "^4.2.0"
 
 utf8-byte-length@^1.0.1:
   version "1.0.4"


### PR DESCRIPTION
introduced here 10332ee2b7337a91525f7d3ae058d891b622e571,

turns out this dependencies [are optional in ws](https://github.com/websockets/ws/blob/master/lib/buffer-util.js#L103) and it was not required to add them.
the real key to successful `@suite/native` build was changing webpack target in commit above
