### PR TITLE
chore: update trezor-utils version

### DIFF
--- a/packages/blockchain-link/package.json
+++ b/packages/blockchain-link/package.json
@@ -58,7 +58,7 @@
         "worker-loader": "^3.0.8"
     },
     "dependencies": {
-        "@trezor/utils": "^1.0.0",
+        "@trezor/utils": "^9.0.1",
         "@trezor/utxo-lib": "^1.0.0",
         "@types/web": "^0.0.51",
         "bignumber.js": "^9.0.1",

--- a/packages/connect-web/package.json
+++ b/packages/connect-web/package.json
@@ -36,7 +36,7 @@
     },
     "dependencies": {
         "@trezor/connect": "9.0.0-beta.1",
-        "@trezor/utils": "^1.0.1",
+        "@trezor/utils": "^9.0.1",
         "events": "^3.3.0",
         "tslib": "^2.3.1"
     },

--- a/packages/connect/package.json
+++ b/packages/connect/package.json
@@ -44,7 +44,7 @@
     "dependencies": {
         "@trezor/blockchain-link": "^2.1.3",
         "@trezor/transport": "^1.1.2",
-        "@trezor/utils": "^1.0.1",
+        "@trezor/utils": "^9.0.1",
         "@trezor/utxo-lib": "^1.0.0",
         "bignumber.js": "^9.0.2",
         "bowser": "^2.11.0",

--- a/packages/integration-tests/package.json
+++ b/packages/integration-tests/package.json
@@ -23,7 +23,7 @@
         "@playwright/test": "^1.19.1",
         "@trezor/suite-analytics": "*",
         "@trezor/transport": "1.1.2",
-        "@trezor/utils": "^1.0.0",
+        "@trezor/utils": "^9.0.1",
         "chrome-remote-interface": "^0.31.2",
         "cypress-image-snapshot": "^4.0.1",
         "cypress-wait-until": "^1.7.2",

--- a/packages/transport/package.json
+++ b/packages/transport/package.json
@@ -37,7 +37,7 @@
         "@types/w3c-web-usb": "^1.0.5"
     },
     "dependencies": {
-        "@trezor/utils": "^1.0.0",
+        "@trezor/utils": "^9.0.1",
         "bytebuffer": "^5.0.1",
         "json-stable-stringify": "^1.0.1",
         "long": "^4.0.0",

--- a/packages/utils/package.json
+++ b/packages/utils/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@trezor/utils",
-    "version": "1.0.2",
+    "version": "9.0.1",
     "author": "Trezor <info@trezor.io>",
     "homepage": "https://github.com/trezor/trezor-suite/packages/utils",
     "description": "A collection of typescript utils that are intended to be used across trezor-suite monorepo.",

--- a/packages/utxo-lib/package.json
+++ b/packages/utxo-lib/package.json
@@ -33,7 +33,7 @@
         "build:lib": "rimraf lib && tsc --build ./tsconfig.lib.json"
     },
     "dependencies": {
-        "@trezor/utils": "^1.0.0",
+        "@trezor/utils": "^9.0.1",
         "bchaddrjs": "^0.5.2",
         "bech32": "^2.0.0",
         "bip66": "^1.1.5",


### PR DESCRIPTION
We had [accidental](https://github.com/trezor/trezor-suite/pull/5495#issuecomment-1138542249) release of `@trezor/utils` so we should update all the packages that use it as dependency.

https://www.npmjs.com/package/@trezor/utils

This PR is a part of https://github.com/trezor/trezor-suite/issues/5505
