### PR TITLE
test(connect-popup): fix cardano sign test with latest fw

### DIFF
--- a/packages/integration-tests/projects/connect-popup/tests/__fixtures__/methods.js
+++ b/packages/integration-tests/projects/connect-popup/tests/__fixtures__/methods.js
@@ -485,7 +485,7 @@ const cardanoSignTransaction = [
     {
         device: initializedDevice,
         url: 'cardanoSignTransaction',
-        views: [followDevice, followDevice],
+        views: [followDevice, followDevice, followDevice],
     },
 ];
 


### PR DESCRIPTION
looks like there is an additional screen in the newest model T fw when signing cardano tx. I am starting to think that device interaction in tests could be more generic / automated :thinking: 

green https://gitlab.com/satoshilabs/trezor/trezor-suite/-/jobs/2716355435