### PR TITLE
fix: prevent rendering of staking component for non-cardano accounts

### DIFF
--- a/packages/suite/src/support/messages.ts
+++ b/packages/suite/src/support/messages.ts
@@ -6349,6 +6349,10 @@ export default defineMessages({
         defaultMessage:
             'Stake pool your are delegating on is oversaturated. Please redelegate your stake to maximize your staking rewards',
     },
+    TR_STAKING_IS_NOT_SUPPORTED: {
+        id: 'TR_STAKING_IS_NOT_SUPPORTED',
+        defaultMessage: 'Staking is not supported on this network.',
+    },
     TR_RECEIVING_SYMBOL: {
         id: 'TR_RECEIVING_SYMBOL',
         defaultMessage: 'Receiving {symbol}',

--- a/packages/suite/src/views/wallet/staking/index.tsx
+++ b/packages/suite/src/views/wallet/staking/index.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
-import { WalletLayout } from '@wallet-components';
+import { Translation } from '@suite-components';
+import { AccountExceptionLayout, WalletLayout } from '@wallet-components';
 import { AppState } from '@suite-types';
 import { useCardanoStaking } from '@wallet-hooks/useCardanoStaking';
 import Rewards from './components/Rewards';
@@ -34,7 +35,21 @@ const CardanoStaking = () => {
     if (selectedAccount.status !== 'loaded') {
         return <WalletLayout title="TR_NAV_STAKING" account={selectedAccount} />;
     }
-    return <CardanoStakingLoaded selectedAccount={selectedAccount} />;
+
+    // render staking component only in cardano
+    if (selectedAccount.account.networkType === 'cardano') {
+        return <CardanoStakingLoaded selectedAccount={selectedAccount} />;
+    }
+
+    // unsupported network
+    return (
+        <WalletLayout title="TR_NAV_STAKING" account={selectedAccount}>
+            <AccountExceptionLayout
+                title={<Translation id="TR_STAKING_IS_NOT_SUPPORTED" />}
+                image="CLOUDY"
+            />
+        </WalletLayout>
+    );
 };
 
 export default CardanoStaking;


### PR DESCRIPTION
fixes possible crash when accessing staking tab with non cardano networks

It is related to more generic issue https://github.com/trezor/trezor-suite/issues/5080, this is intended as a fix for caradno since `useCardanoStaking` hook will intentionally throw an error when used in network other than cardano.

https://user-images.githubusercontent.com/6961901/157414684-8ffdc336-2ac3-474a-a246-c408f0106279.mov

