### PR TITLE
refactor(suite): add hook for custom backends

### DIFF
--- a/packages/suite/src/components/suite/NavigationBar/components/NavigationActions/components/ActionItem/index.tsx
+++ b/packages/suite/src/components/suite/NavigationBar/components/NavigationActions/components/ActionItem/index.tsx
@@ -27,7 +27,6 @@ const MobileWrapper = styled.div<Pick<Props, 'isActive'>>`
     position: relative;
     cursor: pointer;
     align-items: center;
-    margin-right: 16px;
 
     & + & {
         border-top: 1px solid ${props => props.theme.STROKE_GREY};

--- a/packages/suite/src/components/suite/NavigationBar/components/NavigationActions/components/NavBackends.tsx
+++ b/packages/suite/src/components/suite/NavigationBar/components/NavigationActions/components/NavBackends.tsx
@@ -71,11 +71,14 @@ const BackendRow = ({
     );
 };
 
-export const NavBackends = () => {
+type NavBackendsProps = {
+    customBackends: BackendSettings[];
+};
+
+export const NavBackends = ({ customBackends }: NavBackendsProps) => {
     const [open, setOpen] = useState(false);
     const dropdownRef = useRef<DropdownRef>();
-    const { backends, blockchain } = useSelector(state => ({
-        backends: state.wallet.settings.backends,
+    const { blockchain } = useSelector(state => ({
         blockchain: state.wallet.blockchain,
     }));
     const { goto, openModal } = useActions({
@@ -83,13 +86,7 @@ export const NavBackends = () => {
         openModal: openModalAction,
     });
 
-    const customBackends: BackendSettings[] = (
-        Object.entries(backends) as Array<
-            [Network['symbol'], NonNullable<typeof backends[Network['symbol']]>]
-        >
-    ).map(([coin, settings]) => ({ coin, ...settings }));
-
-    return customBackends.length ? (
+    return (
         <Wrapper>
             <Dropdown
                 onToggle={() => setOpen(!open)}
@@ -139,5 +136,5 @@ export const NavBackends = () => {
                 />
             </Dropdown>
         </Wrapper>
-    ) : null;
+    );
 };

--- a/packages/suite/src/components/suite/NavigationBar/components/NavigationActions/index.tsx
+++ b/packages/suite/src/components/suite/NavigationBar/components/NavigationActions/index.tsx
@@ -6,6 +6,7 @@ import * as routerActions from '@suite-actions/routerActions';
 import { Translation } from '@suite-components';
 import { findRouteByName } from '@suite-utils/router';
 import { useActions, useAnalytics, useSelector } from '@suite-hooks';
+import { useCustomBackends } from '@settings-hooks/backends';
 import ActionItem from './components/ActionItem';
 import { isDesktop } from '@suite-utils/env';
 import { NavTor } from './components/NavTor';
@@ -102,6 +103,8 @@ const NavigationActions: React.FC<NavigationActionsProps> = ({
 
     const unseenNotifications = useMemo(() => notifications.some(n => !n.seen), [notifications]);
 
+    const customBackends = useCustomBackends();
+
     return (
         <WrapperComponent>
             <ActionItemWrapper>
@@ -122,16 +125,18 @@ const NavigationActions: React.FC<NavigationActionsProps> = ({
                 />
             </ActionItemWrapper>
 
-            {isMobileLayout ? (
-                <ActionItem
-                    onClick={() => action('settings-coins')}
-                    label={<Translation id="TR_BACKENDS" />}
-                    icon="BACKEND"
-                    isMobileLayout
-                />
-            ) : (
-                <NavBackends />
-            )}
+            {!!customBackends.length &&
+                (isMobileLayout ? (
+                    <ActionItem
+                        onClick={() => action('settings-coins')}
+                        label={<Translation id="TR_BACKENDS" />}
+                        icon="BACKEND"
+                        isMobileLayout
+                        indicator="check"
+                    />
+                ) : (
+                    <NavBackends customBackends={customBackends} />
+                ))}
 
             {isDesktop() && (
                 <>

--- a/packages/suite/src/components/suite/NavigationBar/components/NavigationActions/index.tsx
+++ b/packages/suite/src/components/suite/NavigationBar/components/NavigationActions/index.tsx
@@ -36,10 +36,6 @@ const MobileWrapper = styled.div`
     padding: 0px 16px;
 `;
 
-const ActionItemWrapper = styled.div`
-    position: relative;
-`;
-
 const Separator = styled.div`
     border: 1px solid ${props => props.theme.STROKE_GREY};
     height: 38px;
