### PR TITLE
fix(connect): improve env detection

### DIFF
--- a/packages/connect/src/device/DeviceList.ts
+++ b/packages/connect/src/device/DeviceList.ts
@@ -101,7 +101,11 @@ export class DeviceList extends EventEmitter {
             const { signal } = this.fetchController;
             // @ts-expect-error TODO: https://github.com/trezor/trezor-suite/issues/5332
             const fetchWithSignal = (args, options = {}) => fetch(args, { ...options, signal });
-            BridgeV2.setFetch(fetchWithSignal, typeof window === 'undefined');
+
+            // detection of environment browser/node
+            // todo: code should not be detecting environment itself. imho it should be built with this information passed from build process maybe?
+            const isNode = process?.release?.name?.search(/node|io\.js/) !== -1;
+            BridgeV2.setFetch(fetchWithSignal, isNode);
 
             // @ts-expect-error TODO: https://github.com/trezor/trezor-suite/issues/5332
             transports.push(bridge);


### PR DESCRIPTION
improve nodejs/browser env detection in connect

## Description

global window object should not be available in node.js environment. should not. it is not really bulletproof check. For example [this implementation](https://github.com/MyCryptoHQ/wallets) has `window` defined in their tests which leads to not spoofing http headers in bridge communication which leads to the "transport is missing" error 
https://github.com/MyCryptoHQ/wallets/runs/7672569113?check_suite_focus=true#step:6:61
 
For those who are interested in code:
https://github.com/trezor/trezor-suite/blob/develop/packages/connect/src/device/DeviceList.ts#L104
https://github.com/trezor/trezor-suite/blob/develop/packages/transport/src/bridge/http.ts#L15
https://github.com/trezor/trezor-suite/blob/develop/packages/transport/src/bridge/http.ts#L62-L67

## Related Issue

Not sure if there is some? 
