### PR TITLE
fix(onboarding): get back preserving params when go to Suite from SecurityCheck

### DIFF
--- a/packages/suite/src/hooks/suite/useOnboarding.ts
+++ b/packages/suite/src/hooks/suite/useOnboarding.ts
@@ -29,7 +29,7 @@ export const useOnboarding = () => {
     const goToSuite = (initialRedirection = false) => {
         dispatch(suiteActions.initialRunCompleted());
         dispatch(onboardingActions.resetOnboarding());
-        dispatch(routerActions.closeModalApp());
+        dispatch(routerActions.closeModalApp(true));
 
         // fixes a bug that user ends up in settings after initialization of a new device because he navigated to settings before
         if (initialRedirection) {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Preserving params has been removed here https://github.com/trezor/trezor-suite/pull/5899/files#diff-f7207d83cab0cd72fe28f5df77959b09baf38e31c76fad975e3589f926f209bcL144 
I believe it was unintentional, was it @tomasklim?

## Related Issue

Related to https://github.com/trezor/trezor-suite/issues/5861

