### PR TITLE
feat(suite): add coinjoin status bar

### DIFF
--- a/packages/suite/src/components/suite/CoinjoinStatusBar.tsx
+++ b/packages/suite/src/components/suite/CoinjoinStatusBar.tsx
@@ -1,0 +1,178 @@
+import React from 'react';
+import styled from 'styled-components';
+import { Button, variables } from '@trezor/components';
+import { Translation } from './Translation';
+import { CoinjoinSession, WalletParams } from '@suite-common/wallet-types';
+import { CountdownTimer } from './CountdownTimer';
+import { useActions } from '@suite-hooks/useActions';
+import * as routerActions from '@suite-actions/routerActions';
+import * as suiteActions from '@suite-actions/suiteActions';
+import { useSelector } from '@suite-hooks/useSelector';
+import { STATUS as DiscoveryStatus } from '@wallet-actions/constants/discoveryConstants';
+import { TranslationKey } from '@suite-common/intl-types';
+import { WalletLabeling } from './Labeling';
+
+const SPACING = 6;
+
+const Container = styled.div`
+    display: flex;
+    align-items: center;
+    height: 28px;
+    padding: 0 ${SPACING}px;
+    background: ${({ theme }) => theme.BG_WHITE};
+    border-bottom: 1px solid ${({ theme }) => theme.STROKE_LIGHT_GREY};
+    font-size: ${variables.FONT_SIZE.TINY};
+    font-weight: ${variables.FONT_WEIGHT.MEDIUM};
+`;
+
+const ProgressPie = styled.div<{ progress: number }>`
+    width: 16px;
+    height: 16px;
+    margin-right: ${SPACING}px;
+    border-radius: 50%;
+    background: ${({ theme, progress }) =>
+        `conic-gradient(${theme.BG_GREEN} ${3.6 * progress}deg, ${theme.STROKE_GREY} 0)`};
+`;
+
+const StatusText = styled.span`
+    color: ${({ theme }) => theme.TYPE_GREEN};
+`;
+
+const Note = styled.span`
+    color: ${({ theme }) => theme.TYPE_LIGHT_GREY};
+`;
+
+const Separator = styled.span`
+    margin: 0 ${SPACING / 2}px;
+`;
+
+const ViewButton = styled(Button)`
+    height: 20px;
+    margin-left: auto;
+`;
+
+enum MockCoinjoinPhase {
+    Starting,
+    Ongoing,
+    Error,
+}
+
+const PHASE_MESSAGES: Record<MockCoinjoinPhase, TranslationKey> = {
+    [MockCoinjoinPhase.Starting]: 'TR_COINJOIN_PHASE_0_MESSAGE',
+    [MockCoinjoinPhase.Ongoing]: 'TR_COINJOIN_PHASE_1_MESSAGE',
+    [MockCoinjoinPhase.Error]: 'TR_COINJOIN_PHASE_2_MESSAGE',
+};
+
+interface CoinjoinStatusBarProps {
+    accountKey: string;
+    session: CoinjoinSession;
+    isSingle: boolean;
+}
+
+export const CoinjoinStatusBar = ({ accountKey, session, isSingle }: CoinjoinStatusBarProps) => {
+    const devices = useSelector(state => state.devices);
+    const accounts = useSelector(state => state.wallet.accounts);
+    const selectedDevice = useSelector(state => state.suite.device);
+    const routerParams = useSelector(state => state.router.params);
+    const discovery = useSelector(state => state.wallet.discovery);
+
+    const { goto, selectDevice } = useActions({
+        goto: routerActions.goto,
+        selectDevice: suiteActions.selectDevice,
+    });
+
+    const relatedAccount = accounts?.find(account => account?.key === accountKey);
+
+    if (!relatedAccount) {
+        return null;
+    }
+
+    const { symbol, index, accountType, deviceState } = relatedAccount;
+
+    const isOnSelectedDevice = selectedDevice?.state === deviceState;
+    const relatedDevice = devices.find(device => device.state === deviceState);
+
+    if (!relatedDevice) {
+        return null;
+    }
+
+    const handleViewAccount = () => {
+        if (!isOnSelectedDevice) {
+            selectDevice(relatedDevice);
+        }
+
+        goto('wallet-index', {
+            params: {
+                symbol,
+                accountIndex: index,
+                accountType,
+            },
+        });
+    };
+
+    const { signedRounds, maxRounds, deadline } = session;
+
+    const phase = MockCoinjoinPhase.Ongoing; // TEMPORARY
+    const progress = signedRounds.length / (maxRounds / 100);
+
+    const {
+        symbol: symbolParam,
+        accountIndex: indexParam,
+        accountType: accountTypeParam,
+    } = (routerParams as WalletParams) || {};
+
+    const isOnAccountPage =
+        symbolParam === symbol && indexParam === index && accountTypeParam === accountType;
+
+    const areDevicesDiscovered = devices.every(({ state }) =>
+        discovery.find(
+            discoveryState =>
+                discoveryState.deviceState === state &&
+                discoveryState.status === DiscoveryStatus.COMPLETED,
+        ),
+    );
+
+    return (
+        <Container>
+            <ProgressPie progress={progress} />
+
+            <StatusText>
+                <Translation id={PHASE_MESSAGES[phase]} />
+
+                <Separator>•</Separator>
+
+                <Translation
+                    id="TR_COINJOIN_COUNTDOWN"
+                    values={{ rounds: maxRounds - signedRounds.length }}
+                />
+            </StatusText>
+
+            {session?.deadline && (
+                <Note>
+                    <Separator>•</Separator>
+
+                    <Translation
+                        id="TR_COINJOIN_ROUND_COUNTDOWN"
+                        values={{
+                            time: <CountdownTimer deadline={Number(deadline)} />,
+                        }}
+                    />
+                </Note>
+            )}
+
+            {!isSingle && (
+                <Note>
+                    <Separator>•</Separator>
+                    <WalletLabeling device={relatedDevice} shouldUseDeviceLabel />
+                </Note>
+            )}
+
+            {((isOnSelectedDevice && !isOnAccountPage) ||
+                (!isOnSelectedDevice && areDevicesDiscovered)) && (
+                <ViewButton variant="tertiary" onClick={handleViewAccount}>
+                    <Translation id="TR_VIEW" />
+                </ViewButton>
+            )}
+        </Container>
+    );
+};

