### PR TITLE
fix(custom-protocol): register custom protocol only when it is supported

### DIFF
--- a/packages/suite/src/support/suite/Protocol.tsx
+++ b/packages/suite/src/support/suite/Protocol.tsx
@@ -54,7 +54,7 @@ const Protocol = () => {
     }, [search, handleProtocolRequest]);
 
     useEffect(() => {
-        if (isWeb()) {
+        if (isWeb() && navigator.registerProtocolHandler) {
             navigator.registerProtocolHandler(
                 'bitcoin',
                 `${window.location.origin}${process.env.ASSET_PREFIX ?? ''}/?uri=%s`,


### PR DESCRIPTION
Custom protocol is not available on Android
https://caniuse.com/?search=Custom%20protocol%20handling 

