### PR TITLE
minor legacy passphrase cleanup

### DIFF
--- a/packages/connect/src/device/Device.ts
+++ b/packages/connect/src/device/Device.ts
@@ -625,15 +625,6 @@ export class Device extends EventEmitter {
         return this.originalDescriptor.path;
     }
 
-    needAuthentication() {
-        if (this.isUnacquired() || this.isUsedElsewhere() || this.featuresNeedsReload) return true;
-        if (this.features.bootloader_mode || !this.features.initialized) return true;
-        const pin = this.features.pin_protection ? !!this.features.unlocked : true;
-        // @ts-expect-error legacy protobuf
-        const pass = this.features.passphrase_protection ? this.features.passphrase_cached : true;
-        return pin && pass;
-    }
-
     isT1() {
         return this.features ? this.features.major_version === 1 : false;
     }

--- a/packages/integration-tests/projects/suite-web/tests/suite/passphrase-legacy.test.ts
+++ b/packages/integration-tests/projects/suite-web/tests/suite/passphrase-legacy.test.ts
@@ -40,5 +40,16 @@ describe('Passphrase - legacy flow', () => {
         cy.getTestElement('@passphrase/confirm-checkbox').click();
         cy.getTestElement('@passphrase/input').type('b{enter}');
         cy.getTestElement('@dashboard/wallet-ready');
+
+        // documenting a bug with wrong walletNumber. It is not correctly assigned for the first
+        // hidden wallet created. I am not fixing this since 2.2.0 will soon be marked with required update
+        cy.screenshot();
+        cy.getTestElement('@menu/switch-device').click();
+
+        // try to get address. passhprase should not be prompted
+        cy.getTestElement('@switch-device/wallet-on-index/2').click();
+        cy.getTestElement('@dashboard/receive-button').click();
+        cy.getTestElement('@wallet/receive/reveal-address-button').click();
+        cy.getTestElement('@modal/confirm-address/address-field');
     });
 });

--- a/packages/suite/src/actions/suite/modalActions.ts
+++ b/packages/suite/src/actions/suite/modalActions.ts
@@ -169,7 +169,7 @@ export const onPassphraseSubmit =
             dispatch({
                 type: SUITE.UPDATE_PASSPHRASE_MODE,
                 payload: device,
-                hidden: passphraseOnDevice || value,
+                hidden: passphraseOnDevice || !!value,
                 alwaysOnDevice: passphraseOnDevice,
             });
         }

--- a/packages/suite/src/views/dashboard/components/PortfolioCard/components/Header.tsx
+++ b/packages/suite/src/views/dashboard/components/PortfolioCard/components/Header.tsx
@@ -71,7 +71,11 @@ export const Header = (props: HeaderProps) => {
     if (!props.isWalletLoading && !props.isWalletError) {
         if (props.isWalletEmpty) {
             actions = (
-                <ActionButton variant="primary" onClick={props.receiveClickHandler}>
+                <ActionButton
+                    variant="primary"
+                    onClick={props.receiveClickHandler}
+                    data-test="@dashboard/receive-button"
+                >
                     <Translation id="TR_RECEIVE" />
                 </ActionButton>
             );


### PR DESCRIPTION
ef61da047a35e698210978ea9622e9ee1cc9f787 - just found a piece of unused code and removed it 
e2be82ba3ff0c70aa01ba745d33c59b9bd541d56 - extends e2e test for legacy passphrase. also found a bug here with wallet numbering. so far I have only added screenshot to document this issue. Imho it is not worth fixing because legacy passhprase in suite will soon be deprecated
c4bd99c1f5e33ff3c0e9c0f5b92ff47a596c9fe5 - it appears actions types don't work. according to the actions types, `hidden` param should be `boolean` but it was being sent as `string`
