### PR TITLE
chore(connect): add "amountUnit" field to signTransaction method

### DIFF
--- a/docs/packages/connect/methods/signTransaction.md
+++ b/docs/packages/connect/methods/signTransaction.md
@@ -31,6 +31,8 @@ const result = await TrezorConnect.signTransaction(params);
 -   `timestamp` - _optional_ `number` only for Capricoin, transaction timestamp,
 -   `branchId` - _optional_ `number`, only for Zcash, BRANCH_ID when overwintered is set
 -   `push` - _optional_ `boolean` Broadcast signed transaction to blockchain. Default is set to false
+-   `amountUnit` — _optional_ `PROTO.AmountUnit`
+    > show amounts in BTC, mBTC, uBTC, sat
 
 ### Example
 

--- a/packages/connect/src/api/signTransaction.ts
+++ b/packages/connect/src/api/signTransaction.ts
@@ -61,6 +61,7 @@ export default class SignTransaction extends AbstractMethod<'signTransaction', P
             { name: 'decredStakingTicket', type: 'boolean' },
             { name: 'push', type: 'boolean' },
             { name: 'preauthorized', type: 'boolean' },
+            { name: 'amountUnit', type: ['number', 'string'] },
         ]);
 
         const coinInfo = getBitcoinNetwork(payload.coin);
@@ -108,6 +109,7 @@ export default class SignTransaction extends AbstractMethod<'signTransaction', P
                 version_group_id: payload.versionGroupId,
                 branch_id: payload.branchId,
                 decred_staking_ticket: payload.decredStakingTicket,
+                amount_unit: payload.amountUnit,
             },
             coinInfo,
             push: typeof payload.push === 'boolean' ? payload.push : false,

--- a/packages/connect/src/data/config.ts
+++ b/packages/connect/src/data/config.ts
@@ -156,7 +156,7 @@ export const config = {
             ],
         },
         {
-            capabilities: ['replaceTransaction'],
+            capabilities: ['replaceTransaction', 'amountUnit'],
             min: ['1.9.4', '2.3.5'],
             comment: ['new sign tx process since 1.9.4/2.3.5'],
         },

--- a/packages/connect/src/types/api/signTransaction.ts
+++ b/packages/connect/src/types/api/signTransaction.ts
@@ -49,6 +49,7 @@ export interface TransactionOptions {
     timestamp?: number;
     branch_id?: number;
     decred_staking_ticket?: boolean;
+    amount_unit?: PROTO.AmountUnit;
 }
 
 export interface SignTransaction {
@@ -70,6 +71,7 @@ export interface SignTransaction {
     decredStakingTicket?: boolean;
     push?: boolean;
     preauthorized?: boolean;
+    amountUnit?: PROTO.AmountUnit;
 }
 
 export type SignedTransaction = {

--- a/packages/connect/src/utils/__tests__/deviceFeaturesUtils.test.ts
+++ b/packages/connect/src/utils/__tests__/deviceFeaturesUtils.test.ts
@@ -131,6 +131,7 @@ describe('utils/deviceFeaturesUtils', () => {
                 xvg: 'update-required',
                 zcr: 'update-required',
                 replaceTransaction: 'update-required',
+                amountUnit: 'update-required',
                 decreaseOutput: 'update-required',
                 eip1559: 'update-required',
                 'eip712-domain-only': 'update-required',
@@ -143,6 +144,7 @@ describe('utils/deviceFeaturesUtils', () => {
             // @ts-expect-error incomplete features
             expect(getUnavailableCapabilities(feat2, coins)).toEqual({
                 replaceTransaction: 'update-required',
+                amountUnit: 'update-required',
                 decreaseOutput: 'update-required',
                 eip1559: 'update-required',
                 'eip712-domain-only': 'update-required',


### PR DESCRIPTION
Prerequisite for https://github.com/trezor/trezor-suite/pull/5526

usage by `PROTO.AmountUnit` enum value
``` 
TrezorConnect.signTransaction({ ..., amountUnit: 3 });
```
or enum key
```
TrezorConnect.signTransaction({ ..., amountUnit: 'SATOSHI' });
```

![Screenshot from 2022-06-06 10-37-05](https://user-images.githubusercontent.com/3435913/172128249-219e3d18-e3e7-45e4-9d4a-b0e2cf603288.png)
![Screenshot from 2022-06-06 10-36-37](https://user-images.githubusercontent.com/3435913/172128271-4bb2be9b-0cbb-43d5-a1cc-14b99d75009a.png)
![Screenshot from 2022-06-06 10-36-03](https://user-images.githubusercontent.com/3435913/172128275-2463f560-7afb-43a3-a4c7-9a5e3efdf9eb.png)
![Screenshot from 2022-06-06 10-34-46](https://user-images.githubusercontent.com/3435913/172128277-ba721436-a0b4-4fcd-8b30-135ec0ea90ce.png)
![Screenshot from 2022-06-06 10-34-04](https://user-images.githubusercontent.com/3435913/172128280-5b84e46b-8383-4a10-a49e-ab312b5467f5.png)
![Screenshot from 2022-06-06 10-33-33](https://user-images.githubusercontent.com/3435913/172128283-a76501db-92cc-4e75-abb6-f66bb457e6e1.png)

