### PR TITLE
chore(connect-explorer): gh-action to sync with gh-pages

### DIFF
--- a/.github/workflows/connect_explorer_deploy.yml
+++ b/.github/workflows/connect_explorer_deploy.yml
@@ -1,0 +1,39 @@
+name: connect-explorer deploy
+
+on: [workflow_dispatch]
+
+jobs:
+  crowdin-sync:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+        with:
+          path: trezor-suite
+
+      - name: Checkout gh pages repo
+        uses: actions/checkout@v3
+        with:
+          repository: trezor/connect-explorer
+          path: connect-explorer-ghpages
+
+      - name: Setup node
+        uses: actions/setup-node@v2
+        with:
+          node-version-file: ".nvmrc"
+
+      - name: Build and deploy connect explorer
+        run: |
+          npm install -g yarn && yarn install
+          git config --global user.name "trezor-ci"
+          git config --global user.email "${{ secrets.TREZOR_BOT_EMAIL }}"
+          yarn build:libs
+          TREZOR_CONNECT_SRC=https://connect.trezor.io/8/ yarn workspace @trezor/connect-explorer build
+          cd ../connect-explorer-ghpages
+          git checkout gh-pages
+          cp -r ../trezor-suite/packages/connect-explorer/build/* ./
+          git add .
+          git commit -m "new  build"
+          git push origin gh-pages
+        env:
+          GITHUB_TOKEN: ${{ secrets.TREZOR_BOT_TOKEN }}

--- a/.github/workflows/connect_explorer_deploy.yml
+++ b/.github/workflows/connect_explorer_deploy.yml
@@ -33,7 +33,7 @@ jobs:
           git checkout gh-pages
           cp -r ../trezor-suite/packages/connect-explorer/build/* ./
           git add .
-          git commit -m "new  build"
+          git commit -m "new build"
           git push origin gh-pages
         env:
           GITHUB_TOKEN: ${{ secrets.TREZOR_BOT_TOKEN }}


### PR DESCRIPTION
trezor-connect has on its index https://connect.trezor.io/8/ link to connect-explorer hosted on github pages. https://trezor.github.io/connect-explorer/#/ but this connect-explorer build is fairly outdated. We would like to update connect explorer hosted in github-pages it with a new build with every pipeline on develop branch.

could you please have a look @vdovhanych if this is doable when you have few spare moments? 