### PR TITLE
fix(suite): fix coinjoin in desktop app on Mac with M1 chip

### DIFF
--- a/packages/suite-desktop/package.json
+++ b/packages/suite-desktop/package.json
@@ -64,6 +64,7 @@
             "!node_modules/@sentry/**/build",
             "!node_modules/tiny-secp256k1/**/build",
             "!node_modules/blake-hash/**/build",
+            "!node_modules/bcrypto/**/build",
             "!**/node_modules/*/{test,__tests__,tests,powered-test,example,examples}",
             "!**/node_modules/*.d.ts",
             "!**/node_modules/.bin",

--- a/packages/suite-desktop/scripts/build-inject.ts
+++ b/packages/suite-desktop/scripts/build-inject.ts
@@ -2,3 +2,6 @@ import fetch from 'node-fetch';
 
 // @ts-expect-error
 global.fetch = fetch;
+
+// fix bcrypto - use JS implementaion instead of native binaries
+process.env.NODE_BACKEND = 'js';

--- a/packages/suite-desktop/src/app.ts
+++ b/packages/suite-desktop/src/app.ts
@@ -31,9 +31,6 @@ global.resourcesPath = isDevEnv
     ? path.join(__dirname, '..', 'build', 'static')
     : process.resourcesPath;
 
-// fix bcrypto - use JS implementaion instead of native binaries
-process.env.NODE_BACKEND = 'js';
-
 const clearAppCache = () =>
     new Promise<void>((resolve, reject) => {
         const appFolder = process.env.PKGNAME!.replace('/', path.sep);

--- a/packages/suite-desktop/src/app.ts
+++ b/packages/suite-desktop/src/app.ts
@@ -31,6 +31,9 @@ global.resourcesPath = isDevEnv
     ? path.join(__dirname, '..', 'build', 'static')
     : process.resourcesPath;
 
+// fix bcrypto - use JS implementaion instead of native binaries
+process.env.NODE_BACKEND = 'js';
+
 const clearAppCache = () =>
     new Promise<void>((resolve, reject) => {
         const appFolder = process.env.PKGNAME!.replace('/', path.sep);


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Use JS implementation of bcrypto instead of native binaries to be able to run on arm mac.

Without this, we get this error on M1 macs:
```
2022-10-11T13:58:48.665Z - ERROR(modules): Couldn't initialize coinjoin (Error: dlopen(/Applications/Trezor Suite.app/Contents/Resources/app.asar.unpacked/node_modules/bcrypto/build/Release/bcrypto.node, 0x0001): tried: '/Applications/Trezor Suite.app/Contents/Resources/app.asar.unpacked/node_modules/bcrypto/build/Release/bcrypto.node' (mach-o file, but is an incompatible architecture (have (x86_64), need (arm64e))))
```

bcrypto provides `NODE_BACKEND` environment variable to select between native and js implementation - see https://github.com/bcoin-org/bcrypto/blob/master/lib/hash256.js#L9

We are not building bcrypto using webpack so we can't replace that variable in build time so I set it in runtime.

Any idea where to place the process.env.NODE_BACKEND setup? 

