### PR TITLE
tests(e2e): add pre passphrase redesign flow test

### DIFF
--- a/packages/integration-tests/projects/suite-web/tests/suite/passphrase-legacy.test.ts
+++ b/packages/integration-tests/projects/suite-web/tests/suite/passphrase-legacy.test.ts
@@ -1,0 +1,44 @@
+// @group:suite
+// @retry=2
+
+describe('Passphrase - legacy flow', () => {
+    beforeEach(() => {
+        cy.task('startEmu', { wipe: true, version: '2.2.0' });
+        cy.task('setupEmu', { mnemonic: 'all all all all all all all all all all all all' });
+        cy.task('startBridge');
+
+        cy.viewport(1024, 768).resetDb();
+        cy.prefixedVisit('/');
+        cy.passThroughInitialRun();
+    });
+
+    it('2.2.0 asks whether user wants to input on host or device first', () => {
+        cy.getTestElement('@menu/switch-device').click();
+        cy.getTestElement('@switch-device/add-hidden-wallet-button').click();
+
+        // passphrase feature is turned on first
+        cy.getTestElement('@suite/modal/confirm-action-on-device');
+        cy.task('pressYes');
+
+        // entry on device
+        cy.getTestElement('@modal/passphrase-source');
+        cy.task('clickEmu', { x: 120, y: 120 });
+        cy.getTestElement('@modal/enter-passphrase-on-device');
+        cy.task('inputEmu', 'a');
+        // this passphrase is not empty -> no prompt for another passphrase entry
+        cy.getTestElement('@dashboard/graph');
+
+        // entry on host
+        cy.getTestElement('@menu/switch-device').click();
+        cy.getTestElement('@switch-device/add-hidden-wallet-button').click();
+        cy.getTestElement('@modal/passphrase-source');
+        cy.task('clickEmu', { x: 120, y: 180 });
+        cy.getTestElement('@passphrase/input').type('b{enter}');
+        // this passphrase is empty -> has a prompt for another passphrase entry
+        cy.getTestElement('@modal/confirm-empty-hidden-wallet');
+        cy.task('clickEmu', { x: 120, y: 180 });
+        cy.getTestElement('@passphrase/confirm-checkbox').click();
+        cy.getTestElement('@passphrase/input').type('b{enter}');
+        cy.getTestElement('@dashboard/wallet-ready');
+    });
+});

--- a/packages/suite/src/components/suite/modals/PassphraseOnDevice/index.tsx
+++ b/packages/suite/src/components/suite/modals/PassphraseOnDevice/index.tsx
@@ -61,6 +61,7 @@ const PassphraseOnDevice = ({ device, getDiscoveryAuthConfirmationStatus, ...res
                 />
             }
             description={<Translation id="TR_PASSPHRASE_CASE_SENSITIVE" />}
+            data-test="@modal/enter-passphrase-on-device"
             {...rest}
         >
             <DeviceConfirmImage device={device} />

--- a/packages/suite/src/components/suite/modals/PassphraseSource/index.tsx
+++ b/packages/suite/src/components/suite/modals/PassphraseSource/index.tsx
@@ -34,6 +34,7 @@ const PassphraseSource = ({ device, getDiscoveryAuthConfirmationStatus, ...rest 
                         values={{ deviceLabel: device.label }}
                     />
                 }
+                data-test="@modal/confirm-empty-hidden-wallet"
                 {...rest}
             >
                 <DeviceConfirmImage device={device} />
@@ -57,6 +58,7 @@ const PassphraseSource = ({ device, getDiscoveryAuthConfirmationStatus, ...rest 
                     animated
                 />
             }
+            data-test="@modal/passphrase-source"
             {...rest}
         >
             <DeviceConfirmImage device={device} />


### PR DESCRIPTION
there was some refactoring in trezor-connect and I would like to make sure that we are not breaking pre passphrase redesign flow. It looks like we are not, but just to make sure I am adding this to December 8 project, so that QA checks on in too. 