### PR TITLE
feat(suite): Coinjoin account info selector

### DIFF
--- a/packages/suite/src/components/wallet/CoinjoinSummary/BalancePrivacyBreakdown.tsx
+++ b/packages/suite/src/components/wallet/CoinjoinSummary/BalancePrivacyBreakdown.tsx
@@ -2,10 +2,14 @@ import React from 'react';
 import styled from 'styled-components';
 import { useTheme } from '@trezor/components';
 import { isZero } from '@suite-common/wallet-utils';
-import { SelectedAccountLoaded } from '@suite-common/wallet-types';
 import { Translation } from '@suite-components/Translation';
 import { useSelector } from '@suite-hooks';
 import { CryptoAmountWithHeader } from '@wallet-components/PrivacyAccount/CryptoAmountWithHeader';
+import {
+    selectCurrentCoinjoinBalanceBreakdown,
+    selectCurrentCoinjoinSession,
+} from '@wallet-reducers/coinjoinReducer';
+import { selectSelectedAccount } from '@wallet-reducers/selectedAccountReducer';
 
 const Container = styled.div<{ isSessionRunning: boolean }>`
     display: flex;
@@ -14,26 +18,29 @@ const Container = styled.div<{ isSessionRunning: boolean }>`
     max-width: ${({ isSessionRunning }) => (isSessionRunning ? '480px' : '400px')};
 `;
 
-export const FundsPrivacyBreakdown = () => {
-    const currentAccount = useSelector(
-        state => state.wallet.selectedAccount,
-    ) as SelectedAccountLoaded;
+export const BalancePrivacyBreakdown = () => {
+    const currentAccount = useSelector(selectSelectedAccount);
+    const balanceBreakdown = useSelector(selectCurrentCoinjoinBalanceBreakdown);
+    const currentSession = useSelector(selectCurrentCoinjoinSession);
 
     const theme = useTheme();
 
-    const notPrivateAmount = '0.00055';
-    const anonymizingAmount = '0.0001';
-    const privateAmount = '0.00003';
+    const notPrivateAmount = balanceBreakdown.notAnonymized;
+    const privateAmount = balanceBreakdown.anonymized;
 
-    const isSessionRunning = true;
+    const isSessionRunning = !!currentSession;
+
+    if (!currentAccount) {
+        return null;
+    }
 
     return (
         <Container isSessionRunning={isSessionRunning}>
             <CryptoAmountWithHeader
                 header={<Translation id="TR_NOT_PRIVATE" />}
                 headerIcon="CROSS"
-                value={privateAmount}
-                symbol={currentAccount?.account.symbol}
+                value={notPrivateAmount}
+                symbol={currentAccount?.symbol}
                 color={!isZero(notPrivateAmount || '0') ? undefined : theme.TYPE_LIGHT_GREY}
             />
 
@@ -41,8 +48,8 @@ export const FundsPrivacyBreakdown = () => {
                 <CryptoAmountWithHeader
                     header={<Translation id="TR_ANONYMIZING" />}
                     headerIcon="SHUFFLE"
-                    value={anonymizingAmount}
-                    symbol={currentAccount?.account.symbol}
+                    value={balanceBreakdown.anonymizing}
+                    symbol={currentAccount?.symbol}
                 />
             )}
 
@@ -50,7 +57,7 @@ export const FundsPrivacyBreakdown = () => {
                 header={<Translation id="TR_PRIVATE" />}
                 headerIcon="EYE_CLOSED"
                 value={privateAmount}
-                symbol={currentAccount?.account.symbol}
+                symbol={currentAccount?.symbol}
                 color={!isZero(privateAmount || '0') ? theme.TYPE_GREEN : theme.TYPE_LIGHT_GREY}
             />
         </Container>

--- a/packages/suite/src/components/wallet/CoinjoinSummary/BalanceSection.tsx
+++ b/packages/suite/src/components/wallet/CoinjoinSummary/BalanceSection.tsx
@@ -6,7 +6,7 @@ import { Account, CoinjoinSession } from '@suite-common/wallet-types';
 import { Card, Translation } from '@suite-components';
 import { useActions, useSelector } from '@suite-hooks';
 import { Button } from '@trezor/components';
-import { FundsPrivacyBreakdown } from './FundsPrivacyBreakdown';
+import { BalancePrivacyBreakdown } from './BalancePrivacyBreakdown';
 import { CoinjoinStatus } from './CoinjoinStatus';
 
 const Container = styled(Card)`
