### PR TITLE
fix: update public packages homepage

### DIFF
--- a/packages/blockchain-link/package.json
+++ b/packages/blockchain-link/package.json
@@ -2,7 +2,7 @@
     "name": "@trezor/blockchain-link",
     "version": "2.1.3",
     "author": "Trezor <info@trezor.io>",
-    "homepage": "https://github.com/trezor/trezor-suite/packages/blockchain-link",
+    "homepage": "https://github.com/trezor/trezor-suite/tree/develop/packages/blockchain-link",
     "description": "High-level javascript interface for blockchain communication",
     "license": "SEE LICENSE IN LICENSE.md",
     "repository": {

--- a/packages/connect-common/package.json
+++ b/packages/connect-common/package.json
@@ -2,7 +2,7 @@
     "name": "@trezor/connect-common",
     "version": "0.0.6",
     "author": "Trezor <info@trezor.io>",
-    "homepage": "https://github.com/trezor/trezor-suite/packages/connect-common",
+    "homepage": "https://github.com/trezor/trezor-suite/tree/develop/packages/connect-common",
     "keywords": [
         "Trezor",
         "trezor-connect"

--- a/packages/connect-plugin-ethereum/package.json
+++ b/packages/connect-plugin-ethereum/package.json
@@ -2,7 +2,7 @@
     "name": "@trezor/connect-plugin-ethereum",
     "version": "9.0.0",
     "author": "Trezor <info@trezor.io>",
-    "homepage": "https://github.com/trezor/trezor-suite/packages/connect-plugin-ethereum",
+    "homepage": "https://github.com/trezor/trezor-suite/tree/develop/packages/connect-plugin-ethereum",
     "description": "@trezor/connect plugin for Ethereum",
     "license": "SEE LICENSE IN LICENSE.md",
     "repository": {

--- a/packages/connect-web/package.json
+++ b/packages/connect-web/package.json
@@ -2,7 +2,7 @@
     "name": "@trezor/connect-web",
     "version": "9.0.0-beta.1",
     "author": "Trezor <info@trezor.io>",
-    "homepage": "https://github.com/trezor/trezor-suite/packages/connect",
+    "homepage": "https://github.com/trezor/trezor-suite/tree/develop/packages/connect-web",
     "description": "High-level javascript interface for Trezor hardware wallet.",
     "license": "SEE LICENSE IN LICENSE.md",
     "repository": {

--- a/packages/connect/package.json
+++ b/packages/connect/package.json
@@ -2,7 +2,7 @@
     "name": "@trezor/connect",
     "version": "9.0.0-beta.1",
     "author": "Trezor <info@trezor.io>",
-    "homepage": "https://github.com/trezor/trezor-suite/packages/connect",
+    "homepage": "https://github.com/trezor/trezor-suite/tree/develop/packages/connect",
     "description": "High-level javascript interface for Trezor hardware wallet.",
     "license": "SEE LICENSE IN LICENSE.md",
     "repository": {

--- a/packages/suite-desktop-api/package.json
+++ b/packages/suite-desktop-api/package.json
@@ -3,7 +3,6 @@
     "version": "1.0.0",
     "private": true,
     "author": "Trezor <info@trezor.io>",
-    "homepage": "https://github.com/trezor/trezor-suite/packages/suite-desktop-api",
     "description": "Strongly typed DesktopApi",
     "repository": {
         "type": "git",

--- a/packages/transport-native/package.json
+++ b/packages/transport-native/package.json
@@ -2,7 +2,7 @@
     "name": "@trezor/transport-native",
     "version": "1.0.0",
     "author": "Trezor.io",
-    "homepage": "https://github.com/trezor/trezor-suite",
+    "homepage": "https://github.com/trezor/trezor-suite/tree/develop/packages/transport-native",
     "description": "Trezor device transport layer for React Native",
     "main": "lib/commonjs/index",
     "module": "lib/module/index",

--- a/packages/utils/package.json
+++ b/packages/utils/package.json
@@ -2,7 +2,7 @@
     "name": "@trezor/utils",
     "version": "9.0.1",
     "author": "Trezor <info@trezor.io>",
-    "homepage": "https://github.com/trezor/trezor-suite/packages/utils",
+    "homepage": "https://github.com/trezor/trezor-suite/tree/develop/packages/utils",
     "description": "A collection of typescript utils that are intended to be used across trezor-suite monorepo.",
     "license": "SEE LICENSE IN LICENSE.md",
     "repository": {

--- a/packages/utxo-lib/package.json
+++ b/packages/utxo-lib/package.json
@@ -2,7 +2,7 @@
     "name": "@trezor/utxo-lib",
     "version": "1.0.0",
     "author": "Trezor <info@trezor.io>",
-    "homepage": "https://github.com/trezor/trezor-suite/packages/utxo-lib",
+    "homepage": "https://github.com/trezor/trezor-suite/tree/develop/packages/utxo-lib",
     "description": "Client-side Bitcoin-like JavaScript library",
     "license": "SEE LICENSE IN LICENSE.md",
     "repository": {


### PR DESCRIPTION
if you are browsing npm registry, for example recently published connect@9 beta and click on the "homepage" link then... it throws 404, because of invalid link

https://www.npmjs.com/package/@trezor/connect