### PR TITLE
Sentry in electron

### DIFF
--- a/packages/suite-build/configs/base.webpack.config.ts
+++ b/packages/suite-build/configs/base.webpack.config.ts
@@ -20,6 +20,11 @@ import { getPathForProject } from '../utils/path';
 import { suiteVersion } from '../../suite/package.json';
 
 const gitRevision = getRevision();
+
+/**
+ * Assemble release name for Sentry
+ * Same definition is in packages/suite-desktop/scripts/build.js
+ */
 const sentryRelease = `${suiteVersion}.${project}${
     isCodesignBuild ? '.codesign' : ''
 }.${gitRevision}`;

--- a/packages/suite-desktop/package.json
+++ b/packages/suite-desktop/package.json
@@ -173,6 +173,7 @@
         "afterSign": "scripts/notarize.js"
     },
     "dependencies": {
+        "@sentry/electron": "3.0.0",
         "@trezor/suite-desktop-api": "1.0.0",
         "@trezor/utils": "*",
         "chalk": "^4.1.2",

--- a/packages/suite-desktop/src-electron/app.ts
+++ b/packages/suite-desktop/src-electron/app.ts
@@ -1,7 +1,9 @@
 import path from 'path';
 import url from 'url';
-import { app, BrowserWindow, ipcMain } from 'electron';
+import { app, BrowserWindow, ipcMain, session } from 'electron';
+import { init as initSentry, ElectronOptions, IPCMode } from '@sentry/electron';
 
+import { SENTRY_CONFIG } from '@suite-config';
 import { isDev } from '@suite-utils/build';
 import { PROTOCOL } from './libs/constants';
 import * as store from './libs/store';
@@ -140,3 +142,13 @@ ipcMain.on('app/restart', () => {
     app.relaunch();
     app.exit();
 });
+
+if (!isDev) {
+    const sentryConfig: ElectronOptions = {
+        ...SENTRY_CONFIG,
+        ipcMode: IPCMode.Classic,
+        getSessions: () => [session.defaultSession],
+    };
+
+    initSentry(sentryConfig);
+}

--- a/packages/suite-desktop/src-electron/index.d.ts
+++ b/packages/suite-desktop/src-electron/index.d.ts
@@ -53,7 +53,7 @@ declare interface ILogger {
 
 declare type BeforeRequestListener = (
     details: Electron.OnBeforeRequestListenerDetails,
-) => Promise<Electron.Response | undefined>;
+) => Electron.Response | undefined;
 
 declare interface RequestInterceptor {
     onBeforeRequest(listener: BeforeRequestListener): void;

--- a/packages/suite-desktop/src-electron/libs/request-interceptor.ts
+++ b/packages/suite-desktop/src-electron/libs/request-interceptor.ts
@@ -7,10 +7,9 @@ export const createInterceptor = (): RequestInterceptor => {
     let beforeRequestListeners: BeforeRequestListener[] = [];
 
     const filter = { urls: ['*://*/*'] };
-    session.defaultSession.webRequest.onBeforeRequest(filter, async (details, callback) => {
+    session.defaultSession.webRequest.onBeforeRequest(filter, (details, callback) => {
         for (let i = 0; i < beforeRequestListeners.length; ++i) {
-            /* eslint-disable no-await-in-loop */
-            const res = await beforeRequestListeners[i](details);
+            const res = beforeRequestListeners[i](details);
             if (res) {
                 callback(res);
                 return;

--- a/packages/suite-desktop/src-electron/modules/request-filter.ts
+++ b/packages/suite-desktop/src-electron/modules/request-filter.ts
@@ -1,6 +1,7 @@
 /**
  * Request Filter feature (blocks non-allowed requests)
  */
+import { captureMessage, Severity } from '@sentry/electron';
 import { allowedDomains } from '../config';
 import { Module } from './index';
 
@@ -31,6 +32,7 @@ const init: Module = ({ interceptor }) => {
             'request-filter',
             `${details.url} was blocked because ${hostname} is not in the exception list`,
         );
+        captureMessage(`request-filter: ${hostname}`, Severity.Warning);
         return { cancel: true };
     });
 };

--- a/packages/suite-desktop/src-electron/modules/tor.ts
+++ b/packages/suite-desktop/src-electron/modules/tor.ts
@@ -85,14 +85,13 @@ const init: Module = async ({ mainWindow, store, interceptor }) => {
             protocol === 'https:'
         ) {
             logger.info('tor', `Rewriting ${details.url} to .onion URL`);
-            return Promise.resolve({
+            return {
                 redirectURL: details.url.replace(
                     /https:\/\/(([a-z0-9]+\.)*)trezor\.io(.*)/,
                     `http://$1${onionDomain}$3`,
                 ),
-            });
+            };
         }
-        return Promise.resolve(undefined);
     });
 
     app.on('before-quit', () => {

--- a/packages/suite-desktop/src/index.tsx
+++ b/packages/suite-desktop/src/index.tsx
@@ -2,13 +2,13 @@ import React, { useEffect, useState } from 'react';
 import { render } from 'react-dom';
 import { Provider as ReduxProvider } from 'react-redux';
 import { Router as RouterProvider } from 'react-router-dom';
+import { init as initSentry } from '@sentry/electron/renderer';
 import { desktopApi } from '@trezor/suite-desktop-api';
 
 import { store } from '@suite/reducers/store';
 import { isDev } from '@suite-utils/build';
 import { SENTRY_CONFIG } from '@suite-config';
 
-import { initSentry } from '@suite-utils/sentry';
 import Metadata from '@suite-components/Metadata';
 import Preloader from '@suite-components/Preloader';
 import ToastContainer from '@suite-components/ToastContainer';

--- a/packages/suite-web/package.json
+++ b/packages/suite-web/package.json
@@ -14,12 +14,13 @@
         "build": "rimraf ./build && yarn workspace @trezor/suite-build run build:web"
     },
     "dependencies": {
+        "@sentry/browser": "6.17.2",
         "@trezor/suite": "1.0.0",
-        "worker-loader": "^3.0.8",
         "react-helmet": "^6.1.0",
         "react-router": "^5.2.0",
         "react-router-dom": "^5.2.0",
-        "styled-components": "^5.3.3"
+        "styled-components": "^5.3.3",
+        "worker-loader": "^3.0.8"
     },
     "devDependencies": {
         "@types/react": "^17.0.0",

--- a/packages/suite-web/src/Main.tsx
+++ b/packages/suite-web/src/Main.tsx
@@ -2,12 +2,12 @@ import React, { useEffect } from 'react';
 import { Provider as ReduxProvider } from 'react-redux';
 import { Router as RouterProvider } from 'react-router-dom';
 import TrezorConnect from 'trezor-connect';
+import { init as initSentry } from '@sentry/browser';
 
 import { store } from '@suite/reducers/store';
 import { isDev } from '@suite-utils/build';
 import { SENTRY_CONFIG } from '@suite-config';
 
-import { initSentry } from '@suite-utils/sentry';
 import Metadata from '@suite-components/Metadata';
 import Preloader from '@suite-components/Preloader';
 import ToastContainer from '@suite-components/ToastContainer';

--- a/packages/suite/package.json
+++ b/packages/suite/package.json
@@ -24,8 +24,8 @@
         "@ethereumjs/common": "^2.6.0",
         "@ethereumjs/tx": "^3.4.0",
         "@fivebinaries/coin-selection": "2.0.0-beta.10",
-        "@sentry/browser": "^6.16.1",
-        "@sentry/integrations": "^6.16.1",
+        "@sentry/integrations": "6.17.2",
+        "@sentry/minimal": "6.17.2",
         "@trezor/components": "1.0.0",
         "@trezor/suite-data": "1.0.0",
         "@trezor/suite-desktop-api": "1.0.0",
@@ -75,6 +75,7 @@
     "devDependencies": {
         "@crowdin/cli": "^3.7.8",
         "@formatjs/cli": "^3.0.5",
+        "@sentry/types": "6.17.2",
         "@testing-library/dom": "^7.29.2",
         "@testing-library/react": "^11.2.3",
         "@testing-library/react-hooks": "^4.0.0",

--- a/packages/suite/src/actions/suite/logActions.ts
+++ b/packages/suite/src/actions/suite/logActions.ts
@@ -1,6 +1,6 @@
 import { LogEntry } from '@suite-reducers/logReducer';
 import { Action, Dispatch, GetState } from '@suite-types';
-import * as Sentry from '@sentry/browser';
+import * as Sentry from '@sentry/minimal';
 import { LOG } from './constants';
 import { redactDevice, redactCustom, redactAction, redactDiscovery } from '@suite-utils/logUtils';
 

--- a/packages/suite/src/config/suite/sentry.ts
+++ b/packages/suite/src/config/suite/sentry.ts
@@ -1,9 +1,9 @@
 import { CaptureConsole, Dedupe } from '@sentry/integrations';
-import { BrowserOptions } from '@sentry/browser';
+import type { Options } from '@sentry/types';
 
 export const allowReportTag = 'allowReport';
 
-const beforeSend: BrowserOptions['beforeSend'] = event => {
+const beforeSend: Options['beforeSend'] = event => {
     // sentry events are skipped until user confirm analytics reporting
     const allowReport = event.tags?.[allowReportTag];
     if (allowReport === false) {
@@ -16,7 +16,7 @@ const beforeSend: BrowserOptions['beforeSend'] = event => {
     return event;
 };
 
-const beforeBreadcrumb: BrowserOptions['beforeBreadcrumb'] = breadcrumb => {
+const beforeBreadcrumb: Options['beforeBreadcrumb'] = breadcrumb => {
     // filter out analytics requests and image fetche
     const isAnalytics =
         breadcrumb.category === 'fetch' &&
@@ -30,7 +30,7 @@ const beforeBreadcrumb: BrowserOptions['beforeBreadcrumb'] = breadcrumb => {
     return breadcrumb;
 };
 
-export default {
+const config: Options = {
     dsn: 'https://6d91ca6e6a5d4de7b47989455858b5f6@o117836.ingest.sentry.io/5193825',
     autoSessionTracking: false, // do not send analytical data to Sentry
     integrations: [
@@ -45,4 +45,11 @@ export default {
     normalizeDepth: 4,
     maxBreadcrumbs: 30,
     beforeBreadcrumb,
-} as BrowserOptions;
+    initialScope: {
+        tags: {
+            version: process.env.VERSION || 'undefined',
+        },
+    },
+};
+
+export default config;

--- a/packages/suite/src/utils/suite/sentry.ts
+++ b/packages/suite/src/utils/suite/sentry.ts
@@ -1,4 +1,4 @@
-import * as Sentry from '@sentry/browser';
+import * as Sentry from '@sentry/minimal';
 import { allowReportTag } from '@suite-config/sentry';
 
 export const allowSentryReport = (value: boolean) => {
@@ -17,15 +17,4 @@ export const unsetSentryUser = () => {
     Sentry.configureScope(scope => {
         scope.setUser(null);
     });
-};
-
-export const setSentryVersionTag = () => {
-    Sentry.configureScope(scope => {
-        scope.setTag('version', process.env.VERSION || 'undefined');
-    });
-};
-
-export const initSentry = (options: Sentry.BrowserOptions) => {
-    Sentry.init(options);
-    setSentryVersionTag();
 };

--- a/yarn.lock
+++ b/yarn.lock
@@ -3569,14 +3569,14 @@
     "@react-spring/shared" "~9.4.0"
     "@react-spring/types" "~9.4.0"
 
-"@sentry/browser@^6.16.1":
-  version "6.16.1"
-  resolved "https://registry.yarnpkg.com/@sentry/browser/-/browser-6.16.1.tgz#4270ab0fbd1de425e339b3e7a364feb09f470a87"
-  integrity sha512-F2I5RL7RTLQF9CccMrqt73GRdK3FdqaChED3RulGQX5lH6U3exHGFxwyZxSrY4x6FedfBFYlfXWWCJXpLnFkow==
+"@sentry/browser@6.17.2":
+  version "6.17.2"
+  resolved "https://registry.yarnpkg.com/@sentry/browser/-/browser-6.17.2.tgz#8e794b846f43a341068c83420918d896683d903e"
+  integrity sha512-4Ow5z9GxK5dG9+stBNKb7s6NoxE4wgEcHRmO66QTK4gH2NNmzV4R/aaZ7iDoS/lD86sH0M86jm76dpg9uiJPmw==
   dependencies:
-    "@sentry/core" "6.16.1"
-    "@sentry/types" "6.16.1"
-    "@sentry/utils" "6.16.1"
+    "@sentry/core" "6.17.2"
+    "@sentry/types" "6.17.2"
+    "@sentry/utils" "6.17.2"
     tslib "^1.9.3"
 
 "@sentry/cli@^1.70.1":
@@ -3591,56 +3591,95 @@
     progress "^2.0.3"
     proxy-from-env "^1.1.0"
 
-"@sentry/core@6.16.1":
-  version "6.16.1"
-  resolved "https://registry.yarnpkg.com/@sentry/core/-/core-6.16.1.tgz#d9f7a75f641acaddf21b6aafa7a32e142f68f17c"
-  integrity sha512-UFI0264CPUc5cR1zJH+S2UPOANpm6dLJOnsvnIGTjsrwzR0h8Hdl6rC2R/GPq+WNbnipo9hkiIwDlqbqvIU5vw==
+"@sentry/core@6.17.2":
+  version "6.17.2"
+  resolved "https://registry.yarnpkg.com/@sentry/core/-/core-6.17.2.tgz#f218920f269ccdbaee20a092bbc90a71a007cc88"
+  integrity sha512-Uew0CNMr+QvowrF4EJYjOUgHep/sZJ3l5zevPEELugIgqWBodd+ZDCV3fQFR7cr6KOqx1rMgVrgcKIkLl0l+RA==
   dependencies:
-    "@sentry/hub" "6.16.1"
-    "@sentry/minimal" "6.16.1"
-    "@sentry/types" "6.16.1"
-    "@sentry/utils" "6.16.1"
+    "@sentry/hub" "6.17.2"
+    "@sentry/minimal" "6.17.2"
+    "@sentry/types" "6.17.2"
+    "@sentry/utils" "6.17.2"
     tslib "^1.9.3"
 
-"@sentry/hub@6.16.1":
-  version "6.16.1"
-  resolved "https://registry.yarnpkg.com/@sentry/hub/-/hub-6.16.1.tgz#526e19db51f4412da8634734044c605b936a7b80"
-  integrity sha512-4PGtg6AfpqMkreTpL7ymDeQ/U1uXv03bKUuFdtsSTn/FRf9TLS4JB0KuTZCxfp1IRgAA+iFg6B784dDkT8R9eg==
+"@sentry/electron@3.0.0":
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/@sentry/electron/-/electron-3.0.0.tgz#28f1f37b599f71f7e2c8dcd8f3c4c0220a37fb11"
+  integrity sha512-cOjbBWaIyg4HPQ2izH1KFtrLR3YX3OJ52YeIq7H+lsZqcotnNzP4VmHehe5Jo4lWSW1RQTSxTFynPLDFM9RF9A==
   dependencies:
-    "@sentry/types" "6.16.1"
-    "@sentry/utils" "6.16.1"
+    "@sentry/browser" "6.17.2"
+    "@sentry/core" "6.17.2"
+    "@sentry/node" "6.17.2"
+    "@sentry/types" "6.17.2"
+    "@sentry/utils" "6.17.2"
+    deepmerge "^4.2.2"
+    tslib "^2.3.1"
+
+"@sentry/hub@6.17.2":
+  version "6.17.2"
+  resolved "https://registry.yarnpkg.com/@sentry/hub/-/hub-6.17.2.tgz#d92accada845fa21fff1b2b491d3c6964851693b"
+  integrity sha512-CMi6jU920bTwRTmGHjP4u8toOx4gm1dsx+rsxvp+FKzqRwpwoyi9mOw8oEYERVzaqaYceGdFylyRUrjdf0f77g==
+  dependencies:
+    "@sentry/types" "6.17.2"
+    "@sentry/utils" "6.17.2"
     tslib "^1.9.3"
 
-"@sentry/integrations@^6.16.1":
-  version "6.16.1"
-  resolved "https://registry.yarnpkg.com/@sentry/integrations/-/integrations-6.16.1.tgz#ef29e47e3b920126b31c332d381c5a1ca43b0185"
-  integrity sha512-YobbH3jWMRJxCeFzr8USlju1Up0EJoxaAT4y+LQQ0ZLfyfOdPX0d0iFnWMCar8gwR1nRujFS0HM0BBKY3an0LA==
+"@sentry/integrations@6.17.2":
+  version "6.17.2"
+  resolved "https://registry.yarnpkg.com/@sentry/integrations/-/integrations-6.17.2.tgz#09fa2411cb0aeabe8d6b30b15f9723d0c64cc6cb"
+  integrity sha512-6UINdiJpXs3AeJVwVMuRjo94ZJB9jJaywfEe2ZgwEmnmjsVTCXcfeJMbn45z6IJbks62J0RlmXK4v/aW5CvfXw==
   dependencies:
-    "@sentry/types" "6.16.1"
-    "@sentry/utils" "6.16.1"
+    "@sentry/types" "6.17.2"
+    "@sentry/utils" "6.17.2"
     localforage "^1.8.1"
     tslib "^1.9.3"
 
-"@sentry/minimal@6.16.1":
-  version "6.16.1"
-  resolved "https://registry.yarnpkg.com/@sentry/minimal/-/minimal-6.16.1.tgz#6a9506a92623d2ff1fc17d60989688323326772e"
-  integrity sha512-dq+mI1EQIvUM+zJtGCVgH3/B3Sbx4hKlGf2Usovm9KoqWYA+QpfVBholYDe/H2RXgO7LFEefDLvOdHDkqeJoyA==
+"@sentry/minimal@6.17.2":
+  version "6.17.2"
+  resolved "https://registry.yarnpkg.com/@sentry/minimal/-/minimal-6.17.2.tgz#3b482a0d76aa33b6c9441dd21acbcc3a113e5120"
+  integrity sha512-Cdh+iM6QhLKfxwUWWP4mk2K7+EsQj4tuF2dGQke4Zcbp7zQ7wbcMruUcZHiZfvg5kiSYxwNVkH7cXMzcO7AJsg==
   dependencies:
-    "@sentry/hub" "6.16.1"
-    "@sentry/types" "6.16.1"
+    "@sentry/hub" "6.17.2"
+    "@sentry/types" "6.17.2"
     tslib "^1.9.3"
 
-"@sentry/types@6.16.1":
-  version "6.16.1"
-  resolved "https://registry.yarnpkg.com/@sentry/types/-/types-6.16.1.tgz#4917607115b30315757c2cf84f80bac5100b8ac0"
-  integrity sha512-Wh354g30UsJ5kYJbercektGX4ZMc9MHU++1NjeN2bTMnbofEcpUDWIiKeulZEY65IC1iU+1zRQQgtYO+/hgCUQ==
-
-"@sentry/utils@6.16.1":
-  version "6.16.1"
-  resolved "https://registry.yarnpkg.com/@sentry/utils/-/utils-6.16.1.tgz#1b9e14c2831b6e8b816f7021b9876133bf2be008"
-  integrity sha512-7ngq/i4R8JZitJo9Sl8PDnjSbDehOxgr1vsoMmerIsyRZ651C/8B+jVkMhaAPgSdyJ0AlE3O7DKKTP1FXFw9qw==
+"@sentry/node@6.17.2":
+  version "6.17.2"
+  resolved "https://registry.yarnpkg.com/@sentry/node/-/node-6.17.2.tgz#32a5fa00b64a331073daf1e44f500c8c57184eb1"
+  integrity sha512-358z45WaejnsE8RZVpuLJJiFVCSEi0TRY7P60CljZuz8rnvniD3G0tuXChvu4djVty8NScWZHT/QoxvuJdTHgQ==
   dependencies:
-    "@sentry/types" "6.16.1"
+    "@sentry/core" "6.17.2"
+    "@sentry/hub" "6.17.2"
+    "@sentry/tracing" "6.17.2"
+    "@sentry/types" "6.17.2"
+    "@sentry/utils" "6.17.2"
+    cookie "^0.4.1"
+    https-proxy-agent "^5.0.0"
+    lru_map "^0.3.3"
+    tslib "^1.9.3"
+
+"@sentry/tracing@6.17.2":
+  version "6.17.2"
+  resolved "https://registry.yarnpkg.com/@sentry/tracing/-/tracing-6.17.2.tgz#437337071fdeffa319746905b3706518b099ec6b"
+  integrity sha512-oWY2Ga+5D5f90utvfF2Y0eQvme+eS768ZWjR+klRYgZWoY8r1v8uWwWsvroYU1g+h6X0G/xh3giFjsdOWtRENw==
+  dependencies:
+    "@sentry/hub" "6.17.2"
+    "@sentry/minimal" "6.17.2"
+    "@sentry/types" "6.17.2"
+    "@sentry/utils" "6.17.2"
+    tslib "^1.9.3"
+
+"@sentry/types@6.17.2":
+  version "6.17.2"
+  resolved "https://registry.yarnpkg.com/@sentry/types/-/types-6.17.2.tgz#4dde3423db5953e798b19ed29618c28fc7bf2e30"
+  integrity sha512-UrFLRDz5mn253O8k/XftLxoldF+NyZdkqKLGIQmST5HEVr7ub9nQJ4Y5ZFA3zJYWpraaW8faIbuw+pgetC8hmQ==
+
+"@sentry/utils@6.17.2":
+  version "6.17.2"
+  resolved "https://registry.yarnpkg.com/@sentry/utils/-/utils-6.17.2.tgz#e8044e753b47f86068053c8d79e4ae61a39b6732"
+  integrity sha512-ePWtO44KJQwUULOiU86fa1WU3Ird2TH0i39gqB2d3zNS3QyVp9qPlzSdPKSPJ9LdgadzBHw7ikEuE+GY8JTrhA==
+  dependencies:
+    "@sentry/types" "6.17.2"
     tslib "^1.9.3"
 
 "@sentry/webpack-plugin@^1.18.3":
@@ -9027,7 +9066,7 @@ cookie-signature@1.0.6:
   resolved "https://registry.yarnpkg.com/cookie-signature/-/cookie-signature-1.0.6.tgz#e303a882b342cc3ee8ca513a79999734dab3ae2c"
   integrity sha1-4wOogrNCzD7oylE6eZmXNNqzriw=
 
-cookie@0.4.2:
+cookie@0.4.2, cookie@^0.4.1:
   version "0.4.2"
   resolved "https://registry.yarnpkg.com/cookie/-/cookie-0.4.2.tgz#0e41f24de5ecf317947c82fc789e06a884824432"
   integrity sha512-aSWTXFzaKWkvHO1Ny/s+ePFpvKsPnjc551iI41v3ny/ow6tBG5Vd+FuqGNhh1LxOmVzOlGUriIlOaokOvhaStA==
@@ -16067,6 +16106,11 @@ lru-queue@^0.1.0:
   integrity sha1-Jzi9nw089PhEkMVzbEhpmsYyzaM=
   dependencies:
     es5-ext "~0.10.2"
+
+lru_map@^0.3.3:
+  version "0.3.3"
+  resolved "https://registry.yarnpkg.com/lru_map/-/lru_map-0.3.3.tgz#b5c8351b9464cbd750335a79650a0ec0e56118dd"
+  integrity sha1-tcg1G5Rky9dQM1p5ZQoOwOVhGN0=
 
 lz-string@^1.4.4:
   version "1.4.4"
@@ -23585,7 +23629,7 @@ tslib@^1.8.1, tslib@^1.9.0, tslib@^1.9.3:
   resolved "https://registry.yarnpkg.com/tslib/-/tslib-1.14.1.tgz#cf2d38bdc34a134bcaf1091c41f6619e2f672d00"
   integrity sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==
 
-tslib@^2.0.0, tslib@^2.0.1, tslib@^2.0.3, tslib@^2.1.0, tslib@^2.2.0, tslib@^2.3.0:
+tslib@^2.0.0, tslib@^2.0.1, tslib@^2.0.3, tslib@^2.1.0, tslib@^2.2.0, tslib@^2.3.0, tslib@^2.3.1:
   version "2.3.1"
   resolved "https://registry.yarnpkg.com/tslib/-/tslib-2.3.1.tgz#e8a335add5ceae51aa261d32a490158ef042ef01"
   integrity sha512-77EbyPPpMz+FRFRuAFlWMtmgUWGe9UOG2Z25NqCwiIjRhOf5iKGuzSe5P2w1laq+FkRy4p+PCuVkJSGkzTEKVw==


### PR DESCRIPTION
https://github.com/trezor/trezor-suite/pull/4853/commits/929c258ec5b9bda3226dc7dc32403d38990b57bc - removes allow/deny dialog from electron app when requesting unknown hostnames completely, as it's not needed anymore (part of #4684).
https://github.com/trezor/trezor-suite/pull/4853/commits/5f79bdba05817814b03ac1e01e46bf4970f11d30 - use only `@sentry/minimal` in shared code, add `@sentry/browser` to `suite-web` and `@sentry/electron` to `suite-desktop`.
https://github.com/trezor/trezor-suite/pull/4853/commits/28b8d04c49b829d0d80b51650fba3d735720ffde - initialize `@sentry/electron` and log domains filtered by `request-filter` (part of #4684).