### PR TITLE
Fix/connect passphrase tests

### DIFF
--- a/.github/workflows/connect-test.yml
+++ b/.github/workflows/connect-test.yml
@@ -6,6 +6,7 @@ on:
     paths:
       - "packages/blockchain-link"
       - "packages/connect*/**"
+      - "packages/integration-tests/project/connect*/**"
       - "packages/transport"
       - "packages/utxo-lib"
       - "packages/utils"
@@ -42,7 +43,7 @@ jobs:
     needs: [build]
     uses: ./.github/workflows/connect-test-params.yml
     with:
-      test-pattern: "init authorizeCoinJoin"
+      test-pattern: "init authorizeCoinJoin passphrase"
 
   management:
     needs: [build]

--- a/ci/test.yml
+++ b/ci/test.yml
@@ -290,7 +290,7 @@ connect-popup manual:
   parallel:
     matrix:
       - TESTS_ENVIRONMENT: ["node", "web"]
-        TESTS_PATTERN: "init authorizeCoinJoin"
+        TESTS_PATTERN: "init authorizeCoinJoin passphrase"
         TESTS_FIRMWARE: ["2-master", "2.2.0"]
         # todo:
         # TESTS_NODE_VERSION: ["12", "14", "16"]

--- a/packages/connect/src/device/Device.ts
+++ b/packages/connect/src/device/Device.ts
@@ -435,12 +435,10 @@ export class Device extends EventEmitter {
                 payload.session_id = internalState;
             }
             if (legacy && !this.isT1()) {
-                // @ts-expect-error legacy protobuf
-                payload.state = internalState;
+                payload.session_id = internalState;
                 if (useEmptyPassphrase) {
                     payload._skip_passphrase = useEmptyPassphrase;
-                    // @ts-expect-error legacy protobuf
-                    payload.state = null;
+                    payload.session_id = undefined;
                 }
             }
         }

