### PR TITLE
fix(webusb): begin setup after wipe device

### DIFF
--- a/packages/suite/src/actions/settings/deviceSettingsActions.ts
+++ b/packages/suite/src/actions/settings/deviceSettingsActions.ts
@@ -76,13 +76,6 @@ export const wipeDevice = () => async (dispatch: Dispatch, getState: GetState) =
             dispatch(suiteActions.forgetDevice(d));
         });
         dispatch(addToast({ type: 'device-wiped' }));
-        // special case with webusb. device after wipe changes device_id. with webusb transport, device_id is used as path
-        // and thus as descriptor for webusb. So, after device is wiped, in the transport layer, device is still paired
-        // through old descriptor but suite already works with a new one. it kinda works but only until we try a new call,
-        // typically resetDevice when in onboarding - we get device disconnected error;
-        if (isWebUSB(transport)) {
-            dispatch(modalActions.openModal({ type: 'disconnect-device' }));
-        }
     } else {
         dispatch(addToast({ type: 'error', error: result.payload.error }));
     }


### PR DESCRIPTION
Closes https://github.com/trezor/trezor-suite/issues/4527

After testing what are differences between using webusb or trezor bridge in the workflow described [here #4527](https://github.com/trezor/trezor-suite/issues/4527). 

I found out that when using webusb the modal in state is set to `@modal/context-user` instead of `@modal/context-none` and therefore preventing `goto('onboarding-index')` in [https://github.com/trezor/trezor-suite/blob/develop/packages/suite/src/components/suite/PrerequisitesGuide/components/DeviceInitialize.tsx#L35](https://github.com/trezor/trezor-suite/blob/develop/packages/suite/src/components/suite/PrerequisitesGuide/components/DeviceInitialize.tsx#L35) from completing the routing because it is set to locked in [https://github.com/trezor/trezor-suite/blob/develop/packages/suite/src/actions/suite/routerActions.ts#L68](https://github.com/trezor/trezor-suite/blob/develop/packages/suite/src/actions/suite/routerActions.ts#L68)

There was a commented code explaining that the reason to have it for webusb is because the the `device_id` is changed and without it there are issues. The issue that the comment is addressing is still happening with Trezor Model One but not with Trezor Model T.
