### PR TITLE
feat(message-system):  inform mac EAP users about broken autoupdater on 22.2.1 and 22.2.2

### DIFF
--- a/packages/suite-data/src/message-system/config/config.v1.json
+++ b/packages/suite-data/src/message-system/config/config.v1.json
@@ -1,8 +1,52 @@
 {
     "version": 1,
     "timestamp": "2022-02-17T00:00:00+00:00",
-    "sequence": 7,
+    "sequence": 8,
     "actions": [
+        {
+            "conditions": [
+                {
+                    "environment": {
+                        "desktop": ["22.2.1", "22.2.2"],
+                        "mobile": "!",
+                        "web": "!"
+                    },
+                    "os": {
+                        "macos": "*",
+                        "linux": "!",
+                        "windows": "!",
+                        "android": "!",
+                        "ios": "!",
+                        "chromeos": "!"
+                    }
+                }
+            ],
+            "message": {
+                "id": "13644716-b26b-4f62-808d-6ee0dfb23069",
+                "priority": 97,
+                "dismissible": true,
+                "variant": "critical",
+                "category": "banner",
+                "content": {
+                    "en-GB": "We’re sorry, the auto-update feature is broken. Please install the latest version of Trezor Suite.",
+                    "en": "We’re sorry, the auto-update feature is broken. Please install the latest version of Trezor Suite.",
+                    "es": "Lo sentimos, la función de actualización automática no funciona. Por favor, instale la última versión de Trezor Suite.",
+                    "cs": "Je nám líto, ale automatická aktualizace je nefunkční. Nainstalujte si prosím nejnovější verzi Trezor Suite.",
+                    "ru": " К сожалению, функция авто-обновления сломалась. Пожалуйста, установите последнюю версию Trezor Suite вручную."
+                },
+                "cta": {
+                    "action": "external-link",
+                    "link": "https://suite.trezor.io/",
+                    "label": {
+                        "en-GB": "Go to suite.trezor.io",
+                        "en": "Go to suite.trezor.io",
+                        "es": "Vaya a suite.trezor.io",
+                        "cs": "Přejít na suite.trezor.io",
+                        "ru": "Перейти на suite.trezor.io"
+                    }
+                }
+            }
+        },
         {
             "conditions": [
                 {


### PR DESCRIPTION
Unfortunatelly the message is visible only if the user close the Update modal due to https://github.com/trezor/trezor-suite/issues/4964
<img width="1207" alt="image" src="https://user-images.githubusercontent.com/3729633/154711975-156291f7-721b-43fc-a237-a4b6e1c180d5.png">

<img width="1210" alt="image" src="https://user-images.githubusercontent.com/3729633/154711997-7c707a8b-0d87-4e84-9438-a9f2709ad050.png">
