### PR TITLE
fix(ci): load nix-shell for new darwin runner

### DIFF
--- a/ci/prebuild.yml
+++ b/ci/prebuild.yml
@@ -19,6 +19,7 @@ msg-system config sign stable:
   variables:
     IS_CODESIGN_BUILD: "true"
   script:
+    - . /nix/var/nix/profiles/default/etc/profile.d/nix-daemon.sh || true # loads nix-shell
     - nix-shell --option system x86_64-darwin --run "git lfs pull"
     - nix-shell --option system x86_64-darwin --run "yarn install --frozen-lockfile --cache-folder .yarn-nix --prefer-offline"
     - nix-shell --option system x86_64-darwin --run "yarn workspace @trezor/suite-data msg-system-sign-config"


### PR DESCRIPTION
@matejkriz Missed the line here and it's not working because of it. I tested it on the codesign branch and it is working as it is supposed to. 