### PR TITLE
chore(suite-native): rename accounts to assets in tab bar

### DIFF
--- a/suite-native/app/src/navigation/routes.ts
+++ b/suite-native/app/src/navigation/routes.ts
@@ -6,14 +6,14 @@ export const rootTabsOptions: TabsOptions = {
         label: 'Home',
     },
     [AppTabsRoutes.AccountsStack]: {
-        iconName: 'standardWallet',
-        label: 'Accounts',
+        iconName: 'discover',
+        label: 'My Assets',
     },
     [AppTabsRoutes.Action]: {
         iconName: 'action',
     },
     [AppTabsRoutes.Prices]: {
-        iconName: 'discover',
+        iconName: 'prices',
         label: 'Discover',
     },
     [AppTabsRoutes.SettingsStack]: {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

accounts to assets renamed in tab bar

## Related Issue

Resolve https://github.com/trezor/trezor-suite/issues/6277

## Screenshots (if appropriate):

![Snímek obrazovky 2022-09-15 v 12 15 50](https://user-images.githubusercontent.com/2227592/190378835-01f598f2-65fc-48b0-8d1c-811e34ffd627.png)
