### PR TITLE
fix(suite): display validation status during fw installation

### DIFF
--- a/packages/suite/src/support/messages.ts
+++ b/packages/suite/src/support/messages.ts
@@ -3012,6 +3012,11 @@ export default defineMessages({
         description: 'Info what is happening with users device.',
         id: 'TR_WAIT_FOR_REBOOT',
     },
+    TR_VALIDATION: {
+        defaultMessage: 'Validating firmware',
+        description: 'Info what is happening with users device.',
+        id: 'TR_VALIDATION',
+    },
     TR_WALLET_DUPLICATE_DESC: {
         defaultMessage: 'The Hidden wallet you are trying to add has been already discovered.',
         id: 'TR_WALLET_DUPLICATE_DESC',

--- a/packages/suite/src/utils/firmware/index.ts
+++ b/packages/suite/src/utils/firmware/index.ts
@@ -17,13 +17,15 @@ export const getTextForStatus = (status: AppState['firmware']['status']) => {
         case 'started':
         case 'installing':
             return 'TR_INSTALLING';
+        case 'wait-for-reboot':
+            return 'TR_WAIT_FOR_REBOOT';
+        case 'validation':
+            return 'TR_VALIDATION';
         case 'unplug':
         case 'reconnect-in-normal':
         case 'done':
         case 'partially-done':
             return 'TR_FIRMWARE_STATUS_INSTALLATION_COMPLETED';
-        case 'wait-for-reboot':
-            return 'TR_WAIT_FOR_REBOOT';
         default:
             return null;
     }

--- a/packages/suite/src/views/firmware/index.tsx
+++ b/packages/suite/src/views/firmware/index.tsx
@@ -27,7 +27,7 @@ const Wrapper = styled.div<{ isWithTopPadding: boolean }>`
     position: relative;
 
     ${variables.SCREEN_QUERY.ABOVE_TABLET} {
-        padding-top: ${({ isWithTopPadding }) => isWithTopPadding && '40px'};
+        padding-top: ${({ isWithTopPadding }) => isWithTopPadding && '44px'};
     }
 `;
 

--- a/packages/suite/src/views/onboarding/steps/Firmware/index.tsx
+++ b/packages/suite/src/views/onboarding/steps/Firmware/index.tsx
@@ -26,7 +26,6 @@ const FirmwareStep = () => {
         firmwareHashInvalid,
     } = useFirmware();
     const [cachedDevice, setCachedDevice] = useState<TrezorDevice | undefined>(device);
-
     // special and hopefully very rare case. this appears when somebody tried to fool user into using a hacked firmware
     if (device?.id && firmwareHashInvalid.includes(device.id)) {
         return (
@@ -67,8 +66,9 @@ const FirmwareStep = () => {
         );
     }
 
-    // // edge case 2 - user has reconnected device that is already up to date
-    if (status !== 'done' && device?.firmware === 'valid') {
+    // edge case 2 - user has reconnected device that is already up to date
+    // include "validation" status to prevent displaying this during installation
+    if (!['validation', 'done'].includes(status) && device?.firmware === 'valid') {
         return (
             <OnboardingStepBox
                 image="FIRMWARE"
@@ -106,6 +106,7 @@ const FirmwareStep = () => {
         case 'started': // called from firmwareUpdate()
         case 'installing':
         case 'wait-for-reboot':
+        case 'validation':
         case 'unplug': // only relevant for T1, TT auto restarts itself
         case 'reconnect-in-normal': // only relevant for T1, TT auto restarts itself
         case 'partially-done': // only relevant for T1, updating from very old fw is done in 2 fw updates, partially-done means first update was installed


### PR DESCRIPTION
Display correct installation status during firmware has check. There is a wrong component displayed in onboarding and no status shown in fw update, both is confusing:

onboarding before:
![onboarding-before](https://user-images.githubusercontent.com/42465546/182184736-36616e60-3ad5-4a0d-a288-f44824a10931.gif)
onboarding after:
![onboarding-after (1)](https://user-images.githubusercontent.com/42465546/182184771-eaa55811-dab2-417e-a9c8-d2c75547c1bb.gif)
update before:
![update-before](https://user-images.githubusercontent.com/42465546/182184794-c883acb2-09a3-4b23-aa11-56a41a821831.gif)
update after:
![update-after-2](https://user-images.githubusercontent.com/42465546/182342846-8383f3c1-a7f2-4524-be97-278c308b00b2.gif)


**QA**: Firmware update status is shown correctly in onboarding and settings. Please test with both T1 and TT.

