### PR TITLE
chore(transport): remove flow remnants

### DIFF
--- a/packages/transport/README.md
+++ b/packages/transport/README.md
@@ -17,10 +17,12 @@ _You probably don't want to use this package directly._ For communication with T
     -   WebUSB
 -   Create and expose typescript definitions based on protobuf definitions.
 
-## From Protobuf to TypeScript and Flow
+## From Protobuf to TypeScript ~~and Flow~~
+
+> note: flow.js support was removed in @trezor/connect v9 (https://github.com/trezor/trezor-suite/pull/6389)
 
 This section describes how the definitions of protobuf messages maintained in the
-firmware repo are semi-automatically translated to Flow and TypeScript definitions that are used in Connect codebase and by Connect users respectively.
+firmware repo are semi-automatically translated to ~~Flow~~ and TypeScript definitions that are used in Connect codebase and by Connect users respectively.
 
 ### The short version
 
@@ -28,7 +30,7 @@ In order to be able to use new features of trezor-firmware you need to update pr
 
 1. `git submodule update --init --recursive` to initialize trezor-common submodule
 1. `yarn update-submodules` to update trezor-common submodule
-1. `yarn workspace @trezor/transport update:protobuf` to generate new `./messages.json` and `./src/types/messages.ts`
+1. `yarn update-protobuf` to generate new `./messages.json` and `./src/types/messages.ts`
 
 ### In depth explanation
 
@@ -37,9 +39,9 @@ The beginning and source of truth are the `.proto` definitions in the [firmware 
 `trezor-common` is included in `trezor-suite` as a git submodule mounted at `packages/transport/trezor-common`.`
 
 Here, `.proto` definitions are translated to a JSON format using [pbjs](https://www.npmjs.com/package/pbjs) package. This JSON is used on runtime by the `@trezor/transport` package
-for (de)serialization logic and to generate the Flow and Typescript definitions.
+for (de)serialization logic and to generate Typescript definitions.
 
-The JSON is transformed to Flow and/or TypeScript definitions by a script in `scripts/protobuf-types.js`. The script also applies 'patches' I.e. after-the-fact fixes manually described in `scripts/protobuf-patches.js`. The patches compensate for/fix
+The JSON is transformed to TypeScript definitions by a script in `scripts/protobuf-types.js`. The script also applies 'patches' I.e. after-the-fact fixes manually described in `scripts/protobuf-patches.js`. The patches compensate for/fix
 
 -   The source `.proto` definitions that do not reflect the actual business logic. Usually fields marked as required which are in fact optional.
 -   Fields typed as `uint32`, `uint64`, `sint32`, `sint64` in protobuf that need to be represented as strings in runtime because of javascript number's insufficient range. Runtime conversion is handled automatically by `@trezor/transport`.

--- a/packages/transport/scripts/protobuf-build.sh
+++ b/packages/transport/scripts/protobuf-build.sh
@@ -8,27 +8,18 @@ PARENT_PATH=$( cd "$(dirname "${BASH_SOURCE[0]}")" ; pwd -P )
 
 SRC="../../submodules/trezor-common/protob"
 DIST="."
-LANG="typescript"
 
-if [[ $# -ne 0 && $# -ne 3 ]]
+if [[ $# -ne 0 && $# -ne 2 ]]
     then
-        echo "must provide either 3 or 0 arguments. $# provided"
+        echo "must provide either 2 or 0 arguments. $# provided"
         exit 1
 fi
 
-if [[ $# -eq 3 ]]
+if [[ $# -eq 2 ]]
     then
         SRC=$1
         DIST=$2
-        LANG=$3
 fi
-
-if [[ "$LANG" != "typescript" && "$LANG" != "flow" ]];
-    then
-        echo "either typescript or flow must be specified as the third argument"
-        exit 1
-fi
-
 
 # BUILD combined messages.proto file from protobuf files
 # this code was copied from ./submodules/trezor-common/protob Makekile
@@ -47,8 +38,6 @@ grep -hv -e '^import ' -e '^syntax' -e '^package' -e 'option java_' "$SRC"/messa
 node_modules/.bin/pbjs -t json -p "$DIST" -o "$DIST"/messages.json --keep-case messages.proto
 rm "$DIST"/messages.proto
 
-echo "generating type definitions for: $LANG"
-
 cd "$PARENT_PATH"
 
-node ./protobuf-types.js "$LANG"
+node ./protobuf-types.js typescript

--- a/packages/transport/scripts/protobuf-patches/TxAck.js
+++ b/packages/transport/scripts/protobuf-patches/TxAck.js
@@ -1,31 +1,22 @@
-// @flow
-
 // TxAck replacement
 // TxAck needs more exact types
 // PrevInput and TxInputType requires exact responses in TxAckResponse
 // main difference: PrevInput should not contain address_n (unexpected field by protobuf)
 
-// @overhead-start this will be removed during compilation
-type TxInputType = any;
-type PrevInput = any;
-type TxOutputBinType = any;
-type TxOutputType = any;
-// @overhead-end
-
 export type TxAckResponse =
-    | {|
+    | {
           inputs: Array<TxInputType | PrevInput>,
-      |}
-    | {|
+      }
+    | {
           bin_outputs: TxOutputBinType[],
-      |}
-    | {|
+      }
+    | {
           outputs: TxOutputType[],
-      |}
-    | {|
+      }
+    | {
           extra_data: string,
-      |}
-    | {|
+      }
+    | {
           version?: number,
           lock_time?: number,
           inputs_cnt: number,
@@ -36,7 +27,7 @@ export type TxAckResponse =
           version_group_id?: number,
           expiry?: number,
           branch_id?: number,
-      |};
+      };
 
 export type TxAck = {
     tx: TxAckResponse,

--- a/packages/transport/scripts/protobuf-patches/TxInputType.js
+++ b/packages/transport/scripts/protobuf-patches/TxInputType.js
@@ -1,20 +1,10 @@
-// @flow
 // TxInputType replacement
 // TxInputType needs more exact types
 // differences: external input (no address_n + required script_pubkey)
 
-// @overhead-start
-// will be removed during compilation
-type UintType = any;
-type MultisigRedeemScriptType = any;
-type InternalInputScriptType = any;
-type DecredStakingSpendType = any;
-// @overhead-end
+export type InternalInputScriptType = Exclude<InputScriptType, 'EXTERNAL'>;
 
-// @flowtype-variant: export type InternalInputScriptType = $Keys<$Diff<typeof Enum_InputScriptType, { EXTERNAL: * }>>;
-// @typescript-variant: export type InternalInputScriptType = Exclude<InputScriptType, 'EXTERNAL'>;
-
-type CommonTxInputType = {|
+type CommonTxInputType = {
     prev_hash: string, // required: previous transaction hash (reversed)
     prev_index: number, // required: previous transaction index
     amount: UintType, // required
@@ -29,20 +19,18 @@ type CommonTxInputType = {|
     witness?: string, // used by EXTERNAL, depending on script_pubkey
     ownership_proof?: string, // used by EXTERNAL, depending on script_pubkey
     commitment_data?: string, // used by EXTERNAL, depending on ownership_proof
-|};
+};
 
 export type TxInputType =
-    | {|
-          ...CommonTxInputType,
+    | (CommonTxInputType & {
           address_n: number[],
           script_type?: InternalInputScriptType,
-      |}
-    | {|
-          ...CommonTxInputType,
+      })
+    | (CommonTxInputType & {
           address_n?: typeof undefined,
           script_type: 'EXTERNAL',
           script_pubkey: string,
-      |};
+      });
 
 export type TxInput = TxInputType;
 

--- a/packages/transport/scripts/protobuf-patches/TxOutputType.js
+++ b/packages/transport/scripts/protobuf-patches/TxOutputType.js
@@ -1,20 +1,11 @@
-// @flow
 // TxOutputType replacement
 // TxOutputType needs more exact types
 // differences: external output (no address_n), opreturn output (no address_n, no address)
 
-// @overhead-start
-// will be removed during compilation
-type UintType = any;
-type MultisigRedeemScriptType = any;
-type ChangeOutputScriptType = any;
-// @overhead-end
-
-// @typescript-variant: export type ChangeOutputScriptType = Exclude<OutputScriptType, 'PAYTOOPRETURN'>;
-// @flowtype-variant: export type ChangeOutputScriptType = $Keys<$Diff<typeof Enum_OutputScriptType, { PAYTOOPRETURN: * }>>;
+export type ChangeOutputScriptType = Exclude<OutputScriptType, 'PAYTOOPRETURN'>;
 
 export type TxOutputType =
-    | {|
+    | {
           address: string,
           address_n?: typeof undefined,
           script_type: 'PAYTOADDRESS',
@@ -23,8 +14,8 @@ export type TxOutputType =
           orig_hash?: string,
           orig_index?: number,
           payment_req_index?: number,
-      |}
-    | {|
+      }
+    | {
           address?: typeof undefined,
           address_n: number[],
           script_type: ChangeOutputScriptType,
@@ -33,8 +24,8 @@ export type TxOutputType =
           orig_hash?: string,
           orig_index?: number,
           payment_req_index?: number,
-      |}
-    | {|
+      }
+    | {
           address?: typeof undefined,
           address_n?: typeof undefined,
           amount: '0',
@@ -43,7 +34,7 @@ export type TxOutputType =
           orig_hash?: string,
           orig_index?: number,
           payment_req_index?: number,
-      |};
+      };
 
 export type TxOutput = TxOutputType;
 

--- a/packages/transport/src/types/messages.ts
+++ b/packages/transport/src/types/messages.ts
@@ -421,7 +421,6 @@ export type TxAckPaymentRequest = {
 };
 
 // TxAck
-
 // TxAck replacement
 // TxAck needs more exact types
 // PrevInput and TxInputType requires exact responses in TxAckResponse


### PR DESCRIPTION
## Description

Remove flow type generation. We do not support flowtype anyway and in my opinion supporting might bear some maintanance cost in the future. If somebody will request this feature, we might consider adding it back - I have updated README in transport package so that we can find it later easily.
