### PR TITLE
fix: discovery issue (unexpected message)

### DIFF
--- a/docker/docker-compose.connect-explorer-test.yml
+++ b/docker/docker-compose.connect-explorer-test.yml
@@ -46,7 +46,7 @@ services:
       # useful for debugging tests
       - PWDEBUG=console
     working_dir: /trezor-suite
-    command: bash -c "npx playwright install && docker/wait-for-env.sh && yarn workspace @trezor/integration-tests test:connect-explorer"
+    command: bash -c "npx playwright install && docker/wait-for-env.sh && docker/wait-for-200.sh https://localhost:8088/popup.html &&  yarn workspace @trezor/integration-tests test:connect-explorer"
     volumes:
       - ../:/trezor-suite
       - /tmp/.X11-unix:/tmp/.X11-unix:rw

--- a/docker/wait-for-200.sh
+++ b/docker/wait-for-200.sh
@@ -1,0 +1,19 @@
+#!/usr/bin/env bash
+
+echo "Waiting for $1 to load up..."
+counter=0
+max_attempts=60
+
+curl -i -s -I $1
+
+until (curl -i -s -I --insecure  $1 | grep '200 OK'); do
+  if [ ${counter} -eq ${max_attempts} ]; then
+    echo "$1 is not running. exiting"
+    exit 1
+  fi
+  counter=$(($counter+1))
+  printf "."
+  sleep 1
+done
+
+echo "$1 loaded up"

--- a/packages/connect-explorer/package.json
+++ b/packages/connect-explorer/package.json
@@ -35,7 +35,7 @@
         "redux-thunk": "^2.3.0",
         "stringify-object": "^3.3.0",
         "styled-components": "^5.3.3",
