### PR TITLE
feat(ci): remove lib and node modules from git clean flags

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -6,7 +6,7 @@ variables:
   STAGING_WALLET_SERVER_URL: "https://staging-wallet.trezor.io/wallet"
   STAGING_SUITE_SERVER_URL: "https://staging-suite.trezor.io"
   DESKTOP_APP_NAME: "Trezor-Suite"
-  GIT_CLEAN_FLAGS: "-ffdx -e node_modules -e packages/*/lib -e .yarn"
+  GIT_CLEAN_FLAGS: "-ffdx -e .yarn"
 
 stages:
   - setup environment

--- a/ci/prebuild.yml
+++ b/ci/prebuild.yml
@@ -2,6 +2,7 @@
 msg-system config sign dev:
   stage: prebuild
   script:
+    - yarn install --frozen-lockfile --cache-folder .yarn --prefer-offline
     - yarn workspace @trezor/suite-data msg-system-sign-config
   artifacts:
     expire_in: 7 days

--- a/ci/validation.yml
+++ b/ci/validation.yml
@@ -29,4 +29,5 @@ yaml lint:
 msg-system config validation:
   stage: validation
   script:
+    - yarn install --frozen-lockfile --cache-folder .yarn --prefer-offline
     - yarn workspace @trezor/suite-data msg-system-validate-config


### PR DESCRIPTION
This removes `node_modules` and `.yarn` from GIT_CLEAN_FLAGS  
