### PR TITLE
fix(ci): add suite as implicit dependency to suite-desktop

### DIFF
--- a/packages/suite-desktop/package.json
+++ b/packages/suite-desktop/package.json
@@ -219,5 +219,10 @@
         "rimraf": "^3.0.2",
         "styled-components": "^5.3.5",
         "typescript": "4.7.4"
+    },
+    "nx": {
+        "implicitDependencies": [
+            "@trezor/suite"
+        ]
     }
 }


### PR DESCRIPTION
This is related to issue https://github.com/trezor/trezor-suite/issues/4989 because `suite/` is direct dependency of `suite-desktop/` but it's not defined in dependencies, it will break Nx affected packages tree calculation.