### PR TITLE
refactor(suite): replace react-redux binding with hooks

### DIFF
--- a/packages/suite-native/src/components/suite/Layout/index.tsx
+++ b/packages/suite-native/src/components/suite/Layout/index.tsx
@@ -1,19 +1,15 @@
 import React from 'react';
-import { connect } from 'react-redux';
 import { Text, ScrollView, View } from 'react-native';
 import { useTheme } from '@trezor/components';
+import { useSelector } from '@suite-hooks';
 import Head from '@native/support/suite/Head';
-import { AppState, SuiteThemeColors } from '@suite-types';
+import type { SuiteThemeColors } from '@suite-types';
 
 const styles = (theme: SuiteThemeColors) => ({
     wrapper: { backgroundColor: theme.BG_WHITE },
 });
 
-const mapStateToProps = (state: AppState) => ({
-    suite: state.suite,
-});
-
-type Props = ReturnType<typeof mapStateToProps> & {
+type Props = {
     title: string;
     disableTabs?: boolean;
     children: React.ReactNode;
@@ -22,9 +18,9 @@ type Props = ReturnType<typeof mapStateToProps> & {
 const Layout = (props: Props) => {
     const {
         title,
-        suite,
         // router,
     } = props;
+    const suite = useSelector(state => state.suite);
     const theme = useTheme();
 
     // connect was initialized, but didn't emit "TRANSPORT" event yet (it could take a while)
@@ -91,4 +87,4 @@ const Layout = (props: Props) => {
     );
 };
 
-export default connect(mapStateToProps)(Layout);
+export default Layout;

--- a/packages/suite-native/src/components/suite/Preloader/index.tsx
+++ b/packages/suite-native/src/components/suite/Preloader/index.tsx
@@ -6,33 +6,28 @@
  */
 
 import React, { useEffect } from 'react';
-import { connect } from 'react-redux';
 import { Text, View } from 'react-native';
 import { SafeAreaView } from 'react-navigation';
 import { SUITE } from '@suite-actions/constants';
 import { useTheme } from '@trezor/components';
-import { AppState, Dispatch } from '@suite-types';
+import { useSelector, useActions } from '@suite-hooks';
 import styles from '@native/support/suite/styles';
 
-const mapStateToProps = (state: AppState) => ({
-    loading: state.suite.loading,
-    loaded: state.suite.loaded,
-    error: state.suite.error,
-});
-
-type Props = ReturnType<typeof mapStateToProps> & {
-    dispatch: Dispatch;
-    children: React.ReactNode;
-};
-
-const Preloader = (props: Props) => {
-    const { loading, loaded, error, dispatch } = props;
+const Preloader: React.FC = ({ children }) => {
+    const { loading, loaded, error } = useSelector(state => ({
+        loading: state.suite.loading,
+        loaded: state.suite.loaded,
+        error: state.suite.error,
+    }));
+    const { init } = useActions({
+        init: () => ({ type: SUITE.INIT }),
+    });
     const theme = useTheme();
     useEffect(() => {
         if (!loading && !loaded && !error) {
-            dispatch({ type: SUITE.INIT });
+            init();
         }
-    }, [dispatch, loaded, loading, error]);
+    }, [init, loaded, loading, error]);
 
     if (error) {
         return (
@@ -46,9 +41,9 @@ const Preloader = (props: Props) => {
     return (
         <SafeAreaView style={styles(theme).safeArea}>
             {!loaded && <Text>Loading</Text>}
-            {loaded && props.children}
+            {loaded && children}
         </SafeAreaView>
     );
 };
 
-export default connect(mapStateToProps)(Preloader);
+export default Preloader;

--- a/packages/suite-native/src/views/dashboard/index.tsx
+++ b/packages/suite-native/src/views/dashboard/index.tsx
@@ -1,21 +1,16 @@
 import React from 'react';
-import { connect } from 'react-redux';
-import { bindActionCreators } from 'redux';
 import { View, Button } from 'react-native';
 import { P as Text, useTheme } from '@trezor/components';
+import { useActions } from '@suite-hooks';
 import * as routerActions from '@suite-actions/routerActions';
 import styles from '@native/support/suite/styles';
 import Layout from '@native-components/suite/Layout';
-import { Dispatch } from '@suite-types';
 
-const mapDispatchToProps = (dispatch: Dispatch) => ({
-    goto: bindActionCreators(routerActions.goto, dispatch),
-});
-
-type Props = ReturnType<typeof mapDispatchToProps>;
-
-const Dashboard = (props: Props) => {
+const Dashboard = () => {
     const theme = useTheme();
+    const actions = useActions({
+        goto: routerActions.goto,
+    });
 
     return (
         <Layout title="Dashboard">
@@ -28,14 +23,14 @@ const Dashboard = (props: Props) => {
             </View>
             <View style={{ margin: 20 }}>
                 <Button
-                    onPress={() => props.goto('settings-coins')}
+                    onPress={() => actions.goto('settings-coins')}
                     title="Go to wallet settings and add some coins"
                 />
             </View>
             <View style={{ margin: 20 }}>
                 <Button
                     onPress={() =>
-                        props.goto('wallet-receive', {
+                        actions.goto('wallet-receive', {
                             accountType: 'normal',
                             accountIndex: 1,
                             symbol: 'btc',
@@ -45,10 +40,10 @@ const Dashboard = (props: Props) => {
                 />
             </View>
             <View style={{ margin: 20 }}>
-                <Button onPress={() => props.goto('onboarding-index')} title="Go to onboarding" />
+                <Button onPress={() => actions.goto('onboarding-index')} title="Go to onboarding" />
             </View>
         </Layout>
     );
 };
 
-export default connect(null, mapDispatchToProps)(Dashboard);
+export default Dashboard;

--- a/packages/suite-native/src/views/suite/backup/index.tsx
+++ b/packages/suite-native/src/views/suite/backup/index.tsx
@@ -1,22 +1,16 @@
 import React from 'react';
-import { connect } from 'react-redux';
-import { bindActionCreators } from 'redux';
 import { View, Text, Button } from 'react-native';
 import { useTheme } from '@trezor/components';
-
+import { useActions } from '@suite-hooks';
 import * as routerActions from '@suite-actions/routerActions';
 import styles from '@native/support/suite/styles';
-import { Dispatch } from '@suite-types';
 
-const mapDispatchToProps = (dispatch: Dispatch) => ({
-    goto: bindActionCreators(routerActions.goto, dispatch),
-    back: bindActionCreators(routerActions.back, dispatch),
-});
-
-type Props = ReturnType<typeof mapDispatchToProps>;
-
-const Backup = (props: Props) => {
+const Backup = () => {
     const theme = useTheme();
+    const actions = useActions({
+        goto: routerActions.goto,
+        back: routerActions.back,
+    });
 
     return (
         <View style={styles(theme).container}>
@@ -28,11 +22,11 @@ const Backup = (props: Props) => {
                 </Text>
             </View>
             <View style={{ margin: 20 }}>
-                <Button onPress={props.back} title="Back to previous screen" />
+                <Button onPress={actions.back} title="Back to previous screen" />
             </View>
-            <Button onPress={() => props.goto('wallet-send')} title="Go to wallet send page" />
+            <Button onPress={() => actions.goto('wallet-send')} title="Go to wallet send page" />
         </View>
     );
 };
 
-export default connect(null, mapDispatchToProps)(Backup);
+export default Backup;

--- a/packages/suite-native/src/views/suite/firmware/index.tsx
+++ b/packages/suite-native/src/views/suite/firmware/index.tsx
@@ -1,23 +1,16 @@
 import React from 'react';
-import { connect } from 'react-redux';
-import { bindActionCreators } from 'redux';
 import { View, Text, Button } from 'react-native';
 import { useTheme } from '@trezor/components';
-
+import { useActions } from '@suite-hooks';
 import * as routerActions from '@suite-actions/routerActions';
 import styles from '@native/support/suite/styles';
 
-import { Dispatch } from '@suite-types';
-
-const mapDispatchToProps = (dispatch: Dispatch) => ({
-    goto: bindActionCreators(routerActions.goto, dispatch),
-    back: bindActionCreators(routerActions.back, dispatch),
-});
-
-type Props = ReturnType<typeof mapDispatchToProps>;
-
-const Backup = (props: Props) => {
+const Backup = () => {
     const theme = useTheme();
+    const actions = useActions({
+        goto: routerActions.goto,
+        back: routerActions.back,
+    });
     return (
         <View style={styles(theme).container}>
             <Text style={styles(theme).h1}>Firmware update</Text>
@@ -28,11 +21,11 @@ const Backup = (props: Props) => {
                 </Text>
             </View>
             <View style={{ margin: 20 }}>
-                <Button onPress={props.back} title="Back to previous screen" />
+                <Button onPress={actions.back} title="Back to previous screen" />
             </View>
             <Button
                 onPress={() =>
-                    props.goto('wallet-receive', {
+                    actions.goto('wallet-receive', {
                         symbol: 'btc',
                         accountIndex: 2,
                         accountType: 'normal',
@@ -44,4 +37,4 @@ const Backup = (props: Props) => {
     );
 };
 
-export default connect(null, mapDispatchToProps)(Backup);
+export default Backup;

--- a/packages/suite-native/src/views/suite/onboarding/components/InitialRun/index.tsx
+++ b/packages/suite-native/src/views/suite/onboarding/components/InitialRun/index.tsx
@@ -1,34 +1,29 @@
 import React from 'react';
 import { View, Text, Button } from 'react-native';
-import { bindActionCreators } from 'redux';
-import { connect } from 'react-redux';
 import { useTheme } from '@trezor/components';
+import { useActions } from '@suite-hooks';
 import * as routerActions from '@suite-actions/routerActions';
 import * as suiteActions from '@suite-actions/suiteActions';
 import styles from '@native/support/suite/styles';
-import { Dispatch } from '@suite-types';
 
-const mapDispatchToProps = (dispatch: Dispatch) => ({
-    goto: bindActionCreators(routerActions.goto, dispatch),
-    initialRunCompleted: bindActionCreators(suiteActions.initialRunCompleted, dispatch),
-});
-
-type Props = ReturnType<typeof mapDispatchToProps>;
-
-const InitialRun = (props: Props) => {
+const InitialRun = () => {
     const theme = useTheme();
+    const actions = useActions({
+        goto: routerActions.goto,
+        initialRunCompleted: suiteActions.initialRunCompleted,
+    });
     return (
         <View style={styles(theme).container}>
             <Text style={styles(theme).h1}>Initial run</Text>
             <Text>What is your intention?</Text>
             <View style={{ margin: 20 }}>
-                <Button onPress={props.initialRunCompleted} title="I'm new. Start onboarding" />
+                <Button onPress={actions.initialRunCompleted} title="I'm new. Start onboarding" />
             </View>
             <Button
                 color="gray"
                 onPress={() => {
-                    props.initialRunCompleted();
-                    props.goto('suite-index');
+                    actions.initialRunCompleted();
+                    actions.goto('suite-index');
                 }}
                 title="I want to use suite now"
             />
@@ -36,4 +31,4 @@ const InitialRun = (props: Props) => {
     );
 };
 
-export default connect(null, mapDispatchToProps)(InitialRun);
+export default InitialRun;

--- a/packages/suite-native/src/views/suite/onboarding/index.tsx
+++ b/packages/suite-native/src/views/suite/onboarding/index.tsx
@@ -1,32 +1,23 @@
 import React from 'react';
-import { connect } from 'react-redux';
-import { bindActionCreators } from 'redux';
 import { View, Text, Button } from 'react-native';
 import { useTheme } from '@trezor/components';
-
+import { useSelector, useActions } from '@suite-hooks';
 import * as routerActions from '@suite-actions/routerActions';
 import * as suiteActions from '@suite-actions/suiteActions';
 import styles from '@native/support/suite/styles';
 import InitialRun from './components/InitialRun';
-import { AppState, Dispatch } from '@suite-types';
 
-const mapStateToProps = (state: AppState) => ({
-    initialRun: state.suite.flags.initialRun,
-});
-
-const mapDispatchToProps = (dispatch: Dispatch) => ({
-    goto: bindActionCreators(routerActions.goto, dispatch),
-    back: bindActionCreators(routerActions.back, dispatch),
-    initialRunCompleted: bindActionCreators(suiteActions.initialRunCompleted, dispatch),
-});
-
-type Props = ReturnType<typeof mapStateToProps> & ReturnType<typeof mapDispatchToProps>;
-
-const Onboarding = (props: Props) => {
+const Onboarding = () => {
     const theme = useTheme();
+    const initialRun = useSelector(state => state.suite.flags.initialRun);
+    const actions = useActions({
+        goto: routerActions.goto,
+        back: routerActions.back,
+        initialRunCompleted: suiteActions.initialRunCompleted,
+    });
 
     // TODO: "initialRun" view should not depend on props.initialRun
-    if (props.initialRun) {
+    if (initialRun) {
         return <InitialRun />;
     }
 
@@ -42,16 +33,16 @@ const Onboarding = (props: Props) => {
             <View style={{ margin: 20 }}>
                 <Button
                     onPress={() => {
-                        props.initialRunCompleted();
-                        props.back();
+                        actions.initialRunCompleted();
+                        actions.back();
                     }}
                     title="Go to suite"
                 />
             </View>
             <Button
                 onPress={() => {
-                    props.goto('wallet-index');
-                    props.initialRunCompleted();
+                    actions.goto('wallet-index');
+                    actions.initialRunCompleted();
                 }}
                 title="Go to wallet first page"
             />
@@ -59,4 +50,4 @@ const Onboarding = (props: Props) => {
     );
 };
 
-export default connect(mapStateToProps, mapDispatchToProps)(Onboarding);
+export default Onboarding;

--- a/packages/suite-native/src/views/suite/switch-device/index.tsx
+++ b/packages/suite-native/src/views/suite/switch-device/index.tsx
@@ -1,21 +1,15 @@
 import React from 'react';
-import { connect } from 'react-redux';
-import { bindActionCreators } from 'redux';
 import { View, Text, Button } from 'react-native';
 import { useTheme } from '@trezor/components';
-
+import { useActions } from '@suite-hooks';
 import * as routerActions from '@suite-actions/routerActions';
 import styles from '@native/support/suite/styles';
-import { Dispatch } from '@suite-types';
 
-const mapDispatchToProps = (dispatch: Dispatch) => ({
-    goto: bindActionCreators(routerActions.goto, dispatch),
-});
-
-type Props = ReturnType<typeof mapDispatchToProps>;
-
-const SwitchDevice = (props: Props) => {
+const SwitchDevice = () => {
     const theme = useTheme();
+    const { goto } = useActions({
+        goto: routerActions.goto,
+    });
 
     return (
         <View style={styles(theme).container}>
@@ -27,10 +21,10 @@ const SwitchDevice = (props: Props) => {
                 </Text>
             </View>
             <View style={{ margin: 20 }}>
-                <Button onPress={() => props.goto('suite-index')} title="Back to dashboard" />
+                <Button onPress={() => goto('suite-index')} title="Back to dashboard" />
             </View>
         </View>
     );
 };
 
-export default connect(null, mapDispatchToProps)(SwitchDevice);
+export default SwitchDevice;

--- a/packages/suite-native/src/views/wallet/index.tsx
+++ b/packages/suite-native/src/views/wallet/index.tsx
@@ -1,17 +1,13 @@
 import React from 'react';
-import { connect } from 'react-redux';
 import { Text, View } from 'react-native';
+import { useSelector } from '@suite-hooks';
 import Layout from '@native-components/suite/Layout';
-import { AppState } from '@suite-types';
 
-const mapStateToProps = (state: AppState) => ({
-    accounts: state.wallet.accounts,
-    router: state.router,
-});
-
-type Props = ReturnType<typeof mapStateToProps>;
-
-const Wallet = (props: Props) => {
+const Wallet = () => {
+    const props = useSelector(state => ({
+        accounts: state.wallet.accounts,
+        router: state.router,
+    }));
     const accounts = props.accounts.map(a => (
         <View key={a.descriptor} style={{ borderWidth: 1, borderBottomColor: 'red' }}>
             <Text>{a.descriptor}</Text>
@@ -36,4 +32,4 @@ const Wallet = (props: Props) => {
     );
 };
 
-export default connect(mapStateToProps)(Wallet);
+export default Wallet;

--- a/packages/suite/src/components/backup/AfterBackupCheckboxes.tsx
+++ b/packages/suite/src/components/backup/AfterBackupCheckboxes.tsx
@@ -1,10 +1,7 @@
 import React from 'react';
 import styled from 'styled-components';
-import { connect } from 'react-redux';
-import { bindActionCreators } from 'redux';
-
 import { CheckItem, Translation } from '@suite-components';
-import { AppState, Dispatch } from '@suite-types';
+import { useSelector, useActions } from '@suite-hooks';
 import * as backupActions from '@suite/actions/backup/backupActions';
 
 const CheckboxWrapper = styled.div`
@@ -15,22 +12,11 @@ const CheckboxWrapper = styled.div`
     margin-bottom: 2px;
 `;
 
-const mapStateToProps = (state: AppState) => ({
-    backup: state.backup,
-});
-
-const mapDispatchToProps = (dispatch: Dispatch) =>
-    bindActionCreators(
-        {
-            toggleCheckboxByKey: backupActions.toggleCheckboxByKey,
-            backupDevice: backupActions.backupDevice,
-        },
-        dispatch,
-    );
-
-type Props = ReturnType<typeof mapStateToProps> & ReturnType<typeof mapDispatchToProps>;
-
-const AfterBackupCheckboxes = ({ toggleCheckboxByKey, backup }: Props) => {
+const AfterBackupCheckboxes = () => {
+    const backup = useSelector(state => state.backup);
+    const { toggleCheckboxByKey } = useActions({
+        toggleCheckboxByKey: backupActions.toggleCheckboxByKey,
+    });
     const isChecked = (key: backupActions.ConfirmKey) => backup.userConfirmed.includes(key);
 
     return (
@@ -60,4 +46,4 @@ const AfterBackupCheckboxes = ({ toggleCheckboxByKey, backup }: Props) => {
     );
 };
 
-export default connect(mapStateToProps, mapDispatchToProps)(AfterBackupCheckboxes);
+export default AfterBackupCheckboxes;

--- a/packages/suite/src/components/backup/PreBackupCheckboxes.tsx
+++ b/packages/suite/src/components/backup/PreBackupCheckboxes.tsx
@@ -1,11 +1,8 @@
 import React from 'react';
 import styled from 'styled-components';
-import { bindActionCreators } from 'redux';
-import { connect } from 'react-redux';
-
-import * as backupActions from '@suite/actions/backup/backupActions';
 import { CheckItem, Translation } from '@suite-components';
-import { Dispatch, AppState } from '@suite-types';
+import { useSelector, useActions } from '@suite-hooks';
+import * as backupActions from '@suite/actions/backup/backupActions';
 import { variables } from '@trezor/components';
 
 const CheckboxWrapper = styled.div`
@@ -22,22 +19,11 @@ const CheckboxWrapper = styled.div`
     }
 `;
 
-const mapStateToProps = (state: AppState) => ({
-    backup: state.backup,
-});
-
-const mapDispatchToProps = (dispatch: Dispatch) =>
-    bindActionCreators(
-        {
-            toggleCheckboxByKey: backupActions.toggleCheckboxByKey,
-            backupDevice: backupActions.backupDevice,
-        },
-        dispatch,
-    );
-
-type Props = ReturnType<typeof mapStateToProps> & ReturnType<typeof mapDispatchToProps>;
-
-const PreBackupCheckboxes = ({ toggleCheckboxByKey, backup }: Props) => {
+const PreBackupCheckboxes = () => {
+    const backup = useSelector(state => state.backup);
+    const { toggleCheckboxByKey } = useActions({
+        toggleCheckboxByKey: backupActions.toggleCheckboxByKey,
+    });
     const isChecked = (key: backupActions.ConfirmKey) => backup.userConfirmed.includes(key);
 
     return (
@@ -67,4 +53,4 @@ const PreBackupCheckboxes = ({ toggleCheckboxByKey, backup }: Props) => {
     );
 };
 
-export default connect(mapStateToProps, mapDispatchToProps)(PreBackupCheckboxes);
+export default PreBackupCheckboxes;

--- a/packages/suite/src/components/suite/DeviceInvalidModeLayout/index.tsx
+++ b/packages/suite/src/components/suite/DeviceInvalidModeLayout/index.tsx
@@ -1,11 +1,9 @@
 import React from 'react';
-import { connect } from 'react-redux';
-import { bindActionCreators } from 'redux';
 import styled, { css } from 'styled-components';
 import { Button } from '@trezor/components';
 import { Image as Img, Translation, Modal } from '@suite-components';
+import { useSelector, useActions } from '@suite-hooks';
 import * as routerActions from '@suite-actions/routerActions';
-import { AppState, Dispatch } from '@suite-types';
 
 const Image = styled(Img)`
     flex: 1;
@@ -35,18 +33,6 @@ const Buttons = styled.div`
  * like views listed in suite/views
  */
 
-const mapDispatchToProps = (dispatch: Dispatch) =>
-    bindActionCreators(
-        {
-            goto: routerActions.goto,
-        },
-        dispatch,
-    );
-
-const mapStateToProps = (state: AppState) => ({
-    devices: state.devices,
-});
-
 type Props = {
     title: React.ReactNode;
     text?: React.ReactNode;
@@ -54,19 +40,15 @@ type Props = {
     allowSwitchDevice?: boolean;
     resolveButton?: React.ReactNode;
     ['data-test']?: string;
-} & ReturnType<typeof mapStateToProps> &
-    ReturnType<typeof mapDispatchToProps>;
+};
 
 const DeviceInvalidModeLayout = (props: Props) => {
-    const {
-        title,
-        text,
-        image = 'UNI_WARNING',
-        allowSwitchDevice,
-        devices,
-        resolveButton,
-        goto,
-    } = props;
+    const { title, text, image = 'UNI_WARNING', allowSwitchDevice, resolveButton } = props;
+
+    const devices = useSelector(state => state.devices);
+    const { goto } = useActions({
+        goto: routerActions.goto,
+    });
 
     return (
         <Modal size="small" heading={title} description={text} data-test={props['data-test']}>
@@ -83,4 +65,4 @@ const DeviceInvalidModeLayout = (props: Props) => {
     );
 };
 
-export default connect(mapStateToProps, mapDispatchToProps)(DeviceInvalidModeLayout);
+export default DeviceInvalidModeLayout;

--- a/packages/suite/src/components/suite/SuiteLayout/index.tsx
+++ b/packages/suite/src/components/suite/SuiteLayout/index.tsx
@@ -1,11 +1,9 @@
 import React, { useState, createContext } from 'react';
 import styled, { css } from 'styled-components';
-import { connect } from 'react-redux';
 import { useHotkeys } from 'react-hotkeys-hook';
 
 import { variables } from '@trezor/components';
 import SuiteBanners from '@suite-components/Banners';
-import { AppState } from '@suite-types';
 import { Metadata } from '@suite-components';
 import { GuidePanel, GuideButton } from '@guide-components';
 import MenuSecondary from '@suite-components/MenuSecondary';
@@ -116,14 +114,6 @@ const StyledGuidePanel = styled(GuidePanel)<{ open?: boolean; isModalOpen?: bool
         `}
 `;
 
-const mapStateToProps = (state: AppState) => ({
-    router: state.router,
-});
-
-type Props = ReturnType<typeof mapStateToProps> & {
-    children?: React.ReactNode;
-};
-
 interface MobileBodyProps {
     url: string;
     menu?: React.ReactNode;
@@ -209,13 +199,13 @@ const BodyMobile = ({ url, menu, appMenu, children }: MobileBodyProps) => (
     </Body>
 );
 
-type SuiteLayoutProps = Omit<Props, 'menu' | 'appMenu'>;
-const SuiteLayout = (props: SuiteLayoutProps) => {
+const SuiteLayout: React.FC = ({ children }) => {
     const analytics = useAnalytics();
 
     // TODO: if (props.layoutSize === 'UNAVAILABLE') return <SmallLayout />;
     const { isMobileLayout, layoutSize } = useLayoutSize();
-    const { guideOpen, isModalOpen } = useSelector(state => ({
+    const { router, guideOpen, isModalOpen } = useSelector(state => ({
+        router: state.router,
         guideOpen: state.guide.open,
         // 2 types of modals exist. 1. redux 'modal' based, 2. redux 'router' based
         isModalOpen:
@@ -275,17 +265,17 @@ const SuiteLayout = (props: SuiteLayoutProps) => {
                     <BodyNormal
                         menu={menu}
                         appMenu={appMenu}
-                        url={props.router.url}
+                        url={router.url}
                         guideOpen={guideOpen}
                         isMenuInline={isMenuInline}
                         isModalOpen={isModalOpen}
                     >
-                        {props.children}
+                        {children}
                     </BodyNormal>
                 )}
                 {isMobileLayout && (
-                    <BodyMobile menu={menu} appMenu={appMenu} url={props.router.url}>
-                        {props.children}
+                    <BodyMobile menu={menu} appMenu={appMenu} url={router.url}>
+                        {children}
                     </BodyMobile>
                 )}
             </LayoutContext.Provider>
@@ -303,4 +293,4 @@ const SuiteLayout = (props: SuiteLayoutProps) => {
     );
 };
 
-export default connect(mapStateToProps)(SuiteLayout);
+export default SuiteLayout;

--- a/packages/suite/src/components/suite/modals/PassphraseOnDevice/index.tsx
+++ b/packages/suite/src/components/suite/modals/PassphraseOnDevice/index.tsx
@@ -1,29 +1,24 @@
 import React from 'react';
-import { connect } from 'react-redux';
 import { ConfirmOnDevice } from '@trezor/components';
-import { Modal, ModalProps } from '@suite-components';
+import { Modal } from '@suite-components';
 import { Translation } from '@suite-components/Translation';
+import { useActions } from '@suite-hooks';
 import * as discoveryActions from '@wallet-actions/discoveryActions';
-import { Dispatch, TrezorDevice } from '@suite-types';
-
 import DeviceConfirmImage from '@suite-components/images/DeviceConfirmImage';
+import type { TrezorDevice } from '@suite-types';
 
-const mapDispatchToProps = (dispatch: Dispatch) => ({
-    getDiscoveryAuthConfirmationStatus: () =>
-        dispatch(discoveryActions.getDiscoveryAuthConfirmationStatus()),
-});
-
-interface OwnProps extends ModalProps {
+interface Props {
     device: TrezorDevice;
 }
-
-type Props = OwnProps & ReturnType<typeof mapDispatchToProps>;
 
 /**
  * Modal used with model T with legacy firmware as result of 'ButtonRequest_PassphraseType' where passphrase source is requested on device
  * @param {Props}
  */
-const PassphraseOnDevice = ({ device, getDiscoveryAuthConfirmationStatus, ...rest }: Props) => {
+const PassphraseOnDevice = ({ device, ...rest }: Props) => {
+    const { getDiscoveryAuthConfirmationStatus } = useActions({
+        getDiscoveryAuthConfirmationStatus: discoveryActions.getDiscoveryAuthConfirmationStatus,
+    });
     const authConfirmation = getDiscoveryAuthConfirmationStatus() || device.authConfirm;
 
     if (authConfirmation) {
@@ -69,4 +64,4 @@ const PassphraseOnDevice = ({ device, getDiscoveryAuthConfirmationStatus, ...res
     );
 };
 
-export default connect(null, mapDispatchToProps)(PassphraseOnDevice);
+export default PassphraseOnDevice;

--- a/packages/suite/src/components/suite/modals/PassphraseSource/index.tsx
+++ b/packages/suite/src/components/suite/modals/PassphraseSource/index.tsx
@@ -1,27 +1,24 @@
 import React from 'react';
-import { connect } from 'react-redux';
 import { ConfirmOnDevice } from '@trezor/components';
-import { Modal, ModalProps } from '@suite-components';
+import { Modal } from '@suite-components';
 import { Translation } from '@suite-components/Translation';
 import DeviceConfirmImage from '@suite-components/images/DeviceConfirmImage';
+import { useActions } from '@suite-hooks';
 import * as discoveryActions from '@wallet-actions/discoveryActions';
-import { Dispatch, TrezorDevice } from '@suite-types';
+import type { TrezorDevice } from '@suite-types';
 
-const mapDispatchToProps = (dispatch: Dispatch) => ({
-    getDiscoveryAuthConfirmationStatus: () =>
-        dispatch(discoveryActions.getDiscoveryAuthConfirmationStatus()),
-});
-interface OwnProps extends ModalProps {
+interface Props {
     device: TrezorDevice;
 }
-
-type Props = OwnProps & ReturnType<typeof mapDispatchToProps>;
 
 /**
  * Modal used with model T with legacy firmware as result of 'ButtonRequest_PassphraseType' where passphrase source is requested on device
  * @param {Props}
  */
-const PassphraseSource = ({ device, getDiscoveryAuthConfirmationStatus, ...rest }: Props) => {
+const PassphraseSource = ({ device, ...rest }: Props) => {
+    const { getDiscoveryAuthConfirmationStatus } = useActions({
+        getDiscoveryAuthConfirmationStatus: discoveryActions.getDiscoveryAuthConfirmationStatus,
+    });
     const authConfirmation = getDiscoveryAuthConfirmationStatus() || device.authConfirm;
 
     if (authConfirmation) {
@@ -66,4 +63,4 @@ const PassphraseSource = ({ device, getDiscoveryAuthConfirmationStatus, ...rest 
     );
 };
 
-export default connect(null, mapDispatchToProps)(PassphraseSource);
+export default PassphraseSource;

--- a/packages/suite/src/components/wallet/AccountMode/BackendDisconnected.tsx
+++ b/packages/suite/src/components/wallet/AccountMode/BackendDisconnected.tsx
@@ -1,27 +1,16 @@
 import React, { useState, useEffect } from 'react';
-import { connect } from 'react-redux';
-import { bindActionCreators } from 'redux';
 import { NotificationCard, Translation } from '@suite-components';
+import { useSelector, useActions } from '@suite-hooks';
 import * as blockchainActions from '@wallet-actions/blockchainActions';
 
-import { AppState, Dispatch } from '@suite-types';
-
-const mapStateToProps = (state: AppState) => ({
-    blockchain: state.wallet.blockchain,
-    selectedAccount: state.wallet.selectedAccount,
-});
-
-const mapDispatchToProps = (dispatch: Dispatch) =>
-    bindActionCreators(
-        {
-            reconnect: blockchainActions.reconnect,
-        },
-        dispatch,
-    );
-
-export type Props = ReturnType<typeof mapStateToProps> & ReturnType<typeof mapDispatchToProps>;
-
-const Disconnected = ({ selectedAccount, reconnect, blockchain }: Props) => {
+const Disconnected = () => {
+    const { reconnect } = useActions({
+        reconnect: blockchainActions.reconnect,
+    });
+    const { blockchain, selectedAccount } = useSelector(state => ({
+        blockchain: state.wallet.blockchain,
+        selectedAccount: state.wallet.selectedAccount,
+    }));
     const [progress, setProgress] = useState(false);
     const [time, setTime] = useState<number | null>(null);
     const symbol = selectedAccount.status === 'loaded' ? selectedAccount.network.symbol : undefined;
@@ -71,4 +60,4 @@ const Disconnected = ({ selectedAccount, reconnect, blockchain }: Props) => {
     );
 };
 
-export default connect(mapStateToProps, mapDispatchToProps)(Disconnected);
+export default Disconnected;

--- a/packages/suite/src/components/wallet/AccountsMenu/index.tsx
+++ b/packages/suite/src/components/wallet/AccountsMenu/index.tsx
@@ -1,12 +1,10 @@
 import React, { useCallback, useState } from 'react';
 import styled, { css } from 'styled-components';
-import { connect } from 'react-redux';
-import { useDiscovery, useAccountSearch } from '@suite-hooks';
+import { useDiscovery, useAccountSearch, useSelector } from '@suite-hooks';
 import { H2, variables, useTheme, Icon } from '@trezor/components';
 import { Translation, AddAccountButton, LayoutContext } from '@suite-components';
 
 import { sortByCoin, getFailedAccounts, accountSearchFn } from '@wallet-utils/accountUtils';
-import { AppState } from '@suite-types';
 import { Account } from '@wallet-types';
 
 import AccountSearchBox from './components/AccountSearchBox';
@@ -123,17 +121,14 @@ const NoResults = styled.div`
     margin: 36px 0px;
 `;
 
-const mapStateToProps = (state: AppState) => ({
-    device: state.suite.device,
-    accounts: state.wallet.accounts,
-    selectedAccount: state.wallet.selectedAccount,
-});
-
-type Props = ReturnType<typeof mapStateToProps>;
-
-const AccountsMenu = ({ device, accounts, selectedAccount }: Props) => {
+const AccountsMenu = () => {
     const theme = useTheme();
     const { discovery, getDiscoveryStatus } = useDiscovery();
+    const { device, accounts, selectedAccount } = useSelector(state => ({
+        device: state.suite.device,
+        accounts: state.wallet.accounts,
+        selectedAccount: state.wallet.selectedAccount,
+    }));
     const { params } = selectedAccount;
     const { isMenuInline } = React.useContext(LayoutContext);
     const [isExpanded, setIsExpanded] = useState(false);
@@ -315,4 +310,4 @@ const AccountsMenu = ({ device, accounts, selectedAccount }: Props) => {
     );
 };
 
-export default connect(mapStateToProps)(AccountsMenu);
+export default AccountsMenu;

--- a/packages/suite/src/views/dashboard/components/PortfolioCard/index.tsx
+++ b/packages/suite/src/views/dashboard/components/PortfolioCard/index.tsx
@@ -1,15 +1,14 @@
 import React, { useMemo } from 'react';
 import styled from 'styled-components';
-import { useDispatch } from 'react-redux';
 import { Dropdown } from '@trezor/components';
 import { Card, QuestionTooltip, Translation } from '@suite-components';
 import { Section } from '@dashboard-components';
-import * as accountUtils from '@wallet-utils/accountUtils';
 import { useDiscovery, useSelector, useActions } from '@suite-hooks';
 import { useFastAccounts, useFiatValue } from '@wallet-hooks';
-import { goto } from '@suite-actions/routerActions';
 import { SkeletonTransactionsGraph } from '@suite-components/TransactionsGraph';
+import * as routerActions from '@suite-actions/routerActions';
 import * as suiteActions from '@suite-actions/suiteActions';
+import * as accountUtils from '@wallet-utils/accountUtils';
 
 import Header from './components/Header';
 import Exception from './components/Exception';
@@ -30,12 +29,14 @@ const Body = styled.div`
 `;
 
 const PortfolioCard = React.memo(() => {
-    const dispatch = useDispatch();
     const { fiat, localCurrency } = useFiatValue();
     const { discovery, getDiscoveryStatus } = useDiscovery();
     const accounts = useFastAccounts();
     const { dashboardGraphHidden } = useSelector(s => s.suite.flags);
-    const { setFlag } = useActions({ setFlag: suiteActions.setFlag });
+    const { setFlag, goto } = useActions({
+        setFlag: suiteActions.setFlag,
+        goto: routerActions.goto,
+    });
 
     const isDeviceEmpty = useMemo(() => accounts.every(a => a.empty), [accounts]);
     const portfolioValue = accountUtils
@@ -124,7 +125,7 @@ const PortfolioCard = React.memo(() => {
                     isWalletEmpty={isWalletEmpty}
                     isWalletLoading={isWalletLoading}
                     isWalletError={isWalletError}
-                    receiveClickHandler={() => dispatch(goto('wallet-receive'))}
+                    receiveClickHandler={() => goto('wallet-receive')}
                 />
 
                 {body && <Body>{body}</Body>}

--- a/packages/suite/src/views/suite/device-bootloader/index.tsx
+++ b/packages/suite/src/views/suite/device-bootloader/index.tsx
@@ -1,40 +1,32 @@
 // TODO: remove whole file, replaced by @suite-components/PrerequisitesGuide/components/DeviceBootloader
 
 import React from 'react';
-import { connect } from 'react-redux';
-import { bindActionCreators } from 'redux';
-
+import { useActions } from '@suite-hooks';
 import * as routerActions from '@suite-actions/routerActions';
 import { Button } from '@trezor/components';
 import { DeviceInvalidModeLayout, Translation } from '@suite-components';
-import { Dispatch } from '@suite-types';
 
-const mapDispatchToProps = (dispatch: Dispatch) =>
-    bindActionCreators(
-        {
-            goto: routerActions.goto,
-        },
-        dispatch,
+const Index = () => {
+    const actions = useActions({
+        goto: routerActions.goto,
+    });
+    return (
+        <DeviceInvalidModeLayout
+            data-test="@device-invalid-mode/bootloader"
+            title={<Translation id="TR_DEVICE_IN_BOOTLOADER" />}
+            text={<Translation id="TR_DEVICE_IN_BOOTLOADER_EXPLAINED" />}
+            allowSwitchDevice
+            resolveButton={
+                <Button
+                    onClick={() => {
+                        actions.goto('firmware-index');
+                    }}
+                >
+                    <Translation id="TR_GO_TO_FIRMWARE" />
+                </Button>
+            }
+        />
     );
+};
 
-type Props = ReturnType<typeof mapDispatchToProps>;
-
-const Index = (props: Props) => (
-    <DeviceInvalidModeLayout
-        data-test="@device-invalid-mode/bootloader"
-        title={<Translation id="TR_DEVICE_IN_BOOTLOADER" />}
-        text={<Translation id="TR_DEVICE_IN_BOOTLOADER_EXPLAINED" />}
-        allowSwitchDevice
-        resolveButton={
-            <Button
-                onClick={() => {
-                    props.goto('firmware-index');
-                }}
-            >
-                <Translation id="TR_GO_TO_FIRMWARE" />
-            </Button>
-        }
-    />
-);
-
-export default connect(null, mapDispatchToProps)(Index);
+export default Index;

--- a/packages/suite/src/views/suite/device-connect/index.tsx
+++ b/packages/suite/src/views/suite/device-connect/index.tsx
@@ -1,14 +1,12 @@
 // TODO: remove whole file, replaced by @suite-components/PrerequisitesGuide/components/DeviceConnect
 
 import React from 'react';
-import { connect } from 'react-redux';
-import { bindActionCreators } from 'redux';
 import styled from 'styled-components';
 import { Link, P, H2 } from '@trezor/components';
+import { useSelector, useActions } from '@suite-hooks';
 import * as routerActions from '@suite-actions/routerActions';
 import { Translation, WebusbButton, ConnectDeviceImage, Modal } from '@suite-components';
 import HelpBuyIcons from '@suite-components/ProgressBar/components/HelpBuyIcons';
-import { Dispatch, AppState } from '@suite-types';
 import { isWebUSB } from '@suite-utils/transport';
 import { isAndroid, isLinux } from '@suite-utils/env';
 
@@ -34,22 +32,12 @@ const BridgeWrapper = styled.div`
 
 const StyledLink = styled(Link)``;
 
-const mapStateToProps = (state: AppState) => ({
-    transport: state.suite.transport,
-});
-
-const mapDispatchToProps = (dispatch: Dispatch) =>
-    bindActionCreators(
-        {
-            goto: routerActions.goto,
-        },
-        dispatch,
-    );
-
-type Props = ReturnType<typeof mapStateToProps> & ReturnType<typeof mapDispatchToProps>;
-
-const Index = (props: Props) => {
-    const showWebUsb = isWebUSB(props.transport);
+const Index = () => {
+    const transport = useSelector(state => state.suite.transport);
+    const { goto } = useActions({
+        goto: routerActions.goto,
+    });
+    const showWebUsb = isWebUSB(transport);
     const showUdev = isLinux();
 
     return (
@@ -74,9 +62,7 @@ const Index = (props: Props) => {
                             values={{
                                 link: (
                                     <StyledLink
-                                        onClick={() =>
-                                            props.goto('suite-udev', { cancelable: true })
-                                        }
+                                        onClick={() => goto('suite-udev', { cancelable: true })}
                                         data-test="@modal/connect-device/goto/suite-udev"
                                     >
                                         Udev rules
@@ -95,9 +81,7 @@ const Index = (props: Props) => {
                             values={{
                                 link: (
                                     <StyledLink
-                                        onClick={() =>
-                                            props.goto('suite-bridge', { cancelable: true })
-                                        }
+                                        onClick={() => goto('suite-bridge', { cancelable: true })}
                                         data-test="@modal/connect-device/goto/suite-bridge"
                                     >
                                         Trezor Bridge
@@ -112,4 +96,4 @@ const Index = (props: Props) => {
     );
 };
 
-export default connect(mapStateToProps, mapDispatchToProps)(Index);
+export default Index;

--- a/packages/suite/src/views/wallet/coinmarket/buy/detail/index.tsx
+++ b/packages/suite/src/views/wallet/coinmarket/buy/detail/index.tsx
@@ -1,21 +1,13 @@
 import React from 'react';
-import { AppState } from '@suite-types';
+import styled from 'styled-components';
+import { WalletLayout } from '@wallet-components';
+import { useSelector } from '@suite-hooks';
 import {
     useCoinmarketBuyDetail,
     CoinmarketBuyDetailContext,
 } from '@wallet-hooks/useCoinmarketBuyDetail';
-import { WalletLayout } from '@wallet-components';
-import styled from 'styled-components';
-import { ComponentProps, Props } from '@wallet-types/coinmarketBuyDetail';
-import { connect } from 'react-redux';
-
 import Detail from './Detail';
-
-const mapStateToProps = (state: AppState): ComponentProps => ({
-    selectedAccount: state.wallet.selectedAccount,
-    trades: state.wallet.coinmarket.trades,
-    transactionId: state.wallet.coinmarket.buy.transactionId,
-});
+import type { Props } from '@wallet-types/coinmarketBuyDetail';
 
 const Wrapper = styled.div`
     display: flex;
@@ -36,13 +28,17 @@ const DetailIndexLoaded = (props: Props) => {
     );
 };
 
-const DetailIndex = (props: ComponentProps) => {
-    const { selectedAccount } = props;
+const DetailIndex = () => {
+    const props = useSelector(state => ({
+        selectedAccount: state.wallet.selectedAccount,
+        trades: state.wallet.coinmarket.trades,
+        transactionId: state.wallet.coinmarket.buy.transactionId,
+    }));
 
-    if (selectedAccount.status !== 'loaded') {
-        return <WalletLayout title="TR_NAV_BUY" account={selectedAccount} />;
+    if (props.selectedAccount.status !== 'loaded') {
+        return <WalletLayout title="TR_NAV_BUY" account={props.selectedAccount} />;
     }
-    return <DetailIndexLoaded {...props} selectedAccount={selectedAccount} />;
+    return <DetailIndexLoaded {...props} selectedAccount={props.selectedAccount} />;
 };
 
-export default connect(mapStateToProps)(DetailIndex);
+export default DetailIndex;

--- a/packages/suite/src/views/wallet/coinmarket/buy/index.tsx
+++ b/packages/suite/src/views/wallet/coinmarket/buy/index.tsx
@@ -1,14 +1,9 @@
 import React from 'react';
-import { AppState } from '@suite-types';
+import { useSelector } from '@suite-hooks';
 import { useCoinmarketBuyForm, BuyFormContext } from '@wallet-hooks/useCoinmarketBuyForm';
 import { CoinmarketLayout, WalletLayout } from '@wallet-components';
-import { ComponentProps, Props } from '@wallet-types/coinmarketBuyForm';
-import { connect } from 'react-redux';
 import BuyForm from './components/BuyForm';
-
-const mapStateToProps = (state: AppState): ComponentProps => ({
-    selectedAccount: state.wallet.selectedAccount,
-});
+import type { Props } from '@wallet-types/coinmarketBuyForm';
 
 const CoinmarketBuyLoaded = (props: Props) => {
     const { selectedAccount } = props;
@@ -29,12 +24,12 @@ const CoinmarketBuyLoaded = (props: Props) => {
     );
 };
 
-const CoinmarketBuy = (props: ComponentProps) => {
-    const { selectedAccount } = props;
+const CoinmarketBuy = () => {
+    const selectedAccount = useSelector(state => state.wallet.selectedAccount);
     if (selectedAccount.status !== 'loaded') {
         return <WalletLayout title="TR_NAV_BUY" account={selectedAccount} />;
     }
-    return <CoinmarketBuyLoaded {...props} selectedAccount={selectedAccount} />;
+    return <CoinmarketBuyLoaded selectedAccount={selectedAccount} />;
 };
 
-export default connect(mapStateToProps)(CoinmarketBuy);
+export default CoinmarketBuy;

--- a/packages/suite/src/views/wallet/coinmarket/buy/offers/index.tsx
+++ b/packages/suite/src/views/wallet/coinmarket/buy/offers/index.tsx
@@ -1,22 +1,10 @@
 import React from 'react';
-import { connect } from 'react-redux';
-import { AppState } from '@suite-types';
-import { WalletLayout } from '@wallet-components';
 import styled from 'styled-components';
-import { ComponentProps, Props } from '@wallet-types/coinmarketBuyOffers';
+import { WalletLayout } from '@wallet-components';
+import { useSelector } from '@suite-hooks';
 import { CoinmarketBuyOffersContext, useOffers } from '@wallet-hooks/useCoinmarketBuyOffers';
 import Offers from './Offers';
-
-const mapStateToProps = (state: AppState): ComponentProps => ({
-    selectedAccount: state.wallet.selectedAccount,
-    device: state.suite.device,
-    quotes: state.wallet.coinmarket.buy.quotes,
-    alternativeQuotes: state.wallet.coinmarket.buy.alternativeQuotes,
-    quotesRequest: state.wallet.coinmarket.buy.quotesRequest,
-    isFromRedirect: state.wallet.coinmarket.buy.isFromRedirect,
-    addressVerified: state.wallet.coinmarket.buy.addressVerified,
-    providersInfo: state.wallet.coinmarket.buy.buyInfo?.providerInfos,
-});
+import type { Props } from '@wallet-types/coinmarketBuyOffers';
 
 const Wrapper = styled.div`
     display: flex;
@@ -37,12 +25,21 @@ const OffersIndexLoaded = (props: Props) => {
     );
 };
 
-const OffersIndex = (props: ComponentProps) => {
-    const { selectedAccount } = props;
-    if (selectedAccount.status !== 'loaded') {
-        return <WalletLayout title="TR_NAV_BUY" account={selectedAccount} />;
+const OffersIndex = () => {
+    const props = useSelector(state => ({
+        selectedAccount: state.wallet.selectedAccount,
+        device: state.suite.device,
+        quotes: state.wallet.coinmarket.buy.quotes,
+        alternativeQuotes: state.wallet.coinmarket.buy.alternativeQuotes,
+        quotesRequest: state.wallet.coinmarket.buy.quotesRequest,
+        isFromRedirect: state.wallet.coinmarket.buy.isFromRedirect,
+        addressVerified: state.wallet.coinmarket.buy.addressVerified,
+        providersInfo: state.wallet.coinmarket.buy.buyInfo?.providerInfos,
+    }));
+    if (props.selectedAccount.status !== 'loaded') {
+        return <WalletLayout title="TR_NAV_BUY" account={props.selectedAccount} />;
     }
-    return <OffersIndexLoaded {...props} selectedAccount={selectedAccount} />;
+    return <OffersIndexLoaded {...props} selectedAccount={props.selectedAccount} />;
 };
 
-export default connect(mapStateToProps)(OffersIndex);
+export default OffersIndex;

--- a/packages/suite/src/views/wallet/coinmarket/exchange/offers/Offers/SelectedOffer/components/VerifyAddress/ReceiveOptions/index.tsx
+++ b/packages/suite/src/views/wallet/coinmarket/exchange/offers/Offers/SelectedOffer/components/VerifyAddress/ReceiveOptions/index.tsx
@@ -1,15 +1,14 @@
 import React, { useState } from 'react';
 import styled from 'styled-components';
-import { getUnusedAddressFromAccount } from '@wallet-utils/coinmarket/coinmarketUtils';
-import { FiatValue, Translation, HiddenPlaceholder, AccountLabeling } from '@suite-components';
-import { variables, CoinLogo, Select, Icon, useTheme } from '@trezor/components';
-import { useCoinmarketExchangeOffersContext } from '@wallet-hooks/useCoinmarketExchangeOffers';
-import { Account } from '@wallet-types';
-import * as modalActions from '@suite-actions/modalActions';
-import { useDispatch } from 'react-redux';
-import { Dispatch } from '@suite-types';
 import useTimeoutFn from 'react-use/lib/useTimeoutFn';
-import { UseFormMethods } from 'react-hook-form';
+import { variables, CoinLogo, Select, Icon, useTheme } from '@trezor/components';
+import { FiatValue, Translation, HiddenPlaceholder, AccountLabeling } from '@suite-components';
+import { useActions } from '@suite-hooks';
+import * as modalActions from '@suite-actions/modalActions';
+import { useCoinmarketExchangeOffersContext } from '@wallet-hooks/useCoinmarketExchangeOffers';
+import { getUnusedAddressFromAccount } from '@wallet-utils/coinmarket/coinmarketUtils';
+import type { UseFormMethods } from 'react-hook-form';
+import type { Account } from '@wallet-types';
 
 const LogoWrapper = styled.div`
     display: flex;
@@ -70,10 +69,12 @@ type Props = Pick<UseFormMethods<FormState>, 'setValue'> & {
 
 const ReceiveOptions = (props: Props) => {
     const theme = useTheme();
+    const { openModal } = useActions({
+        openModal: modalActions.openModal,
+    });
     const { device, suiteReceiveAccounts, receiveSymbol, setReceiveAccount } =
         useCoinmarketExchangeOffersContext();
     const [menuIsOpen, setMenuIsOpen] = useState<boolean | undefined>(undefined);
-    const dispatch = useDispatch<Dispatch>();
 
     const { selectedAccountOption, setSelectedAccountOption, setValue } = props;
 
@@ -102,14 +103,12 @@ const ReceiveOptions = (props: Props) => {
         if (account.type === 'ADD_SUITE') {
             if (device) {
                 setMenuIsOpen(true);
-                dispatch(
-                    modalActions.openModal({
-                        type: 'add-account',
-                        device: device!,
-                        symbol: receiveSymbol as Account['symbol'],
-                        noRedirect: true,
-                    }),
-                );
+                openModal({
+                    type: 'add-account',
+                    device: device!,
+                    symbol: receiveSymbol as Account['symbol'],
+                    noRedirect: true,
+                });
             }
         } else {
             selectAccountOption(account);


### PR DESCRIPTION
❄❄❄❄❄Winter season cleanup❄❄❄❄❄

Refactored legacy way of accessing redux state via `connect(mapStateToProps, mapActionsToProps)(...)` in favor of `{ useActions, useSelector }` hooks

Some changes are straight forward, some requires more careful reading.