### PR TITLE
[wip] feat: desktop modules bundle optimization

### DIFF
--- a/packages/suite-desktop/package.json
+++ b/packages/suite-desktop/package.json
@@ -46,7 +46,18 @@
             "!build/static/bin/**/*",
             "dist/**/*.js",
             "!dist/__**",
-            "package.json"
+            "package.json",
+            "!node_modules/lodash/**",
+            "!node_modules/react/**",
+            "!node_modules/react-dom/**",
+            "!node_modules/styled-components/**",
+            "!node_modules/@babel/**",
+            "!node_modules/babel-*/**",
+            "!node_modules/hoist-non-react-statics/**",
+            "!node_modules/react-is/**",
+            "!node_modules/openpgp/**",
+            "node_modules/openpgp/package.json",
+            "node_modules/openpgp/dist/node"
         ],
         "extraResources": [
             {

--- a/packages/suite-desktop/scripts/build.js
+++ b/packages/suite-desktop/scripts/build.js
@@ -15,10 +15,6 @@ const useMocks = USE_MOCKS === 'true' || (isDev && USE_MOCKS !== 'false');
 // Get git revision
 const gitRevision = child_process.execSync('git rev-parse HEAD').toString().trim();
 
-// Get all modules (used as entry points)
-const modulePath = path.join(electronSource, 'modules');
-const modules = glob.sync(`${modulePath}/**/*.ts`).map(m => `modules${m.replace(modulePath, '')}`);
-
 // Prepare mock plugin with files from the mocks folder
 const mockPath = path.join(electronSource, 'mocks');
 const mocks = glob
@@ -45,18 +41,19 @@ console.log(`[Electron Build] Mode: ${isDev ? 'development' : 'production'}`);
 console.log(`[Electron Build] Using mocks: ${useMocks}`);
 
 build({
-    entryPoints: ['app.ts', 'preload.ts', ...modules].map(f => path.join(electronSource, f)),
+    entryPoints: ['app.ts', 'preload.ts'].map(f => path.join(electronSource, f)),
     platform: 'node',
     bundle: true,
     target: 'node16.5.0', // Electron 15
     external: Object.keys({
         ...pkg.dependencies,
-        ...pkg.devDependencies,
+        ...pkg.devDependencies
     }),
     tsconfig: path.join(electronSource, 'tsconfig.json'),
     sourcemap: isDev,
     minify: !isDev,
     outdir: path.join(__dirname, '..', 'dist'),
+
     define: {
         'process.env.NODE_ENV': JSON.stringify(NODE_ENV),
         'process.env.COMMITHASH': JSON.stringify(gitRevision),

--- a/packages/suite-desktop/scripts/build.js
+++ b/packages/suite-desktop/scripts/build.js
@@ -45,15 +45,17 @@ build({
     platform: 'node',
     bundle: true,
     target: 'node16.5.0', // Electron 15
-    external: Object.keys({
-        ...pkg.dependencies,
-        ...pkg.devDependencies
-    }),
+    external: [
+        // app won't run without:
+        'electron',
+        // appear in both preload and app.js
+        'encoding',
+        'node-fetch',
+    ],
     tsconfig: path.join(electronSource, 'tsconfig.json'),
     sourcemap: isDev,
     minify: !isDev,
     outdir: path.join(__dirname, '..', 'dist'),
-
     define: {
         'process.env.NODE_ENV': JSON.stringify(NODE_ENV),
         'process.env.COMMITHASH': JSON.stringify(gitRevision),

--- a/packages/suite-desktop/src-electron/app.ts
+++ b/packages/suite-desktop/src-electron/app.ts
@@ -8,8 +8,8 @@ import * as store from '@desktop-electron/libs/store';
 import { MIN_HEIGHT, MIN_WIDTH } from '@desktop-electron/libs/screen';
 import Logger, { LogLevel, defaultOptions as loggerDefaults } from '@desktop-electron/libs/logger';
 import { buildInfo, computerInfo } from '@desktop-electron/libs/info';
-import modules from '@desktop-electron/libs/modules';
 import { createInterceptor } from '@desktop-electron/libs/request-interceptor';
+import modules from '@desktop-electron/libs/modules';
 
 let mainWindow: BrowserWindow;
 const APP_NAME = 'Trezor Suite';

--- a/packages/suite-desktop/src-electron/libs/constants.ts
+++ b/packages/suite-desktop/src-electron/libs/constants.ts
@@ -2,38 +2,6 @@ import { TOR_URLS } from '@suite-constants/tor';
 
 export const PROTOCOL = 'file';
 
-// General modules (both dev & prod)
-export const MODULES = [
-    // Event Logging
-    'event-logging/process',
-    'event-logging/app',
-    'event-logging/contents',
-    // Standard modules
-    'crash-recover',
-    'hang-detect',
-    'menu',
-    'shortcuts',
-    'request-filter',
-    'external-links',
-    'window-controls',
-    'theme',
-    'http-receiver',
-    'metadata',
-    'bridge',
-    'tor',
-    'custom-protocols',
-    'auto-updater',
-    'store',
-    'udev-install',
-    'user-data',
-];
-
-// Modules only used in prod mode
-export const MODULES_PROD = ['csp', 'file-protocol'];
-
-// Modules only used in dev mode
-export const MODULES_DEV = ['dev-tools'];
-
 // HTTP server default origins
 export const HTTP_ORIGINS_DEFAULT = [
     '127.0.0.1',

--- a/packages/suite-desktop/src-electron/libs/modules.ts
+++ b/packages/suite-desktop/src-electron/libs/modules.ts
@@ -1,26 +1,72 @@
-/* eslint-disable import/no-dynamic-require */
-/* eslint-disable global-require */
-import { MODULES, MODULES_DEV, MODULES_PROD } from '@desktop-electron/libs/constants';
 import { isDev } from '@suite-utils/build';
+
+import * as eventLoggingProcess from '../modules/event-logging/process';
+import * as eventLoggingApp from '../modules/event-logging/app';
+import * as eventLoggingContents from '../modules/event-logging/contents';
+import * as crashRecover from '../modules/crash-recover';
+import * as hangDetect from '../modules/hang-detect';
+import * as menu from '../modules/menu';
+import * as shortcuts from '../modules/shortcuts';
+import * as requestFilter from '../modules/request-filter';
+import * as externalLinks from '../modules/external-links';
+import * as windowControls from '../modules/window-controls';
+import * as theme from '../modules/theme';
+import * as httpReceiver from '../modules/http-receiver';
+import * as metadata from '../modules/metadata';
+import * as bridge from '../modules/bridge';
+import * as tor from '../modules/tor';
+import * as customProtocol from '../modules/custom-protocols';
+import * as autoUpdater from '../modules/auto-updater';
+import * as store from '../modules/store';
+import * as udevInstall from '../modules/udev-install';
+
+// Modules only used in prod mode
+import * as csp from '../modules/csp';
+import * as fileProtocol from '../modules/file-protocol';
+
+// Modules only used in dev mode
+import * as devTools from '../modules/dev-tools';
+
+const common = [
+    eventLoggingProcess,
+    eventLoggingApp,
+    eventLoggingContents,
+    crashRecover,
+    hangDetect,
+    menu,
+    shortcuts,
+    requestFilter,
+    externalLinks,
+    windowControls,
+    theme,
+    httpReceiver,
+    metadata,
+    bridge,
+    tor,
+    customProtocol,
+    autoUpdater,
+    store,
+    udevInstall,
+];
+
+const prod = [csp, fileProtocol];
+
+const dev = [devTools];
 
 const modules = async (dependencies: Dependencies) => {
     const { logger } = global;
+    const finalModules = [...common, ...(isDev ? dev : prod)];
+    logger.info('modules', `Loading ${finalModules.length} modules`);
 
-    logger.info('modules', `Loading ${MODULES.length} modules`);
+    const promises = finalModules.map(async module => {
+        try {
+            await module.default(dependencies);
+        } catch (err) {
+            logger.error('modules', `Couldn't load ${module} (${err.toString()})`);
+        }
+    });
 
-    await Promise.all(
-        [...MODULES, ...(isDev ? MODULES_DEV : MODULES_PROD)].flatMap(async module => {
-            logger.debug('modules', `Loading ${module}`);
-
-            try {
-                const m = await require(`./modules/${module}`);
-                return [m.default(dependencies)];
-            } catch (err) {
-                logger.error('modules', `Couldn't load ${module} (${err.toString()})`);
-            }
-        }),
-    );
-
+    await Promise.all(promises);
     logger.info('modules', 'All modules loaded');
 };
 

--- a/packages/suite-desktop/src-electron/modules/file-protocol.ts
+++ b/packages/suite-desktop/src-electron/modules/file-protocol.ts
@@ -10,7 +10,7 @@ const init = ({ mainWindow, src }: Dependencies) => {
     // Point to the right directory for file protocol requests
     session.defaultSession.protocol.interceptFileProtocol(PROTOCOL, (request, callback) => {
         let url = request.url.substr(PROTOCOL.length + 1);
-        url = path.join(__dirname, '..', '..', 'build', url);
+        url = path.join(__dirname, '..', 'build', url);
         callback(url);
     });
 

--- a/packages/suite-desktop/src-electron/modules/http-receiver.ts
+++ b/packages/suite-desktop/src-electron/modules/http-receiver.ts
@@ -7,10 +7,10 @@ import { buyRedirectHandler } from '@desktop-electron/libs/buy';
 import { sellRedirectHandler } from '@desktop-electron/libs/sell';
 import { HttpReceiver } from '@desktop-electron/libs/http-receiver';
 
-// External request handler
-const httpReceiver = new HttpReceiver();
-
 const init = ({ mainWindow, src }: Dependencies) => {
+    // External request handler
+    const httpReceiver = new HttpReceiver();
+
     const { logger } = global;
 
     // wait for httpReceiver to start accepting connections then register event handlers

--- a/packages/suite-desktop/src-electron/modules/metadata.ts
+++ b/packages/suite-desktop/src-electron/modules/metadata.ts
@@ -6,7 +6,7 @@ import { save, read } from '@desktop-electron/libs/user-data';
 
 const DATA_DIR = '/metadata';
 
-export const init = () => {
+const init = () => {
     const { logger } = global;
 
     ipcMain.handle('metadata/write', async (_, message) => {


### PR DESCRIPTION
# WIP. Experimens with bundle size


`du -h filename`

|                 | Trezor-Suite-22.1.0-linux-x86_64.AppImage  | 
|--------------|-------------------------------------------------------------|
| develop   | 141M  (144156)                                               |
| 4b8f452   | 141M (144136)                                               | 
| 8f96606  | 135M (137896)                                               |

commits: 
- 4b8f452 removed multiple entrypoints for modules to address the original concern that each bundled file may contain duplicated code. so at the moment, bundled `app.js`  only contains about [900 lines of code](https://gist.github.com/mroz22/f21b86d45de3a239dd0eb42cc702791c#file-app-js-L69) from `../suite/node_modules/ua-parser-js/src/ua-parser.js` which is a module imported by `suite-desktop` via `suite` which is bundled into `app.js` and not omitted like all other modules because it is not listed in `suite-desktop/package.json` and thus not part of `buid.js` `extraDependencies` field 
- 8f96606 electron-builder is now bundling unnecessary modules within node_modules folder. this commit removes some of them. Maybe I was too aggressive here.