### PR TITLE
fix: trezord kill on app exit

### DIFF
--- a/packages/suite-desktop/src-electron/app.ts
+++ b/packages/suite-desktop/src-electron/app.ts
@@ -83,6 +83,23 @@ const init = async () => {
     logger.debug('init', `Load URL (${src})`);
     mainWindow.loadURL(src);
 
+    let resizeDebounce: ReturnType<typeof setTimeout> | null = null;
+    mainWindow.on('resize', () => {
+        if (resizeDebounce) return;
+        resizeDebounce = setTimeout(() => {
+            resizeDebounce = null;
+            if (!mainWindow) return;
+            const winBound = mainWindow.getBounds() as WinBounds;
+            store.setWinBounds(winBound);
+            logger.debug('app', 'new winBounds saved');
+        }, 1000);
+    });
+    mainWindow.on('closed', () => {
+        if (resizeDebounce) {
+            clearTimeout(resizeDebounce);
+        }
+    });
+
     const interceptor = createInterceptor();
 
     // Modules

--- a/packages/suite-desktop/src-electron/modules/shortcuts.ts
+++ b/packages/suite-desktop/src-electron/modules/shortcuts.ts
@@ -1,4 +1,3 @@
-import { app } from 'electron';
 import electronLocalshortcut from 'electron-localshortcut';
 
 const init = ({ mainWindow, src }: Dependencies) => {
@@ -21,10 +20,6 @@ const init = ({ mainWindow, src }: Dependencies) => {
     electronLocalshortcut.register(mainWindow, 'CommandOrControl+R', () => {
         logger.info('shortcuts', 'CTRL+R pressed');
         mainWindow.loadURL(src);
-    });
-
-    app.on('before-quit', () => {
-        electronLocalshortcut.unregisterAll(mainWindow);
     });
 };
 

--- a/packages/suite-desktop/src-electron/modules/window-controls.ts
+++ b/packages/suite-desktop/src-electron/modules/window-controls.ts
@@ -3,7 +3,7 @@
  */
 import { app, ipcMain } from 'electron';
 
-const init = ({ mainWindow, store }: Dependencies) => {
+const init = ({ mainWindow }: Dependencies) => {
     const { logger } = global;
 
     if (process.platform === 'darwin') {
@@ -79,12 +79,6 @@ const init = ({ mainWindow, store }: Dependencies) => {
     ipcMain.on('app/focus', () => {
         logger.debug('window-control', 'Focus requested');
         app.focus({ steal: true });
-    });
-
-    app.on('before-quit', () => {
-        // store window bounds on cmd/ctrl+q
-        const winBound = mainWindow.getBounds() as WinBounds;
-        store.setWinBounds(winBound);
     });
 };
 


### PR DESCRIPTION
Found that there were 2 places stopping `before-quit` events from executing. 

-  when calling `mainWindow.getBounds()` inside `before-quite` event. Doing this feels wrong in general as this event is fired after `window-all-closed` so doing something with browserWindow instance which maybe (I am not sure yet, did not check that yet) does not exist anymore doesn't feel right. 
-  to my dismay, also calling `electronLocalshortcut.unregisterAll(mainWindow);` in `before-quit` stops further `before-quit` events from executing. I don't know why yet, but my first question is whether it is needed to unregister some event listeners for key presses when app is going to stop after few miliseconds anyway? 

As it is now, it should be fixing #4904 and also it fixes a bug (not sure if there is an issue) that window size is not saved and therefore can't be restored on next application run. 