### PR TITLE
Fix/ripple transactions list

### DIFF
--- a/packages/suite/src/actions/wallet/selectedAccountActions.ts
+++ b/packages/suite/src/actions/wallet/selectedAccountActions.ts
@@ -231,6 +231,7 @@ export const getStateForAction = (action: Action) => (dispatch: Dispatch, getSta
             'descriptor',
             'availableBalance',
             'misc',
+            'marker',
             'tokens',
             'metadata',
             'addresses',

--- a/packages/suite/src/actions/wallet/transactionActions.ts
+++ b/packages/suite/src/actions/wallet/transactionActions.ts
@@ -175,7 +175,8 @@ export const fetchTransactions =
             // updates the marker/page object for the account
             dispatch(accountActions.update(account, result.payload));
 
-            if (recursive && page < totalPages) {
+            // totalPages (blockbook + blockfrost), marker (ripple) if is undefined, no more pages are available
+            if (recursive && (page < totalPages || (marker && updatedAccount.marker))) {
                 await dispatch(
                     fetchTransactions(updatedAccount, page + 1, perPage, noLoading, true),
                 );


### PR DESCRIPTION
- `selectedAccount` in redux was not updated when `marker` changed which broke pagination
- `marker` describes "order" when fetching transactions. If it is undefined, there is no more transactions available.