### PR TITLE
Fix/custom backend onion

### DIFF
--- a/packages/suite/src/components/suite/modals/AdvancedCoinSettings/components/CustomBackends.tsx
+++ b/packages/suite/src/components/suite/modals/AdvancedCoinSettings/components/CustomBackends.tsx
@@ -91,7 +91,7 @@ export const CustomBackends = ({ network, onCancel }: CustomBackendsProps) => {
             <BackendTypeSelect network={network} value={type} onChange={changeType} />
 
             {(editable ? urls : defaultUrls).map(u => {
-                const url = tor ? toTorUrl(u) : u;
+                const url = tor && !editable ? toTorUrl(u) : u;
                 return (
                     <BackendInput
                         key={url}

--- a/patches/trezor-connect+8.2.7-beta.3.patch
+++ b/patches/trezor-connect+8.2.7-beta.3.patch
@@ -1,5 +1,5 @@
 diff --git a/node_modules/trezor-connect/lib/backend/BlockchainLink.js b/node_modules/trezor-connect/lib/backend/BlockchainLink.js
-index 765cf6b..63e79d6 100644
+index 765cf6b..746eb03 100644
 --- a/node_modules/trezor-connect/lib/backend/BlockchainLink.js
 +++ b/node_modules/trezor-connect/lib/backend/BlockchainLink.js
 @@ -38,6 +38,9 @@ var getWorker = function getWorker(type) {
@@ -12,6 +12,67 @@ index 765cf6b..63e79d6 100644
      default:
        return null;
    }
+@@ -59,9 +62,16 @@ var Blockchain = /*#__PURE__*/function () {
+ 
+     if (!worker) {
+       throw _constants.ERRORS.TypedError('Backend_WorkerMissing', "BlockchainLink worker not found " + blockchainLink.type);
+-    }
++    } // map clean urls in to object. key = onion domain, value = clean domain
+ 
+-    var server = options.onionDomains ? (0, _urlUtils.getOnionDomain)(blockchainLink.url, options.onionDomains) : blockchainLink.url;
++
++    var onionDomains = options.onionDomains;
++    this.onionDomains = onionDomains ? blockchainLink.url.reduce(function (a, url) {
++      var onion = (0, _urlUtils.getOnionDomain)(url, onionDomains);
++      a[onion] = url;
++      return a;
++    }, {}) : {};
++    var server = onionDomains ? Object.keys(this.onionDomains) : blockchainLink.url;
+     this.link = new _blockchainLink["default"]({
+       name: this.coinInfo.shortcut,
+       worker: worker,
+@@ -92,7 +102,7 @@ var Blockchain = /*#__PURE__*/function () {
+           switch (_context2.prev = _context2.next) {
+             case 0:
+               this.link.on('connected', /*#__PURE__*/(0, _asyncToGenerator2["default"])( /*#__PURE__*/_regenerator["default"].mark(function _callee() {
+-                var info, shortcut;
++                var info, shortcut, cleanUrl;
+                 return _regenerator["default"].wrap(function _callee$(_context) {
+                   while (1) {
+                     switch (_context.prev = _context.next) {
+@@ -116,14 +126,18 @@ var Blockchain = /*#__PURE__*/function () {
+                         return _context.abrupt("return");
+ 
+                       case 7:
+-                        // eslint-disable-next-line no-use-before-define
+-                        setPreferredBacked(_this.coinInfo, info.url);
++                        // find clean domain for current connection
++                        cleanUrl = _this.onionDomains[info.url]; // eslint-disable-next-line no-use-before-define
++
++                        setPreferredBacked(_this.coinInfo, cleanUrl || info.url);
+ 
+-                        _this.postMessage((0, _builder.BlockchainMessage)(_constants.BLOCKCHAIN.CONNECT, _objectSpread({
++                        _this.postMessage((0, _builder.BlockchainMessage)(_constants.BLOCKCHAIN.CONNECT, _objectSpread(_objectSpread({
+                           coin: _this.coinInfo
+-                        }, info)));
++                        }, info), {}, {
++                          cleanUrl: cleanUrl
++                        })));
+ 
+-                      case 9:
++                      case 10:
+                       case "end":
+                         return _context.stop();
+                     }
+@@ -481,7 +495,7 @@ var initBlockchain = /*#__PURE__*/function () {
+               postMessage: postMessage,
+               debug: _DataManager["default"].getSettings('debug'),
+               proxy: _DataManager["default"].getSettings('proxy'),
+-              onionDomains: _DataManager["default"].getSettings('useOnionLinks') ? _DataManager["default"].getConfig().onionDomains : undefined
++              onionDomains: _DataManager["default"].getSettings('useOnionLinks') && !customBackends[coinInfo.shortcut] ? _DataManager["default"].getConfig().onionDomains : undefined
+             });
+             instances.push(backend);
+             _context6.prev = 4;
 diff --git a/node_modules/trezor-connect/lib/env/node/workers.js b/node_modules/trezor-connect/lib/env/node/workers.js
 index 4ca7840..f2c38cb 100644
 --- a/node_modules/trezor-connect/lib/env/node/workers.js


### PR DESCRIPTION
- patch trezor-connect custom backend domain to onion transaltion fix https://github.com/trezor/connect/pull/1045/commits/edf3e71f16ba26ff41b8693dd3581d565879d6e2 commit from https://github.com/trezor/connect/pull/1045
  
- do not use `toTorUrl` on custom backends (editable fields)