### PR TITLE
fix: fix ts refs generator parse error

### DIFF
--- a/packages/connect-plugin-ethereum/tsconfig.json
+++ b/packages/connect-plugin-ethereum/tsconfig.json
@@ -1,0 +1,6 @@
+{
+    "extends": "../../tsconfig.json",
+    "compilerOptions": { "outDir": "./libDev" },
+    "include": ["."],
+    "references": []
+}

--- a/packages/connect-web/tsconfig.json
+++ b/packages/connect-web/tsconfig.json
@@ -9,18 +9,12 @@
             "jest"
         ],
         "rootDir": ".."
-        // "module": "CommonJS"
     },
     "include": [
         "./connect-web",
         "../connect-iframe/webpack/prod.webpack.config.ts",
         "../connect-popup/webpack/prod.webpack.config.ts"
     ],
-    // "ts-node": {
-    //     "compilerOptions": {
-    //         "module": "CommonJS"
-    //     }
-    // },
     "references": [
         { "path": "../connect" },
         { "path": "../utils" }

--- a/packages/connect/tsconfig.json
+++ b/packages/connect/tsconfig.json
@@ -1,8 +1,6 @@
 {
     "extends": "../../tsconfig.json",
-    "compilerOptions": {
-        "outDir": "libDev"
-    },
+    "compilerOptions": { "outDir": "libDev" },
     "references": [
         { "path": "../blockchain-link" },
         { "path": "../transport" },

--- a/scripts/updateProjectReferences.js
+++ b/scripts/updateProjectReferences.js
@@ -28,8 +28,14 @@ import chalk from 'chalk';
         printWidth: 50,
     };
 
-    const serializeConfig = config =>
-        prettier.format(JSON.stringify(config).replace(/\\\\/g, '/'), prettierConfig);
+    const serializeConfig = config => {
+        try {
+            return prettier.format(JSON.stringify(config).replace(/\\\\/g, '/'), prettierConfig);
+        } catch (error) {
+            console.error(error);
+            process.exit(1);
+        }
+    };
 
     const workspaces = JSON.parse(
         JSON.parse(execSync('yarn workspaces --json info').toString()).data,
@@ -92,7 +98,7 @@ import chalk from 'chalk';
 
             if (isTesting) {
                 if (
-                    serializeConfig(workspaceConfig.references) !==
+                    serializeConfig(workspaceConfig.references ?? []) !==
                     serializeConfig(nextWorkspaceReferences)
                 ) {
                     console.error(


### PR DESCRIPTION
Comments in tsconfig will break ts project references generator. Sadly script did not thrown on CI because on syntax error it did not end process with code 1, so CI passed. This should be fixed too.