### PR TITLE
chore(pull-requests): fix docker image link

### DIFF
--- a/.github/workflows/project-automation.yml
+++ b/.github/workflows/project-automation.yml
@@ -13,28 +13,28 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: add-new-issues-to-repository-based-project-column
-        uses: docker://takanabe/github-actions-automate-projects:v0.0.2
+        uses: docker://takanabe/github-actions-automate-projects:latest
         if: github.event_name == 'issues' && github.event.action == 'opened'
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           GITHUB_PROJECT_URL: https://github.com/trezor/trezor-suite/projects/1
           GITHUB_PROJECT_COLUMN_NAME: 📥 Inbox
       - name: add-new-prs-to-repository-based-project-column
-        uses: docker://takanabe/github-actions-automate-projects:v0.0.2
+        uses: docker://takanabe/github-actions-automate-projects:latest
         if: github.event_name == 'pull_request' && github.event.action == 'opened'
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           GITHUB_PROJECT_URL: https://github.com/trezor/trezor-suite/projects/8
           GITHUB_PROJECT_COLUMN_NAME: 🗒 Draft
       - name: move-prs-to-review-column-by-label
-        uses: docker://takanabe/github-actions-automate-projects:v0.0.2
+        uses: docker://takanabe/github-actions-automate-projects:latest
         if: github.event_name == 'pull_request' && github.event.action == 'labeled' && github.event.label == 'READY TO REVIEW'
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           GITHUB_PROJECT_URL: https://github.com/trezor/trezor-suite/projects/8
           GITHUB_PROJECT_COLUMN_NAME: 🔎 To be reviewed
       - name: move-prs-to-review-column-by-status
-        uses: docker://takanabe/github-actions-automate-projects:v0.0.2
+        uses: docker://takanabe/github-actions-automate-projects:latest
         if: github.event_name == 'pull_request' && github.event.action == 'ready_for_review'
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
- there is no image for v0.0.2 unfortunatelly https://hub.docker.com/r/takanabe/github-actions-automate-projects/tags
- there is only latest tag https://hub.docker.com/r/takanabe/github-actions-automate-projects/tags
- v0.0.1 supports only "opened" action and we want other actions too