### PR TITLE
chore(suite-desktop): specify app lang to avoid bambilion lang files

### DIFF
--- a/packages/suite-desktop/package.json
+++ b/packages/suite-desktop/package.json
@@ -128,6 +128,13 @@
                     "to": "bin/tor"
                 }
             ],
+            "electronLanguages": [
+                "en",
+                "es",
+                "cs",
+                "ja",
+                "ru"
+            ],
             "icon": "build/static/images/icons/512x512.icns",
             "artifactName": "Trezor-Suite-${version}-mac-${arch}.${ext}",
             "hardenedRuntime": true,

--- a/packages/suite/src/config/suite/languages.ts
+++ b/packages/suite/src/config/suite/languages.ts
@@ -1,5 +1,6 @@
 export const TRANSLATION_PSEUDOLANGUAGE = 'lol' as const;
 
+// After marking a language complete, add this language also to suite-desktop/package.json -> electronLanguages array
 const LANGUAGES = {
     en: { name: 'English', en: 'English', complete: true },
     es: { name: 'Español', en: 'Spanish', complete: true },


### PR DESCRIPTION
## Description

- specify electron languages to get rid of mess

https://www.electron.build/configuration/mac.html
`electronLanguages Array<String> | String - The electron locales. By default Electron locales used as is.`

## Related Issue

Part of #4989

## Screenshots (if appropriate):

![Screenshot 2022-09-21 at 19 14 47](https://user-images.githubusercontent.com/33235762/191569675-d7a000db-32cf-4d34-814d-e5a4a7bdb067.png)
![Screenshot 2022-09-21 at 19 15 28](https://user-images.githubusercontent.com/33235762/191569677-5227258f-29ba-421f-8785-78e0d71dfb08.png)

Do not check `app.asar` size. It is not reduced by this commit but by 18 commits together.
