### PR TITLE
Better representation of coinjoin transactions

### DIFF
--- a/packages/components/src/components/others/Card.tsx
+++ b/packages/components/src/components/others/Card.tsx
@@ -23,7 +23,7 @@ const getPaddingSize = (
     return '20px';
 };
 
-export interface CardProps {
+export interface CardProps extends React.HTMLAttributes<HTMLDivElement> {
     children?: React.ReactNode;
     largePadding?: boolean;
     noPadding?: boolean;
@@ -31,18 +31,16 @@ export interface CardProps {
     customPadding?: string;
 }
 
-export const Card = ({
-    children,
-    largePadding,
-    noPadding,
-    noVerticalPadding,
-    customPadding,
-    ...rest
-}: CardProps) => (
-    <Wrapper
-        paddingSize={customPadding || getPaddingSize(largePadding, noPadding, noVerticalPadding)}
-        {...rest}
-    >
-        {children}
-    </Wrapper>
+export const Card = React.forwardRef<HTMLDivElement, CardProps>(
+    ({ children, largePadding, noPadding, noVerticalPadding, customPadding, ...rest }, ref) => (
+        <Wrapper
+            ref={ref}
+            paddingSize={
+                customPadding || getPaddingSize(largePadding, noPadding, noVerticalPadding)
+            }
+            {...rest}
+        >
+            {children}
+        </Wrapper>
+    ),
 );

--- a/packages/suite/.stylelintrc
+++ b/packages/suite/.stylelintrc
@@ -17,6 +17,11 @@
                 "ignoreProperties": ["composes", "font-smoothing", "font-smooth"]
             }
         ],
+		"selector-type-no-unknown": [
+            true, {
+                "ignoreTypes": ["/-styled-mixin/"]
+            }
+        ],
         "at-rule-no-unknown": [ true, {
             "ignoreAtRules": ["each"]
         }]

--- a/packages/suite/src/components/suite/FormattedCryptoAmount.tsx
+++ b/packages/suite/src/components/suite/FormattedCryptoAmount.tsx
@@ -20,7 +20,7 @@ const Symbol = styled.span`
     word-break: initial;
 `;
 
-interface FormattedCryptoAmountProps {
+export interface FormattedCryptoAmountProps {
     value: string | number | undefined;
     symbol: string | undefined;
     isBalance?: boolean;

--- a/packages/suite/src/components/suite/modals/TransactionDetail/components/ChainedTxs.tsx
+++ b/packages/suite/src/components/suite/modals/TransactionDetail/components/ChainedTxs.tsx
@@ -13,6 +13,15 @@ const StyledTrezorLink = styled(TrezorLink)`
     width: 100%;
 `;
 
+const ChainedTransactionItem = styled(TransactionItem)`
+    width: 100%;
+    padding: 0px 40px;
+    cursor: pointer;
+    &:hover {
+        background: ${props => props.theme.BG_GREY};
+    }
+`;
+
 interface ChainedTxsProps {
     txs: WalletAccountTransaction[];
     explorerUrl: string;
@@ -21,8 +30,8 @@ interface ChainedTxsProps {
 export const ChainedTxs = ({ txs, explorerUrl }: ChainedTxsProps) => (
     <Wrapper>
         {txs.map(tx => (
-            <StyledTrezorLink href={`${explorerUrl}${tx.txid}`} variant="nostyle">
-                <TransactionItem
+            <StyledTrezorLink key={tx.txid} href={`${explorerUrl}${tx.txid}`} variant="nostyle">
+                <ChainedTransactionItem
                     key={tx.txid}
                     transaction={tx}
                     isPending

--- a/packages/suite/src/components/suite/modals/TransactionDetail/components/IODetails.tsx
+++ b/packages/suite/src/components/suite/modals/TransactionDetail/components/IODetails.tsx
@@ -1,18 +1,22 @@
 import React from 'react';
-import styled from 'styled-components';
+import styled, { css } from 'styled-components';
 import { Icon, useTheme, variables } from '@trezor/components';
 import { WalletAccountTransaction } from '@suite-common/wallet-types';
-import { formatNetworkAmount, getNetwork } from '@suite-common/wallet-utils';
+import { formatNetworkAmount } from '@suite-common/wallet-utils';
 import { FormattedCryptoAmount, HiddenPlaceholder, Translation } from '@suite-components';
+
+export const blurFix = css`
+    margin-left: -10px;
+    margin-right: -10px;
+    padding-left: 10px;
+    padding-right: 10px;
+`;
 
 const Wrapper = styled.div`
     text-align: left;
     margin-top: 25px;
-`;
-
-const IOWrapper = styled.div`
     overflow: auto;
-    padding: 0 1px;
+    ${blurFix}
 `;
 
 const IconWrapper = styled.div`
@@ -23,96 +27,122 @@ const IconWrapper = styled.div`
     margin-bottom: 16px;
 `;
 
-const IORowTitle = styled.div`
+const IOGridTitle = styled.div`
     margin-bottom: 4px;
     color: ${({ theme }) => theme.TYPE_LIGHT_GREY};
     font-size: ${variables.NEUE_FONT_SIZE.TINY};
 `;
 
-const IORow = styled.div<{ isAccountOwned?: boolean }>`
-    display: flex;
+const IOGrid = styled.div`
+    display: grid;
+    gap: 0 16px;
     line-height: 1.9;
-    color: ${({ theme, isAccountOwned }) =>
-        isAccountOwned ? theme.TYPE_DARK_GREY : theme.TYPE_LIGHT_GREY};
     font-weight: ${variables.FONT_WEIGHT.MEDIUM};
     font-size: ${variables.NEUE_FONT_SIZE.SMALL};
-`;
-
-const CryptoAmountWrapper = styled.div`
-    flex: 0 0 auto;
-`;
-
-const Circle = styled.div`
-    display: inline-flex;
-    margin-left: 5px;
-    margin-right: 5px;
     color: ${({ theme }) => theme.TYPE_LIGHT_GREY};
+    grid-template-columns: auto auto auto; /* address, extra, amount */
+    ${blurFix}
 `;
+
+const IOGridCell = styled.div<{ isAccountOwned?: boolean }>`
+    white-space: nowrap;
+    overflow: hidden;
+    ${blurFix}
+
+    ${({ theme, isAccountOwned }) =>
+        isAccountOwned &&
+        css`
+            color: ${theme.TYPE_DARK_GREY};
+        `}
+
+    :nth-child(3n + 1) {
+        /* address */
+        text-overflow: ellipsis;
+    }
+
+    :nth-child(3n + 2) {
+        /* extra */
+    }
+
+    :nth-child(3n + 3) {
+        /* amount */
+        text-align: right;
+    }
+`;
+
+type EnhancedVinVout = WalletAccountTransaction['details']['vin'][number];
+
+const IOGridRow = ({
+    tx: { symbol },
+    vinvout: { isAccountOwned, addresses, value },
+}: {
+    tx: WalletAccountTransaction;
+    vinvout: EnhancedVinVout;
+}) => (
+    <>
+        <IOGridCell isAccountOwned={isAccountOwned}>
+            <HiddenPlaceholder>{addresses}</HiddenPlaceholder>
+        </IOGridCell>
+        <IOGridCell isAccountOwned={isAccountOwned} />
+        <IOGridCell isAccountOwned={isAccountOwned}>
+            {value && (
+                <FormattedCryptoAmount value={formatNetworkAmount(value, symbol)} symbol={symbol} />
+            )}
+        </IOGridCell>
+    </>
+);
+
+type IOSectionProps = {
+    tx: WalletAccountTransaction;
+    inputs: EnhancedVinVout[];
+    outputs: EnhancedVinVout[];
+};
+
+const IOSection = ({ tx, inputs, outputs }: IOSectionProps) => {
+    const theme = useTheme();
+    const hasInputs = !!inputs?.length;
+    const hasOutputs = !!outputs?.length;
+    return (
+        <>
+            {hasInputs && (
+                <IOGridTitle>
+                    <Translation id="TR_INPUTS" />
+                </IOGridTitle>
+            )}
+            {hasInputs && (
+                <IOGrid>
+                    {inputs.map(input => (
+                        <IOGridRow key={input.n} tx={tx} vinvout={input} />
+                    ))}
+                </IOGrid>
+            )}
+            {hasInputs && hasOutputs && (
+                <IconWrapper>
+                    <Icon icon="ARROW_DOWN" size={17} color={theme.TYPE_LIGHT_GREY} />
+                </IconWrapper>
+            )}
+            {hasOutputs && (
+                <IOGridTitle>
+                    <Translation id="TR_OUTPUTS" />
+                </IOGridTitle>
+            )}
+            {hasOutputs && (
+                <IOGrid>
+                    {outputs.map(output => (
+                        <IOGridRow key={output.n} tx={tx} vinvout={output} />
+                    ))}
+                </IOGrid>
+            )}
+        </>
+    );
+};
 
 interface IODetailsProps {
     tx: WalletAccountTransaction;
 }
 
-export const IODetails = ({ tx }: IODetailsProps) => {
-    const theme = useTheme();
-    const network = getNetwork(tx.symbol);
-
-    return (
-        <Wrapper>
-            {tx.details.vin && tx.details.vout && (
-                <IOWrapper>
-                    <div>
-                        <IORowTitle>
-                            <Translation id="TR_INPUTS" />
-                        </IORowTitle>
-
-                        {tx.details.vin.map(input => (
-                            <IORow key={input.n} isAccountOwned={input.isAccountOwned}>
-                                {network?.networkType !== 'ethereum' && (
-                                    // don't show input amount in ethereum
-                                    // consider faking it by showing the same value os the output
-                                    <CryptoAmountWrapper>
-                                        <FormattedCryptoAmount
-                                            value={
-                                                input.value &&
-                                                formatNetworkAmount(input.value, tx.symbol)
-                                            }
-                                            symbol={tx.symbol}
-                                        />
-                                        <Circle>&bull;</Circle>
-                                    </CryptoAmountWrapper>
-                                )}
-                                <HiddenPlaceholder>{input.addresses}</HiddenPlaceholder>
-                            </IORow>
-                        ))}
-                    </div>
-
-                    <IconWrapper>
-                        <Icon icon="ARROW_DOWN" size={17} color={theme.TYPE_LIGHT_GREY} />
-                    </IconWrapper>
-
-                    <div>
-                        <IORowTitle>
-                            <Translation id="TR_OUTPUTS" />
-                        </IORowTitle>
-                        {tx.details.vout.map(output => (
-                            <IORow key={output.n} isAccountOwned={output.isAccountOwned}>
-                                <CryptoAmountWrapper>
-                                    <FormattedCryptoAmount
-                                        value={
-                                            output.value &&
-                                            formatNetworkAmount(output.value, tx.symbol)
-                                        }
-                                        symbol={tx.symbol}
-                                    />
-                                    <Circle>&bull;</Circle>
-                                </CryptoAmountWrapper>
-                                <HiddenPlaceholder>{output.addresses}</HiddenPlaceholder>
-                            </IORow>
-                        ))}
-                    </div>
-                </IOWrapper>
-            )}
-        </Wrapper>
-    );
-};
+export const IODetails = ({ tx }: IODetailsProps) => (
+    <Wrapper>
+        <IOSection tx={tx} inputs={tx.details.vin} outputs={tx.details.vout} />
+    </Wrapper>
+);

--- a/packages/suite/src/components/wallet/TransactionItem/CoinjoinBatchItem.tsx
+++ b/packages/suite/src/components/wallet/TransactionItem/CoinjoinBatchItem.tsx
@@ -1,0 +1,195 @@
+import React from 'react';
+import styled from 'styled-components';
+
+import {
+    formatNetworkAmount,
+    isTestnet,
+    sumTransactions,
+    sumTransactionsFiat,
+} from '@suite-common/wallet-utils';
+import { useFormatters } from '@suite-common/formatters';
+import { variables, CollapsibleBox } from '@trezor/components';
+
+import { useActions } from '@suite-hooks/useActions';
+import * as modalActions from '@suite-actions/modalActions';
+import { WalletAccountTransaction } from '@wallet-types/index';
+import { HiddenPlaceholder, Translation } from '@suite-components';
+import { TransactionTimestamp } from '@wallet-components/TransactionTimestamp';
+
+import { StyledCryptoAmount } from './components/Target';
+import { TransactionTypeIcon } from './components/TransactionTypeIcon';
+import { BaseTargetLayout } from './components/BaseTargetLayout';
+import {
+    Content,
+    Description,
+    NextRow,
+    TargetsWrapper,
+    TimestampWrapper,
+    TxTypeIconWrapper,
+} from './components/CommonComponents';
+
+const CryptoAmount = styled(StyledCryptoAmount)`
+    width: unset;
+`;
+
+const RoundRow = styled.div`
+    display: flex;
+    align-items: center;
+    padding: 8px 16px;
+    border-radius: 8px;
+    cursor: pointer;
+
+    :hover {
+        background-color: ${({ theme }) => theme.BG_GREY};
+    }
+
+    > div:first-child {
+        margin-right: 28px;
+    }
+`;
+
+const Round = ({ transaction }: { transaction: WalletAccountTransaction }) => {
+    const { openModal } = useActions({ openModal: modalActions.openModal });
+    return (
+        <RoundRow
+            onClick={() =>
+                openModal({
+                    type: 'transaction-detail',
+                    tx: transaction,
+                })
+            }
+        >
+            <TransactionTypeIcon type="joint" isPending={false} size={20} />
+            <TransactionTimestamp transaction={transaction} />
+            <BaseTargetLayout
+                addressLabel={
+                    <Translation
+                        id="TR_JOINT_TRANSACTION_TARGET"
+                        values={{
+                            in: transaction.details.vin.length,
+                            inMy: transaction.details.vin.filter(v => v.isAccountOwned).length,
+                            out: transaction.details.vout.length,
+                            outMy: transaction.details.vout.filter(v => v.isAccountOwned).length,
+                        }}
+                    />
+                }
+                amount={
+                    <CryptoAmount
+                        value={formatNetworkAmount(
+                            transaction.amount.startsWith('-')
+                                ? transaction.amount.slice(1)
+                                : transaction.amount,
+                            transaction.symbol,
+                        )}
+                        symbol={transaction.symbol}
+                        signValue={transaction.amount}
+                    />
+                }
+                isFirst
+                isLast
+            />
+        </RoundRow>
+    );
+};
+
+const StyledCollapsibleBox = styled(CollapsibleBox)`
+    background-color: ${props => props.theme.BG_WHITE};
+    box-shadow: none;
+    border-radius: 12px;
+    margin-bottom: 0;
+
+    ${CollapsibleBox.Header} {
+        padding: 12px 24px;
+
+        @media (max-width: ${variables.SCREEN_SIZE.SM}) {
+            padding: 12px 16px;
+        }
+
+        :not(:hover) {
+            ${CollapsibleBox.IconWrapper} {
+                margin-left: -20px;
+                opacity: 0;
+            }
+        }
+    }
+
+    ${CollapsibleBox.IconWrapper} {
+        transition: all 0.25s ease-in-out;
+        transition-property: margin-left, opacity;
+    }
+
+    ${CollapsibleBox.Heading} {
+        flex: 1;
+        align-items: initial;
+    }
+
+    ${CollapsibleBox.Content} {
+        padding: 8px;
+    }
+`;
+
+type CoinjoinBatchItemProps = {
+    transactions: WalletAccountTransaction[];
+    localCurrency: string;
+};
+
+export const CoinjoinBatchItem = ({ transactions, localCurrency }: CoinjoinBatchItemProps) => {
+    const lastTx = transactions[0];
+    const amount = sumTransactions(transactions);
+    const fiatAmount = sumTransactionsFiat(transactions, localCurrency);
+    const { FiatAmountFormatter } = useFormatters();
+    return (
+        <StyledCollapsibleBox
+            variant="large"
+            heading={
+                <>
+                    <TxTypeIconWrapper>
+                        <TransactionTypeIcon type="joint" isPending={false} />
+                    </TxTypeIconWrapper>
+                    <Content>
+                        <Description>
+                            <Translation id="TR_COINJOIN_TRANSACTION_BATCH" />
+                            <CryptoAmount
+                                value={amount.absoluteValue().toFixed()}
+                                symbol={lastTx.symbol}
+                                signValue={amount}
+                            />
+                        </Description>
+                        <NextRow>
+                            <TimestampWrapper>
+                                <TransactionTimestamp transaction={lastTx} />
+                            </TimestampWrapper>
+                            <TargetsWrapper>
+                                <BaseTargetLayout
+                                    addressLabel={
+                                        <Translation
+                                            id="TR_N_TRANSACTIONS"
+                                            values={{ value: transactions.length }}
+                                        />
+                                    }
+                                    fiatAmount={
+                                        !isTestnet(lastTx.symbol) ? (
+                                            <HiddenPlaceholder>
+                                                <FiatAmountFormatter
+                                                    currency={localCurrency}
+                                                    value={fiatAmount.absoluteValue().toFixed()}
+                                                />
+                                            </HiddenPlaceholder>
+                                        ) : undefined
+                                    }
+                                    singleRowLayout
+                                    isFirst
+                                    isLast
+                                />
+                            </TargetsWrapper>
+                        </NextRow>
+                    </Content>
+                </>
+            }
+        >
+            {transactions.map(tx => (
+                <Round key={tx.txid} transaction={tx} />
+            ))}
+        </StyledCollapsibleBox>
+    );
+};

--- a/packages/suite/src/components/wallet/TransactionItem/components/CommonComponents.tsx
+++ b/packages/suite/src/components/wallet/TransactionItem/components/CommonComponents.tsx
@@ -1,0 +1,64 @@
+import React from 'react';
+import styled from 'styled-components';
+import { variables } from '@trezor/components';
+import { HiddenPlaceholder } from '@suite-components';
+import { MIN_ROW_HEIGHT } from './BaseTargetLayout';
+
+export const TxTypeIconWrapper = styled.div`
+    padding-right: 24px;
+    margin-top: 8px;
+    cursor: pointer;
+
+    @media (max-width: ${variables.SCREEN_SIZE.SM}) {
+        display: none;
+    }
+`;
+
+export const TimestampWrapper = styled.div`
+    cursor: pointer;
+    display: flex;
+    height: ${MIN_ROW_HEIGHT};
+    align-items: center;
+`;
+
+export const Content = styled.div`
+    display: flex;
+    flex: 1;
+    overflow: hidden;
+    flex-direction: column;
+    font-variant-numeric: tabular-nums;
+    /* workarounds for nice blur effect without cutoffs even inside parent with overflow: hidden */
+    padding-left: 10px;
+    margin-left: -10px;
+    padding-right: 10px;
+    margin-right: -10px;
+    margin-top: -10px;
+    padding-top: 10px;
+`;
+
+export const Description = styled(props => <HiddenPlaceholder {...props} />)`
+    color: ${props => props.theme.TYPE_DARK_GREY};
+    font-size: ${variables.FONT_SIZE.NORMAL};
+    font-weight: ${variables.FONT_WEIGHT.MEDIUM};
+    line-height: 1.5;
+    display: flex;
+    justify-content: space-between;
+    overflow: hidden;
+    white-space: nowrap;
+`;
+
+export const NextRow = styled.div`
+    display: flex;
+    flex: 1;
+    align-items: flex-start;
+    margin-bottom: 6px;
+`;
+
+export const TargetsWrapper = styled.div`
+    display: flex;
+    flex-direction: column;
+    flex: 1;
+    overflow: hidden;
+    padding-right: 10px;
+    margin-right: -10px;
+`;

--- a/packages/suite/src/components/wallet/TransactionItem/components/Target.tsx
+++ b/packages/suite/src/components/wallet/TransactionItem/components/Target.tsx
@@ -22,7 +22,7 @@ import { copyToClipboard } from '@trezor/dom-utils';
 import { AccountMetadata } from '@suite-types/metadata';
 import { ExtendedMessageDescriptor } from '@suite-types';
 
-const StyledCryptoAmount = styled(FormattedCryptoAmount)`
+export const StyledCryptoAmount = styled(FormattedCryptoAmount)`
     width: 100%;
     color: ${({ theme }) => theme.TYPE_DARK_GREY};
     font-size: ${variables.FONT_SIZE.NORMAL};

--- a/packages/suite/src/components/wallet/TransactionItem/index.tsx
+++ b/packages/suite/src/components/wallet/TransactionItem/index.tsx
@@ -2,8 +2,8 @@
 import React, { useState } from 'react';
 import styled, { css } from 'styled-components';
 import { AnimatePresence } from 'framer-motion';
-import { variables, Button } from '@trezor/components';
-import { Translation, HiddenPlaceholder } from '@suite-components';
+import { variables, Button, Card } from '@trezor/components';
+import { Translation } from '@suite-components';
 import { useActions } from '@suite-hooks';
 import * as modalActions from '@suite-actions/modalActions';
 import { formatNetworkAmount, isTestnet, isTxUnknown } from '@suite-common/wallet-utils';
@@ -11,7 +11,6 @@ import { AccountMetadata } from '@suite-types/metadata';
 import { WalletAccountTransaction } from '@wallet-types';
 import { TransactionTypeIcon } from './components/TransactionTypeIcon';
 import { TransactionHeading } from './components/TransactionHeading';
-import { MIN_ROW_HEIGHT } from './components/BaseTargetLayout';
 import {
     Target,
     TokenTransfer,
@@ -20,40 +19,27 @@ import {
     DepositRow,
     CoinjoinRow,
 } from './components/Target';
+import {
+    Content,
+    Description,
+    NextRow,
+    TargetsWrapper,
+    TimestampWrapper,
+    TxTypeIconWrapper,
+} from './components/CommonComponents';
 import { useAnchor } from '@suite-hooks/useAnchor';
 import { AccountTransactionBaseAnchor } from '@suite-constants/anchors';
 import { SECONDARY_PANEL_HEIGHT } from '@suite-components/AppNavigation';
 import { anchorOutlineStyles } from '@suite-utils/anchor';
 import { TransactionTimestamp } from '@wallet-components/TransactionTimestamp';
 
-const Wrapper = styled.div<{
-    chainedTxMode?: boolean;
+const Wrapper = styled(Card)<{
     isPending?: boolean;
     shouldHighlight?: boolean;
 }>`
     display: flex;
     flex-direction: row;
     padding: 0 24px;
-    background: ${props => props.theme.BG_WHITE};
-
-    ${props =>
-        props.chainedTxMode
-            ? css`
-                  width: 100%;
-                  padding: 0px 40px;
-                  cursor: pointer;
-                  &:hover {
-                      border-radius: 8px;
-                      background: ${props => props.theme.BG_GREY};
-                  }
-              `
-            : css`
-                  &:not(:first-child) {
-                      > * {
-                          border-top: 1px solid ${props => props.theme.STROKE_GREY};
-                      }
-                  }
-              `}
 
     @media (max-width: ${variables.SCREEN_SIZE.SM}) {
         padding: 0px 16px;
@@ -70,18 +56,6 @@ const Wrapper = styled.div<{
             }
         `}
 
-    &:first-of-type {
-        padding-top: 12px;
-        border-top-left-radius: 12px;
-        border-top-right-radius: 12px;
-    }
-
-    &:last-of-type {
-        padding-bottom: 12px;
-        border-bottom-left-radius: 12px;
-        border-bottom-right-radius: 12px;
-    }
-
     /* height of secondary panel and a gap between transactions and graph */
     scroll-margin-top: calc(${SECONDARY_PANEL_HEIGHT} + 115px);
 
@@ -92,65 +66,6 @@ const Body = styled.div`
     display: flex;
     width: 100%;
     padding: 12px 0;
-`;
-
-const TxTypeIconWrapper = styled.div`
-    padding-right: 24px;
-    margin-top: 8px;
-    cursor: pointer;
-
-    @media (max-width: ${variables.SCREEN_SIZE.SM}) {
-        display: none;
-    }
-`;
-
-const TimestampWrapper = styled.div`
-    cursor: pointer;
-    display: flex;
-    height: ${MIN_ROW_HEIGHT};
-    align-items: center;
-`;
-
-const Content = styled.div`
-    display: flex;
-    flex: 1;
-    overflow: hidden;
-    flex-direction: column;
-    font-variant-numeric: tabular-nums;
-    /* workarounds for nice blur effect without cutoffs even inside parent with overflow: hidden */
-    padding-left: 10px;
-    margin-left: -10px;
-    padding-right: 10px;
-    margin-right: -10px;
-    margin-top: -10px;
-    padding-top: 10px;
-`;
-
-const Description = styled(props => <HiddenPlaceholder {...props} />)`
-    color: ${props => props.theme.TYPE_DARK_GREY};
-    font-size: ${variables.FONT_SIZE.NORMAL};
-    font-weight: ${variables.FONT_WEIGHT.MEDIUM};
-    line-height: 1.5;
-    display: flex;
-    justify-content: space-between;
-    overflow: hidden;
-    white-space: nowrap;
-`;
-
-const NextRow = styled.div`
-    display: flex;
-    flex: 1;
-    align-items: flex-start;
-    margin-bottom: 6px;
-`;
-
-const TargetsWrapper = styled.div`
-    display: flex;
-    flex-direction: column;
-    flex: 1;
-    overflow: hidden;
-    padding-right: 10px;
-    margin-right: -10px;
 `;
 
 const ExpandButton = styled(Button)`
@@ -170,6 +85,7 @@ interface TransactionItemProps {
     isActionDisabled?: boolean; // Used in "chained transactions" transaction detail modal
     accountMetadata?: AccountMetadata;
     accountKey: string;
+    className?: string;
 }
 
 const TransactionItem = React.memo(
@@ -179,6 +95,7 @@ const TransactionItem = React.memo(
         accountMetadata,
         isActionDisabled,
         isPending,
+        className,
     }: TransactionItemProps) => {
         const { type, targets, tokens } = transaction;
         const [limit, setLimit] = useState(0);
@@ -237,10 +154,10 @@ const TransactionItem = React.memo(
             <Wrapper
                 onMouseEnter={() => setTxItemIsHovered(true)}
                 onMouseLeave={() => setTxItemIsHovered(false)}
-                chainedTxMode={isActionDisabled}
                 isPending={isPending}
                 ref={anchorRef}
                 shouldHighlight={shouldHighlight}
+                className={className}
             >
                 <Body>
                     <TxTypeIconWrapper

--- a/packages/suite/src/support/messages.ts
+++ b/packages/suite/src/support/messages.ts
@@ -3284,6 +3284,10 @@ export default defineMessages({
         defaultMessage: '{inMy} out of {in} inputs, {outMy} out of {out} outputs',
         id: 'TR_JOINT_TRANSACTION_TARGET',
     },
+    TR_COINJOIN_TRANSACTION_BATCH: {
+        defaultMessage: 'CoinJoin transactions',
+        id: 'TR_COINJOIN_TRANSACTION_BATCH',
+    },
     TR_UNKNOWN_ERROR_SEE_CONSOLE: {
         defaultMessage: 'Unknown error. See console logs for details.',
         id: 'TR_UNKNOWN_ERROR_SEE_CONSOLE',

--- a/packages/suite/src/support/messages.ts
+++ b/packages/suite/src/support/messages.ts
@@ -5909,6 +5909,14 @@ export default defineMessages({
         id: 'TR_INPUTS_OUTPUTS',
         defaultMessage: 'Inputs, Outputs',
     },
+    TR_MY_INPUTS_AND_OUTPUTS: {
+        id: 'TR_MY_INPUTS_AND_OUTPUTS',
+        defaultMessage: 'My inputs and outputs',
+    },
+    TR_OTHER_INPUTS_AND_OUTPUTS: {
+        id: 'TR_OTHER_INPUTS_AND_OUTPUTS',
+        defaultMessage: 'Other input and outputs',
+    },
     TR_CHAINED_TXS: {
         id: 'TR_CHAINED_TXS',
         defaultMessage: 'Chained transactions',

--- a/packages/suite/src/views/wallet/transactions/components/TransactionList/components/TransactionsGroup/index.tsx
+++ b/packages/suite/src/views/wallet/transactions/components/TransactionList/components/TransactionsGroup/index.tsx
@@ -11,6 +11,10 @@ const TransactionsGroupWrapper = styled.div`
     & + & {
         margin-top: 36px;
     }
+
+    > * + * {
+        margin-top: 8px;
+    }
 `;
 
 interface Props {

--- a/suite-common/wallet-utils/src/__tests__/transactionUtils.test.ts
+++ b/suite-common/wallet-utils/src/__tests__/transactionUtils.test.ts
@@ -12,6 +12,7 @@ import {
     getAccountTransactions,
     getRbfParams,
     groupTransactionsByDate,
+    groupJointTransactions,
     isPending,
     parseDateKey,
 } from '../transactionUtils';
@@ -54,6 +55,35 @@ describe('transaction utils', () => {
                 testMocks.getWalletTransaction({ blockTime: 1565792379, blockHeight: 4 }),
             ],
         });
+    });
+
+    it('groupJointTransactions', () => {
+        const [j1, r2, j3, j4, s5, s6, j7, f8, j9, j10, j11] = (
+            [
+                'joint',
+                'recv',
+                'joint',
+                'joint',
+                'sent',
+                'sent',
+                'joint',
+                'failed',
+                'joint',
+                'joint',
+                'joint',
+            ] as const
+        ).map((type, blockHeight) => testMocks.getWalletTransaction({ type, blockHeight }));
+        const groupedTxs = groupJointTransactions([j1, r2, j3, j4, s5, s6, j7, f8, j9, j10, j11]);
+        expect(groupedTxs).toEqual([
+            { type: 'single-tx', tx: j1 },
+            { type: 'single-tx', tx: r2 },
+            { type: 'joint-batch', rounds: [j3, j4] },
+            { type: 'single-tx', tx: s5 },
+            { type: 'single-tx', tx: s6 },
+            { type: 'single-tx', tx: j7 },
+            { type: 'single-tx', tx: f8 },
+            { type: 'joint-batch', rounds: [j9, j10, j11] },
+        ]);
     });
 
     fixtures.analyzeTransactions.forEach(f => {

--- a/suite-common/wallet-utils/src/transactionUtils.ts
+++ b/suite-common/wallet-utils/src/transactionUtils.ts
@@ -71,6 +71,21 @@ export const groupTransactionsByDate = (transactions: WalletAccountTransaction[]
             };
         }, {});
 
+export const groupJointTransactions = (transactions: WalletAccountTransaction[]) =>
+    transactions
+        .reduce<WalletAccountTransaction[][]>((prev, tx) => {
+            const last = prev.pop();
+            if (!last) return [[tx]];
+            return tx.type === 'joint' && last[0].type === 'joint'
+                ? [...prev, [...last, tx]]
+                : [...prev, last, [tx]];
+        }, [])
+        .map(txs =>
+            txs.length > 1
+                ? ({ type: 'joint-batch', rounds: txs } as const)
+                : ({ type: 'single-tx', tx: txs[0] } as const),
+        );
+
 export const formatCardanoWithdrawal = (tx: WalletAccountTransaction) =>
     tx.cardanoSpecific?.withdrawal
         ? formatNetworkAmount(tx.cardanoSpecific.withdrawal, tx.symbol)


### PR DESCRIPTION
## Description

Batching of consecutive coinjoin transactions in transaction list and separating owned and non-owned inputs and outputs in joint transaction detail.

https://github.com/trezor/trezor-suite/commit/c0306ec132d4c043f5d33222103ee815a3887265 - refactoring, `groupTransactionsByDate` util should be better readable
https://github.com/trezor/trezor-suite/commit/8809279fdcfd3cf0435bb306684d4465f56b58cc - implementing util which batches consecutive `joint` txs in an array
https://github.com/trezor/trezor-suite/commit/5d4404f0635853c817eef7b062ce178480ecc8ef - allows to restyle `Card` component; small optimization of `CollapsibleBox` animation; restylable `CollapsibleBox` subcomponents
https://github.com/trezor/trezor-suite/commit/a09757f36f2bbb058515f881791b50503366c687 - transactions are now separate `Card`s even in a single day; shared components are extracted from `TransactionItem` into `CommonComponents`; consecutive `joint` txs are now batched into new `CoinjoinBatchItem` component
https://github.com/trezor/trezor-suite/commit/68dc7fb83dd7a7d450592c17a83aee814ba27afc - tx inputs and outputs in `IODetails` are now presented in a css grid and therefore better aligned; discreet mode blur fixed a bit in `IODetails` 
https://github.com/trezor/trezor-suite/commit/333ef536b7dc1c82a19a4728a316df6b3567e611 - inputs and outputs in `IODetails` are now (only for `joint` transactions) separated into two collapsible boxes based on whether they're owned by the selected account
https://github.com/trezor/trezor-suite/pull/6580/commits/0f088ee832f4736f38bfd443a94e0b67c3ec55fc - fixes #6597

## Related Issue

Resolve #6211
Resolve #6597

## Screenshots
![image](https://user-images.githubusercontent.com/26326960/196194491-f2a1723d-8640-47fc-a545-a96cadf15f0f.png)
![image](https://user-images.githubusercontent.com/26326960/196194688-56df86a2-443f-4bd7-997b-65df0f2167ac.png)
