### PR TITLE
Fix daily sum with joint transactions

### DIFF
--- a/suite-common/wallet-utils/src/transactionUtils.ts
+++ b/suite-common/wallet-utils/src/transactionUtils.ts
@@ -110,7 +110,7 @@ export const sumTransactions = (transactions: WalletAccountTransaction[]) => {
             totalAmount = totalAmount.minus(amount);
             totalAmount = totalAmount.minus(fee);
         }
-        if (tx.type === 'recv') {
+        if (tx.type === 'recv' || tx.type === 'joint') {
             totalAmount = totalAmount.plus(amount);
         }
         if (tx.type === 'failed') {
@@ -154,7 +154,7 @@ export const sumTransactionsFiat = (
             );
             totalAmount = totalAmount.minus(toFiatCurrency(fee, fiatCurrency, tx.rates, -1) ?? 0);
         }
-        if (tx.type === 'recv') {
+        if (tx.type === 'recv' || tx.type === 'joint') {
             totalAmount = totalAmount.plus(toFiatCurrency(amount, fiatCurrency, tx.rates, -1) ?? 0);
         }
         if (tx.type === 'failed') {


### PR DESCRIPTION
## Description

New `joint` transactions are now correctly taken into account when displaying daily sums (both crypto and fiat) in transaction list.

![image](https://user-images.githubusercontent.com/26326960/194047868-b653a48d-71c7-4588-9232-04fd62f88b03.png)

## Screenshots
![Screenshot 2022-10-05 at 9 09 18 (1)](https://user-images.githubusercontent.com/216917/194049176-8b91e8ba-b13a-42b9-87aa-8bc446316c36.png)
![Screenshot 2022-10-05 at 9 07 04](https://user-images.githubusercontent.com/216917/194049187-83c97abf-918d-4054-8abe-48346289331b.png)

