### PR TITLE
Fix(tor): use explicit DataDirectory than default Tor

### DIFF
--- a/packages/request-manager/README.md
+++ b/packages/request-manager/README.md
@@ -15,13 +15,13 @@ const controlPort = 9031;
 // cookie" file named "control_auth_cookie" into its data directory (or
 // to another file specified in the 'CookieAuthFile' option).
 // https://gitweb.torproject.org/torspec.git/tree/control-spec.txt
-const authFilePath = '/path/to/control_auth_cookie/';
+const torDataDir = '/path/to/control_auth_cookie/';
 
 const torController = new TorController({
     host: torHost,
     port: port,
     controlPort: controlPort,
-    authFilePath: authFilePath,
+    torDataDir: torDataDir,
 });
 
 try {

--- a/packages/request-manager/e2e/interceptor.test.ts
+++ b/packages/request-manager/e2e/interceptor.test.ts
@@ -15,7 +15,7 @@ jest.setTimeout(60000);
 
 // Because tmp/control_auth_cookie is shared by other tests, this test should not run in parallel
 // using `--runInBand` option with jest.
-const authFilePath = path.join(__dirname, 'tmp');
+const torDataDir = path.join(__dirname, 'tmp');
 const ipRegex = /\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3}/;
 
 const testGetUrlHttp = 'http://check.torproject.org/';
@@ -37,7 +37,7 @@ describe('Interceptor', () => {
             host,
             port,
             controlPort,
-            authFilePath,
+            torDataDir,
         });
         const torParams = torController.getTorConfiguration(processId);
         // Starting Tor process from binary.

--- a/packages/request-manager/e2e/torControlPort.test.ts
+++ b/packages/request-manager/e2e/torControlPort.test.ts
@@ -11,19 +11,19 @@ const existsDirectory = util.promisify(fs.exists);
 const mkdir = util.promisify(fs.mkdir);
 const unlinkFile = util.promisify(fs.unlink);
 
-const authFilePath = path.join(__dirname, 'tmp');
+const torDataDir = path.join(__dirname, 'tmp');
 // Because control_auth_cookie is shared by other tests, this test should not run in parallel
 // using `--runInBand` option with jest.
