### PR TITLE
feat(auto-update): setting auto-update feedURL from CLI to simplify testing flow

### DIFF
--- a/packages/suite/src/services/github.ts
+++ b/packages/suite/src/services/github.ts
@@ -28,6 +28,23 @@ export const getReleaseNotes = async (version?: string) => {
     return release as ReleaseInfo;
 };
 
+export const getSignatureFileURL = async (filename: string, version?: string) => {
+    // Get release info from Github
+    const info = await getReleaseNotes(version);
+
+    if (!info) {
+        throw new Error('Version does not exist.');
+    }
+
+    const releaseSignature = info.assets.find(asset => asset.name === `${filename}.asc`);
+
+    if (!releaseSignature) {
+        throw new Error('Signature not found.');
+    }
+
+    return releaseSignature.browser_download_url;
+};
+
 const getDeviceInfo = (device?: TrezorDevice) => {
     if (!device?.features) {
         return '';


### PR DESCRIPTION
closes #5214 

**The goal is the full auto-update from different provider than GIthub to help us with testing auto-update from release candidate to a next version without interfering with Early Access Program.**

This PR is about adapting signature verification and getting release notes methods to work with custom URL (to make it work for versions not yet published on Github).

It is kind of tricky to test this fully, because to finish auto update process you need to start from signed version and update on signed version too. 

### testing:
To be able to test full autoupdate from custom URL:
1. download&install app from this pipeline:
https://gitlab.com/satoshilabs/trezor/trezor-suite/-/pipelines/547816934
1. connect to satoshilabs-vpn
1. run the app from CLI with extra param `--updater-url=https://suite.corp.sldev.cz/suite-desktop/codesign/`
(e.g. on Mac: `/Applications/Trezor\ Suite.app/Contents/MacOS/Trezor\ Suite  --updater-url=https://suite.corp.sldev.cz/suite-desktop/codesign/`)

Suite should offer you the latest version available on the provided updater-url for update and you could do the full update to that version in all possible ways (directly after start with update on next lunch or immediate restart or if you close the dialog on start and check for updates from the Settings).

You will see "Could not retrieve the changelog" for this version, sorry for that. From the next version I will include the release notes to the build so it's available in the update dialog. But link to changelog on GitHub will always lead you to non-existent version if it is not yet available.

