### PR TITLE
Analytics in onboarding

### DIFF
--- a/docs/misc/analytics.md
+++ b/docs/misc/analytics.md
@@ -20,12 +20,10 @@ Data from **production** builds (codesign branch) are sent to:
 -   Desktop build: https://data.trezor.io/suite/log/desktop/stable.log
 -   Web build: https://data.trezor.io/suite/log/web/stable.log
 
-Data from **development** builds are sent to:
+Data from **development** and **localhost** builds are sent to:
 
 -   Desktop build: https://data.trezor.io/suite/log/desktop/develop.log
 -   Web build: https://data.trezor.io/suite/log/web/develop.log
-
-Data from localhost are not currently tracked anywhere.
 
 List of available configured endpoints:
 

--- a/docs/misc/analytics.md
+++ b/docs/misc/analytics.md
@@ -125,6 +125,23 @@ Add event to the analytics overview in the [company Notion](https://www.notion.s
 
 ## Changelog
 
+### 1.16
+
+Added:
+
+-   device-setup-completed
+    -   duration: number (in ms)
+    -   device: 'T' | '1'
+    -   firmware: 'install' | 'skip' | 'up-to-date'
+    -   seed: 'create' | 'recover'
+    -   recoveryType?: 'standard' | 'advanced' (empty if seed equals to 'create')
+    -   backup?: 'create' | 'skip' (empty if seed equals to 'recover')
+    -   pin: 'create' | 'skip'
+
+Removed:
+
+-   initial-run-completed (in favor of device-setup-completed, analytics/enable, and analytics/dispose)
+
 ### 1.15
 
 Added:

--- a/docs/misc/analytics.md
+++ b/docs/misc/analytics.md
@@ -62,7 +62,7 @@ Attributes which are always tracked:
 -   **c_commit**: current revision of app
 -   **c_instance_id**: until user does not wipe storage, the id is still same
 -   **c_session_id**: id changed on every launch of app
--   **c_timestamp**: time in ms when event is created
+-   **c_timestamp**: time in ms when event is created (added in 1.11)
 
 Other attributes are connected to a specific type of events.
 
@@ -119,7 +119,6 @@ Add event to the analytics overview in the [company Notion](https://www.notion.s
 1. **Option**: Open DevTools, navigate to **Network tab**, filter traffic by `.log` and check the **Query String Parameters** section
 2. **Option**: Get access to Keboola
 3. **Option**: Create a modified build of app with an analytics server URL pointing to your server
-4. **Option**: Edit NAT to resolve requests to `https://data.trezor.io/suite/log/web/stable.log` to your local server
 
 ## Changelog
 
@@ -139,6 +138,9 @@ Added:
 Removed:
 
 -   initial-run-completed (in favor of device-setup-completed, analytics/enable, and analytics/dispose)
+-   suite-ready
+    -   platform
+    -   platformLanguage
 
 ### 1.15
 
@@ -273,122 +275,6 @@ Added:
 
 Fixed:
 
--   device-update-firmware
-    -   toBtcOnly
--   accounts/empty-account/buy
-    -   symbol (lowercase instead of uppercase)
+### 1.0 - 1.8
 
-### 1.8
-
-Added:
-
--   settings/device/update-auto-lock
-    -   value: string
--   suite-ready
-    -   browserName: string
-    -   browserVersion: string
-    -   osName: string
-    -   osVersion: string
-    -   windowWidth: number
-    -   windowHeight: number
-
-Fixed:
-
--   suite-ready
-    -   suiteVersion
-    -   c_instance_id
-    -   c_session_id
--   device-update-firmware
-    -   fromFwVersion (changed separator to dots from commas)
-    -   fromBlVersion (changed separator to dots from commas)
--   analytics/dispose
-
-Removed:
-
--   menu/goto/exchange-index
-
-Changed:
-
--   `desktop` build is now tracked to `stable.log` instead of `beta.log`
-
-### 1.7
-
-Added:
-
--   send-raw-transaction
-    -   networkSymbol: string
--   device-connect
-    -   totalDevices: number
-
-### 1.6
-
-Added:
-
--   suite-ready
-    -   suiteVersion: string | ""
--   device-connect
-    -   isBitcoinOnly: boolean
--   desktop-init
-    -   desktopOSVersion: string | "" (in format: {platform}\_{release})
--   accounts/empty-account/buy
-    -   symbol: string
--   account-create
-    -   tokensCount: number
--   add-token
-    -   networkSymbol: string
-    -   addedNth: number
-
-### 1.5
-
-Added:
-
--   suite-ready
-    -   theme (dark mode)
--   wallet/created
-    -   type: standard | hidden
--   device-disconnect
-
-### 1.4
-
-Added:
-
--   suite-ready
-    -   rememberedStandardWallets
-    -   rememberedHiddenWallets
--   analytics/enable
--   analytics/dispose
--   check-seed/error
--   check-seed/success
-
-### 1.3
-
-Added:
-
--   device-connect
-    -   backup_type
--   router/location-change
-    -   prevRouterUrl
-    -   nextRouterUrl
-
-### 1.2
-
-Added
-
--   suite-ready
-    -   tor
-
-### 1.1
-
-Added:
-
--   device-update-firmware:
-    -   toFwVersion
--   suite-ready
-    -   platformLanguage
-    -   platform
--   device-connect:
-    -   totalInstances
-
-### 1.0
-
--   initial version
+-   initial version (<1.8 events are discarded)

--- a/packages/integration-tests/projects/suite-web/tests/suite/analytics.test.ts
+++ b/packages/integration-tests/projects/suite-web/tests/suite/analytics.test.ts
@@ -4,7 +4,7 @@
 import { urlSearchParams } from '../../../../../suite/src/utils/suite/metadata';
 
 type Requests = ReturnType<typeof urlSearchParams>[];
-const requests: Requests = [];
+let requests: Requests;
 const instance = new RegExp(/^[A-Za-z0-9]{10,10}$/);
 const timestamp = new RegExp(/^[0-9]{13,16}$/);
 
@@ -14,15 +14,11 @@ describe('Analytics', () => {
         cy.task('setupEmu');
         cy.task('startBridge');
         cy.viewport(1024, 768).resetDb();
+
+        requests = [];
     });
 
-    it('Analytics should be enabled on initial run, then user may disable it and this option should be respected on subsequent reloads', () => {
-        /*
-         * Skip test on localhost as analytics is disabled on location.hostname === "localhost". See getUrl function.
-         * TODO: Build app with test flag, modify getUrl function to return test url and mock this test url.
-         */
-        cy.skipOn('localhost');
-
+    it('should respect disabled analytics in onboarding with following enabling in settings', () => {
         cy.intercept({ hostname: 'data.trezor.io', url: '/suite/log/**' }, req => {
             const params = urlSearchParams(req.url);
             requests.push(params);
@@ -30,54 +26,50 @@ describe('Analytics', () => {
 
         cy.prefixedVisit('/');
 
-        // pass through initial run
+        // pass through onboarding with disabled analytics
         cy.getTestElement('@analytics/toggle-switch').should('be.checked');
         cy.getTestElement('@analytics/toggle-switch').click({ force: true });
         cy.getTestElement('@analytics/toggle-switch').should('not.be.checked');
         cy.getTestElement('@onboarding/continue-button').click();
-        cy.getTestElement('@onboarding/exit-app-button').click();
 
-        // assert that only 2 requests was fired
+        // assert that only "analytics/dispose" event was fired
         cy.wait('@data-fetch');
         cy.wrap(requests).its(0).should('have.property', 'c_type', 'analytics/dispose');
-        cy.wrap(requests).its(1).its('c_session_id').as('request0');
-        cy.wrap(requests).its(1).should('have.property', 'c_type', 'initial-run-completed');
+        cy.wrap(requests).its(0).its('c_session_id').as('request0');
+        cy.wrap(requests)
+            .its(0)
+            .should('have.property', 'c_timestamp')
+            .should('match', timestamp)
+            .as('timestamp0');
+        cy.wrap(requests).should('have.length', 1);
+
+        // finish onboarding
+        cy.getTestElement('@onboarding/exit-app-button').click();
+
+        // reload app (important, app needs time to save initialRun flag into storage) to change session id
+        cy.getTestElement('@suite/loading').should('not.exist');
+        cy.discoveryShouldFinish();
+        cy.reload();
+        cy.discoveryShouldFinish();
+
+        // go to settings, analytics should not enabled and no additional analytics requests should be fired
+        cy.getTestElement('@suite/menu/settings').click();
+        cy.getTestElement('@analytics/toggle-switch').should('not.be.checked');
+        cy.wrap(requests).should('have.length', 1);
+
+        // enable analytics and check "analytics/enable" event was fired
+        cy.getTestElement('@analytics/toggle-switch').click({ force: true });
+        cy.getTestElement('@analytics/toggle-switch').should('be.checked');
+        cy.wait('@data-fetch');
+        cy.wrap(requests).its(1).should('have.property', 'c_type', 'analytics/enable');
+        cy.wrap(requests).its(1).its('c_session_id').as('request1');
         cy.wrap(requests)
             .its(1)
             .should('have.property', 'c_timestamp')
             .should('match', timestamp)
-            .as('timestamp0');
-        cy.wrap(requests).its(1).should('have.property', 'analytics', 'false');
-        cy.wrap(requests).its(2).should('equal', undefined);
-
-        // important, suite needs time to save initialRun flag into storage
-        cy.getTestElement('@suite/loading').should('not.exist');
-        cy.discoveryShouldFinish();
-
-        // go to settings
-        cy.prefixedVisit('/');
-        cy.task('startEmu', { wipe: false });
-        cy.discoveryShouldFinish();
-        cy.getTestElement('@suite/menu/settings').click();
-
-        // analytics is not enabled and no additional requests were fired
-        cy.getTestElement('@analytics/toggle-switch').should('not.be.checked');
-        cy.wrap(requests).its(0).should('have.property', 'c_type', 'analytics/dispose');
-        cy.wrap(requests).its(1).should('have.property', 'c_type', 'initial-run-completed');
-        cy.wrap(requests).its(1).should('have.property', 'analytics', 'false');
-        cy.wrap(requests).its(2).should('equal', undefined);
-
-        // enable it and reload page
-        cy.log('enable it again, reload and see it remains checked');
-        cy.getTestElement('@analytics/toggle-switch').click({ force: true });
-        cy.getTestElement('@analytics/toggle-switch').should('be.checked');
-        cy.wait('@data-fetch');
-        cy.wrap(requests).its(2).should('have.property', 'c_type', 'analytics/enable');
-        cy.wrap(requests)
-            .its(2)
-            .should('have.property', 'c_timestamp')
-            .should('match', timestamp)
             .as('timestamp1');
+        cy.wrap(requests).should('have.length', 2);
+
         // check that timestamp changes between requests
         cy.get('@timestamp0').then(t0 => {
             cy.get('@timestamp1').then(t1 => {
@@ -85,34 +77,87 @@ describe('Analytics', () => {
             });
         });
 
-        // change fiat
-        cy.getTestElement('@settings/fiat-select/input').click({ force: true });
-        cy.getTestElement('@settings/fiat-select/option/huf').click({ force: true });
-
-        // check that fiat change got logged.
-
-        cy.wait('@data-fetch');
-        cy.wrap(requests).its(3).its('c_session_id').as('request1');
-        cy.wrap(requests).its(3).should('have.property', 'c_type', 'settings/general/change-fiat');
-        cy.wrap(requests).its(3).should('have.property', 'fiat', 'huf');
-        cy.wrap(requests).its(3).should('have.property', 'c_instance_id').should('match', instance);
-        // and check that session ids changed after reload;
+        // check that session ids changed after reload;
         cy.get('@request0').then(r0 => {
             cy.get('@request1').then(r1 => {
                 expect(r1).not.to.equal(r0);
             });
         });
 
-        // opening device modal
+        // change fiat and check that it was logged
+        cy.getTestElement('@settings/fiat-select/input').click({ force: true });
+        cy.getTestElement('@settings/fiat-select/option/huf').click({ force: true });
+        cy.wait('@data-fetch');
+        cy.wrap(requests).its(2).should('have.property', 'c_type', 'settings/general/change-fiat');
+        cy.wrap(requests).its(2).should('have.property', 'fiat', 'huf');
+        cy.wrap(requests).its(2).should('have.property', 'c_instance_id').should('match', instance);
+        cy.wrap(requests).should('have.length', 3);
+
+        // open device modal and check that it was logged
         cy.getTestElement('@menu/switch-device').click();
         cy.wait('@data-fetch');
-        cy.wrap(requests).its(5).should('have.property', 'c_type', 'menu/goto/switch-device');
+        cy.wrap(requests).its(3).should('have.property', 'c_type', 'router/location-change');
+        cy.wrap(requests).its(4).should('have.property', 'c_type', 'menu/goto/switch-device');
+        cy.wrap(requests).should('have.length', 5);
 
-        // adding wallet
+        // add hidden wallet and check that it was logged
         cy.getTestElement('@switch-device/add-hidden-wallet-button').click();
         cy.wait('@data-fetch');
         cy.wrap(requests)
-            .its(6)
+            .its(5)
             .should('have.property', 'c_type', 'switch-device/add-hidden-wallet');
+    });
+
+    it('should respect enabled analytics in onboarding with following disabling in settings', () => {
+        cy.intercept({ hostname: 'data.trezor.io', url: '/suite/log/**' }, req => {
+            const params = urlSearchParams(req.url);
+            requests.push(params);
+        }).as('data-fetch');
+
+        cy.prefixedVisit('/');
+
+        // pass through onboarding with enabled analytics
+        cy.getTestElement('@analytics/toggle-switch').should('be.checked');
+        cy.getTestElement('@onboarding/continue-button').click();
+
+        // assert that more than 1 event was fired and it was "suite/ready" and "analytics/enable" for sure
+        cy.wait('@data-fetch');
+        cy.wrap(requests).its('length').should('be.gt', 1);
+        cy.wrap(requests)
+            .then(list => Cypress._.map(list, 'c_type'))
+            .should('include', 'suite-ready');
+        cy.wrap(requests)
+            .then(list => Cypress._.map(list, 'c_type'))
+            .should('include', 'analytics/enable');
+
+        // finish onboarding
+        cy.getTestElement('@onboarding/exit-app-button').click();
+
+        // go to settings, analytics should be enabled
+        cy.getTestElement('@suite/menu/settings').click();
+        cy.getTestElement('@analytics/toggle-switch').should('be.checked');
+
+        // disable analytics
+        cy.getTestElement('@analytics/toggle-switch').click({ force: true });
+        cy.getTestElement('@analytics/toggle-switch').should('not.be.checked');
+
+        // change fiat
+        cy.getTestElement('@settings/fiat-select/input').click({ force: true });
+        cy.getTestElement('@settings/fiat-select/option/huf').click({ force: true });
+        cy.wait('@data-fetch');
+        cy.wrap(requests).its('length').as('length1');
+
+        // check that analytics disable event was fired
+        cy.wrap(requests)
+            .then(list => Cypress._.map(list, 'c_type'))
+            .should('include', 'analytics/dispose');
+        cy.wrap(requests).its('length').as('length0');
+
+        // check that "settings/general/change-fiat" event was not fired
+        cy.get('@length0').then(l0 => {
+            cy.get('@length1').then(l1 => {
+                expect(l1).to.equal(l0);
+            });
+        });
     });
 });

--- a/packages/suite-native/src/utils/suite/env.ts
+++ b/packages/suite-native/src/utils/suite/env.ts
@@ -21,8 +21,6 @@ export const getWindowHeight = () => Dimensions.get('window').height;
 
 export const getPlatform = () => 'todo react-native';
 
-export const getPlatformLanguage = () => 'en';
-
 export const getPlatformLanguages = () => ['en'];
 
 export const getLocationOrigin = () => 'implementation of getLocationOrigin in native';

--- a/packages/suite/src/actions/onboarding/constants/onboarding.ts
+++ b/packages/suite/src/actions/onboarding/constants/onboarding.ts
@@ -4,3 +4,4 @@ export const ADD_PATH = '@onboarding/add-path';
 export const REMOVE_PATH = '@onboarding/remove-path';
 export const RESET_ONBOARDING = '@onboarding/reset-onboarding';
 export const ENABLE_ONBOARDING_REDUCER = '@onboarding/enable-onboarding-reducer';
+export const ANALYTICS = '@onboarding/analytics';

--- a/packages/suite/src/actions/onboarding/onboardingActions.ts
+++ b/packages/suite/src/actions/onboarding/onboardingActions.ts
@@ -1,6 +1,6 @@
 import { ONBOARDING } from '@onboarding-actions/constants';
 import * as STEP from '@onboarding-constants/steps';
-import { AnyStepId, AnyPath } from '@onboarding-types';
+import { AnyStepId, AnyPath, OnboardingAnalytics } from '@onboarding-types';
 import steps from '@onboarding-config/steps';
 import { findNextStep, findPrevStep, isStepInPath } from '@onboarding-utils/steps';
 
@@ -29,6 +29,10 @@ export type OnboardingAction =
     | {
           type: typeof ONBOARDING.SET_STEP_ACTIVE;
           stepId: AnyStepId;
+      }
+    | {
+          type: typeof ONBOARDING.ANALYTICS;
+          payload: Partial<OnboardingAnalytics>;
       };
 
 const goToStep = (stepId: AnyStepId): OnboardingAction => ({
@@ -98,6 +102,11 @@ const enableOnboardingReducer = (payload: boolean): OnboardingAction => ({
     payload,
 });
 
+const updateAnalytics = (payload: Partial<OnboardingAnalytics>): OnboardingAction => ({
+    type: ONBOARDING.ANALYTICS,
+    payload,
+});
+
 export {
     enableOnboardingReducer,
     goToNextStep,
@@ -107,4 +116,5 @@ export {
     addPath,
     removePath,
     resetOnboarding,
+    updateAnalytics,
 };

--- a/packages/suite/src/actions/suite/analyticsActions.ts
+++ b/packages/suite/src/actions/suite/analyticsActions.ts
@@ -49,9 +49,6 @@ export type AnalyticsEvent =
               discreetMode: AppState['wallet']['settings']['discreetMode'];
               screenWidth: number;
               screenHeight: number;
-              // added in 1.1
-              platform: string;
-              platformLanguage: string;
               // added in 1.2
               tor: boolean;
               // added in 1.4

--- a/packages/suite/src/actions/suite/analyticsActions.ts
+++ b/packages/suite/src/actions/suite/analyticsActions.ts
@@ -14,6 +14,8 @@ import { allowSentryReport, setSentryUser } from '@suite-utils/sentry';
 import { State } from '@suite-reducers/analyticsReducer';
 import { DeviceMode } from 'trezor-connect';
 
+import type { OnboardingAnalytics } from '@onboarding-types';
+
 export type AnalyticsAction =
     | { type: typeof ANALYTICS.ENABLE }
     | { type: typeof ANALYTICS.DISPOSE }
@@ -30,7 +32,7 @@ export type AnalyticsAction =
 
 // Don't forget to update docs with changelog!
 // <breaking-change>.<analytics-extended>
-export const version = '1.15';
+export const version = '1.16';
 
 export type AnalyticsEvent =
     | {
@@ -38,7 +40,6 @@ export type AnalyticsEvent =
          suite-ready
          Triggers on application start. Logs part of suite setup that might have been loaded from storage
          but it might also be suite default setup that is loaded when suite starts for the first time.
-         IMPORTANT: skipped if user opens suite for the first time. In such case, the first log will be 'initial-run-completed'
          */
           type: 'suite-ready';
           payload: {
@@ -136,24 +137,10 @@ export type AnalyticsEvent =
           };
       }
     | {
-          /**
-         initial-run-completed
-         when new installation of trezor suite starts it is in initial-run mode which means that some additional screens appear (welcome, analytics, onboarding)
-         it is completed either by going trough onboarding or skipping it. once completed event is registered, we log some data connected up to this point
-          */
-          type: 'initial-run-completed';
-          payload: {
-              analytics: false;
-          };
-      }
-    | {
-          type: 'initial-run-completed';
-          payload: {
-              analytics: true;
-              /** how many users chose to create new wallet */
-              createSeed: boolean;
-              /** how many users chose to do recovery */
-              recoverSeed: boolean;
+          type: 'device-setup-completed';
+          payload: Partial<Omit<OnboardingAnalytics, 'startTime'>> & {
+              duration: number;
+              device: 'T' | '1';
           };
       }
     | {

--- a/packages/suite/src/actions/suite/analyticsActions.ts
+++ b/packages/suite/src/actions/suite/analyticsActions.ts
@@ -9,7 +9,7 @@ import { Dispatch, GetState, AppState } from '@suite-types';
 import { getAnalyticsRandomId } from '@suite-utils/random';
 import { encodeDataToQueryString } from '@suite-utils/analytics';
 import { Account } from '@wallet-types';
-import { setOnBeforeUnloadListener, getLocationHostname, getEnvironment } from '@suite-utils/env';
+import { setOnBeforeUnloadListener, getEnvironment } from '@suite-utils/env';
 import { allowSentryReport, setSentryUser } from '@suite-utils/sentry';
 import { State } from '@suite-reducers/analyticsReducer';
 import { DeviceMode } from 'trezor-connect';
@@ -421,18 +421,12 @@ export type AnalyticsEvent =
       };
 
 const getUrl = () => {
-    const hostname = getLocationHostname();
     const environment = getEnvironment();
 
     const base = `https://data.trezor.io/suite/log/${environment}`;
 
     if (process.env.CODESIGN_BUILD) {
         return `${base}/stable.log`;
-    }
-
-    // no reporting on localhost
-    if (hostname === 'localhost') {
-        return;
     }
 
     return `${base}/develop.log`;

--- a/packages/suite/src/actions/suite/constants/suiteConstants.ts
+++ b/packages/suite/src/actions/suite/constants/suiteConstants.ts
@@ -2,7 +2,6 @@ export const INIT = '@suite/init';
 export const READY = '@suite/ready';
 export const ERROR = '@suite/error';
 export const SET_DB_ERROR = '@suite/set-db-error';
-export const INITIAL_RUN_COMPLETED = '@suite/initial-run-completed';
 export const CONNECT_INITIALIZED = '@suite/trezor-connect-initialized';
 export const SELECT_DEVICE = '@suite/select-device';
 export const UPDATE_SELECTED_DEVICE = '@suite/update-selected-device';

--- a/packages/suite/src/components/recovery/SelectRecoveryType.tsx
+++ b/packages/suite/src/components/recovery/SelectRecoveryType.tsx
@@ -1,17 +1,16 @@
 import React from 'react';
+
 import { Option, OptionsWrapper, OptionsDivider } from '@onboarding-components';
 import { Translation } from '@suite-components';
 
-interface Props {
-    onSelect: (number: boolean) => void;
+interface SelectRecoveryTypeProps {
+    onSelect: (type: 'standard' | 'advanced') => void;
 }
 
-const SelectRecoveryType = ({ onSelect }: Props) => (
+const SelectRecoveryType = ({ onSelect }: SelectRecoveryTypeProps) => (
     <OptionsWrapper>
         <Option
-            onClick={() => {
-                onSelect(false);
-            }}
+            onClick={() => onSelect('standard')}
             icon="SEED_SINGLE"
             heading={<Translation id="TR_BASIC_RECOVERY" />}
             description={<Translation id="TR_BASIC_RECOVERY_OPTION" />}
@@ -19,9 +18,7 @@ const SelectRecoveryType = ({ onSelect }: Props) => (
         />
         <OptionsDivider />
         <Option
-            onClick={() => {
-                onSelect(true);
-            }}
+            onClick={() => onSelect('advanced')}
             icon="SEED_SHAMIR"
             heading={<Translation id="TR_ADVANCED_RECOVERY" />}
             description={<Translation id="TR_ADVANCED_RECOVERY_OPTION" />}

--- a/packages/suite/src/hooks/suite/useOnboarding.ts
+++ b/packages/suite/src/hooks/suite/useOnboarding.ts
@@ -19,6 +19,8 @@ export const useOnboarding = () => {
         enableOnboardingReducer: onboardingActions.enableOnboardingReducer,
         goto: routerActions.goto,
         rerun: recoveryActions.rerun,
+        updateAnalytics: onboardingActions.updateAnalytics,
+        addPath: onboardingActions.addPath,
     });
 
     return {

--- a/packages/suite/src/middlewares/recovery/recoveryMiddleware.ts
+++ b/packages/suite/src/middlewares/recovery/recoveryMiddleware.ts
@@ -2,6 +2,8 @@ import { UI } from 'trezor-connect';
 import { MiddlewareAPI } from 'redux';
 import { SUITE } from '@suite-actions/constants';
 import * as recoveryActions from '@recovery-actions/recoveryActions';
+import * as onboardingActions from '@onboarding-actions/onboardingActions';
+
 import { AppState, Action, Dispatch } from '@suite-types';
 
 const recovery =
@@ -30,6 +32,11 @@ const recovery =
             action.payload?.features?.recovery_mode &&
             recovery.status !== 'in-progress'
         ) {
+            api.dispatch(
+                onboardingActions.updateAnalytics({
+                    startTime: Date.now(),
+                }),
+            );
             if (!analytics.confirmed) {
                 // If you connect TT in recovery mode to fresh Suite, you should see analytics optout option first.
                 api.dispatch(recoveryActions.setStatus('in-progress'));

--- a/packages/suite/src/middlewares/suite/analyticsMiddleware.ts
+++ b/packages/suite/src/middlewares/suite/analyticsMiddleware.ts
@@ -2,16 +2,13 @@
 
 import { MiddlewareAPI } from 'redux';
 import { TRANSPORT, DEVICE } from 'trezor-connect';
+
 import { SUITE, ROUTER, ANALYTICS } from '@suite-actions/constants';
 import { DISCOVERY } from '@wallet-actions/constants';
-
-import { AppState, Action, Dispatch } from '@suite-types';
 import * as analyticsActions from '@suite-actions/analyticsActions';
 import {
     getScreenWidth,
     getScreenHeight,
-    getPlatform,
-    getPlatformLanguage,
     getBrowserName,
     getBrowserVersion,
     getOsName,
@@ -23,6 +20,8 @@ import {
 import { isBitcoinOnly, getPhysicalDeviceCount } from '@suite-utils/device';
 import { allowSentryReport } from '@suite/utils/suite/sentry';
 
+import type { AppState, Action, Dispatch } from '@suite-types';
+
 const reportSuiteReadyAction = (state: AppState) =>
     analyticsActions.report({
         type: 'suite-ready',
@@ -33,8 +32,6 @@ const reportSuiteReadyAction = (state: AppState) =>
             discreetMode: state.wallet.settings.discreetMode,
             screenWidth: getScreenWidth(),
             screenHeight: getScreenHeight(),
-            platform: getPlatform(),
-            platformLanguage: getPlatformLanguage(),
             platformLanguages: getPlatformLanguages().join(','),
             tor: state.suite.tor,
             rememberedStandardWallets: state.devices.filter(d => d.remember && d.useEmptyPassphrase)

--- a/packages/suite/src/reducers/onboarding/onboardingReducer.ts
+++ b/packages/suite/src/reducers/onboarding/onboardingReducer.ts
@@ -4,7 +4,8 @@ import { DEVICE, Device } from 'trezor-connect';
 import { ONBOARDING } from '@onboarding-actions/constants';
 import * as STEP from '@onboarding-constants/steps';
 import { Action } from '@suite-types';
-import { AnyStepId, AnyPath } from '@onboarding-types';
+
+import type { AnyStepId, AnyPath, OnboardingAnalytics } from '@onboarding-types';
 
 export interface OnboardingState {
     reducerEnabled: boolean;
@@ -12,6 +13,7 @@ export interface OnboardingState {
     activeStepId: AnyStepId;
     activeSubStep: string | null;
     path: AnyPath[];
+    onboardingAnalytics: Partial<OnboardingAnalytics>;
 }
 
 const initialState: OnboardingState = {
@@ -20,10 +22,12 @@ const initialState: OnboardingState = {
     // would be better to implement field "isMatchingPrevDevice" along with prevDevice
     // prevDevice is used only in firmwareUpdate so maybe move it to firmwareUpdate
     // and here leave only isMatchingPrevDevice ?
+
     prevDevice: null,
     activeStepId: STEP.ID_WELCOME_STEP,
     activeSubStep: null,
     path: [],
+    onboardingAnalytics: {},
 };
 
 const addPath = (path: AnyPath, state: OnboardingState) => {
@@ -64,6 +68,9 @@ const onboarding = (state: OnboardingState = initialState, action: Action) => {
                 break;
             case DEVICE.DISCONNECT:
                 draft.prevDevice = action.payload;
+                break;
+            case ONBOARDING.ANALYTICS:
+                draft.onboardingAnalytics = { ...state.onboardingAnalytics, ...action.payload };
                 break;
             case ONBOARDING.RESET_ONBOARDING:
                 return initialState;

--- a/packages/suite/src/types/onboarding/index.ts
+++ b/packages/suite/src/types/onboarding/index.ts
@@ -22,3 +22,12 @@ export type AnyStepId =
     | typeof STEP.ID_COINS_STEP;
 
 export type AnyPath = typeof STEP.PATH_CREATE | typeof STEP.PATH_RECOVERY;
+
+export type OnboardingAnalytics = {
+    startTime: number;
+    firmware: 'install' | 'skip' | 'up-to-date';
+    seed: 'create' | 'recover';
+    recoveryType: 'standard' | 'advanced';
+    backup: 'create' | 'skip';
+    pin: 'create' | 'skip';
+};

--- a/packages/suite/src/utils/suite/__fixtures__/analytics.ts
+++ b/packages/suite/src/utils/suite/__fixtures__/analytics.ts
@@ -14,16 +14,4 @@ export default [
             '2021-04-01T12:10:00.000Z',
         ).getTime()}&type=bridge&version=2`,
     },
-    {
-        currentDate: '2021-04-01T12:10:00.000Z',
-        input: {
-            type: 'initial-run-completed',
-            payload: {
-                analytics: false,
-            },
-        },
-        encoded: `c_v=${version}&c_type=initial-run-completed&c_commit=&c_instance_id=1&c_session_id=2&c_timestamp=${new Date(
-            '2021-04-01T12:10:00.000Z',
-        ).getTime()}&analytics=false`,
-    },
 ] as const;

--- a/packages/suite/src/utils/suite/device.ts
+++ b/packages/suite/src/utils/suite/device.ts
@@ -130,7 +130,7 @@ export const isSelectedDevice = (selected?: TrezorDevice | Device, device?: Trez
     return selected.id === device.id;
 };
 
-export const getDeviceModel = (device: TrezorDevice) => {
+export const getDeviceModel = (device: TrezorDevice): 'T' | '1' => {
     const { features } = device;
     return features && features.major_version > 1 ? 'T' : '1';
 };

--- a/packages/suite/src/utils/suite/env.ts
+++ b/packages/suite/src/utils/suite/env.ts
@@ -9,8 +9,6 @@ export const getUserAgent = () => window.navigator.userAgent;
 // List of platforms https://docker.apachezone.com/blog/74
 export const getPlatform = () => window.navigator.platform;
 
-export const getPlatformLanguage = () => window.navigator.language;
-
 export const getPlatformLanguages = () => window.navigator.languages;
 
 export const getScreenWidth = () => window.screen.width;

--- a/packages/suite/src/views/onboarding/steps/Backup/index.tsx
+++ b/packages/suite/src/views/onboarding/steps/Backup/index.tsx
@@ -23,10 +23,11 @@ const StyledImage = styled(Image)`
 
 const BackupStep = () => {
     const [showSkipConfirmation, setShowSkipConfirmation] = useState(false);
-    const { goToNextStep, backupDevice, goto } = useActions({
+    const { goToNextStep, backupDevice, goto, updateAnalytics } = useActions({
         goToNextStep: onboardingActions.goToNextStep,
         backupDevice: backupActions.backupDevice,
         goto: routerActions.goto,
+        updateAnalytics: onboardingActions.updateAnalytics,
     });
     const { device, backup, locks } = useSelector(state => ({
         device: state.suite.device,
@@ -67,7 +68,10 @@ const BackupStep = () => {
                     innerActions={
                         <OnboardingButtonCta
                             data-test="@backup/start-button"
-                            onClick={() => backupDevice()}
+                            onClick={() => {
+                                updateAnalytics({ backup: 'create' });
+                                backupDevice();
+                            }}
                             isDisabled={!canContinue(backup.userConfirmed, locks)}
                         >
                             <Translation id="TR_START_BACKUP" />
@@ -76,7 +80,10 @@ const BackupStep = () => {
                     outerActions={
                         <OnboardingButtonSkip
                             data-test="@onboarding/exit-app-button"
-                            onClick={() => setShowSkipConfirmation(true)}
+                            onClick={() => {
+                                updateAnalytics({ backup: 'skip' });
+                                setShowSkipConfirmation(true);
+                            }}
                         >
                             <Translation id="TR_SKIP_BACKUP" />
                         </OnboardingButtonSkip>

--- a/packages/suite/src/views/onboarding/steps/CreateOrRecover/index.tsx
+++ b/packages/suite/src/views/onboarding/steps/CreateOrRecover/index.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { Translation } from '@suite-components';
-import { useActions } from '@suite-hooks';
+import { useOnboarding } from '@suite-hooks';
 import * as STEP from '@onboarding-constants/steps';
 import {
     Option,
@@ -9,14 +9,9 @@ import {
     OptionsDivider,
     OnboardingStepBox,
 } from '@onboarding-components';
-import * as onboardingActions from '@onboarding-actions/onboardingActions';
 
 const CreateOrRecoverStep = () => {
-    const { goToNextStep, addPath } = useActions({
-        goToNextStep: onboardingActions.goToNextStep,
-        goToPreviousStep: onboardingActions.goToPreviousStep,
-        addPath: onboardingActions.addPath,
-    });
+    const { goToNextStep, addPath, updateAnalytics } = useOnboarding();
 
     return (
         <OnboardingStepBox
@@ -31,6 +26,7 @@ const CreateOrRecoverStep = () => {
                         onClick={() => {
                             addPath(STEP.PATH_CREATE);
                             goToNextStep();
+                            updateAnalytics({ seed: 'create' });
                         }}
                         heading={<Translation id="TR_CREATE_WALLET" />}
                     />
@@ -43,6 +39,7 @@ const CreateOrRecoverStep = () => {
                         onClick={() => {
                             addPath(STEP.PATH_RECOVERY);
                             goToNextStep();
+                            updateAnalytics({ seed: 'recover' });
                         }}
                         heading={<Translation id="TR_RESTORE_EXISTING_WALLET" />}
                     />

--- a/packages/suite/src/views/onboarding/steps/Firmware/index.tsx
+++ b/packages/suite/src/views/onboarding/steps/Firmware/index.tsx
@@ -16,7 +16,7 @@ const FirmwareStep = () => {
     const { device } = useSelector(state => ({
         device: state.suite.device,
     }));
-    const { goToNextStep } = useOnboarding();
+    const { goToNextStep, updateAnalytics } = useOnboarding();
     const { status, error, resetReducer, firmwareUpdate, showFingerprintCheck } = useFirmware();
     const [cachedDevice, setCachedDevice] = useState<TrezorDevice | undefined>(device);
 
@@ -62,7 +62,14 @@ const FirmwareStep = () => {
                         values={{ version: getFwVersion(device) }}
                     />
                 }
-                innerActions={<ContinueButton onClick={() => goToNextStep()} />}
+                innerActions={
+                    <ContinueButton
+                        onClick={() => {
+                            goToNextStep();
+                            updateAnalytics({ firmware: 'up-to-date' });
+                        }}
+                    />
+                }
             />
         );
     }

--- a/packages/suite/src/views/onboarding/steps/Pin/index.tsx
+++ b/packages/suite/src/views/onboarding/steps/Pin/index.tsx
@@ -16,7 +16,7 @@ const SetPinStep = () => {
     const [status, setStatus] = useState<'initial' | 'enter-pin' | 'repeat-pin' | 'success'>(
         'initial',
     );
-    const { goToNextStep, showPinMatrix } = useOnboarding();
+    const { goToNextStep, showPinMatrix, updateAnalytics } = useOnboarding();
 
     const { changePin } = useActions({
         changePin: deviceSettingsActions.changePin,
@@ -125,6 +125,7 @@ const SetPinStep = () => {
                             data-test="@onboarding/set-pin-button"
                             onClick={() => {
                                 changePin();
+                                updateAnalytics({ pin: 'create' });
                             }}
                         >
                             <Translation id="TR_SET_PIN" />
@@ -137,7 +138,10 @@ const SetPinStep = () => {
                     !showConfirmationPrompt ? (
                         <OnboardingButtonSkip
                             data-test="@onboarding/skip-button"
-                            onClick={() => setShowSkipConfirmation(true)}
+                            onClick={() => {
+                                setShowSkipConfirmation(true);
+                                updateAnalytics({ pin: 'skip' });
+                            }}
                         >
                             <Translation id="TR_SKIP" />
                         </OnboardingButtonSkip>

--- a/packages/suite/src/views/onboarding/steps/Recovery/index.tsx
+++ b/packages/suite/src/views/onboarding/steps/Recovery/index.tsx
@@ -7,8 +7,9 @@ import { useActions, useRecovery, useSelector } from '@suite-hooks';
 import RecoveryStepBox from './RecoveryStepBox';
 
 const RecoveryStep = () => {
-    const { goToNextStep } = useActions({
+    const { goToNextStep, updateAnalytics } = useActions({
         goToNextStep: onboardingActions.goToNextStep,
+        updateAnalytics: onboardingActions.updateAnalytics,
     });
 
     const { device } = useSelector(state => ({
@@ -79,8 +80,9 @@ const RecoveryStep = () => {
                 description={<Translation id="TR_RECOVERY_TYPES_DESCRIPTION" />}
             >
                 <SelectRecoveryType
-                    onSelect={(type: boolean) => {
-                        setAdvancedRecovery(type);
+                    onSelect={(type: 'standard' | 'advanced') => {
+                        setAdvancedRecovery(type === 'advanced');
+                        updateAnalytics({ recoveryType: type });
                         recoverDevice();
                     }}
                 />

--- a/packages/suite/src/views/onboarding/steps/ResetDevice/index.tsx
+++ b/packages/suite/src/views/onboarding/steps/ResetDevice/index.tsx
@@ -9,17 +9,16 @@ import {
     OnboardingStepBox,
 } from '@onboarding-components';
 import { Translation } from '@suite-components';
-import { useActions, useSelector } from '@suite-hooks';
+import { useActions, useSelector, useOnboarding } from '@suite-hooks';
 import * as deviceSettingsActions from '@settings-actions/deviceSettingsActions';
-import * as onboardingActions from '@onboarding-actions/onboardingActions';
 
 const ResetDeviceStep = () => {
     const [submitted, setSubmitted] = useState(false);
-    const { resetDevice, goToPreviousStep, goToNextStep } = useActions({
+    const { resetDevice } = useActions({
         resetDevice: deviceSettingsActions.resetDevice,
-        goToPreviousStep: onboardingActions.goToPreviousStep,
-        goToNextStep: onboardingActions.goToNextStep,
     });
+    const { goToPreviousStep, goToNextStep, updateAnalytics } = useOnboarding();
+
     const device = useSelector(state => state.suite.device);
 
     // this step expects device
@@ -75,6 +74,7 @@ const ResetDeviceStep = () => {
                                 } else {
                                     await onResetDevice();
                                 }
+                                updateAnalytics({ recoveryType: undefined });
                             }}
                             heading={<Translation id="SINGLE_SEED" />}
                             description={<Translation id="SINGLE_SEED_DESCRIPTION" />}
@@ -89,6 +89,7 @@ const ResetDeviceStep = () => {
                                     data-test="@onboarding/shamir-backup-option-button"
                                     onClick={async () => {
                                         await onResetDevice({ backup_type: 1 });
+                                        updateAnalytics({ recoveryType: undefined });
                                     }}
                                     heading={<Translation id="SHAMIR_SEED" />}
                                     description={<Translation id="SHAMIR_SEED_DESCRIPTION" />}

--- a/packages/suite/src/views/onboarding/steps/Security/index.tsx
+++ b/packages/suite/src/views/onboarding/steps/Security/index.tsx
@@ -10,7 +10,7 @@ import { useOnboarding } from '@suite-hooks';
 
 const SecurityStep = () => {
     const [showSkipConfirmation, setShowSkipConfirmation] = useState(false);
-    const { goToNextStep } = useOnboarding();
+    const { goToNextStep, updateAnalytics } = useOnboarding();
     return (
         <>
             {showSkipConfirmation && (
@@ -36,7 +36,10 @@ const SecurityStep = () => {
                 outerActions={
                     <OnboardingButtonSkip
                         data-test="@onboarding/skip-backup"
-                        onClick={() => setShowSkipConfirmation(true)}
+                        onClick={() => {
+                            setShowSkipConfirmation(true);
+                            updateAnalytics({ backup: 'skip' });
+                        }}
                     >
                         <Translation id="TR_SKIP_BACKUP" />
                     </OnboardingButtonSkip>

--- a/packages/suite/src/views/onboarding/steps/Welcome/components/PreOnboardingSetup/SecurityCheck.tsx
+++ b/packages/suite/src/views/onboarding/steps/Welcome/components/PreOnboardingSetup/SecurityCheck.tsx
@@ -69,7 +69,7 @@ const OuterActions = styled.div`
 `;
 
 const SecurityCheck = () => {
-    const { goToNextStep, goto, rerun } = useOnboarding();
+    const { goToNextStep, goto, rerun, updateAnalytics } = useOnboarding();
     const { device, recovery } = useSelector(s => ({
         device: s.suite.device,
         recovery: s.recovery,
@@ -148,11 +148,16 @@ const SecurityCheck = () => {
                     ) : (
                         <Items>
                             <OnboardingButtonCta
-                                onClick={
-                                    recovery.status === 'in-progress'
-                                        ? () => rerun()
-                                        : () => goToNextStep()
-                                }
+                                onClick={() => {
+                                    if (recovery.status === 'in-progress') {
+                                        rerun();
+                                    } else {
+                                        goToNextStep();
+                                    }
+                                    updateAnalytics({
+                                        startTime: Date.now(),
+                                    });
+                                }}
                                 data-test="@onboarding/continue-button"
                             >
                                 <Translation id="TR_ONBOARDING_START_CTA" />

--- a/packages/suite/src/views/recovery/index.tsx
+++ b/packages/suite/src/views/recovery/index.tsx
@@ -110,8 +110,8 @@ const Recovery = ({ modal, closeModalApp }: InjectedModalApplicationProps) => {
         actions.setStatus('select-recovery-type');
     };
 
-    const onSetRecoveryType = (type: boolean) => {
-        actions.setAdvancedRecovery(type);
+    const onSetRecoveryType = (type: 'standard' | 'advanced') => {
+        actions.setAdvancedRecovery(type === 'advanced');
         actions.checkSeed();
     };
 
@@ -263,7 +263,7 @@ const Recovery = ({ modal, closeModalApp }: InjectedModalApplicationProps) => {
                         <StatusTitle>
                             <Translation id="TR_CHOSE_RECOVERY_TYPE" />
                         </StatusTitle>
-                        <SelectRecoveryType onSelect={(type: boolean) => onSetRecoveryType(type)} />
+                        <SelectRecoveryType onSelect={onSetRecoveryType} />
                         <Buttons>
                             <CloseButton onClick={() => closeModalApp()}>
                                 <Translation id="TR_CANCEL" />


### PR DESCRIPTION
1.
A new event is logged when onboarding is completed.
```
-   device-setup-completed
    -   duration: number (in ms)
    -   device: 'T' | '1'
    -   firmware: 'install' | 'skip' | 'up-to-date'
    -   seed: 'create' | 'recover'
    -   recoveryType?: 'standard' | 'advanced' (empty if seed equals to 'create')
    -   backup?: 'create' | 'skip' (empty if seed equals to 'recover')
    -   pin: 'create' | 'skip'
```

`initial-run-completed` event was deleted as it provided some info about device initialisation only if the app was never used before. It also provided info about analytics. However, this is also reported by `analytics/enable` and `analytics/dispose`.

2. 
Log events also from `localhost` for easier debugging and also to be consistent with dev/production

3. 
Discarded changelog for version <= 1.8 as they are not used anymore. Removed unused/duplicated params from `suite-ready`

4. 
Pro tests