### PR TITLE
feat: display coinmarket info notes as tags

### DIFF
--- a/packages/suite/src/components/wallet/CoinmarketTag/index.tsx
+++ b/packages/suite/src/components/wallet/CoinmarketTag/index.tsx
@@ -1,0 +1,26 @@
+import React from 'react';
+import styled from 'styled-components';
+import { variables } from '@trezor/components';
+
+const TagRow = styled.div`
+    display: flex;
+`;
+
+const Tag = styled.div`
+    margin: 0 16px 2px 16px;
+    padding: 0 8px;
+    border-radius: 8px;
+    background: ${props => props.theme.TYPE_ORANGE};
+    color: ${props => props.theme.TYPE_WHITE};
+    font-size: ${variables.FONT_SIZE.TINY};
+    line-height: 21px;
+    text-transform: uppercase;
+`;
+
+interface CoinmarketTagProps {
+    tag?: string;
+}
+
+export const CoinmarketTag = ({ tag }: CoinmarketTagProps) => (
+    <TagRow>{tag && <Tag>{tag}</Tag>}</TagRow>
+);

--- a/packages/suite/src/components/wallet/index.tsx
+++ b/packages/suite/src/components/wallet/index.tsx
@@ -26,6 +26,7 @@ import CoinmarketExchangeOfferInfo from './CoinmarketExchangeOfferInfo';
 import CoinmarketTransactionId from './CoinmarketTransactionId';
 import CoinmarketProviderInfo from './CoinmarketProviderInfo';
 import CoinmarketRefreshTime from './CoinmarketRefreshTime';
+import { CoinmarketTag } from './CoinmarketTag';
 import { DiscoveryProgress } from './DiscoveryProgress';
 import KYCInProgress from './KYCInProgress';
 import KYCFailed from './KYCFailed';
@@ -54,6 +55,7 @@ export {
     CoinmarketProvidedByInvity,
     CoinmarketPaymentType,
     CoinmarketRefreshTime,
+    CoinmarketTag,
     DiscoveryProgress,
     withCoinmarket,
     withSelectedAccountLoaded,

--- a/packages/suite/src/utils/wallet/coinmarket/__tests__/coinmarketUtils.test.ts
+++ b/packages/suite/src/utils/wallet/coinmarket/__tests__/coinmarketUtils.test.ts
@@ -7,6 +7,7 @@ import {
     getCountryLabelParts,
     mapTestnetSymbol,
     getSendCryptoOptions,
+    getTagAndInfoNote,
 } from '../coinmarketUtils';
 import { accountBtc, accountEth } from '../__fixtures__/coinmarketUtils';
 
@@ -80,5 +81,16 @@ describe('coinmarket utils', () => {
                 value: 'USDC',
             },
         ]);
+    });
+
+    it('getTagAndInfoNote', () => {
+        expect(getTagAndInfoNote({})).toStrictEqual({ infoNote: undefined });
+        expect(getTagAndInfoNote({ infoNote: '' })).toStrictEqual({ infoNote: '' });
+        expect(getTagAndInfoNote({ infoNote: 'Foo' })).toStrictEqual({ infoNote: 'Foo' });
+        expect(getTagAndInfoNote({ infoNote: ' #Foo' })).toStrictEqual({ infoNote: ' #Foo' });
+        expect(getTagAndInfoNote({ infoNote: 'Foo#Bar' })).toStrictEqual({ infoNote: 'Foo#Bar' });
+        expect(getTagAndInfoNote({ infoNote: '#Foo' })).toStrictEqual({ tag: 'Foo' });
+        expect(getTagAndInfoNote({ infoNote: '# Foo' })).toStrictEqual({ tag: ' Foo' });
+        expect(getTagAndInfoNote({ infoNote: '##Bar' })).toStrictEqual({ tag: '#Bar' });
     });
 });

--- a/packages/suite/src/utils/wallet/coinmarket/coinmarketUtils.ts
+++ b/packages/suite/src/utils/wallet/coinmarket/coinmarketUtils.ts
@@ -165,3 +165,10 @@ export const mapTestnetSymbol = (symbol: Network['symbol']) => {
     if (symbol === 'tada') return 'ada';
     return symbol;
 };
+
+export const getTagAndInfoNote = (quote: { infoNote?: string }) => {
+    if (quote.infoNote?.startsWith('#')) {
+        return { tag: quote.infoNote.substring(1) };
+    }
+    return { infoNote: quote.infoNote };
+};

