### PR TITLE
chore(suite-types): move guide types from suite-data to suite-types

### DIFF
--- a/packages/suite-data/package.json
+++ b/packages/suite-data/package.json
@@ -20,6 +20,7 @@
         "type-check": "tsc --build tsconfig.json"
     },
     "dependencies": {
+        "@suite-common/suite-types": "*",
         "@trezor/urls": "*",
         "@trezor/utils": "*",
         "ua-parser-js": "^1.0.2"

--- a/packages/suite-data/src/guide/parser.ts
+++ b/packages/suite-data/src/guide/parser.ts
@@ -2,13 +2,13 @@ import { join } from 'path';
 import * as fs from 'fs-extra';
 
 import { GITBOOK_ASSETS_DIR_PREFIX } from './constants';
-import type { Node, GuideCategory } from '@suite-common/suite-types';
+import type { GuideNode, GuideCategory } from '@suite-common/suite-types';
 
 /** @returns true if given path is a directory. */
 const isDirectory = (path: string): boolean => fs.lstatSync(path).isDirectory();
 
 /** @returns true if left and right are variants of the same content. */
-const match = (left: Node, right: Node): boolean =>
+const match = (left: GuideNode, right: GuideNode): boolean =>
     left.type === right.type && left.id === right.id;
 
 export class Parser {
@@ -102,7 +102,7 @@ export class Parser {
      * @param locale locale of the given tree.
      * @returns object representation of the given tree.
      */
-    private parseTree(path: string, locale: string): Node {
+    private parseTree(path: string, locale: string): GuideNode {
         if (isDirectory(path)) {
             const children = fs
                 .readdirSync(path)
@@ -140,7 +140,7 @@ export class Parser {
      *
      * Nodes in the right that are not in the left are discarded.
      */
-    private zip(left: Node, right: Node): Node {
+    private zip(left: GuideNode, right: GuideNode): GuideNode {
         if (!match(left, right)) {
             return left;
         }
@@ -191,7 +191,7 @@ export class Parser {
      * Parses the GitBook content including all locales
      * and returns its object representation for subsequent processing.
      */
-    parse(): Node {
+    parse(): GuideNode {
         const locales = this.parseLocales();
         console.log(`Detected ${locales.length} locales: ${locales}`);
 

--- a/packages/suite-data/src/guide/parser.ts
+++ b/packages/suite-data/src/guide/parser.ts
@@ -2,38 +2,7 @@ import { join } from 'path';
 import * as fs from 'fs-extra';
 
 import { GITBOOK_ASSETS_DIR_PREFIX } from './constants';
-
-/**
- * A group of Guide content.
- * Can contain other Pages or Categories.
- * Cannot contain content on its own except the title.
- */
-export interface GuideCategory {
-    type: 'category';
-    /** Serves both as unique identifier and relative path to the directory. */
-    id: string;
-    /** List of locales this Category is available in. */
-    locales: string[];
-    /** Titles keyed by locales. */
-    title: {
-        [key: string]: string;
-    };
-    image?: string;
-    /** Sub-categories and sub-pages. */
-    children: Node[];
-}
-
-/** A single unit of Guide content. */
-export interface Page {
-    type: 'page';
-    id: string;
-    locales: string[];
-    title: {
-        [key: string]: string;
-    };
-}
-
-export type Node = GuideCategory | Page;
+import type { Node, GuideCategory } from '@suite-common/suite-types';
 
 /** @returns true if given path is a directory. */
 const isDirectory = (path: string): boolean => fs.lstatSync(path).isDirectory();

--- a/packages/suite-data/src/guide/transformer.ts
+++ b/packages/suite-data/src/guide/transformer.ts
@@ -2,7 +2,7 @@ import { join } from 'path';
 import * as fs from 'fs-extra';
 
 import { resolveStaticPath } from '@trezor/utils';
-import { Node } from '@suite-common/suite-types';
+import { GuideNode } from '@suite-common/suite-types';
 
 /** Removes the front-matter from beginning of a string. */
 const clean = (md: string): string => md.replace(/^---\n.*?\n---\n/s, '');
@@ -25,7 +25,7 @@ const transformImagesPath = (md: string): string =>
  * @param source Path to directory with the markdown files.
  * @param destination Path to directory where the cleaned markdown will be dumped.
  */
-export const transform = (node: Node, source: string, destination: string) => {
+export const transform = (node: GuideNode, source: string, destination: string) => {
     if (node.type === 'category') {
         node.locales.forEach(locale => {
             fs.mkdirpSync(join(destination, locale, node.id));

--- a/packages/suite-data/src/guide/transformer.ts
+++ b/packages/suite-data/src/guide/transformer.ts
@@ -2,7 +2,7 @@ import { join } from 'path';
 import * as fs from 'fs-extra';
 
 import { resolveStaticPath } from '@trezor/utils';
-import { Node } from './parser';
+import { Node } from '@suite-common/suite-types';
 
 /** Removes the front-matter from beginning of a string. */
 const clean = (md: string): string => md.replace(/^---\n.*?\n---\n/s, '');

--- a/packages/suite-data/tsconfig.json
+++ b/packages/suite-data/tsconfig.json
@@ -7,6 +7,9 @@
     },
     "include": ["./src"],
     "references": [
+        {
+            "path": "../../suite-common/suite-types"
+        },
         { "path": "../urls" },
         { "path": "../utils" }
     ]

--- a/packages/suite-desktop/package.json
+++ b/packages/suite-desktop/package.json
@@ -185,6 +185,7 @@
     },
     "dependencies": {
         "@sentry/electron": "3.0.0",
+        "@suite-common/suite-types": "*",
         "@suite-common/suite-utils": "*",
         "@trezor/connect": "9.0.2",
         "@trezor/connect-common": "*",

--- a/packages/suite/src/actions/suite/guideActions.ts
+++ b/packages/suite/src/actions/suite/guideActions.ts
@@ -9,7 +9,7 @@ import type {
     Feedback,
     FeedbackType,
     GuideCategory,
-    Node,
+    GuideNode,
 } from '@suite-common/suite-types';
 
 export type GuideAction =
@@ -18,7 +18,7 @@ export type GuideAction =
     | { type: typeof GUIDE.SET_INDEX_NODE; payload: GuideCategory }
     | { type: typeof GUIDE.SET_VIEW; payload: ActiveView }
     | { type: typeof GUIDE.UNSET_NODE }
-    | { type: typeof GUIDE.OPEN_NODE; payload: Node };
+    | { type: typeof GUIDE.OPEN_NODE; payload: GuideNode };
 
 export const open = (): GuideAction => {
     analytics.report({
@@ -51,7 +51,7 @@ export const setView = (payload: ActiveView) => (dispatch: Dispatch) => {
     dispatch({ type: GUIDE.SET_VIEW, payload });
 };
 
-export const openNode = (payload: Node) => (dispatch: Dispatch) => {
+export const openNode = (payload: GuideNode) => (dispatch: Dispatch) => {
     if (payload.type === 'page') {
         dispatch(setView('GUIDE_PAGE'));
     } else {

--- a/packages/suite/src/components/guide/GuideNode.tsx
+++ b/packages/suite/src/components/guide/GuideNode.tsx
@@ -7,7 +7,7 @@ import { resolveStaticPath } from '@trezor/utils';
 import { Icon, variables, useTheme } from '@trezor/components';
 import { useActions, useSelector } from '@suite-hooks';
 import * as guideActions from '@suite-actions/guideActions';
-import { Node } from '@suite-common/suite-types';
+import { GuideNode as GuideNodeType } from '@suite-common/suite-types';
 import { getNodeTitle } from '@suite-utils/guide';
 
 const NodeButton = styled.button`
@@ -66,7 +66,7 @@ const Image = styled.img`
 `;
 
 type GuideNodeProps = {
-    node: Node;
+    node: GuideNodeType;
     description?: React.ReactNode;
 };
 

--- a/packages/suite/src/hooks/guide/useGuideLoadPage.ts
+++ b/packages/suite/src/hooks/guide/useGuideLoadPage.ts
@@ -1,5 +1,5 @@
 import { useState, useEffect } from 'react';
-import type { Node } from '@suite-common/suite-types';
+import type { GuideNode } from '@suite-common/suite-types';
 import type { Locale } from '@suite-config/languages';
 
 export const loadPageMarkdownFile = async (id: string, language = 'en'): Promise<string> => {
@@ -8,7 +8,7 @@ export const loadPageMarkdownFile = async (id: string, language = 'en'): Promise
     return md;
 };
 
-export const useGuideLoadPage = (currentNode: Node | null, language: Locale = 'en') => {
+export const useGuideLoadPage = (currentNode: GuideNode | null, language: Locale = 'en') => {
     const [markdown, setMarkdown] = useState<string>();
     const [hasError, setHasError] = useState<boolean>(false);
 

--- a/packages/suite/src/hooks/guide/useGuideSearch.ts
+++ b/packages/suite/src/hooks/guide/useGuideSearch.ts
@@ -1,5 +1,5 @@
 import { useState, useEffect, useMemo } from 'react';
-import { GuideCategory, Page } from '@suite-common/suite-types';
+import { GuideCategory, GuidePage } from '@suite-common/suite-types';
 import { loadPageMarkdownFile } from '@guide-hooks/useGuideLoadPage';
 
 const SEARCH_DELAY = 300;
@@ -7,11 +7,11 @@ const MIN_QUERY_LENGTH = 3;
 const MAX_RESULTS = 5;
 
 type PageMap = {
-    [url: string]: Page;
+    [url: string]: GuidePage;
 };
 
 export type SearchResult = {
-    page: Page;
+    page: GuidePage;
     score: number;
     preview?: {
         content: string;
@@ -72,7 +72,7 @@ const search = async (query: string, pageMap: PageMap): Promise<SearchResult[]> 
 
 export const useGuideSearch = (query: string, pageRoot: GuideCategory | null) => {
     const pageMap = useMemo(() => {
-        const reduceNode = (node: GuideCategory | Page): PageMap =>
+        const reduceNode = (node: GuideCategory | GuidePage): PageMap =>
             node.type === 'page'
                 ? { [node.id]: node }
                 : node.children.reduce(

--- a/packages/suite/src/reducers/suite/guideReducer.ts
+++ b/packages/suite/src/reducers/suite/guideReducer.ts
@@ -1,14 +1,14 @@
 import produce from 'immer';
 import { Action } from '@suite-types';
 import { GUIDE } from '@suite-actions/constants';
-import type { ActiveView, GuideCategory, Node } from '@suite-common/suite-types';
+import type { ActiveView, GuideCategory, GuideNode } from '@suite-common/suite-types';
 import * as indexNodeJSON from '@trezor/suite-data/files/guide/index.json';
 
 export interface State {
     open: boolean;
     view: ActiveView;
     indexNode: GuideCategory | null;
-    currentNode: Node | null;
+    currentNode: GuideNode | null;
 }
 
 const indexNode = indexNodeJSON as GuideCategory;

--- a/packages/suite/src/utils/suite/__fixtures__/guide.ts
+++ b/packages/suite/src/utils/suite/__fixtures__/guide.ts
@@ -1,8 +1,8 @@
-import { Page, GuideCategory } from '@suite-common/suite-types';
+import { GuidePage, GuideCategory } from '@suite-common/suite-types';
 
 const { getGuideNode } = global.JestMocks;
 
-const GUIDE_PAGE_NODE = getGuideNode('page') as Page;
+const GUIDE_PAGE_NODE = getGuideNode('page') as GuidePage;
 const GUIDE_CATEGORY_NODE = getGuideNode('category') as GuideCategory;
 const GUIDE_CATEGORY_NODE_CHILD = GUIDE_CATEGORY_NODE.children.find(
     x => x.id === '/security',
@@ -31,10 +31,10 @@ export const getNodeById = [
     {
         description: 'root node: Page',
         input: {
-            node: getGuideNode('page', '/') as Page,
+            node: getGuideNode('page', '/') as GuidePage,
             id: '/',
         },
-        result: getGuideNode('page', '/') as Page,
+        result: getGuideNode('page', '/') as GuidePage,
     },
     {
         description: 'root node: Category',

--- a/packages/suite/src/utils/suite/guide.ts
+++ b/packages/suite/src/utils/suite/guide.ts
@@ -1,10 +1,10 @@
-import { GuideCategory, Node } from '@suite-common/suite-types';
+import { GuideCategory, GuideNode } from '@suite-common/suite-types';
 
 /** @returns title in given language or in english if not available. */
-export const getNodeTitle = (node: Node, language: string): string =>
+export const getNodeTitle = (node: GuideNode, language: string): string =>
     node.title[language] || node.title.en;
 
-export const getNodeById = (id: string, root: Node): Node | undefined => {
+export const getNodeById = (id: string, root: GuideNode): GuideNode | undefined => {
     if (id === root.id) {
         return root;
     }
@@ -33,7 +33,7 @@ export const getAncestorIds = (id: string): string[] =>
         }, []);
 
 /** @returns ancestors nodes for node. */
-export const findAncestorNodes = (node: Node, root: GuideCategory): Node[] => {
+export const findAncestorNodes = (node: GuideNode, root: GuideCategory): GuideNode[] => {
     const ancestorIds = getAncestorIds(node.id);
 
     return (
@@ -42,7 +42,7 @@ export const findAncestorNodes = (node: Node, root: GuideCategory): Node[] => {
             .filter(id => id !== '/')
             .map(id => getNodeById(id, root))
             // omit not-existing nodes
-            .filter((ancestorNode): ancestorNode is Node => {
+            .filter((ancestorNode): ancestorNode is GuideNode => {
                 if (ancestorNode === undefined) {
                     throw Error(`Ancestor node of '${node.id}' node was not found!`);
                 }

--- a/suite-common/suite-types/package.json
+++ b/suite-common/suite-types/package.json
@@ -13,16 +13,10 @@
         "@reduxjs/toolkit": "^1.8.3",
         "@suite-common/metadata-types": "*",
         "@suite-common/wallet-config": "*",
-        "@trezor/connect": "9.0.2",
-        "@trezor/suite-data": "*"
+        "@trezor/connect": "9.0.2"
     },
     "devDependencies": {
         "jest": "^26.6.3",
         "typescript": "4.7.4"
-    },
-    "nx": {
-        "implicitDependencies": [
-            "@trezor/suite-data"
-        ]
     }
 }

--- a/suite-common/suite-types/src/guide.ts
+++ b/suite-common/suite-types/src/guide.ts
@@ -17,11 +17,11 @@ export interface GuideCategory {
     };
     image?: string;
     /** Sub-categories and sub-pages. */
-    children: Node[];
+    children: GuideNode[];
 }
 
 /** A single unit of Guide content. */
-export interface Page {
+export interface GuidePage {
     type: 'page';
     id: string;
     locales: string[];
@@ -30,7 +30,7 @@ export interface Page {
     };
 }
 
-export type Node = GuideCategory | Page;
+export type GuideNode = GuideCategory | GuidePage;
 
 export type GuideView = 'GUIDE_DEFAULT' | 'GUIDE_CATEGORY' | 'GUIDE_PAGE';
 

--- a/suite-common/suite-types/src/guide.tsx
+++ b/suite-common/suite-types/src/guide.tsx
@@ -1,6 +1,36 @@
-import { Page, GuideCategory, Node } from '@trezor/suite-data/src/guide/parser';
-
 import type { EnvironmentType } from './environment';
+
+/**
+ * A group of Guide content.
+ * Can contain other Pages or Categories.
+ * Cannot contain content on its own except the title.
+ */
+export interface GuideCategory {
+    type: 'category';
+    /** Serves both as unique identifier and relative path to the directory. */
+    id: string;
+    /** List of locales this Category is available in. */
+    locales: string[];
+    /** Titles keyed by locales. */
+    title: {
+        [key: string]: string;
+    };
+    image?: string;
+    /** Sub-categories and sub-pages. */
+    children: Node[];
+}
+
+/** A single unit of Guide content. */
+export interface Page {
+    type: 'page';
+    id: string;
+    locales: string[];
+    title: {
+        [key: string]: string;
+    };
+}
+
+export type Node = GuideCategory | Page;
 
 export type GuideView = 'GUIDE_DEFAULT' | 'GUIDE_CATEGORY' | 'GUIDE_PAGE';
 
@@ -55,5 +85,3 @@ export type FeedbackSuggestion = {
 };
 
 export type Feedback = FeedbackBug | FeedbackSuggestion;
-
-export type { Page, GuideCategory, Node };

--- a/suite-common/suite-types/tsconfig.json
+++ b/suite-common/suite-types/tsconfig.json
@@ -4,7 +4,6 @@
     "references": [
         { "path": "../metadata-types" },
         { "path": "../wallet-config" },
-        { "path": "../../packages/connect" },
-        { "path": "../../packages/suite-data" }
+        { "path": "../../packages/connect" }
     ]
 }

--- a/suite-common/test-utils/src/mocks.ts
+++ b/suite-common/test-utils/src/mocks.ts
@@ -4,8 +4,8 @@
 import { Device, Features } from '@trezor/connect';
 import {
     TrezorDevice,
-    Node,
-    Page,
+    GuideNode,
+    GuidePage,
     GuideCategory,
     MessageSystem,
     Action,
@@ -552,8 +552,8 @@ const getMessageSystemConfig = (
     ...root,
 });
 
-const getGuideNode = (type: string, id?: string): Node => {
-    let result: Node;
+const getGuideNode = (type: string, id?: string): GuideNode => {
+    let result: GuideNode;
     if (type === 'page' && id === '/') {
         result = {
             type: 'page',
@@ -562,7 +562,7 @@ const getGuideNode = (type: string, id?: string): Node => {
             title: {
                 en: 'Locktime',
             },
-        } as Page;
+        } as GuidePage;
     } else if (type === 'page' && id !== '/') {
         result = {
             type: 'page',
@@ -571,7 +571,7 @@ const getGuideNode = (type: string, id?: string): Node => {
             title: {
                 en: 'Locktime',
             },
-        } as Page;
+        } as GuidePage;
     } else {
         result = {
             type: 'category',

--- a/yarn.lock
+++ b/yarn.lock
@@ -6066,7 +6066,6 @@ __metadata:
     "@suite-common/metadata-types": "*"
     "@suite-common/wallet-config": "*"
     "@trezor/connect": 9.0.2
-    "@trezor/suite-data": "*"
     jest: ^26.6.3
     typescript: 4.7.4
   languageName: unknown
@@ -7086,6 +7085,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@trezor/suite-data@workspace:packages/suite-data"
   dependencies:
+    "@suite-common/suite-types": "*"
     "@trezor/urls": "*"
     "@trezor/utils": "*"
     "@types/fs-extra": ^9.0.13
@@ -7124,6 +7124,7 @@ __metadata:
   resolution: "@trezor/suite-desktop@workspace:packages/suite-desktop"
   dependencies:
     "@sentry/electron": 3.0.0
+    "@suite-common/suite-types": "*"
     "@suite-common/suite-utils": "*"
     "@trezor/connect": 9.0.2
     "@trezor/connect-common": "*"


### PR DESCRIPTION
## Description

Move guide types to avoid `suite-data` as a dependency in `suite-types`. It resulted into copying `suite-data` dependencies into app installer package.

## Related Issue

Part of #4989