### PR TITLE
npm-release @trezor/connect patch [1/2]

### DIFF
--- a/packages/connect-explorer/package.json
+++ b/packages/connect-explorer/package.json
@@ -10,7 +10,7 @@
     },
     "dependencies": {
         "@trezor/components": "*",
-        "@trezor/connect-web": "9.0.2",
+        "@trezor/connect-web": "9.0.3",
         "markdown-it": "^12.3.2",
         "markdown-it-link-attributes": "^4.0.0",
         "markdown-it-replace-link": "^1.0.1",

--- a/packages/connect-iframe/package.json
+++ b/packages/connect-iframe/package.json
@@ -10,7 +10,7 @@
         "type-check": "tsc --build tsconfig.json"
     },
     "devDependencies": {
-        "@trezor/connect": "9.0.2",
+        "@trezor/connect": "9.0.3",
         "copy-webpack-plugin": "^11.0.0",
         "html-webpack-plugin": "^5.5.0",
         "jest": "^26.6.3",

--- a/packages/connect-popup/package.json
+++ b/packages/connect-popup/package.json
@@ -12,7 +12,7 @@
     },
     "dependencies": {
         "@trezor/components": "*",
-        "@trezor/connect": "9.0.2",
+        "@trezor/connect": "9.0.3",
         "@trezor/connect-ui": "*",
         "@trezor/crypto-utils": "*",
         "@trezor/urls": "*",

--- a/packages/connect-ui/package.json
+++ b/packages/connect-ui/package.json
@@ -12,7 +12,7 @@
     },
     "dependencies": {
         "@trezor/components": "*",
-        "@trezor/connect": "9.0.2",
+        "@trezor/connect": "9.0.3",
         "@trezor/env-utils": "*",
         "@trezor/urls": "*",
         "react": "17.0.2",

--- a/packages/connect-web/package.json
+++ b/packages/connect-web/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@trezor/connect-web",
-    "version": "9.0.2",
+    "version": "9.0.3",
     "author": "Trezor <info@trezor.io>",
     "homepage": "https://github.com/trezor/trezor-suite/tree/develop/packages/connect-web",
     "description": "High-level javascript interface for Trezor hardware wallet.",
@@ -35,7 +35,7 @@
         "build": "rimraf build && yarn build:inline && yarn build:webextension"
     },
     "dependencies": {
-        "@trezor/connect": "9.0.2",
+        "@trezor/connect": "9.0.3",
         "@trezor/utils": "^9.0.2",
         "events": "^3.3.0",
         "tslib": "^2.3.1"

--- a/packages/connect-web/src/webextension/trezor-usb-permissions.js
+++ b/packages/connect-web/src/webextension/trezor-usb-permissions.js
@@ -1,4 +1,4 @@
-const VERSION = '9.0.2';
+const VERSION = '9.0.3';
 const versionN = VERSION.split('.').map(s => parseInt(s, 10));
 // const DIRECTORY = `${ versionN[0] }${ (versionN[1] > 0 ? `.${versionN[1]}` : '') }/`;
 const DIRECTORY = `${versionN[0]}/`;

--- a/packages/connect/README.md
+++ b/packages/connect/README.md
@@ -1,6 +1,6 @@
 # @trezor/connect
 
-API version 9.0.2
+API version 9.0.3
 
 [![Build Status](https://github.com/trezor/trezor-suite/actions/workflows/connect-test.yml/badge.svg)](https://github.com/trezor/trezor-suite/actions/workflows/connect-test.yml)
 [![NPM](https://img.shields.io/npm/v/@trezor/connect.svg)](https://www.npmjs.org/package/@trezor/connect)

--- a/packages/connect/package.json
+++ b/packages/connect/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@trezor/connect",
-    "version": "9.0.2",
+    "version": "9.0.3",
     "author": "Trezor <info@trezor.io>",
     "homepage": "https://github.com/trezor/trezor-suite/tree/develop/packages/connect",
     "description": "High-level javascript interface for Trezor hardware wallet.",

--- a/packages/connect/src/data/version.ts
+++ b/packages/connect/src/data/version.ts
@@ -1,4 +1,4 @@
-export const VERSION = '9.0.2';
+export const VERSION = '9.0.3';
 
 const versionN = VERSION.split('.').map(s => parseInt(s, 10));
 

--- a/packages/suite-desktop-ui/package.json
+++ b/packages/suite-desktop-ui/package.json
@@ -16,7 +16,7 @@
         "@suite-common/formatters": "*",
         "@suite-common/sentry": "*",
         "@trezor/components": "*",
-        "@trezor/connect": "9.0.2",
+        "@trezor/connect": "9.0.3",
         "@trezor/suite": "*",
         "@trezor/suite-analytics": "*",
         "@trezor/suite-desktop-api": "*",

--- a/packages/suite-desktop/package.json
+++ b/packages/suite-desktop/package.json
@@ -214,7 +214,7 @@
         "@suite-common/sentry": "*",
         "@suite-common/suite-types": "*",
         "@suite-common/suite-utils": "*",
-        "@trezor/connect": "9.0.2",
+        "@trezor/connect": "9.0.3",
         "@trezor/connect-common": "*",
         "@trezor/request-manager": "*",
         "@trezor/suite-desktop-api": "*",

--- a/packages/suite/package.json
+++ b/packages/suite/package.json
@@ -43,7 +43,7 @@
         "@suite-common/wallet-utils": "*",
         "@trezor/coinjoin": "*",
         "@trezor/components": "*",
-        "@trezor/connect": "9.0.2",
+        "@trezor/connect": "9.0.3",
         "@trezor/crypto-utils": "*",
         "@trezor/dom-utils": "*",
         "@trezor/env-utils": "*",

--- a/suite-common/connect-init/package.json
+++ b/suite-common/connect-init/package.json
@@ -16,7 +16,7 @@
         "@suite-common/redux-utils": "*",
         "@suite-common/suite-types": "*",
         "@suite-common/test-utils": "*",
-        "@trezor/connect": "9.0.2",
+        "@trezor/connect": "9.0.3",
         "@trezor/utils": "*"
     },
     "devDependencies": {

--- a/suite-common/formatters/package.json
+++ b/suite-common/formatters/package.json
@@ -16,7 +16,7 @@
         "@suite-common/suite-types": "*",
         "@suite-common/wallet-config": "*",
         "@suite-common/wallet-utils": "*",
-        "@trezor/connect": "9.0.2",
+        "@trezor/connect": "9.0.3",
         "bignumber.js": "^9.1.0",
         "react": "17.0.2",
         "react-intl": "^6.0.5"

--- a/suite-common/notifications/package.json
+++ b/suite-common/notifications/package.json
@@ -13,7 +13,7 @@
     "dependencies": {
         "@suite-common/suite-types": "*",
         "@suite-common/wallet-config": "*",
-        "@trezor/connect": "9.0.2"
+        "@trezor/connect": "9.0.3"
     },
     "devDependencies": {
         "jest": "^26.6.3",

--- a/suite-common/redux-utils/package.json
+++ b/suite-common/redux-utils/package.json
@@ -15,7 +15,7 @@
         "@suite-common/suite-types": "*",
         "@suite-common/wallet-config": "*",
         "@suite-common/wallet-types": "*",
-        "@trezor/connect": "9.0.2",
+        "@trezor/connect": "9.0.3",
         "react": "17.0.2",
         "react-redux": "7.2.2",
         "redux": "^4.2.0"

--- a/suite-common/suite-constants/package.json
+++ b/suite-common/suite-constants/package.json
@@ -10,7 +10,7 @@
         "type-check": "tsc --build"
     },
     "dependencies": {
-        "@trezor/connect": "9.0.2"
+        "@trezor/connect": "9.0.3"
     },
     "devDependencies": {
         "jest": "^26.6.3",

--- a/suite-common/suite-types/package.json
+++ b/suite-common/suite-types/package.json
@@ -13,7 +13,7 @@
         "@reduxjs/toolkit": "^1.8.3",
         "@suite-common/metadata-types": "*",
         "@suite-common/wallet-config": "*",
-        "@trezor/connect": "9.0.2",
+        "@trezor/connect": "9.0.3",
         "bignumber.js": "^9.1.0"
     },
     "devDependencies": {

--- a/suite-common/test-utils/package.json
+++ b/suite-common/test-utils/package.json
@@ -15,7 +15,7 @@
         "@suite-common/suite-types": "*",
         "@suite-common/wallet-config": "*",
         "@suite-common/wallet-types": "*",
-        "@trezor/connect": "9.0.2",
+        "@trezor/connect": "9.0.3",
         "@trezor/message-system": "*",
         "@trezor/utils": "*",
         "dropbox": "^10.32.0",

--- a/suite-common/wallet-core/package.json
+++ b/suite-common/wallet-core/package.json
@@ -21,7 +21,7 @@
         "@suite-common/wallet-config": "*",
         "@suite-common/wallet-types": "*",
         "@suite-common/wallet-utils": "*",
-        "@trezor/connect": "9.0.2",
+        "@trezor/connect": "9.0.3",
         "@trezor/utils": "*",
         "date-fns": "^2.29.1"
     },

--- a/suite-common/wallet-types/package.json
+++ b/suite-common/wallet-types/package.json
@@ -14,7 +14,7 @@
         "@suite-common/suite-utils": "*",
         "@suite-common/wallet-config": "*",
         "@suite-common/wallet-constants": "*",
-        "@trezor/connect": "9.0.2",
+        "@trezor/connect": "9.0.3",
         "@trezor/type-utils": "*",
         "@trezor/utils": "*",
         "react": "17.0.2",

--- a/suite-common/wallet-utils/package.json
+++ b/suite-common/wallet-utils/package.json
@@ -24,7 +24,7 @@
         "@suite-common/wallet-config": "*",
         "@suite-common/wallet-constants": "*",
         "@suite-common/wallet-types": "*",
-        "@trezor/connect": "9.0.2",
+        "@trezor/connect": "9.0.3",
         "@trezor/urls": "*",
         "@trezor/utils": "*",
         "bignumber.js": "^9.1.0",

--- a/suite-native/app/package.json
+++ b/suite-native/app/package.json
@@ -40,7 +40,7 @@
         "@suite-native/state": "*",
         "@suite-native/storage": "*",
         "@suite-native/transactions": "*",
-        "@trezor/connect": "9.0.2",
+        "@trezor/connect": "9.0.3",
         "@trezor/icons": "*",
         "@trezor/styles": "*",
         "@trezor/suite-data": "*",

--- a/suite-native/module-accounts-import/package.json
+++ b/suite-native/module-accounts-import/package.json
@@ -28,7 +28,7 @@
         "@suite-native/module-devices": "*",
         "@suite-native/module-settings": "*",
         "@suite-native/navigation": "*",
-        "@trezor/connect": "9.0.2",
+        "@trezor/connect": "9.0.3",
         "@trezor/icons": "*",
         "@trezor/styles": "*",
         "@trezor/validation": "*",

--- a/suite-native/state/package.json
+++ b/suite-native/state/package.json
@@ -17,7 +17,7 @@
         "@suite-native/module-devices": "*",
         "@suite-native/module-settings": "*",
         "@suite-native/storage": "*",
-        "@trezor/connect": "9.0.2",
+        "@trezor/connect": "9.0.3",
         "@trezor/styles": "*",
         "@trezor/utils": "*",
         "redux-flipper": "2.0.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -6051,7 +6051,7 @@ __metadata:
     "@suite-common/redux-utils": "*"
     "@suite-common/suite-types": "*"
     "@suite-common/test-utils": "*"
-    "@trezor/connect": 9.0.2
+    "@trezor/connect": 9.0.3
     "@trezor/utils": "*"
     jest: ^26.6.3
     redux-mock-store: ^1.5.4
@@ -6081,7 +6081,7 @@ __metadata:
     "@suite-common/suite-types": "*"
     "@suite-common/wallet-config": "*"
     "@suite-common/wallet-utils": "*"
-    "@trezor/connect": 9.0.2
+    "@trezor/connect": 9.0.3
     bignumber.js: ^9.1.0
     jest: ^26.6.3
     react: 17.0.2
@@ -6117,7 +6117,7 @@ __metadata:
   dependencies:
     "@suite-common/suite-types": "*"
     "@suite-common/wallet-config": "*"
-    "@trezor/connect": 9.0.2
+    "@trezor/connect": 9.0.3
     jest: ^26.6.3
     typescript: 4.7.4
   languageName: unknown
@@ -6132,7 +6132,7 @@ __metadata:
     "@suite-common/suite-types": "*"
     "@suite-common/wallet-config": "*"
     "@suite-common/wallet-types": "*"
-    "@trezor/connect": 9.0.2
+    "@trezor/connect": 9.0.3
     jest: ^26.6.3
     react: 17.0.2
     react-redux: 7.2.2
@@ -6166,7 +6166,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@suite-common/suite-constants@workspace:suite-common/suite-constants"
   dependencies:
-    "@trezor/connect": 9.0.2
+    "@trezor/connect": 9.0.3
     jest: ^26.6.3
     typescript: 4.7.4
   languageName: unknown
@@ -6179,7 +6179,7 @@ __metadata:
     "@reduxjs/toolkit": ^1.8.3
     "@suite-common/metadata-types": "*"
     "@suite-common/wallet-config": "*"
-    "@trezor/connect": 9.0.2
+    "@trezor/connect": 9.0.3
     bignumber.js: ^9.1.0
     jest: ^26.6.3
     typescript: 4.7.4
@@ -6207,7 +6207,7 @@ __metadata:
     "@suite-common/suite-types": "*"
     "@suite-common/wallet-config": "*"
     "@suite-common/wallet-types": "*"
-    "@trezor/connect": 9.0.2
+    "@trezor/connect": 9.0.3
     "@trezor/message-system": "*"
     "@trezor/utils": "*"
     dropbox: ^10.32.0
@@ -6251,7 +6251,7 @@ __metadata:
     "@suite-common/wallet-config": "*"
     "@suite-common/wallet-types": "*"
     "@suite-common/wallet-utils": "*"
-    "@trezor/connect": 9.0.2
+    "@trezor/connect": 9.0.3
     "@trezor/utils": "*"
     date-fns: ^2.29.1
     jest: ^26.6.3
@@ -6267,7 +6267,7 @@ __metadata:
     "@suite-common/suite-utils": "*"
     "@suite-common/wallet-config": "*"
     "@suite-common/wallet-constants": "*"
-    "@trezor/connect": 9.0.2
+    "@trezor/connect": 9.0.3
     "@trezor/type-utils": "*"
     "@trezor/utils": "*"
     jest: ^26.6.3
@@ -6293,7 +6293,7 @@ __metadata:
     "@suite-common/wallet-config": "*"
     "@suite-common/wallet-constants": "*"
     "@suite-common/wallet-types": "*"
-    "@trezor/connect": 9.0.2
+    "@trezor/connect": 9.0.3
     "@trezor/urls": "*"
     "@trezor/utils": "*"
     "@types/pdfmake": ^0.1.21
@@ -6386,7 +6386,7 @@ __metadata:
     "@suite-native/module-devices": "*"
     "@suite-native/module-settings": "*"
     "@suite-native/navigation": "*"
-    "@trezor/connect": 9.0.2
+    "@trezor/connect": 9.0.3
     "@trezor/icons": "*"
     "@trezor/styles": "*"
     "@trezor/validation": "*"
@@ -6573,7 +6573,7 @@ __metadata:
     "@suite-native/module-devices": "*"
     "@suite-native/module-settings": "*"
     "@suite-native/storage": "*"
-    "@trezor/connect": 9.0.2
+    "@trezor/connect": 9.0.3
     "@trezor/styles": "*"
     "@trezor/utils": "*"
     jest: ^26.6.3
@@ -6873,7 +6873,7 @@ __metadata:
   resolution: "@trezor/connect-explorer@workspace:packages/connect-explorer"
   dependencies:
     "@trezor/components": "*"
-    "@trezor/connect-web": 9.0.2
+    "@trezor/connect-web": 9.0.3
     "@types/markdown-it": 12.2.3
     "@types/markdown-it-link-attributes": 3.0.1
     "@types/react-router": ^5.1.11
@@ -6911,7 +6911,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@trezor/connect-iframe@workspace:packages/connect-iframe"
   dependencies:
-    "@trezor/connect": 9.0.2
+    "@trezor/connect": 9.0.3
     copy-webpack-plugin: ^11.0.0
     html-webpack-plugin: ^5.5.0
     jest: ^26.6.3
@@ -6958,7 +6958,7 @@ __metadata:
   dependencies:
     "@playwright/test": ^1.22.2
     "@trezor/components": "*"
-    "@trezor/connect": 9.0.2
+    "@trezor/connect": 9.0.3
     "@trezor/connect-ui": "*"
     "@trezor/crypto-utils": "*"
     "@trezor/trezor-user-env-link": "*"
@@ -6985,7 +6985,7 @@ __metadata:
   resolution: "@trezor/connect-ui@workspace:packages/connect-ui"
   dependencies:
     "@trezor/components": "*"
-    "@trezor/connect": 9.0.2
+    "@trezor/connect": 9.0.3
     "@trezor/env-utils": "*"
     "@trezor/urls": "*"
     "@types/react": ^17.0.0
@@ -7000,11 +7000,11 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@trezor/connect-web@9.0.2, @trezor/connect-web@workspace:packages/connect-web":
+"@trezor/connect-web@9.0.3, @trezor/connect-web@workspace:packages/connect-web":
   version: 0.0.0-use.local
   resolution: "@trezor/connect-web@workspace:packages/connect-web"
   dependencies:
-    "@trezor/connect": 9.0.2
+    "@trezor/connect": 9.0.3
     "@trezor/utils": ^9.0.2
     "@types/chrome": 0.0.181
     "@types/w3c-web-usb": ^1.0.5
@@ -7018,7 +7018,7 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@trezor/connect@9.0.2, @trezor/connect@workspace:packages/connect":
+"@trezor/connect@9.0.3, @trezor/connect@workspace:packages/connect":
   version: 0.0.0-use.local
   resolution: "@trezor/connect@workspace:packages/connect"
   dependencies:
@@ -7291,7 +7291,7 @@ __metadata:
     "@suite-common/formatters": "*"
     "@suite-common/sentry": "*"
     "@trezor/components": "*"
-    "@trezor/connect": 9.0.2
+    "@trezor/connect": 9.0.3
     "@trezor/suite": "*"
     "@trezor/suite-analytics": "*"
     "@trezor/suite-desktop-api": "*"
@@ -7321,7 +7321,7 @@ __metadata:
     "@suite-common/sentry": "*"
     "@suite-common/suite-types": "*"
     "@suite-common/suite-utils": "*"
-    "@trezor/connect": 9.0.2
+    "@trezor/connect": 9.0.3
     "@trezor/connect-common": "*"
     "@trezor/request-manager": "*"
     "@trezor/suite-desktop-api": "*"
@@ -7378,7 +7378,7 @@ __metadata:
     "@suite-native/state": "*"
     "@suite-native/storage": "*"
     "@suite-native/transactions": "*"
-    "@trezor/connect": 9.0.2
+    "@trezor/connect": 9.0.3
     "@trezor/icons": "*"
     "@trezor/styles": "*"
     "@trezor/suite-data": "*"
@@ -7509,7 +7509,7 @@ __metadata:
     "@testing-library/user-event": 12.8.3
     "@trezor/coinjoin": "*"
     "@trezor/components": "*"
-    "@trezor/connect": 9.0.2
+    "@trezor/connect": 9.0.3
     "@trezor/crypto-utils": "*"
     "@trezor/dom-utils": "*"
     "@trezor/env-utils": "*"


### PR DESCRIPTION
## @trezor/connect npm release

-   [x] Bump version in all @trezor/connect\* packages (except plugin packages). `yarn workspace @trezor/connect version:<beta|patch|minor|major>`
-   [x] Make sure you have released all npm dependencies. If unsure run `node ./ci/scripts/check-npm-dependencies.js connect`. Please note that this script will report unreleased dependencies even for changes that do not affect runtime (READMEs etc.)
-   [x] If there are any unreleased npm dependencies you should [release them](./npm-packages.md)
-   [x] Make sure [CHANGELOG](https://github.com/trezor/trezor-suite/blob/develop/packages/connect/CHANGELOG.md) file has been updated
-   [x] Tested and approved by @trezor/qa. Typically using [dev build](https://suite.corp.sldev.cz/connect/develop/)
-   [x] Release npm packages for `@trezor/connect` and `@trezor/connect-web` [from gitlab](https://gitlab.com/satoshilabs/trezor/trezor-suite/-/pipelines)