@@ -52,7 +52,7 @@ export const BalanceSection = ({ account }: BalanceSectionProps) => {
 
     return (
         <Container>
-            <FundsPrivacyBreakdown />
+            <BalancePrivacyBreakdown />
 
             {session ? (
                 <CoinjoinStatus session={session} />

--- a/packages/suite/src/components/wallet/PrivacyAccount/AnonymityIndicator.tsx
+++ b/packages/suite/src/components/wallet/PrivacyAccount/AnonymityIndicator.tsx
@@ -1,6 +1,8 @@
 import React from 'react';
 import styled from 'styled-components';
 import { Icon, variables } from '@trezor/components';
+import { useSelector } from '@suite-hooks/useSelector';
+import { selectCurrentTargetAnonymity } from '@wallet-reducers/coinjoinReducer';
 
 const Container = styled.div`
     display: flex;
@@ -31,14 +33,14 @@ interface AnonymityIndicatorProps {
 }
 
 export const AnonymityIndicator = ({ className }: AnonymityIndicatorProps) => {
-    const anomymityLevel = 10;
+    const targetAnonymity = useSelector(selectCurrentTargetAnonymity);
 
     return (
         <Container className={className}>
             <Icon icon="USERS" />
 
             <div>
-                <p>{`1 in ${anomymityLevel}`}</p>
+                <p>{`1 in ${targetAnonymity}`}</p>
                 <AnonymityStatus>{AnomymityStatus.Good}</AnonymityStatus>
             </div>
         </Container>

--- a/packages/suite/src/components/wallet/PrivacyAccount/CryptoAmountWithHeader.tsx
+++ b/packages/suite/src/components/wallet/PrivacyAccount/CryptoAmountWithHeader.tsx
@@ -4,6 +4,7 @@ import { Icon, IconType, variables } from '@trezor/components';
 import { FiatValue } from '@suite-components/FiatValue';
 import { FormattedCryptoAmount } from '@suite-components/FormattedCryptoAmount';
 import { NetworkSymbol } from '@wallet-types';
+import { formatNetworkAmount } from '@suite-common/wallet-utils';
 
 const Container = styled.div`
     display: flex;
@@ -60,7 +61,7 @@ export const CryptoAmountWithHeader = ({
             {headerIcon && <HeaderIcon icon={headerIcon} size={14} />} {header}
         </Header>
 
-        <CryptoAmount value={value} symbol={symbol} color={color} />
+        <CryptoAmount value={formatNetworkAmount(value, symbol)} symbol={symbol} color={color} />
         <FiatValue amount={value} symbol={symbol} showApproximationIndicator />
 
         {note && <Note>{note}</Note>}

--- a/packages/suite/src/reducers/wallet/selectedAccountReducer.ts
+++ b/packages/suite/src/reducers/wallet/selectedAccountReducer.ts
@@ -4,6 +4,12 @@ import type { SelectedAccountStatus } from '@suite-common/wallet-types';
 
 export type State = SelectedAccountStatus;
 
+export type SelectedAccountRootState = {
+    wallet: {
+        selectedAccount: SelectedAccountStatus;
+    };
+};
+
 export const initialState: State = {
     status: 'none',
 };
@@ -13,5 +19,8 @@ const selectedAccountReducer = (state: State = initialState, action: Action): St
     if (accountsActions.disposeAccount.match(action)) return initialState;
     return state;
 };
+
+export const selectSelectedAccount = (state: SelectedAccountRootState) =>
+    state.wallet.selectedAccount.account;
 
 export default selectedAccountReducer;

--- a/packages/suite/src/utils/wallet/__tests__/coinjoinUtils.test.ts
+++ b/packages/suite/src/utils/wallet/__tests__/coinjoinUtils.test.ts
@@ -1,0 +1,62 @@
+import * as coinjoinUtils from '../coinjoinUtils';
+
+describe('breakdownCoinjoinBalance', () => {
+    const commonUtxo = {
+        vout: 1,
+        amount: '100',
+        blockHeight: 100,
+        path: 'string',
+        confirmations: 100,
+    };
+
+    const params: Parameters<typeof coinjoinUtils.breakdownCoinjoinBalance>[0] = {
+        targetAnonymity: 80,
+        anonymitySet: {
+            one: 1,
+            two: 100,
+            three: 30,
+        },
+        utxos: [
+            {
+                txid: '1',
+                address: 'one',
+                ...commonUtxo,
+            },
+            {
+                txid: '2',
+                address: 'two',
+                ...commonUtxo,
+            },
+            {
+                txid: '0dac366fd8a67b2a89fbb0d31086e7acded7a5bbf9ef9daa935bc873229ef5b5',
+                address: 'three',
+                ...commonUtxo,
+            },
+        ],
+    };
+
+    it('works without session', () => {
+        const breakdown = coinjoinUtils.breakdownCoinjoinBalance(params);
+
+        expect(breakdown).toEqual({
+            notAnonymized: '200',
+            anonymizing: '0',
+            anonymized: '100',
+        });
+    });
+
+    it('works with session', () => {
+        const breakdown = coinjoinUtils.breakdownCoinjoinBalance({
+            ...params,
+            registeredUtxos: [
+                'b5f59e2273c85b93aa9deff9bba5d7deace78610d3b0fb892a7ba6d86f36ac0d01000000',
+            ],
+        });
+
+        expect(breakdown).toEqual({
+            notAnonymized: '100',
+            anonymizing: '100',
+            anonymized: '100',
+        });
+    });
+});

--- a/packages/suite/src/utils/wallet/coinjoinUtils.ts
+++ b/packages/suite/src/utils/wallet/coinjoinUtils.ts
@@ -1,0 +1,56 @@
+import BigNumber from 'bignumber.js';
+import { getUtxoOutpoint } from '@suite-common/wallet-utils';
+import { Account } from '@suite-common/wallet-types';
+
+export type CoinjoinBalanceBreakdown = {
+    notAnonymized: string;
+    anonymizing: string;
+    anonymized: string;
+};
+
+/**
+ * Breaks down account balance based on anonymity status
+ */
+export const breakdownCoinjoinBalance = ({
+    targetAnonymity,
+    anonymitySet,
+    utxos,
+    registeredUtxos,
+}: {
+    targetAnonymity: number | undefined;
+    anonymitySet: Record<string, number | undefined> | undefined;
+    utxos: Account['utxo'];
+    registeredUtxos?: string[];
+}): CoinjoinBalanceBreakdown => {
+    const balanceBreakdown = {
+        notAnonymized: '0',
+        anonymizing: '0',
+        anonymized: '0',
+    };
+
+    if (!anonymitySet || targetAnonymity === undefined || !utxos) {
+        return balanceBreakdown;
+    }
+
+    utxos?.forEach(({ address, amount, txid, vout }) => {
+        const outpoint = getUtxoOutpoint({ txid, vout });
+        const bigAmount = new BigNumber(amount);
+        const { notAnonymized, anonymizing, anonymized } = balanceBreakdown;
+
+        if (registeredUtxos?.includes(outpoint)) {
+            const newAnonymizing = new BigNumber(anonymizing).plus(bigAmount);
+
+            balanceBreakdown.anonymizing = newAnonymizing.toString();
+        } else if ((anonymitySet[address] || 0) < targetAnonymity) {
+            const newNotAnonymized = new BigNumber(notAnonymized).plus(bigAmount);
+
+            balanceBreakdown.notAnonymized = newNotAnonymized.toString();
+        } else if ((anonymitySet[address] || 0) >= targetAnonymity) {
+            const newAnonymized = new BigNumber(anonymized).plus(bigAmount);
+
+            balanceBreakdown.anonymized = newAnonymized.toString();
+        }
+    });
+
+    return balanceBreakdown;
+};


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Added a `useCoinjoinAccountInfo` hook for accessing Coinjoin info, especially the funds anonymity status info. The `breakdownCoinjoinFunds()` util can be used outside of react components.

prerequisite for [#6205](https://github.com/trezor/trezor-suite/issues/6205)

