### PR TITLE
fix(ci): RN mac os develop build, add node from .nvmrc

### DIFF
--- a/.github/workflows/suite-native_develop_ci.yml
+++ b/.github/workflows/suite-native_develop_ci.yml
@@ -21,6 +21,10 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v3
+      - name: Setup node
+        uses: actions/setup-node@v3
+        with:
+          node-version-file: ".nvmrc"
       - name: Setup react-native kernel and increase watchers
         run: echo fs.inotify.max_user_watches=524288 | sudo tee -a /etc/sysctl.conf && sudo sysctl -p
       - name: Decode files
@@ -62,8 +66,10 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v3
-      - name: Setup react-native kernel and increase watchers
-        run: echo fs.inotify.max_user_watches=524288 | sudo tee -a /etc/sysctl.conf && sudo sysctl -p
+      - name: Setup node
+        uses: actions/setup-node@v3
+        with:
+          node-version-file: ".nvmrc"
       - name: Install dependecies
         run: yarn install
       - name: Ruby Setup for Fastlane

--- a/.github/workflows/suite-native_production_ci.yml
+++ b/.github/workflows/suite-native_production_ci.yml
@@ -14,6 +14,10 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v3
+      - name: Setup node
+        uses: actions/setup-node@v3
+        with:
+          node-version-file: ".nvmrc"
       - name: Setup react-native kernel and increase watchers
         run: echo fs.inotify.max_user_watches=524288 | sudo tee -a /etc/sysctl.conf && sudo sysctl -p
       - name: Decode files


### PR DESCRIPTION
- Use node version from .nvmrc
- remove inotify (linux only) for mac