### PR TITLE
Add low anonymity warnings to coinjoin account send form

### DIFF
--- a/packages/components/src/components/Warning/Warning.tsx
+++ b/packages/components/src/components/Warning/Warning.tsx
@@ -1,9 +1,10 @@
 import React from 'react';
 import styled from 'styled-components';
-import { darken, transparentize } from 'polished';
+import { transparentize } from 'polished';
 
 import { Icon } from '../Icon';
 import { useTheme } from '../../utils';
+import { variables } from '../../config';
 
 const Wrapper = styled.div<Pick<WarningProps, 'critical' | 'withIcon'>>`
     align-items: center;
@@ -12,14 +13,15 @@ const Wrapper = styled.div<Pick<WarningProps, 'critical' | 'withIcon'>>`
     border-radius: 8px;
     color: ${({ critical, theme }) => (critical ? theme.TYPE_DARK_GREY : theme.TYPE_DARK_ORANGE)};
     display: flex;
-    font-weight: 500;
+    font-size: ${variables.FONT_SIZE.SMALL};
+    font-weight: ${variables.FONT_WEIGHT.MEDIUM};
     justify-content: ${({ withIcon }) => !withIcon && 'center'};
-    padding: 10px 12px;
+    padding: 14px 20px;
     width: 100%;
 `;
 
 const StyledIcon = styled(Icon)`
-    margin-right: 8px;
+    margin-right: 14px;
 `;
 
 interface WarningProps {
@@ -36,7 +38,7 @@ export const Warning = ({ children, className, critical, withIcon }: WarningProp
 
     return (
         <Wrapper critical={critical} withIcon={withIcon} className={className}>
-            {withIcon && <StyledIcon size={18} icon="WARNING" color={iconColor} />}
+            {withIcon && <StyledIcon size={20} icon="WARNING" color={iconColor} />}
             {children}
         </Wrapper>
     );

--- a/packages/components/src/components/buttons/TooltipButton.tsx/index.tsx
+++ b/packages/components/src/components/buttons/TooltipButton.tsx/index.tsx
@@ -18,11 +18,13 @@ const InfoIcon = styled(Icon)`
 `;
 
 export interface TooltipButtonProps extends ButtonProps {
+    interactiveTooltip?: boolean;
     tooltipContent: React.ReactNode;
 }
 
 export const TooltipButton = ({
     tooltipContent,
+    interactiveTooltip = false,
     isDisabled,
     children,
     ...buttonProps
@@ -30,7 +32,7 @@ export const TooltipButton = ({
     const theme = useTheme();
 
     return (
-        <Tooltip maxWidth={285} content={tooltipContent} interactive={false}>
+        <Tooltip maxWidth={285} content={tooltipContent} interactive={interactiveTooltip}>
             <StyledButton isDisabled={isDisabled} {...buttonProps}>
                 {tooltipContent && (
                     <InfoIcon

--- a/packages/components/src/components/form/Checkbox/index.tsx
+++ b/packages/components/src/components/form/Checkbox/index.tsx
@@ -17,7 +17,9 @@ const Wrapper = styled.div<Pick<CheckboxProps, 'isDisabled'>>`
     }
 `;
 
-const IconWrapper = styled.div<Pick<CheckboxProps, 'isChecked' | 'isDisabled'>>`
+const IconWrapper = styled.div<
+    Pick<CheckboxProps, 'isChecked' | 'isDisabled'> & { $color?: string }
+>`
     display: flex;
     justify-content: center;
     align-items: center;
@@ -26,9 +28,11 @@ const IconWrapper = styled.div<Pick<CheckboxProps, 'isChecked' | 'isDisabled'>>`
     max-width: 24px;
     height: 24px;
     border-radius: 4px;
-    background: ${({ theme, isChecked }) => (isChecked ? theme.BG_GREEN : theme.BG_WHITE)};
+    background: ${({ $color, isChecked, theme }) =>
+        isChecked ? $color || theme.BG_GREEN : theme.BG_WHITE};
     border: 2px solid
