### PR TITLE
fix(component): use transient props on ActionItem

### DIFF
--- a/packages/components/src/components/Icon/index.tsx
+++ b/packages/components/src/components/Icon/index.tsx
@@ -35,19 +35,27 @@ const chooseIconAnimationType = (canAnimate?: boolean, isActive?: boolean) => {
     return null;
 };
 
-const SvgWrapper = styled.div<WrapperProps>`
+const SvgWrapper = styled.div<{
+    $canAnimate: WrapperProps['canAnimate'];
+    $color: WrapperProps['color'];
+    $isActive: WrapperProps['isActive'];
+    $isHollow: WrapperProps['isHollow'];
+    $hoverColor: WrapperProps['hoverColor'];
+    $size: WrapperProps['size'];
+    $useCursorPointer: WrapperProps['useCursorPointer'];
+}>`
     display: flex;
     align-items: center;
     justify-content: center;
-    height: ${props => props.size}px;
-    width: ${props => props.size}px;
-    animation: ${props => chooseIconAnimationType(props.canAnimate, props.isActive)} 0.2s linear 1
-        forwards;
+    height: ${({ $size }) => $size}px;
+    width: ${({ $size }) => $size}px;
+    animation: ${({ $canAnimate, $isActive }) => chooseIconAnimationType($canAnimate, $isActive)}
+        0.2s linear 1 forwards;
 
     div {
         display: flex;
-        height: ${props => props.size}px;
-        line-height: ${props => props.size}px;
+        height: ${({ $size }) => $size}px;
+        line-height: ${({ $size }) => $size}px;
         align-items: center;
         justify-content: center;
     }
@@ -59,18 +67,18 @@ const SvgWrapper = styled.div<WrapperProps>`
     }
 
     path {
-        stroke: ${({ color, isHollow }) => isHollow && color};
-        fill: ${({ color, isHollow }) => !isHollow && color};
+        stroke: ${({ $color, $isHollow }) => $isHollow && $color};
+        fill: ${({ $color, $isHollow }) => !$isHollow && $color};
     }
 
     :hover {
         path {
-            fill: ${props => props.hoverColor};
+            fill: ${({ $hoverColor }) => $hoverColor};
         }
     }
 
-    ${props =>
-        props.useCursorPointer &&
+    ${({ $useCursorPointer }) =>
+        $useCursorPointer &&
         css`
             cursor: pointer;
         `}
@@ -87,9 +95,10 @@ export interface IconProps extends React.SVGAttributes<HTMLDivElement> {
     canAnimate?: boolean;
     hoverColor?: string;
     useCursorPointer?: boolean;
+    'data-test'?: string;
 }
 
-const Icon = React.forwardRef(
+export const Icon = React.forwardRef(
     (
         {
             icon,
@@ -105,7 +114,7 @@ const Icon = React.forwardRef(
             onMouseEnter,
             onMouseLeave,
             onFocus,
-            ...rest
+            'data-test': dataTest,
         }: IconProps,
         ref?: React.Ref<HTMLDivElement>,
     ) => {
@@ -114,19 +123,19 @@ const Icon = React.forwardRef(
         return (
             <SvgWrapper
                 className={className}
-                canAnimate={canAnimate}
-                hoverColor={hoverColor}
+                $canAnimate={canAnimate}
+                $hoverColor={hoverColor}
                 onClick={onClick}
                 onMouseEnter={onMouseEnter}
                 onMouseLeave={onMouseLeave}
                 onFocus={onFocus}
-                isActive={isActive}
-                size={size}
-                isHollow={isHollow}
+                $isActive={isActive}
+                $size={size}
+                $isHollow={isHollow}
                 ref={ref}
-                useCursorPointer={onClick !== undefined || useCursorPointer}
-                color={defaultColor}
-                {...rest}
+                $useCursorPointer={onClick !== undefined || useCursorPointer}
+                $color={defaultColor}
+                data-test={dataTest}
             >
                 <ReactSVG
                     src={ICONS[icon]}
@@ -141,5 +150,3 @@ const Icon = React.forwardRef(
         );
     },
 );
-
-export { Icon };

--- a/packages/suite/src/components/suite/NavigationBar/components/NavigationActions/components/ActionItem.tsx
+++ b/packages/suite/src/components/suite/NavigationBar/components/NavigationActions/components/ActionItem.tsx
@@ -10,7 +10,10 @@ import {
 } from '@trezor/components';
 import { FADE_IN } from '@trezor/components/src/config/animations';
 
-const Wrapper = styled.div<Pick<ActionItemProps, 'isOpen' | 'marginLeft'>>`
+const Wrapper = styled.div<{
+    $isOpen: ActionItemProps['isOpen'];
+    $marginLeft: ActionItemProps['marginLeft'];
+}>`
     width: 44px;
     height: 44px;
     display: flex;
@@ -19,8 +22,8 @@ const Wrapper = styled.div<Pick<ActionItemProps, 'isOpen' | 'marginLeft'>>`
     align-items: center;
     justify-content: center;
     border-radius: 8px;
