### PR TITLE
chore(ci): update awscli to a new version

### DIFF
--- a/packages/suite-web-landing/scripts/s3sync.sh
+++ b/packages/suite-web-landing/scripts/s3sync.sh
@@ -1,5 +1,5 @@
 #! /usr/bin/env nix-shell
-#! nix-shell -i bash -p awscli
+#! nix-shell -i bash -p awscli2
 
 # Before first use:
 # Install awscli (pip install awscli)

--- a/packages/suite-web/scripts/s3sync.sh
+++ b/packages/suite-web/scripts/s3sync.sh
@@ -1,5 +1,5 @@
 #! /usr/bin/env nix-shell
-#! nix-shell -i bash -p awscli
+#! nix-shell -i bash -p awscli2
 
 # Before first use:
 # Install awscli (pip install awscli)


### PR DESCRIPTION
This fixes the issue when uploading files to s3 were assigned wrong MIME types, especially `application/wasm` was not added to files `*.module.wasm`. I have tested that the `awscli2` version works as expected.
