### PR TITLE
fix: single account error

### DIFF
--- a/packages/suite/src/actions/wallet/selectedAccountActions.ts
+++ b/packages/suite/src/actions/wallet/selectedAccountActions.ts
@@ -126,7 +126,12 @@ const getAccountState = () => (dispatch: Dispatch, getState: GetState) => {
         };
     }
 
-    const failed = discovery.failed.find(f => f.symbol === network.symbol);
+    const failed = discovery.failed.find(
+        f =>
+            f.symbol === network.symbol &&
+            f.index === params.accountIndex &&
+            f.accountType === params.accountType,
+    );
     // discovery for requested network failed
     if (failed) {
         return {


### PR DESCRIPTION
hello 
I found behavior that felt somewhat weird to me. Don't know, might well be inteded.

User might have let's say 10 accounts and if single one of them not loaded correctly, we get exception screen for every account. 

before: https://files.fm/u/phmtpb3xc#/view/pgb8zgy4q
after: https://files.fm/u/phmtpb3xc#/view/3253uhqss

How to test:
- run with local trezor-connect where you modify GetAccountInfo method to throw error only for certain descriptor. 