### PR TITLE
fix(win): start signing DLL binaries to satisfy AppLocker policy

### DIFF
--- a/packages/suite-desktop/package.json
+++ b/packages/suite-desktop/package.json
@@ -146,7 +146,8 @@
             "artifactName": "Trezor-Suite-${version}-win-${arch}.${ext}",
             "target": [
                 "nsis"
-            ]
+            ],
+            "signDlls": true
         },
         "linux": {
             "extraResources": [


### PR DESCRIPTION
https://www.electron.build/configuration/win#WindowsConfiguration-signDlls