@@ -107,23 +103,21 @@ const NavigationActions: React.FC<NavigationActionsProps> = ({
 
     return (
         <WrapperComponent>
-            <ActionItemWrapper>
-                <ActionItem
-                    onClick={() => {
-                        analytics.report({
-                            type: 'menu/toggle-discreet',
-                            payload: {
-                                value: !discreetMode,
-                            },
-                        });
-                        setDiscreetMode(!discreetMode);
-                    }}
-                    isActive={discreetMode}
-                    label={<Translation id="TR_DISCREET" />}
-                    icon={discreetMode ? 'HIDE' : 'SHOW'}
-                    isMobileLayout={isMobileLayout}
-                />
-            </ActionItemWrapper>
+            <ActionItem
+                onClick={() => {
+                    analytics.report({
+                        type: 'menu/toggle-discreet',
+                        payload: {
+                            value: !discreetMode,
+                        },
+                    });
+                    setDiscreetMode(!discreetMode);
+                }}
+                isActive={discreetMode}
+                label={<Translation id="TR_DISCREET" />}
+                icon={discreetMode ? 'HIDE' : 'SHOW'}
+                isMobileLayout={isMobileLayout}
+            />
 
             {!!customBackends.length &&
                 (isMobileLayout ? (
@@ -138,26 +132,21 @@ const NavigationActions: React.FC<NavigationActionsProps> = ({
                     <NavBackends customBackends={customBackends} />
                 ))}
 
-            {isDesktop() && (
-                <>
-                    {isMobileLayout ? (
-                        <ActionItemWrapper>
-                            <ActionItem
-                                onClick={() => {
-                                    toggleTor(!tor);
-                                }}
-                                label={<Translation id="TR_TOR" />}
-                                icon="TOR"
-                                isMobileLayout={isMobileLayout}
-                                marginLeft
-                                indicator={tor ? 'check' : undefined}
-                            />
-                        </ActionItemWrapper>
-                    ) : (
-                        <NavTor isActive={tor} />
-                    )}
-                </>
-            )}
+            {isDesktop() &&
+                (isMobileLayout ? (
+                    <ActionItem
+                        onClick={() => {
+                            toggleTor(!tor);
+                        }}
+                        label={<Translation id="TR_TOR" />}
+                        icon="TOR"
+                        isMobileLayout
+                        marginLeft
+                        indicator={tor ? 'check' : undefined}
+                    />
+                ) : (
+                    <NavTor isActive={tor} />
+                ))}
 
             {allowPrerelease &&
                 (isMobileLayout ? (

--- a/packages/suite/src/components/suite/modals/DisableTor.tsx
+++ b/packages/suite/src/components/suite/modals/DisableTor.tsx
@@ -2,8 +2,9 @@ import React from 'react';
 import styled from 'styled-components';
 import { Button, H3, P, CoinLogo, variables } from '@trezor/components';
 import { Modal, Translation } from '@suite-components';
-import { useActions, useSelector } from '@suite-hooks';
+import { useActions } from '@suite-hooks';
 import { isOnionUrl } from '@suite-utils/tor';
+import { useCustomBackends } from '@settings-hooks/backends';
 import { getTitleForNetwork } from '@wallet-utils/accountUtils';
 import { setBackend as setBackendAction } from '@settings-actions/walletSettingsActions';
 import AdvancedCoinSettings from './AdvancedCoinSettings';
@@ -89,14 +90,11 @@ type DisableTorProps = Omit<Extract<UserContextPayload, { type: 'disable-tor' }>
 };
 
 export const DisableTor = ({ onCancel, decision }: DisableTorProps) => {
-    const backends = useSelector(state => state.wallet.settings.backends);
     const { setBackend } = useActions({
         setBackend: setBackendAction,
     });
     const [coin, setCoin] = React.useState<Network['symbol']>();
-    const onionBackends = Object.entries(backends)
-        .filter(([_, settings]) => settings.urls.every(isOnionUrl))
-        .map(([coin, settings]) => ({ coin: coin as Network['symbol'], ...settings }));
+    const onionBackends = useCustomBackends().filter(({ urls }) => urls.every(isOnionUrl));
 
     const onDisableTor = () => {
         onionBackends.forEach(({ coin, type, urls }) =>

--- a/packages/suite/src/hooks/settings/backends/index.ts
+++ b/packages/suite/src/hooks/settings/backends/index.ts
@@ -1,3 +1,4 @@
 export { useDefaultUrls } from './useDefaultUrls';
 export { useBackendsForm } from './useBackendsForm';
+export { useCustomBackends } from './useCustomBackends';
 export type { BackendOption } from './useBackendsForm';

--- a/packages/suite/src/hooks/settings/backends/useCustomBackends.ts
+++ b/packages/suite/src/hooks/settings/backends/useCustomBackends.ts
@@ -1,0 +1,12 @@
+import { useSelector } from '@suite-hooks';
+import type { Network } from '@wallet-types';
+import type { BackendSettings } from '@wallet-reducers/settingsReducer';
+
+export const useCustomBackends = (): BackendSettings[] => {
+    const backends = useSelector(state => state.wallet.settings.backends);
+    return (
+        Object.entries(backends) as Array<
+            [Network['symbol'], NonNullable<typeof backends[Network['symbol']]>]
+        >
+    ).map(([coin, settings]) => ({ coin, ...settings }));
+};


### PR DESCRIPTION
Implemented `useCustomBackends` as a simple helper hook to obtain correctly typed array of backend settings.