### PR TITLE
fix: make use of tor settings in news feed

### DIFF
--- a/packages/suite-desktop/src-electron/config.ts
+++ b/packages/suite-desktop/src-electron/config.ts
@@ -1,6 +1,6 @@
-import { TOR_DOMAIN } from '@suite-constants/urls';
+import { TOR_URLS } from '@suite-constants/tor';
 
-export const onionDomain = TOR_DOMAIN;
+export const onionDomain = TOR_URLS['trezor.io'];
 
 export const oauthUrls = [
     'https://accounts.google.com',

--- a/packages/suite-desktop/src-electron/libs/constants.ts
+++ b/packages/suite-desktop/src-electron/libs/constants.ts
@@ -1,4 +1,4 @@
-import { TOR_DOMAIN } from '@suite-constants/urls';
+import { TOR_URLS } from '@suite-constants/tor';
 
 export const PROTOCOL = 'file';
 
@@ -39,6 +39,6 @@ export const HTTP_ORIGINS_DEFAULT = [
     'trezor.io',
     '*.trezor.io',
     '*.sldev.cz',
-    TOR_DOMAIN,
-    `*.${TOR_DOMAIN}`,
+    TOR_URLS['trezor.io'],
+    `*.${TOR_URLS['trezor.io']}`,
 ];

--- a/packages/suite-web-landing/pages/_document.tsx
+++ b/packages/suite-web-landing/pages/_document.tsx
@@ -4,7 +4,7 @@ import { resolveStaticPath } from '@suite-utils/build';
 import { ServerStyleSheet } from 'styled-components';
 import globalStyles from '../support/styles';
 import { isEnabled } from '@suite-utils/features';
-import { TOR_DOMAIN } from '@suite-constants/urls';
+import { TOR_URLS } from '@suite-constants/tor';
 
 const isOnionLocation = isEnabled('ONION_LOCATION_META');
 
@@ -48,7 +48,10 @@ export default class MyDocument extends Document {
                     <meta httpEquiv="cache-control" content="no-cache" />
                     <meta httpEquiv="expires" content="-1" />
                     {isOnionLocation && (
-                        <meta httpEquiv="onion-location" content={`http://suite.${TOR_DOMAIN}`} />
+                        <meta
+                            httpEquiv="onion-location"
+                            content={`http://suite.${TOR_URLS['trezor.io']}`}
+                        />
                     )}
                     <link
                         media="all"

--- a/packages/suite/src/components/suite/Banners/MessageSystemBanner.tsx
+++ b/packages/suite/src/components/suite/Banners/MessageSystemBanner.tsx
@@ -3,6 +3,7 @@ import React, { useMemo } from 'react';
 import * as routerActions from '@suite-actions/routerActions';
 import * as messageSystemActions from '@suite-actions/messageSystemActions';
 import { useActions, useSelector } from '@suite-hooks';
+import { getTorUrlIfAvailable } from '@suite-utils/tor';
 import Wrapper from './components/Wrapper';
 
 import type { Message } from '@suite-types/messageSystem';
@@ -14,8 +15,10 @@ type Props = {
 const MessageSystemBanner = ({ message }: Props) => {
     const { cta, variant, id, content, dismissible } = message;
 
-    const { language } = useSelector(state => ({
+    const { language, tor, torOnionLinks } = useSelector(state => ({
         language: state.suite.settings.language,
+        tor: state.suite.tor,
+        torOnionLinks: state.suite.settings.torOnionLinks,
     }));
 
     const { goto, dismissNotification } = useActions({
@@ -33,7 +36,8 @@ const MessageSystemBanner = ({ message }: Props) => {
             // @ts-ignore: impossible to add all href options to the message system config json schema
             onClick = () => goto(link);
         } else if (action === 'external-link') {
-            onClick = () => window.open(link, '_blank');
+            onClick = () =>
+                window.open(tor && torOnionLinks ? getTorUrlIfAvailable(link) : link, '_blank');
         }
 
         return {
@@ -41,7 +45,7 @@ const MessageSystemBanner = ({ message }: Props) => {
             onClick: onClick!,
             'data-test': `@message-system/${id}/cta`,
         };
-    }, [id, cta, goto, language]);
+    }, [id, cta, goto, language, tor, torOnionLinks]);
 
     const dismissalConfig = useMemo(() => {
         if (!dismissible) return undefined;

--- a/packages/suite/src/components/suite/TrezorLink/index.tsx
+++ b/packages/suite/src/components/suite/TrezorLink/index.tsx
@@ -1,21 +1,9 @@
-import React, { useMemo } from 'react';
+import React from 'react';
 import { Link, LinkProps } from '@trezor/components';
-import { useSelector } from '@suite-hooks';
-import { toTorUrl } from '@suite-utils/tor';
+import { useExternalLink } from '@suite-hooks';
 
 const TrezorLink = (props: LinkProps) => {
-    const { tor, torOnionLinks } = useSelector(state => ({
-        tor: state.suite.tor,
-        torOnionLinks: state.suite.settings.torOnionLinks,
-    }));
-
-    const url = useMemo(() => {
-        if (props.href && tor && torOnionLinks) {
-            return toTorUrl(props.href);
-        }
-
-        return props.href;
-    }, [tor, torOnionLinks, props.href]);
+    const url = useExternalLink(props.href);
 
     return <Link {...props} href={url} />;
 };

--- a/packages/suite/src/constants/suite/index.ts
+++ b/packages/suite/src/constants/suite/index.ts
@@ -2,5 +2,6 @@ import { homescreensT1, homescreensT2 } from './homescreens';
 import * as URLS from './urls';
 import BIP_39 from './bip39';
 import * as DEVICE from './device';
+import { TOR_URLS } from './tor';
 
-export { homescreensT1, homescreensT2, URLS, BIP_39, DEVICE };
+export { homescreensT1, homescreensT2, URLS, TOR_URLS, BIP_39, DEVICE };

--- a/packages/suite/src/constants/suite/tor.ts
+++ b/packages/suite/src/constants/suite/tor.ts
@@ -1,0 +1,6 @@
+// mapping of normal to tor domains.
+// we probably can list only domains that trezor has under control, for security reasons
+// it is maybe likely that this map will have only one record forever?
+export const TOR_URLS: { [key: string]: string } = {
+    'trezor.io': 'trezoriovpjcahpzkrewelclulmszwbqpzmzgub37gbcjlvluxtruqad.onion',
+};

--- a/packages/suite/src/constants/suite/urls.ts
+++ b/packages/suite/src/constants/suite/urls.ts
@@ -54,8 +54,4 @@ export const FEEDBACK_FORM = 'https://satoshilabs.typeform.com/to/Dqb71wm1';
 export const FIRMWARE_COMMIT_URL = 'https://github.com/trezor/trezor-firmware/commit/';
 export const FIRMWARE_BINARIES_URL =
     'https://github.com/trezor/webwallet-data/tree/master/firmware';
-
-// Tor domain
-export const TOR_DOMAIN = 'trezoriovpjcahpzkrewelclulmszwbqpzmzgub37gbcjlvluxtruqad.onion';
-
 export const SL_SIGNING_KEY = 'https://trezor.io/security/satoshilabs-2021-signing-key.asc';

--- a/packages/suite/src/hooks/dashboard/useNews.ts
+++ b/packages/suite/src/hooks/dashboard/useNews.ts
@@ -2,8 +2,15 @@ import { useState, useEffect } from 'react';
 
 const NEWS_API_URL = 'https://news.trezor.io';
 
+interface Post {
+    link: string;
+    thumbnail: string;
+    title: string;
+    description: string;
+}
+
 export function useFetchNews() {
-    const [posts, setPosts] = useState<any[]>([]);
+    const [posts, setPosts] = useState<Post[]>([]);
     const [isError, setError] = useState(false);
     const [fetchCount, incrementFetchCount] = useState(4);
 

--- a/packages/suite/src/hooks/suite/index.ts
+++ b/packages/suite/src/hooks/suite/index.ts
@@ -15,3 +15,4 @@ export { useOnboarding } from './useOnboarding';
 export { useRecovery } from './useRecovery';
 export { useGuide } from './useGuide';
 export { useLocales } from './useLocales';
+export { useExternalLink } from './useExternalLink';

--- a/packages/suite/src/hooks/suite/useExternalLink.ts
+++ b/packages/suite/src/hooks/suite/useExternalLink.ts
@@ -1,6 +1,6 @@
 import { useMemo } from 'react';
 import { useSelector } from '@suite-hooks';
-import { toTorUrl } from '@suite-utils/tor';
+import { getTorUrlIfAvailable } from '@suite-utils/tor';
 
 /**
  * Returns plain url or onion url if available and tor is active
@@ -10,10 +10,9 @@ export const useExternalLink = (originalUrl?: string) => {
         tor: state.suite.tor,
         torOnionLinks: state.suite.settings.torOnionLinks,
     }));
-
     const url = useMemo(() => {
         if (originalUrl && tor && torOnionLinks) {
-            return toTorUrl(originalUrl);
+            return getTorUrlIfAvailable(originalUrl) || originalUrl;
         }
 
         return originalUrl;

--- a/packages/suite/src/hooks/suite/useExternalLink.ts
+++ b/packages/suite/src/hooks/suite/useExternalLink.ts
@@ -1,0 +1,23 @@
+import { useMemo } from 'react';
+import { useSelector } from '@suite-hooks';
+import { toTorUrl } from '@suite-utils/tor';
+
+/**
+ * Returns plain url or onion url if available and tor is active
+ */
+export const useExternalLink = (originalUrl?: string) => {
+    const { tor, torOnionLinks } = useSelector(state => ({
+        tor: state.suite.tor,
+        torOnionLinks: state.suite.settings.torOnionLinks,
+    }));
+
+    const url = useMemo(() => {
+        if (originalUrl && tor && torOnionLinks) {
+            return toTorUrl(originalUrl);
+        }
+
+        return originalUrl;
+    }, [tor, torOnionLinks, originalUrl]);
+
+    return url;
+};

--- a/packages/suite/src/utils/suite/__tests__/tor.test.ts
+++ b/packages/suite/src/utils/suite/__tests__/tor.test.ts
@@ -1,0 +1,70 @@
+import { TOR_URLS } from '@suite-constants';
+import { getTorUrlIfAvailable, isTorDomain, toTorUrl } from '@suite-utils/tor';
+
+describe('tor', () => {
+    describe('getTorUrlIfAvailable', () => {
+        const fixtures = [
+            {
+                desc: 'simple domain',
+                in: 'https://trezor.io',
+                out: `http://${TOR_URLS['trezor.io']}/`,
+            },
+            {
+                desc: 'subdomain',
+                in: 'https://cdn.trezor.io/static/medium/images/max/1024/1*RPmW1VsUphMbk83oKWXpLw.png',
+                out: `http://cdn.${TOR_URLS['trezor.io']}/static/medium/images/max/1024/1*RPmW1VsUphMbk83oKWXpLw.png`,
+            },
+        ];
+
+        fixtures.forEach(f => {
+            it(f.desc, () => {
+                expect(getTorUrlIfAvailable(f.in)).toEqual(f.out);
+            });
+        });
+    });
+
+    describe('isTorDomain', () => {
+        const fixtures = [
+            {
+                desc: 'yes',
+                in: TOR_URLS['trezor.io'],
+                out: true,
+            },
+            {
+                desc: 'no',
+                in: 'google.com',
+                out: false,
+            },
+        ];
+
+        fixtures.forEach(f => {
+            it(f.desc, () => {
+                expect(isTorDomain(f.in)).toEqual(f.out);
+            });
+        });
+    });
+
+    describe('toTorUrl', () => {
+        const fixtures = [
+            {
+                desc: 'returns tor url',
+                in: 'https://trezor.io',
+                out: `http://${TOR_URLS['trezor.io']}/`,
+            },
+            {
+                desc: 'throws',
+                in: 'https://google.com',
+            },
+        ];
+
+        fixtures.forEach(f => {
+            it(f.desc, () => {
+                if (!f.out) {
+                    expect(() => toTorUrl(f.in)).toThrow();
+                } else {
+                    expect(toTorUrl(f.in)).toEqual(f.out);
+                }
+            });
+        });
+    });
+});

--- a/packages/suite/src/views/dashboard/components/NewsFeed/index.tsx
+++ b/packages/suite/src/views/dashboard/components/NewsFeed/index.tsx
@@ -89,7 +89,13 @@ interface Props {
 // For that reason, limit maximum posts shown to 9.
 const NewsFeed = ({ maxVisibleCount = 9 }: Props) => {
     const [visibleCount, incrementVisibleCount] = useState(3);
-    const isTor = useSelector(state => state.suite.tor);
+
+    // todo: this should be refactored using something like TrezorLink component which already contains the same logic.
+    const { isTor, torOnionLinks } = useSelector(state => ({
+        isTor: state.suite.tor,
+        torOnionLinks: state.suite.settings.torOnionLinks,
+    }));
+
     const { posts, isError, fetchCount, incrementFetchCount } = useFetchNews();
     const theme = useTheme();
 
@@ -102,7 +108,7 @@ const NewsFeed = ({ maxVisibleCount = 9 }: Props) => {
                 <MediumLink
                     target="_blank"
                     rel="noopener noreferrer"
-                    href={isTor ? toTorUrl(BLOG_URL) : BLOG_URL}
+                    href={isTor && torOnionLinks ? toTorUrl(BLOG_URL) : BLOG_URL}
                 >
                     <Button isWhite variant="tertiary" icon="MEDIUM">
                         <Translation id="TR_OPEN_IN_MEDIUM" />
@@ -116,7 +122,7 @@ const NewsFeed = ({ maxVisibleCount = 9 }: Props) => {
                         key={item.link}
                         target="_blank"
                         rel="noopener noreferrer"
-                        href={isTor ? toTorUrl(item.link) : item.link}
+                        href={isTor && torOnionLinks ? toTorUrl(item.link) : item.link}
                         data-test={`@dashboard/news/post/${index}`}
                     >
                         <Image src={isTor ? toTorUrl(item.thumbnail) : item.thumbnail} />

--- a/packages/suite/src/views/settings/index.tsx
+++ b/packages/suite/src/views/settings/index.tsx
@@ -282,27 +282,30 @@ const Settings = () => {
                             </SectionItem>
                         </>
                     )}
-                    <SectionItem>
-                        <TextColumn
-                            title={<Translation id="TR_ONION_LINKS_TITLE" />}
-                            description={<Translation id="TR_ONION_LINKS_DESCRIPTION" />}
-                        />
-                        <ActionColumn>
-                            <Switch
-                                data-test="@settings/general/onion-links-switch"
-                                checked={torOnionLinks}
-                                onChange={() => {
-                                    analytics.report({
-                                        type: 'menu/toggle-onion-links',
-                                        payload: {
-                                            value: !torOnionLinks,
-                                        },
-                                    });
-                                    setOnionLinks(!torOnionLinks);
-                                }}
+                    {/* keep torOnionLinks value as it is but hide this section when tor is off. when tor is off this value has no effect anyway (handled by ExternalLink hook) */}
+                    {tor && (
+                        <SectionItem>
+                            <TextColumn
+                                title={<Translation id="TR_ONION_LINKS_TITLE" />}
+                                description={<Translation id="TR_ONION_LINKS_DESCRIPTION" />}
                             />
-                        </ActionColumn>
-                    </SectionItem>
+                            <ActionColumn>
+                                <Switch
+                                    data-test="@settings/general/onion-links-switch"
+                                    checked={torOnionLinks}
+                                    onChange={() => {
+                                        analytics.report({
+                                            type: 'menu/toggle-onion-links',
+                                            payload: {
+                                                value: !torOnionLinks,
+                                            },
+                                        });
+                                        setOnionLinks(!torOnionLinks);
+                                    }}
+                                />
+                            </ActionColumn>
+                        </SectionItem>
+                    )}
                 </Section>
             )}
 

--- a/packages/suite/test/health/urls.test.ts
+++ b/packages/suite/test/health/urls.test.ts
@@ -8,8 +8,6 @@ const excluded = [
     URLS.TREZOR_DATA_URL,
     // TODO: it works locally but CI times out, probably cant handle the redirect or something..
     URLS.TOS_URL,
-    // Trezor onion domain is unreachable without Tor
-    URLS.TOR_DOMAIN,
 ];
 
 const getUrls = () => {


### PR DESCRIPTION
Hello, I am opening this PR to resolve #3793

cce61c6 implements suite.settings.torOnionLinks in dashboard news feed 
92794ea makes an attempt to refactor duplicated logic between NewsFeed and TrezorLink component by introducing useTorUrl hook. I have always hard time deciding if I actually like these hook-like solutions, so your input is welcome here definitely
b76f451 turning tor off should probably also turn suite.settings.torOnionLinks off. 