### PR TITLE
cypress maintanance

### DIFF
--- a/ci/test.yml
+++ b/ci/test.yml
@@ -22,7 +22,6 @@
     - yarn install --pure-lockfile --cache-folder .yarn --prefer-offline
     - docker-compose pull
     - docker-compose up -d trezor-user-env-unix
-    - sleep 5
     - docker-compose run test-run
   after_script:
     - docker cp ${CI_JOB_ID}_trezor-user-env-unix_1:/trezor-user-env/logs/debugging.log trezor-user-env-debugging.log

--- a/packages/integration-tests/projects/suite-web/plugins/websocket-client.js
+++ b/packages/integration-tests/projects/suite-web/plugins/websocket-client.js
@@ -169,7 +169,6 @@ class Controller extends EventEmitter {
         const ws = new WebSocket(url);
         ws.once('error', error => {
             this.dispose();
-            console.log(error);
             dfd.reject(new Error('websocket_runtime_error: ', error.message));
         });
         ws.on('open', () => {

--- a/packages/integration-tests/projects/suite-web/run_tests.js
+++ b/packages/integration-tests/projects/suite-web/run_tests.js
@@ -13,6 +13,8 @@ const fetch = require('node-fetch');
 const path = require('path');
 const fs = require('fs');
 
+const { Controller } = require('./plugins/websocket-client');
+
 const TEST_DIR = './packages/integration-tests/projects/suite-web';
 
 const getGrepCommand = (word = '', args = '-rlIw', path = TEST_DIR) =>
@@ -50,7 +52,32 @@ function getTestFiles() {
         .filter(f => f.includes('.test.'));
 }
 
+const wait = (timeout) => {
+    return new Promise((resolve) => {
+        setTimeout(() => {
+            resolve()
+        }, timeout)
+    })
+}
+
 async function runTests() {
+
+
+    // wait for trezor-user-env
+    let retries = 0;
+    let connected = false;
+    const controller = new Controller({ url: 'ws://localhost:9001/' });
+    while (!connected && retries < 60) {
+        try {
+            await controller.connect();
+            connected = true;
+        } catch (err) {
+            console.log('waiting for trezor-user-env...');
+        }
+        await wait(1000);
+        retries++;
+    }
+
     const {
         BROWSER = 'chrome',
         CYPRESS_baseUrl, // eslint-disable-line @typescript-eslint/naming-convention

--- a/packages/integration-tests/projects/suite-web/tests/metadata/account-metadata.test.ts
+++ b/packages/integration-tests/projects/suite-web/tests/metadata/account-metadata.test.ts
@@ -43,8 +43,8 @@ Hovering over fields that may be labeled shows "add label" button upon which is 
 
             cy.prefixedVisit('/', {
                 onBeforeLoad: (win: Window) => {
-                    cy.stub(win, 'open', stubOpen(win));
-                    cy.stub(win, 'fetch', rerouteMetadataToMockProvider);
+                    cy.stub(win, 'open').callsFake(stubOpen(win));
+                    cy.stub(win, 'fetch').callsFake(rerouteMetadataToMockProvider);
                 },
             });
 

--- a/packages/integration-tests/projects/suite-web/tests/metadata/address-metadata.test.ts
+++ b/packages/integration-tests/projects/suite-web/tests/metadata/address-metadata.test.ts
@@ -23,8 +23,8 @@ describe('Metadata - address labeling', () => {
             cy.task('metadataStartProvider', provider);
             cy.prefixedVisit('/', {
                 onBeforeLoad: (win: Window) => {
-                    cy.stub(win, 'open', stubOpen(win));
-                    cy.stub(win, 'fetch', rerouteMetadataToMockProvider);
+                    cy.stub(win, 'open').callsFake(stubOpen(win));
+                    cy.stub(win, 'fetch').callsFake(rerouteMetadataToMockProvider);
                 },
             });
 

--- a/packages/integration-tests/projects/suite-web/tests/metadata/dropbox-api-errors.test.ts
+++ b/packages/integration-tests/projects/suite-web/tests/metadata/dropbox-api-errors.test.ts
@@ -29,8 +29,8 @@ describe('Dropbox api errors', () => {
         });
         cy.prefixedVisit('/', {
             onBeforeLoad: (win: Window) => {
-                cy.stub(win, 'open', stubOpen(win));
-                cy.stub(win, 'fetch', rerouteMetadataToMockProvider);
+                cy.stub(win, 'open').callsFake(stubOpen(win));
+                cy.stub(win, 'fetch').callsFake(rerouteMetadataToMockProvider);
             },
         });
 

--- a/packages/integration-tests/projects/suite-web/tests/metadata/google-api-errors.test.ts
+++ b/packages/integration-tests/projects/suite-web/tests/metadata/google-api-errors.test.ts
@@ -16,8 +16,8 @@ describe('Google api errors', () => {
         cy.task('metadataStartProvider', provider);
         cy.prefixedVisit('/', {
             onBeforeLoad: (win: Window) => {
-                cy.stub(win, 'open', stubOpen(win));
-                cy.stub(win, 'fetch', rerouteMetadataToMockProvider);
+                cy.stub(win, 'open').callsFake(stubOpen(win));
+                cy.stub(win, 'fetch').callsFake(rerouteMetadataToMockProvider);
             },
         });
         cy.passThroughInitialRun();

--- a/packages/integration-tests/projects/suite-web/tests/metadata/interval-fetching.test.ts
+++ b/packages/integration-tests/projects/suite-web/tests/metadata/interval-fetching.test.ts
@@ -48,8 +48,8 @@ describe('Metadata - suite is watching cloud provider and syncs periodically', (
             });
             cy.prefixedVisit('/', {
                 onBeforeLoad: win => {
-                    cy.stub(win, 'open', stubOpen(win));
-                    cy.stub(win, 'fetch', rerouteMetadataToMockProvider);
+                    cy.stub(win, 'open').callsFake(stubOpen(win));
+                    cy.stub(win, 'fetch').callsFake(rerouteMetadataToMockProvider);
                 },
             });
             cy.tick(1000);

--- a/packages/integration-tests/projects/suite-web/tests/metadata/output-labeling.test.ts
+++ b/packages/integration-tests/projects/suite-web/tests/metadata/output-labeling.test.ts
@@ -27,8 +27,8 @@ describe('Metadata - Output labeling', () => {
 
             cy.prefixedVisit('/', {
                 onBeforeLoad: (win: Window) => {
-                    cy.stub(win, 'open', stubOpen(win));
-                    cy.stub(win, 'fetch', rerouteMetadataToMockProvider);
+                    cy.stub(win, 'open').callsFake(stubOpen(win));
+                    cy.stub(win, 'fetch').callsFake(rerouteMetadataToMockProvider);
                 },
             });
 

--- a/packages/integration-tests/projects/suite-web/tests/metadata/remembered-device.test.ts
+++ b/packages/integration-tests/projects/suite-web/tests/metadata/remembered-device.test.ts
@@ -44,8 +44,8 @@ On disable, it throws away all metadata related records from memory.`, () => {
 
             cy.prefixedVisit('/', {
                 onBeforeLoad: (win: Window) => {
-                    cy.stub(win, 'open', stubOpen(win));
-                    cy.stub(win, 'fetch', rerouteMetadataToMockProvider);
+                    cy.stub(win, 'open').callsFake(stubOpen(win));
+                    cy.stub(win, 'fetch').callsFake(rerouteMetadataToMockProvider);
                 },
             });
             cy.log(

--- a/packages/integration-tests/projects/suite-web/tests/metadata/switching-providers.test.ts
+++ b/packages/integration-tests/projects/suite-web/tests/metadata/switching-providers.test.ts
@@ -20,8 +20,8 @@ describe(`Metadata - switching between cloud providers`, () => {
 
         cy.prefixedVisit('/', {
             onBeforeLoad: (win: Window) => {
-                cy.stub(win, 'open', stubOpen(win));
-                cy.stub(win, 'fetch', rerouteMetadataToMockProvider);
+                cy.stub(win, 'open').callsFake(stubOpen(win));
+                cy.stub(win, 'fetch').callsFake(rerouteMetadataToMockProvider);
             },
         });
         cy.passThroughInitialRun();

--- a/packages/integration-tests/projects/suite-web/tests/metadata/wallet-metadata.test.ts
+++ b/packages/integration-tests/projects/suite-web/tests/metadata/wallet-metadata.test.ts
@@ -28,8 +28,8 @@ describe('Metadata - wallet labeling', () => {
 
             cy.prefixedVisit('/', {
                 onBeforeLoad: (win: Window) => {
-                    cy.stub(win, 'open', stubOpen(win));
-                    cy.stub(win, 'fetch', rerouteMetadataToMockProvider);
+                    cy.stub(win, 'open').callsFake(stubOpen(win));
+                    cy.stub(win, 'fetch').callsFake(rerouteMetadataToMockProvider);
                 },
             });
 


### PR DESCRIPTION
again few occasional improvements

- removed cases where cy.stub deprecated method signature was used
- removed sleep 5. instead implemented dynamic waiting for trezor-user-env first response. 