### PR TITLE
Revert "feat(suite): Enable amount unit switching only in debug mode"

### DIFF
--- a/packages/integration-tests/projects/suite-web/tests/wallet/bitcoin-send-form.test.ts
+++ b/packages/integration-tests/projects/suite-web/tests/wallet/bitcoin-send-form.test.ts
@@ -51,7 +51,7 @@ describe('Send form for bitcoin', () => {
         cy.getTestElement('@wallet/send/outputs-and-options').matchImageSnapshot('bitcoin-send');
     });
 
-    it.skip('switch display units to satoshis, fill a form in satoshis and send', () => {
+    it('switch display units to satoshis, fill a form in satoshis and send', () => {
         cy.getTestElement('amount-unit-switch/regtest').click();
 
         // test adding and removing outputs
@@ -66,7 +66,7 @@ describe('Send form for bitcoin', () => {
         cy.getTestElement('@wallet/send/outputs-and-options').matchImageSnapshot(
             'bitcoin-send-sats',
         );
-    }); // TEMPORARY SOLUTION!
+    });
 });
 
 // todo: send tx

--- a/packages/suite/src/components/suite/AmountUnitSwitchWrapper.tsx
+++ b/packages/suite/src/components/suite/AmountUnitSwitchWrapper.tsx
@@ -4,7 +4,6 @@ import { Tooltip, variables } from '@trezor/components';
 import { useBitcoinAmountUnit } from '@wallet-hooks/useBitcoinAmountUnit';
 import { NetworkSymbol } from '@wallet-types';
 import { Translation } from './Translation';
-import { useSelector } from '@suite-hooks/useSelector';
 
 const Container = styled.div`
     position: relative;
@@ -30,15 +29,10 @@ interface AmountUnitSwitchWrapperProps {
 }
 
 export const AmountUnitSwitchWrapper = ({ symbol, children }: AmountUnitSwitchWrapperProps) => {
-    const { isInDebugMode } = useSelector(state => ({
-        isInDebugMode: state.suite.settings.debug.showDebugMenu,
-    }));
-
     const { areSatsDisplayed, toggleBitcoinAmountUnits, areUnitsSupportedByNetwork } =
         useBitcoinAmountUnit(symbol);
 
-    // TEMPORARY SOLUTION!
-    if (!areUnitsSupportedByNetwork || !isInDebugMode) {
+    if (!areUnitsSupportedByNetwork) {
         return <>{children}</>;
     }
 

--- a/packages/suite/src/views/settings/general/SettingsGeneral.tsx
+++ b/packages/suite/src/views/settings/general/SettingsGeneral.tsx
@@ -24,11 +24,10 @@ import { BitcoinAmountUnit } from './BitcoinAmountUnit';
 import { NETWORKS } from '@wallet-config';
 
 export const SettingsGeneral = () => {
-    const { desktopUpdate, isTorEnabled, enabledNetworks, isInDebugMode } = useSelector(state => ({
+    const { desktopUpdate, isTorEnabled, enabledNetworks } = useSelector(state => ({
         desktopUpdate: state.desktopUpdate,
         isTorEnabled: getIsTorEnabled(state.suite.torStatus),
         enabledNetworks: state.wallet.settings.enabledNetworks,
-        isInDebugMode: state.suite.settings.debug.showDebugMenu,
     }));
 
     const hasBitcoinNetworks = NETWORKS.some(
@@ -36,15 +35,12 @@ export const SettingsGeneral = () => {
             enabledNetworks.includes(symbol) && features?.includes('amount-unit'),
     );
 
-    // TEMPORARY SOLUTION!
-    const isUnitSectionShown = hasBitcoinNetworks && isInDebugMode;
-
     return (
         <SettingsLayout data-test="@settings/index">
             <SettingsSection title={<Translation id="TR_LOCALIZATION" />} icon="FLAG">
                 <Language />
                 <Fiat />
-                {isUnitSectionShown && <BitcoinAmountUnit />}
+                {hasBitcoinNetworks && <BitcoinAmountUnit />}
             </SettingsSection>
 
             <SettingsSection title={<Translation id="TR_LABELING" />} icon="TAG_MINIMAL">


### PR DESCRIPTION
This reverts commit f2ba7592defbc08711b8bc6baea8a102b7f9f398.

<!--- Provide a general summary of your changes in the Title above -->

## Description

Enable bitcoin unit selection for everyone, no need to be in debug mode anymore.

## Related Issue

https://github.com/trezor/trezor-suite/issues/3004

## Screenshots (if appropriate):
<img width="809" alt="image" src="https://user-images.githubusercontent.com/3729633/189844861-ee98151b-0029-482f-8f13-eaf3977e0c82.png">
