### PR TITLE
chore: remove trailing whitespaces

### DIFF
--- a/docker/suite/Dockerfile
+++ b/docker/suite/Dockerfile
@@ -1,5 +1,5 @@
 # For suite-dev, the idea behind docker is that we install, build and run dev server for user without any
-# dependencies on host (yarn, node). But all source files remain on host. We must ensure that permissions 
+# dependencies on host (yarn, node). But all source files remain on host. We must ensure that permissions
 # of newly created files in docker (entire monorepo is mounted volume) match users default.
 # Otherwise user would run into permission denied problem when trying to rebuild project outside docker.
 ## Use a proxy or fallback to no proxy at all (direct access to Docker Hub).

--- a/packages/blockchain-link/src/workers/electrum/devrun.ts
+++ b/packages/blockchain-link/src/workers/electrum/devrun.ts
@@ -78,12 +78,12 @@ const TX_HASH =
     });
     return;
     await sendAndWait({ id: ++id, type: 'm_get_info' });
-    
+
     console.time('tx');
     await sendAndWait({ id: ++id, type: 'm_get_account_utxo', payload: ADDR_SEGWIT_MID });
     console.timeEnd('tx');
     return;
-    
+
     await sendAndWait({
         id: ++id,
         type: 'm_subscribe',
@@ -91,10 +91,10 @@ const TX_HASH =
     });
     return;
     await sendAndWait({ id: ++id, type: 'm_get_block_hash', payload: 666666 });
-    
+
     await sendAndWait({ id: ++id, type: 'm_get_transaction', payload: TX });
     return;
