### PR TITLE
Feat: create Coinjoin account in suite (regtest only)

### DIFF
--- a/packages/suite-analytics/src/types/events.ts
+++ b/packages/suite-analytics/src/types/events.ts
@@ -300,7 +300,7 @@ export type SuiteAnalyticsEvent =
           type: EventType.SettingsCoinsBackend;
           payload: {
               symbol: string;
-              type: 'blockbook' | 'electrum' | 'ripple' | 'blockfrost' | 'default';
+              type: 'blockbook' | 'electrum' | 'ripple' | 'blockfrost' | 'coinjoin' | 'default';
               totalRegular: number;
               totalOnion: number;
           };

--- a/packages/suite/src/actions/wallet/__fixtures__/coinjoinAccountActions.ts
+++ b/packages/suite/src/actions/wallet/__fixtures__/coinjoinAccountActions.ts
@@ -1,0 +1,70 @@
+export const createCoinjoinAccount = [
+    {
+        description: 'invalid accountType',
+        params: {
+            accountType: 'segwit',
+        },
+        result: {
+            actions: 0,
+        },
+    },
+    {
+        description: 'experimental features not enabled',
+        connect: {
+            success: false,
+        },
+        params: {
+            accountType: 'coinjoin',
+        },
+        result: {
+            actions: 1, // notification
+        },
+    },
+    {
+        description: 'public key not given',
+        connect: [
+            {
+                success: true, // applySettings
+            },
+            {
+                success: false, // getPublicKey
+            },
+        ],
+        params: {
+            accountType: 'coinjoin',
+        },
+        result: {
+            actions: 1, // notification
+        },
+    },
+    {
+        description: 'success',
+        connect: [
+            {
+                success: true, // applySettings
+            },
+            {
+                success: true, // getPublicKey
+                payload: {
+                    xpub: 'legacy-xpub',
+                    xpubSegwit: 'xpub',
+                },
+            },
+            {
+                success: true, // getAccountInfo
+                payload: {
+                    xpub: 'legacy-xpub',
+                    xpubSegwit: 'xpub',
+                },
+            },
+        ],
+        params: {
+            symbol: 'btc',
+            networkType: 'bitcoin',
+            accountType: 'coinjoin',
+        },
+        result: {
+            actions: 3, // @account/create + @coinjoin/account-create + @account/account-update actions
+        },
+    },
+];

--- a/packages/suite/src/actions/wallet/__tests__/coinjoinAccountActions.test.ts
+++ b/packages/suite/src/actions/wallet/__tests__/coinjoinAccountActions.test.ts
@@ -1,0 +1,41 @@
+import configureStore from 'redux-mock-store';
+import thunk from 'redux-thunk';
+import * as coinjoinAccountActions from '../coinjoinAccountActions';
+import * as fixtures from '../__fixtures__/coinjoinAccountActions';
+
+jest.mock('@trezor/connect', () => global.JestMocks.getTrezorConnect({}));
+// eslint-disable-next-line @typescript-eslint/no-var-requires
+const TrezorConnect = require('@trezor/connect').default;
+
+export const getInitialState = () => ({
+    suite: {
+        locks: [],
+        device: global.JestMocks.getSuiteDevice({ state: 'device-state', connected: true }),
+    },
+    modal: {},
+});
+
+type State = ReturnType<typeof getInitialState>;
+const mockStore = configureStore<State, any>([thunk]);
+
+const initStore = (state: State) => {
+    const store = mockStore(state);
+    store.subscribe(() => {
+        const action = store.getActions().pop();
+        store.getActions().push(action);
+    });
+    return store;
+};
+
+describe('coinjoinAccountActions', () => {
+    fixtures.createCoinjoinAccount.forEach(f => {
+        it(`createCoinjoinAccount: ${f.description}`, async () => {
+            const initialState = getInitialState();
+            const store = initStore(initialState);
+            TrezorConnect.setTestFixtures(f.connect);
+
+            await store.dispatch(coinjoinAccountActions.createCoinjoinAccount(f.params as any)); // params are incomplete
+            expect(store.getActions().length).toBe(f.result.actions);
+        });
+    });
+});

