### PR TITLE
chore: Use io.trezor.suite instead of com.trezorsuite (iOS, Android)

### DIFF
--- a/packages/suite-native/android/app/_BUCK
+++ b/packages/suite-native/android/app/_BUCK
@@ -35,12 +35,12 @@ android_library(
 
 android_build_config(
     name = "build_config",
-    package = "com.trezorsuite",
+    package = "io.trezor.suite",
 )
 
 android_resource(
     name = "res",
-    package = "com.trezorsuite",
+    package = "io.trezor.suite",
     res = "src/main/res",
 )
 

--- a/packages/suite-native/android/app/build.gradle
+++ b/packages/suite-native/android/app/build.gradle
@@ -140,7 +140,7 @@ android {
     compileSdkVersion rootProject.ext.compileSdkVersion
 
     defaultConfig {
-        applicationId "com.trezorsuite"
+        applicationId "io.trezor.suite"
         minSdkVersion rootProject.ext.minSdkVersion
         targetSdkVersion rootProject.ext.targetSdkVersion
         versionCode 1

--- a/packages/suite-native/android/app/src/debug/java/io/trezor/suite/ReactNativeFlipper.java
+++ b/packages/suite-native/android/app/src/debug/java/io/trezor/suite/ReactNativeFlipper.java
@@ -4,7 +4,7 @@
  * <p>This source code is licensed under the MIT license found in the LICENSE file in the root
  * directory of this source tree.
  */
-package com.trezorsuite;
+package io.trezor.suite;
 
 import android.content.Context;
 import com.facebook.flipper.android.AndroidFlipperClient;

--- a/packages/suite-native/android/app/src/main/AndroidManifest.xml
+++ b/packages/suite-native/android/app/src/main/AndroidManifest.xml
@@ -1,5 +1,5 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
-  package="com.trezorsuite">
+  package="io.trezor.suite">
 
     <uses-permission android:name="android.permission.INTERNET" />
 

--- a/packages/suite-native/android/app/src/main/java/io/trezor/suite/MainActivity.java
+++ b/packages/suite-native/android/app/src/main/java/io/trezor/suite/MainActivity.java
@@ -1,4 +1,4 @@
-package com.trezorsuite;
+package io.trezor.suite;
 
 import android.os.Bundle;
 import com.facebook.react.ReactActivity;

--- a/packages/suite-native/android/app/src/main/java/io/trezor/suite/MainApplication.java
+++ b/packages/suite-native/android/app/src/main/java/io/trezor/suite/MainApplication.java
@@ -1,4 +1,4 @@
-package com.trezorsuite;
+package io.trezor.suite;
 
 import android.app.Application;
 import android.content.Context;
@@ -9,7 +9,7 @@ import com.facebook.react.ReactNativeHost;
 import com.facebook.react.ReactPackage;
 import com.facebook.react.config.ReactFeatureFlags;
 import com.facebook.soloader.SoLoader;
-import com.trezorsuite.newarchitecture.MainApplicationReactNativeHost;
+import io.trezor.suite.newarchitecture.MainApplicationReactNativeHost;
 import java.lang.reflect.InvocationTargetException;
 import java.util.List;
 
@@ -73,7 +73,7 @@ public class MainApplication extends Application implements ReactApplication {
          We use reflection here to pick up the class that initializes Flipper,
         since Flipper library is not available in release mode
         */
-        Class<?> aClass = Class.forName("com.trezorsuite.ReactNativeFlipper");
+        Class<?> aClass = Class.forName("io.trezor.suite.ReactNativeFlipper");
         aClass
             .getMethod("initializeFlipper", Context.class, ReactInstanceManager.class)
             .invoke(null, context, reactInstanceManager);

--- a/packages/suite-native/android/app/src/main/java/io/trezor/suite/newarchitecture/MainApplicationReactNativeHost.java
+++ b/packages/suite-native/android/app/src/main/java/io/trezor/suite/newarchitecture/MainApplicationReactNativeHost.java
@@ -1,4 +1,4 @@
-package com.trezorsuite.newarchitecture;
+package io.trezor.suite.newarchitecture;
 
 import android.app.Application;
 import androidx.annotation.NonNull;
@@ -19,9 +19,9 @@ import com.facebook.react.fabric.CoreComponentsRegistry;
 import com.facebook.react.fabric.EmptyReactNativeConfig;
 import com.facebook.react.fabric.FabricJSIModuleProvider;
 import com.facebook.react.uimanager.ViewManagerRegistry;
-import com.trezorsuite.BuildConfig;
-import com.trezorsuite.newarchitecture.components.MainComponentsRegistry;
-import com.trezorsuite.newarchitecture.modules.MainApplicationTurboModuleManagerDelegate;
+import io.trezor.suite.BuildConfig;
+import io.trezor.suite.newarchitecture.components.MainComponentsRegistry;
+import io.trezor.suite.newarchitecture.modules.MainApplicationTurboModuleManagerDelegate;
 import java.util.ArrayList;
 import java.util.List;
 

--- a/packages/suite-native/android/app/src/main/java/io/trezor/suite/newarchitecture/components/MainComponentsRegistry.java
+++ b/packages/suite-native/android/app/src/main/java/io/trezor/suite/newarchitecture/components/MainComponentsRegistry.java
@@ -1,4 +1,4 @@
-package com.trezorsuite.newarchitecture.components;
+package io.trezor.suite.newarchitecture.components;
 
 import com.facebook.jni.HybridData;
 import com.facebook.proguard.annotations.DoNotStrip;

--- a/packages/suite-native/android/app/src/main/java/io/trezor/suite/newarchitecture/modules/MainApplicationTurboModuleManagerDelegate.java
+++ b/packages/suite-native/android/app/src/main/java/io/trezor/suite/newarchitecture/modules/MainApplicationTurboModuleManagerDelegate.java
@@ -1,4 +1,4 @@
-package com.trezorsuite.newarchitecture.modules;
+package io.trezor.suite.newarchitecture.modules;
 
 import com.facebook.jni.HybridData;
 import com.facebook.react.ReactPackage;

--- a/packages/suite-native/ios/TrezorSuite.xcodeproj/project.pbxproj
+++ b/packages/suite-native/ios/TrezorSuite.xcodeproj/project.pbxproj
@@ -507,6 +507,7 @@
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CLANG_ENABLE_MODULES = YES;
+				CODE_SIGN_IDENTITY = "iPhone Developer";
 				CURRENT_PROJECT_VERSION = 1;
 				ENABLE_BITCODE = NO;
 				INFOPLIST_FILE = TrezorSuite/Info.plist;
@@ -519,7 +520,7 @@
 					"-ObjC",
 					"-lc++",
 				);
-				PRODUCT_BUNDLE_IDENTIFIER = "org.reactjs.native.example.$(PRODUCT_NAME:rfc1034identifier)";
+				PRODUCT_BUNDLE_IDENTIFIER = io.trezor.suite;
 				PRODUCT_NAME = TrezorSuite;
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
 				SWIFT_VERSION = 5.0;
@@ -533,6 +534,7 @@
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CLANG_ENABLE_MODULES = YES;
+				CODE_SIGN_IDENTITY = "iPhone Distribution";
 				CURRENT_PROJECT_VERSION = 1;
 				INFOPLIST_FILE = TrezorSuite/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = (
@@ -544,7 +546,7 @@
 					"-ObjC",
 					"-lc++",
 				);
-				PRODUCT_BUNDLE_IDENTIFIER = "org.reactjs.native.example.$(PRODUCT_NAME:rfc1034identifier)";
+				PRODUCT_BUNDLE_IDENTIFIER = io.trezor.suite;
 				PRODUCT_NAME = TrezorSuite;
 				SWIFT_VERSION = 5.0;
 				VERSIONING_SYSTEM = "apple-generic";

--- a/packages/suite-native/ios/TrezorSuite.xcodeproj/project.xcworkspace/contents.xcworkspacedata
+++ b/packages/suite-native/ios/TrezorSuite.xcodeproj/project.xcworkspace/contents.xcworkspacedata
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Workspace
+   version = "1.0">
+   <FileRef
+      location = "self:">
+   </FileRef>
+</Workspace>

--- a/packages/suite-native/ios/TrezorSuite.xcodeproj/project.xcworkspace/xcshareddata/IDEWorkspaceChecks.plist
+++ b/packages/suite-native/ios/TrezorSuite.xcodeproj/project.xcworkspace/xcshareddata/IDEWorkspaceChecks.plist
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>IDEDidComputeMac32BitWarning</key>
+	<true/>
+</dict>
+</plist>

--- a/packages/suite-native/ios/TrezorSuite/Info.plist
+++ b/packages/suite-native/ios/TrezorSuite/Info.plist
@@ -36,7 +36,14 @@
 		</dict>
 	</dict>
 	<key>NSLocationWhenInUseUsageDescription</key>
-	<string/>
+	<string></string>
+	<key>UIAppFonts</key>
+	<array>
+		<string>TTSatoshi-Bold.otf</string>
+		<string>TTSatoshi-DemiBold.otf</string>
+		<string>TTSatoshi-Medium.otf</string>
+		<string>TTSatoshi-Regular.otf</string>
+	</array>
 	<key>UILaunchStoryboardName</key>
 	<string>LaunchScreen</string>
 	<key>UIRequiredDeviceCapabilities</key>
@@ -51,12 +58,5 @@
 	</array>
 	<key>UIViewControllerBasedStatusBarAppearance</key>
 	<false/>
-	<key>UIAppFonts</key>
-	<array>
-		<string>TTSatoshi-Bold.otf</string>
-		<string>TTSatoshi-DemiBold.otf</string>
-		<string>TTSatoshi-Medium.otf</string>
-		<string>TTSatoshi-Regular.otf</string>
-	</array>
 </dict>
 </plist>


### PR DESCRIPTION
App IDs for both platforms changed to be correct with the company setup.

Closes https://github.com/trezor/trezor-suite/issues/5624 