### PR TITLE
Improve connect release

### DIFF
--- a/docs/SUMMARY.md
+++ b/docs/SUMMARY.md
@@ -19,7 +19,6 @@
     -   [@trezor/connect](./packages/connect/index.md)
         -   [debugging](./packages/connect/debugging.md)
         -   [dependencies](./packages/connect/dependencies.md)
-        -   [deployment](./packages/connect/deployment.md)
         -   [protobuf](./packages/connect/protobuf-type-definitions.md)
         -   [coins support](./packages/connect/supported-coins.md)
         -   [events](./packages/connect/events.md)

--- a/packages/connect-explorer/package.json
+++ b/packages/connect-explorer/package.json
@@ -10,7 +10,7 @@
     },
     "dependencies": {
         "@trezor/components": "*",
-        "@trezor/connect-web": "9.0.0-beta.2",
+        "@trezor/connect-web": "9.0.0-beta.4",
         "markdown-it": "^12.3.2",
         "markdown-it-link-attributes": "^4.0.0",
         "markdown-it-replace-link": "^1.0.1",

--- a/packages/connect-iframe/package.json
+++ b/packages/connect-iframe/package.json
@@ -11,7 +11,7 @@
     },
     "dependencies": {},
     "devDependencies": {
-        "@trezor/connect": "9.0.0-beta.2",
+        "@trezor/connect": "9.0.0-beta.3",
         "copy-webpack-plugin": "^10.2.4",
         "html-webpack-plugin": "^5.3.2",
         "terser-webpack-plugin": "5.3.1",

--- a/packages/connect-iframe/package.json
+++ b/packages/connect-iframe/package.json
@@ -11,7 +11,7 @@
     },
     "dependencies": {},
     "devDependencies": {
-        "@trezor/connect": "9.0.0-beta.3",
+        "@trezor/connect": "9.0.0-beta.4",
         "copy-webpack-plugin": "^10.2.4",
         "html-webpack-plugin": "^5.3.2",
         "terser-webpack-plugin": "5.3.1",

--- a/packages/connect-popup/package.json
+++ b/packages/connect-popup/package.json
@@ -10,7 +10,7 @@
         "build": "rimraf build && TS_NODE_PROJECT=\"tsconfig.json\" wp --config ./webpack/prod.webpack.config.ts"
     },
     "dependencies": {
-        "@trezor/connect": "9.0.0-beta.2",
+        "@trezor/connect": "9.0.0-beta.3",
         "@trezor/urls": "*"
     }
 }

--- a/packages/connect-popup/package.json
+++ b/packages/connect-popup/package.json
@@ -10,7 +10,7 @@
         "build": "rimraf build && TS_NODE_PROJECT=\"tsconfig.json\" wp --config ./webpack/prod.webpack.config.ts"
     },
     "dependencies": {
-        "@trezor/connect": "9.0.0-beta.3",
+        "@trezor/connect": "9.0.0-beta.4",
         "@trezor/urls": "*"
     }
 }

--- a/packages/connect-web/package.json
+++ b/packages/connect-web/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@trezor/connect-web",
-    "version": "9.0.0-beta.3",
+    "version": "9.0.0-beta.4",
     "author": "Trezor <info@trezor.io>",
     "homepage": "https://github.com/trezor/trezor-suite/tree/develop/packages/connect-web",
     "description": "High-level javascript interface for Trezor hardware wallet.",
