### PR TITLE
fix(suite): registerProtocolHandler in old browsers

### DIFF
--- a/packages/suite/src/support/suite/Protocol.tsx
+++ b/packages/suite/src/support/suite/Protocol.tsx
@@ -51,6 +51,8 @@ const Protocol = () => {
             navigator.registerProtocolHandler(
                 'bitcoin',
                 `${window.location.origin}${process.env.ASSET_PREFIX ?? ''}/?uri=%s`,
+                // @ts-ignore deprecated but required for Firefox <= 78, Chrome <= 87
+                'Trezor Suite - Bitcoin',
             );
         }
 


### PR DESCRIPTION
fixes #5763

- [x] Check cypress if we can try running the app in the lowest supported browser version