### PR TITLE
fix: workaround for menu overflow caused by new staking tab

### DIFF
--- a/packages/suite/src/components/suite/AppNavigation/index.tsx
+++ b/packages/suite/src/components/suite/AppNavigation/index.tsx
@@ -241,6 +241,18 @@ const AppNavigation = ({ items, primaryContent, maxWidth, inView }: Props) => {
         }
     }, [wrapper, primary, secondary, screenWidth]);
 
+    // Move staking tab from primary location to secondary if condensed dropdown menu is visible.
+    // It is ugly, byt it will save precious space and prevent menu overflow on smaller screens
+    const stakingIndex = items.findIndex(i => i.id === 'wallet-staking' && !i.isHidden);
+    const itemsToHideToDropdown = items[stakingIndex];
+    if (itemsToHideToDropdown) {
+        if (condensedSecondaryMenuVisible) {
+            itemsToHideToDropdown.position = 'secondary';
+        } else {
+            itemsToHideToDropdown.position = 'primary';
+        }
+    }
+
     const visibleItems = items.filter(item => !item.isHidden);
 
     const itemsPrimary = visibleItems.filter(item => item.position === 'primary');


### PR DESCRIPTION
resolves https://github.com/trezor/trezor-suite/issues/5167

moves staking tab from primary menu items to secondary on smaller screens.
<img width="500" alt="Screenshot 2022-03-24 at 15 51 41" src="https://user-images.githubusercontent.com/6961901/159944678-dab50418-b71e-45ee-81d3-b1c4e53d0f70.png">

