### PR TITLE
fix(invity): fix inconsistent translation ids

### DIFF
--- a/packages/suite/src/support/messages.ts
+++ b/packages/suite/src/support/messages.ts
@@ -386,7 +386,7 @@ export default defineMessages({
     },
     TR_EXCHANGE_DETAIL_ERROR_SUPPORT: {
         defaultMessage: "Open partner's support site",
-        id: 'TR_BUY_DETAIL_ERROR_SUPPORT',
+        id: 'TR_EXCHANGE_DETAIL_ERROR_SUPPORT',
     },
     TR_EXCHANGE_DETAIL_ERROR_BUTTON: {
         defaultMessage: 'Back to Account',
@@ -750,7 +750,7 @@ export default defineMessages({
     },
     TR_SELL_DETAIL_ERROR_SUPPORT: {
         defaultMessage: "Open partner's support site",
-        id: 'TR_BUY_DETAIL_ERROR_SUPPORT',
+        id: 'TR_SELL_DETAIL_ERROR_SUPPORT',
     },
     TR_SELL_DETAIL_ERROR_BUTTON: {
         defaultMessage: 'Back to Account',


### PR DESCRIPTION
fixes #4553 
- Running `yarn workspace @trezor/suite translations:extract` doesn't result in error now.
- Messages `TR_EXCHANGE_DETAIL_ERROR_SUPPORT` and `TR_SELL_DETAIL_ERROR_SUPPORT` are for different part of coin market.