### PR TITLE
feat(suite-native): One hidden device with all imported accounts

### DIFF
--- a/suite-common/suite-types/src/account.ts
+++ b/suite-common/suite-types/src/account.ts
@@ -1,1 +1,1 @@
-export type AccountHash = string;
+export type AccountKey = string;

--- a/suite-common/wallet-core/src/accounts/accountsActions.ts
+++ b/suite-common/wallet-core/src/accounts/accountsActions.ts
@@ -1,7 +1,12 @@
 import { createAction } from '@reduxjs/toolkit';
 
 import { AccountInfo } from '@trezor/connect';
-import { Account, SelectedAccountStatus, DiscoveryItem } from '@suite-common/wallet-types';
+import {
+    Account,
+    SelectedAccountStatus,
+    DiscoveryItem,
+    MetadataItem,
+} from '@suite-common/wallet-types';
 import {
     enhanceAddresses,
     enhanceTokens,
@@ -35,6 +40,7 @@ const createAccount = createAction(
         deviceState: string,
         discoveryItem: DiscoveryItem,
         accountInfo: AccountInfo,
+        accountLabel?: MetadataItem,
     ): { payload: Account } => ({
         payload: {
             deviceState,
@@ -72,6 +78,7 @@ const createAccount = createAction(
                 key: accountInfo.legacyXpub || accountInfo.descriptor,
                 fileName: '',
                 aesKey: '',
+                accountLabel,
                 outputLabels: {},
                 addressLabels: {},
             },

--- a/suite-common/wallet-core/src/transactions/transactionsReducer.ts
+++ b/suite-common/wallet-core/src/transactions/transactionsReducer.ts
@@ -2,7 +2,7 @@ import { Account, WalletAccountTransaction } from '@suite-common/wallet-types';
 import { findTransaction } from '@suite-common/wallet-utils';
 import { settingsCommonConfig } from '@suite-common/suite-config';
 import { createReducerWithExtraDeps } from '@suite-common/redux-utils';
-import { AccountHash } from '@suite-common/suite-types';
+import { AccountKey } from '@suite-common/suite-types';
 
 import { fiatRatesActions } from '../fiat-rates/fiatRatesActions';
 import { accountsActions } from '../accounts/accountsActions';
@@ -11,8 +11,8 @@ import { transactionsActions } from './transactionsActions';
 export interface TransactionsState {
     isLoading: boolean;
     error: string | null;
-    // Key is accountHash and value is sparse array of fetched txs
-    transactions: { [key: AccountHash]: WalletAccountTransaction[] };
+    // Key is accountKey and value is sparse array of fetched txs
+    transactions: { [key: AccountKey]: WalletAccountTransaction[] };
 }
 
 export const transactionsInitialState: TransactionsState = {
@@ -27,12 +27,12 @@ export interface TransactionsRootState {
     };
 }
 
-const initializeAccount = (state: TransactionsState, accountHash: AccountHash) => {
-    // initialize an empty array at 'accountHash' index if not yet initialized
-    if (!state.transactions[accountHash]) {
-        state.transactions[accountHash] = [];
+const initializeAccount = (state: TransactionsState, accountKey: AccountKey) => {
+    // initialize an empty array at 'accountKey' index if not yet initialized
+    if (!state.transactions[accountKey]) {
+        state.transactions[accountKey] = [];
     }
-    return state.transactions[accountHash];
+    return state.transactions[accountKey];
 };
 
 export const updateTransaction = (

--- a/suite-common/wallet-utils/src/__tests__/accountUtils.test.ts
+++ b/suite-common/wallet-utils/src/__tests__/accountUtils.test.ts
@@ -116,7 +116,7 @@ describe('account utils', () => {
         expect(getNetwork('doesntexist')).toBeNull();
     });
 
-    it('getAccountHash', () => {
+    it('getAccountKey', () => {
         expect(getAccountKey('descriptor', 'symbol', 'deviceState')).toEqual(
             'descriptor-symbol-deviceState',
         );

--- a/suite-native/config/package.json
+++ b/suite-native/config/package.json
@@ -7,7 +7,7 @@
     "main": "src/index",
     "scripts": {
         "lint:js": "yarn g:eslint '**/*.{ts,tsx,js}'",
-        "test:unit": "jest --passWithNoTests",
+        "test:unit": "jest -c ../../jest.config.native.js --passWithNoTests",
         "type-check": "tsc --build"
     },
     "dependencies": {

--- a/suite-native/module-accounts-import/src/components/AccountImportOverview.tsx
+++ b/suite-native/module-accounts-import/src/components/AccountImportOverview.tsx
@@ -1,47 +1,23 @@
 import React from 'react';
 
-import { CryptoIcon, IconName } from '@trezor/icons';
-import {
-    Box,
-    Card,
-    Input,
-    InputWrapper,
-    SelectableListItem,
-    Text,
-    VStack,
-} from '@suite-native/atoms';
+import { CryptoIcon } from '@trezor/icons';
+import { Box, Card, Input, InputWrapper, Text } from '@suite-native/atoms';
 import { AccountInfo } from '@trezor/connect';
 import { formatNetworkAmount } from '@suite-common/wallet-utils';
-
-export type DummyDevice = { icon: IconName; title: string; value: string };
+import { NetworkSymbol } from '@suite-common/wallet-config';
 
 type AssetsOverviewProps = {
     accountInfo: AccountInfo;
-    selectedDevice: DummyDevice | undefined;
     assetName: string;
-    onSelectDevice: (device: DummyDevice) => void;
-    onAssetNameChange: (value: string) => void;
+    currencySymbol: NetworkSymbol;
+    onChangeAccountName: (accountName: string) => void;
 };
-
-export const dummyDevices: Array<DummyDevice> = [
-    {
-        icon: 'trezorT',
-        title: 'Model T',
-        value: 'modelT',
-    },
-    {
-        icon: 'trezorT',
-        title: 'Model One',
-        value: 'modelOne',
-    },
-];
 
 export const AccountImportOverview = ({
     accountInfo,
-    selectedDevice,
     assetName,
-    onSelectDevice,
-    onAssetNameChange,
+    currencySymbol,
+    onChangeAccountName,
 }: AssetsOverviewProps) => (
     <Card>
         <Box marginTop="large" marginBottom="medium">
@@ -54,28 +30,14 @@ export const AccountImportOverview = ({
                     </Text>
                 </Box>
                 <Text variant="label" color="gray1000">
-                    ≈ {formatNetworkAmount(accountInfo.availableBalance, 'btc', true)}
+                    ≈ {formatNetworkAmount(accountInfo.availableBalance, currencySymbol, true)}
                 </Text>
             </Box>
             <Box marginBottom="large">
                 <InputWrapper>
-                    <Input value={assetName} onChange={onAssetNameChange} label="" />
+                    <Input value={assetName} onChange={onChangeAccountName} label="" />
                 </InputWrapper>
             </Box>
-            <InputWrapper label="Device">
-                <VStack spacing="small">
-                    {dummyDevices.map(device => (
-                        <SelectableListItem
-                            key={device.value}
-                            iconName={device.icon}
-                            title={device.title}
-                            onPress={() => onSelectDevice(device)}
-                            value={device.value}
-                            isChecked={selectedDevice?.value === device.value}
-                        />
-                    ))}
-                </VStack>
-            </InputWrapper>
         </Box>
     </Card>
 );

--- a/suite-native/module-accounts-import/src/screens/AccountsImportScreen.tsx
+++ b/suite-native/module-accounts-import/src/screens/AccountsImportScreen.tsx
@@ -1,6 +1,6 @@
 import React, { useEffect, useState } from 'react';
 import { Alert, View } from 'react-native';
-import { useDispatch } from 'react-redux';
+import { useDispatch, useSelector } from 'react-redux';
 
 import TrezorConnect, { AccountInfo } from '@trezor/connect';
 import {
@@ -16,11 +16,12 @@ import {
 import { Button } from '@suite-native/atoms';
 import { prepareNativeStyle, useNativeStyles } from '@trezor/styles';
 import { setOnboardingFinished } from '@suite-native/module-settings';
+import { AccountsRootState, selectAccountsByNetworkAndDevice } from '@suite-common/wallet-core';
 
 import { AccountImportLoader } from '../components/AccountImportLoader';
 import { AccountImportHeader } from '../components/AccountImportHeader';
-import { AccountImportOverview, DummyDevice } from '../components/AccountImportOverview';
-import { importAccountThunk } from '../accountsThunks';
+import { AccountImportOverview } from '../components/AccountImportOverview';
+import { HIDDEN_DEVICE_ID, HIDDEN_DEVICE_STATE, importAccountThunk } from '../accountsImportThunks';
 
 const assetsStyle = prepareNativeStyle(_ => ({
     flex: 1,
@@ -44,14 +45,17 @@ export const AccountsImportScreen = ({
     AccountsImportStackRoutes.AccountImport,
     RootStackParamList
 >) => {
+    const { xpubAddress, currencySymbol } = route.params;
     const dispatch = useDispatch();
+    const deviceNetworkAccounts = useSelector((state: AccountsRootState) =>
+        selectAccountsByNetworkAndDevice(state, HIDDEN_DEVICE_STATE, currencySymbol),
+    );
     const [accountInfo, setAccountInfo] = useState<AccountInfo | null>(null);
-    const [selectedDevice, setSelectedDevice] = useState<DummyDevice>();
-    const [assetName, setAssetName] = useState<string>('bitcoines #1');
+    const [accountLabel, setAccountLabel] = useState<string>(
+        `${currencySymbol} #${deviceNetworkAccounts.length + 1}`,
+    );
 
     const { applyStyle } = useNativeStyles();
-
-    const { xpubAddress, currencySymbol } = route.params;
 
     useEffect(() => {
         let ignore = false;
@@ -94,13 +98,13 @@ export const AccountsImportScreen = ({
     }, [xpubAddress, currencySymbol, navigation]);
 
     const handleConfirmAssets = () => {
-        if (accountInfo && selectedDevice) {
-            const { title, value } = selectedDevice;
+        if (accountInfo) {
             dispatch(
                 importAccountThunk({
-                    deviceId: value,
-                    deviceTitle: title,
+                    deviceId: HIDDEN_DEVICE_ID,
+                    deviceTitle: 'Hidden Device',
                     accountInfo,
+                    accountLabel,
                     coin: currencySymbol,
                 }),
             );
@@ -114,10 +118,6 @@ export const AccountsImportScreen = ({
         }
     };
 
-    const handleSelectDevice = (device: DummyDevice) => {
-        setSelectedDevice(device);
-    };
-
     return (
         <Screen>
             {!accountInfo ? (
@@ -128,10 +128,9 @@ export const AccountsImportScreen = ({
                         <AccountImportHeader />
                         <AccountImportOverview
                             accountInfo={accountInfo}
-                            selectedDevice={selectedDevice}
-                            assetName={assetName}
-                            onSelectDevice={handleSelectDevice}
-                            onAssetNameChange={setAssetName}
+                            assetName={accountLabel}
+                            currencySymbol={currencySymbol}
+                            onChangeAccountName={setAccountLabel}
                         />
                     </View>
                     <View style={applyStyle(importAnotherWrapperStyle)}>

--- a/suite-native/module-accounts/src/components/AccountBalance.tsx
+++ b/suite-native/module-accounts/src/components/AccountBalance.tsx
@@ -7,7 +7,7 @@ import { Account } from '@suite-common/wallet-types';
 
 type AccountBalanceProps = {
     account: Account;
-    accountName: string;
+    accountName?: string;
 };
 
 const accountNameStyle = prepareNativeStyle(utils => ({

--- a/suite-native/module-accounts/src/components/AccountListItem.tsx
+++ b/suite-native/module-accounts/src/components/AccountListItem.tsx
@@ -4,7 +4,7 @@ import { TouchableOpacity } from 'react-native';
 
 import { useNavigation } from '@react-navigation/native';
 
-import { AccountsRootState, selectAccountName } from '@suite-common/wallet-core';
+import { AccountsRootState, selectAccountLabel } from '@suite-common/wallet-core';
 import { Box, Text } from '@suite-native/atoms';
 import {
     AccountsStackParamList,
@@ -31,7 +31,7 @@ export const AccountListItem = ({ account }: AccountListItemProps) => {
         useNavigation<StackNavigationProps<AccountsStackParamList, AccountsStackRoutes.Accounts>>();
     const { applyStyle } = useNativeStyles();
     const accountName = useSelector((state: AccountsRootState) =>
-        selectAccountName(state, account.key),
+        selectAccountLabel(state, account.key),
     );
 
     const handleSelectAccount = (key: string) => {

--- a/suite-native/module-accounts/src/screens/AccountDetailScreen.tsx
+++ b/suite-native/module-accounts/src/screens/AccountDetailScreen.tsx
@@ -11,8 +11,8 @@ import {
 import {
     AccountsRootState,
     fetchTransactionsThunk,
-    selectAccountName,
-    selectAccount,
+    selectAccountLabel,
+    selectAccountByKey,
     TransactionsRootState,
     selectAccountTransactions,
 } from '@suite-common/wallet-core';
@@ -25,9 +25,11 @@ export const AccountDetailScreen = ({
     route,
 }: StackProps<AccountsStackParamList, AccountsStackRoutes.AccountDetail>) => {
     const { accountKey } = route.params;
-    const account = useSelector((state: AccountsRootState) => selectAccount(state, accountKey));
+    const account = useSelector((state: AccountsRootState) =>
+        selectAccountByKey(state, accountKey),
+    );
     const accountName = useSelector((state: AccountsRootState) =>
-        selectAccountName(state, accountKey),
+        selectAccountLabel(state, accountKey),
     );
     const accountTransactions = useSelector((state: TransactionsRootState) =>
         selectAccountTransactions(state, accountKey),

--- a/suite-native/storage/package.json
+++ b/suite-native/storage/package.json
@@ -7,7 +7,7 @@
     "main": "src/index",
     "scripts": {
         "lint:js": "yarn g:eslint '**/*.{ts,tsx,js}'",
-        "test:unit": "jest --passWithNoTests",
+        "test:unit": "jest -c ../../jest.config.native.js --passWithNoTests",
         "type-check": "tsc --build"
     },
     "dependencies": {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

We agreed on the functionality which is slightly different from the first iteration:

- the app will have one hidden device under the hood => all imported accounts (xpub scans) will be assigned to this hidden device.

## Related Issue

Resolve https://github.com/trezor/trezor-suite/issues/6274