-    margin-left: ${({ marginLeft }) => marginLeft && '8px'};
-    background: ${({ isOpen, theme }) => isOpen && theme.BG_GREY_OPEN};
+    margin-left: ${({ $marginLeft }) => $marginLeft && '8px'};
+    background: ${({ $isOpen, theme }) => $isOpen && theme.BG_GREY_OPEN};
     transition: ${({ theme }) =>
         `background ${theme.HOVER_TRANSITION_TIME} ${theme.HOVER_TRANSITION_EFFECT}`};
 `;
@@ -36,7 +39,7 @@ const MobileWrapper = styled.div<Pick<ActionItemProps, 'isActive'>>`
     }
 `;
 
-const MobileIconWrapper = styled.div<Pick<ActionItemProps, 'isActive'>>`
+const MobileIconWrapper = styled.div`
     display: flex;
     position: relative;
     cursor: pointer;
@@ -109,6 +112,7 @@ interface CommonProps extends Pick<React.HTMLAttributes<HTMLDivElement>, 'onClic
     indicator?: IndicatorStatus;
     isMobileLayout?: boolean;
     marginLeft?: boolean;
+    'data-test'?: string;
 }
 
 interface CustomIconComponentProps extends CommonProps {
@@ -125,59 +129,79 @@ type ActionItemProps = CustomIconComponentProps | IconComponentProps;
 // Reason to use forwardRef: We want the user to be able to close Notifications dropdown by clicking somewhere else.
 // In order to achieve that behavior, we need to pass reference to ActionItem
 export const ActionItem = React.forwardRef(
-    (props: ActionItemProps, ref: React.Ref<HTMLDivElement>) => {
+    (
+        {
+            icon,
+            iconComponent,
+            indicator,
+            isActive,
+            isMobileLayout,
+            isOpen,
+            label,
+            marginLeft,
+            onClick,
+            'data-test': dataTest,
+        }: ActionItemProps,
+        ref: React.Ref<HTMLDivElement>,
+    ) => {
         const theme = useTheme();
 
-        const iconComponent = useMemo(
+        const IconComponent = useMemo(
             () =>
-                props.icon ? (
+                icon ? (
                     <Icon
-                        color={props.isActive ? theme.TYPE_DARK_GREY : theme.TYPE_LIGHT_GREY}
+                        color={isActive ? theme.TYPE_DARK_GREY : theme.TYPE_LIGHT_GREY}
                         size={24}
-                        icon={props.icon}
+                        icon={icon}
                     />
                 ) : (
-                    props.iconComponent
+                    iconComponent
                 ),
-            [props.icon, props.iconComponent, theme, props.isActive],
+            [icon, iconComponent, theme, isActive],
         );
 
         const Content = useMemo(
             () => (
                 <>
-                    {iconComponent}
-                    {props.indicator === 'alert' && (
+                    {IconComponent}
+                    {indicator === 'alert' && (
                         <AlertDotWrapper>
                             <AlertDot />
                         </AlertDotWrapper>
                     )}
-                    {props.indicator === 'loading' && (
+                    {indicator === 'loading' && (
                         <Indicator>
                             <FluidSpinner size={6} />
                         </Indicator>
                     )}
-                    {props.indicator === 'check' && (
+                    {indicator === 'check' && (
                         <Indicator>
                             <Icon icon="CHECK" size={10} color={theme.TYPE_GREEN} />
                         </Indicator>
                     )}
                 </>
             ),
-            [props.indicator, iconComponent, theme],
+            [indicator, IconComponent, theme],
         );
 
-        if (props.isMobileLayout) {
+        if (isMobileLayout) {
             return (
-                <MobileWrapper {...props}>
-                    <MobileIconWrapper isActive={props.isActive}>{Content}</MobileIconWrapper>
-                    <Label>{props.label}</Label>
+                <MobileWrapper data-test={dataTest} onClick={onClick}>
+                    <MobileIconWrapper>{Content}</MobileIconWrapper>
+                    <Label>{label}</Label>
                 </MobileWrapper>
             );
         }
 
         return (
-            <HoverAnimation isHoverable={!props.isOpen}>
-                <Wrapper isActive={props.isActive} isOpen={props.isOpen} ref={ref} {...props}>
+            <HoverAnimation isHoverable={!isOpen}>
+                <Wrapper
+                    ref={ref}
+                    data-test={dataTest}
+                    onClick={onClick}
+                    $isOpen={isOpen}
+                    $marginLeft={marginLeft}
+                >
                     {Content}
                 </Wrapper>
             </HoverAnimation>


### PR DESCRIPTION
Switch to [transient props](https://styled-components.com/docs/api#transient-props) on styled components and stop spreading props in `ActionItem` and `Icon` to prevent appending unintended attributes to the elements.

Before:
![Screenshot 2022-07-25 at 14 38 10](https://user-images.githubusercontent.com/42465546/180780920-38da22ef-4196-4244-a170-0f3b0dbb1d1c.png)
After:
![Screenshot 2022-07-25 at 14 39 36](https://user-images.githubusercontent.com/42465546/180780947-560c7b25-3c78-445d-a50e-a6bb92a5714e.png)

**QA:** No visible impact. Changes were made to clickable icons, e.g.:
![Screenshot 2022-07-25 at 14 55 10](https://user-images.githubusercontent.com/42465546/180782436-15483a3b-546e-4c56-a96f-1c223632b7e8.png)


