### PR TITLE
fix(analytics): enrich onboarding analytics

### DIFF
--- a/docs/misc/analytics.md
+++ b/docs/misc/analytics.md
@@ -129,10 +129,11 @@ Added:
 -   device-setup-completed
     -   duration: number (in ms)
     -   device: 'T' | '1'
-    -   firmware: 'install' | 'skip' | 'up-to-date'
-    -   seed: 'create' | 'recover'
-    -   recoveryType?: 'standard' | 'advanced' (empty if seed equals to 'create')
-    -   backup?: 'create' | 'skip' (empty if seed equals to 'recover')
+    -   firmware?: 'install' | 'update' | 'skip' | 'up-to-date' (empty if seed === 'recovery-in-progress')
+    -   seed: 'create' | 'recovery' | 'recovery-in-progress'
+    -   seedType?: 'standard' | 'shamir' (empty seed === 'recovery')
+    -   recoveryType?: 'standard' | 'advanced' (empty if seed === 'create' || device === 'T')
+    -   backup?: 'create' | 'skip' (empty if seed === 'recovery')
     -   pin: 'create' | 'skip'
 
 Removed:

--- a/packages/suite/src/actions/suite/analyticsActions.ts
+++ b/packages/suite/src/actions/suite/analyticsActions.ts
@@ -434,11 +434,6 @@ export const report =
     (_dispatch: Dispatch, getState: GetState) => {
         const url = getUrl();
 
-        // no reporting on localhost
-        if (!url) {
-            return;
-        }
-
         const { enabled, sessionId, instanceId, confirmed } = getState().analytics;
 
         // don't report until user confirmed his choice

--- a/packages/suite/src/components/firmware/FirmwareInitial.tsx
+++ b/packages/suite/src/components/firmware/FirmwareInitial.tsx
@@ -11,7 +11,7 @@ import { ReconnectDevicePrompt, InstallButton, FirmwareOffer } from '@firmware-c
 import { TrezorDevice } from '@suite/types/suite';
 import { getFwVersion, getFwUpdateVersion } from '@suite-utils/device';
 
-interface Props {
+interface FirmwareInitialProps {
     cachedDevice?: TrezorDevice;
     setCachedDevice: React.Dispatch<React.SetStateAction<TrezorDevice | undefined>>;
     // This component is shared between Onboarding flow and standalone fw update modal with few minor UI changes
@@ -44,7 +44,7 @@ const FirmwareInitial = ({
     setCachedDevice,
     onInstall,
     standaloneFwUpdate = false,
-}: Props) => {
+}: FirmwareInitialProps) => {
     const { device: liveDevice } = useDevice();
     const { setStatus, status } = useFirmware();
     const { goToNextStep, updateAnalytics } = useOnboarding();
@@ -93,7 +93,14 @@ const FirmwareInitial = ({
             body: cachedDevice?.firmwareRelease ? (
                 <FirmwareOffer device={cachedDevice} />
             ) : undefined,
-            innerActions: <InstallButton onClick={onInstall} />,
+            innerActions: (
+                <InstallButton
+                    onClick={() => {
+                        onInstall();
+                        updateAnalytics({ firmware: 'install' });
+                    }}
+                />
+            ),
         };
     } else if (device.mode === 'bootloader' && !standaloneFwUpdate) {
         // We can check if device.mode is bootloader only after checking that firmware !== none (condition above)
@@ -133,7 +140,7 @@ const FirmwareInitial = ({
                 <Button
                     onClick={() => {
                         setStatus(standaloneFwUpdate ? 'check-seed' : 'waiting-for-bootloader');
-                        updateAnalytics({ firmware: 'install' });
+                        updateAnalytics({ firmware: 'update' });
                     }}
                     data-test="@firmware/get-ready-button"
                 >

--- a/packages/suite/src/middlewares/recovery/recoveryMiddleware.ts
+++ b/packages/suite/src/middlewares/recovery/recoveryMiddleware.ts
@@ -35,6 +35,7 @@ const recovery =
             api.dispatch(
                 onboardingActions.updateAnalytics({
                     startTime: Date.now(),
+                    seed: 'recovery-in-progress',
                 }),
             );
             if (!analytics.confirmed) {

--- a/packages/suite/src/types/onboarding/index.ts
+++ b/packages/suite/src/types/onboarding/index.ts
@@ -25,8 +25,9 @@ export type AnyPath = typeof STEP.PATH_CREATE | typeof STEP.PATH_RECOVERY;
 
 export type OnboardingAnalytics = {
     startTime: number;
-    firmware: 'install' | 'skip' | 'up-to-date';
-    seed: 'create' | 'recover';
+    firmware: 'install' | 'update' | 'skip' | 'up-to-date';
+    seed: 'create' | 'recovery' | 'recovery-in-progress';
+    seedType: 'standard' | 'shamir';
     recoveryType: 'standard' | 'advanced';
     backup: 'create' | 'skip';
     pin: 'create' | 'skip';

--- a/packages/suite/src/views/onboarding/steps/CreateOrRecover/index.tsx
+++ b/packages/suite/src/views/onboarding/steps/CreateOrRecover/index.tsx
@@ -39,7 +39,7 @@ const CreateOrRecoverStep = () => {
                         onClick={() => {
                             addPath(STEP.PATH_RECOVERY);
                             goToNextStep();
-                            updateAnalytics({ seed: 'recover' });
+                            updateAnalytics({ seed: 'recovery' });
                         }}
                         heading={<Translation id="TR_RESTORE_EXISTING_WALLET" />}
                     />

--- a/packages/suite/src/views/onboarding/steps/ResetDevice/index.tsx
+++ b/packages/suite/src/views/onboarding/steps/ResetDevice/index.tsx
@@ -74,7 +74,7 @@ const ResetDeviceStep = () => {
                                 } else {
                                     await onResetDevice();
                                 }
-                                updateAnalytics({ recoveryType: undefined });
+                                updateAnalytics({ recoveryType: undefined, seedType: 'standard' });
                             }}
                             heading={<Translation id="SINGLE_SEED" />}
                             description={<Translation id="SINGLE_SEED_DESCRIPTION" />}
@@ -89,7 +89,10 @@ const ResetDeviceStep = () => {
                                     data-test="@onboarding/shamir-backup-option-button"
                                     onClick={async () => {
                                         await onResetDevice({ backup_type: 1 });
-                                        updateAnalytics({ recoveryType: undefined });
+                                        updateAnalytics({
+                                            recoveryType: undefined,
+                                            seedType: 'shamir',
+                                        });
                                     }}
                                     heading={<Translation id="SHAMIR_SEED" />}
                                     description={<Translation id="SHAMIR_SEED_DESCRIPTION" />}


### PR DESCRIPTION
- adds `seedType`
- distinguishes ` update` and `install` of firmware
- renames `recover` to `recovery`
- fixes missing `seed` attribute if `recovery-in-progress` on `T`

- [x] Notion updated (https://www.notion.so/satoshilabs/Onboarding-new-version-99e4979e5f2f46d8b63fcf79a0d0d06d)