### PR TITLE
chore: update npm ignore

### DIFF
--- a/packages/blockchain-link/.npmignore
+++ b/packages/blockchain-link/.npmignore
@@ -1,2 +1,3 @@
 # OSX
 .DS_Store
+libDev

--- a/packages/rollout/.npmignore
+++ b/packages/rollout/.npmignore
@@ -41,3 +41,4 @@ package-lock.json
 logs
 *.log
 .yarnclean
+libDev

--- a/packages/transport/.npmignore
+++ b/packages/transport/.npmignore
@@ -40,3 +40,4 @@ jest.config*
 
 # Other
 scripts
+libDev


### PR DESCRIPTION
just noticed that we might be accidentally publishing libDev content. Luckily I always use `--dry-run` before publishing :]

![image](https://user-images.githubusercontent.com/30367552/159530100-da75de64-f242-4971-bde0-2acfc41e78b7.png)

there are two possible solutions:
- A] .npmignore
- B] package.json `files` field

So I am not sure if it makes sense to update .npmignore even if we are using B] approach for @trezor/blockchain-link and @trezor/transport and only not defining files field for @trezor/rollout which is going to be removed (I believe) during the upcoming trezor-connect transfer to monorepo. 