### PR TITLE
feat(analytics): 'no-provider' if labeling enabled but provider not set

### DIFF
--- a/packages/suite-analytics/CHANGELOG.md
+++ b/packages/suite-analytics/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 This changelog lists changes in suite events.
 
+### 1.22
+
+Added:
+
+-   suite-ready
+    -   labeling: 'missing-provider' (in case labeling is enabled, but no provider set)
+
 ### 1.21
 
 Added:

--- a/packages/suite-analytics/package.json
+++ b/packages/suite-analytics/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@trezor/suite-analytics",
-    "version": "0.1.21",
+    "version": "0.1.22",
     "private": true,
     "license": "See LICENSE.md in repo root",
     "sideEffects": false,

--- a/packages/suite-analytics/src/types/events.ts
+++ b/packages/suite-analytics/src/types/events.ts
@@ -279,7 +279,7 @@ export type SuiteAnalyticsEvent =
     | {
           type: EventType.SettingsGeneralLabelingProvider;
           payload: {
-              provider: 'dropbox' | 'google' | 'fileSystem' | 'sdCard' | '';
+              provider: 'dropbox' | 'google' | 'fileSystem' | 'sdCard' | 'missing-provider' | '';
           };
       }
     | {

--- a/packages/suite/src/utils/suite/analytics.ts
+++ b/packages/suite/src/utils/suite/analytics.ts
@@ -44,7 +44,7 @@ export const getSuiteReadyPayload = (state: AppState) => ({
     screenHeight: getScreenHeight(),
     platformLanguages: getPlatformLanguages().join(','),
     tor: getIsTorEnabled(state.suite.torStatus),
-    labeling: state.metadata.enabled ? state.metadata.provider?.type || '' : '',
+    labeling: state.metadata.enabled ? state.metadata.provider?.type || 'missing-provider' : '',
     rememberedStandardWallets: state.devices.filter(d => d.remember && d.useEmptyPassphrase).length,
     rememberedHiddenWallets: state.devices.filter(d => d.remember && !d.useEmptyPassphrase).length,
     theme: state.suite.settings.theme.variant,


### PR DESCRIPTION
Based on https://github.com/trezor/trezor-suite/pull/5714#discussion_r930058409