### PR TITLE
fix(message-system): add file to Nx output config

### DIFF
--- a/packages/message-system/package.json
+++ b/packages/message-system/package.json
@@ -25,5 +25,20 @@
         "jest": "^26.6.3",
         "tsx": "^3.8.2",
         "typescript": "4.7.4"
+    },
+    "nx": {
+        "targets": {
+            "build:lib": {
+                "outputs": [
+                    "./src/types/messageSystem.ts"
+                ]
+            },
+            "type-check": {
+                "dependsOn": [
+                    "^build:lib",
+                    "build:lib"
+                ]
+            }
+        }
     }
 }

--- a/packages/suite-data/package.json
+++ b/packages/suite-data/package.json
@@ -42,7 +42,6 @@
             "build:lib": {
                 "outputs": [
                     "./tmp",
-                    "../../suite-common/suite-types/src/messageSystem.ts",
                     "./files/browser-detection",
                     "./files/guide"
                 ]


### PR DESCRIPTION
Because `build:lib` of message-system package has no standart output to `./lib` folder, we need to define it manually 
