### PR TITLE
fix(suite): correctly detect Android, Linux and Chrome OS users

### DIFF
--- a/docs/misc/analytics.md
+++ b/docs/misc/analytics.md
@@ -116,6 +116,11 @@ Add event to the analytics overview in the [company Notion](https://www.notion.s
 
 ## Changelog
 
+### 1.14
+Fixed:
+- suite-ready
+  - osName: android is now correctly detected, added chromeos
+
 ### 1.13
 Added:
 - switch-device/add-hidden-wallet

--- a/packages/suite/src/actions/suite/analyticsActions.ts
+++ b/packages/suite/src/actions/suite/analyticsActions.ts
@@ -29,7 +29,7 @@ export type AnalyticsAction =
 
 // Don't forget to update docs with changelog!
 // <breaking-change>.<analytics-extended>
-export const version = '1.13';
+export const version = '1.14';
 
 export type AnalyticsEvent =
     | {

--- a/packages/suite/src/utils/suite/__fixtures__/env.ts
+++ b/packages/suite/src/utils/suite/__fixtures__/env.ts
@@ -1,0 +1,263 @@
+export const isMacOs = [
+    {
+        description: 'should be MacOs according to process.platform',
+        processPlatform: 'darwin',
+        navigatorPlatform: '',
+        result: true,
+    },
+    {
+        description: 'should not be MacOs according to process.platform',
+        processPlatform: 'win32',
+        navigatorPlatform: '',
+        result: false,
+    },
+    {
+        description: 'should be MacOs according to window.navigator.platform',
+        processPlatform: '',
+        navigatorPlatform: 'MacIntel',
+        result: true,
+    },
+    {
+        description: 'should not be MacOs according to window.navigator.platform',
+        processPlatform: '',
+        navigatorPlatform: 'Win32',
+        result: false,
+    },
+];
+
+export const isWindows = [
+    {
+        description: 'should be Windows according to process.platform',
+        processPlatform: 'win32',
+        navigatorPlatform: '',
+        result: true,
+    },
+    {
+        description: 'should not be Windows according to process.platform',
+        processPlatform: 'darwin',
+        navigatorPlatform: '',
+        result: false,
+    },
+    {
+        description: 'should be Windows according to window.navigator.platform',
+        processPlatform: '',
+        navigatorPlatform: 'Win32',
+        result: true,
+    },
+    {
+        description: 'should not be Windows according to window.navigator.platform',
+        processPlatform: '',
+        navigatorPlatform: 'MacIntel',
+        result: false,
+    },
+];
+
+export const isLinux = [
+    {
+        description: 'should be Linux according to process.platform, userAgent should be ignored',
+        processPlatform: 'linux',
+        userAgent:
+            'Mozilla/5.0 (Linux; Android 11; SM-A102U) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/89.0.4389.72 Mobile Safari/537.36',
+        navigatorPlatform: '',
+        result: true,
+    },
+    {
+        description:
+            'should not be Linux according to process.platform, userAgent should be ignored',
+        processPlatform: 'darwin',
+        userAgent: 'Mozilla/5.0 (X11; Ubuntu; Linux i686; rv:24.0) Gecko/20100101 Firefox/24.0',
+        navigatorPlatform: '',
+        result: false,
+    },
+    {
+        description:
+            'should be Linux according to window.navigator.platform, userAgent should be ignored',
+        processPlatform: '',
+        userAgent:
+            'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_9_5) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/67.0.3396.87 Safari/537.366',
+        navigatorPlatform: 'Linux armv7l',
+        result: true,
+    },
+    {
+        description:
+            'should not be Linux according to window.navigator.platform, userAgent should be ignored',
+        processPlatform: '',
+        userAgent: 'Mozilla/5.0 (X11; Ubuntu; Linux i686; rv:24.0) Gecko/20100101 Firefox/24.0',
+        navigatorPlatform: 'Win32',
+        result: false,
+    },
+    {
+        description: 'should not be Linux as it should be Android according to userAgent',
+        processPlatform: '',
+        userAgent:
+            'Mozilla/5.0 (Linux; Android 11; SM-A102U) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/89.0.4389.72 Mobile Safari/537.36',
+        navigatorPlatform: 'Linux armv7l',
+        result: false,
+    },
+    {
+        description: 'should not be Linux as it should be Chrome OS according to userAgent',
+        processPlatform: '',
+        userAgent:
+            'Mozilla/5.0 (X11; CrOS x86_64 14150.57.0) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/94.0.4606.97 Safari/537.36',
+        navigatorPlatform: 'Linux armv7l',
+        result: false,
+    },
+];
+
+export const isIOs = [
+    {
+        description: 'should be iOS on iPhone device',
+        navigatorPlatform: 'iPhone',
+        result: true,
+    },
+    {
+        description: 'should be iOS on iPod device',
+        navigatorPlatform: 'iPod',
+        result: true,
+    },
+    {
+        description: 'should be iOS on iPad device',
+        navigatorPlatform: 'iPad',
+        result: true,
+    },
+    {
+        description: 'should not be iOS on Android device',
+        navigatorPlatform: 'Android',
+        result: false,
+    },
+];
+
+export const isAndroid = [
+    {
+        description: 'should be Android on Samsung device',
+        userAgent:
+            'Mozilla/5.0 (Linux; Android 11; SM-A102U) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/89.0.4389.72 Mobile Safari/537.36',
+        result: true,
+    },
+    {
+        description: 'should be Android on Nexus One device',
+        userAgent:
+            'Mozilla/5.0 (Linux; U; Android 2.2.1; en-us; Nexus One Build/FRG83) AppleWebKit/533.1 (KHTML, like Gecko) Version/4.0 Mobile Safari/533.1',
+        result: true,
+    },
+    {
+        description: 'should be Android on Lenovo device',
+        userAgent:
+            'Mozilla/5.0 (Linux; Android 5.1.1; Lenovo-A6020l36 Build/LMY47V) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/43.0.2357.93 Mobile Safari/537.36',
+        result: true,
+    },
+    {
+        description: 'should not be Android on iPad device',
+        userAgent:
+            'Mozilla/5.0 (iPad; CPU OS 12_2 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Mobile/15E148',
+        result: false,
+    },
+];
+
+export const isChromeOS = [
+    {
+        description: 'should be ChromeOS',
+        userAgent:
+            'Mozilla/5.0 (X11; CrOS x86_64 14150.57.0) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/94.0.4606.97 Safari/537.36',
+        result: true,
+    },
+    {
+        description: 'should not be ChromeOS',
+        userAgent:
+            'Mozilla/5.0 (Linux; U; Android 2.2.1; en-us; Nexus One Build/FRG83) AppleWebKit/533.1 (KHTML, like Gecko) Version/4.0 Mobile Safari/533.1',
+        result: false,
+    },
+];
+
+export const getOsName = [
+    {
+        description: 'should be Windows 1',
+        processPlatform: 'win32',
+        navigatorPlatform: '',
+        userAgent: '',
+        result: 'windows',
+    },
+    {
+        description: 'should be Windows 2',
+        processPlatform: '',
+        navigatorPlatform: 'Win32',
+        userAgent: '',
+        result: 'windows',
+    },
+    {
+        description: 'should be macOS 1',
+        processPlatform: 'darwin',
+        navigatorPlatform: '',
+        userAgent: '',
+        result: 'macos',
+    },
+    {
+        description: 'should be macOS 2',
+        processPlatform: '',
+        navigatorPlatform: 'MacIntel',
+        userAgent: '',
+        result: 'macos',
+    },
+    {
+        description: 'should be Android 1',
+        processPlatform: '',
+        navigatorPlatform: 'Linux',
+        userAgent:
+            'Mozilla/5.0 (Linux; Android 11; SM-A102U) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/89.0.4389.72 Mobile Safari/537.36',
+        result: 'android',
+    },
+    {
+        description: 'should be Android 2',
+        processPlatform: '',
+        navigatorPlatform: 'Linux',
+        userAgent:
+            'Mozilla/5.0 (Linux; U; Android 2.2.1; en-us; Nexus One Build/FRG83) AppleWebKit/533.1 (KHTML, like Gecko) Version/4.0 Mobile Safari/533.1',
+        result: 'android',
+    },
+    {
+        description: 'should be Android 3',
+        processPlatform: '',
+        navigatorPlatform: 'Android',
+        userAgent:
+            'Mozilla/5.0 (Linux; Android 5.1.1; Lenovo-A6020l36 Build/LMY47V) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/43.0.2357.93 Mobile Safari/537.36',
+        result: 'android',
+    },
+    {
+        description: 'should be ChromeOS 1',
+        processPlatform: '',
+        navigatorPlatform: 'Linux',
+        userAgent:
+            'Mozilla/5.0 (X11; CrOS x86_64 14150.57.0) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/94.0.4606.97 Safari/537.36',
+        result: 'chromeos',
+    },
+    {
+        description: 'should be Linux 1',
+        processPlatform: 'linux',
+        navigatorPlatform: '',
+        userAgent: '',
+        result: 'linux',
+    },
+    {
+        description: 'should be Linux 2',
+        processPlatform: '',
+        navigatorPlatform: 'Linux',
+        userAgent: '',
+        result: 'linux',
+    },
+    {
+        description: 'should be Linux 3',
+        processPlatform: '',
+        navigatorPlatform: 'Linux',
+        userAgent:
+            'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_9_5) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/67.0.3396.87 Safari/537.36',
+        result: 'linux',
+    },
+    {
+        description: 'should be iOS 1',
+        processPlatform: '',
+        navigatorPlatform: 'iPhone',
+        userAgent:
+            'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_9_5) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/67.0.3396.87 Safari/537.36',
+        result: 'ios',
+    },
+];

--- a/packages/suite/src/utils/suite/__tests__/env.test.ts
+++ b/packages/suite/src/utils/suite/__tests__/env.test.ts
@@ -1,0 +1,160 @@
+import * as env from '@suite-utils/env';
+import * as fixtures from '../__fixtures__/env';
+
+describe('isMacOs', () => {
+    let navigatorPlatformGetter: any;
+
+    beforeEach(() => {
+        navigatorPlatformGetter = jest.spyOn(window.navigator, 'platform', 'get');
+    });
+
+    afterEach(() => {
+        jest.resetModules();
+    });
+
+    fixtures.isMacOs.forEach(f => {
+        it(f.description, () => {
+            // @ts-ignore
+            jest.spyOn(env, 'getProcessPlatform').mockImplementation(() => f.processPlatform);
+
+            navigatorPlatformGetter.mockReturnValue(f.navigatorPlatform);
+
+            expect(env.isMacOs()).toEqual(f.result);
+        });
+    });
+});
+
+describe('isWindows', () => {
+    let navigatorPlatformGetter: any;
+
+    beforeEach(() => {
+        navigatorPlatformGetter = jest.spyOn(window.navigator, 'platform', 'get');
+    });
+
+    afterEach(() => {
+        jest.resetModules();
+    });
+
+    fixtures.isWindows.forEach(f => {
+        it(f.description, () => {
+            // @ts-ignore
+            jest.spyOn(env, 'getProcessPlatform').mockImplementation(() => f.processPlatform);
+
+            navigatorPlatformGetter.mockReturnValue(f.navigatorPlatform);
+
+            expect(env.isWindows()).toEqual(f.result);
+        });
+    });
+});
+
+describe('isLinux', () => {
+    let navigatorPlatformGetter: any;
+    let userAgentGetter: any;
+
+    beforeEach(() => {
+        navigatorPlatformGetter = jest.spyOn(window.navigator, 'platform', 'get');
+        userAgentGetter = jest.spyOn(window.navigator, 'userAgent', 'get');
+    });
+
+    afterEach(() => {
+        jest.resetModules();
+    });
+
+    fixtures.isLinux.forEach(f => {
+        it(f.description, () => {
+            // @ts-ignore
+            jest.spyOn(env, 'getProcessPlatform').mockImplementation(() => f.processPlatform);
+
+            userAgentGetter.mockReturnValue(f.userAgent);
+            navigatorPlatformGetter.mockReturnValue(f.navigatorPlatform);
+
+            expect(env.isLinux()).toEqual(f.result);
+        });
+    });
+});
+
+describe('isIOs', () => {
+    let navigatorPlatformGetter: any;
+
+    beforeEach(() => {
+        navigatorPlatformGetter = jest.spyOn(window.navigator, 'platform', 'get');
+    });
+
+    afterEach(() => {
+        jest.resetModules();
+    });
+
+    fixtures.isIOs.forEach(f => {
+        it(f.description, () => {
+            navigatorPlatformGetter.mockReturnValue(f.navigatorPlatform);
+
+            expect(env.isIOs()).toEqual(f.result);
+        });
+    });
+});
+
+describe('isAndroid', () => {
+    let userAgentGetter: any;
+
+    beforeEach(() => {
+        userAgentGetter = jest.spyOn(window.navigator, 'userAgent', 'get');
+    });
+
+    afterEach(() => {
+        jest.resetModules();
+    });
+
+    fixtures.isAndroid.forEach(f => {
+        it(f.description, () => {
+            userAgentGetter.mockReturnValue(f.userAgent);
+
+            expect(env.isAndroid()).toEqual(f.result);
+        });
+    });
+});
+
+describe('isChromeOS', () => {
+    let userAgentGetter: any;
+
+    beforeEach(() => {
+        userAgentGetter = jest.spyOn(window.navigator, 'userAgent', 'get');
+    });
+
+    afterEach(() => {
+        jest.resetModules();
+    });
+
+    fixtures.isChromeOS.forEach(f => {
+        it(f.description, () => {
+            userAgentGetter.mockReturnValue(f.userAgent);
+
+            expect(env.isChromeOs()).toEqual(f.result);
+        });
+    });
+});
+
+describe('getOsName', () => {
+    let navigatorPlatformGetter: any;
+    let userAgentGetter: any;
+
+    beforeEach(() => {
+        navigatorPlatformGetter = jest.spyOn(window.navigator, 'platform', 'get');
+        userAgentGetter = jest.spyOn(window.navigator, 'userAgent', 'get');
+    });
+
+    afterEach(() => {
+        jest.resetModules();
+    });
+
+    fixtures.getOsName.forEach(f => {
+        it(f.description, () => {
+            // @ts-ignore
+            jest.spyOn(env, 'getProcessPlatform').mockImplementation(() => f.processPlatform);
+
+            userAgentGetter.mockReturnValue(f.userAgent);
+            navigatorPlatformGetter.mockReturnValue(f.navigatorPlatform);
+
+            expect(env.getOsName()).toEqual(f.result);
+        });
+    });
+});

--- a/packages/suite/src/utils/suite/env.ts
+++ b/packages/suite/src/utils/suite/env.ts
@@ -5,13 +5,12 @@ import type { SuiteThemeVariant, EnvironmentType } from '@suite-types';
 /* This way, we can override simple utils, which helps to polyfill methods which are not available in react-native. */
 export const getUserAgent = () => window.navigator.userAgent;
 
+// List of platforms https://docker.apachezone.com/blog/74
 export const getPlatform = () => window.navigator.platform;
 
 export const getPlatformLanguage = () => window.navigator.language;
 
 export const getPlatformLanguages = () => window.navigator.languages;
-
-export const getAppVersion = () => window.navigator.appVersion;
 
 export const getScreenWidth = () => window.screen.width;
 
@@ -25,7 +24,7 @@ export const getLocationOrigin = () => window.location.origin;
 
 export const getLocationHostname = () => window.location.hostname;
 
-/* For usage in Electron (SSR) */
+/* For usage in Electron */
 export const getProcessPlatform = () => process.platform;
 
 let userAgentParser: UAParser;
@@ -41,32 +40,38 @@ export const isMacOs = () => {
     if (getProcessPlatform() === 'darwin') return true;
     if (typeof window === 'undefined') return;
 
-    return ['Macintosh', 'MacIntel', 'MacPPC', 'Mac68K'].includes(getPlatform());
+    return getPlatform().startsWith('Mac');
 };
 
 export const isWindows = () => {
     if (getProcessPlatform() === 'win32') return true;
     if (typeof window === 'undefined') return;
 
-    return ['Win32', 'Win64', 'Windows', 'WinCE'].includes(getPlatform());
+    return getPlatform().startsWith('Win');
 };
+
+export const isIOs = () => ['iPhone', 'iPad', 'iPod'].includes(getPlatform());
+
+export const isAndroid = () => /Android/.test(getUserAgent());
+
+export const isChromeOs = () => /CrOS/.test(getUserAgent());
 
 export const isLinux = () => {
     if (getProcessPlatform() === 'linux') return true;
     if (typeof window === 'undefined') return;
 
-    return /Linux/.test(getPlatform());
+    // exclude Android and Chrome OS as window.navigator.platform of those OS is Linux
+    if (isAndroid() || isChromeOs()) return false;
+
+    return getPlatform().startsWith('Linux');
 };
 
-export const isAndroid = () => getAppVersion().includes('Android');
-
-export const isIOs = () => ['iPhone', 'iPad', 'iPod'].includes(getPlatform());
-
 export const getOsName = () => {
-    if (isMacOs()) return 'macos';
-    if (isLinux()) return 'linux';
     if (isWindows()) return 'windows';
+    if (isMacOs()) return 'macos';
     if (isAndroid()) return 'android';
+    if (isChromeOs()) return 'chromeos';
+    if (isLinux()) return 'linux';
     if (isIOs()) return 'ios';
 
     return '';


### PR DESCRIPTION
Closes #4380

`Android` was never detected correctly. It was detected as `Linux` because we checked `Linux` first and `navigator.platform` on `Android` is `Linux` https://stackoverflow.com/a/23736334

Moreover, a lot of people uses `Chrome OS` so we will start tracking it into analytics correctly. Now it is also tracked as `Linux`. 
