### PR TITLE
fix: tooltips above guide on mobile

### DIFF
--- a/packages/components/src/config/variables.ts
+++ b/packages/components/src/config/variables.ts
@@ -44,6 +44,7 @@ export const Z_INDEX = {
     GUIDE_BUTTON: 10,
     GUIDE_BUTTON_BESIDE_MODAL: 10001,
     DROPDOWN_MENU: 10003, // should lay above GUIDE_PANEL
+    TOOLTIP: 10003, // should lay above GUIDE_PANEL
     TOAST_CONTAINER: 10003, // should lay above GUIDE_PANEL
 } as const;
 

--- a/packages/integration-tests/projects/suite-web/tests/suite/tooltip.test.ts
+++ b/packages/integration-tests/projects/suite-web/tests/suite/tooltip.test.ts
@@ -19,7 +19,7 @@ describe('Test tooltip links', () => {
             .children()
             .children()
             .trigger('mouseenter');
-        cy.hoverTestElement('@tooltip/openGuide').click();
+        cy.hoverTestElement('@tooltip/guideAnchor').click();
         cy.getTestElement('@guide/panel').should('exist');
     });
 });

--- a/packages/suite/src/components/suite/SwitchDevice/components/DeviceItem/components/ColHeader/index.tsx
+++ b/packages/suite/src/components/suite/SwitchDevice/components/DeviceItem/components/ColHeader/index.tsx
@@ -19,13 +19,13 @@ const Text = styled.span`
 interface Props {
     children?: React.ReactNode;
     tooltipContent?: TooltipProps['content'];
-    tooltipOpenGuide?: { node: React.ReactElement };
+    tooltipOpenGuide?: TooltipProps['guideAnchor'];
 }
 
 const ColHeader = ({ children, tooltipContent, tooltipOpenGuide, ...rest }: Props) => (
     <Wrapper {...rest}>
         {tooltipContent ? (
-            <Tooltip maxWidth={285} content={tooltipContent} openGuide={tooltipOpenGuide} dashed>
+            <Tooltip maxWidth={285} content={tooltipContent} guideAnchor={tooltipOpenGuide} dashed>
                 <Text>{children}</Text>
             </Tooltip>
         ) : (

--- a/packages/suite/src/components/suite/SwitchDevice/components/DeviceItem/index.tsx
+++ b/packages/suite/src/components/suite/SwitchDevice/components/DeviceItem/index.tsx
@@ -255,11 +255,12 @@ const DeviceItem = ({ device, instances, closeModalApp, backgroundRoute }: Props
                                             />
                                         </WalletsCount>
                                         <ColRememberHeader
-                                            tooltipOpenGuide={{
-                                                node: (
-                                                    <OpenGuideFromTooltip id="/privacy/remember-and-eject.md" />
-                                                ),
-                                            }}
+                                            tooltipOpenGuide={instance => (
+                                                <OpenGuideFromTooltip
+                                                    id="/privacy/remember-and-eject.md"
+                                                    instance={instance}
+                                                />
+                                            )}
                                             tooltipContent={
                                                 <Translation id="TR_REMEMBER_ALLOWS_YOU_TO" />
                                             }
@@ -267,11 +268,12 @@ const DeviceItem = ({ device, instances, closeModalApp, backgroundRoute }: Props
                                             <Translation id="TR_REMEMBER_HEADING" />
                                         </ColRememberHeader>
                                         <ColEjectHeader
-                                            tooltipOpenGuide={{
-                                                node: (
-                                                    <OpenGuideFromTooltip id="/privacy/remember-and-eject.md" />
-                                                ),
-                                            }}
+                                            tooltipOpenGuide={instance => (
+                                                <OpenGuideFromTooltip
+                                                    id="/privacy/remember-and-eject.md"
+                                                    instance={instance}
+                                                />
+                                            )}
                                             tooltipContent={
                                                 <Translation id="TR_EJECT_WALLET_EXPLANATION" />
                                             }

--- a/packages/suite/src/components/suite/modals/Passphrase/components/PassphraseTypeCard/index.tsx
+++ b/packages/suite/src/components/suite/modals/Passphrase/components/PassphraseTypeCard/index.tsx
@@ -284,14 +284,13 @@ const PassphraseTypeCard = (props: Props) => {
                                 {props.type === 'hidden' ? (
                                     <Tooltip
                                         title={<Translation id="TR_WHAT_IS_PASSPHRASE" />}
-                                        openGuide={{
-                                            node: (
-                                                <OpenGuideFromTooltip
-                                                    dataTest="@tooltip/openGuide"
-                                                    id="/security/passphrase.md"
-                                                />
-                                            ),
-                                        }}
+                                        guideAnchor={instance => (
+                                            <OpenGuideFromTooltip
+                                                dataTest="@tooltip/guideAnchor"
+                                                id="/security/passphrase.md"
+                                                instance={instance}
+                                            />
+                                        )}
                                         content={<Translation id="TR_HIDDEN_WALLET_TOOLTIP" />}
                                         dashed
                                     >

--- a/packages/suite/src/views/guide/OpenGuideFromTooltip.tsx
+++ b/packages/suite/src/views/guide/OpenGuideFromTooltip.tsx
@@ -33,10 +33,11 @@ const StyledIconWrap = styled.span`
 
 type OpenGuideFromTooltipProps = {
     id: string;
+    instance: { hide: () => void };
     dataTest?: string;
 };
 
