### PR TITLE
npm-release @trezor/connect patch [1/2]

### DIFF
--- a/packages/connect-explorer/package.json
+++ b/packages/connect-explorer/package.json
@@ -10,7 +10,7 @@
     },
     "dependencies": {
         "@trezor/components": "*",
-        "@trezor/connect-web": "9.0.1",
+        "@trezor/connect-web": "9.0.2",
         "markdown-it": "^12.3.2",
         "markdown-it-link-attributes": "^4.0.0",
         "markdown-it-replace-link": "^1.0.1",

--- a/packages/connect-iframe/package.json
+++ b/packages/connect-iframe/package.json
@@ -10,7 +10,7 @@
         "type-check": "tsc --build tsconfig.json"
     },
     "devDependencies": {
-        "@trezor/connect": "9.0.1",
+        "@trezor/connect": "9.0.2",
         "copy-webpack-plugin": "^11.0.0",
         "html-webpack-plugin": "^5.5.0",
         "jest": "^26.6.3",

--- a/packages/connect-popup/package.json
+++ b/packages/connect-popup/package.json
@@ -12,7 +12,7 @@
     },
     "dependencies": {
         "@trezor/components": "*",
-        "@trezor/connect": "9.0.1",
+        "@trezor/connect": "9.0.2",
         "@trezor/connect-ui": "*",
         "@trezor/crypto-utils": "*",
         "@trezor/urls": "*",

--- a/packages/connect-ui/package.json
+++ b/packages/connect-ui/package.json
@@ -12,7 +12,7 @@
     },
     "dependencies": {
         "@trezor/components": "*",
-        "@trezor/connect": "9.0.1",
+        "@trezor/connect": "9.0.2",
         "@trezor/env-utils": "*",
         "@trezor/urls": "*",
         "react": "17.0.2",

--- a/packages/connect-web/package.json
+++ b/packages/connect-web/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@trezor/connect-web",
-    "version": "9.0.1",
+    "version": "9.0.2",
     "author": "Trezor <info@trezor.io>",
     "homepage": "https://github.com/trezor/trezor-suite/tree/develop/packages/connect-web",
     "description": "High-level javascript interface for Trezor hardware wallet.",
@@ -35,7 +35,7 @@
         "build": "rimraf build && yarn build:inline && yarn build:webextension"
     },
     "dependencies": {
-        "@trezor/connect": "9.0.1",
+        "@trezor/connect": "9.0.2",
         "@trezor/utils": "^9.0.2",
         "events": "^3.3.0",
         "tslib": "^2.3.1"

--- a/packages/connect-web/src/webextension/trezor-usb-permissions.js
+++ b/packages/connect-web/src/webextension/trezor-usb-permissions.js
@@ -1,4 +1,4 @@
-const VERSION = '9.0.1';
+const VERSION = '9.0.2';
 const versionN = VERSION.split('.').map(s => parseInt(s, 10));
 // const DIRECTORY = `${ versionN[0] }${ (versionN[1] > 0 ? `.${versionN[1]}` : '') }/`;
 const DIRECTORY = `${versionN[0]}/`;

--- a/packages/connect/CHANGELOG.md
+++ b/packages/connect/CHANGELOG.md
@@ -1,3 +1,12 @@
+# 9.0.2
+
+-   improved passphrase dialog in popup window
+-   if popup window does not load in a predefined period of time, error screen with troubleshooting tips is shown
+
+# 9.0.1
+
+-   @trezor/blockchain-link 2.1.4
+
 # 9.0.0
 
 ## Breaking changes:

--- a/packages/connect/README.md
+++ b/packages/connect/README.md
@@ -1,6 +1,6 @@
 # @trezor/connect
 
-API version 9.0.1
+API version 9.0.2
 
 [![Build Status](https://github.com/trezor/trezor-suite/actions/workflows/connect-test.yml/badge.svg)](https://github.com/trezor/trezor-suite/actions/workflows/connect-test.yml)
 [![NPM](https://img.shields.io/npm/v/@trezor/connect.svg)](https://www.npmjs.org/package/@trezor/connect)

--- a/packages/connect/package.json
+++ b/packages/connect/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@trezor/connect",
-    "version": "9.0.1",
+    "version": "9.0.2",
     "author": "Trezor <info@trezor.io>",
     "homepage": "https://github.com/trezor/trezor-suite/tree/develop/packages/connect",
     "description": "High-level javascript interface for Trezor hardware wallet.",

--- a/packages/connect/src/data/version.ts
+++ b/packages/connect/src/data/version.ts
@@ -1,4 +1,4 @@
-export const VERSION = '9.0.1';
+export const VERSION = '9.0.2';
 
 const versionN = VERSION.split('.').map(s => parseInt(s, 10));
 

--- a/packages/suite-desktop/package.json
+++ b/packages/suite-desktop/package.json
@@ -186,7 +186,7 @@
     "dependencies": {
         "@sentry/electron": "3.0.0",
         "@suite-common/suite-utils": "*",
-        "@trezor/connect": "9.0.1",
+        "@trezor/connect": "9.0.2",
         "@trezor/connect-common": "*",
         "@trezor/request-manager": "*",
         "@trezor/suite-analytics": "*",

--- a/packages/suite/package.json
+++ b/packages/suite/package.json
@@ -42,7 +42,7 @@
         "@suite-common/wallet-types": "*",
         "@suite-common/wallet-utils": "*",
         "@trezor/components": "*",
-        "@trezor/connect": "9.0.1",
+        "@trezor/connect": "9.0.2",
         "@trezor/crypto-utils": "*",
         "@trezor/dom-utils": "*",
         "@trezor/env-utils": "*",

--- a/suite-common/connect-init/package.json
+++ b/suite-common/connect-init/package.json
@@ -16,7 +16,7 @@
         "@suite-common/redux-utils": "*",
         "@suite-common/suite-types": "*",
         "@suite-common/test-utils": "*",
-        "@trezor/connect": "9.0.1",
+        "@trezor/connect": "9.0.2",
         "@trezor/utils": "*"
     },
     "devDependencies": {

--- a/suite-common/notifications/package.json
+++ b/suite-common/notifications/package.json
@@ -13,7 +13,7 @@
     "dependencies": {
         "@suite-common/suite-types": "*",
         "@suite-common/wallet-config": "*",
-        "@trezor/connect": "9.0.1"
+        "@trezor/connect": "9.0.2"
     },
     "devDependencies": {
         "jest": "^26.6.3",

--- a/suite-common/redux-utils/package.json
+++ b/suite-common/redux-utils/package.json
@@ -15,7 +15,7 @@
         "@suite-common/suite-types": "*",
         "@suite-common/wallet-config": "*",
         "@suite-common/wallet-types": "*",
-        "@trezor/connect": "9.0.1",
+        "@trezor/connect": "9.0.2",
         "react": "17.0.2",
         "react-redux": "7.2.2",
         "redux": "^4.2.0"

--- a/suite-common/suite-types/package.json
+++ b/suite-common/suite-types/package.json
@@ -13,7 +13,7 @@
         "@reduxjs/toolkit": "^1.8.3",
         "@suite-common/metadata-types": "*",
         "@suite-common/wallet-config": "*",
-        "@trezor/connect": "9.0.1",
+        "@trezor/connect": "9.0.2",
         "@trezor/suite-data": "*"
     },
     "devDependencies": {

--- a/suite-common/test-utils/package.json
+++ b/suite-common/test-utils/package.json
@@ -15,7 +15,7 @@
         "@suite-common/suite-types": "*",
         "@suite-common/wallet-config": "*",
         "@suite-common/wallet-types": "*",
-        "@trezor/connect": "9.0.1",
+        "@trezor/connect": "9.0.2",
         "@trezor/utils": "*",
         "dropbox": "^10.32.0",
         "fake-indexeddb": "^3.1.7",

--- a/suite-common/wallet-core/package.json
+++ b/suite-common/wallet-core/package.json
@@ -21,7 +21,7 @@
         "@suite-common/wallet-config": "*",
         "@suite-common/wallet-types": "*",
         "@suite-common/wallet-utils": "*",
-        "@trezor/connect": "9.0.1",
+        "@trezor/connect": "9.0.2",
         "@trezor/utils": "*",
         "date-fns": "^2.29.1"
     },

--- a/suite-common/wallet-types/package.json
+++ b/suite-common/wallet-types/package.json
@@ -14,7 +14,7 @@
         "@suite-common/suite-utils": "*",
         "@suite-common/wallet-config": "*",
         "@suite-common/wallet-constants": "*",
-        "@trezor/connect": "9.0.1",
+        "@trezor/connect": "9.0.2",
         "@trezor/type-utils": "*",
         "@trezor/utils": "*",
         "react": "17.0.2",

--- a/suite-common/wallet-utils/package.json
+++ b/suite-common/wallet-utils/package.json
@@ -24,7 +24,7 @@
         "@suite-common/wallet-config": "*",
         "@suite-common/wallet-constants": "*",
         "@suite-common/wallet-types": "*",
-        "@trezor/connect": "9.0.1",
+        "@trezor/connect": "9.0.2",
         "@trezor/urls": "*",
         "@trezor/utils": "*",
         "bignumber.js": "^9.1.0",

--- a/suite-native/app/package.json
+++ b/suite-native/app/package.json
@@ -33,7 +33,7 @@
         "@suite-native/state": "*",
         "@suite-native/storage": "*",
         "@suite-native/transactions": "*",
-        "@trezor/connect": "9.0.1",
+        "@trezor/connect": "9.0.2",
         "@trezor/icons": "*",
         "@trezor/styles": "*",
         "@trezor/theme": "*",

--- a/suite-native/module-accounts-import/package.json
+++ b/suite-native/module-accounts-import/package.json
@@ -27,7 +27,7 @@
         "@suite-native/module-devices": "*",
         "@suite-native/module-settings": "*",
         "@suite-native/navigation": "*",
-        "@trezor/connect": "9.0.1",
+        "@trezor/connect": "9.0.2",
         "@trezor/icons": "*",
         "@trezor/styles": "*",
         "react": "^17.0.2",

--- a/suite-native/state/package.json
+++ b/suite-native/state/package.json
@@ -17,7 +17,7 @@
         "@suite-native/module-devices": "*",
         "@suite-native/module-settings": "*",
         "@suite-native/storage": "*",
-        "@trezor/connect": "9.0.1",
+        "@trezor/connect": "9.0.2",
         "@trezor/styles": "*",
         "@trezor/utils": "*",
         "redux-flipper": "2.0.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -5968,7 +5968,7 @@ __metadata:
     "@suite-common/redux-utils": "*"
     "@suite-common/suite-types": "*"
     "@suite-common/test-utils": "*"
-    "@trezor/connect": 9.0.1
+    "@trezor/connect": 9.0.2
     "@trezor/utils": "*"
     jest: ^26.6.3
     redux-mock-store: ^1.5.4
@@ -6016,7 +6016,7 @@ __metadata:
   dependencies:
     "@suite-common/suite-types": "*"
     "@suite-common/wallet-config": "*"
-    "@trezor/connect": 9.0.1
+    "@trezor/connect": 9.0.2
     jest: ^26.6.3
     typescript: 4.7.4
   languageName: unknown
@@ -6031,7 +6031,7 @@ __metadata:
     "@suite-common/suite-types": "*"
     "@suite-common/wallet-config": "*"
     "@suite-common/wallet-types": "*"
-    "@trezor/connect": 9.0.1
+    "@trezor/connect": 9.0.2
     jest: ^26.6.3
     react: 17.0.2
     react-redux: 7.2.2
@@ -6065,7 +6065,7 @@ __metadata:
     "@reduxjs/toolkit": ^1.8.3
     "@suite-common/metadata-types": "*"
     "@suite-common/wallet-config": "*"
-    "@trezor/connect": 9.0.1
+    "@trezor/connect": 9.0.2
     "@trezor/suite-data": "*"
     jest: ^26.6.3
     typescript: 4.7.4
@@ -6093,7 +6093,7 @@ __metadata:
     "@suite-common/suite-types": "*"
     "@suite-common/wallet-config": "*"
     "@suite-common/wallet-types": "*"
-    "@trezor/connect": 9.0.1
+    "@trezor/connect": 9.0.2
     "@trezor/utils": "*"
     dropbox: ^10.32.0
     fake-indexeddb: ^3.1.7
@@ -6136,7 +6136,7 @@ __metadata:
     "@suite-common/wallet-config": "*"
     "@suite-common/wallet-types": "*"
     "@suite-common/wallet-utils": "*"
-    "@trezor/connect": 9.0.1
+    "@trezor/connect": 9.0.2
     "@trezor/utils": "*"
     date-fns: ^2.29.1
     jest: ^26.6.3
@@ -6152,7 +6152,7 @@ __metadata:
     "@suite-common/suite-utils": "*"
     "@suite-common/wallet-config": "*"
     "@suite-common/wallet-constants": "*"
-    "@trezor/connect": 9.0.1
+    "@trezor/connect": 9.0.2
     "@trezor/type-utils": "*"
     "@trezor/utils": "*"
     jest: ^26.6.3
@@ -6178,7 +6178,7 @@ __metadata:
     "@suite-common/wallet-config": "*"
     "@suite-common/wallet-constants": "*"
     "@suite-common/wallet-types": "*"
-    "@trezor/connect": 9.0.1
+    "@trezor/connect": 9.0.2
     "@trezor/urls": "*"
     "@trezor/utils": "*"
     "@types/pdfmake": ^0.1.21
@@ -6242,7 +6242,7 @@ __metadata:
     "@suite-native/module-devices": "*"
     "@suite-native/module-settings": "*"
     "@suite-native/navigation": "*"
-    "@trezor/connect": 9.0.1
+    "@trezor/connect": 9.0.2
     "@trezor/icons": "*"
     "@trezor/styles": "*"
     jest: ^26.6.3
@@ -6424,7 +6424,7 @@ __metadata:
     "@suite-native/module-devices": "*"
     "@suite-native/module-settings": "*"
     "@suite-native/storage": "*"
-    "@trezor/connect": 9.0.1
+    "@trezor/connect": 9.0.2
     "@trezor/styles": "*"
     "@trezor/utils": "*"
     jest: ^26.6.3
@@ -6709,7 +6709,7 @@ __metadata:
   resolution: "@trezor/connect-explorer@workspace:packages/connect-explorer"
   dependencies:
     "@trezor/components": "*"
-    "@trezor/connect-web": 9.0.1
+    "@trezor/connect-web": 9.0.2
     "@types/markdown-it": 12.2.3
     "@types/markdown-it-link-attributes": 3.0.1
     "@types/react-router": ^5.1.11
@@ -6747,7 +6747,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@trezor/connect-iframe@workspace:packages/connect-iframe"
   dependencies:
-    "@trezor/connect": 9.0.1
+    "@trezor/connect": 9.0.2
     copy-webpack-plugin: ^11.0.0
     html-webpack-plugin: ^5.5.0
     jest: ^26.6.3
@@ -6794,7 +6794,7 @@ __metadata:
   dependencies:
     "@playwright/test": ^1.22.2
     "@trezor/components": "*"
-    "@trezor/connect": 9.0.1
+    "@trezor/connect": 9.0.2
     "@trezor/connect-ui": "*"
     "@trezor/crypto-utils": "*"
     "@trezor/trezor-user-env-link": "*"
@@ -6821,7 +6821,7 @@ __metadata:
   resolution: "@trezor/connect-ui@workspace:packages/connect-ui"
   dependencies:
     "@trezor/components": "*"
-    "@trezor/connect": 9.0.1
+    "@trezor/connect": 9.0.2
     "@trezor/env-utils": "*"
     "@trezor/urls": "*"
     "@types/react": ^17.0.0
@@ -6836,11 +6836,11 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@trezor/connect-web@9.0.1, @trezor/connect-web@workspace:packages/connect-web":
+"@trezor/connect-web@9.0.2, @trezor/connect-web@workspace:packages/connect-web":
   version: 0.0.0-use.local
   resolution: "@trezor/connect-web@workspace:packages/connect-web"
   dependencies:
-    "@trezor/connect": 9.0.1
+    "@trezor/connect": 9.0.2
     "@trezor/utils": ^9.0.2
     "@types/chrome": 0.0.181
     "@types/w3c-web-usb": ^1.0.5
@@ -6854,7 +6854,7 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@trezor/connect@9.0.1, @trezor/connect@workspace:packages/connect":
+"@trezor/connect@9.0.2, @trezor/connect@workspace:packages/connect":
   version: 0.0.0-use.local
   resolution: "@trezor/connect@workspace:packages/connect"
   dependencies:
@@ -7112,7 +7112,7 @@ __metadata:
   dependencies:
     "@sentry/electron": 3.0.0
     "@suite-common/suite-utils": "*"
-    "@trezor/connect": 9.0.1
+    "@trezor/connect": 9.0.2
     "@trezor/connect-common": "*"
     "@trezor/request-manager": "*"
     "@trezor/suite-analytics": "*"
@@ -7170,7 +7170,7 @@ __metadata:
     "@suite-native/state": "*"
     "@suite-native/storage": "*"
     "@suite-native/transactions": "*"
-    "@trezor/connect": 9.0.1
+    "@trezor/connect": 9.0.2
     "@trezor/icons": "*"
     "@trezor/styles": "*"
     "@trezor/theme": "*"
@@ -7294,7 +7294,7 @@ __metadata:
     "@testing-library/react": 12.1.5
     "@testing-library/user-event": 12.8.3
     "@trezor/components": "*"
-    "@trezor/connect": 9.0.1
+    "@trezor/connect": 9.0.2
     "@trezor/crypto-utils": "*"
     "@trezor/dom-utils": "*"
     "@trezor/env-utils": "*"


### PR DESCRIPTION
## @trezor/connect npm release

-   [x] Bump version in all @trezor/connect\* packages (except plugin packages). `yarn workspace @trezor/connect version:<beta|patch|minor|major>`
-   [x] Make sure you have released all npm dependencies. If unsure run `node ./ci/scripts/check-npm-dependencies.js connect`. Please note that this script will report unreleased dependencies even for changes that do not affect runtime (READMEs etc.)
-   [x] If there are any unreleased npm dependencies you should [release them](./npm-packages.md)
-   [x] Make sure CHANGELOG files have been updated
-   [x] Release npm packages for `@trezor/connect` and `@trezor/connect-web` [from gitlab](https://gitlab.com/satoshilabs/trezor/trezor-suite/-/pipelines)
