### PR TITLE
fix: metadata should not disconnect when internet disconnects

### DIFF
--- a/packages/suite/package.json
+++ b/packages/suite/package.json
@@ -39,7 +39,7 @@
         "ethereumjs-util": "^7.1.3",
         "file-saver": "^2.0.5",
         "framer-motion": "^4.1.17",
-        "google-auth-library": "^7.10.3",
+        "google-auth-library": "^8.0.2",
         "history": "^4.10.1",
         "immer": "^9.0.7",
         "jws": "^4.0.0",

--- a/packages/suite/src/actions/suite/metadataActions.ts
+++ b/packages/suite/src/actions/suite/metadataActions.ts
@@ -155,7 +155,6 @@ const handleProviderError =
                 }),
             );
         }
-
         // handle nicely wrapped errors here
         switch (error.code) {
             // possibly programmer errors
@@ -172,6 +171,7 @@ const handleProviderError =
             case 'AUTH_ERROR':
                 dispatch(disconnectProvider());
                 break;
+            case 'CONNECTIVITY_ERROR':
             default:
                 break;
         }

--- a/packages/suite/src/services/google.ts
+++ b/packages/suite/src/services/google.ts
@@ -287,20 +287,23 @@ class Client {
         if (!forceReload && this.nameIdMap[name]) {
             return this.nameIdMap[name];
         }
-        // request to list files might have already been dispatched and exist as unresolved promise, so wait for it here in that case
-        if (this.listPromise) {
-            await this.listPromise;
-            this.listPromise = undefined; // unset
-            return this.nameIdMap[name];
-        }
-        // refresh nameIdMap
-        const promise = this.list({
-            query: { spaces: 'appDataFolder' },
-        });
 
-        this.listPromise = promise;
-        await this.listPromise;
-        this.listPromise = undefined; // unset
+        try {
+            // request to list files might have already been dispatched and exist as unresolved promise, so wait for it here in that case
+            if (this.listPromise) {
+                await this.listPromise;
+                this.listPromise = undefined; // unset
+                return this.nameIdMap[name];
+            }
+            // refresh nameIdMap
+            this.listPromise = this.list({
+                query: { spaces: 'appDataFolder' },
+            });
+            await this.listPromise;
+        } finally {
+            this.listPromise = undefined; // unset
+        }
+        // request to list files might have already been dispatched and exist as unresolved promise, so wait for it here in that case
 
         return this.nameIdMap[name];
     }

--- a/packages/suite/src/services/suite/metadata/DropboxProvider.ts
+++ b/packages/suite/src/services/suite/metadata/DropboxProvider.ts
@@ -200,6 +200,11 @@ class DropboxProvider extends AbstractMetadataProvider {
             // this should never happen
             message = 'unknown error';
         }
