### PR TITLE
fix(ci): urls tests back

### DIFF
--- a/packages/urls/package.json
+++ b/packages/urls/package.json
@@ -7,7 +7,8 @@
     "main": "src/index",
     "scripts": {
         "lint": "eslint '**/*.{ts,tsx,js}'",
-        "type-check": "tsc --build"
+        "type-check": "tsc --build",
+        "test:integration": "jest -c ../../jest.config.base.js"
     },
     "devDependencies": {
         "node-fetch": "^2.6.7"


### PR DESCRIPTION
fixing this https://gitlab.com/satoshilabs/trezor/trezor-suite/-/jobs/2794050736 
just puts back one line removed by this https://github.com/trezor/trezor-suite/pull/5883