### PR TITLE
Add charset parameter to content-type header

### DIFF
--- a/packages/suite/src/actions/wallet/signVerifyActions.ts
+++ b/packages/suite/src/actions/wallet/signVerifyActions.ts
@@ -220,7 +220,7 @@ export const sendAopp =
 
         const { success, error } = await fetch(callback, {
             method: 'POST',
-            headers: { 'content-type': 'application/json; utf-8' },
+            headers: { 'content-type': 'application/json; charset=utf-8' },
             body: JSON.stringify({
                 version: 0,
                 address,


### PR DESCRIPTION
I think the `charset` directive specified [here](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Content-Type#directives) is missing. 