### PR TITLE
feat(suite): add transport info and firmware revision to created issue

### DIFF
--- a/packages/suite/src/views/settings/debug/GithubIssue.tsx
+++ b/packages/suite/src/views/settings/debug/GithubIssue.tsx
@@ -1,12 +1,12 @@
 import React from 'react';
-
 import { ActionButton, ActionColumn, SectionItem, TextColumn } from '@suite-components/Settings';
-import { useDevice } from '@suite-hooks';
+import { useDevice, useSelector } from '@suite-hooks';
 import { openGithubIssue } from '@suite/services/github';
 import { useAnchor } from '@suite-hooks/useAnchor';
 import { SettingsAnchor } from '@suite-constants/anchors';
 
 export const GithubIssue = () => {
+    const transport = useSelector(state => state.suite.transport);
     const { device } = useDevice();
     const { anchorRef, shouldHighlight } = useAnchor(SettingsAnchor.GithubIssue);
 
@@ -21,7 +21,10 @@ export const GithubIssue = () => {
                 description="Open issue on Github with pre-filled details. Do not use with sensitive data!"
             />
             <ActionColumn>
-                <ActionButton variant="secondary" onClick={() => openGithubIssue(device)}>
+                <ActionButton
+                    variant="secondary"
+                    onClick={() => openGithubIssue({ device, transport })}
+                >
                     Open issue
                 </ActionButton>
             </ActionColumn>


### PR DESCRIPTION
Add transport type ("bridge" or "WebUsbPlugin"), bridge version (if applicable) and firmware revision to pre-populated Github issue when opening it from suite Debug tab. Log is not included because it is too long to pass to GitHub in query string (communicated with QA).

![Screenshot 2022-04-11 at 18 12 27](https://user-images.githubusercontent.com/42465546/162916527-eb1b09f3-17a8-40b7-88ac-578e58309e81.png)

