### PR TITLE
github actions fixes and some cleanup for better consistency

### DIFF
--- a/.github/workflows/crowdin_sync.yml
+++ b/.github/workflows/crowdin_sync.yml
@@ -20,6 +20,7 @@ jobs:
           git config --global user.email "${{ secrets.TREZOR_BOT_EMAIL }}"
           git checkout -B trezor-ci/crowdin-sync
           yarn workspace @trezor/suite translations:download --token=${{ secrets.CROWDIN_PERSONAL_TOKEN }}
+          yarn workspace @trezor/suite translations:format
           git add . && git commit -m "chore: crowdin translation update" && git push origin trezor-ci/crowdin-sync -f
           gh config set prompt disabled
           gh pr create --repo trezor/trezor-suite --title "Crowdin translations update" --body "Automatically generated PR for updating crowdin translations." --base develop --label translations

--- a/.github/workflows/fixup_check.yml
+++ b/.github/workflows/fixup_check.yml
@@ -1,9 +1,9 @@
-name: Git Checks
+name: Fixup commit check
 
 on: [pull_request]
 
 jobs:
-  block-fixup:
+  block-fixup-commit:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2.0.0

--- a/.github/workflows/project_automation.yml
+++ b/.github/workflows/project_automation.yml
@@ -17,11 +17,11 @@ jobs:
         run: gh issue edit $ISSUE --add-project "Backlog 🗂"
         env:
           ISSUE: ${{github.event.issue.html_url}}
-          GITHUB_TOKEN: ${{ secrets.GH_BOT_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.TREZOR_BOT_TOKEN }}
 
       - name: Add new pull request to the Pull Requests project board
         if: github.event_name == 'pull_request' && github.event.action == 'opened'
         run: gh pr edit $PULL_REQUEST --add-project "Pull Requests"
         env:
           PULL_REQUEST: ${{github.event.pull_request.html_url}}
-          GITHUB_TOKEN: ${{ secrets.GH_BOT_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.TREZOR_BOT_TOKEN }}

--- a/.github/workflows/validation.yml
+++ b/.github/workflows/validation.yml
@@ -1,4 +1,4 @@
-name: Validation
+name: Validation check
 
 on: [pull_request]
 
@@ -11,8 +11,8 @@ jobs:
         uses: actions/setup-node@v2
         with:
           node-version-file: ".nvmrc"
-      - run: |
-          npm install -g yarn
+      - name: install yarn
+        run: npm install -g yarn
       - name: deduplicate deps
         run: npx yarn-deduplicate --list --fail
       - name: install deps

--- a/packages/suite/package.json
+++ b/packages/suite/package.json
@@ -10,7 +10,7 @@
         "translations:format": "yarn prettier --write \"../suite-data/files/translations/*\"",
         "translations:extract": "formatjs extract src/support/messages.ts --format simple > ../suite-data/files/translations/master.json",
         "translations:upload": "crowdin upload",
-        "translations:download": "crowdin download --all && translations:format",
+        "translations:download": "crowdin download --all",
         "translations:backport-en": "yarn ts-node -O '{\"module\": \"commonjs\"}' ../suite-data/scripts/backport-en.ts && yarn prettier --write \"./src/support/messages.ts\"",
         "translations:list-duplicates": "yarn ts-node -O '{\"module\": \"commonjs\"}' ../suite-data/scripts/list-duplicates.ts",
         "type-check": "tsc --project tsconfig.json",


### PR DESCRIPTION
I removed the translations:format  from translations:download script and left it only as a standalone one. This fixes the automation in the github action and we should only update translations in the CI from now on.

- chore(ci): cleanup files and change step names for better consistency
- chore(ci): remove translations format from download script and add it to crowdin gh action
