### PR TITLE
chore: update trezor-connect with blockchain-link@2.0

### DIFF
--- a/packages/connect-iframe/package.json
+++ b/packages/connect-iframe/package.json
@@ -17,7 +17,7 @@
     },
     "dependencies": {},
     "devDependencies": {
-        "@trezor/blockchain-link": "1.1.0",
+        "@trezor/blockchain-link": "2.0.0",
         "@trezor/connect-common": "^0.0.4",
         "@trezor/rollout": "^1.2.1",
         "@trezor/transport": "1.0.1",

--- a/packages/suite/package.json
+++ b/packages/suite/package.json
@@ -60,7 +60,7 @@
         "semver": "^7.3.5",
         "styled-components": "^5.3.3",
         "trezor-address-validator": "^0.4.2",
-        "trezor-connect": "8.2.6-beta.2",
+        "trezor-connect": "8.2.7-beta.2",
         "ua-parser-js": "^1.0.2",
         "uuid": "^8.3.2",
         "web3-utils": "^1.6.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -5333,18 +5333,6 @@
   dependencies:
     tippy.js "^6.3.1"
 
-"@trezor/blockchain-link@1.1.0":
-  version "1.1.0"
-  resolved "https://registry.yarnpkg.com/@trezor/blockchain-link/-/blockchain-link-1.1.0.tgz#065d18d7c948c4de45437fc2178d9e26a7c2304b"
-  integrity sha512-tH3hLG54VZ52Y6Fxdw51kqORbuzUSt1VReISj/oZROMexmDDCRgFR14/wxasjHp94XRYrx8777Boa1qrpAos4w==
-  dependencies:
-    bignumber.js "^9.0.1"
-    es6-promise "^4.2.8"
-    events "^3.2.0"
-    ripple-lib "1.10.0"
-    tiny-worker "^2.3.0"
-    ws "^7.4.0"
-
 "@tsconfig/node10@^1.0.7":
   version "1.0.8"
   resolved "https://registry.yarnpkg.com/@tsconfig/node10/-/node10-1.0.8.tgz#c1e4e80d6f964fbecb3359c43bd48b40f7cadad9"
@@ -11560,7 +11548,7 @@ es6-object-assign@^1.1.0:
   resolved "https://registry.yarnpkg.com/es6-object-assign/-/es6-object-assign-1.1.0.tgz#c2c3582656247c39ea107cb1e6652b6f9f24523c"
   integrity sha1-wsNYJlYkfDnqEHyx5mUrb58kUjw=
 
-es6-promise@^4.0.3, es6-promise@^4.2.8:
+es6-promise@^4.0.3:
   version "4.2.8"
   resolved "https://registry.yarnpkg.com/es6-promise/-/es6-promise-4.2.8.tgz#4eb21594c972bc40553d276e510539143db53e0a"
   integrity sha512-HJDGx5daxeIvxdBxvG2cb9g4tEvwIk3i8+nhX0yGrYmZUzbkdg8QbDevheDB8gd0//uPj4c1EQua8Q+MViT0/w==
@@ -20622,7 +20610,7 @@ ramda@^0.21.0:
   resolved "https://registry.yarnpkg.com/ramda/-/ramda-0.21.0.tgz#a001abedb3ff61077d4ff1d577d44de77e8d0a35"
   integrity sha1-oAGr7bP/YQd9T/HVd9RN536NCjU=
 
-randombytes@^2.0.0, randombytes@^2.0.1, randombytes@^2.0.5, randombytes@^2.1.0:
+randombytes@2.1.0, randombytes@^2.0.0, randombytes@^2.0.1, randombytes@^2.0.5, randombytes@^2.1.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/randombytes/-/randombytes-2.1.0.tgz#df6f84372f0270dc65cdf6291349ab7a473d4f2a"
   integrity sha512-vYl3iOX+4CKUWuxGi9Ukhie6fsqXqS9FE2Zaic4tNFD2N2QQaXOMFbuKK4QmDHC0JO6B1Zp41J0LpT0oR68amQ==
@@ -24345,13 +24333,13 @@ trezor-address-validator@^0.4.2:
     jssha "2.3.1"
     lodash "^4.17.15"
 
-trezor-connect@8.2.6-beta.2:
-  version "8.2.6-beta.2"
-  resolved "https://registry.yarnpkg.com/trezor-connect/-/trezor-connect-8.2.6-beta.2.tgz#635912bc16abff1a2fab13afbc1106c04a472165"
-  integrity sha512-SfCWEYJ1Us3ibd3y1oOHWWuUZxdkkskhakKNKj1JqjIGkYKErsqtmq1dE4LQUvN2VUfy0z9fI4z+27wd1TmZWg==
+trezor-connect@8.2.7-beta.2:
+  version "8.2.7-beta.2"
+  resolved "https://registry.yarnpkg.com/trezor-connect/-/trezor-connect-8.2.7-beta.2.tgz#94dfe8625bcd402450e6956923ecbabe54195356"
+  integrity sha512-H/GoMtFUwGn2xq53G5yMRgwzmlVJoE2R0LNSLMdNlgu817nPydS1JPhfIUGGZPn1DBec6bE3SXVjNEf3ZFRzbg==
   dependencies:
     "@babel/runtime" "^7.15.4"
-    "@trezor/blockchain-link" "1.1.0"
+    "@trezor/blockchain-link" "2.0.0"
     "@trezor/connect-common" "0.0.4"
     "@trezor/rollout" "^1.2.1"
     "@trezor/transport" "1.0.1"
@@ -24362,7 +24350,7 @@ trezor-connect@8.2.6-beta.2:
     cross-fetch "^3.1.4"
     events "^3.3.0"
     parse-uri "^1.0.3"
-    tiny-worker "^2.3.0"
+    randombytes "2.1.0"
 
 trim-newlines@^1.0.0:
   version "1.0.0"
@@ -26075,7 +26063,7 @@ write-pkg@^3.1.0:
     sort-keys "^2.0.0"
     write-json-file "^2.2.0"
 
-ws@7.4.6, ws@^7, ws@^7.2.0, ws@^7.2.3, ws@^7.3.1, ws@^7.4.0:
+ws@7.4.6, ws@^7, ws@^7.2.0, ws@^7.2.3, ws@^7.3.1:
   version "7.4.6"
   resolved "https://registry.yarnpkg.com/ws/-/ws-7.4.6.tgz#5654ca8ecdeee47c33a9a4bf6d28e2be2980377c"
   integrity sha512-YmhHDO4MzaDLB+M9ym/mDA5z0naX8j7SIlT8f8z+I0VtzsRbekxEutHSme7NPS2qE8StCYQNUnfWdXta/Yu85A==


### PR DESCRIPTION
cherry-picked from https://github.com/trezor/trezor-suite/pull/4704

connect in electron is still in progress, but blockchain-link 2.0 is already in develop, lets use it