### PR TITLE
Feat/connect: preauthorize signTransaction and getOwnershipProof

### DIFF
--- a/.github/workflows/connect-test-params.yml
+++ b/.github/workflows/connect-test-params.yml
@@ -40,7 +40,7 @@ jobs:
       - run: yarn install
       # todo: ideally reuse libs from build step
       - run: yarn build:libs
-      - run: "./docker/docker-connect-test.sh node -p ${{ inputs.test-pattern }} -i ${{ inputs.methods }}"
+      - run: './docker/docker-connect-test.sh node -p "${{ inputs.test-pattern }}" -i ${{ inputs.methods }}'
 
   web:
     name: web
@@ -67,4 +67,4 @@ jobs:
           path: packages/connect-web/build
       - name: "Echo download path"
         run: echo ${{steps.download.outputs.download-path}}
-      - run: "./docker/docker-connect-test.sh web -p ${{ inputs.test-pattern }} -i ${{ inputs.methods }}"
+      - run: './docker/docker-connect-test.sh web -p "${{ inputs.test-pattern }}" -i ${{ inputs.methods }}'

--- a/.github/workflows/connect-test.yml
+++ b/.github/workflows/connect-test.yml
@@ -42,7 +42,7 @@ jobs:
     needs: [build]
     uses: ./.github/workflows/connect-test-params.yml
     with:
-      test-pattern: init
+      test-pattern: "init authorizeCoinJoin"
 
   management:
     needs: [build]

--- a/ci/test.yml
+++ b/ci/test.yml
@@ -283,7 +283,7 @@ connect-popup manual:
   parallel:
     matrix:
       - TESTS_ENVIRONMENT: ["node", "web"]
-        TESTS_PATTERN: "init"
+        TESTS_PATTERN: "init authorizeCoinJoin"
         TESTS_FIRMWARE: ["2-master", "2.2.0"]
         # todo:
         # TESTS_NODE_VERSION: ["12", "14", "16"]

--- a/packages/connect/CHANGELOG.md
+++ b/packages/connect/CHANGELOG.md
@@ -21,3 +21,4 @@
 
 -   `getOwnershipId` method
 -   `getOwnershipProof` method
+-   `authorizeCoinJoin` method

