### PR TITLE
test(e2e): connect-explorer manual

### DIFF
--- a/ci/build.yml
+++ b/ci/build.yml
@@ -119,7 +119,7 @@ suite-web-landing build stable:
     expire_in: 1 days
 
 .build_nix: &build_nix
-  script:  # override build script to use nix-shell instead
+  script: # override build script to use nix-shell instead
     - . /nix/var/nix/profiles/default/etc/profile.d/nix-daemon.sh || true # loads nix-shell
     - nix-shell --option system x86_64-darwin --run "git lfs pull"
     - nix-shell --option system x86_64-darwin --run "yarn install --frozen-lockfile --cache-folder .yarn-nix --prefer-offline"
@@ -296,7 +296,7 @@ suite-desktop build windows codesign:
 #     paths:
 #       - app-release.apk
 
-connect-explorer build:
+.connect-explorer build base:
   stage: build
   script:
     - yarn install --frozen-lockfile --cache-folder .yarn --prefer-offline
@@ -306,3 +306,14 @@ connect-explorer build:
     expire_in: 7 days
     paths:
       - packages/connect-explorer/build
+
+connect-explorer build:
+  extends: .connect-explorer build base
+  only:
+    <<: *run_everything_rules
+
+connect-explorer build manual:
+  extends: .connect-explorer build base
+  except:
+    <<: *run_everything_rules
+  when: manual

--- a/ci/deploy.yml
+++ b/ci/deploy.yml
@@ -86,12 +86,10 @@ msg-system deploy dev:
     - aws s3 cp packages/suite-data/files/message-system/config.v1.jws s3://data.trezor.io/config/develop/config.v1.jws
     - aws cloudfront create-invalidation --distribution-id ${AWS_CLOUDFRONT_ID} --paths '/config/develop/*'
 
-connect-explorer deploy dev:
+.connect-explorer deploy dev base:
   stage: deploy to dev
   variables:
     DEPLOY_DIRECTORY: ${DEPLOY_BASE_DIR}/connect-explorer/${CI_BUILD_REF_NAME}
-  needs:
-    - connect-explorer build
   environment:
     name: ${CI_BUILD_REF_NAME}
     url: $BASE_REVIEW_URL/${CI_BUILD_REF_NAME}
@@ -101,6 +99,21 @@ connect-explorer deploy dev:
     - rsync --delete -va packages/connect-explorer/build/ "${DEPLOY_DIRECTORY}/"
   tags:
     - deploy
+
+connect-explorer deploy dev:
+  extends: .connect-explorer deploy dev base
+  needs:
+    - connect-explorer build
+  only:
+    <<: *run_everything_rules
+
+connect-explorer deploy dev manual:
+  extends: .connect-explorer deploy dev base
+  needs:
+    - connect-explorer build manual
+  except:
+    <<: *run_everything_rules
+  when: manual
 
 # npm packages deploy to npm registry
 .npm_deploy_rules: &npm_deploy_rules


### PR DESCRIPTION
I would like NOT to run conect-explorer build and deploy for casual branches. We don't really need it, running it for develop branch is perfectly enough. 