### PR TITLE
feat(message-system): WebUSB now works again on Android

### DIFF
--- a/packages/message-system/src/config/config.v1.json
+++ b/packages/message-system/src/config/config.v1.json
@@ -7,14 +7,14 @@
             "conditions": [
                 {
                     "environment": {
-                        "desktop": "<22.8.2",
+                        "desktop": "<22.9.3",
                         "mobile": "!",
                         "web": "!"
                     }
                 }
             ],
             "message": {
-                "id": "a99d0ad4-3bab-4630-9352-fd17a518153e",
+                "id": "a99d0ad4-3bab-4630-9352-fd17a518153f",
                 "priority": 91,
                 "dismissible": true,
                 "variant": "warning",
@@ -262,40 +262,6 @@
                         "ru": "Обновить прошивку",
                         "ja": "ファームウェアのアップデート"
                     }
-                }
-            }
-        },
-        {
-            "conditions": [
-                {
-                    "os": {
-                        "macos": "!",
-                        "linux": "!",
-                        "windows": "!",
-                        "android": "*",
-                        "ios": "!",
-                        "chromeos": "!"
-                    },
-                    "browser": {
-                        "firefox": "!",
-                        "chrome": ">105",
-                        "chromium": ">105"
-                    }
-                }
-            ],
-            "message": {
-                "id": "b6c6dbeb-dca2-4481-b421-0381d2bd4927",
-                "priority": 91,
-                "dismissible": true,
-                "variant": "warning",
-                "category": "banner",
-                "content": {
-                    "en-GB": "USB connections are currently unavailable for Chrome on Android. Please use the desktop app instead.",
-                    "en": "USB connections are currently unavailable for Chrome on Android. Please use the desktop app instead.",
-                    "es": "Las conexiones con USB no están disponibles para Chrome en Android. Por favor usa la aplicación de escritorio.",
-                    "cs": "V prohlížeči Chrome na Androidu je momentálně nedostupné USB připojení. Použijte prosím počítačovou verzi aplikace.",
-                    "ru": "В настоящее время USB-подключение не работает в Chrome на Android. Пожалуйста, воспользуйтесь программой для настольных компьютеров.",
-                    "ja": "現在、AndroidのChromeでは、USB接続がうまくいきません。デスクトップ用ソフトをご利用ください。"
                 }
             }
         }


### PR DESCRIPTION
## Description

- WebUSB in Chrome on Android works again.
- Prompt users to update app in `<22.9.3`

