### PR TITLE
fix(suite-common): Immutable array for sorting

### DIFF
--- a/suite-common/wallet-utils/src/transactionUtils.ts
+++ b/suite-common/wallet-utils/src/transactionUtils.ts
@@ -48,26 +48,29 @@ export const groupTransactionsByDate = (
     const r: { [key: string]: WalletAccountTransaction[] } = {};
     // Note: We should use ts-belt for sorting this array but currently, there can be undefined inside
     // Built-in sort doesn't include undefined elements but ts-belt does so there will be some refactoring involved.
-    [...transactions].sort(sortByBlockHeight).forEach(item => {
-        let key = 'pending';
-        if (item.blockHeight && item.blockHeight > 0 && item.blockTime && item.blockTime > 0) {
-            const t = item.blockTime * 1000;
-            const d = new Date(t);
-            if (d) {
-                // YYYY-MM-DD format
-                key = `${d.getFullYear()}-${d.getMonth() + 1}-${d.getDate()}`;
-            } else {
-                // eslint-disable-next-line no-console
-                console.log(
-                    `Error during grouping transaction by date. Failed timestamp conversion (${t})`,
-                );
+    transactions
+        .slice()
+        .sort(sortByBlockHeight)
+        .forEach(item => {
+            let key = 'pending';
+            if (item.blockHeight && item.blockHeight > 0 && item.blockTime && item.blockTime > 0) {
+                const t = item.blockTime * 1000;
+                const d = new Date(t);
+                if (d) {
+                    // YYYY-MM-DD format
+                    key = `${d.getFullYear()}-${d.getMonth() + 1}-${d.getDate()}`;
+                } else {
+                    // eslint-disable-next-line no-console
+                    console.log(
+                        `Error during grouping transaction by date. Failed timestamp conversion (${t})`,
+                    );
+                }
             }
-        }
-        if (!r[key]) {
-            r[key] = [];
-        }
-        r[key].push(item);
-    });
+            if (!r[key]) {
+                r[key] = [];
+            }
+            r[key].push(item);
+        });
     return r;
 };
 

--- a/suite-common/wallet-utils/src/transactionUtils.ts
+++ b/suite-common/wallet-utils/src/transactionUtils.ts
@@ -46,7 +46,7 @@ export const groupTransactionsByDate = (
     transactions: WalletAccountTransaction[],
 ): { [key: string]: WalletAccountTransaction[] } => {
     const r: { [key: string]: WalletAccountTransaction[] } = {};
-    transactions.sort(sortByBlockHeight).forEach(item => {
+    [...transactions].sort(sortByBlockHeight).forEach(item => {
         let key = 'pending';
         if (item.blockHeight && item.blockHeight > 0 && item.blockTime && item.blockTime > 0) {
             const t = item.blockTime * 1000;

--- a/suite-common/wallet-utils/src/transactionUtils.ts
+++ b/suite-common/wallet-utils/src/transactionUtils.ts
@@ -46,6 +46,8 @@ export const groupTransactionsByDate = (
     transactions: WalletAccountTransaction[],
 ): { [key: string]: WalletAccountTransaction[] } => {
     const r: { [key: string]: WalletAccountTransaction[] } = {};
+    // Note: We should use ts-belt for sorting this array but currently, there can be undefined inside
+    // Built-in sort doesn't include undefined elements but ts-belt does so there will be some refactoring involved.
     [...transactions].sort(sortByBlockHeight).forEach(item => {
         let key = 'pending';
         if (item.blockHeight && item.blockHeight > 0 && item.blockTime && item.blockTime > 0) {


### PR DESCRIPTION
## Description
Make transactions array immutable to avoid assigning to read-only property in mobile app. 
