### PR TITLE
feat(suite-native): Fix network utils for RN in trezor/connect

### DIFF
--- a/packages/blockchain-link/package.json
+++ b/packages/blockchain-link/package.json
@@ -32,7 +32,7 @@
     },
     "react-native": {
         "__comment__": "Hotfix for issue where RN metro bundler resolve relatives paths wrong",
-        "ws": "@trezor/blockchain-link/lib/utils/ws.js",
+        "ws": "@trezor/blockchain-link/lib/utils/ws-native.js",
         "socks-proxy-agent": "@trezor/blockchain-link/lib/utils/socks-proxy-agent.js"
     },
     "scripts": {

--- a/packages/blockchain-link/src/utils/ws-native.ts
+++ b/packages/blockchain-link/src/utils/ws-native.ts
@@ -1,0 +1,58 @@
+import { EventEmitter } from 'events';
+
+/**
+ * Provides `EventEmitter` interface for React Native `WebSocket`,
+ * same, as `ws` package provides.
+ */
+class WSWrapper extends EventEmitter {
+    private _ws: WebSocket;
+    static CONNECTING = 0;
+    static OPEN = 1;
+    static CLOSING = 2;
+    static CLOSED = 3;
+
+    constructor(url: string, _protocols: any, _websocketOptions: any) {
+        super();
+        this.setMaxListeners(Infinity);
+
+        // React Native WebSocket is able to accept headers compared to the native browser `WebSocket`.
+        // @ts-ignore
+        this._ws = new WebSocket(url, '', {
+            headers: {
+                'User-Agent': 'Trezor Suite Native',
+            },
+        });
+
+        this._ws.onclose = () => {
+            this.emit('close');
+        };
+
+        this._ws.onopen = () => {
+            this.emit('open');
+        };
+
+        this._ws.onerror = error => {
+            this.emit('error', error);
+        };
+
+        this._ws.onmessage = message => {
+            this.emit('message', message.data);
+        };
+    }
+
+    close() {
+        if (this.readyState === 1) {
+            this._ws.close();
+        }
+    }
+
+    send(message: any) {
+        this._ws.send(message);
+    }
+
+    get readyState() {
+        return this._ws.readyState;
+    }
+}
+
+export = WSWrapper;

--- a/packages/connect/package.json
+++ b/packages/connect/package.json
@@ -25,7 +25,9 @@
         "./lib/utils/assets": "./lib/utils/assets-browser"
     },
     "react-native": {
-        "./lib/workers/workers": "./lib/workers/workers-react-native"
+        "./lib/index": "./lib/index",
+        "./lib/workers/workers": "./lib/workers/workers-react-native",
+        "./lib/utils/assets": "./lib/utils/assets-native"
     },
     "files": [
         "lib/",

--- a/packages/connect/src/utils/assetUtils.ts
+++ b/packages/connect/src/utils/assetUtils.ts
@@ -1,0 +1,19 @@
+/* eslint-disable global-require */
+
+export const getAssetByUrl = (url: string) => {
+    const fileUrl = url.split('?')[0];
+    switch (fileUrl) {
+        case './data/coins.json':
+            return require('@trezor/connect-common/files/coins.json');
+        case './data/bridge/releases.json':
+            return require('@trezor/connect-common/files/bridge/releases.json');
+        case './data/firmware/1/releases.json':
+            return require('@trezor/connect-common/files/firmware/1/releases.json');
+        case './data/firmware/2/releases.json':
+            return require('@trezor/connect-common/files/firmware/2/releases.json');
+        case './data/messages/messages.json':
+            return require('@trezor/transport/messages.json');
+        default:
+            return null;
+    }
+};

--- a/packages/connect/src/utils/assets-native.ts
+++ b/packages/connect/src/utils/assets-native.ts
@@ -1,0 +1,3 @@
+import { getAssetByUrl } from './assetUtils';
+
+export const httpRequest = (url: string, _type: string): any => getAssetByUrl(url);

--- a/packages/connect/src/utils/assets.ts
+++ b/packages/connect/src/utils/assets.ts
@@ -1,31 +1,18 @@
-/* eslint-disable global-require */
-
 // https://github.com/trezor/connect/blob/develop/src/js/env/node/networkUtils.js
 
 import fetch from 'cross-fetch';
 import { promises as fs } from 'fs';
 import { httpRequest as browserHttpRequest } from './assets-browser';
+import { getAssetByUrl } from './assetUtils';
 
 if (global && typeof global.fetch !== 'function') {
     global.fetch = fetch;
 }
 
 export const httpRequest = (url: string, _type: string): any => {
-    const fileUrl = url.split('?')[0];
-
-    switch (fileUrl) {
-        case './data/coins.json':
-            return require('@trezor/connect-common/files/coins.json');
-        case './data/bridge/releases.json':
-            return require('@trezor/connect-common/files/bridge/releases.json');
-        case './data/firmware/1/releases.json':
-            return require('@trezor/connect-common/files/firmware/1/releases.json');
-        case './data/firmware/2/releases.json':
-            return require('@trezor/connect-common/files/firmware/2/releases.json');
-        case './data/messages/messages.json':
-            return require('@trezor/transport/messages.json');
-        // no default
+    const asset = getAssetByUrl(url);
+    if (!asset) {
+        return /^https?/.test(url) ? browserHttpRequest(url) : fs.readFile(url);
     }
-
-    return /^https?/.test(url) ? browserHttpRequest(url) : fs.readFile(url);
+    return asset;
 };

--- a/suite-native/app/ios/Podfile.lock
+++ b/suite-native/app/ios/Podfile.lock
@@ -602,9 +602,9 @@ EXTERNAL SOURCES:
     :path: "../../../node_modules/react-native/ReactCommon/yoga"
 
 SPEC CHECKSUMS:
-  boost: 33822b9202be3240e51605d20431570aa3a6c58e
+  boost: a7c83b31436843459a1961bfd74b96033dc77234
   CocoaAsyncSocket: 065fd1e645c7abab64f7a6a2007a48038fdc6a99
-  DoubleConversion: 5c2288575b9bd33de61ab847e51d0dca167323e7
+  DoubleConversion: 831926d9b8bf8166fd87886c4abab286c2422662
   FBLazyVector: a7a655862f6b09625d11c772296b01cd5164b648
   FBReactNativeSpec: d8bedf13ce939219aacc80bbbe2675ce47f67e27
   Flipper: a543f6bd6571f07047d96640e19d8477452af0a5
@@ -617,11 +617,11 @@ SPEC CHECKSUMS:
   Flipper-RSocket: d9d9ade67cbecf6ac10730304bf5607266dd2541
   FlipperKit: efaa1aceb084376b7b5e6256126e2568627b278e
   fmt: ff9d55029c625d3757ed641535fd4a75fedc7ce9
-  glog: 46667b3bfd7b7368ebbef149ba7e1d17a61a1b94
+  glog: 476ee3e89abb49e07f822b48323c51c57124b572
   hermes-engine: 84e3af1ea01dd7351ac5d8689cbbea1f9903ffc3
   libevent: 4049cae6c81cdb3654a443be001fb9bdceff7913
   OpenSSL-Universal: ebc357f1e6bc71fa463ccb2fe676756aff50e88c
-  RCT-Folly: 97ba718a5f53eedf76d63d51074d5a9ca1245029
+  RCT-Folly: 4d8508a426467c48885f1151029bc15fa5d7b3b8
   RCTRequired: 3e917ea5377751094f38145fdece525aa90545a0
   RCTTypeSafety: c43c072a4bd60feb49a9570b0517892b4305c45e
   React: 176dd882de001854ced260fad41bb68a31aa4bd0

--- a/suite-native/app/src/App.tsx
+++ b/suite-native/app/src/App.tsx
@@ -1,5 +1,6 @@
-import React from 'react';
+import React, { useCallback, useEffect } from 'react';
 
+import TrezorConnect from '@trezor/connect';
 import { NavigationContainer } from '@react-navigation/native';
 import { store } from '@suite-native/state';
 import { GestureHandlerRootView } from 'react-native-gesture-handler';
@@ -9,16 +10,58 @@ import { Provider } from 'react-redux';
 import { RootTabNavigator } from './navigation/RootTabNavigator';
 import { StylesProvider } from './StylesProvider';
 
-export const App = () => (
-    <GestureHandlerRootView style={{ flex: 1 }}>
-        <NavigationContainer>
-            <Provider store={store}>
-                <SafeAreaProvider>
-                    <StylesProvider>
-                        <RootTabNavigator />
-                    </StylesProvider>
-                </SafeAreaProvider>
-            </Provider>
-        </NavigationContainer>
-    </GestureHandlerRootView>
-);
+const connectOptions = {
+    // connectSrc: 'https://connect.corp.sldev.cz/develop/',
+
+    connectSrc: 'http://localhost:8088/',
+    // transportReconnect: true,
+    debug: true,
+    popup: false,
+    webusb: false,
+    lazyLoad: true,
+    manifest: {
+        email: 'info@trezor.io',
+        appUrl: '@trezor/suite',
+    },
+};
+
+export const App = () => {
+    const getAccountInfo = useCallback(() => {
+        TrezorConnect.getAccountInfo({
+            coin: 'btc',
+            descriptor:
+                'zpub6rszzdAK6RuafeRwyN8z1cgWcXCuKbLmjjfnrW4fWKtcoXQ8787214pNJjnBG5UATyghuNzjn6Lfp5k5xymrLFJnCy46bMYJPyZsbpFGagT',
+        })
+            .then(accountInfo => {
+                console.log('Account info result: ', JSON.stringify(accountInfo, null, 2));
+            })
+            .catch(error => {
+                console.log('getAccountInfo failed: ', JSON.stringify(error));
+            });
+    }, []);
+
+    useEffect(() => {
+        TrezorConnect.init(connectOptions)
+            .then(initResult => {
+                console.log('Init result: ', initResult);
+                getAccountInfo();
+            })
+            .catch(error => {
+                console.log('Init failed', JSON.stringify(error.code));
+            });
+    }, [getAccountInfo]);
+
+    return (
+        <GestureHandlerRootView style={{ flex: 1 }}>
+            <NavigationContainer>
+                <Provider store={store}>
+                    <SafeAreaProvider>
+                        <StylesProvider>
+                            <RootTabNavigator />
+                        </StylesProvider>
+                    </SafeAreaProvider>
+                </Provider>
+            </NavigationContainer>
+        </GestureHandlerRootView>
+    );
+}

--- a/suite-native/app/src/App.tsx
+++ b/suite-native/app/src/App.tsx
@@ -1,8 +1,8 @@
 import React, { useCallback, useEffect } from 'react';
 
-import TrezorConnect from '@trezor/connect';
 import { NavigationContainer } from '@react-navigation/native';
 import { store } from '@suite-native/state';
+import TrezorConnect from '@trezor/connect';
 import { GestureHandlerRootView } from 'react-native-gesture-handler';
 import { SafeAreaProvider } from 'react-native-safe-area-context';
 import { Provider } from 'react-redux';
@@ -11,17 +11,10 @@ import { RootTabNavigator } from './navigation/RootTabNavigator';
 import { StylesProvider } from './StylesProvider';
 
 const connectOptions = {
-    // connectSrc: 'https://connect.corp.sldev.cz/develop/',
-
-    connectSrc: 'http://localhost:8088/',
-    // transportReconnect: true,
     debug: true,
-    popup: false,
-    webusb: false,
-    lazyLoad: true,
     manifest: {
         email: 'info@trezor.io',
-        appUrl: '@trezor/suite',
+        appUrl: '@trezor/suite-native',
     },
 };
 
@@ -64,4 +57,4 @@ export const App = () => {
             </NavigationContainer>
         </GestureHandlerRootView>
     );
-}
+};


### PR DESCRIPTION
- TrezorConnect init was not able to be invoked because `index-browser.ts` as an entry point was loaded for RN from **@trezor/connect**
- loading assets for RN fixed in a similar way (`assets-browser.ts` had been loaded for RN app...) but with a new file `assets-native.ts` - slightly merged from `assets.ts` for Node.
- WS init overriden for React Native in **@trezor/blockchain-link** (RN app has to send User-Agent. Otherwise, it fails with 403 from blockbook)
- demo for init and getAccountInfo in RN app

This is related to https://github.com/trezor/trezor-suite/issues/5708