### PR TITLE
Feat/intercept requests

### DIFF
--- a/packages/request-manager/src/index.ts
+++ b/packages/request-manager/src/index.ts
@@ -1,1 +1,3 @@
 export { TorController } from './controller';
+export { createInterceptor } from './interceptor';
+export type { InterceptedEvent } from './types';

--- a/packages/request-manager/src/interceptor.ts
+++ b/packages/request-manager/src/interceptor.ts
@@ -1,0 +1,74 @@
+import net from 'net';
+import http from 'http';
+import https from 'https';
+import tls from 'tls';
+import { InterceptedEvent } from './types';
+
+type Listener = (event: InterceptedEvent) => void;
+
+const interceptNetSocketConnect = (listener: Listener) => {
+    const originalSocketConnect = net.Socket.prototype.connect;
+
+    net.Socket.prototype.connect = function (options: any, connectionListener: any) {
+        let details;
+        if (Array.isArray(options) && options.length > 0 && options[0].href) {
+            // When websockets in clearnet options contains array where first element is networkOptions.
+            details = options[0].href;
+        } else if (typeof options === 'object' && options.host && options.port) {
+            // When Tor is used options is object with host and port that is used to connect to SocksPort.
+            details = `${options.host}:${options.port}`;
+        } else if (typeof options === 'number') {
+            // When stablishing conneciton to Tor control port `connectionListener` is Tor control port and
+            // `options` is Tor control port host, most likely 127.0.0.1.
+            details = `${connectionListener}:${options}`;
+        }
+
+        listener({
+            method: 'net.Socket.connect',
+            details,
+        });
+        return originalSocketConnect.call(this, options, connectionListener);
+    };
+};
+
+const interceptNetConnect = (listener: Listener) => {
+    const originalConnect = net.connect;
+    net.connect = (connectArguments, connectionListener) => {
+        listener({ method: 'net.connect', details: (connectArguments as any).host });
+        return originalConnect.call(this, connectArguments as any, connectionListener as any);
+    };
+};
+
+const interceptHttp = (listener: Listener) => {
+    const originalHttpRequest = http.request;
+
+    http.request = function (options: any, callback) {
+        listener({ method: 'http.request', details: options.href });
+        return originalHttpRequest.call(this, options, callback as any);
+    };
+};
+
+const interceptHttps = (listener: Listener) => {
+    const originalHttpsRequest = https.request;
+    https.request = function (options: any, callback) {
+        listener({ method: 'https.request', details: options.href });
+        return originalHttpsRequest.call(this, options, callback as any);
+    };
+};
+
+const interceptTlsConnect = (listener: Listener) => {
+    const orginalTlsConnect = tls.connect;
+
+    tls.connect = function (options: any, secureConnectListener) {
+        listener({ method: 'tls.connect', details: options.servername });
+        return orginalTlsConnect.call(this, options as any, secureConnectListener as any);
+    };
+};
+
+export const createInterceptor = (listener: Listener) => {
+    interceptNetSocketConnect(listener);
+    interceptNetConnect(listener);
+    interceptHttp(listener);
+    interceptHttps(listener);
+    interceptTlsConnect(listener);
+};

--- a/packages/request-manager/src/types.ts
+++ b/packages/request-manager/src/types.ts
@@ -9,3 +9,8 @@ export type BootstrapEvent = {
     progress: string | undefined;
     summary: string | undefined;
 };
+
+export interface InterceptedEvent {
+    method: string;
+    details: string;
+}

--- a/packages/suite-desktop/src-electron/modules/index.ts
+++ b/packages/suite-desktop/src-electron/modules/index.ts
@@ -30,6 +30,7 @@ const MODULES = [
     'user-data',
     'trezor-connect-ipc',
     'dev-tools',
+    'request-logger',
     // Modules used only in dev/prod mode
     ...(isDev ? [] : ['csp', 'file-protocol']),
 ];

--- a/packages/suite-desktop/src-electron/modules/request-logger.ts
+++ b/packages/suite-desktop/src-electron/modules/request-logger.ts
@@ -1,0 +1,21 @@
+/**
+ * Request Logger (logs intercepted requests from electron main processs)
+ *
+ * Differences from request-filter module is that it logs all requests from electron nodejs main process,
+ * whereas request-filter only logs requests from electron renderer process and it also filters allowed requests.
+ */
+import { createInterceptor, InterceptedEvent } from '@trezor/request-manager';
+import { Module } from './index';
+
+const init: Module = () => {
+    const { logger } = global;
+
+    // NodeJS interceptor of the main process network requests.
+    createInterceptor((event: InterceptedEvent) => {
+        if (event.method && event.details) {
+            logger.debug('request-logger', `${event.method} - ${event.details}`);
+        }
+    });
+};
+
+export default init;


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
Interceptor that wraps all the network connection methods from nodejs that allows to see all the requests that are generated from electron nodejs main process.

## Description

<!--- Describe your changes in detail -->
* c38ddf59b4d8a8d41aafd42615dca5d08ff25de5 - extends package request-manager with an interceptor that wraps all the network connect methods from nodejs and does not modify any thing, it only provides some information to the listener.
* 367f842ccfc3eff5fded67a27b4c83a4297249c6 -  new module `request-logger` that allows us to log most of the requests that are happening in the electron main process.

There are still requests like the one happening for auto-update that is not logged here.

## Related Issue
https://github.com/trezor/trezor-suite/issues/5527
