### PR TITLE
docs(connect-explorer): change port in README

### DIFF
--- a/packages/connect-explorer/README.md
+++ b/packages/connect-explorer/README.md
@@ -5,4 +5,8 @@ This package serves as:
 -   an interactive documentation for [@trezor/connect](../connect) package
 -   a referential implementation of @trezor/connect-web in "popup mode"
 
-`yarn dev` - runs dev server on port 8082
+`yarn dev` - runs a dev server on port `8088` that provides:
+
+-   connect-explorer - `http://localhost:8088`
+-   connect-popup - `http://localhost:8088/popup.html`
+-   connect-iframe - `http://localhost:8088/iframe.html`


### PR DESCRIPTION
Just a detail to have the right port in the connect-explorer README.