### PR TITLE
feat: implement aopp for bitcoin and ethereum

### DIFF
--- a/packages/suite-desktop/src/support/Router.tsx
+++ b/packages/suite-desktop/src/support/Router.tsx
@@ -12,6 +12,7 @@ import WalletDetails from '@wallet-views/details';
 import WalletTokens from '@wallet-views/tokens';
 import WalletSend from '@wallet-views/send';
 import WalletSignVerify from '@wallet-views/sign-verify';
+import WalletSignAopp from '@wallet-views/sign-aopp';
 
 import WalletCoinmarketBuy from '@wallet-views/coinmarket/buy';
 import WalletCoinmarketBuyDetail from '@wallet-views/coinmarket/buy/detail';
@@ -40,6 +41,7 @@ const components: { [key: string]: React.ComponentType<any> } = {
     'wallet-tokens': WalletTokens,
     'wallet-send': WalletSend,
     'wallet-sign-verify': WalletSignVerify,
+    'wallet-sign-aopp': WalletSignAopp,
 
     'wallet-coinmarket-buy': WalletCoinmarketBuy,
     'wallet-coinmarket-buy-detail': WalletCoinmarketBuyDetail,

--- a/packages/suite-native/src/support/suite/router.config.ts
+++ b/packages/suite-native/src/support/suite/router.config.ts
@@ -50,6 +50,7 @@ export default [
             { key: getRoute('wallet-receive'), screen: AccountReceive },
             { key: getRoute('wallet-send'), screen: AccountSend },
             { key: getRoute('wallet-sign-verify'), screen: AccountSignVerify },
+            { key: getRoute('wallet-sign-aopp'), screen: AccountSignVerify },
         ],
         navigators: defaultNavigatorsViews,
     },

