### PR TITLE
fix(suite): add trailing slash to bitcoin handler URI to prevent redirection

### DIFF
--- a/packages/suite/src/support/suite/Protocol.tsx
+++ b/packages/suite/src/support/suite/Protocol.tsx
@@ -57,7 +57,7 @@ const Protocol = () => {
         if (isWeb()) {
             navigator.registerProtocolHandler(
                 'bitcoin',
-                `${window.location.origin}${process.env.ASSET_PREFIX ?? ''}?uri=%s`,
+                `${window.location.origin}${process.env.ASSET_PREFIX ?? ''}/?uri=%s`,
                 // @ts-ignore - title is deprecated but it is recommended to be set because of backwards-compatibility
                 'Bitcoin / Trezor Suite',
             );


### PR DESCRIPTION
URL query parameters are not preserved on staging/production environment so far, so this fix bitcoin: URI handler

It's also better to prevent unnecessary redirection even when we start preserving those query params...