### PR TITLE
Fix request-manager intercepting

### DIFF
--- a/packages/request-manager/src/interceptor.ts
+++ b/packages/request-manager/src/interceptor.ts
@@ -9,7 +9,8 @@ type Listener = (event: InterceptedEvent) => void;
 const interceptNetSocketConnect = (listener: Listener) => {
     const originalSocketConnect = net.Socket.prototype.connect;
 
-    net.Socket.prototype.connect = function (options: any, connectionListener: any) {
+    net.Socket.prototype.connect = function (...args) {
+        const [options, connectionListener] = args as any;
         let details;
         if (Array.isArray(options) && options.length > 0 && options[0].href) {
             // When websockets in clearnet options contains array where first element is networkOptions.
@@ -27,41 +28,52 @@ const interceptNetSocketConnect = (listener: Listener) => {
             method: 'net.Socket.connect',
             details,
         });
-        return originalSocketConnect.call(this, options, connectionListener);
+        // @ts-expect-error
+        return originalSocketConnect.apply(this, args);
     };
 };
 
 const interceptNetConnect = (listener: Listener) => {
     const originalConnect = net.connect;
-    net.connect = (connectArguments, connectionListener) => {
+
+    net.connect = function (...args) {
+        const [connectArguments] = args;
         listener({ method: 'net.connect', details: (connectArguments as any).host });
-        return originalConnect.call(this, connectArguments as any, connectionListener as any);
+        // @ts-expect-error
+        return originalConnect.apply(this, args);
     };
 };
 
 const interceptHttp = (listener: Listener) => {
     const originalHttpRequest = http.request;
 
-    http.request = function (options: any, callback) {
+    http.request = function (...args) {
+        const [options] = args as any;
         listener({ method: 'http.request', details: options.href });
-        return originalHttpRequest.call(this, options, callback as any);
+        // @ts-expect-error
+        return originalHttpRequest.apply(this, args);
     };
 };
 
 const interceptHttps = (listener: Listener) => {
     const originalHttpsRequest = https.request;
-    https.request = function (options: any, callback) {
+
+    https.request = function (...args) {
+        const [options] = args as any;
         listener({ method: 'https.request', details: options.href });
-        return originalHttpsRequest.call(this, options, callback as any);
+        // @ts-expect-error
+        return originalHttpsRequest.apply(this, args);
     };
 };
 
 const interceptTlsConnect = (listener: Listener) => {
     const orginalTlsConnect = tls.connect;
 
-    tls.connect = function (options: any, secureConnectListener) {
+    tls.connect = function (...args) {
+        const [options] = args as any;
         listener({ method: 'tls.connect', details: options.servername });
-        return orginalTlsConnect.call(this, options as any, secureConnectListener as any);
+        // @ts-expect-error
+        return orginalTlsConnect.apply(this, args);
     };
 };
 


### PR DESCRIPTION
## Description

This PR fixes a bug where not all the args in `request-manager`'s interceptor were properly passed to the wrapped methods and therefore e.g. Electrum backend was broken.