### PR TITLE
@trezor/connect: add SLIP 25 support

### DIFF
--- a/.github/workflows/connect-test.yml
+++ b/.github/workflows/connect-test.yml
@@ -43,7 +43,7 @@ jobs:
     needs: [build]
     uses: ./.github/workflows/connect-test-params.yml
     with:
-      test-pattern: "init authorizeCoinJoin passphrase"
+      test-pattern: "init authorizeCoinJoin passphrase unlockPath"
 
   management:
     needs: [build]

--- a/ci/test.yml
+++ b/ci/test.yml
@@ -262,7 +262,7 @@ connect-popup manual:
   parallel:
     matrix:
       - TESTS_ENVIRONMENT: ["node", "web"]
-        TESTS_PATTERN: "init authorizeCoinJoin passphrase"
+        TESTS_PATTERN: "init authorizeCoinJoin passphrase unlockPath"
         TESTS_FIRMWARE: ["2-master", "2.2.0"]
         # todo:
         # TESTS_NODE_VERSION: ["12", "14", "16"]

--- a/docs/packages/connect/methods/authorizeCoinJoin.md
+++ b/docs/packages/connect/methods/authorizeCoinJoin.md
@@ -10,7 +10,7 @@ const result = await TrezorConnect.authorizeCoinJoin(params);
 
 > :warning: **This feature is experimental! Do not use it in production!**
 
-> :note: **Supported only by Trezor T with Firmware 2.4.4 or higher!**
+> :note: **Supported only by Trezor T with Firmware 2.5.3 or higher!**
 
 ### Params
 

