### PR TITLE
chore: prettier eslint as warning

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -114,7 +114,7 @@ module.exports = {
         '@typescript-eslint/explicit-member-accessibility': 'off',
         '@typescript-eslint/no-explicit-any': 'off',
         'react/destructuring-assignment': 'off',
-        'prettier/prettier': 'off',
+        'prettier/prettier': 'warn',
         'func-names': 'off',
         'react/require-default-props': 'off',
         '@typescript-eslint/no-non-null-assertion': 'off',

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -4,5 +4,27 @@
     },
     "editor.defaultFormatter": "esbenp.prettier-vscode",
     "typescript.reportStyleChecksAsWarnings": false,
-    "cSpell.words": ["blockbook", "webworkers"]
+    "cSpell.words": ["blockbook", "webworkers"],
+    "editor.formatOnSave": true,
+    "[html]": {
+        "editor.defaultFormatter": "esbenp.prettier-vscode"
+    },
+    "[javascript]": {
+        "editor.defaultFormatter": "esbenp.prettier-vscode"
+    },
+    "[typescript]": {
+        "editor.defaultFormatter": "esbenp.prettier-vscode"
+    },
+    "[typescriptreact]": {
+        "editor.defaultFormatter": "esbenp.prettier-vscode"
+    },
+    "[markdown]": {
+        "editor.defaultFormatter": "esbenp.prettier-vscode"
+    },
+    "[yaml]": {
+        "editor.defaultFormatter": "esbenp.prettier-vscode"
+    },
+    "[json]": {
+        "editor.defaultFormatter": "esbenp.prettier-vscode"
+    }
 }


### PR DESCRIPTION
Some people had problem with their setup with only prettier. This will bring back `prettier-eslint` as warning so it should help.

Also some vscode settings changes was made to ensure that all supported files are formatted with prettier.

Warning: If you are not going to use prettier extension for vscode and rely just to eslint, keep in mind that eslint doesn't care about other files than JS/TS files, but in suite repo all compatible files (md, yaml, html, json...) must be formatted using prettier so don't forget to run `yarn format` if you change any non-JS file. @matejkriz 