### PR TITLE
chore: update root readme

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -4,5 +4,6 @@
     },
     "editor.defaultFormatter": "esbenp.prettier-vscode",
     "editor.formatOnSave": true,
-    "typescript.reportStyleChecksAsWarnings": false
+    "typescript.reportStyleChecksAsWarnings": false,
+    "cSpell.words": ["blockbook", "webworkers"]
 }

--- a/README.md
+++ b/README.md
@@ -4,15 +4,31 @@
 
 ## Packages
 
-| Name              | Packages                                                                                                                                                                                          |
-| ----------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| suite             | [core](./packages/suite), [web](./packages/suite-web), [desktop](./packages/suite-desktop), [native](./packages/suite-native), [data](./packages/suite-data), [storage](./packages/suite-storage) |
-| components        | [components](./packages/components), [storybook native](./packages/components-storybook-native)                                                                                                   |
-| rollout           | [rollout](./packages/rollout)                                                                                                                                                                     |
-| blockchain-link   | [blockchain-link](./packages/blockchain-link)                                                                                                                                                     |
-| integration-tests | [integration-tests](./packages/integration-tests)                                                                                                                                                 |
+| package                                                   | description                                 |
+| --------------------------------------------------------- | ------------------------------------------- |
+| [@trezor/blockchain-link](./packages/blockchain-link)     | lib for connecting to blockchains           |
+| [@trezor/components](./packages/components)               | frontend react components                   |
+| [@trezor/connect-common](./packages/connect-common)       | static files and commons for trezor-connect |
+| [@trezor/connect-explorer](./packages/connect-explorer)   | interactive demo for trezor-connect         |
+| [@trezor/connect-iframe](./packages/connect-iframe)       | connect-iframe build from monorepo          |
+| [@trezor/integration-tests](./packages/integration-tests) | cross-packages e2e tests                    |
+| [@trezor/news-api](./packages/news-api)                   | medium proxy providing allow-origin headers |
+| [@trezor/rollout](./packages/rollout)                     | firmware updated utilities                  |
+| [@trezor/suite-build](./packages/suite-build)             | build utilities                             |
+| [@trezor/suite-data](./packages/suite-data)               | suite static data                           |
+| [@trezor/suite-desktop-api](./packages/suite-desktop-api) | API for suite - suite-desktop communication |
+| [@trezor/suite-desktop](./packages/suite-desktop)         | suite build target for Mac, Win, Linux      |
+| [@trezor/suite-native](./packages/suite-native)           | suite build target for react-native         |
+| [@trezor/suite-storage](./packages/suite-storage)         | abstract database definition for suite      |
+| [@trezor/suite-web-landing](./packages/suite-web-landing) | https://suite.trezor.io/                    |
+| [@trezor/suite-web](./packages/suite-web)                 | suite build target for web                  |
+| [@trezor/suite](./packages/suite)                         | trezor suite common code                    |
+| [@trezor/transport-native](./packages/transport-native)   | communication lib for react-native          |
+| [@trezor/transport](./packages/transport)                 | communication lib for javascript            |
+| [@trezor/utils](./packages/utils)                         | shared utility functions                    |
+| [@trezor/utxo-lib](./packages/utxo-lib)                   | btc-like coins lib                          |
 
