### PR TITLE
feat(analytics): labeling

### DIFF
--- a/packages/suite-analytics/CHANGELOG.md
+++ b/packages/suite-analytics/CHANGELOG.md
@@ -2,6 +2,17 @@
 
 This changelog lists changes in suite events.
 
+### 1.21
+
+Added:
+
+-   suite-ready
+    -   labeling: 'dropbox' | 'google' | 'fileSystem' | 'sdCard' | ''
+-   settings/general/labeling
+    -   value: boolean
+-   settings/general/labeling-provider
+    -   provider: 'dropbox' | 'google' | 'fileSystem' | 'sdCard' | ''
+
 ### 1.20
 
 -   analytics 1.19 was never released due to a bug

--- a/packages/suite-analytics/package.json
+++ b/packages/suite-analytics/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@trezor/suite-analytics",
-    "version": "0.1.20",
+    "version": "0.1.21",
     "private": true,
     "license": "See LICENSE.md in repo root",
     "sideEffects": false,

--- a/packages/suite-analytics/src/constants.ts
+++ b/packages/suite-analytics/src/constants.ts
@@ -58,6 +58,8 @@ export enum EventType {
     SettingsGeneralChangeTheme = 'settings/general/change-theme',
     SettingsGeneralChangeFiat = 'settings/general/change-fiat',
     SettingsGeneralEarlyAccess = 'settings/general/early-access',
+    SettingsGeneralLabeling = 'settings/general/labeling',
+    SettingsGeneralLabelingProvider = 'settings/general/labeling-provider',
     SettingsCoinsBackend = 'settings/coins/backend',
     SettingsCoins = 'settings/coins',
     SettingsTor = 'settings/tor',

--- a/packages/suite-analytics/src/types/events.ts
+++ b/packages/suite-analytics/src/types/events.ts
@@ -14,6 +14,7 @@ export type SuiteAnalyticsEvent =
               screenWidth: number;
               screenHeight: number;
               tor: boolean;
+              labeling: string;
               rememberedStandardWallets: number;
               rememberedHiddenWallets: number;
               theme: string;
@@ -268,6 +269,18 @@ export type SuiteAnalyticsEvent =
           type: EventType.SettingsGeneralEarlyAccess;
           payload: {
               allowPrerelease: boolean;
+          };
+      }
+    | {
+          type: EventType.SettingsGeneralLabeling;
+          payload: {
+              value: boolean;
+          };
+      }
+    | {
+          type: EventType.SettingsGeneralLabelingProvider;
+          payload: {
+              provider: 'dropbox' | 'google' | 'fileSystem' | 'sdCard' | '';
           };
       }
     | {

--- a/packages/suite/src/actions/suite/metadataActions.ts
+++ b/packages/suite/src/actions/suite/metadataActions.ts
@@ -1,4 +1,6 @@
 import TrezorConnect from '@trezor/connect';
+import { analytics, EventType } from '@trezor/suite-analytics';
+
 import { createDeferred } from '@trezor/utils';
 import { METADATA } from '@suite-actions/constants';
 import { Dispatch, GetState } from '@suite-types';
@@ -129,6 +131,13 @@ export const disconnectProvider =
         dispatch({
             type: METADATA.SET_PROVIDER,
             payload: undefined,
+        });
+
+        analytics.report({
+            type: EventType.SettingsGeneralLabelingProvider,
+            payload: {
+                provider: '',
+            },
         });
 
         // dispose metadata values (not keys)
@@ -422,6 +431,13 @@ export const connectProvider = (type: MetadataProviderType) => async (dispatch: 
         payload: result.payload,
     });
 
+    analytics.report({
+        type: EventType.SettingsGeneralLabelingProvider,
+        payload: {
+            provider: result.payload.type,
+        },
+    });
+
     return true;
 };
 
@@ -676,6 +692,7 @@ export const init =
 
             return false;
         }
+
         // if yes, add metadata keys to accounts
         if (getState().metadata.initiating) {
             dispatch(syncMetadataKeys());

--- a/packages/suite/src/utils/suite/analytics.ts
+++ b/packages/suite/src/utils/suite/analytics.ts
@@ -43,6 +43,7 @@ export const getSuiteReadyPayload = (state: AppState) => ({
     screenHeight: getScreenHeight(),
     platformLanguages: getPlatformLanguages().join(','),
     tor: state.suite.tor,
+    labeling: state.metadata.enabled ? state.metadata.provider?.type || '' : '',
     rememberedStandardWallets: state.devices.filter(d => d.remember && d.useEmptyPassphrase).length,
     rememberedHiddenWallets: state.devices.filter(d => d.remember && !d.useEmptyPassphrase).length,
     theme: state.suite.settings.theme.variant,

--- a/packages/suite/src/views/settings/general/Labeling.tsx
+++ b/packages/suite/src/views/settings/general/Labeling.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
-
+import { analytics, EventType } from '@trezor/suite-analytics';
 import { Switch, Tooltip } from '@trezor/components';
+
 import { Translation } from '@suite-components';
 import { ActionColumn, SectionItem, TextColumn } from '@suite-components/Settings';
 import { useSelector, useActions, useDevice } from '@suite-hooks';
@@ -54,7 +55,19 @@ export const Labeling = () => {
                         isDisabled={isDisabled}
                         dataTest="@settings/metadata-switch"
                         isChecked={metadata.enabled}
-                        onChange={() => (metadata.enabled ? disableMetadata() : initMetadata(true))}
+                        onChange={() => {
+                            if (metadata.enabled) {
+                                disableMetadata();
+                            } else {
+                                initMetadata(true);
+                            }
+                            analytics.report({
+                                type: EventType.SettingsGeneralLabeling,
+                                payload: {
+                                    value: !metadata.enabled,
+                                },
+                            });
+                        }}
                     />
                 </Tooltip>
             </ActionColumn>


### PR DESCRIPTION
Closes #5591

- added `labeling` provider into `suite-ready`.
   -  If provider is defined and labeling is enabled, then `labeling` is one of `'dropbox' | 'google' | 'fileSystem' | 'sdCard'`
   -  If labeling is disabled. `labeling` is ``. 
   -  If labeling is enabled but provider undefined, labeling is ``

- added `settings/general/labeling` event
   - `value` is `true` if user enables labeling in settings
   - `value` is `false` if user disables labeling in settings

- added `settings/general/labeling-provider` event
   - `provider` is one of `'dropbox' | 'google' | 'fileSystem' | 'sdCard'` when user connects a provider
   - `provider` is `` when user disconnects provider

The events are separated like this to avoid tracking into analytics at the start of the app
