### PR TITLE
fix(suite-native): add @trezor/utxo-lib to extraModules

### DIFF
--- a/packages/suite-native/metro.config.js
+++ b/packages/suite-native/metro.config.js
@@ -47,6 +47,7 @@ module.exports = (async () => {
                     '../../packages/blockchain-link',
                 ),
                 '@trezor/rollout': path.resolve(__dirname, '../../packages/rollout'),
+                '@trezor/utxo-lib': path.resolve(__dirname, '../../packages/utxo-lib'),
             },
             // https://github.com/facebook/metro/issues/265
             blacklistRE: blacklist([


### PR DESCRIPTION
fix for failing suite-native build in develop
![Screenshot from 2021-11-08 10-33-51](https://user-images.githubusercontent.com/3435913/140718032-6900c0ba-791f-4910-aaf4-3ca86ebeefc3.png)

