### PR TITLE
feat: Add react navigation

### DIFF
--- a/packages/atoms/package.json
+++ b/packages/atoms/package.json
@@ -17,7 +17,8 @@
         "@shopify/react-native-skia": "0.1.123",
         "@trezor/styles": "*",
         "@trezor/theme": "*",
-        "react-native": "*",
+        "react": "^17.0.2",
+        "react-native": "0.68.2",
         "type-fest": "^2.12.2"
     },
     "devDependencies": {

--- a/packages/suite-native-navigation-root/jest.config.js
+++ b/packages/suite-native-navigation-root/jest.config.js
@@ -1,0 +1,3 @@
+module.exports = {
+    preset: '../../jest.config.base.js',
+};

--- a/packages/suite-native-navigation-root/package.json
+++ b/packages/suite-native-navigation-root/package.json
@@ -1,0 +1,23 @@
+{
+    "name": "@suite-native/navigation-root",
+    "version": "1.0.0",
+    "private": true,
+    "license": "See LICENSE.md in repo root",
+    "sideEffects": false,
+    "main": "src/index",
+    "scripts": {
+        "lint": "eslint '**/*.{ts,tsx,js}'",
+        "test:unit": "jest --passWithNoTests",
+        "type-check": "tsc --build"
+    },
+    "dependencies": {
+        "@react-navigation/bottom-tabs": "^6.3.1",
+        "@react-navigation/native": "^6.0.10",
+        "@suite-native/settings": "*",
+        "@suite-native/navigation": "*",
+        "@trezor/atoms": "*",
+        "@trezor/styles": "*",
+        "react": "^17.0.2",
+        "react-native": "0.68.2"
+    }
+}

--- a/packages/suite-native-navigation-root/src/dummyScreens/AccountsScreen.tsx
+++ b/packages/suite-native-navigation-root/src/dummyScreens/AccountsScreen.tsx
@@ -1,0 +1,20 @@
+import React from 'react';
+import { View } from 'react-native';
+import { Text } from '@trezor/atoms';
+import { prepareNativeStyle, useNativeStyles } from '@trezor/styles';
+
+const accountScreenStyle = prepareNativeStyle(() => ({
+    flex: 1,
+    justifyContent: 'center',
+    alignItems: 'center',
+}));
+
+export const AccountsScreen = () => {
+    const { applyStyle } = useNativeStyles();
+
+    return (
+        <View style={[applyStyle(accountScreenStyle)]}>
+            <Text>Accounts content</Text>
+        </View>
+    );
+};

--- a/packages/suite-native-navigation-root/src/dummyScreens/ActionScreen.tsx
+++ b/packages/suite-native-navigation-root/src/dummyScreens/ActionScreen.tsx
@@ -1,0 +1,20 @@
+import React from 'react';
+import { View } from 'react-native';
+import { Text } from '@trezor/atoms';
+import { prepareNativeStyle, useNativeStyles } from '@trezor/styles';
+
+const actionScreenStyle = prepareNativeStyle(() => ({
+    flex: 1,
+    justifyContent: 'center',
+    alignItems: 'center',
+}));
+
+export const ActionScreen = () => {
+    const { applyStyle } = useNativeStyles();
+
+    return (
+        <View style={[applyStyle(actionScreenStyle)]}>
+            <Text>Action content</Text>
+        </View>
+    );
+};

--- a/packages/suite-native-navigation-root/src/dummyScreens/DemoScreen.tsx
+++ b/packages/suite-native-navigation-root/src/dummyScreens/DemoScreen.tsx
@@ -23,7 +23,7 @@ const backgroundStyle = prepareNativeStyle<{ isDarkMode: boolean }>(
     }),
 );
 
