### PR TITLE
Feat/blockchain syncing

### DIFF
--- a/packages/components/src/utils/colors.ts
+++ b/packages/components/src/utils/colors.ts
@@ -1,4 +1,4 @@
-import { InputState, SuiteThemeColors } from '../support/types';
+import type { InputState, SuiteThemeColors } from '../support/types';
 
 const getStateColor = (state: InputState | undefined, theme: SuiteThemeColors) => {
     switch (state) {

--- a/packages/suite/src/actions/wallet/__fixtures__/blockchainActions.ts
+++ b/packages/suite/src/actions/wallet/__fixtures__/blockchainActions.ts
@@ -32,9 +32,11 @@ const parseTx = (data: any) => ({
 });
 
 const analyzeTransactionsExtended = [
-    undefined,
     {
-        result: [TRANSACTION.ADD, ACCOUNT.UPDATE],
+        result: [BLOCKCHAIN.SYNCED],
+    },
+    {
+        result: [TRANSACTION.ADD, ACCOUNT.UPDATE, BLOCKCHAIN.SYNCED],
         resultTxs: {
             'xpub-btc-deviceState': [
                 { blockHeight: 5, blockHash: '5', txid: '5' },
@@ -46,49 +48,49 @@ const analyzeTransactionsExtended = [
         },
     },
     {
-        result: [TRANSACTION.ADD, ACCOUNT.UPDATE],
+        result: [TRANSACTION.ADD, ACCOUNT.UPDATE, BLOCKCHAIN.SYNCED],
         resultTxs: {
             'xpub-btc-deviceState': [{ blockHeight: undefined, blockHash: '1', txid: '1' }],
         },
     },
     {
-        result: [],
+        result: [BLOCKCHAIN.SYNCED],
         resultTxs: {
             'xpub-btc-deviceState': [{ blockHeight: undefined, blockHash: '1', txid: '1' }],
         },
     },
     {
-        result: [TRANSACTION.REMOVE, ACCOUNT.UPDATE],
+        result: [TRANSACTION.REMOVE, ACCOUNT.UPDATE, BLOCKCHAIN.SYNCED],
         resultTxs: {
             'xpub-btc-deviceState': [],
         },
     },
     {
-        result: [TRANSACTION.REMOVE, ACCOUNT.UPDATE],
+        result: [TRANSACTION.REMOVE, ACCOUNT.UPDATE, BLOCKCHAIN.SYNCED],
         resultTxs: {
             'xpub-btc-deviceState': [{ blockHeight: 1, blockHash: '1', txid: '1' }],
         },
     },
     {
-        result: [TRANSACTION.REMOVE, ACCOUNT.UPDATE],
+        result: [TRANSACTION.REMOVE, ACCOUNT.UPDATE, BLOCKCHAIN.SYNCED],
         resultTxs: {
             'xpub-btc-deviceState': [],
         },
     },
     {
-        result: [TRANSACTION.REMOVE, TRANSACTION.ADD, ACCOUNT.UPDATE],
+        result: [TRANSACTION.REMOVE, TRANSACTION.ADD, ACCOUNT.UPDATE, BLOCKCHAIN.SYNCED],
         resultTxs: {
             'xpub-btc-deviceState': [{ blockHeight: 1, blockHash: '1', txid: '1' }],
         },
     },
     {
-        result: [TRANSACTION.REMOVE, TRANSACTION.ADD, ACCOUNT.UPDATE],
+        result: [TRANSACTION.REMOVE, TRANSACTION.ADD, ACCOUNT.UPDATE, BLOCKCHAIN.SYNCED],
         resultTxs: {
             'xpub-btc-deviceState': [{ blockHeight: 1, blockHash: '1a', txid: '1a' }],
         },
     },
     {
-        result: [TRANSACTION.ADD, ACCOUNT.UPDATE],
+        result: [TRANSACTION.ADD, ACCOUNT.UPDATE, BLOCKCHAIN.SYNCED],
         resultTxs: {
             'xpub-btc-deviceState': [
                 { blockHeight: undefined, blockHash: '4', txid: '4' },
@@ -99,7 +101,7 @@ const analyzeTransactionsExtended = [
         },
     },
     {
-        result: [TRANSACTION.ADD, ACCOUNT.UPDATE],
+        result: [TRANSACTION.ADD, ACCOUNT.UPDATE, BLOCKCHAIN.SYNCED],
         resultTxs: {
             'xpub-btc-deviceState': [
                 { blockHeight: 2, blockHash: '2', txid: '2' },
@@ -109,7 +111,7 @@ const analyzeTransactionsExtended = [
         },
     },
     {
-        result: [TRANSACTION.ADD, ACCOUNT.UPDATE],
+        result: [TRANSACTION.ADD, ACCOUNT.UPDATE, BLOCKCHAIN.SYNCED],
         resultTxs: {
             'xpub-btc-deviceState': [
                 { blockHeight: 4, blockHash: '4', txid: '4' },
@@ -123,7 +125,7 @@ const analyzeTransactionsExtended = [
         },
     },
     {
-        result: [TRANSACTION.REMOVE, TRANSACTION.ADD, ACCOUNT.UPDATE],
+        result: [TRANSACTION.REMOVE, TRANSACTION.ADD, ACCOUNT.UPDATE, BLOCKCHAIN.SYNCED],
         resultTxs: {
             'xpub-btc-deviceState': [
                 { blockHeight: undefined, blockHash: '4', txid: '4' },
@@ -133,7 +135,7 @@ const analyzeTransactionsExtended = [
         },
     },
     {
-        result: [TRANSACTION.REMOVE, TRANSACTION.ADD, ACCOUNT.UPDATE],
+        result: [TRANSACTION.REMOVE, TRANSACTION.ADD, ACCOUNT.UPDATE, BLOCKCHAIN.SYNCED],
         resultTxs: {
             'xpub-btc-deviceState': [
                 { blockHeight: undefined, blockHash: '4', txid: '4' },
@@ -146,7 +148,7 @@ const analyzeTransactionsExtended = [
         },
     },
     {
-        result: [TRANSACTION.REMOVE, TRANSACTION.ADD, ACCOUNT.UPDATE],
+        result: [TRANSACTION.REMOVE, TRANSACTION.ADD, ACCOUNT.UPDATE, BLOCKCHAIN.SYNCED],
         resultTxs: {
             'xpub-btc-deviceState': [
                 { blockHeight: 3, blockHash: '3a', txid: '3a' },
@@ -181,8 +183,6 @@ export const onBlock = analyzeTransactions
                 'xpub-btc-deviceState': f.known,
             },
         },
-        result: undefined,
-        resultTxs: {},
         ...analyzeTransactionsExtended[i],
     }))
     // add more test cases
@@ -199,7 +199,7 @@ export const onBlock = analyzeTransactions
             state: {
                 accounts: [{ ...DEFAULT_ACCOUNT, history: { total: 0, unconfirmed: 0 } }],
             },
-            result: [ACCOUNT.UPDATE],
+            result: [ACCOUNT.UPDATE, BLOCKCHAIN.SYNCED],
         },
         {
             description: 'Account specific fields changed, blockbook: total',
@@ -213,7 +213,7 @@ export const onBlock = analyzeTransactions
             state: {
                 accounts: [{ ...DEFAULT_ACCOUNT, history: { total: 0, unconfirmed: 0 } }],
             },
-            result: [ACCOUNT.UPDATE],
+            result: [ACCOUNT.UPDATE, BLOCKCHAIN.SYNCED],
         },
         {
             description: 'Account specific fields changed, ripple: sequence',
@@ -227,7 +227,7 @@ export const onBlock = analyzeTransactions
             state: {
                 accounts: [{ ...DEFAULT_ACCOUNT, networkType: 'ripple', misc: { sequence: 0 } }],
             },
-            result: [ACCOUNT.UPDATE],
+            result: [ACCOUNT.UPDATE, BLOCKCHAIN.SYNCED],
         },
         {
             description: 'Account specific fields changed, ripple: balance',
@@ -249,7 +249,7 @@ export const onBlock = analyzeTransactions
                     },
                 ],
             },
-            result: [ACCOUNT.UPDATE],
+            result: [ACCOUNT.UPDATE, BLOCKCHAIN.SYNCED],
         },
         {
             description: 'Account specific fields changed, ethereum: nonce',
@@ -263,7 +263,7 @@ export const onBlock = analyzeTransactions
             state: {
                 accounts: [{ ...DEFAULT_ACCOUNT, networkType: 'ethereum', misc: { nonce: 0 } }],
             },
-            result: [ACCOUNT.UPDATE],
+            result: [ACCOUNT.UPDATE, BLOCKCHAIN.SYNCED],
         },
         {
             description: 'Account does not exists',
@@ -274,6 +274,7 @@ export const onBlock = analyzeTransactions
             state: {
                 accounts: [],
             },
+            result: [BLOCKCHAIN.SYNCED],
         },
     ] as any);
 
@@ -319,7 +320,11 @@ export const onConnect = [
     {
         description: 'successful, no accounts, no subscriptions',
         symbol: 'btc',
-        actions: [{ type: BLOCKCHAIN.UPDATE_FEE }, { type: BLOCKCHAIN.CONNECTED }],
+        actions: [
+            { type: BLOCKCHAIN.UPDATE_FEE },
+            { type: BLOCKCHAIN.SYNCED },
+            { type: BLOCKCHAIN.CONNECTED },
+        ],
         blockchainEstimateFee: 1,
         blockchainSubscribeFiatRates: 1,
         blockchainSubscribe: 0,
@@ -330,7 +335,11 @@ export const onConnect = [
             accounts: [{ symbol: 'ltc' }],
         },
         symbol: 'btc',
-        actions: [{ type: BLOCKCHAIN.UPDATE_FEE }, { type: BLOCKCHAIN.CONNECTED }],
+        actions: [
+            { type: BLOCKCHAIN.UPDATE_FEE },
+            { type: BLOCKCHAIN.SYNCED },
+            { type: BLOCKCHAIN.CONNECTED },
+        ],
         blockchainEstimateFee: 1,
         blockchainSubscribeFiatRates: 1,
         blockchainSubscribe: 0,
@@ -346,7 +355,11 @@ export const onConnect = [
             },
         },
         symbol: 'btc',
-        actions: [{ type: BLOCKCHAIN.UPDATE_FEE }, { type: BLOCKCHAIN.CONNECTED }],
+        actions: [
+            { type: BLOCKCHAIN.UPDATE_FEE },
+            { type: BLOCKCHAIN.SYNCED },
+            { type: BLOCKCHAIN.CONNECTED },
+        ],
         blockchainEstimateFee: 1,
         blockchainSubscribeFiatRates: 1,
         blockchainSubscribe: 1,
@@ -362,7 +375,11 @@ export const onConnect = [
             { payload: { levels: [{ label: 'normal' }, { label: 'high' }, { label: 'low' }] } },
         ],
         symbol: 'btc',
-        actions: [{ type: BLOCKCHAIN.UPDATE_FEE }, { type: BLOCKCHAIN.CONNECTED }],
+        actions: [
+            { type: BLOCKCHAIN.UPDATE_FEE },
+            { type: BLOCKCHAIN.SYNCED },
+            { type: BLOCKCHAIN.CONNECTED },
+        ],
         blockchainEstimateFee: 1,
         blockchainSubscribeFiatRates: 1,
         blockchainSubscribe: 0,
@@ -375,7 +392,7 @@ export const onConnect = [
         // order: subscribeFiatRates > subscribe > estimateFee
         connect: [undefined, undefined, { success: false }],
         symbol: 'eth',
-        actions: [{ type: BLOCKCHAIN.CONNECTED }],
+        actions: [{ type: BLOCKCHAIN.SYNCED }, { type: BLOCKCHAIN.CONNECTED }],
         blockchainEstimateFee: 1,
         blockchainSubscribeFiatRates: 1,
         blockchainSubscribe: 1,
@@ -464,7 +481,7 @@ export const onNotification = [
             coin: { shortcut: 'eth' },
         },
         actions: [{ type: NOTIFICATION.EVENT, payload: { formattedAmount: '0.001 ERC20' } }],
-        getAccountInfo: 1,
+        getAccountInfo: 2,
     },
     {
         description: 'sent btc, multiple accounts update',
@@ -495,7 +512,7 @@ export const onNotification = [
             coin: { shortcut: 'eth' },
         },
         actions: [],
-        getAccountInfo: 1,
+        getAccountInfo: 2,
     },
     {
         description: 'sent ripple, no account update',

--- a/packages/suite/src/actions/wallet/__tests__/blockchainActions.test.ts
+++ b/packages/suite/src/actions/wallet/__tests__/blockchainActions.test.ts
@@ -130,7 +130,7 @@ describe('Blockchain Actions', () => {
     });
 
     fixtures.onNotification.forEach(f => {
-        it(`onConnect: ${f.description}`, async () => {
+        it(`onNotification: ${f.description}`, async () => {
             // TrezorConnect.setTestFixtures(f.connect);
             const store = initStore(getInitialState(f.initialState as Args));
             await store.dispatch(blockchainActions.onNotification(f.params as any));

--- a/packages/suite/src/actions/wallet/accountActions.ts
+++ b/packages/suite/src/actions/wallet/accountActions.ts
@@ -7,9 +7,9 @@ import * as tokenActions from '@wallet-actions/tokenActions';
 import * as accountUtils from '@wallet-utils/accountUtils';
 import { analyzeTransactions, isPending } from '@wallet-utils/transactionUtils';
 import { NETWORKS } from '@wallet-config';
-import { Account } from '@wallet-types';
-import { Dispatch, GetState } from '@suite-types';
 import { SETTINGS } from '@suite-config';
+import type { Account } from '@wallet-types';
+import type { Dispatch, GetState } from '@suite-types';
 
 export type AccountAction =
     | { type: typeof ACCOUNT.CREATE; payload: Account }

--- a/packages/suite/src/actions/wallet/accountActions.ts
+++ b/packages/suite/src/actions/wallet/accountActions.ts
@@ -123,6 +123,8 @@ export const changeAccountVisibility = (payload: Account, visible = true): Accou
     },
 });
 
+// Left here for clarity, but shouldn't be called anywhere but in blockchainActions.syncAccounts
+// as we usually want to update all accounts for a single coin at once
 export const fetchAndUpdateAccount =
     (account: Account) => async (dispatch: Dispatch, getState: GetState) => {
         // first basic check, traffic optimization

--- a/packages/suite/src/actions/wallet/accountSearchActions.ts
+++ b/packages/suite/src/actions/wallet/accountSearchActions.ts
@@ -1,5 +1,5 @@
-import { Account } from '@wallet-types';
 import { ACCOUNT_SEARCH } from '@wallet-actions/constants';
+import type { Account } from '@wallet-types';
 
 export type AccountSearchAction =
     | {

--- a/packages/suite/src/actions/wallet/blockchainActions.ts
+++ b/packages/suite/src/actions/wallet/blockchainActions.ts
@@ -11,10 +11,10 @@ import { getNetwork } from '@wallet-utils/accountUtils';
 import * as notificationActions from '@suite-actions/notificationActions';
 import { State as FeeState } from '@wallet-reducers/feesReducer';
 import { NETWORKS } from '@wallet-config';
-import { Dispatch, GetState } from '@suite-types';
-import { Account, Network } from '@wallet-types';
 import { BLOCKCHAIN } from './constants';
 import { getDefaultBackendType } from '@suite-utils/backend';
+import type { Dispatch, GetState } from '@suite-types';
+import type { Account, Network } from '@wallet-types';
 
 // Conditionally subscribe to blockchain backend
 // called after TrezorConnect.init successfully emits TRANSPORT.START event

--- a/packages/suite/src/actions/wallet/blockchainActions.ts
+++ b/packages/suite/src/actions/wallet/blockchainActions.ts
@@ -23,6 +23,7 @@ import { BLOCKCHAIN } from './constants';
 import { getDefaultBackendType } from '@suite-utils/backend';
 import type { Dispatch, GetState } from '@suite-types';
 import type { Account, Network } from '@wallet-types';
+import type { Timeout } from '@suite/types/utils';
 
 const ACCOUNTS_SYNC_INTERVAL = 60 * 1000;
 
@@ -43,7 +44,7 @@ export type BlockchainAction =
           type: typeof BLOCKCHAIN.RECONNECT_TIMEOUT_START;
           payload: {
               symbol: Network['symbol'];
-              id: ReturnType<typeof setTimeout>;
+              id: Timeout;
               time: number;
               count: number;
           };
@@ -56,7 +57,7 @@ export type BlockchainAction =
           type: typeof BLOCKCHAIN.SYNCED;
           payload: {
               symbol: Network['symbol'];
-              timeout: ReturnType<typeof setTimeout>;
+              timeout: Timeout;
           };
       };
 
@@ -274,7 +275,7 @@ export const unsubscribe = (removedAccounts: Account[]) => (_: Dispatch, getStat
     return Promise.all(promises as Promise<any>[]);
 };
 
-const tryClearTimeout = (timeout?: ReturnType<typeof setTimeout>) => {
+const tryClearTimeout = (timeout?: Timeout) => {
     if (timeout) clearTimeout(timeout);
 };
 

--- a/packages/suite/src/actions/wallet/constants/blockchainConstants.ts
+++ b/packages/suite/src/actions/wallet/constants/blockchainConstants.ts
@@ -4,6 +4,7 @@ export const READY = '@blockchain/ready';
 export const RECONNECT_TIMEOUT_START = '@blockchain/reconnect-timeout-start';
 export const CONNECTED = '@blockchain/connected';
 export const UPDATE_FEE = '@blockchain/update-fee';
+export const SYNCED = '@blockchain/synced';
 
 // reexport from trezor-connect
 export const { CONNECT } = BLOCKCHAIN;

--- a/packages/suite/src/actions/wallet/selectedAccountActions.ts
+++ b/packages/suite/src/actions/wallet/selectedAccountActions.ts
@@ -17,11 +17,6 @@ export const dispose = (): SelectedAccountAction => ({
     type: ACCOUNT.DISPOSE,
 });
 
-export const update = (payload: State): SelectedAccountAction => ({
-    type: ACCOUNT.UPDATE_SELECTED_ACCOUNT,
-    payload,
-});
-
 // Add notification to loaded SelectedAccountState
 const getAccountStateWithMode =
     (selectedAccount?: State) => (_dispatch: Dispatch, getState: GetState) => {

--- a/packages/suite/src/actions/wallet/transactionActions.ts
+++ b/packages/suite/src/actions/wallet/transactionActions.ts
@@ -163,8 +163,8 @@ export const fetchTransactions =
         });
 
         if (result && result.success) {
-            const updatedAccount = accountActions.update(account, result.payload)
-                .payload as Account;
+            const updateAction = accountActions.update(account, result.payload);
+            const updatedAccount = updateAction.payload as Account;
             const transactions = result.payload.history.transactions || [];
             const totalPages = result.payload.page?.total || 0;
 
@@ -173,7 +173,7 @@ export const fetchTransactions =
             });
             dispatch(add(transactions, updatedAccount, page));
             // updates the marker/page object for the account
-            dispatch(accountActions.update(account, result.payload));
+            dispatch(updateAction);
 
             // totalPages (blockbook + blockfrost), marker (ripple) if is undefined, no more pages are available
             if (recursive && (page < totalPages || (marker && updatedAccount.marker))) {

--- a/packages/suite/src/components/suite/Labeling/components/Metadata/index.tsx
+++ b/packages/suite/src/components/suite/Labeling/components/Metadata/index.tsx
@@ -11,6 +11,8 @@ import { Props, ExtendedProps, DropdownMenuItem } from './definitions';
 import { withEditable } from './withEditable';
 import { withDropdown } from './withDropdown';
 
+import type { Timeout } from '@suite/types/utils';
+
 const LabelDefaultValue = styled.div`
     width: 0;
     display: inline-block;
@@ -214,7 +216,7 @@ const MetadataLabeling = (props: Props) => {
     const dataTestBase = `@metadata/${props.payload.type}/${props.payload.defaultValue}`;
     const actionButtonsDisabled = isDiscoveryRunning || pending;
     const isSubscribedToSubmitResult = useRef(props.payload.defaultValue);
-    let timeout: ReturnType<typeof setTimeout> | undefined;
+    let timeout: Timeout | undefined;
 
     useEffect(() => {
         setPending(false);

--- a/packages/suite/src/components/suite/NavigationBar/components/DeviceSelector/index.tsx
+++ b/packages/suite/src/components/suite/NavigationBar/components/DeviceSelector/index.tsx
@@ -10,6 +10,7 @@ import * as suiteActions from '@suite-actions/suiteActions';
 import * as deviceUtils from '@suite-utils/device';
 import { DeviceStatus } from './DeviceStatus';
 import { transparentize } from 'polished';
+import type { Timeout } from '@suite/types/utils';
 
 const ArrowDown = styled(Icon)`
     margin-left: 4px;
@@ -113,8 +114,8 @@ export const DeviceSelector = () => {
     const [showTextStatus, setShowTextStatus] = useState(false);
 
     const countChanged = localCount && localCount !== deviceCount;
-    const shakeAnimationTimerRef = useRef<ReturnType<typeof setTimeout> | undefined>(undefined);
-    const stateAnimationTimerRef = useRef<ReturnType<typeof setTimeout> | undefined>(undefined);
+    const shakeAnimationTimerRef = useRef<Timeout | undefined>(undefined);
+    const stateAnimationTimerRef = useRef<Timeout | undefined>(undefined);
 
     const analytics = useAnalytics();
 

--- a/packages/suite/src/components/suite/NotificationRenderer/renderers/TransactionRenderer.tsx
+++ b/packages/suite/src/components/suite/NotificationRenderer/renderers/TransactionRenderer.tsx
@@ -33,7 +33,7 @@ const TransactionRenderer = ({ render: View, ...props }: TransactionRendererProp
         blockchain: state.wallet.blockchain,
     }));
 
-    const networkAccounts = accounts.filter(a => a.symbol === symbol);
+    const networkAccounts = accountUtils.findAccountsByNetwork(symbol, accounts);
     const found = accountUtils.findAccountsByDescriptor(descriptor, networkAccounts);
     // fallback: account not found, it should never happen tho
     if (!found.length) return <View {...props} />;

--- a/packages/suite/src/config/onboarding/steps.ts
+++ b/packages/suite/src/config/onboarding/steps.ts
@@ -1,4 +1,4 @@
-import { Step } from '@onboarding-types';
+import type { Step } from '@onboarding-types';
 import * as STEP from '@onboarding-constants/steps';
 
 const commonPrerequisites: Step['prerequisites'] = [

--- a/packages/suite/src/hooks/suite/useAsyncDebounce.ts
+++ b/packages/suite/src/hooks/suite/useAsyncDebounce.ts
@@ -1,13 +1,12 @@
 import { useCallback, useRef } from 'react';
 import { createDeferred } from '@trezor/utils';
-
-type TimeoutType = ReturnType<typeof setTimeout>; // resolves to Timeout type in react-native, number otherwise
+import type { Timeout } from '@suite/types/utils';
 
 // composeTransaction should be debounced from both sides
 // `timeout` prevents from calling 'trezor-connect' method to many times (inputs mad-clicking)
 // TODO: maybe it should be converted to regular module, could be useful elsewhere
 export const useAsyncDebounce = () => {
-    const timeout = useRef<TimeoutType | null>(null);
+    const timeout = useRef<Timeout | null>(null);
 
     const debounce = useCallback(
         async <F extends (...args: any) => Promise<any>>(fn: F): Promise<ReturnType<F>> => {

--- a/packages/suite/src/hooks/wallet/__fixtures__/useSendForm.ts
+++ b/packages/suite/src/hooks/wallet/__fixtures__/useSendForm.ts
@@ -90,6 +90,11 @@ export const DEFAULT_STORE = {
             lastUsedFeeLevel: {},
             debug: {},
         },
+        blockchain: {
+            btc: {},
+            eth: {},
+            xrp: {},
+        },
         fees: {
             btc: {
                 minFee: 1,

--- a/packages/suite/src/middlewares/wallet/walletMiddleware.ts
+++ b/packages/suite/src/middlewares/wallet/walletMiddleware.ts
@@ -1,4 +1,4 @@
-import { MiddlewareAPI } from 'redux';
+import type { MiddlewareAPI } from 'redux';
 import { SUITE, ROUTER } from '@suite-actions/constants';
 import { ACCOUNT, TRANSACTION } from '@wallet-actions/constants';
 import { WALLET_SETTINGS } from '@settings-actions/constants';
@@ -10,7 +10,7 @@ import * as cardanoStakingActions from '@wallet-actions/cardanoStakingActions';
 import * as coinmarketBuyActions from '@wallet-actions/coinmarketBuyActions';
 import * as transactionActions from '@wallet-actions/transactionActions';
 import * as blockchainActions from '@wallet-actions/blockchainActions';
-import { AppState, Action, Dispatch } from '@suite-types';
+import type { AppState, Action, Dispatch } from '@suite-types';
 
 const walletMiddleware =
     (api: MiddlewareAPI<Dispatch, AppState>) =>

--- a/packages/suite/src/reducers/wallet/accountsReducer.ts
+++ b/packages/suite/src/reducers/wallet/accountsReducer.ts
@@ -63,6 +63,9 @@ export type Account = {
 
 const initialState: Account[] = [];
 
+const accountEqualTo = (b: Account) => (a: Account) =>
+    a.deviceState === b.deviceState && a.descriptor === b.descriptor && a.symbol === b.symbol;
+
 const create = (draft: Account[], account: Account) => {
     // TODO: check if account already exist, for example 2 device instances with same passphrase
     // remove "transactions" field, they are stored in "transactionReducer"
@@ -74,23 +77,13 @@ const create = (draft: Account[], account: Account) => {
 
 const remove = (draft: Account[], accounts: Account[]) => {
     accounts.forEach(a => {
-        const index = draft.findIndex(
-            ac =>
-                ac.deviceState === a.deviceState &&
-                ac.descriptor === a.descriptor &&
-                ac.symbol === a.symbol,
-        );
+        const index = draft.findIndex(accountEqualTo(a));
         draft.splice(index, 1);
     });
 };
 
 const update = (draft: Account[], account: Account) => {
-    const accountIndex = draft.findIndex(
-        ac =>
-            ac.deviceState === account.deviceState &&
-            ac.descriptor === account.descriptor &&
-            ac.symbol === account.symbol,
-    );
+    const accountIndex = draft.findIndex(accountEqualTo(account));
 
     if (accountIndex !== -1) {
         draft[accountIndex] = account;

--- a/packages/suite/src/reducers/wallet/blockchainReducer.ts
+++ b/packages/suite/src/reducers/wallet/blockchainReducer.ts
@@ -3,10 +3,9 @@ import { BlockchainInfo, BlockchainBlock } from 'trezor-connect';
 import { BLOCKCHAIN } from '@wallet-actions/constants';
 import { getNetwork } from '@wallet-utils/accountUtils';
 import { NETWORKS } from '@wallet-config';
-import { Network } from '@wallet-types';
-import { Action } from '@suite-types';
-
-type Timeout = ReturnType<typeof setTimeout>;
+import type { Network } from '@wallet-types';
+import type { Action } from '@suite-types';
+import type { Timeout } from '@suite/types/utils';
 
 interface BlockchainReconnection {
     id: Timeout; // setTimeout id

--- a/packages/suite/src/reducers/wallet/blockchainReducer.ts
+++ b/packages/suite/src/reducers/wallet/blockchainReducer.ts
@@ -6,8 +6,10 @@ import { NETWORKS } from '@wallet-config';
 import { Network } from '@wallet-types';
 import { Action } from '@suite-types';
 
+type Timeout = ReturnType<typeof setTimeout>;
+
 interface BlockchainReconnection {
-    id: ReturnType<typeof setTimeout>; // setTimeout id
+    id: Timeout; // setTimeout id
     time: number; // timestamp when it will be resolved
     count: number; // number of tries
 }
@@ -25,6 +27,7 @@ export interface Blockchain {
     blockHeight: number;
     version: string;
     reconnection?: BlockchainReconnection;
+    syncTimeout?: Timeout;
 }
 
 export type BlockchainState = {
@@ -130,6 +133,9 @@ const blockchainReducer = (state: BlockchainState = initialState, action: Action
                         count: action.payload.count,
                     },
                 };
+                break;
+            case BLOCKCHAIN.SYNCED:
+                draft[action.payload.symbol].syncTimeout = action.payload.timeout;
                 break;
             // no default
         }

--- a/packages/suite/src/types/utils/index.ts
+++ b/packages/suite/src/types/utils/index.ts
@@ -40,3 +40,5 @@ export type DeepPartial<T> = T extends () => any
     : T;
 
 export type PrimitiveType = string | number | boolean | Date | null | undefined;
+
+export type Timeout = ReturnType<typeof setTimeout>;

--- a/packages/suite/src/utils/suite/theme.ts
+++ b/packages/suite/src/utils/suite/theme.ts
@@ -1,5 +1,5 @@
 import { THEME } from '@trezor/components/src/config/colors';
-import { AppState } from '@suite-types';
+import type { AppState } from '@suite-types';
 
 export const getThemeColors = (theme: AppState['suite']['settings']['theme']) => {
     switch (theme?.variant) {

--- a/packages/suite/src/utils/wallet/accountUtils.ts
+++ b/packages/suite/src/utils/wallet/accountUtils.ts
@@ -211,6 +211,9 @@ export const sortByCoin = (accounts: Account[]) =>
         return aIndex - bIndex;
     });
 
+export const findAccountsByNetwork = (symbol: Network['symbol'], accounts: Account[]) =>
+    accounts.filter(a => a.symbol === symbol);
+
 export const findAccountsByDescriptor = (descriptor: string, accounts: Account[]) =>
     accounts.filter(a => a.descriptor === descriptor);
 


### PR DESCRIPTION
This draft PR should resolve or at least improve #4849. It adds a timer which checks (and updates if needed) all acounts of a given coin if they weren't checked for the last minute (automatically, manually or based on backend notification). Moreover there's a refresh button in every account view which allows to initiate the check manually. [PREVIEW](https://suite.corp.sldev.cz/suite-web/feat/blockchain-syncing/web/accounts)

Is really possible (and reasonable) to update all coin accounts instead of a single one in [sendFormActions](https://github.com/trezor/trezor-suite/compare/feat/blockchain-syncing?expand=1#diff-38581ddf07235dae32f96fa731c91cd468abdde80382d5a0571616d64662ef53), @szymonlesisz?

Currently, the refresh button is placed below the fiat rate and is completely my suggestion. It should be (ap/im)proved by designers before merge.
![image](https://user-images.githubusercontent.com/26326960/162428489-21651687-e5f8-4483-a1d3-e26811aaffaa.png)

