### PR TITLE
ci: micro improvement of connect release script

### DIFF
--- a/.github/workflows/connect-release-init.yml
+++ b/.github/workflows/connect-release-init.yml
@@ -1,3 +1,9 @@
+# TODOs:
+# - add release_to_npm section (now in gitlab). should be triggered after release_trezor-io is done
+# - read new version from yarn workspace @trezor/connect version:<semver> and use it in commit messages etc
+# - consider generation of changelog etc
+# - in release/connect-v9 branch PR, post info about changed files only for connect?
+
 name: release - connect v9 - init
 
 on:
@@ -12,7 +18,7 @@ on:
           - minor
 
 jobs:
-  release_npm:
+  bump_version:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
@@ -21,17 +27,22 @@ jobs:
         uses: actions/setup-node@v3
         with:
           node-version-file: ".nvmrc"
-
-      - name: Run @trezor/connect release npm
+      - name: Run @trezor/connect create release branch
         run: |
+          if [${{ github.event.inputs.semver }} == 'beta']
+          then
+              git  checkout -B beta-release/connect
+          else
+              git checkout -B npm-release/connect
+          fi
           npm install -g yarn && yarn install
           git config --global user.name "trezor-ci"
           git config --global user.email "${{ secrets.TREZOR_BOT_EMAIL }}"
           git checkout -B npm-release/connect
           yarn workspace @trezor/connect version:${{ github.event.inputs.semver }}
-          git add . && git commit -m "release: @trezor/connect" && git push origin npm-release/connect -f
+          git add . && git commit -m "release: @trezor/connect (${{ github.event.inputs.semver }})" && git push origin npm-release/connect -f
           gh config set prompt disabled
-          gh pr create --repo trezor/trezor-suite --title "npm-release @trezor/connect [1/2]" --body-file "docs/releases/connect-npm.md" --base develop
+          gh pr create --repo trezor/trezor-suite --title "npm-release @trezor/connect ${{ github.event.inputs.semver }} [1/2]" --body-file "docs/releases/connect-npm.md" --base develop
         env:
           GITHUB_TOKEN: ${{ secrets.TREZOR_BOT_TOKEN }}
 
@@ -50,6 +61,6 @@ jobs:
           git config --global user.name "trezor-ci"
           git config --global user.email "${{ secrets.TREZOR_BOT_EMAIL }}"
           gh config set prompt disabled
-          gh pr create --repo trezor/trezor-suite --title "release connect.trezor.io/9 [2/2]" --body-file "docs/releases/connect-trezor.io.md" --base release/connect-v9
+          gh pr create --repo trezor/trezor-suite --title "release connect.trezor.io/9 ${{ github.event.inputs.semver }} [2/2]" --body-file "docs/releases/connect-trezor.io.md" --base release/connect-v9
         env:
           GITHUB_TOKEN: ${{ secrets.TREZOR_BOT_TOKEN }}

--- a/ci/npm-deploy.yml
+++ b/ci/npm-deploy.yml
@@ -64,26 +64,20 @@ deploy npm:
     - nix-shell --run "node ./ci/scripts/check-version $PACKAGE $CI_COMMIT_BRANCH latest"
     - nix-shell --run "yarn && cd ./packages/${PACKAGE} && npm publish"
 
-# temporary beta release for connect. connect is still in beta but use it for testing of release process
-# so I need to disable some checks
 beta deploy npm connect:
   extends: .deploy npm base
   only:
     refs:
-      - /^npm-release\//
+      - /^beta-release\//
   <<: *packages_matrix_connect
   script:
-    # this is the difference, disabled check
-    # - nix-shell --run "node ./ci/scripts/check-version $PACKAGE $CI_COMMIT_BRANCH beta"
     - nix-shell --run "yarn && cd ./packages/$PACKAGE && npm publish --tag beta"
 
 deploy npm connect:
   extends: .deploy npm base
   only:
     refs:
-      - release/connect-v9
+      - /^npm-release\//
   <<: *packages_matrix_connect
   script:
-    # todo: consider this. might not be needed, it is run in github.
-    # - nix-shell --run "node ./ci/scripts/check-version $PACKAGE $CI_COMMIT_BRANCH latest"
     - nix-shell --run "cd ./packages/${PACKAGE} && npm publish"


### PR DESCRIPTION
yet another improvement for connect release script

I would like to create npm release branch conditionally base on user input from workflow dispatch. I need this because I then want in gitlab create  npm release job only for beta or only for production based on branch name. 
