### PR TITLE
Fix/xrp reserve

### DIFF
--- a/packages/blockchain-link/CHANGELOG.md
+++ b/packages/blockchain-link/CHANGELOG.md
@@ -1,3 +1,9 @@
+# 1.0.18 (not released)
+
+#### changes
+- lower default XRP reserve
+- set XRP reserve after `getInfo` call (get server info)
+
 # 1.0.17
 
 #### changes

--- a/packages/blockchain-link/package.json
+++ b/packages/blockchain-link/package.json
@@ -57,7 +57,7 @@
         "bignumber.js": "^9.0.1",
         "es6-promise": "^4.2.8",
         "events": "^3.2.0",
-        "ripple-lib": "1.8.2",
+        "ripple-lib": "1.10.0",
         "tiny-worker": "^2.3.0",
         "ws": "^7.4.0"
     }

--- a/packages/blockchain-link/src/workers/ripple/index.ts
+++ b/packages/blockchain-link/src/workers/ripple/index.ts
@@ -20,8 +20,8 @@ const DEFAULT_PING_TIMEOUT = 3 * 60 * 1000;
 
 let endpoints: string[] = [];
 const RESERVE = {
-    BASE: '20000000',
-    OWNER: '5000000',
+    BASE: '10000000',
+    OWNER: '2000000',
 };
 
 const setPingTimeout = () => {
@@ -124,13 +124,16 @@ const getInfo = async (data: { id: number } & MessageTypes.GetInfo): Promise<voi
     try {
         const api = await connect();
         const info = await api.getServerInfo();
-        // @ts-ignore: accessing private var _url
-        const url = api.connection._url; // eslint-disable-line no-underscore-dangle
+
+        // store current ledger values
+        RESERVE.BASE = api.xrpToDrops(info.validatedLedger.reserveBaseXRP);
+        RESERVE.OWNER = api.xrpToDrops(info.validatedLedger.reserveIncrementXRP);
+
         common.response({
             id: data.id,
             type: RESPONSES.GET_INFO,
             payload: {
-                url,
+                url: api.connection.getUrl(),
                 ...utils.transformServerInfo(info),
             },
         });

--- a/packages/blockchain-link/tests/unit/fixtures/getAccountInfo-ripple.ts
+++ b/packages/blockchain-link/tests/unit/fixtures/getAccountInfo-ripple.ts
@@ -17,7 +17,7 @@ export default [
                 unconfirmed: 0,
             },
             misc: {
-                reserve: '20000000',
+                reserve: '10000000',
                 sequence: 0,
             },
         },
@@ -40,14 +40,14 @@ export default [
         response: {
             descriptor: 'rfkV3EoXimH6JrG1QAyofgbVhnyZZDjWSj',
             balance: '20000000',
-            availableBalance: '0',
+            availableBalance: '10000000',
             empty: false,
             history: {
                 total: -1,
                 unconfirmed: 0,
             },
             misc: {
-                reserve: '20000000',
+                reserve: '10000000',
                 sequence: 2,
             },
         },
@@ -88,7 +88,7 @@ export default [
         response: {
             descriptor: 'rfkV3EoXimH6JrG1QAyofgbVhnyZZDjWSj',
             balance: '20000000',
-            availableBalance: '0',
+            availableBalance: '10000000',
             empty: false,
             history: {
                 total: -1,
@@ -112,7 +112,7 @@ export default [
                 ],
             },
             misc: {
-                reserve: '20000000',
+                reserve: '10000000',
                 sequence: 2,
             },
         },
@@ -135,14 +135,14 @@ export default [
         response: {
             descriptor: 'rfkV3EoXimH6JrG1QAyofgbVhnyZZDjWSj',
             balance: '20000000',
-            availableBalance: '0',
+            availableBalance: '10000000',
             empty: false,
             history: {
                 total: -1,
                 unconfirmed: 1,
             },
             misc: {
-                reserve: '20000000',
+                reserve: '10000000',
                 sequence: 2,
             },
         },
@@ -170,7 +170,7 @@ export default [
         response: {
             descriptor: 'rfkV3EoXimH6JrG1QAyofgbVhnyZZDjWSj',
             balance: '20000000',
-            availableBalance: '0',
+            availableBalance: '10000000',
             empty: false,
             history: {
                 total: -1,
@@ -233,7 +233,7 @@ export default [
                 ],
             },
             misc: {
-                reserve: '20000000',
+                reserve: '10000000',
                 sequence: 2,
             },
         },

--- a/packages/blockchain-link/webpack/dev.babel.js
+++ b/packages/blockchain-link/webpack/dev.babel.js
@@ -46,6 +46,7 @@ module.exports = {
             'ws-browser': `${SRC}/utils/ws.js`,
         },
         fallback: {
+            https: false, // required by ripple-lib
             crypto: require.resolve('crypto-browserify'),
             stream: require.resolve('stream-browserify'),
         },

--- a/packages/blockchain-link/webpack/workers.module.babel.js
+++ b/packages/blockchain-link/webpack/workers.module.babel.js
@@ -42,6 +42,7 @@ module.exports = {
             'ws-browser': `${SRC}/utils/ws.js`,
         },
         fallback: {
+            https: false, // required by ripple-lib
             crypto: require.resolve('crypto-browserify'),
             stream: require.resolve('stream-browserify'),
         },

--- a/packages/blockchain-link/webpack/workers.web.babel.js
+++ b/packages/blockchain-link/webpack/workers.web.babel.js
@@ -34,6 +34,7 @@ module.exports = {
             'ws-browser': `${SRC}/utils/ws.js`,
         },
         fallback: {
+            https: false, // required by ripple-lib
             crypto: require.resolve('crypto-browserify'),
             stream: require.resolve('stream-browserify'),
         },

--- a/packages/connect-iframe/webpack/prod.webpack.config.js
+++ b/packages/connect-iframe/webpack/prod.webpack.config.js
@@ -61,10 +61,9 @@ module.exports = {
         fallback: {
             fs: false, // ignore "fs" import in fastxpub (hd-wallet)
             path: false, // ignore "path" import in protobufjs-old-fixed-webpack (dependency of trezor-link)
-            net: false, // ignore "net" import in "ripple-lib"
-            tls: false, // ignore "tls" imports in "ripple-lib"
+            https: false, // ignore "https" import in "ripple-lib"
             vm: false, // ignore "vm" imports in "asn1.js@4.10.1" > crypto-browserify"
-            util: require.resolve('util'), // required by "ripple-lib"
+            // util: require.resolve('util'), // required by "ripple-lib"
             assert: require.resolve('assert'), // required by multiple dependencies
             crypto: require.resolve('crypto-browserify'), // required by multiple dependencies
             stream: require.resolve('stream-browserify'), // required by utxo-lib and keccak

--- a/packages/suite/src/utils/wallet/accountUtils.ts
+++ b/packages/suite/src/utils/wallet/accountUtils.ts
@@ -327,7 +327,8 @@ export const isAccountOutdated = (account: Account, freshInfo: AccountInfo) => {
     const changedRipple =
         account.networkType === 'ripple' &&
         (freshInfo.misc!.sequence !== account.misc.sequence ||
-            freshInfo.balance !== account.balance);
+            freshInfo.balance !== account.balance ||
+            freshInfo.misc!.reserve !== account.misc.reserve);
 
     const changedEthereum =
         account.networkType === 'ethereum' && freshInfo.misc!.nonce !== account.misc.nonce;

--- a/yarn.lock
+++ b/yarn.lock
@@ -7880,7 +7880,7 @@ assert-plus@1.0.0, assert-plus@^1.0.0:
   resolved "https://registry.yarnpkg.com/assert-plus/-/assert-plus-1.0.0.tgz#f12e0f3c5d77b0b1cdd9146942e4e96c1e4dd525"
   integrity sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU=
 
-assert@2.0.0:
+assert@2.0.0, assert@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/assert/-/assert-2.0.0.tgz#95fc1c616d48713510680f2eaf2d10dd22e02d32"
   integrity sha512-se5Cd+js9dXJnu6Ag2JFc00t+HmHOen+8Q+L7O9zI0PqQXr20uk2J0XQqMxZEeo5U50o8Nvmmx7dZrl+Ufr35A==
@@ -8464,6 +8464,11 @@ big-integer@^1.6.16, big-integer@^1.6.44:
   version "1.6.48"
   resolved "https://registry.yarnpkg.com/big-integer/-/big-integer-1.6.48.tgz#8fd88bd1632cba4a1c8c3e3d7159f08bb95b4b9e"
   integrity sha512-j51egjPa7/i+RdiRuJbPdJ2FIUYYPhvYLjzoYbcMMm62ooO6F94fETG4MTs46zPAF9Brs04OajboA/qTGuz78w==
+
+big-integer@^1.6.48:
+  version "1.6.49"
+  resolved "https://registry.yarnpkg.com/big-integer/-/big-integer-1.6.49.tgz#f6817d3ea5d4f3fb19e24df9f4b1b4471a8328ce"
+  integrity sha512-KJ7VhqH+f/BOt9a3yMwJNmcZjG53ijWMTjSAGMveQWyLwqIiwkjNP5PFgDob3Snnx86SjDj6I89fIbv0dkQeNw==
 
 big.js@^3.1.3:
   version "3.2.0"
@@ -22733,7 +22738,7 @@ ripemd160@^2.0.0, ripemd160@^2.0.1:
     hash-base "^3.0.0"
     inherits "^2.0.1"
 
-ripple-address-codec@^4.0.0, ripple-address-codec@^4.1.0, ripple-address-codec@^4.1.1:
+ripple-address-codec@^4.0.0, ripple-address-codec@^4.1.1:
   version "4.1.2"
   resolved "https://registry.yarnpkg.com/ripple-address-codec/-/ripple-address-codec-4.1.2.tgz#c573309dbd0fdd4ef8c803bf36959b8a716c2aa1"
   integrity sha512-bIhmaxOg6rwVYkPQha9cuHdIdwmD8XTnaklBmyRjFvNZwYJ6Cf0cdCt+SpJd+RRJhRU65+U1Eup6YkoCBrqebg==
@@ -22741,23 +22746,22 @@ ripple-address-codec@^4.0.0, ripple-address-codec@^4.1.0, ripple-address-codec@^
     base-x "3.0.8"
     create-hash "^1.1.2"
 
-ripple-binary-codec@^0.2.7:
-  version "0.2.7"
-  resolved "https://registry.yarnpkg.com/ripple-binary-codec/-/ripple-binary-codec-0.2.7.tgz#c5390e97e4072747a3ff386ee99558b496c6e5ab"
-  integrity sha512-VD+sHgZK76q3kmO765klFHPDCEveS5SUeg/bUNVpNrj7w2alyDNkbF17XNbAjFv+kSYhfsUudQanoaSs2Y6uzw==
+ripple-binary-codec@^1.1.3:
+  version "1.1.3"
+  resolved "https://registry.yarnpkg.com/ripple-binary-codec/-/ripple-binary-codec-1.1.3.tgz#9dc6cd139fd587ec6fc2ffe72fc1f0ced53ca906"
+  integrity sha512-NnFNZZ+225BxdDdHtcEn4GiGzup+V0DGAbtKygZIwbqA5116oZBt6uY3g43gYpdDMISsEbM7NewBij8+7jdlvA==
   dependencies:
-    babel-runtime "^6.26.0"
-    bn.js "^5.1.1"
+    assert "^2.0.0"
+    big-integer "^1.6.48"
+    buffer "5.6.0"
     create-hash "^1.2.0"
     decimal.js "^10.2.0"
-    inherits "^2.0.4"
-    lodash "^4.17.15"
-    ripple-address-codec "^4.1.0"
+    ripple-address-codec "^4.1.1"
 
-ripple-keypairs@^1.0.0:
-  version "1.0.2"
-  resolved "https://registry.yarnpkg.com/ripple-keypairs/-/ripple-keypairs-1.0.2.tgz#91c724210734e704e35053925a80bf1cd8104c92"
-  integrity sha512-3l2cUhUO4VEK42NfHtn7WA1NEO+vGU7p7/36QhCIvYFf8+lNdNrY0PrriJ3Mef/TG8hQvO8coCVEO5fpOKSAag==
+ripple-keypairs@^1.0.3:
+  version "1.0.3"
+  resolved "https://registry.yarnpkg.com/ripple-keypairs/-/ripple-keypairs-1.0.3.tgz#346f15fa25e020e0afaa7f6e31fe398e119344b2"
+  integrity sha512-Na5q8sUdxjd5DXBM88ocJgL2Ig0I1USyO3bvI0SMxJPp7F9DHvqLdPX45PVXs7HUq0Dj691Z9Uz9NeD/K7/eOA==
   dependencies:
     bn.js "^5.1.1"
     brorand "^1.0.5"
@@ -22773,10 +22777,10 @@ ripple-lib-transactionparser@0.8.2:
     bignumber.js "^9.0.0"
     lodash "^4.17.15"
 
-ripple-lib@1.8.2:
-  version "1.8.2"
-  resolved "https://registry.yarnpkg.com/ripple-lib/-/ripple-lib-1.8.2.tgz#d36dafcb64a913a5dab8a2f66a3b0727baaa9347"
-  integrity sha512-7fLQtiXb8LfyedkXQtDSNQPy7omNu7rGUO8M8bK2qiE+DuX4FPl8B8tVJbxBwOusAuYzdoVQfZtfdXt4WmBpmw==
+ripple-lib@1.10.0:
+  version "1.10.0"
+  resolved "https://registry.yarnpkg.com/ripple-lib/-/ripple-lib-1.10.0.tgz#e41aaf17d5c6e6f8bcc8116736ac108ff3d6b810"
+  integrity sha512-Cg2u73UybfM1PnzcuLt5flvLKZn35ovdIp+1eLrReVB4swuRuUF/SskJG9hf5wMosbvh+E+jZu8A6IbYJoyFIA==
   dependencies:
     "@types/lodash" "^4.14.136"
     "@types/ws" "^7.2.0"
@@ -22784,10 +22788,9 @@ ripple-lib@1.8.2:
     https-proxy-agent "^5.0.0"
     jsonschema "1.2.2"
     lodash "^4.17.4"
-    lodash.isequal "^4.5.0"
     ripple-address-codec "^4.1.1"
-    ripple-binary-codec "^0.2.7"
-    ripple-keypairs "^1.0.0"
+    ripple-binary-codec "^1.1.3"
+    ripple-keypairs "^1.0.3"
     ripple-lib-transactionparser "0.8.2"
     ws "^7.2.0"
 


### PR DESCRIPTION
- blockchain-link update `ripple-lib` dependency and reflect changes in webpack configs
- blockchain-link: set default XRP reserve to lower values see: https://xrpl.org/reserves.html#base-reserve-and-owner-reserve
- blockchain-link: XRP reserve values are taken not only from "on ledger" event abut also from "getServerInfo" call.
- suite: observe XRP reserve change


fix: https://github.com/trezor/trezor-suite/issues/4316