### PR TITLE
fix(suite): check ref for field to avoid error

### DIFF
--- a/packages/suite/src/hooks/wallet/sign-verify/useSignVerifyForm.ts
+++ b/packages/suite/src/hooks/wallet/sign-verify/useSignVerifyForm.ts
@@ -84,8 +84,8 @@ export const useSignVerifyForm = (page: 'sign' | 'verify', account?: Account) =>
     });
 
     useEffect(() => {
-        trigger('message');
-    }, [trigger, formValues.message, formValues.hex]);
+        if (control?.fieldsRef?.current?.message) trigger('message');
+    }, [trigger, formValues.message, formValues.hex, control?.fieldsRef]);
 
     useEffect(() => {
         if (page === 'sign') setValue('signature', '');


### PR DESCRIPTION
Should fix error on production builds in sign&verify form, where 'message' tries to validate even if corresponding input doesn't exist yet.