### PR TITLE
chore: more type-safe color types

### DIFF
--- a/packages/styles/src/types.ts
+++ b/packages/styles/src/types.ts
@@ -1,12 +1,11 @@
 import type * as RN from 'react-native';
 
 import type * as CSS from 'csstype';
-import type { darken, lighten, transparentize } from 'polished';
 
 // TODO: In the future, we might want to move the `theme` to a standalone module and instead
 // use an ambient module declaration instead of importing it here, just like Emotion does.
 // https://emotion.sh/docs/typescript#define-a-theme
-import type { Theme, NativeTheme } from '@trezor/theme';
+import type { Theme, NativeTheme, CSSColor } from '@trezor/theme';
 
 import type { multiply, getValueAndUnit, sum, negative } from './utils';
 import type { mediaQueries } from './mediaQueries';
@@ -27,24 +26,24 @@ export interface DirectionUtils {
     isRtl: boolean;
 }
 
-export interface StyleUtils extends Theme, DirectionUtils {
-    breakpoints: BreakpointMediaQueries;
-    darken: typeof darken;
+export type ColorTransformFunction = (amount: string | number, color: CSSColor) => CSSColor;
+
+export interface UniversalStyleUtils extends DirectionUtils {
     getValueAndUnit: typeof getValueAndUnit;
-    lighten: typeof lighten;
-    media: typeof mediaQueries;
     multiply: typeof multiply;
     sum: typeof sum;
     negative: typeof negative;
-    transparentize: typeof transparentize;
+    darken: ColorTransformFunction;
+    lighten: ColorTransformFunction;
+    transparentize: ColorTransformFunction;
 }
 
-export interface NativeStyleUtils extends NativeTheme, DirectionUtils {
-    darken: typeof darken;
-    lighten: typeof lighten;
-    transparentize: typeof transparentize;
-    negative: typeof negative;
+export interface StyleUtils extends Theme, UniversalStyleUtils {
+    breakpoints: BreakpointMediaQueries;
+    media: typeof mediaQueries;
 }
+
+export interface NativeStyleUtils extends NativeTheme, UniversalStyleUtils {}
 
 export type PlainStyleObject = CSS.Properties<string | number>;
 
@@ -86,6 +85,15 @@ export type NativeStyleObject = RN.TextStyle &
     RN.ViewStyle &
     RN.ImageStyle & {
         extend?: ConditionalExtend<NativeStyleObject> | Array<ConditionalExtend<NativeStyleObject>>;
+    } & {
+        // More strict color type than default one, feel free to add more valid properties, only most used are here
+        backgroundColor?: CSSColor;
+        borderColor?: CSSColor;
+        borderBottomColor?: CSSColor;
+        borderLeftColor?: CSSColor;
+        borderRightColor?: CSSColor;
+        borderTopColor?: CSSColor;
+        color?: CSSColor;
     };
 
 export type Style<TProps extends object = object> = (

--- a/packages/styles/src/useStyles.ts
+++ b/packages/styles/src/useStyles.ts
@@ -7,6 +7,7 @@ import { Theme, NativeTheme } from '@trezor/theme';
 
 import { breakpointMediaQueries } from './breakpoints';
 import {
+    ColorTransformFunction,
     NativeStyle,
     NativeStyleObject,
     NativeStyleOrStylesParam,
@@ -21,13 +22,13 @@ import { mediaQueries } from './mediaQueries';
 import { useDirection } from './useDirection';
 
 const sharedUtils = {
-    darken,
+    darken: darken as ColorTransformFunction,
     getValueAndUnit,
-    lighten,
+    lighten: lighten as ColorTransformFunction,
     multiply,
     sum,
     negative,
-    transparentize,
+    transparentize: transparentize as ColorTransformFunction,
 };
 
 export const useStyles = () => {

--- a/packages/theme/src/boxShadows.ts
+++ b/packages/theme/src/boxShadows.ts
@@ -1,3 +1,5 @@
+import { CSSColor } from './types';
+
 export const boxShadows = {
     small: '0px 2px 4px rgba(0, 0, 0, 0.04)',
     // TODO: next shadows needs to be defined
@@ -10,7 +12,7 @@ export type BoxShadows = typeof boxShadows;
 
 interface NativeBoxShadowDefinition {
     elevation: number;
-    shadowColor: string;
+    shadowColor: CSSColor;
     shadowOffset: {
         height: number;
         width: number;
@@ -22,7 +24,7 @@ interface NativeBoxShadowDefinition {
 export const nativeBoxShadows: Record<string, NativeBoxShadowDefinition> = {
     small: {
         elevation: 4,
-        shadowColor: '#rgba(0, 0, 0, 0.04)',
+        shadowColor: 'rgba(0, 0, 0, 0.04)',
         shadowOffset: {
             height: 0,
             width: 0,
@@ -33,7 +35,7 @@ export const nativeBoxShadows: Record<string, NativeBoxShadowDefinition> = {
     // TODO: next shadows needs to be defined
     medium: {
         elevation: 4,
-        shadowColor: '#rgba(0, 0, 0, 0.04)',
+        shadowColor: 'rgba(0, 0, 0, 0.04)',
         shadowOffset: {
             height: 0,
             width: 0,
@@ -43,7 +45,7 @@ export const nativeBoxShadows: Record<string, NativeBoxShadowDefinition> = {
     },
     big: {
         elevation: 4,
-        shadowColor: '#rgba(0, 0, 0, 0.04)',
+        shadowColor: 'rgba(0, 0, 0, 0.04)',
         shadowOffset: {
             height: 0,
             width: 0,

--- a/packages/theme/src/colors.ts
+++ b/packages/theme/src/colors.ts
@@ -1,4 +1,4 @@
-import type * as CSS from 'csstype';
+import { CSSColor } from './types';
 
 const defaultColorVariant = {
     green: '#00854D',
@@ -24,7 +24,7 @@ const defaultColorVariant = {
 
 export type Color = keyof typeof defaultColorVariant;
 
-export type Colors = Record<Color, CSS.Property.Color>;
+export type Colors = Record<Color, CSSColor>;
 
 export const colorVariants = {
     standard: {

--- a/packages/theme/src/index.ts
+++ b/packages/theme/src/index.ts
@@ -8,3 +8,4 @@ export * from './sizes';
 export * from './spacings';
 export * from './zIndices';
 export * from './prepareTheme';
+export * from './types';

--- a/packages/theme/src/types.ts
+++ b/packages/theme/src/types.ts
@@ -1,0 +1,4 @@
+export type CSSColor =
+    | `#${string}`
+    | `rgb(${number}, ${number}, ${number})`
+    | `rgba(${number}, ${number}, ${number}, ${number})`;

--- a/suite-native/atoms/src/AssetItem.tsx
+++ b/suite-native/atoms/src/AssetItem.tsx
@@ -2,6 +2,7 @@ import React from 'react';
 
 import { CryptoIcon, CryptoIconName } from '@trezor/icons';
 import { prepareNativeStyle, useNativeStyles } from '@trezor/styles';
+import { CSSColor } from '@trezor/theme';
 
 import { Box } from './Box';
 import { Text } from './Text';
@@ -17,7 +18,7 @@ type AssetItemProps = {
 };
 
 // TODO this config should be in some shared package for constants etc
-export const assetColorConfig: Record<string, string> = {
+export const assetColorConfig: Record<string, CSSColor> = {
     BTC: '#F29937',
     ETH: '#454A75',
 };

--- a/suite-native/atoms/src/ProgressBar.tsx
+++ b/suite-native/atoms/src/ProgressBar.tsx
@@ -1,12 +1,13 @@
 import React from 'react';
 
 import { prepareNativeStyle, useNativeStyles } from '@trezor/styles';
+import { CSSColor } from '@trezor/theme';
 
 import { Box } from './Box';
 
 type ProgressBarProps = {
     value: number; // Percentage value
-    color: string;
+    color: CSSColor;
 };
 
 const PROGRESS_BAR_WIDTH = 82;
@@ -16,7 +17,7 @@ const progressBarStyle = prepareNativeStyle(utils => ({
     backgroundColor: utils.colors.gray200,
 }));
 
-const progressFillStyle = prepareNativeStyle<{ width: number; color: string }>(
+const progressFillStyle = prepareNativeStyle<{ width: number; color: CSSColor }>(
     (_, { width, color }) => ({
         width: (width / 100) * PROGRESS_BAR_WIDTH,
         height: 3,

--- a/suite-native/module-settings/src/components/ColorSchemePickerItem.tsx
+++ b/suite-native/module-settings/src/components/ColorSchemePickerItem.tsx
@@ -1,10 +1,10 @@
 import React from 'react';
-import { ColorValue, TouchableOpacity, useColorScheme } from 'react-native';
+import { TouchableOpacity, useColorScheme } from 'react-native';
 import { useDispatch, useSelector } from 'react-redux';
 
 import { Box, Text } from '@suite-native/atoms';
 import { prepareNativeStyle, useNativeStyles } from '@trezor/styles';
-import { colorVariants, ThemeColorVariant } from '@trezor/theme';
+import { colorVariants, CSSColor, ThemeColorVariant } from '@trezor/theme';
 
 import { selectIsColorSchemeActive, setColorScheme, AppColorScheme } from '../slice';
 
@@ -25,7 +25,7 @@ const pickerItemWrapperStyle = prepareNativeStyle<{ isColorSchemeActive: boolean
 );
 
 type PickerItemDotStyleProps = {
-    backgroundColor: ColorValue;
+    backgroundColor: CSSColor;
     isFirstItem: boolean;
 };
 const pickerItemDotStyle = prepareNativeStyle<PickerItemDotStyleProps>(


### PR DESCRIPTION
Color is now using template type literals instead of plain string
