### PR TITLE
fix(cardano): allow withdrawals despite failing to fetch stake pools

### DIFF
--- a/packages/suite/src/types/wallet/cardanoStaking.ts
+++ b/packages/suite/src/types/wallet/cardanoStaking.ts
@@ -19,6 +19,20 @@ export type PoolsResponse =
       }
     | undefined;
 
+export type ActionAvailability =
+    | {
+          status: true;
+          reason?: undefined;
+      }
+    | {
+          status: false;
+          reason: 'POOL_ID_FETCH_FAIL' | 'TX_NOT_FINAL' | 'UTXO_BALANCE_INSUFFICIENT';
+      }
+    | {
+          status: false;
+          reason?: string;
+      };
+
 export type CardanoStaking = {
     address: string;
     pendingStakeTx: PendingStakeTx | undefined;
@@ -26,19 +40,8 @@ export type CardanoStaking = {
         status: boolean;
         reason?: 'DEVICE_LOCK' | 'DEVICE_DISCONNECTED';
     };
-    actionAvailable:
-        | {
-              status: true;
-              reason?: undefined;
-          }
-        | {
-              status: false;
-              reason: 'POOL_ID_FETCH_FAIL' | 'TX_NOT_FINAL' | 'UTXO_BALANCE_INSUFFICIENT';
-          }
-        | {
-              status: false;
-              reason?: string;
-          };
+    withdrawingAvailable: ActionAvailability;
+    delegatingAvailable: ActionAvailability;
     loading: boolean;
     fee?: string;
     deposit?: string;

--- a/packages/suite/src/views/wallet/staking/components/Redelegate/index.tsx
+++ b/packages/suite/src/views/wallet/staking/components/Redelegate/index.tsx
@@ -9,7 +9,7 @@ const Redelegate = () => {
         delegate,
         calculateFeeAndDeposit,
         loading,
-        actionAvailable,
+        delegatingAvailable,
         deviceAvailable,
         pendingStakeTx,
         isCurrentPoolOversaturated,
@@ -22,7 +22,7 @@ const Redelegate = () => {
     const actionButton = (
         <Button
             isLoading={loading}
-            isDisabled={!actionAvailable.status || !deviceAvailable.status || !!pendingStakeTx}
+            isDisabled={!delegatingAvailable.status || !deviceAvailable.status || !!pendingStakeTx}
             icon="T2"
             onClick={() => delegate()}
         >
@@ -30,7 +30,7 @@ const Redelegate = () => {
         </Button>
     );
 
-    const reasonMessageId = getReasonForDisabledAction(actionAvailable?.reason);
+    const reasonMessageId = getReasonForDisabledAction(delegatingAvailable?.reason);
 
     return (
         <StyledCard>
@@ -58,7 +58,7 @@ const Redelegate = () => {
                 </Text>
 
                 <Actions>
-                    {deviceAvailable.status && actionAvailable.status ? (
+                    {deviceAvailable.status && delegatingAvailable.status ? (
                         actionButton
                     ) : (
                         <Tooltip

--- a/packages/suite/src/views/wallet/staking/components/Rewards/index.tsx
+++ b/packages/suite/src/views/wallet/staking/components/Rewards/index.tsx
@@ -35,7 +35,7 @@ const Rewards = (props: { account: Account }) => {
         withdraw,
         calculateFeeAndDeposit,
         loading,
-        actionAvailable,
+        withdrawingAvailable,
         deviceAvailable,
         pendingStakeTx,
     } = useCardanoStaking();
@@ -50,7 +50,7 @@ const Rewards = (props: { account: Account }) => {
             isLoading={loading}
             isDisabled={
                 rewards === '0' ||
-                !actionAvailable.status ||
+                !withdrawingAvailable.status ||
                 !deviceAvailable.status ||
                 !!pendingStakeTx
             }
@@ -61,7 +61,7 @@ const Rewards = (props: { account: Account }) => {
         </Button>
     );
 
-    const reasonMessageId = getReasonForDisabledAction(actionAvailable?.reason);
+    const reasonMessageId = getReasonForDisabledAction(withdrawingAvailable?.reason);
 
     return (
         <StyledCard>
@@ -102,7 +102,7 @@ const Rewards = (props: { account: Account }) => {
             )}
 
             <Actions>
-                {deviceAvailable.status && actionAvailable.status ? (
+                {deviceAvailable.status && withdrawingAvailable.status ? (
                     actionButton
                 ) : (
                     <Tooltip

--- a/packages/suite/src/views/wallet/staking/components/Stake/index.tsx
+++ b/packages/suite/src/views/wallet/staking/components/Stake/index.tsx
@@ -33,7 +33,7 @@ const Delegate = (props: { account: Account }) => {
         calculateFeeAndDeposit,
         fee,
         loading,
-        actionAvailable,
+        delegatingAvailable,
         deviceAvailable,
         pendingStakeTx,
     } = useCardanoStaking();
@@ -47,7 +47,7 @@ const Delegate = (props: { account: Account }) => {
         <Button
             isDisabled={
                 account.availableBalance === '0' ||
-                !actionAvailable.status ||
+                !delegatingAvailable.status ||
                 !deviceAvailable.status ||
                 !!pendingStakeTx
             }
@@ -59,7 +59,7 @@ const Delegate = (props: { account: Account }) => {
         </Button>
     );
 
-    const reasonMessageId = getReasonForDisabledAction(actionAvailable?.reason);
+    const reasonMessageId = getReasonForDisabledAction(delegatingAvailable?.reason);
 
     return (
         <StyledCard>
@@ -85,7 +85,7 @@ const Delegate = (props: { account: Account }) => {
                 </Content>
             </Row>
             <Row>
-                {actionAvailable.status && !pendingStakeTx ? (
+                {delegatingAvailable.status && !pendingStakeTx ? (
                     // delegation is allowed
                     <>
                         <Column>
@@ -110,8 +110,8 @@ const Delegate = (props: { account: Account }) => {
                 ) : (
                     // If building a transaction fails we don't have the information about used deposit and fee required
                     <>
-                        {!actionAvailable.status &&
-                            actionAvailable.reason === 'UTXO_BALANCE_INSUFFICIENT' && (
+                        {!delegatingAvailable.status &&
+                            delegatingAvailable.reason === 'UTXO_BALANCE_INSUFFICIENT' && (
                                 <Column>
                                     <InfoBox>
                                         <Translation id="TR_STAKING_NOT_ENOUGH_FUNDS" />
@@ -127,7 +127,7 @@ const Delegate = (props: { account: Account }) => {
                 )}
             </Row>
             <Actions>
-                {deviceAvailable.status && actionAvailable.status ? (
+                {deviceAvailable.status && delegatingAvailable.status ? (
                     actionButton
                 ) : (
                     <Tooltip


### PR DESCRIPTION
In `useCaradanoStaking` hook we fetch list of stake pools to delegate on. If the fetch fails then an error is set and user cannot start delegating (because we don't know the stake pool id we need for the transaction). So far so good.

The problem is that this error is also set when `useCardanoStaking` is used in context of rewards withdrawal. Despite the fact that Information about the staking pool is not necessary for withdrawing, we disable withdrawal button and show the error about failed fetch.

<img width="655" alt="Screenshot 2022-03-14 at 14 08 50" src="https://user-images.githubusercontent.com/6961901/158179089-876bef00-2839-47c2-bdcd-3e21680f5510.png">

This PR splits local state where we store the info about action availability (delegating/withdrawing) to 2 separate local states (`delegatingAvailable` and `withdrawingAvailable`) and updates them accordingly, making withdrawals available even with failed fetch.


