### PR TITLE
Minor CoinJoin prerequisites

### DIFF
--- a/packages/blockchain-link/src/workers/blockbook/utils.ts
+++ b/packages/blockchain-link/src/workers/blockbook/utils.ts
@@ -81,9 +81,16 @@ export const filterTokenTransfers = (
         });
 };
 
+// Lighter version of AccountAddresses for tx classification
+type TransformAddresses = {
+    used: { address: string }[];
+    unused: { address: string }[];
+    change: { address: string }[];
+};
+
 export const transformTransaction = (
     descriptor: string,
-    addresses: AccountAddresses | undefined,
+    addresses: TransformAddresses | undefined,
     tx: BlockbookTransaction,
 ): Transaction => {
     // combine all addresses into array

--- a/packages/blockchain-link/src/workers/utils.ts
+++ b/packages/blockchain-link/src/workers/utils.ts
@@ -1,9 +1,9 @@
 import BigNumber from 'bignumber.js';
 import { isNotUndefined, parseHostname } from '@trezor/utils';
-import type { Address, EnhancedVinVout } from '../types';
+import type { EnhancedVinVout } from '../types';
 import type { VinVout } from '../types/blockbook';
 
-export type Addresses = (Address | string)[] | string;
+export type Addresses = ({ address: string } | string)[] | string;
 
 export const isAccountOwned = (addresses: string[]) => (vinVout: VinVout) =>
     Array.isArray(vinVout?.addresses) && vinVout.addresses.some(a => addresses.includes(a));

--- a/packages/suite/src/actions/wallet/__tests__/selectedAccountActions.test.ts
+++ b/packages/suite/src/actions/wallet/__tests__/selectedAccountActions.test.ts
@@ -2,7 +2,7 @@ import { configureStore } from '@suite/support/tests/configureStore';
 
 import selectedAccountReducer from '@wallet-reducers/selectedAccountReducer';
 
-import { getStateForAction } from '../selectedAccountActions';
+import { syncSelectedAccount } from '../selectedAccountActions';
 import fixtures from '../__fixtures__/selectedAccountActions';
 
 export const getInitialState = (_settings?: any) => ({
@@ -32,7 +32,7 @@ describe('selectedAccount Actions', () => {
         it(f.description, () => {
             const state = getInitialState(f.initialState);
             const store = initStore(state);
-            const selectedAccountState = store.dispatch(getStateForAction(f.action as any));
+            const selectedAccountState = store.dispatch(syncSelectedAccount(f.action as any));
             if (f.result) {
                 expect(selectedAccountState).toMatchObject(f.result as any);
             } else {

--- a/packages/suite/src/actions/wallet/selectedAccountActions.ts
+++ b/packages/suite/src/actions/wallet/selectedAccountActions.ts
@@ -2,200 +2,194 @@ import { ROUTER, SUITE } from '@suite-actions/constants';
 import { DISCOVERY } from '@wallet-actions/constants';
 import { NETWORKS } from '@wallet-config';
 
-import * as discoveryActions from '@wallet-actions/discoveryActions';
+import { selectDiscoveryForDevice } from '@wallet-reducers/discoveryReducer';
 import * as metadataActions from '@suite-actions/metadataActions';
 import * as comparisonUtils from '@suite-utils/comparisonUtils';
 import { getSelectedAccount } from '@wallet-utils/accountUtils';
 import { accountsActions, blockchainActions } from '@suite-common/wallet-core';
 import { SelectedAccountStatus, SelectedAccountWatchOnlyMode } from '@suite-common/wallet-types';
 
-import { Action, Dispatch, GetState } from '@suite-types';
+import { Action, Dispatch, GetState, AppState } from '@suite-types';
 import { State } from '@wallet-reducers/selectedAccountReducer';
 
 // Add notification to loaded SelectedAccountState
-const getAccountStateWithMode =
-    (selectedAccount?: State) => (_dispatch: Dispatch, getState: GetState) => {
-        const state = getState();
-        const {
-            device,
-            lifecycle: { status },
-        } = state.suite;
-        if (!device || status !== 'ready') return;
+const getAccountStateWithMode = (state: AppState, selectedAccount?: State) => {
+    const {
+        device,
+        lifecycle: { status },
+    } = state.suite;
+    if (!device || status !== 'ready') return;
 
-        // From this point there could be multiple loaders
-        const mode: SelectedAccountWatchOnlyMode[] = [];
+    // From this point there could be multiple loaders
+    const mode: SelectedAccountWatchOnlyMode[] = [];
 
-        if (selectedAccount && selectedAccount.status === 'loaded') {
-            const { account, discovery, network } = selectedAccount;
-            // Account does exists and it's visible but shouldn't be active
-            if (account && discovery && discovery.status < DISCOVERY.STATUS.STOPPING) {
-                mode.push('account-loading-others');
-            }
-
-            // Backend status
-            const blockchain = state.wallet.blockchain[network.symbol];
-            if (!blockchain.connected && state.suite.online) {
-                mode.push('backend-disconnected');
-            }
+    if (selectedAccount && selectedAccount.status === 'loaded') {
+        const { account, discovery, network } = selectedAccount;
+        // Account does exists and it's visible but shouldn't be active
+        if (account && discovery && discovery.status < DISCOVERY.STATUS.STOPPING) {
+            mode.push('account-loading-others');
         }
 
-        // Account cannot be accessed
-        if (!device.connected) {
-            // device is disconnected
-            mode.push('device-disconnected');
-        } else if (device.authConfirm) {
-            // device needs auth confirmation (empty wallet)
-            mode.push('auth-confirm-failed');
-        } else if (!device.available) {
-            // device is unavailable (created with different passphrase settings)
-            mode.push('device-unavailable');
+        // Backend status
+        const blockchain = state.wallet.blockchain[network.symbol];
+        if (!blockchain.connected && state.suite.online) {
+            mode.push('backend-disconnected');
         }
+    }
 
-        return mode.length > 0 ? mode : undefined;
-    };
+    // Account cannot be accessed
+    if (!device.connected) {
+        // device is disconnected
+        mode.push('device-disconnected');
+    } else if (device.authConfirm) {
+        // device needs auth confirmation (empty wallet)
+        mode.push('auth-confirm-failed');
+    } else if (!device.available) {
+        // device is unavailable (created with different passphrase settings)
+        mode.push('device-unavailable');
+    }
 
-const getAccountState =
-    () =>
-    (dispatch: Dispatch, getState: GetState): SelectedAccountStatus => {
-        const state = getState();
+    return mode.length > 0 ? mode : undefined;
+};
 
-        const { device } = state.suite;
+const getAccountState = (state: AppState): SelectedAccountStatus => {
+    const { device } = state.suite;
 
-        // waiting for device
-        if (!device) {
-            return {
-                status: 'loading',
-                loader: 'waiting-for-device',
-            };
-        }
+    // waiting for device
+    if (!device) {
+        return {
+            status: 'loading',
+            loader: 'waiting-for-device',
+        };
+    }
 
-        if (device.authFailed) {
-            return {
-                status: 'exception',
-                loader: 'auth-failed',
-            };
-        }
-
-        // waiting for discovery
-        const discovery = dispatch(discoveryActions.getDiscoveryForDevice());
-        if (!device.state || !discovery) {
-            return {
-                status: 'loading',
-                loader: 'auth',
-            };
-        }
-
-        const mode = dispatch(getAccountStateWithMode());
-
-        // account cannot exists since there are no selected networks in settings/wallet
-        if (discovery.networks.length === 0) {
-            return {
-                status: 'exception',
-                loader: 'discovery-empty',
-                mode,
-            };
-        }
-
-        // get params from router
-        // or set first default account from discovery list
-        const params =
-            state.router.app === 'wallet' && state.router.params
-                ? state.router.params
-                : {
-                      accountIndex: 0,
-                      accountType: 'normal' as const,
-                      symbol: discovery.networks[0],
-                  };
-
-        const network = NETWORKS.find(c => c.symbol === params.symbol)!;
-
-        // account cannot exists since requested network is not selected in settings/wallet
-        if (!discovery.networks.find(n => n === network.symbol)) {
-            return {
-                status: 'exception',
-                loader: 'account-not-enabled',
-                network,
-                discovery,
-                params,
-                mode,
-            };
-        }
-
-        const failed = discovery.failed.find(
-            f =>
-                f.symbol === network.symbol &&
-                f.index === params.accountIndex &&
-                f.accountType === params.accountType,
-        );
-        // discovery for requested network failed
-        if (failed) {
-            return {
-                status: 'exception',
-                loader: 'account-not-loaded',
-                network,
-                discovery,
-                params,
-                mode,
-            };
-        }
-
-        // get selected account
-        const account = getSelectedAccount(device.state, state.wallet.accounts, params);
-
-        // account does exist
-        if (account && account.visible) {
-            if (typeof account?.lastKnownState?.progress === 'number') {
-                return {
-                    status: 'loading',
-                    loader: 'account-loading',
-                    account,
-                };
-            }
-            // Success!
-            const loadedState = {
-                status: 'loaded',
-                account,
-                network,
-                discovery,
-                params,
-                mode: undefined,
-            } as const;
-            const loadedMode = dispatch(getAccountStateWithMode(loadedState));
-            return {
-                ...loadedState,
-                mode: loadedMode,
-            };
-        }
-
-        // account doesn't exist (yet?) checking why...
-        // discovery is still running
-        if (discovery.error) {
-            return {
-                status: 'exception',
-                loader: 'discovery-error',
-                network,
-                discovery,
-                params,
-                mode,
-            };
-        }
-
-        if (discovery.status !== DISCOVERY.STATUS.COMPLETED) {
-            return {
-                status: 'loading',
-                loader: 'account-loading',
-            };
-        }
-
+    if (device.authFailed) {
         return {
             status: 'exception',
-            loader: 'account-not-exists',
+            loader: 'auth-failed',
+        };
+    }
+
+    // waiting for discovery
+    const discovery = selectDiscoveryForDevice(state);
+    if (!device.state || !discovery) {
+        return {
+            status: 'loading',
+            loader: 'auth',
+        };
+    }
+
+    const mode = getAccountStateWithMode(state);
+
+    // account cannot exists since there are no selected networks in settings/wallet
+    if (discovery.networks.length === 0) {
+        return {
+            status: 'exception',
+            loader: 'discovery-empty',
+            mode,
+        };
+    }
+
+    // get params from router
+    // or set first default account from discovery list
+    const params =
+        state.router.app === 'wallet' && state.router.params
+            ? state.router.params
+            : {
+                  accountIndex: 0,
+                  accountType: 'normal' as const,
+                  symbol: discovery.networks[0],
+              };
+
+    const network = NETWORKS.find(c => c.symbol === params.symbol)!;
+
+    // account cannot exists since requested network is not selected in settings/wallet
+    if (!discovery.networks.find(n => n === network.symbol)) {
+        return {
+            status: 'exception',
+            loader: 'account-not-enabled',
             network,
             discovery,
             params,
             mode,
         };
+    }
+
+    const failed = discovery.failed.find(
+        f =>
+            f.symbol === network.symbol &&
+            f.index === params.accountIndex &&
+            f.accountType === params.accountType,
+    );
+    // discovery for requested network failed
+    if (failed) {
+        return {
+            status: 'exception',
+            loader: 'account-not-loaded',
+            network,
+            discovery,
+            params,
+            mode,
+        };
+    }
+
+    // get selected account
+    const account = getSelectedAccount(device.state, state.wallet.accounts, params);
+
+    // account does exist
+    if (account && account.visible) {
+        if (typeof account?.lastKnownState?.progress === 'number') {
+            return {
+                status: 'loading',
+                loader: 'account-loading',
+                account,
+            };
+        }
+        // Success!
+        const loadedState = {
+            status: 'loaded',
+            account,
+            network,
+            discovery,
+            params,
+            mode: undefined,
+        } as const;
+        const loadedMode = getAccountStateWithMode(state, loadedState);
+        return {
+            ...loadedState,
+            mode: loadedMode,
+        };
+    }
+
+    // account doesn't exist (yet?) checking why...
+    // discovery is still running
+    if (discovery.error) {
+        return {
+            status: 'exception',
+            loader: 'discovery-error',
+            network,
+            discovery,
+            params,
+            mode,
+        };
+    }
+
+    if (discovery.status !== DISCOVERY.STATUS.COMPLETED) {
+        return {
+            status: 'loading',
+            loader: 'account-loading',
+        };
+    }
+
+    return {
+        status: 'exception',
+        loader: 'account-not-exists',
+        network,
+        discovery,
+        params,
+        mode,
     };
+};
 
 // list of all actions which has influence on "selectedAccount" reducer
 // other actions will be ignored
@@ -221,7 +215,7 @@ const actions = [
 /*
  * Called from WalletMiddleware
  */
-export const getStateForAction = (action: Action) => (dispatch: Dispatch, getState: GetState) => {
+export const syncSelectedAccount = (action: Action) => (dispatch: Dispatch, getState: GetState) => {
     // ignore not listed actions
     if (actions.indexOf(action.type) < 0) return;
     const state = getState();
@@ -229,7 +223,7 @@ export const getStateForAction = (action: Action) => (dispatch: Dispatch, getSta
     if (state.router.app !== 'wallet') return;
 
     // get new state
-    const newState = dispatch(getAccountState());
+    const newState = getAccountState(state);
     if (!newState) return;
 
     // find differences

--- a/packages/suite/src/components/suite/SwitchDevice/components/WalletInstance.tsx
+++ b/packages/suite/src/components/suite/SwitchDevice/components/WalletInstance.tsx
@@ -5,8 +5,8 @@ import { analytics, EventType } from '@trezor/suite-analytics';
 import { Switch, Box, Icon, useTheme, variables } from '@trezor/components';
 import { getAllAccounts, getTotalFiatBalance } from '@suite-common/wallet-utils';
 import * as suiteActions from '@suite-actions/suiteActions';
-import * as discoveryActions from '@wallet-actions/discoveryActions';
 import { useFormatters } from '@suite-common/formatters';
+import { selectDiscovery } from '@wallet-reducers/discoveryReducer';
 import {
     WalletLabeling,
     Translation,
@@ -101,10 +101,9 @@ export const WalletInstance = ({
     index,
     ...rest
 }: WalletInstanceProps) => {
-    const { toggleRememberDevice, forgetDevice, getDiscovery } = useActions({
+    const { toggleRememberDevice, forgetDevice } = useActions({
         toggleRememberDevice: suiteActions.toggleRememberDevice,
         forgetDevice: suiteActions.forgetDevice,
-        getDiscovery: discoveryActions.getDiscovery,
     });
     const { accounts, fiat, localCurrency, editing } = useSelector(state => ({
         accounts: state.wallet.accounts,
@@ -116,7 +115,8 @@ export const WalletInstance = ({
     const { FiatAmountFormatter } = useFormatters();
     const theme = useTheme();
 
-    const discoveryProcess = instance.state ? getDiscovery(instance.state) : null;
+    const discoveryProcess = useSelector(state => selectDiscovery(state, instance.state));
+
     const deviceAccounts = getAllAccounts(instance.state, accounts);
     const accountsCount = deviceAccounts.length;
     const instanceBalance = getTotalFiatBalance(deviceAccounts, localCurrency, fiat.coins);

--- a/packages/suite/src/components/suite/modals/Passphrase/index.tsx
+++ b/packages/suite/src/components/suite/modals/Passphrase/index.tsx
@@ -4,7 +4,7 @@ import styled from 'styled-components';
 import { variables, PassphraseTypeCard } from '@trezor/components';
 import { useSelector, useActions } from '@suite-hooks';
 import * as modalActions from '@suite-actions/modalActions';
-import * as discoveryActions from '@wallet-actions/discoveryActions';
+import { selectIsDiscoveryAuthConfirmationRequired } from '@wallet-reducers/discoveryReducer';
 import * as deviceUtils from '@suite-utils/device';
 import { Translation, Modal } from '@suite-components';
 import type { TrezorDevice } from '@suite-types';
@@ -48,10 +48,10 @@ export const Passphrase = ({ device }: Props) => {
     const [submitted, setSubmitted] = useState(false);
     const devices = useSelector(state => state.devices);
     const actions = useActions({
-        getDiscoveryAuthConfirmationStatus: discoveryActions.getDiscoveryAuthConfirmationStatus,
         onPassphraseSubmit: modalActions.onPassphraseSubmit,
     });
-    const authConfirmation = actions.getDiscoveryAuthConfirmationStatus() || device.authConfirm;
+    const authConfirmation =
+        useSelector(selectIsDiscoveryAuthConfirmationRequired) || device.authConfirm;
     const stateConfirmation = !!device.state;
     const hasEmptyPassphraseWallet = deviceUtils
         .getDeviceInstances(device, devices)

--- a/packages/suite/src/components/suite/modals/PassphraseOnDevice.tsx
+++ b/packages/suite/src/components/suite/modals/PassphraseOnDevice.tsx
@@ -2,8 +2,8 @@ import React from 'react';
 import styled from 'styled-components';
 import { H1, variables } from '@trezor/components';
 import { Translation } from '@suite-components/Translation';
-import { useActions } from '@suite-hooks';
-import * as discoveryActions from '@wallet-actions/discoveryActions';
+import { useSelector } from '@suite-hooks';
+import { selectIsDiscoveryAuthConfirmationRequired } from '@wallet-reducers/discoveryReducer';
 import { DeviceConfirmImage } from '@suite-components/images/DeviceConfirmImage';
 import type { TrezorDevice } from '@suite-types';
 import { DevicePromptModal } from '@suite-components/Modal/DevicePromptModal';
@@ -36,11 +36,8 @@ interface PassphraseOnDeviceProps {
  * @param {PassphraseOnDeviceProps}
  */
 export const PassphraseOnDevice = ({ device }: PassphraseOnDeviceProps) => {
-    const { getDiscoveryAuthConfirmationStatus } = useActions({
-        getDiscoveryAuthConfirmationStatus: discoveryActions.getDiscoveryAuthConfirmationStatus,
-    });
-
-    const authConfirmation = getDiscoveryAuthConfirmationStatus() || device.authConfirm;
+    const authConfirmation =
+        useSelector(selectIsDiscoveryAuthConfirmationRequired) || device.authConfirm;
 
     return (
         <StyledDevicePromptModal isAbortable={false} data-test="@modal/enter-passphrase-on-device">

--- a/packages/suite/src/components/suite/modals/PassphraseSource.tsx
+++ b/packages/suite/src/components/suite/modals/PassphraseSource.tsx
@@ -3,8 +3,8 @@ import styled from 'styled-components';
 import { H1, variables } from '@trezor/components';
 import { Translation } from '@suite-components/Translation';
 import { DeviceConfirmImage } from '@suite-components/images/DeviceConfirmImage';
-import { useActions } from '@suite-hooks';
-import * as discoveryActions from '@wallet-actions/discoveryActions';
+import { useSelector } from '@suite-hooks';
+import { selectIsDiscoveryAuthConfirmationRequired } from '@wallet-reducers/discoveryReducer';
 import type { TrezorDevice } from '@suite-types';
 import { DevicePromptModal } from '@suite-components/Modal/DevicePromptModal';
 
@@ -26,11 +26,8 @@ interface PassphraseSourceProps {
  * @param {PassphraseSourceProps}
  */
 export const PassphraseSource = ({ device }: PassphraseSourceProps) => {
-    const { getDiscoveryAuthConfirmationStatus } = useActions({
-        getDiscoveryAuthConfirmationStatus: discoveryActions.getDiscoveryAuthConfirmationStatus,
-    });
-
-    const authConfirmation = getDiscoveryAuthConfirmationStatus() || device.authConfirm;
+    const authConfirmation =
+        useSelector(selectIsDiscoveryAuthConfirmationRequired) || device.authConfirm;
 
     return (
         <StyledDevicePromptModal

--- a/packages/suite/src/middlewares/wallet/discoveryMiddleware.ts
+++ b/packages/suite/src/middlewares/wallet/discoveryMiddleware.ts
@@ -5,6 +5,7 @@ import { DISCOVERY } from '@wallet-actions/constants';
 import * as walletSettingsActions from '@settings-actions/walletSettingsActions';
 import * as suiteActions from '@suite-actions/suiteActions';
 import * as discoveryActions from '@wallet-actions/discoveryActions';
+import { selectDiscoveryForDevice } from '@wallet-reducers/discoveryReducer';
 import { accountsActions, disableAccountsThunk } from '@suite-common/wallet-core';
 import { getApp } from '@suite-utils/router';
 import { AppState, Action, Dispatch } from '@suite-types';
@@ -14,7 +15,7 @@ const discoveryMiddleware =
     (next: Dispatch) =>
     async (action: Action): Promise<Action> => {
         const prevState = api.getState();
-        const prevDiscovery = api.dispatch(discoveryActions.getDiscoveryForDevice());
+        const prevDiscovery = selectDiscoveryForDevice(prevState);
         const discoveryIsRunning =
             prevDiscovery &&
             prevDiscovery.status > DISCOVERY.STATUS.IDLE &&
@@ -144,7 +145,7 @@ const discoveryMiddleware =
             walletSettingsActions.changeNetworks.match(action) ||
             accountsActions.changeAccountVisibility.match(action)
         ) {
-            const discovery = api.dispatch(discoveryActions.getDiscoveryForDevice());
+            const discovery = selectDiscoveryForDevice(api.getState());
             if (
                 device &&
                 device.connected &&

--- a/packages/suite/src/middlewares/wallet/graphMiddleware.ts
+++ b/packages/suite/src/middlewares/wallet/graphMiddleware.ts
@@ -1,7 +1,7 @@
 import { MiddlewareAPI } from 'redux';
 import { DISCOVERY } from '@wallet-actions/constants';
 import * as graphActions from '@wallet-actions/graphActions';
-import { getDiscoveryForDevice } from '@wallet-actions/discoveryActions';
+import { selectDiscoveryForDevice } from '@wallet-reducers/discoveryReducer';
 import { AppState, Action, Dispatch } from '@suite-types';
 import { accountsActions, transactionsActions } from '@suite-common/wallet-core';
 
@@ -28,7 +28,7 @@ const graphMiddleware =
             const { account, transactions } = action.payload;
 
             // don't run during discovery and on unconfirmed txs
-            const discovery = api.dispatch(getDiscoveryForDevice());
+            const discovery = selectDiscoveryForDevice(api.getState());
             if (
                 discovery?.status === DISCOVERY.STATUS.COMPLETED &&
                 transactions.some(t => (t.blockHeight ?? 0) > 0)

--- a/packages/suite/src/middlewares/wallet/storageMiddleware.ts
+++ b/packages/suite/src/middlewares/wallet/storageMiddleware.ts
@@ -8,7 +8,7 @@ import * as storageActions from '@suite-actions/storageActions';
 import * as accountUtils from '@suite-common/wallet-utils';
 import { SUITE, ANALYTICS, METADATA, MESSAGE_SYSTEM, STORAGE } from '@suite-actions/constants';
 import { FIRMWARE } from '@firmware-actions/constants';
-import { getDiscovery } from '@wallet-actions/discoveryActions';
+import { selectDiscovery } from '@wallet-reducers/discoveryReducer';
 import * as metadataActions from '@suite-actions/metadataActions';
 import { isDeviceRemembered } from '@suite-utils/device';
 import { serializeDiscovery } from '@suite-utils/storage';
@@ -134,7 +134,7 @@ const storageMiddleware = (api: MiddlewareAPI<Dispatch, AppState>) => {
                     const device = api.getState().devices.find(d => d.state === deviceState);
                     // update discovery for remembered device
                     if (isDeviceRemembered(device)) {
-                        const discovery = api.dispatch(getDiscovery(deviceState));
+                        const discovery = selectDiscovery(api.getState(), deviceState);
                         if (discovery) {
                             storageActions.saveDiscovery([serializeDiscovery(discovery)]);
                         }

--- a/packages/suite/src/middlewares/wallet/walletMiddleware.ts
+++ b/packages/suite/src/middlewares/wallet/walletMiddleware.ts
@@ -115,7 +115,7 @@ const walletMiddleware =
             api.dispatch(coinmarketCommonActions.convertDrafts());
         }
 
-        api.dispatch(selectedAccountActions.getStateForAction(action));
+        api.dispatch(selectedAccountActions.syncSelectedAccount(action));
 
         return action;
     };

--- a/suite-common/wallet-core/src/accounts/tests/accountsReducer.test.ts
+++ b/suite-common/wallet-core/src/accounts/tests/accountsReducer.test.ts
@@ -26,6 +26,7 @@ const initStore = ({ extra = {}, preloadedState }: InitStoreArgs = {}) => {
 const getAccount = (a?: Partial<Account>) => ({
     descriptor: 'xpubDeFauLT1',
     symbol: 'btc',
+    history: {},
     ...a,
 });
 

--- a/suite-common/wallet-core/src/transactions/transactionsReducer.ts
+++ b/suite-common/wallet-core/src/transactions/transactionsReducer.ts
@@ -114,7 +114,8 @@ export const prepareTransactionsReducer = createReducerWithExtraDeps(
                         );
 
                         if (
-                            (!existingTx.blockHeight && transaction.blockHeight) ||
+                            ((existingTx.blockHeight ?? 0) <= 0 &&
+                                (transaction.blockHeight ?? 0) > 0) ||
                             (!existingTx.blockTime && transaction.blockTime)
                         ) {
                             // pending tx got confirmed (blockHeight changed from undefined/0 to a number > 0)

--- a/suite-common/wallet-utils/src/accountUtils.ts
+++ b/suite-common/wallet-utils/src/accountUtils.ts
@@ -358,6 +358,16 @@ export const enhanceUtxo = (
     return enhancedUtxos;
 };
 
+export const enhanceHistory = ({
+    total,
+    unconfirmed,
+    tokens,
+}: AccountInfo['history']): Account['history'] => ({
+    total,
+    unconfirmed,
+    tokens,
+});
+
 export const getAccountFiatBalance = (
     account: Account,
     localCurrency: string,


### PR DESCRIPTION
## Description

Various standalone refactorings/fixes which could be merged independently before #6068.

- https://github.com/trezor/trezor-suite/pull/6351/commits/4d9c14011df9f7e8d5a515c2faba6c67f3f2816f - Reworked some `discoveryActions` to ordinary util functions as they don't change the state at all.
- https://github.com/trezor/trezor-suite/pull/6351/commits/f8dfbab97e38f5f6ec21558c276568366355226e - Moving these functions to newly created `discoveryUtils`
- https://github.com/trezor/trezor-suite/pull/6351/commits/141c34221cf7102a73bfc1a17bb45794ea81680f - Allowed to use `transformTransaction` when we know only string addresses (instead of whole `Address` objects)
- https://github.com/trezor/trezor-suite/pull/6351/commits/9dedfed8f5b30e28e6b01b55348336e3f7460587 - Removing `account.history.transactions` when account is updated (until now they were removed only when account was created)
- https://github.com/trezor/trezor-suite/pull/6351/commits/271506d5133ebb102ba514e27c25f932a17a0556 - When adding transactions one by one, update even these pending ones which have `blockHeight = -1` (not only 0)