### PR TITLE
chore(env-utils): isFirefox util

### DIFF
--- a/packages/env-utils/src/envUtils.ts
+++ b/packages/env-utils/src/envUtils.ts
@@ -17,15 +17,17 @@ export const isAndroid = () => /Android/.test(getUserAgent());
 
 export const isChromeOs = () => /CrOS/.test(getUserAgent());
 
-export const getBrowserVersion = (): string => getUserAgentParser().getBrowser().version || '';
+export const getBrowserVersion = () => getUserAgentParser().getBrowser().version || '';
 
 /* Not correct for Linux as there is many different distributions in different versions */
 export const getOsVersion = () => getUserAgentParser().getOS().version || '';
 
-export const getBrowserName = (): string => {
+export const getBrowserName = () => {
     const browserName = getUserAgentParser().getBrowser().name;
     return browserName?.toLowerCase() || '';
 };
+
+export const isFirefox = () => getBrowserName() === 'firefox';
 
 // List of platforms https://docker.apachezone.com/blog/74
 export const getPlatform = () => window.navigator.platform;

--- a/packages/suite-storage/package.json
+++ b/packages/suite-storage/package.json
@@ -18,6 +18,7 @@
     "react-native": "./src/native/index.ts",
     "browser": "./src/web/index.ts",
     "dependencies": {
+        "@trezor/env-utils": "*",
         "broadcast-channel": "^4.14.0",
         "idb": "^7.0.2"
     },

--- a/packages/suite-storage/src/web/index.ts
+++ b/packages/suite-storage/src/web/index.ts
@@ -11,6 +11,7 @@ import {
     deleteDB,
 } from 'idb';
 import { BroadcastChannel } from 'broadcast-channel';
+import { isFirefox } from '@trezor/env-utils';
 import { StorageMessageEvent } from './types';
 
 export type OnUpgradeFunc<TDBStructure> = (
@@ -65,17 +66,14 @@ class CommonDB<TDBStructure> {
         CommonDB.instance = this;
     }
 
-    static isDBAvailable = () => {
+    static isDBAvailable = () =>
         // Firefox doesn't support indexedDB while in incognito mode, but still returns valid window.indexedDB object.
         // https://bugzilla.mozilla.org/show_bug.cgi?id=781982
         // so we need to try accessing the IDB. try/catch around idb.open() does not catch the error (bug in idb?), that's why we use callbacks.
         // this solution calls callback function from within onerror/onsuccess event handlers.
         // For other browsers checking the window.indexedDB should be enough.
-        const isFirefox =
-            typeof navigator !== 'undefined' &&
-            navigator.userAgent.toLowerCase().indexOf('firefox') > -1;
-        return new Promise<boolean>(resolve => {
-            if (isFirefox) {
+        new Promise<boolean>(resolve => {
+            if (isFirefox()) {
                 const r = indexedDB.open('test');
                 r.onerror = () => resolve(false);
                 r.onsuccess = () => {
@@ -91,7 +89,6 @@ class CommonDB<TDBStructure> {
                 }
             }
         });
-    };
 
     isSupported = async () => {
         if (this.supported === undefined) {

--- a/packages/suite-storage/tsconfig.json
+++ b/packages/suite-storage/tsconfig.json
@@ -2,5 +2,5 @@
     "extends": "../../tsconfig.json",
     "compilerOptions": { "outDir": "./libDev" },
     "include": [".", "**/*.json"],
-    "references": []
+    "references": [{ "path": "../env-utils" }]
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -7025,6 +7025,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@trezor/suite-storage@workspace:packages/suite-storage"
   dependencies:
+    "@trezor/env-utils": "*"
     broadcast-channel: ^4.14.0
     idb: ^7.0.2
     jest: ^26.6.3


### PR DESCRIPTION
Code sharing again.

Initially I thought I'd use `getBrowserName() === 'firefox'` directly but it has return type `string` and not some literal type. So I kept `isFirefox` utility in `@trezor/env-utils`