### PR TITLE
Fix/buy post xss

### DIFF
--- a/packages/utils/src/index.ts
+++ b/packages/utils/src/index.ts
@@ -22,3 +22,4 @@ export * from './isHex';
 export * from './resolveStaticPath';
 export * from './createTimeoutPromise';
 export * from './redactUserPath';
+export * as xssFilters from './xssFilters';

--- a/packages/utils/src/xssFilters.ts
+++ b/packages/utils/src/xssFilters.ts
@@ -1,0 +1,9 @@
+const LT = /</g;
+const SQUOT = /'/g;
+const QUOT = /"/g;
+
+export const inHTML = (value: string) => value.replace(LT, '&lt;');
+
+export const inSingleQuotes = (value: string) => value.replace(SQUOT, '&#39;');
+
+export const inDoubleQuotes = (value: string) => value.replace(QUOT, '&quot;');

--- a/packages/utils/tests/xssFilters.test.ts
+++ b/packages/utils/tests/xssFilters.test.ts
@@ -1,0 +1,27 @@
+import { inHTML, inSingleQuotes, inDoubleQuotes } from '../src/xssFilters';
+
+describe('XSS filters', () => {
+    describe('in HTML data', () => {
+        it('it should escape < symbol', () => {
+            expect(inHTML(`"a"<script>alert(1)</script>'b'`)).toBe(
+                `"a"&lt;script>alert(1)&lt;/script>'b'`,
+            );
+        });
+    });
+
+    describe('in single quoted attribute', () => {
+        it('it should escape single quote symbol', () => {
+            expect(inSingleQuotes(`"a"<script>alert(1)</script>'b'`)).toBe(
+                `"a"<script>alert(1)</script>&#39;b&#39;`,
+            );
+        });
+    });
+
+    describe('in double quoted attribute', () => {
+        it('it should escape double quote symbol', () => {
+            expect(inDoubleQuotes(`"a"<script>alert(1)</script>'b'`)).toBe(
+                `&quot;a&quot;<script>alert(1)</script>'b'`,
+            );
+        });
+    });
+});


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

Verify  `a` (action) query param on /buy-post endpoint is valid URL and escape unsafe symbols depending on context for all params on /buy-post endpoint.

We were considering whitelist of allowed provider URLs for the a param but we don't want to hardcode them in Suite.

<!--- Describe your changes in detail -->


