### PR TITLE
Improve labeling debugability [do not merge]

### DIFF
--- a/packages/suite-analytics/src/types/events.ts
+++ b/packages/suite-analytics/src/types/events.ts
@@ -321,7 +321,14 @@ export type SuiteAnalyticsEvent =
     | {
           type: EventType.SettingsGeneralLabelingProvider;
           payload: {
-              provider: 'dropbox' | 'google' | 'fileSystem' | 'sdCard' | 'missing-provider' | '';
+              provider:
+                  | 'dropbox'
+                  | 'dropbox-passwords'
+                  | 'google'
+                  | 'fileSystem'
+                  | 'sdCard'
+                  | 'missing-provider'
+                  | '';
           };
       }
     | {

--- a/packages/suite/src/actions/suite/__tests__/metadataActions.test.ts
+++ b/packages/suite/src/actions/suite/__tests__/metadataActions.test.ts
@@ -101,7 +101,7 @@ const initStore = (state: State) => {
             // automatically resolve modal decision
             switch (action.payload.type) {
                 case 'metadata-provider':
-                    await store.dispatch(metadataActions.connectProvider('dropbox'));
+                    await store.dispatch(metadataActions.connectProvider({ type: 'dropbox' }));
                     action.payload.decision.resolve(true);
                     break;
                 default:
@@ -203,6 +203,7 @@ describe('Metadata Actions', () => {
                             refreshToken: 'token',
                         },
                         user: 'power-user',
+                        clientId: 'meow',
                     },
                 });
 

--- a/packages/suite/src/actions/suite/constants/metadataConstants.ts
+++ b/packages/suite/src/actions/suite/constants/metadataConstants.ts
@@ -4,12 +4,15 @@ export const SET_READY = '@metadata/set-ready';
 export const CANCELLED = '@metadata/cancelled';
 export const SET_DEVICE_METADATA = '@metadata/set-device-metadata';
 export const SET_PROVIDER = '@metadata/set-provider';
+export const ADD_PROVIDER = '@metadata/add-provider';
 export const WALLET_LOADED = '@metadata/wallet-loaded';
 export const WALLET_ADD = '@metadata/wallet-loaded';
 export const ACCOUNT_LOADED = '@metadata/account-loaded';
 export const ACCOUNT_ADD = '@metadata/account-add';
 export const SET_EDITING = '@metadata/set-editing';
 export const SET_INITIATING = '@metadata/set-initiating';
+export const SET_DATA = '@metadata/set-data';
+export const SET_SELECTED_PROVIDER = '@metadata/set-selected-provider';
 
 // todo: use in metadataActions, currently migration is not implemented yet
 export const METADATA_VERSION = '2.0.0';

--- a/packages/suite/src/actions/suite/constants/metadataConstants.ts
+++ b/packages/suite/src/actions/suite/constants/metadataConstants.ts
@@ -39,3 +39,5 @@ export const GOOGLE_IMPLICIT_FLOW_CLIENT_ID =
 
 // dropbox allows authorization code flow for both web and desktop without client secret
 export const DROPBOX_CLIENT_ID = 'wg0yz2pbgjyhoda';
+
+export const DROPBOX_PASSWODS_CLIENT_ID = 's340kh3l0vla1nv';

--- a/packages/suite/src/actions/suite/storageActions.ts
+++ b/packages/suite/src/actions/suite/storageActions.ts
@@ -323,16 +323,16 @@ export const saveAnalytics = () => async (_dispatch: Dispatch, getState: GetStat
 /**
  * save general metadata settings
  */
-export const saveMetadata = () => async (_dispatch: Dispatch, getState: GetState) => {
+export const saveMetadata = () => async (_dispatch: Dispatch, _getState: GetState) => {
     if (!(await db.isAccessible())) return;
 
-    const { metadata } = getState();
-    db.addItem(
-        'metadata',
-        { provider: metadata.provider, enabled: metadata.enabled },
-        'state',
-        true,
-    );
+    // const { metadata } = getState();
+    // db.addItem(
+    //     'metadata',
+    //     { provider: metadata.provider, enabled: metadata.enabled, data: {} },
+    //     'state',
+    //     true,
+    // );
 };
 
 export const saveMessageSystem = () => async (_dispatch: Dispatch, getState: GetState) => {

--- a/packages/suite/src/components/suite/DropZone.tsx
+++ b/packages/suite/src/components/suite/DropZone.tsx
@@ -13,6 +13,7 @@ interface Props {
     // function which is called after the file is selected
     onSelect: (data: File, setError: (msg: ExtendedMessageDescriptor) => void) => void;
     className?: string;
+    placeholder?: string;
 }
 
 export const useDropZone = ({ accept, onSelect, className }: Props) => {
@@ -179,7 +180,7 @@ export const DropZone = (props: Props) => {
             <StyledInput {...getInputProps()} />
             <Label>
                 <StyledIcon icon={props.icon || 'BINARY'} />
-                {filename || <Translation id="TR_DROPZONE" />}
+                {filename || props.placeholder || <Translation id="TR_DROPZONE" />}
             </Label>
             {error && (
                 <P>

--- a/packages/suite/src/components/suite/modals/metadata/MetadataProvider/index.tsx
+++ b/packages/suite/src/components/suite/modals/metadata/MetadataProvider/index.tsx
@@ -62,7 +62,7 @@ export const MetadataProvider = ({ onCancel, decision }: MetadataProviderProps) 
 
     const connect = async (type: MetadataProviderType) => {
         setIsLoading(type);
-        const result = await connectProvider(type);
+        const result = await connectProvider({ type });
         // window close indicates user action, user knows what happened, no need to show an error message
         if (result === 'window closed') {
             setIsLoading('');

--- a/packages/suite/src/components/wallet/AccountTopPanel/index.tsx
+++ b/packages/suite/src/components/wallet/AccountTopPanel/index.tsx
@@ -16,6 +16,7 @@ import { Stack, SkeletonCircle, SkeletonRectangle } from '@suite-components/Skel
 import { useSelector } from '@suite-hooks';
 import { isTestnet } from '@suite-common/wallet-utils';
 import { AccountNavigation } from './AccountNavigation';
+import { selectLabelingDataForSelectedAccount } from '@suite-reducers/metadataReducer';
 
 const Balance = styled(H1)`
     height: 32px;
@@ -59,7 +60,8 @@ const AccountTopPanelSkeleton = ({ animate, account, symbol }: AccountTopPanelSk
 
 export const AccountTopPanel = () => {
     const { account, loader, status } = useSelector(state => state.wallet.selectedAccount);
-
+    const selectedAccountLabels = useSelector(selectLabelingDataForSelectedAccount);
+    console.log('account top panel selectedAccountLabels', selectedAccountLabels);
     if (status !== 'loaded' || !account) {
         return (
             <AccountTopPanelSkeleton
@@ -82,7 +84,7 @@ export const AccountTopPanel = () => {
                         type: 'accountLabel',
                         accountKey: account.key,
                         defaultValue: account.path,
-                        value: account?.metadata.accountLabel,
+                        value: selectedAccountLabels.accountLabel,
                     }}
                 />
             }

--- a/packages/suite/src/components/wallet/CoinControl/UtxoSelection.tsx
+++ b/packages/suite/src/components/wallet/CoinControl/UtxoSelection.tsx
@@ -13,6 +13,7 @@ import { TransactionTimestamp, UtxoAnonymity } from '@wallet-components';
 import { UtxoTag } from '@wallet-components/CoinControl/UtxoTag';
 import { useSendFormContext } from '@wallet-hooks';
 import { WalletAccountTransaction } from '@wallet-types';
+import { selectLabelingDataForSelectedAccount } from '@suite-reducers/metadataReducer';
 
 const VisibleOnHover = styled.div<{ alwaysVisible?: boolean }>`
     display: ${({ alwaysVisible }) => (alwaysVisible ? 'contents' : 'none')};
@@ -134,9 +135,8 @@ export const UtxoSelection = ({ isChecked, transaction, utxo }: UtxoSelectionPro
     const coordinatorData = useSelector(state => state.wallet.coinjoin.clients[account.symbol]);
     const device = useSelector(state => state.suite.device);
     // selecting metadata from store rather than send form context which does not update on metadata change
-    const outputLabels = useSelector(
-        state => state.wallet.selectedAccount.account?.metadata.outputLabels,
-    );
+    const { outputLabels } = useSelector(selectLabelingDataForSelectedAccount);
+
     const { openModal } = useActions({
         openModal: modalActions.openModal,
     });

--- a/packages/suite/src/components/wallet/TransactionItem/components/Target.tsx
+++ b/packages/suite/src/components/wallet/TransactionItem/components/Target.tsx
@@ -12,13 +12,14 @@ import {
 } from '@suite-common/wallet-utils';
 import { WalletAccountTransaction } from '@wallet-types';
 import { notificationsActions } from '@suite-common/toast-notifications';
-import { useActions } from '@suite-hooks';
+import { useActions, useSelector } from '@suite-hooks';
 import { TokenTransferAddressLabel } from './TokenTransferAddressLabel';
 import { TargetAddressLabel } from './TargetAddressLabel';
 import { BaseTargetLayout } from './BaseTargetLayout';
 import { copyToClipboard } from '@trezor/dom-utils';
 import { AccountMetadata } from '@suite-types/metadata';
 import { StyledFormattedCryptoAmount, StyledFormattedNftAmount } from './CommonComponents';
+import { selectLabelingDataForSelectedAccount } from '@suite-reducers/metadataReducer';
 
 interface BaseTransfer {
     singleRowLayout?: boolean;
@@ -125,7 +126,8 @@ export const Target = ({
     const targetAmount = getTargetAmount(target, transaction);
     const operation = getTxOperation(transaction.type);
     const { addNotification } = useActions({ addNotification: notificationsActions.addToast });
-    const targetMetadata = accountMetadata?.outputLabels?.[transaction.txid]?.[target.n];
+    const { outputLabels } = useSelector(selectLabelingDataForSelectedAccount);
+    const targetMetadata = outputLabels?.[transaction.txid]?.[target.n];
 
     return (
         <BaseTargetLayout

--- a/packages/suite/src/middlewares/suite/logsMiddleware.ts
+++ b/packages/suite/src/middlewares/suite/logsMiddleware.ts
@@ -83,18 +83,18 @@ const log =
                     }),
                 );
                 break;
-            case METADATA.SET_PROVIDER:
-                api.dispatch(
-                    addLog({
-                        type: action.type,
-                        payload: {
-                            ...action.payload,
-                            tokens: undefined,
-                            user: undefined,
-                        },
-                    }),
-                );
-                break;
+            // case METADATA.SET_PROVIDER:
+            //     api.dispatch(
+            //         addLog({
+            //             type: action.type,
+            //             payload: {
+            //                 ...action.payload,
+            //                 tokens: undefined,
+            //                 user: undefined,
+            //             },
+            //         }),
+            //     );
+            //     break;
             case TRANSPORT.START:
                 api.dispatch(
                     addLog({

--- a/packages/suite/src/reducers/suite/metadataReducer.ts
+++ b/packages/suite/src/reducers/suite/metadataReducer.ts
@@ -5,11 +5,17 @@ import { STORAGE, METADATA } from '@suite-actions/constants';
 import { Action } from '@suite-types';
 import { MetadataState } from '@suite-types/metadata';
 import { selectDevice } from '@suite-reducers/suiteReducer';
+import { selectSelectedAccount } from '@wallet-reducers/selectedAccountReducer';
 
 export const initialState: MetadataState = {
     // is Suite trying to load metadata (get master key -> sync cloud)?
     enabled: false,
     initiating: false,
+    providers: [],
+    selectedProvider: {
+        labels: '',
+        passwords: '',
+    },
 };
 
 const metadataReducer = (state = initialState, action: Action): MetadataState =>
@@ -23,8 +29,11 @@ const metadataReducer = (state = initialState, action: Action): MetadataState =>
             case METADATA.DISABLE:
                 draft.enabled = false;
                 break;
-            case METADATA.SET_PROVIDER:
-                draft.provider = action.payload;
+            case METADATA.ADD_PROVIDER:
+                draft.providers.push(action.payload);
+                break;
+            case METADATA.SET_SELECTED_PROVIDER:
+                draft.selectedProvider[action.payload.dataType] = action.payload.clientId;
                 break;
             case METADATA.SET_EDITING:
                 draft.editing = action.payload;
@@ -32,17 +41,64 @@ const metadataReducer = (state = initialState, action: Action): MetadataState =>
             case METADATA.SET_INITIATING:
                 draft.initiating = action.payload;
                 break;
+            case METADATA.SET_DATA:
+                // if (!draft.data[action.payload.provider]) {
+                //     draft.data[action.payload.provider] = {};
+                // }
+                const targetProvider = draft.providers.find(
+                    p =>
+                        p.type === action.payload.provider.type &&
+                        p.clientId === action.payload.provider.clientId,
+                );
+                if (!targetProvider) {
+                    break;
+                }
+                if (!targetProvider.data) {
+                    targetProvider.data = {};
+                }
+                targetProvider.data = {
+                    ...action.payload.data,
+                    ...targetProvider.data,
+                };
+                break;
             // no default
         }
     });
 
 const selectMetadata = (state: { metadata: MetadataState }) => state.metadata;
 
+export const selectSelectedProviderForLabels = (state: { metadata: MetadataState }) =>
+    state.metadata.providers.find(p => p.clientId === state.metadata.selectedProvider['labels']);
+
+export const selectLabelingDataForSelectedAccount = createSelector(
+    [selectSelectedProviderForLabels, selectSelectedAccount],
+    (provider, selectedAccount) => {
+        if (!provider?.data || !selectedAccount?.metadata.fileName) {
+            return {
+                addressLabels: {},
+                outputLabels: {},
+                accountLabel: '',
+            };
+        }
+
+        const data = provider.data[selectedAccount.metadata.fileName];
+        if (data && 'outputLabels' in data) {
+            return data;
+        }
+
+        return {
+            addressLabels: {},
+            outputLabels: {},
+            accountLabel: '',
+        };
+    },
+);
+
 // is everything ready (more or less) to add label?
 export const selectIsLabelingAvailable = createSelector(
-    [selectDevice, selectMetadata],
-    (device, metadata) =>
-        !!(metadata.enabled && device?.metadata?.status === 'enabled' && metadata.provider),
+    [selectDevice, selectMetadata, selectSelectedProviderForLabels],
+    (device, metadata, provider) =>
+        !!(metadata.enabled && device?.metadata?.status === 'enabled' && provider),
 );
 
 export default metadataReducer;

--- a/packages/suite/src/services/suite/metadata/FileSystemProvider.ts
+++ b/packages/suite/src/services/suite/metadata/FileSystemProvider.ts
@@ -7,6 +7,10 @@ class FileSystemProvider extends AbstractMetadataProvider {
         super('fileSystem');
     }
 
+    get clientId() {
+        return this.type;
+    }
+
     connect() {
         return Promise.resolve(this.ok());
     }
@@ -22,11 +26,12 @@ class FileSystemProvider extends AbstractMetadataProvider {
             isCloud: this.isCloud,
             tokens: {},
             user: '',
+            clientId: this.clientId,
         });
     }
 
     async getFileContent(file: string) {
-        const result = await desktopApi.metadataRead({ file: `${file}.mtdt` });
+        const result = await desktopApi.metadataRead({ file });
         if (!result.success && result.code !== 'ENOENT') {
             return this.error('PROVIDER_ERROR', result.error);
         }
@@ -37,7 +42,7 @@ class FileSystemProvider extends AbstractMetadataProvider {
         const hex = content.toString('hex');
 
         const result = await desktopApi.metadataWrite({
-            file: `${file}.mtdt`,
+            file,
             content: hex,
         });
         if (!result.success) {

--- a/packages/suite/src/services/suite/metadata/GoogleProvider.ts
+++ b/packages/suite/src/services/suite/metadata/GoogleProvider.ts
@@ -9,6 +9,10 @@ class GoogleProvider extends AbstractMetadataProvider {
         GoogleClient.init(tokens, environment);
     }
 
+    get clientId() {
+        return GoogleClient.clientId;
+    }
+
     async connect() {
         try {
             await GoogleClient.authorize();
@@ -36,7 +40,7 @@ class GoogleProvider extends AbstractMetadataProvider {
 
     async getFileContent(file: string) {
         try {
-            const id = await GoogleClient.getIdByName(`${file}.mtdt`);
+            const id = await GoogleClient.getIdByName(file);
             if (!id) {
                 return this.ok(undefined);
             }
@@ -66,12 +70,12 @@ class GoogleProvider extends AbstractMetadataProvider {
         try {
             // search for file by name with forceReload=true parameter to make sure that we do not save
             // two files with the same name but different ids
-            const id = await GoogleClient.getIdByName(`${file}.mtdt`, true);
+            const id = await GoogleClient.getIdByName(file, true);
             if (id) {
                 await GoogleClient.update(
                     {
                         body: {
-                            name: `${file}.mtdt`,
+                            name: file,
                             mimeType: 'text/plain;charset=UTF-8',
                         },
                     },
@@ -83,7 +87,7 @@ class GoogleProvider extends AbstractMetadataProvider {
             await GoogleClient.create(
                 {
                     body: {
-                        name: `${file}.mtdt`,
+                        name: file,
                         mimeType: 'text/plain;charset=UTF-8',
                         parents: ['appDataFolder'],
                     },
@@ -109,6 +113,7 @@ class GoogleProvider extends AbstractMetadataProvider {
                     refreshToken: GoogleClient.refreshToken,
                 },
                 user: response.user.displayName,
+                clientId: this.clientId,
             } as const);
         } catch (err) {
             return this.handleProviderError(err);

--- a/packages/suite/src/storage/migrations/index.ts
+++ b/packages/suite/src/storage/migrations/index.ts
@@ -1,6 +1,6 @@
 import BigNumber from 'bignumber.js';
 import { toWei } from 'web3-utils';
-import { isDesktop } from '@suite-utils/env';
+// import { isDesktop } from '@suite-utils/env';
 import type { State } from '@wallet-reducers/settingsReducer';
 import type { CustomBackend, BlockbookUrl } from '@wallet-types/backend';
 import type { Network, Account, Discovery } from '@wallet-types';
@@ -500,31 +500,31 @@ export const migrate: OnUpgradeFunc<SuiteDBSchema> = async (
             });
     }
 
-    if (oldVersion < 29) {
-        db.createObjectStore('firmware');
+    // if (oldVersion < 29) {
+    //     db.createObjectStore('firmware');
 
-        const providerStore = await transaction.objectStore('metadata');
-        await providerStore.openCursor().then(async function update(cursor): Promise<void> {
-            if (!cursor) {
-                return;
-            }
-            const state = cursor.value;
-            // @ts-expect-error (token property removed)
-            if (state.provider?.token) {
-                if (isDesktop()) {
-                    state.provider.tokens = {
-                        accessToken: '',
-                        // @ts-expect-error
-                        refreshToken: state.provider.token,
-                    };
-                }
-                // @ts-expect-error
-                delete state.provider.token;
-                await cursor.update(state);
-            }
-            return cursor.continue().then(update);
-        });
-    }
+    //     const providerStore = await transaction.objectStore('metadata');
+    //     await providerStore.openCursor().then(async function update(cursor): Promise<void> {
+    //         if (!cursor) {
+    //             return;
+    //         }
+    //         const state = cursor.value;
+    //         // @ts-expect-error (token property removed)
+    //         if (state.provider?.token) {
+    //             if (isDesktop()) {
+    //                 state.provider.tokens = {
+    //                     accessToken: '',
+    //                     // @ts-expect-error
+    //                     refreshToken: state.provider.token,
+    //                 };
+    //             }
+    //             // @ts-expect-error
+    //             delete state.provider.token;
+    //             await cursor.update(state);
+    //         }
+    //         return cursor.continue().then(update);
+    //     });
+    // }
 
     if (oldVersion < 30) {
         const walletSettingsStore = transaction.objectStore('walletSettings');

--- a/packages/suite/src/utils/suite/analytics.ts
+++ b/packages/suite/src/utils/suite/analytics.ts
@@ -41,7 +41,7 @@ export const getSuiteReadyPayload = (state: AppState) => ({
     screenHeight: getScreenHeight(),
     platformLanguages: getPlatformLanguages().join(','),
     tor: getIsTorEnabled(state.suite.torStatus),
-    labeling: state.metadata.enabled ? state.metadata.provider?.type || 'missing-provider' : '',
+    labeling: state.metadata.enabled ? state.metadata.providers[0]?.type || 'missing-provider' : '',
     rememberedStandardWallets: state.devices.filter(d => d.remember && d.useEmptyPassphrase).length,
     rememberedHiddenWallets: state.devices.filter(d => d.remember && !d.useEmptyPassphrase).length,
     theme: state.suite.settings.theme.variant,

--- a/packages/suite/src/utils/suite/logsUtils.ts
+++ b/packages/suite/src/utils/suite/logsUtils.ts
@@ -192,7 +192,8 @@ export const getApplicationInfo = (state: AppState, hideSensitiveInfo: boolean) 
     discreetMode: state.wallet.settings.discreetMode,
     tor: getIsTorEnabled(state.suite.torStatus),
     torOnionLinks: state.suite.settings.torOnionLinks,
-    labeling: state.metadata.enabled ? state.metadata.provider?.type || 'missing-provider' : '',
+    // todo:
+    labeling: state.metadata.enabled ? state.metadata.providers[0]?.type || 'missing-provider' : '',
     analytics: state.analytics.enabled,
     instanceId: hideSensitiveInfo ? REDACTED_REPLACEMENT : state.analytics.instanceId,
     sessionId: hideSensitiveInfo ? REDACTED_REPLACEMENT : state.analytics.sessionId,

--- a/packages/suite/src/utils/suite/metadata.ts
+++ b/packages/suite/src/utils/suite/metadata.ts
@@ -5,6 +5,7 @@ import * as base58check from 'bs58check';
 
 const CIPHER_TYPE = 'aes-256-gcm';
 const CIPHER_IVSIZE = 96 / 8;
+const AUTH_SIZE = 128 / 8;
 
 export const deriveMetadataKey = (masterKey: string, xpub: string) => {
     const hmac = crypto.createHmac('sha256', Buffer.from(masterKey, 'hex'));
@@ -64,6 +65,7 @@ export const arrayBufferToBuffer = (ab: ArrayBuffer) => {
 };
 
 export const encrypt = async (input: Record<string, any>, aesKey: string | Buffer) => {
+    console.log('encrypting!!!', input, aesKey);
     if (typeof aesKey === 'string') {
         aesKey = Buffer.from(aesKey, 'hex');
     }
@@ -83,11 +85,10 @@ export const decrypt = (input: Buffer, key: string | Buffer) => {
         key = Buffer.from(key, 'hex');
     }
 
-    const ivsize = CIPHER_IVSIZE;
-    const iv = input.slice(0, ivsize);
+    const iv = input.slice(0, CIPHER_IVSIZE);
     // tag is always 128-bits
-    const authTag = input.slice(ivsize, ivsize + 128 / 8);
-    const cText = input.slice(ivsize + 128 / 8);
+    const authTag = input.slice(CIPHER_IVSIZE, CIPHER_IVSIZE + AUTH_SIZE);
+    const cText = input.slice(CIPHER_IVSIZE + AUTH_SIZE);
     const decipher = crypto.createDecipheriv(CIPHER_TYPE, key, iv);
     const start = decipher.update(cText);
 
@@ -97,7 +98,8 @@ export const decrypt = (input: Buffer, key: string | Buffer) => {
 
     const res = Buffer.concat([start, end]);
     const stringified = res.toString('utf8');
-    return JSON.parse(stringified);
+    const result = JSON.parse(stringified);
+    return result;
 };
 
 /**

--- a/packages/suite/src/views/settings/debug/Metadata.tsx
+++ b/packages/suite/src/views/settings/debug/Metadata.tsx
@@ -1,0 +1,176 @@
+import React, { useState, useMemo } from 'react';
+import styled from 'styled-components';
+
+import { SectionItem, TextColumn } from '@suite-components/Settings';
+import { useSelector } from '@suite-hooks';
+import { MetadataState } from '@suite-common/metadata-types';
+import { DropZone } from '@suite-components/DropZone';
+import { Button, Select } from '@trezor/components';
+import * as metadataUtils from '@suite-utils/metadata';
+import { Account } from 'suite-common/wallet-types/src';
+import { METADATA } from '@suite-actions/constants';
+
+const LabelingViewer = styled.div`
+    display: flex;
+    flex-direction: column;
+`;
+
+const StyledPre = styled.pre`
+    font-size: 10px;
+`;
+
+const DecodedSection = styled.div`
+    display: flex;
+    flex-direction: row;
+    margin: 8px 0;
+    flex: 1;
+`;
+
+const DecodedItem = styled.div`
+    padding: 8px;
+    flex: 1;
+    max-width: 50%;
+    line-break: anywhere;
+    overflow: hidden;
+`;
+
+const DecodedItemTitle = styled.div`
+    margin-bottom: 4px;
+    font-size: 16px;
+    font-weight: 500;
+`;
+
+interface MetadataItemProps {
+    metadata: MetadataState;
+    fileName: string;
+    aesKey: string;
+}
+
+const MetadataItem = ({ metadata, fileName, aesKey }: MetadataItemProps) => {
+    const [custom, setCustom] = useState(undefined);
+
+    const onSelect = (file: File, setError: (msg: any) => void) => {
+        const reader = new FileReader();
+        reader.onload = () => {
+            try {
+                const decrypted = metadataUtils.decrypt(
+                    // @ts-expect-error
+                    metadataUtils.arrayBufferToBuffer(reader.result),
+                    aesKey,
+                );
+                console.log(decrypted);
+                setCustom(decrypted);
+            } catch (err) {
+                setError({ id: 'TR_DROPZONE_ERROR', values: { error: err.message } });
+            }
+        };
+        reader.onerror = () => {
+            setError({ id: 'TR_DROPZONE_ERROR', values: { error: reader.error!.message } });
+            reader.abort();
+        };
+        reader.readAsArrayBuffer(file);
+    };
+
+    if (!metadata.providers.length) return null;
+
+    const selectedProvider = metadata.providers.find(
+        p => p.clientId !== METADATA.DROPBOX_PASSWODS_CLIENT_ID,
+    );
+
+    if (!selectedProvider) return null;
+
+    return (
+        <DecodedSection>
+            <DecodedItem>
+                <DecodedItemTitle>Fetched from {selectedProvider.type}</DecodedItemTitle>
+                {!selectedProvider.data?.[fileName] && 'No data found'}
+                {selectedProvider.data?.[fileName] && (
+                    <StyledPre>
+                        {JSON.stringify(selectedProvider.data[fileName] || {}, null, 2)}
+                    </StyledPre>
+                )}
+            </DecodedItem>
+            <DecodedItem>
+                <DecodedItemTitle>Compare with a local file</DecodedItemTitle>
+                {!custom && (
+                    <DropZone
+                        accept=".mtdt"
+                        icon="SEARCH"
+                        onSelect={onSelect}
+                        placeholder="Upload file"
+                    />
+                )}
+                {custom && <StyledPre>{JSON.stringify(custom, null, 2)}</StyledPre>}
+                {custom && <Button onClick={() => setCustom(undefined)}>Clear</Button>}
+            </DecodedItem>
+        </DecodedSection>
+    );
+};
+
+export const Metadata = () => {
+    const { metadata, accounts } = useSelector(state => ({
+        metadata: state.metadata,
+        accounts: state.wallet.accounts,
+    }));
+
+    const selectedProvider = metadata.providers.find(
+        p => p.clientId !== METADATA.DROPBOX_PASSWODS_CLIENT_ID,
+    );
+    const [selectedAccountPath, setSelectedAccountPath] = useState(undefined);
+    const selectedAccount = useMemo(() => {
+        return accounts.find(a => a.path === selectedAccountPath);
+    }, [accounts, selectedAccountPath]);
+
+    const getLabel = (a: Account) => {
+        return `${a.symbol} - ${a.path} - ${a.metadata.fileName}`;
+    };
+
+    if (!metadata.enabled) {
+        return (
+            <SectionItem>
+                <TextColumn
+                    title="No labeling data"
+                    description="Go back to Suite and enable labeling"
+                />
+            </SectionItem>
+        );
+    }
+    return (
+        <>
+            <SectionItem>
+                <div>
+                    <div>provider type: {selectedProvider?.type}</div>
+                    <div>provider clientId: {selectedProvider?.clientId}</div>
+                    <div>provider user: {selectedProvider?.user}</div>
+                </div>
+            </SectionItem>
+            <SectionItem>
+                <LabelingViewer>
+                    <Select
+                        onChange={(selected: any) => {
+                            setSelectedAccountPath(selected.value);
+                        }}
+                        value={{
+                            label: selectedAccount ? getLabel(selectedAccount) : 'Select account',
+                        }}
+                        isClearable={false}
+                        options={accounts.map(a => ({
+                            label: getLabel(a),
+                            value: a.path,
+                        }))}
+                        isClean
+                        hideTextCursor
+                    />
+
+                    {selectedAccount && (
+                        <MetadataItem
+                            metadata={metadata}
+                            fileName={selectedAccount.metadata.fileName}
+                            aesKey={selectedAccount.metadata.aesKey}
+                        />
+                    )}
+                </LabelingViewer>
+            </SectionItem>
+        </>
+    );
+};

--- a/packages/suite/src/views/settings/debug/Passwords.tsx
+++ b/packages/suite/src/views/settings/debug/Passwords.tsx
@@ -1,0 +1,238 @@
+import React, { useState, useMemo, useEffect, useCallback } from 'react';
+import styled from 'styled-components';
+import TrezorConnect from '@trezor/connect';
+import crypto from 'crypto';
+import { Button } from '@trezor/components';
+
+import { SectionItem } from '@suite-components/Settings';
+import { useSelector, useActions } from '@suite-hooks';
+import * as metadataActions from '@suite-actions/metadataActions';
+import * as metadataUtils from '@suite-utils/metadata';
+import type { PasswordEntry } from '@suite-types/metadata';
+import { METADATA } from '@suite-actions/constants';
+
+const PasswordsList = styled.div`
+    display: flex;
+    flex-direction: column;
+    width: 100%;
+    flex: 1;
+`;
+
+const PasswordEntryRow = styled.div<{ clickable: boolean }>`
+    display: flex;
+    flex-direction: row;
+    margin-bottom: 4px;
+    cursor: ${({ clickable }) => (clickable ? '' : 'pointer')};
+`;
+
+const PasswordEntryBody = styled.div`
+    dipslay: flex;
+    flex-direction: column;
+    margin-left: 8px;
+`;
+
+const PasswordEntryIcon = styled.div`
+    width: 40px;
+    height: 40px;
+    background-color: yellow;
+`;
+
+const PasswordEntryTitle = styled.div`
+    font-size: 16px;
+`;
+
+const PasswordEntryUsername = styled.div`
+    font-size: 12px;
+`;
+
+const PasswordEntryPassword = styled.div`
+    font-size: 12px;
+`;
+
+interface PasswordEntryProps extends PasswordEntry {
+    devicePath: string;
+}
+
+const getDisplayKey = (title: string, username: string) => {
+    // title = this.bgStore.isUrl(title) ? this.bgStore.decomposeUrl(title).domain : title;
+    return 'Unlock ' + title + ' for user ' + username + '?';
+};
+
+const PasswordEntryComponent = ({
+    username,
+    title,
+    nonce,
+    password,
+
+    devicePath,
+}: PasswordEntryProps) => {
+    const [decodedPassword, setDecodedPassword] = useState('');
+    const [inProgress, setInProgress] = useState(false);
+
+    const decode = useCallback(() => {
+        if (inProgress) return;
+        setInProgress(true);
+        TrezorConnect.cipherKeyValue({
+            device: { path: devicePath },
+            override: true,
+            useEmptyPassphrase: true,
+            path: PATH,
+            key: getDisplayKey(title, username),
+            value: nonce,
+            encrypt: false,
+            askOnEncrypt: false,
+            askOnDecrypt: true,
+        })
+            .then(result => {
+                console.log(result);
+                if (result.success) {
+                    console.log('password', password);
+                    const decrypted = metadataUtils.decrypt(
+                        new Buffer(password.data),
+                        new Buffer(result.payload.value, 'hex'),
+                    );
+                    console.log('decrypted', decrypted);
+                    setDecodedPassword(decrypted);
+                }
+            })
+            .finally(() => {
+                setInProgress(false);
+            });
+    }, [username, title, inProgress]);
+
+    return (
+        <PasswordEntryRow onClick={decode} clickable={!inProgress && !decodedPassword}>
+            <PasswordEntryIcon />
+            <PasswordEntryBody>
+                <PasswordEntryTitle>{title}</PasswordEntryTitle>
+                <PasswordEntryUsername>{username}</PasswordEntryUsername>
+                {inProgress ? (
+                    '...'
+                ) : (
+                    <PasswordEntryPassword>
+                        {!decodedPassword ? '*****' : decodedPassword}
+                    </PasswordEntryPassword>
+                )}
+            </PasswordEntryBody>
+        </PasswordEntryRow>
+    );
+};
+
+const FILENAME_MESS = '5f91add3fa1c3c76e90c90a3bd0999e2bd7833d06a483fe884ee60397aca277a';
+const HD_HARDENED = 0x80000000;
+const PATH = [(10016 | HD_HARDENED) >>> 0, 0];
+const DEFAULT_KEYPHRASE = 'Activate TREZOR Password Manager?';
+const DEFAULT_NONCE =
+    '2d650551248d792eabf628f451200d7f51cb63e46aadcbb1038aacb05e8c8aee2d650551248d792eabf628f451200d7f51cb63e46aadcbb1038aacb05e8c8aee';
+
+export const PasswordManager = () => {
+    const [fileName, setFileName] = useState('');
+    const [providerConnected, setProviderConnected] = useState(false);
+    const [providerConnecting, setProviderConnecting] = useState(false);
+
+    const { device, metadata } = useSelector(state => ({
+        metadata: state.metadata,
+        device: state.suite.device,
+    }));
+
+    const { fetchPasswords, connectProvider, disconnectProvider } = useActions({
+        connectProvider: metadataActions.connectProvider,
+        disconnectProvider: metadataActions.disconnectProvider,
+        fetchPasswords: metadataActions.fetchPasswords,
+    });
+
+    const selectedProvider = metadata.providers.find(
+        p => p.clientId === METADATA.DROPBOX_PASSWODS_CLIENT_ID,
+    );
+
+    const passwordEntries: PasswordEntry[] = useMemo(() => {
+        if (!fileName || !selectedProvider || !selectedProvider?.data?.[fileName]) {
+            return [];
+        }
+
+        const data = selectedProvider?.data![fileName];
+        if ('entries' in data) {
+            return data.entries;
+        }
+        return [];
+    }, [metadata]);
+    console.log('passwordEntries', passwordEntries);
+
+    const connect = useCallback(async () => {
+        setProviderConnecting(true);
+        setProviderConnected(false);
+
+        await disconnectProvider();
+        connectProvider({ type: 'dropbox', clientId: METADATA.DROPBOX_PASSWODS_CLIENT_ID })
+            .then(() => {
+                setProviderConnected(true);
+            })
+            .finally(() => {
+                setProviderConnecting(false);
+            });
+    }, []);
+
+    useEffect(() => {
+        if (providerConnected) {
+            TrezorConnect.cipherKeyValue({
+                device: { path: device?.path },
+                override: true,
+                useEmptyPassphrase: true,
+                path: PATH,
+                key: DEFAULT_KEYPHRASE,
+                value: DEFAULT_NONCE,
+                encrypt: true,
+                askOnEncrypt: true,
+                askOnDecrypt: true,
+            }).then(res => {
+                if (res.success) {
+                    const encryptionKey = new Buffer(
+                        res.payload.value.substring(
+                            res.payload.value.length / 2,
+                            res.payload.value.length,
+                        ),
+                        'hex',
+                    );
+
+                    let fileKey = res.payload.value.substring(0, res.payload.value.length / 2);
+                    const fname =
+                        crypto.createHmac('sha256', fileKey).update(FILENAME_MESS).digest('hex') +
+                        '.pswd';
+                    setFileName(fname);
+                    fetchPasswords(device?.state!, fname, encryptionKey);
+                }
+            });
+        }
+    }, [providerConnected]);
+
+    if (providerConnecting) {
+        return <SectionItem>Connecting...</SectionItem>;
+    }
+
+    if (!providerConnected) {
+        return (
+            <SectionItem>
+                <Button onClick={connect}>Connect to dropbox</Button>
+            </SectionItem>
+        );
+    }
+
+    return (
+        <>
+            <SectionItem>
+                <div>
+                    <div>provider type: {selectedProvider?.type}</div>
+                    <div>provider clientId: {selectedProvider?.clientId}</div>
+                    <div>provider user: {selectedProvider?.user}</div>
+                </div>
+            </SectionItem>
+            <SectionItem>
+                <PasswordsList>
+                    {Object.entries(passwordEntries).map(([key, entry]) => (
+                        <PasswordEntryComponent {...entry} devicePath={device!.path} key={key} />
+                    ))}
+                </PasswordsList>
+            </SectionItem>
+        </>
+    );
+};

--- a/packages/suite/src/views/settings/debug/SettingsDebug.tsx
+++ b/packages/suite/src/views/settings/debug/SettingsDebug.tsx
@@ -15,6 +15,8 @@ import { CheckFirmwareAuthenticity } from './CheckFirmwareAuthenticity';
 import { Devkit } from './Devkit';
 import { Transport } from './Transport';
 import { Processes } from './Processes';
+import { Metadata } from './Metadata';
+import { PasswordManager } from './Passwords';
 
 export const SettingsDebug = () => (
     <SettingsLayout>
@@ -50,6 +52,12 @@ export const SettingsDebug = () => (
         )}
         <SettingsSection title="Transports">
             <Transport />
+        </SettingsSection>
+        <SettingsSection title="Labeling viewer">
+            <Metadata />
+        </SettingsSection>
+        <SettingsSection title="Password manager">
+            <PasswordManager />
         </SettingsSection>
     </SettingsLayout>
 );

--- a/packages/suite/src/views/settings/general/LabelingConnect.tsx
+++ b/packages/suite/src/views/settings/general/LabelingConnect.tsx
@@ -6,6 +6,7 @@ import * as metadataActions from '@suite-actions/metadataActions';
 import { Translation } from '@suite-components';
 import { useAnchor } from '@suite-hooks/useAnchor';
 import { SettingsAnchor } from '@suite-constants/anchors';
+import { METADATA } from '@suite-actions/constants';
 
 export const LabelingConnect = () => {
     const { device } = useDevice();
@@ -19,7 +20,13 @@ export const LabelingConnect = () => {
         initMetadata: metadataActions.init,
     });
 
-    if (metadata.enabled && !metadata.provider && device?.metadata.status === 'enabled') {
+    if (
+        metadata.enabled &&
+        !metadata.providers.find(
+            p => p.type !== 'dropbox' || p.clientId === METADATA.DROPBOX_CLIENT_ID,
+        ) &&
+        device?.metadata.status === 'enabled'
+    ) {
         return (
             <SectionItem
                 data-test="@settings/labeling-connect"

--- a/packages/suite/src/views/settings/general/LabelingDisconnect.tsx
+++ b/packages/suite/src/views/settings/general/LabelingDisconnect.tsx
@@ -7,6 +7,7 @@ import * as metadataActions from '@suite-actions/metadataActions';
 import { Translation } from '@suite-components';
 import { useAnchor } from '@suite-hooks/useAnchor';
 import { SettingsAnchor } from '@suite-constants/anchors';
+import { METADATA } from '@suite-actions/constants';
 
 export const LabelingDisconnect = () => {
     const { metadata } = useSelector(state => ({
@@ -18,7 +19,12 @@ export const LabelingDisconnect = () => {
         disconnectProvider: metadataActions.disconnectProvider,
     });
 
-    if (!metadata.enabled || !metadata.provider) return null;
+    if (!metadata.enabled) return null;
+    // todo + includes labes and is selected
+    const selectedProvider = metadata.providers.find(
+        p => p.type !== 'dropbox' || p.clientId === METADATA.DROPBOX_CLIENT_ID,
+    );
+    if (!selectedProvider) return null;
 
     return (
         <SectionItem
@@ -28,12 +34,12 @@ export const LabelingDisconnect = () => {
         >
             <TextColumn
                 title={
-                    metadata.provider.isCloud ? (
+                    selectedProvider.isCloud ? (
                         <Translation
                             id="TR_CONNECTED_TO_PROVIDER"
                             values={{
-                                provider: capitalizeFirstLetter(metadata.provider.type),
-                                user: metadata.provider.user,
+                                provider: capitalizeFirstLetter(selectedProvider.type),
+                                user: selectedProvider.user,
                             }}
                         />
                     ) : (
@@ -41,7 +47,7 @@ export const LabelingDisconnect = () => {
                     )
                 }
                 description={
-                    metadata.provider.isCloud ? (
+                    selectedProvider.isCloud ? (
                         <Translation id="TR_YOUR_LABELING_IS_SYNCED" />
                     ) : (
                         <Translation id="TR_YOUR_LABELING_IS_SYNCED_LOCALLY" />

--- a/packages/suite/src/views/wallet/send/index.tsx
+++ b/packages/suite/src/views/wallet/send/index.tsx
@@ -13,6 +13,7 @@ import { TotalSent } from './components/TotalSent';
 import { ReviewButton } from './components/ReviewButton';
 import Raw from './components/Raw';
 import { selectCurrentTargetAnonymity } from '@wallet-reducers/coinjoinReducer';
+import { selectSelectedProviderForLabels } from '@suite-reducers/metadataReducer';
 
 const StyledCard = styled(Card)`
     display: flex;
@@ -58,13 +59,14 @@ interface SendProps {
 }
 
 const Send = ({ children }: SendProps) => {
+    const provider = useSelector(selectSelectedProviderForLabels);
     const props = useSelector(state => ({
         fiat: state.wallet.fiat,
         localCurrency: state.wallet.settings.localCurrency,
         fees: state.wallet.fees,
         online: state.suite.online,
         sendRaw: state.wallet.send.sendRaw,
-        metadataEnabled: state.metadata.enabled && !!state.metadata.provider,
+        metadataEnabled: state.metadata.enabled && !!provider,
         targetAnonymity: selectCurrentTargetAnonymity(state),
     }));
     const selectedAccount = useSelector(state => state.wallet.selectedAccount);


### PR DESCRIPTION
## Description

Debugging labeling data is hard since it is stored in encrypted form. Sometimes we might want to see how this data looks like.

So far in c311ff99f2eb2e1a9150c2a571b21f6d0cbe56c8, I have only added a way how to see all the files that suite was able to download and decrypt in debugging menu

![image](https://user-images.githubusercontent.com/30367552/196195723-540c107c-d8c4-4a7b-8bad-40f628173d09.png)

a0b3315c214d046fca13c2831452a31f017e6b85 is a temporary commit that contains only some addional debugging console.logs 

e44910f8fabd7a379b769d5633285321e953041a  introduces a new way how labeling data are store in trezor-suite application state. I could achieve debugging purposes without this but on the other hand I believe that we are going to need to change data structure here anyway to enable features such as migration between storage providers ands so on. 

Testing: 
desktop mac - https://gitlab.com/satoshilabs/trezor/trezor-suite/-/jobs/3183609942/artifacts/browse
desktop linux - https://gitlab.com/satoshilabs/trezor/trezor-suite/-/jobs/3183609944/artifacts/browse
