### PR TITLE
chore: Fix hot reload

### DIFF
--- a/.github/workflows/validation.yml
+++ b/.github/workflows/validation.yml
@@ -37,4 +37,4 @@ jobs:
       - name: msg-system config validation
         run: yarn workspace @trezor/suite-data msg-system-validate-config
       - name: unit tests
-        run: lerna run --stream test:unit -- --passWithNoTests
+        run: lerna run --stream test:unit

--- a/packages/analytics/jest.config.js
+++ b/packages/analytics/jest.config.js
@@ -1,3 +1,3 @@
-export default {
+module.exports = {
     preset: '../../jest.config.base.js',
 };

--- a/packages/analytics/package.json
+++ b/packages/analytics/package.json
@@ -4,7 +4,6 @@
     "private": true,
     "license": "See LICENSE.md in repo root",
     "sideEffects": false,
-    "type": "module",
     "main": "src/index",
     "scripts": {
         "lint": "eslint '**/*.{ts,tsx,js}'",

--- a/packages/atoms/jest.config.js
+++ b/packages/atoms/jest.config.js
@@ -1,3 +1,3 @@
-export default {
+module.exports = {
     preset: '../../jest.config.base.js',
 };

--- a/packages/atoms/package.json
+++ b/packages/atoms/package.json
@@ -4,11 +4,10 @@
     "private": true,
     "license": "See LICENSE.md in repo root",
     "sideEffects": false,
-    "type": "module",
     "main": "src/index",
     "scripts": {
         "lint": "eslint '**/*.{ts,tsx,js}'",
-        "test:unit": "jest",
+        "test:unit": "jest --passWithNoTests",
         "type-check": "tsc --build",
         "generate-icons": "yarn run-script generateIcons.js",
         "run-script": "babel-node --experimental-specifier-resolution=node --"

--- a/packages/connect-web/package.json
+++ b/packages/connect-web/package.json
@@ -26,7 +26,7 @@
     "scripts": {
         "predev": "node webpack/generate_dev_cert.js",
         "lint": "eslint '**/*.{ts,tsx,js}'",
-        "test:unit": "jest",
+        "test:unit": "jest --passWithNoTests",
         "type-check": "tsc --build",
         "build:lib": "rimraf ./lib && tsc --build tsconfig.lib.json",
         "dev": "rimraf build && TS_NODE_PROJECT=\"tsconfig.lib.json\" webpack --config ./webpack/dev.webpack.config.ts",

--- a/packages/request-manager/package.json
+++ b/packages/request-manager/package.json
@@ -11,7 +11,7 @@
     ],
     "scripts": {
         "lint": "eslint '**/*.{ts,tsx,js}'",
-        "test:unit": "jest --verbose -c jest.config.js",
+        "test:unit": "jest --passWithNoTests",
         "type-check": "tsc --build tsconfig.json",
         "build:lib": "rimraf ./lib && tsc --build tsconfig.lib.json"
     },

--- a/packages/styles/jest.config.js
+++ b/packages/styles/jest.config.js
@@ -1,3 +1,3 @@
-export default {
+module.exports = {
     preset: '../../jest.config.base.js',
 };

--- a/packages/styles/package.json
+++ b/packages/styles/package.json
@@ -4,7 +4,6 @@
     "private": true,
     "license": "SEE ROOT LICENSE.md",
     "main": "src/index",
-    "type": "module",
     "sideEffects": false,
     "scripts": {
         "type-check": "tsc --build",

--- a/packages/suite-analytics/jest.config.js
+++ b/packages/suite-analytics/jest.config.js
@@ -1,3 +1,3 @@
-export default {
+module.exports = {
     preset: '../../jest.config.base.js',
 };

--- a/packages/suite-analytics/package.json
+++ b/packages/suite-analytics/package.json
@@ -4,11 +4,10 @@
     "private": true,
     "license": "See LICENSE.md in repo root",
     "sideEffects": false,
-    "type": "module",
     "main": "src/index",
     "scripts": {
         "lint": "eslint '**/*.{ts,tsx,js}'",
-        "test:unit": "jest",
+        "test:unit": "jest --passWithNoTests",
         "type-check": "tsc --build"
     },
     "dependencies": {

--- a/packages/suite-analytics/tsconfig.json
+++ b/packages/suite-analytics/tsconfig.json
@@ -1,8 +1,6 @@
 {
     "extends": "../../tsconfig.json",
-    "compilerOptions": {
-        "outDir": "libDev"
-    },
+    "compilerOptions": { "outDir": "libDev" },
     "include": ["./package.json"],
     "references": [{ "path": "../analytics" }]
 }

--- a/packages/theme/package.json
+++ b/packages/theme/package.json
@@ -4,7 +4,6 @@
     "private": true,
     "license": "See LICENSE.md in repo root",
     "sideEffects": false,
-    "type": "module",
     "main": "src/index",
     "scripts": {
         "lint": "eslint '**/*.{ts,tsx,js}'",

--- a/packages/validation/package.json
+++ b/packages/validation/package.json
@@ -6,7 +6,6 @@
     "sideEffects": [
         "src/config.ts"
     ],
-    "type": "module",
     "main": "src/index",
     "scripts": {
         "lint": "eslint '**/*.{ts,tsx,js}'",

--- a/scripts/package-template/jest.config.js
+++ b/scripts/package-template/jest.config.js
@@ -1,3 +1,3 @@
-export default {
+module.exports = {
     preset: '../../jest.config.base.js',
 };

--- a/scripts/package-template/package.json
+++ b/scripts/package-template/package.json
@@ -5,10 +5,9 @@
     "license": "See LICENSE.md in repo root",
     "private": true,
     "sideEffects": false,
-    "type": "module",
     "scripts": {
         "type-check": "tsc --build",
         "lint": "eslint '**/*.{ts,tsx,js}'",
-        "test:unit": "jest"
+        "test:unit": "jest --passWithNoTests"
     }
 }


### PR DESCRIPTION
For those who are curious where the problem was. It look there is something(bug?) in webpack hot module replacement that is causing `exports is not defined` error when we combine `commonjs` with `ESmodules` that have `type: "module"` in `package.json`.

Removing `type: "module"` will solve this issue because webpack will fallback to [default behavior](https://webpack.js.org/guides/ecma-script-modules/#flagging-modules-as-esm) when it will detect module type per file based on syntax (import vs require) inside of file.

Example of error:
![Screenshot from 2022-05-19 19-00-12](https://user-images.githubusercontent.com/5837757/170023128-e0259690-ea10-44eb-bd0f-218e77fe84d7.png)