--- a/packages/connect/docs/methods.md
+++ b/packages/connect/docs/methods.md
@@ -26,6 +26,7 @@ Every method require an [`Object`](https://developer.mozilla.org/en-US/docs/Web/
 -   [TrezorConnect.pushTransaction](methods/pushTransaction.md)
 -   [TrezorConnect.signMessage](methods/signMessage.md)
 -   [TrezorConnect.verifyMessage](methods/verifyMessage.md)
+-   [TrezorConnect.authorizeCoinJoin](methods/authorizeCoinJoin.md)
 
 ### Ethereum
 

--- a/packages/connect/docs/methods/authorizeCoinJoin.md
+++ b/packages/connect/docs/methods/authorizeCoinJoin.md
@@ -1,0 +1,71 @@
+## Bitcoin: authorize CoinJoin
+
+Allow device to do preauthorized operations in `signTransaction` and `getOwnershipProof` methods without further user interaction.
+
+Permission persists until physical device disconnection or `maxRounds` limit is reached.
+
+```javascript
+const result = await TrezorConnect.authorizeCoinJoin(params);
+```
+
+> :warning: **This feature is experimental! Do not use it in production!**
+
+> :note: **Supported only by Trezor T with Firmware 2.4.4 or higher!**
+
+### Params
+
+[\***\*Optional common params\*\***](commonParams.md)
+
+#### Exporting single id
+
+-   `path` — _required_ `string | Array<number>`
+    > prefix of the BIP-32 path leading to the account (m / purpose' / coin_type' / account')[read more](path.md)
+-   `coordinator` — _required_ `string`
+    > coordinator identifier to approve as a prefix in commitment data (max. 36 ASCII characters)
+-   `maxRounds` — _required_ `number`
+    > maximum number of rounds that Trezor is authorized to take part in
+-   `maxCoordinatorFeeRate` — _required_ `number`
+    > maximum coordination fee rate in units of 10\*\*8 percent
+-   `maxFeePerKvbyte` — _required_ `number`
+    > maximum mining fee rate in units of satoshis per 1000 vbytes
+-   `coin` - _optional_ `string`
+    > Determines network definition specified in [coins.json](../../../connect-common/files/coins.json) file.
+    > Coin `shortcut`, `name` or `label` can be used.
+-   `scriptType` — _optional_ `PROTO.InputScriptType`
+    > used to distinguish between various address formats (non-segwit, segwit, etc.)
+-   `amountUnit` — _optional_ `PROTO.AmountUnit`
+    > show amounts in
+
+### Example:
+
+```javascript
+TrezorConnect.authorizeCoinJoin({
+    path: "m/10086'/0'/0'",
+    maxRounds: 3,
+    maxCoordinatorFeeRate: 5000000, // 5% => 0.05 * 10**8;
+    maxFeePerKvbyte: 3500,
+    scriptType: 'SPENDWITNESS',
+});
+```
+
+### Result
+
+```javascript
+{
+    success: true,
+    payload: {
+        message: 'CoinJoin authorized'
+    }
+}
+```
+
+Error
+
+```javascript
+{
+    success: false,
+    payload: {
+        error: string // error message
+    }
+}
+```

--- a/packages/connect/docs/methods/getOwnershipProof.md
+++ b/packages/connect/docs/methods/getOwnershipProof.md
@@ -23,6 +23,7 @@ const result = await TrezorConnect.getOwnershipProof(params);
 -   `ownershipIds` — _optional_ `Array<string>`
 -   `commitmentData` — _optional_ `string`
 -   `multisig` — _optional_ `MultisigRedeemScriptType`
+-   `preauthorized` — _optional_ `boolean` [read more](./authorizeCoinJoin.md)
 
 #### Exporting bundle of proofs
 

--- a/packages/connect/src/api/authorizeCoinJoin.ts
+++ b/packages/connect/src/api/authorizeCoinJoin.ts
@@ -1,0 +1,52 @@
+import { AbstractMethod } from '../core/AbstractMethod';
+import { validateParams, getFirmwareRange } from './common/paramsValidator';
+import { validatePath, getScriptType } from '../utils/pathUtils';
+import { getBitcoinNetwork } from '../data/coinInfo';
+import { PROTO } from '../constants';
+
+export default class AuthorizeCoinJoin extends AbstractMethod<
+    'authorizeCoinJoin',
+    PROTO.AuthorizeCoinJoin
+> {
+    init() {
+        const { payload } = this;
+
+        validateParams(payload, [
+            { name: 'path', required: true },
+            { name: 'coordinator', type: 'string', required: true },
+            { name: 'maxRounds', type: 'number', required: true },
+            { name: 'maxCoordinatorFeeRate', type: 'number', required: true },
+            { name: 'maxFeePerKvbyte', type: 'number', required: true },
+            { name: 'coin', type: 'string' },
+            { name: 'scriptType', type: 'string' },
+            { name: 'amountUnit', type: 'uint' },
+        ]);
+
+        const address_n = validatePath(payload.path, 3);
+        const script_type = payload.scriptType || getScriptType(address_n);
+        const coinInfo = getBitcoinNetwork(payload.coin || address_n);
+        this.firmwareRange = getFirmwareRange(this.name, coinInfo, this.firmwareRange);
+
+        this.params = {
+            coordinator: payload.coordinator,
+            max_rounds: payload.maxRounds,
+            max_coordinator_fee_rate: payload.maxCoordinatorFeeRate,
+            max_fee_per_kvbyte: payload.maxFeePerKvbyte,
+            address_n,
+            coin_name: coinInfo?.name,
+            script_type,
+            amount_unit: payload.amountUnit,
+        };
+    }
+
+    async run() {
+        const cmd = this.device.getCommands();
+        if (!this.device.features.experimental_features) {
+            // enable experimental features
+            await cmd.typedCall('ApplySettings', 'Success', { experimental_features: true });
+        }
+
+        const response = await cmd.typedCall('AuthorizeCoinJoin', 'Success', this.params);
+        return response.message;
+    }
+}

--- a/packages/connect/src/api/getOwnershipProof.ts
+++ b/packages/connect/src/api/getOwnershipProof.ts
@@ -5,10 +5,11 @@ import { getBitcoinNetwork } from '../data/coinInfo';
 import { PROTO } from '../constants';
 import { UI, createUiMessage } from '../events';
 
-export default class GetOwnershipProof extends AbstractMethod<
-    'getOwnershipProof',
-    PROTO.GetOwnershipProof[]
-> {
+interface Params extends PROTO.GetOwnershipProof {
+    preauthorized?: boolean;
+}
+
+export default class GetOwnershipProof extends AbstractMethod<'getOwnershipProof', Params[]> {
     hasBundle?: boolean;
     confirmed?: boolean;
 
@@ -35,6 +36,7 @@ export default class GetOwnershipProof extends AbstractMethod<
                 { name: 'userConfirmation', type: 'boolean' },
                 { name: 'ownershipIds', type: 'array' },
                 { name: 'commitmentData', type: 'string' },
+                { name: 'preauthorized', type: 'boolean' },
             ]);
 
             const address_n = validatePath(batch.path, 1);
@@ -50,6 +52,7 @@ export default class GetOwnershipProof extends AbstractMethod<
                 user_confirmation: batch.userConfirmation,
                 ownership_ids: batch.ownershipIds,
                 commitment_data: batch.commitmentData,
+                preauthorized: batch.preauthorized,
             };
         });
     }
