### PR TITLE
Fix/redux without messages

### DIFF
--- a/packages/suite-native/src/actions/settings/languageActions.ts
+++ b/packages/suite-native/src/actions/settings/languageActions.ts
@@ -1,23 +1,9 @@
 /* eslint-disable global-require */
 
 import { SUITE } from '@suite-actions/constants';
-import { Dispatch } from '@suite-types';
 import type { Locale } from '@suite-config/languages';
 
-// TODO: copy files from suite-data and then require from this package just to be consistent?
-export const fetchLocale = (locale: Locale) => (dispatch: Dispatch) => {
-    const messages: { [key: string]: any } = {
-        en: require('@trezor/suite-data/files/translations/en'),
-        // cs: require('@trezor/suite-data/files/translations/cs'),
-        // de: require('@trezor/suite-data/files/translations/de'),
-        // es: require('@trezor/suite-data/files/translations/es'),
-        // fr: require('@trezor/suite-data/files/translations/fr'),
-        // ru: require('@trezor/suite-data/files/translations/ru'),
-    };
-
-    dispatch({
-        type: SUITE.SET_LANGUAGE,
-        locale,
-        messages: messages[locale],
-    });
-};
+export const fetchLocale = (locale: Locale) => ({
+    type: SUITE.SET_LANGUAGE,
+    locale,
+});

--- a/packages/suite-native/src/actions/settings/languageActions.ts
+++ b/packages/suite-native/src/actions/settings/languageActions.ts
@@ -3,7 +3,7 @@
 import { SUITE } from '@suite-actions/constants';
 import type { Locale } from '@suite-config/languages';
 
