### PR TITLE
feat(external-links): block non-whitelisted url protocol schemes

### DIFF
--- a/packages/suite-desktop/src-electron/config.ts
+++ b/packages/suite-desktop/src-electron/config.ts
@@ -7,6 +7,8 @@ export const oauthUrls = [
     'https://www.dropbox.com/oauth2/authorize',
 ];
 
+export const allowedProtocols = ['http:', 'https:'];
+
 export const allowedDomains = [
     'localhost',
     '127.0.0.1',

--- a/packages/suite-desktop/src-electron/modules/external-links.ts
+++ b/packages/suite-desktop/src-electron/modules/external-links.ts
@@ -12,6 +12,13 @@ const init: Module = ({ mainWindow, store }) => {
 
     mainWindow.webContents.setWindowOpenHandler((details: HandlerDetails) => {
         const { url } = details;
+        const { protocol } = new URL(url);
+
+        // https://benjamin-altpeter.de/shell-openexternal-dangers/
+        if (!config.allowedProtocols.includes(protocol)) {
+            logger.error('external-links', `Protocol '${protocol}' not allowed`);
+            return { action: 'deny' };
+        }
 
         if (config.oauthUrls.some(u => url.startsWith(u))) {
             logger.info('external-links', `${url} was allowed (OAuth list)`);

--- a/packages/suite-desktop/src-electron/modules/external-links.ts
+++ b/packages/suite-desktop/src-electron/modules/external-links.ts
@@ -48,7 +48,12 @@ const init: Module = ({ mainWindow, store }) => {
         }
 
         // open URL in the user's default browser instead of headless browser window
-        shell.openExternal(url);
+        shell.openExternal(url).catch(err =>
+            dialog.showMessageBoxSync(mainWindow, {
+                type: 'error',
+                message: `${err} ${url}`,
+            }),
+        );
 
         // do not open headless browser window
         return { action: 'deny' };


### PR DESCRIPTION
## Description

Fixes vulnerability
https://benjamin-altpeter.de/shell-openexternal-dangers/

and shows pop-up to a user in case user cannot open urls.

## Related Issue

While investigating #5881, I found this vulnerability. Most of our URLs are hardcoded, but something can get here (very unlikely) from messaging system or Invity backend.

## Screenshots (if appropriate):
Before:
https://user-images.githubusercontent.com/33235762/183850019-ab60d146-3460-47c4-bb85-ba81c99db156.mov

<img width="1112" alt="Screenshot 2022-08-10 at 9 46 03" src="https://user-images.githubusercontent.com/33235762/183862611-60dd0280-f730-46c2-8dc1-aa5fa5567431.png">

Now:
<img width="533" alt="Screenshot 2022-08-10 at 9 46 25" src="https://user-images.githubusercontent.com/33235762/183849976-1abbbc91-b55e-472b-8af1-5923e363de46.png">

<img width="320" alt="Screenshot 2022-08-10 at 11 07 03" src="https://user-images.githubusercontent.com/33235762/183862517-04df3ae9-bc27-4581-838c-295bf258bc66.png">

