### PR TITLE
chore(webpack): ignore "require in generated wasm module" warning from cardano-serialization-lib

### DIFF
--- a/packages/suite-build/configs/base.webpack.config.ts
+++ b/packages/suite-build/configs/base.webpack.config.ts
@@ -95,6 +95,11 @@ const config: webpack.Configuration = {
     experiments: {
         asyncWebAssembly: true,
     },
+    ignoreWarnings: [
+        {
+            module: /cardano-serialization-lib-browser/, // see the comment above `experiments`
+        },
+    ],
     module: {
         rules: [
             // TypeScript/JavaScript


### PR DESCRIPTION
just remove the warning from terminal so we don't miss any other warnings