### PR TITLE
feat(invity): buy and sell ERC20 tokens

### DIFF
--- a/packages/suite/src/hooks/wallet/useCoinmarketBuyForm.ts
+++ b/packages/suite/src/hooks/wallet/useCoinmarketBuyForm.ts
@@ -42,7 +42,7 @@ export const useCoinmarketBuyForm = (props: Props): BuyFormContextValues => {
         loadInvityData();
     }, [loadInvityData]);
 
-    const { selectedAccount } = props;
+    const { selectedAccount, exchangeCoinInfo } = props;
     const { account, network } = selectedAccount;
     const { navigateToBuyOffers } = useCoinmarketNavigation(account);
     const [amountLimits, setAmountLimits] = useState<AmountLimits | undefined>(undefined);
@@ -136,6 +136,7 @@ export const useCoinmarketBuyForm = (props: Props): BuyFormContextValues => {
         defaultCurrency,
         register: typedRegister,
         buyInfo,
+        exchangeCoinInfo,
         saveQuotes,
         saveTrade,
         amountLimits,

--- a/packages/suite/src/services/suite/invityAPI.ts
+++ b/packages/suite/src/services/suite/invityAPI.ts
@@ -44,7 +44,7 @@ type BodyType =
 class InvityAPI {
     unknownCountry = 'unknown';
     productionAPIServer = 'https://exchange.trezor.io';
-    stagingAPIServer = 'https://staging-exchange.invity.io';
+    stagingAPIServer = 'https://staging-exchange1.invity.io';
     localhostAPIServer = 'http://localhost:3330';
 
     server = this.productionAPIServer;

--- a/packages/suite/src/types/wallet/coinmarketBuyForm.ts
+++ b/packages/suite/src/types/wallet/coinmarketBuyForm.ts
@@ -4,9 +4,11 @@ import { BuyInfo, saveQuotes, saveTrade } from '@wallet-actions/coinmarketBuyAct
 import { UseFormMethods, FormState as ReactHookFormState } from 'react-hook-form';
 import { TypedValidationRules } from './form';
 import { DefaultCountryOption, Option } from './coinmarketCommonTypes';
+import { ExchangeCoinInfo } from 'invity-api';
 
 export interface ComponentProps {
     selectedAccount: AppState['wallet']['selectedAccount'];
+    exchangeCoinInfo: AppState['wallet']['coinmarket']['exchange']['exchangeCoinInfo'];
 }
 
 export interface Props extends ComponentProps {
@@ -36,6 +38,7 @@ export type BuyFormContextValues = Omit<UseFormMethods<FormState>, 'register'> &
     defaultCountry: DefaultCountryOption;
     defaultCurrency: Option;
     buyInfo?: BuyInfo;
+    exchangeCoinInfo?: ExchangeCoinInfo[];
     saveQuotes: typeof saveQuotes;
     saveTrade: typeof saveTrade;
     amountLimits?: AmountLimits;

--- a/packages/suite/src/types/wallet/coinmarketSellForm.ts
+++ b/packages/suite/src/types/wallet/coinmarketSellForm.ts
@@ -9,6 +9,7 @@ import { FeeInfo, FormState, PrecomposedLevels } from '@wallet-types/sendForm';
 import { Option, DefaultCountryOption } from './coinmarketCommonTypes';
 
 export const OUTPUT_AMOUNT = 'outputs[0].amount';
+export const CRYPTO_TOKEN = 'outputs[0].token';
 export const FIAT_INPUT = 'fiatInput';
 export const FIAT_CURRENCY_SELECT = 'fiatCurrencySelect';
 export const CRYPTO_INPUT = 'cryptoInput';

--- a/packages/suite/src/utils/wallet/coinmarket/__fixtures__/coinmarketUtils.ts
+++ b/packages/suite/src/utils/wallet/coinmarket/__fixtures__/coinmarketUtils.ts
@@ -1,0 +1,44 @@
+export const accountBtc = {
+    index: 1,
+    accountType: 'segwit',
+    networkType: 'bitcoin',
+    symbol: 'btc',
+    addresses: {
+        unused: [
+            {
+                address: '177BUDVZqTTzK1Fogqcrfbb5ketHEUDGSJ',
+                transfers: 0,
+                path: "m/44'/0'/3'/0/0",
+            },
+        ],
+    },
+};
+
+export const accountEth = {
+    index: 1,
+    accountType: 'normal',
+    networkType: 'ethereum',
+    symbol: 'eth',
+    descriptor: '0x2e0DC981d301cdd443C3987cf19Eb9671CB99ddC',
+    path: "m/44'/60'/0'/0/1",
+    tokens: [
+        {
+            type: 'ERC20',
+            address: '0x1234123412341234123412341234123412341234',
+            symbol: 'usdt',
+            decimals: 18,
+        },
+        {
+            type: 'ERC20',
+            address: '0x1234123412341234123412341234123412341235',
+            symbol: 'usdc',
+            decimals: 18,
+        },
+        {
+            type: 'ERC20',
+            address: '0x1234123412341234123412341234123412341236',
+            symbol: 'other',
+            decimals: 18,
+        },
+    ],
+};

--- a/packages/suite/src/utils/wallet/coinmarket/__tests__/buyUtils.test.ts
+++ b/packages/suite/src/utils/wallet/coinmarket/__tests__/buyUtils.test.ts
@@ -92,13 +92,27 @@ describe('coinmarket/buy utils', () => {
     });
 
     it('getCryptoOptions', () => {
-        expect(getCryptoOptions('btc', 'bitcoin')).toStrictEqual([
+        expect(getCryptoOptions('btc', 'bitcoin', new Set(), undefined)).toStrictEqual([
             {
                 value: 'BTC',
                 label: 'BTC',
             },
         ]);
-        expect(getCryptoOptions('eth', 'ethereum')).toStrictEqual([
+        expect(
+            getCryptoOptions(
+                'eth',
+                'ethereum',
+                new Set(['eth', 'usdt20', 'usdc', 'dai', 'gusd', 'other']),
+                [
+                    { ticker: 'ETH', category: 'Popular', name: 'Ethereum' },
+                    { ticker: 'USDT20', category: 'Ethereum ERC20 tokens', name: 'Tether' },
+                    { ticker: 'USDC', category: 'Ethereum ERC20 tokens', name: 'Usdc' },
+                    { ticker: 'DAI', category: 'Ethereum ERC20 tokens', name: 'Dai' },
+                    { ticker: 'GUSD', category: 'Ethereum ERC20 tokens', name: 'GUsd' },
+                    { ticker: 'OTHER', category: 'Other coins', name: 'Other' },
+                ],
+            ),
+        ).toStrictEqual([
             {
                 value: 'ETH',
                 label: 'ETH',

--- a/packages/suite/src/utils/wallet/coinmarket/__tests__/coinmarketUtils.test.ts
+++ b/packages/suite/src/utils/wallet/coinmarket/__tests__/coinmarketUtils.test.ts
@@ -1,3 +1,4 @@
+import { Account } from '@suite/types/wallet';
 import {
     buildOption,
     formatCryptoAmount,
@@ -5,7 +6,9 @@ import {
     getUnusedAddressFromAccount,
     getCountryLabelParts,
     mapTestnetSymbol,
+    getSendCryptoOptions,
 } from '../coinmarketUtils';
+import { accountBtc, accountEth } from '../__fixtures__/coinmarketUtils';
 
 describe('coinmarket utils', () => {
     it('buildOption', () => {
@@ -24,38 +27,12 @@ describe('coinmarket utils', () => {
     });
 
     it('getUnusedAddressFromAccount', () => {
-        const accountMockBtc = {
-            index: 1,
-            accountType: 'segwit',
-            networkType: 'bitcoin',
-            symbol: 'btc',
-            addresses: {
-                unused: [
-                    {
-                        address: '177BUDVZqTTzK1Fogqcrfbb5ketHEUDGSJ',
-                        transfers: 0,
-                        path: "m/44'/0'/3'/0/0",
-                    },
-                ],
-            },
-        };
-        // @ts-ignore
-        expect(getUnusedAddressFromAccount(accountMockBtc)).toStrictEqual({
+        expect(getUnusedAddressFromAccount(accountBtc as Account)).toStrictEqual({
             address: '177BUDVZqTTzK1Fogqcrfbb5ketHEUDGSJ',
             path: "m/44'/0'/3'/0/0",
         });
 
-        const accountMockEth = {
-            index: 1,
-            accountType: 'normal',
-            networkType: 'ethereum',
-            symbol: 'eth',
-            descriptor: '0x2e0DC981d301cdd443C3987cf19Eb9671CB99ddC',
-            path: "m/44'/60'/0'/0/1",
-        };
-
-        // @ts-ignore
-        expect(getUnusedAddressFromAccount(accountMockEth)).toStrictEqual({
+        expect(getUnusedAddressFromAccount(accountEth as Account)).toStrictEqual({
             address: '0x2e0DC981d301cdd443C3987cf19Eb9671CB99ddC',
             path: "m/44'/60'/0'/0/1",
         });
@@ -78,5 +55,30 @@ describe('coinmarket utils', () => {
         expect(mapTestnetSymbol('test')).toStrictEqual('btc');
         expect(mapTestnetSymbol('trop')).toStrictEqual('eth');
         expect(mapTestnetSymbol('txrp')).toStrictEqual('xrp');
+    });
+
+    it('getSendCryptoOptions', () => {
+        expect(getSendCryptoOptions(accountBtc as Account, new Set())).toStrictEqual([
+            {
+                value: 'BTC',
+                label: 'BTC',
+            },
+        ]);
+        expect(
+            getSendCryptoOptions(accountEth as Account, new Set(['eth', 'usdt20', 'usdc', 'dai'])),
+        ).toStrictEqual([
+            {
+                value: 'ETH',
+                label: 'ETH',
+            },
+            {
+                value: 'USDT20',
+                label: 'USDT20',
+            },
+            {
+                label: 'USDC',
+                value: 'USDC',
+            },
+        ]);
     });
 });

--- a/packages/suite/src/utils/wallet/coinmarket/buyUtils.ts
+++ b/packages/suite/src/utils/wallet/coinmarket/buyUtils.ts
@@ -134,11 +134,12 @@ export const getCryptoOptions = (
         coinInfo?.forEach(coin => {
             if (coin.category === 'Ethereum ERC20 tokens') {
                 const ticker = coin.ticker.toLowerCase();
-                if (supportedCoins.has(ticker))
+                if (supportedCoins.has(ticker)) {
                     options.push({
                         label: invityApiSymbolToSymbol(ticker).toUpperCase(),
                         value: coin.ticker,
                     });
+                }
             }
         });
     }

--- a/packages/suite/src/utils/wallet/coinmarket/coinmarketUtils.ts
+++ b/packages/suite/src/utils/wallet/coinmarket/coinmarketUtils.ts
@@ -28,6 +28,29 @@ export const symbolToInvityApiSymbol = (symbol?: string) => {
     return result ? result.invitySymbol : symbol;
 };
 
+export const getSendCryptoOptions = (account: Account, supportedCoins: Set<string>) => {
+    const uppercaseSymbol = account.symbol.toUpperCase();
+    const options: { value: string; label: string }[] = [
+        { value: uppercaseSymbol, label: uppercaseSymbol },
+    ];
+
+    if (account.networkType === 'ethereum' && account.tokens) {
+        account.tokens.forEach(token => {
+            if (token.symbol) {
+                const invityToken = symbolToInvityApiSymbol(token.symbol);
+                if (supportedCoins.has(invityToken)) {
+                    options.push({
+                        label: invityToken.toUpperCase(),
+                        value: invityToken.toUpperCase(),
+                    });
+                }
+            }
+        });
+    }
+
+    return options;
+};
+
 export function formatCryptoAmount(amount: number, decimals = 8): string {
     let digits = 4;
     if (amount < 1) {

--- a/packages/suite/src/utils/wallet/coinmarket/exchangeUtils.ts
+++ b/packages/suite/src/utils/wallet/coinmarket/exchangeUtils.ts
@@ -1,8 +1,6 @@
 import { ExchangeInfo } from '@wallet-actions/coinmarketExchangeActions';
 import { AmountLimits } from '@wallet-types/coinmarketExchangeForm';
 import { ExchangeTrade, ExchangeTradeStatus } from 'invity-api';
-import { symbolToInvityApiSymbol } from './coinmarketUtils';
-import { Account } from '@wallet-types';
 
 // loop through quotes and if all quotes are either with error below minimum or over maximum, return error message
 export const getAmountLimits = (quotes: ExchangeTrade[]): AmountLimits | undefined => {
@@ -100,29 +98,6 @@ export const splitToQuoteCategories = (
     return [fixedQuotes, floatQuotes, dexQuotes];
 };
 
-export const getSendCryptoOptions = (account: Account, exchangeInfo?: ExchangeInfo) => {
-    const uppercaseSymbol = account.symbol.toUpperCase();
-    const options: { value: string; label: string }[] = [
-        { value: uppercaseSymbol, label: uppercaseSymbol },
-    ];
-
-    if (account.networkType === 'ethereum' && account.tokens) {
-        account.tokens.forEach(token => {
-            if (token.symbol) {
-                const invityToken = symbolToInvityApiSymbol(token.symbol);
-                if (exchangeInfo?.sellSymbols.has(invityToken)) {
-                    options.push({
-                        label: token.symbol.toUpperCase(),
-                        value: invityToken.toUpperCase(),
-                    });
-                }
-            }
-        });
-    }
-
-    return options;
-};
-
 export const getStatusMessage = (status: ExchangeTradeStatus) => {
     switch (status) {
         case 'ERROR':
@@ -136,10 +111,4 @@ export const getStatusMessage = (status: ExchangeTradeStatus) => {
         default:
             return 'TR_EXCHANGE_STATUS_CONFIRMING';
     }
-};
-
-export const formatLabel = (tokenLabel: string) => {
-    const lowerCaseLabel = tokenLabel.toLowerCase();
-    const label = lowerCaseLabel === 'usdt' ? 'usdt20' : tokenLabel;
-    return label.toUpperCase();
 };

--- a/packages/suite/src/views/wallet/coinmarket/buy/components/BuyForm/Inputs/index.tsx
+++ b/packages/suite/src/views/wallet/coinmarket/buy/components/BuyForm/Inputs/index.tsx
@@ -1,10 +1,12 @@
 import React, { useEffect, useState } from 'react';
+import styled from 'styled-components';
+import invityAPI from '@suite-services/invityAPI';
 import Bignumber from 'bignumber.js';
 import { Controller } from 'react-hook-form';
 import { FIAT } from '@suite-config';
 import { Translation } from '@suite-components';
 import { getCryptoOptions } from '@wallet-utils/coinmarket/buyUtils';
-import { Select, Input } from '@trezor/components';
+import { Select, Input, CoinLogo } from '@trezor/components';
 import { buildOption } from '@wallet-utils/coinmarket/coinmarketUtils';
 import { useCoinmarketBuyFormContext } from '@wallet-hooks/useCoinmarketBuyForm';
 import { isDecimalsValid } from '@wallet-utils/validation';
@@ -12,6 +14,21 @@ import { InputError } from '@wallet-components';
 import { MAX_LENGTH } from '@suite-constants/inputs';
 import { getInputState } from '@wallet-utils/sendFormUtils';
 import { Wrapper, Left, Middle, Right, StyledIcon } from '@wallet-views/coinmarket';
+
+const Option = styled.div`
+    display: flex;
+    align-items: center;
+`;
+
+const Label = styled.div`
+    padding-left: 10px;
+`;
+
+const TokenLogo = styled.img`
+    display: flex;
+    align-items: center;
+    height: 18px;
+`;
 
 const Inputs = () => {
     const {
@@ -30,6 +47,7 @@ const Inputs = () => {
         defaultCurrency,
         cryptoInputValue,
         getValues,
+        exchangeCoinInfo,
     } = useCoinmarketBuyFormContext();
     const { symbol } = account;
     const uppercaseSymbol = symbol.toUpperCase();
@@ -239,12 +257,29 @@ const Inputs = () => {
                                     value={value}
                                     isSearchable
                                     isClearable={false}
-                                    options={getCryptoOptions(account.symbol, account.networkType)}
+                                    options={getCryptoOptions(
+                                        account.symbol,
+                                        account.networkType,
+                                        buyInfo?.supportedCryptoCurrencies || new Set(),
+                                        exchangeCoinInfo,
+                                    )}
+                                    formatOptionLabel={(option: any) => (
+                                        <Option>
+                                            {account.symbol.toUpperCase() === option.value ? (
+                                                <CoinLogo size={18} symbol={account.symbol} />
+                                            ) : (
+                                                <TokenLogo
+                                                    src={`${invityAPI.server}/images/coins/suite/${option.value}.svg`}
+                                                />
+                                            )}
+                                            <Label>{option.label}</Label>
+                                        </Option>
+                                    )}
                                     isClean
                                     hideTextCursor
                                     isDropdownVisible={account.networkType === 'ethereum'}
                                     isDisabled={account.networkType !== 'ethereum'}
-                                    minWidth="58px"
+                                    minWidth="100px"
                                 />
                             )}
                         />

--- a/packages/suite/src/views/wallet/coinmarket/buy/index.tsx
+++ b/packages/suite/src/views/wallet/coinmarket/buy/index.tsx
@@ -25,11 +25,15 @@ const CoinmarketBuyLoaded = (props: Props) => {
 };
 
 const CoinmarketBuy = () => {
-    const selectedAccount = useSelector(state => state.wallet.selectedAccount);
+    const props = useSelector(state => ({
+        selectedAccount: state.wallet.selectedAccount,
+        exchangeCoinInfo: state.wallet.coinmarket.exchange.exchangeCoinInfo,
+    }));
+    const { selectedAccount } = props;
     if (selectedAccount.status !== 'loaded') {
         return <WalletLayout title="TR_NAV_BUY" account={selectedAccount} />;
     }
-    return <CoinmarketBuyLoaded selectedAccount={selectedAccount} />;
+    return <CoinmarketBuyLoaded {...props} selectedAccount={selectedAccount} />;
 };
 
 export default CoinmarketBuy;

--- a/packages/suite/src/views/wallet/coinmarket/exchange/components/ExchangeForm/Inputs/ReceiveCryptoSelect/index.tsx
+++ b/packages/suite/src/views/wallet/coinmarket/exchange/components/ExchangeForm/Inputs/ReceiveCryptoSelect/index.tsx
@@ -36,10 +36,12 @@ const Option = styled.div`
 const OptionName = styled.div`
     display: flex;
     color: ${props => props.theme.TYPE_LIGHT_GREY};
+    font-size: ${variables.FONT_SIZE.TINY};
+    max-width: 150px;
 `;
 
 const OptionLabel = styled.div`
-    min-width: 70px;
+    min-width: 60px;
 `;
 
 const buildOptions = (

--- a/packages/suite/src/views/wallet/coinmarket/exchange/components/ExchangeForm/Inputs/SendCryptoInput/SendCryptoSelect/index.tsx
+++ b/packages/suite/src/views/wallet/coinmarket/exchange/components/ExchangeForm/Inputs/SendCryptoInput/SendCryptoSelect/index.tsx
@@ -4,9 +4,11 @@ import { Controller } from 'react-hook-form';
 import styled from 'styled-components';
 import invityAPI from '@suite-services/invityAPI';
 import { useCoinmarketExchangeFormContext } from '@wallet-hooks/useCoinmarketExchangeForm';
-import { getSendCryptoOptions, formatLabel } from '@wallet-utils/coinmarket/exchangeUtils';
 import { CRYPTO_INPUT, FIAT_INPUT, CRYPTO_TOKEN } from '@wallet-types/coinmarketExchangeForm';
-import { invityApiSymbolToSymbol } from '@suite/utils/wallet/coinmarket/coinmarketUtils';
+import {
+    getSendCryptoOptions,
+    invityApiSymbolToSymbol,
+} from '@suite/utils/wallet/coinmarket/coinmarketUtils';
 
 const Option = styled.div`
     display: flex;
@@ -27,17 +29,14 @@ const SendCryptoSelect = () => {
     const { control, setAmountLimits, account, setValue, exchangeInfo, composeRequest } =
         useCoinmarketExchangeFormContext();
 
-    const { symbol, tokens } = account;
-    const uppercaseSymbol = symbol.toUpperCase();
+    const { tokens } = account;
+    const sendCryptoOptions = getSendCryptoOptions(account, exchangeInfo?.sellSymbols || new Set());
 
     return (
         <Controller
             control={control}
             name="sendCryptoSelect"
-            defaultValue={{
-                value: uppercaseSymbol,
-                label: formatLabel(uppercaseSymbol),
-            }}
+            defaultValue={sendCryptoOptions[0]}
             render={({ onChange, value }) => (
                 <Select
                     onChange={(selected: any) => {
@@ -63,19 +62,19 @@ const SendCryptoSelect = () => {
                     }}
                     formatOptionLabel={(option: any) => (
                         <Option>
-                            {account.symbol.toUpperCase() === option.value ? (
+                            {account.symbol === option.value.toLowerCase() ? (
                                 <CoinLogo size={18} symbol={account.symbol} />
                             ) : (
                                 <TokenLogo
                                     src={`${invityAPI.server}/images/coins/suite/${option.value}.svg`}
                                 />
                             )}
-                            <Label>{formatLabel(option.label)}</Label>
+                            <Label>{option.label}</Label>
                         </Option>
                     )}
                     value={value}
                     isClearable={false}
-                    options={getSendCryptoOptions(account, exchangeInfo)}
+                    options={sendCryptoOptions}
                     isDropdownVisible={account.networkType === 'ethereum'}
                     isDisabled={account.networkType !== 'ethereum'}
                     minWidth="100px"

--- a/packages/suite/src/views/wallet/coinmarket/exchange/components/ExchangeForm/Inputs/SendCryptoInput/SendCryptoSelect/index.tsx
+++ b/packages/suite/src/views/wallet/coinmarket/exchange/components/ExchangeForm/Inputs/SendCryptoInput/SendCryptoSelect/index.tsx
@@ -2,6 +2,7 @@ import { Select, CoinLogo } from '@trezor/components';
 import React from 'react';
 import { Controller } from 'react-hook-form';
 import styled from 'styled-components';
+import invityAPI from '@suite-services/invityAPI';
 import { useCoinmarketExchangeFormContext } from '@wallet-hooks/useCoinmarketExchangeForm';
 import { getSendCryptoOptions, formatLabel } from '@wallet-utils/coinmarket/exchangeUtils';
 import { CRYPTO_INPUT, FIAT_INPUT, CRYPTO_TOKEN } from '@wallet-types/coinmarketExchangeForm';
@@ -14,6 +15,12 @@ const Option = styled.div`
 
 const Label = styled.div`
     padding-left: 10px;
+`;
+
+const TokenLogo = styled.img`
+    display: flex;
+    align-items: center;
+    height: 18px;
 `;
 
 const SendCryptoSelect = () => {
@@ -56,7 +63,13 @@ const SendCryptoSelect = () => {
                     }}
                     formatOptionLabel={(option: any) => (
                         <Option>
-                            <CoinLogo size={18} symbol={account.symbol} />
+                            {account.symbol.toUpperCase() === option.value ? (
+                                <CoinLogo size={18} symbol={account.symbol} />
+                            ) : (
+                                <TokenLogo
+                                    src={`${invityAPI.server}/images/coins/suite/${option.value}.svg`}
+                                />
+                            )}
                             <Label>{formatLabel(option.label)}</Label>
                         </Option>
                     )}

--- a/packages/suite/src/views/wallet/coinmarket/sell/components/SellForm/Inputs/FiatInput/index.tsx
+++ b/packages/suite/src/views/wallet/coinmarket/sell/components/SellForm/Inputs/FiatInput/index.tsx
@@ -34,9 +34,13 @@ const FiatInput = ({ activeInput, setActiveInput }: Props) => {
         quotesRequest,
         onFiatAmountChange,
         getValues,
+        account,
     } = useCoinmarketSellFormContext();
 
     const fiatInputValue = getValues(FIAT_INPUT);
+    const { outputs } = getValues();
+    const tokenAddress = outputs?.[0]?.token;
+    const tokenData = account.tokens?.find(t => t.address === tokenAddress);
 
     return (
         <Input
@@ -105,6 +109,7 @@ const FiatInput = ({ activeInput, setActiveInput }: Props) => {
                 setActiveInput(FIAT_INPUT);
                 onFiatAmountChange(event.target.value);
             }}
+            isDisabled={tokenData !== undefined}
             state={getInputState(errors.fiatInput, fiatInputValue)}
             name={FIAT_INPUT}
             maxLength={MAX_LENGTH.AMOUNT}


### PR DESCRIPTION
This PR improves a selection of ERC20 tokens to buy and adds a possibility to sell ERC20 tokens.

Buy crypto change: the list of tokens available to buy is fetched from the API server (before it was a hardcoded list of tokens).
Before:
![image](https://user-images.githubusercontent.com/11609674/148703230-df8be0d5-d70b-4834-9ebd-c5b68c9182a7.png)

After:
![image](https://user-images.githubusercontent.com/11609674/148703350-353d8bb8-41d1-471d-a215-61c5c1200214.png)

Sell crypto change: added a possibility to choose ERC20 tokens.
There is a limitation, if a token is chosen, it is not possible to enter an amount in fiat as it is not assured that we have an estimate of the corresponding value in crypto.
![image](https://user-images.githubusercontent.com/11609674/148703435-0dd0df51-815d-4700-a7be-441b0b8d66b5.png)

The change requires also update on the API server. At this moment it can be tested only using our staging API server.

The change is split into two commits, one for buy and one for sell functionality.