### PR TITLE
chore(fw-update): revamp error message displayed to user

### DIFF
--- a/packages/suite/src/actions/firmware/firmwareActions.ts
+++ b/packages/suite/src/actions/firmware/firmwareActions.ts
@@ -187,7 +187,7 @@ export const validateFirmwareHash =
             if (!fwHash.success) {
                 dispatch({
                     type: FIRMWARE.SET_ERROR,
-                    payload: 'Unable to validate firmware hash. Please reinstall firmware again',
+                    payload: `${fwHash.payload.error}. Unable to validate firmware hash. If you want to check authenticity of newly installed firmware please proceed to device settings and reinstall firmware.`,
                 });
                 analytics.report({
                     type: EventType.FirmwareValidateHashError,


### PR DESCRIPTION
This error will appear in rare edgecase only. 95% cases will be "device disconnected during action" due to broken cable that needs to happen within split of second. But to make sure that users are not confused about what is going on I propose that we show the actual error, most likely "device disconnected during action", followed by an explanatory sentence.