### PR TITLE
feat(invity): ReceiveCryptoSelect shows grouped coins in general way

### DIFF
--- a/packages/suite/src/support/messages.ts
+++ b/packages/suite/src/support/messages.ts
@@ -222,18 +222,6 @@ export default defineMessages({
         defaultMessage: 'Loading',
         id: 'TR_EXCHANGE_LOADING',
     },
-    TR_EXCHANGE_OTHER_COINS: {
-        defaultMessage: 'All other coins',
-        id: 'TR_EXCHANGE_OTHER_COINS',
-    },
-    TR_EXCHANGE_POPULAR_COINS: {
-        defaultMessage: 'Popular coins',
-        id: 'TR_EXCHANGE_POPULAR_COINS',
-    },
-    TR_EXCHANGE_STABLE_COINS: {
-        defaultMessage: 'Stablecoins',
-        id: 'TR_EXCHANGE_STABLE_COINS',
-    },
     TR_EXCHANGE_NO_PROVIDERS: {
         defaultMessage: 'No providers',
         id: 'TR_EXCHANGE_NO_PROVIDERS',

--- a/packages/suite/src/views/wallet/coinmarket/exchange/components/ExchangeForm/Inputs/ReceiveCryptoSelect/index.tsx
+++ b/packages/suite/src/views/wallet/coinmarket/exchange/components/ExchangeForm/Inputs/ReceiveCryptoSelect/index.tsx
@@ -50,61 +50,35 @@ const buildOptions = (
 ) => {
     if (!exchangeInfo || !exchangeCoinInfo) return null;
 
-    interface Options {
-        label: React.ReactElement;
+    interface OptionsGroup {
+        label: string;
         options: { label: string; value: string; name: string }[];
     }
 
-    const popular: Options = {
-        label: <Translation id="TR_EXCHANGE_POPULAR_COINS" />,
-        options: [],
-    };
-
-    const stable: Options = {
-        label: <Translation id="TR_EXCHANGE_STABLE_COINS" />,
-        options: [],
-    };
-
-    const all: Options = {
-        label: <Translation id="TR_EXCHANGE_OTHER_COINS" />,
-        options: [],
-    };
-
     const symbolToFilter = symbolToInvityApiSymbol(token || account.symbol);
 
-    const filteredExchangeCoins = exchangeCoinInfo.filter(
-        coin => coin.ticker.toLowerCase() !== symbolToFilter,
-    );
-
-    filteredExchangeCoins.forEach(info => {
-        if (!exchangeInfo.buySymbols.has(info.ticker.toLowerCase())) return false;
-
-        if (info.category === 'Popular currencies') {
-            popular.options.push({
-                label: info.ticker.toUpperCase(),
-                value: info.ticker.toUpperCase(),
-                name: info.name,
+    return exchangeCoinInfo
+        .filter(
+            coin =>
+                coin.ticker &&
+                coin.name &&
+                coin.category &&
+                coin.ticker.toLowerCase() !== symbolToFilter &&
+                exchangeInfo.buySymbols.has(coin.ticker.toLowerCase()),
+        )
+        .reduce((options, coin) => {
+            let category = options.find(option => option.label === coin.category);
+            if (!category) {
+                category = { label: coin.category, options: [] };
+                options.push(category);
+            }
+            category.options.push({
+                label: coin.ticker.toUpperCase(),
+                value: coin.ticker.toUpperCase(),
+                name: coin.name,
             });
-        }
-
-        if (info.category === 'Stablecoins') {
-            stable.options.push({
-                label: `${info.ticker.toUpperCase()}`,
-                value: info.ticker.toUpperCase(),
-                name: info.name,
-            });
-        }
-
-        if (info.category === 'All currencies') {
-            all.options.push({
-                label: `${info.ticker.toUpperCase()}`,
-                value: info.ticker.toUpperCase(),
-                name: info.name,
-            });
-        }
-    });
-
-    return [popular, stable, all];
+            return options;
+        }, [] as OptionsGroup[]);
 };
 
 const ReceiveCryptoSelect = () => {


### PR DESCRIPTION
This PR abstracts rendering of `ReceiveCryptoSelect` options. That means the groups of coins are no longer rendered as hardcoded options, but the options are grouped and rendered based on Invity API data (namely `ExchangeCoinInfo[]`) instead. This change allows us to set groups as needed in time.

**Facts:**
- The change has impact on translations. Names of groups will be in English even if the UI is switched to non-English language, until there will be server with translations (as I heard of this kind of server is planned).
- Users of Suite without this change would be affected by new Invity coin group setting, so Invity will release change in the groups some time after this PR will be part of production release of Suite.