### PR TITLE
Feat/update app config

### DIFF
--- a/packages/suite-data/src/message-system/config/config.v1.json
+++ b/packages/suite-data/src/message-system/config/config.v1.json
@@ -1,29 +1,30 @@
 {
     "version": 1,
-    "timestamp": "2021-10-11T00:00:00+00:00",
-    "sequence": 6,
+    "timestamp": "2022-02-17T00:00:00+00:00",
+    "sequence": 7,
     "actions": [
         {
             "conditions": [
                 {
                     "environment": {
-                        "desktop": "21.9.1",
+                        "desktop": "<22.0.0",
                         "mobile": "!",
                         "web": "!"
                     }
                 }
             ],
             "message": {
-                "id": "40d88610-170f-11ec-9621-0242ac130002",
+                "id": "53644716-b26b-4f62-808d-7ee0dfb23069",
                 "priority": 91,
-                "dismissible": false,
-                "variant": "critical",
+                "dismissible": true,
+                "variant": "warning",
                 "category": "banner",
                 "content": {
-                    "en-GB": "There has been an error updating Trezor Suite. Please install the latest version manually from the Trezor Suite homepage.",
-                    "en": "There has been an error updating Trezor Suite. Please install the latest version manually from the Trezor Suite homepage.",
-                    "es": "Ha habido un error al actualizar Trezor Suite. Instale la última versión manualmente desde la página de inicio de Trezor Suite.",
-                    "cs": "Při aktualizaci Trezor Suite došlo k chybě. Nainstalujte prosím nejnovější verzi ručně z domovské stránky Trezor Suite."
+                    "en-GB": "Update Trezor Suite for enhanced security, all the latest features, and to keep everything running as smoothly as possible.",
+                    "en": "Update Trezor Suite for enhanced security, all the latest features, and to keep everything running as smoothly as possible.",
+                    "es": "Actualice Trezor Suite para obtener una mayor seguridad, las últimas funciones y para que todo funcione lo mejor posible.",
+                    "cs": "Aktualizujte Trezor Suite, abyste získali lepší zabezpečení a nejnovější funkce.",
+                    "ru": "Обновите Trezor Suite, чтобы улучшить безопасность, использовать все новейшие функции и обеспечить максимально эффективную работу."
                 },
                 "cta": {
                     "action": "external-link",
@@ -32,7 +33,8 @@
                         "en-GB": "Go to suite.trezor.io",
                         "en": "Go to suite.trezor.io",
                         "es": "Ir a suite.trezor.io",
-                        "cs": "Přejít na suite.trezor.io"
+                        "cs": "Přejít na suite.trezor.io",
+                        "ru": "Перейти на suite.trezor.io"
                     }
                 }
             }

--- a/packages/suite-data/src/message-system/schema/config.schema.v1.json
+++ b/packages/suite-data/src/message-system/schema/config.schema.v1.json
@@ -316,7 +316,7 @@
             "title": "Localization",
             "description": "A multilingual text localization.",
             "type": "object",
-            "required": ["en-GB", "en", "es", "cs"],
+            "required": ["en-GB", "en", "es", "cs", "ru"],
             "properties": {
                 "en-GB": {
                     "type": "string"
@@ -328,6 +328,9 @@
                     "type": "string"
                 },
                 "cs": {
+                    "type": "string"
+                },
+                "ru": {
                     "type": "string"
                 }
             },

--- a/packages/suite/src/components/onboarding/Layouts/OnboardingLayout.tsx
+++ b/packages/suite/src/components/onboarding/Layouts/OnboardingLayout.tsx
@@ -9,13 +9,22 @@ import { SUPPORT_URL } from '@suite-constants/urls';
 import { MAX_WIDTH } from '@suite-constants/layout';
 import steps from '@onboarding-config/steps';
 import { GuideButton, GuidePanel } from '@guide-components';
+import { useMessageSystem } from '@suite-hooks/useMessageSystem';
+import MessageSystemBanner from '@suite-components/Banners/MessageSystemBanner';
 
 const Wrapper = styled.div`
     display: flex;
     width: 100%;
     height: 100%;
-    justify-content: center;
+    flex-direction: column;
     background: ${props => props.theme.BG_LIGHT_GREY};
+`;
+
+const Body = styled.div`
+    justify-content: center;
+    display: flex;
+    width: 100%;
+    height: 100%;
 `;
 
 const MaxWidth = styled.div`
@@ -105,6 +114,8 @@ interface Props {
 }
 
 const OnboardingLayout = ({ children }: Props) => {
+    const { banner } = useMessageSystem();
+
     const { activeStepId } = useOnboarding();
     const activeStep = steps.find(step => step.id === activeStepId)!;
 
@@ -114,50 +125,53 @@ const OnboardingLayout = ({ children }: Props) => {
 
     return (
         <Wrapper>
-            <MaxWidth>
-                <Header>
-                    <LogoHeaderRow>
-                        <TrezorLogo type="suite" width="128px" />
+            {banner && <MessageSystemBanner message={banner} />}
+            <Body>
+                <MaxWidth>
+                    <Header>
+                        <LogoHeaderRow>
+                            <TrezorLogo type="suite" width="128px" />
 
-                        <TrezorLink size="small" variant="nostyle" href={SUPPORT_URL}>
-                            <Button variant="tertiary" icon="EXTERNAL_LINK" alignIcon="right">
-                                <Translation id="TR_HELP" />
-                            </Button>
-                        </TrezorLink>
-                    </LogoHeaderRow>
-                    <ProgressBarRow>
-                        <StyledProgressBar
-                            guideOpen={guideOpen}
-                            steps={[
-                                {
-                                    key: 'fw',
-                                    label: <Translation id="TR_ONBOARDING_STEP_FIRMWARE" />,
-                                },
-                                {
-                                    key: 'wallet',
-                                    label: <Translation id="TR_ONBOARDING_STEP_WALLET" />,
-                                },
-                                {
-                                    key: 'pin',
-                                    label: <Translation id="TR_ONBOARDING_STEP_PIN" />,
-                                },
-                                {
-                                    key: 'coins',
-                                    label: <Translation id="TR_ONBOARDING_STEP_COINS" />,
-                                },
-                                {
-                                    key: 'final',
-                                },
-                            ]}
-                            activeStep={activeStep.stepGroup}
-                        />
-                    </ProgressBarRow>
-                </Header>
+                            <TrezorLink size="small" variant="nostyle" href={SUPPORT_URL}>
+                                <Button variant="tertiary" icon="EXTERNAL_LINK" alignIcon="right">
+                                    <Translation id="TR_HELP" />
+                                </Button>
+                            </TrezorLink>
+                        </LogoHeaderRow>
+                        <ProgressBarRow>
+                            <StyledProgressBar
+                                guideOpen={guideOpen}
+                                steps={[
+                                    {
+                                        key: 'fw',
+                                        label: <Translation id="TR_ONBOARDING_STEP_FIRMWARE" />,
+                                    },
+                                    {
+                                        key: 'wallet',
+                                        label: <Translation id="TR_ONBOARDING_STEP_WALLET" />,
+                                    },
+                                    {
+                                        key: 'pin',
+                                        label: <Translation id="TR_ONBOARDING_STEP_PIN" />,
+                                    },
+                                    {
+                                        key: 'coins',
+                                        label: <Translation id="TR_ONBOARDING_STEP_COINS" />,
+                                    },
+                                    {
+                                        key: 'final',
+                                    },
+                                ]}
+                                activeStep={activeStep.stepGroup}
+                            />
+                        </ProgressBarRow>
+                    </Header>
 
-                <Content>{children}</Content>
-            </MaxWidth>
-            <GuideButton />
-            <GuidePanel />
+                    <Content>{children}</Content>
+                </MaxWidth>
+                <GuideButton />
+                <GuidePanel />
+            </Body>
         </Wrapper>
     );
 };

--- a/packages/suite/src/components/suite/WelcomeLayout/index.tsx
+++ b/packages/suite/src/components/suite/WelcomeLayout/index.tsx
@@ -16,6 +16,13 @@ import { useGuide } from '@guide-hooks';
 
 const Wrapper = styled.div`
     display: flex;
+    flex-direction: column;
+    width: 100%;
+    height: 100%;
+`;
+
+const Body = styled.div`
+    display: flex;
     width: 100%;
     height: 100%;
 `;
@@ -80,12 +87,6 @@ const StyledTrezorLink = styled(TrezorLink)`
     margin-right: 14px;
 `;
 
-const BannerWrapper = styled.div`
-    position: absolute;
-    z-index: 1;
-    width: 100%;
-`;
-
 const SettingsWrapper = styled.div`
     align-self: flex-end;
 `;
@@ -119,76 +120,74 @@ const WelcomeLayout: React.FC = ({ children }) => {
 
     return (
         <Wrapper>
-            {banner && (
-                <BannerWrapper>
-                    <MessageSystemBanner message={banner} />
-                </BannerWrapper>
-            )}
-            <WelcomeWrapper>
-                <AnimatePresence>
-                    {!guideOpen && (
-                        <MotionWelcome
-                            initial={
-                                !firstRenderDone
-                                    ? {
-                                          width: welcomeBarWidth,
-                                      }
-                                    : { width: 0 }
-                            }
-                            animate={{
-                                width: welcomeBarWidth,
-                                transition: { duration: 0.3, bounce: 0 },
-                            }}
-                            exit={{
-                                width: 0,
-                                transition: { duration: 0.3, bounce: 0 },
-                            }}
-                        >
-                            <Expander>
-                                <TrezorLogo type="suite" width="128px" />
-                                <WelcomeTitle>
-                                    <Translation id="TR_ONBOARDING_WELCOME_HEADING" />
-                                </WelcomeTitle>
-                            </Expander>
-                            <Bottom>
-                                {isWeb() && (
-                                    <StyledTrezorLink
-                                        size="small"
-                                        variant="nostyle"
-                                        href={SUITE_URL}
-                                    >
+            {banner && <MessageSystemBanner message={banner} />}
+            <Body>
+                <WelcomeWrapper>
+                    <AnimatePresence>
+                        {!guideOpen && (
+                            <MotionWelcome
+                                initial={
+                                    !firstRenderDone
+                                        ? {
+                                              width: welcomeBarWidth,
+                                          }
+                                        : { width: 0 }
+                                }
+                                animate={{
+                                    width: welcomeBarWidth,
+                                    transition: { duration: 0.3, bounce: 0 },
+                                }}
+                                exit={{
+                                    width: 0,
+                                    transition: { duration: 0.3, bounce: 0 },
+                                }}
+                            >
+                                <Expander>
+                                    <TrezorLogo type="suite" width="128px" />
+                                    <WelcomeTitle>
+                                        <Translation id="TR_ONBOARDING_WELCOME_HEADING" />
+                                    </WelcomeTitle>
+                                </Expander>
+                                <Bottom>
+                                    {isWeb() && (
+                                        <StyledTrezorLink
+                                            size="small"
+                                            variant="nostyle"
+                                            href={SUITE_URL}
+                                        >
+                                            <Button
+                                                variant="tertiary"
+                                                icon="EXTERNAL_LINK"
+                                                alignIcon="right"
+                                            >
+                                                <Translation id="TR_ONBOARDING_DOWNLOAD_DESKTOP_APP" />
+                                            </Button>
+                                        </StyledTrezorLink>
+                                    )}
+                                    <TrezorLink size="small" variant="nostyle" href={TREZOR_URL}>
                                         <Button
                                             variant="tertiary"
                                             icon="EXTERNAL_LINK"
                                             alignIcon="right"
                                         >
-                                            <Translation id="TR_ONBOARDING_DOWNLOAD_DESKTOP_APP" />
+                                            trezor.io
                                         </Button>
-                                    </StyledTrezorLink>
-                                )}
-                                <TrezorLink size="small" variant="nostyle" href={TREZOR_URL}>
-                                    <Button
-                                        variant="tertiary"
-                                        icon="EXTERNAL_LINK"
-                                        alignIcon="right"
-                                    >
-                                        trezor.io
-                                    </Button>
-                                </TrezorLink>
-                            </Bottom>
-                        </MotionWelcome>
-                    )}
-                </AnimatePresence>
-            </WelcomeWrapper>
-            <Content>
-                <SettingsWrapper>
-                    <SettingsDropdown />
-                </SettingsWrapper>
-                {children}
-            </Content>
+                                    </TrezorLink>
+                                </Bottom>
+                            </MotionWelcome>
+                        )}
+                    </AnimatePresence>
+                </WelcomeWrapper>
+                <Content>
+                    <SettingsWrapper>
+                        <SettingsDropdown />
+                    </SettingsWrapper>
+                    {children}
+                </Content>
 
-            <GuideButton />
-            <GuidePanel />
+                <GuideButton />
+                <GuidePanel />
+            </Body>
         </Wrapper>
     );
 };

--- a/packages/suite/src/support/tests/setupJest.ts
+++ b/packages/suite/src/support/tests/setupJest.ts
@@ -446,6 +446,7 @@ const getMessageSystemConfig = (
                     en: 'New Trezor firmware is available!',
                     es: 'El nuevo firmware de Trezor está disponible!',
                     cs: 'Nová verze Trezor firmware je k dispozici',
+                    ru: 'Доступна новая прошивка Trezor!',
                 },
                 cta: {
                     action: 'internal-link',
@@ -455,6 +456,7 @@ const getMessageSystemConfig = (
                         en: 'Update now',
                         es: 'Actualizar ahora',
                         cs: 'Aktualizovat',
+                        ru: 'Обновить сейчас',
                     },
                 },
             },
@@ -471,8 +473,9 @@ const getMessageSystemConfig = (
                 content: {
                     'en-GB': 'New Trezor app is available!',
                     en: 'New Trezor app is available!',
-                    es: 'La nueva aplicación Trezor está disponible',
-                    cs: 'Nová Trezor aplikace je k dispozici',
+                    es: 'La nueva aplicación Trezor está disponible!',
+                    cs: 'Nová Trezor aplikace je k dispozici!',
+                    ru: 'Доступно новое приложение Trezor!',
                 },
                 cta: {
                     action: 'external-link',
@@ -482,6 +485,7 @@ const getMessageSystemConfig = (
                         en: 'Download now',
                         es: 'Descargar ahora',
                         cs: 'Stáhnout nyní',
+                        ru: 'Скачать сейчас',
                     },
                 },
                 modal: {
@@ -490,6 +494,7 @@ const getMessageSystemConfig = (
                         en: 'Update now',
                         es: 'Actualizar ahora',
                         cs: 'Aktualizovat',
+                        ru: 'Обновить сейчас',
                     },
                     image: 'https://example.com/example.png',
                 },


### PR DESCRIPTION
closes #4462
- feat(message-system): add prompt message to update desktop app 

fixes:
- fix(message-system): banner on welcome page
- bug settings icon: <img width="1434" alt="Screenshot 2022-01-17 at 11 58 39" src="https://user-images.githubusercontent.com/33235762/149784984-7971b6cc-16d4-4f6b-a96f-186166bb0572.png">

new: 
- feat(message-system): banner in onboarding

How to test?

1. Change app version to 21.X.X
2. `yarn msg-system-sign-config` in `packages/suite-data`
2. `yarn build:libs` to get new types
3. Run desktop app
4. Open network tab and block remote `config.v1.jsw`
5. Refresh
6. Banner should be there. 
