### PR TITLE
Fix/fw update remembered device macos

### DIFF
--- a/packages/suite/src/middlewares/wallet/storageMiddleware.ts
+++ b/packages/suite/src/middlewares/wallet/storageMiddleware.ts
@@ -106,7 +106,7 @@ const storageMiddleware =
             }
 
             case SUITE.UPDATE_SELECTED_DEVICE:
-                if (isDeviceRemembered(action.payload)) {
+                if (isDeviceRemembered(action.payload) && action.payload.mode === 'normal') {
                     storageActions.saveDevice(action.payload);
                 }
                 break;

--- a/packages/suite/src/reducers/suite/deviceReducer.ts
+++ b/packages/suite/src/reducers/suite/deviceReducer.ts
@@ -25,6 +25,7 @@ export const isUnlocked = (features: Features): boolean =>
 const merge = (device: AcquiredDevice, upcoming: Partial<AcquiredDevice>): TrezorDevice => ({
     ...device,
     ...upcoming,
+    id: upcoming.id ?? device.id,
     state: device.state,
     instance: device.instance,
     features: {
@@ -141,8 +142,10 @@ const changeDevice = (
     const affectedDevices = draft.filter(
         d =>
             d.features &&
-            d.connected &&
-            (d.id === device.id || (d.path.length > 0 && d.path === device.path)),
+            ((d.connected &&
+                (d.id === device.id || (d.path.length > 0 && d.path === device.path))) ||
+                // update "disconnected" remembered devices if in bootloader mode
+                (d.mode === 'bootloader' && d.remember && d.id === device.id)),
     ) as AcquiredDevice[];
 
     const otherDevices = draft.filter(d => affectedDevices.indexOf(d as AcquiredDevice) === -1);

--- a/packages/suite/src/views/firmware/FirmwareCustom.tsx
+++ b/packages/suite/src/views/firmware/FirmwareCustom.tsx
@@ -15,6 +15,7 @@ import {
     ReconnectDevicePrompt,
     SelectCustomFirmware,
 } from '@firmware-components';
+import * as suiteActions from '@suite-actions/suiteActions';
 
 const ModalContent = styled.div`
     text-align: left;
@@ -25,9 +26,9 @@ const FirmwareCustom = () => {
     const { device: liveDevice } = useDevice();
     const cachedDevice = useCachedDevice(liveDevice);
     const [firmwareBinary, setFirmwareBinary] = useState<ArrayBuffer>();
-
-    const { closeModalApp } = useActions({
+    const { closeModalApp, acquireDevice } = useActions({
         closeModalApp: routerActions.closeModalApp,
+        acquireDevice: suiteActions.acquireDevice,
     });
 
     const onFirmwareSelected = (fw: ArrayBuffer) => {
@@ -51,6 +52,9 @@ const FirmwareCustom = () => {
     };
 
     const onClose = () => {
+        if (liveDevice?.status !== 'available') {
+            acquireDevice(liveDevice);
+        }
         closeModalApp();
         resetReducer();
     };

--- a/packages/suite/src/views/firmware/index.tsx
+++ b/packages/suite/src/views/firmware/index.tsx
@@ -13,6 +13,7 @@ import { Translation, Modal } from '@suite-components';
 import { OnboardingStepBox } from '@onboarding-components';
 import { useActions, useFirmware, useSelector } from '@suite-hooks';
 import { ConfirmOnDevice, Icon, useTheme } from '@trezor/components';
+import * as suiteActions from '@suite-actions/suiteActions';
 
 const Wrapper = styled.div`
     display: flex;
@@ -40,11 +41,15 @@ const Firmware = () => {
     const { device } = useSelector(state => ({
         device: state.suite.device,
     }));
-    const { closeModalApp } = useActions({
+    const { closeModalApp, acquireDevice } = useActions({
         closeModalApp: routerActions.closeModalApp,
+        acquireDevice: suiteActions.acquireDevice,
     });
 
     const onClose = () => {
+        if (device?.status !== 'available') {
+            acquireDevice(device);
+        }
         closeModalApp();
         resetReducer();
     };


### PR DESCRIPTION
Close #4307

This is only macOS problem when updating Trezor 1 while having remembered accounts.

> fix(suite): no update of remembered device in indexDB if bootloader mode

- if user refreshes app to cancel firmware update (before fw update starts) he ended with remembered devices in bootloader mode

> chore(suite): acquire device after fw update if not available

- remembered devices are sometimes changed to be `occupied` or `used` after fw update, acquire them when closing fw update modal

> fix(suite): update remembered devices in bootloader mode

- remembered devices are turned into `bootloader` mode so they lose `id`. When fw update is `done`, they are also disconnected so they lose `path`. We can get their `id` from `state` and refresh them.
