### PR TITLE
fix: connect tests in gitlab

### DIFF
--- a/ci/test.yml
+++ b/ci/test.yml
@@ -234,7 +234,7 @@ connect-popup manual:
     TESTS_INCLUDED_METHODS: $TESTS_INCLUDED_METHODS
     TESTS_EXCLUDED_METHODS: $TESTS_EXCLUDED_METHODS
     TESTS_PATTERN: $TESTS_PATTERN
-    TESTS_SCRIPT: yarn workspace @trezor/integration-tests test:connect:${TESTS_ENVIRONMENT}
+    TESTS_SCRIPT: yarn workspace @trezor/connect test:e2e:${TESTS_ENVIRONMENT}
     TESTS_FIRMWARE: $TESTS_FIRMWARE
     TESTS_USE_TX_CACHE: $TESTS_MOCK_BACKENDS
     TESTS_USE_WS_CACHE: $TESTS_MOCK_BACKENDS
@@ -273,7 +273,7 @@ connect-popup manual:
         # TESTS_NODE_VERSION: ["12", "14", "16"]
         TESTS_INCLUDED_METHODS:
           [
-            "applySettings,applyFlags,getFeatures,getFirmwareHash,checkFirmwareAuthenticity",
+            "applySettings,applyFlags,getFeatures,getFirmwareHash",
             "signTransaction",
             "getAccountInfo,getAddress,getPublicKey,signMessage,verifyMessage,composeTransaction,getOwnershipId,getOwnershipProof",
             "stellarGetAddress,stellarSignTransaction",
@@ -290,6 +290,7 @@ connect-popup manual:
 
 connect:
   extends: .connect
+  retry: 1
   only:
     refs:
       - schedules # only nightly jobs, this is too heavy for develop branches at the moment

--- a/packages/connect/e2e/__fixtures__/getPublicKey.ts
+++ b/packages/connect/e2e/__fixtures__/getPublicKey.ts
@@ -14,6 +14,12 @@ export default {
                 xpub: 'xpub6D1saVFSZYgqXCXDfc5m2KdPXUsBXC12E3WntXXzWGJB8dEBr3CGR62emtC8sxJRVRSmBKbtJubuaaGEvZeeCEWaPaYvD9iJwp2Ky7sZws7',
                 xpubSegwit: `tr([95d8f670/86'/0'/0']xpub6D1saVFSZYgqXCXDfc5m2KdPXUsBXC12E3WntXXzWGJB8dEBr3CGR62emtC8sxJRVRSmBKbtJubuaaGEvZeeCEWaPaYvD9iJwp2Ky7sZws7/<0;1>/*)`,
             },
+            legacyResults: [
+                {
+                    rules: ['<1.10.4', '<2.4.3'],
+                    result: false,
+                },
+            ],
         },
         {
             description: 'Bitcoin bech32 first account',


### PR DESCRIPTION
- Fixing bug in CI configuration introduced lately. I forgot to change the scrit that runs tests after I moved test fixtures from `package/integration-tests` to `package/connect`
- also removing `checkFirmwareAuthenticity` as these tests are run either with 2.2.0 firmware where this method does not exist or with 2-master where it always fails since it is not the officially released version 
- I am seing end to tests to fail a lot in CI on some infrastructure problem, such as ` Cannot start service trezor-user-env-unix: failed to create endpoint 3115897403_trezor-user-env-unix_1 on network bridge: failed to add the host (veth0c62ada) <=> sandbox (veth118584b) pair interfaces: cannot allocate memory` And retrying usually helps. So maybe we could add retry clause here too? 
- fixed taproot public key tests fixture for pre-taproot firmwares. 

Green pipeline https://gitlab.com/satoshilabs/trezor/trezor-suite/-/pipelines/656613742