### PR TITLE
feat(connect): ~~add versionChannel init option~~ connectSrc test

### DIFF
--- a/ci/test.yml
+++ b/ci/test.yml
@@ -300,3 +300,17 @@ connect manual:
     refs:
       - schedules
   when: manual
+
+.e2e connect-web:
+  stage: integration testing
+  variables:
+    URL: ${DEV_SERVER_URL}/connect/${CI_BUILD_REF_NAME}/
+  script:
+    - yarn install --immutable
+    - yarn workspace @trezor/connect-web test:e2e
+  interruptible: true
+
+connect-web:
+  extends: .e2e connect-web
+  only:
+    <<: *run_everything_rules

--- a/packages/connect-web/e2e/playwright.config.ts
+++ b/packages/connect-web/e2e/playwright.config.ts
@@ -1,0 +1,14 @@
+import { PlaywrightTestConfig } from '@playwright/test';
+
+const config: PlaywrightTestConfig = {
+    testDir: 'tests',
+    retries: 0,
+    workers: 1, // to disable parallelism between test files
+    timeout: 30000,
+    use: {
+        headless: process.env.HEADLESS === 'true',
+        ignoreHTTPSErrors: true,
+        trace: 'retain-on-failure',
+    },
+};
+export default config;

--- a/packages/connect-web/e2e/tests/init.test.ts
+++ b/packages/connect-web/e2e/tests/init.test.ts
@@ -1,0 +1,53 @@
+import { test, expect } from '@playwright/test';
+
+test.beforeAll(async () => {});
+
+const inlineScriptUrl = process.env.URL
+    ? // url of build from CI
+      `${process.env.URL}/trezor-connect.js`
+    : // for testing out on localhost
+      'https://connect.trezor.io/9/trezor-connect.js';
+
+const fixtures = [
+    {
+        params: {
+            connectSrc: '',
+        },
+        result: 'https://connect.trezor.io/9/iframe.html',
+    },
+    {
+        params: {
+            versionChannel: undefined,
+            connectSrc: 'https://connect.trezor.io/9.0.1/',
+        },
+        result: 'https://connect.trezor.io/9.0.1/iframe.html',
+    },
+    {
+        // it is even possible to load old connect version 8
+        params: {
+            connectSrc: 'https://connect.trezor.io/8/',
+        },
+        result: 'https://connect.trezor.io/8/iframe.html',
+    },
+];
+
+fixtures.forEach(f => {
+    test(`TrezorConnect.init ${JSON.stringify(f.params)} => ${f.result}`, async ({ page }) => {
+        await page.addScriptTag({ url: inlineScriptUrl });
+        await page.addScriptTag({
+            content: `
+                window.TrezorConnect.init({
+                    lazyLoad: false,
+                    manifest: {
+                        email: 'developer@xyz.com',
+                        appUrl: 'http://your.application.com',
+                    },
+                    versionChannel: '${f.params.versionChannel}',
+                    connectSrc: '${f.params.connectSrc}'
+                });
+        `,
+        });
+        const iframeSrc = await page.locator('iframe').getAttribute('src');
+        expect(iframeSrc).toContain(f.result);
+    });
+});

--- a/packages/connect-web/package.json
+++ b/packages/connect-web/package.json
@@ -26,13 +26,13 @@
     "scripts": {
         "predev": "node webpack/generate_dev_cert.js",
         "lint:js": "yarn g:eslint '**/*.{ts,tsx,js}'",
-        "test:unit": "jest --passWithNoTests",
         "type-check": "tsc --build",
         "build:lib": "rimraf ./lib && yarn tsc --build tsconfig.lib.json",
         "dev": "rimraf build && TS_NODE_PROJECT=\"tsconfig.lib.json\" yarn webpack --config ./webpack/dev.webpack.config.ts",
         "build:inline": "TS_NODE_PROJECT=\"tsconfig.lib.json\" webpack --config ./webpack/inline.webpack.config.ts",
         "build:webextension": "TS_NODE_PROJECT=\"tsconfig.lib.json\" yarn webpack --config ./webpack/prod.webpack.config.ts",
-        "build": "rimraf build && yarn build:inline && yarn build:webextension"
+        "build": "rimraf build && yarn build:inline && yarn build:webextension",
+        "test:e2e": "yarn xvfb-maybe -- playwright test --config=./e2e/playwright.config.ts"
     },
     "dependencies": {
         "@trezor/connect": "9.0.2",
@@ -44,9 +44,11 @@
         "@types/chrome": "0.0.181",
         "@types/w3c-web-usb": "^1.0.5",
         "jest": "^26.6.3",
+        "playwright": "^1.22.2",
         "rimraf": "^3.0.2",
         "typescript": "4.7.4",
         "webpack": "^5.73.0",
-        "webpack-cli": "^4.10.0"
+        "webpack-cli": "^4.10.0",
+        "xvfb-maybe": "^0.2.1"
     }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -7010,11 +7010,13 @@ __metadata:
     "@types/w3c-web-usb": ^1.0.5
     events: ^3.3.0
     jest: ^26.6.3
+    playwright: ^1.22.2
     rimraf: ^3.0.2
     tslib: ^2.3.1
     typescript: 4.7.4
     webpack: ^5.73.0
     webpack-cli: ^4.10.0
+    xvfb-maybe: ^0.2.1
   languageName: unknown
   linkType: soft
 


### PR DESCRIPTION
Terms: 

- **pinned** version channel: connect.trezor.io/<9.minor.patch>
- **edge** version channel: connect.trezor.io/9

Behavior:

- [ ] settings.connectSrc is defined -> should be always used
- [ ] settings.connectSrc is not defined && settings.versionChannel is not defined: should use `pinned` versionChannel which resolve to current version of connect. So **'pinned'** is default ? 
- [ ] settings.connectSrc is not defined && settings.versionChannel is set to `edge`. use always the latest released version 