### PR TITLE
Fix/long token names

### DIFF
--- a/packages/suite/src/views/wallet/tokens/components/NoTokens.tsx
+++ b/packages/suite/src/views/wallet/tokens/components/NoTokens.tsx
@@ -5,7 +5,7 @@ import { Translation } from '@suite-components';
 import * as modalActions from '@suite-actions/modalActions';
 import { useActions, useSelector } from '@suite-hooks';
 
-const NoTokens = () => {
+export const NoTokens = () => {
     const { selectedAccount } = useSelector(state => ({
         selectedAccount: state.wallet.selectedAccount,
     }));
@@ -36,5 +36,3 @@ const NoTokens = () => {
         />
     );
 };
-
-export default NoTokens;

--- a/packages/suite/src/views/wallet/tokens/components/TokenList.tsx
+++ b/packages/suite/src/views/wallet/tokens/components/TokenList.tsx
@@ -67,7 +67,7 @@ interface TokenListProps {
     isTestnet?: boolean;
 }
 
-const TokenList = ({ tokens, explorerUrl, isTestnet, networkType }: TokenListProps) => {
+export const TokenList = ({ tokens, explorerUrl, isTestnet, networkType }: TokenListProps) => {
     const theme = useTheme();
     if (!tokens || tokens.length === 0) return null;
 
@@ -121,5 +121,3 @@ const TokenList = ({ tokens, explorerUrl, isTestnet, networkType }: TokenListPro
         </Wrapper>
     );
 };
-
-export default TokenList;

--- a/packages/suite/src/views/wallet/tokens/components/TokenList/index.tsx
+++ b/packages/suite/src/views/wallet/tokens/components/TokenList/index.tsx
@@ -8,101 +8,66 @@ const Wrapper = styled(Card)<{ isTestnet?: boolean }>`
     display: grid;
     padding: 12px 16px;
     grid-template-columns: ${props => (props.isTestnet ? 'auto auto 44px' : 'auto auto auto 44px')};
-    overflow: auto;
+    word-break: break-all;
 `;
 
-interface ColProps {
-    justify?: 'left' | 'right';
-    paddingHorizontal?: boolean;
-    isTestnet?: boolean;
-}
-
-const TokenSymbol = styled.div`
+const TokenSymbol = styled.span`
     font-weight: ${variables.FONT_WEIGHT.MEDIUM};
     font-size: ${variables.FONT_SIZE.NORMAL};
     text-transform: uppercase;
     padding-right: 2px;
 `;
 
-const Col = styled.div<ColProps>`
-    display: flex;
-    align-items: center;
-    padding: 10px 12px 10px 0px;
-    color: ${props => props.theme.TYPE_DARK_GREY};
-    font-size: ${variables.FONT_SIZE.SMALL};
-    border-top: 1px solid ${props => props.theme.STROKE_GREY};
+interface ColProps {
+    justify?: 'left' | 'right';
+    isTestnet?: boolean;
+}
 
-    &:nth-child(${props => (props.isTestnet ? '-n + 3' : '-n + 4')}) {
+const Col = styled.div<ColProps>`
+    padding: 10px 12px 10px 0px;
+    color: ${({ theme }) => theme.TYPE_DARK_GREY};
+    font-size: ${variables.FONT_SIZE.SMALL};
+    border-top: 1px solid ${({ theme }) => theme.STROKE_GREY};
+
+    &:nth-child(${({ isTestnet }) => (isTestnet ? '-n + 3' : '-n + 4')}) {
         /* first row */
         border-top: none;
     }
 
-    ${props =>
-        props.justify &&
+    ${({ justify }) =>
+        justify &&
         css`
-            justify-content: ${(props: ColProps) =>
-                props.justify === 'right' ? 'flex-end' : 'flex-start'};
-            text-align: ${(props: ColProps) => (props.justify === 'right' ? 'right' : 'left')};
+            justify-content: ${justify === 'right' ? 'flex-end' : 'flex-start'};
+            text-align: ${justify === 'right' ? 'right' : 'left'};
         `}
-
-    ${props =>
-        props.paddingHorizontal &&
-        css`
-            padding-left: 14px;
-            padding-right: 14px;
-        `}
-`;
-
-const ColWithoutOverflow = styled(Col)`
-    overflow: hidden;
-`;
-
-const TokenNameWrapper = styled.div`
-    display: flex;
-    flex: 1;
-    overflow: hidden;
-    text-overflow: ellipsis;
-    align-items: center;
 `;
 
 const TokenName = styled.span`
-    white-space: nowrap;
-    overflow: hidden;
-    text-overflow: ellipsis;
-
     @media only screen and (max-width: ${variables.SCREEN_SIZE.SM}) {
         display: none;
     }
 `;
 
-const TokenValue = styled.div`
-    display: flex;
-    font-size: ${variables.FONT_SIZE.NORMAL};
-    font-weight: ${variables.FONT_WEIGHT.MEDIUM};
-    color: ${props => props.theme.TYPE_DARK_GREY};
-    white-space: nowrap;
-`;
-
 const FiatWrapper = styled.div`
-    display: flex;
     font-size: ${variables.FONT_SIZE.SMALL};
     font-weight: ${variables.FONT_WEIGHT.MEDIUM};
-    color: ${props => props.theme.TYPE_LIGHT_GREY};
+    color: ${({ theme }) => theme.TYPE_LIGHT_GREY};
 `;
 
 const CryptoAmount = styled(FormattedCryptoAmount)`
-    display: flex;
-    overflow: hidden;
+    color: ${({ theme }) => theme.TYPE_DARK_GREY};
+    font-size: ${variables.FONT_SIZE.NORMAL};
+    font-weight: ${variables.FONT_WEIGHT.MEDIUM};
 `;
 
-interface Props {
+interface TokenListProps {
     tokens: Account['tokens'];
     networkType: Account['networkType'];
     explorerUrl: string;
     isTestnet?: boolean;
 }
 
-const TokenList = ({ tokens, explorerUrl, isTestnet, networkType }: Props) => {
+const TokenList = ({ tokens, explorerUrl, isTestnet, networkType }: TokenListProps) => {
     const theme = useTheme();
     if (!tokens || tokens.length === 0) return null;
 
@@ -113,22 +78,20 @@ const TokenList = ({ tokens, explorerUrl, isTestnet, networkType }: Props) => {
 
                 return (
                     <Fragment key={t.address}>
-                        <ColWithoutOverflow isTestnet={isTestnet}>
-                            <TokenNameWrapper>
-                                {!noName && <TokenSymbol>{t.symbol}</TokenSymbol>}
+                        <Col isTestnet={isTestnet}>
+                            {!noName && <TokenSymbol>{t.symbol}</TokenSymbol>}
+                            <TokenName>
                                 {!noName && ` - `}
-                                <TokenName>{t.name}</TokenName>
-                            </TokenNameWrapper>
-                        </ColWithoutOverflow>
+                                {t.name}
+                            </TokenName>
+                        </Col>
                         <Col isTestnet={isTestnet} justify="right">
-                            <TokenValue>
-                                {t.balance && (
-                                    <CryptoAmount
-                                        value={t.balance}
-                                        symbol={networkType === 'cardano' ? undefined : t.symbol}
-                                    />
-                                )}
-                            </TokenValue>
+                            {t.balance && (
+                                <CryptoAmount
+                                    value={t.balance}
+                                    symbol={networkType === 'cardano' ? undefined : t.symbol}
+                                />
+                            )}
                         </Col>
                         {!isTestnet && (
                             <Col isTestnet={isTestnet} justify="right">

--- a/packages/suite/src/views/wallet/tokens/index.tsx
+++ b/packages/suite/src/views/wallet/tokens/index.tsx
@@ -2,19 +2,17 @@ import React from 'react';
 import { WalletLayout } from '@wallet-components';
 import { isTestnet } from '@suite-common/wallet-utils';
 import { useSelector } from '@suite-hooks';
-import { AppState } from '@suite-types';
 
-import NoTokens from './components/NoTokens';
-import TokenList from './components/TokenList';
-import AccountEmpty from '../transactions/components/AccountEmpty';
+import { NoTokens } from './components/NoTokens';
+import { TokenList } from './components/TokenList';
 
-interface ContentProps {
-    children?: React.ReactNode;
-    selectedAccount: AppState['wallet']['selectedAccount'];
-}
+export const Tokens = () => {
+    const { selectedAccount } = useSelector(state => state.wallet);
 
-const Content = ({ selectedAccount, children }: ContentProps) => {
-    if (selectedAccount.status !== 'loaded') return null;
+    if (selectedAccount.status !== 'loaded') {
+        return <WalletLayout title="TR_TOKENS" account={selectedAccount} />;
+    }
+
     const { account, network } = selectedAccount;
     const explorerUrl =
         network.networkType === 'cardano' ? network.explorer.token : network.explorer.account;
@@ -27,40 +25,9 @@ const Content = ({ selectedAccount, children }: ContentProps) => {
                 tokens={account.tokens}
                 networkType={account.networkType}
             />
-
-            {children}
+            {!account.tokens?.length && <NoTokens />}
         </WalletLayout>
     );
-};
-
-const Tokens = () => {
-    const { selectedAccount } = useSelector(state => ({
-        selectedAccount: state.wallet.selectedAccount,
-    }));
-
-    if (selectedAccount.status !== 'loaded') {
-        return <WalletLayout title="TR_TOKENS" account={selectedAccount} />;
-    }
-
-    const { account } = selectedAccount;
-
-    if (!account.tokens?.length) {
-        return (
-            <Content selectedAccount={selectedAccount}>
-                <NoTokens />
-            </Content>
-        );
-    }
-
-    if (account.empty) {
-        return (
-            <Content selectedAccount={selectedAccount}>
-                <AccountEmpty account={selectedAccount.account} />
-            </Content>
-        );
-    }
-
-    return <Content selectedAccount={selectedAccount} />;
 };
 
 export default Tokens;


### PR DESCRIPTION
Fixes bug reported on [Slack](https://satoshilabs.slack.com/archives/CKZHV2G13/p1665665529471299)

## Description

- fix long token name/symbol balance breaking layout
- add bottom margin to the container
- hide the hyphen after token symbol along with the name on narrow screens
- refactor

The affected users reported that they could not see the whole table after they have been sent a scam token with long name and symbol. They did not see a scroll bar. This can be caused by OS settings (on a Mac, "Show scroll bars" can be set to "When scrolling", which hides the scroll bar in this case and only allows navigation by keyboard. Plus most of the table was overflowing and hidden beyond max width anyway, even if they could use the scroll bar.

To avoid potential problems with scrolling, I applied `word-break: break-all` to the table. Now, everything should be visible (potentially on multiple lines) without scrolling.

## Screenshots (if appropriate):
Before (long token name and missing scrollbar):
![Screenshot 2022-10-13 at 18 03 58](https://user-images.githubusercontent.com/42465546/195650824-ac84d436-bd26-45ae-aaba-886cbca769e0.png)
Before (extra hyphen when token name is hidden and missing `margin-bottom`):
![Screenshot 2022-10-13 at 18 05 37](https://user-images.githubusercontent.com/42465546/195650840-4a1340fb-f412-48c2-b917-8358755b4b1a.png)

After (no hyphen):
![Screenshot 2022-10-13 at 17 51 55](https://user-images.githubusercontent.com/42465546/195650802-bf1625cd-8f48-4ccb-82df-a2137fdd0cbd.png)
After:
![Screenshot 2022-10-13 at 18 21 19](https://user-images.githubusercontent.com/42465546/195651814-fb401409-f4de-46f5-ab40-430f18352a97.png)


**QA:** This is the token causing the problem with scrolling: https://etherscan.io/token/0xc9da518db3abdb90a82c4d1838b7cf9b0c945e7e

