### PR TITLE
test(suite): add getPhysicalDeviceCount unit tests

### DIFF
--- a/packages/suite/src/utils/suite/__fixtures__/device.ts
+++ b/packages/suite/src/utils/suite/__fixtures__/device.ts
@@ -746,6 +746,22 @@ const parseFirmwareChangelog = [
     },
 ];
 
+const getPhysicalDeviceCount = [
+    {
+        description: 'getPhysicalDeviceCount',
+        devices: [d({ id: '1' }), d({ path: '2' }), d({ id: '2' })],
+        result: 2,
+    },
+];
+
+const getPhysicalDeviceUniqueIds = [
+    {
+        description: 'getPhysicalDeviceUniqueIds',
+        devices: [d({ id: '1' }), d({ path: '2' }), d({ id: '2' })],
+        result: ['1', '2'],
+    },
+];
+
 export default {
     getStatus,
     isDeviceAccessible,
@@ -761,4 +777,6 @@ export default {
     getDeviceInstances,
     isDeviceRemembered,
     parseFirmwareChangelog,
+    getPhysicalDeviceCount,
+    getPhysicalDeviceUniqueIds,
 };

--- a/packages/suite/src/utils/suite/__tests__/device.test.ts
+++ b/packages/suite/src/utils/suite/__tests__/device.test.ts
@@ -128,3 +128,19 @@ describe('parseFirmwareChangelog', () => {
         });
     });
 });
+
+describe('getPhysicalDeviceCount', () => {
+    fixtures.getPhysicalDeviceCount.forEach(f => {
+        it(f.description, () => {
+            expect(utils.getPhysicalDeviceCount(f.devices as any)).toEqual(f.result);
+        });
+    });
+});
+
+describe('getPhysicalDeviceUniqueIds', () => {
+    fixtures.getPhysicalDeviceUniqueIds.forEach(f => {
+        it(f.description, () => {
+            expect(utils.getPhysicalDeviceUniqueIds(f.devices as any)).toEqual(f.result);
+        });
+    });
+});


### PR DESCRIPTION
follow-up for #6279 and #6283

initially I thought I'd refactor these methods a bit so I started writing some missing tests but then I ended up not using this utility. 
also we should revisit those device utils 