### PR TITLE
chore(suite): update trezor-connect 8.2.3-beta.3

### DIFF
--- a/packages/suite/package.json
+++ b/packages/suite/package.json
@@ -62,7 +62,7 @@
         "semver": "^7.3.5",
         "styled-components": "5.1.1",
         "trezor-address-validator": "^0.4.0",
-        "trezor-connect": "8.2.2-beta.4",
+        "trezor-connect": "8.2.3-beta.3",
         "ua-parser-js": "^0.7.28",
         "uuid": "^8.3.2",
         "web3-utils": "^1.2.6",

--- a/packages/suite/src/actions/settings/deviceSettingsActions.ts
+++ b/packages/suite/src/actions/settings/deviceSettingsActions.ts
@@ -1,5 +1,5 @@
 /* eslint-disable @typescript-eslint/naming-convention */
-import TrezorConnect, { ApplySettings, ChangePin, ResetDevice } from 'trezor-connect';
+import TrezorConnect from 'trezor-connect';
 import { addToast } from '@suite-actions/notificationActions';
 import * as suiteActions from '@suite-actions/suiteActions';
 import * as deviceUtils from '@suite-utils/device';
@@ -10,7 +10,8 @@ import { DEVICE } from '@suite-constants';
 import { SUITE } from '@suite-actions/constants';
 
 export const applySettings =
-    (params: ApplySettings) => async (dispatch: Dispatch, getState: GetState) => {
+    (params: Parameters<typeof TrezorConnect.applySettings>[0]) =>
+    async (dispatch: Dispatch, getState: GetState) => {
         const { device } = getState().suite;
         if (!device) return;
         const result = await TrezorConnect.applySettings({
@@ -29,7 +30,7 @@ export const applySettings =
     };
 
 export const changePin =
-    (params: ChangePin = {}) =>
+    (params: Parameters<typeof TrezorConnect.changePin>[0] = {}) =>
     async (dispatch: Dispatch, getState: GetState) => {
         const { device } = getState().suite;
 
@@ -88,7 +89,7 @@ export const wipeDevice = () => async (dispatch: Dispatch, getState: GetState) =
 };
 
 export const resetDevice =
-    (params: ResetDevice = {}) =>
+    (params: Parameters<typeof TrezorConnect.resetDevice>[0] = {}) =>
     async (dispatch: Dispatch, getState: GetState) => {
         const { device } = getState().suite;
         if (!device) return;

--- a/packages/utxo-lib/package.json
+++ b/packages/utxo-lib/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@trezor/utxo-lib",
-    "version": "1.0.0-beta.9",
+    "version": "1.0.0-beta.10",
     "author": "Trezor <info@trezor.io>",
     "homepage": "https://github.com/trezor/trezor-suite/packages/utxo-lib",
     "description": "Client-side Bitcoin-like JavaScript library",

--- a/yarn.lock
+++ b/yarn.lock
@@ -25195,16 +25195,16 @@ trezor-address-validator@^0.4.0:
     jssha "2.3.1"
     lodash "^4.17.15"
 
-trezor-connect@8.2.2-beta.4:
-  version "8.2.2-beta.4"
-  resolved "https://registry.yarnpkg.com/trezor-connect/-/trezor-connect-8.2.2-beta.4.tgz#d3a19697e2ba3f88a981318e1fabfe9850e2b740"
-  integrity sha512-EwEkl1iz376WbSSnHtlN+GysYhwgyZvzW6Bl6OWhzFSeUEmyteLIFXmC0TsZQb/9bKM/WXtwn+mdDeIfUae34A==
+trezor-connect@8.2.3-beta.3:
+  version "8.2.3-beta.3"
+  resolved "https://registry.yarnpkg.com/trezor-connect/-/trezor-connect-8.2.3-beta.3.tgz#5f397a95839ed39472cbaf1b1d3cbaacc04a2530"
+  integrity sha512-WOyhVjEYyk7+CwJaMKEzJ8o4wj5RmYmbUr2mr/Dwl4YiJXWK2J+RWwYf97HsGJFL4DUmCzRmkmF8oIK8l8QLSQ==
   dependencies:
     "@babel/runtime" "^7.15.4"
     "@trezor/blockchain-link" "^1.0.17"
     "@trezor/connect-common" "^0.0.2"
     "@trezor/rollout" "^1.2.0"
-    "@trezor/utxo-lib" "1.0.0-beta.9"
+    "@trezor/utxo-lib" "1.0.0-beta.10"
     bignumber.js "^9.0.1"
     bowser "^2.11.0"
     cbor-web "^7.0.6"


### PR DESCRIPTION
## trezor-connect changes
- enabled support for Taproot T1 FW 1.10.4
- Taproot descriptor range updated from {0,1} to <0,1>
- using utxo/lib beta.10 released from branch fb9eb4b with breaking changes in fees
- Regtest support
- add AOPP support for signMessage method
- add experimental_features in ApplySettings
- Cardano derivation_path support


suite code (types) changed because of [this commit](https://github.com/trezor/connect/commit/83b028ea551f7cafa9e3cd10922cec3cc9ab7a05)
