### PR TITLE
fix: add default url regtest blockbook

### DIFF
--- a/packages/integration-tests/projects/suite-web/support/utils/shortcuts.ts
+++ b/packages/integration-tests/projects/suite-web/support/utils/shortcuts.ts
@@ -101,11 +101,6 @@ export const enableRegtestAndGetCoins = ({ payments = [] }) => {
 
     cy.getTestElement('@settings/wallet/network/regtest').click({ force: true });
 
-    cy.getTestElement('@settings/wallet/network/regtest/advance').click();
-
-    cy.getTestElement('@settings/advance/url').type('http://localhost:19121');
-    cy.getTestElement('@settings/advance/button/save').click({ force: true });
-
     // send 1 regtest bitcoin to first address in the derivation path
     payments.forEach(payment => {
         cy.task('sendToAddressAndMineBlock', {

--- a/packages/suite/src/reducers/wallet/settingsReducer.ts
+++ b/packages/suite/src/reducers/wallet/settingsReducer.ts
@@ -32,7 +32,12 @@ export const initialState: State = {
     discreetMode: false,
     enabledNetworks: ['btc'],
     lastUsedFeeLevel: {},
-    backends: {},
+    backends: {
+        regtest: {
+            type: 'blockbook',
+            urls: ['http://localhost:19121'],
+        },
+    },
 };
 
 const settingsReducer = (state: State = initialState, action: Action): State =>


### PR DESCRIPTION
Adding default blockbook URL to regtest coin.
* I added that default configuration to settingsReduces initial state as @szymonlesisz  suggested, let me know if you had something else in mind.
* I removed the part of the integration test that  was adding that that URL since now it is not necessary anymore.