### PR TITLE
fix(suite): hide firmware type suggestion if no coin is enabled

### DIFF
--- a/packages/suite/src/views/settings/coins/SettingsCoins.tsx
+++ b/packages/suite/src/views/settings/coins/SettingsCoins.tsx
@@ -30,9 +30,9 @@ export const SettingsCoins = () => {
     const { device } = useDevice();
 
     const bitcoinOnlyFirmware = device?.firmwareType === 'bitcoin-only';
-    const onlyBitcoinEnabled = enabledNetworks.every(coin =>
-        ['btc', 'regtest', 'test'].includes(coin),
-    );
+    const onlyBitcoinEnabled =
+        !!enabledNetworks.length &&
+        enabledNetworks.every(coin => ['btc', 'regtest', 'test'].includes(coin));
     const showDeviceBanner = device?.connected === false; // device is remembered and disconnected
     const showFirmwareTypeBanner =
         !firmwareTypeBannerClosed &&


### PR DESCRIPTION
Hide firmware type suggestion when no coins are enabled.

## Description

When Universal firmware is installed and only bitcoin is enabled, a suggestion to install Bitcoin-only firmware is displayed. However, it was also (incorrectly) displayed when no coins were enabled - this PR fixes it.

## Related Issue
#4661 

## Screenshots (if appropriate):
With only bitcoin enabled:
![Screenshot 2022-09-12 at 16 54 50](https://user-images.githubusercontent.com/42465546/189686603-c2a5de04-49a2-45a1-974f-c86f427d1b8f.png)
With no coins enabled:
![Screenshot 2022-09-12 at 16 55 13](https://user-images.githubusercontent.com/42465546/189686693-56b984dc-3bd9-4c21-8c89-3842e2dbfd9b.png)

**QA:** Unlike previously, when Universal firmware is installed and no coin are enabled, you should not see any message at the top.
