### PR TITLE
wip(connect): correct bip48 multisig outputs

### DIFF
--- a/packages/connect/src/api/bitcoin/outputs.ts
+++ b/packages/connect/src/api/bitcoin/outputs.ts
@@ -27,6 +27,9 @@ export const validateTrezorOutputs = (
             { name: 'amount', type: 'uint' },
             { name: 'op_return_data', type: 'string' },
             { name: 'multisig', type: 'object' },
+            { name: 'orig_hash', type: 'string' },
+            { name: 'orig_index', type: 'number' },
+            { name: 'payment_req_index', type: 'number' },
         ]);
 
         if (
@@ -39,13 +42,11 @@ export const validateTrezorOutputs = (
             );
         }
 
-        if (output.address_n) {
-            const scriptType = getOutputScriptType(output.address_n);
-            if (output.script_type !== scriptType)
-                throw ERRORS.TypedError(
-                    'Method_InvalidParameter',
-                    `Output change script_type should be set to ${scriptType}`,
-                );
+        // discuss: does it make sense to recreate the same validation client side if it is done on device anyway?
+        // discuss: does it make sense to provide fallback here?
+        if (output.address_n && !output.script_type) {
+            // @ts-expect-error
+            output.script_type = getOutputScriptType(output.address_n);
         }
 
         if (
@@ -153,6 +154,7 @@ export const outputToTrezor = (
         return {
             address_n: output.path,
             amount: output.value,
+            // todo
             script_type: getOutputScriptType(output.path),
         };
     }

--- a/packages/connect/src/api/bitcoin/refTx.ts
+++ b/packages/connect/src/api/bitcoin/refTx.ts
@@ -153,6 +153,7 @@ export const transformOrigTransactions = (
                 ? {
                       address_n,
                       amount,
+                      // todo:
                       script_type: getOutputScriptType(address_n),
                   }
                 : {

--- a/packages/connect/src/api/signTransaction.ts
+++ b/packages/connect/src/api/signTransaction.ts
@@ -138,6 +138,7 @@ export default class SignTransaction extends AbstractMethod<'signTransaction', P
                 isBackendSupported(params.coinInfo);
                 const blockchain = await initBlockchain(params.coinInfo, this.postMessage);
                 const rawTxs = await blockchain.getTransactions(refTxsIds);
+                console.log('----refTxIds', rawTxs);
                 enhanceTrezorInputs(this.params.inputs, rawTxs);
                 refTxs = transformReferencedTransactions(rawTxs, params.coinInfo);
 

--- a/packages/connect/src/utils/pathUtils.ts
+++ b/packages/connect/src/utils/pathUtils.ts
@@ -75,6 +75,15 @@ export const getScriptType = (path: number[] | undefined): PROTO.InternalInputSc
     }
 };
 
+/**
+ * TODO: getOutputScriptType is not correct.
+ * see: https://github.com/trezor/trezor-suite/issues/6343
+ * at the moment, we use it only in connection with @trezor/utxo-lib which does
+ * not support the other types of transaction that would fail with the current
+ * implementation of getOutputScriptType
+ * see related implementation in firmware:
+ * https://github.com/trezor/trezor-firmware/blob/master/legacy/firmware/crypto.c#L488
+ */
 export const getOutputScriptType = (path?: number[]): PROTO.ChangeOutputScriptType => {
     if (!Array.isArray(path) || path.length < 1) return 'PAYTOADDRESS';
 

--- a/packages/integration-tests/projects/connect/__fixtures__/signTransactionMultisig.ts
+++ b/packages/integration-tests/projects/connect/__fixtures__/signTransactionMultisig.ts
@@ -192,5 +192,84 @@ export default {
             },
             result: false,
         },
+        {
+            description: 'https://github.com/trezor/trezor-suite/issues/6234',
+            setup: {
+                mnemonic:
+                    'solar segment strike patrol broccoli witness praise tennis fat elegant yellow menu favorite upgrade grace pulp subject tribe impact head west museum pulse term',
+            },
+            params: {
+                coin: 'testnet',
+                inputs: [
+                    {
+                        address_n: [2147483696, 2147483649, 2147483648, 2147483650, 0, 13],
+                        prev_index: 0,
+                        prev_hash:
+                            'a48aa3de3a0d5e82625d004ac316c8dbbe7a0b2380dd632f974e0513b0a181ef',
+                        script_type: 'SPENDWITNESS',
+                        multisig: {
+                            pubkeys: [
+                                {
+                                    node: 'tpubDEAEqUEydwjFkvZrk63u5qnhyQkMct2h7mmhUvue2GYACSygeyiDCXV5g59bs5Nursa3nAEWy1UamZaLL37tBqwVVLdhr9LzpkA7hdK2K3j',
+                                    address_n: [0, 13],
+                                },
+                                {
+                                    node: 'tpubDEFGNNrhcGZYq8i21XtJBfQqoktvRs3vmGT8nvS31QFgDMzPtLDyowdLLBMNf7fMQ7EBXCovagQctkFoXJqmUGeN4RzP3U7LKxzVp8R5YMu',
+                                    address_n: [0, 13],
+                                },
+                                {
+                                    node: 'tpubDEkumAckjusYPWdDBUm1HPg7tcJHAMRFfChXyBRu4Cyae6EteY3wekSh4rMmEVwPqiqY3CtZovtnR2X9dS7nbZ56C9hvpPiqtitDdvKCYFv',
+                                    address_n: [0, 13],
+                                },
+                            ],
+                            signatures: [],
+                            m: 2,
+                        },
+                        amount: '600000',
+                    },
+                ],
+                outputs: [
+                    {
+                        address_n: [2147483696, 2147483649, 2147483648, 2147483650, 1, 1],
+                        script_type: 'PAYTOWITNESS',
+                        amount: '199811',
+                        multisig: {
+                            pubkeys: [
+                                {
+                                    node: 'tpubDEAEqUEydwjFkvZrk63u5qnhyQkMct2h7mmhUvue2GYACSygeyiDCXV5g59bs5Nursa3nAEWy1UamZaLL37tBqwVVLdhr9LzpkA7hdK2K3j',
+                                    address_n: [1, 1],
+                                },
+                                {
+                                    node: 'tpubDEFGNNrhcGZYq8i21XtJBfQqoktvRs3vmGT8nvS31QFgDMzPtLDyowdLLBMNf7fMQ7EBXCovagQctkFoXJqmUGeN4RzP3U7LKxzVp8R5YMu',
+                                    address_n: [1, 1],
+                                },
+                                {
+                                    node: 'tpubDEkumAckjusYPWdDBUm1HPg7tcJHAMRFfChXyBRu4Cyae6EteY3wekSh4rMmEVwPqiqY3CtZovtnR2X9dS7nbZ56C9hvpPiqtitDdvKCYFv',
+                                    address_n: [1, 1],
+                                },
+                            ],
+                            signatures: [],
+                            m: 2,
+                        },
+                    },
+                    {
+                        script_type: 'PAYTOADDRESS',
+                        amount: '400000',
+                        address: 'tb1q0egy6cmrhzz69l3xn7tpndjt2dtqkk7a9mlruh',
+                    },
+                ],
+                refTxs: TX_CACHE(['a48aa3']),
+            },
+            result: {
+                signatures: [
+                    '3045022100fe3c723cdb1ebbbf4b3f889ec3c4449412a4f64231a3f48dba74ce037945d658022025424ca47d221ef02e3ba08ef9a104e506a10f4aecb36ea3d2013c6495b262fe',
+                ],
+                serializedTx:
+                    '01000000000101ef81a1b013054e972f63dd80230b7abedbc816c34a005d62825e0d3adea38aa40000000000ffffffff02830c030000000000220020ab4e9fef404206b0112ce540e01286e6a07a18ca9005fee27908659a2169ae05801a0600000000001600147e504d6363b885a2fe269f9619b64b53560b5bdd0300483045022100fe3c723cdb1ebbbf4b3f889ec3c4449412a4f64231a3f48dba74ce037945d658022025424ca47d221ef02e3ba08ef9a104e506a10f4aecb36ea3d2013c6495b262fe01695221028ea1d4d06cef29e8bf919995ffb9e55cea91eef5b85ca036e1f9ebe1ab6e5f5521035d4060d36c60a512837ffb316c03bd68e7e448c72c66e462fe528813042e340b2103da108bf1722968df8c228bd6e3981388127169884482664c21f859d3b8d7f1a853ae00000000',
+                witnesses: [
+                    '0300483045022100fe3c723cdb1ebbbf4b3f889ec3c4449412a4f64231a3f48dba74ce037945d658022025424ca47d221ef02e3ba08ef9a104e506a10f4aecb36ea3d2013c6495b262fe01695221028ea1d4d06cef29e8bf919995ffb9e55cea91eef5b85ca036e1f9ebe1ab6e5f5521035d4060d36c60a512837ffb316c03bd68e7e448c72c66e462fe528813042e340b2103da108bf1722968df8c228bd6e3981388127169884482664c21f859d3b8d7f1a853ae',
+                ],
+            },
+        },
     ],
 };

