### PR TITLE
fix(suite): use example.com not foobar.com as a domain placeholder

### DIFF
--- a/packages/suite/src/hooks/settings/backends/useBackendsForm.ts
+++ b/packages/suite/src/hooks/settings/backends/useBackendsForm.ts
@@ -35,7 +35,7 @@ const getUrlPlaceholder = (coin: Network['symbol'], type: BackendOption) => {
         case 'blockfrost':
             return `wss://blockfrost.io`;
         case 'electrum':
-            return `electrum.foobar.com:50001:t`;
+            return `electrum.example.com:50001:t`;
         default:
             return '';
     }

--- a/packages/suite/src/utils/suite/__tests__/backend.test.ts
+++ b/packages/suite/src/utils/suite/__tests__/backend.test.ts
@@ -9,22 +9,22 @@ describe('backend utils', () => {
     });
 
     test('isElectrumUrl', () => {
-        expect(utils.isElectrumUrl('electrum.foobar.com:50001:t')).toBe(true);
-        expect(utils.isElectrumUrl('electrum.foobar.com:50001:s')).toBe(true);
-        expect(utils.isElectrumUrl('electrum.foobar.onion:50001:t')).toBe(true);
-        expect(utils.isElectrumUrl('electrum.foobar.com:50001:x')).toBe(false);
+        expect(utils.isElectrumUrl('electrum.example.com:50001:t')).toBe(true);
+        expect(utils.isElectrumUrl('electrum.example.com:50001:s')).toBe(true);
+        expect(utils.isElectrumUrl('electrum.example.onion:50001:t')).toBe(true);
+        expect(utils.isElectrumUrl('electrum.example.com:50001:x')).toBe(false);
         expect(utils.isElectrumUrl('wss://blockfrost.io')).toBe(false);
         expect(utils.isElectrumUrl('https://google.com')).toBe(false);
         expect(utils.isElectrumUrl('')).toBe(false);
     });
 
     test('getElectrumHost', () => {
-        expect(utils.getElectrumHost('electrum.foobar.com:50001:t')).toBe('electrum.foobar.com');
-        expect(utils.getElectrumHost('electrum.foobar.com:50001:s')).toBe('electrum.foobar.com');
-        expect(utils.getElectrumHost('electrum.foobar.onion:50001:t')).toBe(
-            'electrum.foobar.onion',
+        expect(utils.getElectrumHost('electrum.example.com:50001:t')).toBe('electrum.example.com');
+        expect(utils.getElectrumHost('electrum.example.com:50001:s')).toBe('electrum.example.com');
+        expect(utils.getElectrumHost('electrum.example.onion:50001:t')).toBe(
+            'electrum.example.onion',
         );
-        expect(utils.getElectrumHost('electrum.foobar.com:50001:x')).toBe(undefined);
+        expect(utils.getElectrumHost('electrum.example.com:50001:x')).toBe(undefined);
         expect(utils.getElectrumHost('wss://blockfrost.io')).toBe(undefined);
         expect(utils.getElectrumHost('https://google.com')).toBe(undefined);
         expect(utils.getElectrumHost('')).toBe(undefined);


### PR DESCRIPTION
example.com is much better placeholder as foobar.com because the latter is a privately owned domain

see https://www.iana.org/domains/reserved for more info