### PR TITLE
fix(suite-desktop): add dropbox to allowed origins

### DIFF
--- a/packages/suite-desktop/src-electron/libs/http-receiver.ts
+++ b/packages/suite-desktop/src-electron/libs/http-receiver.ts
@@ -56,7 +56,7 @@ export class HttpReceiver extends EventEmitter {
             {
                 pathname: '/oauth',
                 handler: this.oauthHandler,
-                origins: ['', '127.0.0.1'], // No referer is sent by Google and Dropbox
+                origins: ['', '127.0.0.1', 'www.dropbox.com'], // No referer is sent by Google, Dropbox sends referer when using Safari
             },
             {
                 pathname: '/buy-redirect',


### PR DESCRIPTION
Fixes redirect from Dropbox OAuth as described in #5759. I don't really know why Dropbox adds a `referer` header only in Safari, but that's why it didn't work.