### PR TITLE
Fix/react native date fns locales

### DIFF
--- a/packages/suite-native/babel.config.js
+++ b/packages/suite-native/babel.config.js
@@ -14,9 +14,11 @@ module.exports = api => {
                         // web and desktop use next.js router
                         '@suite-actions/routerActions':
                             './packages/suite-native/src/actions/suite/routerActions',
-                        // unlike on web, messages are bundled with application and might be simply required
+                        // unlike on web, messages and locales are bundled with application and might be simply required
                         '@suite-actions/languageActions':
                             './packages/suite-native/src/actions/suite/languageActions',
+                        '@suite-hooks/useLocales':
+                            './packages/suite-native/src/hooks/suite/useLocales',
 
                         // react-native env utils
                         '^@suite-utils/env': './packages/suite-native/src/utils/suite/env',

--- a/packages/suite-native/src/hooks/suite/useLocales.ts
+++ b/packages/suite-native/src/hooks/suite/useLocales.ts
@@ -1,0 +1,36 @@
+/* eslint-disable global-require */
+import { useMemo } from 'react';
+
+import type { Locale } from 'date-fns';
+
+import { useSelector } from '@suite-hooks';
+
+export const useLocales = () => {
+    const { language } = useSelector(state => ({
+        language: state.suite.settings.language,
+    }));
+
+    const locale = useMemo(() => {
+        const lang = language === 'en' ? 'en-US' : language;
+        const locales: { [key: string]: Locale } = {
+            'en-US': require('date-fns/locale/en-US/index'),
+            // cs: require('date-fns/locale/cs/index'),
+            // es: require('date-fns/locale/es/index'),
+            // de: require('date-fns/locale/de/index'),
+            // fr: require('date-fns/locale/fr/index'),
+            // ru: require('@date-fns/locale/ru/index'),
+        };
+
+        let dateLocale = locales[lang];
+
+        if (!dateLocale) {
+            dateLocale = locales['en-US'];
+
+            console.warn(`date-fns language: ${language} is not available. Using en-US fallback.`);
+        }
+
+        return dateLocale;
+    }, [language]);
+
+    return locale;
+};

--- a/packages/suite-native/tsconfig.json
+++ b/packages/suite-native/tsconfig.json
@@ -275,7 +275,9 @@
     "include": [
         "./src/App.tsx",
         "./index.d.ts",
-        "./src/utils/suite/oauth.ts" // todo: remove when used somewhere, otherwise eslint complaints
+        // TODO: remove paths below if used somewhere, otherwise eslint complaints
+        "./src/utils/suite/oauth.ts", 
+        "./src/hooks/suite/useLocales.ts"
     ],
     "exclude": ["node_modules", "babel.config.js", "metro.config.js", "jest.config.js"]
 }

--- a/packages/suite/src/hooks/suite/index.ts
+++ b/packages/suite/src/hooks/suite/index.ts
@@ -14,5 +14,7 @@ export { useThemeContext } from './useThemeContext';
 export { useOnboarding } from './useOnboarding';
 export { useRecovery } from './useRecovery';
 export { useGuide } from './useGuide';
-export { useLocales } from './useLocales';
 export { useExternalLink } from './useExternalLink';
+
+// replaced in suite-native
+export { useLocales } from '@suite-hooks/useLocales';

--- a/packages/suite/src/hooks/suite/useLocales.ts
+++ b/packages/suite/src/hooks/suite/useLocales.ts
@@ -16,11 +16,11 @@ export const useLocales = () => {
 
             let dateLocale;
             try {
-                dateLocale = await import(`date-fns/locale/${lang}/index.js`);
+                dateLocale = await import(`date-fns/locale/${lang}/index`);
             } catch (error) {
-                dateLocale = await import(`date-fns/locale/en-US/index.js`);
+                dateLocale = await import(`date-fns/locale/en-US/index`);
 
-                console.error(
+                console.warn(
                     `date-fns language: ${language} is not available. Using en-US fallback.`,
                 );
             }


### PR DESCRIPTION
This is the only solution I found that was working for me.

`react-native` does not allow dynamic import. `languageActions.ts` is a good existing example.

_error packages/suite/src/hooks/suite/useLocales.ts: packages/suite/src/hooks/suite/useLocales.ts:Invalid call at line 19: import("date-fns/locale/" + lang + "/index")_