### PR TITLE
fix(suite): use JS implementation of bcrypto instead of native binaries to be able to run on arm mac

### DIFF
--- a/packages/suite-desktop/package.json
+++ b/packages/suite-desktop/package.json
@@ -64,6 +64,7 @@
             "!node_modules/@sentry/**/build",
             "!node_modules/tiny-secp256k1/**/build",
             "!node_modules/blake-hash/**/build",
+            "!node_modules/bcrypto/**/build",
             "!**/node_modules/*/{test,__tests__,tests,powered-test,example,examples}",
             "!**/node_modules/*.d.ts",
             "!**/node_modules/.bin",

--- a/packages/suite-desktop/scripts/build-inject.ts
+++ b/packages/suite-desktop/scripts/build-inject.ts
@@ -2,3 +2,6 @@ import fetch from 'node-fetch';
 
 // @ts-expect-error
 global.fetch = fetch;
+
+// fix bcrypto - use JS implementaion to prevent using binaries for wrong architecture
+process.env.NODE_BACKEND = 'js';


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Use JS implementation of bcrypto instead of native binaries to be able to run on arm mac.

Without this, we get this error on M1 macs:
```
2022-10-11T13:58:48.665Z - ERROR(modules): Couldn't initialize coinjoin (Error: dlopen(/Applications/Trezor Suite.app/Contents/Resources/app.asar.unpacked/node_modules/bcrypto/build/Release/bcrypto.node, 0x0001): tried: '/Applications/Trezor Suite.app/Contents/Resources/app.asar.unpacked/node_modules/bcrypto/build/Release/bcrypto.node' (mach-o file, but is an incompatible architecture (have (x86_64), need (arm64e))))
```

bcrypto provides `NODE_BACKEND` environment variable to select between native and js implementation - see https://github.com/bcoin-org/bcrypto/blob/master/lib/hash256.js#L9

To be able to set `NODE_BACKEND` in build time we would need to start building @trezor/coinjoin with esbuild and that brings lot of duplicated library code, see https://github.com/trezor/trezor-suite/pull/6542