### PR TITLE
fix(message-system): remove targeting by app revision

### DIFF
--- a/docs/misc/message_system.md
+++ b/docs/misc/message_system.md
@@ -108,7 +108,7 @@ Structure of config, types and optionality of specific keys can be found in the 
                     },
                     /*
                     For os, environment, browser and transport.
-                    - All values (except for revision in environment) are version definitions
+                    - All values are version definitions
                     - Semver npm library is used for working with versions https://www.npmjs.com/package/semver.
                     - "*" = all versions; "!" = not for this type of browser/os/...
                     - Options: gte, lt, ranges, tildes, carets,... are supported, see semver lib for more info.
@@ -125,12 +125,10 @@ Structure of config, types and optionality of specific keys can be found in the 
                         "ios": "13",
                         "chromeos": "*"
                     },
-                    // revision is optional
                     "environment": {
                         "desktop": "<21.5",
                         "mobile": "!",
-                        "web": "<22",
-                        "revision": "7281ac61483e38d974625c2505bfe5efd519aacb"
+                        "web": "<22"
                     },
                     "browser": {
                         "firefox": [

--- a/packages/suite-data/src/message-system/schema/config.schema.v1.json
+++ b/packages/suite-data/src/message-system/schema/config.schema.v1.json
@@ -97,10 +97,10 @@
                                         },
                                         "web": {
                                             "$ref": "#/definitions/version"
-                                        },
-                                        "revision": {
-                                            "type": "string"
                                         }
+                                    },
+                                    "additionalProperties": {
+                                        "$ref": "#/definitions/version"
                                     }
                                 },
                                 "browser": {

--- a/packages/suite/src/utils/suite/__fixtures__/messageSystem.ts
+++ b/packages/suite/src/utils/suite/__fixtures__/messageSystem.ts
@@ -373,11 +373,8 @@ export const validateVersionCompatibility = [
         version: '34.0.2',
         result: true,
     },
-];
-
-export const validateEnvironmentCompatibility = [
     {
-        description: 'validateEnvironmentCompatibility case 1',
+        description: 'environment validateVersionCompatibility case 1',
         condition: {
             web: '',
             desktop: '0',
@@ -388,7 +385,7 @@ export const validateEnvironmentCompatibility = [
         result: true,
     },
     {
-        description: 'validateEnvironmentCompatibility case 2',
+        description: 'environment validateVersionCompatibility case 2',
         condition: {
             web: '',
             desktop: '0',
@@ -399,19 +396,18 @@ export const validateEnvironmentCompatibility = [
         result: false,
     },
     {
-        description: 'validateEnvironmentCompatibility case 3',
+        description: 'environment validateVersionCompatibility case 3',
         condition: {
             web: '',
             desktop: '0',
             mobile: '!',
         },
-        commitHash: 'fa8eab',
         type: 'desktop',
         version: '0.0.1',
         result: true,
     },
     {
-        description: 'validateEnvironmentCompatibility case 4',
+        description: 'environment validateVersionCompatibility case 4',
         condition: {
             web: '',
             desktop: '0',
@@ -419,45 +415,6 @@ export const validateEnvironmentCompatibility = [
         },
         type: 'mobile',
         version: '0.0.1',
-        result: false,
-    },
-    {
-        description: 'validateEnvironmentCompatibility case 5',
-        condition: {
-            web: '*',
-            desktop: '!',
-            mobile: '!',
-            revision: 'fa8eab',
-        },
-        commitHash: 'fa8eab',
-        type: 'web',
-        version: '22.2.2',
-        result: true,
-    },
-    {
-        description: 'validateEnvironmentCompatibility case 6',
-        condition: {
-            web: '*',
-            desktop: '!',
-            mobile: '!',
-            revision: 'fa8eab',
-        },
-        commitHash: 'hahhah',
-        type: 'web',
-        version: '22.2.2',
-        result: false,
-    },
-    {
-        description: 'validateEnvironmentCompatibility case 7',
-        condition: {
-            web: '*',
-            desktop: '!',
-            mobile: '!',
-            revision: 'fa8eab',
-        },
-        commitHash: undefined,
-        type: 'web',
-        version: '22.2.2',
         result: false,
     },
 ];

--- a/packages/suite/src/utils/suite/__tests__/messageSystem.test.ts
+++ b/packages/suite/src/utils/suite/__tests__/messageSystem.test.ts
@@ -48,32 +48,6 @@ describe('Message system utils', () => {
         });
     });
 
-    describe('validateEnvironmentCompatibility', () => {
-        const OLD_ENV = { ...process.env };
-
-        afterEach(() => {
-            jest.resetModules();
-            process.env = OLD_ENV;
-        });
-
-        fixtures.validateEnvironmentCompatibility.forEach(f => {
-            it(f.description, () => {
-                process.env.COMMITHASH = f.commitHash;
-
-                expect(
-                    // @ts-ignore
-                    messageSystem.validateEnvironmentCompatibility(
-                        f.condition,
-                        // @ts-ignore
-                        f.type,
-                        f.version,
-                        f.commitHash,
-                    ),
-                ).toEqual(f.result);
-            });
-        });
-    });
-
     describe('validateTransportCompatibility', () => {
         fixtures.validateTransportCompatibility.forEach(f => {
             it(f.description, () => {

--- a/packages/suite/src/utils/suite/messageSystem.ts
+++ b/packages/suite/src/utils/suite/messageSystem.ts
@@ -28,6 +28,8 @@ import type {
     Transport,
     Device,
     Environment,
+    Browser,
+    OperatingSystem,
 } from '@suite-types/messageSystem';
 
 type CurrentSettings = {
@@ -73,8 +75,8 @@ export const validateDurationCompatibility = (durationCondition: Duration): bool
 };
 
 export const validateVersionCompatibility = (
-    condition: { [key: string]: Version | undefined },
-    type: string,
+    condition: Browser | OperatingSystem | Environment | Transport,
+    type: string | EnvironmentType,
     version: string,
 ): boolean => {
     const conditionVersion = createVersionRange(condition[type]);
@@ -161,28 +163,6 @@ export const validateDeviceCompatibility = (
     });
 };
 
-export const validateEnvironmentCompatibility = (
-    environmentCondition: Environment,
-    environment: EnvironmentType,
-    suiteVersion: string,
-    commitHash: string | undefined,
-) => {
-    const { revision, desktop, web, mobile } = environmentCondition;
-
-    return (
-        validateVersionCompatibility(
-            {
-                desktop,
-                web,
-                mobile,
-            },
-            environment,
-            suiteVersion,
-        ) &&
-        (revision === commitHash || revision === '*' || revision === undefined)
-    );
-};
-
 export const getValidMessages = (config: MessageSystem | null, options: Options): Message[] => {
     if (!config) {
         return [];
@@ -198,7 +178,6 @@ export const getValidMessages = (config: MessageSystem | null, options: Options)
 
     const environment = getEnvironment();
     const suiteVersion = transformVersionToSemverFormat(process.env.VERSION);
-    const commitHash = process.env.COMMITHASH;
 
     return config.actions
         .filter(
@@ -221,11 +200,10 @@ export const getValidMessages = (config: MessageSystem | null, options: Options)
 
                     if (
                         environmentCondition &&
-                        !validateEnvironmentCompatibility(
+                        !validateVersionCompatibility(
                             environmentCondition,
                             environment,
                             suiteVersion,
-                            commitHash,
                         )
                     ) {
                         return false;


### PR DESCRIPTION
Should remove code from 0f26ab773089d8bcc6249448aa9005c7ea09bc3e which breaks message system in old app versions if revision is used in config.

2aa5f338ebd155472926f70034241e8a254d358a this commit should not contain anything related to revision. PLease check