### PR TITLE
fix(rollout): Support Node v12

### DIFF
--- a/packages/rollout/src/utils/fetch.ts
+++ b/packages/rollout/src/utils/fetch.ts
@@ -1,4 +1,4 @@
-import * as fs from 'fs/promises';
+import { promises as fs } from 'fs';
 import { fetchFirmware as httpFetch } from './fetch-browser';
 
 // This module should be used only in nodejs environment. see package.json "browser" field.


### PR DESCRIPTION
Orig PR: #5108 
Fixes #5107

Node v10 and Node v12 do not support
`import * as fs from 'fs/promises'`.

Instead, you need to use `import {promises as fs} from 'fs';`
(e.g. `const {promises: fs} = require('fs');` in CJS.

See Node v12 fs Promises docs:
  https://nodejs.org/docs/latest-v12.x/api/fs.html#fs_fs_promises_api