### PR TITLE
feat(invity): coinmarket buy/exchange account/address selection

### DIFF
--- a/packages/suite/src/actions/wallet/coinmarket/__fixtures__/coinmarketCommonActions/verifyAddress.ts
+++ b/packages/suite/src/actions/wallet/coinmarket/__fixtures__/coinmarketCommonActions/verifyAddress.ts
@@ -6,7 +6,7 @@ const { getSuiteDevice } = global.JestMocks;
 const UNAVAILABLE_DEVICE = getSuiteDevice({ available: false });
 const AVAILABLE_DEVICE = getSuiteDevice({ available: true, connected: true });
 
-export const VERIFY_ADDRESS_FIXTURES = [
+export const VERIFY_BUY_ADDRESS_FIXTURES = [
     {
         description: 'verifyAddress, bitcoin account',
         initialState: {
@@ -16,7 +16,9 @@ export const VERIFY_ADDRESS_FIXTURES = [
         },
         params: {
             account: BTC_ACCOUNT,
-            inExchange: false,
+            address: BTC_ACCOUNT.addresses?.unused[0].address,
+            path: BTC_ACCOUNT.addresses?.unused[0].path,
+            coinmarketAction: COINMARKET_BUY.VERIFY_ADDRESS as typeof COINMARKET_BUY.VERIFY_ADDRESS,
         },
         result: {
             value: BTC_ACCOUNT.addresses?.unused[0].address,
@@ -48,7 +50,9 @@ export const VERIFY_ADDRESS_FIXTURES = [
         },
         params: {
             account: BTC_ACCOUNT,
-            inExchange: false,
+            address: BTC_ACCOUNT.addresses?.unused[0].address,
+            path: BTC_ACCOUNT.addresses?.unused[0].path,
+            coinmarketAction: COINMARKET_BUY.VERIFY_ADDRESS as typeof COINMARKET_BUY.VERIFY_ADDRESS,
         },
         result: {
             value: BTC_ACCOUNT.addresses?.unused[0].address,
@@ -66,38 +70,6 @@ export const VERIFY_ADDRESS_FIXTURES = [
                 },
                 {
                     type: COINMARKET_BUY.VERIFY_ADDRESS,
-                    addressVerified: BTC_ACCOUNT.addresses?.unused[0].address,
-                },
-            ],
-        },
-    },
-    {
-        description: 'verifyAddress, bitcoin account, in exchange',
-        initialState: {
-            suite: {
-                device: AVAILABLE_DEVICE,
-            },
-        },
-        params: {
-            account: BTC_ACCOUNT,
-            inExchange: true,
-        },
-        result: {
-            value: BTC_ACCOUNT.addresses?.unused[0].address,
-            actions: [
-                {
-                    type: MODAL.OPEN_USER_CONTEXT,
-                    payload: {
-                        type: 'address',
-                        device: AVAILABLE_DEVICE,
-                        address: BTC_ACCOUNT.addresses?.unused[0].address,
-                        networkType: BTC_ACCOUNT.networkType,
-                        symbol: BTC_ACCOUNT.symbol,
-                        addressPath: BTC_ACCOUNT.addresses?.unused[0].path,
-                    },
-                },
-                {
-                    type: COINMARKET_EXCHANGE.VERIFY_ADDRESS,
                     addressVerified: BTC_ACCOUNT.addresses?.unused[0].address,
                 },
             ],
@@ -112,7 +84,9 @@ export const VERIFY_ADDRESS_FIXTURES = [
         },
         params: {
             account: ETH_ACCOUNT,
-            inExchange: false,
+            address: ETH_ACCOUNT.descriptor,
+            path: ETH_ACCOUNT.path,
+            coinmarketAction: COINMARKET_BUY.VERIFY_ADDRESS as typeof COINMARKET_BUY.VERIFY_ADDRESS,
         },
         result: {
             value: ETH_ACCOUNT.descriptor,
@@ -144,7 +118,9 @@ export const VERIFY_ADDRESS_FIXTURES = [
         },
         params: {
             account: XRP_ACCOUNT,
-            inExchange: false,
+            address: XRP_ACCOUNT.descriptor,
+            path: XRP_ACCOUNT.path,
+            coinmarketAction: COINMARKET_BUY.VERIFY_ADDRESS as typeof COINMARKET_BUY.VERIFY_ADDRESS,
         },
         result: {
             value: XRP_ACCOUNT.descriptor,
@@ -176,7 +152,9 @@ export const VERIFY_ADDRESS_FIXTURES = [
         },
         params: {
             account: XRP_ACCOUNT,
-            inExchange: false,
+            address: XRP_ACCOUNT.descriptor,
+            path: XRP_ACCOUNT.path,
+            coinmarketAction: COINMARKET_BUY.VERIFY_ADDRESS as typeof COINMARKET_BUY.VERIFY_ADDRESS,
         },
         result: {
             value: undefined,
@@ -191,6 +169,44 @@ export const VERIFY_ADDRESS_FIXTURES = [
                         symbol: XRP_ACCOUNT.symbol,
                         addressPath: XRP_ACCOUNT.path,
                     },
+                },
+            ],
+        },
+    },
+];
+
+export const VERIFY_EXCHANGE_ADDRESS_FIXTURES = [
+    {
+        description: 'verifyAddress, bitcoin account, in exchange',
+        initialState: {
+            suite: {
+                device: AVAILABLE_DEVICE,
+            },
+        },
+        params: {
+            account: BTC_ACCOUNT,
+            address: BTC_ACCOUNT.addresses?.unused[0].address,
+            path: BTC_ACCOUNT.addresses?.unused[0].path,
+            coinmarketAction:
+                COINMARKET_EXCHANGE.VERIFY_ADDRESS as typeof COINMARKET_EXCHANGE.VERIFY_ADDRESS,
+        },
+        result: {
+            value: BTC_ACCOUNT.addresses?.unused[0].address,
+            actions: [
+                {
+                    type: MODAL.OPEN_USER_CONTEXT,
+                    payload: {
+                        type: 'address',
+                        device: AVAILABLE_DEVICE,
+                        address: BTC_ACCOUNT.addresses?.unused[0].address,
+                        networkType: BTC_ACCOUNT.networkType,
+                        symbol: BTC_ACCOUNT.symbol,
+                        addressPath: BTC_ACCOUNT.addresses?.unused[0].path,
+                    },
+                },
+                {
+                    type: COINMARKET_EXCHANGE.VERIFY_ADDRESS,
+                    addressVerified: BTC_ACCOUNT.addresses?.unused[0].address,
                 },
             ],
         },

--- a/packages/suite/src/actions/wallet/coinmarket/__tests__/coinmarketCommonActions.test.ts
+++ b/packages/suite/src/actions/wallet/coinmarket/__tests__/coinmarketCommonActions.test.ts
@@ -4,7 +4,10 @@ import coinmarketReducer, { ComposedTransactionInfo } from '@wallet-reducers/coi
 import selectedAccountReducer from '@wallet-reducers/selectedAccountReducer';
 import * as coinmarketCommonActions from '../coinmarketCommonActions';
 import { DEFAULT_STORE } from '../__fixtures__/coinmarketCommonActions/store';
-import { VERIFY_ADDRESS_FIXTURES } from '../__fixtures__/coinmarketCommonActions/verifyAddress';
+import {
+    VERIFY_BUY_ADDRESS_FIXTURES,
+    VERIFY_EXCHANGE_ADDRESS_FIXTURES,
+} from '../__fixtures__/coinmarketCommonActions/verifyAddress';
 import transactionReducer from '@wallet-reducers/transactionReducer';
 
 export const getInitialState = (initial = {}) => ({
@@ -102,18 +105,40 @@ describe('Coinmarket Common Actions', () => {
         jest.clearAllMocks();
     });
 
-    VERIFY_ADDRESS_FIXTURES.forEach(f => {
+    VERIFY_BUY_ADDRESS_FIXTURES.forEach(f => {
         it(f.description, async () => {
             const store = initStore(getInitialState(f.initialState));
 
             await store.dispatch(
-                coinmarketCommonActions.verifyAddress(f.params.account, f.params.inExchange),
+                coinmarketCommonActions.verifyAddress(
+                    f.params.account,
+                    f.params.address,
+                    f.params.path,
+                    f.params.coinmarketAction,
+                ),
             );
-            expect(
-                f.params.inExchange
-                    ? store.getState().wallet.coinmarket.exchange.addressVerified
-                    : store.getState().wallet.coinmarket.buy.addressVerified,
-            ).toEqual(f.result.value);
+            expect(store.getState().wallet.coinmarket.buy.addressVerified).toEqual(f.result.value);
+            if (f.result && f.result.actions) {
+                expect(store.getActions()).toMatchObject(f.result.actions);
+            }
+        });
+    });
+
+    VERIFY_EXCHANGE_ADDRESS_FIXTURES.forEach(f => {
+        it(f.description, async () => {
+            const store = initStore(getInitialState(f.initialState));
+
+            await store.dispatch(
+                coinmarketCommonActions.verifyAddress(
+                    f.params.account,
+                    f.params.address,
+                    f.params.path,
+                    f.params.coinmarketAction,
+                ),
+            );
+            expect(store.getState().wallet.coinmarket.exchange.addressVerified).toEqual(
+                f.result.value,
+            );
             if (f.result && f.result.actions) {
                 expect(store.getActions()).toMatchObject(f.result.actions);
             }

--- a/packages/suite/src/actions/wallet/coinmarket/coinmarketCommonActions.ts
+++ b/packages/suite/src/actions/wallet/coinmarket/coinmarketCommonActions.ts
@@ -24,11 +24,20 @@ export type CoinmarketCommonAction =
       };
 
 export const verifyAddress =
-    (account: Account, inExchange = false) =>
+    (
+        account: Account,
+        address: string | undefined,
+        path: string | undefined,
+        coinmarketAction:
+            | typeof COINMARKET_EXCHANGE.VERIFY_ADDRESS
+            | typeof COINMARKET_BUY.VERIFY_ADDRESS,
+    ) =>
     async (dispatch: Dispatch, getState: GetState) => {
         const { device } = getState().suite;
         if (!device || !account) return;
-        const { path, address } = getUnusedAddressFromAccount(account);
+        const accountAddress = getUnusedAddressFromAccount(account);
+        address ??= accountAddress.address;
+        path ??= accountAddress.path;
         if (!path || !address) return;
 
         const { networkType, symbol } = account;
@@ -96,9 +105,7 @@ export const verifyAddress =
 
         if (response.success) {
             dispatch({
-                type: inExchange
-                    ? COINMARKET_EXCHANGE.VERIFY_ADDRESS
-                    : COINMARKET_BUY.VERIFY_ADDRESS,
+                type: coinmarketAction,
                 addressVerified: address,
             });
         } else {

--- a/packages/suite/src/actions/wallet/coinmarketBuyActions.ts
+++ b/packages/suite/src/actions/wallet/coinmarketBuyActions.ts
@@ -5,6 +5,7 @@ import { COINMARKET_BUY, COINMARKET_COMMON } from './constants';
 import { Dispatch } from '@suite-types';
 import regional from '@wallet-constants/coinmarket/regional';
 import * as modalActions from '@suite-actions/modalActions';
+import { verifyAddress as verifyBuyAddress } from '@wallet-actions/coinmarket/coinmarketCommonActions';
 
 export interface BuyInfo {
     buyInfo?: BuyListResponse;
@@ -151,3 +152,6 @@ export const saveQuotes = (
 export const clearQuotes = (): CoinmarketBuyAction => ({
     type: COINMARKET_BUY.CLEAR_QUOTES,
 });
+
+export const verifyAddress = (account: Account, address?: string, path?: string) =>
+    verifyBuyAddress(account, address, path, COINMARKET_BUY.VERIFY_ADDRESS);

--- a/packages/suite/src/actions/wallet/coinmarketExchangeActions.ts
+++ b/packages/suite/src/actions/wallet/coinmarketExchangeActions.ts
@@ -10,6 +10,7 @@ import {
 import invityAPI from '@suite-services/invityAPI';
 import { COINMARKET_EXCHANGE, COINMARKET_COMMON } from './constants';
 import * as modalActions from '@suite-actions/modalActions';
+import { verifyAddress as verifyExchangeAddress } from '@wallet-actions/coinmarket/coinmarketCommonActions';
 
 export interface ExchangeInfo {
     exchangeList?: ExchangeListResponse;
@@ -156,3 +157,6 @@ export const saveQuotes = (
 export const clearQuotes = (): CoinmarketExchangeAction => ({
     type: COINMARKET_EXCHANGE.CLEAR_QUOTES,
 });
+
+export const verifyAddress = (account: Account, address?: string, path?: string) =>
+    verifyExchangeAddress(account, address, path, COINMARKET_EXCHANGE.VERIFY_ADDRESS);

--- a/packages/suite/src/hooks/wallet/useCoinmarketBuyOffers.ts
+++ b/packages/suite/src/hooks/wallet/useCoinmarketBuyOffers.ts
@@ -51,7 +51,7 @@ export const useOffers = (props: Props) => {
         addNotification: notificationActions.addToast,
         saveTransactionDetailId: coinmarketBuyActions.saveTransactionDetailId,
         submitRequestForm: coinmarketCommonActions.submitRequestForm,
-        verifyAddress: coinmarketCommonActions.verifyAddress,
+        verifyAddress: coinmarketBuyActions.verifyAddress,
         goto: routerActions.goto,
     });
 

--- a/packages/suite/src/hooks/wallet/useCoinmarketExchangeOffers.ts
+++ b/packages/suite/src/hooks/wallet/useCoinmarketExchangeOffers.ts
@@ -3,7 +3,6 @@ import invityAPI from '@suite-services/invityAPI';
 import { useActions, useSelector, useDevice } from '@suite-hooks';
 import { useTimer } from '@suite-hooks/useTimeInterval';
 import { ExchangeCoinInfo, ExchangeTrade } from 'invity-api';
-import * as coinmarketCommonActions from '@wallet-actions/coinmarket/coinmarketCommonActions';
 import * as coinmarketExchangeActions from '@wallet-actions/coinmarketExchangeActions';
 import * as routerActions from '@suite-actions/routerActions';
 import { Account } from '@wallet-types';
@@ -73,7 +72,7 @@ export const useOffers = (props: Props) => {
             coinmarketExchangeActions.openCoinmarketExchangeConfirmModal,
         saveTransactionId: coinmarketExchangeActions.saveTransactionId,
         addNotification: notificationActions.addToast,
-        verifyAddress: coinmarketCommonActions.verifyAddress,
+        verifyAddress: coinmarketExchangeActions.verifyAddress,
     });
 
     const { invityAPIUrl, exchangeCoinInfo, accounts } = useSelector(state => ({

--- a/packages/suite/src/support/messages.ts
+++ b/packages/suite/src/support/messages.ts
@@ -3903,6 +3903,10 @@ export default defineMessages({
         id: 'RECEIVE_TABLE_NOT_USED',
         defaultMessage: 'Unused',
     },
+    RECEIVE_TABLE_USED: {
+        id: 'RECEIVE_TABLE_USED',
+        defaultMessage: 'Used',
+    },
     TR_SHOW_MORE: {
         defaultMessage: 'Show more',
         description: 'Show more used address',

--- a/packages/suite/src/types/wallet/coinmarketBuyOffers.ts
+++ b/packages/suite/src/types/wallet/coinmarketBuyOffers.ts
@@ -27,7 +27,7 @@ export type ContextValues = {
     quotes: AppState['wallet']['coinmarket']['buy']['quotes'];
     device: AppState['suite']['device'];
     selectedQuote?: BuyTrade;
-    verifyAddress: (account: Account) => Promise<void>;
+    verifyAddress: (account: Account, address?: string, path?: string) => Promise<void>;
     addressVerified: AppState['wallet']['coinmarket']['buy']['addressVerified'];
     providersInfo?: BuyInfo['providerInfos'];
     selectQuote: (quote: BuyTrade) => void;

--- a/packages/suite/src/types/wallet/coinmarketExchangeOffers.ts
+++ b/packages/suite/src/types/wallet/coinmarketExchangeOffers.ts
@@ -34,7 +34,7 @@ export type ContextValues = {
     exchangeStep: ExchangeStep;
     setExchangeStep: (step: ExchangeStep) => void;
     selectQuote: (quote: ExchangeTrade) => void;
-    verifyAddress: (account: Account, inExchange: boolean) => Promise<void>;
+    verifyAddress: (account: Account, address?: string, path?: string) => Promise<void>;
     receiveSymbol?: string;
     receiveAccount?: Account;
     setReceiveAccount: (account?: Account) => void;

--- a/packages/suite/src/views/wallet/coinmarket/common/AddressOptions/index.tsx
+++ b/packages/suite/src/views/wallet/coinmarket/common/AddressOptions/index.tsx
@@ -1,0 +1,139 @@
+import React, { useEffect } from 'react';
+import styled from 'styled-components';
+import type { AccountAddress } from 'trezor-connect';
+import { Translation, HiddenPlaceholder, FiatValue } from '@suite-components';
+import { variables, Select } from '@trezor/components';
+import { UseFormMethods, Control, Controller } from 'react-hook-form';
+import { formatNetworkAmount } from '@wallet-utils/accountUtils';
+import type { Account } from '@wallet-types';
+import { useAccountAddressDictionary } from '@wallet-hooks/useAccounts';
+
+const AddressWrapper = styled.div`
+    display: flex;
+    flex-direction: column;
+`;
+
+const FiatWrapper = styled.div`
+    padding: 0 0 0 3px;
+`;
+
+const PathWrapper = styled.div`
+    padding: 0 3px 0 3px;
+`;
+
+const Amount = styled.div`
+    display: flex;
+    font-size: ${variables.FONT_SIZE.TINY};
+    color: ${props => props.theme.TYPE_LIGHT_GREY};
+    font-weight: ${variables.FONT_WEIGHT.MEDIUM};
+`;
+
+const Address = styled.div`
+    display: flex;
+    font-weight: ${variables.FONT_WEIGHT.MEDIUM};
+`;
+
+const Option = styled.div`
+    display: flex;
+    align-items: center;
+`;
+
+const UpperCase = styled.div`
+    text-transform: uppercase;
+    padding: 0 3px;
+`;
+
+const buildOptions = (addresses: Account['addresses']) => {
+    if (!addresses) return null;
+
+    interface Options {
+        label: React.ReactElement;
+        options: AccountAddress[];
+    }
+
+    const unused: Options = {
+        label: <Translation id="RECEIVE_TABLE_NOT_USED" />,
+        options: addresses.unused,
+    };
+
+    const used: Options = {
+        label: <Translation id="RECEIVE_TABLE_USED" />,
+        options: addresses.used,
+    };
+
+    return [unused, used];
+};
+
+type FormState = {
+    address?: string;
+};
+
+interface Props extends Pick<UseFormMethods<FormState>, 'setValue'> {
+    control: Control;
+    receiveSymbol?: string;
+    account?: Account;
+    address?: string;
+}
+const AddressOptions = (props: Props) => {
+    const { control, receiveSymbol, setValue, address, account } = props;
+    const addresses = account?.addresses;
+    const addressDictionary = useAccountAddressDictionary(account);
+
+    useEffect(() => {
+        if (!address && addresses) {
+            setValue('address', addresses.unused[0].address);
+        }
+    }, [address, addresses, setValue]);
+
+    return (
+        <Controller
+            control={control}
+            name="address"
+            defaultValue={addressDictionary && address && addressDictionary[address]}
+            render={({ ref, ...field }) => (
+                <>
+                    <Select
+                        {...field}
+                        onChange={(accountAddress: AccountAddress) =>
+                            setValue('address', accountAddress.address)
+                        }
+                        noTopLabel
+                        isClearable={false}
+                        value={addressDictionary && address && addressDictionary[address]}
+                        options={buildOptions(addresses)}
+                        minWidth="70px"
+                        formatOptionLabel={(accountAddress: AccountAddress) => {
+                            if (!accountAddress) return null;
+                            const formattedCryptoAmount = formatNetworkAmount(
+                                accountAddress.balance || '0',
+                                receiveSymbol as Account['symbol'],
+                            );
+                            return (
+                                <Option>
+                                    <AddressWrapper>
+                                        <Address>{accountAddress.address}</Address>
+                                        <Amount>
+                                            <HiddenPlaceholder>
+                                                {formattedCryptoAmount}
+                                            </HiddenPlaceholder>{' '}
+                                            <UpperCase>{receiveSymbol}</UpperCase> •
+                                            <PathWrapper>{accountAddress.path}</PathWrapper> •
+                                            <FiatWrapper>
+                                                <FiatValue
+                                                    amount={formattedCryptoAmount}
+                                                    symbol={receiveSymbol || ''}
+                                                />
+                                            </FiatWrapper>
+                                        </Amount>
+                                    </AddressWrapper>
+                                </Option>
+                            );
+                        }}
+                    />
+                </>
+            )}
+        />
+    );
+};
+
+export default AddressOptions;

--- a/packages/suite/src/views/wallet/coinmarket/exchange/offers/Offers/SelectedOffer/components/VerifyAddress/ReceiveOptions/index.tsx
+++ b/packages/suite/src/views/wallet/coinmarket/exchange/offers/Offers/SelectedOffer/components/VerifyAddress/ReceiveOptions/index.tsx
@@ -54,14 +54,13 @@ const AccountType = styled.span`
     padding-left: 5px;
 `;
 
-type AccountSelectOption = {
+export type AccountSelectOption = {
     type: 'SUITE' | 'ADD_SUITE' | 'NON_SUITE';
     account?: Account;
 };
 
 type FormState = {
     address?: string;
-    extraField?: string;
 };
 
 type Props = Pick<UseFormMethods<FormState>, 'setValue'> & {
@@ -94,6 +93,8 @@ const ReceiveOptions = (props: Props) => {
         if (option.account) {
             const { address } = getUnusedAddressFromAccount(option.account);
             setValue('address', address, { shouldValidate: true });
+        } else {
+            setValue('address', '', { shouldValidate: false });
         }
     };
 


### PR DESCRIPTION
**User story**

> As a user, I want to select any reciving address from currently selected account when buying or exchanging crypto, so I have better control over the receiving address.

Receiving address can be selected for any account with `networkType` set to `bitcoin`.
For `ethereum`, `ripple` and the rest it stays as it is: readonly text input with first unused address or text input where user fills out receiving address

![image](https://user-images.githubusercontent.com/7394177/141493935-a51c0d0d-c3dc-4f4c-a924-7293cb45cd28.png)
