### PR TITLE
fix(suite): fix GuidePanel position

### DIFF
--- a/packages/components/src/components/Dropdown/index.tsx
+++ b/packages/components/src/components/Dropdown/index.tsx
@@ -68,7 +68,7 @@ const Menu = styled.ul<MenuProps>`
     padding: ${props => props.topPadding}px ${props => props.horizontalPadding}px
         ${props => props.bottomPadding}px;
     border-radius: 10px;
-    z-index: ${Z_INDEX.NAVIGATION_BAR};
+    z-index: ${Z_INDEX.TOOLTIP};
 
     ${props =>
         props.coords &&

--- a/packages/suite/src/components/guide/GuideButton.tsx
+++ b/packages/suite/src/components/guide/GuideButton.tsx
@@ -6,7 +6,7 @@ import { resolveStaticPath } from '@trezor/utils';
 import { useGuide } from '@guide-hooks';
 import { FreeFocusInside } from 'react-focus-lock';
 
-const Wrapper = styled.button`
+const Wrapper = styled.button<{ $isGuideOpen: boolean }>`
     display: flex;
     justify-content: center;
     align-items: center;
@@ -23,18 +23,23 @@ const Wrapper = styled.button`
     box-shadow: 0 2px 7px 0 ${({ theme }) => theme.BOX_SHADOW_BLACK_15},
         0 2px 3px 0 ${({ theme }) => theme.BOX_SHADOW_BLACK_5};
     transition: opacity 0.3s ease 0.3s;
+    opacity: ${({ $isGuideOpen }) => ($isGuideOpen ? 0 : 1)};
 
-    & > img {
+    :focus {
+        transition: opacity 0.1s ease; /* hide button faster on guide open to prevent overlap */
+    }
+
+    > img {
         display: block;
     }
 `;
 
 export const GuideButton = () => {
-    const { openGuide } = useGuide();
+    const { openGuide, isGuideOpen } = useGuide();
 
     return (
         <FreeFocusInside>
-            <Wrapper data-test="@guide/button-open" onClick={openGuide}>
+            <Wrapper data-test="@guide/button-open" onClick={openGuide} $isGuideOpen={isGuideOpen}>
                 <img
                     src={resolveStaticPath('/images/suite/lightbulb.svg')}
                     width="18"

--- a/packages/suite/src/components/guide/GuidePanel.tsx
+++ b/packages/suite/src/components/guide/GuidePanel.tsx
@@ -41,7 +41,6 @@ const StyledBackdrop = styled(Backdrop)`
 `;
 
 const GuideWrapper = styled.div`
-    position: relative; /* non-static position enables covering the GuideButton by the GuidePanel */
     max-width: 100vw;
     height: 100%;
     z-index: ${variables.Z_INDEX.GUIDE};


### PR DESCRIPTION
https://user-images.githubusercontent.com/42465546/171625004-8b3d04e4-044e-48d9-b544-e80968b6bc22.mov

Fixes stacking of `GuidePanel` and `Dropdown` reported by QA with the video. Reverts to hiding the `GuideButton` by changing `opacity` rather than by `z-index` setting. By removing `transition-delay`, slightly improves the `transition` on `opacity` in `GuideButton` when guide is opening.

QA: Please check the bug is gone and guide opens/closes as expected.