### PR TITLE
fix(ci): fix yamllint after tenv update

### DIFF
--- a/ci/validation.yml
+++ b/ci/validation.yml
@@ -29,10 +29,9 @@ unit tests:
 
 yaml lint:
   stage: validation
-  image: registry.gitlab.com/satoshilabs/trezor/trezor-user-env/trezor-user-env
+  image: registry.gitlab.com/pipeline-components/yamllint:latest
   script:
-    - nix-shell --run "yamllint --version"
-    - nix-shell --run "yamllint . && echo 'Success!'"
+    - yamllint . && echo "Success!"
 
 msg-system config validation:
   stage: validation


### PR DESCRIPTION
fixes lint after tenv update to a new image. Unfortunately, it broke nix-shell linting and I changed it to default GitLab one. If we wish we can also change this to some js tool later.