### PR TITLE
feat(docs): enhance Summary and Introduction page

### DIFF
--- a/docs/SUMMARY.md
+++ b/docs/SUMMARY.md
@@ -1,7 +1,8 @@
 # Summary
 
--   [Introduction](./index.md)
-    -   [Analytics](./analytics/index.md)
+[Introduction](./index.md)
+
+-   [Analytics](./analytics/index.md)
     -   [AWS](./analytics/aws.md)
     -   [Sentry](./analytics/sentry.md)
 -   [Releases](./releases/index.md)

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,7 +1,3 @@
 # Trezor Suite documentation
 
-_This documentation can also be found at [docs.trezor.io/trezor-suite](https://docs.trezor.io/trezor-suite) where it is available in a HTML-built version compiled using [mdBook](https://github.com/rust-lang/mdBook)._
-
-## Repository Structure
-
-TODO
+This documentation provides technical information for Suite developers, third-party wallet developers integrating Trezor, and users interested in implementation details. It is available at [docs.trezor.io/trezor-suite](https://docs.trezor.io/trezor-suite) in an HTML version compiled using [mdBook](https://github.com/rust-lang/mdBook). More guidance on Suite development can be found in package READMEs of the [trezor-suite](https://github.com/trezor/trezor-suite/tree/develop/packages) monorepo.

--- a/docs/misc/index.md
+++ b/docs/misc/index.md
@@ -8,6 +8,5 @@ At any time, information stored here might be restructured or moved to a differe
 location, so as to ensure that the documentation is well structured overall.
 
 -   [build](./build.md)
--   [notes](./notes.md)
 -   [review](./review.md)
 -   [videos](./videos.md)


### PR DESCRIPTION
Cleanup at https://docs.trezor.io/trezor-suite/
- change the [Introduction](https://docs.trezor.io/trezor-suite/index.html) text
- in the navigation, make [Introduction](https://docs.trezor.io/trezor-suite/index.html) un-numbered and move [Analytics ](https://docs.trezor.io/trezor-suite/analytics/index.html) one level higher (without affecting the URL)
- remove the link to a non-existent page from [Miscellaneous](https://docs.trezor.io/trezor-suite/misc/index.html).