-        "trezor-connect": "8.2.8-beta.2"
+        "trezor-connect": "8.2.8-beta.3"
     },
     "devDependencies": {
         "@types/markdown-it": "12.2.3",

--- a/packages/integration-tests/projects/connect-explorer/playwright.config.ts
+++ b/packages/integration-tests/projects/connect-explorer/playwright.config.ts
@@ -2,7 +2,9 @@ import { PlaywrightTestConfig } from '@playwright/test';
 
 const config: PlaywrightTestConfig = {
     testDir: 'tests',
-    retries: 3,
+    retries: 0,
+    workers: 1, // to disable parallelism between test files
+    timeout: 30000,
     use: {
         headless: process.env.HEADLESS === 'true',
         ignoreHTTPSErrors: true,

--- a/packages/integration-tests/projects/connect-explorer/tests/fixtures.js
+++ b/packages/integration-tests/projects/connect-explorer/tests/fixtures.js
@@ -17,6 +17,24 @@ const followDevice = {
     },
 };
 
+const confirmExportAddressScreen = {
+    selector: '.export-address >> visible=true',
+    screenshot: {
+        name: 'export-address',
+    },
+    next: 'button.confirm >> visible=true',
+};
+
+const getConfirmAddressOnDeviceScreen = address => ({
+    selector: `text=${address}`,
+    screenshot: {
+        name: 'confirm-on-device',
+    },
+    nextEmu: {
+        type: 'emulator-press-yes',
+    },
+});
+
 // todo: method field is not used anywhere at the moment;
 
 const getPublicKey = [
@@ -43,22 +61,8 @@ const getAddress = [
         url: 'getAddress',
         method: 'getAddress',
         views: [
-            {
-                selector: '.export-address >> visible=true',
-                screenshot: {
-                    name: 'export-address',
-                },
-                next: 'button.confirm >> visible=true',
-            },
-            {
-                selector: 'text=3AnYTd2FGxJLNKL1AzxfW3FJMntp9D2KKX',
-                screenshot: {
-                    name: 'confirm-on-device',
-                },
-                nextEmu: {
-                    type: 'emulator-press-yes',
-                },
-            },
+            confirmExportAddressScreen,
+            getConfirmAddressOnDeviceScreen('3AnYTd2FGxJLNKL1AzxfW3FJMntp9D2KKX'),
         ],
     },
 ];
@@ -324,6 +328,98 @@ const recoverDevice = [
     },
 ];
 
+const ethereumGetPublicKey = [
+    {
+        ...getPublicKey[0],
+        url: 'ethereumGetPublicKey',
+    },
+];
+
+const ethereumGetAddress = [
+    {
+        ...getAddress[0],
+        url: 'ethereumGetAddress',
+        views: [
+            confirmExportAddressScreen,
+            getConfirmAddressOnDeviceScreen('0x3f2329C9ADFbcCd9A84f52c906E936A42dA18CB8'),
+        ],
+    },
+];
+
+const cardanoGetPublicKey = [
+    {
+        ...getPublicKey[0],
+        url: 'cardanoGetPublicKey',
+    },
+];
+
+const cardanoGetAddress = [
+    {
+        ...getAddress[0],
+        url: 'cardanoGetAddress',
+        views: [
+            confirmExportAddressScreen,
+            getConfirmAddressOnDeviceScreen(
+                'addr1q9hsv6vspp4l3nvmqzw529teq2ha08s0fgjvzghzh628uccfey0wtrgp5rmxvld7khc745x9mk7gts5ctuzerlf4edrqhtk02t',
+            ),
+        ],
+    },
+];
+
+const tezosGetPublicKey = [
+    {
+        ...getAddress[0],
+        url: 'tezosGetPublicKey',
+        views: [confirmExportAddressScreen, followDevice],
+    },
+];
+
+const tezosGetAddress = [
+    {
+        ...getAddress[0],
+        url: 'tezosGetAddress',
+        views: [
+            confirmExportAddressScreen,
+            getConfirmAddressOnDeviceScreen('tz1ckrgqGGGBt4jGDmwFhtXc1LNpZJUnA9F2'),
+        ],
+    },
+];
+
+const eosGetPublicKey = [
+    {
+        ...getPublicKey[0],
+        url: 'eosGetPublicKey',
+        views: [confirmExportAddressScreen, followDevice],
+    },
+];
+
+const eosGetAddress = [
+    {
+        ...getAddress[0],
+        url: 'eosGetAddress',
+        views: [confirmExportAddressScreen, getConfirmAddressOnDeviceScreen('meow')],
+    },
+];
+
+const binanceGetPublicKey = [
+    {
+        ...getPublicKey[0],
+        url: 'binanceGetPublicKey',
+        views: [confirmExportAddressScreen, followDevice],
+    },
+];
+
+const binanceGetAddress = [
+    {
+        ...getAddress[0],
+        url: 'binanceGetAddress',
+        views: [
+            confirmExportAddressScreen,
+            getConfirmAddressOnDeviceScreen('bnb1afwh46v6nn30nkmugw5swdmsyjmlxslgjfugre'),
+        ],
+    },
+];
+
 const fixtures = [
     ...getPublicKey,
     ...getAddress,
@@ -336,6 +432,20 @@ const fixtures = [
     ...recoverDevice,
     // todo: resetDevice also breaks next test in queue and is flaky itself
     // ...resetDevice,
+    ...ethereumGetPublicKey,
+    ...ethereumGetAddress,
+    ...cardanoGetPublicKey,
+    ...cardanoGetAddress,
+    // todo: unify tezosGetPublicKey with other getPublicKey calls (show on device)
+    ...tezosGetPublicKey,
+    ...tezosGetAddress,
+    // todo: unify eosGetPublicKey with other getPublicKey calls (show on device)
+    ...eosGetPublicKey,
+    // todo: missing in connect-explorer
+    // ...eosGetAddress,
+    // todo: unify binanceGetPublicKey with other getPublicKey calls (show on device)
+    ...binanceGetPublicKey,
+    ...binanceGetAddress,
 ];
 
 module.exports = fixtures;

--- a/packages/integration-tests/projects/connect-explorer/tests/fixtures.js
+++ b/packages/integration-tests/projects/connect-explorer/tests/fixtures.js
@@ -328,12 +328,7 @@ const fixtures = [
     ...getPublicKey,
     ...getAddress,
     ...getAccountInfo,
-    // todo: compose transaction breaks next test in queue
-    // this tests ends with POST "Cancel" call through bridge here https://github.com/trezor/connect/blob/develop/src/js/device/DeviceCommands.js#L669
-    // for reference /post/session endpoint works check here https://github.com/trezor/trezord-go
-    // subsequent call (in next tests) fails here https://github.com/trezor/connect/blob/develop/src/js/device/DeviceCommands.js#L368
-    // as trezord returns response belonging to the prev call.
-    // ...composeTransaction,
+    ...composeTransaction,
     ...signTransaction,
     ...signMessage,
     ...verifyMessage,

--- a/packages/integration-tests/projects/connect-explorer/tests/popup-close.test.js
+++ b/packages/integration-tests/projects/connect-explorer/tests/popup-close.test.js
@@ -1,0 +1,222 @@
+const { test, expect } = require('@playwright/test');
+const { Controller } = require('../../../websocket-client');
+const { createDeferred } = require('@trezor/utils');
+
+const url = process.env.URL || 'http://localhost:8082/';
+const controller = new Controller({ url: 'ws://localhost:9001/' });
+
+const WAIT_AFTER_TEST = 3000; // how long test should wait for more potential trezord requests
+
+// requests to bridge
+let requests = [];
+// responses from bridge
+let responses = [];
+
+let releasePromise;
+// popup window reference
+let popup;
+let popupClosedPromise;
+
+test.beforeAll(async () => {
+    await controller.connect();
+});
+
+// todo: 2.0.27 version don't have localhost nor sldev whitelisted. So this can't be tested in CI. Possible workarounds:
+// - host bridge that is used in this test on trezor.io domain, or
+// - run it all locally in CI (./docker/docker-compose.connect.explorer.test.yml)
+[/* '2.0.27', */ '2.0.31'].forEach(bridgeVersion => {
+    test.beforeEach(async ({ page }) => {
+        requests = [];
+        responses = [];
+        releasePromise = createDeferred();
+
+        await controller.send({
+            type: 'bridge-stop',
+        });
+        await controller.send({
+            type: 'emulator-stop',
+        });
+        await controller.send({
+            type: 'emulator-start',
+            wipe: true,
+        });
+        await controller.send({
+            type: 'emulator-setup',
+            mnemonic:
+                'alcohol woman abuse must during monitor noble actual mixed trade anger aisle',
+            pin: '',
+            passphrase_protection: false,
+            label: 'My Trevor',
+            needs_backup: false,
+        });
+        await controller.send({
+            type: 'bridge-start',
+            version: bridgeVersion,
+        });
+
+        await page.goto(`${url}#/method/verifyMessage`);
+        await page.waitForSelector("button[data-test='@submit-button']", { state: 'visible' });
+
+        // Subscribe to 'request' and 'response' events.
+        page.on('request', request => {
+            // ignore other than bridge requests
+            if (!request.url().startsWith('http://127.0.0.1:21325')) {
+                return;
+            }
+            requests.push({ url: request.url() });
+        });
+
+        page.on('response', async response => {
+            // ignore other than bridge requests
+            if (!response.url().startsWith('http://127.0.0.1:21325')) {
+                return;
+            }
+            if (response.url().endsWith('release/2')) {
+                releasePromise.resolve();
+            }
+            console.log(response.status(), response.url());
+            responses.push({
+                url: response.url(),
+                status: response.status(),
+                body: await response.text(),
+            });
+        });
+
+        [popup] = await Promise.all([
+            page.waitForEvent('popup'),
+            page.click("button[data-test='@submit-button']"),
+        ]);
+
+        popupClosedPromise = new Promise(resolve => {
+            popup.on('close', () => resolve());
+        });
+
+        await popup.waitForLoadState('load');
+
+        await popup.waitForSelector('button.confirm', { state: 'visible', timeout: 40000 });
+        await popup.click('button.confirm');
+        await popup.waitForSelector('.follow-device >> visible=true');
+    });
+
+    // Finish verify message in afterEach. This is here to prove that after the first
+    // failed attempt it is possible to retry successfully without any weird bug/race condition/edge-case
+    // we are validating here this commit https://github.com/trezor/connect/commit/fc60c3c03d6e689f3de2d518cc51f62e649a20e2
+    test.afterEach(async ({ page }) => {
+        await page.goto(`${url}#/method/verifyMessage`);
+        await page.waitForSelector("button[data-test='@submit-button']", { state: 'visible' });
+        [popup] = await Promise.all([
+            page.waitForEvent('popup'),
+            page.click("button[data-test='@submit-button']"),
+        ]);
+
+        await popup.waitForLoadState('load');
+
+        await popup.waitForSelector('button.confirm', { state: 'visible', timeout: 40000 });
+        await popup.click('button.confirm');
+        await popup.waitForSelector('.follow-device >> visible=true');
+        await controller.send({ type: 'emulator-press-yes' });
+        await controller.send({ type: 'emulator-press-yes' });
+        await controller.send({ type: 'emulator-press-yes' });
+        await page.waitForSelector('text=Message verified');
+    });
+
+    test(`popup closed by user with bridge version ${bridgeVersion}`, async ({ page }) => {
+        // user closed popup
+        await popup.close();
+        await popupClosedPromise;
+        await page.waitForTimeout(WAIT_AFTER_TEST);
+
+        if (bridgeVersion === '2.0.31') {
+            expect(responses[12].url).toEqual('http://127.0.0.1:21325/post/2');
+            await page.waitForSelector('text=Failure_ActionCancelled');
+        }
+    });
+
+    test(`device dialog canceled by user with bridge version ${bridgeVersion}`, async ({
+        page,
+    }) => {
+        // user canceled dialog on device
+        await controller.send({ type: 'emulator-press-no' });
+        await releasePromise.promise;
+        await popupClosedPromise;
+        await page.waitForTimeout(WAIT_AFTER_TEST);
+
+        responses.forEach(response => {
+            expect(response.status).toEqual(200);
+            // no post endpoint is used
+            expect(response.url).not.toContain('post');
+        });
+
+        await page.waitForSelector('text=Failure_ActionCancelled');
+    });
+
+    test(`device disconnected during device interaction with bridge version ${bridgeVersion}`, async ({
+        page,
+    }) => {
+        // user canceled interaction on device
+        await controller.send({ type: 'emulator-stop' });
+        await releasePromise.promise;
+        await popupClosedPromise;
+        await page.waitForTimeout(WAIT_AFTER_TEST);
+
+        responses.forEach(response => {
+            expect(response.url).not.toContain('post');
+        });
+
+        // 'device disconnected during action' error
+        expect(responses[12]).toMatchObject({
+            url: 'http://127.0.0.1:21325/call/2',
+            status: 400,
+        });
+
+        await page.waitForSelector('text=device disconnected during action');
+
+        await controller.send({
+            type: 'emulator-start',
+        });
+    });
+
+    // todo: this one is somewhat flaky. tends to produce "RuntimeError - Emulator proces died" error
+    test.skip(`trezor bridge ${bridgeVersion} was killed during action`, async ({ page }) => {
+        // user canceled interaction on device
+        await controller.send({ type: 'bridge-stop' });
+        await popupClosedPromise;
+
+        await page.waitForSelector('text=Aborted');
+
+        // todo: emulator stop should not be needed. this indicate some kind of bug
+        await controller.send({
+            type: 'emulator-stop',
+        });
+
+        await controller.send({
+            type: 'bridge-start',
+        });
+
+        // todo: see previous comment, emulator should be already running
+        await controller.send({
+            type: 'emulator-start',
+        });
+    });
+
+    // reloading page might end with "closed device" error from here:
+    // https://github.com/trezor/trezord-go/blob/106e5e9af3573ac2b27ebf2082bbee91650949bf/usb/libusb.go#L511
+    // this was probably targeted by this (never merged) trezor-bridge PR https://github.com/trezor/trezord-go/pull/156
+    test.skip(`client (connect-explorer) is reloaded by user while popup is active. bridge version ${bridgeVersion}`, async ({
+        page,
+    }) => {
+        await page.reload();
+        // todo: page reload closes popup, which is what we want, but it does not cancel interaction on device.
+        await popupClosedPromise;
+    });
+
+    // just like the previous skipped test.
+    // request: http://127.0.0.1:21325/call/3
+    // response {"error":"closed device"}
+    test.skip(`popup is reloaded by user. bridge version ${bridgeVersion}`, async ({ page }) => {
+        await popup.reload();
+        // after popup is reload, communication is lost, there is only infinite loader
+        await popup.waitForSelector('.loader');
+        // todo: there is no message into client about the fact that popup was unloaded
+    });
+});

--- a/packages/suite-desktop/package.json
+++ b/packages/suite-desktop/package.json
@@ -183,7 +183,7 @@
         "node-fetch": "^2.6.7",
         "openpgp": "^5.0.0",
         "systeminformation": "^5.9.9",
-        "trezor-connect": "8.2.8-beta.2"
+        "trezor-connect": "8.2.8-beta.3"
     },
     "devDependencies": {
         "@types/electron-localshortcut": "^3.1.0",

--- a/packages/suite/package.json
+++ b/packages/suite/package.json
@@ -66,7 +66,7 @@
         "semver": "^7.3.5",
         "styled-components": "^5.3.3",
         "trezor-address-validator": "^0.4.2",
-        "trezor-connect": "8.2.8-beta.2",
+        "trezor-connect": "8.2.8-beta.3",
         "ua-parser-js": "^1.0.2",
         "uuid": "^8.3.2",
         "web3-utils": "^1.6.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -23452,10 +23452,10 @@ trezor-address-validator@^0.4.2:
     jssha "2.3.1"
     lodash "^4.17.15"
 
-trezor-connect@8.2.8-beta.2:
-  version "8.2.8-beta.2"
-  resolved "https://registry.yarnpkg.com/trezor-connect/-/trezor-connect-8.2.8-beta.2.tgz#59e02a94d95c9820b54d0f7f6289f0651c15ba33"
-  integrity sha512-l8EN5wt90aPxQcHFO+KYm46OylMRjwL73PMLr5lCBJQGLfvCbRG8AoBgjYi/5rSu5uzpN75PQQmSylJ7G4Z1+w==
+trezor-connect@8.2.8-beta.3:
+  version "8.2.8-beta.3"
+  resolved "https://registry.yarnpkg.com/trezor-connect/-/trezor-connect-8.2.8-beta.3.tgz#4a549f5e82dea9dbda5feac46ea7d32aec8150d4"
+  integrity sha512-AmACFWdAGWNMxEG9Ms2QEAXSaMXyG7ujzJn2N/2h2PyZWvNUk+yyjtnnb+tBARYBJWqA2gQ9gLfYmX6KglaZMA==
   dependencies:
     "@babel/runtime" "^7.15.4"
     "@trezor/blockchain-link" "^2.1.1"


### PR DESCRIPTION
- 1st commit changes setup of popup tests to run in series. this is important as there is only one trezor-bridge instance and it is not possible to share it between tests
- 2nd commit adds popup test for various cases of how popup can be closed.
- 3th commit enables yet another test that kept failing prior to https://github.com/trezor/connect/pull/1059 fix 
- 4th commit adds getPublicKey and getAddress screens for altcoins where possible. Some of the altcoins don't have respective methods defined for connect-explorer. Also interesting observation could be found - some of the altcoins are using `export address` views instead of `export public key` views and I am not sure if this is intentional. 
- 5th commit updates trezor-connect with a fix that should make everything work https://github.com/trezor/connect/pull/1059