### PR TITLE
SQLite cache for CJ block filters

### DIFF
--- a/packages/coinjoin/package.json
+++ b/packages/coinjoin/package.json
@@ -20,16 +20,25 @@
         "!**/*.map"
     ],
     "types": "lib/index.d.ts",
+    "browser": {
+        "./lib/backend/CoinjoinFilterController": "./lib/backend/CoinjoinFilterController.browser",
+        "./lib/backend/CoinjoinStorage": false,
+        "better-sqlite3": false
+    },
     "scripts": {
         "lint": "eslint '**/*.{ts,js}'",
         "test:unit": "jest",
         "type-check": "tsc --build",
         "build:lib": "rimraf lib && tsc --build ./tsconfig.lib.json"
     },
+    "devDependencies": {
+        "@types/better-sqlite3": "^7.5.0"
+    },
     "dependencies": {
         "@trezor/blockchain-link": "*",
         "@trezor/utils": "*",
         "@trezor/utxo-lib": "*",
+        "better-sqlite3": "^7.6.2",
         "bignumber.js": "^9.0.2",
         "cross-fetch": "^3.1.5",
         "events": "^3.3.0",

--- a/packages/coinjoin/src/backend/CoinjoinBackendClient.ts
+++ b/packages/coinjoin/src/backend/CoinjoinBackendClient.ts
@@ -1,0 +1,148 @@
+import { EventEmitter } from 'events';
+
+import { httpGet, httpPost, RequestOptions } from '../utils/http';
+import type {
+    BlockFilter,
+    BlockbookBlock,
+    BlockFilterResponse,
+    BlockbookTransaction,
+} from './types';
+
+type CoinjoinBackendClientSettings = {
+    coordinatorUrl: string;
+    blockbookUrls: readonly string[];
+    timeout?: number;
+};
+
+type CoinjoinRequestOptions = Pick<RequestOptions, 'identity' | 'signal' | 'delay'>;
+
+export class CoinjoinBackendClient extends EventEmitter {
+    protected readonly wabisabiUrl;
+    protected readonly blockbookUrl;
+    protected readonly blockCache: BlockbookBlock[] = [];
+
+    constructor(settings: CoinjoinBackendClientSettings) {
+        super();
+        this.wabisabiUrl = `${settings.coordinatorUrl}api/v4/btc`;
+        this.blockbookUrl =
+            settings.blockbookUrls[Math.floor(Math.random() * settings.blockbookUrls.length)];
+    }
+
+    private fetchAndParseBlock(
+        height: number,
+        options?: CoinjoinRequestOptions,
+    ): Promise<BlockbookBlock> {
+        return this.blockbook(options)
+            .get(`block/${height}`)
+            .then(this.handleBlockbookResponse.bind(this));
+    }
+
+    async fetchBlock(height: number, options?: CoinjoinRequestOptions) {
+        if (!this.blockCache[height]) {
+            this.blockCache[height] = await this.fetchAndParseBlock(height, options);
+        }
+        return this.blockCache[height];
+    }
+
+    fetchBlocks(heights: number[], options?: CoinjoinRequestOptions): Promise<BlockbookBlock[]> {
+        return Promise.all(heights.map(height => this.fetchBlock(height, options)));
+    }
+
+    fetchTransaction(
+        txid: string,
+        options?: CoinjoinRequestOptions,
+    ): Promise<BlockbookTransaction> {
+        return this.blockbook(options)
+            .get(`tx/${txid}`)
+            .then(this.handleBlockbookResponse.bind(this));
+    }
+
+    async fetchFilters(
+        bestKnownBlockHash: string,
+        count: number,
+        options?: CoinjoinRequestOptions,
+    ): Promise<BlockFilterResponse> {
+        const response = await this.wabisabi(options).get('Blockchain/filters', {
+            bestKnownBlockHash,
+            count,
+        });
+
+        if (response.status === 204) {
+            // Provided hash is a tip
+            return {
+                bestHeight: -1,
+                filters: [],
+            };
+        }
+        if (response.status === 200) {
+            const result: { bestHeight: number; filters: string[] } = await response.json();
+            const filters = result.filters.map<BlockFilter>(data => {
+                const [blockHeight, blockHash, filter, prevHash, blockTime] = data.split(':');
+                return {
+                    blockHeight: Number(blockHeight),
+                    blockHash,
+                    filter,
+                    prevHash,
+                    blockTime: Number(blockTime),
+                };
+            });
+            return {
+                bestHeight: result.bestHeight,
+                filters,
+            };
+        }
+        if (response.status >= 400 && response.status < 500) {
+            const error = await response.json();
+            throw new Error(`${response.status}: ${error}`);
+        }
+        throw new Error(`${response.status}: ${response.statusText}`);
+    }
+
+    async fetchMempoolTxids(options?: CoinjoinRequestOptions): Promise<string[]> {
+        const response = await this.wabisabi(options).get('Blockchain/mempool-hashes');
+        if (response.status === 200) {
+            return response.json();
+        }
+
+        throw new Error(`${response.status}: ${response.statusText}`);
+    }
+
+    // TODO
+    async fetchServerInfo(options?: CoinjoinRequestOptions) {
+        const res = await this.wabisabi(options).get('Batch/synchronize', {
+            bestKnownBlockHash: '0f9188f13cb7b2c71f2a335e3a4fc328bf5beb436012afca590b1a11466e2206',
+            maxNumberOfFilters: 0,
+            estimateSmartFeeMode: 'Conservative',
+        });
+        return res.json();
+    }
+
+    protected async handleBlockbookResponse(response: Response) {
+        if (response.status === 200) {
+            return response.json();
+        }
+
+        if (response.status >= 400 && response.status < 500) {
+            const { error } = await response.json();
+            throw new Error(`${response.status}: ${error}`);
+        }
+        throw new Error(`${response.status}: ${response.statusText}`);
+    }
+
+    protected wabisabi(options?: CoinjoinRequestOptions) {
+        return this.request(this.wabisabiUrl, options);
+    }
+
+    protected blockbook(options?: CoinjoinRequestOptions) {
+        return this.request(this.blockbookUrl, options);
+    }
+
+    private request(url: string, options?: CoinjoinRequestOptions) {
+        return {
+            get: (path: string, query?: Record<string, any>) =>
+                httpGet(`${url}/${path}`, query, options),
+            post: (path: string, body?: Record<string, any>) =>
+                httpPost(`${url}/${path}`, body, options),
+        };
+    }
+}

--- a/packages/coinjoin/src/backend/CoinjoinFilterController.browser.ts
+++ b/packages/coinjoin/src/backend/CoinjoinFilterController.browser.ts
@@ -1,0 +1,42 @@
+import { FILTERS_BATCH_SIZE } from '../constants';
+import type {
+    FilterClient,
+    FilterController,
+    FilterControllerParams,
+    FilterControllerContext,
+} from './types';
+import type { CoinjoinBackendSettings } from '../types';
+
+export class CoinjoinFilterController implements FilterController {
+    private readonly client;
+    private readonly baseBlockHash;
+
+    private bestHeight: number;
+    get bestBlockHeight() {
+        return this.bestHeight;
+    }
+
+    constructor(client: FilterClient, { baseBlockHash }: CoinjoinBackendSettings) {
+        this.client = client;
+        this.baseBlockHash = baseBlockHash;
+        this.bestHeight = -1;
+    }
+
+    async *getFilterIterator(params?: FilterControllerParams, context?: FilterControllerContext) {
+        const batchSize = params?.batchSize ?? FILTERS_BATCH_SIZE;
+        let knownBlockHash = params?.fromHash ?? this.baseBlockHash;
+        while (knownBlockHash) {
+            // eslint-disable-next-line no-await-in-loop
+            const { bestHeight, filters } = await this.client.fetchFilters(
+                knownBlockHash,
+                batchSize,
+                { signal: context?.abortSignal },
+            );
+            this.bestHeight = bestHeight;
+            for (let i = 0; i < filters.length; ++i) {
+                yield filters[i];
+            }
+            knownBlockHash = filters[filters.length - 1]?.blockHash;
+        }
+    }
+}

--- a/packages/coinjoin/src/backend/CoinjoinFilterController.ts
+++ b/packages/coinjoin/src/backend/CoinjoinFilterController.ts
@@ -1,3 +1,4 @@
+import { CoinjoinStorage } from './CoinjoinStorage';
 import { FILTERS_BATCH_SIZE } from '../constants';
 import type {
     FilterClient,
@@ -9,6 +10,8 @@ import type { CoinjoinBackendSettings } from '../types';
 
 export class CoinjoinFilterController implements FilterController {
     private readonly client;
+    private readonly storage;
+    private readonly baseBlockHeight;
     private readonly baseBlockHash;
 
     private bestHeight: number;
@@ -16,15 +19,38 @@ export class CoinjoinFilterController implements FilterController {
         return this.bestHeight;
     }
 
-    constructor(client: FilterClient, { baseBlockHash }: CoinjoinBackendSettings) {
+    constructor(client: FilterClient, settings: CoinjoinBackendSettings) {
         this.client = client;
-        this.baseBlockHash = baseBlockHash;
-        this.bestHeight = -1;
+        this.storage = new CoinjoinStorage(settings.storagePath);
+        this.baseBlockHeight = settings.baseBlockHeight;
+        this.baseBlockHash = settings.baseBlockHash;
+        this.bestHeight = this.storage.peekBlockFilter()?.blockHeight ?? -1;
+    }
+
+    private checkConsistency() {
+        // Check whether DB data are consistent
+        if (!this.storage.isConsistent(this.baseBlockHeight, this.baseBlockHash)) {
+            throw new Error('Storage inconsistent');
+        }
     }
 
     async *getFilterIterator(params?: FilterControllerParams, context?: FilterControllerContext) {
+        this.checkConsistency();
+
+        // TODO this is redudant call only to know the bestHeight beforehand
+        const { bestHeight } = await this.client.fetchFilters(this.baseBlockHash, 1, {
+            signal: context?.abortSignal,
+        });
+        this.bestHeight = bestHeight;
+
         const batchSize = params?.batchSize ?? FILTERS_BATCH_SIZE;
         let knownBlockHash = params?.fromHash ?? this.baseBlockHash;
+
+        const iterator = this.storage.getBlockFilterIterator();
+        // eslint-disable-next-line no-restricted-syntax
+        for (const filter of iterator()) yield filter;
+
+        knownBlockHash = this.storage.peekBlockFilter()?.blockHash ?? knownBlockHash;
         while (knownBlockHash) {
             // eslint-disable-next-line no-await-in-loop
             const { bestHeight, filters } = await this.client.fetchFilters(
@@ -33,6 +59,7 @@ export class CoinjoinFilterController implements FilterController {
                 { signal: context?.abortSignal },
             );
             this.bestHeight = bestHeight;
+            this.storage.loadBlockFilters(filters);
             for (let i = 0; i < filters.length; ++i) {
                 yield filters[i];
             }

--- a/packages/coinjoin/src/backend/CoinjoinFilterController.ts
+++ b/packages/coinjoin/src/backend/CoinjoinFilterController.ts
@@ -1,0 +1,42 @@
+import { FILTERS_BATCH_SIZE } from '../constants';
+import type {
+    FilterClient,
+    FilterController,
+    FilterControllerParams,
+    FilterControllerContext,
+} from './types';
+import type { CoinjoinBackendSettings } from '../types';
+
+export class CoinjoinFilterController implements FilterController {
+    private readonly client;
+    private readonly baseBlockHash;
+
+    private bestHeight: number;
+    get bestBlockHeight() {
+        return this.bestHeight;
+    }
+
+    constructor(client: FilterClient, { baseBlockHash }: CoinjoinBackendSettings) {
+        this.client = client;
+        this.baseBlockHash = baseBlockHash;
+        this.bestHeight = -1;
+    }
+
+    async *getFilterIterator(params?: FilterControllerParams, context?: FilterControllerContext) {
+        const batchSize = params?.batchSize ?? FILTERS_BATCH_SIZE;
+        let knownBlockHash = params?.fromHash ?? this.baseBlockHash;
+        while (knownBlockHash) {
+            // eslint-disable-next-line no-await-in-loop
+            const { bestHeight, filters } = await this.client.fetchFilters(
+                knownBlockHash,
+                batchSize,
+                { signal: context?.abortSignal },
+            );
+            this.bestHeight = bestHeight;
+            for (let i = 0; i < filters.length; ++i) {
+                yield filters[i];
+            }
+            knownBlockHash = filters[filters.length - 1]?.blockHash;
+        }
+    }
+}

--- a/packages/coinjoin/src/backend/CoinjoinMempoolController.ts
+++ b/packages/coinjoin/src/backend/CoinjoinMempoolController.ts
@@ -1,0 +1,39 @@
+import type { BlockbookTransaction, MempoolClient } from './types';
+import { doesTxContainAddress } from './utils';
+
+export type MempoolController = {
+    update(): Promise<void>;
+    getTransactions(addresses: string[]): BlockbookTransaction[];
+};
+
+const isFulfilled = <T>(promise: PromiseSettledResult<T>): promise is PromiseFulfilledResult<T> =>
+    promise.status === 'fulfilled';
+
+export class CoinjoinMempoolController implements MempoolController {
+    private readonly client;
+    private mempool: { [txid: string]: BlockbookTransaction };
+
+    constructor(client: MempoolClient) {
+        this.client = client;
+        this.mempool = {};
+    }
+
+    async update() {
+        const txids = await this.client.fetchMempoolTxids();
+        const entries = await Promise.allSettled(
+            txids.map(async txid => {
+                const tx = this.mempool[txid] ?? (await this.client.fetchTransaction(txid));
+                return [txid, tx] as const;
+            }),
+        )
+            .then(promises => promises.filter(isFulfilled)) // Failed fetchTransaction could be ignored
+            .then(promises => promises.map(({ value }) => value));
+        this.mempool = Object.fromEntries(entries);
+    }
+
+    getTransactions(addresses: string[]) {
+        return Object.values(this.mempool).filter(tx =>
+            addresses.some(address => doesTxContainAddress(address)(tx)),
+        );
+    }
+}

--- a/packages/coinjoin/src/backend/CoinjoinStorage.ts
+++ b/packages/coinjoin/src/backend/CoinjoinStorage.ts
@@ -1,0 +1,146 @@
+// https://github.com/WiseLibs/better-sqlite3/blob/HEAD/docs/api.md
+// https://github.com/WiseLibs/better-sqlite3/issues/262
+import DB from 'better-sqlite3';
+
+import type { BlockFilter } from './types';
+
+const FILTER_COLUMNS: (keyof BlockFilter)[] = [
+    'blockHeight',
+    'blockHash',
+    'filter',
+    'prevHash',
+    'blockTime',
+];
+
+export class CoinjoinStorage {
+    protected readonly db: DB.Database;
+    protected readonly get;
+    protected readonly all;
+    protected readonly run;
+
+    constructor(path = ':memory:') {
+        this.db = new DB(path);
+        this.get = <T>(sql: string, ...params: any[]): T => this.db.prepare(sql).get(...params);
+        this.all = <T>(sql: string, ...params: any[]): T[] => this.db.prepare(sql).all(...params);
+        this.run = (sql: string, ...params: any[]) => this.db.prepare(sql).run(...params);
+        this.run(`
+            CREATE TABLE IF NOT EXISTS BlockFilters (
+                blockHeight INTEGER PRIMARY KEY,
+                blockHash TEXT NOT NULL UNIQUE,
+                filter TEXT NOT NULL,
+                prevHash TEXT NOT NULL,
+                blockTime INTEGER NOT NULL
+            ) WITHOUT ROWID
+        `);
+    }
+
+    isConsistent(baseBlockHeight: number, baseBlockHash: string) {
+        const { firstFilterHeight, lastFilterHeight, filterCount } = this.get(`
+            SELECT
+                MIN(blockHeight) AS firstFilterHeight,
+                MAX(blockHeight) AS lastFilterHeight,
+                COUNT(blockHeight) as filterCount
+            FROM BlockFilters
+        `);
+        if (filterCount === 0) return true; // No stored filter, OK
+        if (firstFilterHeight > baseBlockHeight + 1) return false; // Filters missing from the start
+        if (lastFilterHeight < baseBlockHeight + 1) return false; // Filters missing at the end
+        if (lastFilterHeight - firstFilterHeight + 1 !== filterCount) return false; // Filters missing somewhere inbetween
+
+        const faults = this.all<{ blockHeight: number }>(`
+            SELECT A.blockHeight
+            FROM BlockFilters A
+                LEFT JOIN BlockFilters B
+                ON A.blockHeight = B.blockHeight + 1
+            WHERE A.prevHash <> B.blockHash
+                OR B.blockHash IS NULL
+        `);
+        if (faults.length !== 1 || faults[0].blockHeight !== firstFilterHeight) return false; // Hash continuity broken
+
+        const firstFilter = this.get<BlockFilter | undefined>(
+            `SELECT ${FILTER_COLUMNS}
+            FROM BlockFilters
+            WHERE blockHeight = (?)`,
+            baseBlockHeight + 1,
+        );
+        if (firstFilter?.prevHash !== baseBlockHash) return false; // Wrong first filter
+
+        return true;
+    }
+
+    peekBlockFilter(): BlockFilter | undefined {
+        return this.get(`
+            SELECT ${FILTER_COLUMNS}
+            FROM BlockFilters
+            WHERE blockHeight=(
+                SELECT MAX(blockHeight)
+                FROM BlockFilters
+            )
+        `);
+    }
+
+    // Stupid, without checking, fails on error
+    loadBlockFilters(filters: BlockFilter[]) {
+        const transaction = this.db.transaction((fltrs: BlockFilter[]) => {
+            const insert = this.db.prepare(`
+                INSERT INTO BlockFilters (
+                    ${FILTER_COLUMNS}
+                ) VALUES (
+                    ${FILTER_COLUMNS.map(col => `@${col}`)}
+                )
+            `);
+            fltrs.forEach(filter => insert.run(filter));
+        });
+        transaction(filters);
+    }
+
+    // Smarter, keeping valid db still valid
+    pushBlockFilter(filter: BlockFilter) {
+        this.db.transaction((fltr: BlockFilter) => {
+            const prev = this.get<BlockFilter | undefined>(
+                `SELECT blockHash
+                FROM BlockFilters
+                WHERE blockHeight = (?)`,
+                fltr.blockHeight - 1,
+            );
+            if (prev?.blockHash !== fltr.prevHash) {
+                throw new Error('Previous block filter is missing');
+            }
+            this.run(
+                `DELETE FROM BlockFilters
+                WHERE blockHeight >= (?)`,
+                fltr.blockHeight,
+            );
+            this.run(
+                `INSERT INTO BlockFilters (
+                    ${FILTER_COLUMNS}
+                ) VALUES (
+                    ${FILTER_COLUMNS.map(col => `@${col}`)}
+                )`,
+                fltr,
+            );
+        })(filter);
+    }
+
+    // TODO probably should fail when fromHash is not found
+    getBlockFilterIterator(fromHash?: string): () => IterableIterator<BlockFilter> {
+        const stmt = this.db.prepare(
+            `SELECT ${FILTER_COLUMNS}
+            FROM BlockFilters
+            WHERE blockHeight > (${
+                fromHash
+                    ? `
+                        SELECT blockHeight
+                        FROM BlockFilters
+                        WHERE blockHash = '${fromHash}'
+                    `
+                    : '0'
+            })`,
+        );
+        return stmt.iterate.bind(stmt);
+    }
+
+    dispose() {
+        this.db.close();
+    }
+}

--- a/packages/coinjoin/src/backend/filters.ts
+++ b/packages/coinjoin/src/backend/filters.ts
@@ -1,0 +1,29 @@
+/**
+ * https://github.com/MetacoSA/NBitcoin/blob/master/NBitcoin/BIP158/GolombRiceFilter.cs
+ * https://github.com/MetacoSA/NBitcoin/blob/ec3da1c2019a828e52d1885fc452ef55b6f72271/NBitcoin/Protocol/VarInt.cs#L81
+ * https://github.com/zkSNACKs/WalletWasabi/blob/master/WalletWasabi/Backend/Models/FilterModel.cs
+ * https://github.com/bcoin-org/golomb/blob/master/lib/golomb.js
+ */
+import Golomb from 'golomb';
+import { U64 } from 'n64';
+
+import { address as addressBjs, Network } from '@trezor/utxo-lib';
+
+const M = new U64(1 << 20);
+
+const createFilter = (data: Buffer) => {
+    const filter = Golomb.fromNBytes(20, data);
+    filter.m = M.mul(new U64(filter.n));
+    return filter;
+};
+
+export const getAddressScript = (address: string, network: Network) => {
+    const script = addressBjs.toOutputScript(address, network);
+    return Buffer.concat([Buffer.from([script.length + 6]), script]);
+};
+
+export const getFilter = (filterHex: string, blockHash: string) => {
+    const filter = createFilter(Buffer.from(filterHex, 'hex'));
+    const key = Buffer.from(blockHash, 'hex').reverse().slice(0, 16);
+    return (script: Buffer) => filter.match(key, script);
+};

--- a/packages/coinjoin/src/backend/getAccountInfo.ts
+++ b/packages/coinjoin/src/backend/getAccountInfo.ts
@@ -1,0 +1,109 @@
+import { Network, deriveAddresses } from '@trezor/utxo-lib';
+import {
+    sumAddressValues,
+    sortTxsFromLatest,
+} from '@trezor/blockchain-link/lib/workers/electrum/methods/getAccountInfo';
+
+import { isTxConfirmed, doesTxContainAddress } from './utils';
+import type { Transaction, AccountInfo, ScanAccountCheckpoint, Address } from './types';
+
+const PAGE_SIZE_DEFAULT = 25;
+
+const getPagination = (txCount: number, perPage = PAGE_SIZE_DEFAULT) => ({
+    index: 1,
+    size: perPage,
+    total: Math.ceil(txCount / perPage),
+});
+
+const getDelta = ({ type, amount, fee }: Transaction) => {
+    switch (type) {
+        case 'recv':
+        case 'joint':
+            return Number.parseInt(amount, 10);
+        case 'sent':
+            return -(Number.parseInt(amount, 10) + Number.parseInt(fee, 10));
+        case 'self':
+            return -Number.parseInt(amount, 10);
+        default:
+            return 0;
+    }
+};
+
+const sumBalance = (current: number, tx: Transaction) => current + getDelta(tx);
+
+const deriveTxAddresses = (
+    descriptor: string,
+    type: 'receive' | 'change',
+    count: number,
+    network: Network,
+    transactions: Transaction[],
+): Address[] =>
+    deriveAddresses(descriptor, type, 0, count, network).map(({ address, path }) => {
+        const txs = transactions.filter(tx => doesTxContainAddress(address)(tx.details));
+        const sent = sumAddressValues(txs, address, tx => tx.details.vin);
+        const received = sumAddressValues(txs, address, tx => tx.details.vout);
+        return {
+            address,
+            path,
+            transfers: txs.length,
+            balance: txs.length ? (received - sent).toString() : undefined,
+            sent: txs.length ? sent.toString() : undefined,
+            received: txs.length ? received.toString() : undefined,
+        };
+    });
+
+export const getAccountInfo = ({
+    descriptor,
+    transactions,
+    checkpoint,
+    network,
+}: {
+    descriptor: string;
+    transactions: Transaction[];
+    checkpoint?: ScanAccountCheckpoint;
+    network: Network;
+}): AccountInfo => {
+    const txCountTotal = transactions.length;
+    const balanceTotal = transactions.reduce(sumBalance, 0);
+
+    const txsConfirmed = transactions.filter(isTxConfirmed);
+    const txCountConfirmed = txsConfirmed.length;
+    const balanceConfirmed = txsConfirmed.reduce(sumBalance, 0);
+
+    let addresses;
+    if (checkpoint) {
+        const receive = deriveTxAddresses(
+            descriptor,
+            'receive',
+            checkpoint.receiveCount,
+            network,
+            txsConfirmed,
+        );
+        const change = deriveTxAddresses(
+            descriptor,
+            'change',
+            checkpoint.changeCount,
+            network,
+            txsConfirmed,
+        );
+        addresses = {
+            change,
+            unused: receive.filter(({ transfers }) => !transfers),
+            used: receive.filter(({ transfers }) => transfers),
+        };
+    }
+
+    return {
+        descriptor,
+        balance: balanceConfirmed.toString(),
+        availableBalance: balanceTotal.toString(),
+        empty: !txCountTotal,
+        history: {
+            total: txCountConfirmed,
+            unconfirmed: txCountTotal - txCountConfirmed,
+            transactions: transactions.slice().sort(sortTxsFromLatest),
+        },
+        addresses,
+        page: getPagination(transactions.length),
+    };
+};

--- a/packages/coinjoin/src/backend/getAccountInfo.ts
+++ b/packages/coinjoin/src/backend/getAccountInfo.ts
@@ -6,6 +6,7 @@ import {
 
 import { isTxConfirmed, doesTxContainAddress } from './utils';
 import type { Transaction, AccountInfo, ScanAccountCheckpoint, Address } from './types';
+import { getAccountUtxo } from './getAccountUtxo';
 
 const PAGE_SIZE_DEFAULT = 25;
 
@@ -93,6 +94,9 @@ export const getAccountInfo = ({
         };
     }
 
+    const txsFromLatest = transactions.slice().sort(sortTxsFromLatest);
+    const txsFromOldest = txsFromLatest.slice().reverse();
+
     return {
         descriptor,
         balance: balanceConfirmed.toString(),
@@ -101,9 +105,13 @@ export const getAccountInfo = ({
         history: {
             total: txCountConfirmed,
             unconfirmed: txCountTotal - txCountConfirmed,
-            transactions: transactions.slice().sort(sortTxsFromLatest),
+            transactions: txsFromLatest,
         },
         addresses,
         page: getPagination(transactions.length),
+        utxo: getAccountUtxo({
+            transactions: txsFromOldest,
+            addresses,
+        }),
     };
 };

--- a/packages/coinjoin/src/backend/getAccountUtxo.ts
+++ b/packages/coinjoin/src/backend/getAccountUtxo.ts
@@ -1,0 +1,73 @@
+import { throwError } from '@trezor/utils';
+
+import type { Utxo, VinVout, Transaction, AccountAddresses } from './types';
+
+type AddressPaths = {
+    [address: string]: string;
+};
+
+const isCoinbaseUtxo = (tx: Transaction) =>
+    tx.details.vin.length === 1 && !!tx.details.vin[0].coinbase;
+
+const getHeightData = (tx: Transaction) =>
+    tx.blockHeight && tx.blockHeight > 0
+        ? {
+              blockHeight: tx.blockHeight,
+              confirmations: 1, // Correct value should be calculated from current height in caller
+          }
+        : {
+              blockHeight: -1,
+              confirmations: 0,
+          };
+
+const getAddressData = (vout: VinVout, paths: AddressPaths) => {
+    const address = vout.addresses?.[0] ?? throwError('Address is missing from tx output');
+    return {
+        address,
+        path: paths[address],
+    };
+};
+
+const transformUtxo = (vout: VinVout, tx: Transaction, paths: AddressPaths): Utxo => ({
+    amount: vout.value ?? throwError('Value is missing from tx output'),
+    vout: vout.n,
+    txid: tx.txid,
+    coinbase: isCoinbaseUtxo(tx),
+    ...getHeightData(tx),
+    ...getAddressData(vout, paths),
+});
+
+export const getAccountUtxo = ({
+    transactions,
+    addresses,
+}: {
+    transactions: Transaction[];
+    addresses?: AccountAddresses;
+}): Utxo[] => {
+    const paths = addresses
+        ? addresses.used.concat(addresses.unused, addresses.change).reduce<AddressPaths>(
+              (prev, cur) => ({
+                  ...prev,
+                  [cur.address]: cur.path,
+              }),
+              {},
+          )
+        : {};
+
+    const utxos = new Map<string, [VinVout, Transaction]>();
+
+    transactions.forEach(tx => {
+        tx.details.vin
+            .filter(vin => vin.isAccountOwned)
+            .forEach(vin => {
+                utxos.delete(`${vin.txid}-${vin.vout ?? 0}`);
+            });
+        tx.details.vout
+            .filter(vout => vout.isAccountOwned)
+            .forEach(vout => {
+                utxos.set(`${tx.txid}-${vout.n}`, [vout, tx]);
+            });
+    });
+
+    return Array.from(utxos.values(), ([vout, tx]) => transformUtxo(vout, tx, paths));
+};

--- a/packages/coinjoin/src/backend/scanAccount.ts
+++ b/packages/coinjoin/src/backend/scanAccount.ts
@@ -1,0 +1,117 @@
+import { deriveAddresses } from '@trezor/utxo-lib';
+import { transformTransaction } from '@trezor/blockchain-link/lib/workers/blockbook/utils';
+
+import { getAddressScript, getFilter } from './filters';
+import { doesTxContainAddress } from './utils';
+import type {
+    AccountAddress,
+    BlockbookBlock,
+    BlockbookTransaction,
+    ScanAccountParams,
+    ScanAccountCheckpoint,
+    ScanAccountContext,
+    ScanAccountResult,
+} from './types';
+import { DISCOVERY_LOOKOUT } from '../constants';
+
+const transformTx =
+    (xpub: string, receive: AccountAddress[], change: AccountAddress[]) =>
+    (tx: BlockbookTransaction) =>
+        // It doesn't matter for transformTransaction which receive addrs are used and which are unused
+        transformTransaction(xpub, { used: receive, unused: [], change }, tx);
+
+const analyzeAddresses = async (
+    addresses: AccountAddress[],
+    isMatch: (script: Buffer) => boolean,
+    getBlock: () => Promise<BlockbookBlock>,
+    deriveMore: (from: number, count: number) => AccountAddress[],
+    txs: Set<BlockbookTransaction>,
+    lookout = DISCOVERY_LOOKOUT,
+): Promise<AccountAddress[]> => {
+    let addrs = addresses;
+    for (let i = 0; i < addrs.length; ++i) {
+        const { address, script } = addrs[i];
+        if (isMatch(script)) {
+            // eslint-disable-next-line no-await-in-loop
+            const block = await getBlock();
+            const transactions = block.txs.filter(doesTxContainAddress(address));
+            if (transactions.length) {
+                transactions.forEach(txs.add, txs);
+                const missing = lookout + i + 1 - addrs.length;
+                if (missing > 0) {
+                    addrs = addrs.concat(deriveMore(addrs.length, missing));
+                }
+            }
+        }
+    }
+    return addrs;
+};
+
+export const scanAccount = async (
+    params: ScanAccountParams & { checkpoint: ScanAccountCheckpoint },
+    { client, network, filters, mempool, abortSignal, onProgress }: ScanAccountContext,
+): Promise<ScanAccountResult> => {
+    const xpub = params.descriptor;
+    const deriveMore = (type: 'receive' | 'change') => (from: number, count: number) =>
+        deriveAddresses(xpub, type, from, count, network).map(({ address }) => ({
+            address,
+            script: getAddressScript(address, network),
+        }));
+
+    let { checkpoint } = params;
+    let receive: AccountAddress[] = deriveMore('receive')(0, checkpoint.receiveCount);
+    let change: AccountAddress[] = deriveMore('change')(0, checkpoint.changeCount);
+
+    let firstBlockHeight = -1;
+
+    const txs = new Set<BlockbookTransaction>();
+
+    const everyFilter = filters.getFilterIterator(
+        { fromHash: checkpoint.blockHash },
+        { abortSignal },
+    );
+    // eslint-disable-next-line no-restricted-syntax
+    for await (const { filter, blockHash, blockHeight } of everyFilter) {
+        if (firstBlockHeight < 0) firstBlockHeight = blockHeight;
+
+        const isMatch = getFilter(filter, blockHash);
+
+        let block: BlockbookBlock | undefined;
+        const lazyBlock = async () =>
+            block ?? (block = await client.fetchBlock(blockHeight, { signal: abortSignal }));
+
+        receive = await analyzeAddresses(receive, isMatch, lazyBlock, deriveMore('receive'), txs);
+        change = await analyzeAddresses(change, isMatch, lazyBlock, deriveMore('change'), txs);
+
+        const transactions = Array.from(txs, transformTx(xpub, receive, change));
+        const progress =
+            (blockHeight - firstBlockHeight) / (filters.bestBlockHeight - firstBlockHeight);
+        checkpoint = {
+            blockHash,
+            blockHeight,
+            receiveCount: receive.length,
+            changeCount: change.length,
+        };
+
+        txs.clear();
+
+        onProgress({
+            checkpoint,
+            transactions,
+            info: {
+                progress,
+            },
+        });
+    }
+
+    await mempool.update();
+
+    const pending = mempool
+        .getTransactions(receive.concat(change).map(({ address }) => address))
+        .map(transformTx(xpub, receive, change));
+
+    return {
+        pending,
+        checkpoint,
+    };
+};

--- a/packages/coinjoin/src/backend/scanAccount.ts
+++ b/packages/coinjoin/src/backend/scanAccount.ts
@@ -2,7 +2,7 @@ import { deriveAddresses } from '@trezor/utxo-lib';
 import { transformTransaction } from '@trezor/blockchain-link/lib/workers/blockbook/utils';
 
 import { getAddressScript, getFilter } from './filters';
-import { doesTxContainAddress } from './utils';
+import { doesTxContainAddress, fixTxInputs } from './utils';
 import type {
     AccountAddress,
     BlockbookBlock,
@@ -95,6 +95,8 @@ export const scanAccount = async (
 
         txs.clear();
 
+        await fixTxInputs(transactions, client);
+
         onProgress({
             checkpoint,
             transactions,
@@ -109,6 +111,8 @@ export const scanAccount = async (
     const pending = mempool
         .getTransactions(receive.concat(change).map(({ address }) => address))
         .map(transformTx(xpub, receive, change));
+
+    await fixTxInputs(pending, client);
 
     return {
         pending,

--- a/packages/coinjoin/src/backend/scanAddress.ts
+++ b/packages/coinjoin/src/backend/scanAddress.ts
@@ -1,7 +1,7 @@
 import { transformTransaction } from '@trezor/blockchain-link/lib/workers/blockbook/utils';
 
 import { getAddressScript, getFilter } from './filters';
-import { doesTxContainAddress } from './utils';
+import { doesTxContainAddress, fixTxInputs } from './utils';
 import type {
     ScanAddressParams,
     ScanAddressCheckpoint,
@@ -29,6 +29,9 @@ export const scanAddress = async (
             const block = await client.fetchBlock(blockHeight);
             const blockTxs = block.txs.filter(doesTxContainAddress(address));
             const transactions = blockTxs.map(tx => transformTransaction(address, undefined, tx));
+
+            await fixTxInputs(transactions, client);
+
             onProgress({
                 checkpoint,
                 transactions,
@@ -41,6 +44,8 @@ export const scanAddress = async (
     const pending = mempool
         .getTransactions([address])
         .map(tx => transformTransaction(address, undefined, tx));
+
+    await fixTxInputs(pending, client);
 
     return {
         pending,

--- a/packages/coinjoin/src/backend/scanAddress.ts
+++ b/packages/coinjoin/src/backend/scanAddress.ts
@@ -1,0 +1,49 @@
+import { transformTransaction } from '@trezor/blockchain-link/lib/workers/blockbook/utils';
+
+import { getAddressScript, getFilter } from './filters';
+import { doesTxContainAddress } from './utils';
+import type {
+    ScanAddressParams,
+    ScanAddressCheckpoint,
+    ScanAddressContext,
+    ScanAddressResult,
+} from './types';
+
+export const scanAddress = async (
+    params: ScanAddressParams & { checkpoint: ScanAddressCheckpoint },
+    { client, network, filters, mempool, abortSignal, onProgress }: ScanAddressContext,
+): Promise<ScanAddressResult> => {
+    const address = params.descriptor;
+    const script = getAddressScript(address, network);
+    let { checkpoint } = params;
+
+    const everyFilter = filters.getFilterIterator(
+        { fromHash: checkpoint.blockHash },
+        { abortSignal },
+    );
+    // eslint-disable-next-line no-restricted-syntax
+    for await (const { filter, blockHash, blockHeight } of everyFilter) {
+        checkpoint = { blockHash, blockHeight };
+        const isMatch = getFilter(filter, blockHash);
+        if (isMatch(script)) {
+            const block = await client.fetchBlock(blockHeight);
+            const blockTxs = block.txs.filter(doesTxContainAddress(address));
+            const transactions = blockTxs.map(tx => transformTransaction(address, undefined, tx));
+            onProgress({
+                checkpoint,
+                transactions,
+            });
+        }
+    }
+
+    await mempool.update();
+
+    const pending = mempool
+        .getTransactions([address])
+        .map(tx => transformTransaction(address, undefined, tx));
+
+    return {
+        pending,
+        checkpoint,
+    };
+};

--- a/packages/coinjoin/src/backend/types.ts
+++ b/packages/coinjoin/src/backend/types.ts
@@ -1,0 +1,114 @@
+import type { Network } from '@trezor/utxo-lib';
+import type { AccountInfo, Address, Transaction } from '@trezor/blockchain-link/src/types';
+import type { Transaction as BlockbookTransaction } from '@trezor/blockchain-link/src/types/blockbook';
+
+import type { CoinjoinBackendClient } from './CoinjoinBackendClient';
+import type { MempoolController } from './CoinjoinMempoolController';
+
+export type { BlockbookTransaction };
+export type { AccountInfo, Address, Transaction };
+
+export type BlockbookBlock = {
+    height: number;
+    txs: BlockbookTransaction[];
+};
+
+export type BlockFilter = {
+    blockHeight: number;
+    blockHash: string;
+    filter: string;
+    prevHash: string;
+    blockTime: number;
+};
+
+export type BlockFilterResponse = {
+    bestHeight: number;
+    filters: BlockFilter[];
+};
+
+type MethodContext = {
+    client: CoinjoinBackendClient;
+    network: Network;
+    abortSignal?: AbortSignal;
+};
+
+type ScanContext<T> = MethodContext & {
+    filters: FilterController;
+    mempool: MempoolController;
+    onProgress: (progress: T) => void;
+};
+
+export type ScanAddressContext = ScanContext<ScanAddressProgress>;
+
+export type ScanAccountContext = ScanContext<ScanAccountProgress>;
+
+export type ScanAddressCheckpoint = {
+    blockHash: string;
+    blockHeight: number;
+};
+
+export type ScanAccountCheckpoint = ScanAddressCheckpoint & {
+    receiveCount: number;
+    changeCount: number;
+};
+
+export type ScanProgressInfo = {
+    progress?: number;
+    message?: string;
+};
+
+type ScanProgress<T> = {
+    checkpoint: T;
+    transactions: Transaction[];
+    info?: ScanProgressInfo;
+};
+
+export type ScanAddressProgress = ScanProgress<ScanAddressCheckpoint>;
+
+export type ScanAccountProgress = ScanProgress<ScanAccountCheckpoint>;
+
+export type ScanAccountParams = {
+    descriptor: string;
+    checkpoint?: ScanAccountCheckpoint;
+};
+
+export type ScanAddressParams = {
+    descriptor: string;
+    checkpoint?: ScanAddressCheckpoint;
+};
+
+export type ScanAccountResult = {
+    pending: Transaction[];
+    checkpoint: ScanAccountCheckpoint;
+};
+
+export type ScanAddressResult = {
+    pending: Transaction[];
+    checkpoint: ScanAddressCheckpoint;
+};
+
+export type FilterControllerParams = {
+    fromHash?: string;
+    batchSize?: number;
+};
+
+export type FilterControllerContext = {
+    abortSignal?: AbortSignal;
+};
+
+export interface FilterController {
+    get bestBlockHeight(): number;
+    getFilterIterator(
+        params?: FilterControllerParams,
+        context?: FilterControllerContext,
+    ): AsyncGenerator<BlockFilter>;
+}
+
+export type FilterClient = Pick<CoinjoinBackendClient, 'fetchFilters'>;
+
+export type MempoolClient = Pick<CoinjoinBackendClient, 'fetchMempoolTxids' | 'fetchTransaction'>;
+
+export type AccountAddress = {
+    address: string;
+    script: Buffer;
+};

--- a/packages/coinjoin/src/backend/types.ts
+++ b/packages/coinjoin/src/backend/types.ts
@@ -1,12 +1,21 @@
 import type { Network } from '@trezor/utxo-lib';
-import type { AccountInfo, Address, Transaction } from '@trezor/blockchain-link/src/types';
-import type { Transaction as BlockbookTransaction } from '@trezor/blockchain-link/src/types/blockbook';
+import type {
+    Address,
+    Utxo,
+    Transaction,
+    AccountAddresses,
+    AccountInfo as AccountInfoBase,
+} from '@trezor/blockchain-link/src/types';
+import type {
+    Transaction as BlockbookTransaction,
+    VinVout,
+} from '@trezor/blockchain-link/src/types/blockbook';
 
 import type { CoinjoinBackendClient } from './CoinjoinBackendClient';
 import type { MempoolController } from './CoinjoinMempoolController';
 
-export type { BlockbookTransaction };
-export type { AccountInfo, Address, Transaction };
+export type { BlockbookTransaction, VinVout };
+export type { Address, Utxo, Transaction, AccountAddresses };
 
 export type BlockbookBlock = {
     height: number;
@@ -111,4 +120,8 @@ export type MempoolClient = Pick<CoinjoinBackendClient, 'fetchMempoolTxids' | 'f
 export type AccountAddress = {
     address: string;
     script: Buffer;
+};
+
+export type AccountInfo = AccountInfoBase & {
+    utxo: Utxo[];
 };

--- a/packages/coinjoin/src/backend/utils.ts
+++ b/packages/coinjoin/src/backend/utils.ts
@@ -1,0 +1,11 @@
+import type { VinVout } from '@trezor/blockchain-link/src/types/blockbook';
+
+export const isTxConfirmed = ({ blockHeight = -1 }: { blockHeight?: number }) => blockHeight > 0;
+
+export const doesTxContainAddress =
+    (address: string) =>
+    ({ vin, vout }: { vin: VinVout[]; vout: VinVout[] }) =>
+        vin
+            .concat(vout)
+            .flatMap(({ addresses = [] }) => addresses)
+            .includes(address);

--- a/packages/coinjoin/src/backend/utils.ts
+++ b/packages/coinjoin/src/backend/utils.ts
@@ -1,4 +1,5 @@
-import type { VinVout } from '@trezor/blockchain-link/src/types/blockbook';
+import type { CoinjoinBackendClient } from './CoinjoinBackendClient';
+import type { VinVout, Transaction } from './types';
 
 export const isTxConfirmed = ({ blockHeight = -1 }: { blockHeight?: number }) => blockHeight > 0;
 
@@ -9,3 +10,19 @@ export const doesTxContainAddress =
             .concat(vout)
             .flatMap(({ addresses = [] }) => addresses)
             .includes(address);
+
+/** @deprecated Temporary workaround, should be removed before releasing */
+export const fixTxInputs = (transactions: Transaction[], client: CoinjoinBackendClient) =>
+    Promise.all(
+        transactions
+            .filter(tx => tx.details.vin.some(vin => vin.isAccountOwned))
+            .map(async tx => {
+                const fetched = await client.fetchTransaction(tx.txid);
+                tx.details.vin.forEach(vin => {
+                    if (!vin.isAccountOwned) return;
+                    vin.txid = fetched.vin[vin.n].txid;
+                    vin.vout = fetched.vin[vin.n].vout;
+                    vin.coinbase = fetched.vin[vin.n].coinbase;
+                });
+            }),
+    );

--- a/packages/coinjoin/src/constants.ts
+++ b/packages/coinjoin/src/constants.ts
@@ -1,0 +1,3 @@
+export const FILTERS_BATCH_SIZE = 100;
+
+export const DISCOVERY_LOOKOUT = 20;

--- a/packages/coinjoin/tests/backend/CoinjoinBackend.test.ts
+++ b/packages/coinjoin/tests/backend/CoinjoinBackend.test.ts
@@ -1,0 +1,52 @@
+import { BlockbookAPI } from '@trezor/blockchain-link/lib/workers/blockbook/websocket';
+import { transformAccountInfo } from '@trezor/blockchain-link/src/workers/blockbook/utils';
+
+import { CoinjoinBackend } from '../../src';
+import { COINJOIN_BACKEND_SETTINGS } from '../fixtures/config.fixture';
+import { SEGWIT_XPUB, SEGWIT_RECEIVE_ADDRESSES } from '../fixtures/methods.fixture';
+
+describe.skip(`CoinjoinBackend`, () => {
+    let blockbook: BlockbookAPI;
+    let backend: CoinjoinBackend;
+
+    beforeAll(async () => {
+        blockbook = new BlockbookAPI({
+            url: 'https://coinjoin.corp.sldev.cz/blockbook/',
+        });
+        await blockbook.connect();
+    });
+
+    afterAll(() => {
+        blockbook.dispose();
+    });
+
+    beforeEach(() => {
+        backend = new CoinjoinBackend(COINJOIN_BACKEND_SETTINGS);
+    });
+
+    it('scanAddress', async () => {
+        const referential = await blockbook
+            .getAccountInfo({
+                descriptor: SEGWIT_RECEIVE_ADDRESSES[0],
+                details: 'txs',
+            })
+            .then(transformAccountInfo);
+        const info = await backend.scanAddress({
+            descriptor: SEGWIT_RECEIVE_ADDRESSES[0],
+        });
+        expect(info).toMatchObject(referential);
+    });
+
+    it('scanAccount', async () => {
+        const referential = await blockbook
+            .getAccountInfo({
+                descriptor: SEGWIT_XPUB,
+                details: 'txs',
+            })
+            .then(transformAccountInfo);
+        const info = await backend.scanAccount({
+            descriptor: SEGWIT_XPUB,
+        });
+        expect(info).toMatchObject(referential);
+    }, 15000);
+});

--- a/packages/coinjoin/tests/backend/CoinjoinBackendClient.test.ts
+++ b/packages/coinjoin/tests/backend/CoinjoinBackendClient.test.ts
@@ -1,0 +1,74 @@
+import { CoinjoinBackendClient } from '../../src/backend/CoinjoinBackendClient';
+import { COINJOIN_BACKEND_SETTINGS } from '../fixtures/config.fixture';
+
+const ZERO_HASH = '0f9188f13cb7b2c71f2a335e3a4fc328bf5beb436012afca590b1a11466e2206';
+const TIP_HASH = '66a8baf3fe7e759f4682a2c9780efcbb78a9bd938c95d0114737b3fcef709b82';
+const NONEXISTENT_HASH = 'deadbeef3cb7b2c71f2a335e3a4fc328bf5beb436012afca590b1a11466e2206';
+const MALFORMED_HASH = 'deadbeef';
+
+const VALID_TX = 'd20a1e1f3b98f82dc7aa0fa0538b75be357ab53f2d1c6f68c0be4e7537122f5d';
+const INVALID_TX = 'deadbeef';
+
+describe.skip('CoinjoinBackendClient', () => {
+    let client: CoinjoinBackendClient;
+
+    beforeAll(() => {
+        client = new CoinjoinBackendClient(COINJOIN_BACKEND_SETTINGS);
+    });
+
+    it('fetchFilters success', async () => {
+        const { filters } = await client.fetchFilters(ZERO_HASH, 10);
+        expect(filters.length).toBe(10);
+    });
+
+    it('fetchFilters tip', async () => {
+        const { filters } = await client.fetchFilters(TIP_HASH, 10);
+        expect(filters.length).toBe(0);
+    });
+
+    it('fetchFilters bad params', async () => {
+        await expect(client.fetchFilters(TIP_HASH, -1)).rejects.toThrow(/^400:/);
+    });
+
+    it('fetchFilters not found', async () => {
+        await expect(client.fetchFilters(NONEXISTENT_HASH, 10)).rejects.toThrow(
+            new RegExp(`404:.*${NONEXISTENT_HASH}`),
+        );
+    });
+
+    it('fetchFilters malformed', async () => {
+        await expect(client.fetchFilters(MALFORMED_HASH, 10)).rejects.toThrow(/^500:/);
+    });
+
+    it('fetchMempoolTxids', async () => {
+        const res = await client.fetchMempoolTxids();
+        expect(Array.isArray(res)).toBe(true);
+    });
+
+    it('fetchBlock success', async () => {
+        const block = await client.fetchBlock(3);
+        expect(block).toMatchObject({ height: 3 });
+    });
+
+    it('fetchBlock not found', async () => {
+        await expect(client.fetchBlock(999)).rejects.toThrow(/^400:/);
+    });
+
+    it('fetchBlocks success', async () => {
+        const blocks = await client.fetchBlocks([1, 7, 4]);
+        expect(blocks).toMatchObject([{ height: 1 }, { height: 7 }, { height: 4 }]);
+    });
+
+    it('fetchBlocks not found', async () => {
+        await expect(client.fetchBlocks([1, 999, 222])).rejects.toThrow(/^400:/);
+    });
+
+    it('fetchTransaction success', async () => {
+        const tx = await client.fetchTransaction(VALID_TX);
+        expect(tx).toMatchObject({ txid: VALID_TX, blockHeight: 1 });
+    });
+
+    it('fetchTransaction not found', async () => {
+        await expect(client.fetchTransaction(INVALID_TX)).rejects.toThrow(/^400:/);
+    });
+});

--- a/packages/coinjoin/tests/backend/CoinjoinFilterController.test.ts
+++ b/packages/coinjoin/tests/backend/CoinjoinFilterController.test.ts
@@ -1,0 +1,66 @@
+import { CoinjoinFilterController } from '../../src/backend/CoinjoinFilterController';
+import { BlockFilter, FilterClient } from '../../src/backend/types';
+import { mockFilterSequence } from '../fixtures/filters.fixture';
+import { COINJOIN_BACKEND_SETTINGS } from '../fixtures/config.fixture';
+import { MockFilterClient } from '../mocks/MockFilterClient';
+
+const FILTER_COUNT = 16;
+const FILTER_MIDDLE = 8;
+
+const FILTERS: BlockFilter[] = mockFilterSequence(
+    FILTER_COUNT,
+    COINJOIN_BACKEND_SETTINGS.baseBlockHeight,
+    COINJOIN_BACKEND_SETTINGS.baseBlockHash,
+);
+
+const BEST_HEIGHT = FILTER_COUNT + COINJOIN_BACKEND_SETTINGS.baseBlockHeight;
+
+const FIXTURES = [
+    {
+        description: 'From start',
+        params: {
+            batchSize: 5,
+        },
+        expected: FILTERS,
+    },
+    {
+        description: 'From middle',
+        params: {
+            batchSize: 5,
+            fromHash: FILTERS[FILTER_MIDDLE].prevHash,
+        },
+        expected: FILTERS.slice(FILTER_MIDDLE),
+    },
+    {
+        description: 'Not found',
+        params: {
+            batchSize: 5,
+            fromHash: 'foo',
+        },
+        expected: [],
+    },
+];
+
+describe('CoinjoinFilterController', () => {
+    let client: FilterClient;
+
+    beforeEach(() => {
+        client = new MockFilterClient(FILTERS);
+    });
+
+    describe('Filter controller', () => {
+        FIXTURES.forEach(({ description, params, expected }) => {
+            it(description, async () => {
+                const controller = new CoinjoinFilterController(client, COINJOIN_BACKEND_SETTINGS);
+                const iterator = controller.getFilterIterator(params);
+                const received = [];
+                // eslint-disable-next-line no-restricted-syntax
+                for await (const b of iterator) {
+                    expect(controller.bestBlockHeight).toBe(BEST_HEIGHT);
+                    received.push(b);
+                }
+                expect(received).toEqual(expected);
+            });
+        });
+    });
+});

--- a/packages/coinjoin/tests/backend/CoinjoinFilterController.test.ts
+++ b/packages/coinjoin/tests/backend/CoinjoinFilterController.test.ts
@@ -1,4 +1,5 @@
-import { CoinjoinFilterController } from '../../src/backend/CoinjoinFilterController';
+import { CoinjoinFilterController as NodeController } from '../../src/backend/CoinjoinFilterController';
+import { CoinjoinFilterController as BrowserController } from '../../src/backend/CoinjoinFilterController.browser';
 import { BlockFilter, FilterClient } from '../../src/backend/types';
 import { mockFilterSequence } from '../fixtures/filters.fixture';
 import { COINJOIN_BACKEND_SETTINGS } from '../fixtures/config.fixture';
@@ -48,10 +49,26 @@ describe('CoinjoinFilterController', () => {
         client = new MockFilterClient(FILTERS);
     });
 
-    describe('Filter controller', () => {
+    describe('Node controller', () => {
         FIXTURES.forEach(({ description, params, expected }) => {
             it(description, async () => {
-                const controller = new CoinjoinFilterController(client, COINJOIN_BACKEND_SETTINGS);
+                const controller = new NodeController(client, COINJOIN_BACKEND_SETTINGS);
+                const iterator = controller.getFilterIterator(params);
+                const received = [];
+                // eslint-disable-next-line no-restricted-syntax
+                for await (const b of iterator) {
+                    expect(controller.bestBlockHeight).toBe(BEST_HEIGHT);
+                    received.push(b);
+                }
+                expect(received).toEqual(expected);
+            });
+        });
+    });
+
+    describe('Browser controller', () => {
+        FIXTURES.forEach(({ description, params, expected }) => {
+            it(description, async () => {
+                const controller = new BrowserController(client, COINJOIN_BACKEND_SETTINGS);
                 const iterator = controller.getFilterIterator(params);
                 const received = [];
                 // eslint-disable-next-line no-restricted-syntax

--- a/packages/coinjoin/tests/backend/CoinjoinMempoolController.test.ts
+++ b/packages/coinjoin/tests/backend/CoinjoinMempoolController.test.ts
@@ -1,0 +1,42 @@
+import { CoinjoinMempoolController } from '../../src/backend/CoinjoinMempoolController';
+import { MockMempoolClient } from '../mocks/MockMempoolClient';
+import { BLOCKS, SEGWIT_RECEIVE_ADDRESSES } from '../fixtures/methods.fixture';
+
+const TXS = BLOCKS.flatMap(block => block.txs);
+const ADDRESS = SEGWIT_RECEIVE_ADDRESSES[1];
+const TXS_MATCH = [TXS[1], TXS[3]];
+
+describe('CoinjoinMempoolController', () => {
+    const client = new MockMempoolClient();
+    let mempool: CoinjoinMempoolController;
+
+    beforeEach(() => {
+        mempool = new CoinjoinMempoolController(client);
+    });
+
+    it('All at once', async () => {
+        client.setFixture(TXS);
+        await mempool.update();
+        const received = mempool.getTransactions([ADDRESS]);
+        expect(received).toEqual(TXS_MATCH);
+        expect(client.fetched).toEqual(TXS.map(({ txid }) => txid));
+    });
+
+    it('Progressing', async () => {
+        client.setFixture(TXS.slice(0, 3));
+        const start = mempool.getTransactions([ADDRESS]);
+        expect(start).toEqual([]);
+        expect(client.fetched).toEqual([]);
+
+        await mempool.update();
+        const mid = mempool.getTransactions([ADDRESS]);
+        expect(mid).toEqual(TXS_MATCH.slice(0, 1));
+        expect(client.fetched).toEqual(TXS.slice(0, 3).map(({ txid }) => txid));
+
+        client.setFixture(TXS);
+        await mempool.update();
+        const end = mempool.getTransactions([ADDRESS]);
+        expect(end).toEqual(TXS_MATCH);
+        expect(client.fetched).toEqual(TXS.slice(3).map(({ txid }) => txid));
+    });
+});

--- a/packages/coinjoin/tests/backend/CoinjoinStorage.test.ts
+++ b/packages/coinjoin/tests/backend/CoinjoinStorage.test.ts
@@ -1,0 +1,60 @@
+import { CoinjoinStorage } from '../../src/backend/CoinjoinStorage';
+import { mockFilter } from '../fixtures/filters.fixture';
+
+describe('CoinjoinStorage', () => {
+    let storage: CoinjoinStorage;
+
+    beforeEach(() => {
+        storage = new CoinjoinStorage(':memory:');
+    });
+
+    afterEach(() => {
+        storage.dispose();
+    });
+
+    it('isConsistent', () => {
+        expect(storage.isConsistent(2, 'hash_2')).toBe(true);
+        storage.loadBlockFilters([3, 4, 5].map(mockFilter));
+        expect(storage.isConsistent(2, 'hash_2')).toBe(true);
+        expect(storage.isConsistent(1, 'hash_1')).toBe(false);
+        storage.loadBlockFilters([7].map(mockFilter));
+        expect(storage.isConsistent(2, 'hash_2')).toBe(false);
+    });
+
+    it('(load|peek)BlockFilters', () => {
+        expect(storage.peekBlockFilter()).toBe(undefined);
+        expect(() => storage.loadBlockFilters([3, 4, 5].map(mockFilter))).not.toThrow();
+        expect(storage.peekBlockFilter()?.blockHeight).toBe(5);
+        expect(() => storage.loadBlockFilters([6, 5].map(mockFilter))).toThrow(); // PRIMARY KEY violation
+        expect(storage.peekBlockFilter()?.blockHeight).toBe(5);
+        expect(() => storage.loadBlockFilters([7, 8].map(mockFilter))).not.toThrow(); // ignoring broken sequence
+        expect(storage.peekBlockFilter()?.blockHeight).toBe(8);
+        expect(() =>
+            storage.loadBlockFilters([{ ...mockFilter(9), blockHash: 'hash_8' }]),
+        ).toThrow(); // UNIQUE violation
+    });
+
+    describe('getBlockFilterIterator', () => {
+        it('From start', () => {
+            const mockFilters = [5, 6, 7, 8].map(mockFilter);
+            storage.loadBlockFilters(mockFilters);
+            const iterator = storage.getBlockFilterIterator();
+            let index = 0;
+            // eslint-disable-next-line no-restricted-syntax
+            for (const filter of iterator()) {
+                expect(filter).toEqual(mockFilters[index++]);
+            }
+        });
+
+        it('From middle', () => {
+            const mockFilters = [5, 6, 7, 8].map(mockFilter);
+            storage.loadBlockFilters(mockFilters);
+            let index = 2;
+            const iterator = storage.getBlockFilterIterator(mockFilters[index].prevHash);
+            // eslint-disable-next-line no-restricted-syntax
+            for (const filter of iterator()) {
+                expect(filter).toEqual(mockFilters[index++]);
+            }
+        });
+    });
+});

--- a/packages/coinjoin/tests/backend/filters.test.ts
+++ b/packages/coinjoin/tests/backend/filters.test.ts
@@ -1,0 +1,158 @@
+import { networks } from '@trezor/utxo-lib';
+
+import { getAddressScript, getFilter } from '../../src/backend/filters';
+
+const NETWORK = networks.regtest;
+
+const COINJOIN_RECEIVE_0 = 'bcrt1pksw3pwfgueqmnxvyesjxj24q2wek77lsq4jan745j2z9wr9csf3qpgmdpz'; // OUT 106, IN 108
+const COINJOIN_CHANGE_0 = 'bcrt1pc3488glntqgqel3jjtwujl8g50xrvx04ewpt799ns77dg756km5qa66ca8'; // OUT 108, IN 109
+const BECH32_RECEIVE_0 = 'bcrt1qkvwu9g3k2pdxewfqr7syz89r3gj557l374sg5v'; // OUT 157, IN 158
+const BECH32_CHANGE_0 = 'bcrt1qejqxwzfld7zr6mf7ygqy5s5se5xq7vmt8ntmj0'; // OUT 159, IN 160
+const TAPROOT_RECEIVE_0 = 'bcrt1pswrqtykue8r89t9u4rprjs0gt4qzkdfuursfnvqaa3f2yql07zmq2fdmpx'; // OUT 161, IN 162
+const TAPROOT_CHANGE_0 = 'bcrt1pn2d0yjeedavnkd8z8lhm566p0f2utm3lgvxrsdehnl94y34txmtsef5dqz'; // OUT 162, IN 163
+
+const BLOCK_106 = {
+    height: 106,
+    filter: '0135dff8',
+    hash: '2c94e940c0584944bfdf0137936e6a6fc8ad4416a96b3663b09961574568331c',
+};
+
+const BLOCK_108 = {
+    height: 108,
+    filter: '0662a3ec50c3e5524c8b25ceaa9c061aef80',
+    hash: '4bf55f6337c2e921fe2bf87bb121ded31988ea99d9edf2dc5498f605fd1d966e',
+};
+
+const BLOCK_109 = {
+    height: 109,
+    filter: '0704ac18e1c3e5f4f22fd21e20233627d8927624',
+    hash: '35fbbceea020bc388dcb1b7afcba60e27da0889bd3d0689d2a786e9a8bd12746',
+};
+
+const BLOCK_157 = {
+    height: 157,
+    filter: '01656c90',
+    hash: '09f69854a4572575e2a8af0dea70ff5efd46957e2cb60e81c0d760098ab48b44',
+};
+
+const BLOCK_158 = {
+    height: 158,
+    filter: '0298ad7857d0c0',
+    hash: '5513d63651bbb32985b54fa9e0e530553e3e9cebdd10feae7f019c04edb80f61',
+};
+
+const BLOCK_159 = {
+    height: 159,
+    filter: '03a69058941e6f5fc1',
+    hash: '5021a2185f27ad04d45f1b53c873b2231311aea99e0f1d7a6252167540b9db4c',
+};
+
+const BLOCK_160 = {
+    height: 160,
+    filter: '023eee59053e40',
+    hash: '01d37c4490e9ddaf6b5c886eaa215b8d0b658c93ea42cfd871b226f606672c0b',
+};
+
+const BLOCK_161 = {
+    height: 161,
+    filter: '012d70f8',
+    hash: '01c8add70f124c8d220d8f82e759ad3d1d0fa8f174dab9a9363a4c36de4e4b44',
+};
+
+const BLOCK_162 = {
+    height: 162,
+    filter: '03018bfa4d4731ee2480',
+    hash: '12de06b8ae4bbc660e3f565c876c606f5a1bd3463364c6abfc882b5ff6dd86e3',
+};
+
+const BLOCK_163 = {
+    height: 163,
+    filter: '02782a5165c980',
+    hash: '36d01c975372c363d94f0e9e22e8a61a6a52e3408c98920ef1587b024ec487e3',
+};
+
+describe('Golomb filtering', () => {
+    it('Receive address as input', () => {
+        const script = getAddressScript(COINJOIN_RECEIVE_0, NETWORK);
+        const filter = getFilter(BLOCK_108.filter, BLOCK_108.hash);
+        expect(filter(script)).toBe(true);
+    });
+
+    it('Receive address as output', () => {
+        const script = getAddressScript(COINJOIN_RECEIVE_0, NETWORK);
+        const filter = getFilter(BLOCK_106.filter, BLOCK_106.hash);
+        expect(filter(script)).toBe(true);
+    });
+
+    it('Receive address nowhere', () => {
+        const script = getAddressScript(COINJOIN_RECEIVE_0, NETWORK);
+        const filter = getFilter(BLOCK_109.filter, BLOCK_109.hash);
+        expect(filter(script)).toBe(false);
+    });
+
+    it('Change address as input', () => {
+        const script = getAddressScript(COINJOIN_CHANGE_0, NETWORK);
+        const filter = getFilter(BLOCK_109.filter, BLOCK_109.hash);
+        expect(filter(script)).toBe(true);
+    });
+
+    it('Change address as output', () => {
+        const script = getAddressScript(COINJOIN_CHANGE_0, NETWORK);
+        const filter = getFilter(BLOCK_108.filter, BLOCK_108.hash);
+        expect(filter(script)).toBe(true);
+    });
+
+    it('Change address nowhere', () => {
+        const script = getAddressScript(COINJOIN_CHANGE_0, NETWORK);
+        const filter = getFilter(BLOCK_106.filter, BLOCK_106.hash);
+        expect(filter(script)).toBe(false);
+    });
+
+    it('Bech32 receive address as input', () => {
+        const script = getAddressScript(BECH32_RECEIVE_0, NETWORK);
+        const filter = getFilter(BLOCK_158.filter, BLOCK_158.hash);
+        expect(filter(script)).toBe(true);
+    });
+
+    it('Bech32 receive address as output', () => {
+        const script = getAddressScript(BECH32_RECEIVE_0, NETWORK);
+        const filter = getFilter(BLOCK_157.filter, BLOCK_157.hash);
+        expect(filter(script)).toBe(true);
+    });
+
+    it('Bech32 change address as input', () => {
+        const script = getAddressScript(BECH32_CHANGE_0, NETWORK);
+        const filter = getFilter(BLOCK_160.filter, BLOCK_160.hash);
+        expect(filter(script)).toBe(true);
+    });
+
+    it('Bech32 change address as output', () => {
+        const script = getAddressScript(BECH32_CHANGE_0, NETWORK);
+        const filter = getFilter(BLOCK_159.filter, BLOCK_159.hash);
+        expect(filter(script)).toBe(true);
+    });
+
+    it('Taproot receive address as input', () => {
+        const script = getAddressScript(TAPROOT_RECEIVE_0, NETWORK);
+        const filter = getFilter(BLOCK_162.filter, BLOCK_162.hash);
+        expect(filter(script)).toBe(true);
+    });
+
+    it('Taproot receive address as output', () => {
+        const script = getAddressScript(TAPROOT_RECEIVE_0, NETWORK);
+        const filter = getFilter(BLOCK_161.filter, BLOCK_161.hash);
+        expect(filter(script)).toBe(true);
+    });
+
+    it('Taproot change address as input', () => {
+        const script = getAddressScript(TAPROOT_CHANGE_0, NETWORK);
+        const filter = getFilter(BLOCK_163.filter, BLOCK_163.hash);
+        expect(filter(script)).toBe(true);
+    });
+
+    it('Taproot change address as output', () => {
+        const script = getAddressScript(TAPROOT_CHANGE_0, NETWORK);
+        const filter = getFilter(BLOCK_162.filter, BLOCK_162.hash);
+        expect(filter(script)).toBe(true);
+    });
+});

--- a/packages/coinjoin/tests/backend/methods.test.ts
+++ b/packages/coinjoin/tests/backend/methods.test.ts
@@ -26,8 +26,8 @@ describe(`CoinjoinBackend methods`, () => {
 
     const getRequestedFilters = () =>
         Promise.all(fetchFiltersMock.mock.results.map(res => res.value)).then(
-            (res: BlockFilterResponse[]) =>
-                res.flatMap(res => res.filters.map(filter => filter.blockHeight as number)),
+            (response: BlockFilterResponse[]) =>
+                response.flatMap(res => res.filters.map(filter => filter.blockHeight as number)),
         );
 
     const getRequestedBlocks = () =>
@@ -59,6 +59,7 @@ describe(`CoinjoinBackend methods`, () => {
     beforeEach(() => {
         fetchFiltersMock.mockClear();
         fetchBlockMock.mockClear();
+        fetchTxMock.mockClear();
         client.setFixture(FIXTURES.BLOCKS);
     });
 
@@ -156,8 +157,9 @@ describe(`CoinjoinBackend methods`, () => {
         fetchBlockMock.mockClear();
 
         // Should request only txid_4 transaction from mempool
+        // and txid_2 because it has account's inputs (TEMPORARY FIX)
         const halfTxs = getRequestedTxs();
-        expect(halfTxs).toEqual([FIXTURES.TX_4_PENDING.txid]);
+        expect(halfTxs).toEqual(['txid_2', FIXTURES.TX_4_PENDING.txid]);
         fetchTxMock.mockClear();
 
         // All blocks are known
@@ -191,7 +193,8 @@ describe(`CoinjoinBackend methods`, () => {
         expect(restBlocks).toEqual([6, 7, 8]);
 
         // Shouldn't request any transaction from mempool
+        // and txid_4 and txid_5 because they have account's inputs (TEMPORARY FIX)
         const restTxs = getRequestedTxs();
-        expect(restTxs).toEqual([]);
+        expect(restTxs).toEqual(['txid_4', 'txid_5']);
     });
 });

--- a/packages/coinjoin/tests/backend/methods.test.ts
+++ b/packages/coinjoin/tests/backend/methods.test.ts
@@ -1,0 +1,197 @@
+import { arrayDistinct } from '@trezor/utils';
+import { networks } from '@trezor/utxo-lib';
+
+import { DISCOVERY_LOOKOUT } from '../../src/constants';
+import { scanAccount } from '../../src/backend/scanAccount';
+import { scanAddress } from '../../src/backend/scanAddress';
+import { getAccountInfo } from '../../src/backend/getAccountInfo';
+import { CoinjoinFilterController } from '../../src/backend/CoinjoinFilterController';
+import { CoinjoinMempoolController } from '../../src/backend/CoinjoinMempoolController';
+import * as FIXTURES from '../fixtures/methods.fixture';
+import { MockBackendClient } from '../mocks/MockBackendClient';
+import type { BlockFilterResponse, Transaction } from '../../src/backend/types';
+
+const EMPTY_CHECKPOINT = {
+    blockHash: FIXTURES.BASE_HASH,
+    blockHeight: 0,
+    receiveCount: DISCOVERY_LOOKOUT,
+    changeCount: DISCOVERY_LOOKOUT,
+};
+
+describe(`CoinjoinBackend methods`, () => {
+    const client = new MockBackendClient();
+    const fetchFiltersMock = jest.spyOn(client, 'fetchFilters');
+    const fetchBlockMock = jest.spyOn(client, 'fetchBlock');
+    const fetchTxMock = jest.spyOn(client, 'fetchTransaction');
+
+    const getRequestedFilters = () =>
+        Promise.all(fetchFiltersMock.mock.results.map(res => res.value)).then(
+            (res: BlockFilterResponse[]) =>
+                res.flatMap(res => res.filters.map(filter => filter.blockHeight as number)),
+        );
+
+    const getRequestedBlocks = () =>
+        fetchBlockMock.mock.calls
+            .map(call => call[0])
+            .filter(arrayDistinct)
+            .sort();
+
+    const getRequestedTxs = () =>
+        fetchTxMock.mock.calls
+            .map(call => call[0])
+            .filter(arrayDistinct)
+            .sort();
+
+    const getContext = <T>(onProgress: (t: T) => void) => ({
+        client,
+        filters: new CoinjoinFilterController(client, {
+            baseBlockHash: FIXTURES.BASE_HASH,
+            baseBlockHeight: FIXTURES.BASE_HEIGHT,
+            blockbookUrls: ['foo'],
+            coordinatorUrl: 'bar',
+            network: 'regtest',
+        }),
+        mempool: new CoinjoinMempoolController(client),
+        network: networks.regtest,
+        onProgress,
+    });
+
+    beforeEach(() => {
+        fetchFiltersMock.mockClear();
+        fetchBlockMock.mockClear();
+        client.setFixture(FIXTURES.BLOCKS);
+    });
+
+    it('scanAddress', async () => {
+        let txs: Transaction[] = [];
+
+        const { pending } = await scanAddress(
+            {
+                descriptor: FIXTURES.SEGWIT_RECEIVE_ADDRESSES[0],
+                checkpoint: EMPTY_CHECKPOINT,
+            },
+            getContext(progress => {
+                txs = txs.concat(progress.transactions);
+            }),
+        );
+
+        const info = getAccountInfo({
+            descriptor: FIXTURES.SEGWIT_RECEIVE_ADDRESSES[0],
+            network: networks.regtest,
+            transactions: txs.concat(pending),
+        });
+
+        expect(info).toMatchObject(FIXTURES.SEGWIT_RECEIVE_RESULT);
+
+        const filters = await getRequestedFilters();
+        expect(filters).toEqual([1, 2, 3, 4, 5, 6, 7, 8]);
+
+        const blocks = getRequestedBlocks();
+        expect(blocks).toEqual([1, 2, 4, 6, 7, 8]);
+    });
+
+    it('scanAccount at once', async () => {
+        let txs: Transaction[] = [];
+
+        const { pending, checkpoint } = await scanAccount(
+            {
+                descriptor: FIXTURES.SEGWIT_XPUB,
+                checkpoint: EMPTY_CHECKPOINT,
+            },
+            getContext(progress => {
+                txs = txs.concat(progress.transactions);
+            }),
+        );
+
+        const info = getAccountInfo({
+            descriptor: FIXTURES.SEGWIT_XPUB,
+            network: networks.regtest,
+            transactions: txs.concat(pending),
+            checkpoint,
+        });
+
+        expect(info).toMatchObject(FIXTURES.SEGWIT_XPUB_RESULT);
+
+        const filters = await getRequestedFilters();
+        expect(filters).toEqual([1, 2, 3, 4, 5, 6, 7, 8]);
+
+        const blocks = getRequestedBlocks();
+        expect(blocks).toEqual([1, 2, 4, 6, 7, 8]);
+    });
+
+    it('scanAccount differential', async () => {
+        let txs: Transaction[] = [];
+
+        // Only four blocks are known,
+        // txid_4 is in mempool
+        client.setFixture(FIXTURES.BLOCKS.slice(0, 4), [FIXTURES.TX_4_PENDING]);
+
+        const half = await scanAccount(
+            {
+                descriptor: FIXTURES.SEGWIT_XPUB,
+                checkpoint: EMPTY_CHECKPOINT,
+            },
+            getContext(progress => {
+                txs = txs.concat(progress.transactions);
+            }),
+        );
+
+        const halfInfo = getAccountInfo({
+            descriptor: FIXTURES.SEGWIT_XPUB,
+            network: networks.regtest,
+            transactions: txs.concat(half.pending),
+            checkpoint: half.checkpoint,
+        });
+
+        expect(halfInfo).toMatchObject(FIXTURES.SEGWIT_XPUB_RESULT_HALF);
+
+        // Should request only first four block filters
+        const halfFilters = await getRequestedFilters();
+        expect(halfFilters).toEqual([1, 2, 3, 4]);
+        fetchFiltersMock.mockClear();
+
+        // Should request only first four blocks (except the third which is empty)
+        const halfBlocks = getRequestedBlocks();
+        expect(halfBlocks).toEqual([1, 2, 4]);
+        fetchBlockMock.mockClear();
+
+        // Should request only txid_4 transaction from mempool
+        const halfTxs = getRequestedTxs();
+        expect(halfTxs).toEqual([FIXTURES.TX_4_PENDING.txid]);
+        fetchTxMock.mockClear();
+
+        // All blocks are known
+        client.setFixture(FIXTURES.BLOCKS);
+
+        const full = await scanAccount(
+            {
+                descriptor: FIXTURES.SEGWIT_XPUB,
+                checkpoint: half.checkpoint,
+            },
+            getContext(progress => {
+                txs = txs.concat(progress.transactions);
+            }),
+        );
+
+        const fullInfo = getAccountInfo({
+            descriptor: FIXTURES.SEGWIT_XPUB,
+            network: networks.regtest,
+            transactions: txs.concat(full.pending),
+            checkpoint: full.checkpoint,
+        });
+
+        expect(fullInfo).toMatchObject(FIXTURES.SEGWIT_XPUB_RESULT);
+
+        // Should request only block filters after the fourth one
+        const restFilters = await getRequestedFilters();
+        expect(restFilters).toEqual([5, 6, 7, 8]);
+
+        // Should request only blocks after the fourth one (except the fifth which is empty)
+        const restBlocks = getRequestedBlocks();
+        expect(restBlocks).toEqual([6, 7, 8]);
+
+        // Shouldn't request any transaction from mempool
+        const restTxs = getRequestedTxs();
+        expect(restTxs).toEqual([]);
+    });
+});

--- a/packages/coinjoin/tests/backend/methods.test.ts
+++ b/packages/coinjoin/tests/backend/methods.test.ts
@@ -5,7 +5,7 @@ import { DISCOVERY_LOOKOUT } from '../../src/constants';
 import { scanAccount } from '../../src/backend/scanAccount';
 import { scanAddress } from '../../src/backend/scanAddress';
 import { getAccountInfo } from '../../src/backend/getAccountInfo';
-import { CoinjoinFilterController } from '../../src/backend/CoinjoinFilterController';
+import { CoinjoinFilterController } from '../../src/backend/CoinjoinFilterController.browser';
 import { CoinjoinMempoolController } from '../../src/backend/CoinjoinMempoolController';
 import * as FIXTURES from '../fixtures/methods.fixture';
 import { MockBackendClient } from '../mocks/MockBackendClient';

--- a/packages/coinjoin/tests/fixtures/config.fixture.ts
+++ b/packages/coinjoin/tests/fixtures/config.fixture.ts
@@ -1,0 +1,7 @@
+export const COINJOIN_BACKEND_SETTINGS = {
+    network: 'regtest',
+    coordinatorUrl: 'http://localhost:8081/WabiSabi/',
+    blockbookUrls: ['http://localhost:8081/blockbook/api/v2'],
+    baseBlockHeight: 0,
+    baseBlockHash: '0f9188f13cb7b2c71f2a335e3a4fc328bf5beb436012afca590b1a11466e2206',
+} as const;

--- a/packages/coinjoin/tests/fixtures/filters.fixture.ts
+++ b/packages/coinjoin/tests/fixtures/filters.fixture.ts
@@ -1,0 +1,33 @@
+import { BlockFilter } from '../../src/backend/types';
+
+/**
+ * example: 3 => {
+ *  blockHeight: 3,
+ *  blockTime: 30,
+ *  blockHash: 'hash_3',
+ *  prevHash: 'hash_2'
+ *  filter: 'filter_3',
+ * }
+ */
+export const mockFilter = (height: number): BlockFilter => ({
+    blockHeight: height,
+    blockTime: height * 10,
+    blockHash: `hash_${height}`,
+    prevHash: `hash_${height - 1}`,
+    filter: `filter_${height}`,
+});
+
+export const mockFilterSequence = (
+    count: number,
+    baseHeight = 0,
+    baseHash = 'hash_0',
+): BlockFilter[] => {
+    const filters: BlockFilter[] = [];
+    for (let i = 0; i < count; ++i) {
+        filters.push({
+            ...mockFilter(baseHeight + i + 1),
+            prevHash: filters[i - 1]?.blockHash ?? baseHash,
+        });
+    }
+    return filters;
+};

--- a/packages/coinjoin/tests/fixtures/methods.fixture.ts
+++ b/packages/coinjoin/tests/fixtures/methods.fixture.ts
@@ -79,6 +79,8 @@ export const BLOCKS = [
                         addresses: ['bcrt1qkvwu9g3k2pdxewfqr7syz89r3gj557l374sg5v'],
                         isAddress: true,
                         value: '1000000000',
+                        txid: 'txid_1',
+                        vout: 1,
                     },
                 ],
                 vout: [
@@ -167,6 +169,7 @@ export const BLOCKS = [
                         addresses: ['bcrt1qldlynaqp0hy4zc2aag3pkenzvxy65saej0huey'],
                         isAddress: true,
                         value: '999999890',
+                        txid: 'txid_2',
                     },
                 ],
                 vout: [
@@ -206,12 +209,15 @@ export const BLOCKS = [
                         addresses: ['bcrt1qkvwu9g3k2pdxewfqr7syz89r3gj557l374sg5v'],
                         isAddress: true,
                         value: '547',
+                        txid: 'txid_4',
                     },
                     {
                         n: 1,
                         addresses: ['bcrt1qejqxwzfld7zr6mf7ygqy5s5se5xq7vmt8ntmj0'],
                         isAddress: true,
                         value: '999999202',
+                        txid: 'txid_4',
+                        vout: 1,
                     },
                 ],
                 vout: [
@@ -787,6 +793,35 @@ export const SEGWIT_XPUB_RESULT = {
         ],
     },
     page: { index: 1, size: 25, total: 1 },
+    utxo: [
+        {
+            address: 'bcrt1qkvwu9g3k2pdxewfqr7syz89r3gj557l374sg5v',
+            path: "m/84'/1'/0'/0/0",
+            txid: 'txid_3',
+            vout: 0,
+            blockHeight: 4,
+            amount: '547',
+            confirmations: 1,
+        },
+        {
+            address: 'bcrt1qkvwu9g3k2pdxewfqr7syz89r3gj557l374sg5v',
+            path: "m/84'/1'/0'/0/0",
+            txid: 'txid_5',
+            vout: 0,
+            blockHeight: 7,
+            amount: '999999571',
+            confirmations: 1,
+        },
+        {
+            address: 'bcrt1qkvwu9g3k2pdxewfqr7syz89r3gj557l374sg5v',
+            path: "m/84'/1'/0'/0/0",
+            txid: 'txid_6',
+            vout: 0,
+            blockHeight: 8,
+            amount: '999999212',
+            confirmations: 1,
+        },
+    ],
 };
 
 const {
@@ -798,6 +833,7 @@ const {
     history: {
         transactions: [, , pending, ...transactions],
     },
+    utxo: [utxo],
     ...rest
 } = SEGWIT_XPUB_RESULT;
 
@@ -824,6 +860,27 @@ export const SEGWIT_XPUB_RESULT_HALF = {
         unconfirmed: 1,
         transactions: [{ ...pending, blockHeight: -1, blockTime: undefined }, ...transactions],
     },
+    utxo: [
+        utxo,
+        {
+            txid: 'txid_4',
+            vout: 0,
+            address: 'bcrt1qkvwu9g3k2pdxewfqr7syz89r3gj557l374sg5v',
+            path: "m/84'/1'/0'/0/0",
+            blockHeight: -1,
+            confirmations: 0,
+            amount: '547',
+        },
+        {
+            txid: 'txid_4',
+            vout: 1,
+            address: 'bcrt1qejqxwzfld7zr6mf7ygqy5s5se5xq7vmt8ntmj0',
+            path: "m/84'/1'/0'/1/0",
+            blockHeight: -1,
+            confirmations: 0,
+            amount: '999999202',
+        },
+    ],
 };
 
 const {
@@ -842,6 +899,11 @@ const {
         ],
         ...xpubHistory
     },
+    utxo: [
+        { address: addr1, path: p1, ...utxo1 },
+        { address: addr2, path: p2, ...utxo2 },
+        { address: addr3, path: p3, ...utxo3 },
+    ],
     ...xpubRest
 } = SEGWIT_XPUB_RESULT;
 
@@ -866,4 +928,5 @@ export const SEGWIT_RECEIVE_RESULT = {
             tx1,
         ],
     },
+    utxo: [utxo1, utxo2, utxo3],
 };

--- a/packages/coinjoin/tests/fixtures/methods.fixture.ts
+++ b/packages/coinjoin/tests/fixtures/methods.fixture.ts
@@ -1,0 +1,869 @@
+export const SEGWIT_XPUB =
+    'vpub5YX1yJFY8E236pH3iNvCpThsXLxoQoC4nwraaS5h4TZwaSp1Gg9SQoxCsrumxjh7nZRQQkNfH29TEDeMvAZVmD3rpmsDnFc5Sj4JgJG6m4b';
+
+export const SEGWIT_RECEIVE_ADDRESSES = [
+    'bcrt1qkvwu9g3k2pdxewfqr7syz89r3gj557l374sg5v', // receive 1
+    'bcrt1qldlynaqp0hy4zc2aag3pkenzvxy65saej0huey', // receive 2
+    'bcrt1q9l0rk0gkgn73d0gc57qn3t3cwvucaj3h98jwg4', // receive 3
+    'bcrt1qtxe2hdle9he8hc2xds7yl2m8zutjksv0gmszw2', // receive 4
+    'bcrt1qglrv8xrtf68udd5pxj2pxyq5s7lynq204v2da8', // receive 5
+];
+
+export const SEGWIT_CHANGE_ADDRESSES = [
+    'bcrt1qejqxwzfld7zr6mf7ygqy5s5se5xq7vmt8ntmj0', // change 1
+    'bcrt1qze76uzqteg6un6jfcryrxhwvfvjj58tsdeh9xy', // change 2
+    'bcrt1qr5p6f5sk09sms57ket074vywfymuthlg7y8tn0', // change 3
+    'bcrt1qwn0s88t9r39g72m78mcaxj72sy3ct4m4dulavf', // change 4
+    'bcrt1qguznsd2hyl69gjx2axd6f5qu9k274qj9v5syhd', // change 5
+];
+
+export const BASE_HEIGHT = 0;
+export const BASE_HASH = 'craigwrightisafraud';
+
+// hash + filter must be always preserved for the filters to work
+export const BLOCKS = [
+    {
+        height: 1,
+        hash: '09f69854a4572575e2a8af0dea70ff5efd46957e2cb60e81c0d760098ab48b44',
+        filter: '01656c90', // receive 1 out
+        previousBlockHash: BASE_HASH,
+        txs: [
+            {
+                txid: 'txid_1',
+                blockHeight: 1,
+                blockTime: 1337,
+                value: '1578597058',
+                fees: '28059',
+                vin: [
+                    {
+                        n: 0,
+                        addresses: ['mkUzYq8aQ4xzgPoCw8QVsRzkn1dceiPzmi'],
+                        isAddress: true,
+                        value: '1578625117',
+                    },
+                ],
+                vout: [
+                    {
+                        value: '578597058',
+                        n: 0,
+                        spent: true,
+                        addresses: ['n29Q5yZh813J4MHtY4KjteNs1rfRWVRRPJ'],
+                        isAddress: true,
+                    },
+                    {
+                        value: '1000000000',
+                        n: 1,
+                        spent: true,
+                        addresses: ['bcrt1qkvwu9g3k2pdxewfqr7syz89r3gj557l374sg5v'],
+                        isAddress: true,
+                    },
+                ],
+            },
+        ],
+    },
+    {
+        height: 2,
+        hash: '5513d63651bbb32985b54fa9e0e530553e3e9cebdd10feae7f019c04edb80f61',
+        filter: '0298ad7857d0c0', // receive 1 in, receive 2 out
+        previousBlockHash: '09f69854a4572575e2a8af0dea70ff5efd46957e2cb60e81c0d760098ab48b44',
+        txs: [
+            {
+                txid: 'txid_2',
+                blockHeight: 2,
+                blockTime: 1337,
+                value: '999999890',
+                fees: '110',
+                vin: [
+                    {
+                        n: 0,
+                        addresses: ['bcrt1qkvwu9g3k2pdxewfqr7syz89r3gj557l374sg5v'],
+                        isAddress: true,
+                        value: '1000000000',
+                    },
+                ],
+                vout: [
+                    {
+                        value: '999999890',
+                        n: 0,
+                        spent: true,
+                        addresses: ['bcrt1qldlynaqp0hy4zc2aag3pkenzvxy65saej0huey'],
+                        isAddress: true,
+                    },
+                ],
+            },
+        ],
+    },
+    {
+        height: 3,
+        hash: '295578a3c8eb87736a5e657b06a0933f7ec5f82c43f8418fdb38f74c0fc066c7',
+        filter: '0802a1103e91e638632d0f148d8c4618cc6118aeaad3d0', // nothing
+        previousBlockHash: '5513d63651bbb32985b54fa9e0e530553e3e9cebdd10feae7f019c04edb80f61',
+        txs: [],
+    },
+    {
+        height: 4,
+        hash: '12de06b8ae4bbc660e3f565c876c606f5a1bd3463364c6abfc882b5ff6dd86e3',
+        filter: '03018bfa4d4731ee2480', // receive 1 out
+        previousBlockHash: '295578a3c8eb87736a5e657b06a0933f7ec5f82c43f8418fdb38f74c0fc066c7',
+        txs: [
+            {
+                txid: 'txid_3',
+                blockHeight: 4,
+                blockTime: 1337,
+                value: '999999858',
+                fees: '142',
+                vin: [
+                    {
+                        n: 0,
+                        addresses: [
+                            'bcrt1pswrqtykue8r89t9u4rprjs0gt4qzkdfuursfnvqaa3f2yql07zmq2fdmpx',
+                        ],
+                        isAddress: true,
+                        value: '1000000000',
+                    },
+                ],
+                vout: [
+                    {
+                        value: '547',
+                        n: 0,
+                        addresses: ['bcrt1qkvwu9g3k2pdxewfqr7syz89r3gj557l374sg5v'],
+                        isAddress: true,
+                    },
+                    {
+                        value: '999999311',
+                        n: 1,
+                        spent: true,
+                        addresses: [
+                            'bcrt1pn2d0yjeedavnkd8z8lhm566p0f2utm3lgvxrsdehnl94y34txmtsef5dqz',
+                        ],
+                        isAddress: true,
+                    },
+                ],
+            },
+        ],
+    },
+    {
+        height: 5,
+        hash: '2c2c65aad93eebe235955e170913fd6558453dd999a4ded6249bbdc9d54da1f7',
+        filter: '08a4afd740dddb6185ca00666d22a55fc9252008f9cda0', // nothing
+        previousBlockHash: '12de06b8ae4bbc660e3f565c876c606f5a1bd3463364c6abfc882b5ff6dd86e3',
+        txs: [],
+    },
+    {
+        height: 6,
+        hash: '5021a2185f27ad04d45f1b53c873b2231311aea99e0f1d7a6252167540b9db4c',
+        filter: '03a69058941e6f5fc1', // receive 2 in, receive 1 out, change 1 out'
+        previousBlockHash: '2c2c65aad93eebe235955e170913fd6558453dd999a4ded6249bbdc9d54da1f7',
+        txs: [
+            {
+                txid: 'txid_4',
+                blockHeight: 6,
+                blockTime: 1337,
+                value: '999999749',
+                fees: '141',
+                vin: [
+                    {
+                        n: 0,
+                        addresses: ['bcrt1qldlynaqp0hy4zc2aag3pkenzvxy65saej0huey'],
+                        isAddress: true,
+                        value: '999999890',
+                    },
+                ],
+                vout: [
+                    {
+                        value: '547',
+                        n: 0,
+                        spent: true,
+                        addresses: ['bcrt1qkvwu9g3k2pdxewfqr7syz89r3gj557l374sg5v'],
+                        isAddress: true,
+                    },
+                    {
+                        value: '999999202',
+                        n: 1,
+                        spent: true,
+                        addresses: ['bcrt1qejqxwzfld7zr6mf7ygqy5s5se5xq7vmt8ntmj0'],
+                        isAddress: true,
+                    },
+                ],
+            },
+        ],
+    },
+    {
+        height: 7,
+        hash: '01d37c4490e9ddaf6b5c886eaa215b8d0b658c93ea42cfd871b226f606672c0b',
+        filter: '023eee59053e40', // receive 1 in, change 1 in, receive 1 out'
+        previousBlockHash: '5021a2185f27ad04d45f1b53c873b2231311aea99e0f1d7a6252167540b9db4c',
+        txs: [
+            {
+                txid: 'txid_5',
+                blockHeight: 7,
+                blockTime: 1337,
+                value: '999999571',
+                fees: '178',
+                vin: [
+                    {
+                        n: 0,
+                        addresses: ['bcrt1qkvwu9g3k2pdxewfqr7syz89r3gj557l374sg5v'],
+                        isAddress: true,
+                        value: '547',
+                    },
+                    {
+                        n: 1,
+                        addresses: ['bcrt1qejqxwzfld7zr6mf7ygqy5s5se5xq7vmt8ntmj0'],
+                        isAddress: true,
+                        value: '999999202',
+                    },
+                ],
+                vout: [
+                    {
+                        value: '999999571',
+                        n: 0,
+                        addresses: ['bcrt1qkvwu9g3k2pdxewfqr7syz89r3gj557l374sg5v'],
+                        isAddress: true,
+                    },
+                ],
+            },
+        ],
+    },
+    {
+        height: 8,
+        hash: '36d01c975372c363d94f0e9e22e8a61a6a52e3408c98920ef1587b024ec487e3',
+        filter: '02782a5165c980', // receive 1 out
+        previousBlockHash: '01d37c4490e9ddaf6b5c886eaa215b8d0b658c93ea42cfd871b226f606672c0b',
+        txs: [
+            {
+                txid: 'txid_6',
+                blockHeight: 8,
+                blockTime: 1337,
+                value: '999999212',
+                fees: '99',
+                vin: [
+                    {
+                        n: 0,
+                        addresses: [
+                            'bcrt1pn2d0yjeedavnkd8z8lhm566p0f2utm3lgvxrsdehnl94y34txmtsef5dqz',
+                        ],
+                        isAddress: true,
+                        value: '999999311',
+                    },
+                ],
+                vout: [
+                    {
+                        value: '999999212',
+                        n: 0,
+                        addresses: ['bcrt1qkvwu9g3k2pdxewfqr7syz89r3gj557l374sg5v'],
+                        isAddress: true,
+                    },
+                ],
+            },
+        ],
+    },
+];
+
+export const TX_4_PENDING = {
+    ...BLOCKS[5].txs[0],
+    blockHeight: -1,
+    blockTime: undefined,
+};
+
+export const SEGWIT_XPUB_RESULT = {
+    descriptor:
+        'vpub5YX1yJFY8E236pH3iNvCpThsXLxoQoC4nwraaS5h4TZwaSp1Gg9SQoxCsrumxjh7nZRQQkNfH29TEDeMvAZVmD3rpmsDnFc5Sj4JgJG6m4b',
+    balance: '1999999330',
+    availableBalance: '1999999330',
+    empty: false,
+    addresses: {
+        change: [
+            {
+                address: 'bcrt1qejqxwzfld7zr6mf7ygqy5s5se5xq7vmt8ntmj0',
+                path: "m/84'/1'/0'/1/0",
+                transfers: 2,
+                balance: '0',
+                sent: '999999202',
+                received: '999999202',
+            },
+            {
+                address: 'bcrt1qze76uzqteg6un6jfcryrxhwvfvjj58tsdeh9xy',
+                path: "m/84'/1'/0'/1/1",
+                transfers: 0,
+            },
+            {
+                address: 'bcrt1qr5p6f5sk09sms57ket074vywfymuthlg7y8tn0',
+                path: "m/84'/1'/0'/1/2",
+                transfers: 0,
+            },
+            {
+                address: 'bcrt1qwn0s88t9r39g72m78mcaxj72sy3ct4m4dulavf',
+                path: "m/84'/1'/0'/1/3",
+                transfers: 0,
+            },
+            {
+                address: 'bcrt1qguznsd2hyl69gjx2axd6f5qu9k274qj9v5syhd',
+                path: "m/84'/1'/0'/1/4",
+                transfers: 0,
+            },
+            {
+                address: 'bcrt1q8zx9dlztqz9apm7y5gtx8a0tlz57fhncycvun5',
+                path: "m/84'/1'/0'/1/5",
+                transfers: 0,
+            },
+            {
+                address: 'bcrt1qger2dlc2mykcavfxs0ad8eupr058njwp2e8n6m',
+                path: "m/84'/1'/0'/1/6",
+                transfers: 0,
+            },
+            {
+                address: 'bcrt1qjm4p4nykvsczt26llswppmfe7xraane9nfruqv',
+                path: "m/84'/1'/0'/1/7",
+                transfers: 0,
+            },
+            {
+                address: 'bcrt1qm3sx7jlgj7yd3y2ad0jm587k98pcc2x5wfq5jf',
+                path: "m/84'/1'/0'/1/8",
+                transfers: 0,
+            },
+            {
+                address: 'bcrt1qcvgld0z38vnx9fnpsgwuc583838ldv8sf38pwz',
+                path: "m/84'/1'/0'/1/9",
+                transfers: 0,
+            },
+            {
+                address: 'bcrt1quja53ex7clst8yhkwenhy8p67aa36kedqszlun',
+                path: "m/84'/1'/0'/1/10",
+                transfers: 0,
+            },
+            {
+                address: 'bcrt1qlxvp7fwy0azketw0afgw0snxssyphmtthe4g8g',
+                path: "m/84'/1'/0'/1/11",
+                transfers: 0,
+            },
+            {
+                address: 'bcrt1ql02lgacsfm543teeymtw2p7xz9unxe6572mxeh',
+                path: "m/84'/1'/0'/1/12",
+                transfers: 0,
+            },
+            {
+                address: 'bcrt1qnuafw94yvu6td7tcfqea823y342ttrc9d32qnx',
+                path: "m/84'/1'/0'/1/13",
+                transfers: 0,
+            },
+            {
+                address: 'bcrt1q92khcru77q7hrctf7ter2kltpgtrz23nhnkcaz',
+                path: "m/84'/1'/0'/1/14",
+                transfers: 0,
+            },
+            {
+                address: 'bcrt1qu8ts4a80ylfq7hgy9aqt0rk65gekmt5p029ymm',
+                path: "m/84'/1'/0'/1/15",
+                transfers: 0,
+            },
+            {
+                address: 'bcrt1qc0zg0xrs0grvrmr0hrq7u0rdthadsrk406w0dk',
+                path: "m/84'/1'/0'/1/16",
+                transfers: 0,
+            },
+            {
+                address: 'bcrt1quvm4wfs9pjrqvr4rmy60k8uevg009jhtx9zzxr',
+                path: "m/84'/1'/0'/1/17",
+                transfers: 0,
+            },
+            {
+                address: 'bcrt1qetngs772lxz97x94v9ycfjtwelmu7aqmuu5vkl',
+                path: "m/84'/1'/0'/1/18",
+                transfers: 0,
+            },
+            {
+                address: 'bcrt1qaydzjvcf0qnfxs9aw8zmazt88f6j0wjtgqqn22',
+                path: "m/84'/1'/0'/1/19",
+                transfers: 0,
+            },
+            {
+                address: 'bcrt1qlecqdxptwt65c52uqzmdqk9njyt4rmygf2vsvd',
+                path: "m/84'/1'/0'/1/20",
+                transfers: 0,
+            },
+        ],
+        used: [
+            {
+                address: 'bcrt1qkvwu9g3k2pdxewfqr7syz89r3gj557l374sg5v',
+                path: "m/84'/1'/0'/0/0",
+                transfers: 6,
+                balance: '1999999330',
+                sent: '1000000547',
+                received: '2999999877',
+            },
+            {
+                address: 'bcrt1qldlynaqp0hy4zc2aag3pkenzvxy65saej0huey',
+                path: "m/84'/1'/0'/0/1",
+                transfers: 2,
+                balance: '0',
+                sent: '999999890',
+                received: '999999890',
+            },
+        ],
+        unused: [
+            {
+                address: 'bcrt1q9l0rk0gkgn73d0gc57qn3t3cwvucaj3h98jwg4',
+                path: "m/84'/1'/0'/0/2",
+                transfers: 0,
+            },
+            {
+                address: 'bcrt1qtxe2hdle9he8hc2xds7yl2m8zutjksv0gmszw2',
+                path: "m/84'/1'/0'/0/3",
+                transfers: 0,
+            },
+            {
+                address: 'bcrt1qglrv8xrtf68udd5pxj2pxyq5s7lynq204v2da8',
+                path: "m/84'/1'/0'/0/4",
+                transfers: 0,
+            },
+            {
+                address: 'bcrt1qds6ygc07t7d8prjs60qnx0nv4gexx9hex07wwl',
+                path: "m/84'/1'/0'/0/5",
+                transfers: 0,
+            },
+            {
+                address: 'bcrt1q86udlgffezp9kgjvqlfah7a6c8dpepameugfw5',
+                path: "m/84'/1'/0'/0/6",
+                transfers: 0,
+            },
+            {
+                address: 'bcrt1q503m8pxyvf7ypurcvwv2kp0ajyjumsjq5ad7xq',
+                path: "m/84'/1'/0'/0/7",
+                transfers: 0,
+            },
+            {
+                address: 'bcrt1qg805w4uhsz3sy9stasdx2rkwp4haf446ew055v',
+                path: "m/84'/1'/0'/0/8",
+                transfers: 0,
+            },
+            {
+                address: 'bcrt1qy2f6mkfa3aaecqz2s2xr0utf6edza7qzh7gnnn',
+                path: "m/84'/1'/0'/0/9",
+                transfers: 0,
+            },
+            {
+                address: 'bcrt1q4tm6cgxd3m7uqgzmwxfclruqz894qdv5w05kss',
+                path: "m/84'/1'/0'/0/10",
+                transfers: 0,
+            },
+            {
+                address: 'bcrt1qguvdun4cjty8js34wswdn4nv2ne7jamajjwgkj',
+                path: "m/84'/1'/0'/0/11",
+                transfers: 0,
+            },
+            {
+                address: 'bcrt1qp6py2d8acmqcvdfeht3escetv5aunru5d4vlk0',
+                path: "m/84'/1'/0'/0/12",
+                transfers: 0,
+            },
+            {
+                address: 'bcrt1q88fkyl4zxrcejt4s75ynkunpps3n9kchzvnaw8',
+                path: "m/84'/1'/0'/0/13",
+                transfers: 0,
+            },
+            {
+                address: 'bcrt1qjfvfjqsp3khtgdkqw87up39skp6zvp062q7y93',
+                path: "m/84'/1'/0'/0/14",
+                transfers: 0,
+            },
+            {
+                address: 'bcrt1qf49m5zxk9957z8yzyfed6glrcvz3r7y4demdex',
+                path: "m/84'/1'/0'/0/15",
+                transfers: 0,
+            },
+            {
+                address: 'bcrt1qfmej7qk4f66vx8a5aq5t5nlvp0hxuwe0fg9rrp',
+                path: "m/84'/1'/0'/0/16",
+                transfers: 0,
+            },
+            {
+                address: 'bcrt1qlfxf67wwud59ru0d4e7qa36zh0daxcfr6ec53g',
+                path: "m/84'/1'/0'/0/17",
+                transfers: 0,
+            },
+            {
+                address: 'bcrt1qcmmen68dyt59pkh7dv2xxf07tme7qxzn0upszf',
+                path: "m/84'/1'/0'/0/18",
+                transfers: 0,
+            },
+            {
+                address: 'bcrt1qpcgw9fuec7wjjnq8rl0cwfwa7mqvrheud24890',
+                path: "m/84'/1'/0'/0/19",
+                transfers: 0,
+            },
+            {
+                address: 'bcrt1qxukydnhdldsjf0c8rguxmja9kxsydjzwj486hk',
+                path: "m/84'/1'/0'/0/20",
+                transfers: 0,
+            },
+            {
+                address: 'bcrt1qq7tkmktggcwp46jefmnh7ytade562ka8qte4un',
+                path: "m/84'/1'/0'/0/21",
+                transfers: 0,
+            },
+        ],
+    },
+    history: {
+        total: 6,
+        unconfirmed: 0,
+        transactions: [
+            {
+                type: 'recv',
+                txid: 'txid_6',
+                blockTime: 1337,
+                blockHeight: 8,
+                amount: '999999212',
+                fee: '99',
+                targets: [
+                    {
+                        n: 0,
+                        addresses: ['bcrt1qkvwu9g3k2pdxewfqr7syz89r3gj557l374sg5v'],
+                        isAddress: true,
+                        amount: '999999212',
+                        isAccountTarget: true,
+                    },
+                ],
+                tokens: [],
+                details: {
+                    vin: [
+                        {
+                            n: 0,
+                            addresses: [
+                                'bcrt1pn2d0yjeedavnkd8z8lhm566p0f2utm3lgvxrsdehnl94y34txmtsef5dqz',
+                            ],
+                            isAddress: true,
+                            value: '999999311',
+                            isAccountOwned: undefined,
+                        },
+                    ],
+                    vout: [
+                        {
+                            value: '999999212',
+                            n: 0,
+                            addresses: ['bcrt1qkvwu9g3k2pdxewfqr7syz89r3gj557l374sg5v'],
+                            isAddress: true,
+                            isAccountOwned: true,
+                        },
+                    ],
+                    totalInput: '999999311',
+                    totalOutput: '999999212',
+                },
+            },
+            {
+                type: 'self',
+                txid: 'txid_5',
+                blockTime: 1337,
+                blockHeight: 7,
+                amount: '178',
+                fee: '178',
+                targets: [
+                    {
+                        n: 0,
+                        addresses: ['bcrt1qkvwu9g3k2pdxewfqr7syz89r3gj557l374sg5v'],
+                        isAddress: true,
+                        amount: '999999571',
+                        isAccountTarget: true,
+                    },
+                ],
+                tokens: [],
+                details: {
+                    vin: [
+                        {
+                            n: 0,
+                            addresses: ['bcrt1qkvwu9g3k2pdxewfqr7syz89r3gj557l374sg5v'],
+                            isAddress: true,
+                            value: '547',
+                            isAccountOwned: true,
+                        },
+                        {
+                            n: 1,
+                            addresses: ['bcrt1qejqxwzfld7zr6mf7ygqy5s5se5xq7vmt8ntmj0'],
+                            isAddress: true,
+                            value: '999999202',
+                        },
+                    ],
+                    vout: [
+                        {
+                            value: '999999571',
+                            n: 0,
+                            addresses: ['bcrt1qkvwu9g3k2pdxewfqr7syz89r3gj557l374sg5v'],
+                            isAddress: true,
+                            isAccountOwned: true,
+                        },
+                    ],
+                    totalInput: '999999749',
+                    totalOutput: '999999571',
+                },
+            },
+            {
+                type: 'self',
+                txid: 'txid_4',
+                blockTime: 1337,
+                blockHeight: 6,
+                amount: '141',
+                fee: '141',
+                targets: [
+                    {
+                        n: 0,
+                        addresses: ['bcrt1qkvwu9g3k2pdxewfqr7syz89r3gj557l374sg5v'],
+                        isAddress: true,
+                        amount: '547',
+                        isAccountTarget: true,
+                    },
+                ],
+                tokens: [],
+                details: {
+                    vin: [
+                        {
+                            n: 0,
+                            addresses: ['bcrt1qldlynaqp0hy4zc2aag3pkenzvxy65saej0huey'],
+                            isAddress: true,
+                            value: '999999890',
+                        },
+                    ],
+                    vout: [
+                        {
+                            value: '547',
+                            n: 0,
+                            spent: true,
+                            addresses: ['bcrt1qkvwu9g3k2pdxewfqr7syz89r3gj557l374sg5v'],
+                            isAddress: true,
+                            isAccountOwned: true,
+                        },
+                        {
+                            value: '999999202',
+                            n: 1,
+                            spent: true,
+                            addresses: ['bcrt1qejqxwzfld7zr6mf7ygqy5s5se5xq7vmt8ntmj0'],
+                            isAddress: true,
+                        },
+                    ],
+                    totalInput: '999999890',
+                    totalOutput: '999999749',
+                },
+            },
+            {
+                type: 'recv',
+                txid: 'txid_3',
+                blockTime: 1337,
+                blockHeight: 4,
+                amount: '547',
+                fee: '142',
+                targets: [
+                    {
+                        n: 0,
+                        addresses: ['bcrt1qkvwu9g3k2pdxewfqr7syz89r3gj557l374sg5v'],
+                        isAddress: true,
+                        amount: '547',
+                        isAccountTarget: true,
+                    },
+                ],
+                tokens: [],
+                details: {
+                    vin: [
+                        {
+                            n: 0,
+                            addresses: [
+                                'bcrt1pswrqtykue8r89t9u4rprjs0gt4qzkdfuursfnvqaa3f2yql07zmq2fdmpx',
+                            ],
+                            isAddress: true,
+                            value: '1000000000',
+                            isAccountOwned: undefined,
+                        },
+                    ],
+                    vout: [
+                        {
+                            value: '547',
+                            n: 0,
+                            addresses: ['bcrt1qkvwu9g3k2pdxewfqr7syz89r3gj557l374sg5v'],
+                            isAddress: true,
+                            isAccountOwned: true,
+                        },
+                        {
+                            value: '999999311',
+                            n: 1,
+                            spent: true,
+                            addresses: [
+                                'bcrt1pn2d0yjeedavnkd8z8lhm566p0f2utm3lgvxrsdehnl94y34txmtsef5dqz',
+                            ],
+                            isAddress: true,
+                            isAccountOwned: undefined,
+                        },
+                    ],
+                    totalInput: '1000000000',
+                    totalOutput: '999999858',
+                },
+            },
+            {
+                type: 'self',
+                txid: 'txid_2',
+                blockTime: 1337,
+                blockHeight: 2,
+                amount: '110',
+                fee: '110',
+                targets: [
+                    {
+                        n: 0,
+                        addresses: ['bcrt1qldlynaqp0hy4zc2aag3pkenzvxy65saej0huey'],
+                        isAddress: true,
+                        amount: '999999890',
+                        isAccountTarget: true,
+                    },
+                ],
+                tokens: [],
+                details: {
+                    vin: [
+                        {
+                            n: 0,
+                            addresses: ['bcrt1qkvwu9g3k2pdxewfqr7syz89r3gj557l374sg5v'],
+                            isAddress: true,
+                            value: '1000000000',
+                            isAccountOwned: true,
+                        },
+                    ],
+                    vout: [
+                        {
+                            value: '999999890',
+                            n: 0,
+                            spent: true,
+                            addresses: ['bcrt1qldlynaqp0hy4zc2aag3pkenzvxy65saej0huey'],
+                            isAddress: true,
+                        },
+                    ],
+                    totalInput: '1000000000',
+                    totalOutput: '999999890',
+                },
+            },
+            {
+                type: 'recv',
+                txid: 'txid_1',
+                blockTime: 1337,
+                blockHeight: 1,
+                amount: '1000000000',
+                fee: '28059',
+                targets: [
+                    {
+                        n: 1,
+                        addresses: ['bcrt1qkvwu9g3k2pdxewfqr7syz89r3gj557l374sg5v'],
+                        isAddress: true,
+                        amount: '1000000000',
+                        isAccountTarget: true,
+                    },
+                ],
+                tokens: [],
+                details: {
+                    vin: [
+                        {
+                            n: 0,
+                            addresses: ['mkUzYq8aQ4xzgPoCw8QVsRzkn1dceiPzmi'],
+                            isAddress: true,
+                            value: '1578625117',
+                            isAccountOwned: undefined,
+                        },
+                    ],
+                    vout: [
+                        {
+                            value: '578597058',
+                            n: 0,
+                            spent: true,
+                            addresses: ['n29Q5yZh813J4MHtY4KjteNs1rfRWVRRPJ'],
+                            isAddress: true,
+                            isAccountOwned: undefined,
+                        },
+                        {
+                            value: '1000000000',
+                            n: 1,
+                            spent: true,
+                            addresses: ['bcrt1qkvwu9g3k2pdxewfqr7syz89r3gj557l374sg5v'],
+                            isAddress: true,
+                            isAccountOwned: true,
+                        },
+                    ],
+                    totalInput: '1578625117',
+                    totalOutput: '1578597058',
+                },
+            },
+        ],
+    },
+    page: { index: 1, size: 25, total: 1 },
+};
+
+const {
+    addresses: {
+        unused,
+        used: [used1, used2],
+        change: [{ balance, sent, received, transfers, ...change1 }, ...change],
+    },
+    history: {
+        transactions: [, , pending, ...transactions],
+    },
+    ...rest
+} = SEGWIT_XPUB_RESULT;
+
+export const SEGWIT_XPUB_RESULT_HALF = {
+    ...rest,
+    balance: '1000000437',
+    availableBalance: '1000000296',
+    addresses: {
+        unused,
+        used: [
+            {
+                ...used1,
+                balance: '547',
+                received: '1000000547',
+                sent: '1000000000',
+                transfers: 3,
+            },
+            { ...used2, balance: '999999890', received: '999999890', sent: '0', transfers: 1 },
+        ],
+        change: [{ ...change1, transfers: 0 }, ...change.slice(0, -1)],
+    },
+    history: {
+        total: 3,
+        unconfirmed: 1,
+        transactions: [{ ...pending, blockHeight: -1, blockTime: undefined }, ...transactions],
+    },
+};
+
+const {
+    addresses,
+    history: {
+        transactions: [
+            tx6,
+            tx5,
+            tx4,
+            tx3,
+            {
+                targets: [{ isAccountTarget, ...tx2Target }],
+                ...tx2
+            },
+            tx1,
+        ],
+        ...xpubHistory
+    },
+    ...xpubRest
+} = SEGWIT_XPUB_RESULT;
+
+export const SEGWIT_RECEIVE_RESULT = {
+    ...xpubRest,
+    descriptor: 'bcrt1qkvwu9g3k2pdxewfqr7syz89r3gj557l374sg5v',
+    balance: '1999999330',
+    availableBalance: '1999999330',
+    history: {
+        ...xpubHistory,
+        transactions: [
+            tx6,
+            { ...tx5, type: 'joint', amount: '999999024', targets: [] },
+            { ...tx4, type: 'recv', amount: '547' },
+            tx3,
+            {
+                ...tx2,
+                type: 'sent',
+                amount: '999999890',
+                targets: [tx2Target],
+            },
+            tx1,
+        ],
+    },
+};

--- a/packages/coinjoin/tests/mocks/MockBackendClient.ts
+++ b/packages/coinjoin/tests/mocks/MockBackendClient.ts
@@ -1,0 +1,97 @@
+import { CoinjoinBackendClient } from '../../src/backend/CoinjoinBackendClient';
+
+type MockEndpoint = ReturnType<InstanceType<typeof CoinjoinBackendClient>['request']>;
+
+type BlockFixture = {
+    height: number;
+    hash: string;
+    previousBlockHash: string;
+    filter: string;
+};
+
+export class MockBackendClient extends CoinjoinBackendClient {
+    constructor() {
+        super({ blockbookUrls: ['foo'], coordinatorUrl: 'bar' });
+        this.blocks = [];
+        this.mempool = [];
+    }
+
+    private blocks: BlockFixture[];
+    private mempool: { txid: string }[];
+
+    setFixture(blocks: BlockFixture[], mempool: { txid: string }[] = []) {
+        this.blocks = blocks;
+        this.mempool = mempool;
+    }
+
+    private mockResponse(status: number, content?: any) {
+        const defaultContent = status === 404 ? 'Not found' : undefined;
+        return Promise.resolve({
+            status,
+            json: () => Promise.resolve(content ?? defaultContent),
+        } as Response);
+    }
+
+    protected wabisabi(): MockEndpoint {
+        const parseGet = (
+            path: string,
+            { bestKnownBlockHash, count }: Record<string, any> = {},
+        ) => {
+            switch (path) {
+                case 'Blockchain/mempool-hashes':
+                    return this.mockResponse(
+                        200,
+                        this.mempool.map(({ txid }) => txid),
+                    );
+                case 'Blockchain/filters': {
+                    if (typeof bestKnownBlockHash !== 'string') this.mockResponse(404);
+                    if (typeof count !== 'number') return this.mockResponse(404);
+                    if (this.blocks[this.blocks.length - 1].hash === bestKnownBlockHash)
+                        return this.mockResponse(204);
+                    const from = this.blocks.findIndex(
+                        ({ previousBlockHash }) => previousBlockHash === bestKnownBlockHash,
+                    );
+                    if (from < 0) return this.mockResponse(404);
+                    return this.mockResponse(200, {
+                        bestHeight: -1,
+                        filters: this.blocks
+                            .slice(from, from + count)
+                            .map(
+                                ({ height, hash, filter, previousBlockHash }) =>
+                                    `${height}:${hash}:${filter}:${previousBlockHash}:${999}`,
+                            ),
+                    });
+                }
+                default:
+                    return this.mockResponse(404);
+            }
+        };
+        return {
+            get: parseGet,
+            post: () => this.mockResponse(404),
+        };
+    }
+
+    protected blockbook(): MockEndpoint {
+        const parseGet = (path: string) => {
+            const [what, which] = path.split('/');
+            switch (what) {
+                case 'tx': {
+                    const tx = this.mempool.find(t => t.txid === which);
+                    return tx ? this.mockResponse(200, tx) : this.mockResponse(404);
+                }
+                case 'block': {
+                    const height = parseInt(which, 10);
+                    const block = this.blocks.find(b => b.height === height);
+                    return block ? this.mockResponse(200, block) : this.mockResponse(404);
+                }
+                default:
+                    return this.mockResponse(404);
+            }
+        };
+        return {
+            get: parseGet,
+            post: () => this.mockResponse(404),
+        };
+    }
+}

--- a/packages/coinjoin/tests/mocks/MockFilterClient.ts
+++ b/packages/coinjoin/tests/mocks/MockFilterClient.ts
@@ -1,0 +1,19 @@
+import type { BlockFilter, FilterClient } from '../../src/backend/types';
+
+export class MockFilterClient implements FilterClient {
+    private bestHeight;
+    private readonly filters;
+
+    constructor(filters: BlockFilter[]) {
+        this.filters = filters;
+        this.bestHeight = this.filters[this.filters.length - 1].blockHeight;
+    }
+
+    fetchFilters(knownHash: string, count: number) {
+        const from = this.filters.findIndex(f => f.prevHash === knownHash);
+        return Promise.resolve({
+            bestHeight: this.bestHeight,
+            filters: from < 0 ? [] : this.filters.slice(from, from + count),
+        });
+    }
+}

--- a/packages/coinjoin/tests/mocks/MockMempoolClient.ts
+++ b/packages/coinjoin/tests/mocks/MockMempoolClient.ts
@@ -1,0 +1,23 @@
+import type { BlockbookTransaction, MempoolClient } from '../../src/backend/types';
+
+type MockTx = Pick<BlockbookTransaction, 'txid' | 'vin' | 'vout'>;
+
+export class MockMempoolClient implements MempoolClient {
+    private transactions: MockTx[] = [];
+    fetched: string[] = [];
+
+    setFixture(fixture: MockTx[]) {
+        this.transactions = fixture;
+        this.fetched = [];
+    }
+
+    fetchMempoolTxids() {
+        return Promise.resolve(this.transactions.map(tx => tx.txid));
+    }
+
+    fetchTransaction(txid: string) {
+        this.fetched.push(txid);
+        const tx = this.transactions.find(tx => tx.txid === txid);
+        return tx ? Promise.resolve(tx as BlockbookTransaction) : Promise.reject();
+    }
+}

--- a/packages/suite/src/actions/wallet/__fixtures__/coinjoinAccountActions.ts
+++ b/packages/suite/src/actions/wallet/__fixtures__/coinjoinAccountActions.ts
@@ -98,7 +98,8 @@ export const createCoinjoinAccount = [
             actions: [
                 accountsActions.createAccount.type,
                 '@coinjoin/account-create',
-                accountsActions.updateAccount.type,
+                accountsActions.updateCoinjoinAccountStatus.type,
+                accountsActions.updateCoinjoinAccountStatus.type,
             ],
         },
     },

--- a/packages/suite/src/actions/wallet/__tests__/coinjoinAccountActions.test.ts
+++ b/packages/suite/src/actions/wallet/__tests__/coinjoinAccountActions.test.ts
@@ -1,5 +1,6 @@
 import { configureStore } from '@suite/support/tests/configureStore';
 
+import { accountsReducer } from '@wallet-reducers';
 import { coinjoinReducer } from '@wallet-reducers/coinjoinReducer';
 import * as coinjoinAccountActions from '../coinjoinAccountActions';
 import * as fixtures from '../__fixtures__/coinjoinAccountActions';
@@ -33,6 +34,19 @@ jest.mock('@suite/services/coinjoin/coinjoinClient', () => {
     };
 });
 
+jest.mock('@suite/services/coinjoin/coinjoinBackend', () =>
+    // for test purposes enable only btc network
+    ({
+        CoinjoinBackendService: {
+            getInstance: () => ({
+                on: jest.fn(),
+                off: jest.fn(),
+                scanAccount: jest.fn(() => Promise.reject(new Error('TODO'))),
+            }),
+        },
+    }),
+);
+
 const DEVICE = global.JestMocks.getSuiteDevice({ state: 'device-state', connected: true });
 export const getInitialState = () => ({
     suite: {
@@ -42,6 +56,7 @@ export const getInitialState = () => ({
     devices: [DEVICE],
     wallet: {
         coinjoin: coinjoinReducer(undefined, { type: 'foo' } as any),
+        accounts: accountsReducer(undefined, { type: 'foo' } as any),
     },
     modal: {},
 });
@@ -53,9 +68,10 @@ const initStore = (state: State) => {
     const store = mockStore(state);
     store.subscribe(() => {
         const action = store.getActions().pop();
-        const { coinjoin } = store.getState().wallet;
+        const { coinjoin, accounts } = store.getState().wallet;
         store.getState().wallet = {
             coinjoin: coinjoinReducer(coinjoin, action),
+            accounts: accountsReducer(accounts, action),
         };
         store.getActions().push(action);
     });
@@ -72,7 +88,6 @@ describe('coinjoinAccountActions', () => {
             await store.dispatch(coinjoinAccountActions.createCoinjoinAccount(f.params as any)); // params are incomplete
 
             const actions = store.getActions();
-            expect(actions.length).toBe(f.result.actions.length);
             expect(actions.map(a => a.type)).toEqual(f.result.actions);
         });
     });
@@ -86,7 +101,6 @@ describe('coinjoinAccountActions', () => {
             await store.dispatch(coinjoinAccountActions.startCoinjoinSession(f.params, {}));
 
             const actions = store.getActions();
-            expect(actions.length).toBe(f.result.actions.length);
             expect(actions.map(a => a.type)).toEqual(f.result.actions);
         });
     });
@@ -99,7 +113,6 @@ describe('coinjoinAccountActions', () => {
             await store.dispatch(coinjoinAccountActions.stopCoinjoinSession(f.params as any));
 
             const actions = store.getActions();
-            expect(actions.length).toBe(f.result.actions.length);
             expect(actions.map(a => a.type)).toEqual(f.result.actions);
         });
     });

--- a/packages/suite/src/actions/wallet/coinjoinAccountActions.ts
+++ b/packages/suite/src/actions/wallet/coinjoinAccountActions.ts
@@ -1,4 +1,5 @@
 import TrezorConnect from '@trezor/connect';
+import type { ScanAccountProgress } from '@trezor/coinjoin/src/backend/types';
 import * as COINJOIN from './constants/coinjoinConstants';
 import { goto } from '../suite/routerActions';
 import { addToast } from '../suite/notificationActions';
@@ -8,6 +9,7 @@ import { Dispatch, GetState } from '@suite-types';
 import { Network } from '@suite-common/wallet-config';
 import { Account, CoinjoinSessionParameters } from '@suite-common/wallet-types';
 import { accountsActions, transactionsActions } from '@suite-common/wallet-core';
+import { isAccountOutdated, getAccountTransactions } from '@suite-common/wallet-utils';
 
 const coinjoinAccountCreate = (account: Account) =>
     ({
@@ -41,33 +43,43 @@ const coinjoinAccountUnregister = (account: Account) =>
         account,
     } as const);
 
+const coinjoinAccountDiscoveryProgress = (account: Account, progress: ScanAccountProgress) =>
+    ({
+        type: COINJOIN.ACCOUNT_DISCOVERY_PROGRESS,
+        account,
+        progress,
+    } as const);
+
 export type CoinjoinAccountAction =
     | ReturnType<typeof coinjoinAccountCreate>
     | ReturnType<typeof coinjoinAccountAuthorize>
     | ReturnType<typeof coinjoinAccountAuthorizeSuccess>
     | ReturnType<typeof coinjoinAccountAuthorizeFailed>
-    | ReturnType<typeof coinjoinAccountUnregister>;
+    | ReturnType<typeof coinjoinAccountUnregister>
+    | ReturnType<typeof coinjoinAccountDiscoveryProgress>;
+
+const getCheckpoint = (
+    account: Extract<Account, { backendType: 'coinjoin' }>,
+    getState: GetState,
+) => getState().wallet.coinjoin.accounts.find(a => a.key === account.key)?.checkpoint;
 
 export const fetchAndUpdateAccount =
     (account: Account) => async (dispatch: Dispatch, getState: GetState) => {
-        if (account.backendType !== 'coinjoin') return;
+        if (account.backendType !== 'coinjoin' || account.discoveryStatus === 'syncing') return;
 
-        const lastKnownState = {
-            time: Date.now(),
-            blockHash: account.lastKnownState?.blockHash || '',
-            progress: 0,
-        };
+        const isInitialUpdate = account.discoveryStatus !== 'ready';
+        dispatch(accountsActions.updateCoinjoinAccountStatus(account, 'syncing'));
 
-        const onProgress = (progressState: any) => {
-            dispatch(
-                accountsActions.updateAccount({
-                    ...account,
-                    lastKnownState: {
-                        ...progressState,
-                        time: Date.now(),
-                    },
-                }),
-            );
+        const onProgress = (progress: ScanAccountProgress) => {
+            if (progress.transactions.length) {
+                dispatch(
+                    transactionsActions.addTransaction({
+                        account,
+                        transactions: progress.transactions,
+                    }),
+                );
+            }
+            dispatch(coinjoinAccountDiscoveryProgress(account, progress));
         };
 
         const api = CoinjoinBackendService.getInstance(account.symbol);
@@ -75,49 +87,39 @@ export const fetchAndUpdateAccount =
 
         try {
             api.on('progress', onProgress);
-            // @ts-expect-error, method is...
-            const accountInfo: any = await api.getAccountInfo({
+
+            const { pending, checkpoint } = await api.scanAccount({
                 descriptor: account.descriptor,
-                lastKnownState: {
-                    balance: account.balance,
-                    blockHash: lastKnownState.blockHash,
-                },
-                symbol: account.symbol,
+                checkpoint: getCheckpoint(account, getState),
             });
 
-            if (accountInfo) {
-                // get fresh info from reducer
-                const updatedAccount = getState().wallet.accounts.find(a => a.key === account.key);
-                if (updatedAccount && updatedAccount.lastKnownState) {
-                    // finalize
-                    dispatch(
-                        accountsActions.updateAccount(
-                            {
-                                ...updatedAccount,
-                                lastKnownState: {
-                                    time: Date.now(),
-                                    blockHash: updatedAccount.lastKnownState.blockHash,
-                                },
-                            },
-                            accountInfo,
-                        ),
-                    );
-                    // add account transactions
-                    if (accountInfo.history.transactions) {
-                        dispatch(
-                            transactionsActions.addTransaction({
-                                transactions: accountInfo.history.transactions,
-                                account,
-                            }),
-                        );
-                    }
-                }
-            } else {
-                // TODO: no accountInfo
+            onProgress({ checkpoint, transactions: pending });
+
+            const transactions = getAccountTransactions(
+                account.key,
+                getState().wallet.transactions.transactions,
+            );
+
+            const accountInfo = api.getAccountInfo(account.descriptor, transactions, checkpoint);
+
+            // TODO add isPending check?
+            if (isAccountOutdated(account, accountInfo) || isInitialUpdate) {
+                dispatch(accountsActions.updateAccount(account, accountInfo));
             }
+
+            // TODO remove invalid transactions
+
+            // TODO notify about new transactions
+
+            dispatch(accountsActions.updateCoinjoinAccountStatus(account, 'ready'));
         } catch (error) {
-            // TODO
             console.warn('fetchAndUpdateAccount', error);
+            dispatch(
+                accountsActions.updateCoinjoinAccountStatus(
+                    account,
+                    isInitialUpdate ? 'error' : 'ready',
+                ),
+            );
         } finally {
             api.off('progress', onProgress);
         }
@@ -189,11 +191,7 @@ export const createCoinjoinAccount =
                     backendType: 'coinjoin',
                     coin: network.symbol,
                     derivationType: 0,
-                    lastKnownState: {
-                        time: 0,
-                        blockHash: '',
-                        progress: 0,
-                    },
+                    discoveryStatus: 'initial',
                 },
                 {
                     addresses: { change: [], used: [], unused: [] },

--- a/packages/suite/src/actions/wallet/coinjoinAccountActions.ts
+++ b/packages/suite/src/actions/wallet/coinjoinAccountActions.ts
@@ -101,6 +101,7 @@ export const fetchAndUpdateAccount =
             );
 
             const accountInfo = api.getAccountInfo(account.descriptor, transactions, checkpoint);
+            // TODO accountInfo.utxo don't have proper utxo.confirmations field, only 0/1
 
             // TODO add isPending check?
             if (isAccountOutdated(account, accountInfo) || isInitialUpdate) {

--- a/packages/suite/src/actions/wallet/constants/coinjoinConstants.ts
+++ b/packages/suite/src/actions/wallet/constants/coinjoinConstants.ts
@@ -3,6 +3,7 @@ export const ACCOUNT_AUTHORIZE = '@coinjoin/account-authorize';
 export const ACCOUNT_AUTHORIZE_SUCCESS = '@coinjoin/account-authorize-success';
 export const ACCOUNT_AUTHORIZE_FAILED = '@coinjoin/account-authorize-failed';
 export const ACCOUNT_UNREGISTER = '@coinjoin/account-unregister';
+export const ACCOUNT_DISCOVERY_PROGRESS = '@coinjoin/account-discovery-progress';
 
 export const CLIENT_ENABLE = '@coinjoin/client-enable';
 export const CLIENT_ENABLE_SUCCESS = '@coinjoin/client-enable-success';

--- a/packages/suite/src/actions/wallet/selectedAccountActions.ts
+++ b/packages/suite/src/actions/wallet/selectedAccountActions.ts
@@ -138,13 +138,25 @@ const getAccountState = (state: AppState): SelectedAccountStatus => {
 
     // account does exist
     if (account && account.visible) {
-        if (typeof account?.lastKnownState?.progress === 'number') {
-            return {
-                status: 'loading',
-                loader: 'account-loading',
-                account,
-            };
+        if (account.backendType === 'coinjoin') {
+            if (account.discoveryStatus === 'initial') {
+                return {
+                    status: 'loading',
+                    loader: 'account-loading',
+                    account,
+                };
+            }
+            if (account.discoveryStatus === 'error') {
+                return {
+                    status: 'exception',
+                    loader: 'account-not-loaded',
+                    network,
+                    discovery,
+                    params,
+                };
+            }
         }
+
         // Success!
         const loadedState = {
             status: 'loaded',
@@ -237,7 +249,8 @@ export const syncSelectedAccount = (action: Action) => (dispatch: Dispatch, getS
             'addresses',
             'visible',
             'utxo',
-            'lastKnownState',
+            'discoveryStatus',
+            'discoveryCheckpoint',
         ],
         discovery: [
             'status',

--- a/packages/suite/src/components/wallet/WalletLayout/index.tsx
+++ b/packages/suite/src/components/wallet/WalletLayout/index.tsx
@@ -1,4 +1,5 @@
-import React from 'react';
+import React, { useState, useEffect } from 'react';
+import { Progress } from '@trezor/components';
 import styled from 'styled-components';
 import { AccountsMenu } from '@wallet-components';
 import Exception from '@wallet-components/AccountException';
@@ -9,6 +10,7 @@ import { MAX_WIDTH_WALLET_CONTENT } from '@suite-constants/layout';
 import { AppState, ExtendedMessageDescriptor } from '@suite-types';
 import { useTranslation, useLayout } from '@suite-hooks';
 import { SkeletonRectangle } from '@suite-components/Skeleton';
+import { CoinjoinBackendService } from '@suite/services/coinjoin/coinjoinBackend';
 
 const Wrapper = styled.div`
     display: flex;
@@ -35,6 +37,37 @@ type WalletLayoutProps = {
     children?: React.ReactNode;
 };
 
+type ProgressInfo = {
+    progress?: number;
+    message?: string;
+};
+
+const AccountLoadingProgress = ({ account: { account } }: Pick<WalletLayoutProps, 'account'>) => {
+    const network = account?.symbol;
+    const backendType = account?.backendType;
+    const [progress, setProgress] = useState<ProgressInfo>();
+
+    useEffect(() => {
+        if (!network || backendType !== 'coinjoin') return;
+        const backend = CoinjoinBackendService.getInstance(network);
+        if (!backend) return;
+        const onProgress = ({ info }: { info?: ProgressInfo }) => setProgress(info);
+        backend.on('progress', onProgress);
+        return () => {
+            backend.off('progress', onProgress);
+        };
+    }, [network, backendType]);
+
+    return progress ? (
+        <>
+            <Progress max={1} value={progress.progress ?? 0} />
+            <p>
+                {Math.floor(100 * (progress.progress ?? 0))} % {progress.message}
+            </p>
+        </>
+    ) : null;
+};
+
 export const WalletLayout = ({
     showEmptyHeaderPlaceholder = false,
     title,
@@ -54,9 +87,7 @@ export const WalletLayout = ({
                     height="300px"
                     animate={account.loader === 'account-loading'}
                 >
-                    {account.account?.lastKnownState && (
-                        <>TODO: Display progress {account.account?.lastKnownState.progress}</>
-                    )}
+                    <AccountLoadingProgress account={account} />
                 </SkeletonRectangle>
             </Wrapper>
         );

--- a/packages/suite/src/reducers/wallet/coinjoinReducer.ts
+++ b/packages/suite/src/reducers/wallet/coinjoinReducer.ts
@@ -58,6 +58,15 @@ const stopSession = (
     }
 };
 
+const saveCheckpoint = (
+    draft: CoinjoinState,
+    action: Extract<Action, { type: typeof COINJOIN.ACCOUNT_DISCOVERY_PROGRESS }>,
+) => {
+    const account = draft.accounts.find(a => a.key === action.account.key);
+    if (!account) return;
+    account.checkpoint = action.progress.checkpoint;
+};
+
 const createClient = (
     draft: CoinjoinState,
     action: Extract<Action, { type: typeof COINJOIN.CLIENT_ENABLE_SUCCESS }>,
@@ -93,6 +102,9 @@ export const coinjoinReducer = (
                 break;
             case COINJOIN.ACCOUNT_UNREGISTER:
                 stopSession(draft, action);
+                break;
+            case COINJOIN.ACCOUNT_DISCOVERY_PROGRESS:
+                saveCheckpoint(draft, action);
                 break;
 
             case COINJOIN.CLIENT_ENABLE_SUCCESS:

--- a/packages/suite/src/services/coinjoin/coinjoinBackend.ts
+++ b/packages/suite/src/services/coinjoin/coinjoinBackend.ts
@@ -1,9 +1,7 @@
 import { CoinjoinBackend } from '@trezor/coinjoin';
 import { createIpcProxy } from '@trezor/ipc-proxy';
-import TrezorConnect, { AccountInfo } from '@trezor/connect';
 import { isDesktop } from '@suite-utils/env';
 import { COINJOIN_NETWORKS } from './config';
-import { Account } from '@suite-common/wallet-types';
 
 const loadInstance = (network: string) => {
     const settings = COINJOIN_NETWORKS[network];
@@ -19,147 +17,12 @@ const loadInstance = (network: string) => {
     );
 };
 
-// NOTE: blockbook does not understand 4th hardended field in path (slip25 script type) and returns error: "Invalid address, decoded address is of unknown format"
-// temporary replace SLIP-25 path with taproot path
-const slip25Path = "/10025'/1'/0'/1'";
-const taprootPath = "/86'/1'/0'";
-
-const blockbookPatchResponse = (accountInfo: AccountInfo, anonymitySet: any) => {
-    const { addresses } = accountInfo;
-    if (!addresses) return accountInfo;
-
-    const patchAddresses: Account['addresses'] = {
-        used: [],
-        unused: [],
-        change: [],
-        anonymitySet,
-    };
-    const replace = (path: string) => {
-        if (!path.includes('unknown')) return { isChange: false, path };
-        const pathParts = path.split('/');
-        return {
-            path: path.replace('unknown', "m/10025'/1'/0'"),
-            isChange: pathParts[pathParts.length - 2] === '1',
-        };
-    };
-
-    addresses.used.forEach(a => {
-        const { path, isChange } = replace(a.path);
-        if (isChange) {
-            patchAddresses.change.push({ ...a, path });
-        } else {
-            patchAddresses.used.push({ ...a, path });
-        }
-    });
-    addresses.unused.forEach(a => {
-        const { path, isChange } = replace(a.path);
-        if (isChange) {
-            patchAddresses.change.push({ ...a, path });
-        } else {
-            patchAddresses.unused.push({ ...a, path });
-        }
-    });
-    accountInfo.utxo = accountInfo.utxo?.map(utxo => {
-        const { path } = replace(utxo.path);
-        return { ...utxo, path };
-    });
-
-    return {
-        ...accountInfo,
-        descriptor: accountInfo.descriptor.replace(taprootPath, slip25Path),
-        addresses: patchAddresses,
-    };
-};
-
-// NOTE: function below will be replaced by @trezor/coinjoin implementation
-type GetAccountInfoParams = {
-    descriptor: string;
-    lastKnownState?: {
-        balance: string;
-        blockHash: string;
-    };
-    symbol: string;
-    onProgress: (state: any) => void;
-};
-
-const getCoinjoinAccountInfo = async (
-    { descriptor, symbol, lastKnownState }: GetAccountInfoParams,
-    onProgress: (...args: any[]) => any,
-    abortSignal: AbortSignal,
-) => {
-    const accountInfo = await TrezorConnect.getAccountInfo({
-        descriptor: descriptor.replace(slip25Path, taprootPath),
-        coin: symbol,
-        details: 'txs',
-    });
-
-    if (!accountInfo.success) {
-        console.log('No accountInfo');
-        return;
-    }
-
-    // getCoinjoinAccountInfo is only a "mock"
-    // anonymitySet is also temporary mocked
-    const anonymitySet: Record<string, number> = {};
-    accountInfo.payload.utxo?.forEach(utxo => {
-        anonymitySet[utxo.address] = 1;
-    });
-
-    const info = blockbookPatchResponse(accountInfo.payload, anonymitySet);
-
-    if (lastKnownState?.blockHash === '11') {
-        return info;
-    }
-
-    return new Promise<typeof accountInfo.payload>(resolve => {
-        // simulate account discovery by block filters
-        let i = !lastKnownState?.blockHash ? 0 : 70;
-        let timeout: ReturnType<typeof setTimeout>;
-        const tick = () => {
-            i += 10;
-            if (i < 100) {
-                onProgress({
-                    blockHash: `0${i}`,
-                    progress: i,
-                    progressMessage:
-                        i > 60 ? 'Checking transaction history' : 'Loading block filters',
-                });
-                timeout = setTimeout(tick, 1000);
-            } else {
-                // Finish loading
-                onProgress({
-                    blockHash: '11',
-                });
-                resolve(info);
-            }
-        };
-        tick();
-
-        abortSignal.addEventListener('abort', () => {
-            console.warn('ABORTED!');
-            clearTimeout(timeout);
-        });
-    });
-};
-
 export class CoinjoinBackendService {
     private static instances: Record<string, CoinjoinBackend> = {};
 
     static async createInstance(network: string) {
         if (this.instances[network]) return this.instances[network];
         const instance = await loadInstance(network);
-        // NOTE: temporary use blockbook implementation
-        // @ts-expect-error
-        instance.getAccountInfo = (params: GetAccountInfoParams) => {
-            const abortController = new AbortController();
-            return getCoinjoinAccountInfo(
-                params,
-                (progress: any) => {
-                    instance.emit('progress', progress);
-                },
-                abortController.signal,
-            );
-        };
         this.instances[network] = instance;
         return instance;
     }

--- a/suite-common/wallet-core/src/accounts/accountsActions.ts
+++ b/suite-common/wallet-core/src/accounts/accountsActions.ts
@@ -52,8 +52,14 @@ const createAccount = createAction(
             accountType: discoveryItem.accountType,
             symbol: discoveryItem.coin,
             empty: accountInfo.empty,
-            backendType: discoveryItem.backendType,
-            lastKnownState: discoveryItem.lastKnownState,
+            ...(discoveryItem.backendType === 'coinjoin'
+                ? {
+                      backendType: 'coinjoin',
+                      discoveryStatus: discoveryItem.discoveryStatus,
+                  }
+                : {
+                      backendType: discoveryItem.backendType,
+                  }),
             visible:
                 !accountInfo.empty ||
                 discoveryItem.accountType === 'coinjoin' ||
@@ -123,6 +129,19 @@ const updateAccount = createAction(
     },
 );
 
+const updateCoinjoinAccountStatus = createAction(
+    `${actionPrefix}/updateCoinjoinAccountStatus`,
+    (
+        account: Extract<Account, { backendType: 'coinjoin' }>,
+        discoveryStatus: Extract<Account, { backendType: 'coinjoin' }>['discoveryStatus'],
+    ) => ({
+        payload: {
+            ...account,
+            discoveryStatus,
+        },
+    }),
+);
+
 const changeAccountVisibility = createAction(
     `${actionPrefix}/changeAccountVisibility`,
     (account: Account, visible = true): { payload: Account } => ({
@@ -139,5 +158,6 @@ export const accountsActions = {
     createAccount,
     updateAccount,
     updateSelectedAccount,
+    updateCoinjoinAccountStatus,
     changeAccountVisibility,
 } as const;

--- a/suite-common/wallet-core/src/accounts/accountsReducer.ts
+++ b/suite-common/wallet-core/src/accounts/accountsReducer.ts
@@ -71,6 +71,9 @@ export const prepareAccountsReducer = createReducerWithExtraDeps(
             .addCase(accountsActions.updateAccount, (state, action) => {
                 update(state, action.payload);
             })
+            .addCase(accountsActions.updateCoinjoinAccountStatus, (state, action) => {
+                update(state, action.payload);
+            })
             .addCase(accountsActions.changeAccountVisibility, (state, action) => {
                 update(state, action.payload);
             })

--- a/suite-common/wallet-types/src/account.ts
+++ b/suite-common/wallet-types/src/account.ts
@@ -50,12 +50,15 @@ export interface AddressesWithAnonymity extends NonNullable<AccountInfo['address
     anonymitySet?: Record<string, number | undefined>; // key -> address, value -> anonymity
 }
 
-export interface AccountLastKnownState {
-    time: number;
-    blockHash: string;
-    progress?: number;
-    progressMessage?: string;
-}
+// decides if account is using TrezorConnect/blockchain-link or other non-standard api
+export type AccountBackendSpecific =
+    | {
+          backendType?: Exclude<BackendType, 'coinjoin'>;
+      }
+    | {
+          backendType: Extract<BackendType, 'coinjoin'>;
+          discoveryStatus: 'initial' | 'syncing' | 'ready' | 'error';
+      };
 
 export type Account = {
     deviceState: string;
@@ -78,9 +81,8 @@ export type Account = {
     utxo: AccountInfo['utxo'];
     history: AccountInfo['history'];
     metadata: AccountMetadata;
-    backendType?: BackendType; // decides if account is using TrezorConnect/blockchain-link or other non-standard api
-    lastKnownState?: AccountLastKnownState;
-} & AccountNetworkSpecific;
+} & AccountBackendSpecific &
+    AccountNetworkSpecific;
 
 export type WalletParams =
     | NonNullable<{

--- a/suite-common/wallet-types/src/coinjoin.ts
+++ b/suite-common/wallet-types/src/coinjoin.ts
@@ -24,8 +24,16 @@ export interface CoinjoinSession extends CoinjoinSessionParameters {
     signedRounds: string[]; // already signed rounds
 }
 
+export interface CoinjoinDiscoveryCheckpoint {
+    blockHash: string;
+    blockHeight: number;
+    receiveCount: number;
+    changeCount: number;
+}
+
 export interface CoinjoinAccount {
     key: string; // reference to wallet Account.key
     session?: CoinjoinSession; // current/active authorized session
     previousSessions: CoinjoinSession[]; // history
+    checkpoint?: CoinjoinDiscoveryCheckpoint;
 }

--- a/suite-common/wallet-types/src/discovery.ts
+++ b/suite-common/wallet-types/src/discovery.ts
@@ -3,7 +3,7 @@ import { STATUS as discoveryStatus } from '@suite-common/wallet-constants';
 import { Network } from '@suite-common/wallet-config';
 import { Deferred } from '@trezor/utils';
 
-import { Account } from './account';
+import { Account, AccountBackendSpecific } from './account';
 
 export interface Discovery {
     deviceState: string;
@@ -30,7 +30,7 @@ export interface Discovery {
     availableCardanoDerivations?: ('normal' | 'legacy' | 'ledger')[];
 }
 
-export interface DiscoveryItem {
+export type DiscoveryItem = {
     // @trezor/connect
     path: string;
     unlockPath?: Account['unlockPath'];
@@ -41,7 +41,5 @@ export interface DiscoveryItem {
     index: number;
     accountType: Account['accountType'];
     networkType: Account['networkType'];
-    backendType?: Account['backendType'];
     derivationType?: 0 | 1 | 2;
-    lastKnownState?: Account['lastKnownState'];
-}
+} & AccountBackendSpecific;

--- a/suite-common/wallet-utils/src/transactionUtils.ts
+++ b/suite-common/wallet-utils/src/transactionUtils.ts
@@ -539,7 +539,7 @@ export const getRbfParams = (
     getBitcoinRbfParams(tx, account) || getEthereumRbfParams(tx, account);
 
 /**
- * Formats amounts and attaches fields from the account (descriptor, deviceState, symbol) to the tx object
+ * Attaches fields from the account (descriptor, deviceState, symbol) to the tx object
  *
  * @param {AccountTransaction} tx
  * @param {Account} account
@@ -566,6 +566,15 @@ export const enhanceTransaction = (
         rbfParams: getRbfParams(tx, account),
     };
 };
+
+export const getOriginalTransaction = ({
+    descriptor,
+    deviceState,
+    symbol,
+    rbfParams,
+    rates,
+    ...tx
+}: WalletAccountTransaction): AccountTransaction => tx;
 
 const groupTransactionIdsByAddress = (transactions: WalletAccountTransaction[]) => {
     const addresses: { [address: string]: string[] } = {};

--- a/yarn.lock
+++ b/yarn.lock
@@ -6836,6 +6836,8 @@ __metadata:
     "@trezor/blockchain-link": "*"
     "@trezor/utils": "*"
     "@trezor/utxo-lib": "*"
+    "@types/better-sqlite3": ^7.5.0
+    better-sqlite3: ^7.6.2
     bignumber.js: ^9.0.2
     cross-fetch: ^3.1.5
     events: ^3.3.0
@@ -7873,6 +7875,15 @@ __metadata:
   version: 0.4.0
   resolution: "@types/bchaddrjs@npm:0.4.0"
   checksum: 6f62e4189d510cc880fdd5e1715c25b72ce6d95aaa8f949b9d870166ea2849c01c83f179aad9f68a70a671e1226d80a0cd46b4c240d7be3b528fea8985202eee
+  languageName: node
+  linkType: hard
+
+"@types/better-sqlite3@npm:^7.5.0":
+  version: 7.6.0
+  resolution: "@types/better-sqlite3@npm:7.6.0"
+  dependencies:
+    "@types/node": "*"
+  checksum: 778b7d082b4b1f661572b7f945a4f42442a7d07a07ede9b56f8c4f2c613dbeb546a969f169c2e1a2fb989c838363705366b1f9780e583989cd3d7264e597500c
   languageName: node
   linkType: hard
 
@@ -11294,6 +11305,17 @@ __metadata:
   languageName: node
   linkType: hard
 
+"better-sqlite3@npm:^7.6.2":
+  version: 7.6.2
+  resolution: "better-sqlite3@npm:7.6.2"
+  dependencies:
+    bindings: ^1.5.0
+    node-gyp: latest
+    prebuild-install: ^7.1.0
+  checksum: 45159e535d2c4f81456f85adcfef82e8a49025ca3e70a79bb8c0a47c13e4d822633a51b457cc37b986c42f8912344152091c91cab485048a187900aab7e7d619
+  languageName: node
+  linkType: hard
+
 "big-integer@npm:1.6.36":
   version: 1.6.36
   resolution: "big-integer@npm:1.6.36"
@@ -14421,6 +14443,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"decompress-response@npm:^6.0.0":
+  version: 6.0.0
+  resolution: "decompress-response@npm:6.0.0"
+  dependencies:
+    mimic-response: ^3.1.0
+  checksum: d377cf47e02d805e283866c3f50d3d21578b779731e8c5072d6ce8c13cc31493db1c2f6784da9d1d5250822120cefa44f1deab112d5981015f2e17444b763812
+  languageName: node
+  linkType: hard
+
 "dedent@npm:^0.7.0":
   version: 0.7.0
   resolution: "dedent@npm:0.7.0"
@@ -14689,6 +14720,13 @@ __metadata:
   bin:
     detect-libc: ./bin/detect-libc.js
   checksum: daaaed925ffa7889bd91d56e9624e6c8033911bb60f3a50a74a87500680652969dbaab9526d1e200a4c94acf80fc862a22131841145a0a8482d60a99c24f4a3e
+  languageName: node
+  linkType: hard
+
+"detect-libc@npm:^2.0.0":
+  version: 2.0.1
+  resolution: "detect-libc@npm:2.0.1"
+  checksum: ccb05fcabbb555beb544d48080179c18523a343face9ee4e1a86605a8715b4169f94d663c21a03c310ac824592f2ba9a5270218819bb411ad7be578a527593d7
   languageName: node
   linkType: hard
 
@@ -17023,6 +17061,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"expand-template@npm:^2.0.3":
+  version: 2.0.3
+  resolution: "expand-template@npm:2.0.3"
+  checksum: 588c19847216421ed92befb521767b7018dc88f88b0576df98cb242f20961425e96a92cbece525ef28cc5becceae5d544ae0f5b9b5e2aa05acb13716ca5b3099
+  languageName: node
+  linkType: hard
+
 "expect@npm:^26.6.2":
   version: 26.6.2
   resolution: "expect@npm:26.6.2"
@@ -18502,6 +18547,13 @@ __metadata:
   dependencies:
     ini: ^1.3.2
   checksum: e6d2764c15bbab6d1d1000d1181bb907f6b3796bb04f63614dba571b18369e0ecb1beaf27ce8da5b24307ef607e3a5f262a67cb9575510b9446aac697d421beb
+  languageName: node
+  linkType: hard
+
+"github-from-package@npm:0.0.0":
+  version: 0.0.0
+  resolution: "github-from-package@npm:0.0.0"
+  checksum: 14e448192a35c1e42efee94c9d01a10f42fe790375891a24b25261246ce9336ab9df5d274585aedd4568f7922246c2a78b8a8cd2571bfe99c693a9718e7dd0e3
   languageName: node
   linkType: hard
 
@@ -24271,6 +24323,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"mimic-response@npm:^3.1.0":
+  version: 3.1.0
+  resolution: "mimic-response@npm:3.1.0"
+  checksum: 25739fee32c17f433626bf19f016df9036b75b3d84a3046c7d156e72ec963dd29d7fc8a302f55a3d6c5a4ff24259676b15d915aad6480815a969ff2ec0836867
+  languageName: node
+  linkType: hard
+
 "min-document@npm:^2.19.0":
   version: 2.19.0
   resolution: "min-document@npm:2.19.0"
@@ -24381,7 +24440,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"minimist@npm:^1.1.1, minimist@npm:^1.1.3, minimist@npm:^1.2.0, minimist@npm:^1.2.5, minimist@npm:^1.2.6":
+"minimist@npm:^1.1.1, minimist@npm:^1.1.3, minimist@npm:^1.2.0, minimist@npm:^1.2.3, minimist@npm:^1.2.5, minimist@npm:^1.2.6":
   version: 1.2.6
   resolution: "minimist@npm:1.2.6"
   checksum: d15428cd1e11eb14e1233bcfb88ae07ed7a147de251441d61158619dfb32c4d7e9061d09cab4825fdee18ecd6fce323228c8c47b5ba7cd20af378ca4048fb3fb
@@ -24511,6 +24570,13 @@ __metadata:
     for-in: ^1.0.2
     is-extendable: ^1.0.1
   checksum: 820d5a51fcb7479f2926b97f2c3bb223546bc915e6b3a3eb5d906dda871bba569863595424a76682f2b15718252954644f3891437cb7e3f220949bed54b1750d
+  languageName: node
+  linkType: hard
+
+"mkdirp-classic@npm:^0.5.2, mkdirp-classic@npm:^0.5.3":
+  version: 0.5.3
+  resolution: "mkdirp-classic@npm:0.5.3"
+  checksum: 3f4e088208270bbcc148d53b73e9a5bd9eef05ad2cbf3b3d0ff8795278d50dd1d11a8ef1875ff5aea3fa888931f95bfcb2ad5b7c1061cfefd6284d199e6776ac
   languageName: node
   linkType: hard
 
@@ -24732,6 +24798,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"napi-build-utils@npm:^1.0.1":
+  version: 1.0.2
+  resolution: "napi-build-utils@npm:1.0.2"
+  checksum: 06c14271ee966e108d55ae109f340976a9556c8603e888037145d6522726aebe89dd0c861b4b83947feaf6d39e79e08817559e8693deedc2c94e82c5cbd090c7
+  languageName: node
+  linkType: hard
+
 "natural-compare@npm:^1.4.0":
   version: 1.4.0
   resolution: "natural-compare@npm:1.4.0"
@@ -24901,6 +24974,15 @@ __metadata:
   version: 2.1.0
   resolution: "nocache@npm:2.1.0"
   checksum: 702ad516a7f8b21364c3e9b6ed982b0dfbcbdad9c28ed35331c4025025c729eb9d93523c3370947c5c8391ae33c6f69b67e35ef301d0e9424cee84f0b1d015c2
+  languageName: node
+  linkType: hard
+
+"node-abi@npm:^3.3.0":
+  version: 3.24.0
+  resolution: "node-abi@npm:3.24.0"
+  dependencies:
+    semver: ^7.3.5
+  checksum: d90ab48802497b2203800cac71018668e99c246435395ca4f67afcabf689e7e81568ed36e8036bae79a052b63ea5707375bece6ca0a1d2e2b99bfafde7a5c9b2
   languageName: node
   linkType: hard
 
@@ -27182,6 +27264,28 @@ __metadata:
   languageName: node
   linkType: hard
 
+"prebuild-install@npm:^7.1.0":
+  version: 7.1.1
+  resolution: "prebuild-install@npm:7.1.1"
+  dependencies:
+    detect-libc: ^2.0.0
+    expand-template: ^2.0.3
+    github-from-package: 0.0.0
+    minimist: ^1.2.3
+    mkdirp-classic: ^0.5.3
+    napi-build-utils: ^1.0.1
+    node-abi: ^3.3.0
+    pump: ^3.0.0
+    rc: ^1.2.7
+    simple-get: ^4.0.0
+    tar-fs: ^2.0.0
+    tunnel-agent: ^0.6.0
+  bin:
+    prebuild-install: bin.js
+  checksum: dbf96d0146b6b5827fc8f67f72074d2e19c69628b9a7a0a17d0fad1bf37e9f06922896972e074197fc00a52eae912993e6ef5a0d471652f561df5cb516f3f467
+  languageName: node
+  linkType: hard
+
 "prelude-ls@npm:^1.2.1":
   version: 1.2.1
   resolution: "prelude-ls@npm:1.2.1"
@@ -27859,7 +27963,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"rc@npm:^1.2.8":
+"rc@npm:^1.2.7, rc@npm:^1.2.8":
   version: 1.2.8
   resolution: "rc@npm:1.2.8"
   dependencies:
@@ -30481,6 +30585,17 @@ __metadata:
   languageName: node
   linkType: hard
 
+"simple-get@npm:^4.0.0":
+  version: 4.0.1
+  resolution: "simple-get@npm:4.0.1"
+  dependencies:
+    decompress-response: ^6.0.0
+    once: ^1.3.1
+    simple-concat: ^1.0.0
+  checksum: e4132fd27cf7af230d853fa45c1b8ce900cb430dd0a3c6d3829649fe4f2b26574c803698076c4006450efb0fad2ba8c5455fbb5755d4b0a5ec42d4f12b31d27e
+  languageName: node
+  linkType: hard
+
 "simple-git@npm:^3.12.0":
   version: 3.12.0
   resolution: "simple-git@npm:3.12.0"
@@ -32007,7 +32122,19 @@ __metadata:
   languageName: node
   linkType: hard
 
-"tar-stream@npm:~2.2.0":
+"tar-fs@npm:^2.0.0":
+  version: 2.1.1
+  resolution: "tar-fs@npm:2.1.1"
+  dependencies:
+    chownr: ^1.1.1
+    mkdirp-classic: ^0.5.2
+    pump: ^3.0.0
+    tar-stream: ^2.1.4
+  checksum: f5b9a70059f5b2969e65f037b4e4da2daf0fa762d3d232ffd96e819e3f94665dbbbe62f76f084f1acb4dbdcce16c6e4dac08d12ffc6d24b8d76720f4d9cf032d
+  languageName: node
+  linkType: hard
+
+"tar-stream@npm:^2.1.4, tar-stream@npm:~2.2.0":
   version: 2.2.0
   resolution: "tar-stream@npm:2.2.0"
   dependencies:


### PR DESCRIPTION
Optional optimization of https://github.com/trezor/trezor-suite/pull/6068, adding `better-sqlite3` package and storing fetched block filters indefinitely. Only in desktop app.

**NOT ENTIRELY FINISHED**