### PR TITLE
fix(suite): initialRun not completed by going to settings

### DIFF
--- a/packages/integration-tests/projects/suite-web/tests/onboarding/analytics-consent.test.ts
+++ b/packages/integration-tests/projects/suite-web/tests/onboarding/analytics-consent.test.ts
@@ -1,0 +1,107 @@
+// @group:onboarding
+// @retry=2
+
+describe('Onboarding - analytics consent', () => {
+    beforeEach(() => {
+        cy.task('startBridge');
+        cy.viewport(1080, 1440).resetDb();
+    });
+
+    it('shows analytics consent when going to settings and back on non-initialized T1 device', () => {
+        cy.task('startEmu', { version: '1-latest', wipe: true });
+        cy.prefixedVisit('/');
+
+        cy.getTestElement('@analytics/consent');
+        cy.getTestElement('@suite/menu/settings').click();
+        cy.getTestElement('@settings/menu/close').click();
+
+        cy.getTestElement('@analytics/consent');
+        cy.getTestElement('@onboarding/continue-button').click();
+        cy.getTestElement('@onboarding/continue-button').click();
+
+        cy.getTestElement('@onboarding-layout/body').should('be.visible');
+    });
+
+    it('shows analytics consent when going to settings and back on non-initialized T2 device', () => {
+        cy.task('startEmu', { wipe: true });
+        cy.prefixedVisit('/');
+
+        cy.getTestElement('@analytics/consent');
+        cy.getTestElement('@suite/menu/settings').click();
+        cy.getTestElement('@settings/menu/close').click();
+
+        cy.getTestElement('@analytics/consent');
+        cy.getTestElement('@onboarding/continue-button').click();
+        cy.getTestElement('@onboarding/continue-button').click();
+
+        cy.getTestElement('@onboarding-layout/body').should('be.visible');
+    });
+
+    it('shows analytics consent when going to settings and back on initialized T1 device', () => {
+        cy.task('startEmu', { version: '1-latest', wipe: true });
+        cy.task('setupEmu', {
+            needs_backup: false,
+        });
+        cy.prefixedVisit('/');
+
+        cy.getTestElement('@analytics/consent');
+        cy.getTestElement('@suite/menu/settings').click();
+        cy.getTestElement('@settings/menu/close').click();
+
+        cy.getTestElement('@analytics/consent');
+        cy.getTestElement('@onboarding/continue-button').click();
+        cy.getTestElement('@onboarding/exit-app-button').click();
+
+        cy.getTestElement('@suite-layout/body').should('be.visible');
+        cy.getTestElement('@settings/menu/close').should('be.visible');
+    });
+
+    it('shows analytics consent when going to settings and back on initialized T2 device', () => {
+        cy.task('startEmu', { wipe: true });
+        cy.task('setupEmu', {
+            needs_backup: false,
+        });
+        cy.prefixedVisit('/');
+
+        cy.getTestElement('@analytics/consent');
+        cy.getTestElement('@suite/menu/settings').click();
+        cy.getTestElement('@settings/menu/close').click();
+
+        cy.getTestElement('@analytics/consent');
+        cy.getTestElement('@onboarding/continue-button').click();
+        cy.getTestElement('@onboarding/exit-app-button').click();
+
+        cy.getTestElement('@suite-layout/body').should('be.visible');
+        cy.getTestElement('@settings/menu/close').should('be.visible');
+    });
+
+    it('shows analytics consent and then goes to /accounts on initialized T1 device', () => {
+        cy.task('startEmu', { version: '1-latest', wipe: true });
+        cy.task('setupEmu', {
+            needs_backup: false,
+        });
+        cy.prefixedVisit('/accounts');
+
+        cy.getTestElement('@analytics/consent');
+        cy.getTestElement('@onboarding/continue-button').click();
+        cy.getTestElement('@onboarding/exit-app-button').click();
+
+        cy.getTestElement('@suite-layout/body').should('be.visible');
+        cy.getTestElement('@wallet/menu/wallet-send');
+    });
+
+    it('shows analytics consent and then goes to /accounts on initialized T2 device', () => {
+        cy.task('startEmu', { wipe: true });
+        cy.task('setupEmu', {
+            needs_backup: false,
+        });
+        cy.prefixedVisit('/accounts');
+
+        cy.getTestElement('@analytics/consent');
+        cy.getTestElement('@onboarding/continue-button').click();
+        cy.getTestElement('@onboarding/exit-app-button').click();
+
+        cy.getTestElement('@suite-layout/body').should('be.visible');
+        cy.getTestElement('@wallet/menu/wallet-send');
+    });
+});

