### PR TITLE
fix(suite): guide search highlight substring

### DIFF
--- a/packages/suite/src/components/guide/GuideSearch.tsx
+++ b/packages/suite/src/components/guide/GuideSearch.tsx
@@ -57,7 +57,7 @@ interface PreviewProps {
 const Preview: React.FC<PreviewProps> = ({ content, from, length }) => (
     <PreviewContent>
         {content.substring(0, from)}
-        <em>{content.substring(from, length)}</em>
+        <em>{content.substring(from, from + length)}</em>
         {content.substring(from + length)}
     </PreviewContent>
 );


### PR DESCRIPTION
`substring` parameters have different meaning than `substr` ones, therefore highlighted part when searching in Guide was messed up (see current staging).

Probably should be cherrypicked.