### PR TITLE
Feat/coinjoin account registration

### DIFF
--- a/packages/coinjoin/src/client/Account.ts
+++ b/packages/coinjoin/src/client/Account.ts
@@ -1,0 +1,58 @@
+import { Network } from '@trezor/utxo-lib';
+
+import { getScriptPubKeyFromAddress } from '../utils/coordinatorUtils';
+import { AllowedScriptTypes } from '../types/coordinator';
+import { RegisterAccountParams } from '../types';
+import { AccountUtxo, AccountAddress } from '../types/account';
+
+const enhanceAccountAddresses = (
+    addresses: Omit<AccountAddress, 'scriptPubKey'>[],
+    network: Network,
+    scriptType: AllowedScriptTypes,
+): AccountAddress[] =>
+    addresses.flatMap(address => ({
+        path: address.path,
+        address: address.address,
+        scriptPubKey: getScriptPubKeyFromAddress(address.address, network, scriptType),
+    }));
+
+export class Account {
+    accountKey: string;
+    scriptType: AllowedScriptTypes;
+    network: Network;
+    utxos: AccountUtxo[];
+    changeAddresses: AccountAddress[];
+    targetAnonymity: number;
+    maxFeePerKvbyte: number;
+    maxCoordinatorFeeRate: number;
+    maxRounds: number;
+    skipRounds?: [number, number];
+    signedRounds: string[] = [];
+
+    constructor(account: RegisterAccountParams, network: Network) {
+        this.accountKey = account.accountKey;
+        this.network = network;
+        this.scriptType = account.scriptType;
+        this.utxos = account.utxos;
+        this.changeAddresses = enhanceAccountAddresses(
+            account.changeAddresses,
+            network,
+            account.scriptType,
+        );
+        this.targetAnonymity = account.targetAnonymity;
+        this.maxFeePerKvbyte = account.maxFeePerKvbyte;
+        this.maxCoordinatorFeeRate = account.maxCoordinatorFeeRate;
+        this.maxRounds = account.maxRounds;
+        this.skipRounds = account.skipRounds;
+    }
+
+    update(account: RegisterAccountParams) {
+        this.utxos = account.utxos;
+        this.changeAddresses = enhanceAccountAddresses(
+            account.changeAddresses,
+            this.network,
+            account.scriptType,
+        );
+        this.targetAnonymity = account.targetAnonymity;
+    }
+}

--- a/packages/coinjoin/src/types/account.ts
+++ b/packages/coinjoin/src/types/account.ts
@@ -1,0 +1,26 @@
+import { AllowedScriptTypes } from './coordinator';
+
+export type RegisterAccountParams = {
+    accountKey: string;
+    scriptType: AllowedScriptTypes;
+    utxos: AccountUtxo[];
+    changeAddresses: Omit<AccountAddress, 'scriptPubKey'>[];
+    targetAnonymity: number;
+    maxFeePerKvbyte: number;
+    maxCoordinatorFeeRate: number;
+    maxRounds: number;
+    skipRounds?: [number, number];
+};
+
+export interface AccountUtxo {
+    path: string;
+    outpoint: string;
+    amount: number;
+    anonymityLevel: number;
+}
+
+export interface AccountAddress {
+    path: string;
+    address: string;
+    scriptPubKey: string;
+}

--- a/packages/coinjoin/src/types/client.ts
+++ b/packages/coinjoin/src/types/client.ts
@@ -6,7 +6,3 @@ export interface CoinjoinStatusEvent {
     feeRatesMedians: FeeRateMedians[];
     coordinatorFeeRate: number;
 }
-
-export type RegisterAccountParams = {
-    descriptor: string;
-};

--- a/packages/coinjoin/src/types/index.ts
+++ b/packages/coinjoin/src/types/index.ts
@@ -16,4 +16,5 @@ export interface CoinjoinClientSettings extends BaseSettings {
     middlewareUrl: string;
 }
 
+export * from './account';
 export * from './client';

