### PR TITLE
fix(suite): improve label expansion

### DIFF
--- a/packages/suite/src/components/suite/Labeling/components/Metadata/index.tsx
+++ b/packages/suite/src/components/suite/Labeling/components/Metadata/index.tsx
@@ -13,23 +13,27 @@ import { withDropdown } from './withDropdown';
 
 import type { Timeout } from '@trezor/type-utils';
 
-const LabelDefaultValue = styled.div`
-    width: 0;
-    display: inline-block;
-    transition: width 0.6s, visibility 0.3s, opacity 0.3s;
-    visibility: hidden;
-    opacity: 0;
-
-    &::before {
-        content: ': ';
-    }
-`;
-
 const LabelValue = styled.div`
-    display: inline-block;
     overflow: hidden;
     text-overflow: ellipsis;
-    padding-left: 1px;
+`;
+
+const LabelDefaultValue = styled(LabelValue)`
+    /* do not shrink when the expanded label does not fit the contener - shrink only the label value */
+    flex-shrink: 0;
+    max-width: 0;
+    /* transition max-width because it does not work with auto value */
+    transition: max-width 0.25s, opacity 0.25s;
+    transition-timing-function: ease-out;
+    opacity: 0;
+
+    ::before {
+        content: '|';
+        font-size: 14px;
+        line-height: 12px;
+        margin: 0 6px;
+        opacity: 0.25;
+    }
 `;
 
 const Label = styled.div`
@@ -41,8 +45,6 @@ const Label = styled.div`
 `;
 
 const LabelButton = styled(Button)`
-    justify-content: flex-start;
-    text-align: left;
     overflow: hidden;
 `;
 
@@ -59,7 +61,7 @@ const SuccessButton = styled(Button)`
     margin-left: 14px;
     background-color: ${props => props.theme.BG_LIGHT_GREEN};
     color: ${props => props.theme.BG_GREEN};
-    &:hover {
+    :hover {
         color: ${props => props.theme.BG_GREEN};
         background-color: ${props => props.theme.BG_LIGHT_GREEN};
     }
@@ -72,16 +74,17 @@ const LabelContainer = styled.div`
     justify-content: flex-start;
     overflow: hidden;
 
-    &:hover {
+    :hover {
         ${ActionButton} {
             visibility: visible;
             width: auto;
         }
 
         ${LabelDefaultValue} {
-            width: 200px;
-            visibility: visible;
+            max-width: 300px;
             opacity: 1;
+            /* the right side of the transition process cannot be reliably animated because we animate max-width while the width can vary  */
+            transition-timing-function: ease-in;
         }
     }
 `;
@@ -116,13 +119,11 @@ const ButtonLikeLabel = (props: ExtendedProps) => {
     if (props.payload.value) {
         return (
             <LabelButton variant="tertiary" icon="TAG" data-test={props['data-test']}>
-                <LabelValue>
-                    {props.payload.value}
-                    {props.defaultVisibleValue && (
-                        <LabelDefaultValue>{props.defaultVisibleValue}</LabelDefaultValue>
-                    )}
-                </LabelValue>
-                {/* This is the defaultVisibleValue which shows up after you hover over the label name */}
+                <LabelValue>{props.payload.value} </LabelValue>
+                {/* This is the defaultVisibleValue which shows up after you hover over the label name: */}
+                {props.defaultVisibleValue && (
+                    <LabelDefaultValue>{props.defaultVisibleValue}</LabelDefaultValue>
+                )}
             </LabelButton>
         );
     }
@@ -201,7 +202,7 @@ const getLocalizedActions = (type: MetadataAddPayload['type']) => {
  * - This component shows defaultVisibleValue and "Add label" button if no metadata is present.
  * - Otherwise it shows metadata value and provides way to edit it.
  */
-const MetadataLabeling = (props: Props) => {
+export const MetadataLabeling = (props: Props) => {
     const metadata = useSelector(state => state.metadata);
     const { isDiscoveryRunning, device } = useDiscovery();
     const [showSuccess, setShowSuccess] = useState(false);
@@ -395,5 +396,3 @@ const MetadataLabeling = (props: Props) => {
         </LabelContainer>
     );
 };
-
-export default MetadataLabeling;

--- a/packages/suite/src/components/suite/Labeling/index.tsx
+++ b/packages/suite/src/components/suite/Labeling/index.tsx
@@ -3,6 +3,6 @@ import { AccountLabeling } from './components/AccountLabeling';
 import { AddressLabeling } from './components/AddressLabeling';
 import { WalletLabeling } from './components/WalletLabeling';
 // "User defined labeling"
-import MetadataLabeling from './components/Metadata';
+import { MetadataLabeling } from './components/Metadata';
 
 export { AccountLabeling, AddressLabeling, WalletLabeling, MetadataLabeling };


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
Improves label expansion when default value (typically address) exists.
## Description
Css `transition` does not work on value `auto`, but we want the label expand to the width of the contents. Otherwise, there are various problems as shown in the screenshot below. The solution is to apply the transition to `max-width` instead.
<!--- Describe your changes in detail -->

## Screenshots:

Before:
![label before](https://user-images.githubusercontent.com/42465546/184890048-5280cd45-ea4b-40e1-ad48-cfe9ad560d6f.gif)

After:
![label after](https://user-images.githubusercontent.com/42465546/184890031-7a7f3601-3857-4a48-b906-831b60fa6228.gif)

**QA**: Please check that labels have correct styles in the whole app.
