### PR TITLE
fix: webusb regression

### DIFF
--- a/packages/transport/src/lowlevel/sharedConnectionWorker.ts
+++ b/packages/transport/src/lowlevel/sharedConnectionWorker.ts
@@ -6,8 +6,8 @@
 // about intent to acquire/release and then send another message when that is done.
 // Other windows then can acquire/release
 
-import { createDeferred, Deferred } from '@trezor/utils';
-
+import { create as createDeferred } from '../utils/defered';
+import type { Deferred } from '../utils/defered';
 import type { TrezorDeviceInfoDebug } from './sharedPlugin';
 import type { MessageFromSharedWorker, MessageToSharedWorker } from './withSharedConnections';
 

--- a/packages/transport/src/lowlevel/withSharedConnections.ts
+++ b/packages/transport/src/lowlevel/withSharedConnections.ts
@@ -1,11 +1,10 @@
 // @ts-nocheck
 
-import { createDeferred, Deferred } from '@trezor/utils';
-import { resolveTimeoutPromise } from '../utils/defered';
+import { create as createDeferred, resolveTimeoutPromise } from '../utils/defered';
 import { parseConfigure } from './protobuf/messages';
 import { buildAndSend } from './send';
 import { receiveAndParse } from './receive';
-
+import type { Deferred } from '../utils/defered';
 import type { LowlevelTransportSharedPlugin, TrezorDeviceInfoDebug } from './sharedPlugin';
 import type { MessageFromTrezor, TrezorDeviceInfoWithSession, AcquireInput } from '../types';
 

--- a/packages/transport/src/utils/defered.ts
+++ b/packages/transport/src/utils/defered.ts
@@ -1,5 +1,33 @@
 // todo: move to @trezor/utils. probably "resolveAfter"?
 
+export type Deferred<T> = {
+    promise: Promise<T>;
+    resolve: (t: T) => void;
+    reject: (e: Error) => void;
+    rejectingPromise: Promise<any>;
+};
+
+export function create<T>(): Deferred<T> {
+    let localResolve: (t: T) => void = () => {};
+    let localReject: (e?: Error) => void = () => {};
+
+    const promise = new Promise<T>((resolve, reject) => {
+        localResolve = resolve;
+        localReject = reject;
+    });
+    const rejectingPromise = promise.then(() => {
+        throw new Error(`Promise is always rejecting`);
+    });
+    rejectingPromise.catch(() => {});
+
+    return {
+        resolve: localResolve,
+        reject: localReject,
+        promise,
+        rejectingPromise,
+    };
+}
+
 export function resolveTimeoutPromise<T>(delay: number, result: T): Promise<T> {
     return new Promise(resolve => {
         setTimeout(() => {


### PR DESCRIPTION
@trezor/utils version of deferred is not the same what we have at the moment in @trezor/transport. This slipped through as this part of @trezor/transport is not typed-checked yet. For now, I am only reverting changes, refactoring of @trezor/transport is in progress anyway. 