### PR TITLE
chore(lint): enforce usage of @ts-expect-error

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -37,6 +37,7 @@ module.exports = {
         'packages/transport/scripts/protobuf-patches/*',
     ],
     rules: {
+        '@typescript-eslint/prefer-ts-expect-error': 'error',
         // I believe type is enforced by callers.
         '@typescript-eslint/explicit-function-return-type': 'off',
         // Enforce arrow functions only is afaik not possible. But this helps.

--- a/packages/analytics/src/tests/analytics.test.ts
+++ b/packages/analytics/src/tests/analytics.test.ts
@@ -8,7 +8,7 @@ describe('analytics', () => {
             json: () => Promise.resolve({}),
         });
         global.fetch = jest.fn().mockImplementation(() => mockFetchPromise);
-        // @ts-ignore
+        // @ts-expect-error
         jest.spyOn(global, 'fetch').mockImplementation(() => mockFetchPromise);
 
         const timestamp = new Date().getTime();

--- a/packages/blockchain-link/src/utils/ws-native.ts
+++ b/packages/blockchain-link/src/utils/ws-native.ts
@@ -16,7 +16,7 @@ class WSWrapper extends EventEmitter {
         this.setMaxListeners(Infinity);
 
         // React Native WebSocket is able to accept headers compared to the native browser `WebSocket`.
-        // @ts-ignore
+        // @ts-expect-error
         this._ws = new WebSocket(url, '', {
             headers: {
                 'User-Agent': 'Trezor Suite Native',

--- a/packages/blockchain-link/src/workers/electrum/index.ts
+++ b/packages/blockchain-link/src/workers/electrum/index.ts
@@ -118,9 +118,9 @@ const onRequest = async <T extends Message>(
                 default:
                     throw new CustomError(`Subscription ${request.payload.type} not implemented`);
             }
-        // @ts-ignore this message is used in tests
+        // @ts-expect-error this message is used in tests
         case 'raw':
-            // @ts-ignore
+            // @ts-expect-error
             // eslint-disable-next-line
             const { method, params } = request.payload;
             return client

--- a/packages/blockchain-link/tests/unit/workers.ts
+++ b/packages/blockchain-link/tests/unit/workers.ts
@@ -6,7 +6,7 @@ class BaseMockWorker {
     onmessage(_data: any) {}
     postMessage(_data: any) {}
     terminate() {
-        // @ts-ignore
+        // @ts-expect-error
         global.Worker = undefined;
     }
     onmessageerror() {}

--- a/packages/connect-explorer/src/actions/docsActions.ts
+++ b/packages/connect-explorer/src/actions/docsActions.ts
@@ -58,7 +58,7 @@ export const loadDocs = () => async (dispatch: Dispatch, getState: GetState) => 
     const response = await fetch(url, { credentials: 'same-origin' });
     if (response.ok) {
         const content = await response.text();
-        // @ts-ignore
+        // @ts-expect-error
         const markdown = new Markdown({
             replaceLink: (link: any, _env: any) => `${GITHUB}${link}`,
         });

--- a/packages/connect-explorer/src/actions/methodActions.ts
+++ b/packages/connect-explorer/src/actions/methodActions.ts
@@ -61,7 +61,6 @@ export const onSubmit = () => async (dispatch: Dispatch, getState: GetState) => 
     const { method } = getState();
     if (!method?.name) throw new Error('method name not specified');
 
-    // @ts-ignore method name is string. can't be used to index TrezorConnect
     const connectMethod = TrezorConnect[method.name];
     if (typeof connectMethod !== 'function') {
         dispatch(
@@ -99,9 +98,7 @@ export const onVerify = () => (dispatch: Dispatch, getState: GetState) => {
 
     const verifyMethod = getState().method;
     verifyMethod?.fields.forEach((f: any) => {
-        // @ts-ignore
         if (verifyMethodValues[f.name]) {
-            // @ts-ignore
             dispatch(onFieldChange(f, verifyMethodValues[f.name]));
         }
     });

--- a/packages/connect-explorer/src/reducers/methodReducer.ts
+++ b/packages/connect-explorer/src/reducers/methodReducer.ts
@@ -151,7 +151,7 @@ const setAffectedValues = (state: MethodState, field: any) => {
     } else if (field.affect && typeof field.affect === 'string' && field.value) {
         const affectedField = state.fields.find(f => f.name === field.affect);
         if (affectedField) {
-            // @ts-ignore todo: what is this?
+            // @ts-expect-error todo: what is this?
             affectedField.value = field.value;
         }
     }

--- a/packages/connect-explorer/src/store/index.ts
+++ b/packages/connect-explorer/src/store/index.ts
@@ -21,7 +21,7 @@ if (process.env.NODE_ENV === 'development') {
         collapsed: true,
     });
 
-    // @ts-ignore
+    // @ts-expect-error
     const { devToolsExtension } = window;
     if (typeof devToolsExtension === 'function') {
         enhancers.push(devToolsExtension());

--- a/packages/connect-explorer/webpack/dev.webpack.config.ts
+++ b/packages/connect-explorer/webpack/dev.webpack.config.ts
@@ -3,9 +3,7 @@ import path from 'path';
 import { merge } from 'webpack-merge';
 import { WebpackPluginServe } from 'webpack-plugin-serve';
 
-// @ts-ignore todo: https://github.com/trezor/trezor-suite/issues/5305
 import popup from '../../connect-popup/webpack/prod.webpack.config';
-// @ts-ignore todo: https://github.com/trezor/trezor-suite/issues/5305
 import iframe from '../../connect-iframe/webpack/prod.webpack.config';
 import prod from './prod.webpack.config';
 

--- a/packages/connect-plugin-ethereum/__tests__/index.test.ts
+++ b/packages/connect-plugin-ethereum/__tests__/index.test.ts
@@ -1,5 +1,6 @@
 /* eslint-disable camelcase */
 
+// eslint-disable-next-line @typescript-eslint/prefer-ts-expect-error
 // @ts-ignore
 import commonFixtures from '../../../submodules/trezor-common/tests/fixtures/ethereum/sign_typed_data.json';
 import { transformTypedData } from '../src/index';
@@ -16,7 +17,6 @@ describe('typedData', () => {
         .forEach((test: any) => {
             it('typedData to message_hash and domain_separator_hash', () => {
                 const transformed = transformTypedData(
-                    // @ts-ignore JSON..
                     test.parameters.data,
                     test.parameters.metamask_v4_compat,
                 );

--- a/packages/connect-web/src/iframe/index.ts
+++ b/packages/connect-web/src/iframe/index.ts
@@ -47,9 +47,9 @@ const injectStyleSheet = () => {
     style.setAttribute('type', 'text/css');
     style.setAttribute('id', 'TrezorConnectStylesheet');
 
-    // @ts-ignore
+    // @ts-expect-error
     if (style.styleSheet) {
-        // @ts-ignore
+        // @ts-expect-error
         style.styleSheet.cssText = css;
         head.appendChild(style);
     } else {
@@ -138,9 +138,9 @@ export const init = async (settings: ConnectSettings) => {
     };
 
     // IE hack
-    // @ts-ignore
+    // @ts-expect-error
     if (instance.attachEvent) {
-        // @ts-ignore
+        // @ts-expect-error
         instance.attachEvent('onload', onLoad);
     } else {
         instance.onload = onLoad;

--- a/packages/connect-web/src/popup/index.ts
+++ b/packages/connect-web/src/popup/index.ts
@@ -319,7 +319,7 @@ export class PopupManager extends EventEmitter {
 
         if (this._window) {
             if (this.settings.env === 'webextension') {
-                // @ts-ignore
+                // @ts-expect-error
                 let _e = chrome.runtime.lastError;
 
                 chrome.tabs.remove(this._window.id, () => {

--- a/packages/connect/src/api/ethereum/__fixtures__/ethereumSignTypedData.ts
+++ b/packages/connect/src/api/ethereum/__fixtures__/ethereumSignTypedData.ts
@@ -1,3 +1,4 @@
+/* eslint-disable @typescript-eslint/prefer-ts-expect-error */
 import BigNumber from 'bignumber.js';
 import { TrezorError } from '../../../constants/errors';
 import { PROTO } from '../../../constants';

--- a/packages/connect/src/utils/__tests__/firmwareUtils.test.ts
+++ b/packages/connect/src/utils/__tests__/firmwareUtils.test.ts
@@ -30,7 +30,7 @@ describe('parse', () => {
     describe('isStrictFeatures()', () => {
         it('fail on not matching pattern', () => {
             expect(
-                // @ts-ignore
+                // @ts-expect-error
                 isStrictFeatures({ foo: 'bar' }),
             ).toEqual(false);
         });
@@ -38,10 +38,7 @@ describe('parse', () => {
 
     describe('isValidReleases()', () => {
         it('fail on not matching pattern', () => {
-            expect(
-                // @ts-ignore
-                isValidReleases({ foo: 'bar' }),
-            ).toEqual(false);
+            expect(isValidReleases({ foo: 'bar' })).toEqual(false);
         });
     });
 });

--- a/packages/integration-tests/projects/connect/__fixtures__/cardanoGetAddressDerivations.ts
+++ b/packages/integration-tests/projects/connect/__fixtures__/cardanoGetAddressDerivations.ts
@@ -11,12 +11,12 @@ export default {
         description: name,
         params: {
             addressParameters: {
-                // @ts-ignore loading untyped json
+                // @ts-expect-error loading untyped json
                 addressType: CardanoAddressType[parameters.address_type.toUpperCase()],
                 path: parameters.path,
                 stakingPath: parameters.staking_path,
             },
-            // @ts-ignore loading untyped json
+            // @ts-expect-error loading untyped json
             derivationType: CardanoDerivationType[parameters.derivation_type],
             networkId: parameters.network_id,
             protocolMagic: parameters.protocol_magic,

--- a/packages/integration-tests/projects/connect/tests/api/init.test.ts
+++ b/packages/integration-tests/projects/connect/tests/api/init.test.ts
@@ -12,7 +12,7 @@ describe('TrezorConnect.init', () => {
 
     beforeAll(() => {
         // use local build, not trezor connect version hosted on trezor.connect.io
-        // @ts-ignore
+        // @ts-expect-error
         global.__TREZOR_CONNECT_SRC = process.env.TREZOR_CONNECT_SRC;
     });
 

--- a/packages/integration-tests/projects/connect/tests/device/methods.test.ts
+++ b/packages/integration-tests/projects/connect/tests/device/methods.test.ts
@@ -80,7 +80,7 @@ describe(`TrezorConnect methods`, () => {
                         await setup(controller, t.setup || testCase.setup);
 
                         controller.options.name = t.description;
-                        // @ts-ignore, string + params union
+                        // @ts-expect-error, string + params union
                         const result = await TrezorConnect[testCase.method](t.params);
                         let expected = t.result
                             ? { success: true, payload: t.result }

--- a/packages/integration-tests/projects/suite-web/stubs/metadata.ts
+++ b/packages/integration-tests/projects/suite-web/stubs/metadata.ts
@@ -2,9 +2,9 @@
 // Cypress can't touch other windows/tabs it so what we do here is that we replace implementation
 // of window.open to invoke only postMessage with data that satisfy application flow
 export const stubOpen = (win: Window) => {
-    // @ts-ignore
+    // @ts-expect-error
     win.Math.random = () => 0.4; // to make tests deterministic, this value ensures state YYYYYYYYYYYYYYYYYYYYYYYYYYYYYY
-    // @ts-ignore
+    // @ts-expect-error
     return () =>
         win.postMessage({ search: '?code=chicken-cho-cha&state=YYYYYYYYYY', key: 'trezor-oauth' });
 };

--- a/packages/integration-tests/wait-for-env.ts
+++ b/packages/integration-tests/wait-for-env.ts
@@ -84,9 +84,9 @@ const wait = async () => {
 
 // consume all unexpected outputs so that they do not go to stdout
 Object.keys(console).forEach(k => {
-    // @ts-ignore
+    // @ts-expect-error
     if (typeof console[k] === 'function') {
-        // @ts-ignore
+        // @ts-expect-error
         console[k] = () => {};
     }
 });

--- a/packages/react-utils/src/hooks/useAsyncDebounce.ts
+++ b/packages/react-utils/src/hooks/useAsyncDebounce.ts
@@ -15,9 +15,7 @@ export const useAsyncDebounce = () => {
             if (timeout.current) clearTimeout(timeout.current);
             // set new timeout
             const timeoutDfd = createDeferred();
-            // @ts-ignore needed with @types/react-native 0.63.45, could be a bug
             const newTimeout = setTimeout(timeoutDfd.resolve, 300);
-            // @ts-ignore needed with @types/react-native 0.63.45, could be a bug
             timeout.current = newTimeout;
             await timeoutDfd.promise;
 

--- a/packages/suite-build/configs/base.webpack.config.ts
+++ b/packages/suite-build/configs/base.webpack.config.ts
@@ -182,7 +182,6 @@ const config: webpack.Configuration = {
                   }),
               ]
             : []),
-        // @ts-ignore - @sentry/webpack-plugin types depends on @types/webpack@4
         ...(!isDev && sentryAuthToken
             ? [
                   new SentryWebpackPlugin({

--- a/packages/suite-build/webpack.config.ts
+++ b/packages/suite-build/webpack.config.ts
@@ -26,7 +26,7 @@ switch (project) {
 }
 
 // Prevent "webpack: TypeError: Do not know how to serialize a BigInt"
-// @ts-ignore
+// @ts-expect-error
 BigInt.prototype.toJSON = function toJSON() {
     return this.toString();
 };

--- a/packages/suite-data/src/translations/backport-en.ts
+++ b/packages/suite-data/src/translations/backport-en.ts
@@ -25,12 +25,10 @@ const source: { [key in keyof typeof messages]: string } = JSON.parse(
 );
 
 Object.entries(source).forEach(([key, value]) => {
-    // @ts-ignore
     if (!messages[key]) {
         return;
     }
 
-    // @ts-ignore remove line break from the end of string. probably translators accident;
     messages[key].defaultMessage = value.replace(/\n$/, '');
 });
 
@@ -40,7 +38,7 @@ fs.writeFileSync(
 import { defineMessages } from 'react-intl';
 
 export default defineMessages(${JSON.stringify(messages, null, 2).replace(/"([^"]+)":/g, '$1:')})
-    
+
 `,
 );
 

--- a/packages/suite-desktop-api/src/__tests__/renderer.test.ts
+++ b/packages/suite-desktop-api/src/__tests__/renderer.test.ts
@@ -17,7 +17,7 @@ describe('Renderer', () => {
     it('api is defined', () => {
         const api = factory(ipcRenderer);
         process.env.SUITE_TYPE = 'desktop';
-        // @ts-ignore
+        // @ts-expect-error
         window.desktopApi = api;
         // getter returns API
         expect(getDesktopApi().available).toBe(true);

--- a/packages/suite-desktop-api/src/renderer.ts
+++ b/packages/suite-desktop-api/src/renderer.ts
@@ -5,7 +5,7 @@ export const getDesktopApi = () => {
     let api: DesktopApi | undefined;
     if (typeof window !== 'undefined' && process.env.SUITE_TYPE === 'desktop') {
         // it's pointless to write type declaration in global.Window since this is the only reference
-        // @ts-ignore
+        // @ts-expect-error
         api = window.desktopApi;
     }
     return api || factory();

--- a/packages/suite-desktop/src-electron/app.ts
+++ b/packages/suite-desktop/src-electron/app.ts
@@ -5,7 +5,8 @@ import { app, BrowserWindow, session } from 'electron';
 import { init as initSentry, ElectronOptions, IPCMode } from '@sentry/electron';
 import { ipcMain } from './typed-electron';
 
-// @ts-ignore TODO fix
+// eslint-disable-next-line @typescript-eslint/prefer-ts-expect-error
+// @ts-ignore
 import { SENTRY_CONFIG } from '@suite-config';
 import { isDev } from '@suite-utils/build';
 import { APP_NAME } from './libs/constants';
@@ -21,7 +22,7 @@ import { hangDetect } from './hang-detect';
 import { createLogger } from './logger';
 import type { HandshakeClient } from '@trezor/suite-desktop-api';
 
-// @ts-ignore using internal electron API to set suite version in dev mode correctly
+// @ts-expect-error using internal electron API to set suite version in dev mode correctly
 if (isDev) app.setVersion(process.env.VERSION);
 
 // Logger

--- a/packages/suite-desktop/src-electron/libs/http-receiver.ts
+++ b/packages/suite-desktop/src-electron/libs/http-receiver.ts
@@ -119,7 +119,7 @@ export class HttpReceiver extends EventEmitter {
     start() {
         return new Promise((resolve, reject) => {
             this.server.on('error', e => {
-                // @ts-ignore - type is missing
+                // @ts-expect-error - type is missing
                 this.logger.error('http-receiver', `Start error code: ${e.code}`);
                 // if (e.code === 'EADDRINUSE') {} // TODO: Try different port if already in use
                 this.server.close();

--- a/packages/suite-desktop/src-electron/modules/event-logging/process.ts
+++ b/packages/suite-desktop/src-electron/modules/event-logging/process.ts
@@ -9,7 +9,7 @@ const init: Module = () => {
 
     process.on('unhandledRejection', e => {
         if (e) {
-            // @ts-ignore type is unknown
+            // @ts-expect-error type is unknown
             logger.warn('rejection', `Unhandled Rejection: ${e?.toString()}`);
         }
     });

--- a/packages/suite-desktop/src-electron/modules/trezor-connect-ipc.ts
+++ b/packages/suite-desktop/src-electron/modules/trezor-connect-ipc.ts
@@ -35,7 +35,7 @@ const init: Module = ({ mainWindow, store }) => {
         async ({ reply }: Electron.IpcMainEvent, [method, responseEvent, ...params]: Call) => {
             logger.debug(SERVICE_NAME, `TrezorConnect.${method}`);
 
-            // @ts-ignore method name union
+            // @ts-expect-error method name union
             const response = await TrezorConnect[method](...params);
 
             if (method === 'init') {

--- a/packages/suite-desktop/src/support/trezor-connect-ipc-wrapper.ts
+++ b/packages/suite-desktop/src/support/trezor-connect-ipc-wrapper.ts
@@ -10,7 +10,7 @@ export * from '@trezor/connect/lib/exports';
 // override each method of @trezor/connect
 // use ipcRenderer message instead of iframe.postMessage (see ./src-electron/modules/trezor-connect-preloader)
 Object.keys(TrezorConnect).forEach(method => {
-    // @ts-ignore
+    // @ts-expect-error
     TrezorConnect[method] = (...params: any[]) =>
         window.TrezorConnectIpcChannel
             ? window.TrezorConnectIpcChannel(method, ...params)

--- a/packages/suite-storage/src/native/index.ts
+++ b/packages/suite-storage/src/native/index.ts
@@ -52,7 +52,7 @@ class CommonDB<TDBStructure> {
         this.blocking = false;
         this.blocked = false;
 
-        // @ts-ignore
+        // @ts-expect-error
         this.db = null;
         // create global instance of broadcast channel
         this.broadcastChannel = null;
@@ -100,7 +100,7 @@ class CommonDB<TDBStructure> {
     onChange = (_handler: (event: StorageMessageEvent<TDBStructure>) => any) => {};
 
     getDB = (): Promise<IDBPDatabase<TDBStructure>> =>
-        // @ts-ignore
+        // @ts-expect-error
         Promise.resolve();
 
     addItem = <
@@ -113,7 +113,7 @@ class CommonDB<TDBStructure> {
         _key?: TKey,
         _upsert?: boolean,
     ): Promise<StoreKey<TDBStructure, TStoreName>> =>
-        // @ts-ignore
+        // @ts-expect-error
         Promise.resolve();
 
     addItems = <
@@ -132,7 +132,7 @@ class CommonDB<TDBStructure> {
         _store: TStoreName,
         _primaryKey: TKey,
     ): Promise<StoreValue<TDBStructure, TStoreName> | undefined> =>
-        // @ts-ignore
+        // @ts-expect-error
         Promise.resolve();
 
     getItemByIndex = <

--- a/packages/suite-storage/src/web/index.ts
+++ b/packages/suite-storage/src/web/index.ts
@@ -189,7 +189,7 @@ class CommonDB<TDBStructure> {
         // TODO: When using idb wrapper something throws 'Uncaught (in promise) null'
         // and I couldn't figure out how to catch it. Maybe a bug in idb?
         // So instead of using idb wrapper I use indexedDB directly, wrapped in my own promise.
-        // @ts-ignore
+        // @ts-expect-error
         const db = unwrap(await this.getDB()) as IDBDatabase;
 
         const storeName = store as string;
@@ -199,10 +199,8 @@ class CommonDB<TDBStructure> {
                 const tx = db.transaction(storeName, 'readwrite');
                 const params: [TItem, TKey | undefined] = key ? [item, key] : [item, undefined];
                 const req: IDBRequest = upsert
-                    ? // @ts-ignore
-                      tx.objectStore(storeName).put(...params)
-                    : // @ts-ignore
-                      tx.objectStore(storeName).add(...params);
+                    ? tx.objectStore(storeName).put(...params)
+                    : tx.objectStore(storeName).add(...params);
                 req.onerror = _event => {
                     reject(req.error);
                 };

--- a/packages/suite-web/src/index.ts
+++ b/packages/suite-web/src/index.ts
@@ -4,7 +4,6 @@
  * After the div is added, MutationObserver detects the change and adds React app to the DOM.
  */
 
-// @ts-ignore - Export not needed
 const observer = new MutationObserver(() => {
     const appElement = document.getElementById('app');
     if (appElement) {
@@ -19,3 +18,5 @@ const observer = new MutationObserver(() => {
 observer.observe(document.body, {
     childList: true,
 });
+
+export {};

--- a/packages/suite/src/actions/onboarding/__tests__/onboardingActions.test.ts
+++ b/packages/suite/src/actions/onboarding/__tests__/onboardingActions.test.ts
@@ -83,7 +83,6 @@ const updateStore = (store: ReturnType<typeof createStore>) => {
         const action = store.getActions().pop();
         const { onboarding } = store.getState();
 
-        // @ts-ignore
         store.getState().onboarding = onboardingReducer(onboarding, action);
         // add action back to stack
         store.getActions().push(action);

--- a/packages/suite/src/actions/suite/__tests__/messageSystemActions.test.ts
+++ b/packages/suite/src/actions/suite/__tests__/messageSystemActions.test.ts
@@ -42,7 +42,7 @@ describe('Message system actions', () => {
                 text: () => Promise.resolve(fixtures.validJws),
             });
             global.fetch = jest.fn().mockImplementation(() => mockFetchPromise);
-            // @ts-ignore
+            // @ts-expect-error
             jest.spyOn(global, 'fetch').mockImplementation(() => mockFetchPromise);
         });
 

--- a/packages/suite/src/actions/suite/__tests__/metadataActions.test.ts
+++ b/packages/suite/src/actions/suite/__tests__/metadataActions.test.ts
@@ -41,7 +41,7 @@ jest.mock('@trezor/connect', () => {
     };
 });
 
-// @ts-ignore declare fetch (used in Dropbox constructor)
+// @ts-expect-error declare fetch (used in Dropbox constructor)
 global.fetch = () => {};
 
 type MetadataState = ReturnType<typeof metadataReducer>;
@@ -108,7 +108,7 @@ const initStore = (state: State) => {
         }
         const { metadata, suite, devices, wallet } = store.getState();
         store.getState().metadata = metadataReducer(metadata, action);
-        // @ts-ignore
+        // @ts-expect-error
         store.getState().suite = suiteReducer(suite, action);
         store.getState().wallet.accounts = accountsReducer(wallet.accounts, action);
         store.getState().devices = deviceReducer(devices, action);
@@ -122,7 +122,7 @@ describe('Metadata Actions', () => {
         it(`setDeviceMetadataKey - ${f.description}`, async () => {
             // set fixtures in @trezor/connect
             require('@trezor/connect').setTestFixtures(f.connect);
-            // @ts-ignore
+            // @ts-expect-error
             const store = initStore(getInitialState(f.initialState));
             await store.dispatch(metadataActions.setDeviceMetadataKey());
             if (!f.result) {
@@ -135,9 +135,9 @@ describe('Metadata Actions', () => {
 
     fixtures.setAccountMetadataKey.forEach(f => {
         it(`setAccountMetadataKey - ${f.description}`, async () => {
-            // @ts-ignore
+            // @ts-expect-error
             const store = initStore(getInitialState(f.initialState));
-            // @ts-ignore Account is not complete
+            // @ts-expect-error Account is not complete
             const account = await store.dispatch(metadataActions.setAccountMetadataKey(f.account));
             expect(account).toMatchObject(f.result);
         });
@@ -145,9 +145,9 @@ describe('Metadata Actions', () => {
 
     fixtures.addDeviceMetadata.forEach(f => {
         it(`addDeviceMetadata - ${f.description}`, async () => {
-            // @ts-ignore
+            // @ts-expect-error
             const store = initStore(getInitialState(f.initialState));
-            // @ts-ignore, params
+            // @ts-expect-error, params
             await store.dispatch(metadataActions.addDeviceMetadata(f.params));
             if (!f.result) {
                 expect(store.getActions().length).toEqual(0);
@@ -157,9 +157,9 @@ describe('Metadata Actions', () => {
 
     fixtures.addAccountMetadata.forEach(f => {
         it(`addAccountMetadata - ${f.description}`, async () => {
-            // @ts-ignore
+            // @ts-expect-error
             const store = initStore(getInitialState(f.initialState));
-            // @ts-ignore, params
+            // @ts-expect-error, params
             await store.dispatch(metadataActions.addAccountMetadata(f.params));
             if (!f.result) {
                 expect(store.getActions().length).toEqual(0);
@@ -173,9 +173,9 @@ describe('Metadata Actions', () => {
             DropboxProvider.prototype.connect = () =>
                 Promise.resolve({ success: true, payload: undefined });
 
-            // @ts-ignore
+            // @ts-expect-error
             const store = initStore(getInitialState(f.initialState));
-            // @ts-ignore, params
+            // @ts-expect-error, params
             const result = await store.dispatch(metadataActions.connectProvider(f.params));
 
             if (!f.result) {
@@ -219,10 +219,10 @@ describe('Metadata Actions', () => {
                 }
                 return { success: true, payload: undefined };
             };
-            // @ts-ignore
+            // @ts-expect-error
             const store = initStore(getInitialState(f.initialState));
 
-            // @ts-ignore, params
+            // @ts-expect-error, params
             const result = await store.dispatch(metadataActions.addMetadata(f.params));
 
             if (!f.result) {
@@ -235,9 +235,9 @@ describe('Metadata Actions', () => {
 
     fixtures.enableMetadata.forEach(f => {
         it(`enableMetadata - ${f.description}`, async () => {
-            // @ts-ignore
+            // @ts-expect-error
             const store = initStore(getInitialState(f.initialState));
-            // @ts-ignore, params
+            // @ts-expect-error, params
             const result = await store.dispatch(metadataActions.enableMetadata());
             if (!f.result) {
                 expect(store.getActions().length).toEqual(0);
@@ -249,9 +249,9 @@ describe('Metadata Actions', () => {
 
     fixtures.disableMetadata.forEach(f => {
         it(`disableMetadata - ${f.description}`, async () => {
-            // @ts-ignore
+            // @ts-expect-error
             const store = initStore(getInitialState(f.initialState));
-            // @ts-ignore, params
+            // @ts-expect-error, params
             const result = await store.dispatch(metadataActions.disableMetadata());
             if (!f.result) {
                 expect(store.getActions().length).toEqual(0);
@@ -264,9 +264,9 @@ describe('Metadata Actions', () => {
     fixtures.init.forEach(f => {
         it(`initMetadata - ${f.description}`, async () => {
             jest.mock('@suite-services/metadata/DropboxProvider');
-            // @ts-ignore
+            // @ts-expect-error
             const store = initStore(getInitialState(f.initialState));
-            // @ts-ignore, params
+            // @ts-expect-error, params
             const result = await store.dispatch(metadataActions.init(f.params));
             if (!f.result) {
                 expect(store.getActions().length).toEqual(0);

--- a/packages/suite/src/actions/suite/__tests__/routerActions.test.ts
+++ b/packages/suite/src/actions/suite/__tests__/routerActions.test.ts
@@ -108,7 +108,7 @@ describe('Suite Actions', () => {
     });
 
     it('closeModalApp', () => {
-        // @ts-ignore this test is interested only in router.pathname, for better maintainability ignore other properties
+        // @ts-expect-error this test is interested only in router.pathname, for better maintainability ignore other properties
         const state = getInitialState({ router: { pathname: '/firmware' } });
         const store = initStore(state);
         // eslint-disable-next-line global-require

--- a/packages/suite/src/actions/suite/__tests__/storageActions.test.ts
+++ b/packages/suite/src/actions/suite/__tests__/storageActions.test.ts
@@ -183,16 +183,13 @@ describe('Storage actions', () => {
     it('should store suite settings in the db and update them automatically', async () => {
         const store = mockStore(getInitialState());
         updateStore(store);
-        // @ts-ignore
         const f = global.fetch;
-        // @ts-ignore
         global.fetch = mockFetch({ TR_ID: 'Message' });
         await store.dispatch(storageActions.saveSuiteSettings());
         await store.dispatch(suiteActions.initialRunCompleted());
         store.dispatch(await preloadStore());
 
         expect(store.getState().suite.flags.initialRun).toEqual(false);
-        // @ts-ignore
         global.fetch = f;
     });
 
@@ -200,12 +197,12 @@ describe('Storage actions', () => {
         let store = mockStore(getInitialState());
         updateStore(store);
 
-        // @ts-ignore partial params
+        // @ts-expect-error partial params
         await storageActions.saveDraft({ address: 'a' }, 'account-key');
         store.dispatch(await preloadStore());
         expect(store.getState().wallet.send.drafts).toEqual({ 'account-key': { address: 'a' } });
 
-        // @ts-ignore partial params
+        // @ts-expect-error partial params
         await storageActions.saveDraft({ address: 'b' }, 'account-key');
         store.dispatch(await preloadStore());
         expect(store.getState().wallet.send.drafts).toEqual({ 'account-key': { address: 'b' } });
@@ -225,7 +222,7 @@ describe('Storage actions', () => {
                     accounts: [acc1, acc2],
                     send: {
                         drafts: {
-                            // @ts-ignore partial params
+                            // @ts-expect-error partial params
                             'desc1-btc-state1': { address: 'A' },
                         },
                     },

--- a/packages/suite/src/actions/wallet/__tests__/blockchainActions.test.ts
+++ b/packages/suite/src/actions/wallet/__tests__/blockchainActions.test.ts
@@ -114,7 +114,7 @@ describe('Blockchain Actions', () => {
             const store = initStore(getInitialState(f.initialState as Args));
             await store.dispatch(
                 blockchainActions.onDisconnect({
-                    // @ts-ignore partial params
+                    // @ts-expect-error partial params
                     coin: { shortcut: f.symbol },
                 }),
             );
@@ -165,7 +165,7 @@ describe('Blockchain Actions', () => {
                 if (f.resultTxs) {
                     const txs = store.getState().wallet.transactions.transactions;
                     Object.keys(txs).forEach(key => {
-                        // @ts-ignore
+                        // @ts-expect-error
                         const resTxs = f.resultTxs[key];
                         expect(txs[key].length).toEqual(resTxs.length);
                         txs[key].forEach((t, i) => expect(t).toMatchObject(resTxs[i]));
@@ -189,11 +189,11 @@ describe('Blockchain Actions', () => {
         const store = initStore(
             getInitialState({
                 blockchain: {
-                    // @ts-ignore partial params
+                    // @ts-expect-error partial params
                     btc: { blockHeight: 109 },
                 },
                 fees: {
-                    // @ts-ignore partial params
+                    // @ts-expect-error partial params
                     btc: { blockHeight: 100 },
                 },
             }),

--- a/packages/suite/src/actions/wallet/__tests__/coinmarketBuyActions.test.ts
+++ b/packages/suite/src/actions/wallet/__tests__/coinmarketBuyActions.test.ts
@@ -31,7 +31,6 @@ const initStore = (state: State) => {
 };
 
 const setFetchMock = (mock: any) => {
-    // @ts-ignore
     global.fetch = jest.fn().mockImplementation(() => {
         const p = new Promise(resolve => {
             resolve({

--- a/packages/suite/src/actions/wallet/__tests__/coinmarketExchangeActions.test.ts
+++ b/packages/suite/src/actions/wallet/__tests__/coinmarketExchangeActions.test.ts
@@ -31,7 +31,6 @@ const initStore = (state: State) => {
 };
 
 const setFetchMock = (mocks: any) => {
-    // @ts-ignore
     global.fetch = jest.fn().mockImplementation(url => {
         const mock = mocks[url];
         if (!mock) return;

--- a/packages/suite/src/actions/wallet/__tests__/discoveryActions.test.ts
+++ b/packages/suite/src/actions/wallet/__tests__/discoveryActions.test.ts
@@ -62,7 +62,7 @@ jest.mock('@trezor/connect', () => {
             // error code is used in case where one of requested coins is not supported
             const { code, error } = connect.error;
             if (code) {
-                // @ts-ignore The operand of a 'delete' operator must be optional.
+                // @ts-expect-error The operand of a 'delete' operator must be optional.
                 delete connect.error; // reset this value, it shouldn't be used in next iteration
                 return scopedParamsError(error, code);
             }
@@ -347,7 +347,7 @@ describe('Discovery Actions', () => {
                 },
             },
         };
-        // @ts-ignore: invalid state (suite empty)
+        // @ts-expect-error: invalid state (suite empty)
         const store = initStore(state);
         await store.dispatch(discoveryActions.start());
         const action = store.getActions().pop();
@@ -357,7 +357,6 @@ describe('Discovery Actions', () => {
     it('Start discovery with device without auth confirmation', async () => {
         const state = getInitialState();
         state.suite.device = getSuiteDevice({ authConfirm: true });
-        // @ts-ignore: invalid state (suite empty)
         const store = initStore(state);
         await store.dispatch(discoveryActions.start());
         const action = store.getActions().pop();
@@ -415,7 +414,7 @@ describe('Discovery Actions', () => {
                 discovery: [],
             },
         };
-        // @ts-ignore: invalid state (suite empty)
+        // @ts-expect-error: invalid state (suite empty)
         const store = initStore(state);
         await store.dispatch(discoveryActions.stop());
         expect(store.getActions()).toEqual([]);
@@ -646,7 +645,7 @@ describe('Discovery Actions', () => {
         store.dispatch(discoveryActions.remove('device-state'));
         expect(store.dispatch(fn())).toEqual(undefined);
 
-        // @ts-ignore remove device from state
+        // @ts-expect-error remove device from state
         store.getState().suite.device = undefined;
         expect(store.dispatch(fn())).toEqual(undefined);
     });

--- a/packages/suite/src/components/suite/Banners/MessageSystemBanner.tsx
+++ b/packages/suite/src/components/suite/Banners/MessageSystemBanner.tsx
@@ -40,7 +40,7 @@ const MessageSystemBanner = ({ message }: Props) => {
 
         let onClick: () => Window | Promise<void> | null;
         if (action === 'internal-link') {
-            // @ts-ignore: impossible to add all href options to the message system config json schema
+            // @ts-expect-error: impossible to add all href options to the message system config json schema
             onClick = () => goto(link, { anchor });
         } else if (action === 'external-link') {
             onClick = () =>

--- a/packages/suite/src/components/suite/Labeling/components/Metadata/index.tsx
+++ b/packages/suite/src/components/suite/Labeling/components/Metadata/index.tsx
@@ -103,7 +103,7 @@ const ButtonLikeLabel = (props: ExtendedProps) => {
     if (props.editActive) {
         return (
             <EditableButton
-                // @ts-ignore todo: hm this needs some clever generic
+                // @ts-expect-error todo: hm this needs some clever generic
                 variant="tertiary"
                 icon="TAG"
                 data-test={props['data-test']}

--- a/packages/suite/src/components/suite/WebUsbButton/index.tsx
+++ b/packages/suite/src/components/suite/WebUsbButton/index.tsx
@@ -10,7 +10,6 @@ export const WebUsbButton = (props: ButtonProps) => (
         onClick={async e => {
             e.stopPropagation();
             try {
-                // @ts-ignore navigator.usb not found
                 await navigator.usb.requestDevice({ filters: config.webusb });
             } catch (error) {
                 // empty

--- a/packages/suite/src/components/suite/__tests__/Translation.test.tsx
+++ b/packages/suite/src/components/suite/__tests__/Translation.test.tsx
@@ -31,7 +31,7 @@ describe('Translation component', () => {
 
     test('with message that holds string in value (passed via props)', () => {
         const component = createComponentWithIntl(
-            // @ts-ignore
+            // @ts-expect-error
             <Translation {...messages.TR_NAME} values={{ name: 'John' }} />,
         );
         const tree = component.toJSON();
@@ -43,7 +43,7 @@ describe('Translation component', () => {
             <Translation
                 {...messages.TR_HELLO_NAME}
                 values={{
-                    // @ts-ignore
+                    // @ts-expect-error
                     TR_NAME: { ...messages.TR_NAME, values: { name: 'John' } },
                     TR_AGE: 100,
                 }}
@@ -55,11 +55,11 @@ describe('Translation component', () => {
 
     test('with message that holds another in values (passed via props)', () => {
         const component = createComponentWithIntl(
-            // @ts-ignore
+            // @ts-expect-error
             <Translation
                 {...messages.TR_HELLO_NAME}
                 values={{
-                    // @ts-ignore
+                    // @ts-expect-error
                     TR_NAME: <Translation {...messages.TR_NAME} values={{ name: 'John' }} />,
                     TR_AGE: 100,
                 }}

--- a/packages/suite/src/components/wallet/AccountException/FirmwareUnsupported.tsx
+++ b/packages/suite/src/components/wallet/AccountException/FirmwareUnsupported.tsx
@@ -25,7 +25,7 @@ const getInfoUrl = (symbol?: Props['symbol']) => {
     if (!symbol) {
         result = urls.default;
     } else if (symbol in urls) {
-        // @ts-ignore
+        // @ts-expect-error
         result = urls[symbol];
     } else {
         result = urls.default;

--- a/packages/suite/src/hooks/wallet/__tests__/useRbfForm.test.tsx
+++ b/packages/suite/src/hooks/wallet/__tests__/useRbfForm.test.tsx
@@ -123,7 +123,7 @@ describe('useRbfForm hook', () => {
             const callback: TestCallback = {};
             const { unmount } = renderWithProviders(
                 store,
-                // @ts-ignore f.tx is not exact
+                // @ts-expect-error f.tx is not exact
                 <ChangeFee tx={f.tx} finalize={false} chainedTxs={[]} showChained={() => {}}>
                     <Component callback={callback} />
                 </ChangeFee>,

--- a/packages/suite/src/hooks/wallet/__tests__/useSendForm.test.tsx
+++ b/packages/suite/src/hooks/wallet/__tests__/useSendForm.test.tsx
@@ -171,7 +171,7 @@ const actionCallback = (
         // expect(errors).toMatchObject(result.errors);
         Object.keys(result.errors).forEach(key => {
             const expectedError = result.errors[key];
-            // @ts-ignore key: string
+            // @ts-expect-error key: string
             const error = errors[key];
             if (expectedError) {
                 expect(error).toMatchObject(expectedError);

--- a/packages/suite/src/hooks/wallet/form/useCompose.ts
+++ b/packages/suite/src/hooks/wallet/form/useCompose.ts
@@ -188,7 +188,7 @@ export const useCompose = ({
                     composed = composedLevels[nearest];
                     setValue('selectedFee', nearest);
                     if (nearest === 'custom') {
-                        // @ts-ignore: type = error already filtered above
+                        // @ts-expect-error: type = error already filtered above
                         const { feePerByte, feeLimit } = composed;
                         setValue('feePerUnit', feePerByte);
                         setValue('feeLimit', feeLimit);

--- a/packages/suite/src/hooks/wallet/useSendFormCompose.ts
+++ b/packages/suite/src/hooks/wallet/useSendFormCompose.ts
@@ -198,7 +198,7 @@ export const useSendFormCompose = ({
                 composed = composedLevels[nearest];
                 setValue('selectedFee', nearest);
                 if (nearest === 'custom') {
-                    // @ts-ignore: type = error already filtered above
+                    // @ts-expect-error: type = error already filtered above
                     const { feePerByte, feeLimit } = composed;
                     setValue('feePerUnit', feePerByte);
                     setValue('feeLimit', feeLimit);

--- a/packages/suite/src/hooks/wallet/useSendFormFields.ts
+++ b/packages/suite/src/hooks/wallet/useSendFormFields.ts
@@ -92,7 +92,7 @@ export const useSendFormFields = ({
             // they will set defaultValue from draft on every mount
             // to prevent that behavior reset defaultValue in `react-hook-form.control.defaultValuesRef`
             const { current } = control.defaultValuesRef;
-            // @ts-ignore: react-hook-form type returns "unknown" (bug?)
+            // @ts-expect-error: react-hook-form type returns "unknown" (bug?)
             if (current && current[fieldName]) current[fieldName] = '';
             // reset current value
             setValue(fieldName, '');

--- a/packages/suite/src/middlewares/suite/__tests__/buttonRequestMiddleware.test.ts
+++ b/packages/suite/src/middlewares/suite/__tests__/buttonRequestMiddleware.test.ts
@@ -95,9 +95,9 @@ describe('buttonRequest middleware', () => {
         require('@trezor/connect');
         require('@wallet-actions/blockchainActions');
         const store = initStore(getInitialState());
-        // @ts-ignore
+        // @ts-expect-error
         await store.dispatch(connectInitThunk());
-        // @ts-ignore
+        // @ts-expect-error
         const call = store.dispatch(deviceSettingsActions.changePin({ remove: false }));
         // fake few ui events, just like when user is changing PIN
         const { emit } = require('@trezor/connect');

--- a/packages/suite/src/middlewares/suite/__tests__/firmwareMiddleware.test.ts
+++ b/packages/suite/src/middlewares/suite/__tests__/firmwareMiddleware.test.ts
@@ -49,7 +49,7 @@ const initStore = (state: State) => {
     store.subscribe(() => {
         const action = store.getActions().pop();
         const { firmware, suite } = store.getState();
-        // @ts-ignore
+        // @ts-expect-error
         store.getState().firmware = firmwareReducer(firmware, action);
         store.getState().suite = suiteReducer(suite, action);
 

--- a/packages/suite/src/middlewares/suite/__tests__/messageSystemMiddleware.test.ts
+++ b/packages/suite/src/middlewares/suite/__tests__/messageSystemMiddleware.test.ts
@@ -67,7 +67,7 @@ describe('Message system middleware', () => {
             category: ['modal'],
         };
 
-        // @ts-ignore: all properties except category and id are not required for testing
+        // @ts-expect-error: all properties except category and id are not required for testing
         jest.spyOn(messageSystem, 'getValidMessages').mockImplementation(() => [
             message1,
             message2,

--- a/packages/suite/src/middlewares/suite/__tests__/protocolMiddleware.test.ts
+++ b/packages/suite/src/middlewares/suite/__tests__/protocolMiddleware.test.ts
@@ -33,7 +33,7 @@ const initStore = (state: State) => {
         const { protocol, notifications } = store.getState();
 
         store.getState().protocol = protocolReducer(protocol, action);
-        // @ts-ignore
+        // @ts-expect-error
         store.getState().notifications = notificationReducer(notifications, action);
 
         store.getActions().push(action);
@@ -64,7 +64,7 @@ describe('Protocol middleware', () => {
             },
         ];
 
-        // @ts-ignore
+        // @ts-expect-error
         const store = initStore(getInitialState(notifications));
         await store.dispatch({
             type: PROTOCOL.SAVE_COIN_PROTOCOL,

--- a/packages/suite/src/middlewares/wallet/__tests__/coinmarketMiddleware.test.ts
+++ b/packages/suite/src/middlewares/wallet/__tests__/coinmarketMiddleware.test.ts
@@ -102,7 +102,6 @@ describe('coinmarketMiddleware', () => {
             'setInvityServersEnvironment',
         );
 
-        // @ts-ignore
         const store = initStore(
             getInitialState({
                 coinmarket: initialState,
@@ -130,7 +129,6 @@ describe('coinmarketMiddleware', () => {
             'setInvityServersEnvironment',
         );
 
-        // @ts-ignore
         const store = initStore(
             getInitialState({
                 coinmarket: { ...initialState, lastLoadedTimestamp: 0 },
@@ -158,7 +156,6 @@ describe('coinmarketMiddleware', () => {
             'setInvityServersEnvironment',
         );
 
-        // @ts-ignore
         const store = initStore(
             getInitialState({
                 coinmarket: {

--- a/packages/suite/src/middlewares/wallet/__tests__/coinmarketSavingsMiddleware.test.ts
+++ b/packages/suite/src/middlewares/wallet/__tests__/coinmarketSavingsMiddleware.test.ts
@@ -93,7 +93,6 @@ describe('coinmarketSavingsMiddleware', () => {
     });
 
     it('loadSavingsTrade', () => {
-        // @ts-ignore
         const store = initStore(
             getInitialState({
                 coinmarket: initialState,

--- a/packages/suite/src/middlewares/wallet/__tests__/pollingMiddleware.test.ts
+++ b/packages/suite/src/middlewares/wallet/__tests__/pollingMiddleware.test.ts
@@ -40,7 +40,6 @@ describe('pollingMiddleware', () => {
     jest.useFakeTimers();
 
     it('start', () => {
-        // @ts-ignore
         const store = initStore(
             getInitialState({
                 pollings: initialState,
@@ -67,7 +66,6 @@ describe('pollingMiddleware', () => {
 
     it('request', () => {
         jest.spyOn(global, 'setTimeout');
-        // @ts-ignore
         const store = initStore(
             getInitialState({
                 pollings: {
@@ -94,7 +92,6 @@ describe('pollingMiddleware', () => {
     });
 
     it('stop', () => {
-        // @ts-ignore
         const store = initStore(
             getInitialState({
                 pollings: initialState,

--- a/packages/suite/src/middlewares/wallet/__tests__/walletMiddleware.test.ts
+++ b/packages/suite/src/middlewares/wallet/__tests__/walletMiddleware.test.ts
@@ -91,7 +91,6 @@ describe('walletMiddleware', () => {
 
     fixtures.blockchainSubscription.forEach(f => {
         it(f.description, () => {
-            // @ts-ignore
             const initialAccounts = f.initialAccounts.map((a: any) => getWalletAccount(a));
             const store = initStore(
                 getInitialState({
@@ -101,7 +100,7 @@ describe('walletMiddleware', () => {
 
             f.actions.forEach((action: any) => {
                 const payload = Array.isArray(action.payload)
-                    ? // @ts-ignore
+                    ? // @ts-expect-error
                       action.payload.map(a => getWalletAccount(a))
                     : getWalletAccount(action.payload);
                 store.dispatch({ ...action, payload });
@@ -111,7 +110,7 @@ describe('walletMiddleware', () => {
             if (subscribe) {
                 expect(TrezorConnect.blockchainSubscribe).toBeCalledTimes(subscribe.called);
                 if (subscribe.called) {
-                    // @ts-ignore
+                    // @ts-expect-error
                     const accounts = subscribe.accounts?.map(a => getWalletAccount(a));
                     expect(TrezorConnect.blockchainSubscribe).toHaveBeenLastCalledWith({
                         accounts,

--- a/packages/suite/src/reducers/suite/__tests__/desktopUpdateReducer.test.ts
+++ b/packages/suite/src/reducers/suite/__tests__/desktopUpdateReducer.test.ts
@@ -11,7 +11,7 @@ const fixtures: [Action, Partial<State>][] = [
     [
         {
             type: SUITE.DESKTOP_HANDSHAKE,
-            // @ts-ignore
+            // @ts-expect-error
             payload: {
                 desktopUpdate: {
                     allowPrerelease: true,
@@ -52,7 +52,6 @@ describe('desktopUpdateReducer', () => {
     it('DESKTOP_UPDATE actions', () => {
         let lastState: State | undefined;
         fixtures.forEach(([action, state]) => {
-            // @ts-ignore
             lastState = desktopUpdateReducer(lastState, action);
             expect(lastState).toMatchObject(state);
         });

--- a/packages/suite/src/reducers/wallet/__tests__/cardanoStakingReducer.test.ts
+++ b/packages/suite/src/reducers/wallet/__tests__/cardanoStakingReducer.test.ts
@@ -5,7 +5,7 @@ describe('cardanoStakingReducer reducer', () => {
     it('test initial state', () => {
         expect(
             reducer(undefined, {
-                // @ts-ignore
+                // @ts-expect-error
                 type: 'none',
             }),
         ).toEqual(initialState);

--- a/packages/suite/src/reducers/wallet/__tests__/coinmarketReducer.test.ts
+++ b/packages/suite/src/reducers/wallet/__tests__/coinmarketReducer.test.ts
@@ -21,7 +21,7 @@ describe('settings reducer', () => {
     it('test initial state', () => {
         expect(
             reducer(undefined, {
-                // @ts-ignore
+                // @ts-expect-error
                 type: 'none',
             }),
         ).toEqual(initialState);

--- a/packages/suite/src/reducers/wallet/__tests__/settingsReducer.test.ts
+++ b/packages/suite/src/reducers/wallet/__tests__/settingsReducer.test.ts
@@ -6,7 +6,7 @@ describe('settings reducer', () => {
     it('test initial state', () => {
         expect(
             reducer(undefined, {
-                // @ts-ignore
+                // @ts-expect-error
                 type: 'none',
             }),
         ).toEqual(initialState);

--- a/packages/suite/src/services/suite/metadata/DropboxProvider.ts
+++ b/packages/suite/src/services/suite/metadata/DropboxProvider.ts
@@ -155,7 +155,7 @@ class DropboxProvider extends AbstractMetadataProvider {
             await this.client.filesUpload({
                 path: `/${file}.mtdt`,
                 contents: blob,
-                // @ts-ignore
+                // @ts-expect-error
                 mode: 'overwrite',
             });
 

--- a/packages/suite/src/storage/migrations/index.ts
+++ b/packages/suite/src/storage/migrations/index.ts
@@ -117,7 +117,7 @@ export const migrate: OnUpgradeFunc<SuiteDBSchema> = async (
 
     if (oldVersion < 16) {
         // object store for send form
-        // @ts-ignore sendForm doesn't exists anymore
+        // @ts-expect-error sendForm doesn't exists anymore
         db.deleteObjectStore('sendForm');
         db.createObjectStore('sendFormDrafts');
     }
@@ -476,16 +476,16 @@ export const migrate: OnUpgradeFunc<SuiteDBSchema> = async (
                 return;
             }
             const state = cursor.value;
-            // @ts-ignore (token property removed)
+            // @ts-expect-error (token property removed)
             if (state.provider?.token) {
                 if (isDesktop()) {
                     state.provider.tokens = {
                         accessToken: '',
-                        // @ts-ignore
+                        // @ts-expect-error
                         refreshToken: state.provider.token,
                     };
                 }
-                // @ts-ignore
+                // @ts-expect-error
                 delete state.provider.token;
                 cursor.update(state);
             }

--- a/packages/suite/src/support/suite/Protocol.tsx
+++ b/packages/suite/src/support/suite/Protocol.tsx
@@ -28,7 +28,7 @@ const Protocol = () => {
             navigator.registerProtocolHandler(
                 'bitcoin',
                 `${window.location.origin}${process.env.ASSET_PREFIX ?? ''}/?uri=%s`,
-                // @ts-ignore deprecated but required for Firefox <= 78, Chrome <= 87
+                // @ts-expect-error deprecated but required for Firefox <= 78, Chrome <= 87
                 'Trezor Suite - Bitcoin',
             );
         }

--- a/packages/suite/src/support/tests/hooksHelper.tsx
+++ b/packages/suite/src/support/tests/hooksHelper.tsx
@@ -76,7 +76,6 @@ export const actionSequence = async <A extends UserAction[]>(
             } else {
                 // eslint-disable-next-line no-await-in-loop
                 await act(() =>
-                    // @ts-ignore: act => Promise
                     userEvent.type(
                         element,
                         value,

--- a/packages/suite/src/support/tests/npmMocks.tsx
+++ b/packages/suite/src/support/tests/npmMocks.tsx
@@ -36,7 +36,7 @@ jest.mock('dropbox', () => {
     };
 });
 
-// @ts-ignore
+// @ts-expect-error
 jest.mock('react-markdown', () => props => <>{props.children}</>);
 
 jest.mock('@fivebinaries/coin-selection', () => ({

--- a/packages/suite/src/support/tests/setupJest.ts
+++ b/packages/suite/src/support/tests/setupJest.ts
@@ -47,7 +47,7 @@ global.JestMocks = {
     intlMock: testMocks.intlMock,
 };
 
-// @ts-ignore
+// @ts-expect-error
 global.BroadcastChannel = BroadcastChannel;
 
 // this helps with debugging - find unhandled promise rejections in jest

--- a/packages/suite/src/utils/onboarding/steps.ts
+++ b/packages/suite/src/utils/onboarding/steps.ts
@@ -9,7 +9,7 @@ export const isStepInPath = (step: Step, path: AnyPath[]) => {
         return true;
     }
     return path.every((pathMember: AnyPath) =>
-        // @ts-ignore
+        // @ts-expect-error
         step.path.some((stepPathMember: AnyPath) => stepPathMember === pathMember),
     );
 };

--- a/packages/suite/src/utils/suite/__fixtures__/device.ts
+++ b/packages/suite/src/utils/suite/__fixtures__/device.ts
@@ -55,7 +55,7 @@ const getStatus = [
         status: 'unreadable',
     },
     {
-        // @ts-ignore: invalid type
+        // @ts-expect-error: invalid type
         device: getSuiteDevice({ type: 'unknown' }),
         status: 'unknown',
     },

--- a/packages/suite/src/utils/suite/__tests__/comparisonUtils.test.ts
+++ b/packages/suite/src/utils/suite/__tests__/comparisonUtils.test.ts
@@ -4,7 +4,6 @@ import * as comparisonUtils from '../comparisonUtils';
 describe('reducer utils', () => {
     fixtures.isChanged.forEach(f => {
         it(`isChanged${f.testName}`, () => {
-            // @ts-ignore
             expect(comparisonUtils.isChanged(f.prev, f.current, f.filter)).toEqual(f.result);
         });
     });

--- a/packages/suite/src/utils/suite/__tests__/env.test.ts
+++ b/packages/suite/src/utils/suite/__tests__/env.test.ts
@@ -21,7 +21,7 @@ describe.skip('isMacOs', () => {
 
     fixtures.isMacOs.forEach(f => {
         it(f.description, () => {
-            // @ts-ignore
+            // @ts-expect-error
             jest.spyOn(env, 'getProcessPlatform').mockImplementation(() => f.processPlatform);
 
             navigatorPlatformGetter.mockReturnValue(f.navigatorPlatform);
@@ -44,7 +44,7 @@ describe.skip('isWindows', () => {
 
     fixtures.isWindows.forEach(f => {
         it(f.description, () => {
-            // @ts-ignore
+            // @ts-expect-error
             jest.spyOn(env, 'getProcessPlatform').mockImplementation(() => f.processPlatform);
 
             navigatorPlatformGetter.mockReturnValue(f.navigatorPlatform);
@@ -69,7 +69,7 @@ describe.skip('isLinux', () => {
 
     fixtures.isLinux.forEach(f => {
         it(f.description, () => {
-            // @ts-ignore
+            // @ts-expect-error
             jest.spyOn(env, 'getProcessPlatform').mockImplementation(() => f.processPlatform);
 
             userAgentGetter.mockReturnValue(f.userAgent);
@@ -155,7 +155,7 @@ describe.skip('getOsName', () => {
 
     fixtures.getOsName.forEach(f => {
         it(f.description, () => {
-            // @ts-ignore
+            // @ts-expect-error
             jest.spyOn(env, 'getProcessPlatform').mockImplementation(() => f.processPlatform);
 
             userAgentGetter.mockReturnValue(f.userAgent);

--- a/packages/suite/src/utils/suite/__tests__/homescreen.test.ts
+++ b/packages/suite/src/utils/suite/__tests__/homescreen.test.ts
@@ -144,7 +144,7 @@ describe('homescreen', () => {
 
         describe('returns false for null', () => {
             // defensively test a corner case violating type-checking
-            // @ts-ignore
+            // @ts-expect-error
             expect(homescreen.validateImageFormat(null)).toBe(
                 homescreen.ImageValidationError.InvalidFormat,
             );

--- a/packages/suite/src/utils/suite/__tests__/messageSystem.test.ts
+++ b/packages/suite/src/utils/suite/__tests__/messageSystem.test.ts
@@ -29,7 +29,7 @@ describe('Message system utils', () => {
                 expect(
                     messageSystem.validateSettingsCompatibility(
                         f.settingsCondition,
-                        // @ts-ignore
+                        // @ts-expect-error
                         f.currentSettings,
                     ),
                 ).toEqual(f.result);
@@ -41,7 +41,6 @@ describe('Message system utils', () => {
         fixtures.validateVersionCompatibility.forEach(f => {
             it(f.description, () => {
                 expect(
-                    // @ts-ignore
                     messageSystem.validateVersionCompatibility(f.condition, f.type, f.version),
                 ).toEqual(f.result);
             });
@@ -61,10 +60,9 @@ describe('Message system utils', () => {
                 process.env.COMMITHASH = f.commitHash;
 
                 expect(
-                    // @ts-ignore
                     messageSystem.validateEnvironmentCompatibility(
                         f.condition,
-                        // @ts-ignore
+                        // @ts-expect-error
                         f.type,
                         f.version,
                         f.commitHash,
@@ -88,7 +86,7 @@ describe('Message system utils', () => {
         fixtures.validateDeviceCompatibility.forEach(f => {
             it(f.description, () => {
                 expect(
-                    // @ts-ignore
+                    // @ts-expect-error
                     messageSystem.validateDeviceCompatibility(f.deviceConditions, f.device),
                 ).toEqual(f.result);
             });
@@ -111,14 +109,14 @@ describe('Message system utils', () => {
         fixtures.getValidMessages.forEach(f => {
             it(f.description, () => {
                 jest.spyOn(Date, 'now').mockImplementation(() => new Date(f.currentDate).getTime());
-                // @ts-ignore
+                // @ts-expect-error
                 jest.spyOn(env, 'getOsName').mockImplementation(() => f.osName);
                 userAgentGetter.mockReturnValue(f.userAgent);
-                // @ts-ignore
+                // @ts-expect-error
                 jest.spyOn(env, 'getEnvironment').mockImplementation(() => f.environment);
                 process.env.VERSION = f.suiteVersion;
 
-                // @ts-ignore
+                // @ts-expect-error
                 expect(messageSystem.getValidMessages(f.config, f.options)).toEqual(f.result);
             });
         });

--- a/packages/suite/src/utils/suite/__tests__/router.test.ts
+++ b/packages/suite/src/utils/suite/__tests__/router.test.ts
@@ -53,7 +53,7 @@ describe('router', () => {
 
     describe('getRoute', () => {
         it('should return the route for given name', () => {
-            // @ts-ignore: invalid params
+            // @ts-expect-error: invalid params
             expect(getRoute('unknown-route')).toEqual('/');
             expect(getRoute('wallet-index')).toEqual('/accounts');
             // tests below with intentionally mixed # params
@@ -79,7 +79,7 @@ describe('router', () => {
                 }),
             ).toEqual('/accounts#/btc/0');
             expect(
-                // @ts-ignore: invalid params
+                // @ts-expect-error: invalid params
                 getRoute('wallet-index', {
                     accountIndex: 1,
                     symbol: 'btc',
@@ -87,7 +87,7 @@ describe('router', () => {
             ).toEqual('/accounts#/btc/1');
             // route shouldn't have params
             expect(
-                // @ts-ignore: invalid params
+                // @ts-expect-error: invalid params
                 getRoute('onboarding-index', {
                     symbol: 'btc',
                 }),
@@ -182,7 +182,7 @@ describe('router', () => {
             expect(getTopLevelRoute('/accounts')).toEqual(undefined);
             expect(getTopLevelRoute('/accounts/receive')).toEqual('/accounts');
             expect(getTopLevelRoute('dummy-data-without-slash')).toEqual(undefined);
-            // @ts-ignore: intentional invalid param type
+            // @ts-expect-error: intentional invalid param type
             expect(getTopLevelRoute(1)).toEqual(undefined);
         });
 

--- a/packages/suite/src/utils/suite/__tests__/theme.test.ts
+++ b/packages/suite/src/utils/suite/__tests__/theme.test.ts
@@ -4,7 +4,7 @@ import { THEME } from '@trezor/components/src/config/colors';
 describe('theme', () => {
     describe('getThemeColors', () => {
         it('should return light theme if theme variant does not exists', () => {
-            // @ts-ignore
+            // @ts-expect-error
             expect(getThemeColors({ variant: 'purple' })).toBe(THEME.light);
         });
 

--- a/packages/suite/src/utils/suite/comparisonUtils.ts
+++ b/packages/suite/src/utils/suite/comparisonUtils.ts
@@ -35,9 +35,9 @@ export const isChanged = (prev?: any, current?: any, filter?: { [k: string]: str
                 const currentFiltered = {};
                 for (let i2 = 0; i2 < filter[key].length; i2++) {
                     const field = filter[key][i2];
-                    // @ts-ignore
+                    // @ts-expect-error
                     prevFiltered[field] = prev[key][field];
-                    // @ts-ignore
+                    // @ts-expect-error
                     currentFiltered[field] = current[key][field];
                 }
                 if (isChanged(prevFiltered, currentFiltered)) return true;

--- a/packages/suite/src/utils/suite/homescreen.ts
+++ b/packages/suite/src/utils/suite/homescreen.ts
@@ -152,7 +152,7 @@ export const fileToDataUrl = (file: File): Promise<string> => {
     const reader = new FileReader();
     return new Promise((resolve, reject) => {
         reader.onload = e =>
-            // @ts-ignore
+            // @ts-expect-error
             resolve(e.target.result);
         reader.onerror = err => {
             reject(err);

--- a/packages/suite/src/utils/suite/metadata.ts
+++ b/packages/suite/src/utils/suite/metadata.ts
@@ -1,5 +1,4 @@
 import * as crypto from 'crypto';
-// @ts-ignore
 import * as base58check from 'bs58check';
 // note we only need base58 conversion fn from base58check, other functions from there might
 // be supplemented from crypto module
@@ -71,7 +70,6 @@ export const encrypt = async (input: Record<string, any>, aesKey: string | Buffe
     const iv = await getRandomIv();
     const stringified = JSON.stringify(input);
     const buffer = Buffer.from(stringified, 'utf8');
-    // @ts-ignore
     const cipher = crypto.createCipheriv(CIPHER_TYPE, aesKey, iv);
     const startCText = cipher.update(buffer);
     const endCText = cipher.final();

--- a/packages/suite/src/utils/wallet/__tests__/cardanoUtils.test.ts
+++ b/packages/suite/src/utils/wallet/__tests__/cardanoUtils.test.ts
@@ -47,22 +47,22 @@ describe('cardano utils', () => {
     expect(getAddressType('normal')).toEqual(PROTO.CardanoAddressType.BASE);
     expect(getAddressType('legacy')).toEqual(PROTO.CardanoAddressType.BASE);
 
-    // @ts-ignore
+    // @ts-expect-error
     expect(getStakingPath({ index: 1, symbol: 'ada' })).toEqual(`m/1852'/1815'/1'/2/0`);
 
-    // @ts-ignore
+    // @ts-expect-error
     expect(getStakingPath({ index: 12, symbol: 'ada' })).toEqual(`m/1852'/1815'/12'/2/0`);
     expect(getShortFingerprint('asset1dffrfk79uxwq2a8yaslcfedycgga55tuv5dezd')).toEqual(
         'asset1dffr…55tuv5dezd',
     );
 
-    // @ts-ignore params are partial
+    // @ts-expect-error params are partial
     expect(isCardanoTx({ networkType: 'cardano' }, {})).toBe(true);
-    // @ts-ignore params are partial
+    // @ts-expect-error params are partial
     expect(isCardanoTx({ networkType: 'bitcoin' }, {})).toBe(false);
-    // @ts-ignore params are partial
+    // @ts-expect-error params are partial
     expect(isCardanoExternalOutput({ address: 'addr1' }, {})).toBe(true);
-    // @ts-ignore params are partial
+    // @ts-expect-error params are partial
     expect(isCardanoExternalOutput({ addressParameters: {} }, {})).toBe(false);
 
     it('composeTxPlan', async () => {
@@ -108,7 +108,7 @@ describe('cardano utils', () => {
 
     fixtures.getChangeAddressParameters.forEach(f => {
         it(`getChangeAddressParameters: ${f.description}`, () => {
-            // @ts-ignore params are partial
+            // @ts-expect-error params are partial
             expect(getChangeAddressParameters(f.account)).toMatchObject(f.result);
         });
     });
@@ -117,7 +117,7 @@ describe('cardano utils', () => {
         it(`transformUserOutputs: ${f.description}`, () => {
             expect(
                 transformUserOutputs(
-                    // @ts-ignore params are partial
+                    // @ts-expect-error params are partial
                     f.outputs,
                     f.accountTokens,
                     f.symbol,
@@ -130,7 +130,7 @@ describe('cardano utils', () => {
     fixtures.formatMaxOutputAmount.forEach(f => {
         it(`transformUserOutputs: ${f.description}`, () => {
             expect(
-                // @ts-ignore params are partial
+                // @ts-expect-error params are partial
                 formatMaxOutputAmount(f.maxAmount, f.maxOutput, f.account),
             ).toBe(f.result);
         });
@@ -156,7 +156,7 @@ describe('cardano utils', () => {
 
     fixtures.isPoolOverSaturated.forEach(f => {
         it(`isPoolOverSaturated: ${f.description}`, () => {
-            // @ts-ignore params are partial
+            // @ts-expect-error params are partial
             expect(isPoolOverSaturated(f.pool, f.additionalStake)).toBe(f.result);
         });
     });

--- a/packages/suite/src/utils/wallet/__tests__/graph.test.ts
+++ b/packages/suite/src/utils/wallet/__tests__/graph.test.ts
@@ -201,7 +201,7 @@ describe('Graph utils', () => {
                 },
             ],
         );
-        // @ts-ignore
+        // @ts-expect-error
         expect(utils.aggregateBalanceHistory([graphData2, graphData3], 'day', 'account')).toEqual([
             {
                 received: '1.1',

--- a/packages/suite/src/utils/wallet/coinmarket/__tests__/buyUtils.test.ts
+++ b/packages/suite/src/utils/wallet/coinmarket/__tests__/buyUtils.test.ts
@@ -60,11 +60,11 @@ describe('coinmarket/buy utils', () => {
             accountType: 'normal',
             symbol: 'btc',
         };
-        // @ts-ignore
+        // @ts-expect-error
         expect(await createQuoteLink(QUOTE_REQUEST_FIAT, accountMock)).toStrictEqual(
             `${window.location.origin}/coinmarket-redirect#offers/btc/normal/1/qf/CZ/EUR/10/BTC`,
         );
-        // @ts-ignore
+        // @ts-expect-error
         expect(await createQuoteLink(QUOTE_REQUEST_CRYPTO, accountMock)).toStrictEqual(
             `${window.location.origin}/coinmarket-redirect#offers/btc/normal/1/qc/CZ/EUR/0.001/BTC`,
         );
@@ -76,7 +76,7 @@ describe('coinmarket/buy utils', () => {
             accountType: 'normal',
             symbol: 'btc',
         };
-        // @ts-ignore
+        // @ts-expect-error
         expect(await createTxLink(MIN_MAX_QUOTES_OK[0], accountMock)).toStrictEqual(
             `${window.location.origin}/coinmarket-redirect#detail/btc/normal/1/e709df77-ee9e-4d12-98c2-84004a19c546`,
         );

--- a/packages/transport/src/fallback.ts
+++ b/packages/transport/src/fallback.ts
@@ -3,7 +3,7 @@ import type { Transport, AcquireInput, TrezorDeviceInfoWithSession } from './typ
 export default class FallbackTransport {
     _availableTransports: Array<Transport> = [];
     activeName = '';
-    // @ts-ignore
+    // @ts-expect-error
     activeTransport: Transport;
     configured = false;
     debug = false;

--- a/packages/transport/src/lowlevel/protobuf/decode.ts
+++ b/packages/transport/src/lowlevel/protobuf/decode.ts
@@ -48,7 +48,7 @@ function messageToJSON(Message: Message<Record<string, unknown>>, fields: Type['
 
     Object.keys(fields).forEach(key => {
         const field = fields[key];
-        // @ts-ignore
+        // @ts-expect-error
         const value = message[key];
 
         if (field.repeated) {

--- a/packages/transport/src/lowlevel/protobuf/messages.ts
+++ b/packages/transport/src/lowlevel/protobuf/messages.ts
@@ -3,7 +3,6 @@
 import * as protobuf from 'protobufjs/light';
 
 export function parseConfigure(data: protobuf.INamespace) {
-    // @ts-ignore [compatiblity]: connect is sending stringified json
     if (typeof data === 'string') {
         return protobuf.Root.fromJSON(JSON.parse(data));
     }

--- a/packages/transport/src/lowlevel/sharedConnectionWorker.ts
+++ b/packages/transport/src/lowlevel/sharedConnectionWorker.ts
@@ -232,12 +232,12 @@ function handleMessage(
 
 // TODO:
 // proper ts configuration for lib webworker
-// @ts-ignore
+// @ts-expect-error
 if (typeof onconnect !== 'undefined') {
-    // @ts-ignore
+    // @ts-expect-error
     onconnect = function (e) {
         const port = e.ports[0];
-        // @ts-ignore
+        // @ts-expect-error
         port.onmessage = function (e) {
             handleMessage(e.data, port);
         };

--- a/packages/transport/src/lowlevel/webusb.ts
+++ b/packages/transport/src/lowlevel/webusb.ts
@@ -148,7 +148,6 @@ export default class WebUsbPlugin {
             }
             return res.data.buffer.slice(1);
         } catch (e) {
-            // @ts-ignore
             if (e.message === 'Device unavailable.') {
                 throw new Error('Action was interrupted.');
             } else {

--- a/packages/transport/src/utils/highlevel-checks.ts
+++ b/packages/transport/src/utils/highlevel-checks.ts
@@ -53,7 +53,7 @@ export function devices(res: any): Array<TrezorDeviceInfoWithSession> {
             path: pathS,
             session: convertSession(o.session),
             debugSession: convertSession(o.debugSession),
-            // @ts-ignore
+            // @ts-expect-error
             product: o.product,
             vendor: o.vendor,
             debug: !!o.debug,

--- a/packages/utxo-lib/tests/address.test.ts
+++ b/packages/utxo-lib/tests/address.test.ts
@@ -4,7 +4,7 @@ import * as bscript from '../src/script';
 import fixtures from './__fixtures__/address';
 
 // keyof typeof NETWORKS;
-// @ts-ignore expression of type string can't be used to index type
+// @ts-expect-error expression of type string can't be used to index type
 const getNetwork = (name?: any) => (name ? NETWORKS[name] : NETWORKS.bitcoin);
 
 describe('address', () => {

--- a/packages/utxo-lib/tests/bip32.test.ts
+++ b/packages/utxo-lib/tests/bip32.test.ts
@@ -3,7 +3,7 @@ import * as NETWORKS from '../src/networks';
 import fixtures from './__fixtures__/bip32';
 
 // keyof typeof NETWORKS;
-// @ts-ignore expression of type string can't be used to index type
+// @ts-expect-error expression of type string can't be used to index type
 const getNetwork = (name?: any) => (name ? NETWORKS[name] : NETWORKS.bitcoin);
 
 type F = typeof fixtures.valid;

--- a/packages/utxo-lib/tests/compose.test.ts
+++ b/packages/utxo-lib/tests/compose.test.ts
@@ -10,7 +10,7 @@ import fixturesCrossCheck from './__fixtures__/compose.crosscheck';
 
 // keyof typeof NETWORKS;
 const getNetwork = (name?: string) =>
-    // @ts-ignore expression of type string can't be used to index type
+    // @ts-expect-error expression of type string can't be used to index type
     typeof name === 'string' && NETWORKS[name] ? NETWORKS[name] : NETWORKS.bitcoin;
 
 describe('composeTx', () => {

--- a/packages/utxo-lib/tests/transaction.utils.ts
+++ b/packages/utxo-lib/tests/transaction.utils.ts
@@ -6,7 +6,7 @@ const DEFAULT_SEQUENCE = 0xffffffff;
 const EMPTY_SCRIPT = Buffer.allocUnsafe(0);
 
 // keyof typeof NETWORKS;
-// @ts-ignore expression of type string can't be used to index type
+// @ts-expect-error expression of type string can't be used to index type
 export const getNetwork = (name?: string) => (name ? NETWORKS[name] : undefined);
 // export const getNetwork = (name?: string) => {
 //     Object.keys(NETWORKS).forEach(network => {

--- a/suite-common/suite-utils/src/__tests__/features.test.ts
+++ b/suite-common/suite-utils/src/__tests__/features.test.ts
@@ -30,27 +30,27 @@ jest.mock('@suite-common/suite-config', () => ({
 
 describe('Features utils', () => {
     test('mock flag should be disabled', () => {
-        // @ts-ignore Mocked flag
+        // @ts-expect-error Mocked flag
         expect(features.isEnabled('FLAG')).toBe(false);
     });
 
     test('mock flag should be enabled for web', () => {
-        // @ts-ignore Mocked flag
+        // @ts-expect-error Mocked flag
         expect(features.isEnabled('FLAG', 'web')).toBe(true);
     });
 
     test('mock flag should be disabled for desktop', () => {
-        // @ts-ignore Mocked flag
+        // @ts-expect-error Mocked flag
         expect(features.isEnabled('FLAG', 'desktop')).toBe(false);
     });
 
     test('mock flag should be enabled for landing', () => {
-        // @ts-ignore Mocked flag
+        // @ts-expect-error Mocked flag
         expect(features.isEnabled('FLAG', 'landing')).toBe(true);
     });
 
     test('Unknown flag should always default to false', () => {
-        // @ts-ignore Mocked flag
+        // @ts-expect-error Mocked flag
         expect(features.isEnabled('UNKNOWN')).toBe(false);
     });
 });

--- a/suite-common/test-utils/src/mocks.ts
+++ b/suite-common/test-utils/src/mocks.ts
@@ -19,7 +19,7 @@ import 'fake-indexeddb/auto';
  * @param {Partial<Account>} [account]
  * @returns {Features}
  */
-// @ts-ignore
+// @ts-expect-error
 const getWalletAccount = (account?: Partial<Account>): Account => ({
     deviceState: '7dcccffe70d8bb8bb28a2185daac8e05639490eee913b326097ae1d73abc8b4f',
     index: 0,
@@ -626,7 +626,6 @@ const fee: FeeInfo = {
 };
 
 const intlMock = {
-    // @ts-ignore
     formatMessage: (s: any) => s.defaultMessage,
 };
 

--- a/suite-common/wallet-utils/src/__tests__/accountUtils.test.ts
+++ b/suite-common/wallet-utils/src/__tests__/accountUtils.test.ts
@@ -23,7 +23,7 @@ import * as fixtures from '../__fixtures__/accountUtils';
 describe('account utils', () => {
     fixtures.getUtxoFromSignedTransaction.forEach(f => {
         it(`getUtxoFromSignedTransaction: ${f.description}`, () => {
-            // @ts-ignore params are partial
+            // @ts-expect-error params are partial
             expect(getUtxoFromSignedTransaction(...f.params)).toMatchObject(f.result);
         });
     });
@@ -51,7 +51,7 @@ describe('account utils', () => {
     describe('getBip43Type', () => {
         fixtures.getBip43Type.forEach(f => {
             it(f.description, () => {
-                // @ts-ignore intentional invalid params
+                // @ts-expect-error intentional invalid params
                 const bip43 = getBip43Type(f.path);
                 expect(bip43).toBe(f.result);
             });

--- a/suite-common/wallet-utils/src/__tests__/balanceUtils.test.ts
+++ b/suite-common/wallet-utils/src/__tests__/balanceUtils.test.ts
@@ -1,7 +1,7 @@
 import { formatCoinBalance } from '../balanceUtils';
 
 test('formatBalanceUtils', () => {
-    // @ts-ignore
+    // @ts-expect-error
     expect(formatCoinBalance(undefined)).toEqual('0');
     expect(formatCoinBalance('ssssstring')).toEqual('0');
     expect(formatCoinBalance('0')).toEqual('0');

--- a/suite-common/wallet-utils/src/__tests__/fiatConverter.test.ts
+++ b/suite-common/wallet-utils/src/__tests__/fiatConverter.test.ts
@@ -32,7 +32,7 @@ describe('fiatConverter utils: toFiatCurrency', () => {
     });
 
     it('to existing fiat missing network rates', () => {
-        // @ts-ignore
+        // @ts-expect-error
         expect(toFiatCurrency('1', 'czk', null)).toBe(null);
     });
 });
@@ -78,7 +78,6 @@ describe('fiatConverter utils: fromFiatCurrency', () => {
     });
 
     it('missing fiat rates', () => {
-        // @ts-ignore
         expect(fromFiatCurrency('1', 'usd', undefined, decimals)).toBe(null);
     });
 });

--- a/suite-common/wallet-utils/src/__tests__/networkUtils.test.ts
+++ b/suite-common/wallet-utils/src/__tests__/networkUtils.test.ts
@@ -1,7 +1,6 @@
 import { httpRequest } from '../networkUtils';
 
 const setMock = (mock: any) => {
-    // @ts-ignore
     global.fetch = jest.fn().mockImplementation(() => {
         const p = new Promise(resolve => {
             resolve({

--- a/suite-common/wallet-utils/src/__tests__/sendFormUtils.test.ts
+++ b/suite-common/wallet-utils/src/__tests__/sendFormUtils.test.ts
@@ -85,13 +85,13 @@ describe('sendForm utils', () => {
 
     it('findComposeErrors', () => {
         expect(findComposeErrors({})).toEqual([]);
-        // @ts-ignore: params
+        // @ts-expect-error: params
         expect(findComposeErrors(null)).toEqual([]);
-        // @ts-ignore: params
+        // @ts-expect-error: params
         expect(findComposeErrors(true)).toEqual([]);
-        // @ts-ignore: params
+        // @ts-expect-error: params
         expect(findComposeErrors(1)).toEqual([]);
-        // @ts-ignore: params
+        // @ts-expect-error: params
         expect(findComposeErrors('A')).toEqual([]);
 
         expect(findComposeErrors({ someField: { type: 'validate' } })).toEqual([]);
@@ -115,13 +115,13 @@ describe('sendForm utils', () => {
     });
 
     it('getBitcoinComposeOutputs', () => {
-        // @ts-ignore: invalid params
+        // @ts-expect-error: invalid params
         expect(getBitcoinComposeOutputs(null, 'btc')).toEqual([]);
-        // @ts-ignore: invalid params
+        // @ts-expect-error: invalid params
         expect(getBitcoinComposeOutputs(true, 'btc')).toEqual([]);
-        // @ts-ignore: invalid params
+        // @ts-expect-error: invalid params
         expect(getBitcoinComposeOutputs(1, 'btc')).toEqual([]);
-        // @ts-ignore: invalid params
+        // @ts-expect-error: invalid params
         expect(getBitcoinComposeOutputs('A', 'btc')).toEqual([]);
 
         expect(getBitcoinComposeOutputs({ outputs: [] }, 'btc')).toEqual([]);
@@ -220,28 +220,28 @@ describe('sendForm utils', () => {
     });
 
     it('getExternalComposeOutput', () => {
-        // @ts-ignore: invalid params
+        // @ts-expect-error: invalid params
         expect(getExternalComposeOutput(null)).toEqual(undefined);
-        // @ts-ignore: invalid params
+        // @ts-expect-error: invalid params
         expect(getExternalComposeOutput(true)).toEqual(undefined);
-        // @ts-ignore: invalid params
+        // @ts-expect-error: invalid params
         expect(getExternalComposeOutput(1)).toEqual(undefined);
-        // @ts-ignore: invalid params
+        // @ts-expect-error: invalid params
         expect(getExternalComposeOutput('A')).toEqual(undefined);
         expect(
-            // @ts-ignore: invalid params
+            // @ts-expect-error: invalid params
             getExternalComposeOutput({ outputs: [null] }),
         ).toEqual(undefined);
         expect(
-            // @ts-ignore: invalid params
+            // @ts-expect-error: invalid params
             getExternalComposeOutput({ outputs: [1] }),
         ).toEqual(undefined);
         expect(
-            // @ts-ignore: invalid params
+            // @ts-expect-error: invalid params
             getExternalComposeOutput({ outputs: ['A'] }),
         ).toEqual(undefined);
         expect(
-            // @ts-ignore: invalid params
+            // @ts-expect-error: invalid params
             getExternalComposeOutput({ outputs: [{}] }),
         ).toEqual(undefined);
 
@@ -348,24 +348,24 @@ describe('sendForm utils', () => {
         expect(calculateEthFee('', '')).toEqual('0');
         expect(calculateEthFee('1', '')).toEqual('0');
         expect(calculateEthFee('0', '1')).toEqual('0');
-        // @ts-ignore invalid params
+        // @ts-expect-error invalid params
         expect(calculateEthFee({}, {})).toEqual('0');
-        // @ts-ignore invalid params
+        // @ts-expect-error invalid params
         expect(calculateEthFee(() => {}, {})).toEqual('0');
-        // @ts-ignore invalid params
+        // @ts-expect-error invalid params
         expect(calculateEthFee(null, true)).toEqual('0');
         expect(calculateEthFee('1', '2')).toEqual('2');
     });
 
     it('getFiatRate', () => {
         expect(getFiatRate(undefined, 'usd')).toBe(undefined);
-        // @ts-ignore invalid params
+        // @ts-expect-error invalid params
         expect(getFiatRate({}, 'usd')).toBe(undefined);
-        // @ts-ignore invalid params
+        // @ts-expect-error invalid params
         expect(getFiatRate({ current: {} }, 'usd')).toBe(undefined);
-        // @ts-ignore invalid params
+        // @ts-expect-error invalid params
         expect(getFiatRate({ current: { rates: {} } }, 'usd')).toBe(undefined);
-        // @ts-ignore invalid params
+        // @ts-expect-error invalid params
         expect(getFiatRate({ current: { rates: { usd: 1 } } }, 'usd')).toBe(1);
     });
 });


### PR DESCRIPTION
Enforce usage of `@ts-expect-error` instead of `@ts-ignore`

Removed lot of unused `@ts-ignore`

More details in code style guide: https://www.notion.so/satoshilabs/Typescript-4640c944a60442e684b45f343104de37