### PR TITLE
Fix/coins

### DIFF
--- a/packages/suite/src/components/suite/Coin/index.tsx
+++ b/packages/suite/src/components/suite/Coin/index.tsx
@@ -6,7 +6,10 @@ import { Translation } from '@suite-components';
 import type { ExtendedMessageDescriptor } from '@suite-types';
 import type { Network } from '@wallet-types';
 
-const SettingsWrapper = styled.div<{ onClick: ((e: React.MouseEvent) => void) | undefined }>`
+const SettingsWrapper = styled.div<{
+    toggled: boolean;
+    onClick: ((e: React.MouseEvent) => void) | undefined;
+}>`
     display: flex;
     align-self: stretch;
     align-items: center;
@@ -26,6 +29,12 @@ const SettingsWrapper = styled.div<{ onClick: ((e: React.MouseEvent) => void) | 
                     props.theme.HOVER_PRIMER_COLOR,
                 )};
             }
+        `}
+
+    ${props =>
+        !props.toggled &&
+        css`
+            pointer-events: none;
         `}
 `;
 
@@ -192,6 +201,7 @@ const Coin = ({
             )}
             <SettingsWrapper
                 onClick={onSettingsClick}
+                toggled={toggled}
                 data-test={`@settings/wallet/network/${symbol}/advance`}
             >
                 <Icon icon="SETTINGS" />

--- a/packages/suite/src/components/suite/Coin/index.tsx
+++ b/packages/suite/src/components/suite/Coin/index.tsx
@@ -36,6 +36,10 @@ const SettingsWrapper = styled.div<{
         css`
             pointer-events: none;
         `}
+
+    @media (hover: none) {
+        pointer-events: none;
+    }
 `;
 
 const ImageWrapper = styled.div`

--- a/packages/suite/src/components/suite/CoinsGroup/CoinsList.tsx
+++ b/packages/suite/src/components/suite/CoinsGroup/CoinsList.tsx
@@ -67,7 +67,9 @@ const CoinsList = ({
                 // When in bootloader mode we cannot check version of firmware so we do not know if coin is available.
                 // In order to achieve consistency between devices we do not use it when in bootloader mode.
                 const disabled =
-                    (!!unavailable && !isBootloaderMode) || locked || !supportedBySuite;
+                    (!settingsMode && !!unavailable && !isBootloaderMode) ||
+                    locked ||
+                    !supportedBySuite;
                 const unavailabilityTooltip =
                     !!unavailable &&
                     !isBootloaderMode &&

--- a/packages/suite/src/components/suite/NavigationBar/components/NavigationActions/index.tsx
+++ b/packages/suite/src/components/suite/NavigationBar/components/NavigationActions/index.tsx
@@ -54,14 +54,17 @@ const NavigationActions: React.FC<NavigationActionsProps> = ({
     isMobileLayout,
 }) => {
     const analytics = useAnalytics();
-    const { activeApp, notifications, discreetMode, tor, allowPrerelease } = useSelector(state => ({
-        activeApp: state.router.app,
-        notifications: state.notifications,
-        discreetMode: state.wallet.settings.discreetMode,
-        tor: state.suite.tor,
-        theme: state.suite.settings.theme,
-        allowPrerelease: state.desktopUpdate.allowPrerelease,
-    }));
+    const { activeApp, notifications, discreetMode, tor, allowPrerelease, enabledNetworks } =
+        useSelector(state => ({
+            activeApp: state.router.app,
+            notifications: state.notifications,
+            discreetMode: state.wallet.settings.discreetMode,
+            tor: state.suite.tor,
+            theme: state.suite.settings.theme,
+            allowPrerelease: state.desktopUpdate.allowPrerelease,
+            enabledNetworks: state.wallet.settings.enabledNetworks,
+        }));
+
     const { goto, setDiscreetMode, toggleTor } = useActions({
         goto: routerActions.goto,
         setDiscreetMode: walletSettingsActions.setDiscreetMode,
@@ -99,7 +102,9 @@ const NavigationActions: React.FC<NavigationActionsProps> = ({
 
     const unseenNotifications = useMemo(() => notifications.some(n => !n.seen), [notifications]);
 
-    const customBackends = useCustomBackends();
+    const customBackends = useCustomBackends().filter(backend =>
+        enabledNetworks.includes(backend.coin),
+    );
 
     return (
         <WrapperComponent>

--- a/packages/suite/src/hooks/settings/backends/useCustomBackends.ts
+++ b/packages/suite/src/hooks/settings/backends/useCustomBackends.ts
@@ -3,7 +3,10 @@ import type { Network } from '@wallet-types';
 import type { BackendSettings } from '@wallet-reducers/settingsReducer';
 
 export const useCustomBackends = (): BackendSettings[] => {
-    const backends = useSelector(state => state.wallet.settings.backends);
+    const { backends } = useSelector(state => ({
+        backends: state.wallet.settings.backends,
+    }));
+
     return (
         Object.entries(backends) as Array<
             [Network['symbol'], NonNullable<typeof backends[Network['symbol']]>]


### PR DESCRIPTION
closes #5001, #4992

**additional issue**
- user is on mobile
- user has custom backend set for coin available only for TT
- user is now on T1
   - user can now edit/delete custom backend 
   
**another issue**
- on touch device if you click on the right side of the active coin "badge" it will open the settings instead of deactivating the coin