### PR TITLE
feat(landing-page): detect mac-arm64 via webgl

### DIFF
--- a/packages/suite-web-landing/utils/navigator.ts
+++ b/packages/suite-web-landing/utils/navigator.ts
@@ -4,8 +4,18 @@ export const getPlatform = (navigator: Navigator): Platform => {
     const macPlatforms = ['Macintosh', 'MacIntel', 'MacPPC', 'Mac68K'];
     const windowsPlatforms = ['Win32', 'Win64', 'Windows', 'WinCE'];
     if (macPlatforms.includes(navigator.platform)) {
-        // navigator.platform returns "MacIntel" on Apple Silicon too
-        // so let's always return "mac-x64" for now
+        // https://stackoverflow.com/questions/65146751/detecting-apple-silicon-mac-in-javascript
+        const w = document.createElement('canvas').getContext('webgl');
+        if (w) {
+            const d = w.getExtension('WEBGL_debug_renderer_info');
+            const g = (d && w.getParameter(d.UNMASKED_RENDERER_WEBGL)) || '';
+            if (g.match(/Apple/) && !g.match(/Apple GPU/)) {
+                // "Apple GPU" is returned on both platforms.
+                // If it's something else starting with "Apple" (e.g. "Apple M1")
+                // we can be sure it is Apple Silicon.
+                return 'mac-arm64';
+            }
+        }
         return 'mac-x64';
     }
     if (windowsPlatforms.includes(navigator.platform)) {


### PR DESCRIPTION
I added trick described in https://stackoverflow.com/questions/65146751/detecting-apple-silicon-mac-in-javascript to detect mac-arm64 on the landing page.

I was not able to build and test the landing page, so definitively test on real hardware before merging this in!