### PR TITLE
chore(suite): move normalizeVersion from suite pkg to utils pkg

### DIFF
--- a/packages/suite-web-landing/components/Download/index.tsx
+++ b/packages/suite-web-landing/components/Download/index.tsx
@@ -5,7 +5,7 @@ import { Button, Dropdown, Icon, colors, variables, Link } from '@trezor/compone
 import { IconType } from '@trezor/components/src/support/types';
 import Translation from '../Translation';
 import { Platform, getPlatform } from '../../utils/navigator';
-import { normalizeVersion } from '@suite-utils/build';
+import { versionUtils } from '@trezor/utils';
 
 const StyledDropdown = styled(Dropdown)`
     height: 100%;
@@ -146,7 +146,9 @@ const getInstallerSignatureURI = (props: GetURIProps) => {
 };
 
 const Index = ({ pathToApp }: { pathToApp: string }) => {
-    const version: string = process.env.VERSION ? normalizeVersion(process.env.VERSION) : '';
+    const version: string = process.env.VERSION
+        ? versionUtils.normalizeVersion(process.env.VERSION)
+        : '';
     const [platform, setPlatform] = useState<Platform | null>(null);
     const dropdownItems = [
         {

--- a/packages/suite/src/utils/suite/__tests__/build.test.ts
+++ b/packages/suite/src/utils/suite/__tests__/build.test.ts
@@ -1,7 +1,4 @@
-/* eslint-disable global-require, @typescript-eslint/no-var-requires */
-import { normalizeVersion } from '../build';
-import { resolveStaticPath } from '@trezor/utils';
-
+/* eslint-disable @typescript-eslint/no-var-requires, global-require */
 const OLD_ENV = { ...process.env };
 
 describe('build', () => {
@@ -42,46 +39,6 @@ describe('build', () => {
             expect(isDev).toEqual(true);
         });
     });
-
-    describe('normalizeVersion', () => {
-        it('removes preceding zeros from versions to normalize it', () => {
-            expect(normalizeVersion('2020.05.13-beta')).toEqual('2020.5.13-beta');
-            expect(normalizeVersion('2022.12.01-beta')).toEqual('2022.12.1-beta');
-            expect(normalizeVersion('3000.04.04-beta')).toEqual('3000.4.4-beta');
-            expect(normalizeVersion('3000.04.04')).toEqual('3000.4.4');
-            expect(normalizeVersion('3000.04.0')).toEqual('3000.4.0');
-        });
-
-        it('does nothing with normalized versions', () => {
-            expect(normalizeVersion('20.11.0')).toEqual('20.11.0');
-            expect(normalizeVersion('20.11.1')).toEqual('20.11.1');
-        });
-    });
-
-    describe('resolve static path', () => {
-        beforeEach(() => {
-            jest.resetModules();
-        });
-
-        afterEach(() => {
-            process.env = { ...OLD_ENV };
-        });
-
-        it('should return static path', () => {
-            process.env.ASSET_PREFIX = '';
-            expect(resolveStaticPath('mypath')).toBe('/static/mypath');
-        });
-
-        it('should return static path even if ASSET_PREFIX is undefined', () => {
-            process.env.ASSET_PREFIX = undefined;
-            expect(resolveStaticPath('mypath')).toBe('/static/mypath');
-            expect(resolveStaticPath('/mypath')).toBe('/static/mypath');
-        });
-
-        it('should return static path prefixed with ASSET_PREFIX', () => {
-            process.env.ASSET_PREFIX = 'brachName';
-            expect(resolveStaticPath('mypath')).toBe('brachName/static/mypath');
-            expect(resolveStaticPath('/mypath')).toBe('brachName/static/mypath');
-        });
-    });
 });
+
+export {};

--- a/packages/suite/src/utils/suite/build.ts
+++ b/packages/suite/src/utils/suite/build.ts
@@ -1,5 +1,1 @@
 export const isDev = process.env.NODE_ENV !== 'production';
-
-export const normalizeVersion = (version: string) =>
-    // remove any zeros that are not preceded by Latin letters, decimal digits, underscores
-    version.replace(/\b0+(\d)/g, '$1');

--- a/packages/utils/src/resolveStaticPath.ts
+++ b/packages/utils/src/resolveStaticPath.ts
@@ -1,3 +1,5 @@
+// TODO: related to Suite, move it to '@suite-common/suite-utils' package
+
 export const resolveStaticPath = (
     path: string,
     pathPrefix: string | undefined = process.env.ASSET_PREFIX,

--- a/packages/utils/src/versionUtils.ts
+++ b/packages/utils/src/versionUtils.ts
@@ -62,3 +62,7 @@ export const isEqual = (versionX: VersionInput, versionY: VersionInput) => {
  */
 export const isNewerOrEqual = (versionX: VersionInput, versionY: VersionInput) =>
     isNewer(versionX, versionY) || isEqual(versionX, versionY);
+
+export const normalizeVersion = (version: string) =>
+    // remove any zeros that are not preceded by Latin letters, decimal digits, underscores
+    version.replace(/\b0+(\d)/g, '$1');

--- a/packages/utils/tests/resolveStaticPath.test.ts
+++ b/packages/utils/tests/resolveStaticPath.test.ts
@@ -1,0 +1,30 @@
+import { resolveStaticPath } from '../src';
+
+const OLD_ENV = { ...process.env };
+
+describe('resolve static path', () => {
+    beforeEach(() => {
+        jest.resetModules();
+    });
+
+    afterEach(() => {
+        process.env = { ...OLD_ENV };
+    });
+
+    it('should return static path', () => {
+        process.env.ASSET_PREFIX = '';
+        expect(resolveStaticPath('mypath')).toBe('/static/mypath');
+    });
+
+    it('should return static path even if ASSET_PREFIX is undefined', () => {
+        process.env.ASSET_PREFIX = undefined;
+        expect(resolveStaticPath('mypath')).toBe('/static/mypath');
+        expect(resolveStaticPath('/mypath')).toBe('/static/mypath');
+    });
+
+    it('should return static path prefixed with ASSET_PREFIX', () => {
+        process.env.ASSET_PREFIX = 'brachName';
+        expect(resolveStaticPath('mypath')).toBe('brachName/static/mypath');
+        expect(resolveStaticPath('/mypath')).toBe('brachName/static/mypath');
+    });
+});

--- a/packages/utils/tests/version.test.ts
+++ b/packages/utils/tests/version.test.ts
@@ -1,4 +1,4 @@
-import { isNewer, isNewerOrEqual, isEqual } from '../src/versionUtils';
+import { isNewer, isNewerOrEqual, isEqual, normalizeVersion } from '../src/versionUtils';
 
 describe('Version Utils', () => {
     describe('is newer', () => {
@@ -82,6 +82,21 @@ describe('Version Utils', () => {
         it('it should return true [1, 1, 1], [1, 1, 1]', () => {
             const result = isNewerOrEqual([1, 1, 1], [1, 1, 1]);
             expect(result).toBe(true);
+        });
+    });
+
+    describe('normalizeVersion', () => {
+        it('removes preceding zeros from versions to normalize it', () => {
+            expect(normalizeVersion('2020.05.13-beta')).toEqual('2020.5.13-beta');
+            expect(normalizeVersion('2022.12.01-beta')).toEqual('2022.12.1-beta');
+            expect(normalizeVersion('3000.04.04-beta')).toEqual('3000.4.4-beta');
+            expect(normalizeVersion('3000.04.04')).toEqual('3000.4.4');
+            expect(normalizeVersion('3000.04.0')).toEqual('3000.4.0');
+        });
+
+        it('does nothing with normalized versions', () => {
+            expect(normalizeVersion('20.11.0')).toEqual('20.11.0');
+            expect(normalizeVersion('20.11.1')).toEqual('20.11.1');
         });
     });
 });


### PR DESCRIPTION
## Description

Not exactly required for desktop optimization but I also moved `isDev` from `build.ts` file

- moved version util to `versionUtils` file in `@trezor/utils` package
- forgotten `resolveStaticPath` test to `@trezor/utils` package

## Related Issue

Part of #4989
