### PR TITLE
feat(suite-desktop): introduce featureless trezorsuite: uri handler

### DIFF
--- a/packages/suite-desktop/package.json
+++ b/packages/suite-desktop/package.json
@@ -97,6 +97,7 @@
         "protocols": {
             "name": "Trezor Suite",
             "schemes": [
+                "trezorsuite",
                 "bitcoin",
                 "litecoin",
                 "bitcoincash",


### PR DESCRIPTION
## Description

- register `trezorsuite:` uri handler to open Trezor Suite app
- can be extended later, now it only opens/focuses already opened app

https://satoshilabs.slack.com/archives/CKZHV2G13/p1665577840740539

## Related Issue

#991

## Screenshots (if appropriate):

https://user-images.githubusercontent.com/33235762/197479390-324b68b8-b744-4b0a-bb65-1b7f88eafbc9.mov

