### PR TITLE
chore(connect-popup): remove cookie fallback

### DIFF
--- a/packages/connect-common/src/storage/index.test.ts
+++ b/packages/connect-common/src/storage/index.test.ts
@@ -22,29 +22,6 @@ describe('storage', () => {
         expect(storage.load(storage.BROWSER_KEY)).toBe(false);
     });
 
-    test('window.document.cookie', () => {
-        const org = window.localStorage;
-        // @ts-expect-error, deactivate localStorage
-        delete window.localStorage;
-
-        expect(storage.load(storage.PERMISSIONS_KEY)).toBe(undefined);
-        storage.save(storage.BROWSER_KEY, true);
-        storage.save(storage.PERMISSIONS_KEY, [{ type: 'read' }]);
-
-        expect(storage.load(storage.PERMISSIONS_KEY)).toEqual([{ type: 'read' }]);
-        expect(storage.load(storage.BROWSER_KEY)).toBe(true);
-
-        // @ts-expect-error
-        storage.save(storage.PERMISSIONS_KEY, 'not-array');
-        expect(storage.load(storage.PERMISSIONS_KEY)).toEqual(undefined);
-        // @ts-expect-error
-        storage.save(storage.BROWSER_KEY, 'not-boolean');
-        expect(storage.load(storage.BROWSER_KEY)).toBe(false);
-
-        // restore localStorage
-        window.localStorage = org;
-    });
-
     test('memoryStorage', () => {
         expect(storage.load(storage.PERMISSIONS_KEY, true)).toBe(undefined);
         storage.save(storage.PERMISSIONS_KEY, [], true);

--- a/packages/connect-common/src/storage/index.ts
+++ b/packages/connect-common/src/storage/index.ts
@@ -21,14 +21,6 @@ export function save(storageKey: Key, value: any, temporary = false) {
     }
     try {
         window.localStorage[storageKey] = JSON.stringify(value);
-        return;
-    } catch (ignore) {
-        // empty
-    }
-
-    // Fallback cookie
-    try {
-        window.document.cookie = `${encodeURIComponent(storageKey)}=${JSON.stringify(value)};`;
     } catch (ignore) {
         // empty
     }
@@ -46,23 +38,6 @@ export function load(storageKey: Key, temporary = false): any {
             value = window.localStorage[storageKey];
         } catch (ignore) {
             // empty
-        }
-
-        // Fallback cookie if local storage gives us nothing
-        if (typeof value === 'undefined') {
-            try {
-                const { cookie } = window.document;
-                const prefix = `${encodeURIComponent(storageKey)}=`;
-                const location = cookie.indexOf(prefix);
-                if (location !== -1) {
-                    const matches = /^([^;]+)/.exec(cookie.slice(location));
-                    if (matches) {
-                        value = matches[0].replace(prefix, '');
-                    }
-                }
-            } catch (ignore) {
-                // empty
-            }
         }
     }
 


### PR DESCRIPTION
I believe that this code was never executed in the last couple of years because Local storage has been present in every supported browser.

Maybe @szymonlesisz has some ancient lore why falling back to cookie was needed? 