### PR TITLE
Analytics and desktop app improvements

### DIFF
--- a/docs/packages/suite-desktop.md
+++ b/docs/packages/suite-desktop.md
@@ -54,13 +54,13 @@ _TODO_
 
 ## Runtime flags
 
-Runtime flags can be used when running the Suite Desktop executable, enabling or disabling certain features. For example: `./Trezor-Suite-20.10.1.AppImage --disable-csp` will run with this flag turned on, which will result in the Content Security Policy being disabled.
+Runtime flags can be used when running the Suite Desktop executable, enabling or disabling certain features. For example: `./Trezor-Suite-22.7.2.AppImage --open-devtools` will run with this flag turned on, which will result in opening DevTools on app launch.
 
 Available flags:
 
 | name                  | description                                                                                                                                                                            |
 | --------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-
+| `--open-devtools`     | Open DevTools on app launch.                                                                                                                                                           |
 | `--pre-release`       | Tells the auto-updater to fetch pre-release updates.                                                                                                                                   |
 | `--bridge-dev`        | Instruct Bridge to support emulator (starts Bridge with `-e 21324`).                                                                                                                   |
 | `--log-level=NAME`    | Set the logging level. Available levels are [name (value)]: error (1), warn (2), info(3), debug (4). All logs with a value equal or lower to the selected log level will be displayed. |
@@ -97,7 +97,7 @@ The auto-updater has been mocked to simulate similar behavior to the actual libr
 
 #### Linux
 
-`./Trezor-Suite-20.10.1.AppImage --log-level=debug`
+`./Trezor-Suite-22.7.2.AppImage --log-level=debug`
 
 #### MacOS
 

--- a/docs/packages/suite-desktop.md
+++ b/docs/packages/suite-desktop.md
@@ -56,6 +56,7 @@ Available shortcuts:
 | --------------- | ---------------------------------------------------- |
 | Reload app      | F5, Ctrl+R, Cmd+R                                    |
 | Hard Reload app | Shift+F5, Shift+Ctrl+R, Shift+Cmd+R                  |
+| Restart app     | Alt+F5, Option+F5, Alt+Shift+R, Option+Shift+R       |
 | Open DevTools   | F12, Cmd+Shift+I,Ctrl+Shift+I, Cmd+Alt+I, Ctrl+Alt+I |
 
 ## Runtime flags

--- a/docs/packages/suite-desktop.md
+++ b/docs/packages/suite-desktop.md
@@ -54,7 +54,9 @@ Available shortcuts:
 
 | name                  | commands                                             |
 | --------------------- | ---------------------------------------------------- |
+| Reload app (renderer) | F5, Ctrl+R, Cmd+R                                    |
 | Open DevTools         | F12, Cmd+Shift+I,Ctrl+Shift+I, Cmd+Alt+I, Ctrl+Alt+I |
+
 ## Runtime flags
 
 Runtime flags can be used when running the Suite Desktop executable, enabling or disabling certain features. For example: `./Trezor-Suite-22.7.2.AppImage --open-devtools` will run with this flag turned on, which will result in opening DevTools on app launch.

--- a/docs/packages/suite-desktop.md
+++ b/docs/packages/suite-desktop.md
@@ -60,7 +60,7 @@ Available flags:
 
 | name                  | description                                                                                                                                                                            |
 | --------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `--disable-csp`       | Disables the Content Security Policy. Necessary for using DevTools in a production build.                                                                                              |
+
 | `--pre-release`       | Tells the auto-updater to fetch pre-release updates.                                                                                                                                   |
 | `--bridge-dev`        | Instruct Bridge to support emulator (starts Bridge with `-e 21324`).                                                                                                                   |
 | `--log-level=NAME`    | Set the logging level. Available levels are [name (value)]: error (1), warn (2), info(3), debug (4). All logs with a value equal or lower to the selected log level will be displayed. |

