### PR TITLE
chore(connect): enums in arrays as strings

### DIFF
--- a/packages/connect/src/utils/__tests__/deviceFeaturesUtils.test.ts
+++ b/packages/connect/src/utils/__tests__/deviceFeaturesUtils.test.ts
@@ -76,25 +76,16 @@ describe('utils/deviceFeaturesUtils', () => {
 
         // bitcoin only
         expect(
+            // @ts-expect-error incomplete features
             parseCapabilities({
                 major_version: 1,
-                // @ts-expect-error - wrong/legacy decoding of capabilities in @trezor/transport
-                capabilities: [1],
+                capabilities: ['Capability_Bitcoin'],
             }),
         ).toEqual(['Capability_Bitcoin']);
 
         // no features
         // @ts-expect-error
         expect(parseCapabilities(null)).toEqual([]);
-
-        // unknown
-        expect(
-            parseCapabilities({
-                major_version: 1,
-                // @ts-expect-error - wrong/legacy decoding of capabilities in @trezor/transport
-                capabilities: [1000],
-            }),
-        ).toEqual([]);
     });
 
     describe('getUnavailableCapabilities', () => {

--- a/packages/connect/src/utils/deviceFeaturesUtils.ts
+++ b/packages/connect/src/utils/deviceFeaturesUtils.ts
@@ -29,25 +29,13 @@ const DEFAULT_CAPABILITIES_TT: PROTO.Capability[] = [
     'Capability_U2F',
 ];
 
-//  It should return [Capability_Bitcoin], instead it returns [1]
 export const parseCapabilities = (features?: Features): PROTO.Capability[] => {
     if (!features || features.firmware_present === false) return []; // no features or no firmware - no capabilities
     // fallback for older firmware that does not report capabilities
     if (!features.capabilities || !features.capabilities.length) {
         return features.major_version === 1 ? DEFAULT_CAPABILITIES_T1 : DEFAULT_CAPABILITIES_TT;
     }
-    // TODO: https://github.com/trezor/trezor-suite/issues/5299
-    // @trezor/transport is not parsing enums in arrays correctly. this part of code can be removed
-    // once this is fixed in @trezor/transport
-    // regular capabilities
-    return features.capabilities.flatMap(c => {
-        const capabilityName = Object.values(PROTO.Enum_Capability).find(
-            capability => c === capability,
-        );
-        return capabilityName
-            ? [PROTO.Enum_Capability[capabilityName as PROTO.Enum_Capability]]
-            : [];
-    }) as PROTO.Capability[];
+    return features.capabilities;
 };
 
 // TODO: support type

--- a/packages/transport/tests/encode-decode.test.js
+++ b/packages/transport/tests/encode-decode.test.js
@@ -446,8 +446,7 @@ const fixtures = [
         },
         in: { capabilities: ['Capability_Bitcoin'], safety_checks: 'Strict' },
         encoded: 'f00101a80200',
-        // [compatibility]: enums in arrays are not decoded
-        out: { capabilities: [1], safety_checks: 'Strict' },
+        out: { capabilities: ['Capability_Bitcoin'], safety_checks: 'Strict' },
     },
     {
         name: 'CardanoTxWitnessRequest',


### PR DESCRIPTION
For legacy reasons, transport used to decode enums in arrays as numbers while other (not in array) enums used to be decoded as strings. 

This PR unifies decoding all enums as strings. 