### PR TITLE
fix: discovery error screen icon

### DIFF
--- a/packages/suite/src/views/dashboard/components/PortfolioCard/components/Exception/index.tsx
+++ b/packages/suite/src/views/dashboard/components/PortfolioCard/components/Exception/index.tsx
@@ -172,7 +172,7 @@ const Exception = ({ exception, discovery }: Props) => {
                             values={{ details: discoveryFailedMessage(discovery) }}
                         />
                     }
-                    cta={{ action: actions.restartDiscovery }}
+                    cta={{ action: actions.restartDiscovery, icon: 'REFRESH' }}
                     dataTestBase={exception.type}
                 />
             );


### PR DESCRIPTION
Micro PR. I just got triggered while doing something else: 

Before  
![image](https://user-images.githubusercontent.com/30367552/156056493-ce4c399a-1ef6-4f2c-94df-4194c393f7e4.png)

After: 
![image](https://user-images.githubusercontent.com/30367552/156057064-290bd447-c52f-4fdb-b7df-a2bf41cecaeb.png)

I think PLUS icon does not fit here. Maybe it would be better to provide REFRESH as fallback here https://github.com/trezor/trezor-suite/blob/5b644e3cdc77d1cb483d74fd75c6f87582d47b38/packages/suite/src/views/dashboard/components/PortfolioCard/components/Exception/index.tsx#L76