### PR TITLE
fix(suite-native): add missing package to metro.config

### DIFF
--- a/packages/suite-native/metro.config.js
+++ b/packages/suite-native/metro.config.js
@@ -47,6 +47,7 @@ module.exports = (async () => {
                     '../../packages/blockchain-link',
                 ),
                 '@trezor/rollout': path.resolve(__dirname, '../../packages/rollout'),
+                '@trezor/transport': path.resolve(__dirname, '../../packages/transport'),
                 '@trezor/utxo-lib': path.resolve(__dirname, '../../packages/utxo-lib'),
             },
             // https://github.com/facebook/metro/issues/265


### PR DESCRIPTION
fixes failing suite-native build in develop 
trezor-link is now a part of monorepo, renamed to @trezor/transport