-    
+
     await sendAndWait({
         id: ++id,
         // @ts-ignore

--- a/packages/components/src/config/animations.ts
+++ b/packages/components/src/config/animations.ts
@@ -1,10 +1,10 @@
 import { keyframes } from 'styled-components';
 
 export const SPIN = keyframes`
-    0% { 
-        transform: rotate(0deg); 
+    0% {
+        transform: rotate(0deg);
     }
-    100% { 
+    100% {
         transform: rotate(360deg);
     }
 `;

--- a/packages/connect-examples/webextension/background.js
+++ b/packages/connect-examples/webextension/background.js
@@ -1,7 +1,7 @@
 /**
 When the button's clicked:
 - call for TrezorConnect action
-- show a notification with response 
+- show a notification with response
 */
 
 TrezorConnect.manifest({

--- a/packages/connect-explorer/src/GlobalStyle.tsx
+++ b/packages/connect-explorer/src/GlobalStyle.tsx
@@ -30,7 +30,7 @@ const GlobalStyle = createGlobalStyle`
     #root, .app-container {
         height: 100%;
     }
-    
+
     a {
         text-decoration: none;
         cursor: pointer;

--- a/packages/connect-explorer/src/components/Menu.tsx
+++ b/packages/connect-explorer/src/components/Menu.tsx
@@ -48,7 +48,7 @@ const Style = createGlobalStyle`
     padding: 4px 0px;
     color: rgb(73, 73, 73);
     cursor: pointer;
-    
+
     &.selected {
         .leaf-arrow {
             transform: rotateZ(90deg);

--- a/packages/suite-desktop/src/support/DesktopUpdater/Available.tsx
+++ b/packages/suite-desktop/src/support/DesktopUpdater/Available.tsx
@@ -46,8 +46,8 @@ const ChangelogWrapper = styled.div`
         line-height: 1.57;
     }
 
-    /* 
-    Styling similar to  Link component. 
+    /*
+    Styling similar to  Link component.
     It seems overriding via linkReference renderer doesn't work for some reason
     */
     a {

--- a/packages/suite/src/components/suite/TransactionsGraph/components/CustomBar.tsx
+++ b/packages/suite/src/components/suite/TransactionsGraph/components/CustomBar.tsx
@@ -38,7 +38,7 @@ export const CustomBar = (props: CustomBarProps) => {
     // Tutorial about SVG coordinate system: https://medium.com/@dennismphil/one-side-rounded-rectangle-using-svg-fb31cf318d90
 
     const path = `
-    M${x},${yStartDrawingPoint}  
+    M${x},${yStartDrawingPoint}
     v-${minHeight - BAR_BORDER_RADIUS}
     q0, ${-BAR_BORDER_RADIUS} ${BAR_BORDER_RADIUS}, ${-BAR_BORDER_RADIUS}
     h${width - 2 * BAR_BORDER_RADIUS}

--- a/packages/suite/src/middlewares/suite/analyticsMiddleware.ts
+++ b/packages/suite/src/middlewares/suite/analyticsMiddleware.ts
@@ -20,7 +20,7 @@ import type { AppState, Action, Dispatch } from '@suite-types';
 /*
     In analytics middleware we may intercept actions we would like to log. For example:
     - trezor model
-    - firmware version 
+    - firmware version
     - transport (webusb/bridge) and its version
     - backup type (shamir/bip39)
 */

--- a/packages/suite/src/support/suite/styles/animations.ts
+++ b/packages/suite/src/support/suite/styles/animations.ts
@@ -92,7 +92,7 @@ export const SHAKE = keyframes`
     10%, 90% {
         transform: translate3d(-1px, 0, 0);
     }
-    
+
     20%, 80% {
         transform: translate3d(2px, 0, 0);
     }

--- a/packages/suite/src/views/wallet/coinmarket/buy/detail/components/WaitingForUser/index.tsx
+++ b/packages/suite/src/views/wallet/coinmarket/buy/detail/components/WaitingForUser/index.tsx
@@ -95,7 +95,7 @@ const WaitingForUser = ({ trade, account, providerName }: Props) => {
             <PaymentButton onClick={goToPayment} isLoading={isWorking} isDisabled={isWorking}>
                 <Translation id={translations.buttonTextTranslationId} />
             </PaymentButton>
-            {/* TODO add a possibility in the future to cancel the transaction by the user                
+            {/* TODO add a possibility in the future to cancel the transaction by the user
             <CancelButton isWhite variant="tertiary" onClick={cancelTrade}>
                 <Translation id="TR_BUY_DETAIL_SUBMITTED_CANCEL" />
             </CancelButton> */}

--- a/suite-native/app/android/app/src/dev/res/drawable/ic_launcher_foreground.xml
+++ b/suite-native/app/android/app/src/dev/res/drawable/ic_launcher_foreground.xml
@@ -9,7 +9,7 @@
     <path
         android:pathData="M26.76,74.92C26.76,48.32 48.32,26.76 74.92,26.76H199.08C225.68,26.76 247.24,48.32 247.24,74.92V199.08C247.24,225.68 225.68,247.24 199.08,247.24H74.92C48.32,247.24 26.76,225.68 26.76,199.08V74.92Z">
       <aapt:attr name="android:fillColor">
-        <gradient 
+        <gradient
             android:startX="137"
             android:startY="26.76"
             android:endX="2.53"

--- a/suite-native/app/android/app/src/firebaseDevelop/res/drawable/ic_launcher_foreground.xml
+++ b/suite-native/app/android/app/src/firebaseDevelop/res/drawable/ic_launcher_foreground.xml
@@ -9,7 +9,7 @@
     <path
         android:pathData="M26.76,74.92C26.76,48.32 48.32,26.76 74.92,26.76H199.08C225.68,26.76 247.24,48.32 247.24,74.92V199.08C247.24,225.68 225.68,247.24 199.08,247.24H74.92C48.32,247.24 26.76,225.68 26.76,199.08V74.92Z">
       <aapt:attr name="android:fillColor">
-        <gradient 
+        <gradient
             android:startX="137"
             android:startY="26.76"
             android:endX="2.53"

--- a/suite-native/app/android/app/src/firebaseStaging/res/drawable/ic_launcher_foreground.xml
+++ b/suite-native/app/android/app/src/firebaseStaging/res/drawable/ic_launcher_foreground.xml
@@ -9,7 +9,7 @@
     <path
         android:pathData="M26.76,74.92C26.76,48.32 48.32,26.76 74.92,26.76H199.08C225.68,26.76 247.24,48.32 247.24,74.92V199.08C247.24,225.68 225.68,247.24 199.08,247.24H74.92C48.32,247.24 26.76,225.68 26.76,199.08V74.92Z">
       <aapt:attr name="android:fillColor">
-        <gradient 
+        <gradient
             android:startX="137"
             android:startY="26.76"
             android:endX="2.53"

--- a/suite-native/app/android/app/src/main/jni/Android.mk
+++ b/suite-native/app/android/app/src/main/jni/Android.mk
@@ -17,7 +17,7 @@ LOCAL_SRC_FILES := $(wildcard $(LOCAL_PATH)/*.cpp)
 LOCAL_EXPORT_C_INCLUDES := $(LOCAL_PATH)
 
 # If you wish to add a custom TurboModule or Fabric component in your app you
-# will have to uncomment those lines to include the generated source 
+# will have to uncomment those lines to include the generated source
 # files from the codegen (placed in $(GENERATED_SRC_DIR)/codegen/jni)
 #
 # LOCAL_C_INCLUDES += $(GENERATED_SRC_DIR)/codegen/jni


### PR DESCRIPTION
removing some trailing whitespaces, can be done with pre-commit using this hook config:

```
          - id: trailing-whitespace
            exclude_types: [svg]
            exclude: '.*\.patch|.*\.snap|.yarn'
            args:
                - --markdown-linebreak-ext=md
```