### PR TITLE
fix(suite): add translation strings and use locales for time

### DIFF
--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -44,7 +44,7 @@
         "@storybook/react": "^6.3.7",
         "@types/randomcolor": "0.5.5",
         "@types/react": "^17.0.0",
-        "@types/react-datepicker": "^3.1.2",
+        "@types/react-date-range": "^1.1.8",
         "@types/react-select": "^3.1.2",
         "@types/react-truncate": "^2.3.3",
         "@types/styled-components": "^5.1.7",

--- a/packages/components/src/components/Timerange/index.tsx
+++ b/packages/components/src/components/Timerange/index.tsx
@@ -1,6 +1,9 @@
-import React, { useState, useEffect } from 'react';
+import React, { useState } from 'react';
 import { DateRange } from 'react-date-range';
 import styled from 'styled-components';
+
+import type { Locale } from 'date-fns';
+
 import { Button } from '../buttons/Button';
 import { style as datepickerStyle } from './index.style';
 
@@ -177,6 +180,7 @@ interface Props {
     onCancel: () => any;
     startDate?: Date;
     endDate?: Date;
+    locale?: Locale;
     ctaCancel: React.ReactNode | string;
     ctaSubmit: React.ReactNode | string;
 }
@@ -211,6 +215,7 @@ const Timerange = (props: Props) => {
                     ranges={[state]}
                     startDatePlaceholder=""
                     endDatePlaceholder=""
+                    locale={props.locale}
                 />
             </Calendar>
             <Buttons>

--- a/packages/suite/src/components/onboarding/Hologram/index.tsx
+++ b/packages/suite/src/components/onboarding/Hologram/index.tsx
@@ -3,7 +3,7 @@ import styled from 'styled-components';
 
 import { variables } from '@trezor/components';
 import { DeviceAnimation } from '@onboarding-components';
-import { Translation, TrezorLink } from '@suite/components/suite';
+import { Translation, TrezorLink } from '@suite-components';
 import {
     TREZOR_PACKAGING_URL,
     TREZOR_RESELLERS_URL,

--- a/packages/suite/src/components/recovery/SelectRecoveryWord.tsx
+++ b/packages/suite/src/components/recovery/SelectRecoveryWord.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { useRecovery } from '@suite-hooks';
 import TrezorConnect, { UI } from 'trezor-connect';
-import { WordInput, WordInputAdvanced } from '@suite/components/suite';
+import { WordInput, WordInputAdvanced } from '@suite-components';
 
 const RecoveryWordSelect = () => {
     const { wordRequestInputType } = useRecovery();

--- a/packages/suite/src/components/suite/NavigationBar/components/DeviceSelector/components/DeviceStatus/index.tsx
+++ b/packages/suite/src/components/suite/NavigationBar/components/DeviceSelector/components/DeviceStatus/index.tsx
@@ -3,6 +3,7 @@ import { Icon, variables, useTheme, SuiteThemeColors } from '@trezor/components'
 import styled from 'styled-components';
 import * as deviceUtils from '@suite-utils/device';
 import { TrezorDevice } from '@suite-types';
+import { Translation } from '@suite-components';
 
 type Status = 'connected' | 'disconnected' | 'warning';
 
@@ -27,6 +28,18 @@ const getStatusForDevice = (device: TrezorDevice) => {
         return 'warning';
     }
     return 'connected';
+};
+
+const getTextForStatus = (status: 'connected' | 'disconnected' | 'warning') => {
+    switch (status) {
+        case 'connected':
+            return <Translation id="TR_CONNECTED" />;
+        case 'disconnected':
+            return <Translation id="TR_DISCONNECTED" />;
+        case 'warning':
+        default:
+            return <Translation id="TR_WARNING" />;
+    }
 };
 
 const StatusText = styled.div<{ show: boolean; status: Status }>`
@@ -115,7 +128,7 @@ const DeviceStatus = ({
     return (
         <>
             <StatusText status={status} show={showTextStatus}>
-                {status}
+                {getTextForStatus(status)}
             </StatusText>
             <OuterCircle status={status} show={showIconStatus}>
                 <InnerCircle status={status} />

--- a/packages/suite/src/components/suite/TransactionsGraph/components/GraphScaleDropdownItem/index.tsx
+++ b/packages/suite/src/components/suite/TransactionsGraph/components/GraphScaleDropdownItem/index.tsx
@@ -2,6 +2,7 @@ import React from 'react';
 import { SelectBar, SelectBarProps } from '@trezor/components';
 import { useGraph } from '@suite-hooks';
 import { GraphScale } from '@wallet-types/graph';
+import { Translation } from '@suite-components';
 
 const GraphScaleDropdownItem = (props: Omit<SelectBarProps<GraphScale>, 'options'>) => {
     const { selectedView, setSelectedView } = useGraph();
@@ -11,8 +12,8 @@ const GraphScaleDropdownItem = (props: Omit<SelectBarProps<GraphScale>, 'options
             onChange={setSelectedView}
             selectedOption={selectedView}
             options={[
-                { label: 'Linear', value: 'linear' },
-                { label: 'Logarithmic', value: 'log' },
+                { label: <Translation id="TR_GRAPH_LINEAR" />, value: 'linear' },
+                { label: <Translation id="TR_GRAPH_LOGARITHMIC" />, value: 'log' },
             ]}
             {...props}
         />

--- a/packages/suite/src/components/suite/TransactionsGraph/components/RangeSelector/index.tsx
+++ b/packages/suite/src/components/suite/TransactionsGraph/components/RangeSelector/index.tsx
@@ -2,9 +2,8 @@ import React, { useState, useRef } from 'react';
 import styled from 'styled-components';
 import { colors, variables, Dropdown, DropdownRef, Timerange } from '@trezor/components';
 import { Translation } from '@suite-components';
-import { useGraph } from '@suite-hooks';
+import { useGraph, useLocales } from '@suite-hooks';
 import { GraphRange } from '@wallet-types/graph';
-import { getFormattedLabel } from '@wallet-utils/graphUtils';
 import {
     startOfDay,
     startOfToday,
@@ -78,6 +77,24 @@ const RANGES = [
     },
 ] as const;
 
+const getFormattedLabel = (rangeLabel: GraphRange['label']) => {
+    switch (rangeLabel) {
+        case 'range':
+            return <Translation id="TR_RANGE" />;
+        case 'all':
+            return <Translation id="TR_ALL" />;
+        case 'year':
+            return <Translation id="TR_DATE_YEAR_SHORT" />;
+        case 'month':
+            return <Translation id="TR_DATE_MONTH_SHORT" />;
+        case 'week':
+            return <Translation id="TR_DATE_WEEK_SHORT" />;
+        case 'day':
+            return <Translation id="TR_DATE_DAY_SHORT" />;
+        // no default
+    }
+};
+
 interface Props {
     onSelectedRange?: (range: GraphRange) => void;
     className?: string;
@@ -86,6 +103,7 @@ interface Props {
 
 const RangeSelector = (props: Props) => {
     const dropdownRef = useRef<DropdownRef>();
+    const locale = useLocales();
     const { onSelectedRange } = props;
     const { selectedRange, setSelectedRange } = useGraph();
     const [customTimerangeStart, setCustomTimerangeStart] = useState<Date>();
@@ -145,6 +163,7 @@ const RangeSelector = (props: Props) => {
                                         onCancel={() => dropdownRef.current!.close()}
                                         ctaSubmit={<Translation id="TR_CONFIRM" />}
                                         ctaCancel={<Translation id="TR_CANCEL" />}
+                                        locale={locale}
                                     />
                                 ),
                                 callback: () => false,

--- a/packages/suite/src/components/suite/hocNotification/index.tsx
+++ b/packages/suite/src/components/suite/hocNotification/index.tsx
@@ -367,12 +367,7 @@ const hocNotification = (notification: NotificationEntry, View: React.ComponentT
             return simple(View, {
                 notification,
                 variant: 'info',
-                message: {
-                    id: 'EVENT_WALLET_CREATED',
-                    values: {
-                        walletLabel: 'New wallet',
-                    },
-                },
+                message: 'EVENT_WALLET_CREATED',
             });
 
         default:

--- a/packages/suite/src/components/suite/modals/Passphrase/components/PassphraseTypeCard/index.tsx
+++ b/packages/suite/src/components/suite/modals/Passphrase/components/PassphraseTypeCard/index.tsx
@@ -9,6 +9,7 @@ import { MAX_LENGTH } from '@suite-constants/inputs';
 import { countBytesInString } from '@suite-utils/string';
 import { OpenGuideFromTooltip } from '@guide-views';
 import PasswordStrengthIndicator from '@suite-components/PasswordStrengthIndicator';
+import { useTranslation } from '@suite-hooks';
 
 const Wrapper = styled.div<Pick<Props, 'type' | 'singleColModal'>>`
     display: flex;
@@ -164,6 +165,7 @@ const DOT = '●';
 
 const PassphraseTypeCard = (props: Props) => {
     const theme = useTheme();
+    const { translationString } = useTranslation();
     const [value, setValue] = useState('');
     const [enabled, setEnabled] = useState(!props.authConfirmation);
     const [showPassword, setShowPassword] = useState(false);
@@ -305,7 +307,7 @@ const PassphraseTypeCard = (props: Props) => {
                         <InputWrapper authConfirmation={props.authConfirmation}>
                             <PassphraseInput
                                 data-test="@passphrase/input"
-                                placeholder="Enter passphrase" // TODO: Localize
+                                placeholder={translationString('TR_ENTER_PASSPHRASE')}
                                 onChange={onChange}
                                 value={displayValue}
                                 innerRef={ref}

--- a/packages/suite/src/components/wallet/AccountsMenu/components/AccountSearchBox/index.tsx
+++ b/packages/suite/src/components/wallet/AccountsMenu/components/AccountSearchBox/index.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import styled, { css } from 'styled-components';
 import { useTheme, Icon, Input, CoinLogo } from '@trezor/components';
-import { useSelector, useAccountSearch } from '@suite-hooks';
+import { useSelector, useAccountSearch, useTranslation } from '@suite-hooks';
 
 const Wrapper = styled.div`
     background: ${props => props.theme.BG_WHITE};
@@ -67,6 +67,7 @@ interface Props {
 
 const AccountSearchBox = (props: Props) => {
     const theme = useTheme();
+    const { translationString } = useTranslation();
     const { coinFilter, setCoinFilter, searchString, setSearchString } = useAccountSearch();
     const { enabledNetworks, device } = useSelector(state => ({
         enabledNetworks: state.wallet.settings.enabledNetworks,
@@ -99,7 +100,7 @@ const AccountSearchBox = (props: Props) => {
                     addonAlign="left"
                     textIndent={[16, 12]}
                     variant="small"
-                    placeholder="Search"
+                    placeholder={translationString('TR_SEARCH')}
                     noTopLabel
                     noError
                     clearButton

--- a/packages/suite/src/components/wallet/Fees/index.tsx
+++ b/packages/suite/src/components/wallet/Fees/index.tsx
@@ -84,9 +84,17 @@ const Label = styled.div<Pick<Props, 'rbfForm'>>`
     color: ${props => props.theme.TYPE_DARK_GREY};
 `;
 
+enum FEE_LEVELS_TRANSLATION {
+    custom = 'FEE_LEVEL_CUSTOM',
+    high = 'FEE_LEVEL_HIGH',
+    normal = 'FEE_LEVEL_NORMAL',
+    economy = 'FEE_LEVEL_ECONOMY',
+    low = 'FEE_LEVEL_LOW',
+}
+
 const buildFeeOptions = (levels: FeeLevel[]) =>
     levels.map(({ label }) => ({
-        label,
+        label: <Translation id={FEE_LEVELS_TRANSLATION[label]} />,
         value: label,
     }));
 

--- a/packages/suite/src/components/wallet/TransactionItem/components/Target/index.tsx
+++ b/packages/suite/src/components/wallet/TransactionItem/components/Target/index.tsx
@@ -108,7 +108,7 @@ export const Target = ({
                                 }
                                 return addNotification({ type: 'copy-to-clipboard' });
                             },
-                            label: 'Copy address',
+                            label: <Translation id="TR_ADDRESS_MODAL_CLIPBOARD" />,
                             key: 'copy-address',
                         },
                     ]}

--- a/packages/suite/src/components/wallet/TransactionItem/components/TransactionHeading/index.tsx
+++ b/packages/suite/src/components/wallet/TransactionItem/components/TransactionHeading/index.tsx
@@ -110,11 +110,23 @@ const TransactionHeading = ({
     if (isTxUnknown(transaction)) {
         heading = <Translation id="TR_UNKNOWN_TRANSACTION" />;
     } else if (transaction.type === 'sent') {
-        heading = isPending ? `Sending ${symbol}` : `Sent ${symbol}`;
+        heading = isPending ? (
+            <Translation id="TR_SENDING_TRANSACTION" values={{ symbol }} />
+        ) : (
+            <Translation id="TR_SENT_TRANSACTION" values={{ symbol }} />
+        );
     } else if (transaction.type === 'recv') {
-        heading = isPending ? `Receiving ${symbol}` : `Received ${symbol}`;
+        heading = isPending ? (
+            <Translation id="TR_RECEIVING_TRANSACTION" values={{ symbol }} />
+        ) : (
+            <Translation id="TR_RECEIVED_TRANSACTION" values={{ symbol }} />
+        );
     } else if (transaction.type === 'self') {
-        heading = isPending ? `Sending ${symbol} to myself` : `Sent ${symbol} to myself`;
+        heading = isPending ? (
+            <Translation id="TR_SENDING_TO_MYSELF_TRANSACTION" values={{ symbol }} />
+        ) : (
+            <Translation id="TR_SENT_TO_MYSELF_TRANSACTION" values={{ symbol }} />
+        );
     } else if (transaction.type === 'failed') {
         heading = <Translation id="TR_FAILED_TRANSACTION" />;
     } else {

--- a/packages/suite/src/hooks/suite/index.ts
+++ b/packages/suite/src/hooks/suite/index.ts
@@ -14,3 +14,4 @@ export { useThemeContext } from './useThemeContext';
 export { useOnboarding } from './useOnboarding';
 export { useRecovery } from './useRecovery';
 export { useGuide } from './useGuide';
+export { useLocales } from './useLocales';

--- a/packages/suite/src/hooks/suite/useLocales.ts
+++ b/packages/suite/src/hooks/suite/useLocales.ts
@@ -1,0 +1,34 @@
+import { useEffect, useState } from 'react';
+
+import type { Locale } from 'date-fns';
+
+import { useSelector } from '@suite-hooks';
+
+export const useLocales = () => {
+    const [locale, setLocale] = useState<Locale>();
+    const { language } = useSelector(state => ({
+        language: state.suite.settings.language,
+    }));
+
+    useEffect(() => {
+        const loadLocale = async () => {
+            const lang = language === 'en' ? 'en-US' : language;
+
+            let dateLocale;
+            try {
+                dateLocale = await import(`date-fns/locale/${lang}/index.js`);
+            } catch (error) {
+                dateLocale = await import(`date-fns/locale/en-US/index.js`);
+
+                console.error(
+                    `date-fns language: ${language} is not available. Using en-US fallback.`,
+                );
+            }
+            setLocale(dateLocale);
+        };
+
+        loadLocale();
+    }, [language]);
+
+    return locale;
+};

--- a/packages/suite/src/support/messages.ts
+++ b/packages/suite/src/support/messages.ts
@@ -1404,6 +1404,11 @@ export default defineMessages({
         defaultMessage: 'Connect your Trezor to verify this address',
         id: 'TR_CONNECT_YOUR_TREZOR_TO_CHECK',
     },
+    TR_WARNING: {
+        defaultMessage: 'Warning',
+        description: 'Device status',
+        id: 'TR_WARNING',
+    },
     TR_CONNECTED: {
         defaultMessage: 'Connected',
         description: 'Device status',
@@ -2401,7 +2406,7 @@ export default defineMessages({
     },
     TR_PASSPHRASE_CASE_SENSITIVE: {
         defaultMessage: 'Note: Passphrase is case-sensitive.',
-        id: 'PASSPHRASE_CASE_SENSITIVE',
+        id: 'TR_PASSPHRASE_CASE_SENSITIVE',
     },
     TR_PASSPHRASE_HIDDEN_WALLET: {
         defaultMessage: 'Hidden wallet',
@@ -2968,6 +2973,30 @@ export default defineMessages({
         defaultMessage: 'Failed transaction',
         id: 'TR_FAILED_TRANSACTION',
     },
+    TR_SENDING_TRANSACTION: {
+        defaultMessage: 'Sending {symbol}',
+        id: 'TR_SENDING_TRANSACTION',
+    },
+    TR_SENT_TRANSACTION: {
+        defaultMessage: 'Sent {symbol}',
+        id: 'TR_SENT_TRANSACTION',
+    },
+    TR_SENDING_TO_MYSELF_TRANSACTION: {
+        defaultMessage: 'Sending {symbol} to myself',
+        id: 'TR_SENDING_TO_MYSELF_TRANSACTION',
+    },
+    TR_SENT_TO_MYSELF_TRANSACTION: {
+        defaultMessage: 'Sent {symbol} to myself',
+        id: 'TR_SENT_TO_MYSELF_TRANSACTION',
+    },
+    TR_RECEIVING_TRANSACTION: {
+        defaultMessage: 'Receiving {symbol}',
+        id: 'TR_RECEIVING_TRANSACTION',
+    },
+    TR_RECEIVED_TRANSACTION: {
+        defaultMessage: 'Received {symbol}',
+        id: 'TR_RECEIVED_TRANSACTION',
+    },
     TR_UNKNOWN_ERROR_SEE_CONSOLE: {
         defaultMessage: 'Unknown error. See console logs for details.',
         id: 'TR_UNKNOWN_ERROR_SEE_CONSOLE',
@@ -3532,7 +3561,7 @@ export default defineMessages({
     },
     EVENT_WALLET_CREATED: {
         id: 'EVENT_WALLET_CREATED',
-        defaultMessage: '{walletLabel} created',
+        defaultMessage: 'New wallet created',
     },
     TR_WIPE_DEVICE_HEADING: {
         id: 'TR_WIPE_DEVICE_HEADING',
@@ -5227,6 +5256,26 @@ export default defineMessages({
         description: 'Label in Send form',
         id: 'FEE',
     },
+    FEE_LEVEL_CUSTOM: {
+        defaultMessage: 'Custom',
+        id: 'FEE_LEVEL_CUSTOM',
+    },
+    FEE_LEVEL_HIGH: {
+        defaultMessage: 'High',
+        id: 'FEE_LEVEL_HIGH',
+    },
+    FEE_LEVEL_NORMAL: {
+        defaultMessage: 'Normal',
+        id: 'FEE_LEVEL_NORMAL',
+    },
+    FEE_LEVEL_ECONOMY: {
+        defaultMessage: 'Economy',
+        id: 'FEE_LEVEL_ECONOMY',
+    },
+    FEE_LEVEL_LOW: {
+        defaultMessage: 'Low',
+        id: 'FEE_LEVEL_LOW',
+    },
     FEE_NEEDS_UPDATE: {
         defaultMessage: 'Fee levels are outdated',
         id: 'FEE_NEEDS_UPDATE',
@@ -6006,6 +6055,10 @@ export default defineMessages({
         id: 'TR_EXPORT_FAIL',
         defaultMessage: 'Export failed.',
     },
+    TR_SEARCH: {
+        id: 'TR_SEARCH',
+        defaultMessage: 'Search',
+    },
     TR_SEARCH_FAIL: {
         id: 'TR_SEARCH_FAIL',
         defaultMessage: 'Search failed.',
@@ -6174,6 +6227,18 @@ export default defineMessages({
         id: 'TR_BYTES',
         defaultMessage: 'bytes',
     },
+    TR_GRAPH_LINEAR: {
+        id: 'TR_GRAPH_LINEAR',
+        defaultMessage: 'Linear',
+    },
+    TR_GRAPH_LOGARITHMIC: {
+        id: 'TR_GRAPH_LOGARITHMIC',
+        defaultMessage: 'Logarithmic',
+    },
+    TR_GRAPH_VIEW: {
+        id: 'TR_GRAPH_VIEW',
+        defaultMessage: 'Graph View',
+    },
     TR_SHOW_GRAPH: {
         id: 'TR_SHOW_GRAPH',
         defaultMessage: 'Show Graph',
@@ -6181,6 +6246,38 @@ export default defineMessages({
     TR_HIDE_GRAPH: {
         id: 'TR_HIDE_GRAPH',
         defaultMessage: 'Hide Graph',
+    },
+    TR_DATE_DAY_LONG: {
+        id: 'TR_DATE_DAY_LONG',
+        defaultMessage: '1 day',
+    },
+    TR_DATE_DAY_SHORT: {
+        id: 'TR_DATE_DAY_SHORT',
+        defaultMessage: '1D',
+    },
+    TR_DATE_WEEK_LONG: {
+        id: 'TR_DATE_WEEK_LONG',
+        defaultMessage: '1 week',
+    },
+    TR_DATE_WEEK_SHORT: {
+        id: 'TR_DATE_WEEK_SHORT',
+        defaultMessage: '1W',
+    },
+    TR_DATE_MONTH_LONG: {
+        id: 'TR_DATE_MONTH_LONG',
+        defaultMessage: '1 month',
+    },
+    TR_DATE_MONTH_SHORT: {
+        id: 'TR_DATE_MONTH_SHORT',
+        defaultMessage: '1M',
+    },
+    TR_DATE_YEAR_LONG: {
+        id: 'TR_DATE_YEAR_LONG',
+        defaultMessage: '1 year',
+    },
+    TR_DATE_YEAR_SHORT: {
+        id: 'TR_DATE_YEAR_SHORT',
+        defaultMessage: '1Y',
     },
     TR_SUITE_META_DESCRIPTION: {
         id: 'TR_SUITE_META_DESCRIPTION',
@@ -6438,11 +6535,11 @@ export default defineMessages({
     },
     TR_TROUBLESHOOTING_TIP_BRIDGE_STATUS_TITLE: {
         defaultMessage: 'Ensure the Trezor Bridge process is running',
-        id: 'TR_TROUBLESHOOTING_BRIDGE_STATUS_TITLE',
+        id: 'TR_TROUBLESHOOTING_TIP_BRIDGE_STATUS_TITLE',
     },
     TR_TROUBLESHOOTING_TIP_BRIDGE_STATUS_DESCRIPTION: {
         defaultMessage: 'Visit <a>Trezor Bridge status page</a>',
-        id: 'TR_TROUBLESHOOTING_BRIDGE_STATUS_DESCRIPTION',
+        id: 'TR_TROUBLESHOOTING_TIP_BRIDGE_STATUS_DESCRIPTION',
     },
     TR_TROUBLESHOOTING_TIP_BRIDGE_INSTALL_TITLE: {
         id: 'TR_TOUBLESHOOTING_TIP_BRIDGE_INSTALL_TITLE',

--- a/packages/suite/src/utils/suite/date.ts
+++ b/packages/suite/src/utils/suite/date.ts
@@ -11,13 +11,15 @@ import {
     eachMonthOfInterval,
     eachDayOfInterval,
     differenceInMinutes,
+    Locale,
 } from 'date-fns';
 import { utcToZonedTime } from 'date-fns-tz';
 
 export const formatDuration = (seconds: number) =>
     formatDistance(0, seconds * 1000, { includeSeconds: true });
 
-export const formatDurationStrict = (seconds: number) => formatDistanceStrict(0, seconds * 1000);
+export const formatDurationStrict = (seconds: number, locale?: Locale) =>
+    formatDistanceStrict(0, seconds * 1000, { locale });
 
 export const getLocalTimeZone = () => Intl.DateTimeFormat().resolvedOptions().timeZone;
 

--- a/packages/suite/src/utils/wallet/graphUtils.ts
+++ b/packages/suite/src/utils/wallet/graphUtils.ts
@@ -329,42 +329,6 @@ export const calcXDomain = (
     return [start - xPadding, end + xPadding];
 };
 
-export const getFormattedLabel = (rangeLabel: GraphRange['label']) => {
-    switch (rangeLabel) {
-        case 'range':
-            return 'range';
-        case 'all':
-            return 'all';
-        case 'year':
-            return '1Y';
-        case 'month':
-            return '1M';
-        case 'week':
-            return '1W';
-        case 'day':
-            return '1D';
-        // no default
-    }
-};
-
-export const getFormattedLabelLong = (rangeLabel: GraphRange['label']) => {
-    switch (rangeLabel) {
-        case 'range':
-            return 'range';
-        case 'all':
-            return 'all';
-        case 'year':
-            return '1 year';
-        case 'month':
-            return '1 month';
-        case 'week':
-            return '1 week';
-        case 'day':
-            return '1 day';
-        // no default
-    }
-};
-
 export const calcFakeGraphDataForTimestamps = (
     timestamps: number[],
     data: CommonAggregatedHistory[],

--- a/packages/suite/src/views/wallet/sign-verify/components/SignAddressInput.tsx
+++ b/packages/suite/src/views/wallet/sign-verify/components/SignAddressInput.tsx
@@ -87,6 +87,7 @@ const SignAddressInput = ({
             state={error ? 'error' : undefined}
             isSearchable
             isDisabled={!!isDisabled}
+            placeholder=""
             components={{
                 Option,
                 Input,

--- a/packages/suite/src/views/wallet/transactions/components/TransactionSummary/components/SummaryCards/index.tsx
+++ b/packages/suite/src/views/wallet/transactions/components/TransactionSummary/components/SummaryCards/index.tsx
@@ -3,7 +3,7 @@ import styled from 'styled-components';
 import BigNumber from 'bignumber.js';
 import { variables } from '@trezor/components';
 import { Translation, HiddenPlaceholder, FormattedNumber, FormattedDate } from '@suite-components';
-import { sumFiatValueMap, getFormattedLabelLong } from '@wallet-utils/graphUtils';
+import { sumFiatValueMap } from '@wallet-utils/graphUtils';
 import { Account } from '@wallet-types';
 import { GraphRange, AggregatedAccountHistory } from '@wallet-types/graph';
 import InfoCard from './components/InfoCard';
@@ -18,6 +18,24 @@ const InfoCardsWrapper = styled.div`
         grid-template-columns: 1fr;
     }
 `;
+
+const getFormattedLabelLong = (rangeLabel: GraphRange['label']) => {
+    switch (rangeLabel) {
+        case 'range':
+            return <Translation id="TR_RANGE" />;
+        case 'all':
+            return <Translation id="TR_ALL" />;
+        case 'year':
+            return <Translation id="TR_DATE_YEAR_LONG" />;
+        case 'month':
+            return <Translation id="TR_DATE_MONTH_LONG" />;
+        case 'week':
+            return <Translation id="TR_DATE_WEEK_LONG" />;
+        case 'day':
+            return <Translation id="TR_DATE_DAY_LONG" />;
+        // no default
+    }
+};
 
 interface Props {
     selectedRange: GraphRange;

--- a/packages/suite/src/views/wallet/transactions/components/TransactionSummary/components/TransactionSummaryDropdown/index.tsx
+++ b/packages/suite/src/views/wallet/transactions/components/TransactionSummary/components/TransactionSummaryDropdown/index.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import { Dropdown } from '@trezor/components';
 import GraphScaleDropdownItem from '@suite-components/TransactionsGraph/components/GraphScaleDropdownItem';
+import { Translation } from '@suite-components';
 
 interface Props {
     isGraphHidden: boolean;
@@ -16,7 +17,7 @@ const TransactionSummaryDropdown = (_props: Props) => (
         items={[
             {
                 key: 'group1',
-                label: 'Graph View',
+                label: <Translation id="TR_GRAPH_VIEW" />,
                 options: [
                     {
                         key: 'graphView',

--- a/yarn.lock
+++ b/yarn.lock
@@ -6275,14 +6275,13 @@
   dependencies:
     "@types/react" "*"
 
-"@types/react-datepicker@^3.1.2":
-  version "3.1.2"
-  resolved "https://registry.yarnpkg.com/@types/react-datepicker/-/react-datepicker-3.1.2.tgz#72c80a16ec2c323e8f51063e08b3c24f41352ed3"
-  integrity sha512-luMH1fUF3GRJwaNFh4cogHV7FSFCJLU8Ai2dZ60Xw0n+MrExvuwOHxcbNkaIkIztPwyuT0H0K8Q4g0RN88LoFQ==
+"@types/react-date-range@^1.1.8":
+  version "1.1.8"
+  resolved "https://registry.yarnpkg.com/@types/react-date-range/-/react-date-range-1.1.8.tgz#3df8f8f0ce2112c0e27613c4d45428761bf393a5"
+  integrity sha512-sXbPByk5xWxfa0KiCHXBSfq6Luc3WTfrzm3sfg7tMTAjnpQfKs8f6hOIwz2337iDsDxgbkN4V9pNQl8SIpYtoA==
   dependencies:
     "@types/react" "*"
-    date-fns "^2.0.1"
-    popper.js "^1.14.1"
+    date-fns "^2.16.1"
 
 "@types/react-dom@*", "@types/react-dom@^17.0.0":
   version "17.0.0"
@@ -20532,11 +20531,6 @@ popmotion@^9.1.0:
     hey-listen "^1.0.8"
     style-value-types "^4.0.1"
     tslib "^1.10.0"
-
-popper.js@^1.14.1:
-  version "1.16.1"
-  resolved "https://registry.yarnpkg.com/popper.js/-/popper.js-1.16.1.tgz#2a223cb3dc7b6213d740e40372be40de43e65b1b"
-  integrity sha512-Wb4p1J4zyFTbM+u6WuO4XstYx4Ky9Cewe4DWrel7B0w6VVICvPwdOpotjzcf6eD8TsckVnIMNONQyPIUFOUbCQ==
 
 portfinder@^1.0.28:
   version "1.0.28"


### PR DESCRIPTION
Fixes bugs from #4338 which are fixable in code. (to the date of PR) https://github.com/trezor/trezor-suite/issues/4338#issuecomment-937695677

Not translated are https://github.com/trezor/trezor-suite/issues/4338#issuecomment-936940300 https://github.com/trezor/trezor-suite/issues/4338#issuecomment-936998783 as they are strings from `connect` and we need to decide if we translate it in `suite` or `connect`. @szymonlesisz 

I am not 100% sure with `useLocales` hook, so please check if you think, that it is correct solution.