### PR TITLE
fix(msg-system): missing msg if device goes from incorrect to correct state

### DIFF
--- a/packages/suite/src/middlewares/suite/messageSystemMiddleware.ts
+++ b/packages/suite/src/middlewares/suite/messageSystemMiddleware.ts
@@ -1,5 +1,5 @@
 import { MiddlewareAPI } from 'redux';
-import { TRANSPORT } from '@trezor/connect';
+import { TRANSPORT, DEVICE } from '@trezor/connect';
 
 import { MESSAGE_SYSTEM, STORAGE, SUITE } from '@suite-actions/constants';
 import { getValidMessages } from '@suite-utils/messageSystem';
@@ -17,6 +17,7 @@ const actions = [
     MESSAGE_SYSTEM.FETCH_CONFIG_SUCCESS_UPDATE,
     WALLET_SETTINGS.CHANGE_NETWORKS,
     TRANSPORT.START,
+    DEVICE.CONNECT,
 ];
 
 const messageSystemMiddleware =


### PR DESCRIPTION
Fixes minor bug - flow:
The app is running with a device connected. User got modal to choose standard/hidden wallet but instead of choosing he refreshed the app => device got into an incorrect state. After claiming it, the message system was not activated. 

Caused by #5475