### PR TITLE
chore: refactor selected suite hooks and utils

### DIFF
--- a/packages/components/src/utils/hooks.ts
+++ b/packages/components/src/utils/hooks.ts
@@ -3,6 +3,7 @@ import { ThemeContext } from '../support/ThemeProvider';
 import { platform } from './env';
 import { useTheme as useSCTheme } from 'styled-components';
 
+// todo: duplicity
 export const useKeyPress = (targetKey: string) => {
     // State for keeping track of whether key is pressed
     const [keyPressed, setKeyPressed] = useState(false);

--- a/packages/suite/src/components/suite/modals/Passphrase/components/PassphraseTypeCard/index.tsx
+++ b/packages/suite/src/components/suite/modals/Passphrase/components/PassphraseTypeCard/index.tsx
@@ -1,7 +1,7 @@
 import React, { useState, useRef, useEffect, useCallback } from 'react';
 import { AnimatePresence, motion } from 'framer-motion';
 import { ANIMATION } from '@suite-config';
-import { setCaretPosition, useKeyPress } from '@suite-utils/dom';
+import { setCaretPosition } from '@suite-utils/dom';
 import styled, { css } from 'styled-components';
 import { Button, useTheme, variables, Input, Tooltip, Checkbox, Icon } from '@trezor/components';
 import { Translation } from '@suite-components/Translation';
@@ -9,7 +9,7 @@ import { MAX_LENGTH } from '@suite-constants/inputs';
 import { countBytesInString } from '@trezor/utils';
 import { OpenGuideFromTooltip } from '@guide-components';
 import PasswordStrengthIndicator from '@suite-components/PasswordStrengthIndicator';
-import { useTranslation } from '@suite-hooks';
+import { useTranslation, useKeyPress } from '@suite-hooks';
 import { isAndroid } from '@suite-utils/env';
 
 const Wrapper = styled.div<Pick<Props, 'type' | 'singleColModal'>>`

--- a/packages/suite/src/components/wallet/CoinmarketFooter/index.tsx
+++ b/packages/suite/src/components/wallet/CoinmarketFooter/index.tsx
@@ -3,7 +3,7 @@ import React, { useState, useRef } from 'react';
 import styled from 'styled-components';
 import { DATA_TOS_INVITY_URL, INVITY_URL } from '@trezor/urls';
 import { CoinmarketProvidedByInvity } from '@wallet-components';
-import { useOnClickOutside } from '@suite-utils/dom';
+import { useOnClickOutside } from '@suite-hooks/useOnClickOutside';
 import { Translation } from '@suite-components';
 import { resolveStaticPath } from '@trezor/utils';
 

--- a/packages/suite/src/hooks/suite/index.ts
+++ b/packages/suite/src/hooks/suite/index.ts
@@ -16,6 +16,8 @@ export { useRecovery } from './useRecovery';
 export { useExternalLink } from './useExternalLink';
 export { useFilteredModal } from './useFilteredModal';
 export { usePreferredModal } from './usePreferredModal';
+export { useKeyPress } from './useKeyPress';
+export { useOnClickOutside } from './useOnClickOutside';
 
 // replaced in suite-native
 export { useLocales } from '@suite-hooks/useLocales';

--- a/packages/suite/src/hooks/suite/useKeyPress.ts
+++ b/packages/suite/src/hooks/suite/useKeyPress.ts
@@ -1,0 +1,37 @@
+import { useState, useEffect } from 'react';
+
+// todo: duplicity
+export const useKeyPress = (targetKey: string) => {
+    // State for keeping track of whether key is pressed
+    const [keyPressed, setKeyPressed] = useState(false);
+
+    // If pressed key is our target key then set to true
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    const downHandler = (event: KeyboardEvent) => {
+        if (event.key === targetKey) {
+            setKeyPressed(true);
+        }
+    };
+
+    // If released key is our target key then set to false
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    const upHandler = (event: KeyboardEvent) => {
+        if (event.key === targetKey) {
+            setKeyPressed(false);
+        }
+    };
+
+    // Add event listeners
+    useEffect(() => {
+        window.addEventListener('keydown', downHandler);
+        window.addEventListener('keyup', upHandler);
+        // Remove event listeners on cleanup
+        return () => {
+            window.removeEventListener('keydown', downHandler);
+            window.removeEventListener('keyup', upHandler);
+        };
+        // eslint-disable-next-line react-hooks/exhaustive-deps
+    }, []); // Empty array ensures that effect is only run on mount and unmount
+
+    return keyPressed;
+};

--- a/packages/suite/src/hooks/suite/useOnClickOutside.ts
+++ b/packages/suite/src/hooks/suite/useOnClickOutside.ts
@@ -1,0 +1,31 @@
+import { useEffect } from 'react';
+
+export const useOnClickOutside = (
+    elementRefs: React.MutableRefObject<HTMLElement | null>[],
+    callback: (event: MouseEvent | TouchEvent) => void,
+) => {
+    useEffect(() => {
+        if (!elementRefs?.length) return;
+        const listener = (event: MouseEvent | TouchEvent) => {
+            let clickInsideElements = false;
+
+            elementRefs.forEach(elRef => {
+                // Do nothing if clicking ref's element or descendent elements
+                if (!elRef.current || elRef.current.contains(event.target as Node)) {
+                    clickInsideElements = true;
+                }
+            });
+            if (clickInsideElements) return;
+
+            callback(event);
+        };
+
+        document.addEventListener('mousedown', listener);
+        document.addEventListener('touchstart', listener);
+
+        return () => {
+            document.removeEventListener('mousedown', listener);
+            document.removeEventListener('touchstart', listener);
+        };
+    }, [elementRefs, callback]);
+};

--- a/packages/suite/src/utils/suite/dom.ts
+++ b/packages/suite/src/utils/suite/dom.ts
@@ -1,5 +1,3 @@
-import { useState, useEffect } from 'react';
-
 export const selectText = (element: HTMLElement) => {
     const doc = document;
     if (window.getSelection) {
@@ -11,41 +9,6 @@ export const selectText = (element: HTMLElement) => {
             selection.addRange(range);
         }
     }
-};
-
-export const useKeyPress = (targetKey: string) => {
-    // State for keeping track of whether key is pressed
-    const [keyPressed, setKeyPressed] = useState(false);
-
-    // If pressed key is our target key then set to true
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-    const downHandler = (event: KeyboardEvent) => {
-        if (event.key === targetKey) {
-            setKeyPressed(true);
-        }
-    };
-
-    // If released key is our target key then set to false
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-    const upHandler = (event: KeyboardEvent) => {
-        if (event.key === targetKey) {
-            setKeyPressed(false);
-        }
-    };
-
-    // Add event listeners
-    useEffect(() => {
-        window.addEventListener('keydown', downHandler);
-        window.addEventListener('keyup', upHandler);
-        // Remove event listeners on cleanup
-        return () => {
-            window.removeEventListener('keydown', downHandler);
-            window.removeEventListener('keyup', upHandler);
-        };
-        // eslint-disable-next-line react-hooks/exhaustive-deps
-    }, []); // Empty array ensures that effect is only run on mount and unmount
-
-    return keyPressed;
 };
 
 /**
@@ -74,36 +37,6 @@ export const copyToClipboard = (
     } catch (error) {
         return error.message;
     }
-};
-
-export const useOnClickOutside = (
-    elementRefs: React.MutableRefObject<HTMLElement | null>[],
-    callback: (event: MouseEvent | TouchEvent) => void,
-) => {
-    useEffect(() => {
-        if (!elementRefs?.length) return;
-        const listener = (event: MouseEvent | TouchEvent) => {
-            let clickInsideElements = false;
-
-            elementRefs.forEach(elRef => {
-                // Do nothing if clicking ref's element or descendent elements
-                if (!elRef.current || elRef.current.contains(event.target as Node)) {
-                    clickInsideElements = true;
-                }
-            });
-            if (clickInsideElements) return;
-
-            callback(event);
-        };
-
-        document.addEventListener('mousedown', listener);
-        document.addEventListener('touchstart', listener);
-
-        return () => {
-            document.removeEventListener('mousedown', listener);
-            document.removeEventListener('touchstart', listener);
-        };
-    }, [elementRefs, callback]);
 };
 
 export const download = (value: string, filename: string) => {


### PR DESCRIPTION
Hello, this PR does not bring any new code only refactoring. I need that to make code sharing between suite and connect-popup possible. 

- imho react hooks should not be part of utils. moving `useKeyPress` and `useOnClickOutside` into hooks folder
- there is duplcite code  https://github.com/trezor/trezor-suite/blob/6253be3f9f657a9a14f21941c76ae1db36e2193c/packages/components/src/utils/hooks.ts#L41 and in suite https://github.com/trezor/trezor-suite/blob/130b17ff0d52b67079d29b4e7250637528be1def/packages/suite/src/utils/suite/dom.ts#L79 would you suggest creating a package for abstract react hooks? 