### PR TITLE
fix(invity): adjust DEX gas limit

### DIFF
--- a/packages/suite/src/actions/wallet/send/sendFormEthereumActions.ts
+++ b/packages/suite/src/actions/wallet/send/sendFormEthereumActions.ts
@@ -136,6 +136,11 @@ export const composeTransaction =
 
         if (estimatedFee.success) {
             customFeeLimit = estimatedFee.payload.levels[0].feeLimit;
+            if (formValues.ethereumAdjustGasLimit && customFeeLimit) {
+                customFeeLimit = new BigNumber(customFeeLimit)
+                    .multipliedBy(new BigNumber(formValues.ethereumAdjustGasLimit))
+                    .toFixed(0);
+            }
         } else {
             // TODO: catch error from blockbook/geth (invalid contract, not enough balance...)
         }

--- a/packages/suite/src/hooks/wallet/useCoinmarketExchangeOffers.ts
+++ b/packages/suite/src/hooks/wallet/useCoinmarketExchangeOffers.ts
@@ -242,6 +242,9 @@ export const useOffers = (props: Props) => {
             selectedQuote.dexTx &&
             (selectedQuote.status === 'APPROVAL_REQ' || selectedQuote.status === 'CONFIRM')
         ) {
+            // after discussion with 1inch, adjust the gas limit by the factor of 1.25
+            // swap can use different swap paths when mining tx than when estimating tx
+            // the geth gas estimate may be too low
             const result = await recomposeAndSign(
                 selectedAccount,
                 selectedQuote.dexTx.to,
@@ -249,6 +252,7 @@ export const useOffers = (props: Props) => {
                 selectedQuote.partnerPaymentExtraId,
                 selectedQuote.dexTx.data,
                 true,
+                selectedQuote.status === 'CONFIRM' ? '1.25' : undefined,
             );
 
             // in case of not success, recomposeAndSign shows notification

--- a/packages/suite/src/hooks/wallet/useCoinmarketRecomposeAndSign .ts
+++ b/packages/suite/src/hooks/wallet/useCoinmarketRecomposeAndSign .ts
@@ -29,6 +29,7 @@ export const useCoinmarketRecomposeAndSign = () => {
             destinationTag?: string,
             ethereumDataHex?: string,
             recalcCustomLimit?: boolean,
+            ethereumAdjustGasLimit?: string,
         ) => {
             const { account, network } = selectedAccount;
 
@@ -58,6 +59,7 @@ export const useCoinmarketRecomposeAndSign = () => {
                 options: ['broadcast'],
                 rippleDestinationTag: destinationTag,
                 ethereumDataHex,
+                ethereumAdjustGasLimit,
             };
 
             // prepare form state for composeAction
@@ -79,9 +81,22 @@ export const useCoinmarketRecomposeAndSign = () => {
                     normalLevels.normal.type !== 'final' ||
                     !normalLevels.normal.feeLimit
                 ) {
+                    let errorMessage: string | undefined;
+                    if (
+                        normalLevels?.normal?.type === 'error' &&
+                        normalLevels?.normal?.errorMessage
+                    ) {
+                        errorMessage = translationString(
+                            normalLevels.normal.errorMessage.id,
+                            normalLevels.normal.errorMessage.values as { [key: string]: any },
+                        );
+                    }
+                    if (!errorMessage) {
+                        errorMessage = 'Missing fee level';
+                    }
                     addNotification({
                         type: 'sign-tx-error',
-                        error: 'Missing level',
+                        error: errorMessage,
                     });
                     return;
                 }
@@ -93,7 +108,7 @@ export const useCoinmarketRecomposeAndSign = () => {
             if (!selectedFee || !composedLevels) {
                 addNotification({
                     type: 'sign-tx-error',
-                    error: 'Missing level',
+                    error: 'Missing fee level',
                 });
                 return;
             }

--- a/packages/suite/src/types/wallet/sendForm.ts
+++ b/packages/suite/src/types/wallet/sendForm.ts
@@ -47,6 +47,7 @@ export type FormState = {
     ethereumNonce?: string; // TODO: ethereum RBF
     ethereumDataAscii?: string;
     ethereumDataHex?: string;
+    ethereumAdjustGasLimit?: string; // if used, final gas limit = estimated limit * ethereumAdjustGasLimit
     rippleDestinationTag?: string;
     rbfParams?: RbfTransactionParams;
 };


### PR DESCRIPTION
During our testing, several of our test swap transactions failed with out of gas error. We discussed the situation with 1inch and they recommended to adjust the gas limit estimated by geth by factor of 1.25 (they use the same factor in their own app).

The reason is that the swap can use different swap paths when mining tx than when estimating tx (as the market situation changes dynamically), therefore the geth gas estimate may be too low.
