### PR TITLE
chore(e2e): refactor add accounts test

### DIFF
--- a/packages/integration-tests/projects/suite-web/support/pageObjects/accountsObject.ts
+++ b/packages/integration-tests/projects/suite-web/support/pageObjects/accountsObject.ts
@@ -1,0 +1,18 @@
+/// <reference types="cypress" />
+
+import { NetworkSymbol } from '../../../../../../suite-common/wallet-config/src/networksConfig';
+
+class AccountsPage {
+    unpackAllAccountTypes() {
+        cy.getTestElement('@account-menu/arrow').click({ multiple: true });
+    }
+
+    applyCoinFilter(coin: NetworkSymbol) {
+        cy.getTestElement(`@account-menu/filter/${coin}`)
+            .click()
+            .invoke('attr', 'data-test-activated')
+            .should('eq', 'true');
+    }
+}
+
+export const onAccountsPage = new AccountsPage();

--- a/packages/integration-tests/projects/suite-web/support/pageObjects/settingsCryptoObject.ts
+++ b/packages/integration-tests/projects/suite-web/support/pageObjects/settingsCryptoObject.ts
@@ -1,0 +1,14 @@
+/// <reference types="cypress" />
+
+import { NetworkSymbol } from '../../../../../../suite-common/wallet-config/src/networksConfig';
+
+class SettingsCrypto {
+    activateCoin(coin: NetworkSymbol) {
+        cy.getTestElement(`@settings/wallet/network/${coin}`)
+            .click()
+            .invoke('attr', 'data-active')
+            .should('be.eq', 'true');
+    }
+}
+
+export const onSettingsCryptoPage = new SettingsCrypto();

--- a/packages/integration-tests/projects/suite-web/support/pageObjects/topBarObject.ts
+++ b/packages/integration-tests/projects/suite-web/support/pageObjects/topBarObject.ts
@@ -1,0 +1,17 @@
+/// <reference types="cypress" />
+
+class TopBar {
+    openAccounts() {
+        cy.getTestElement('@suite/menu/wallet-index', { timeout: 30000 })
+            .should('be.visible')
+            .click();
+        cy.getTestElement('@account-menu/search-input', { timeout: 15000 }).should('be.visible');
+    }
+
+    openSettings() {
+        cy.getTestElement('@suite/menu/settings', { timeout: 30000 }).should('be.visible').click();
+        cy.getTestElement('@settings/menu/general').should('be.visible');
+    }
+}
+
+export const onTopBar = new TopBar();

--- a/packages/integration-tests/projects/suite-web/tests/wallet/add-account-types.test.ts
+++ b/packages/integration-tests/projects/suite-web/tests/wallet/add-account-types.test.ts
@@ -1,7 +1,12 @@
 // @group:suite
 // @retry=2
 
