### PR TITLE
fix(ci): fix Nx inputs

### DIFF
--- a/nx.json
+++ b/nx.json
@@ -17,16 +17,21 @@
             }
         }
     },
+    "namedInputs": {
+        "default": ["{projectRoot}/**/*"],
+        "prod": ["!{projectRoot}/**/*.test.{ts,tsx}"]
+    },
     "targetDefaults": {
         "build:lib": {
             "dependsOn": ["^build:lib"],
+            "inputs": ["default", "^prod"],
             "outputs": ["./lib", "./build"]
         },
         "type-check": {
             "dependsOn": ["^build:lib"],
-            "outputs": [],
             "inputs": [
                 "default",
+                "^prod",
                 "{workspaceRoot}/tsconfig.json",
                 "{workspaceRoot}/tsconfig.aliases.json",
                 "{workspaceRoot}/tsconfig.lib.json"
@@ -34,23 +39,18 @@
         },
         "test:unit": {
             "dependsOn": ["^build:lib"],
-            "outputs": [],
             "inputs": [
                 "default",
+                "^prod",
                 "{workspaceRoot}/jest.config.base.js",
                 "{workspaceRoot}/jest.config.native.js"
             ]
         },
         "lint:js": {
-            "inputs": [
-                "{projectRoot}/**/*.js",
-                "{projectRoot}/**/*.ts",
-                "{projectRoot}/**/*.tsx",
-                "{workspaceRoot}/.eslintrc.js"
-            ]
+            "inputs": ["default", "{workspaceRoot}/.eslintrc.js"]
         },
         "lint:styles": {
-            "inputs": ["{projectRoot}/**/*.tsx"]
+            "inputs": ["default"]
         }
     },
     "implicitDependencies": {


### PR DESCRIPTION
Previously dependencies of packages was not considered as input. Example: I change something in `@suite-common/test-utils` and run `yarn nx:test-unit`, before this changes Nx will consider to rerun unit tests only for `@suite-common/test-utils` but not for packages that depends on this package like `@suite-common/wallet-core` which is clearly wrong because any change in `test-utils` can affect test results.

This is why I needed to add `^prod`. Prod is just alias for for regexp that will select all not test files and `^` meand dependendencies. `^prod` => select all files from dependecies of this package

Better explained in official Nx docs https://nx.dev/configuration/projectjson#inputs-&-namedinputs
