### PR TITLE
Fix/redact user path in app log

### DIFF
--- a/packages/suite/src/components/suite/VersionWithGithubTooltip.tsx
+++ b/packages/suite/src/components/suite/VersionWithGithubTooltip.tsx
@@ -7,7 +7,8 @@ import { Translation } from '@suite-components';
 
 const VersionTooltip = styled(Tooltip)`
     display: inline-flex;
-    margin-left: 10px;
+    margin-left: 5px;
+    margin-right: 5px;
 `;
 
 const VersionButton = styled(Button)<{ isDev?: boolean }>`
@@ -39,6 +40,7 @@ export const VersionWithGithubTooltip: React.FC<VersionWithGithubTooltipProps> =
     isDev,
 }) => (
     <VersionTooltip
+        cursor="pointer"
         content={
             <GithubWrapper>
                 <Link variant="nostyle" href={getReleaseUrl(appVersion)}>

--- a/packages/suite/src/config/suite/sentry.ts
+++ b/packages/suite/src/config/suite/sentry.ts
@@ -1,17 +1,10 @@
 import { CaptureConsole, Dedupe } from '@sentry/integrations';
 import { isDev } from '@suite-utils/build';
+import { redactUserPathFromString } from '@trezor/utils';
 
 import type { Options, Event } from '@sentry/types';
 
 export const allowReportTag = 'allowReport';
-
-/**
- * From paths like /Users/username/, C:\Users\username\, C:\\Users\\username\\,
- * this matches /Users/, \Users\ or \Users\\ as first group
- * and text (supposed to be a username) before the next slash (or special character not allowed in username)
- * as second group.
- */
-const startOfUserPathRegex = /([/\\][Uu]sers[/\\]{1,4})([^"^'^[^\]^/^\\]*)/g;
 
 /**
  * Full user path could be part of reported error in some cases and we want to actively filter username out.
@@ -25,7 +18,7 @@ const startOfUserPathRegex = /([/\\][Uu]sers[/\\]{1,4})([^"^'^[^\]^/^\\]*)/g;
 const redactUserPath = (event: Event) => {
     try {
         const eventAsString = JSON.stringify(event);
-        const redactedString = eventAsString.replace(startOfUserPathRegex, '$1[redacted]');
+        const redactedString = redactUserPathFromString(eventAsString);
         return JSON.parse(redactedString);
     } catch (error) {
         console.warn('Redacting user path failed', error);

--- a/packages/suite/src/middlewares/suite/logsMiddleware.ts
+++ b/packages/suite/src/middlewares/suite/logsMiddleware.ts
@@ -18,6 +18,7 @@ import { WALLET_SETTINGS } from '@settings-actions/constants';
 import { redactTransactionIdFromAnchor } from '@suite-utils/analytics';
 import { accountsActions } from '@suite-common/wallet-core';
 import { isAnyOf } from '@reduxjs/toolkit';
+import { redactUserPathFromString } from '@trezor/utils';
 
 const log =
     (api: MiddlewareAPI<Dispatch, AppState>) =>
@@ -64,12 +65,22 @@ const log =
             case DESKTOP_UPDATE.CHECKING:
             case DESKTOP_UPDATE.AVAILABLE:
             case DESKTOP_UPDATE.NOT_AVAILABLE:
-            case DESKTOP_UPDATE.READY:
             case MODAL.CLOSE:
                 api.dispatch(
                     logActions.addAction(action, {
                         ...action,
                         type: undefined,
+                    }),
+                );
+                break;
+            case DESKTOP_UPDATE.READY:
+                api.dispatch(
+                    logActions.addAction(action, {
+                        version: action.payload.version,
+                        releaseDate: action.payload.releaseDate,
+                        downloadedFile: redactUserPathFromString(
+                            action.payload.downloadedFile || '',
+                        ),
                     }),
                 );
                 break;

--- a/packages/utils/src/index.ts
+++ b/packages/utils/src/index.ts
@@ -21,3 +21,4 @@ export * from './throwError';
 export * from './isHex';
 export * from './resolveStaticPath';
 export * from './createTimeoutPromise';
+export * from './redactUserPath';

--- a/packages/utils/src/redactUserPath.ts
+++ b/packages/utils/src/redactUserPath.ts
@@ -1,0 +1,10 @@
+/**
+ * From paths like /Users/username/, C:\Users\username\, C:\\Users\\username\\,
+ * this matches /Users/, \Users\ or \Users\\ as first group
+ * and text (supposed to be a username) before the next slash (or special character not allowed in username)
+ * as second group.
+ */
+export const startOfUserPathRegex = /([/\\][Uu]sers[/\\]{1,4})([^"^'^[^\]^/^\\]*)/g;
+
+export const redactUserPathFromString = (text: string) =>
+    text.replace(startOfUserPathRegex, '$1[*]');


### PR DESCRIPTION
## Description

- fixes padding and cursor on version button in settings when app is downloaded but not installed
- removes username from application log

## Related Issue

no issue

## Screenshots (if appropriate):
Before:
<img width="796" alt="Screenshot 2022-08-26 at 11 12 27" src="https://user-images.githubusercontent.com/33235762/186870510-36e20f59-a627-46e3-9a54-b21d4cd249ea.png">
help cursor on 1px border
<img width="776" alt="Screenshot 2022-08-26 at 11 13 30" src="https://user-images.githubusercontent.com/33235762/186870713-2f5db34b-3c33-48fc-adba-de89536f705d.png">

Now:
<img width="791" alt="Screenshot 2022-08-26 at 11 14 03" src="https://user-images.githubusercontent.com/33235762/186870822-a2e6d9bd-31fc-486f-a9c9-9dbc3a73ddf4.png">
+ no help cursor, only pointer

Before:
<img width="752" alt="Screenshot 2022-08-26 at 11 16 25" src="https://user-images.githubusercontent.com/33235762/186871347-53ee96c8-007a-4f73-a2de-3a377daa6153.png">

Now: 
<img width="707" alt="Screenshot 2022-08-26 at 11 20 12" src="https://user-images.githubusercontent.com/33235762/186872117-3a9b1bf6-7c1b-4a8c-a4f4-34b6786191c7.png">

