### PR TITLE
ci: display bundle info in PR [wip]

### DIFF
--- a/ci/build.yml
+++ b/ci/build.yml
@@ -197,12 +197,14 @@ suite-desktop build mac codesign:
 ## Suite desktop Linux app
 suite-desktop build linux:
   <<: *config_sign_dev
-  only:
-    <<: *run_everything_rules
+  # only:
+  #   <<: *run_everything_rules
   variables:
     artifact: ${DESKTOP_APP_NAME}*
     platform: linux
   <<: *build
+  after_script:
+    - yarn tsx ci/scripts/bundle-size.ts
 
 suite-desktop build linux manual:
   <<: *config_sign_dev

--- a/ci/scripts/bundle-size.ts
+++ b/ci/scripts/bundle-size.ts
@@ -1,0 +1,45 @@
+console.log('hello');
+
+import fetch from 'node-fetch';
+
+const suiteProjectId = '14570634';
+const artifactPath = 'latest-linux.yml';
+const jobName = 'suite-desktop build linux';
+
+const devBundleUrl = encodeURI(
+    `https://gitlab.com/api/v4/projects/${suiteProjectId}/jobs/artifacts/develop/raw/${artifactPath}?job=${jobName}`,
+);
+const currentBundleUrl = encodeURI(
+    `https://gitlab.com/api/v4/projects/${suiteProjectId}/jobs/artifacts/${process.env.CI_BUILD_REF_NAME}/raw/${artifactPath}?job=${jobName}`,
+);
+
+const getBundleSize = async (url: string) => {
+    const bundleInfoResp = await fetch(url);
+    if (bundleInfoResp.status !== 200) {
+        throw new Error(bundleInfoResp.statusText);
+    }
+    return bundleInfoResp.text();
+};
+
+const getSize = (yml: string) => {
+    const regexp = /size: \d+/;
+    const match = regexp.exec(yml);
+
+    if (!match) {
+        throw new Error('could not parse yaml file');
+    }
+    return match[0].replace('size: ', '');
+};
+
+const run = async () => {
+    const devBundleInfo = await getBundleSize(devBundleUrl);
+    const currentBundleInfo = await getBundleSize(currentBundleUrl);
+
+    const devSize = getSize(devBundleInfo);
+    const currentBundleSize = getSize(currentBundleInfo);
+
+    console.log('dev bundle size: ', devSize);
+    console.log('current bundle size', currentBundleSize);
+};
+
+run();


### PR DESCRIPTION
WIP
The idea here is to compare build size of desktop app in current branch and destkop app in develop branch and post the result into PR. but it makes not much sense to do this in gitlab.

steps / todos: 
- [ ] migrate build to github
- [ ] update script (artifacts fetching)
- [ ] post / update message into PR (use bot similary like in crowdin update)
