### PR TITLE
fix(suite): fix the send form getting prefilled with an incorrect amount

### DIFF
--- a/packages/connect/src/data/coinInfo.ts
+++ b/packages/connect/src/data/coinInfo.ts
@@ -13,6 +13,7 @@ const bitcoinNetworks: BitcoinNetworkInfo[] = [];
 const ethereumNetworks: EthereumNetworkInfo[] = [];
 const miscNetworks: MiscNetworkInfo[] = [];
 
+// TODO: replace by structuredClone() after updating TS
 export function cloneCoinInfo<T>(info: T): T {
     const jsonString = JSON.stringify(info);
     if (jsonString === undefined) {

--- a/packages/suite/src/middlewares/wallet/__fixtures__/walletMiddleware.ts
+++ b/packages/suite/src/middlewares/wallet/__fixtures__/walletMiddleware.ts
@@ -1,4 +1,10 @@
-import { ACCOUNT } from '@wallet-actions/constants';
+import { PROTO } from '@trezor/connect';
+import { ACCOUNT, SEND } from '@wallet-actions/constants';
+import { Account } from 'suite-common/wallet-types/src';
+import { FormState as SendFormState, Output } from '@wallet-types/sendForm';
+import { WALLET_SETTINGS } from '@settings-actions/constants';
+import { RouterState } from '@suite-reducers/routerReducer';
+import { State as SelectedAccountState } from '@wallet-reducers/selectedAccountReducer';
 
 export const blockchainSubscription = [
     {
@@ -84,6 +90,112 @@ export const blockchainSubscription = [
             disconnect: {
                 called: 1,
                 coin: 'ltc',
+            },
+        },
+    },
+];
+
+export const draftsFixtures = [
+    {
+        initialState: {
+            router: {
+                route: {
+                    name: 'wallet-send',
+                },
+            } as RouterState,
+            settings: { bitcoinAmountUnit: PROTO.AmountUnit.BITCOIN },
+            accounts: [
+                {
+                    key: 'one',
+                    networkType: 'bitcoin',
+                    symbol: 'btc',
+                    accountType: 'normal',
+                } as Account,
+                {
+                    key: 'two',
+                    networkType: 'bitcoin',
+                    symbol: 'regtest',
+                    accountType: 'normal',
+                } as Account,
+            ],
+            selectedAccount: {
+                status: 'loaded',
+                account: {
+                    key: 'one',
+                    networkType: 'bitcoin',
+                    symbol: 'btc',
+                    accountType: 'normal',
+                },
+            } as SelectedAccountState,
+            send: {
+                drafts: {
+                    one: {
+                        outputs: [
+                            {
+                                amount: '0.00001',
+                            } as Output,
+                            {
+                                amount: '0.00002',
+                            } as Output,
+                        ],
+                    } as SendFormState,
+                    two: {
+                        outputs: [
+                            {
+                                amount: '0.00003',
+                            } as Output,
+                            {
+                                amount: '0.00004',
+                            } as Output,
+                        ],
+                    } as SendFormState,
+                },
+            },
+        },
+        action: {
+            type: WALLET_SETTINGS.SET_BITCOIN_AMOUNT_UNITS,
+            payload: PROTO.AmountUnit.SATOSHI,
+        },
+        expectedActions: [
+            {
+                type: WALLET_SETTINGS.SET_BITCOIN_AMOUNT_UNITS,
+                payload: PROTO.AmountUnit.SATOSHI,
+            },
+            {
+                type: SEND.STORE_DRAFT,
+                key: 'two',
+                formState: {
+                    outputs: [
+                        {
+                            amount: '3000',
+                        },
+                        {
+                            amount: '4000',
+                        },
+                    ],
+                },
+            },
+        ],
+        expectedDrafts: {
+            one: {
+                outputs: [
+                    {
+                        amount: '0.00001',
+                    },
+                    {
+                        amount: '0.00002',
+                    },
+                ],
+            },
+            two: {
+                outputs: [
+                    {
+                        amount: '3000',
+                    },
+                    {
+                        amount: '4000',
+                    },
+                ],
             },
         },
     },

--- a/packages/suite/src/middlewares/wallet/walletMiddleware.ts
+++ b/packages/suite/src/middlewares/wallet/walletMiddleware.ts
@@ -1,5 +1,7 @@
 import type { MiddlewareAPI } from 'redux';
+
 import { SUITE, ROUTER } from '@suite-actions/constants';
+import { WALLET_SETTINGS } from '@settings-actions/constants';
 import { ACCOUNT, TRANSACTION, BLOCKCHAIN } from '@wallet-actions/constants';
 import * as selectedAccountActions from '@wallet-actions/selectedAccountActions';
 import * as sendFormActions from '@wallet-actions/sendFormActions';
@@ -94,6 +96,10 @@ const walletMiddleware =
             api.dispatch(sendFormActions.dispose());
             api.dispatch(receiveActions.dispose());
             api.dispatch(coinmarketBuyActions.dispose());
+        }
+
+        if (action.type === WALLET_SETTINGS.SET_BITCOIN_AMOUNT_UNITS) {
+            api.dispatch(sendFormActions.convertDrafts());
         }
 
         api.dispatch(selectedAccountActions.getStateForAction(action));

--- a/packages/suite/src/reducers/suite/routerReducer.ts
+++ b/packages/suite/src/reducers/suite/routerReducer.ts
@@ -4,7 +4,7 @@ import { Action } from '@suite-types';
 
 import type { AnchorType } from '@suite-constants/anchors';
 
-type State = {
+export type RouterState = {
     loaded: boolean;
     url: string;
     pathname: string;
@@ -13,7 +13,7 @@ type State = {
     anchor?: AnchorType;
 } & RouterAppWithParams;
 
-const initialState: State = {
+const initialState: RouterState = {
     loaded: false,
     url: '/',
     pathname: '/',
@@ -25,7 +25,7 @@ const initialState: State = {
     },
 };
 
-const routerReducer = (state: State = initialState, action: Action): State => {
+const routerReducer = (state: RouterState = initialState, action: Action): RouterState => {
     switch (action.type) {
         case ROUTER.LOCATION_CHANGE: {
             return {

--- a/suite-common/wallet-config/src/networksConfig.ts
+++ b/suite-common/wallet-config/src/networksConfig.ts
@@ -381,12 +381,12 @@ export type BackendType =
     | typeof NON_STANDARD_BACKENDS[number];
 
 type Networks = typeof networks;
-export type NetworkKey = keyof Networks;
-type NetworkValue = Networks[NetworkKey];
+export type NetworkSymbol = keyof Networks;
+type NetworkValue = Networks[NetworkSymbol];
 type AccountType = Keys<NetworkValue['accountTypes']>;
 export type NetworkFeature = 'rbf' | 'sign-verify' | 'amount-unit' | 'tokens';
 export type Network = Without<NetworkValue, 'accountTypes'> & {
-    symbol: NetworkKey;
+    symbol: NetworkSymbol;
     accountType?: 'normal' | AccountType;
     backendType?: BackendType;
     testnet?: boolean;

--- a/suite-common/wallet-types/src/account.ts
+++ b/suite-common/wallet-types/src/account.ts
@@ -1,4 +1,4 @@
-import { Network, BackendType } from '@suite-common/wallet-config';
+import { Network, BackendType, NetworkSymbol } from '@suite-common/wallet-config';
 import { AccountInfo } from '@trezor/connect';
 
 export type MetadataItem = string;
@@ -60,7 +60,7 @@ export type Account = {
     path: string;
     descriptor: string;
     accountType: NonNullable<Network['accountType']>;
-    symbol: Network['symbol'];
+    symbol: NetworkSymbol;
     empty: boolean;
     visible: boolean;
     imported?: boolean;

--- a/suite-native/module-onboarding/src/navigation/routes.ts
+++ b/suite-native/module-onboarding/src/navigation/routes.ts
@@ -1,6 +1,6 @@
 import { StackNavigationProp } from '@react-navigation/stack';
 
-import { NetworkKey } from '@suite-common/wallet-config';
+import { NetworkSymbol } from '@suite-common/wallet-config';
 import { XpubAddress } from '@suite-common/wallet-types';
 
 export enum OnboardingStackRoutes {
@@ -14,7 +14,7 @@ export type OnboardingStackParamList = {
     [OnboardingStackRoutes.OnboardingXpubScan]: undefined;
     [OnboardingStackRoutes.OnboardingAssets]: {
         xpubAddress: XpubAddress;
-        currencySymbol: NetworkKey;
+        currencySymbol: NetworkSymbol;
     };
 };
 

--- a/suite-native/module-onboarding/src/screens/OnboardingXpubScan.tsx
+++ b/suite-native/module-onboarding/src/screens/OnboardingXpubScan.tsx
@@ -7,7 +7,7 @@ import { Screen, StackProps } from '@suite-native/navigation';
 import { Box, Chip, Input, InputWrapper, Text } from '@suite-native/atoms';
 import { prepareNativeStyle, useNativeStyles } from '@trezor/styles';
 import { CryptoIcon } from '@trezor/icons';
-import { NetworkKey } from '@suite-common/wallet-config';
+import { NetworkSymbol } from '@suite-common/wallet-config';
 
 import { Camera, CAMERA_HEIGHT } from '../components/Camera';
 import { OnboardingStackParamList, OnboardingStackRoutes } from '../navigation/routes';
@@ -45,7 +45,7 @@ export const OnboardingXpubScan = ({
     navigation,
 }: StackProps<OnboardingStackParamList, OnboardingStackRoutes.OnboardingXpubScan>) => {
     const [selectedCurrencySymbol, setSelectedCurrencySymbol] =
-        useState<NetworkKey>(DEFAULT_CURRENCY_SYMBOL);
+        useState<NetworkSymbol>(DEFAULT_CURRENCY_SYMBOL);
     const [inputText, setInputText] = useState<string>(DEFAULT_XPUB_INPUT_TEXT);
     const [cameraRequested, setCameraRequested] = useState<boolean>(false);
     const { applyStyle } = useNativeStyles();
@@ -58,7 +58,7 @@ export const OnboardingXpubScan = ({
 
     useFocusEffect(resetToDefaultValues);
 
-    const handleSelectCurrency = (currencySymbol: NetworkKey) => {
+    const handleSelectCurrency = (currencySymbol: NetworkSymbol) => {
         setSelectedCurrencySymbol(currencySymbol);
     };
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Now amounts in a draft are converted every time a user switches units, so that the form is always prefilled with relevant units.

## Related Issue

Resolves https://github.com/trezor/trezor-suite/issues/3004#issuecomment-1209278647
