### PR TITLE
fix(suite): exclude from builds binaries with missing write permissions

### DIFF
--- a/packages/suite-desktop/package.json
+++ b/packages/suite-desktop/package.json
@@ -53,6 +53,8 @@
             "!**/node_modules/**/*.js.flow",
             "!**/node_modules/**/*.ts",
             "!**/node_modules/**/.*",
+            "!**/node_modules/tiny-secp256k1/**/build",
+            "!**/node_modules/blake-hash/**/build",
             "!**/jest*",
             "!**/babel*",
             "!**/bower*",


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Attempt to fix auto-update on Mac.

Excluding unused binaries from the build. There was an issue with wrong permissions. 

`Trezor%20Suite.app/Contents/Resources/app.asar.unpacked/node_modules/tiny-secp256k1/build/node_gyp_bins/python3` miss write permissions when built on Gitlab runner, so it wasn't possible to install it. (When we built it locally, there were no issues - that file had write permissions.)

That `app.asar.unpacked` folder started to appear when we migrated to yarn3 https://github.com/trezor/trezor-suite/commit/39c0ed80e
<!--- Describe your changes in detail -->

