### PR TITLE
Feat/2737 electrum server

### DIFF
--- a/packages/blockchain-link/.eslintrc.js
+++ b/packages/blockchain-link/.eslintrc.js
@@ -1,5 +1,6 @@
 module.exports = {
     rules: {
+        camelcase: 'off',
         'no-underscore-dangle': 'off',
         'no-console': 'warn',
     },

--- a/packages/blockchain-link/package.json
+++ b/packages/blockchain-link/package.json
@@ -51,6 +51,7 @@
     },
     "dependencies": {
         "@trezor/utils": "1.0.0",
+        "@trezor/utxo-lib": "^1.0.0-beta.10",
         "bignumber.js": "^9.0.1",
         "events": "^3.3.0",
         "ripple-lib": "1.10.0",

--- a/packages/blockchain-link/package.json
+++ b/packages/blockchain-link/package.json
@@ -30,6 +30,7 @@
     },
     "scripts": {
         "dev": "webpack serve --config ./webpack/dev.js",
+        "dev:electrum": "ts-node ./src/workers/electrum/devrun.ts",
         "dev:module": "USE_MODULES=true webpack serve --config ./webpack/dev.js",
         "build:lib": "rimraf lib && tsc --p ./tsconfig.lib.json && tsc --p ./tsconfig.workers.json",
         "build:workers": "rimraf build && yarn build:workers-web && yarn build:workers-module",

--- a/packages/blockchain-link/src/types/electrum.ts
+++ b/packages/blockchain-link/src/types/electrum.ts
@@ -1,0 +1,162 @@
+// ElectrumX API 1.4
+// https://electrumx.readthedocs.io/en/latest/protocol-methods.html
+
+type ServerFeatures = {
+    genesis_hash: string;
+    hash_function: string;
+    protocol_min: string;
+    protocol_max: string;
+    server_version: string;
+    pruning: number | null;
+    hosts:
+        | {
+              tcp_port?: number | null;
+              ssl_port?: number | null;
+          }
+        | {
+              [address: string]: {
+                  tcp_port?: number | null;
+                  ssl_port?: number | null;
+              };
+          };
+};
+
+export type TxIn = {
+    txid: string;
+    vout: number;
+    sequence: number;
+    n?: number;
+    scriptSig: unknown;
+    txinwitness: unknown;
+};
+
+export type TxCoinbase = {
+    coinbase: string;
+    sequence: number;
+};
+
+export type TxOut = {
+    value: number;
+    n: number;
+    scriptPubKey: {
+        asm: string;
+        hex: string;
+        address?: string;
+        addresses?: string[];
+        type: 'nulldata' | 'pubkeyhash' | 'scripthash' | 'pubkey' | unknown;
+    };
+};
+
+export type TransactionVerbose = {
+    txid: string;
+    hash: string;
+    hex: string;
+    blockhash: string;
+    version: number;
+    size: number;
+    vsize: number;
+    weight: number;
+    locktime: number;
+    confirmations: number;
+    time: number;
+    blocktime: number;
+    vin: (TxIn | TxCoinbase)[];
+    vout: TxOut[];
+};
+
+type Balance = { confirmed: number; unconfirmed: number };
+type Tx = { tx_hash: string; height: number };
+type MempoolTx = Tx & { fee: number };
+export type HistoryTx = Tx | MempoolTx;
+export type Utxo = Tx & { tx_pos: number; value: number };
+export type BlockHeader = { height: number; hex: string };
+type BlockHeaders = { count: number; max: number; hex: string };
+type Listener<T> = (data: T) => void;
+export type Version = [string, string];
+export type Info = { url: string; version: Version; block: BlockHeader };
+export type StatusChange = [string, string | null];
+
+export interface ElectrumAPI {
+    getInfo(): Info | undefined;
+    on(event: 'blockchain.headers.subscribe', listener: Listener<BlockHeader[]>): void;
+    on(event: 'blockchain.scripthash.subscribe', listener: Listener<StatusChange>): void;
+    /** @deprecated 1.2 */
+    on(event: 'blockchain.address.subscribe', listener: Listener<unknown>): void;
+    /** @deprecated 1.0 */
+    on(event: 'blockchain.numblocks.subscribe', listener: Listener<unknown>): void;
+    /** @deprecated only for servers */
+    on(event: 'server.peers.subscribe', listener: Listener<unknown>): void;
+    off(event: 'blockchain.headers.subscribe', listener: Listener<BlockHeader[]>): void;
+    off(event: 'blockchain.scripthash.subscribe', listener: Listener<StatusChange>): void;
+    /** @deprecated 1.2 */
+    off(event: 'blockchain.address.subscribe', listener: Listener<unknown>): void;
+    /** @deprecated 1.0 */
+    off(event: 'blockchain.numblocks.subscribe', listener: Listener<unknown>): void;
+    /** @deprecated only for servers */
+    off(event: 'server.peers.subscribe', listener: Listener<unknown>): void;
+    request(
+        method: 'server.version',
+        client_name: string,
+        protocol_version: string | [string, string]
+    ): Promise<Version>;
+    request(method: 'server.banner'): Promise<string>;
+    request(method: 'server.ping'): Promise<null>;
+    request(method: 'server.donation_address'): Promise<string>;
+    request(method: 'server.features'): Promise<ServerFeatures>;
+    request(method: 'server.peers.subscribe'): Promise<[string, string, string[]][]>;
+    request(method: 'blockchain.scripthash.get_balance', scripthash: string): Promise<Balance>;
+    request(method: 'blockchain.scripthash.get_history', scripthash: string): Promise<HistoryTx[]>;
+    request(method: 'blockchain.scripthash.get_mempool', scripthash: string): Promise<MempoolTx[]>;
+    request(method: 'blockchain.scripthash.listunspent', scripthash: string): Promise<Utxo[]>;
+    request(method: 'blockchain.scripthash.subscribe', scripthash: string): Promise<string | null>;
+    request(method: 'blockchain.scripthash.unsubscribe', scripthash: string): Promise<boolean>;
+    request(method: 'blockchain.block.header', height: number, cp_height?: number): Promise<string>;
+    request(
+        method: 'blockchain.block.headers',
+        start_height: number,
+        count: number,
+        cp_height?: number
+    ): Promise<BlockHeaders>;
+    request(method: 'blockchain.estimatefee', number: number): Promise<number>;
+    request(method: 'blockchain.headers.subscribe'): Promise<BlockHeader>;
+    request(method: 'blockchain.relayfee'): Promise<number>;
+    request(method: 'blockchain.transaction.broadcast', raw_tx: string): Promise<string>;
+    request(
+        method: 'blockchain.transaction.get',
+        tx_hash: string,
+        verbose?: false
+    ): Promise<string>;
+    request(
+        method: 'blockchain.transaction.get',
+        tx_hash: string,
+        verbose: true
+    ): Promise<TransactionVerbose>;
+    request(
+        method: 'blockchain.transaction.get_merkle',
+        tx_hash: string,
+        height: number
+    ): Promise<unknown>;
+    request(method: 'mempool.get_fee_histogram'): Promise<unknown>;
+    /** @deprecated 1.1 */
+    request(
+        method: 'blockchain.utxo.get_address',
+        tx_hash: string,
+        index: unknown
+    ): Promise<unknown>;
+    /** @deprecated 1.1 */
+    request(method: 'blockchain.numblocks.subscribe'): Promise<unknown>;
+    /** @deprecated 1.2 */
+    request(method: 'blockchain.block.get_chunk', index: unknown): Promise<unknown>;
+    /** @deprecated 1.2 */
+    request(method: 'blockchain.address.get_balance', address: string): Promise<unknown>;
+    /** @deprecated 1.2 */
+    request(method: 'blockchain.address.get_history', address: string): Promise<unknown>;
+    /** @deprecated 1.2 */
+    request(method: 'blockchain.address.get_mempool', address: string): Promise<unknown>;
+    /** @deprecated 1.2 */
+    request(method: 'blockchain.address.listunspent', address: string): Promise<unknown>;
+    /** @deprecated 1.2 */
+    request(method: 'blockchain.address.subscribe', address: string): Promise<unknown>;
+    /** @deprecated only for servers */
+    request(method: 'server.add_peer', features: ServerFeatures): Promise<boolean>;
+}

--- a/packages/blockchain-link/src/types/electrum.ts
+++ b/packages/blockchain-link/src/types/electrum.ts
@@ -1,3 +1,5 @@
+import type { Network } from '@trezor/utxo-lib';
+
 // ElectrumX API 1.4
 // https://electrumx.readthedocs.io/en/latest/protocol-methods.html
 
@@ -64,6 +66,14 @@ export type TransactionVerbose = {
     vout: TxOut[];
 };
 
+export type Info = {
+    url: string;
+    coin: string;
+    network: Network;
+    version: Version;
+    block: BlockHeader;
+};
+
 type Balance = { confirmed: number; unconfirmed: number };
 type Tx = { tx_hash: string; height: number };
 type MempoolTx = Tx & { fee: number };
@@ -73,7 +83,6 @@ export type BlockHeader = { height: number; hex: string };
 type BlockHeaders = { count: number; max: number; hex: string };
 type Listener<T> = (data: T) => void;
 export type Version = [string, string];
-export type Info = { url: string; version: Version; block: BlockHeader };
 export type StatusChange = [string, string | null];
 
 export interface ElectrumAPI {

--- a/packages/blockchain-link/src/workers/electrum/client/batching.ts
+++ b/packages/blockchain-link/src/workers/electrum/client/batching.ts
@@ -1,0 +1,48 @@
+import { JsonRpcClient } from './json-rpc';
+
+type Options = {
+    timeoutMs?: number;
+    maxQueueLength?: number;
+};
+
+const TIMEOUT_MS = 50;
+const MAX_QUEUE_LENGTH = 15;
+
+// TODO batching should in theory improve performance
+export class BatchingJsonRpcClient extends JsonRpcClient {
+    private queue: string[] = [];
+    private batchTimer?: ReturnType<typeof setTimeout>;
+
+    private timeoutMs: number;
+    private maxQueueLength: number;
+
+    constructor(options?: Options) {
+        super();
+        this.timeoutMs = options?.timeoutMs || TIMEOUT_MS;
+        this.maxQueueLength = options?.maxQueueLength || MAX_QUEUE_LENGTH;
+    }
+
+    protected send(message: string) {
+        const { queue } = this;
+        queue.push(message);
+        if (this.batchTimer) clearTimeout(this.batchTimer);
+        this.batchTimer = setTimeout(() => {
+            this.batchTimer = undefined;
+            while (queue.length) {
+                const q = queue.splice(0, this.maxQueueLength);
+                const content = q.length > 1 ? `[${q.join(',')}]` : q[0];
+                super.send(content);
+            }
+        }, this.timeoutMs);
+    }
+
+    protected onMessage(body: string) {
+        const msg = JSON.parse(body);
+        this.log('RECEIVED:', msg);
+        if (Array.isArray(msg)) {
+            msg.forEach(this.response, this);
+        } else {
+            this.response(msg);
+        }
+    }
+}

--- a/packages/blockchain-link/src/workers/electrum/client/caching.ts
+++ b/packages/blockchain-link/src/workers/electrum/client/caching.ts
@@ -1,0 +1,86 @@
+import { ElectrumClient } from './electrum';
+
+type Cache = {
+    [descriptor: string]: [string | null, any];
+};
+
+type Statuses = {
+    [scripthash: string]: string;
+};
+
+export class CachingElectrumClient extends ElectrumClient {
+    private readonly cache: Cache = {};
+    private readonly statuses: Statuses = {};
+    private cached = 0;
+    private total = 0;
+    private logTimer: ReturnType<typeof setInterval>;
+
+    constructor() {
+        super();
+        this.logTimer = setInterval(() => {
+            this.log(`Caching effectiveness: ${this.cached}/${this.total}`);
+        }, 60000);
+    }
+
+    private async cacheRequest(status: string | null, method: string, params: any[]) {
+        const descriptor = [method, ...params].join(':');
+        const cached = this.cache[descriptor];
+        if (cached) {
+            const [cachedStatus, cachedResponse] = cached;
+            if (cachedStatus === status) {
+                this.cached++;
+                return cachedResponse;
+            }
+        }
+        const response = await super.request(method, ...params);
+        this.cache[descriptor] = [status, response];
+        return response;
+    }
+
+    async request(method: string, ...params: any[]) {
+        this.total++;
+        switch (method) {
+            case 'blockchain.scripthash.get_history':
+            case 'blockchain.scripthash.get_balance':
+            case 'blockchain.scripthash.listunspent': {
+                const [scripthash] = params;
+                const status = this.statuses[scripthash];
+                if (status === undefined) break;
+                return this.cacheRequest(status, method, params);
+            }
+            case 'blockchain.transaction.get': {
+                const curBlock = this.lastBlock?.hex;
+                if (curBlock === undefined) break;
+                return this.cacheRequest(curBlock, method, params);
+            }
+            case 'blockchain.scripthash.subscribe': {
+                const [scripthash] = params;
+                const status = await super.request(method, ...params);
+                this.statuses[scripthash] = status;
+                return status;
+            }
+            default:
+                break;
+        }
+        return super.request(method, ...params);
+    }
+
+    protected response(response: any) {
+        const { method, params } = response;
+        switch (method) {
+            case 'blockchain.scripthash.subscribe': {
+                const [scripthash, status] = params;
+                this.statuses[scripthash] = status;
+                break;
+            }
+            default:
+                break;
+        }
+        super.response(response);
+    }
+
+    onClose() {
+        super.onClose();
+        clearInterval(this.logTimer);
+    }
+}

--- a/packages/blockchain-link/src/workers/electrum/client/electrum.ts
+++ b/packages/blockchain-link/src/workers/electrum/client/electrum.ts
@@ -1,0 +1,91 @@
+import { ElectrumAPI, BlockHeader, Version } from '../../../types/electrum';
+import { JsonRpcClientOptions } from './json-rpc';
+import { BatchingJsonRpcClient } from './batching';
+import type { ISocket } from '../sockets/interface';
+
+const KEEP_ALIVE_INTERVAL = 120 * 1000; // 2 minutes
+
+type ElectrumClientOptions = JsonRpcClientOptions & {
+    client: {
+        name: string;
+        protocolVersion: string | [string, string];
+    };
+    url: string;
+};
+
+export class ElectrumClient extends BatchingJsonRpcClient implements ElectrumAPI {
+    private options?: ElectrumClientOptions;
+    private version?: Version;
+    protected lastBlock?: BlockHeader;
+    private timeLastCall = 0;
+
+    async connect(socket: ISocket, options: ElectrumClientOptions) {
+        this.timeLastCall = 0;
+        this.options = options;
+
+        const { name, protocolVersion } = options.client;
+
+        await super.connect(socket, options);
+
+        try {
+            // this.banner = await (this as ElectrumAPI).request('server.banner');
+            this.version = await (this as ElectrumAPI).request(
+                'server.version',
+                name,
+                protocolVersion
+            );
+            (this as ElectrumAPI).on('blockchain.headers.subscribe', this.onBlock);
+            this.lastBlock = await (this as ElectrumAPI).request('blockchain.headers.subscribe');
+        } catch (err) {
+            this.socket = undefined;
+            throw new Error(`Communication with Electrum server failed: [${err}]`);
+        }
+
+        this.keepAlive();
+    }
+
+    getInfo() {
+        if (this.options?.url && this.version && this.lastBlock) {
+            return {
+                url: this.options?.url,
+                version: this.version,
+                block: this.lastBlock,
+            };
+        }
+    }
+
+    private onBlock(blocks: BlockHeader[]) {
+        const [last] = blocks.sort((a, b) => b.height - a.height);
+        if (last) this.lastBlock = last;
+    }
+
+    request(method: string, ...params: any[]) {
+        this.timeLastCall = new Date().getTime();
+        return super.request(method, ...params);
+    }
+
+    private keepAliveHandle?: ReturnType<typeof setInterval>;
+    private keepAlive() {
+        if (!this.socket) return;
+        this.keepAliveHandle = setInterval(
+            async client => {
+                if (
+                    this.timeLastCall !== 0 &&
+                    new Date().getTime() > this.timeLastCall + KEEP_ALIVE_INTERVAL / 2
+                ) {
+                    await (this as ElectrumAPI).request('server.ping').catch(err => {
+                        console.error(`Ping to server failed: [${err}]`);
+                        client.close();
+                    });
+                }
+            },
+            KEEP_ALIVE_INTERVAL,
+            this
+        );
+    }
+
+    onClose() {
+        super.onClose();
+        if (this.keepAliveHandle) clearInterval(this.keepAliveHandle);
+    }
+}

--- a/packages/blockchain-link/src/workers/electrum/client/json-rpc.ts
+++ b/packages/blockchain-link/src/workers/electrum/client/json-rpc.ts
@@ -1,0 +1,128 @@
+import { EventEmitter } from 'events';
+import { fail } from '../utils';
+import type { ISocket } from '../sockets/interface';
+
+type Callback = (error: any, result?: any) => void;
+type CallbackMessageQueue = Record<number, Callback>;
+
+export type JsonRpcClientOptions = {
+    debug?: boolean;
+};
+
+export class JsonRpcClient {
+    private id = 0;
+    private buffer = '';
+    private emitter = new EventEmitter();
+    protected callbacks: CallbackMessageQueue = {};
+    protected socket?: ISocket;
+    protected debug = false;
+
+    async connect(socket: ISocket, options?: JsonRpcClientOptions) {
+        if (this.socket) return;
+
+        this.debug = options?.debug || false;
+
+        try {
+            this.socket = socket;
+            await this.socket.connect(this);
+        } catch (err) {
+            this.socket = undefined;
+            throw new Error(`JSON RPC connection failed: [${err}]`);
+        }
+    }
+
+    connected() {
+        return !!this.socket;
+    }
+
+    close() {
+        this.socket?.close();
+        this.socket = undefined;
+        this.onClose();
+    }
+
+    request(method: string, ...params: any[]) {
+        return new Promise<any>((resolve, reject) => {
+            const id = ++this.id;
+            const request = JSON.stringify({
+                jsonrpc: '2.0',
+                method,
+                params,
+                id,
+            });
+            this.callbacks[id] = (err, result) => {
+                if (err) reject(err);
+                else resolve(result);
+            };
+            this.send(request);
+        });
+    }
+
+    on(event: string, listener: (...args: any[]) => void) {
+        this.emitter.on(event, listener);
+    }
+
+    off(event: string, listener: (...args: any[]) => void) {
+        this.emitter.off(event, listener);
+    }
+
+    protected send(message: string) {
+        const socket = this.socket || fail('Connection not established');
+        this.log('SENDING:', message);
+        socket.send(`${message}\n`);
+    }
+
+    protected response(response: any) {
+        const { id, method, params, result, error } = response;
+        if (!id) {
+            // Notification
+            this.emitter.emit(method, params);
+        } else {
+            // Response
+            const callback = this.callbacks[id];
+            if (callback) {
+                delete this.callbacks[id];
+                callback(error, result);
+            } else {
+                this.log(`Can't get callback for ${id}`);
+            }
+        }
+    }
+
+    protected onMessage(body: string) {
+        const msg = JSON.parse(body);
+        this.log('RECEIVED:', msg);
+        this.response(msg);
+    }
+
+    onConnect() {
+        this.log('onConnect');
+    }
+
+    onReceive(chunk: string) {
+        const msgs = (this.buffer + chunk).split('\n');
+        this.buffer = msgs.pop() || '';
+        msgs.filter(msg => !!msg).forEach(this.onMessage, this);
+    }
+
+    onEnd(e: unknown) {
+        this.log(`onEnd: [${e}]`);
+    }
+
+    onError(error: unknown) {
+        this.log(`onError: [${error}]`);
+    }
+
+    onClose() {
+        this.log('onClose');
+        Object.values(this.callbacks).forEach(cb => cb(new Error('Connection closed')));
+        this.callbacks = {};
+        this.emitter.removeAllListeners();
+    }
+
+    protected log(...data: any[]) {
+        if (this.debug) {
+            console.log(...data);
+        }
+    }
+}

--- a/packages/blockchain-link/src/workers/electrum/devrun.ts
+++ b/packages/blockchain-link/src/workers/electrum/devrun.ts
@@ -1,0 +1,128 @@
+// @ts-nocheck
+/// <reference path="../../../../suite/global.d.ts" />
+
+import ElectrumWorker from '.';
+import { createSocket } from './sockets';
+import type { Message, Response } from '../../types';
+
+const TOR_ADDRESS = '127.0.0.1:9050';
+
+const TCP_CONFIG = 'electrum.corp.sldev.cz:50001:t';
+const TLS_CONFIG = 'bitcoin.aranguren.org:50002:s';
+const TOR_CONFIG = ''; // My personal Umbrel
+
+const ADDR_LEGACY = '1BitcoinEaterAddressDontSendf59kuE'; // 393 transactions
+const ADDR_SEGWIT = '3AVjhFvVHKhPfFccdFnPTBaqRqWq4EWoU2'; // 2 transactions
+const ADDR_SEGWIT_MID = '33QJtiYPkQzYf5BNbCztHWowhco77sg18g'; // 44 transactions
+const ADDR_BECH32 = 'bc1qwqdg6squsna38e46795at95yu9atm8azzmyvckulcc7kytlcckxswvvzej'; // almost 1M transactions
+const XPUB_ALL_SEED_1 =
+    'xpub6BiVtCpG9fQPxnPmHXG8PhtzQdWC2Su4qWu6XW9tpWFYhxydCLJGrWBJZ5H6qTAHdPQ7pQhtpjiYZVZARo14qHiay2fvrX996oEP42u8wZy';
+const XPUB_ALL_SEED_2 =
+    'xpub6BiVtCpG9fQQ1EW99bMSYwySbPWvzTFRQZCFgTmV3samLSZAYU7C3f4Je9vkNh7h1GAWi5Fn93BwoGBy9EAXbWTTgTnVKAbthHpxM1fXVRL';
+const YPUB =
+    'ypub6XKbB5DSkq8Royg8isNtGktj6bmEfGJXDs83Ad5CZ5tpDV8QofwSWQFTWP2Pv24vNdrPhquehL7vRMvSTj2GpKv6UaTQCBKZALm6RJAmxG6';
+const ZPUB =
+    'zpub6rDjzkRoJEhB4Z4j77umtwDFpuqDhNxWy85wZZwF6z7TM1TUw1oCucRsPHjeVNCPa29EXxFbzoPCSSbdcR66KUh9R7oPWD7XQtHuVSy47mk';
+const ZPUB_FIRST = 'bc1qqmu7jr0twysm6n0zd3xz93h3jysre8aaatd6g8';
+const ZPUB_SECOND = 'bc1qrhl9v6nagn9v9ckg4u63vwgzteh5wzdutj2ecd';
+const TX = '353cad24cf028dc32d7be44d9b96acc112dba7705a4f3bba4be077f500cdc416';
+const COINBASE_TX = '485579924ce684df7aa7a9861abb4b2858a8d917aa1df94bf3a234368a250516';
+const OP_RETURN_TX = '8bae12b5f4c088d940733dcd1455efc6a3a69cf9340e17a981286d3778615684';
+const MULTISIG_TX = 'aafbce314cadd619585034c4d949a59569fcf79902d3c35e162d25aa207dfb61';
+
+const SCRIPTHASH = '495fa456cdb66064db3dae04d7b2f307a874cb6f731ab4251b7d73308001ebba';
+
+const TX_HASH =
+    '02000000000102f503777e6e86bbdc285fdc781807466ab7187496b9c13d1e11aab6a45c3a31c90000000017160014207b37056ce222c4c7511dbaa9441df907904a73feffffffc1b3e9aa635f20f98a611bee50077aa7d36bde466a0deb547df1efbceecdfec30100000000feffffff02fa990e00000000001600148775fb220c008347029e71b76e3b31a941cf588269601a00000000001976a9140093caafa7c8d442cf37b26eb79e4c4f6a9afae188ac02473044022027a921f91fd8c5a5b198c8851c08a00824f8678768964c7069bcdc498513992802203b2eb659f5b7a77a17db8093e10e0dc4b35bf6315a4f6f4fa0b2e5fd8e6895760121036761cccced49d0500e036b59f69b21f9455bcd055e005405bd6c13b11d40293602473044022036da9dd150c2d3501fa18c1f3d121999c3bd64003137f9eb68330f1833c214f202206de0a66364b5ddb0feb12b87df6f15ec5389d4201bea1f929d7d6e8ea97a2d560121021506315fd256cfad9cf15257eebbf80411a1ab0cc00de3e96ff9df4a8cd1f83608cd0a00';
+
+(async () => {
+    const worker = ElectrumWorker();
+
+    const resolvers: { [id: number]: (value: any) => void } = {};
+
+    worker.onmessage = ({ data }: { data: Response }) => {
+        console.log('ONMESSAGE', JSON.stringify(data, null, 4));
+        if (resolvers[data.id]) resolvers[data.id](data);
+    };
+
+    let id = 0;
+    const sendAndWait = (data: Message) =>
+        new Promise((resolve, reject) => {
+            resolvers[data.id] = resolve;
+            worker.postMessage(data);
+        });
+
+    worker.postMessage({
+        type: 'm_handshake',
+        id: 0,
+        settings: {
+            name: 'Electrum',
+            worker: 'unknown',
+            server: [TCP_CONFIG],
+            debug: true,
+        },
+    });
+
+    await sendAndWait({ id: ++id, type: 'm_connect' });
+    // await sendAndWait({ id: ++id, type: 'm_push_tx', payload: TX_HASH });
+    /* await sendAndWait({
+        id: ++id,
+        // @ts-ignore
+        type: 'raw',
+        // @ts-ignore
+        payload: {
+            method: 'blockchain.block.headers',
+            params: [666666, 3],
+        },
+    });
+    return;
+    await sendAndWait({ id: ++id, type: 'm_get_info' });
+    
+    console.time('tx');
+    await sendAndWait({ id: ++id, type: 'm_get_account_utxo', payload: ADDR_SEGWIT_MID });
+    console.timeEnd('tx');
+    return;
+    
+    await sendAndWait({
+        id: ++id,
+        type: 'm_subscribe',
+        payload: { addresses: [ZPUB_FIRST], type: 'addresses' },
+    });
+    return;
+    await sendAndWait({ id: ++id, type: 'm_get_block_hash', payload: 666666 });
+    
+    await sendAndWait({ id: ++id, type: 'm_get_transaction', payload: TX });
+    return;
+    
+    await sendAndWait({
+        id: ++id,
+        // @ts-ignore
+        type: 'raw',
+        // @ts-ignore
+        payload: {
+            method: 'server.ping',
+        },
+    });
+
+    return;
+    */
+    await sendAndWait({
+        id: ++id,
+        type: 'm_get_account_info',
+        payload: { descriptor: ADDR_SEGWIT, details: 'txs' },
+    });
+    return;
+    await sendAndWait({
+        id: ++id,
+        type: 'm_get_account_balance_history',
+        payload: {
+            descriptor: ADDR_SEGWIT,
+            from: NaN,
+            to: NaN,
+            groupBy: 7200000,
+            currencies: ['btc'],
+        },
+    });
+    return;
+    await sendAndWait({ id: ++id, type: 'm_estimate_fee', payload: { blocks: [1, 2, 10] } });
+})();

--- a/packages/blockchain-link/src/workers/electrum/index.ts
+++ b/packages/blockchain-link/src/workers/electrum/index.ts
@@ -150,12 +150,13 @@ class ElectrumWorker extends BaseWorker<ElectrumClient> {
 
     async connect(): Promise<ElectrumClient> {
         if (!this.api?.connected()) {
-            const { server = [], debug, timeout, keepAlive } = this.settings;
+            const { server = [], debug, timeout, keepAlive, name } = this.settings;
             const url = this.chooseServer(server);
             const socket = createSocket(url, { timeout, keepAlive, proxyAgent: this.proxyAgent });
             const api = new CachingElectrumClient();
             await api.connect(socket, {
                 url,
+                coin: name ?? 'BTC',
                 debug,
                 client: {
                     name: 'blockchain-link',

--- a/packages/blockchain-link/src/workers/electrum/index.ts
+++ b/packages/blockchain-link/src/workers/electrum/index.ts
@@ -1,0 +1,219 @@
+import { CustomError } from '../../constants/errors';
+import { MESSAGES, RESPONSES } from '../../constants';
+import { BaseWorker, CONTEXT, ContextType } from '../base';
+import * as M from './methods';
+import * as L from './listeners';
+import { createSocket } from './sockets';
+import { CachingElectrumClient } from './client/caching';
+import type { ElectrumClient } from './client/electrum';
+import type { Message, Response } from '../../types';
+
+type BlockListener = ReturnType<typeof L.blockListener>;
+type TxListener = ReturnType<typeof L.txListener>;
+
+// reason:
+// https://stackoverflow.com/questions/57103834/typescript-omit-a-property-from-all-interfaces-in-a-union-but-keep-the-union-s#answer-57103940
+type Without<T, K extends keyof any> = T extends any ? Omit<T, K> : never;
+type Request<T> = T extends any
+    ? T & ContextType<ElectrumClient> & { blockListener: BlockListener; txListener: TxListener }
+    : never;
+type MessageType = Message['type'];
+type ResponseType<T extends MessageType> = T extends typeof MESSAGES.GET_INFO
+    ? typeof RESPONSES.GET_INFO
+    : T extends typeof MESSAGES.GET_BLOCK_HASH
+    ? typeof RESPONSES.GET_BLOCK_HASH
+    : T extends typeof MESSAGES.GET_ACCOUNT_INFO
+    ? typeof RESPONSES.GET_ACCOUNT_INFO
+    : T extends typeof MESSAGES.GET_ACCOUNT_UTXO
+    ? typeof RESPONSES.GET_ACCOUNT_UTXO
+    : T extends typeof MESSAGES.GET_TRANSACTION
+    ? typeof RESPONSES.GET_TRANSACTION
+    : T extends typeof MESSAGES.GET_ACCOUNT_BALANCE_HISTORY
+    ? typeof RESPONSES.GET_ACCOUNT_BALANCE_HISTORY
+    : T extends typeof MESSAGES.ESTIMATE_FEE
+    ? typeof RESPONSES.ESTIMATE_FEE
+    : T extends typeof MESSAGES.PUSH_TRANSACTION
+    ? typeof RESPONSES.PUSH_TRANSACTION
+    : T extends typeof MESSAGES.SUBSCRIBE
+    ? typeof RESPONSES.SUBSCRIBE
+    : T extends typeof MESSAGES.UNSUBSCRIBE
+    ? typeof RESPONSES.UNSUBSCRIBE
+    : never;
+type Reply<T extends MessageType> = Without<Extract<Response, { type: ResponseType<T> }>, 'id'>;
+
+const onRequest = async <T extends Message>(
+    request: Request<T>
+): Promise<Reply<typeof request.type>> => {
+    const client = await request.connect();
+    switch (request.type) {
+        case MESSAGES.GET_INFO:
+            return {
+                type: RESPONSES.GET_INFO,
+                payload: await M.getInfo(client),
+            };
+        case MESSAGES.GET_BLOCK_HASH:
+            return {
+                type: RESPONSES.GET_BLOCK_HASH,
+                payload: await M.getBlockHash(client, request.payload),
+            };
+        case MESSAGES.GET_ACCOUNT_INFO:
+            return {
+                type: RESPONSES.GET_ACCOUNT_INFO,
+                payload: await M.getAccountInfo(client, request.payload),
+            };
+        case MESSAGES.GET_ACCOUNT_UTXO:
+            return {
+                type: RESPONSES.GET_ACCOUNT_UTXO,
+                payload: await M.getAccountUtxo(client, request.payload),
+            };
+        case MESSAGES.GET_TRANSACTION:
+            return {
+                type: RESPONSES.GET_TRANSACTION,
+                payload: await M.getTransaction(client, request.payload),
+            };
+        case MESSAGES.GET_ACCOUNT_BALANCE_HISTORY:
+            return {
+                type: RESPONSES.GET_ACCOUNT_BALANCE_HISTORY,
+                payload: await M.getAccountBalanceHistory(client, request.payload),
+            };
+        case MESSAGES.ESTIMATE_FEE:
+            return {
+                type: RESPONSES.ESTIMATE_FEE,
+                payload: await M.estimateFee(client, request.payload),
+            };
+        case MESSAGES.PUSH_TRANSACTION:
+            return {
+                type: RESPONSES.PUSH_TRANSACTION,
+                payload: await M.pushTransaction(client, request.payload),
+            };
+        case MESSAGES.SUBSCRIBE:
+            switch (request.payload.type) {
+                case 'block':
+                    return {
+                        type: RESPONSES.SUBSCRIBE,
+                        payload: request.blockListener.subscribe(),
+                    };
+                case 'addresses':
+                case 'accounts':
+                    return {
+                        type: RESPONSES.SUBSCRIBE,
+                        payload: await request.txListener.subscribe(request.payload),
+                    };
+                default:
+                    throw new CustomError(`Subscription ${request.payload.type} not implemented`);
+            }
+        case MESSAGES.UNSUBSCRIBE:
+            switch (request.payload.type) {
+                case 'block':
+                    return {
+                        type: RESPONSES.UNSUBSCRIBE,
+                        payload: request.blockListener.unsubscribe(),
+                    };
+                case 'addresses':
+                case 'accounts':
+                    return {
+                        type: RESPONSES.UNSUBSCRIBE,
+                        payload: await request.txListener.unsubscribe(request.payload),
+                    };
+                default:
+                    throw new CustomError(`Subscription ${request.payload.type} not implemented`);
+            }
+        // @ts-ignore this message is used in tests
+        case 'raw':
+            // @ts-ignore
+            // eslint-disable-next-line
+            const { method, params } = request.payload;
+            return client
+                .request(method, ...params)
+                .then((res: any) => ({ type: method, payload: res }));
+        default:
+            throw new CustomError('worker_unknown_request', `+${request.type}`);
+    }
+};
+
+class ElectrumWorker extends BaseWorker<ElectrumClient> {
+    private blockListener: BlockListener;
+    private txListener: TxListener;
+
+    constructor() {
+        super();
+        this.blockListener = L.blockListener(this);
+        this.txListener = L.txListener(this);
+    }
+
+    private chooseServer(server: string[]): string {
+        if (!server || !Array.isArray(server) || server.length < 1) {
+            throw new CustomError('connect', 'Endpoint not set');
+        }
+        return server[0];
+    }
+
+    async connect(): Promise<ElectrumClient> {
+        if (!this.api?.connected()) {
+            const { server = [], debug, timeout, keepAlive } = this.settings;
+            const url = this.chooseServer(server);
+            const socket = createSocket(url, { timeout, keepAlive, proxyAgent: this.proxyAgent });
+            const api = new CachingElectrumClient();
+            await api.connect(socket, {
+                url,
+                debug,
+                client: {
+                    name: 'blockchain-link',
+                    protocolVersion: '1.4',
+                },
+            });
+            this.api = api;
+
+            this.post({
+                id: -1,
+                type: RESPONSES.CONNECTED,
+            });
+        }
+        return this.api;
+    }
+
+    disconnect() {
+        if (this.api?.connected()) {
+            this.api.close();
+        }
+    }
+
+    cleanup() {
+        // TODO
+        if (this.api) {
+            this.api.close();
+        }
+        super.cleanup();
+    }
+
+    async messageHandler(event: { data: Message }) {
+        try {
+            // skip processed messages
+            if (await super.messageHandler(event)) return true;
+
+            const request: Request<Message> = {
+                ...event.data,
+                connect: () => this.connect(),
+                post: (data: Response) => this.post(data),
+                state: this.state,
+                blockListener: this.blockListener,
+                txListener: this.txListener,
+            };
+            const response = await onRequest(request);
+            this.post({ id: event.data.id, ...response });
+        } catch (error) {
+            this.errorResponse(event.data.id, error);
+        }
+    }
+}
+
+// export worker factory used in src/index
+export default function Electrum() {
+    return new ElectrumWorker();
+}
+
+if (CONTEXT === 'worker') {
+    // Initialize module if script is running in worker context
+    const module = new ElectrumWorker();
+    onmessage = module.messageHandler.bind(module);
+}

--- a/packages/blockchain-link/src/workers/electrum/listeners/blockListener.ts
+++ b/packages/blockchain-link/src/workers/electrum/listeners/blockListener.ts
@@ -1,0 +1,46 @@
+import { RESPONSES } from '../../../constants';
+import { blockheaderToBlockhash, fail } from '../utils';
+import type { BaseWorker } from '../../base';
+import type { BlockHeader, ElectrumAPI } from '../../../types/electrum';
+
+export const blockListener = (worker: BaseWorker<ElectrumAPI>) => {
+    const { state } = worker;
+    const api = () => worker.api ?? fail('API not created');
+
+    const onBlock = (blocks: BlockHeader[]) => {
+        blocks.forEach(({ height, hex }) =>
+            worker.post({
+                id: -1,
+                type: RESPONSES.NOTIFICATION,
+                payload: {
+                    type: 'block',
+                    payload: {
+                        blockHeight: height,
+                        blockHash: blockheaderToBlockhash(hex),
+                    },
+                },
+            })
+        );
+    };
+
+    const subscribe = () => {
+        if (!state.getSubscription('block')) {
+            state.addSubscription('block');
+            api().on('blockchain.headers.subscribe', onBlock);
+        }
+        return { subscribed: true };
+    };
+
+    const unsubscribe = () => {
+        if (state.getSubscription('block')) {
+            api().off('blockchain.headers.subscribe', onBlock);
+            state.removeSubscription('block');
+        }
+        return { subscribed: false };
+    };
+
+    return {
+        subscribe,
+        unsubscribe,
+    };
+};

--- a/packages/blockchain-link/src/workers/electrum/listeners/index.ts
+++ b/packages/blockchain-link/src/workers/electrum/listeners/index.ts
@@ -1,0 +1,2 @@
+export { blockListener } from './blockListener';
+export { txListener } from './txListener';

--- a/packages/blockchain-link/src/workers/electrum/listeners/txListener.ts
+++ b/packages/blockchain-link/src/workers/electrum/listeners/txListener.ts
@@ -24,7 +24,7 @@ export const txListener = (worker: BaseWorker<ElectrumAPI>) => {
     const { state } = worker;
     const api = () => worker.api ?? fail('API not created');
 
-    const addressManager = createAddressManager();
+    const addressManager = createAddressManager(worker.api?.getInfo()?.network);
 
     const onTransaction = async ([scripthash, _status]: StatusChange) => {
         const { descriptor, addresses } = addressManager.getInfo(scripthash);

--- a/packages/blockchain-link/src/workers/electrum/listeners/txListener.ts
+++ b/packages/blockchain-link/src/workers/electrum/listeners/txListener.ts
@@ -1,0 +1,94 @@
+import { RESPONSES } from '../../../constants';
+import { createAddressManager, getTransactions } from '../utils';
+import { transformTransaction } from '../../blockbook/utils';
+import type { BaseWorker } from '../../base';
+import type { ElectrumAPI, HistoryTx, StatusChange } from '../../../types/electrum';
+import type { Subscribe, Unsubscribe } from '../../../types/messages';
+
+type Payload<T extends { type: string; payload: any }> = Extract<
+    T['payload'],
+    { type: 'addresses' | 'accounts' }
+>;
+
+// TODO optimize if neccessary
+const mostRecent = (previous: HistoryTx | undefined, current: HistoryTx) => {
+    if (previous === undefined) return current;
+    if (previous.height === -1) return previous;
+    if (current.height === -1) return current;
+    if (previous.height === 0) return previous;
+    if (current.height === 0) return current;
+    return previous.height >= current.height ? previous : current;
+};
+
+export const txListener = (worker: BaseWorker<ElectrumAPI>) => {
+    const { state } = worker;
+    const api = () => worker.api ?? fail('API not created');
+
+    const addressManager = createAddressManager();
+
+    const onTransaction = async ([scripthash, _status]: StatusChange) => {
+        const { descriptor, addresses } = addressManager.getInfo(scripthash);
+        const history = await api().request('blockchain.scripthash.get_history', scripthash);
+        const recent = history.reduce<HistoryTx | undefined>(mostRecent, undefined);
+        if (!recent) return;
+        const [tx] = await getTransactions(api(), [recent]);
+        worker.post({
+            id: -1,
+            type: RESPONSES.NOTIFICATION,
+            payload: {
+                type: 'notification',
+                payload: {
+                    descriptor,
+                    tx: transformTransaction(descriptor, addresses, tx),
+                },
+            },
+        });
+    };
+
+    const subscribe = async (data: Payload<Subscribe>) => {
+        const shToSubscribe =
+            data.type === 'accounts'
+                ? addressManager.addAccounts(data.accounts)
+                : addressManager.addAddresses(data.addresses);
+
+        if (!shToSubscribe.length) return { subscribed: false };
+
+        if (!state.getSubscription('notification')) {
+            api().on('blockchain.scripthash.subscribe', onTransaction);
+            state.addSubscription('notification');
+        }
+
+        await Promise.all(
+            shToSubscribe.map(scripthash =>
+                api().request('blockchain.scripthash.subscribe', scripthash)
+            )
+        );
+        return { subscribed: true };
+    };
+
+    const unsubscribe = async (data: Payload<Unsubscribe>) => {
+        const shToUnsubscribe =
+            data.type === 'accounts'
+                ? addressManager.removeAccounts(data.accounts)
+                : addressManager.removeAddresses(data.addresses);
+
+        if (!shToUnsubscribe.length) return { subscribed: false };
+
+        if (state.getSubscription('notification') && !addressManager.getCount()) {
+            api().off('blockchain.scripthash.subscribe', onTransaction);
+            state.removeSubscription('notification');
+        }
+
+        await Promise.all(
+            shToUnsubscribe.map(scripthash =>
+                api().request('blockchain.scripthash.unsubscribe', scripthash)
+            )
+        );
+        return { subscribed: false };
+    };
+
+    return {
+        subscribe,
+        unsubscribe,
+    };
+};

--- a/packages/blockchain-link/src/workers/electrum/methods/estimateFee.ts
+++ b/packages/blockchain-link/src/workers/electrum/methods/estimateFee.ts
@@ -1,0 +1,14 @@
+import { Api, btcToSat } from '../utils';
+import type { EstimateFee as Req } from '../../../types/messages';
+import type { EstimateFee as Res } from '../../../types/responses';
+
+const estimateFee: Api<Req, Res> = (client, payload) =>
+    Promise.all(
+        (payload.blocks || []).map(num =>
+            client
+                .request('blockchain.estimatefee', num)
+                .then(btc => ({ feePerUnit: btcToSat(btc) }))
+        )
+    );
+
+export default estimateFee;

--- a/packages/blockchain-link/src/workers/electrum/methods/getAccountBalanceHistory.ts
+++ b/packages/blockchain-link/src/workers/electrum/methods/getAccountBalanceHistory.ts
@@ -1,0 +1,95 @@
+import {
+    Api,
+    tryGetScripthash,
+    getTransactions,
+    discovery,
+    flatten,
+    AddressHistory,
+} from '../utils';
+import { transformTransaction } from '../../blockbook/utils';
+import type { GetAccountBalanceHistory as Req } from '../../../types/messages';
+import type { GetAccountBalanceHistory as Res } from '../../../types/responses';
+import type { AccountAddresses, Transaction } from '../../../types/common';
+import type { HistoryTx } from '../../../types/electrum';
+
+const transformAddress = (addr: AddressHistory) => ({
+    address: addr.address,
+    path: addr.path,
+    transfers: addr.history.length,
+});
+
+const aggregateTransactions = (txs: (Transaction & { blockTime: number })[], groupBy = 3600) => {
+    const result: Res['payload'] = [];
+    let i = 0;
+    while (i < txs.length) {
+        const time = Math.floor(txs[i].blockTime / groupBy) * groupBy;
+        let j = i;
+        let received = 0;
+        let sent = 0;
+        let sentToSelf = 0;
+        while (j < txs.length && txs[j].blockTime < time + groupBy) {
+            const {
+                type,
+                totalSpent,
+                details: { totalInput, totalOutput },
+            } = txs[j];
+            if (type === 'recv') received += Number.parseInt(totalSpent, 10);
+            else if (type === 'sent') sent += Number.parseInt(totalSpent, 10);
+            else if (type === 'self') {
+                sentToSelf += Number.parseInt(totalOutput, 10);
+                sent += Number.parseInt(totalInput, 10);
+                received += Number.parseInt(totalOutput, 10);
+            }
+            j++;
+        }
+        result.push({
+            time,
+            txs: j - i,
+            received: received.toString(),
+            sent: sent.toString(),
+            sentToSelf: sentToSelf.toString(),
+            rates: {},
+        });
+        i = j;
+    }
+    return result;
+};
+
+const getAccountBalanceHistory: Api<Req, Res> = async (
+    client,
+    { descriptor, from, to, groupBy }
+) => {
+    let history: HistoryTx[];
+    let addresses: AccountAddresses | undefined;
+
+    const parsed = tryGetScripthash(descriptor);
+    if (parsed.valid) {
+        history = await client.request('blockchain.scripthash.get_history', parsed.scripthash);
+        addresses = undefined;
+    } else {
+        const receive = await discovery(client, descriptor, 'receive');
+        const change = await discovery(client, descriptor, 'change');
+        addresses = {
+            change: change.map(transformAddress),
+            used: receive.filter(({ history }) => history.length).map(transformAddress),
+            unused: receive.filter(({ history }) => !history.length).map(transformAddress),
+        };
+        history = flatten(
+            receive.map(({ history }) => history).concat(change.map(({ history }) => history))
+        );
+    }
+
+    const txs = await getTransactions(client, history).then(txs =>
+        txs
+            .filter(
+                ({ blockTime }) =>
+                    (from || 0) <= blockTime && blockTime <= (to || Number.MAX_SAFE_INTEGER)
+            )
+            .sort((a, b) => a.blockTime - b.blockTime)
+            .map(tx => ({ blockTime: -1, ...transformTransaction(descriptor, addresses, tx) }))
+    );
+
+    return aggregateTransactions(txs, groupBy);
+};
+
+export default getAccountBalanceHistory;

--- a/packages/blockchain-link/src/workers/electrum/methods/getAccountBalanceHistory.ts
+++ b/packages/blockchain-link/src/workers/electrum/methods/getAccountBalanceHistory.ts
@@ -62,7 +62,7 @@ const getAccountBalanceHistory: Api<Req, Res> = async (
     let history: HistoryTx[];
     let addresses: AccountAddresses | undefined;
 
-    const parsed = tryGetScripthash(descriptor);
+    const parsed = tryGetScripthash(descriptor, client.getInfo()?.network);
     if (parsed.valid) {
         history = await client.request('blockchain.scripthash.get_history', parsed.scripthash);
         addresses = undefined;

--- a/packages/blockchain-link/src/workers/electrum/methods/getAccountInfo.ts
+++ b/packages/blockchain-link/src/workers/electrum/methods/getAccountInfo.ts
@@ -1,0 +1,166 @@
+import {
+    Api,
+    flatten,
+    tryGetScripthash,
+    discovery,
+    AddressHistory,
+    getTransactions,
+    sum,
+} from '../utils';
+import { transformTransaction } from '../../blockbook/utils';
+import type { ElectrumAPI } from '../../../types/electrum';
+import type { GetAccountInfo as Req } from '../../../types/messages';
+import type { GetAccountInfo as Res } from '../../../types/responses';
+import type { VinVout } from '../../../types/blockbook';
+import type { Address } from '../../../types';
+
+// const PAGE_DEFAULT = 0;
+const PAGE_SIZE_DEFAULT = 25;
+
+type AddressInfo = Omit<AddressHistory, 'scripthash'> & {
+    confirmed: number;
+    unconfirmed: number;
+};
+
+const getBalances =
+    (client: ElectrumAPI) =>
+    (addresses: AddressHistory[]): Promise<AddressInfo[]> =>
+        Promise.all(
+            addresses.map(async ({ address, path, history, scripthash }) => {
+                const { confirmed, unconfirmed } = history.length
+                    ? await client.request('blockchain.scripthash.get_balance', scripthash)
+                    : {
+                          confirmed: 0,
+                          unconfirmed: 0,
+                      };
+                return {
+                    address,
+                    path,
+                    history,
+                    confirmed,
+                    unconfirmed,
+                };
+            })
+        );
+
+const getAccountInfo: Api<Req, Res> = async (client, payload) => {
+    const { descriptor, details = 'basic', pageSize } = payload;
+
+    const parsed = tryGetScripthash(descriptor);
+    if (parsed.valid) {
+        const { confirmed, unconfirmed, history } = await Promise.all([
+            client.request('blockchain.scripthash.get_balance', parsed.scripthash),
+            client.request('blockchain.scripthash.get_history', parsed.scripthash),
+        ]).then(([{ confirmed, unconfirmed }, history]) => ({
+            confirmed,
+            unconfirmed,
+            history,
+        }));
+        const historyUnconfirmed = history.filter(r => r.height <= 0).length;
+
+        const transactions =
+            details === 'txs'
+                ? await getTransactions(client, history).then(txs =>
+                      txs.map(tx => transformTransaction(descriptor, undefined, tx))
+                  )
+                : undefined;
+
+        const page =
+            details === 'txids' || details === 'txs'
+                ? {
+                      index: 1,
+                      size: pageSize || PAGE_SIZE_DEFAULT,
+                      total: 1,
+                  }
+                : undefined;
+
+        return {
+            descriptor,
+            balance: confirmed.toString(),
+            availableBalance: (confirmed + unconfirmed).toString(),
+            empty: !history.length,
+            history: {
+                total: history.length - historyUnconfirmed,
+                unconfirmed: historyUnconfirmed,
+                transactions,
+            },
+            page,
+        };
+    }
+
+    const receive = await discovery(client, descriptor, 'receive').then(getBalances(client));
+    const change = await discovery(client, descriptor, 'change').then(getBalances(client));
+    const batch = receive.concat(change);
+    const [confirmed, unconfirmed] = batch.reduce(
+        ([c, u], { confirmed, unconfirmed }) => [c + confirmed, u + unconfirmed],
+        [0, 0]
+    );
+    const history = flatten(batch.map(({ history }) => history));
+    const historyUnconfirmed = history.filter(r => r.height <= 0).length;
+
+    const transformAddressInfo = ({ address, path, history, confirmed }: AddressInfo): Address => ({
+        address,
+        path,
+        transfers: history.length,
+        balance: confirmed.toString(), // TODO or confirmed + unconfirmed?
+    });
+
+    const addresses = {
+        change: change.map(transformAddressInfo),
+        unused: receive.filter(recv => !recv.history.length).map(transformAddressInfo),
+        used: receive.filter(recv => recv.history.length).map(transformAddressInfo),
+    };
+
+    const transactions = ['tokenBalances', 'txids', 'txs'].includes(details)
+        ? await getTransactions(client, history).then(txs =>
+              txs.map(tx => transformTransaction(descriptor, addresses, tx))
+          )
+        : [];
+
+    const sumAddressValues = (
+        address: string,
+        getVinVouts: (tr: ReturnType<typeof transformTransaction>) => VinVout[]
+    ) =>
+        flatten(
+            transactions.map(tx =>
+                getVinVouts(tx)
+                    .filter(({ addresses }) => addresses?.includes(address))
+                    .map(({ value }) => (value ? Number.parseFloat(value) : 0))
+            )
+        ).reduce(sum, 0);
+
+    const extendAddressInfo = ({ address, path, transfers, balance }: Address): Address => ({
+        address,
+        path,
+        transfers,
+        ...(['tokenBalances', 'txids', 'txs'].includes(details) && transfers
+            ? {
+                  balance,
+                  sent: sumAddressValues(address, tx => tx.details.vin).toString(),
+                  received: sumAddressValues(address, tx => tx.details.vout).toString(),
+              }
+            : {}),
+    });
+
+    return {
+        descriptor,
+        balance: confirmed.toString(),
+        availableBalance: (confirmed + unconfirmed).toString(),
+        empty: !history.length,
+        history: {
+            total: history.length - historyUnconfirmed,
+            unconfirmed: historyUnconfirmed,
+            transactions: details === 'txs' ? transactions : undefined,
+        },
+        addresses:
+            details !== 'basic'
+                ? {
+                      change: addresses.change.map(extendAddressInfo),
+                      unused: addresses.unused.map(extendAddressInfo),
+                      used: addresses.used.map(extendAddressInfo),
+                  }
+                : undefined,
+    };
+};
+
+export default getAccountInfo;

--- a/packages/blockchain-link/src/workers/electrum/methods/getAccountInfo.ts
+++ b/packages/blockchain-link/src/workers/electrum/methods/getAccountInfo.ts
@@ -46,7 +46,7 @@ const getBalances =
 const getAccountInfo: Api<Req, Res> = async (client, payload) => {
     const { descriptor, details = 'basic', pageSize } = payload;
 
-    const parsed = tryGetScripthash(descriptor);
+    const parsed = tryGetScripthash(descriptor, client.getInfo()?.network);
     if (parsed.valid) {
         const { confirmed, unconfirmed, history } = await Promise.all([
             client.request('blockchain.scripthash.get_balance', parsed.scripthash),

--- a/packages/blockchain-link/src/workers/electrum/methods/getAccountUtxo.ts
+++ b/packages/blockchain-link/src/workers/electrum/methods/getAccountUtxo.ts
@@ -1,0 +1,52 @@
+import { Api, tryGetScripthash, discovery, flatten, fail } from '../utils';
+import type { GetAccountUtxo as Req } from '../../../types/messages';
+import type { GetAccountUtxo as Res } from '../../../types/responses';
+import type { Utxo } from '../../../types/electrum';
+
+const transformUtxo =
+    (currentHeight: number, addressInfo: { address?: string; path?: string } = {}) =>
+    ({ height, tx_hash, tx_pos, value }: Utxo): Res['payload'][number] => ({
+        txid: tx_hash,
+        vout: tx_pos,
+        amount: value.toString(),
+        address: '',
+        path: '',
+        ...addressInfo,
+        ...(height
+            ? {
+                  blockHeight: height,
+                  confirmations: currentHeight - height + 1,
+              }
+            : {
+                  blockHeight: -1,
+                  confirmations: 0,
+              }),
+    });
+
+const getAccountUtxo: Api<Req, Res> = async (client, descriptor) => {
+    const parsed = tryGetScripthash(descriptor);
+    const {
+        block: { height },
+    } = client.getInfo() || fail('Client not initialized');
+
+    if (parsed.valid) {
+        const utxos = await client.request('blockchain.scripthash.listunspent', parsed.scripthash);
+        return utxos.map(transformUtxo(height));
+    }
+
+    const receive = await discovery(client, descriptor, 'receive');
+    const change = await discovery(client, descriptor, 'change');
+    const result = await Promise.all(
+        receive
+            .concat(change)
+            .filter(a => a.history.length)
+            .map(({ address, path, scripthash }) =>
+                client
+                    .request('blockchain.scripthash.listunspent', scripthash)
+                    .then(utxos => utxos.map(transformUtxo(height, { address, path })))
+            )
+    ).then(flatten);
+    return result;
+};
+
+export default getAccountUtxo;

--- a/packages/blockchain-link/src/workers/electrum/methods/getAccountUtxo.ts
+++ b/packages/blockchain-link/src/workers/electrum/methods/getAccountUtxo.ts
@@ -24,7 +24,7 @@ const transformUtxo =
     });
 
 const getAccountUtxo: Api<Req, Res> = async (client, descriptor) => {
-    const parsed = tryGetScripthash(descriptor);
+    const parsed = tryGetScripthash(descriptor, client.getInfo()?.network);
     const {
         block: { height },
     } = client.getInfo() || fail('Client not initialized');

--- a/packages/blockchain-link/src/workers/electrum/methods/getBlockHash.ts
+++ b/packages/blockchain-link/src/workers/electrum/methods/getBlockHash.ts
@@ -1,0 +1,10 @@
+import { Api, blockheaderToBlockhash } from '../utils';
+import type { GetBlockHash as Req } from '../../../types/messages';
+import type { GetBlockHash as Res } from '../../../types/responses';
+
+const getBlockHash: Api<Req, Res> = async (client, payload) => {
+    const blockheader = await client.request('blockchain.block.header', payload);
+    return blockheaderToBlockhash(blockheader);
+};
+
+export default getBlockHash;

--- a/packages/blockchain-link/src/workers/electrum/methods/getInfo.ts
+++ b/packages/blockchain-link/src/workers/electrum/methods/getInfo.ts
@@ -1,0 +1,27 @@
+import { Api, blockheaderToBlockhash, fail } from '../utils';
+import type { GetInfo as Req } from '../../../types/messages';
+import type { GetInfo as Res } from '../../../types/responses';
+
+const NETWORK_INFO = {
+    name: 'Bitcoin',
+    shortcut: 'BTC',
+    testnet: false,
+    decimals: 8,
+};
+
+const getInfo: Api<Req, Res> = client => {
+    const {
+        url,
+        block: { hex, height },
+        version: [_name, version],
+    } = client.getInfo() || fail('Client not initialized');
+    return Promise.resolve({
+        url,
+        version,
+        blockHeight: height,
+        blockHash: blockheaderToBlockhash(hex),
+        ...NETWORK_INFO,
+    });
+};
+
+export default getInfo;

--- a/packages/blockchain-link/src/workers/electrum/methods/getInfo.ts
+++ b/packages/blockchain-link/src/workers/electrum/methods/getInfo.ts
@@ -2,16 +2,10 @@ import { Api, blockheaderToBlockhash, fail } from '../utils';
 import type { GetInfo as Req } from '../../../types/messages';
 import type { GetInfo as Res } from '../../../types/responses';
 
-const NETWORK_INFO = {
-    name: 'Bitcoin',
-    shortcut: 'BTC',
-    testnet: false,
-    decimals: 8,
-};
-
 const getInfo: Api<Req, Res> = client => {
     const {
         url,
+        coin,
         block: { hex, height },
         version: [_name, version],
     } = client.getInfo() || fail('Client not initialized');
@@ -20,7 +14,10 @@ const getInfo: Api<Req, Res> = client => {
         version,
         blockHeight: height,
         blockHash: blockheaderToBlockhash(hex),
-        ...NETWORK_INFO,
+        name: 'Bitcoin',
+        shortcut: coin,
+        testnet: coin === 'REGTEST',
+        decimals: 8,
     });
 };
 

--- a/packages/blockchain-link/src/workers/electrum/methods/getTransaction.ts
+++ b/packages/blockchain-link/src/workers/electrum/methods/getTransaction.ts
@@ -1,0 +1,13 @@
+import { Api, getTransactions } from '../utils';
+import type { GetTransaction as Req } from '../../../types/messages';
+import type { GetTransaction as Res } from '../../../types/responses';
+
+const getTransaction: Api<Req, Res> = async (client, payload) => {
+    const [tx] = await getTransactions(client, [{ tx_hash: payload, height: -1 }]);
+    return {
+        type: 'blockbook',
+        tx,
+    };
+};
+
+export default getTransaction;

--- a/packages/blockchain-link/src/workers/electrum/methods/index.ts
+++ b/packages/blockchain-link/src/workers/electrum/methods/index.ts
@@ -1,0 +1,8 @@
+export { default as estimateFee } from './estimateFee';
+export { default as getAccountBalanceHistory } from './getAccountBalanceHistory';
+export { default as getAccountInfo } from './getAccountInfo';
+export { default as getAccountUtxo } from './getAccountUtxo';
+export { default as getBlockHash } from './getBlockHash';
+export { default as getInfo } from './getInfo';
+export { default as getTransaction } from './getTransaction';
+export { default as pushTransaction } from './pushTransaction';

--- a/packages/blockchain-link/src/workers/electrum/methods/pushTransaction.ts
+++ b/packages/blockchain-link/src/workers/electrum/methods/pushTransaction.ts
@@ -1,0 +1,10 @@
+import { Api } from '../utils';
+import type { PushTransaction as Req } from '../../../types/messages';
+import type { PushTransaction as Res } from '../../../types/responses';
+
+const pushTransaction: Api<Req, Res> = async (client, payload) => {
+    const res = await client.request('blockchain.transaction.broadcast', payload);
+    return res;
+};
+
+export default pushTransaction;

--- a/packages/blockchain-link/src/workers/electrum/sockets/base.ts
+++ b/packages/blockchain-link/src/workers/electrum/sockets/base.ts
@@ -1,0 +1,97 @@
+import type { Socket as TCPSocket } from 'net';
+import type { TLSSocket } from 'tls';
+import type { SocksProxyAgent } from 'socks-proxy-agent';
+import type { ISocket, SocketListener } from './interface';
+
+const TIMEOUT = 10000;
+const KEEP_ALIVE = true;
+
+type Socket = TCPSocket | TLSSocket;
+
+export type SocketOptions = {
+    timeout?: number;
+    keepAlive?: boolean;
+    proxyAgent?: SocksProxyAgent;
+};
+
+type Err = Error &
+    Partial<{
+        errorno: string;
+        code: string;
+        connect: boolean;
+    }>;
+
+export type SocketConfig = SocketOptions & {
+    host: string;
+    port: number;
+};
+
+export abstract class SocketBase implements ISocket {
+    private socket?: Socket;
+    protected host: string;
+    protected port: number;
+    protected timeout: number;
+    protected keepAlive: boolean;
+
+    constructor({ host, port, timeout, keepAlive }: SocketConfig) {
+        this.host = host;
+        this.port = port;
+        this.timeout = timeout !== undefined ? timeout : TIMEOUT;
+        this.keepAlive = keepAlive !== undefined ? keepAlive : KEEP_ALIVE;
+    }
+
+    async connect(listener: SocketListener) {
+        this.socket = await this.openSocket(listener);
+    }
+
+    close() {
+        this.socket?.end();
+        this.socket?.destroy();
+    }
+
+    send(data: string | Uint8Array) {
+        return this.socket?.write(data);
+    }
+
+    protected abstract openSocket(listener: SocketListener): Promise<Socket>;
+
+    protected configureSocket(socket: Socket) {
+        socket.setTimeout(this.timeout);
+        socket.setEncoding('utf8');
+        socket.setKeepAlive(this.keepAlive);
+        socket.setNoDelay(true);
+    }
+
+    protected bindSocket(socket: Socket, listener: SocketListener) {
+        socket.on('connect', () => {
+            socket.setTimeout(0);
+            listener.onConnect();
+        });
+
+        socket.on('close', e => {
+            listener.onClose(e);
+        });
+
+        socket.on('timeout', () => {
+            const e: Err = new Error('ETIMEDOUT');
+            e.errorno = 'ETIMEDOUT';
+            e.code = 'ETIMEDOUT';
+            e.connect = false;
+            socket.emit('error', e);
+        });
+
+        socket.on('data', chunk => {
+            socket.setTimeout(0);
+            listener.onReceive(chunk);
+        });
+
+        socket.on('end', (e: unknown) => {
+            socket.setTimeout(0);
+            listener.onEnd(e);
+        });
+
+        socket.on('error', e => {
+            listener.onError(e);
+        });
+    }
+}

--- a/packages/blockchain-link/src/workers/electrum/sockets/index.ts
+++ b/packages/blockchain-link/src/workers/electrum/sockets/index.ts
@@ -1,0 +1,32 @@
+import { CustomError } from '../../../constants/errors';
+import { TcpSocket } from './tcp';
+import { TlsSocket } from './tls';
+import { TorSocket } from './tor';
+import type { SocketBase, SocketOptions } from './base';
+
+export const createSocket = (url: string, options?: SocketOptions): SocketBase => {
+    const [host, portString, protocol] = url.replace(/.*:\/\//, '').split(':');
+    if (!host) throw new CustomError('Missing host');
+    const port = Number.parseInt(portString, 10);
+    if (!port) throw new CustomError('Invalid port');
+    const { timeout, keepAlive, proxyAgent } = options || {};
+    // Onion address is TCP over Tor
+    if (proxyAgent /* host.endsWith('.onion') */) {
+        return new TorSocket({
+            host,
+            port,
+            timeout,
+            keepAlive,
+            proxyAgent,
+        });
+    }
+    // TCP socket
+    if (protocol === 't') {
+        return new TcpSocket({ host, port, timeout, keepAlive });
+    }
+    // TLS socket
+    if (!protocol || protocol === 's') {
+        return new TlsSocket({ host, port, timeout, keepAlive });
+    }
+    throw new CustomError('Invalid protocol');
+};

--- a/packages/blockchain-link/src/workers/electrum/sockets/interface.ts
+++ b/packages/blockchain-link/src/workers/electrum/sockets/interface.ts
@@ -1,0 +1,13 @@
+export type SocketListener = {
+    onConnect: () => void;
+    onReceive: (e: string) => void;
+    onClose: (e: unknown) => void;
+    onEnd: (e: unknown) => void;
+    onError: (e: unknown) => void;
+};
+
+export interface ISocket {
+    connect(listener: SocketListener): Promise<void>;
+    close(): void;
+    send(data: string): void;
+}

--- a/packages/blockchain-link/src/workers/electrum/sockets/tcp.ts
+++ b/packages/blockchain-link/src/workers/electrum/sockets/tcp.ts
@@ -1,0 +1,19 @@
+import { Socket as TCPSocket } from 'net';
+import { SocketBase } from './base';
+import type { SocketListener } from './interface';
+
+export class TcpSocket extends SocketBase {
+    protected openSocket(listener: SocketListener) {
+        const socket = new TCPSocket();
+        this.configureSocket(socket);
+        this.bindSocket(socket, listener);
+        return new Promise<TCPSocket>((resolve, reject) => {
+            const errorHandler = (err: Error) => reject(err);
+            socket.on('error', errorHandler);
+            socket.connect(this.port, this.host, () => {
+                socket.removeListener('error', errorHandler);
+                resolve(socket);
+            });
+        });
+    }
+}

--- a/packages/blockchain-link/src/workers/electrum/sockets/tls.ts
+++ b/packages/blockchain-link/src/workers/electrum/sockets/tls.ts
@@ -1,0 +1,19 @@
+import { TLSSocket } from 'tls';
+import { SocketBase } from './base';
+import type { SocketListener } from './interface';
+
+export class TlsSocket extends SocketBase {
+    protected openSocket(listener: SocketListener) {
+        const socket = new TLSSocket(null as any /* TODO omg why? */);
+        this.configureSocket(socket);
+        this.bindSocket(socket, listener);
+        return new Promise<TLSSocket>((resolve, reject) => {
+            const errorHandler = (err: Error) => reject(err);
+            socket.on('error', errorHandler);
+            socket.connect(this.port, this.host, () => {
+                socket.removeListener('error', errorHandler);
+                resolve(socket);
+            });
+        });
+    }
+}

--- a/packages/blockchain-link/src/workers/electrum/sockets/tor.ts
+++ b/packages/blockchain-link/src/workers/electrum/sockets/tor.ts
@@ -1,0 +1,30 @@
+import { SocketBase, SocketConfig } from './base';
+import type { SocksProxyAgent } from 'socks-proxy-agent';
+import type { SocketListener } from './interface';
+
+type TorSocketConfig = SocketConfig & {
+    proxyAgent: SocksProxyAgent;
+};
+
+export class TorSocket extends SocketBase {
+    private proxyAgent: SocksProxyAgent;
+
+    constructor({ proxyAgent, ...rest }: TorSocketConfig) {
+        super(rest);
+        this.proxyAgent = proxyAgent;
+    }
+
+    protected async openSocket(listener: SocketListener) {
+        const { host, port } = this;
+        const socket = await this.proxyAgent
+            .callback(null as any, { host, port, timeout: this.timeout, secureEndpoint: false })
+            .catch(e => {
+                listener.onError(e);
+                throw e;
+            });
+        listener.onConnect();
+        this.configureSocket(socket);
+        this.bindSocket(socket, listener);
+        return socket;
+    }
+}

--- a/packages/blockchain-link/src/workers/electrum/utils/addressManager.ts
+++ b/packages/blockchain-link/src/workers/electrum/utils/addressManager.ts
@@ -1,0 +1,101 @@
+import { flatten, notUndefined, separate, distinct } from './misc';
+import { addressToScripthash } from './transform';
+import type { AccountAddresses, SubscriptionAccountInfo } from '../../../types';
+
+type AddressMap = { [address: string]: string };
+type AccountMap = { [descriptor: string]: AccountAddresses };
+
+const addressesFromAccounts = (array: (AccountAddresses | undefined)[]) =>
+    flatten(
+        array
+            .filter(notUndefined)
+            .map(({ change, used, unused }) =>
+                change.concat(used, unused).map(({ address }) => address)
+            )
+    );
+
+export const createAddressManager = () => {
+    let subscribedAddrs: AddressMap = {};
+    let subscribedAccs: AccountMap = {};
+
+    const addAddresses = (addresses: string[]) => {
+        const toAdd = addresses.filter(distinct).filter(addr => !subscribedAddrs[addr]);
+
+        subscribedAddrs = toAdd.reduce<AddressMap>(
+            (dic, addr) => ({
+                ...dic,
+                [addr]: addressToScripthash(addr),
+            }),
+            subscribedAddrs
+        );
+
+        return toAdd.map(addr => subscribedAddrs[addr]);
+    };
+
+    const removeAddresses = (addresses?: string[]) => {
+        const [toRemove, toPreserve] = addresses
+            ? separate(subscribedAddrs, addresses)
+            : [subscribedAddrs, {}];
+
+        subscribedAddrs = toPreserve;
+
+        return Object.values(toRemove);
+    };
+
+    const addAccounts = (accounts: SubscriptionAccountInfo[]) => {
+        const toAdd = accounts.filter(acc => !subscribedAccs[acc.descriptor]);
+
+        subscribedAccs = toAdd.reduce<AccountMap>(
+            (dic, acc) => ({
+                ...dic,
+                [acc.descriptor]: acc.addresses || { change: [], used: [], unused: [] },
+            }),
+            subscribedAccs
+        );
+
+        const addresses = addressesFromAccounts(toAdd.map(acc => acc.addresses));
+
+        return addAddresses(addresses);
+    };
+
+    const removeAccounts = (accounts?: SubscriptionAccountInfo[]) => {
+        const [toRemove, toPreserve] = accounts
+            ? separate(
+                  subscribedAccs,
+                  accounts.map(({ descriptor }) => descriptor)
+              )
+            : [subscribedAccs, {}];
+
+        subscribedAccs = toPreserve;
+
+        const addresses = addressesFromAccounts(Object.values(toRemove));
+
+        return removeAddresses(addresses);
+    };
+
+    const getCount = () => Object.keys(subscribedAddrs).length;
+
+    const getInfo = (scripthash: string) => {
+        const [address, _sh] =
+            Object.entries(subscribedAddrs).find(([_addr, sh]) => sh === scripthash) || [];
+        if (!address) return { descriptor: scripthash };
+        const [account, addresses] =
+            Object.entries(subscribedAccs).find(
+                ([_acc, { change, unused, used }]) =>
+                    !!change.concat(used, unused).find(ad => ad.address === address)
+            ) || [];
+        return {
+            descriptor: account || address,
+            addresses,
+        };
+    };
+
+    return {
+        addAddresses,
+        removeAddresses,
+        addAccounts,
+        removeAccounts,
+        getCount,
+        getInfo,
+    };
+};

--- a/packages/blockchain-link/src/workers/electrum/utils/addressManager.ts
+++ b/packages/blockchain-link/src/workers/electrum/utils/addressManager.ts
@@ -1,5 +1,6 @@
 import { flatten, notUndefined, separate, distinct } from './misc';
 import { addressToScripthash } from './transform';
+import type { Network } from '@trezor/utxo-lib';
 import type { AccountAddresses, SubscriptionAccountInfo } from '../../../types';
 
 type AddressMap = { [address: string]: string };
@@ -14,7 +15,7 @@ const addressesFromAccounts = (array: (AccountAddresses | undefined)[]) =>
             )
     );
 
-export const createAddressManager = () => {
+export const createAddressManager = (network?: Network) => {
     let subscribedAddrs: AddressMap = {};
     let subscribedAccs: AccountMap = {};
 
@@ -24,7 +25,7 @@ export const createAddressManager = () => {
         subscribedAddrs = toAdd.reduce<AddressMap>(
             (dic, addr) => ({
                 ...dic,
-                [addr]: addressToScripthash(addr),
+                [addr]: addressToScripthash(addr, network),
             }),
             subscribedAddrs
         );

--- a/packages/blockchain-link/src/workers/electrum/utils/derivation.ts
+++ b/packages/blockchain-link/src/workers/electrum/utils/derivation.ts
@@ -1,0 +1,143 @@
+import { decode } from 'bs58';
+import { payments, bip32, networks } from '@trezor/utxo-lib';
+import { fail } from './misc';
+
+const BIP32_VERSIONS = {
+    // 76067358, xpub
+    0x0488b21e: {
+        type: 'pkh',
+        purpose: "44'",
+    },
+    // 77429938, ypub
+    0x049d7cb2: {
+        type: 'shwpkh',
+        purpose: "49'",
+    },
+    // 78792518, zpub
+    0x04b24746: {
+        type: 'wpkh',
+        purpose: "84'",
+    },
+} as const;
+
+type Version = keyof typeof BIP32_VERSIONS;
+
+const validateVersion = (version: number): version is Version =>
+    !!BIP32_VERSIONS[version as Version];
+
+type PaymentType = typeof BIP32_VERSIONS[Version]['type'] | 'tr';
+
+const getPubkeyToPayment = (type: PaymentType) => (pubkey: Buffer) => {
+    switch (type) {
+        case 'pkh':
+            return payments.p2pkh({ pubkey });
+        case 'shwpkh':
+            return payments.p2sh({
+                redeem: payments.p2wpkh({
+                    pubkey,
+                }),
+            });
+        case 'wpkh':
+            return payments.p2wpkh({ pubkey });
+        case 'tr':
+            return payments.p2tr({ pubkey });
+        default:
+            throw new Error(`Unknown payment type '${type}'`);
+    }
+};
+
+const parseDescriptor = (descriptor: string) => {
+    const [_match, _script, _fingerprint, purpose, coinType, account, xpub] =
+        descriptor.match(
+            /^([a-z]+\()+\[([a-z0-9]{8})\/([0-9]{2}'?)\/([01]'?)\/([0-9]+'?)\]([xyz]pub[a-zA-Z0-9]*)\/<0;1>\/\*\)+$/
+        ) || fail(`Descriptor cannot be parsed: ${descriptor}`);
+    return {
+        purpose,
+        coinType,
+        account,
+        xpub,
+    };
+};
+
+const getXpubDefaults = (xpub: string) => {
+    const version = decode(xpub).readUInt32BE();
+    if (!validateVersion(version)) throw new Error(`Unknown xpub version: ${xpub}`);
+    return {
+        version,
+        ...BIP32_VERSIONS[version],
+    };
+};
+
+const getXpubInfo = (xpub: string) => {
+    const { version, purpose, type } = getXpubDefaults(xpub);
+    const node = bip32.fromBase58(xpub, {
+        ...networks.bitcoin,
+        bip32: {
+            ...networks.bitcoin.bip32,
+            public: version,
+        },
+    });
+    const coinType = "0'";
+    // eslint-disable-next-line
+    const account = `${(node.index << 1) >>> 1}'`; // Unsigned to signed conversion
+    return {
+        purpose,
+        coinType,
+        account,
+        paymentType: type,
+        node,
+    };
+};
+
+const getDescriptorInfo = (descriptor: string, paymentType: PaymentType) => {
+    const { xpub, purpose, coinType, account } = parseDescriptor(descriptor);
+    const { node, ...rest } = getXpubInfo(xpub);
+    if (rest.account !== account) {
+        console.warn(`Account indices doesn't match: ${rest.account}, ${account}`);
+    }
+    return {
+        purpose,
+        coinType,
+        account,
+        paymentType,
+        node,
+    };
+};
+
+const recognizeDescriptor = (descriptor: string) => {
+    if (descriptor.startsWith('pkh(')) {
+        return getDescriptorInfo(descriptor, 'pkh');
+    }
+    if (descriptor.startsWith('sh(wpkh(')) {
+        return getDescriptorInfo(descriptor, 'shwpkh');
+    }
+    if (descriptor.startsWith('wpkh(')) {
+        return getDescriptorInfo(descriptor, 'wpkh');
+    }
+    if (descriptor.startsWith('tr(')) {
+        return getDescriptorInfo(descriptor, 'tr');
+    }
+    return getXpubInfo(descriptor);
+};
+
+export const deriveAddresses = (
+    descriptor: string,
+    type: 'receive' | 'change',
+    from: number,
+    count: number
+): {
+    address: string;
+    path: string;
+}[] => {
+    const { purpose, coinType, account, node, paymentType } = recognizeDescriptor(descriptor);
+    const getAddress = getPubkeyToPayment(paymentType);
+    const change = type === 'receive' ? 0 : 1;
+    const changeNode = node.derive(change);
+    return Array.from(Array(count).keys())
+        .map(i => changeNode.derive(from + i).publicKey)
+        .map(a => getAddress(a).address || fail('Cannot convert pubkey to address'))
+        .map((address, i) => ({
+            address,
+            path: `m/${purpose}/${coinType}/${account}/${change}/${from + i}`,
+        }));
+};

--- a/packages/blockchain-link/src/workers/electrum/utils/discovery.ts
+++ b/packages/blockchain-link/src/workers/electrum/utils/discovery.ts
@@ -1,0 +1,53 @@
+import { deriveAddresses } from './derivation';
+import { addressToScripthash } from './transform';
+import type { ElectrumAPI, HistoryTx } from '../../../types/electrum';
+
+const DISCOVERY_LOOKOUT = 20;
+
+export type AddressHistory = {
+    address: string;
+    scripthash: string;
+    path: string;
+    history: HistoryTx[];
+};
+
+const countUnusedFromEnd = (array: AddressHistory[]): number => {
+    const boundary = array.length > DISCOVERY_LOOKOUT ? array.length - DISCOVERY_LOOKOUT : 0;
+    for (let i = array.length; i > boundary; --i) {
+        if (array[i - 1].history.length) {
+            return array.length - i;
+        }
+    }
+    return array.length;
+};
+
+const discoverAddress =
+    (client: ElectrumAPI) =>
+    async ({
+        address,
+        path,
+    }: ReturnType<typeof deriveAddresses>[number]): Promise<AddressHistory> => {
+        const scripthash = addressToScripthash(address);
+        const history = await client.request('blockchain.scripthash.get_history', scripthash);
+        return {
+            address,
+            scripthash,
+            path,
+            history,
+        };
+    };
+
+export const discovery = (client: ElectrumAPI, xpub: string, type: 'receive' | 'change') => {
+    const discoverRecursive = async (
+        from: number,
+        prev: AddressHistory[]
+    ): Promise<AddressHistory[]> => {
+        const unused = countUnusedFromEnd(prev);
+        if (unused >= DISCOVERY_LOOKOUT) return prev;
+        const moreCount = DISCOVERY_LOOKOUT - unused;
+        const addresses = deriveAddresses(xpub, type, from, moreCount);
+        const more = await Promise.all(addresses.map(discoverAddress(client)));
+        return discoverRecursive(from + moreCount, prev.concat(more));
+    };
+    return discoverRecursive(0, []);
+};

--- a/packages/blockchain-link/src/workers/electrum/utils/discovery.ts
+++ b/packages/blockchain-link/src/workers/electrum/utils/discovery.ts
@@ -27,7 +27,7 @@ const discoverAddress =
         address,
         path,
     }: ReturnType<typeof deriveAddresses>[number]): Promise<AddressHistory> => {
-        const scripthash = addressToScripthash(address);
+        const scripthash = addressToScripthash(address, client.getInfo()?.network);
         const history = await client.request('blockchain.scripthash.get_history', scripthash);
         return {
             address,

--- a/packages/blockchain-link/src/workers/electrum/utils/index.ts
+++ b/packages/blockchain-link/src/workers/electrum/utils/index.ts
@@ -1,0 +1,13 @@
+import type { Response } from '../../../types';
+import type { ElectrumAPI } from '../../../types/electrum';
+
+export * from './addressManager';
+export * from './derivation';
+export * from './discovery';
+export * from './transform';
+export * from './transaction';
+export * from './misc';
+
+export type Api<M, R extends Omit<Response, 'id'>> = M extends { payload: any }
+    ? (client: ElectrumAPI, params: M['payload']) => Promise<R['payload']>
+    : (client: ElectrumAPI) => Promise<R['payload']>;

--- a/packages/blockchain-link/src/workers/electrum/utils/misc.ts
+++ b/packages/blockchain-link/src/workers/electrum/utils/misc.ts
@@ -1,0 +1,31 @@
+export const arrayToDic = <T>(array: T[], getKey: (item: T) => string) =>
+    array.reduce<{ [key: string]: T }>(
+        (prev, cur) => ({
+            ...prev,
+            [getKey(cur)]: cur,
+        }),
+        {}
+    );
+
+export const separate = <T>(dic: { [key: string]: T }, keys: string[]) =>
+    keys.reduce(
+        ([included, excluded], key) => {
+            const { [key]: value, ...rest } = excluded;
+            return typeof value !== 'undefined'
+                ? [{ ...included, [key]: value }, rest]
+                : [included, excluded];
+        },
+        [{}, dic]
+    );
+
+export const notUndefined = <T>(item?: T): item is T => typeof item !== 'undefined';
+
+export const distinct = <T>(txid: T, index: number, self: T[]) => self.indexOf(txid) === index;
+
+export const flatten = <T>(array: T[][]): T[] => ([] as T[]).concat(...array);
+
+export const sum = (a: number, b: number) => a + b;
+
+export const fail = (reason: string) => {
+    throw new Error(reason);
+};

--- a/packages/blockchain-link/src/workers/electrum/utils/transform.ts
+++ b/packages/blockchain-link/src/workers/electrum/utils/transform.ts
@@ -1,0 +1,35 @@
+import { address as a, crypto as c } from '@trezor/utxo-lib';
+
+export const btcToSat = (btc: number) => Math.round(100000000 * btc).toString();
+
+export const addressToScripthash = (address: string) => {
+    const script = a.toOutputScript(address);
+    const scripthash = c.sha256(script).reverse().toString('hex');
+    return scripthash;
+};
+
+export const scriptToScripthash = (hex: string) => {
+    const buffer = Buffer.from(hex, 'hex');
+    return c.sha256(buffer).reverse().toString('hex');
+};
+
+export const blockheaderToBlockhash = (header: string) => {
+    const buffer = Buffer.from(header, 'hex');
+    const hash = c.hash256(buffer).reverse().toString('hex');
+    return hash;
+};
+
+export const tryGetScripthash = (
+    address: string
+): { valid: true; scripthash: string } | { valid: false } => {
+    try {
+        return {
+            valid: true,
+            scripthash: addressToScripthash(address),
+        };
+    } catch {
+        return {
+            valid: false,
+        };
+    }
+};

--- a/packages/blockchain-link/src/workers/electrum/utils/transform.ts
+++ b/packages/blockchain-link/src/workers/electrum/utils/transform.ts
@@ -1,9 +1,9 @@
-import { address as a, crypto as c } from '@trezor/utxo-lib';
+import { address as a, crypto as c, Network } from '@trezor/utxo-lib';
 
 export const btcToSat = (btc: number) => Math.round(100000000 * btc).toString();
 
-export const addressToScripthash = (address: string) => {
-    const script = a.toOutputScript(address);
+export const addressToScripthash = (address: string, network?: Network) => {
+    const script = a.toOutputScript(address, network);
     const scripthash = c.sha256(script).reverse().toString('hex');
     return scripthash;
 };
@@ -20,12 +20,13 @@ export const blockheaderToBlockhash = (header: string) => {
 };
 
 export const tryGetScripthash = (
-    address: string
+    address: string,
+    network?: Network
 ): { valid: true; scripthash: string } | { valid: false } => {
     try {
         return {
             valid: true,
-            scripthash: addressToScripthash(address),
+            scripthash: addressToScripthash(address, network),
         };
     } catch {
         return {

--- a/packages/blockchain-link/tests/unit/electrum.ts
+++ b/packages/blockchain-link/tests/unit/electrum.ts
@@ -1,0 +1,28 @@
+import fixtures from './fixtures/electrum';
+import { deriveAddresses } from '../../src/workers/electrum/utils/derivation';
+
+describe('Testing address derivation from xpubs', () => {
+    fixtures.derivation.forEach(f => {
+        it(f.description, () => {
+            const { xpubs, change, receive, pathPrefix } = f;
+
+            xpubs.forEach(xpub => {
+                const rec = deriveAddresses(xpub, 'receive', 0, receive.length);
+                expect(
+                    receive.map((address, i) => ({
+                        address,
+                        path: `${pathPrefix}/0/${i}`,
+                    }))
+                ).toEqual(rec);
+
+                const cng = deriveAddresses(xpub, 'change', 0, change.length);
+                expect(
+                    change.map((address, i) => ({
+                        address,
+                        path: `${pathPrefix}/1/${i}`,
+                    }))
+                ).toEqual(cng);
+            });
+        });
+    });
+});

--- a/packages/blockchain-link/tests/unit/fixtures/electrum.ts
+++ b/packages/blockchain-link/tests/unit/fixtures/electrum.ts
@@ -1,0 +1,112 @@
+export default {
+    derivation: [
+        {
+            description: 'First xpub of all seed',
+            xpubs: [
+                'xpub6BiVtCpG9fQPxnPmHXG8PhtzQdWC2Su4qWu6XW9tpWFYhxydCLJGrWBJZ5H6qTAHdPQ7pQhtpjiYZVZARo14qHiay2fvrX996oEP42u8wZy',
+                "pkh([5c9e228d/44'/0'/0']xpub6BiVtCpG9fQPxnPmHXG8PhtzQdWC2Su4qWu6XW9tpWFYhxydCLJGrWBJZ5H6qTAHdPQ7pQhtpjiYZVZARo14qHiay2fvrX996oEP42u8wZy/<0;1>/*)",
+            ],
+            pathPrefix: "m/44'/0'/0'",
+            receive: [
+                '1JAd7XCBzGudGpJQSDSfpmJhiygtLQWaGL',
+                '1GWFxtwWmNVqotUPXLcKVL2mUKpshuJYo',
+                '1Eni8JFS4yA2wJkicc3yx3QzCNzopLybCM',
+                '124dT55Jqpj9AKTyJnTX6G8RkUs7ReTzun',
+                '15T9DSqc6wjkPxcr2MNVSzF9JAePdvS3n1',
+            ],
+            change: [
+                '1DyHzbQUoQEsLxJn6M7fMD8Xdt1XvNiwNE',
+                '139SnSTcoTF7jpkqh4wZFc7y6fQ1SLj4oR',
+                '1E9KUz71DjP3rNk2Xibd1FwyHLWfbnhrCz',
+                '1EcL6AyfQTyWKGvXwNSfsWoYnD3whzVFdu',
+                '1G4xRtLmjuKnXfNaR2wVZcv2LFwjuVXova',
+            ],
+        },
+        {
+            description: 'Second xpub of all seed',
+            xpubs: [
+                'xpub6BiVtCpG9fQQ1EW99bMSYwySbPWvzTFRQZCFgTmV3samLSZAYU7C3f4Je9vkNh7h1GAWi5Fn93BwoGBy9EAXbWTTgTnVKAbthHpxM1fXVRL',
+            ],
+            pathPrefix: "m/44'/0'/1'",
+            receive: [
+                '1Dgews942GZs2GV7JT5v1t4KxuaDZpJgG9',
+                '1JU5KeFft721edDn21TjHsWspP3WRUwKks',
+                '1AnSRAXb1edeitKfvqWqDDJ3D3u7UHjSe3',
+                '12ACCMJ7zQ7sjRqZgeerQTcHxwWCVoxXgJ',
+                '1DcRyGXW5E8s3hCSkFi6gPBUbfKT6Lnzfs',
+            ],
+            change: [
+                '1LDXMxD2rsDHevMEoQAv8jqdgBZ5QNq2z8',
+                '14ngocLr2N2d4Pm4oBCRa4DRzu9R1au35t',
+                '1E24zAcYH7tNeZDYvAmBHTLKEwbsqwysV',
+                '1GywuG7nURzdhys4EgG2iTkitwrTtkSe4z',
+                '18h8dwNfoSA7HtiLXVnNoWEJHjSGHdiaXv',
+            ],
+        },
+        {
+            description: 'First ypub of all seed',
+            xpubs: [
+                'ypub6XKbB5DSkq8Royg8isNtGktj6bmEfGJXDs83Ad5CZ5tpDV8QofwSWQFTWP2Pv24vNdrPhquehL7vRMvSTj2GpKv6UaTQCBKZALm6RJAmxG6',
+                "sh(wpkh([5c9e228d/49'/0'/0']xpub6CVKsQYXc9awxgV1tWbG4foDvdcnieK2JkbpPEBKB5WwAPKBZ1mstLbKVB4ov7QzxzjaxNK6EfmNY5Jsk2cG26EVcEkycGW4tchT2dyUhrx/<0;1>/*))",
+            ],
+            pathPrefix: "m/49'/0'/0'",
+            receive: [
+                '3L6TyTisPBmrDAj6RoKmDzNnj4eQi54gD2',
+                '3GMMgFUQiYTYQhuHQuZfQoXPvW3GPqfGmD',
+                '3BKbtvJtLSjnSoGUYTeQ17tMKTuyqbUV7P',
+                '3Dyf1D6pVR6ZAQYN1th6ehgS1uqgGk1TGh',
+                '33wLRyxHFtrXLF7Aun38Dctw5QyiBdruK2',
+            ],
+            change: [
+                '3Jdnbtqg3f8YberUzEirLLAumsp7RYt4Kw',
+                '33nnWkqcLEQAmafj9LwKxNqypPWssrNWfB',
+                '3C8Cekw7txB392s8qr9ABCRLysTxxUgGv2',
+                '3Fc9XcbBskvGaHGNLoYDu8ti68nQvQrAQj',
+                '3P6rpDhDGpyZXGk8ZTqk1QVJFcWeWH5QF3',
+            ],
+        },
+        {
+            description: 'First zpub of all seed',
+            xpubs: [
+                'zpub6rszzdAK6RuafeRwyN8z1cgWcXCuKbLmjjfnrW4fWKtcoXQ8787214pNJjnBG5UATyghuNzjn6Lfp5k5xymrLFJnCy46bMYJPyZsbpFGagT',
+                "wpkh([5c9e228d/84'/0'/0']xpub6DDUPHpUo4pcy43iJeZjbSVWGav1SMMmuWdMHiGtkK8rhKmfbomtkwW6GKs1GGAKehT6QRocrmda3WWxXawpjmwaUHfFRXuKrXSapdckEYF/<0;1>/*)",
+            ],
+            pathPrefix: "m/84'/0'/0'",
+            receive: [
+                'bc1qannfxke2tfd4l7vhepehpvt05y83v3qsf6nfkk',
+                'bc1q7e6qu5smalrpgqrx9k2gnf0hgjyref5p36ru2m',
+                'bc1q5f2lvs7t29wv8nwssse6a4f6099sc3nagchqyc',
+                'bc1q6hr68ewf72l6r7cj6ut286x0xkwg5706jq450u',
+                'bc1q7zql632newlfv9rt269jyxdn30370rh4kp23pd',
+            ],
+            change: [
+                'bc1qktmhrsmsenepnnfst8x6j27l0uqv7ggrg8x38q',
+                'bc1q0tl5v4u3ct2xgf8cmzgsgx2t76vxpzy5y7afuj',
+                'bc1qrzt6et9754t86mm4xjlqz8zmdcumh5p0fh7037',
+                'bc1qkhtd2nqfrxngl3fghtjtdesuu04zkfw5h0p0p2',
+                'bc1qhlm0ahnghjcjcpgrd70uvzyrwy5y8y2eyd8gsx',
+            ],
+        },
+        {
+            description: 'First taproot of all seed',
+            xpubs: [
+                "tr([5c9e228d/86'/0'/0']xpub6Bw885JisRbcKmowfBvMmCxaFHodKn1VpmRmctmJJoM8D4DzyP4qJv8ZdD9V9r3SSGjmK2KJEDnvLH6f1Q4HrobEvnCeKydNvf1eir3RHZk/<0;1>/*)",
+            ],
+            pathPrefix: "m/86'/0'/0'",
+            receive: [
+                'bc1ptxs597p3fnpd8gwut5p467ulsydae3rp9z75hd99w8k3ljr9g9rqx6ynaw',
+                'bc1plca7n9vs7d906nwlqyvk0d0jxnxss6x7w3x2y879quuvj8xn3p3s7vrrl2',
+                'bc1pks4em3l8vg4zyk5xpcmgygh7elkhu03z3fqj48a2a2lv948cn4hsyltl3h',
+                'bc1pvlme5mvcme0mqvfxknqr4mmcajthd9c9vqwknfghgvnsdt0ghtyquf66nq',
+                'bc1pu4kdwq4jvpk3psqt6tw38fax7l20xj8y6gtzdgm9dj2amgy6t77sn420ak',
+            ],
+            change: [
+                'bc1pgypgja2hmcx2l6s2ssq75k6ev68ved6nujcspt47dgvkp8euc70s6uegk6',
+                'bc1p74s7kfn0ckxtz44dhzvkfvkn8relggkk4q2lxe5d8e03m09gj03qaa6m4d',
+                'bc1pfdq8ju5ns9e2l3fmkrn5e4cxynk3r2nhvvr0zwcad7xwxqck0q8smsjzqm',
+                'bc1pjr4k7glxyh2s8pu36pm8anmquj4yav8nqyke04mhpvvx9u5h7lzqramszw',
+                'bc1pm7ry8yykuz7e56dyraczpj728jg8wlz5u7gwutdecxjxczlehz4q70glmv',
+            ],
+        },
+    ],
+};

--- a/packages/blockchain-link/tsconfig.workers.json
+++ b/packages/blockchain-link/tsconfig.workers.json
@@ -6,6 +6,7 @@
     "include": [
         "./src/workers/ripple/index.ts",
         "./src/workers/blockbook/index.ts",
-        "./src/workers/blockfrost/index.ts"
+        "./src/workers/blockfrost/index.ts",
+        "./src/workers/electrum/index.ts"
     ]
 }

--- a/packages/suite/src/actions/wallet/fiatRatesActions.ts
+++ b/packages/suite/src/actions/wallet/fiatRatesActions.ts
@@ -5,7 +5,7 @@ import {
     getFiatRatesForTimestamps,
     fetchLastWeekRates,
     fetchCurrentTokenFiatRates,
-} from '@suite/services/coingecko';
+} from '@suite/services/fiat';
 import { getAccountTransactions, isTestnet } from '@wallet-utils/accountUtils';
 import { getBlockbookSafeTime } from '@suite-utils/date';
 import { FIAT } from '@suite-config';

--- a/packages/suite/src/components/suite/modals/AdvancedCoinSettings/components/BackendTypeSelect.tsx
+++ b/packages/suite/src/components/suite/modals/AdvancedCoinSettings/components/BackendTypeSelect.tsx
@@ -1,7 +1,9 @@
-import React from 'react';
+import React, { useMemo } from 'react';
 import styled from 'styled-components';
 import { Select } from '@trezor/components';
 import { Translation } from '@suite-components';
+import { isDesktop } from '@suite-utils/env';
+import { useSelector } from '@suite-hooks';
 import type { Network } from '@wallet-types';
 import type { BackendOption } from '@settings-hooks/backends';
 
@@ -9,23 +11,31 @@ const Capitalize = styled.span`
     text-transform: capitalize;
 `;
 
-const getBackendOptions = (network: Network) => {
-    const backends: BackendOption[] = [];
-    if (network.symbol !== 'regtest') backends.push('default');
-    if (network.networkType !== 'ripple') backends.push('blockbook');
-    // if (network.symbol === 'btc') backends.push('electrum');
-    return backends.map(backend => ({
-        label:
-            backend === 'default' ? (
-                <Translation id="TR_BACKEND_DEFAULT_SERVERS" />
-            ) : (
-                <Translation
-                    id="TR_BACKEND_CUSTOM_SERVERS"
-                    values={{ type: <Capitalize>{backend}</Capitalize> }}
-                />
-            ),
-        value: backend,
-    }));
+const useBackendOptions = (network: Network) => {
+    const debug = useSelector(state => state.suite.settings.debug.showDebugMenu);
+
+    const options = useMemo(() => {
+        const backends: BackendOption[] = [];
+        if (network.symbol !== 'regtest') backends.push('default');
+        if (network.networkType !== 'ripple') backends.push('blockbook');
+        if (['btc', 'regtest'].includes(network.symbol) && isDesktop() && debug)
+            backends.push('electrum');
+
+        return backends.map(backend => ({
+            label:
+                backend === 'default' ? (
+                    <Translation id="TR_BACKEND_DEFAULT_SERVERS" />
+                ) : (
+                    <Translation
+                        id="TR_BACKEND_CUSTOM_SERVERS"
+                        values={{ type: <Capitalize>{backend}</Capitalize> }}
+                    />
+                ),
+            value: backend,
+        }));
+    }, [network, debug]);
+
+    return options;
 };
 
 type BackendTypeSelectProps = {
@@ -35,7 +45,7 @@ type BackendTypeSelectProps = {
 };
 
 export const BackendTypeSelect = ({ network, value, onChange }: BackendTypeSelectProps) => {
-    const backendOptions = getBackendOptions(network);
+    const backendOptions = useBackendOptions(network);
 
     const changeType = (option: { value: BackendOption }) => onChange(option.value);
 

--- a/packages/suite/src/services/fiat/blockbook.ts
+++ b/packages/suite/src/services/fiat/blockbook.ts
@@ -1,0 +1,81 @@
+import { RateLimiter } from './limiter';
+import type { LastWeekRates, TimestampedRates, TickerId } from '@wallet-types/fiatRates';
+
+const ENDPOINTS = {
+    btc: ['btc1', 'btc2', 'btc3', 'btc4', 'btc5'],
+};
+
+type Ticker = keyof typeof ENDPOINTS;
+
+const randomEndpoint = (ticker: Ticker) =>
+    ENDPOINTS[ticker][Math.floor(Math.random() * ENDPOINTS[ticker].length)];
+
+const getQuery = (query?: { currency?: string; timestamp?: number | string }) =>
+    Object.entries(query || {})
+        .filter(([, val]) => val !== undefined)
+        .map(([key, val]) => `${key}=${val}`)
+        .join('&');
+
+const getApiUrl = (ticker: Ticker) => `https://${randomEndpoint(ticker)}.trezor.io/api/v2`;
+
+const limiter = new RateLimiter(500);
+
+const request = <T>(url: string): Promise<T | null> =>
+    limiter
+        .limit(() => fetch(url))
+        .then(res =>
+            res.ok
+                ? res.json()
+                : Promise.reject(new Error(`Fiat rates failed to fetch: ${res.status}`)),
+        )
+        .catch(err => {
+            console.warn(err);
+            return null;
+        });
+
+const getTickers = (ticker: Ticker, timestamp?: number, currency?: string) => {
+    const url = `${getApiUrl(ticker)}/tickers/?${getQuery({
+        timestamp,
+        currency,
+    })}`;
+
+    return request<TimestampedRates>(url);
+};
+
+const getMultiTickers = async (
+    ticker: Ticker,
+    timestamps: number[],
+    currency?: string,
+): Promise<LastWeekRates | null> => {
+    const url = `${getApiUrl(ticker)}/multi-tickers/?${getQuery({
+        timestamp: timestamps.join(','),
+        currency,
+    })}`;
+
+    const rates = !timestamps.length ? [] : await request<TimestampedRates[]>(url);
+
+    return (
+        rates && {
+            ts: new Date().getTime(),
+            symbol: ticker,
+            tickers: rates.map((rate, i) => ({ ...rate, ts: timestamps[i] })),
+        }
+    );
+};
+
+const getLastWeekTimestamps = () =>
+    Array.from(Array(7).keys()).map(i => {
+        const date = new Date();
+        date.setDate(date.getDate() - 7 + i);
+        return Math.floor(date.getTime() / 1000);
+    });
+
+export const isTickerSupported = (ticker: TickerId): ticker is TickerId & { symbol: Ticker } =>
+    !!ENDPOINTS[ticker.symbol as Ticker];
+
+export const fetchCurrentFiatRates = getTickers;
+
+export const getFiatRatesForTimestamps = getMultiTickers;
+
+export const fetchLastWeekRates = (ticker: Ticker, currency: string) =>
+    getMultiTickers(ticker, getLastWeekTimestamps(), currency);

--- a/packages/suite/src/services/fiat/coingecko.ts
+++ b/packages/suite/src/services/fiat/coingecko.ts
@@ -1,52 +1,13 @@
 /* eslint-disable max-classes-per-file */
 import { LastWeekRates, TickerId } from '@wallet-types/fiatRates';
 import FIAT_CONFIG from '@suite-config/fiat';
-import { differenceInMilliseconds } from 'date-fns';
+import { RateLimiter } from './limiter';
 
 // a proxy for https://api.coingecko.com/api/v3
 const COINGECKO_API_BASE_URL = 'https://cdn.trezor.io/dynamic/coingecko/api/v3';
 
 interface HistoricalResponse extends LastWeekRates {
     symbol: string;
-}
-
-class RateLimiter {
-    // Poor man's coingecko rate limiter
-    // Slows down requests so there is `delayMs` gap between them
-    private delayMs: number; // gap between each request
-    private lastFetchTimestamp: number;
-    private queued: number; // how many requests are waiting to be fired
-    private totalDelay: number; // by how much time are we gonna slown down next request
-
-    constructor(delayMs: number) {
-        this.delayMs = delayMs;
-
-        this.lastFetchTimestamp = 0;
-        this.queued = 0;
-        this.totalDelay = 0;
-    }
-
-    async limit<T>(fn: () => Promise<T>): Promise<T> {
-        const msSinceLastFetch = differenceInMilliseconds(
-            new Date().getTime(),
-            this.lastFetchTimestamp,
-        );
-        if (msSinceLastFetch < this.delayMs) {
-            this.queued += 1;
-            this.totalDelay += this.delayMs;
-            // dummy wait for this.totalDelay before we fire next request
-            await new Promise(resolve => setTimeout(resolve, this.totalDelay)); // slow down firing next request
-        }
-
-        this.lastFetchTimestamp = new Date().getTime();
-        const results = await fn();
-        this.queued -= 1;
-        if (this.queued === 0) {
-            // if all queued requests were fired, we need to reset totalDelay to properly delay next batch of requests
-            this.totalDelay = 0;
-        }
-        return results;
-    }
 }
 
 const rateLimiter = new RateLimiter(1000);

--- a/packages/suite/src/services/fiat/index.ts
+++ b/packages/suite/src/services/fiat/index.ts
@@ -1,9 +1,30 @@
-import * as coingecko from './coingecko';
+import * as cg from './coingecko';
+import * as bb from './blockbook';
+import type { TickerId, TimestampedRates, LastWeekRates } from '@wallet-types/fiatRates';
 
-export const {
-    getTickerConfig,
-    fetchCurrentTokenFiatRates,
-    fetchCurrentFiatRates,
-    fetchLastWeekRates,
-    getFiatRatesForTimestamps,
-} = coingecko;
+export const { getTickerConfig, fetchCurrentTokenFiatRates } = cg;
+
+export const fetchCurrentFiatRates = async (ticker: TickerId): Promise<TimestampedRates | null> => {
+    const res = bb.isTickerSupported(ticker) ? await bb.fetchCurrentFiatRates(ticker.symbol) : null;
+    return res ?? cg.fetchCurrentFiatRates(ticker);
+};
+
+export const fetchLastWeekRates = async (
+    ticker: TickerId,
+    currency: string,
+): Promise<LastWeekRates | null> => {
+    const res = bb.isTickerSupported(ticker)
+        ? await bb.fetchLastWeekRates(ticker.symbol, currency)
+        : null;
+    return res ?? cg.fetchLastWeekRates(ticker, currency);
+};
+
+export const getFiatRatesForTimestamps = async (
+    ticker: TickerId,
+    timestamps: number[],
+): Promise<LastWeekRates | null> => {
+    const res = bb.isTickerSupported(ticker)
+        ? await bb.getFiatRatesForTimestamps(ticker.symbol, timestamps)
+        : null;
+    return res ?? cg.getFiatRatesForTimestamps(ticker, timestamps);
+};

--- a/packages/suite/src/services/fiat/index.ts
+++ b/packages/suite/src/services/fiat/index.ts
@@ -1,0 +1,9 @@
+import * as coingecko from './coingecko';
+
+export const {
+    getTickerConfig,
+    fetchCurrentTokenFiatRates,
+    fetchCurrentFiatRates,
+    fetchLastWeekRates,
+    getFiatRatesForTimestamps,
+} = coingecko;

--- a/packages/suite/src/services/fiat/limiter.ts
+++ b/packages/suite/src/services/fiat/limiter.ts
@@ -1,0 +1,40 @@
+import { differenceInMilliseconds } from 'date-fns';
+
+export class RateLimiter {
+    // Poor man's rate limiter
+    // Slows down requests so there is `delayMs` gap between them
+    private delayMs: number; // gap between each request
+    private lastFetchTimestamp: number;
+    private queued: number; // how many requests are waiting to be fired
+    private totalDelay: number; // by how much time are we gonna slown down next request
+
+    constructor(delayMs: number) {
+        this.delayMs = delayMs;
+
+        this.lastFetchTimestamp = 0;
+        this.queued = 0;
+        this.totalDelay = 0;
+    }
+
+    async limit<T>(fn: () => Promise<T>): Promise<T> {
+        const msSinceLastFetch = differenceInMilliseconds(
+            new Date().getTime(),
+            this.lastFetchTimestamp,
+        );
+        if (msSinceLastFetch < this.delayMs) {
+            this.queued += 1;
+            this.totalDelay += this.delayMs;
+            // dummy wait for this.totalDelay before we fire next request
+            await new Promise(resolve => setTimeout(resolve, this.totalDelay)); // slow down firing next request
+        }
+
+        this.lastFetchTimestamp = new Date().getTime();
+        const results = await fn();
+        this.queued -= 1;
+        if (this.queued === 0) {
+            // if all queued requests were fired, we need to reset totalDelay to properly delay next batch of requests
+            this.totalDelay = 0;
+        }
+        return results;
+    }
+}

--- a/packages/suite/src/utils/wallet/graphUtils.ts
+++ b/packages/suite/src/utils/wallet/graphUtils.ts
@@ -13,7 +13,7 @@ import {
 } from '@wallet-types/graph';
 import { formatNetworkAmount } from './accountUtils';
 import { resetTime } from '@suite-utils/date';
-import { getFiatRatesForTimestamps, getTickerConfig } from '@suite/services/coingecko';
+import { getFiatRatesForTimestamps, getTickerConfig } from '@suite/services/fiat';
 
 type FiatRates = NonNullable<CoinFiatRates['current']>['rates'];
 

--- a/packages/utxo-lib/src/bufferutils.ts
+++ b/packages/utxo-lib/src/bufferutils.ts
@@ -110,11 +110,25 @@ export function cloneBuffer(buffer: Buffer): Buffer {
     return clone;
 }
 
-export const pushDataSize = pushdata.encodingLength;
-export const readPushDataInt = pushdata.decode;
+// These types need to be defined here, otherwise
+// importing @trezor/utxo-lib/lib from blockchain-link fails
+// because of missing pushdata-bitcoin types
+type PushDataSize = (len: number) => number;
+type ReadPushDataInt = (
+    buffer: Buffer,
+    offset: number,
+) => {
+    opcode: number;
+    number: number;
+    size: number;
+};
+type WritePushDataInt = (buffer: Buffer, number: number, offset: number) => number;
+
+export const pushDataSize: PushDataSize = pushdata.encodingLength;
+export const readPushDataInt: ReadPushDataInt = pushdata.decode;
 // export const varIntBuffer = varuint.encode; // TODO: not-used
 export const varIntSize = varuint.encodingLength;
-export const writePushDataInt = pushdata.encode;
+export const writePushDataInt: WritePushDataInt = pushdata.encode;
 
 /**
  * Helper class for serialization of bitcoin data types into a pre-allocated buffer.

--- a/patches/trezor-connect+8.2.7-beta.3.patch
+++ b/patches/trezor-connect+8.2.7-beta.3.patch
@@ -1,0 +1,29 @@
+diff --git a/node_modules/trezor-connect/lib/backend/BlockchainLink.js b/node_modules/trezor-connect/lib/backend/BlockchainLink.js
+index 765cf6b..63e79d6 100644
+--- a/node_modules/trezor-connect/lib/backend/BlockchainLink.js
++++ b/node_modules/trezor-connect/lib/backend/BlockchainLink.js
+@@ -38,6 +38,9 @@ var getWorker = function getWorker(type) {
+     case 'blockfrost':
+       return _workers.BlockfrostWorker;
+ 
++    case 'electrum':
++      return _workers.ElectrumWorker;
++
+     default:
+       return null;
+   }
+diff --git a/node_modules/trezor-connect/lib/env/node/workers.js b/node_modules/trezor-connect/lib/env/node/workers.js
+index 4ca7840..f2c38cb 100644
+--- a/node_modules/trezor-connect/lib/env/node/workers.js
++++ b/node_modules/trezor-connect/lib/env/node/workers.js
+@@ -16,6 +16,10 @@ exports.RippleWorker = _ripple["default"];
+ var _blockfrost = _interopRequireDefault(require("@trezor/blockchain-link/lib/workers/blockfrost"));
+ 
+ exports.BlockfrostWorker = _blockfrost["default"];
++
++var _electrum = _interopRequireDefault(require("@trezor/blockchain-link/lib/workers/electrum"));
++
++exports.ElectrumWorker = _electrum["default"];
+ var WebUsbPlugin = undefined;
+ exports.WebUsbPlugin = WebUsbPlugin;
+ var ReactNativeUsbPlugin = undefined;


### PR DESCRIPTION
## Electrum backend pre-alpha
### How to run
- `yarn workspace @trezor/blockchain-link dev:electrum`, which runs `devrun.ts` file, or
- `yarn suite:dev:desktop --electrum=${URL}`
    - URL is in format **host**:**port**:[**t**|**s**] (**t** for tcp, **s** for ssl)
    - public server list for example [here](https://1209k.com/bitcoin-eye/ele.php)
    - our private electrs instance runs at `electrum.corp.sldev.cz:50001:t`

**DO NOT USE TOO BIG ACCOUNTS OR PUBLIC SERVER WILL LIKELY BAN YOU**

### Commits
- https://github.com/trezor/trezor-suite/pull/4500/commits/98f8c1f5c066b73ba60e552dfda48ac75780efb1 - added electrum worker to `@trezor/blockchain-link` package, which translates Blockchain Link requests to Electrum and, vice versa, Electrum responses to Blockchain Link. Ideally, Trezor Suite shouldn't even know that the backend is different (except setting the custom backend, of course).
- https://github.com/trezor/trezor-suite/pull/4500/commits/7187a878c40d00dbc7b00c8978b7e23e93aa2540 - added API to `@trezor/suite-desktop` for forwarding requests from connect iframe via TCP/TLS socket and back to iframe.
- https://github.com/trezor/trezor-suite/pull/4500/commits/c27c6758be59cbfb0b31eaedcb357b79dcf233e9 - random changes needed for development, which should be removed or fixed later (e.g. temporarily patched `trezor-connect` to support new backend type)

### Structure (only important files/folders)
- `packages/blockchain-link/src/types/electrum.ts` - interface definition of [ElectrumX API 1.4](https://electrumx-spesmilo.readthedocs.io/en/latest/protocol-methods.html), implemented by Electrum client below
- `packages/blockchain-link/src/workers/electrum/`
    - `index.ts` - contains electrum worker's root, similarly to blockbook worker's index file
    - `client/` - Electrum client, based on https://github.com/CodeWarriorr/electrum-client-js, which translates typed method calls to text messages, sends them via given socket and returns messages received from that socket. Consists of 4 hierarchical classes:
        - `json-rpc.ts` - pure JSON RPC client, doesn't know anything about meaning of messages
        - `batching.ts` - **optional** extension of json-rpc, supports message batching
        - `electrum.ts` - uses underlying JSON RPC client to communicate according to Electrum protocol
        - `caching.ts` - **optional** extension of Electrum client, with simple request caching 
    - `sockets/` - contains different types of sockets (TCP, TLS...) implementing `ISocket` interface, which can be passed to Electrum client to provide means of communication
        - `proxy.ts` - special type of socket which uses desktopApi to create a bridge between Electrum client and any other socket in electron layer of application
    - `methods/` - particular methods of Blockchain Link API, translating multiple Electrum responses to single BlockchainLink response
    - `listeners/` - subscription to new block/new transaction events from server
    - `utils/` - data transform methods, helper methods etc., some of them could be probably moved to utxo-lib later
 - `packages/suite-desktop/src-electron/modules/`
     - `electrum.ts` - desktop app module which forwards requests and responses between proxy socket in web layer and other socket in electron layer, via desktopApi

### Notes
- electrum worker is not in fact a worker, but uses @szymonlesisz's  [packages/blockchain-link/src/workers/context.ts](https://github.com/trezor/trezor-suite/blob/c6c584902dc5dd5ad4b39b61b30a27765f24fcdd/packages/blockchain-link/src/workers/context.ts) instead to look like one
- currently electrum backend is not supported in web Suite, because TCP/TLS sockets are not accessible there and WebSockets are rarely enabled on Electrum servers. It could be added later.
- caching layer should be added as there is too much requests to Electrum server for some single BlockchainLink requests (**EDIT**: simple caching was added, but must be thoroughly tested)
