### PR TITLE
feat: prepare connect-plugin-ethereum for release

### DIFF
--- a/ci/npm-deploy.yml
+++ b/ci/npm-deploy.yml
@@ -10,6 +10,7 @@
             "utils",
             "utxo-lib",
             "connect-plugin-stellar",
+            "connect-plugin-ethereum",
             "connect",
             "connect-web",
             "connect-common",

--- a/packages/connect-plugin-ethereum/__tests__/index.test.ts
+++ b/packages/connect-plugin-ethereum/__tests__/index.test.ts
@@ -1,11 +1,12 @@
 /* eslint-disable camelcase */
 
-const commonFixtures = require('../../../submodules/trezor-common/tests/fixtures/ethereum/sign_typed_data.json');
-const typedData = require('..');
+// @ts-ignore
+import commonFixtures from '../../../submodules/trezor-common/tests/fixtures/ethereum/sign_typed_data.json';
+import { transformTypedData } from '../src/index';
 
 // Adds 0x to a string if it doesn't start with one
 // fixtures sometimes start with 0x, sometimes not
-function messageToHex(string) {
+function messageToHex(string: string) {
     return string.startsWith('0x') ? string : `0x${string}`;
 }
 
@@ -14,7 +15,8 @@ describe('typedData', () => {
         .filter(test => test.parameters.metamask_v4_compat)
         .forEach(test => {
             it('typedData to message_hash and domain_separator_hash', () => {
-                const transformed = typedData(
+                const transformed = transformTypedData(
+                    // @ts-ignore JSON..
                     test.parameters.data,
                     test.parameters.metamask_v4_compat,
                 );
@@ -23,7 +25,7 @@ describe('typedData', () => {
                 expect(messageToHex(domain_separator_hash)).toEqual(
                     messageToHex(test.parameters.domain_separator_hash),
                 );
-                if (message_hash) {
+                if (message_hash && test.parameters.message_hash) {
                     expect(messageToHex(message_hash)).toEqual(
                         messageToHex(test.parameters.message_hash),
                     );

--- a/packages/connect-plugin-ethereum/jest.config.js
+++ b/packages/connect-plugin-ethereum/jest.config.js
@@ -1,0 +1,16 @@
+module.exports = {
+    globals: {
+        'ts-jest': {
+            tsconfig: 'tsconfig.lib.json',
+        },
+    },
+    testEnvironment: 'node',
+    testMatch: ['**/*.test.ts'],
+    coverageDirectory: './coverage/',
+    collectCoverage: true,
+    collectCoverageFrom: ['**/src/**/*.ts'],
+    modulePathIgnorePatterns: ['node_modules', '<rootDir>/lib', '<rootDir>/libDev'],
+    transform: {
+        '^.+\\.ts$': 'ts-jest',
+    },
+};

--- a/packages/connect-plugin-ethereum/package.json
+++ b/packages/connect-plugin-ethereum/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@trezor/connect-plugin-ethereum",
-    "version": "9.0.0",
+    "version": "9.0.0-beta.1",
     "author": "Trezor <info@trezor.io>",
     "homepage": "https://github.com/trezor/trezor-suite/tree/develop/packages/connect-plugin-ethereum",
     "description": "@trezor/connect plugin for Ethereum",
@@ -18,7 +18,10 @@
         "Ethereum"
     ],
     "sideEffects": false,
-    "main": "index.js",
+    "main": "lib/index.js",
+    "files": [
+        "lib/"
+    ],
     "peerDependencies": {
         "@metamask/eth-sig-util": "^4.0.1"
     },
@@ -26,6 +29,9 @@
         "@metamask/eth-sig-util": "^4.0.1"
     },
     "scripts": {
-        "test:unit": "jest"
+        "lint": "eslint '**/*.{ts,tsx,js}'",
+        "test:unit": "jest --verbose -c jest.config.js",
+        "type-check": "tsc --build tsconfig.json",
+        "build:lib": "rimraf ./lib && tsc --build tsconfig.lib.json"
     }
 }

--- a/packages/connect-plugin-ethereum/src/index.ts
+++ b/packages/connect-plugin-ethereum/src/index.ts
@@ -1,9 +1,9 @@
 /* eslint-disable camelcase */
 
-const sigUtil = require('@metamask/eth-sig-util');
+import * as sigUtil from '@metamask/eth-sig-util';
 
 // Sanitization is used for T1 as eth-sig-util does not support BigInt
-function sanitizeData(data) {
+function sanitizeData(data: any): any {
     switch (Object.prototype.toString.call(data)) {
         case '[object Object]': {
             const entries = Object.keys(data).map(k => [k, sanitizeData(data[k])]);
@@ -11,7 +11,7 @@ function sanitizeData(data) {
         }
 
         case '[object Array]':
-            return data.map(v => sanitizeData(v));
+            return data.map((v: any[]) => sanitizeData(v));
 
         case '[object BigInt]':
             return data.toString();
@@ -30,9 +30,12 @@ function sanitizeData(data) {
  * @template {sigUtil.TypedMessage} T
  * @param {T} data - The EIP-712 Typed Data object.
  * @param {boolean} metamask_v4_compat - Set to `true` for compatibility with Metamask's signTypedData_v4 function.
- * @returns {{domain_separator_hash: string, message_hash?: string} & T} The hashes.
+ * @returns {{domain_separator_hash: string, message_hash?: string | null} & T} The hashes.
  */
-const transformTypedData = (data, metamask_v4_compat) => {
+export const transformTypedData = <T extends sigUtil.MessageTypes>(
+    data: sigUtil.TypedMessage<T>,
+    metamask_v4_compat: boolean,
+) => {
     if (!metamask_v4_compat) {
         throw new Error('Trezor: Only version 4 of typed data signing is supported');
     }
@@ -52,7 +55,7 @@ const transformTypedData = (data, metamask_v4_compat) => {
 
     if (primaryType !== 'EIP712Domain') {
         messageHash = sigUtil.TypedDataUtils.hashStruct(
-            primaryType,
+            primaryType as string,
             sanitizeData(message),
             types,
             version,
@@ -66,4 +69,4 @@ const transformTypedData = (data, metamask_v4_compat) => {
     };
 };
 
-module.exports = transformTypedData;
+export default transformTypedData;

--- a/packages/connect-plugin-ethereum/tsconfig.json
+++ b/packages/connect-plugin-ethereum/tsconfig.json
@@ -1,6 +1,9 @@
 {
     "extends": "../../tsconfig.json",
-    "compilerOptions": { "outDir": "./libDev" },
+    "compilerOptions": {
+        "skipLibCheck": false,
+        "outDir": "./libDev"
+    },
     "include": ["."],
     "references": []
 }

--- a/packages/connect-plugin-ethereum/tsconfig.lib.json
+++ b/packages/connect-plugin-ethereum/tsconfig.lib.json
@@ -1,0 +1,8 @@
+{
+    "extends": "../../tsconfig.lib.json",
+    "compilerOptions": {
+        "outDir": "lib",
+        "lib": ["ES2019"]
+    },
+    "include": ["./src"]
+}


### PR DESCRIPTION
... was not released yet from monorepo. Connect v9 will still work with the old plugin released from connect 8 repository, but we of course want to release everything from here.