### PR TITLE
fix(analytics): report to stable.log only from codesign builds

### DIFF
--- a/packages/analytics/src/tests/analytics.test.ts
+++ b/packages/analytics/src/tests/analytics.test.ts
@@ -17,7 +17,7 @@ describe('analytics', () => {
 
         const app = 'suite';
         const environment = 'desktop';
-        const isDev = false;
+        const isDev = true;
         const instanceId = getRandomId();
         const sessionId = getRandomId();
         const commitId = 'abc';
@@ -32,7 +32,7 @@ describe('analytics', () => {
 
         expect(global.fetch).toHaveBeenNthCalledWith(
             1,
-            `https://data.trezor.io/${app}/log/${environment}/stable.log?c_v=1.18&c_type=${actionType}&c_commit=${commitId}&c_instance_id=${instanceId}&c_session_id=${sessionId}&c_timestamp=${timestamp}`,
+            `https://data.trezor.io/${app}/log/${environment}/develop.log?c_v=1.18&c_type=${actionType}&c_commit=${commitId}&c_instance_id=${instanceId}&c_session_id=${sessionId}&c_timestamp=${timestamp}`,
             { method: 'GET' },
         );
         expect(global.fetch).toHaveBeenCalledTimes(1);
@@ -53,7 +53,7 @@ describe('analytics', () => {
 
         const app = 'suite';
         const environment = 'desktop';
-        const isDev = false;
+        const isDev = true;
         const instanceId = getRandomId();
         const sessionId = getRandomId();
         const commitId = 'abc';

--- a/packages/suite-analytics/CHANGELOG.md
+++ b/packages/suite-analytics/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 This changelog lists changes in suite events.
 
+### 1.20
+
+-   analytics 1.19 was never released due to a bug
+
 ### 1.19
 
 Added:

--- a/packages/suite-analytics/package.json
+++ b/packages/suite-analytics/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@trezor/suite-analytics",
-    "version": "0.1.19",
+    "version": "0.1.20",
     "private": true,
     "license": "See LICENSE.md in repo root",
     "sideEffects": false,

--- a/packages/suite/src/actions/suite/analyticsActions.ts
+++ b/packages/suite/src/actions/suite/analyticsActions.ts
@@ -10,7 +10,6 @@ import { ANALYTICS } from '@suite-actions/constants';
 import { getTrackingRandomId } from '@suite-utils/random';
 import { allowSentryReport, setSentryUser } from '@suite-utils/sentry';
 import { AnalyticsState } from '@suite-reducers/analyticsReducer';
-import { isDev } from '@suite-utils/build';
 import { getEnvironment } from '@suite-utils/env';
 import { hasUserAllowedTracking } from '@suite-utils/analytics';
 
@@ -64,7 +63,7 @@ export const init = (state: AnalyticsState) => (dispatch: Dispatch) => {
         sessionId,
         environment: getEnvironment(),
         commitId: process.env.COMMITHASH || '',
-        isDev,
+        isDev: !process.env.CODESIGN_BUILD,
         callbacks: {
             onEnable: () => dispatch(enable()),
             onDisable: () => dispatch(disable()),

--- a/packages/suite/src/utils/suite/analytics.ts
+++ b/packages/suite/src/utils/suite/analytics.ts
@@ -27,16 +27,11 @@ export const redactTransactionIdFromAnchor = (anchor?: string) => {
     return anchor.startsWith(AccountTransactionBaseAnchor) ? AccountTransactionBaseAnchor : anchor;
 };
 
+// allow tracking only if user already confirmed data collection
 export const hasUserAllowedTracking = (
     enabled: AnalyticsState['enabled'],
     confirmed: AnalyticsState['confirmed'],
-) => {
-    const isConfirmed = !!confirmed;
-    const isEnabled = isConfirmed ? !!enabled : true;
-
-    // allow tracking only if user already confirmed data collection
-    return isConfirmed && isEnabled;
-};
+) => !!confirmed && !!enabled;
 
 export const getSuiteReadyPayload = (state: AppState) => ({
     language: state.suite.settings.language,


### PR DESCRIPTION
- only codesign builds should send analytics to `stable.log` endpoint