### PR TITLE
Feat/coinjoin account anonymity in send form

### DIFF
--- a/packages/connect/e2e/__txcache__/gen-reftx.js
+++ b/packages/connect/e2e/__txcache__/gen-reftx.js
@@ -1,4 +1,5 @@
 const BitcoinJs = require('@trezor/utxo-lib');
+const { bufferUtils } = require('@trezor/utils');
 
 // Referenced transaction generator script.
 // Transform bitcoin-like transaction data in to format required by tests of signTransaction method.
@@ -12,17 +13,10 @@ if (!hex) throw new Error('tx hex not provided');
 // Step 2. set network
 const tx = BitcoinJs.Transaction.fromHex(hex, { network: BitcoinJs.networks.testnet });
 
-const reverseBuffer = buf => {
-    const copy = Buffer.alloc(buf.length);
-    buf.copy(copy);
-    [].reverse.call(copy);
-    return copy;
-};
-
 const inputsMap = input => ({
     prev_index: input.index,
     sequence: input.sequence,
-    prev_hash: reverseBuffer(input.hash).toString('hex'),
+    prev_hash: bufferUtils.reverseBuffer(input.hash).toString('hex'),
     script_sig: input.script.toString('hex'),
 });
 

--- a/packages/connect/src/api/bitcoin/inputs.ts
+++ b/packages/connect/src/api/bitcoin/inputs.ts
@@ -2,7 +2,7 @@
 
 import type { ComposedTxInput } from '@trezor/utxo-lib';
 import type { TypedRawTransaction } from '@trezor/blockchain-link';
-import { reverseBuffer } from '../../utils/bufferUtils';
+import { bufferUtils } from '@trezor/utils';
 import { validatePath, isSegwitPath, getScriptType, fixPath } from '../../utils/pathUtils';
 import { convertMultisigPubKey } from '../../utils/hdnodeUtils';
 import { validateParams } from '../common/paramsValidator';
