### PR TITLE
Fix/connect methods docs

### DIFF
--- a/docs/packages/connect/methods/authorizeCoinJoin.md
+++ b/docs/packages/connect/methods/authorizeCoinJoin.md
@@ -19,7 +19,7 @@ const result = await TrezorConnect.authorizeCoinJoin(params);
 #### Exporting single id
 
 -   `path` — _required_ `string | Array<number>`
-    > prefix of the BIP-32 path leading to the account (m / purpose' / coin_type' / account')[read more](path.md)
+    > prefix of the BIP-32 path leading to the account (m / purpose' / coin_type' / account')[read more](../path.md)
 -   `coordinator` — _required_ `string`
     > coordinator identifier to approve as a prefix in commitment data (max. 36 ASCII characters)
 -   `maxRounds` — _required_ `number`

--- a/docs/packages/connect/methods/authorizeCoinJoin.md
+++ b/docs/packages/connect/methods/authorizeCoinJoin.md
@@ -14,7 +14,7 @@ const result = await TrezorConnect.authorizeCoinJoin(params);
 
 ### Params
 
-[\***\*Optional common params\*\***](commonParams.md)
+[Optional common params](commonParams.md)
 
 #### Exporting single id
 
@@ -29,7 +29,7 @@ const result = await TrezorConnect.authorizeCoinJoin(params);
 -   `maxFeePerKvbyte` — _required_ `number`
     > maximum mining fee rate in units of satoshis per 1000 vbytes
 -   `coin` - _optional_ `string`
-    > Determines network definition specified in [coins.json](../../../connect-common/files/coins.json) file.
+    > Determines network definition specified in [coins.json](https://github.com/trezor/trezor-suite/blob/develop/packages/connect-common/files/coins.json) file.
     > Coin `shortcut`, `name` or `label` can be used.
 -   `scriptType` — _optional_ `PROTO.InputScriptType`
     > used to distinguish between various address formats (non-segwit, segwit, etc.)
@@ -49,6 +49,8 @@ TrezorConnect.authorizeCoinJoin({
 ```
 
 ### Result
+
+[Success type](https://github.com/trezor/trezor-suite/blob/develop/packages/transport/src/types/messages.ts)
 
 ```javascript
 {

--- a/docs/packages/connect/methods/binanceGetAddress.md
+++ b/docs/packages/connect/methods/binanceGetAddress.md
@@ -1,6 +1,6 @@
 ## Binance: get address
 
-Display requested address derived by given [BIP44 path](path.md) on device and returns it to caller. User is presented with a description of the requested key and asked to confirm the export on Trezor.
+Display requested address derived by given [BIP44 path](../path.md) on device and returns it to caller. User is presented with a description of the requested key and asked to confirm the export on Trezor.
 
 ```javascript
 const result = await TrezorConnect.binanceGetAddress(params);
@@ -12,7 +12,7 @@ const result = await TrezorConnect.binanceGetAddress(params);
 
 #### Exporting single address
 
--   `path` — _required_ `string | Array<number>` minimum length is `5`. [read more](path.md)
+-   `path` — _required_ `string | Array<number>` minimum length is `5`. [read more](../path.md)
 -   `address` — _optional_ `string` address for validation (read `Handle button request` section below)
 -   `showOnTrezor` — _optional_ `boolean` determines if address will be displayed on device. Default is set to `true`
 

--- a/docs/packages/connect/methods/binanceGetAddress.md
+++ b/docs/packages/connect/methods/binanceGetAddress.md
@@ -8,7 +8,7 @@ const result = await TrezorConnect.binanceGetAddress(params);
 
 ### Params
 
-[\***\*Optional common params\*\***](commonParams.md)
+[Optional common params](commonParams.md)
 
 #### Exporting single address
 
@@ -74,6 +74,8 @@ const result = await TrezorConnect.binanceGetAddress({
 ```
 
 ### Result
+
+[Address type](https://github.com/trezor/trezor-suite/blob/develop/packages/connect/src/types/params.ts)
 
 Result with only one address
 

--- a/docs/packages/connect/methods/binanceGetPublicKey.md
+++ b/docs/packages/connect/methods/binanceGetPublicKey.md
@@ -9,7 +9,7 @@ const result = await TrezorConnect.binanceGetPublicKey(params);
 
 ### Params
 
-[\***\*Optional common params\*\***](commonParams.md)
+[Optional common params](commonParams.md)
 
 #### Exporting single address
 
@@ -43,6 +43,8 @@ TrezorConnect.binanceGetPublicKey({
 ```
 
 ### Result
+
+[PublicKey type](https://github.com/trezor/trezor-suite/blob/develop/packages/connect/src/types/params.ts)
 
 Result with only one public key
 

--- a/docs/packages/connect/methods/binanceGetPublicKey.md
+++ b/docs/packages/connect/methods/binanceGetPublicKey.md
@@ -1,6 +1,6 @@
 ## Binance: get public key
 
-Display requested public key derived by given [BIP44 path](path.md) on device and returns it to caller.
+Display requested public key derived by given [BIP44 path](../path.md) on device and returns it to caller.
 User is presented with a description of the requested public key and asked to confirm the export.
 
 ```javascript
@@ -13,7 +13,7 @@ const result = await TrezorConnect.binanceGetPublicKey(params);
 
 #### Exporting single address
 
--   `path` — _required_ `string | Array<number>` minimum length is `5`. [read more](path.md)
+-   `path` — _required_ `string | Array<number>` minimum length is `5`. [read more](../path.md)
 -   `showOnTrezor` — _optional_ `boolean` determines if address will be displayed on device. Default is set to `true`
 
 #### Exporting bundle of addresses

--- a/docs/packages/connect/methods/binanceSignTransaction.md
+++ b/docs/packages/connect/methods/binanceSignTransaction.md
@@ -9,10 +9,10 @@ const result = await TrezorConnect.binanceSignTransaction(params);
 
 ### Params
 
-[\***\*Optional common params\*\***](commonParams.md)
+[Optional common params](commonParams.md)
 
 -   `path` — _required_ `string | Array<number>` minimum length is `5`. [read more](../path.md)
--   `transaction` - _required_ `Object` type of [Transaction](../../src/js/types/binance.js#L61-71)
+-   `transaction` - _required_ `Object` type of [BinanceSDKTransaction](https://github.com/trezor/trezor-suite/blob/develop/packages/connect/src/types/api/binance/index.ts)
 
 ### Transfer example
 
@@ -89,6 +89,8 @@ TrezorConnect.binanceSignTransaction({
 ```
 
 ### Result
+
+[BinanceSignedTx type](https://github.com/trezor/trezor-suite/blob/develop/packages/transport/src/types/messages.ts)
 
 ```javascript
 {

--- a/docs/packages/connect/methods/binanceSignTransaction.md
+++ b/docs/packages/connect/methods/binanceSignTransaction.md
@@ -1,6 +1,6 @@
 ## Binance: sign transaction
 
-Asks device to sign given transaction using the private key derived by given [BIP44 path](path.md). User is asked to confirm all transaction
+Asks device to sign given transaction using the private key derived by given [BIP44 path](../path.md). User is asked to confirm all transaction
 details on Trezor.
 
 ```javascript
@@ -11,7 +11,7 @@ const result = await TrezorConnect.binanceSignTransaction(params);
 
 [\***\*Optional common params\*\***](commonParams.md)
 
--   `path` — _required_ `string | Array<number>` minimum length is `5`. [read more](path.md)
+-   `path` — _required_ `string | Array<number>` minimum length is `5`. [read more](../path.md)
 -   `transaction` - _required_ `Object` type of [Transaction](../../src/js/types/binance.js#L61-71)
 
 ### Transfer example

--- a/docs/packages/connect/methods/cardanoGetAddress.md
+++ b/docs/packages/connect/methods/cardanoGetAddress.md
@@ -8,9 +8,9 @@ const result = await TrezorConnect.cardanoGetAddress(params);
 
 ### Params
 
-[\***\*Optional common params\*\***](commonParams.md)
+[Optional common params](commonParams.md)
 
-#### [type](../../../../packages/connect/src/types/api/cardanoGetAddress.ts#L20)
+[CardanoGetAddress type](https://github.com/trezor/trezor-suite/blob/develop/packages/connect/src/types/api/cardano/index.ts)
 
 #### Exporting single address
 
@@ -27,13 +27,13 @@ const result = await TrezorConnect.cardanoGetAddress(params);
 
 #### Address Parameters
 
-##### [type](../../../../packages/connect/src/types/api/cardanoGetAddress.ts#L10)
+##### [CardanoAddressParameters type](https://github.com/trezor/trezor-suite/blob/develop/packages/connect/src/types/api/cardano/index.ts)
 
 -   `addressType` - _required_ `CardanoAddressType`/`number` - you can use the flow `CARDANO.ADDRESS_TYPE` object or typescript `CardanoAddressType` enum. Supports all address types.
 -   `path` — _required_ `string | Array<number>` minimum length is `5`. [read more](../path.md)
 -   `stakingPath` — _optional_ `string | Array<number>` minimum length is `5`. [read more](../path.md) Used for base and reward address derivation
 -   `stakingKeyHash` - _optional_ `string` hex string of staking key hash. Used for base address derivation (as an alternative to `stakingPath`)
--   `certificatePointer` - _optional_ [CardanoCertificatePointer](../../../../packages/connect/src/types/api/cardanoGetAddress.ts#L4) object. Must contain `number`s `blockIndex`, `txIndex` and `certificateIndex`. Used for pointer address derivation. [read more about pointer address](https://hydra.iohk.io/build/2006688/download/1/delegation_design_spec.pdf#subsubsection.3.2.2)
+-   `certificatePointer` - _optional_ [CardanoCertificatePointer](https://github.com/trezor/trezor-suite/blob/develop/packages/connect/src/types/api/cardano/index.ts) object. Must contain `number`s `blockIndex`, `txIndex` and `certificateIndex`. Used for pointer address derivation. [read more about pointer address](https://hydra.iohk.io/build/2006688/download/1/delegation_design_spec.pdf#subsubsection.3.2.2)
 -   `paymentScriptHash` - _optional_ `string` hex string of payment script hash.
 -   `stakingScriptHash` - _optional_ `string` hex string of staking script hash.
 
@@ -273,6 +273,8 @@ const result = await TrezorConnect.cardanoGetAddress({
 ```
 
 ### Result
+
+[CardanoAddress type](https://github.com/trezor/trezor-suite/blob/develop/packages/connect/src/types/api/cardano/index.ts)
 
 Result with only one address
 

--- a/docs/packages/connect/methods/cardanoGetAddress.md
+++ b/docs/packages/connect/methods/cardanoGetAddress.md
@@ -30,8 +30,8 @@ const result = await TrezorConnect.cardanoGetAddress(params);
 ##### [type](../../../../packages/connect/src/types/api/cardanoGetAddress.ts#L10)
 
 -   `addressType` - _required_ `CardanoAddressType`/`number` - you can use the flow `CARDANO.ADDRESS_TYPE` object or typescript `CardanoAddressType` enum. Supports all address types.
--   `path` — _required_ `string | Array<number>` minimum length is `5`. [read more](path.md)
--   `stakingPath` — _optional_ `string | Array<number>` minimum length is `5`. [read more](path.md) Used for base and reward address derivation
+-   `path` — _required_ `string | Array<number>` minimum length is `5`. [read more](../path.md)
+-   `stakingPath` — _optional_ `string | Array<number>` minimum length is `5`. [read more](../path.md) Used for base and reward address derivation
 -   `stakingKeyHash` - _optional_ `string` hex string of staking key hash. Used for base address derivation (as an alternative to `stakingPath`)
 -   `certificatePointer` - _optional_ [CardanoCertificatePointer](../../../../packages/connect/src/types/api/cardanoGetAddress.ts#L4) object. Must contain `number`s `blockIndex`, `txIndex` and `certificateIndex`. Used for pointer address derivation. [read more about pointer address](https://hydra.iohk.io/build/2006688/download/1/delegation_design_spec.pdf#subsubsection.3.2.2)
 -   `paymentScriptHash` - _optional_ `string` hex string of payment script hash.

--- a/docs/packages/connect/methods/cardanoGetNativeScriptHash.md
+++ b/docs/packages/connect/methods/cardanoGetNativeScriptHash.md
@@ -8,9 +8,9 @@ const result = await TrezorConnect.cardanoGetNativeScriptHash(params);
 
 ### Params
 
-[\***\*Optional common params\*\***](commonParams.md)
+[Optional common params](commonParams.md)
 
-#### [type](../../../../packages/connect/src/types/api/cardanoGetNativeScriptHash.ts#L14)
+[CardanoGetNativeScriptHash type](https://github.com/trezor/trezor-suite/blob/develop/packages/connect/src/types/api/cardano/index.ts)
 
 -   `script` — _required_ `CardanoNativeScript` see description below.
 -   `displayFormat` — _required_ `CardanoNativeScriptHashDisplayFormat` enum.
@@ -18,7 +18,7 @@ const result = await TrezorConnect.cardanoGetNativeScriptHash(params);
 
 #### CardanoNativeScript
 
-##### [type](../../../../packages/connect/src/types/api/cardanoGetNativeScriptHash.ts#L4)
+[CardanoNativeScript type](https://github.com/trezor/trezor-suite/blob/develop/packages/connect/src/types/api/cardano/index.ts)
 
 -   `type` - _required_ `CardanoNativeScriptType`/`number`.
 -   `scripts` — _optional_ `Array` of nested `CardanoNativeScript`s.
@@ -103,6 +103,8 @@ TrezorConnect.cardanoGetAddress({
 ```
 
 ### Result
+
+[CardanoNativeScriptHash type](https://github.com/trezor/trezor-suite/blob/develop/packages/connect/src/types/api/cardano/index.ts)
 
 ```javascript
 {

--- a/docs/packages/connect/methods/cardanoGetPublicKey.md
+++ b/docs/packages/connect/methods/cardanoGetPublicKey.md
@@ -15,7 +15,7 @@ const result = await TrezorConnect.cardanoGetPublicKey(params);
 
 #### Exporting single public key
 
--   `path` — _required_ `string | Array<number>` minimum length is `3`. [read more](path.md)
+-   `path` — _required_ `string | Array<number>` minimum length is `3`. [read more](../path.md)
 -   `showOnTrezor` — _optional_ `boolean` determines if publick key will be displayed on device. Default is set to `true`
 -   `derivationType` — _optional_ `CardanoDerivationType` enum. determines used derivation type. Default is set to ICARUS_TREZOR=2
 

--- a/docs/packages/connect/methods/cardanoGetPublicKey.md
+++ b/docs/packages/connect/methods/cardanoGetPublicKey.md
@@ -9,9 +9,9 @@ const result = await TrezorConnect.cardanoGetPublicKey(params);
 
 ### Params
 
-[\***\*Optional common params\*\***](commonParams.md)
+[Optional common params](commonParams.md)
 
-#### [type](../../../../packages/connect/src/types/api/cardanoGetPublicKey.ts#L4)
+[CardanoGetPublicKey type](https://github.com/trezor/trezor-suite/blob/develop/packages/connect/src/types/api/cardano/index.ts)
 
 #### Exporting single public key
 
@@ -47,6 +47,8 @@ TrezorConnect.cardanoGetPublicKey({
 
 ### Result
 
+[CardanoPublicKey type](https://github.com/trezor/trezor-suite/blob/develop/packages/connect/src/types/api/cardano/index.ts)
+
 Result with only one public key
 
 ```javascript
@@ -57,20 +59,19 @@ Result with only one public key
         serializedPath: string,
         publicKey: string,
         node: HDPubNode,
-        rootHDPassphrase: string,
     }
 }
 ```
 
-Result with bundle of publick keys
+Result with a bundle of public keys
 
 ```javascript
 {
     success: true,
     payload: [
-        { path: Array<number>, serializedPath: string, publicKey: string, node: HDPubNode, hdPassphrase: string }, // account 1
-        { path: Array<number>, serializedPath: string, publicKey: string, node: HDPubNode, rootHDPassphrase: string }, // account 2
-        { path: Array<number>, serializedPath: string, publicKey: string, node: HDPubNode, hdPassphrase: string }  // account 3
+        { path: Array<number>, serializedPath: string, publicKey: string, node: HDPubNode }, // account 1
+        { path: Array<number>, serializedPath: string, publicKey: string, node: HDPubNode}, // account 2
+        { path: Array<number>, serializedPath: string, publicKey: string, node: HDPubNode }  // account 3
     ]
 }
 ```

--- a/docs/packages/connect/methods/cardanoSignTransaction.md
+++ b/docs/packages/connect/methods/cardanoSignTransaction.md
@@ -9,28 +9,28 @@ const result = await TrezorConnect.cardanoSignTransaction(params);
 
 ### Params
 
-[\***\*Optional common params\*\***](commonParams.md)
+[Optional common params](commonParams.md)
 
-#### [type](../../../../packages/connect/src/types/api/cardanoSignTransaction.ts#L119)
+[CardanoSignTransaction type](https://github.com/trezor/trezor-suite/blob/develop/packages/connect/src/types/api/cardano/index.ts)
 
 -   `signingMode` - _required_ [CardanoTxSigningMode](#CardanoTxSigningMode)
--   `inputs` - _required_ `Array` of [CardanoInput](../../../../packages/connect/src/types/api/cardanoSignTransaction.ts#L5)
--   `outputs` - _required_ `Array` of [CardanoOutput](../../../../packages/connect/src/types/api/cardanoSignTransaction.ts#L22)
+-   `inputs` - _required_ `Array` of [CardanoInput](https://github.com/trezor/trezor-suite/blob/develop/packages/connect/src/types/api/cardano/index.ts)
+-   `outputs` - _required_ `Array` of [CardanoOutput](https://github.com/trezor/trezor-suite/blob/develop/packages/connect/src/types/api/cardano/index.ts)
 -   `fee` - _required_ `String`
 -   `protocolMagic` - _required_ `Integer` 764824073 for Mainnet, 1097911063 for Testnet
 -   `networkId` - _required_ `Integer` 1 for Mainnet, 0 for Testnet
 -   `ttl` - _optional_ `String`
 -   `validityIntervalStart` - _optional_ `String`
--   `certificates` - _optional_ `Array` of [CardanoCertificate](../../../../packages/connect/src/types/api/cardanoSignTransaction.ts#L73)
--   `withdrawals` - _optional_ `Array` of [CardanoWithdrawal](../../../../packages/connect/src/types/api/cardanoSignTransaction.ts#L82)
--   `auxiliaryData` - _optional_ [CardanoAuxiliaryData](../../../../packages/connect/src/types/api/cardanoSignTransaction.ts#L114)
--   `mint` - _optional_ [CardanoMint](../../../../packages/connect/src/types/api/cardanoSignTransaction.ts#L89)
+-   `certificates` - _optional_ `Array` of [CardanoCertificate](https://github.com/trezor/trezor-suite/blob/develop/packages/connect/src/types/api/cardano/index.ts)
+-   `withdrawals` - _optional_ `Array` of [CardanoWithdrawal](https://github.com/trezor/trezor-suite/blob/develop/packages/connect/src/types/api/cardano/index.ts)
+-   `auxiliaryData` - _optional_ [CardanoAuxiliaryData](https://github.com/trezor/trezor-suite/blob/develop/packages/connect/src/types/api/cardano/index.ts)
+-   `mint` - _optional_ [CardanoMint](https://github.com/trezor/trezor-suite/blob/develop/packages/connect/src/types/api/cardano/index.ts)
 -   `scriptDataHash` - _optional_ `String`
--   `collateralInputs` - _optional_ `Array` of [CardanoCollateralInput](../../../../packages/connect/src/types/api/cardanoSignTransaction.ts#L91)
--   `requiredSigners` - _optional_ `Array` of [CardanoRequiredSigner](../../../../packages/connect/src/types/api/cardanoSignTransaction.ts#L97)
--   `collateralReturn` - _optional_ [CardanoOutput](../../../../packages/connect/src/types/api/cardanoSignTransaction.ts#L22)
+-   `collateralInputs` - _optional_ `Array` of [CardanoCollateralInput](https://github.com/trezor/trezor-suite/blob/develop/packages/connect/src/types/api/cardano/index.ts)
+-   `requiredSigners` - _optional_ `Array` of [CardanoRequiredSigner](https://github.com/trezor/trezor-suite/blob/develop/packages/connect/src/types/api/cardano/index.ts)
+-   `collateralReturn` - _optional_ [CardanoOutput](https://github.com/trezor/trezor-suite/blob/develop/packages/connect/src/types/api/cardano/index.ts)
 -   `totalCollateral` - _optional_ `String`
--   `referenceInputs` - _optional_ `Array` of [CardanoReferenceInput](../../../../packages/connect/src/types/api/cardanoSignTransaction.ts#L102)
+-   `referenceInputs` - _optional_ `Array` of [CardanoReferenceInput](https://github.com/trezor/trezor-suite/blob/develop/packages/connect/src/types/api/cardano/index.ts)
 -   `additionalWitnessRequests` - _optional_ `Array` of `string | Array<number>` (paths). Used for multi-sig and token minting witness requests as those can not be determined from the transaction parameters.
 -   `metadata` - _removed_ - use `auxiliaryData` instead
 -   `derivationType` — _optional_ `CardanoDerivationType` enum. Determines used derivation type. Default is set to ICARUS_TREZOR=2.
@@ -527,7 +527,7 @@ TrezorConnect.cardanoSignTransaction({
 
 Since transaction streaming has been introduced to the Cardano implementation on Trezor because of memory constraints, Trezor no longer returns the whole serialized transaction as a result of the `CardanoSignTransaction` call. Instead the transaction hash, transaction witnesses and auxiliary data supplement are returned and the serialized transaction needs to be assembled by the client.
 
-#### [type](../../../../packages/connect/src/types/api/cardanoSignTransaction.ts#L156)
+[CardanoSignedTxData type](https://github.com/trezor/trezor-suite/blob/develop/packages/connect/src/types/api/cardano/index.ts)
 
 ```javascript
 {

--- a/docs/packages/connect/methods/cipherKeyValue.md
+++ b/docs/packages/connect/methods/cipherKeyValue.md
@@ -16,7 +16,7 @@ Common parameter `useEmptyPassphrase` - is always set to `true` and it will be i
 
 #### Encrypt single value
 
--   `path` — _required_ `string | Array<number>` minimum length is `1`. [read more](path.md)
+-   `path` — _required_ `string | Array<number>` minimum length is `1`. [read more](../path.md)
 -   `key` — _optional_ `string` a message shown on device
 -   `value` — _optional_ `string` hexadecimal value with length a multiple of 16 bytes (32 letters in hexadecimal). Value is what is actually being encrypted.
 -   `askOnEncrypt` - _optional_ `boolean` should user confirm encrypt?

--- a/docs/packages/connect/methods/cipherKeyValue.md
+++ b/docs/packages/connect/methods/cipherKeyValue.md
@@ -10,8 +10,8 @@ const result = await TrezorConnect.cipherKeyValue(params);
 
 ### Params
 
-[\***\*Optional common params\*\***](commonParams.md)
-<br>
+[Optional common params](commonParams.md)
+
 Common parameter `useEmptyPassphrase` - is always set to `true` and it will be ignored by this method
 
 #### Encrypt single value
@@ -65,6 +65,8 @@ TrezorConnect.cipherKeyValue({
 ```
 
 ### Result
+
+[CipheredValue type](https://github.com/trezor/trezor-suite/blob/develop/packages/connect/src/types/api/cipherKeyValue.ts)
 
 Result with only one value
 

--- a/docs/packages/connect/methods/composeTransaction.md
+++ b/docs/packages/connect/methods/composeTransaction.md
@@ -17,10 +17,10 @@ Returned response is a signed transaction in hexadecimal format same as in [sign
 
 ## Params:
 
-[\***\*Optional common params\*\***](commonParams.md)
+[Optional common params](commonParams.md)
 
 -   `outputs` — _required_ `Array` of output objects described [below](#accepted-output-objects)
--   `coin` — _required_ `string` determines network definition specified in [coins.json](../../src/data/coins.json) file. Coin `shortcut`, `name` or `label` can be used.
+-   `coin` — _required_ `string` determines network definition specified in [coins.json](https://github.com/trezor/trezor-suite/blob/develop/packages/connect-common/files/coins.json) file. Coin `shortcut`, `name` or `label` can be used.
 -   `push` — _optional_ `boolean` determines if composed transaction will be broadcasted into blockchain network. Default is set to false.
 -   `sequence` — _optional_ `number` transaction input field used in RBF or locktime transactions
 
@@ -28,7 +28,7 @@ Returned response is a signed transaction in hexadecimal format same as in [sign
 
 Skip first two steps of `payment request` (described above) by providing `account` and `feeLevels` params and perform **only** transaction calculation. [[2]](#additional-notes)
 
-The result, internally called [`PrecomposedTransaction`](../../src/js/types/account.js#L208) is a set of params that can be used in [signTransaction method](signTransaction.md#params) afterwards.
+The result, internally called [`PrecomposedTransaction`](https://github.com/trezor/trezor-suite/blob/develop/packages/connect/src/types/api/composeTransaction.ts) is a set of params that can be used in [signTransaction method](signTransaction.md#params) afterwards.
 
 This useful for the quick preparation of multiple variants for the same transaction using different fee levels or using incomplete data (like missing output addresses just to calculate fee)
 
@@ -37,7 +37,7 @@ _Device and backend connection is not required for this case since all data are 
 ## Params:
 
 -   `outputs` — _required_ `Array` of output objects described [below](#accepted-output-objects)
--   `coin` — _required_ `string` determines network definition specified in [coins.json](../../src/data/coins.json) file. Coin `shortcut`, `name` or `label` can be used.
+-   `coin` — _required_ `string` determines network definition specified in [coins.json](https://github.com/trezor/trezor-suite/blob/develop/packages/connect-common/files/coins.json) file. Coin `shortcut`, `name` or `label` can be used.
 -   `account` — _required_ `Object` containing essential data, partial result of [getAccountInfo method](getAccountInfo.md#result)
     -   `path` - _required_ `string`
     -   `utxo` - _required_ `Array`
@@ -83,6 +83,8 @@ TrezorConnect.composeTransaction({
 ```
 
 ### Payment result
+
+[SignedTransaction type](https://github.com/trezor/trezor-suite/blob/develop/packages/connect/src/types/api/composeTransaction.ts)
 
 ```javascript
 {

--- a/docs/packages/connect/methods/eosGetPublicKey.md
+++ b/docs/packages/connect/methods/eosGetPublicKey.md
@@ -1,6 +1,6 @@
 ## Eos: get public key
 
-Display requested public key derived by given [BIP44 path](path.md) on device and returns it to caller.
+Display requested public key derived by given [BIP44 path](../path.md) on device and returns it to caller.
 User is presented with a description of the requested public key and asked to confirm the export.
 
 ```javascript
@@ -13,7 +13,7 @@ const result = await TrezorConnect.eosGetPublicKey(params);
 
 #### Exporting single address
 
--   `path` — _required_ `string | Array<number>` minimum length is `5`. [read more](path.md)
+-   `path` — _required_ `string | Array<number>` minimum length is `5`. [read more](../path.md)
 -   `showOnTrezor` — _optional_ `boolean` determines if address will be displayed on device. Default is set to `true`
 
 #### Exporting bundle of addresses

--- a/docs/packages/connect/methods/eosGetPublicKey.md
+++ b/docs/packages/connect/methods/eosGetPublicKey.md
@@ -9,7 +9,7 @@ const result = await TrezorConnect.eosGetPublicKey(params);
 
 ### Params
 
-[\***\*Optional common params\*\***](commonParams.md)
+[Optional common params](commonParams.md)
 
 #### Exporting single address
 
@@ -44,6 +44,8 @@ TrezorConnect.eosGetPublicKey({
 
 ### Result
 
+[EosPublicKey type](https://github.com/trezor/trezor-suite/blob/develop/packages/connect/src/types/api/eos/index.ts)
+
 Result with only one public key
 
 ```javascript
@@ -52,6 +54,8 @@ Result with only one public key
     payload: {
         wifPublicKey: string,
         rawPublicKey: string,
+        path: number[],
+        serializedPath: string
     }
 }
 ```
@@ -62,9 +66,9 @@ Result with bundle of public keys sorted by FIFO
 {
     success: true,
     payload: [
-        { wifPublicKey: string, rawPublicKey: string }, // public key 1
-        { wifPublicKey: string, rawPublicKey: string }, // public key 2
-        { wifPublicKey: string, rawPublicKey: string }  // public key 3
+        { wifPublicKey: string, rawPublicKey: string, path: number[], serializedPath: string }, // public key 1
+        { wifPublicKey: string, rawPublicKey: string, path: number[], serializedPath: string }, // public key 2
+        { wifPublicKey: string, rawPublicKey: string, path: number[], serializedPath: string }  // public key 3
     ]
 }
 ```

--- a/docs/packages/connect/methods/eosSignTransaction.md
+++ b/docs/packages/connect/methods/eosSignTransaction.md
@@ -1,6 +1,6 @@
 ## Eos: sign transaction
 
-Asks device to sign given transaction using the private key derived by given [BIP44 path](path.md). User is asked to confirm all transaction
+Asks device to sign given transaction using the private key derived by given [BIP44 path](../path.md). User is asked to confirm all transaction
 details on Trezor.
 
 ```javascript
@@ -13,7 +13,7 @@ const result = await TrezorConnect.eosSignTransaction(params);
 
 ###### [flowtype](../../src/js/types/params.js#L69-L72)
 
--   `path` — _required_ `string | Array<number>` minimum length is `3`. [read more](path.md)
+-   `path` — _required_ `string | Array<number>` minimum length is `3`. [read more](../path.md)
 -   `transaction` - _required_ `Object` type of [Transaction](../../src/js/types/eos.js#L145-L149)
 
 ### Transfer example

--- a/docs/packages/connect/methods/eosSignTransaction.md
+++ b/docs/packages/connect/methods/eosSignTransaction.md
@@ -9,12 +9,12 @@ const result = await TrezorConnect.eosSignTransaction(params);
 
 ### Params
 
-[\***\*Optional common params\*\***](commonParams.md)
+[Optional common params](commonParams.md)
 
-###### [flowtype](../../src/js/types/params.js#L69-L72)
+[EosSignTransaction type](https://github.com/trezor/trezor-suite/blob/develop/packages/connect/src/types/api/eos/index.ts)
 
 -   `path` — _required_ `string | Array<number>` minimum length is `3`. [read more](../path.md)
--   `transaction` - _required_ `Object` type of [Transaction](../../src/js/types/eos.js#L145-L149)
+-   `transaction` - _required_ `Object` type of [EosSDKTransaction](https://github.com/trezor/trezor-suite/blob/develop/packages/connect/src/types/api/eos/index.ts)
 
 ### Transfer example
 
@@ -55,7 +55,7 @@ TrezorConnect.eosSignTransaction({
 
 ### Result
 
-###### [flowtype](../../src/js/types/eos.js#L160-L163)
+[EosSignedTx type](https://github.com/trezor/trezor-suite/blob/develop/packages/transport/src/types/messages.ts)
 
 ```javascript
 {

--- a/docs/packages/connect/methods/ethereumGetAddress.md
+++ b/docs/packages/connect/methods/ethereumGetAddress.md
@@ -8,7 +8,7 @@ const result = await TrezorConnect.ethereumGetAddress(params);
 
 ### Params
 
-[\***\*Optional common params\*\***](commonParams.md)
+[Optional common params](commonParams.md)
 
 #### Exporting single address
 
@@ -74,6 +74,8 @@ const result = await TrezorConnect.ethereumGetAddress({
 ```
 
 ### Result
+
+[Address type](https://github.com/trezor/trezor-suite/blob/develop/packages/connect/src/types/params.ts)
 
 Result with only one address
 

--- a/docs/packages/connect/methods/ethereumGetAddress.md
+++ b/docs/packages/connect/methods/ethereumGetAddress.md
@@ -12,7 +12,7 @@ const result = await TrezorConnect.ethereumGetAddress(params);
 
 #### Exporting single address
 
--   `path` — _required_ `string | Array<number>` minimum length is `5`. [read more](path.md)
+-   `path` — _required_ `string | Array<number>` minimum length is `5`. [read more](../path.md)
 -   `address` — _required_ `string` address for validation (read `Handle button request` section below)
 -   `showOnTrezor` — _optional_ `boolean` determines if address will be displayed on device. Default is set to `true`
 

--- a/docs/packages/connect/methods/ethereumSignMessage.md
+++ b/docs/packages/connect/methods/ethereumSignMessage.md
@@ -8,9 +8,8 @@ const result = await TrezorConnect.ethereumSignMessage(params);
 
 ### Params
 
-[\***\*Optional common params\*\***](commonParams.md)
-
-###### [flowtype](../../src/js/types/params.js#L64-L67)
+[Optional common params](commonParams.md)
+[EthereumSignMessage type](https://github.com/trezor/trezor-suite/blob/develop/packages/connect/src/types/api/ethereum/index.ts)
 
 -   `path` — _required_ `string | Array<number>` minimum length is `3`. [read more](../path.md)
 -   `message` - _required_ `string` message to sign in plain text
@@ -27,7 +26,7 @@ TrezorConnect.ethereumSignMessage({
 
 ### Result
 
-###### [flowtype](../../src/js/types/response.js#L47-L50)
+[MessageSignature type](https://github.com/trezor/trezor-suite/blob/develop/packages/transport/src/types/messages.ts)
 
 ```javascript
 {

--- a/docs/packages/connect/methods/ethereumSignMessage.md
+++ b/docs/packages/connect/methods/ethereumSignMessage.md
@@ -12,7 +12,7 @@ const result = await TrezorConnect.ethereumSignMessage(params);
 
 ###### [flowtype](../../src/js/types/params.js#L64-L67)
 
--   `path` — _required_ `string | Array<number>` minimum length is `3`. [read more](path.md)
+-   `path` — _required_ `string | Array<number>` minimum length is `3`. [read more](../path.md)
 -   `message` - _required_ `string` message to sign in plain text
 -   `hex` - _optional_ `boolean` convert message from hex
 

--- a/docs/packages/connect/methods/ethereumSignTransaction.md
+++ b/docs/packages/connect/methods/ethereumSignTransaction.md
@@ -9,12 +9,12 @@ const result = await TrezorConnect.ethereumSignTransaction(params);
 
 ### Params
 
-[\***\*Optional common params\*\***](commonParams.md)
+[Optional common params](commonParams.md)
 
-###### [flowtype](../../src/js/types/params.js#L69-L72)
+[EthereumSignTransaction type](https://github.com/trezor/trezor-suite/blob/develop/packages/connect/src/types/api/ethereum/index.ts)
 
 -   `path` — _required_ `string | Array<number>` minimum length is `3`. [read more](../path.md)
--   `transaction` - _required_ `Object` type of [`EthereumTransactionEIP1559`](../../src/js/types/networks/ethereum.js#L46)`|`[`EthereumSignTransaction`](../../src/js/types/networks/ethereum.js#L59) "0x" prefix for each field is optional
+-   `transaction` - _required_ `Object` type of [`EthereumTransactionEIP1559`](https://github.com/trezor/trezor-suite/blob/develop/packages/connect/src/types/api/ethereum/index.ts)`|`[`EthereumSignTransaction`](https://github.com/trezor/trezor-suite/blob/develop/packages/connect/src/types/api/ethereum/index.ts) "0x" prefix for each field is optional
 
 ### Examples
 
@@ -61,7 +61,7 @@ TrezorConnect.ethereumSignTransaction({
 
 ### Result
 
-###### [flowtype](../../src/js/types/api.js#L252)
+[EthereumSignedTx type](https://github.com/trezor/trezor-suite/blob/develop/packages/connect/src/types/api/ethereum/index.ts)
 
 ```javascript
 {

--- a/docs/packages/connect/methods/ethereumSignTransaction.md
+++ b/docs/packages/connect/methods/ethereumSignTransaction.md
@@ -13,7 +13,7 @@ const result = await TrezorConnect.ethereumSignTransaction(params);
 
 ###### [flowtype](../../src/js/types/params.js#L69-L72)
 
--   `path` — _required_ `string | Array<number>` minimum length is `3`. [read more](path.md)
+-   `path` — _required_ `string | Array<number>` minimum length is `3`. [read more](../path.md)
 -   `transaction` - _required_ `Object` type of [`EthereumTransactionEIP1559`](../../src/js/types/networks/ethereum.js#L46)`|`[`EthereumSignTransaction`](../../src/js/types/networks/ethereum.js#L59) "0x" prefix for each field is optional
 
 ### Examples

--- a/docs/packages/connect/methods/ethereumSignTypedData.md
+++ b/docs/packages/connect/methods/ethereumSignTypedData.md
@@ -19,7 +19,7 @@ const result = await TrezorConnect.ethereumSignTypedData(params);
 
 > :warning: **Domain-only signing (`data.primaryType` = `"EIP712Domain"`) is supported only on Trezor T with Firmware 2.4.4 or higher!**
 
--   `path` — _required_ `string | Array<number>` minimum length is `3`. [read more](path.md)
+-   `path` — _required_ `string | Array<number>` minimum length is `3`. [read more](../path.md)
 -   `data` - _required_ `Object` type of [`EthereumSignTypedDataMessage`](../../src/js/types/networks/ethereum.js#L90)`. A JSON Schema definition can be found in the [EIP-712 spec](<[EIP-712](https://eips.ethereum.org/EIPS/eip-712)>).
 -   `metamask_v4_compat` - _required_ `boolean` set to `true` for compatibility with [MetaMask's signTypedData_v4](https://docs.metamask.io/guide/signing-data.html#sign-typed-data-v4).
 

--- a/docs/packages/connect/methods/ethereumSignTypedData.md
+++ b/docs/packages/connect/methods/ethereumSignTypedData.md
@@ -13,14 +13,14 @@ const result = await TrezorConnect.ethereumSignTypedData(params);
 
 ### Params
 
-[\***\*Optional common params\*\***](commonParams.md)
+[Optional common params](commonParams.md)
 
-###### [flowtype](../../src/js/types/networks/ethereum.js#104-116)
+[EthereumSignTypedData type](https://github.com/trezor/trezor-suite/blob/develop/packages/connect/src/types/api/ethereum/index.ts)
 
 > :warning: **Domain-only signing (`data.primaryType` = `"EIP712Domain"`) is supported only on Trezor T with Firmware 2.4.4 or higher!**
 
 -   `path` — _required_ `string | Array<number>` minimum length is `3`. [read more](../path.md)
--   `data` - _required_ `Object` type of [`EthereumSignTypedDataMessage`](../../src/js/types/networks/ethereum.js#L90)`. A JSON Schema definition can be found in the [EIP-712 spec](<[EIP-712](https://eips.ethereum.org/EIPS/eip-712)>).
+-   `data` - _required_ `Object` type of [`EthereumSignTypedDataMessage`](https://github.com/trezor/trezor-suite/blob/develop/packages/connect/src/types/api/ethereum/index.ts)`. A JSON Schema definition can be found in the [EIP-712 spec](https://eips.ethereum.org/EIPS/eip-712).
 -   `metamask_v4_compat` - _required_ `boolean` set to `true` for compatibility with [MetaMask's signTypedData_v4](https://docs.metamask.io/guide/signing-data.html#sign-typed-data-v4).
 
 #### Blind signing (optional addition for Trezor Model 1 compatibility)
@@ -31,12 +31,11 @@ hashes.
 However, it supports signing pre-constructed hashes.
 
 EIP-712 hashes can be constructed with the plugin function at
-["trezor-connect/lib/plugins/ethereum/typedData.js"](../../src/js/plugins/ethereum/typedData.js)
-(included as a plugin due to a depedency on `@metamask/eth-sig-utils`).
+[@trezor/connetct-plugin-ethereum](https://github.com/trezor/trezor-suite/blob/develop/packages/connect-plugin-ethereum).
 
 You may also wish to contruct your own hashes using a different library.
 
-###### [flowtype](../../src/js/types/networks/ethereum.js#L114-121)
+[EthereumSignTypedHash type](https://github.com/trezor/trezor-suite/blob/develop/packages/connect/src/types/api/ethereum/index.ts)
 
 > :warning: **Domain-only signing (empty `message_hash`) is supported only on Trezor Model 1 with Firmware 1.10.6 or higher!**
 
@@ -94,7 +93,7 @@ TrezorConnect.ethereumSignTypedData({
 
 ### Result
 
-###### [flowtype](../../src/js/types/api.js#L257)
+[EthereumMessageSignature type](https://github.com/trezor/trezor-suite/blob/develop/packages/transport/src/types/messages.ts)
 
 ```javascript
 {

--- a/docs/packages/connect/methods/ethereumVerifyMessage.md
+++ b/docs/packages/connect/methods/ethereumVerifyMessage.md
@@ -9,9 +9,9 @@ const result = await TrezorConnect.ethereumVerifyMessage(params);
 
 ### Params
 
-[\***\*Optional common params\*\***](commonParams.md)
+[Optional common params](commonParams.md)
 
-###### [flowtype](../../src/js/types/params.js#L74-L78)
+[EthereumVerifyMessage type](https://github.com/trezor/trezor-suite/blob/develop/packages/connect/src/types/api/ethereum/index.ts)
 
 -   `address` - _required_ `string` signer address. "0x" prefix is optional
 -   `message` - _required_ `string` signed message in plain text
@@ -31,7 +31,7 @@ TrezorConnect.ethereumVerifyMessage({
 
 ### Result
 
-###### [flowtype](../../src/js/types/response.js#L133-L136)
+[Success type](https://github.com/trezor/trezor-suite/blob/develop/packages/transport/src/types/messages.ts)
 
 ```javascript
 {

--- a/docs/packages/connect/methods/firmwareUpdate.md
+++ b/docs/packages/connect/methods/firmwareUpdate.md
@@ -8,7 +8,7 @@ const result = await TrezorConnect.firmwareUpdate(params);
 
 ### Params
 
-[\***\*Optional common params\*\***](commonParams.md)
+[Optional common params](commonParams.md)
 
 #### You either provide binary
 
@@ -59,6 +59,8 @@ TrezorConnect.firmwareUpdate({
 ```
 
 ### Result
+
+[FirmwareUpdateResponse type](https://github.com/trezor/trezor-suite/blob/develop/packages/connect/src/types/api/firmwareUpdate.ts)
 
 ```javascript
 {

--- a/docs/packages/connect/methods/getAccountInfo.md
+++ b/docs/packages/connect/methods/getAccountInfo.md
@@ -8,23 +8,23 @@ const result = await TrezorConnect.getAccountInfo(params);
 
 ### Params
 
-[\***\*Optional common params\*\***](commonParams.md)
+[Optional common params](commonParams.md)
 
 #### Using path
 
 -   `path` — _required_ `string | Array<number>` minimum length is `3`. [read more](../path.md)
--   `coin` — _required_ `string` determines network definition specified in [coins.json](../../src/data/coins.json) file. Coin `shortcut`, `name` or `label` can be used.
+-   `coin` — _required_ `string` determines network definition specified in [coins.json](https://github.com/trezor/trezor-suite/blob/develop/packages/connect-common/files/coins.json) file. Coin `shortcut`, `name` or `label` can be used.
 
 #### Using public key
 
 -   `descriptor` — _required_ `string` public key of account
--   `coin` — _required_ `string` determines network definition specified in [coins.json](../../src/data/coins.json) file. Coin `shortcut`, `name` or `label` can be used.
+-   `coin` — _required_ `string` determines network definition specified in [coins.json](https://github.com/trezor/trezor-suite/blob/develop/packages/connect-common/files/coins.json) file. Coin `shortcut`, `name` or `label` can be used.
 
 #### Using discovery
 
 BIP-0044 account discovery is performed and user is presented with a list of accounts. Result is returned after account selection.
 
--   `coin` — _required_ `string` determines network definition specified in [coins.json](../../src/data/coins.json) file. Coin `shortcut`, `name` or `label` can be used.
+-   `coin` — _required_ `string` determines network definition specified in [coins.json](https://github.com/trezor/trezor-suite/blob/develop/packages/connect-common/files/coins.json) file. Coin `shortcut`, `name` or `label` can be used.
 
 ### Other optional params
 
@@ -83,6 +83,8 @@ TrezorConnect.getAccountInfo({
 
 ### Result
 
+[AccountInfo type](https://github.com/trezor/trezor-suite/blob/develop/packages/connect/src/types/account.ts)
+
 ```javascript
 {
     success: true,
@@ -130,12 +132,6 @@ TrezorConnect.getAccountInfo({
     } //
 }
 ```
-
-[AccountInfo](../../src/js/types/account.js#L108)
-[AccountAddress](../../src/js/types/account.js#L34)
-[AccountTransaction](../../src/js/types/account.js#L83)
-[AccountUtxo](../../src/js/types/account.js#L49)
-[TokenInfo](../../src/js/types/account.js#L24)
 
 Error
 

--- a/docs/packages/connect/methods/getAccountInfo.md
+++ b/docs/packages/connect/methods/getAccountInfo.md
@@ -12,7 +12,7 @@ const result = await TrezorConnect.getAccountInfo(params);
 
 #### Using path
 
--   `path` — _required_ `string | Array<number>` minimum length is `3`. [read more](path.md)
+-   `path` — _required_ `string | Array<number>` minimum length is `3`. [read more](../path.md)
 -   `coin` — _required_ `string` determines network definition specified in [coins.json](../../src/data/coins.json) file. Coin `shortcut`, `name` or `label` can be used.
 
 #### Using public key

--- a/docs/packages/connect/methods/getAddress.md
+++ b/docs/packages/connect/methods/getAddress.md
@@ -12,7 +12,7 @@ const result = await TrezorConnect.getAddress(params);
 
 #### Exporting single address
 
--   `path` — _required_ `string | Array<number>` minimum length is `5`. [read more](path.md)
+-   `path` — _required_ `string | Array<number>` minimum length is `5`. [read more](../path.md)
 -   `address` — _optional_ `string` address for validation (read `Handle button request` section below)
 -   `showOnTrezor` — _optional_ `boolean` determines if address will be displayed on device. Default is set to `true`
 -   `coin` - _optional_ `string` determines network definition specified in [coins.json](../../src/data/coins.json) file. Coin `shortcut`, `name` or `label` can be used. If `coin` is not set API will try to get network definition from `path`.

--- a/docs/packages/connect/methods/getAddress.md
+++ b/docs/packages/connect/methods/getAddress.md
@@ -8,17 +8,17 @@ const result = await TrezorConnect.getAddress(params);
 
 ### Params
 
-[\***\*Optional common params\*\***](commonParams.md)
+[Optional common params](commonParams.md)
 
 #### Exporting single address
 
 -   `path` — _required_ `string | Array<number>` minimum length is `5`. [read more](../path.md)
 -   `address` — _optional_ `string` address for validation (read `Handle button request` section below)
 -   `showOnTrezor` — _optional_ `boolean` determines if address will be displayed on device. Default is set to `true`
--   `coin` - _optional_ `string` determines network definition specified in [coins.json](../../src/data/coins.json) file. Coin `shortcut`, `name` or `label` can be used. If `coin` is not set API will try to get network definition from `path`.
+-   `coin` - _optional_ `string` determines network definition specified in [coins.json](https://github.com/trezor/trezor-suite/blob/develop/packages/connect-common/files/coins.json) file. Coin `shortcut`, `name` or `label` can be used. If `coin` is not set API will try to get network definition from `path`.
 -   `crossChain` — _optional_ `boolean` Advanced feature. Use it only if you are know what you are doing. Allows to generate address between chains. For example Bitcoin path on Litecoin network will display cross chain address in Litecoin format.
--   `multisig` - _optional_ [MultisigRedeemScriptType](../../src/js/types/trezor.js#L107), redeem script information (multisig addresses only)
--   `scriptType` - _optional_ [InputScriptType](../../src/js/types/trezor.js#L113), address script type
+-   `multisig` - _optional_ [MultisigRedeemScriptType](https://github.com/trezor/trezor-suite/blob/develop/packages/transport/src/types/messages.ts), redeem script information (multisig addresses only)
+-   `scriptType` - _optional_ [InputScriptType](https://github.com/trezor/trezor-suite/blob/develop/packages/transport/src/types/messages.ts), address script type
 
 #### Exporting bundle of addresses
 
@@ -79,6 +79,8 @@ const result = await TrezorConnect.getAddress({
 ```
 
 ### Result
+
+[Address type](https://github.com/trezor/trezor-suite/blob/develop/packages/connect/src/types/params.ts)
 
 Result with only one address
 

--- a/docs/packages/connect/methods/getCoinInfo.md
+++ b/docs/packages/connect/methods/getCoinInfo.md
@@ -1,6 +1,6 @@
 ## Get Coin Info
 
-Returns information about a specified coin from the [coins.json](../../src/data/coins.json) file.
+Returns information about a specified coin from the [coins.json](https://github.com/trezor/trezor-suite/blob/develop/packages/connect-common/files/coins.json) file.
 
 ```javascript
 const result = await TrezorConnect.getCoinInfo(params);
@@ -8,7 +8,7 @@ const result = await TrezorConnect.getCoinInfo(params);
 
 ### Params
 
-[\***\*Optional common params\*\***](commonParams.md)
+[Optional common params](commonParams.md)
 
 #### Exporting single address
 
@@ -27,6 +27,8 @@ TrezorConnect.getCoinInfo({
 ### Result
 
 Result for Bitcoin
+
+[BitcoinNetworkInfo](https://github.com/trezor/trezor-suite/blob/develop/packages/connect/src/types/coinInfo.ts)
 
 ```javascript
 {

--- a/docs/packages/connect/methods/getCurrentFiatRates.md
+++ b/docs/packages/connect/methods/getCurrentFiatRates.md
@@ -28,6 +28,8 @@ const result = await TrezorConnect.blockchainGetCurrentFiatRates({
 
 ### Result
 
+[GetCurrentFiatRates type](https://github.com/trezor/trezor-suite/blob/develop/packages/blockchain-link/src/types/responses.ts)
+
 ```javascript
 {
     success: true,

--- a/docs/packages/connect/methods/getDeviceState.md
+++ b/docs/packages/connect/methods/getDeviceState.md
@@ -10,7 +10,7 @@ const result = await TrezorConnect.getDeviceState(params);
 
 ### Params
 
-[\***\*Optional common params\*\***](commonParams.md)
+[Optional common params](commonParams.md)
 
 ## Example
 
@@ -36,6 +36,8 @@ await TrezorConnect.getPublicKey({
 ```
 
 ### Result
+
+[DeviceStateResponse type](https://github.com/trezor/trezor-suite/blob/develop/packages/connect/src/types/api/getDeviceState.ts)
 
 ```javascript
 {

--- a/docs/packages/connect/methods/getFirmwareHash.md
+++ b/docs/packages/connect/methods/getFirmwareHash.md
@@ -4,7 +4,7 @@
 
 ### Params
 
-[\***\*Optional common params\*\***](commonParams.md)
+[Optional common params](commonParams.md)
 
 -   `challenge` — _required_ `string` a random 32-byte challenge which is return form successful [TrezorConnect.firmwareUpdate](./firmwareUpdate) call
 
@@ -19,6 +19,8 @@ TrezorConnect.getFirmwareHash({
 ```
 
 ### Result
+
+[FirmwareHash type](https://github.com/trezor/trezor-suite/blob/develop/packages/transport/src/types/messages.ts)
 
 ```javascript
 {

--- a/docs/packages/connect/methods/getOwnershipId.md
+++ b/docs/packages/connect/methods/getOwnershipId.md
@@ -14,7 +14,7 @@ const result = await TrezorConnect.getOwnershipId(params);
 
 #### Exporting single id
 
--   `path` — _required_ `string | Array<number>` minimum length is `5`. [read more](path.md)
+-   `path` — _required_ `string | Array<number>` minimum length is `5`. [read more](../path.md)
 -   `coin` - _optional_ `string`
     > Determines network definition specified in [coins.json](../../../connect-common/files/coins.json) file.
     > Coin `shortcut`, `name` or `label` can be used.

--- a/docs/packages/connect/methods/getOwnershipId.md
+++ b/docs/packages/connect/methods/getOwnershipId.md
@@ -10,13 +10,13 @@ const result = await TrezorConnect.getOwnershipId(params);
 
 ### Params
 
-[\***\*Optional common params\*\***](commonParams.md)
+[Optional common params](commonParams.md)
 
 #### Exporting single id
 
 -   `path` — _required_ `string | Array<number>` minimum length is `5`. [read more](../path.md)
 -   `coin` - _optional_ `string`
-    > Determines network definition specified in [coins.json](../../../connect-common/files/coins.json) file.
+    > Determines network definition specified in [coins.json](https://github.com/trezor/trezor-suite/blob/develop/packages/connect-common/files/coins.json) file.
     > Coin `shortcut`, `name` or `label` can be used.
 -   `scriptType` — _optional_ `InputScriptType`
 -   `multisig` — _optional_ `MultisigRedeemScriptType`
@@ -49,6 +49,8 @@ TrezorConnect.getOwnershipId({
 
 ### Result
 
+[OwnershipId type](https://github.com/trezor/trezor-suite/blob/develop/packages/connect/src/types/api/getOwnershipId.ts)
+
 Result with single id:
 
 ```javascript
@@ -56,6 +58,8 @@ Result with single id:
     success: true,
     payload: {
         ownership_id: string,
+        path: number[],
+        serializedPath: string
     }
 }
 ```
@@ -66,9 +70,9 @@ Result with bundle of ids sorted by FIFO
 {
     success: true,
     payload: [
-        { ownership_id: string }, // taproot
-        { ownership_id: string }, // bech32
-        { ownership_id: string }  // segwit
+        { ownership_id: string, path: number[], serializedPath: string }, // taproot
+        { ownership_id: string, path: number[], serializedPath: string }, // bech32
+        { ownership_id: string, path: number[], serializedPath: string }  // segwit
     ]
 }
 ```

--- a/docs/packages/connect/methods/getOwnershipProof.md
+++ b/docs/packages/connect/methods/getOwnershipProof.md
@@ -10,13 +10,13 @@ const result = await TrezorConnect.getOwnershipProof(params);
 
 ### Params
 
-[\***\*Optional common params\*\***](commonParams.md)
+[Optional common params](commonParams.md)
 
 #### Exporting single proof
 
 -   `path` — _required_ `string | Array<number>` minimum length is `5`. [read more](../path.md)
 -   `coin` - _optional_ `string`
-    > Determines network definition specified in [coins.json](../../../connect-common/files/coins.json) file.
+    > Determines network definition specified in [coins.json](https://github.com/trezor/trezor-suite/blob/develop/packages/connect-common/files/coins.json) file.
     > Coin `shortcut`, `name` or `label` can be used.
 -   `scriptType` — _optional_ `InputScriptType`
 -   `userConfirmation` — _optional_ `boolean`
@@ -53,6 +53,8 @@ TrezorConnect.getOwnershipProof({
 
 ### Result
 
+[OwnershipProof type](https://github.com/trezor/trezor-suite/blob/develop/packages/connect/src/types/api/getOwnershipProof.ts)
+
 Result with single proof:
 
 ```javascript
@@ -60,7 +62,9 @@ Result with single proof:
     success: true,
     payload: {
         ownership_proof: string,
-        signature: string
+        signature: string,
+        path: number[],
+        serializedPath: string
     }
 }
 ```
@@ -71,9 +75,9 @@ Result with bundle of proofs sorted by FIFO
 {
     success: true,
     payload: [
-        { ownership_proof: string, signature: string }, // taproot
-        { ownership_proof: string, signature: string }, // bech32
-        { ownership_proof: string, signature: string }  // segwit
+        { ownership_proof: string, signature: string, path: number[], serializedPath: string }, // taproot
+        { ownership_proof: string, signature: string, path: number[], serializedPath: string }, // bech32
+        { ownership_proof: string, signature: string, path: number[], serializedPath: string }  // segwit
     ]
 }
 ```

--- a/docs/packages/connect/methods/getOwnershipProof.md
+++ b/docs/packages/connect/methods/getOwnershipProof.md
@@ -14,7 +14,7 @@ const result = await TrezorConnect.getOwnershipProof(params);
 
 #### Exporting single proof
 
--   `path` — _required_ `string | Array<number>` minimum length is `5`. [read more](path.md)
+-   `path` — _required_ `string | Array<number>` minimum length is `5`. [read more](../path.md)
 -   `coin` - _optional_ `string`
     > Determines network definition specified in [coins.json](../../../connect-common/files/coins.json) file.
     > Coin `shortcut`, `name` or `label` can be used.

--- a/docs/packages/connect/methods/getPublicKey.md
+++ b/docs/packages/connect/methods/getPublicKey.md
@@ -9,12 +9,12 @@ const result = await TrezorConnect.getPublicKey(params);
 
 ### Params
 
-[\***\*Optional common params\*\***](commonParams.md)
+[Optional common params](commonParams.md)
 
 #### Exporting single public key
 
 -   `path` — _required_ `string | Array<number>` minimum length is `1`. [read more](../path.md)
--   `coin` - _optional_ `string` determines network definition specified in [coins.json](../../src/data/coins.json) file. Coin `shortcut`, `name` or `label` can be used. If `coin` is not set API will try to get network definition from `path`.
+-   `coin` - _optional_ `string` determines network definition specified in [coins.json](https://github.com/trezor/trezor-suite/blob/develop/packages/connect-common/files/coins.json) file. Coin `shortcut`, `name` or `label` can be used. If `coin` is not set API will try to get network definition from `path`.
 -   `crossChain` — _optional_ `boolean` Advanced feature. Use it only if you are know what you are doing. Allows to generate address between chains. For example Bitcoin path on Litecoin network will display cross chain address in Litecoin format.
 
 #### Exporting bundle of public keys
@@ -45,6 +45,8 @@ TrezorConnect.getPublicKey({
 ```
 
 ### Result
+
+[HDNodeResponse type](https://github.com/trezor/trezor-suite/blob/develop/packages/connect/src/types/api/getPublicKey.ts)
 
 Result with only one public key
 

--- a/docs/packages/connect/methods/nemGetAddress.md
+++ b/docs/packages/connect/methods/nemGetAddress.md
@@ -13,7 +13,7 @@ const result = await TrezorConnect.nemGetAddress(params);
 
 #### Exporting single address
 
--   `path` — _required_ `string | Array<number>` minimum length is `3`. [read more](path.md)
+-   `path` — _required_ `string | Array<number>` minimum length is `3`. [read more](../path.md)
 -   `address` — _optional_ `string` address for validation (read `Handle button request` section below)
 -   `network` — _optional_ `number` `0x68` - Mainnet, `0x96` - Testnet, `0x60` - Mijin. Default is set to `Mainnet`
 -   `showOnTrezor` — _optional_ `boolean` determines if address will be displayed on device. Default is set to `true`

--- a/docs/packages/connect/methods/nemGetAddress.md
+++ b/docs/packages/connect/methods/nemGetAddress.md
@@ -9,7 +9,7 @@ const result = await TrezorConnect.nemGetAddress(params);
 
 ### Params
 
-[\***\*Optional common params\*\***](commonParams.md)
+[Optional common params](commonParams.md)
 
 #### Exporting single address
 
@@ -76,6 +76,8 @@ const result = await TrezorConnect.nemGetAddress({
 ```
 
 ### Result
+
+[Address type](https://github.com/trezor/trezor-suite/blob/develop/packages/connect/src/types/params.ts)
 
 Result with only one address
 

--- a/docs/packages/connect/methods/nemSignTransaction.md
+++ b/docs/packages/connect/methods/nemSignTransaction.md
@@ -9,12 +9,12 @@ const result = await TrezorConnect.nemSignTransaction(params);
 
 ### Params
 
-[\***\*Optional common params\*\***](commonParams.md)
+[Optional common params](commonParams.md)
 
-###### [flowtype](../../src/js/types/params.js#L114-L117)
+[NEMSignTransaction type](https://github.com/trezor/trezor-suite/blob/develop/packages/connect/src/types/api/nem/index.ts)
 
 -   `path` - _required_ `string | Array<number>`
--   `transaction` - _required_ `Object` type of [NEMTransaction](../../src/js/types/nem.js#L41)
+-   `transaction` - _required_ `Object` type of [NEMTransaction](https://github.com/trezor/trezor-suite/blob/develop/packages/connect/src/types/api/nem/index.ts)
 
 ### Example
 
@@ -80,7 +80,7 @@ TrezorConnect.nemSignTransaction(
 
 ### Result
 
-###### [flowtype](../../src/js/types/response.js#L271-L274)
+[NEMSignedTx type](https://github.com/trezor/trezor-suite/blob/develop/packages/transport/src/types/messages.ts)
 
 ```javascript
 {

--- a/docs/packages/connect/methods/pushTransaction.md
+++ b/docs/packages/connect/methods/pushTransaction.md
@@ -8,12 +8,12 @@ const result = await TrezorConnect.pushTransaction(params);
 
 ### Params
 
-[\***\*Optional common params\*\***](commonParams.md)
+[Optional common params](commonParams.md)
 
-###### [flowtype](../../src/js/types/params.js#L119-L22)
+[PushTransaction type](https://github.com/trezor/trezor-suite/blob/develop/packages/connect/src/types/api/pushTransaction.ts)
 
 -   `tx` - _required_ `string` serialized transaction,
--   `coin` - _required_ `string` Determines network definition specified in [coins.json](../../src/data/coins.json) file. Coin `shortcut`, `name` or `label` can be used.
+-   `coin` - _required_ `string` Determines network definition specified in [coins.json](https://github.com/trezor/trezor-suite/blob/develop/packages/connect-common/files/coins.json) file. Coin `shortcut`, `name` or `label` can be used.
 
 ### Example
 
@@ -26,7 +26,7 @@ TrezorConnect.pushTransaction({
 
 ### Result
 
-###### [flowtype](../../src/js/types/response.js#L94-L96)
+[PushedTransaction type](https://github.com/trezor/trezor-suite/blob/develop/packages/connect/src/types/api/pushTransaction.ts)
 
 ```javascript
 {

--- a/docs/packages/connect/methods/requestLogin.md
+++ b/docs/packages/connect/methods/requestLogin.md
@@ -21,7 +21,7 @@ const result = await TrezorConnect.requestLogin(params);
 
 ### Params
 
-[\***\*Optional common params\*\***](commonParams.md)
+[Optional common params](commonParams.md)
 <br>
 Common parameter `useEmptyPassphrase` - is always set to `true` and it will be ignored by this method
 
@@ -60,6 +60,8 @@ TrezorConnect.requestLogin({
 ```
 
 ### Result
+
+[Login type](https://github.com/trezor/trezor-suite/blob/develop/packages/connect/src/types/api/requestLogin.ts)
 
 ```javascript
 {

--- a/docs/packages/connect/methods/resetDevice.md
+++ b/docs/packages/connect/methods/resetDevice.md
@@ -8,8 +8,7 @@ const result = await TrezorConnect.resetDevice(params);
 
 ### Params
 
-[\***\*Optional common params\*\***](commonParams.md)
-<br>
+[Optional common params](commonParams.md)
 
 -   `strength` — _optional_ `number` Accepted values are [128|192|256]. Default is set to `256`
 -   `label` — _optional_ `string`
@@ -28,6 +27,8 @@ TrezorConnect.resetDevice({
 ```
 
 ### Result
+
+[Success type](https://github.com/trezor/trezor-suite/blob/develop/packages/transport/src/types/messages.ts)
 
 ```javascript
 {

--- a/docs/packages/connect/methods/rippleGetAddress.md
+++ b/docs/packages/connect/methods/rippleGetAddress.md
@@ -12,7 +12,7 @@ const result = await TrezorConnect.rippleGetAddress(params);
 
 #### Exporting single address
 
--   `path` — _required_ `string | Array<number>` minimum length is `5`. [read more](path.md)
+-   `path` — _required_ `string | Array<number>` minimum length is `5`. [read more](../path.md)
 -   `address` — _optional_ `string` address for validation (read `Handle button request` section below)
 -   `showOnTrezor` — _optional_ `boolean` determines if address will be displayed on device. Default is set to `true`
 

--- a/docs/packages/connect/methods/rippleGetAddress.md
+++ b/docs/packages/connect/methods/rippleGetAddress.md
@@ -8,7 +8,7 @@ const result = await TrezorConnect.rippleGetAddress(params);
 
 ### Params
 
-[\***\*Optional common params\*\***](commonParams.md)
+[Optional common params](commonParams.md)
 
 #### Exporting single address
 
@@ -74,6 +74,8 @@ const result = await TrezorConnect.rippleGetAddress({
 ```
 
 ### Result
+
+[Address type](https://github.com/trezor/trezor-suite/blob/develop/packages/connect/src/types/params.ts)
 
 Result with only one address
 

--- a/docs/packages/connect/methods/rippleSignTransaction.md
+++ b/docs/packages/connect/methods/rippleSignTransaction.md
@@ -9,12 +9,12 @@ const result = await TrezorConnect.rippleSignTransaction(params);
 
 ### Params
 
-[\***\*Optional common params\*\***](commonParams.md)
+[Optional common params](commonParams.md)
 
-###### [flowtype](../../src/js/types/params.js#L149-L154)
+[RippleSignTransaction type](https://github.com/trezor/trezor-suite/blob/develop/packages/connect/src/types/api/ripple/index.ts)
 
 -   `path` — _required_ `string | Array<number>` minimum length is `3`. [read more](../path.md)
--   `transaction` - _required_ `Object` type of [RippleTransaction](../../src/js/types/ripple.js#L36-L42)
+-   `transaction` - _required_ `Object` type of [RippleTransaction](https://github.com/trezor/trezor-suite/blob/develop/packages/connect/src/types/api/ripple/index.ts)
 
 ### Example
 
@@ -35,7 +35,7 @@ TrezorConnect.rippleSignTransaction(
 
 ### Result
 
-###### [flowtype](../../src/js/types/ripple.js#L49-L52)
+[RippleSignedTx type](https://github.com/trezor/trezor-suite/blob/develop/packages/connect/src/types/api/ripple/index.ts)
 
 ```javascript
 {

--- a/docs/packages/connect/methods/rippleSignTransaction.md
+++ b/docs/packages/connect/methods/rippleSignTransaction.md
@@ -13,7 +13,7 @@ const result = await TrezorConnect.rippleSignTransaction(params);
 
 ###### [flowtype](../../src/js/types/params.js#L149-L154)
 
--   `path` — _required_ `string | Array<number>` minimum length is `3`. [read more](path.md)
+-   `path` — _required_ `string | Array<number>` minimum length is `3`. [read more](../path.md)
 -   `transaction` - _required_ `Object` type of [RippleTransaction](../../src/js/types/ripple.js#L36-L42)
 
 ### Example

--- a/docs/packages/connect/methods/signMessage.md
+++ b/docs/packages/connect/methods/signMessage.md
@@ -12,7 +12,7 @@ const result = await TrezorConnect.signMessage(params);
 
 ###### [flowtype](../../src/js/types/params.js#L131-L135)
 
--   `path` — _required_ `string | Array<number>` minimum length is `3`. [read more](path.md)
+-   `path` — _required_ `string | Array<number>` minimum length is `3`. [read more](../path.md)
 -   `message` - _required_ `string`
 -   `coin` - _optional_ `string` Determines network definition specified in [coins.json](../../src/data/coins.json) file. Coin `shortcut`, `name` or `label` can be used. If `coin` is not set API will try to get network definition from `path`.
 -   `hex` - _optional_ `boolean` convert message from hex

--- a/docs/packages/connect/methods/signMessage.md
+++ b/docs/packages/connect/methods/signMessage.md
@@ -8,13 +8,13 @@ const result = await TrezorConnect.signMessage(params);
 
 ### Params
 
-[\***\*Optional common params\*\***](commonParams.md)
+[Optional common params](commonParams.md)
 
-###### [flowtype](../../src/js/types/params.js#L131-L135)
+[SignMessage type](https://github.com/trezor/trezor-suite/blob/develop/packages/connect/src/types/api/bitcoin/index.ts)
 
 -   `path` — _required_ `string | Array<number>` minimum length is `3`. [read more](../path.md)
 -   `message` - _required_ `string`
--   `coin` - _optional_ `string` Determines network definition specified in [coins.json](../../src/data/coins.json) file. Coin `shortcut`, `name` or `label` can be used. If `coin` is not set API will try to get network definition from `path`.
+-   `coin` - _optional_ `string` Determines network definition specified in [coins.json](https://github.com/trezor/trezor-suite/blob/develop/packages/connect-common/files/coins.json) file. Coin `shortcut`, `name` or `label` can be used. If `coin` is not set API will try to get network definition from `path`.
 -   `hex` - _optional_ `boolean` convert message from hex
 
 ### Example
@@ -28,7 +28,7 @@ TrezorConnect.signMessage({
 
 ### Result
 
-###### [flowtype](../../src/js/types/response.js#L113-L116)
+[MessageSignature type](https://github.com/trezor/trezor-suite/blob/develop/packages/transport/src/types/messages.ts)
 
 ```javascript
 {

--- a/docs/packages/connect/methods/signTransaction.md
+++ b/docs/packages/connect/methods/signTransaction.md
@@ -8,18 +8,20 @@ details on Trezor.
 const result = await TrezorConnect.signTransaction(params);
 ```
 
-### Params [types](../../src/types/api/signTransaction.ts#L54)
+### Params
 
-[\***\*Optional common params\*\***](commonParams.md)
+[Optional common params](commonParams.md)
+
+[SignTransaction type](https://github.com/trezor/trezor-suite/blob/develop/packages/connect/src/types/api/bitcoin/index.ts)
 
 -   `coin` - _required_ `string`
-    > Determines network definition specified in [coins.json](../../../connect-common/files/coins.json) file.
+    > Determines network definition specified in [coins.json](https://github.com/trezor/trezor-suite/blob/develop/packages/connect-common/files/coins.json) file.
     > Coin `shortcut`, `name` or `label` can be used.
     > See [supported coins](../supported-coins.md)
--   `inputs` - _required_ `Array` of [PROTO.TxInputType](../../../transport/src/types/messages.ts#L300),
--   `outputs` - _required_ `Array` of [PROTO.TxOutputType](../../../transport/src/types/messages.ts#L327),
--   `paymentRequests` - _optional_ `Array` of [PROTO.TxAckPaymentRequest](../../../transport/src/types/messages.ts#L415). See [SLIP-24](https://github.com/satoshilabs/slips/blob/slip24/slip-0024.md)
--   `refTxs` - _optional_ `Array` of [RefTransaction](../../src/types/api/signTransaction.ts#L12).
+-   `inputs` - _required_ `Array` of [PROTO.TxInputType](https://github.com/trezor/trezor-suite/blob/develop/packages/transport/src/types/messages.ts),
+-   `outputs` - _required_ `Array` of [PROTO.TxOutputType](https://github.com/trezor/trezor-suite/blob/develop/packages/transport/src/types/messages.ts),
+-   `paymentRequests` - _optional_ `Array` of [PROTO.TxAckPaymentRequest](https://github.com/trezor/trezor-suite/blob/develop/packages/transport/src/types/messages.ts). See [SLIP-24](https://github.com/satoshilabs/slips/blob/slip24/slip-0024.md)
+-   `refTxs` - _optional_ `Array` of [RefTransaction](https://github.com/trezor/trezor-suite/blob/develop/packages/connect/src/types/api/bitcoin/index.ts).
     > If you don't want to use build-in `blockbook` backend you can optionally provide those data from your own backend transformed to `Trezor` format.
     > Since Firmware 2.3.0/1.9.0 referenced transactions are required.
     > Zcash and Komodo refTxs should also contains `expiry`, `version_group_id` and `extra_data` fields.
@@ -183,7 +185,9 @@ TrezorConnect.signTransaction({
 });
 ```
 
-### Result [types](../../src/types/api/signTransaction.ts#L74)
+### Result
+
+[SignedTransaction type](https://github.com/trezor/trezor-suite/blob/develop/packages/connect/src/types/api/bitcoin/index.ts)
 
 ```javascript
 {

--- a/docs/packages/connect/methods/stellarGetAddress.md
+++ b/docs/packages/connect/methods/stellarGetAddress.md
@@ -8,7 +8,7 @@ const result = await TrezorConnect.stellarGetAddress(params);
 
 ### Params
 
-[\***\*Optional common params\*\***](commonParams.md)
+[Optional common params](commonParams.md)
 
 #### Exporting single address
 
@@ -74,6 +74,8 @@ const result = await TrezorConnect.stellarGetAddress({
 ```
 
 ### Result
+
+[Address type](https://github.com/trezor/trezor-suite/blob/develop/packages/connect/src/types/params.ts)
 
 Result with only one address
 

--- a/docs/packages/connect/methods/stellarGetAddress.md
+++ b/docs/packages/connect/methods/stellarGetAddress.md
@@ -12,7 +12,7 @@ const result = await TrezorConnect.stellarGetAddress(params);
 
 #### Exporting single address
 
--   `path` — _required_ `string | Array<number>` minimum length is `3`. [read more](path.md)
+-   `path` — _required_ `string | Array<number>` minimum length is `3`. [read more](../path.md)
 -   `address` — _optional_ `string` address for validation (read `Handle button request` section below)
 -   `showOnTrezor` — _optional_ `boolean` determines if address will be displayed on device. Default is set to `true`
 

--- a/docs/packages/connect/methods/stellarSignTransaction.md
+++ b/docs/packages/connect/methods/stellarSignTransaction.md
@@ -9,18 +9,18 @@ const result = await TrezorConnect.stellarSignTransaction(params);
 
 ### Params
 
-[\***\*Optional common params\*\***](commonParams.md)
+[Optional common params](commonParams.md)
 
-###### [flowtype](../../src/js/types/params.js#L149-L154)
+[StellarSignTransaction type](https://github.com/trezor/trezor-suite/blob/develop/packages/connect/src/types/api/stellar/index.ts)
 
 -   `path` — _required_ `string | Array<number>` minimum length is `3`. [read more](../path.md)
 -   `networkPassphrase` - _required_ `string` network passphrase
--   `transaction` - _required_ `Object` type of [StellarTransaction](../../src/js/types/stellar.js#L129)
+-   `transaction` - _required_ `Object` type of [StellarTransaction](https://github.com/trezor/trezor-suite/blob/develop/packages/connect/src/types/api/stellar/index.ts)
 
 ### Stellar SDK compatibility
 
 `stellar-sdk` is not a part of `trezor-connect` repository.
-To transform `StellarSDK.Transaction` object into `TrezorConnect.StellarTransaction` object copy [this plugin](../../src/js/plugins/stellar/plugin.js) into your project.
+To transform `StellarSDK.Transaction` object into `TrezorConnect.StellarTransaction`, install [@trezor/connect-plugin-stellar](https://github.com/trezor/trezor-suite/tree/develop/packages/connect-plugin-stellar) into your project.
 
 ```javascript
 import StellarSDK from 'stellar-sdk';
@@ -65,7 +65,7 @@ TrezorConnect.stellarSignTransaction(
 
 ### Result
 
-###### [flowtype](../../src/js/types/response.js#L129-L132)
+[StellarSignedTx type](https://github.com/trezor/trezor-suite/blob/develop/packages/connect/src/types/api/stellar/index.ts)
 
 ```javascript
 {

--- a/docs/packages/connect/methods/stellarSignTransaction.md
+++ b/docs/packages/connect/methods/stellarSignTransaction.md
@@ -13,7 +13,7 @@ const result = await TrezorConnect.stellarSignTransaction(params);
 
 ###### [flowtype](../../src/js/types/params.js#L149-L154)
 
--   `path` — _required_ `string | Array<number>` minimum length is `3`. [read more](path.md)
+-   `path` — _required_ `string | Array<number>` minimum length is `3`. [read more](../path.md)
 -   `networkPassphrase` - _required_ `string` network passphrase
 -   `transaction` - _required_ `Object` type of [StellarTransaction](../../src/js/types/stellar.js#L129)
 

--- a/docs/packages/connect/methods/tezosGetAddress.md
+++ b/docs/packages/connect/methods/tezosGetAddress.md
@@ -8,7 +8,7 @@ const result = await TrezorConnect.tezosGetAddress(params);
 
 ### Params
 
-[\***\*Optional common params\*\***](commonParams.md)
+[Optional common params](commonParams.md)
 
 #### Exporting single address
 
@@ -74,6 +74,8 @@ const result = await TrezorConnect.tezosGetAddress({
 ```
 
 ### Result
+
+[Address type](https://github.com/trezor/trezor-suite/blob/develop/packages/connect/src/types/params.ts)
 
 Result with only one address
 

--- a/docs/packages/connect/methods/tezosGetAddress.md
+++ b/docs/packages/connect/methods/tezosGetAddress.md
@@ -12,7 +12,7 @@ const result = await TrezorConnect.tezosGetAddress(params);
 
 #### Exporting single address
 
--   `path` — _required_ `string | Array<number>` minimum length is `3`. [read more](path.md)
+-   `path` — _required_ `string | Array<number>` minimum length is `3`. [read more](../path.md)
 -   `address` — _optional_ `string` address for validation (read `Handle button request` section below)
 -   `showOnTrezor` — _optional_ `boolean` determines if address will be displayed on device. Default is set to `true`
 

--- a/docs/packages/connect/methods/tezosGetPublicKey.md
+++ b/docs/packages/connect/methods/tezosGetPublicKey.md
@@ -9,7 +9,7 @@ const result = await TrezorConnect.tezosGetPublicKey(params);
 
 ### Params
 
-[\***\*Optional common params\*\***](commonParams.md)
+[Optional common params](commonParams.md)
 
 #### Exporting single public key
 
@@ -43,6 +43,8 @@ TrezorConnect.tezosGetPublicKey({
 ```
 
 ### Result
+
+[PublicKey type](https://github.com/trezor/trezor-suite/blob/develop/packages/connect/src/types/params.ts)
 
 Result with only one public key
 

--- a/docs/packages/connect/methods/tezosGetPublicKey.md
+++ b/docs/packages/connect/methods/tezosGetPublicKey.md
@@ -13,7 +13,7 @@ const result = await TrezorConnect.tezosGetPublicKey(params);
 
 #### Exporting single public key
 
--   `path` — _required_ `string | Array<number>` minimum length is `3`. [read more](path.md)
+-   `path` — _required_ `string | Array<number>` minimum length is `3`. [read more](../path.md)
 -   `showOnTrezor` — _optional_ `boolean` determines if public key will be displayed on device.
 
 #### Exporting bundle of public keys

--- a/docs/packages/connect/methods/tezosSignTransaction.md
+++ b/docs/packages/connect/methods/tezosSignTransaction.md
@@ -9,13 +9,13 @@ const result = await TrezorConnect.tezosSignTransaction(params);
 
 ### Params
 
-[\***\*Optional common params\*\***](commonParams.md)
+[Optional common params](commonParams.md)
 
-###### [flowtype](../../src/js/types/tezos.js#L104-L108)
+[TezosSignTransaction type](https://github.com/trezor/trezor-suite/blob/develop/packages/connect/src/types/api/tezos/index.ts)
 
 -   `path` - _required_ `string | Array<number>`
 -   `branch` - _required_ `string`
--   `operation` - _required_ `Object` type of [TezosOperation](../../src/js/types/tezos.js#L54)
+-   `operation` - _required_ `Object` type of [TezosOperation](https://github.com/trezor/trezor-suite/blob/develop/packages/connect/src/types/api/tezos/index.ts)
 
 ### Example
 
@@ -208,7 +208,7 @@ TrezorConnect.tezosSignTransaction({
 
 ### Result
 
-###### [flowtype](../../src/js/types/tezos.js#L110-L114)
+[TezosSignedTx type](https://github.com/trezor/trezor-suite/blob/develop/packages/transport/src/types/messages.ts)
 
 ```javascript
 {

--- a/docs/packages/connect/methods/verifyMessage.md
+++ b/docs/packages/connect/methods/verifyMessage.md
@@ -9,14 +9,14 @@ const result = await TrezorConnect.verifyMessage(params);
 
 ### Params
 
-[\***\*Optional common params\*\***](commonParams.md)
+[Optional common params](commonParams.md)
 
-###### [flowtype](../../src/js/types/params.js#L156-L161)
+[VerifyMessage type](https://github.com/trezor/trezor-suite/blob/develop/packages/connect/src/types/api/bitcoin/index.ts)
 
 -   `address` - _required_ `string` signer address,
 -   `message` - _required_ `string` signed message,
 -   `signature` - _required_ `string` signature in base64 format,
--   `coin` - _required_ `string` Determines network definition specified in [coins.json](../../src/data/coins.json) file. Coin `shortcut`, `name` or `label` can be used.
+-   `coin` - _required_ `string` Determines network definition specified in [coins.json](https://github.com/trezor/trezor-suite/blob/develop/packages/connect-common/files/coins.json) file. Coin `shortcut`, `name` or `label` can be used.
 -   `hex` - _optional_ `boolean` convert message from hex
 
 ### Example
@@ -33,7 +33,7 @@ TrezorConnect.verifyMessage({
 
 ### Result
 
-###### [flowtype](../../src/js/types/response.js#L133-L136)
+[Success type](https://github.com/trezor/trezor-suite/blob/develop/packages/transport/src/types/messages.ts)
 
 ```javascript
 {

--- a/docs/packages/connect/methods/wipeDevice.md
+++ b/docs/packages/connect/methods/wipeDevice.md
@@ -8,8 +8,8 @@ const result = await TrezorConnect.wipeDevice(params);
 
 ### Params
 
-[\***\*Optional common params\*\***](commonParams.md)
-<br>
+[Optional common params](commonParams.md)
+
 Common parameter `useEmptyPassphrase` - is set to `true`
 Common parameter `allowSeedlessDevice` - is set to `true`
 
@@ -20,6 +20,8 @@ TrezorConnect.wipeDevice();
 ```
 
 ### Result
+
+[Success type](https://github.com/trezor/trezor-suite/blob/develop/packages/transport/src/types/messages.ts)
 
 ```javascript
 {


### PR DESCRIPTION
This should fix all URLs and types in Connect docs.

## Description

I fixed broken URLS, added missing links to types and fixed some types in the docs by adding properties which have not been documented. I also unified formatting a bit.

## Related Issue

#6066

