### PR TITLE
tests(connect): make fixture work with multiple firmwares

### DIFF
--- a/packages/integration-tests/projects/connect/__fixtures__/checkFirmwareAuthenticity.ts
+++ b/packages/integration-tests/projects/connect/__fixtures__/checkFirmwareAuthenticity.ts
@@ -1,3 +1,10 @@
+// if custom build is used, we ignore firmware version numbers
+const customFirmwareBuild =
+    process.env.TESTS_CUSTOM_FIRMWARE_BUILD ||
+    process.env.TESTS_FIRMWARE?.includes('master') ||
+    // integration tests in trezor-firmware repo use 2.99.99 version
+    process.env.TESTS_FIRMWARE === '2.99.99';
+
 export default {
     method: 'checkFirmwareAuthenticity',
     setup: {
@@ -15,7 +22,7 @@ export default {
             },
             legacyResults: [
                 {
-                    rules: ['<2.5.1'],
+                    rules: [customFirmwareBuild ? '<2.99.99' : '<2.5.1'],
                     success: false,
                 },
             ],

--- a/packages/integration-tests/projects/connect/__fixtures__/index.ts
+++ b/packages/integration-tests/projects/connect/__fixtures__/index.ts
@@ -61,7 +61,12 @@ import tezosSignTransaction from './tezosSignTransaction';
 import verifyMessage from './verifyMessage';
 import verifyMessageSegwit from './verifyMessageSegwit';
 import verifyMessageSegwitNative from './verifyMessageSegwitNative';
-import checkFirmwareAuthenticity from './checkFirmwareAuthenticty';
+
+// todo: this test fixture relies on actual firmware binary being deployed to data.trezor.io
+// this is sometimes the case and sometimes it is not. to fix this we:
+// a] either need more flexibility in selecting which tests should be run based on some env variables
+// b] move this test outside of methods.test.js and create a custom test file for it, possibly with some mocking
+import checkFirmwareAuthenticity from './checkFirmwareAuthenticity';
 
 // TODO: add fixtures for missing dependencies https://github.com/trezor/trezor-suite/issues/5353
 // backupDevice


### PR DESCRIPTION
## Description

Fw people have problem with `checkFirmwareAuthenticity` test https://gitlab.com/satoshilabs/trezor/trezor-firmware/-/jobs/2994862912#L6235 which is makes sense, because this test relies on actual firmware being released and it is usually not in their case. 
This is a quick fix that is still not 100% bullet proof. This is why I have excluded this fixture from running in firmware tests https://github.com/trezor/trezor-firmware/pull/2496 and also added some comments with ideas how to improve this in the future

