### PR TITLE
Test review transaction modal

### DIFF
--- a/ci/test.yml
+++ b/ci/test.yml
@@ -46,6 +46,9 @@
       - trezor-user-env-debugging.log
       - tenv-emulator-bridge-debugging.log
       - trezor-user-env-version.txt
+
+.suite web base:
+  extends: .e2e web
   parallel:
     matrix:
       - TEST_GROUP: ['@group:suite', '@group:onboarding', '@group:device-management', '@group:settings', '@group:metadata']
@@ -53,11 +56,31 @@
       - TEST_GROUP: '@group:wallet'
         CONTAINERS: 'trezor-user-env-unix bitcoin-regtest'
 
-suite web:
+# fragile group is dependent on external powers which means it might fail when some external resource
+# is modified. We still believe it might be worth having to fix such broken test time to time.
+.suite web fragile base:
   extends: .e2e web
+  allow_failure: true # most importantly - when a test in this category fails, it does not make entire pipeline fail
+  parallel:
+    matrix:
+      - TEST_GROUP: '@group:fragile'
+        CONTAINERS: 'trezor-user-env-unix'
+
+suite web:
+  extends: .suite web base
 
 suite web snapshots:
-  extends: .e2e web
+  extends: .suite web base
+  when: manual
+  variables:
+    CYPRESS_SNAPSHOT: 1
+    CYPRESS_updateSnapshots: 1
+
+suite web fragile:
+  extends: .suite web fragile base
+
+suite web fragile snapshots:
+  extends: .suite web fragile base
   when: manual
   variables:
     CYPRESS_SNAPSHOT: 1
@@ -65,14 +88,14 @@ suite web snapshots:
 
 # Tests against latest trezor-firmware master
 suite web 2-master:
-  extends: .e2e web
+  extends: .suite web base
   only:
     <<: *run_everything_rules
   variables:
     FIRMWARE: 2-master
 
 suite web 2-master manual:
-  extends: .e2e web
+  extends: .suite web base
   except:
     <<: *run_everything_rules
   when: manual

