### PR TITLE
Feat/enable oauth url change

### DIFF
--- a/packages/auth-server/README.md
+++ b/packages/auth-server/README.md
@@ -8,8 +8,8 @@ Google requires `client_secret` specific for an app to grant long term access to
 
 1. Generate your own testing credentials for a Desktop App in [Google Cloud Platform](https://console.cloud.google.com/apis/credentials).
 1. In Google Cloud Platform, add your account as a test user of the app.
-1. Replace `client_secret` and `client_id` values in requests with generated credentials.
-1. Set `AUTH_SERVER_URL` in [@trezor/suite](../suite/src/actions/suite/constants/metadataConstants.ts) to `http://localhost:3005`.
+1. Replace `client_secret` in [index.ts](./src/index.ts) and `client_id` in [@trezor/suite](../suite/src/actions/suite/constants/metadataConstants.ts) with generated credentials.
+1. Set OAuth API in Suite debug settings to `http://localhost:3005` or override the `authServerUrl` [here](../suite/src/services/google.ts).
 1. Install dependencies via `yarn workspace @trezor/auth-server install`.
 1. Run the server locally via `yarn workspace @trezor/auth-server dev`.
 

--- a/packages/auth-server/src/index.ts
+++ b/packages/auth-server/src/index.ts
@@ -8,10 +8,10 @@ app.use(express.json());
 
 const corsOptions: CorsOptions = {
     origin: [
-        'trezor.io', // production web
-        'sldev.cz', // staging web
-        'localhost', // development web + all desktop
-        'trezoriovpjcahpzkrewelclulmszwbqpzmzgub37gbcjlvluxtruqad.onion', // onion address for production web (Suite does not work here now)
+        'https://suite.trezor.io', // production web
+        /\.sldev\.cz$/, // staging web
+        'http://localhost:8000', // development web
+        'http://trezoriovpjcahpzkrewelclulmszwbqpzmzgub37gbcjlvluxtruqad.onion', // onion address for production web (Suite does not work here now)
     ],
 };
 app.use(cors(corsOptions));
@@ -22,10 +22,17 @@ const { GOOGLE_CLIENT_SECRET } = process.env; // generate testing credentials fo
 const checkResponse = (responseBody: object, expectedProperties: string[]) => {
     expectedProperties.forEach(property => {
         if (!Object.prototype.hasOwnProperty.call(responseBody, property)) {
-            throw new Error('Unexpected response from authentiacation server.');
+            throw new Error('Unexpected response from authentication server.');
         }
     });
 };
+
+/**
+ * Root URL should return 200 for health check.
+ */
+app.get('/', (_req, res) => {
+    res.send();
+});
 
 /**
  * Is server alive?
@@ -51,7 +58,7 @@ app.post('/google-oauth-init', async (req, res) => {
             method: 'POST',
         });
         const json = await response.json();
-        checkResponse(json, ['refresh_token', 'access_token', 'expires_in']);
+        checkResponse(json, ['refresh_token', 'access_token']);
         res.status(response.status).send(json);
     } catch (error) {
         res.status(401).json(`Authorization failed: ${error}`);
@@ -73,7 +80,7 @@ app.post('/google-oauth-refresh', async (req, res) => {
             method: 'POST',
         });
         const json = await response.json();
-        checkResponse(json, ['access_token', 'expires_in']);
+        checkResponse(json, ['access_token']);
         res.status(response.status).send(json);
     } catch (error) {
         res.status(401).json(`Refresh failed: ${error}`);

--- a/packages/suite/src/actions/suite/__tests__/metadataActions.test.ts
+++ b/packages/suite/src/actions/suite/__tests__/metadataActions.test.ts
@@ -57,12 +57,18 @@ export const getInitialState = (state?: InitialState) => {
         ? state.device
         : { state: 'device-state', connected: true, metadata: { status: 'disabled' } };
     const accounts = state ? state.accounts || [] : [];
+    const settings = suite?.settings || { debug: {} };
+    const debug = settings?.debug || {};
     const initAction: any = { type: STORAGE.LOADED, payload: { metadata } };
     return {
         metadata: metadataReducer(metadata, initAction),
         devices: device ? [device] : [], // device is needed for notification/event
         suite: {
             ...suite,
+            settings: {
+                ...settings,
+                debug, // debug settings are needed for OAuth API
+            },
             device, // device is needed for notification/event
         },
         wallet: {

--- a/packages/suite/src/actions/suite/constants/metadataConstants.ts
+++ b/packages/suite/src/actions/suite/constants/metadataConstants.ts
@@ -26,12 +26,9 @@ export const AUTH_WINDOW_WIDTH = 600;
 export const AUTH_WINDOW_HEIGHT = 720;
 export const AUTH_WINDOW_PROPS = `width=${AUTH_WINDOW_WIDTH},height=${AUTH_WINDOW_HEIGHT},dialog=yes,dependent=yes,scrollbars=yes,location=yes`;
 
-// server holding client_secret used in Google OAuth authorization code flow - set to 'http://localhost:3005' for development
-export const AUTH_SERVER_URL = 'https://suite-auth.trezor.io';
-
 // used when auth-server is running - generate testing credentials for development
 export const GOOGLE_CODE_FLOW_CLIENT_ID =
-    '705190185912-m4mrh55knjbg6gqhi72fr906a6n0b0u1.apps.googleusercontent.com'; //
+    '705190185912-m4mrh55knjbg6gqhi72fr906a6n0b0u1.apps.googleusercontent.com';
 
 // used as a fallback from authorization code flow
 export const GOOGLE_IMPLICIT_FLOW_CLIENT_ID =

--- a/packages/suite/src/constants/suite/anchors.ts
+++ b/packages/suite/src/constants/suite/anchors.ts
@@ -35,6 +35,7 @@ export const enum SettingsAnchor {
     GithubIssue = '@debug-settings/github-issue',
     WipeData = '@debug-settings/wipe-data',
     InvityApi = '@debug-settings/invity-api',
+    OAuthApi = '@debug-settings/oauth-api',
 }
 
 export const AccountTransactionBaseAnchor = '@account/transaction';

--- a/packages/suite/src/reducers/suite/suiteReducer.ts
+++ b/packages/suite/src/reducers/suite/suiteReducer.ts
@@ -9,10 +9,12 @@ import type { Locale } from '@suite-config/languages';
 import { isWeb, getWindowWidth } from '@suite-utils/env';
 import { ensureLocale } from '@suite-utils/l10n';
 import { getNumberFromPixelString } from '@trezor/utils';
+import type { OAuthServerEnvironment } from '@suite-types/metadata';
 import type { InvityServerEnvironment } from '@wallet-types/invity';
 
 export interface DebugModeOptions {
     invityServerEnvironment?: InvityServerEnvironment;
+    oauthServerEnvironment?: OAuthServerEnvironment;
     showDebugMenu: boolean;
 }
 

--- a/packages/suite/src/services/suite/metadata/GoogleProvider.ts
+++ b/packages/suite/src/services/suite/metadata/GoogleProvider.ts
@@ -1,12 +1,12 @@
-import { AbstractMetadataProvider, Tokens } from '@suite-types/metadata';
+import { AbstractMetadataProvider, OAuthServerEnvironment, Tokens } from '@suite-types/metadata';
 import GoogleClient from '@suite/services/google';
 
 class GoogleProvider extends AbstractMetadataProvider {
     connected = false;
     isCloud = true;
-    constructor(tokens: Tokens) {
+    constructor(tokens: Tokens, environment: OAuthServerEnvironment) {
         super('google');
-        GoogleClient.init(tokens);
+        GoogleClient.init(tokens, environment);
     }
 
     async connect() {

--- a/packages/suite/src/types/suite/metadata.ts
+++ b/packages/suite/src/types/suite/metadata.ts
@@ -169,3 +169,5 @@ export interface MetadataState {
     editing?: string;
     initiating?: boolean;
 }
+
+export type OAuthServerEnvironment = 'production' | 'staging' | 'localhost';

--- a/packages/suite/src/views/settings/debug/OAuthApi.tsx
+++ b/packages/suite/src/views/settings/debug/OAuthApi.tsx
@@ -1,0 +1,58 @@
+import React from 'react';
+import styled from 'styled-components';
+
+import GoogleClient from '@suite/services/google';
+import { ActionColumn, ActionSelect, SectionItem, TextColumn } from '@suite-components/Settings';
+import * as suiteActions from '@suite-actions/suiteActions';
+import { useSelector, useActions } from '@suite-hooks';
+import type { OAuthServerEnvironment } from '@suite-types/metadata';
+import { useAnchor } from '@suite-hooks/useAnchor';
+import { SettingsAnchor } from '@suite-constants/anchors';
+
+const StyledActionSelect = styled(ActionSelect)`
+    min-width: 256px;
+`;
+
+export const OAuthApi = () => {
+    const { setDebugMode } = useActions({
+        setDebugMode: suiteActions.setDebugMode,
+    });
+    const { debug } = useSelector(state => ({
+        debug: state.suite.settings.debug,
+    }));
+    const { anchorRef, shouldHighlight } = useAnchor(SettingsAnchor.OAuthApi);
+
+    const options = Object.entries(GoogleClient.servers).map(([environment, server]) => ({
+        label: server,
+        value: environment,
+    }));
+    const selectedOption =
+        options.find(option => option.value === debug.oauthServerEnvironment) || options[0];
+
+    const handleChange = (item: { value: OAuthServerEnvironment }) => {
+        setDebugMode({
+            oauthServerEnvironment: item.value,
+        });
+        GoogleClient.setEnvironment(item.value);
+    };
+
+    return (
+        <SectionItem
+            data-test="@settings/debug/oauth-api"
+            ref={anchorRef}
+            shouldHighlight={shouldHighlight}
+        >
+            <TextColumn
+                title="Google auth server"
+                description="Set the authorisation server url for labeling in Google Drive"
+            />
+            <ActionColumn>
+                <StyledActionSelect
+                    onChange={handleChange}
+                    value={selectedOption}
+                    options={options}
+                />
+            </ActionColumn>
+        </SectionItem>
+    );
+};

--- a/packages/suite/src/views/settings/debug/SettingsDebug.tsx
+++ b/packages/suite/src/views/settings/debug/SettingsDebug.tsx
@@ -8,6 +8,7 @@ import { TranslationMode } from './TranslationMode';
 import { GithubIssue } from './GithubIssue';
 import { WipeData } from './WipeData';
 import { InvityApi } from './InvityApi';
+import { OAuthApi } from './OAuthApi';
 
 export const SettingsDebug = () => (
     <SettingsLayout>
@@ -22,6 +23,9 @@ export const SettingsDebug = () => (
         </SettingsSection>
         <SettingsSection title="Invity">
             <InvityApi />
+        </SettingsSection>
+        <SettingsSection title="OAuth">
+            <OAuthApi />
         </SettingsSection>
     </SettingsLayout>
 );


### PR DESCRIPTION
Merging these changes and redeploying `@trezor/auth-server` to staging should allow testing the default (authorisation code) Google OAuth flow.

1. Fixes allowed origins in `@trezor/auth-server`
2. Adds the option to change auth-server URL in debug settings
3. Adds handling for unexpected response from auth server

@vdovhanych I noticed the calls to auth server fail when Tor is on (it requests an onion address). How can we fix that?

**QA:** Authorising with Google should behave the same as previously from the user's perspective, but access is not limited to 1 hour (access token will always refresh if invalid). There is a new setting in debug to change between production/staging/localhost for the authorization server - you can keep the default (production value); staging does not work with Tor enabled. Please check that the user stays authorized with Google for more than 1 hour on desktop. You can confirm it by changing a label and seeing a successful request to https://suite-auth.trezor.io/google-oauth-refresh in DevTools. These changes should not affect Dropbox, filesystem storage.