### PR TITLE
fix(suite): remove prop from the DOM element to prevent warning

### DIFF
--- a/packages/suite/src/components/wallet/TransactionItem/index.tsx
+++ b/packages/suite/src/components/wallet/TransactionItem/index.tsx
@@ -151,8 +151,8 @@ const ExpandButton = styled(Button)`
     align-self: flex-start;
 `;
 
-const StyledFeeRow = styled(FeeRow)<{ isFailed?: boolean }>`
-    margin-top: ${props => (props.isFailed ? '20px' : '0px')};
+const StyledFeeRow = styled(FeeRow)<{ $isFailed?: boolean }>`
+    margin-top: ${({ $isFailed }) => ($isFailed ? '20px' : '0px')};
 `;
 
 const DEFAULT_LIMIT = 3;
@@ -369,7 +369,7 @@ const TransactionItem = React.memo(
                                     <StyledFeeRow
                                         transaction={transaction}
                                         useFiatValues={useFiatValues}
-                                        isFailed={type !== 'failed'}
+                                        $isFailed={type !== 'failed'}
                                         isFirst
                                         isLast
                                     />


### PR DESCRIPTION
isFailed is unrecognized prop and trigger React warning, it's not meant to be passed to DOM element