+
+        if (message.includes('Failed to fetch')) {
+            return this.error('CONNECTIVITY_ERROR', 'Internet connection problem');
+        }
+
         // https://www.dropbox.com/developers/documentation/http/documentation#error-handling
         if (err?.status) {
             if (err.status >= 500) {

--- a/packages/suite/src/services/suite/metadata/GoogleProvider.ts
+++ b/packages/suite/src/services/suite/metadata/GoogleProvider.ts
@@ -132,6 +132,9 @@ class GoogleProvider extends AbstractMetadataProvider {
             return this.error('PROVIDER_ERROR', message);
         }
 
+        if (message.includes('Failed to fetch')) {
+            return this.error('CONNECTIVITY_ERROR', 'Internet connection problem');
+        }
         // todo: more fine grained errors for google drive
         // https://developers.google.com/drive/api/v3/handle-errors
         switch (err?.error?.code) {

--- a/packages/suite/src/types/suite/metadata.ts
+++ b/packages/suite/src/types/suite/metadata.ts
@@ -62,6 +62,7 @@ enum ProviderErrorReason {
     PROVIDER_ERROR,
     // common error if none of the above
     OTHER_ERROR,
+    CONNECTIVITY_ERROR,
 }
 
 /**

--- a/yarn.lock
+++ b/yarn.lock
@@ -12531,12 +12531,23 @@ gaxios@^4.0.0:
     is-stream "^2.0.0"
     node-fetch "^2.6.1"
 
-gcp-metadata@^4.2.0:
-  version "4.3.1"
-  resolved "https://registry.yarnpkg.com/gcp-metadata/-/gcp-metadata-4.3.1.tgz#fb205fe6a90fef2fd9c85e6ba06e5559ee1eefa9"
-  integrity sha512-x850LS5N7V1F3UcV7PoupzGsyD6iVwTVvsh3tbXfkctZnBnjW5yu5z1/3k3SehF7TyoTIe78rJs02GMMy+LF+A==
+gaxios@^5.0.0:
+  version "5.0.0"
+  resolved "https://registry.yarnpkg.com/gaxios/-/gaxios-5.0.0.tgz#df11e5d0a45831dd39eb5fbbba0d6a6b09815e70"
+  integrity sha512-VD/yc5ln6XU8Ch1hyYY6kRMBE0Yc2np3fPyeJeYHhrPs1i8rgnsApPMWyrugkl7LLoSqpOJVBWlQIa87OAvt8Q==
   dependencies:
-    gaxios "^4.0.0"
+    abort-controller "^3.0.0"
+    extend "^3.0.2"
+    https-proxy-agent "^5.0.0"
+    is-stream "^2.0.0"
+    node-fetch "^2.6.7"
+
+gcp-metadata@^5.0.0:
+  version "5.0.0"
+  resolved "https://registry.yarnpkg.com/gcp-metadata/-/gcp-metadata-5.0.0.tgz#a00f999f60a4461401e7c515f8a3267cfb401ee7"
+  integrity sha512-gfwuX3yA3nNsHSWUL4KG90UulNiq922Ukj3wLTrcnX33BB7PwB1o0ubR8KVvXu9nJH+P5w1j2SQSNNqto+H0DA==
+  dependencies:
+    gaxios "^5.0.0"
     json-bigint "^1.0.0"
 
 genfun@^5.0.0:
@@ -12914,27 +12925,27 @@ gonzales-pe@^4.3.0:
   dependencies:
     minimist "^1.2.5"
 
-google-auth-library@^7.10.3:
-  version "7.11.0"
-  resolved "https://registry.yarnpkg.com/google-auth-library/-/google-auth-library-7.11.0.tgz#b63699c65037310a424128a854ba7e736704cbdb"
-  integrity sha512-3S5jn2quRumvh9F/Ubf7GFrIq71HZ5a6vqosgdIu105kkk0WtSqc2jGCRqtWWOLRS8SX3AHACMOEDxhyWAQIcg==
+google-auth-library@^8.0.2:
+  version "8.0.2"
+  resolved "https://registry.yarnpkg.com/google-auth-library/-/google-auth-library-8.0.2.tgz#5fa0f2d3795c3e4019d2bb315ade4454cc9c30b5"
+  integrity sha512-HoG+nWFAThLovKpvcbYzxgn+nBJPTfAwtq0GxPN821nOO+21+8oP7MoEHfd1sbDulUFFGfcjJr2CnJ4YssHcyg==
   dependencies:
     arrify "^2.0.0"
     base64-js "^1.3.0"
     ecdsa-sig-formatter "^1.0.11"
     fast-text-encoding "^1.0.0"
-    gaxios "^4.0.0"
-    gcp-metadata "^4.2.0"
-    gtoken "^5.0.4"
+    gaxios "^5.0.0"
+    gcp-metadata "^5.0.0"
+    gtoken "^5.3.2"
     jws "^4.0.0"
     lru-cache "^6.0.0"
 
-google-p12-pem@^3.0.3:
-  version "3.1.3"
-  resolved "https://registry.yarnpkg.com/google-p12-pem/-/google-p12-pem-3.1.3.tgz#5497998798ee86c2fc1f4bb1f92b7729baf37537"
-  integrity sha512-MC0jISvzymxePDVembypNefkAQp+DRP7dBE+zNUPaIjEspIlYg0++OrsNr248V9tPbz6iqtZ7rX1hxWA5B8qBQ==
+google-p12-pem@^3.1.3:
+  version "3.1.4"
+  resolved "https://registry.yarnpkg.com/google-p12-pem/-/google-p12-pem-3.1.4.tgz#123f7b40da204de4ed1fbf2fd5be12c047fc8b3b"
+  integrity sha512-HHuHmkLgwjdmVRngf5+gSmpkyaRI6QmOg77J8tkNBHhNEI62sGHyw4/+UkgyZEI7h84NbWprXDJ+sa3xOYFvTg==
   dependencies:
-    node-forge "^1.0.0"
+    node-forge "^1.3.1"
 
 got@^9.6.0:
   version "9.6.0"
@@ -12973,13 +12984,13 @@ growly@^1.3.0:
   resolved "https://registry.yarnpkg.com/growly/-/growly-1.3.0.tgz#f10748cbe76af964b7c96c93c6bcc28af120c081"
   integrity sha1-8QdIy+dq+WS3yWyTxrzCivEgwIE=
 
-gtoken@^5.0.4:
-  version "5.3.1"
-  resolved "https://registry.yarnpkg.com/gtoken/-/gtoken-5.3.1.tgz#c1c2598a826f2b5df7c6bb53d7be6cf6d50c3c78"
-  integrity sha512-yqOREjzLHcbzz1UrQoxhBtpk8KjrVhuqPE7od1K2uhyxG2BHjKZetlbLw/SPZak/QqTIQW+addS+EcjqQsZbwQ==
+gtoken@^5.3.2:
+  version "5.3.2"
+  resolved "https://registry.yarnpkg.com/gtoken/-/gtoken-5.3.2.tgz#deb7dc876abe002178e0515e383382ea9446d58f"
+  integrity sha512-gkvEKREW7dXWF8NV8pVrKfW7WqReAmjjkMBh6lNCCGOM4ucS0r0YyXXl0r/9Yj8wcW/32ISkfc8h5mPTDbtifQ==
   dependencies:
     gaxios "^4.0.0"
-    google-p12-pem "^3.0.3"
+    google-p12-pem "^3.1.3"
     jws "^4.0.0"
 
 gzip-size@^6.0.0:
@@ -17707,10 +17718,10 @@ node-fetch@^1.0.1:
     encoding "^0.1.11"
     is-stream "^1.0.1"
 
-node-forge@^1.0.0, node-forge@^1.2.0:
-  version "1.3.0"
-  resolved "https://registry.yarnpkg.com/node-forge/-/node-forge-1.3.0.tgz#37a874ea723855f37db091e6c186e5b67a01d4b2"
-  integrity sha512-08ARB91bUi6zNKzVmaj3QO7cr397uiDT2nJ63cHjyNtCTWIgvS47j3eT0WfzUwS9+6Z5YshRaoasFkXCKrIYbA==
+node-forge@^1.2.0, node-forge@^1.3.1:
+  version "1.3.1"
+  resolved "https://registry.yarnpkg.com/node-forge/-/node-forge-1.3.1.tgz#be8da2af243b2417d5f646a770663a92b7e9ded3"
+  integrity sha512-dPEtOeMvF9VMcYV/1Wb8CPoVAXtp6MKMlcbAt4ddqmGqUJ6fQZFXkNZNkNlfevtNkGtaSoXf/vNNNSvgrdXwtA==
 
 node-gyp-build@^4.2.0, node-gyp-build@^4.2.2:
   version "4.3.0"


### PR DESCRIPTION
this should resolve #5187

QA please test before merging:
- [ ] disconnecting internet, doing something with metadata, reconnecting internet -> works normally. no disconnection
- [ ] also this should work -> disconnect interent -> do something, it fails to sync but stays in app memory -> turn on internet and change another different label -> both labels should be synced now in the cloud provider
- [ ] google drive authentication. both web and desktop. this PR updates google-auth-lib by one major version https://github.com/googleapis/google-auth-library-nodejs/blob/main/CHANGELOG.md

possible followups: 
- error handling could be rethought abit
- code cleanup and refactoring could definitely be done here
- syncing after internet connection starts working again could be cleverer. Now you need to edit another label so that those that previously failed sync. 