### PR TITLE
Feat coinjoin Tor requirement modal with loader

### DIFF
--- a/packages/components/src/components/Modal/index.tsx
+++ b/packages/components/src/components/Modal/index.tsx
@@ -30,13 +30,6 @@ const Header = styled.div<HeaderProps>`
         isBottomBorderShown ? `1px solid ${theme.STROKE_GREY}` : 'none'};
 `;
 
-const BackIcon = styled(Icon)`
-    svg {
-        width: 27px;
-        height: 27px;
-    }
-`;
-
 interface HeadingContainerProps {
     isHeadingCentered?: boolean;
     isWithBackButton?: boolean;
@@ -160,6 +153,13 @@ const ModalWindow = styled.div`
 const CloseIcon = styled(Icon)`
     width: 26px;
     height: 26px;
+`;
+
+const BackIcon = styled(Icon)`
+    width: 40px;
+    height: 27px;
+    padding-right: 20px;
+    margin-left: auto;
 `;
 
 interface ModalProps {

--- a/packages/request-manager/src/controller.ts
+++ b/packages/request-manager/src/controller.ts
@@ -79,6 +79,7 @@ export class TorController extends EventEmitter {
     waitUntilAlive(): Promise<void> {
         const errorMessages: string[] = [];
         this.torIsDisabledWhileStarting = false;
+        this.isCircuitEstablished = false;
         const waitUntilResponse = async (triesCount: number): Promise<void> => {
             if (this.torIsDisabledWhileStarting) {
                 // If TOR is starting and we want to cancel it.
@@ -98,7 +99,7 @@ export class TorController extends EventEmitter {
                 }
             } catch (error) {
                 // Some error here is expected when waiting but
-                // we do not want to throw untill maxTriesWaiting is reach.
+                // we do not want to throw until maxTriesWaiting is reach.
                 // Instead we want to log it to know what causes the error.
                 if (error && error.message) {
                     console.warn('request-manager:', error.message);

--- a/packages/suite-desktop-ui/src/support/screens/TorLoadingScreen.tsx
+++ b/packages/suite-desktop-ui/src/support/screens/TorLoadingScreen.tsx
@@ -3,9 +3,9 @@ import React, { useState, useEffect } from 'react';
 import styled from 'styled-components';
 import { ThemeProvider } from '@suite-support/ThemeProvider';
 import { TorStatus } from '@suite-types';
-import { Translation } from '@suite-components/Translation';
+import { Translation, TorLoader } from '@suite-components';
 
-import { Button, Progress, Image, variables, Modal } from '@trezor/components';
+import { Button, Modal } from '@trezor/components';
 import { desktopApi, BootstrapTorEvent } from '@trezor/suite-desktop-api';
 
 const Wrapper = styled.div`
@@ -19,73 +19,6 @@ const Wrapper = styled.div`
 
 const StyledModal = styled(Modal)`
     max-width: 600px;
-`;
-
-const StyledImage = styled(Image)`
-    margin-bottom: 28px;
-`;
-
-const Text = styled.h2`
-    font-size: ${variables.FONT_SIZE.H2};
-    font-weight: ${variables.FONT_WEIGHT.MEDIUM};
-    color: ${({ theme }) => theme.TYPE_DARK_GREY};
-`;
-
-const InfoWrapper = styled.div`
-    display: flex;
-    justify-content: space-between;
-`;
-
-const MessageWrapper = styled.div`
-    display: flex;
-    flex-direction: column;
-    align-items: center;
-    justify-content: center;
-    margin-bottom: 28px;
-`;
-
-const DisableButton = styled(Button)`
-    margin-left: 10px;
-    border: 1px solid ${({ theme }) => theme.STROKE_GREY};
-    background: ${({ theme }) => theme.BG_WHITE};
-    color: ${({ theme }) => theme.TYPE_LIGHT_GREY};
-
-    :hover {
-        background: ${({ theme }) => theme.BG_LIGHT_RED};
-    }
-`;
-
-const Percentage = styled.span`
-    display: flex;
-    align-items: center;
-    font-variant-numeric: tabular-nums;
-    height: 24px;
-`;
-
-const StyledProgress = styled(Progress)`
-    display: flex;
-    margin: 0 20px;
-    border-radius: 5px;
-    flex: 1;
-
-    ${Progress.Value} {
-        position: relative;
-        border-radius: 5px;
-    }
-`;
-
-const ProgressWrapper = styled.div`
-    display: flex;
-    align-items: center;
-    border-radius: 8px;
-    width: 100%;
-    min-height: 45px;
-`;
-
-const ProgressMessage = styled.div`
-    margin-right: 16px;
-    color: ${({ theme }) => theme.TYPE_LIGHT_GREY};
-    font-weight: ${variables.FONT_WEIGHT.MEDIUM};
 `;
 
 const StyledButton = styled(Button)`
@@ -125,14 +58,6 @@ export const TorLoadingScreen = ({ callback }: TorLoadingScreenProps) => {
         return () => desktopApi.removeAllListeners('tor/bootstrap');
     }, [torStatus, callback]);
 
