### PR TITLE
feat(auto-update): get signature file without request on  api.github.com

### DIFF
--- a/packages/suite-desktop/src-electron/libs/update-checker.ts
+++ b/packages/suite-desktop/src-electron/libs/update-checker.ts
@@ -20,7 +20,7 @@ const getSignatureFile = async ({ version, filename, feedURL }: GetSignatureFile
      */
     const signatureFileURL = feedURL
         ? `${feedURL.replace(/\/+$/, '')}/${filename}.asc`
-        : await getSignatureFileURL(filename, version);
+        : getSignatureFileURL(filename, version);
 
     const signatureFile = await fetch(signatureFileURL);
 

--- a/packages/suite/src/services/github.ts
+++ b/packages/suite/src/services/github.ts
@@ -29,22 +29,8 @@ export const getReleaseNotes = async (version?: string) => {
     return release as ReleaseInfo;
 };
 
-export const getSignatureFileURL = async (filename: string, version?: string) => {
-    // Get release info from Github
-    const info = await getReleaseNotes(version);
-
-    if (!info) {
-        throw new Error('Version does not exist.');
-    }
-
-    const releaseSignature = info.assets.find(asset => asset.name === `${filename}.asc`);
-
-    if (!releaseSignature) {
-        throw new Error('Signature not found.');
-    }
-
-    return releaseSignature.browser_download_url;
-};
+export const getSignatureFileURL = (filename: string, version?: string) =>
+    `${RELEASE_URL}/releases/download/v${version}/${filename}.asc`;
 
 const getDeviceInfo = (device?: TrezorDevice) => {
     if (!device?.features) {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

We don't need to fetch the whole release notes for getting signature file – the link to signature file has static structure. 

Fetch on api.github.com is rate-limited (60 requests / "user" / hour ?). So this prevent getting stuck during auto-update process because of the rate limit (possible to reached on shared IPs – using VPN or Tor...)

So worst thing that could happen to user when reach that limit is that changelog for new update is not displayed directly in Suite and he has to click on link to github to see it.