--- a/packages/coinjoin/src/utils/coordinatorUtils.ts
+++ b/packages/coinjoin/src/utils/coordinatorUtils.ts
@@ -1,0 +1,33 @@
+import { payments, Network } from '@trezor/utxo-lib';
+
+import { AllowedScriptTypes } from '../types/coordinator';
+
+// WabiSabi coordinator is using custom format of address scriptPubKey
+// utxo-lib format: `OP_0 {sha256(redeemScript)}`, `OP_1 {witnessProgram}`
+// wabisabi format: `0 hash`, `1 hash`
+export const getScriptPubKeyFromAddress = (
+    address: string,
+    network: Network,
+    scriptType: AllowedScriptTypes,
+) => {
+    if (scriptType === 'P2WPKH') {
+        return `0 ${payments
+            .p2wpkh({
+                address,
+                network,
+            })
+            .hash?.toString('hex')}`;
+    }
+
+    if (scriptType === 'Taproot') {
+        // OP_1: 51
+        return `1 ${payments
+            .p2tr({
+                address,
+                network,
+            })
+            .hash?.toString('hex')}`;
+    }
+
+    throw new Error('Unsupported scriptType');
+};

--- a/packages/coinjoin/tests/utils/coordinatorUtils.test.ts
+++ b/packages/coinjoin/tests/utils/coordinatorUtils.test.ts
@@ -1,0 +1,77 @@
+import { networks } from '@trezor/utxo-lib';
+
+import { getScriptPubKeyFromAddress } from '../../src/utils/coordinatorUtils';
+
+describe('coordinatorUtils', () => {
+    it('getScriptPubKeyFromAddress', () => {
+        expect(
+            getScriptPubKeyFromAddress(
+                'bcrt1qejqxwzfld7zr6mf7ygqy5s5se5xq7vmt8ntmj0',
+                networks.regtest,
+                'P2WPKH',
+            ),
+        ).toEqual('0 cc8067093f6f843d6d3e22004a4290cd0c0f336b');
+
+        expect(
+            getScriptPubKeyFromAddress(
+                'bcrt1pn2d0yjeedavnkd8z8lhm566p0f2utm3lgvxrsdehnl94y34txmtsef5dqz',
+                networks.regtest,
+                'Taproot',
+            ),
+        ).toEqual('1 9a9af24b396f593b34e23fefba6b417a55c5ee3f430c3837379fcb5246ab36d7');
+
+        expect(
+            getScriptPubKeyFromAddress(
+                'tb1paxhjl357yzctuf3fe58fcdx6nul026hhh6kyldpfsf3tckj9a3wslqd7zd',
+                networks.testnet,
+                'Taproot',
+            ),
+        ).toEqual('1 e9af2fc69e20b0be2629cd0e9c34da9f3ef56af7beac4fb4298262bc5a45ec5d');
+        expect(
+            getScriptPubKeyFromAddress(
+                'tb1qkvwu9g3k2pdxewfqr7syz89r3gj557l3uuf9r9',
+                networks.testnet,
+                'P2WPKH',
+            ),
+        ).toEqual('0 b31dc2a236505a6cb9201fa0411ca38a254a7bf1');
+
+        expect(
+            getScriptPubKeyFromAddress(
+                'bc1qkkr2uvry034tsj4p52za2pg42ug4pxg5qfxyfa',
+                networks.bitcoin,
+                'P2WPKH',
+            ),
+        ).toEqual('0 b586ae30647c6ab84aa1a285d505155711509914');
+        expect(
+            getScriptPubKeyFromAddress(
+                'bc1p5cyxnuxmeuwuvkwfem96lqzszd02n6xdcjrs20cac6yqjjwudpxqkedrcr',
+                networks.bitcoin,
+                'Taproot',
+            ),
+        ).toEqual('1 a60869f0dbcf1dc659c9cecbaf8050135ea9e8cdc487053f1dc6880949dc684c');
+
+        // invalid combinations
+        expect(() =>
+            getScriptPubKeyFromAddress(
+                'bc1qkkr2uvry034tsj4p52za2pg42ug4pxg5qfxyfa',
+                networks.testnet, // invalid network
+                'P2WPKH',
+            ),
+        ).toThrow(/Network mismatch/);
+        expect(() =>
+            getScriptPubKeyFromAddress(
+                'bc1qkkr2uvry034tsj4p52za2pg42ug4pxg5qfxyfa',
+                networks.bitcoin,
+                'Taproot', // invalid scriptType
+            ),
+        ).toThrow(/Invalid checksum/);
+        expect(() =>
+            getScriptPubKeyFromAddress(
+                '3AnYTd2FGxJLNKL1AzxfW3FJMntp9D2KKX',
+                networks.bitcoin,
+                // @ts-expect-error
+                'P2SH', // unknown scriptType
+            ),
+        ).toThrow(/Unsupported scriptType/);
+    });
+});