--- a/packages/components/src/components/prompts/ConfirmOnDevice/index.tsx
+++ b/packages/components/src/components/prompts/ConfirmOnDevice/index.tsx
@@ -132,19 +132,25 @@ const ConfirmOnDevice = ({
     animated,
     animation = 'SLIDE_UP',
 }: Props) => (
-    <Wrapper animated={animated} animation={animation}>
+    <Wrapper animated={animated} animation={animation} data-test="@prompts/confirm-on-device">
         <Left>
             <DeviceImage height="34px" trezorModel={trezorModel} />
         </Left>
         <Middle>
             <Title>{title}</Title>
             {successText && typeof steps === 'number' && activeStep && activeStep > steps ? (
-                <Success>{successText}</Success>
+                <Success data-test="@prompts/confirm-on-device/success">{successText}</Success>
             ) : undefined}
             {typeof steps === 'number' && activeStep && activeStep <= steps ? (
                 <Steps>
                     {Array.from(Array(steps).keys()).map((s, i) => (
-                        <Step key={s} isActive={isStepActive(i, activeStep)} />
+                        <Step
+                            key={s}
+                            isActive={isStepActive(i, activeStep)}
+                            data-test={`@prompts/confirm-on-device/step/${i}${
+                                isStepActive(i, activeStep) ? '/active' : ''
+                            }`}
+                        />
                     ))}
                 </Steps>
             ) : undefined}

--- a/packages/integration-tests/projects/suite-web/run_tests.js
+++ b/packages/integration-tests/projects/suite-web/run_tests.js
@@ -49,13 +49,6 @@ const getTestFiles = () => {
         .filter(f => f.includes('.test.'));
 };
 
-const wait = timeout =>
-    new Promise(resolve => {
-        setTimeout(() => {
-            resolve();
-        }, timeout);
-    });
-
 const runTests = async () => {
     const {
         BROWSER = 'chrome',

--- a/packages/integration-tests/projects/suite-web/snapshots/wallet/review-transaction.test.ts/tada-confirm-address.snap.png
+++ b/packages/integration-tests/projects/suite-web/snapshots/wallet/review-transaction.test.ts/tada-confirm-address.snap.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:26f0d8bd33f70269ecf372d866f82022b8ea0256286e1ddf7ee74c0adffb197d
+size 31363

--- a/packages/integration-tests/projects/suite-web/snapshots/wallet/review-transaction.test.ts/test-confirm-address.snap.png
+++ b/packages/integration-tests/projects/suite-web/snapshots/wallet/review-transaction.test.ts/test-confirm-address.snap.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:f6f2cdac495252661c670e775bc639e18fdbb15e3cdd6007edf0a5c7807d3033
+size 31921

--- a/packages/integration-tests/projects/suite-web/snapshots/wallet/review-transaction.test.ts/trop-confirm-address.snap.png
+++ b/packages/integration-tests/projects/suite-web/snapshots/wallet/review-transaction.test.ts/trop-confirm-address.snap.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:353595e4f45a0e1c3bc364633bdab7b2b570ba3fd4e01669197a919654c8bd74
+size 29287

--- a/packages/integration-tests/projects/suite-web/tests/wallet/review-transaction.test.ts
+++ b/packages/integration-tests/projects/suite-web/tests/wallet/review-transaction.test.ts
@@ -1,0 +1,110 @@
+// @group:fragile
+// @retry=2
+
+describe('Review transaction modal', () => {
+    beforeEach(() => {
+        cy.task('startEmu', { wipe: true });
+
+        cy.task('setupEmu', {
+            mnemonic:
+                'volcano budget pact suit embody rocket rescue congress orient appear gadget multiply',
+        });
+        cy.task('startBridge');
+
+        cy.viewport(1080, 1440).resetDb();
+        cy.prefixedVisit('/');
+        cy.passThroughInitialRun();
+    });
+
+    const fixtures = [
+        {
+            network: 'test',
+            address: 'tb1qajr3a3y5uz27lkxrmn7ck8lp22dgytvagr5nqy',
+            amount: '0.00001',
+            fee: '1',
+            confirmationSteps: [
+                {
+                    element: '@prompts/confirm-on-device/step/0/active',
+                    screenshot: true,
+                },
+            ],
+        },
+        {
+            network: 'trop',
+            address: '0x7de62F23453E9230cC038390901A9A0130105A3c',
+            token: 'KOMBUCHA',
+            fee: '1',
+            amount: '1',
+            confirmationSteps: [
+                {
+                    element: '@prompts/confirm-on-device/step/0/active',
+                    screenshot: true,
+                },
+            ],
+        },
+        {
+            network: 'tada',
+            address:
+                'addr_test1qp4jwf78hftza48x8ajc74ygn47lr0w0hfmsnvzx66sehssj922xhxkn6twlq2wn4q50q352annk3903tj00h45mgfmssfrxrt',
+            token: 'FINANCEBINARIES',
+            fee: '44',
+            amount: '1',
+            confirmationSteps: [
+                {
+                    element: '@prompts/confirm-on-device',
+                    screenshot: true,
+                },
+            ],
+        },
+    ];
+
+    fixtures.forEach(f => {
+        it(`${f.network}: Review transaction modal`, () => {
+            cy.discoveryShouldFinish(); // todo: this should't be needed here
+
+            // go to coin settings and enable cardano
+            cy.getTestElement('@suite/menu/settings').click();
+            cy.getTestElement('@settings/menu/wallet').click();
+            cy.getTestElement(`@settings/wallet/network/btc`).click(); // turn off btc
+
+            cy.getTestElement(`@settings/wallet/network/${f.network}`).click();
+
+            // go to account #1
+            cy.getTestElement('@suite/menu/suite-index').click();
+            cy.getTestElement('@suite/menu/wallet-index').click();
+            cy.getTestElement(`@account-menu/${f.network}/normal/0`).click();
+            cy.discoveryShouldFinish();
+
+            // go to send form and fill it with data
+            cy.getTestElement('@wallet/menu/wallet-send').click();
+
+            if (f.token) {
+                // todo: ethereum only
+                cy.getTestElement('@amount-select/input').click({ force: true });
+                cy.getTestElement('@amount-select/input').type(`${f.token}{enter}`);
+            }
+
+            cy.getTestElement('outputs[0].address').type(f.address);
+            cy.getTestElement('outputs[0].amount').type(f.amount);
+            cy.getTestElement('select-bar/custom').click();
+            cy.getTestElement('feePerUnit').clear().type(f.fee);
+
+            // submit form
+            cy.getTestElement('@send/review-button').click();
+            f.confirmationSteps.forEach(step => {
+                cy.getTestElement(step.element);
+                if (step.screenshot) {
+                    cy.getTestElement('@modal').matchImageSnapshot(`${f.network}-confirm-address`);
+                }
+            });
+
+            // todo: it seems like pressYes can't confirm signing transaction on device?
+            // cy.task('pressYes');
+            // cy.getTestElement('@prompts/confirm-on-device/step/1/active');
+            // cy.getTestElement('@modal').matchImageSnapshot(`${f.network}-confirm-amount`);
+            // cy.task('pressYes');
+            // cy.getTestElement('@prompts/confirm-on-device/success');
+            // cy.getTestElement('@modal').matchImageSnapshot(`${f.network}-confirmed`);
+        });
+    });
+});

--- a/packages/suite/src/views/wallet/send/components/Outputs/components/Amount/components/TokenSelect/index.tsx
+++ b/packages/suite/src/views/wallet/send/components/Outputs/components/Amount/components/TokenSelect/index.tsx
@@ -172,6 +172,7 @@ const TokenSelect = ({ output, outputId }: Props) => {
                         // compose (could be prevented because of Amount error from re-validation above)
                         composeTransaction(amountInputName);
                     }}
+                    data-test="@amount-select"
                 />
             )}
         />


### PR DESCRIPTION
- splits e2e tests into 2 parts. 1. "devs" part where tests should be maximally stable, future proof, indempotent. This however puts certain limitations on what can be tested, so we are experimenting with having another group "qa", that does not need to follow these rules so strictly. Test under this group should be mantained mostly by qa team and since we are expecting that they may fail time to time all jobs running qa tests should have allow_failure: true
- this PR adds the first test for this group - visual regression testing of review transaction modals.

Latest screenshots overview https://track-suite.herokuapp.com/#/test-review-transaction-modal/c1e779fc57276930416ab45a496f52e08fdfa2cd