### PR TITLE
fix: Add Chromium Edge Support

### DIFF
--- a/packages/suite-build/browserslist
+++ b/packages/suite-build/browserslist
@@ -1,2 +1,3 @@
 Chrome >= 69
+Edge >= 96
 Firefox >= 62

--- a/packages/suite-data/src/browser-detection/index.ts
+++ b/packages/suite-data/src/browser-detection/index.ts
@@ -108,6 +108,11 @@ window.addEventListener('load', () => {
             mobile: true,
         },
         {
+            name: 'Edge',
+            version: 96,
+            mobile: true,
+        },
+        {
             name: 'Firefox',
             version: 62,
             mobile: false, // no webusb support

--- a/packages/suite-data/src/browser-detection/index.ts
+++ b/packages/suite-data/src/browser-detection/index.ts
@@ -110,7 +110,7 @@ window.addEventListener('load', () => {
         {
             name: 'Edge',
             version: 96,
-            mobile: true,
+            mobile: false,
         },
         {
             name: 'Firefox',


### PR DESCRIPTION
Add in support for Microsoft's Chromium based Edge browser.  Works just like any other Chrome based browser.

I have not added any download link to Edge, as Microsoft would generally include this browser as packaged inside Windows 10 and 11, and should be keeping it updated via Windows Update.