### PR TITLE
fix(message-system): no config validity check on DEVICE.CHANGED event

### DIFF
--- a/packages/suite/src/middlewares/suite/messageSystemMiddleware.ts
+++ b/packages/suite/src/middlewares/suite/messageSystemMiddleware.ts
@@ -1,5 +1,5 @@
 import { MiddlewareAPI } from 'redux';
-import { DEVICE, TRANSPORT } from '@trezor/connect';
+import { TRANSPORT } from '@trezor/connect';
 
 import { MESSAGE_SYSTEM, STORAGE, SUITE } from '@suite-actions/constants';
 import { getValidMessages } from '@suite-utils/messageSystem';
@@ -16,7 +16,6 @@ const actions = [
     MESSAGE_SYSTEM.FETCH_CONFIG_SUCCESS_UPDATE,
     WALLET_SETTINGS.CHANGE_NETWORKS,
     TRANSPORT.START,
-    DEVICE.CHANGED,
 ];
 
 const messageSystemMiddleware =


### PR DESCRIPTION
close #5469

When a device is connected or updated, it also fires `SUITE.SELECT_DEVICE` so it should be saved to remove it.