### PR TITLE
feat(ci): setup codesign builds to run on multiple runners

### DIFF
--- a/ci/build.yml
+++ b/ci/build.yml
@@ -57,7 +57,7 @@ suite-web build stable codesign:
     refs:
       - codesign
   tags:
-    - darwin_arm
+    - darwin
   variables:
     IS_CODESIGN_BUILD: "true"
     ASSET_PREFIX: /web
@@ -144,7 +144,7 @@ suite-desktop build mac:
   only:
     <<: *run_everything_rules
   tags:
-    - darwin_arm
+    - darwin
   variables:
     artifact: ${DESKTOP_APP_NAME}*
     platform: mac
@@ -157,7 +157,7 @@ suite-desktop build mac manual:
   except:
     <<: *run_everything_rules
   tags:
-    - darwin_arm
+    - darwin
   variables:
     artifact: ${DESKTOP_APP_NAME}*
     platform: mac
@@ -170,7 +170,7 @@ suite-desktop build mac codesign:
     refs:
       - codesign
   tags:
-    - darwin_arm
+    - darwin
   variables:
     IS_CODESIGN_BUILD: "true"
     artifact: ${DESKTOP_APP_NAME}*
@@ -209,7 +209,7 @@ suite-desktop build linux codesign:
     refs:
       - codesign
   tags:
-    - darwin_arm
+    - darwin
   variables:
     IS_CODESIGN_BUILD: "true"
     artifact: ${DESKTOP_APP_NAME}*
@@ -250,7 +250,7 @@ suite-desktop build windows codesign:
     refs:
       - codesign
   tags:
-    - darwin_arm
+    - darwin
   image: $CI_DEPENDENCY_PROXY_DIRECT_GROUP_IMAGE_PREFIX/vdovhanych/electron-builder:wine
   variables:
     IS_CODESIGN_BUILD: "true"

--- a/ci/prebuild.yml
+++ b/ci/prebuild.yml
@@ -15,7 +15,7 @@ msg-system config sign stable:
     refs:
       - codesign
   tags:
-    - darwin_arm
+    - darwin
   variables:
     IS_CODESIGN_BUILD: "true"
   script:


### PR DESCRIPTION
After runner0 was reconfigured, I'm returning it to production. From now on, all release/ and codesign builds will run on two runners, thus improving build times of release and codesign pipelines.