### PR TITLE
fix(suite): fix bump fee and finalize transaction not working for sats

### DIFF
--- a/packages/suite/src/hooks/wallet/useRbfForm.ts
+++ b/packages/suite/src/hooks/wallet/useRbfForm.ts
@@ -8,6 +8,7 @@ import { Account, WalletAccountTransaction } from '@wallet-types';
 import { FormState, FeeInfo } from '@wallet-types/sendForm';
 import { useFees } from './form/useFees';
 import { useCompose } from './form/useCompose';
+import { useBitcoinAmountUnit } from './useBitcoinAmountUnit';
 
 export type Props = {
     tx: WalletAccountTransaction;
@@ -60,6 +61,9 @@ const useRbfState = ({ tx, finalize, chainedTxs }: Props, currentState: boolean)
         fees: state.wallet.fees,
         transactions: state.wallet.transactions.transactions,
     }));
+
+    const { areSatsDisplayed } = useBitcoinAmountUnit();
+
     // do not calculate if currentState is already set (prevent re-renders)
     if (state.selectedAccount.status !== 'loaded' || !tx.rbfParams || currentState) return;
 
@@ -97,7 +101,7 @@ const useRbfState = ({ tx, finalize, chainedTxs }: Props, currentState: boolean)
         return {
             ...DEFAULT_PAYMENT,
             address: o.address,
-            amount: o.formattedAmount,
+            amount: areSatsDisplayed ? o.amount : o.formattedAmount,
             token: o.token,
         };
     });


### PR DESCRIPTION

<!--- Provide a general summary of your changes in the Title above -->

## Description

Fix for bump fee and finalize transaction not working when sats are used. Potentially fixes more things that haven't been discovered yet, since the `useRbfForm()` hook had incorrect transaction values for transaction in sats
## Related Issue

Resolve https://github.com/trezor/trezor-suite/issues/3004#issuecomment-1211834478

