### PR TITLE
fix: correct fee rate in tx detail

### DIFF
--- a/packages/blockchain-link/CHANGELOG.md
+++ b/packages/blockchain-link/CHANGELOG.md
@@ -1,3 +1,8 @@
+# 2.1.5
+
+-   added Transaction.feeRate
+-   use Transaction.size provided by Blockbook instead of computing it from hex if available
+
 # 2.1.4
 
 -   add missing ADA types

--- a/packages/blockchain-link/src/types/blockbook.ts
+++ b/packages/blockchain-link/src/types/blockbook.ts
@@ -113,6 +113,8 @@ export interface Transaction {
     fees: string;
     hex: string;
     lockTime?: number;
+    vsize?: number;
+    size?: number;
     ethereumSpecific?: {
         status: number;
         nonce: number;

--- a/packages/blockchain-link/src/types/common.ts
+++ b/packages/blockchain-link/src/types/common.ts
@@ -116,6 +116,8 @@ export interface Transaction {
         deposit?: string;
     };
     details: TransactionDetail;
+    vsize?: number;
+    feeRate?: string;
 }
 
 /* Account */

--- a/packages/blockchain-link/src/workers/blockbook/utils.ts
+++ b/packages/blockchain-link/src/workers/blockbook/utils.ts
@@ -177,6 +177,14 @@ export const transformTransaction = (
                   .toString()
             : tx.fees;
 
+    // some instances of bb don't send vsize yet
+    const feeRate = tx.vsize
+        ? new BigNumber(fee).div(tx.vsize).decimalPlaces(2).toString()
+        : undefined;
+
+    // some instances of bb don't send size yet
+    const size = tx.size || typeof tx.hex === 'string' ? tx.hex.length / 2 : 0;
+
     return {
         type,
 
@@ -188,6 +196,8 @@ export const transformTransaction = (
 
         amount,
         fee,
+        vsize: tx.vsize, // some instances of bb don't send vsize yet
+        feeRate,
 
         targets: targets.filter(t => typeof t === 'object').map(t => transformTarget(t, myOutputs)),
         tokens: myTokens,
@@ -196,7 +206,7 @@ export const transformTransaction = (
         details: {
             vin: inputs.map(enhanceVinVout(myAddresses)),
             vout: outputs.map(enhanceVinVout(myAddresses)),
-            size: typeof tx.hex === 'string' ? tx.hex.length / 2 : 0,
+            size,
             totalInput: totalInput.toString(),
             totalOutput: totalOutput.toString(),
         },

--- a/packages/blockchain-link/src/workers/blockfrost/utils.ts
+++ b/packages/blockchain-link/src/workers/blockfrost/utils.ts
@@ -273,6 +273,7 @@ export const transformTransaction = (
             withdrawal,
             deposit,
         },
+        feeRate: undefined,
         details: {
             vin: inputs.map(enhanceVinVout(myAddresses)),
             vout: outputs.map(enhanceVinVout(myAddresses)),

--- a/packages/blockchain-link/src/workers/electrum/utils/transaction.ts
+++ b/packages/blockchain-link/src/workers/electrum/utils/transaction.ts
@@ -38,7 +38,19 @@ const isNotCoinbase = (item: TxIn | TxCoinbase): item is TxIn => (item as any).t
 const formatTransaction =
     (getVout: GetVout, getSpent: GetSpent, currentHeight: number) =>
     (tx: TransactionVerbose): BlockbookTransaction => {
-        const { txid, version, vin, vout, hex, blockhash, confirmations, blocktime, locktime } = tx;
+        const {
+            txid,
+            version,
+            vin,
+            vout,
+            hex,
+            blockhash,
+            confirmations,
+            blocktime,
+            locktime,
+            vsize,
+            size,
+        } = tx;
         const vinRegular = vin.filter(isNotCoinbase);
         const value = vout.map(({ value }) => value).reduce((a, b) => a + b, 0);
         const valueIn = vinRegular
@@ -56,6 +68,8 @@ const formatTransaction =
             value: btcToSat(value),
             valueIn: btcToSat(valueIn),
             fees: btcToSat(valueIn - value),
+            vsize,
+            size,
             vin: vinRegular.map(({ txid, vout, sequence, n }, index) => ({
                 txid,
                 vout,

--- a/packages/blockchain-link/src/workers/ripple/utils.ts
+++ b/packages/blockchain-link/src/workers/ripple/utils.ts
@@ -47,6 +47,7 @@ export const transformTransaction = (descriptor: string, tx: any): Transaction =
             blockHash: tx.hash,
             targets: [],
             tokens: [],
+            feeRate: undefined,
             details: {
                 vin: [],
                 vout: [],
@@ -80,6 +81,7 @@ export const transformTransaction = (descriptor: string, tx: any): Transaction =
             },
         ],
         tokens: [],
+        feeRate: undefined,
         details: {
             vin: [],
             vout: [],

--- a/packages/blockchain-link/tests/unit/fixtures/getAccountInfo-blockbook.ts
+++ b/packages/blockchain-link/tests/unit/fixtures/getAccountInfo-blockbook.ts
@@ -608,6 +608,95 @@ const fixtures: {
             misc: undefined,
         },
     },
+    {
+        description: 'BTC account with vsize and feeRate',
+        params: {
+            descriptor:
+                'vpub5YX1yJFY8E236pH3iNvCpThsXLxoQoC4nwraaS5h4TZwaSp1Gg9SQoxCsrumxjh7nZRQQkNfH29TEDeMvAZVmD3rpmsDnFc5Sj4JgJG6m4b',
+        },
+
+        serverFixtures: [
+            {
+                method: 'getAccountInfo',
+                response: {
+                    data: {
+                        page: 1,
+                        totalPages: 1,
+                        itemsOnPage: 25,
+                        address:
+                            'vpub5YX1yJFY8E236pH3iNvCpThsXLxoQoC4nwraaS5h4TZwaSp1Gg9SQoxCsrumxjh7nZRQQkNfH29TEDeMvAZVmD3rpmsDnFc5Sj4JgJG6m4b',
+                        balance: '41159',
+                        totalReceived: '773325477',
+                        totalSent: '773284318',
+                        unconfirmedBalance: '0',
+                        unconfirmedTxs: 0,
+                        txs: 1,
+                        transactions: [
+                            {
+                                txid: '7f42f8e47f8af81a333ec622bf5688499f00e1f9b2d5f89865609e1663ad4a89',
+                                version: 1,
+                                vin: [],
+                                vout: [],
+                                blockHash:
+                                    '00000000000ec214f1cc387e3d6f781118378afca5c4b0a325f8f97353f1365d',
+                                blockHeight: 2349586,
+                                confirmations: 4,
+                                blockTime: 1665050739,
+                                size: 222,
+                                vsize: 141,
+                                value: '40577',
+                                valueIn: '40859',
+                                fees: '282',
+                                hex: '01000000000101a5818c7911116e6dd1e1f2017701071f3165aeff48d296cfb439ed9f266aefc30100000000fdffffff02d007000000000000160014f8e00fa515aea7693cf042c1e18d9ab345185cecb196000000000000160014fcf1910a28fba7613b92ee64aa6615e1a31a17330247304402202b4671022b7ce8d40775565b8c90cdd63e58188475f2a9658a89e2765fbf92d902203b29a451839e5c6983dec5139cb376e015cf8c54cb51deb8d21b53d6ba0773b401210355b9248c4643574b56c8beae840d0f341da456855f7f0a88527d66282fd6fb4900000000',
+                            },
+                        ],
+                        tokens: [],
+                    },
+                },
+            },
+        ],
+
+        response: {
+            descriptor:
+                'vpub5YX1yJFY8E236pH3iNvCpThsXLxoQoC4nwraaS5h4TZwaSp1Gg9SQoxCsrumxjh7nZRQQkNfH29TEDeMvAZVmD3rpmsDnFc5Sj4JgJG6m4b',
+            empty: false,
+            balance: '41159',
+            availableBalance: '41159',
+            history: {
+                total: 1,
+                unconfirmed: 0,
+                transactions: [
+                    {
+                        type: 'unknown',
+                        txid: '7f42f8e47f8af81a333ec622bf5688499f00e1f9b2d5f89865609e1663ad4a89',
+                        blockTime: 1665050739,
+                        blockHeight: 2349586,
+                        blockHash:
+                            '00000000000ec214f1cc387e3d6f781118378afca5c4b0a325f8f97353f1365d',
+                        amount: '40577',
+                        fee: '282',
+                        vsize: 141,
+                        feeRate: '2',
+                        targets: [],
+                        tokens: [],
+                        details: {
+                            vin: [],
+                            vout: [],
+                            size: 222,
+                            totalInput: '0',
+                            totalOutput: '0',
+                        },
+                    },
+                ],
+            },
+
+            page: {
+                index: 1,
+                size: 25,
+                total: 1,
+            },
+        },
+    },
 ];
 
 export default fixtures;

--- a/packages/suite/src/components/suite/modals/TransactionDetail/components/BasicDetails.tsx
+++ b/packages/suite/src/components/suite/modals/TransactionDetail/components/BasicDetails.tsx
@@ -9,11 +9,11 @@ import {
 } from '@suite-components';
 import { WalletAccountTransaction, Network } from '@wallet-types';
 import {
-    getFeeRate,
     isTxFinal,
     getTxIcon,
     isPending,
     getFeeUnits,
+    getFeeRate,
 } from '@suite-common/wallet-utils';
 import { TransactionHeader } from '@suite/components/wallet/TransactionItem/components/TransactionHeader';
 import { fromWei } from 'web3-utils';
@@ -277,7 +277,14 @@ export const BasicDetails = ({ tx, confirmations, network, explorerUrl }: BasicD
                             <Translation id="TR_FEE_RATE" />
                         </Title>
 
-                        <Value>{`${getFeeRate(tx)} ${getFeeUnits('bitcoin')}`}</Value>
+                        <Value>
+                            {/* tx.feeRate was added in @trezor/blockchain-link 2.1.5 meaning that users 
+                            might have locally saved old transactions without this field. since we 
+                            cant reliably migrate this data, we are keeping old way of displaying feeRate in place */}
+                            {`${tx?.feeRate ? tx.feeRate : getFeeRate(tx)} ${getFeeUnits(
+                                'bitcoin',
+                            )}`}
+                        </Value>
 
                         {/* RBF Status */}
                         <Title>

--- a/suite-common/wallet-utils/src/transactionUtils.ts
+++ b/suite-common/wallet-utils/src/transactionUtils.ts
@@ -522,16 +522,16 @@ const getBitcoinRbfParams = (
 
     if (!utxo.length || !outputs.length || outputs.length !== vout.length) return;
 
-    // calculate fee rate, TODO: add this to blockchain-link tx details
-    const feeRate = getFeeRate(tx);
-
     // TODO: get other params, like locktime etc.
     return {
         txid: tx.txid,
         utxo,
         outputs,
         changeAddress,
-        feeRate,
+        // fee rate is calculated in blockchain-link but only for newer versions of blockbook. users
+        // that have old transactions saved in their database might not have this data so legacy way
+        // of displaying fee rate is kept here
+        feeRate: tx.feeRate || getFeeRate(tx),
         baseFee: parseInt(tx.fee, 10),
     };
 };


### PR DESCRIPTION
We can finally resolve #3355 (specifically https://github.com/trezor/trezor-suite/issues/3355#issuecomment-1240449933) 

Changes: 
- `size` seems to be available from backends, doesnt need to be calculated locally anymore. Not avaialble everywhere though, so fallback kept in place. 
- added `tx.vsize` field which is now available from backends. Not everywhere, fallback. 
- added `tx.feeRate` field

Notes: 
- I was considering `tx.feeRate` or `tx.details.feeRate` option. But decided for the first one, details should be imho removed in some future version as it is concept that only suite is using and blockchain-link does not need to know about that. 
- As I mentioned, there are fallbacks and there are 2 reasons for them. Not all backends have been updated yet. This one could be solved and fallback thus removed. But we also need to cover transactions saved in users local state. 
- We could consider migration but we would either need to A] refetch data during migration which is imho NO-GO, B] compute vsize from data we already have but it would be quite heavy-weight and I am not sure if doable, maybe yes. My current gut feeling is that it is not worth doing it.
- I am not sure about this newly added test fixture [e4aa0d9](https://github.com/trezor/trezor-suite/pull/6261/commits/e4aa0d98b7ffbc4abaf3c4d1b82f80a3f31155da) it has so many unrelated and unreal fields. I don't like it very much :thinking: 

Commits: 

QA: 
- please check transactions list for all btc like coins. fee rate in tx detail should match fee rate in blockbook. some blockbooks might not have this new feature deployed yet.
- try rbf transaction for btc and testnet
- altcoins should not break (eth, ada, ripple)

Related issues: 
-  https://github.com/trezor/blockbook/issues/559
- part of https://github.com/trezor/trezor-suite/issues/3327