-describe('Add-account-types', () => {
+import { onAccountsPage } from '../../support/pageObjects/accountsObject';
+import { onSettingsCryptoPage } from '../../support/pageObjects/settingsCryptoObject';
+import { onTopBar } from '../../support/pageObjects/topBarObject';
+import { NetworkSymbol } from '../../../../../../suite-common/wallet-config/src/networksConfig';
+
+describe('Account types suite', () => {
     beforeEach(() => {
         cy.task('startEmu', { wipe: true });
         cy.task('setupEmu', {
@@ -32,41 +37,143 @@ describe('Add-account-types', () => {
         //
         // Test preparation
         //
-        const coin = 'btc';
+        const coin: NetworkSymbol = 'btc';
         const accsArray = [
-            ['normal', 'Bitcoin'],
-            ['taproot', 'Bitcoin (Taproot)'],
-            ['segwit', 'Bitcoin (Legacy Segwit)'],
-            ['legacy', 'Bitcoin (Legacy)'],
+            { type: 'normal', coinAccountName: 'Bitcoin' },
+            { type: 'taproot', coinAccountName: 'Bitcoin (Taproot)' },
+            { type: 'segwit', coinAccountName: 'Bitcoin (Legacy Segwit)' },
+            { type: 'legacy', coinAccountName: 'Bitcoin (Legacy)' },
         ];
 
         //
         // Test execution
         //
-        cy.getTestElement('@suite/menu/wallet-index', { timeout: 30000 }).click();
-        cy.getTestElement('@account-menu/arrow').click({ multiple: true });
 
-        accsArray.forEach(accountarray =>
+        onTopBar.openAccounts();
+        onAccountsPage.unpackAllAccountTypes();
+        accsArray.forEach(({ type, coinAccountName }: { type: string; coinAccountName: string }) =>
             // for a specific type of BTC acc, get the current number of accounts
             cy
-                .get(
-                    `[type="${accountarray[0]}"] > [data-test^="@account-menu/${coin}/${accountarray[0]}/"]`,
-                )
+                .get(`[type="${type}"] > [data-test^="@account-menu/${coin}/${type}/"]`)
                 .then(specificAccounts => {
                     const numberOfAccounts1 = specificAccounts.length;
 
                     // for a specific type of BTC acc, add a new acc
-                    cy.createAccountFromMyAccounts(coin, accountarray[1]);
+                    cy.createAccountFromMyAccounts(coin, coinAccountName);
 
                     // for a specific type of BTC acc, get the current number of accounts again for comparison
-                    cy.get(
-                        `[type="${accountarray[0]}"] > [data-test^="@account-menu/${coin}/${accountarray[0]}/"]`,
-                    ).then(specificAccounts => {
-                        const numberOfAccounts2 = specificAccounts.length;
+                    cy.get(`[type="${type}"] > [data-test^="@account-menu/${coin}/${type}/"]`).then(
+                        specificAccounts => {
+                            const numberOfAccounts2 = specificAccounts.length;
 
-                        expect(numberOfAccounts2).to.be.equal(numberOfAccounts1 + 1);
-                    });
+                            expect(numberOfAccounts2).to.be.equal(numberOfAccounts1 + 1);
+                        },
+                    );
                 }),
         );
+    });
+
+    /**
+     * Test case
+     * 1. go to Settings
+     * 2. activate LTC
+     * 3. go to Accounts
+     * 4. Unpack all account types
+     * 5. Get the number of accounts
+     * 6. Create new account for each account type
+     * 7. Get the number of accounts again
+     * 8. Verify that the current number is equeal to previous number + 1
+     */
+    it('Add-account-types-LTC', () => {
+        //
+        // Test preparation
+        //
+        const coin: NetworkSymbol = 'ltc';
+        const accsArray = [
+            { type: 'normal', coinAccountName: 'Litecoin' },
+            { type: 'segwit', coinAccountName: 'Litecoin (segwit)' },
+            { type: 'legacy', coinAccountName: 'Litecoin (legacy)' },
+        ];
+
+        //
+        // Test execution
+        //
+
+        // activate the coin
+        cy.prefixedVisit('/settings/coins');
+        onSettingsCryptoPage.activateCoin(coin);
+
+        onTopBar.openAccounts();
+        onAccountsPage.applyCoinFilter(coin);
+        cy.discoveryShouldFinish();
+        onAccountsPage.unpackAllAccountTypes();
+
+        accsArray.forEach(({ type, coinAccountName }: { type: string; coinAccountName: string }) =>
+            cy
+                .get(`[type="${type}"] > [data-test^="@account-menu/${coin}/${type}/"]`)
+                .then(specificAccounts => {
+                    const numberOfAccounts1 = specificAccounts.length;
+                    cy.createAccountFromMyAccounts(coin, coinAccountName);
+                    cy.get(`[type="${type}"] > [data-test^="@account-menu/${coin}/${type}/"]`).then(
+                        specificAccounts => {
+                            const numberOfAccounts2 = specificAccounts.length;
+                            expect(numberOfAccounts2).to.be.equal(numberOfAccounts1 + 1);
+                        },
+                    );
+                }),
+        );
+    });
+
+    /**
+     * Test case
+     * 1. go to Settings
+     * 2. activate ADA and ETH
+     * 3. go to Accounts
+     * 4. for each coin:
+     * 5. Get the number of accounts
+     * 6. Create new account
+     * 7. Get the number of accounts again
+     * 8. Verify that the current number is equeal to previous number + 1
+     */
+    it('Add-account-types-non-BTC-coins', () => {
+        //
+        // Test execution
+        //
+        const coins: NetworkSymbol[] = ['ada', 'eth'];
+
+        // activate the coin
+        cy.prefixedVisit('/settings/coins');
+        coins.forEach((coin: NetworkSymbol) => {
+            onSettingsCryptoPage.activateCoin(coin);
+        });
+
+        onTopBar.openAccounts();
+        cy.discoveryShouldFinish();
+        // cardano
+
+        coins.forEach((coin: NetworkSymbol) => {
+            onAccountsPage.applyCoinFilter(coin);
+            // get the element containing all accounts
+            cy.get(`[type="normal"] > [data-test*="@account-menu/${coin}/normal"]`).then(
+                currentAccounts => {
+                    const numberOfAccounts1 = currentAccounts.length;
+
+                    cy.getTestElement('@account-menu/add-account').should('be.visible').click();
+                    cy.getTestElement('@modal').should('be.visible');
+                    cy.get(`[data-test="@settings/wallet/network/${coin}"]`)
+                        .should('be.visible')
+                        .click();
+                    cy.getTestElement('@add-account').click();
+                    cy.discoveryShouldFinish();
+
+                    cy.get(`[type="normal"] > [data-test*="@account-menu/${coin}/normal"]`).then(
+                        newAccounts => {
+                            const numberOfAccounts2 = newAccounts.length;
+                            expect(numberOfAccounts2).to.be.equal(numberOfAccounts1 + 1);
+                        },
+                    );
+                },
+            );
+        });
     });
 });

--- a/packages/suite/src/components/wallet/AccountsMenu/AccountSearchBox.tsx
+++ b/packages/suite/src/components/wallet/AccountsMenu/AccountSearchBox.tsx
@@ -130,9 +130,11 @@ export const AccountSearchBox = (props: AccountSearchBoxProps) => {
                             }}
                         >
                             <StyledCoinLogo
+                                data-test={`@account-menu/filter/${n}`}
                                 symbol={n}
                                 size={props.isMobile ? 24 : 16}
                                 filterActivated={!!coinFilter}
+                                data-test-activated={coinFilter === n}
                                 isSelected={coinFilter === n}
                             />
                         </OuterCircle>


### PR DESCRIPTION
- implemented a basic page object model (POM)
- adjusted the current add-account-types-btc test
  - separation of BTC and LTC is done for a better readability
- added tests for LTC, ADA and ETH