### PR TITLE
chore(suite-data): update tor binaries to 0.4.6.9

### DIFF
--- a/packages/suite-data/files/bin/tor/linux-arm64/libcrypto.so.1.1
+++ b/packages/suite-data/files/bin/tor/linux-arm64/libcrypto.so.1.1
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:e87858ccb421eae02132e856aa799595ad2bb5bb01464c9a9a687515c38ec866
-size 2703072

--- a/packages/suite-data/files/bin/tor/linux-arm64/libevent-2.1.so.6
+++ b/packages/suite-data/files/bin/tor/linux-arm64/libevent-2.1.so.6
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:4e928e650f18fa9cf82591381bc6b40ba5ed0c8daea7f90a295339cbc18b7e1c
-size 309520

--- a/packages/suite-data/files/bin/tor/linux-arm64/libssl.so.1.1
+++ b/packages/suite-data/files/bin/tor/linux-arm64/libssl.so.1.1
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:3748a68c721dbdaa63888a1dee58bf7801ff3559b051116e1c0c9b0ca3ace907
-size 564864

--- a/packages/suite-data/files/bin/tor/linux-arm64/tor
+++ b/packages/suite-data/files/bin/tor/linux-arm64/tor
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:facd547a0aa15682f8ac9aae6dd757b446e33bc380f6a331f6d7aa6ff837cac5
-size 3026152
+oid sha256:edec49e615017fb588ea2592e6fae6f56878f03d6846510e8f31617240fb0001
+size 20528808

--- a/packages/suite-data/files/bin/tor/linux-arm64/torrc
+++ b/packages/suite-data/files/bin/tor/linux-arm64/torrc
@@ -1,4 +1,4 @@
 AvoidDiskWrites 1
 Log notice stdout
 CookieAuthentication 1
-# DormantCanceledByStartup 1
+DormantCanceledByStartup 1

--- a/packages/suite-data/files/bin/tor/linux-x64/libcrypto.so.1.1
+++ b/packages/suite-data/files/bin/tor/linux-x64/libcrypto.so.1.1
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:76484afbab0ab633a21c54755b878d70bf18efddfa47b95e3fee4149a9fab517
-size 3142432

--- a/packages/suite-data/files/bin/tor/linux-x64/libevent-2.1.so.7
+++ b/packages/suite-data/files/bin/tor/linux-x64/libevent-2.1.so.7
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:680c0c3d41c93758db2c024ba70d20519757e7289f44c3fb090dfed0d3ea198a
-size 354616

--- a/packages/suite-data/files/bin/tor/linux-x64/libssl.so.1.1
+++ b/packages/suite-data/files/bin/tor/linux-x64/libssl.so.1.1
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:ddc03547ffcb738f63ffeab06e78af4b78f8bf8602b4b19e66fdb0af5820ea6e
-size 605952

--- a/packages/suite-data/files/bin/tor/linux-x64/tor
+++ b/packages/suite-data/files/bin/tor/linux-x64/tor
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:16414f39a837e46d10898d6d238c6e75fa5ff5d1892ff55321cdc2972a7452bb
-size 3417624
+oid sha256:ee2f76903ea8f090af8f567bee14dde83873ed45bea8cff51c6c225d572f39c3
+size 21374416

--- a/packages/suite-data/files/bin/tor/mac-arm64/tor
+++ b/packages/suite-data/files/bin/tor/mac-arm64/tor
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:66b6c7daa15821ca4b0a23db3e28b4ceab479331354f9bad80d3923ca75886f8
-size 6425616
+oid sha256:8fc22b690da0ef2ba93d1c0a18d4f9dca96c93d1312f253462659d215ae82a91
+size 6377968

--- a/packages/suite-data/files/bin/tor/mac-x64/libevent-2.1.7.dylib
+++ b/packages/suite-data/files/bin/tor/mac-x64/libevent-2.1.7.dylib
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:09de2ccc5384f686c9bd7d6582965fe0c8c975d5284aabb1dc5cf4d6230a8e66
-size 390432

--- a/packages/suite-data/files/bin/tor/mac-x64/tor
+++ b/packages/suite-data/files/bin/tor/mac-x64/tor
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:1e8ae287c2227b54bf7d71b688f901689dc4e2526943a86e1dc59cacf04e08e8
-size 6010496
+oid sha256:a6714abdd2f78c88641411cd27bfa565d4aabe95f650fbc2ec7cc488d2087cf5
+size 6845808

