### PR TITLE
minor bash refactoring in packages/ folder

### DIFF
--- a/packages/suite-desktop/scripts/gnupg-sign.sh
+++ b/packages/suite-desktop/scripts/gnupg-sign.sh
@@ -1,4 +1,6 @@
-if [ -z "$GPG_CSC_USERID" -o -z "$GPG_CSC_LINK" -o -z "$GPG_CSC_KEY_PASSWORD" ]; then
+#!/usr/bin/env bash
+
+if [ -z "$GPG_CSC_USERID" ] || [ -z "$GPG_CSC_LINK" ] || [ -z "$GPG_CSC_KEY_PASSWORD" ]; then
   echo "GPG sign skipped"
   exit 0
 fi
@@ -8,5 +10,5 @@ gpg --batch --import "$GPG_CSC_LINK"
 shopt -s extglob
 
 for f in packages/suite-desktop/build-electron/*.@(AppImage|zip|dmg|exe) ; do
-  gpg --batch --local-user "$GPG_CSC_USERID" --armor --detach-sig --passphrase "$GPG_CSC_KEY_PASSWORD" --pinentry-mode loopback $f
+  gpg --batch --local-user "$GPG_CSC_USERID" --armor --detach-sig --passphrase "$GPG_CSC_KEY_PASSWORD" --pinentry-mode loopback "$f"
 done

--- a/packages/suite-web-landing/scripts/s3sync.sh
+++ b/packages/suite-web-landing/scripts/s3sync.sh
@@ -44,7 +44,7 @@ if [ "x$1" == "xsuite" ]; then
 fi
 
 set -e
-cd `dirname $0`
+cd "$(dirname "$0")"
 
 if [ "x$2" == "x-clear" ]; then
     aws s3 sync --delete --cache-control 'public, max-age=3600' $SOURCE s3://$BUCKET$DESTDIR

--- a/packages/suite-web/scripts/s3sync.sh
+++ b/packages/suite-web/scripts/s3sync.sh
@@ -44,7 +44,7 @@ if [ "x$1" == "xsuite" ]; then
 fi
 
 set -e
-cd `dirname $0`
+cd "$(dirname "$0")"
 
 if [ "x$2" == "x-clear" ]; then
     aws s3 sync --delete --cache-control 'public, max-age=3600' $SOURCE s3://$BUCKET$DESTDIR

--- a/packages/transport/scripts/protobuf-build.sh
+++ b/packages/transport/scripts/protobuf-build.sh
@@ -33,25 +33,25 @@ fi
 # BUILD combined messages.proto file from protobuf files
 # this code was copied from ./submodules/trezor-common/protob Makekile
 # clear protobuf syntax and remove unknown values to be able to work with proto2js
-echo 'syntax = "proto2";' > $DIST/messages.proto
-echo 'import "google/protobuf/descriptor.proto";' >> $DIST/messages.proto
+echo 'syntax = "proto2";' > "$DIST"/messages.proto
+echo 'import "google/protobuf/descriptor.proto";' >> "$DIST"/messages.proto
 echo "Build proto file from $SRC"
-grep -hv -e '^import ' -e '^syntax' -e '^package' -e 'option java_' $SRC/messages*.proto \
+grep -hv -e '^import ' -e '^syntax' -e '^package' -e 'option java_' "$SRC"/messages*.proto \
 | sed 's/ hw\.trezor\.messages\.common\./ /' \
 | sed 's/ common\./ /' \
 | sed 's/ management\./ /' \
 | sed 's/^option /\/\/ option /' \
-| grep -v '    reserved '>> $DIST/messages.proto
+| grep -v '    reserved '>> "$DIST"/messages.proto
 
 # BUILD messages.json from message.proto
-node_modules/.bin/pbjs -t json -p $DIST -o $DIST/messages.json --keep-case messages.proto
-rm $DIST/messages.proto
+node_modules/.bin/pbjs -t json -p "$DIST" -o "$DIST"/messages.json --keep-case messages.proto
+rm "$DIST"/messages.proto
 
 echo "generating type definitions for: $LANG"
 
 cd "$PARENT_PATH"
 
-node ./protobuf-types.js $LANG
+node ./protobuf-types.js "$LANG"
 
 yarn prettier --write messages.json
-yarn prettier --write **/messages.ts
+yarn prettier --write -- **/messages.ts


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Minor refactoring of all some bash code in `packages/` folder (more PRs incoming for other folders later on)

All these issues are easily detected by shellcheck https://www.shellcheck.net local binary and using shellcheck in pre-commit hooks.

I mainly refactored:
* double quoting to prevent globbing and word splitting https://www.shellcheck.net/wiki/SC2086
* or vs. || in test https://github.com/koalaman/shellcheck/wiki/SC2109
* prevent globbing in args https://github.com/koalaman/shellcheck/wiki/SC2035
* legacy backticks
... and others

<!--- Describe your changes in detail -->