@@ -85,6 +88,9 @@ export default class GetOwnershipProof extends AbstractMethod<
         const cmd = this.device.getCommands();
         for (let i = 0; i < this.params.length; i++) {
             const batch = this.params[i];
+            if (batch.preauthorized) {
+                await cmd.typedCall('DoPreauthorized', 'PreauthorizedRequest', {});
+            }
             const { message } = await cmd.typedCall('GetOwnershipProof', 'OwnershipProof', batch);
             responses.push({
                 ...message,

--- a/packages/connect/src/api/index.ts
+++ b/packages/connect/src/api/index.ts
@@ -1,5 +1,6 @@
 export { default as applyFlags } from './applyFlags';
 export { default as applySettings } from './applySettings';
+export { default as authorizeCoinJoin } from './authorizeCoinJoin';
 export { default as backupDevice } from './backupDevice';
 export { default as binanceGetAddress } from './binanceGetAddress';
 export { default as binanceGetPublicKey } from './binanceGetPublicKey';

--- a/packages/connect/src/api/signTransaction.ts
+++ b/packages/connect/src/api/signTransaction.ts
@@ -33,6 +33,7 @@ type Params = {
     options: TransactionOptions;
     coinInfo: BitcoinNetworkInfo;
     push: boolean;
+    preauthorized?: boolean;
 };
 
 export default class SignTransaction extends AbstractMethod<'signTransaction', Params> {
@@ -59,6 +60,7 @@ export default class SignTransaction extends AbstractMethod<'signTransaction', P
             { name: 'branchId', type: 'number' },
             { name: 'decredStakingTicket', type: 'boolean' },
             { name: 'push', type: 'boolean' },
+            { name: 'preauthorized', type: 'boolean' },
         ]);
 
         const coinInfo = getBitcoinNetwork(payload.coin);
@@ -109,6 +111,7 @@ export default class SignTransaction extends AbstractMethod<'signTransaction', P
             },
             coinInfo,
             push: typeof payload.push === 'boolean' ? payload.push : false,
+            preauthorized: payload.preauthorized,
         };
 
         if (coinInfo.hasTimestamp && !Object.prototype.hasOwnProperty.call(payload, 'timestamp')) {
@@ -164,6 +167,10 @@ export default class SignTransaction extends AbstractMethod<'signTransaction', P
             }
         } else {
             refTxs = params.refTxs;
+        }
+
+        if (params.preauthorized) {
+            await device.getCommands().typedCall('DoPreauthorized', 'PreauthorizedRequest', {});
         }
 
         const signTxMethod = !useLegacySignProcess ? signTx : signTxLegacy;

