### PR TITLE
fix: correct detection for multiple devices in firmware update vol 2

### DIFF
--- a/packages/suite/src/components/firmware/FirmwareInitial.tsx
+++ b/packages/suite/src/components/firmware/FirmwareInitial.tsx
@@ -90,7 +90,10 @@ export const FirmwareInitial = ({
     const { goToNextStep, updateAnalytics } = useOnboarding();
     const theme = useTheme();
     const devices = useSelector(state => state.devices);
-    const multipleDevicesConnected = devices.filter(device => device.connected).length > 1;
+
+    // todo: move to utils device.ts
+    const devicesConnected = devices.filter(device => device?.connected);
+    const multipleDevicesConnected = [...new Set(devicesConnected.map(d => d.path))].length > 1;
 
     useEffect(() => {
         // When the user choses to install a new firmware update we will ask him/her to reconnect a device in bootloader mode.


### PR DESCRIPTION
Look before you leap, right? #6279 was not enough. We still need to pick only unique ids. Without this fix, in case you would have 1 device with 2 instances, you would have fw update blocked. 

https://github.com/trezor/trezor-suite/pull/new/fix-multiple-vol2