### PR TITLE
Feat/coinjoin: remember and forget Coinjoin accounts

### DIFF
--- a/packages/suite/src/actions/suite/storageActions.ts
+++ b/packages/suite/src/actions/suite/storageActions.ts
@@ -45,6 +45,20 @@ export const removeAccountDraft = async (account: Account) => {
     return db.removeItemByPK('sendFormDrafts', account.key);
 };
 
+export const saveCoinjoinAccount =
+    (accountKey: string) => async (_: Dispatch, getState: GetState) => {
+        const state = getState();
+        const { device } = state.suite;
+        const account = state.wallet.coinjoin.accounts.find(a => a.key === accountKey);
+        if (!device?.remember || !account || !(await db.isAccessible())) return;
+        return db.addItem('coinjoinAccounts', account, accountKey, true);
+    };
+
+export const removeCoinjoinAccount = async (accountKey: string) => {
+    if (!(await db.isAccessible())) return;
+    return db.removeItemByPK('coinjoinAccounts', accountKey);
+};
+
 // send form drafts end
 
 export const saveFormDraft = async (key: string, draft: FormDraft) => {
@@ -183,6 +197,7 @@ export const rememberDevice =
                     [
                         dispatch(saveAccountTransactions(account)),
                         dispatch(saveAccountDraft(account)),
+                        dispatch(saveCoinjoinAccount(account.key)),
                     ],
                     FormDraftPrefixKeyValues.map(prefix =>
                         dispatch(saveAccountFormDraft(prefix, account.key)),

--- a/packages/suite/src/actions/wallet/coinjoinClientActions.ts
+++ b/packages/suite/src/actions/wallet/coinjoinClientActions.ts
@@ -6,23 +6,33 @@ import { Dispatch } from '@suite-types';
 import { Account } from '@suite-common/wallet-types';
 
 const clientEnable = (symbol: Account['symbol']) =>
-    ({ type: COINJOIN.CLIENT_ENABLE, symbol } as const);
+    ({
+        type: COINJOIN.CLIENT_ENABLE,
+        payload: {
+            symbol,
+        },
+    } as const);
 
 const clientEnableSuccess = (symbol: Account['symbol'], status: CoinjoinStatus) =>
     ({
         type: COINJOIN.CLIENT_ENABLE_SUCCESS,
-        symbol,
-        status,
+        payload: {
+            symbol,
+            status,
+        },
     } as const);
 
 const clientEnableFailed = (symbol: Account['symbol']) =>
     ({
         type: COINJOIN.CLIENT_ENABLE_FAILED,
-        symbol,
+        payload: {
+            symbol,
+        },
     } as const);
 
 export type CoinjoinClientAction =
     | ReturnType<typeof clientEnable>
+    | ReturnType<typeof clientDisable>
     | ReturnType<typeof clientEnableSuccess>
     | ReturnType<typeof clientEnableFailed>;
 

--- a/packages/suite/src/actions/wallet/coinjoinClientActions.ts
+++ b/packages/suite/src/actions/wallet/coinjoinClientActions.ts
@@ -13,6 +13,14 @@ const clientEnable = (symbol: Account['symbol']) =>
         },
     } as const);
 
