### PR TITLE
feat(invity): Dex exchange crypto functionality

### DIFF
--- a/packages/suite/package.json
+++ b/packages/suite/package.json
@@ -77,7 +77,7 @@
         "@testing-library/react-hooks": "^4.0.0",
         "@testing-library/user-event": "^12.6.0",
         "@types/file-saver": "^2.0.1",
-        "@types/invity-api": "^1.0.3",
+        "@types/invity-api": "^1.0.5",
         "@types/jws": "^3.2.4",
         "@types/pako": "^1.0.1",
         "@types/pdfmake": "^0.1.16",

--- a/packages/suite/src/actions/suite/modalActions.ts
+++ b/packages/suite/src/actions/suite/modalActions.ts
@@ -84,6 +84,11 @@ export type UserContextPayload =
           decision: Deferred<boolean>;
       }
     | {
+          type: 'coinmarket-exchange-dex-terms';
+          provider?: string;
+          decision: Deferred<boolean>;
+      }
+    | {
           type: 'log';
       }
     | {
@@ -193,6 +198,7 @@ type DeferredModals = Extract<
             | 'import-transaction'
             | 'coinmarket-buy-terms'
             | 'coinmarket-sell-terms'
+            | 'coinmarket-exchange-dex-terms'
             | 'coinmarket-exchange-terms';
     }
 >;

--- a/packages/suite/src/actions/wallet/__tests__/coinmarketExchangeActions.test.ts
+++ b/packages/suite/src/actions/wallet/__tests__/coinmarketExchangeActions.test.ts
@@ -153,9 +153,11 @@ describe('Coinmarket Exchange Actions', () => {
 
         const fixedQuotes: ExchangeTrade[] = [];
         const floatQuotes: ExchangeTrade[] = [];
+        const dexQuotes: ExchangeTrade[] = [];
 
-        store.dispatch(coinmarketExchangeActions.saveQuotes(fixedQuotes, floatQuotes));
+        store.dispatch(coinmarketExchangeActions.saveQuotes(fixedQuotes, floatQuotes, dexQuotes));
         expect(store.getState().wallet.coinmarket.exchange.fixedQuotes).toEqual(fixedQuotes);
         expect(store.getState().wallet.coinmarket.exchange.floatQuotes).toEqual(floatQuotes);
+        expect(store.getState().wallet.coinmarket.exchange.dexQuotes).toEqual(dexQuotes);
     });
 });

