### PR TITLE
ci(gh): fix loading available fws from tenv in connect tests

### DIFF
--- a/.github/workflows/connect-test.yml
+++ b/.github/workflows/connect-test.yml
@@ -10,6 +10,7 @@ on:
       - "packages/transport"
       - "packages/utxo-lib"
       - "packages/utils"
+      - "docker"
 
 jobs:
   # todo: meaning of 'build' job is questionable. only 'web' tests use part of this jobs output

--- a/docker/docker-connect-test.sh
+++ b/docker/docker-connect-test.sh
@@ -108,14 +108,13 @@ runDocker() {
 }
 
 getLatestFirmware() {
-  TESTS_FIRMWARE=$(node ./packages/integration-tests/get-latest-firmware.js)
+  TESTS_FIRMWARE=${TESTS_FIRMWARE:=$(node ./packages/integration-tests/get-latest-firmware.js)}
 }
-
 
 run() {
 
   echo "Testing env: ${ENVIRONEMT}. Using: ${SCRIPT} ${PATTERN}"
-  echo "  Firmware: ${FIRMWARE}"
+  echo "  Firmware: ${TESTS_FIRMWARE}"
   echo "  Test pattern: $PATTERN"
   echo "  Included methods: ${INCLUDED_METHODS}"
   echo "  Excluded methods: ${EXCLUDED_METHODS}"
@@ -132,4 +131,3 @@ run() {
 }
 
 run
-


### PR DESCRIPTION
tests still don't pass but this is a step forward. response in firmwares event has changed in the latest tenv