### PR TITLE
fix(e2e): patch tests to pass after text change

### DIFF
--- a/packages/integration-tests/projects/suite-web/tests/wallet/new-account-message.test.ts
+++ b/packages/integration-tests/projects/suite-web/tests/wallet/new-account-message.test.ts
@@ -37,7 +37,8 @@ describe('New accounts', () => {
         cy.getTestElement('@dashboard/loading').should('not.exist');
     };
 
-    const expectedAccountMessage = 'New to Trezor Suite: BTC Bech32 accounts!';
+    const expectedAccountMessage = 'New to Trezor Suite: Bech32 accounts!';
+
     it(`Goes to accounts and verifies that the "${expectedAccountMessage}" is displayed:`, () => {
         const passphraseToType = 'we need regtest{enter}';
 


### PR DESCRIPTION
lessons learnt: 
- dont merge before tests have finished. even if there are only changes in messages!

ethernal questions:
- how verbose should assertions in tests be :thinking: matching against strings probably doesn't make much sense. if we wan't to be verbose, screenshot is maybe better?