### PR TITLE
fix(suite): fix form getting filled from uri using wrong units when using sat

### DIFF
--- a/packages/suite/src/hooks/wallet/useSendForm.ts
+++ b/packages/suite/src/hooks/wallet/useSendForm.ts
@@ -268,7 +268,13 @@ export const useSendForm = (props: UseSendFormProps): SendContextValues => {
             const outputIndex = 0;
 
             if (protocol.sendForm.amount) {
-                sendFormUtils.setAmount(outputIndex, protocol.sendForm.amount.toString());
+                const protocolAmount = protocol.sendForm.amount.toString();
+
+                const formattedAmount = areSatsUsed
+                    ? amountToSatoshi(protocolAmount, state.network.decimals)
+                    : protocolAmount;
+
+                sendFormUtils.setAmount(outputIndex, formattedAmount);
             }
             setValue(
                 `outputs[${outputIndex}]`,
@@ -288,6 +294,8 @@ export const useSendForm = (props: UseSendFormProps): SendContextValues => {
         updateContext,
         sendFormUtils,
         composeRequest,
+        areSatsUsed,
+        state.network.decimals,
     ]);
 
     // load draft from reducer


### PR DESCRIPTION


<!--- Provide a general summary of your changes in the Title above -->

## Description

Now the form is filled in sats when using the URI handler

## Related Issue

Resolve https://github.com/trezor/trezor-suite/issues/3004#issuecomment-1211680810

