### PR TITLE
test(transport): fix after wallet deprecation

### DIFF
--- a/packages/transport/CHANGELOG.md
+++ b/packages/transport/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 1.1.1 (not released)
+
+-   Changed latest bridge url to https://connect.trezor.io/8/data/bridge/latest.txt'
+
 # 1.1.0
 
 -   Added @trezor/utils dependency.

--- a/packages/transport/src/config.ts
+++ b/packages/transport/src/config.ts
@@ -1,5 +1,5 @@
 export const DEFAULT_URL = 'http://127.0.0.1:21325';
-export const DEFAULT_VERSION_URL = 'https://wallet.trezor.io/data/bridge/latest.txt';
+export const DEFAULT_VERSION_URL = 'https://connect.trezor.io/8/data/bridge/latest.txt';
 export const MESSAGE_HEADER_BYTE = 0x23;
 export const HEADER_SIZE = 1 + 1 + 4 + 2;
 export const BUFFER_SIZE = 63;


### PR DESCRIPTION
info about bridge is no longer available from

'https://wallet.trezor.io/data/bridge/latest.txt'

trezor-connect is using @trezor/transport in another way so we don't need to hurry with update.