-## Development
+## @trezor/suite development
 
 Before you start make sure you have downloaded and installed [NVM](https://github.com/nvm-sh/nvm), [Yarn](https://yarnpkg.com/lang/en/docs/install/) and git with [git lfs](https://git-lfs.github.com/).
 
@@ -30,6 +46,10 @@ Run a dev build:
 -   `yarn suite:dev:desktop` (electron app)
 -   `yarn suite:dev:android` (react-native Android)
 -   `yarn suite:dev:ios` (react-native iOS)
+
+## trezor-connect development
+
+Trezor Connect is a platform for easy integration of Trezor into 3rd party services. At the moment, trezor-connect has its [own repository](https://github.com/trezor/connect) but we expect it to be migrated into the trezor-suite monorepo in a very short time.
 
 ## Contribute
 

--- a/packages/blockchain-link/README.md
+++ b/packages/blockchain-link/README.md
@@ -1,5 +1,7 @@
 # @trezor/blockchain-link
 
+[![NPM](https://img.shields.io/npm/v/@trezor/blockchain-link.svg)](https://www.npmjs.org/package/@trezor/blockchain-link)
+
 blockchain-link is a client and unified interface for several backends (_BE_ further on) of various blockchain networks. Currently, there are implementations for
 
 -   [blockbook](https://github.com/trezor/blockbook): BE developed and deployed by SatoshiLabs. Provides access to Bitcoin(like) and Ethereum(like) networks.
@@ -53,7 +55,7 @@ Run UI with webworkers support
 yarn workspace @trezor/blockchain-link dev
 ```
 
-or without webworkes support (workers are compiled into a bundle)
+or without webworkers support (workers are compiled into a bundle)
 
 ```shell
 yarn workspace @trezor/blockchain-link dev:module

--- a/packages/components/README.md
+++ b/packages/components/README.md
@@ -1,5 +1,3 @@
 # @trezor/components
 
-[![npm version](https://badge.fury.io/js/trezor-ui-components.svg)](https://badge.fury.io/js/trezor-ui-components)
-
-This repository contains UI components that are intended to be used accross related Trezor frontend projects.
+This repository contains UI components that are intended to be used across related Trezor frontend projects.

--- a/packages/integration-tests/README.md
+++ b/packages/integration-tests/README.md
@@ -1,4 +1,4 @@
-# Integration tests
+# @trezor/integration-tests
 
 This package contains Suite web end-to-end tests and components library tests.
 
@@ -7,9 +7,3 @@ This package contains Suite web end-to-end tests and components library tests.
 Suite uses [Cypress](https://docs.cypress.io/guides/overview/why-cypress.html) to run e2e tests. It also uses [trezor-user-env](https://github.com/trezor/trezor-user-env) which is [daily built](https://gitlab.com/satoshilabs/trezor/trezor-user-env/-/pipelines) into a docker image providing all the necessary instrumentation required to run tests (bridge and emulators).
 
 See how to run them [here](../../docs/tests/e2e-web.md).
-
-## Components library + storybook v2
-
-`docker build -t tests-components-storybook -f packages/integration-tests/projects/components-storybook/Dockerfile .`
-
-`docker run -it -v $PWD:/tests/packages/integration-tests/projects/components-storybook -e CYPRESS_baseUrl='https://suite.corp.sldev.cz/components-storybook/develop' tests-components-storybook`

--- a/packages/news-api/README.md
+++ b/packages/news-api/README.md
@@ -1,0 +1,1 @@
+# @trezor/news-api

--- a/packages/suite-build/README.md
+++ b/packages/suite-build/README.md
@@ -1,3 +1,3 @@
-# Suite Build
+# @trezor/suite-build
 
 Build configuration and helpers for `suite-web` and `suite-desktop` front-ends.

--- a/packages/suite-data/README.md
+++ b/packages/suite-data/README.md
@@ -1,0 +1,3 @@
+# @trezor/suite-data
+
+Collection of static assets for `@trezor/suite/*` packages.

--- a/packages/suite-storage/README.md
+++ b/packages/suite-storage/README.md
@@ -1,0 +1,1 @@
+# @trezor/suite-storage

--- a/packages/suite-web-landing/README.md
+++ b/packages/suite-web-landing/README.md
@@ -1,0 +1,3 @@
+# @trezor/suite-web-landing
+
+https://suite.trezor.io

--- a/packages/suite-web/README.md
+++ b/packages/suite-web/README.md
@@ -1,15 +1,3 @@
 # @trezor/suite-web
 
 Build target for web environment.
-
-## Tests
-
-Notes on testing strategies [here](./test/README.md)
-
-## How to sync into staging
-
-`ASSET_PREFIX=/suite yarn workspace @trezor/suite-web build`
-
-and
-
-`./scripts/s3sync.sh stage beta`

--- a/packages/suite/README.md
+++ b/packages/suite/README.md
@@ -1,5 +1,3 @@
-## @trezor/suite
-
-Web + next.js + redux
+# @trezor/suite
 
 [Documentation](./docs/README.md)

--- a/packages/transport/README.md
+++ b/packages/transport/README.md
@@ -1,5 +1,7 @@
 # @trezor/transport
 
+[![NPM](https://img.shields.io/npm/v/@trezor/transport.svg)](https://www.npmjs.org/package/@trezor/transport)
+
 Library for low-level communication with Trezor.
 
 Intended as a "building block" for other packages - it is used in ~~trezor.js~~ (deprecated) and trezor-connect.

--- a/packages/utils/README.md
+++ b/packages/utils/README.md
@@ -1,4 +1,6 @@
-# Trezor utils library (@trezor/utils)
+# @trezor/utils
+
+[![NPM](https://img.shields.io/npm/v/@trezor/utils.svg)](https://www.npmjs.org/package/@trezor/utils)
 
 A collection of typescript utils that are intended to be used across trezor-suite monorepo.
 

--- a/packages/utxo-lib/README.md
+++ b/packages/utxo-lib/README.md
@@ -1,4 +1,4 @@
-# Trezor UTXO library (@trezor/utxo-lib)
+# @trezor/utxo-lib
 
 [![NPM](https://img.shields.io/npm/v/@trezor/utxo-lib.svg)](https://www.npmjs.org/package/@trezor/utxo-lib)
 


### PR DESCRIPTION
Along with the ongoing effort of migrating trezor-connect into trezor-suite repository, we desperately need to improve documentation, as we are going to see many more 3rd party devs lurking around this repository. 

At the moment, I would like to satisfiy @Nodonisko note here https://github.com/trezor/trezor-suite/pull/5156#discussion_r832615240 but before that we need to fix all the outdated parts.

I have just started with updating pacakges description in the root README.md. Definitely you can suggest more! 

also cc to @sime 