### PR TITLE
Feat/6116 anonymity level control

### DIFF
--- a/packages/components/src/components/form/Range/Range.tsx
+++ b/packages/components/src/components/form/Range/Range.tsx
@@ -27,6 +27,7 @@ type RangeProps = {
     className?: string;
     max?: number;
     min?: number;
+    step?: number;
     onChange: React.ChangeEventHandler<HTMLInputElement>;
     thumbStyle?: CSSObject;
     trackStyle?: CSSObject;

--- a/packages/components/src/config/colors.ts
+++ b/packages/components/src/config/colors.ts
@@ -50,6 +50,12 @@ export const THEME = {
         GRADIENT_RED_START: '#d15b5b',
         GRADIENT_RED_END: '#e75f5f',
 
+        GRADIENT_SLIDER_GREEN_START: '#2A9649',
+        GRADIENT_SLIDER_GREEN_END: '#95CDA5',
+        GRADIENT_SLIDER_YELLOW_START: '#C8B883',
+        GRADIENT_SLIDER_YELLOW_END: '#C8B882',
+        GRADIENT_SLIDER_RED_END: '#BF6767',
+
         BOX_SHADOW_BLACK_5: 'rgba(0, 0, 0, 0.05)',
         BOX_SHADOW_BLACK_15: 'rgba(0, 0, 0, 0.15)',
         BOX_SHADOW_BLACK_20: 'rgba(0, 0, 0, 0.2)',
@@ -108,6 +114,12 @@ export const THEME = {
         GRADIENT_GREEN_END: '#5fa548',
         GRADIENT_RED_START: '#d15b5b', // same as in light theme
         GRADIENT_RED_END: '#e75f5f', // same as in light theme
+
+        GRADIENT_SLIDER_GREEN_START: '#2A9649',
+        GRADIENT_SLIDER_GREEN_END: '#95CDA5',
+        GRADIENT_SLIDER_YELLOW_START: '#C8B883',
+        GRADIENT_SLIDER_YELLOW_END: '#C8B882',
+        GRADIENT_SLIDER_RED_END: '#BF6767',
 
         BOX_SHADOW_BLACK_5: 'rgba(255, 255, 255, 0.05)',
         BOX_SHADOW_BLACK_15: 'rgba(0, 0, 0, 0.2)',
@@ -168,6 +180,12 @@ export const THEME = {
         GRADIENT_GREEN_END: '#5fa548',
         GRADIENT_RED_START: '#d15b5b', // same as in light theme
         GRADIENT_RED_END: '#e75f5f', // same as in light theme
+
+        GRADIENT_SLIDER_GREEN_START: '#2A9649',
+        GRADIENT_SLIDER_GREEN_END: '#95CDA5',
+        GRADIENT_SLIDER_YELLOW_START: '#C8B883',
+        GRADIENT_SLIDER_YELLOW_END: '#C8B882',
+        GRADIENT_SLIDER_RED_END: '#BF6767',
 
         BOX_SHADOW_BLACK_5: 'rgba(255, 255, 255, 0.05)',
         BOX_SHADOW_BLACK_15: 'rgba(0, 0, 0, 0.2)',

--- a/packages/suite/src/actions/wallet/coinjoinAccountActions.ts
+++ b/packages/suite/src/actions/wallet/coinjoinAccountActions.ts
@@ -35,7 +35,7 @@ const coinjoinAccountRemove = (accountKey: string) =>
         },
     } as const);
 
-const coinjoinAccountUpdateAnonymity = (accountKey: string, targetAnonymity: number) =>
+export const coinjoinAccountUpdateAnonymity = (accountKey: string, targetAnonymity: number) =>
     ({
         type: COINJOIN.ACCOUNT_UPDATE_TARGET_ANONYMITY,
         payload: {

--- a/packages/suite/src/components/wallet/CoinjoinSummary/index.tsx
+++ b/packages/suite/src/components/wallet/CoinjoinSummary/index.tsx
@@ -4,7 +4,7 @@ import styled from 'styled-components';
 import { H3 } from '@trezor/components';
 import { Account } from '@suite-common/wallet-types';
 import { Translation } from '@suite-components/Translation';
-import { AnonymityLevelIndicator } from '@wallet-components/PrivacyAccount/AnonymityLevelIndicator';
+import { AnonymityLevelSetup } from '@wallet-components/PrivacyAccount/AnonymityLevelSetup';
 import { AnonymityChart } from './AnonymityChart';
 import { BalanceSection } from './BalanceSection';
 
@@ -29,7 +29,7 @@ export const CoinjoinSummary = ({ account }: CoinjoinSummaryProps) => (
             <H3>
                 <Translation id="TR_MY_COINS" />
             </H3>
-            <AnonymityLevelIndicator />
+            <AnonymityLevelSetup />
         </Row>
 
         <BalanceSection account={account} />

--- a/packages/suite/src/components/wallet/CoinjoinSummary/index.tsx
+++ b/packages/suite/src/components/wallet/CoinjoinSummary/index.tsx
@@ -4,7 +4,7 @@ import styled from 'styled-components';
 import { H3 } from '@trezor/components';
 import { Account } from '@suite-common/wallet-types';
 import { Translation } from '@suite-components/Translation';
-import { AnonymityIndicator } from '@wallet-components/PrivacyAccount/AnonymityIndicator';
+import { AnonymityLevelIndicator } from '@wallet-components/PrivacyAccount/AnonymityLevelIndicator';
 import { AnonymityChart } from './AnonymityChart';
 import { BalanceSection } from './BalanceSection';
 
@@ -19,10 +19,6 @@ const Row = styled.div`
     margin-bottom: 28px;
 `;
 
-const StyledAnonymityIndicator = styled(AnonymityIndicator)`
-    margin-left: auto;
-`;
-
 interface CoinjoinSummaryProps {
     account: Account;
 }
@@ -33,7 +29,7 @@ export const CoinjoinSummary = ({ account }: CoinjoinSummaryProps) => (
             <H3>
                 <Translation id="TR_MY_COINS" />
             </H3>
-            <StyledAnonymityIndicator />
+            <AnonymityLevelIndicator />
         </Row>
 
         <BalanceSection account={account} />

--- a/packages/suite/src/components/wallet/PrivacyAccount/AnonymityLevelIndicator.tsx
+++ b/packages/suite/src/components/wallet/PrivacyAccount/AnonymityLevelIndicator.tsx
@@ -3,19 +3,36 @@ import styled from 'styled-components';
 import { Icon, variables } from '@trezor/components';
 import { useSelector } from '@suite-hooks/useSelector';
 import { selectCurrentTargetAnonymity } from '@wallet-reducers/coinjoinReducer';
+import { darken } from 'polished';
 
 const Container = styled.div`
     display: flex;
     align-items: center;
     justify-content: space-between;
-    width: 104px;
-    height: 44px;
     padding: 6px 10px;
     border-radius: 8px;
-    background: ${({ theme }) => theme.STROKE_GREY};
+
     font-weight: ${variables.FONT_WEIGHT.MEDIUM};
     font-size: ${variables.FONT_SIZE.SMALL};
     text-align: right;
+
+    background: ${({ theme }) => theme.STROKE_GREY};
+
+    &:hover,
+    &:focus,
+    &:active {
+        background: ${({ theme }) => darken(theme.HOVER_DARKEN_FILTER, theme.STROKE_GREY)};
+    }
+
+    cursor: ${({ onClick }) => (onClick ? 'pointer' : 'default')};
+`;
+
+const Values = styled.div`
+    min-width: 64px;
+`;
+
+const AnonymityLevel = styled.p`
+    font-variant-numeric: tabular-nums;
 `;
 
 const AnonymityStatus = styled.p`
@@ -28,21 +45,22 @@ enum AnomymityStatus {
     Great = 'GREAT',
 }
 
-interface AnonymityIndicatorProps {
+interface AnonymityLevelIndicatorProps {
     className?: string;
+    onClick?: () => void;
 }
 
-export const AnonymityIndicator = ({ className }: AnonymityIndicatorProps) => {
+export const AnonymityLevelIndicator = ({ className, onClick }: AnonymityLevelIndicatorProps) => {
     const targetAnonymity = useSelector(selectCurrentTargetAnonymity);
 
     return (
-        <Container className={className}>
+        <Container className={className} onClick={onClick}>
             <Icon icon="USERS" />
 
-            <div>
-                <p>{`1 in ${targetAnonymity}`}</p>
+            <Values>
+                <AnonymityLevel>{`1 in ${targetAnonymity}`}</AnonymityLevel>
                 <AnonymityStatus>{AnomymityStatus.Good}</AnonymityStatus>
-            </div>
+            </Values>
         </Container>
     );
 };

--- a/packages/suite/src/components/wallet/PrivacyAccount/AnonymityLevelIndicator.tsx
+++ b/packages/suite/src/components/wallet/PrivacyAccount/AnonymityLevelIndicator.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { forwardRef } from 'react';
 import styled from 'styled-components';
 import { Icon, variables } from '@trezor/components';
 import { useSelector } from '@suite-hooks/useSelector';
@@ -50,17 +50,28 @@ interface AnonymityLevelIndicatorProps {
     onClick?: () => void;
 }
 
-export const AnonymityLevelIndicator = ({ className, onClick }: AnonymityLevelIndicatorProps) => {
-    const targetAnonymity = useSelector(selectCurrentTargetAnonymity);
+export const AnonymityLevelIndicator = forwardRef<HTMLDivElement, AnonymityLevelIndicatorProps>(
+    ({ className, onClick }, ref) => {
+        const targetAnonymity = useSelector(selectCurrentTargetAnonymity) || 1;
 
-    return (
-        <Container className={className} onClick={onClick}>
-            <Icon icon="USERS" />
+        const anonymityStatus = getAnonymityStatus(targetAnonymity);
 
-            <Values>
-                <AnonymityLevel>{`1 in ${targetAnonymity}`}</AnonymityLevel>
-                <AnonymityStatus>{AnomymityStatus.Good}</AnonymityStatus>
-            </Values>
-        </Container>
-    );
-};
+        return (
+            <Container className={className} onClick={onClick} ref={ref}>
+                <Icon icon="USERS" />
+
+                <Values>
+                    <AnonymityLevel>
+                        <Translation
+                            id="TR_COINJOIN_ANONYMITY_LEVEL_INDICATOR"
+                            values={{ targetAnonymity }}
+                        />
+                    </AnonymityLevel>
+                    <AnonymityStatus color={anonymityStatus.color}>
+                        {anonymityStatus.label}
+                    </AnonymityStatus>
+                </Values>
+            </Container>
+        );
+    },
+);

--- a/packages/suite/src/components/wallet/PrivacyAccount/AnonymityLevelIndicator.tsx
+++ b/packages/suite/src/components/wallet/PrivacyAccount/AnonymityLevelIndicator.tsx
@@ -1,9 +1,10 @@
 import React, { forwardRef } from 'react';
-import styled from 'styled-components';
-import { Icon, variables } from '@trezor/components';
-import { useSelector } from '@suite-hooks/useSelector';
-import { selectCurrentTargetAnonymity } from '@wallet-reducers/coinjoinReducer';
+import styled, { DefaultTheme } from 'styled-components';
+import { Icon, variables, useTheme } from '@trezor/components';
+import { Translation } from '@suite-components';
+import { useAnonymityStatus } from '@suite-hooks';
 import { darken } from 'polished';
+import { AnonymityStatus } from '@suite-constants/coinjoin';
 
 const Container = styled.div`
     display: flex;
@@ -35,15 +36,45 @@ const AnonymityLevel = styled.p`
     font-variant-numeric: tabular-nums;
 `;
 
-const AnonymityStatus = styled.p`
-    color: ${({ theme }) => theme.TYPE_GREEN};
+interface GetAnonymityStatusColorProps {
+    theme: DefaultTheme;
+    anonymityStatus: AnonymityStatus;
+}
+
+const getAnonymityStatusColor = ({ theme, anonymityStatus }: GetAnonymityStatusColorProps) => {
+    switch (anonymityStatus) {
+        case AnonymityStatus.Bad:
+            return theme.TYPE_RED;
+        case AnonymityStatus.Medium:
+            return theme.TYPE_DARK_ORANGE;
+        default:
+            return theme.TYPE_GREEN;
+    }
+};
+
+const AnonymityStatusLabel = styled.p<{ color: string }>`
+    color: ${({ color }) => color};
     font-size: ${variables.FONT_SIZE.TINY};
 `;
 
-enum AnomymityStatus {
-    Good = 'GOOD',
-    Great = 'GREAT',
+interface AnonymityStatusLabelValueProps {
+    anonymityStatus: AnonymityStatus;
 }
+
+const AnonymityStatusLabelValue = ({ anonymityStatus }: AnonymityStatusLabelValueProps) => {
+    switch (anonymityStatus) {
+        case AnonymityStatus.Bad:
+            return <Translation id="TR_ANONYMITY_LEVEL_BAD" />;
+        case AnonymityStatus.Medium:
+            return <Translation id="TR_ANONYMITY_LEVEL_MEDIUM" />;
+        case AnonymityStatus.Good:
+            return <Translation id="TR_ANONYMITY_LEVEL_GOOD" />;
+        case AnonymityStatus.Great:
+            return <Translation id="TR_ANONYMITY_LEVEL_GREAT" />;
+        default:
+            return null;
+    }
+};
 
 interface AnonymityLevelIndicatorProps {
     className?: string;
@@ -52,9 +83,8 @@ interface AnonymityLevelIndicatorProps {
 
 export const AnonymityLevelIndicator = forwardRef<HTMLDivElement, AnonymityLevelIndicatorProps>(
     ({ className, onClick }, ref) => {
-        const targetAnonymity = useSelector(selectCurrentTargetAnonymity) || 1;
-
-        const anonymityStatus = getAnonymityStatus(targetAnonymity);
+        const { anonymityStatus, targetAnonymity } = useAnonymityStatus();
+        const theme = useTheme();
 
         return (
             <Container className={className} onClick={onClick} ref={ref}>
@@ -67,9 +97,11 @@ export const AnonymityLevelIndicator = forwardRef<HTMLDivElement, AnonymityLevel
                             values={{ targetAnonymity }}
                         />
                     </AnonymityLevel>
-                    <AnonymityStatus color={anonymityStatus.color}>
-                        {anonymityStatus.label}
-                    </AnonymityStatus>
+                    <AnonymityStatusLabel
+                        color={getAnonymityStatusColor({ theme, anonymityStatus })}
+                    >
+                        <AnonymityStatusLabelValue anonymityStatus={anonymityStatus} />
+                    </AnonymityStatusLabel>
                 </Values>
             </Container>
         );

--- a/packages/suite/src/components/wallet/PrivacyAccount/AnonymityLevelSetup.tsx
+++ b/packages/suite/src/components/wallet/PrivacyAccount/AnonymityLevelSetup.tsx
@@ -1,0 +1,27 @@
+import React, { useRef, useState, useCallback } from 'react';
+import { useOnClickOutside } from '@trezor/react-utils';
+
+import { AnonymityLevelIndicator } from './AnonymityLevelIndicator';
+import { AnonymityLevelSetupCard } from './AnonymityLevelSetupCard';
+
+interface AnonymityLevelSetupProps {
+    className?: string;
+}
+
+export const AnonymityLevelSetup = ({ className }: AnonymityLevelSetupProps) => {
+    const [isOpen, setIsOpen] = useState(false);
+    const indicatorRef = useRef<HTMLDivElement>(null);
+    const setupCardRef = useRef<HTMLDivElement>(null);
+
+    const handleClick = useCallback(() => setIsOpen(prevState => !prevState), []);
+    const handleClickOutside = useCallback(() => setIsOpen(false), []);
+
+    useOnClickOutside([indicatorRef, setupCardRef], handleClickOutside);
+
+    return (
+        <div className={className}>
+            <AnonymityLevelIndicator onClick={handleClick} ref={indicatorRef} />
+            {isOpen && <AnonymityLevelSetupCard ref={setupCardRef} />}
+        </div>
+    );
+};

--- a/packages/suite/src/components/wallet/PrivacyAccount/AnonymityLevelSetupCard.tsx
+++ b/packages/suite/src/components/wallet/PrivacyAccount/AnonymityLevelSetupCard.tsx
@@ -1,0 +1,44 @@
+import React, { forwardRef } from 'react';
+import styled from 'styled-components';
+import { Card, P, variables } from '@trezor/components';
+import { Translation } from '@suite-components';
+
+import { AnonymityLevelSlider } from './AnonymityLevelSlider';
+import { DROPDOWN_MENU } from '@trezor/components/src/config/animations';
+
+const Container = styled.div`
+    position: relative;
+`;
+
+const SetupCard = styled(Card)`
+    position: absolute;
+    top: 12px;
+    right: 0;
+    width: 460px;
+    z-index: ${variables.Z_INDEX.BASE};
+    box-shadow: 0px 4px 4px ${({ theme }) => theme.BOX_SHADOW_BLACK_15};
+    border-radius: 16px;
+    animation: ${DROPDOWN_MENU} 0.15s ease-in-out;
+`;
+
+const SliderWrapper = styled.div`
+    padding-bottom: 10px;
+`;
+
+export const AnonymityLevelSetupCard = forwardRef<HTMLDivElement, Record<string, unknown>>(
+    (_, ref) => (
+        <Container ref={ref}>
+            <SetupCard>
+                <P weight="medium">
+                    <Translation id="TR_COINJOIN_ANONYMITY_LEVEL_SETUP_TITLE" />
+                </P>
+                <P size="tiny" weight="medium">
+                    <Translation id="TR_COINJOIN_ANONYMITY_LEVEL_SETUP_DESCRIPTION" />
+                </P>
+                <SliderWrapper>
+                    <AnonymityLevelSlider />
+                </SliderWrapper>
+            </SetupCard>
+        </Container>
+    ),
+);

--- a/packages/suite/src/components/wallet/PrivacyAccount/AnonymityLevelSlider.tsx
+++ b/packages/suite/src/components/wallet/PrivacyAccount/AnonymityLevelSlider.tsx
@@ -31,7 +31,9 @@ const LabelsWrapper = styled.div`
     margin-left: 10px;
 `;
 
-const Label = styled(P)`
+const Label = styled(P)<{ $offset?: number }>`
+    position: relative;
+    left: ${({ $offset }) => $offset ?? 0}px;
     font-size: ${variables.FONT_SIZE.TINY};
     font-weight: ${variables.FONT_WEIGHT.MEDIUM};
     opacity: 0.5;
@@ -107,7 +109,7 @@ export const AnonymityLevelSlider = ({ className }: AnonymityLevelSliderProps) =
             <LabelsWrapper>
                 <Label>1</Label>
                 <Label>3</Label>
-                <Label>10</Label>
+                <Label $offset={7}>10</Label>
                 <Label>30</Label>
                 <Label>100</Label>
             </LabelsWrapper>

--- a/packages/suite/src/components/wallet/PrivacyAccount/AnonymityLevelSlider.tsx
+++ b/packages/suite/src/components/wallet/PrivacyAccount/AnonymityLevelSlider.tsx
@@ -1,9 +1,10 @@
 import React, { useCallback, useState, ChangeEventHandler } from 'react';
 import styled from 'styled-components';
-import { Range, P, variables, useTheme } from '@trezor/components';
-import { useSelector, useActions } from '@suite-hooks';
+import { Range, P, Warning, variables, useTheme } from '@trezor/components';
+import { Translation } from '@suite-components';
+import { useSelector, useActions, useAnonymityStatus } from '@suite-hooks';
+import { AnonymityStatus } from '@suite-constants/coinjoin';
 import { selectSelectedAccount } from '@wallet-reducers/selectedAccountReducer';
-import { selectCurrentTargetAnonymity } from '@wallet-reducers/coinjoinReducer';
 import * as coinjoinActions from '@wallet-actions/coinjoinAccountActions';
 
 const Container = styled.div`
@@ -36,6 +37,11 @@ const Label = styled(P)`
     opacity: 0.5;
 `;
 
+const WarningWrapper = styled.div`
+    margin-top: 24px;
+    margin-bottom: -14px;
+`;
+
 const minPosition = 0;
 const maxPosition = 100;
 
@@ -54,7 +60,7 @@ interface AnonymityLevelSliderProps {
 
 export const AnonymityLevelSlider = ({ className }: AnonymityLevelSliderProps) => {
     const currentAccount = useSelector(selectSelectedAccount);
-    const targetAnonymity = useSelector(selectCurrentTargetAnonymity);
+    const { anonymityStatus, targetAnonymity } = useAnonymityStatus();
 
     const [sliderPosition, setSliderPosition] = useState(getPosition(targetAnonymity || 1));
 
@@ -105,6 +111,13 @@ export const AnonymityLevelSlider = ({ className }: AnonymityLevelSliderProps) =
                 <Label>30</Label>
                 <Label>100</Label>
             </LabelsWrapper>
+            {anonymityStatus === AnonymityStatus.Bad && (
+                <WarningWrapper>
+                    <Warning critical withIcon>
+                        <Translation id="TR_ANONYMITY_LEVEL_BAD_WARNING" />
+                    </Warning>
+                </WarningWrapper>
+            )}
         </Container>
     );
 };

--- a/packages/suite/src/components/wallet/PrivacyAccount/AnonymityLevelSlider.tsx
+++ b/packages/suite/src/components/wallet/PrivacyAccount/AnonymityLevelSlider.tsx
@@ -1,0 +1,110 @@
+import React, { useCallback, useState, ChangeEventHandler } from 'react';
+import styled from 'styled-components';
+import { Range, P, variables, useTheme } from '@trezor/components';
+import { useSelector, useActions } from '@suite-hooks';
+import { selectSelectedAccount } from '@wallet-reducers/selectedAccountReducer';
+import { selectCurrentTargetAnonymity } from '@wallet-reducers/coinjoinReducer';
+import * as coinjoinActions from '@wallet-actions/coinjoinAccountActions';
+
+const Container = styled.div`
+    display: flex;
+    flex-direction: column;
+`;
+
+const Slider = styled(Range)`
+    padding-bottom: 50px;
+    padding-top: 60px;
+    margin-top: 0;
+
+    cursor: pointer;
+    background: none;
+`;
+
+const LabelsWrapper = styled.div`
+    display: flex;
+    justify-content: space-between;
+    pointer-events: none;
+
+    margin-top: -46px;
+    margin-bottom: -16px;
+    margin-left: 10px;
+`;
+
+const Label = styled(P)`
+    font-size: ${variables.FONT_SIZE.TINY};
+    font-weight: ${variables.FONT_WEIGHT.MEDIUM};
+    opacity: 0.5;
+`;
+
+const minPosition = 0;
+const maxPosition = 100;
+
+const minValue = Math.log(1);
+const maxValue = Math.log(100);
+
+const scale = (maxValue - minValue) / (maxPosition - minPosition);
+
+const getValue = (position: number) =>
+    Math.round(Math.exp((position - minPosition) * scale + minValue));
+const getPosition = (value: number) => minPosition + (Math.log(value) - minValue) / scale;
+
+interface AnonymityLevelSliderProps {
+    className?: string;
+}
+
+export const AnonymityLevelSlider = ({ className }: AnonymityLevelSliderProps) => {
+    const currentAccount = useSelector(selectSelectedAccount);
+    const targetAnonymity = useSelector(selectCurrentTargetAnonymity);
+
+    const [sliderPosition, setSliderPosition] = useState(getPosition(targetAnonymity || 1));
+
+    const { coinjoinAccountUpdateAnonymity } = useActions({
+        coinjoinAccountUpdateAnonymity: coinjoinActions.coinjoinAccountUpdateAnonymity,
+    });
+
+    const theme = useTheme();
+
+    const handleSliderChange: ChangeEventHandler<HTMLInputElement> = useCallback(
+        event => {
+            const position = Number(event?.target?.value);
+            if (!Number.isNaN(position)) {
+                coinjoinAccountUpdateAnonymity(currentAccount?.key ?? '', getValue(position));
+                setSliderPosition(position);
+            }
+        },
+        [coinjoinAccountUpdateAnonymity, currentAccount?.key],
+    );
+
+    if (!currentAccount) {
+        return null;
+    }
+
+    const trackStyle = {
+        background: `\
+            linear-gradient(270deg,\
+                ${theme.GRADIENT_SLIDER_GREEN_START} 0%,\
+                ${theme.GRADIENT_SLIDER_GREEN_END} 45%,\
+                ${theme.GRADIENT_SLIDER_YELLOW_START} 55%,\
+                ${theme.GRADIENT_SLIDER_YELLOW_END} 60%,\
+                ${theme.GRADIENT_SLIDER_RED_END} 100%\
+            );`,
+    };
+
+    return (
+        <Container className={className}>
+            <Slider
+                value={sliderPosition}
+                onChange={handleSliderChange}
+                trackStyle={trackStyle}
+                step={0.1}
+            />
+            <LabelsWrapper>
+                <Label>1</Label>
+                <Label>3</Label>
+                <Label>10</Label>
+                <Label>30</Label>
+                <Label>100</Label>
+            </LabelsWrapper>
+        </Container>
+    );
+};

--- a/packages/suite/src/constants/suite/coinjoin.ts
+++ b/packages/suite/src/constants/suite/coinjoin.ts
@@ -8,3 +8,13 @@ export const COINJOIN_PHASE_MESSAGES: Record<RoundPhase, TranslationKey> = {
     [RoundPhase.TransactionSigning]: 'TR_COINJOIN_PHASE_3_MESSAGE',
     [RoundPhase.Ended]: 'TR_COINJOIN_PHASE_4_MESSAGE',
 };
+
+/**
+ * Values are upper limits of anonymity level for each status.
+ */
+export enum AnonymityStatus {
+    Bad = 5,
+    Medium = 10,
+    Good = 20,
+    Great = 100,
+}

--- a/packages/suite/src/hooks/suite/index.ts
+++ b/packages/suite/src/hooks/suite/index.ts
@@ -15,6 +15,7 @@ export { useExternalLink } from './useExternalLink';
 export { useFilteredModal } from './useFilteredModal';
 export { usePreferredModal } from './usePreferredModal';
 export { useFormattersConfig } from './useFormattersConfig';
+export { useAnonymityStatus } from './useAnonymityStatus';
 
 // replaced in suite-native
 export { useLocales } from '@suite-hooks/useLocales';

--- a/packages/suite/src/hooks/suite/useAnonymityStatus.ts
+++ b/packages/suite/src/hooks/suite/useAnonymityStatus.ts
@@ -1,0 +1,27 @@
+import { useSelector } from './useSelector';
+import { AnonymityStatus } from '@suite-constants/coinjoin';
+import { selectCurrentTargetAnonymity } from '@wallet-reducers/coinjoinReducer';
+
+const getAnonymityStatus = (targetAnonymity: number) => {
+    if (targetAnonymity < AnonymityStatus.Bad) {
+        return AnonymityStatus.Bad;
+    }
+    if (targetAnonymity < AnonymityStatus.Medium) {
+        return AnonymityStatus.Medium;
+    }
+    if (targetAnonymity < AnonymityStatus.Good) {
+        return AnonymityStatus.Good;
+    }
+    return AnonymityStatus.Great;
+};
+
+export const useAnonymityStatus = () => {
+    const targetAnonymity = useSelector(selectCurrentTargetAnonymity) || 1;
+
+    const anonymityStatus = getAnonymityStatus(targetAnonymity);
+
+    return {
+        anonymityStatus,
+        targetAnonymity,
+    };
+};

--- a/packages/suite/src/support/messages.ts
+++ b/packages/suite/src/support/messages.ts
@@ -7488,6 +7488,7 @@ export default defineMessages({
     TR_COINJOIN_COMPLETED: {
         id: 'TR_COINJOIN_COMPLETED',
         defaultMessage: 'Coinjoin successfully completed!',
+    },
     TR_COINJOIN_ANONYMITY_LEVEL_SETUP_TITLE: {
         id: 'TR_COINJOIN_ANONYMITY_LEVEL_SETUP_TITLE',
         defaultMessage: 'Desired anonymity level',

--- a/packages/suite/src/support/messages.ts
+++ b/packages/suite/src/support/messages.ts
@@ -7496,4 +7496,28 @@ export default defineMessages({
         id: 'TR_COINJOIN_ANONYMITY_LEVEL_SETUP_DESCRIPTION',
         defaultMessage: 'Shows the number of people with whom your resources are indistinguishable',
     },
+    TR_COINJOIN_ANONYMITY_LEVEL_INDICATOR: {
+        id: 'TR_COINJOIN_ANONYMITY_LEVEL_INDICATOR',
+        defaultMessage: '1 in {targetAnonymity}',
+    },
+    TR_ANONYMITY_LEVEL_BAD: {
+        id: 'TR_ANONYMITY_LEVEL_BAD',
+        defaultMessage: 'BAD',
+    },
+    TR_ANONYMITY_LEVEL_MEDIUM: {
+        id: 'TR_ANONYMITY_LEVEL_MEDIUM',
+        defaultMessage: 'MEDIUM',
+    },
+    TR_ANONYMITY_LEVEL_GOOD: {
+        id: 'TR_ANONYMITY_LEVEL_GOOD',
+        defaultMessage: 'GOOD',
+    },
+    TR_ANONYMITY_LEVEL_GREAT: {
+        id: 'TR_ANONYMITY_LEVEL_GREAT',
+        defaultMessage: 'GREAT',
+    },
+    TR_ANONYMITY_LEVEL_BAD_WARNING: {
+        id: 'TR_ANONYMITY_LEVEL_BAD_WARNING',
+        defaultMessage: 'We recommend a minimum "1 in 5" anonymity level',
+    },
 });

--- a/packages/suite/src/support/messages.ts
+++ b/packages/suite/src/support/messages.ts
@@ -7488,5 +7488,12 @@ export default defineMessages({
     TR_COINJOIN_COMPLETED: {
         id: 'TR_COINJOIN_COMPLETED',
         defaultMessage: 'Coinjoin successfully completed!',
+    TR_COINJOIN_ANONYMITY_LEVEL_SETUP_TITLE: {
+        id: 'TR_COINJOIN_ANONYMITY_LEVEL_SETUP_TITLE',
+        defaultMessage: 'Desired anonymity level',
+    },
+    TR_COINJOIN_ANONYMITY_LEVEL_SETUP_DESCRIPTION: {
+        id: 'TR_COINJOIN_ANONYMITY_LEVEL_SETUP_DESCRIPTION',
+        defaultMessage: 'Shows the number of people with whom your resources are indistinguishable',
     },
 });

--- a/packages/suite/src/views/wallet/anonymize/index.tsx
+++ b/packages/suite/src/views/wallet/anonymize/index.tsx
@@ -3,11 +3,11 @@ import styled from 'styled-components';
 
 import { useSelector } from '@suite-hooks';
 import { WalletLayoutHeader } from '@wallet-components';
-import { AnonymityLevelIndicator } from '@wallet-components/PrivacyAccount/AnonymityLevelIndicator';
+import { AnonymityLevelSetup } from '@wallet-components/PrivacyAccount/AnonymityLevelSetup';
 import { CoinjoinSetupStrategies } from '@wallet-views/anonymize/components/CoinjoinSetupStrategies';
 import { WalletLayout } from '@wallet-components/WalletLayout';
 
-const StyledAnonymityLevelSetup = styled(AnonymityLevelIndicator)`
+const StyledAnonymityLevelSetup = styled(AnonymityLevelSetup)`
     margin-right: 12px;
 `;
 

--- a/packages/suite/src/views/wallet/anonymize/index.tsx
+++ b/packages/suite/src/views/wallet/anonymize/index.tsx
@@ -3,11 +3,11 @@ import styled from 'styled-components';
 
 import { useSelector } from '@suite-hooks';
 import { WalletLayoutHeader } from '@wallet-components';
-import { AnonymityIndicator } from '@wallet-components/PrivacyAccount/AnonymityIndicator';
+import { AnonymityLevelIndicator } from '@wallet-components/PrivacyAccount/AnonymityLevelIndicator';
 import { CoinjoinSetupStrategies } from '@wallet-views/anonymize/components/CoinjoinSetupStrategies';
 import { WalletLayout } from '@wallet-components/WalletLayout';
 
-const StyledAnonymityIndicator = styled(AnonymityIndicator)`
+const StyledAnonymityLevelSetup = styled(AnonymityLevelIndicator)`
     margin-right: 12px;
 `;
 
@@ -17,7 +17,7 @@ const Anonymize = () => {
     return (
         <WalletLayout title="TR_NAV_ANONYMIZE" account={selectedAccount}>
             <WalletLayoutHeader title="TR_NAV_ANONYMIZE">
-                <StyledAnonymityIndicator />
+                <StyledAnonymityLevelSetup />
             </WalletLayoutHeader>
             {selectedAccount.account && (
                 <CoinjoinSetupStrategies account={selectedAccount.account} />


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Add possibility to change target account anonymity level by slider with logarithmic scale. 

Adding this slider directly to CoinJoin onboarding modals will be following PR.

commits
- [feat(coinjoin): prepare anonymity level indicator to be clickable](https://github.com/trezor/trezor-suite/pull/6569/commits/8f3bd9150e5e1c417b5cac96e142662cb25eb34e)
refactoring, preparation
- [feat(coinjoin): add possibility to setup target anonymity level by logarithmic slider](https://github.com/trezor/trezor-suite/pull/6569/commits/690cff9eed436986fa9b319524d56698a9fa22f3)
adding slider to enable setting target anonymity 
- [feat(coinjoin): dynamic values in target anonymity level indicator](https://github.com/trezor/trezor-suite/pull/6569/commits/147a3c0c4a4d6a2308158ce7d6d98b5a87fac058)
making anonymity level indicator (the badge with 1 in X value and GOOD/BAD status) dynamic 
- [feat(coinjoin): more precise position for labels below slider](https://github.com/trezor/trezor-suite/pull/6569/commits/91b3710cebea0c60304a0f408c8c738ddb7198cf) 
small enhancment of positions for the slider labels so slider thumb appears above them
- [feat(coinjoin): optimize handling slider change by putting lower priority on the state change](https://github.com/trezor/trezor-suite/pull/6569/commits/59e2b7125a9d7d23df80dc467602d0d65eef2c78)
use new React 18 feature useTransition to optimize performance of slider for slower computers and handle invalid values better


## Related Issue

Resolve  https://github.com/trezor/trezor-suite/issues/6116

## Screenshots (if appropriate):
<img width="471" alt="image" src="https://user-images.githubusercontent.com/3729633/196946795-3f21547f-149b-4f89-9433-abe5d788c717.png">
<img width="528" alt="image" src="https://user-images.githubusercontent.com/3729633/196946864-f41e48a6-e9a5-433e-9887-42b73e20ec42.png">
<img width="475" alt="image" src="https://user-images.githubusercontent.com/3729633/196946971-9ef6dd80-dea6-4baf-9cf8-06a886429bc5.png">

<img width="454" alt="image" src="https://user-images.githubusercontent.com/3729633/196946687-15dbeaa2-b749-41bd-a688-cf64fe76a09c.png">

