### PR TITLE
chore(ci): set permissions for github token on workflow

### DIFF
--- a/.github/workflows/project-automation.yml
+++ b/.github/workflows/project-automation.yml
@@ -1,5 +1,13 @@
 name: Add to GitHub Project
+
 on: [issues]
+
+permissions:
+  contents: read
+  pull-requests: write
+  issues: write
+  repository-projects: write
+
 jobs:
   github-actions-automate-projects:
     runs-on: ubuntu-latest


### PR DESCRIPTION
This will set up permissions for GitHub token to only access issues pr and project. If the automation on the marketplace gets compromised, the job would not be able to access anything else.