### PR TITLE
feat: fee per byte improvements

### DIFF
--- a/packages/suite/src/actions/wallet/send/sendFormBitcoinActions.ts
+++ b/packages/suite/src/actions/wallet/send/sendFormBitcoinActions.ts
@@ -149,10 +149,8 @@ export const composeTransaction =
         Object.keys(wrappedResponse).forEach(key => {
             const tx = wrappedResponse[key];
             if (tx.type !== 'error') {
-                // make sure that feePerByte is an integer (@trezor/connect may return float)
-                tx.feePerByte = new BigNumber(tx.feePerByte)
-                    .integerValue(BigNumber.ROUND_FLOOR)
-                    .toString();
+                // round to
+                tx.feePerByte = new BigNumber(tx.feePerByte).decimalPlaces(2).toString();
                 if (typeof tx.max === 'string') {
                     tx.max = isSatoshis ? tx.max : formatNetworkAmount(tx.max, account.symbol);
                 }

--- a/packages/suite/src/actions/wallet/send/sendFormBitcoinActions.ts
+++ b/packages/suite/src/actions/wallet/send/sendFormBitcoinActions.ts
@@ -149,17 +149,10 @@ export const composeTransaction =
         Object.keys(wrappedResponse).forEach(key => {
             const tx = wrappedResponse[key];
             if (tx.type !== 'error') {
-                if (formValues.selectedFee === 'custom' && key === 'custom') {
-                    // calculated/real feeePerByte may be slightly higher that requested
-                    // example: spending dust limit, chained txs in rbf...
-                    // override calculated value
-                    tx.feePerByte = formValues.feePerUnit;
-                } else {
-                    // make sure that feePerByte is an integer (@trezor/connect may return float)
-                    tx.feePerByte = new BigNumber(tx.feePerByte)
-                        .integerValue(BigNumber.ROUND_FLOOR)
-                        .toString();
-                }
+                // make sure that feePerByte is an integer (@trezor/connect may return float)
+                tx.feePerByte = new BigNumber(tx.feePerByte)
+                    .integerValue(BigNumber.ROUND_FLOOR)
+                    .toString();
                 if (typeof tx.max === 'string') {
                     tx.max = isSatoshis ? tx.max : formatNetworkAmount(tx.max, account.symbol);
                 }

--- a/packages/suite/src/components/wallet/Fees/index.tsx
+++ b/packages/suite/src/components/wallet/Fees/index.tsx
@@ -2,15 +2,19 @@ import React from 'react';
 import styled from 'styled-components';
 import { FeeLevel } from '@trezor/connect';
 import { UseFormMethods } from 'react-hook-form';
-import { AnimatePresence, motion } from 'framer-motion';
-import { SelectBar, variables, motionAnimation } from '@trezor/components';
+import { SelectBar, variables } from '@trezor/components';
 import { FiatValue, FormattedCryptoAmount, Translation } from '@suite-components';
 import { formatNetworkAmount } from '@suite-common/wallet-utils';
 import { useLayoutSize } from '@suite-hooks';
 import { InputError } from '@wallet-components';
 import { Account } from '@wallet-types';
 import { ExtendedMessageDescriptor } from '@suite-types';
-import { FeeInfo, PrecomposedLevels, PrecomposedLevelsCardano } from '@wallet-types/sendForm';
+import {
+    FeeInfo,
+    PrecomposedLevels,
+    PrecomposedLevelsCardano,
+    PrecomposedTransactionFinal,
+} from '@wallet-types/sendForm';
 import { TypedValidationRules } from '@wallet-types/form';
 import { CustomFee } from './components/CustomFee';
 import FeeDetails from './components/FeeDetails';
@@ -49,10 +53,10 @@ const FiatAmount = styled.div`
     color: ${({ theme }) => theme.TYPE_LIGHT_GREY};
 `;
 
-const Row = styled.div`
+const FeeInfoRow = styled.div`
     display: flex;
     width: 100%;
-    min-height: 56px; /* reserve space for fiat/crypto amounts */
+    min-height: 50px; /* reserve space for fiat/crypto amounts */
 `;
 
 const FeeAmount = styled.div`
@@ -168,7 +172,7 @@ export const Fees = ({
             {isDesktopLayout && labelComponent}
 
             <FeeSetupWrapper>
-                <Row>
+                <FeeInfoRow>
                     {isDesktopLayout ? selectBarComponent : labelComponent}
 
                     {transactionInfo !== undefined && transactionInfo.type !== 'error' && (
@@ -196,33 +200,32 @@ export const Fees = ({
                             <InputError error={error} />
                         </FeeError>
                     )}
-                </Row>
+                </FeeInfoRow>
 
                 {!isDesktopLayout && selectBarComponent}
 
                 <FeeInfoWrapper>
-                    <AnimatePresence initial={false}>
-                        {isCustomLevel ? (
-                            <motion.div style={{ width: '100%' }} {...motionAnimation.expand}>
-                                <CustomFee
-                                    networkType={networkType}
-                                    feeInfo={feeInfo}
-                                    errors={errors}
-                                    register={register}
-                                    getValues={getValues}
-                                    setValue={setValue}
-                                    changeFeeLimit={changeFeeLimit}
-                                />
-                            </motion.div>
-                        ) : (
-                            <FeeDetails
-                                networkType={networkType}
-                                feeInfo={feeInfo}
-                                selectedLevel={selectedLevel}
-                                transactionInfo={transactionInfo}
-                            />
-                        )}
-                    </AnimatePresence>
+                    {isCustomLevel ? (
+                        <CustomFee
+                            networkType={networkType}
+                            feeInfo={feeInfo}
+                            errors={errors}
+                            register={register}
+                            getValues={getValues}
+                            setValue={setValue}
+                            changeFeeLimit={changeFeeLimit}
+                            composedFeePerByte={
+                                (transactionInfo as PrecomposedTransactionFinal)?.feePerByte
+                            }
+                        />
+                    ) : (
+                        <FeeDetails
+                            networkType={networkType}
+                            feeInfo={feeInfo}
+                            selectedLevel={selectedLevel}
+                            transactionInfo={transactionInfo}
+                        />
+                    )}
                 </FeeInfoWrapper>
             </FeeSetupWrapper>
         </FeesWrapper>

--- a/packages/suite/src/hooks/wallet/__fixtures__/useRbfForm.ts
+++ b/packages/suite/src/hooks/wallet/__fixtures__/useRbfForm.ts
@@ -272,7 +272,7 @@ export const composeAndSign = [
             custom: {
                 type: 'final',
                 fee: '600',
-                feePerByte: '3',
+                feePerByte: '3.13',
                 transaction: {
                     outputs: [
                         // change-output is gone
@@ -416,7 +416,7 @@ export const composeAndSign = [
             custom: {
                 type: 'final',
                 fee: '1000',
-                feePerByte: '2',
+                feePerByte: '2.94',
                 transaction: {
                     inputs: [{ prev_hash: 'dcba' }, { prev_hash: 'abcddcba' }],
                     outputs: [
@@ -490,7 +490,7 @@ export const composeAndSign = [
             custom: {
                 type: 'final',
                 fee: '1800', // new utxo + old change-output + old fee (100)
-                feePerByte: '5',
+                feePerByte: '5.29',
                 transaction: {
                     inputs: [{ prev_hash: 'dcba' }, { prev_hash: 'abcddcba' }], // new utxo added
                     outputs: [

--- a/packages/suite/src/support/messages.ts
+++ b/packages/suite/src/support/messages.ts
@@ -6817,4 +6817,12 @@ export default defineMessages({
         id: 'TR_FIRMWARE_CHECK_AUTHENTICITY_SUCCESS',
         defaultMessage: 'Firmware authenthic',
     },
+    TR_FEE_ROUNDING_WARNING: {
+        id: 'TR_FEE_ROUNDING_WARNING',
+        defaultMessage: 'Your Trezor may display a different rate caused by fee rounding.',
+    },
+    TR_FEE_RATE_CHANGED: {
+        id: 'TR_FEE_RATE_CHANGED',
+        defaultMessage: 'Fee rate has changed to complete transaction.',
+    },
 });


### PR DESCRIPTION
This PR aims to solve inconsistency between fee rate displayed in suite and on device

## Description

- 261817b90075531f1be5bfd32e99eaceeafda661 removes code responsible for keeping the same fee rate which was typed into custom input 
- todo: explain to users why final fee rate does not match fee rate from the input. probably some tooltip? the reasons may be:
  - change output would be below dust limit.
  - there is not enough funds to create change output 
- todo: rounding in suite differs from rounding on device

## Related Issue

should resolve https://github.com/trezor/trezor-suite/issues/5907
related to https://github.com/trezor/trezor-firmware/issues/2438

cc @sime 

## Screenshots:

Before: 
![image](https://user-images.githubusercontent.com/30367552/183461798-efcbf189-770f-43be-b603-b1ea41abb770.png)

![image](https://user-images.githubusercontent.com/30367552/183462304-0be18380-8c73-404c-8d2d-140116b1b75d.png)

After: 
![image](https://user-images.githubusercontent.com/30367552/183461798-efcbf189-770f-43be-b603-b1ea41abb770.png)

![image](https://user-images.githubusercontent.com/30367552/183463280-9761ab56-e70e-43e8-8f55-5a69b6cbf8a9.png)

