### PR TITLE
Fix migration to 31 when tx.details are missing

### DIFF
--- a/packages/suite/src/storage/migrations/index.ts
+++ b/packages/suite/src/storage/migrations/index.ts
@@ -574,7 +574,7 @@ export const migrate: OnUpgradeFunc<SuiteDBSchema> = async (
                           deposit: unformatIfDefined(origTx.cardanoSpecific.deposit),
                       }
                     : undefined,
-                details: {
+                details: origTx.details && {
                     ...origTx.details,
                     vin: origTx.details.vin.map(v => ({
                         ...v,


### PR DESCRIPTION
## Description

Should resolve issue where DB migration to v31 fails because tx.details are missing in some stored transaction. The data will remain incomplete in the same way as before the migration, but the migration itself should succeed.

## Related Issue

Resolve #6333
