### PR TITLE
Pr/aopp

### DIFF
--- a/packages/components/src/components/form/SelectBar/index.tsx
+++ b/packages/components/src/components/form/SelectBar/index.tsx
@@ -36,6 +36,7 @@ const Options = styled.div`
 `;
 
 const Option = styled.div<{ isSelected: boolean }>`
+    white-space: nowrap;
     padding: 0 14px;
     margin: 2px 0;
     padding-top: 1px;

--- a/packages/suite-desktop/package.json
+++ b/packages/suite-desktop/package.json
@@ -57,7 +57,8 @@
         "protocols": {
             "name": "Trezor Suite",
             "schemes": [
-                "bitcoin"
+                "bitcoin",
+                "aopp"
             ]
         },
         "publish": {

--- a/packages/suite-desktop/src-electron/index.d.ts
+++ b/packages/suite-desktop/src-electron/index.d.ts
@@ -53,7 +53,7 @@ declare interface ILogger {
 
 declare type BeforeRequestListener = (
     details: Electron.OnBeforeRequestListenerDetails,
-) => Electron.Response | undefined;
+) => Promise<Electron.Response | undefined>;
 
 declare interface RequestInterceptor {
     onBeforeRequest(listener: BeforeRequestListener): void;

--- a/packages/suite-desktop/src-electron/libs/request-interceptor.ts
+++ b/packages/suite-desktop/src-electron/libs/request-interceptor.ts
@@ -7,9 +7,10 @@ export const createInterceptor = (): RequestInterceptor => {
     let beforeRequestListeners: BeforeRequestListener[] = [];
 
     const filter = { urls: ['*://*/*'] };
-    session.defaultSession.webRequest.onBeforeRequest(filter, (details, callback) => {
+    session.defaultSession.webRequest.onBeforeRequest(filter, async (details, callback) => {
         for (let i = 0; i < beforeRequestListeners.length; ++i) {
-            const res = beforeRequestListeners[i](details);
+            /* eslint-disable no-await-in-loop */
+            const res = await beforeRequestListeners[i](details);
             if (res) {
                 callback(res);
                 return;

--- a/packages/suite-desktop/src-electron/modules/tor.ts
+++ b/packages/suite-desktop/src-electron/modules/tor.ts
@@ -83,13 +83,14 @@ const init = async ({ mainWindow, store, interceptor }: Dependencies) => {
             protocol === 'https:'
         ) {
             logger.info('tor', `Rewriting ${details.url} to .onion URL`);
-            return {
+            return Promise.resolve({
                 redirectURL: details.url.replace(
                     /https:\/\/(([a-z0-9]+\.)*)trezor\.io(.*)/,
                     `http://$1${onionDomain}$3`,
                 ),
-            };
+            });
         }
+        return Promise.resolve(undefined);
     });
 
     app.on('before-quit', () => {

--- a/packages/suite/src/actions/suite/__tests__/protocolActions.test.ts
+++ b/packages/suite/src/actions/suite/__tests__/protocolActions.test.ts
@@ -4,7 +4,7 @@ import thunk from 'redux-thunk';
 import protocolReducer, { State as ProtocolState } from '@suite-reducers/protocolReducer';
 import * as protocolActions from '../protocolActions';
 import * as protocolConstants from '../constants/protocolConstants';
-import { PROTOCOL_SCHEME } from '@suite/support/suite/Protocol';
+import { PROTOCOL_SCHEME } from '@suite-constants/protocol';
 
 export const getInitialState = (state?: ProtocolState) => ({
     protocol: {
@@ -37,7 +37,7 @@ describe('Protocol actions', () => {
                     scheme: PROTOCOL_SCHEME.BITCOIN,
                     address: '12345abcde',
                     amount: 1.02,
-                    shouldFillSendForm: false,
+                    shouldFill: false,
                 },
             },
         });
@@ -60,7 +60,7 @@ describe('Protocol actions', () => {
                     scheme: PROTOCOL_SCHEME.BITCOIN,
                     address: '12345abcde',
                     amount: undefined,
-                    shouldFillSendForm: false,
+                    shouldFill: false,
                 },
             },
         });
@@ -119,7 +119,7 @@ describe('Protocol actions', () => {
                     scheme: PROTOCOL_SCHEME.BITCOIN,
                     address: '12345abcde',
                     amount: 1.02,
-                    shouldFillSendForm: false,
+                    shouldFill: false,
                 },
             },
         });

--- a/packages/suite/src/actions/suite/constants/protocolConstants.ts
+++ b/packages/suite/src/actions/suite/constants/protocolConstants.ts
@@ -1,3 +1,5 @@
 export const FILL_SEND_FORM = '@protocol/fill-send-form';
 export const SAVE_COIN_PROTOCOL = '@protocol/save-coin-protocol';
+export const FILL_AOPP = '@protocol/fill-aopp';
+export const SAVE_AOPP_PROTOCOL = '@protocol/save-aopp-protocol';
 export const RESET = '@protocol/reset';

--- a/packages/suite/src/actions/suite/modalActions.ts
+++ b/packages/suite/src/actions/suite/modalActions.ts
@@ -114,6 +114,13 @@ export type UserContextPayload =
       }
     | {
           type: 'safety-checks';
+      }
+    | {
+          type: 'send-aopp-message';
+          address: string;
+          signature: string;
+          callback: string;
+          decision: Deferred<boolean>;
       };
 
 export type ModalAction =
@@ -200,7 +207,8 @@ type DeferredModals = Extract<
             | 'coinmarket-buy-terms'
             | 'coinmarket-sell-terms'
             | 'coinmarket-exchange-dex-terms'
-            | 'coinmarket-exchange-terms';
+            | 'coinmarket-exchange-terms'
+            | 'send-aopp-message';
     }
 >;
 // extract single modal by `type` util

