### PR TITLE
chore(suite-native): Skip onboarding on development

### DIFF
--- a/suite-native/app/src/App.tsx
+++ b/suite-native/app/src/App.tsx
@@ -44,10 +44,11 @@ const AppComponent = () => {
         dispatch(connectInitThunk());
     }, [dispatch]);
 
-    if (!isOnboardingFinished) {
-        return <OnboardingStackNavigator />;
+    // NOTE: Skip onboarding for development right now to speed up app loading
+    if (isOnboardingFinished || process.env.NODE_ENV === 'development') {
+        return <RootTabNavigator />;
     }
-    return <RootTabNavigator />;
+    return <OnboardingStackNavigator />;
 };
 
 export const App = () => {


### PR DESCRIPTION
Right now there is no need to go through onboarding on development as there is no work implemented with the actual XPUB so it is a waste of development time to click through it. 

This is just a quick solution to speed up the process of loading the app until further functionalities are implemented. I suppose that in the future, there will be a functionality implemented that will mock the onboarding with some mocked XPUB.