### PR TITLE
Chore/redux actions typing

### DIFF
--- a/packages/suite-native/src/actions/settings/languageActions.ts
+++ b/packages/suite-native/src/actions/settings/languageActions.ts
@@ -2,8 +2,9 @@
 
 import { SUITE } from '@suite-actions/constants';
 import type { Locale } from '@suite-config/languages';
+import type { SuiteAction } from '@suite-actions/suiteActions';
 
-export const setLanguage = (locale: Locale) => ({
+export const setLanguage = (locale: Locale): SuiteAction => ({
     type: SUITE.SET_LANGUAGE,
     locale,
 });

--- a/packages/suite/src/actions/settings/languageActions.ts
+++ b/packages/suite/src/actions/settings/languageActions.ts
@@ -1,8 +1,9 @@
 import { SUITE } from '@suite-actions/constants';
 import { ensureLocale } from '@suite-utils/l10n';
 import type { Locale } from '@suite-config/languages';
+import type { SuiteAction } from '@suite-actions/suiteActions';
 
-export const setLanguage = (locale: Locale) => ({
+export const setLanguage = (locale: Locale): SuiteAction => ({
     type: SUITE.SET_LANGUAGE,
     locale: ensureLocale(locale),
 });

--- a/packages/suite/src/actions/settings/walletSettingsActions.ts
+++ b/packages/suite/src/actions/settings/walletSettingsActions.ts
@@ -25,7 +25,7 @@ export type WalletSettingsAction =
           };
       };
 
-export const setLocalCurrency = (localCurrency: string) => ({
+export const setLocalCurrency = (localCurrency: string): WalletSettingsAction => ({
     type: WALLET_SETTINGS.SET_LOCAL_CURRENCY,
     localCurrency: localCurrency.toLowerCase(),
 });

--- a/packages/suite/src/actions/suite/guideActions.ts
+++ b/packages/suite/src/actions/suite/guideActions.ts
@@ -12,11 +12,11 @@ export type GuideAction =
     | { type: typeof GUIDE.UNSET_NODE }
     | { type: typeof GUIDE.OPEN_NODE; payload: Node };
 
-export const open = () => ({
+export const open = (): GuideAction => ({
     type: GUIDE.OPEN,
 });
 
-export const close = () => ({
+export const close = (): GuideAction => ({
     type: GUIDE.CLOSE,
 });
 

--- a/packages/suite/src/actions/suite/messageSystemActions.ts
+++ b/packages/suite/src/actions/suite/messageSystemActions.ts
@@ -118,7 +118,7 @@ export const saveValidMessages = (payload: ValidMessagesPayload) => ({
     payload,
 });
 
-export const dismissMessage = (id: string, category: Category) => ({
+export const dismissMessage = (id: string, category: Category): MessageSystemAction => ({
     type: MESSAGE_SYSTEM.DISMISS_MESSAGE,
     id,
     category,

--- a/packages/suite/src/actions/suite/modalActions.ts
+++ b/packages/suite/src/actions/suite/modalActions.ts
@@ -139,7 +139,7 @@ export const onPinSubmit = (payload: string) => () => {
     TrezorConnect.uiResponse({ type: UI.RECEIVE_PIN, payload });
 };
 
-export const onPinCancel = () => {
+export const onPinCancel = () => () => {
     TrezorConnect.cancel('pin-cancelled');
 };
 

--- a/packages/suite/src/actions/suite/suiteActions.ts
+++ b/packages/suite/src/actions/suite/suiteActions.ts
@@ -96,12 +96,12 @@ export const setDbError = (payload: AppState['suite']['dbError']) => ({
     payload,
 });
 
-export const setTheme = (variant: SuiteThemeVariant) => ({
+export const setTheme = (variant: SuiteThemeVariant): SuiteAction => ({
     type: SUITE.SET_THEME,
     variant,
 });
 
-export const setAutodetect = (payload: Partial<AutodetectSettings>) => ({
+export const setAutodetect = (payload: Partial<AutodetectSettings>): SuiteAction => ({
     type: SUITE.SET_AUTODETECT,
     payload,
 });
@@ -144,12 +144,12 @@ export const updateOnlineStatus = (payload: boolean): SuiteAction => ({
  * @param {boolean} payload
  * @returns {Action}
  */
-export const updateTorStatus = (payload: boolean) => ({
+export const updateTorStatus = (payload: boolean): SuiteAction => ({
     type: SUITE.TOR_STATUS,
     payload,
 });
 
-export const setOnionLinks = (payload: boolean) => ({
+export const setOnionLinks = (payload: boolean): SuiteAction => ({
     type: SUITE.ONION_LINKS,
     payload,
 });

--- a/packages/suite/src/actions/wallet/coinmarket/coinmarketCommonActions.ts
+++ b/packages/suite/src/actions/wallet/coinmarket/coinmarketCommonActions.ts
@@ -152,6 +152,6 @@ export const setLoading = (isLoading: boolean, lastLoadedTimestamp?: number) => 
     ...(lastLoadedTimestamp && { lastLoadedTimestamp }),
 });
 
-export const loadInvityData = () => ({
+export const loadInvityData = (): CoinmarketCommonAction => ({
     type: COINMARKET_COMMON.LOAD_DATA,
 });

--- a/packages/suite/src/hooks/suite/useActions.ts
+++ b/packages/suite/src/hooks/suite/useActions.ts
@@ -1,9 +1,9 @@
 import { useMemo, useRef } from 'react';
 import { useDispatch } from 'react-redux';
 import { bindActionCreators, ActionCreatorsMapObject } from 'redux';
-import { Dispatch } from '@suite-types';
+import type { Action, ThunkAction, Dispatch } from '@suite-types';
 
-export const useActions = <M extends ActionCreatorsMapObject<any>>(actions: M) => {
+export const useActions = <M extends ActionCreatorsMapObject<Action | ThunkAction>>(actions: M) => {
     const dispatch = useDispatch<Dispatch>();
     const ref = useRef(actions);
     return useMemo(() => bindActionCreators(ref.current, dispatch), [dispatch, ref]);

--- a/packages/suite/src/types/suite/index.ts
+++ b/packages/suite/src/types/suite/index.ts
@@ -1,4 +1,4 @@
-import type { ThunkDispatch } from 'redux-thunk';
+import type { ThunkDispatch, ThunkAction as TAction } from 'redux-thunk';
 import type { Store as ReduxStore } from 'redux';
 import type {
     UiEvent,
@@ -69,6 +69,8 @@ export type Action =
     | MessageSystemAction
     | GuideAction
     | ProtocolAction;
+
+export type ThunkAction = TAction<any, AppState, any, Action>;
 
 // export type Dispatch = ReduxDispatch<Action>;
 // export type Dispatch = ThunkDispatch<AppState, any, Action>;


### PR DESCRIPTION
Fixed typing of `useActions` hook. Up to now, <code>ActionCreatorsMapObject<**any**></code> was used, therefore code like this was perfectly valid from `ts` point of view:

```
useActions({
    foobar: () => ({ type: 'nonsense' })
})
```

After changing to <code>ActionCreatorsMapObject<**Action | ThunkAction**></code>, only Actions `({ type: 'our-type', ...payload })` and ThunkActions `(dispatch: OurDispatch, getState: () => OurState) => any` are allowed.

Real-life example: There was a
```
const actions = useActions({
    onPinCancel: actions.onPinCancel,
});
```

call, but `onPinCancel` returned neither `Action` nor `ThunkAction`, therefore couldn't have been dispatched at all (which we ignored because the action apparently wasn't called anywhere) even if the code was valid.