### PR TITLE
fix: disappearing of outpus when removing

### DIFF
--- a/packages/suite/src/config/suite/animation.ts
+++ b/packages/suite/src/config/suite/animation.ts
@@ -2,8 +2,8 @@ export default {
     EXPAND: {
         variants: {
             initial: {
-                overflow: 'hidden',
-                height: 0,
+                overflow: 'unset',
+                height: 'auto',
             },
             visible: {
                 height: 'auto',


### PR DESCRIPTION
Closes https://github.com/trezor/trezor-suite/issues/4710

It seams that the library `framer-motion` that was upgraded 1 month ago has caused this new issue in develop.

Updating the initial CSS `overflow` and `height` fixes it.