### PR TITLE
Feat/analytics 1.17

### DIFF
--- a/docs/analytics/changelog.md
+++ b/docs/analytics/changelog.md
@@ -2,6 +2,13 @@
 
 This changelog lists all events that Suite tracks.
 
+### 1.17
+
+Added:
+
+-   create-backup
+    -   status: 'finished' | 'error'
+    -   error: string
 ### 1.16
 
 Added:

--- a/docs/analytics/changelog.md
+++ b/docs/analytics/changelog.md
@@ -9,6 +9,35 @@ Added:
 -   create-backup
     -   status: 'finished' | 'error'
     -   error: string
+-   app-update
+    -   fromVersion: string
+    -   toVersion: string
+    -   status: 'finished' | 'cancelled' | 'error'
+    -   version: 'stable' | 'beta'
+    -   status: 'downloaded' | 'cancelled' | 'error'
+    -   earlyAccessProgram: boolean
+    -   isPrerelease: boolean
+-   suite-ready
+    -   customBackends: ['btc', 'eth', 'ada', ...] (array of coins with custom backend)
+    -   autodetectLanguage: boolean;
+    -   autodetectTheme: boolean;
+-   settings/coin-backend
+    -   symbol: 'btc', 'eth', 'ada', ...
+    -   type: 'default' | 'blockbook' | 'electrum' | 'ripple' | 'blockfrost'
+    -   totalRegular: number
+    -   totalOnion: number
+-   settings/general/change-language
+    -   previousLanguage: string
+    -   previousAutodetectLanguage: boolean
+    -   autodetectLanguage: boolean
+    -   platformLanguages: string
+-   settings/general/change-theme
+    -   previousTheme: 'light' | 'dark'
+    -   previousAutodetectTheme: boolean;
+    -   theme: 'light' | 'dark'
+    -   autodetectTheme: boolean;
+    -   platformTheme: 'light' | 'dark'
+
 ### 1.16
 
 Added:

--- a/docs/analytics/changelog.md
+++ b/docs/analytics/changelog.md
@@ -23,6 +23,8 @@ Added:
     -   autodetectTheme: boolean;
 -   suite-ready
     -   customBackends: ['btc', 'eth', 'ada', ...] (array of coins with custom backend)
+    -   autodetectLanguage: boolean;
+    -   autodetectTheme: boolean;
 -   settings/coin-backend
     -   symbol: 'btc', 'eth', 'ada', ...
     -   type: 'default' | 'blockbook' | 'electrum' | 'ripple' | 'blockfrost'

--- a/docs/analytics/changelog.md
+++ b/docs/analytics/changelog.md
@@ -21,6 +21,8 @@ Added:
     -   customBackends: ['btc', 'eth', 'ada', ...] (array of coins with custom backend)
     -   autodetectLanguage: boolean;
     -   autodetectTheme: boolean;
+-   suite-ready
+    -   customBackends: ['btc', 'eth', 'ada', ...] (array of coins with custom backend)
 -   settings/coin-backend
     -   symbol: 'btc', 'eth', 'ada', ...
     -   type: 'default' | 'blockbook' | 'electrum' | 'ripple' | 'blockfrost'

