### PR TITLE
feat: add mobile QR generator using Skia

### DIFF
--- a/suite-native/module-home/src/screens/HomeScreen.tsx
+++ b/suite-native/module-home/src/screens/HomeScreen.tsx
@@ -3,6 +3,7 @@ import React from 'react';
 import { VStack } from '@suite-native/atoms';
 import { Screen } from '@suite-native/navigation';
 import { PortfolioGraph } from '@suite-native/module-graph';
+import { QRCode } from '@suite-native/qr-code-generator';
 
 import { Assets } from '../components/Assets';
 import { DashboardHeader } from '../components/DashboardHeader';
@@ -10,6 +11,7 @@ import { DashboardHeader } from '../components/DashboardHeader';
 export const HomeScreen = () => (
     <Screen>
         <VStack spacing={40}>
+            <QRCode value="test test test test test" />
             <DashboardHeader />
             <PortfolioGraph />
             <Assets />

--- a/suite-native/qr-code-generator/package.json
+++ b/suite-native/qr-code-generator/package.json
@@ -1,0 +1,19 @@
+{
+    "name": "@suite-native/qr-code-generator",
+    "version": "1.0.0",
+    "private": true,
+    "license": "See LICENSE.md in repo root",
+    "sideEffects": false,
+    "main": "src/index",
+    "scripts": {
+        "lint:js": "yarn g:eslint '**/*.{ts,tsx,js}'",
+        "test:unit": "jest -c ../../jest.config.base.js --passWithNoTests",
+        "type-check": "tsc --build"
+    },
+    "dependencies": {
+        "@shopify/react-native-skia": "0.1.152",
+        "@types/qrcode": "^1.5.0",
+        "qrcode": "^1.5.1",
+        "react": "^17.0.2"
+    }
+}

--- a/suite-native/qr-code-generator/src/components/QRCode.tsx
+++ b/suite-native/qr-code-generator/src/components/QRCode.tsx
@@ -1,0 +1,73 @@
+// A `qr.js` doesn't handle error level of zero (M) so we need to do it right, thus the deep require.
+import React, { memo, useMemo } from 'react';
+
+import QRCodeAPI from 'qrcode';
+
+import { QRCodeCell } from './QRCodeCell';
+import { QRCodeSurface } from './QRCodeSurface';
+
+// TODO
+// const propTypes = {
+//     bgColor: PropTypes.oneOfType([PropTypes.object, PropTypes.string]),
+//     fgColor: PropTypes.oneOfType([PropTypes.object, PropTypes.string]),
+//     level: PropTypes.string,
+//     size: PropTypes.number,
+//     value: PropTypes.string.isRequired,
+// };
+
+const qrDataToChunks = (inputArray: Uint8Array, chunkSize: number) => {
+    const result = inputArray.reduce((resultArray, item, index) => {
+        const chunkIndex = Math.floor(index / chunkSize);
+
+        if (!resultArray[chunkIndex]) {
+            resultArray[chunkIndex] = []; // start a new chunk
+        }
+
+        resultArray[chunkIndex].push(item as 1 | 2);
+
+        return resultArray;
+    }, [] as Array<Array<1 | 2>>);
+
+    return result;
+};
+
+export const QRCode = memo(
+    ({
+        bgColor = '#FFFFFF',
+        fgColor = '#000000',
+        level = 'L',
+        size = 256,
+        value,
+        ...props
+    }: any) => {
+        const { modules } = useMemo(
+            () => QRCodeAPI.create(value, { errorCorrectionLevel: level }),
+            [value, level],
+        );
+        const cells = useMemo(() => qrDataToChunks(modules.data, modules.size), [modules]);
+        const tileSize = size / cells.length;
+        return (
+            <QRCodeSurface {...props} size={size}>
+                {cells.map((row, rowIndex) =>
+                    row.map((cell, cellIndex) => {
+                        const transformX = Math.round(cellIndex * tileSize);
+                        const transformY = Math.round(rowIndex * tileSize);
+                        const qrItemWidth = Math.round((cellIndex + 1) * tileSize) - transformX;
+                        const qrItemHeight = Math.round((rowIndex + 1) * tileSize) - transformY;
+                        return (
+                            <QRCodeCell
+                                /* eslint-disable react/no-array-index-key */
+                                key={`rectangle-${rowIndex}-${cellIndex}`}
+                                /* eslint-enable react/no-array-index-key */
+                                d={`M 0 0 L ${qrItemWidth} 0 L ${qrItemWidth} ${qrItemHeight} L 0 ${qrItemHeight} Z`}
+                                fill={cell ? fgColor : bgColor}
+                                transformX={transformX}
+                                transformY={transformY}
+                            />
+                        );
+                    }),
+                )}
+            </QRCodeSurface>
+        );
+    },
+);

--- a/suite-native/qr-code-generator/src/components/QRCodeCell.tsx
+++ b/suite-native/qr-code-generator/src/components/QRCodeCell.tsx
@@ -1,0 +1,18 @@
+import React from 'react';
+
+import { Path } from '@shopify/react-native-skia';
+
+type QRCodeCellProps = {
+    d: string;
+    fill: string;
+    transformX: number;
+    transformY: number;
+};
+
+export const QRCodeCell = ({ d, fill, transformX, transformY }: QRCodeCellProps) => (
+    <Path
+        path={d}
+        color={fill}
+        transform={[{ translateX: transformX }, { translateY: transformY }]}
+    />
+);

--- a/suite-native/qr-code-generator/src/components/QRCodeSurface.tsx
+++ b/suite-native/qr-code-generator/src/components/QRCodeSurface.tsx
@@ -1,0 +1,12 @@
+import React from 'react';
+
+import { Canvas } from '@shopify/react-native-skia';
+
+type QRCodeSurfaceProps = {
+    children: React.ReactNode;
+    size: number;
+};
+
+export const QRCodeSurface = ({ children, size }: QRCodeSurfaceProps) => (
+    <Canvas style={{ height: size, width: size }}>{children}</Canvas>
+);

--- a/suite-native/qr-code-generator/src/index.ts
+++ b/suite-native/qr-code-generator/src/index.ts
@@ -1,0 +1,1 @@
+export * from './components/QRCode';

--- a/suite-native/qr-code-generator/tsconfig.json
+++ b/suite-native/qr-code-generator/tsconfig.json
@@ -1,0 +1,5 @@
+{
+    "extends": "../../tsconfig.json",
+    "compilerOptions": { "outDir": "libDev" },
+    "references": []
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -6562,6 +6562,17 @@ __metadata:
   languageName: unknown
   linkType: soft
 
+"@suite-native/qr-code-generator@workspace:suite-native/qr-code-generator":
+  version: 0.0.0-use.local
+  resolution: "@suite-native/qr-code-generator@workspace:suite-native/qr-code-generator"
+  dependencies:
+    "@shopify/react-native-skia": 0.1.152
+    "@types/qrcode": ^1.5.0
+    qrcode: ^1.5.1
+    react: ^17.0.2
+  languageName: unknown
+  linkType: soft
+
 "@suite-native/state@*, @suite-native/state@workspace:suite-native/state":
   version: 0.0.0-use.local
   resolution: "@suite-native/state@workspace:suite-native/state"
@@ -8595,6 +8606,15 @@ __metadata:
   dependencies:
     "@types/react": "*"
   checksum: be256f0192366b4c0822da43c732bf3e29beb954c89d739aa770f09e5160842a3ca4d6814cb57bbcbbf8997cf7af0b998de318dab957f0820f267bb746c9a329
+  languageName: node
+  linkType: hard
+
+"@types/qrcode@npm:^1.5.0":
+  version: 1.5.0
+  resolution: "@types/qrcode@npm:1.5.0"
+  dependencies:
+    "@types/node": "*"
+  checksum: b0ece3834ca5ba6171132928fd1ef764772dc619b45cb4123461ee05e377ad15553a330d234c69db0d0028c6639a99429e88d99192fbba9c5ee97c23f278c48b
   languageName: node
   linkType: hard
 
@@ -14712,6 +14732,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"dijkstrajs@npm:^1.0.1":
+  version: 1.0.2
+  resolution: "dijkstrajs@npm:1.0.2"
+  checksum: 8cd822441a26f190da24d69bfab7b433d080b09e069e41e046ac84e152f182a1ed9478d531b34126e000adaa7b73114a0f85fcac117a7d25b3edf302d57c0d09
+  languageName: node
+  linkType: hard
+
 "dir-compare@npm:^2.4.0":
   version: 2.4.0
   resolution: "dir-compare@npm:2.4.0"
@@ -15301,6 +15328,13 @@ __metadata:
   version: 3.0.0
   resolution: "emojis-list@npm:3.0.0"
   checksum: ddaaa02542e1e9436c03970eeed445f4ed29a5337dfba0fe0c38dfdd2af5da2429c2a0821304e8a8d1cadf27fdd5b22ff793571fa803ae16852a6975c65e8e70
+  languageName: node
+  linkType: hard
+
+"encode-utf8@npm:^1.0.3":
+  version: 1.0.3
+  resolution: "encode-utf8@npm:1.0.3"
+  checksum: 550224bf2a104b1d355458c8a82e9b4ea07f9fc78387bc3a49c151b940ad26473de8dc9e121eefc4e84561cb0b46de1e4cd2bc766f72ee145e9ea9541482817f
   languageName: node
   linkType: hard
 
@@ -26486,6 +26520,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"pngjs@npm:^5.0.0":
+  version: 5.0.0
+  resolution: "pngjs@npm:5.0.0"
+  checksum: 04e912cc45fb9601564e2284efaf0c5d20d131d9b596244f8a6789fc6cdb6b18d2975a6bbf7a001858d7e159d5c5c5dd7b11592e97629b7137f7f5cef05904c8
+  languageName: node
+  linkType: hard
+
 "pnp-webpack-plugin@npm:1.6.4":
   version: 1.6.4
   resolution: "pnp-webpack-plugin@npm:1.6.4"
@@ -27545,6 +27586,20 @@ __metadata:
   peerDependencies:
     react: ^16.8.0 || ^17.0.0 || ^18.0.0
   checksum: 94a2942ecf83f461d869adb20305ae663c6d1abe93ef2c72442b07d756ce70cf6deb6fd588dc5b382b48c6991cfde1dfd5ac9b814c1461e71d5edb2d945e67fc
+  languageName: node
+  linkType: hard
+
+"qrcode@npm:^1.5.1":
+  version: 1.5.1
+  resolution: "qrcode@npm:1.5.1"
+  dependencies:
+    dijkstrajs: ^1.0.1
+    encode-utf8: ^1.0.3
+    pngjs: ^5.0.0
+    yargs: ^15.3.1
+  bin:
+    qrcode: bin/qrcode
+  checksum: 842f899d95caaad2ac507408b5498be3197e1df16bc6b537b20069d2cb1330e4588b50f672ce4a9ccf01338f7c97b5732ff9b5caaa6eb2338187d3c25a973e79
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Less dependencies and also `qrcode` lib that it is using under the hood seems better maintained and better build that that in `react-qr-code`.

![Simulator Screen Shot - iPhone 14 - 2022-10-04 at 17 04 05](https://user-images.githubusercontent.com/5837757/193855633-90250e48-1066-4fe3-97ab-27394b679cc4.png)
