### PR TITLE
chore(tests): remove problematic timezone test

### DIFF
--- a/suite-common/suite-utils/src/__tests__/date.test.ts
+++ b/suite-common/suite-utils/src/__tests__/date.test.ts
@@ -1,10 +1,6 @@
 import { formatDuration, formatDurationStrict } from '../date';
 
 describe('Date utils', () => {
-    test('timezone should always be UTC', () => {
-        expect(new Date().getTimezoneOffset()).toBe(0);
-    });
-
     test('format duration', () => {
         expect(formatDuration(1)).toBe('less than 5 seconds');
         expect(formatDuration(3600)).toBe('about 1 hour');


### PR DESCRIPTION
It doesn't make sense to test this, it's native functionality and test will fail for everyone who are not in UTC timezone.