### PR TITLE
Coin control prerequisite: reused components

### DIFF
--- a/packages/components/src/components/buttons/Button/index.tsx
+++ b/packages/components/src/components/buttons/Button/index.tsx
@@ -50,10 +50,9 @@ const getFontSize = (variant: ButtonVariant) => {
 interface WrapperProps {
     variant: ButtonVariant;
     hasLabel: boolean;
-    isDisabled: boolean;
     disabled: boolean;
     fullWidth: boolean;
-    color: string | undefined;
+    $color: string | undefined;
 }
 
 const Wrapper = styled.button<WrapperProps>`
@@ -63,7 +62,7 @@ const Wrapper = styled.button<WrapperProps>`
     justify-content: center;
     border: none;
     white-space: nowrap;
-    cursor: ${({ isDisabled }) => (isDisabled ? 'default' : 'pointer')};
+    cursor: ${({ disabled }) => (disabled ? 'default' : 'pointer')};
     border-radius: 8px;
     font-size: ${({ variant }) => getFontSize(variant)};
     font-weight: ${variables.FONT_WEIGHT.MEDIUM};
@@ -71,7 +70,8 @@ const Wrapper = styled.button<WrapperProps>`
     padding: ${({ variant, hasLabel }) => getPadding(variant, hasLabel)};
     transition: ${({ theme }) =>
         `background ${theme.HOVER_TRANSITION_TIME} ${theme.HOVER_TRANSITION_EFFECT}`};
-    color: ${({ variant, isDisabled, theme }) => getColor(variant, isDisabled, theme)};
+    color: ${({ $color, variant, disabled, theme }) =>
+        $color || getColor(variant, disabled, theme)};
     pointer-events: ${({ disabled }) => disabled && 'none'};
 
     ${({ variant, theme }) =>
@@ -126,8 +126,8 @@ const Wrapper = styled.button<WrapperProps>`
             }
         `}
 
-    ${({ isDisabled, theme }) =>
-        isDisabled &&
+    ${({ disabled, theme }) =>
+        disabled &&
         css`
             background: ${theme.BG_GREY};
 
