### PR TITLE
fix: connect-web dev script

### DIFF
--- a/packages/connect-popup/webpack/prod.webpack.config.ts
+++ b/packages/connect-popup/webpack/prod.webpack.config.ts
@@ -48,6 +48,15 @@ export default {
                 test: /\.(gif|jpe?g|png|svg)$/,
                 type: 'asset/resource',
             },
+            // resolving framer-motion in @trezor/components
+            // https://github.com/react-dnd/react-dnd/issues/3425
+            // todo: not sure, if it should be done like this and if yes, maybe I should add this to the previous rule?
+            {
+                test: /\.m?js$/,
+                resolve: {
+                    fullySpecified: false,
+                },
+            },
         ],
     },
     resolve: {


### PR DESCRIPTION
## Description

before this commit https://github.com/trezor/trezor-suite/commit/39c0ed80edea5e9996828b8e7dc18fbe5f831704
and after this one https://github.com/trezor/trezor-suite/commit/638050e3f9c77fe7191a5eada90dc221b528b823 

`yarn workspace @trezor/connect-web dev` command stopped working with this error: 

![image](https://user-images.githubusercontent.com/30367552/186440561-2eafa6c3-ad85-4fcb-9544-9387c318e28e.png)

btw you can see Toolitp component from `@trezor/components` which was refactored here 638050e3f9c77fe7191a5eada90dc221b528b823 

This PR fixes that but I feel uneasy because I dont know why `@trezor/suite-web dev` is not affected although configuration of `@trezor/suite-web dev`  and `@trezor/connect-web dev` seem to be pretty similar.

