### PR TITLE
tor and external backends

### DIFF
--- a/packages/suite-desktop/src-electron/app.ts
+++ b/packages/suite-desktop/src-electron/app.ts
@@ -1,9 +1,9 @@
 import path from 'path';
 import url from 'url';
-import { app, BrowserWindow, ipcMain, session } from 'electron';
-import { init as initSentry, ElectronOptions, IPCMode } from '@sentry/electron';
+import { app, BrowserWindow, ipcMain } from 'electron';
+// import { init as initSentry, ElectronOptions, IPCMode } from '@sentry/electron';
 
-import { SENTRY_CONFIG } from '@suite-config';
+// import { SENTRY_CONFIG } from '@suite-config';
 import { isDev } from '@suite-utils/build';
 import { PROTOCOL } from './libs/constants';
 import * as store from './libs/store';
@@ -143,12 +143,12 @@ ipcMain.on('app/restart', () => {
     app.exit();
 });
 
-if (!isDev) {
-    const sentryConfig: ElectronOptions = {
-        ...SENTRY_CONFIG,
-        ipcMode: IPCMode.Classic,
-        getSessions: () => [session.defaultSession],
-    };
+// if (!isDev) {
+//     const sentryConfig: ElectronOptions = {
+//         ...SENTRY_CONFIG,
+//         ipcMode: IPCMode.Classic,
+//         getSessions: () => [session.defaultSession],
+//     };
 
-    initSentry(sentryConfig);
-}
+//     initSentry(sentryConfig);
+// }


### PR DESCRIPTION
it looks like that this commit 6645643bbe1f1f0a9333ad82d3b5ffa21df0ff73 breaks ripple and cardano backends over tor. so far I have added a "fix" just to demonstrate the problem. now I am investigating how to fix it properly. 