### PR TITLE
feat(cardano): show withdrawal and deposit amounts in txs history

### DIFF
--- a/packages/suite/src/components/suite/modals/TransactionDetail/components/AmountDetails/index.tsx
+++ b/packages/suite/src/components/suite/modals/TransactionDetail/components/AmountDetails/index.tsx
@@ -203,6 +203,63 @@ const AmountDetails = ({ tx, isTestnet }: Props) => {
                         color="light"
                     />
                 )}
+                {tx.cardanoSpecific?.withdrawal && (
+                    <AmountRow
+                        firstColumn={<Translation id="TR_TX_WITHDRAWAL" />}
+                        secondColumn={
+                            <FormattedCryptoAmount
+                                value={tx.cardanoSpecific.withdrawal}
+                                symbol={tx.symbol}
+                            />
+                        }
+                        thirdColumn={
+                            showHistoricalRates && (
+                                <FiatValue
+                                    amount={tx.cardanoSpecific.withdrawal}
+                                    symbol={tx.symbol}
+                                    source={tx.rates}
+                                    useCustomSource
+                                />
+                            )
+                        }
+                        fourthColumn={
+                            showFiat && (
+                                <FiatValue
+                                    amount={tx.cardanoSpecific.withdrawal}
+                                    symbol={tx.symbol}
+                                />
+                            )
+                        }
+                        color="light"
+                    />
+                )}
+                {tx.cardanoSpecific?.deposit && (
+                    <AmountRow
+                        firstColumn={<Translation id="TR_TX_DEPOSIT" />}
+                        secondColumn={
+                            <FormattedCryptoAmount
+                                value={tx.cardanoSpecific.deposit}
+                                symbol={tx.symbol}
+                            />
+                        }
+                        thirdColumn={
+                            showHistoricalRates && (
+                                <FiatValue
+                                    amount={tx.cardanoSpecific.deposit}
+                                    symbol={tx.symbol}
+                                    source={tx.rates}
+                                    useCustomSource
+                                />
+                            )
+                        }
+                        fourthColumn={
+                            showFiat && (
+                                <FiatValue amount={tx.cardanoSpecific.deposit} symbol={tx.symbol} />
+                            )
+                        }
+                        color="light"
+                    />
+                )}
                 {tx.tokens.map((t, i) => (
                     <AmountRow
                         // eslint-disable-next-line react/no-array-index-key

--- a/packages/suite/src/components/wallet/TransactionItem/components/Target/index.tsx
+++ b/packages/suite/src/components/wallet/TransactionItem/components/Target/index.tsx
@@ -13,6 +13,7 @@ import TargetAddressLabel from '../TargetAddressLabel';
 import BaseTargetLayout from '../BaseTargetLayout';
 import { copyToClipboard } from '@suite-utils/dom';
 import { AccountMetadata } from '@suite-types/metadata';
+import { ExtendedMessageDescriptor } from '@suite-types';
 
 const StyledHiddenPlaceholder = styled(props => <HiddenPlaceholder {...props} />)`
     /* padding: 8px 0px; row padding */
@@ -144,6 +145,45 @@ export const Target = ({
     );
 };
 
+export const CustomRow = ({
+    transaction,
+    title,
+    amount,
+    sign,
+    useFiatValues,
+    ...baseLayoutProps
+}: {
+    amount: string;
+    sign: 'pos' | 'neg';
+    title: ExtendedMessageDescriptor['id'];
+    transaction: WalletAccountTransaction;
+    useFiatValues?: boolean;
+    isFirst?: boolean;
+    isLast?: boolean;
+    className?: string;
+}) => (
+    <BaseTargetLayout
+        {...baseLayoutProps}
+        addressLabel={<Translation id={title} />}
+        amount={
+            <StyledHiddenPlaceholder>
+                <Sign value={sign} />
+                {amount} {transaction.symbol}
+            </StyledHiddenPlaceholder>
+        }
+        fiatAmount={
+            useFiatValues ? (
+                <FiatValue
+                    amount={amount}
+                    symbol={transaction.symbol}
+                    source={transaction.rates}
+                    useCustomSource
+                />
+            ) : undefined
+        }
+    />
+);
+
 export const FeeRow = ({
     transaction,
     useFiatValues,
@@ -155,24 +195,54 @@ export const FeeRow = ({
     isLast?: boolean;
     className?: string;
 }) => (
-    <BaseTargetLayout
+    <CustomRow
         {...baseLayoutProps}
-        addressLabel={<Translation id="FEE" />}
-        amount={
-            <StyledHiddenPlaceholder>
-                <Sign value="neg" />
-                {transaction.fee} {transaction.symbol}
-            </StyledHiddenPlaceholder>
-        }
-        fiatAmount={
-            useFiatValues ? (
-                <FiatValue
-                    amount={transaction.fee}
-                    symbol={transaction.symbol}
-                    source={transaction.rates}
-                    useCustomSource
-                />
-            ) : undefined
-        }
+        title="FEE"
+        sign="neg"
+        amount={transaction.fee}
+        transaction={transaction}
+        useFiatValues={useFiatValues}
+    />
+);
+
+export const WithdrawalRow = ({
+    transaction,
+    useFiatValues,
+    ...baseLayoutProps
+}: {
+    transaction: WalletAccountTransaction;
+    useFiatValues?: boolean;
+    isFirst?: boolean;
+    isLast?: boolean;
+    className?: string;
+}) => (
+    <CustomRow
+        {...baseLayoutProps}
+        title="TR_TX_WITHDRAWAL"
+        sign="pos"
+        amount={transaction.cardanoSpecific?.withdrawal ?? '0'}
+        transaction={transaction}
+        useFiatValues={useFiatValues}
+    />
+);
+
+export const DepositRow = ({
+    transaction,
+    useFiatValues,
+    ...baseLayoutProps
+}: {
+    transaction: WalletAccountTransaction;
+    useFiatValues?: boolean;
+    isFirst?: boolean;
+    isLast?: boolean;
+    className?: string;
+}) => (
+    <CustomRow
+        {...baseLayoutProps}
+        title="TR_TX_DEPOSIT"
+        sign="neg"
+        amount={transaction.cardanoSpecific?.deposit ?? '0'}
+        transaction={transaction}
+        useFiatValues={useFiatValues}
     />
 );

--- a/packages/suite/src/components/wallet/TransactionItem/index.tsx
+++ b/packages/suite/src/components/wallet/TransactionItem/index.tsx
@@ -13,7 +13,7 @@ import { WalletAccountTransaction } from '@wallet-types';
 import TransactionTypeIcon from './components/TransactionTypeIcon';
 import TransactionHeading from './components/TransactionHeading';
 import { MIN_ROW_HEIGHT } from './components/BaseTargetLayout';
-import { Target, TokenTransfer, FeeRow } from './components/Target';
+import { Target, TokenTransfer, FeeRow, WithdrawalRow, DepositRow } from './components/Target';
 import TransactionTimestamp from './components/TransactionTimestamp';
 import { useAnchor } from '@suite-hooks/useAnchor';
 import { AccountTransactionBaseAnchor } from '@suite-constants/anchors';
@@ -176,7 +176,10 @@ const TransactionItem = React.memo(
         const isUnknown = isTxUnknown(transaction);
         const useFiatValues = !isTestnet(transaction.symbol);
         const useSingleRowLayout =
-            !isUnknown && (targets.length + tokens.length === 1 || transaction.type === 'self');
+            !isUnknown &&
+            (targets.length + tokens.length === 1 || transaction.type === 'self') &&
+            transaction.cardanoSpecific?.subtype !== 'withdrawal' &&
+            transaction.cardanoSpecific?.subtype !== 'stake_registration';
 
         const showFeeRow = !isUnknown && type !== 'recv' && transaction.fee !== '0';
 
@@ -341,6 +344,24 @@ const TransactionItem = React.memo(
                                         </AnimatePresence>
                                     </>
                                 ) : null}
+
+                                {transaction.cardanoSpecific?.withdrawal && (
+                                    <WithdrawalRow
+                                        transaction={transaction}
+                                        useFiatValues={useFiatValues}
+                                        isFirst
+                                        isLast
+                                    />
+                                )}
+
+                                {transaction.cardanoSpecific?.deposit && (
+                                    <DepositRow
+                                        transaction={transaction}
+                                        useFiatValues={useFiatValues}
+                                        isFirst
+                                        isLast
+                                    />
+                                )}
 
                                 {showFeeRow && (
                                     <StyledFeeRow

--- a/packages/suite/src/support/messages.ts
+++ b/packages/suite/src/support/messages.ts
@@ -6303,6 +6303,16 @@ export default defineMessages({
         id: 'TR_STAKING_WITHDRAW',
         defaultMessage: 'Withdraw',
     },
+    TR_TX_WITHDRAWAL: {
+        id: 'TR_TX_WITHDRAWAL',
+        defaultMessage: 'Withdrawal',
+        description: 'Label for withdrawal amount in transaction detail',
+    },
+    TR_TX_DEPOSIT: {
+        id: 'TR_TX_DEPOSIT',
+        defaultMessage: 'Deposit',
+        description: 'Label for a deposit amount in transaction detail',
+    },
     TR_STAKING_DEPOSIT: {
         id: 'TR_STAKING_DEPOSIT',
         defaultMessage: 'Refundable Deposit',
@@ -6405,11 +6415,11 @@ export default defineMessages({
     },
     TR_STAKE_REGISTERED: {
         id: 'TR_STAKE_REGISTERED',
-        defaultMessage: 'Registration of a stake address',
+        defaultMessage: 'Stake address registration',
     },
     TR_STAKE_DEREGISTERED: {
         id: 'TR_STAKE_DEREGISTERED',
-        defaultMessage: 'Deregistration of a stake address',
+        defaultMessage: 'Stake address deregistration',
     },
     TR_ERROR_CARDANO_DELEGATE: {
         id: 'TR_ERROR_CARDANO_DELEGATE',

--- a/patches/trezor-connect+8.2.8-beta.3.patch
+++ b/patches/trezor-connect+8.2.8-beta.3.patch
@@ -1,0 +1,13 @@
+diff --git a/node_modules/trezor-connect/lib/typescript/account.d.ts b/node_modules/trezor-connect/lib/typescript/account.d.ts
+index 16c8728..1704f0e 100644
+--- a/node_modules/trezor-connect/lib/typescript/account.d.ts
++++ b/node_modules/trezor-connect/lib/typescript/account.d.ts
+@@ -110,6 +110,8 @@ export interface AccountTransaction {
+             | 'stake_registration'
+             | 'stake_deregistration'
+             | null;
++        withdrawal?: string;
++        deposit?: string;
+     };
+     details: {
+         vin: VinVout[];


### PR DESCRIPTION
- added withdrawal and deposit amount to txs history and tx details modal that were missing and could confuse users once they start doing their first withdrawals since it is not clear how much they earned (or how much they spent while doing their first stake delegation).
- fixed non cardano-related bug with daily sums of transactions subtracting fee twice for sent-to-self transactions
- small changes to copy (not shown on screenshots) https://github.com/trezor/trezor-suite/pull/5180/files#diff-988baecac61429698981f7b86b979d1627f33f484918f65402c4b345b5c57cbaR6418. `Registration of stake address` reworded to `Stake address registration`, it sounds a bit better to us. Is this okay with you @alex-jerechinsky? I am okay dropping this if it would cause too much hassle changing it now since I noticed that translation of these messages to other languages is already done.

To function properly it needs new blockchain-link build due to calculating and passing withdrawal and deposit amounts as part of `tx.cardanoSpecific` object.


<img width="800" alt="Screenshot 2022-03-24 at 13 34 33" src="https://user-images.githubusercontent.com/6961901/159922239-1b2961b4-440b-42a0-8668-0b86cdef77a5.png">
<img width="768" alt="Screenshot 2022-03-24 at 13 34 40" src="https://user-images.githubusercontent.com/6961901/159922270-2135ea74-eac7-4a99-b433-56a37f93eab6.png">
<img width="796" alt="Screenshot 2022-03-24 at 13 34 54" src="https://user-images.githubusercontent.com/6961901/159922287-0a838131-113d-4919-9f8e-a11bc8192c13.png">
<img width="794" alt="Screenshot 2022-03-24 at 13 34 07" src="https://user-images.githubusercontent.com/6961901/159922306-a4f46bc5-d34d-411b-9a57-21c5e4dc4529.png">

