### PR TITLE
Fix `Cannot read properties of undefined (reading 'blockHeight')` in tx pagination

### DIFF
--- a/suite-common/wallet-utils/src/transactionUtils.ts
+++ b/suite-common/wallet-utils/src/transactionUtils.ts
@@ -1,6 +1,5 @@
 import BigNumber from 'bignumber.js';
 import { fromWei } from 'web3-utils';
-import { A } from '@mobily/ts-belt';
 
 import {
     Account,
@@ -47,8 +46,7 @@ export const groupTransactionsByDate = (
     transactions: WalletAccountTransaction[],
 ): { [key: string]: WalletAccountTransaction[] } => {
     const r: { [key: string]: WalletAccountTransaction[] } = {};
-    const sortedTxs = A.sort(transactions, (a, b) => sortByBlockHeight(a, b));
-    A.sort(sortedTxs, sortByBlockHeight).forEach(item => {
+    transactions.sort(sortByBlockHeight).forEach(item => {
         let key = 'pending';
         if (item.blockHeight && item.blockHeight > 0 && item.blockTime && item.blockTime > 0) {
             const t = item.blockTime * 1000;


### PR DESCRIPTION
## Description

From https://github.com/trezor/trezor-suite/commit/f475369a9c4b93254229980bf20e38bf8322ad28, there was an error when trying to paginate in transaction list (example: all seed, first BTC legacy account, go to page 5 and then to page 3). This is kind of rollback of relevant code in said commit which should fix it.

## Explanation
It seems that `A.sort` from `@mobily/ts-belt` calls the comparison function even on `undefined` items (which I would expect), but the built-in `sort` function doesn't and therefore doesn't throw in this case. It should be ofc fixed by improving the comparison function, but this is imho the safest way which could be merged immediately.

## Screenshots
![image](https://user-images.githubusercontent.com/26326960/196148042-a56737bb-4017-4f7f-aa41-c7e62efa6b5e.png)