-        ${({ theme, isChecked }) => (isChecked ? theme.TYPE_GREEN : theme.STROKE_GREY)};
+        ${({ $color, isChecked, theme }) =>
+            isChecked ? $color || theme.BG_GREEN : theme.STROKE_GREY};
 
     :hover,
     :focus {
@@ -59,14 +63,22 @@ const handleKeyboard = (
 };
 
 export interface CheckboxProps extends React.HTMLAttributes<HTMLDivElement> {
+    color?: string;
+    isChecked?: boolean;
+    isDisabled?: boolean;
     onClick: (
         event: React.KeyboardEvent<HTMLElement> | React.MouseEvent<HTMLElement> | null,
     ) => any;
-    isChecked?: boolean;
-    isDisabled?: boolean;
 }
 
-export const Checkbox = ({ isChecked, isDisabled, children, onClick, ...rest }: CheckboxProps) => {
+export const Checkbox = ({
+    children,
+    color,
+    isChecked,
+    isDisabled,
+    onClick,
+    ...rest
+}: CheckboxProps) => {
     const theme = useTheme();
 
     const handleClick = isDisabled ? undefined : onClick;
@@ -79,7 +91,7 @@ export const Checkbox = ({ isChecked, isDisabled, children, onClick, ...rest }: 
             tabIndex={0}
             {...rest}
         >
-            <IconWrapper isChecked={isChecked} isDisabled={isDisabled}>
+            <IconWrapper $color={color} isChecked={isChecked} isDisabled={isDisabled}>
                 {isChecked && <Icon size={24} color={theme.TYPE_WHITE} icon="CHECK" />}
             </IconWrapper>
 

--- a/packages/suite-web/src/support/Router.tsx
+++ b/packages/suite-web/src/support/Router.tsx
@@ -122,20 +122,21 @@ const components: { [key: string]: React.LazyExoticComponent<any> } = {
 const AppRouter = () => (
     // inititating strict mode higher would throw an error from react-helmet
     // TODO: replace react-helmet with a maintained alternative
-    <React.StrictMode>
-        <Suspense fallback={<BundleLoader />}>
-            <Switch>
-                {routes.map(route => (
-                    <Route
-                        key={route.name}
-                        path={process.env.ASSET_PREFIX + route.pattern}
-                        exact={route.exact}
-                        component={components[route.name]}
-                    />
-                ))}
-            </Switch>
-        </Suspense>
-    </React.StrictMode>
+    // strict mode is commented out because of its interplay with compose errors in send form
+    // <React.StrictMode>
+    <Suspense fallback={<BundleLoader />}>
+        <Switch>
+            {routes.map(route => (
+                <Route
+                    key={route.name}
+                    path={process.env.ASSET_PREFIX + route.pattern}
+                    exact={route.exact}
+                    component={components[route.name]}
+                />
+            ))}
+        </Switch>
+    </Suspense>
+    // </React.StrictMode>
 );
 
 export default memo(AppRouter);

--- a/packages/suite/src/actions/wallet/send/sendFormBitcoinActions.ts
+++ b/packages/suite/src/actions/wallet/send/sendFormBitcoinActions.ts
@@ -173,11 +173,21 @@ export const composeTransaction =
                     tx.max = isSatoshis ? tx.max : formatNetworkAmount(tx.max, account.symbol);
                 }
             } else if (tx.error === 'NOT-ENOUGH-FUNDS') {
-                tx.errorMessage = {
-                    id: formValues.isCoinControlEnabled
+                const getErrorMessage = () => {
+                    const isLowAnonymity =
+                        account.accountType === 'coinjoin' &&
+                        !!Object.values(excludedUtxos).filter(reason => reason === 'low-anonymity')
+                            .length;
+
+                    if (isLowAnonymity && !formValues.isCoinControlEnabled) {
+                        return 'TR_NOT_ENOUGH_ANONYMIZED_FUNDS_WARNING';
+                    }
+                    return formValues.isCoinControlEnabled
                         ? 'TR_NOT_ENOUGH_SELECTED'
-                        : 'AMOUNT_IS_NOT_ENOUGH',
+                        : 'AMOUNT_IS_NOT_ENOUGH';
                 };
+
+                tx.errorMessage = { id: getErrorMessage() };
             } else {
                 // catch unexpected error
                 dispatch(

--- a/packages/suite/src/hooks/wallet/useBitcoinAmountUnit.ts
+++ b/packages/suite/src/hooks/wallet/useBitcoinAmountUnit.ts
@@ -30,7 +30,7 @@ export const useBitcoinAmountUnit = (symbol?: NetworkSymbol) => {
     return {
         bitcoinAmountUnit,
         areSatsDisplayed,
-        souldSendInSats:
+        shouldSendInSats:
             areSatsDisplayed && areUnitsSupportedByNetwork && areUnitsSupportedByDevice,
         toggleBitcoinAmountUnits,
         setBitcoinAmountUnits,

--- a/packages/suite/src/hooks/wallet/useCoinmarketBuyForm.ts
+++ b/packages/suite/src/hooks/wallet/useCoinmarketBuyForm.ts
@@ -59,7 +59,7 @@ export const useCoinmarketBuyForm = (props: UseCoinmarketBuyFormProps): BuyFormC
         exchangeCoinInfo: state.wallet.coinmarket.exchange.exchangeCoinInfo,
     }));
 
-    const { souldSendInSats } = useBitcoinAmountUnit(account.symbol);
+    const { shouldSendInSats } = useBitcoinAmountUnit(account.symbol);
     const { defaultValues, defaultCountry, defaultCurrency } = useCoinmarketBuyFormDefaultValues(
         account.symbol,
         buyInfo,
@@ -84,12 +84,12 @@ export const useCoinmarketBuyForm = (props: UseCoinmarketBuyFormProps): BuyFormC
         if (!cryptoInputValue) {
             return;
         }
-        const conversion = souldSendInSats ? amountToSatoshi : formatAmount;
+        const conversion = shouldSendInSats ? amountToSatoshi : formatAmount;
         setValue(CRYPTO_INPUT, conversion(cryptoInputValue, network.decimals), {
             shouldValidate: true,
             shouldDirty: true,
         });
-    }, [souldSendInSats]);
+    }, [shouldSendInSats]);
 
     const resetForm = useCallback(() => {
         reset({});
@@ -103,7 +103,7 @@ export const useCoinmarketBuyForm = (props: UseCoinmarketBuyFormProps): BuyFormC
             }
         },
         200,
-        [errors, saveDraft, account.key, values, souldSendInSats],
+        [errors, saveDraft, account.key, values, shouldSendInSats],
     );
     useEffect(() => {
         if (!isChanged(defaultValues, values)) {
@@ -115,7 +115,7 @@ export const useCoinmarketBuyForm = (props: UseCoinmarketBuyFormProps): BuyFormC
         const formValues = methods.getValues();
         const fiatStringAmount = formValues.fiatInput;
         const cryptoStringAmount =
-            formValues.cryptoInput && souldSendInSats
+            formValues.cryptoInput && shouldSendInSats
                 ? formatAmount(formValues.cryptoInput, network.decimals)
                 : formValues.cryptoInput;
         const wantCrypto = !fiatStringAmount;

--- a/packages/suite/src/hooks/wallet/useCoinmarketExchangeForm.ts
+++ b/packages/suite/src/hooks/wallet/useCoinmarketExchangeForm.ts
@@ -107,7 +107,7 @@ export const useCoinmarketExchangeForm = ({
     const { account, network } = selectedAccount;
     const { navigateToExchangeOffers } = useCoinmarketNavigation(account);
     const { symbol, networkType } = account;
-    const { souldSendInSats } = useBitcoinAmountUnit(symbol);
+    const { shouldSendInSats } = useBitcoinAmountUnit(symbol);
 
     const coinFees = fees[symbol];
     const levels = getFeeLevels(networkType, coinFees);
@@ -207,18 +207,18 @@ export const useCoinmarketExchangeForm = ({
             const currency: { value: string; label: string } | undefined = getValues(FIAT_CURRENCY);
             if (!fiatRates || !fiatRates.current || !currency) return;
             const cryptoAmount =
-                amount && souldSendInSats ? formatAmount(amount, network.decimals) : amount;
+                amount && shouldSendInSats ? formatAmount(amount, network.decimals) : amount;
             const fiatValue = toFiatCurrency(cryptoAmount, currency.value, fiatRates.current.rates);
             setValue(FIAT_INPUT, fiatValue || '', { shouldValidate: true });
         },
-        [souldSendInSats, fiatRates, getValues, network.decimals, setValue],
+        [shouldSendInSats, fiatRates, getValues, network.decimals, setValue],
     );
 
     const updateFiatCurrency = (currency: { label: string; value: string }) => {
         if (!fiatRates || !fiatRates.current || !currency) return;
         const amount = getValues(CRYPTO_INPUT) as string;
         const cryptoAmount =
-            amount && souldSendInSats ? formatAmount(amount, network.decimals) : amount;
+            amount && shouldSendInSats ? formatAmount(amount, network.decimals) : amount;
         const fiatValue = toFiatCurrency(cryptoAmount, currency.value, fiatRates.current.rates);
         if (fiatValue) {
             setValue(FIAT_INPUT, fiatValue, { shouldValidate: true });
@@ -235,7 +235,7 @@ export const useCoinmarketExchangeForm = ({
             decimals,
         );
         const formattedCryptoValue =
-            cryptoValue && souldSendInSats
+            cryptoValue && shouldSendInSats
                 ? amountToSatoshi(cryptoValue, network.decimals)
                 : cryptoValue || '';
 
@@ -302,20 +302,20 @@ export const useCoinmarketExchangeForm = ({
         if (!cryptoInputValue) {
             return;
         }
-        const conversion = souldSendInSats ? amountToSatoshi : formatAmount;
+        const conversion = shouldSendInSats ? amountToSatoshi : formatAmount;
         const cryptoAmount = conversion(cryptoInputValue, network.decimals);
         setValue(CRYPTO_INPUT, cryptoAmount, {
             shouldValidate: true,
             shouldDirty: true,
         });
         updateFiatValue(cryptoAmount);
-    }, [souldSendInSats]);
+    }, [shouldSendInSats]);
 
     const onSubmit = async () => {
         const formValues = getValues();
         const unformattedOutputAmount = formValues.outputs[0].amount || '';
         const sendStringAmount =
-            unformattedOutputAmount && souldSendInSats
+            unformattedOutputAmount && shouldSendInSats
                 ? formatAmount(unformattedOutputAmount, network.decimals)
                 : unformattedOutputAmount;
         const send = formValues.sendCryptoSelect.value.toUpperCase();

--- a/packages/suite/src/hooks/wallet/useCoinmarketExchangeOffers.ts
+++ b/packages/suite/src/hooks/wallet/useCoinmarketExchangeOffers.ts
@@ -40,7 +40,7 @@ export const useOffers = ({ selectedAccount }: UseCoinmarketExchangeFormProps) =
     const timer = useTimer();
     const { isLocked } = useDevice();
     const { account, network } = selectedAccount;
-    const { souldSendInSats } = useBitcoinAmountUnit(account.symbol);
+    const { shouldSendInSats } = useBitcoinAmountUnit(account.symbol);
     const [callInProgress, setCallInProgress] = useState<boolean>(isLocked() || false);
     const [selectedQuote, setSelectedQuote] = useState<ExchangeTrade>();
     const [receiveAccount, setReceiveAccount] = useState<Account | undefined>();
@@ -302,7 +302,7 @@ export const useOffers = ({ selectedAccount }: UseCoinmarketExchangeFormProps) =
             selectedQuote.sendAddress &&
             selectedQuote.sendStringAmount
         ) {
-            const sendStringAmount = souldSendInSats
+            const sendStringAmount = shouldSendInSats
                 ? amountToSatoshi(selectedQuote.sendStringAmount, network.decimals)
                 : selectedQuote.sendStringAmount;
             const result = await recomposeAndSign(

--- a/packages/suite/src/hooks/wallet/useCoinmarketSellForm.ts
+++ b/packages/suite/src/hooks/wallet/useCoinmarketSellForm.ts
@@ -108,7 +108,7 @@ export const useCoinmarketSellForm = ({
     const { account, network } = selectedAccount;
     const { navigateToSellOffers } = useCoinmarketNavigation(account);
     const { symbol, networkType } = account;
-    const { souldSendInSats } = useBitcoinAmountUnit(symbol);
+    const { shouldSendInSats } = useBitcoinAmountUnit(symbol);
 
     const coinFees = fees[symbol];
     const levels = getFeeLevels(networkType, coinFees);
@@ -255,7 +255,7 @@ export const useCoinmarketSellForm = ({
                 network.decimals,
             );
             const cryptoInputValue =
-                cryptoValue && souldSendInSats
+                cryptoValue && shouldSendInSats
                     ? amountToSatoshi(cryptoValue, network.decimals)
                     : cryptoValue;
             setValue(OUTPUT_AMOUNT, cryptoInputValue || '', { shouldDirty: true });
@@ -266,7 +266,7 @@ export const useCoinmarketSellForm = ({
             clearErrors,
             getValues,
             fiatRates,
-            souldSendInSats,
+            shouldSendInSats,
             network.decimals,
             composeRequest,
         ],
@@ -311,18 +311,18 @@ export const useCoinmarketSellForm = ({
         if (!cryptoInputValue) {
             return;
         }
-        const conversion = souldSendInSats ? amountToSatoshi : formatAmount;
+        const conversion = shouldSendInSats ? amountToSatoshi : formatAmount;
         setValue(CRYPTO_INPUT, conversion(cryptoInputValue, network.decimals), {
             shouldValidate: true,
             shouldDirty: true,
         });
-    }, [souldSendInSats]);
+    }, [shouldSendInSats]);
 
     const onSubmit = async () => {
         const formValues = getValues();
         const fiatStringAmount = formValues.fiatInput;
         const cryptoStringAmount =
-            formValues.cryptoInput && souldSendInSats
+            formValues.cryptoInput && shouldSendInSats
                 ? formatAmount(formValues.cryptoInput, network.decimals)
                 : formValues.cryptoInput;
         const amountInCrypto = !fiatStringAmount;

--- a/packages/suite/src/hooks/wallet/useCoinmarketSellOffers.ts
+++ b/packages/suite/src/hooks/wallet/useCoinmarketSellOffers.ts
@@ -21,7 +21,7 @@ export const useOffers = ({ selectedAccount }: UseOffersProps) => {
     const timer = useTimer();
 
     const { account, network } = selectedAccount;
-    const { souldSendInSats } = useBitcoinAmountUnit(account.symbol);
+    const { shouldSendInSats } = useBitcoinAmountUnit(account.symbol);
     const [callInProgress, setCallInProgress] = useState<boolean>(false);
     const [selectedQuote, setSelectedQuote] = useState<SellFiatTrade>();
 
@@ -255,7 +255,7 @@ export const useOffers = ({ selectedAccount }: UseOffersProps) => {
             destinationAddress &&
             selectedQuote.cryptoStringAmount
         ) {
-            const cryptoStringAmount = souldSendInSats
+            const cryptoStringAmount = shouldSendInSats
                 ? amountToSatoshi(selectedQuote.cryptoStringAmount, network.decimals)
                 : selectedQuote.cryptoStringAmount;
             const result = await recomposeAndSign(

--- a/packages/suite/src/hooks/wallet/useCoinmarketSpend.ts
+++ b/packages/suite/src/hooks/wallet/useCoinmarketSpend.ts
@@ -67,7 +67,7 @@ export const useCoinmarketSpend = ({
     const { translationString } = useTranslation();
 
     const { account, network } = selectedAccount;
-    const { souldSendInSats } = useBitcoinAmountUnit(account.symbol);
+    const { shouldSendInSats } = useBitcoinAmountUnit(account.symbol);
     const { sellInfo, language, fees } = useSelector(state => ({
         sellInfo: state.wallet.coinmarket.sell.sellInfo,
         language: state.suite.settings.language,
@@ -222,7 +222,7 @@ export const useCoinmarketSpend = ({
                                                 ...DEFAULT_PAYMENT,
                                                 address: trade.destinationAddress || '',
                                                 amount:
-                                                    trade.cryptoAmount && souldSendInSats
+                                                    trade.cryptoAmount && shouldSendInSats
                                                         ? amountToSatoshi(
                                                               trade.cryptoAmount.toString(),
                                                               network.decimals,
@@ -261,7 +261,7 @@ export const useCoinmarketSpend = ({
         provider,
         addNotification,
         composeRequest,
-        souldSendInSats,
+        shouldSendInSats,
         network.decimals,
     ]);
 

--- a/packages/suite/src/hooks/wallet/useSendForm.ts
+++ b/packages/suite/src/hooks/wallet/useSendForm.ts
@@ -68,11 +68,9 @@ const getStateFromProps = (props: UseSendFormProps) => {
         const coinjoinSession = props.coinjoinAccount?.session;
         const targetAnonymity = props.coinjoinAccount?.targetAnonymity || 1;
         const anonymitySet = account.addresses?.anonymitySet || {};
-        account.utxo?.forEach((utxo, i) => {
+        account.utxo?.forEach(utxo => {
             const outpoint = getUtxoOutpoint(utxo);
-            // uncomment to mock the first address having higher anonymity for testing purposes
-            const anonymity = i === 0 ? 80 : anonymitySet[utxo.address] || 1;
-            // const anonymity = anonymitySet[utxo.address] || 1;
+            const anonymity = anonymitySet[utxo.address] || 1;
             if (coinjoinSession && coinjoinSession.registeredUtxos.includes(outpoint)) {
                 // utxo is registered in coinjoin
                 excludedUtxos[outpoint] = 'mixing';

--- a/packages/suite/src/hooks/wallet/useSendFormCompose.ts
+++ b/packages/suite/src/hooks/wallet/useSendFormCompose.ts
@@ -11,6 +11,7 @@ import {
 } from '@wallet-types/sendForm';
 import { useAsyncDebounce } from '@trezor/react-utils';
 import { useActions } from '@suite-hooks';
+import { isChanged } from '@suite-utils/comparisonUtils';
 import * as sendFormActions from '@wallet-actions/sendFormActions';
 import { findComposeErrors } from '@suite-common/wallet-utils';
 
@@ -244,9 +245,18 @@ export const useSendFormCompose = ({
     // - update context state (state.account)
     // - compose transaction with new data
     useEffect(() => {
-        if (state.account === account) return; // account didn't change
+        if (
+            !isChanged(
+                { account: state.account },
+                { account },
+                { account: ['availableBalance', 'addresses', 'balance', 'misc', 'utxo'] }, // only check relevant properties, otherwise it might recompose the transaction unnecessarily
+            )
+        ) {
+            return; // account didn't change
+        }
         if (!state.isDirty) {
             // there was no interaction with the form, just update state.account
+            console.log('returning because no interaction');
             updateContext({ account });
             return;
         }

--- a/packages/suite/src/hooks/wallet/useSendFormFields.ts
+++ b/packages/suite/src/hooks/wallet/useSendFormFields.ts
@@ -25,7 +25,7 @@ export const useSendFormFields = ({
     fiatRates,
     network,
 }: Props) => {
-    const { souldSendInSats } = useBitcoinAmountUnit(network.symbol);
+    const { shouldSendInSats } = useBitcoinAmountUnit(network.symbol);
 
     const calculateFiat = useCallback(
         (outputIndex: number, amount?: string) => {
@@ -45,7 +45,7 @@ export const useSendFormFields = ({
             // calculate Fiat value
             if (!fiatRates || !fiatRates.current) return;
 
-            const formattedAmount = souldSendInSats // toFiatCurrency always works with BTC, not satoshis
+            const formattedAmount = shouldSendInSats // toFiatCurrency always works with BTC, not satoshis
                 ? formatNetworkAmount(amount, network.symbol)
                 : amount;
 
@@ -58,7 +58,7 @@ export const useSendFormFields = ({
                 setValue(inputName, fiatValue, { shouldValidate: true });
             }
         },
-        [getValues, setValue, fiatRates, souldSendInSats, network.symbol],
+        [getValues, setValue, fiatRates, shouldSendInSats, network.symbol],
     );
 
     const setAmount = useCallback(

--- a/packages/suite/src/support/messages.ts
+++ b/packages/suite/src/support/messages.ts
@@ -7553,4 +7553,45 @@ export default defineMessages({
         id: 'TR_ANONYMITY_LEVEL_BAD_WARNING',
         defaultMessage: 'We recommend a minimum "1 in 5" anonymity level',
     },
+    TR_NOT_ENOUGH_ANONYMIZED_FUNDS_WARNING: {
+        id: 'TR_NOT_ENOUGH_ANONYMIZED_FUNDS',
+        description: 'Warning in coinjoin send form',
+        defaultMessage:
+            'Not enough anonymized funds{br}Either anonymize more funds, or lower the anonymity level at your own risk',
+    },
+    TR_BREAKING_ANONYMITY_CHECKBOX: {
+        id: 'TR_BREAKING_ANONYMITY_CHECKBOX',
+        description: 'Checkbox in coinjoin send form',
+        defaultMessage: "I understand I'm breaking my anonymity",
+    },
+    TR_NOT_ENOUGH_ANONYMIZED_FUNDS_TOOLTIP: {
+        id: 'TR_NOT_ENOUGH_ANONYMIZED_FUNDS_TOOLTIP',
+        description: 'Tooltip in coinjoin send form',
+        defaultMessage: 'You can:',
+    },
+    TR_ANONYMIZATION_OPTION_1: {
+        id: 'TR_ANONYMIZATION_OPTION_1',
+        description: 'Tooltip in coinjoin send form',
+        defaultMessage: 'Anonymize more coins',
+    },
+    TR_ANONYMIZATION_OPTION_2: {
+        id: 'TR_ANONYMIZATION_OPTION_2',
+        description: 'Tooltip in coinjoin send form',
+        defaultMessage: 'Select UTXOs in <button>Coin Control</button>',
+    },
+    TR_ANONYMIZATION_OPTION_3: {
+        id: 'TR_ANONYMIZATION_OPTION_3',
+        description: 'Tooltip in coinjoin send form',
+        defaultMessage: 'Reduce anonymity level',
+    },
+    TR_NOT_ENOUGH_ANONYMIZED_FUNDS: {
+        id: 'TR_NOT_ENOUGH_ANONYMIZED_FUNDS',
+        description: 'Secondary button text in coinjoin sed form',
+        defaultMessage: 'Not enough anonymized funds',
+    },
+    TR_YOU_SHOULD_ANONYMIZE: {
+        id: 'TR_YOU_SHOULD_ANONYMIZE',
+        description: 'Secondary button text in coinjoin sed form',
+        defaultMessage: 'You should anonymize them',
+    },
 });

--- a/packages/suite/src/views/wallet/coinmarket/buy/components/BuyForm/Inputs/index.tsx
+++ b/packages/suite/src/views/wallet/coinmarket/buy/components/BuyForm/Inputs/index.tsx
@@ -54,7 +54,7 @@ const Inputs = () => {
         getValues,
         exchangeCoinInfo,
     } = useCoinmarketBuyFormContext();
-    const { souldSendInSats } = useBitcoinAmountUnit(account.symbol);
+    const { shouldSendInSats } = useBitcoinAmountUnit(account.symbol);
 
     const { symbol } = account;
     const uppercaseSymbol = symbol.toUpperCase();
@@ -148,7 +148,7 @@ const Inputs = () => {
                     return <Translation id="AMOUNT_IS_NOT_NUMBER" />;
                 }
 
-                if (souldSendInSats && !isInteger(value)) {
+                if (shouldSendInSats && !isInteger(value)) {
                     return 'AMOUNT_IS_NOT_INTEGER';
                 }
 
@@ -170,7 +170,7 @@ const Inputs = () => {
 
                     let minCrypto = 0;
                     if (amountLimits.minCrypto) {
-                        minCrypto = souldSendInSats
+                        minCrypto = shouldSendInSats
                             ? Number(
                                   amountToSatoshi(
                                       amountLimits.minCrypto.toString(),
@@ -197,7 +197,7 @@ const Inputs = () => {
 
                     let maxCrypto = 0;
                     if (amountLimits.maxCrypto) {
-                        maxCrypto = souldSendInSats
+                        maxCrypto = shouldSendInSats
                             ? Number(
                                   amountToSatoshi(
                                       amountLimits.maxCrypto.toString(),
@@ -322,7 +322,7 @@ const Inputs = () => {
                                                     }.svg`}
                                                 />
                                             )}
-                                            <Label>{souldSendInSats ? 'sat' : option.label}</Label>
+                                            <Label>{shouldSendInSats ? 'sat' : option.label}</Label>
                                         </Option>
                                     )}
                                     isClean

--- a/packages/suite/src/views/wallet/coinmarket/exchange/components/ExchangeForm/Inputs/SendCryptoInput/SendCryptoSelect/index.tsx
+++ b/packages/suite/src/views/wallet/coinmarket/exchange/components/ExchangeForm/Inputs/SendCryptoInput/SendCryptoSelect/index.tsx
@@ -29,7 +29,7 @@ const TokenLogo = styled.img`
 const SendCryptoSelect = () => {
     const { control, setAmountLimits, account, setValue, exchangeInfo, composeRequest } =
         useCoinmarketExchangeFormContext();
-    const { souldSendInSats } = useBitcoinAmountUnit(account.symbol);
+    const { shouldSendInSats } = useBitcoinAmountUnit(account.symbol);
 
     const { tokens } = account;
     const sendCryptoOptions = getSendCryptoOptions(account, exchangeInfo?.sellSymbols || new Set());
@@ -78,7 +78,7 @@ const SendCryptoSelect = () => {
                                     }.svg`}
                                 />
                             )}
-                            <Label>{souldSendInSats ? 'sat' : option.label}</Label>
+                            <Label>{shouldSendInSats ? 'sat' : option.label}</Label>
                         </Option>
                     )}
                     value={value}

--- a/packages/suite/src/views/wallet/coinmarket/exchange/components/ExchangeForm/Inputs/SendCryptoInput/index.tsx
+++ b/packages/suite/src/views/wallet/coinmarket/exchange/components/ExchangeForm/Inputs/SendCryptoInput/index.tsx
@@ -41,13 +41,13 @@ const SendCryptoInput = () => {
         getValues,
         setValue,
     } = useCoinmarketExchangeFormContext();
-    const { souldSendInSats } = useBitcoinAmountUnit(account.symbol);
+    const { shouldSendInSats } = useBitcoinAmountUnit(account.symbol);
     const { symbol, tokens } = account;
 
     const tokenAddress = getValues(CRYPTO_TOKEN);
     const tokenData = tokens?.find(t => t.address === tokenAddress);
 
-    const conversion = souldSendInSats ? amountToSatoshi : formatAmount;
+    const conversion = shouldSendInSats ? amountToSatoshi : formatAmount;
     const formattedAvailableBalance = tokenData
         ? tokenData.balance || '0'
         : conversion(account.availableBalance, network.decimals);
@@ -75,7 +75,7 @@ const SendCryptoInput = () => {
                     return 'AMOUNT_IS_NOT_NUMBER';
                 }
 
-                if (souldSendInSats && !isInteger(value)) {
+                if (shouldSendInSats && !isInteger(value)) {
                     return 'AMOUNT_IS_NOT_INTEGER';
                 }
 
@@ -88,7 +88,7 @@ const SendCryptoInput = () => {
 
                     let minCrypto = 0;
                     if (amountLimits.min) {
-                        minCrypto = souldSendInSats
+                        minCrypto = shouldSendInSats
                             ? Number(amountToSatoshi(amountLimits.min.toString(), network.decimals))
                             : amountLimits.min;
                     }
@@ -110,7 +110,7 @@ const SendCryptoInput = () => {
 
                     let maxCrypto = 0;
                     if (amountLimits.max) {
-                        maxCrypto = souldSendInSats
+                        maxCrypto = shouldSendInSats
                             ? Number(amountToSatoshi(amountLimits.max.toString(), network.decimals))
                             : amountLimits.max;
                     }

--- a/packages/suite/src/views/wallet/coinmarket/exchange/components/ExchangeForm/Inputs/index.tsx
+++ b/packages/suite/src/views/wallet/coinmarket/exchange/components/ExchangeForm/Inputs/index.tsx
@@ -64,7 +64,7 @@ const Inputs = () => {
         updateFiatValue,
         clearErrors,
     } = useCoinmarketExchangeFormContext();
-    const { souldSendInSats } = useBitcoinAmountUnit(account.symbol);
+    const { shouldSendInSats } = useBitcoinAmountUnit(account.symbol);
 
     const { outputs } = getValues();
     const tokenAddress = outputs?.[0]?.token;
@@ -91,7 +91,7 @@ const Inputs = () => {
                       .dividedBy(divisor)
                       .decimalPlaces(network.decimals)
                       .toString();
-            const cryptoInputValue = souldSendInSats
+            const cryptoInputValue = shouldSendInSats
                 ? amountToSatoshi(amount, network.decimals)
                 : amount;
             setValue(CRYPTO_INPUT, cryptoInputValue, { shouldDirty: true });
@@ -101,7 +101,7 @@ const Inputs = () => {
         },
         [
             account.formattedBalance,
-            souldSendInSats,
+            shouldSendInSats,
             clearErrors,
             composeRequest,
             network.decimals,

--- a/packages/suite/src/views/wallet/coinmarket/sell/components/SellForm/Inputs/CryptoInput/index.tsx
+++ b/packages/suite/src/views/wallet/coinmarket/sell/components/SellForm/Inputs/CryptoInput/index.tsx
@@ -62,7 +62,7 @@ const CryptoInput = ({ activeInput, setActiveInput }: Props) => {
         setAmountLimits,
         composeRequest,
     } = useCoinmarketSellFormContext();
-    const { souldSendInSats } = useBitcoinAmountUnit(account.symbol);
+    const { shouldSendInSats } = useBitcoinAmountUnit(account.symbol);
 
     const uppercaseSymbol = account.symbol.toUpperCase();
     const cryptoOption = {
@@ -89,7 +89,7 @@ const CryptoInput = ({ activeInput, setActiveInput }: Props) => {
                     return <Translation id="AMOUNT_IS_NOT_NUMBER" />;
                 }
 
-                if (souldSendInSats && !isInteger(value)) {
+                if (shouldSendInSats && !isInteger(value)) {
                     return 'AMOUNT_IS_NOT_INTEGER';
                 }
 
@@ -111,7 +111,7 @@ const CryptoInput = ({ activeInput, setActiveInput }: Props) => {
 
                     let minCrypto = 0;
                     if (amountLimits.minCrypto) {
-                        minCrypto = souldSendInSats
+                        minCrypto = shouldSendInSats
                             ? Number(
                                   amountToSatoshi(
                                       amountLimits.minCrypto.toString(),
@@ -138,7 +138,7 @@ const CryptoInput = ({ activeInput, setActiveInput }: Props) => {
 
                     let maxCrypto = 0;
                     if (amountLimits.maxCrypto) {
-                        maxCrypto = souldSendInSats
+                        maxCrypto = shouldSendInSats
                             ? Number(
                                   amountToSatoshi(
                                       amountLimits.maxCrypto.toString(),
@@ -237,7 +237,7 @@ const CryptoInput = ({ activeInput, setActiveInput }: Props) => {
                                             }.svg`}
                                         />
                                     )}
-                                    <Label>{souldSendInSats ? 'sat' : option.label}</Label>
+                                    <Label>{shouldSendInSats ? 'sat' : option.label}</Label>
                                 </Option>
                             )}
                         />

--- a/packages/suite/src/views/wallet/coinmarket/sell/components/SellForm/Inputs/index.tsx
+++ b/packages/suite/src/views/wallet/coinmarket/sell/components/SellForm/Inputs/index.tsx
@@ -30,7 +30,7 @@ const Inputs = () => {
         setActiveInput,
         getValues,
     } = useCoinmarketSellFormContext();
-    const { souldSendInSats } = useBitcoinAmountUnit(account.symbol);
+    const { shouldSendInSats } = useBitcoinAmountUnit(account.symbol);
 
     // if FIAT_INPUT has a valid value, set it as the activeInput
     if (watch(FIAT_INPUT) && !errors[FIAT_INPUT] && activeInput === CRYPTO_INPUT) {
@@ -59,7 +59,7 @@ const Inputs = () => {
                       .dividedBy(divisor)
                       .decimalPlaces(network.decimals)
                       .toString();
-            const cryptoInputValue = souldSendInSats
+            const cryptoInputValue = shouldSendInSats
                 ? amountToSatoshi(amount, network.decimals)
                 : amount;
             setValue(CRYPTO_INPUT, cryptoInputValue, { shouldDirty: true });
@@ -69,7 +69,7 @@ const Inputs = () => {
         },
         [
             account.formattedBalance,
-            souldSendInSats,
+            shouldSendInSats,
             clearErrors,
             network.decimals,
             onCryptoAmountChange,

--- a/packages/suite/src/views/wallet/send/components/Options/components/BitcoinOptions/components/CoinControl.tsx
+++ b/packages/suite/src/views/wallet/send/components/Options/components/BitcoinOptions/components/CoinControl.tsx
@@ -92,7 +92,7 @@ export const CoinControl = ({ close }: CoinControlProps) => {
         toggleCoinControl,
     } = useSendFormContext();
 
-    const { souldSendInSats } = useBitcoinAmountUnit(account.symbol);
+    const { shouldSendInSats } = useBitcoinAmountUnit(account.symbol);
 
     const inputs = isCoinControlEnabled ? selectedUtxos : composedInputs;
 
@@ -106,14 +106,14 @@ export const CoinControl = ({ close }: CoinControlProps) => {
     const totalOutputs = getTotal(
         outputs.map((_, i) => Number(getDefaultValue(`outputs[${i}].amount`, ''))),
     );
-    const totalOutputsInSats = souldSendInSats
+    const totalOutputsInSats = shouldSendInSats
         ? totalOutputs
         : Number(amountToSatoshi(totalOutputs.toString(), network.decimals));
     const missingToInput = totalOutputsInSats - totalInputs;
     const isMissingToAmount = missingToInput > 0; // relevant when the amount field is not validated, e.g. there is an error in the address
     const missingAmountTooBig = missingToInput > Number.MAX_SAFE_INTEGER;
     const amountHasError = errors.outputs?.some(error => error?.amount); // relevant when input is a number, but there is an error, e.g. decimals in sats
-    const notEnougFundsSelectedError = !!errors.outputs?.some(
+    const notEnoughFundsSelectedError = !!errors.outputs?.some(
         error =>
             ((error?.amount as TypedFieldError)?.message as ExtendedMessageDescriptor)?.id ===
             'TR_NOT_ENOUGH_SELECTED',
@@ -121,8 +121,8 @@ export const CoinControl = ({ close }: CoinControlProps) => {
     const isMissingVisible =
         isCoinControlEnabled &&
         !missingAmountTooBig &&
-        !(amountHasError && !notEnougFundsSelectedError) &&
-        (isMissingToAmount || notEnougFundsSelectedError);
+        !(amountHasError && !notEnoughFundsSelectedError) &&
+        (isMissingToAmount || notEnoughFundsSelectedError);
     const missingToInputId = isMissingToAmount ? 'TR_MISSING_TO_INPUT' : 'TR_MISSING_TO_FEE';
     const formattedTotal = getFormattedAmount(totalInputs);
     const formattedMissing = isMissingVisible ? getFormattedAmount(missingToInput) : ''; // set to empty string when hidden to avoid affecting the layout

--- a/packages/suite/src/views/wallet/send/components/Options/components/BitcoinOptions/index.tsx
+++ b/packages/suite/src/views/wallet/send/components/Options/components/BitcoinOptions/index.tsx
@@ -1,5 +1,7 @@
 import React from 'react';
+import { useWatch } from 'react-hook-form';
 import styled from 'styled-components';
+
 import { Translation } from '@suite-components';
 import { OnOffSwitcher } from '@wallet-components';
 import { Button, Tooltip } from '@trezor/components';
@@ -8,6 +10,7 @@ import { isFeatureFlagEnabled } from '@suite-common/suite-utils';
 import { OpenGuideFromTooltip } from '@guide-components';
 import { Locktime } from './components/Locktime';
 import { CoinControl } from './components/CoinControl';
+import { FormOptions } from '@wallet-types/sendForm';
 
 const Wrapper = styled.div`
     display: flex;
@@ -45,18 +48,26 @@ export const BitcoinOptions = () => {
     const {
         network,
         addOutput,
-        getDefaultValue,
+        control,
         isCoinControlEnabled,
+        getDefaultValue,
         toggleOption,
         composeTransaction,
         resetDefaultValue,
     } = useSendFormContext();
 
-    const options = getDefaultValue('options', []);
+    const options = useWatch<FormOptions[]>({
+        name: 'options',
+        defaultValue: getDefaultValue('options', []),
+        control,
+    });
+
     const locktimeEnabled = options.includes('bitcoinLockTime');
     const rbfEnabled = options.includes('bitcoinRBF');
     const utxoSelectionEnabled = options.includes('utxoSelection');
     const broadcastEnabled = options.includes('broadcast');
+
+    const toggleUtxoSelection = () => toggleOption('utxoSelection');
 
     return (
         <Wrapper>
@@ -72,15 +83,7 @@ export const BitcoinOptions = () => {
                     }}
                 />
             )}
-            {utxoSelectionEnabled && (
-                <CoinControl
-                    close={() => {
-                        resetDefaultValue('utxoSelection');
-                        toggleOption('utxoSelection');
-                        composeTransaction();
-                    }}
-                />
-            )}
+            {utxoSelectionEnabled && <CoinControl close={toggleUtxoSelection} />}
 
             <Row>
                 <Left>
@@ -163,11 +166,7 @@ export const BitcoinOptions = () => {
                             <StyledButton
                                 variant="tertiary"
                                 icon="COIN_CONTROL"
-                                onClick={() => {
-                                    // open additional form
-                                    toggleOption('utxoSelection');
-                                    composeTransaction();
-                                }}
+                                onClick={toggleUtxoSelection}
                             >
                                 <Translation id="TR_COIN_CONTROL" />
                                 {isCoinControlEnabled && <OnOffSwitcher isOn />}

--- a/packages/suite/src/views/wallet/send/components/Outputs/components/Amount/components/Fiat.tsx
+++ b/packages/suite/src/views/wallet/send/components/Outputs/components/Amount/components/Fiat.tsx
@@ -13,6 +13,7 @@ import {
     getInputState,
     getFiatRate,
     findToken,
+    isLowAnonymityWarning,
     amountToSatoshi,
     formatAmount,
     buildCurrencyOptions,
@@ -48,7 +49,7 @@ export const Fiat = ({ output, outputId }: Props) => {
         composeTransaction,
     } = useSendFormContext();
 
-    const { souldSendInSats } = useBitcoinAmountUnit(account.symbol);
+    const { shouldSendInSats } = useBitcoinAmountUnit(account.symbol);
 
     const inputName = `outputs[${outputId}].fiat`;
     const currencyInputName = `outputs[${outputId}].currency`;
@@ -70,6 +71,10 @@ export const Fiat = ({ output, outputId }: Props) => {
     // or as a result on composeTransaction process
     const amountError = outputError ? outputError.amount : undefined;
     const errorToDisplay = !error && fiatValue && amountError ? amountError : error;
+
+    const isLowAnonymity = isLowAnonymityWarning(outputError);
+    const inputState = isLowAnonymity ? 'warning' : getInputState(errorToDisplay, fiatValue);
+    const bottomText = isLowAnonymity ? null : <InputError error={errorToDisplay} />;
 
     const handleChange = useCallback(
         (event: ChangeEvent<HTMLInputElement>) => {
@@ -105,7 +110,7 @@ export const Fiat = ({ output, outputId }: Props) => {
                       )
                     : null;
 
-            const formattedAmount = souldSendInSats
+            const formattedAmount = shouldSendInSats
                 ? amountToSatoshi(amount || '0', decimals)
                 : amount;
 
@@ -131,7 +136,7 @@ export const Fiat = ({ output, outputId }: Props) => {
             network.decimals,
             setValue,
             token,
-            souldSendInSats,
+            shouldSendInSats,
         ],
     );
 
@@ -159,7 +164,9 @@ export const Fiat = ({ output, outputId }: Props) => {
                     const amountValue = getDefaultValue(amountInputName, '');
 
                     const formattedAmount = new BigNumber(
-                        souldSendInSats ? formatAmount(amountValue, network.decimals) : amountValue,
+                        shouldSendInSats
+                            ? formatAmount(amountValue, network.decimals)
+                            : amountValue,
                     );
 
                     if (
@@ -187,7 +194,7 @@ export const Fiat = ({ output, outputId }: Props) => {
             getDefaultValue,
             inputName,
             setValue,
-            souldSendInSats,
+            shouldSendInSats,
             network.decimals,
         ],
     );
@@ -195,7 +202,7 @@ export const Fiat = ({ output, outputId }: Props) => {
     return (
         <Wrapper>
             <Input
-                inputState={getInputState(errorToDisplay, fiatValue)}
+                inputState={inputState}
                 isMonospace
                 onChange={handleChange}
                 name={inputName}
@@ -223,7 +230,7 @@ export const Fiat = ({ output, outputId }: Props) => {
                         }
                     },
                 })}
-                bottomText={<InputError error={errorToDisplay} />}
+                bottomText={bottomText}
                 innerAddon={
                     <Controller
                         control={control}

--- a/packages/suite/src/views/wallet/send/components/Outputs/index.tsx
+++ b/packages/suite/src/views/wallet/send/components/Outputs/index.tsx
@@ -33,8 +33,6 @@ const OutputWrapper = styled.div<{ index: number }>`
 `;
 
 const Row = styled.div`
-    display: flex;
-    flex-direction: ${(props: { isColumn?: boolean }) => (props.isColumn ? 'column' : 'row')};
     padding: 0 0 10px 0;
 
     &:last-child {

--- a/packages/suite/src/views/wallet/send/components/ReviewButton.tsx
+++ b/packages/suite/src/views/wallet/send/components/ReviewButton.tsx
@@ -1,6 +1,8 @@
 import React from 'react';
-import styled from 'styled-components';
-import { Button } from '@trezor/components';
+import { useWatch } from 'react-hook-form';
+import styled, { useTheme } from 'styled-components';
+
+import { Checkbox, TooltipButton, Warning, variables } from '@trezor/components';
 import { useDevice } from '@suite-hooks';
 import { useSendFormContext } from '@wallet-hooks';
 import { Translation } from '@suite-components/Translation';
@@ -38,6 +40,8 @@ export const ReviewButton = () => {
     const { online, isLoading, signTransaction, getValues, getDefaultValue, composedLevels } =
         useSendFormContext();
 
+    const theme = useTheme();
+
     const values = getValues();
     const broadcastEnabled = getDefaultValue('options', []).includes('broadcast');
     const composedTx = composedLevels ? composedLevels[values.selectedFee || 'normal'] : undefined;
@@ -49,20 +53,34 @@ export const ReviewButton = () => {
         !online;
 
     return (
-        <Wrapper>
-            <Row>
-                <ButtonReview
-                    data-test="@send/review-button"
-                    isDisabled={isDisabled || isLoading}
-                    onClick={signTransaction}
-                >
-                    {broadcastEnabled ? (
-                        <Translation id="REVIEW_AND_SEND_TRANSACTION" />
-                    ) : (
-                        <Translation id="SIGN_TRANSACTION" />
-                    )}
-                </ButtonReview>
-            </Row>
-        </Wrapper>
+        <>
+            {possibleToSubmit && isLowAnonymityUtxoSelected && (
+                <StyledWarning critical>
+                    <Checkbox
+                        color={theme.BG_RED}
+                        isChecked={anonymityWarningChecked}
+                        onClick={toggleAnonymityWarning}
+                    >
+                        <Translation id="TR_BREAKING_ANONYMITY_CHECKBOX" />
+                    </Checkbox>
+                </StyledWarning>
+            )}
+            <ButtonReview
+                interactiveTooltip={!coinControlOpen}
+                isRed={anonymityWarningChecked}
+                tooltipContent={tooltipContent}
+                data-test="@send/review-button"
+                isDisabled={isDisabled || isLoading}
+                onClick={signTransaction}
+            >
+                <Translation id={primaryText} />
+                {isOutputWarning ||
+                    (isLowAnonymityUtxoSelected && (
+                        <SecondLine>
+                            <Translation id={secondaryText} />
+                        </SecondLine>
+                    ))}
+            </ButtonReview>
+        </>
     );
 };

--- a/suite-common/wallet-types/src/sendForm.ts
+++ b/suite-common/wallet-types/src/sendForm.ts
@@ -103,6 +103,9 @@ export type SendContextValues = Omit<UseFormMethods<FormState>, 'register'> &
         isCoinControlEnabled: boolean;
         selectedUtxos: AccountUtxo[];
         spendableUtxos: AccountUtxo[];
+        isLowAnonymityUtxoSelected: boolean;
+        anonymityWarningChecked: boolean;
+        toggleAnonymityWarning: () => void;
         toggleCheckAllUtxos: () => void;
         toggleCoinControl: () => void;
         toggleUtxoSelection: (utxo: AccountUtxo) => void;

--- a/suite-common/wallet-utils/src/sendFormUtils.ts
+++ b/suite-common/wallet-utils/src/sendFormUtils.ts
@@ -1,10 +1,11 @@
-import { FieldError, UseFormMethods } from 'react-hook-form';
+import { DeepMap, FieldError, UseFormMethods } from 'react-hook-form';
 
 import BigNumber from 'bignumber.js';
 import Common, { Chain, Hardfork } from '@ethereumjs/common';
 import { Transaction, TxData } from '@ethereumjs/tx';
 import { fromWei, padLeft, toHex, toWei } from 'web3-utils';
 
+import { TypedFieldError } from '@suite-common/wallet-types';
 import { FIAT } from '@suite-common/suite-config';
 import { isFeatureFlagEnabled } from '@suite-common/suite-utils';
 import { Network } from '@suite-common/wallet-config';
@@ -195,6 +196,18 @@ export const getInputState = (error?: FieldError, value?: string) => {
     if (value && value.length > 0 && !error) {
         return 'success';
     }
+};
+
+export const isLowAnonymityWarning = (
+    outputErrors?: DeepMap<Output, FieldError> | (DeepMap<Output, FieldError> | undefined)[],
+) => {
+    const isLowAnonymityMessage = (error?: DeepMap<Output, FieldError>) =>
+        ((error?.amount as TypedFieldError)?.message as { id: string })?.id === // TODO: type message as ExtendedMessageDescriptor after https://github.com/trezor/trezor-suite/pull/5647 is merged
+        'TR_NOT_ENOUGH_ANONYMIZED_FUNDS_WARNING';
+
+    return Array.isArray(outputErrors)
+        ? outputErrors?.some(isLowAnonymityMessage)
+        : isLowAnonymityMessage(outputErrors);
 };
 
 export const getFiatRate = (fiatRates: CoinFiatRates | undefined, currency: string) => {


### PR DESCRIPTION
Adjust send form for coinjoin account

## Description
- displays warnings and tooltip as seen in the screenshots
- be default, all UTXOs have `targetAnonymity` of 1; to test this feature, uncomment line 76 in `useSendForm.tsx` which sets the `targetAnonymity` of the first address to 80
- I had to turn off `React.StrictMode` because it's [double rendering](https://reactjs.org/docs/strict-mode.html#detecting-unexpected-side-effects) resets compose errors, therefore hiding the yellow warnings; this indicates a problem we need to investigate further
- I deviated slightly from the designs as discussed with @hynek-jina - the submit button is never yellow when disabled, it is grey as normal to avoid confusion (see the first screenshot)
- components should re-render when `options` value changes so I replaced `getDefaultValue` with `useWatch`; future refactoring of the form logic would be beneficial as the current setup is hard to work with

## Related Issue

Resolve #6205

## Screenshots (if appropriate):
Disabled button when warning is displayed:
![Screenshot 2022-10-19 at 11 32 43](https://user-images.githubusercontent.com/42465546/196654263-5d7c2462-21be-4953-ac40-a13784b8142c.png)
Without coin control:
![Screenshot 2022-10-19 at 11 18 18](https://user-images.githubusercontent.com/42465546/196650915-c8c1c658-5cd9-476e-94fe-062dea216867.png)
With coin control:
![Screenshot 2022-10-19 at 11 18 02](https://user-images.githubusercontent.com/42465546/196650877-b37b5117-5e47-4e27-91ee-6bb9fe0d870f.png)

