### PR TITLE
fix(suite): error on favicon change on os theme change

### DIFF
--- a/packages/suite-web/src/static/index.html
+++ b/packages/suite-web/src/static/index.html
@@ -68,7 +68,7 @@
                 // not supported in IE
                 if (_mm.addEventListener) {
                     _mm.addEventListener('change', function (e) {
-                        return switchIcons(e);
+                        return si(e);
                     });
                 }
 


### PR DESCRIPTION
## Description
Fixes an issue that favicon icon was not changed if user/system changed os theme and web app was running.

## Related Issue
#4934

## Screenshots (if appropriate):
![Screenshot 2022-07-18 at 9 25 59](https://user-images.githubusercontent.com/33235762/179462824-0bfe3fe2-5a7c-4ea0-b663-2f882cfd9181.png)

## Aditional notes
I tried to add lint to `.html` files. However, it does not detect unused/not-existing functions. Moreover, it wants to use ES6 syntax, but we can't do that here.