### PR TITLE
fix(suite): dashboard y-axis

### DIFF
--- a/packages/suite/src/components/suite/QuestionTooltip/index.tsx
+++ b/packages/suite/src/components/suite/QuestionTooltip/index.tsx
@@ -14,13 +14,18 @@ const Label = styled(H3)`
     color: ${props => props.theme.TYPE_DARK_GREY};
 `;
 
-interface Props {
+// Label container to avoid jumping when tooltip appears
+const FakeTooltipContainer = styled.div`
+    border-bottom: 1.5px solid transparent;
+`;
+
+interface QuestionTooltipProps {
     label?: JSX.Element | ExtendedMessageDescriptor['id'];
     tooltip?: JSX.Element | ExtendedMessageDescriptor['id'];
     className?: string;
 }
 
-export const QuestionTooltip = ({ label, tooltip, className }: Props) => (
+export const QuestionTooltip = ({ label, tooltip, className }: QuestionTooltipProps) => (
     <Wrapper className={className}>
         {label &&
             (tooltip ? (
@@ -31,7 +36,9 @@ export const QuestionTooltip = ({ label, tooltip, className }: Props) => (
                     <Label>{typeof label === 'string' ? <Translation id={label} /> : label}</Label>
                 </Tooltip>
             ) : (
-                <Label>{typeof label === 'string' ? <Translation id={label} /> : label}</Label>
+                <FakeTooltipContainer>
+                    <Label>{typeof label === 'string' ? <Translation id={label} /> : label}</Label>
+                </FakeTooltipContainer>
             ))}
     </Wrapper>
 );

--- a/packages/suite/src/components/suite/TransactionsGraph/components/CustomYAxisTick.tsx
+++ b/packages/suite/src/components/suite/TransactionsGraph/components/CustomYAxisTick.tsx
@@ -1,7 +1,6 @@
 import React, { useRef, useLayoutEffect } from 'react';
 import { useTheme } from '@trezor/components';
 import { FormattedFiatAmount, FormattedCryptoAmount } from '@suite-components';
-import BigNumber from 'bignumber.js';
 import { NetworkSymbol } from '@wallet-types';
 
 interface CommonProps {
@@ -31,9 +30,6 @@ export const CustomYAxisTick = ({
         }
     }, [ref, setWidth]);
 
-    const bValue = new BigNumber(payload.value);
-    const cryptoValue = bValue.toFixed();
-
     return (
         <g ref={ref} transform={`translate(${x},${y})`}>
             <text
@@ -46,15 +42,14 @@ export const CustomYAxisTick = ({
             >
                 {localCurrency && (
                     <FormattedFiatAmount
-                        currency={localCurrency}
                         value={payload.value}
-                        minimumFractionDigits={bValue.lt(1) ? 2 : 0}
-                        maximumFractionDigits={bValue.lt(1) ? 2 : 0}
+                        currency={localCurrency}
+                        minimumFractionDigits={0}
                     />
                 )}
 
                 {symbol && (
-                    <FormattedCryptoAmount value={cryptoValue} symbol={symbol} isRawString />
+                    <FormattedCryptoAmount value={payload.value} symbol={symbol} isRawString />
                 )}
             </text>
         </g>

--- a/packages/suite/src/components/suite/TransactionsGraph/index.tsx
+++ b/packages/suite/src/components/suite/TransactionsGraph/index.tsx
@@ -83,13 +83,7 @@ const TransactionsGraph = React.memo((props: Props) => {
             {!props.hideToolbar && (
                 <Toolbar>
                     <RangeSelector align="right" />
-                    {props.onRefresh && (
-                        <Icon
-                            size={14}
-                            icon="REFRESH"
-                            onClick={() => (props.onRefresh ? props.onRefresh() : undefined)}
-                        />
-                    )}
+                    {props.onRefresh && <Icon size={14} icon="REFRESH" onClick={props.onRefresh} />}
                 </Toolbar>
             )}
             <Description>

--- a/packages/suite/src/views/dashboard/components/PortfolioCard/index.tsx
+++ b/packages/suite/src/views/dashboard/components/PortfolioCard/index.tsx
@@ -28,6 +28,17 @@ const Body = styled.div`
     flex: 1;
 `;
 
+const SkeletonTransactionsGraphWrapper = styled.div`
+    display: flex;
+    flex-direction: column;
+    padding: 20px 0px;
+    height: 320px;
+`;
+
+const Wrapper = styled.div`
+    display: flex;
+`;
+
 const PortfolioCard = React.memo(() => {
     const { fiat, localCurrency } = useFiatValue();
     const { discovery, getDiscoveryStatus, isDiscoveryRunning } = useDiscovery();
@@ -55,7 +66,11 @@ const PortfolioCard = React.memo(() => {
         body = <Exception exception={discoveryStatus} discovery={discovery} />;
     } else if (discoveryStatus && discoveryStatus.status === 'loading') {
         body = dashboardGraphHidden ? null : (
-            <SkeletonTransactionsGraph data-test="@dashboard/loading" />
+            <SkeletonTransactionsGraphWrapper>
+                <Wrapper>
+                    <SkeletonTransactionsGraph data-test="@dashboard/loading" />
+                </Wrapper>
+            </SkeletonTransactionsGraphWrapper>
         );
     } else if (isDeviceEmpty) {
         body = <EmptyWallet />;


### PR DESCRIPTION
## Description

- Fixes cases in which there was a loss of decimal detail in the y-axis in the fiat dashboard chart
- UI: Fixes jumping of `Portfolio` on dashboard
- UI: Fixes overflow of chart skeleton 

## Related Issue

Closes #5955

## Screenshots (if appropriate):
![Screenshot 2022-09-12 at 14 01 33](https://user-images.githubusercontent.com/33235762/189649646-968975b0-2c56-4367-97fc-ca14428e04fe.png)

Before:
![Screenshot 2022-09-13 at 12 42 02](https://user-images.githubusercontent.com/33235762/189881222-9249dff6-2e32-4e0a-934c-9bf3677d4b0c.png)

Now:
![Screenshot 2022-09-13 at 12 41 39](https://user-images.githubusercontent.com/33235762/189881128-776f5050-7d31-465b-accd-1fa9dbb87cec.png)
