### PR TITLE
Coinjoin address derivation optimization

### DIFF
--- a/packages/coinjoin/src/backend/CoinjoinBackend.ts
+++ b/packages/coinjoin/src/backend/CoinjoinBackend.ts
@@ -15,6 +15,7 @@ import type {
     ScanAccountCheckpoint,
     ScanAccountProgress,
     Transaction,
+    AccountCache,
 } from '../types/backend';
 
 interface Events {
@@ -45,12 +46,12 @@ export class CoinjoinBackend extends EventEmitter {
         this.mempool = new CoinjoinMempoolController(this.client);
     }
 
-    scanAccount({ descriptor, checkpoint }: ScanAccountParams) {
+    scanAccount({ descriptor, checkpoint, cache }: ScanAccountParams) {
         this.abortController = new AbortController();
         const filters = new CoinjoinFilterController(this.client, this.settings);
 
         return scanAccount(
-            { descriptor, checkpoint: checkpoint ?? this.getInitialCheckpoint() },
+            { descriptor, checkpoint: checkpoint ?? this.getInitialCheckpoint(), cache },
             {
                 client: this.client,
                 network: this.network,
@@ -88,11 +89,13 @@ export class CoinjoinBackend extends EventEmitter {
         descriptor: string,
         transactions: Transaction[],
         checkpoint?: ScanAccountCheckpoint,
+        cache?: AccountCache,
     ) {
         const accountInfo = getAccountInfo({
             descriptor,
             transactions,
             checkpoint,
+            cache,
             network: this.network,
         });
         return Promise.resolve(accountInfo);

--- a/packages/coinjoin/src/backend/backendUtils.ts
+++ b/packages/coinjoin/src/backend/backendUtils.ts
@@ -1,5 +1,7 @@
+import { deriveAddresses as deriveNewAddresses } from '@trezor/utxo-lib';
+
 import type { CoinjoinBackendClient } from './CoinjoinBackendClient';
-import type { VinVout, Transaction } from '../types/backend';
+import type { VinVout, Transaction, PrederivedAddress } from '../types/backend';
 
 export const isTxConfirmed = ({ blockHeight = -1 }: { blockHeight?: number }) => blockHeight > 0;
 
@@ -10,6 +12,21 @@ export const doesTxContainAddress =
             .concat(vout)
             .flatMap(({ addresses = [] }) => addresses)
             .includes(address);
+
+export const deriveAddresses = (
+    prederived: PrederivedAddress[] = [],
+    ...[descriptor, type, from, count, network]: Parameters<typeof deriveNewAddresses>
+) => {
+    const fromPrederived = Math.min(from, prederived.length);
+    const countPrederived = Math.min(prederived.length - fromPrederived, count);
+    const fromNew = Math.max(from, prederived.length);
+    const countNew = Math.max(count - countPrederived, 0);
+
+    const derived = countNew
+        ? deriveNewAddresses(descriptor, type, fromNew, countNew, network)
+        : [];
+    return prederived.slice(fromPrederived, fromPrederived + countPrederived).concat(derived);
+};
 
 /** @deprecated Temporary workaround, should be removed before releasing */
 export const fixTxInputs = (transactions: Transaction[], client: CoinjoinBackendClient) =>

--- a/packages/coinjoin/src/types/backend.ts
+++ b/packages/coinjoin/src/types/backend.ts
@@ -79,6 +79,7 @@ export type ScanAccountProgress = ScanProgress<ScanAccountCheckpoint>;
 export type ScanAccountParams = {
     descriptor: string;
     checkpoint?: ScanAccountCheckpoint;
+    cache?: AccountCache;
 };
 
 export type ScanAddressParams = {
@@ -89,6 +90,7 @@ export type ScanAddressParams = {
 export type ScanAccountResult = {
     pending: Transaction[];
     checkpoint: ScanAccountCheckpoint;
+    cache?: AccountCache;
 };
 
 export type ScanAddressResult = {
@@ -117,13 +119,17 @@ export type FilterClient = Pick<CoinjoinBackendClient, 'fetchFilters'>;
 
 export type MempoolClient = Pick<CoinjoinBackendClient, 'fetchMempoolTxids' | 'fetchTransaction'>;
 
-export type AccountAddress = {
-    address: string;
-    script: Buffer;
-};
-
 export type AccountInfo = AccountInfoBase & {
     utxo: Utxo[];
 };
 
 export type PrederivedAddress = Pick<Address, 'address' | 'path'>;
+
+export type AccountAddress = PrederivedAddress & {
+    script: Buffer;
+};
+
+export type AccountCache = {
+    receivePrederived?: PrederivedAddress[];
+    changePrederived?: PrederivedAddress[];
+};

--- a/packages/coinjoin/src/types/backend.ts
+++ b/packages/coinjoin/src/types/backend.ts
@@ -125,3 +125,5 @@ export type AccountAddress = {
 export type AccountInfo = AccountInfoBase & {
     utxo: Utxo[];
 };
+
+export type PrederivedAddress = Pick<Address, 'address' | 'path'>;

--- a/packages/coinjoin/tests/backend/backendUtils.test.ts
+++ b/packages/coinjoin/tests/backend/backendUtils.test.ts
@@ -1,0 +1,41 @@
+import { deriveAddresses as deriveAddressesOriginal } from '@trezor/utxo-lib';
+
+import { deriveAddresses } from '../../src/backend/backendUtils';
+import { SEGWIT_XPUB } from '../fixtures/methods.fixture';
+
+const PARAMS = [SEGWIT_XPUB, 'receive', 0, 10] as const;
+const ADDRESSES = deriveAddressesOriginal(...PARAMS);
+
+describe('backendUtils', () => {
+    describe('deriveAddresses', () => {
+        it('whole, empty prederived', () => {
+            expect(deriveAddresses(undefined, ...PARAMS)).toEqual(ADDRESSES);
+        });
+
+        it('whole, full prederived', () => {
+            expect(deriveAddresses(ADDRESSES, ...PARAMS)).toEqual(ADDRESSES);
+        });
+
+        it('whole, half prederived', () => {
+            expect(deriveAddresses(ADDRESSES.slice(0, 5), ...PARAMS)).toEqual(ADDRESSES);
+        });
+
+        it('part, empty prederived', () => {
+            expect(deriveAddresses(undefined, SEGWIT_XPUB, 'receive', 3, 5)).toEqual(
+                ADDRESSES.slice(3, 8),
+            );
+        });
+
+        it('part, full prederived', () => {
+            expect(deriveAddresses(ADDRESSES, SEGWIT_XPUB, 'receive', 3, 5)).toEqual(
+                ADDRESSES.slice(3, 8),
+            );
+        });
+
+        it('part, half prederived', () => {
+            expect(deriveAddresses(ADDRESSES.slice(0, 5), SEGWIT_XPUB, 'receive', 3, 5)).toEqual(
+                ADDRESSES.slice(3, 8),
+            );
+        });
+    });
+});

--- a/suite-common/wallet-utils/src/__tests__/accountUtils.test.ts
+++ b/suite-common/wallet-utils/src/__tests__/accountUtils.test.ts
@@ -21,6 +21,7 @@ import {
     sortByCoin,
     getUtxoOutpoint,
     readUtxoOutpoint,
+    sortByBIP44AddressIndex,
 } from '../accountUtils';
 import * as fixtures from '../__fixtures__/accountUtils';
 
@@ -267,5 +268,17 @@ describe('account utils', () => {
             txid: '0dac366fd8a67b2a89fbb0d31086e7acded7a5bbf9ef9daa935bc873229ef5b5',
             vout: 1,
         });
+    });
+
+    it('sortByBIP44AddressIndex', () => {
+        const path = 'm/1234';
+        const [a, b, c, d, e, f] = ['a', 'b', 'c', 'd', 'e', 'f'].map((address, i) => ({
+            address,
+            path: `${path}/${i}`,
+        }));
+        expect(sortByBIP44AddressIndex(path, [a, b, c, d, e, f])).toEqual([a, b, c, d, e, f]);
+        expect(sortByBIP44AddressIndex(path, [f, e, d, c, b, a])).toEqual([a, b, c, d, e, f]);
+        expect(sortByBIP44AddressIndex(path, [e, c, b, a, f, d])).toEqual([a, b, c, d, e, f]);
+        expect(sortByBIP44AddressIndex(path, [b, c, a, f, d, e])).toEqual([a, b, c, d, e, f]);
     });
 });

--- a/suite-common/wallet-utils/src/accountUtils.ts
+++ b/suite-common/wallet-utils/src/accountUtils.ts
@@ -54,6 +54,18 @@ export const getFirstFreshAddress = (
     return firstFreshAddress;
 };
 
+/** NOTE: input addresses' paths sequence must be uninterrupted and start with 0 */
+export const sortByBIP44AddressIndex = <T extends { path: string }>(
+    pathBase: string,
+    addresses: T[],
+) => {
+    const lookup = addresses.reduce<{ [path: string]: number }>((prev, _, i) => {
+        prev[`${pathBase}/${i}`] = i;
+        return prev;
+    }, {});
+    return addresses.slice().sort((a, b) => lookup[a.path] - lookup[b.path]);
+};
+
 export const parseBIP44Path = (path: string) => {
     const regEx = /m\/(\d+'?)\/(\d+'?)\/(\d+'?)\/([0,1])\/(\d+)/;
     const tokens = path.match(regEx);


### PR DESCRIPTION
## Description

Optimizes CoinJoin discovery so every address is (ideally) derived only once.

https://github.com/trezor/trezor-suite/commit/4f35b1c656402023a968c829d51e96376d5e8bf2 - adds `sortAddresses` util meant for potentially unsorted used/unused addresses, which sorts them without the need of parsing path and getting address index.
https://github.com/trezor/trezor-suite/commit/a1bb033952d34c1155c1fa630edb16a6c59dd89a - `deriveAddresses` util is now enhanced in `coinjoin` package so it takes an array of prederived addresses which don't have to be derived again.
https://github.com/trezor/trezor-suite/commit/d30396b9645ee9aff07a597be5994d618d30c6bc - adds optional `cache: AccountCache` param to `scanAccount` and `getAccountInfo` methods which contains prederived addresses if available.
https://github.com/trezor/trezor-suite/commit/da2a16ce57cfe5e234488f9bcf867fdf5bbc51c3 - send cached addresses to `scanAccount` and `getAccountInfo` methods from `coinjoinAccountActions`.