@@ -69,7 +69,7 @@ export const inputToTrezor = (input: ComposedTxInput, sequence: number): PROTO.T
     return {
         address_n,
         prev_index: input.index,
-        prev_hash: reverseBuffer(input.hash).toString('hex'),
+        prev_hash: bufferUtils.reverseBuffer(input.hash).toString('hex'),
         script_type: getScriptType(address_n),
         amount: input.amount,
         sequence,

--- a/packages/connect/src/api/bitcoin/refTx.ts
+++ b/packages/connect/src/api/bitcoin/refTx.ts
@@ -4,7 +4,7 @@ import {
     payments as BitcoinJsPayments,
     Transaction as BitcoinJsTransaction,
 } from '@trezor/utxo-lib';
-import { reverseBuffer } from '../../utils/bufferUtils';
+import { bufferUtils } from '@trezor/utils';
 import { getHDPath, getScriptType, getOutputScriptType } from '../../utils/pathUtils';
 import { validateParams } from '../common/paramsValidator';
 import { TypedError } from '../../constants/errors';
@@ -104,7 +104,7 @@ export const transformOrigTransactions = (
 
             return {
                 address_n,
-                prev_hash: reverseBuffer(input.hash).toString('hex'),
+                prev_hash: bufferUtils.reverseBuffer(input.hash).toString('hex'),
                 prev_index: input.index,
                 script_sig: input.script.toString('hex'),
                 sequence: input.sequence,
@@ -189,7 +189,7 @@ export const transformReferencedTransactions = (
         const inputsMap = (input: BitcoinJsInput) => ({
             prev_index: input.index,
             sequence: input.sequence,
-            prev_hash: reverseBuffer(input.hash).toString('hex'),
+            prev_hash: bufferUtils.reverseBuffer(input.hash).toString('hex'),
             script_sig: input.script.toString('hex'),
         });
 

--- a/packages/connect/src/utils/__tests__/bufferUtils.test.ts
+++ b/packages/connect/src/utils/__tests__/bufferUtils.test.ts
@@ -1,7 +1,0 @@
-import { reverseBuffer } from '../bufferUtils';
-
-describe('utils/bufferUtils', () => {
-    it('reverseBuffer', () => {
-        expect(reverseBuffer(Buffer.from('abcd', 'hex'))).toEqual(Buffer.from('cdab', 'hex'));
-    });
-});

--- a/packages/connect/src/utils/bufferUtils.ts
+++ b/packages/connect/src/utils/bufferUtils.ts
@@ -1,8 +1,0 @@
-// origin: https://github.com/trezor/connect/blob/develop/src/js/utils/bufferUtils.js
-
-export const reverseBuffer = (buf: Buffer) => {
-    const copy = Buffer.alloc(buf.length);
-    buf.copy(copy);
-    [].reverse.call(copy);
-    return copy;
-};

--- a/packages/suite/src/actions/wallet/__tests__/coinjoinAccountActions.test.ts
+++ b/packages/suite/src/actions/wallet/__tests__/coinjoinAccountActions.test.ts
@@ -69,7 +69,7 @@ describe('coinjoinAccountActions', () => {
             const store = initStore(initialState);
             TrezorConnect.setTestFixtures(f.connect);
 
-            await store.dispatch(coinjoinAccountActions.createCoinjoinAccount(f.params as any)); // params are incomplete
+            await store.dispatch(coinjoinAccountActions.createCoinjoinAccount(f.params as any, 80)); // params are incomplete
 
             const actions = store.getActions();
             expect(actions.length).toBe(f.result.actions.length);

--- a/packages/suite/src/actions/wallet/coinjoinAccountActions.ts
+++ b/packages/suite/src/actions/wallet/coinjoinAccountActions.ts
@@ -9,10 +9,18 @@ import { Network } from '@suite-common/wallet-config';
 import { Account, CoinjoinSessionParameters } from '@suite-common/wallet-types';
 import { accountsActions, transactionsActions } from '@suite-common/wallet-core';
 
-const coinjoinAccountCreate = (account: Account) =>
+const coinjoinAccountCreate = (account: Account, targetAnonymity: number) =>
     ({
         type: COINJOIN.ACCOUNT_CREATE,
         account,
+        targetAnonymity,
+    } as const);
+
+const coinjoinAccountUpdateAnonymity = (key: string, targetAnonymity: number) =>
+    ({
+        type: COINJOIN.ACCOUNT_UPDATE_TARGET_ANONYMITY,
+        key,
+        targetAnonymity,
     } as const);
 
 const coinjoinAccountAuthorize = (account: Account) =>
@@ -43,6 +51,7 @@ const coinjoinAccountUnregister = (account: Account) =>
 
 export type CoinjoinAccountAction =
     | ReturnType<typeof coinjoinAccountCreate>
+    | ReturnType<typeof coinjoinAccountUpdateAnonymity>
     | ReturnType<typeof coinjoinAccountAuthorize>
     | ReturnType<typeof coinjoinAccountAuthorizeSuccess>
     | ReturnType<typeof coinjoinAccountAuthorizeFailed>
@@ -124,7 +133,8 @@ export const fetchAndUpdateAccount =
     };
 
 export const createCoinjoinAccount =
-    (network: Network) => async (dispatch: Dispatch, getState: GetState) => {
+    (network: Network, targetAnonymity: number) =>
+    async (dispatch: Dispatch, getState: GetState) => {
         if (network.accountType !== 'coinjoin') {
             throw new Error('createCoinjoinAccount: invalid account type');
         }
@@ -208,7 +218,7 @@ export const createCoinjoinAccount =
                 },
             ),
         );
-        dispatch(coinjoinAccountCreate(account.payload));
+        dispatch(coinjoinAccountCreate(account.payload, targetAnonymity));
 
         // switch to account
         dispatch(

--- a/packages/suite/src/actions/wallet/constants/coinjoinConstants.ts
+++ b/packages/suite/src/actions/wallet/constants/coinjoinConstants.ts
@@ -1,4 +1,5 @@
 export const ACCOUNT_CREATE = '@coinjoin/account-create';
+export const ACCOUNT_UPDATE_TARGET_ANONYMITY = '@coinjoin/account-update-target-anonymity';
 export const ACCOUNT_AUTHORIZE = '@coinjoin/account-authorize';
 export const ACCOUNT_AUTHORIZE_SUCCESS = '@coinjoin/account-authorize-success';
 export const ACCOUNT_AUTHORIZE_FAILED = '@coinjoin/account-authorize-failed';

--- a/packages/suite/src/components/suite/modals/AddAccount/components/AddCoinJoinAccountButton.tsx
+++ b/packages/suite/src/components/suite/modals/AddAccount/components/AddCoinJoinAccountButton.tsx
@@ -67,7 +67,7 @@ export const AddCoinJoinAccountButton = ({ network }: AddCoinJoinAccountProps) =
             // When Tor was not loaded it means there was an error or user canceled it, stop the coinjoin account activation.
             if (!isTorLoaded) return;
         }
-        action.createCoinjoinAccount(network);
+        action.createCoinjoinAccount(network, 80);
     };
 
     const isDisabled = coinjoinAccounts.length > 0;

--- a/packages/suite/src/hooks/wallet/__tests__/useSendForm.test.tsx
+++ b/packages/suite/src/hooks/wallet/__tests__/useSendForm.test.tsx
@@ -35,10 +35,17 @@ interface Args {
     send?: Partial<SendState>;
     fees?: any;
     selectedAccount?: any;
+    coinjoin?: any;
     bitcoinAmountUnit?: PROTO.AmountUnit;
 }
 
-export const getInitialState = ({ send, fees, selectedAccount, bitcoinAmountUnit }: Args = {}) => ({
+export const getInitialState = ({
+    send,
+    fees,
+    selectedAccount,
+    coinjoin,
+    bitcoinAmountUnit,
+}: Args = {}) => ({
     ...fixtures.DEFAULT_STORE,
     wallet: {
         ...fixtures.DEFAULT_STORE.wallet,
@@ -51,6 +58,10 @@ export const getInitialState = ({ send, fees, selectedAccount, bitcoinAmountUnit
             ...fees,
         },
         selectedAccount: selectedAccount ?? fixtures.DEFAULT_STORE.wallet.selectedAccount,
+        coinjoin: {
+            ...fixtures.DEFAULT_STORE.wallet.coinjoin,
+            ...coinjoin,
+        },
         settings: {
             ...fixtures.DEFAULT_STORE.wallet.settings,
             bitcoinAmountUnit:
@@ -125,9 +136,19 @@ const actionCallback = (
 
     // validate '@trezor/connect' params
     if (result.composeTransactionParams) {
-        expect(TrezorConnect.composeTransaction).toHaveBeenLastCalledWith(
-            expect.objectContaining(result.composeTransactionParams),
-        );
+        if (result.composeTransactionParams.account) {
+            expect(TrezorConnect.composeTransaction).toHaveBeenLastCalledWith(
+                expect.objectContaining({
+                    account: expect.objectContaining({
+                        utxo: expect.arrayContaining(result.composeTransactionParams.account.utxo),
+                    }),
+                }),
+            );
+        } else {
+            expect(TrezorConnect.composeTransaction).toHaveBeenLastCalledWith(
+                expect.objectContaining(result.composeTransactionParams),
+            );
+        }
     }
     if (result.estimateFeeParams) {
         expect(TrezorConnect.blockchainEstimateFee).toHaveBeenLastCalledWith(

--- a/packages/suite/src/reducers/wallet/coinjoinReducer.ts
+++ b/packages/suite/src/reducers/wallet/coinjoinReducer.ts
@@ -55,6 +55,7 @@ const createSession = (
         timeCreated: Date.now(),
         // phase: 0,
         deadline: Date.now(),
+        registeredUtxos: [],
         signedRounds: [],
     };
 };

--- a/packages/suite/src/views/wallet/send/index.tsx
+++ b/packages/suite/src/views/wallet/send/index.tsx
@@ -51,6 +51,7 @@ const SendLoaded: React.FC<UseSendFormProps> = ({ children, ...props }) => {
 const Send: React.FC = ({ children }) => {
     const props = useSelector(state => ({
         selectedAccount: state.wallet.selectedAccount,
+        coinjoinAccounts: state.wallet.coinjoin.accounts,
         fiat: state.wallet.fiat,
         localCurrency: state.wallet.settings.localCurrency,
         fees: state.wallet.fees,
@@ -59,15 +60,21 @@ const Send: React.FC = ({ children }) => {
         metadataEnabled: state.metadata.enabled && !!state.metadata.provider,
     }));
 
-    const { selectedAccount } = props;
+    const { selectedAccount, coinjoinAccounts } = props;
 
     if (selectedAccount.status !== 'loaded') {
         return <WalletLayout title="TR_NAV_SEND" account={selectedAccount} />;
     }
 
+    // find coinjoin account related to current account
+    const coinjoinAccount =
+        selectedAccount.account.accountType === 'coinjoin'
+            ? coinjoinAccounts.find(a => a.key === selectedAccount.account.key)
+            : undefined;
+
     /* children are only for test purposes, this prop is not available in regular build */
     return (
-        <SendLoaded {...props} selectedAccount={selectedAccount}>
+        <SendLoaded {...props} selectedAccount={selectedAccount} coinjoinAccount={coinjoinAccount}>
             {children}
         </SendLoaded>
     );

--- a/packages/utils/CHANGELOG.md
+++ b/packages/utils/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 9.0.3
+
+-   add `bufferUtils.reverseBuffer`
+
 # 1.0.1
 
 -   add `arrayToDictionary`, `arrayDistinct`, `isNotUndefined`, `objectPartition`, `throwError` utilities.

--- a/packages/utils/src/bufferUtils.ts
+++ b/packages/utils/src/bufferUtils.ts
@@ -1,0 +1,11 @@
+export const reverseBuffer = (src: Buffer) => {
+    if (src.length < 1) return src;
+    const buffer = Buffer.alloc(src.length);
+    let j = buffer.length - 1;
+    for (let i = 0; i < buffer.length / 2; i++) {
+        buffer[i] = src[j];
+        buffer[j] = src[i];
+        j--;
+    }
+    return buffer;
+};

--- a/packages/utils/src/index.ts
+++ b/packages/utils/src/index.ts
@@ -2,6 +2,7 @@ export * from './createDeferred';
 export * from './arrayDistinct';
 export * from './arrayPartition';
 export * from './arrayToDictionary';
+export * as bufferUtils from './bufferUtils';
 export * from './bytesToHumanReadable';
 export * from './mergeObject';
 export * from './getWeakRandomId';

--- a/packages/utils/tests/bufferUtils.test.ts
+++ b/packages/utils/tests/bufferUtils.test.ts
@@ -1,0 +1,16 @@
+import { reverseBuffer } from '../src/bufferUtils';
+
+describe('bufferUtils', () => {
+    it('reverseBuffer', () => {
+        expect(reverseBuffer(Buffer.from('abcd', 'hex'))).toEqual(Buffer.from('cdab', 'hex'));
+
+        expect(
+            reverseBuffer(
+                Buffer.from(
+                    '0dac366fd8a67b2a89fbb0d31086e7acded7a5bbf9ef9daa935bc873229ef5b5',
+                    'hex',
+                ),
+            ).toString('hex'),
+        ).toEqual('b5f59e2273c85b93aa9deff9bba5d7deace78610d3b0fb892a7ba6d86f36ac0d');
+    });
+});

--- a/packages/utxo-lib/src/bufferutils.ts
+++ b/packages/utxo-lib/src/bufferutils.ts
@@ -11,6 +11,7 @@ import * as pushdata from 'pushdata-bitcoin';
 import * as varuint from 'varuint-bitcoin';
 import { Int64LE } from 'int64-buffer';
 import * as typeforce from 'typeforce';
+import { bufferUtils } from '@trezor/utils';
 import * as types from './types';
 
 export function verifuint(value: number, max: number) {
@@ -92,18 +93,6 @@ export function writeVarInt(buffer: Buffer, number: number, offset: number) {
     return varuint.encode.bytes;
 }
 
-export function reverseBuffer(src: Buffer): Buffer {
-    if (src.length < 1) return src;
-    const buffer = Buffer.alloc(src.length);
-    let j = buffer.length - 1;
-    for (let i = 0; i < buffer.length / 2; i++) {
-        buffer[i] = src[j];
-        buffer[j] = src[i];
-        j--;
-    }
-    return buffer;
-}
-
 export function cloneBuffer(buffer: Buffer): Buffer {
     const clone = Buffer.allocUnsafe(buffer.length);
     buffer.copy(clone);
@@ -135,6 +124,7 @@ export const readPushDataInt: ReadPushDataInt = pushdata.decode;
 // export const varIntBuffer = varuint.encode; // TODO: not-used
 export const varIntSize = varuint.encodingLength;
 export const writePushDataInt: WritePushDataInt = pushdata.encode;
+export const { reverseBuffer } = bufferUtils;
 
 /**
  * Helper class for serialization of bitcoin data types into a pre-allocated buffer.

--- a/suite-common/wallet-types/src/coinjoin.ts
+++ b/suite-common/wallet-types/src/coinjoin.ts
@@ -17,6 +17,7 @@ export enum RoundPhase {
 }
 
 export interface CoinjoinSession extends CoinjoinSessionParameters {
+    registeredUtxos: string[]; // list of utxos (outpoints) registered in session
     timeCreated: number; // timestamp when was created
     timeEnded?: number; // timestamp when was finished
     phase?: RoundPhase; // current phase enum

--- a/suite-common/wallet-types/src/coinjoin.ts
+++ b/suite-common/wallet-types/src/coinjoin.ts
@@ -26,6 +26,7 @@ export interface CoinjoinSession extends CoinjoinSessionParameters {
 
 export interface CoinjoinAccount {
     key: string; // reference to wallet Account.key
+    targetAnonymity: number; // anonymity set by the user
     session?: CoinjoinSession; // current/active authorized session
     previousSessions: CoinjoinSession[]; // history
 }

--- a/suite-common/wallet-types/src/sendForm.ts
+++ b/suite-common/wallet-types/src/sendForm.ts
@@ -47,6 +47,7 @@ export type FormState = {
 // local state of @wallet-hooks/useSendForm
 export type UseSendFormState = {
     account: Account;
+    excludedUtxos: Record<string, 'mixing' | 'low-anonymity' | 'dust' | 'unconfirmed' | undefined>;
     network: Network;
     coinFees: FeeInfo;
     feeInfo: FeeInfo;

--- a/suite-common/wallet-utils/src/__tests__/accountUtils.test.ts
+++ b/suite-common/wallet-utils/src/__tests__/accountUtils.test.ts
@@ -19,6 +19,8 @@ import {
     networkAmountToSatoshi,
     parseBIP44Path,
     sortByCoin,
+    getUtxoOutpoint,
+    readUtxoOutpoint,
 } from '../accountUtils';
 import * as fixtures from '../__fixtures__/accountUtils';
 
@@ -248,5 +250,22 @@ describe('account utils', () => {
         expect(hasNetworkFeatures(ethAcc, 'tokens')).toEqual(true);
         expect(hasNetworkFeatures(ethAcc, 'amount-unit')).toEqual(false);
         expect(hasNetworkFeatures(ethAcc, ['amount-unit', 'sign-verify'])).toEqual(false);
+    });
+
+    it('getUtxoOutpoint/readUtxoOutpoint', () => {
+        expect(
+            getUtxoOutpoint({
+                txid: '0dac366fd8a67b2a89fbb0d31086e7acded7a5bbf9ef9daa935bc873229ef5b5',
+                vout: 1,
+            }),
+        ).toEqual('b5f59e2273c85b93aa9deff9bba5d7deace78610d3b0fb892a7ba6d86f36ac0d01000000');
+        expect(
+            readUtxoOutpoint(
+                'b5f59e2273c85b93aa9deff9bba5d7deace78610d3b0fb892a7ba6d86f36ac0d01000000',
+            ),
+        ).toEqual({
+            txid: '0dac366fd8a67b2a89fbb0d31086e7acded7a5bbf9ef9daa935bc873229ef5b5',
+            vout: 1,
+        });
     });
 });

--- a/suite-common/wallet-utils/src/accountUtils.ts
+++ b/suite-common/wallet-utils/src/accountUtils.ts
@@ -1,6 +1,7 @@
 import BigNumber from 'bignumber.js';
 
 import { AccountInfo, AccountAddresses, AccountAddress } from '@trezor/connect';
+import { bufferUtils } from '@trezor/utils';
 import {
     networksCompatibility as NETWORKS,
     Network,
@@ -783,4 +784,21 @@ export const hasNetworkFeatures = (
         .every(feature => networkFeatures.includes(feature));
 
     return areFeaturesPresent;
+};
+
+// https://developer.bitcoin.org/reference/transactions.html#outpoint-the-specific-part-of-a-specific-output
+export const getUtxoOutpoint = (utxo: { txid: string; vout: number }) => {
+    const hash = bufferUtils.reverseBuffer(Buffer.from(utxo.txid, 'hex'));
+    const buffer = Buffer.allocUnsafe(36);
+    hash.copy(buffer);
+    buffer.writeUInt32LE(utxo.vout, hash.length);
+    return buffer.toString('hex');
+};
+
+// https://developer.bitcoin.org/reference/transactions.html#outpoint-the-specific-part-of-a-specific-output
+export const readUtxoOutpoint = (outpoint: string) => {
+    const buffer = Buffer.from(outpoint, 'hex');
+    const txid = bufferUtils.reverseBuffer(buffer.slice(0, 32));
+    const vout = buffer.readUInt32LE(txid.length);
+    return { txid: txid.toString('hex'), vout };
 };


### PR DESCRIPTION
*Edit*

To create and use `getUtxoOutpoint` and `readUtxoOutpoint` utilities (3rd commit) i needed to move `buferUtils.reverseBuffer` utility from @trezor/connect and @trezor/utxo-lib into shared @trezor/utils (first two commits) @mroz22 

- `CoinjoinAccount.targetAnonymity` should be set on account creation and  and might be changed later using `coinjoinAccountActions.coinjoinAccountUpdateAnonymity` @matejkriz 
- `CoinjoinSession.registeredUtxos` should be used to determine which utxos are currently registred in coinjoin @dahaca 
- `excludedUtxo` prop should be used in `CoinControl` component @komret 



