### PR TITLE
fix: Fix the sentry-electron IPC error when Sentry is disabled in dev mode

### DIFF
--- a/packages/suite-desktop/src-electron/app.ts
+++ b/packages/suite-desktop/src-electron/app.ts
@@ -143,12 +143,10 @@ ipcMain.on('app/restart', () => {
     app.exit();
 });
 
-if (!isDev) {
-    const sentryConfig: ElectronOptions = {
-        ...SENTRY_CONFIG,
-        ipcMode: IPCMode.Classic,
-        getSessions: () => [session.defaultSession],
-    };
+const sentryConfig: ElectronOptions = {
+    ...SENTRY_CONFIG,
+    ipcMode: IPCMode.Classic,
+    getSessions: () => [session.defaultSession],
+};
 
-    initSentry(sentryConfig);
-}
+initSentry(sentryConfig);

--- a/packages/suite-desktop/src-electron/preload.ts
+++ b/packages/suite-desktop/src-electron/preload.ts
@@ -3,6 +3,8 @@ import { getDesktopApi } from '@trezor/suite-desktop-api';
 import { ipcRenderer } from './typed-electron';
 import { initTrezorConnectIpcChannel } from './modules/trezor-connect-preload';
 
+import '@sentry/electron/preload';
+
 initTrezorConnectIpcChannel();
 
 const desktopApi = getDesktopApi(ipcRenderer);

--- a/packages/suite-desktop/src/index.tsx
+++ b/packages/suite-desktop/src/index.tsx
@@ -6,8 +6,6 @@ import { init as initSentry } from '@sentry/electron/renderer';
 import { desktopApi } from '@trezor/suite-desktop-api';
 
 import { store } from '@suite/reducers/store';
-import { isDev } from '@suite-utils/build';
-import { SENTRY_CONFIG } from '@suite-config';
 
 import Metadata from '@suite-components/Metadata';
 import Preloader from '@suite-components/Preloader';
@@ -24,14 +22,14 @@ import ThemeProvider from '@suite-support/ThemeProvider';
 import history from '@suite/support/history';
 import AppRouter from './support/Router';
 import DesktopUpdater from './support/DesktopUpdater';
+import { SENTRY_CONFIG } from '@suite/config/suite';
 
 const Index = () => {
     const [isUpdateVisible, setIsUpdateVisible] = useState(false);
 
     useEffect(() => {
-        if (!isDev) {
-            initSentry(SENTRY_CONFIG);
-        }
+        initSentry(SENTRY_CONFIG);
+
         desktopApi.clientReady();
     }, []);
 

--- a/packages/suite/src/config/suite/sentry.ts
+++ b/packages/suite/src/config/suite/sentry.ts
@@ -1,4 +1,6 @@
 import { CaptureConsole, Dedupe } from '@sentry/integrations';
+import { isDev } from '@suite-utils/build';
+
 import type { Options } from '@sentry/types';
 
 export const allowReportTag = 'allowReport';
@@ -40,6 +42,7 @@ const config: Options = {
         new Dedupe(),
     ],
     beforeSend,
+    enabled: !isDev,
     release: process.env.SENTRY_RELEASE,
     environment: process.env.SUITE_TYPE,
     normalizeDepth: 4,


### PR DESCRIPTION
fix #5046

Added the preload script manually, so that it's possible to disable Sentry in dev mode, moved the enable/disable condition to the config.