### PR TITLE
@trezor/connect: cleanup in gethdnode method

### DIFF
--- a/docs/packages/connect/methods/getPublicKey.md
+++ b/docs/packages/connect/methods/getPublicKey.md
@@ -15,6 +15,9 @@ const result = await TrezorConnect.getPublicKey(params);
 
 -   `path` — _required_ `string | Array<number>` minimum length is `1`. [read more](../path.md)
 -   `coin` - _optional_ `string` determines network definition specified in [coins.json](https://github.com/trezor/trezor-suite/blob/develop/packages/connect-common/files/coins.json) file. Coin `shortcut`, `name` or `label` can be used. If `coin` is not set API will try to get network definition from `path`.
+-   `scriptType` — _optional_ `string` used to distinguish between various address formats (non-segwit, segwit, etc.).
+-   `ignoreXpubMagic` — _optional_ `boolean` ignore SLIP-0132 XPUB magic, use xpub/tpub prefix for all account types.
+-   `ecdsaCurveName` — _optional_ `string` ECDSA curve name to use
 -   `crossChain` — _optional_ `boolean` Advanced feature. Use it only if you are know what you are doing. Allows to generate address between chains. For example Bitcoin path on Litecoin network will display cross chain address in Litecoin format.
 
 #### Exporting bundle of public keys

--- a/packages/connect/src/api/bitcoin/signtxVerify.ts
+++ b/packages/connect/src/api/bitcoin/signtxVerify.ts
@@ -10,13 +10,9 @@ import { PROTO, ERRORS } from '../../constants';
 import { getOutputScriptType } from '../../utils/pathUtils';
 
 import type { BitcoinNetworkInfo } from '../../types';
-import type { HDNodeResponse } from '../../types/api/getPublicKey';
+import type { DeviceCommands } from '../../device/DeviceCommands';
 
-type GetHDNode = (
-    path: number[],
-    coinInfo?: BitcoinNetworkInfo,
-    validation?: boolean,
-) => Promise<HDNodeResponse>;
+type GetHDNode = DeviceCommands['getHDNode'];
 
 const derivePubKeyHash = async (
     address_n: number[],
@@ -25,12 +21,12 @@ const derivePubKeyHash = async (
 ) => {
     // regular bip44 output
     if (address_n.length === 5) {
-        const response = await getHDNode(address_n.slice(0, 4), coinInfo);
+        const response = await getHDNode({ address_n: address_n.slice(0, 4) }, { coinInfo });
         const node = bip32.fromBase58(response.xpub, coinInfo.network);
         return node.derive(address_n[address_n.length - 1]);
     }
     // custom address_n
-    const response = await getHDNode(address_n, coinInfo);
+    const response = await getHDNode({ address_n }, { coinInfo });
     return bip32.fromBase58(response.xpub, coinInfo.network);
 };
 

--- a/packages/connect/src/api/signTransaction.ts
+++ b/packages/connect/src/api/signTransaction.ts
@@ -153,9 +153,10 @@ export default class SignTransaction extends AbstractMethod<'signTransaction', P
                         if (!accountPath || !accountPath.address_n) {
                             throw ERRORS.TypedError('Runtime', 'Account not found');
                         }
+                        const address_n = accountPath.address_n.slice(0, 3);
                         const node = await device
                             .getCommands()
-                            .getHDNode(accountPath.address_n.slice(0, 3), params.coinInfo);
+                            .getHDNode({ address_n }, { coinInfo: params.coinInfo });
                         const account = await blockchain.getAccountInfo({
                             descriptor: node.xpubSegwit || node.xpub,
                             details: 'tokens',

--- a/packages/connect/src/device/DeviceCommands.ts
+++ b/packages/connect/src/device/DeviceCommands.ts
@@ -120,28 +120,26 @@ export class DeviceCommands {
         return this.disposed;
     }
 
-    async getPublicKey(
-        address_n: number[],
-        coin_name = 'Bitcoin',
-        script_type?: Messages.InputScriptType,
-        show_display?: boolean,
-    ) {
+    async getPublicKey(params: Messages.GetPublicKey) {
         const response = await this.typedCall('GetPublicKey', 'PublicKey', {
-            address_n,
-            coin_name,
-            script_type,
-            show_display,
+            address_n: params.address_n,
+            coin_name: params.coin_name || 'Bitcoin',
+            script_type: params.script_type,
+            show_display: params.show_display,
+            ignore_xpub_magic: params.ignore_xpub_magic,
+            ecdsa_curve_name: params.ecdsa_curve_name,
         });
         return response.message;
     }
 
     // Validation of xpub
     async getHDNode(
-        path: number[],
-        coinInfo?: BitcoinNetworkInfo,
-        validation = true,
-        showOnTrezor = false,
+        params: Messages.GetPublicKey,
+        options: { coinInfo?: BitcoinNetworkInfo; validation?: boolean } = {},
     ) {
+        const path = params.address_n;
+        const { coinInfo } = options;
+        const validation = typeof options.validation === 'boolean' ? options.validation : true;
         if (!this.device.atLeast(['1.7.2', '2.0.10']) || !coinInfo) {
             return this.getBitcoinHDNode(path, coinInfo);
         }
@@ -155,22 +153,30 @@ export class DeviceCommands {
             network = getBech32Network(coinInfo);
         }
 
-        let scriptType: Messages.InternalInputScriptType | undefined = getScriptType(path);
+        if (!params.script_type && network) {
+            // to prevent compatibility issues
+            // add script_type automatically only(!) if Network is detected, otherwise leave empty (protobuf fallbacks to SPENDADDRESS by default)
+            params.script_type = getScriptType(path);
+        }
+
         if (!network) {
+            // use default Network
             network = coinInfo.network;
-            if (scriptType !== 'SPENDADDRESS') {
-                scriptType = undefined;
-            }
+        }
+
+        if (!params.coin_name) {
+            // use default name
+            params.coin_name = coinInfo.name;
         }
 
         let publicKey: Messages.PublicKey;
-        if (showOnTrezor || !validation) {
-            publicKey = await this.getPublicKey(path, coinInfo.name, scriptType, showOnTrezor);
+        if (params.show_display || !validation) {
+            publicKey = await this.getPublicKey(params);
         } else {
             const suffix = 0;
             const childPath = path.concat([suffix]);
-            const resKey = await this.getPublicKey(path, coinInfo.name, scriptType);
-            const childKey = await this.getPublicKey(childPath, coinInfo.name, scriptType);
+            const resKey = await this.getPublicKey(params);
+            const childKey = await this.getPublicKey({ ...params, address_n: childPath });
             publicKey = hdnodeUtils.xpubDerive(resKey, childKey, suffix, network, coinInfo.network);
         }
 
@@ -207,13 +213,13 @@ export class DeviceCommands {
     async getBitcoinHDNode(path: number[], coinInfo?: BitcoinNetworkInfo, validation = true) {
         let publicKey: Messages.PublicKey;
         if (!validation) {
-            publicKey = await this.getPublicKey(path);
+            publicKey = await this.getPublicKey({ address_n: path });
         } else {
             const suffix = 0;
             const childPath = path.concat([suffix]);
 
-            const resKey = await this.getPublicKey(path);
-            const childKey = await this.getPublicKey(childPath);
+            const resKey = await this.getPublicKey({ address_n: path });
+            const childKey = await this.getPublicKey({ address_n: childPath });
             publicKey = hdnodeUtils.xpubDerive(resKey, childKey, suffix);
         }
 
@@ -294,7 +300,7 @@ export class DeviceCommands {
         show_display,
     }: Messages.EthereumGetPublicKey): Promise<HDNodeResponse> {
         if (!this.device.atLeast(['1.8.1', '2.1.0'])) {
-            return this.getHDNode(address_n);
+            return this.getHDNode({ address_n });
         }
 
         const suffix = 0;
@@ -608,7 +614,7 @@ export class DeviceCommands {
             : getAccountAddressN(coinInfo, indexOrPath);
 
         if (coinInfo.type === 'bitcoin') {
-            const resp = await this.getHDNode(address_n, coinInfo, false);
+            const resp = await this.getHDNode({ address_n }, { coinInfo, validation: false });
             return {
                 descriptor: resp.xpubSegwit || resp.xpub,
                 legacyXpub: resp.xpub,

--- a/packages/connect/src/types/api/cardano/index.ts
+++ b/packages/connect/src/types/api/cardano/index.ts
@@ -1,4 +1,5 @@
 import type { PROTO } from '../../../constants';
+import type { GetPublicKey, PublicKey } from '../../params';
 
 // cardanoGetAddress
 
@@ -60,16 +61,11 @@ export interface CardanoNativeScriptHash {
 
 // cardanoGetPublicKey
 
-export interface CardanoGetPublicKey {
-    path: string | number[];
-    showOnTrezor?: boolean;
+export interface CardanoGetPublicKey extends GetPublicKey {
     derivationType?: PROTO.CardanoDerivationType;
 }
 
-export interface CardanoPublicKey {
-    path: number[];
-    serializedPath: string;
-    publicKey: string;
+export interface CardanoPublicKey extends PublicKey {
     node: PROTO.HDNodeType;
 }
 

--- a/packages/connect/src/types/api/eos/index.ts
+++ b/packages/connect/src/types/api/eos/index.ts
@@ -3,11 +3,6 @@ import { PROTO } from '../../../constants';
 
 // eosGetPublicKey
 
-export interface EosGetPublicKey {
-    path: string | number[];
-    showOnTrezor?: boolean;
-}
-
 export interface EosPublicKey {
     wifPublicKey: string;
     rawPublicKey: string;

--- a/packages/connect/src/types/api/eosGetPublicKey.ts
+++ b/packages/connect/src/types/api/eosGetPublicKey.ts
@@ -1,7 +1,7 @@
-import type { Params, BundledParams, Response } from '../params';
-import { EosGetPublicKey, EosPublicKey } from './eos';
+import type { Params, GetPublicKey, BundledParams, Response } from '../params';
+import { EosPublicKey } from './eos';
 
-export declare function eosGetPublicKey(params: Params<EosGetPublicKey>): Response<EosPublicKey>;
+export declare function eosGetPublicKey(params: Params<GetPublicKey>): Response<EosPublicKey>;
 export declare function eosGetPublicKey(
-    params: BundledParams<EosGetPublicKey>,
+    params: BundledParams<GetPublicKey>,
 ): Response<EosPublicKey[]>;

--- a/packages/connect/src/types/api/getPublicKey.ts
+++ b/packages/connect/src/types/api/getPublicKey.ts
@@ -1,3 +1,4 @@
+import type { PROTO } from '../../constants';
 import type {
     GetPublicKey as GetPublicKeyShared,
     Params,
@@ -8,6 +9,9 @@ import type {
 export interface GetPublicKey extends GetPublicKeyShared {
     coin?: string;
     crossChain?: boolean;
+    scriptType?: PROTO.InternalInputScriptType;
+    ignoreXpubMagic?: boolean;
+    ecdsaCurveName?: string;
 }
 
 // PROTO.HDNodeType with camelcase fields + path


### PR DESCRIPTION
Problem:
`DeviceCommands.getHDNode` and `DeviceCommands.getPublicKey` methods are incorrectly designed by accepting list of optional arguments instead of two objects.

Solution:
Accept two arguments: `params` (protobuf object sent to device) and `options` (the rest)