### PR TITLE
Feat(tor): add logs to tor request manager

### DIFF
--- a/packages/request-manager/src/controller.ts
+++ b/packages/request-manager/src/controller.ts
@@ -17,21 +17,32 @@ export class TorController extends EventEmitter {
         this.controlPort = new TorControlPort(options);
     }
 
-    waitUntilAlive() {
-        const waitUntilResponse = async (triesCount: number) => {
+    waitUntilAlive(): Promise<void> {
+        const errorMessages: string[] = [];
+        const waitUntilResponse = async (triesCount: number): Promise<void> => {
             if (triesCount >= this.maxTriesWaiting) {
-                throw new Error('Timeout waiting for TOR control port');
+                throw new Error(
+                    `Timeout waiting for TOR control port: \n${errorMessages.join('\n')}`,
+                );
             }
-            const isAlive = await this.controlPort
-                .connect()
-                .then(() => this.controlPort.ping())
-                .catch(() => false);
-            if (isAlive) {
-                // It is running so let's not wait anymore.
-                return;
+            try {
+                const isConnected = await this.controlPort.connect();
+                const isAlive = this.controlPort.ping();
+                if (isConnected && isAlive) {
+                    // It is running so let's not wait anymore.
+                    return;
+                }
+            } catch (error) {
+                // Some error here is expected when waiting but
+                // we do not want to throw untill maxTriesWaiting is reach.
+                // Instead we want to log it to know what causes the error.
+                if (error && error.message) {
+                    console.warn('request-manager:', error.message);
+                    errorMessages.push(error.message);
+                }
             }
             await createTimeoutPromise(this.waitingTime);
-            await waitUntilResponse(triesCount + 1);
+            return waitUntilResponse(triesCount + 1);
         };
         return waitUntilResponse(1);
     }

--- a/packages/request-manager/src/torControlPort.ts
+++ b/packages/request-manager/src/torControlPort.ts
@@ -61,7 +61,12 @@ export class TorControlPort {
                         /^250 AUTHCHALLENGE SERVERHASH=([a-fA-F0-9]+) SERVERNONCE=([a-fA-F0-9]+)$/,
                     );
                 if (authchallengeResponse) {
-                    const cookieString = await getCookieString(this.options.authFilePath);
+                    let cookieString;
+                    try {
+                        cookieString = await getCookieString(this.options.authFilePath);
+                    } catch (error) {
+                        reject(new Error('TOR control port control_auth_cookie cannot be read'));
+                    }
                     const serverNonce = authchallengeResponse[2];
                     const authString = `${cookieString}${this.clientNonce}${serverNonce}`;
 

--- a/packages/suite-desktop/src-electron/modules/tor.ts
+++ b/packages/suite-desktop/src-electron/modules/tor.ts
@@ -1,6 +1,7 @@
 /**
  * Tor feature (toggle, configure)
  */
+import { captureException } from '@sentry/electron';
 import { session } from 'electron';
 import TorProcess from '../libs/processes/TorProcess';
 import { onionDomain } from '../config';
@@ -41,9 +42,19 @@ const init: Module = async ({ mainWindow, store, interceptor }) => {
         const shouldRunBundledTor = settings.running;
         if (settings.running !== (await tor.status()).process) {
             if (shouldRunBundledTor === true) {
-                await tor.start();
+                try {
+                    await tor.start();
+                } catch (error) {
+                    logger.error('tor', `Failed to start: ${error.message}`);
+                    captureException(error);
+                }
             } else {
-                await tor.stop();
+                try {
+                    await tor.stop();
+                } catch (error) {
+                    logger.error('tor', `Failed to stop: ${error.message}`);
+                    captureException(error);
+                }
             }
         }
 


### PR DESCRIPTION
Basically a little refactor to catch some errors that might cause the failing of Tor ControlPort and log it properly in sentry.

* 4604d00eef3df7a7ec40b697d2fd017b379ff463 - catch potential error when `control_auth_cookie` is not being created by Tor and throw error
* d591a6ae4457ee91f257283e369618c0e9cb7cba - refactor `waitUntilAlive` method in controller request manager so errors are catch and return so it can be properly log and send to sentry.
* 4c8be607163a07d8bcebf7c9d7ce2b6156799501 - catch errors in starting and stopping tor process 