### PR TITLE
Feat/coinjoin cherrypicks

### DIFF
--- a/packages/coinjoin/src/backend/CoinjoinBackendClient.ts
+++ b/packages/coinjoin/src/backend/CoinjoinBackendClient.ts
@@ -7,10 +7,9 @@ import type {
     BlockFilterResponse,
     BlockbookTransaction,
 } from '../types/backend';
+import type { CoinjoinBackendSettings } from '../types';
 
-type CoinjoinBackendClientSettings = {
-    coordinatorUrl: string;
-    blockbookUrls: readonly string[];
+type CoinjoinBackendClientSettings = CoinjoinBackendSettings & {
     timeout?: number;
 };
 
@@ -23,7 +22,7 @@ export class CoinjoinBackendClient extends EventEmitter {
 
     constructor(settings: CoinjoinBackendClientSettings) {
         super();
-        this.wabisabiUrl = `${settings.coordinatorUrl}api/v4/btc`;
+        this.wabisabiUrl = `${settings.wabisabiBackendUrl}api/v4/btc`;
         this.blockbookUrl =
             settings.blockbookUrls[Math.floor(Math.random() * settings.blockbookUrls.length)];
     }

--- a/packages/coinjoin/src/types/index.ts
+++ b/packages/coinjoin/src/types/index.ts
@@ -4,6 +4,7 @@ interface BaseSettings {
 }
 
 export interface CoinjoinBackendSettings extends BaseSettings {
+    wabisabiBackendUrl: string;
     blockbookUrls: readonly string[];
     baseBlockHeight: number;
     baseBlockHash: string;

--- a/packages/coinjoin/src/utils/http.ts
+++ b/packages/coinjoin/src/utils/http.ts
@@ -7,6 +7,7 @@ export interface RequestOptions {
     parseJson?: boolean;
     delay?: number;
     identity?: string;
+    userAgent?: string;
 }
 
 const parseResult = (text: string, json = true) => {
@@ -41,8 +42,14 @@ const createHeaders = (options: RequestOptions) => {
     };
     // add custom header to define TOR identity.
     // request is intercepted by @trezor/request-manager and requested identity is used to create TOR circuit
+    // header works only in nodejs environment (suite-desktop). browser throws: Refused to set unsafe header "proxy-authorization" error
     if (options.identity) {
         headers['Proxy-Authorization'] = `Basic ${options.identity}`;
+    }
+    // blockbook api requires 'User-Agent' to be set
+    // same as in @trezor/blockchain-link/src/workers/blockbook/websocket
+    if (typeof options.userAgent === 'string') {
+        headers['User-Agent'] = options.userAgent || 'Trezor Suite';
     }
     return headers;
 };

--- a/packages/coinjoin/tests/backend/CoinjoinBackend.test.ts
+++ b/packages/coinjoin/tests/backend/CoinjoinBackend.test.ts
@@ -11,7 +11,7 @@ describe.skip(`CoinjoinBackend`, () => {
 
     beforeAll(async () => {
         blockbook = new BlockbookAPI({
-            url: 'https://coinjoin.corp.sldev.cz/blockbook/',
+            url: 'http://localhost:8081/blockbook/',
         });
         await blockbook.connect();
     });

--- a/packages/coinjoin/tests/backend/methods.test.ts
+++ b/packages/coinjoin/tests/backend/methods.test.ts
@@ -8,6 +8,7 @@ import { getAccountInfo } from '../../src/backend/getAccountInfo';
 import { CoinjoinFilterController } from '../../src/backend/CoinjoinFilterController';
 import { CoinjoinMempoolController } from '../../src/backend/CoinjoinMempoolController';
 import * as FIXTURES from '../fixtures/methods.fixture';
+import { COINJOIN_BACKEND_SETTINGS } from '../fixtures/config.fixture';
 import { MockBackendClient } from '../mocks/MockBackendClient';
 import type { BlockFilterResponse, Transaction } from '../../src/types/backend';
 
@@ -45,11 +46,9 @@ describe(`CoinjoinBackend methods`, () => {
     const getContext = <T>(onProgress: (t: T) => void) => ({
         client,
         filters: new CoinjoinFilterController(client, {
+            ...COINJOIN_BACKEND_SETTINGS,
             baseBlockHash: FIXTURES.BASE_HASH,
             baseBlockHeight: FIXTURES.BASE_HEIGHT,
-            blockbookUrls: ['foo'],
-            coordinatorUrl: 'bar',
-            network: 'regtest',
         }),
         mempool: new CoinjoinMempoolController(client),
         network: networks.regtest,

--- a/packages/coinjoin/tests/fixtures/config.fixture.ts
+++ b/packages/coinjoin/tests/fixtures/config.fixture.ts
@@ -1,5 +1,6 @@
 export const COINJOIN_BACKEND_SETTINGS = {
     network: 'regtest',
+    wabisabiBackendUrl: 'http://localhost:8081/WabiSabi/',
     coordinatorUrl: 'http://localhost:8081/WabiSabi/',
     blockbookUrls: ['http://localhost:8081/blockbook/api/v2'],
     baseBlockHeight: 0,

--- a/packages/coinjoin/tests/mocks/MockBackendClient.ts
+++ b/packages/coinjoin/tests/mocks/MockBackendClient.ts
@@ -1,4 +1,5 @@
 import { CoinjoinBackendClient } from '../../src/backend/CoinjoinBackendClient';
+import { COINJOIN_BACKEND_SETTINGS } from '../fixtures/config.fixture';
 
 type MockEndpoint = ReturnType<InstanceType<typeof CoinjoinBackendClient>['request']>;
 
@@ -16,7 +17,7 @@ type BlockFixture = {
 
 export class MockBackendClient extends CoinjoinBackendClient {
     constructor() {
-        super({ blockbookUrls: ['foo'], coordinatorUrl: 'bar' });
+        super(COINJOIN_BACKEND_SETTINGS);
         this.blocks = [];
         this.mempool = [];
         this.transactions = [];

--- a/packages/suite/src/services/coinjoin/config.ts
+++ b/packages/suite/src/services/coinjoin/config.ts
@@ -17,6 +17,7 @@ export const COINJOIN_NETWORKS: PartialRecord<NetworkSymbol, ServerEnvironment> 
             coordinatorName: 'CoinJoinCoordinatorIdentifier',
             coordinatorUrl: 'https://dev-coinjoin.trezor.io/WabiSabi/',
             // backend settings
+            wabisabiBackendUrl: 'https://dev-coinjoin.trezor.io/WabiSabi/',
             blockbookUrls: ['https://dev-coinjoin.trezor.io/blockbook/api/v2'],
             baseBlockHeight: 0,
             baseBlockHash: '0f9188f13cb7b2c71f2a335e3a4fc328bf5beb436012afca590b1a11466e2206',
@@ -30,6 +31,7 @@ export const COINJOIN_NETWORKS: PartialRecord<NetworkSymbol, ServerEnvironment> 
             coordinatorName: 'CoinJoinCoordinatorIdentifier',
             coordinatorUrl: 'http://localhost:8081/WabiSabi/',
             // backend settings
+            wabisabiBackendUrl: 'http://localhost:8081/WabiSabi/',
             blockbookUrls: ['http://localhost:8081/blockbook/api/v2'],
             baseBlockHeight: 0,
             baseBlockHash: '0f9188f13cb7b2c71f2a335e3a4fc328bf5beb436012afca590b1a11466e2206',


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

1. Minor fixes regarding coinjoin config, distinguish coordinator and backend urls (adding wabisabiBackendUrl)
>  on testnet they are on two different urls

optimizing code around config (removed type duplicate, use same config in each tests)
   
2. Fix of header sent to blockbook api
>  on production blockbook api requires 'User-Agent' header to be present

removed type duplicate 
