### PR TITLE
fix(suite): regtest segwit addresses support

### DIFF
--- a/packages/suite/src/utils/wallet/validation.ts
+++ b/packages/suite/src/utils/wallet/validation.ts
@@ -1,14 +1,16 @@
 import addressValidator from 'trezor-address-validator';
 import { Account } from '@wallet-types';
 
-const isTestnet = (symbol: Account['symbol']): boolean => {
+const getNetworkType = (symbol: Account['symbol']) => {
+    if (symbol === 'regtest') return symbol;
     const testnets = ['test', 'txrp', 'trop', 'tada'];
-    return testnets.includes(symbol);
+    return testnets.includes(symbol) ? 'testnet' : 'prod';
 };
 
 const getCoinFromTestnet = (symbol: Account['symbol']) => {
     switch (symbol) {
         case 'test':
+        case 'regtest':
             return 'btc';
         case 'txrp':
             return 'xrp';
@@ -22,7 +24,7 @@ const getCoinFromTestnet = (symbol: Account['symbol']) => {
 };
 
 export const isAddressValid = (address: string, symbol: Account['symbol']) => {
-    const networkType = isTestnet(symbol) ? 'testnet' : 'prod';
+    const networkType = getNetworkType(symbol);
     const updatedSymbol = getCoinFromTestnet(symbol);
     return addressValidator.validate(address, updatedSymbol.toUpperCase(), networkType);
 };
@@ -40,7 +42,7 @@ export const isAddressDeprecated = (address: string, symbol: Account['symbol']) 
 };
 
 export const isTaprootAddress = (address: string, symbol: Account['symbol']) => {
-    const networkType = isTestnet(symbol) ? 'testnet' : 'prod';
+    const networkType = getNetworkType(symbol);
     const updatedSymbol = getCoinFromTestnet(symbol);
     return (
         addressValidator.getAddressType(address, updatedSymbol.toUpperCase(), networkType) ===

--- a/patches/trezor-address-validator+0.4.2.patch
+++ b/patches/trezor-address-validator+0.4.2.patch
@@ -1,0 +1,36 @@
+diff --git a/node_modules/trezor-address-validator/src/bitcoin_validator.js b/node_modules/trezor-address-validator/src/bitcoin_validator.js
+index 2479ab8..0413059 100644
+--- a/node_modules/trezor-address-validator/src/bitcoin_validator.js
++++ b/node_modules/trezor-address-validator/src/bitcoin_validator.js
+@@ -67,11 +67,11 @@ function getOutputIndex(address, currency, networkType) {
+     let correctAddressTypes;
+     const addressType = getAddressType(address, currency);
+     if (addressType) {
+-        if (networkType === 'prod' || networkType === 'testnet') {
+-            correctAddressTypes = currency.addressTypes[networkType]
+-        } else {
+-            correctAddressTypes = currency.addressTypes.prod.concat(currency.addressTypes.testnet);
+-        }
++        const correctAddressTypes =
++            currency.addressTypes[networkType] ||
++            Object.keys(currency.addressTypes).reduce((all, key) => {
++                return all.concat(currency.addressTypes[key]);
++            }, []);
+         return correctAddressTypes.indexOf(addressType);
+     }
+     return null;
+diff --git a/node_modules/trezor-address-validator/src/currencies.js b/node_modules/trezor-address-validator/src/currencies.js
+index 509ebbd..710dd48 100644
+--- a/node_modules/trezor-address-validator/src/currencies.js
++++ b/node_modules/trezor-address-validator/src/currencies.js
+@@ -30,8 +30,8 @@ var CURRENCIES = [
+     {
+         name: 'Bitcoin',
+         symbol: 'btc',
+-        segwitHrp: { prod: 'bc', testnet: 'tb' },
+-        addressTypes: { prod: ['00', '05'], testnet: ['6f', 'c4', '3c', '26'] },
++        segwitHrp: { prod: 'bc', testnet: 'tb', regtest: 'bcrt' },
++        addressTypes: { prod: ['00', '05'], testnet: ['6f', 'c4', '3c', '26'], regtest: ['6f', 'c4', '3c', '26'] },
+         validator: BTCValidator,
+     }, {
+         name: 'BitcoinCash',


### PR DESCRIPTION
Part of https://github.com/trezor/trezor-suite/issues/4977

This is probably blocking further e2e testing with regtest since segwit and taproot addresses was not validated properly

`trezor-address-validator` patch created, could be removed after [this PR](https://github.com/trezor/trezor-address-validator/pull/18) is merged and released to npm

@trezor/qa how to test it:
you can use `trezor-user-env` with regtest and try to send between all account types