### PR TITLE
chore(ci): Add Nx implicit deps

### DIFF
--- a/nx.json
+++ b/nx.json
@@ -37,6 +37,17 @@
             "inputs": ["{projectRoot}/**/*.tsx"]
         }
     },
+    "implicitDependencies": {
+        "tsconfig.json": "*",
+        "tsconfig.aliases.json": "*",
+        "tsconfig.lib.json": "*",
+        "jest.config.base.js": "*",
+        "jest.config.native.js": "*",
+        ".eslintrc.js": "*",
+        "package.json": "*",
+        "nx.json": "*",
+        "!yarn.lock": "*"
+    },
     "affected": {
         "defaultBase": "origin/develop"
     }


### PR DESCRIPTION
Added some files to implicit dependencies so if these files will be changes it will consider all packages as affected. I also removed yarn.lock from it because it's modified in nearly every PR even when local package is added as dependency to another local package.
