### PR TITLE
fix(connect): improve connect logs (debug)

### DIFF
--- a/packages/connect-web/src/index.ts
+++ b/packages/connect-web/src/index.ts
@@ -31,7 +31,7 @@ import * as popup from './popup';
 import webUSBButton from './webusb/button';
 
 const eventEmitter = new EventEmitter();
-const _log = initLog('[trezor-connect.js]');
+const _log = initLog('@trezor/connect');
 
 let _settings = parseConnectSettings();
 let _popupManager: popup.PopupManager | undefined;

--- a/packages/connect/src/device/DescriptorStream.ts
+++ b/packages/connect/src/device/DescriptorStream.ts
@@ -99,7 +99,6 @@ export class DescriptorStream extends EventEmitter {
     constructor(transport: Transport) {
         super();
         this.transport = transport;
-        logger.enabled = !!DataManager.getSettings('debug');
     }
 
     // emits changes
@@ -141,7 +140,7 @@ export class DescriptorStream extends EventEmitter {
                 await resolveAfter(1000, null);
                 if (this.listening) this.listen();
             } else {
-                logger.log('Transport error');
+                logger.warn('Transport error');
                 this.emit(TRANSPORT.ERROR, error);
             }
         }

--- a/packages/connect/src/device/DeviceList.ts
+++ b/packages/connect/src/device/DeviceList.ts
@@ -86,8 +86,7 @@ export class DeviceList extends EventEmitter {
     constructor() {
         super();
 
-        const { debug, env, webusb } = DataManager.settings;
-        _log.enabled = !!debug;
+        const { env, webusb } = DataManager.settings;
 
         const transports: Transport[] = [];
 

--- a/packages/connect/src/index.ts
+++ b/packages/connect/src/index.ts
@@ -26,7 +26,7 @@ import { ERRORS } from './constants';
 import type { ConnectSettings, Manifest } from './types';
 
 export const eventEmitter = new EventEmitter();
-const _log = initLog('[@trezor/connect]');
+const _log = initLog('@trezor/connect');
 
 let _settings = parseConnectSettings();
 let _core: Core | null = null;
@@ -64,7 +64,7 @@ const handleMessage = (message: CoreMessage) => {
 
     if (type === POPUP.CANCEL_POPUP_REQUEST) return;
 
-    _log.log('handleMessage', message);
+    _log.debug('handleMessage', message);
 
     switch (event) {
         case RESPONSE_EVENT:
@@ -104,7 +104,7 @@ const handleMessage = (message: CoreMessage) => {
             break;
 
         default:
-            _log.log('Undefined message', event, message);
+            _log.warn('Undefined message', event, message);
     }
 };
 
@@ -146,8 +146,6 @@ const init = async (settings: Partial<ConnectSettings> = {}) => {
         return;
     }
 
-    _log.enabled = !!_settings.debug;
-
     _core = await initCore(_settings);
     _core.on(CORE_EVENT, handleMessage);
 
@@ -173,7 +171,7 @@ const call: CallMethod = async params => {
         }
         return createErrorMessage(ERRORS.TypedError('Method_NoResponse'));
     } catch (error) {
-        _log.error('__call error', error);
+        _log.error('call', error);
         return createErrorMessage(error);
     }
 };

--- a/packages/connect/src/utils/debug.ts
+++ b/packages/connect/src/utils/debug.ts
@@ -1,14 +1,16 @@
 // origin: https://github.com/trezor/connect/blob/develop/src/js/utils/debug.js
 /* eslint-disable no-console */
 
-const colors: { [k: string]: string } = {
-    // green
-    DescriptorStream: 'color: #77ab59',
-    DeviceList: 'color: #36802d',
-    Device: 'color: #bada55',
-    Core: 'color: #c9df8a',
-    IFrame: 'color: #FFFFFF; background: #f4a742;',
-    Popup: 'color: #f48a00',
+const colors: Record<string, string> = {
+    // orange, api related
+    '@trezor/connect': 'color: #f4a742; background: #000;',
+    IFrame: 'color: #f4a742; background: #000;',
+    Core: 'color: #f4a742; background: #000;',
+    // green, device related
+    DescriptorStream: 'color: #77ab59; background: #000;',
+    DeviceList: 'color: #77ab59; background: #000;',
+    Device: 'color: #bada55; background: #000;',
+    DeviceCommands: 'color: #bada55; background: #000;',
 };
 
 type LogMessage = {
@@ -22,18 +24,15 @@ const MAX_ENTRIES = 100;
 
 class Log {
     prefix: string;
-
     enabled: boolean;
-
     css: string;
-
     messages: LogMessage[];
 
     constructor(prefix: string, enabled: boolean) {
         this.prefix = prefix;
         this.enabled = enabled;
         this.messages = [];
-        this.css = colors[prefix] || 'color: #000000; background: #FFFFFF;';
+        this.css = typeof window !== 'undefined' && colors[prefix] ? colors[prefix] : '';
     }
 
     addMessage(level: string, prefix: string, ...args: any[]) {
@@ -72,7 +71,11 @@ class Log {
     debug(...args: any[]) {
         this.addMessage('debug', this.prefix, ...args);
         if (this.enabled) {
-            console.log(`%c${this.prefix}`, this.css, ...args);
+            if (this.css) {
+                console.log(`%c${this.prefix}`, this.css, ...args);
+            } else {
+                console.log(this.prefix, ...args);
+            }
         }
     }
 }
@@ -85,9 +88,9 @@ export const initLog = (prefix: string, enabled?: boolean) => {
     return instance;
 };
 
-export const enableLog = (enabled: boolean) => {
+export const enableLog = (enabled?: boolean) => {
     Object.keys(_logs).forEach(key => {
-        _logs[key].enabled = enabled;
+        _logs[key].enabled = !!enabled;
     });
 };
 

--- a/packages/connect/src/utils/interactionTimeout.ts
+++ b/packages/connect/src/utils/interactionTimeout.ts
@@ -33,9 +33,9 @@ export class InteractionTimeout {
         // Clear any previous timeouts set (reset)
         this.stop();
 
-        _log.log(`starting interaction timeout for ${time} seconds`);
+        _log.debug(`starting interaction timeout for ${time} seconds`);
         this.timeout = setTimeout(() => {
-            _log.log('interaction timed out');
+            _log.debug('interaction timed out');
             cancelFn();
         }, 1000 * time);
     }
@@ -46,7 +46,7 @@ export class InteractionTimeout {
      */
     stop() {
         if (this.timeout) {
-            _log.log('clearing interaction timeout');
+            _log.debug('clearing interaction timeout');
             clearTimeout(this.timeout);
         }
     }


### PR DESCRIPTION
- logs are enabled globally in one place after `DataManager.load` in Core (exception: entrypoint of connect-web because it is outside of iframe/core)
- removed unused fn `initData` from Core
- enable logs in `DeviceCommands` and `InteractionTimeout` (it was always disabled, `debug` option was not used there)
- do not use console css styling in nodejs
- nicer css
- nicer log messages