### PR TITLE
fix(suite): fix display of data in review of ETH transaction

### DIFF
--- a/packages/suite/src/components/suite/modals/ReviewTransaction/components/Output.tsx
+++ b/packages/suite/src/components/suite/modals/ReviewTransaction/components/Output.tsx
@@ -52,9 +52,6 @@ const Output = (props: Props) => {
     if (type === 'opreturn') {
         outputLabel = <Translation id="OP_RETURN" />;
     }
-    if (type === 'data') {
-        outputLabel = <Translation id="DATA_ETH" />;
-    }
     if (type === 'locktime') {
         const isTimestamp = new BigNumber(value).gte(BTC_LOCKTIME_VALUE);
         outputLabel = (
@@ -82,7 +79,7 @@ const Output = (props: Props) => {
 
     let outputLines: OutputElementLine[];
 
-    if (props.type === 'fee-replace') {
+    if (type === 'fee-replace') {
         outputLines = [
             {
                 id: 'increase-fee-by',
@@ -97,7 +94,7 @@ const Output = (props: Props) => {
         ];
         outputSymbol = symbol;
         fiatVisible = !isTestnet(symbol);
-    } else if (props.type === 'reduce-output') {
+    } else if (type === 'reduce-output') {
         outputLines = [
             {
                 id: 'decrease-address',
@@ -118,11 +115,20 @@ const Output = (props: Props) => {
         ];
         outputSymbol = symbol;
         fiatVisible = !isTestnet(symbol);
-    } else if (props.type === 'txid') {
+    } else if (type === 'txid') {
         outputLines = [
             {
                 id: 'txid',
                 label: <Translation id="TR_TXID" />,
+                value: outputValue,
+                plainValue: true,
+            },
+        ];
+    } else if (type === 'data') {
+        outputLines = [
+            {
+                id: 'default',
+                label: <Translation id="DATA_ETH" />,
                 value: outputValue,
                 plainValue: true,
             },


### PR DESCRIPTION
Before fix: Suite incorrectly formats ETH transaction Data as huge decimal number

<img width="356" alt="image" src="https://user-images.githubusercontent.com/11609674/195051985-449be3a6-c9f3-4319-ba8e-9515f0601e2a.png">

After fix: the tx Data are displayed correctly as hexadecimal string

<img width="660" alt="image" src="https://user-images.githubusercontent.com/11609674/195052218-36720e64-7591-46d9-ae5c-aa29444a96e6.png">
