### PR TITLE
Feat/4503 bigger receiving qr code

### DIFF
--- a/packages/suite/src/components/suite/QrCode/index.tsx
+++ b/packages/suite/src/components/suite/QrCode/index.tsx
@@ -5,7 +5,7 @@ import { colors } from '@trezor/components';
 
 const Wrapper = styled.div`
     margin: 0 auto 28px;
-    padding: 4px; /* some qr code scanners can't recognize qr codes on dark background, having white border around helps with this */
+    padding: 12px; /* some qr code scanners can't recognize qr codes on dark background, having white border around helps with this */
     background: ${colors.BG_WHITE};
 `;
 

--- a/packages/suite/src/components/suite/QrCode/index.tsx
+++ b/packages/suite/src/components/suite/QrCode/index.tsx
@@ -4,10 +4,7 @@ import styled from 'styled-components';
 import { colors } from '@trezor/components';
 
 const Wrapper = styled.div`
-    display: flex;
-    flex-direction: column;
-    align-items: center;
-    margin-right: 28px;
+    margin: 0 auto 28px;
     padding: 4px; /* some qr code scanners can't recognize qr codes on dark background, having white border around helps with this */
     background: ${colors.BG_WHITE};
 `;
@@ -15,16 +12,20 @@ const Wrapper = styled.div`
 interface Props {
     value: string;
     className?: string;
+    size?: number;
+    width?: string | number;
+    height?: string | number;
 }
 
-const QrCode = (props: Props) => (
-    <Wrapper className={props.className}>
+const QrCode = ({ className, value, size, width, height }: Props) => (
+    <Wrapper className={className}>
         <QRCode
             bgColor={colors.BG_WHITE}
             fgColor={colors.TYPE_DARK_GREY}
             level="Q"
-            style={{ width: '80px', height: '80px' }}
-            value={props.value}
+            size={size}
+            style={{ width, height }}
+            value={value}
         />
     </Wrapper>
 );

--- a/packages/suite/src/components/suite/QrCode/index.tsx
+++ b/packages/suite/src/components/suite/QrCode/index.tsx
@@ -1,33 +1,33 @@
 import React from 'react';
 import QRCode from 'qrcode.react';
 import styled from 'styled-components';
+
 import { colors } from '@trezor/components';
 
+export const QRCODE_SIZE = 384;
+export const QRCODE_PADDING = 12;
+
 const Wrapper = styled.div`
-    margin: 0 auto 28px;
-    padding: 12px; /* some qr code scanners can't recognize qr codes on dark background, having white border around helps with this */
+    margin: 0 auto 20px;
+
+    /* some qr code scanners can't recognize qr codes on dark background, having white border around helps with this */
+    padding: ${QRCODE_PADDING}px;
     background: ${colors.BG_WHITE};
 `;
 
-interface Props {
+interface QrCodeProps {
     value: string;
-    className?: string;
-    size?: number;
-    width?: string | number;
-    height?: string | number;
 }
 
-const QrCode = ({ className, value, size, width, height }: Props) => (
-    <Wrapper className={className}>
+export const QrCode = ({ value }: QrCodeProps) => (
+    <Wrapper>
         <QRCode
             bgColor={colors.BG_WHITE}
             fgColor={colors.TYPE_DARK_GREY}
             level="Q"
-            size={size}
-            style={{ width, height }}
+            size={QRCODE_SIZE}
             value={value}
+            style={{ width: '100%', height: 'auto' }}
         />
     </Wrapper>
 );
-
-export default QrCode;

--- a/packages/suite/src/components/suite/index.tsx
+++ b/packages/suite/src/components/suite/index.tsx
@@ -20,7 +20,6 @@ import BundleLoader from './BundleLoader';
 import FiatValue from './FiatValue';
 import WebusbButton from './WebusbButton';
 import { HiddenPlaceholder } from './HiddenPlaceholder';
-import QrCode from './QrCode';
 import { QuestionTooltip } from './QuestionTooltip';
 import TransactionsGraph from './TransactionsGraph';
 
@@ -78,7 +77,6 @@ export {
     BundleLoader,
     WebusbButton,
     HiddenPlaceholder,
-    QrCode,
     AccountLabeling,
     AddressLabeling,
     WalletLabeling,

--- a/packages/suite/src/components/suite/modals/confirm/Address/components/DeviceDisconnected.tsx
+++ b/packages/suite/src/components/suite/modals/confirm/Address/components/DeviceDisconnected.tsx
@@ -1,11 +1,11 @@
 import React from 'react';
 import styled from 'styled-components';
-import { P } from '@trezor/components';
+
+import { P, variables } from '@trezor/components';
 import { Translation, Image } from '@suite-components';
 
 const Wrapper = styled.div`
     display: flex;
