### PR TITLE
Feat: improve Tor starting and reconnecting

### DIFF
--- a/packages/request-manager/src/__tests__/torControlPort.test.ts
+++ b/packages/request-manager/src/__tests__/torControlPort.test.ts
@@ -1,0 +1,125 @@
+import util from 'util';
+import path from 'path';
+import fs from 'fs';
+import net, { Socket } from 'net';
+
+import type { TorConnectionOptions } from '../types';
+import { createHmacSignature, getCookieString, TorControlPort } from '../torControlPort';
+
+const writeFile = util.promisify(fs.writeFile);
+const existsDirectory = util.promisify(fs.exists);
+const mkdir = util.promisify(fs.mkdir);
+const unlinkFile = util.promisify(fs.unlink);
+
+const authFilePath = path.join(__dirname, 'tmp');
+const controlAuthCookiePath = `${authFilePath}/control_auth_cookie`;
+const host = 'localhost';
+const port = 9998;
+const controlPort = 9999;
+
+describe('TorControlPort', () => {
+    beforeAll(async () => {
+        if (!(await existsDirectory(authFilePath))) {
+            // Make sure there is `authFilePath` directory.
+            mkdir(authFilePath);
+        }
+        await writeFile(controlAuthCookiePath, 'test');
+    });
+
+    afterAll(async () => {
+        await unlinkFile(controlAuthCookiePath);
+    });
+
+    describe('TorControlPort is not connected', () => {
+        it('TorControlPort ping should return false when TOR is not running', () => {
+            const options: TorConnectionOptions = {
+                host,
+                port,
+                controlPort,
+                authFilePath,
+            };
+            const fakeListener = () => {};
+            const torControlPort = new TorControlPort(options, fakeListener);
+            const pingResponse = torControlPort.ping();
+            expect(pingResponse).toEqual(false);
+        });
+    });
+
+    describe('TorControlPort should authorize when connecting', () => {
+        it('Tor control port connects', async () => {
+            let isProperlyAuthenticated = false;
+            const serverHash = '1A6C3485BD58CAF688C5AF98B878E713A6EF0EAC0240D7E3453341689BA7FC60';
+            const serverNonce = '88601906AB5EB92B8CB86E012C0074855E23AA1C79F843BEA5FDE674936E9AB1';
+            const cookieString = await getCookieString(authFilePath);
+            const authenticationKey = 'Tor safe cookie authentication controller-to-server hash';
+
+            let clientNonce = '';
+
+            function torControlPortMock(sock: Socket) {
+                sock.on('data', (data: string) => {
+                    const message = data.toString();
+
+                    const authchallengeRequest = message
+                        .trim()
+                        .match(/^AUTHCHALLENGE SAFECOOKIE ([a-fA-F0-9]+)$/m);
+                    const authenticateRequest = message
+                        .trim()
+                        .match(/^AUTHENTICATE ([a-fA-F0-9]+)$/m);
+                    const providedAuthSignature = authenticateRequest && authenticateRequest[1];
+
+                    const authString = `${cookieString}${clientNonce}${serverNonce}`;
+                    const authSignature = createHmacSignature(authString, authenticationKey);
+
+                    switch (true) {
+                        case !!authenticateRequest:
+                            isProperlyAuthenticated = providedAuthSignature === authSignature;
+                            sock.write('250 OK');
+                            break;
+                        case !!authchallengeRequest:
+                            clientNonce = authchallengeRequest ? authchallengeRequest[1] : '';
+                            sock.write(
+                                `250 AUTHCHALLENGE SERVERHASH=${serverHash} SERVERNONCE=${serverNonce}`,
+                            );
+                            break;
+                        default:
+                    }
+                });
+            }
+
+            const serverControlPort = net.createServer(torControlPortMock);
+            const startListening = () =>
+                new Promise(resolve => {
+                    serverControlPort.listen(controlPort, host, () => {
+                        resolve(1);
+                    });
+                });
+
+            await startListening();
+
+            const options: TorConnectionOptions = {
+                host,
+                port,
+                controlPort,
+                authFilePath,
+            };
+            const fakeListener = () => {};
+            const torControlPort = new TorControlPort(options, fakeListener);
+            await torControlPort.connect();
+            const response = torControlPort.ping();
+            expect(response).toEqual(true);
+            const waitForProperAuth = () =>
+                new Promise(resolve => {
+                    const interval = setInterval(() => {
+                        if (isProperlyAuthenticated) {
+                            clearInterval(interval);
+                            resolve(isProperlyAuthenticated);
+                        }
+                    }, 100);
+                });
+            expect(await waitForProperAuth()).toEqual(true);
+
+            serverControlPort.close();
+            torControlPort.socket.destroy();
+        });
+    });
+});

--- a/packages/request-manager/src/events/bootstrap.ts
+++ b/packages/request-manager/src/events/bootstrap.ts
@@ -1,0 +1,27 @@
+// Section 4.1.10. Status events in https://gitweb.torproject.org/torspec.git/tree/control-spec.txt
+
+import type { BootstrapEvent } from '../types';
+
+const clientStatusGroupParser = (message: string): RegExpMatchArray | null =>
+    message.trim().match(/^(^650 STATUS_CLIENT NOTICE BOOTSTRAP PROGRESS=.*)+/gm);
+
+const statusParser = (status: string): RegExpMatchArray | null =>
+    status.trim().match(/^650 STATUS_CLIENT NOTICE BOOTSTRAP (PROGRESS=(?<progress>\d+)?.*)?/);
+
+export const bootstrapParser = (message: string): BootstrapEvent[] => {
+    const clientStatusGroups = clientStatusGroupParser(message);
+    if (!clientStatusGroups) {
+        return [];
+    }
+
+    return clientStatusGroups.map(clientStatus => {
+        const clientStatusParsed = statusParser(clientStatus);
+        return {
+            progress: clientStatusParsed?.groups?.progress ?? '',
+        };
+    });
+};
+
+export enum BootstrapEventProgress {
+    Done = '100',
+}

--- a/packages/request-manager/src/types.ts
+++ b/packages/request-manager/src/types.ts
@@ -4,3 +4,7 @@ export interface TorConnectionOptions {
     controlPort: number;
     authFilePath: string;
 }
+
+export type BootstrapEvent = {
+    progress: string | undefined;
+};


### PR DESCRIPTION
Closes [5140](https://github.com/trezor/trezor-suite/issues/5140)

* 3cd0f70f83f1087f999db272a92bb015baf7d129 - listen to "STATUS_CLIENT" bootstrap to make sure with know that Tor is not only active but available to be used, it makes that connection and re-connections works faster since it starts when the circuit is really available and avoiding fails and timeouts.
* 066858fbbf06207d70b9c13aa9a83f3327152423 - just extracting a separate function so it can be used for example in tests without duplication
* 885cb476f3291cbb4e3eb6eb012d4f380ef0036e - some simple tests to make sure the authentication for connection with Tor ControlPort is working properly