### PR TITLE
Revert "chore(suite-desktop): specify desktop app lang to avoid usele…

### DIFF
--- a/packages/suite-desktop/package.json
+++ b/packages/suite-desktop/package.json
@@ -147,13 +147,6 @@
                     "to": "bin/tor"
                 }
             ],
-            "electronLanguages": [
-                "en",
-                "es",
-                "cs",
-                "ja",
-                "ru"
-            ],
             "icon": "build/static/images/desktop/512x512.icns",
             "artifactName": "Trezor-Suite-${version}-mac-${arch}.${ext}",
             "hardenedRuntime": true,

--- a/packages/suite/src/config/suite/languages.ts
+++ b/packages/suite/src/config/suite/languages.ts
@@ -1,6 +1,5 @@
 export const TRANSLATION_PSEUDOLANGUAGE = 'lol' as const;
 
-// After marking a language complete, add this language also to suite-desktop/package.json -> electronLanguages array
 const LANGUAGES = {
     en: { name: 'English', en: 'English', complete: true },
     es: { name: 'Español', en: 'Spanish', complete: true },


### PR DESCRIPTION
## Description

This reverts commit 7af22e5fd1ebf674040f9e8b321f414023ccd333.

## Related Issue

#6492

## Screenshots (if appropriate):
<img width="316" alt="Screenshot 2022-10-10 at 9 54 22" src="https://user-images.githubusercontent.com/33235762/194820501-dbc38aac-c633-4463-8939-e2c39c2f8054.png">