--- a/packages/suite/src/components/suite/CountdownTimer.tsx
+++ b/packages/suite/src/components/suite/CountdownTimer.tsx
@@ -1,0 +1,26 @@
+import React, { useEffect, useState } from 'react';
+import { useLocales } from '@suite-hooks/useLocales';
+import { formatTimeLeft } from '@suite-utils/formatTimeLeft';
+
+interface TimerProps {
+    deadline: number;
+    className?: string;
+}
+
+export const CountdownTimer = ({ deadline, className }: TimerProps) => {
+    const locale = useLocales();
+
+    const [timeLeftString, setTimeLeftString] = useState(
+        formatTimeLeft(new Date(deadline), locale),
+    );
+
+    useEffect(() => {
+        const interval = setInterval(() => {
+            setTimeLeftString(formatTimeLeft(new Date(deadline), locale));
+        }, 100);
+
+        return () => clearInterval(interval);
+    }, [deadline, locale]);
+
+    return <span className={className}>{timeLeftString}</span>;
+};

--- a/packages/suite/src/components/suite/Labeling/components/WalletLabeling.tsx
+++ b/packages/suite/src/components/suite/Labeling/components/WalletLabeling.tsx
@@ -23,5 +23,5 @@ export const WalletLabeling = ({ device, shouldUseDeviceLabel }: WalletLabelling
         return <>{`${device.label} ${label}`}</>;
     }
 
-    return <>{label}</>;
+    return <span>{label}</span>;
 };

--- a/packages/suite/src/components/suite/SwitchDevice/components/WalletInstance.tsx
+++ b/packages/suite/src/components/suite/SwitchDevice/components/WalletInstance.tsx
@@ -139,11 +139,7 @@ export const WalletInstance = ({
                         )}
                         {instance.state ? (
                             <MetadataLabeling
-                                defaultVisibleValue={
-                                    <span>
-                                        <WalletLabeling device={instance} />
-                                    </span>
-                                }
+                                defaultVisibleValue={<WalletLabeling device={instance} />}
                                 payload={{
                                     type: 'walletLabel',
                                     deviceState: instance.state,
@@ -155,9 +151,7 @@ export const WalletInstance = ({
                                 }}
                             />
                         ) : (
-                            <span>
-                                <WalletLabeling device={instance} />
-                            </span>
+                            <WalletLabeling device={instance} />
                         )}
                     </InstanceType>
                 )}