+export const clientDisable = (symbol: Account['symbol']) =>
+    ({
+        type: COINJOIN.CLIENT_DISABLE,
+        payload: {
+            symbol,
+        },
+    } as const);
+
 const clientEnableSuccess = (symbol: Account['symbol'], status: CoinjoinStatus) =>
     ({
         type: COINJOIN.CLIENT_ENABLE_SUCCESS,

--- a/packages/suite/src/actions/wallet/constants/coinjoinConstants.ts
+++ b/packages/suite/src/actions/wallet/constants/coinjoinConstants.ts
@@ -1,4 +1,5 @@
 export const ACCOUNT_CREATE = '@coinjoin/account-create';
+export const ACCOUNT_REMOVE = '@coinjoin/account-remove';
 export const ACCOUNT_UPDATE_TARGET_ANONYMITY = '@coinjoin/account-update-target-anonymity';
 export const ACCOUNT_AUTHORIZE = '@coinjoin/account-authorize';
 export const ACCOUNT_AUTHORIZE_SUCCESS = '@coinjoin/account-authorize-success';
@@ -6,5 +7,6 @@ export const ACCOUNT_AUTHORIZE_FAILED = '@coinjoin/account-authorize-failed';
 export const ACCOUNT_UNREGISTER = '@coinjoin/account-unregister';
 
 export const CLIENT_ENABLE = '@coinjoin/client-enable';
+export const CLIENT_DISABLE = '@coinjoin/client-disable';
 export const CLIENT_ENABLE_SUCCESS = '@coinjoin/client-enable-success';
 export const CLIENT_ENABLE_FAILED = '@coinjoin/client-enable-failed';

--- a/packages/suite/src/middlewares/wallet/coinjoinMiddleware.ts
+++ b/packages/suite/src/middlewares/wallet/coinjoinMiddleware.ts
@@ -1,5 +1,5 @@
 import type { MiddlewareAPI } from 'redux';
-import { ROUTER } from '@suite-actions/constants';
+import { SUITE, ROUTER } from '@suite-actions/constants';
 import { DISCOVERY } from '@wallet-actions/constants';
 import * as coinjoinAccountActions from '@wallet-actions/coinjoinAccountActions';
 import { CoinjoinBackendService } from '@suite/services/coinjoin/coinjoinBackend';
@@ -17,6 +17,10 @@ export const coinjoinMiddleware =
 
         // propagate action to reducers
         next(action);
+
+        if (action.type === SUITE.READY) {
+            api.dispatch(coinjoinAccountActions.restoreCoinjoin());
+        }
 
         if (accountsActions.removeAccount.match(action)) {
             api.dispatch(coinjoinAccountActions.forgetCoinjoinAccounts(action.payload));

--- a/packages/suite/src/middlewares/wallet/coinjoinMiddleware.ts
+++ b/packages/suite/src/middlewares/wallet/coinjoinMiddleware.ts
@@ -4,7 +4,7 @@ import { DISCOVERY } from '@wallet-actions/constants';
 import * as coinjoinAccountActions from '@wallet-actions/coinjoinAccountActions';
 import { CoinjoinBackendService } from '@suite/services/coinjoin/coinjoinBackend';
 import type { AppState, Action, Dispatch } from '@suite-types';
-import { blockchainActions } from '@suite-common/wallet-core';
+import { blockchainActions, accountsActions } from '@suite-common/wallet-core';
 
 export const coinjoinMiddleware =
     (api: MiddlewareAPI<Dispatch, AppState>) =>
@@ -17,6 +17,10 @@ export const coinjoinMiddleware =
 
         // propagate action to reducers
         next(action);
+
+        if (accountsActions.removeAccount.match(action)) {
+            api.dispatch(coinjoinAccountActions.forgetCoinjoinAccounts(action.payload));
+        }
 
         if (action.type === DISCOVERY.START) {
             // find all coinjoin accounts

--- a/packages/suite/src/middlewares/wallet/storageMiddleware.ts
+++ b/packages/suite/src/middlewares/wallet/storageMiddleware.ts
@@ -4,6 +4,7 @@ import { db } from '@suite/storage';
 import { WALLET_SETTINGS } from '@settings-actions/constants';
 import * as walletSettingsActions from '@settings-actions/walletSettingsActions';
 import { DISCOVERY, GRAPH, SEND, COINMARKET_COMMON, FORM_DRAFT } from '@wallet-actions/constants';
+import * as COINJOIN from '@wallet-actions/constants/coinjoinConstants';
 import * as storageActions from '@suite-actions/storageActions';
 import * as accountUtils from '@suite-common/wallet-utils';
 import { SUITE, ANALYTICS, METADATA, MESSAGE_SYSTEM, STORAGE } from '@suite-actions/constants';
@@ -220,6 +221,18 @@ const storageMiddleware = (api: MiddlewareAPI<Dispatch, AppState>) => {
                     break;
                 case FIRMWARE.SET_HASH_INVALID:
                     api.dispatch(storageActions.saveFirmware());
+                    break;
+
+                case COINJOIN.ACCOUNT_CREATE:
+                    api.dispatch(storageActions.saveCoinjoinAccount(action.payload.account.key));
+                    break;
+                case COINJOIN.ACCOUNT_AUTHORIZE_SUCCESS:
+                case COINJOIN.ACCOUNT_UNREGISTER:
+                case COINJOIN.ACCOUNT_UPDATE_TARGET_ANONYMITY:
+                    api.dispatch(storageActions.saveCoinjoinAccount(action.payload.accountKey));
+                    break;
+                case COINJOIN.ACCOUNT_REMOVE:
+                    storageActions.removeCoinjoinAccount(action.payload.accountKey);
                     break;
 
                 default:

--- a/packages/suite/src/reducers/wallet/coinjoinReducer.ts
+++ b/packages/suite/src/reducers/wallet/coinjoinReducer.ts
@@ -104,18 +104,7 @@ export const coinjoinReducer = (
     produce(state, draft => {
         switch (action.type) {
             case STORAGE.LOAD:
-                // Temporary code
-                // coinjoin reducer is not stored in DB yet
-                // restore accounts with coinjoin accountType
-                action.payload.accounts.forEach(account => {
-                    if (account.accountType === 'coinjoin') {
-                        draft.accounts.push({
-                            key: account.key,
-                            targetAnonymity: 0,
-                            previousSessions: [],
-                        });
-                    }
-                });
+                draft.accounts = action.payload.coinjoinAccounts;
                 break;
 
             case COINJOIN.ACCOUNT_CREATE:

--- a/packages/suite/src/reducers/wallet/coinjoinReducer.ts
+++ b/packages/suite/src/reducers/wallet/coinjoinReducer.ts
@@ -121,6 +121,9 @@ export const coinjoinReducer = (
             case COINJOIN.ACCOUNT_CREATE:
                 createAccount(draft, action.payload);
                 break;
+            case COINJOIN.ACCOUNT_REMOVE:
+                draft.accounts = draft.accounts.filter(a => a.key !== action.payload.accountKey);
+                break;
             case COINJOIN.ACCOUNT_UPDATE_TARGET_ANONYMITY:
                 updateTargetAnonymity(draft, action.payload);
                 break;
@@ -133,6 +136,9 @@ export const coinjoinReducer = (
 
             case COINJOIN.CLIENT_ENABLE_SUCCESS:
                 createClient(draft, action.payload);
+                break;
+            case COINJOIN.CLIENT_DISABLE:
+                delete draft.clients[action.payload.symbol];
                 break;
 
             // no default

--- a/packages/suite/src/reducers/wallet/coinjoinReducer.ts
+++ b/packages/suite/src/reducers/wallet/coinjoinReducer.ts
@@ -40,6 +40,7 @@ const createAccount = (
     if (exists) return;
     draft.accounts.push({
         key: account.key,
+        symbol: account.symbol,
         targetAnonymity,
         previousSessions: [],
     });

--- a/packages/suite/src/services/coinjoin/coinjoinBackend.ts
+++ b/packages/suite/src/services/coinjoin/coinjoinBackend.ts
@@ -171,4 +171,11 @@ export class CoinjoinBackendService {
     static getInstances() {
         return Object.keys(this.instances).map(key => this.instances[key]);
     }
+
+    static removeInstance(network: string) {
+        if (this.instances[network]) {
+            this.instances[network].cancel();
+            delete this.instances[network];
+        }
+    }
 }

--- a/packages/suite/src/services/coinjoin/coinjoinClient.ts
+++ b/packages/suite/src/services/coinjoin/coinjoinClient.ts
@@ -30,4 +30,11 @@ export class CoinjoinClientService {
     static getInstances() {
         return Object.keys(this.instances).map(key => this.instances[key]);
     }
+
+    static removeInstance(network: string) {
+        if (this.instances[network]) {
+            this.instances[network].disable();
+            delete this.instances[network];
+        }
+    }
 }

--- a/packages/suite/src/storage/CHANGELOG.md
+++ b/packages/suite/src/storage/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Storage changelog
 
+## 32
+
+-   added `coinjoinAccounts`
+
 ## 31
 
 -   txs are now stored unconverted (mostly `sat` units instead of `BTC`), therefore migration was needed

--- a/packages/suite/src/storage/definitions.ts
+++ b/packages/suite/src/storage/definitions.ts
@@ -16,7 +16,7 @@ import type {
 } from '@wallet-types';
 
 import type { MessageSystem } from '@trezor/message-system';
-import type { BackendSettings, WalletSettings } from '@suite-common/wallet-types';
+import type { BackendSettings, WalletSettings, CoinjoinAccount } from '@suite-common/wallet-types';
 import type { GraphData } from '@suite-common/wallet-graph';
 import type { StorageUpdateMessage } from '@trezor/suite-storage';
 
@@ -66,6 +66,10 @@ export interface SuiteDBSchema extends DBSchema {
         indexes: {
             deviceState: string;
         };
+    };
+    coinjoinAccounts: {
+        key: string; // accountKey
+        value: CoinjoinAccount;
     };
     discovery: {
         key: string;

--- a/packages/suite/src/storage/index.ts
+++ b/packages/suite/src/storage/index.ts
@@ -4,7 +4,7 @@ import { migrate } from './migrations';
 
 import type { SuiteDBSchema } from './definitions';
 
-const VERSION = 31; // don't forget to add migration and CHANGELOG when changing versions!
+const VERSION = 32; // don't forget to add migration and CHANGELOG when changing versions!
 
 /**
  *  If the object stores don't already exist then creates them.
@@ -82,6 +82,9 @@ const onUpgrade: OnUpgradeFunc<SuiteDBSchema> = async (db, oldVersion, newVersio
 
         // firmware. added in 28
         db.createObjectStore('firmware');
+
+        // coinjoin, added in 32
+        db.createObjectStore('coinjoinAccounts');
     } else {
         // migrate functions
         await migrate(db, oldVersion, newVersion, transaction);

--- a/packages/suite/src/storage/migrations/index.ts
+++ b/packages/suite/src/storage/migrations/index.ts
@@ -626,4 +626,8 @@ export const migrate: OnUpgradeFunc<SuiteDBSchema> = async (
             return cursor.continue().then(update);
         });
     }
+
+    if (oldVersion < 32) {
+        db.createObjectStore('coinjoinAccounts');
+    }
 };

--- a/packages/suite/src/support/suite/preloadStore.ts
+++ b/packages/suite/src/support/suite/preloadStore.ts
@@ -39,6 +39,7 @@ export const preloadStore = async () => {
     const sendFormDrafts = await db.getItemsWithKeys('sendFormDrafts');
     const formDrafts = await db.getItemsWithKeys('formDrafts');
     const firmware = await db.getItemByPK('firmware', 'firmware');
+    const coinjoinAccounts = await db.getItemsExtended('coinjoinAccounts');
 
     return {
         type: STORAGE.LOAD,
@@ -59,6 +60,7 @@ export const preloadStore = async () => {
             messageSystem,
             backendSettings,
             firmware,
+            coinjoinAccounts,
         },
     } as const;
 };

--- a/suite-common/wallet-types/src/coinjoin.ts
+++ b/suite-common/wallet-types/src/coinjoin.ts
@@ -1,3 +1,5 @@
+import { NetworkSymbol } from '@suite-common/wallet-config';
+
 export interface CoinjoinSessionParameters {
     anonymityLevel: number;
     maxRounds: number;
@@ -27,6 +29,7 @@ export interface CoinjoinSession extends CoinjoinSessionParameters {
 
 export interface CoinjoinAccount {
     key: string; // reference to wallet Account.key
+    symbol: NetworkSymbol;
     targetAnonymity: number; // anonymity set by the user
     session?: CoinjoinSession; // current/active authorized session
     previousSessions: CoinjoinSession[]; // history


### PR DESCRIPTION
## Remember and forget CoinjoinAccounts

another prerequisite for coinjoin https://github.com/trezor/trezor-suite/pull/6485

- [ef20eb1](https://github.com/trezor/trezor-suite/pull/6566/commits/ef20eb1fc7d74563fd86bcbe29db88e165e0738b) coinjoin related action unification, wrap data into payload object for easier transition into reduxtoolik actions in the future

- [4df2c06](https://github.com/trezor/trezor-suite/pull/6566/commits/4df2c069493d8afde9c735354319ba2e9da87260) adding `symbol` to `CoinjoinAccount` for easier matching between coinjoin.accounts and coinjoin.clients

- [39ebea1](https://github.com/trezor/trezor-suite/pull/6566/commits/39ebea17acc67ecc0390bea6f0a4c8439bcc40a2) remove running CoinjoinClient instances, removing CoinjoinAccount data from reducers

- [4d00f8f](https://github.com/trezor/trezor-suite/pull/6566/commits/4d00f8f1f03de5f9655d64160d5f6ecb6e134b0d) create new table in indexedDB

- [2b3d746](https://github.com/trezor/trezor-suite/pull/6566/commits/2b3d7464ab03568e641cf6d6f79138384939f5ea) save/remove CoinjoinAccounts actions

- [510b2ca](https://github.com/trezor/trezor-suite/pull/6566/commits/510b2ca23ff8696b5a846df70e8d4d4eeba5e880) restore CoinjoinClient and CoinjoinBackend for stored accouts. If account had active `session` this session will be terminated





