### PR TITLE
feat(ci): connect v9 production release setup

### DIFF
--- a/.github/workflows/connect-version_check.yml
+++ b/.github/workflows/connect-version_check.yml
@@ -1,0 +1,25 @@
+name: "Connect version check"
+
+on:
+  push:
+    branches: [release/connect-v9]
+
+jobs:
+  version_beta_check:
+    name: Check if connect version is beta
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - run: |
+          bash ./scripts/ci-check-beta-version.sh
+
+  version_bump_check:
+    name: Check connect version bump
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-node@v3
+      - run: |
+          yarn install
+          REMOTE_VERSION=$(npm show trezor-connect version)
+          node ci/scripts/ci-check-version.js $REMOTE_VERSION npm-release

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -26,5 +26,8 @@
     },
     "[json]": {
         "editor.defaultFormatter": "esbenp.prettier-vscode"
+    },
+    "[shellscript]": {
+        "editor.defaultFormatter": "foxundermoon.shell-format"
     }
 }

--- a/ci/releases.yml
+++ b/ci/releases.yml
@@ -99,3 +99,36 @@ msg-system codesign deploy:
     - source ${MSG_SYSTEM_DATA_DEPLOY_KEYFILE}
     - aws s3 cp packages/suite-data/files/message-system/config.v1.jws s3://data.trezor.io/config/stable/config.v1.jws
     - aws cloudfront create-invalidation --distribution-id ${AWS_CLOUDFRONT_ID} --paths '/config/stable/*'
+
+# connect v9 deploy to production jobs
+
+# Create rollback copy of connect.trezo.io
+connect v9 rollback production:
+  stage: deploy to production
+  only:
+    refs:
+      - release/connect-v9
+  when: manual
+  before_script: []
+  script:
+    - source ${CONNECT_DEPLOY_KEYFILE}
+    - aws s3 sync s3://connect.trezor.io s3://rollback-connect.trezor.io
+  tags:
+    - connect_deploy
+
+# Deploy connect v9 to connect.trezor.io
+connect v9 deploy production:
+  stage: deploy to production
+  only:
+    refs:
+      - release/connect-v9
+  when: manual
+  dependencies:
+    - connect-web build
+    - connect-explorer build
+  before_script: []
+  script:
+    - source ${CONNECT_DEPLOY_KEYFILE}
+    - ./ci/scripts/connect-release.sh 9
+  tags:
+    - connect_deploy

--- a/ci/scripts/check-package-beta-version.sh
+++ b/ci/scripts/check-package-beta-version.sh
@@ -1,0 +1,15 @@
+#!/usr/bin/env bash
+
+VERSION=$(jq -r .version package.json)
+
+[[ "$VERSION" != *"beta"* ]]
+
+if [ $? -eq 0 ]; then
+    echo "Not a beta version, all good."
+    exit 0
+
+else
+    echo "FAIL! package.json contains beta version!" >&2
+
+    exit 1
+fi

--- a/ci/scripts/connect-release.sh
+++ b/ci/scripts/connect-release.sh
@@ -1,0 +1,44 @@
+#!/usr/bin/env bash
+
+set -e -o pipefail
+
+# Usage:
+# ./connect-release.sh DESTINATION
+# @DESTINATION: required, destination directory (connect major version)
+
+# Validate params
+while [[ "$#" > 0 ]]; do case $1 in
+    9)
+        latest_version="9"
+        current_version=$(jq -r .version packages/connect/package.json)
+        shift
+        ;;
+    *)
+        echo "Invalid version parameter passed: $1
+Used only for version 9"
+        exit 1
+        shift
+        ;;
+    esac done
+
+echo "Uploading to s3://connect.trezor.io/$latest_version/ and s3://connect.trezor.io/$current_version/"
+
+# organize the files in one directory
+tmp_folder="tmp-connect-release"
+
+mkdir $tmp_folder/
+cp -r packages/connect-iframe/build/* $tmp_folder/.
+cp -r packages/connect-popup/build/* $tmp_folder/.
+cp -r packages/connect-web/build/* $tmp_folder/.
+cp -r packages/connect-explorer/build/* $tmp_folder/.
+
+# sync the files to aws
+aws s3 sync --delete --cache-control 'public, max-age=3600' $tmp_folder/ s3://connect.trezor.io/$latest_version/
+aws s3 sync --delete --cache-control 'public, max-age=3600' $tmp_folder/ s3://connect.trezor.io/$current_version/
+aws cloudfront create-invalidation --distribution-id E3LVNAOGT94E37 --paths '/*'
+
+# cleaning up
+echo "Cleaning up"
+rm -rf $tmp_folder
+
+echo "DONE"


### PR DESCRIPTION
Sets up connect v9 release to production from suite monorepo. Using its own deploy runner and configuration. 
Release to production will be possible only from the branch `release/connect-v9`

branch `release/connect-v9` should be protected and only select people should be able to push and merge content there. 

I would also keep the exact same setup as we had in connect. Meaning PR from develop to release/connect-v9 only and not from any other branches.

Next steps

- [ ] Branch `release/connect-v9` but after this is merged
- [ ] Setup that branch as protected
- [ ] Update docs? 