### PR TITLE
fix(suite): showing same y-axis values multiple times

### DIFF
--- a/packages/suite/src/components/suite/TransactionsGraph/components/CustomYAxisTick.tsx
+++ b/packages/suite/src/components/suite/TransactionsGraph/components/CustomYAxisTick.tsx
@@ -1,7 +1,6 @@
 import React, { useRef, useLayoutEffect } from 'react';
 import { useTheme } from '@trezor/components';
 import { FormattedFiatAmount, FormattedCryptoAmount } from '@suite-components';
-import { formatCoinBalance } from '@suite-common/wallet-utils';
 import BigNumber from 'bignumber.js';
 import { NetworkSymbol } from '@wallet-types';
 
@@ -33,9 +32,7 @@ export const CustomYAxisTick = ({
     }, [ref, setWidth]);
 
     const bValue = new BigNumber(payload.value);
-    const cryptoValue = bValue.abs().lt(0.01)
-        ? formatCoinBalance(bValue.toFixed())
-        : bValue.toFixed(2);
+    const cryptoValue = bValue.toFixed();
 
     return (
         <g ref={ref} transform={`translate(${x},${y})`}>

--- a/packages/suite/src/components/suite/TransactionsGraph/index.tsx
+++ b/packages/suite/src/components/suite/TransactionsGraph/index.tsx
@@ -27,6 +27,11 @@ const Wrapper = styled.div`
     .recharts-wrapper .recharts-cartesian-grid-horizontal line:last-child {
         stroke-opacity: 0;
     }
+
+    /* hides circle dot in case only one month is displayed */
+    .recharts-dot.recharts-line-dot {
+        display: none;
+    }
 `;
 
 const Toolbar = styled.div`


### PR DESCRIPTION
## Description

- I spend a lot of time on it because I wanted to fix values to the same decimal places, but without success (I would need to know counted `ticks` from `YAxis`). At least the main problem is fixed.
- I also removed the orange circle which was there on case only one month was available

## Related Issue

closes #5955

## Screenshots (if appropriate):
![Screenshot 2022-09-07 at 15 48 30](https://user-images.githubusercontent.com/33235762/188894799-d7570941-b0ea-4ebf-856a-fabaed1ab8bb.png)
![Screenshot 2022-09-07 at 15 49 59](https://user-images.githubusercontent.com/33235762/188895138-953122aa-30cb-4795-a3cf-82cccd5253ad.png)
![Screenshot 2022-09-07 at 15 51 10](https://user-images.githubusercontent.com/33235762/188895385-4ef7f0ee-7f60-4300-aede-b48b876fcb43.png)

Before:
![Screenshot 2022-09-07 at 15 50 38](https://user-images.githubusercontent.com/33235762/188895259-28e59734-061c-4ee2-9a4b-2ca78074cd1a.png)
![Screenshot 2022-09-07 at 15 50 58](https://user-images.githubusercontent.com/33235762/188895350-502c67af-9894-4b30-815d-72761845f4bd.png)
![Screenshot 2022-09-07 at 15 51 29](https://user-images.githubusercontent.com/33235762/188895436-9e8cf3d6-3432-4670-8a4c-00304a71dc03.png)
![Screenshot 2022-09-07 at 15 56 09](https://user-images.githubusercontent.com/33235762/188896510-261a1bdf-6c4e-46db-9811-f6c93a7fc637.png)
