### PR TITLE
Improve transaction export - PDF, CSV, JSON

### DIFF
--- a/packages/suite-analytics/CHANGELOG.md
+++ b/packages/suite-analytics/CHANGELOG.md
@@ -7,7 +7,10 @@ This changelog lists changes in suite events.
 Added:
 
 -   app-update
-    -   status: available | download | install-and-restart | downloaded | closed | error
+    -   status: available | download | install-and-restart | install-on-quit | downloaded | closed | error
+-   accounts/transactions-export
+    -   symbol: string
+    -   format: 'pdf' | 'csv' | 'json'
 
 ### 1.22
 

--- a/packages/suite-analytics/src/constants.ts
+++ b/packages/suite-analytics/src/constants.ts
@@ -34,6 +34,7 @@ export enum EventType {
     AddToken = 'add-token',
     AccountsEmptyAccountBuy = 'accounts/empty-account/buy',
     AccountsEmptyAccountReceive = 'accounts/empty-account/receive',
+    AccountsTransactionsExport = 'accounts/transactions-export',
     TransactionCreated = 'transaction-created',
     SendRawTransaction = 'send-raw-transaction',
 

--- a/packages/suite-analytics/src/types/events.ts
+++ b/packages/suite-analytics/src/types/events.ts
@@ -124,6 +124,13 @@ export type SuiteAnalyticsEvent =
           };
       }
     | {
+          type: EventType.AccountsTransactionsExport;
+          payload: {
+              symbol: string;
+              format: 'pdf' | 'csv' | 'json';
+          };
+      }
+    | {
           type: EventType.TransactionCreated;
           payload: {
               action: 'sent' | 'copied' | 'downloaded' | 'replaced';

--- a/packages/suite/src/views/wallet/transactions/components/TransactionList/components/Actions/components/ExportAction/index.tsx
+++ b/packages/suite/src/views/wallet/transactions/components/TransactionList/components/Actions/components/ExportAction/index.tsx
@@ -1,5 +1,6 @@
 import React, { useState, useCallback } from 'react';
 import { Loader, Dropdown } from '@trezor/components';
+import { analytics, EventType } from '@trezor/suite-analytics';
 import { Translation } from '@suite-components';
 import { useActions } from '@suite-hooks';
 import { SETTINGS } from '@suite-config';
@@ -10,11 +11,11 @@ import { Account } from '@wallet-types';
 import { isFeatureFlagEnabled } from '@suite-common/suite-utils';
 import { getTitleForNetwork } from '@suite-common/wallet-utils';
 
-export interface Props {
+export interface ExportActionProps {
     account: Account;
 }
 
-const ExportAction = ({ account }: Props) => {
+const ExportAction = ({ account }: ExportActionProps) => {
     const { translationString } = useTranslation();
     const { addToast, fetchTransactions, exportTransactions } = useActions({
         addToast: notificationActions.addToast,
@@ -28,6 +29,14 @@ const ExportAction = ({ account }: Props) => {
             if (isExportRunning) {
                 return;
             }
+
+            analytics.report({
+                type: EventType.AccountsTransactionsExport,
+                payload: {
+                    format: type,
+                    symbol: account.symbol,
+                },
+            });
 
             setIsExportRunning(true);
             try {

--- a/packages/suite/src/views/wallet/transactions/components/TransactionList/components/Actions/index.tsx
+++ b/packages/suite/src/views/wallet/transactions/components/TransactionList/components/Actions/index.tsx
@@ -1,14 +1,14 @@
 import React from 'react';
 import styled from 'styled-components';
 import SearchAction, { Props as SearchProps } from './components/SearchAction';
-import ExportAction, { Props as ExportProps } from './components/ExportAction';
+import ExportAction, { ExportActionProps } from './components/ExportAction';
 
 const Wrapper = styled.div`
     display: flex;
     align-items: center;
 `;
 
-interface Props extends SearchProps, ExportProps {}
+interface Props extends SearchProps, ExportActionProps {}
 
 const Actions = ({ account, search, setSearch, setSelectedPage }: Props) => (
     <Wrapper>

--- a/suite-common/wallet-core/src/transactions/transactionsThunks.ts
+++ b/suite-common/wallet-core/src/transactions/transactionsThunks.ts
@@ -125,9 +125,6 @@ export const addFakePendingTxThunk = createThunk(
     },
 );
 
-// Note: This was not moved to suite-common due browser API that wouldn't work on mobile right now
-// (rest of the actions will be found in suite-common/wallet-core/transactions)
-
 export const exportTransactionsThunk = createThunk(
     `${modulePrefix}/exportTransactions`,
     async (
@@ -142,9 +139,10 @@ export const exportTransactionsThunk = createThunk(
         },
         { getState, extra },
     ) => {
-        const { utils } = extra;
+        const { utils, selectors } = extra;
         // Get state of transactions
         const allTransactions = selectTransactions(getState());
+        const localCurrency = selectors.selectLocalCurrency(getState());
         const transactions = getAccountTransactions(
             account.key,
             allTransactions,
@@ -163,6 +161,7 @@ export const exportTransactionsThunk = createThunk(
             accountName,
             type,
             transactions,
+            localCurrency,
         });
 
         // Save file

--- a/suite-common/wallet-core/src/transactions/transactionsThunks.ts
+++ b/suite-common/wallet-core/src/transactions/transactionsThunks.ts
@@ -8,6 +8,7 @@ import {
     findTransactions,
     formatData,
     getAccountTransactions,
+    getExportedFileName,
     isTrezorConnectBackendType,
 } from '@suite-common/wallet-utils';
 import TrezorConnect from '@trezor/connect';
@@ -165,7 +166,9 @@ export const exportTransactionsThunk = createThunk(
         });
 
         // Save file
-        utils.saveAs(data, `export-${account.symbol}-${+new Date()}.${type}`);
+        const fileName = getExportedFileName(accountName, type);
+
+        utils.saveAs(data, fileName);
     },
 );
 

--- a/suite-common/wallet-utils/package.json
+++ b/suite-common/wallet-utils/package.json
@@ -27,6 +27,7 @@
         "@trezor/urls": "*",
         "@trezor/utils": "*",
         "bignumber.js": "^9.1.0",
+        "date-fns": "^2.29.1",
         "ethereumjs-util": "^7.1.5",
         "pdfmake": "^0.2.5",
         "react-hook-form": "6.15.7",

--- a/suite-common/wallet-utils/src/__tests__/localizeNumber.ts
+++ b/suite-common/wallet-utils/src/__tests__/localizeNumber.ts
@@ -19,4 +19,17 @@ describe('localizeNumber', () => {
         // @ts-expect-error invalid arg
         expect(localizeNumber('asadff')).toStrictEqual('');
     });
+
+    it('formats decimals', () => {
+        expect(localizeNumber(123456789, 'en', 0, 2)).toStrictEqual('123,456,789');
+        expect(localizeNumber(123456789.101, 'en', 0, 2)).toStrictEqual('123,456,789.1');
+        expect(localizeNumber(123456789.123, 'en', 0, 2)).toStrictEqual('123,456,789.12');
+
+        expect(localizeNumber(123456789, 'en', 1, 2)).toStrictEqual('123,456,789.0');
+        expect(localizeNumber(123456789.111, 'en', 1, 2)).toStrictEqual('123,456,789.11');
+
+        expect(localizeNumber(123456789.111, 'en', 2, 2)).toStrictEqual('123,456,789.11');
+
+        expect(localizeNumber(123456789, 'en', 3, 2)).toThrowError();
+    });
 });

--- a/suite-common/wallet-utils/src/exportTransactions.ts
+++ b/suite-common/wallet-utils/src/exportTransactions.ts
@@ -1,5 +1,6 @@
 import type { TDocumentDefinitions } from 'pdfmake/interfaces';
 import { fromWei } from 'web3-utils';
+import { format } from 'date-fns';
 
 import { trezorLogo } from '@suite-common/suite-constants';
 import { AccountTransaction, TransactionTarget } from '@trezor/connect';
@@ -11,10 +12,12 @@ type AccountTransactionForExports = Omit<AccountTransaction, 'targets'> & {
     targets: (TransactionTarget & { metadataLabel?: string })[];
 };
 
+type FileType = 'csv' | 'pdf' | 'json';
+
 type Data = {
     coin: Network['symbol'];
     accountName: string;
-    type: 'csv' | 'pdf' | 'json';
+    type: FileType;
     transactions: AccountTransactionForExports[];
 };
 
@@ -260,4 +263,18 @@ export const formatData = async (data: Data) => {
         }
         // no default
     }
+};
+
+export const getExportedFileName = (accountName: string, type: FileType) => {
+    const accountNameSanitized = accountName
+        .slice(0, 240) // limit the file name length
+        .replace(/[^a-z0-9]/gi, '_') // replace any special character by _ symbol
+        .concat('_') // add one _ at the end as separator from date
+        .replace(/_{2,}/g, '_'); // prevent multiple __ in a row
+
+    const currentDateTime = new Date();
+    const date = format(currentDateTime, 'yyyyMMdd');
+    const time = format(currentDateTime, 'HHmmss');
+
+    return `${accountNameSanitized}${date}T${time}.${type}`;
 };

--- a/suite-common/wallet-utils/src/exportTransactions.ts
+++ b/suite-common/wallet-utils/src/exportTransactions.ts
@@ -349,10 +349,14 @@ export const formatData = async (data: Data) => {
             return pdf;
         }
         case 'json': {
-            const json = JSON.stringify({
-                coin,
-                transactions: transactions.map(formatAmounts(coin)),
-            });
+            const json = JSON.stringify(
+                {
+                    coin,
+                    transactions: transactions.map(formatAmounts(coin)),
+                },
+                null,
+                2,
+            );
             return new Blob([json], { type: 'text/json;charset=utf-8' });
         }
         // no default

--- a/suite-common/wallet-utils/src/localizeNumber.ts
+++ b/suite-common/wallet-utils/src/localizeNumber.ts
@@ -1,4 +1,9 @@
-export const localizeNumber = (amount: number, locale = 'en', decimals = 0): string => {
+export const localizeNumber = (
+    amount: number,
+    locale = 'en',
+    minDecimals = 0,
+    maxDecimals = 20,
+): string => {
     if (
         typeof amount !== 'number' ||
         Number.isNaN(amount) ||
@@ -9,9 +14,15 @@ export const localizeNumber = (amount: number, locale = 'en', decimals = 0): str
         return '';
     }
 
+    if (maxDecimals < minDecimals) {
+        throw Error(
+            `maxDecimals (${maxDecimals}) cannot be lower than minDecimals (${minDecimals})`,
+        );
+    }
+
     return Intl.NumberFormat(locale, {
         style: 'decimal',
-        maximumFractionDigits: 20,
-        minimumFractionDigits: decimals,
+        maximumFractionDigits: maxDecimals,
+        minimumFractionDigits: minDecimals,
     }).format(amount);
 };

--- a/yarn.lock
+++ b/yarn.lock
@@ -6173,6 +6173,7 @@ __metadata:
     "@trezor/utils": "*"
     "@types/pdfmake": ^0.1.21
     bignumber.js: ^9.1.0
+    date-fns: ^2.29.1
     ethereumjs-util: ^7.1.5
     jest: ^26.6.3
     pdfmake: ^0.2.5


### PR DESCRIPTION
## Description

Improves transaction export

- PDF file has to be compact to fit into A4 landscape paper
- CSV file can contain more data as it is not intended to be human readable
- JSON was previously an export of Suite internal data, I changed it to be in the same format as CSV file is

Note:
- `Address` column is kinda weird, as in the case of `SENT` tx, it contains `to` address, in the case of `RECV` tx it also contains `to` but that's my address. (It is also in transaction history, not sure if bug)

## Related Issue

closes #5904

## Screenshots (if appropriate):
![Screenshot 2022-08-24 at 17 37 26](https://user-images.githubusercontent.com/33235762/186461258-2978fbfc-895b-431d-90d1-0b358e8c1d78.png)

## Exported files from ALL seed
[Archive.zip](https://github.com/trezor/trezor-suite/files/9417494/Archive.zip)

