### PR TITLE
fix(suite): align text

### DIFF
--- a/packages/suite/src/views/recovery/index.tsx
+++ b/packages/suite/src/views/recovery/index.tsx
@@ -26,7 +26,10 @@ const StepsContainer = styled.div`
 
 const StyledP = styled(P)`
     font-size: ${variables.FONT_SIZE.SMALL};
-    color: ${props => props.theme.TYPE_LIGHT_GREY};
+    color: ${({ theme }) => theme.TYPE_LIGHT_GREY};
+`;
+
+const LeftAlignedP = styled(StyledP)`
     text-align: left;
 `;
 
@@ -140,9 +143,9 @@ export const Recovery = ({ onCancel }: ForegroundAppProps) => {
             case 'initial':
                 return (
                     <>
-                        <StyledP>
+                        <LeftAlignedP>
                             {model && <Translation id={`TR_CHECK_RECOVERY_SEED_DESC_T${model}`} />}
-                        </StyledP>
+                        </LeftAlignedP>
 
                         <StepsContainer>
                             <InstructionStep
@@ -207,9 +210,9 @@ export const Recovery = ({ onCancel }: ForegroundAppProps) => {
                 return modal.context !== '@modal/context-none' ? (
                     <>
                         {model === 2 && (
-                            <StyledP>
+                            <LeftAlignedP>
                                 <Translation id="TR_ALL_THE_WORDS" />
-                            </StyledP>
+                            </LeftAlignedP>
                         )}
                         <ReduxModal {...modal} renderer={InstructionModal} />
                     </>


### PR DESCRIPTION
Fix text alignment

## Description

I believe the `text-align` property added #6168 should not affect this element.

## Screenshots (if appropriate):
Before the fix:
![Screenshot 2022-10-04 at 13 24 18](https://user-images.githubusercontent.com/42465546/193809274-e6ac2f3f-399d-40ad-8973-16a4584244a7.png)

After:
![Screenshot 2022-10-04 at 13 22 48](https://user-images.githubusercontent.com/42465546/193809225-3b487dc2-7f1f-43ee-b37e-86bf80ca71cd.png)

QA: Only fixing the alignment of the bottom text in this modal, nothing else should be affected. 