### PR TITLE
fix(connect): bitcoind native descriptor format

### DIFF
--- a/packages/connect/src/device/DeviceCommands.ts
+++ b/packages/connect/src/device/DeviceCommands.ts
@@ -12,7 +12,6 @@ import {
     isTaprootPath,
     getSerializedPath,
     getScriptType,
-    fromHardened,
     toHardened,
 } from '../utils/pathUtils';
 import { getAccountAddressN } from '../utils/accountUtils';
@@ -193,9 +192,9 @@ export class DeviceCommands {
 
         if (isTaprootPath(path)) {
             // wrap regular xpub into bitcoind native descriptor
-            response.xpubSegwit = `tr([5c9e228d/86'/${fromHardened(path[1])}'/${fromHardened(
-                path[2],
-            )}']${response.xpub}/<0;1>/*)`;
+            const fingerprint = Number(publicKey.root_fingerprint || 0).toString(16);
+            const descriptorPath = `${fingerprint}${response.serializedPath.substring(1)}`;
+            response.xpubSegwit = `tr([${descriptorPath}]${response.xpub}/<0;1>/*)`;
         }
 
         return response;

--- a/packages/integration-tests/projects/connect/__fixtures__/getPublicKey.ts
+++ b/packages/integration-tests/projects/connect/__fixtures__/getPublicKey.ts
@@ -12,7 +12,7 @@ export default {
             },
             result: {
                 xpub: 'xpub6D1saVFSZYgqXCXDfc5m2KdPXUsBXC12E3WntXXzWGJB8dEBr3CGR62emtC8sxJRVRSmBKbtJubuaaGEvZeeCEWaPaYvD9iJwp2Ky7sZws7',
-                xpubSegwit: `tr([5c9e228d/86'/0'/0']xpub6D1saVFSZYgqXCXDfc5m2KdPXUsBXC12E3WntXXzWGJB8dEBr3CGR62emtC8sxJRVRSmBKbtJubuaaGEvZeeCEWaPaYvD9iJwp2Ky7sZws7/<0;1>/*)`,
+                xpubSegwit: `tr([95d8f670/86'/0'/0']xpub6D1saVFSZYgqXCXDfc5m2KdPXUsBXC12E3WntXXzWGJB8dEBr3CGR62emtC8sxJRVRSmBKbtJubuaaGEvZeeCEWaPaYvD9iJwp2Ky7sZws7/<0;1>/*)`,
             },
         },
         {


### PR DESCRIPTION
Values returned from `getHDNode` in `xpubSegwit` field contains hardcoded fingerprint.
Luckily this fingerprint is not validated in blockbook and that's why everything is working :) however it should be fixed to use a real fingerprint (see [python-trezor](https://github.com/trezor/trezor-firmware/blob/3a8e84a86efba76d76985614d8da540f526d9b38/python/src/trezorlib/cli/btc.py#L286))



@mroz22 , @matejkriz pls validate if it's a breaking change for suite accounts/transactions/labeling or not
