### PR TITLE
fix(suite): fix fw type switch for old devices

### DIFF
--- a/packages/suite/src/middlewares/firmware/firmwareMiddleware.ts
+++ b/packages/suite/src/middlewares/firmware/firmwareMiddleware.ts
@@ -8,7 +8,7 @@ const firmware =
     (api: MiddlewareAPI<Dispatch, AppState>) =>
     (next: Dispatch) =>
     (action: Action): Action => {
-        const { app: prevApp } = api.getState().router;
+        const { firmware, router } = api.getState();
 
         // pass action
         next(action);
@@ -44,7 +44,7 @@ const firmware =
                 // 2. I use special intermediary firmware instead of using normal one (see @trezor/connect/src/api/firmware)
                 // 3. Intermediary firmware updates bootloader to the latest and keeps device in bootloader mode after reconnect
                 // 4. This point happens here. After I reconnect the device, firmware middleware finds that the newly connected
-                // 4. device does not have the latest firmware, proceed with subsequent updated automatically
+                // device does not have the latest firmware, proceed with subsequent updated automatically
                 // todo: this is a 'client side' implementation. It would be nicer to have it in @trezor/connect
                 // todo: but this would require reworking the entire TRAKTOR
 
@@ -60,7 +60,7 @@ const firmware =
                     console.warn(
                         'Device with intermediary firmware detected. Installing the latest update.',
                     );
-                    api.dispatch(firmwareActions.firmwareUpdate());
+                    api.dispatch(firmwareActions.firmwareUpdate(firmware.targetType));
                     break;
                 }
 
@@ -77,7 +77,7 @@ const firmware =
                 break;
             case SUITE.APP_CHANGED:
                 // leaving firmware update context
-                if (['firmware', 'firmware-type', 'onboarding'].includes(prevApp)) {
+                if (['firmware', 'firmware-type', 'onboarding'].includes(router.app)) {
                     api.dispatch(firmwareActions.resetReducer());
                 }
 

--- a/packages/suite/src/support/messages.ts
+++ b/packages/suite/src/support/messages.ts
@@ -4502,6 +4502,11 @@ export default defineMessages({
         defaultMessage:
             'Bitcoin-only firmware is a light-weight option for users only interested in Bitcoin. Universal firmware enables all supported coins and features. Do you wish to switch firmware type?',
     },
+    TR_BITCOIN_ONLY_UNAVAILABLE: {
+        id: 'TR_BITCOIN_ONLY_UNAVAILABLE',
+        defaultMessage:
+            'Before you can switch to Bitcoin-only, we need to upgrade your firmware to a newer version.',
+    },
     TR_EXPERIMENTAL_FEATURES: {
         id: 'TR_EXPERIMENTAL_FEATURES',
         defaultMessage: 'Experimental features',

--- a/packages/suite/src/views/onboarding/steps/Firmware/index.tsx
+++ b/packages/suite/src/views/onboarding/steps/Firmware/index.tsx
@@ -24,6 +24,7 @@ const FirmwareStep = () => {
         firmwareUpdate,
         showFingerprintCheck,
         firmwareHashInvalid,
+        targetType,
     } = useFirmware();
     const [cachedDevice, setCachedDevice] = useState<TrezorDevice | undefined>(device);
 
@@ -57,7 +58,7 @@ const FirmwareStep = () => {
                 image="FIRMWARE"
                 heading={<Translation id="TR_FW_INSTALLATION_FAILED" />}
                 description={<Translation id="TOAST_GENERIC_ERROR" values={{ error }} />}
-                innerActions={<RetryButton onClick={() => firmwareUpdate()} />}
+                innerActions={<RetryButton onClick={() => firmwareUpdate(targetType)} />}
                 outerActions={
                     <OnboardingButtonBack onClick={() => resetReducer()}>
                         <Translation id="TR_BACK" />


### PR DESCRIPTION
- Disable installing Bitcoin-only firmware for T2 devices before 2.0.8.
- Enable installing Bitcoin-only firmware for T1 devices before intermediary firmware.

## Description

Older model T devices (prior to v 2.0.8) need to upgrade to v2.1.1 before they can install the latest version, as explained [here](https://github.com/trezor/trezor-suite/issues/4262). The proposed solution in abec4571e240d155e8eeaa89ad3acc8758d32765 is to offer an upgrade instead of type switch when a user with outdated firmware clicks "Switch to Bitcoin". This is not great UX, but I think it's justifiable for this edge case. An alternative would be to disable or hide this option, but users would still be able to open the modal directly via the URL.

Older model One devices (prior to v1.6.3 or so) need to upgrade to intermediary firmware before automatically upgrading to the latest. Commit 93267f8fa507431b3a84b287416be87657d8a254 correctly sets the target type of the second installation.

## Related Issue

Resolve #5929

## Screenshots (if appropriate):

![chrome-capture-2022-7-4](https://user-images.githubusercontent.com/42465546/182840988-413c2165-1582-4ebb-84db-633f63ceb061.gif)

