### PR TITLE
fix(ci): deploy script to use installed packages on the runner

### DIFF
--- a/packages/suite-web/scripts/s3sync.sh
+++ b/packages/suite-web/scripts/s3sync.sh
@@ -1,5 +1,4 @@
-#! /usr/bin/env nix-shell
-#! nix-shell -i bash -p awscli2
+#!/usr/bin/env bash
 
 # Before first use:
 # Install awscli (pip install awscli)


### PR DESCRIPTION
This should fix deplyoy script for staging, its failing on having two awscli present so lets use the one already installed on the runner. Needs to be cherry-picked to release.
