### PR TITLE
fix: disconnecting from blockfrost backend after 50s

### DIFF
--- a/packages/suite/src/actions/wallet/blockchainActions.ts
+++ b/packages/suite/src/actions/wallet/blockchainActions.ts
@@ -203,8 +203,23 @@ export const init = () => async (dispatch: Dispatch, getState: GetState) => {
 export const subscribe =
     (symbol: Network['symbol'], fiatRates = false) =>
     async (_: Dispatch, getState: GetState) => {
+        const network = getNetwork(symbol);
         // fiat rates should be subscribed only once, after onConnect event
-        if (fiatRates) {
+        if (fiatRates && network?.networkType !== 'cardano') {
+            // Note:
+            // Because Blockfrost worker for cardano doesn't provide fiat rates,
+            // calling blockchainSubscribeFiatRates will return res.success set to false.
+            // That will cause skipping account subscription (because of return statement) which is called few lines below.
+            // That is not expected as the original idea was to catch problem with subscribing and prevent
+            // another call when we already know that something is not working (it used to cause spawning multiple websocket connections).
+
+            // Skipping account subscription has a problem (besides that you actually don't subscribe to all addresses),
+            // due to lack of subscriptions for the network, blockchain-link will close the connection
+            // after 50s thinking it is not needed anymore. https://github.com/trezor/trezor-suite/blob/6253be3f9f657a9a14f21941c76ae1db36e2193c/packages/blockchain-link/src/workers/blockfrost/websocket.ts#L104
+            // However if you do full discovery then everything seems to be normal. It is because
+            // subscribe func will be called, without fiatRates param, every time new account is added (from walletMiddleware), but if you have the device remembered
+            // subscribe function is called only once, after bl connects to a backend, with param fiatRates set to true,
+            // thus it will not subscribe the accounts addresses.
             const { success } = await TrezorConnect.blockchainSubscribeFiatRates({ coin: symbol });
             // if first subscription fails, do not run the second one
             if (!success) return;


### PR DESCRIPTION
👋  Suite keeps disconnecting from blockfrost backends after 50s. More detailed explanation is in the code comment. tl;dr is that connection is closed from blockchain-link due to skipped subscription of account addresses after unsuccessful attempt to subscribe fiat rates (that blockfrost worker doesn't provide).

It can be fixed by not exiting subscribe function if the reason of unsuccessful response is missing feature rather than some kind of error and this PR fixes this in simplest way possible.