--- a/packages/suite/src/actions/suite/modalActions.ts
+++ b/packages/suite/src/actions/suite/modalActions.ts
@@ -7,7 +7,8 @@ import { createDeferred, Deferred, DeferredResponse } from '@suite-utils/deferre
 export type UserContextPayload =
     | {
           type: 'qr-reader';
-          decision: Deferred<{ address: string; amount?: string }>;
+          decision: Deferred<string>;
+          allowPaste?: boolean;
       }
     | {
           type: 'unverified-address';

--- a/packages/suite/src/actions/suite/protocolActions.ts
+++ b/packages/suite/src/actions/suite/protocolActions.ts
@@ -1,5 +1,6 @@
-import { PROTOCOL_SCHEME } from '@suite-support/Protocol';
 import { PROTOCOL } from './constants';
+import type { PROTOCOL_SCHEME } from '@suite-constants/protocol';
+import type { SendFormState } from '@suite-reducers/protocolReducer';
 
 export type ProtocolAction =
     | {
@@ -8,13 +9,13 @@ export type ProtocolAction =
       }
     | {
           type: typeof PROTOCOL.SAVE_COIN_PROTOCOL;
-          payload: { scheme: PROTOCOL_SCHEME; address: string; amount?: number };
+          payload: SendFormState;
       }
     | { type: typeof PROTOCOL.RESET };
 
-export const fillSendForm = (shouldFillSendForm: boolean): ProtocolAction => ({
+export const fillSendForm = (shouldFill: boolean): ProtocolAction => ({
     type: PROTOCOL.FILL_SEND_FORM,
-    payload: shouldFillSendForm,
+    payload: shouldFill,
 });
 
 export const saveCoinProtocol = (

--- a/packages/suite/src/actions/suite/protocolActions.ts
+++ b/packages/suite/src/actions/suite/protocolActions.ts
@@ -1,6 +1,6 @@
 import { PROTOCOL } from './constants';
 import type { PROTOCOL_SCHEME } from '@suite-constants/protocol';
-import type { SendFormState } from '@suite-reducers/protocolReducer';
+import type { SendFormState, AoppState } from '@suite-reducers/protocolReducer';
 
 export type ProtocolAction =
     | {
@@ -8,8 +8,16 @@ export type ProtocolAction =
           payload: boolean;
       }
     | {
+          type: typeof PROTOCOL.FILL_AOPP;
+          payload: boolean;
+      }
+    | {
           type: typeof PROTOCOL.SAVE_COIN_PROTOCOL;
           payload: SendFormState;
+      }
+    | {
+          type: typeof PROTOCOL.SAVE_AOPP_PROTOCOL;
+          payload: AoppState;
       }
     | { type: typeof PROTOCOL.RESET };
 
@@ -25,6 +33,16 @@ export const saveCoinProtocol = (
 ): ProtocolAction => ({
     type: PROTOCOL.SAVE_COIN_PROTOCOL,
     payload: { scheme, address, amount },
+});
+
+export const fillAopp = (shouldFill: boolean): ProtocolAction => ({
+    type: PROTOCOL.FILL_AOPP,
+    payload: shouldFill,
+});
+
+export const saveAoppProtocol = (payload: AoppState): ProtocolAction => ({
+    type: PROTOCOL.SAVE_AOPP_PROTOCOL,
+    payload,
 });
 
 export const resetProtocol = (): ProtocolAction => ({

--- a/packages/suite/src/actions/wallet/signVerifyActions.ts
+++ b/packages/suite/src/actions/wallet/signVerifyActions.ts
@@ -128,10 +128,11 @@ const onSignSuccess =
                 type: 'sign-message-success',
             }),
         );
-        return dispatch({
+        dispatch({
             type: SIGN_VERIFY.SIGN_SUCCESS,
             signSignature: signature,
         });
+        return signature;
     };
 
 const onVerifySuccess = (dispatch: Dispatch) => () => {
@@ -140,9 +141,10 @@ const onVerifySuccess = (dispatch: Dispatch) => () => {
             type: 'verify-message-success',
         }),
     );
-    return dispatch({
+    dispatch({
         type: SIGN_VERIFY.VERIFY_SUCCESS,
     });
+    return true;
 };
 
 const throwWhenFailed = <T>(response: Unsuccessful | Success<T>) =>
@@ -155,13 +157,15 @@ const onError =
         dispatch: Dispatch,
         type: 'sign-message-error' | 'verify-message-error' | 'verify-address-error',
     ) =>
-    (error: Error) =>
+    (error: Error) => {
         dispatch(
             addToast({
                 type,
                 error: error.message,
             }),
         );
+        return false as const;
+    };
 
 export const showAddress =
     (address: string, path: string) => (dispatch: Dispatch, getState: GetState) =>
@@ -234,4 +238,5 @@ export const sendAopp =
 
         if (success) dispatch(addToast({ type: 'aopp-success' }));
         else dispatch(addToast({ type: 'aopp-error', error }));
+        return success;
     };

--- a/packages/suite/src/actions/wallet/signVerifyActions.ts
+++ b/packages/suite/src/actions/wallet/signVerifyActions.ts
@@ -1,7 +1,10 @@
 import TrezorConnect, { ButtonRequestMessage, UI, Unsuccessful, Success } from 'trezor-connect';
 import { SIGN_VERIFY } from './constants';
 import { addToast } from '@suite-actions/notificationActions';
-import { openModal } from '@suite-actions/modalActions';
+import { PROTOCOL_SCHEME } from '@suite-constants/protocol';
+import { openModal, openDeferredModal } from '@suite-actions/modalActions';
+import { getProtocolInfo } from '@suite-utils/parseUri';
+import { isHex } from '@wallet-utils/ethUtils';
 import type { Dispatch, GetState, TrezorDevice } from '@suite-types';
 import type { Account } from '@wallet-types';
 
@@ -74,7 +77,7 @@ const showAddressByNetwork =
     };
 
 const signByNetwork =
-    (path: string | number[], message: string, hex: boolean) =>
+    (path: string | number[], message: string, hex: boolean, aopp: boolean) =>
     ({ account, device, coin, useEmptyPassphrase }: StateParams) => {
         const params = {
             device,
@@ -83,6 +86,7 @@ const signByNetwork =
             message,
             useEmptyPassphrase,
             hex,
+            no_script_type: aopp,
         };
         switch (account.networkType) {
             case 'bitcoin':
@@ -167,10 +171,10 @@ export const showAddress =
             .catch(onError(dispatch, 'verify-address-error'));
 
 export const sign =
-    (path: string | number[], message: string, hex = false) =>
+    (path: string | number[], message: string, hex = false, aopp = false) =>
     (dispatch: Dispatch, getState: GetState) =>
         getStateParams(getState)
-            .then(signByNetwork(path, message, hex))
+            .then(signByNetwork(path, message, hex, aopp))
             .then(throwWhenFailed)
             .then(onSignSuccess(dispatch))
             .catch(onError(dispatch, 'sign-message-error'));
@@ -183,3 +187,51 @@ export const verify =
             .then(throwWhenFailed)
             .then(onVerifySuccess(dispatch))
             .catch(onError(dispatch, 'verify-message-error'));
+
+export const importAopp = (symbol?: Account['symbol']) => async (dispatch: Dispatch) => {
+    const uri = await dispatch(openDeferredModal({ type: 'qr-reader', allowPaste: true }));
+    if (!uri) return;
+    const info = getProtocolInfo(uri);
+    if (info?.scheme !== PROTOCOL_SCHEME.AOPP) return;
+    if (info.asset && symbol && info.asset !== symbol) return;
+    return {
+        asset: info.asset,
+        message: info.msg,
+        callback: info.callback,
+        format: info.format,
+    };
+};
+
+export const sendAopp =
+    (address: string, sig: string, callback: string) =>
+    async (dispatch: Dispatch, getState: GetState) => {
+        const network = getState().wallet.selectedAccount.account?.networkType;
+        const signature =
+            network === 'ethereum' && isHex(sig) ? Buffer.from(sig, 'hex').toString('base64') : sig;
+
+        const confirm = await dispatch(
+            openDeferredModal({ type: 'send-aopp-message', address, signature, callback }),
+        );
+        if (!confirm) return;
+
+        const { success, error } = await fetch(callback, {
+            method: 'POST',
+            headers: { 'content-type': 'application/json; utf-8' },
+            body: JSON.stringify({
+                version: 0,
+                address,
+                signature,
+            }),
+        })
+            .then(res => ({
+                success: res.status === 204,
+                error: undefined,
+            }))
+            .catch(err => ({
+                success: false,
+                error: err.message,
+            }));
+
+        if (success) dispatch(addToast({ type: 'aopp-success' }));
+        else dispatch(addToast({ type: 'aopp-error', error }));
+    };

--- a/packages/suite/src/components/suite/hocNotification/components/withCoinProtocolScheme.tsx
+++ b/packages/suite/src/components/suite/hocNotification/components/withCoinProtocolScheme.tsx
@@ -1,89 +1,63 @@
 import React from 'react';
-import { connect } from 'react-redux';
 import styled from 'styled-components';
-import { useRouteMatch } from 'react-router-dom';
 
 import * as protocolActions from '@suite-actions/protocolActions';
-
-import { useSelector } from '@suite-hooks';
 import { Translation } from '@suite-components';
-import { CoinLogo, variables } from '@trezor/components';
+import { CoinLogo } from '@trezor/components';
 import { capitalizeFirstLetter } from '@suite-utils/string';
 import { PROTOCOL_TO_NETWORK } from '@suite-constants/protocol';
+import withConditionalAction from './withConditionalAction';
 
 import type { NotificationEntry } from '@suite-reducers/notificationReducer';
-import type { Dispatch } from '@suite-types';
 import type { ViewProps } from '../definitions';
-
-type StrictViewProps = ViewProps & {
-    notification: Extract<NotificationEntry, { type: 'coin-scheme-protocol' }>;
-};
-
-const Header = styled.div`
-    font-weight: ${variables.FONT_WEIGHT.MEDIUM};
-    color: ${props => props.theme.TYPE_LIGHT_GREY};
-    margin-top: 1px;
-`;
-
-const Body = styled.div`
-    font-weight: ${variables.FONT_WEIGHT.MEDIUM};
-    margin-top: 1px;
-`;
+import type { Network } from '@wallet-types';
 
 const Row = styled.span`
     display: flex;
 `;
 
-const withCoinProtocolScheme = (View: React.ComponentType<ViewProps>, props: StrictViewProps) => {
-    const WrappedView = connect()(({ dispatch }: { dispatch: Dispatch }) => {
-        const { message, notification } = props;
+const getIcon = (symbol?: Network['symbol']) => symbol && <CoinLogo symbol={symbol} size={20} />;
 
-        const { selectedAccount } = useSelector(state => ({
-            selectedAccount: state.wallet.selectedAccount,
-        }));
-
-        if (typeof message !== 'string') {
-            message.values = {
-                header: (
-                    <Header>
-                        <Translation id="TOAST_COIN_SCHEME_PROTOCOL_HEADER" />
-                    </Header>
-                ),
-                body: (
-                    <Body>
-                        <Row>
-                            {notification.amount && `${notification.amount} `}
-                            {capitalizeFirstLetter(notification.scheme)}
-                        </Row>
-                        <Row>{notification.address}</Row>
-                    </Body>
-                ),
-            };
-        }
-
-        const isCorrectCoinSendForm =
-            useRouteMatch(`${process.env.ASSET_PREFIX || ''}/accounts/send`) &&
-            selectedAccount?.network?.symbol === PROTOCOL_TO_NETWORK[notification.scheme];
-
-        return (
-            <View
-                {...props}
-                action={
-                    isCorrectCoinSendForm
-                        ? {
-                              onClick: () => dispatch(protocolActions.fillSendForm(true)),
-                              label: 'TOAST_COIN_SCHEME_PROTOCOL_ACTION',
-                              position: 'bottom',
-                              variant: 'primary',
-                          }
-                        : undefined
-                }
-                icon={<CoinLogo symbol={PROTOCOL_TO_NETWORK[notification.scheme] as any} size={20} />}
-                onCancel={() => dispatch(protocolActions.resetProtocol())}
-            />
-        );
+export const withAoppProtocol = (
+    View: React.ComponentType<ViewProps>,
+    notification: Extract<NotificationEntry, { type: 'aopp-protocol' }>,
+) =>
+    withConditionalAction(View, {
+        notification,
+        header: <Translation id="TOAST_AOPP_FILL_HEADER" />,
+        body: notification.message,
+        icon: getIcon(notification.asset),
+        actionLabel: 'TOAST_AOPP_FILL_ACTION',
+        actionCondition: {
+            path: '/accounts/sign-verify',
+            network: notification.asset,
+        },
+        onAction: protocolActions.fillAopp(true),
+        onCancel: protocolActions.resetProtocol(),
     });
-    return <WrappedView key={props.notification.id} />;
-};
 
-export default withCoinProtocolScheme;
+export const withCoinProtocol = (
+    View: React.ComponentType<ViewProps>,
+    notification: Extract<NotificationEntry, { type: 'coin-scheme-protocol' }>,
+) =>
+    withConditionalAction(View, {
+        notification,
+        header: <Translation id="TOAST_COIN_SCHEME_PROTOCOL_HEADER" />,
+        body: (
+            <>
+                <Row>
+                    {notification.amount && `${notification.amount} `}
+                    {capitalizeFirstLetter(notification.scheme)}
+                </Row>
+                <Row>{notification.address}</Row>
+            </>
+        ),
+        actionLabel: 'TOAST_COIN_SCHEME_PROTOCOL_ACTION',
+        actionCondition: {
+            path: '/accounts/send',
+            network: PROTOCOL_TO_NETWORK[notification.scheme],
+        },
+        onAction: protocolActions.fillSendForm(true),
+        onCancel: protocolActions.resetProtocol(),
+        icon: getIcon(PROTOCOL_TO_NETWORK[notification.scheme]),
+    });

--- a/packages/suite/src/components/suite/hocNotification/components/withCoinProtocolScheme.tsx
+++ b/packages/suite/src/components/suite/hocNotification/components/withCoinProtocolScheme.tsx
@@ -9,7 +9,7 @@ import { useSelector } from '@suite-hooks';
 import { Translation } from '@suite-components';
 import { CoinLogo, variables } from '@trezor/components';
 import { capitalizeFirstLetter } from '@suite-utils/string';
-import { PROTOCOL_TO_SYMBOL } from '@suite-support/Protocol';
+import { PROTOCOL_TO_NETWORK } from '@suite-constants/protocol';
 
 import type { NotificationEntry } from '@suite-reducers/notificationReducer';
 import type { Dispatch } from '@suite-types';
@@ -63,7 +63,7 @@ const withCoinProtocolScheme = (View: React.ComponentType<ViewProps>, props: Str
 
         const isCorrectCoinSendForm =
             useRouteMatch(`${process.env.ASSET_PREFIX || ''}/accounts/send`) &&
-            selectedAccount?.network?.symbol === PROTOCOL_TO_SYMBOL[notification.scheme];
+            selectedAccount?.network?.symbol === PROTOCOL_TO_NETWORK[notification.scheme];
 
         return (
             <View
@@ -78,7 +78,7 @@ const withCoinProtocolScheme = (View: React.ComponentType<ViewProps>, props: Str
                           }
                         : undefined
                 }
-                icon={<CoinLogo symbol={PROTOCOL_TO_SYMBOL[notification.scheme]} size={20} />}
+                icon={<CoinLogo symbol={PROTOCOL_TO_NETWORK[notification.scheme] as any} size={20} />}
                 onCancel={() => dispatch(protocolActions.resetProtocol())}
             />
         );

--- a/packages/suite/src/components/suite/hocNotification/components/withConditionalAction.tsx
+++ b/packages/suite/src/components/suite/hocNotification/components/withConditionalAction.tsx
@@ -1,0 +1,94 @@
+import React from 'react';
+import styled from 'styled-components';
+import { connect } from 'react-redux';
+import { useRouteMatch } from 'react-router-dom';
+
+import { useSelector } from '@suite-hooks';
+import { variables } from '@trezor/components';
+
+import type { NotificationEntry } from '@suite-reducers/notificationReducer';
+import type { Dispatch, Action, ExtendedMessageDescriptor } from '@suite-types';
+import type { Network } from '@wallet-types';
+import type { ViewProps } from '../definitions';
+
+const Header = styled.div`
+    font-weight: ${variables.FONT_WEIGHT.MEDIUM};
+    color: ${props => props.theme.TYPE_LIGHT_GREY};
+    margin-top: 1px;
+`;
+
+const Body = styled.div`
+    font-weight: ${variables.FONT_WEIGHT.MEDIUM};
+    margin-top: 1px;
+`;
+
+type WithConditionalActionProps = {
+    notification: NotificationEntry;
+    header: React.ReactNode;
+    body: React.ReactNode;
+    icon?: JSX.Element;
+    actionLabel: ExtendedMessageDescriptor['id'];
+    actionCondition: {
+        path?: string;
+        network?: Network['symbol'];
+    };
+    onAction: Action;
+    onCancel: Action;
+};
+
+const withConditionalAction = (
+    View: React.ComponentType<ViewProps>,
+    props: WithConditionalActionProps,
+) => {
+    const WrappedView = connect()(({ dispatch }: { dispatch: Dispatch }) => {
+        const {
+            notification,
+            header,
+            body,
+            icon,
+            actionCondition: { path, network },
+            actionLabel,
+            onAction,
+            onCancel,
+        } = props;
+
+        const { selectedAccount } = useSelector(state => ({
+            selectedAccount: state.wallet.selectedAccount,
+        }));
+
+        const actionAllowed =
+            (!path || useRouteMatch(`${process.env.ASSET_PREFIX || ''}${path}`)) &&
+            (!network || selectedAccount?.network?.symbol === network);
+
+        const action = actionAllowed
+            ? ({
+                  onClick: () => dispatch(onAction),
+                  label: actionLabel,
+                  position: 'bottom',
+                  variant: 'primary',
+              } as const)
+            : undefined;
+
+        const message = {
+            id: 'TOAST_COIN_SCHEME_PROTOCOL',
+            values: {
+                header: <Header>{header}</Header>,
+                body: <Body>{body}</Body>,
+            },
+        } as const;
+
+        return (
+            <View
+                variant="transparent"
+                notification={notification}
+                message={message}
+                icon={icon}
+                action={action}
+                onCancel={() => dispatch(onCancel)}
+            />
+        );
+    });
+    return <WrappedView key={props.notification.id} />;
+};
+
+export default withConditionalAction;

--- a/packages/suite/src/components/suite/hocNotification/index.tsx
+++ b/packages/suite/src/components/suite/hocNotification/index.tsx
@@ -4,7 +4,7 @@ import { SUITE } from '@suite-actions/constants';
 import { NotificationEntry } from '@suite-reducers/notificationReducer';
 import withAction from './components/withAction';
 import withTransaction from './components/withTransaction';
-import withCoinProtocolScheme from './components/withCoinProtocolScheme';
+import { withAoppProtocol, withCoinProtocol } from './components/withCoinProtocolScheme';
 import { ViewProps } from './definitions';
 
 const simple = (View: React.ComponentType<ViewProps>, props: ViewProps) => (
@@ -21,12 +21,9 @@ const simple = (View: React.ComponentType<ViewProps>, props: ViewProps) => (
 const hocNotification = (notification: NotificationEntry, View: React.ComponentType<ViewProps>) => {
     switch (notification.type) {
         case 'coin-scheme-protocol':
-            return withCoinProtocolScheme(View, {
-                notification,
-                variant: 'transparent',
-                // values get filled in `withCoinProtocolScheme`
-                message: { id: 'TOAST_COIN_SCHEME_PROTOCOL', values: {} },
-            });
+            return withCoinProtocol(View, notification);
+        case 'aopp-protocol':
+            return withAoppProtocol(View, notification);
         case 'acquire-error':
             return simple(View, {
                 notification,

--- a/packages/suite/src/components/suite/hocNotification/index.tsx
+++ b/packages/suite/src/components/suite/hocNotification/index.tsx
@@ -24,6 +24,23 @@ const hocNotification = (notification: NotificationEntry, View: React.ComponentT
             return withCoinProtocol(View, notification);
         case 'aopp-protocol':
             return withAoppProtocol(View, notification);
+        case 'aopp-success':
+            return simple(View, {
+                notification,
+                variant: 'success',
+                message: 'TOAST_AOPP_SUCCESS',
+            });
+        case 'aopp-error':
+            return simple(View, {
+                notification,
+                variant: 'error',
+                message: {
+                    id: 'TOAST_AOPP_ERROR',
+                    values: {
+                        error: notification.error,
+                    },
+                },
+            });
         case 'acquire-error':
             return simple(View, {
                 notification,

--- a/packages/suite/src/components/suite/modals/QrScanner/index.tsx
+++ b/packages/suite/src/components/suite/modals/QrScanner/index.tsx
@@ -3,7 +3,7 @@ import styled from 'styled-components';
 
 import { TrezorLink, Translation, Modal, BundleLoader } from '@suite-components';
 import * as URLS from '@suite-constants/urls';
-import { parseUri } from '@suite-utils/parseUri';
+import { parseQuery } from '@suite-utils/parseUri';
 import { Icon, colors, P } from '@trezor/components';
 import { UserContextPayload } from '@suite-actions/modalActions';
 
@@ -92,14 +92,19 @@ const QrScanner = ({ onCancel, decision }: Props) => {
         }
     };
 
-    const handleScan = (data: string | null) => {
-        if (data) {
+    const handleScan = (uri: string | null) => {
+        if (uri) {
             try {
-                const parsedUri = parseUri(data);
-                if (parsedUri) {
-                    decision.resolve(parsedUri);
+                const query = parseQuery(uri);
+                if (query) {
+                    decision.resolve({
+                        uri,
+                        ...query,
+                    });
                     setReaderLoaded(true);
                     onCancel();
+                } else {
+                    handleError({ name: 'unknown' });
                 }
             } catch (error) {
                 handleError(error);

--- a/packages/suite/src/components/suite/modals/SendAoppMessage/index.tsx
+++ b/packages/suite/src/components/suite/modals/SendAoppMessage/index.tsx
@@ -1,0 +1,63 @@
+import React from 'react';
+import styled from 'styled-components';
+import { Button, variables } from '@trezor/components';
+import { Modal, Translation } from '@suite-components';
+import type { UserContextPayload } from '@suite-actions/modalActions';
+
+const Row = styled.div`
+    display: flex;
+    text-align: left;
+    margin-bottom: 8px;
+    & > * {
+        &:first-child {
+            min-width: 120px;
+            font-weight: ${variables.FONT_WEIGHT.MEDIUM};
+        }
+        &:not(:first-child) {
+            overflow-wrap: anywhere;
+        }
+    }
+`;
+
+const ActionRow = styled.div`
+    display: flex;
+    justify-content: space-evenly;
+    margin-top: 24px;
+`;
+
+const StyledButton = styled(Button)`
+    width: 200px;
+`;
+
+type Props = Extract<UserContextPayload, { type: 'send-aopp-message' }> & {
+    onCancel: () => void;
+};
+
+const SendAoppMessage = ({ onCancel, decision, address, signature, callback }: Props) => (
+    <Modal cancelable onCancel={onCancel} heading={<Translation id="TR_AOPP_SEND" />}>
+        <Row>
+            <Translation id="TR_ADDRESS" />
+            <div>{address}</div>
+        </Row>
+        <Row>
+            <Translation id="TR_SIGNATURE" />
+            <div>{signature}</div>
+        </Row>
+        <Row>
+            <Translation id="TR_TO" />
+            <div>{callback}</div>
+        </Row>
+        <ActionRow>
+            <StyledButton
+                onClick={() => {
+                    decision.resolve(true);
+                    onCancel();
+                }}
+            >
+                <Translation id="TR_NAV_SEND" />
+            </StyledButton>
+        </ActionRow>
+    </Modal>
+);
+
+export default SendAoppMessage;

--- a/packages/suite/src/components/suite/modals/index.tsx
+++ b/packages/suite/src/components/suite/modals/index.tsx
@@ -168,7 +168,13 @@ const getUserContextModal = ({ modal, onCancel }: SharedProps) => {
         case 'wipe-device':
             return <WipeDevice onCancel={onCancel} />;
         case 'qr-reader':
-            return <QrScanner decision={payload.decision} onCancel={onCancel} />;
+            return (
+                <QrScanner
+                    decision={payload.decision}
+                    allowPaste={payload.allowPaste}
+                    onCancel={onCancel}
+                />
+            );
         case 'transaction-detail':
             return <TransactionDetail {...payload} onCancel={onCancel} />;
         case 'passphrase-duplicate':

--- a/packages/suite/src/components/suite/modals/index.tsx
+++ b/packages/suite/src/components/suite/modals/index.tsx
@@ -40,6 +40,7 @@ import MetadataProvider from './metadata/MetadataProvider';
 import AdvancedCoinSettings from './AdvancedCoinSettings';
 import AddToken from './AddToken';
 import SafetyChecks from './SafetyChecks';
+import SendAoppMessage from './SendAoppMessage';
 
 import type { AcquiredDevice } from '@suite-types';
 
@@ -231,6 +232,8 @@ const getUserContextModal = ({ modal, onCancel }: SharedProps) => {
             return <AddToken {...payload} onCancel={onCancel} />;
         case 'safety-checks':
             return <SafetyChecks onCancel={onCancel} />;
+        case 'send-aopp-message':
+            return <SendAoppMessage {...payload} onCancel={onCancel} />;
         default:
             return null;
     }

--- a/packages/suite/src/constants/suite/protocol.ts
+++ b/packages/suite/src/constants/suite/protocol.ts
@@ -1,0 +1,10 @@
+import type { Network } from '@wallet-types';
+
+export enum PROTOCOL_SCHEME {
+    BITCOIN = 'bitcoin',
+    AOPP = 'aopp',
+}
+
+export const PROTOCOL_TO_NETWORK: Partial<{ [key in PROTOCOL_SCHEME]: Network['symbol'] }> = {
+    [PROTOCOL_SCHEME.BITCOIN]: 'btc',
+};

--- a/packages/suite/src/hooks/wallet/sign-verify/useSignVerifyForm.ts
+++ b/packages/suite/src/hooks/wallet/sign-verify/useSignVerifyForm.ts
@@ -1,10 +1,12 @@
-import { useEffect } from 'react';
+import { useEffect, useCallback } from 'react';
 import { useForm, useController } from 'react-hook-form';
-import { useTranslation } from '@suite-hooks';
+import { useTranslation, useSelector, useActions } from '@suite-hooks';
+import * as protocolActions from '@suite-actions/protocolActions';
 import { isHex } from '@wallet-utils/ethUtils';
 import { isASCII } from '@suite-utils/validators';
 import { isAddressValid } from '@wallet-utils/validation';
 import type { Account } from '@wallet-types';
+import type { AoppState } from '@suite-reducers/protocolReducer';
 
 export const MAX_LENGTH_MESSAGE = 1024;
 export const MAX_LENGTH_SIGNATURE = 255;
@@ -15,6 +17,8 @@ export type SignVerifyFields = {
     path: string;
     signature: string;
     hex: boolean;
+    aopp: boolean;
+    callback: string;
 };
 
 const DEFAULT_VALUES: SignVerifyFields = {
@@ -23,6 +27,31 @@ const DEFAULT_VALUES: SignVerifyFields = {
     path: '',
     signature: '',
     hex: false,
+    aopp: false,
+    callback: '',
+};
+
+const useAoppListener = (account: Account | undefined, setAopp: (aopp: AoppState) => void) => {
+    const { aoppState } = useSelector(state => ({
+        aoppState: state.protocol.aopp,
+    }));
+
+    const { fillAopp } = useActions({
+        fillAopp: protocolActions.fillAopp,
+    });
+
+    const shouldFill = useCallback(
+        (aopp: typeof aoppState): aopp is AoppState =>
+            !!aopp.shouldFill && !!aopp.message && aopp.asset === account?.symbol,
+        [account],
+    );
+
+    useEffect(() => {
+        if (shouldFill(aoppState)) {
+            setAopp(aoppState);
+            fillAopp(false);
+        }
+    }, [aoppState, shouldFill, fillAopp, setAopp]);
 };
 
 export const useSignVerifyForm = (page: 'sign' | 'verify', account?: Account) => {
@@ -71,6 +100,9 @@ export const useSignVerifyForm = (page: 'sign' | 'verify', account?: Account) =>
         name: 'hex',
     });
 
+    register('aopp');
+    register('callback');
+
     const messageRef = register({
         maxLength: {
             value: MAX_LENGTH_MESSAGE,
@@ -117,6 +149,14 @@ export const useSignVerifyForm = (page: 'sign' | 'verify', account?: Account) =>
         });
     }, [reset, account, page]);
 
+    const formSetAopp = (aopp: AoppState) => {
+        setValue('aopp', !!aopp);
+        setValue('callback', aopp?.callback ?? '');
+        setValue('message', aopp?.message ?? '');
+    };
+
+    useAoppListener(account, formSetAopp);
+
     return {
         formDirty: isDirty,
         formReset: () => reset(),
@@ -129,6 +169,7 @@ export const useSignVerifyForm = (page: 'sign' | 'verify', account?: Account) =>
             signature: errors.signature?.message,
         },
         formSetSignature: (value: string) => setValue('signature', value),
+        formSetAopp,
         messageRef,
         signatureRef,
         hexField: {

--- a/packages/suite/src/hooks/wallet/useSendForm.ts
+++ b/packages/suite/src/hooks/wallet/useSendForm.ts
@@ -19,7 +19,7 @@ import { useSendFormFields } from './useSendFormFields';
 import { useSendFormCompose } from './useSendFormCompose';
 import { useSendFormImport } from './useSendFormImport';
 import { useFees } from './form/useFees';
-import { PROTOCOL_TO_SYMBOL } from '@suite/support/suite/Protocol';
+import { PROTOCOL_TO_NETWORK } from '@suite-constants/protocol';
 
 export const SendContext = createContext<SendContextValues | null>(null);
 SendContext.displayName = 'SendContext';
@@ -235,9 +235,9 @@ export const useSendForm = (props: UseSendFormProps): SendContextValues => {
     // fill form using data from URI protocol handler e.g. 'bitcoin:address?amount=0.01'
     useEffect(() => {
         if (
-            protocol.sendForm.shouldFillSendForm &&
+            protocol.sendForm.shouldFill &&
             protocol.sendForm.scheme &&
-            props.selectedAccount.network.symbol === PROTOCOL_TO_SYMBOL[protocol.sendForm.scheme]
+            props.selectedAccount.network.symbol === PROTOCOL_TO_NETWORK[protocol.sendForm.scheme]
         ) {
             // for now we always fill only first output
             const outputIndex = 0;

--- a/packages/suite/src/middlewares/suite/__tests__/protocolMiddleware.test.ts
+++ b/packages/suite/src/middlewares/suite/__tests__/protocolMiddleware.test.ts
@@ -72,7 +72,7 @@ describe('Protocol middleware', () => {
                 address: 'bc1q00h58c5vzcyqavwpjvw8tl8r53t9d57e6smwqe',
                 amount: 0.001,
                 scheme: 'bitcoin',
-                shouldFillSendForm: false,
+                shouldFill: false,
             },
         });
 
@@ -83,7 +83,7 @@ describe('Protocol middleware', () => {
                     address: 'bc1q00h58c5vzcyqavwpjvw8tl8r53t9d57e6smwqe',
                     amount: 0.001,
                     scheme: 'bitcoin',
-                    shouldFillSendForm: false,
+                    shouldFill: false,
                 },
                 type: '@protocol/save-coin-protocol',
             },

--- a/packages/suite/src/middlewares/suite/protocolMiddleware.ts
+++ b/packages/suite/src/middlewares/suite/protocolMiddleware.ts
@@ -4,6 +4,14 @@ import { close } from '@suite-actions/notificationActions';
 import { PROTOCOL } from '@suite-actions/constants';
 
 import type { AppState, Action, Dispatch } from '@suite-types';
+import type { ToastPayload } from '@suite-reducers/notificationReducer';
+
+// close custom protocol notification of given type
+const closeNotifications = (api: MiddlewareAPI<Dispatch, AppState>, type: ToastPayload['type']) => {
+    api.getState()
+        .notifications.filter(notification => notification.type === type && !notification.closed)
+        .forEach(protocolNotification => api.dispatch(close(protocolNotification.id)));
+};
 
 const protocolMiddleware =
     (api: MiddlewareAPI<Dispatch, AppState>) =>
@@ -11,14 +19,15 @@ const protocolMiddleware =
     (action: Action): Action => {
         next(action);
 
-        if (action.type === PROTOCOL.SAVE_COIN_PROTOCOL) {
-            // close current custom protocol notification
-            api.getState()
-                .notifications.filter(
-                    notification =>
-                        notification.type === 'coin-scheme-protocol' && !notification.closed,
-                )
-                .forEach(protocolNotification => api.dispatch(close(protocolNotification.id)));
+        switch (action.type) {
+            case PROTOCOL.SAVE_COIN_PROTOCOL:
+                closeNotifications(api, 'coin-scheme-protocol');
+                break;
+            case PROTOCOL.SAVE_AOPP_PROTOCOL:
+                closeNotifications(api, 'aopp-protocol');
+                break;
+            default:
+                break;
         }
 
         return action;

--- a/packages/suite/src/reducers/suite/__fixtures__/protocolReducer.ts
+++ b/packages/suite/src/reducers/suite/__fixtures__/protocolReducer.ts
@@ -1,8 +1,5 @@
 import { PROTOCOL } from '@suite-actions/constants';
-
-const initialState = {
-    sendForm: {},
-};
+import { initialState } from '@suite-reducers/protocolReducer';
 
 const protocol = {
     address: 'bc1q00h58c5vzcyqavwpjvw8tl8r53t9d57e6smwqe',
@@ -14,9 +11,10 @@ export default [
     {
         description: 'Should fill send form',
         initialState: {
+            ...initialState,
             sendForm: {
                 ...protocol,
-                shouldFillSendForm: false,
+                shouldFill: false,
             },
         },
         actions: [
@@ -26,15 +24,17 @@ export default [
             },
         ],
         result: {
+            ...initialState,
             sendForm: {
                 ...protocol,
-                shouldFillSendForm: true,
+                shouldFill: true,
             },
         },
     },
     {
         description: 'Send form filled',
         initialState: {
+            ...initialState,
             sendForm: {
                 ...protocol,
             },
@@ -46,9 +46,10 @@ export default [
             },
         ],
         result: {
+            ...initialState,
             sendForm: {
                 ...protocol,
-                shouldFillSendForm: false,
+                shouldFill: false,
             },
         },
     },
@@ -62,18 +63,20 @@ export default [
             },
         ],
         result: {
+            ...initialState,
             sendForm: {
                 ...protocol,
-                shouldFillSendForm: false,
+                shouldFill: false,
             },
         },
     },
     {
         description: 'Protocol state reset',
         initialState: {
+            ...initialState,
             sendForm: {
                 ...protocol,
-                shouldFillSendForm: false,
+                shouldFill: false,
             },
         },
         actions: [

--- a/packages/suite/src/reducers/suite/notificationReducer.ts
+++ b/packages/suite/src/reducers/suite/notificationReducer.ts
@@ -3,8 +3,8 @@ import { DEVICE } from 'trezor-connect';
 import { NOTIFICATION, SUITE } from '@suite-actions/constants';
 import { Action, TrezorDevice } from '@suite-types';
 import { Network } from '@wallet-types';
-import { PROTOCOL_SCHEME } from '@suite/support/suite/Protocol';
 import { UpdateState } from '@suite-reducers/desktopUpdateReducer';
+import type { PROTOCOL_SCHEME } from '@suite-constants/protocol';
 
 interface Options {
     seen?: boolean;

--- a/packages/suite/src/reducers/suite/notificationReducer.ts
+++ b/packages/suite/src/reducers/suite/notificationReducer.ts
@@ -30,7 +30,8 @@ export type ToastPayload = (
               | 'backup-success'
               | 'backup-failed'
               | 'sign-message-success'
-              | 'verify-message-success';
+              | 'verify-message-success'
+              | 'aopp-success';
       }
     | {
           type: 'tx-sent';
@@ -65,6 +66,7 @@ export type ToastPayload = (
               | 'verify-address-error'
               | 'sign-message-error'
               | 'verify-message-error'
+              | 'aopp-error'
               | 'sign-tx-error'
               | 'metadata-auth-error'
               | 'metadata-not-found-error'

--- a/packages/suite/src/reducers/suite/notificationReducer.ts
+++ b/packages/suite/src/reducers/suite/notificationReducer.ts
@@ -91,6 +91,11 @@ export type ToastPayload = (
           address: string;
           amount?: number;
       }
+    | {
+          type: 'aopp-protocol';
+          message: string;
+          asset: Network['symbol'];
+      }
 ) &
     Options;
 

--- a/packages/suite/src/reducers/suite/protocolReducer.ts
+++ b/packages/suite/src/reducers/suite/protocolReducer.ts
@@ -2,11 +2,19 @@ import produce from 'immer';
 import { PROTOCOL } from '@suite-actions/constants';
 import type { Action } from '@suite-types';
 import type { PROTOCOL_SCHEME } from '@suite-constants/protocol';
+import type { Network } from '@wallet-types';
 
 export interface SendFormState {
     scheme: PROTOCOL_SCHEME;
     address: string;
     amount?: number;
+}
+
+export interface AoppState {
+    message: string;
+    asset: Network['symbol'];
+    callback?: string;
+    format?: string;
 }
 
 type Autofill<T> = Partial<T> & {
@@ -15,10 +23,12 @@ type Autofill<T> = Partial<T> & {
 
 export interface State {
     sendForm: Autofill<SendFormState>;
+    aopp: Autofill<AoppState>;
 }
 
 export const initialState: State = {
     sendForm: {},
+    aopp: {},
 };
 
 const protocolReducer = (state: State = initialState, action: Action): State =>
@@ -32,6 +42,16 @@ const protocolReducer = (state: State = initialState, action: Action): State =>
                 draft.sendForm.scheme = action.payload.scheme;
                 draft.sendForm.amount = action.payload.amount;
                 draft.sendForm.shouldFill = false;
+                break;
+            case PROTOCOL.FILL_AOPP:
+                draft.aopp.shouldFill = action.payload;
+                break;
+            case PROTOCOL.SAVE_AOPP_PROTOCOL:
+                draft.aopp.message = action.payload.message;
+                draft.aopp.callback = action.payload.callback;
+                draft.aopp.asset = action.payload.asset;
+                draft.aopp.format = action.payload.format;
+                draft.aopp.shouldFill = false;
                 break;
             case PROTOCOL.RESET:
                 return initialState;

--- a/packages/suite/src/reducers/suite/protocolReducer.ts
+++ b/packages/suite/src/reducers/suite/protocolReducer.ts
@@ -1,14 +1,20 @@
 import produce from 'immer';
 import { PROTOCOL } from '@suite-actions/constants';
-import { Action } from '@suite-types';
+import type { Action } from '@suite-types';
+import type { PROTOCOL_SCHEME } from '@suite-constants/protocol';
+
+export interface SendFormState {
+    scheme: PROTOCOL_SCHEME;
+    address: string;
+    amount?: number;
+}
+
+type Autofill<T> = Partial<T> & {
+    shouldFill?: boolean;
+};
 
 export interface State {
-    sendForm: {
-        address?: string;
-        amount?: number;
-        scheme?: 'bitcoin';
-        shouldFillSendForm?: boolean;
-    };
+    sendForm: Autofill<SendFormState>;
 }
 
 export const initialState: State = {
@@ -19,13 +25,13 @@ const protocolReducer = (state: State = initialState, action: Action): State =>
     produce(state, draft => {
         switch (action.type) {
             case PROTOCOL.FILL_SEND_FORM:
-                draft.sendForm.shouldFillSendForm = action.payload;
+                draft.sendForm.shouldFill = action.payload;
                 break;
             case PROTOCOL.SAVE_COIN_PROTOCOL:
                 draft.sendForm.address = action.payload.address;
                 draft.sendForm.scheme = action.payload.scheme;
                 draft.sendForm.amount = action.payload.amount;
-                draft.sendForm.shouldFillSendForm = false;
+                draft.sendForm.shouldFill = false;
                 break;
             case PROTOCOL.RESET:
                 return initialState;

--- a/packages/suite/src/support/messages.ts
+++ b/packages/suite/src/support/messages.ts
@@ -2804,10 +2804,18 @@ export default defineMessages({
         defaultMessage: 'Retrying..',
         id: 'TR_RETRYING_DOT_DOT',
     },
+    TR_QR_CODE: {
+        defaultMessage: 'QR code',
+        id: 'TR_QR_CODE',
+    },
     TR_SCAN_QR_CODE: {
         defaultMessage: 'Scan QR code',
         description: 'Title for the Scan QR modal dialog',
         id: 'TR_SCAN_QR_CODE',
+    },
+    TR_PASTE_URI: {
+        defaultMessage: 'Paste URI',
+        id: 'TR_PASTE_URI',
     },
     TR_SECURITY_HEADING: {
         defaultMessage: 'Your wallet is almost ready',

--- a/packages/suite/src/support/messages.ts
+++ b/packages/suite/src/support/messages.ts
@@ -7062,4 +7062,12 @@ export default defineMessages({
         id: 'TR_DO_YOU_REALLY_WANT_TO_SKIP',
         defaultMessage: 'Do you really want to skip this step?',
     },
+    TOAST_AOPP_FILL_HEADER: {
+        id: 'TOAST_AOPP_FILL_HEADER',
+        defaultMessage: 'Go to Sign & Verify form',
+    },
+    TOAST_AOPP_FILL_ACTION: {
+        id: 'TOAST_AOPP_FILL_ACTION',
+        defaultMessage: 'Fill form',
+    },
 });

--- a/packages/suite/src/support/messages.ts
+++ b/packages/suite/src/support/messages.ts
@@ -2934,6 +2934,10 @@ export default defineMessages({
         description: 'Sign button in Sign and Verify form',
         id: 'TR_SIGN',
     },
+    TR_SIGNED: {
+        defaultMessage: 'Signed',
+        id: 'TR_SIGNED',
+    },
     TR_SIGN_MESSAGE: {
         defaultMessage: 'Sign message',
         description: 'Header for the Sign and Verify form',
@@ -3277,6 +3281,10 @@ export default defineMessages({
         defaultMessage: 'Verify',
         description: 'Verify button in Sign and Verify form',
         id: 'TR_VERIFY',
+    },
+    TR_VERIFIED: {
+        defaultMessage: 'Verified',
+        id: 'TR_VERIFIED',
     },
     TR_VERIFY_MESSAGE: {
         defaultMessage: 'Verify message',

--- a/packages/suite/src/support/messages.ts
+++ b/packages/suite/src/support/messages.ts
@@ -7062,6 +7062,14 @@ export default defineMessages({
         id: 'TR_DO_YOU_REALLY_WANT_TO_SKIP',
         defaultMessage: 'Do you really want to skip this step?',
     },
+    TR_AOPP_IMPORT: {
+        id: 'TR_AOPP_IMPORT',
+        defaultMessage: 'Import AOPP',
+    },
+    TR_AOPP_SEND: {
+        id: 'TR_AOPP_SEND',
+        defaultMessage: 'Send ownership proof',
+    },
     TOAST_AOPP_FILL_HEADER: {
         id: 'TOAST_AOPP_FILL_HEADER',
         defaultMessage: 'Go to Sign & Verify form',
@@ -7069,5 +7077,13 @@ export default defineMessages({
     TOAST_AOPP_FILL_ACTION: {
         id: 'TOAST_AOPP_FILL_ACTION',
         defaultMessage: 'Fill form',
+    },
+    TOAST_AOPP_SUCCESS: {
+        id: 'TOAST_AOPP_SUCCESS',
+        defaultMessage: 'Address ownership proof sent',
+    },
+    TOAST_AOPP_ERROR: {
+        id: 'TOAST_AOPP_ERROR',
+        defaultMessage: 'Address ownership proof failed: {error}',
     },
 });

--- a/packages/suite/src/support/suite/Protocol.tsx
+++ b/packages/suite/src/support/suite/Protocol.tsx
@@ -9,9 +9,10 @@ import * as protocolActions from '@suite-actions/protocolActions';
 import { PROTOCOL_SCHEME } from '@suite-constants/protocol';
 
 const Protocol = () => {
-    const { addToast, saveCoinProtocol } = useActions({
+    const { addToast, saveCoinProtocol, saveAoppProtocol } = useActions({
         addToast: notificationActions.addToast,
         saveCoinProtocol: protocolActions.saveCoinProtocol,
+        saveAoppProtocol: protocolActions.saveAoppProtocol,
     });
 
     const handleProtocolRequest = useCallback(
@@ -30,11 +31,27 @@ const Protocol = () => {
                     });
                     break;
                 }
+                case PROTOCOL_SCHEME.AOPP: {
+                    const { asset, msg, callback, format } = protocolInfo;
+                    saveAoppProtocol({
+                        asset,
+                        message: msg,
+                        callback,
+                        format,
+                    });
+                    addToast({
+                        type: 'aopp-protocol',
+                        message: msg,
+                        asset,
+                        autoClose: false,
+                    });
+                    break;
+                }
                 default:
                     break;
             }
         },
-        [addToast, saveCoinProtocol],
+        [addToast, saveCoinProtocol, saveAoppProtocol],
     );
 
     const { search } = useLocation();

--- a/packages/suite/src/support/suite/Protocol.tsx
+++ b/packages/suite/src/support/suite/Protocol.tsx
@@ -6,16 +6,7 @@ import { getProtocolInfo } from '@suite-utils/parseUri';
 import { useActions } from '@suite-hooks';
 import * as notificationActions from '@suite-actions/notificationActions';
 import * as protocolActions from '@suite-actions/protocolActions';
-
-import type { CoinType } from '@trezor/components';
-
-export enum PROTOCOL_SCHEME {
-    BITCOIN = 'bitcoin',
-}
-
-export const PROTOCOL_TO_SYMBOL: { [key: string]: CoinType } = {
-    [PROTOCOL_SCHEME.BITCOIN]: 'btc',
-};
+import { PROTOCOL_SCHEME } from '@suite-constants/protocol';
 
 const Protocol = () => {
     const { addToast, saveCoinProtocol } = useActions({
@@ -26,17 +17,21 @@ const Protocol = () => {
     const handleProtocolRequest = useCallback(
         uri => {
             const protocolInfo = getProtocolInfo(uri);
-
-            if (protocolInfo?.scheme === PROTOCOL_SCHEME.BITCOIN) {
-                saveCoinProtocol(protocolInfo.scheme, protocolInfo.address, protocolInfo.amount);
-
-                addToast({
-                    type: 'coin-scheme-protocol',
-                    address: protocolInfo.address,
-                    scheme: protocolInfo.scheme,
-                    amount: protocolInfo.amount,
-                    autoClose: false,
-                });
+            switch (protocolInfo?.scheme) {
+                case PROTOCOL_SCHEME.BITCOIN: {
+                    const { scheme, amount, address } = protocolInfo;
+                    saveCoinProtocol(scheme, address, amount);
+                    addToast({
+                        type: 'coin-scheme-protocol',
+                        address,
+                        scheme,
+                        amount,
+                        autoClose: false,
+                    });
+                    break;
+                }
+                default:
+                    break;
             }
         },
         [addToast, saveCoinProtocol],

--- a/packages/suite/src/utils/suite/__fixtures__/parseUri.ts
+++ b/packages/suite/src/utils/suite/__fixtures__/parseUri.ts
@@ -1,0 +1,153 @@
+export const parseUri = [
+    {
+        description: 'valid http scheme',
+        uri: 'http://www.trezor.io?amount=1',
+        result: {
+            host: 'www.trezor.io',
+            protocol: 'http:',
+            pathname: '/',
+            search: '?amount=1',
+        },
+    },
+    {
+        description: 'valid protocol scheme',
+        uri: 'bitcoin:3QmuBaZrJNCxc5Xs7aGzZUK8RirUT8jRKf?amount=0.1',
+        result: {
+            host: '',
+            protocol: 'bitcoin:',
+            pathname: '3QmuBaZrJNCxc5Xs7aGzZUK8RirUT8jRKf',
+            search: '?amount=0.1',
+        },
+    },
+    {
+        description: 'valid scheme with slashes, but address is value is in host field',
+        uri: 'bitcoin://3QmuBaZrJNCxc5Xs7aGzZUK8RirUT8jRKf?amount=0.1',
+        result: {
+            host: '3QmuBaZrJNCxc5Xs7aGzZUK8RirUT8jRKf',
+            protocol: 'bitcoin:',
+            pathname: '',
+            search: '?amount=0.1',
+        },
+    },
+    {
+        description: 'invalid: no-http',
+        uri: 'www.trezor.io',
+        result: undefined,
+    },
+    {
+        description: 'invalid: null',
+        uri: null,
+        result: undefined,
+    },
+];
+
+export const parseQuery = [
+    {
+        description: 'accepted simple string',
+        uri: 'amount=1&foo=bar',
+        result: {
+            amount: '1',
+            foo: 'bar',
+        },
+    },
+    {
+        description: 'accepted query string',
+        uri: '?amount=1&foo=bar',
+        result: {
+            amount: '1',
+            foo: 'bar',
+        },
+    },
+    {
+        description: 'skip host',
+        uri: 'http://foo.bar?amount=1',
+        result: {
+            amount: '1',
+        },
+    },
+    {
+        description: 'invalid: null',
+        uri: null,
+        result: {},
+    },
+    {
+        description: 'invalid: number',
+        uri: 1,
+        result: {},
+    },
+    {
+        description: 'invalid: no search',
+        uri: 'foo?',
+        result: {},
+    },
+];
+
+export const getProtocolInfo = [
+    {
+        description: 'should parse Bitcoin URI when address and amount are both available',
+        uri: 'bitcoin:3QmuBaZrJNCxc5Xs7aGzZUK8RirUT8jRKf?amount=0.1',
+        result: {
+            scheme: 'bitcoin',
+            address: '3QmuBaZrJNCxc5Xs7aGzZUK8RirUT8jRKf',
+            amount: 0.1,
+        },
+    },
+    {
+        description:
+            'should parse Bitcoin URI when it consists not only of address and amount but also not yet existing variable',
+        uri: 'bitcoin:3QmuBaZrJNCxc5Xs7aGzZUK8RirUT8jRKf?amount=1&layer=lightning&label=Bender&message=Bite%20my%20shiny%20metal%20Bitcoin',
+        result: {
+            scheme: 'bitcoin',
+            address: '3QmuBaZrJNCxc5Xs7aGzZUK8RirUT8jRKf',
+            amount: 1,
+        },
+    },
+    {
+        description: 'should parse Bitcoin URI when it consists only of address',
+        uri: 'bitcoin://3QmuBaZrJNCxc5Xs7aGzZUK8RirUT8jRKf',
+        result: {
+            scheme: 'bitcoin',
+            address: '3QmuBaZrJNCxc5Xs7aGzZUK8RirUT8jRKf',
+            amount: undefined,
+        },
+    },
+    {
+        description: 'should parse Bitcoin URI when it consists of address and zero amount',
+        uri: 'bitcoin:3QmuBaZrJNCxc5Xs7aGzZUK8RirUT8jRKf?amount=0',
+        result: {
+            scheme: 'bitcoin',
+            address: '3QmuBaZrJNCxc5Xs7aGzZUK8RirUT8jRKf',
+            amount: undefined,
+        },
+    },
+    {
+        description:
+            'should parse Bitcoin URI and ignore amount when it consists of address, and amount is not a number',
+        uri: 'bitcoin:3QmuBaZrJNCxc5Xs7aGzZUK8RirUT8jRKf?amount=thousand',
+        result: {
+            scheme: 'bitcoin',
+            address: '3QmuBaZrJNCxc5Xs7aGzZUK8RirUT8jRKf',
+            amount: undefined,
+        },
+    },
+    {
+        description: 'invalid uri',
+        uri: 'gibberish',
+        result: null,
+    },
+    {
+        description: 'invalid uri',
+        uri: null,
+        result: null,
+    },
+    {
+        description: 'should log an error with non-existing scheme',
+        uri: 'litecoin:3QmuBaZrJNCxc5Xs7aGzZUK8RirUT8jRKf?amount=0.1',
+        result: null,
+    },
+    {
+        description: 'should log an error when address is missing',
+        uri: 'bitcoin:?amount=0.1',
+        result: null,
+    },
+];

--- a/packages/suite/src/utils/suite/__fixtures__/parseUri.ts
+++ b/packages/suite/src/utils/suite/__fixtures__/parseUri.ts
@@ -131,6 +131,42 @@ export const getProtocolInfo = [
         },
     },
     {
+        description: 'valid AOPP uri',
+        uri: 'aopp:?v=0&msg=MESSAGE&asset=btc&format=any&callback=https%3A%2F%2Ftesting.21analytics.ch%2Fproofs%2Fc220a28e-0e99-4be6-8578-a886f628ee20',
+        result: {
+            scheme: 'aopp',
+            v: '0',
+            msg: 'MESSAGE',
+            asset: 'btc',
+            format: 'any',
+            callback: 'https://testing.21analytics.ch/proofs/c220a28e-0e99-4be6-8578-a886f628ee20',
+        },
+    },
+    {
+        description: 'valid AOPP uri with invalid callback',
+        uri: 'aopp:?v=0&msg=MESSAGE&asset=btc&format=any&callback=a',
+        result: {
+            scheme: 'aopp',
+            v: '0',
+            msg: 'MESSAGE',
+            asset: 'btc',
+            format: 'any',
+            callback: undefined,
+        },
+    },
+    {
+        description: 'valid AOPP uri, callback with slashes',
+        uri: 'aopp:?v=0&msg=MESSAGE&asset=btc&format=any&callback=https://foo.bar',
+        result: {
+            scheme: 'aopp',
+            v: '0',
+            msg: 'MESSAGE',
+            asset: 'btc',
+            format: 'any',
+            callback: 'https://foo.bar',
+        },
+    },
+    {
         description: 'invalid uri',
         uri: 'gibberish',
         result: null,

--- a/packages/suite/src/utils/suite/parseUri.ts
+++ b/packages/suite/src/utils/suite/parseUri.ts
@@ -1,4 +1,4 @@
-import { PROTOCOL_SCHEME } from '@suite-support/Protocol';
+import { PROTOCOL_SCHEME } from '@suite-constants/protocol';
 
 /* eslint-disable prefer-destructuring */
 export interface ParsedURI {

--- a/packages/suite/src/utils/suite/parseUri.ts
+++ b/packages/suite/src/utils/suite/parseUri.ts
@@ -1,4 +1,6 @@
 import { PROTOCOL_SCHEME } from '@suite-constants/protocol';
+import { isNetworkSymbol } from '@wallet-utils/accountUtils';
+import type { Network } from '@wallet-types';
 
 // Parse URL query string (like 'foo=bar&baz=1337) into an object
 export const parseQuery = (uri: string) => {
@@ -28,7 +30,16 @@ export type CoinProtocolInfo = {
     amount?: number;
 };
 
-export const getProtocolInfo = (uri: string): CoinProtocolInfo | null => {
+export type AoppProtocolInfo = {
+    scheme: PROTOCOL_SCHEME.AOPP;
+    msg: string;
+    asset: Network['symbol'];
+    v?: string;
+    format?: string;
+    callback?: string;
+};
+
+export const getProtocolInfo = (uri: string): CoinProtocolInfo | AoppProtocolInfo | null => {
     const url = parseUri(uri);
     if (!url) return null;
 
@@ -45,6 +56,20 @@ export const getProtocolInfo = (uri: string): CoinProtocolInfo | null => {
             scheme,
             address: pathname?.replace('//', '') || host,
             amount,
+        };
+    }
+
+    if (scheme === PROTOCOL_SCHEME.AOPP) {
+        if (!params.msg) return null;
+        if (!params.asset || !isNetworkSymbol(params.asset)) return null;
+        const validCallback = parseUri(params.callback ?? '');
+        return {
+            scheme,
+            v: params.v,
+            asset: params.asset,
+            format: params.format,
+            msg: params.msg,
+            callback: validCallback ? params.callback : undefined,
         };
     }
 

--- a/packages/suite/src/utils/suite/parseUri.ts
+++ b/packages/suite/src/utils/suite/parseUri.ts
@@ -1,72 +1,49 @@
 import { PROTOCOL_SCHEME } from '@suite-constants/protocol';
 
-/* eslint-disable prefer-destructuring */
-export interface ParsedURI {
-    address: string;
-    amount?: string;
-}
-
-const stripPrefix = (str: string): string => {
-    if (!str.match(':')) {
-        return str;
-    }
-    const parts = str.split(':');
-    parts.shift();
-    return parts.join('');
-};
-
 // Parse URL query string (like 'foo=bar&baz=1337) into an object
-export const parseQuery = (str: string) =>
-    str
-        .split('&')
-        .map(val => val.split('='))
-        .reduce((vals: { [key: string]: any }, pair: string[]) => {
-            if (pair.length > 1) {
-                vals[pair[0]] = pair[1];
-            }
-            return vals;
-        }, {});
-
-// Parse a string read from a bitcoin QR code into an object
-export const parseUri = (uri: string): ParsedURI => {
-    const str = stripPrefix(uri);
-    const query: string[] = str.split('?');
-    const values: Record<string, any> = query.length > 1 ? parseQuery(query[1]) : {};
-    const address = query[0] || '';
-
-    return {
-        ...values,
-        address,
-    };
+export const parseQuery = (uri: string) => {
+    const params: Record<string, string | undefined> = {};
+    try {
+        const index = uri.indexOf('?');
+        new URLSearchParams(uri.substring(index)).forEach((v, k) => {
+            params[k] = v;
+        });
+    } catch (e) {
+        // empty
+    }
+    return params;
 };
 
-interface BaseProtocol {
-    scheme: string;
+export const parseUri = (uri: string) => {
+    try {
+        return new URL(uri);
+    } catch (e) {
+        // empty
+    }
+};
+
+export type CoinProtocolInfo = {
+    scheme: PROTOCOL_SCHEME.BITCOIN;
     address: string;
-}
-
-interface BitcoinProtocol extends BaseProtocol {
-    scheme: PROTOCOL_SCHEME;
     amount?: number;
-}
+};
 
-export const getProtocolInfo = (uri: string): BitcoinProtocol | null => {
-    const { protocol, pathname, search } = new URL(uri.replace('://', ':'));
-    const scheme = protocol.slice(0, -1);
+export const getProtocolInfo = (uri: string): CoinProtocolInfo | null => {
+    const url = parseUri(uri);
+    if (!url) return null;
 
-    const params: { [key: string]: string } = {};
+    const { protocol, pathname, host, search } = url;
+    const scheme = protocol.slice(0, -1); // slice ":" from protocol
 
-    new URLSearchParams(search).forEach((v, k) => {
-        params[k] = v;
-    });
+    const params = parseQuery(search);
 
-    const floatAmount = Number.parseFloat(params.amount);
-    const amount = !Number.isNaN(floatAmount) && floatAmount > 0 ? floatAmount : undefined;
-
-    if (scheme === PROTOCOL_SCHEME.BITCOIN && pathname) {
+    if (scheme === PROTOCOL_SCHEME.BITCOIN) {
+        if (!pathname && !host) return null; // address may be in pathname (regular bitcoin:addr) or host (bitcoin://addr)
+        const floatAmount = Number.parseFloat(params.amount ?? '');
+        const amount = !Number.isNaN(floatAmount) && floatAmount > 0 ? floatAmount : undefined;
         return {
             scheme,
-            address: pathname,
+            address: pathname?.replace('//', '') || host,
             amount,
         };
     }

--- a/packages/suite/src/utils/wallet/accountUtils.ts
+++ b/packages/suite/src/utils/wallet/accountUtils.ts
@@ -247,6 +247,9 @@ export const getSelectedAccount = (
 
 export const getNetwork = (symbol: string) => NETWORKS.find(c => c.symbol === symbol) || null;
 
+export const isNetworkSymbol = (symbol: string): symbol is Network['symbol'] =>
+    !!getNetwork(symbol);
+
 /**
  * Returns a string used as an index to separate txs for given account inside a transactions reducer
  *


### PR DESCRIPTION
First version of AOPP protocol support (#4512), without any product input for now. It is an alternative for PR #4468, which is WIP and probably stalled.

- you can give it a try e.g. [here](https://testing.aopp.group/)
- `aopp:` protocol link works only in desktop app, you must copy URI/scan QR code in web app instead
- sending ownership proof to the example page above doesn't work from web app because of CORS configuration on their side