--- a/packages/suite-data/files/bin/tor/update.sh
+++ b/packages/suite-data/files/bin/tor/update.sh
@@ -1,0 +1,29 @@
+#!/usr/bin/env bash
+set -e
+
+CRX_VER=1_0_24
+TOR_VER=0.4.6.9
+
+curl https://tor.bravesoftware.com/release/biahpgbdmdkfgndcmfiipgcebobojjkp/extension_${CRX_VER}.crx -o brave-tor-lin.crx
+curl https://tor.bravesoftware.com/release/cldoidikboihgcjfkhdeidbpclkineef/extension_${CRX_VER}.crx -o brave-tor-mac.crx
+curl https://tor.bravesoftware.com/release/cpoalefficncklhjfpglfiplenlpccdb/extension_${CRX_VER}.crx -o brave-tor-win.crx
+
+for p in lin mac win ; do
+    7z x -y -o_${p}/ brave-tor-${p}.crx
+done
+
+mv _lin/tor-${TOR_VER}-linux-brave-0 linux-x64/tor
+# linux-arm64/tor needs to be built manually using the build_linux.sh script
+# from https://github.com/brave/tor_build_scripts and running on aarch64/arm64 machine
+rm -rf _lin/
+
+lipo _mac/tor-${TOR_VER}-darwin-brave-0 -thin arm64 -output mac-arm64/tor
+lipo _mac/tor-${TOR_VER}-darwin-brave-0 -thin x86_64 -output mac-x64/tor
+rm -rf _mac/
+
+mv _win/tor-${TOR_VER}-win32-brave-0 win-x64/tor.exe
+rm -rf _win/
+
+chmod +x linux-x64/tor mac-arm64/tor mac-x64/tor
+
+rm -rf brave-tor-*.crx

--- a/packages/suite-data/files/bin/tor/win-x64/libcrypto-1_1-x64.dll
+++ b/packages/suite-data/files/bin/tor/win-x64/libcrypto-1_1-x64.dll
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:f183f00e7994595ea28a7735ff2ebf4b6dda95f0c4768d0a5825f419725ed1cc
-size 3909212

--- a/packages/suite-data/files/bin/tor/win-x64/libevent-2-1-7.dll
+++ b/packages/suite-data/files/bin/tor/win-x64/libevent-2-1-7.dll
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:26018bebbf68ae64ca76eadf2985656a8209ebbf17f466916c4f9e1fbdb01494
-size 1231089

--- a/packages/suite-data/files/bin/tor/win-x64/libevent_core-2-1-7.dll
+++ b/packages/suite-data/files/bin/tor/win-x64/libevent_core-2-1-7.dll
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:33f8b69cb772f40799343d471812ca6fd0ce6ed58fd4532ee1c61ee7b348903d
-size 1058565

--- a/packages/suite-data/files/bin/tor/win-x64/libevent_extra-2-1-7.dll
+++ b/packages/suite-data/files/bin/tor/win-x64/libevent_extra-2-1-7.dll
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:90fc72ab89dc6bec2001141206779035c121e8b7538007352680e46631bad677
-size 721554

--- a/packages/suite-data/files/bin/tor/win-x64/libgcc_s_seh-1.dll
+++ b/packages/suite-data/files/bin/tor/win-x64/libgcc_s_seh-1.dll
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:2583c47a10cdb916071992db289b05feaf463ec0b43c2039d0e5b7ee64f9ed49
-size 1151146

--- a/packages/suite-data/files/bin/tor/win-x64/libssl-1_1-x64.dll
+++ b/packages/suite-data/files/bin/tor/win-x64/libssl-1_1-x64.dll
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:42c71964f19922298e06b02ed4208ddb7e704490f890ad315ece9ed976a220b8
-size 1113311

--- a/packages/suite-data/files/bin/tor/win-x64/libssp-0.dll
+++ b/packages/suite-data/files/bin/tor/win-x64/libssp-0.dll
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:6fe06ee21d2b588f879cc8c2e5e2cd8087d5ef8d5ec8ed124077b63dd0721f3d
-size 267850

--- a/packages/suite-data/files/bin/tor/win-x64/libwinpthread-1.dll
+++ b/packages/suite-data/files/bin/tor/win-x64/libwinpthread-1.dll
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:b22bb7378321110fa38ed8e52be577405d8be6a279563d7bc9c99c5c9c3af8e2
-size 600055

--- a/packages/suite-data/files/bin/tor/win-x64/tor.exe
+++ b/packages/suite-data/files/bin/tor/win-x64/tor.exe
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:ce7a09deb47c2ccfbc6e80b54db9e397be8452448aff90db90877346402ef446
-size 4562944
+oid sha256:41e5408b3ff314988c859dca7c03d62d6d378f75841f6a7f0a2b37564a872dcf
+size 19533520

--- a/packages/suite-data/files/bin/tor/win-x64/zlib1.dll
+++ b/packages/suite-data/files/bin/tor/win-x64/zlib1.dll
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:2b72593b8ce94c046dc862c690aa9af7bd89bee72fce0aa1ea196f491a71ad36
-size 130560


### PR DESCRIPTION
- fixes https://github.com/trezor/trezor-suite/issues/5184
- add script to update binaries
- use static Tor builds (extracted from Brave extensions), so no dynamic libraries are needed
- linux-arm64/tor needs to be built manually using the build_linux.sh script from https://github.com/brave/tor_build_scripts and running on aarch64/arm64 machine

Please test whether the binaries work on all supported systems:
- [ ] linux-arm64 (i.e. Raspberry Pi 3/4)
- [x] linux-x64
- [x] mac-arm64
- [x] mac-x64
- [x] win-x64