@@ -35,7 +35,7 @@
         "build": "rimraf build && yarn build:inline && yarn build:webextension"
     },
     "dependencies": {
-        "@trezor/connect": "9.0.0-beta.3",
+        "@trezor/connect": "9.0.0-beta.4",
         "@trezor/utils": "^9.0.2",
         "events": "^3.3.0",
         "tslib": "^2.3.1"

--- a/packages/connect-web/package.json
+++ b/packages/connect-web/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@trezor/connect-web",
-    "version": "9.0.0-beta.2",
+    "version": "9.0.0-beta.3",
     "author": "Trezor <info@trezor.io>",
     "homepage": "https://github.com/trezor/trezor-suite/tree/develop/packages/connect-web",
     "description": "High-level javascript interface for Trezor hardware wallet.",
@@ -35,7 +35,7 @@
         "build": "rimraf build && yarn build:inline && yarn build:webextension"
     },
     "dependencies": {
-        "@trezor/connect": "9.0.0-beta.2",
+        "@trezor/connect": "9.0.0-beta.3",
         "@trezor/utils": "^9.0.2",
         "events": "^3.3.0",
         "tslib": "^2.3.1"

--- a/packages/connect-web/src/webextension/trezor-usb-permissions.js
+++ b/packages/connect-web/src/webextension/trezor-usb-permissions.js
@@ -1,4 +1,4 @@
-const VERSION = '9.0.0-beta.1';
+const VERSION = '9.0.0-beta.3';
 const versionN = VERSION.split('.').map(s => parseInt(s, 10));
 // const DIRECTORY = `${ versionN[0] }${ (versionN[1] > 0 ? `.${versionN[1]}` : '') }/`;
 const DIRECTORY = `${versionN[0]}/`;

--- a/packages/connect-web/src/webextension/trezor-usb-permissions.js
+++ b/packages/connect-web/src/webextension/trezor-usb-permissions.js
@@ -1,4 +1,4 @@
-const VERSION = '9.0.0-beta.3';
+const VERSION = '9.0.0-beta.4';
 const versionN = VERSION.split('.').map(s => parseInt(s, 10));
 // const DIRECTORY = `${ versionN[0] }${ (versionN[1] > 0 ? `.${versionN[1]}` : '') }/`;
 const DIRECTORY = `${versionN[0]}/`;

--- a/packages/connect/README.md
+++ b/packages/connect/README.md
@@ -1,4 +1,4 @@
-# @trezor/connect API version 9.0.0-beta.1
+# @trezor/connect API version 9.0.0-beta.3
 
 [![Build Status](https://github.com/trezor/trezor-suite/actions/workflows/connect-test.yml/badge.svg)](https://github.com/trezor/trezor-suite/actions/workflows/connect-test.yml)
 [![NPM](https://img.shields.io/npm/v/@trezor/connect.svg)](https://www.npmjs.org/package/@trezor/connect)

--- a/packages/connect/README.md
+++ b/packages/connect/README.md
@@ -21,13 +21,14 @@ Version 9+ will be available as `@trezor/connect` and `@trezor/connect-web` npm 
 
 ## Step by step release process
 
--   Make sure you have released all [npm dependencies](../../releases/npm-packages.md)
--   bump version in all @trezor/connect\* packages (except plugin packages).
+-   Make sure you have released all [npm dependencies](../../releases/npm-packages.md).
+-   Optional: if unsure run `node ./ci/scripts/check-npm-dependencies.js connect`. Please note that this script will report unreleased dependencies even for changes that do not affect runtime (READMEs etc.)
+-   bump version in all @trezor/connect\* packages (except plugin packages). `yarn workspace @trezor/connect version:<beta|patch|minor|major>`
 -   make sure CHANGELOG files have been updated
 -   merge into develop branch
 -   from develop branch create a pull requests into branch `release/connect-v9`
 -   gitlab: click manual release `@trezor/connect-web` and `@trezor/connect` into npm
--   gitlab: click manual release `@trezor/connect-web` and `@trezor/connect` into npm
+-   gitlab: click manual deploy job to connect.trezor.io/9
 
 ## Version 8 (stable)
 

--- a/packages/connect/README.md
+++ b/packages/connect/README.md
@@ -1,4 +1,4 @@
-# @trezor/connect API version 9.0.0-beta.3
+# @trezor/connect API version 9.0.0-beta.4
 
 [![Build Status](https://github.com/trezor/trezor-suite/actions/workflows/connect-test.yml/badge.svg)](https://github.com/trezor/trezor-suite/actions/workflows/connect-test.yml)
 [![NPM](https://img.shields.io/npm/v/@trezor/connect.svg)](https://www.npmjs.org/package/@trezor/connect)

--- a/packages/connect/package.json
+++ b/packages/connect/package.json
@@ -43,6 +43,7 @@
     },
     "dependencies": {
         "@trezor/blockchain-link": "^2.1.3",
+        "@trezor/connect-common": "0.0.7",
         "@trezor/transport": "^1.1.3",
         "@trezor/utils": "^9.0.2",
         "@trezor/utxo-lib": "^1.0.0",

--- a/packages/connect/package.json
+++ b/packages/connect/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@trezor/connect",
-    "version": "9.0.0-beta.2",
+    "version": "9.0.0-beta.3",
     "author": "Trezor <info@trezor.io>",
     "homepage": "https://github.com/trezor/trezor-suite/tree/develop/packages/connect",
     "description": "High-level javascript interface for Trezor hardware wallet.",

--- a/packages/connect/package.json
+++ b/packages/connect/package.json
@@ -36,10 +36,10 @@
         "test:unit": "jest",
         "type-check": "tsc --build",
         "build:lib": "rimraf ./lib && tsc --build tsconfig.lib.json",
-        "version:beta": "yarn bump prerelease ./package.json ./README.md ./src/data/ConnectSettings.ts ../connect-web/package.json ../connect-web/src/webextension/trezor-usb-permissions.ts",
-        "version:patch": "yarn bump patch ./package.json ./README.md ./src/data/ConnectSettings.ts ../connect-web/package.json ../connect-web/src/webextension/trezor-usb-permissions.ts",
-        "version:minor": "yarn bump minor ./package.json ./README.md ./src/data/ConnectSettings.ts ../connect-web/package.json ../connect-web/src/webextension/trezor-usb-permissions.ts",
-        "version:major": "yarn bump major ./package.json ./README.md ./src/data/ConnectSettings.ts ../connect-web/package.json ../connect-web/src/webextension/trezor-usb-permissions.ts"
+        "version:beta": "node scripts/bump-version.js prerelease",
+        "version:patch": "node scripts/bump-version.js patch",
+        "version:minor": "node scripts/bump-version.js minor",
+        "version:major": "node scripts/bump-version.js major"
     },
     "dependencies": {
         "@trezor/blockchain-link": "^2.1.3",

--- a/packages/connect/package.json
+++ b/packages/connect/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@trezor/connect",
-    "version": "9.0.0-beta.3",
+    "version": "9.0.0-beta.4",
     "author": "Trezor <info@trezor.io>",
     "homepage": "https://github.com/trezor/trezor-suite/tree/develop/packages/connect",
     "description": "High-level javascript interface for Trezor hardware wallet.",

--- a/packages/connect/package.json
+++ b/packages/connect/package.json
@@ -43,7 +43,7 @@
     },
     "dependencies": {
         "@trezor/blockchain-link": "^2.1.3",
-        "@trezor/connect-common": "0.0.7",
+        "@trezor/connect-common": "0.0.8",
         "@trezor/transport": "^1.1.3",
         "@trezor/utils": "^9.0.2",
         "@trezor/utxo-lib": "^1.0.0",

--- a/packages/connect/scripts/bump-version.js
+++ b/packages/connect/scripts/bump-version.js
@@ -1,0 +1,42 @@
+const child_process = require('child_process');
+const path = require('path');
+
+const PACKAGE_PATH = path.join(__dirname, '..');
+
+const args = process.argv.slice(2);
+
+console.log('args', args);
+
+if (args.length !== 1) {
+    throw new Error('semver arg is missing');
+}
+
+const [semver] = args;
+
+const allowedSemver = ['prerelease', 'patch', 'minor', 'major'];
+
+if (!allowedSemver.includes(semver)) {
+    throw new Error(
+        `semver arg "${semver} is invalid. Must be one of [${allowedSemver.join(', ')}]`,
+    );
+}
+
+const cmd = [
+    'bump',
+    semver,
+
+    // files with version
+    './package.json',
+    'README.md',
+    './src/data/version.ts',
+    '../connect-web/package.json',
+    '../connect-web/src/webextension/trezor-usb-permissions.js',
+
+    // todo: add examples package.jsons
+    // todo: consider adding all suite/package.json
+];
+
+const res = child_process.spawnSync('yarn', cmd, {
+    encoding: 'utf-8',
+    cwd: PACKAGE_PATH,
+}).stdout;

--- a/packages/connect/src/data/version.ts
+++ b/packages/connect/src/data/version.ts
@@ -1,4 +1,4 @@
-export const VERSION = '9.0.0-beta.3';
+export const VERSION = '9.0.0-beta.4';
 
 const versionN = VERSION.split('.').map(s => parseInt(s, 10));
 

--- a/packages/connect/src/data/version.ts
+++ b/packages/connect/src/data/version.ts
@@ -1,4 +1,4 @@
-export const VERSION = '9.0.0-beta.1';
+export const VERSION = '9.0.0-beta.3';
 
 const versionN = VERSION.split('.').map(s => parseInt(s, 10));
 

--- a/packages/connect/tsconfig.json
+++ b/packages/connect/tsconfig.json
@@ -3,6 +3,7 @@
     "compilerOptions": { "outDir": "libDev" },
     "references": [
         { "path": "../blockchain-link" },
+        { "path": "../connect-common" },
         { "path": "../transport" },
         { "path": "../utils" },
         { "path": "../utxo-lib" }

--- a/packages/suite-desktop/package.json
+++ b/packages/suite-desktop/package.json
@@ -183,7 +183,7 @@
     },
     "dependencies": {
         "@sentry/electron": "3.0.0",
-        "@trezor/connect": "9.0.0-beta.2",
+        "@trezor/connect": "9.0.0-beta.3",
         "@trezor/suite-analytics": "*",
         "@trezor/suite-desktop-api": "*",
         "@trezor/urls": "*",

--- a/packages/suite-desktop/package.json
+++ b/packages/suite-desktop/package.json
@@ -183,7 +183,7 @@
     },
     "dependencies": {
         "@sentry/electron": "3.0.0",
-        "@trezor/connect": "9.0.0-beta.3",
+        "@trezor/connect": "9.0.0-beta.4",
         "@trezor/suite-analytics": "*",
         "@trezor/suite-desktop-api": "*",
         "@trezor/urls": "*",

--- a/packages/suite-native/package.json
+++ b/packages/suite-native/package.json
@@ -18,7 +18,7 @@
         "@shopify/react-native-skia": "0.1.123",
         "@suite-native/atoms": "*",
         "@suite-native/navigation-root": "*",
-        "@trezor/connect": "9.0.0-beta.3",
+        "@trezor/connect": "9.0.0-beta.4",
         "@trezor/styles": "*",
         "@trezor/theme": "*",
         "@trezor/transport-native": "*",

--- a/packages/suite-native/package.json
+++ b/packages/suite-native/package.json
@@ -18,7 +18,7 @@
         "@shopify/react-native-skia": "0.1.123",
         "@suite-native/atoms": "*",
         "@suite-native/navigation-root": "*",
-        "@trezor/connect": "9.0.0-beta.2",
+        "@trezor/connect": "9.0.0-beta.3",
         "@trezor/styles": "*",
         "@trezor/theme": "*",
         "@trezor/transport-native": "*",

--- a/packages/suite/package.json
+++ b/packages/suite/package.json
@@ -27,7 +27,7 @@
         "@sentry/integrations": "6.17.2",
         "@sentry/minimal": "6.17.2",
         "@trezor/components": "*",
-        "@trezor/connect": "9.0.0-beta.2",
+        "@trezor/connect": "9.0.0-beta.3",
         "@trezor/suite-analytics": "*",
         "@trezor/suite-data": "*",
         "@trezor/suite-desktop-api": "*",

--- a/packages/suite/package.json
+++ b/packages/suite/package.json
@@ -27,7 +27,7 @@
         "@sentry/integrations": "6.17.2",
         "@sentry/minimal": "6.17.2",
         "@trezor/components": "*",
-        "@trezor/connect": "9.0.0-beta.3",
+        "@trezor/connect": "9.0.0-beta.4",
         "@trezor/suite-analytics": "*",
         "@trezor/suite-data": "*",
         "@trezor/suite-desktop-api": "*",

--- a/yarn.lock
+++ b/yarn.lock
@@ -4652,6 +4652,38 @@
   resolved "https://registry.yarnpkg.com/@tootallnate/once/-/once-2.0.0.tgz#f544a148d3ab35801c1f633a7441fd87c2e484bf"
   integrity sha512-XCuKFP5PS55gnMVu3dty8KPatLqUoy/ZYzDzAGCQ8JNFCkLXzmI7vNHCR+XpbZaMWQK/vQubr7PkYq8g470J/A==
 
+"@trezor/connect-common@0.0.7":
+  version "0.0.7"
+  resolved "https://registry.yarnpkg.com/@trezor/connect-common/-/connect-common-0.0.7.tgz#fabe15bbb5e99b4563c9d63ae7ea3165b321198d"
+  integrity sha512-Z4I/LlxUwdiZL9L59rhjZ/x9Hkf+rfLXVgaYpp0AX5INgp9/AGfcLJvYgAuuF7iJ/xLgArXTICbgBq8VxvB+jg==
+
+"@trezor/connect-web@9.0.0-beta.2":
+  version "9.0.0-beta.2"
+  resolved "https://registry.yarnpkg.com/@trezor/connect-web/-/connect-web-9.0.0-beta.2.tgz#693438382ed6de148dee9864e3a25051ef2d3d9e"
+  integrity sha512-lC1I+4lULF2SwEq2jEj+PJQDelUei3n71j+CvL1vg7YhW2bYvRf+74S+USLu8BeRAIViTa8EZFFqhYY7pGBIEw==
+  dependencies:
+    "@trezor/connect" "9.0.0-beta.2"
+    "@trezor/utils" "^9.0.2"
+    events "^3.3.0"
+    tslib "^2.3.1"
+
+"@trezor/connect@9.0.0-beta.2":
+  version "9.0.0-beta.2"
+  resolved "https://registry.yarnpkg.com/@trezor/connect/-/connect-9.0.0-beta.2.tgz#723e88d53887ef3e4fea132785602028daa20d93"
+  integrity sha512-j262a9msuP4FZht+uyAGrfhqNk5v/z8M9vptxkqEOPZH/EcQxoQKQfisZ53ANX50tGuXS/JwOrrgRAIoWQPKnQ==
+  dependencies:
+    "@trezor/blockchain-link" "^2.1.3"
+    "@trezor/transport" "^1.1.3"
+    "@trezor/utils" "^9.0.2"
+    "@trezor/utxo-lib" "^1.0.0"
+    bignumber.js "^9.0.2"
+    bowser "^2.11.0"
+    cross-fetch "^3.1.5"
+    events "^3.3.0"
+    parse-uri "1.0.7"
+    randombytes "2.1.0"
+    tslib "^2.3.1"
+
 "@trysound/sax@0.2.0":
   version "0.2.0"
   resolved "https://registry.yarnpkg.com/@trysound/sax/-/sax-0.2.0.tgz#cccaab758af56761eb7bf37af6f03f326dd798ad"

--- a/yarn.lock
+++ b/yarn.lock
@@ -4652,38 +4652,6 @@
   resolved "https://registry.yarnpkg.com/@tootallnate/once/-/once-2.0.0.tgz#f544a148d3ab35801c1f633a7441fd87c2e484bf"
   integrity sha512-XCuKFP5PS55gnMVu3dty8KPatLqUoy/ZYzDzAGCQ8JNFCkLXzmI7vNHCR+XpbZaMWQK/vQubr7PkYq8g470J/A==
 
-"@trezor/connect-common@0.0.8":
-  version "0.0.8"
-  resolved "https://registry.yarnpkg.com/@trezor/connect-common/-/connect-common-0.0.8.tgz#949def3db3ddc64f44a6c1bf5f25108296d85f39"
-  integrity sha512-C8TEfYmzLanV9c1yuD77n1aZp+0gWJNBxg8pz2PSfsmaQtLKjiX3UXo+MJHgtGjnVnncK89HtNnus5cOogwYPg==
-
-"@trezor/connect-web@9.0.0-beta.2":
-  version "9.0.0-beta.2"
-  resolved "https://registry.yarnpkg.com/@trezor/connect-web/-/connect-web-9.0.0-beta.2.tgz#693438382ed6de148dee9864e3a25051ef2d3d9e"
-  integrity sha512-lC1I+4lULF2SwEq2jEj+PJQDelUei3n71j+CvL1vg7YhW2bYvRf+74S+USLu8BeRAIViTa8EZFFqhYY7pGBIEw==
-  dependencies:
-    "@trezor/connect" "9.0.0-beta.2"
-    "@trezor/utils" "^9.0.2"
-    events "^3.3.0"
-    tslib "^2.3.1"
-
-"@trezor/connect@9.0.0-beta.2":
-  version "9.0.0-beta.2"
-  resolved "https://registry.yarnpkg.com/@trezor/connect/-/connect-9.0.0-beta.2.tgz#723e88d53887ef3e4fea132785602028daa20d93"
-  integrity sha512-j262a9msuP4FZht+uyAGrfhqNk5v/z8M9vptxkqEOPZH/EcQxoQKQfisZ53ANX50tGuXS/JwOrrgRAIoWQPKnQ==
-  dependencies:
-    "@trezor/blockchain-link" "^2.1.3"
-    "@trezor/transport" "^1.1.3"
-    "@trezor/utils" "^9.0.2"
-    "@trezor/utxo-lib" "^1.0.0"
-    bignumber.js "^9.0.2"
-    bowser "^2.11.0"
-    cross-fetch "^3.1.5"
-    events "^3.3.0"
-    parse-uri "1.0.7"
-    randombytes "2.1.0"
-    tslib "^2.3.1"
-
 "@trysound/sax@0.2.0":
   version "0.2.0"
   resolved "https://registry.yarnpkg.com/@trysound/sax/-/sax-0.2.0.tgz#cccaab758af56761eb7bf37af6f03f326dd798ad"

--- a/yarn.lock
+++ b/yarn.lock
@@ -4652,10 +4652,10 @@
   resolved "https://registry.yarnpkg.com/@tootallnate/once/-/once-2.0.0.tgz#f544a148d3ab35801c1f633a7441fd87c2e484bf"
   integrity sha512-XCuKFP5PS55gnMVu3dty8KPatLqUoy/ZYzDzAGCQ8JNFCkLXzmI7vNHCR+XpbZaMWQK/vQubr7PkYq8g470J/A==
 
-"@trezor/connect-common@0.0.7":
-  version "0.0.7"
-  resolved "https://registry.yarnpkg.com/@trezor/connect-common/-/connect-common-0.0.7.tgz#fabe15bbb5e99b4563c9d63ae7ea3165b321198d"
-  integrity sha512-Z4I/LlxUwdiZL9L59rhjZ/x9Hkf+rfLXVgaYpp0AX5INgp9/AGfcLJvYgAuuF7iJ/xLgArXTICbgBq8VxvB+jg==
+"@trezor/connect-common@0.0.8":
+  version "0.0.8"
+  resolved "https://registry.yarnpkg.com/@trezor/connect-common/-/connect-common-0.0.8.tgz#949def3db3ddc64f44a6c1bf5f25108296d85f39"
+  integrity sha512-C8TEfYmzLanV9c1yuD77n1aZp+0gWJNBxg8pz2PSfsmaQtLKjiX3UXo+MJHgtGjnVnncK89HtNnus5cOogwYPg==
 
 "@trezor/connect-web@9.0.0-beta.2":
   version "9.0.0-beta.2"


### PR DESCRIPTION
- add bump-version script. nicer and easier to mantain
- fix some docs
- list @trezor/connect-common in dependencies

considering more automation:
- bump version script as github job? similar to crowdin etc? 

