### PR TITLE
[WIP] chore: make yarn install faster

### DIFF
--- a/.github/workflows/validation.yml
+++ b/.github/workflows/validation.yml
@@ -28,21 +28,23 @@ jobs:
           key: yarn-cache-folder-${{ hashFiles('**/yarn.lock', '.yarnrc.yml') }}
           restore-keys: |
             yarn-cache-folder-
+      # mode=skip-build will make yarn install faster and we don't need builded executables for validation.
       - name: install deps
-        run: yarn --immutable
+        run: yarn --immutable --mode=skip-build
+      # Because we skipped build command, no scripts was run, but for validation we
+      # need only one, our postinstall in root package.json that will patch packages.
+      - name: Run only root package.json "postinstall" script to patch packages
+        run: yarn postinstall
       - name: check files for correct formatting
         run: yarn nx format:check
       - name: verify TS project references
         run: yarn verify-project-references
       - name: msg-system config validation
         run: yarn workspace @trezor/suite-data msg-system-validate-config
-      - run: git status
       - name: build libs
         run: yarn nx:build:libs
-      - run: git status
       - name: type check
         run: yarn nx:type-check
-      - run: git status
       - name: lint js
         run: yarn nx:lint:js
       - name: lint styles

--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
         "lint:shellcheck": "./scripts/shellcheck.sh",
         "_______ Global Scripts _______": "Shared scripts for running in all workspaces",
         "g:eslint": "cd $INIT_CWD && eslint --report-unused-disable-directives --cache --ignore-path ../../.gitignore",
-        "_______ Nx testing _______": "Nx wrapped commands for testing, linting, type checking...",
+        "_______ Nx command _______": "Nx wrapped commands for testing, linting, type checking, building...",
         "nx:build:libs": "yarn nx affected --target=build:lib",
         "nx:type-check": "yarn nx affected --target=type-check",
         "nx:test-unit": "yarn nx affected --target=test:unit",

--- a/package.json
+++ b/package.json
@@ -124,5 +124,16 @@
         "typescript": "4.7.4",
         "version-bump-prompt": "^6.1.0"
     },
-    "packageManager": "yarn@3.2.2"
+    "packageManager": "yarn@3.2.2",
+    "dependenciesMeta": {
+        "cypress": {
+            "built": false
+        },
+        "electron": {
+            "built": false
+        },
+        "playwright": {
+            "built": false
+        }
+    }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -31721,6 +31721,13 @@ __metadata:
     tsx: ^3.8.2
     typescript: 4.7.4
     version-bump-prompt: ^6.1.0
+  dependenciesMeta:
+    cypress:
+      built: false
+    electron:
+      built: false
+    playwright:
+      built: false
   languageName: unknown
   linkType: soft
 


### PR DESCRIPTION
Usage of `yarn install mode=skip-build` will make install faster (~1 minute faster) because we don't need to build executables like playwright or electron which we don't need at all for type-check and linting. We only need run our own postinstall to patch packages. 