### PR TITLE
fix(suite): fix missing tooltip in graph in account section

### DIFF
--- a/packages/suite/src/components/suite/TransactionsGraph/components/CustomTooltipAccount.tsx
+++ b/packages/suite/src/components/suite/TransactionsGraph/components/CustomTooltipAccount.tsx
@@ -74,6 +74,8 @@ export const CustomTooltipAccount = ({
     return (
         <CustomTooltipBase
             {...props}
+            active={active}
+            payload={payload}
             sentAmount={formatAmount(sentAmountString, symbol, sentFiat, localCurrency, 'neg')}
             receivedAmount={formatAmount(
                 receivedAmountString,


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

There were missing props excluded by destructuring.

## Related Issue

Resolve https://github.com/trezor/trezor-suite/issues/5937

## Screenshots (if appropriate):
![image](https://user-images.githubusercontent.com/3729633/183026296-453d13b5-c885-4c4c-913d-cecf047081d8.png)

## Notes
I considered rewriting it more universally like this:
```javascript
export const CustomTooltipAccount = (props: CustomTooltipAccountProps) => {
    const { active, balanceValueFn, receivedValueFn, sentValueFn, payload, localCurrency, symbol } =
        props;
```
but in this case there are some props like `balanceValueFn` that should be excluded, so I see no nice universal solution not to forget the optional params.