### PR TITLE
fix(docs): add path.md to SUMMARY.md, unify heading types

### DIFF
--- a/docs/SUMMARY.md
+++ b/docs/SUMMARY.md
@@ -19,6 +19,7 @@
         -   [protobuf](./packages/connect/protobuf-type-definitions.md)
         -   [coins support](./packages/connect/supported-coins.md)
         -   [events](./packages/connect/events.md)
+        -   [path](./packages/connect/path.md)
         -   [methods](./packages/connect/methods.md)
             -   [common parameters](./packages/connect/methods/commonParams.md)
             -   [getPublicKey](./packages/connect/methods/getPublicKey.md)

--- a/docs/packages/connect/dependencies.md
+++ b/docs/packages/connect/dependencies.md
@@ -1,3 +1,5 @@
+# Dependencies
+
 ## Webpack:
 
 Since `webpack@5` auto polyfills for `nodejs` are not provided.

--- a/docs/packages/connect/events.md
+++ b/docs/packages/connect/events.md
@@ -1,3 +1,5 @@
+# Events
+
 ## Handling events
 
 Once user grants permission for hosting page to communicate with API TrezorConnect will emits events

--- a/docs/packages/connect/index.md
+++ b/docs/packages/connect/index.md
@@ -1,3 +1,5 @@
+# Trezor Connect
+
 ## How to use
 
 Initialize in project

--- a/docs/packages/connect/methods.md
+++ b/docs/packages/connect/methods.md
@@ -1,4 +1,4 @@
-## Methods
+# Methods
 
 API call return a [`Promise`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise). Resolve is guaranteed to get called
 with a `result` object, even if user closes the window, network connection times
@@ -16,7 +16,7 @@ Every method require an [`Object`](https://developer.mozilla.org/en-US/docs/Web/
 -   [TrezorConnect.getCoinInfo](methods/getCoinInfo.md)
 -   [TrezorConnect.getDeviceState](methods/getDeviceState.md)
 
-### Bitcoin, Bitcoin Cash, Bitcoin Gold, Litecoin, Dash, ZCash, Testnet
+## Bitcoin, Bitcoin Cash, Bitcoin Gold, Litecoin, Dash, ZCash, Testnet
 
 -   [TrezorConnect.getAddress](methods/getAddress.md)
 -   [TrezorConnect.getAccountInfo](methods/getAccountInfo.md)
@@ -29,7 +29,7 @@ Every method require an [`Object`](https://developer.mozilla.org/en-US/docs/Web/
 -   [TrezorConnect.verifyMessage](methods/verifyMessage.md)
 -   [TrezorConnect.authorizeCoinJoin](methods/authorizeCoinJoin.md)
 
-### Ethereum
+## Ethereum
 
 -   [TrezorConnect.ethereumGetAddress](methods/ethereumGetAddress.md)
 -   [TrezorConnect.ethereumSignTransaction](methods/ethereumSignTransaction.md)
@@ -37,45 +37,45 @@ Every method require an [`Object`](https://developer.mozilla.org/en-US/docs/Web/
 -   [TrezorConnect.ethereumSignTypedData](methods/ethereumSignTypedData.md)
 -   [TrezorConnect.ethereumVerifyMessage](methods/ethereumVerifyMessage.md)
 
-### Eos
+## Eos
 
 -   [TrezorConnect.eosGetPublicKey](methods/eosGetPublicKey.md)
 -   [TrezorConnect.eosSignTransaction](methods/eosSignTransaction.md)
 
-### NEM
+## NEM
 
 -   [TrezorConnect.nemGetAddress](methods/nemGetAddress.md)
 -   [TrezorConnect.nemSignTransaction](methods/nemSignTransaction.md)
 
-### Stellar
+## Stellar
 
 -   [TrezorConnect.stellarGetAddress](methods/stellarGetAddress.md)
 -   [TrezorConnect.stellarSignTransaction](methods/stellarSignTransaction.md)
 
-### Cardano
+## Cardano
 
 -   [TrezorConnect.cardanoGetPublicKey](methods/cardanoGetPublicKey.md)
 -   [TrezorConnect.cardanoGetAddress](methods/cardanoGetAddress.md)
 -   [TrezorConnect.cardanoSignTransaction](methods/cardanoSignTransaction.md)
 
-### Ripple
+## Ripple
 
 -   [TrezorConnect.rippleGetAddress](methods/rippleGetAddress.md)
 -   [TrezorConnect.rippleSignTransaction](methods/rippleSignTransaction.md)
 
-### Tezos
+## Tezos
 
 -   [TrezorConnect.tezosGetAddress](methods/tezosGetAddress.md)
 -   [TrezorConnect.tezosGetPublicKey](methods/tezosGetPublicKey.md)
 -   [TrezorConnect.tezosSignTransaction](methods/tezosSignTransaction.md)
 
-### Binance
+## Binance
 
 -   [TrezorConnect.binanceGetAddress](methods/binanceGetAddress.md)
 -   [TrezorConnect.binanceGetPublicKey](methods/binanceGetPublicKey.md)
 -   [TrezorConnect.binanceSignTransaction](methods/binanceSignTransaction.md)
 
-### Management
+## Management
 
 > please note that these method are not available from popup mode
 

--- a/docs/packages/connect/methods/commonParams.md
+++ b/docs/packages/connect/methods/commonParams.md
@@ -1,4 +1,4 @@
-## Common parameters
+# Common parameters
 
 Every call requires an [`Object`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object) with a combination of common and method-specified fields.
 All common parameters are optional.

--- a/docs/packages/connect/methods/getPublicKey.md
+++ b/docs/packages/connect/methods/getPublicKey.md
@@ -13,7 +13,7 @@ const result = await TrezorConnect.getPublicKey(params);
 
 #### Exporting single public key
 
--   `path` — _required_ `string | Array<number>` minimum length is `1`. [read more](path.md)
+-   `path` — _required_ `string | Array<number>` minimum length is `1`. [read more](../path.md)
 -   `coin` - _optional_ `string` determines network definition specified in [coins.json](../../src/data/coins.json) file. Coin `shortcut`, `name` or `label` can be used. If `coin` is not set API will try to get network definition from `path`.
 -   `crossChain` — _optional_ `boolean` Advanced feature. Use it only if you are know what you are doing. Allows to generate address between chains. For example Bitcoin path on Litecoin network will display cross chain address in Litecoin format.
 

--- a/docs/packages/connect/path.md
+++ b/docs/packages/connect/path.md
@@ -1,8 +1,8 @@
-## Path
+# Path
 
 -   `path` - `string | Array<number>` in [BIP44](https://github.com/trezor/trezor-firmware/blob/master/docs/misc/coins-bip44-paths.md#bip-44-derivation-paths) path scheme or `Array` of hardended numbers.
 
-### Examples
+## Examples
 
 Bitcoin account 1 using BIP44 derivation path
 


### PR DESCRIPTION
Fixes a broken link to _path.md_ in docs by actually adding the file to the published docs.
Also unifies heading styles in the Connect section.

## Related Issue

Resolve https://www.notion.so/satoshilabs/Broken-Links-5771-66fdc1b727a048648aba5ae0cc3fc325 (FYI @bosomt)
With the removal of the specs section (#5961) and fixing paths in Connect methods docs (#6066), all links in docs should be working now.