--- a/packages/integration-tests/projects/connect/__txcache__/testnet/a48aa3de3a0d5e82625d004ac316c8dbbe7a0b2380dd632f974e0513b0a181ef.json
+++ b/packages/integration-tests/projects/connect/__txcache__/testnet/a48aa3de3a0d5e82625d004ac316c8dbbe7a0b2380dd632f974e0513b0a181ef.json
@@ -1,0 +1,34 @@
+{
+  "version": 2,
+  "inputs": [
+    {
+      "prev_index": 0,
+      "sequence": 4294967293,
+      "prev_hash": "0e208b27dca9be1a07eedabcd992a6baae02cab982fdaf590a2c0a8a9e0b7305",
+      "script_sig": ""
+    },
+    {
+      "prev_index": 1,
+      "sequence": 4294967293,
+      "prev_hash": "35471d2c456535d04385c147307ca0dca2c0d36283a1dfe3cea047f7a2f8d614",
+      "script_sig": ""
+    },
+    {
+      "prev_index": 1,
+      "sequence": 4294967293,
+      "prev_hash": "7080ab54e25c90bceebbf10a1434e370eb19db3f9131987b14b16cb7d96c8787",
+      "script_sig": ""
+    }
+  ],
+  "bin_outputs": [
+    {
+      "amount": "600000",
+      "script_pubkey": "0020bff9853d18b6633b59460754963fbf078191a68b5755ce7dc800b3b08d5429c1"
+    },
+    {
+      "amount": "13299500",
+      "script_pubkey": "001468e4b73ffe439318b7812195b4f0590776bd9138"
+    }
+  ],
+  "lock_time": 2345926
+}


### PR DESCRIPTION
WIP. Looks like I can force connect to allow correct outputs simply by removing incorrect validation. But still need investigate few topis. Mainly that we still use `getOutputScriptType` and `getScriptType` in other places

