### PR TITLE
chore(connect-explorer): Add strength option to reset device

### DIFF
--- a/packages/connect-explorer/src/data/methods/management/resetDevice.ts
+++ b/packages/connect-explorer/src/data/methods/management/resetDevice.ts
@@ -43,6 +43,17 @@ export default [
                 defaultValue: false,
                 value: false,
             },
+            {
+                name: 'strength',
+                placeholder: 'Select strength',
+                type: 'select',
+                optional: true,
+                data: [
+                    { value: 128, label: '128bit (12 words)' },
+                    { value: 192, label: '192bit (18 words)' },
+                    { value: 256, label: '256bit (24 words)' },
+                ],
+            },
         ],
     },
 ];


### PR DESCRIPTION
## Description

Connect supports sending strength option during device reset, but it's not available in Connect Explorer