### PR TITLE
chore: add missing params to cardano in connect-explorer

### DIFF
--- a/packages/connect-explorer/src/js/data/methods/cardano/getAccountInfo.ts
+++ b/packages/connect-explorer/src/js/data/methods/cardano/getAccountInfo.ts
@@ -18,6 +18,16 @@ export default [
                     { value: 'tada', label: 'Cardano Testnet' },
                 ],
             },
+            {
+                name: 'useCardanoDerivation',
+                type: 'boolean',
+                value: true,
+            },
+            {
+                name: 'derivationType',
+                type: 'number',
+                value: 2,
+            },
         ],
     },
 ];


### PR DESCRIPTION
make cardano discovery work in connect-explorer 