### PR TITLE
Connect getHdNode fix

### DIFF
--- a/docker/docker-compose.connect-popup-test.yml
+++ b/docker/docker-compose.connect-popup-test.yml
@@ -30,8 +30,9 @@ services:
       - HEADLESS=false
       # useful for debugging tests
       - PWDEBUG=console
+      - TEST_FILE=$TEST_FILE
     working_dir: /trezor-suite
-    command: bash -c "npx playwright install && docker/wait-for-200.sh http://localhost:8088/index.html && yarn workspace @trezor/connect-popup test:e2e"
+    command: bash -c "npx playwright install && docker/wait-for-200.sh http://localhost:8088/index.html && yarn workspace @trezor/connect-popup test:e2e $TEST_FILE"
     volumes:
       - ../:/trezor-suite
       - /tmp/.X11-unix:/tmp/.X11-unix:rw

--- a/docker/docker-connect-popup-test.sh
+++ b/docker/docker-connect-popup-test.sh
@@ -4,5 +4,6 @@ set -e
 xhost +
 LOCAL_USER_ID="$(id -u "$USER")"
 export LOCAL_USER_ID
+export TEST_FILE=$1
 
 docker-compose -f ./docker/docker-compose.connect-popup-test.yml up --build --abort-on-container-exit

--- a/packages/connect/e2e/__fixtures__/getPublicKeyBip48.ts
+++ b/packages/connect/e2e/__fixtures__/getPublicKeyBip48.ts
@@ -1,0 +1,42 @@
+export default {
+    method: 'getPublicKey',
+    setup: {
+        mnemonic: 'mnemonic_12',
+    },
+    tests: [
+        {
+            description: 'bip 48 SPENDWITNESS (implicitly returns zpub)',
+            params: {
+                path: "m/48'/0'/0'/2'/0/0",
+                coin: 'btc',
+            },
+            result: {
+                xpubSegwit:
+                    'zpub6wECHaiZeZ9cuPQjdWrGiNCz8zJB2JB16ENHZz8KhbvkxzvRtC3kyzs7PtKMeGNos6QAmexY1MmgRgbEncrWHuhUhcSbcJ1CHphHtg3HcZj',
+                xpub: 'xpub6HZfgFNjMC4fCo2VxoH2JC1yo41H94C1G1Kr1CLYwbAzroHyNsidjsYqMUQBeT4y3pAZGhmR634af7N7ME2UhSLGxw3kSUNDkNa17X6skwe',
+            },
+        },
+        {
+            description: 'bip 48 SPENDP2SHWITNESS (implicitly returns ypub)',
+            params: {
+                path: "m/48'/0'/0'/1'/0/0",
+                coin: 'btc',
+            },
+            result: {
+                xpub: 'xpub6J2XMT5GQZkqU14eNeP7H8DDWn66JpLJxUdcYbqZ2LrSSUrNoyA5NMgub9tM5dLND2VStfzQdt4m9jbsqeceUgmw5daCTB1TiN3nCuqaDTS',
+                xpubSegwit:
+                    'ypub6crnf7kBZFJKKJFmD1AjVDJigkEYFSKosb9qKzjSQMEKVafc4dKdzRM3cMqw5XzHcfcFe9ay6YRK32DSZM2fGvTXwyGd35pwz67RbRxgxa6',
+            },
+        },
+        {
+            description: 'bip 48 SPENDMULTISIG',
+            params: {
+                path: "m/48'/0'/0'/0'/0/0",
+                coin: 'btc',
+            },
+            result: {
+                xpub: 'xpub6HPqwmk3y75QR9S27EzDLXoGBAha9DepXPY5T4YfUMTLdiMxwjqaqgYqsV28PCpCuzpcbSawiS9mRGtX3zRQ4dvETW69RQ9RLyQ3gZ5J6Lb',
+            },
+        },
+    ],
+};

--- a/packages/connect/e2e/__fixtures__/index.ts
+++ b/packages/connect/e2e/__fixtures__/index.ts
@@ -28,6 +28,7 @@ import getFirmwareHash from './getFirmwareHash';
 import getOwnershipId from './getOwnershipId';
 import getOwnershipProof from './getOwnershipProof';
 import getPublicKey from './getPublicKey';
+import getPublicKeyBip48 from './getPublicKeyBip48';
 import nemGetAddress from './nemGetAddress';
 import nemSignTransactionMosaic from './nemSignTransactionMosaic';
 import nemSignTransactionMultisig from './nemSignTransactionMultisig';
@@ -126,6 +127,7 @@ let fixtures = [
     getOwnershipId,
     getOwnershipProof,
     getPublicKey,
+    getPublicKeyBip48,
     nemGetAddress,
     nemSignTransactionMosaic,
     nemSignTransactionMultisig,

--- a/packages/connect/src/utils/pathUtils.ts
+++ b/packages/connect/src/utils/pathUtils.ts
@@ -38,9 +38,6 @@ export const getHDPath = (path: string): number[] => {
         });
 };
 
-export const isMultisigPath = (path: number[] | undefined) =>
-    Array.isArray(path) && path[0] === toHardened(48);
-
 export const isSegwitPath = (path: number[] | undefined) =>
     Array.isArray(path) && path[0] === toHardened(49);
 


### PR DESCRIPTION
Hello stranger, have youreself seated and listen to the story of this PR:

- First, we merged this #6393, then it broke a [3rd party integration test](https://gitlab.com/satoshilabs/trezor/trezor-suite/-/jobs/3091875100)
- so I went to refactor it, but it was impossible to run only 1 connect-popup test locally, so I added it in  [b6aaf71](https://github.com/trezor/trezor-suite/pull/6407/commits/b6aaf7102242347ebb95067e6812d58db0fc59d9) 
- the actual fix was added in [2900123](https://github.com/trezor/trezor-suite/pull/6407/commits/29001239b303626bdc3a62a1cac86601a63547b2)
- tests for getPublicKey on multisig paths were added here [2c42516](https://github.com/trezor/trezor-suite/pull/6407/commits/2c425162b70149b283db2d198416bd9df8ec2d8b) but unfortunately I wasn't able to find any fixtures in trezor-firmware repo so I would like to ask @matejcik  for help here. :pray: do you have any suggestion how to validate the newly added fixtures are correct? can I simply rely on what trezor device tells me? :imp: 