-const OpenGuideFromTooltip = ({ id, dataTest }: OpenGuideFromTooltipProps) => {
+const OpenGuideFromTooltip = ({ id, instance, dataTest }: OpenGuideFromTooltipProps) => {
     const { openNodeById } = useGuideOpenNode();
 
     return (
@@ -44,6 +45,7 @@ const OpenGuideFromTooltip = ({ id, dataTest }: OpenGuideFromTooltipProps) => {
             data-test={dataTest}
             onClick={(e: React.MouseEvent<any>) => {
                 e.stopPropagation();
+                instance.hide();
                 openNodeById(id);
             }}
             variant="nostyle"

--- a/packages/suite/src/views/wallet/send/components/Options/components/BitcoinOptions/index.tsx
+++ b/packages/suite/src/views/wallet/send/components/Options/components/BitcoinOptions/index.tsx
@@ -74,9 +74,12 @@ const BitcoinOptions = () => {
                 <Left>
                     {!locktimeEnabled && (
                         <Tooltip
-                            openGuide={{
-                                node: <OpenGuideFromTooltip id="/suite-basics/send/locktime.md" />,
-                            }}
+                            guideAnchor={instance => (
+                                <OpenGuideFromTooltip
+                                    id="/suite-basics/send/locktime.md"
+                                    instance={instance}
+                                />
+                            )}
                             content={<Translation id="LOCKTIME_ADD_TOOLTIP" />}
                             cursor="pointer"
                         >
@@ -98,11 +101,12 @@ const BitcoinOptions = () => {
                         network.features?.includes('rbf') &&
                         !locktimeEnabled && (
                             <Tooltip
-                                openGuide={{
-                                    node: (
-                                        <OpenGuideFromTooltip id="/suite-basics/send/rbf-replace-by-fee.md" />
-                                    ),
-                                }}
+                                guideAnchor={instance => (
+                                    <OpenGuideFromTooltip
+                                        id="/suite-basics/send/rbf-replace-by-fee.md"
+                                        instance={instance}
+                                    />
+                                )}
                                 content={<Translation id="RBF_TOOLTIP" />}
                                 cursor="pointer"
                             >

--- a/packages/suite/src/views/wallet/send/components/Outputs/components/OpReturn/index.tsx
+++ b/packages/suite/src/views/wallet/send/components/Outputs/components/OpReturn/index.tsx
@@ -72,9 +72,12 @@ const OpReturn = ({ outputId }: { outputId: number }) => {
                 label={
                     <Label>
                         <Tooltip
-                            openGuide={{
-                                node: <OpenGuideFromTooltip id="/suite-basics/send/op_return.md" />,
-                            }}
+                            guideAnchor={instance => (
+                                <OpenGuideFromTooltip
+                                    id="/suite-basics/send/op_return.md"
+                                    instance={instance}
+                                />
+                            )}
                             content={<Translation id="OP_RETURN_TOOLTIP" />}
                             dashed
                         >

--- a/packages/suite/src/views/wallet/send/components/Raw.tsx
+++ b/packages/suite/src/views/wallet/send/components/Raw.tsx
@@ -82,9 +82,12 @@ const Raw = ({ network }: { network: Network }) => {
                     bottomText={<InputError error={error} />}
                     label={
                         <Tooltip
-                            openGuide={{
-                                node: <OpenGuideFromTooltip id="/suite-basics/send/send-raw.md" />,
-                            }}
+                            guideAnchor={instance => (
+                                <OpenGuideFromTooltip
+                                    id="/suite-basics/send/send-raw.md"
+                                    instance={instance}
+                                />
+                            )}
                             content={<Translation id="SEND_RAW_TRANSACTION_TOOLTIP" />}
                             dashed
                         >


### PR DESCRIPTION
Fixes https://github.com/trezor/trezor-suite/issues/4739#issuecomment-1095153000

Now tooltip hides when the guide anchor is used. Allows to keep the z-index and use tooltips in guide too. 