### PR TITLE
feat(suite): coinjoin account types also supports changing amount unit (satoshis)

### DIFF
--- a/suite-common/wallet-config/src/networksConfig.ts
+++ b/suite-common/wallet-config/src/networksConfig.ts
@@ -268,7 +268,7 @@ export const networks = {
                 name: 'Bitcoin Regtest (PEA)',
                 bip43Path: "m/10025'/1'/i'/1'", // https://github.com/satoshilabs/slips/blob/master/slip-0025.md#public-key-derivation
                 backendType: 'coinjoin', // use non-standard backend
-                features: [], // no rbf, no sign-verify
+                features: ['amount-unit'], // no rbf, no sign-verify
             },
             taproot: {
                 name: 'Bitcoin Regtest (taproot)',

--- a/suite-common/wallet-utils/src/__tests__/accountUtils.test.ts
+++ b/suite-common/wallet-utils/src/__tests__/accountUtils.test.ts
@@ -234,7 +234,7 @@ describe('account utils', () => {
         expect(getNetworkFeatures(btcAcc)).toEqual(['rbf', 'sign-verify', 'amount-unit']);
         expect(getNetworkFeatures(btcTaprootAcc)).toEqual(['rbf', 'amount-unit']);
         expect(getNetworkFeatures(ethAcc)).toEqual(['sign-verify', 'tokens']);
-        expect(getNetworkFeatures(coinJoinAcc)).toEqual([]);
+        expect(getNetworkFeatures(coinJoinAcc)).toEqual(['amount-unit']);
     });
 
     it('hasNetworkFeatures', () => {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Isn't it strange that satoshis work on coinjoin account without this? The reason is, that `networksCompatibility` contains more items with symbol === regtest - one general and one per every account type:

<details>
  <summary> networksCompatibility </summary>
  
```json
[
    {
        "symbol": "regtest",
        "name": "Bitcoin Regtest",
        "networkType": "bitcoin",
        "bip43Path": "m/84'/1'/i'",
        "decimals": 8,
        "testnet": true,
        "label": "TR_TESTNET_COINS_LABEL",
        "explorer": {
            "tx": "http://localhost:19121/tx/",
            "account": "http://localhost:19121/xpub/"
        },
        "features": [
            "rbf",
            "sign-verify",
            "amount-unit"
        ],
        "customBackends": [
            "blockbook",
            "electrum"
        ]
    },
    {
        "symbol": "regtest",
        "accountType": "coinjoin",
        "name": "Bitcoin Regtest (PEA)",
        "networkType": "bitcoin",
        "bip43Path": "m/10025'/1'/i'/1'",
        "decimals": 8,
        "testnet": true,
        "label": "TR_TESTNET_COINS_LABEL",
        "explorer": {
            "tx": "http://localhost:19121/tx/",
            "account": "http://localhost:19121/xpub/"
        },
        "features": [],
        "customBackends": [
            "blockbook",
            "electrum"
        ],
        "backendType": "coinjoin"
    },
    {
        "symbol": "regtest",
        "accountType": "taproot",
        "name": "Bitcoin Regtest (taproot)",
        "networkType": "bitcoin",
        "bip43Path": "m/86'/1'/i'",
        "decimals": 8,
        "testnet": true,
        "label": "TR_TESTNET_COINS_LABEL",
        "explorer": {
            "tx": "http://localhost:19121/tx/",
            "account": "http://localhost:19121/xpub/"
        },
        "features": [
            "rbf",
            "amount-unit"
        ],
        "customBackends": [
            "blockbook",
            "electrum"
        ]
    },
    {
        "symbol": "regtest",
        "accountType": "segwit",
        "name": "Bitcoin Regtest (segwit)",
        "networkType": "bitcoin",
        "bip43Path": "m/49'/1'/i'",
        "decimals": 8,
        "testnet": true,
        "label": "TR_TESTNET_COINS_LABEL",
        "explorer": {
            "tx": "http://localhost:19121/tx/",
            "account": "http://localhost:19121/xpub/"
        },
        "features": [
            "rbf",
            "sign-verify",
            "amount-unit"
        ],
        "customBackends": [
            "blockbook",
            "electrum"
        ]
    },
    {
        "symbol": "regtest",
        "accountType": "legacy",
        "name": "Bitcoin Regtest (legacy)",
        "networkType": "bitcoin",
        "bip43Path": "m/44'/1'/i'",
        "decimals": 8,
        "testnet": true,
        "label": "TR_TESTNET_COINS_LABEL",
        "explorer": {
            "tx": "http://localhost:19121/tx/",
            "account": "http://localhost:19121/xpub/"
        },
        "features": [
            "rbf",
            "sign-verify",
            "amount-unit"
        ],
        "customBackends": [
            "blockbook",
            "electrum"
        ]
    }
]
```
</details>

but we use NETWORKS.find just by symbol like this: https://github.com/trezor/trezor-suite/pull/6544/files#diff-644bf5706d3a615cd7cef6207e6c4c6864f547b612c4cdab11ca501e18ee41d4R14 🤷 
