### PR TITLE
fix(rollout): Support Node v12

### DIFF
--- a/packages/rollout/src/utils/fetch.ts
+++ b/packages/rollout/src/utils/fetch.ts
@@ -1,4 +1,4 @@
-import * as fs from 'fs/promises';
+import {promises as fs} from 'fs';
 import { fetchFirmware as httpFetch } from './fetch-browser';
 
 // This module should be used only in nodejs environment. see package.json "browser" field.


### PR DESCRIPTION
Fixes #5107.

The latest `trezor-connect@8.2.7-extended` drops support for Node v12,
since Node v12 do not support `import * as fs from 'fs/promises'`.

Instead, you need to use `import {promises as fs} from 'fs';`
(e.g. `const {promises: fs} = require('fs');` in CJS.)

See Node v12 `fs` Promises docs: https://nodejs.org/docs/latest-v12.x/api/fs.html#fs_fs_promises_api

To be honest, Node v12 is pretty old, so it might not be worth supporting it (if so, please document it in the package.json/CHANGELOG!).

If you guys do want to support Node v12, it's just a one line change to get `@trezor/rollup` working again in Node v12, and thus get `trezor-connect@8.2.7-extended` working in Node v12 too.