--- a/packages/suite/src/components/settings/SettingsMenu.tsx
+++ b/packages/suite/src/components/settings/SettingsMenu.tsx
@@ -24,16 +24,16 @@ const CloseButtonSticky = styled(CloseButton)<{ isAppNavigationPanelInView?: boo
             position: fixed;
         `}
 `;
-
 export const SettingsMenu = () => {
     const { setDebugMode, goto } = useActions({
         goto: routerActions.goto,
         setDebugMode: suiteActions.setDebugMode,
     });
 
-    const { settingsBackRoute, showDebugMenu } = useSelector(state => ({
+    const { settingsBackRoute, showDebugMenu, initialRun } = useSelector(state => ({
         settingsBackRoute: state.router.settingsBackRoute,
         showDebugMenu: state.suite.settings.debug.showDebugMenu,
+        initialRun: state.suite.flags.initialRun,
     }));
 
     // show debug menu item after 5 clicks on "Settings" heading
@@ -99,7 +99,9 @@ export const SettingsMenu = () => {
                     <CloseButtonSticky
                         isAppNavigationPanelInView={isAppNavigationPanelInView}
                         onClick={() =>
-                            goto(settingsBackRoute.name, { params: settingsBackRoute.params })
+                            initialRun
+                                ? goto('onboarding-index')
+                                : goto(settingsBackRoute.name, { params: settingsBackRoute.params })
                         }
                         data-test="@settings/menu/close"
                     />

--- a/packages/suite/src/components/suite/SuiteLayout/index.tsx
+++ b/packages/suite/src/components/suite/SuiteLayout/index.tsx
@@ -88,9 +88,10 @@ type SuiteLayoutProps = {
 };
 
 export const SuiteLayout = ({ children }: SuiteLayoutProps) => {
-    const { url, anchor } = useSelector(state => ({
+    const { url, anchor, initialRun } = useSelector(state => ({
         url: state.router.url,
         anchor: state.router.anchor,
+        initialRun: state.suite.flags.initialRun,
     }));
 
     const { isMobileLayout, layoutSize } = useLayoutSize();
@@ -110,7 +111,7 @@ export const SuiteLayout = ({ children }: SuiteLayoutProps) => {
 
     // Setting screens are available even if the device is not connected in normal mode
     // but then we need to hide NavigationBar so user can't navigate to Dashboard and Accounts.
-    const isNavigationBarVisible = device?.mode === 'normal';
+    const isNavigationBarVisible = device?.mode === 'normal' && !initialRun;
 
     const isGuideFullHeight = isMobileLayout || isModalOpen;
 

--- a/packages/suite/src/hooks/suite/useOnboarding.ts
+++ b/packages/suite/src/hooks/suite/useOnboarding.ts
@@ -2,9 +2,13 @@ import { UI } from '@trezor/connect';
 import * as onboardingActions from '@onboarding-actions/onboardingActions';
 import * as routerActions from '@suite-actions/routerActions';
 import * as recoveryActions from '@recovery-actions/recoveryActions';
+import * as suiteActions from '@suite-actions/suiteActions';
 import { useActions, useSelector } from '@suite-hooks';
+import { useDispatch } from 'react-redux';
 
 export const useOnboarding = () => {
+    const dispatch = useDispatch();
+
     const { onboarding, modal } = useSelector(state => state);
 
     const showPinMatrix =
@@ -15,7 +19,6 @@ export const useOnboarding = () => {
         goToSubStep: onboardingActions.goToSubStep,
         goToNextStep: onboardingActions.goToNextStep,
         goToPreviousStep: onboardingActions.goToPreviousStep,
-        goToSuite: routerActions.closeModalApp,
         resetOnboarding: onboardingActions.resetOnboarding,
         enableOnboardingReducer: onboardingActions.enableOnboardingReducer,
         rerun: recoveryActions.rerun,
@@ -23,9 +26,21 @@ export const useOnboarding = () => {
         addPath: onboardingActions.addPath,
     });
 
+    const goToSuite = (initialRedirection = false) => {
+        dispatch(suiteActions.initialRunCompleted());
+        dispatch(onboardingActions.resetOnboarding());
+        dispatch(routerActions.closeModalApp());
+
+        // fixes a bug that user ends up in settings after initialization of a new device because he navigated to settings before
+        if (initialRedirection) {
+            dispatch(routerActions.goto('suite-index'));
+        }
+    };
+
     return {
         ...onboarding,
         ...actions,
         showPinMatrix,
+        goToSuite,
     };
 };

--- a/packages/suite/src/middlewares/onboarding/__tests__/onboardingMiddleware.test.ts
+++ b/packages/suite/src/middlewares/onboarding/__tests__/onboardingMiddleware.test.ts
@@ -85,37 +85,5 @@ describe('onboardingMiddleware', () => {
                 { type: '@onboarding/enable-onboarding-reducer', payload: true },
             ]);
         });
-
-        it('from onboarding', async () => {
-            const store = initStore(
-                getInitialState({
-                    loaded: true,
-                    url: '/onboarding',
-                    pathname: '/',
-                    hash: undefined,
-                    app: 'onboarding',
-                    params: undefined,
-                    route: {
-                        name: 'onboarding-index',
-                        pattern: '/onboarding',
-                        app: 'onboarding',
-                        isForegroundApp: true,
-                        isFullscreenApp: true,
-                        params: undefined,
-                        exact: undefined,
-                    },
-                    settingsBackRoute: {
-                        name: 'suite-index',
-                    },
-                }),
-            );
-            await store.dispatch({ type: SUITE.APP_CHANGED, payload: 'wallet' });
-            const result = store.getActions();
-            expect(result).toEqual([
-                { type: SUITE.APP_CHANGED, payload: 'wallet' },
-                { type: '@suite/set-flag', key: 'initialRun', value: false },
-                { type: '@onboarding/reset-onboarding' },
-            ]);
-        });
     });
 });

--- a/packages/suite/src/middlewares/onboarding/onboardingMiddleware.ts
+++ b/packages/suite/src/middlewares/onboarding/onboardingMiddleware.ts
@@ -1,14 +1,12 @@
 import { MiddlewareAPI } from 'redux';
 import { SUITE } from '@suite-actions/constants';
 import * as onboardingActions from '@onboarding-actions/onboardingActions';
-import * as suiteActions from '@suite-actions/suiteActions';
 import { AppState, Action, Dispatch } from '@suite-types';
 
 const onboardingMiddleware =
     (api: MiddlewareAPI<Dispatch, AppState>) =>
     (next: Dispatch) =>
     (action: Action): Action => {
-        const prevApp = api.getState().router.app;
         // pass action
         next(action);
 
@@ -17,14 +15,6 @@ const onboardingMiddleware =
             //  1. make reducer to accept actions (enableReducer) and apply changes
             if (action.payload === 'onboarding') {
                 api.dispatch(onboardingActions.enableOnboardingReducer(true));
-            }
-
-            // here middleware detects that onboarding app is disposed, do following:
-            // 1. reset onboarding reducer to initialState
-            // 2. set initialRun field in suite reducer to false (do not redirect to onboarding on first load next time)
-            if (action.payload !== 'onboarding' && prevApp === 'onboarding') {
-                api.dispatch(suiteActions.initialRunCompleted());
-                api.dispatch(onboardingActions.resetOnboarding());
             }
         }
 

--- a/packages/suite/src/middlewares/suite/routerMiddleware.ts
+++ b/packages/suite/src/middlewares/suite/routerMiddleware.ts
@@ -12,8 +12,8 @@ const router = (api: MiddlewareAPI<Dispatch, AppState>) => (next: Dispatch) => (
         case ROUTER.LOCATION_CHANGE:
             /**
              * Store back route for navigation when closing the settings.
-             * Exclude settings routes – we want to close the settings and not just switch the settigns tab...
-             * Exculde foreground apps – to prevent going back to modals and other unexpected states.
+             * Exclude settings routes – we want to close the settings and not just switch the settings tab...
+             * Exclude foreground apps – to prevent going back to modals and other unexpected states.
              */
             if (router.app !== 'settings' && !router.route?.isForegroundApp) {
                 return next({

--- a/packages/suite/src/views/onboarding/steps/Final/index.tsx
+++ b/packages/suite/src/views/onboarding/steps/Final/index.tsx
@@ -6,11 +6,10 @@ import { analytics, EventType } from '@trezor/suite-analytics';
 import { Button, Icon, variables, Input, Dropdown, DropdownRef } from '@trezor/components';
 import { Translation, HomescreenGallery } from '@suite-components';
 import { DeviceAnimation, OnboardingStepBox } from '@onboarding-components';
-import { useActions, useDevice, useSelector } from '@suite-hooks';
+import { useActions, useDevice, useOnboarding, useSelector } from '@suite-hooks';
 import * as deviceSettingsActions from '@settings-actions/deviceSettingsActions';
 import { DEFAULT_LABEL, MAX_LABEL_LENGTH } from '@suite-constants/device';
 import { getDeviceModel } from '@suite-utils/device';
-import * as routerActions from '@suite-actions/routerActions';
 
 const Option = styled.div`
     display: flex;
@@ -125,10 +124,11 @@ const Wrapper = styled.div<{ shouldWrap?: boolean }>`
 `;
 
 export const FinalStep = () => {
+    const { goToSuite } = useOnboarding();
+
     const dropdownRef = useRef<DropdownRef>();
-    const { applySettings, goToSuite } = useActions({
+    const { applySettings } = useActions({
         applySettings: deviceSettingsActions.applySettings,
-        goToSuite: routerActions.closeModalApp,
     });
 
     const { isLocked, device } = useDevice();

--- a/packages/suite/src/views/onboarding/steps/Welcome/components/PreOnboardingSetup/DataAnalytics.tsx
+++ b/packages/suite/src/views/onboarding/steps/Welcome/components/PreOnboardingSetup/DataAnalytics.tsx
@@ -113,7 +113,7 @@ export const DataAnalytics = () => {
     };
 
     return (
-        <Box variant="small">
+        <Box variant="small" data-test="@analytics/consent">
             <Wrapper>
                 <Heading>
                     <Translation id="TR_ONBOARDING_DATA_COLLECTION_HEADING" />

--- a/packages/suite/src/views/onboarding/steps/Welcome/components/PreOnboardingSetup/SecurityCheck.tsx
+++ b/packages/suite/src/views/onboarding/steps/Welcome/components/PreOnboardingSetup/SecurityCheck.tsx
@@ -141,7 +141,7 @@ const SecurityCheck = () => {
                     {initialized ? (
                         <OnboardingButtonCta
                             data-test="@onboarding/exit-app-button"
-                            onClick={() => goToSuite(true)}
+                            onClick={() => goToSuite()}
                         >
                             <Translation id="TR_GO_TO_SUITE" />
                         </OnboardingButtonCta>


### PR DESCRIPTION
closes #5861

We should create a follow-up issue and refactor whole router and fullscreen/foreground apps logic.

If a user navigates to settings on the welcome page, he is navigated to Settings after exiting onboarding.
