### PR TITLE
Fix/repeated anchor clicks

### DIFF
--- a/packages/suite/src/actions/suite/routerActions.ts
+++ b/packages/suite/src/actions/suite/routerActions.ts
@@ -73,11 +73,13 @@ export const onLocationChange =
         });
     };
 
-export const onAnchorChange = (anchor: AnchorType) => (dispatch: Dispatch, _getState: GetState) =>
+// if anchor param is not set, it works as reset
+export const onAnchorChange = (anchor?: AnchorType) => (dispatch: Dispatch, _getState: GetState) =>
     dispatch({
         type: ROUTER.ANCHOR_CHANGE,
         payload: anchor,
     });
+
 /**
  * Dispatch initial url
  * Called from `@suite-middlewares/suiteMiddleware`
@@ -115,7 +117,11 @@ export const goto =
         const urlBase = getPrefixedURL(getRoute(routeName, params));
 
         if (urlBase === router.url) {
-            if (anchor && anchor !== router.anchor) dispatch(onAnchorChange(anchor));
+            // if location is same, but anchor is set (e.g. click on tor icon when in app settings), let's propagate it to redux state
+            if (anchor) {
+                // postpone propagation to allow clearing anchor in redux state by click listener
+                setTimeout(() => dispatch(onAnchorChange(anchor)), 0);
+            }
             return;
         }
 

--- a/packages/suite/src/components/suite/NotificationRenderer/renderers/ActionRenderer.tsx
+++ b/packages/suite/src/components/suite/NotificationRenderer/renderers/ActionRenderer.tsx
@@ -19,19 +19,19 @@ const ActionRenderer = ({ render: View, ...props }: ActionRendererProps) => {
         case DEVICE.CONNECT:
             action = {
                 label: 'TR_SELECT_DEVICE',
-                onClick: () => (!seen ? selectDevice(device) : undefined),
+                onClick: () => selectDevice(device),
             };
             break;
         case DEVICE.CONNECT_UNACQUIRED:
             action = {
                 label: 'TR_SOLVE_ISSUE',
-                onClick: () => (!seen ? acquireDevice(device) : undefined),
+                onClick: () => acquireDevice(device),
             };
             break;
         // no default
     }
 
-    return <View {...props} action={action} />;
+    return <View {...props} action={!seen ? action : undefined} />;
 };
 
 export default ActionRenderer;

--- a/packages/suite/src/components/suite/NotificationRenderer/renderers/TransactionRenderer.tsx
+++ b/packages/suite/src/components/suite/NotificationRenderer/renderers/TransactionRenderer.tsx
@@ -25,8 +25,9 @@ const TransactionRenderer = ({ render: View, ...props }: TransactionRendererProp
         goto: routerActions.goto,
     });
 
-    const { accounts, transactions, devices, blockchain } = useSelector(state => ({
+    const { accounts, transactions, devices, blockchain, currentDevice } = useSelector(state => ({
         devices: state.devices,
+        currentDevice: state.suite.device,
         accounts: state.wallet.accounts,
         transactions: state.wallet.transactions,
         blockchain: state.wallet.blockchain,
@@ -55,7 +56,10 @@ const TransactionRenderer = ({ render: View, ...props }: TransactionRendererProp
             }}
             action={{
                 onClick: () => {
-                    selectDevice(accountDevice || device);
+                    const deviceToSelect = accountDevice || device;
+                    if (deviceToSelect?.id !== currentDevice?.id) {
+                        selectDevice(deviceToSelect);
+                    }
                     const txAnchor = getTxAnchor(tx?.txid);
                     goto('wallet-index', {
                         params: {


### PR DESCRIPTION
closes #4915, #4588

- fix(anchor): make it work on repeated clicks on the same app page
   - scroll listener cannot be added easily because it is also activated by auto anchor scrolling
   - click listener has to be added on `id="app"` div otherwise it behaves randomly (probably because of event propagation)
   - to make it work on the same page more times in a row, we need to delete the anchor from redux and set it there again. This is why it is wrapped in `setTimeout` in `goto` function to have bigger chance that "deleting" event is faster than "setting" event
- fix(anchor): do not reload device if the device is same
   - activating anchor from notification did not work properly because it also updated device on click. However, we do not need to update device if we do not navigate to different device
   - I was thinking about putting some `isSameDevice` check into `selectDevice` method. However, it can potentially break a lot of things, so I did not do that. It is not only `id` check but also `isRemembered`,... checks
- fix(suite): dont show not working notification buttons in notifications
   - when I was into playing with notifications, I found a bug which was already reported, so i fixed it here as it was easy