### PR TITLE
chore: Less restrictive node version hotfix

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,8 +5,8 @@
     "repository": "https://github.com/trezor/trezor-suite.git",
     "license": "SEE LICENSE IN LICENSE.md",
     "engines": {
-        "node": "14.18.1",
-        "yarn": ">=1.22.11 <2"
+        "node": "14",
+        "yarn": ">=1.22.0 <2"
     },
     "workspaces": {
         "packages": [


### PR DESCRIPTION
This will make engine check less restrictive, all Node v14 will work and all Yarn version will work. This should be changes back after @vdovhanych will create our own Docker repository where we can manage versions.

Hotfix for #4841 