--- a/packages/suite/src/components/suite/SwitchDevice/index.tsx
+++ b/packages/suite/src/components/suite/SwitchDevice/index.tsx
@@ -11,18 +11,6 @@ import { useSelector } from '@suite-hooks';
 
 import { WebUsbButton } from '../WebUsbButton';
 
-const HeadingActions = styled.div`
-    display: flex;
-    align-items: center;
-    flex: 1;
-    justify-content: flex-end;
-`;
-
-const CheckForDevicesWrapper = styled.div`
-    display: flex;
-    justify-content: center;
-`;
-
 const DeviceItemsWrapper = styled.div`
     display: flex;
     flex-direction: column;
@@ -57,17 +45,9 @@ export const SwitchDevice = ({ cancelable, onCancel }: ForegroundAppProps) => {
         <Modal
             isCancelable={cancelable}
             onCancel={onCancel}
-            heading={
-                <>
-                    <Translation id="TR_CHOOSE_WALLET" />
-                    <HeadingActions>
-                        {isWebUsbTransport && (
-                            <CheckForDevicesWrapper>
-                                <WebUsbButton icon="SEARCH" variant="tertiary" />
-                            </CheckForDevicesWrapper>
-                        )}
-                    </HeadingActions>
-                </>
+            heading={<Translation id="TR_CHOOSE_WALLET" />}
+            headerComponents={
+                isWebUsbTransport ? [<WebUsbButton icon="SEARCH" variant="tertiary" />] : undefined
             }
         >
             <DeviceItemsWrapper>

--- a/packages/suite/src/components/suite/index.tsx
+++ b/packages/suite/src/components/suite/index.tsx
@@ -50,6 +50,8 @@ import { AmountUnitSwitchWrapper } from './AmountUnitSwitchWrapper';
 import { renderToast } from './ToastNotification';
 import { SuiteLayout } from './SuiteLayout';
 import { TorLoader } from './TorLoader';
+import { CoinjoinStatusBar } from './CoinjoinStatusBar';
+import { CountdownTimer } from './CountdownTimer';
 
 export {
     DeviceIcon,
@@ -107,5 +109,7 @@ export {
     AmountUnitSwitchWrapper,
     renderToast,
     TorLoader,
+    CoinjoinStatusBar,
+    CountdownTimer,
 };
 export type { ModalProps };

--- a/packages/suite/src/support/messages.ts
+++ b/packages/suite/src/support/messages.ts
@@ -7153,7 +7153,19 @@ export default defineMessages({
     },
     TR_FEE_RATE_CHANGED: {
         id: 'TR_FEE_RATE_CHANGED',
-        defaultMessage: 'Fee rate has changed to complete transaction.',
+        defaultMessage: 'Fee rate has changed to complete transaction',
+    },
+    TR_COINJOIN_COUNTDOWN: {
+        id: 'TR_COINJOIN_COUNTDOWN',
+        defaultMessage: '{rounds} rounds left',
+    },
+    TR_COINJOIN_ROUND_COUNTDOWN: {
+        id: 'TR_FEE_RATE_CHANGED',
+        defaultMessage: 'Next transaction signing starts in {time}',
+    },
+    TR_VIEW: {
+        id: 'TR_VIEW',
+        defaultMessage: 'View',
     },
     TR_MY_COINS: {
         id: 'TR_MY_COINS',
@@ -7327,5 +7339,17 @@ export default defineMessages({
         id: 'TR_RESET_TO_DEFAULT',
         description: 'Button in coin join settings',
         defaultMessage: 'Reset to default',
+    },
+    TR_COINJOIN_PHASE_0_MESSAGE: {
+        id: 'TR_COINJOIN_PHASE_1_MESSAGE',
+        defaultMessage: 'Collecting inputs',
+    },
+    TR_COINJOIN_PHASE_1_MESSAGE: {
+        id: 'TR_COINJOIN_PHASE_2_MESSAGE',
+        defaultMessage: 'Joining coins',
+    },
+    TR_COINJOIN_PHASE_2_MESSAGE: {
+        id: 'TR_COINJOIN_PHASE_3_MESSAGE',
+        defaultMessage: 'U poor now',
     },
 });

--- a/packages/suite/src/utils/suite/__tests__/formatTimeLeft.test.ts
+++ b/packages/suite/src/utils/suite/__tests__/formatTimeLeft.test.ts
@@ -1,0 +1,22 @@
+import { formatTimeLeft } from '@suite-utils/formatTimeLeft';
+import enLocale from 'date-fns/locale/en-US/index';
+
+describe('formatTimeLeft', () => {
+    global.Date.now = jest.fn(() => new Date('2022-02-22T22:22:22Z').getTime());
+
+    it('correctly formats with default params', () => {
+        expect(formatTimeLeft(new Date('2022-02-22T23:22:22Z'), enLocale)).toEqual('1 hour');
+    });
+
+    it('correctly formats with more units', () => {
+        expect(
+            formatTimeLeft(new Date('2022-02-23T23:23:22Z'), enLocale, [
+                'days',
+                'hours',
+                'minutes',
+            ]),
+        ).toEqual('1 day 1 hour 1 minute');
+    });
+
+    global.Date.now = Date.now;
+});

--- a/packages/suite/src/utils/suite/formatTimeLeft.tsx
+++ b/packages/suite/src/utils/suite/formatTimeLeft.tsx
@@ -1,0 +1,17 @@
+import formatDuration from 'date-fns/formatDuration';
+import intervalToDuration from 'date-fns/intervalToDuration';
+
+export const formatTimeLeft = (
+    deadline: Date,
+    locale?: Locale,
+    format: Array<keyof Duration> = ['hours', 'minutes'],
+) => {
+    const duration = intervalToDuration({
+        start: Date.now(),
+        end: deadline,
+    });
+
+    const formattedTimeLeft = formatDuration(duration, { locale, format });
+
+    return formattedTimeLeft;
+};

--- a/suite-common/wallet-core/src/accounts/accountsReducer.ts
+++ b/suite-common/wallet-core/src/accounts/accountsReducer.ts
@@ -7,20 +7,18 @@ import { NetworkSymbol } from '@suite-common/wallet-config';
 
 import { accountsActions } from './accountsActions';
 
-export type AccountsState = Account[];
-
-export const accountsInitialState: AccountsState = [];
+export const accountsInitialState: Account[] = [];
 
 export type AccountsRootState = {
     wallet: {
-        accounts: AccountsState;
+        accounts: Account[];
     };
 };
 
 const accountEqualTo = (b: Account) => (a: Account) =>
     a.deviceState === b.deviceState && a.descriptor === b.descriptor && a.symbol === b.symbol;
 
-const update = (state: AccountsState, account: Account) => {
+const update = (state: Account[], account: Account) => {
     const accountIndex = state.findIndex(accountEqualTo(account));
 
     if (accountIndex !== -1) {
@@ -41,14 +39,14 @@ const update = (state: AccountsState, account: Account) => {
     }
 };
 
-const remove = (state: AccountsState, accounts: Account[]) => {
+const remove = (state: Account[], accounts: Account[]) => {
     accounts.forEach(a => {
         const index = state.findIndex(accountEqualTo(a));
         state.splice(index, 1);
     });
 };
 
-const setMetadata = (state: AccountsState, account: Account) => {
+const setMetadata = (state: Account[], account: Account) => {
     const index = state.findIndex(a => a.key === account.key);
     if (!state[index]) return;
     state[index].metadata = account.metadata;


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Added a coinjoin status bar. Total time left was removed as it's hard to estimate. It's still up to debate how will we communicate approximate duration of coinjoin to users @hynek-jina. 

Since the coinjoin implementation supports having multiple active coinjoin sessions **(still 1 per wallet)** I decided to render a status bar _per session_. At the same time, the current plan is to not have several session in suite – that will be handled by not allowing to initiate a session when one is already active. By rendering a bar per session we also ease debugging in some cases, since it will be visible that something is wrong – when you have more than one status bar rendered. If multiple sessions are permitted in the future, we won't have to adjust the code too much.

Also I recommend to use the `CoinjoinStatusBar` as an initiator for the critical phase modal _(#6117)_

## Related Issue

Resolve #6119

## Screenshots:

<img width="978" alt="image" src="https://user-images.githubusercontent.com/45338719/191732440-f5d0258b-5587-496c-9d04-4fc3a85a3560.png">

