### PR TITLE
fix(invity): coinmarket set full width for exchange form

### DIFF
--- a/packages/suite/src/views/wallet/coinmarket/exchange/components/ExchangeForm/index.tsx
+++ b/packages/suite/src/views/wallet/coinmarket/exchange/components/ExchangeForm/index.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { Translation } from '@suite-components';
 import { useCoinmarketExchangeFormContext } from '@wallet-hooks/useCoinmarketExchangeForm';
-import { Wrapper, FeesWrapper, NoProviders } from '@wallet-views/coinmarket';
+import { Wrapper, FeesWrapper, NoProviders, FullWidthForm } from '@wallet-views/coinmarket';
 import { CoinmarketSkeleton } from '@wallet-views/coinmarket/skeleton';
 import Inputs from './Inputs';
 import Fees from './Fees';
@@ -19,13 +19,13 @@ const CoinmarketExchangeForm = () => {
                 </NoProviders>
             )}
             {!isLoading && !noProviders && (
-                <form onSubmit={handleSubmit(onSubmit)}>
+                <FullWidthForm onSubmit={handleSubmit(onSubmit)}>
                     <Inputs />
                     <FeesWrapper>
                         <Fees />
                     </FeesWrapper>
                     <Footer />
-                </form>
+                </FullWidthForm>
             )}
         </Wrapper>
     );

--- a/packages/suite/src/views/wallet/coinmarket/index.tsx
+++ b/packages/suite/src/views/wallet/coinmarket/index.tsx
@@ -17,6 +17,10 @@ export const Wrapper = styled.div<ResponsiveSize>`
     }
 `;
 
+export const FullWidthForm = styled.form`
+    width: 100%;
+`;
+
 export const Left = styled.div`
     display: flex;
     flex: 1;


### PR DESCRIPTION
@tomasklim reported this behavior when resizing width of browser:
![image](https://user-images.githubusercontent.com/7394177/141490787-9cc0c03b-9723-44c5-9b57-fe435581d1fa.png)

Solution is to set `width: 100%` to the `form`