### PR TITLE
fix(suite-desktop): use @trezor/suite-desktop app data location

### DIFF
--- a/packages/suite-desktop/package.json
+++ b/packages/suite-desktop/package.json
@@ -1,6 +1,5 @@
 {
     "name": "@trezor/suite-desktop",
-    "productName": "Trezor Suite",
     "description": "Trezor Suite desktop application",
     "version": "1.0.0",
     "private": true,

--- a/packages/suite-desktop/src-electron/app.ts
+++ b/packages/suite-desktop/src-electron/app.ts
@@ -12,6 +12,7 @@ import modules from '@desktop-electron/libs/modules';
 import { createInterceptor } from '@desktop-electron/libs/request-interceptor';
 
 let mainWindow: BrowserWindow;
+const APP_NAME = 'Trezor Suite';
 const src = isDev
     ? 'http://localhost:8000/'
     : url.format({
@@ -62,7 +63,7 @@ const init = async () => {
     logger.debug('init', `Create Browser Window (${winBounds.width}x${winBounds.height})`);
 
     mainWindow = new BrowserWindow({
-        title: app.getName(),
+        title: APP_NAME,
         width: winBounds.width,
         height: winBounds.height,
         minWidth: MIN_WIDTH,
@@ -107,6 +108,7 @@ if (!singleInstance) {
         }
     });
 
+    app.name = APP_NAME; // overrides @trezor/suite-desktop app name in menu
     app.on('ready', init);
 }
 


### PR DESCRIPTION
New version of desktop app used `Trezor Suite` folder instead of `@trezor/suite-desktop` which caused missing application settings.