### PR TITLE
fix(fiat-rates): fiat rates update action handling returned back

### DIFF
--- a/suite-common/wallet-core/src/fiat-rates/fiatRatesMiddleware.ts
+++ b/suite-common/wallet-core/src/fiat-rates/fiatRatesMiddleware.ts
@@ -1,4 +1,5 @@
 import { createMiddlewareWithExtraDeps } from '@suite-common/redux-utils';
+import { BLOCKCHAIN as TREZOR_CONNECT_BLOCKCHAIN_ACTIONS } from '@trezor/connect';
 
 import { transactionsActions } from '../transactions/transactionsActions';
 import { accountsActions } from '../accounts/accountsActions';
@@ -9,6 +10,7 @@ import {
     initFiatRatesThunk,
     updateLastWeekFiatRatesThunk,
     updateTxsFiatRatesThunk,
+    onUpdateFiatRateThunk,
 } from './fiatRatesThunks';
 import { blockchainActions } from '../blockchain/blockchainActions';
 
@@ -89,6 +91,10 @@ export const prepareFiatRatesMiddleware = createMiddlewareWithExtraDeps(
 
         if (blockchainActions.connected.match(action)) {
             dispatch(initFiatRatesThunk(action.payload));
+        }
+
+        if (action.type === TREZOR_CONNECT_BLOCKCHAIN_ACTIONS.FIAT_RATES_UPDATE) {
+            dispatch(onUpdateFiatRateThunk(action.payload));
         }
 
         return next(action);

--- a/suite-common/wallet-core/src/fiat-rates/fiatRatesThunks.ts
+++ b/suite-common/wallet-core/src/fiat-rates/fiatRatesThunks.ts
@@ -6,7 +6,7 @@ import {
     fetchLastWeekFiatRates,
     getFiatRatesForTimestamps,
 } from '@suite-common/fiat-services';
-import TrezorConnect, { AccountTransaction } from '@trezor/connect';
+import TrezorConnect, { AccountTransaction, BlockchainFiatRatesUpdate } from '@trezor/connect';
 import { createThunk } from '@suite-common/redux-utils';
 import { NetworkSymbol, networksCompatibility as NETWORKS } from '@suite-common/wallet-config';
 import { Account, CoinFiatRates, TickerId } from '@suite-common/wallet-types';
@@ -217,6 +217,26 @@ export const updateStaleFiatRatesThunk = createThunk(
             // dispatch({ type: '@rate/error', payload: error.message });
             console.error(error);
         }
+    },
+);
+
+export const onUpdateFiatRateThunk = createThunk(
+    `${actionPrefix}/onUpdateFiatRate`,
+    (res: BlockchainFiatRatesUpdate, { dispatch }) => {
+        if (!res?.rates) return;
+        const symbol = res.coin.shortcut.toLowerCase();
+        dispatch(
+            fiatRatesActions.updateFiatRate({
+                ticker: {
+                    symbol,
+                },
+                payload: {
+                    ts: getUnixTime(new Date()) * 1000,
+                    rates: res.rates,
+                    symbol,
+                },
+            }),
+        );
     },
 );
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

While migrating fiat rates to suite-common (in https://github.com/trezor/trezor-suite/pull/6118), we forgot to migrate thunk which handles the blockchain event dispatched action in Trezor Connect init:

```
        TrezorConnect.on(BLOCKCHAIN_EVENT, ({ event: _, ...action }) => {
            // dispatch event as action
            dispatch(action);
        });
```

Action type:

```
payload: {coin: {…}, rates: {…}}
type: "fiat-rates-update"
```

is not handled anymore in fiat rates middleware as before this migration.

The PR fix this.

<!--- Describe your changes in detail -->

## Related Issue

Related to https://github.com/trezor/trezor-suite/issues/6115

## Screenshots (if appropriate):