-    let message: 'TR_ENABLING_TOR' | 'TR_ENABLING_TOR_FAILED' | 'TR_DISABLING_TOR' =
-        'TR_ENABLING_TOR';
-    if (torStatus === TorStatus.Error) {
-        message = 'TR_ENABLING_TOR_FAILED';
-    } else if (torStatus === TorStatus.Disabling) {
-        message = 'TR_DISABLING_TOR';
-    }
-
     const tryAgain = async () => {
         setProgress(0);
         setTorStatus(TorStatus.Enabling);
@@ -152,7 +77,7 @@ export const TorLoadingScreen = ({ callback }: TorLoadingScreenProps) => {
         desktopApi.removeAllListeners('tor/bootstrap');
         desktopApi.toggleTor(false);
 
-        // This is a total fake progress, otherwise it would be to fast for user.
+        // This is a total fake progress, otherwise it would be too fast for user.
         await new Promise(resolve => {
             const interval = setInterval(() => {
                 if (fakeProgress === 100) {
@@ -184,39 +109,7 @@ export const TorLoadingScreen = ({ callback }: TorLoadingScreenProps) => {
                         )
                     }
                 >
-                    <MessageWrapper>
-                        <StyledImage width={130} height={130} image="TOR_ENABLING" />
-                        <Text>
-                            <Translation id={message} />
-                        </Text>
-                    </MessageWrapper>
-
-                    <InfoWrapper>
-                        <ProgressWrapper>
-                            <StyledProgress
-                                isRed={torStatus === TorStatus.Error}
-                                value={torStatus === TorStatus.Error ? 100 : progress}
-                            />
-
-                            <ProgressMessage>
-                                {torStatus === TorStatus.Error ? (
-                                    <Translation id="TR_FAILED" />
-                                ) : (
-                                    <Percentage>{progress} %</Percentage>
-                                )}
-                            </ProgressMessage>
-                        </ProgressWrapper>
-
-                        {torStatus !== TorStatus.Disabling && (
-                            <DisableButton
-                                data-test="@tor-loading-screen/disable-button"
-                                variant="secondary"
-                                onClick={disableTor}
-                            >
-                                <Translation id="TR_TOR_DISABLE" />
-                            </DisableButton>
-                        )}
-                    </InfoWrapper>
+                    <TorLoader torStatus={torStatus} progress={progress} disableTor={disableTor} />
                 </StyledModal>
             </Wrapper>
         </ThemeProvider>

--- a/packages/suite-desktop/src/libs/processes/TorProcess.ts
+++ b/packages/suite-desktop/src/libs/processes/TorProcess.ts
@@ -57,7 +57,7 @@ class TorProcess extends BaseProcess {
         const torConfiguration = this.torController.getTorConfiguration(electronProcessId);
 
         await super.start(torConfiguration);
-        // Initlialize TorIdentities with TorController so requests are intercepted to use Tor.
+        // Initialize TorIdentities with TorController so requests are intercepted to use Tor.
         // `TorIdentities` needs to be initialized with `TorController` because it needs to know the
         // `host` and `port` of the Tor process to create SocksProxyAgent.
         TorIdentities.init(this.torController);

--- a/packages/suite/src/actions/suite/modalActions.ts
+++ b/packages/suite/src/actions/suite/modalActions.ts
@@ -128,6 +128,14 @@ export type UserContextPayload =
     | {
           type: 'disable-tor';
           decision: Deferred<boolean>;
+      }
+    | {
+          type: 'request-enable-tor';
+          decision: Deferred<boolean>;
+      }
+    | {
+          type: 'tor-loading';
+          decision: Deferred<boolean>;
       };
 
 export type ModalAction =
@@ -210,6 +218,8 @@ type DeferredModals = Extract<
         type:
             | 'qr-reader'
             | 'disable-tor'
+            | 'request-enable-tor'
+            | 'tor-loading'
             | 'review-transaction'
             | 'import-transaction'
             | 'coinmarket-buy-terms'

--- a/packages/suite/src/components/suite/ModalSwitcher/UserContextModal.tsx
+++ b/packages/suite/src/components/suite/ModalSwitcher/UserContextModal.tsx
@@ -28,6 +28,8 @@ import {
     AddToken,
     SafetyChecks,
     DisableTor,
+    RequestEnableTor,
+    TorLoading,
 } from '@suite-components/modals';
 
 import type { AcquiredDevice } from '@suite-types';
@@ -144,6 +146,10 @@ export const UserContextModal = ({
             return <SafetyChecks onCancel={onCancel} />;
         case 'disable-tor':
             return <DisableTor decision={payload.decision} onCancel={onCancel} />;
+        case 'request-enable-tor':
+            return <RequestEnableTor decision={payload.decision} onCancel={onCancel} />;
+        case 'tor-loading':
+            return <TorLoading decision={payload.decision} onCancel={onCancel} />;
         default:
             return null;
     }

--- a/packages/suite/src/components/suite/TorLoader.tsx
+++ b/packages/suite/src/components/suite/TorLoader.tsx
@@ -7,6 +7,8 @@ import { Translation } from '@suite-components/Translation';
 
 const StyledImage = styled(Image)`
     margin-bottom: 28px;
+    width: auto;
+    height: 110px;
 `;
 
 const Text = styled.h2`
@@ -90,7 +92,7 @@ export const TorLoader = ({ torStatus, progress, disableTor }: TorLoaderProps) =
     return (
         <>
             <MessageWrapper>
-                <StyledImage width={130} height={130} image="TOR_ENABLING" />
+                <StyledImage image="TOR_ENABLING" />
                 <Text>
                     <Translation id={message} />
                 </Text>

--- a/packages/suite/src/components/suite/TorLoader.tsx
+++ b/packages/suite/src/components/suite/TorLoader.tsx
@@ -1,0 +1,127 @@
+import React from 'react';
+import styled from 'styled-components';
+
+import { Button, Progress, Image, variables } from '@trezor/components';
+import { TorStatus } from '@suite-types';
+import { Translation } from '@suite-components/Translation';
+
+const StyledImage = styled(Image)`
+    margin-bottom: 28px;
+`;
+
+const Text = styled.h2`
+    font-size: ${variables.FONT_SIZE.H2};
+    font-weight: ${variables.FONT_WEIGHT.MEDIUM};
+    color: ${({ theme }) => theme.TYPE_DARK_GREY};
+`;
+
+const InfoWrapper = styled.div`
+    display: flex;
+    justify-content: space-between;
+`;
+
+const MessageWrapper = styled.div`
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    justify-content: center;
+    margin-bottom: 28px;
+`;
+
+const DisableButton = styled(Button)`
+    margin-left: 10px;
+    border: 1px solid ${({ theme }) => theme.STROKE_GREY};
+    background: ${({ theme }) => theme.BG_WHITE};
+    color: ${({ theme }) => theme.TYPE_LIGHT_GREY};
+
+    :hover {
+        background: ${({ theme }) => theme.BG_LIGHT_RED};
+    }
+`;
+
+const Percentage = styled.span`
+    display: flex;
+    align-items: center;
+    font-variant-numeric: tabular-nums;
+    height: 24px;
+`;
+
+const StyledProgress = styled(Progress)`
+    display: flex;
+    margin: 0 20px;
+    border-radius: 5px;
+    flex: 1;
+
+    ${Progress.Value} {
+        position: relative;
+        border-radius: 5px;
+    }
+`;
+
+const ProgressWrapper = styled.div`
+    display: flex;
+    align-items: center;
+    border-radius: 8px;
+    width: 100%;
+    min-height: 45px;
+`;
+
+const ProgressMessage = styled.div`
+    margin-right: 16px;
+    color: ${({ theme }) => theme.TYPE_LIGHT_GREY};
+    font-weight: ${variables.FONT_WEIGHT.MEDIUM};
+`;
+
+interface TorLoaderProps {
+    torStatus: TorStatus;
+    progress: number;
+    disableTor: () => void;
+}
+
+export const TorLoader = ({ torStatus, progress, disableTor }: TorLoaderProps) => {
+    let message: 'TR_ENABLING_TOR' | 'TR_ENABLING_TOR_FAILED' | 'TR_DISABLING_TOR' =
+        'TR_ENABLING_TOR';
+    if (torStatus === TorStatus.Error) {
+        message = 'TR_ENABLING_TOR_FAILED';
+    } else if (torStatus === TorStatus.Disabling) {
+        message = 'TR_DISABLING_TOR';
+    }
+
+    return (
+        <>
+            <MessageWrapper>
+                <StyledImage width={130} height={130} image="TOR_ENABLING" />
+                <Text>
+                    <Translation id={message} />
+                </Text>
+            </MessageWrapper>
+
+            <InfoWrapper>
+                <ProgressWrapper>
+                    <StyledProgress
+                        isRed={torStatus === TorStatus.Error}
+                        value={torStatus === TorStatus.Error ? 100 : progress}
+                    />
+
+                    <ProgressMessage>
+                        {torStatus === TorStatus.Error ? (
+                            <Translation id="TR_FAILED" />
+                        ) : (
+                            <Percentage>{progress} %</Percentage>
+                        )}
+                    </ProgressMessage>
+                </ProgressWrapper>
+
+                {torStatus !== TorStatus.Disabling && (
+                    <DisableButton
+                        data-test="@tor-loading-screen/disable-button"
+                        variant="secondary"
+                        onClick={disableTor}
+                    >
+                        <Translation id="TR_TOR_DISABLE" />
+                    </DisableButton>
+                )}
+            </InfoWrapper>
+        </>
+    );
+};

--- a/packages/suite/src/components/suite/index.tsx
+++ b/packages/suite/src/components/suite/index.tsx
@@ -49,6 +49,7 @@ import StatusLight from './StatusLight';
 import { AmountUnitSwitchWrapper } from './AmountUnitSwitchWrapper';
 import { renderToast } from './ToastNotification';
 import { SuiteLayout } from './SuiteLayout';
+import { TorLoader } from './TorLoader';
 
 export {
     DeviceIcon,
@@ -105,5 +106,6 @@ export {
     StatusLight,
     AmountUnitSwitchWrapper,
     renderToast,
+    TorLoader,
 };
 export type { ModalProps };

--- a/packages/suite/src/components/suite/modals/AddAccount/components/AddCoinJoinAccountButton.tsx
+++ b/packages/suite/src/components/suite/modals/AddAccount/components/AddCoinJoinAccountButton.tsx
@@ -1,20 +1,32 @@
 import React from 'react';
 import { Translation } from '@suite-components';
 import { useSelector, useActions } from '@suite-hooks';
+import { useDispatch } from 'react-redux';
 import { createCoinjoinAccount } from '@wallet-actions/coinjoinAccountActions';
+import * as modalActions from '@suite-actions/modalActions';
 import type { Network } from '@wallet-types';
 import { AddButton } from './AddButton';
+import { getIsTorEnabled } from '@suite-utils/tor';
+import { isDesktop } from '@suite-utils/env';
+import { desktopApi } from '@trezor/suite-desktop-api';
 
 interface AddCoinJoinAccountProps {
     network: Network;
 }
 
 export const AddCoinJoinAccountButton = ({ network }: AddCoinJoinAccountProps) => {
+    const isTorEnabled = useSelector(state => getIsTorEnabled(state.suite.torStatus));
+
     const action = useActions({ createCoinjoinAccount });
+    const dispatch = useDispatch();
     const { device, accounts } = useSelector(state => ({
         device: state.suite.device,
         accounts: state.wallet.accounts,
     }));
+
+    if (!device) {
+        return null;
+    }
 
     const coinjoinAccounts = accounts.filter(
         a =>
@@ -26,13 +38,45 @@ export const AddCoinJoinAccountButton = ({ network }: AddCoinJoinAccountProps) =
     // TODO: more disabled button states
     // no-capability, device connected etc
 
+    const onCreateCoinjoinAccountClick = async () => {
+        // Checking if Tor is enable and if not open modal to force the user to enable it to use coinjoin.
+        // TODO: if the current network is regtest or testnet we could ignore this to make faster developer experience.
+        // const isDevNetwork = ['regtest', 'test'].includes(network.symbol);
+        // Tor only works in desktop so checking we are running desktop.
+        if (!isTorEnabled && isDesktop()) {
+            const continueWithTor = await dispatch(
+                modalActions.openDeferredModal({ type: 'request-enable-tor' }),
+            );
+            if (!continueWithTor) {
+                // Going back to the previous screen.
+                dispatch(
+                    modalActions.openModal({
+                        type: 'add-account',
+                        device,
+                    }),
+                );
+
+                return;
+            }
+
+            // Triggering Tor process and displaying Tor loading to give user feedback of Tor progress.
+            desktopApi.toggleTor(true);
+            const isTorLoaded = await dispatch(
+                modalActions.openDeferredModal({ type: 'tor-loading' }),
+            );
+            // When Tor was not loaded it means there was an error or user canceled it, stop the coinjoin account activation.
+            if (!isTorLoaded) return;
+        }
+        action.createCoinjoinAccount(network);
+    };
+
     const isDisabled = coinjoinAccounts.length > 0;
     return (
         <AddButton
             disabledMessage={
                 isDisabled ? <Translation id="MODAL_ADD_ACCOUNT_LIMIT_EXCEEDED" /> : null
             }
-            handleClick={() => action.createCoinjoinAccount(network)}
+            handleClick={onCreateCoinjoinAccountClick}
         />
     );
 };

--- a/packages/suite/src/components/suite/modals/RequestEnableTor.tsx
+++ b/packages/suite/src/components/suite/modals/RequestEnableTor.tsx
@@ -1,0 +1,74 @@
+import React from 'react';
+import styled from 'styled-components';
+import { Button, P } from '@trezor/components';
+import { Modal, Translation } from '@suite-components';
+import { UserContextPayload } from '@suite-actions/modalActions';
+
+const SmallModal = styled(Modal)`
+    width: 560px;
+`;
+
+const Description = styled(P)`
+    text-align: left;
+    margin-bottom: 16px;
+`;
+
+const ItalicDescription = styled(Description)`
+    font-style: italic;
+`;
+
+type RequestEnableTorProps = Omit<
+    Extract<UserContextPayload, { type: 'request-enable-tor' }>,
+    'type'
+> & {
+    onCancel: () => void;
+};
+
+export const RequestEnableTor = ({ onCancel, decision }: RequestEnableTorProps) => {
+    const onEnableTor = () => {
+        decision.resolve(true);
+        onCancel();
+    };
+
+    const onBackClick = () => {
+        decision.resolve(false);
+        onCancel();
+    };
+
+    return (
+        <>
+            <SmallModal
+                isCancelable
+                onCancel={onCancel}
+                onBackClick={onBackClick}
+                isHeadingCentered
+                heading={<Translation id="TR_TOR_ENABLE" />}
+                bottomBar={
+                    <>
+                        <Button variant="secondary" onClick={onCancel}>
+                            <Translation id="TR_TOR_REQUEST_ENABLE_FOR_COIN_JOIN_LEAVE" />
+                        </Button>
+
+                        <Button variant="primary" onClick={onEnableTor}>
+                            <Translation id="TR_TOR_ENABLE" />
+                        </Button>
+                    </>
+                }
+            >
+                <>
+                    <Description>
+                        <Translation
+                            id="TR_TOR_REQUEST_ENABLE_FOR_COIN_JOIN_TITLE"
+                            values={{
+                                b: chunks => <b>{chunks}</b>,
+                            }}
+                        />
+                    </Description>
+                    <ItalicDescription>
+                        <Translation id="TR_TOR_REQUEST_ENABLE_FOR_COIN_JOIN_SUBTITLE" />
+                    </ItalicDescription>
+                </>
+            </SmallModal>
+        </>
+    );
+};

--- a/packages/suite/src/components/suite/modals/TorLoading.tsx
+++ b/packages/suite/src/components/suite/modals/TorLoading.tsx
@@ -1,0 +1,103 @@
+import React, { useState, useEffect } from 'react';
+import styled from 'styled-components';
+
+import { desktopApi, BootstrapTorEvent } from '@trezor/suite-desktop-api';
+import { Button } from '@trezor/components';
+import { TorStatus } from '@suite-types';
+import { TorLoader, Modal, Translation } from '@suite-components';
+
+import type { UserContextPayload } from '@suite-actions/modalActions';
+
+const SmallModal = styled(Modal)`
+    width: 560px;
+`;
+
+type RequestEnableTorProps = Omit<
+    Extract<UserContextPayload, { type: 'request-enable-tor' }>,
+    'type'
+> & {
+    onCancel: () => void;
+};
+
+export const TorLoading = ({ onCancel, decision }: RequestEnableTorProps) => {
+    const [torStatus, setTorStatus] = useState<TorStatus>(TorStatus.Enabling);
+    const [progress, setProgress] = useState<number>(0);
+
+    useEffect(() => {
+        desktopApi.on('tor/bootstrap', (bootstrapEvent: BootstrapTorEvent) => {
+            if (bootstrapEvent.type === 'error') {
+                setTorStatus(TorStatus.Error);
+            }
+
+            if (bootstrapEvent.type !== 'progress') {
+                return;
+            }
+
+            if (bootstrapEvent.type === 'progress' && bootstrapEvent.progress.current) {
+                setProgress(bootstrapEvent.progress.current);
+
+                if (bootstrapEvent.progress.current === bootstrapEvent.progress.total) {
+                    setTorStatus(TorStatus.Enabled);
+                    decision.resolve(true);
+                } else {
+                    setTorStatus(TorStatus.Enabling);
+                }
+            }
+        });
+
+        return () => desktopApi.removeAllListeners('tor/bootstrap');
+    }, [torStatus, decision]);
+
+    const tryAgain = async () => {
+        setProgress(0);
+        setTorStatus(TorStatus.Enabling);
+
+        const torLoaded = await desktopApi.toggleTor(true);
+
+        if (!torLoaded.success) {
+            setTorStatus(TorStatus.Error);
+        }
+    };
+
+    const disableTor = async () => {
+        let fakeProgress = 0;
+
+        setTorStatus(TorStatus.Disabling);
+
+        desktopApi.removeAllListeners('tor/bootstrap');
+        desktopApi.toggleTor(false);
+
+        // This is a total fake progress, otherwise it would be too fast for user.
+        await new Promise(resolve => {
+            const interval = setInterval(() => {
+                if (fakeProgress === 100) {
+                    clearInterval(interval);
+                    return resolve(null);
+                }
+
+                fakeProgress += 10;
+                setProgress(fakeProgress);
+            }, 300);
+        });
+
+        decision.resolve(false);
+        onCancel();
+    };
+
+    return (
+        <>
+            <SmallModal
+                heading={<Translation id="TR_TOR_ENABLE" />}
+                bottomBar={
+                    torStatus === TorStatus.Error && (
+                        <Button icon="REFRESH" onClick={tryAgain}>
+                            <Translation id="TR_TRY_AGAIN" />
+                        </Button>
+                    )
+                }
+            >
+                <TorLoader torStatus={torStatus} progress={progress} disableTor={disableTor} />
+            </SmallModal>
+        </>
+    );
+};

--- a/packages/suite/src/components/suite/modals/index.tsx
+++ b/packages/suite/src/components/suite/modals/index.tsx
@@ -33,3 +33,5 @@ export { AdvancedCoinSettings } from './AdvancedCoinSettings';
 export { AddToken } from './AddToken';
 export { SafetyChecks } from './SafetyChecks';
 export { DisableTor } from './DisableTor';
+export { RequestEnableTor } from './RequestEnableTor';
+export { TorLoading } from './TorLoading';

--- a/packages/suite/src/support/messages.ts
+++ b/packages/suite/src/support/messages.ts
@@ -3813,6 +3813,18 @@ export default defineMessages({
         id: 'TR_TOR_BRIDGE',
         defaultMessage: 'Bridge not working in Tor Browser?',
     },
+    TR_TOR_REQUEST_ENABLE_FOR_COIN_JOIN_TITLE: {
+        id: 'TR_TOR_REQUEST_ENABLE_FOR_COIN_JOIN_TITLE',
+        defaultMessage: '<b>Tor</b> must be enable to remain anonymous when running CoinJoin.',
+    },
+    TR_TOR_REQUEST_ENABLE_FOR_COIN_JOIN_SUBTITLE: {
+        id: 'TR_TOR_REQUEST_ENABLE_FOR_COIN_JOIN_SUBTITLE',
+        defaultMessage: "Please select 'Enable Tor' to continue o 'Leave' to quit the process.",
+    },
+    TR_TOR_REQUEST_ENABLE_FOR_COIN_JOIN_LEAVE: {
+        id: 'TR_TOR_REQUEST_ENABLE_FOR_COIN_JOIN_LEAVE',
+        defaultMessage: 'Leave',
+    },
     TR_TRANSACTIONS: {
         id: 'TR_TRANSACTIONS',
         defaultMessage: 'Transactions',


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Add a new modal to force user to use Tor when coinjoining.
It refactors Tor Splash screen in order to have some reusable components.


## Related Issue

https://github.com/trezor/trezor-suite/issues/6212

## Screenshots (if appropriate):
![image](https://user-images.githubusercontent.com/5362163/192271525-e5d33f35-07ee-4977-91e6-4d75386b045b.png)

