### PR TITLE
Fix/modal guide followup

### DIFF
--- a/packages/components/src/config/variables.ts
+++ b/packages/components/src/config/variables.ts
@@ -29,8 +29,10 @@ export const SCREEN_QUERY = {
 
 export const LAYOUT_SIZE = {
     MENU_SECONDARY_WIDTH: '300px',
+    /** Guide width including border */
     GUIDE_PANEL_WIDTH: '350px',
-    GUIDE_PANEL_CONTENT_WIDTH: '305px',
+    /** Guide width without border */
+    GUIDE_PANEL_CONTENT_WIDTH: '349px',
 } as const;
 
 export const Z_INDEX = {

--- a/packages/suite/src/components/guide/Content.tsx
+++ b/packages/suite/src/components/guide/Content.tsx
@@ -1,23 +1,13 @@
 import React from 'react';
 import styled from 'styled-components';
 
-import { variables } from '@trezor/components';
-
 const Wrapper = styled.div`
     height: 100%;
     padding: 15px 22px 0;
-`;
-
-const WrapperWidth = styled.div`
-    width: ${variables.LAYOUT_SIZE.GUIDE_PANEL_CONTENT_WIDTH};
 `;
 
 type ContentProps = {
     children: React.ReactNode;
 };
 
-export const Content = ({ children }: ContentProps) => (
-    <Wrapper>
-        <WrapperWidth>{children}</WrapperWidth>
-    </Wrapper>
-);
+export const Content = ({ children }: ContentProps) => <Wrapper>{children}</Wrapper>;

--- a/packages/suite/src/components/guide/GuideButton.tsx
+++ b/packages/suite/src/components/guide/GuideButton.tsx
@@ -5,6 +5,7 @@ import { variables } from '@trezor/components';
 import { resolveStaticPath } from '@trezor/utils';
 import { useAnalytics } from '@suite-hooks';
 import { useGuide } from '@guide-hooks';
+import { FreeFocusInside } from 'react-focus-lock';
 
 const Wrapper = styled.button<{ isGuideOpen?: boolean; isModalOpen?: boolean }>`
     display: flex;
@@ -43,18 +44,20 @@ export const GuideButton = () => {
     };
 
     return (
-        <Wrapper
-            isModalOpen={isModalOpen}
-            isGuideOpen={isGuideOpen}
-            data-test="@guide/button-open"
-            onClick={handleButtonClick}
-        >
-            <img
-                src={resolveStaticPath('/images/suite/lightbulb.svg')}
-                width="18"
-                height="18"
-                alt=""
-            />
-        </Wrapper>
+        <FreeFocusInside>
+            <Wrapper
+                isModalOpen={isModalOpen}
+                isGuideOpen={isGuideOpen}
+                data-test="@guide/button-open"
+                onClick={handleButtonClick}
+            >
+                <img
+                    src={resolveStaticPath('/images/suite/lightbulb.svg')}
+                    width="18"
+                    height="18"
+                    alt=""
+                />
+            </Wrapper>
+        </FreeFocusInside>
     );
 };

--- a/packages/suite/src/components/guide/GuideCategories.tsx
+++ b/packages/suite/src/components/guide/GuideCategories.tsx
@@ -19,7 +19,7 @@ const SectionHeading = styled.h3`
 const Nodes = styled.div`
     display: flex;
     flex-wrap: wrap;
-    justify-content: space-between;
+    gap: 10px;
 `;
 
 type GuideCategoriesProps = {

--- a/packages/suite/src/components/guide/GuideCategory.tsx
+++ b/packages/suite/src/components/guide/GuideCategory.tsx
@@ -26,7 +26,7 @@ const SectionHeading = styled.h3`
 const Nodes = styled.div`
     display: flex;
     flex-wrap: wrap;
-    justify-content: space-between;
+    gap: 10px;
 `;
 
 export const GuideCategory = () => {

--- a/packages/suite/src/components/guide/GuideMarkdown.tsx
+++ b/packages/suite/src/components/guide/GuideMarkdown.tsx
@@ -2,16 +2,10 @@ import React, { useEffect } from 'react';
 import { variables } from '@trezor/components';
 import { TrezorLink } from '@suite-components';
 import ReactMarkdown from 'react-markdown';
-import styled, { keyframes } from 'styled-components';
+import styled from 'styled-components';
 import { useGuideOpenNode } from '@guide-hooks';
 
-const DISPLAY_SLOWLY = keyframes`
-    from { opacity: 0.0; }
-    to { opacity: 1.0; }
-`;
-
 const StyledMarkdown = styled.div`
-    animation: ${DISPLAY_SLOWLY} 0.5s ease;
     color: ${props => props.theme.TYPE_LIGHT_GREY};
     font-size: ${variables.FONT_SIZE.SMALL};
     font-weight: ${variables.FONT_WEIGHT.MEDIUM};
@@ -65,7 +59,7 @@ const StyledMarkdown = styled.div`
 `;
 
 interface GuideMarkdownProps {
-    markdown: any;
+    markdown: string | undefined;
 }
 
 export const GuideMarkdown = ({ markdown }: GuideMarkdownProps) => {
@@ -79,28 +73,30 @@ export const GuideMarkdown = ({ markdown }: GuideMarkdownProps) => {
 
     return (
         <StyledMarkdown ref={ref}>
-            <ReactMarkdown
-                components={{
-                    a: ({ children, href }) => {
-                        if (!href) {
-                            console.error(`Missing href in Suite Guide link!`);
-                            return null;
-                        }
+            {markdown && (
+                <ReactMarkdown
+                    components={{
+                        a: ({ children, href }) => {
+                            if (!href) {
+                                console.error(`Missing href in Suite Guide link!`);
+                                return null;
+                            }
 
-                        return href.startsWith('http') ? (
-                            <TrezorLink variant="default" href={href}>
-                                {children}
-                            </TrezorLink>
-                        ) : (
-                            <TrezorLink variant="default" onClick={() => openNodeById(href)}>
-                                {children}
-                            </TrezorLink>
-                        );
-                    },
-                }}
-            >
-                {markdown}
-            </ReactMarkdown>
+                            return href.startsWith('http') ? (
+                                <TrezorLink variant="default" href={href}>
+                                    {children}
+                                </TrezorLink>
+                            ) : (
+                                <TrezorLink variant="default" onClick={() => openNodeById(href)}>
+                                    {children}
+                                </TrezorLink>
+                            );
+                        },
+                    }}
+                >
+                    {markdown}
+                </ReactMarkdown>
+            )}
         </StyledMarkdown>
     );
 };

--- a/packages/suite/src/components/guide/GuideNode.tsx
+++ b/packages/suite/src/components/guide/GuideNode.tsx
@@ -29,7 +29,6 @@ const NodeButton = styled.button`
 
 const PageNodeButton = styled(NodeButton)`
     text-align: left;
-    margin-bottom: 10px;
 `;
 
 const PageNodeButtonIcon = styled(Icon)`
@@ -43,22 +42,25 @@ const Label = styled.div<{ isBold: boolean }>`
         isBold ? variables.FONT_WEIGHT.DEMI_BOLD : variables.FONT_WEIGHT.MEDIUM};
     color: ${props => props.theme.TYPE_DARK_GREY};
     overflow: hidden;
-    line-height: 20px;
+    line-height: 16px;
+    flex: 1;
+    display: flex;
+    flex-direction: column;
+    justify-content: center;
 `;
 
 const CategoryNodeButton = styled(NodeButton)`
     display: flex;
     flex-direction: column;
     justify-content: center;
-    width: 142px;
+    min-width: 140px;
     text-align: center;
-    margin-bottom: 21px;
     height: 120px;
+    flex: 1;
 `;
 
 const Image = styled.img`
     width: 64px;
-    margin-bottom: 8px;
 `;
 
 type GuideNodeProps = {

--- a/packages/suite/src/components/guide/GuidePanel.tsx
+++ b/packages/suite/src/components/guide/GuidePanel.tsx
@@ -56,6 +56,7 @@ const MotionGuide = styled(motion.div)`
     height: 100%;
     border-left: 1px solid ${({ theme }) => theme.STROKE_GREY};
     display: flex;
+    overflow-x: hidden;
 `;
 
 export const GuidePanel = () => {

--- a/packages/suite/src/components/guide/GuidePanel.tsx
+++ b/packages/suite/src/components/guide/GuidePanel.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import styled, { css, keyframes } from 'styled-components';
 import { AnimatePresence, motion } from 'framer-motion';
-import FocusLock from 'react-focus-lock';
+import { FreeFocusInside } from 'react-focus-lock';
 
 import { variables, Backdrop } from '@trezor/components';
 import { useOnce, useSelector } from '@suite-hooks';
@@ -64,17 +64,13 @@ export const GuidePanel = () => {
         activeView: state.guide.view,
     }));
 
-    const { isGuideOpen, isGuideOnTop, isModalOpen, closeGuide } = useGuide();
+    const { isGuideOpen, closeGuide } = useGuide();
 
     // if guide is open, do not animate guide opening if transitioning between onboarding, welcome and suite layout
     const isFirstRender = useOnce(isGuideOpen, false);
 
     return (
-        <FocusLock
-            disabled={!isGuideOpen || (!isGuideOnTop && !isModalOpen)}
-            group="overlay"
-            autoFocus={false}
-        >
+        <FreeFocusInside>
             {isGuideOpen && <StyledBackdrop onClick={closeGuide} />}
 
             <GuideWrapper>
@@ -112,6 +108,6 @@ export const GuidePanel = () => {
                     )}
                 </AnimatePresence>
             </GuideWrapper>
-        </FocusLock>
+        </FreeFocusInside>
     );
 };

--- a/packages/suite/src/components/guide/GuideSearch.tsx
+++ b/packages/suite/src/components/guide/GuideSearch.tsx
@@ -16,7 +16,7 @@ const PageFoundList = styled.div`
     margin-top: 10px;
     display: flex;
     flex-wrap: wrap;
-    justify-content: space-between;
+    gap: 10px;
 `;
 
 const NoResults = styled.p`

--- a/packages/suite/src/components/guide/HeaderBreadcrumb.tsx
+++ b/packages/suite/src/components/guide/HeaderBreadcrumb.tsx
@@ -14,6 +14,7 @@ import type { Category } from '@suite-types/guide';
 const BreadcrumbWrapper = styled.span`
     font-size: ${variables.FONT_SIZE.SMALL};
     font-weight: ${variables.FONT_WEIGHT.MEDIUM};
+    white-space: normal;
 `;
 
 const PreviousCategoryLink = styled(TrezorLink)`

--- a/packages/suite/src/components/guide/SupportFeedbackSelection.tsx
+++ b/packages/suite/src/components/guide/SupportFeedbackSelection.tsx
@@ -15,8 +15,8 @@ import { UpdateState } from '@suite-reducers/desktopUpdateReducer';
 import { FORUM_URL, SUPPORT_URL } from '@suite-constants/urls';
 
 const Section = styled.div`
-    :not(:last-of-type) {
-        margin-bottom: 50px;
+    & + & {
+        margin-top: 50px;
     }
 `;
 
@@ -51,7 +51,7 @@ const StyledLink = styled(Link)`
     width: 100%;
 `;
 
-const Details = styled.p`
+const Details = styled.div`
     padding: 10px 0 0 0;
     font-size: 10px;
     font-weight: ${variables.FONT_WEIGHT.MEDIUM};

--- a/packages/suite/src/components/guide/ViewWrapper.tsx
+++ b/packages/suite/src/components/guide/ViewWrapper.tsx
@@ -1,5 +1,6 @@
 import React, { createContext, useCallback, useState } from 'react';
 import styled from 'styled-components';
+import { variables } from '@trezor/components';
 
 const Wrapper = styled.div`
     background: ${({ theme }) => theme.BG_WHITE};
@@ -7,7 +8,7 @@ const Wrapper = styled.div`
     flex-direction: column;
     overflow-x: hidden;
     overflow-y: scroll;
-    width: 100%;
+    min-width: ${variables.LAYOUT_SIZE.GUIDE_PANEL_CONTENT_WIDTH};
 `;
 
 export const ContentScrolledContext = createContext<boolean>(false);

--- a/packages/suite/src/components/suite/Modal/ModalEnvironment.tsx
+++ b/packages/suite/src/components/suite/Modal/ModalEnvironment.tsx
@@ -1,18 +1,14 @@
 import React from 'react';
 import FocusLock from 'react-focus-lock';
 import { Backdrop } from '@trezor/components';
-import { useGuide } from '@guide-hooks';
 
 type ModalEnvironmentProps = {
     onClickBackdrop?: () => void;
     children: React.ReactNode;
 };
 
-export const ModalEnvironment = ({ onClickBackdrop, children }: ModalEnvironmentProps) => {
-    const { isGuideOpen, isGuideOnTop } = useGuide();
-    return (
-        <FocusLock disabled={isGuideOpen && isGuideOnTop} group="overlay" autoFocus={false}>
-            <Backdrop onClick={() => onClickBackdrop?.()}>{children}</Backdrop>
-        </FocusLock>
-    );
-};
+export const ModalEnvironment = ({ onClickBackdrop, children }: ModalEnvironmentProps) => (
+    <FocusLock autoFocus={false}>
+        <Backdrop onClick={() => onClickBackdrop?.()}>{children}</Backdrop>
+    </FocusLock>
+);

--- a/packages/suite/src/components/suite/SuiteLayout/index.tsx
+++ b/packages/suite/src/components/suite/SuiteLayout/index.tsx
@@ -114,12 +114,12 @@ export const SuiteLayout = ({ children }: SuiteLayoutProps) => {
 
     const isGuideFullHeight = isMobileLayout || isModalOpen;
 
-    const pageWrapperRef = useAnchorRemoving(anchor);
+    const wrapperRef = useAnchorRemoving(anchor);
     const appWrapperRef = useResetScroll(url);
 
     return (
-        <Wrapper>
-            <PageWrapper ref={pageWrapperRef}>
+        <Wrapper ref={wrapperRef}>
+            <PageWrapper>
                 <ModalContextProvider>
                     <Metadata title={title} />
                     <SuiteBanners />


### PR DESCRIPTION
Fixes regarding #5313:

https://github.com/trezor/trezor-suite/commit/2af8f5d6e548123b866c5ee46f9150cccbbd778a - guide panel width and scrollbars fix (please check it on Mac, @tomasklim)
https://github.com/trezor/trezor-suite/commit/e5b44294ccb771171ecf9565284a622cbe675522 - guide article fade-in removed as it caused ugly flashing when opening/closing modal next to opened guide and wasn't working as intended anyway (when the articles loaded slowly, the animation had usually ended before the text appeared)
https://github.com/trezor/trezor-suite/commit/ee7abfd4baf813904dc979eee9c5a26ea93bbe0b - click detection for anchor removal moved one level up (as it was before the previous PR)
https://github.com/trezor/trezor-suite/commit/ec4a2b1d1e40a453c5ee797952a103ba398bdfd8 - guide button and guide panel are now wrapped in `FreeFocusInside` which should hopefully resolve the refocus-to-the-first-modal-input-when-guide-is-opening issue (cc: @dahaca)