--- a/packages/suite/src/actions/wallet/coinmarket/__tests__/coinmarketCommonActions.test.ts
+++ b/packages/suite/src/actions/wallet/coinmarket/__tests__/coinmarketCommonActions.test.ts
@@ -126,6 +126,7 @@ describe('Coinmarket Common Actions', () => {
         const info: ComposedTransactionInfo = {
             selectedFee: 'normal',
             composed: {
+                fee: '43214234',
                 feePerByte: '13',
             },
         };

--- a/packages/suite/src/actions/wallet/coinmarketExchangeActions.ts
+++ b/packages/suite/src/actions/wallet/coinmarketExchangeActions.ts
@@ -31,6 +31,7 @@ export type CoinmarketExchangeAction =
           type: typeof COINMARKET_EXCHANGE.SAVE_QUOTES;
           fixedQuotes: ExchangeTrade[];
           floatQuotes: ExchangeTrade[];
+          dexQuotes: ExchangeTrade[];
       }
     | { type: typeof COINMARKET_EXCHANGE.CLEAR_QUOTES }
     | {
@@ -113,8 +114,14 @@ export const saveExchangeCoinInfo = (
 
 // this is only a wrapper for `openDeferredModal` since it doesn't work with `bindActionCreators`
 // used in useCoinmarketExchangeOffers
-export const openCoinmarketExchangeConfirmModal = (provider?: string) => (dispatch: Dispatch) =>
-    dispatch(modalActions.openDeferredModal({ type: 'coinmarket-exchange-terms', provider }));
+export const openCoinmarketExchangeConfirmModal =
+    (provider?: string, isDex?: boolean) => (dispatch: Dispatch) =>
+        dispatch(
+            modalActions.openDeferredModal({
+                type: isDex ? 'coinmarket-exchange-dex-terms' : 'coinmarket-exchange-terms',
+                provider,
+            }),
+        );
 
 export const saveTrade = (
     exchangeTrade: ExchangeTrade,
@@ -147,10 +154,12 @@ export const saveTransactionId = (transactionId: string): CoinmarketExchangeActi
 export const saveQuotes = (
     fixedQuotes: ExchangeTrade[],
     floatQuotes: ExchangeTrade[],
+    dexQuotes: ExchangeTrade[],
 ): CoinmarketExchangeAction => ({
     type: COINMARKET_EXCHANGE.SAVE_QUOTES,
     fixedQuotes,
     floatQuotes,
+    dexQuotes,
 });
 
 export const clearQuotes = (): CoinmarketExchangeAction => ({

--- a/packages/suite/src/components/suite/modals/confirm/CoinmarketExchangeDexTerms/index.tsx
+++ b/packages/suite/src/components/suite/modals/confirm/CoinmarketExchangeDexTerms/index.tsx
@@ -1,0 +1,130 @@
+import { Button, Icon, variables, Checkbox } from '@trezor/components';
+import React, { useState } from 'react';
+import { Translation, Modal } from '@suite-components';
+import styled, { css } from 'styled-components';
+import { Deferred } from '@suite-utils/deferred';
+
+const Text = styled.div<{ isLast?: boolean; isFirst?: boolean }>`
+    padding: 20px 0;
+    border-bottom: 1px solid ${props => props.theme.STROKE_GREY};
+    text-align: left;
+
+    ${props =>
+        props.isLast &&
+        css`
+            border-bottom: 0;
+        `};
+
+    ${props =>
+        props.isFirst &&
+        css`
+            padding-top: 0;
+        `};
+`;
+
+const Terms = styled.div`
+    padding: 10px 35px;
+`;
+
+const Header = styled.div`
+    display: flex;
+    width: 100%;
+    padding: 10px 0;
+    align-items: center;
+    color: ${props => props.theme.TYPE_DARK_GREY};
+    font-size: ${variables.FONT_SIZE.H2};
+    font-weight: ${variables.FONT_WEIGHT.MEDIUM};
+`;
+
+const StyledIcon = styled(Icon)`
+    padding-right: 9px;
+`;
+
+const CheckText = styled.div`
+    font-size: ${variables.FONT_SIZE.BIG};
+`;
+
+const Footer = styled.div`
+    display: flex;
+    padding: 35px 0;
+    flex: 1;
+    border-top: 1px solid ${props => props.theme.STROKE_GREY};
+`;
+
+const FooterContent = styled.div`
+    display: flex;
+    justify-content: space-between;
+    flex: 1;
+    padding: 0 35px;
+`;
+
+const Left = styled.div`
+    display: flex;
+    flex: 1;
+    align-items: center;
+`;
+
+export type Props = {
+    decision: Deferred<boolean>;
+    onCancel: () => void;
+    provider?: string;
+};
+
+const CoinmarketExchangeDexTerms = ({ decision, onCancel, provider }: Props) => {
+    const [isChecked, setIsChecked] = useState<boolean>(false);
+    const providerName = provider || 'unknown provider';
+
+    return (
+        <Modal
+            cancelable
+            onCancel={onCancel}
+            noPadding
+            heading={
+                <Header>
+                    <Left>
+                        <StyledIcon size={16} icon="LOCK" />
+                        <Translation id="TR_EXCHANGE_FOR_YOUR_SAFETY" />
+                    </Left>
+                </Header>
+            }
+        >
+            <Terms>
+                <Text isFirst>
+                    <Translation id="TR_EXCHANGE_DEX_TERMS_1" values={{ provider: providerName }} />
+                </Text>
+                <Text>
+                    <Translation id="TR_EXCHANGE_TERMS_2" />
+                </Text>
+                <Text>
+                    <Translation id="TR_EXCHANGE_TERMS_3" />
+                </Text>
+                <Text>
+                    <Translation id="TR_EXCHANGE_TERMS_4" />
+                </Text>
+                <Text isLast>
+                    <Translation id="TR_EXCHANGE_TERMS_5" />
+                </Text>
+            </Terms>
+            <Footer>
+                <FooterContent>
+                    <Checkbox isChecked={isChecked} onClick={() => setIsChecked(!isChecked)}>
+                        <CheckText>
+                            <Translation id="TR_EXCHANGE_I_UNDERSTAND" />
+                        </CheckText>
+                    </Checkbox>
+                    <Button
+                        isDisabled={!isChecked}
+                        onClick={() => {
+                            decision.resolve(true);
+                            onCancel();
+                        }}
+                    >
+                        <Translation id="TR_EXCHANGE_CONFIRM" />
+                    </Button>
+                </FooterContent>
+            </Footer>
+        </Modal>
+    );
+};
+
+export default CoinmarketExchangeDexTerms;

--- a/packages/suite/src/components/suite/modals/index.tsx
+++ b/packages/suite/src/components/suite/modals/index.tsx
@@ -21,6 +21,7 @@ import ConfirmFingerPrint from './confirm/Fingerprint';
 import CoinmarketBuyTerms from './confirm/CoinmarketBuyTerms';
 import CoinmarketSellTerms from './confirm/CoinmarketSellTerms';
 import CoinmarketExchangeTerms from './confirm/CoinmarketExchangeTerms';
+import CoinmarketExchangeDexTerms from './confirm/CoinmarketExchangeDexTerms';
 import CoinmarketLeaveSpend from './confirm/CoinmarketLeaveSpend';
 import Word from './Word';
 import WordAdvanced from './WordAdvanced';
@@ -200,6 +201,14 @@ const getUserContextModal = (props: Props) => {
         case 'coinmarket-exchange-terms':
             return (
                 <CoinmarketExchangeTerms
+                    provider={payload.provider}
+                    onCancel={modalActions.onCancel}
+                    decision={payload.decision}
+                />
+            );
+        case 'coinmarket-exchange-dex-terms':
+            return (
+                <CoinmarketExchangeDexTerms
                     provider={payload.provider}
                     onCancel={modalActions.onCancel}
                     decision={payload.decision}

--- a/packages/suite/src/components/wallet/CoinmarketExchangeOfferInfo/index.tsx
+++ b/packages/suite/src/components/wallet/CoinmarketExchangeOfferInfo/index.tsx
@@ -174,6 +174,7 @@ const CoinmarketExchangeOfferInfo = ({
                                 src={`${invityAPI.server}/images/coins/suite/${receive}.svg`}
                             />
                             <Amount>
+                                {(!provider.isFixedRate || selectedQuote.isDex) && '≈ '}
                                 {`${formatCryptoAmount(Number(receiveStringAmount))} ${receive}`}
                             </Amount>
                         </Dark>
@@ -195,17 +196,19 @@ const CoinmarketExchangeOfferInfo = ({
                 )}
                 <RowWithBorder>
                     <Middle>
-                        {provider.isFixedRate ? (
+                        {provider.isFixedRate && !selectedQuote.isDex && (
                             <>
                                 <Translation id="TR_EXCHANGE_FIXED" />
                                 <StyledQuestionTooltip tooltip="TR_EXCHANGE_FIXED_OFFERS_INFO" />
                             </>
-                        ) : (
+                        )}
+                        {!provider.isFixedRate && !selectedQuote.isDex && (
                             <>
                                 <Translation id="TR_EXCHANGE_FLOAT" />
                                 <StyledQuestionTooltip tooltip="TR_EXCHANGE_FLOAT_OFFERS_INFO" />
                             </>
                         )}
+                        {selectedQuote.isDex && <Translation id="TR_EXCHANGE_DEX" />}
                     </Middle>
                 </RowWithBorder>
                 <Row>

--- a/packages/suite/src/hooks/wallet/useCoinmarketExchangeForm.ts
+++ b/packages/suite/src/hooks/wallet/useCoinmarketExchangeForm.ts
@@ -18,7 +18,7 @@ import {
     FIAT_CURRENCY,
 } from '@wallet-types/coinmarketExchangeForm';
 import { getComposeAddressPlaceholder } from '@wallet-utils/coinmarket/coinmarketUtils';
-import { getAmountLimits, splitToFixedFloatQuotes } from '@wallet-utils/coinmarket/exchangeUtils';
+import { getAmountLimits, splitToQuoteCategories } from '@wallet-utils/coinmarket/exchangeUtils';
 import { useFees } from './form/useFees';
 import { useCompose } from './form/useCompose';
 import { useFormDraft } from '@wallet-hooks/useFormDraft';
@@ -274,6 +274,7 @@ export const useCoinmarketExchangeForm = (props: Props): ExchangeFormContextValu
                 receive,
                 send,
                 sendStringAmount,
+                dex: 'enable',
             };
             saveQuoteRequest(request);
             const allQuotes = await invityAPI.getExchangeQuotes(request);
@@ -282,11 +283,11 @@ export const useCoinmarketExchangeForm = (props: Props): ExchangeFormContextValu
                 if (limits) {
                     setAmountLimits(limits);
                 } else {
-                    const [fixedQuotes, floatQuotes] = splitToFixedFloatQuotes(
+                    const [fixedQuotes, floatQuotes, dexQuotes] = splitToQuoteCategories(
                         allQuotes,
                         exchangeInfo,
                     );
-                    saveQuotes(fixedQuotes, floatQuotes);
+                    saveQuotes(fixedQuotes, floatQuotes, dexQuotes);
                     navigateToExchangeOffers();
                 }
             } else {

--- a/packages/suite/src/hooks/wallet/useCoinmarketNavigation.ts
+++ b/packages/suite/src/hooks/wallet/useCoinmarketNavigation.ts
@@ -28,6 +28,7 @@ export const useCoinmarketNavigation = (account: Account) => {
 
         navigateToExchangeForm: useNavigateToRouteName('wallet-coinmarket-exchange'),
         navigateToExchangeOffers: useNavigateToRouteName('wallet-coinmarket-exchange-offers'),
+        navigateToExchangeDetail: useNavigateToRouteName('wallet-coinmarket-exchange-detail'),
 
         navigateToSellForm: useNavigateToRouteName('wallet-coinmarket-sell'),
         navigateToSellOffers: useNavigateToRouteName('wallet-coinmarket-sell-offers'),

--- a/packages/suite/src/hooks/wallet/useCoinmarketRedirect.ts
+++ b/packages/suite/src/hooks/wallet/useCoinmarketRedirect.ts
@@ -118,6 +118,7 @@ export const useCoinmarketRedirect = () => {
         const composed = {
             feeLimit,
             feePerByte: feePerByte || '',
+            fee: '', // fee is not passed by redirect, will be recalculated
         };
         saveComposedTransactionInfo({ selectedFee: selectedFee || 'normal', composed });
         goto('wallet-coinmarket-sell-offers', { symbol, accountIndex: index, accountType });

--- a/packages/suite/src/reducers/wallet/coinmarketReducer.ts
+++ b/packages/suite/src/reducers/wallet/coinmarketReducer.ts
@@ -28,7 +28,7 @@ import { Trade } from '@wallet-types/coinmarketCommonTypes';
 export interface ComposedTransactionInfo {
     composed?: Pick<
         PrecomposedTransactionFinal,
-        'feePerByte' | 'estimatedFeeLimit' | 'feeLimit' | 'token'
+        'feePerByte' | 'estimatedFeeLimit' | 'feeLimit' | 'token' | 'fee'
     >;
     selectedFee?: FeeLevel['label'];
 }
@@ -55,6 +55,7 @@ interface Exchange {
     quotesRequest?: ExchangeTradeQuoteRequest;
     fixedQuotes: ExchangeTrade[] | undefined;
     floatQuotes: ExchangeTrade[] | undefined;
+    dexQuotes: ExchangeTrade[] | undefined;
     transactionId?: string;
     addressVerified?: string;
 }
@@ -102,6 +103,7 @@ export const initialState = {
         quotesRequest: undefined,
         fixedQuotes: [],
         floatQuotes: [],
+        dexQuotes: [],
         addressVerified: undefined,
     },
     sell: {
@@ -179,6 +181,7 @@ const coinmarketReducer = (
             case COINMARKET_EXCHANGE.SAVE_QUOTES:
                 draft.exchange.fixedQuotes = action.fixedQuotes;
                 draft.exchange.floatQuotes = action.floatQuotes;
+                draft.exchange.dexQuotes = action.dexQuotes;
                 break;
             case COINMARKET_EXCHANGE.CLEAR_QUOTES:
                 draft.exchange.fixedQuotes = undefined;

--- a/packages/suite/src/support/messages.ts
+++ b/packages/suite/src/support/messages.ts
@@ -261,6 +261,39 @@ export default defineMessages({
         defaultMessage:
             "Floating rates mean that the final amount you'll get may change slightly due to fluctuations in the market between when you select the rate and when your transaction is complete. These rates are usually higher, meaning you could end up with more crypto in the end.",
     },
+    TR_EXCHANGE_DEX_OFFERS: {
+        id: 'TR_EXCHANGE_DEX_OFFERS',
+        defaultMessage: 'Decentralized exchange offers',
+    },
+    TR_EXCHANGE_DEX_OFFERS_INFO: {
+        id: 'TR_EXCHANGE_DEX_OFFERS_INFO',
+        defaultMessage:
+            'Decentralized exchange (DEX) swaps are performed via smart contracts running on the blockchain. They may be faster and offer better rates, especially for large amounts.',
+    },
+    TR_EXCHANGE_DEX_OFFER_NO_FUNDS_FEES: {
+        id: 'TR_EXCHANGE_DEX_OFFER_NO_FUNDS_FEES',
+        defaultMessage:
+            'No funds remaining for the transaction fees. Please lower the exchange amount to max {symbol} {max}',
+    },
+    TR_EXCHANGE_DEX_OFFER_FEE_INFO: {
+        defaultMessage:
+            'The fees to perform this swap are estimated at {symbol} {approvalFee} ({approvalFeeFiat}) for approval (if required) and {symbol} {swapFee} ({swapFeeFiat}) for the swap.',
+        id: 'TR_EXCHANGE_DEX_FEE_INFO',
+    },
+    TR_EXCHANGE_FEES_INFO: {
+        id: 'TR_EXCHANGE_FEES_INFO',
+        defaultMessage:
+            'All fees included; the transaction fee is estimated at {feeAmount} ({feeAmountFiat}).',
+    },
+    TR_EXCHANGE_DEX_FEES_INFO: {
+        id: 'TR_EXCHANGE_FEES_INFO',
+        defaultMessage: 'See info about fees in each DEX offer.',
+    },
+    TR_EXCHANGE_DEX_FEES_INFO_TOOLTIP: {
+        id: 'TR_EXCHANGE_DEX_FEES_INFO_TOOLTIP',
+        defaultMessage:
+            'To perform a DEX swap, it may be necessary to perform two blockchain transactions: an approval transaction and a swap transaction. Each transaction has a different fee.',
+    },
     TR_EXCHANGE_FEES_INCLUDED: {
         id: 'TR_EXCHANGE_FEES_INCLUDED',
         defaultMessage: 'All fees included',
@@ -330,6 +363,11 @@ export default defineMessages({
         defaultMessage:
             'You understand that cryptocurrency transactions are irreversible and you won’t be able to receive a refund for your purchase.',
         id: 'TR_EXCHANGE_TERMS_5',
+    },
+    TR_EXCHANGE_DEX_TERMS_1: {
+        defaultMessage:
+            "You're here to exchange cryptocurrency using DEX (Decentralized Exchange) by using {provider}'s contract.",
+        id: 'TR_EXCHANGE_DEX_TERMS_1',
     },
     TR_EXCHANGE_STATUS_ERROR: {
         defaultMessage: 'Rejected',
@@ -441,6 +479,10 @@ export default defineMessages({
         defaultMessage: 'Confirm & Send',
         id: 'TR_EXCHANGE_CONFIRM_SEND_STEP',
     },
+    TR_EXCHANGE_CREATE_APPROVAL_STEP: {
+        defaultMessage: 'Create approval',
+        id: 'TR_EXCHANGE_CREATE_APPROVAL_STEP',
+    },
     TR_EXCHANGE_SEND_FROM: {
         defaultMessage: 'Sending account',
         id: 'TR_EXCHANGE_SEND_FROM',
@@ -448,6 +490,130 @@ export default defineMessages({
     TR_EXCHANGE_SEND_TO: {
         defaultMessage: '{providerName}’s address',
         id: 'TR_EXCHANGE_SEND_TO',
+    },
+    TR_EXCHANGE_APPROVAL_SEND_TO: {
+        defaultMessage: '{send} contract',
+        id: 'TR_EXCHANGE_SEND_TO',
+    },
+    TR_EXCHANGE_APPROVAL_VALUE: {
+        defaultMessage: 'Approval value',
+        id: 'TR_EXCHANGE_APPROVAL_VALUE',
+    },
+    TR_EXCHANGE_APPROVAL_VALUE_MINIMAL: {
+        defaultMessage: 'Necessary value of {value} {send}',
+        id: 'TR_EXCHANGE_APPROVAL_VALUE_MINIMAL',
+    },
+    TR_EXCHANGE_APPROVAL_VALUE_MINIMAL_INFO: {
+        defaultMessage:
+            'Approve only the exact amount required for this swap. You will need to pay an additional fee if you want to make a similar swap again.',
+        id: 'TR_EXCHANGE_APPROVAL_VALUE_MINIMAL_INFO',
+    },
+    TR_EXCHANGE_APPROVAL_VALUE_INFINITE: {
+        defaultMessage: 'Infinite value',
+        id: 'TR_EXCHANGE_APPROVAL_VALUE_INFINITE',
+    },
+    TR_EXCHANGE_APPROVAL_VALUE_INFINITE_INFO: {
+        defaultMessage:
+            'Create a single approval transaction to simplify multiple exchanges of {send} with {provider}. This saves on fees but carries a risk to your funds in the unlikely case of a flaw in {provider}’s contract.',
+        id: 'TR_EXCHANGE_APPROVAL_VALUE_INFINITE_INFO',
+    },
+    TR_EXCHANGE_APPROVAL_VALUE_ZERO: {
+        defaultMessage: 'Revoke previous approval',
+        id: 'TR_EXCHANGE_APPROVAL_VALUE_ZERO',
+    },
+    TR_EXCHANGE_APPROVAL_VALUE_ZERO_INFO: {
+        defaultMessage:
+            'Perform a transaction that will remove previous approval of contract with {provider}.',
+        id: 'TR_EXCHANGE_APPROVAL_VALUE_ZERO_INFO',
+    },
+    TR_EXCHANGE_APPROVAL_DATA: {
+        defaultMessage: 'Approval transaction data',
+        id: 'TR_EXCHANGE_APPROVAL_DATA',
+    },
+    TR_EXCHANGE_APPROVAL_TXID: {
+        defaultMessage: 'Approval transaction ID',
+        id: 'TR_EXCHANGE_APPROVAL_TXID',
+    },
+    TR_EXCHANGE_APPROVAL_CONFIRMING: {
+        defaultMessage: 'Waiting for the blockchain to confirm the approval transaction.',
+        id: 'TR_EXCHANGE_APPROVAL_CONFIRMING',
+    },
+    TR_EXCHANGE_APPROVAL_FAILED: {
+        defaultMessage: 'The approval transaction failed.',
+        id: 'TR_EXCHANGE_APPROVAL_FAILED',
+    },
+    TR_EXCHANGE_APPROVAL_SUCCESS: {
+        defaultMessage: 'The approval transaction is confirmed.',
+        id: 'TR_EXCHANGE_APPROVAL_SUCCESS',
+    },
+    TR_EXCHANGE_APPROVAL_NOT_REQUIRED: {
+        defaultMessage: 'No approval transaction needed for {send}.',
+        id: 'TR_EXCHANGE_APPROVAL_NOT_REQUIRED',
+    },
+    TR_EXCHANGE_APPROVAL_PREAPPROVED: {
+        defaultMessage: 'Contract already approved',
+        id: 'TR_EXCHANGE_APPROVAL_PREAPPROVED',
+    },
+    TR_EXCHANGE_APPROVAL_PROCEED: {
+        defaultMessage: 'Proceed to swap, no approval transaction needed.',
+        id: 'TR_EXCHANGE_APPROVAL_PROCEED',
+    },
+    TR_EXCHANGE_APPROVAL_TO_SWAP_BUTTON: {
+        defaultMessage: 'Proceed to swap',
+        id: 'TR_EXCHANGE_APPROVAL_TO_SWAP_BUTTON',
+    },
+    TR_EXCHANGE_SWAP_SEND_TO: {
+        defaultMessage: "{provider}'s contract",
+        id: 'TR_EXCHANGE_SWAP_SEND_TO',
+    },
+    TR_EXCHANGE_SWAP_DATA: {
+        defaultMessage: 'Swap transaction data',
+        id: 'TR_EXCHANGE_SWAP_DATA',
+    },
+    TR_EXCHANGE_SWAP_SLIPPAGE: {
+        defaultMessage: 'Slippage',
+        id: 'TR_EXCHANGE_SWAP_SLIPPAGE',
+    },
+    TR_EXCHANGE_SWAP_SLIPPAGE_TOLERANCE: {
+        defaultMessage: 'Slippage tolerance',
+        id: 'TR_EXCHANGE_SWAP_SLIPPAGE_TOLERANCE',
+    },
+    TR_EXCHANGE_SWAP_SLIPPAGE_SUMMARY: {
+        defaultMessage: 'Slippage summary',
+        id: 'TR_EXCHANGE_SWAP_SLIPPAGE_SUMMARY',
+    },
+    TR_EXCHANGE_SWAP_SLIPPAGE_OFFERED: {
+        defaultMessage: 'Swap offer amount',
+        id: 'TR_EXCHANGE_SWAP_SLIPPAGE_OFFERED',
+    },
+    TR_EXCHANGE_SWAP_SLIPPAGE_AMOUNT: {
+        defaultMessage: 'Maximum slippage amount',
+        id: 'TR_EXCHANGE_SWAP_SLIPPAGE_AMOUNT',
+    },
+    TR_EXCHANGE_SWAP_SLIPPAGE_MINIMUM: {
+        defaultMessage: 'Minimum received amount',
+        id: 'TR_EXCHANGE_SWAP_SLIPPAGE_MINIMUM',
+    },
+    TR_EXCHANGE_SWAP_SLIPPAGE_INFO: {
+        defaultMessage:
+            "Exchange rates shift constantly, so the amount you accept in this offer and the amount ultimately confirmed on the blockchain may differ; this is slippage. Slippage tolerance sets the percentage of your transaction you may lose due to slippage; in other words, you set the minimum amount you are willing to accept in the end. If slippage tolerance is too high, you may receive a lot less than offered. If slippage tolerance is too low, your transaction may fail (revert) and you'll still pay the transaction fee.",
+        id: 'TR_EXCHANGE_SWAP_SLIPPAGE_INFO',
+    },
+    TR_EXCHANGE_SWAP_SLIPPAGE_CUSTOM: {
+        defaultMessage: 'Custom',
+        id: 'TR_EXCHANGE_SWAP_SLIPPAGE_CUSTOM',
+    },
+    TR_EXCHANGE_SWAP_SLIPPAGE_NOT_SET: {
+        defaultMessage: 'Enter your desired slippage.',
+        id: 'TR_EXCHANGE_SWAP_SLIPPAGE_NOT_SET',
+    },
+    TR_EXCHANGE_SWAP_SLIPPAGE_NOT_NUMBER: {
+        defaultMessage: 'Please enter a number.',
+        id: 'TR_EXCHANGE_SWAP_SLIPPAGE_NOT_NUMBER',
+    },
+    TR_EXCHANGE_SWAP_SLIPPAGE_NOT_IN_RANGE: {
+        defaultMessage: 'Slippage must be in range 0.01% - 50%',
+        id: 'TR_EXCHANGE_SWAP_SLIPPAGE_NOT_IN_RANGE',
     },
     TR_EXCHANGE_CONFIRM_ON_TREZOR_SEND: {
         defaultMessage: 'Confirm on Trezor & send',
@@ -542,6 +708,10 @@ export default defineMessages({
     TR_EXCHANGE_FLOAT: {
         defaultMessage: 'Floating-rate offer',
         id: 'TR_EXCHANGE_FLOAT',
+    },
+    TR_EXCHANGE_DEX: {
+        defaultMessage: 'Decentralized exchange offer',
+        id: 'TR_EXCHANGE_DEX',
     },
     TR_SELL_STATUS_ERROR: {
         defaultMessage: 'Rejected',

--- a/packages/suite/src/types/wallet/coinmarketExchangeForm.ts
+++ b/packages/suite/src/types/wallet/coinmarketExchangeForm.ts
@@ -55,6 +55,7 @@ export type ExchangeFormContextValues = Omit<UseFormMethods<ExchangeFormState>, 
     saveQuotes: (
         fixedQuotes: ExchangeTrade[],
         floatQuotes: ExchangeTrade[],
+        dexQuotes: ExchangeTrade[],
     ) => CoinmarketExchangeAction;
     saveTrade: (
         exchangeTrade: ExchangeTrade,

--- a/packages/suite/src/types/wallet/coinmarketExchangeOffers.ts
+++ b/packages/suite/src/types/wallet/coinmarketExchangeOffers.ts
@@ -9,6 +9,7 @@ export interface ComponentProps {
     device: AppState['suite']['device'];
     fixedQuotes: AppState['wallet']['coinmarket']['exchange']['fixedQuotes'];
     floatQuotes: AppState['wallet']['coinmarket']['exchange']['floatQuotes'];
+    dexQuotes: AppState['wallet']['coinmarket']['exchange']['dexQuotes'];
     quotesRequest: AppState['wallet']['coinmarket']['exchange']['quotesRequest'];
     addressVerified: AppState['wallet']['coinmarket']['exchange']['addressVerified'];
     exchangeInfo?: ExchangeInfo;
@@ -18,16 +19,18 @@ export interface Props extends ComponentProps {
     selectedAccount: Extract<AppState['wallet']['selectedAccount'], { status: 'loaded' }>;
 }
 
-export type ExchangeStep = 'RECEIVING_ADDRESS' | 'SEND_TRANSACTION';
+export type ExchangeStep = 'RECEIVING_ADDRESS' | 'SEND_TRANSACTION' | 'SEND_APPROVAL_TRANSACTION';
 
 export type ContextValues = {
     callInProgress: boolean;
     account: Account;
     fixedQuotes: AppState['wallet']['coinmarket']['exchange']['fixedQuotes'];
     floatQuotes: AppState['wallet']['coinmarket']['exchange']['floatQuotes'];
+    dexQuotes: AppState['wallet']['coinmarket']['exchange']['dexQuotes'];
     quotesRequest: AppState['wallet']['coinmarket']['exchange']['quotesRequest'];
     device: AppState['suite']['device'];
     selectedQuote?: ExchangeTrade;
+    setSelectedQuote: (quote?: ExchangeTrade) => void;
     suiteReceiveAccounts?: AppState['wallet']['accounts'];
     addressVerified: AppState['wallet']['coinmarket']['exchange']['addressVerified'];
     exchangeInfo?: ExchangeInfo;
@@ -43,7 +46,7 @@ export type ContextValues = {
         account: Account,
         date: string,
     ) => CoinmarketExchangeAction;
-    confirmTrade: (address: string, extraField?: string) => void;
+    confirmTrade: (address: string, extraField?: string) => Promise<boolean>;
     sendTransaction: () => void;
     timer: Timer;
     getQuotes: () => Promise<void>;

--- a/packages/suite/src/utils/wallet/coinmarket/__fixtures__/exchangeUtils.ts
+++ b/packages/suite/src/utils/wallet/coinmarket/__fixtures__/exchangeUtils.ts
@@ -9,6 +9,7 @@ export const EXCHANGE_INFO: ExchangeInfo = {
             logo: 'changenow-icon.jpg',
             isActive: true,
             isFixedRate: false,
+            isDex: false,
             buyTickers: ['ETH', 'XMR', 'BTC'],
             sellTickers: ['ETH', 'XMR', 'BTC'],
             addressFormats: {
@@ -27,6 +28,7 @@ export const EXCHANGE_INFO: ExchangeInfo = {
             logo: 'changenowfr-icon.jpg',
             isActive: true,
             isFixedRate: true,
+            isDex: false,
             buyTickers: ['ETH', 'BTC'],
             sellTickers: ['ETH', 'BTC'],
             addressFormats: {
@@ -45,6 +47,7 @@ export const EXCHANGE_INFO: ExchangeInfo = {
             logo: 'changelly-icon.jpg',
             isActive: true,
             isFixedRate: false,
+            isDex: false,
             buyTickers: ['BTC', 'ETH'],
             sellTickers: ['BTC', 'ETH'],
             addressFormats: {
@@ -64,6 +67,7 @@ export const EXCHANGE_INFO: ExchangeInfo = {
             logo: 'changellyfr-icon.jpg',
             isActive: true,
             isFixedRate: true,
+            isDex: false,
             buyTickers: ['BTC', 'ETH'],
             sellTickers: ['BTC', 'ETH'],
             addressFormats: {
@@ -83,6 +87,7 @@ export const EXCHANGE_INFO: ExchangeInfo = {
             logo: 'changehero-icon.jpg',
             isActive: true,
             isFixedRate: false,
+            isDex: false,
             buyTickers: ['BTC'],
             sellTickers: ['BTC'],
             addressFormats: {
@@ -101,6 +106,7 @@ export const EXCHANGE_INFO: ExchangeInfo = {
             logo: 'changeherofr-icon.jpg',
             isActive: true,
             isFixedRate: true,
+            isDex: false,
             buyTickers: ['BTC'],
             sellTickers: ['BTC'],
             addressFormats: {
@@ -119,6 +125,7 @@ export const EXCHANGE_INFO: ExchangeInfo = {
             logo: 'foxexchange-icon.jpg',
             isActive: true,
             isFixedRate: false,
+            isDex: false,
             buyTickers: ['BTC'],
             sellTickers: ['BTC'],
             addressFormats: {
@@ -138,6 +145,7 @@ export const EXCHANGE_INFO: ExchangeInfo = {
             logo: 'foxexchange-icon.jpg',
             isActive: true,
             isFixedRate: true,
+            isDex: false,
             buyTickers: ['BTC'],
             sellTickers: ['BTC', 'ETH'],
             addressFormats: {
@@ -157,6 +165,7 @@ export const EXCHANGE_INFO: ExchangeInfo = {
             logo: 'morphtoken-icon.jpg',
             isActive: true,
             isFixedRate: false,
+            isDex: false,
             buyTickers: ['BTC', 'ETH', 'XMR'],
             sellTickers: ['BTC', 'ETH', 'XMR'],
             addressFormats: {
@@ -174,6 +183,7 @@ export const EXCHANGE_INFO: ExchangeInfo = {
             logo: 'coinswitch-icon.jpg',
             isActive: true,
             isFixedRate: false,
+            isDex: false,
             buyTickers: ['ETH'],
             sellTickers: ['ETH'],
             addressFormats: {
@@ -193,6 +203,7 @@ export const EXCHANGE_INFO: ExchangeInfo = {
             logo: 'coinswitchfr-icon.jpg',
             isActive: true,
             isFixedRate: true,
+            isDex: false,
             buyTickers: ['BTC'],
             sellTickers: ['BTC'],
             addressFormats: {
@@ -214,6 +225,7 @@ export const EXCHANGE_INFO: ExchangeInfo = {
             logo: 'changenow-icon.jpg',
             isActive: true,
             isFixedRate: false,
+            isDex: false,
             buyTickers: ['ETH', 'XMR', 'BTC'],
             sellTickers: ['ETH', 'XMR', 'BTC'],
             addressFormats: {
@@ -232,6 +244,7 @@ export const EXCHANGE_INFO: ExchangeInfo = {
             logo: 'changenowfr-icon.jpg',
             isActive: true,
             isFixedRate: true,
+            isDex: false,
             buyTickers: ['ETH', 'XMR', 'BTC'],
             sellTickers: ['ETH', 'XMR', 'BTC'],
             addressFormats: {
@@ -250,6 +263,7 @@ export const EXCHANGE_INFO: ExchangeInfo = {
             logo: 'changelly-icon.jpg',
             isActive: true,
             isFixedRate: false,
+            isDex: false,
             buyTickers: ['BTC', 'ETH'],
             sellTickers: ['BTC', 'ETH'],
             addressFormats: {
@@ -269,6 +283,7 @@ export const EXCHANGE_INFO: ExchangeInfo = {
             logo: 'changellyfr-icon.jpg',
             isActive: true,
             isFixedRate: true,
+            isDex: false,
             buyTickers: ['BTC', 'ETH'],
             sellTickers: ['BTC', 'ETH'],
             addressFormats: {
@@ -288,6 +303,7 @@ export const EXCHANGE_INFO: ExchangeInfo = {
             logo: 'changehero-icon.jpg',
             isActive: true,
             isFixedRate: false,
+            isDex: false,
             buyTickers: ['BTC'],
             sellTickers: ['BTC'],
             addressFormats: {
@@ -306,6 +322,7 @@ export const EXCHANGE_INFO: ExchangeInfo = {
             logo: 'changeherofr-icon.jpg',
             isActive: true,
             isFixedRate: true,
+            isDex: false,
             buyTickers: ['BTC'],
             sellTickers: ['BTC'],
             addressFormats: {
@@ -324,6 +341,7 @@ export const EXCHANGE_INFO: ExchangeInfo = {
             logo: 'foxexchange-icon.jpg',
             isActive: true,
             isFixedRate: false,
+            isDex: false,
             buyTickers: ['BTC'],
             sellTickers: ['BTC'],
             addressFormats: {
@@ -343,6 +361,7 @@ export const EXCHANGE_INFO: ExchangeInfo = {
             logo: 'foxexchange-icon.jpg',
             isActive: true,
             isFixedRate: true,
+            isDex: false,
             buyTickers: ['BTC'],
             sellTickers: ['BTC'],
             addressFormats: {
@@ -362,6 +381,7 @@ export const EXCHANGE_INFO: ExchangeInfo = {
             logo: 'morphtoken-icon.jpg',
             isActive: true,
             isFixedRate: false,
+            isDex: false,
             buyTickers: ['BTC', 'ETH', 'XMR'],
             sellTickers: ['BTC', 'ETH', 'XMR'],
             addressFormats: {
@@ -379,6 +399,7 @@ export const EXCHANGE_INFO: ExchangeInfo = {
             logo: 'coinswitch-icon.jpg',
             isActive: true,
             isFixedRate: false,
+            isDex: false,
             buyTickers: ['ETH'],
             sellTickers: ['ETH'],
             addressFormats: {
@@ -398,6 +419,7 @@ export const EXCHANGE_INFO: ExchangeInfo = {
             logo: 'coinswitchfr-icon.jpg',
             isActive: true,
             isFixedRate: true,
+            isDex: false,
             buyTickers: ['BTC'],
             sellTickers: ['BTC'],
             addressFormats: {

--- a/packages/suite/src/utils/wallet/coinmarket/__tests__/exchangeUtils.test.ts
+++ b/packages/suite/src/utils/wallet/coinmarket/__tests__/exchangeUtils.test.ts
@@ -3,7 +3,7 @@ import {
     getAmountLimits,
     getStatusMessage,
     isQuoteError,
-    splitToFixedFloatQuotes,
+    splitToQuoteCategories,
 } from '../exchangeUtils';
 
 const { EXCHANGE_INFO, MIN_MAX_QUOTES_OK, MIN_MAX_QUOTES_LOW, MIN_MAX_QUOTES_CANNOT_TRADE } =
@@ -27,7 +27,7 @@ describe('coinmarket/exchange utils', () => {
     });
 
     it('splitQuotes', () => {
-        expect(splitToFixedFloatQuotes(MIN_MAX_QUOTES_OK, EXCHANGE_INFO)).toStrictEqual([
+        expect(splitToQuoteCategories(MIN_MAX_QUOTES_OK, EXCHANGE_INFO)).toStrictEqual([
             [
                 {
                     send: 'LTC',
@@ -148,8 +148,9 @@ describe('coinmarket/exchange utils', () => {
                     exchange: 'coinswitch',
                 },
             ],
+            [],
         ]);
-        expect(splitToFixedFloatQuotes(MIN_MAX_QUOTES_CANNOT_TRADE, EXCHANGE_INFO)).toStrictEqual([
+        expect(splitToQuoteCategories(MIN_MAX_QUOTES_CANNOT_TRADE, EXCHANGE_INFO)).toStrictEqual([
             [
                 { error: 'Cannot trade pair LTC-DATA.', exchange: 'changeherofr' },
                 { error: 'Cannot trade pair LTC-DATA.', exchange: 'changellyfr' },
@@ -164,6 +165,7 @@ describe('coinmarket/exchange utils', () => {
                 { error: 'Cannot trade pair LTC-DATA.', exchange: 'coinswitch' },
                 { error: 'Cannot trade pair LTC-DATA.', exchange: 'foxexchange' },
             ],
+            [],
         ]);
     });
     it('getStatusMessage', () => {

--- a/packages/suite/src/views/wallet/coinmarket/exchange/components/ExchangeForm/Footer/index.tsx
+++ b/packages/suite/src/views/wallet/coinmarket/exchange/components/ExchangeForm/Footer/index.tsx
@@ -18,15 +18,21 @@ const StyledButton = styled(Button)`
 `;
 
 const Footer = () => {
-    const { formState, watch, errors, isComposing } = useCoinmarketExchangeFormContext();
+    const { formState, getValues, watch, errors, isComposing } = useCoinmarketExchangeFormContext();
     const hasValues = !!watch(CRYPTO_INPUT) && !!watch('receiveCryptoSelect')?.value;
+    const formValues = getValues();
+    const equalCrypto =
+        formValues.sendCryptoSelect.value.toUpperCase() ===
+        formValues.receiveCryptoSelect?.value?.toUpperCase();
     const formIsValid = Object.keys(errors).length === 0;
 
     return (
         <FooterWrapper>
             <Center>
                 <StyledButton
-                    isDisabled={!(formIsValid && hasValues) || formState.isSubmitting}
+                    isDisabled={
+                        !(formIsValid && hasValues) || formState.isSubmitting || equalCrypto
+                    }
                     isLoading={formState.isSubmitting || isComposing}
                     type="submit"
                 >

--- a/packages/suite/src/views/wallet/coinmarket/exchange/offers/Offers/SelectedOffer/components/SendApprovalTransaction/index.tsx
+++ b/packages/suite/src/views/wallet/coinmarket/exchange/offers/Offers/SelectedOffer/components/SendApprovalTransaction/index.tsx
@@ -1,0 +1,371 @@
+import React, { useEffect, useState } from 'react';
+import styled from 'styled-components';
+import { Translation, AccountLabeling } from '@suite-components';
+import { Button, Loader, P, RadioButton, Truncate, variables } from '@trezor/components';
+import { useCoinmarketExchangeOffersContext } from '@wallet-hooks/useCoinmarketExchangeOffers';
+import { useCoinmarketNavigation } from '@wallet-hooks/useCoinmarketNavigation';
+import { DexApprovalType, ExchangeTrade } from 'invity-api';
+import useTimeoutFn from 'react-use/lib/useTimeoutFn';
+import useUnmount from 'react-use/lib/useUnmount';
+import invityAPI from '@suite-services/invityAPI';
+
+// add APPROVED means no approval request is necessary
+type ExtendedDexApprovalType = DexApprovalType | 'APPROVED';
+
+const Wrapper = styled.div`
+    display: flex;
+    flex-direction: column;
+    margin-top: 10px;
+`;
+
+const LabelText = styled.div`
+    font-size: ${variables.FONT_SIZE.TINY};
+    color: ${props => props.theme.TYPE_LIGHT_GREY};
+`;
+
+const Value = styled.div`
+    padding-top: 6px;
+    font-size: ${variables.FONT_SIZE.SMALL};
+    color: ${props => props.theme.TYPE_DARK_GREY};
+    font-weight: ${variables.FONT_WEIGHT.MEDIUM};
+`;
+
+const BreakableValue = styled(Value)`
+    word-break: break-all;
+`;
+
+const ButtonWrapper = styled.div`
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    padding-top: 20px;
+    border-top: 1px solid ${props => props.theme.STROKE_GREY};
+    margin: 20px 0;
+`;
+
+const Row = styled.div`
+    margin: 10px 24px;
+`;
+
+const RadioButtonInner = styled.div`
+    display: flex;
+    flex-direction: column;
+    align-items: flex-center;
+    justify-self: center;
+`;
+
+const Address = styled.div``;
+
+const Title = styled.div`
+    margin-top: 25px;
+    font-weight: ${variables.FONT_WEIGHT.DEMI_BOLD};
+`;
+
+const LoaderWrapper = styled.div`
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    padding: 60px 20px 60px 20px;
+    flex-direction: column;
+`;
+
+const ErrorWrapper = styled(LoaderWrapper)`
+    color: ${props => props.theme.TYPE_RED};
+`;
+
+const REFRESH_SECONDS = 15;
+
+const shouldRefresh = (quote?: ExchangeTrade) => quote?.status === 'APPROVAL_PENDING';
+
+const SendApprovalTransactionComponent = () => {
+    const {
+        account,
+        callInProgress,
+        selectedQuote,
+        setSelectedQuote,
+        exchangeInfo,
+        confirmTrade,
+        sendTransaction,
+        setExchangeStep,
+    } = useCoinmarketExchangeOffersContext();
+    const [approvalType, setApprovalType] = useState<ExtendedDexApprovalType>(
+        selectedQuote?.status === 'CONFIRM' ? 'APPROVED' : 'MINIMAL',
+    );
+
+    // watch the trade if transaction in confirmation
+    const [refreshCount, setRefreshCount] = useState(0);
+    const invokeRefresh = () => {
+        if (shouldRefresh(selectedQuote)) {
+            setRefreshCount(prevValue => prevValue + 1);
+        }
+    };
+    const [, cancelRefresh, resetRefresh] = useTimeoutFn(invokeRefresh, REFRESH_SECONDS * 1000);
+    useUnmount(() => {
+        cancelRefresh();
+    });
+    useEffect(() => {
+        if (selectedQuote && shouldRefresh(selectedQuote)) {
+            cancelRefresh();
+            invityAPI.watchExchangeTrade(selectedQuote, refreshCount).then(response => {
+                if (response.status && response.status !== selectedQuote.status) {
+                    selectedQuote.status = response.status;
+                    selectedQuote.error = response.error;
+                    selectedQuote.approvalType = undefined;
+                    if (selectedQuote.dexTx) {
+                        confirmTrade(selectedQuote.dexTx.from);
+                    }
+                }
+                resetRefresh();
+            });
+        }
+    }, [cancelRefresh, confirmTrade, refreshCount, resetRefresh, selectedQuote, setSelectedQuote]);
+
+    const { navigateToExchangeForm } = useCoinmarketNavigation(account);
+
+    if (!selectedQuote) return null;
+
+    const { exchange, dexTx } = selectedQuote;
+    if (!exchange || !dexTx) return null;
+
+    const providerName =
+        exchangeInfo?.providerInfos[exchange]?.companyName || selectedQuote.exchange;
+
+    const isFullApproval = !(Number(selectedQuote.preapprovedStringAmount) > 0);
+    const isToken = selectedQuote.send !== account.symbol.toUpperCase();
+
+    if (isFullApproval && approvalType === 'ZERO') {
+        setApprovalType('MINIMAL');
+    }
+
+    const translationValues = {
+        value: selectedQuote.approvalStringAmount,
+        send: selectedQuote.send,
+        provider: providerName,
+    };
+
+    const selectApprovalValue = (type: ExtendedDexApprovalType) => {
+        setApprovalType(type);
+        if (type !== 'APPROVED') {
+            selectedQuote.approvalType = type;
+            confirmTrade(dexTx.from);
+        }
+    };
+
+    return (
+        <Wrapper>
+            <Row>
+                <LabelText>
+                    <Translation id="TR_EXCHANGE_SEND_FROM" />
+                </LabelText>
+                <Value>
+                    <AccountLabeling account={account} />
+                </Value>
+            </Row>
+            <Row>
+                <LabelText>
+                    <Translation
+                        id={
+                            approvalType === 'APPROVED'
+                                ? 'TR_EXCHANGE_SWAP_SEND_TO'
+                                : 'TR_EXCHANGE_APPROVAL_SEND_TO'
+                        }
+                        values={translationValues}
+                    />
+                </LabelText>
+                <Value>
+                    <Address>{dexTx.to}</Address>
+                </Value>
+            </Row>
+
+            {selectedQuote.approvalSendTxHash && (
+                <Row>
+                    <LabelText>
+                        <Translation id="TR_EXCHANGE_APPROVAL_TXID" />
+                    </LabelText>
+                    <Value>
+                        <Address>{selectedQuote.approvalSendTxHash}</Address>
+                    </Value>
+                </Row>
+            )}
+            {selectedQuote.status === 'APPROVAL_PENDING' && (
+                <LoaderWrapper>
+                    <Loader />
+                    <Title>
+                        <Translation id="TR_EXCHANGE_APPROVAL_CONFIRMING" />
+                    </Title>
+                </LoaderWrapper>
+            )}
+            {selectedQuote.status === 'ERROR' && (
+                <ErrorWrapper>
+                    <Title>
+                        <Translation id="TR_EXCHANGE_APPROVAL_FAILED" />
+                    </Title>
+                </ErrorWrapper>
+            )}
+
+            {(selectedQuote.status === 'APPROVAL_REQ' || selectedQuote.status === 'CONFIRM') && (
+                <Row>
+                    <LabelText>
+                        <Translation id="TR_EXCHANGE_APPROVAL_VALUE" />
+                    </LabelText>
+                    {selectedQuote.status === 'APPROVAL_REQ' && (
+                        <>
+                            <Value>
+                                <RadioButton
+                                    isChecked={approvalType === 'MINIMAL'}
+                                    onClick={() => selectApprovalValue('MINIMAL')}
+                                >
+                                    <RadioButtonInner>
+                                        <>
+                                            <P>
+                                                <Translation
+                                                    id="TR_EXCHANGE_APPROVAL_VALUE_MINIMAL"
+                                                    values={translationValues}
+                                                />
+                                            </P>
+                                            <LabelText>
+                                                <Translation
+                                                    id="TR_EXCHANGE_APPROVAL_VALUE_MINIMAL_INFO"
+                                                    values={translationValues}
+                                                />
+                                            </LabelText>
+                                        </>
+                                    </RadioButtonInner>
+                                </RadioButton>
+                            </Value>
+                            <Value>
+                                <RadioButton
+                                    isChecked={approvalType === 'INFINITE'}
+                                    onClick={() => selectApprovalValue('INFINITE')}
+                                >
+                                    <RadioButtonInner>
+                                        <P>
+                                            <Translation
+                                                id="TR_EXCHANGE_APPROVAL_VALUE_INFINITE"
+                                                values={translationValues}
+                                            />
+                                        </P>
+                                        <LabelText>
+                                            <Translation
+                                                id="TR_EXCHANGE_APPROVAL_VALUE_INFINITE_INFO"
+                                                values={translationValues}
+                                            />
+                                        </LabelText>
+                                    </RadioButtonInner>
+                                </RadioButton>
+                            </Value>
+                        </>
+                    )}
+                    {selectedQuote.status !== 'APPROVAL_REQ' && (
+                        <Value>
+                            <RadioButton
+                                isChecked={approvalType === 'APPROVED'}
+                                onClick={() => selectApprovalValue('APPROVED')}
+                            >
+                                <RadioButtonInner>
+                                    <P>
+                                        {!isToken && (
+                                            <Translation
+                                                id="TR_EXCHANGE_APPROVAL_NOT_REQUIRED"
+                                                values={translationValues}
+                                            />
+                                        )}
+                                        {isToken && selectedQuote.approvalSendTxHash && (
+                                            <Translation id="TR_EXCHANGE_APPROVAL_SUCCESS" />
+                                        )}
+                                        {isToken && !selectedQuote.approvalSendTxHash && (
+                                            <Translation id="TR_EXCHANGE_APPROVAL_PREAPPROVED" />
+                                        )}
+                                    </P>
+                                    <LabelText>
+                                        <Translation id="TR_EXCHANGE_APPROVAL_PROCEED" />
+                                    </LabelText>
+                                </RadioButtonInner>
+                            </RadioButton>
+                        </Value>
+                    )}
+                    {isToken && !isFullApproval && (
+                        <Value>
+                            <RadioButton
+                                isChecked={approvalType === 'ZERO'}
+                                onClick={() => selectApprovalValue('ZERO')}
+                            >
+                                <RadioButtonInner>
+                                    <P>
+                                        <Translation
+                                            id="TR_EXCHANGE_APPROVAL_VALUE_ZERO"
+                                            values={translationValues}
+                                        />
+                                    </P>
+                                    <LabelText>
+                                        <Translation
+                                            id="TR_EXCHANGE_APPROVAL_VALUE_ZERO_INFO"
+                                            values={translationValues}
+                                        />
+                                    </LabelText>
+                                </RadioButtonInner>
+                            </RadioButton>
+                        </Value>
+                    )}
+                </Row>
+            )}
+
+            {dexTx.data && (selectedQuote.status !== 'CONFIRM' || approvalType === 'ZERO') && (
+                <Row>
+                    <LabelText>
+                        <Translation id="TR_EXCHANGE_APPROVAL_DATA" />
+                    </LabelText>
+                    <BreakableValue>
+                        <P size="small">
+                            <Truncate>{dexTx.data}</Truncate>
+                        </P>
+                    </BreakableValue>
+                </Row>
+            )}
+
+            {(selectedQuote.status === 'APPROVAL_REQ' ||
+                (selectedQuote.status === 'CONFIRM' && approvalType === 'ZERO')) && (
+                <ButtonWrapper>
+                    <Button
+                        isLoading={callInProgress}
+                        isDisabled={callInProgress}
+                        onClick={sendTransaction}
+                    >
+                        <Translation id="TR_EXCHANGE_CONFIRM_ON_TREZOR_SEND" />
+                    </Button>
+                </ButtonWrapper>
+            )}
+
+            {selectedQuote.status === 'CONFIRM' && approvalType !== 'ZERO' && (
+                <ButtonWrapper>
+                    <Button
+                        isLoading={callInProgress}
+                        isDisabled={callInProgress}
+                        onClick={async () => {
+                            // if the last step was change in approval, we have to recompute the swap request
+                            if (selectedQuote.approvalType) {
+                                selectedQuote.approvalType = undefined;
+                                if (!(await confirmTrade(dexTx.from))) {
+                                    return;
+                                }
+                            }
+                            setExchangeStep('SEND_TRANSACTION');
+                        }}
+                    >
+                        <Translation id="TR_EXCHANGE_APPROVAL_TO_SWAP_BUTTON" />
+                    </Button>
+                </ButtonWrapper>
+            )}
+
+            {selectedQuote.status === 'ERROR' && (
+                <ButtonWrapper>
+                    <Button onClick={navigateToExchangeForm}>
+                        <Translation id="TR_EXCHANGE_DETAIL_ERROR_BUTTON" />
+                    </Button>
+                </ButtonWrapper>
+            )}
+        </Wrapper>
+    );
+};
+
+export default SendApprovalTransactionComponent;

--- a/packages/suite/src/views/wallet/coinmarket/exchange/offers/Offers/SelectedOffer/components/SendSwapTransaction/index.tsx
+++ b/packages/suite/src/views/wallet/coinmarket/exchange/offers/Offers/SelectedOffer/components/SendSwapTransaction/index.tsx
@@ -1,0 +1,376 @@
+import React, { useState } from 'react';
+import styled from 'styled-components';
+import { Translation, AccountLabeling } from '@suite-components';
+import {
+    Button,
+    Icon,
+    Input,
+    P,
+    SelectBar,
+    Tooltip,
+    Truncate,
+    useTheme,
+    variables,
+} from '@trezor/components';
+import { TypedFieldError } from '@wallet-types/form';
+import { useCoinmarketExchangeOffersContext } from '@wallet-hooks/useCoinmarketExchangeOffers';
+import { InputError } from '@wallet-components';
+import useDebounce from 'react-use/lib/useDebounce';
+import BigNumber from 'bignumber.js';
+import { formatCryptoAmount } from '@wallet-utils/coinmarket/coinmarketUtils';
+
+const Wrapper = styled.div`
+    display: flex;
+    flex-direction: column;
+    margin-top: 10px;
+`;
+
+const LabelText = styled.div`
+    font-size: ${variables.FONT_SIZE.TINY};
+    color: ${props => props.theme.TYPE_LIGHT_GREY};
+`;
+
+const Value = styled.div`
+    padding-top: 6px;
+    font-size: ${variables.FONT_SIZE.SMALL};
+    color: ${props => props.theme.TYPE_DARK_GREY};
+    font-weight: ${variables.FONT_WEIGHT.MEDIUM};
+`;
+
+const PaddedValue = styled(Value)`
+    padding-right: 15px;
+`;
+
+const BreakableValue = styled(Value)`
+    word-break: break-all;
+`;
+
+const ButtonWrapper = styled.div`
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    padding-top: 20px;
+    border-top: 1px solid ${props => props.theme.STROKE_GREY};
+    margin: 20px 0;
+`;
+
+const Row = styled.div`
+    margin: 10px 24px;
+`;
+
+const Address = styled.div``;
+
+const Columns = styled.div`
+    display: flex;
+    flex-direction: row;
+`;
+
+const PaddedColumns = styled(Columns)`
+    padding-top: 6px;
+`;
+
+const LeftColumn = styled.div`
+    display: flex;
+    flex: 1;
+`;
+
+const RightColumn = styled.div`
+    display: flex;
+    justify-content: flex-end;
+    flex: 2;
+`;
+
+const Slippage = styled.div`
+    color: ${props => props.theme.TYPE_DARK_GREY};
+    font-weight: ${variables.FONT_WEIGHT.MEDIUM};
+`;
+
+const SlippageAmount = styled(Slippage)`
+    padding-right: 15px;
+`;
+
+const SlippageSettingsRow = styled.div`
+    margin: 0 24px;
+    min-height: 65px;
+`;
+
+const SlippageSettingsButton = styled.button`
+    background: none;
+    border: 0;
+    margin: 0 3px 0 15px;
+    cursor: pointer;
+    display: inline-block;
+    width: 25px;
+    height: auto;
+    position: relative;
+    line-height: 1;
+`;
+
+const StyledInput = styled(Input)`
+    display: flex;
+    flex: 1;
+    max-width: 70px;
+`;
+
+const slippageOptions = [
+    {
+        label: '0.1%',
+        value: '0.1',
+    },
+    {
+        label: '0.5%',
+        value: '0.5',
+    },
+    {
+        label: '1%',
+        value: '1',
+    },
+    {
+        label: '3%',
+        value: '3',
+    },
+    {
+        label: <Translation id="TR_EXCHANGE_SWAP_SLIPPAGE_CUSTOM" />,
+        value: 'CUSTOM',
+    },
+];
+
+const slippageMin = '0.01';
+const slippageMax = '50';
+
+export function formatCryptoAmountAsAmount(
+    amount: number,
+    baseAmount: number,
+    decimals = 8,
+): string {
+    let digits = 4;
+    if (baseAmount < 1) {
+        digits = 6;
+    }
+    if (baseAmount < 0.01) {
+        digits = decimals;
+    }
+    return amount.toFixed(digits);
+}
+
+const SendSwapTransactionComponent = () => {
+    const theme = useTheme();
+    const { account, callInProgress, selectedQuote, exchangeInfo, confirmTrade, sendTransaction } =
+        useCoinmarketExchangeOffersContext();
+    const [slippageSettings, setSlippageSettings] = useState(false);
+    const [slippage, setSlippage] = useState(selectedQuote?.swapSlippage || '1');
+    const [customSlippage, setCustomSlippage] = useState(slippage);
+    const [customSlippageError, setCustomSlippageError] = useState<TypedFieldError | undefined>();
+    useDebounce(
+        () => {
+            if (
+                selectedQuote &&
+                selectedQuote?.dexTx &&
+                !customSlippageError &&
+                customSlippage !== selectedQuote.swapSlippage
+            ) {
+                selectedQuote.swapSlippage = customSlippage;
+                selectedQuote.approvalType = undefined;
+                confirmTrade(selectedQuote.dexTx.from);
+            }
+        },
+        500,
+        [customSlippage, slippage],
+    );
+
+    if (!selectedQuote) return null;
+
+    const { exchange, dexTx, receive, receiveStringAmount } = selectedQuote;
+    if (!exchange || !dexTx) return null;
+
+    const providerName =
+        exchangeInfo?.providerInfos[exchange]?.companyName || selectedQuote.exchange;
+
+    const translationValues = {
+        value: selectedQuote.approvalStringAmount,
+        send: selectedQuote.send,
+        provider: providerName,
+    };
+
+    const toggleSlippage = (e: React.MouseEvent<HTMLButtonElement, MouseEvent>) => {
+        e.preventDefault();
+        setSlippageSettings(!slippageSettings);
+    };
+
+    const selectedSlippage = slippageOptions.find(o => o.value === slippage)?.value || 'CUSTOM';
+
+    const changeSlippage = (value: string) => {
+        setSlippage(value);
+        if (value !== 'CUSTOM') {
+            setCustomSlippage(value);
+            selectedQuote.swapSlippage = value;
+            selectedQuote.approvalType = undefined;
+            confirmTrade(dexTx.from);
+        }
+    };
+
+    const changeCustomSlippage = (event: React.ChangeEvent<HTMLInputElement>) => {
+        const { value } = event.target;
+        setCustomSlippage(value);
+        if (!value) {
+            setCustomSlippageError({
+                type: 'error',
+                message: 'TR_EXCHANGE_SWAP_SLIPPAGE_NOT_SET',
+            });
+            return;
+        }
+        const slippage = new BigNumber(value);
+        if (slippage.isNaN() || value.startsWith('.') || value.endsWith('.')) {
+            setCustomSlippageError({
+                type: 'error',
+                message: 'TR_EXCHANGE_SWAP_SLIPPAGE_NOT_NUMBER',
+            });
+        } else if (slippage.lt(slippageMin) || slippage.gt(slippageMax)) {
+            setCustomSlippageError({
+                type: 'error',
+                message: 'TR_EXCHANGE_SWAP_SLIPPAGE_NOT_IN_RANGE',
+            });
+        } else {
+            setCustomSlippageError(undefined);
+        }
+    };
+
+    return (
+        <Wrapper>
+            <Row>
+                <LabelText>
+                    <Translation id="TR_EXCHANGE_SEND_FROM" />
+                </LabelText>
+                <Value>
+                    <AccountLabeling account={account} />
+                </Value>
+            </Row>
+            <Row>
+                <LabelText>
+                    <Translation id="TR_EXCHANGE_SWAP_SEND_TO" values={translationValues} />
+                </LabelText>
+                <Value>
+                    <Address>{dexTx.to}</Address>
+                </Value>
+            </Row>
+            <Row>
+                <LabelText>
+                    <Translation id="TR_EXCHANGE_SWAP_SLIPPAGE" />
+                </LabelText>
+                <PaddedColumns>
+                    <LeftColumn>
+                        <Slippage>
+                            <Tooltip
+                                content={<Translation id="TR_EXCHANGE_SWAP_SLIPPAGE_INFO" />}
+                                dashed
+                            >
+                                <Translation id="TR_EXCHANGE_SWAP_SLIPPAGE_TOLERANCE" />
+                            </Tooltip>
+                        </Slippage>
+                    </LeftColumn>
+                    <RightColumn>
+                        <SlippageAmount>{selectedQuote.swapSlippage}%</SlippageAmount>
+                        <SlippageSettingsButton type="button" onClick={toggleSlippage}>
+                            <Icon
+                                icon={slippageSettings ? 'ARROW_UP' : 'ARROW_DOWN'}
+                                color={theme.TYPE_DARK_GREY}
+                                size={14}
+                            />
+                        </SlippageSettingsButton>
+                    </RightColumn>
+                </PaddedColumns>
+            </Row>
+            {slippageSettings && (
+                <SlippageSettingsRow>
+                    <PaddedColumns>
+                        <LeftColumn>
+                            <SelectBar
+                                selectedOption={selectedSlippage}
+                                options={slippageOptions}
+                                onChange={changeSlippage}
+                            />
+                        </LeftColumn>
+                        {slippage === 'CUSTOM' && (
+                            <RightColumn>
+                                <StyledInput
+                                    monospace
+                                    noTopLabel
+                                    value={customSlippage}
+                                    variant="small"
+                                    state={customSlippageError ? 'error' : 'success'}
+                                    name="CustomSlippage"
+                                    data-test="CustomSlippage"
+                                    onChange={changeCustomSlippage}
+                                    bottomText={<InputError error={customSlippageError} />}
+                                />
+                            </RightColumn>
+                        )}
+                    </PaddedColumns>
+                </SlippageSettingsRow>
+            )}
+            <Row>
+                <LabelText>
+                    <Translation id="TR_EXCHANGE_SWAP_SLIPPAGE_SUMMARY" />
+                </LabelText>
+                <PaddedValue>
+                    <Columns>
+                        <Translation id="TR_EXCHANGE_SWAP_SLIPPAGE_OFFERED" />
+                        <RightColumn>
+                            {formatCryptoAmount(Number(receiveStringAmount))} {receive}
+                        </RightColumn>
+                    </Columns>
+                </PaddedValue>
+                <PaddedValue>
+                    <Columns>
+                        <Translation id="TR_EXCHANGE_SWAP_SLIPPAGE_AMOUNT" />
+                        <RightColumn>
+                            -
+                            {formatCryptoAmountAsAmount(
+                                (Number(selectedQuote.swapSlippage) / 100) *
+                                    Number(receiveStringAmount),
+                                Number(receiveStringAmount),
+                            )}{' '}
+                            {receive}
+                        </RightColumn>
+                    </Columns>
+                </PaddedValue>
+                <PaddedValue>
+                    <Columns>
+                        <LeftColumn>
+                            <Translation id="TR_EXCHANGE_SWAP_SLIPPAGE_MINIMUM" />
+                        </LeftColumn>
+                        <RightColumn>
+                            {formatCryptoAmountAsAmount(
+                                ((100 - Number(selectedQuote.swapSlippage)) / 100) *
+                                    Number(receiveStringAmount),
+                                Number(receiveStringAmount),
+                            )}{' '}
+                            {receive}
+                        </RightColumn>
+                    </Columns>
+                </PaddedValue>
+            </Row>
+            <Row>
+                <LabelText>
+                    <Translation id="TR_EXCHANGE_SWAP_DATA" />
+                </LabelText>
+                <BreakableValue>
+                    <P size="small">
+                        <Truncate>{dexTx.data}</Truncate>
+                    </P>
+                </BreakableValue>
+            </Row>
+            <ButtonWrapper>
+                <Button
+                    isLoading={callInProgress}
+                    isDisabled={callInProgress}
+                    onClick={sendTransaction}
+                >
+                    <Translation id="TR_EXCHANGE_CONFIRM_ON_TREZOR_SEND" />
+                </Button>
+            </ButtonWrapper>
+        </Wrapper>
+    );
+};
+
+export default SendSwapTransactionComponent;

--- a/packages/suite/src/views/wallet/coinmarket/exchange/offers/Offers/SelectedOffer/index.tsx
+++ b/packages/suite/src/views/wallet/coinmarket/exchange/offers/Offers/SelectedOffer/index.tsx
@@ -6,6 +6,8 @@ import CoinmarketExchangeOfferInfo from '@wallet-components/CoinmarketExchangeOf
 import VerifyAddress from './components/VerifyAddress';
 import SendTransaction from './components/SendTransaction';
 import { Translation } from '@suite-components';
+import SendApprovalTransaction from './components/SendApprovalTransaction';
+import SendSwapTransaction from './components/SendSwapTransaction';
 
 const Wrapper = styled.div`
     display: flex;
@@ -64,6 +66,14 @@ const Middle = styled.div`
     color: ${props => props.theme.STROKE_GREY};
 `;
 
+const MiddleNarrow = styled.div`
+    display: flex;
+    height: 48px;
+    align-items: center;
+    justify-content: center;
+    color: ${props => props.theme.STROKE_GREY};
+`;
+
 const SelectedOffer = () => {
     const { account, selectedQuote, exchangeInfo, exchangeStep, receiveAccount } =
         useCoinmarketExchangeOffersContext();
@@ -78,9 +88,25 @@ const SelectedOffer = () => {
                             <Translation id="TR_EXCHANGE_VERIFY_ADDRESS_STEP" />
                         </Step>
                     </Left>
-                    <Middle>
-                        <Icon icon="ARROW_RIGHT" color={colors.TYPE_LIGHT_GREY} />
-                    </Middle>
+                    {selectedQuote.isDex ? (
+                        <>
+                            <MiddleNarrow>
+                                <Icon icon="ARROW_RIGHT" color={colors.TYPE_LIGHT_GREY} />
+                            </MiddleNarrow>
+                            <Left>
+                                <Step active={exchangeStep === 'SEND_APPROVAL_TRANSACTION'}>
+                                    <Translation id="TR_EXCHANGE_CREATE_APPROVAL_STEP" />
+                                </Step>
+                            </Left>
+                            <MiddleNarrow>
+                                <Icon icon="ARROW_RIGHT" color={colors.TYPE_LIGHT_GREY} />
+                            </MiddleNarrow>
+                        </>
+                    ) : (
+                        <Middle>
+                            <Icon icon="ARROW_RIGHT" color={colors.TYPE_LIGHT_GREY} />
+                        </Middle>
+                    )}
                     <Right>
                         <Step active={exchangeStep === 'SEND_TRANSACTION'}>
                             <Translation id="TR_EXCHANGE_CONFIRM_SEND_STEP" />
@@ -88,7 +114,11 @@ const SelectedOffer = () => {
                     </Right>
                 </Header>
                 {exchangeStep === 'RECEIVING_ADDRESS' && <VerifyAddress />}
-                {exchangeStep === 'SEND_TRANSACTION' && <SendTransaction />}
+                {exchangeStep === 'SEND_TRANSACTION' && !selectedQuote.isDex && <SendTransaction />}
+                {exchangeStep === 'SEND_APPROVAL_TRANSACTION' && <SendApprovalTransaction />}
+                {exchangeStep === 'SEND_TRANSACTION' && selectedQuote.isDex && (
+                    <SendSwapTransaction />
+                )}
             </StyledCard>
             <CoinmarketExchangeOfferInfo
                 selectedQuote={selectedQuote}

--- a/packages/suite/src/views/wallet/coinmarket/exchange/offers/Offers/index.tsx
+++ b/packages/suite/src/views/wallet/coinmarket/exchange/offers/Offers/index.tsx
@@ -71,8 +71,16 @@ const TextAmount = styled(Text)`
 `;
 
 const Offers = () => {
-    const { fixedQuotes, floatQuotes, quotesRequest, selectedQuote, timer, account, getQuotes } =
-        useCoinmarketExchangeOffersContext();
+    const {
+        fixedQuotes,
+        floatQuotes,
+        dexQuotes,
+        quotesRequest,
+        selectedQuote,
+        timer,
+        account,
+        getQuotes,
+    } = useCoinmarketExchangeOffersContext();
     const { setLayout } = useContext(LayoutContext);
     const { navigateToExchangeForm } = useCoinmarketNavigation(account);
 
@@ -81,8 +89,10 @@ const Offers = () => {
     }, [setLayout]);
 
     if (!quotesRequest) return null;
-    const hasLoadingFailed = !(fixedQuotes && floatQuotes);
-    const noOffers = hasLoadingFailed || (fixedQuotes.length === 0 && floatQuotes.length === 0);
+    const hasLoadingFailed = !(fixedQuotes && floatQuotes && dexQuotes);
+    const noOffers =
+        hasLoadingFailed ||
+        (fixedQuotes.length === 0 && floatQuotes.length === 0 && dexQuotes.length === 0);
     return (
         <Wrapper>
             {!selectedQuote && (
@@ -123,8 +133,9 @@ const Offers = () => {
                                     )}
                                 </SummaryRow>
                             </Header>
-                            {fixedQuotes.length > 0 && <List quotes={fixedQuotes} isFixed />}
-                            {floatQuotes.length > 0 && <List quotes={floatQuotes} />}
+                            {dexQuotes.length > 0 && <List quotes={dexQuotes} type="dex" />}
+                            {fixedQuotes.length > 0 && <List quotes={fixedQuotes} type="fixed" />}
+                            {floatQuotes.length > 0 && <List quotes={floatQuotes} type="float" />}
                         </>
                     )}
                 </>

--- a/packages/suite/src/views/wallet/coinmarket/exchange/offers/index.tsx
+++ b/packages/suite/src/views/wallet/coinmarket/exchange/offers/index.tsx
@@ -34,6 +34,7 @@ const OffersIndex = () => {
         device: state.suite.device,
         fixedQuotes: state.wallet.coinmarket.exchange.fixedQuotes,
         floatQuotes: state.wallet.coinmarket.exchange.floatQuotes,
+        dexQuotes: state.wallet.coinmarket.exchange.dexQuotes,
         quotesRequest: state.wallet.coinmarket.exchange.quotesRequest,
         addressVerified: state.wallet.coinmarket.exchange.addressVerified,
         exchangeInfo: state.wallet.coinmarket.exchange.exchangeInfo,

--- a/yarn.lock
+++ b/yarn.lock
@@ -5987,10 +5987,10 @@
   dependencies:
     "@types/node" "*"
 
-"@types/invity-api@^1.0.3":
-  version "1.0.3"
-  resolved "https://registry.yarnpkg.com/@types/invity-api/-/invity-api-1.0.3.tgz#2632a0fe35454384f655004fe09363378524b788"
-  integrity sha512-gBBqQBa7FUTgRovMbPu+OFr672gyZYU+0/ahhIscoCCREtN4K4qkk8rqt29ok5yztfWPp0NPdK8vxjz/jFx8/Q==
+"@types/invity-api@^1.0.5":
+  version "1.0.5"
+  resolved "https://registry.yarnpkg.com/@types/invity-api/-/invity-api-1.0.5.tgz#87e46a0f40c6011c85b00fc80e0d00172f2571a5"
+  integrity sha1-h+RqD0DGARyFsA/IDg0AFy8lcaU=
 
 "@types/is-function@^1.0.0":
   version "1.0.0"


### PR DESCRIPTION
This PR adds a possibility to exchange ETH and ERC20 tokens in a decentralized exchange using smart contract provided by 1Inch.

The functionality extends the existing Exchange Crypto dialogs in the Trade section of the account. If the selected account is ETH (user can choose ETH or ERC20 token as a source) and the target coin is ETH or ERC20, the system gets a DEX quote in addition to the traditional floating/fixed rates quotes.
![image](https://user-images.githubusercontent.com/11609674/142742637-4e658bbe-f943-44e0-a6c5-52c1a6754260.png)

When the DEX quote is selected, the user proceeds through the target account selection (like in standard exchange) and then to two new steps:  
1) approval transaction step (necessary to approve 1Inch's contract to access the user's tokens)
![image](https://user-images.githubusercontent.com/11609674/142742616-343dc153-d238-4af2-b9e1-8d1d4cb00bb6.png)

2) the swap transaction step
![image](https://user-images.githubusercontent.com/11609674/142742659-3338e466-9e7a-4270-a05a-a13bf0d58a50.png)
