### PR TITLE
fix(suite): Ethereum transaction with token transfers shown incorrectly

### DIFF
--- a/packages/suite/src/components/wallet/TransactionItem/components/Target/index.tsx
+++ b/packages/suite/src/components/wallet/TransactionItem/components/Target/index.tsx
@@ -37,7 +37,7 @@ export const TokenTransfer = ({
 
     ...baseLayoutProps
 }: TokenTransferProps) => {
-    const operation = getTxOperation(transaction);
+    const operation = getTxOperation(transfer);
     return (
         <BaseTargetLayout
             {...baseLayoutProps}

--- a/packages/suite/src/utils/wallet/transactionUtils.ts
+++ b/packages/suite/src/utils/wallet/transactionUtils.ts
@@ -259,7 +259,9 @@ export const analyzeTransactions = (
     });
 };
 
-export const getTxOperation = (tx: WalletAccountTransaction) => {
+// getTxOperation is used with types WalletAccountTransaction and ArrayElement<WalletAccountTransaction['tokens']
+// the only interesting field is 'type', which has compatible string literal union in both types
+export const getTxOperation = (tx: { type: WalletAccountTransaction['type'] }) => {
     if (tx.type === 'sent' || tx.type === 'self' || tx.type === 'failed') {
         return 'neg';
     }


### PR DESCRIPTION
Fixes #4526. 
It is necessary to detect the sign from the individual token transfer, not from the whole transaction.
The transaction after fix:
![image](https://user-images.githubusercontent.com/11609674/142932896-976b8ee5-9bca-4cbf-a0ee-04c0889dbae6.png)
