### PR TITLE
fix(suite): use http-equiv instead of httpEquiv

### DIFF
--- a/packages/suite-web/src/static/index.html
+++ b/packages/suite-web/src/static/index.html
@@ -18,7 +18,7 @@
         />
         <% if(isOnionLocation) { %>
             <meta
-                httpEquiv="onion-location"
+                http-equiv="onion-location"
                 content="http://suite.trezoriovpjcahpzkrewelclulmszwbqpzmzgub37gbcjlvluxtruqad.onion/web"
             />
         <% } %>


### PR DESCRIPTION
Fixes https://github.com/trezor/trezor-suite/issues/4626

In 0390b4354e38c3c7f869624e9b3011f01d5311ac we replaced `packages/suite-web/pages/_document.tsx` with `packages/suite-web/src/static/index.html` but since the file is not processed by React anymore we have to convert `httpEquiv` to `http-equiv` manually.