### PR TITLE
fix(suite): endless fetching of txs if txs length is a multiple of 25

### DIFF
--- a/packages/suite/src/views/wallet/transactions/components/TransactionList/index.tsx
+++ b/packages/suite/src/views/wallet/transactions/components/TransactionList/index.tsx
@@ -86,18 +86,15 @@ const TransactionList = ({ transactions, isLoading, account, ...props }: Transac
         setSelectedPage(startPage);
     }, [account.descriptor, account.symbol, startPage]);
 
-    const { size, total } = {
-        size: perPage,
-        total: isSearching
-            ? Math.ceil(searchedTransactions.length / perPage)
-            : account?.page?.total ?? 1,
-    };
+    const total = isSearching
+        ? Math.ceil(searchedTransactions.length / perPage)
+        : account?.page?.total ?? 1;
 
     const onPageSelected = (page: number) => {
         setSelectedPage(page);
 
         if (!isSearching) {
-            fetchTransactions(account, page, size);
+            fetchTransactions(account, page, perPage);
         }
 
         if (ref.current) {


### PR DESCRIPTION
Close #5072

Fixes endless fetching of transactions if a txs length is a multiple of 25. 

It breaks the possibility to export transactions and makes the app slow. 
(Probably a lot of people are exporting transactions now for taxes.)

The problem is that if a user has a specific number of transactions. The condition `transactions.length === (perPage || SETTINGS.TXS_PER_PAGE)` is always true as Blockbook returns the last 25 transactions even if `page` attribute is higher than total number of pages the user has.

![Screenshot 2022-03-14 at 10 17 49](https://user-images.githubusercontent.com/33235762/158146541-615c28cd-d6e1-4355-9c98-8f6a9dda70f0.png)

cc @martinboehm is it a bug or feature of Blockbook?
