### PR TITLE
feat(coinjoin): add http module

### DIFF
--- a/packages/coinjoin/src/utils/http.ts
+++ b/packages/coinjoin/src/utils/http.ts
@@ -1,0 +1,100 @@
+import fetch from 'cross-fetch';
+
+export interface RequestOptions {
+    method?: 'POST' | 'GET';
+    baseUrl?: string;
+    signal?: AbortSignal;
+    parseJson?: boolean;
+    delay?: number;
+    identity?: string;
+}
+
+const parseResult = (text: string, json = true) => {
+    if (!json) return text;
+    return JSON.parse(text);
+};
+
+const requestDelay = async (options: RequestOptions) => {
+    const delay = options.delay || 0;
+    if (delay > 0) {
+        await new Promise<void>((resolve, reject) => {
+            let timeout: ReturnType<typeof setTimeout> | undefined;
+            const abortHandler = () => {
+                if (timeout) {
+                    clearTimeout(timeout);
+                    reject(new Error('The user aborted a request.'));
+                }
+            };
+            options.signal?.addEventListener('abort', abortHandler);
+            timeout = setTimeout(() => {
+                timeout = undefined;
+                options.signal?.removeEventListener('abort', abortHandler);
+                resolve();
+            }, delay);
+        });
+    }
+};
+
+const createHeaders = (options: RequestOptions) => {
+    const headers: HeadersInit = {
+        'Content-Type': 'application/json-patch+json',
+    };
+    // add custom header to define TOR identity.
+    // request is intercepted by @trezor/request-manager and requested identity is used to create TOR circuit
+    if (options.identity) {
+        headers['Proxy-Authorization'] = `Basic ${options.identity}`;
+    }
+    return headers;
+};
+
+export const httpGet = async (
+    url: string,
+    query?: Record<string, any>,
+    options: RequestOptions = {},
+) => {
+    const queryString = query ? `?${new URLSearchParams(query)}` : '';
+    await requestDelay(options);
+    return fetch(`${url}${queryString}`, {
+        method: 'GET',
+        signal: options.signal,
+        headers: createHeaders(options),
+    });
+};
+
+export const httpPost = async (
+    url: string,
+    body?: Record<string, any>,
+    options: RequestOptions = {},
+) => {
+    await requestDelay(options);
+    return fetch(url, {
+        method: 'POST',
+        body: JSON.stringify(body),
+        signal: options.signal,
+        headers: createHeaders(options),
+    });
+};
+
+// Requests to wasabi coordinator and middleware (CoinjoinClientLibrary bin)
+export const coordinatorRequest = async <R = void>(
+    url: string,
+    body: Record<string, any>,
+    options: RequestOptions = {},
+): Promise<R> => {
+    const baseUrl = options.baseUrl || '';
+
+    const response = await httpPost(`${baseUrl}${url}`, body, options);
+
+    const text = await response.text();
+    if (response.ok) {
+        const json = typeof options.parseJson === 'boolean' ? options.parseJson : true;
+        return parseResult(text, json);
+    }
+    if (response.headers.get('content-type')?.includes('json')) {
+        // NOTE: coordinator/middleware error shape {type: string, errorCode: string, description: string, exceptionData: { Type: string } }
+        const { errorCode } = parseResult(text);
+        throw new Error(errorCode || text);
+    }
+    const error = text ? `${response.statusText}: ${text}` : response.statusText;
+    throw new Error(`${baseUrl}${url} ${error}`);
+};

--- a/packages/coinjoin/tests/mocks/server.ts
+++ b/packages/coinjoin/tests/mocks/server.ts
@@ -1,0 +1,117 @@
+import * as net from 'net';
+import * as http from 'http';
+
+// Mock coordinator and middleware responses
+
+const DEFAULT = {
+    // middleware
+    'analyze-transaction': {
+        results: {},
+    },
+    'select-utxo-for-round': {
+        indices: [],
+    },
+    'create-request': {
+        realCredentialsRequestData: {},
+    },
+    'create-request-for-zero-amount': {
+        zeroCredentialsRequestData: {
+            credentialsRequest: {},
+        },
+    },
+    'handle-response': {
+        credentials: [{}, {}],
+    },
+    'decompose-amounts': { outputAmounts: [] },
+    // payment request server
+    'payment-request': {
+        recipient_name: 'trezor.io',
+        signature: 'AA',
+    },
+    // coordinator
+    status: {
+        roundStates: [],
+    },
+    'input-registration': {
+        aliceId: Math.random().toString(),
+    },
+    'connection-confirmation': {
+        realAmountCredentials: {
+            credentialsRequest: {},
+        },
+        realVsizeCredentials: {
+            credentialsRequest: {},
+        },
+    },
+    'credential-issuance': {},
+    'output-registration': {},
+    'ready-to-sign': {},
+    'transaction-signature': {},
+};
+
+export const getFreePort = () =>
+    new Promise<number>((resolve, reject) => {
+        const server = net.createServer();
+        server.unref();
+        server.on('error', reject);
+        server.listen(0, () => {
+            const { port } = server.address() as net.AddressInfo;
+            server.close(() => {
+                resolve(port);
+            });
+        });
+    });
+
+const handleRequest = (req: http.IncomingMessage, res: http.ServerResponse, testResponse?: any) => {
+    if (res.writableEnded) return; // send default response if res.end wasn't called in test
+
+    res.setHeader('Content-Type', 'application/json');
+    if (testResponse) {
+        res.write(JSON.stringify(testResponse));
+        res.end();
+        return;
+    }
+    const url = req.url?.split('/').pop();
+    const data = DEFAULT[url as keyof typeof DEFAULT] || {};
+    res.write(JSON.stringify(data));
+    res.end();
+};
+
+// export type Server = http.Server;
+export interface Server extends http.Server {
+    requestOptions: any;
+}
+
+export const createServer = async () => {
+    const port = await getFreePort();
+    const server = http.createServer((req, res) => {
+        server.emit('test-handle-request', req);
+        if (server.listenerCount('test-request') > 0) {
+            let data = '';
+            req.on('data', chunk => {
+                data += chunk;
+            });
+            req.on('end', () => {
+                server.emit('test-request', JSON.parse(data), req, res);
+            });
+            // notify test and wait for the response
+            req.on('test-response', (responseData: any) => {
+                handleRequest(req, res, responseData);
+            });
+        } else {
+            handleRequest(req, res);
+        }
+    });
+    server.listen(port);
+
+    // @ts-expect-error
+    server.requestOptions = {
+        coordinatorName: 'CoinJoinCoordinatorIdentifier',
+        coordinatorUrl: `http://localhost:${port}/`,
+        middlewareUrl: `http://localhost:${port}/`,
+        signal: new AbortController().signal,
+        log: () => {},
+    };
+
+    return server as Server;
+};