-export const Home = () => {
+export const DemoScreen = () => {
     const isDarkMode = useColorScheme() === 'dark';
     const [inputText, setInputText] = useState<string>('');
     const { applyStyle } = useNativeStyles();
@@ -107,7 +107,11 @@ export const Home = () => {
                         <Hint variant="error">Please enter a valid address dumbo</Hint>
                     </Box>
                     <Box marginVertical="md">
-                        <Button onPress={() => {}} size="md" colorScheme="primary">
+                        <Button
+                            onPress={() => console.log('Get features')}
+                            size="md"
+                            colorScheme="primary"
+                        >
                             My Fancy Button
                         </Button>
                     </Box>

--- a/packages/suite-native-navigation-root/src/dummyScreens/HomeScreen.tsx
+++ b/packages/suite-native-navigation-root/src/dummyScreens/HomeScreen.tsx
@@ -1,0 +1,22 @@
+import React from 'react';
+import { View } from 'react-native';
+import { TabProps } from '@suite-native/navigation';
+import { Text } from '@trezor/atoms';
+import { prepareNativeStyle, useNativeStyles } from '@trezor/styles';
+import { RootTabsParamList, RouteTabs } from '../navigation/routes';
+
+const homeScreenStyle = prepareNativeStyle(() => ({
+    flex: 1,
+    justifyContent: 'center',
+    alignItems: 'center',
+}));
+
+export const HomeScreen: React.FC<TabProps<RootTabsParamList, RouteTabs.Prices>> = () => {
+    const { applyStyle } = useNativeStyles();
+
+    return (
+        <View style={[applyStyle(homeScreenStyle)]}>
+            <Text>Home content</Text>
+        </View>
+    );
+};

--- a/packages/suite-native-navigation-root/src/dummyScreens/PricesScreen.tsx
+++ b/packages/suite-native-navigation-root/src/dummyScreens/PricesScreen.tsx
@@ -1,0 +1,22 @@
+import React from 'react';
+import { View } from 'react-native';
+import { TabProps } from '@suite-native/navigation';
+import { Text } from '@trezor/atoms';
+import { prepareNativeStyle, useNativeStyles } from '@trezor/styles';
+import { RootTabsParamList, RouteTabs } from '../navigation/routes';
+
+const pricesScreenStyle = prepareNativeStyle(() => ({
+    flex: 1,
+    justifyContent: 'center',
+    alignItems: 'center',
+}));
+
+export const PricesScreen: React.FC<TabProps<RootTabsParamList, RouteTabs.Prices>> = () => {
+    const { applyStyle } = useNativeStyles();
+
+    return (
+        <View style={[applyStyle(pricesScreenStyle)]}>
+            <Text>Prices content</Text>
+        </View>
+    );
+};

--- a/packages/suite-native-navigation-root/src/index.ts
+++ b/packages/suite-native-navigation-root/src/index.ts
@@ -1,0 +1,2 @@
+export * from './navigation/RootTabNavigator';
+export * from './navigation/routes';

--- a/packages/suite-native-navigation-root/src/navigation/RootTabNavigator.tsx
+++ b/packages/suite-native-navigation-root/src/navigation/RootTabNavigator.tsx
@@ -1,0 +1,31 @@
+import { createBottomTabNavigator } from '@react-navigation/bottom-tabs';
+import { TabBar } from '@suite-native/navigation';
+import { SettingsStackNavigator } from '@suite-native/settings';
+import React from 'react';
+import { AccountsScreen } from '../dummyScreens/AccountsScreen';
+import { ActionScreen } from '../dummyScreens/ActionScreen';
+import { DemoScreen } from '../dummyScreens/DemoScreen';
+import { PricesScreen } from '../dummyScreens/PricesScreen';
+import { RootTabsParamList, RouteTabs, rootTabsOptions } from './routes';
+import { NavigationContainer } from '@react-navigation/native';
+
+const Tab = createBottomTabNavigator<RootTabsParamList>();
+
+export const RootTabNavigator = () => (
+    <NavigationContainer>
+        <Tab.Navigator
+            initialRouteName={RouteTabs.Home}
+            screenOptions={{
+                headerShown: false,
+                unmountOnBlur: true,
+            }}
+            tabBar={props => <TabBar tabItemOptions={rootTabsOptions} {...props} />}
+        >
+            <Tab.Screen name={RouteTabs.Home} component={DemoScreen} />
+            <Tab.Screen name={RouteTabs.Accounts} component={AccountsScreen} />
+            <Tab.Screen name={RouteTabs.Action} component={ActionScreen} />
+            <Tab.Screen name={RouteTabs.Prices} component={PricesScreen} />
+            <Tab.Screen name={RouteTabs.SettingsStack} component={SettingsStackNavigator} />
+        </Tab.Navigator>
+    </NavigationContainer>
+);

--- a/packages/suite-native-navigation-root/src/navigation/navigationMap.d.ts
+++ b/packages/suite-native-navigation-root/src/navigation/navigationMap.d.ts
@@ -1,0 +1,8 @@
+// Specifying default types for useNavigation, Link, ref etc
+import { RootTabsParamList } from './routes';
+
+declare global {
+    namespace ReactNavigation {
+        type RootParamList = RootTabsParamList;
+    }
+}

--- a/packages/suite-native-navigation-root/src/navigation/routes.ts
+++ b/packages/suite-native-navigation-root/src/navigation/routes.ts
@@ -1,0 +1,37 @@
+import { NavigatorScreenParams } from '@react-navigation/native';
+import { SettingsStackParamList } from '@suite-native/settings';
+import { TabsOption } from '@suite-native/navigation';
+
+export enum RouteTabs {
+    Home = 'Home',
+    Accounts = 'Accounts',
+    Action = 'Action',
+    Prices = 'Prices',
+    SettingsStack = 'SettingsStack',
+}
+
+export type RootTabsParamList = {
+    [RouteTabs.Home]: undefined;
+    [RouteTabs.Accounts]: undefined;
+    [RouteTabs.Action]: undefined;
+    [RouteTabs.Prices]: undefined;
+    [RouteTabs.SettingsStack]: NavigatorScreenParams<SettingsStackParamList>;
+};
+
+export const rootTabsOptions: TabsOption = {
+    [RouteTabs.Home]: {
+        icon: 'home',
+    },
+    [RouteTabs.Accounts]: {
+        icon: 'accounts',
+    },
+    [RouteTabs.Action]: {
+        icon: 'action',
+    },
+    [RouteTabs.Prices]: {
+        icon: 'prices',
+    },
+    [RouteTabs.SettingsStack]: {
+        icon: 'settings',
+    },
+};

--- a/packages/suite-native-navigation-root/tsconfig.json
+++ b/packages/suite-native-navigation-root/tsconfig.json
@@ -1,0 +1,10 @@
+{
+    "extends": "../../tsconfig.json",
+    "compilerOptions": { "outDir": "libDev" },
+    "references": [
+        { "path": "../suite-native-settings" },
+        { "path": "../suite-native-navigation" },
+        { "path": "../atoms" },
+        { "path": "../styles" }
+    ]
+}

--- a/packages/suite-native-navigation/jest.config.js
+++ b/packages/suite-native-navigation/jest.config.js
@@ -1,0 +1,3 @@
+export default {
+    preset: '../../jest.config.base.js',
+};

--- a/packages/suite-native-navigation/package.json
+++ b/packages/suite-native-navigation/package.json
@@ -1,0 +1,22 @@
+{
+    "name": "@suite-native/navigation",
+    "version": "1.0.0",
+    "private": true,
+    "license": "See LICENSE.md in repo root",
+    "sideEffects": false,
+    "type": "module",
+    "main": "src/index",
+    "scripts": {
+        "lint": "eslint '**/*.{ts,tsx,js}'",
+        "test:unit": "jest --passWithNoTests",
+        "type-check": "tsc --build"
+    },
+    "dependencies": {
+        "@react-navigation/bottom-tabs": "^6.3.1",
+        "@react-navigation/native": "^6.0.10",
+        "@trezor/atoms": "*",
+        "@trezor/styles": "*",
+        "react": "^17.0.2",
+        "react-native": "0.68.2"
+    }
+}

--- a/packages/suite-native-navigation/src/TabBar.tsx
+++ b/packages/suite-native-navigation/src/TabBar.tsx
@@ -1,0 +1,57 @@
+import React from 'react';
+import { View } from 'react-native';
+import { BottomTabBarProps } from '@react-navigation/bottom-tabs';
+import { prepareNativeStyle, useNativeStyles } from '@trezor/styles';
+import { TabBarItem } from './TabBarItem';
+import { TabsOption } from './types';
+
+interface TabBarProps extends BottomTabBarProps {
+    tabItemOptions: TabsOption;
+}
+
+const tabBarStyle = prepareNativeStyle(utils => ({
+    height: 86,
+    backgroundColor: utils.colors.gray100,
+    borderTopColor: utils.colors.gray300,
+    borderTopWidth: utils.borders.widths.sm,
+    flexDirection: 'row',
+    justifyContent: 'space-between',
+    paddingTop: 20.5,
+    paddingLeft: 51.5,
+    paddingRight: 51.5,
+}));
+
+export const TabBar = ({ state, navigation, tabItemOptions }: TabBarProps) => {
+    const { applyStyle } = useNativeStyles();
+
+    return (
+        <View style={[applyStyle(tabBarStyle)]}>
+            {state.routes.map((route, index) => {
+                const isFocused = state.index === index;
+                const { icon } = tabItemOptions[route.name];
+
+                const handleTabBarItemPress = () => {
+                    const event = navigation.emit({
+                        type: 'tabPress',
+                        target: route.key,
+                        canPreventDefault: true,
+                    });
+
+                    if (!isFocused && !event.defaultPrevented) {
+                        // The `merge: true` option makes sure that the params inside the tab screen are preserved
+                        navigation.navigate(route.name, { merge: true });
+                    }
+                };
+
+                return (
+                    <TabBarItem
+                        key={route.key}
+                        isFocused={isFocused}
+                        icon={icon}
+                        onPress={handleTabBarItemPress}
+                    />
+                );
+            })}
+        </View>
+    );
+};

--- a/packages/suite-native-navigation/src/TabBarItem.tsx
+++ b/packages/suite-native-navigation/src/TabBarItem.tsx
@@ -1,0 +1,25 @@
+import React from 'react';
+import { TouchableOpacity } from 'react-native';
+import { Icon, IconType } from '@trezor/atoms';
+
+type TabBarItemProps = {
+    isFocused: boolean;
+    onPress: () => void;
+    icon: IconType;
+};
+
+export const TabBarItem = ({ isFocused, onPress, icon }: TabBarItemProps) => (
+    <TouchableOpacity
+        accessibilityRole="button"
+        accessibilityState={isFocused ? { selected: true } : {}}
+        onPress={() => {
+            /*
+             Calling in a function prevents Animation warning in iOS simulator
+             see https://github.com/react-navigation/react-navigation/issues/7839#issuecomment-829438793
+             */
+            onPress();
+        }}
+    >
+        <Icon type={icon} size="big" color={isFocused ? 'black' : 'gray500'} />
+    </TouchableOpacity>
+);

--- a/packages/suite-native-navigation/src/index.ts
+++ b/packages/suite-native-navigation/src/index.ts
@@ -1,0 +1,3 @@
+export * from './types';
+export * from './TabBar';
+export * from './TabBarItem';

--- a/packages/suite-native-navigation/src/types.tsx
+++ b/packages/suite-native-navigation/src/types.tsx
@@ -1,0 +1,23 @@
+import type { BottomTabScreenProps, BottomTabNavigationProp } from '@react-navigation/bottom-tabs';
+import type { StackScreenProps, StackNavigationProp } from '@react-navigation/stack';
+import { ParamListBase } from '@react-navigation/native';
+import type { RouteProp } from '@react-navigation/native';
+import { IconType } from '@trezor/atoms';
+
+export type TabProps<T extends ParamListBase, K extends keyof T> = BottomTabScreenProps<T, K>;
+export type TabNavigationProp<
+    T extends ParamListBase,
+    K extends keyof ParamListBase,
+> = BottomTabNavigationProp<T, K>;
+
+export type StackProps<T extends ParamListBase, K extends keyof T> = StackScreenProps<T, K>;
+export type StackNavigationProps<
+    T extends ParamListBase,
+    K extends keyof ParamListBase,
+> = StackNavigationProp<T, K>;
+
+export type RouteProps<T extends ParamListBase, K extends keyof T> = RouteProp<T, K>;
+
+export interface TabsOption {
+    [tabName: string]: { icon: IconType };
+}

--- a/packages/suite-native-navigation/tsconfig.json
+++ b/packages/suite-native-navigation/tsconfig.json
@@ -1,0 +1,8 @@
+{
+    "extends": "../../tsconfig.json",
+    "compilerOptions": { "outDir": "libDev" },
+    "references": [
+        { "path": "../atoms" },
+        { "path": "../styles" }
+    ]
+}

--- a/packages/suite-native-settings/jest.config.js
+++ b/packages/suite-native-settings/jest.config.js
@@ -1,0 +1,3 @@
+export default {
+    preset: '../../jest.config.base.js',
+};

--- a/packages/suite-native-settings/package.json
+++ b/packages/suite-native-settings/package.json
@@ -1,0 +1,23 @@
+{
+    "name": "@suite-native/settings",
+    "version": "1.0.0",
+    "private": true,
+    "license": "See LICENSE.md in repo root",
+    "sideEffects": false,
+    "type": "module",
+    "main": "src/index",
+    "scripts": {
+        "lint": "eslint '**/*.{ts,tsx,js}'",
+        "test:unit": "jest --passWithNoTests",
+        "type-check": "tsc --build"
+    },
+    "dependencies": {
+        "@react-navigation/native": "^6.0.10",
+        "@react-navigation/stack": "^6.2.1",
+        "@suite-native/navigation": "*",
+        "@trezor/atoms": "*",
+        "@trezor/styles": "*",
+        "react": "^17.0.2",
+        "react-native": "0.68.2"
+    }
+}

--- a/packages/suite-native-settings/src/index.ts
+++ b/packages/suite-native-settings/src/index.ts
@@ -1,0 +1,2 @@
+export * from './navigation/routes';
+export * from './navigation/SettingsStackNavigator';

--- a/packages/suite-native-settings/src/navigation/SettingsStackNavigator.tsx
+++ b/packages/suite-native-settings/src/navigation/SettingsStackNavigator.tsx
@@ -1,0 +1,25 @@
+import React from 'react';
+import { createStackNavigator } from '@react-navigation/stack';
+import { SettingsScreen } from '../screens/SettingsScreen';
+import { SettingsDetailScreen } from '../screens/SettingsDetailScreen';
+import { SettingsStackRoutes, SettingsStackParamList } from './routes';
+
+const SettingsStack = createStackNavigator<SettingsStackParamList>();
+
+export const SettingsStackNavigator = () => (
+    <SettingsStack.Navigator
+        initialRouteName={SettingsStackRoutes.Settings}
+        screenOptions={{ headerShown: false, gestureEnabled: true, gestureDirection: 'horizontal' }}
+    >
+        <SettingsStack.Screen
+            options={{ title: 'Settings' }}
+            name={SettingsStackRoutes.Settings}
+            component={SettingsScreen}
+        />
+        <SettingsStack.Screen
+            options={{ title: 'SettingsDetail' }}
+            name={SettingsStackRoutes.SettingsDetail}
+            component={SettingsDetailScreen}
+        />
+    </SettingsStack.Navigator>
+);

--- a/packages/suite-native-settings/src/navigation/routes.ts
+++ b/packages/suite-native-settings/src/navigation/routes.ts
@@ -1,0 +1,9 @@
+export enum SettingsStackRoutes {
+    Settings = 'Settings',
+    SettingsDetail = 'SettingsDetail',
+}
+
+export type SettingsStackParamList = {
+    [SettingsStackRoutes.Settings]: undefined;
+    [SettingsStackRoutes.SettingsDetail]: { message: string };
+};

--- a/packages/suite-native-settings/src/screens/SettingsDetailScreen.tsx
+++ b/packages/suite-native-settings/src/screens/SettingsDetailScreen.tsx
@@ -1,0 +1,24 @@
+import React from 'react';
+import { View } from 'react-native';
+import { Text } from '@trezor/atoms';
+import { prepareNativeStyle, useNativeStyles } from '@trezor/styles';
+import { SettingsStackRoutes, SettingsStackParamList } from '../navigation/routes';
+import { StackProps } from '@suite-native/navigation';
+
+const settingsDetailScreenStyle = prepareNativeStyle(() => ({
+    flex: 1,
+    justifyContent: 'center',
+    alignItems: 'center',
+}));
+
+export const SettingsDetailScreen = ({
+    route,
+}: StackProps<SettingsStackParamList, SettingsStackRoutes.SettingsDetail>) => {
+    const { applyStyle } = useNativeStyles();
+
+    return (
+        <View style={[applyStyle(settingsDetailScreenStyle)]}>
+            <Text>{route.params.message}</Text>
+        </View>
+    );
+};

--- a/packages/suite-native-settings/src/screens/SettingsScreen.tsx
+++ b/packages/suite-native-settings/src/screens/SettingsScreen.tsx
@@ -1,0 +1,37 @@
+import React from 'react';
+import { Box, Button, Text } from '@trezor/atoms';
+import { View } from 'react-native';
+import { prepareNativeStyle, useNativeStyles } from '@trezor/styles';
+import { SettingsStackRoutes, SettingsStackParamList } from '../navigation/routes';
+import { StackProps } from '@suite-native/navigation';
+
+const settingsScreenStyle = prepareNativeStyle(() => ({
+    flex: 1,
+    justifyContent: 'center',
+    alignItems: 'center',
+}));
+
+export const SettingsScreen = ({
+    navigation,
+}: StackProps<SettingsStackParamList, SettingsStackRoutes.Settings>) => {
+    const { applyStyle } = useNativeStyles();
+
+    return (
+        <View style={[applyStyle(settingsScreenStyle)]}>
+            <Text>Settings content</Text>
+            <Box marginVertical="md">
+                <Button
+                    onPress={() =>
+                        navigation.navigate(SettingsStackRoutes.SettingsDetail, {
+                            message: 'this is detail',
+                        })
+                    }
+                    size="md"
+                    colorScheme="primary"
+                >
+                    Show detail
+                </Button>
+            </Box>
+        </View>
+    );
+};

--- a/packages/suite-native-settings/tsconfig.json
+++ b/packages/suite-native-settings/tsconfig.json
@@ -1,0 +1,9 @@
+{
+    "extends": "../../tsconfig.json",
+    "compilerOptions": { "outDir": "libDev" },
+    "references": [
+        { "path": "../suite-native-navigation" },
+        { "path": "../atoms" },
+        { "path": "../styles" }
+    ]
+}

--- a/packages/suite-native/android/app/src/main/java/com/trezorsuite/MainActivity.java
+++ b/packages/suite-native/android/app/src/main/java/com/trezorsuite/MainActivity.java
@@ -1,5 +1,6 @@
 package com.trezorsuite;
 
+import android.os.Bundle;
 import com.facebook.react.ReactActivity;
 import com.facebook.react.ReactActivityDelegate;
 import com.facebook.react.ReactRootView;
@@ -13,6 +14,14 @@ public class MainActivity extends ReactActivity {
   @Override
   protected String getMainComponentName() {
     return "TrezorSuite";
+  }
+
+  /**
+   * To avoid crashes related to View state being not persisted consistently across Activity restarts.
+   */
+  @Override
+  protected void onCreate(Bundle savedInstanceState) {
+    super.onCreate(null);
   }
 
   /**

--- a/packages/suite-native/index.js
+++ b/packages/suite-native/index.js
@@ -1,3 +1,4 @@
+import 'react-native-gesture-handler';
 import './globalPolyfills';
 import { AppRegistry } from 'react-native';
 

--- a/packages/suite-native/ios/Podfile.lock
+++ b/packages/suite-native/ios/Podfile.lock
@@ -300,6 +300,12 @@ PODS:
   - React-jsinspector (0.68.2)
   - React-logger (0.68.2):
     - glog
+  - react-native-safe-area-context (4.2.5):
+    - RCT-Folly
+    - RCTRequired
+    - RCTTypeSafety
+    - React
+    - ReactCommon/turbomodule/core
   - react-native-skia (0.1.123):
     - React
     - React-callinvoker
@@ -394,6 +400,11 @@ PODS:
     - React-jsi (= 0.68.2)
     - React-logger (= 0.68.2)
     - React-perflogger (= 0.68.2)
+  - RNGestureHandler (2.4.2):
+    - React-Core
+  - RNScreens (3.13.1):
+    - React-Core
+    - React-RCTImage
   - SocketRocket (0.6.0)
   - trezor-transport-native (1.0.0):
     - React-Core
@@ -447,6 +458,7 @@ DEPENDENCIES:
   - React-jsiexecutor (from `../../../node_modules/react-native/ReactCommon/jsiexecutor`)
   - React-jsinspector (from `../../../node_modules/react-native/ReactCommon/jsinspector`)
   - React-logger (from `../../../node_modules/react-native/ReactCommon/logger`)
+  - react-native-safe-area-context (from `../../../node_modules/react-native-safe-area-context`)
   - "react-native-skia (from `../../../node_modules/@shopify/react-native-skia`)"
   - React-perflogger (from `../../../node_modules/react-native/ReactCommon/reactperflogger`)
   - React-RCTActionSheet (from `../../../node_modules/react-native/Libraries/ActionSheetIOS`)
@@ -460,6 +472,8 @@ DEPENDENCIES:
   - React-RCTVibration (from `../../../node_modules/react-native/Libraries/Vibration`)
   - React-runtimeexecutor (from `../../../node_modules/react-native/ReactCommon/runtimeexecutor`)
   - ReactCommon/turbomodule/core (from `../../../node_modules/react-native/ReactCommon`)
+  - RNGestureHandler (from `../../../node_modules/react-native-gesture-handler`)
+  - RNScreens (from `../../../node_modules/react-native-screens`)
   - trezor-transport-native (from `../../transport-native`)
   - Yoga (from `../../../node_modules/react-native/ReactCommon/yoga`)
 
@@ -521,6 +535,8 @@ EXTERNAL SOURCES:
     :path: "../../../node_modules/react-native/ReactCommon/jsinspector"
   React-logger:
     :path: "../../../node_modules/react-native/ReactCommon/logger"
+  react-native-safe-area-context:
+    :path: "../../../node_modules/react-native-safe-area-context"
   react-native-skia:
     :path: "../../../node_modules/@shopify/react-native-skia"
   React-perflogger:
@@ -547,6 +563,10 @@ EXTERNAL SOURCES:
     :path: "../../../node_modules/react-native/ReactCommon/runtimeexecutor"
   ReactCommon:
     :path: "../../../node_modules/react-native/ReactCommon"
+  RNGestureHandler:
+    :path: "../../../node_modules/react-native-gesture-handler"
+  RNScreens:
+    :path: "../../../node_modules/react-native-screens"
   trezor-transport-native:
     :path: "../../transport-native"
   Yoga:
@@ -586,6 +606,7 @@ SPEC CHECKSUMS:
   React-jsiexecutor: b7b553412f2ec768fe6c8f27cd6bafdb9d8719e6
   React-jsinspector: c5989c77cb89ae6a69561095a61cce56a44ae8e8
   React-logger: a0833912d93b36b791b7a521672d8ee89107aff1
+  react-native-safe-area-context: ebf8c413eb8b5f7c392a036a315eb7b46b96845f
   react-native-skia: 8a3e1b513020e2c9b0b4e49404f396d2a88f9ac7
   React-perflogger: a18b4f0bd933b8b24ecf9f3c54f9bf65180f3fe6
   React-RCTActionSheet: 547fe42fdb4b6089598d79f8e1d855d7c23e2162
@@ -599,6 +620,8 @@ SPEC CHECKSUMS:
   React-RCTVibration: 79040b92bfa9c3c2d2cb4f57e981164ec7ab9374
   React-runtimeexecutor: b960b687d2dfef0d3761fbb187e01812ebab8b23
   ReactCommon: 095366164a276d91ea704ce53cb03825c487a3f2
+  RNGestureHandler: 61628a2c859172551aa2100d3e73d1e57878392f
+  RNScreens: 40a2cb40a02a609938137a1e0acfbf8fc9eebf19
   SocketRocket: fccef3f9c5cedea1353a9ef6ada904fde10d6608
   trezor-transport-native: b3e33732dbf396a18b4759b5e418ce8984bd643c
   Yoga: 99652481fcd320aefa4a7ef90095b95acd181952

--- a/packages/suite-native/package.json
+++ b/packages/suite-native/package.json
@@ -14,15 +14,20 @@
         "pods": "npx pod-install"
     },
     "dependencies": {
+        "@react-navigation/native": "^6.0.10",
         "@shopify/react-native-skia": "0.1.123",
         "@trezor/atoms": "*",
-        "@trezor/transport-native": "*",
+        "@suite-native/navigation-root": "*",
+        "@trezor/connect": "9.0.0-beta.1",
         "@trezor/styles": "*",
         "@trezor/theme": "*",
+        "@trezor/transport-native": "*",
         "node-libs-browser": "^2.2.1",
         "react": "17.0.2",
         "react-native": "0.68.2",
-        "@trezor/connect": "9.0.0-beta.1"
+        "react-native-gesture-handler": "^2.4.2",
+        "react-native-screens": "^3.13.1",
+        "react-native-safe-area-context": "^4.2.5"
     },
     "devDependencies": {
         "@babel/core": "^7.12.9",

--- a/packages/suite-native/src/App.tsx
+++ b/packages/suite-native/src/App.tsx
@@ -1,9 +1,9 @@
 import React from 'react';
 
+import { RootTabNavigator } from '@suite-native/navigation-root';
 import { StylesProvider, createRenderer } from '@trezor/styles';
 import { prepareNativeTheme } from '@trezor/theme';
-
-import { Home } from './screens/Home';
+import { SafeAreaProvider } from 'react-native-safe-area-context';
 
 const renderer = createRenderer();
 
@@ -11,8 +11,10 @@ export const App = () => {
     const theme = prepareNativeTheme({ colorVariant: 'standard' });
 
     return (
-        <StylesProvider theme={theme} renderer={renderer}>
-            <Home />
-        </StylesProvider>
+        <SafeAreaProvider>
+            <StylesProvider theme={theme} renderer={renderer}>
+                <RootTabNavigator />
+            </StylesProvider>
+        </SafeAreaProvider>
     );
 };

--- a/packages/suite-native/tsconfig.json
+++ b/packages/suite-native/tsconfig.json
@@ -3,10 +3,13 @@
     "compilerOptions": { "outDir": "libDev" },
     "references": [
         { "path": "../atoms" },
-        { "path": "../transport-native" },
+        {
+            "path": "../suite-native-navigation-root"
+        },
+        { "path": "../connect" },
         { "path": "../styles" },
         { "path": "../theme" },
-        { "path": "../connect" }
+        { "path": "../transport-native" }
     ],
     "include": [".", "**.json"]
 }

--- a/packages/transport-native/ios/TrezorTransportNative.m
+++ b/packages/transport-native/ios/TrezorTransportNative.m
@@ -6,4 +6,10 @@ RCT_EXTERN_METHOD(multiply:(float)a withB:(float)b
                  withResolver:(RCTPromiseResolveBlock)resolve
                  withRejecter:(RCTPromiseRejectBlock)reject)
 
+// https://github.com/facebook/react-native/issues/23755#issuecomment-474235632
++ (BOOL)requiresMainQueueSetup
+{
+  return NO;
+}
+
 @end

--- a/yarn.lock
+++ b/yarn.lock
@@ -1320,6 +1320,13 @@
   resolved "https://registry.yarnpkg.com/@discoveryjs/json-ext/-/json-ext-0.5.6.tgz#d5e0706cf8c6acd8c6032f8d54070af261bbbb2f"
   integrity sha512-ws57AidsDvREKrZKYffXddNkyaF14iHNHm8VQnZH6t99E8gczjNN0GpvcGny0imC80yQ0tHz1xVUKk/KFQSUyA==
 
+"@egjs/hammerjs@^2.0.17":
+  version "2.0.17"
+  resolved "https://registry.yarnpkg.com/@egjs/hammerjs/-/hammerjs-2.0.17.tgz#5dc02af75a6a06e4c2db0202cae38c9263895124"
+  integrity sha512-XQsZgjm2EcVUiZQf11UBJQfmZeEmOW8DpI1gsFeln6w0ae0ii4dMQEQ0kjl6DspdWX1aGY1/loyXnP0JS06e/A==
+  dependencies:
+    "@types/hammerjs" "^2.0.36"
+
 "@electron/get@^1.13.0":
   version "1.13.1"
   resolved "https://registry.yarnpkg.com/@electron/get/-/get-1.13.1.tgz#42a0aa62fd1189638bd966e23effaebb16108368"
@@ -3395,6 +3402,57 @@
   resolved "https://registry.yarnpkg.com/@react-native/polyfills/-/polyfills-2.0.0.tgz#4c40b74655c83982c8cf47530ee7dc13d957b6aa"
   integrity sha512-K0aGNn1TjalKj+65D7ycc1//H9roAQ51GJVk5ZJQFb2teECGmzd86bYDC0aYdbRf7gtovescq4Zt6FR0tgXiHQ==
 
+"@react-navigation/bottom-tabs@^6.3.1":
+  version "6.3.1"
+  resolved "https://registry.yarnpkg.com/@react-navigation/bottom-tabs/-/bottom-tabs-6.3.1.tgz#1552ccdb789b6c9fc05af0877f8f3a50ab28870c"
+  integrity sha512-sL9F4WMhhR6I9bE7bpsPVHnK1cN9doaFHAuy5YmD+Sw6OyO0TAmNgQFx4xZWqboA5ZwSkN0tWcRCr6wGXaRRag==
+  dependencies:
+    "@react-navigation/elements" "^1.3.3"
+    color "^3.1.3"
+    warn-once "^0.1.0"
+
+"@react-navigation/core@^6.2.1":
+  version "6.2.1"
+  resolved "https://registry.yarnpkg.com/@react-navigation/core/-/core-6.2.1.tgz#90459f9afd25b71a9471b0706ebea2cdd2534fc4"
+  integrity sha512-3mjS6ujwGnPA/BC11DN9c2c42gFld6B6dQBgDedxP2djceXESpY2kVTTwISDHuqFnF7WjvRjsrDu3cKBX+JosA==
+  dependencies:
+    "@react-navigation/routers" "^6.1.0"
+    escape-string-regexp "^4.0.0"
+    nanoid "^3.1.23"
+    query-string "^7.0.0"
+    react-is "^16.13.0"
+
+"@react-navigation/elements@^1.3.3":
+  version "1.3.3"
+  resolved "https://registry.yarnpkg.com/@react-navigation/elements/-/elements-1.3.3.tgz#9f56b650a9a1a8263a271628be7342c8121d1788"
+  integrity sha512-Lv2lR7si5gNME8dRsqz57d54m4FJtrwHRjNQLOyQO546ZxO+g864cSvoLC6hQedQU0+IJnPTsZiEI2hHqfpEpw==
+
+"@react-navigation/native@^6.0.10":
+  version "6.0.10"
+  resolved "https://registry.yarnpkg.com/@react-navigation/native/-/native-6.0.10.tgz#c58aa176eb0e63f3641c83a65c509faf253e4385"
+  integrity sha512-H6QhLeiieGxNcAJismIDXIPZgf1myr7Og8v116tezIGmincJTOcWavTd7lPHGnMMXaZg94LlVtbaBRIx9cexqw==
+  dependencies:
+    "@react-navigation/core" "^6.2.1"
+    escape-string-regexp "^4.0.0"
+    fast-deep-equal "^3.1.3"
+    nanoid "^3.1.23"
+
+"@react-navigation/routers@^6.1.0":
+  version "6.1.0"
+  resolved "https://registry.yarnpkg.com/@react-navigation/routers/-/routers-6.1.0.tgz#d5682be88f1eb7809527c48f9cd3dedf4f344e40"
+  integrity sha512-8xJL+djIzpFdRW/sGlKojQ06fWgFk1c5jER9501HYJ12LF5DIJFr/tqBI2TJ6bk+y+QFu0nbNyeRC80OjRlmkA==
+  dependencies:
+    nanoid "^3.1.23"
+
+"@react-navigation/stack@^6.2.1":
+  version "6.2.1"
+  resolved "https://registry.yarnpkg.com/@react-navigation/stack/-/stack-6.2.1.tgz#2b14473579eced6def5cca06860044d60e59d06e"
+  integrity sha512-JI7boxtPAMCBXi4VJHVEq61jLVHFW5f3npvbndS+XfOsv7Gf0f91HOVJ28DS5c2Fn4+CO4AByjUozzlN296X+A==
+  dependencies:
+    "@react-navigation/elements" "^1.3.3"
+    color "^3.1.3"
+    warn-once "^0.1.0"
+
 "@react-spring/animated@~9.4.4":
   version "9.4.4"
   resolved "https://registry.yarnpkg.com/@react-spring/animated/-/animated-9.4.4.tgz#15e21923e55c06ca2bcea432869b91b2f8b07519"
@@ -4878,6 +4936,11 @@
   integrity sha512-anKkLmZZ+xm4p8JWBf4hElkM4XR+EZeA2M9BAkkTldmcyDY4mbdIJnRghDJH3Ov5ooY7/UAoENtmdMSkaAd7Cw==
   dependencies:
     "@types/node" "*"
+
+"@types/hammerjs@^2.0.36":
+  version "2.0.41"
+  resolved "https://registry.yarnpkg.com/@types/hammerjs/-/hammerjs-2.0.41.tgz#f6ecf57d1b12d2befcce00e928a6a097c22980aa"
+  integrity sha512-ewXv/ceBaJprikMcxCmWU1FKyMAQ2X7a9Gtmzw8fcg2kIePI1crERDM818W+XYrxqdBBOdlf2rm137bU+BltCA==
 
 "@types/har-format@*":
   version "1.2.8"
@@ -8492,7 +8555,7 @@ collection-visit@^1.0.0:
     map-visit "^1.0.0"
     object-visit "^1.0.0"
 
-color-convert@^1.9.0:
+color-convert@^1.9.0, color-convert@^1.9.3:
   version "1.9.3"
   resolved "https://registry.yarnpkg.com/color-convert/-/color-convert-1.9.3.tgz#bb71850690e1f136567de629d2d5471deda4c1e8"
   integrity sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==
@@ -8511,15 +8574,31 @@ color-name@1.1.3:
   resolved "https://registry.yarnpkg.com/color-name/-/color-name-1.1.3.tgz#a7d0558bd89c42f795dd42328f740831ca53bc25"
   integrity sha1-p9BVi9icQveV3UIyj3QIMcpTvCU=
 
-color-name@~1.1.4:
+color-name@^1.0.0, color-name@~1.1.4:
   version "1.1.4"
   resolved "https://registry.yarnpkg.com/color-name/-/color-name-1.1.4.tgz#c2a09a87acbde69543de6f63fa3995c826c536a2"
   integrity sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==
+
+color-string@^1.6.0:
+  version "1.9.1"
+  resolved "https://registry.yarnpkg.com/color-string/-/color-string-1.9.1.tgz#4467f9146f036f855b764dfb5bf8582bf342c7a4"
+  integrity sha512-shrVawQFojnZv6xM40anx4CkoDP+fZsw/ZerEMsW/pyzsRbElpsL/DBVW7q3ExxwusdNXI3lXpuhEZkzs8p5Eg==
+  dependencies:
+    color-name "^1.0.0"
+    simple-swizzle "^0.2.2"
 
 color-support@^1.1.2:
   version "1.1.3"
   resolved "https://registry.yarnpkg.com/color-support/-/color-support-1.1.3.tgz#93834379a1cc9a0c61f82f52f0d04322251bd5a2"
   integrity sha512-qiBjkpbMLO/HL68y+lh4q0/O1MZFj2RX6X/KmMa3+gJD3z+WwI1ZzDHysvqHGS3mP6mznPckpXmw1nI9cJjyRg==
+
+color@^3.1.3:
+  version "3.2.1"
+  resolved "https://registry.yarnpkg.com/color/-/color-3.2.1.tgz#3544dc198caf4490c3ecc9a790b54fe9ff45e164"
+  integrity sha512-aBl7dZI9ENN6fUGC7mWpMTPNHmWUSNan9tuWN6ahh5ZLNk9baLJOnSMlrQkHcrfFgz2/RigjUVAjdx36VcemKA==
+  dependencies:
+    color-convert "^1.9.3"
+    color-string "^1.6.0"
 
 colord@^2.9.1:
   version "2.9.2"
@@ -13985,6 +14064,11 @@ is-arrayish@^0.2.1:
   resolved "https://registry.yarnpkg.com/is-arrayish/-/is-arrayish-0.2.1.tgz#77c99840527aa8ecb1a8ba697b80645a7a926a9d"
   integrity sha1-d8mYQFJ6qOyxqLppe4BkWnqSap0=
 
+is-arrayish@^0.3.1:
+  version "0.3.2"
+  resolved "https://registry.yarnpkg.com/is-arrayish/-/is-arrayish-0.3.2.tgz#4574a2ae56f7ab206896fb431eaeed066fdf8f03"
+  integrity sha512-eVRqCvVlZbuw3GrM63ovNSNAeA1K16kaR/LRY/92w0zxQ5/1YzwblUX652i4Xs9RwAGjW9d9y6X88t8OaAJfWQ==
+
 is-bigint@^1.0.1:
   version "1.0.4"
   resolved "https://registry.yarnpkg.com/is-bigint/-/is-bigint-1.0.4.tgz#08147a1875bc2b32005d41ccd8291dffc6691df3"
@@ -17529,10 +17613,10 @@ nanoclone@^0.2.1:
   resolved "https://registry.yarnpkg.com/nanoclone/-/nanoclone-0.2.1.tgz#dd4090f8f1a110d26bb32c49ed2f5b9235209ed4"
   integrity sha512-wynEP02LmIbLpcYw8uBKpcfF6dmg2vcpKqxeH5UcoKEYdExslsdUA4ugFauuaeYdTB76ez6gJW8XAZ6CgkXYxA==
 
-nanoid@^3.1.3, nanoid@^3.1.30, nanoid@^3.3.1:
-  version "3.3.2"
-  resolved "https://registry.yarnpkg.com/nanoid/-/nanoid-3.3.2.tgz#c89622fafb4381cd221421c69ec58547a1eec557"
-  integrity sha512-CuHBogktKwpm5g2sRgv83jEy2ijFzBwMoYA60orPDR7ynsLijJDqgsi4RDGj3OJpy3Ieb+LYwiRmIOGyytgITA==
+nanoid@^3.1.23, nanoid@^3.1.3, nanoid@^3.1.30, nanoid@^3.3.1:
+  version "3.3.4"
+  resolved "https://registry.yarnpkg.com/nanoid/-/nanoid-3.3.4.tgz#730b67e3cd09e2deacf03c027c81c9d9dbc5e8ab"
+  integrity sha512-MqBkQh/OHTS2egovRtLk45wEyNXwF+cokD+1YPf9u5VfJiRdAiRwB2froX5Co9Rh20xs4siNPm8naNotSD6RBw==
 
 nanomatch@^1.2.9:
   version "1.2.13"
@@ -19769,6 +19853,16 @@ query-string@^6.13.8:
     split-on-first "^1.0.0"
     strict-uri-encode "^2.0.0"
 
+query-string@^7.0.0:
+  version "7.1.1"
+  resolved "https://registry.yarnpkg.com/query-string/-/query-string-7.1.1.tgz#754620669db978625a90f635f12617c271a088e1"
+  integrity sha512-MplouLRDHBZSG9z7fpuAAcI7aAYjDLhtsiVZsevsfaHWDS2IDdORKbSd1kWUA+V4zyva/HZoSfpwnYMMQDhb0w==
+  dependencies:
+    decode-uri-component "^0.2.0"
+    filter-obj "^1.1.0"
+    split-on-first "^1.0.0"
+    strict-uri-encode "^2.0.0"
+
 querystring-es3@^0.2.0:
   version "0.2.1"
   resolved "https://registry.yarnpkg.com/querystring-es3/-/querystring-es3-0.2.1.tgz#9ec61f79049875707d69414596fd907a4d711e73"
@@ -20006,6 +20100,11 @@ react-focus-lock@^2.6.0:
     use-callback-ref "^1.2.5"
     use-sidecar "^1.0.5"
 
+react-freeze@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/react-freeze/-/react-freeze-1.0.0.tgz#b21c65fe1783743007c8c9a2952b1c8879a77354"
+  integrity sha512-yQaiOqDmoKqks56LN9MTgY06O0qQHgV4FUrikH357DydArSZHQhl0BJFqGKIZoTqi8JizF9Dxhuk1FIZD6qCaw==
+
 react-helmet-async@^1.0.7:
   version "1.2.2"
   resolved "https://registry.yarnpkg.com/react-helmet-async/-/react-helmet-async-1.2.2.tgz#38d58d32ebffbc01ba42b5ad9142f85722492389"
@@ -20081,7 +20180,7 @@ react-intl@^5.23.0:
     intl-messageformat "9.11.1"
     tslib "^2.1.0"
 
-react-is@16.13.1, react-is@^16.10.2, react-is@^16.13.1, react-is@^16.6.0, react-is@^16.7.0:
+react-is@16.13.1, react-is@^16.10.2, react-is@^16.13.0, react-is@^16.13.1, react-is@^16.6.0, react-is@^16.7.0:
   version "16.13.1"
   resolved "https://registry.yarnpkg.com/react-is/-/react-is-16.13.1.tgz#789729a4dc36de2999dc156dd6c1d9c18cea56a4"
   integrity sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==
@@ -20142,10 +20241,34 @@ react-native-codegen@^0.0.17:
     jscodeshift "^0.13.1"
     nullthrows "^1.1.1"
 
+react-native-gesture-handler@^2.4.2:
+  version "2.4.2"
+  resolved "https://registry.yarnpkg.com/react-native-gesture-handler/-/react-native-gesture-handler-2.4.2.tgz#de93760b0bc251d94e8ae692f9850ec3ed2e4f27"
+  integrity sha512-K3oMiQV7NOVB5RvNlxkyJxU1Gn6m1cYu53MoFA542FVDSTR491d1eQkWDdqy4lW52rfF7IK7eE1LCi+kTJx7jw==
+  dependencies:
+    "@egjs/hammerjs" "^2.0.17"
+    hoist-non-react-statics "^3.3.0"
+    invariant "^2.2.4"
+    lodash "^4.17.21"
+    prop-types "^15.7.2"
+
 react-native-gradle-plugin@^0.0.6:
   version "0.0.6"
   resolved "https://registry.yarnpkg.com/react-native-gradle-plugin/-/react-native-gradle-plugin-0.0.6.tgz#b61a9234ad2f61430937911003cddd7e15c72b45"
   integrity sha512-eIlgtsmDp1jLC24dRn43hB3kEcZVqx6DUQbR0N1ABXGnMEafm9I3V3dUUeD1vh+Dy5WqijSoEwLNUPLgu5zDMg==
+
+react-native-safe-area-context@^4.2.5:
+  version "4.2.5"
+  resolved "https://registry.yarnpkg.com/react-native-safe-area-context/-/react-native-safe-area-context-4.2.5.tgz#23006dc1a398bb825d7d795c27f1c46119efe8a5"
+  integrity sha512-nUil2de1gk/8ZB9IzIxFyGCiKeAYcHzJb/Tks2NzSkev1qH4MNR05DWYDSmW6vLT+y4mospLVyG/H5dyUd+KQQ==
+
+react-native-screens@^3.13.1:
+  version "3.13.1"
+  resolved "https://registry.yarnpkg.com/react-native-screens/-/react-native-screens-3.13.1.tgz#b3b1c5788dca25a71668909f66d87fb35c5c5241"
+  integrity sha512-xcrnuUs0qUrGpc2gOTDY4VgHHADQwp80mwR1prU/Q0JqbZN5W3koLhuOsT6FkSRKjR5t40l+4LcjhHdpqRB2HA==
+  dependencies:
+    react-freeze "^1.0.0"
+    warn-once "^0.1.0"
 
 react-native-web@^0.14.9:
   version "0.14.13"
@@ -20162,7 +20285,7 @@ react-native-web@^0.14.9:
     prop-types "^15.6.0"
     react-timer-mixin "^0.13.4"
 
-react-native@*, react-native@0.66.4, react-native@0.68.2:
+react-native@0.66.4, react-native@0.68.2:
   version "0.68.2"
   resolved "https://registry.yarnpkg.com/react-native/-/react-native-0.68.2.tgz#07547cd31bb9335a7fa4135cfbdc24e067142585"
   integrity sha512-qNMz+mdIirCEmlrhapAtAG+SWVx6MAiSfCbFNhfHqiqu1xw1OKXdzIrjaBEPihRC2pcORCoCHduHGQe/Pz9Yuw==
@@ -21835,6 +21958,13 @@ simple-plist@1.3.1, simple-plist@^1.1.0:
     bplist-creator "0.1.0"
     bplist-parser "0.3.1"
     plist "^3.0.5"
+
+simple-swizzle@^0.2.2:
+  version "0.2.2"
+  resolved "https://registry.yarnpkg.com/simple-swizzle/-/simple-swizzle-0.2.2.tgz#a4da6b635ffcccca33f70d17cb92592de95e557a"
+  integrity sha1-pNprY1/8zMoz9w0Xy5JZLeleVXo=
+  dependencies:
+    is-arrayish "^0.3.1"
 
 sirv@^1.0.7:
   version "1.0.19"
@@ -24494,6 +24624,11 @@ walker@^1.0.7, walker@~1.0.5:
   integrity sha512-ts/8E8l5b7kY0vlWLewOkDXMmPdLcVV4GmOQLyxuSswIJsweeFZtAsMF7k1Nszz+TYBQrlYRmzOnr398y1JemQ==
   dependencies:
     makeerror "1.0.12"
+
+warn-once@^0.1.0:
+  version "0.1.0"
+  resolved "https://registry.yarnpkg.com/warn-once/-/warn-once-0.1.0.tgz#4f58d89b84f968d0389176aa99e0cf0f14ffd4c8"
+  integrity sha512-recZTSvuaH/On5ZU5ywq66y99lImWqzP93+AiUo9LUwG8gXHW+LJjhOd6REJHm7qb0niYqrEQJvbHSQfuJtTqA==
 
 warning@^4.0.2:
   version "4.0.3"


### PR DESCRIPTION
Add structure for react navigation:
- root bottom tab navigation
- tab _settings_ includes stack navigation
- types (screens, navigation, routes)
- tab bar stylying based on [figma](https://www.figma.com/file/Z6AGVUmKQzLNtDozFamW7f/s2-Mobile)
- iOS simulator warning _Module TrezorTransportNative requires main queue setup since it overrides init but does not implement requiresMainQueueSetup_ [fix](https://github.com/trezor/trezor-suite/pull/5455/files#diff-e6a2ba7d7340399c6d3727b466e8f6b06ba8a4752d7340e9c0911f8e0397d51d)

@Nodonisko Please let's discuss about the solution and possible improvements/changes.

[video](https://user-images.githubusercontent.com/2227592/169706671-1f5f068d-9a67-466f-b18c-57d4193b2c89.mov)

Closes https://github.com/trezor/trezor-suite/issues/5422