### PR TITLE
chore(suite): export areSatsUsed fom useBitcoinAmountUnit

### DIFF
--- a/packages/suite/src/hooks/wallet/useBitcoinAmountUnit.ts
+++ b/packages/suite/src/hooks/wallet/useBitcoinAmountUnit.ts
@@ -46,9 +46,9 @@ export const useBitcoinAmountUnit = (symbol?: NetworkSymbol) => {
     return {
         bitcoinAmountUnit,
         areSatsDisplayed,
+        areSatsUsed: areSatsDisplayed && areUnitsSupportedByNetwork && areUnitsSupportedByDevice,
         toggleBitcoinAmountUnits,
         setBitcoinAmountUnits,
-        areUnitsSupportedByDevice,
         areUnitsSupportedByNetwork,
         UNIT_LABELS,
         UNIT_OPTIONS,

--- a/packages/suite/src/hooks/wallet/useSendForm.ts
+++ b/packages/suite/src/hooks/wallet/useSendForm.ts
@@ -115,9 +115,7 @@ export const useSendForm = (props: UseSendFormProps): SendContextValues => {
         name: 'outputs',
     });
 
-    const { areSatsDisplayed, areUnitsSupportedByNetwork, areUnitsSupportedByDevice } =
-        useBitcoinAmountUnit(props.selectedAccount.account.symbol);
-    const areSatsUsed = areSatsDisplayed && areUnitsSupportedByNetwork && areUnitsSupportedByDevice;
+    const { areSatsUsed } = useBitcoinAmountUnit(props.selectedAccount.account.symbol);
 
     // enhance DEFAULT_VALUES with last remembered FeeLevel and localCurrencyOption
     // used in "loadDraft" useEffect and "importTransaction" callback

--- a/packages/suite/src/hooks/wallet/useSendFormFields.ts
+++ b/packages/suite/src/hooks/wallet/useSendFormFields.ts
@@ -25,9 +25,7 @@ export const useSendFormFields = ({
     fiatRates,
     network,
 }: Props) => {
-    const { areSatsDisplayed, areUnitsSupportedByNetwork, areUnitsSupportedByDevice } =
-        useBitcoinAmountUnit(network.symbol);
-    const areSatsUsed = areSatsDisplayed && areUnitsSupportedByNetwork && areUnitsSupportedByDevice;
+    const { areSatsUsed } = useBitcoinAmountUnit(network.symbol);
 
     const calculateFiat = useCallback(
         (outputIndex: number, amount?: string) => {

--- a/packages/suite/src/views/wallet/send/components/Outputs/components/Amount/components/Fiat/index.tsx
+++ b/packages/suite/src/views/wallet/send/components/Outputs/components/Amount/components/Fiat/index.tsx
@@ -48,9 +48,7 @@ const Fiat = ({ output, outputId }: Props) => {
         composeTransaction,
     } = useSendFormContext();
 
-    const { areSatsDisplayed, areUnitsSupportedByNetwork, areUnitsSupportedByDevice } =
-        useBitcoinAmountUnit(account.symbol);
-    const areSatsUsed = areSatsDisplayed && areUnitsSupportedByNetwork && areUnitsSupportedByDevice;
+    const { areSatsUsed } = useBitcoinAmountUnit(account.symbol);
 
     const inputName = `outputs[${outputId}].fiat`;
     const currencyInputName = `outputs[${outputId}].currency`;

--- a/packages/suite/src/views/wallet/send/components/Outputs/components/Amount/index.tsx
+++ b/packages/suite/src/views/wallet/send/components/Outputs/components/Amount/index.tsx
@@ -108,9 +108,7 @@ const Amount = ({ output, outputId }: Props) => {
     const { symbol, tokens, availableBalance, balance } = account;
 
     const theme = useTheme();
-    const { areSatsDisplayed, areUnitsSupportedByNetwork, areUnitsSupportedByDevice } =
-        useBitcoinAmountUnit(symbol);
-    const areSatsUsed = areSatsDisplayed && areUnitsSupportedByNetwork && areUnitsSupportedByDevice;
+    const { areSatsUsed } = useBitcoinAmountUnit(symbol);
 
     const inputName = `outputs[${outputId}].amount`;
     const tokenInputName = `outputs[${outputId}].token`;


### PR DESCRIPTION
Removes repeating code.

## Description

This is a repeatedly needed functionality and I needed it as well so I export it from the hook.

## Related Issue

#3004

## Screenshots (if appropriate):
