### PR TITLE
feat(translations): activate japanese

### DIFF
--- a/packages/suite/src/config/suite/languages.ts
+++ b/packages/suite/src/config/suite/languages.ts
@@ -17,7 +17,7 @@ const LANGUAGES = {
     hu: { name: 'Magyar', en: 'Hungarian' },
     id: { name: 'Bahasa Indonesia', en: 'Indonesian' },
     it: { name: 'Italiano', en: 'Italian' },
-    ja: { name: '日本語', en: 'Japanese' },
+    ja: { name: '日本語', en: 'Japanese', complete: true },
     jv: { name: 'Basa Jawa', en: 'Javanese' },
     ko: { name: '한국어', en: 'Korean' },
     nl: { name: 'Nederlands', en: 'Dutch' },


### PR DESCRIPTION
I have completed the correction of the newly added keys, the renamed keys, and #4819.
If you download ja.json from crowdin again, Japanese is in perfect condition.

https://crowdin.com/project/trezor-suite