### PR TITLE
fix: prevent collabsible box to expand when clicking on webusb button

### DIFF
--- a/packages/suite/src/components/suite/WebusbButton/index.tsx
+++ b/packages/suite/src/components/suite/WebusbButton/index.tsx
@@ -13,7 +13,8 @@ const WebusbButton = (props: ButtonProps) => (
     <Button
         {...props}
         icon={props.icon || 'PLUS'}
-        onClick={async () => {
+        onClick={async e => {
+            e.stopPropagation();
             try {
                 // @ts-ignore navigator.usb not found
                 await navigator.usb.requestDevice({ filters });


### PR DESCRIPTION
just noticed that clicking on the webusb button toggled expanded / collapsed state of troubleshooting tips 

![image](https://user-images.githubusercontent.com/30367552/136254520-ff31486e-02f0-48e4-b8d7-9f0b8f383cb6.png)

