### PR TITLE
fix(docs): remove links to readmes from summary

### DIFF
--- a/docs/SUMMARY.md
+++ b/docs/SUMMARY.md
@@ -1,13 +1,9 @@
 # Summary
 
--   [Introduction](index.md)
-    -   [Analytics](analytics/index.md)
+-   [Introduction](./index.md)
+    -   [Analytics](./analytics/index.md)
     -   [AWS](./analytics/aws.md)
     -   [Sentry](./analytics/sentry.md)
-    <!-- todo: looks like links outside docs folder don't work -->
-    -   [Generic analytics package](../packages/analytics/README.md)
-    -   [Suite analytics package](../packages/suite-analytics/README.md)
-    -   [Events changelog](../packages/suite-analytics/CHANGELOG.md)
 -   [Releases](./releases/index.md)
     -   [adding new firmwares](./releases/adding-new-firmwares.md)
     -   [desktop updates](./releases/desktop_updates.md)

--- a/docs/analytics/index.md
+++ b/docs/analytics/index.md
@@ -26,11 +26,11 @@ Data are logged in the form of HTTPS requests to an AWS S3 bucket. Those data lo
 
 ## Error tracking using Sentry
 
-To catch errors quickly and deliver you the best experience with your Trezor, we use [Sentry.io](https://sentry.io/), a tool for error tracking and performance monitoring. Data is only available to Sentry when usage data tracking is enabled. See our page about [Sentry](sentry.md) for more information on how it works.
+To catch errors quickly and deliver you the best experience with your Trezor, we use [Sentry.io](https://sentry.io/), a tool for error tracking and performance monitoring. Data is only available to Sentry when usage data tracking is enabled. See our page about [Sentry](./sentry.md) for more information on how it works.
 
 ## Retention period
 
-By principle, the logs collected are destroyed without delay once the purpose of use is met. However, the minimum retention period equals to 90 days when the data is processed to improve Trezor Suite. 90 days are related to the data concerning any errors occurring in Trezor Suite. Performance related data may be stored for longer periods of time. When the retention period ends, all event data and most metadata is eradicated from the storage and from the servers without additional archiving in order to prevent the threat of intrusion.
+By principle, the logs collected are destroyed without delay once the purpose of use is met. However, the minimum retention period equals to 90 days when the data is processed to improve Trezor Suite. The 90 days are related to the data concerning any errors occurring in Trezor Suite. Performance related data may be stored for longer periods of time. When the retention period ends, all event data and most metadata is eradicated from the storage and from the servers without additional archiving in order to prevent the threat of intrusion.
 
 ## Security of data
 


### PR DESCRIPTION
Looks like adding links to package readmes into `SUMMARY.md` caused other links under the same category (Analytics, AWS, Sentry) to disappear at docs.trezor.io. Also, when displaying contents of the READMEs at docs.trezor.io, links to relative URLs inside them are broken. Suggested solution:

- Remove links to READMEs from `SUMMARY.md` and keep them in other files (`./analytics/index.md` in this case)
- Links from docs to READMEs must be absolute so that they open the file on Github

Can you remove this page, @vdovhanych? https://docs.trezor.io/packages/