### PR TITLE
feat: enable taproot for vertcoin (vtc)

### DIFF
--- a/packages/suite/src/config/wallet/networks.ts
+++ b/packages/suite/src/config/wallet/networks.ts
@@ -197,6 +197,10 @@ const networks = {
         features: ['sign-verify'],
         customBackends: ['blockbook'],
         accountTypes: {
+            taproot: {
+                name: 'Vertcoin (Taproot)',
+                bip43Path: "m/86'/28'/i'",
+            },
             segwit: {
                 name: 'Vertcoin (segwit)',
                 bip43Path: "m/49'/28'/i'",


### PR DESCRIPTION
Backend blockbook https://vtc1.trezor.io/ explorers need to be re-deployed to broadcast P2TR with version 0.18.0 which [has been merged.](https://github.com/trezor/blockbook/commit/9b8fe717dffba172a8264b68450a278e1b6cf7ed)

Update: Trezor's backend explorers have been updated and can now broadcast P2TR with this PR