### PR TITLE
fix(suite): fix inconsistent state when user switch wallets with default accounts closed

### DIFF
--- a/packages/suite/src/components/wallet/AccountsMenu/AccountGroup.tsx
+++ b/packages/suite/src/components/wallet/AccountsMenu/AccountGroup.tsx
@@ -64,7 +64,7 @@ export const AccountGroup = forwardRef(
         const theme = useTheme();
         const wrapperRef = useRef<HTMLDivElement>(null);
         const [isOpen, setIsOpen] = useState(props.hasBalance || props.keepOpen);
-        const [previouslyOpen, setPreviouslyOpen] = useState(isOpen);
+        const [previouslyOpen, setPreviouslyOpen] = useState(isOpen); // used to follow props changes without unnecessary rerenders
         const [animatedIcon, setAnimatedIcon] = useState(false);
 
         // follow props change (example: add new coin/account which has balance but group is closed)
@@ -74,7 +74,8 @@ export const AccountGroup = forwardRef(
         }
 
         const onClick = () => {
-            setIsOpen(previous => !previous);
+            setIsOpen(!isOpen);
+            setPreviouslyOpen(!isOpen);
             setAnimatedIcon(true);
         };
 

--- a/packages/suite/src/components/wallet/AccountsMenu/index.tsx
+++ b/packages/suite/src/components/wallet/AccountsMenu/index.tsx
@@ -206,7 +206,7 @@ export const AccountsMenu = ({ isMenuInline }: AccountsMenuProps) => {
 
         return (
             <AccountGroup
-                key={type}
+                key={`${device.state}-${type}`}
                 type={type}
                 hasBalance={groupHasBalance}
                 keepOpen={keepOpen(type) || (!!searchString && searchString.length > 0)}


### PR DESCRIPTION

<!--- Provide a general summary of your changes in the Title above -->

## Description

It is possible to get in inconsistent state where you have Default accounts group closed but without arrow to open it (see screenshot)

Steps to reproduce:
1. discover two wallets (e.g. standard one and 1 hidden)
2. select non-default account (e.g. taproot)
3. close default accounts group by clicking on carret
4. switch to the other wallet 

## Related Issue

Fix bug from implementation of https://github.com/trezor/trezor-suite/issues/5873

## Screenshots (if appropriate):
bug state:
![image](https://user-images.githubusercontent.com/3729633/194099832-a4192a5f-e72c-47ac-a8d6-2c7272e8fce6.png)

