### PR TITLE
feat: script for regtest electrum

### DIFF
--- a/docker/docker-compose.regtest-electrum.yml
+++ b/docker/docker-compose.regtest-electrum.yml
@@ -1,0 +1,6 @@
+version: '3'
+services:
+  electrum-regtest:
+    image: ghcr.io/vdovhanych/electrs:latest
+    ports:
+      - "50001:50001"

--- a/docker/docker-regtest-electrum.sh
+++ b/docker/docker-regtest-electrum.sh
@@ -1,0 +1,6 @@
+#!/usr/bin/env bash
+set -e
+
+export LOCAL_USER_ID=`id -u $USER`
+
+docker-compose -f ./docker/docker-compose.regtest-electrum.yml up --build --abort-on-container-exit --force-recreate

--- a/docs/tests/regtest.md
+++ b/docs/tests/regtest.md
@@ -1,0 +1,17 @@
+# Regtest
+
+Regtest is a private blockchain which has the same rules and address format as testnet, but there is no global p2p network to connect to.
+
+To use custom backend (electrum server) with bitcoind running in regtest mode you can use the docker container by running the command below:
+
+```bash
+bash docker/docker-regtest-electrum.sh
+```
+
+The previous command will initialize a new fresh regtest bitcoin blockchain with electrum server running and expose to the localhost at TCP port 50001.
+
+In order to be able to use regtest electrum in suite it is required to configured the REGTEST coin with custom backend with URL below:
+
+```
+localhost:50001:t
+```


### PR DESCRIPTION
This is a new bash script with a docker compose that only starts an electrum server with bitcoind in regtest and expose the electrum port to be accessible for suite desktop running in the same computer.

The idea is that this can be run by the QA team to manually test sending and receiving in trezor using custom backend.

This is a  step forward in order to make testing based on regtest possible, other improvements can be done like:
* creating scripts inside docker container that makes creating/signing/broadcasting transactions easier.
* creating a UI that will use the previous mentioned scripts in a very simple way