### PR TITLE
fix(ci): fix suite-types implicit dependecies

### DIFF
--- a/suite-common/suite-types/package.json
+++ b/suite-common/suite-types/package.json
@@ -19,5 +19,10 @@
     "devDependencies": {
         "jest": "^26.6.3",
         "typescript": "4.7.4"
+    },
+    "nx": {
+        "implicitDependencies": [
+            "@trezor/suite-data"
+        ]
     }
 }


### PR DESCRIPTION
`@suite-common/suite-types` has file `src/messageSystem.ts` which is generated by build step in `@trezor/suite-data`. But because there is no direct dependency  `@suite-common/suite-types` <= `@trezor/suite-data` in some cases when nothing is changed directly `@trezor/suite-data` affected command can think it's not necessary to run build step of that package.

This PR adds `@trezor/suite-data` as implicit dependency of `@suite-common/suite-types` so it will should fix this issue.
