### PR TITLE
refactor bash ci/ folder

### DIFF
--- a/ci/scripts/check-beta-version.sh
+++ b/ci/scripts/check-beta-version.sh
@@ -2,14 +2,13 @@
 
 VERSION=$(jq -r .version packages/connect/package.json)
 
-[[ "$VERSION" != *"beta"* ]]
 
-if [ $? -eq 0 ]; then
-    echo "Not a beta version, all good."
-    exit 0
 
-else
+if [[ "$VERSION" != *"beta"* ]];
+then
     echo "FAIL! package.json contains beta version!" >&2
-
     exit 1
 fi
+
+echo "Not a beta version, all good."
+exit 0

--- a/ci/scripts/check-package-beta-version.sh
+++ b/ci/scripts/check-package-beta-version.sh
@@ -2,14 +2,11 @@
 
 VERSION=$(jq -r .version package.json)
 
-[[ "$VERSION" != *"beta"* ]]
-
-if [ $? -eq 0 ]; then
-    echo "Not a beta version, all good."
-    exit 0
-
-else
+if [[ "$VERSION" != *"beta"* ]];
+then
     echo "FAIL! package.json contains beta version!" >&2
-
     exit 1
 fi
+
+echo "Not a beta version, all good."
+exit 0

--- a/ci/scripts/check_lockfile.sh
+++ b/ci/scripts/check_lockfile.sh
@@ -11,7 +11,7 @@ CKSUM_AFTER=$(cksum yarn.lock)
 echo "checksum after $CKSUM_AFTER"
 
 
-if [[ $CKSUM_BEFORE != $CKSUM_AFTER ]]; then
+if [[ "$CKSUM_BEFORE" != "$CKSUM_AFTER" ]]; then
   echo "check-lockfile.sh: yarn.lock was modified unexpectedly - terminating"
   exit 1
 fi

--- a/ci/scripts/check_release_commit_messages.sh
+++ b/ci/scripts/check_release_commit_messages.sh
@@ -7,16 +7,16 @@ git fetch origin develop
 # list all commits between HEAD and develop
 for commit in $(git rev-list origin/develop..)
 do
-    message=$(git log -n1 --format=%B $commit)
+    message=$(git log -n1 --format=%B "$commit")
     echo "Checking $commit"
 
     # The commit message must contain either
     # 1. "cherry-picked from [some commit in develop]"
     if [[ $message =~ "(cherry picked from commit" ]]; then
       # remove last ")" and extract commit hash
-      develop_commit=$(echo ${message:0:-1} | tr ' ' '\n' | tail -1)
+      develop_commit=$(echo "${message:0:-1}" | tr ' ' '\n' | tail -1)
       # check if develop really contains this commit hash
-      if [[ $(git branch -a --contains $develop_commit | grep --only-matching "remotes/origin/develop") == "remotes/origin/develop" ]]; then
+      if [[ $(git branch -a --contains "$develop_commit" | grep --only-matching "remotes/origin/develop") == "remotes/origin/develop" ]]; then
         continue
       fi
     fi

--- a/ci/scripts/connect-release.sh
+++ b/ci/scripts/connect-release.sh
@@ -7,7 +7,7 @@ set -e -o pipefail
 # @DESTINATION: required, destination directory (connect major version)
 
 # Validate params
-while [[ "$#" > 0 ]]; do case $1 in
+while [[ "$#" -gt 0 ]]; do case $1 in
     9)
         latest_version="9"
         current_version=$(jq -r .version packages/connect/package.json)
@@ -33,8 +33,8 @@ cp -r packages/connect-web/build/* $tmp_folder/.
 cp -r packages/connect-explorer/build/* $tmp_folder/.
 
 # sync the files to aws
-aws s3 sync --delete --cache-control 'public, max-age=3600' $tmp_folder/ s3://connect.trezor.io/$latest_version/
-aws s3 sync --delete --cache-control 'public, max-age=3600' $tmp_folder/ s3://connect.trezor.io/$current_version/
+aws s3 sync --delete --cache-control 'public, max-age=3600' "$tmp_folder/" "s3://connect.trezor.io/$latest_version/"
+aws s3 sync --delete --cache-control 'public, max-age=3600' "$tmp_folder/" "s3://connect.trezor.io/$current_version/"
 aws cloudfront create-invalidation --distribution-id E3LVNAOGT94E37 --paths '/*'
 
 # cleaning up

--- a/ci/scripts/find_duplicates.sh
+++ b/ci/scripts/find_duplicates.sh
@@ -1,9 +1,10 @@
+#!/usr/bin/env bash
 # this script finds duplicated files in project per provided extension
 
 # $1 should contain path such as ./packages/suite-data/files
 # $2 should contain file extension such as .png
 
-result=$(find $1 -name *$2 ! -path "**/node_modules/*" ! -empty -type f -exec md5sum {} + | sort | uniq -w32 -dD)
+result=$(find "$1" -name "*$2" ! -path "**/node_modules/*" ! -empty -type f -exec md5sum {} + | sort | uniq -w32 -dD)
 
 
 if [ -z "$result" ]
@@ -11,6 +12,6 @@ then
       echo "no duplicates for ${2}"
 else
       echo "duplicates found"
-      echo $result | tr "$2 " "$2\n"
+      echo "$result" | tr "$2 " "$2\n"
       exit 1
 fi

--- a/ci/scripts/outdated.sh
+++ b/ci/scripts/outdated.sh
@@ -5,7 +5,7 @@ number=$(yarn outdated | wc -l)
 
 echo outdated packages treshold $treshold
 
-if [ $number -gt $treshold ]
+if [ "$number" -gt "$treshold" ]
 then
     echo number of outdated packages [$number] is over treshold [$treshold]. consider updating.
     exit 1


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Minor refactoring of all some bash code in `ci/` folder (more PRs incoming for other folders later on)

All these issues are easily detected by shellcheck https://www.shellcheck.net local binary and using shellcheck in pre-commit hooks.

I mainly refactored:
* double quoting to prevent globbing and word splitting https://www.shellcheck.net/wiki/SC2086
* prevent globbing in args https://github.com/koalaman/shellcheck/wiki/SC2035
* Quote the right-hand side of != in [[ ]] to prevent glob matching. https://github.com/koalaman/shellcheck/wiki/SC2053
* Check exit code directly with e.g. 'if mycmd;', not indirectly with $?. https://github.com/koalaman/shellcheck/wiki/SC2181
* Tips depend on target shell and yours is unknown. Add a shebang. https://github.com/koalaman/shellcheck/wiki/SC2148
* > is for string comparisons. Use -gt instead https://github.com/koalaman/shellcheck/wiki/SC2071
... and others

<!--- Describe your changes in detail -->
