### PR TITLE
chore: fix missing @trezor/transport in native build

### DIFF
--- a/packages/connect-iframe/package.json
+++ b/packages/connect-iframe/package.json
@@ -19,6 +19,7 @@
     "devDependencies": {
         "@trezor/blockchain-link": "*",
         "@trezor/rollout": "*",
+        "@trezor/transport": "*",
         "copy-webpack-plugin": "^9.0.1",
         "html-webpack-plugin": "^5.3.2",
         "terser-webpack-plugin": "5.2.4",


### PR DESCRIPTION
At the moment suite native build in develop is failing. This change here seems to be fixing it.

fails
https://gitlab.com/satoshilabs/trezor/trezor-suite/-/jobs/1888720380

works:
https://gitlab.com/satoshilabs/trezor/trezor-suite/-/jobs/1888869459