### PR TITLE
feat(suite): POC replace createStore with configureStore

### DIFF
--- a/packages/suite/package.json
+++ b/packages/suite/package.json
@@ -24,6 +24,7 @@
         "@ethereumjs/tx": "^3.5.2",
         "@fivebinaries/coin-selection": "2.0.0-beta.10",
         "@hookform/resolvers": "1.3.8",
+        "@reduxjs/toolkit": "^1.8.3",
         "@sentry/integrations": "6.17.2",
         "@sentry/minimal": "6.17.2",
         "@trezor/components": "*",


### PR DESCRIPTION


<!--- Provide a general summary of your changes in the Title above -->

## Description

POC of how we could avoid using `redux` in suite's `store.ts` as a part of the transition to `redux-toolkit`. I replaced the `createStore` method from `redux` with `configureStore` and tried to preserve all the functionality.