### PR TITLE
fix(connect-explorer): do not forward to the test build when deployed on production

### DIFF
--- a/packages/connect-explorer/src/js/GlobalStyle.tsx
+++ b/packages/connect-explorer/src/js/GlobalStyle.tsx
@@ -11,12 +11,6 @@ const GlobalStyle = createGlobalStyle`
         padding: 0;
     }
 
-    *:focus, *:active, *:active:focus, *::selection, *::-moz-selection {
-        outline: 0 !important;
-        -webkit-appearance: none;
-        -webkit-tap-highlight-color: rgba(0,0,0,0);
-    }
-
     html, body {
         width: 100%;
         height: 100%;

--- a/packages/connect-explorer/src/js/actions/trezorConnectActions.ts
+++ b/packages/connect-explorer/src/js/actions/trezorConnectActions.ts
@@ -40,7 +40,7 @@ export const init =
 
         const { origin } = window.location;
 
-        if (process?.env?.__TREZOR_CONNECT_SRC) {
+        if (process?.env?.__TREZOR_CONNECT_SRC && origin !== 'https://connect.trezor.io/') {
             window.__TREZOR_CONNECT_SRC = process?.env?.__TREZOR_CONNECT_SRC;
         }
         // yarn workspace @trezor/connect-explorer dev starts @trezor/connect-web on localhost port

--- a/packages/connect-explorer/webpack/prod.webpack.config.ts
+++ b/packages/connect-explorer/webpack/prod.webpack.config.ts
@@ -1,8 +1,7 @@
-/* eslint-disable no-underscore-dangle */
-
 import webpack from 'webpack';
 import path from 'path';
 import HtmlWebpackPlugin from 'html-webpack-plugin';
+import TerserPlugin from 'terser-webpack-plugin';
 
 const config: webpack.Configuration = {
     mode: 'production',
@@ -59,11 +58,25 @@ const config: webpack.Configuration = {
             template: path.resolve(__dirname, '../src/index.html'),
             filename: 'index.html',
             inject: true,
+            minify: false,
         }),
         new webpack.DefinePlugin({
+            // eslint-disable-next-line no-underscore-dangle
             'process.env.__TREZOR_CONNECT_SRC': JSON.stringify(process.env.__TREZOR_CONNECT_SRC),
         }),
     ],
+    optimization: {
+        minimizer: [
+            new TerserPlugin({
+                extractComments: false,
+                terserOptions: {
+                    format: {
+                        comments: false,
+                    },
+                },
+            }),
+        ],
+    },
 };
 
 export default config;


### PR DESCRIPTION
Fixes the issue with `connect-explorer` on connect.trezor.io where it would forward to our test server instead of production `connect.trezor.io/9/`