### PR TITLE
minor bash refactoring

### DIFF
--- a/docker/create-funds-on-regtest.sh
+++ b/docker/create-funds-on-regtest.sh
@@ -11,7 +11,7 @@ else
   # Get unspent transactions
   UNSENT_TR=$( /usr/bin/bitcoin-cli -regtest -datadir=/root/.bitcoin --rpccookiefile=/root/.cookie -rpcport=18021 listunspent)
   # Get trxId of the last transaction
-  TRX_ID=$(echo $UNSENT_TR | jq -r '.[-1].txid')
+  TRX_ID=$(echo "$UNSENT_TR" | jq -r '.[-1].txid')
 
   # Create a btc transaction
   TRX=$(/usr/bin/bitcoin-cli -regtest -datadir=/root/.bitcoin --rpccookiefile=/root/.cookie -rpcport=18021 createrawtransaction \
@@ -22,13 +22,13 @@ else
   "{\""$BTC_REC_ADDR"\": 49.99999}")
 
   # Sign the transaction
-  TX_OUTPUT=$(/usr/bin/bitcoin-cli -regtest -datadir=/root/.bitcoin --rpccookiefile=/root/.cookie -rpcport=18021 signrawtransactionwithwallet $TRX)
+  TX_OUTPUT=$(/usr/bin/bitcoin-cli -regtest -datadir=/root/.bitcoin --rpccookiefile=/root/.cookie -rpcport=18021 signrawtransactionwithwallet "$TRX")
 
   # Broadcast the tx to the network
-  HEX_ID=$(echo $TX_OUTPUT | jq -r '.hex')
-  /usr/bin/bitcoin-cli -regtest -datadir=/root/.bitcoin --rpccookiefile=/root/.cookie -rpcport=18021 sendrawtransaction $HEX_ID &>/dev/null
+  HEX_ID=$(echo "$TX_OUTPUT" | jq -r '.hex')
+  /usr/bin/bitcoin-cli -regtest -datadir=/root/.bitcoin --rpccookiefile=/root/.cookie -rpcport=18021 sendrawtransaction "$HEX_ID" &>/dev/null
 
   # Mine a new block
   ADDR=$(/usr/bin/bitcoin-cli -regtest -datadir=/root/.bitcoin --rpccookiefile=/root/.cookie -rpcport=18021 -rpcwallet=tenv-test getnewaddress)
-  /usr/bin/bitcoin-cli -regtest -datadir=/root/.bitcoin --rpccookiefile=/root/.cookie -rpcport=18021 -rpcwallet=tenv-test generatetoaddress 150 $ADDR &>/dev/null
+  /usr/bin/bitcoin-cli -regtest -datadir=/root/.bitcoin --rpccookiefile=/root/.cookie -rpcport=18021 -rpcwallet=tenv-test generatetoaddress 150 "$ADDR" &>/dev/null
 fi

--- a/docker/docker-blockchain-link-test.sh
+++ b/docker/docker-blockchain-link-test.sh
@@ -1,6 +1,7 @@
 #!/usr/bin/env bash
 set -e
 
-export LOCAL_USER_ID=`id -u $USER`
+LOCAL_USER_ID="$(id -u "$USER")"
+export LOCAL_USER_ID
 
 docker-compose -f ./docker/docker-compose.blockchain-link-test.yml up --build --abort-on-container-exit --force-recreate

--- a/docker/docker-connect-popup-test.sh
+++ b/docker/docker-connect-popup-test.sh
@@ -2,6 +2,7 @@
 set -e
 
 xhost +
-export LOCAL_USER_ID=`id -u $USER`
+LOCAL_USER_ID="$(id -u "$USER")"
+export LOCAL_USER_ID
 
 docker-compose -f ./docker/docker-compose.connect-popup-test.yml up --build --abort-on-container-exit

