### PR TITLE
fix: regtest only available in debug mode

### DIFF
--- a/packages/integration-tests/projects/suite-web/support/commands.ts
+++ b/packages/integration-tests/projects/suite-web/support/commands.ts
@@ -15,6 +15,7 @@ import { getTestElement, getConfirmActionOnDeviceModal, hoverTestElement } from 
 import { resetDb, dispatch } from './utils/test-env';
 import {
     toggleDeviceMenu,
+    toggleDebugModeInSettings,
     goToOnboarding,
     passThroughInitialRun,
     passThroughBackup,
@@ -78,6 +79,7 @@ declare global {
             dashboardShouldLoad: () => Chainable<Subject>;
             discoveryShouldFinish: () => Chainable<Subject>;
             toggleDeviceMenu: () => Chainable<Subject>;
+            toggleDebugModeInSettings: () => Chainable<Subject>;
             text: () => Chainable<Subject>;
             passThroughInitialRun: () => Chainable<Subject>;
             passThroughBackup: () => Chainable<Subject>;
@@ -123,6 +125,7 @@ Cypress.Commands.add('hoverTestElement', hoverTestElement);
 
 // various shortcuts
 Cypress.Commands.add('toggleDeviceMenu', toggleDeviceMenu);
+Cypress.Commands.add('toggleDebugModeInSettings', toggleDebugModeInSettings);
 Cypress.Commands.add('goToOnboarding', goToOnboarding);
 Cypress.Commands.add('passThroughInitialRun', passThroughInitialRun);
 Cypress.Commands.add('passThroughBackup', passThroughBackup);

--- a/packages/integration-tests/projects/suite-web/support/utils/shortcuts.ts
+++ b/packages/integration-tests/projects/suite-web/support/utils/shortcuts.ts
@@ -85,3 +85,10 @@ export const passThroughSetPin = () => {
     cy.task('pressYes');
     cy.getTestElement('@onboarding/pin/continue-button').click();
 };
+
+export const toggleDebugModeInSettings = () => {
+    const timesClickToSetDebugMode = 5;
+    for (let i = 0; i < timesClickToSetDebugMode; i++) {
+        cy.getTestElement('@settings/menu/title').click();
+    }
+};

--- a/packages/integration-tests/projects/suite-web/tests/wallet/coin-balance.test.ts
+++ b/packages/integration-tests/projects/suite-web/tests/wallet/coin-balance.test.ts
@@ -25,6 +25,16 @@ describe('Dashboard with regtest', () => {
 
         cy.getTestElement('@suite/menu/settings').click();
         cy.getTestElement('@suite/menu/settings-coins').click();
+
+        // before setting debug mode, regtest coin should not exist
+        cy.getTestElement('@settings/wallet/network/regtest', { timeout: 30000 }).should(
+            'not.exist',
+        );
+
+        // set it to debug mode so regtest is available
+        cy.toggleDebugModeInSettings();
+        cy.getTestElement('@settings/wallet/network/regtest', { timeout: 30000 }).should('exist');
+
         cy.getTestElement('@settings/wallet/network/btc').should('be.checked');
         cy.getTestElement('@settings/wallet/network/regtest').click({ force: true });
         cy.getTestElement('@settings/wallet/network/regtest/advance').click({ force: true });

--- a/packages/suite/src/components/settings/SettingsMenu/index.tsx
+++ b/packages/suite/src/components/settings/SettingsMenu/index.tsx
@@ -35,6 +35,7 @@ const SettingsMenu = () => {
             title={
                 <span
                     aria-hidden="true"
+                    data-test="@settings/menu/title"
                     onClick={() => {
                         setClickCounter(prev => prev + 1);
                         if (clickCounter === 4) {

--- a/packages/suite/src/components/suite/modals/AddAccount/index.tsx
+++ b/packages/suite/src/components/suite/modals/AddAccount/index.tsx
@@ -46,11 +46,13 @@ const AddAccountModal = ({ device, onCancel, symbol, noRedirect }: Props) => {
     });
     const {
         app,
+        debug,
         accounts,
         enabledNetworks: enabledNetworksSymbols,
     } = useSelector(state => ({
         app: state.router.app,
         accounts: state.wallet.accounts,
+        debug: state.suite.settings.debug,
         enabledNetworks: state.wallet.settings.enabledNetworks,
     }));
 
@@ -74,6 +76,10 @@ const AddAccountModal = ({ device, onCancel, symbol, noRedirect }: Props) => {
     const [disabledMainnetNetworks, disabledTestnetNetworks] = partition(
         disabledNetworks,
         network => !network?.testnet,
+    );
+
+    const availableDisabledTestnetNetworks = disabledTestnetNetworks.filter(
+        (n: Network) => !(n.symbol === 'regtest' && !debug.showDebugMenu),
     );
 
     const handleNetworkSelection = (symbol?: Network['symbol']) => {
@@ -157,7 +163,7 @@ const AddAccountModal = ({ device, onCancel, symbol, noRedirect }: Props) => {
             {!selectedNetworkEnabled && hasDisabledNetworks && (
                 <EnableNetwork
                     networks={disabledMainnetNetworks}
-                    testnetNetworks={disabledTestnetNetworks}
+                    testnetNetworks={availableDisabledTestnetNetworks}
                     selectedNetworks={selectedNetworks}
                     handleNetworkSelection={handleNetworkSelection}
                 />

--- a/packages/suite/src/views/onboarding/steps/BasicSettings/index.tsx
+++ b/packages/suite/src/views/onboarding/steps/BasicSettings/index.tsx
@@ -8,8 +8,9 @@ import BasicSettingsStepBox from './BasicSettingsStepBox';
 import AdvancedSetup from './AdvancedSetup';
 
 const BasicSettings = () => {
-    const { enabledNetworks } = useSelector(state => ({
+    const { enabledNetworks, debug } = useSelector(state => ({
         enabledNetworks: state.wallet.settings.enabledNetworks,
+        debug: state.suite.settings.debug,
     }));
 
     const enabledMainnetNetworks: Network['symbol'][] = [];
@@ -17,7 +18,7 @@ const BasicSettings = () => {
 
     enabledNetworks.forEach(symbol => {
         const network = NETWORKS.find(n => n.symbol === symbol);
-        if (!network) return;
+        if (!network || (network.symbol === 'regtest' && !debug.showDebugMenu)) return;
         if (network.testnet) {
             enabledTestnetNetworks.push(network.symbol);
         } else {
@@ -26,7 +27,12 @@ const BasicSettings = () => {
     });
 
     const mainnetNetworks = NETWORKS.filter(n => !n.accountType && !n.testnet);
-    const testnetNetworks = NETWORKS.filter(n => !n.accountType && n?.testnet === true);
+    const testnetNetworks = NETWORKS.filter(n => {
+        if (n.symbol === 'regtest' && !debug.showDebugMenu) {
+            return false;
+        }
+        return !n.accountType && n?.testnet === true;
+    });
 
     const setupNetworks = [...mainnetNetworks, ...testnetNetworks].filter(
         n => enabledMainnetNetworks.includes(n.symbol) || enabledTestnetNetworks.includes(n.symbol),

--- a/packages/suite/src/views/settings/coins/index.tsx
+++ b/packages/suite/src/views/settings/coins/index.tsx
@@ -12,8 +12,9 @@ const Settings = () => {
         changeCoinVisibility: walletSettingsActions.changeCoinVisibility,
         changeNetworks: walletSettingsActions.changeNetworks,
     });
-    const { device, enabledNetworks } = useSelector(state => ({
+    const { device, enabledNetworks, debug } = useSelector(state => ({
         device: state.suite.device,
+        debug: state.suite.settings.debug,
         enabledNetworks: state.wallet.settings.enabledNetworks,
     }));
 
@@ -21,8 +22,12 @@ const Settings = () => {
 
     const mainnetNetworksFilterFn = (n: Network) => !n.accountType && !n.testnet;
 
-    const testnetNetworksFilterFn = (n: Network) =>
-        !n.accountType && 'testnet' in n && n.testnet === true;
+    const testnetNetworksFilterFn = (n: Network) => {
+        if (n.symbol === 'regtest' && !debug.showDebugMenu) {
+            return false;
+        }
+        return !n.accountType && 'testnet' in n && n.testnet === true;
+    };
 
     const unavailableNetworksFilterFn = (symbol: Network['symbol']) =>
         !unavailableCapabilities[symbol];


### PR DESCRIPTION
Make regtest available only in debug mode.

There are few places where it is clearly seen that we have duplicated code for filter coinst to display to the user. I was considering create an utility function to make it better maintainable but after talking with @marekrjpolak he is already doing it in one of his next tasks, so I don't think it is worthy now make it.

I made the changes in 3 parts where we display coins for accounts:
* In settings/crypto
* Onboarding initial coin selection
* When no coin is selected there is other modal in account discovery to add more coins
