### PR TITLE
chore(ci): Add deduplicate check to CI

### DIFF
--- a/.github/workflows/validation.yml
+++ b/.github/workflows/validation.yml
@@ -7,14 +7,18 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2.0.0
-      - name: Install dependencies
+      - name: Install node and yarn
         uses: actions/setup-node@v2
         with:
           node-version-file: ".nvmrc"
       - run: |
           npm install -g yarn
-          yarn
-          yarn build:libs
+      - name: deduplicate deps
+        run: npx yarn-deduplicate --list --fail
+      - name: install deps
+        run: yarn
+      - name: build libs
+        run: yarn build:libs
       - name: type check
         run: yarn type-check
       - name: lint

--- a/ci/validation.yml
+++ b/ci/validation.yml
@@ -1,6 +1,7 @@
 lint:
   stage: validation
   script:
+    - npx yarn-deduplicate --list --fail
     - yarn install --frozen-lockfile --cache-folder .yarn --prefer-offline
     - yarn build:libs
     - yarn lint

--- a/package.json
+++ b/package.json
@@ -85,6 +85,7 @@
         "ts-jest": "^26.5.4",
         "ts-node": "^10.3.0",
         "tsconfig-paths": "^3.9.0",
-        "typescript": "4.4.4"
+        "typescript": "4.4.4",
+        "yarn-deduplicate": "^3.1.0"
     }
 }

--- a/package.json
+++ b/package.json
@@ -32,7 +32,8 @@
         "test:unit": "yarn lerna run test:unit",
         "lint:js": "eslint --cache --ignore-path .gitignore --ext .js,.ts,.tsx ./",
         "lint": "yarn lerna run lint:styles && yarn lint:js",
-        "lint-staged": "npx lint-staged"
+        "lint-staged": "npx lint-staged",
+        "deduplicate": "yarn-deduplicate && yarn"
     },
     "lint-staged": {
         "packages/**/*.{ts,tsx}": [

--- a/yarn.lock
+++ b/yarn.lock
@@ -8585,7 +8585,7 @@ commander@^5.0.0, commander@^5.1.0:
   resolved "https://registry.yarnpkg.com/commander/-/commander-5.1.0.tgz#46abbd1652f8e059bddaef99bbdcb2ad9cf179ae"
   integrity sha512-P0CysNDQ7rtVw4QIQtm+MRxV66vKFSvlsQvGYXZWR3qFU0jlMKHZZZgw8e+8DSah4UDKMqnknRDQz+xuQXQ/Zg==
 
-commander@^6.2.0, commander@^6.2.1:
+commander@^6.1.0, commander@^6.2.0, commander@^6.2.1:
   version "6.2.1"
   resolved "https://registry.yarnpkg.com/commander/-/commander-6.2.1.tgz#0792eb682dfbc325999bb2b84fddddba110ac73c"
   integrity sha512-U7VdrJFnJgo4xjrHpTzu0yrHPGImdsmD95ZlgYSEajAn2JKzDhDTPG9kBTefmObL2w/ngeZnilk+OV9CG3d7UA==
@@ -25390,6 +25390,15 @@ yargs@^17.0.1:
     string-width "^4.2.0"
     y18n "^5.0.5"
     yargs-parser "^20.2.2"
+
+yarn-deduplicate@^3.1.0:
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/yarn-deduplicate/-/yarn-deduplicate-3.1.0.tgz#3018d93e95f855f236a215b591fe8bc4bcabba3e"
+  integrity sha512-q2VZ6ThNzQpGfNpkPrkmV7x5HT9MOhCUsTxVTzyyZB0eSXz1NTodHn+r29DlLb+peKk8iXxzdUVhQG9pI7moFw==
+  dependencies:
+    "@yarnpkg/lockfile" "^1.1.0"
+    commander "^6.1.0"
+    semver "^7.3.2"
 
 yauzl@^2.10.0:
   version "2.10.0"


### PR DESCRIPTION
Add check if some dependencies could be deduplicated. This is quite important because it will force us to do deduplication with every change in `yarn.lock` so we can avoid huge deduplication in future.

I also separated some steps in Github YML because deduplication check is super fast and can be run before anything else.

**Important:**
**After this will be merged, every change in `yarn.lock` must be followed by calling `yarn deduplicate`.**

Hopefully we will migrate to Yarn v2 soon we will get rid of this stuff.