-const controlAuthCookiePath = `${authFilePath}/control_auth_cookie`;
+const controlAuthCookiePath = `${torDataDir}/control_auth_cookie`;
 const host = 'localhost';
 const port = 9998;
 const controlPort = 9999;
 
 describe('TorControlPort', () => {
     beforeAll(async () => {
-        if (!(await existsDirectory(authFilePath))) {
-            // Make sure there is `authFilePath` directory.
-            mkdir(authFilePath);
+        if (!(await existsDirectory(torDataDir))) {
+            // Make sure there is `torDataDir` directory.
+            mkdir(torDataDir);
         }
         await writeFile(controlAuthCookiePath, 'test');
     });
@@ -38,7 +38,7 @@ describe('TorControlPort', () => {
                 host,
                 port,
                 controlPort,
-                authFilePath,
+                torDataDir,
             };
             const fakeListener = () => {};
             const torControlPort = new TorControlPort(options, fakeListener);
@@ -52,7 +52,7 @@ describe('TorControlPort', () => {
             let isProperlyAuthenticated = false;
             const serverHash = '1A6C3485BD58CAF688C5AF98B878E713A6EF0EAC0240D7E3453341689BA7FC60';
             const serverNonce = '88601906AB5EB92B8CB86E012C0074855E23AA1C79F843BEA5FDE674936E9AB1';
-            const cookieString = await getCookieString(authFilePath);
+            const cookieString = await getCookieString(torDataDir);
             const authenticationKey = 'Tor safe cookie authentication controller-to-server hash';
 
             let clientNonce = '';
@@ -102,7 +102,7 @@ describe('TorControlPort', () => {
                 host,
                 port,
                 controlPort,
-                authFilePath,
+                torDataDir,
             };
             const fakeListener = () => {};
             const torControlPort = new TorControlPort(options, fakeListener);

--- a/packages/request-manager/src/controller.ts
+++ b/packages/request-manager/src/controller.ts
@@ -23,7 +23,7 @@ export class TorController extends EventEmitter {
     }
 
     getTorConfiguration(processId: number): string[] {
-        const controlAuthCookiePath = path.join(this.options.authFilePath, 'control_auth_cookie');
+        const controlAuthCookiePath = path.join(this.options.torDataDir, 'control_auth_cookie');
         return [
             // Try to write to disk less frequently than we would otherwise.
             '--AvoidDiskWrites',
@@ -59,6 +59,11 @@ export class TorController extends EventEmitter {
             // the PID specified in the __OwningControllerProcess option.
             '__OwningControllerProcess',
             `${processId}`,
+            // Store working data in DIR. It has to be different that default one especially for macOS otherwise the
+            // custom Tor process cannot run when there is already a Tor process running.
+            // On Windows, the default is your ApplicationData folder.
+            '--DataDirectory',
+            this.options.torDataDir,
         ];
     }
 

--- a/packages/request-manager/src/torControlPort.ts
+++ b/packages/request-manager/src/torControlPort.ts
@@ -8,8 +8,8 @@ import { TorConnectionOptions } from './types';
 const readFile = util.promisify(fs.readFile);
 const randomBytes = util.promisify(crypto.randomBytes);
 
-export const getCookieString = async (authFilePath: string) => {
-    const controlAuthCookiePath = path.join(authFilePath, 'control_auth_cookie');
+export const getCookieString = async (torDataDir: string) => {
+    const controlAuthCookiePath = path.join(torDataDir, 'control_auth_cookie');
     return (await readFile(controlAuthCookiePath)).toString('hex');
 };
 
@@ -63,7 +63,7 @@ export class TorControlPort {
                 if (authchallengeResponse) {
                     let cookieString;
                     try {
-                        cookieString = await getCookieString(this.options.authFilePath);
+                        cookieString = await getCookieString(this.options.torDataDir);
                     } catch (error) {
                         reject(new Error('TOR control port control_auth_cookie cannot be read'));
                     }

--- a/packages/request-manager/src/types.ts
+++ b/packages/request-manager/src/types.ts
@@ -2,7 +2,7 @@ export interface TorConnectionOptions {
     host: string;
     port: number;
     controlPort: number;
-    authFilePath: string;
+    torDataDir: string;
 }
 
 export type BootstrapEvent = {

--- a/packages/suite-desktop/src-electron/libs/processes/TorProcess.ts
+++ b/packages/suite-desktop/src-electron/libs/processes/TorProcess.ts
@@ -6,7 +6,7 @@ interface TorConnectionOptions {
     host: string;
     port: number;
     controlPort: number;
-    authFilePath: string;
+    torDataDir: string;
 }
 
 class TorProcess extends BaseProcess {
@@ -14,7 +14,7 @@ class TorProcess extends BaseProcess {
     port: number;
     controlPort: number;
     torHost: string;
-    authFilePath: string;
+    torDataDir: string;
 
     constructor(options: TorConnectionOptions) {
         super('tor', 'tor');
@@ -22,13 +22,13 @@ class TorProcess extends BaseProcess {
         this.port = options.port;
         this.controlPort = options.controlPort;
         this.torHost = options.host;
-        this.authFilePath = options.authFilePath;
+        this.torDataDir = options.torDataDir;
 
         this.torController = new TorController({
             host: this.torHost,
             port: this.port,
             controlPort: this.controlPort,
-            authFilePath: this.authFilePath,
+            torDataDir: this.torDataDir,
         });
     }
 

--- a/packages/suite-desktop/src-electron/modules/tor.ts
+++ b/packages/suite-desktop/src-electron/modules/tor.ts
@@ -17,7 +17,8 @@ const load = async ({ mainWindow, store, interceptor }: Dependencies) => {
     const port = await getFreePort();
     const address = `${host}:${port}`;
     const controlPort = await getFreePort();
-    const authFilePath = app.getPath('userData');
+    const userData = app.getPath('userData');
+    const torDataDir = `${userData}/tor`;
 
     /**
      * Merges given TorSettings with settings already present in the store,
@@ -30,7 +31,7 @@ const load = async ({ mainWindow, store, interceptor }: Dependencies) => {
     };
 
     persistSettings({ address });
-    const tor = new TorProcess({ host, port, controlPort, authFilePath });
+    const tor = new TorProcess({ host, port, controlPort, torDataDir });
 
     const setProxy = (rule: string) => {
         logger.info('tor', `Setting proxy rules to "${rule}"`);


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Declares explicit tor DataDirectory so there is no confusion with DataDirecory running from other Tor process in the same computer.

## Related Issue

Resolve https://github.com/trezor/trezor-suite/issues/6361


## How to test it in macOS


    1. Have Tor successfully enabled in Trezor Suite. Exit the app.
    1. Turn on the tor service with `brew services start tor`.
    1. Start Trezor Suite and Tor should load normally.
