### PR TITLE
Chore/bump address validation

### DIFF
--- a/packages/suite/package.json
+++ b/packages/suite/package.json
@@ -61,7 +61,7 @@
         "redux-thunk": "^2.3.0",
         "semver": "^7.3.5",
         "styled-components": "5.1.1",
-        "trezor-address-validator": "^0.3.22",
+        "trezor-address-validator": "^0.4.0",
         "trezor-connect": "8.2.2-beta.4",
         "ua-parser-js": "^0.7.28",
         "uuid": "^8.3.2",

--- a/packages/suite/src/support/messages.ts
+++ b/packages/suite/src/support/messages.ts
@@ -4975,6 +4975,10 @@ export default defineMessages({
         defaultMessage: 'Address is not valid',
         id: 'RECIPIENT_IS_NOT_VALID',
     },
+    RECIPIENT_IS_NOT_SUPPORTED: {
+        defaultMessage: 'Unsupported address format.',
+        id: 'RECIPIENT_IS_NOT_SUPPORTED',
+    },
     RECIPIENT_FORMAT_DEPRECATED: {
         defaultMessage: 'Unsupported address format. {TR_LEARN_MORE}',
         id: 'RECIPIENT_FORMAT_DEPRECATED',

--- a/packages/suite/src/utils/wallet/__tests__/validation.test.ts
+++ b/packages/suite/src/utils/wallet/__tests__/validation.test.ts
@@ -13,23 +13,32 @@ describe('validation', () => {
         // BTC valid
         expect(isAddressValid('12QeMLzSrB8XH8FvEzPMVoRxVAzTr5XM2y', 'btc')).toEqual(true);
         expect(isAddressValid('3FyVFsEyyBPzHjD3qUEgX7Jsn4tcHNZFkn', 'btc')).toEqual(true);
-        expect(isAddressValid('bc1zw508d6qejxtdg4y5r3zarvaryvg6kdaj', 'btc')).toEqual(true);
-        expect(
-            isAddressValid(
-                'bc1pw508d6qejxtdg4y5r3zarvary0c5xw7kw508d6qejxtdg4y5r3zarvary0c5xw7k7grplx',
-                'btc',
-            ),
-        ).toEqual(true);
-        expect(isAddressValid('BC1SW50QA3JX3S', 'btc')).toEqual(true);
         expect(isAddressValid('BC1QW508D6QEJXTDG4Y5R3ZARVARY0C5XW7KV8F3T4', 'btc')).toEqual(true);
+        expect(isAddressValid('bc1qafk4yhqvj4wep57m62dgrmutldusqde8adh20d', 'btc')).toEqual(true); // p2pkh
+        expect(
+            isAddressValid('bc1q6rgl33d3s9dugudw7n68yrryajkr3ha9q8q24j20zs62se4q9tsqdy0t2q', 'btc'),
+        ).toEqual(true); // p2wsh
+        expect(
+            isAddressValid('bc1p5cyxnuxmeuwuvkwfem96lqzszd02n6xdcjrs20cac6yqjjwudpxqkedrcr', 'btc'),
+        ).toEqual(true); // p2tr
 
         // BTC invalid
         expect(isAddressValid('mzBc4XEFSdzCDcTxAgf6EZXgsZWpztRhef', 'btc')).toEqual(false);
         expect(isAddressValid('2MxKEf2su6FGAUfCEAHreGFQvEYrfYNHvL7', 'btc')).toEqual(false);
         expect(isAddressValid('bc1qw508d6qejxtdg4y5r3zarvary0c5xw7kv8f3t5', 'btc')).toEqual(false);
+        expect(isAddressValid('bc1zw508d6qejxtdg4y5r3zarvaryvg6kdaj', 'btc')).toEqual(false); // p2w-unknown
         expect(
             isAddressValid('tb1qrp33g0q5c5txsp9arysrx4k6zdkfs4nce4xj0gdcccefvpysxf3q0sl5k7', 'btc'),
         ).toEqual(false); // testnet address
+        expect(isAddressValid('BC1SW50QA3JX3S', 'btc')).toEqual(false); // p2w-unknown
+        expect(isAddressValid('bc1zw508d6qejxtdg4y5r3zarvaryvaxxpcs', 'btc')).toEqual(false); // version 2
+        expect(isAddressValid('BC1SW50QGDZ25J', 'btc')).toEqual(false); // version 16
+        expect(
+            isAddressValid(
+                'bc1pw508d6qejxtdg4y5r3zarvary0c5xw7kw508d6qejxtdg4y5r3zarvary0c5xw7k7grplx',
+                'btc',
+            ),
+        ).toEqual(false); // p2w-unknown
 
         // TEST valid
         expect(isAddressValid('mzBc4XEFSdzCDcTxAgf6EZXgsZWpztRhef', 'test')).toEqual(true);
@@ -40,6 +49,18 @@ describe('validation', () => {
                 'test',
             ),
         ).toEqual(true);
+        expect(
+            isAddressValid(
+                'tb1qusxlgq9quu27ucxs7a2fg8nv0pycdzvxsjk9npyupupxw3y892ssaskm8v',
+                'test',
+            ),
+        ).toEqual(true); // p2wsh
+        expect(
+            isAddressValid(
+                'tb1pn2d0yjeedavnkd8z8lhm566p0f2utm3lgvxrsdehnl94y34txmts5s7t4c',
+                'test',
+            ),
+        ).toEqual(true); // taproot
         expect(isAddressValid('GSa5espVLNseXEfKt46zEdS6jrPkmFghBU', 'test')).toEqual(true); // regtest
 
         // TEST invalid

--- a/packages/suite/src/utils/wallet/__tests__/validation.test.ts
+++ b/packages/suite/src/utils/wallet/__tests__/validation.test.ts
@@ -2,6 +2,7 @@ import {
     isAddressValid,
     isDecimalsValid,
     isInteger,
+    isTaprootAddress,
     isBech32AddressUppercase,
     isAddressDeprecated,
     isHexValid,
@@ -134,6 +135,29 @@ describe('validation', () => {
         expect(isInteger('a01')).toBe(false);
         expect(isInteger('0a1')).toBe(false);
         expect(isInteger('01a')).toBe(false);
+    });
+
+    it('isTaprootAddress', () => {
+        expect(isTaprootAddress('', 'btc')).toBe(false);
+        expect(isTaprootAddress('bc1zw508d6qejxtdg4y5r3zarvaryvg6kdaj', 'btc')).toBe(false);
+        expect(
+            isTaprootAddress(
+                'bc1q6rgl33d3s9dugudw7n68yrryajkr3ha9q8q24j20zs62se4q9tsqdy0t2q',
+                'btc',
+            ),
+        ).toBe(false);
+        expect(
+            isTaprootAddress(
+                'bc1p5cyxnuxmeuwuvkwfem96lqzszd02n6xdcjrs20cac6yqjjwudpxqkedrcr',
+                'btc',
+            ),
+        ).toBe(true);
+        expect(
+            isTaprootAddress(
+                'tb1pn2d0yjeedavnkd8z8lhm566p0f2utm3lgvxrsdehnl94y34txmts5s7t4c',
+                'test',
+            ),
+        ).toEqual(true);
     });
 
     it('isBech32AddressUppercase', () => {

--- a/packages/suite/src/utils/wallet/validation.ts
+++ b/packages/suite/src/utils/wallet/validation.ts
@@ -37,6 +37,15 @@ export const isAddressDeprecated = (address: string, symbol: Account['symbol']) 
     }
 };
 
+export const isTaprootAddress = (address: string, symbol: Account['symbol']) => {
+    const networkType = isTestnet(symbol) ? 'testnet' : 'prod';
+    const updatedSymbol = getCoinFromTestnet(symbol);
+    return (
+        addressValidator.getAddressType(address, updatedSymbol.toUpperCase(), networkType) ===
+        'p2tr'
+    );
+};
+
 export const isBech32AddressUppercase = (address: string) =>
     /^(bc1|tb1|ltc1|tltc1)/.test(address.toLowerCase()) && /[A-Z]/.test(address);
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -25181,12 +25181,13 @@ tree-kill@^1.2.1, tree-kill@^1.2.2:
   resolved "https://registry.yarnpkg.com/tree-kill/-/tree-kill-1.2.2.tgz#4ca09a9092c88b73a7cdc5e8a01b507b0790a0cc"
   integrity sha512-L0Orpi8qGpRG//Nd+H90vFB+3iHnue1zSSGmNOOCh1GLJ7rUKVwV2HvijphGQS2UmhUZewS9VgvxYIdgr+fG1A==
 
-trezor-address-validator@^0.3.22:
-  version "0.3.22"
-  resolved "https://registry.yarnpkg.com/trezor-address-validator/-/trezor-address-validator-0.3.22.tgz#1769d1338c2d5c2a5b67ea04b1758563c2bf1c7a"
-  integrity sha512-98G8Y3q7WbkjmSYOT0RN088OJhRbPb4lncPQ+6v1jh+O48G5q5xUxE38Jvq6J1DJLsI3Qx1FHuO6vUXrOfs4Ow==
+trezor-address-validator@^0.4.0:
+  version "0.4.0"
+  resolved "https://registry.yarnpkg.com/trezor-address-validator/-/trezor-address-validator-0.4.0.tgz#691e2e48b6e7b331596f0a884b357b0fe10e53d4"
+  integrity sha512-yr7lamnEjHvxVEk+EcSFCdKxrWBeYL+LfKmqYLcj89qEJLsvF7Ncwqug5I1INtTgJx0GpZNUJupcroOJM/0mSQ==
   dependencies:
     base-x "^3.0.7"
+    bech32 "^2.0.0"
     browserify-bignum "^1.3.0-2"
     cbor-js "^0.1.0"
     crc "^3.8.0"


### PR DESCRIPTION
- update `trezor-address-validation` lib with Taproot support
- add send form Taproot address validation (may not be supported by FW version)

![Screenshot from 2021-11-10 10-28-41](https://user-images.githubusercontent.com/3435913/141088262-334ffb19-f38f-41e0-bbb8-0224ebad2fe3.png)


tagging @martinboehm and @LukasRada, maybe you want to do same validation in invity?