--- a/docker/docker-connect-test.sh
+++ b/docker/docker-connect-test.sh
@@ -32,7 +32,7 @@ show_usage() {
   echo "Options:"
   echo "  -c       Disable backend cache. default: enabled"
   echo "  -d       Disable docker. Useful when running own instance of trezor-user-env. default: enabled"
-  echo "  -D PATH  Set path to docker executable. Can be replaced with `podman`. default: docker"
+  echo "  -D PATH  Set path to docker executable. Can be replaced with \`podman\`. default: docker"
   echo "  -e       All methods except excluded, example: applySettings,signTransaction"
   echo "  -f       Use specific firmware version, example: 2.1.4, 1.8.0 default: 2-master"
   echo "  -i       Included methods only, example: applySettings,signTransaction"
@@ -46,6 +46,7 @@ FIRMWARE_URL=""
 INCLUDED_METHODS=""
 EXCLUDED_METHODS=""
 DOCKER=true
+# TODO: DOCKER_PATH appears unused. Remove or export?
 DOCKER_PATH="docker"
 USE_TX_CACHE=true
 USE_WS_CACHE=true
@@ -95,7 +96,7 @@ shift $((OPTIND - 1))
 if [[ $ENVIRONEMT == "node" ]];
   then
     SCRIPT="yarn workspace @trezor/integration-tests test:connect:node"
-  else 
+  else
     SCRIPT="yarn workspace @trezor/integration-tests test:connect:web"
 fi
 
@@ -127,9 +128,9 @@ run() {
   if [ $DOCKER = true ]; then
     runDocker
   else
-    $SCRIPT $PATTERN
+    $SCRIPT "$PATTERN"
   fi
-  
+
 }
 
 run

--- a/docker/docker-regtest-electrum.sh
+++ b/docker/docker-regtest-electrum.sh
@@ -1,7 +1,8 @@
 #!/usr/bin/env bash
 set -e
 
-export LOCAL_USER_ID=`id -u $USER`
+LOCAL_USER_ID="$(id -u "$USER")"
+export LOCAL_USER_ID
 
 docker-compose -f ./docker/docker-compose.regtest-electrum.yml up --build --abort-on-container-exit --force-recreate
 

--- a/docker/docker-suite-desktop-test.sh
+++ b/docker/docker-suite-desktop-test.sh
@@ -5,6 +5,7 @@ set -e
 # todo: resolve generated files permissions
 
 xhost +
-export LOCAL_USER_ID=`id -u $USER`
+LOCAL_USER_ID="$(id -u "$USER")"
+export LOCAL_USER_ID
 
 docker-compose -f ./docker/docker-compose.suite-desktop-test.yml up --build --abort-on-container-exit --force-recreate

--- a/docker/docker-suite-install.sh
+++ b/docker/docker-suite-install.sh
@@ -1,4 +1,5 @@
 #!/usr/bin/env bash
 set -e
 
-docker-compose -f ./docker/docker-compose.suite-base.yml run -e LOCAL_USER_ID=`id -u $USER` --rm suite-install
+LOCAL_USER_ID="$(id -u "$USER")"
+docker-compose -f ./docker/docker-compose.suite-base.yml run -e LOCAL_USER_ID="$LOCAL_USER_ID" --rm suite-install

--- a/docker/docker-suite-snapshots.sh
+++ b/docker/docker-suite-snapshots.sh
@@ -4,7 +4,8 @@ set -e
 # todo: I am not sure whether locally generated snapshots won't somethimes differ from CI generated, this is to be tested
 
 xhost +
-export LOCAL_USER_ID=`id -u $USER`
+LOCAL_USER_ID=$(id -u "$USER")
+export LOCAL_USER_ID
 export CYPRESS_SNAPSHOT=1
 export CYPRESS_updateSnapshots=1
 

--- a/docker/docker-suite-test.sh
+++ b/docker/docker-suite-test.sh
@@ -5,6 +5,7 @@ set -e
 # todo: resolve generated files permissions
 
 xhost +
-export LOCAL_USER_ID=`id -u $USER`
+LOCAL_USER_ID=$(id -u "$USER")
+export LOCAL_USER_ID
 
 docker-compose -f ./docker/docker-compose.suite-test.yml up --build --abort-on-container-exit --force-recreate

--- a/docker/wait-for-200.sh
+++ b/docker/wait-for-200.sh
@@ -4,14 +4,14 @@ echo "Waiting for $1 to load up..."
 counter=0
 max_attempts=60
 
-curl -i -s -I $1
+curl -i -s -I "$1"
 
-until (curl -i -s -I --insecure  $1 | grep '200 OK'); do
+until (curl -i -s -I --insecure "$1" | grep '200 OK'); do
   if [ ${counter} -eq ${max_attempts} ]; then
     echo "$1 is not running. exiting"
     exit 1
   fi
-  counter=$(($counter+1))
+  counter=$((counter+1))
   printf "."
   sleep 1
 done

--- a/scripts/update-submodules.sh
+++ b/scripts/update-submodules.sh
@@ -6,7 +6,7 @@ PARENT_PATH=$( cd "$(dirname "${BASH_SOURCE[0]}")" ; pwd -P )
 cd "$PARENT_PATH"
 cd ../submodules/trezor-common
 commit=$(git rev-parse --short HEAD)
-echo $commit
+echo "$commit"
 git pull origin master
 cd ../
 git add .


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Minor refactoring of all some bash code in `docker/` and `scripts/` folders (more PRs incoming for other folders later on)

All these issues are easily detected by shellcheck https://www.shellcheck.net local binary and using shellcheck in pre-commit hooks.

I mainly refactored:
* double quoting to prevent globbing and word splitting https://www.shellcheck.net/wiki/SC2086
* unused vars https://www.shellcheck.net/wiki/SC2034
* separately declaring and assigning vars to avoid masking return values https://www.shellcheck.net/wiki/SC2155
* unnecessary `$` in arithmetics https://www.shellcheck.net/wiki/SC2004
* whitespaces
<!--- Describe your changes in detail -->


