### PR TITLE
fix(suite): labels in exported file

### DIFF
--- a/packages/suite/src/actions/wallet/transactionActions.ts
+++ b/packages/suite/src/actions/wallet/transactionActions.ts
@@ -205,9 +205,9 @@ export const exportTransactions =
             // add metadata directly to transactions
         ).map(transaction => ({
             ...transaction,
-            targets: transaction.targets.map((target, index) => ({
+            targets: transaction.targets.map(target => ({
                 ...target,
-                metadataLabel: account.metadata?.outputLabels?.[transaction.txid]?.[index],
+                metadataLabel: account.metadata?.outputLabels?.[transaction.txid]?.[target.n],
             })),
         }));
 


### PR DESCRIPTION
## Description

Labels are now in exported files 🦘 

## Related Issue

Fixes #4604

## Screenshots (if appropriate):
Before:
<img width="133" alt="Screenshot 2022-08-10 at 13 14 44" src="https://user-images.githubusercontent.com/33235762/183887832-5bfcef53-5601-45ac-ae57-6d8ee789bb9a.png">

Now:
<img width="175" alt="Screenshot 2022-08-10 at 13 14 18" src="https://user-images.githubusercontent.com/33235762/183887752-b86bd19d-53d2-4973-b1b2-cbfeccaef949.png">

