### PR TITLE
feat(ci): switch to using the new tenv image from ghcr.io

### DIFF
--- a/docker/docker-compose.blockchain-link-ci.yml
+++ b/docker/docker-compose.blockchain-link-ci.yml
@@ -1,7 +1,7 @@
 version: '3'
 services:
   trezor-user-env-unix:
-    image: registry.gitlab.com/satoshilabs/trezor/trezor-user-env/trezor-user-env
+    image: ghcr.io/trezor/trezor-user-env
     environment:
       - SDL_VIDEODRIVER=dummy
       - XDG_RUNTIME_DIR=/var/tmp

--- a/docker/docker-compose.connect-explorer-ci.yml
+++ b/docker/docker-compose.connect-explorer-ci.yml
@@ -1,7 +1,7 @@
 version: '2'
 services:
   trezor-user-env-unix:
-    image: registry.gitlab.com/satoshilabs/trezor/trezor-user-env/trezor-user-env
+    image: ghcr.io/trezor/trezor-user-env
     environment:
       - SDL_VIDEODRIVER=dummy
       - XDG_RUNTIME_DIR=/var/tmp

--- a/docker/docker-compose.connect-explorer-test.yml
+++ b/docker/docker-compose.connect-explorer-test.yml
@@ -1,7 +1,7 @@
 version: '2'
 services:
   trezor-user-env-unix:
-    image: registry.gitlab.com/satoshilabs/trezor/trezor-user-env/trezor-user-env
+    image: ghcr.io/trezor/trezor-user-env
     environment:
       - DISPLAY=$DISPLAY
       - QT_X11_NO_MITSHM=1

--- a/docker/docker-compose.suite-ci.yml
+++ b/docker/docker-compose.suite-ci.yml
@@ -1,7 +1,7 @@
 version: "3"
 services:
   trezor-user-env-unix:
-    image: registry.gitlab.com/satoshilabs/trezor/trezor-user-env/trezor-user-env
+    image: ghcr.io/trezor/trezor-user-env
     environment:
       - SDL_VIDEODRIVER=dummy
       - XDG_RUNTIME_DIR=/var/tmp
@@ -30,5 +30,5 @@ services:
     volumes:
       - ../:/trezor-suite
   bitcoin-regtest:
-    image: registry.gitlab.com/satoshilabs/trezor/trezor-user-env/trezor-user-env-regtest # this is a special image that runs regtest and blockbook
+    image: ghcr.io/trezor/trezor-user-env-regtest # this is a special image that runs regtest and blockbook
     network_mode: service:trezor-user-env-unix

--- a/docker/docker-compose.suite-desktop-ci.yml
+++ b/docker/docker-compose.suite-desktop-ci.yml
@@ -1,7 +1,7 @@
 version: "3"
 services:
   trezor-user-env-unix:
-    image: registry.gitlab.com/satoshilabs/trezor/trezor-user-env/trezor-user-env
+    image: ghcr.io/trezor/trezor-user-env
     environment:
       - SDL_VIDEODRIVER=dummy
       - XDG_RUNTIME_DIR=/var/tmp

--- a/docker/docker-compose.suite-desktop-test.yml
+++ b/docker/docker-compose.suite-desktop-test.yml
@@ -1,7 +1,7 @@
 version: "3"
 services:
   trezor-user-env-unix:
-    image: registry.gitlab.com/satoshilabs/trezor/trezor-user-env/trezor-user-env
+    image: ghcr.io/trezor/trezor-user-env
     environment:
       - DISPLAY=$DISPLAY
     volumes:

--- a/docker/docker-compose.suite-dev.yml
+++ b/docker/docker-compose.suite-dev.yml
@@ -4,7 +4,7 @@
 version: "2"
 services:
   trezor-user-env-unix:
-    image: registry.gitlab.com/satoshilabs/trezor/trezor-user-env/trezor-user-env
+    image: ghcr.io/trezor/trezor-user-env
     environment:
       - DISPLAY=$DISPLAY
       - QT_X11_NO_MITSHM=1

--- a/docker/docker-compose.suite-test.yml
+++ b/docker/docker-compose.suite-test.yml
@@ -1,7 +1,7 @@
 version: "2"
 services:
   trezor-user-env-unix:
-    image: registry.gitlab.com/satoshilabs/trezor/trezor-user-env/trezor-user-env
+    image: ghcr.io/trezor/trezor-user-env
     environment:
       - DISPLAY=$DISPLAY
       - QT_X11_NO_MITSHM=1
@@ -42,5 +42,5 @@ services:
       - ../:/e2e
       - /tmp/.X11-unix:/tmp/.X11-unix:rw
   bitcoin-regtest:
-    image: registry.gitlab.com/satoshilabs/trezor/trezor-user-env/trezor-user-env-regtest # this is a special image that runs regtest and blockbook
+    image: ghcr.io/trezor/trezor-user-env-regtest # this is a special image that runs regtest and blockbook
     network_mode: service:trezor-user-env-unix

--- a/docker/docker-compose.transport-test.yml
+++ b/docker/docker-compose.transport-test.yml
@@ -1,7 +1,7 @@
 version: "3"
 services:
   trezor-user-env-unix:
-    image: registry.gitlab.com/satoshilabs/trezor/trezor-user-env/trezor-user-env
+    image: ghcr.io/trezor/trezor-user-env
     environment:
       - SDL_VIDEODRIVER=dummy
       - XDG_RUNTIME_DIR=/var/tmp


### PR DESCRIPTION
changes the tenv image to a new version built and hosted on GitHub.