-    margin: 20px 0px;
     text-align: left;
     background: ${props => props.theme.BG_GREY};
     align-items: center;
@@ -23,16 +23,21 @@ const Col = styled.div`
 const ContentCol = styled(Col)`
     padding: 16px 24px;
 `;
+
 const ImageCol = styled(Col)`
     padding: 16px;
+
+    @media (max-width: ${variables.SCREEN_SIZE.SM}) {
+        display: none;
+    }
 `;
 
-interface Props {
+interface DeviceDisconnectedProps {
     label: string;
 }
 
-const DeviceDisconnected = ({ label }: Props) => (
-    <Wrapper>
+const DeviceDisconnected = ({ label, ...rest }: DeviceDisconnectedProps) => (
+    <Wrapper {...rest}>
         <ContentCol>
             <P size="small">
                 <Translation

--- a/packages/suite/src/components/suite/modals/confirm/Address/index.tsx
+++ b/packages/suite/src/components/suite/modals/confirm/Address/index.tsx
@@ -1,42 +1,48 @@
 import React, { createRef } from 'react';
 import styled from 'styled-components';
+
 import * as notificationActions from '@suite-actions/notificationActions';
-import { Button, variables, ConfirmOnDevice, Box } from '@trezor/components';
+import { Button, variables, ConfirmOnDevice } from '@trezor/components';
 import { copyToClipboard } from '@suite-utils/dom';
 import { TrezorDevice } from '@suite-types';
-import { Translation, QrCode, Modal } from '@suite-components';
+import { Translation, Modal } from '@suite-components';
 import { useActions } from '@suite-hooks';
 import DeviceDisconnected from './components/DeviceDisconnected';
+import { QrCode, QRCODE_PADDING, QRCODE_SIZE } from '@suite-components/QrCode';
 
 const Wrapper = styled.div`
     display: flex;
     flex-direction: column;
     align-self: center;
-`;
-
-const StyledBox = styled(Box)`
-    flex-direction: column;
     padding: 30px 24px;
 `;
 
-const Address = styled.span`
+const Address = styled.span<{ confirmed?: boolean }>`
     font-size: ${variables.FONT_SIZE.NORMAL};
     color: ${props => props.theme.TYPE_DARK_GREY};
     font-weight: ${variables.FONT_WEIGHT.MEDIUM};
+    font-variant-numeric: tabular-nums slashed-zero;
+    margin-bottom: ${props => (props.confirmed ? '20px' : '0')};
+    width: 100%;
+    background: ${props => props.theme.BG_LIGHT_GREY};
+    border: 1px solid ${props => props.theme.STROKE_GREY};
     border-radius: 8px;
     word-break: break-all;
-    font-variant-numeric: tabular-nums slashed-zero;
+    padding: 10px;
+    max-width: calc(${QRCODE_SIZE}px + ${QRCODE_PADDING * 2}px);
 `;
 
 const CopyButtonWrapper = styled.div`
     display: flex;
     justify-content: center;
-    margin-top: 14px;
+    height: 23px; /* height of tertiary button */
 `;
 
-const QRCODE_SIZE = 384;
+const StyledDeviceDisconnected = styled(DeviceDisconnected)`
+    max-width: calc(${QRCODE_SIZE}px + ${QRCODE_PADDING * 2}px);
+`;
 
