### PR TITLE
Fix/3153 Labelling - Cursor dismissed when clicking account title during editing label

### DIFF
--- a/packages/suite/src/components/suite/Labeling/components/Metadata/index.tsx
+++ b/packages/suite/src/components/suite/Labeling/components/Metadata/index.tsx
@@ -35,6 +35,7 @@ const Label = styled.div`
     display: flex;
     overflow: hidden;
     padding-left: 1px;
+    position: relative;
 `;
 
 const LabelButton = styled(Button)`
@@ -83,8 +84,16 @@ const LabelContainer = styled.div`
     }
 `;
 
+const RelativeButton = styled(Button)`
+    position: relative;
+`;
+
+const RelativeLabel = styled(Label)`
+    position: relative;
+`;
+
 const ButtonLikeLabel = (props: ExtendedProps) => {
-    const EditableButton = useMemo(() => withEditable(Button), []);
+    const EditableButton = useMemo(() => withEditable(RelativeButton), []);
 
     if (props.editActive) {
         return (
@@ -97,6 +106,7 @@ const ButtonLikeLabel = (props: ExtendedProps) => {
                 onSubmit={props.onSubmit}
                 onBlur={props.onBlur}
                 defaultVisibleValue={props.defaultVisibleValue}
+                isButton
             />
         );
     }
@@ -118,7 +128,7 @@ const ButtonLikeLabel = (props: ExtendedProps) => {
 };
 
 const TextLikeLabel = (props: ExtendedProps) => {
-    const EditableLabel = useMemo(() => withEditable(Label), []);
+    const EditableLabel = useMemo(() => withEditable(RelativeLabel), []);
 
     if (props.editActive) {
         return (
@@ -309,7 +319,10 @@ const MetadataLabeling = (props: Props) => {
         showActionButton && (!props.payload.value || (props.payload.value && pending));
 
     return (
-        <LabelContainer data-test={labelContainerDatatest}>
+        <LabelContainer
+            data-test={labelContainerDatatest}
+            onClick={e => editActive && e.stopPropagation()}
+        >
             {props.payload.type === 'outputLabel' ? (
                 <>
                     <ButtonLikeLabelWithDropdown

--- a/packages/suite/src/components/suite/Labeling/components/Metadata/withEditable.tsx
+++ b/packages/suite/src/components/suite/Labeling/components/Metadata/withEditable.tsx
@@ -1,5 +1,5 @@
 import React, { useEffect, useState, useCallback, useRef } from 'react';
-import styled from 'styled-components';
+import styled, { css } from 'styled-components';
 import { Icon, useTheme } from '@trezor/components';
 
 import { moveCaretToEndOfContentEditable } from '@suite-utils/dom';
@@ -23,9 +23,26 @@ const Placeholder = styled.div`
     color: ${props => props.theme.TYPE_LIGHT_GREY};
 `;
 
-const Editable = styled.div<{ touched: boolean }>`
+const Editable = styled.div<{ value?: string; isButton?: boolean; touched: boolean }>`
     padding-left: 1px;
     margin-right: 1px;
+    text-align: left;
+    cursor: text;
+
+    ${props =>
+        props.value &&
+        css`
+            position: unset;
+        `}
+
+    ${props =>
+        !props.value &&
+        css`
+           left: ${props.isButton ? '22px;' : '0px;'}
+           right: 0;
+           position: absolute;
+         `}
+
     color: ${props => (!props.touched ? props.theme.TYPE_LIGHT_GREY : 'inherit')};
 `;
 
@@ -34,6 +51,7 @@ interface Props {
     defaultVisibleValue: React.ReactNode;
     onSubmit: (value: string | undefined | null) => void;
     onBlur: () => void;
+    isButton?: boolean;
 }
 
 /**
@@ -130,9 +148,12 @@ export const withEditable =
                                 setValue('');
                             }
                         }}
+                        onPaste={e => setValue(e.clipboardData.getData('text/plain'))}
                         ref={divRef}
                         data-test="@metadata/input"
                         touched={touched}
+                        value={value}
+                        isButton={props.isButton}
                     />
                     {/* show default placeholder */}
                     {!value && <Placeholder>{props.defaultVisibleValue}</Placeholder>}


### PR DESCRIPTION
fix caret and its position:
labeling wallet :white_check_mark:  
labeling account :white_check_mark: 
labeling transaction :white_check_mark: 

fix #3153