### PR TITLE
fix(suite): open safety-checks modal from banner

### DIFF
--- a/packages/suite/src/components/suite/Banners/SafetyChecks.tsx
+++ b/packages/suite/src/components/suite/Banners/SafetyChecks.tsx
@@ -1,16 +1,16 @@
 import React from 'react';
 import { Translation } from '@suite-components';
 import { useActions } from '@suite-hooks';
+import * as modalActions from '@suite-actions/modalActions';
 import Wrapper from './components/Wrapper';
-import * as routerActions from '@suite/actions/suite/routerActions';
 
 interface Props {
     onDismiss?: () => void;
 }
 
 const SafetyChecksBanner = (props: Props) => {
-    const { goto } = useActions({
-        goto: routerActions.goto,
+    const { openModal } = useActions({
+        openModal: modalActions.openModal,
     });
 
     return (
@@ -19,8 +19,7 @@ const SafetyChecksBanner = (props: Props) => {
             body={<Translation id="TR_SAFETY_CHECKS_DISABLED_WARNING" />}
             action={{
                 label: <Translation id="TR_SAFETY_CHECKS_BANNER_CHANGE" />,
-                // TODO: Use anchor to bring the user to the appropriate section of settings.
-                onClick: () => goto('settings-device'),
+                onClick: () => openModal({ type: 'safety-checks' }),
                 'data-test': '@banner/safety-checks/button',
             }}
             dismissal={

--- a/packages/suite/src/components/suite/modals/SafetyChecks/index.tsx
+++ b/packages/suite/src/components/suite/modals/SafetyChecks/index.tsx
@@ -1,5 +1,5 @@
 import React, { useState } from 'react';
-import { useActions, useSelector } from '@suite-hooks';
+import { useActions, useDevice } from '@suite-hooks';
 import { RadioButton, Button, H3, P, Warning } from '@trezor/components';
 import { Translation, Modal, ModalProps } from '@suite-components';
 import * as deviceSettingsActions from '@settings-actions/deviceSettingsActions';
@@ -42,7 +42,7 @@ const WarningWrapper = styled.div`
  * set only via command line and trezor-lib.
  */
 const SafetyChecks = (props: ModalProps) => {
-    const device = useSelector(state => state.suite.device);
+    const { device, isLocked } = useDevice();
     const { applySettings } = useActions({ applySettings: deviceSettingsActions.applySettings });
     const [level, setLevel] = useState(device?.features?.safety_checks || undefined);
 
@@ -53,7 +53,7 @@ const SafetyChecks = (props: ModalProps) => {
                     applySettings({ safety_checks: level });
                 }}
                 // Only allow confirming when the value will be changed.
-                isDisabled={level === device?.features?.safety_checks}
+                isDisabled={isLocked() || level === device?.features?.safety_checks}
                 data-test="@safety-checks-apply"
             >
                 <Translation id="TR_CONFIRM" />


### PR DESCRIPTION
Open modal from any route instead of navigating back to settings/device.

Previous:
- goto settings/device
- find safety checks, disable them
- goto dashboard, safety-checks banner should be visible
- clicking on banner navigates you to settings/device and you need to locate "safety checks" once again to open the modal

Fixed:
- goto settings/device
- find safety checks, disable them
- goto dashboard, safety-checks banner should be visible
- clicking on banner will open the modal right away