### PR TITLE
feat: making sure we avoid orphan Tor processes

### DIFF
--- a/packages/request-manager/src/torControlPort.ts
+++ b/packages/request-manager/src/torControlPort.ts
@@ -75,7 +75,11 @@ export class TorControlPort {
                         .toUpperCase();
 
                     this.socket.write(`AUTHENTICATE ${authSignature}\r\n`);
-                    this.socket.write('GETINFO circuit-status\n');
+                    // Section 3.23. TAKEOWNERSHIP in https://gitweb.torproject.org/torspec.git/tree/control-spec.txt
+                    // This command instructs Tor to shut down when this control connection is closed.
+                    // If multiple control connections send the TAKEOWNERSHIP command to a Tor instance, Tor
+                    // will shut down when any of those connections closes.
+                    this.socket.write('TAKEOWNERSHIP\r\n');
                     this.isSocketConnected = true;
                     resolve(true);
                 }


### PR DESCRIPTION
In order to make sure we avoid orphan Tor processes this PR add feature of Tor ownership in 2 ways as it is recommended in the [Tor control-specs](https://gitweb.torproject.org/torspec.git/tree/control-spec.txt)

* 56eaf167387e791f2d73a655f1cb46bfa608fe87 adds `TAKEOWNERSHIP` from Tor ControlPort so when the control port is disconnected the Tor process should end. This makes sure if we start different instance we are killing the other one not only from the [BaseProcess](packages/suite-desktop/src-electron/libs/processes/BaseProcess.ts)  but from Tor.
* 292f32e20bacf53bd32bde5b32d07beaaee250b5 adds property `__OwningControllerProcess` that monitors the electron process so Tor will monitor if that process is running and kill it self when it is not, so we avoid letting the Tor process running suite is not running.

The issues described above should already be solved by [BaseProcess](packages/suite-desktop/src-electron/libs/processes/BaseProcess.ts) but this adds a Tor native way of doing it now that we have ControlPort in place.