### PR TITLE
fix(suite): replace changelog links

### DIFF
--- a/packages/suite/src/components/firmware/FirmwareOffer.tsx
+++ b/packages/suite/src/components/firmware/FirmwareOffer.tsx
@@ -1,9 +1,9 @@
 import React from 'react';
 import styled from 'styled-components';
 import { Button, Icon, Tooltip, variables } from '@trezor/components';
-import { GITHUB_FW_CHANGELOG_URL } from '@trezor/urls';
 import { Translation, TrezorLink } from '@suite-components';
 import {
+    getChangelogUrl,
     getFwType,
     getFwUpdateVersion,
     getFwVersion,
@@ -109,6 +109,7 @@ const FirmwareOffer = ({ device, customFirmware, targetFirmwareType }: Props) =>
     const previousFirmwareType = `${getFwType(device)} `;
     const nextFirmwareType = targetFirmwareType || targetType;
     const formattedNextFirmwareType = nextFirmwareType ? `${nextFirmwareType} ` : '';
+    const changelogUrl = getChangelogUrl(device);
 
     return (
         <FwVersionWrapper>
@@ -153,7 +154,7 @@ const FirmwareOffer = ({ device, customFirmware, targetFirmwareType }: Props) =>
                                                 href={
                                                     parsedChangelog.notes
                                                         ? parsedChangelog.notes
-                                                        : GITHUB_FW_CHANGELOG_URL
+                                                        : changelogUrl
                                                 }
                                             >
                                                 <Button

--- a/packages/suite/src/utils/suite/device.ts
+++ b/packages/suite/src/utils/suite/device.ts
@@ -290,6 +290,14 @@ export const getSelectedDevice = (
     });
 };
 
