### PR TITLE
fix windows app build and disable native android app build

### DIFF
--- a/ci/build.yml
+++ b/ci/build.yml
@@ -255,39 +255,41 @@ suite-desktop build windows codesign:
       - latest*.yml
     expire_in: 7 days
 
+## Temporarily disable native android app build, will be completely change in the near future.
+
 # Suite native build
 
 ## Suite mobile Android app
-suite-native build android:
-  image: $CI_DEPENDENCY_PROXY_DIRECT_GROUP_IMAGE_PREFIX/reactnativecommunity/react-native-android
-  stage: build
-  only:
-    <<: *run_everything_rules
-  script:
-    - yarn install --frozen-lockfile --cache-folder .yarn --prefer-offline
-    - yarn build:libs
-    - yarn workspace @trezor/suite-data copy-static-files
-    - yarn workspace @trezor/suite-native build:android
-    - mv packages/suite-native/android/app/build/outputs/apk/release/app-release.apk .
-  artifacts:
-    expire_in: 1 day
-    paths:
-      - app-release.apk
+# suite-native build android:
+#   image: $CI_DEPENDENCY_PROXY_DIRECT_GROUP_IMAGE_PREFIX/reactnativecommunity/react-native-android
+#   stage: build
+#   only:
+#     <<: *run_everything_rules
+#   script:
+#     - yarn install --frozen-lockfile --cache-folder .yarn --prefer-offline
+#     - yarn build:libs
+#     - yarn workspace @trezor/suite-data copy-static-files
+#     - yarn workspace @trezor/suite-native build:android
+#     - mv packages/suite-native/android/app/build/outputs/apk/release/app-release.apk .
+#   artifacts:
+#     expire_in: 1 day
+#     paths:
+#       - app-release.apk
 
-suite-native build android manual:
-  stage: build
-  <<: *config_sign_dev
-  when: manual
-  except:
-    <<: *run_everything_rules
-  image: $CI_DEPENDENCY_PROXY_DIRECT_GROUP_IMAGE_PREFIX/reactnativecommunity/react-native-android
-  script:
-    - yarn install --frozen-lockfile --cache-folder .yarn --prefer-offline
-    - yarn build:libs
-    - yarn workspace @trezor/suite-data copy-static-files
-    - yarn workspace @trezor/suite-native build:android
-    - mv packages/suite-native/android/app/build/outputs/apk/release/app-release.apk .
-  artifacts:
-    expire_in: 1 day
-    paths:
-      - app-release.apk
+# suite-native build android manual:
+#   stage: build
+#   <<: *config_sign_dev
+#   when: manual
+#   except:
+#     <<: *run_everything_rules
+#   image: $CI_DEPENDENCY_PROXY_DIRECT_GROUP_IMAGE_PREFIX/reactnativecommunity/react-native-android
+#   script:
+#     - yarn install --frozen-lockfile --cache-folder .yarn --prefer-offline
+#     - yarn build:libs
+#     - yarn workspace @trezor/suite-data copy-static-files
+#     - yarn workspace @trezor/suite-native build:android
+#     - mv packages/suite-native/android/app/build/outputs/apk/release/app-release.apk .
+#   artifacts:
+#     expire_in: 1 day
+#     paths:
+#       - app-release.apk

--- a/ci/build.yml
+++ b/ci/build.yml
@@ -218,7 +218,7 @@ suite-desktop build windows:
   <<: *config_sign_dev
   only:
     <<: *run_everything_rules
-  image: $CI_DEPENDENCY_PROXY_DIRECT_GROUP_IMAGE_PREFIX/electronuserland/builder:wine
+  image: $CI_DEPENDENCY_PROXY_DIRECT_GROUP_IMAGE_PREFIX/vdovhanych/electron-builder:wine
   variables:
     artifact: ${DESKTOP_APP_NAME}*
     platform: win
@@ -229,7 +229,7 @@ suite-desktop build windows manual:
   when: manual
   except:
     <<: *run_everything_rules
-  image: $CI_DEPENDENCY_PROXY_DIRECT_GROUP_IMAGE_PREFIX/electronuserland/builder:wine
+  image: $CI_DEPENDENCY_PROXY_DIRECT_GROUP_IMAGE_PREFIX/vdovhanych/electron-builder:wine
   variables:
     artifact: ${DESKTOP_APP_NAME}*
     platform: win
@@ -242,7 +242,7 @@ suite-desktop build windows codesign:
       - codesign
   tags:
     - darwin
-  image: $CI_DEPENDENCY_PROXY_DIRECT_GROUP_IMAGE_PREFIX/electronuserland/builder:wine
+  image: $CI_DEPENDENCY_PROXY_DIRECT_GROUP_IMAGE_PREFIX/vdovhanych/electron-builder:wine
   variables:
     IS_CODESIGN_BUILD: "true"
     artifact: ${DESKTOP_APP_NAME}*


### PR DESCRIPTION
This pr fixes windows app build with modified docker image to ensure proper node version. This is temporary, and we should discuss what to do with some of the images we're using in the suite.

Also, as @Nodonisko said, there is no need to have a native android app job for the time being as it will get rewritten soon.

