### PR TITLE
Feat/coinjoin cherry picks

### DIFF
--- a/packages/blockchain-link/src/types/common.ts
+++ b/packages/blockchain-link/src/types/common.ts
@@ -134,6 +134,9 @@ export interface AccountAddresses {
     change: Address[];
     used: Address[];
     unused: Address[];
+    // NOTE: anonymitySet currently is not calculated by @trezor/blockchain-link
+    // format: key -> address, value -> anonymityLevel
+    anonymitySet?: Record<string, number | undefined>;
 }
 
 export interface Utxo {

--- a/packages/suite-desktop/src/modules/coinjoin.ts
+++ b/packages/suite-desktop/src/modules/coinjoin.ts
@@ -83,6 +83,12 @@ export const init: Module = ({ mainWindow }) => {
         );
 
         const dispose = () => {
+            backends.forEach(b => b.cancel());
+            backends.splice(0, backends.length);
+
+            clients.forEach(c => c.disable());
+            clients.splice(0, clients.length);
+
             unregisterBackendProxy();
             unregisterClientProxy();
         };

--- a/packages/suite/src/actions/wallet/__tests__/coinjoinAccountActions.test.ts
+++ b/packages/suite/src/actions/wallet/__tests__/coinjoinAccountActions.test.ts
@@ -30,6 +30,7 @@ jest.mock('@suite/services/coinjoin/coinjoinClient', () => {
                     enable: jest.fn(() => Promise.reject(new Error('Client not supported'))),
                 };
             },
+            removeInstance: jest.fn(),
         },
     };
 });
@@ -43,6 +44,7 @@ jest.mock('@suite/services/coinjoin/coinjoinBackend', () =>
                 off: jest.fn(),
                 scanAccount: jest.fn(() => Promise.reject(new Error('TODO'))),
             }),
+            removeInstance: jest.fn(),
         },
     }),
 );

--- a/packages/suite/src/actions/wallet/coinjoinAccountActions.ts
+++ b/packages/suite/src/actions/wallet/coinjoinAccountActions.ts
@@ -179,15 +179,15 @@ export const createCoinjoinAccount =
             throw new Error('createCoinjoinAccount: invalid account type');
         }
 
-        // initialize @trezor/coinjoin backend
-        if (!CoinjoinBackendService.getInstance(network.symbol)) {
-            await CoinjoinBackendService.createInstance(network.symbol);
-        }
-
         // initialize @trezor/coinjoin client
         const client = await dispatch(initCoinjoinClient(network.symbol));
         if (!client) {
             return;
+        }
+
+        // initialize @trezor/coinjoin backend
+        if (!CoinjoinBackendService.getInstance(network.symbol)) {
+            await CoinjoinBackendService.createInstance(network.symbol);
         }
 
         const { device } = getState().suite;

--- a/packages/suite/src/actions/wallet/coinjoinAccountActions.ts
+++ b/packages/suite/src/actions/wallet/coinjoinAccountActions.ts
@@ -3,7 +3,12 @@ import type { ScanAccountProgress } from '@trezor/coinjoin/lib/types/backend';
 import * as COINJOIN from './constants/coinjoinConstants';
 import { goto } from '../suite/routerActions';
 import { addToast } from '../suite/notificationActions';
-import { initCoinjoinClient, getCoinjoinClient, clientDisable } from './coinjoinClientActions';
+import {
+    initCoinjoinClient,
+    getCoinjoinClient,
+    clientDisable,
+    analyzeTransactions,
+} from './coinjoinClientActions';
 import { CoinjoinBackendService } from '@suite/services/coinjoin/coinjoinBackend';
 import { CoinjoinClientService } from '@suite/services/coinjoin/coinjoinClient';
 import { Dispatch, GetState } from '@suite-types';
@@ -142,7 +147,12 @@ export const fetchAndUpdateAccount =
 
             // TODO add isPending check?
             if (isAccountOutdated(account, accountInfo) || isInitialUpdate) {
-                dispatch(accountsActions.updateAccount(account, accountInfo));
+                // calculate account anonymity set in CoinjoinClient
+                const accountInfoWithAnonymitySet = await dispatch(
+                    analyzeTransactions(accountInfo),
+                );
+
+                dispatch(accountsActions.updateAccount(account, accountInfoWithAnonymitySet));
             }
 
             // TODO remove invalid transactions

--- a/packages/suite/src/actions/wallet/coinjoinClientActions.ts
+++ b/packages/suite/src/actions/wallet/coinjoinClientActions.ts
@@ -61,6 +61,7 @@ export const initCoinjoinClient = (symbol: Account['symbol']) => async (dispatch
         dispatch(clientEnableSuccess(symbol, status));
         return client;
     } catch (error) {
+        CoinjoinClientService.removeInstance(symbol);
         dispatch(clientEnableFailed(symbol));
         dispatch(
             addToast({

--- a/suite-common/wallet-types/src/account.ts
+++ b/suite-common/wallet-types/src/account.ts
@@ -46,10 +46,6 @@ type AccountNetworkSpecific =
           page: AccountInfo['page'];
       };
 
-export interface AddressesWithAnonymity extends NonNullable<AccountInfo['addresses']> {
-    anonymitySet?: Record<string, number | undefined>; // key -> address, value -> anonymity
-}
-
 // decides if account is using TrezorConnect/blockchain-link or other non-standard api
 export type AccountBackendSpecific =
     | {
@@ -78,7 +74,7 @@ export type Account = {
     availableBalance: string;
     formattedBalance: string;
     tokens: AccountInfo['tokens'];
-    addresses?: AddressesWithAnonymity;
+    addresses?: AccountInfo['addresses'];
     utxo: AccountInfo['utxo'];
     history: AccountInfo['history'];
     metadata: AccountMetadata;

--- a/suite-common/wallet-utils/src/accountUtils.ts
+++ b/suite-common/wallet-utils/src/accountUtils.ts
@@ -368,7 +368,7 @@ export const enhanceAddresses = (
     const unused = addresses.unused.map(replaceAccountIndex);
     const change = addresses.change.map(replaceAccountIndex);
 
-    return { used, unused, change };
+    return { used, unused, change, anonymitySet: addresses.anonymitySet };
 };
 
 export const enhanceUtxo = (


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Few cherry picks from [coinjoin PR](https://github.com/trezor/trezor-suite/pull/6485)

- restored `anonymitySet` "calculation", it went missing after merge of [coinjoin discovery pr](https://github.com/trezor/trezor-suite/pull/6068)
  Real implementation of `CoinjoinClient.analyzeTransactions` is on the way
  
- dispose and clear initialized CoinjoinClient/CoinjoinBackend instances on renrerer reload (Ctrl + R) in desktop

- change remove `CoinjoinClient` instance if it fail to initialize (catch error from desktop initialization). Prerequisite for [middleware pr](https://github.com/trezor/trezor-suite/pull/6528)