--- a/packages/coinjoin/tests/utils/http.test.ts
+++ b/packages/coinjoin/tests/utils/http.test.ts
@@ -1,0 +1,128 @@
+import { coordinatorRequest } from '../../src/utils/http';
+import { createServer, Server } from '../mocks/server';
+
+let server: Server | undefined;
+let baseUrl = 'http://localhost:8081/';
+
+describe('http', () => {
+    beforeAll(async () => {
+        server = await createServer();
+        baseUrl = server.requestOptions.coordinatorUrl;
+    });
+
+    beforeEach(() => {
+        server?.removeAllListeners('test-handle-request');
+        server?.removeAllListeners('test-request');
+    });
+
+    afterAll(() => {
+        if (server) server.close();
+    });
+
+    it('with 500 error', async () => {
+        server?.addListener('test-request', (_, req, res) => {
+            res.statusCode = 500;
+            res.setHeader('Content-Type', 'application/json');
+            res.write(JSON.stringify({ errorCode: 'InternalErrorCodeExample' }));
+            res.end();
+            req.emit('test-response');
+        });
+
+        await expect(coordinatorRequest('status', {}, { baseUrl })).rejects.toThrow(
+            'InternalErrorCodeExample',
+        );
+    });
+
+    it('with 500 error without errorCode', async () => {
+        server?.addListener('test-request', (_, req, res) => {
+            res.statusCode = 500;
+            res.setHeader('Content-Type', 'application/json');
+            res.write(JSON.stringify({ error: 'InternalErrorCodeExample' }));
+            res.end();
+            req.emit('test-response');
+        });
+
+        await expect(coordinatorRequest('status', {}, { baseUrl })).rejects.toThrow(
+            JSON.stringify({ error: 'InternalErrorCodeExample' }),
+        );
+    });
+
+    it('with 500 error without json header', async () => {
+        server?.addListener('test-request', (_, req, res) => {
+            res.statusCode = 500;
+            res.write('InternalErrorCodeExample');
+            res.end();
+            req.emit('test-response');
+        });
+
+        await expect(coordinatorRequest('status', {}, { baseUrl })).rejects.toThrow(
+            'Internal Server Error: InternalErrorCodeExample',
+        );
+    });
+
+    it('with 500 error with invalid json', async () => {
+        server?.addListener('test-request', (_, req, res) => {
+            res.statusCode = 500;
+            res.setHeader('Content-Type', 'application/json');
+            res.write('InternalErrorCodeExample');
+            res.end();
+            req.emit('test-response');
+        });
+
+        await expect(coordinatorRequest('status', {}, { baseUrl })).rejects.toThrow(
+            'Unexpected token',
+        );
+    });
+
+    it('with 404 error', async () => {
+        server?.addListener('test-request', (_, req, res) => {
+            res.statusCode = 404;
+            res.end();
+            req.emit('test-response');
+        });
+
+        await expect(coordinatorRequest('status', {}, { baseUrl })).rejects.toThrow('Not Found');
+    });
+
+    it('aborted request', async () => {
+        const abort = new AbortController();
+        abort.abort();
+
+        await expect(
+            coordinatorRequest('status', {}, { baseUrl, signal: abort.signal }),
+        ).rejects.toThrow('The user aborted a request');
+    });
+
+    it('aborted delayed request', async () => {
+        const abort = new AbortController();
+        setTimeout(() => abort.abort(), 300);
+        await expect(
+            coordinatorRequest('status', {}, { baseUrl, delay: 1000, signal: abort.signal }),
+        ).rejects.toThrow('The user aborted a request.');
+    });
+
+    it('successful', done => {
+        coordinatorRequest('input-registration', {}, { baseUrl }).then(resp => {
+            expect(resp).toMatchObject({ aliceId: expect.any(String) });
+        });
+        // without baseUrl
+        coordinatorRequest(`${baseUrl}status`, {}).then(resp => {
+            expect(resp).toEqual({ roundStates: [] });
+        });
+        // without json response
+        coordinatorRequest('ready-to-sign', {}, { baseUrl, parseJson: false }).then(resp => {
+            expect(resp).toEqual('{}');
+            done();
+        });
+    });
+
+    it('with identity', async () => {
+        const requestListener = jest.fn(req => {
+            expect(req.headers).toMatchObject({
+                'proxy-authorization': 'Basic abcd',
+            });
+        });
+        server?.addListener('test-handle-request', requestListener);
+        await coordinatorRequest('status', {}, { baseUrl, identity: 'abcd' });
+    });
+});


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Prerequisite for other coinjoin related branches.
Create `http` module to send requests to coordinator, middleware and blockbook
