### PR TITLE
Disabling custom backend fixed

### DIFF
--- a/suite-common/wallet-utils/src/backend.ts
+++ b/suite-common/wallet-utils/src/backend.ts
@@ -17,10 +17,11 @@ export const getBackendFromSettings = (
     settings?: BackendSettings,
 ): CustomBackend => {
     const type = settings?.selected ?? getDefaultBackendType(coin);
+    const urls = (settings?.selected && settings?.urls?.[type]) ?? [];
     return {
         coin,
         type,
-        urls: settings?.urls?.[type] ?? [],
+        urls,
     };
 };
 


### PR DESCRIPTION
## Description

Minifix which should properly reset custom backend to default without needing to reload Suite.

## Related Issue

Resolve #6496
