### PR TITLE
chore(all): shellcheck disable =~ literal match

### DIFF
--- a/ci/scripts/check_release_commit_messages.sh
+++ b/ci/scripts/check_release_commit_messages.sh
@@ -12,6 +12,7 @@ do
 
     # The commit message must contain either
     # 1. "cherry-picked from [some commit in develop]"
+    # shellcheck disable=SC2076
     if [[ $message =~ "(cherry picked from commit" ]]; then
       # remove last ")" and extract commit hash
       develop_commit=$(echo ${message:0:-1} | tr ' ' '\n' | tail -1)
@@ -22,6 +23,7 @@ do
     fi
 
     # 2. [RELEASE ONLY] substring
+    # shellcheck disable=SC2076
     if [[ $message =~ "[RELEASE ONLY]" ]]; then
       continue
     fi


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Don't quote rhs of =~, it'll match literally rather than as a regex.
https://www.shellcheck.net/wiki/SC2076

We have two options here:
1. rewrite `[[ $message =~ "[RELEASE ONLY]" ]]` -> `[[ $message == *"[RELEASE ONLY]"* ]]`
2. ignore this check inline in the code 

I'd go with 2. (as I did in this PR) 

I could also add some reasoning inline in the code to explain why we ignore this lint rule

<!--- Describe your changes in detail -->

## Related Issue

Resolve <!--- link the issue here -->

## Screenshots (if appropriate):