+export const getChangelogUrl = (
+    device: TrezorDevice,
+    revision?: string | null,
+) => `https://github.com/trezor/trezor-firmware/blob/${revision || 'master'}/${
+    getDeviceModel(device) === '1' ? 'legacy/firmware' : 'core'
+}/CHANGELOG.md
+    `;
+
 /**
  * Used by suiteActions
  * Sort devices by "ts" (timestamp) field

--- a/packages/suite/src/views/settings/device/FirmwareTypeChange.tsx
+++ b/packages/suite/src/views/settings/device/FirmwareTypeChange.tsx
@@ -1,13 +1,12 @@
 import React from 'react';
 import styled from 'styled-components';
 
-import { GITHUB_FW_COMMIT_URL } from '@trezor/urls';
-import { Translation, TrezorLink } from '@suite-components';
+import { Translation } from '@suite-components';
 import { ActionButton, ActionColumn, SectionItem, TextColumn } from '@suite-components/Settings';
 import { useDevice, useActions } from '@suite-hooks';
 import * as routerActions from '@suite-actions/routerActions';
 import { getFwType, getFwVersion, isDeviceBitcoinOnly } from '@suite-utils/device';
-import { Button, Tooltip } from '@trezor/components';
+import { Button } from '@trezor/components';
 import { useAnchor } from '@suite-hooks/useAnchor';
 import { SettingsAnchor } from '@suite-constants/anchors';
 
@@ -20,10 +19,6 @@ const Version = styled.div`
             margin-left: 6px;
         }
     }
-`;
-
-const VersionTooltip = styled(Tooltip)`
-    display: inline-flex;
 `;
 
 interface FirmwareTypeProps {
@@ -41,7 +36,6 @@ export const FirmwareTypeChange = ({ isDeviceLocked }: FirmwareTypeProps) => {
         return null;
     }
 
-    const { revision } = device.features;
     const currentFwVersion = getFwVersion(device);
     const currentFwType = getFwType(device);
     const actionButtonId = isDeviceBitcoinOnly(device)
@@ -69,21 +63,14 @@ export const FirmwareTypeChange = ({ isDeviceLocked }: FirmwareTypeProps) => {
                                 id="TR_YOUR_FIRMWARE_TYPE"
                                 values={{
                                     version: (
-                                        <VersionTooltip content={revision} disabled={!revision}>
-                                            <TrezorLink
-                                                href={GITHUB_FW_COMMIT_URL + revision}
-                                                variant="nostyle"
-                                            >
-                                                <Button
-                                                    variant="tertiary"
-                                                    icon={revision ? 'EXTERNAL_LINK' : undefined}
-                                                    alignIcon="right"
-                                                    disabled={!revision}
-                                                >
-                                                    {currentFwType}
-                                                </Button>
-                                            </TrezorLink>
-                                        </VersionTooltip>
+                                        <Button
+                                            variant="tertiary"
+                                            // icon={revision ? 'EXTERNAL_LINK' : undefined}
+                                            // alignIcon="right"
+                                            disabled // TODO: this should link to an article in knowledge base or guide in the future
+                                        >
+                                            {currentFwType}
+                                        </Button>
                                     ),
                                 }}
                             />

--- a/packages/suite/src/views/settings/device/FirmwareVersion.tsx
+++ b/packages/suite/src/views/settings/device/FirmwareVersion.tsx
@@ -5,7 +5,7 @@ import { Translation, TrezorLink } from '@suite-components';
 import { ActionButton, ActionColumn, SectionItem, TextColumn } from '@suite-components/Settings';
 import { useDevice, useActions } from '@suite-hooks';
 import * as routerActions from '@suite-actions/routerActions';
-import { getDeviceModel, getFwVersion, getFwUpdateVersion } from '@suite-utils/device';
+import { getChangelogUrl, getFwVersion, getFwUpdateVersion } from '@suite-utils/device';
 import { Button, Tooltip } from '@trezor/components';
 import { AcquiredDevice } from '@suite-types';
 import { useAnchor } from '@suite-hooks/useAnchor';
@@ -68,10 +68,7 @@ export const FirmwareVersion = ({ isDeviceLocked }: FirmwareVersionProps) => {
     const currentFwVersion = getFwVersion(device);
     const availableFwVersion = getFwUpdateVersion(device);
     const { revision } = device.features;
-    const githubUrl = `https://github.com/trezor/trezor-firmware/blob/${revision}/${
-        getDeviceModel(device) === '1' ? 'legacy/firmware' : 'core'
-    }/CHANGELOG.md
-    `;
+    const changelogUrl = getChangelogUrl(device, revision);
     const githubButtonIcon = revision ? 'EXTERNAL_LINK' : undefined;
 
     const handleUpdate = () => goto('firmware-index', { params: { cancelable: true } });
@@ -99,7 +96,7 @@ export const FirmwareVersion = ({ isDeviceLocked }: FirmwareVersionProps) => {
                                     version: (
                                         <VersionTooltip content={revision} disabled={!revision}>
                                             {revision ? (
-                                                <TrezorLink href={githubUrl} variant="nostyle">
+                                                <TrezorLink href={changelogUrl} variant="nostyle">
                                                     <GithubButton />
                                                 </TrezorLink>
                                             ) : (

--- a/packages/suite/src/views/settings/device/FirmwareVersion.tsx
+++ b/packages/suite/src/views/settings/device/FirmwareVersion.tsx
@@ -1,12 +1,11 @@
 import React from 'react';
 import styled from 'styled-components';
-import { GITHUB_FW_COMMIT_URL } from '@trezor/urls';
 
 import { Translation, TrezorLink } from '@suite-components';
 import { ActionButton, ActionColumn, SectionItem, TextColumn } from '@suite-components/Settings';
 import { useDevice, useActions } from '@suite-hooks';
 import * as routerActions from '@suite-actions/routerActions';
-import { getFwVersion, getFwUpdateVersion } from '@suite-utils/device';
+import { getDeviceModel, getFwVersion, getFwUpdateVersion } from '@suite-utils/device';
 import { Button, Tooltip } from '@trezor/components';
 import { AcquiredDevice } from '@suite-types';
 import { useAnchor } from '@suite-hooks/useAnchor';
@@ -69,7 +68,10 @@ export const FirmwareVersion = ({ isDeviceLocked }: FirmwareVersionProps) => {
     const currentFwVersion = getFwVersion(device);
     const availableFwVersion = getFwUpdateVersion(device);
     const { revision } = device.features;
-    const githubUrl = GITHUB_FW_COMMIT_URL + revision;
+    const githubUrl = `https://github.com/trezor/trezor-firmware/blob/${revision}/${
+        getDeviceModel(device) === '1' ? 'legacy/firmware' : 'core'
+    }/CHANGELOG.md
+    `;
     const githubButtonIcon = revision ? 'EXTERNAL_LINK' : undefined;
 
     const handleUpdate = () => goto('firmware-index', { params: { cancelable: true } });


### PR DESCRIPTION
Provide correct links to FW changelog in Device Settings.
## Description

1. Remove link from firmware type button because it is redundant (repeated from the line above).
2. Link to the changelog file rather than the whole commit which is hard to read.
3. Link to the changelog corresponding to the device, not statically to core changelog.

## Related Issue

Resolve #4665

## Screenshots (if appropriate):

![Screenshot 2022-08-03 at 14 39 55](https://user-images.githubusercontent.com/42465546/182843726-b1b13414-9a65-45c0-a932-167b92f77ba8.png)

