### PR TITLE
feat: wipe locally saved data from debug settings

### DIFF
--- a/packages/suite-desktop/src-electron/libs/constants.ts
+++ b/packages/suite-desktop/src-electron/libs/constants.ts
@@ -25,6 +25,7 @@ export const MODULES = [
     'auto-updater',
     'store',
     'udev-install',
+    'user-data',
 ];
 
 // Modules only used in prod mode

--- a/packages/suite-desktop/src-electron/libs/user-data.ts
+++ b/packages/suite-desktop/src-electron/libs/user-data.ts
@@ -38,3 +38,30 @@ export const read = async (directory: string, name: string) => {
         return { success: false, error };
     }
 };
+
+export const clear = async () => {
+    const dir = app.getPath('userData');
+    try {
+        await fs.promises.rm(dir, { recursive: true, force: true });
+        return { success: true };
+    } catch (error) {
+        global.logger.error('user-data', `Remove dir failed: ${error.message}`);
+        return { success: false, error };
+    }
+};
+
+export const getInfo = () => {
+    const dir = app.getPath('userData');
+    try {
+        return {
+            success: true,
+            payload: {
+                dir,
+                // possibly more info can be returned (size, last modified,...)
+            },
+        };
+    } catch (error) {
+        global.logger.error('user-data', `getInfo failed: ${error.message}`);
+        return { success: false, error };
+    }
+};

--- a/packages/suite-desktop/src-electron/modules/user-data.ts
+++ b/packages/suite-desktop/src-electron/modules/user-data.ts
@@ -1,0 +1,19 @@
+import * as userData from '@desktop-electron/libs/user-data';
+
+import { ipcMain } from 'electron';
+
+const init = () => {
+    const { logger } = global;
+
+    ipcMain.handle('user-data/get-info', () => {
+        logger.info('user-data', `Gathering user-data info.`);
+        return userData.getInfo();
+    });
+
+    ipcMain.handle('user-data/clear', () => {
+        logger.info('user-data', `Clearing user-data.`);
+        return userData.clear();
+    });
+};
+
+export default init;

--- a/packages/suite-desktop/src-electron/preload.ts
+++ b/packages/suite-desktop/src-electron/preload.ts
@@ -78,6 +78,10 @@ contextBridge.exposeInMainWorld('desktopApi', {
     // Store
     clearStore: () => ipcRenderer.send('store/clear'),
 
+    // user-data
+    clearUserData: () => ipcRenderer.invoke('user-data/clear'),
+    getUserDataInfo: () => ipcRenderer.invoke('user-data/get-info'),
+
     // Udev rules
     installUdevRules: () => ipcRenderer.invoke('udev/install'),
 });

--- a/packages/suite/global.d.ts
+++ b/packages/suite/global.d.ts
@@ -1,5 +1,16 @@
 type SuiteThemeVariant = 'light' | 'dark' | 'custom';
 
+type Result<Payload = undefined> = Promise<
+    | {
+          success: true;
+          payload?: Payload;
+      }
+    | {
+          success: false;
+          error: string;
+      }
+>;
+
 // Interface for exposed Electron API (ipcRenderer)
 interface DesktopApi {
     on: (channel: string, func: (...args: any[]) => any) => void;
@@ -36,8 +47,10 @@ interface DesktopApi {
     setTorAddress: (address: string) => void;
     // Store
     clearStore: () => void;
+    clearUserData: () => Result;
+    getUserDataInfo: () => Result<{ dir: string }>;
     // Udev rules
-    installUdevRules: () => Promise<{ success: true } | { success: false; error: string }>;
+    installUdevRules: () => Result;
 }
 
 interface Window {


### PR DESCRIPTION
Some design input is needed here!

There are basically 2 groups of locally saved data for desktop:
A]  "store", which cointans stuff such as update settings, theme settings, tor settings, etc related info
B] "everything else" - which contains whatever applications needs to save for its own purposes under the hood and/or what we chose to save, for example locally saved labelling data.

Right now, clicking "Reset App" button wipes only A]

![image](https://user-images.githubusercontent.com/30367552/146191357-bb955d7c-45f8-49a3-97eb-0a12aa2f1dbb.png)

![image](https://user-images.githubusercontent.com/30367552/146193353-44e3f0b0-a765-4858-9a7d-d4c81aeed4ad.png)

I made some changes so that clicking "Reset app" button wipes entire content of appData folder - which is effectively everything. While this is an option we probably want to have (#4533) I think we want to communicate this better. It might even have sense to have 2 different buttons for this? 

Also note that this does not remove all traces of Trezor Suite being used on given computer at all. This button also restarts the application upon which fresh folder structure in app data folder is recreated. 




