### PR TITLE
chore(e2e): make all tests run against latest released fw

### DIFF
--- a/packages/integration-tests/projects/suite-web/tests/firmware/firmware.test.ts
+++ b/packages/integration-tests/projects/suite-web/tests/firmware/firmware.test.ts
@@ -38,20 +38,18 @@ describe('Firmware', () => {
         });
     });
 
-    ['1-master', '2-master'].forEach(fw => {
-        it(`For latest firmware ${fw}, update button in device settings should display "Up to date" but still be clickable`, () => {
-            cy.task('startEmu', { wipe: true, version: fw });
-            cy.task('setupEmu');
-            cy.task('startBridge');
-            cy.prefixedVisit('/');
-            cy.passThroughInitialRun();
-            cy.getTestElement('@suite/menu/settings').click();
-            cy.getTestElement('@suite/menu/settings-index').click();
-            cy.getTestElement('@settings/menu/device').click();
-            cy.getTestElement('@settings/device/update-button')
-                .should('contain.text', 'Up to date')
-                .click();
-            cy.getTestElement('@modal/close-button').click();
-        });
+    it(`For the latest firmware, update button in device settings should display "Up to date" but still be clickable`, () => {
+        cy.task('startEmu', { wipe: true });
+        cy.task('setupEmu');
+        cy.task('startBridge');
+        cy.prefixedVisit('/');
+        cy.passThroughInitialRun();
+        cy.getTestElement('@suite/menu/settings').click();
+        cy.getTestElement('@suite/menu/settings-index').click();
+        cy.getTestElement('@settings/menu/device').click();
+        cy.getTestElement('@settings/device/update-button')
+            .should('contain.text', 'Up to date')
+            .click();
+        cy.getTestElement('@modal/close-button').click();
     });
 });

