### PR TITLE
improve connect release process

### DIFF
--- a/.github/workflows/connect-release.yml
+++ b/.github/workflows/connect-release.yml
@@ -1,0 +1,27 @@
+name: Connect npm release
+
+on: [workflow_dispatch]
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+      - name: Setup node
+        uses: actions/setup-node@v3
+        with:
+          node-version-file: ".nvmrc"
+
+      - name: Run @trezor/connect release
+        run: |
+          npm install -g yarn && yarn install
+          git config --global user.name "trezor-ci"
+          git config --global user.email "${{ secrets.TREZOR_BOT_EMAIL }}"
+          git checkout -B npm-release/connect
+          yarn workspace @trezor/connect version:beta
+          git add . && git commit -m "release: @trezor/connect" && git push origin npm-release/connect -f
+          gh config set prompt disabled
+          gh pr create --repo trezor/trezor-suite --title "npm-release @trezor/connect" --body "- [ ] checkbox 1 \n - checkbox 2 [ ]" --base develop
+        env:
+          GITHUB_TOKEN: ${{ secrets.TREZOR_BOT_TOKEN }}

--- a/README.md
+++ b/README.md
@@ -65,7 +65,7 @@ Run a dev build:
 Trezor Connect is a platform for easy integration of Trezor hardware wallets into 3rd party applications.
 Historically, Trezor Connect had its [own repository](https://github.com/trezor/connect). This repository is still active and accepts hotfixes for trezor-connect version 8.
 
-@trezor/connect version 9 is developed in this repository only.
+@trezor/connect version 9 is developed in this repository only. For documentation proceed to this [page](./docs/packages/connect/index.md)
 
 ## Contribute
 

--- a/docs/packages/connect/deployment.md
+++ b/docs/packages/connect/deployment.md
@@ -1,18 +1,6 @@
 # Version 9
 
-## Versioning
-
--   bump version in all @trezor/connect\* packages (except plugin packages)
--   build and deploy npm packages @trezor/connect and @trezor/connect-web
--   deploy @trezor/connect to connect.trezor.io/9.0.0 and connect.trezor.io/9
-
-## Step by step release process
-
--   bump version in all @trezor/connect\* packages (except plugin packages) using `yarn workspace @trezor/connect version:<beta|patch|minor|major>`
--   make sure [CHANGELOG](../../../packages/connect/CHANGELOG.md) files have been updated
--   [prepare a branch with npm releases](../../releases/npm-packages.md). Make sure you have released all dependencies (transport, blockchain-link...)
--   merge into develop branch
--   from develop, create pull requests into branch `release/connect-v9`
+[Described here](../../releases/connect.md)
 
 # Version 8 and lower
 

--- a/docs/packages/connect/index.md
+++ b/docs/packages/connect/index.md
@@ -1,42 +1,20 @@
-## Installation
+## How to use
 
-Install library as npm module:
-
-```javascript
-npm install @trezor/connect
-```
-
-or
+Initialize in project
 
 ```javascript
-yarn add @trezor/connect
+TrezorConnect.init({
+    lazyLoad: true, // this param will prevent iframe injection until TrezorConnect.method will be called
+    manifest: {
+        email: 'developer@xyz.com',
+        appUrl: 'http://your.application.com',
+    },
+});
 ```
-
-Include library as inline script:
-
-```javascript
-<script src="https://connect.trezor.io/9/trezor-connect.js"></script>
-```
-
-## Initialization
-
-ES6
-
-```javascript
-import TrezorConnect from '@trezor/connect';
-```
-
-Inline
-
-```javascript
-var TrezorConnect = window.TrezorConnect;
-```
-
-## Trezor Connect Manifest
 
 Starting with Trezor Connect 7, we have implemented a new feature — Trezor Connect Manifest — which requires that you as a Trezor Connect integrator, to share your e-mail and application url with us.
 This provides us with the **ability to reach you in case of any required maintenance.**
-This subscription is mandatory. Trezor Connect raises an error that reads "Manifest not set. Read more at https://github.com/trezor/trezor-suite/blob/develop/docs/packages/connect/index.md" if manifest is not provided.
+This subscription is mandatory. Trezor Connect raises an error that reads "Manifest not set if manifest is not provided. It can be either either set via `manifest` method or passed as a param in `init` method.
 
 ```javascript
 TrezorConnect.manifest({
@@ -53,25 +31,7 @@ TrezorConnect.manifest({
 
 -   [Events](events.md)
 
-## Running local version (develop/stable)
-
--   clone repository: `git clone git@github.com:trezor/trezor-suite.git`
--   install node_modules: `yarn`
--   run localhost server: `yarn dev`
-
-Initialize in project
-
-```javascript
-TrezorConnect.init({
-    lazyLoad: true, // this param will prevent iframe injection until TrezorConnect.method will be called
-    manifest: {
-        email: 'developer@xyz.com',
-        appUrl: 'http://your.application.com',
-    },
-});
-```
-
-## How Trezor Connect works
+## How @trezor/connect-web works
 
 After implementing Trezor Connect, a small file containing a declaration
 of methods is downloaded. Once the Trezor Connect [method](methods.md) is used,

--- a/docs/releases/connect.md
+++ b/docs/releases/connect.md
@@ -1,0 +1,11 @@
+## @trezor/connect step by step release process
+
+-   Make sure you have released all npm dependencies. If unsure run `node ./ci/scripts/check-npm-dependencies.js connect`. Please note that this script will report unreleased dependencies even for changes that do not affect runtime (READMEs etc.)
+-   If there are any unreleased npm dependencies you should [release them](./npm-packages.md)
+-   bump version in all @trezor/connect\* packages (except plugin packages). `yarn workspace @trezor/connect version:<beta|patch|minor|major>`
+-   make sure CHANGELOG files have been updated
+-   create npm release for `@trezor/connect` and `@trezor/connect-web` packages.
+-   merge into develop branch
+-   from develop branch create a pull requests into branch `release/connect-v9`
+-   gitlab: click manual release `@trezor/connect-web` and `@trezor/connect` into npm
+-   gitlab: click manual deploy job to connect.trezor.io/9

--- a/packages/connect-web/README.md
+++ b/packages/connect-web/README.md
@@ -4,7 +4,7 @@
 [![NPM](https://img.shields.io/npm/v/@trezor/connect-web.svg)](https://www.npmjs.org/package/@trezor/connect-web)
 [![Known Vulnerabilities](https://snyk.io/test/github/trezor/connect-web/badge.svg?targetFile=package.json)](https://snyk.io/test/github/trezor/trezor-suite?targetFile=packages/connect-web/package.json)
 
-This package is bundled into web implementations.
+This package is bundled into web implementations. User interface is presented in a secure popup window served from `connect.trezor.io/<version>/popup.html`. To try it out, use [@trezor/connect-explorer](../connect-explorer) hosted [here](https://trezor.github.io/trezor-suite/connect-explorer).
 
 Contains minimum of code required to:
 
@@ -12,53 +12,44 @@ Contains minimum of code required to:
 -   Create and handle communication between `@trezor/connect-iframe` hosted on `https://connect.trezor.io/<version>/iframe.html`
 -   Create and handle communication and lifecycle of `@trezor/connect-popup` hosted on `https://connect.trezor.io/<version>/popup.html`
 
-## Usage
+## Installation
 
+Install library as npm module:
+
+```javascript
+npm install @trezor/connect-web
 ```
+
+or
+
+```javascript
 yarn add @trezor/connect-web
 ```
 
+Include library as inline script:
+
+```javascript
+<script src="https://connect.trezor.io/9/trezor-connect.js"></script>
+```
+
+## Initialization
+
+ES6
+
 ```javascript
 import TrezorConnect from '@trezor/connect-web';
-
-// set manifest once anywhere in your app index
-TrezorConnect.manifest({
-    appUrl: 'https://my.app.com',
-    email: 'developer@email.com',
-});
-
-function getAddress() {
-    const btcAddress = await TrezorConnect.getAddress({ path: "m/84'/0'/'0'/0/0", coin: 'btc' });
-    if (btcAddress.success) {
-        return btcAddress.payload; // { address: "xxx" }
-    }
-}
 ```
 
-For more examples see [TrezorConnect API documentation](../../docs/packages/connect/methods.md)
+Inline
 
-## NPM publish:
-
-[Follow instructions](../../docs/releases/npm-packages.md) how to publish @trezor package to npm registry.
-
-## Dev
-
-It is possible to run local dev server with iframe and popup using:
-
-`yarn workspace @trezor/connect-web dev`
-
-Note: don't forget to visit `https://localhost:8088/` and allow self-signed certificate. No UI is displayed here.
-
-With dev server running, you may initialize TrezorConnect like this
-
-```js
-import TrezorConnect from '@trezor/connect-web';
-
-const connectOptions = {
-    connectSrc: 'https://localhost:8088/',
-    manifest: {
-        email: 'info@trezor.io',
-        appUrl: '@trezor/suite',
-    },
-};
+```javascript
+var TrezorConnect = window.TrezorConnect;
 ```
+
+For more instructions [refer to this document](../../docs/packages/connect/index.md)
+
+## Development
+
+-   clone repository: `git clone git@github.com:trezor/trezor-suite.git`
+-   install node_modules: `yarn && yarn build:libs`
+-   It is possible to run local dev server with iframe and popup using: `yarn workspace @trezor/connect-web dev` Note: don't forget to visit `https://localhost:8088/` and allow self-signed certificate. No UI is displayed here.

--- a/packages/connect/README.md
+++ b/packages/connect/README.md
@@ -1,4 +1,6 @@
-# @trezor/connect API version 9.0.0-beta.6
+# @trezor/connect
+
+API version 9.0.0-beta.6
 
 [![Build Status](https://github.com/trezor/trezor-suite/actions/workflows/connect-test.yml/badge.svg)](https://github.com/trezor/trezor-suite/actions/workflows/connect-test.yml)
 [![NPM](https://img.shields.io/npm/v/@trezor/connect.svg)](https://www.npmjs.org/package/@trezor/connect)
@@ -6,9 +8,31 @@
 
 Trezor Connect is a platform for easy integration of Trezor into 3rd party services, as well as into Trezor Suite. It provides an API with functionality to access public keys, sign transactions and authenticate users.
 
-User interface is presented in a secure popup window served from `connect.trezor.io/<version>/popup.html`. To try it out, use [@trezor/connect-explorer](../connect-explorer) hosted [here](https://trezor.github.io/trezor-suite/connect-explorer).
+This package is intended to be used in node.js environment. If you wan't to build a web application please refer to [@trezor/connect-web package](../connect-web/README.md).
 
--   [Integration](https://github.com/trezor/trezor-suite/blob/develop/docs/packages/connect/index.md)
+## Installation
+
+Install library as npm module:
+
+```javascript
+npm install @trezor/connect
+```
+
+or
+
+```javascript
+yarn add @trezor/connect
+```
+
+## Initialization
+
+ES6
+
+```javascript
+import TrezorConnect from '@trezor/connect';
+```
+
+For more instructions [refer to this document](../../docs/packages/connect/index.md)
 
 ## Version 9+ (experimental)
 
@@ -18,17 +42,6 @@ Since version 9 we are adopting a new versioning strategy. With every release, w
 -   B] For those who like to have more control over their dependencies, there will be also a new url created in form of https://connect.trezor.io/9.1../trezor-connect.js. Please note that these endpoints will not receive any further updates including security updates.
 
 Version 9+ will be available as `@trezor/connect` and `@trezor/connect-web` npm packages.
-
-## Step by step release process
-
--   Make sure you have released all [npm dependencies](../../releases/npm-packages.md).
--   Optional: if unsure run `node ./ci/scripts/check-npm-dependencies.js connect`. Please note that this script will report unreleased dependencies even for changes that do not affect runtime (READMEs etc.)
--   bump version in all @trezor/connect\* packages (except plugin packages). `yarn workspace @trezor/connect version:<beta|patch|minor|major>`
--   make sure CHANGELOG files have been updated
--   merge into develop branch
--   from develop branch create a pull requests into branch `release/connect-v9`
--   gitlab: click manual release `@trezor/connect-web` and `@trezor/connect` into npm
--   gitlab: click manual deploy job to connect.trezor.io/9
 
 ## Version 8 (stable)
 


### PR DESCRIPTION
 [f7980f5](https://github.com/trezor/trezor-suite/pull/5984/commits/f7980f57230d223181d0e95bd1a38589da9eedf4)  drafts a github action that:
   - bumps connect packages versions
   - creates npm-release brach and opens PR with a releasechecklist 
   - after this is done autmatically, we can update this branch in case we forgot about something, e.g changelog
   - followup: once we are migrated into github, merging this brach should automatically release into npm?
  
[34fabd7](https://github.com/trezor/trezor-suite/pull/5984/commits/34fabd7c12d7f5e4857538e5a4c47cce03fef88b) updates docs. trying to remove duplicities, moving pieces of text around where I believe they make more sense.