--- a/packages/connect/src/events/ui-response.ts
+++ b/packages/connect/src/events/ui-response.ts
@@ -61,9 +61,9 @@ export interface UiResponseWord {
 export interface UiResponsePassphrase {
     type: typeof UI_RESPONSE.RECEIVE_PASSPHRASE;
     payload: {
-        save: boolean;
         value: string;
         passphraseOnDevice?: boolean;
+        save?: boolean;
     };
 }
 

--- a/packages/connect/src/factory.ts
+++ b/packages/connect/src/factory.ts
@@ -44,7 +44,11 @@ export const factory = ({
         },
 
         removeAllListeners: type => {
-            eventEmitter.removeAllListeners(type);
+            if (typeof type === 'string') {
+                eventEmitter.removeAllListeners(type);
+            } else {
+                eventEmitter.removeAllListeners();
+            }
         },
 
         uiResponse,

--- a/packages/connect/src/types/params.ts
+++ b/packages/connect/src/types/params.ts
@@ -2,7 +2,7 @@
 
 export interface CommonParams {
     device?: {
-        path: string;
+        path?: string;
         state?: string;
         instance?: number;
     };

--- a/packages/integration-tests/projects/connect/common.setup.js
+++ b/packages/integration-tests/projects/connect/common.setup.js
@@ -72,7 +72,7 @@ const setup = async (controller, options) => {
             type: 'emulator-setup',
             mnemonic,
             pin: options.pin || '',
-            passphrase_protection: false,
+            passphrase_protection: !!options.passphrase_protection,
             label: options.label || 'TrezorT',
             needs_backup: false,
             options,

--- a/packages/integration-tests/projects/connect/tests/device/passphrase.test.ts
+++ b/packages/integration-tests/projects/connect/tests/device/passphrase.test.ts
@@ -1,0 +1,293 @@
+import TrezorConnect from '@trezor/connect';
+
+const { getController, setup, conditionalTest, initTrezorConnect } = global.Trezor;
+const { ADDRESS_N } = global.TestUtils;
+
+const controller = getController();
+
+const passphraseHandler = (value: string) => () => {
+    TrezorConnect.uiResponse({
+        type: 'ui-receive_passphrase',
+        payload: {
+            passphraseOnDevice: false,
+            value,
+            save: true, // NOTE: this field is used only in legacy test of T1 firmware
+        },
+    });
+    TrezorConnect.removeAllListeners('ui-request_passphrase');
+};
+
+describe('TrezorConnect passphrase', () => {
+    beforeAll(async () => {
+        await setup(controller, {
+            mnemonic: 'mnemonic_all',
+            passphrase_protection: true,
+        });
+        await initTrezorConnect(controller, { debug: false });
+    });
+
+    afterAll(() => {
+        controller.dispose();
+        TrezorConnect.dispose();
+    });
+
+    // firmware after passphrase redesign
+    conditionalTest(
+        ['<1.9.0', '<2.3.0'],
+        'Using multiple passphrases at the same time',
+        async () => {
+            const XPUB_PATH = ADDRESS_N("m/84'/0'/0'");
+            const ADDRESS_PATH = ADDRESS_N("m/84'/0'/0'/0/0");
+            // get state of default wallet with empty passphrase
+            const walletDefault = await TrezorConnect.getDeviceState({
+                device: {
+                    instance: 0,
+                    state: undefined, // reset state from previous tests on this instance
+                },
+                useEmptyPassphrase: true,
+            });
+            if (!walletDefault.success) {
+                throw new Error(`default Wallet exception: ${walletDefault.payload.error}`);
+            }
+            const xpub = await TrezorConnect.getPublicKey({
+                device: {
+                    instance: 0,
+                },
+                useEmptyPassphrase: true,
+                path: XPUB_PATH,
+            });
+            expect(xpub.payload).toMatchObject({
+                xpub: 'xpub6DDUPHpUo4pcy43iJeZjbSVWGav1SMMmuWdMHiGtkK8rhKmfbomtkwW6GKs1GGAKehT6QRocrmda3WWxXawpjmwaUHfFRXuKrXSapdckEYF',
+            });
+
+            // get state of walletA using passphrase "a"
+            TrezorConnect.on('ui-request_passphrase', passphraseHandler('a'));
+            const walletA = await TrezorConnect.getDeviceState({
+                device: {
+                    instance: 1,
+                    state: undefined, // reset state from previous tests on this instance
+                },
+            });
+            if (!walletA.success) {
+                throw new Error(`Wallet A exception: ${walletA.payload.error}`);
+            }
+            const xpubA = await TrezorConnect.getPublicKey({
+                device: {
+                    instance: 1,
+                    state: walletA.payload.state,
+                },
+                path: XPUB_PATH,
+            });
+            expect(xpubA.payload).toMatchObject({
+                xpub: 'xpub6CixwCVCacLWy2pdyzvcWATbm8cHRqLkmC3B335NzEVx3DBMG8mhoqyJzm62Qkv3UyN4haP7xnihe7ZR134vVGY8pjAHtGgiyD139Ro29N8',
+            });
+
+            // get state of walletB using passphrase "b"
+            TrezorConnect.on('ui-request_passphrase', passphraseHandler('b'));
+            const walletB = await TrezorConnect.getDeviceState({
+                device: {
+                    instance: 2,
+                },
+            });
+            if (!walletB.success) {
+                throw new Error(`Wallet B exception: ${walletB.payload.error}`);
+            }
+            const xpubB = await TrezorConnect.getPublicKey({
+                device: {
+                    instance: 2,
+                    state: walletB.payload.state,
+                },
+                path: XPUB_PATH,
+            });
+            expect(xpubB.payload).toMatchObject({
+                xpub: 'xpub6CUsAXLNQXX9oGjwXi2EjL1Hp8BMPSKXsgdRHv5pgPoqb9CxncThcup7YAsbYcKMgRqDbedLCNUWzD7JhPVsEc82yYz15AYR35UGiUkXtWa',
+            });
+
+            // generate addresses from 3 different wallets in random order using same derivation path
+            const addressA = await TrezorConnect.getAddress({
+                device: {
+                    instance: 1,
+                    state: walletA.payload.state,
+                },
+                path: ADDRESS_PATH,
+            });
+            expect(addressA.payload).toMatchObject({
+                address: 'bc1qjgjmd5mg4acxghjcmflpvh44dfxdwnespafrd3',
+            });
+            const addressB = await TrezorConnect.getAddress({
+                device: {
+                    instance: 2,
+                    state: walletB.payload.state,
+                },
+                path: ADDRESS_PATH,
+            });
+            expect(addressB.payload).toMatchObject({
+                address: 'bc1qrfe6tkm77tgg03xzgvnjf9mgrr7sfez2gk2h47',
+            });
+            const address = await TrezorConnect.getAddress({
+                device: {
+                    instance: 0,
+                    state: walletDefault.payload.state,
+                },
+                path: ADDRESS_PATH,
+                showOnTrezor: false,
+            });
+            expect(address.payload).toMatchObject({
+                address: 'bc1qannfxke2tfd4l7vhepehpvt05y83v3qsf6nfkk',
+            });
+
+            // use invalid state on default instance
+            const invalidState = await TrezorConnect.getAddress({
+                device: {
+                    instance: 0,
+                    state: walletA.payload.state, // NOTE: state from different wallet/instance
+                },
+                path: ADDRESS_N("m/84'/0'/0'/0/0"),
+                showOnTrezor: false,
+            });
+            expect(invalidState.payload).toMatchObject({
+                error: 'Passphrase is incorrect',
+            });
+        },
+    );
+
+    // passphrase on device is possible only on TT
+    conditionalTest(['1', '<2.3.0'], 'Input passphrase on device', async () => {
+        TrezorConnect.on('ui-request_passphrase', () => {
+            TrezorConnect.uiResponse({
+                type: 'ui-receive_passphrase',
+                payload: {
+                    passphraseOnDevice: true,
+                    value: '',
+                },
+            });
+            TrezorConnect.removeAllListeners('ui-request_passphrase');
+            controller.send({ type: 'emulator-input', value: 'a' });
+        });
+        const walletA = await TrezorConnect.getDeviceState({
+            device: {
+                instance: 0,
+                state: undefined, // reset state from previous tests on this instance
+            },
+        });
+        if (!walletA.success) {
+            throw new Error(`Wallet A exception: ${walletA.payload.error}`);
+        }
+        const xpubA = await TrezorConnect.getPublicKey({
+            device: {
+                instance: 0,
+                state: walletA.payload.state,
+            },
+            path: ADDRESS_N("m/84'/0'/0'"),
+        });
+        // same xpub as walletA from previous test case enforced on instance 0
+        expect(xpubA.payload).toMatchObject({
+            xpub: 'xpub6CixwCVCacLWy2pdyzvcWATbm8cHRqLkmC3B335NzEVx3DBMG8mhoqyJzm62Qkv3UyN4haP7xnihe7ZR134vVGY8pjAHtGgiyD139Ro29N8',
+        });
+    });
+
+    // legacy firmware before passphrase redesing
+    // FW didn't have multiple slots at that time, therefore passphrase was requested each time it was changed
+    conditionalTest(['>1.8.0', '>2.2.0'], 'Legacy passphrase flow', async () => {
+        const XPUB_PATH = ADDRESS_N("m/84'/0'/0'");
+        const ADDRESS_PATH = ADDRESS_N("m/84'/0'/0'/0/0");
+        const legacyPassphraseSourceHandler = ({ code }: any) => {
+            if (code === 'ButtonRequest_PassphraseType') {
+                controller.send({ type: 'emulator-click', x: 120, y: 180 });
+                TrezorConnect.off('ui-button', legacyPassphraseSourceHandler);
+            }
+        };
+
+        const walletDefault = await TrezorConnect.getDeviceState({
+            device: {
+                instance: 0,
+            },
+            useEmptyPassphrase: true,
+        });
+        if (!walletDefault.success) {
+            throw new Error(`default Wallet exception: ${walletDefault.payload.error}`);
+        }
+        const xpub = await TrezorConnect.getPublicKey({
+            device: {
+                instance: 0,
+            },
+            useEmptyPassphrase: true,
+            path: XPUB_PATH,
+        });
+        expect(xpub.payload).toMatchObject({
+            xpub: 'xpub6DDUPHpUo4pcy43iJeZjbSVWGav1SMMmuWdMHiGtkK8rhKmfbomtkwW6GKs1GGAKehT6QRocrmda3WWxXawpjmwaUHfFRXuKrXSapdckEYF',
+        });
+
+        TrezorConnect.on('ui-button', legacyPassphraseSourceHandler);
+        TrezorConnect.on('ui-request_passphrase', passphraseHandler('a'));
+        const walletA = await TrezorConnect.getDeviceState({
+            device: {
+                instance: 1,
+                state: undefined, // restet state from previous tests on instance 0
+            },
+        });
+        if (!walletA.success) {
+            throw new Error(`Wallet A exception: ${walletA.payload.error}`);
+        }
+        const xpubA = await TrezorConnect.getPublicKey({
+            device: {
+                instance: 1,
+                state: walletA.payload.state,
+            },
+            path: XPUB_PATH,
+        });
+        expect(xpubA.payload).toMatchObject({
+            xpub: 'xpub6CixwCVCacLWy2pdyzvcWATbm8cHRqLkmC3B335NzEVx3DBMG8mhoqyJzm62Qkv3UyN4haP7xnihe7ZR134vVGY8pjAHtGgiyD139Ro29N8',
+        });
+
+        TrezorConnect.on('ui-button', legacyPassphraseSourceHandler);
+        TrezorConnect.on('ui-request_passphrase', passphraseHandler('b'));
+        const walletB = await TrezorConnect.getDeviceState({
+            device: {
+                instance: 2,
+            },
+        });
+        if (!walletB.success) {
+            throw new Error(`Wallet B exception: ${walletB.payload.error}`);
+        }
+        const xpubB = await TrezorConnect.getPublicKey({
+            device: {
+                instance: 2,
+                state: walletB.payload.state,
+            },
+            path: XPUB_PATH,
+        });
+        expect(xpubB.payload).toMatchObject({
+            xpub: 'xpub6CUsAXLNQXX9oGjwXi2EjL1Hp8BMPSKXsgdRHv5pgPoqb9CxncThcup7YAsbYcKMgRqDbedLCNUWzD7JhPVsEc82yYz15AYR35UGiUkXtWa',
+        });
+
+        // NOTE: switching back to wallet A will trigger passphrase request again
+        TrezorConnect.on('ui-button', legacyPassphraseSourceHandler);
+        TrezorConnect.on('ui-request_passphrase', passphraseHandler('a'));
+        const addressA = await TrezorConnect.getAddress({
+            device: {
+                instance: 1,
+                state: walletA.payload.state,
+            },
+            path: ADDRESS_PATH,
+        });
+        expect(addressA.payload).toMatchObject({
+            address: 'bc1qjgjmd5mg4acxghjcmflpvh44dfxdwnespafrd3',
+        });
+
+        // use invalid state/passphrase (passphrase "b" on walletA)
+        TrezorConnect.on('ui-button', legacyPassphraseSourceHandler);
+        TrezorConnect.on('ui-request_passphrase', passphraseHandler('b'));
+        const invalidState = await TrezorConnect.getAddress({
+            device: {
+                instance: 1,
+                state: walletB.payload.state, // NOTE: state from different wallet/instance
+            },
+            path: ADDRESS_PATH,
+            showOnTrezor: false,
+        });
+        expect(invalidState.payload).toMatchObject({
+            error: 'Passphrase is incorrect',
+        });
+    });
+});


### PR DESCRIPTION
- fixing .removeAllListeners method when used without any param
- few types were unnecessary required:
  - device.path will use first available device if not provided
  - receive_passphrase.save is used only on T1
- legacy passphrase was not working properly, there is no `session` field in protobuf messages
  should be catched by t[his test](https://github.com/trezor/trezor-suite/blob/develop/packages/integration-tests/projects/suite-web/tests/suite/passphrase-legacy.test.ts) but somehow it doesnt?
- adding missing test scenarios for passphrase (it is tested by suite, but not by connect) related to #5598 and #5599