### PR TITLE
feat: increase timeout for Tor initial ~ 200 seconds

### DIFF
--- a/packages/request-manager/src/controller.ts
+++ b/packages/request-manager/src/controller.ts
@@ -11,7 +11,7 @@ export class TorController extends EventEmitter {
     options: TorConnectionOptions;
     controlPort: TorControlPort;
     waitingTime = 1000;
-    maxTriesWaiting = 60;
+    maxTriesWaiting = 200;
     isCircuitEstablished = false;
     torIsDisabledWhileStarting: boolean;
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Increase Tor timeout from 60  to 200 seconds.
Sometimes Tor network can be slow and it will take a lot of time to create the circuit but it will in most cases eventually created. So instead of making the user Try again multiple time, just increase the timeout.
<!--- Describe your changes in detail -->