### PR TITLE
Coin control prerequisite: "send max" switch

### DIFF
--- a/packages/components/src/components/form/Input/index.tsx
+++ b/packages/components/src/components/form/Input/index.tsx
@@ -186,8 +186,7 @@ export const Input = ({
                 <Label>
                     <LabelLeft>{label}</LabelLeft>
                     <LabelRight>
-                        {labelAddonIsVisible && <div>{labelAddon}</div>}
-                        {isHovered && !labelAddonIsVisible && <div>{labelAddon}</div>}
+                        {(labelAddonIsVisible || isHovered) && labelAddon}
                         {labelRight && <RightLabel>{labelRight}</RightLabel>}
                     </LabelRight>
                 </Label>

--- a/packages/components/src/components/form/Switch/index.tsx
+++ b/packages/components/src/components/form/Switch/index.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useState } from 'react';
+import React from 'react';
 import styled, { css } from 'styled-components';
 
 const Container = styled.div<{ isChecked: boolean; isDisabled?: boolean; isSmall?: boolean }>`
@@ -69,6 +69,7 @@ const CheckboxInput = styled.input`
 `;
 
 export interface SwitchProps {
+    id?: string;
     isChecked: boolean;
     onChange: (isChecked?: boolean) => void;
     isDisabled?: boolean;
@@ -79,6 +80,7 @@ export interface SwitchProps {
 
 export const Switch = ({
     onChange,
+    id,
     isDisabled,
     isSmall,
     dataTest,
@@ -98,6 +100,7 @@ export const Switch = ({
     >
         <Handle isSmall={isSmall} isChecked={isChecked} type="button" />
         <CheckboxInput
+            id={id}
             type="checkbox"
             role="switch"
             checked={isChecked}

--- a/packages/suite/src/views/wallet/send/components/Outputs/components/Amount/index.tsx
+++ b/packages/suite/src/views/wallet/send/components/Outputs/components/Amount/index.tsx
@@ -1,7 +1,8 @@
 import React, { useCallback } from 'react';
 import BigNumber from 'bignumber.js';
 import styled from 'styled-components';
-import { Input, Icon, Button, variables, useTheme } from '@trezor/components';
+
+import { Input, Icon, Switch, variables, useTheme } from '@trezor/components';
 import { FiatValue, Translation } from '@suite-components';
 import { InputError } from '@wallet-components';
 import {
@@ -16,7 +17,6 @@ import {
 import { useSendFormContext } from '@wallet-hooks';
 import { Output } from '@wallet-types/sendForm';
 import { MAX_LENGTH } from '@suite-constants/inputs';
-
 import TokenSelect from './components/TokenSelect';
 import Fiat from './components/Fiat';
 import { useBitcoinAmountUnit } from '@wallet-hooks/useBitcoinAmountUnit';
@@ -32,6 +32,17 @@ const Wrapper = styled.div`
 
 const Text = styled.div`
     margin-right: 3px;
+`;
+
+const SwitchWrapper = styled.div`
+    align-items: center;
+    display: flex;
+    gap: 4px;
+`;
+
+const SwitchLabel = styled.label`
+    font-size: 14px;
+    font-weight: 500;
 `;
 
 const StyledInput = styled(Input)`
@@ -116,7 +127,8 @@ const Amount = ({ output, outputId }: Props) => {
     const outputError = errors.outputs ? errors.outputs[outputId] : undefined;
     const error = outputError ? outputError.amount : undefined;
     // corner-case: do not display "setMax" button if FormState got ANY error (setMax probably cannot be calculated)
-    const isSetMaxVisible = isSetMaxActive || error || Object.keys(errors).length === 0;
+    const isSetMaxVisible = isSetMaxActive && !error && !Object.keys(errors).length;
+    const maxSwitchId = `outputs[${outputId}].setMax`;
 
     const amountValue = getDefaultValue(inputName, output.amount || '');
     const tokenValue = getDefaultValue(tokenInputName, output.token);
@@ -242,21 +254,23 @@ const Amount = ({ output, outputId }: Props) => {
                 <StyledInput
                     inputState={getInputState(error, amountValue)}
                     isMonospace
-                    labelAddonIsVisible={isSetMaxActive}
+                    labelAddonIsVisible={isSetMaxVisible}
                     labelAddon={
-                        isSetMaxVisible ? (
-                            <Button
-                                icon={isSetMaxActive ? 'CHECK' : 'SEND'}
-                                data-test={`outputs[${outputId}].setMax`}
-                                onClick={() => {
+                        <SwitchWrapper>
+                            <Switch
+                                isSmall
+                                isChecked={isSetMaxActive}
+                                id={maxSwitchId}
+                                dataTest={maxSwitchId}
+                                onChange={() => {
                                     setMax(outputId, isSetMaxActive);
                                     composeTransaction(inputName);
                                 }}
-                                variant="tertiary"
-                            >
+                            />
+                            <SwitchLabel htmlFor={maxSwitchId}>
                                 <Translation id="AMOUNT_SEND_MAX" />
-                            </Button>
-                        ) : undefined
+                            </SwitchLabel>
+                        </SwitchWrapper>
                     }
                     label={
                         <Label>


### PR DESCRIPTION
Replaces the "send max" button with a switch.

## Description

We want to communicate that setting max amount is a state rather than an action - the user can add or remove UTXOs after checking the switch and the amount in the input field always adjusts to be the maximum amount composed from available/selected UTXOs.

There is also a minor improvement in the `Switch` component - when given an `id`, it can be controlled by clicking on its label.

## Related Issue

#2770

## Screenshots (if appropriate):
![Screenshot 2022-08-30 at 12 47 48](https://user-images.githubusercontent.com/42465546/187417870-e84cbf51-1bb9-42f8-8829-f3e2bc7896f2.png)

QA: Please see above. There are no changes to the behaviour from the previous version with the button.
