### PR TITLE
Eslint unblacklist suite-desktop package and transform /scripts and /e2e files into typescript

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -78,6 +78,7 @@ module.exports = {
             {
                 devDependencies: [
                     '**/*.test.{tsx,ts,js}',
+                    '**/suite-desktop/scripts/**',
                     '**/suite-desktop/e2e/**',
                 ],
             },

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -76,8 +76,10 @@ module.exports = {
         'import/no-extraneous-dependencies': [
             'error',
             {
-                // add scripts/ folder
-                devDependencies: ['**/*.test.{tsx,ts,js}'],
+                devDependencies: [
+                    '**/*.test.{tsx,ts,js}',
+                    '**/suite-desktop/e2e/**',
+                ],
             },
         ],
         // Does not work with TypeScript export type.

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -246,7 +246,6 @@ module.exports = {
                 'packages/suite/**/*',
                 'packages/suite-build/**/*',
                 'packages/suite-data/**/*',
-                'packages/suite-desktop/**/*',
                 'packages/suite-desktop-api/**/*',
                 'packages/suite-storage/**/*',
                 'packages/suite-web-landing/**/*',

--- a/docs/packages/suite-desktop.md
+++ b/docs/packages/suite-desktop.md
@@ -88,7 +88,7 @@ Some libraries are difficult to test in development environments, such as the au
 
 ### How to make a new mock?
 
-1. Open the suite-desktop build script located at `/packages/suite-desktop/scripts/build.js`.
+1. Open the suite-desktop build script located at `/packages/suite-desktop/scripts/build.ts`.
 1. Add a new entry to the `mocks` object. The key should be the name of the package, exactly as written when imported. The value should be the path to the mock file to point to (located in `/packages/suite-desktop/src/mocks`).
 1. Create the file in `/packages/suite-desktop/src/mocks` and export mocked properties that you have imported across the project.
 

--- a/packages/suite-build/configs/base.webpack.config.ts
+++ b/packages/suite-build/configs/base.webpack.config.ts
@@ -23,7 +23,7 @@ const gitRevision = getRevision();
 
 /**
  * Assemble release name for Sentry
- * Same definition is in packages/suite-desktop/scripts/build.js
+ * Same definition is in packages/suite-desktop/scripts/build.ts
  */
 const sentryRelease = `${suiteVersion}.${project}${
     isCodesignBuild ? '.codesign' : ''

--- a/packages/suite-desktop/.eslintrc.js
+++ b/packages/suite-desktop/.eslintrc.js
@@ -1,0 +1,7 @@
+// electron has to be dev dependency
+
+module.exports = {
+    settings: {
+        'import/core-modules': ['electron'],
+    },
+};

--- a/packages/suite-desktop/e2e/playwright.config.ts
+++ b/packages/suite-desktop/e2e/playwright.config.ts
@@ -1,4 +1,4 @@
-import { PlaywrightTestConfig } from '@playwright/test';
+import type { PlaywrightTestConfig } from '@playwright/test';
 
 const config: PlaywrightTestConfig = {
     testDir: 'tests',
@@ -8,4 +8,6 @@ const config: PlaywrightTestConfig = {
         headless: true,
     },
 };
+
+// eslint-disable-next-line import/no-default-export
 export default config;

--- a/packages/suite-desktop/e2e/support/common.ts
+++ b/packages/suite-desktop/e2e/support/common.ts
@@ -1,12 +1,13 @@
-const { _electron: electron } = require('playwright');
-const path = require('path');
-const { promisify } = require('util');
+import { promisify } from 'util';
+import path from 'path';
+import fs from 'fs';
+import { Page, _electron as electron } from 'playwright';
 
-const mkdir = promisify(require('fs').mkdir);
-const fileExists = promisify(require('fs').exists);
-const copyFile = promisify(require('fs').copyFile);
+const mkdir = promisify(fs.mkdir);
+const fileExists = promisify(fs.exists);
+const copyFile = promisify(fs.copyFile);
 
-module.exports.launchSuite = async () => {
+export const launchSuite = async () => {
     const electronApp = await electron.launch({
         cwd: '../suite-desktop',
         args: ['./dist/app.js', '--log-level=debug', '--bridge-test'],
@@ -15,7 +16,7 @@ module.exports.launchSuite = async () => {
     return { electronApp, window };
 };
 
-module.exports.patchBinaries = async () => {
+export const patchBinaries = async () => {
     const binResourcesPathFrom = path.join(__dirname, '../../..', 'suite-data/files/bin');
     const binResourcesPathTo = path.join(
         __dirname,
@@ -42,5 +43,5 @@ module.exports.patchBinaries = async () => {
     await copyFile(torPathFrom, `${torPathTo}/tor`);
 };
 
-module.exports.waitForDataTestSelector = (window, selector, options) =>
+export const waitForDataTestSelector = (window: Page, selector: string, options = {}) =>
     window.waitForSelector(`[data-test="${selector}"]`, options);

--- a/packages/suite-desktop/e2e/support/networkAnalyzer.ts
+++ b/packages/suite-desktop/e2e/support/networkAnalyzer.ts
@@ -1,7 +1,9 @@
-const { exec } = require('child_process');
+import { exec } from 'child_process';
 
-class NetworkAnalyzer {
-    interval;
+export class NetworkAnalyzer {
+    interval?: string | number | NodeJS.Timer;
+    tcp: string[];
+
     constructor() {
         this.tcp = [];
     }
@@ -11,8 +13,8 @@ class NetworkAnalyzer {
             try {
                 // When running in Tests the electron process has name `electron`,
                 // but when running without the tests is is `trezor-su`.
-                exec('lsof -i TCP | grep electron', (error, stdout, stderr) => {
-                    const outputGroupParser = message =>
+                exec('lsof -i TCP | grep electron', (_, stdout) => {
+                    const outputGroupParser = (message: string) =>
                         message && message.trim().match(/electron .*/gm);
                     const group = outputGroupParser(stdout);
                     if (group) {
@@ -35,7 +37,7 @@ class NetworkAnalyzer {
 
     start() {
         this.interval = setInterval(async () => {
-            const requests = await this.checkTCP();
+            const requests = (await this.checkTCP()) as string[];
             this.tcp.push(...requests);
         }, 1000);
     }
@@ -48,7 +50,3 @@ class NetworkAnalyzer {
         return this.tcp;
     }
 }
-
-module.exports = {
-    NetworkAnalyzer,
-};

--- a/packages/suite-desktop/e2e/tests/electrum.test.ts
+++ b/packages/suite-desktop/e2e/tests/electrum.test.ts
@@ -1,16 +1,12 @@
-const { _electron: electron } = require('playwright');
-const path = require('path');
-const { promisify } = require('util');
-const rmdir = promisify(require('fs').rmdir);
-const fetch = require('node-fetch');
-const { test, expect } = require('@playwright/test');
+import { Page, test as testPlaywright } from '@playwright/test';
 
-const { TrezorUserEnvLink } = require('@trezor/trezor-user-env-link');
-const { patchBinaries, launchSuite, waitForDataTestSelector } = require('../support/common');
+import { TrezorUserEnvLink } from '@trezor/trezor-user-env-link';
 
-const clickDataTest = (window, selector) => window.click(`[data-test="${selector}"]`);
+import { patchBinaries, launchSuite, waitForDataTestSelector } from '../support/common';
 
-const toggleDebugModeInSettings = async window => {
+const clickDataTest = (window: Page, selector: string) => window.click(`[data-test="${selector}"]`);
+
+const toggleDebugModeInSettings = async (window: Page) => {
     const timesClickToSetDebugMode = 5;
     for (let i = 0; i < timesClickToSetDebugMode; i++) {
         // eslint-disable-next-line no-await-in-loop
@@ -18,8 +14,8 @@ const toggleDebugModeInSettings = async window => {
     }
 };
 
-test.describe.serial('Suite works with Electrum server', () => {
-    test.beforeAll(async () => {
+testPlaywright.describe.serial('Suite works with Electrum server', () => {
+    testPlaywright.beforeAll(async () => {
         // todo: some problems with path in dev and production and tests. tldr tests are expecting
         // binaries somewhere where they are not, so I copy them to that place. Maybe I find a
         // better solution later
@@ -32,8 +28,8 @@ test.describe.serial('Suite works with Electrum server', () => {
         });
     });
 
-    test('Electrum completes discovery successfully', async () => {
-        suite = await launchSuite();
+    testPlaywright('Electrum completes discovery successfully', async () => {
+        const suite = await launchSuite();
 
         await waitForDataTestSelector(suite.window, '@welcome/title');
 

--- a/packages/suite-desktop/e2e/tests/spawn-bridge.test.ts
+++ b/packages/suite-desktop/e2e/tests/spawn-bridge.test.ts
@@ -1,14 +1,11 @@
-const { _electron: electron } = require('playwright');
-const fs = require('fs');
-const path = require('path');
-const fetch = require('node-fetch');
-const { test, expect } = require('@playwright/test');
+import { test as testPlaywright, expect as expectPlaywright } from '@playwright/test';
 
-const { patchBinaries, launchSuite, waitForDataTestSelector } = require('../support/common');
-const { TrezorUserEnvLink } = require('@trezor/trezor-user-env-link');
+import { TrezorUserEnvLink } from '@trezor/trezor-user-env-link';
 
-test.describe.serial('Bridge', () => {
-    test.beforeAll(async () => {
+import { patchBinaries, launchSuite, waitForDataTestSelector } from '../support/common';
+
+testPlaywright.describe.serial('Bridge', () => {
+    testPlaywright.beforeAll(async () => {
         // todo: some problems with path in dev and production and tests. tldr tests are expecting
         // binaries somewhere where they are not, so I copy them to that place. Maybe I find a
         // better solution later
@@ -19,15 +16,15 @@ test.describe.serial('Bridge', () => {
         await TrezorUserEnvLink.api.stopBridge();
     });
 
-    test.afterAll(async () => {
+    testPlaywright.afterAll(async () => {
         // When finish we make bridge from trezor-user-env to run so it is ready for the rest of the tests.
         await TrezorUserEnvLink.api.startBridge();
     });
 
-    test('App spawns bundled bridge and stops it after app quit', async ({ request }) => {
+    testPlaywright('App spawns bundled bridge and stops it after app quit', async ({ request }) => {
         const suite = await launchSuite();
         const title = await suite.window.title();
-        expect(title).toBe('Trezor Suite');
+        expectPlaywright(title).toBe('Trezor Suite');
 
         // We wait for `@welcome/title` or `@dashboard/graph` since
         // one or the other will be display depending on the state of the app
@@ -40,7 +37,7 @@ test.describe.serial('Bridge', () => {
 
         // bridge is running
         const bridgeRes1 = await request.get('http://127.0.0.1:21325/status/');
-        await expect(bridgeRes1).toBeOK();
+        await expectPlaywright(bridgeRes1).toBeOK();
 
         await suite.electronApp.close();
 

--- a/packages/suite-desktop/e2e/tests/spawn-tor.test.ts
+++ b/packages/suite-desktop/e2e/tests/spawn-tor.test.ts
@@ -1,16 +1,11 @@
-const { _electron: electron } = require('playwright');
-const path = require('path');
-const { promisify } = require('util');
-const rmdir = promisify(require('fs').rmdir);
-const fetch = require('node-fetch');
-const { test, expect } = require('@playwright/test');
+import { Page, test as testPlaywright, expect as expectPlaywright } from '@playwright/test';
 
-const { patchBinaries, launchSuite } = require('../support/common');
-const { NetworkAnalyzer } = require('../support/networkAnalyzer');
+import { patchBinaries, launchSuite } from '../support/common';
+import { NetworkAnalyzer } from '../support/networkAnalyzer';
 
 const timeout = 100 * 1000; // 100 seconds, because it takes a while to start tor.
 
-const turnOnTorInSettings = async (window, shouldEnableTor = true) => {
+const turnOnTorInSettings = async (window: Page, shouldEnableTor = true) => {
     await window.click('[data-test="@suite/menu/settings"]');
     await window.waitForSelector('[data-test="@settings/general/tor-switch"]');
     const torIAlreadyEnabled = await window.isChecked(
@@ -29,22 +24,22 @@ const turnOnTorInSettings = async (window, shouldEnableTor = true) => {
         state: 'detached',
         timeout,
     });
-    await expect(
+    await expectPlaywright(
         window.locator('[data-test="@settings/general/tor-switch"] > input'),
     ).toBeChecked();
 
     await window.waitForTimeout(1000);
 };
 
-test.describe('Tor loading screen', () => {
-    test.beforeAll(async () => {
+testPlaywright.describe('Tor loading screen', () => {
+    testPlaywright.beforeAll(async () => {
         // todo: some problems with path in dev and production and tests. tldr tests are expecting
         // binaries somewhere where they are not, so I copy them to that place. Maybe I find a
         // better solution later
         await patchBinaries();
     });
 
-    test('Tor loading screen: happy path', async () => {
+    testPlaywright('Tor loading screen: happy path', async () => {
         let suite = await launchSuite();
 
         await turnOnTorInSettings(suite.window);
@@ -62,34 +57,37 @@ test.describe('Tor loading screen', () => {
         suite.electronApp.close();
     });
 
-    test('Tor loading screen: making sure that all the request go throw Tor', async () => {
-        const networkAnalyzer = new NetworkAnalyzer();
+    testPlaywright(
+        'Tor loading screen: making sure that all the request go throw Tor',
+        async () => {
+            const networkAnalyzer = new NetworkAnalyzer();
 
-        let suite = await launchSuite();
+            let suite = await launchSuite();
 
-        await turnOnTorInSettings(suite.window);
+            await turnOnTorInSettings(suite.window);
 
-        suite.electronApp.close();
+            suite.electronApp.close();
 
-        suite = await launchSuite();
-        // Start network analyzer after making sure tor is going to be running.
-        networkAnalyzer.start();
+            suite = await launchSuite();
+            // Start network analyzer after making sure tor is going to be running.
+            networkAnalyzer.start();
 
-        await suite.window.waitForSelector('[data-test="@tor-loading-screen"]', {
-            state: 'visible',
-        });
+            await suite.window.waitForSelector('[data-test="@tor-loading-screen"]', {
+                state: 'visible',
+            });
 
-        await suite.window.waitForSelector('[data-test="@welcome/title"]', { timeout });
-        networkAnalyzer.stop();
-        const requests = networkAnalyzer.getRequests();
-        requests.forEach(request => {
-            expect(request).toContain('localhost:');
-        });
+            await suite.window.waitForSelector('[data-test="@welcome/title"]', { timeout });
+            networkAnalyzer.stop();
+            const requests = networkAnalyzer.getRequests();
+            requests.forEach(request => {
+                expectPlaywright(request).toContain('localhost:');
+            });
 
-        suite.electronApp.close();
-    });
+            suite.electronApp.close();
+        },
+    );
 
-    test('Tor loading screen: disable tor while loading', async ({ request }) => {
+    testPlaywright('Tor loading screen: disable tor while loading', async () => {
         let suite = await launchSuite();
 
         await turnOnTorInSettings(suite.window);
@@ -107,7 +105,7 @@ test.describe('Tor loading screen', () => {
         suite.window.locator('text=Disabling Tor');
         await suite.window.click('[data-test="@suite/menu/settings"]');
 
-        await expect(
+        await expectPlaywright(
             suite.window.locator('[data-test="@settings/general/tor-switch"] > input'),
         ).not.toBeChecked();
 

--- a/packages/suite-desktop/package.json
+++ b/packages/suite-desktop/package.json
@@ -13,8 +13,8 @@
         "dev:local": "yarn workspace @trezor/suite-build run dev:desktop",
         "clean": "rimraf ./build-electron && yarn rimraf ./build && yarn rimraf ./dist",
         "build:ui": "yarn workspace @trezor/suite-build run build:desktop",
-        "build:app": "NODE_ENV=production node scripts/build.js && yarn build:app:electron",
-        "build:app:dev": "node scripts/build.js",
+        "build:app": "NODE_ENV=production tsx scripts/build.ts && yarn build:app:electron",
+        "build:app:dev": "tsx scripts/build.ts",
         "build:app:electron": "yarn electron-builder --c.extraMetadata.version=$(node -p \"require('../suite/package').suiteVersion\")",
         "build:linux": "yarn clean && yarn build:ui && yarn build:app --publish never --linux --x64 --arm64",
         "build:mac": "yarn clean && yarn build:ui && yarn build:app --publish never --mac --x64 --arm64",
@@ -24,7 +24,7 @@
         "publish:mac": "yarn build:mac && yarn build:app:electron --publish always --mac",
         "publish:win": "yarn build:win && yarn build:app:electron --publish always --win",
         "lint:js": "yarn g:eslint '**/*.{ts,tsx,js}'",
-        "type-check": "tsc --build tsconfig.json",
+        "type-check": "tsc --build tsconfig.json && tsc --build scripts/tsconfig.json",
         "test:unit": "jest",
         "test:e2e": "yarn xvfb-maybe -- playwright test --config=./e2e/playwright.config.ts"
     },
@@ -207,7 +207,7 @@
                 "AppImage"
             ]
         },
-        "afterSign": "scripts/notarize.js"
+        "afterSign": "scripts/notarize.ts"
     },
     "dependencies": {
         "@sentry/electron": "3.0.0",
@@ -239,9 +239,11 @@
         "electron-builder": "23.3.3",
         "electron-notarize": "1.2.1",
         "esbuild": "^0.15.7",
+        "glob": "^8.0.3",
         "jest": "^26.6.3",
         "playwright": "^1.22.2",
         "rimraf": "^3.0.2",
+        "tsx": "^3.8.2",
         "typescript": "4.7.4",
         "xvfb-maybe": "^0.2.1"
     }

--- a/packages/suite-desktop/scripts/build-inject.ts
+++ b/packages/suite-desktop/scripts/build-inject.ts
@@ -1,3 +1,4 @@
 import fetch from 'node-fetch';
 
+// @ts-expect-error
 global.fetch = fetch;

--- a/packages/suite-desktop/scripts/build.ts
+++ b/packages/suite-desktop/scripts/build.ts
@@ -1,11 +1,16 @@
-const fs = require('fs');
-const path = require('path');
-const childProcess = require('child_process');
-const glob = require('glob');
-const { build } = require('esbuild');
-const pkg = require('../package.json');
-// @ts-expect-error
-const { suiteVersion } = require('../../suite/package.json');
+/* eslint-disable no-console */
+import fs from 'fs';
+import path from 'path';
+import childProcess from 'child_process';
+import glob from 'glob';
+import { build, PluginBuild } from 'esbuild';
+
+// eslint-disable-next-line
+// @ts-ignore
+import pkg from '../package.json';
+// eslint-disable-next-line
+// @ts-ignore
+import { suiteVersion } from '../../suite/package.json';
 
 const { NODE_ENV, USE_MOCKS, IS_CODESIGN_BUILD } = process.env;
 const PROJECT = 'desktop';
@@ -38,8 +43,8 @@ const mocks = glob
 const mockFilter = new RegExp(`^${mocks.join('|')}$`);
 const mockPlugin = {
     name: 'mock-plugin',
-    setup: build => {
-        build.onResolve({ filter: mockFilter }, args => ({
+    setup: (setup: PluginBuild) => {
+        setup.onResolve({ filter: mockFilter }, args => ({
             path: path.join(mockPath, `${args.path}.ts`),
         }));
     },
@@ -89,7 +94,7 @@ build({
         'process.env.SENTRY_RELEASE': JSON.stringify(sentryRelease),
         'process.env.SUITE_TYPE': JSON.stringify(PROJECT),
     },
-    inject: [path.join(__dirname, 'build-inject.js')],
+    inject: [path.join(__dirname, 'build-inject.ts')],
     plugins: useMocks ? [mockPlugin] : [],
 })
     .then(() => {

--- a/packages/suite-desktop/scripts/notarize.ts
+++ b/packages/suite-desktop/scripts/notarize.ts
@@ -1,7 +1,12 @@
+/* eslint-disable @typescript-eslint/no-var-requires */
+/* eslint-disable no-console */
+
 const { notarize } = require('electron-notarize');
+
 const pkg = require('../package.json');
 
-exports.default = function notarizing(context) {
+// @ts-expect-error cannot import AfterPackContext as type using require
+exports.default = context => {
     const { electronPlatformName, appOutDir } = context;
 
     if (electronPlatformName !== 'darwin') {

--- a/packages/suite-desktop/scripts/tsconfig.json
+++ b/packages/suite-desktop/scripts/tsconfig.json
@@ -1,0 +1,8 @@
+{
+    "extends": "../../../tsconfig.json",
+    "compilerOptions": {
+        "isolatedModules": false,
+        "outDir": "../libDev/scripts"
+    },
+    "include": ["."]
+}

--- a/packages/suite-desktop/src/__fixtures__/http.ts
+++ b/packages/suite-desktop/src/__fixtures__/http.ts
@@ -1,4 +1,4 @@
-export default [
+export const fixtures = [
     {
         method: 'GET',
         path: '/oauth?code=meow',

--- a/packages/suite-desktop/src/__tests__/http.test.ts
+++ b/packages/suite-desktop/src/__tests__/http.test.ts
@@ -1,7 +1,8 @@
 import fetch from 'node-fetch';
+
 import { HttpReceiver } from '../libs/http-receiver';
-import fixtures from '../__fixtures__/http';
-import Logger from '../libs/logger';
+import { fixtures } from '../__fixtures__/http';
+import { Logger } from '../libs/logger';
 
 global.logger = new Logger('mute');
 

--- a/packages/suite-desktop/src/__tests__/logger.test.ts
+++ b/packages/suite-desktop/src/__tests__/logger.test.ts
@@ -1,6 +1,8 @@
+/* eslint-disable no-console */
 import fs from 'fs';
 import path from 'path';
-import Logger, { Options } from '../libs/logger';
+
+import { Logger, Options } from '../libs/logger';
 
 const testOptions: Options = {
     colors: false,

--- a/packages/suite-desktop/src/app.ts
+++ b/packages/suite-desktop/src/app.ts
@@ -1,24 +1,23 @@
 import path from 'path';
 import fs from 'fs';
-
 import { app, BrowserWindow, session } from 'electron';
 import { init as initSentry, ElectronOptions, IPCMode } from '@sentry/electron';
-import { ipcMain } from './typed-electron';
 
 import { SENTRY_CONFIG } from '@suite-common/sentry';
 import { isDevEnv } from '@suite-common/suite-utils';
+import type { HandshakeClient } from '@trezor/suite-desktop-api';
+
+import { ipcMain } from './typed-electron';
 import { APP_NAME } from './libs/constants';
 import * as store from './libs/store';
 import { MIN_HEIGHT, MIN_WIDTH } from './libs/screen';
 import { getBuildInfo, getComputerInfo } from './libs/info';
 import { restartApp } from './libs/app-utils';
 import { initModules } from './modules';
-import initTorModule from './modules/tor';
-
+import { init as initTorModule } from './modules/tor';
 import { createInterceptor } from './libs/request-interceptor';
 import { hangDetect } from './hang-detect';
 import { createLogger } from './logger';
-import type { HandshakeClient } from '@trezor/suite-desktop-api';
 
 // @ts-expect-error using internal electron API to set suite version in dev mode correctly
 if (isDevEnv) app.setVersion(process.env.VERSION);

--- a/packages/suite-desktop/src/hang-detect.ts
+++ b/packages/suite-desktop/src/hang-detect.ts
@@ -1,4 +1,5 @@
 import { BrowserWindow, dialog } from 'electron';
+
 import { ipcMain } from './typed-electron';
 import { APP_SRC } from './libs/constants';
 

--- a/packages/suite-desktop/src/libs/constants.ts
+++ b/packages/suite-desktop/src/libs/constants.ts
@@ -1,4 +1,5 @@
 import url from 'url';
+
 import { TOR_URLS } from '@trezor/urls';
 import { isDevEnv } from '@suite-common/suite-utils';
 

--- a/packages/suite-desktop/src/libs/http-receiver.ts
+++ b/packages/suite-desktop/src/libs/http-receiver.ts
@@ -1,11 +1,11 @@
 import * as http from 'http';
 import * as net from 'net';
 import * as url from 'url';
-import { URL } from 'url';
-
 import { EventEmitter } from 'events';
-import { HTTP_ORIGINS_DEFAULT } from './constants';
+
 import { xssFilters } from '@trezor/utils';
+
+import { HTTP_ORIGINS_DEFAULT } from './constants';
 
 export type RequiredKey<M, K extends keyof M> = Omit<M, K> & Required<Pick<M, K>>;
 

--- a/packages/suite-desktop/src/libs/info.ts
+++ b/packages/suite-desktop/src/libs/info.ts
@@ -1,8 +1,9 @@
 import { app } from 'electron';
 import si from 'systeminformation';
-import { bytesToHumanReadable } from '@trezor/utils';
 
+import { bytesToHumanReadable } from '@trezor/utils';
 import { isDevEnv } from '@suite-common/suite-utils';
+
 import { b2t } from './utils';
 
 export const getBuildInfo = () => [

--- a/packages/suite-desktop/src/libs/logger.ts
+++ b/packages/suite-desktop/src/libs/logger.ts
@@ -1,3 +1,4 @@
+/* eslint-disable no-console */
 import fs from 'fs';
 import path from 'path';
 import chalk from 'chalk';
@@ -24,7 +25,7 @@ export const defaultOptions: Options = {
     logFormat: '%dt - %lvl(%top): %msg',
 } as const;
 
-class Logger implements ILogger {
+export class Logger implements ILogger {
     static instance: Logger;
     private stream: fs.WriteStream | undefined;
     private options: Options;
@@ -150,5 +151,3 @@ class Logger implements ILogger {
         return logLevels[this.logLevel];
     }
 }
-
-export default Logger;

--- a/packages/suite-desktop/src/libs/menu.ts
+++ b/packages/suite-desktop/src/libs/menu.ts
@@ -1,6 +1,7 @@
 import { app, shell, Menu, MenuItemConstructorOptions } from 'electron';
 
 import { isDevEnv } from '@suite-common/suite-utils';
+
 import { restartApp } from './app-utils';
 
 const isMac = process.platform === 'darwin';

--- a/packages/suite-desktop/src/libs/processes/BaseProcess.ts
+++ b/packages/suite-desktop/src/libs/processes/BaseProcess.ts
@@ -2,6 +2,7 @@ import path from 'path';
 import { spawn, ChildProcess } from 'child_process';
 
 import { isDevEnv } from '@suite-common/suite-utils';
+
 import { b2t } from '../utils';
 
 export type Status = {
@@ -26,7 +27,7 @@ const defaultOptions: Options = {
     autoRestart: 2,
 } as const;
 
-abstract class BaseProcess {
+export abstract class BaseProcess {
     process: ChildProcess | null;
     resourceName: string;
     processName: string;
@@ -236,5 +237,3 @@ abstract class BaseProcess {
         }
     }
 }
-
-export default BaseProcess;

--- a/packages/suite-desktop/src/libs/processes/BridgeProcess.ts
+++ b/packages/suite-desktop/src/libs/processes/BridgeProcess.ts
@@ -1,8 +1,6 @@
-import fetch from 'node-fetch';
+import { BaseProcess, Status } from './BaseProcess';
 
-import BaseProcess, { Status } from './BaseProcess';
-
-class BridgeProcess extends BaseProcess {
+export class BridgeProcess extends BaseProcess {
     constructor() {
         super('bridge', 'trezord', {
             startupCooldown: 3,
@@ -47,5 +45,3 @@ class BridgeProcess extends BaseProcess {
         await this.start(['-e', '21324', '-u=false']);
     }
 }
-
-export default BridgeProcess;

--- a/packages/suite-desktop/src/libs/processes/TorProcess.ts
+++ b/packages/suite-desktop/src/libs/processes/TorProcess.ts
@@ -1,6 +1,6 @@
-import BaseProcess, { Status } from './BaseProcess';
-
 import { TorController, TorIdentities } from '@trezor/request-manager';
+
+import { BaseProcess, Status } from './BaseProcess';
 
 interface TorConnectionOptions {
     host: string;
@@ -9,7 +9,7 @@ interface TorConnectionOptions {
     torDataDir: string;
 }
 
-class TorProcess extends BaseProcess {
+export class TorProcess extends BaseProcess {
     torController: TorController;
     port: number;
     controlPort: number;
@@ -64,5 +64,3 @@ class TorProcess extends BaseProcess {
         return this.torController.waitUntilAlive();
     }
 }
-
-export default TorProcess;

--- a/packages/suite-desktop/src/libs/store.ts
+++ b/packages/suite-desktop/src/libs/store.ts
@@ -1,5 +1,7 @@
 import Store from 'electron-store';
+
 import { SuiteThemeVariant } from '@trezor/suite-desktop-api';
+
 import { getInitialWindowSize } from './screen';
 
 // creates config.json inside appData folder https://electronjs.org/docs/api/app#appgetpathname

--- a/packages/suite-desktop/src/libs/update-checker.ts
+++ b/packages/suite-desktop/src/libs/update-checker.ts
@@ -1,6 +1,7 @@
 import fs from 'fs';
 import path from 'path';
 import { createMessage, readKey, readSignature, verify } from 'openpgp';
+
 import { getSignatureFileURL } from './github';
 
 const signingKey = process.env.APP_PUBKEY;

--- a/packages/suite-desktop/src/libs/user-data.ts
+++ b/packages/suite-desktop/src/libs/user-data.ts
@@ -1,5 +1,6 @@
 import fs from 'fs';
 import { app } from 'electron';
+
 import { InvokeResult } from '@trezor/suite-desktop-api';
 
 export const save = async (

--- a/packages/suite-desktop/src/logger.ts
+++ b/packages/suite-desktop/src/logger.ts
@@ -1,6 +1,8 @@
 import { app } from 'electron';
-import Logger, { LogLevel, defaultOptions as loggerDefaults } from './libs/logger';
+
 import { isDevEnv } from '@suite-common/suite-utils';
+
+import { Logger, LogLevel, defaultOptions as loggerDefaults } from './libs/logger';
 
 export const createLogger = () => {
     const log = {

--- a/packages/suite-desktop/src/modules/auto-updater.ts
+++ b/packages/suite-desktop/src/modules/auto-updater.ts
@@ -6,13 +6,16 @@ import {
     UpdateDownloadedEvent,
     ProgressInfo,
 } from 'electron-updater';
+
 import { bytesToHumanReadable } from '@trezor/utils';
 import { isFeatureFlagEnabled, isDevEnv } from '@suite-common/suite-utils';
+
 import { app, ipcMain } from '../typed-electron';
 import { b2t } from '../libs/utils';
 import { verifySignature } from '../libs/update-checker';
-import { Module } from './index';
 import { getReleaseNotes } from '../libs/github';
+
+import { Module } from './index';
 
 // Runtime flags
 const enableUpdater = app.commandLine.hasSwitch('enable-updater');
@@ -20,7 +23,7 @@ const disableUpdater = app.commandLine.hasSwitch('disable-updater');
 const preReleaseFlag = app.commandLine.hasSwitch('pre-release');
 const feedURL = app.commandLine.getSwitchValue('updater-url');
 
-const init: Module = ({ mainWindow, store }) => {
+export const init: Module = ({ mainWindow, store }) => {
     const { logger } = global;
     if (!isFeatureFlagEnabled('DESKTOP_AUTO_UPDATER') && !enableUpdater) {
         logger.info('auto-updater', 'Disabled via feature flag');
@@ -237,8 +240,8 @@ const init: Module = ({ mainWindow, store }) => {
     ipcMain.on('update/allow-prerelease', (_, value = true) => {
         logger.info('auto-updater', `${value ? 'allow' : 'disable'} prerelease!`);
         mainWindow.webContents.send('update/allow-prerelease', value);
-        const updateSettings = store.getUpdateSettings();
-        store.setUpdateSettings({ ...updateSettings, allowPrerelease: value });
+        const settings = store.getUpdateSettings();
+        store.setUpdateSettings({ ...settings, allowPrerelease: value });
 
         autoUpdater.allowPrerelease = value;
     });
@@ -248,8 +251,8 @@ const init: Module = ({ mainWindow, store }) => {
         // if there is savedCurrentVersion in store (it doesn't have to be there as it was added in later versions)
         // and if it does not match current application version it means that application got updated and the new version
         // is run for the first time.
-        const updateSettings = store.getUpdateSettings();
-        const { savedCurrentVersion } = updateSettings;
+        const settings = store.getUpdateSettings();
+        const { savedCurrentVersion } = settings;
         const currentVersion = app.getVersion();
         logger.debug(
             'auto-updater',
@@ -271,5 +274,3 @@ const init: Module = ({ mainWindow, store }) => {
         };
     };
 };
-
-export default init;

--- a/packages/suite-desktop/src/modules/bridge.ts
+++ b/packages/suite-desktop/src/modules/bridge.ts
@@ -2,8 +2,10 @@
  * Bridge runner
  */
 import { app } from 'electron';
-import BridgeProcess from '../libs/processes/BridgeProcess';
+
+import { BridgeProcess } from '../libs/processes/BridgeProcess';
 import { b2t } from '../libs/utils';
+
 import type { Module } from './index';
 
 const bridgeDev = app.commandLine.hasSwitch('bridge-dev');
@@ -32,7 +34,7 @@ const load = async () => {
     }
 };
 
-const init: Module = () => {
+export const init: Module = () => {
     let loaded = false;
     return () => {
         if (loaded) return;
@@ -41,5 +43,3 @@ const init: Module = () => {
         load();
     };
 };
-
-export default init;

--- a/packages/suite-desktop/src/modules/coinjoin.ts
+++ b/packages/suite-desktop/src/modules/coinjoin.ts
@@ -3,13 +3,15 @@
  */
 
 import { app, ipcMain } from 'electron';
+
 import { createIpcProxyHandler, IpcProxyHandlerOptions } from '@trezor/ipc-proxy';
 import { CoinjoinBackend, CoinjoinClient } from '@trezor/coinjoin';
+
 import type { Module } from './index';
 
 const SERVICE_NAME = '@trezor/coinjoin';
 
-const init: Module = ({ mainWindow }) => {
+export const init: Module = ({ mainWindow }) => {
     const { logger } = global;
 
     const backends: CoinjoinBackend[] = [];
@@ -94,5 +96,3 @@ const init: Module = ({ mainWindow }) => {
         });
     };
 };
-
-export default init;

--- a/packages/suite-desktop/src/modules/crash-recover.ts
+++ b/packages/suite-desktop/src/modules/crash-recover.ts
@@ -1,6 +1,8 @@
 import { app, dialog } from 'electron';
-import { Module } from './index';
+
 import { restartApp } from '../libs/app-utils';
+
+import { Module } from './index';
 
 // Reasons for prompting a restart
 const unexpectedReasons = [
@@ -9,7 +11,7 @@ const unexpectedReasons = [
     'launch-failure', // Process couldn't launch
 ];
 
-const init: Module = ({ mainWindow }) => {
+export const init: Module = ({ mainWindow }) => {
     // Check if the renderer process got unexpectedly terminated
     mainWindow.webContents.on('render-process-gone', (_, { reason }) => {
         if (unexpectedReasons.includes(reason)) {
@@ -29,5 +31,3 @@ const init: Module = ({ mainWindow }) => {
         }
     });
 };
-
-export default init;

--- a/packages/suite-desktop/src/modules/csp.ts
+++ b/packages/suite-desktop/src/modules/csp.ts
@@ -5,9 +5,10 @@
 import { session } from 'electron';
 
 import * as config from '../config';
+
 import { Module } from './index';
 
-const init: Module = () => {
+export const init: Module = () => {
     const { logger } = global;
 
     session.defaultSession.webRequest.onHeadersReceived((details, callback) => {
@@ -20,5 +21,3 @@ const init: Module = () => {
         });
     });
 };
-
-export default init;

--- a/packages/suite-desktop/src/modules/custom-protocols.ts
+++ b/packages/suite-desktop/src/modules/custom-protocols.ts
@@ -2,10 +2,12 @@
  * Support custom protocols (for example: `bitcoin:`)
  */
 import { app } from 'electron';
+
 import { isValidProtocol } from '../libs/protocol';
+
 import type { Module } from './index';
 
-const init: Module = ({ mainWindow }) => {
+export const init: Module = ({ mainWindow }) => {
     const { logger } = global;
 
     const protocols = process.env.PROTOCOLS as unknown as string[];
@@ -88,5 +90,3 @@ const init: Module = ({ mainWindow }) => {
         }
     }
 };
-
-export default init;

--- a/packages/suite-desktop/src/modules/dev-tools.ts
+++ b/packages/suite-desktop/src/modules/dev-tools.ts
@@ -9,10 +9,8 @@ import type { Module } from './index';
 
 const openDevToolsFlag = app.commandLine.hasSwitch('open-devtools');
 
-const init: Module = ({ mainWindow }) => {
+export const init: Module = ({ mainWindow }) => {
     if (isDevEnv || openDevToolsFlag) {
         mainWindow.webContents.openDevTools();
     }
 };
-
-export default init;

--- a/packages/suite-desktop/src/modules/event-logging/app.ts
+++ b/packages/suite-desktop/src/modules/event-logging/app.ts
@@ -1,7 +1,8 @@
 import { app } from 'electron';
+
 import type { Module } from '../index';
 
-const init: Module = () => {
+export const init: Module = () => {
     const { logger } = global;
 
     app.on('ready', () => {
@@ -20,5 +21,3 @@ const init: Module = () => {
         logger.error('app', `Child process (${type}) gone (reason: ${reason})`);
     });
 };
-
-export default init;

--- a/packages/suite-desktop/src/modules/event-logging/contents.ts
+++ b/packages/suite-desktop/src/modules/event-logging/contents.ts
@@ -1,11 +1,12 @@
 import { app } from 'electron';
 
 import { isDevEnv } from '@suite-common/suite-utils';
+
 import { Module } from '../index';
 
 const logUI = app.commandLine.hasSwitch('log-ui');
 
-const init: Module = ({ mainWindow }) => {
+export const init: Module = ({ mainWindow }) => {
     const { logger } = global;
 
     mainWindow.webContents.on('did-fail-load', (_, errorCode, errorDescription, validatedUrl) => {
@@ -71,5 +72,3 @@ const init: Module = ({ mainWindow }) => {
         }
     });
 };
-
-export default init;

--- a/packages/suite-desktop/src/modules/event-logging/process.ts
+++ b/packages/suite-desktop/src/modules/event-logging/process.ts
@@ -1,18 +1,15 @@
 import type { Module } from '../index';
 
-const init: Module = () => {
+export const init: Module = () => {
     const { logger } = global;
 
     process.on('uncaughtException', e => {
         logger.error('exception', e.message);
     });
 
-    process.on('unhandledRejection', e => {
+    process.on('unhandledRejection', (e: Error) => {
         if (e) {
-            // @ts-expect-error type is unknown
             logger.warn('rejection', `Unhandled Rejection: ${e?.toString()}`);
         }
     });
 };
-
-export default init;

--- a/packages/suite-desktop/src/modules/external-links.ts
+++ b/packages/suite-desktop/src/modules/external-links.ts
@@ -5,9 +5,10 @@ import { shell, dialog } from 'electron';
 import { HandlerDetails } from 'electron/main';
 
 import * as config from '../config';
+
 import { Module } from './index';
 
-const init: Module = ({ mainWindow, store }) => {
+export const init: Module = ({ mainWindow, store }) => {
     const { logger } = global;
 
     mainWindow.webContents.setWindowOpenHandler((details: HandlerDetails) => {
@@ -59,5 +60,3 @@ const init: Module = ({ mainWindow, store }) => {
         return { action: 'deny' };
     });
 };
-
-export default init;

--- a/packages/suite-desktop/src/modules/file-protocol.ts
+++ b/packages/suite-desktop/src/modules/file-protocol.ts
@@ -5,9 +5,10 @@ import path from 'path';
 import { session } from 'electron';
 
 import { FILE_PROTOCOL, APP_SRC } from '../libs/constants';
+
 import type { Module } from './index';
 
-const init: Module = ({ mainWindow }) => {
+export const init: Module = ({ mainWindow }) => {
     // Point to the right directory for file protocol requests
     session.defaultSession.protocol.interceptFileProtocol(FILE_PROTOCOL, (request, callback) => {
         let url = request.url.substring(FILE_PROTOCOL.length + 1);
@@ -20,5 +21,3 @@ const init: Module = ({ mainWindow }) => {
         mainWindow.loadURL(APP_SRC);
     });
 };
-
-export default init;

--- a/packages/suite-desktop/src/modules/http-receiver.ts
+++ b/packages/suite-desktop/src/modules/http-receiver.ts
@@ -3,9 +3,10 @@
  */
 import { app, ipcMain } from '../typed-electron';
 import { HttpReceiver } from '../libs/http-receiver';
+
 import { Module } from './index';
 
-const init: Module = ({ mainWindow }) => {
+export const init: Module = ({ mainWindow }) => {
     const { logger } = global;
     let httpReceiver: HttpReceiver | null = null;
     return async () => {
@@ -59,5 +60,3 @@ const init: Module = ({ mainWindow }) => {
         return receiver.getInfo();
     };
 };
-
-export default init;

--- a/packages/suite-desktop/src/modules/menu.ts
+++ b/packages/suite-desktop/src/modules/menu.ts
@@ -2,9 +2,10 @@ import { Menu } from 'electron';
 
 import { buildMainMenu, inputMenu, selectionMenu } from '../libs/menu';
 import { b2t } from '../libs/utils';
+
 import { Module } from './index';
 
-const init: Module = ({ mainWindow }) => {
+export const init: Module = ({ mainWindow }) => {
     const { logger } = global;
 
     Menu.setApplicationMenu(buildMainMenu());
@@ -27,5 +28,3 @@ const init: Module = ({ mainWindow }) => {
         }
     });
 };
-
-export default init;

--- a/packages/suite-desktop/src/modules/metadata.ts
+++ b/packages/suite-desktop/src/modules/metadata.ts
@@ -3,6 +3,7 @@
  */
 import { ipcMain } from '../typed-electron';
 import { save, read } from '../libs/user-data';
+
 import type { Module } from './index';
 
 const DATA_DIR = '/metadata';
@@ -22,5 +23,3 @@ export const init: Module = () => {
         return resp;
     });
 };
-
-export default init;

--- a/packages/suite-desktop/src/modules/request-filter.ts
+++ b/packages/suite-desktop/src/modules/request-filter.ts
@@ -2,10 +2,12 @@
  * Request Filter feature (blocks non-allowed requests)
  */
 import { captureMessage, Severity } from '@sentry/electron';
+
 import { allowedDomains } from '../config';
+
 import { Module } from './index';
 
-const init: Module = ({ interceptor }) => {
+export const init: Module = ({ interceptor }) => {
     const { logger } = global;
 
     const resourceTypeFilter = ['xhr']; // What resource types we want to filter
@@ -36,5 +38,3 @@ const init: Module = ({ interceptor }) => {
         return { cancel: true };
     });
 };
-
-export default init;

--- a/packages/suite-desktop/src/modules/request-interceptor.ts
+++ b/packages/suite-desktop/src/modules/request-interceptor.ts
@@ -8,9 +8,10 @@
  * whereas request-filter logs and filters allowed requests from electron renderer process.
  */
 import { createInterceptor, InterceptedEvent } from '@trezor/request-manager';
+
 import { Module } from './index';
 
-const init: Module = ({ store }) => {
+export const init: Module = ({ store }) => {
     const { logger } = global;
 
     const options = {
@@ -24,5 +25,3 @@ const init: Module = ({ store }) => {
 
     createInterceptor(options);
 };
-
-export default init;

--- a/packages/suite-desktop/src/modules/shortcuts.ts
+++ b/packages/suite-desktop/src/modules/shortcuts.ts
@@ -4,7 +4,7 @@ import { restartApp } from '../libs/app-utils';
 
 import type { Module } from './index';
 
-const init: Module = ({ mainWindow }) => {
+export const init: Module = ({ mainWindow }) => {
     const { logger } = global;
 
     const openDevToolsShortcuts = ['F12', 'CommandOrControl+Shift+I', 'CommandOrControl+Alt+I'];
@@ -44,5 +44,3 @@ const init: Module = ({ mainWindow }) => {
         });
     });
 };
-
-export default init;

--- a/packages/suite-desktop/src/modules/store.ts
+++ b/packages/suite-desktop/src/modules/store.ts
@@ -1,7 +1,8 @@
 import { ipcMain } from '../typed-electron';
+
 import { Module } from './index';
 
-const init: Module = ({ store }) => {
+export const init: Module = ({ store }) => {
     const { logger } = global;
 
     ipcMain.on('store/clear', () => {
@@ -9,5 +10,3 @@ const init: Module = ({ store }) => {
         store.clear();
     });
 };
-
-export default init;

--- a/packages/suite-desktop/src/modules/theme.ts
+++ b/packages/suite-desktop/src/modules/theme.ts
@@ -1,7 +1,10 @@
 import { nativeTheme } from 'electron';
+
 import { SuiteThemeVariant } from '@trezor/suite-desktop-api';
+
 import { getThemeSettings, setThemeSettings } from '../libs/store';
 import { ipcMain } from '../typed-electron';
+
 import type { Module } from './index';
 
 const setThemeManually = (theme: SuiteThemeVariant) => {
@@ -13,7 +16,7 @@ const setThemeManually = (theme: SuiteThemeVariant) => {
     setThemeSettings(theme);
 };
 
-const init: Module = () => {
+export const init: Module = () => {
     const { logger } = global;
 
     const theme = getThemeSettings();
@@ -22,7 +25,5 @@ const init: Module = () => {
         nativeTheme.themeSource = theme;
     }
 
-    ipcMain.on('theme/change', (_, theme) => setThemeManually(theme));
+    ipcMain.on('theme/change', (_, newTheme) => setThemeManually(newTheme));
 };
-
-export default init;

--- a/packages/suite-desktop/src/modules/tor.ts
+++ b/packages/suite-desktop/src/modules/tor.ts
@@ -3,13 +3,16 @@
  */
 import { captureException } from '@sentry/electron';
 import { session } from 'electron';
-import TorProcess from '../libs/processes/TorProcess';
+import { HandshakeTorModule } from 'packages/suite-desktop-api/lib/messages';
+
+import TrezorConnect from '@trezor/connect';
+
+import { TorProcess } from '../libs/processes/TorProcess';
 import { onionDomain } from '../config';
 import { app, ipcMain } from '../typed-electron';
 import { getFreePort } from '../libs/getFreePort';
-import TrezorConnect from '@trezor/connect';
+
 import type { Dependencies } from './index';
-import { HandshakeTorModule } from 'packages/suite-desktop-api/lib/messages';
 
 const load = async ({ mainWindow, store, interceptor }: Dependencies) => {
     const { logger } = global;
@@ -191,7 +194,7 @@ const load = async ({ mainWindow, store, interceptor }: Dependencies) => {
 
 type TorModule = (dependencies: Dependencies) => () => Promise<HandshakeTorModule>;
 
-const init: TorModule = dependencies => {
+export const init: TorModule = dependencies => {
     let loaded = false;
     return async () => {
         if (loaded) return { shouldRunTor: false };
@@ -204,5 +207,3 @@ const init: TorModule = dependencies => {
         };
     };
 };
-
-export default init;

--- a/packages/suite-desktop/src/modules/trezor-connect.ts
+++ b/packages/suite-desktop/src/modules/trezor-connect.ts
@@ -1,11 +1,13 @@
 import { app, ipcMain } from 'electron';
+
 import TrezorConnect from '@trezor/connect';
 import { createIpcProxyHandler, IpcProxyHandlerOptions } from '@trezor/ipc-proxy';
+
 import type { Module } from './index';
 
 const SERVICE_NAME = '@trezor/connect';
 
-const init: Module = ({ store }) => {
+export const init: Module = ({ store }) => {
     const { logger } = global;
     logger.info(SERVICE_NAME, `Starting service`);
 
@@ -56,5 +58,3 @@ const init: Module = ({ store }) => {
         TrezorConnect.dispose();
     };
 };
-
-export default init;

--- a/packages/suite-desktop/src/modules/user-data.ts
+++ b/packages/suite-desktop/src/modules/user-data.ts
@@ -1,8 +1,9 @@
 import * as userData from '../libs/user-data';
 import { ipcMain } from '../typed-electron';
+
 import type { Module } from './index';
 
-const init: Module = () => {
+export const init: Module = () => {
     const { logger } = global;
 
     ipcMain.handle('user-data/clear', () => {
@@ -12,5 +13,3 @@ const init: Module = () => {
 
     return () => userData.getInfo();
 };
-
-export default init;

--- a/packages/suite-desktop/src/modules/window-controls.ts
+++ b/packages/suite-desktop/src/modules/window-controls.ts
@@ -2,9 +2,10 @@
  * Window events handler
  */
 import { app, ipcMain } from '../typed-electron';
+
 import { Module } from './index';
 
-const init: Module = ({ mainWindow }) => {
+export const init: Module = ({ mainWindow }) => {
     const { logger } = global;
 
     if (process.platform === 'darwin') {
@@ -82,5 +83,3 @@ const init: Module = ({ mainWindow }) => {
         app.focus({ steal: true });
     });
 };
-
-export default init;

--- a/packages/suite-desktop/src/preload.ts
+++ b/packages/suite-desktop/src/preload.ts
@@ -1,4 +1,5 @@
 import { contextBridge, ipcRenderer } from 'electron';
+
 import { exposeIpcProxy } from '@trezor/ipc-proxy';
 import { getDesktopApi } from '@trezor/suite-desktop-api';
 

--- a/packages/suite-desktop/src/typed-electron.ts
+++ b/packages/suite-desktop/src/typed-electron.ts
@@ -1,4 +1,5 @@
 import * as electron from 'electron';
+
 import * as desktopApi from '@trezor/suite-desktop-api';
 
 export type StrictIpcMain = desktopApi.StrictIpcMain<

--- a/packages/suite-desktop/tsconfig.json
+++ b/packages/suite-desktop/tsconfig.json
@@ -4,7 +4,7 @@
         "module": "commonjs",
         "outDir": "./libDev"
     },
-    "include": [".", "**/*.json"],
+    "include": ["./src", "./e2e", "**/*.json"],
     "references": [
         { "path": "../../suite-common/sentry" },
         {

--- a/yarn.lock
+++ b/yarn.lock
@@ -7382,12 +7382,14 @@ __metadata:
     electron-store: ^8.1.0
     electron-updater: 5.2.1
     esbuild: ^0.15.7
+    glob: ^8.0.3
     jest: ^26.6.3
     node-fetch: ^2.6.7
     openpgp: ^5.5.0
     playwright: ^1.22.2
     rimraf: ^3.0.2
     systeminformation: ^5.12.6
+    tsx: ^3.8.2
     typescript: 4.7.4
     xvfb-maybe: ^0.2.1
   languageName: unknown
@@ -18594,7 +18596,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"glob@npm:^8.0.1":
+"glob@npm:^8.0.1, glob@npm:^8.0.3":
   version: 8.0.3
   resolution: "glob@npm:8.0.3"
   dependencies:


### PR DESCRIPTION
## Description

- Eslint rules now applies for `suite-desktop` package
- e2e tests and scripts in `suite-desktop` are now in typescript

## Related Issue


