### PR TITLE
fix(native): add missing intl dependency

### DIFF
--- a/packages/suite-native/package.json
+++ b/packages/suite-native/package.json
@@ -19,6 +19,7 @@
     },
     "dependencies": {
         "@trezor/suite-storage": "1.0.0",
+        "intl": "^1.2.5",
         "react": "17.0.1",
         "react-native": "0.63.4",
         "react-native-gesture-handler": "^1.5.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -15515,6 +15515,11 @@ intl-messageformat@9.4.6:
     intl-messageformat-parser "6.3.1"
     tslib "^2.0.1"
 
+intl@^1.2.5:
+  version "1.2.5"
+  resolved "https://registry.yarnpkg.com/intl/-/intl-1.2.5.tgz#82244a2190c4e419f8371f5aa34daa3420e2abde"
+  integrity sha1-giRKIZDE5Bn4Nx9ao02qNCDiq94=
+
 invariant@^2.2.3, invariant@^2.2.4:
   version "2.2.4"
   resolved "https://registry.yarnpkg.com/invariant/-/invariant-2.2.4.tgz#610f3c92c9359ce1db616e538008d23ff35158e6"


### PR DESCRIPTION
intl depencency was not directly listed in trezor-suite project and it got removed by this commit https://github.com/trezor/trezor-suite/pull/4556/files#diff-51e4f558fae534656963876761c95b83b6ef5da5103c4adef6768219ed76c2deL15649 which lead to broken suite-native build (happening right now in develop brach)

build is now passing https://gitlab.com/satoshilabs/trezor/trezor-suite/-/jobs/1879497769