--- a/packages/suite/src/actions/wallet/coinjoinClientActions.ts
+++ b/packages/suite/src/actions/wallet/coinjoinClientActions.ts
@@ -89,7 +89,7 @@ export const initCoinjoinClient =
     };
 
 // return only active instances
-export const getCoinjoinClient = (symbol: Account['symbol']) => () =>
+export const getCoinjoinClient = (symbol: Account['symbol']) =>
     CoinjoinClientService.getInstance(symbol);
 
 // NOTE: this function will be extended in upcoming PR

--- a/packages/suite/src/components/wallet/CoinjoinSummary/BalanceSection.tsx
+++ b/packages/suite/src/components/wallet/CoinjoinSummary/BalanceSection.tsx
@@ -31,7 +31,7 @@ const mockSession: CoinjoinSession = {
     signedRounds: ['1', '1', '1'],
     timeCreated: 1203040234,
     deadline: 1234712054,
-    anonymityLevel: 1,
+    targetAnonymity: 1,
     maxFeePerKvbyte: 2,
     maxCoordinatorFeeRate: 3,
 };

--- a/packages/suite/src/views/wallet/anonymize/components/CoinjoinDefaultStrategy.tsx
+++ b/packages/suite/src/views/wallet/anonymize/components/CoinjoinDefaultStrategy.tsx
@@ -34,13 +34,13 @@ const Text = styled(P)`
 export const COINJOIN_STRATEGIES = {
     recommended: {
         maxRounds: 10,
-        anonymityLevel: 80,
+        targetAnonymity: 80,
         maxFeePerKvbyte: 129000,
         maxCoordinatorFeeRate: 0.003 * 10 ** 10, // 0.003 from coordinator
     },
     fast: {
         maxRounds: 3,
-        anonymityLevel: 40,
+        targetAnonymity: 40,
         maxFeePerKvbyte: 129000,
         maxCoordinatorFeeRate: 0.003 * 10 ** 10, // 0.003 from coordinator
     },

--- a/suite-common/wallet-types/src/coinjoin.ts
+++ b/suite-common/wallet-types/src/coinjoin.ts
@@ -3,8 +3,9 @@ import { NetworkSymbol } from '@suite-common/wallet-config';
 export type CoinjoinServerEnvironment = 'localhost' | 'public';
 
 export interface CoinjoinSessionParameters {
-    anonymityLevel: number;
+    targetAnonymity: number;
     maxRounds: number;
+    skipRounds?: [number, number];
     maxFeePerKvbyte: number;
     maxCoordinatorFeeRate: number;
 }


### PR DESCRIPTION
Cherry picks from [coinjoin branch](https://github.com/trezor/trezor-suite/pull/6485)

1. adding `Account` class to coinjoin package
> - transforming address to custom scriptPubKey format
> -  control Status heartbeat. when account is registered status is fetched more frequently

2. implement coinjoin account registration in suite
> - transform from suite Account to coinjoin Account
> - renamed anonymityLevel in coinjoin params > `targetAnonymity`
> - added `skipRound` to coinjoin params