### PR TITLE
feat: guide links between articles

### DIFF
--- a/packages/suite/src/hooks/suite/useGuide.ts
+++ b/packages/suite/src/hooks/suite/useGuide.ts
@@ -10,8 +10,9 @@ export const useGuide = () => {
         openNode: guideActions.openNode,
     });
 
-    const { indexNode } = useSelector(state => ({
+    const { indexNode, open } = useSelector(state => ({
         indexNode: state.guide.indexNode,
+        open: state.guide.open,
     }));
 
     const openNodeById = (id: string) => {
@@ -24,8 +25,12 @@ export const useGuide = () => {
             console.error(`Guide node with id: ${id} was not found.`);
             return;
         }
+
         openNode(node);
-        openGuide();
+
+        if (!open) {
+            openGuide();
+        }
 
         analytics.report({
             type: 'guide/tooltip-link/navigation',

--- a/packages/suite/src/views/guide/GuideMarkdown.tsx
+++ b/packages/suite/src/views/guide/GuideMarkdown.tsx
@@ -1,0 +1,100 @@
+import React, { useEffect } from 'react';
+import { variables } from '@trezor/components';
+import { TrezorLink } from '@suite-components';
+import ReactMarkdown from 'react-markdown';
+import styled, { keyframes } from 'styled-components';
+import { useGuide } from '@suite-hooks';
+
+const DISPLAY_SLOWLY = keyframes`
+    from { opacity: 0.0; }
+    to { opacity: 1.0; }
+`;
+
+const StyledMarkdown = styled.div`
+    animation: ${DISPLAY_SLOWLY} 0.5s ease;
+    color: ${props => props.theme.TYPE_LIGHT_GREY};
+    font-size: ${variables.FONT_SIZE.SMALL};
+    font-weight: ${variables.FONT_WEIGHT.MEDIUM};
+    line-height: 1.5;
+    padding: 0 0 32px 0;
+    h1,
+    h2,
+    h3,
+    h4,
+    h5,
+    h6 {
+        color: ${props => props.theme.TYPE_DARK_GREY};
+        font-weight: ${variables.FONT_WEIGHT.DEMI_BOLD};
+    }
+    h1 {
+        margin: 8px 0 16px;
+        font-size: ${variables.FONT_SIZE.BIG};
+    }
+    h2 {
+        margin-bottom: 8px 0 12px;
+        font-size: ${variables.FONT_SIZE.NORMAL};
+    }
+    h3,
+    h4,
+    h5,
+    h6 {
+        margin: 4px 0 12px;
+        font-size: ${variables.FONT_SIZE.SMALL};
+    }
+    p,
+    ul,
+    ol {
+        margin: 4px 0 12px;
+    }
+    ul,
+    ol {
+        padding: 0 0 0 16px;
+    }
+    li {
+        margin: 0 0 8px;
+    }
+    a {
+        color: ${props => props.theme.TYPE_GREEN};
+        &:hover {
+            text-decoration: underline;
+        }
+    }
+`;
+
+const StyledInnerLink = styled.a``;
+
+interface Props {
+    markdown: any;
+}
+
+const GuideMarkdown = ({ markdown }: Props) => {
+    const { openNodeById } = useGuide();
+    const ref = React.createRef<HTMLDivElement>();
+    useEffect(() => {
+        if (ref.current) {
+            ref.current.parentElement?.parentElement?.scrollTo(0, 0); // scroll wrapper to top on new content
+        }
+    }, [markdown, ref]);
+
+    return (
+        <StyledMarkdown ref={ref}>
+            <ReactMarkdown
+                renderers={{
+                    link: ({ children, href }) =>
+                        href.startsWith('http') ? (
+                            <TrezorLink variant="default" href={href}>
+                                {children}
+                            </TrezorLink>
+                        ) : (
+                            <StyledInnerLink role="link" onClick={() => openNodeById(href)}>
+                                {children}
+                            </StyledInnerLink>
+                        ),
+                }}
+            >
+                {markdown}
+            </ReactMarkdown>
+        </StyledMarkdown>
+    );
+};
+export default GuideMarkdown;

--- a/packages/suite/src/views/guide/GuidePage.tsx
+++ b/packages/suite/src/views/guide/GuidePage.tsx
@@ -1,67 +1,8 @@
 import React, { useEffect, useState } from 'react';
-import ReactMarkdown from 'react-markdown';
-import styled, { keyframes } from 'styled-components';
-
 import { useSelector } from '@suite-hooks';
-import { variables } from '@trezor/components';
 import { Header, Content, ViewWrapper } from '@guide-components';
+import { GuideMarkdown } from '@guide-views';
 import { Translation } from '@suite-components';
-
-const DISPLAY_SLOWLY = keyframes`
-    from { opacity: 0.0; }
-    to { opacity: 1.0; }
-`;
-
-const StyledMarkdown = styled.div`
-    animation: ${DISPLAY_SLOWLY} 0.5s ease;
-    color: ${props => props.theme.TYPE_LIGHT_GREY};
-    font-size: ${variables.FONT_SIZE.SMALL};
-    font-weight: ${variables.FONT_WEIGHT.MEDIUM};
-    line-height: 1.5;
-    padding: 0 0 32px 0;
-    h1,
-    h2,
-    h3,
-    h4,
-    h5,
-    h6 {
-        color: ${props => props.theme.TYPE_DARK_GREY};
-        font-weight: ${variables.FONT_WEIGHT.DEMI_BOLD};
-    }
-    h1 {
-        margin: 8px 0 16px;
-        font-size: ${variables.FONT_SIZE.BIG};
-    }
-    h2 {
-        margin-bottom: 8px 0 12px;
-        font-size: ${variables.FONT_SIZE.NORMAL};
-    }
-    h3,
-    h4,
-    h5,
-    h6 {
-        margin: 4px 0 12px;
-        font-size: ${variables.FONT_SIZE.SMALL};
-    }
-    p,
-    ul,
-    ol {
-        margin: 4px 0 12px;
-    }
-    ul,
-    ol {
-        padding: 0 0 0 16px;
-    }
-    li {
-        margin: 0 0 8px;
-    }
-    a {
-        color: ${props => props.theme.TYPE_GREEN};
-        &:hover {
-            text-decoration: underline;
-        }
-    }
-`;
 
 const loadPageMarkdownFile = async (id: string, language = 'en') => {
     const file = await import(`@trezor/suite-data/files/guide/${language}${id}`);
@@ -106,21 +47,7 @@ const GuidePage = () => {
         <ViewWrapper>
             <Header useBreadcrumb />
             <Content>
-                {markdown && (
-                    <StyledMarkdown>
-                        <ReactMarkdown
-                            renderers={{
-                                link: ({ children, href }) => (
-                                    <a href={href} target="_blank" rel="noopener noreferrer">
-                                        {children}
-                                    </a>
-                                ),
-                            }}
-                        >
-                            {markdown}
-                        </ReactMarkdown>
-                    </StyledMarkdown>
-                )}
+                <GuideMarkdown markdown={markdown} />
                 {hasError && <Translation id="TR_GENERIC_ERROR_TITLE" />}
             </Content>
         </ViewWrapper>

--- a/packages/suite/src/views/guide/index.tsx
+++ b/packages/suite/src/views/guide/index.tsx
@@ -4,6 +4,7 @@ import GuideDefault from './GuideDefault';
 import GuidePage from './GuidePage';
 import GuideCategory from './GuideCategory';
 import OpenGuideFromTooltip from './OpenGuideFromTooltip';
+import GuideMarkdown from './GuideMarkdown';
 
 export {
     Feedback,
@@ -12,4 +13,5 @@ export {
     GuidePage,
     GuideCategory,
     OpenGuideFromTooltip,
+    GuideMarkdown,
 };


### PR DESCRIPTION
should fix #4412 

using markdown links as `[text](NODE_ID)` e.g. `[some text](/security/pin.md)`

also fixing minor bug when linking between articles or open an article through tooltip when another is opened and scroll position is not top, it should scroll to top on new content

