### PR TITLE
fix(connect-explorer): change dev port to 8082

### DIFF
--- a/packages/connect-explorer/webpack/dev.webpack.config.ts
+++ b/packages/connect-explorer/webpack/dev.webpack.config.ts
@@ -21,7 +21,7 @@ const dev: webpack.Configuration = {
     },
     plugins: [
         new WebpackPluginServe({
-            port: 8088,
+            port: 8082,
             hmr: true,
             static: [
                 path.join(__dirname, '../build'),


### PR DESCRIPTION
Change port in `connect-explorer` to really have the one that is mentioned in the [README](https://github.com/trezor/trezor-suite/blob/develop/packages/connect-explorer/README.md?plain=1#L8).

Besides port `8088` is the same that connect-web and it wouldn't be possible to run both at same time.