### PR TITLE
fix(ci): make suite desktop test manual available when the automatic is not running

### DIFF
--- a/ci/test.yml
+++ b/ci/test.yml
@@ -151,8 +151,9 @@ suite desktop:
 
 suite desktop manual:
   extends: .e2e desktop
-  only:
+  except:
     <<: *run_everything_rules
+  when: manual
 
 # @trezor/transport
 .e2e transport:


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

The manual job to run suite desktop test should be allowed to be run except when `run_everything_rules` because in that case it runs always because of the previous rule.
