### PR TITLE
fix: missing desktop icon

### DIFF
--- a/packages/suite-desktop/src-electron/app.ts
+++ b/packages/suite-desktop/src-electron/app.ts
@@ -76,6 +76,7 @@ const init = async () => {
             contextIsolation: true,
             preload: path.join(__dirname, 'preload.js'),
         },
+        icon: path.join(global.resourcesPath, 'images', 'icons', '512x512.png'),
     });
 
     // Load page


### PR DESCRIPTION
This should fix #4680 
Buggy behaviour started to appear with this commit https://github.com/trezor/trezor-suite/commit/fbd87b0c4ae55c06c8782b850bcc5a0802afa335

Simply reverting one line seems to do the job but I am not 100% sure whether there was some special intention in removing this. Maybe @tomasklim knows?