### PR TITLE
docs(readme): add git lfs step to readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,9 +14,10 @@
 
 ## Development
 
-Before you start make sure you have downloaded and installed [Node.js LTS](https://nodejs.org/en/download/), [Yarn](https://yarnpkg.com/lang/en/docs/install/) and git.
+Before you start make sure you have downloaded and installed [Node.js LTS](https://nodejs.org/en/download/), [Yarn](https://yarnpkg.com/lang/en/docs/install/) and git with [git lfs](https://git-lfs.github.com/).
 
 -   `git clone git@github.com:trezor/trezor-suite.git`
+-   `git lfs pull`
 -   `yarn`
 -   `yarn build:libs && yarn workspace @trezor/suite-data msg-system-sign-config`
 


### PR DESCRIPTION
In order to have firmware update fully working on development, it is required to have `git lfs` installed and run the command `git lfs pull` before running `yarn build:libs && yarn workspace @trezor/suite-data msg-system-sign-config` so it downloads the firmware binary files locally that are later going to be flashed when updating.

Otherwise it tries to update the firmware with the file just containing text and the device displays error "Firmware is too small" in T1 and "Failed! Please, reconnect." in TT.