### PR TITLE
fix(browser-detection): do not use browser-detection styles in app

### DIFF
--- a/packages/suite-data/browser-detection.webpack.ts
+++ b/packages/suite-data/browser-detection.webpack.ts
@@ -22,9 +22,15 @@ module.exports = {
                 },
             },
             {
-                test: /\.css$/,
+                // target css file to ensure unique id for <style> tag
+                include: path.resolve(__dirname, 'src', 'browser-detection', 'styles.css'),
                 use: [
-                    'style-loader',
+                    {
+                        loader: 'style-loader',
+                        options: {
+                            attributes: { id: 'browser-detection-style' },
+                        },
+                    },
                     {
                         loader: 'css-loader',
                         options: {

--- a/packages/suite-data/src/browser-detection/index.ts
+++ b/packages/suite-data/src/browser-detection/index.ts
@@ -186,6 +186,11 @@ window.addEventListener('load', () => {
         const child = document.getElementById('unsupported-browser');
         child?.parentNode?.removeChild(child);
 
+        // browser-detection styles are removed because they should not be available and used in app
+        // styles.css gets id="browser-detection-style" on its <style> tag due to "style-loader" configuration in webpack
+        const style = document.getElementById('browser-detection-style');
+        style?.parentNode?.removeChild(style);
+
         const appDiv = document.createElement('div');
         appDiv.id = 'app';
         document.body.appendChild(appDiv);


### PR DESCRIPTION
I was thinking about disabling `browser-detection` styleSheet using JavaScript. https://developer.mozilla.org/en-US/docs/Web/API/StyleSheet

However, this solution feels more clear to me.