### PR TITLE
fix(blockchain-link): throttle block events

### DIFF
--- a/packages/blockchain-link/src/types/common.ts
+++ b/packages/blockchain-link/src/types/common.ts
@@ -14,6 +14,7 @@ export interface BlockchainSettings {
     timeout?: number;
     pingTimeout?: number;
     keepAlive?: boolean;
+    throttleBlockEvent?: number;
 }
 
 export interface ServerInfo {

--- a/packages/blockchain-link/tests/unit/fixtures/notifications-blockbook.ts
+++ b/packages/blockchain-link/tests/unit/fixtures/notifications-blockbook.ts
@@ -26,13 +26,14 @@ const notifyBlocks = [
                 data: { hash: 'abcd', height: 1 },
             },
         ],
+        notificationsCount: 1,
         result: {
             blockHash: 'abcd',
             blockHeight: 1,
         },
     },
     {
-        description: 'multiple block notifications',
+        description: 'multiple block notifications, no throttle',
         method: 'subscribe',
         notifications: [
             {
@@ -45,9 +46,45 @@ const notifyBlocks = [
                 data: { hash: 'efgh', height: 2 },
             },
         ],
+        notificationsCount: 2,
         result: {
             blockHash: 'efgh',
             blockHeight: 2,
+        },
+    },
+    {
+        description: 'block notifications flood, throttled',
+        method: 'subscribe',
+        notifications: [
+            {
+                id: '0',
+                data: { hash: 'abcd01', height: 1 },
+            },
+            {
+                id: '0',
+                delay: 5,
+                data: { hash: 'efgh02', height: 2 },
+            },
+            {
+                id: '0',
+                delay: 10,
+                data: { hash: 'efgh03', height: 3 },
+            },
+            {
+                id: '0',
+                delay: 15,
+                data: { hash: 'efgh04', height: 4 },
+            },
+            {
+                id: '0',
+                delay: 20,
+                data: { hash: 'efgh05', height: 5 },
+            },
+        ],
+        notificationsCount: 1,
+        result: {
+            blockHash: 'efgh05',
+            blockHeight: 5,
         },
     },
     {
@@ -64,6 +101,7 @@ const notifyBlocks = [
                 data: { hash: 'efgh', height: 2 },
             },
         ],
+        notificationsCount: 0,
         result: undefined,
     },
     {
@@ -75,6 +113,7 @@ const notifyBlocks = [
                 data: { hash: 'abcd', height: 1 },
             },
         ],
+        notificationsCount: 1,
         result: {
             blockHash: 'abcd',
             blockHeight: 1,

--- a/packages/blockchain-link/tests/unit/fixtures/notifications-blockfrost.ts
+++ b/packages/blockchain-link/tests/unit/fixtures/notifications-blockfrost.ts
@@ -26,6 +26,7 @@ const notifyBlocks = [
                 data: { hash: 'abcd', height: 1 },
             },
         ],
+        notificationsCount: 1,
         result: {
             blockHash: 'abcd',
             blockHeight: 1,
@@ -45,6 +46,7 @@ const notifyBlocks = [
                 data: { hash: 'efgh', height: 2 },
             },
         ],
+        notificationsCount: 2,
         result: {
             blockHash: 'efgh',
             blockHeight: 2,
@@ -64,6 +66,7 @@ const notifyBlocks = [
                 data: { hash: 'efgh', height: 2 },
             },
         ],
+        notificationsCount: 0,
         result: undefined,
     },
     {
@@ -75,6 +78,7 @@ const notifyBlocks = [
                 data: { hash: 'abcd', height: 1 },
             },
         ],
+        notificationsCount: 1,
         result: {
             blockHash: 'abcd',
             blockHeight: 1,

--- a/packages/blockchain-link/tests/unit/fixtures/notifications-ripple.ts
+++ b/packages/blockchain-link/tests/unit/fixtures/notifications-ripple.ts
@@ -46,6 +46,7 @@ const notifyBlocks = [
                 ...block,
             },
         ],
+        notificationsCount: 1,
         result: {
             blockHash: 'abcd',
             blockHeight: 1,
@@ -67,6 +68,7 @@ const notifyBlocks = [
                 ...block,
             },
         ],
+        notificationsCount: 2,
         result: {
             blockHash: 'efgh',
             blockHeight: 2,
@@ -88,6 +90,7 @@ const notifyBlocks = [
                 ...block,
             },
         ],
+        notificationsCount: 0,
         result: undefined,
     },
 ] as const;

--- a/packages/blockchain-link/tests/unit/notifications.ts
+++ b/packages/blockchain-link/tests/unit/notifications.ts
@@ -27,6 +27,7 @@ workers.forEach(instance => {
                 ...instance,
                 server: [`ws://localhost:${server.options.port}`],
                 debug: false,
+                throttleBlockEvent: 50,
             });
         };
 
@@ -83,8 +84,13 @@ workers.forEach(instance => {
 
                     await server.sendNotification(f.notifications);
 
+                    // wait for block event throttling
+                    await new Promise(resolve =>
+                        setTimeout(resolve, blockchain.settings.throttleBlockEvent),
+                    );
+
                     if (f.result) {
-                        expect(callback).toHaveBeenCalledTimes(f.notifications.length);
+                        expect(callback).toHaveBeenCalledTimes(f.notificationsCount);
                         expect(callback).toHaveBeenLastCalledWith(f.result);
                     } else {
                         expect(callback).not.toHaveBeenCalled();


### PR DESCRIPTION
There are cases like tab/network suspension or regtest sync where blockchain-link is sending a lot of `block` events in short period of time.

Those events are handled by suite and triggers another chain of events like getAccountInfo, updateFiatRates etc.

It's safe to ignore previous events since suite only cares about the recent one.