--- a/packages/suite-web/src/support/Router.tsx
+++ b/packages/suite-web/src/support/Router.tsx
@@ -21,6 +21,9 @@ const components: { [key: string]: React.LazyExoticComponent<any> } = {
     'wallet-sign-verify': lazy(
         () => import(/* webpackChunkName: "wallet" */ '@wallet-views/sign-verify'),
     ),
+    'wallet-sign-aopp': lazy(
+        () => import(/* webpackChunkName: "wallet" */ '@wallet-views/sign-aopp'),
+    ),
 
     // coinmarket
     'wallet-coinmarket-buy': lazy(

--- a/packages/suite/src/components/suite/AccountStickyContent/index.tsx
+++ b/packages/suite/src/components/suite/AccountStickyContent/index.tsx
@@ -88,6 +88,9 @@ const AccountStickyContent = ({ account, routeName }: AccountStickyContentProps)
         if (routeName === 'wallet-sign-verify') {
             return <Translation id="TR_NAV_SIGN_VERIFY" />;
         }
+        if (routeName === 'wallet-sign-aopp') {
+            return <Translation id="TR_NAV_SIGN_AOPP" />;
+        }
     };
 
     return (

--- a/packages/suite/src/components/wallet/AccountTopPanel/components/AccountNavigation/index.tsx
+++ b/packages/suite/src/components/wallet/AccountTopPanel/components/AccountNavigation/index.tsx
@@ -5,7 +5,7 @@ import { Translation } from '@suite-components/Translation';
 import { useActions } from '@suite-hooks';
 import * as routerActions from '@suite-actions/routerActions';
 import * as modalActions from '@suite-actions/modalActions';
-import { hasSignVerify } from '@wallet-utils/accountUtils';
+import { hasFeature } from '@wallet-utils/accountUtils';
 
 interface Props {
     account?: Account;
@@ -95,7 +95,18 @@ const AccountNavigation = (props: Props) => {
             icon: 'SIGN',
             position: 'secondary',
             extra: true,
-            isHidden: () => !account || !hasSignVerify(account),
+            isHidden: () => !account || !hasFeature(account, 'sign-verify'),
+        },
+        {
+            id: 'wallet-sign-aopp',
+            callback: () => {
+                goto('wallet-sign-aopp', undefined, true);
+            },
+            title: <Translation id="TR_NAV_SIGN_AOPP" />,
+            icon: 'SIGN',
+            position: 'secondary',
+            extra: true,
+            isHidden: () => !account || !hasFeature(account, 'aopp'),
         },
     ];
 

--- a/packages/suite/src/config/suite/routes.ts
+++ b/packages/suite/src/config/suite/routes.ts
@@ -129,6 +129,12 @@ const routes = [
         params: walletParams,
     },
     {
+        name: 'wallet-sign-aopp',
+        pattern: '/accounts/sign-aopp',
+        app: 'wallet',
+        params: walletParams,
+    },
+    {
         name: 'wallet-coinmarket-buy',
         pattern: '/accounts/coinmarket/buy',
         app: 'wallet',

--- a/packages/suite/src/config/wallet/networks.ts
+++ b/packages/suite/src/config/wallet/networks.ts
@@ -13,7 +13,7 @@ const networks = [
             tx: 'https://btc1.trezor.io/tx/',
             account: 'https://btc1.trezor.io/xpub/',
         },
-        features: ['rbf', 'sign-verify'],
+        features: ['rbf', 'sign-verify', 'aopp'],
     },
     {
         name: 'Bitcoin (segwit)',
@@ -26,7 +26,7 @@ const networks = [
             tx: 'https://btc1.trezor.io/tx/',
             account: 'https://btc1.trezor.io/xpub/',
         },
-        features: ['rbf', 'sign-verify'],
+        features: ['rbf', 'sign-verify', 'aopp'],
     },
     {
         name: 'Bitcoin (legacy)',
@@ -39,7 +39,7 @@ const networks = [
             tx: 'https://btc1.trezor.io/tx/',
             account: 'https://btc1.trezor.io/xpub/',
         },
-        features: ['rbf', 'sign-verify'],
+        features: ['rbf', 'sign-verify', 'aopp'],
     },
     // Litecoin
     {
@@ -92,7 +92,7 @@ const networks = [
             tx: 'https://eth1.trezor.io/tx/',
             account: 'https://eth1.trezor.io/address/',
         },
-        features: ['sign-verify'],
+        features: ['sign-verify', 'aopp'],
         label: 'TR_NETWORK_ETHEREUM_LABEL',
         tooltip: 'TR_NETWORK_ETHEREUM_TOOLTIP',
     },
@@ -269,7 +269,7 @@ const networks = [
             tx: 'https://tbtc1.trezor.io/tx/',
             account: 'https://tbtc1.trezor.io/xpub/',
         },
-        features: ['rbf', 'sign-verify'],
+        features: ['rbf', 'sign-verify', 'aopp'],
     },
     {
         name: 'Bitcoin Testnet (segwit)',
@@ -284,7 +284,7 @@ const networks = [
             tx: 'https://tbtc1.trezor.io/tx/',
             account: 'https://tbtc1.trezor.io/xpub/',
         },
-        features: ['rbf', 'sign-verify'],
+        features: ['rbf', 'sign-verify', 'aopp'],
     },
     {
         name: 'Bitcoin Testnet (legacy)',
@@ -299,7 +299,7 @@ const networks = [
             tx: 'https://tbtc1.trezor.io/tx/',
             account: 'https://tbtc1.trezor.io/xpub/',
         },
-        features: ['rbf', 'sign-verify'],
+        features: ['rbf', 'sign-verify', 'aopp'],
     },
     {
         name: 'Ethereum Ropsten',
@@ -314,7 +314,7 @@ const networks = [
             tx: 'https://ropsten1.trezor.io/tx/',
             account: 'https://ropsten1.trezor.io/address/',
         },
-        features: ['sign-verify'],
+        features: ['sign-verify', 'aopp'],
     },
     {
         name: 'XRP Testnet',

--- a/packages/suite/src/support/messages.ts
+++ b/packages/suite/src/support/messages.ts
@@ -2170,6 +2170,16 @@ export default defineMessages({
         description: 'Used as a label for message input field in Sign and Verify form',
         id: 'TR_MESSAGE',
     },
+    TR_AOPP_URI: {
+        defaultMessage: 'AOPP URI',
+        description: 'Used as a label for AOPP input field in Sign AOPP form',
+        id: 'TR_AOPP_URI',
+    },
+    TR_UNEXPECTED_AOPP_URI: {
+        defaultMessage: 'unexpected URI',
+        description: 'Used as an error message when the URI cannot be parsed',
+        id: 'TR_UNEXPECTED_AOPP_URI',
+    },
     TR_MINED_TIME: {
         defaultMessage: 'Mined Time',
         id: 'TR_MINED_TIME',
@@ -2217,6 +2227,11 @@ export default defineMessages({
         description:
             'Title of the navigation tab that contains a form for signing and verifying messages',
         id: 'TR_NAV_SIGN_AND_VERIFY',
+    },
+    TR_NAV_SIGN_AOPP: {
+        defaultMessage: 'Sign AOPP request',
+        description: 'Title of the navigation tab that contains a form for signing an AOPP request',
+        id: 'TR_NAV_SIGN_AOPP',
     },
     TR_NAV_TRANSACTIONS: {
         defaultMessage: 'Overview',
@@ -2720,6 +2735,11 @@ export default defineMessages({
         defaultMessage: 'Sign',
         description: 'Sign button in Sign and Verify form',
         id: 'TR_SIGN',
+    },
+    TR_SIGN_AND_SUBMIT: {
+        defaultMessage: 'Sign and submit',
+        description: 'Sign and submit button in Aopp form',
+        id: 'TR_SIGN_AND_SUBMIT',
     },
     TR_SIGN_MESSAGE: {
         defaultMessage: 'Sign message',
@@ -4870,6 +4890,10 @@ export default defineMessages({
     TR_NAV_SIGN_VERIFY: {
         id: 'TR_NAV_SIGN_VERIFY',
         defaultMessage: 'Sign/Verify message',
+    },
+    TR_NAV_SIGN_AOPP_REQUEST: {
+        id: 'TR_NAV_SIGN_AOPP_REQUEST',
+        defaultMessage: 'Sign an AOPP request',
     },
     TR_BALANCE: {
         id: 'TR_BALANCE',

--- a/packages/suite/src/utils/wallet/accountUtils.ts
+++ b/packages/suite/src/utils/wallet/accountUtils.ts
@@ -578,11 +578,11 @@ export const getPendingAccount = (
     };
 };
 
-export const hasSignVerify = (account: Account) =>
+export const hasFeature = (account: Account, feature: string) =>
     !!NETWORKS.find(
         ({ networkType, symbol, accountType, features }) =>
             networkType === account.networkType &&
             symbol === account.symbol &&
             (accountType || 'normal') === account.accountType &&
-            (features || []).includes('sign-verify'),
+            (features || []).includes(feature),
     );

--- a/packages/suite/src/views/wallet/sign-aopp/aopp.tsx
+++ b/packages/suite/src/views/wallet/sign-aopp/aopp.tsx
@@ -1,0 +1,58 @@
+import { MAX_LENGTH_MESSAGE } from '@suite/hooks/wallet/sign-verify/useSignVerifyForm';
+
+const AOPP_VERSION = 0;
+
+export const validateUri = (uri: string, network: string | undefined): boolean => {
+    let url;
+    try {
+        url = new URL(uri.replace(/\s/g, ''));
+    } catch (error) {
+        return false;
+    }
+    if (url.protocol !== 'aopp:') {
+        return false;
+    }
+    if (url.searchParams.get('v') !== AOPP_VERSION.toString()) {
+        return false;
+    }
+    switch (network) {
+        case 'bitcoin':
+            if (url.searchParams.get('asset') !== 'btc') {
+                return false;
+            }
+            if (url.searchParams.get('format') !== 'any') {
+                return false;
+            }
+            break;
+        case 'ethereum':
+            if (url.searchParams.get('asset') !== 'eth') {
+                return false;
+            }
+            if (url.searchParams.get('format') !== 'standard') {
+                return false;
+            }
+            break;
+        default:
+    }
+    if (String(url.searchParams.get('msg')).length > MAX_LENGTH_MESSAGE) {
+        return false;
+    }
+    return true;
+};
+
+export const submitProof = async (uri: string, address: string, signature: string) => {
+    const url = new URL(uri).searchParams.get('callback');
+    if (url) {
+        await fetch(url, {
+            method: 'POST',
+            headers: {
+                'Content-Type': 'application/json',
+            },
+            body: JSON.stringify({
+                version: AOPP_VERSION,
+                address,
+                signature,
+            }),
+        });
+    }
+};

--- a/packages/suite/src/views/wallet/sign-aopp/index.tsx
+++ b/packages/suite/src/views/wallet/sign-aopp/index.tsx
@@ -1,0 +1,181 @@
+import React, { useEffect, useState } from 'react';
+import styled from 'styled-components';
+import { Button, Textarea, Card } from '@trezor/components';
+import { useForm, useController } from 'react-hook-form';
+import { WalletLayout, WalletLayoutHeader } from '@wallet-components';
+import { Translation } from '@suite-components';
+import { useActions, useDevice, useSelector, useTranslation } from '@suite-hooks';
+import { sign as signAction } from '@wallet-actions/signVerifyActions';
+import SignAddressInput from '../sign-verify/components/SignAddressInput';
+import { submitProof, validateUri } from './aopp';
+import {
+    AddressItem,
+    useSignAddressOptions,
+} from '@suite/hooks/wallet/sign-verify/useSignAddressOptions';
+
+const Row = styled.div`
+    display: flex;
+    justify-content: center;
+    & + & {
+        padding-top: 12px;
+    }
+`;
+
+const StyledButton = styled(Button)`
+    width: 230px;
+`;
+
+const Form = styled.form`
+    padding: 42px;
+`;
+
+type AoppFields = {
+    uri: string;
+    address: string;
+    path: string;
+};
+
+const DEFAULT_VALUES: AoppFields = {
+    uri: '',
+    address: '',
+    path: '',
+};
+
+const SignAopp = () => {
+    const [addressUsed, setAddressUsed] = useState<AddressItem | null>(null);
+    const { selectedAccount, revealedAddresses } = useSelector(state => ({
+        selectedAccount: state.wallet.selectedAccount,
+        revealedAddresses: state.wallet.receive,
+    }));
+
+    const {
+        register,
+        handleSubmit,
+        formState: { errors },
+        reset,
+        clearErrors,
+        control,
+    } = useForm<AoppFields>({
+        mode: 'onBlur',
+        reValidateMode: 'onChange',
+        defaultValues: DEFAULT_VALUES,
+    });
+
+    const { isLocked } = useDevice();
+    const { translationString } = useTranslation();
+
+    const { field: pathField } = useController({
+        control,
+        name: 'path',
+        rules: {
+            required: translationString('TR_SELL_VALIDATION_ERROR_EMPTY'),
+        },
+    });
+
+    const { getValue } = useSignAddressOptions(selectedAccount.account, revealedAddresses);
+
+    const pathFieldAttrs = {
+        value: pathField.value,
+        onBlur: pathField.onBlur,
+        onChange: (addr: { path: string; address: string } | null) => {
+            clearErrors(['path', 'address']);
+            pathField.onChange(addr?.path || '');
+            setAddressUsed(getValue(addr?.path || ''));
+        },
+        isDisabled: selectedAccount.account?.networkType === 'ethereum',
+    };
+
+    const { sign } = useActions({
+        sign: signAction,
+    });
+
+    const uriRef = register({
+        validate: v =>
+            validateUri(v, selectedAccount.account?.networkType)
+                ? undefined
+                : translationString('TR_UNEXPECTED_AOPP_URI'),
+    });
+
+    const onSubmit = async (data: AoppFields) => {
+        const { path, uri } = data;
+        const msg = new URL(uri.replace(/\s/g, '')).searchParams.get('msg');
+        if (msg) {
+            const result = await sign(path, msg, false);
+            if (result?.signSignature) {
+                let address;
+                let signature = result.signSignature;
+                switch (selectedAccount.account?.networkType) {
+                    case 'bitcoin':
+                        address = addressUsed?.label;
+                        break;
+                    case 'ethereum':
+                        address = selectedAccount.account?.descriptor;
+                        signature = Buffer.from(signature, 'hex').toString('base64');
+                        break;
+                    default:
+                        break;
+                }
+                if (address) await submitProof(uri, address, signature);
+            }
+        }
+    };
+
+    const formErrors = {
+        uri: errors.uri?.message,
+        address: errors.address?.message,
+        path: errors.path?.message,
+    };
+
+    const errorState = (err?: string) => (err ? 'error' : undefined);
+
+    useEffect(() => {
+        const overrideValues =
+            selectedAccount.account?.networkType === 'ethereum'
+                ? {
+                      path: selectedAccount.account.path,
+                  }
+                : {};
+        reset({
+            ...DEFAULT_VALUES,
+            ...overrideValues,
+        });
+    }, [reset, selectedAccount.account]);
+
+    return (
+        <WalletLayout title="TR_NAV_SIGN_AOPP" account={selectedAccount}>
+            <WalletLayoutHeader title="TR_NAV_SIGN_AOPP" />
+            <Card noPadding>
+                <Form onSubmit={handleSubmit(onSubmit)}>
+                    <Row>
+                        <Textarea
+                            name="uri"
+                            label={<Translation id="TR_AOPP_URI" />}
+                            innerRef={uriRef}
+                            state={errorState(formErrors.uri)}
+                            bottomText={formErrors.uri}
+                            rows={2}
+                            maxRows={2}
+                        />
+                    </Row>
+                    <Row>
+                        <SignAddressInput
+                            name="path"
+                            label={<Translation id="TR_ADDRESS" />}
+                            account={selectedAccount.account}
+                            revealedAddresses={revealedAddresses}
+                            error={formErrors.path}
+                            {...pathFieldAttrs}
+                        />
+                    </Row>
+                    <Row>
+                        <StyledButton type="submit" isDisabled={isLocked()}>
+                            <Translation id="TR_SIGN_AND_SUBMIT" />
+                        </StyledButton>
+                    </Row>
+                </Form>
+            </Card>
+        </WalletLayout>
+    );
+};
+
+export default SignAopp;


### PR DESCRIPTION
This PR implements [Address Ownership Proof Protocol](https://aopp.group) support as outlined in https://github.com/trezor/trezor-firmware/issues/1586. The issue is somewhat misplaced, as support doesn't require any changes in the firmware.

For testing, the AOPP testing backend can be used:
- To receive a Bitcoin AOPP URI: https://testing.aopp.group
- To receive a Ethereum AOPP URI: https://testing.aopp.group/?asset=eth&format=standard

The blue button then links to the URI. After successful proof submission, the address should show up on the page.

What's unfortunately yet missing is URI support. This PR at the moment implements a form field where an AOPP URI can be pasted. Clearly, this is far inferior to URI support from a UX perspective. Unfortunately so far I could not get my local dev setup to support even `bitcoin:` URIs, but I'll keep trying. If anybody wants to help out with this it would be greatly appreciated.