--- a/docs/packages/suite-desktop.md
+++ b/docs/packages/suite-desktop.md
@@ -50,8 +50,11 @@ More technical information can be found on the [Desktop Logger page](../misc/des
 
 ## Shortcuts
 
-_TODO_
+Available shortcuts:
 
+| name                  | commands                                             |
+| --------------------- | ---------------------------------------------------- |
+| Open DevTools         | F12, Cmd+Shift+I,Ctrl+Shift+I, Cmd+Alt+I, Ctrl+Alt+I |
 ## Runtime flags
 
 Runtime flags can be used when running the Suite Desktop executable, enabling or disabling certain features. For example: `./Trezor-Suite-22.7.2.AppImage --open-devtools` will run with this flag turned on, which will result in opening DevTools on app launch.

--- a/docs/packages/suite-desktop.md
+++ b/docs/packages/suite-desktop.md
@@ -52,10 +52,11 @@ More technical information can be found on the [Desktop Logger page](../misc/des
 
 Available shortcuts:
 
-| name                  | commands                                             |
-| --------------------- | ---------------------------------------------------- |
-| Reload app (renderer) | F5, Ctrl+R, Cmd+R                                    |
-| Open DevTools         | F12, Cmd+Shift+I,Ctrl+Shift+I, Cmd+Alt+I, Ctrl+Alt+I |
+| name            | commands                                             |
+| --------------- | ---------------------------------------------------- |
+| Reload app      | F5, Ctrl+R, Cmd+R                                    |
+| Hard Reload app | Shift+F5, Shift+Ctrl+R, Shift+Cmd+R                  |
+| Open DevTools   | F12, Cmd+Shift+I,Ctrl+Shift+I, Cmd+Alt+I, Ctrl+Alt+I |
 
 ## Runtime flags
 

--- a/packages/analytics/src/analytics.ts
+++ b/packages/analytics/src/analytics.ts
@@ -1,4 +1,5 @@
-import { encodeDataToQueryString, getRandomId, getUrl } from './utils';
+import { encodeDataToQueryString, getRandomId, getUrl, reportEvent } from './utils';
+
 import type { InitOptions, Event, App } from './types';
 
 export class Analytics<T extends Event> {
@@ -61,12 +62,16 @@ export class Analytics<T extends Event> {
             data,
         );
 
-        try {
-            fetch(`${this.url}?${qs}`, {
+        // try to report analytics event once again if the previous one fails
+        // easy solution which should solve missing events on the launch of the app
+        // if it does not help, then queue or more sophisticated solution should be implemented
+        reportEvent({
+            type: data.type,
+            url: `${this.url}?${qs}`,
+            options: {
                 method: 'GET',
-            });
-        } catch (err) {
-            console.error('Failed to log analytics', err);
-        }
+            },
+            retry: true,
+        });
     };
 }

--- a/packages/suite-desktop/src-electron/app.ts
+++ b/packages/suite-desktop/src-electron/app.ts
@@ -1,7 +1,7 @@
 import path from 'path';
 import fs from 'fs';
 
-import { app, BrowserWindow, RelaunchOptions, session } from 'electron';
+import { app, BrowserWindow, session } from 'electron';
 import { init as initSentry, ElectronOptions, IPCMode } from '@sentry/electron';
 import { ipcMain } from './typed-electron';
 
@@ -12,6 +12,7 @@ import { APP_NAME } from './libs/constants';
 import * as store from './libs/store';
 import { MIN_HEIGHT, MIN_WIDTH } from './libs/screen';
 import { getBuildInfo, getComputerInfo } from './libs/info';
+import { restartApp } from './libs/app-utils';
 import { initModules } from './modules';
 import { createInterceptor } from './libs/request-interceptor';
 import { hangDetect } from './hang-detect';
@@ -110,15 +111,7 @@ const init = async () => {
 
     ipcMain.on('app/restart', () => {
         logger.info('main', 'App restart requested');
-        const options: RelaunchOptions = {};
-        options.args = process.argv.slice(1).concat(['--relaunch']);
-        options.execPath = process.execPath;
-        if (process.env.APPIMAGE) {
-            options.execPath = process.env.APPIMAGE;
-            options.args.unshift('--appimage-extract-and-run');
-        }
-        app.relaunch(options);
-        app.quit();
+        restartApp();
     });
 
     await app.whenReady();
@@ -184,8 +177,7 @@ const init = async () => {
         await clearAppCache().catch(err =>
             logger.error('hang-detect', `Couldn't clear cache: ${err.message}`),
         );
-        app.relaunch();
-        app.quit();
+        restartApp();
     }
 };
 

--- a/packages/suite-desktop/src-electron/app.ts
+++ b/packages/suite-desktop/src-electron/app.ts
@@ -47,8 +47,6 @@ const createMainWindow = (winBounds: WinBounds) => {
         webPreferences: {
             webSecurity: !isDev,
             allowRunningInsecureContent: isDev,
-            nodeIntegration: false,
-            contextIsolation: true,
             preload: path.join(__dirname, 'preload.js'),
         },
         icon: path.join(global.resourcesPath, 'images', 'icons', '512x512.png'),

--- a/packages/suite-desktop/src-electron/libs/app-utils.ts
+++ b/packages/suite-desktop/src-electron/libs/app-utils.ts
@@ -1,0 +1,13 @@
+import { app, RelaunchOptions } from 'electron';
+
+export const restartApp = () => {
+    const options: RelaunchOptions = {};
+    options.args = process.argv.slice(1).concat(['--relaunch']);
+    options.execPath = process.execPath;
+    if (process.env.APPIMAGE) {
+        options.execPath = process.env.APPIMAGE;
+        options.args.unshift('--appimage-extract-and-run');
+    }
+    app.relaunch(options);
+    app.quit();
+};

--- a/packages/suite-desktop/src-electron/libs/app-utils.ts
+++ b/packages/suite-desktop/src-electron/libs/app-utils.ts
@@ -1,13 +1,10 @@
-import { app, RelaunchOptions } from 'electron';
+import { app } from 'electron';
 
 export const restartApp = () => {
-    const options: RelaunchOptions = {};
-    options.args = process.argv.slice(1).concat(['--relaunch']);
-    options.execPath = process.execPath;
-    if (process.env.APPIMAGE) {
-        options.execPath = process.env.APPIMAGE;
-        options.args.unshift('--appimage-extract-and-run');
-    }
-    app.relaunch(options);
+    const { logger } = global;
+
+    logger.info('app', `Relaunching app with ${process.argv.slice(1).join(', ')} arguments.`);
+
+    app.relaunch();
     app.quit();
 };

--- a/packages/suite-desktop/src-electron/libs/menu.ts
+++ b/packages/suite-desktop/src-electron/libs/menu.ts
@@ -1,6 +1,7 @@
 import { app, shell, Menu, MenuItemConstructorOptions } from 'electron';
 
 import { isDev } from '@suite-utils/build';
+import { restartApp } from './app-utils';
 
 const isMac = process.platform === 'darwin';
 
@@ -17,7 +18,10 @@ const mainMenuTemplate: MenuItem[] = [
     // { role: 'fileMenu' }
     {
         label: 'File',
-        submenu: [isMac ? { role: 'close' } : { role: 'quit' }],
+        submenu: [
+            { label: 'Restart', click: restartApp },
+            isMac ? { role: 'close' } : { role: 'quit' },
+        ],
     },
     // { role: 'editMenu' }
     {

--- a/packages/suite-desktop/src-electron/modules/crash-recover.ts
+++ b/packages/suite-desktop/src-electron/modules/crash-recover.ts
@@ -1,5 +1,6 @@
 import { app, dialog } from 'electron';
 import { Module } from './index';
+import { restartApp } from '../libs/app-utils';
 
 // Reasons for prompting a restart
 const unexpectedReasons = [
@@ -21,10 +22,10 @@ const init: Module = ({ mainWindow }) => {
 
             // Restart
             if (result === 1) {
-                app.relaunch();
+                restartApp();
+            } else {
+                app.quit();
             }
-
-            app.quit();
         }
     });
 };

--- a/packages/suite-desktop/src-electron/modules/csp.ts
+++ b/packages/suite-desktop/src-electron/modules/csp.ts
@@ -2,35 +2,23 @@
  * Adds a CSP (Content Security Policy) header to all requests
  */
 
-import { app, dialog, session } from 'electron';
+import { session } from 'electron';
 
 import * as config from '../config';
 import { Module } from './index';
 
-const disableCspFlag = app.commandLine.hasSwitch('disable-csp');
-
-const init: Module = ({ mainWindow }) => {
+const init: Module = () => {
     const { logger } = global;
 
-    if (disableCspFlag) {
-        logger.warn('csp', 'The application was launched with CSP disabled');
-        dialog.showMessageBox(mainWindow, {
-            type: 'warning',
-            message:
-                'The application is running with CSP disabled. This is a security risk! If this is not intentional, please close the application immediately.',
-            buttons: ['OK'],
+    session.defaultSession.webRequest.onHeadersReceived((details, callback) => {
+        logger.debug('csp', `Header applied to ${details.url}`);
+        callback({
+            responseHeaders: {
+                'Content-Security-Policy': [config.cspRules.join(';')],
+                ...details.responseHeaders,
+            },
         });
-    } else {
-        session.defaultSession.webRequest.onHeadersReceived((details, callback) => {
-            logger.debug('csp', `Header applied to ${details.url}`);
-            callback({
-                responseHeaders: {
-                    'Content-Security-Policy': [config.cspRules.join(';')],
-                    ...details.responseHeaders,
-                },
-            });
-        });
-    }
+    });
 };
 
 export default init;

--- a/packages/suite-desktop/src-electron/modules/dev-tools.ts
+++ b/packages/suite-desktop/src-electron/modules/dev-tools.ts
@@ -1,12 +1,18 @@
 /**
- * Enable development tools
+ * Enable DevTools
  */
-import { Module } from './index';
+import { app } from 'electron';
+
+import { isDev } from '@suite-utils/build';
+
+import type { Module } from './index';
+
+const openDevToolsFlag = app.commandLine.hasSwitch('open-devtools');
 
 const init: Module = ({ mainWindow }) => {
-    mainWindow.webContents.once('dom-ready', () => {
+    if (isDev || openDevToolsFlag) {
         mainWindow.webContents.openDevTools();
-    });
+    }
 };
 
 export default init;

--- a/packages/suite-desktop/src-electron/modules/index.ts
+++ b/packages/suite-desktop/src-electron/modules/index.ts
@@ -30,8 +30,9 @@ const MODULES = [
     'udev-install',
     'user-data',
     'trezor-connect-ipc',
+    'dev-tools',
     // Modules used only in dev/prod mode
-    ...(isDev ? ['dev-tools'] : ['csp', 'file-protocol']),
+    ...(isDev ? [] : ['csp', 'file-protocol']),
 ];
 
 export type Dependencies = {

--- a/packages/suite-desktop/src-electron/modules/shortcuts.ts
+++ b/packages/suite-desktop/src-electron/modules/shortcuts.ts
@@ -18,14 +18,12 @@ const init: Module = ({ mainWindow }) => {
         });
     });
 
-    electronLocalshortcut.register(mainWindow, 'F5', () => {
-        logger.info('shortcuts', 'F5 pressed');
-        mainWindow.loadURL(APP_SRC);
-    });
-
-    electronLocalshortcut.register(mainWindow, 'CommandOrControl+R', () => {
-        logger.info('shortcuts', 'CTRL+R pressed');
-        mainWindow.loadURL(APP_SRC);
+    const reloadAppShortcuts = ['F5', 'CommandOrControl+R'];
+    reloadAppShortcuts.forEach(shortcut => {
+        electronLocalshortcut.register(mainWindow, shortcut, () => {
+            logger.info('shortcuts', `${shortcut} pressed to reload app`);
+            mainWindow.webContents.reload();
+        });
     });
 };
 

--- a/packages/suite-desktop/src-electron/modules/shortcuts.ts
+++ b/packages/suite-desktop/src-electron/modules/shortcuts.ts
@@ -1,5 +1,7 @@
 import electronLocalshortcut from 'electron-localshortcut';
 
+import { restartApp } from '@desktop-electron/libs/app-utils';
+
 import type { Module } from './index';
 
 const init: Module = ({ mainWindow }) => {
@@ -31,6 +33,14 @@ const init: Module = ({ mainWindow }) => {
         electronLocalshortcut.register(mainWindow, shortcut, () => {
             logger.info('shortcuts', `${shortcut} pressed to hard reload app`);
             mainWindow.webContents.reloadIgnoringCache();
+        });
+    });
+
+    const restartAppShortcuts = ['Option+F5', 'Alt+F5', 'Option+Shift+R', 'Alt+Shift+R'];
+    restartAppShortcuts.forEach(shortcut => {
+        electronLocalshortcut.register(mainWindow, shortcut, () => {
+            logger.info('shortcuts', `${shortcut} pressed to restart app`);
+            restartApp();
         });
     });
 };

--- a/packages/suite-desktop/src-electron/modules/shortcuts.ts
+++ b/packages/suite-desktop/src-electron/modules/shortcuts.ts
@@ -5,12 +5,16 @@ import type { Module } from './index';
 const init: Module = ({ mainWindow }) => {
     const { logger } = global;
 
-    // Register more shortcuts for opening dev tools
-    const openDevToolsShortcuts = ['CommandOrControl+Shift+I', 'CommandOrControl+Alt+I'];
+    const openDevToolsShortcuts = ['F12', 'CommandOrControl+Shift+I', 'CommandOrControl+Alt+I'];
     openDevToolsShortcuts.forEach(shortcut => {
         electronLocalshortcut.register(mainWindow, shortcut, () => {
-            logger.info('shortcuts', `${shortcut} pressed`);
-            mainWindow.webContents.openDevTools();
+            logger.info('shortcuts', `${shortcut} pressed to open/close DevTools`);
+
+            if (mainWindow.webContents.isDevToolsOpened()) {
+                mainWindow.webContents.closeDevTools();
+            } else {
+                mainWindow.webContents.openDevTools();
+            }
         });
     });
 

--- a/packages/suite-desktop/src-electron/modules/shortcuts.ts
+++ b/packages/suite-desktop/src-electron/modules/shortcuts.ts
@@ -1,5 +1,5 @@
 import electronLocalshortcut from 'electron-localshortcut';
-import { APP_SRC } from '../libs/constants';
+
 import type { Module } from './index';
 
 const init: Module = ({ mainWindow }) => {
@@ -23,6 +23,14 @@ const init: Module = ({ mainWindow }) => {
         electronLocalshortcut.register(mainWindow, shortcut, () => {
             logger.info('shortcuts', `${shortcut} pressed to reload app`);
             mainWindow.webContents.reload();
+        });
+    });
+
+    const hardReloadAppShortcuts = ['Shift+F5', 'CommandOrControl+Shift+R'];
+    hardReloadAppShortcuts.forEach(shortcut => {
+        electronLocalshortcut.register(mainWindow, shortcut, () => {
+            logger.info('shortcuts', `${shortcut} pressed to hard reload app`);
+            mainWindow.webContents.reloadIgnoringCache();
         });
     });
 };

--- a/packages/suite/src/middlewares/suite/analyticsMiddleware.ts
+++ b/packages/suite/src/middlewares/suite/analyticsMiddleware.ts
@@ -35,7 +35,7 @@ const analyticsMiddleware =
         const state = api.getState();
 
         switch (action.type) {
-            case ANALYTICS.INIT:
+            case SUITE.READY:
                 // reporting can start when analytics is properly initialized and enabled
                 analytics.report({
                     type: EventType.SuiteReady,

--- a/packages/suite/src/middlewares/suite/analyticsMiddleware.ts
+++ b/packages/suite/src/middlewares/suite/analyticsMiddleware.ts
@@ -114,14 +114,19 @@ const analyticsMiddleware =
                 break;
             }
             case ROUTER.LOCATION_CHANGE:
-                analytics.report({
-                    type: EventType.RouterLocationChange,
-                    payload: {
-                        prevRouterUrl,
-                        nextRouterUrl: action.payload.url,
-                        anchor: redactTransactionIdFromAnchor(action.payload.anchor),
-                    },
-                });
+                if (
+                    state.suite.lifecycle.status !== 'initial' &&
+                    state.suite.lifecycle.status !== 'loading'
+                ) {
+                    analytics.report({
+                        type: EventType.RouterLocationChange,
+                        payload: {
+                            prevRouterUrl,
+                            nextRouterUrl: action.payload.url,
+                            anchor: redactTransactionIdFromAnchor(action.payload.anchor),
+                        },
+                    });
+                }
                 break;
             case ROUTER.ANCHOR_CHANGE:
                 if (action.payload) {


### PR DESCRIPTION
closes #5848

This PR contains code to make it easier to debug missing `suite-ready` analytics events (There are some minor desktop app improvements though) and a fix to report analytics event again if the previous report fails

- removed `disable-csp` flag which was there to be able to open devTools on production
- removed some params from creating `BrowserWindow` as they were same as default settings
- add `--open-devtools` flag to be able to open production app with DevTools open (required to see all networks events after launch of the app), open devtool when electron app starts, do not wait for `dom-ready` event, which resulted into missing first network records
- added `F12` shortcut to open devtools (to be consistent with browsers), close devtools by pressing dev tools shortcut when devtools is open
- refactored reloading app shortcut logic and added to documentation
- added hard reloading app shortcut logic to be able to reload app ignoring cache
- postponed `suite-ready` event a little bit which is now fired on `SUITE.READY` instead of `ANALYTICS.INIT`
- skipped `router-location-change` init event which does not need to be reported 
- unify restart app logic to be able to do ⬇️ 
- add shortcut to restart app without resetting app to make debugging easier
- removed Linux restart app fix which stopped working in Electron v18 and it should also that fix command line arguments were not propagated to restarted app
- and finally, try to send analytics events once again if the reporting fails