### PR TITLE
Fix/random fixes

### DIFF
--- a/packages/suite-build/configs/desktop.webpack.config.ts
+++ b/packages/suite-build/configs/desktop.webpack.config.ts
@@ -18,15 +18,7 @@ const config: webpack.Configuration = {
     },
     plugins: [
         new CopyPlugin({
-            patterns: [
-                'bin',
-                'fonts',
-                'guide',
-                'images',
-                'message-system',
-                'translations',
-                'videos',
-            ]
+            patterns: ['bin', 'fonts', 'images', 'message-system', 'videos']
                 .map(dir => ({
                     from: path.join(__dirname, '..', '..', 'suite-data', 'files', dir),
                     to: path.join(baseDir, 'build', 'static', dir),

--- a/packages/suite-build/configs/desktop.webpack.config.ts
+++ b/packages/suite-build/configs/desktop.webpack.config.ts
@@ -9,6 +9,9 @@ import { assetPrefix, isDev, launchElectron } from '../utils/env';
 import { getPathForProject } from '../utils/path';
 import ShellSpawnPlugin from '../plugins/shell-spawn-plugin';
 
+const electronArgsIndex = process.argv.indexOf('./webpack.config.ts') + 1;
+const electronArgs = process.argv.slice(electronArgsIndex);
+
 const baseDir = getPathForProject('desktop');
 const config: webpack.Configuration = {
     target: 'browserslist:Chrome >= 94', // Electron 15
@@ -59,7 +62,7 @@ const config: webpack.Configuration = {
                           },
                           {
                               command: 'yarn',
-                              args: ['run', 'dev:run'],
+                              args: ['run', 'dev:run', ...electronArgs],
                           },
                       ]
                     : []),

--- a/packages/suite-build/configs/web.webpack.config.ts
+++ b/packages/suite-build/configs/web.webpack.config.ts
@@ -18,16 +18,7 @@ const config: webpack.Configuration = {
     },
     plugins: [
         new CopyPlugin({
-            patterns: [
-                'browser-detection',
-                'fonts',
-                'guide',
-                'images',
-                'message-system',
-                'oauth',
-                'translations',
-                'videos',
-            ]
+            patterns: ['browser-detection', 'fonts', 'images', 'message-system', 'oauth', 'videos']
                 .map(dir => ({
                     from: path.join(__dirname, '..', '..', 'suite-data', 'files', dir),
                     to: path.join(baseDir, 'build', 'static', dir),

--- a/packages/suite-data/index.ts
+++ b/packages/suite-data/index.ts
@@ -3,26 +3,9 @@ import * as rm from 'rimraf';
 import { resolve, join } from 'path';
 
 const config = {
-    'suite-desktop': [
-        'bin',
-        'fonts',
-        'guide',
-        'images',
-        'message-system',
-        'translations',
-        'videos',
-    ],
-    'suite-native': ['fonts', 'guide', 'images', 'message-system', 'videos'],
-    'suite-web': [
-        'browser-detection',
-        'fonts',
-        'guide',
-        'images',
-        'message-system',
-        'oauth',
-        'translations',
-        'videos',
-    ],
+    'suite-desktop': ['bin', 'fonts', 'images', 'message-system', 'videos'],
+    'suite-native': ['fonts', 'images', 'message-system', 'videos'],
+    'suite-web': ['browser-detection', 'fonts', 'images', 'message-system', 'oauth', 'videos'],
     'suite-web-landing': ['fonts', 'images/icons/favicon', 'images/suite-web-landing'],
 };
 

--- a/packages/suite-desktop/src-electron/app.ts
+++ b/packages/suite-desktop/src-electron/app.ts
@@ -9,6 +9,7 @@ import { MIN_HEIGHT, MIN_WIDTH } from '@desktop-electron/libs/screen';
 import Logger, { LogLevel, defaultOptions as loggerDefaults } from '@desktop-electron/libs/logger';
 import { buildInfo, computerInfo } from '@desktop-electron/libs/info';
 import modules from '@desktop-electron/libs/modules';
+import { createInterceptor } from '@desktop-electron/libs/request-interceptor';
 
 let mainWindow: BrowserWindow;
 const src = isDev
@@ -81,11 +82,14 @@ const init = async () => {
     logger.debug('init', `Load URL (${src})`);
     mainWindow.loadURL(src);
 
+    const interceptor = createInterceptor();
+
     // Modules
     await modules({
         mainWindow,
         src,
         store,
+        interceptor,
     });
 };
 

--- a/packages/suite-desktop/src-electron/index.d.ts
+++ b/packages/suite-desktop/src-electron/index.d.ts
@@ -51,11 +51,21 @@ declare interface ILogger {
     level: LogLevel;
 }
 
+declare type BeforeRequestListener = (
+    details: Electron.OnBeforeRequestListenerDetails,
+) => Electron.Response | undefined;
+
+declare interface RequestInterceptor {
+    onBeforeRequest(listener: BeforeRequestListener): void;
+    offBeforeRequest(listener: BeforeRequestListener): void;
+}
+
 // Dependencies
 declare type Dependencies = {
     mainWindow: Electron.BrowserWindow;
     store: LocalStore;
     src: string;
+    interceptor: RequestInterceptor;
 };
 
 // Store

--- a/packages/suite-desktop/src-electron/libs/request-interceptor.ts
+++ b/packages/suite-desktop/src-electron/libs/request-interceptor.ts
@@ -1,0 +1,33 @@
+import { session } from 'electron';
+
+// Should be used for all webRequest.on* events as there can be only
+// one listener for each of them, but sometimes we need to bind more
+// of them
+export const createInterceptor = (): RequestInterceptor => {
+    let beforeRequestListeners: BeforeRequestListener[] = [];
+
+    const filter = { urls: ['*://*/*'] };
+    session.defaultSession.webRequest.onBeforeRequest(filter, (details, callback) => {
+        for (let i = 0; i < beforeRequestListeners.length; ++i) {
+            const res = beforeRequestListeners[i](details);
+            if (res) {
+                callback(res);
+                return;
+            }
+        }
+        callback({ cancel: false });
+    });
+
+    const onBeforeRequest = (listener: BeforeRequestListener) => {
+        beforeRequestListeners.push(listener);
+    };
+
+    const offBeforeRequest = (listener: BeforeRequestListener) => {
+        beforeRequestListeners = beforeRequestListeners.filter(f => f !== listener);
+    };
+
+    return {
+        onBeforeRequest,
+        offBeforeRequest,
+    };
+};

--- a/packages/suite-desktop/src-electron/modules/request-filter.ts
+++ b/packages/suite-desktop/src-electron/modules/request-filter.ts
@@ -1,22 +1,21 @@
 /**
  * Request Filter feature (blocks non-allowed requests and displays a warning)
  */
-import { dialog, session } from 'electron';
+import { dialog } from 'electron';
 
 import * as config from '../config';
 
-const init = ({ mainWindow }: Dependencies) => {
+const init = ({ mainWindow, interceptor }: Dependencies) => {
     const { logger } = global;
 
     const resourceTypeFilter = ['xhr']; // What resource types we want to filter
     const caughtDomainExceptions: string[] = []; // Domains that have already shown an exception
-    session.defaultSession.webRequest.onBeforeRequest({ urls: ['*://*/*'] }, (details, cb) => {
+    interceptor.onBeforeRequest(details => {
         if (!resourceTypeFilter.includes(details.resourceType)) {
             logger.debug(
                 'request-filter',
                 `${details.url} was allowed because its resource type (${details.resourceType}) is not filtered`,
             );
-            cb({ cancel: false });
             return;
         }
 
@@ -27,7 +26,6 @@ const init = ({ mainWindow }: Dependencies) => {
                 'request-filter',
                 `${details.url} was allowed because ${hostname} is in the exception list`,
             );
-            cb({ cancel: false });
             return;
         }
 
@@ -44,7 +42,7 @@ const init = ({ mainWindow }: Dependencies) => {
             'request-filter',
             `${details.url} was blocked because ${hostname} is not in the exception list`,
         );
-        cb({ cancel: true });
+        return { cancel: true };
     });
 };
 

--- a/packages/suite-desktop/src-electron/preload.ts
+++ b/packages/suite-desktop/src-electron/preload.ts
@@ -1,7 +1,5 @@
 import { contextBridge, ipcRenderer } from 'electron';
 
-import type { SuiteThemeVariant } from '@suite-types';
-
 // todo: would be great to have these channels strongly typed. for example this is nice reading: https://blog.logrocket.com/electron-ipc-response-request-architecture-with-typescript/
 const validChannels = [
     // oauth

--- a/packages/suite-native/index.d.ts
+++ b/packages/suite-native/index.d.ts
@@ -1,3 +1,5 @@
+/// <reference path="../suite/global.d.ts" />
+
 declare module '*.svg';
 
 // declare module '*.svg' {

--- a/packages/suite-native/src/utils/suite/env.ts
+++ b/packages/suite-native/src/utils/suite/env.ts
@@ -1,5 +1,4 @@
 import { Appearance, Platform, Dimensions } from 'react-native';
-import { SuiteThemeVariant } from '@suite-types';
 
 /**
  * override for suite/utils/env - getUserAgent

--- a/packages/suite/global.d.ts
+++ b/packages/suite/global.d.ts
@@ -1,5 +1,7 @@
+type SuiteThemeVariant = 'light' | 'dark' | 'custom';
+
 // Interface for exposed Electron API (ipcRenderer)
-export interface DesktopApi {
+interface DesktopApi {
     on: (channel: string, func: (...args: any[]) => any) => void;
     once: (channel: string, func: (...args: any[]) => any) => void;
     removeAllListeners: (channel: string) => void;
@@ -37,15 +39,13 @@ export interface DesktopApi {
     installUdevRules: () => Promise<{ success: true } | { success: false; error: string }>;
 }
 
-declare global {
-    interface Window {
-        __REDUX_DEVTOOLS_EXTENSION_COMPOSE__?: (props: any) => any | null;
-        desktopApi?: DesktopApi; // Electron API
-        chrome?: any; // Only in Chromium browsers
+interface Window {
+    __REDUX_DEVTOOLS_EXTENSION_COMPOSE__?: (props: any) => any | null;
+    desktopApi?: DesktopApi; // Electron API
+    chrome?: any; // Only in Chromium browsers
 
-        // Needed for Cypress
-        Cypress?: any;
-        TrezorConnect?: any;
-        store?: any;
-    }
+    // Needed for Cypress
+    Cypress?: any;
+    TrezorConnect?: any;
+    store?: any;
 }

--- a/packages/suite/src/actions/settings/languageActions.ts
+++ b/packages/suite/src/actions/settings/languageActions.ts
@@ -1,4 +1,3 @@
-import { resolveStaticPath } from '@suite-utils/build';
 import { SUITE } from '@suite-actions/constants';
 import { Dispatch } from '@suite-types';
 import type { Locale } from '@suite-config/languages';
@@ -10,8 +9,8 @@ export const fetchLocale = (locale: Locale) => async (dispatch: Dispatch) => {
     const localeOverride: { [key: string]: string } =
         loc === 'en'
             ? {}
-            : await fetch(resolveStaticPath(`translations/${loc}.json`))
-                  .then(res => (res.ok ? res.json() : Promise.reject()))
+            : await import(`@trezor/suite-data/files/translations/${loc}.json`)
+                  .then(res => res.default)
                   .catch(() => ({}));
 
     dispatch({

--- a/packages/suite/src/actions/suite/suiteActions.ts
+++ b/packages/suite/src/actions/suite/suiteActions.ts
@@ -12,7 +12,6 @@ import type {
     TrezorDevice,
     ButtonRequest,
     AppState,
-    SuiteThemeVariant,
     SuiteThemeColors,
 } from '@suite-types';
 import type { DebugModeOptions, AutodetectSettings } from '@suite-reducers/suiteReducer';

--- a/packages/suite/src/actions/wallet/graphActions.ts
+++ b/packages/suite/src/actions/wallet/graphActions.ts
@@ -13,6 +13,7 @@ import {
 import { Account } from '@wallet-types';
 import { GraphRange, GraphScale, GraphData } from '@wallet-types/graph';
 import {
+    ensureHistoryRates,
     accountGraphDataFilterFn,
     deviceGraphDataFilterFn,
     enhanceBlockchainAccountHistory,
@@ -87,8 +88,10 @@ export const fetchAccountGraphData =
         });
 
         if (response?.success) {
+            const responseWithRates = await ensureHistoryRates(account.symbol, response.payload);
+
             const enhancedResponse = enhanceBlockchainAccountHistory(
-                response.payload,
+                responseWithRates,
                 account.symbol,
             );
 

--- a/packages/suite/src/components/suite/Settings/components/Theme.tsx
+++ b/packages/suite/src/components/suite/Settings/components/Theme.tsx
@@ -3,7 +3,7 @@ import * as suiteActions from '@suite-actions/suiteActions';
 import { Translation } from '@suite-components/Translation';
 import { SectionItem, ActionColumn, ActionSelect, TextColumn } from '@suite-components/Settings';
 import { useActions, useSelector, useTranslation } from '@suite-hooks';
-import type { SuiteThemeVariant, SuiteThemeVariantOptions } from '@suite-types';
+import type { SuiteThemeVariantOptions } from '@suite-types';
 
 const useThemeOptions = () => {
     const { translationString } = useTranslation();

--- a/packages/suite/src/hooks/suite/useLocales.ts
+++ b/packages/suite/src/hooks/suite/useLocales.ts
@@ -11,6 +11,7 @@ export const useLocales = () => {
     }));
 
     useEffect(() => {
+        let active = true;
         const loadLocale = async () => {
             const lang = language === 'en' ? 'en-US' : language;
 
@@ -24,10 +25,15 @@ export const useLocales = () => {
                     `date-fns language: ${language} is not available. Using en-US fallback.`,
                 );
             }
-            setLocale(dateLocale);
+            if (active) {
+                setLocale(dateLocale);
+            }
         };
 
         loadLocale();
+        return () => {
+            active = false;
+        };
     }, [language]);
 
     return locale;

--- a/packages/suite/src/reducers/suite/suiteReducer.ts
+++ b/packages/suite/src/reducers/suite/suiteReducer.ts
@@ -2,7 +2,7 @@ import produce from 'immer';
 import { TRANSPORT, TransportInfo } from 'trezor-connect';
 import { SUITE, STORAGE } from '@suite-actions/constants';
 import { DISCOVERY } from '@wallet-actions/constants';
-import { Action, TrezorDevice, Lock, SuiteThemeVariant, SuiteThemeColors } from '@suite-types';
+import { Action, TrezorDevice, Lock, SuiteThemeColors } from '@suite-types';
 import type { Locale } from '@suite-config/languages';
 import { isWeb } from '@suite-utils/env';
 import { ensureLocale } from '@suite-utils/l10n';

--- a/packages/suite/src/services/coingecko.ts
+++ b/packages/suite/src/services/coingecko.ts
@@ -65,17 +65,11 @@ const fetchCoinGecko = async (url: string) => {
     }
 };
 
-const getTickerConfig = (ticker: TickerId) => {
+export const getTickerConfig = (ticker: TickerId) =>
     // for token find its main network
-    const config = FIAT_CONFIG.tickers.find(t =>
+    FIAT_CONFIG.tickers.find(t =>
         ticker.tokenAddress ? t.symbol === ticker.mainNetworkSymbol : t.symbol === ticker.symbol,
     );
-
-    if (!config) {
-        console.error('buildCoinUrl: cannot find ticker config for ', ticker);
-    }
-    return config;
-};
 
 /**
  * Build coinUrl using defined coin ids
@@ -85,7 +79,10 @@ const getTickerConfig = (ticker: TickerId) => {
  */
 const buildCoinUrl = (ticker: TickerId) => {
     const config = getTickerConfig(ticker);
-    if (!config) return null;
+    if (!config) {
+        console.error('buildCoinUrl: cannot find ticker config for ', ticker);
+        return null;
+    }
 
     return `${COINGECKO_API_BASE_URL}/coins/${config.coingeckoId}`;
 };

--- a/packages/suite/src/types/suite/index.ts
+++ b/packages/suite/src/types/suite/index.ts
@@ -131,6 +131,5 @@ export type InjectedModalApplicationProps = {
 };
 
 export type ToastNotificationVariant = 'success' | 'info' | 'warning' | 'error' | 'transparent';
-export type SuiteThemeVariant = 'light' | 'dark' | 'custom';
 export type SuiteThemeVariantOptions = 'light' | 'dark' | 'system';
 export type EnvironmentType = 'web' | 'desktop' | 'mobile' | '';

--- a/packages/suite/src/utils/suite/env.ts
+++ b/packages/suite/src/utils/suite/env.ts
@@ -1,6 +1,6 @@
 import UAParser from 'ua-parser-js';
 
-import type { SuiteThemeVariant, EnvironmentType } from '@suite-types';
+import type { EnvironmentType } from '@suite-types';
 
 /* This way, we can override simple utils, which helps to polyfill methods which are not available in react-native. */
 export const getUserAgent = () => window.navigator.userAgent;


### PR DESCRIPTION
Random fixes and improvements. They should be independent on each other, so if there's a problem with any of them, it could be omitted.

https://github.com/trezor/trezor-suite/commit/bd7d31445d38019d5ed57f5e23da53da677582f5 - electron's `session.defaultSession.webRequest` is unable to bind multiple listeners to one event, which caused `tor` module overwriting `request-filter` module. Therefore, `RequestInterceptor` was created to hold multiple listeners and call them one by one in a single function passed to original webRequest.
https://github.com/trezor/trezor-suite/commit/a987f3e01370f37e0bb97be20780a3e4627b69d6 - in `PassphraseTypeCard`, `submit` was called during rendering phase which causes rerendering of the component and error. Now it's called inside `useEffect`.
https://github.com/trezor/trezor-suite/commit/f6afecd011b6dae83e590f073ffb9fbcecc05ce6 - async effect was calling setState even if parent component was unmounted.
https://github.com/trezor/trezor-suite/commit/c50d4c6f39a4728f7e1aff01cf6fea1afc422641 - even if there is fallback to coingecko fiat rates everywhere else, graph in dashboard relied solely on fiat rates from blockbook. Now, missing rates are filled from coingecko as well, which is a prerequisite for other backends.
https://github.com/trezor/trezor-suite/commit/5da82de04b4e20ced0bfdb5b258af3fe1c2cee2d - `SuiteThemeVariant` type, which is needed in both web suite and electron's `DesktopApi`, was moved to `global.d.ts`, where DesktopApi is defined.
https://github.com/trezor/trezor-suite/commit/62ca0e270064185a54c23b2a19490d2d02b0ae5a - instead of fetching, translated jsons are now dynamically imported in the same way as guide files, therefore copying of `guide` and `translations` folders could be (hopefully) removed.
https://github.com/trezor/trezor-suite/commit/a0b5db5c56f810b0e9de9e4394225e8cdd2042d8 - arguments are now propagated from `desktop.webpack.config.ts` to `yarn dev:run`, so it's possible to call e.g. `yarn suite:dev:desktop --log-level=info`