### PR TITLE
release(connect-common): @trezor/connect-common@0.0.6

### DIFF
--- a/packages/connect-common/CHANGELOG.md
+++ b/packages/connect-common/CHANGELOG.md
@@ -1,3 +1,17 @@
+# 0.0.6
+
+### Added
+
+-   1.11.1 & 2.5.1 FW, (1.11.0 BL)
+-   [storage utils](./src/storage) moved from standalone Connect repository
+-   [coins.json](./files/coins.json) moved from standalone Connect repository
+
+# 0.0.5
+
+### Added
+
+-   1.11.0 & 2.5.0 FW
+
 # 0.0.4
 
 ### Added

--- a/packages/connect-common/files/firmware/1/releases.json
+++ b/packages/connect-common/files/firmware/1/releases.json
@@ -2,7 +2,7 @@
     {
         "required": false,
         "version": [1, 11, 1],
-        "bootloader_version": [1, 10, 0],
+        "bootloader_version": [1, 11, 0],
         "min_bridge_version": [2, 0, 25],
         "min_firmware_version": [1, 6, 2],
         "min_bootloader_version": [1, 5, 0],

--- a/packages/connect-common/package.json
+++ b/packages/connect-common/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@trezor/connect-common",
-    "version": "0.0.4",
+    "version": "0.0.6",
     "author": "Trezor <info@trezor.io>",
     "homepage": "https://github.com/trezor/trezor-suite/packages/connect-common",
     "keywords": [


### PR DESCRIPTION
- 1.11.1 & 2.5.1 FW and 1.11.0 BL