### PR TITLE
tests(e2e): add node tasks retryability

### DIFF
--- a/packages/integration-tests/package.json
+++ b/packages/integration-tests/package.json
@@ -17,6 +17,7 @@
         "@cypress/skip-test": "^2.6.1",
         "@cypress/webpack-preprocessor": "^5.9.1",
         "cypress-image-snapshot": "^4.0.1",
+        "cypress-wait-until": "^1.7.2",
         "chrome-remote-interface": "^0.31.0",
         "shelljs": "^0.8.4",
         "wait-on": "^5.3.0",

--- a/packages/integration-tests/projects/suite-web/support/commands.ts
+++ b/packages/integration-tests/projects/suite-web/support/commands.ts
@@ -2,6 +2,7 @@
 /* eslint-disable @typescript-eslint/no-var-requires */
 
 import TrezorConnect, { Device, Features } from 'trezor-connect';
+import 'cypress-wait-until';
 import { Store, Action } from '@suite-types';
 
 import {

--- a/packages/integration-tests/projects/suite-web/tests/metadata/account-metadata.test.ts
+++ b/packages/integration-tests/projects/suite-web/tests/metadata/account-metadata.test.ts
@@ -5,8 +5,10 @@ import { rerouteMetadataToMockProvider, stubOpen } from '../../stubs/metadata';
 
 // fixture contains number of request that given provider needs go through this test scenario
 const fixtures = [
-    { provider: 'dropbox', numberOfRequests: [27, 28] },
-    { provider: 'google', numberOfRequests: [10, 12] },
+    // todo: [27, 28] when taproot firmware (2.4.3) is in suite
+    { provider: 'dropbox', numberOfRequests: [25, 26] },
+    // todo: [10, 12] when taproot firmware (2.4.3) is in suite
+    { provider: 'google', numberOfRequests: [9, 12] },
 ] as const;
 
 describe(`Metadata is by default disabled, this means, that application does not try to generate master key and connect to cloud.
@@ -97,10 +99,14 @@ Hovering over fields that may be labeled shows "add label" button upon which is 
             //                      in future there should be mocked discovery
             //                      if it shoots somebody in leg, just remove this assertion...
             // - why asserting it:  just to make sure that metadata don't send unnecessary amount of request
-            cy.wait(2000);
-            cy.task('metadataGetRequests', { provider: f.provider }).then(requests => {
-                expect(requests).to.have.length(f.numberOfRequests[0]);
-            });
+            cy.waitUntil(() =>
+                cy.task('metadataGetRequests', { provider: f.provider }).then(requests => {
+                    cy.log(
+                        `requests.length ${requests.length} of expected ${f.numberOfRequests[0]}`,
+                    );
+                    expect(requests.length).equal(f.numberOfRequests[0]);
+                }),
+            );
 
             // test switching between accounts. make sure that "success" button does not remain
             // visible when switching between accounts
@@ -116,15 +122,15 @@ Hovering over fields that may be labeled shows "add label" button upon which is 
             // go to another route that triggers discovery and check whether there are any requests to metadata providers
             cy.getTestElement('@suite/menu/suite-index').click();
             cy.getTestElement('@dashboard/graph');
-            // using wait is almost always anti-pattern but I guess we can live with it
-            // problem is that cypress built in retry ability can't be used here when
-            // retrieving number of requests from node.js
-            cy.wait(2000);
-            cy.getTestElement('@dashboard/graph');
 
-            cy.task('metadataGetRequests', { provider: f.provider }).then(requests => {
-                expect(requests).to.have.length(f.numberOfRequests[1]);
-            });
+            cy.waitUntil(() =>
+                cy.task('metadataGetRequests', { provider: f.provider }).then(requests => {
+                    cy.log(
+                        `requests.length ${requests.length} of expected ${f.numberOfRequests[1]}`,
+                    );
+                    expect(requests.length).equal(f.numberOfRequests[1]);
+                }),
+            );
         });
     });
 });

--- a/packages/integration-tests/projects/suite-web/tsconfig.json
+++ b/packages/integration-tests/projects/suite-web/tsconfig.json
@@ -3,7 +3,7 @@
     "compilerOptions": {
         "noEmit": false,
         "isolatedModules": false,
-        "types": ["trezor-connect", "cypress"],
+        "types": ["trezor-connect", "cypress", "cypress-wait-until"],
         "allowJs": true,
         "skipLibCheck": true,
         "esModuleInterop": true,

--- a/yarn.lock
+++ b/yarn.lock
@@ -10784,6 +10784,11 @@ cypress-image-snapshot@^4.0.1:
     pkg-dir "^3.0.0"
     term-img "^4.0.0"
 
+cypress-wait-until@^1.7.2:
+  version "1.7.2"
+  resolved "https://registry.yarnpkg.com/cypress-wait-until/-/cypress-wait-until-1.7.2.tgz#7f534dd5a11c89b65359e7a0210f20d3dfc22107"
+  integrity sha512-uZ+M8/MqRcpf+FII/UZrU7g1qYZ4aVlHcgyVopnladyoBrpoaMJ4PKZDrdOJ05H5RHbr7s9Tid635X3E+ZLU/Q==
+
 cypress@8.3.0:
   version "8.3.0"
   resolved "https://registry.yarnpkg.com/cypress/-/cypress-8.3.0.tgz#ba906d2170888073ad94b2be1b994a749bbb7c7d"


### PR DESCRIPTION
this contains:
- fix failing acount-metadata.test - this happens because I have changed tests to run against the latest released firmware. But [taproot PR](https://github.com/trezor/trezor-suite/pull/4486) expected them to run against 2-master. on 2.4.2 discovery for taproot accounts does not run thats why there is lower number of metadata requests.  
- adds `cypress-wait-until` plugin. While cypress has pretty cool concept of [retryability](https://docs.cypress.io/guides/core-concepts/retry-ability), this is not available for node scripts invoked from within tests.  the newly added plugin solves this problem and allows us get rid of nasty cy.wait commands. this should improve tests stability.

close #4505