### PR TITLE
fix(suite): display wallet label in WalletLabeling

### DIFF
--- a/packages/suite/src/components/suite/Labeling/components/WalletLabeling.tsx
+++ b/packages/suite/src/components/suite/Labeling/components/WalletLabeling.tsx
@@ -11,7 +11,9 @@ export const WalletLabeling = ({ device, shouldUseDeviceLabel }: WalletLabelling
     const { translationString } = useTranslation();
 
     let label: string | null = null;
-    if (device.state) {
+    if (device.metadata.status === 'enabled' && device.metadata.walletLabel) {
+        label = device.metadata.walletLabel;
+    } else if (device.state) {
         label = device.useEmptyPassphrase
             ? translationString('TR_NO_PASSPHRASE_WALLET')
             : translationString('TR_PASSPHRASE_WALLET', { id: device.walletNumber });

--- a/packages/suite/src/components/suite/NavigationBar/components/DeviceSelector/index.tsx
+++ b/packages/suite/src/components/suite/NavigationBar/components/DeviceSelector/index.tsx
@@ -196,13 +196,7 @@ export const DeviceSelector = () => {
 
                         {selectedDevice.state && (
                             <WalletNameWrapper>
-                                {selectedDevice.metadata.status === 'enabled' &&
-                                selectedDevice.metadata.walletLabel ? (
-                                    selectedDevice.metadata.walletLabel
-                                ) : (
-                                    <WalletLabeling device={selectedDevice} />
-                                )}
-
+                                <WalletLabeling device={selectedDevice} />
                                 <ArrowDown icon="ARROW_DOWN" size={16} />
                             </WalletNameWrapper>
                         )}


### PR DESCRIPTION
Correctly display wallet label in send form when labelling is enabled. To reproduce the bug, open multiple wallets (this can be done with two devices or hidden wallets) and paste an address from one of the connected wallets into a send form of another wallet.

Before:
![Screenshot 2022-08-02 at 10 50 57](https://user-images.githubusercontent.com/42465546/182335153-3dc21af0-1777-4967-8717-c99edbba02a7.png)
After:
![Screenshot 2022-08-02 at 10 49 01](https://user-images.githubusercontent.com/42465546/182335117-21544bf3-9531-4921-8d13-8d5a76dd4bc9.png)

**QA:** Please check wallet labels are displayed and can be edited correctly.