### PR TITLE
feat(invity): add coinmarket account metadata label

### DIFF
--- a/packages/suite/src/components/suite/Labeling/components/Account/index.tsx
+++ b/packages/suite/src/components/suite/Labeling/components/Account/index.tsx
@@ -26,7 +26,9 @@ const Account = ({ account }: Props) => {
 
     if (accounts.length < 1) return null;
 
-    const accountLabel: JSX.Element = (
+    const accountLabel: string | JSX.Element = accounts[0]?.metadata?.accountLabel ? (
+        accounts[0].metadata.accountLabel
+    ) : (
         <Translation
             id="LABELING_ACCOUNT"
             values={{


### PR DESCRIPTION
**User story**
As a user, I want to see labels of my crypto currency account during trade, so I know which one I actually use.

Users see just Bitcoin #<i></i>1 or Ethereum #<i></i>2 even when they have labeled their accounts before.
Now:
![image](https://user-images.githubusercontent.com/7394177/139082135-c1ee72b5-b7b7-417f-949c-b7dc7262744d.png)

Improvement:
![image](https://user-images.githubusercontent.com/7394177/139082601-e8c00333-bafd-440e-9618-4c6adb87659b.png)

It has also impact on another places in application like notification or transaction confirmation dialog.