### PR TITLE
npm-release @trezor/connect patch [1/2]

### DIFF
--- a/packages/connect-explorer/package.json
+++ b/packages/connect-explorer/package.json
@@ -10,7 +10,7 @@
     },
     "dependencies": {
         "@trezor/components": "*",
-        "@trezor/connect-web": "9.0.0",
+        "@trezor/connect-web": "9.0.1",
         "markdown-it": "^12.3.2",
         "markdown-it-link-attributes": "^4.0.0",
         "markdown-it-replace-link": "^1.0.1",

--- a/packages/connect-iframe/package.json
+++ b/packages/connect-iframe/package.json
@@ -10,7 +10,7 @@
         "type-check": "tsc --build tsconfig.json"
     },
     "devDependencies": {
-        "@trezor/connect": "9.0.0",
+        "@trezor/connect": "9.0.1",
         "copy-webpack-plugin": "^11.0.0",
         "html-webpack-plugin": "^5.5.0",
         "jest": "^26.6.3",

--- a/packages/connect-popup/package.json
+++ b/packages/connect-popup/package.json
@@ -11,7 +11,7 @@
     },
     "dependencies": {
         "@trezor/components": "*",
-        "@trezor/connect": "9.0.0",
+        "@trezor/connect": "9.0.1",
         "@trezor/connect-ui": "*",
         "@trezor/urls": "*",
         "react": "17.0.2",

--- a/packages/connect-web/package.json
+++ b/packages/connect-web/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@trezor/connect-web",
-    "version": "9.0.0",
+    "version": "9.0.1",
     "author": "Trezor <info@trezor.io>",
     "homepage": "https://github.com/trezor/trezor-suite/tree/develop/packages/connect-web",
     "description": "High-level javascript interface for Trezor hardware wallet.",
@@ -35,7 +35,7 @@
         "build": "rimraf build && yarn build:inline && yarn build:webextension"
     },
     "dependencies": {
-        "@trezor/connect": "9.0.0",
+        "@trezor/connect": "9.0.1",
         "@trezor/utils": "^9.0.2",
         "events": "^3.3.0",
         "tslib": "^2.3.1"

--- a/packages/connect-web/src/webextension/trezor-usb-permissions.js
+++ b/packages/connect-web/src/webextension/trezor-usb-permissions.js
@@ -1,4 +1,4 @@
-const VERSION = '9.0.0';
+const VERSION = '9.0.1';
 const versionN = VERSION.split('.').map(s => parseInt(s, 10));
 // const DIRECTORY = `${ versionN[0] }${ (versionN[1] > 0 ? `.${versionN[1]}` : '') }/`;
 const DIRECTORY = `${versionN[0]}/`;

--- a/packages/connect/README.md
+++ b/packages/connect/README.md
@@ -1,6 +1,6 @@
 # @trezor/connect
 
-API version 9.0.0
+API version 9.0.1
 
 [![Build Status](https://github.com/trezor/trezor-suite/actions/workflows/connect-test.yml/badge.svg)](https://github.com/trezor/trezor-suite/actions/workflows/connect-test.yml)
 [![NPM](https://img.shields.io/npm/v/@trezor/connect.svg)](https://www.npmjs.org/package/@trezor/connect)

--- a/packages/connect/package.json
+++ b/packages/connect/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@trezor/connect",
-    "version": "9.0.0",
+    "version": "9.0.1",
     "author": "Trezor <info@trezor.io>",
     "homepage": "https://github.com/trezor/trezor-suite/tree/develop/packages/connect",
     "description": "High-level javascript interface for Trezor hardware wallet.",

--- a/packages/connect/src/data/version.ts
+++ b/packages/connect/src/data/version.ts
@@ -1,4 +1,4 @@
-export const VERSION = '9.0.0';
+export const VERSION = '9.0.1';
 
 const versionN = VERSION.split('.').map(s => parseInt(s, 10));
 

--- a/packages/suite-desktop/package.json
+++ b/packages/suite-desktop/package.json
@@ -184,7 +184,7 @@
     "dependencies": {
         "@sentry/electron": "3.0.0",
         "@suite-common/suite-utils": "*",
-        "@trezor/connect": "9.0.0",
+        "@trezor/connect": "9.0.1",
         "@trezor/connect-common": "*",
         "@trezor/request-manager": "*",
         "@trezor/suite-analytics": "*",

--- a/packages/suite/package.json
+++ b/packages/suite/package.json
@@ -42,7 +42,7 @@
         "@suite-common/wallet-types": "*",
         "@suite-common/wallet-utils": "*",
         "@trezor/components": "*",
-        "@trezor/connect": "9.0.0",
+        "@trezor/connect": "9.0.1",
         "@trezor/dom-utils": "*",
         "@trezor/env-utils": "*",
         "@trezor/react-utils": "*",

--- a/suite-common/connect-init/package.json
+++ b/suite-common/connect-init/package.json
@@ -17,7 +17,7 @@
         "@suite-common/suite-types": "*",
         "@suite-common/test-utils": "*",
         "@suite-native/state": "*",
-        "@trezor/connect": "9.0.0",
+        "@trezor/connect": "9.0.1",
         "@trezor/utils": "*"
     },
     "devDependencies": {

--- a/suite-common/notifications/package.json
+++ b/suite-common/notifications/package.json
@@ -13,7 +13,7 @@
     "dependencies": {
         "@suite-common/suite-types": "*",
         "@suite-common/wallet-config": "*",
-        "@trezor/connect": "9.0.0"
+        "@trezor/connect": "9.0.1"
     },
     "devDependencies": {
         "jest": "^26.6.3",

--- a/suite-common/redux-utils/package.json
+++ b/suite-common/redux-utils/package.json
@@ -15,7 +15,7 @@
         "@suite-common/suite-types": "*",
         "@suite-common/wallet-config": "*",
         "@suite-common/wallet-types": "*",
-        "@trezor/connect": "9.0.0",
+        "@trezor/connect": "9.0.1",
         "react": "17.0.2",
         "react-redux": "7.2.2",
         "redux": "^4.2.0"

--- a/suite-common/suite-types/package.json
+++ b/suite-common/suite-types/package.json
@@ -13,7 +13,7 @@
         "@reduxjs/toolkit": "^1.8.3",
         "@suite-common/metadata-types": "*",
         "@suite-common/wallet-config": "*",
-        "@trezor/connect": "9.0.0",
+        "@trezor/connect": "9.0.1",
         "@trezor/suite-data": "*"
     },
     "devDependencies": {

--- a/suite-common/test-utils/package.json
+++ b/suite-common/test-utils/package.json
@@ -15,7 +15,7 @@
         "@suite-common/suite-types": "*",
         "@suite-common/wallet-config": "*",
         "@suite-common/wallet-types": "*",
-        "@trezor/connect": "9.0.0",
+        "@trezor/connect": "9.0.1",
         "@trezor/utils": "*",
         "dropbox": "^10.32.0",
         "fake-indexeddb": "^3.1.7",

--- a/suite-common/wallet-core/package.json
+++ b/suite-common/wallet-core/package.json
@@ -21,7 +21,7 @@
         "@suite-common/wallet-config": "*",
         "@suite-common/wallet-types": "*",
         "@suite-common/wallet-utils": "*",
-        "@trezor/connect": "9.0.0",
+        "@trezor/connect": "9.0.1",
         "@trezor/utils": "*",
         "date-fns": "^2.29.1"
     },

--- a/suite-common/wallet-types/package.json
+++ b/suite-common/wallet-types/package.json
@@ -14,7 +14,7 @@
         "@suite-common/suite-utils": "*",
         "@suite-common/wallet-config": "*",
         "@suite-common/wallet-constants": "*",
-        "@trezor/connect": "9.0.0",
+        "@trezor/connect": "9.0.1",
         "@trezor/type-utils": "*",
         "@trezor/utils": "*",
         "react": "17.0.2",

--- a/suite-common/wallet-utils/package.json
+++ b/suite-common/wallet-utils/package.json
@@ -23,7 +23,7 @@
         "@suite-common/wallet-config": "*",
         "@suite-common/wallet-constants": "*",
         "@suite-common/wallet-types": "*",
-        "@trezor/connect": "9.0.0",
+        "@trezor/connect": "9.0.1",
         "@trezor/urls": "*",
         "@trezor/utils": "*",
         "bignumber.js": "^9.1.0",

--- a/suite-native/app/package.json
+++ b/suite-native/app/package.json
@@ -29,7 +29,7 @@
         "@suite-native/module-settings": "*",
         "@suite-native/navigation": "*",
         "@suite-native/state": "*",
-        "@trezor/connect": "9.0.0",
+        "@trezor/connect": "9.0.1",
         "@trezor/styles": "*",
         "@trezor/theme": "*",
         "@trezor/transport-native": "*",

--- a/suite-native/module-accounts-import/package.json
+++ b/suite-native/module-accounts-import/package.json
@@ -26,7 +26,7 @@
         "@suite-native/module-devices": "*",
         "@suite-native/module-settings": "*",
         "@suite-native/navigation": "*",
-        "@trezor/connect": "9.0.0",
+        "@trezor/connect": "9.0.1",
         "@trezor/icons": "*",
         "@trezor/styles": "*",
         "react": "^17.0.2",

--- a/suite-native/state/package.json
+++ b/suite-native/state/package.json
@@ -17,7 +17,7 @@
         "@suite-native/home-graph": "*",
         "@suite-native/module-devices": "*",
         "@suite-native/module-settings": "*",
-        "@trezor/connect": "9.0.0",
+        "@trezor/connect": "9.0.1",
         "@trezor/styles": "*",
         "@trezor/utils": "*",
         "redux-flipper": "2.0.2"

--- a/yarn.lock
+++ b/yarn.lock
@@ -5959,7 +5959,7 @@ __metadata:
     "@suite-common/suite-types": "*"
     "@suite-common/test-utils": "*"
     "@suite-native/state": "*"
-    "@trezor/connect": 9.0.0
+    "@trezor/connect": 9.0.1
     "@trezor/utils": "*"
     jest: ^26.6.3
     redux-mock-store: ^1.5.4
@@ -6007,7 +6007,7 @@ __metadata:
   dependencies:
     "@suite-common/suite-types": "*"
     "@suite-common/wallet-config": "*"
-    "@trezor/connect": 9.0.0
+    "@trezor/connect": 9.0.1
     jest: ^26.6.3
     typescript: 4.7.4
   languageName: unknown
@@ -6022,7 +6022,7 @@ __metadata:
     "@suite-common/suite-types": "*"
     "@suite-common/wallet-config": "*"
     "@suite-common/wallet-types": "*"
-    "@trezor/connect": 9.0.0
+    "@trezor/connect": 9.0.1
     jest: ^26.6.3
     react: 17.0.2
     react-redux: 7.2.2
@@ -6056,7 +6056,7 @@ __metadata:
     "@reduxjs/toolkit": ^1.8.3
     "@suite-common/metadata-types": "*"
     "@suite-common/wallet-config": "*"
-    "@trezor/connect": 9.0.0
+    "@trezor/connect": 9.0.1
     "@trezor/suite-data": "*"
     jest: ^26.6.3
     typescript: 4.7.4
@@ -6084,7 +6084,7 @@ __metadata:
     "@suite-common/suite-types": "*"
     "@suite-common/wallet-config": "*"
     "@suite-common/wallet-types": "*"
-    "@trezor/connect": 9.0.0
+    "@trezor/connect": 9.0.1
     "@trezor/utils": "*"
     dropbox: ^10.32.0
     fake-indexeddb: ^3.1.7
@@ -6127,7 +6127,7 @@ __metadata:
     "@suite-common/wallet-config": "*"
     "@suite-common/wallet-types": "*"
     "@suite-common/wallet-utils": "*"
-    "@trezor/connect": 9.0.0
+    "@trezor/connect": 9.0.1
     "@trezor/utils": "*"
     date-fns: ^2.29.1
     jest: ^26.6.3
@@ -6143,7 +6143,7 @@ __metadata:
     "@suite-common/suite-utils": "*"
     "@suite-common/wallet-config": "*"
     "@suite-common/wallet-constants": "*"
-    "@trezor/connect": 9.0.0
+    "@trezor/connect": 9.0.1
     "@trezor/type-utils": "*"
     "@trezor/utils": "*"
     jest: ^26.6.3
@@ -6168,7 +6168,7 @@ __metadata:
     "@suite-common/wallet-config": "*"
     "@suite-common/wallet-constants": "*"
     "@suite-common/wallet-types": "*"
-    "@trezor/connect": 9.0.0
+    "@trezor/connect": 9.0.1
     "@trezor/urls": "*"
     "@trezor/utils": "*"
     "@types/pdfmake": ^0.1.21
@@ -6242,7 +6242,7 @@ __metadata:
     "@suite-native/module-devices": "*"
     "@suite-native/module-settings": "*"
     "@suite-native/navigation": "*"
-    "@trezor/connect": 9.0.0
+    "@trezor/connect": 9.0.1
     "@trezor/icons": "*"
     "@trezor/styles": "*"
     jest: ^26.6.3
@@ -6358,7 +6358,7 @@ __metadata:
     "@suite-native/home-graph": "*"
     "@suite-native/module-devices": "*"
     "@suite-native/module-settings": "*"
-    "@trezor/connect": 9.0.0
+    "@trezor/connect": 9.0.1
     "@trezor/styles": "*"
     "@trezor/utils": "*"
     jest: ^26.6.3
@@ -6605,7 +6605,7 @@ __metadata:
   resolution: "@trezor/connect-explorer@workspace:packages/connect-explorer"
   dependencies:
     "@trezor/components": "*"
-    "@trezor/connect-web": 9.0.0
+    "@trezor/connect-web": 9.0.1
     "@types/markdown-it": 12.2.3
     "@types/markdown-it-link-attributes": 3.0.1
     "@types/react-router": ^5.1.11
@@ -6643,7 +6643,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@trezor/connect-iframe@workspace:packages/connect-iframe"
   dependencies:
-    "@trezor/connect": 9.0.0
+    "@trezor/connect": 9.0.1
     copy-webpack-plugin: ^11.0.0
     html-webpack-plugin: ^5.5.0
     jest: ^26.6.3
@@ -6689,7 +6689,7 @@ __metadata:
   resolution: "@trezor/connect-popup@workspace:packages/connect-popup"
   dependencies:
     "@trezor/components": "*"
-    "@trezor/connect": 9.0.0
+    "@trezor/connect": 9.0.1
     "@trezor/connect-ui": "*"
     "@trezor/urls": "*"
     "@types/react": ^17.0.0
@@ -6720,11 +6720,11 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@trezor/connect-web@9.0.0, @trezor/connect-web@workspace:packages/connect-web":
+"@trezor/connect-web@9.0.1, @trezor/connect-web@workspace:packages/connect-web":
   version: 0.0.0-use.local
   resolution: "@trezor/connect-web@workspace:packages/connect-web"
   dependencies:
-    "@trezor/connect": 9.0.0
+    "@trezor/connect": 9.0.1
     "@trezor/utils": ^9.0.2
     "@types/chrome": 0.0.181
     "@types/w3c-web-usb": ^1.0.5
@@ -6738,7 +6738,7 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@trezor/connect@9.0.0, @trezor/connect@workspace:packages/connect":
+"@trezor/connect@9.0.1, @trezor/connect@workspace:packages/connect":
   version: 0.0.0-use.local
   resolution: "@trezor/connect@workspace:packages/connect"
   dependencies:
@@ -6989,7 +6989,7 @@ __metadata:
   dependencies:
     "@sentry/electron": 3.0.0
     "@suite-common/suite-utils": "*"
-    "@trezor/connect": 9.0.0
+    "@trezor/connect": 9.0.1
     "@trezor/connect-common": "*"
     "@trezor/request-manager": "*"
     "@trezor/suite-analytics": "*"
@@ -7043,7 +7043,7 @@ __metadata:
     "@suite-native/module-settings": "*"
     "@suite-native/navigation": "*"
     "@suite-native/state": "*"
-    "@trezor/connect": 9.0.0
+    "@trezor/connect": 9.0.1
     "@trezor/styles": "*"
     "@trezor/theme": "*"
     "@trezor/transport-native": "*"
@@ -7161,7 +7161,7 @@ __metadata:
     "@testing-library/react": 12.1.5
     "@testing-library/user-event": 12.8.3
     "@trezor/components": "*"
-    "@trezor/connect": 9.0.0
+    "@trezor/connect": 9.0.1
     "@trezor/dom-utils": "*"
     "@trezor/env-utils": "*"
     "@trezor/react-utils": "*"


### PR DESCRIPTION
## @trezor/connect npm release

-   [x] Bump version in all @trezor/connect\* packages (except plugin packages). `yarn workspace @trezor/connect version:<beta|patch|minor|major>`
-   [x] Make sure you have released all npm dependencies. If unsure run `node ./ci/scripts/check-npm-dependencies.js connect`. Please note that this script will report unreleased dependencies even for changes that do not affect runtime (READMEs etc.)
-   [x] If there are any unreleased npm dependencies you should [release them](./npm-packages.md)
-   [x] Make sure CHANGELOG files have been updated
-   [x] Release npm packages for `@trezor/connect` and `@trezor/connect-web` [from gitlab](https://gitlab.com/satoshilabs/trezor/trezor-suite/-/pipelines)
