### PR TITLE
fix(suite): jumping of navbar in settings when opening modal

### DIFF
--- a/packages/suite/src/components/suite/AppNavigation/index.tsx
+++ b/packages/suite/src/components/suite/AppNavigation/index.tsx
@@ -204,12 +204,10 @@ interface MenuWidths {
 const isRouteActive = (routeName?: Route['name'], id?: string): boolean => routeName === id;
 
 const isSubsection = (routeName: Route['name']): boolean =>
-    !(
-        routeName.startsWith('settings') ||
-        routeName === 'wallet-index' ||
-        routeName === 'wallet-details' ||
-        routeName === 'wallet-tokens'
-    );
+    routeName.startsWith('wallet') &&
+    routeName !== 'wallet-index' &&
+    routeName !== 'wallet-details' &&
+    routeName !== 'wallet-tokens';
 
 const isSecondaryMenuOverflown = ({ primary, secondary, wrapper }: MenuWidths) =>
     primary + secondary >= wrapper;


### PR DESCRIPTION
**Story:**
One of the most annoying bugs for me.

**Problems:**
When user opened modal in settings, the navbar disappeared. 
When user closed modal in settings, the navbar appeared. 

**Solution:**
Changed condition should do the same except that it fixes modals in Settings.

**Possible consequences:**
It can break navbar in settings and navbar in account (send, receive, trade, transactions)