### PR TITLE
fix(suite): make address in coin control monospace

### DIFF
--- a/packages/suite/src/components/wallet/CoinControl/UtxoSelection.tsx
+++ b/packages/suite/src/components/wallet/CoinControl/UtxoSelection.tsx
@@ -78,6 +78,7 @@ const Dot = styled.div`
 
 const Address = styled.div`
     overflow: hidden;
+    font-variant-numeric: tabular-nums slashed-zero;
     text-overflow: ellipsis;
 `;
 


### PR DESCRIPTION
Add a CSS property to match font variant used for addresses elsewhere in Suite.

## Related Issue

Resolve #6590

## Screenshots (if appropriate):
before:
![Screenshot 2022-10-20 at 10 39 44](https://user-images.githubusercontent.com/42465546/196900130-e59dbbe8-87e8-4390-a84f-e0f2926457f1.png)
after:
![Screenshot 2022-10-20 at 10 39 34](https://user-images.githubusercontent.com/42465546/196900103-0b834330-ef4e-4317-9773-10ce7d4db08c.png)