--- a/packages/integration-tests/projects/suite-web/tests/metadata/wallet-metadata.test.ts
+++ b/packages/integration-tests/projects/suite-web/tests/metadata/wallet-metadata.test.ts
@@ -19,7 +19,7 @@ describe('Metadata - wallet labeling', () => {
     providers.forEach(provider => {
         it(provider, () => {
             // prepare test
-            cy.task('startEmu', { wipe: true, version: Cypress.env('emuVersionT2') });
+            cy.task('startEmu', { wipe: true });
             cy.task('setupEmu', {
                 mnemonic,
             });

--- a/packages/integration-tests/projects/suite-web/tests/recovery/t2-dry-run-persistence.test.ts
+++ b/packages/integration-tests/projects/suite-web/tests/recovery/t2-dry-run-persistence.test.ts
@@ -5,7 +5,7 @@
 
 describe('Recovery - dry run', () => {
     beforeEach(() => {
-        cy.task('startEmu', { wipe: true, version: Cypress.env('emuVersionT2') });
+        cy.task('startEmu', { wipe: true });
         cy.task('setupEmu', {
             mnemonic: 'all all all all all all all all all all all all',
         });
@@ -36,7 +36,7 @@ describe('Recovery - dry run', () => {
         cy.task('stopEmu');
         cy.getTestElement('@recovery/close-button', { timeout: 30000 }).click();
         cy.getTestElement('@connect-device-prompt');
-        cy.task('startEmu', { wipe: false, version: Cypress.env('emuVersionT2') });
+        cy.task('startEmu', { wipe: false });
         cy.getTestElement('@suite/modal/confirm-action-on-device', { timeout: 20000 });
         cy.task('pressYes');
         cy.log('At this moment, communication with device should be re-established');

--- a/packages/integration-tests/projects/suite-web/tests/settings/t2-device-settings.test.ts
+++ b/packages/integration-tests/projects/suite-web/tests/settings/t2-device-settings.test.ts
@@ -3,7 +3,7 @@
 
 describe('T2 - Device settings', () => {
     it('change all possible device settings', () => {
-        cy.task('startEmu', { wipe: true, version: Cypress.env('emuVersionT2') });
+        cy.task('startEmu', { wipe: true });
         cy.task('setupEmu');
         cy.task('startBridge');
 

--- a/packages/integration-tests/projects/suite-web/tests/suite/guide.test.ts
+++ b/packages/integration-tests/projects/suite-web/tests/suite/guide.test.ts
@@ -3,7 +3,7 @@
 
 describe('Test Guide', () => {
     beforeEach(() => {
-        cy.task('startEmu', { wipe: true, version: Cypress.env('emuVersionT2') });
+        cy.task('startEmu', { wipe: true });
         cy.task('setupEmu');
         cy.task('startBridge');
         cy.viewport(1024, 768).resetDb();

--- a/packages/integration-tests/projects/suite-web/tests/suite/passhprase-duplicate.test.ts
+++ b/packages/integration-tests/projects/suite-web/tests/suite/passhprase-duplicate.test.ts
@@ -3,7 +3,7 @@
 
 describe('Passphrase', () => {
     beforeEach(() => {
-        cy.task('startEmu', { wipe: true, version: Cypress.env('emuVersionT2') });
+        cy.task('startEmu', { wipe: true });
         cy.task('setupEmu', { passphrase_protection: true });
         cy.task('startBridge');
 

--- a/packages/integration-tests/projects/suite-web/tests/suite/passhprase-numbering.test.ts
+++ b/packages/integration-tests/projects/suite-web/tests/suite/passhprase-numbering.test.ts
@@ -3,7 +3,7 @@
 
 describe('Passphrase', () => {
     beforeEach(() => {
-        cy.task('startEmu', { wipe: true, version: Cypress.env('emuVersionT2') });
+        cy.task('startEmu', { wipe: true });
         cy.task('setupEmu', { passphrase_protection: true });
         cy.task('startBridge');
         // eslint-disable-next-line @typescript-eslint/naming-convention

--- a/packages/integration-tests/projects/suite-web/tests/suite/passphrase-disabled.test.ts
+++ b/packages/integration-tests/projects/suite-web/tests/suite/passphrase-disabled.test.ts
@@ -11,7 +11,7 @@ describe('Suite switch wallet modal', () => {
     });
 
     it('passphrase_protection: false', () => {
-        cy.task('startEmu', { wipe: true, version: Cypress.env('emuVersionT2') });
+        cy.task('startEmu', { wipe: true });
         cy.task('setupEmu', { passphrase_protection: false });
 
         cy.prefixedVisit('/');

--- a/packages/integration-tests/projects/suite-web/tests/suite/passphrase.test.ts
+++ b/packages/integration-tests/projects/suite-web/tests/suite/passphrase.test.ts
@@ -8,7 +8,7 @@ describe('Passphrase', () => {
     beforeEach(() => {
         // note that versions before 2.3.1 don't have passphrase caching, this means that returning
         // back to passphrase that was used before in the session would require to type the passphrase again
-        cy.task('startEmu', { wipe: true, version: Cypress.env('emuVersionT2') });
+        cy.task('startEmu', { wipe: true });
         cy.task('setupEmu', { mnemonic: 'all all all all all all all all all all all all' });
         cy.task('startBridge');
 

--- a/packages/integration-tests/projects/suite-web/tests/suite/tooltip.test.ts
+++ b/packages/integration-tests/projects/suite-web/tests/suite/tooltip.test.ts
@@ -3,7 +3,7 @@
 
 describe('Test tooltip links', () => {
     beforeEach(() => {
-        cy.task('startEmu', { wipe: true, version: Cypress.env('emuVersionT2') });
+        cy.task('startEmu', { wipe: true });
         cy.task('setupEmu', { passphrase_protection: true });
         cy.task('startBridge');
         // eslint-disable-next-line @typescript-eslint/naming-convention
@@ -26,7 +26,7 @@ describe('Test tooltip links', () => {
 
 describe('Test tooltip conditional rendering', () => {
     beforeEach(() => {
-        cy.task('startEmu', { wipe: true, version: Cypress.env('emuVersionT2') });
+        cy.task('startEmu', { wipe: true });
         cy.task('setupEmu', { mnemonic: 'all all all all all all all all all all all all' });
         cy.task('startBridge');
         cy.viewport(1024, 768).resetDb();

--- a/packages/integration-tests/projects/suite-web/tests/wallet/sign-and-verify.test.ts
+++ b/packages/integration-tests/projects/suite-web/tests/wallet/sign-and-verify.test.ts
@@ -10,7 +10,7 @@ const SIGNATURE =
 
 describe('Sign and verify', () => {
     beforeEach(() => {
-        cy.task('startEmu', { wipe: true, version: Cypress.env('emuVersionT2') });
+        cy.task('startEmu', { wipe: true });
         cy.task('setupEmu', { mnemonic: SEED });
         cy.task('startBridge');
 


### PR DESCRIPTION
- first commit - In my previous PR I mysteriously missed bunch of cases where version is provided directly from test. In most of cases we want to run default firmware version which is the latest released version at time of running the tests. At the moment all tests against 2-master are failing, so at least we know that I haven't missed a single case this time :smile: 
- second commit - removes one test case from firmware.test.ts. 