### PR TITLE
fix: losing labels when multiple devices are connected

### DIFF
--- a/packages/suite/src/actions/suite/metadataActions.ts
+++ b/packages/suite/src/actions/suite/metadataActions.ts
@@ -363,8 +363,11 @@ export const fetchMetadata =
 
 export const setAccountMetadataKey =
     (account: Account) => (dispatch: Dispatch, getState: GetState) => {
-        const { device } = getState().suite;
-        if (!device || device.metadata.status !== 'enabled') return account;
+        const { devices } = getState();
+        const device = devices.find(d => d.state === account.deviceState);
+        if (!device || device.metadata.status !== 'enabled') {
+            return account;
+        }
 
         try {
             const metaKey = metadataUtils.deriveMetadataKey(


### PR DESCRIPTION
fix #3364 

the problem was that when filling some metadata-related-metadata to accounts, they got computed from selected device. not from device that belongs to that account. 