### PR TITLE
npm-release @trezor/connect [1/2]

### DIFF
--- a/packages/connect-explorer/package.json
+++ b/packages/connect-explorer/package.json
@@ -10,7 +10,7 @@
     },
     "dependencies": {
         "@trezor/components": "*",
-        "@trezor/connect-web": "9.0.0-beta.7",
+        "@trezor/connect-web": "9.0.0-beta.8",
         "markdown-it": "^12.3.2",
         "markdown-it-link-attributes": "^4.0.0",
         "markdown-it-replace-link": "^1.0.1",

--- a/packages/connect-iframe/package.json
+++ b/packages/connect-iframe/package.json
@@ -11,7 +11,7 @@
     },
     "dependencies": {},
     "devDependencies": {
-        "@trezor/connect": "9.0.0-beta.7",
+        "@trezor/connect": "9.0.0-beta.8",
         "copy-webpack-plugin": "^11.0.0",
         "html-webpack-plugin": "^5.5.0",
         "terser-webpack-plugin": "^5.3.3",

--- a/packages/connect-popup/package.json
+++ b/packages/connect-popup/package.json
@@ -10,7 +10,7 @@
         "build": "rimraf build && TS_NODE_PROJECT=\"tsconfig.json\" webpack --config ./webpack/prod.webpack.config.ts"
     },
     "dependencies": {
-        "@trezor/connect": "9.0.0-beta.7",
+        "@trezor/connect": "9.0.0-beta.8",
         "@trezor/components": "*",
         "@trezor/connect-ui": "*",
         "@trezor/urls": "*",

--- a/packages/connect-web/package.json
+++ b/packages/connect-web/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@trezor/connect-web",
-    "version": "9.0.0-beta.7",
+    "version": "9.0.0-beta.8",
     "author": "Trezor <info@trezor.io>",
     "homepage": "https://github.com/trezor/trezor-suite/tree/develop/packages/connect-web",
     "description": "High-level javascript interface for Trezor hardware wallet.",
@@ -35,7 +35,7 @@
         "build": "rimraf build && yarn build:inline && yarn build:webextension"
     },
     "dependencies": {
-        "@trezor/connect": "9.0.0-beta.7",
+        "@trezor/connect": "9.0.0-beta.8",
         "@trezor/utils": "^9.0.2",
         "events": "^3.3.0",
         "tslib": "^2.3.1"

--- a/packages/connect-web/src/webextension/trezor-usb-permissions.js
+++ b/packages/connect-web/src/webextension/trezor-usb-permissions.js
@@ -1,4 +1,4 @@
-const VERSION = '9.0.0-beta.7';
+const VERSION = '9.0.0-beta.8';
 const versionN = VERSION.split('.').map(s => parseInt(s, 10));
 // const DIRECTORY = `${ versionN[0] }${ (versionN[1] > 0 ? `.${versionN[1]}` : '') }/`;
 const DIRECTORY = `${versionN[0]}/`;

--- a/packages/connect/README.md
+++ b/packages/connect/README.md
@@ -1,6 +1,6 @@
 # @trezor/connect
 
-API version 9.0.0-beta.7
+API version 9.0.0-beta.8
 
 [![Build Status](https://github.com/trezor/trezor-suite/actions/workflows/connect-test.yml/badge.svg)](https://github.com/trezor/trezor-suite/actions/workflows/connect-test.yml)
 [![NPM](https://img.shields.io/npm/v/@trezor/connect.svg)](https://www.npmjs.org/package/@trezor/connect)

--- a/packages/connect/package.json
+++ b/packages/connect/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@trezor/connect",
-    "version": "9.0.0-beta.7",
+    "version": "9.0.0-beta.8",
     "author": "Trezor <info@trezor.io>",
     "homepage": "https://github.com/trezor/trezor-suite/tree/develop/packages/connect",
     "description": "High-level javascript interface for Trezor hardware wallet.",

--- a/packages/connect/src/data/version.ts
+++ b/packages/connect/src/data/version.ts
@@ -1,4 +1,4 @@
-export const VERSION = '9.0.0-beta.7';
+export const VERSION = '9.0.0-beta.8';
 
 const versionN = VERSION.split('.').map(s => parseInt(s, 10));
 

--- a/packages/suite-desktop/package.json
+++ b/packages/suite-desktop/package.json
@@ -184,7 +184,7 @@
     "dependencies": {
         "@sentry/electron": "3.0.0",
         "@suite-common/suite-utils": "*",
-        "@trezor/connect": "9.0.0-beta.7",
+        "@trezor/connect": "9.0.0-beta.8",
         "@trezor/suite-analytics": "*",
         "@trezor/suite-desktop-api": "*",
         "@trezor/urls": "*",

--- a/packages/suite/package.json
+++ b/packages/suite/package.json
@@ -28,7 +28,7 @@
         "@sentry/integrations": "6.17.2",
         "@sentry/minimal": "6.17.2",
         "@trezor/components": "*",
-        "@trezor/connect": "9.0.0-beta.7",
+        "@trezor/connect": "9.0.0-beta.8",
         "@trezor/react-utils": "*",
         "@trezor/suite-analytics": "*",
         "@suite-common/connect-init": "*",

--- a/suite-common/connect-init/package.json
+++ b/suite-common/connect-init/package.json
@@ -16,7 +16,7 @@
         "@reduxjs/toolkit": "^1.8.3",
         "@suite-common/redux-utils": "*",
         "@suite-native/state": "*",
-        "@trezor/connect": "9.0.0-beta.7",
+        "@trezor/connect": "9.0.0-beta.8",
         "@trezor/utils": "*"
     },
     "devDependencies": {

--- a/suite-common/notifications/package.json
+++ b/suite-common/notifications/package.json
@@ -13,6 +13,6 @@
     "dependencies": {
         "@suite-common/wallet-config": "*",
         "@suite-common/suite-types": "*",
-        "@trezor/connect": "9.0.0-beta.7"
+        "@trezor/connect": "9.0.0-beta.8"
     }
 }

--- a/suite-common/redux-utils/package.json
+++ b/suite-common/redux-utils/package.json
@@ -15,7 +15,7 @@
         "@suite-common/wallet-types": "*",
         "@suite-common/wallet-config": "*",
         "@suite-common/notifications": "*",
-        "@trezor/connect": "9.0.0-beta.7",
+        "@trezor/connect": "9.0.0-beta.8",
         "redux": "^4.2.0"
     }
 }

--- a/suite-common/suite-types/package.json
+++ b/suite-common/suite-types/package.json
@@ -11,7 +11,7 @@
     },
     "dependencies": {
         "@suite-common/metadata-types": "*",
-        "@trezor/connect": "9.0.0-beta.7",
+        "@trezor/connect": "9.0.0-beta.8",
         "@trezor/suite-data": "*"
     }
 }

--- a/suite-common/test-utils/package.json
+++ b/suite-common/test-utils/package.json
@@ -12,7 +12,7 @@
     "dependencies": {
         "@suite-common/suite-types": "*",
         "@suite-common/wallet-types": "*",
-        "@trezor/connect": "9.0.0-beta.7",
+        "@trezor/connect": "9.0.0-beta.8",
         "dropbox": "^10.32.0",
         "fake-indexeddb": "^3.1.7"
     }

--- a/suite-common/wallet-types/package.json
+++ b/suite-common/wallet-types/package.json
@@ -14,7 +14,7 @@
         "@suite-common/wallet-constants": "*",
         "@suite-common/intl-types": "*",
         "@suite-common/suite-utils": "*",
-        "@trezor/connect": "9.0.0-beta.7",
+        "@trezor/connect": "9.0.0-beta.8",
         "@trezor/type-utils": "*",
         "@trezor/utils": "*",
         "react": "17.0.2",

--- a/suite-common/wallet-utils/package.json
+++ b/suite-common/wallet-utils/package.json
@@ -24,7 +24,7 @@
         "@suite-common/wallet-constants": "*",
         "@suite-common/wallet-config": "*",
         "@suite-common/wallet-types": "*",
-        "@trezor/connect": "9.0.0-beta.7",
+        "@trezor/connect": "9.0.0-beta.8",
         "@trezor/urls": "*",
         "@trezor/utils": "*",
         "bignumber.js": "^9.1.0",

--- a/suite-native/app/package.json
+++ b/suite-native/app/package.json
@@ -26,7 +26,7 @@
         "@suite-native/module-settings": "*",
         "@suite-native/navigation": "*",
         "@suite-native/state": "*",
-        "@trezor/connect": "9.0.0-beta.7",
+        "@trezor/connect": "9.0.0-beta.8",
         "@trezor/styles": "*",
         "@trezor/theme": "*",
         "@trezor/transport-native": "*",

--- a/suite-native/module-onboarding/package.json
+++ b/suite-native/module-onboarding/package.json
@@ -20,7 +20,7 @@
         "@suite-native/atoms": "*",
         "@suite-native/navigation": "*",
         "@reduxjs/toolkit": "^1.8.3",
-        "@trezor/connect": "9.0.0-beta.7",
+        "@trezor/connect": "9.0.0-beta.8",
         "@trezor/icons": "*",
         "@trezor/styles": "*",
         "react": "^17.0.2",

--- a/suite-native/state/package.json
+++ b/suite-native/state/package.json
@@ -12,7 +12,7 @@
     "dependencies": {
         "@reduxjs/toolkit": "^1.8.3",
         "@trezor/styles": "*",
-        "@trezor/connect": "9.0.0-beta.7",
+        "@trezor/connect": "9.0.0-beta.8",
         "@suite-common/redux-utils": "*",
         "@suite-common/test-utils": "*",
         "@suite-native/module-onboarding": "*",


### PR DESCRIPTION
## @trezor/connect npm release

-   [x] Bump version in all @trezor/connect\* packages (except plugin packages). `yarn workspace @trezor/connect version:<beta|patch|minor|major>`
-   [ ] Make sure you have released all npm dependencies. If unsure run `node ./ci/scripts/check-npm-dependencies.js connect`. Please note that this script will report unreleased dependencies even for changes that do not affect runtime (READMEs etc.)
-   [ ] If there are any unreleased npm dependencies you should [release them](./npm-packages.md)
-   [ ] Make sure CHANGELOG files have been updated
-   [ ] Release npm packages for `@trezor/connect` and `@trezor/connect-web` [from gitlab](https://gitlab.com/satoshilabs/trezor/trezor-suite/-/pipelines)
