### PR TITLE
fix(suite): show the fee rate change warnings for bitcoin-like networks only

### DIFF
--- a/packages/suite/src/components/suite/modals/ReviewTransaction/components/Summary.tsx
+++ b/packages/suite/src/components/suite/modals/ReviewTransaction/components/Summary.tsx
@@ -287,7 +287,7 @@ const Summary = ({
                     </ReviewRbfLeftDetailsLineRight>
                 </LeftDetailsRow>
 
-                {isComposedFeeRateDifferent && (
+                {isComposedFeeRateDifferent && network.networkType === 'bitcoin' && (
                     <LeftDetailsRow>
                         <RateInfo>
                             <Translation id="TR_FEE_RATE_CHANGED" />

--- a/packages/suite/src/components/wallet/Fees/components/CustomFee.tsx
+++ b/packages/suite/src/components/wallet/Fees/components/CustomFee.tsx
@@ -261,7 +261,7 @@ export const CustomFee = ({
                 </Col>
             </Wrapper>
 
-            {isComposedFeeRateDifferent && (
+            {isComposedFeeRateDifferent && networkType === 'bitcoin' && (
                 <FeeRateWarning>
                     <Icon icon="INFO" size={12} color={theme.TYPE_LIGHTER_GREY} />
                     <Translation id="TR_FEE_ROUNDING_WARNING" />


### PR DESCRIPTION
## Description

Show the fee rate change warnings for bitcoin-like networks only

## Related Issue

Resolve #5907

