### PR TITLE
chore(suite-data): update tor binaries

### DIFF
--- a/packages/suite-data/files/bin/tor/linux-x64/tor
+++ b/packages/suite-data/files/bin/tor/linux-x64/tor
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:ee2f76903ea8f090af8f567bee14dde83873ed45bea8cff51c6c225d572f39c3
-size 21374416
+oid sha256:cb4c2ca060aaf8fc6894e2a41d18e7df587f6ce4c169dd8a4fb0ed91314d0d0e
+size 21387536

--- a/packages/suite-data/files/bin/tor/mac-arm64/tor
+++ b/packages/suite-data/files/bin/tor/mac-arm64/tor
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:8fc22b690da0ef2ba93d1c0a18d4f9dca96c93d1312f253462659d215ae82a91
-size 6377968
+oid sha256:e5bc5e252eab0a85af5334743122abf7bfab53c50f5da55323a2fb5432e524d5
+size 6361824

--- a/packages/suite-data/files/bin/tor/mac-x64/tor
+++ b/packages/suite-data/files/bin/tor/mac-x64/tor
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:a6714abdd2f78c88641411cd27bfa565d4aabe95f650fbc2ec7cc488d2087cf5
-size 6845808
+oid sha256:6830b34b24fc86d353e45e19ce6fb8dd3e544267a2b08977dd916b643100b5de
+size 6846672

--- a/packages/suite-data/files/bin/tor/update.sh
+++ b/packages/suite-data/files/bin/tor/update.sh
@@ -1,8 +1,8 @@
 #!/usr/bin/env bash
 set -e
 
-CRX_VER=1_0_24
-TOR_VER=0.4.6.9
+CRX_VER=1_0_25
+TOR_VER=0.4.6.10
 
 curl https://tor.bravesoftware.com/release/biahpgbdmdkfgndcmfiipgcebobojjkp/extension_${CRX_VER}.crx -o brave-tor-lin.crx
 curl https://tor.bravesoftware.com/release/cldoidikboihgcjfkhdeidbpclkineef/extension_${CRX_VER}.crx -o brave-tor-mac.crx

--- a/packages/suite-data/files/bin/tor/win-x64/tor.exe
+++ b/packages/suite-data/files/bin/tor/win-x64/tor.exe
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:41e5408b3ff314988c859dca7c03d62d6d378f75841f6a7f0a2b37564a872dcf
-size 19533520
+oid sha256:a94f42cc6e0f076292ac051f1cfdb436022421b85dd950da32241fbdd635c554
+size 19537048


### PR DESCRIPTION
0.4.6.9 -> 0.4.6.10

binaries regenerated via `packages/suite-data/files/bin/tor/update.sh`, can be checked via removing the binaries and re-running the script