### PR TITLE
[wip] chore(gh-actions): translations backport-en automatically after trans…

### DIFF
--- a/.github/workflows/crowdin_sync.yml
+++ b/.github/workflows/crowdin_sync.yml
@@ -20,7 +20,10 @@ jobs:
           git config --global user.email "${{ secrets.TREZOR_BOT_EMAIL }}"
           git checkout -B trezor-ci/crowdin-sync
           yarn workspace @trezor/suite translations:download --token=${{ secrets.CROWDIN_PERSONAL_TOKEN }}
+          yarn workspace @trezor/suite translations:backport-en
           yarn workspace @trezor/suite translations:format
+          yarn workspace @trezor/suite translations:extract
+          yarn workspace @trezor/suite translations:upload --dry-run
           git add . && git commit -m "chore: crowdin translation update" && git push origin trezor-ci/crowdin-sync -f
           gh config set prompt disabled
           gh pr create --repo trezor/trezor-suite --title "Crowdin translations update" --body "Automatically generated PR for updating crowdin translations." --base develop --label translations


### PR DESCRIPTION
…lations download

Maybe, after fresh translations are downloaded from crowdin, we should automatically backport en.json into messages.ts? This is something we want to do anyway at some time point. And sooner is better here imho. Maybe we should also re-upload fresh source strings into crowdin so that translators don't translate outdated strings? Does it make sense?

summary: 

1. download translations
2. backport en.json into messages.ts
3. re-upload updated messages.ts into crowdin?

this would be the "full sync cycle". could there be any problems with this? 