### PR TITLE
feat(suite-desktop): electron renderer process running in browser

### DIFF
--- a/packages/suite-desktop/src/index.tsx
+++ b/packages/suite-desktop/src/index.tsx
@@ -31,7 +31,7 @@ const Index = () => {
         if (!isDev) {
             initSentry(SENTRY_CONFIG);
         }
-        window.desktopApi!.clientReady();
+        window.desktopApi?.clientReady();
     }, []);
 
     return (

--- a/packages/suite-desktop/src/support/DesktopUpdater.tsx
+++ b/packages/suite-desktop/src/support/DesktopUpdater.tsx
@@ -37,7 +37,7 @@ const DesktopUpdater = ({ setIsUpdateVisible }: Props) => {
 
     useEffect(() => {
         if (!desktopUpdate.enabled) {
-            window.desktopApi!.on('update/enable', enable);
+            window.desktopApi?.on('update/enable', enable);
             return;
         }
         window.desktopApi!.on('update/checking', checking);

--- a/packages/suite/src/support/suite/Tor.tsx
+++ b/packages/suite/src/support/suite/Tor.tsx
@@ -28,8 +28,8 @@ const Tor = () => {
         }
 
         if (isDesktop()) {
-            window.desktopApi!.getStatus();
-            window.desktopApi!.on('tor/status', updateTorStatus);
+            window.desktopApi?.getStatus();
+            window.desktopApi?.on('tor/status', updateTorStatus);
         }
     }, [updateTorStatus]);
 


### PR DESCRIPTION
close #4495

Not required and maybe not useful for you but:
Changing few `!` to `?` enables running renderer process of a desktop app in browser. It is not super required. However, at least for me it will speedup a process of development because sometimes I am developing something in desktop app and I need to check something e.g. in context or React dev tools (#2728). In this case, I have to exit desktop app and run browser app. This would help me to save some time.

https://user-images.githubusercontent.com/33235762/141804427-3af53d98-3c16-42e2-9834-b73836c7fa8d.mov


