### PR TITLE
fix(send-form): fee over treshold not disappearing tx modal

### DIFF
--- a/packages/suite/src/components/suite/ModalSwitcher/DeviceContextModal.tsx
+++ b/packages/suite/src/components/suite/ModalSwitcher/DeviceContextModal.tsx
@@ -52,6 +52,7 @@ export const DeviceContextModal = ({
         case 'ButtonRequest_PassphraseEntry':
             return <PassphraseOnDevice device={device} />;
         case 'ButtonRequest_ConfirmOutput':
+        case 'ButtonRequest_FeeOverThreshold':
         case 'ButtonRequest_SignTx': {
             return <ReviewTransaction type="sign-transaction" />;
         }


### PR DESCRIPTION

## Description

While working on #5957 I noticed that button request `ButtonRequest_FeeOverThreshold` made review-tx-modal disappear.

The fix is simple but you maybe want some additional UI tweaks such as rendering some warning nex to fee in transaction modal. 

## Related Issue

Guess there is none yet

## Screenshots

![image](https://user-images.githubusercontent.com/30367552/183465816-8831a1ec-6dcc-4af3-87f7-87e037907a2c.png)

