### PR TITLE
fix(coinmarket): fix overview savings sum

### DIFF
--- a/packages/suite/src/hooks/wallet/useCoinmarketSavingsOverview.ts
+++ b/packages/suite/src/hooks/wallet/useCoinmarketSavingsOverview.ts
@@ -37,12 +37,9 @@ export const useSavingsOverview = ({
         fiat: state.wallet.fiat,
     }));
 
-    const savingsTradeItemCompletedExists = trades.some(
-        trade => trade.tradeType === 'savings' && trade.data.status === 'Completed',
-    );
-
     const savingsCryptoSum = trades.reduce((previous: BigNumber, current: Trade) => {
         if (
+            current.account.descriptor === account.descriptor &&
             current.tradeType === 'savings' &&
             current.data.receiveStringAmount &&
             current.data.status === 'Completed'
@@ -51,6 +48,8 @@ export const useSavingsOverview = ({
         }
         return previous;
     }, new BigNumber(0));
+
+    const savingsTradeItemCompletedExists = savingsCryptoSum.isGreaterThan(0);
 
     let savingsFiatSum = new BigNumber(0);
     const fiatRates = fiat.coins.find(item => item.symbol === account.symbol);


### PR DESCRIPTION
**Bug**
On savings trade tab on overview sum of completed trade items are evaluated across all crypto accounts.

**Expectation**
Only savings trade items belonging to current crypto account should be evaluated.