--- a/packages/suite/src/actions/wallet/accountActions.ts
+++ b/packages/suite/src/actions/wallet/accountActions.ts
@@ -35,7 +35,7 @@ export const create = (
     deviceState: string,
     discoveryItem: DiscoveryItem,
     accountInfo: AccountInfo,
-): AccountAction => ({
+) => ({
     type: ACCOUNT.CREATE,
     payload: {
         deviceState,
@@ -46,8 +46,11 @@ export const create = (
         accountType: discoveryItem.accountType,
         symbol: discoveryItem.coin,
         empty: accountInfo.empty,
+        backendType: discoveryItem.backendType,
+        lastKnownState: discoveryItem.lastKnownState,
         visible:
             !accountInfo.empty ||
+            discoveryItem.accountType === 'coinjoin' ||
             (discoveryItem.accountType === 'normal' && discoveryItem.index === 0),
         balance: accountInfo.balance,
         availableBalance: accountInfo.availableBalance,
@@ -77,7 +80,7 @@ export const create = (
     },
 });
 
-export const update = (account: Account, accountInfo: AccountInfo): AccountAction => ({
+export const update = (account: Account, accountInfo: AccountInfo) => ({
     type: ACCOUNT.UPDATE,
     payload: {
         ...account,
@@ -97,7 +100,7 @@ export const update = (account: Account, accountInfo: AccountInfo): AccountActio
     },
 });
 
-export const updateAccount = (payload: Account): AccountAction => ({
+export const updateAccount = (payload: Account) => ({
     type: ACCOUNT.UPDATE,
     payload,
 });

--- a/packages/suite/src/actions/wallet/accountActions.ts
+++ b/packages/suite/src/actions/wallet/accountActions.ts
@@ -4,6 +4,7 @@ import { DiscoveryItem } from '@wallet-actions/discoveryActions';
 import * as notificationActions from '@suite-actions/notificationActions';
 import * as transactionActions from '@wallet-actions/transactionActions';
 import * as tokenActions from '@wallet-actions/tokenActions';
+import { isTrezorConnectBackendType } from '@suite-utils/backend';
 import {
     analyzeTransactions,
     getAccountTransactions,
@@ -132,6 +133,7 @@ export const changeAccountVisibility = (payload: Account, visible = true): Accou
 // as we usually want to update all accounts for a single coin at once
 export const fetchAndUpdateAccount =
     (account: Account) => async (dispatch: Dispatch, getState: GetState) => {
+        if (!isTrezorConnectBackendType(account.backendType)) return; // skip unsupported backend type
         // first basic check, traffic optimization
         // basic check returns only small amount of data without full transaction history
         const basic = await TrezorConnect.getAccountInfo({

--- a/packages/suite/src/actions/wallet/blockchainActions.ts
+++ b/packages/suite/src/actions/wallet/blockchainActions.ts
@@ -20,7 +20,11 @@ import * as notificationActions from '@suite-actions/notificationActions';
 import { State as FeeState } from '@wallet-reducers/feesReducer';
 import { NETWORKS } from '@wallet-config';
 import { BLOCKCHAIN } from './constants';
-import { getCustomBackends, getBackendFromSettings } from '@suite-utils/backend';
+import {
+    isTrezorConnectBackendType,
+    getCustomBackends,
+    getBackendFromSettings,
+} from '@suite-utils/backend';
 import type { Dispatch, GetState } from '@suite-types';
 import type { Account, Network, CustomBackend, BackendType } from '@wallet-types';
 import type { Timeout } from '@trezor/type-utils';
@@ -269,7 +273,10 @@ export const subscribe =
 
         // do NOT subscribe if there are no accounts
         // it leads to websocket disconnection
-        const accountsToSubscribe = findAccountsByNetwork(symbol, getState().wallet.accounts);
+        const accountsToSubscribe = findAccountsByNetwork(
+            symbol,
+            getState().wallet.accounts,
+        ).filter(a => isTrezorConnectBackendType(a.backendType)); // do not subscribe accounts with unsupported backend type
         if (!accountsToSubscribe.length) return;
         return TrezorConnect.blockchainSubscribe({
             accounts: accountsToSubscribe,
@@ -284,7 +291,9 @@ export const unsubscribe = (removedAccounts: Account[]) => (_: Dispatch, getStat
 
     const { accounts } = getState().wallet;
     const promises = symbols.map(symbol => {
-        const accountsToSubscribe = findAccountsByNetwork(symbol, accounts);
+        const accountsToSubscribe = findAccountsByNetwork(symbol, accounts).filter(a =>
+            isTrezorConnectBackendType(a.backendType),
+        ); // do not unsubscribe accounts with unsupported backend type
         if (accountsToSubscribe.length) {
             // there are some accounts left, update subscription
             return TrezorConnect.blockchainSubscribe({

--- a/packages/suite/src/actions/wallet/coinjoinAccountActions.ts
+++ b/packages/suite/src/actions/wallet/coinjoinAccountActions.ts
@@ -1,0 +1,167 @@
+import TrezorConnect from '@trezor/connect';
+import * as COINJOIN from './constants/coinjoinConstants';
+import { goto } from '../suite/routerActions';
+import { addToast } from '../suite/notificationActions';
+import { add as addTransaction } from './transactionActions';
+import {
+    create as createAccount,
+    update as updateAccountInfo,
+    updateAccount,
+} from './accountActions';
+import { CoinjoinBackendService } from '@suite/services/coinjoin/coinjoinBackend';
+import type { Dispatch, GetState } from '@suite-types';
+import type { Account, Network } from '@wallet-types';
+
+export type CoinjoinAccountAction = {
+    type: typeof COINJOIN.ACCOUNT_CREATE;
+    payload: Account;
+};
+
+export const fetchAndUpdateAccount =
+    (account: Account) => async (dispatch: Dispatch, getState: GetState) => {
+        if (account.backendType !== 'coinjoin') return;
+
+        const lastKnownState = {
+            time: Date.now(),
+            blockHash: account.lastKnownState?.blockHash || '',
+            progress: 0,
+        };
+
+        try {
+            const api = CoinjoinBackendService.getInstance(account.symbol);
+            const accountInfo = await api.getAccountInfo({
+                descriptor: account.descriptor,
+                lastKnownState: {
+                    balance: account.balance,
+                    blockHash: lastKnownState.blockHash,
+                },
+                onProgress: (progressState: any) => {
+                    dispatch(
+                        updateAccount({
+                            ...account,
+                            lastKnownState: {
+                                ...progressState,
+                                time: Date.now(),
+                            },
+                        }),
+                    );
+                },
+                symbol: account.symbol,
+            });
+
+            if (accountInfo) {
+                // get fresh info from reducer
+                const updatedAccount = getState().wallet.accounts.find(a => a.key === account.key);
+                if (updatedAccount && updatedAccount.lastKnownState) {
+                    // finalize
+                    dispatch(
+                        updateAccountInfo(
+                            {
+                                ...updatedAccount,
+                                lastKnownState: {
+                                    time: Date.now(),
+                                    blockHash: updatedAccount.lastKnownState.blockHash,
+                                },
+                            },
+                            accountInfo,
+                        ),
+                    );
+                    // add account transactions
+                    if (accountInfo.history.transactions) {
+                        dispatch(addTransaction(accountInfo.history.transactions, account));
+                    }
+                }
+            } else {
+                // TODO: no accountInfo
+            }
+        } catch (error) {
+            // TODO
+            console.warn('fetchAndUpdateAccount', error);
+        }
+    };
+
+export const createCoinjoinAccount =
+    (network: Network) => async (dispatch: Dispatch, getState: GetState) => {
+        if (network.accountType !== 'coinjoin') return;
+        const { device } = getState().suite;
+
+        // TODO: Disable safety_checks until Trezor FW will implement slip-0025
+        // const safety =
+        //     device?.features?.safety_checks !== 'PromptTemporarily'
+        //         ? 'PromptTemporarily'
+        //         : undefined;
+        const experimentalFeatures = await TrezorConnect.applySettings({
+            device,
+            experimental_features: true,
+            // safety_checks: safety,
+        });
+        if (!experimentalFeatures.success) {
+            dispatch(addToast({ type: 'error', error: 'Experimental features not enabled' }));
+            return;
+        }
+
+        // temporary hardcoded until Trezor FW will implement slip-0025
+        const PATH = `m/86'/1'/25'`; // `m/10025'/1'/0'`  network.bip43Path
+
+        // get coinjoin account xpub
+        const publicKey = await TrezorConnect.getPublicKey({
+            device,
+            useEmptyPassphrase: device?.useEmptyPassphrase,
+            path: PATH,
+            coin: network.symbol,
+        });
+        if (!publicKey.success) {
+            dispatch(addToast({ type: 'error', error: 'Public key not given' }));
+            return;
+        }
+
+        // create empty account
+        const account = dispatch(
+            createAccount(
+                device!.state!,
+                {
+                    index: 0,
+                    path: PATH,
+                    accountType: network.accountType,
+                    networkType: network.networkType,
+                    backendType: 'coinjoin',
+                    coin: network.symbol,
+                    derivationType: 0,
+                    lastKnownState: {
+                        time: 0,
+                        blockHash: '',
+                        progress: 0,
+                    },
+                },
+                {
+                    addresses: { change: [], used: [], unused: [] },
+                    availableBalance: '0',
+                    balance: '0',
+                    descriptor: publicKey.payload.xpubSegwit || publicKey.payload.xpub,
+                    empty: true,
+                    history: { total: 0, unconfirmed: 0 },
+                    legacyXpub: publicKey.payload.xpub,
+                    page: { index: 1, size: 25, total: 1 },
+                    utxo: [],
+                },
+            ),
+        );
+        dispatch({
+            type: COINJOIN.ACCOUNT_CREATE,
+            payload: account.payload,
+        });
+
+        // switch to account
+        dispatch(
+            goto('wallet-index', {
+                params: {
+                    symbol: network.symbol,
+                    accountType: network.accountType,
+                    accountIndex: 0,
+                },
+            }),
+        );
+
+        // start discovery
+        dispatch(fetchAndUpdateAccount(account.payload));
+    };

--- a/packages/suite/src/actions/wallet/constants/coinjoinConstants.ts
+++ b/packages/suite/src/actions/wallet/constants/coinjoinConstants.ts
@@ -1,0 +1,1 @@
+export const ACCOUNT_CREATE = '@coinjoin/account-create';

--- a/packages/suite/src/actions/wallet/discoveryActions.ts
+++ b/packages/suite/src/actions/wallet/discoveryActions.ts
@@ -11,6 +11,7 @@ import { NETWORKS } from '@wallet-config';
 import { Dispatch, GetState, TrezorDevice } from '@suite-types';
 import { Account } from '@wallet-types';
 import { getDerivationType } from '@suite-common/wallet-utils';
+import { isTrezorConnectBackendType } from '@suite-utils/backend';
 
 export type DiscoveryAction =
     | { type: typeof DISCOVERY.CREATE; payload: Discovery }
@@ -183,6 +184,7 @@ const filterUnavailableNetworks = (enabledNetworks: Account['symbol'][], device?
                 )); // device version is newer or equal to support field in networks => supported
 
         return (
+            isTrezorConnectBackendType(n.backendType) && // exclude accounts with unsupported backend type
             enabledNetworks.includes(n.symbol) &&
             !n.isHidden &&
             !device?.unavailableCapabilities?.[n.accountType!] && // exclude by account types (ex: taproot)

--- a/packages/suite/src/actions/wallet/discoveryActions.ts
+++ b/packages/suite/src/actions/wallet/discoveryActions.ts
@@ -38,7 +38,9 @@ export interface DiscoveryItem {
     index: number;
     accountType: Account['accountType'];
     networkType: Account['networkType'];
+    backendType?: Account['backendType'];
     derivationType?: 0 | 1 | 2;
+    lastKnownState?: Account['lastKnownState'];
 }
 
 type ProgressEvent = BundleProgress<AccountInfo | null>['payload'];

--- a/packages/suite/src/actions/wallet/graphActions.ts
+++ b/packages/suite/src/actions/wallet/graphActions.ts
@@ -18,6 +18,7 @@ import {
     deviceGraphDataFilterFn,
     enhanceBlockchainAccountHistory,
 } from '@wallet-utils/graphUtils';
+import { isTrezorConnectBackendType } from '@suite-utils/backend';
 
 export type GraphAction =
     | {
@@ -136,15 +137,16 @@ export const updateGraphData =
         const { graph } = getState().wallet;
 
         // TODO: default behaviour should be fetch only new data (since last timestamp)
-        let filteredAccounts: Account[] = accounts;
+        // exclude accounts with unsupported backend type
+        let filteredAccounts = accounts.filter(a => isTrezorConnectBackendType(a.backendType));
         if (options?.newAccountsOnly) {
             // add only accounts for which we don't have any data for given interval
-            filteredAccounts = accounts.filter(
+            filteredAccounts = filteredAccounts.filter(
                 account => !graph.data.find(d => accountGraphDataFilterFn(d, account)),
             );
-            if (filteredAccounts.length === 0) {
-                return;
-            }
+        }
+        if (filteredAccounts.length === 0) {
+            return;
         }
 
         dispatch({

--- a/packages/suite/src/actions/wallet/selectedAccountActions.ts
+++ b/packages/suite/src/actions/wallet/selectedAccountActions.ts
@@ -147,6 +147,13 @@ const getAccountState = () => (dispatch: Dispatch, getState: GetState) => {
 
     // account does exist
     if (account && account.visible) {
+        if (typeof account?.lastKnownState?.progress === 'number') {
+            return {
+                status: 'loading',
+                loader: 'account-loading',
+                account,
+            };
+        }
         // Success!
         const loadedState = {
             status: 'loaded',
@@ -235,6 +242,7 @@ export const getStateForAction = (action: Action) => (dispatch: Dispatch, getSta
             'addresses',
             'visible',
             'utxo',
+            'lastKnownState',
         ],
         discovery: [
             'status',

--- a/packages/suite/src/actions/wallet/transactionActions.ts
+++ b/packages/suite/src/actions/wallet/transactionActions.ts
@@ -1,5 +1,6 @@
 import TrezorConnect, { AccountTransaction } from '@trezor/connect';
 import { saveAs } from 'file-saver';
+import { isTrezorConnectBackendType } from '@suite-utils/backend';
 import {
     formatNetworkAmount,
     enhanceTransaction,
@@ -131,6 +132,7 @@ export const replaceTransaction =
 export const fetchTransactions =
     (account: Account, page: number, perPage: number, noLoading = false, recursive = false) =>
     async (dispatch: Dispatch, getState: GetState) => {
+        if (!isTrezorConnectBackendType(account.backendType)) return; // skip unsupported backend type
         const { transactions } = getState().wallet.transactions;
         const reducerTxs = getAccountTransactions(account.key, transactions);
 

--- a/packages/suite/src/components/suite/modals/AddAccount/components/AddAccountButton.tsx
+++ b/packages/suite/src/components/suite/modals/AddAccount/components/AddAccountButton.tsx
@@ -1,12 +1,12 @@
 import React, { useCallback } from 'react';
 import { analytics, EventType } from '@trezor/suite-analytics';
-
 import { Button, Tooltip } from '@trezor/components';
-import { Account } from '@wallet-types';
+import { Account, Network } from '@wallet-types';
 import { Translation } from '@suite-components';
 import { useAccountSearch } from '@suite-hooks';
+import { AddCoinJoinAccountButton } from './AddCoinJoinAccountButton';
 
-const verifyAvailibility = ({
+const verifyAvailability = ({
     emptyAccounts,
     account,
 }: {
@@ -68,16 +68,22 @@ const AddButton = ({ account, isDisabled, onEnableAccount }: ButtonProps) => {
     );
 };
 
-interface Props {
+interface AddAccountButtonProps {
+    network: Network;
     emptyAccounts: Account[];
     onEnableAccount: (account: Account) => void;
 }
 
-export const AddAccountButton = ({ emptyAccounts, onEnableAccount }: Props) => {
+export const AddAccountButton = ({
+    network,
+    emptyAccounts,
+    onEnableAccount,
+}: AddAccountButtonProps) => {
+    if (network.accountType === 'coinjoin') return <AddCoinJoinAccountButton network={network} />;
     if (emptyAccounts.length === 0) return null;
     const account = emptyAccounts[emptyAccounts.length - 1];
 
-    const disabledMessage = verifyAvailibility({ emptyAccounts, account });
+    const disabledMessage = verifyAvailability({ emptyAccounts, account });
 
     return (
         <Tooltip maxWidth={285} content={disabledMessage}>

--- a/packages/suite/src/components/suite/modals/AddAccount/components/AddCoinJoinAccountButton.tsx
+++ b/packages/suite/src/components/suite/modals/AddAccount/components/AddCoinJoinAccountButton.tsx
@@ -1,7 +1,8 @@
 import React from 'react';
 import { Button, Tooltip } from '@trezor/components';
 import { Translation } from '@suite-components';
-import { useSelector } from '@suite-hooks';
+import { useSelector, useActions } from '@suite-hooks';
+import { createCoinjoinAccount } from '@wallet-actions/coinjoinAccountActions';
 import type { Network } from '@wallet-types';
 
 interface AddCoinJoinAccountProps {
@@ -9,6 +10,7 @@ interface AddCoinJoinAccountProps {
 }
 
 export const AddCoinJoinAccountButton = ({ network }: AddCoinJoinAccountProps) => {
+    const action = useActions({ createCoinjoinAccount });
     const { device, accounts } = useSelector(state => ({
         device: state.suite.device,
         accounts: state.wallet.accounts,
@@ -30,7 +32,12 @@ export const AddCoinJoinAccountButton = ({ network }: AddCoinJoinAccountProps) =
             maxWidth={285}
             content={isDisabled ? <Translation id="MODAL_ADD_ACCOUNT_LIMIT_EXCEEDED" /> : null}
         >
-            <Button icon="PLUS" variant="primary" isDisabled={isDisabled} onClick={() => {}}>
+            <Button
+                icon="PLUS"
+                variant="primary"
+                isDisabled={isDisabled}
+                onClick={() => action.createCoinjoinAccount(network)}
+            >
                 <Translation id="TR_ADD_ACCOUNT" />
             </Button>
         </Tooltip>

--- a/packages/suite/src/components/suite/modals/AddAccount/components/AddCoinJoinAccountButton.tsx
+++ b/packages/suite/src/components/suite/modals/AddAccount/components/AddCoinJoinAccountButton.tsx
@@ -1,0 +1,38 @@
+import React from 'react';
+import { Button, Tooltip } from '@trezor/components';
+import { Translation } from '@suite-components';
+import { useSelector } from '@suite-hooks';
+import type { Network } from '@wallet-types';
+
+interface AddCoinJoinAccountProps {
+    network: Network;
+}
+
+export const AddCoinJoinAccountButton = ({ network }: AddCoinJoinAccountProps) => {
+    const { device, accounts } = useSelector(state => ({
+        device: state.suite.device,
+        accounts: state.wallet.accounts,
+    }));
+
+    const coinjoinAccounts = accounts.filter(
+        a =>
+            a.deviceState === device?.state &&
+            a.symbol === network.symbol &&
+            a.accountType === network.accountType,
+    );
+
+    // TODO: more disabled button states
+    // no-capability, device connected etc
+
+    const isDisabled = coinjoinAccounts.length > 0;
+    return (
+        <Tooltip
+            maxWidth={285}
+            content={isDisabled ? <Translation id="MODAL_ADD_ACCOUNT_LIMIT_EXCEEDED" /> : null}
+        >
+            <Button icon="PLUS" variant="primary" isDisabled={isDisabled} onClick={() => {}}>
+                <Translation id="TR_ADD_ACCOUNT" />
+            </Button>
+        </Tooltip>
+    );
+};

--- a/packages/suite/src/components/suite/modals/AddAccount/index.tsx
+++ b/packages/suite/src/components/suite/modals/AddAccount/index.tsx
@@ -153,6 +153,7 @@ export const AddAccount = ({ device, onCancel, symbol, noRedirect }: Props) => {
                 selectedNetwork &&
                 (selectedNetworkEnabled ? (
                     <AddAccountButton
+                        network={selectedNetwork}
                         emptyAccounts={emptyAccounts}
                         onEnableAccount={onEnableAccount}
                     />

--- a/packages/suite/src/components/wallet/AccountsMenu/components/AccountGroup/index.tsx
+++ b/packages/suite/src/components/wallet/AccountsMenu/components/AccountGroup/index.tsx
@@ -39,6 +39,7 @@ interface Props {
 }
 
 const getGroupLabel = (type: Props['type']) => {
+    if (type === 'coinjoin') return 'TR_COINJOIN_ACCOUNTS';
     if (type === 'taproot') return 'TR_TAPROOT_ACCOUNTS';
     if (type === 'legacy') return 'TR_LEGACY_ACCOUNTS';
     if (type === 'ledger') return 'TR_CARDANO_LEDGER_ACCOUNTS';

--- a/packages/suite/src/components/wallet/AccountsMenu/index.tsx
+++ b/packages/suite/src/components/wallet/AccountsMenu/index.tsx
@@ -181,6 +181,9 @@ const AccountsMenu = ({ isMenuInline }: AccountsMenuProps) => {
     const normalAccounts = filteredAccounts.filter(
         a => a.accountType === 'normal' && (a.index === 0 || !a.empty || a.visible),
     );
+    const coinjoinAccounts = filteredAccounts.filter(
+        a => a.accountType === 'coinjoin' && (!a.empty || a.visible),
+    );
     const taprootAccounts = filteredAccounts.filter(
         a => a.accountType === 'taproot' && (!a.empty || a.visible),
     );
@@ -240,6 +243,7 @@ const AccountsMenu = ({ isMenuInline }: AccountsMenuProps) => {
         listedAccountsLength > 0 || !searchString ? (
             <>
                 {buildGroup('normal', normalAccounts)}
+                {buildGroup('coinjoin', coinjoinAccounts)}
                 {buildGroup('taproot', taprootAccounts)}
                 {buildGroup('segwit', segwitAccounts)}
                 {buildGroup('legacy', legacyAccounts)}

--- a/packages/suite/src/components/wallet/WalletLayout/index.tsx
+++ b/packages/suite/src/components/wallet/WalletLayout/index.tsx
@@ -53,7 +53,11 @@ export const WalletLayout = ({
                     width="100%"
                     height="300px"
                     animate={account.loader === 'account-loading'}
-                />
+                >
+                    {account.account?.lastKnownState && (
+                        <>TODO: Display progress {account.account?.lastKnownState.progress}</>
+                    )}
+                </SkeletonRectangle>
             </Wrapper>
         );
     }

--- a/packages/suite/src/middlewares/wallet/coinjoinMiddleware.ts
+++ b/packages/suite/src/middlewares/wallet/coinjoinMiddleware.ts
@@ -1,0 +1,47 @@
+import type { MiddlewareAPI } from 'redux';
+import { ROUTER } from '@suite-actions/constants';
+import { BLOCKCHAIN, DISCOVERY } from '@wallet-actions/constants';
+import * as coinjoinAccountActions from '@wallet-actions/coinjoinAccountActions';
+import { CoinjoinBackendService } from '@suite/services/coinjoin/coinjoinBackend';
+import type { AppState, Action, Dispatch } from '@suite-types';
+
+export const coinjoinMiddleware =
+    (api: MiddlewareAPI<Dispatch, AppState>) =>
+    (next: Dispatch) =>
+    (action: Action): Action => {
+        // cancel discovery for each CoinjoinBackend
+        if (action.type === ROUTER.LOCATION_CHANGE && action.payload.app !== 'wallet') {
+            CoinjoinBackendService.getInstances().forEach(b => b.cancel());
+        }
+
+        // propagate action to reducers
+        next(action);
+
+        if (action.type === DISCOVERY.START) {
+            // find all coinjoin accounts
+            const coinjoinAccounts = api
+                .getState()
+                .wallet.accounts.filter(a => a.accountType === 'coinjoin');
+            if (coinjoinAccounts.length > 0) {
+                coinjoinAccounts.forEach(a =>
+                    api.dispatch(coinjoinAccountActions.fetchAndUpdateAccount(a)),
+                );
+            }
+        }
+
+        if (action.type === BLOCKCHAIN.SYNCED) {
+            // find all coinjoin accounts for network
+            const coinjoinAccounts = api
+                .getState()
+                .wallet.accounts.filter(
+                    a => a.accountType === 'coinjoin' && a.symbol === action.payload.symbol,
+                );
+            if (coinjoinAccounts.length > 0) {
+                coinjoinAccounts.forEach(a =>
+                    api.dispatch(coinjoinAccountActions.fetchAndUpdateAccount(a)),
+                );
+            }
+        }
+
+        return action;
+    };

--- a/packages/suite/src/middlewares/wallet/index.ts
+++ b/packages/suite/src/middlewares/wallet/index.ts
@@ -7,6 +7,7 @@ import graphMiddleware from './graphMiddleware';
 import coinmarketMiddleware from './coinmarketMiddleware';
 import coinmarketSavingsMiddleware from './coinmarketSavingsMiddleware';
 import pollingMiddleware from './pollingMiddleware';
+import { coinjoinMiddleware } from './coinjoinMiddleware';
 
 export default [
     blockchainMiddleware,
@@ -18,4 +19,5 @@ export default [
     coinmarketMiddleware,
     coinmarketSavingsMiddleware,
     pollingMiddleware,
+    coinjoinMiddleware,
 ];

--- a/packages/suite/src/reducers/wallet/selectedAccountReducer.ts
+++ b/packages/suite/src/reducers/wallet/selectedAccountReducer.ts
@@ -20,7 +20,7 @@ export interface AccountLoading {
         | 'auth' // Waiting for device.state
         | 'account-loading'; // Waiting for account
     mode?: undefined;
-    account?: undefined;
+    account?: Account;
     network?: Network;
     discovery?: Discovery;
     params?: undefined;

--- a/packages/suite/src/services/coinjoin/coinjoinBackend.ts
+++ b/packages/suite/src/services/coinjoin/coinjoinBackend.ts
@@ -1,0 +1,97 @@
+import TrezorConnect from '@trezor/connect';
+
+// NOTE: function below will be replaced by @trezor/coinjoin implementation
+type GetAccountInfoParams = {
+    descriptor: string;
+    lastKnownState?: {
+        balance: string;
+        blockHash: string;
+    };
+    symbol: string;
+    onProgress: (state: any) => void;
+};
+
+const getCoinjoinAccountInfo = async (
+    { descriptor, symbol, onProgress, lastKnownState }: GetAccountInfoParams,
+    abortSignal: AbortSignal,
+) => {
+    const accountInfo = await TrezorConnect.getAccountInfo({
+        descriptor,
+        coin: symbol,
+        details: 'txs',
+    });
+
+    if (!accountInfo.success) {
+        console.log('No accountInfo');
+        return;
+    }
+
+    if (lastKnownState?.blockHash === '11') {
+        return accountInfo.payload;
+    }
+
+    return new Promise<typeof accountInfo.payload>(resolve => {
+        // Temporary simulate account discovery by block filters
+        let i = !lastKnownState?.blockHash ? 0 : 70;
+        let timeout: ReturnType<typeof setTimeout>;
+        const tick = () => {
+            i += 10;
+            if (i < 100) {
+                onProgress({
+                    blockHash: `0${i}`,
+                    progress: i,
+                    progressMessage:
+                        i > 60 ? 'Checking transaction history' : 'Loading block filters',
+                });
+                timeout = setTimeout(tick, 1000);
+            } else {
+                // Finish loading
+                onProgress({
+                    blockHash: '11',
+                });
+                resolve(accountInfo.payload);
+            }
+        };
+        tick();
+
+        abortSignal.addEventListener('abort', () => {
+            console.warn('ABORTED!');
+            clearTimeout(timeout);
+        });
+    });
+};
+
+export class CoinjoinBackendService {
+    private static instances: Record<string, CoinjoinBackendService> = {};
+    settings: Readonly<{
+        network: string;
+    }>;
+    private abortController: AbortController | undefined;
+
+    constructor(network: string) {
+        this.settings = Object.freeze({
+            network,
+        });
+    }
+
+    getAccountInfo(params: GetAccountInfoParams) {
+        this.abortController = new AbortController();
+        return getCoinjoinAccountInfo(params, this.abortController.signal);
+    }
+
+    cancel() {
+        this.abortController?.abort();
+        this.abortController = undefined;
+    }
+
+    static getInstance(network: string) {
+        if (!this.instances[network]) {
+            this.instances[network] = new CoinjoinBackendService(network);
+        }
+        return this.instances[network];
+    }
+
+    static getInstances() {
+        return Object.keys(this.instances).map(key => this.instances[key]);
+    }
+}

--- a/packages/suite/src/support/messages.ts
+++ b/packages/suite/src/support/messages.ts
@@ -2249,6 +2249,10 @@ export default defineMessages({
         description: 'Link to Trezor wiki.',
         id: 'TR_LEARN_MORE',
     },
+    TR_COINJOIN_ACCOUNTS: {
+        defaultMessage: 'Privacy enhanced accounts',
+        id: 'TR_COINJOIN_ACCOUNTS',
+    },
     TR_TAPROOT_ACCOUNTS: {
         defaultMessage: 'Taproot accounts',
         id: 'TR_TAPROOT_ACCOUNTS',

--- a/packages/suite/src/support/messages.ts
+++ b/packages/suite/src/support/messages.ts
@@ -3214,6 +3214,18 @@ export default defineMessages({
         id: 'TR_ACCOUNT_TYPE_BIP44_TECH',
         defaultMessage: 'BIP44, P2PKH, Base58',
     },
+    TR_ACCOUNT_TYPE_SLIP25_NAME: {
+        id: 'TR_ACCOUNT_TYPE_SLIP25_NAME',
+        defaultMessage: 'Privacy enhanced account',
+    },
+    TR_ACCOUNT_TYPE_SLIP25_TECH: {
+        id: 'TR_ACCOUNT_TYPE_SLIP25_TECH',
+        defaultMessage: 'SLIP25, P2TR, Bech32m',
+    },
+    TR_ACCOUNT_TYPE_SLIP25_DESC: {
+        id: 'TR_ACCOUNT_TYPE_SLIP25_DESC',
+        defaultMessage: 'What is a privacy enhanced account?',
+    },
     TOAST_QR_INCORRECT_ADDRESS: {
         id: 'TOAST_QR_INCORRECT_ADDRESS',
         defaultMessage: 'QR code contains invalid address for this account',

--- a/packages/suite/src/types/wallet/index.ts
+++ b/packages/suite/src/types/wallet/index.ts
@@ -18,6 +18,7 @@ import { SelectedAccountAction } from '@wallet-actions/selectedAccountActions';
 import { FormDraftAction } from '@wallet-actions/formDraftActions';
 import { CardanoStakingAction } from '@wallet-actions/cardanoStakingActions';
 import { PollingAction } from '@wallet-actions/pollingActions';
+import { CoinjoinAccountAction } from '@wallet-actions/coinjoinAccountActions';
 import { NETWORKS } from '@wallet-config';
 import { ArrayElement } from '@trezor/type-utils';
 
@@ -67,4 +68,5 @@ export type WalletAction =
     | AccountSearchAction
     | FormDraftAction
     | CardanoStakingAction
-    | PollingAction;
+    | PollingAction
+    | CoinjoinAccountAction;

--- a/packages/suite/src/utils/suite/__tests__/backend.test.ts
+++ b/packages/suite/src/utils/suite/__tests__/backend.test.ts
@@ -17,4 +17,15 @@ describe('backend utils', () => {
         expect(utils.isElectrumUrl('https://google.com')).toBe(false);
         expect(utils.isElectrumUrl('')).toBe(false);
     });
+
+    test('isTrezorConnectBackendType', () => {
+        const { isTrezorConnectBackendType } = utils;
+        expect(isTrezorConnectBackendType()).toBe(true);
+        expect(isTrezorConnectBackendType('blockbook')).toBe(true);
+        expect(isTrezorConnectBackendType('coinjoin')).toBe(false);
+        // @ts-expect-error
+        expect(isTrezorConnectBackendType('gibberish')).toBe(false);
+        // @ts-expect-error
+        expect(isTrezorConnectBackendType({})).toBe(false);
+    });
 });

--- a/packages/suite/src/utils/suite/backend.ts
+++ b/packages/suite/src/utils/suite/backend.ts
@@ -1,3 +1,4 @@
+import { TREZOR_CONNECT_BACKENDS, BackendType } from '@suite-common/wallet-config';
 import type { Network, CustomBackend } from '@wallet-types';
 import type { BlockchainState, BackendSettings } from '@wallet-reducers/blockchainReducer';
 
@@ -35,3 +36,10 @@ export const getCustomBackends = (blockchains: BlockchainState): CustomBackend[]
 const electrumUrlRegex = /^([a-zA-Z0-9.-]+):[0-9]{1,5}:[ts]$/; // URL is in format host:port:[t|s] (t for tcp, s for ssl)
 
 export const isElectrumUrl = (value: string) => electrumUrlRegex.test(value);
+
+// check if account.backendType or NETWORK.accountType.backendType is supported by TrezorConnect api (defined in TREZOR_CONNECT_BACKENDS)
+// if it's not then different (non-standard) api should be used for fetching data
+export const isTrezorConnectBackendType = (type?: BackendType) => {
+    if (!type) return true; // use TrezorConnect by default if not defined
+    return !!TREZOR_CONNECT_BACKENDS.find(b => b === type);
+};

--- a/suite-common/test-utils/src/mocks.ts
+++ b/suite-common/test-utils/src/mocks.ts
@@ -277,6 +277,16 @@ const getTrezorConnect = <M>(methods?: M) => {
                 listeners[event] = cb;
             },
             off: () => {},
+            applySettings: jest.fn(async _params => ({
+                success: true,
+                ...getFixture(),
+                _params,
+            })),
+            authorizeCoinJoin: jest.fn(async _params => ({
+                success: false,
+                ...getFixture(),
+                _params,
+            })),
             blockchainSetCustomBackend: jest.fn(async _params => ({
                 success: true,
                 ...getFixture(),
@@ -316,6 +326,11 @@ const getTrezorConnect = <M>(methods?: M) => {
             })),
             getAccountInfo: jest.fn(async _params => ({
                 success: false,
+                ...getFixture(),
+                _params,
+            })),
+            getPublicKey: jest.fn(async _params => ({
+                success: true,
                 ...getFixture(),
                 _params,
             })),

--- a/suite-common/wallet-config/src/networksConfig.ts
+++ b/suite-common/wallet-config/src/networksConfig.ts
@@ -264,6 +264,12 @@ export const networks = {
         features: ['rbf', 'sign-verify', 'amount-unit'],
         customBackends: ['blockbook', 'electrum'],
         accountTypes: {
+            coinjoin: {
+                name: 'Bitcoin Regtest (PEA)',
+                bip43Path: "m/10025'/1'/i'",
+                backendType: 'coinjoin', // use non-standard backend
+                features: [], // no rbf, no sign-verify
+            },
             taproot: {
                 name: 'Bitcoin Regtest (taproot)',
                 bip43Path: "m/86'/1'/i'",
@@ -367,6 +373,13 @@ export const networks = {
     },
 } as const;
 
+export const TREZOR_CONNECT_BACKENDS = ['blockbook', 'electrum', 'ripple', 'blockfrost'] as const;
+export const NON_STANDARD_BACKENDS = ['coinjoin'] as const;
+
+export type BackendType =
+    | typeof TREZOR_CONNECT_BACKENDS[number]
+    | typeof NON_STANDARD_BACKENDS[number];
+
 type Networks = typeof networks;
 type NetworkKey = keyof Networks;
 type NetworkValue = Networks[NetworkKey];
@@ -375,6 +388,7 @@ export type NetworkFeature = 'rbf' | 'sign-verify' | 'amount-unit' | 'tokens';
 export type Network = Without<NetworkValue, 'accountTypes'> & {
     symbol: NetworkKey;
     accountType?: 'normal' | AccountType;
+    backendType?: BackendType;
     testnet?: boolean;
     isHidden?: boolean;
     chainId?: number;

--- a/suite-common/wallet-types/src/account.ts
+++ b/suite-common/wallet-types/src/account.ts
@@ -45,6 +45,13 @@ type AccountNetworkSpecific =
           page: AccountInfo['page'];
       };
 
+export interface AccountLastKnownState {
+    time: number;
+    blockHash: string;
+    progress?: number;
+    progressMessage?: string;
+}
+
 export type Account = {
     deviceState: string;
     key: string;
@@ -66,4 +73,5 @@ export type Account = {
     history: AccountInfo['history'];
     metadata: AccountMetadata;
     backendType?: BackendType; // decides if account is using TrezorConnect/blockchain-link or other non-standard api
+    lastKnownState?: AccountLastKnownState;
 } & AccountNetworkSpecific;

--- a/suite-common/wallet-types/src/account.ts
+++ b/suite-common/wallet-types/src/account.ts
@@ -1,4 +1,4 @@
-import { Network } from '@suite-common/wallet-config';
+import { Network, BackendType } from '@suite-common/wallet-config';
 import { AccountInfo } from '@trezor/connect';
 
 export type MetadataItem = string;
@@ -65,4 +65,5 @@ export type Account = {
     utxo: AccountInfo['utxo'];
     history: AccountInfo['history'];
     metadata: AccountMetadata;
+    backendType?: BackendType; // decides if account is using TrezorConnect/blockchain-link or other non-standard api
 } & AccountNetworkSpecific;

--- a/suite-common/wallet-utils/src/__fixtures__/accountUtils.ts
+++ b/suite-common/wallet-utils/src/__fixtures__/accountUtils.ts
@@ -165,6 +165,11 @@ export const getBip43Type = [
         result: 'bip44',
     },
     {
+        description: 'bitcoin coinjoin',
+        path: "m/10025'/0'/0'",
+        result: 'slip25',
+    },
+    {
         description: 'litecoin segwit',
         path: "m/84'/2'/0'",
         result: 'bip84',

--- a/suite-common/wallet-utils/src/accountUtils.ts
+++ b/suite-common/wallet-utils/src/accountUtils.ts
@@ -112,6 +112,8 @@ export const getBip43Type = (path: string) => {
             return 'bip44';
         case `1852'`:
             return 'shelley';
+        case `10025'`:
+            return 'slip25';
         default:
             return 'unknown';
     }
@@ -123,6 +125,7 @@ export const getAccountTypeName = (path: string) => {
     if (bip43 === 'bip84') return 'TR_ACCOUNT_TYPE_BIP84_NAME';
     if (bip43 === 'bip49') return 'TR_ACCOUNT_TYPE_BIP49_NAME';
     if (bip43 === 'shelley') return 'TR_ACCOUNT_TYPE_SHELLEY';
+    if (bip43 === 'slip25') return 'TR_ACCOUNT_TYPE_SLIP25_NAME';
     return 'TR_ACCOUNT_TYPE_BIP44_NAME';
 };
 
@@ -132,6 +135,7 @@ export const getAccountTypeTech = (path: string) => {
     if (bip43 === 'bip84') return 'TR_ACCOUNT_TYPE_BIP84_TECH';
     if (bip43 === 'bip49') return 'TR_ACCOUNT_TYPE_BIP49_TECH';
     if (bip43 === 'shelley') return 'TR_ACCOUNT_TYPE_SHELLEY';
+    if (bip43 === 'slip25') return 'TR_ACCOUNT_TYPE_SLIP25_TECH';
     return 'TR_ACCOUNT_TYPE_BIP44_TECH';
 };
 
@@ -141,6 +145,7 @@ export const getAccountTypeDesc = (path: string) => {
     if (bip43 === 'bip84') return 'TR_ACCOUNT_TYPE_BIP84_DESC';
     if (bip43 === 'bip49') return 'TR_ACCOUNT_TYPE_BIP49_DESC';
     if (bip43 === 'shelley') return 'TR_ACCOUNT_TYPE_SHELLEY_DESC';
+    if (bip43 === 'slip25') return 'TR_ACCOUNT_TYPE_SLIP25_DESC';
     return 'TR_ACCOUNT_TYPE_BIP44_DESC';
 };
 
@@ -150,6 +155,7 @@ export const getAccountTypeUrl = (path: string) => {
     if (bip43 === 'bip84') return WIKI_BIP84_URL;
     if (bip43 === 'bip49') return WIKI_BIP49_URL;
     if (bip43 === 'shelley') return undefined;
+    if (bip43 === 'slip25') return undefined;
     return WIKI_BIP44_URL;
 };
 


### PR DESCRIPTION
Prerequisite for futures PR
https://github.com/trezor/trezor-suite/issues/5873
https://github.com/trezor/trezor-suite/issues/5866
https://github.com/trezor/trezor-suite/issues/5628

Motivation:
Coinjoin accounts (Privacy enhanced) will use different api (not TrezorConnect) for network communication (fetching account data, discovery etc) therefore they needs to be excluded from "standard" discovery/account sync actions and treated separately in dedicated `coinjoinAccountActions` 


- add `coinjoin` accountType to network config (only in regtest)
- add `backendType` to network config and Account
- exclude multiple TrezorConnect account operations for accounts with non-standard `backendType` (not supported in TrezorConnect)
- add Coinjoin account selection option in AddAcount modal
- display Coinjoin account in AccuontsMenu
- create non-standard discovery process (CoinjoinBackend service) - only as a POC, still using TrezorConnect as source and the account loading progress is faked. Will be replaced by proper implementation of `@trezor/coinjoin` library
