### PR TITLE
fix(coinjoin): fix build for M1 macs by forcing the use of JS implementation instead of native binaries

### DIFF
--- a/packages/suite-desktop/scripts/build.ts
+++ b/packages/suite-desktop/scripts/build.ts
@@ -63,7 +63,12 @@ console.log(`[Electron Build] Using mocks: ${useMocks}`);
 // All local packages that doesn't have "build:libs" and used in packages/suite-desktop/src
 // must be built and not included in electron node_modules, because they are in TS.
 // Normal src/ folder is fine, because it's builded by webpack.
-const builtTrezorDependencies = ['@trezor/ipc-proxy', '@trezor/urls', '@trezor/utils'];
+const builtTrezorDependencies = [
+    '@trezor/ipc-proxy',
+    '@trezor/urls',
+    '@trezor/utils',
+    '@trezor/coinjoin', // build it so we can set process.env.NODE_BACKEND in build time and fix issue with bcrypto dependency
+];
 
 const dependencies = Object.keys(pkg.dependencies).filter(
     name => !(name.startsWith('@suite-common/') || builtTrezorDependencies.includes(name)),
@@ -93,6 +98,7 @@ build({
         'process.env.VERSION': JSON.stringify(suiteVersion),
         'process.env.SENTRY_RELEASE': JSON.stringify(sentryRelease),
         'process.env.SUITE_TYPE': JSON.stringify(PROJECT),
+        'process.env.NODE_BACKEND': JSON.stringify('js'), // fix bcrypto - use JS implementaion to prevent using binaries for wrong architecture
     },
     inject: [path.join(__dirname, 'build-inject.ts')],
     plugins: useMocks ? [mockPlugin] : [],


### PR DESCRIPTION

<!--- Provide a general summary of your changes in the Title above -->
Alternative solution of this https://github.com/trezor/trezor-suite/pull/6526

## Description

Use JS implementation of bcrypto instead of native binaries to be able to run on arm mac.

Without this, we get this error on M1 macs:
```
2022-10-11T13:58:48.665Z - ERROR(modules): Couldn't initialize coinjoin (Error: dlopen(/Applications/Trezor Suite.app/Contents/Resources/app.asar.unpacked/node_modules/bcrypto/build/Release/bcrypto.node, 0x0001): tried: '/Applications/Trezor Suite.app/Contents/Resources/app.asar.unpacked/node_modules/bcrypto/build/Release/bcrypto.node' (mach-o file, but is an incompatible architecture (have (x86_64), need (arm64e))))
```

bcrypto provides `NODE_BACKEND` environment variable to select between native and js implementation - see https://github.com/bcoin-org/bcrypto/blob/master/lib/hash256.js#L9

coinjoin module output 
before:
[coinjoin.js.txt](https://github.com/trezor/trezor-suite/files/9765301/coinjoin.js.txt) (3KB)

after:
[coinjoin-built.js.txt](https://github.com/trezor/trezor-suite/files/9765310/coinjoin-built.js.txt) (539 KB)


