### PR TITLE
fix(transport): default version url

### DIFF
--- a/packages/integration-tests/projects/transport/tests/bridge.integration.js
+++ b/packages/integration-tests/projects/transport/tests/bridge.integration.js
@@ -49,6 +49,10 @@ describe('bridge', () => {
                 BridgeV2.setFetch(fetch, true);
 
                 bridge = new BridgeV2(null, null);
+
+                // this is how @trezor/connect is using it at the moment
+                // bridge.setBridgeLatestVersion(bridgeVersion);
+
                 await bridge.init(false);
                 bridge.configure(messages);
 

--- a/packages/transport/src/config.ts
+++ b/packages/transport/src/config.ts
@@ -1,5 +1,6 @@
 export const DEFAULT_URL = 'http://127.0.0.1:21325';
-export const DEFAULT_VERSION_URL = 'https://connect.trezor.io/8/data/bridge/latest.txt';
+// todo: DEFAULT_VERSION_URL is not really used anywhere in production at the moment
+export const DEFAULT_VERSION_URL = 'https://data.trezor.io/bridge/latest.txt';
 export const MESSAGE_HEADER_BYTE = 0x23;
 export const HEADER_SIZE = 1 + 1 + 4 + 2;
 export const BUFFER_SIZE = 63;


### PR DESCRIPTION
This fix is actually only needed to make [tests pass](https://gitlab.com/satoshilabs/trezor/trezor-suite/-/jobs/2933976092). @trezor/connect is using transport lib in a different way (see added comment).  