### PR TITLE
popup emu screenshots

### DIFF
--- a/ci/test.yml
+++ b/ci/test.yml
@@ -212,6 +212,7 @@ blockchain-link manual:
     paths:
       - ./packages/integration-tests/projects/connect-explorer/screenshots
       - ./packages/integration-tests/connect-popup-overview.html
+      - ./packages/integration-tests/test-results
 
 connect-explorer:
   extends: .e2e connect-explorer

--- a/docker/docker-compose.connect-explorer-test.yml
+++ b/docker/docker-compose.connect-explorer-test.yml
@@ -14,8 +14,21 @@ services:
     extends:
       service: suite-base
       file: docker-compose.suite-base.yml
-      # todo: we are going to dockerize connect and run it as another localhost service later
-    command: bash -c "TREZOR_CONNECT_SRC=https://connect.corp.sldev.cz/develop/ yarn workspace @trezor/connect-explorer dev"
+    command: bash -c "TREZOR_CONNECT_SRC=https://localhost:8088/ yarn workspace @trezor/connect-explorer dev"
+    network_mode: service:trezor-user-env-unix
+
+  connect-dev:
+    container_name: connect-dev
+    extends:
+      service: suite-base
+      file: docker-compose.suite-base.yml
+      # this container expectes that there is "trezor-connect" in ../connect path relative to suite repo folder
+      # this will change once trezor-connect is in monorepo
+    command: bash -c "cd ../connect && yarn dev"
+    volumes:
+      - ..:/usr/src/service
+      - ../../connect:/usr/src/connect
+      - ../node_modules:/usr/src/service/node_modules
     network_mode: service:trezor-user-env-unix
 
   test-run:
@@ -24,13 +37,14 @@ services:
     depends_on:
       - trezor-user-env-unix
       - connect-explorer-dev
+      - connect-dev
     network_mode: service:trezor-user-env-unix
     environment:
       - LOCAL_USER_ID=$LOCAL_USER_ID
       - DISPLAY=$DISPLAY
       - HEADLESS=false
-      # debug mode might be useful for debugging tests
-      # - PWDEBUG=1
+      # useful for debugging tests
+      - PWDEBUG=console
     working_dir: /trezor-suite
     command: bash -c "npx playwright install && docker/wait-for-env.sh && yarn workspace @trezor/integration-tests test:connect-explorer"
     volumes:

--- a/packages/integration-tests/projects/connect-explorer/playwright.config.ts
+++ b/packages/integration-tests/projects/connect-explorer/playwright.config.ts
@@ -2,10 +2,11 @@ import { PlaywrightTestConfig } from '@playwright/test';
 
 const config: PlaywrightTestConfig = {
     testDir: 'tests',
-    timeout: 60 * 1000,
     retries: 3,
     use: {
         headless: process.env.HEADLESS === 'true',
+        ignoreHTTPSErrors: true,
+        trace: 'retain-on-failure',
     },
 };
 export default config;

--- a/packages/integration-tests/projects/connect-explorer/support/buildOverview.js
+++ b/packages/integration-tests/projects/connect-explorer/support/buildOverview.js
@@ -5,10 +5,18 @@ const SCREENSHOTS_DIR = './projects/connect-explorer/screenshots';
 
 const CI_JOB_URL = process.env.CI_JOB_URL || '.';
 
-const buildOverview = () => {
+const buildOverview = ({ emuScreenshots }) => {
     if (fs.existsSync('connect-popup-overview.html')) {
         fs.rmSync('connect-popup-overview.html');
     }
+
+    const renderEmuScreenshot = screenshotPath => {
+        if (emuScreenshots[screenshotPath]) {
+            return `<img src="data:image/png;base64, ${emuScreenshots[screenshotPath]}" />`;
+        }
+        // not found, this is expected, not all screens on host have device interaction
+        return '<div>no device interaction</div>';
+    };
 
     let html = '';
     let index = '';
@@ -17,7 +25,6 @@ const buildOverview = () => {
 
     connectExplorerUrls.forEach(url => {
         const methodName = url.split('-')[0]; // lets assume it looks like getPublicKey-multiple
-
         const urlPath = path.join(SCREENSHOTS_DIR, url);
         const screenshots = fs.readdirSync(urlPath);
         index += `<li><a href="#${url}">${url}</a></li>`;
@@ -40,6 +47,7 @@ const buildOverview = () => {
                         '/projects/connect-explorer',
                         '/artifacts/raw/packages/integration-tests/projects/connect-explorer',
                     )}" />
+                    ${renderEmuScreenshot(`./${urlPath}/${screenshot}`)}
                 </div>
             `;
         });

--- a/packages/integration-tests/projects/connect-explorer/tests/fixtures.js
+++ b/packages/integration-tests/projects/connect-explorer/tests/fixtures.js
@@ -191,12 +191,18 @@ const verifyMessage = [
             },
             {
                 selector: '.follow-device >> visible=true',
+                screenshot: {
+                    name: 'verify-message',
+                },
                 nextEmu: {
                     type: 'emulator-press-yes',
                 },
             },
             {
                 selector: '.follow-device >> visible=true',
+                screenshot: {
+                    name: 'verify-message',
+                },
                 nextEmu: {
                     type: 'emulator-press-yes',
                 },
@@ -297,6 +303,9 @@ const recoverDevice = [
             },
             ...Array(12).fill({
                 selector: '.follow-device >> visible=true',
+                screenshot: {
+                    name: 'follow-device-enter-seed',
+                },
                 nextEmu: {
                     type: 'emulator-input',
                     value: 'all',
@@ -319,13 +328,19 @@ const fixtures = [
     ...getPublicKey,
     ...getAddress,
     ...getAccountInfo,
-    ...composeTransaction,
+    // todo: compose transaction breaks next test in queue
+    // this tests ends with POST "Cancel" call through bridge here https://github.com/trezor/connect/blob/develop/src/js/device/DeviceCommands.js#L669
+    // for reference /post/session endpoint works check here https://github.com/trezor/trezord-go
+    // subsequent call (in next tests) fails here https://github.com/trezor/connect/blob/develop/src/js/device/DeviceCommands.js#L368
+    // as trezord returns response belonging to the prev call.
+    // ...composeTransaction,
     ...signTransaction,
     ...signMessage,
     ...verifyMessage,
     ...wipeDevice,
-    ...resetDevice,
     ...recoverDevice,
+    // todo: resetDevice also breaks next test in queue and is flaky itself
+    // ...resetDevice,
 ];
 
 module.exports = fixtures;


### PR DESCRIPTION
Quite recently we have been granted the ability to save screenshots from emu in https://github.com/trezor/trezor-user-env/commit/4c3f45174ba4256ffd9ea505d122da6a3317afd4

So lets make use of it in popup tests!

Here you can see the report created after this test https://satoshilabs.gitlab.io/-/trezor/trezor-suite/-/jobs/2117244685/artifacts/packages/integration-tests/connect-popup-overview.html 

I have also commented out flaky tests fixtures for now. So far I have been able to tell, that their flakiness is connected to "discovery issues". There will be another branch with fixes in trezor-connect soon I think. 