### PR TITLE
chore(suite-native): Update react-native-skia library

### DIFF
--- a/packages/icons/package.json
+++ b/packages/icons/package.json
@@ -11,7 +11,7 @@
         "generate-icons": "yarn tsx generateIcons.js"
     },
     "dependencies": {
-        "@shopify/react-native-skia": "0.1.146",
+        "@shopify/react-native-skia": "0.1.152",
         "@trezor/styles": "*",
         "@trezor/theme": "*",
         "react": "^17.0.2",

--- a/suite-native/app/ios/Podfile
+++ b/suite-native/app/ios/Podfile
@@ -39,18 +39,33 @@ target 'TrezorSuite' do
 
   post_install do |installer|
     react_native_post_install(installer)
+    flipper_post_install(installer)
+
     installer.pods_project.targets.each do |target|
       target.build_configurations.each do |config|
         if target.name == 'react-native-config'
           config.build_settings['ENVFILE'] = ENVFILES[config.name]
         end
+
+        # Fix local build with approved iOS device - https://github.com/CocoaPods/CocoaPods/issues/11402
         if target.respond_to?(:product_type) and target.product_type == "com.apple.product-type.bundle"
           target.build_configurations.each do |config|
               config.build_settings['CODE_SIGNING_ALLOWED'] = 'NO'
           end
         end
-        config.build_settings['EXCLUDED_ARCHS[sdk=iphonesimulator*]'] = "arm64"
+
+        config.build_settings["ONLY_ACTIVE_ARCH"] = "NO"
       end
+    end
+
+    # See: https://github.com/facebook/react-native/issues/31941
+    installer.aggregate_targets.each do |aggregate_target|
+      aggregate_target.user_project.native_targets.each do |target|
+        target.build_configurations.each do |config|
+          config.build_settings['LIBRARY_SEARCH_PATHS'] = ['$(SDKROOT)/usr/lib/swift', '$(inherited)']
+        end
+      end
+      aggregate_target.user_project.save
     end
     __apply_Xcode_12_5_M1_post_install_workaround(installer)
   end

--- a/suite-native/app/ios/Podfile.lock
+++ b/suite-native/app/ios/Podfile.lock
@@ -708,9 +708,9 @@ EXTERNAL SOURCES:
     :path: "../../../node_modules/react-native/ReactCommon/yoga"
 
 SPEC CHECKSUMS:
-  boost: a7c83b31436843459a1961bfd74b96033dc77234
+  boost: 33822b9202be3240e51605d20431570aa3a6c58e
   CocoaAsyncSocket: 065fd1e645c7abab64f7a6a2007a48038fdc6a99
-  DoubleConversion: 831926d9b8bf8166fd87886c4abab286c2422662
+  DoubleConversion: 5c2288575b9bd33de61ab847e51d0dca167323e7
   FBLazyVector: a7a655862f6b09625d11c772296b01cd5164b648
   FBReactNativeSpec: d8bedf13ce939219aacc80bbbe2675ce47f67e27
   Flipper: e74096365356f4d41ef6daae24b79b9ed0350662
@@ -723,7 +723,7 @@ SPEC CHECKSUMS:
   Flipper-RSocket: d9d9ade67cbecf6ac10730304bf5607266dd2541
   FlipperKit: 5f38e9e8c3975f0e91373f0b435c2539283c60d6
   fmt: ff9d55029c625d3757ed641535fd4a75fedc7ce9
-  glog: 476ee3e89abb49e07f822b48323c51c57124b572
+  glog: 46667b3bfd7b7368ebbef149ba7e1d17a61a1b94
   GoogleDataTransport: 1c8145da7117bd68bbbed00cf304edb6a24de00f
   GoogleMLKit: 0017a6a8372e1a182139b9def4d89be5d87ca5a7
   GoogleToolboxForMac: 8bef7c7c5cf7291c687cf5354f39f9db6399ad34
@@ -742,7 +742,7 @@ SPEC CHECKSUMS:
   OpenSSL-Universal: ebc357f1e6bc71fa463ccb2fe676756aff50e88c
   PromisesObjC: ab77feca74fa2823e7af4249b8326368e61014cb
   Protobuf: e7846f61e8542750cf311385fc633c1d00928f9f
-  RCT-Folly: 4d8508a426467c48885f1151029bc15fa5d7b3b8
+  RCT-Folly: 97ba718a5f53eedf76d63d51074d5a9ca1245029
   RCTRequired: 3e917ea5377751094f38145fdece525aa90545a0
   RCTTypeSafety: c43c072a4bd60feb49a9570b0517892b4305c45e
   React: 176dd882de001854ced260fad41bb68a31aa4bd0
@@ -783,6 +783,6 @@ SPEC CHECKSUMS:
   Yoga: 99652481fcd320aefa4a7ef90095b95acd181952
   YogaKit: f782866e155069a2cca2517aafea43200b01fd5a
 
-PODFILE CHECKSUM: ae56cd0ef8e681ef7bae7b6bfe045d00dd91ec9b
+PODFILE CHECKSUM: 1b3cd7d50895432becc5f4fb291a9d6b729ec3cc
 
 COCOAPODS: 1.11.3

--- a/suite-native/app/ios/Podfile.lock
+++ b/suite-native/app/ios/Podfile.lock
@@ -372,32 +372,32 @@ PODS:
     - RCTTypeSafety
     - React
     - ReactCommon/turbomodule/core
-  - react-native-skia (0.1.146):
+  - react-native-skia (0.1.152):
     - React
     - React-callinvoker
     - React-Core
-    - react-native-skia/Api (= 0.1.146)
-    - react-native-skia/Jsi (= 0.1.146)
-    - react-native-skia/RNSkia (= 0.1.146)
-    - react-native-skia/SkiaHeaders (= 0.1.146)
-    - react-native-skia/Utils (= 0.1.146)
-  - react-native-skia/Api (0.1.146):
+    - react-native-skia/Api (= 0.1.152)
+    - react-native-skia/Jsi (= 0.1.152)
+    - react-native-skia/RNSkia (= 0.1.152)
+    - react-native-skia/SkiaHeaders (= 0.1.152)
+    - react-native-skia/Utils (= 0.1.152)
+  - react-native-skia/Api (0.1.152):
     - React
     - React-callinvoker
     - React-Core
-  - react-native-skia/Jsi (0.1.146):
+  - react-native-skia/Jsi (0.1.152):
     - React
     - React-callinvoker
     - React-Core
-  - react-native-skia/RNSkia (0.1.146):
+  - react-native-skia/RNSkia (0.1.152):
     - React
     - React-callinvoker
     - React-Core
-  - react-native-skia/SkiaHeaders (0.1.146):
+  - react-native-skia/SkiaHeaders (0.1.152):
     - React
     - React-callinvoker
     - React-Core
-  - react-native-skia/Utils (0.1.146):
+  - react-native-skia/Utils (0.1.152):
     - React
     - React-callinvoker
     - React-Core
@@ -759,7 +759,7 @@ SPEC CHECKSUMS:
   react-native-config: 7cd105e71d903104e8919261480858940a6b9c0e
   react-native-mmkv: 1265a348a4711097ba29c8bcefd5971f48220f2b
   react-native-safe-area-context: 6c12e3859b6f27b25de4fee8201cfb858432d8de
-  react-native-skia: 424150f35cf310927ebc81739971491d87bf4c7b
+  react-native-skia: 1afb1ede8750b9e3534545b18a9a5086e6705f9f
   react-native-splash-screen: 4312f786b13a81b5169ef346d76d33bc0c6dc457
   React-perflogger: a18b4f0bd933b8b24ecf9f3c54f9bf65180f3fe6
   React-RCTActionSheet: 547fe42fdb4b6089598d79f8e1d855d7c23e2162

--- a/suite-native/app/ios/TrezorSuite.xcodeproj/project.pbxproj
+++ b/suite-native/app/ios/TrezorSuite.xcodeproj/project.pbxproj
@@ -501,6 +501,10 @@
 					"@executable_path/Frameworks",
 					"@loader_path/Frameworks",
 				);
