### PR TITLE
Feat/5076 onion first

### DIFF
--- a/packages/blockchain-link/src/index.ts
+++ b/packages/blockchain-link/src/index.ts
@@ -102,7 +102,7 @@ class BlockchainLink extends EventEmitter {
         return dfd.promise as Promise<R>;
     }
 
-    connect(): Promise<void> {
+    connect(): Promise<boolean> {
         return this.sendMessage({
             type: MESSAGES.CONNECT,
         });

--- a/packages/blockchain-link/src/workers/utils.ts
+++ b/packages/blockchain-link/src/workers/utils.ts
@@ -45,3 +45,25 @@ export const transformTarget = (target: VinVout, incoming: VinVout[]) => ({
     coinbase: target.coinbase,
     isAccountTarget: incoming.includes(target) ? true : undefined,
 });
+
+const IS_ONION = /\.onion([/:].*)?$/i;
+const IS_LOCALHOST = /^(\w*:\/\/)?(localhost|127\.0\.0\.1)([/:].*)?$/i;
+
+/**
+ * Sorts array of backend urls so the localhost addresses are first,
+ * then onion addresses and then the rest. Apart from that it will
+ * be shuffled randomly.
+ */
+export const prioritizeEndpoints = (urls: string[]) =>
+    urls
+        .map((url): [string, number] => {
+            let prio = Math.random();
+            if (IS_LOCALHOST.test(url)) {
+                prio += 2;
+            } else if (IS_ONION.test(url)) {
+                prio += 1;
+            }
+            return [url, prio];
+        })
+        .sort(([, a], [, b]) => b - a)
+        .map(([url]) => url);

--- a/packages/blockchain-link/tests/unit/fixtures/utils.ts
+++ b/packages/blockchain-link/tests/unit/fixtures/utils.ts
@@ -35,977 +35,986 @@ const FEES = {
     fees: '10',
 };
 
-export default {
-    filterTargets: [
-        {
-            description: 'addresses as string',
-            addresses: 'A',
-            targets: [{ addresses: ['A'] }, { addresses: ['B'] }],
-            parsed: [{ addresses: ['A'] }],
-        },
-        {
-            description: 'addresses as array of strings',
-            addresses: ['A'],
-            targets: [{ addresses: ['A'] }, { addresses: ['B'] }],
-            parsed: [{ addresses: ['A'] }],
-        },
-        {
-            description: 'addresses as array of mixed objects',
-            addresses: [
-                'A',
-                1,
-                undefined,
-                'C',
-                { address: 'B', path: '', transfers: 0, decimal: 0 },
-            ],
-            targets: [{ addresses: ['A'] }, { addresses: ['B'] }],
-            parsed: [{ addresses: ['A'] }, { addresses: ['B'] }],
-        },
-        {
-            description: 'targets not found',
-            addresses: 'A',
-            targets: [{ addresses: ['B'] }, { addresses: ['C'] }],
-            parsed: [],
-        },
-        {
-            description: 'addresses as unexpected object (number)',
-            addresses: 1,
-            targets: [{ addresses: ['A'] }],
-            parsed: [],
-        },
-        {
-            description: 'addresses as unexpected object (null)',
-            addresses: null,
-            targets: [{ addresses: ['A'] }],
-            parsed: [],
-        },
-        {
-            description: 'addresses as unexpected object (array of numbers)',
-            addresses: [1],
-            targets: [{ addresses: ['A'] }],
-            parsed: [],
-        },
-        {
-            description: 'addresses as unexpected object (array of unexpected objects)',
-            addresses: [{ foo: 'bar' }],
-            targets: [{ addresses: ['A'] }],
-            parsed: [],
-        },
-        {
-            description: 'targets as unexpected object (string)',
-            addresses: 'A',
-            targets: 'A',
-            parsed: [],
-        },
-        {
-            description: 'targets as unexpected object (null)',
-            addresses: 'A',
-            targets: null,
-            parsed: [],
-        },
-        {
-            description: 'targets as unexpected object (array of unexpected objects)',
-            addresses: 'A',
-            targets: ['A', null, 1, {}],
-            parsed: [],
-        },
-    ],
-    filterTokenTransfers: [
-        {
-            description: 'transfer recv',
-            addresses: 'B',
-            transfers: tokenTransfers,
-            parsed: [
-                {
-                    ...tOut,
-                    type: 'recv',
-                    from: 'A',
-                    to: 'B',
-                },
-            ],
-        },
-        {
-            description: 'transfer self',
-            addresses: 'X',
-            transfers: tokenTransfers,
-            parsed: [
-                {
-                    ...tOut,
-                    type: 'self',
-                    from: 'X',
-                    to: 'X',
-                },
-            ],
-        },
-        {
-            description: 'sent: addresses as string',
-            addresses: 'A',
-            transfers: tokenTransfers,
-            parsed: [
-                {
-                    ...tOut,
-                    type: 'sent',
-                    from: 'A',
-                    to: 'B',
-                },
-            ],
-        },
-        {
-            description: 'sent: addresses as array of strings',
-            addresses: ['A'],
-            transfers: tokenTransfers,
-            parsed: [
-                {
-                    ...tOut,
-                    type: 'sent',
-                    from: 'A',
-                    to: 'B',
-                },
-            ],
-        },
-        {
-            description: 'addresses as array of mixed objects (sent/recv/sent)',
-            addresses: ['A', 1, undefined, 'X', { address: 'D' }, 'NOT_FOUND'],
-            transfers: tokenTransfers,
-            parsed: [
-                {
-                    ...tOut,
-                    type: 'sent',
-                    from: 'A',
-                    to: 'B',
-                },
-                {
-                    ...tOut,
-                    type: 'recv',
-                    from: 'C',
-                    to: 'D',
-                },
-                {
-                    ...tOut,
-                    type: 'self',
-                    from: 'X',
-                    to: 'X',
-                },
-            ],
-        },
-        {
-            description: 'sent: addresses as Address object',
-            addresses: [{ address: 'A' }],
-            transfers: tokenTransfers,
-            parsed: [
-                {
-                    ...tOut,
-                    type: 'sent',
-                    from: 'A',
-                    to: 'B',
-                },
-            ],
-        },
-        {
-            description: 'addresses as unexpected object (number)',
-            addresses: 1,
-            transfers: tokenTransfers,
-            parsed: [],
-        },
-        {
-            description: 'addresses as unexpected object (null)',
-            addresses: null,
-            transfers: tokenTransfers,
-            parsed: [],
-        },
-        {
-            description: 'addresses as unexpected object (array of numbers)',
-            addresses: [1],
-            transfers: tokenTransfers,
-            parsed: [],
-        },
-        {
-            description: 'addresses as unexpected object (array of unexpected objects)',
-            addresses: [{ foo: 'bar' }],
-            transfers: tokenTransfers,
-            parsed: [],
-        },
-        {
-            description: 'transfers as unexpected object (string)',
-            addresses: 'A',
-            transfers: 'A',
-            parsed: [],
-        },
-        {
-            description: 'transfers as unexpected object (null)',
-            addresses: 'A',
-            transfers: null,
-            parsed: [],
-        },
-        {
-            description: 'transfers as unexpected object (empty array)',
-            addresses: 'A',
-            transfers: [],
-            parsed: [],
-        },
-        {
-            description: 'transfers as unexpected object (array of unexpected objects)',
-            addresses: 'A',
-            transfers: ['A', null, 1, {}],
-            parsed: [],
-        },
-    ],
-    transformTransaction: [
-        {
-            description: 'BTC: recv from one input to unused address',
-            descriptor: 'xpub',
-            addresses: {
-                used: [],
-                unused: ['A'],
-                change: [],
-            },
-            tx: {
-                vin: [
-                    {
-                        addresses: ['B'],
-                        value: '100',
-                    },
-                ],
-                vout: [
-                    {
-                        value: '50',
-                        addresses: ['B-change'],
-                    },
-                    {
-                        addresses: ['A'],
-                        value: '40',
-                    },
-                ],
-                ...FEES,
-            },
-            parsed: {
+export const filterTargets = [
+    {
+        description: 'addresses as string',
+        addresses: 'A',
+        targets: [{ addresses: ['A'] }, { addresses: ['B'] }],
+        parsed: [{ addresses: ['A'] }],
+    },
+    {
+        description: 'addresses as array of strings',
+        addresses: ['A'],
+        targets: [{ addresses: ['A'] }, { addresses: ['B'] }],
+        parsed: [{ addresses: ['A'] }],
+    },
+    {
+        description: 'addresses as array of mixed objects',
+        addresses: ['A', 1, undefined, 'C', { address: 'B', path: '', transfers: 0, decimal: 0 }],
+        targets: [{ addresses: ['A'] }, { addresses: ['B'] }],
+        parsed: [{ addresses: ['A'] }, { addresses: ['B'] }],
+    },
+    {
+        description: 'targets not found',
+        addresses: 'A',
+        targets: [{ addresses: ['B'] }, { addresses: ['C'] }],
+        parsed: [],
+    },
+    {
+        description: 'addresses as unexpected object (number)',
+        addresses: 1,
+        targets: [{ addresses: ['A'] }],
+        parsed: [],
+    },
+    {
+        description: 'addresses as unexpected object (null)',
+        addresses: null,
+        targets: [{ addresses: ['A'] }],
+        parsed: [],
+    },
+    {
+        description: 'addresses as unexpected object (array of numbers)',
+        addresses: [1],
+        targets: [{ addresses: ['A'] }],
+        parsed: [],
+    },
+    {
+        description: 'addresses as unexpected object (array of unexpected objects)',
+        addresses: [{ foo: 'bar' }],
+        targets: [{ addresses: ['A'] }],
+        parsed: [],
+    },
+    {
+        description: 'targets as unexpected object (string)',
+        addresses: 'A',
+        targets: 'A',
+        parsed: [],
+    },
+    {
+        description: 'targets as unexpected object (null)',
+        addresses: 'A',
+        targets: null,
+        parsed: [],
+    },
+    {
+        description: 'targets as unexpected object (array of unexpected objects)',
+        addresses: 'A',
+        targets: ['A', null, 1, {}],
+        parsed: [],
+    },
+];
+
+export const filterTokenTransfers = [
+    {
+        description: 'transfer recv',
+        addresses: 'B',
+        transfers: tokenTransfers,
+        parsed: [
+            {
+                ...tOut,
                 type: 'recv',
-                amount: '40',
-                targets: [
-                    {
-                        addresses: ['A'],
-                    },
-                ],
+                from: 'A',
+                to: 'B',
             },
-        },
-        {
-            description: 'BTC: recv from one input to used address',
-            descriptor: 'xpub',
-            addresses: {
-                used: ['A'],
-                unused: [],
-                change: [],
-            },
-            tx: {
-                vin: [
-                    {
-                        addresses: ['B'],
-                        value: '100',
-                    },
-                ],
-                vout: [
-                    {
-                        value: '50',
-                        addresses: ['B-change'],
-                    },
-                    {
-                        addresses: ['A'],
-                        value: '40',
-                    },
-                ],
-                ...FEES,
-            },
-            parsed: {
-                type: 'recv',
-                amount: '40',
-                targets: [
-                    {
-                        addresses: ['A'],
-                    },
-                ],
-            },
-        },
-        {
-            description: 'BTC: recv from one input to change address',
-            descriptor: 'xpub',
-            addresses: {
-                used: [],
-                unused: [],
-                change: ['A'],
-            },
-            tx: {
-                vin: [
-                    {
-                        addresses: ['B'],
-                        value: '100',
-                    },
-                ],
-                vout: [
-                    {
-                        value: '50',
-                        addresses: ['B-change'],
-                    },
-                    {
-                        addresses: ['A'],
-                        value: '40',
-                    },
-                ],
-                ...FEES,
-            },
-            parsed: {
-                type: 'recv',
-                amount: '40',
-                targets: [
-                    {
-                        addresses: ['A'],
-                    },
-                ],
-            },
-        },
-        {
-            description: 'BTC: recv from 2 inputs to multiple addresses',
-            descriptor: 'xpub',
-            addresses: {
-                used: ['A', 'B'],
-                unused: ['C', 'D'],
-                change: [],
-            },
-            tx: {
-                vin: [
-                    {
-                        addresses: ['utxo1', 'utxo2'],
-                        value: '50',
-                    },
-                    {
-                        addresses: ['utxo3'],
-                        value: '50',
-                    },
-                ],
-                vout: [
-                    {
-                        addresses: ['A'],
-                        value: '20',
-                    },
-                    {
-                        addresses: ['C'],
-                        value: '20',
-                    },
-                    {
-                        addresses: ['B', 'D'],
-                        value: '20',
-                    },
-                    {
-                        addresses: ['utxo1-change'],
-                        value: '15',
-                    },
-                    {
-                        addresses: ['utxo3-change'],
-                        value: '15',
-                    },
-                ],
-                ...FEES,
-            },
-            parsed: {
-                type: 'recv',
-                amount: '60',
-                targets: [
-                    {
-                        addresses: ['A'],
-                    },
-                    {
-                        addresses: ['C'],
-                    },
-                    {
-                        addresses: ['B', 'D'],
-                    },
-                ],
-            },
-        },
-        {
-            description: 'recv coinbase',
-            descriptor: 'A',
-            tx: {
-                vin: [
-                    {
-                        coinbase: 'ABCD',
-                    },
-                ],
-                vout: [
-                    {
-                        addresses: ['A'],
-                    },
-                ],
-            },
-            parsed: {
-                type: 'recv',
-                targets: [
-                    {
-                        addresses: ['A'],
-                    },
-                ],
-            },
-        },
-        {
-            description: 'recv coinbase with multiple addresses',
-            descriptor: 'xpub',
-            addresses: {
-                used: ['utxo'],
-                unused: ['A', 'D', 'E'],
-                change: ['change'],
-            },
-            tx: {
-                vin: [
-                    {
-                        coinbase: 'ABCD',
-                    },
-                ],
-                vout: [
-                    {
-                        addresses: ['A'],
-                    },
-                    {
-                        addresses: ['B'],
-                    },
-                    {
-                        addresses: ['C'],
-                    },
-                    {
-                        addresses: ['D', 'E'],
-                    },
-                ],
-            },
-            parsed: {
-                type: 'recv',
-                targets: [
-                    {
-                        addresses: ['A'],
-                    },
-                    {
-                        addresses: ['D', 'E'],
-                    },
-                ],
-            },
-        },
-        {
-            description: 'recv without address',
-            descriptor: 'A',
-            tx: {
-                vin: [
-                    {
-                        addresses: [],
-                    },
-                ],
-                vout: [
-                    {
-                        addresses: ['A'],
-                    },
-                ],
-            },
-            parsed: {
-                type: 'recv',
-                targets: [
-                    {
-                        addresses: ['A'],
-                    },
-                ],
-            },
-        },
-        {
-            description: 'recv with no input (vin is undefined)',
-            descriptor: 'A',
-            tx: {
-                vout: [
-                    {
-                        addresses: ['A'],
-                    },
-                ],
-            },
-            parsed: {
-                type: 'recv',
-                targets: [
-                    {
-                        addresses: ['A'],
-                    },
-                ],
-            },
-        },
-        {
-            description: 'recv with no input (vin is empty)',
-            descriptor: 'A',
-            tx: {
-                vin: [],
-                vout: [
-                    {
-                        addresses: ['A'],
-                    },
-                ],
-            },
-            parsed: {
-                type: 'recv',
-                targets: [
-                    {
-                        addresses: ['A'],
-                    },
-                ],
-            },
-        },
-        {
-            description: 'recv with no input (vin is invalid type)',
-            descriptor: 'A',
-            tx: {
-                vin: 1,
-                vout: [
-                    {
-                        addresses: ['A'],
-                    },
-                ],
-            },
-            parsed: {
-                type: 'recv',
-                targets: [
-                    {
-                        addresses: ['A'],
-                    },
-                ],
-            },
-        },
-        {
-            description: 'recv with no input (vin item is invalid type)',
-            descriptor: 'A',
-            tx: {
-                vin: [1],
-                vout: [
-                    {
-                        addresses: ['A'],
-                    },
-                ],
-            },
-            parsed: {
-                type: 'recv',
-                targets: [
-                    {
-                        addresses: ['A'],
-                    },
-                ],
-            },
-        },
-        {
-            description: 'BTC: sent to one address with change',
-            descriptor: 'xpub',
-            addresses: {
-                used: ['A'],
-                unused: [],
-                change: ['A-change'],
-            },
-            tx: {
-                vin: [
-                    {
-                        addresses: ['A'],
-                        value: '100',
-                    },
-                ],
-                vout: [
-                    {
-                        value: '50',
-                        addresses: ['A-change'],
-                    },
-                    {
-                        addresses: ['B'],
-                        value: '40',
-                    },
-                ],
-                ...FEES,
-            },
-            parsed: {
-                type: 'sent',
-                amount: '40',
-                totalSpent: '50', // B.value + fee
-                targets: [
-                    {
-                        addresses: ['B'],
-                    },
-                ],
-            },
-        },
-        {
-            description: 'BTC: sent to multiple addresses with change',
-            descriptor: 'xpub',
-            addresses: {
-                used: ['A'],
-                unused: ['A2'],
-                change: ['A-change'],
-            },
-            tx: {
-                vin: [
-                    {
-                        addresses: ['A'],
-                        value: '100',
-                    },
-                ],
-                vout: [
-                    {
-                        value: '50',
-                        addresses: ['A-change'],
-                    },
-                    {
-                        addresses: ['A2'],
-                        value: '20',
-                    },
-                    {
-                        addresses: ['B'],
-                        value: '20',
-                    },
-                ],
-                ...FEES,
-            },
-            parsed: {
-                type: 'sent',
-                amount: '20',
-                totalSpent: '30', // B.value + fee
-                targets: [
-                    {
-                        addresses: ['A2'],
-                    },
-                    {
-                        addresses: ['B'],
-                    },
-                ],
-            },
-        },
-        {
-            description: 'BTC: sent to myself (1 input, 1 change output)',
-            descriptor: 'xpub',
-            addresses: {
-                used: ['utxo'],
-                unused: [],
-                change: ['change'],
-            },
-            tx: {
-                vin: [
-                    {
-                        addresses: ['utxo'],
-                    },
-                ],
-                vout: [
-                    {
-                        addresses: ['change'],
-                    },
-                ],
-                ...FEES,
-            },
-            parsed: {
+        ],
+    },
+    {
+        description: 'transfer self',
+        addresses: 'X',
+        transfers: tokenTransfers,
+        parsed: [
+            {
+                ...tOut,
                 type: 'self',
-                amount: '10', // only fee
-                targets: [{ addresses: ['change'] }],
+                from: 'X',
+                to: 'X',
             },
-        },
-
-        {
-            description: 'ETH: sent with final fee',
-            descriptor: 'A',
-            tx: {
-                vin: [
-                    {
-                        addresses: ['A'],
-                    },
-                ],
-                vout: [
-                    {
-                        addresses: ['B'],
-                    },
-                ],
-                ethereumSpecific: {
-                    status: 1,
-                    gasLimit: 21000,
-                    gasUsed: 21000,
-                    gasPrice: 3,
-                },
-                ...FEES,
-            },
-            parsed: {
+        ],
+    },
+    {
+        description: 'sent: addresses as string',
+        addresses: 'A',
+        transfers: tokenTransfers,
+        parsed: [
+            {
+                ...tOut,
                 type: 'sent',
-                amount: '90',
-                fee: '10', // fee from blockbook, not calculated from ethereumSpecific
-                targets: [
-                    {
-                        addresses: ['B'],
-                    },
-                ],
+                from: 'A',
+                to: 'B',
             },
-        },
-        {
-            description: 'ETH: pending with not final fee',
-            descriptor: 'A',
-            tx: {
-                vin: [
-                    {
-                        addresses: ['A'],
-                    },
-                ],
-                vout: [
-                    {
-                        addresses: ['B'],
-                    },
-                ],
-                ethereumSpecific: {
-                    status: 1,
-                    gasLimit: 21000,
-                    gasPrice: '3',
-                },
-                ...FEES,
-            },
-            parsed: {
+        ],
+    },
+    {
+        description: 'sent: addresses as array of strings',
+        addresses: ['A'],
+        transfers: tokenTransfers,
+        parsed: [
+            {
+                ...tOut,
                 type: 'sent',
-                fee: '63000', // fee calculated from ethereumSpecific
-                targets: [
-                    {
-                        addresses: ['B'],
-                    },
-                ],
+                from: 'A',
+                to: 'B',
             },
-        },
-
-        {
-            description: 'sent OP_RETURN with change',
-            descriptor: 'A',
-            addresses: {
-                used: ['utxo'],
-                unused: [],
-                change: ['change'],
-            },
-            tx: {
-                vin: [
-                    {
-                        addresses: ['utxo'],
-                    },
-                ],
-                vout: [
-                    {
-                        addresses: ['change'],
-                    },
-                    {
-                        value: '0',
-                        addresses: ['OP_RETURN deadbeef'],
-                        isAddress: false,
-                    },
-                ],
-            },
-            parsed: {
+        ],
+    },
+    {
+        description: 'addresses as array of mixed objects (sent/recv/sent)',
+        addresses: ['A', 1, undefined, 'X', { address: 'D' }, 'NOT_FOUND'],
+        transfers: tokenTransfers,
+        parsed: [
+            {
+                ...tOut,
                 type: 'sent',
-                targets: [
-                    {
-                        amount: '0',
-                        addresses: ['OP_RETURN deadbeef'],
-                        isAddress: false,
-                    },
-                ],
+                from: 'A',
+                to: 'B',
             },
-        },
-        {
-            description: 'sent without output',
-            descriptor: 'utxo',
-            addresses: {
-                used: ['utxo'],
-                unused: [],
-                change: ['change'],
-            },
-            tx: {
-                vin: [
-                    {
-                        addresses: ['utxo'],
-                    },
-                ],
-            },
-            parsed: {
-                type: 'sent',
-                targets: [],
-            },
-        },
-        {
-            description: 'token recv',
-            descriptor: 'A',
-            tx: {
-                vin: [
-                    {
-                        addresses: ['0x1'],
-                    },
-                ],
-                vout: [
-                    {
-                        addresses: ['0x2'],
-                    },
-                ],
-                tokenTransfers: [{ from: '0x2', to: 'A' }],
-            },
-            parsed: {
+            {
+                ...tOut,
                 type: 'recv',
-                targets: [],
-                tokens: [{ ...token, type: 'recv', from: '0x2', to: 'A' }],
+                from: 'C',
+                to: 'D',
             },
-        },
-        {
-            description: 'token sent',
-            descriptor: 'A',
-            tx: {
-                vin: [
-                    {
-                        addresses: ['A'],
-                    },
-                ],
-                vout: [
-                    {
-                        addresses: ['0x2'],
-                    },
-                ],
-                tokenTransfers: [{ from: 'A', to: 'B' }],
+            {
+                ...tOut,
+                type: 'self',
+                from: 'X',
+                to: 'X',
             },
-            parsed: {
+        ],
+    },
+    {
+        description: 'sent: addresses as Address object',
+        addresses: [{ address: 'A' }],
+        transfers: tokenTransfers,
+        parsed: [
+            {
+                ...tOut,
                 type: 'sent',
-                targets: [],
-                tokens: [{ ...token, type: 'sent', from: 'A', to: 'B' }],
+                from: 'A',
+                to: 'B',
             },
+        ],
+    },
+    {
+        description: 'addresses as unexpected object (number)',
+        addresses: 1,
+        transfers: tokenTransfers,
+        parsed: [],
+    },
+    {
+        description: 'addresses as unexpected object (null)',
+        addresses: null,
+        transfers: tokenTransfers,
+        parsed: [],
+    },
+    {
+        description: 'addresses as unexpected object (array of numbers)',
+        addresses: [1],
+        transfers: tokenTransfers,
+        parsed: [],
+    },
+    {
+        description: 'addresses as unexpected object (array of unexpected objects)',
+        addresses: [{ foo: 'bar' }],
+        transfers: tokenTransfers,
+        parsed: [],
+    },
+    {
+        description: 'transfers as unexpected object (string)',
+        addresses: 'A',
+        transfers: 'A',
+        parsed: [],
+    },
+    {
+        description: 'transfers as unexpected object (null)',
+        addresses: 'A',
+        transfers: null,
+        parsed: [],
+    },
+    {
+        description: 'transfers as unexpected object (empty array)',
+        addresses: 'A',
+        transfers: [],
+        parsed: [],
+    },
+    {
+        description: 'transfers as unexpected object (array of unexpected objects)',
+        addresses: 'A',
+        transfers: ['A', null, 1, {}],
+        parsed: [],
+    },
+];
+
+export const transformTransaction = [
+    {
+        description: 'BTC: recv from one input to unused address',
+        descriptor: 'xpub',
+        addresses: {
+            used: [],
+            unused: ['A'],
+            change: [],
         },
-        {
-            description: 'token to myself',
-            descriptor: 'A',
-            tx: {
-                vin: [
-                    {
-                        addresses: ['A'],
-                    },
-                ],
-                vout: [
-                    {
-                        addresses: ['0x2'],
-                    },
-                ],
-                tokenTransfers: [{ from: 'A', to: 'A' }],
-            },
-            parsed: {
-                type: 'sent',
-                targets: [],
-                tokens: [{ ...token, type: 'self', from: 'A', to: 'A' }],
-            },
+        tx: {
+            vin: [
+                {
+                    addresses: ['B'],
+                    value: '100',
+                },
+            ],
+            vout: [
+                {
+                    value: '50',
+                    addresses: ['B-change'],
+                },
+                {
+                    addresses: ['A'],
+                    value: '40',
+                },
+            ],
+            ...FEES,
         },
-        {
-            description: 'token sent without sender (from)',
-            descriptor: 'A',
-            tx: {
-                vin: [
-                    {
-                        addresses: ['A'],
-                    },
-                ],
-                vout: [
-                    {
-                        addresses: ['0x2'],
-                    },
-                ],
-                tokenTransfers: [{ to: 'A' }],
-            },
-            parsed: {
-                type: 'sent',
-                targets: [],
-                tokens: [{ ...token, type: 'recv', to: 'A' }],
-            },
+        parsed: {
+            type: 'recv',
+            amount: '40',
+            targets: [
+                {
+                    addresses: ['A'],
+                },
+            ],
         },
-        {
-            description: 'token recv without sender (from)',
-            descriptor: 'A',
-            tx: {
-                vin: [
-                    {
-                        addresses: ['B'],
-                    },
-                ],
-                vout: [
-                    {
-                        addresses: ['0x2'],
-                    },
-                ],
-                tokenTransfers: [{ to: 'A' }, { to: 'B' }, { to: 'C' }],
-            },
-            parsed: {
-                type: 'recv',
-                targets: [],
-                tokens: [{ ...token, type: 'recv', to: 'A' }],
-            },
+    },
+    {
+        description: 'BTC: recv from one input to used address',
+        descriptor: 'xpub',
+        addresses: {
+            used: ['A'],
+            unused: [],
+            change: [],
         },
-        {
-            description: 'token sent without receiver (to)',
-            descriptor: 'A',
-            tx: {
-                vin: [
-                    {
-                        addresses: ['A'],
-                    },
-                ],
-                vout: [
-                    {
-                        addresses: ['0x2'],
-                    },
-                ],
-                tokenTransfers: [{ from: 'A' }],
-            },
-            parsed: {
-                type: 'sent',
-                targets: [],
-                tokens: [{ ...token, type: 'sent', from: 'A' }],
-            },
+        tx: {
+            vin: [
+                {
+                    addresses: ['B'],
+                    value: '100',
+                },
+            ],
+            vout: [
+                {
+                    value: '50',
+                    addresses: ['B-change'],
+                },
+                {
+                    addresses: ['A'],
+                    value: '40',
+                },
+            ],
+            ...FEES,
         },
-        {
-            description: 'token sent but no tokenTransfer specified',
-            descriptor: 'A',
-            tx: {
-                vin: [
-                    {
-                        addresses: ['A'],
-                    },
-                ],
-                vout: [
-                    {
-                        addresses: ['0x2'],
-                    },
-                ],
-                tokenTransfers: [],
-            },
-            parsed: {
-                type: 'sent',
-                targets: [
-                    {
-                        addresses: ['0x2'],
-                    },
-                ],
-            },
+        parsed: {
+            type: 'recv',
+            amount: '40',
+            targets: [
+                {
+                    addresses: ['A'],
+                },
+            ],
         },
-        {
-            description: 'unknown tx (no inputs, no outputs)',
-            descriptor: 'A',
-            tx: {},
-            parsed: {
-                type: 'unknown',
-                targets: [],
-            },
+    },
+    {
+        description: 'BTC: recv from one input to change address',
+        descriptor: 'xpub',
+        addresses: {
+            used: [],
+            unused: [],
+            change: ['A'],
         },
-        {
-            description: 'unknown tx (inputs and outputs are not mine)',
-            descriptor: 'A',
-            tx: {
-                vin: [
-                    {
-                        coinbase: 'B',
-                    },
-                ],
-                vout: [
-                    {
-                        addresses: ['B'],
-                    },
-                ],
-            },
-            parsed: {
-                type: 'unknown',
-                targets: [],
-            },
+        tx: {
+            vin: [
+                {
+                    addresses: ['B'],
+                    value: '100',
+                },
+            ],
+            vout: [
+                {
+                    value: '50',
+                    addresses: ['B-change'],
+                },
+                {
+                    addresses: ['A'],
+                    value: '40',
+                },
+            ],
+            ...FEES,
         },
-    ],
+        parsed: {
+            type: 'recv',
+            amount: '40',
+            targets: [
+                {
+                    addresses: ['A'],
+                },
+            ],
+        },
+    },
+    {
+        description: 'BTC: recv from 2 inputs to multiple addresses',
+        descriptor: 'xpub',
+        addresses: {
+            used: ['A', 'B'],
+            unused: ['C', 'D'],
+            change: [],
+        },
+        tx: {
+            vin: [
+                {
+                    addresses: ['utxo1', 'utxo2'],
+                    value: '50',
+                },
+                {
+                    addresses: ['utxo3'],
+                    value: '50',
+                },
+            ],
+            vout: [
+                {
+                    addresses: ['A'],
+                    value: '20',
+                },
+                {
+                    addresses: ['C'],
+                    value: '20',
+                },
+                {
+                    addresses: ['B', 'D'],
+                    value: '20',
+                },
+                {
+                    addresses: ['utxo1-change'],
+                    value: '15',
+                },
+                {
+                    addresses: ['utxo3-change'],
+                    value: '15',
+                },
+            ],
+            ...FEES,
+        },
+        parsed: {
+            type: 'recv',
+            amount: '60',
+            targets: [
+                {
+                    addresses: ['A'],
+                },
+                {
+                    addresses: ['C'],
+                },
+                {
+                    addresses: ['B', 'D'],
+                },
+            ],
+        },
+    },
+    {
+        description: 'recv coinbase',
+        descriptor: 'A',
+        tx: {
+            vin: [
+                {
+                    coinbase: 'ABCD',
+                },
+            ],
+            vout: [
+                {
+                    addresses: ['A'],
+                },
+            ],
+        },
+        parsed: {
+            type: 'recv',
+            targets: [
+                {
+                    addresses: ['A'],
+                },
+            ],
+        },
+    },
+    {
+        description: 'recv coinbase with multiple addresses',
+        descriptor: 'xpub',
+        addresses: {
+            used: ['utxo'],
+            unused: ['A', 'D', 'E'],
+            change: ['change'],
+        },
+        tx: {
+            vin: [
+                {
+                    coinbase: 'ABCD',
+                },
+            ],
+            vout: [
+                {
+                    addresses: ['A'],
+                },
+                {
+                    addresses: ['B'],
+                },
+                {
+                    addresses: ['C'],
+                },
+                {
+                    addresses: ['D', 'E'],
+                },
+            ],
+        },
+        parsed: {
+            type: 'recv',
+            targets: [
+                {
+                    addresses: ['A'],
+                },
+                {
+                    addresses: ['D', 'E'],
+                },
+            ],
+        },
+    },
+    {
+        description: 'recv without address',
+        descriptor: 'A',
+        tx: {
+            vin: [
+                {
+                    addresses: [],
+                },
+            ],
+            vout: [
+                {
+                    addresses: ['A'],
+                },
+            ],
+        },
+        parsed: {
+            type: 'recv',
+            targets: [
+                {
+                    addresses: ['A'],
+                },
+            ],
+        },
+    },
+    {
+        description: 'recv with no input (vin is undefined)',
+        descriptor: 'A',
+        tx: {
+            vout: [
+                {
+                    addresses: ['A'],
+                },
+            ],
+        },
+        parsed: {
+            type: 'recv',
+            targets: [
+                {
+                    addresses: ['A'],
+                },
+            ],
+        },
+    },
+    {
+        description: 'recv with no input (vin is empty)',
+        descriptor: 'A',
+        tx: {
+            vin: [],
+            vout: [
+                {
+                    addresses: ['A'],
+                },
+            ],
+        },
+        parsed: {
+            type: 'recv',
+            targets: [
+                {
+                    addresses: ['A'],
+                },
+            ],
+        },
+    },
+    {
+        description: 'recv with no input (vin is invalid type)',
+        descriptor: 'A',
+        tx: {
+            vin: 1,
+            vout: [
+                {
+                    addresses: ['A'],
+                },
+            ],
+        },
+        parsed: {
+            type: 'recv',
+            targets: [
+                {
+                    addresses: ['A'],
+                },
+            ],
+        },
+    },
+    {
+        description: 'recv with no input (vin item is invalid type)',
+        descriptor: 'A',
+        tx: {
+            vin: [1],
+            vout: [
+                {
+                    addresses: ['A'],
+                },
+            ],
+        },
+        parsed: {
+            type: 'recv',
+            targets: [
+                {
+                    addresses: ['A'],
+                },
+            ],
+        },
+    },
+    {
+        description: 'BTC: sent to one address with change',
+        descriptor: 'xpub',
+        addresses: {
+            used: ['A'],
+            unused: [],
+            change: ['A-change'],
+        },
+        tx: {
+            vin: [
+                {
+                    addresses: ['A'],
+                    value: '100',
+                },
+            ],
+            vout: [
+                {
+                    value: '50',
+                    addresses: ['A-change'],
+                },
+                {
+                    addresses: ['B'],
+                    value: '40',
+                },
+            ],
+            ...FEES,
+        },
+        parsed: {
+            type: 'sent',
+            amount: '40',
+            totalSpent: '50', // B.value + fee
+            targets: [
+                {
+                    addresses: ['B'],
+                },
+            ],
+        },
+    },
+    {
+        description: 'BTC: sent to multiple addresses with change',
+        descriptor: 'xpub',
+        addresses: {
+            used: ['A'],
+            unused: ['A2'],
+            change: ['A-change'],
+        },
+        tx: {
+            vin: [
+                {
+                    addresses: ['A'],
+                    value: '100',
+                },
+            ],
+            vout: [
+                {
+                    value: '50',
+                    addresses: ['A-change'],
+                },
+                {
+                    addresses: ['A2'],
+                    value: '20',
+                },
+                {
+                    addresses: ['B'],
+                    value: '20',
+                },
+            ],
+            ...FEES,
+        },
+        parsed: {
+            type: 'sent',
+            amount: '20',
+            totalSpent: '30', // B.value + fee
+            targets: [
+                {
+                    addresses: ['A2'],
+                },
+                {
+                    addresses: ['B'],
+                },
+            ],
+        },
+    },
+    {
+        description: 'BTC: sent to myself (1 input, 1 change output)',
+        descriptor: 'xpub',
+        addresses: {
+            used: ['utxo'],
+            unused: [],
+            change: ['change'],
+        },
+        tx: {
+            vin: [
+                {
+                    addresses: ['utxo'],
+                },
+            ],
+            vout: [
+                {
+                    addresses: ['change'],
+                },
+            ],
+            ...FEES,
+        },
+        parsed: {
+            type: 'self',
+            amount: '10', // only fee
+            targets: [{ addresses: ['change'] }],
+        },
+    },
+
+    {
+        description: 'ETH: sent with final fee',
+        descriptor: 'A',
+        tx: {
+            vin: [
+                {
+                    addresses: ['A'],
+                },
+            ],
+            vout: [
+                {
+                    addresses: ['B'],
+                },
+            ],
+            ethereumSpecific: {
+                status: 1,
+                gasLimit: 21000,
+                gasUsed: 21000,
+                gasPrice: 3,
+            },
+            ...FEES,
+        },
+        parsed: {
+            type: 'sent',
+            amount: '90',
+            fee: '10', // fee from blockbook, not calculated from ethereumSpecific
+            targets: [
+                {
+                    addresses: ['B'],
+                },
+            ],
+        },
+    },
+    {
+        description: 'ETH: pending with not final fee',
+        descriptor: 'A',
+        tx: {
+            vin: [
+                {
+                    addresses: ['A'],
+                },
+            ],
+            vout: [
+                {
+                    addresses: ['B'],
+                },
+            ],
+            ethereumSpecific: {
+                status: 1,
+                gasLimit: 21000,
+                gasPrice: '3',
+            },
+            ...FEES,
+        },
+        parsed: {
+            type: 'sent',
+            fee: '63000', // fee calculated from ethereumSpecific
+            targets: [
+                {
+                    addresses: ['B'],
+                },
+            ],
+        },
+    },
+
+    {
+        description: 'sent OP_RETURN with change',
+        descriptor: 'A',
+        addresses: {
+            used: ['utxo'],
+            unused: [],
+            change: ['change'],
+        },
+        tx: {
+            vin: [
+                {
+                    addresses: ['utxo'],
+                },
+            ],
+            vout: [
+                {
+                    addresses: ['change'],
+                },
+                {
+                    value: '0',
+                    addresses: ['OP_RETURN deadbeef'],
+                    isAddress: false,
+                },
+            ],
+        },
+        parsed: {
+            type: 'sent',
+            targets: [
+                {
+                    amount: '0',
+                    addresses: ['OP_RETURN deadbeef'],
+                    isAddress: false,
+                },
+            ],
+        },
+    },
+    {
+        description: 'sent without output',
+        descriptor: 'utxo',
+        addresses: {
+            used: ['utxo'],
+            unused: [],
+            change: ['change'],
+        },
+        tx: {
+            vin: [
+                {
+                    addresses: ['utxo'],
+                },
+            ],
+        },
+        parsed: {
+            type: 'sent',
+            targets: [],
+        },
+    },
+    {
+        description: 'token recv',
+        descriptor: 'A',
+        tx: {
+            vin: [
+                {
+                    addresses: ['0x1'],
+                },
+            ],
+            vout: [
+                {
+                    addresses: ['0x2'],
+                },
+            ],
+            tokenTransfers: [{ from: '0x2', to: 'A' }],
+        },
+        parsed: {
+            type: 'recv',
+            targets: [],
+            tokens: [{ ...token, type: 'recv', from: '0x2', to: 'A' }],
+        },
+    },
+    {
+        description: 'token sent',
+        descriptor: 'A',
+        tx: {
+            vin: [
+                {
+                    addresses: ['A'],
+                },
+            ],
+            vout: [
+                {
+                    addresses: ['0x2'],
+                },
+            ],
+            tokenTransfers: [{ from: 'A', to: 'B' }],
+        },
+        parsed: {
+            type: 'sent',
+            targets: [],
+            tokens: [{ ...token, type: 'sent', from: 'A', to: 'B' }],
+        },
+    },
+    {
+        description: 'token to myself',
+        descriptor: 'A',
+        tx: {
+            vin: [
+                {
+                    addresses: ['A'],
+                },
+            ],
+            vout: [
+                {
+                    addresses: ['0x2'],
+                },
+            ],
+            tokenTransfers: [{ from: 'A', to: 'A' }],
+        },
+        parsed: {
+            type: 'sent',
+            targets: [],
+            tokens: [{ ...token, type: 'self', from: 'A', to: 'A' }],
+        },
+    },
+    {
+        description: 'token sent without sender (from)',
+        descriptor: 'A',
+        tx: {
+            vin: [
+                {
+                    addresses: ['A'],
+                },
+            ],
+            vout: [
+                {
+                    addresses: ['0x2'],
+                },
+            ],
+            tokenTransfers: [{ to: 'A' }],
+        },
+        parsed: {
+            type: 'sent',
+            targets: [],
+            tokens: [{ ...token, type: 'recv', to: 'A' }],
+        },
+    },
+    {
+        description: 'token recv without sender (from)',
+        descriptor: 'A',
+        tx: {
+            vin: [
+                {
+                    addresses: ['B'],
+                },
+            ],
+            vout: [
+                {
+                    addresses: ['0x2'],
+                },
+            ],
+            tokenTransfers: [{ to: 'A' }, { to: 'B' }, { to: 'C' }],
+        },
+        parsed: {
+            type: 'recv',
+            targets: [],
+            tokens: [{ ...token, type: 'recv', to: 'A' }],
+        },
+    },
+    {
+        description: 'token sent without receiver (to)',
+        descriptor: 'A',
+        tx: {
+            vin: [
+                {
+                    addresses: ['A'],
+                },
+            ],
+            vout: [
+                {
+                    addresses: ['0x2'],
+                },
+            ],
+            tokenTransfers: [{ from: 'A' }],
+        },
+        parsed: {
+            type: 'sent',
+            targets: [],
+            tokens: [{ ...token, type: 'sent', from: 'A' }],
+        },
+    },
+    {
+        description: 'token sent but no tokenTransfer specified',
+        descriptor: 'A',
+        tx: {
+            vin: [
+                {
+                    addresses: ['A'],
+                },
+            ],
+            vout: [
+                {
+                    addresses: ['0x2'],
+                },
+            ],
+            tokenTransfers: [],
+        },
+        parsed: {
+            type: 'sent',
+            targets: [
+                {
+                    addresses: ['0x2'],
+                },
+            ],
+        },
+    },
+    {
+        description: 'unknown tx (no inputs, no outputs)',
+        descriptor: 'A',
+        tx: {},
+        parsed: {
+            type: 'unknown',
+            targets: [],
+        },
+    },
+    {
+        description: 'unknown tx (inputs and outputs are not mine)',
+        descriptor: 'A',
+        tx: {
+            vin: [
+                {
+                    coinbase: 'B',
+                },
+            ],
+            vout: [
+                {
+                    addresses: ['B'],
+                },
+            ],
+        },
+        parsed: {
+            type: 'unknown',
+            targets: [],
+        },
+    },
+];
+
+const LOCAL_A = 'wss://localhost/a.onion';
+const LOCAL_B = 'localhost:50001:t';
+const LOCAL_C = '127.0.0.1:333/url';
+const ONION_A = 'abcd-efg.oNiOn:50002:s';
+const ONION_B = 'http://a.b.onion/localhost';
+const ONION_C = 'localhost.onion:1234';
+const OTHER_A = 'ws://LOCALHOST.onion.cz/onion?a=1';
+const OTHER_B = 'ABcd.efgh.ij:4444:s';
+const OTHER_C = 'https://a/localhost';
+
+export const endpoints = {
+    unsorted: [ONION_B, OTHER_B, LOCAL_B, ONION_A, OTHER_C, LOCAL_A, ONION_C, OTHER_A, LOCAL_C],
+    sorted: [LOCAL_C, LOCAL_B, LOCAL_A, ONION_A, ONION_B, ONION_C, OTHER_B, OTHER_C, OTHER_A],
 };

--- a/packages/blockchain-link/tests/unit/utils.ts
+++ b/packages/blockchain-link/tests/unit/utils.ts
@@ -1,7 +1,7 @@
 import { filterTokenTransfers, transformTransaction } from '../../src/workers/blockbook/utils';
-import { filterTargets } from '../../src/workers/utils';
+import { filterTargets, prioritizeEndpoints } from '../../src/workers/utils';
 
-import fixtures from './fixtures/utils';
+import * as fixtures from './fixtures/utils';
 
 describe('blockbook/utils', () => {
     describe('filterTargets', () => {
@@ -32,6 +32,19 @@ describe('blockbook/utils', () => {
                 const tx = transformTransaction(f.descriptor, f.addresses, f.tx);
                 expect(tx).toMatchObject(f.parsed);
             });
+        });
+    });
+
+    describe('prioritizeEndpoints', () => {
+        it('prioritizeEndpoints', () => {
+            const { unsorted, sorted } = fixtures.endpoints;
+            const res = prioritizeEndpoints(unsorted);
+            const resFixed = [
+                ...res.slice(0, 3).sort(),
+                ...res.slice(3, 6).sort(),
+                ...res.slice(6, 9).sort(),
+            ];
+            expect(resFixed).toStrictEqual(sorted);
         });
     });
 });

--- a/packages/suite/src/utils/suite/__tests__/backend.test.ts
+++ b/packages/suite/src/utils/suite/__tests__/backend.test.ts
@@ -17,16 +17,4 @@ describe('backend utils', () => {
         expect(utils.isElectrumUrl('https://google.com')).toBe(false);
         expect(utils.isElectrumUrl('')).toBe(false);
     });
-
-    test('getElectrumHost', () => {
-        expect(utils.getElectrumHost('electrum.example.com:50001:t')).toBe('electrum.example.com');
-        expect(utils.getElectrumHost('electrum.example.com:50001:s')).toBe('electrum.example.com');
-        expect(utils.getElectrumHost('electrum.example.onion:50001:t')).toBe(
-            'electrum.example.onion',
-        );
-        expect(utils.getElectrumHost('electrum.example.com:50001:x')).toBe(undefined);
-        expect(utils.getElectrumHost('wss://blockfrost.io')).toBe(undefined);
-        expect(utils.getElectrumHost('https://google.com')).toBe(undefined);
-        expect(utils.getElectrumHost('')).toBe(undefined);
-    });
 });

--- a/packages/suite/src/utils/suite/backend.ts
+++ b/packages/suite/src/utils/suite/backend.ts
@@ -35,5 +35,3 @@ export const getCustomBackends = (blockchains: BlockchainState): CustomBackend[]
 const electrumUrlRegex = /^([a-zA-Z0-9.-]+):[0-9]{1,5}:[ts]$/; // URL is in format host:port:[t|s] (t for tcp, s for ssl)
 
 export const isElectrumUrl = (value: string) => electrumUrlRegex.test(value);
-
-export const getElectrumHost = (value: string) => electrumUrlRegex.exec(value)?.[1];

--- a/packages/suite/src/utils/suite/tor.ts
+++ b/packages/suite/src/utils/suite/tor.ts
@@ -1,6 +1,5 @@
+import { parseHostname } from '@trezor/utils';
 import { TOR_URLS } from '@suite-constants/tor';
-import { parseUri } from './parseUri';
-import { isElectrumUrl, getElectrumHost } from './backend';
 
 /**
  * returns tor url if tor url is request and tor url is available for given domain
@@ -34,6 +33,6 @@ export const toTorUrl = (url: string) => {
 export const isTorDomain = (domain: string) => domain.endsWith('.onion');
 
 export const isOnionUrl = (url: string) => {
-    const hostname = isElectrumUrl(url) ? getElectrumHost(url) : parseUri(url)?.hostname;
+    const hostname = parseHostname(url);
     return !!hostname && isTorDomain(hostname);
 };

--- a/packages/utils/src/index.ts
+++ b/packages/utils/src/index.ts
@@ -16,6 +16,7 @@ export * from './isAscii';
 export * from './isNotUndefined';
 export * as versionUtils from './versionUtils';
 export * from './objectPartition';
+export * from './parseHostname';
 export * from './throwError';
 export * from './isHex';
 export * from './resolveStaticPath';

--- a/packages/utils/src/parseHostname.ts
+++ b/packages/utils/src/parseHostname.ts
@@ -1,0 +1,13 @@
+/**
+ * ^([a-z0-9.+-]+:\/\/)? - optionally starts with scheme (http://, wss://, ...)
+ * ([a-z0-9.-]+) - all valid hostname characters until first slash, colon or end of line
+ * ([:/][^:/]+)* - any number of sequences starting with colon (ports) or slash (path segments)
+ * \/?$ - optionally ends with slash
+ */
+const HOSTNAME_REGEX = /^([a-z0-9.+-]+:\/\/)?([a-z0-9.-]+)([:/][^:/]+)*\/?$/i;
+
+/**
+ * Tries to parse hostname from maybe url string, with support of unconventional electrum urls.
+ * @see {@link file://./../tests/parseHostname.test.ts}
+ */
+export const parseHostname = (url: string) => url.match(HOSTNAME_REGEX)?.[2]?.toLowerCase();

--- a/packages/utils/tests/parseHostname.test.ts
+++ b/packages/utils/tests/parseHostname.test.ts
@@ -1,0 +1,24 @@
+import { parseHostname } from '../src/parseHostname';
+
+const fixtures = [
+    ['localHOst', 'localhost'],
+    ['localhost.cz:3', 'localhost.cz'],
+    ['wss://btc1.trezor.io/foo', 'btc1.trezor.io'],
+    ['127.0.0.1:9050/?a=b', '127.0.0.1'],
+    ['http://suite.trezor.io/', 'suite.trezor.io'],
+    ['electrum.exAMple.com:50001:t', 'electrum.example.com'],
+    ['electrum.example.onion:50001:t?abcd', 'electrum.example.onion'],
+    ['a35sf65dFH67awd.onion:999:s', 'a35sf65dfh67awd.onion'],
+    [''],
+    ['ws://'],
+    ['http://a.b://c.d'],
+    ['invalid url'],
+] as const;
+
+describe('parseHostname', () => {
+    it('parseHostname', () => {
+        fixtures.forEach(([url, hostname]) => {
+            expect(parseHostname(url)).toEqual(hostname);
+        });
+    });
+});


### PR DESCRIPTION
Resolves #5076.

When trying to connect to a backend, localhost addresses are tried first, then onion addresses (regardless of Tor status, in worst case it fails), then the rest. Moreover, `parseHostname` util was implemented to be able to obtain hostname (and therefore simply recognize e.g. onion or localhost addresses) from both standard and electrum urls.

### What to test ###
That backends are still chosen randomly from defined custom backends, but whenever there are both plain and onion addresses (and Tor is active, of course), an onion address is always selected.
