### PR TITLE
feat(analytics): allow reporting without environment

### DIFF
--- a/packages/analytics/src/analytics.ts
+++ b/packages/analytics/src/analytics.ts
@@ -26,7 +26,7 @@ export class Analytics<T extends Event> {
         this.instanceId = options.instanceId || getRandomId();
         this.sessionId = options.sessionId || getRandomId();
         this.commitId = options.commitId;
-        this.url = getUrl(this.app, options.environment, options.isDev);
+        this.url = getUrl(this.app, options.isDev, options.environment);
         this.callbacks = options.callbacks;
     };
 

--- a/packages/analytics/src/tests/analytics.test.ts
+++ b/packages/analytics/src/tests/analytics.test.ts
@@ -57,6 +57,40 @@ describe('analytics', () => {
         expect(global.fetch).toHaveBeenCalledTimes(2);
     });
 
+    it('should report even without environment option', () => {
+        const mockFetchPromise = Promise.resolve({
+            json: () => Promise.resolve({}),
+        });
+        global.fetch = jest.fn().mockImplementation(() => mockFetchPromise);
+        // @ts-expect-error
+        jest.spyOn(global, 'fetch').mockImplementation(() => mockFetchPromise);
+
+        const timestamp = new Date().getTime();
+        jest.spyOn(Date, 'now').mockImplementation(() => timestamp);
+        jest.spyOn(console, 'error').mockImplementation(() => {});
+
+        const app = 'connect';
+        const isDev = false;
+        const instanceId = getRandomId();
+        const sessionId = getRandomId();
+        const commitId = 'abc';
+
+        const analytics = new Analytics('1.18', app);
+
+        analytics.init(true, { isDev, instanceId, sessionId, commitId });
+
+        const actionType = 'very-important-action';
+
+        analytics.report({ type: actionType });
+
+        expect(global.fetch).toHaveBeenNthCalledWith(
+            1,
+            `https://data.trezor.io/${app}/log/stable.log?c_v=1.18&c_type=${actionType}&c_commit=${commitId}&c_instance_id=${instanceId}&c_session_id=${sessionId}&c_timestamp=${timestamp}&c_message_id=random`,
+            { method: 'GET' },
+        );
+        expect(global.fetch).toHaveBeenCalledTimes(1);
+    });
+
     it('calls callback on enable and disable', () => {
         jest.spyOn(console, 'log').mockImplementation(() => {});
 

--- a/packages/analytics/src/types.ts
+++ b/packages/analytics/src/types.ts
@@ -1,11 +1,11 @@
-export type App = 'suite' | 'connect-popup';
+export type App = 'suite' | 'connect';
 
 export type Environment = 'desktop' | 'web' | 'mobile' | '';
 
 export type InitOptions = {
     sessionId?: string;
     instanceId?: string;
-    environment: Environment;
+    environment?: Environment;
     isDev: boolean;
     commitId: string;
     callbacks?: {

--- a/packages/analytics/src/utils.ts
+++ b/packages/analytics/src/utils.ts
@@ -4,8 +4,12 @@ import type { App, Environment, Event } from './types';
 
 export const getRandomId = () => getWeakRandomId(10);
 
-export const getUrl = (app: App, environment: Environment, isDev: boolean) => {
-    const base = `https://data.trezor.io/${app}/log/${environment}`;
+export const getUrl = (app: App, isDev: boolean, environment?: Environment) => {
+    let base = `https://data.trezor.io/${app}/log`;
+
+    if (environment) {
+        base = `${base}/${environment}`;
+    }
 
     if (isDev) {
         return `${base}/develop.log`;


### PR DESCRIPTION
## Description
 
Environment in analytics is now optional as we do not need it for analytics in connect

## Related Issue

https://github.com/trezor/trezor-suite/issues/5397
