### PR TITLE
fix(test): fix blockchain-link test in the ci

### DIFF
--- a/ci/test.yml
+++ b/ci/test.yml
@@ -177,7 +177,12 @@ transport manual:
     - yarn workspace @trezor/utxo-lib build:lib
     - yarn workspace @trezor/blockchain-link build:lib
     - yarn workspace @trezor/blockchain-link build:workers
-    - docker-compose up
+    - docker-compose pull
+    - docker-compose up -d trezor-user-env-unix electrum-regtest
+    - docker-compose run test-run
+  after_script:
+    - docker-compose down
+    - docker network prune -f
 
 blockchain-link:
   extends: .e2e blockchain-link

--- a/packages/blockchain-link/tests/unit/fixtures/getInfo.ts
+++ b/packages/blockchain-link/tests/unit/fixtures/getInfo.ts
@@ -57,7 +57,7 @@ export default {
                 blockHeight: 1,
                 blockHash: 'test_block_hash-hash',
                 decimals: 6,
-                name: 'Cardano',
+                name: 'Blockfrost',
                 shortcut: 'ada',
                 testnet: false,
                 version: '1.4.0',

--- a/packages/blockchain-link/tests/websocket/fixtures/blockfrost.json
+++ b/packages/blockchain-link/tests/websocket/fixtures/blockfrost.json
@@ -1,7 +1,7 @@
 {
     "GET_SERVER_INFO": {
         "data": {
-            "name": "Cardano",
+            "name": "Blockfrost",
             "shortcut": "ada",
             "decimals": 6,
             "testnet": false,


### PR DESCRIPTION
This pr fixes the blockchain-link test and its functionality when the test fails (it wouldn't quit the containers, and sometimes the job would be ✅  even though the test would fail.) 