### PR TITLE
feat: Tor configuration from request-manager

### DIFF
--- a/packages/request-manager/src/controller.ts
+++ b/packages/request-manager/src/controller.ts
@@ -1,4 +1,5 @@
 import { EventEmitter } from 'events';
+import path from 'path';
 
 import { createTimeoutPromise } from '@trezor/utils';
 
@@ -19,6 +20,46 @@ export class TorController extends EventEmitter {
         this.options = options;
         this.torIsDisabledWhileStarting = false;
         this.controlPort = new TorControlPort(options, this.onMessageReceived.bind(this));
+    }
+
+    getTorConfiguration(processId: number): string[] {
+        const controlAuthCookiePath = path.join(this.options.authFilePath, 'control_auth_cookie');
+        return [
+            // Try to write to disk less frequently than we would otherwise.
+            '--AvoidDiskWrites',
+            '1',
+            // Send all messages between minSeverity and maxSeverity to the standard output stream.
+            'Log',
+            'notice stdout',
+            // It should treat a startup event as cancelling any previous dormant state.
+            // use this option with caution: it should only be used if Tor is being started because
+            // of something that the user did, and not if Tor is being automatically started in the background.
+            '--DormantCanceledByStartup',
+            '1',
+            // Open this port to listen for connections from SOCKS-speaking applications.
+            '--SocksPort',
+            `${this.options.port}`,
+            // The port on which Tor will listen for local connections from Tor controller applications.
+            '--ControlPort',
+            `${this.options.controlPort}`,
+            // Setting CookieAuthentication will make Tor write an authentication cookie.
+            '--CookieAuthentication',
+            '1',
+            // If the 'CookieAuthentication' option is true, Tor writes a "magic
+            // cookie" file named "control_auth_cookie" into its data directory (or
+            // to another file specified in the 'CookieAuthFile' option)
+            // To authenticate, the controller must demonstrate that it can read the
+            // contents of the cookie file:
+            '--CookieAuthFile',
+            `${controlAuthCookiePath}`,
+            // Tor will periodically check whether a process with the specified PID exists, and exit if one does not.
+            // Once the controller has connected to Tor's control port, it should send the TAKEOWNERSHIP command along its control
+            // connection. At this point, *both* the TAKEOWNERSHIP command and the __OwningControllerProcess option are in effect:
+            // Tor will exit when the control connection ends *and* Tor will exit if it detects that there is no process with
+            // the PID specified in the __OwningControllerProcess option.
+            '__OwningControllerProcess',
+            `${processId}`,
+        ];
     }
 
     onMessageReceived(message: string) {

--- a/packages/suite-desktop/src-electron/libs/processes/TorProcess.ts
+++ b/packages/suite-desktop/src-electron/libs/processes/TorProcess.ts
@@ -1,4 +1,3 @@
-import path from 'path';
 import BaseProcess, { Status } from './BaseProcess';
 
 import { TorController } from '@trezor/request-manager';
@@ -54,44 +53,10 @@ class TorProcess extends BaseProcess {
     }
 
     async start(): Promise<void> {
-        const controlAuthCookiePath = path.join(this.authFilePath, 'control_auth_cookie');
         const electronProcessId = process.pid;
-        await super.start([
-            // Try to write to disk less frequently than we would otherwise.
-            '--AvoidDiskWrites',
-            '1',
-            // Send all messages between minSeverity and maxSeverity to the standard output stream.
-            'Log',
-            'notice stdout',
-            // It should treat a startup event as cancelling any previous dormant state.
-            // use this option with caution: it should only be used if Tor is being started because
-            // of something that the user did, and not if Tor is being automatically started in the background.
-            '--DormantCanceledByStartup',
-            '1',
-            // Open this port to listen for connections from SOCKS-speaking applications.
-            '--SocksPort',
-            `${this.port}`,
-            // The port on which Tor will listen for local connections from Tor controller applications.
-            '--ControlPort',
-            `${this.controlPort}`,
-            // Setting CookieAuthentication will make Tor write an authentication cookie.
-            '--CookieAuthentication',
-            '1',
-            // If the 'CookieAuthentication' option is true, Tor writes a "magic
-            // cookie" file named "control_auth_cookie" into its data directory (or
-            // to another file specified in the 'CookieAuthFile' option)
-            // To authenticate, the controller must demonstrate that it can read the
-            // contents of the cookie file:
-            '--CookieAuthFile',
-            `${controlAuthCookiePath}`,
-            // Tor will periodically check whether a process with the specified PID exists, and exit if one does not.
-            // Once the controller has connected to Tor's control port, it should send the TAKEOWNERSHIP command along its control
-            // connection. At this point, *both* the TAKEOWNERSHIP command and the __OwningControllerProcess option are in effect:
-            // Tor will exit when the control connection ends *and* Tor will exit if it detects that there is no process with
-            // the PID specified in the __OwningControllerProcess option.
-            '__OwningControllerProcess',
-            `${electronProcessId}`,
-        ]);
+        const torConfiguration = this.torController.getTorConfiguration(electronProcessId);
+
+        await super.start(torConfiguration);
         return this.torController.waitUntilAlive();
     }
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
Moving Tor configuration to request-manager package

## Description
Moving Tor configuration to request-manager package because it is the responsible of Tor and it is expecting some specific configurations to work properly so it makes sense to have those configuration provided by the package.

And then these configuration provider can be used for tests of request-manager without that much code duplication.