### PR TITLE
Fix/app log

### DIFF
--- a/packages/suite/src/utils/suite/analytics.ts
+++ b/packages/suite/src/utils/suite/analytics.ts
@@ -38,7 +38,9 @@ export const hasUserAllowedTracking = (
 export const getSuiteReadyPayload = (state: AppState) => ({
     language: state.suite.settings.language,
     enabledNetworks: state.wallet.settings.enabledNetworks,
-    customBackends: getCustomBackends(state.wallet.blockchain).map(({ coin }) => coin),
+    customBackends: getCustomBackends(state.wallet.blockchain)
+        .map(({ coin }) => coin)
+        .filter(coin => state.wallet.settings.enabledNetworks.includes(coin)),
     localCurrency: state.wallet.settings.localCurrency,
     bitcoinUnit: UNIT_ABBREVIATIONS[state.wallet.settings.bitcoinAmountUnit],
     discreetMode: state.wallet.settings.discreetMode,

--- a/packages/suite/src/utils/suite/logsUtils.ts
+++ b/packages/suite/src/utils/suite/logsUtils.ts
@@ -205,9 +205,11 @@ export const getApplicationInfo = (state: AppState, hideSensitiveInfo: boolean) 
         .filter(coin => state.wallet.settings.enabledNetworks.includes(coin)),
     devices: getPhysicalDeviceUniqueIds(state.devices)
         .map(id => state.devices.find(device => device.id === id) as TrezorDevice) // filter unique devices
+        .concat(state.devices.filter(device => device.id === null)) // add devices in bootloader mode
         .map(device => ({
             id: hideSensitiveInfo ? REDACTED_REPLACEMENT : device.id,
             label: hideSensitiveInfo ? REDACTED_REPLACEMENT : device.label,
+            mode: device.mode,
             model: getDeviceModel(device),
             firmware: device.features ? getFwVersion(device) : '',
             firmwareRevision: device.features ? getFwRevision(device) : '',

--- a/packages/suite/src/utils/suite/logsUtils.ts
+++ b/packages/suite/src/utils/suite/logsUtils.ts
@@ -200,7 +200,9 @@ export const getApplicationInfo = (state: AppState, hideSensitiveInfo: boolean) 
     rememberedStandardWallets: state.devices.filter(d => d.remember && d.useEmptyPassphrase).length,
     rememberedHiddenWallets: state.devices.filter(d => d.remember && !d.useEmptyPassphrase).length,
     enabledNetworks: state.wallet.settings.enabledNetworks,
-    customBackends: getCustomBackends(state.wallet.blockchain).map(({ coin }) => coin),
+    customBackends: getCustomBackends(state.wallet.blockchain)
+        .map(({ coin }) => coin)
+        .filter(coin => state.wallet.settings.enabledNetworks.includes(coin)),
     devices: getPhysicalDeviceUniqueIds(state.devices)
         .map(id => state.devices.find(device => device.id === id) as TrezorDevice) // filter unique devices
         .map(device => ({


### PR DESCRIPTION
## Description

- Regtest has custom backend set all the time. Report it only if regtest coin is active.
- Devices in bootloader were missing, because they do not have id.

## Related Issue

## Screenshots (if appropriate):
<img width="422" alt="Screenshot 2022-09-07 at 13 50 03" src="https://user-images.githubusercontent.com/33235762/188871576-7c9d8695-e579-4059-9f7e-8209d5e3498f.png">
