### PR TITLE
fix assetprefix on dev and some other ci changes

### DIFF
--- a/ci/build.yml
+++ b/ci/build.yml
@@ -86,9 +86,6 @@ suite-web-landing build stable:
   stage: build
   only:
     refs:
-      - develop
-      - releases
-      - schedules
       - /^release\//
       - codesign
   script:

--- a/ci/build.yml
+++ b/ci/build.yml
@@ -2,7 +2,6 @@
 .config_sign_stable: &config_sign_stable
   interruptible: true
   dependencies:
-    - install
     - msg-system config sign stable
 
 .config_sign_dev: &config_sign_dev

--- a/ci/build.yml
+++ b/ci/build.yml
@@ -44,26 +44,6 @@ suite-web build dev:
     paths:
       - packages/suite-web/build
 
-suite-web build stable:
-  stage: build
-  <<: *config_sign_dev
-  only:
-    refs:
-      - develop
-      - releases
-      - schedules
-      - /^release\//
-  variables:
-    ASSET_PREFIX: /web
-  script:
-    - yarn install --immutable
-    - yarn workspace @trezor/suite-web build
-  artifacts:
-    expire_in: 7 days
-    paths:
-      - packages/suite-web/scripts/s3sync.sh
-      - packages/suite-web/build
-
 suite-web build stable codesign:
   stage: build
   <<: *config_sign_stable

--- a/ci/environment.yml
+++ b/ci/environment.yml
@@ -18,6 +18,8 @@ build & push image:
 
 install:
   stage: setup environment
+  variables:
+    ASSET_PREFIX: /suite-web/${CI_BUILD_REF_NAME}/web
   script:
     - ci/scripts/check_branch_name.sh $CI_COMMIT_BRANCH
     - yarn --immutable


### PR DESCRIPTION
- fix(ci): asset prefix missing for suite-web build on dev
- chore(ci): remove unused suite-web build stable
- chore(ci): set suite-web-landing stable to run on release and codesign only
- chore(ci): remove install dependency for codesign jobs

<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->

## Related Issue

Resolve <!--- link the issue here -->

## Screenshots (if appropriate):
