### PR TITLE
fix(suite): handle missing account when trying to add more

### DIFF
--- a/packages/suite/src/components/suite/modals/AddAccount/components/AddAccountButton.tsx
+++ b/packages/suite/src/components/suite/modals/AddAccount/components/AddAccountButton.tsx
@@ -13,6 +13,13 @@ const verifyAvailability = ({
     emptyAccounts: Account[];
     account: Account;
 }) => {
+    if (!account) {
+        // discovery failed?
+        return <Translation id="MODAL_ADD_ACCOUNT_NO_ACCOUNT" />;
+    }
+    if (emptyAccounts.length === 0) {
+        return <Translation id="MODAL_ADD_ACCOUNT_NO_EMPTY_ACCOUNT" />;
+    }
     if (emptyAccounts.length > 1) {
         // prev account is empty, do not add another
         return <Translation id="MODAL_ADD_ACCOUNT_PREVIOUS_EMPTY" />;
@@ -61,8 +68,6 @@ const AddDefaultAccountButton = ({
             },
         });
     }, [account, onEnableAccount, setSearchString, setCoinFilter, coinFilter]);
-
-    if (emptyAccounts.length === 0) return null;
 
     return <AddButton disabledMessage={disabledMessage} handleClick={handleClick} />;
 };

--- a/packages/suite/src/support/messages.ts
+++ b/packages/suite/src/support/messages.ts
@@ -3775,6 +3775,14 @@ export default defineMessages({
         id: 'MODAL_ADD_ACCOUNT_TITLE',
         defaultMessage: 'New account',
     },
+    MODAL_ADD_ACCOUNT_NO_ACCOUNT: {
+        id: 'MODAL_ADD_ACCOUNT_NO_ACCOUNT',
+        defaultMessage: 'Account discovery error',
+    },
+    MODAL_ADD_ACCOUNT_NO_EMPTY_ACCOUNT: {
+        id: 'MODAL_ADD_ACCOUNT_NO_EMPTY_ACCOUNT',
+        defaultMessage: 'There is no empty account available.',
+    },
     MODAL_ADD_ACCOUNT_PREVIOUS_EMPTY: {
         id: 'MODAL_ADD_ACCOUNT_PREVIOUS_EMPTY',
         defaultMessage: 'Previous account is empty',


### PR DESCRIPTION
- Also disable button and provide tooltip if there are no empty accounts.

<!--- Provide a general summary of your changes in the Title above -->

## Description
Here I moved `verifyAvailability` check before `emptyAccounts.length === 0` condition:
https://github.com/trezor/trezor-suite/pull/6276/commits/81f46e522f8fe7185bb43ff815d6a37bf4a40efa#diff-d38593712315afa9d7a2059044445bc79cf206d97b71ad5bf5d70c17e7e948efL83
and it caused this error.

Now I moved the check directly in `verifyAvailability` so we show error message in tooltip on disabled button instead of not rendering the button at all.

## Related Issue

Resolve https://github.com/trezor/trezor-suite/issues/6424

## Screenshots (if appropriate):
![image](https://user-images.githubusercontent.com/3729633/193070756-5f946748-9acd-44b3-9b76-89fd2aee2c24.png)