--- a/packages/connect/src/data/config.ts
+++ b/packages/connect/src/data/config.ts
@@ -190,7 +190,8 @@ export const config = {
             comment: ['EIP-712 domain-only signing, when primaryType=EIP712Domain'],
         },
         {
-            methods: ['getOwnershipId', 'getOwnershipProof'],
+            capabilities: ['coinjoin'],
+            methods: ['authorizeCoinJoin', 'getOwnershipId', 'getOwnershipProof'],
             min: ['0', '2.4.4'],
         },
     ],

--- a/packages/connect/src/factory.ts
+++ b/packages/connect/src/factory.ts
@@ -208,6 +208,8 @@ export const factory = ({
 
         applySettings: params => call({ ...params, method: 'applySettings' }),
 
+        authorizeCoinJoin: params => call({ ...params, method: 'authorizeCoinJoin' }),
+
         backupDevice: params => call({ ...params, method: 'backupDevice' }),
 
         changePin: params => call({ ...params, method: 'changePin' }),

--- a/packages/connect/src/types/api/__tests__/bitcoin.ts
+++ b/packages/connect/src/types/api/__tests__/bitcoin.ts
@@ -646,7 +646,7 @@ export const getOwnershipId = async (api: TrezorConnect) => {
     }
 
     // @ts-expect-error missing path
-    TrezorConnect.getOwnershipId({ coin: 'btc' });
+    api.getOwnershipId({ coin: 'btc' });
 };
 
 export const getOwnershipProof = async (api: TrezorConnect) => {
@@ -684,5 +684,37 @@ export const getOwnershipProof = async (api: TrezorConnect) => {
     }
 
     // @ts-expect-error missing path
-    TrezorConnect.getOwnershipProof({ coin_name: 'btc' });
+    api.getOwnershipProof({ coin_name: 'btc' });
+};
+
+export const authorizeCoinJoin = async (api: TrezorConnect) => {
+    const result = await api.authorizeCoinJoin({
+        path: 'm/44',
+        coordinator: 'TrezorCoinjoinCoordinator',
+        maxRounds: 1,
+        maxCoordinatorFeeRate: 100,
+        maxFeePerKvbyte: 100,
+    });
+    if (result.success) {
+        const { payload } = result;
+        payload.message.toLowerCase();
+    }
+
+    api.authorizeCoinJoin({
+        path: 'm/44',
+        coordinator: 'TrezorCoinjoinCoordinator',
+        maxRounds: 1,
+        maxCoordinatorFeeRate: 100,
+        maxFeePerKvbyte: 100,
+        coin: 'btc',
+        scriptType: 'SPENDTAPROOT',
+        amountUnit: 1, // MILLIBITCOIN
+    });
+
+    // @ts-expect-error incomplete params
+    api.authorizeCoinJoin({ path: 'm/44', coordinator: '' });
+    // @ts-expect-error incomplete params
+    api.authorizeCoinJoin({ path: 'm/44', maxRounds: 1 });
+    // @ts-expect-error incomplete params
+    api.authorizeCoinJoin({ coordinator: '', maxCoordinatorFeeRate: 1 });
 };

--- a/packages/connect/src/types/api/authorizeCoinJoin.ts
+++ b/packages/connect/src/types/api/authorizeCoinJoin.ts
@@ -1,0 +1,17 @@
+import type { PROTO } from '../../constants';
+import type { Params, Response } from '../params';
+
+export interface AuthorizeCoinJoin {
+    path: string | number[];
+    coordinator: string;
+    maxRounds: number;
+    maxCoordinatorFeeRate: number;
+    maxFeePerKvbyte: number;
+    coin?: string;
+    scriptType?: PROTO.InternalInputScriptType;
+    amountUnit?: PROTO.AmountUnit;
+}
+
+export declare function authorizeCoinJoin(
+    params: Params<AuthorizeCoinJoin>,
+): Response<PROTO.Success>;

--- a/packages/connect/src/types/api/getOwnershipProof.ts
+++ b/packages/connect/src/types/api/getOwnershipProof.ts
@@ -9,6 +9,7 @@ export interface GetOwnershipProof {
     userConfirmation?: boolean;
     ownershipIds?: string[];
     commitmentData?: string;
+    preauthorized?: boolean;
 }
 
 export interface OwnershipProof extends PROTO.OwnershipProof {

--- a/packages/connect/src/types/api/index.ts
+++ b/packages/connect/src/types/api/index.ts
@@ -1,5 +1,6 @@
 import { applyFlags } from './applyFlags';
 import { applySettings } from './applySettings';
+import { authorizeCoinJoin } from './authorizeCoinJoin';
 import { backupDevice } from './backupDevice';
 import { binanceGetAddress } from './binanceGetAddress';
 import { binanceGetPublicKey } from './binanceGetPublicKey';
@@ -77,6 +78,9 @@ export interface TrezorConnect {
 
     // https://github.com/trezor/trezor-suite/tree/develop/packages/connect/docs/methods/applySettings.md
     applySettings: typeof applySettings;
+
+    // https://github.com/trezor/trezor-suite/tree/develop/packages/connect/docs/methods/authorizeCoinJoin.md
+    authorizeCoinJoin: typeof authorizeCoinJoin;
 
     // https://github.com/trezor/trezor-suite/tree/develop/packages/connect/docs/methods/backupDevice.md
     backupDevice: typeof backupDevice;

--- a/packages/connect/src/types/api/signTransaction.ts
+++ b/packages/connect/src/types/api/signTransaction.ts
@@ -69,6 +69,7 @@ export interface SignTransaction {
     branchId?: number;
     decredStakingTicket?: boolean;
     push?: boolean;
+    preauthorized?: boolean;
 }
 
 export type SignedTransaction = {

--- a/packages/connect/src/utils/__tests__/deviceFeaturesUtils.test.ts
+++ b/packages/connect/src/utils/__tests__/deviceFeaturesUtils.test.ts
@@ -135,6 +135,7 @@ describe('utils/deviceFeaturesUtils', () => {
                 eip1559: 'update-required',
                 'eip712-domain-only': 'update-required',
                 taproot: 'update-required',
+                coinjoin: 'no-support',
                 signMessageNoScriptType: 'update-required',
             });
 
@@ -146,6 +147,7 @@ describe('utils/deviceFeaturesUtils', () => {
                 eip1559: 'update-required',
                 'eip712-domain-only': 'update-required',
                 taproot: 'update-required',
+                coinjoin: 'update-required',
                 signMessageNoScriptType: 'update-required',
             });
         });

--- a/packages/integration-tests/projects/connect/__txcache__/testnet/f982c0a283bd65a59aa89eded9e48f2a3319cb80361dfab4cf6192a03badb60a.json
+++ b/packages/integration-tests/projects/connect/__txcache__/testnet/f982c0a283bd65a59aa89eded9e48f2a3319cb80361dfab4cf6192a03badb60a.json
@@ -1,0 +1,22 @@
+{
+    "bin_outputs": [
+        {
+            "amount": 5000000,
+            "script_pubkey": "a9147a55d61848e77ca266e79a39bfc85c580a6426c987"
+        },
+        {
+            "amount": 7289000,
+            "script_pubkey": "0014cc8067093f6f843d6d3e22004a4290cd0c0f336b"
+        }
+    ],
+    "inputs": [
+        {
+            "prev_hash": "09144602765ce3dd8f4329445b20e3684e948709c5cdcaf12da3bb079c99448a",
+            "prev_index": 0,
+            "script_sig": "",
+            "sequence": 4294967295
+        }
+    ],
+    "lock_time": 0,
+    "version": 1
+}

--- a/packages/integration-tests/projects/connect/tests/device/authorizeCoinJoin.test.ts
+++ b/packages/integration-tests/projects/connect/tests/device/authorizeCoinJoin.test.ts
@@ -1,0 +1,148 @@
+import TrezorConnect from '@trezor/connect';
+
+const { getController, setup, conditionalTest, initTrezorConnect } = global.Trezor;
+const { ADDRESS_N, TX_CACHE } = global.TestUtils;
+
+const controller = getController('applyFlags');
+
+describe('TrezorConnect.authorizeCoinJoin', () => {
+    beforeAll(async () => {
+        await setup(controller, {
+            mnemonic: 'mnemonic_all',
+            settings: {
+                experimental_features: true,
+            },
+        });
+        await initTrezorConnect(controller, { debug: false });
+    });
+
+    afterAll(() => {
+        controller.dispose();
+        TrezorConnect.dispose();
+    });
+
+    conditionalTest(['1', '<2.4.4'], 'Coinjoin success', async () => {
+        const auth = await TrezorConnect.authorizeCoinJoin({
+            coordinator: 'www.example.com',
+            maxRounds: 2,
+            maxCoordinatorFeeRate: 50000000, // 0.5 %
+            maxFeePerKvbyte: 3500,
+            path: ADDRESS_N("m/84'/1'/0'"),
+            coin: 'Testnet',
+            scriptType: 'SPENDWITNESS',
+        });
+
+        expect(auth.success).toBe(true);
+        expect(auth.payload).toEqual({ message: 'CoinJoin authorized' });
+
+        // remove all button listeners from initTrezorConnect (common.setup)
+        // DebugLink decision SHOULD NOT! be required after authorization
+        TrezorConnect.removeAllListeners();
+
+        const commitmentData =
+            '0f7777772e6578616d706c652e636f6d0000000000000000000000000000000000000000000000000000000000000001';
+
+        const proof = await TrezorConnect.getOwnershipProof({
+            coin: 'Testnet',
+            path: ADDRESS_N("m/84'/1'/0'/1/0"),
+            scriptType: 'SPENDWITNESS',
+            userConfirmation: true, // ButtonRequest is not emitted because of preauthorization
+            commitmentData,
+            preauthorized: true,
+        });
+
+        expect(proof.success).toBe(true);
+
+        const params: Parameters<typeof TrezorConnect.signTransaction>[0] = {
+            inputs: [
+                {
+                    // seed "alcohol woman abuse must during monitor noble actual mixed trade anger aisle"
+                    // 84'/1'/0'/0/0
+                    // tb1qnspxpr2xj9s2jt6qlhuvdnxw6q55jvygcf89r2
+                    amount: 100000,
+                    prev_hash: 'e5b7e21b5ba720e81efd6bfa9f854ababdcddc75a43bfa60bf0fe069cfd1bb8a',
+                    prev_index: 0,
+                    script_type: 'EXTERNAL',
+                    script_pubkey: '00149c02608d469160a92f40fdf8c6ccced029493088',
+                    ownership_proof:
+                        '534c001901016b2055d8190244b2ed2d46513c40658a574d3bc2deb6969c0535bb818b44d2c40002483045022100a6c7d59b453efa7b4abc9bc724a94c5655ae986d5924dc29d28bcc2b859cbace022047d2bc4422a47f7b044bd6cdfbf63fe1a0ecbf11393f4c0bf8565f867a5ced16012103505f0d82bbdd251511591b34f36ad5eea37d3220c2b81a1189084431ddb3aa3d',
+                    commitment_data: commitmentData,
+                },
+                // # NOTE: FAKE input tx
+                {
+                    address_n: ADDRESS_N("m/84'/1'/0'/1/0"),
+                    prev_hash: 'f982c0a283bd65a59aa89eded9e48f2a3319cb80361dfab4cf6192a03badb60a',
+                    prev_index: 1,
+                    amount: 7289000,
+                    script_type: 'SPENDWITNESS',
+                },
+            ],
+            outputs: [
+                // Other's coinjoined output.
+                {
+                    address: 'tb1qk7j3ahs2v6hrv4v282cf0tvxh0vqq7rpt3zcml',
+                    amount: 50000,
+                    script_type: 'PAYTOADDRESS',
+                    payment_req_index: 0,
+                },
+                // Our coinjoined output.
+                {
+                    // tb1qze76uzqteg6un6jfcryrxhwvfvjj58ts0swg3d
+                    address_n: ADDRESS_N("m/84'/1'/0'/1/1"),
+                    amount: 50000,
+                    script_type: 'PAYTOWITNESS',
+                    payment_req_index: 0,
+                },
+                // Our change output.
+                {
+                    // tb1qr5p6f5sk09sms57ket074vywfymuthlgud7xyx
+                    address_n: ADDRESS_N("m/84'/1'/0'/1/2"),
+                    amount: 7289000 - 50000 - 36445 - 490,
+                    script_type: 'PAYTOWITNESS',
+                    payment_req_index: 0,
+                },
+                // Other's change output.
+                {
+                    address: 'tb1q9cqhdr9ydetjzrct6tyeuccws9505hl96azwxk',
+                    amount: 100000 - 50000 - 500 - 490,
+                    script_type: 'PAYTOADDRESS',
+                    payment_req_index: 0,
+                },
+                // Coordinator's output.
+                {
+                    address: 'mvbu1Gdy8SUjTenqerxUaZyYjmveZvt33q',
+                    amount: 36945,
+                    script_type: 'PAYTOADDRESS',
+                    payment_req_index: 0,
+                },
+            ],
+            paymentRequests: [
+                {
+                    recipient_name: 'www.example.com',
+                    signature:
+                        'af22d614a4920f54e7704c186bf12f24dbef475df31645574c9f9b4dbb3594c4d4084d8a16a6db0cda814377d58e564b872f02331a3db0bf229856aa33e8bc19',
+                },
+            ],
+            refTxs: TX_CACHE(['e5b7e2', 'f982c0'], true), // Fake tx
+            coin: 'testnet',
+            preauthorized: true,
+        };
+
+        // ButtonRequests during signing is not emitted because of preauthorization
+
+        const round1 = await TrezorConnect.signTransaction(params);
+        expect(round1.payload).toMatchObject({
+            serializedTx:
+                '010000000001028abbd1cf69e00fbf60fa3ba475dccdbdba4a859ffa6bfd1ee820a75b1be2b7e50000000000ffffffff0ab6ad3ba09261cfb4fa1d3680cb19332a8fe4d9de9ea89aa565bd83a2c082f90100000000ffffffff0550c3000000000000160014b7a51ede0a66ae36558a3ab097ad86bbd800786150c3000000000000160014167dae080bca35c9ea49c0c8335dcc4b252a1d7011e56d00000000001600141d03a4d2167961b853d6cadfeab08e4937c5dfe872bf0000000000001600142e01768ca46e57210f0bd2c99e630e8168fa5fe551900000000000001976a914a579388225827d9f2fe9014add644487808c695d88ac000247304402204df07c5baacca264696cc4270665cb759be05387dead8942bd41f20309ceb29002203e685b8e9483435d9b70006bb424b5fef7249415a0f212abdf202b5d62859698012103505647c017ff2156eb6da20fae72173d3b681a1d0a629f95f49e884db300689f00000000',
+        });
+
+        // sign again ...
+        const round2 = await TrezorConnect.signTransaction(params);
+        expect(round2.success).toBe(true);
+
+        // ... and again, fees should exceed maxRounds
+        const round3 = await TrezorConnect.signTransaction(params);
+        expect(round3.success).toBe(false);
+        expect(round3.payload).toMatchObject({ error: 'Exceeded number of CoinJoin rounds.' });
+    });
+});


### PR DESCRIPTION
last part of https://github.com/trezor/connect/pull/1054

- added `authorizeCoinJoin` method
- allow preauthorization for signTransaction and getOwnershipProof methods