### PR TITLE
test: electrum integration test with regtest bitcoind 

### DIFF
--- a/ci/test.yml
+++ b/ci/test.yml
@@ -169,13 +169,15 @@ transport manual:
 # @trezor/blockchain-link
 .e2e blockchain-link:
   stage: integration testing
+  variables:
+    COMPOSE_FILE: ./docker/docker-compose.blockchain-link-ci.yml
   script:
     - yarn install --frozen-lockfile --cache-folder .yarn --prefer-offline
     - yarn workspace @trezor/utils build:lib
     - yarn workspace @trezor/utxo-lib build:lib
     - yarn workspace @trezor/blockchain-link build:lib
     - yarn workspace @trezor/blockchain-link build:workers
-    - yarn workspace @trezor/blockchain-link test:integration
+    - docker-compose up
 
 blockchain-link:
   extends: .e2e blockchain-link

--- a/docker/docker-blockchain-link-test.sh
+++ b/docker/docker-blockchain-link-test.sh
@@ -1,0 +1,6 @@
+#!/usr/bin/env bash
+set -e
+
+export LOCAL_USER_ID=`id -u $USER`
+
+docker-compose -f ./docker/docker-compose.blockchain-link-test.yml up --build --abort-on-container-exit --force-recreate

--- a/docker/docker-compose.blockchain-link-ci.yml
+++ b/docker/docker-compose.blockchain-link-ci.yml
@@ -1,0 +1,27 @@
+version: '3'
+services:
+  trezor-user-env-unix:
+    image: registry.gitlab.com/satoshilabs/trezor/trezor-user-env/trezor-user-env
+    environment:
+      - SDL_VIDEODRIVER=dummy
+      - XDG_RUNTIME_DIR=/var/tmp
+    network_mode: bridge # this makes docker reuse existing networks
+
+  electrum-regtest:
+    image: ghcr.io/vdovhanych/electrs:latest
+    network_mode: service:trezor-user-env-unix
+
+  test-run:
+    build:
+      context: .
+      dockerfile: ./suite/Dockerfile
+    depends_on:
+      - electrum-regtest
+    network_mode: service:trezor-user-env-unix
+    environment:
+      - NODE_ENV=development
+      - LOCAL_USER_ID=$LOCAL_USER_ID
+    working_dir: /trezor-suite
+    command: bash -c "yarn workspace @trezor/blockchain-link test:integration"
+    volumes:
+      - ../:/trezor-suite

--- a/docker/docker-compose.blockchain-link-test.yml
+++ b/docker/docker-compose.blockchain-link-test.yml
@@ -1,0 +1,20 @@
+version: '3'
+services:
+  electrum-regtest:
+    image: ghcr.io/vdovhanych/electrs:latest
+    network_mode: bridge  # this makes docker reuse existing networks
+
+  test-run:
+    build:
+      context: .
+      dockerfile: ./suite/Dockerfile
+    depends_on:
+      - electrum-regtest
+    network_mode: service:electrum-regtest
+    environment:
+      - NODE_ENV=development
+      - LOCAL_USER_ID=$LOCAL_USER_ID
+    working_dir: /trezor-suite
+    command: bash -c "yarn workspace @trezor/blockchain-link test:integration"
+    volumes:
+      - ../:/trezor-suite

--- a/packages/blockchain-link/tests/integration/electrum.ts
+++ b/packages/blockchain-link/tests/integration/electrum.ts
@@ -1,0 +1,67 @@
+import ElectrumWorker from '../../lib/workers/electrum';
+import type { Message, Response } from '../../src/types';
+import { GET_ACCOUNT_INFO, HANDSHAKE } from '../../src/constants/messages';
+
+const TCP_CONFIG = '127.0.0.1:50001:t';
+const NETWORK = 'REGTEST';
+
+describe('Electrum', () => {
+    const worker = ElectrumWorker();
+    const resolvers: { [id: number]: (value: any) => void } = {};
+    let id = 1;
+
+    const sendAndWait = (data: Message) =>
+        new Promise(resolve => {
+            resolvers[data.id] = resolve;
+            worker.postMessage(data);
+        });
+
+    worker.onmessage = ({ data }: { data: Response }) => {
+        if (resolvers[data.id]) {
+            resolvers[data.id](data);
+        }
+    };
+
+    worker.postMessage({
+        type: HANDSHAKE,
+        id,
+        settings: {
+            name: NETWORK,
+            worker: 'unknown',
+            server: [TCP_CONFIG],
+            debug: true,
+        },
+    });
+
+    afterAll(() => {
+        worker.cleanup();
+    });
+
+    it('Connect to electrum', async () => {
+        const testId = ++id;
+        const waited = await sendAndWait({ id: testId, type: 'm_connect' });
+        expect(waited).toEqual({ id: testId, type: 'r_connect', payload: true });
+    });
+
+    it('Get account info return format', async () => {
+        const address = 'bcrt1qu0k7jjux76kpgjhnqn4kyfg6yuekhnd246pjlf';
+        const testId = ++id;
+        const waited = await sendAndWait({
+            id: testId,
+            type: GET_ACCOUNT_INFO,
+            payload: { descriptor: address, details: 'txs' },
+        });
+        expect(waited).toEqual({
+            id: testId,
+            type: 'r_account_info',
+            payload: {
+                descriptor: address,
+                balance: '0',
+                availableBalance: '0',
+                empty: true,
+                history: { total: 0, unconfirmed: 0, transactions: [] },
+                page: { index: 1, size: 25, total: 1 },
+            },
+        });
+    });
+});


### PR DESCRIPTION
Closes https://github.com/trezor/trezor-suite/issues/4731

Simple integration test that test some proper gathering data by electrum worker in blockchain-link that is tested against a electrs running with a bitcoind regtest as backend.

This is now just testing that the connection is established and that we get data for method `GET_ACCOUNT_INFO` in the expected format. This is the structure for tests that can be extended for example with  more functionality like sending and receiving to address in an xpub...

It is using  the docker image that is currently in personal @[vdovhanych](https://github.com/vdovhanych) repository https://github.com/vdovhanych/docker-electrs until we find a proper location for it.

