### PR TITLE
feat(suite): Enable amount unit switching only in debug mode

### DIFF
--- a/packages/integration-tests/projects/suite-web/tests/wallet/bitcoin-send-form.test.ts
+++ b/packages/integration-tests/projects/suite-web/tests/wallet/bitcoin-send-form.test.ts
@@ -51,7 +51,7 @@ describe('Send form for bitcoin', () => {
         cy.getTestElement('@wallet/send/outputs-and-options').matchImageSnapshot('bitcoin-send');
     });
 
-    it('switch display units to satoshis, fill a form in satoshis and send', () => {
+    it.skip('switch display units to satoshis, fill a form in satoshis and send', () => {
         cy.getTestElement('amount-unit-switch/regtest').click();
 
         // test adding and removing outputs
@@ -66,7 +66,7 @@ describe('Send form for bitcoin', () => {
         cy.getTestElement('@wallet/send/outputs-and-options').matchImageSnapshot(
             'bitcoin-send-sats',
         );
-    });
+    }); // TEMPORARY SOLUTION!
 });
 
 // todo: send tx

--- a/packages/suite/src/components/suite/AmountUnitSwitchWrapper.tsx
+++ b/packages/suite/src/components/suite/AmountUnitSwitchWrapper.tsx
@@ -4,6 +4,7 @@ import { Tooltip, variables } from '@trezor/components';
 import { useBitcoinAmountUnit } from '@wallet-hooks/useBitcoinAmountUnit';
 import { NetworkSymbol } from '@wallet-types';
 import { Translation } from './Translation';
+import { useSelector } from '@suite-hooks/useSelector';
 
 const Container = styled.div`
     position: relative;
@@ -29,10 +30,15 @@ interface AmountUnitSwitchWrapperProps {
 }
 
 export const AmountUnitSwitchWrapper = ({ symbol, children }: AmountUnitSwitchWrapperProps) => {
+    const { isInDebugMode } = useSelector(state => ({
+        isInDebugMode: state.suite.settings.debug.showDebugMenu,
+    }));
+
     const { areSatsDisplayed, toggleBitcoinAmountUnits, areUnitsSupportedByNetwork } =
         useBitcoinAmountUnit(symbol);
 
-    if (!areUnitsSupportedByNetwork) {
+    // TEMPORARY SOLUTION!
+    if (!areUnitsSupportedByNetwork || !isInDebugMode) {
         return <>{children}</>;
     }
 

--- a/packages/suite/src/views/settings/general/SettingsGeneral.tsx
+++ b/packages/suite/src/views/settings/general/SettingsGeneral.tsx
@@ -24,10 +24,11 @@ import { BitcoinAmountUnit } from './BitcoinAmountUnit';
 import { NETWORKS } from '@wallet-config';
 
 export const SettingsGeneral = () => {
-    const { desktopUpdate, isTorEnabled, enabledNetworks } = useSelector(state => ({
+    const { desktopUpdate, isTorEnabled, enabledNetworks, isInDebugMode } = useSelector(state => ({
         desktopUpdate: state.desktopUpdate,
         isTorEnabled: getIsTorEnabled(state.suite.torStatus),
         enabledNetworks: state.wallet.settings.enabledNetworks,
+        isInDebugMode: state.suite.settings.debug.showDebugMenu,
     }));
 
     const hasBitcoinNetworks = NETWORKS.some(
@@ -35,12 +36,15 @@ export const SettingsGeneral = () => {
             enabledNetworks.includes(symbol) && features?.includes('amount-unit'),
     );
 
+    // TEMPORARY SOLUTION!
+    const isUnitSectionShown = hasBitcoinNetworks && isInDebugMode;
+
     return (
         <SettingsLayout data-test="@settings/index">
             <SettingsSection title={<Translation id="TR_LOCALIZATION" />} icon="FLAG">
                 <Language />
                 <Fiat />
-                {hasBitcoinNetworks && <BitcoinAmountUnit />}
+                {isUnitSectionShown && <BitcoinAmountUnit />}
             </SettingsSection>
 
             <SettingsSection title={<Translation id="TR_LABELING" />} icon="TAG_MINIMAL">


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Since the **Trade** section remains unfinished it was decided to hide amount unit switching in the debug mode. Now it's only possible to switch the units in debug mode.


