### PR TITLE
Format fiat amount for transactions

### DIFF
--- a/suite-common/formatters/src/FormatterProvider.tsx
+++ b/suite-common/formatters/src/FormatterProvider.tsx
@@ -7,14 +7,14 @@ import { SignValue } from '@suite-common/suite-types';
 import { NetworkSymbol } from '@suite-common/wallet-config';
 
 import {
-    prepareCryptoAmountFormatter,
     CryptoAmountFormatterDataContext,
     CryptoAmountFormatterInputValue,
+    prepareCryptoAmountFormatter,
 } from './formatters/prepareCryptoAmountFormatter';
 import { prepareCoinBalanceFormatter } from './formatters/prepareCoinBalanceFormatter';
 import {
-    prepareFiatAmountFormatter,
     FiatAmountFormatterDataContext,
+    prepareFiatAmountFormatter,
 } from './formatters/prepareFiatAmountFormatter';
 import { Formatter } from './makeFormatter';
 import { FormatterConfig, FormatterProviderConfig } from './types';
@@ -67,9 +67,7 @@ export const FormatterProvider = ({ config, children }: FormatterProviderProps) 
             ...config,
             intl,
         };
-        const formatters = getFormatters(extendedConfig);
-
-        return formatters;
+        return getFormatters(extendedConfig);
     }, [config, intl]);
 
     return (

--- a/suite-common/wallet-utils/src/fiatConverterUtils.ts
+++ b/suite-common/wallet-utils/src/fiatConverterUtils.ts
@@ -11,9 +11,10 @@ export const toFiatCurrency = (
     decimals = 2,
 ) => {
     // calculate amount in local currency
-
+    console.log(amount, fiatCurrency, networkRates, 'to fiat currency');
     const rate = networkRates?.[fiatCurrency];
     if (!rate) {
+        console.log('no rates');
         return null;
     }
 
@@ -24,9 +25,10 @@ export const toFiatCurrency = (
 
     const localAmount = new BigNumber(formattedAmount).times(rate);
     if (localAmount.isNaN()) {
+        console.log('not a number');
         return null;
     }
-
+    console.log(localAmount, 'local amount');
     return decimals === -1 ? localAmount.toFixed() : localAmount.toFixed(decimals);
 };
 

--- a/suite-common/wallet-utils/src/fiatConverterUtils.ts
+++ b/suite-common/wallet-utils/src/fiatConverterUtils.ts
@@ -11,29 +11,22 @@ export const toFiatCurrency = (
     decimals = 2,
 ) => {
     // calculate amount in local currency
-    console.log(amount, fiatCurrency, networkRates, 'to fiat currency');
     const rate = networkRates?.[fiatCurrency];
     if (!rate) {
-        console.log('no rates');
         return null;
     }
 
-    let formattedAmount = amount;
-    if (typeof amount === 'string') {
-        formattedAmount = amount.replace(',', '.');
-    }
-
-    const localAmount = new BigNumber(formattedAmount).times(rate);
-    if (localAmount.isNaN()) {
-        console.log('not a number');
+    console.log(amount, 'amount');
+    const formattedAmount = amount.replace(',', '.');
+    const fiatAmount = new BigNumber(formattedAmount).times(rate);
+    if (fiatAmount.isNaN()) {
         return null;
     }
-    console.log(localAmount, 'local amount');
-    return decimals === -1 ? localAmount.toFixed() : localAmount.toFixed(decimals);
+    return decimals === -1 ? fiatAmount.toFixed() : fiatAmount.toFixed(decimals);
 };
 
 export const fromFiatCurrency = (
-    localAmount: string,
+    fiatAmount: string,
     fiatCurrency: string,
     networkRates: FiatRates | undefined,
     decimals: number,
@@ -43,10 +36,7 @@ export const fromFiatCurrency = (
         return null;
     }
 
-    let formattedLocalAmount = localAmount;
-    if (typeof localAmount === 'string') {
-        formattedLocalAmount = localAmount.replace(',', '.');
-    }
+    const formattedLocalAmount = fiatAmount.replace(',', '.');
 
     const amount = new BigNumber(formattedLocalAmount).div(rate);
     const amountStr = amount.isNaN() ? null : amount.toFixed(decimals);

--- a/suite-common/wallet-utils/src/fiatConverterUtils.ts
+++ b/suite-common/wallet-utils/src/fiatConverterUtils.ts
@@ -16,16 +16,21 @@ export const toFiatCurrency = (
         return null;
     }
 
-    const formattedAmount = amount.replace(',', '.');
-    const fiatAmount = new BigNumber(formattedAmount).times(rate);
-    if (fiatAmount.isNaN()) {
+    let formattedAmount = amount;
+    if (typeof amount === 'string') {
+        formattedAmount = amount.replace(',', '.');
+    }
+
+    const localAmount = new BigNumber(formattedAmount).times(rate);
+    if (localAmount.isNaN()) {
         return null;
     }
-    return decimals === -1 ? fiatAmount.toFixed() : fiatAmount.toFixed(decimals);
+
+    return decimals === -1 ? localAmount.toFixed() : localAmount.toFixed(decimals);
 };
 
 export const fromFiatCurrency = (
-    fiatAmount: string,
+    localAmount: string,
     fiatCurrency: string,
     networkRates: FiatRates | undefined,
     decimals: number,
@@ -35,7 +40,10 @@ export const fromFiatCurrency = (
         return null;
     }
 
-    const formattedLocalAmount = fiatAmount.replace(',', '.');
+    let formattedLocalAmount = localAmount;
+    if (typeof localAmount === 'string') {
+        formattedLocalAmount = localAmount.replace(',', '.');
+    }
 
     const amount = new BigNumber(formattedLocalAmount).div(rate);
     const amountStr = amount.isNaN() ? null : amount.toFixed(decimals);

--- a/suite-common/wallet-utils/src/fiatConverterUtils.ts
+++ b/suite-common/wallet-utils/src/fiatConverterUtils.ts
@@ -16,7 +16,6 @@ export const toFiatCurrency = (
         return null;
     }
 
-    console.log(amount, 'amount');
     const formattedAmount = amount.replace(',', '.');
     const fiatAmount = new BigNumber(formattedAmount).times(rate);
     if (fiatAmount.isNaN()) {

--- a/suite-native/transactions/package.json
+++ b/suite-native/transactions/package.json
@@ -13,11 +13,13 @@
     "dependencies": {
         "@mobily/ts-belt": "^3.11.0",
         "@react-navigation/native": "^6.0.11",
+        "@suite-common/formatters": "*",
         "@suite-common/wallet-config": "*",
         "@suite-common/wallet-core": "*",
         "@suite-common/wallet-types": "*",
         "@suite-common/wallet-utils": "*",
         "@suite-native/atoms": "*",
+        "@suite-native/module-settings": "*",
         "@suite-native/navigation": "*",
         "@trezor/icons": "*",
         "@trezor/styles": "*",

--- a/suite-native/transactions/src/components/TransactionDetail/TransactionDetailHeader.tsx
+++ b/suite-native/transactions/src/components/TransactionDetail/TransactionDetailHeader.tsx
@@ -44,7 +44,7 @@ export const TransactionDetailHeader = ({
                 <Text style={applyStyle(transactionTypeStyle)}>{transactionTypeTextMap[type]}</Text>
             </Box>
             <Text variant="titleMedium">{amount}</Text>
-            <Text variant={'label'} color={'gray700'}>
+            <Text variant="label" color="gray700">
                 ≈ {fiatAmount}
             </Text>
         </>

--- a/suite-native/transactions/src/components/TransactionDetail/TransactionDetailHeader.tsx
+++ b/suite-native/transactions/src/components/TransactionDetail/TransactionDetailHeader.tsx
@@ -1,9 +1,12 @@
 import React from 'react';
+import { useSelector } from 'react-redux';
 
 import { Box, Text } from '@suite-native/atoms';
 import { Icon, IconName } from '@trezor/icons';
 import { TransactionType } from '@suite-common/wallet-types';
 import { prepareNativeStyle, useNativeStyles } from '@trezor/styles';
+import { selectFiatCurrency } from '@suite-native/module-settings';
+import { useFormatters } from '@suite-common/formatters';
 
 type TransactionDetailHeaderProps = {
     type: TransactionType;
@@ -33,6 +36,8 @@ export const TransactionDetailHeader = ({
     fiatAmount,
 }: TransactionDetailHeaderProps) => {
     const { applyStyle } = useNativeStyles();
+    const fiatCurrency = useSelector(selectFiatCurrency);
+    const { FiatAmountFormatter } = useFormatters();
     return (
         <>
             <Box flexDirection="row" marginBottom="small">
@@ -45,7 +50,7 @@ export const TransactionDetailHeader = ({
             </Box>
             <Text variant="titleMedium">{amount}</Text>
             <Text variant="label" color="gray700">
-                ≈ {fiatAmount}
+                <FiatAmountFormatter currency={fiatCurrency.label} value={fiatAmount ?? 0} />
             </Text>
         </>
     );

--- a/suite-native/transactions/src/components/TransactionDetail/TransactionDetailHeader.tsx
+++ b/suite-native/transactions/src/components/TransactionDetail/TransactionDetailHeader.tsx
@@ -8,6 +8,7 @@ import { prepareNativeStyle, useNativeStyles } from '@trezor/styles';
 type TransactionDetailHeaderProps = {
     type: TransactionType;
     amount: string;
+    fiatAmount: string | null;
 };
 
 const transactionTypeTextMap: Partial<Record<TransactionType, string>> = {
@@ -26,7 +27,11 @@ const transactionTypeStyle = prepareNativeStyle(utils => ({
     color: utils.colors.forest,
 }));
 
-export const TransactionDetailHeader = ({ type, amount }: TransactionDetailHeaderProps) => {
+export const TransactionDetailHeader = ({
+    type,
+    amount,
+    fiatAmount,
+}: TransactionDetailHeaderProps) => {
     const { applyStyle } = useNativeStyles();
     return (
         <>
@@ -39,6 +44,9 @@ export const TransactionDetailHeader = ({ type, amount }: TransactionDetailHeade
                 <Text style={applyStyle(transactionTypeStyle)}>{transactionTypeTextMap[type]}</Text>
             </Box>
             <Text variant="titleMedium">{amount}</Text>
+            <Text variant={'label'} color={'gray700'}>
+                ≈ {fiatAmount}
+            </Text>
         </>
     );
 };

--- a/suite-native/transactions/src/components/TransactionsList/TransactionListItem.tsx
+++ b/suite-native/transactions/src/components/TransactionsList/TransactionListItem.tsx
@@ -81,7 +81,7 @@ export const TransactionListItem = memo(({ transaction }: AccountTransactionList
             </Box>
             <Box alignItems="flex-end">
                 <Text>{FiatAmountFormatter.format(fiatAmount ?? 0)}</Text>
-                <Text>
+                <Text variant="hint" color="gray600">
                     <>{`${CryptoAmountFormatter.format(transactionAmount, {
                         symbol: transaction.symbol,
                     })} ${CurrencySymbolFormatter.format(transaction.symbol)}`}</>

--- a/suite-native/transactions/src/components/TransactionsList/TransactionListItem.tsx
+++ b/suite-native/transactions/src/components/TransactionsList/TransactionListItem.tsx
@@ -48,8 +48,9 @@ export const TransactionListItem = memo(({ transaction }: AccountTransactionList
         useNavigation<
             StackNavigationProps<RootStackParamList, AccountsStackRoutes.AccountDetail>
         >();
-    const { FiatAmountFormatter } = useFormatters();
-    const transactionAmount = formatNetworkAmount(transaction.amount, transaction.symbol, true);
+    const { FiatAmountFormatter, CryptoAmountFormatter, CurrencySymbolFormatter } = useFormatters();
+    const transactionAmount = formatNetworkAmount(transaction.amount, transaction.symbol);
+    const fiatAmount = toFiatCurrency(transactionAmount, fiatCurrency.label, transaction.rates);
 
     const getTransactionTimestamp = () => {
         const { blockHeight, blockTime } = transaction;
@@ -64,9 +65,6 @@ export const TransactionListItem = memo(({ transaction }: AccountTransactionList
         });
     };
 
-    const fiatAmount = toFiatCurrency(transactionAmount, fiatCurrency.label, transaction.rates);
-
-    console.log(fiatAmount, 'fiat amount');
     return (
         <TouchableOpacity
             onPress={() => handleNavigateToTransactionDetail()}
@@ -81,9 +79,13 @@ export const TransactionListItem = memo(({ transaction }: AccountTransactionList
                     <Text>{getTransactionTimestamp()?.toLocaleTimeString()}</Text>
                 </Box>
             </Box>
-            <Box>
+            <Box alignItems="flex-end">
                 <Text>{FiatAmountFormatter.format(fiatAmount ?? 0)}</Text>
-                <Text>{transactionAmount}</Text>
+                <Text>
+                    <>{`${CryptoAmountFormatter.format(transactionAmount, {
+                        symbol: transaction.symbol,
+                    })} ${CurrencySymbolFormatter.format(transaction.symbol)}`}</>
+                </Text>
             </Box>
         </TouchableOpacity>
     );

--- a/suite-native/transactions/src/components/TransactionsList/TransactionListItem.tsx
+++ b/suite-native/transactions/src/components/TransactionsList/TransactionListItem.tsx
@@ -1,5 +1,6 @@
 import React, { memo } from 'react';
 import { TouchableOpacity } from 'react-native';
+import { useSelector } from 'react-redux';
 
 import { useNavigation } from '@react-navigation/native';
 
@@ -7,13 +8,15 @@ import { Box, Text } from '@suite-native/atoms';
 import { TransactionType, WalletAccountTransaction } from '@suite-common/wallet-types';
 import { Icon, IconName } from '@trezor/icons';
 import { prepareNativeStyle, useNativeStyles } from '@trezor/styles';
+import { toFiatCurrency, formatNetworkAmount } from '@suite-common/wallet-utils';
 import {
     AccountsStackRoutes,
     RootStackParamList,
     RootStackRoutes,
     StackNavigationProps,
 } from '@suite-native/navigation';
-import { formatNetworkAmount } from '@suite-common/wallet-utils';
+import { selectFiatCurrency } from '@suite-native/module-settings';
+import { useFormatters } from '@suite-common/formatters';
 
 type AccountTransactionListItemProps = {
     transaction: WalletAccountTransaction;
@@ -40,10 +43,12 @@ const transactionListItemStyle = prepareNativeStyle(utils => ({
 
 export const TransactionListItem = memo(({ transaction }: AccountTransactionListItemProps) => {
     const { applyStyle } = useNativeStyles();
+    const fiatCurrency = useSelector(selectFiatCurrency);
     const navigation =
         useNavigation<
             StackNavigationProps<RootStackParamList, AccountsStackRoutes.AccountDetail>
         >();
+    const { FiatAmountFormatter } = useFormatters();
     const transactionAmount = formatNetworkAmount(transaction.amount, transaction.symbol, true);
 
     const getTransactionTimestamp = () => {
@@ -59,6 +64,9 @@ export const TransactionListItem = memo(({ transaction }: AccountTransactionList
         });
     };
 
+    const fiatAmount = toFiatCurrency(transactionAmount, fiatCurrency.label, transaction.rates);
+
+    console.log(fiatAmount, 'fiat amount');
     return (
         <TouchableOpacity
             onPress={() => handleNavigateToTransactionDetail()}
@@ -73,7 +81,10 @@ export const TransactionListItem = memo(({ transaction }: AccountTransactionList
                     <Text>{getTransactionTimestamp()?.toLocaleTimeString()}</Text>
                 </Box>
             </Box>
-            <Text>{transactionAmount}</Text>
+            <Box>
+                <Text>{FiatAmountFormatter.format(fiatAmount ?? 0)}</Text>
+                <Text>{transactionAmount}</Text>
+            </Box>
         </TouchableOpacity>
     );
 });

--- a/suite-native/transactions/src/screens/TransactionDetailScreen.tsx
+++ b/suite-native/transactions/src/screens/TransactionDetailScreen.tsx
@@ -26,7 +26,7 @@ export const TransactionDetailScreen = ({
     const transaction = useSelector(selectTransactionByTxid(txid));
     const blockchain = useSelector(selectBlockchainState);
     const fiatCurrency = useSelector(selectFiatCurrency);
-    const { FiatAmountFormatter, CryptoAmountFormatter, CurrencySymbolFormatter } = useFormatters();
+    const { CryptoAmountFormatter, CurrencySymbolFormatter } = useFormatters();
 
     // TODO please add empty state when design is ready
     if (!transaction) return null;
@@ -44,7 +44,7 @@ export const TransactionDetailScreen = ({
             <TransactionDetailHeader
                 type={transaction.type}
                 amount={cryptoAmountFormatted}
-                fiatAmount={FiatAmountFormatter.format(fiatAmount ?? 0)}
+                fiatAmount={fiatAmount}
             />
             <Box marginVertical="large">
                 <Divider />

--- a/suite-native/transactions/src/screens/TransactionDetailScreen.tsx
+++ b/suite-native/transactions/src/screens/TransactionDetailScreen.tsx
@@ -11,13 +11,13 @@ import {
 } from '@suite-native/navigation';
 import { selectBlockchainState, selectTransactionByTxid } from '@suite-common/wallet-core';
 import { formatNetworkAmount, getConfirmations, toFiatCurrency } from '@suite-common/wallet-utils';
+import { selectFiatCurrency } from '@suite-native/module-settings';
+import { useFormatters } from '@suite-common/formatters';
 
 import { TransactionDetailHeader } from '../components/TransactionDetail/TransactionDetailHeader';
 import { TransactionDetailData } from '../components/TransactionDetail/TransactionDetailData';
 import { TransactionDetailConfirmations } from '../components/TransactionDetail/TransactionDetailConfirmations';
 import { TransactionDetailAmount } from '../components/TransactionDetail/TransactionDetailAmount';
-import { selectFiatCurrency } from '@suite-native/module-settings';
-import { useFormatters } from '@suite-common/formatters';
 
 export const TransactionDetailScreen = ({
     route,

--- a/suite-native/transactions/tsconfig.json
+++ b/suite-native/transactions/tsconfig.json
@@ -3,6 +3,9 @@
     "compilerOptions": { "outDir": "libDev" },
     "references": [
         {
+            "path": "../../suite-common/formatters"
+        },
+        {
             "path": "../../suite-common/wallet-config"
         },
         {
@@ -15,6 +18,7 @@
             "path": "../../suite-common/wallet-utils"
         },
         { "path": "../atoms" },
+        { "path": "../module-settings" },
         { "path": "../navigation" },
         { "path": "../../packages/icons" },
         { "path": "../../packages/styles" }

--- a/yarn.lock
+++ b/yarn.lock
@@ -6832,11 +6832,13 @@ __metadata:
   dependencies:
     "@mobily/ts-belt": ^3.11.0
     "@react-navigation/native": ^6.0.11
+    "@suite-common/formatters": "*"
     "@suite-common/wallet-config": "*"
     "@suite-common/wallet-core": "*"
     "@suite-common/wallet-types": "*"
     "@suite-common/wallet-utils": "*"
     "@suite-native/atoms": "*"
+    "@suite-native/module-settings": "*"
     "@suite-native/navigation": "*"
     "@trezor/icons": "*"
     "@trezor/styles": "*"


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Adding formatted fiat currency to give users idea of what the crypto was worth in time of the transaction. 

It's converted to currency from settings localisation.

Additional styles applied to make it look pretty.

## Related Issue

Resolve #6238 

## Screenshots (if appropriate):

<img width="432" alt="image" src="https://user-images.githubusercontent.com/36101761/196091836-1a16bef2-1616-4343-becf-9b56e937c820.png">

<img width="434" alt="image" src="https://user-images.githubusercontent.com/36101761/196091877-d97d81e3-dfc9-4753-992d-7804c1ac3f43.png">


