### PR TITLE
chore(npm): blockchain-link 2.1.2 rollout 1.3.2

### DIFF
--- a/packages/blockchain-link/CHANGELOG.md
+++ b/packages/blockchain-link/CHANGELOG.md
@@ -1,3 +1,11 @@
+# 2.1.2
+
+#### changes
+
+-   throttling of block events (#5093)
+-   backend selection refactoring (#5047)
+-   set proxyAgent protocol to satisfy sentry wrapper (#5033)
+
 # 2.1.1
 
 #### changes

--- a/packages/rollout/CHANGELOG.md
+++ b/packages/rollout/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 1.3.2
+
+-   fixed to work with node 12
+
 # 1.3.1
 
 -   updated cross-fetch lib to 3.1.5

--- a/packages/rollout/package.json
+++ b/packages/rollout/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@trezor/rollout",
-    "version": "1.3.1",
+    "version": "1.3.2",
     "author": "Trezor <info@trezor.io>",
     "homepage": "https://github.com/trezor/trezor-suite/packages/rollout",
     "keywords": [


### PR DESCRIPTION
anything else we would like to release? 

btw can we release from CI already? how does it work now? bump version and changelog manually and hit the "deploy to npm" job in CI? 