--- a/packages/suite-desktop-api/src/messages.ts
+++ b/packages/suite-desktop-api/src/messages.ts
@@ -7,6 +7,8 @@ export interface UpdateInfo {
     releaseDate: string;
     isManualCheck?: boolean;
     downloadedFile?: string;
+    prerelease?: boolean;
+    changelog?: string;
 }
 
 export type UpdateProgress = Partial<{

--- a/packages/suite-desktop/src/support/DesktopUpdater/Available.tsx
+++ b/packages/suite-desktop/src/support/DesktopUpdater/Available.tsx
@@ -1,4 +1,4 @@
-import React, { useCallback, useEffect, useState } from 'react';
+import React, { useCallback } from 'react';
 import styled from 'styled-components';
 import ReactMarkdown from 'react-markdown';
 
@@ -7,8 +7,7 @@ import { Button, H2, variables, Link } from '@trezor/components';
 import { Translation, Modal, FormattedDate } from '@suite-components';
 import { Row, LeftCol, RightCol, Divider } from './styles';
 import { useActions } from '@suite-hooks';
-
-import { getReleaseNotes, getReleaseUrl } from '@suite/services/github';
+import { getReleaseUrl } from '@suite/services/github';
 import * as desktopUpdateActions from '@suite-actions/desktopUpdateActions';
 
 const GreenH2 = styled(H2)`
@@ -76,13 +75,6 @@ const DateWrapper = styled.span`
     color: ${props => props.theme.TYPE_LIGHT_GREY};
 `;
 
-type ReleaseState = {
-    loading: boolean;
-    version?: string;
-    notes?: string;
-    prerelease: boolean;
-};
-
 interface VersionNameProps {
     latestVersion?: string;
     prerelease: boolean;
@@ -105,56 +97,15 @@ const getVersionName = ({ latestVersion, prerelease }: VersionNameProps): string
     return latestVersion;
 };
 
-interface Props {
+interface AvailableProps {
     hideWindow: () => void;
     latest?: UpdateInfo;
 }
 
-const Available = ({ hideWindow, latest }: Props) => {
-    const [releaseNotes, setReleaseNotes] = useState<ReleaseState>({
-        loading: false,
-        version: undefined,
-        notes: undefined,
-        prerelease: false,
-    });
-
+const Available = ({ hideWindow, latest }: AvailableProps) => {
     const { download } = useActions({
         download: desktopUpdateActions.download,
     });
-
-    useEffect(() => {
-        const fetchData = async () => {
-            setReleaseNotes({
-                ...releaseNotes,
-                loading: true,
-            });
-
-            let notes;
-            let prerelease = false;
-            const version = latest?.version;
-
-            try {
-                if (!version) {
-                    throw new Error("Couldn't get latest version.");
-                }
-
-                const release = await getReleaseNotes(version);
-                notes = release?.body;
-                prerelease = !!release?.prerelease;
-            } finally {
-                setReleaseNotes({
-                    loading: false,
-                    version,
-                    notes,
-                    prerelease,
-                });
-            }
-        };
-
-        if (latest?.version !== releaseNotes.version && !releaseNotes.loading) {
-            fetchData();
-        }
-    }, [latest, releaseNotes]);
 
     const downloadUpdate = useCallback(() => {
         download();
@@ -173,15 +124,15 @@ const Available = ({ hideWindow, latest }: Props) => {
                     values={{
                         version: getVersionName({
                             latestVersion: latest?.version,
-                            prerelease: !!releaseNotes?.prerelease,
+                            prerelease: !!latest?.prerelease,
                         }),
                     }}
                 />
             </GreenH2>
 
             <ChangelogWrapper>
-                {releaseNotes.notes ? (
-                    <ReactMarkdown>{releaseNotes.notes}</ReactMarkdown>
+                {latest?.changelog ? (
+                    <ReactMarkdown>{latest?.changelog}</ReactMarkdown>
                 ) : (
                     <Translation id="TR_COULD_NOT_RETRIEVE_CHANGELOG" />
                 )}

--- a/packages/suite/src/actions/backup/backupActions.ts
+++ b/packages/suite/src/actions/backup/backupActions.ts
@@ -12,7 +12,7 @@ export type ConfirmKey =
     | 'made-no-digital-copy'
     | 'will-hide-seed';
 
-export type BackupStatus = 'initial' | 'in-progress' | 'finished';
+export type BackupStatus = 'initial' | 'in-progress' | 'finished' | 'error';
 export type BackupAction =
     | { type: typeof BACKUP.RESET_REDUCER }
     | { type: typeof BACKUP.TOGGLE_CHECKBOX_BY_KEY; payload: ConfirmKey }
@@ -70,9 +70,9 @@ export const backupDevice =
             });
         } else {
             dispatch(notificationActions.addToast({ type: 'backup-success' }));
+            dispatch({
+                type: BACKUP.SET_STATUS,
+                payload: 'finished',
+            });
         }
-        dispatch({
-            type: BACKUP.SET_STATUS,
-            payload: 'finished',
-        });
     };

--- a/packages/suite/src/actions/suite/analyticsActions.ts
+++ b/packages/suite/src/actions/suite/analyticsActions.ts
@@ -32,7 +32,7 @@ export type AnalyticsAction =
 
 // Don't forget to update docs with changelog!
 // <breaking-change>.<analytics-extended>
-export const version = '1.16';
+export const version = '1.17';
 
 export type AnalyticsEvent =
     | {
@@ -138,6 +138,13 @@ export type AnalyticsEvent =
           payload: Partial<Omit<OnboardingAnalytics, 'startTime'>> & {
               duration: number;
               device: 'T' | '1';
+          };
+      }
+    | {
+          type: 'create-backup';
+          payload: {
+              status: 'finished' | 'error';
+              error: string;
           };
       }
     | {

--- a/packages/suite/src/actions/suite/analyticsActions.ts
+++ b/packages/suite/src/actions/suite/analyticsActions.ts
@@ -5,16 +5,18 @@
  */
 
 import { ANALYTICS } from '@suite-actions/constants';
-import { Dispatch, GetState, AppState } from '@suite-types';
 import { getAnalyticsRandomId } from '@suite-utils/random';
 import { AppUpdateEvent, encodeDataToQueryString } from '@suite-utils/analytics';
-import { Account } from '@wallet-types';
 import { setOnBeforeUnloadListener, getEnvironment } from '@suite-utils/env';
 import { allowSentryReport, setSentryUser } from '@suite-utils/sentry';
 import { State } from '@suite-reducers/analyticsReducer';
 import { DeviceMode } from 'trezor-connect';
 
+import type { Dispatch, GetState, AppState } from '@suite-types';
+import type { Account } from '@wallet-types';
 import type { OnboardingAnalytics } from '@onboarding-types';
+import type { BackendOption } from '@settings-hooks/backends';
+import type { BackendSettings } from '@wallet-reducers/settingsReducer';
 
 export type AnalyticsAction =
     | { type: typeof ANALYTICS.ENABLE }
@@ -45,6 +47,7 @@ export type AnalyticsEvent =
           payload: {
               language: AppState['suite']['settings']['language'];
               enabledNetworks: AppState['wallet']['settings']['enabledNetworks'];
+              customBackends: BackendSettings['coin'][];
               localCurrency: AppState['wallet']['settings']['localCurrency'];
               discreetMode: AppState['wallet']['settings']['discreetMode'];
               screenWidth: number;
@@ -428,11 +431,12 @@ export type AnalyticsEvent =
           payload: AppUpdateEvent;
       }
     | {
+          type: 'settings/coin-backend';
           payload: {
-              fromVersion?: string;
-              toVersion?: string;
-              status: 'finished' | 'closed' | 'error';
-              version: 'stable' | 'beta';
+              symbol: Account['symbol'];
+              type: BackendOption;
+              totalRegular: number;
+              totalOnion: number;
           };
       };
 

--- a/packages/suite/src/actions/suite/analyticsActions.ts
+++ b/packages/suite/src/actions/suite/analyticsActions.ts
@@ -7,7 +7,7 @@
 import { ANALYTICS } from '@suite-actions/constants';
 import { Dispatch, GetState, AppState } from '@suite-types';
 import { getAnalyticsRandomId } from '@suite-utils/random';
-import { encodeDataToQueryString } from '@suite-utils/analytics';
+import { AppUpdateEvent, encodeDataToQueryString } from '@suite-utils/analytics';
 import { Account } from '@wallet-types';
 import { setOnBeforeUnloadListener, getEnvironment } from '@suite-utils/env';
 import { allowSentryReport, setSentryUser } from '@suite-utils/sentry';
@@ -421,6 +421,18 @@ export type AnalyticsEvent =
           type: 'send-raw-transaction';
           payload: {
               networkSymbol: Account['symbol'];
+          };
+      }
+    | {
+          type: 'app-update';
+          payload: AppUpdateEvent;
+      }
+    | {
+          payload: {
+              fromVersion?: string;
+              toVersion?: string;
+              status: 'finished' | 'closed' | 'error';
+              version: 'stable' | 'beta';
           };
       };
 

--- a/packages/suite/src/actions/suite/analyticsActions.ts
+++ b/packages/suite/src/actions/suite/analyticsActions.ts
@@ -72,6 +72,9 @@ export type AnalyticsEvent =
               windowHeight: number;
               // added in 1.9
               platformLanguages: string;
+              // added in 1.17
+              autodetectLanguage: boolean;
+              autodetectTheme: boolean;
           };
       }
     | { type: 'transport-type'; payload: { type: string; version: string } }
@@ -325,7 +328,21 @@ export type AnalyticsEvent =
     | {
           type: 'settings/general/change-language';
           payload: {
+              previousLanguage: AppState['suite']['settings']['language'];
+              previousAutodetectLanguage: boolean;
               language: AppState['suite']['settings']['language'];
+              autodetectLanguage: boolean;
+              platformLanguages: string;
+          };
+      }
+    | {
+          type: 'settings/general/change-theme';
+          payload: {
+              previousTheme: AppState['suite']['settings']['theme']['variant'];
+              previousAutodetectTheme: boolean;
+              theme: AppState['suite']['settings']['theme']['variant'];
+              autodetectTheme: boolean;
+              platformTheme: AppState['suite']['settings']['theme']['variant'];
           };
       }
     | {

--- a/packages/suite/src/actions/suite/constants/desktopUpdateConstants.ts
+++ b/packages/suite/src/actions/suite/constants/desktopUpdateConstants.ts
@@ -5,7 +5,6 @@ export const NOT_AVAILABLE = '@desktop-update/not-available';
 export const DOWNLOAD = '@desktop-update/download';
 export const DOWNLOADING = '@desktop-update/downloading';
 export const READY = '@desktop-update/ready';
-export const ERROR = '@desktop-update/error';
 export const WINDOW = '@desktop-update/window';
 export const OPEN_EARLY_ACCESS_ENABLE = '@desktop-update/open-early-access-enable';
 export const OPEN_EARLY_ACCESS_DISABLE = '@desktop-update/open-early-access-disable';

--- a/packages/suite/src/middlewares/suite/analyticsMiddleware.ts
+++ b/packages/suite/src/middlewares/suite/analyticsMiddleware.ts
@@ -7,49 +7,11 @@ import { SUITE, ROUTER, ANALYTICS } from '@suite-actions/constants';
 import { BACKUP } from '@backup-actions/constants';
 import { DISCOVERY } from '@wallet-actions/constants';
 import * as analyticsActions from '@suite-actions/analyticsActions';
-import {
-    getScreenWidth,
-    getScreenHeight,
-    getBrowserName,
-    getBrowserVersion,
-    getOsName,
-    getOsVersion,
-    getWindowWidth,
-    getWindowHeight,
-    getPlatformLanguages,
-} from '@suite-utils/env';
 import { isBitcoinOnly, getPhysicalDeviceCount } from '@suite-utils/device';
-import { allowSentryReport } from '@suite/utils/suite/sentry';
+import { allowSentryReport } from '@suite-utils/sentry';
+import { reportSuiteReadyAction } from '@suite-utils/analytics';
 
 import type { AppState, Action, Dispatch } from '@suite-types';
-
-const reportSuiteReadyAction = (state: AppState) =>
-    analyticsActions.report({
-        type: 'suite-ready',
-        payload: {
-            language: state.suite.settings.language,
-            enabledNetworks: state.wallet.settings.enabledNetworks,
-            localCurrency: state.wallet.settings.localCurrency,
-            discreetMode: state.wallet.settings.discreetMode,
-            screenWidth: getScreenWidth(),
-            screenHeight: getScreenHeight(),
-            platformLanguages: getPlatformLanguages().join(','),
-            tor: state.suite.tor,
-            rememberedStandardWallets: state.devices.filter(d => d.remember && d.useEmptyPassphrase)
-                .length,
-            rememberedHiddenWallets: state.devices.filter(d => d.remember && !d.useEmptyPassphrase)
-                .length,
-            theme: state.suite.settings.theme.variant,
-            suiteVersion: process.env.VERSION || '',
-            earlyAccessProgram: state.desktopUpdate.allowPrerelease,
-            browserName: getBrowserName(),
-            browserVersion: getBrowserVersion(),
-            osName: getOsName(),
-            osVersion: getOsVersion(),
-            windowWidth: getWindowWidth(),
-            windowHeight: getWindowHeight(),
-        },
-    });
 
 /*
     In analytics middleware we may intercept actions we would like to log. For example:

--- a/packages/suite/src/middlewares/suite/analyticsMiddleware.ts
+++ b/packages/suite/src/middlewares/suite/analyticsMiddleware.ts
@@ -4,6 +4,7 @@ import { MiddlewareAPI } from 'redux';
 import { TRANSPORT, DEVICE } from 'trezor-connect';
 
 import { SUITE, ROUTER, ANALYTICS } from '@suite-actions/constants';
+import { BACKUP } from '@backup-actions/constants';
 import { DISCOVERY } from '@wallet-actions/constants';
 import * as analyticsActions from '@suite-actions/analyticsActions';
 import {
@@ -171,6 +172,30 @@ const analytics =
                         type: 'menu/toggle-tor',
                         payload: {
                             value: action.payload,
+                        },
+                    }),
+                );
+                break;
+            case BACKUP.SET_STATUS:
+                if (action.payload === 'finished') {
+                    api.dispatch(
+                        analyticsActions.report({
+                            type: 'create-backup',
+                            payload: {
+                                status: 'finished',
+                                error: '',
+                            },
+                        }),
+                    );
+                }
+                break;
+            case BACKUP.SET_ERROR:
+                api.dispatch(
+                    analyticsActions.report({
+                        type: 'create-backup',
+                        payload: {
+                            status: 'error',
+                            error: action.payload,
                         },
                     }),
                 );

--- a/packages/suite/src/reducers/backup/backupReducer.ts
+++ b/packages/suite/src/reducers/backup/backupReducer.ts
@@ -35,6 +35,7 @@ const backup = (state: BackupState = initialState, action: Action) =>
                 draft.status = action.payload;
                 break;
             case BACKUP.SET_ERROR:
+                draft.status = 'error';
                 draft.error = action.payload;
                 break;
             case BACKUP.RESET_REDUCER:

--- a/packages/suite/src/reducers/store.ts
+++ b/packages/suite/src/reducers/store.ts
@@ -2,7 +2,6 @@ import { createStore, applyMiddleware, combineReducers, compose } from 'redux';
 import thunkMiddleware from 'redux-thunk';
 import { createLogger } from 'redux-logger';
 
-import { isDev } from '@suite-utils/build';
 import suiteMiddlewares from '@suite-middlewares';
 import walletMiddlewares from '@wallet-middlewares';
 import onboardingMiddlewares from '@onboarding-middlewares';
@@ -44,7 +43,7 @@ const middlewares = [
 
 const enhancers: any[] = [];
 const excludedActions = ['@log/add'];
-if (isDev) {
+if (!process.env.CODESIGN_BUILD) {
     const excludeLogger = (_getState: any, action: any): boolean => {
         const pass = excludedActions.filter(act => action.type === act);
         return pass.length === 0;

--- a/packages/suite/src/utils/suite/analytics.ts
+++ b/packages/suite/src/utils/suite/analytics.ts
@@ -1,6 +1,19 @@
 import { AppState } from '@suite-types';
+import * as analyticsActions from '@suite-actions/analyticsActions';
+import {
+    getScreenWidth,
+    getScreenHeight,
+    getBrowserName,
+    getBrowserVersion,
+    getOsName,
+    getOsVersion,
+    getWindowWidth,
+    getWindowHeight,
+    getPlatformLanguages,
+} from '@suite-utils/env';
 
-import { AnalyticsEvent } from '@suite-actions/analyticsActions';
+import type { UpdateInfo } from '@trezor/suite-desktop-api';
+import type { AnalyticsEvent } from '@suite-actions/analyticsActions';
 
 type Common = Pick<AppState['analytics'], 'instanceId' | 'sessionId'> & { version: string };
 
@@ -30,3 +43,59 @@ export const encodeDataToQueryString = (event: AnalyticsEvent, common: Common) =
 
     return params.toString();
 };
+
+// TODO(analytics-package): union a way how to define analytics actions
+export const reportSuiteReadyAction = (state: AppState) =>
+    analyticsActions.report({
+        type: 'suite-ready',
+        payload: {
+            language: state.suite.settings.language,
+            enabledNetworks: state.wallet.settings.enabledNetworks,
+            localCurrency: state.wallet.settings.localCurrency,
+            discreetMode: state.wallet.settings.discreetMode,
+            screenWidth: getScreenWidth(),
+            screenHeight: getScreenHeight(),
+            platformLanguages: getPlatformLanguages().join(','),
+            tor: state.suite.tor,
+            rememberedStandardWallets: state.devices.filter(d => d.remember && d.useEmptyPassphrase)
+                .length,
+            rememberedHiddenWallets: state.devices.filter(d => d.remember && !d.useEmptyPassphrase)
+                .length,
+            theme: state.suite.settings.theme.variant,
+            suiteVersion: process.env.VERSION || '',
+            earlyAccessProgram: state.desktopUpdate.allowPrerelease,
+            browserName: getBrowserName(),
+            browserVersion: getBrowserVersion(),
+            osName: getOsName(),
+            osVersion: getOsVersion(),
+            windowWidth: getWindowWidth(),
+            windowHeight: getWindowHeight(),
+        },
+    });
+
+export enum AppUpdateEventStatus {
+    Downloaded = 'downloaded',
+    Closed = 'closed',
+    Error = 'error',
+}
+
+// TODO(analytics-package): types file
+export type AppUpdateEvent = {
+    fromVersion?: string;
+    toVersion?: string;
+    status: AppUpdateEventStatus;
+    earlyAccessProgram: boolean;
+    isPrerelease?: boolean;
+};
+
+export const getAppUpdatePayload = (
+    status: AppUpdateEventStatus,
+    earlyAccessProgram: boolean,
+    updateInfo?: UpdateInfo,
+): AppUpdateEvent => ({
+    fromVersion: process.env.VERSION || '',
+    toVersion: updateInfo?.version,
+    status,
+    earlyAccessProgram,
+    isPrerelease: updateInfo?.prerelease,
+});

--- a/packages/suite/src/utils/suite/analytics.ts
+++ b/packages/suite/src/utils/suite/analytics.ts
@@ -74,6 +74,8 @@ export const reportSuiteReadyAction = (state: AppState) =>
             osVersion: getOsVersion(),
             windowWidth: getWindowWidth(),
             windowHeight: getWindowHeight(),
+            autodetectLanguage: state.suite.settings.autodetect.language,
+            autodetectTheme: state.suite.settings.autodetect.theme,
         },
     });
 

--- a/packages/suite/src/utils/suite/analytics.ts
+++ b/packages/suite/src/utils/suite/analytics.ts
@@ -14,6 +14,7 @@ import {
 
 import type { UpdateInfo } from '@trezor/suite-desktop-api';
 import type { AnalyticsEvent } from '@suite-actions/analyticsActions';
+import type { BackendSettings } from '@wallet-reducers/settingsReducer';
 
 type Common = Pick<AppState['analytics'], 'instanceId' | 'sessionId'> & { version: string };
 
@@ -51,6 +52,9 @@ export const reportSuiteReadyAction = (state: AppState) =>
         payload: {
             language: state.suite.settings.language,
             enabledNetworks: state.wallet.settings.enabledNetworks,
+            customBackends: Object.keys(
+                state.wallet.settings.backends,
+            ) as BackendSettings['coin'][],
             localCurrency: state.wallet.settings.localCurrency,
             discreetMode: state.wallet.settings.discreetMode,
             screenWidth: getScreenWidth(),

--- a/packages/suite/src/views/onboarding/steps/Backup/index.tsx
+++ b/packages/suite/src/views/onboarding/steps/Backup/index.tsx
@@ -1,5 +1,6 @@
 import React, { useState } from 'react';
 import styled from 'styled-components';
+
 import {
     OnboardingButtonCta,
     OnboardingButtonSkip,
@@ -39,8 +40,6 @@ const BackupStep = () => {
         return null;
     }
 
-    const { status } = backup;
-
     return (
         <>
             {showSkipConfirmation && (
@@ -49,7 +48,7 @@ const BackupStep = () => {
                     variant="backup"
                 />
             )}
-            {status === 'initial' && (
+            {backup.status === 'initial' && (
                 <OnboardingStepBox
                     image="BACKUP"
                     heading={<Translation id="TR_CREATE_BACKUP" />}
@@ -94,7 +93,7 @@ const BackupStep = () => {
                     </OptionsWrapper>
                 </OnboardingStepBox>
             )}
-            {status === 'in-progress' && (
+            {backup.status === 'in-progress' && (
                 <OnboardingStepBox
                     image="BACKUP"
                     heading={<Translation id="TR_CREATE_BACKUP" />}
@@ -114,7 +113,7 @@ const BackupStep = () => {
                 />
             )}
 
-            {status === 'finished' && !backup.error && (
+            {backup.status === 'finished' && (
                 <OnboardingStepBox
                     image="BACKUP"
                     heading={<Translation id="TR_BACKUP_CREATED" />}
@@ -130,7 +129,7 @@ const BackupStep = () => {
                     }
                 />
             )}
-            {status === 'finished' && backup.error && (
+            {backup.status === 'error' && (
                 <OnboardingStepBox
                     image="BACKUP"
                     heading={<Translation id="TOAST_BACKUP_FAILED" />}

--- a/packages/suite/src/views/settings/general/Language.tsx
+++ b/packages/suite/src/views/settings/general/Language.tsx
@@ -1,7 +1,7 @@
 import React, { useMemo } from 'react';
 
 import { Translation } from '@suite-components';
-import { isTranslationMode } from '@suite-utils/l10n';
+import { isTranslationMode, getOsLocale } from '@suite-utils/l10n';
 import { useActions, useAnalytics, useSelector, useTranslation } from '@suite-hooks';
 import LANGUAGES, { Locale, LocaleInfo } from '@suite-config/languages';
 import * as suiteActions from '@suite-actions/suiteActions';
@@ -9,6 +9,7 @@ import * as languageActions from '@settings-actions/languageActions';
 import { ActionColumn, ActionSelect, SectionItem, TextColumn } from '@suite-components/Settings';
 import { useAnchor } from '@suite-hooks/useAnchor';
 import { SettingsAnchor } from '@suite-constants/anchors';
+import { getPlatformLanguages } from '@suite-utils/env';
 
 const onlyComplete = (locale: [string, LocaleInfo]): locale is [Locale, LocaleInfo] =>
     !!locale[1].complete;
@@ -64,17 +65,21 @@ export const Language = () => {
               };
 
     const onChange = ({ value }: { value: Locale | 'system' }) => {
+        analytics.report({
+            type: 'settings/general/change-language',
+            payload: {
+                platformLanguages: getPlatformLanguages().join(','),
+                previousLanguage: language,
+                previousAutodetectLanguage: autodetectLanguage,
+                language: value === 'system' ? getOsLocale() : value,
+                autodetectLanguage: value === 'system',
+            },
+        });
         if ((value === 'system') !== autodetectLanguage) {
             setAutodetect({ language: !autodetectLanguage });
         }
         if (value !== 'system') {
             setLanguage(value);
-            analytics.report({
-                type: 'settings/general/change-language',
-                payload: {
-                    language: value,
-                },
-            });
         }
     };
 

--- a/packages/suite/src/views/settings/general/Theme.tsx
+++ b/packages/suite/src/views/settings/general/Theme.tsx
@@ -1,11 +1,13 @@
 import React, { useMemo } from 'react';
+
 import { desktopApi, SuiteThemeVariant } from '@trezor/suite-desktop-api';
 import * as suiteActions from '@suite-actions/suiteActions';
 import { Translation } from '@suite-components/Translation';
 import { SectionItem, ActionColumn, ActionSelect, TextColumn } from '@suite-components/Settings';
-import { useActions, useSelector, useTranslation } from '@suite-hooks';
+import { useActions, useSelector, useTranslation, useAnalytics } from '@suite-hooks';
 import { useAnchor } from '@suite-hooks/useAnchor';
 import { SettingsAnchor } from '@suite-constants/anchors';
+import { getOsTheme } from '@suite-utils/env';
 
 const useThemeOptions = () => {
     const { translationString } = useTranslation();
@@ -43,6 +45,7 @@ const useThemeOptions = () => {
 };
 
 export const Theme = () => {
+    const analytics = useAnalytics();
     const { theme, autodetectTheme } = useSelector(state => ({
         theme: state.suite.settings.theme,
         autodetectTheme: state.suite.settings.autodetect.theme,
@@ -58,6 +61,17 @@ export const Theme = () => {
     const selectedValue = getOption(autodetectTheme ? 'system' : theme.variant);
 
     const onChange = ({ value }: { value: SuiteThemeVariant }) => {
+        const platformTheme = getOsTheme();
+        analytics.report({
+            type: 'settings/general/change-theme',
+            payload: {
+                platformTheme,
+                previousTheme: theme.variant,
+                previousAutodetectTheme: autodetectTheme,
+                theme: value === 'system' ? platformTheme : value,
+                autodetectTheme: value === 'system',
+            },
+        });
         if ((value === 'system') !== autodetectTheme) {
             setAutodetect({ theme: !autodetectTheme });
         }


### PR DESCRIPTION
Closes  #5003, #5012, #4955, #5122, #5127

- backup analytics  #5003
- show redux actions in the console in non-codesign builds (good for debugging locally built desktop app)
- desktop update analytics #5012
  - release notes are now fetched in Electron layer which helps to:
    - No flashing of missing changelog text #4955
    - Should fix tor changelog problem #4955
    - Creating another batch of release notes redux actions to get `prerelease` attribute to analytics event
- custom backend analytics #5122
- improved theme and language change tracking #5127