### PR TITLE
fix(trezor-suite): Deduplicate metro bundler

### DIFF
--- a/package.json
+++ b/package.json
@@ -112,7 +112,7 @@
         "eslint-plugin-react-hooks": "^4.6.0",
         "jest": "^26.6.3",
         "lerna": "^3.20.2",
-        "metro-react-native-babel-preset": "^0.72.1",
+        "metro-react-native-babel-preset": "^0.72.3",
         "npm-run-all": "^4.1.5",
         "nx": "14.5.10",
         "patch-package": "^6.4.7",

--- a/yarn.lock
+++ b/yarn.lock
@@ -23640,7 +23640,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"metro-react-native-babel-preset@npm:0.72.3, metro-react-native-babel-preset@npm:^0.72.1, metro-react-native-babel-preset@npm:^0.72.3":
+"metro-react-native-babel-preset@npm:0.72.3, metro-react-native-babel-preset@npm:^0.72.3":
   version: 0.72.3
   resolution: "metro-react-native-babel-preset@npm:0.72.3"
   dependencies:
@@ -32504,7 +32504,7 @@ __metadata:
     eslint-plugin-react-hooks: ^4.6.0
     jest: ^26.6.3
     lerna: ^3.20.2
-    metro-react-native-babel-preset: ^0.72.1
+    metro-react-native-babel-preset: ^0.72.3
     npm-run-all: ^4.1.5
     nx: 14.5.10
     patch-package: ^6.4.7


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
There were 2 versions of same library within our monorepos `yarn.lock` which might cause some unexpected behavior so this unifies versions.

## Related Issue

Resolve [Deduplicate versions of “metro-react-native-babel-preset”#6026](https://github.com/trezor/trezor-suite/issues/6026)


