### PR TITLE
Unable to reset backend to default fix

### DIFF
--- a/packages/suite/src/actions/wallet/selectedAccountActions.ts
+++ b/packages/suite/src/actions/wallet/selectedAccountActions.ts
@@ -207,7 +207,6 @@ const actions = [
     blockchainActions.synced.type,
     blockchainActions.connected.type,
     blockchainActions.reconnectTimeoutStart.type,
-    blockchainActions.resetBackend.type,
     blockchainActions.updateFee.type,
     ...Object.values(DISCOVERY).filter(v => typeof v === 'string'),
 ];

--- a/packages/suite/src/hooks/settings/backends/useBackendsForm.ts
+++ b/packages/suite/src/hooks/settings/backends/useBackendsForm.ts
@@ -97,7 +97,6 @@ export const useBackendsForm = (coin: Network['symbol']) => {
     const [currentValues, setCurrentValues] = useState(initial);
     const actions = useActions({
         setBackend: blockchainActions.setBackend,
-        resetBackend: blockchainActions.resetBackend,
     });
 
     const changeType = (type: BackendOption) => {
@@ -133,11 +132,7 @@ export const useBackendsForm = (coin: Network['symbol']) => {
     const save = () => {
         const { type } = currentValues;
         const urls = type === 'default' ? [] : getUrls();
-        if (type === 'default') {
-            actions.resetBackend(coin);
-        } else {
-            actions.setBackend({ coin, type, urls });
-        }
+        actions.setBackend({ coin, type, urls });
         const totalOnion = urls.filter(isOnionUrl).length;
 
         analytics.report({

--- a/suite-common/wallet-core/src/blockchain/blockchainActions.ts
+++ b/suite-common/wallet-core/src/blockchain/blockchainActions.ts
@@ -34,20 +34,14 @@ const synced = createAction(
     }),
 );
 
-export type SetBackendPayload = CustomBackend | { coin: NetworkSymbol; type: 'default' };
+export type SetBackendPayload =
+    | CustomBackend
+    | { coin: NetworkSymbol; type: 'default'; urls?: unknown };
 const setBackend = createAction(`${actionsPrefix}/setBackend`, (payload: SetBackendPayload) => ({
     payload,
 }));
 
-const resetBackend = createAction(`${actionsPrefix}/resetBackend`, (coin: NetworkSymbol) => ({
-    payload: {
-        coin,
-        type: 'default',
-    },
-}));
-
 export const blockchainActions = {
-    resetBackend,
     setBackend,
     connected,
     reconnectTimeoutStart,

--- a/suite-common/wallet-core/src/blockchain/blockchainReducer.ts
+++ b/suite-common/wallet-core/src/blockchain/blockchainReducer.ts
@@ -140,9 +140,6 @@ export const prepareBlockchainReducer = createReducerWithExtraDeps(
                     };
                 }
             })
-            .addCase(blockchainActions.resetBackend, (state, action) => {
-                delete state[action.payload.coin].backends.selected;
-            })
             .addCase(extra.actionTypes.storageLoad, extra.reducers.storageLoadBlockchain)
             .addMatcher(
                 action => action.type === TREZOR_CONNECT_BLOCKCHAIN_ACTIONS.CONNECT,


### PR DESCRIPTION
## Description

When `setBackend` and `resetBackend` actions were separated in #6140, only `setBackend` was still intercepted in middlewares (primarily in `storageMiddleware`), therefore it was impossible to simply turn the custom backend off.

I've replaced the only `resetBackend` usage in Suite with `setBackend` and remove `resetBackend` completely which should resolve the issue.

## Related Issue

Could resolve #6050
Bug occured in #6140
