### PR TITLE
chore(e2e): optimize e2e metadata tests

### DIFF
--- a/packages/integration-tests/projects/suite-web/tests/metadata/address-metadata.test.ts
+++ b/packages/integration-tests/projects/suite-web/tests/metadata/address-metadata.test.ts
@@ -3,7 +3,7 @@
 
 import { rerouteMetadataToMockProvider, stubOpen } from '../../stubs/metadata';
 
-const providers = ['dropbox', 'google'] as const;
+const provider = 'google';
 
 const metadataEl = '@metadata/addressLabel/bc1q7e6qu5smalrpgqrx9k2gnf0hgjyref5p36ru2m';
 
@@ -12,36 +12,34 @@ describe('Metadata - address labeling', () => {
         cy.viewport(1024, 768).resetDb();
     });
 
-    providers.forEach(provider => {
-        it(provider, () => {
-            // prepare test
-            cy.task('startEmu', { wipe: true });
-            cy.task('setupEmu', {
-                mnemonic: 'all all all all all all all all all all all all',
-            });
-            cy.task('startBridge');
-            cy.task('metadataStartProvider', provider);
-            cy.prefixedVisit('/', {
-                onBeforeLoad: (win: Window) => {
-                    cy.stub(win, 'open').callsFake(stubOpen(win));
-                    cy.stub(win, 'fetch').callsFake(rerouteMetadataToMockProvider);
-                },
-            });
-
-            cy.passThroughInitialRun();
-
-            cy.getTestElement('@suite/menu/wallet-index').click();
-
-            cy.discoveryShouldFinish();
-
-            cy.getTestElement('@wallet/menu/wallet-receive').click();
-            cy.getTestElement(`${metadataEl}/add-label-button`).click({ force: true });
-            cy.passThroughInitMetadata(provider);
-
-            cy.getTestElement('@metadata/input').type('meoew address{enter}');
-            cy.wait(2001); // reasonable here, elements visible only on hover are difficult to wait for in cypress
-            cy.getTestElement(`${metadataEl}/edit-label-button`).click({ force: true });
-            cy.getTestElement('@metadata/input').type(' meoew meow{enter}');
+    it(provider, () => {
+        // prepare test
+        cy.task('startEmu', { wipe: true });
+        cy.task('setupEmu', {
+            mnemonic: 'all all all all all all all all all all all all',
         });
+        cy.task('startBridge');
+        cy.task('metadataStartProvider', provider);
+        cy.prefixedVisit('/', {
+            onBeforeLoad: (win: Window) => {
+                cy.stub(win, 'open').callsFake(stubOpen(win));
+                cy.stub(win, 'fetch').callsFake(rerouteMetadataToMockProvider);
+            },
+        });
+
+        cy.passThroughInitialRun();
+
+        cy.getTestElement('@suite/menu/wallet-index').click();
+
+        cy.discoveryShouldFinish();
+
+        cy.getTestElement('@wallet/menu/wallet-receive').click();
+        cy.getTestElement(`${metadataEl}/add-label-button`).click({ force: true });
+        cy.passThroughInitMetadata(provider);
+
+        cy.getTestElement('@metadata/input').type('meoew address{enter}');
+        cy.wait(2001); // reasonable here, elements visible only on hover are difficult to wait for in cypress
+        cy.getTestElement(`${metadataEl}/edit-label-button`).click({ force: true });
+        cy.getTestElement('@metadata/input').type(' meoew meow{enter}');
     });
 });

--- a/packages/integration-tests/projects/suite-web/tests/metadata/output-labeling.test.ts
+++ b/packages/integration-tests/projects/suite-web/tests/metadata/output-labeling.test.ts
@@ -3,7 +3,8 @@
 
 import { rerouteMetadataToMockProvider, stubOpen } from '../../stubs/metadata';
 
-const providers = ['google', 'dropbox'] as const;
+// we could run this test for multiple providers but it does not give so much value at the moment
+const providers = ['google'] as const;
 
 describe('Metadata - Output labeling', () => {
     beforeEach(() => {

--- a/packages/integration-tests/projects/suite-web/tests/metadata/wallet-metadata.test.ts
+++ b/packages/integration-tests/projects/suite-web/tests/metadata/wallet-metadata.test.ts
@@ -1,9 +1,11 @@
 // @group:metadata
 // @retry=2
 
+import firmware from '@suite/middlewares/firmware';
 import { rerouteMetadataToMockProvider, stubOpen } from '../../stubs/metadata';
 
-const providers = ['google', 'dropbox'] as const;
+const firmwares = ['2.2.0', '2-master'] as const;
+const provider = 'dropbox';
 
 const mnemonic = 'all all all all all all all all all all all all';
 // state corresponding to all seed
@@ -16,8 +18,8 @@ describe('Metadata - wallet labeling', () => {
         cy.viewport(1024, 768).resetDb();
     });
 
-    providers.forEach(provider => {
-        it(provider, () => {
+    firmwares.forEach(firmware => {
+        it(firmware, () => {
             // prepare test
             cy.task('startEmu', { wipe: true });
             cy.task('setupEmu', {


### PR DESCRIPTION
- don't run all metadata scenarios against all providers. This was kinda abuse of end-to-end testing for testing internal logic of providers implementation. This was great to be sure it works correctly, but we don't need anymore to spend so much CI time on it
- run wallet metadata tests with older firmwares (prior to passphrase redesign). just to make sure it works. 

Metadata tests now run somewhat faster, saving around ~1 minute
![image](https://user-images.githubusercontent.com/30367552/144408424-fa6a3f87-e6ae-4813-8a0b-66777c2bf820.png)

pipeline failing but should pass after https://github.com/trezor/trezor-suite/pull/4587 is finished and merged