### PR TITLE
specify coin support by fw version in suite

### DIFF
--- a/packages/suite/src/components/suite/CoinsGroup/CoinsList.tsx
+++ b/packages/suite/src/components/suite/CoinsGroup/CoinsList.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import styled from 'styled-components';
 import { Tooltip } from '@trezor/components';
+import { versionUtils } from '@trezor/utils';
 import { Coin, Translation } from '@suite-components';
 import { useDevice, useSelector } from '@suite-hooks';
 import { getUnavailabilityMessage } from '@suite-utils/device';
@@ -36,19 +37,36 @@ const CoinsList = ({
 
     return (
         <Wrapper>
-            {networks.map(({ symbol, label, tooltip, name }) => {
+            {networks.map(({ symbol, label, tooltip, name, support }) => {
                 const toggled = !!selectedNetworks?.includes(symbol);
-                const unavailable = device?.unavailableCapabilities?.[symbol];
+                let unavailable = device?.unavailableCapabilities?.[symbol];
 
                 const lockedTooltip = locked && 'TR_DISABLED_SWITCH_TOOLTIP';
-                const unavailabilityTooltip =
-                    unavailable &&
-                    getUnavailabilityMessage(unavailable, device.features?.major_version);
-                const anyTooltip = lockedTooltip || unavailabilityTooltip || tooltip;
 
                 const backend = backends[symbol];
                 const note = backend ? 'TR_CUSTOM_BACKEND' : label;
-                const disabled = !!unavailable || locked;
+
+                const features = device?.features;
+                const supportField = features && support && support[features.major_version];
+                const supportedBySuite =
+                    !supportField ||
+                    versionUtils.isNewerOrEqual(
+                        [features.major_version, features.minor_version, features.patch_version],
+                        supportField,
+                    );
+
+                if (!supportedBySuite) {
+                    unavailable = 'update-required';
+                }
+                const unavailabilityTooltip =
+                    unavailable && getUnavailabilityMessage(unavailable, features?.major_version);
+                const anyTooltip = lockedTooltip || unavailabilityTooltip || tooltip;
+
+                // Coin is not available because:
+                // - connect reports this in device.unavailableCapabilities (not supported by fw, not supported by connect)
+                // - suite considers device 'locked'
+                // - suite does not support it which is defined in network.ts
+                const disabled = !!unavailable || locked || !supportedBySuite;
 
                 return (
                     <Tooltip

--- a/packages/suite/src/config/wallet/networks.ts
+++ b/packages/suite/src/config/wallet/networks.ts
@@ -14,6 +14,11 @@ const networks = [
             account: 'https://btc1.trezor.io/xpub/',
         },
         features: ['rbf', 'sign-verify'],
+        // todo: to be used with cardano. leaving it here temporarily for review purposes
+        // support: {
+        //     1: '1.9.9',
+        //     2: '2.9.9',
+        // },
     },
     {
         name: 'Bitcoin (Taproot)',
@@ -426,6 +431,9 @@ type Network = {
     features?: string[];
     label?: ExtendedMessageDescriptor['id'];
     tooltip?: ExtendedMessageDescriptor['id'];
+    support?: {
+        [key: number]: string;
+    };
 } & ArrayElement<typeof networks>;
 
 export default [...networks] as Network[];


### PR DESCRIPTION

At the moment, we have information whether coin (or some feature) is supported by trezor-connect. This can be found in device.unavailableCapabilities.
```
{
  unavailableCapabilities:
  aopp: "update-required"
  decreaseOutput: "update-required"
  eip1559: "update-required"
  taproot: "update-required"
}
```

This information is set by trezor-connect based on [config.json](https://github.com/trezor/connect/blob/cfeb056f1d3c6b2f40fd45bb20e63931dea3f57b/src/data/config.json#L85) and [coins.json](https://github.com/trezor/connect/blob/cfeb056f1d3c6b2f40fd45bb20e63931dea3f57b/src/data/coins.json#L46) which is file generated from data in [trezor-firmare/common](https://github.com/trezor/trezor-firmware/tree/master/common/defs)

Now let's assume there is a coin which is generally supported by trezor-connect but we only want to support it in trezor-suite from certain version. I believe this is the case of cardano.

How should we do this? In my opinion trezor-connect shouldn't know anything about suite so my first idea was that this information could be stored in trezor-suite in `networks.ts`

Lets discuss.
