### PR TITLE
ci: connect dependencies check

### DIFF
--- a/ci/npm-deploy.yml
+++ b/ci/npm-deploy.yml
@@ -59,12 +59,14 @@ beta connect deploy npm:
   <<: *npm_beta_deploy_rules
   script:
     - nix-shell --run "REMOTE_VERSION=\$(npm show @trezor/connect version --tag beta) && node ./ci/scripts/check-version \$REMOTE_VERSION $CI_COMMIT_BRANCH"
+    - nix-shell --run "node ci/scripts/check-npm-dependencies.js connect"
     - nix-shell --run "yarn && cd ./packages/connect && npm publish --tag beta"
 
 beta connect-web deploy npm:
   <<: *npm_beta_deploy_rules
   script:
     - nix-shell --run "REMOTE_VERSION=\$(npm show @trezor/connect-web version --tag beta) && node ./ci/scripts/check-version \$REMOTE_VERSION $CI_COMMIT_BRANCH"
+    - nix-shell --run "node ci/scripts/check-npm-dependencies.js connect-web"
     - nix-shell --run "yarn && cd ./packages/connect-web && npm publish --tag beta"
 
 beta connect-plugin-stellar deploy npm:
@@ -145,6 +147,7 @@ connect deploy npm:
     <<: *npm_registry_release_connect_rules
   <<: *npm_deploy_rules
   script:
+    - nix-shell --run "node ci/scripts/check-npm-dependencies.js connect"
     - nix-shell --run "yarn && cd ./packages/connect && npm publish"
 
 # releases trezor-connect to npm registry
@@ -153,6 +156,7 @@ connect-web deploy npm:
     <<: *npm_registry_release_connect_rules
   <<: *npm_deploy_rules
   script:
+    - nix-shell --run "node ci/scripts/check-npm-dependencies.js connect-web"
     - nix-shell --run "yarn && cd ./packages/connect-web && npm publish"
 
 connect-plugin-stellar deploy npm:


### PR DESCRIPTION
Hi @vdovhanych 
This is an idea how to ensure consistency in node dependencies. Lets discuss it tomorrow maybe?

My notes:
- this is probably too strict. to fail-exit release here because it will happen quite often that there are "unreleased" dependencies. In many cases, this will be expected - just some minor changes not affecting functionality. So where do we put this check? 