### PR TITLE
fix(suite): added AbortButton key

### DIFF
--- a/packages/suite/src/components/suite/Modal/DevicePromptModal.tsx
+++ b/packages/suite/src/components/suite/Modal/DevicePromptModal.tsx
@@ -167,7 +167,9 @@ const DevicePromptModalRenderer = ({
                     )
                 }
                 headerComponents={
-                    isActionAbortable ? [<AbortButton onAbort={onAbort} />] : undefined
+                    isActionAbortable
+                        ? [<AbortButton key="abort-button" onAbort={onAbort} />]
+                        : undefined
                 }
                 {...rest}
             />


### PR DESCRIPTION
Added `key` prop to `AbortButton` in `DevicePromptModal` header to resolve `Each child in an array should have a unique "key" prop`.