### PR TITLE
ci: connect release yarn after bump (yarn3)

### DIFF
--- a/.github/workflows/connect-release-init.yml
+++ b/.github/workflows/connect-release-init.yml
@@ -40,6 +40,7 @@ jobs:
           git config --global user.email "${{ secrets.TREZOR_BOT_EMAIL }}"
           git checkout -B npm-release/connect
           yarn workspace @trezor/connect version:${{ github.event.inputs.semver }}
+          yarn
           git add . && git commit -m "release: @trezor/connect (${{ github.event.inputs.semver }})" && git push origin npm-release/connect -f
           gh config set prompt disabled
           gh pr create --repo trezor/trezor-suite --title "npm-release @trezor/connect ${{ github.event.inputs.semver }} [1/2]" --body-file "docs/releases/connect-npm.md" --base develop

--- a/suite-common/wallet-core/package.json
+++ b/suite-common/wallet-core/package.json
@@ -20,7 +20,7 @@
         "@suite-common/wallet-config": "*",
         "@suite-common/wallet-types": "*",
         "@suite-common/wallet-utils": "*",
-        "@trezor/connect": "9.0.0-beta.6"
+        "@trezor/connect": "9.0.0-beta.7"
     },
     "devDependencies": {
         "jest": "^26.6.3",

--- a/suite-common/wallet-core/tsconfig.json
+++ b/suite-common/wallet-core/tsconfig.json
@@ -9,6 +9,7 @@
         { "path": "../test-utils" },
         { "path": "../wallet-config" },
         { "path": "../wallet-types" },
-        { "path": "../wallet-utils" }
+        { "path": "../wallet-utils" },
+        { "path": "../../packages/connect" }
     ]
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -6062,7 +6062,7 @@ __metadata:
     "@suite-common/wallet-config": "*"
     "@suite-common/wallet-types": "*"
     "@suite-common/wallet-utils": "*"
-    "@trezor/connect": 9.0.0-beta.6
+    "@trezor/connect": 9.0.0-beta.7
     jest: ^26.6.3
     typescript: 4.7.4
   languageName: unknown
@@ -6493,13 +6493,6 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@trezor/connect-common@npm:0.0.8":
-  version: 0.0.8
-  resolution: "@trezor/connect-common@npm:0.0.8"
-  checksum: c66bd361eafff8574da61b5e609df2d209bc84f19c4463ffbaac2a027a331095ca9a2791439f23015354f9c1fe8875ae0181fddb763e6d5f2597a790a1181905
-  languageName: node
-  linkType: hard
-
 "@trezor/connect-explorer@workspace:packages/connect-explorer":
   version: 0.0.0-use.local
   resolution: "@trezor/connect-explorer@workspace:packages/connect-explorer"
@@ -6663,27 +6656,6 @@ __metadata:
     typescript: 4.7.4
   languageName: unknown
   linkType: soft
-
-"@trezor/connect@npm:9.0.0-beta.6":
-  version: 9.0.0-beta.6
-  resolution: "@trezor/connect@npm:9.0.0-beta.6"
-  dependencies:
-    "@trezor/blockchain-link": ^2.1.3
-    "@trezor/connect-common": 0.0.8
-    "@trezor/transport": ^1.1.4
-    "@trezor/utils": ^9.0.2
-    "@trezor/utxo-lib": ^1.0.0
-    bignumber.js: ^9.0.2
-    blakejs: ^1.2.1
-    bowser: ^2.11.0
-    cross-fetch: ^3.1.5
-    events: ^3.3.0
-    parse-uri: 1.0.7
-    randombytes: 2.1.0
-    tslib: ^2.3.1
-  checksum: ca2a88f1bf24d536cf3ed3916243b1c8ab63c569d9a2ed6ed51fabfc9d9bb426362201e7ad58ff52b98df82bb4753ac45ef6e6359f7609e16de6dc9e5ba73142
-  languageName: node
-  linkType: hard
 
 "@trezor/dom-utils@*, @trezor/dom-utils@workspace:packages/dom-utils":
   version: 0.0.0-use.local
@@ -10787,7 +10759,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"bignumber.js@npm:^9.0.0, bignumber.js@npm:^9.0.2, bignumber.js@npm:^9.1.0":
+"bignumber.js@npm:^9.0.0, bignumber.js@npm:^9.1.0":
   version: 9.1.0
   resolution: "bignumber.js@npm:9.1.0"
   checksum: 52ec2bb5a3874d7dc1a1018f28f8f7aff4683515ffd09d6c2d93191343c76567ae0ee32cc45149d53afb2b904bc62ed471a307b35764beea7e9db78e56bef6c6


### PR DESCRIPTION
release script was modifying yarn.lock https://github.com/trezor/trezor-suite/runs/8010445524?check_suite_focus=true this should fix it. 

also pinning connect to the same version  in suite-common/wallet-core/package.json as in other packages. 