### PR TITLE
feat(autoupdate): enable to set custom autoupdate provider by URL for easier testing

### DIFF
--- a/docs/packages/suite-desktop.md
+++ b/docs/packages/suite-desktop.md
@@ -66,6 +66,7 @@ Available flags:
 | `--log-path=PATHNAME` | Path for the output file (defaults to home or current working directory)                                                                                                               |
 | `--enable-updater`    | Enables the auto updater (if disabled in feature flags)                                                                                                                                |
 | `--disable-updater`   | Disables the auto updater (if enabled in feature flags)                                                                                                                                |
+| `--updater-url=URL`   | Set custom URL for auto-updater (default is github)                                                                                                                                    |
 
 ## Mock
 

--- a/packages/suite-desktop/src-electron/modules/auto-updater.ts
+++ b/packages/suite-desktop/src-electron/modules/auto-updater.ts
@@ -23,6 +23,7 @@ import { getReleaseNotes } from '@suite/services/github';
 const enableUpdater = app.commandLine.hasSwitch('enable-updater');
 const disableUpdater = app.commandLine.hasSwitch('disable-updater');
 const preReleaseFlag = app.commandLine.hasSwitch('pre-release');
+const feedURL = app.commandLine.getSwitchValue('updater-url');
 
 const init: Module = ({ mainWindow, store }) => {
     const { logger } = global;
@@ -84,6 +85,10 @@ const init: Module = ({ mainWindow, store }) => {
     mainWindow.webContents.send('update/allow-prerelease', autoUpdater.allowPrerelease);
 
     autoUpdater.logger = null;
+
+    if (feedURL) {
+        autoUpdater.setFeedURL(feedURL);
+    }
 
     const quitAndInstall = () => {
         setImmediate(() => {


### PR DESCRIPTION
fixes https://github.com/trezor/trezor-suite/issues/5214
https://www.electron.build/auto-update.html#appupdatersetfeedurloptions

Enable to change the URL where autoupdate is looking for updates, so we could easily test auto-updating from the release candidate to a next version without interfering with Early Access Program. 

@vdovhanych will prepare CI job for deployment those testing releases from `codesign` on our servers