### PR TITLE
Fix: Remembered backend used even if inaccessible

### DIFF
--- a/packages/connect/src/backend/BlockchainLink.ts
+++ b/packages/connect/src/backend/BlockchainLink.ts
@@ -309,8 +309,13 @@ const setPreferredBacked = (coinInfo: CoinInfo, url?: string) => {
     if (!url) {
         delete preferredBackends[coinInfo.shortcut];
     } else if (coinInfo.blockchainLink) {
-        coinInfo.blockchainLink.url = [url];
-        preferredBackends[coinInfo.shortcut] = coinInfo;
+        preferredBackends[coinInfo.shortcut] = {
+            ...coinInfo,
+            blockchainLink: {
+                ...coinInfo.blockchainLink,
+                url: [url],
+            },
+        };
     }
 };
 
@@ -322,8 +327,10 @@ export const setCustomBackend = (
     if (!blockchainLink || blockchainLink.url.length === 0) {
         delete customBackends[coinInfo.shortcut];
     } else {
-        customBackends[coinInfo.shortcut] = coinInfo;
-        customBackends[coinInfo.shortcut].blockchainLink = blockchainLink;
+        customBackends[coinInfo.shortcut] = {
+            ...coinInfo,
+            blockchainLink,
+        };
     }
 };
 


### PR DESCRIPTION
Small fix regarding https://github.com/trezor/trezor-suite/pull/5408#issuecomment-1135523534.

[linux](https://gitlab.com/satoshilabs/trezor/trezor-suite/-/jobs/2499430634/artifacts/download) | [windows](https://gitlab.com/satoshilabs/trezor/trezor-suite/-/jobs/2499430661/artifacts/download) | [mac](https://gitlab.com/satoshilabs/trezor/trezor-suite/-/jobs/2499430630/artifacts/download)

Last successfully connected backend is by design remembered in `connect`, so Suite always uses this one (if accessible) until the application exits or custom backends are changed. But due to passing the object by reference, its url rewrote all the previous custom backends urls from the user, so the remembered backend was the only one tried even if it became unavailable (e.g. by turning Tor off).

The fix should only clone the `coinInfo` settings objects before storing them and therefore effectively make them immutable (at least in current context).
