### PR TITLE
chore(dependencies): upgrade typescript on latest version to get newest features

### DIFF
--- a/package.json
+++ b/package.json
@@ -83,6 +83,6 @@
         "ts-jest": "^26.5.4",
         "ts-node": "^9.1.1",
         "tsconfig-paths": "^3.9.0",
-        "typescript": "4.3.5"
+        "typescript": "4.4.4"
     }
 }

--- a/package.json
+++ b/package.json
@@ -81,7 +81,7 @@
         "prettier-eslint": "^13.0.0",
         "rimraf": "^3.0.2",
         "ts-jest": "^26.5.4",
-        "ts-node": "^9.1.1",
+        "ts-node": "^10.3.0",
         "tsconfig-paths": "^3.9.0",
         "typescript": "4.4.4"
     }

--- a/packages/blockchain-link/tsconfig.lib.json
+++ b/packages/blockchain-link/tsconfig.lib.json
@@ -9,7 +9,6 @@
         "declaration": true,
         "resolveJsonModule": true,
         "noImplicitAny": false,
-        "preserveSymlinks": true, // ts-node: "Unable to require `.d.ts` file." (https://github.com/TypeStrong/ts-node/issues/797)
         "removeComments": true,
         "types": ["jest", "node"],
         "esModuleInterop": true,

--- a/packages/blockchain-link/tsconfig.lib.json
+++ b/packages/blockchain-link/tsconfig.lib.json
@@ -12,7 +12,8 @@
         "preserveSymlinks": true, // ts-node: "Unable to require `.d.ts` file." (https://github.com/TypeStrong/ts-node/issues/797)
         "removeComments": true,
         "types": ["jest", "node"],
-        "esModuleInterop": true
+        "esModuleInterop": true,
+        "useUnknownInCatchVariables": false
     },
     "include": ["./src/index.ts", "./src/utils/ws.ts"],
     "exclude": ["node_modules"]

--- a/packages/rollout/tsconfig.lib.json
+++ b/packages/rollout/tsconfig.lib.json
@@ -9,7 +9,6 @@
         "declaration": true,
         "resolveJsonModule": true,
         "noImplicitAny": false,
-        "preserveSymlinks": true, // ts-node: "Unable to require `.d.ts` file." (https://github.com/TypeStrong/ts-node/issues/797)
         "removeComments": true,
         "types": ["jest", "node"],
         "esModuleInterop": true,

--- a/packages/suite-data/package.json
+++ b/packages/suite-data/package.json
@@ -30,7 +30,6 @@
         "json-schema-to-typescript": "^10.1.4",
         "jws": "^4.0.0",
         "simple-git": "^2.39.0",
-        "ts-node": "^8.10.2",
         "webpack": "^5.55.1",
         "webpack-cli": "4.8.0"
     }

--- a/packages/suite-data/tsconfig.json
+++ b/packages/suite-data/tsconfig.json
@@ -6,7 +6,6 @@
         "declaration": true,
         "resolveJsonModule": true,
         "noImplicitAny": false,
-        "preserveSymlinks": true, // ts-node: "Unable to require `.d.ts` file." (https://github.com/TypeStrong/ts-node/issues/797)
         "removeComments": true,
         "types": ["jest", "node"],
         "esModuleInterop": true

--- a/packages/suite-native/tsconfig.json
+++ b/packages/suite-native/tsconfig.json
@@ -269,7 +269,8 @@
         "noUnusedParameters": true,
         "sourceMap": true,
         "strict": true,
