### PR TITLE
wip: ideas on onion links handling

### DIFF
--- a/packages/suite/src/constants/suite/index.ts
+++ b/packages/suite/src/constants/suite/index.ts
@@ -2,5 +2,6 @@ import { homescreensT1, homescreensT2 } from './homescreens';
 import * as URLS from './urls';
 import BIP_39 from './bip39';
 import * as DEVICE from './device';
+import * as TOR from './tor';
 
-export { homescreensT1, homescreensT2, URLS, BIP_39, DEVICE };
+export { homescreensT1, homescreensT2, URLS, BIP_39, DEVICE, TOR };

--- a/packages/suite/src/constants/suite/tor.ts
+++ b/packages/suite/src/constants/suite/tor.ts
@@ -1,0 +1,6 @@
+// mapping of normal to tor domains.
+// we probably can list only domains that trezor has under control, for security reasons
+// it is maybe likely that this map will have only one record forever?
+export const TOR_MAP = {
+    'trezor.io': 'trezoriovpjcahpzkrewelclulmszwbqpzmzgub37gbcjlvluxtruqad.onion',
+};

--- a/packages/suite/src/utils/suite/tor.ts
+++ b/packages/suite/src/utils/suite/tor.ts
@@ -1,5 +1,6 @@
 import { TOR_DOMAIN } from '@suite-constants/urls';
 
+// todo: make it general for more tor domain
 export const toTorUrl = (url: string) =>
     url.replace(/https:\/\/(([a-z0-9]+\.)*)trezor\.io(.*)/, `http://$1${TOR_DOMAIN}$3`);
 

--- a/packages/suite/src/utils/suite/url.ts
+++ b/packages/suite/src/utils/suite/url.ts
@@ -1,0 +1,23 @@
+import { toTorUrl } from './tor';
+
+import { TOR } from '@suite-constants';
+
+/**
+ * returns tor url if tor url is request and tor url is available for given domain
+ */
+export const getUrl = (url: string, isTor: boolean) => {
+    const { host } = new URL(url);
+    const [a, b] = host.split('.').reverse();
+    const domain = `${b}.${a}`;
+
+    // @ts-ignore
+    const torCounterpartDomain = TOR[domain];
+
+    console.log(domain);
+
+    if (isTor && torCounterpartDomain) {
+        return toTorUrl(url);
+    }
+
+    return url;
+};

--- a/packages/suite/src/views/dashboard/components/NewsFeed/index.tsx
+++ b/packages/suite/src/views/dashboard/components/NewsFeed/index.tsx
@@ -7,6 +7,8 @@ import { Button, variables } from '@trezor/components';
 import { useSelector } from '@suite-hooks';
 import { useFetchNews } from '@dashboard-hooks/useNews';
 import { toTorUrl } from '@suite-utils/tor';
+import { getUrl } from '@suite-utils/url';
+
 import { BLOG_URL } from '@suite-constants/urls';
 
 const Posts = styled.div`
@@ -102,7 +104,7 @@ const NewsFeed = ({ maxVisibleCount = 9 }: Props) => {
                 <MediumLink
                     target="_blank"
                     rel="noopener noreferrer"
-                    href={isTor ? toTorUrl(BLOG_URL) : BLOG_URL}
+                    href={getUrl(BLOG_URL, isTor)}
                 >
                     <Button isWhite variant="tertiary" icon="MEDIUM">
                         <Translation id="TR_OPEN_IN_MEDIUM" />
@@ -116,10 +118,10 @@ const NewsFeed = ({ maxVisibleCount = 9 }: Props) => {
                         key={item.link}
                         target="_blank"
                         rel="noopener noreferrer"
-                        href={isTor ? toTorUrl(item.link) : item.link}
+                        href={getUrl(item.link, isTor)}
                         data-test={`@dashboard/news/post/${index}`}
                     >
-                        <Image src={isTor ? toTorUrl(item.thumbnail) : item.thumbnail} />
+                        <Image src={getUrl(item.thumbnail, isTor)} />
                         <Content>
                             <Title>
                                 <Truncate lines={2}>{item.title}</Truncate>


### PR DESCRIPTION
this is targeting issue #3793 and so far only contains sketches for discussion and is not ready for review.

In general - it is easy to miss tor links when they are available (this is to root of #3793).

We need 5 lines of code just to be able to switch between tor and normal links


```
import { toTorUrl } from '@suite-utils/tor';
import { BLOG_URL } from '@suite-constants/urls';
import { useSelector } from '@suite-hooks';

const isTor = useSelector(state => state.suite.tor);
href={isTor ? toTorUrl(item.link) : item.link}

```

and current code is not ready to handle other but trezor.io onion links (altough I am not sure if this will ever happen).

Possible solutions:

### util
requires the same number of lines of code (:sob:) but is somewhat easier to use and allows multiple onion domains (proof of concept part of 1340c7d)

```
import { getUrl } from '@suite-utils/url';
import { BLOG_URL } from '@suite-constants/urls';
import { useSelector } from '@suite-hooks';

const isTor = useSelector(state => state.suite.tor);
href={getUrl(BLOG_URL, isTor)}

```

### hook

hook could wrap `useSelector` hook and directly return list of urls modified to use onion urls where available. maybe it is overkill though.. 

### component

unified "Link" component that would take care of it? We need to stop using href attribute and handle navigation with javascript.

### exoctic solutions?

- some kind of (global) event listner does not exist
- monkey patching every dom element with target="_blank" :smile:.. hmm also not a way to go  

Hmm :thinking: 