### PR TITLE
test(e2e): reoranize test groups

### DIFF
--- a/packages/integration-tests/projects/suite-web/tests/wallet/check-xpub-ada.test.ts
+++ b/packages/integration-tests/projects/suite-web/tests/wallet/check-xpub-ada.test.ts
@@ -1,4 +1,4 @@
-// @group:suite
+// @group:wallet
 // @retry=2
 
 describe('Check Cardano XPUB', () => {

--- a/packages/integration-tests/projects/suite-web/tests/wallet/check-xpub-btc.test.ts
+++ b/packages/integration-tests/projects/suite-web/tests/wallet/check-xpub-btc.test.ts
@@ -1,4 +1,4 @@
-// @group:suite
+// @group:wallet
 // @retry=2
 
 describe('Check Bitcoin XPUB', () => {

--- a/packages/integration-tests/projects/suite-web/tests/wallet/check-xpub-ltc.test.ts
+++ b/packages/integration-tests/projects/suite-web/tests/wallet/check-xpub-ltc.test.ts
@@ -1,4 +1,4 @@
-// @group:suite
+// @group:wallet
 // @retry=2
 
 describe('Check Litecoin XPUB', () => {

--- a/packages/integration-tests/projects/suite-web/tests/wallet/check-xpub-vtc.test.ts
+++ b/packages/integration-tests/projects/suite-web/tests/wallet/check-xpub-vtc.test.ts
@@ -1,4 +1,4 @@
-// @group:suite
+// @group:wallet
 // @retry=2
 
 describe('Check Vertcoin XPUB', () => {

--- a/packages/integration-tests/projects/suite-web/tests/wallet/custom-blockbook-discovery.test.ts
+++ b/packages/integration-tests/projects/suite-web/tests/wallet/custom-blockbook-discovery.test.ts
@@ -1,4 +1,4 @@
-// @group:suite
+// @group:wallet
 // @retry=2
 
 describe('Custom-blockbook-discovery', () => {

--- a/packages/integration-tests/projects/suite-web/tests/wallet/look-up-an-account.test.ts
+++ b/packages/integration-tests/projects/suite-web/tests/wallet/look-up-an-account.test.ts
@@ -1,4 +1,4 @@
-// @group:suite
+// @group:wallet
 // @retry=2
 
 describe('Look up a BTC account', () => {

--- a/packages/integration-tests/projects/suite-web/tests/wallet/overview-and-transactions.test.ts
+++ b/packages/integration-tests/projects/suite-web/tests/wallet/overview-and-transactions.test.ts
@@ -1,4 +1,4 @@
-// @group:suite
+// @group:wallet
 // @retry=2
 
 describe('Overview and transactions check', () => {


### PR DESCRIPTION
"suite" group was meant to be a dust bin for whatever did not fit elsewhere and it does not surprise anybody that it bloated over time. At the moment this group runs for about 9 minutes while wallet group runs for 3 minutes. It does not make sense to have wallet tests in suite group.