### PR TITLE
feat(suite): add link to data analytics docs

### DIFF
--- a/docs/analytics/aws.md
+++ b/docs/analytics/aws.md
@@ -1,6 +1,6 @@
 # AWS Analytics: Info
 
-_For a deeper technical writeup of analytics processes intended for developers, please see [README.md](../../packages/analytics/README.md)._
+_For a deeper technical writeup of analytics processes intended for developers, please see [README.md](https://github.com/trezor/trezor-suite/blob/develop/packages/analytics/README.md)._
 
 Trezor Suite can be set to collect real-world data to improve the performance of both web and desktop apps. This anonymous data is only shared by users who have usage data tracking enabled.
 
@@ -12,10 +12,10 @@ Collected data are anonymous. This means that **Suite does not track** personal 
 
 Among the data **not collected** by analytics:
 
--   Device ids
+-   Device IDs
 -   Public keys
 -   Particular amounts
--   Transaction ids
+-   Transaction IDs
 
 When data tracking is enabled, Trezor Suite collects functional information that can be used to directly improve the app, such as:
 

--- a/docs/analytics/index.md
+++ b/docs/analytics/index.md
@@ -40,6 +40,6 @@ Access to the data is limited strictly to the members of the development, securi
 
 -   [AWS](./aws.md)
 -   [Sentry](./sentry.md)
--   [Generic analytics package](../../packages/analytics/README.md)
--   [Suite analytics package](../../packages/suite-analytics/README.md)
-    -   [Events changelog](../../packages/suite-analytics/CHANGELOG.md)
+-   [Generic analytics package](https://github.com/trezor/trezor-suite/blob/develop/packages/analytics/README.md)
+-   [Suite analytics package](https://github.com/trezor/trezor-suite/blob/develop/packages/suite-analytics/README.md)
+    -   [Events changelog](https://github.com/trezor/trezor-suite/blob/develop/packages/suite-analytics/CHANGELOG.md)

--- a/packages/suite/src/constants/suite/urls.ts
+++ b/packages/suite/src/constants/suite/urls.ts
@@ -12,8 +12,7 @@ export const PIN_MANUAL_URL = 'https://wiki.trezor.io/User_manual:Entering_PIN';
 export const DRY_RUN_URL = 'https://wiki.trezor.io/User_manual:Dry-run_recovery';
 export const PASSPHRASE_URL = 'https://wiki.trezor.io/Passphrase';
 export const USER_MANUAL_URL = 'https://wiki.trezor.io/User_manual';
-export const ANALYTICS_DOCS_URL =
-    'https://github.com/trezor/trezor-suite/blob/develop/docs/analytics/index.md';
+export const ANALYTICS_DOCS_URL = 'https://docs.trezor.io/trezor-suite/analytics/';
 export const TOS_URL = 'https://data.trezor.io/legal/wallet-terms.pdf';
 export const TOS_INVITY_URL = 'https://data.trezor.io/legal/invity-terms-of-use.pdf';
 export const SEED_MANUAL_URL = 'https://wiki.trezor.io/Recovery_seed';

--- a/packages/suite/src/constants/suite/urls.ts
+++ b/packages/suite/src/constants/suite/urls.ts
@@ -12,6 +12,8 @@ export const PIN_MANUAL_URL = 'https://wiki.trezor.io/User_manual:Entering_PIN';
 export const DRY_RUN_URL = 'https://wiki.trezor.io/User_manual:Dry-run_recovery';
 export const PASSPHRASE_URL = 'https://wiki.trezor.io/Passphrase';
 export const USER_MANUAL_URL = 'https://wiki.trezor.io/User_manual';
+export const ANALYTICS_DOCS_URL =
+    'https://github.com/trezor/trezor-suite/blob/develop/docs/analytics/index.md';
 export const TOS_URL = 'https://data.trezor.io/legal/wallet-terms.pdf';
 export const TOS_INVITY_URL = 'https://data.trezor.io/legal/invity-terms-of-use.pdf';
 export const SEED_MANUAL_URL = 'https://wiki.trezor.io/Recovery_seed';

--- a/packages/suite/src/support/messages.ts
+++ b/packages/suite/src/support/messages.ts
@@ -1948,7 +1948,7 @@ export default defineMessages({
     TR_ONBOARDING_DATA_COLLECTION_DESCRIPTION: {
         id: 'TR_ONBOARDING_DATA_COLLECTION_DESCRIPTION',
         defaultMessage:
-            'All data is anonymous and is used only for product development purposes. Read more in <a>Terms & Conditions</a>.',
+            'All data is anonymous and is used only for product development purposes. Read more in our <analytics>technical documentation</analytics> and <tos>Terms & Conditions</tos>.',
     },
     TR_EJECT_WALLET: {
         defaultMessage: 'Eject wallet',

--- a/packages/suite/src/views/onboarding/steps/Welcome/components/PreOnboardingSetup/DataAnalytics.tsx
+++ b/packages/suite/src/views/onboarding/steps/Welcome/components/PreOnboardingSetup/DataAnalytics.tsx
@@ -8,7 +8,7 @@ import { CollapsibleBox } from '@suite-components';
 import { Translation } from '@suite-components/Translation';
 import TrezorLink from '@suite-components/TrezorLink'; // Separate import because of circular dep problem. Error: Cannot create styled-component for component: undefined
 import { Box, OnboardingButtonCta } from '@onboarding-components';
-import { TOS_URL } from '@suite-constants/urls';
+import { ANALYTICS_DOCS_URL, TOS_URL } from '@suite-constants/urls';
 
 const Wrapper = styled.div`
     display: flex;
@@ -87,7 +87,7 @@ const collectedData = [
     },
 ];
 
-const DataAnalytics = () => {
+export const DataAnalytics = () => {
     const { goToSubStep, rerun } = useOnboarding();
     const { recovery } = useSelector(state => ({
         recovery: state.recovery,
@@ -123,7 +123,12 @@ const DataAnalytics = () => {
                     <Translation
                         id="TR_ONBOARDING_DATA_COLLECTION_DESCRIPTION"
                         values={{
-                            a: chunks => (
+                            analytics: chunks => (
+                                <StyledTrezorLink variant="underline" href={ANALYTICS_DOCS_URL}>
+                                    {chunks}
+                                </StyledTrezorLink>
+                            ),
+                            tos: chunks => (
                                 <StyledTrezorLink variant="underline" href={TOS_URL}>
                                     {chunks}
                                 </StyledTrezorLink>
@@ -175,5 +180,3 @@ const DataAnalytics = () => {
         </Box>
     );
 };
-
-export default DataAnalytics;

--- a/packages/suite/src/views/onboarding/steps/Welcome/components/PreOnboardingSetup/index.tsx
+++ b/packages/suite/src/views/onboarding/steps/Welcome/components/PreOnboardingSetup/index.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { useOnboarding, useSelector } from '@suite-hooks';
-import DataAnalytics from './DataAnalytics';
+import { DataAnalytics } from './DataAnalytics';
 import SecurityCheck from './SecurityCheck';
 
 const PreOnboardingSetup = () => {


### PR DESCRIPTION
Add a link to technical documentation on data analytics to the onboarding screen.

![Screenshot 2022-05-09 at 14 56 27](https://user-images.githubusercontent.com/42465546/167417471-deb8ec93-1866-4e79-a333-f9be90a6b8d9.png)

