### PR TITLE
feat(ci): automation for updating crowdin translations

### DIFF
--- a/.github/workflows/crowdin_sync.yml
+++ b/.github/workflows/crowdin_sync.yml
@@ -1,0 +1,28 @@
+name: Crowdin translations update
+
+on: [workflow_dispatch]
+
+jobs:
+  crowdin-sync:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+      - name: Setup node
+        uses: actions/setup-node@v2
+        with:
+          node-version-file: ".nvmrc"
+
+      - name: Run crowdin sync
+        run: |
+          npm install -g yarn && yarn install
+          git config --global user.name "trezor-ci"
+          git config --global user.email "${{ secrets.TREZOR_BOT_EMAIL }}"
+          git checkout -B trezor-ci/crowdin-sync
+          yarn workspace @trezor/suite translations:download --token=${{ secrets.CROWDIN_PERSONAL_TOKEN }}
+          git add . && git commit -m "chore: crowdin translation update" && git push origin trezor-ci/crowdin-sync -f
+          gh config set prompt disabled
+          gh pr create --repo trezor/trezor-suite --title "Crowdin translations update" --body "Automatically generated PR for updating crowdin translations." --base develop --label translations
+        env:
+          GITHUB_TOKEN: ${{ secrets.TREZOR_BOT_TOKEN }}
+          CROWDIN_PERSONAL_TOKEN: ${{ secrets.CROWDIN_PERSONAL_TOKEN }}


### PR DESCRIPTION
This pr introduces a semi-automated crowdin translations update. There will be action (job) you can manually trigger to download new translations and create PR into develop with the changes.  

Some not yet resolved things for this. 
1. If you trigger the job and there is older PR still open the job will **FAIL**
2. No option to generate meaningful commit message, it will be the same every time

Thinking if this should also add some docs on how to trigger the workflow from github interface or with gh cli. 