### PR TITLE
chore: enable useful TS options

### DIFF
--- a/packages/connect-explorer/src/js/components/Response.tsx
+++ b/packages/connect-explorer/src/js/components/Response.tsx
@@ -188,7 +188,6 @@ const Response: React.FC<Props> = props => {
                                 {json}
                             </Container>
                         );
-                        break;
                     }
 
                     case 'code':
@@ -198,7 +197,6 @@ const Response: React.FC<Props> = props => {
                                 {props.code}
                             </CodeContainer>
                         );
-                        break;
 
                     case 'docs':
                         return (
@@ -211,7 +209,6 @@ const Response: React.FC<Props> = props => {
                                 ;
                             </div>
                         );
-                        break;
 
                     // case 'tests':
                     //     currentTab = <div className="tests-container">TODO</div>;

--- a/packages/suite-data/src/guide/parser.ts
+++ b/packages/suite-data/src/guide/parser.ts
@@ -73,7 +73,7 @@ export class Parser {
         try {
             return doc
                 .toString()
-                .match(/^# (.+$)/m)![1]
+                .match(/^# (.+$)/m)![1]!
                 .replace(/[\\]/g, '')
                 .trim();
         } catch (e) {

--- a/packages/suite-desktop-api/src/validation.ts
+++ b/packages/suite-desktop-api/src/validation.ts
@@ -14,7 +14,7 @@ export const isPrimitive = (type: OptionalPrimitive, value: any) => {
 export const isObject = (shape: { [key: string]: OptionalPrimitive }, value: any) => {
     if (value == null || typeof value !== 'object') return false;
     const keys = Object.keys(shape).map(key => {
-        const type = shape[key];
+        const type = shape[key]!;
         return isPrimitive(type, value[key]);
     });
     return !keys.includes(false);

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -2,6 +2,7 @@
     "compilerOptions": {
         "allowJs": true,
         "allowSyntheticDefaultImports": true,
+        "allowUnreachableCode": false,
         "baseUrl": ".",
         "jsx": "preserve",
         "module": "esnext",
@@ -12,8 +13,10 @@
         "skipLibCheck": true,
         "sourceMap": true,
         "strict": true,
+        "strictNullChecks": true,
         "target": "esnext",
         "noErrorTruncation": true,
+        "noFallthroughCasesInSwitch": true,
         "useUnknownInCatchVariables": false,
         "resolveJsonModule": true,
         "forceConsistentCasingInFileNames": true,


### PR DESCRIPTION
Enabled few TS options, it's obvious what they are doing from their name and they are quite useful. 

`strictNullChecks` was already enabled because it's on by default when `strict: true`, but it's better have it explicit defined.