### PR TITLE
fix(suite): fix suite stucked in bootloader mode

### DIFF
--- a/packages/suite/src/middlewares/suite/redirectMiddleware.ts
+++ b/packages/suite/src/middlewares/suite/redirectMiddleware.ts
@@ -4,7 +4,7 @@ import * as routerActions from '@suite-actions/routerActions';
 
 import { AppState, Action, Dispatch, TrezorDevice } from '@suite-types';
 
-const handleDeviceRedirect = async (dispatch: Dispatch, state: AppState, device?: TrezorDevice) => {
+const handleDeviceRedirect = (dispatch: Dispatch, state: AppState, device?: TrezorDevice) => {
     // no device, no redirect
     if (!device || !device.features) {
         return;
@@ -20,7 +20,7 @@ const handleDeviceRedirect = async (dispatch: Dispatch, state: AppState, device?
 
     // device is not initialized, redirect to onboarding
     if (device.mode === 'initialize') {
-        await dispatch(routerActions.goto('onboarding-index'));
+        dispatch(routerActions.goto('onboarding-index'));
     }
     // firmware none (model T) or unknown (model One) indicates freshly unpacked device
     if (
@@ -28,16 +28,16 @@ const handleDeviceRedirect = async (dispatch: Dispatch, state: AppState, device?
         device.features &&
         device.features.firmware_present === false
     ) {
-        await dispatch(routerActions.goto('onboarding-index'));
+        dispatch(routerActions.goto('onboarding-index'));
     }
     // device firmware update required, redirect to "firmware update"
     else if (device.firmware === 'required') {
-        await dispatch(routerActions.goto('firmware-index'));
+        dispatch(routerActions.goto('firmware-index'));
     }
 
     // reset wallet params if switching from one device to another
     if (state.suite.device && state.router.app === 'wallet' && state.router.params) {
-        await dispatch(routerActions.goto(state.router.route.name));
+        dispatch(routerActions.goto(state.router.route.name));
     }
 };
 /**
@@ -46,7 +46,7 @@ const handleDeviceRedirect = async (dispatch: Dispatch, state: AppState, device?
 const redirect =
     (api: MiddlewareAPI<Dispatch, AppState>) =>
     (next: Dispatch) =>
-    async (action: Action): Promise<Action> => {
+    (action: Action): Action => {
         const { locks } = api.getState().suite;
 
         if (locks.includes(SUITE.LOCK_TYPE.ROUTER)) {
@@ -65,7 +65,7 @@ const redirect =
         switch (action.type) {
             // todo: this will not get call after acquiring device!
             case SUITE.SELECT_DEVICE:
-                await handleDeviceRedirect(api.dispatch, api.getState(), action.payload);
+                handleDeviceRedirect(api.dispatch, api.getState(), action.payload);
                 break;
             default:
                 break;


### PR DESCRIPTION
This removes race condition (wrong order of two subsequent @suite/select-device actions) when there is a need to reset wallet params.

Steps to reproduce was
1. load /accounts#/btc/0 without device connected
2. connect device in bootloader and then
3. disconnect it.
The Suite looks like the device is still connected in bootloader even if already disconnected.

Awaiting on dispatching actions doesn't guarantee waiting for the action to be processed anyway if the action creator is not returning promise.

So the solution here is to make dispatching @suite/select-device synchronous.

## notes for QA:

please test device connecting/disconnecting especially in the cases where is some redirection:
- device is not initialized -> redirect to onboarding
- no FW -> redirect to onboarding
- FW update required -> redirect to firmware update
- wallet params in route (`/accounts#/{coin}/{accountNumber}`) -> removing the params

better to test not only with one device and one wallet, but also with multiple hidden wallets on one device and multiple devices too
