### PR TITLE
fix(suite): reduce padding to fix guide layout on Windows

### DIFF
--- a/packages/suite/src/components/guide/Content.tsx
+++ b/packages/suite/src/components/guide/Content.tsx
@@ -3,7 +3,7 @@ import styled from 'styled-components';
 
 const Wrapper = styled.div`
     height: 100%;
-    padding: 15px 22px 0;
+    padding: 15px 21px 0;
 `;
 
 type ContentProps = {

--- a/packages/suite/src/components/guide/Header.tsx
+++ b/packages/suite/src/components/guide/Header.tsx
@@ -11,7 +11,7 @@ import { HeaderBreadcrumb, ContentScrolledContext } from '@guide-components';
 const HeaderWrapper = styled.div<{ noLabel?: boolean; isScrolled: boolean }>`
     display: flex;
     align-items: center;
-    padding: 12px 22px;
+    padding: 12px 21px;
     position: sticky;
     top: 0;
     background-color: inherit;


### PR DESCRIPTION
Fixes a UI bug reported by @STew790: guide layout is different on Windows.
![image](https://user-images.githubusercontent.com/42465546/171877979-26ecc1dc-5555-4117-9606-70f16f6d58f7.png)
 
 The bug was introduced in #5366. It is caused by different scrollbar width on Windows and Mac.
 
 QA: Guide should look the same on Windows and Mac (two buttons per line).