-export const fetchLocale = (locale: Locale) => ({
+export const setLanguage = (locale: Locale) => ({
     type: SUITE.SET_LANGUAGE,
     locale,
 });

--- a/packages/suite/src/actions/settings/languageActions.ts
+++ b/packages/suite/src/actions/settings/languageActions.ts
@@ -1,21 +1,8 @@
 import { SUITE } from '@suite-actions/constants';
-import { Dispatch } from '@suite-types';
-import type { Locale } from '@suite-config/languages';
-import enLocale from '@trezor/suite-data/files/translations/en.json';
 import { ensureLocale } from '@suite-utils/l10n';
+import type { Locale } from '@suite-config/languages';
 
-export const fetchLocale = (locale: Locale) => async (dispatch: Dispatch) => {
-    const loc = ensureLocale(locale);
-    const localeOverride: { [key: string]: string } =
-        loc === 'en'
-            ? {}
-            : await import(`@trezor/suite-data/files/translations/${loc}.json`)
-                  .then(res => res.default)
-                  .catch(() => ({}));
-
-    dispatch({
-        type: SUITE.SET_LANGUAGE,
-        locale: loc,
-        messages: { ...enLocale, ...localeOverride },
-    });
-};
+export const fetchLocale = (locale: Locale) => ({
+    type: SUITE.SET_LANGUAGE,
+    locale: ensureLocale(locale),
+});

--- a/packages/suite/src/actions/settings/languageActions.ts
+++ b/packages/suite/src/actions/settings/languageActions.ts
@@ -2,7 +2,7 @@ import { SUITE } from '@suite-actions/constants';
 import { ensureLocale } from '@suite-utils/l10n';
 import type { Locale } from '@suite-config/languages';
 
-export const fetchLocale = (locale: Locale) => ({
+export const setLanguage = (locale: Locale) => ({
     type: SUITE.SET_LANGUAGE,
     locale: ensureLocale(locale),
 });

--- a/packages/suite/src/actions/suite/__fixtures__/suiteActions.ts
+++ b/packages/suite/src/actions/suite/__fixtures__/suiteActions.ts
@@ -188,18 +188,12 @@ const reducerActions = [
             {
                 type: SUITE.SET_LANGUAGE,
                 locale: 'cz',
-                messages: {
-                    key: 'value',
-                },
             },
         ],
         result: [
             {
                 settings: {
                     language: 'cz',
-                },
-                messages: {
-                    key: 'value',
                 },
             },
         ],

--- a/packages/suite/src/actions/suite/suiteActions.ts
+++ b/packages/suite/src/actions/suite/suiteActions.ts
@@ -45,7 +45,6 @@ export type SuiteAction =
     | {
           type: typeof SUITE.SET_LANGUAGE;
           locale: Locale;
-          messages: { [key: string]: string };
       }
     | { type: typeof SUITE.SET_DEBUG_MODE; payload: Partial<DebugModeOptions> }
     | { type: typeof SUITE.ONLINE_STATUS; payload: boolean }

--- a/packages/suite/src/components/suite/Settings/components/Language.tsx
+++ b/packages/suite/src/components/suite/Settings/components/Language.tsx
@@ -44,8 +44,8 @@ const Language = () => {
         language: state.suite.settings.language,
         autodetectLanguage: state.suite.settings.autodetect.language,
     }));
-    const { fetchLocale, setAutodetect } = useActions({
-        fetchLocale: languageActions.fetchLocale,
+    const { setLanguage, setAutodetect } = useActions({
+        setLanguage: languageActions.setLanguage,
         setAutodetect: setAutodetectAction,
     });
 
@@ -64,7 +64,7 @@ const Language = () => {
             setAutodetect({ language: !autodetectLanguage });
         }
         if (value !== 'system') {
-            fetchLocale(value);
+            setLanguage(value);
             analytics.report({
                 type: 'settings/general/change-language',
                 payload: {

--- a/packages/suite/src/middlewares/suite/suiteMiddleware.ts
+++ b/packages/suite/src/middlewares/suite/suiteMiddleware.ts
@@ -66,7 +66,7 @@ const suite =
                 // 3. redirecting user into welcome screen (if needed)
                 await Promise.all([
                     api.dispatch(
-                        languageActions.fetchLocale(action.payload.suite.settings.language),
+                        languageActions.setLanguage(action.payload.suite.settings.language),
                     ),
                     api.dispatch(messageSystemActions.init()),
                     api.dispatch(routerActions.initialRedirection()),

--- a/packages/suite/src/reducers/suite/suiteReducer.ts
+++ b/packages/suite/src/reducers/suite/suiteReducer.ts
@@ -55,7 +55,6 @@ export interface SuiteState {
     dbError?: 'blocking' | 'blocked' | undefined; // blocked if the instance cannot upgrade due to older version running, blocking in case instance is running older version thus blocking other instance
     transport?: Partial<TransportInfo>;
     device?: TrezorDevice;
-    messages: { [key: string]: any };
     locks: Lock[];
     flags: Flags;
     settings: SuiteSettings;
@@ -67,7 +66,6 @@ const initialState: SuiteState = {
     loading: false,
     storageLoaded: false,
     loaded: false,
-    messages: {},
     locks: [],
     flags: {
         initialRun: true,
@@ -149,7 +147,6 @@ const suiteReducer = (state: SuiteState = initialState, action: Action): SuiteSt
 
             case SUITE.SET_LANGUAGE:
                 draft.settings.language = action.locale;
-                draft.messages = action.messages;
                 break;
 
             case SUITE.SET_DEBUG_MODE:

--- a/packages/suite/src/support/suite/Autodetect.tsx
+++ b/packages/suite/src/support/suite/Autodetect.tsx
@@ -14,9 +14,9 @@ const Autodetect = () => {
             currentLanguage: state.suite.settings.language,
             storageLoaded: state.suite.storageLoaded,
         }));
-    const { setTheme, fetchLocale } = useActions({
+    const { setTheme, setLanguage } = useActions({
         setTheme: setThemeAction,
-        fetchLocale: languageActions.fetchLocale,
+        setLanguage: languageActions.setLanguage,
     });
 
     useEffect(() => {
@@ -33,11 +33,11 @@ const Autodetect = () => {
         if (!storageLoaded || !autodetectLanguage) return;
         const osLocale = getOsLocale(currentLanguage);
         if (osLocale !== currentLanguage) {
-            fetchLocale(osLocale);
+            setLanguage(osLocale);
         }
-        const unwatch = watchOsLocale(fetchLocale);
+        const unwatch = watchOsLocale(setLanguage);
         return () => unwatch();
-    }, [storageLoaded, autodetectLanguage, currentLanguage, fetchLocale]);
+    }, [storageLoaded, autodetectLanguage, currentLanguage, setLanguage]);
 
     return null;
 };

--- a/packages/suite/src/support/suite/ConnectedIntlProvider.tsx
+++ b/packages/suite/src/support/suite/ConnectedIntlProvider.tsx
@@ -1,13 +1,37 @@
-import * as React from 'react';
+import React, { useState, useEffect } from 'react';
 import { IntlProvider } from 'react-intl';
+import enMessages from '@trezor/suite-data/files/translations/en.json';
 import { useSelector } from '@suite-hooks/useSelector';
 import { isDev } from '@suite-utils/build';
+import type { Locale } from '@suite-config/languages';
+
+const useFetchMessages = (locale: Locale) => {
+    const [messages, setMessages] = useState<{ [key: string]: any }>({});
+
+    useEffect(() => {
+        let active = true;
+        const fetchMessages = async () => {
+            const messages =
+                locale === 'en'
+                    ? {}
+                    : await import(`@trezor/suite-data/files/translations/${locale}.json`)
+                          .then(res => res.default)
+                          .catch(() => ({}));
+            if (!active) return;
+            setMessages({ ...enMessages, ...messages });
+        };
+        fetchMessages();
+        return () => {
+            active = false;
+        };
+    }, [locale]);
+
+    return messages;
+};
 
 const ConnectedIntlProvider: React.FC = ({ children }) => {
-    const { locale, messages } = useSelector(state => ({
-        locale: state.suite.settings.language,
-        messages: state.suite.messages,
-    }));
+    const locale = useSelector(state => state.suite.settings.language);
+    const messages = useFetchMessages(locale);
     return (
         <IntlProvider
             locale={locale}


### PR DESCRIPTION
Remove translated messages for react-intl from redux store and fetch them directly instead.