@@ -234,10 +234,9 @@ export const Button = React.forwardRef(
                 variant={variant}
                 hasLabel={hasLabel}
                 onChange={onChange}
-                isDisabled={isDisabled}
                 disabled={isDisabled || isLoading}
                 fullWidth={fullWidth}
-                color={color}
+                $color={color}
                 ref={ref}
                 {...rest}
             >

--- a/packages/suite/src/components/wallet/Pagination.tsx
+++ b/packages/suite/src/components/wallet/Pagination.tsx
@@ -26,20 +26,23 @@ const Actions = styled.div<{ isActive: boolean }>`
 
 interface Props {
     currentPage: number;
-    totalPages?: number;
-    isOnLastPage?: boolean;
+    isLastPage?: boolean;
     hasPages?: boolean;
+    perPage: number;
+    totalItems: number;
     onPageSelected: (page: number) => void;
 }
 
 export const Pagination = ({
     currentPage,
-    totalPages,
     onPageSelected,
-    isOnLastPage,
     hasPages = true,
+    isLastPage,
+    perPage,
+    totalItems,
     ...rest
 }: Props) => {
+    const totalPages = Math.ceil(totalItems / perPage);
     const showPrevious = currentPage > 1;
     // array of int used for creating all page buttons
     const calculatedPages = useMemo(
@@ -55,7 +58,7 @@ export const Pagination = ({
                         ‹ <Translation id="TR_PAGINATION_NEWER" />
                     </PageItem>
                 </Actions>
-                <Actions isActive={!isOnLastPage}>
+                <Actions isActive={!isLastPage}>
                     <PageItem onClick={() => onPageSelected(currentPage + 1)}>
                         <Translation id="TR_PAGINATION_OLDER" /> ›
                     </PageItem>

--- a/packages/suite/src/components/wallet/Pagination.tsx
+++ b/packages/suite/src/components/wallet/Pagination.tsx
@@ -32,7 +32,7 @@ interface Props {
     onPageSelected: (page: number) => void;
 }
 
-const Pagination = ({
+export const Pagination = ({
     currentPage,
     totalPages,
     onPageSelected,
@@ -103,5 +103,3 @@ const Pagination = ({
         </Wrapper>
     );
 };
-
-export default Pagination;

--- a/packages/suite/src/components/wallet/TransactionItem/index.tsx
+++ b/packages/suite/src/components/wallet/TransactionItem/index.tsx
@@ -13,11 +13,11 @@ import { TransactionTypeIcon } from './components/TransactionTypeIcon';
 import { TransactionHeading } from './components/TransactionHeading';
 import { MIN_ROW_HEIGHT } from './components/BaseTargetLayout';
 import { Target, TokenTransfer, FeeRow, WithdrawalRow, DepositRow } from './components/Target';
-import { TransactionTimestamp } from './components/TransactionTimestamp';
 import { useAnchor } from '@suite-hooks/useAnchor';
 import { AccountTransactionBaseAnchor } from '@suite-constants/anchors';
 import { SECONDARY_PANEL_HEIGHT } from '@suite-components/AppNavigation';
 import { anchorOutlineStyles } from '@suite-utils/anchor';
+import { TransactionTimestamp } from '@wallet-components/TransactionTimestamp';
 
 const Wrapper = styled.div<{
     chainedTxMode?: boolean;

--- a/packages/suite/src/components/wallet/TransactionTimestamp.tsx
+++ b/packages/suite/src/components/wallet/TransactionTimestamp.tsx
@@ -10,23 +10,26 @@ const TimestampLink = styled.div`
     color: ${({ theme }) => theme.TYPE_LIGHT_GREY};
     font-size: ${variables.FONT_SIZE.SMALL};
     font-weight: ${variables.FONT_WEIGHT.MEDIUM};
-    line-height: 1.57;
     margin-right: 8px;
     white-space: nowrap;
     cursor: pointer;
 `;
 
 interface TransactionTimestampProps {
+    showDate?: boolean;
     transaction: WalletAccountTransaction;
 }
 
-export const TransactionTimestamp = ({ transaction }: TransactionTimestampProps) => {
+export const TransactionTimestamp = ({
+    showDate = false,
+    transaction,
+}: TransactionTimestampProps) => {
     const { blockTime, blockHeight } = transaction;
 
     return (
         <TimestampLink>
             {blockHeight !== 0 && blockTime && blockTime > 0 && (
-                <FormattedDate value={new Date(blockTime * 1000)} time />
+                <FormattedDate value={new Date(blockTime * 1000)} time date={showDate} />
             )}
         </TimestampLink>
     );

--- a/packages/suite/src/components/wallet/index.tsx
+++ b/packages/suite/src/components/wallet/index.tsx
@@ -31,6 +31,8 @@ import { DiscoveryProgress } from './DiscoveryProgress';
 import KYCInProgress from './KYCInProgress';
 import KYCFailed from './KYCFailed';
 import KYCError from './KYCError';
+import { Pagination } from './Pagination';
+import { TransactionTimestamp } from './TransactionTimestamp';
 import { withCoinmarket, withSelectedAccountLoaded } from './hocs';
 import type { WithCoinmarketProps, WithSelectedAccountLoadedProps } from './hocs';
 
@@ -65,5 +67,7 @@ export {
     KYCInProgress,
     KYCFailed,
     KYCError,
+    Pagination,
+    TransactionTimestamp,
 };
 export type { WithCoinmarketProps, WithSelectedAccountLoadedProps };

--- a/packages/suite/src/views/wallet/transactions/components/TransactionList/index.tsx
+++ b/packages/suite/src/views/wallet/transactions/components/TransactionList/index.tsx
@@ -89,9 +89,7 @@ const TransactionList = ({ transactions, isLoading, account, ...props }: Transac
         setSelectedPage(startPage);
     }, [account.descriptor, account.symbol, startPage]);
 
-    const total = isSearching
-        ? Math.ceil(searchedTransactions.length / perPage)
-        : account?.page?.total ?? 1;
+    const totalItems = isSearching ? searchedTransactions.length : account.history.total;
 
     const onPageSelected = (page: number) => {
         setSelectedPage(page);
@@ -118,13 +116,12 @@ const TransactionList = ({ transactions, isLoading, account, ...props }: Transac
         [slicedTransactions],
     );
 
-    // if totalPages is 1 do not render pagination
-    // if totalPages is undefined check current page and number of txs (e.g. XRP)
-    // Edge case: if there is exactly 25 txs, pagination will be displayed
-    const isOnLastPage = slicedTransactions.length < SETTINGS.TXS_PER_PAGE;
-    const shouldShowRipplePagination = !(currentPage === 1 && isOnLastPage);
+    // if total pages cannot be determined check current page and number of txs (XRP)
+    // Edge case: if there is exactly 25 Ripple txs, pagination will be displayed
     const isRipple = account.networkType === 'ripple';
-    const showPagination = isRipple ? shouldShowRipplePagination : total > 1;
+    const isLastRipplePage = isRipple && slicedTransactions.length < perPage;
+    const showRipplePagination = !(isLastRipplePage && currentPage === 1);
+    const showPagination = isRipple ? showRipplePagination : totalItems > perPage;
 
     return (
         <StyledSection
@@ -185,8 +182,9 @@ const TransactionList = ({ transactions, isLoading, account, ...props }: Transac
                     <Pagination
                         hasPages={!isRipple}
                         currentPage={currentPage}
-                        totalPages={total}
-                        isOnLastPage={isOnLastPage}
+                        isLastPage={isLastRipplePage}
+                        perPage={perPage}
+                        totalItems={totalItems}
                         onPageSelected={onPageSelected}
                     />
                 </PaginationWrapper>

--- a/packages/suite/src/views/wallet/transactions/components/TransactionList/index.tsx
+++ b/packages/suite/src/views/wallet/transactions/components/TransactionList/index.tsx
@@ -12,7 +12,7 @@ import { SETTINGS } from '@suite-config';
 import { WalletAccountTransaction, Account } from '@wallet-types';
 import Actions from './components/Actions';
 import TransactionItem from '@wallet-components/TransactionItem';
-import Pagination from './components/Pagination';
+import { Pagination } from '@wallet-components';
 import TransactionsGroup from './components/TransactionsGroup';
 import SkeletonTransactionItem from './components/SkeletonTransactionItem';
 import NoSearchResults from './components/NoSearchResults';


### PR DESCRIPTION
Small adjustments to components so that they can be reused in Coin selection. No visible changes.

## Description
- `Pagination` takes number of items instead of pages and calculates the number of pages on its own ec9ce264b4875dae5dc92e49282b6dc70e71646d
- `TransactionTimestamp` takes a `showDate` prop to control whether full date is shown or just time dee1109fa7892fe687f2060dd74c963f97d9ec25
- `Button` refactored a little bit and now it respects the `color` prop when for its text colour e7f024235952f38588b7aebdbaa239ac6ac7cfa3
- `Pagination` and `TransactionTimestamp` moved to `@wallet-components` 610bb170e44388a70fbd4e74770949c160035045 dee1109fa7892fe687f2060dd74c963f97d9ec25

## Related Issue
#2770

QA: Check the pagination here and in transaction history. It should work exactly the same as it did until now.