### PR TITLE
test(suite-web): fix flaky sign-verify test

### DIFF
--- a/packages/integration-tests/projects/suite-web/tests/wallet/sign-and-verify.test.ts
+++ b/packages/integration-tests/projects/suite-web/tests/wallet/sign-and-verify.test.ts
@@ -21,6 +21,7 @@ describe('Sign and verify', () => {
         cy.passThroughInitialRun();
 
         cy.getTestElement('@suite/menu/wallet-index').click();
+        cy.discoveryShouldFinish();
         cy.getTestElement('@wallet/menu/extra-dropdown').click();
         cy.getTestElement('@wallet/menu/wallet-sign-verify').click();
     });
@@ -40,7 +41,6 @@ describe('Sign and verify', () => {
         cy.getTestElement('@sign-verify/sign-address/input').click();
         cy.getTestElement(`@sign-verify/sign-address/option/${PATH}`).click();
         cy.getTestElement('@sign-verify/sign-address/input').should('contain', ADDRESS);
-        cy.discoveryShouldFinish();
         cy.getTestElement('@sign-verify/submit').click();
         cy.getConfirmActionOnDeviceModal().task('pressYes');
         cy.getConfirmActionOnDeviceModal().task('pressYes');
@@ -55,7 +55,6 @@ describe('Sign and verify', () => {
         cy.getTestElement('@sign-verify/format').within(() =>
             cy.getTestElement(`select-bar/${true}`).click(),
         );
-        cy.discoveryShouldFinish();
         cy.getTestElement('@sign-verify/submit').click();
         cy.getConfirmActionOnDeviceModal().task('pressYes');
         cy.getConfirmActionOnDeviceModal().task('pressYes');
@@ -67,7 +66,6 @@ describe('Sign and verify', () => {
         cy.getTestElement('@sign-verify/message').type(MESSAGE);
         cy.getTestElement('@sign-verify/select-address').type(ADDRESS);
         cy.getTestElement('@sign-verify/signature').type(SIGNATURE);
-        cy.discoveryShouldFinish();
         cy.getTestElement('@sign-verify/submit').click();
         cy.getConfirmActionOnDeviceModal().task('pressYes');
         cy.getConfirmActionOnDeviceModal().task('pressYes');


### PR DESCRIPTION
Fix flaky test

## Description

- `cy.discoveryShouldFinish();` failed time to time since discovery might have been already finished at that point. Waiting for something to finish expects it to not be finished in the first place when using this command.

### Screenshots

![image](https://user-images.githubusercontent.com/30367552/183070057-296e48cd-b803-4685-8ec2-57c063969a9f.png)
