### PR TITLE
Support 50-digit PIN for T1.

### DIFF
--- a/packages/suite/src/actions/settings/deviceSettingsActions.ts
+++ b/packages/suite/src/actions/settings/deviceSettingsActions.ts
@@ -48,6 +48,15 @@ export const changePin =
             dispatch(addToast({ type: 'pin-changed' }));
         } else if (result.payload.code === 'Failure_PinMismatch') {
             dispatch(modalActions.openModal({ type: 'pin-mismatch' }));
+        } else if (result.payload.error.includes('string overflow')) {
+            // this is a workaround for FW < 1.10.0
+            // translate generic error from the device if the entered PIN is longer than 9 digits
+            dispatch(
+                addToast({
+                    type: 'error',
+                    error: 'Please upgrade your firmware to enable extended PIN format.',
+                }),
+            );
         } else {
             dispatch(addToast({ type: 'error', error: result.payload.error }));
         }

--- a/packages/suite/src/components/suite/PinMatrix.tsx
+++ b/packages/suite/src/components/suite/PinMatrix.tsx
@@ -83,7 +83,7 @@ export const PinMatrix = ({ device, hideExplanation, invalid }: Props) => {
                               },
                         {
                             key: 'maxlength',
-                            title: <Translation id="TR_MAXIMUM_LENGTH_IS_9_DIGITS" />,
+                            title: <Translation id="TR_MAXIMUM_PIN_LENGTH" />,
                             icon: 'ASTERISK',
                             iconSize: 20,
                         },

--- a/packages/suite/src/constants/suite/inputs.ts
+++ b/packages/suite/src/constants/suite/inputs.ts
@@ -1,5 +1,5 @@
 export enum MAX_LENGTH {
-    PIN = 9,
+    PIN = 50,
     PASSPHRASE = 50,
 
     BTC_MESSAGE = 255,

--- a/packages/suite/src/support/messages.ts
+++ b/packages/suite/src/support/messages.ts
@@ -2279,9 +2279,9 @@ export default defineMessages({
             'Litecoin changed the format of addresses. Find more info about how to convert your address on our blog. {TR_LEARN_MORE}',
         id: 'TR_LTC_ADDRESS_INFO',
     },
-    TR_MAXIMUM_LENGTH_IS_9_DIGITS: {
-        defaultMessage: "Enter up to 9 digits on your Trezor's keypad.",
-        id: 'TR_MAXIMUM_LENGTH_IS_9_DIGITS',
+    TR_MAXIMUM_PIN_LENGTH: {
+        defaultMessage: 'Enter up to 50 digits.',
+        id: 'TR_MAXIMUM_PIN_LENGTH',
     },
     TR_MESSAGE: {
         defaultMessage: 'Message',


### PR DESCRIPTION
Fixes https://github.com/trezor/trezor-suite/issues/3737, however the issue with the sentence not making sense still needs to be fixed in Hungarian, Japanese and Chinese. I don't know anything about how [Crowdin translations](https://crowdin.com/project/trezor-suite/) work and if something needs to be updated elsewhere. Note that I changed `TR_MAXIMUM_LENGTH_IS_9_DIGITS` to `TR_MAXIMUM_PIN_LENGTH`.
