### PR TITLE
chore: code sharing - motionProps in components

### DIFF
--- a/packages/components/src/config/motion.ts
+++ b/packages/components/src/config/motion.ts
@@ -1,5 +1,5 @@
-export default {
-    EXPAND: {
+export const motionAnimation = {
+    expand: {
         variants: {
             initial: {
                 overflow: 'unset',
@@ -17,6 +17,9 @@ export default {
     },
 };
 
-export const transitionEase = [0.65, 0, 0.35, 1];
-export const enterEase = [0.33, 1, 0.68, 1];
-export const exitEase = [0.32, 0, 0.67, 0];
+export const motionEasing = {
+    transition: [0.65, 0, 0.35, 1],
+    enter: [0.33, 1, 0.68, 1],
+    //  exit easy is not used anywhere?
+    exit: [0.32, 0, 0.67, 0],
+};

--- a/packages/components/src/index.ts
+++ b/packages/components/src/index.ts
@@ -1,6 +1,7 @@
 import colors, { THEME } from './config/colors';
 
 export * as variables from './config/variables';
+export { motionAnimation, motionEasing } from './config/motion';
 
 export * as types from './support/types';
 export * from './support/ThemeProvider';

--- a/packages/suite/src/components/onboarding/Box.tsx
+++ b/packages/suite/src/components/onboarding/Box.tsx
@@ -3,9 +3,16 @@ import styled, { css } from 'styled-components';
 import { motion, Variants } from 'framer-motion';
 import Text from '@onboarding-components/Text';
 import { Translation } from '@suite-components';
-import { H1, variables, Button, Image, useTheme, ImageType } from '@trezor/components';
+import {
+    H1,
+    variables,
+    Button,
+    Image,
+    useTheme,
+    ImageType,
+    motionEasing,
+} from '@trezor/components';
 import useMeasure from 'react-use/lib/useMeasure';
-import { transitionEase } from '@suite-config/animation';
 import { useLayoutSize } from '@suite-hooks/useLayoutSize';
 
 const BoxWrapper = styled(
@@ -217,7 +224,7 @@ export const Box = ({
             nested={nested}
             variants={expandable ? wrapperVariants : undefined}
             animate={expanded ? 'expanded' : 'closed'}
-            transition={{ duration: 0.4, ease: transitionEase }}
+            transition={{ duration: 0.4, ease: motionEasing.transition }}
             onClick={expandable && !expanded ? onToggle : undefined}
             data-test="@onboarding/box-animated"
             {...rest}
@@ -242,7 +249,7 @@ export const Box = ({
                 <motion.div
                     variants={expandable ? animationVariants : undefined}
                     animate={expanded ? 'expanded' : 'closed'}
-                    transition={{ duration: 0.4, ease: transitionEase }}
+                    transition={{ duration: 0.4, ease: motionEasing.transition }}
                 >
                     <div ref={heightRef}>
                         {expandable && expanded && (

--- a/packages/suite/src/components/onboarding/ConnectDevicePromptManager/index.tsx
+++ b/packages/suite/src/components/onboarding/ConnectDevicePromptManager/index.tsx
@@ -15,7 +15,7 @@ import { NoTransport } from './components/NoTransport';
 import { NoDeviceDetected } from './components/NoDeviceDetected';
 import { UnexpectedDeviceState } from './components/UnexpectedDeviceState';
 import { motion } from 'framer-motion';
-import { enterEase } from '@suite-config/animation';
+import { motionEasing } from '@trezor/components';
 
 const Wrapper = styled.div`
     display: flex;
@@ -87,7 +87,7 @@ export const ConnectDevicePromptManager = ({
             <ContentWrapper
                 initial={{ opacity: 0 }}
                 animate={{ opacity: 1 }}
-                transition={{ delay: 0.6, duration: 0.5, ease: enterEase }}
+                transition={{ delay: 0.6, duration: 0.5, ease: motionEasing.enter }}
             >
                 {content ?? children}
             </ContentWrapper>

--- a/packages/suite/src/components/suite/CollapsibleBox.tsx
+++ b/packages/suite/src/components/suite/CollapsibleBox.tsx
@@ -2,8 +2,7 @@ import React, { useState, useEffect, useMemo, useCallback } from 'react';
 import styled, { css } from 'styled-components';
 import { motion, Variants } from 'framer-motion';
 import useMeasure from 'react-use/lib/useMeasure';
-import { Icon, variables } from '@trezor/components';
-import { transitionEase } from '@suite-config/animation';
+import { Icon, variables, motionEasing } from '@trezor/components';
 
 const Wrapper = styled.div<Pick<CollapsibleBoxProps, 'variant'>>`
     display: flex;
@@ -199,7 +198,7 @@ export const CollapsibleBox = ({
                 animate={collapsed ? 'closed' : 'opened'}
                 initial="closed"
                 variants={animationVariants}
-                transition={{ duration: 0.35, ease: transitionEase }}
+                transition={{ duration: 0.35, ease: motionEasing.transition }}
                 style={{ overflow: 'hidden' }}
                 data-test="@collapsible-box/body"
             >

--- a/packages/suite/src/components/suite/ConnectDevicePrompt.tsx
+++ b/packages/suite/src/components/suite/ConnectDevicePrompt.tsx
@@ -1,14 +1,13 @@
 import React from 'react';
 import styled from 'styled-components';
 
-import { variables, Icon, Button, useTheme } from '@trezor/components';
+import { variables, Icon, Button, useTheme, motionEasing } from '@trezor/components';
 import { DeviceAnimation } from '@onboarding-components';
 import { Translation } from '@suite-components';
 import { useDevice, useActions } from '@suite-hooks';
 import * as routerActions from '@suite-actions/routerActions';
 import type { PrerequisiteType } from '@suite-types';
 import { motion } from 'framer-motion';
-import { enterEase } from '@suite-config/animation';
 
 const Wrapper = styled(motion.div)`
     display: flex;
@@ -97,7 +96,7 @@ export const ConnectDevicePrompt = ({
         <Wrapper
             initial={{ opacity: 0, y: -50 }}
             animate={{ opacity: 1, y: -0 }}
-            transition={{ delay: 0.2, duration: 0.6, ease: enterEase }}
+            transition={{ delay: 0.2, duration: 0.6, ease: motionEasing.enter }}
             data-test="@connect-device-prompt"
         >
             <ImageWrapper>

--- a/packages/suite/src/components/suite/PrerequisitesGuide/index.tsx
+++ b/packages/suite/src/components/suite/PrerequisitesGuide/index.tsx
@@ -1,6 +1,6 @@
 import React, { useMemo } from 'react';
 import styled, { css } from 'styled-components';
-import { variables } from '@trezor/components';
+import { variables, motionEasing } from '@trezor/components';
 import { ConnectDevicePrompt } from '@suite-components';
 import { isWebUsb } from '@suite-utils/transport';
 import { getStatus, deviceNeedsAttention } from '@suite-utils/device';
@@ -20,7 +20,6 @@ import { DeviceNoFirmware } from './components/DeviceNoFirmware';
 import { DeviceUpdateRequired } from './components/DeviceUpdateRequired';
 import { DeviceDisconnectRequired } from './components/DeviceDisconnectRequired';
 import { motion } from 'framer-motion';
-import { enterEase } from '@suite-config/animation';
 
 const Wrapper = styled.div<{ padded?: boolean }>`
     display: flex;
@@ -116,7 +115,7 @@ export const PrerequisitesGuide = ({
             <TipsContainer
                 initial={{ opacity: 0 }}
                 animate={{ opacity: 1 }}
-                transition={{ delay: 0.6, duration: 0.5, ease: enterEase }}
+                transition={{ delay: 0.6, duration: 0.5, ease: motionEasing.enter }}
             >
                 <TipComponent />
             </TipsContainer>

--- a/packages/suite/src/components/suite/SwitchDevice/components/DeviceItem/index.tsx
+++ b/packages/suite/src/components/suite/SwitchDevice/components/DeviceItem/index.tsx
@@ -1,10 +1,9 @@
 import React, { useState } from 'react';
 import { AnimatePresence, motion } from 'framer-motion';
 import styled from 'styled-components';
-import { useTheme, variables, Icon, DeviceImage } from '@trezor/components';
+import { useTheme, variables, Icon, DeviceImage, motionAnimation } from '@trezor/components';
 import { Translation } from '@suite-components';
 import * as deviceUtils from '@suite-utils/device';
-import { ANIMATION } from '@suite-config';
 import { useSelector, useActions } from '@suite-hooks';
 import * as routerActions from '@suite-actions/routerActions';
 import * as suiteActions from '@suite-actions/suiteActions';
@@ -246,7 +245,7 @@ const DeviceItem = ({ device, instances, onCancel, backgroundRoute }: Props) => 
             {!needsAttention && (
                 <AnimatePresence initial={false}>
                     {!isUnknown && isExpanded && (
-                        <motion.div {...ANIMATION.EXPAND}>
+                        <motion.div {...motionAnimation.expand}>
                             <WalletsWrapper enabled>
                                 {instancesWithState.length > 0 && (
                                     <WalletsTooltips>

--- a/packages/suite/src/components/suite/modals/AddAccount/components/EnableNetwork.tsx
+++ b/packages/suite/src/components/suite/modals/AddAccount/components/EnableNetwork.tsx
@@ -1,11 +1,11 @@
 import React, { useState } from 'react';
 import styled from 'styled-components';
 import { AnimatePresence, motion } from 'framer-motion';
-import { Icon, P, useTheme } from '@trezor/components';
+import { Icon, P, useTheme, motionAnimation } from '@trezor/components';
 
 import { CoinsList, Translation } from '@suite-components';
 import { Network } from '@wallet-types';
-import { ANIMATION } from '@suite-config';
+
 import { MoreCoins } from './MoreCoins';
 
 const TestnetCoinsTrigger = styled.div`
@@ -29,7 +29,7 @@ const Label = styled(
         isTestnetVisible ? theme.TYPE_DARK_GREY : theme.TYPE_LIGHT_GREY};
 `;
 
-const TestnetCoinsWrapper = styled(motion.div).attrs(() => ({ ...ANIMATION.EXPAND }))`
+const TestnetCoinsWrapper = styled(motion.div).attrs(() => ({ ...motionAnimation.expand }))`
     display: flex;
     flex-direction: column;
 `;

--- a/packages/suite/src/components/suite/modals/ImportTransaction/components/ExampleCSV.tsx
+++ b/packages/suite/src/components/suite/modals/ImportTransaction/components/ExampleCSV.tsx
@@ -1,10 +1,9 @@
 import React, { useState } from 'react';
 import styled from 'styled-components';
 import { motion, AnimatePresence } from 'framer-motion';
-import { P, Icon, variables } from '@trezor/components';
+import { P, Icon, variables, motionAnimation } from '@trezor/components';
 import { Translation } from '@suite-components';
 import { useSelector } from '@suite-hooks';
-import { ANIMATION } from '@suite-config';
 
 const Wrapper = styled.div`
     display: flex;
@@ -65,7 +64,7 @@ export const ExampleCSV = () => {
 
             <AnimatePresence initial={false}>
                 {isExpanded && (
-                    <ExpandWrapper {...ANIMATION.EXPAND}>
+                    <ExpandWrapper {...motionAnimation.expand}>
                         {/* CSV keys shouldn't be translated */}
                         <P size="small">address,amount,currency</P>
                         <P size="small">

--- a/packages/suite/src/components/suite/modals/Passphrase/components/PassphraseTypeCard/index.tsx
+++ b/packages/suite/src/components/suite/modals/Passphrase/components/PassphraseTypeCard/index.tsx
@@ -1,10 +1,18 @@
 import React, { useState, useRef, useEffect, useCallback } from 'react';
 import { AnimatePresence, motion } from 'framer-motion';
 import { useKeyPress } from '@trezor/react-utils';
-import { ANIMATION } from '@suite-config';
 import { setCaretPosition } from '@trezor/dom-utils';
 import styled, { css } from 'styled-components';
-import { Button, useTheme, variables, Input, Tooltip, Checkbox, Icon } from '@trezor/components';
+import {
+    Button,
+    useTheme,
+    variables,
+    Input,
+    Tooltip,
+    Checkbox,
+    Icon,
+    motionAnimation,
+} from '@trezor/components';
 import { Translation } from '@suite-components/Translation';
 import { MAX_LENGTH } from '@suite-constants/inputs';
 import { countBytesInString } from '@trezor/utils';
@@ -368,7 +376,7 @@ const PassphraseTypeCard = (props: Props) => {
                         {/* Submit button */}
                         {/* Visible in standalone modal for creating a hidden wallet or after a click also in modal for selecting wallet type */}
                         {(props.singleColModal || hiddenWalletTouched) && (
-                            <motion.div {...ANIMATION.EXPAND}>
+                            <motion.div {...motionAnimation.expand}>
                                 <ActionButton
                                     data-test={`@passphrase/${
                                         props.type === 'hidden' ? 'hidden' : 'standard'

--- a/packages/suite/src/components/suite/modals/TransactionDetail/components/ChangeFee/components/DecreasedOutputs/index.tsx
+++ b/packages/suite/src/components/suite/modals/TransactionDetail/components/ChangeFee/components/DecreasedOutputs/index.tsx
@@ -1,9 +1,8 @@
 import React from 'react';
 import styled from 'styled-components';
 import { AnimatePresence, motion } from 'framer-motion';
-import { Icon, variables, RadioButton } from '@trezor/components';
+import { Icon, variables, RadioButton, motionAnimation } from '@trezor/components';
 import { Translation, FormattedCryptoAmount, HiddenPlaceholder } from '@suite-components';
-import { ANIMATION } from '@suite-config';
 import { formatNetworkAmount } from '@suite-common/wallet-utils';
 import { useRbfContext } from '@wallet-hooks/useRbfForm';
 import GreyCard from '../GreyCard';
@@ -89,7 +88,7 @@ const DecreasedOutputs = () => {
 
     return (
         <AnimatePresence initial>
-            <motion.div {...ANIMATION.EXPAND}>
+            <motion.div {...motionAnimation.expand}>
                 <GreyCard>
                     <WarnHeader>
                         <Translation id="TR_DECREASE_TX" />

--- a/packages/suite/src/components/wallet/Fees/index.tsx
+++ b/packages/suite/src/components/wallet/Fees/index.tsx
@@ -3,11 +3,10 @@ import styled from 'styled-components';
 import { FeeLevel } from '@trezor/connect';
 import { UseFormMethods } from 'react-hook-form';
 import { AnimatePresence, motion } from 'framer-motion';
-import { SelectBar, variables } from '@trezor/components';
+import { SelectBar, variables, motionAnimation } from '@trezor/components';
 import { FiatValue, FormattedCryptoAmount, Translation } from '@suite-components';
 import { formatNetworkAmount } from '@suite-common/wallet-utils';
 import { useLayoutSize } from '@suite-hooks';
-import { ANIMATION } from '@suite-config';
 import { InputError } from '@wallet-components';
 import { Account } from '@wallet-types';
 import { ExtendedMessageDescriptor } from '@suite-types';
@@ -204,7 +203,7 @@ export const Fees = ({
                 <FeeInfoWrapper>
                     <AnimatePresence initial={false}>
                         {isCustomLevel ? (
-                            <motion.div style={{ width: '100%' }} {...ANIMATION.EXPAND}>
+                            <motion.div style={{ width: '100%' }} {...motionAnimation.expand}>
                                 <CustomFee
                                     networkType={networkType}
                                     feeInfo={feeInfo}

--- a/packages/suite/src/components/wallet/TransactionItem/components/BaseTargetLayout.tsx
+++ b/packages/suite/src/components/wallet/TransactionItem/components/BaseTargetLayout.tsx
@@ -2,8 +2,7 @@ import React from 'react';
 import styled, { css } from 'styled-components';
 import { motion } from 'framer-motion';
 import { HiddenPlaceholder } from '@suite-components';
-import { variables } from '@trezor/components';
-import { ANIMATION } from '@suite-config';
+import { variables, motionAnimation } from '@trezor/components';
 
 export const MIN_ROW_HEIGHT = '23px';
 
@@ -114,7 +113,7 @@ export const BaseTargetLayout = ({
     isLast,
     ...rest
 }: BaseTargetLayoutProps) => {
-    const animation = useAnimation ? ANIMATION.EXPAND : {};
+    const animation = useAnimation ? motionAnimation.expand : {};
 
     return (
         <TargetWrapper {...animation} {...rest}>

--- a/packages/suite/src/config/suite/index.ts
+++ b/packages/suite/src/config/suite/index.ts
@@ -2,6 +2,5 @@ import { FIAT } from '@suite-common/suite-config';
 import LANGUAGES from './languages';
 import SETTINGS from './settings';
 import SENTRY_CONFIG from './sentry';
-import ANIMATION from './animation';
 
-export { LANGUAGES, FIAT, SETTINGS, SENTRY_CONFIG, ANIMATION };
+export { LANGUAGES, FIAT, SETTINGS, SENTRY_CONFIG };

--- a/packages/suite/src/views/dashboard/components/AssetsCard/components/AssetTable.tsx
+++ b/packages/suite/src/views/dashboard/components/AssetsCard/components/AssetTable.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import styled, { css } from 'styled-components';
 import { Network } from '@wallet-types';
-import { CoinLogo, Icon, variables, useTheme } from '@trezor/components';
+import { CoinLogo, Icon, variables, useTheme, motionAnimation } from '@trezor/components';
 import {
     FiatValue,
     AmountUnitSwitchWrapper,
@@ -14,7 +14,6 @@ import { CoinBalance } from '@wallet-components';
 import { isTestnet } from '@suite-common/wallet-utils';
 import * as routerActions from '@suite-actions/routerActions';
 import { useActions, useAccountSearch, useLoadingSkeleton } from '@suite-hooks';
-import { ANIMATION } from '@suite-config';
 import { motion } from 'framer-motion';
 
 const LogoWrapper = styled.div`
@@ -60,7 +59,7 @@ const Col = (props: React.ComponentProps<typeof StyledCol>) => {
     const newProps = { ...props };
     delete newProps.isLastRow;
 
-    return <StyledCol {...ANIMATION.EXPAND} {...newProps} $isLastRow={props.isLastRow} />;
+    return <StyledCol {...motionAnimation.expand} {...newProps} $isLastRow={props.isLastRow} />;
 };
 
 const CoinNameWrapper = styled(Col)`

--- a/packages/suite/src/views/wallet/send/components/Outputs/index.tsx
+++ b/packages/suite/src/views/wallet/send/components/Outputs/index.tsx
@@ -2,11 +2,10 @@ import React, { useRef, useEffect, useState } from 'react';
 import styled, { css } from 'styled-components';
 import { AnimatePresence, motion } from 'framer-motion';
 import { useSendFormContext } from '@wallet-hooks';
-import { variables } from '@trezor/components';
+import { variables, motionAnimation } from '@trezor/components';
 import { Address } from './components/Address';
 import Amount from './components/Amount';
 import OpReturn from './components/OpReturn';
-import { ANIMATION } from '@suite-config';
 
 const Wrapper = styled.div``;
 
@@ -69,7 +68,7 @@ const Outputs = ({ disableAnim }: Props) => {
         }
     }, [outputs.length, renderedOutputs, setRenderedOutputs]);
 
-    const animation = outputs.length > 1 && !disableAnim ? ANIMATION.EXPAND : {}; // do not animate if there is only 1 output, prevents animation on clear
+    const animation = outputs.length > 1 && !disableAnim ? motionAnimation.expand : {}; // do not animate if there is only 1 output, prevents animation on clear
 
     return (
         <AnimatePresence initial={false}>


### PR DESCRIPTION
Another part of codesharing between suite and connect-ui (connect-popup) package

## Description

If I move passhprase component in `@trezor/components` package I need to get rid of all imports from `@trezor/suite` one of such import was [packages/suite/src/config/suite/animation.ts](https://github.com/trezor/trezor-suite/blob/36063222b3bea6bbf3d9c8ae04b036f2c6318422/packages/suite/src/config/suite/animation.ts)

This import is used in the [passphrase component](https://github.com/trezor/trezor-suite/blob/develop/packages/suite/src/components/suite/modals/Passphrase/components/PassphraseTypeCard/index.tsx#L371) which is about to be moved to `@trezor/components` and on many other places in suite. 

Still unsure if this is the best approach. :thinking: leaving it as draft open for discussion

## Related Issue

PR that tries to unify passphrase between connect-popup and suite https://github.com/trezor/trezor-suite/pull/5879

