### PR TITLE
chore: remove unused ipc handler

### DIFF
--- a/packages/suite-desktop-api/src/api.ts
+++ b/packages/suite-desktop-api/src/api.ts
@@ -65,7 +65,6 @@ export interface InvokeChannels {
     'metadata/read': (options: { file: string }) => InvokeResult<string>;
     'metadata/write': (options: { file: string; content: string }) => InvokeResult;
     'server/request-address': (route: string) => string | undefined;
-    'tor/get-address': () => string;
     'tor/toggle': (shouldEnableTor: boolean) => InvokeResult;
     'user-data/clear': () => InvokeResult;
     'udev/install': () => InvokeResult;

--- a/packages/suite-desktop/src/modules/tor.ts
+++ b/packages/suite-desktop/src/modules/tor.ts
@@ -157,11 +157,6 @@ const load = async ({ mainWindow, store, interceptor }: Dependencies) => {
         mainWindow.webContents.send('tor/status', store.getTorSettings().running);
     });
 
-    ipcMain.handle('tor/get-address', () => {
-        logger.debug('tor', `Getting address (${store.getTorSettings().address})`);
-        return store.getTorSettings().address;
-    });
-
     interceptor.onBeforeRequest(details => {
         const { hostname, protocol } = new URL(details.url);
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

IPC handler `tor/get-address` is not used anymore anywhere so there is not need to keep it there.