-        "resolveJsonModule": true
+        "resolveJsonModule": true,
+        "useUnknownInCatchVariables": false
     },
     "include": [
         "./src/App.tsx",

--- a/packages/suite-storage/tsconfig.json
+++ b/packages/suite-storage/tsconfig.json
@@ -1,5 +1,4 @@
 {
-    // "extends": "../../tsconfig.json",
     "compilerOptions": {
         "baseUrl": "./",
         "target": "es5",
@@ -16,7 +15,8 @@
         "noImplicitAny": true,
         "strictNullChecks": true,
         "jsx": "react",
-        "outDir": "./lib"
+        "outDir": "./lib",
+        "useUnknownInCatchVariables": false
     },
     "include": ["./src"],
     "exclude": ["node_modules", "**/__tests__/*"]

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -303,7 +303,8 @@
         "sourceMap": true,
         "strict": true,
         "target": "ES2020",
-        "noErrorTruncation": true
+        "noErrorTruncation": true,
+        "useUnknownInCatchVariables": false
     },
     "exclude": [
         "node_modules",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2722,6 +2722,18 @@
   dependencies:
     shelljs "^0.8.4"
 
+"@cspotcode/source-map-consumer@0.8.0":
+  version "0.8.0"
+  resolved "https://registry.yarnpkg.com/@cspotcode/source-map-consumer/-/source-map-consumer-0.8.0.tgz#33bf4b7b39c178821606f669bbc447a6a629786b"
+  integrity sha512-41qniHzTU8yAGbCp04ohlmSrZf8bkf/iJsl3V0dRGsQN/5GFfx+LbCSsCpp2gqrqjTVg/K6O8ycoV35JIwAzAg==
+
+"@cspotcode/source-map-support@0.7.0":
+  version "0.7.0"
+  resolved "https://registry.yarnpkg.com/@cspotcode/source-map-support/-/source-map-support-0.7.0.tgz#4789840aa859e46d2f3173727ab707c66bf344f5"
+  integrity sha512-X4xqRHqN8ACt2aHVe51OxeA2HjbcL4MqFqXkrmQszJ1NOUuUu5u6Vqx/0lZSVNku7velL5FC/s5uEAj1lsBMhA==
+  dependencies:
+    "@cspotcode/source-map-consumer" "0.8.0"
+
 "@cypress/request@^2.88.5":
   version "2.88.5"
   resolved "https://registry.yarnpkg.com/@cypress/request/-/request-2.88.5.tgz#8d7ecd17b53a849cfd5ab06d5abe7d84976375d7"
@@ -5656,6 +5668,26 @@
   optionalDependencies:
     secp256k1 "^3.5.2"
 
+"@tsconfig/node10@^1.0.7":
+  version "1.0.8"
+  resolved "https://registry.yarnpkg.com/@tsconfig/node10/-/node10-1.0.8.tgz#c1e4e80d6f964fbecb3359c43bd48b40f7cadad9"
+  integrity sha512-6XFfSQmMgq0CFLY1MslA/CPUfhIL919M1rMsa5lP2P097N2Wd1sSX0tx1u4olM16fLNhtHZpRhedZJphNJqmZg==
+
+"@tsconfig/node12@^1.0.7":
+  version "1.0.9"
+  resolved "https://registry.yarnpkg.com/@tsconfig/node12/-/node12-1.0.9.tgz#62c1f6dee2ebd9aead80dc3afa56810e58e1a04c"
+  integrity sha512-/yBMcem+fbvhSREH+s14YJi18sp7J9jpuhYByADT2rypfajMZZN4WQ6zBGgBKp53NKmqI36wFYDb3yaMPurITw==
+
+"@tsconfig/node14@^1.0.0":
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/@tsconfig/node14/-/node14-1.0.1.tgz#95f2d167ffb9b8d2068b0b235302fafd4df711f2"
+  integrity sha512-509r2+yARFfHHE7T6Puu2jjkoycftovhXRqW328PDXTVGKihlb1P8Z9mMZH04ebyajfRY7dedfGynlrFHJUQCg==
+
+"@tsconfig/node16@^1.0.2":
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/@tsconfig/node16/-/node16-1.0.2.tgz#423c77877d0569db20e1fc80885ac4118314010e"
+  integrity sha512-eZxlbI8GZscaGS7kkc/trHTT5xgrjH3/1n2JDwusC9iahPKWMRvRjJSAN5mCXviuTGQ/lHnhvv8Q1YTpnfz9gA==
+
 "@types/accepts@*":
   version "1.3.5"
   resolved "https://registry.yarnpkg.com/@types/accepts/-/accepts-1.3.5.tgz#c34bec115cfc746e04fe5a059df4ce7e7b391575"
@@ -7322,6 +7354,11 @@ acorn-walk@^8.0.0:
   version "8.0.1"
   resolved "https://registry.yarnpkg.com/acorn-walk/-/acorn-walk-8.0.1.tgz#d265d35db6940a656c715806a448456ee4fa3b7f"
   integrity sha512-zn/7dYtoTVkG4EoMU55QlQU4F+m+T7Kren6Vj3C2DapWPnakG/DL9Ns5aPAPW5Ixd3uxXrV/BoMKKVFIazPcdg==
+
+acorn-walk@^8.1.1:
+  version "8.2.0"
+  resolved "https://registry.yarnpkg.com/acorn-walk/-/acorn-walk-8.2.0.tgz#741210f2e2426454508853a2f44d0ab83b7f69c1"
+  integrity sha512-k+iyHEuPgSw6SbuDpGQM+06HQUa04DZ3o+F6CSzXMvvI5KMvnaEqXe+YVe555R9nn6GPt404fos4wcgpw12SDA==
 
 acorn@^6.4.1:
   version "6.4.2"
@@ -25269,7 +25306,7 @@ ts-node-dev@1.0.0-pre.44:
     ts-node "*"
     tsconfig "^7.0.0"
 
-ts-node@*, ts-node@^9.1.1:
+ts-node@*:
   version "9.1.1"
   resolved "https://registry.yarnpkg.com/ts-node/-/ts-node-9.1.1.tgz#51a9a450a3e959401bda5f004a72d54b936d376d"
   integrity sha512-hPlt7ZACERQGf03M253ytLY3dHbGNGrAq9qIHWUY9XHYl1z7wYngSr3OQ5xmui8o2AaxsONxIzjafLUiWBo1Fg==
@@ -25281,15 +25318,22 @@ ts-node@*, ts-node@^9.1.1:
     source-map-support "^0.5.17"
     yn "3.1.1"
 
-ts-node@^8.10.2:
-  version "8.10.2"
-  resolved "https://registry.yarnpkg.com/ts-node/-/ts-node-8.10.2.tgz#eee03764633b1234ddd37f8db9ec10b75ec7fb8d"
-  integrity sha512-ISJJGgkIpDdBhWVu3jufsWpK3Rzo7bdiIXJjQc0ynKxVOVcg2oIrf2H2cejminGrptVc6q6/uynAHNCuWGbpVA==
+ts-node@^10.3.0:
+  version "10.3.0"
+  resolved "https://registry.yarnpkg.com/ts-node/-/ts-node-10.3.0.tgz#a797f2ed3ff50c9a5d814ce400437cb0c1c048b4"
+  integrity sha512-RYIy3i8IgpFH45AX4fQHExrT8BxDeKTdC83QFJkNzkvt8uFB6QJ8XMyhynYiKMLxt9a7yuXaDBZNOYS3XjDcYw==
   dependencies:
+    "@cspotcode/source-map-support" "0.7.0"
+    "@tsconfig/node10" "^1.0.7"
+    "@tsconfig/node12" "^1.0.7"
+    "@tsconfig/node14" "^1.0.0"
+    "@tsconfig/node16" "^1.0.2"
+    acorn "^8.4.1"
+    acorn-walk "^8.1.1"
     arg "^4.1.0"
+    create-require "^1.1.0"
     diff "^4.0.1"
     make-error "^1.1.1"
-    source-map-support "^0.5.17"
     yn "3.1.1"
 
 ts-pnp@^1.1.6:

--- a/yarn.lock
+++ b/yarn.lock
@@ -25497,10 +25497,10 @@ typescript-template-language-service-decorator@^2.2.0:
   resolved "https://registry.yarnpkg.com/typescript-template-language-service-decorator/-/typescript-template-language-service-decorator-2.2.0.tgz#4ee6d580f307fb9239978e69626f2775b8a59b2a"
   integrity sha512-xiolqt1i7e22rpqMaprPgSFVgU64u3b9n6EJlAaUYE61jumipKAdI1+O5khPlWslpTUj80YzjUKjJ2jxT0D74w==
 
-typescript@4.3.5:
-  version "4.3.5"
-  resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.3.5.tgz#4d1c37cc16e893973c45a06886b7113234f119f4"
-  integrity sha512-DqQgihaQ9cUrskJo9kIyW/+g0Vxsk8cDtZ52a3NGh0YNTfpUSArXSohyUGnvbPazEPLu398C0UxmKSOrPumUzA==
+typescript@4.4.4:
+  version "4.4.4"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.4.4.tgz#2cd01a1a1f160704d3101fd5a58ff0f9fcb8030c"
+  integrity sha512-DqGhF5IKoBl8WNf8C1gu8q0xZSInh9j1kJJMqT3a94w1JzVaBU4EXOSMrz9yDqMT0xt3selp83fuFMQ0uzv6qA==
 
 typescript@^3.9.3:
   version "3.9.7"


### PR DESCRIPTION
- see https://www.typescriptlang.org/docs/handbook/release-notes/typescript-4-4.html
- [Defaulting to the `unknown` Type in Catch Variables](https://www.typescriptlang.org/docs/handbook/release-notes/typescript-4-4.html#defaulting-to-the-unknown-type-in-catch-variables---useunknownincatchvariables) turned off for now, we could turn it on later but we need to add `if (err instanceof Error)` in almost every catch clause