### PR TITLE
Revert "fix: add coingecko to allowed domains"

### DIFF
--- a/packages/suite-desktop/src-electron/config.ts
+++ b/packages/suite-desktop/src-electron/config.ts
@@ -19,7 +19,6 @@ export const allowedDomains = [
     'o117836.ingest.sentry.io',
     'oauth2.googleapis.com',
     'googleapis.com',
-    'api.coingecko.com',
     onionDomain,
 ];
 


### PR DESCRIPTION
This reverts commit a2da37ae3023c0d0016f64fa379421ce8a44640a.