### PR TITLE
feat(coinmarket): savings Swan Bitcoin related changes

### DIFF
--- a/packages/suite/src/hooks/wallet/useCoinmarketSavingsSetupContinue.ts
+++ b/packages/suite/src/hooks/wallet/useCoinmarketSavingsSetupContinue.ts
@@ -46,7 +46,8 @@ export const useSavingsSetupContinue = ({
         saveSavingsTradeResponse: coinmarketSavingsActions.saveSavingsTradeResponse,
     });
 
-    const { navigateToSavingsPaymentInfo } = useCoinmarketNavigation(account);
+    const { navigateToSavingsPaymentInfo, navigateToSavingsOverview } =
+        useCoinmarketNavigation(account);
 
     const { removeDraft } = useFormDraft('coinmarket-savings-setup-request');
 
@@ -143,13 +144,26 @@ export const useSavingsSetupContinue = ({
 
                 if (response) {
                     saveSavingsTradeResponse(response);
-                    if (response.trade?.status === 'ConfirmPaymentInfo') {
-                        navigateToSavingsPaymentInfo();
+                    switch (response.trade?.status) {
+                        case 'ConfirmPaymentInfo':
+                            navigateToSavingsPaymentInfo();
+                            break;
+                        case 'Active':
+                            navigateToSavingsOverview();
+                            break;
+                        default:
+                            break;
                     }
                 }
             }
         },
-        [address, navigateToSavingsPaymentInfo, saveSavingsTradeResponse, savingsTrade],
+        [
+            address,
+            navigateToSavingsOverview,
+            navigateToSavingsPaymentInfo,
+            saveSavingsTradeResponse,
+            savingsTrade,
+        ],
     );
 
     // TODO: extract

--- a/packages/suite/src/views/wallet/coinmarket/savings/overview/components/PaymentDetail/index.tsx
+++ b/packages/suite/src/views/wallet/coinmarket/savings/overview/components/PaymentDetail/index.tsx
@@ -48,8 +48,8 @@ const PaymentItemDate = styled.div`
     width: 25%;
 `;
 
-const PaymentItemStatus = styled.div<{ isNextUp: boolean }>`
-    margin: 13px 38px;
+const PaymentItemStatus = styled.div<{ isNextUp: boolean; isPaymentInfoAvailable: boolean }>`
+    margin: ${props => (props.isPaymentInfoAvailable ? '13px 38px' : '0 auto')};
     color: ${props => (props.isNextUp ? props.theme.TYPE_ORANGE : props.theme.TYPE_LIGHT_GREY)};
     display: flex;
     flex-direction: row;
@@ -141,7 +141,10 @@ export const PaymentDetail = ({
                     <PaymentItemDate>
                         {format(parseISO(savingsTradePayment.plannedPaymentAt), 'dd MMM yyyy')}
                     </PaymentItemDate>
-                    <PaymentItemStatus isNextUp={isNextUp}>
+                    <PaymentItemStatus
+                        isNextUp={isNextUp}
+                        isPaymentInfoAvailable={!!savingsTradePayment.paymentInfo}
+                    >
                         {isNextUp ? (
                             <>
                                 <PaymentItemStatusIcon>
@@ -164,15 +167,17 @@ export const PaymentDetail = ({
                             </>
                         )}
                     </PaymentItemStatus>
-                    <PaymentItemButton type="button" onClick={() => setShowDetail(!showDetail)}>
-                        <Translation
-                            id={
-                                showDetail
-                                    ? 'TR_SAVINGS_OVERVIEW_PAYMENT_DETAIL_HIDE_PAYMENT_DETAILS_BUTTON_LABEL'
-                                    : 'TR_SAVINGS_OVERVIEW_PAYMENT_DETAIL_VIEW_PAYMENT_DETAILS_BUTTON_LABEL'
-                            }
-                        />
-                    </PaymentItemButton>
+                    {savingsTradePayment.paymentInfo && (
+                        <PaymentItemButton type="button" onClick={() => setShowDetail(!showDetail)}>
+                            <Translation
+                                id={
+                                    showDetail
+                                        ? 'TR_SAVINGS_OVERVIEW_PAYMENT_DETAIL_HIDE_PAYMENT_DETAILS_BUTTON_LABEL'
+                                        : 'TR_SAVINGS_OVERVIEW_PAYMENT_DETAIL_VIEW_PAYMENT_DETAILS_BUTTON_LABEL'
+                                }
+                            />
+                        </PaymentItemButton>
+                    )}
                 </Row>
                 {showDetail && (
                     <DetailRow>


### PR DESCRIPTION
This PR introduces changes related to Swan Bitcoin savings flow.

## Description

- posibility to navigate user on savings overview page from setup contunuation page
- hide payment info on savings overview page when no payment info exists and style appropriately

## Screenshots
### For savings with payment info
![image](https://user-images.githubusercontent.com/7394177/188113729-f818caeb-85e2-414a-b562-c555f399e037.png)

### For savings without payment info
![image](https://user-images.githubusercontent.com/7394177/188113464-53ac8949-956f-4c88-9c9f-b7ecd5c72a16.png)