-type Props = {
+type ConfirmAddressProps = {
     device: TrezorDevice;
     address: string;
     symbol: string;
@@ -45,7 +51,14 @@ type Props = {
     onCancel?: () => void;
 };
 
-const ConfirmAddress = ({ device, address, symbol, cancelable, confirmed, onCancel }: Props) => {
+const ConfirmAddress = ({
+    device,
+    address,
+    symbol,
+    cancelable,
+    confirmed,
+    onCancel,
+}: ConfirmAddressProps) => {
     // TODO: no-backup, backup failed
     // const needsBackup = device.features && device.features.needs_backup;
 
@@ -80,26 +93,25 @@ const ConfirmAddress = ({ device, address, symbol, cancelable, confirmed, onCanc
             }
             cancelable={cancelable}
             onCancel={onCancel}
-            // size="large"
             useFixedWidth={false}
         >
             <Wrapper>
-                <StyledBox>
-                    <QrCode value={address} size={QRCODE_SIZE} width="100%" height="100%" />
-                    <Address data-test="@modal/confirm-address/address-field">{address}</Address>
+                <QrCode value={address} />
+                <Address data-test="@modal/confirm-address/address-field" confirmed={confirmed}>
+                    {address}
+                </Address>
+                <CopyButtonWrapper ref={htmlElement}>
                     {confirmed && (
-                        <CopyButtonWrapper ref={htmlElement}>
-                            <Button
-                                data-test="@metadata/copy-address-button"
-                                variant="tertiary"
-                                onClick={copyAddress}
-                            >
-                                <Translation id="TR_ADDRESS_MODAL_CLIPBOARD" />
-                            </Button>
-                        </CopyButtonWrapper>
+                        <Button
+                            data-test="@metadata/copy-address-button"
+                            variant="tertiary"
+                            onClick={copyAddress}
+                        >
+                            <Translation id="TR_ADDRESS_MODAL_CLIPBOARD" />
+                        </Button>
                     )}
-                </StyledBox>
-                {!device.connected && <DeviceDisconnected label={device.label} />}
+                </CopyButtonWrapper>
+                {!device.connected && <StyledDeviceDisconnected label={device.label} />}
             </Wrapper>
         </Modal>
     );

--- a/packages/suite/src/components/suite/modals/confirm/Address/index.tsx
+++ b/packages/suite/src/components/suite/modals/confirm/Address/index.tsx
@@ -5,8 +5,8 @@ import { Button, variables, ConfirmOnDevice, Box } from '@trezor/components';
 import { copyToClipboard } from '@suite-utils/dom';
 import { TrezorDevice } from '@suite-types';
 import { Translation, QrCode, Modal } from '@suite-components';
-import DeviceDisconnected from './components/DeviceDisconnected';
 import { useActions } from '@suite-hooks';
+import DeviceDisconnected from './components/DeviceDisconnected';
 
 const Wrapper = styled.div`
     display: flex;
@@ -15,14 +15,8 @@ const Wrapper = styled.div`
 `;
 
 const StyledBox = styled(Box)`
-    flex-direction: row;
-    padding: 30px 24px;
-    align-self: center;
-`;
-
-const Right = styled.div`
-    display: flex;
     flex-direction: column;
+    padding: 30px 24px;
 `;
 
 const Address = styled.span`
@@ -32,13 +26,15 @@ const Address = styled.span`
     border-radius: 8px;
     word-break: break-all;
     font-variant-numeric: tabular-nums slashed-zero;
-    text-align: left;
 `;
 
 const CopyButtonWrapper = styled.div`
     display: flex;
+    justify-content: center;
     margin-top: 14px;
 `;
+
+const QRCODE_SIZE = 384;
 
 type Props = {
     device: TrezorDevice;
@@ -89,23 +85,19 @@ const ConfirmAddress = ({ device, address, symbol, cancelable, confirmed, onCanc
         >
             <Wrapper>
                 <StyledBox>
-                    <QrCode value={address} />
-                    <Right>
-                        <Address data-test="@modal/confirm-address/address-field">
-                            {address}
-                        </Address>
-                        {confirmed && (
-                            <CopyButtonWrapper ref={htmlElement}>
-                                <Button
-                                    data-test="@metadata/copy-address-button"
-                                    variant="tertiary"
-                                    onClick={copyAddress}
-                                >
-                                    <Translation id="TR_ADDRESS_MODAL_CLIPBOARD" />
-                                </Button>
-                            </CopyButtonWrapper>
-                        )}
-                    </Right>
+                    <QrCode value={address} size={QRCODE_SIZE} width="100%" height="100%" />
+                    <Address data-test="@modal/confirm-address/address-field">{address}</Address>
+                    {confirmed && (
+                        <CopyButtonWrapper ref={htmlElement}>
+                            <Button
+                                data-test="@metadata/copy-address-button"
+                                variant="tertiary"
+                                onClick={copyAddress}
+                            >
+                                <Translation id="TR_ADDRESS_MODAL_CLIPBOARD" />
+                            </Button>
+                        </CopyButtonWrapper>
+                    )}
                 </StyledBox>
                 {!device.connected && <DeviceDisconnected label={device.label} />}
             </Wrapper>

--- a/packages/suite/src/components/suite/modals/confirm/Xpub/index.tsx
+++ b/packages/suite/src/components/suite/modals/confirm/Xpub/index.tsx
@@ -1,35 +1,38 @@
 import React, { createRef } from 'react';
 import styled from 'styled-components';
-import { Button } from '@trezor/components';
+import { Button, variables } from '@trezor/components';
 import { copyToClipboard } from '@suite-utils/dom';
 import { Translation, Modal } from '@suite-components';
 import { Account } from '@wallet-types';
 import * as notificationActions from '@suite-actions/notificationActions';
 import { useActions } from '@suite-hooks';
-import QrCode from '@suite-components/QrCode';
+import { QrCode, QRCODE_PADDING, QRCODE_SIZE } from '@suite-components/QrCode';
+
+const Wrapper = styled.div`
+    display: flex;
+    flex-direction: column;
+    align-self: center;
+    padding: 30px 24px;
+`;
 
 const Address = styled.div`
+    font-size: ${variables.FONT_SIZE.NORMAL};
+    color: ${props => props.theme.TYPE_DARK_GREY};
+    font-weight: ${variables.FONT_WEIGHT.MEDIUM};
+    font-variant-numeric: tabular-nums slashed-zero;
+    margin-bottom: 20px;
     width: 100%;
     background: ${props => props.theme.BG_LIGHT_GREY};
     border: 1px solid ${props => props.theme.STROKE_GREY};
     border-radius: 8px;
     word-break: break-all;
-    font-size: 20px;
-    padding: 20px;
-    margin: 20px 0 40px 0;
+    padding: 10px;
+    max-width: calc(${QRCODE_SIZE}px + ${QRCODE_PADDING * 2}px);
 `;
 
-const Row = styled.div`
+const CopyButtonWrapper = styled.div`
     display: flex;
     justify-content: center;
-
-    button + button {
-        margin-top: 10px;
-    }
-`;
-
-const StyledQrCode = styled(QrCode)`
-    align-self: center;
 `;
 
 interface Props {
@@ -58,7 +61,6 @@ const Xpub = ({ xpub, accountIndex, symbol, accountLabel, onCancel }: Props) => 
 
     return (
         <Modal
-            size="small"
             cancelable
             onCancel={onCancel}
             heading={
@@ -74,14 +76,17 @@ const Xpub = ({ xpub, accountIndex, symbol, accountLabel, onCancel }: Props) => 
                     />
                 )
             }
+            useFixedWidth={false}
         >
-            <StyledQrCode value={xpub} />
-            <Address data-test="@xpub-modal/xpub-field">{xpub}</Address>
-            <Row ref={htmlElement}>
-                <Button variant="primary" onClick={copyAddress}>
-                    <Translation id="TR_XPUB_MODAL_CLIPBOARD" />
-                </Button>
-            </Row>
+            <Wrapper>
+                <QrCode value={xpub} />
+                <Address data-test="@xpub-modal/xpub-field">{xpub}</Address>
+                <CopyButtonWrapper ref={htmlElement}>
+                    <Button variant="tertiary" onClick={copyAddress}>
+                        <Translation id="TR_XPUB_MODAL_CLIPBOARD" />
+                    </Button>
+                </CopyButtonWrapper>
+            </Wrapper>
         </Modal>
     );
 };


### PR DESCRIPTION
The successor of #4796.
Unfortunately, we found out that our Cypress tests in CI have some problem with `#` in the branch name 🙈  so I had to rename the branch

close #4792, #4503

#4792 original PR from @mradziwon

I changed @mradziwon's commits to be according to our policy and added 1 commit unifying xpub and receive address modals. Unfortunately, git did not pair it.

![Screenshot 2022-01-24 at 13 10 23](https://user-images.githubusercontent.com/33235762/150783791-8e392f12-f2be-462d-b515-794aa5f5ab1a.png)

