### PR TITLE
chore(lint): add custom rules for selectors

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -1,3 +1,6 @@
+// eslint-disable-next-line import/no-extraneous-dependencies, import/extensions
+const { rules: airbnbRules } = require('eslint-config-airbnb-base/rules/style.js');
+
 module.exports = {
     root: true,
     parser: '@typescript-eslint/parser',
@@ -182,6 +185,32 @@ module.exports = {
                 paths: [{ name: '.' }, { name: '..' }, { name: '../..' }],
             },
         ],
+        'no-restricted-syntax': [
+            ...airbnbRules['no-restricted-syntax'],
+            {
+                message:
+                    "Please don't use createAsyncThunk. Use createThunk from @suite-common/redux-utils instead.",
+                selector: "CallExpression[callee.name='createAsyncThunk']",
+            },
+            {
+                message:
+                    'Please don\'t use getState directly. Always use strongly typed selector, because geState is typed as "any" and it\'s dangerous to use it directly.',
+                selector:
+                    'MemberExpression[property.type="Identifier"]:matches([object.callee.name="getState"])',
+            },
+            {
+                message:
+                    'Do not assign "getState" directly. Always use strongly typed selector, because geState is typed as "any" and it\'s dangerous to use it directly.',
+                selector:
+                    "VariableDeclarator[init.type='CallExpression']:matches([init.callee.name='getState'])",
+            },
+            {
+                message:
+                    'Please don\'t use "state" directly because it\'s typed as "any". Always use it only as parameter for strongly typed selector function.',
+                selector:
+                    "CallExpression[callee.name='useSelector'] MemberExpression[object.type='Identifier']:matches([property.type='Identifier'])",
+            },
+        ],
     },
     overrides: [
         {
@@ -236,6 +265,7 @@ module.exports = {
                 'react/jsx-no-undef': 'off',
                 'no-catch-shadow': 'off',
                 '@typescript-eslint/no-restricted-imports': 'off',
+                'no-restricted-syntax': airbnbRules['no-restricted-syntax'],
             },
         },
     ],

--- a/suite-common/connect-init/package.json
+++ b/suite-common/connect-init/package.json
@@ -14,6 +14,7 @@
     },
     "dependencies": {
         "@reduxjs/toolkit": "^1.8.3",
+        "@suite-common/redux-utils": "*",
         "@suite-native/state": "*",
         "@trezor/connect": "9.0.0-beta.6",
         "@trezor/utils": "*"

--- a/suite-common/connect-init/src/slice.ts
+++ b/suite-common/connect-init/src/slice.ts
@@ -1,9 +1,4 @@
-import {
-    ActionCreatorWithoutPayload,
-    ActionCreatorWithPayload,
-    AnyAction,
-    createAsyncThunk,
-} from '@reduxjs/toolkit';
+import { ActionCreatorWithoutPayload, ActionCreatorWithPayload, AnyAction } from '@reduxjs/toolkit';
 
 import TrezorConnect, {
     BLOCKCHAIN_EVENT,
@@ -13,6 +8,7 @@ import TrezorConnect, {
     TRANSPORT_EVENT,
     UI_EVENT,
 } from '@trezor/connect';
+import { createThunk } from '@suite-common/redux-utils';
 
 import { cardanoConnectPatch } from './cardanoConnectPatch';
 
@@ -37,13 +33,7 @@ export const prepareConnectInitThunk = ({
     };
     initSettings: { manifest: Manifest } & Partial<ConnectSettings>;
 }) =>
-    createAsyncThunk<
-        void,
-        void,
-        {
-            state: any;
-        }
-    >(CONNECT_INIT_ACTION_TYPE, async (_, { dispatch, getState }) => {
+    createThunk(CONNECT_INIT_ACTION_TYPE, async (_, { dispatch, getState }) => {
         const { selectEnabledNetworks, selectIsPendingTransportEvent } = selectors;
         const { lockDevice } = actions;
 

--- a/suite-common/connect-init/tsconfig.json
+++ b/suite-common/connect-init/tsconfig.json
@@ -2,6 +2,7 @@
     "extends": "../../tsconfig.json",
     "compilerOptions": { "outDir": "libDev" },
     "references": [
+        { "path": "../redux-utils" },
         { "path": "../../suite-native/state" },
         { "path": "../../packages/connect" },
         { "path": "../../packages/utils" }

--- a/suite-common/redux-utils/src/createThunk.ts
+++ b/suite-common/redux-utils/src/createThunk.ts
@@ -1,4 +1,8 @@
-import { AsyncThunkOptions, AsyncThunkPayloadCreator, createAsyncThunk } from '@reduxjs/toolkit';
+import {
+    AsyncThunkOptions,
+    AsyncThunkPayloadCreator,
+    createAsyncThunk as createAsyncThunkReduxToolkit,
+} from '@reduxjs/toolkit';
 
 import { ExtraDependencies } from './extraDependenciesType';
 
@@ -6,4 +10,4 @@ export const createThunk = <TPayload = void, TReturn = void>(
     typePrefix: string,
     thunk: AsyncThunkPayloadCreator<TReturn, TPayload, { state: any; extra: ExtraDependencies }>,
     options?: AsyncThunkOptions<TPayload>,
-) => createAsyncThunk(typePrefix, thunk, options);
+) => createAsyncThunkReduxToolkit(typePrefix, thunk, options);


### PR DESCRIPTION
Few custom rules that will prevent dangerous mistakes while using getState and selectors in new packages.