+				LIBRARY_SEARCH_PATHS = (
+					"$(SDKROOT)/usr/lib/swift",
+					"$(inherited)",
+				);
 				OTHER_LDFLAGS = (
 					"-ObjC",
 					"-lc++",
@@ -524,6 +528,10 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 					"@loader_path/Frameworks",
+				);
+				LIBRARY_SEARCH_PATHS = (
+					"$(SDKROOT)/usr/lib/swift",
+					"$(inherited)",
 				);
 				OTHER_LDFLAGS = (
 					"-ObjC",
@@ -620,6 +628,10 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
+				LIBRARY_SEARCH_PATHS = (
+					"$(SDKROOT)/usr/lib/swift",
+					"$(inherited)",
+				);
 				MARKETING_VERSION = 1.0.0;
 				OTHER_LDFLAGS = (
 					"$(inherited)",
@@ -647,6 +659,10 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 					"@loader_path/Frameworks",
+				);
+				LIBRARY_SEARCH_PATHS = (
+					"$(SDKROOT)/usr/lib/swift",
+					"$(inherited)",
 				);
 				OTHER_LDFLAGS = (
 					"-ObjC",
@@ -750,6 +766,10 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
+				LIBRARY_SEARCH_PATHS = (
+					"$(SDKROOT)/usr/lib/swift",
+					"$(inherited)",
+				);
 				MARKETING_VERSION = 1.0.0;
 				OTHER_LDFLAGS = (
 					"$(inherited)",
@@ -782,6 +802,10 @@
 					"@executable_path/Frameworks",
 					"@loader_path/Frameworks",
 				);
+				LIBRARY_SEARCH_PATHS = (
+					"$(SDKROOT)/usr/lib/swift",
+					"$(inherited)",
+				);
 				OTHER_LDFLAGS = (
 					"-ObjC",
 					"-lc++",
@@ -810,6 +834,10 @@
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
+				);
+				LIBRARY_SEARCH_PATHS = (
+					"$(SDKROOT)/usr/lib/swift",
+					"$(inherited)",
 				);
 				MARKETING_VERSION = 1.0.0;
 				OTHER_LDFLAGS = (
@@ -843,6 +871,10 @@
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
+				);
+				LIBRARY_SEARCH_PATHS = (
+					"$(SDKROOT)/usr/lib/swift",
+					"$(inherited)",
 				);
 				MARKETING_VERSION = 1.0.0;
 				OTHER_LDFLAGS = (

--- a/suite-native/app/package.json
+++ b/suite-native/app/package.json
@@ -25,7 +25,7 @@
         "@react-navigation/native": "^6.0.11",
         "@react-navigation/stack": "^6.2.2",
         "@reduxjs/toolkit": "^1.8.3",
-        "@shopify/react-native-skia": "0.1.146",
+        "@shopify/react-native-skia": "0.1.152",
         "@suite-common/connect-init": "*",
         "@suite-common/formatters": "*",
         "@suite-common/wallet-core": "*",

--- a/yarn.lock
+++ b/yarn.lock
@@ -4956,12 +4956,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@shopify/react-native-skia@npm:0.1.146":
-  version: 0.1.146
-  resolution: "@shopify/react-native-skia@npm:0.1.146"
+"@shopify/react-native-skia@npm:0.1.152":
+  version: 0.1.152
+  resolution: "@shopify/react-native-skia@npm:0.1.152"
   dependencies:
-    canvaskit-wasm: ^0.36.0
-    react-reconciler: ^0.26.2
+    canvaskit-wasm: 0.36.1
+    react-reconciler: 0.26.2
   peerDependencies:
     react: ">=16.8.1"
     react-native: ">=0.63.0-rc.0 <1.0.x"
@@ -4971,7 +4971,7 @@ __metadata:
       optional: true
   bin:
     setup-skia-web: scripts/setup-canvaskit.js
-  checksum: 6b58ff144a17e9a783d6d8d08d3970ae97ebed9bbfd3db1e62eafd4ac70ed9e56591de79d31adda21a1b6a9eecdc895057a6814ce2071cd488a40a400754ee57
+  checksum: e54b4395b6190574afd612b1add62a89792428352c827839d22b9a21362a3e9684dd346077e94d860921f5733feace654c03548b8e95cb2d61456add8378b551
   languageName: node
   linkType: hard
 
@@ -7078,7 +7078,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@trezor/icons@workspace:packages/icons"
   dependencies:
-    "@shopify/react-native-skia": 0.1.146
+    "@shopify/react-native-skia": 0.1.152
     "@trezor/styles": "*"
     "@trezor/theme": "*"
     jest: ^26.6.3
@@ -7345,7 +7345,7 @@ __metadata:
     "@react-navigation/native": ^6.0.11
     "@react-navigation/stack": ^6.2.2
     "@reduxjs/toolkit": ^1.8.3
-    "@shopify/react-native-skia": 0.1.146
+    "@shopify/react-native-skia": 0.1.152
     "@suite-common/connect-init": "*"
     "@suite-common/formatters": "*"
     "@suite-common/wallet-core": "*"
@@ -12262,7 +12262,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"canvaskit-wasm@npm:^0.36.0":
+"canvaskit-wasm@npm:0.36.1":
   version: 0.36.1
   resolution: "canvaskit-wasm@npm:0.36.1"
   checksum: 7a90d1a641d9d9fc5a10fcc0ec64a73714247dfb5c41182644f5886b6e601f6e018282d2ac545acce66cd478b598640abdd58d8ae6db282d252d14d1d16eeb47
@@ -28268,7 +28268,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"react-reconciler@npm:^0.26.2":
+"react-reconciler@npm:0.26.2":
   version: 0.26.2
   resolution: "react-reconciler@npm:0.26.2"
   dependencies:


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Still trying to fix broken build for iOS when running on CI (macOS runner). Also this update is useful because we are planning to update react-native to 0.70 and there was a problem in the library which is solved in the new version: https://github.com/Shopify/react-native-skia/pull/897

Closes https://github.com/trezor/trezor-suite/issues/6292