--- a/packages/suite/src/views/wallet/coinmarket/buy/offers/Offers/List/Quote/index.tsx
+++ b/packages/suite/src/views/wallet/coinmarket/buy/offers/Offers/List/Quote/index.tsx
@@ -1,11 +1,11 @@
 import React from 'react';
 import styled from 'styled-components';
 import { useTheme, Button, variables, Icon, H2 } from '@trezor/components';
-import { CoinmarketPaymentType, CoinmarketProviderInfo } from '@wallet-components';
+import { CoinmarketPaymentType, CoinmarketProviderInfo, CoinmarketTag } from '@wallet-components';
 import { QuestionTooltip, Translation } from '@suite-components';
 import { BuyTrade } from 'invity-api';
 import { useCoinmarketBuyOffersContext } from '@wallet-hooks/useCoinmarketBuyOffers';
-import { formatCryptoAmount } from '@wallet-utils/coinmarket/coinmarketUtils';
+import { formatCryptoAmount, getTagAndInfoNote } from '@wallet-utils/coinmarket/coinmarketUtils';
 
 interface Props {
     className?: string;
@@ -24,24 +24,11 @@ const Wrapper = styled.div`
     background: ${props => props.theme.BG_WHITE};
 `;
 
-const TagRow = styled.div`
-    display: flex;
-    min-height: 30px;
-`;
-
-const Tag = styled.div`
-    margin-top: 10px;
-    height: 35px;
-    margin-left: -20px;
-    border: 1px solid tan;
-    text-transform: uppercase;
-`;
-
 const Main = styled.div`
     display: flex;
     margin: 0 30px;
     justify-content: space-between;
-    padding-bottom: 20px;
+    padding: 20px 0;
     border-bottom: 1px solid ${props => props.theme.STROKE_GREY};
 
     @media (max-width: ${variables.SCREEN_SIZE.SM}) {
@@ -52,6 +39,7 @@ const Main = styled.div`
 
 const Left = styled(H2)`
     display: flex;
+    align-items: center;
     font-weight: ${variables.FONT_WEIGHT.REGULAR};
 `;
 
@@ -210,14 +198,11 @@ export function getQuoteError(quote: BuyTrade, wantCrypto: boolean) {
 const Quote = ({ className, quote, wantCrypto }: Props) => {
     const theme = useTheme();
     const { selectQuote, providersInfo } = useCoinmarketBuyOffersContext();
-    // TODO - tags are not yet fully supported by the API server
-    // in the future will be taken from quote.tags, will need some algorithm to evaluate them and show only one
-    const hasTag = false;
+    const { tag, infoNote } = getTagAndInfoNote(quote);
     const { paymentMethod, exchange, error } = quote;
 
     return (
         <Wrapper className={className}>
-            <TagRow>{hasTag && <Tag>best offer</Tag>}</TagRow>
             <Main>
                 {error && <Left>N/A</Left>}
                 {!error && (
@@ -227,6 +212,7 @@ const Quote = ({ className, quote, wantCrypto }: Props) => {
                             : `${formatCryptoAmount(Number(quote.receiveStringAmount))} ${
                                   quote.receiveCurrency
                               }`}
+                        <CoinmarketTag tag={tag} />
                     </Left>
                 )}
                 <Right>
@@ -271,7 +257,7 @@ const Quote = ({ className, quote, wantCrypto }: Props) => {
                 </ErrorFooter>
             )}
 
-            {quote.infoNote && !error && <Footer>{quote.infoNote}</Footer>}
+            {infoNote && !error && <Footer>{infoNote}</Footer>}
         </Wrapper>
     );
 };

--- a/packages/suite/src/views/wallet/coinmarket/exchange/offers/Offers/List/Quote/index.tsx
+++ b/packages/suite/src/views/wallet/coinmarket/exchange/offers/Offers/List/Quote/index.tsx
@@ -3,10 +3,10 @@ import styled from 'styled-components';
 import { Button, variables, Icon, useTheme, H2 } from '@trezor/components';
 import { FormattedFiatAmount, QuestionTooltip, Translation } from '@suite-components';
 import { ExchangeTrade } from 'invity-api';
-import { formatCryptoAmount } from '@wallet-utils/coinmarket/coinmarketUtils';
+import { formatCryptoAmount, getTagAndInfoNote } from '@wallet-utils/coinmarket/coinmarketUtils';
 import { isQuoteError } from '@wallet-utils/coinmarket/exchangeUtils';
 import { useCoinmarketExchangeOffersContext } from '@wallet-hooks/useCoinmarketExchangeOffers';
-import { CoinmarketProviderInfo } from '@wallet-components';
+import { CoinmarketProviderInfo, CoinmarketTag } from '@wallet-components';
 import { useSelector, useTranslation } from '@suite-hooks';
 import { toFiatCurrency } from '@suite-common/wallet-utils';
 import BigNumber from 'bignumber.js';
@@ -21,24 +21,11 @@ const Wrapper = styled.div`
     background: ${props => props.theme.BG_WHITE};
 `;
 
-const TagRow = styled.div`
-    display: flex;
-    min-height: 30px;
-`;
-
-const Tag = styled.div`
-    margin-top: 10px;
-    height: 35px;
-    margin-left: -20px;
-    border: 1px solid tan;
-    text-transform: uppercase;
-`;
-
 const Main = styled.div`
     display: flex;
     margin: 0 30px;
     justify-content: space-between;
-    padding-bottom: 20px;
+    padding: 20px 0;
     border-bottom: 1px solid ${props => props.theme.STROKE_GREY};
 
     @media (max-width: ${variables.SCREEN_SIZE.SM}) {
@@ -49,6 +36,7 @@ const Main = styled.div`
 
 const Left = styled(H2)`
     display: flex;
+    align-items: center;
     font-weight: ${variables.FONT_WEIGHT.REGULAR};
 `;
 
@@ -109,6 +97,20 @@ const Value = styled.div`
     align-items: center;
     color: ${props => props.theme.TYPE_DARK_GREY};
     font-weight: ${variables.FONT_WEIGHT.MEDIUM};
+`;
+
+const Footer = styled.div`
+    margin: 0 30px;
+    padding: 10px 0;
+    padding-top: 23px;
+    color: ${props => props.theme.TYPE_LIGHT_GREY};
+    border-top: 1px solid ${props => props.theme.STROKE_GREY};
+    font-weight: ${variables.FONT_WEIGHT.MEDIUM};
+    font-size: ${variables.FONT_SIZE.SMALL};
+
+    @media (max-width: ${variables.SCREEN_SIZE.SM}) {
+        margin: 0 20px;
+    }
 `;
 
 const ErrorFooter = styled.div`
@@ -192,7 +194,7 @@ const Quote = ({ className, quote }: Props) => {
         localCurrency: state.wallet.settings.localCurrency,
     }));
 
-    const hasTag = false;
+    const { tag, infoNote } = getTagAndInfoNote(quote);
     const { exchange, receive, receiveStringAmount } = quote;
     let errorQuote = isQuoteError(quote);
 
@@ -230,11 +232,13 @@ const Quote = ({ className, quote }: Props) => {
 
     return (
         <Wrapper className={className}>
-            <TagRow>{hasTag && <Tag>best offer</Tag>}</TagRow>
             <Main>
                 {errorQuote && !noFundsForFeesError && <Left>N/A</Left>}
                 {(!errorQuote || noFundsForFeesError) && (
-                    <Left>{`${formatCryptoAmount(Number(receiveStringAmount))} ${receive}`}</Left>
+                    <Left>
+                        {`${formatCryptoAmount(Number(receiveStringAmount))} ${receive}`}
+                        <CoinmarketTag tag={tag} />
+                    </Left>
                 )}
                 <Right>
                     <StyledButton
@@ -304,6 +308,8 @@ const Quote = ({ className, quote }: Props) => {
                     <ErrorText>{noFundsForFeesError || getQuoteError(quote)}</ErrorText>
                 </ErrorFooter>
             )}
+
+            {infoNote && !errorQuote && <Footer>{infoNote}</Footer>}
         </Wrapper>
     );
 };

--- a/packages/suite/src/views/wallet/coinmarket/sell/offers/Offers/List/Quote/index.tsx
+++ b/packages/suite/src/views/wallet/coinmarket/sell/offers/Offers/List/Quote/index.tsx
@@ -1,11 +1,11 @@
 import React from 'react';
 import styled from 'styled-components';
 import { useTheme, Button, variables, Icon, H2 } from '@trezor/components';
-import { CoinmarketPaymentType, CoinmarketProviderInfo } from '@wallet-components';
+import { CoinmarketPaymentType, CoinmarketProviderInfo, CoinmarketTag } from '@wallet-components';
 import { QuestionTooltip, Translation } from '@suite-components';
 import { SellFiatTrade } from 'invity-api';
 import { useCoinmarketSellOffersContext } from '@wallet-hooks/useCoinmarketSellOffers';
-import { formatCryptoAmount } from '@wallet-utils/coinmarket/coinmarketUtils';
+import { formatCryptoAmount, getTagAndInfoNote } from '@wallet-utils/coinmarket/coinmarketUtils';
 
 interface Props {
     className?: string;
@@ -24,24 +24,11 @@ const Wrapper = styled.div`
     background: ${props => props.theme.BG_WHITE};
 `;
 
-const TagRow = styled.div`
-    display: flex;
-    min-height: 30px;
-`;
-
-const Tag = styled.div`
-    margin-top: 10px;
-    height: 35px;
-    margin-left: -20px;
-    border: 1px solid tan;
-    text-transform: uppercase;
-`;
-
 const Main = styled.div`
     display: flex;
     margin: 0 30px;
     justify-content: space-between;
-    padding-bottom: 20px;
+    padding: 20px 0;
     border-bottom: 1px solid ${props => props.theme.STROKE_GREY};
 
     @media (max-width: ${variables.SCREEN_SIZE.SM}) {
@@ -52,6 +39,7 @@ const Main = styled.div`
 
 const Left = styled(H2)`
     display: flex;
+    align-items: center;
     font-weight: ${variables.FONT_WEIGHT.REGULAR};
 `;
 
@@ -217,9 +205,7 @@ const Quote = ({ className, quote, amountInCrypto }: Props) => {
     const theme = useTheme();
     const { selectQuote, sellInfo, needToRegisterOrVerifyBankAccount } =
         useCoinmarketSellOffersContext();
-    // TODO - tags are not yet fully supported by the API server
-    // in the future will be taken from quote.tags, will need some algorithm to evaluate them and show only one
-    const hasTag = false;
+    const { tag, infoNote } = getTagAndInfoNote(quote);
     const { paymentMethod, exchange, error, bankAccounts } = quote;
     if (!exchange || !sellInfo) return null;
 
@@ -231,7 +217,6 @@ const Quote = ({ className, quote, amountInCrypto }: Props) => {
 
     return (
         <Wrapper className={className}>
-            <TagRow>{hasTag && <Tag>best offer</Tag>}</TagRow>
             <Main>
                 {error && <Left>N/A</Left>}
                 {!error && (
@@ -241,6 +226,7 @@ const Quote = ({ className, quote, amountInCrypto }: Props) => {
                             : `${formatCryptoAmount(Number(quote.cryptoStringAmount))} ${
                                   quote.cryptoCurrency
                               }`}
+                        <CoinmarketTag tag={tag} />
                     </Left>
                 )}
                 <Right>
@@ -300,7 +286,7 @@ const Quote = ({ className, quote, amountInCrypto }: Props) => {
                 </ErrorFooter>
             )}
 
-            {quote.infoNote && !error && <Footer>{quote.infoNote}</Footer>}
+            {infoNote && !error && <Footer>{infoNote}</Footer>}
         </Wrapper>
     );
 };

--- a/patches/@types+invity-api+1.0.6.patch
+++ b/patches/@types+invity-api+1.0.6.patch
@@ -1,0 +1,12 @@
+diff --git a/node_modules/@types/invity-api/index.d.ts b/node_modules/@types/invity-api/index.d.ts
+index 0ca6a40..f8d2711 100755
+--- a/node_modules/@types/invity-api/index.d.ts
++++ b/node_modules/@types/invity-api/index.d.ts
+@@ -239,6 +239,7 @@ export interface ExchangeTrade {
+     extraFieldDescription?: CoinExtraField | undefined;
+     tags?: ExchangeTradeTag[] | undefined;
+     id?: string | undefined; // internal DB id
++    infoNote?: string | undefined;
+ 
+     // DEX extra fields
+     isDex?: boolean | undefined;


### PR DESCRIPTION
Display coinmarket info notes as tags.

## Description

Coinmarket info notes starting with # are converted to tags, see screenshots below.

## Screenshots:

<img width="936" alt="image" src="https://user-images.githubusercontent.com/37251117/186183212-97ff181d-0567-4d92-a32d-f44e46421a59.png">
<img width="936" alt="image" src="https://user-images.githubusercontent.com/37251117/186183615-a320d679-c0ed-4c15-bd67-4890ca536bbb.png">
