### PR TITLE
feat(coin-control): add tooltip with link to Guide article

### DIFF
--- a/packages/suite/src/support/messages.ts
+++ b/packages/suite/src/support/messages.ts
@@ -5207,6 +5207,12 @@ export default defineMessages({
         id: 'TR_COIN_CONTROL',
         defaultMessage: 'Coin control',
     },
+    TR_COIN_CONTROL_TOOLTIP: {
+        id: 'TR_COIN_CONTROL_TOOLTIP',
+        defaultMessage:
+            'Coin control enables manual selection of UTXOs to be used as inputs for a transaction.',
+        description: 'Tooltip on coin control button in send form.',
+    },
     TR_SELECTED: {
         id: 'TR_SELECTED',
         defaultMessage: '{amount} selected',

--- a/packages/suite/src/views/wallet/send/components/Options/components/BitcoinOptions/index.tsx
+++ b/packages/suite/src/views/wallet/send/components/Options/components/BitcoinOptions/index.tsx
@@ -150,29 +150,29 @@ export const BitcoinOptions = () => {
                         </StyledButton>
                     </Tooltip>
                     {!utxoSelectionEnabled && (
-                        // <Tooltip
-                        //     guideAnchor={instance => (
-                        //         <OpenGuideFromTooltip
-                        //             id="/suite-basics/send/coin-selection.md"
-                        //             instance={instance}
-                        //         />
-                        //     )}
-                        //     content={<span>Coin selection tooltip...</span>}
-                        //     cursor="pointer"
-                        // >
-                        <StyledButton
-                            variant="tertiary"
-                            icon="COIN_CONTROL"
-                            onClick={() => {
-                                // open additional form
-                                toggleOption('utxoSelection');
-                                composeTransaction();
-                            }}
+                        <Tooltip
+                            guideAnchor={instance => (
+                                <OpenGuideFromTooltip
+                                    id="/suite-basics/coin-control.md"
+                                    instance={instance}
+                                />
+                            )}
+                            content={<Translation id="TR_COIN_CONTROL_TOOLTIP" />}
+                            cursor="pointer"
                         >
-                            <Translation id="TR_COIN_CONTROL" />
-                            {isCoinControlEnabled && <OnOffSwitcher isOn />}
-                        </StyledButton>
-                        // </Tooltip>
+                            <StyledButton
+                                variant="tertiary"
+                                icon="COIN_CONTROL"
+                                onClick={() => {
+                                    // open additional form
+                                    toggleOption('utxoSelection');
+                                    composeTransaction();
+                                }}
+                            >
+                                <Translation id="TR_COIN_CONTROL" />
+                                {isCoinControlEnabled && <OnOffSwitcher isOn />}
+                            </StyledButton>
+                        </Tooltip>
                     )}
                 </Left>
                 <Right>


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Add tooltip for coin control with link to Suite Guide article.


## Screenshots (if appropriate):
<img width="954" alt="image" src="https://user-images.githubusercontent.com/3729633/188882935-adee580c-e967-4156-ba0c-9e803d8d2496.png">