--- a/docs/packages/connect/methods/getAddress.md
+++ b/docs/packages/connect/methods/getAddress.md
@@ -19,6 +19,7 @@ const result = await TrezorConnect.getAddress(params);
 -   `crossChain` — _optional_ `boolean` Advanced feature. Use it only if you are know what you are doing. Allows to generate address between chains. For example Bitcoin path on Litecoin network will display cross chain address in Litecoin format.
 -   `multisig` - _optional_ [MultisigRedeemScriptType](https://github.com/trezor/trezor-suite/blob/develop/packages/transport/src/types/messages.ts), redeem script information (multisig addresses only)
 -   `scriptType` - _optional_ [InputScriptType](https://github.com/trezor/trezor-suite/blob/develop/packages/transport/src/types/messages.ts), address script type
+-   `unlockPath` - _optional_ [PROTO.UnlockPath](https://github.com/trezor/trezor-suite/blob/develop/packages/transport/src/types/messages.ts), the result of [TrezorConnect.unlockPath](./unlockPath.md) method.
 
 #### Exporting bundle of addresses
 

--- a/docs/packages/connect/methods/getPublicKey.md
+++ b/docs/packages/connect/methods/getPublicKey.md
@@ -19,6 +19,7 @@ const result = await TrezorConnect.getPublicKey(params);
 -   `ignoreXpubMagic` — _optional_ `boolean` ignore SLIP-0132 XPUB magic, use xpub/tpub prefix for all account types.
 -   `ecdsaCurveName` — _optional_ `string` ECDSA curve name to use
 -   `crossChain` — _optional_ `boolean` Advanced feature. Use it only if you are know what you are doing. Allows to generate address between chains. For example Bitcoin path on Litecoin network will display cross chain address in Litecoin format.
+-   `unlockPath` - _optional_ [PROTO.UnlockPath](https://github.com/trezor/trezor-suite/blob/develop/packages/transport/src/types/messages.ts), the result of [TrezorConnect.unlockPath](./unlockPath.md) method.
 
 #### Exporting bundle of public keys
 

--- a/docs/packages/connect/methods/signTransaction.md
+++ b/docs/packages/connect/methods/signTransaction.md
@@ -35,6 +35,7 @@ const result = await TrezorConnect.signTransaction(params);
 -   `push` - _optional_ `boolean` Broadcast signed transaction to blockchain. Default is set to false
 -   `amountUnit` — _optional_ `PROTO.AmountUnit`
     > show amounts in BTC, mBTC, uBTC, sat
+-   `unlockPath` - _optional_ [PROTO.UnlockPath](https://github.com/trezor/trezor-suite/blob/develop/packages/transport/src/types/messages.ts), the result of [TrezorConnect.unlockPath](./unlockPath.md) method.
 
 ### Example
 

--- a/docs/packages/connect/methods/unlockPath.md
+++ b/docs/packages/connect/methods/unlockPath.md
@@ -1,0 +1,44 @@
+## Unlock path
+
+Ask device to unlock a subtree of the keychain.
+
+Result is used in `getPublicKey`, `getAddress` and `signTransaction` methods to access requested keychain which is not available by default.
+
+```javascript
+const result = await TrezorConnect.unlockPath(params);
+```
+
+> :warning: **This feature is experimental! Do not use it in production!**
+
+> :note: **Supported only by Trezor T with Firmware 2.5.3 or higher!**
+
+### Params
+
+[Optional common params](commonParams.md)
+
+-   `path` — _required_ `string | Array<number>`
+    > prefix of the BIP-32 path leading to the account (m / purpose')
+
+### Result
+
+```javascript
+{
+    success: true,
+    payload: {
+        address_n: Array<number>,
+        mac: string,
+    }
+}
+
+```
+
+Error
+
+```javascript
+{
+    success: false,
+    payload: {
+        error: string // error message
+    }
+}
+```

--- a/packages/connect/CHANGELOG.md
+++ b/packages/connect/CHANGELOG.md
@@ -1,3 +1,9 @@
+# 9.0.3 (not released)
+
+-   added `unlockPath` method
+-   added `SLIP 25` support
+-   fixed bitcoin extended descriptor (xpubSegwit) for taproot accounts
+
 # 9.0.2
 
 -   improved passphrase dialog in popup window

--- a/packages/connect/e2e/__fixtures__/getOwnershipId.ts
+++ b/packages/connect/e2e/__fixtures__/getOwnershipId.ts
@@ -2,8 +2,8 @@
 
 const legacyResults = [
     {
-        // getOwnershipId not supported on T1 and TT below 2.4.4
-        rules: ['1', '<2.4.4'],
+        // getOwnershipId not supported on T1 and TT below 2.5.3
+        rules: ['1', '<2.5.3'],
         success: false,
     },
 ];

--- a/packages/connect/e2e/__fixtures__/getOwnershipProof.ts
+++ b/packages/connect/e2e/__fixtures__/getOwnershipProof.ts
@@ -2,8 +2,8 @@
 
 const legacyResults = [
     {
-        // getOwnershipProof not supported on T1 and TT below 2.4.4
-        rules: ['1', '<2.4.4'],
+        // getOwnershipProof not supported on T1 and TT below 2.5.3
+        rules: ['1', '<2.5.3'],
         success: false,
     },
 ];

--- a/packages/connect/e2e/tests/device/authorizeCoinJoin.test.ts
+++ b/packages/connect/e2e/tests/device/authorizeCoinJoin.test.ts
@@ -1,7 +1,7 @@
 import TrezorConnect from '@trezor/connect';
 
 const { getController, setup, conditionalTest, initTrezorConnect } = global.Trezor;
-const { ADDRESS_N, TX_CACHE } = global.TestUtils;
+const { ADDRESS_N } = global.TestUtils;
 
 const controller = getController('applyFlags');
 
@@ -21,15 +21,21 @@ describe('TrezorConnect.authorizeCoinJoin', () => {
         TrezorConnect.dispose();
     });
 
-    conditionalTest(['1', '<2.4.4'], 'Coinjoin success', async () => {
+    conditionalTest(['1', '<2.5.3'], 'Coinjoin success', async () => {
+        // unlocked path is required for tx validation
+        const unlockPath = await TrezorConnect.unlockPath({
+            path: ADDRESS_N("m/10025'"),
+        });
+        if (!unlockPath.success) throw new Error(unlockPath.payload.error);
+
         const auth = await TrezorConnect.authorizeCoinJoin({
             coordinator: 'www.example.com',
             maxRounds: 2,
             maxCoordinatorFeeRate: 50000000, // 0.5 %
             maxFeePerKvbyte: 3500,
-            path: ADDRESS_N("m/84'/1'/0'"),
+            path: ADDRESS_N("m/10025'/1'/0'/1'"),
             coin: 'Testnet',
-            scriptType: 'SPENDWITNESS',
+            scriptType: 'SPENDTAPROOT',
         });
 
         expect(auth.success).toBe(true);
@@ -44,8 +50,8 @@ describe('TrezorConnect.authorizeCoinJoin', () => {
 
         const proof = await TrezorConnect.getOwnershipProof({
             coin: 'Testnet',
-            path: ADDRESS_N("m/84'/1'/0'/1/0"),
-            scriptType: 'SPENDWITNESS',
+            path: ADDRESS_N("m/10025'/1'/0'/1'/1/0"),
+            scriptType: 'SPENDTAPROOT',
             userConfirmation: true, // ButtonRequest is not emitted because of preauthorization
             commitmentData,
             preauthorized: true,
@@ -57,53 +63,54 @@ describe('TrezorConnect.authorizeCoinJoin', () => {
             inputs: [
                 {
                     // seed "alcohol woman abuse must during monitor noble actual mixed trade anger aisle"
-                    // 84'/1'/0'/0/0
-                    // tb1qnspxpr2xj9s2jt6qlhuvdnxw6q55jvygcf89r2
+                    // m/10025'/1'/0'/1'/0/0
+                    // tb1pkw382r3plt8vx6e22mtkejnqrxl4z7jugh3w4rjmfmgezzg0xqpsdaww8z
                     amount: 100000,
                     prev_hash: 'e5b7e21b5ba720e81efd6bfa9f854ababdcddc75a43bfa60bf0fe069cfd1bb8a',
                     prev_index: 0,
                     script_type: 'EXTERNAL',
-                    script_pubkey: '00149c02608d469160a92f40fdf8c6ccced029493088',
+                    script_pubkey:
+                        '5120b3a2750e21facec36b2a56d76cca6019bf517a5c45e2ea8e5b4ed191090f3003',
                     ownership_proof:
-                        '534c001901016b2055d8190244b2ed2d46513c40658a574d3bc2deb6969c0535bb818b44d2c40002483045022100a6c7d59b453efa7b4abc9bc724a94c5655ae986d5924dc29d28bcc2b859cbace022047d2bc4422a47f7b044bd6cdfbf63fe1a0ecbf11393f4c0bf8565f867a5ced16012103505f0d82bbdd251511591b34f36ad5eea37d3220c2b81a1189084431ddb3aa3d',
+                        '534c001901019cf1b0ad730100bd7a69e987d55348bb798e2b2096a6a5713e9517655bd2021300014052d479f48d34f1ca6872d4571413660040c3e98841ab23a2c5c1f37399b71bfa6f56364b79717ee90552076a872da68129694e1b4fb0e0651373dcf56db123c5',
                     commitment_data: commitmentData,
                 },
                 // # NOTE: FAKE input tx
                 {
-                    address_n: ADDRESS_N("m/84'/1'/0'/1/0"),
+                    address_n: ADDRESS_N("m/10025'/1'/0'/1'/1/0"),
                     prev_hash: 'f982c0a283bd65a59aa89eded9e48f2a3319cb80361dfab4cf6192a03badb60a',
                     prev_index: 1,
                     amount: 7289000,
-                    script_type: 'SPENDWITNESS',
+                    script_type: 'SPENDTAPROOT',
                 },
             ],
             outputs: [
                 // Other's coinjoined output.
                 {
-                    address: 'tb1qk7j3ahs2v6hrv4v282cf0tvxh0vqq7rpt3zcml',
+                    address: 'tb1pupzczx9cpgyqgtvycncr2mvxscl790luqd8g88qkdt2w3kn7ymhsrdueu2',
                     amount: 50000,
                     script_type: 'PAYTOADDRESS',
                     payment_req_index: 0,
                 },
                 // Our coinjoined output.
                 {
-                    // tb1qze76uzqteg6un6jfcryrxhwvfvjj58ts0swg3d
-                    address_n: ADDRESS_N("m/84'/1'/0'/1/1"),
+                    // tb1phkcspf88hge86djxgtwx2wu7ddghsw77d6sd7txtcxncu0xpx22shcydyf
+                    address_n: ADDRESS_N("m/10025'/1'/0'/1'/1/1"),
                     amount: 50000,
-                    script_type: 'PAYTOWITNESS',
+                    script_type: 'PAYTOTAPROOT',
                     payment_req_index: 0,
                 },
                 // Our change output.
                 {
                     // tb1qr5p6f5sk09sms57ket074vywfymuthlgud7xyx
-                    address_n: ADDRESS_N("m/84'/1'/0'/1/2"),
+                    address_n: ADDRESS_N("m/10025'/1'/0'/1'/1/2"),
                     amount: 7289000 - 50000 - 36445 - 490,
-                    script_type: 'PAYTOWITNESS',
+                    script_type: 'PAYTOTAPROOT',
                     payment_req_index: 0,
                 },
                 // Other's change output.
                 {
-                    address: 'tb1q9cqhdr9ydetjzrct6tyeuccws9505hl96azwxk',
+                    address: 'tb1pvt7lzserh8xd5m6mq0zu9s5wxkpe5wgf5ts56v44jhrr6578hz8saxup5m',
                     amount: 100000 - 50000 - 500 - 490,
                     script_type: 'PAYTOADDRESS',
                     payment_req_index: 0,
@@ -119,21 +126,30 @@ describe('TrezorConnect.authorizeCoinJoin', () => {
             paymentRequests: [
                 {
                     recipient_name: 'www.example.com',
+                    amount: 135955,
                     signature:
-                        'af22d614a4920f54e7704c186bf12f24dbef475df31645574c9f9b4dbb3594c4d4084d8a16a6db0cda814377d58e564b872f02331a3db0bf229856aa33e8bc19',
+                        '07a0b1e1b44d75832bc26ce2c105fe5db35e64d802462ec7b7fc6283214efa743500c60420ae4952d9d41f0be4185816d4dedfabbe699ea2ddc253f9a40ba83c',
                 },
             ],
-            refTxs: TX_CACHE(['e5b7e2', 'f982c0'], true), // Fake tx
             coin: 'testnet',
             preauthorized: true,
+            unlockPath: unlockPath.payload, // NOTE: unlock path is required for validation, it will be removed in future
         };
 
         // ButtonRequests during signing is not emitted because of preauthorization
 
         const round1 = await TrezorConnect.signTransaction(params);
         expect(round1.payload).toMatchObject({
+            signatures: [
+                undefined,
+                'c017fce789fa8db54a2ae032012d2dd6d7c76cc1c1a6f00e29b86acbf93022da8aa559009a574792c7b09b2535d288d6e03c6ed169902ed8c4c97626a83fbc11',
+            ],
+            witnesses: [
+                undefined,
+                '0140c017fce789fa8db54a2ae032012d2dd6d7c76cc1c1a6f00e29b86acbf93022da8aa559009a574792c7b09b2535d288d6e03c6ed169902ed8c4c97626a83fbc11',
+            ],
             serializedTx:
-                '010000000001028abbd1cf69e00fbf60fa3ba475dccdbdba4a859ffa6bfd1ee820a75b1be2b7e50000000000ffffffff0ab6ad3ba09261cfb4fa1d3680cb19332a8fe4d9de9ea89aa565bd83a2c082f90100000000ffffffff0550c3000000000000160014b7a51ede0a66ae36558a3ab097ad86bbd800786150c3000000000000160014167dae080bca35c9ea49c0c8335dcc4b252a1d7011e56d00000000001600141d03a4d2167961b853d6cadfeab08e4937c5dfe872bf0000000000001600142e01768ca46e57210f0bd2c99e630e8168fa5fe551900000000000001976a914a579388225827d9f2fe9014add644487808c695d88ac000247304402204df07c5baacca264696cc4270665cb759be05387dead8942bd41f20309ceb29002203e685b8e9483435d9b70006bb424b5fef7249415a0f212abdf202b5d62859698012103505647c017ff2156eb6da20fae72173d3b681a1d0a629f95f49e884db300689f00000000',
+                '010000000001028abbd1cf69e00fbf60fa3ba475dccdbdba4a859ffa6bfd1ee820a75b1be2b7e50000000000ffffffff0ab6ad3ba09261cfb4fa1d3680cb19332a8fe4d9de9ea89aa565bd83a2c082f90100000000ffffffff0550c3000000000000225120e0458118b80a08042d84c4f0356d86863fe2bffc034e839c166ad4e8da7e26ef50c3000000000000225120bdb100a4e7ba327d364642dc653b9e6b51783bde6ea0df2ccbc1a78e3cc1329511e56d0000000000225120c5c7c63798b59dc16e97d916011e99da5799d1b3dd81c2f2e93392477417e71e72bf00000000000022512062fdf14323b9ccda6f5b03c5c2c28e35839a3909a2e14d32b595c63d53c7b88f51900000000000001976a914a579388225827d9f2fe9014add644487808c695d88ac000140c017fce789fa8db54a2ae032012d2dd6d7c76cc1c1a6f00e29b86acbf93022da8aa559009a574792c7b09b2535d288d6e03c6ed169902ed8c4c97626a83fbc1100000000',
         });
 
         // sign again ...

--- a/packages/connect/e2e/tests/device/unlockPath.test.ts
+++ b/packages/connect/e2e/tests/device/unlockPath.test.ts
@@ -1,0 +1,210 @@
+import TrezorConnect from '@trezor/connect';
+
+const { getController, setup, conditionalTest, initTrezorConnect } = global.Trezor;
+const { ADDRESS_N } = global.TestUtils;
+
+const controller = getController('unlockPath');
+
+describe('TrezorConnect.unlockPath', () => {
+    beforeAll(async () => {
+        await setup(controller, {
+            mnemonic: 'mnemonic_all',
+        });
+        await initTrezorConnect(controller);
+    });
+
+    afterAll(() => {
+        controller.dispose();
+        TrezorConnect.dispose();
+    });
+
+    conditionalTest(['1', '<2.5.3'], 'Unlock SLIP-25 + getAddress', async () => {
+        const unlockPath = await TrezorConnect.unlockPath({
+            path: "m/10025'",
+        });
+        if (!unlockPath.success) throw new Error(unlockPath.payload.error);
+
+        expect(unlockPath.payload).toMatchObject({
+            address_n: [2147493673],
+            mac: 'b25e9eff5c4ae63ff5526984ddd94e66872c94d48be1133bd978e59be7e29ead',
+        });
+
+        const address = await TrezorConnect.getAddress({
+            path: "m/10025'/1'/0'/1'/0/0",
+            unlockPath: unlockPath.payload,
+            coin: 'Testnet',
+        });
+
+        expect(address.payload).toMatchObject({
+            address: 'tb1pl3y9gf7xk2ryvmav5ar66ra0d2hk7lhh9mmusx3qvn0n09kmaghqh32ru7',
+        });
+
+        const address2 = await TrezorConnect.getAddress({
+            path: "m/10025'/1'/0'/1'/0/1",
+            unlockPath: unlockPath.payload,
+            coin: 'Testnet',
+        });
+
+        expect(address2.payload).toMatchObject({
+            address: 'tb1p64rqq64rtt7eq6p0htegalcjl2nkjz64ur8xsclc59s5845jty7skp2843',
+        });
+
+        // Bundle of unlocked addresses
+        const bundle = await TrezorConnect.getAddress({
+            bundle: [
+                {
+                    path: "m/10025'/1'/0'/1'/0/0",
+                    unlockPath: unlockPath.payload,
+                    showOnTrezor: false,
+                    coin: 'Testnet',
+                },
+                {
+                    path: "m/10025'/1'/0'/1'/0/1",
+                    unlockPath: unlockPath.payload,
+                    showOnTrezor: false,
+                    coin: 'Testnet',
+                },
+            ],
+        });
+
+        expect(bundle.payload).toMatchObject([
+            {
+                address: 'tb1pl3y9gf7xk2ryvmav5ar66ra0d2hk7lhh9mmusx3qvn0n09kmaghqh32ru7',
+            },
+            {
+                address: 'tb1p64rqq64rtt7eq6p0htegalcjl2nkjz64ur8xsclc59s5845jty7skp2843',
+            },
+        ]);
+
+        // Ensure that the SLIP-0025 internal chain is inaccessible even with user authorization.
+        const changeAddress = await TrezorConnect.getAddress({
+            path: "m/10025'/1'/0'/1'/1/1",
+            unlockPath: unlockPath.payload,
+            coin: 'Testnet',
+        });
+        expect(changeAddress.payload).toMatchObject({ error: 'Forbidden key path' });
+
+        // Ensure that another SLIP-0025 account is inaccessible with the same MAC.
+        const otherAccount = await TrezorConnect.getAddress({
+            path: "m/10025'/1'/1'/1'/0/0",
+            unlockPath: unlockPath.payload,
+            coin: 'Testnet',
+        });
+        expect(otherAccount.payload).toMatchObject({ error: 'Forbidden key path' });
+    });
+
+    conditionalTest(['1', '<2.5.3'], 'Unlock SLIP-25 + getPublicKey', async () => {
+        const unlockPath = await TrezorConnect.unlockPath({
+            path: "m/10025'",
+        });
+        if (!unlockPath.success) throw new Error(unlockPath.payload.error);
+
+        expect(unlockPath.payload).toMatchObject({
+            address_n: [2147493673],
+            mac: 'b25e9eff5c4ae63ff5526984ddd94e66872c94d48be1133bd978e59be7e29ead',
+        });
+
+        const unlockedPublicKey = await TrezorConnect.getPublicKey({
+            path: "m/10025'/1'/0'/1'",
+            unlockPath: unlockPath.payload,
+            coin: 'Testnet',
+        });
+
+        expect(unlockedPublicKey.payload).toMatchObject({
+            xpub: 'tpubDEMKm4M3S2Grx5DHTfbX9et5HQb9KhdjDCkUYdH9gvVofvPTE6yb2MH52P9uc4mx6eFohUmfN1f4hhHNK28GaZnWRXr3b8KkfFcySo1SmXU',
+            xpubSegwit: `tr([5c9e228d/10025'/1'/0'/1']tpubDEMKm4M3S2Grx5DHTfbX9et5HQb9KhdjDCkUYdH9gvVofvPTE6yb2MH52P9uc4mx6eFohUmfN1f4hhHNK28GaZnWRXr3b8KkfFcySo1SmXU/<0;1>/*)`,
+        });
+
+        // Bundle of unlocked xpubs
+        const bundle = await TrezorConnect.getPublicKey({
+            bundle: [
+                {
+                    path: "m/10025'/1'/0'/1'",
+                    unlockPath: unlockPath.payload,
+                    showOnTrezor: true,
+                    coin: 'Testnet',
+                },
+                {
+                    path: "m/10025'/1'/1'/1'",
+                    unlockPath: unlockPath.payload,
+                    showOnTrezor: true,
+                    coin: 'Testnet',
+                },
+            ],
+        });
+
+        expect(bundle.payload).toMatchObject([
+            {
+                xpub: 'tpubDEMKm4M3S2Grx5DHTfbX9et5HQb9KhdjDCkUYdH9gvVofvPTE6yb2MH52P9uc4mx6eFohUmfN1f4hhHNK28GaZnWRXr3b8KkfFcySo1SmXU',
+                xpubSegwit: `tr([5c9e228d/10025'/1'/0'/1']tpubDEMKm4M3S2Grx5DHTfbX9et5HQb9KhdjDCkUYdH9gvVofvPTE6yb2MH52P9uc4mx6eFohUmfN1f4hhHNK28GaZnWRXr3b8KkfFcySo1SmXU/<0;1>/*)`,
+            },
+            {
+                xpub: 'tpubDEJLCjatfgyLNnuPyZFctb2j7MgJQgEVmbdjgAZyxhiFsA8mZBYg9R8J1ju2HL7sEAXbr6qWtpLnTL5c48x3B48HcBEXALrjEbdsRp9QJ5R',
+                xpubSegwit:
+                    "tr([5c9e228d/10025'/1'/1'/1']tpubDEJLCjatfgyLNnuPyZFctb2j7MgJQgEVmbdjgAZyxhiFsA8mZBYg9R8J1ju2HL7sEAXbr6qWtpLnTL5c48x3B48HcBEXALrjEbdsRp9QJ5R/<0;1>/*)",
+            },
+        ]);
+
+        const forbiddenPublicKey = await TrezorConnect.getPublicKey({
+            path: "m/10025'/1'/0'/1'",
+            coin: 'Testnet',
+        });
+
+        expect(forbiddenPublicKey.payload).toMatchObject({ error: 'Forbidden key path' });
+    });
+
+    conditionalTest(['1', '<2.5.3'], 'Unlock SLIP-25 + signTransaction', async () => {
+        const unlockPath = await TrezorConnect.unlockPath({
+            path: "m/10025'",
+        });
+        if (!unlockPath.success) throw new Error(unlockPath.payload.error);
+
+        expect(unlockPath.payload).toMatchObject({
+            address_n: [2147493673],
+            mac: 'b25e9eff5c4ae63ff5526984ddd94e66872c94d48be1133bd978e59be7e29ead',
+        });
+
+        const params = {
+            inputs: [
+                {
+                    // address_n: "m/10025'/1'/0'/1'/1/0",
+                    address_n: ADDRESS_N("m/10025'/1'/0'/1'/1/0"),
+                    amount: 7289000,
+                    prev_hash: 'f982c0a283bd65a59aa89eded9e48f2a3319cb80361dfab4cf6192a03badb60a',
+                    prev_index: 1,
+                    script_type: 'SPENDTAPROOT',
+                },
+            ],
+            outputs: [
+                // Our change output.
+                {
+                    // tb1pchruvduckkwuzm5hmytqz85emften5dnmkqu9uhfxwfywaqhuu0qjggqyp
+                    // address_n: "m/10025'/1'/0'/1'/1/2",
+                    address_n: ADDRESS_N("m/10025'/1'/0'/1'/1/2"),
+                    amount: 7289000 - 50000 - 400,
+                    script_type: 'PAYTOTAPROOT',
+                },
+                // Payment output.
+                {
+                    address: 'mvbu1Gdy8SUjTenqerxUaZyYjmveZvt33q',
+                    amount: 50000,
+                    script_type: 'PAYTOADDRESS',
+                },
+            ],
+            coin: 'Testnet',
+        } as const;
+
+        const unlockedSignTx = await TrezorConnect.signTransaction({
+            ...params,
+            unlockPath: unlockPath.payload,
+        });
+
+        expect(unlockedSignTx.payload).toMatchObject({
+            serializedTx:
+                '010000000001010ab6ad3ba09261cfb4fa1d3680cb19332a8fe4d9de9ea89aa565bd83a2c082f90100000000ffffffff02c8736e0000000000225120c5c7c63798b59dc16e97d916011e99da5799d1b3dd81c2f2e93392477417e71e50c30000000000001976a914a579388225827d9f2fe9014add644487808c695d88ac014006bc29900d39570fca291c038551817430965ac6aa26f286483559e692a14a82cfaf8e57610eae12a5af05ee1e9600acb31de4757349c0e3066701aa78f65d2a00000000',
+        });
+
+        const forbiddenSignTx = await TrezorConnect.signTransaction(params);
+        expect(forbiddenSignTx.payload).toMatchObject({ error: 'Forbidden key path' });
+    });
+});

--- a/packages/connect/src/api/bitcoin/TransactionComposer.ts
+++ b/packages/connect/src/api/bitcoin/TransactionComposer.ts
@@ -58,12 +58,13 @@ export class TransactionComposer {
             // exclude amounts lower than dust limit if they are NOT required
             if (!u.required && new BigNumber(u.amount).lte(this.coinInfo.dustLimit)) return [];
             const addressPath = getHDPath(u.path);
+            const [chain, index] = addressPath.slice(addressPath.length - 2);
 
             return {
                 index: u.vout,
                 transactionHash: u.txid,
                 value: u.amount,
-                addressPath: [addressPath[3], addressPath[4]],
+                addressPath: [chain, index],
                 height: u.blockHeight,
                 tsize: 0, // doesn't matter
                 vsize: 0, // doesn't matter

--- a/packages/connect/src/api/getPublicKey.ts
+++ b/packages/connect/src/api/getPublicKey.ts
@@ -11,6 +11,7 @@ import type { PROTO } from '../constants';
 
 type Params = PROTO.GetPublicKey & {
     coinInfo?: BitcoinNetworkInfo;
+    unlockPath?: PROTO.UnlockPath;
 };
 
 export default class GetPublicKey extends AbstractMethod<'getPublicKey', Params[]> {
@@ -40,7 +41,15 @@ export default class GetPublicKey extends AbstractMethod<'getPublicKey', Params[
                 { name: 'scriptType', type: ['string', 'number'] },
                 { name: 'ignoreXpubMagic', type: 'boolean' },
                 { name: 'ecdsaCurveName', type: 'boolean' },
+                { name: 'unlockPath', type: 'object' },
             ]);
+
+            if (batch.unlockPath) {
+                validateParams(batch.unlockPath, [
+                    { name: 'address_n', required: true, type: 'array' },
+                    { name: 'mac', required: true, type: 'string' },
+                ]);
+            }
 
             let coinInfo: BitcoinNetworkInfo | undefined;
             if (batch.coin) {
@@ -67,6 +76,7 @@ export default class GetPublicKey extends AbstractMethod<'getPublicKey', Params[
                 ignore_xpub_magic: batch.ignoreXpubMagic,
                 ecdsa_curve_name: batch.ecdsaCurveName,
                 coinInfo,
+                unlockPath: batch.unlockPath,
             };
         });
     }
@@ -103,8 +113,8 @@ export default class GetPublicKey extends AbstractMethod<'getPublicKey', Params[
         const responses: MethodReturnType<typeof this.name> = [];
         const cmd = this.device.getCommands();
         for (let i = 0; i < this.params.length; i++) {
-            const { coinInfo, ...batch } = this.params[i];
-            const response = await cmd.getHDNode(batch, { coinInfo });
+            const { coinInfo, unlockPath, ...batch } = this.params[i];
+            const response = await cmd.getHDNode(batch, { coinInfo, unlockPath });
             responses.push(response);
 
             if (this.hasBundle) {

--- a/packages/connect/src/api/index.ts
+++ b/packages/connect/src/api/index.ts
@@ -68,6 +68,7 @@ export { default as stellarSignTransaction } from './stellarSignTransaction';
 export { default as tezosGetAddress } from './tezosGetAddress';
 export { default as tezosGetPublicKey } from './tezosGetPublicKey';
 export { default as tezosSignTransaction } from './tezosSignTransaction';
+export { default as unlockPath } from './unlockPath';
 // export { default as uiResponse } from './uiResponse';
 export { default as verifyMessage } from './verifyMessage';
 export { default as wipeDevice } from './wipeDevice';

--- a/packages/connect/src/api/unlockPath.ts
+++ b/packages/connect/src/api/unlockPath.ts
@@ -1,0 +1,37 @@
+import { AbstractMethod } from '../core/AbstractMethod';
+import { PROTO } from '../constants';
+import { validatePath } from '../utils/pathUtils';
+import { getFirmwareRange, validateParams } from './common/paramsValidator';
+
+export default class UnlockPath extends AbstractMethod<'unlockPath', PROTO.UnlockPath> {
+    init() {
+        this.requiredPermissions = ['read'];
+        this.skipFinalReload = true;
+        this.firmwareRange = getFirmwareRange(this.name, null, {
+            1: { min: '0', max: '0' },
+            2: { min: '2.5.3', max: '0' },
+        });
+
+        const { payload } = this;
+
+        validateParams(payload, [
+            { name: 'path', required: true },
+            { name: 'mac', type: 'string' },
+        ]);
+        const path = validatePath(payload.path, 1);
+
+        this.params = {
+            address_n: path,
+            mac: payload.mac,
+        };
+    }
+
+    async run() {
+        const cmd = this.device.getCommands();
+        const { message } = await cmd.unlockPath(this.params);
+        return {
+            address_n: this.params.address_n,
+            mac: message.mac,
+        };
+    }
+}

--- a/packages/connect/src/data/config.ts
+++ b/packages/connect/src/data/config.ts
@@ -189,7 +189,7 @@ export const config = {
         {
             capabilities: ['coinjoin'],
             methods: ['authorizeCoinJoin', 'getOwnershipId', 'getOwnershipProof'],
-            min: ['0', '2.4.4'],
+            min: ['0', '2.5.3'],
         },
     ],
 };

--- a/packages/connect/src/device/DeviceCommands.ts
+++ b/packages/connect/src/device/DeviceCommands.ts
@@ -119,6 +119,10 @@ export class DeviceCommands {
         return this.disposed;
     }
 
+    unlockPath(params?: Messages.UnlockPath) {
+        return this.typedCall('UnlockPath', 'UnlockedPathRequest', params);
+    }
+
     async getPublicKey(params: Messages.GetPublicKey) {
         const response = await this.typedCall('GetPublicKey', 'PublicKey', {
             address_n: params.address_n,

--- a/packages/connect/src/factory.ts
+++ b/packages/connect/src/factory.ts
@@ -185,6 +185,8 @@ export const factory = ({
 
         tezosSignTransaction: params => call({ ...params, method: 'tezosSignTransaction' }),
 
+        unlockPath: params => call({ ...params, method: 'unlockPath' }),
+
         eosGetPublicKey: params => call({ ...params, method: 'eosGetPublicKey' }),
 
         eosSignTransaction: params => call({ ...params, method: 'eosSignTransaction' }),

--- a/packages/connect/src/types/api/bitcoin/index.ts
+++ b/packages/connect/src/types/api/bitcoin/index.ts
@@ -77,6 +77,7 @@ export interface SignTransaction {
     push?: boolean;
     preauthorized?: boolean;
     amountUnit?: PROTO.AmountUnit;
+    unlockPath?: PROTO.UnlockPath;
 }
 
 export type SignedTransaction = {

--- a/packages/connect/src/types/api/getAddress.ts
+++ b/packages/connect/src/types/api/getAddress.ts
@@ -12,6 +12,7 @@ interface GetAddress extends GetAddressShared {
     crossChain?: boolean;
     multisig?: PROTO.MultisigRedeemScriptType;
     scriptType?: PROTO.InternalInputScriptType;
+    unlockPath?: PROTO.UnlockPath;
 }
 
 type Address = AddressShared & PROTO.Address;

--- a/packages/connect/src/types/api/getPublicKey.ts
+++ b/packages/connect/src/types/api/getPublicKey.ts
@@ -12,6 +12,7 @@ export interface GetPublicKey extends GetPublicKeyShared {
     scriptType?: PROTO.InternalInputScriptType;
     ignoreXpubMagic?: boolean;
     ecdsaCurveName?: string;
+    unlockPath?: PROTO.UnlockPath;
 }
 
 // PROTO.HDNodeType with camelcase fields + path

--- a/packages/connect/src/types/api/index.ts
+++ b/packages/connect/src/types/api/index.ts
@@ -69,6 +69,7 @@ import { tezosGetAddress } from './tezosGetAddress';
 import { tezosGetPublicKey } from './tezosGetPublicKey';
 import { tezosSignTransaction } from './tezosSignTransaction';
 import { uiResponse } from './uiResponse';
+import { unlockPath } from './unlockPath';
 import { verifyMessage } from './verifyMessage';
 import { wipeDevice } from './wipeDevice';
 import { checkFirmwareAuthenticity } from './checkFirmwareAuthenticity';
@@ -286,6 +287,9 @@ export interface TrezorConnect {
 
     // https://github.com/trezor/trezor-suite/blob/develop/docs/packages/connect/methods/uiResponse.md
     uiResponse: typeof uiResponse;
+
+    // https://github.com/trezor/trezor-suite/blob/develop/docs/packages/connect/methods/unlockPath.md
+    unlockPath: typeof unlockPath;
 
     // https://github.com/trezor/trezor-suite/blob/develop/docs/packages/connect/methods/verifyMessage.md
     verifyMessage: typeof verifyMessage;

--- a/packages/connect/src/types/api/unlockPath.ts
+++ b/packages/connect/src/types/api/unlockPath.ts
@@ -1,0 +1,9 @@
+import type { PROTO } from '../../constants';
+import type { Params, Response } from '../params';
+
+export interface UnlockPathParams {
+    path: string | number[];
+    mac?: string;
+}
+
+export declare function unlockPath(params: Params<UnlockPathParams>): Response<PROTO.UnlockPath>;

--- a/packages/connect/src/utils/__tests__/pathUtils.test.ts
+++ b/packages/connect/src/utils/__tests__/pathUtils.test.ts
@@ -1,0 +1,53 @@
+import { getHDPath, getScriptType, getOutputScriptType, getAccountType } from '../pathUtils';
+
+describe('utils/pathUtils', () => {
+    it('getScriptType', () => {
+        expect(getScriptType(getHDPath("m/44'/1'/0'"))).toEqual('SPENDADDRESS');
+        expect(getScriptType(getHDPath("m/49'/1'/0'"))).toEqual('SPENDP2SHWITNESS');
+        expect(getScriptType(getHDPath("m/84'/1'/0'"))).toEqual('SPENDWITNESS');
+        expect(getScriptType(getHDPath("m/86'/1'/0'"))).toEqual('SPENDTAPROOT');
+        expect(getScriptType(getHDPath("m/10025'/1'/0'/1'"))).toEqual('SPENDTAPROOT'); // slip-25
+        // bip48
+        expect(getScriptType(getHDPath("m/48'/1'/0'"))).toEqual(undefined); // not bip48 path SPENDADDRESS will be used
+        expect(getScriptType(getHDPath("m/48'/1'/0'/0'"))).toEqual('SPENDMULTISIG');
+        expect(getScriptType(getHDPath("m/48'/1'/0'/1'"))).toEqual('SPENDP2SHWITNESS');
+        expect(getScriptType(getHDPath("m/48'/1'/0'/2'"))).toEqual('SPENDWITNESS');
+
+        // defaults
+        expect(getScriptType([])).toEqual(undefined);
+        expect(getScriptType([0])).toEqual(undefined);
+    });
+
+    it('getOutputScriptType', () => {
+        expect(getOutputScriptType(getHDPath("m/44'/1'/0'"))).toEqual('PAYTOADDRESS');
+        expect(getOutputScriptType(getHDPath("m/49'/1'/0'"))).toEqual('PAYTOP2SHWITNESS');
+        expect(getOutputScriptType(getHDPath("m/84'/1'/0'"))).toEqual('PAYTOWITNESS');
+        expect(getOutputScriptType(getHDPath("m/86'/1'/0'"))).toEqual('PAYTOTAPROOT');
+        expect(getOutputScriptType(getHDPath("m/10025'/1'/0'/1'"))).toEqual('PAYTOTAPROOT'); // slip-25
+        // bip48
+        expect(getOutputScriptType(getHDPath("m/48'/1'/0'"))).toEqual(undefined); // not bip48 path SPENDADDRESS will be used
+        expect(getOutputScriptType(getHDPath("m/48'/1'/0'/0'"))).toEqual('PAYTOMULTISIG');
+        expect(getOutputScriptType(getHDPath("m/48'/1'/0'/1'"))).toEqual('PAYTOP2SHWITNESS');
+        expect(getOutputScriptType(getHDPath("m/48'/1'/0'/2'"))).toEqual('PAYTOWITNESS');
+
+        // compatibility for Casa - allow an unhardened 49 path to use PAYTOP2SHWITNESS
+        expect(getOutputScriptType(getHDPath("m/49/1'/0'"))).toEqual('PAYTOP2SHWITNESS');
+        // defaults
+        expect(getOutputScriptType([])).toEqual(undefined);
+        expect(getOutputScriptType([0])).toEqual(undefined);
+    });
+
+    it('getAccountType', () => {
+        expect(getAccountType(getHDPath("m/44'/1'/0'"))).toEqual('p2pkh');
+        expect(getAccountType(getHDPath("m/48'/1'/0'"))).toEqual('p2pkh'); // NOTE: missing "multisig" account type
+        expect(getAccountType(getHDPath("m/49'/1'/0'"))).toEqual('p2sh');
+        expect(getAccountType(getHDPath("m/84'/1'/0'"))).toEqual('p2wpkh');
+        expect(getAccountType(getHDPath("m/86'/1'/0'"))).toEqual('p2tr');
+        expect(getAccountType(getHDPath("m/10025'/1'/0'/1'"))).toEqual('p2tr'); // NOTE: slip25 should be p2tr type
+
+        // defaults
+        expect(getAccountType([])).toEqual('p2pkh');
+        expect(getAccountType([0])).toEqual('p2pkh');
+        expect(getAccountType(undefined)).toEqual('p2pkh');
+    });
+});

--- a/packages/connect/src/utils/pathUtils.ts
+++ b/packages/connect/src/utils/pathUtils.ts
@@ -45,7 +45,7 @@ export const isBech32Path = (path: number[] | undefined) =>
     Array.isArray(path) && path[0] === toHardened(84);
 
 export const isTaprootPath = (path: number[] | undefined) =>
-    Array.isArray(path) && path[0] === toHardened(86);
+    Array.isArray(path) && (path[0] === toHardened(86) || path[0] === toHardened(10025));
 
 export const getAccountType = (path: number[] | undefined) => {
     if (isTaprootPath(path)) return 'p2tr';
@@ -88,7 +88,9 @@ export const getScriptType = (
             return 'SPENDP2SHWITNESS';
         case 84:
             return 'SPENDWITNESS';
+        // 10025 - SLIP-25 https://github.com/satoshilabs/slips/blob/master/slip-0025.md#public-key-derivation
         case 86:
+        case 10025:
             return 'SPENDTAPROOT';
         default:
             return undefined;
@@ -129,7 +131,9 @@ export const getOutputScriptType = (path?: number[]): PROTO.ChangeOutputScriptTy
             return 'PAYTOP2SHWITNESS';
         case 84:
             return 'PAYTOWITNESS';
+        // 10025 - SLIP-25 https://github.com/satoshilabs/slips/blob/master/slip-0025.md#public-key-derivation
         case 86:
+        case 10025:
             return 'PAYTOTAPROOT';
         default:
             return undefined;

--- a/packages/suite/src/actions/wallet/__fixtures__/coinjoinAccountActions.ts
+++ b/packages/suite/src/actions/wallet/__fixtures__/coinjoinAccountActions.ts
@@ -24,9 +24,12 @@ export const createCoinjoinAccount = [
         },
     },
     {
-        description: 'experimental features not enabled',
+        description: 'path not unlocked',
         connect: {
             success: false,
+            payload: {
+                error: 'Cancelled',
+            },
         },
         params: {
             symbol: 'btc',
@@ -45,16 +48,20 @@ export const createCoinjoinAccount = [
         description: 'public key not given',
         connect: [
             {
-                success: true, // applySettings
+                success: true, // unlockPath
             },
             {
                 success: false, // getPublicKey
+                payload: {
+                    error: 'Forbidden key path',
+                },
             },
         ],
         params: {
             symbol: 'btc',
             networkType: 'bitcoin',
             accountType: 'coinjoin',
+            bip43Path: "m/10025'/1'/i'/1'",
         },
         result: {
             actions: ['@notification/toast'],
@@ -64,7 +71,7 @@ export const createCoinjoinAccount = [
         description: 'success',
         connect: [
             {
-                success: true, // applySettings
+                success: true, // unlockPath
             },
             {
                 success: true, // getPublicKey
@@ -85,6 +92,7 @@ export const createCoinjoinAccount = [
             symbol: 'btc',
             networkType: 'bitcoin',
             accountType: 'coinjoin',
+            bip43Path: "m/10025'/1'/i'/1'",
         },
         result: {
             actions: [

--- a/packages/suite/src/actions/wallet/receiveActions.ts
+++ b/packages/suite/src/actions/wallet/receiveActions.ts
@@ -91,6 +91,7 @@ export const showAddress =
         const params = {
             device,
             path,
+            unlockPath: account.unlockPath,
             useEmptyPassphrase: device.useEmptyPassphrase,
             coin: account.symbol,
         };

--- a/packages/suite/src/actions/wallet/send/sendFormBitcoinActions.ts
+++ b/packages/suite/src/actions/wallet/send/sendFormBitcoinActions.ts
@@ -231,6 +231,10 @@ export const signTransaction =
             signEnhancement.amountUnit = bitcoinAmountUnit;
         }
 
+        if (account.unlockPath) {
+            signEnhancement.unlockPath = account.unlockPath;
+        }
+
         const signPayload: Params<SignTransaction> = {
             device: {
                 path: device.path,

--- a/suite-common/test-utils/src/mocks.ts
+++ b/suite-common/test-utils/src/mocks.ts
@@ -367,6 +367,12 @@ const getTrezorConnect = <M>(methods?: M) => {
                 ...getFixture(),
                 _params,
             })),
+            unlockPath: jest.fn(async _params => ({
+                success: true,
+                payload: { address_n: [2147493673], mac: '0MaC' },
+                ...getFixture(),
+                _params,
+            })),
             changePin: () => ({
                 success: true,
                 payload: {

--- a/suite-common/wallet-config/src/networksConfig.ts
+++ b/suite-common/wallet-config/src/networksConfig.ts
@@ -266,7 +266,7 @@ export const networks = {
         accountTypes: {
             coinjoin: {
                 name: 'Bitcoin Regtest (PEA)',
-                bip43Path: "m/10025'/1'/i'",
+                bip43Path: "m/10025'/1'/i'/1'", // https://github.com/satoshilabs/slips/blob/master/slip-0025.md#public-key-derivation
                 backendType: 'coinjoin', // use non-standard backend
                 features: [], // no rbf, no sign-verify
             },

--- a/suite-common/wallet-core/src/accounts/accountsActions.ts
+++ b/suite-common/wallet-core/src/accounts/accountsActions.ts
@@ -46,6 +46,7 @@ const createAccount = createAction(
             deviceState,
             index: discoveryItem.index,
             path: discoveryItem.path,
+            unlockPath: discoveryItem.unlockPath,
             descriptor: accountInfo.descriptor,
             key: getAccountKey(accountInfo.descriptor, discoveryItem.coin, deviceState),
             accountType: discoveryItem.accountType,

--- a/suite-common/wallet-types/src/account.ts
+++ b/suite-common/wallet-types/src/account.ts
@@ -1,5 +1,5 @@
 import { Network, BackendType, NetworkSymbol, AccountType } from '@suite-common/wallet-config';
-import { AccountInfo } from '@trezor/connect';
+import { AccountInfo, PROTO } from '@trezor/connect';
 
 export type MetadataItem = string;
 export type XpubAddress = string;
@@ -58,6 +58,7 @@ export type Account = {
     key: string;
     index: number;
     path: string;
+    unlockPath?: PROTO.UnlockPath; // parameter used to unlock SLIP-25/coinjoin keychain
     descriptor: string;
     accountType: NonNullable<Network['accountType']>;
     symbol: NetworkSymbol;

--- a/suite-common/wallet-types/src/discovery.ts
+++ b/suite-common/wallet-types/src/discovery.ts
@@ -33,6 +33,7 @@ export interface Discovery {
 export interface DiscoveryItem {
     // @trezor/connect
     path: string;
+    unlockPath?: Account['unlockPath'];
     coin: Account['symbol'];
     details?: 'basic' | 'tokens' | 'tokenBalances' | 'txids' | 'txs';
     pageSize?: number;


### PR DESCRIPTION
Based on:
https://github.com/trezor/trezor-suite/pull/6327 and https://github.com/trezor/trezor-suite/pull/6328 and https://github.com/trezor/trezor-suite/pull/6350

Connect:
- Added `TrezorConnect.unlockPath` method
- Use the result of `unlockPath` method to access SLIP-25 keychain (getAddress, getPublicKey, signTransaction)
- Fixed tests for coinjoin using SLIP-25 account
- Fixed `addressPath` in `composeTransaction`

Suite:
- Use SLIP-25 path for coinjoin accounts
- Use `unlockPath` for coinjoin accounts (getAddress, getPublicKey, signTransaction)
- Temporary patch for blockbook responses for SLIP-25 accounts
