### PR TITLE
Fix transaction list styles

### DIFF
--- a/suite-native/module-accounts/package.json
+++ b/suite-native/module-accounts/package.json
@@ -21,7 +21,6 @@
         "@suite-common/wallet-utils": "*",
         "@suite-native/accounts": "*",
         "@suite-native/atoms": "*",
-        "@suite-native/graph": "*",
         "@suite-native/navigation": "*",
         "@suite-native/transactions": "*",
         "@trezor/icons": "*",

--- a/suite-native/module-accounts/src/components/AccountDetailHeader.tsx
+++ b/suite-native/module-accounts/src/components/AccountDetailHeader.tsx
@@ -1,6 +1,5 @@
 import React, { memo } from 'react';
 
-import { Graph } from '@suite-native/graph';
 import { AccountBalance } from '@suite-native/accounts';
 import { Box, Text } from '@suite-native/atoms';
 import { AccountKey } from '@suite-common/suite-types';
@@ -13,7 +12,6 @@ type AccountDetailHeaderProps = {
 export const AccountDetailHeader = memo(({ accountKey, accountName }: AccountDetailHeaderProps) => (
     <>
         <AccountBalance accountKey={accountKey} accountName={accountName} />
-        <Graph points={[]} />
         <Box marginBottom="large">
             <Text variant="titleSmall">Transactions</Text>
         </Box>

--- a/suite-native/module-accounts/tsconfig.json
+++ b/suite-native/module-accounts/tsconfig.json
@@ -19,7 +19,6 @@
         },
         { "path": "../accounts" },
         { "path": "../atoms" },
-        { "path": "../graph" },
         { "path": "../navigation" },
         { "path": "../transactions" },
         { "path": "../../packages/icons" },

--- a/suite-native/transactions/src/components/TransactionsList/TransactionList.tsx
+++ b/suite-native/transactions/src/components/TransactionsList/TransactionList.tsx
@@ -20,6 +20,9 @@ type AccountTransactionProps = {
 
 export const TX_PER_PAGE = 25;
 
+// NOTE: This is due to Box wrapper that is set by isScrollable prop in suite-native/module-accounts/src/screens/AccountDetailScreen.tsx
+// The box doesn't seem to be stopped visually by tab bar and SectionList cmp cannot be inside ScrollView cmp
+// That's why we add padding bottom to avoid style clash.
 const listWrapperStyle = prepareNativeStyle(_ => ({
     paddingBottom: TAB_BAR_HEIGHT,
 }));
@@ -91,7 +94,6 @@ export const TransactionList = ({
     if (isLoadingTransactions)
         // TODO Temporary loading state just so it's visible that transactions are loading
         return <ActivityIndicator size="large" color={utils.colors.forest} />;
-
 
     return (
         <Box style={applyStyle(listWrapperStyle)}>

--- a/suite-native/transactions/src/components/TransactionsList/TransactionList.tsx
+++ b/suite-native/transactions/src/components/TransactionsList/TransactionList.tsx
@@ -2,11 +2,12 @@ import React, { useCallback, useEffect, useMemo, useState } from 'react';
 import { ActivityIndicator, SectionList } from 'react-native';
 import { useSelector } from 'react-redux';
 
-import { useNativeStyles } from '@trezor/styles';
+import { useNativeStyles, prepareNativeStyle } from '@trezor/styles';
 import { WalletAccountTransaction } from '@suite-common/wallet-types';
 import { groupTransactionsByDate } from '@suite-common/wallet-utils';
 import { selectIsLoadingTransactions } from '@suite-common/wallet-core';
-import { Text } from '@suite-native/atoms';
+import { Text, Box } from '@suite-native/atoms';
+import { TAB_BAR_HEIGHT } from '@suite-native/navigation';
 
 import { TransactionListGroupTitle } from './TransactionListGroupTitle';
 import { TransactionListItem } from './TransactionListItem';
@@ -19,12 +20,16 @@ type AccountTransactionProps = {
 
 export const TX_PER_PAGE = 25;
 
+const listWrapperStyle = prepareNativeStyle(_ => ({
+    paddingBottom: TAB_BAR_HEIGHT,
+}));
+
 export const TransactionList = ({
     transactions,
     listHeaderComponent,
     fetchMoreTransactions,
 }: AccountTransactionProps) => {
-    const { utils } = useNativeStyles();
+    const { applyStyle, utils } = useNativeStyles();
     const isLoadingTransactions = useSelector(selectIsLoadingTransactions);
     const accountTransactionsByDate = useMemo(
         () => groupTransactionsByDate(transactions),
@@ -87,14 +92,17 @@ export const TransactionList = ({
         // TODO Temporary loading state just so it's visible that transactions are loading
         return <ActivityIndicator size="large" color={utils.colors.forest} />;
 
+
     return (
-        <SectionList
-            sections={sectionsData}
-            renderSectionHeader={renderSectionHeader}
-            renderItem={renderItem}
-            ListHeaderComponent={listHeaderComponent}
-            ListEmptyComponent={<Text>No transactions.</Text>}
-            onEndReached={handleOnEndReached}
-        />
+        <Box style={applyStyle(listWrapperStyle)}>
+            <SectionList
+                sections={sectionsData}
+                renderSectionHeader={renderSectionHeader}
+                renderItem={renderItem}
+                ListHeaderComponent={listHeaderComponent}
+                ListEmptyComponent={<Text>No transactions.</Text>}
+                onEndReached={handleOnEndReached}
+            />
+        </Box>
     );
 };

--- a/yarn.lock
+++ b/yarn.lock
@@ -6640,7 +6640,6 @@ __metadata:
     "@suite-common/wallet-utils": "*"
     "@suite-native/accounts": "*"
     "@suite-native/atoms": "*"
-    "@suite-native/graph": "*"
     "@suite-native/navigation": "*"
     "@suite-native/transactions": "*"
     "@trezor/icons": "*"


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
There was empty graph that was blocking half of the screen with no empty state and it was ugly for now, so let's add it when data is applied to the graph.

Added padding bottom to transaction list wrapper to avoid last transaction from being hidden behind bottom tab bar. 

## Screenshots (if appropriate):
Before: 
<img width="326" alt="image" src="https://user-images.githubusercontent.com/36101761/196609014-53264f5f-708f-4ca8-a500-bbdb5bd871e0.png">

After: 
<img width="325" alt="image" src="https://user-images.githubusercontent.com/36101761/196608928-6d56b236-8481-4d51-ae6c-325bd73e797c.png">

