### PR TITLE
fix: e2e metadata tests new required key in oauth message

### DIFF
--- a/packages/integration-tests/projects/suite-web/stubs/metadata.ts
+++ b/packages/integration-tests/projects/suite-web/stubs/metadata.ts
@@ -5,7 +5,8 @@ export const stubOpen = (win: Window) => {
     // @ts-ignore
     win.Math.random = () => 0.4; // to make tests deterministic, this value ensures state YYYYYYYYYYYYYYYYYYYYYYYYYYYYYY
     // @ts-ignore
-    return () => win.postMessage({ search: '?code=chicken-cho-cha&state=YYYYYYYYYY' });
+    return () =>
+        win.postMessage({ search: '?code=chicken-cho-cha&state=YYYYYYYYYY', key: 'trezor-oauth' });
 };
 
 export const rerouteMetadataToMockProvider = (


### PR DESCRIPTION
we introduced bug in e2e tests here https://github.com/trezor/trezor-suite/pull/4359

mergin non-green pipelines is a sin. 