### PR TITLE
feat(suite): add pause/restore coinjoin actions

### DIFF
--- a/packages/suite/src/actions/wallet/constants/coinjoinConstants.ts
+++ b/packages/suite/src/actions/wallet/constants/coinjoinConstants.ts
@@ -12,3 +12,6 @@ export const CLIENT_DISABLE = '@coinjoin/client-disable';
 export const CLIENT_ENABLE_SUCCESS = '@coinjoin/client-enable-success';
 export const CLIENT_ENABLE_FAILED = '@coinjoin/client-enable-failed';
 export const CLIENT_STATUS = '@coinjoin/client-status';
+
+export const SESSION_PAUSE = '@coinjoin/session-pause';
+export const SESSION_RESTORE = '@coinjoin/session-restore';

--- a/packages/suite/src/components/suite/modals/CancelCoinjoin.tsx
+++ b/packages/suite/src/components/suite/modals/CancelCoinjoin.tsx
@@ -45,7 +45,13 @@ export const CancelCoinjoin = ({ onClose }: CancelCoinjoinProps) => {
                     <CancelButton variant="secondary" onClick={onClose}>
                         <Translation id="TR_CANCEL_COINJOIN_NO" />
                     </CancelButton>
-                    <StyledButton variant="danger" onClick={() => stopCoinjoinSession(account)}>
+                    <StyledButton
+                        variant="danger"
+                        onClick={() => {
+                            stopCoinjoinSession(account);
+                            onClose();
+                        }}
+                    >
                         <Translation id="TR_CANCEL_COINJOIN_YES" />
                     </StyledButton>
                 </>

--- a/packages/suite/src/components/wallet/CoinjoinSummary/BalanceSection.tsx
+++ b/packages/suite/src/components/wallet/CoinjoinSummary/BalanceSection.tsx
@@ -2,6 +2,8 @@ import React from 'react';
 import styled from 'styled-components';
 
 import { goto } from '@suite-actions/routerActions';
+import * as coinjoinActions from '@wallet-actions/coinjoinAccountActions';
+import * as modalActions from '@suite-actions/modalActions';
 import { Account, CoinjoinSession } from '@suite-common/wallet-types';
 import { Card, Translation } from '@suite-components';
 import { useActions, useSelector } from '@suite-hooks';
@@ -43,6 +45,9 @@ interface BalanceSectionProps {
 export const BalanceSection = ({ account }: BalanceSectionProps) => {
     const actions = useActions({
         goto,
+        pauseSession: coinjoinActions.pauseCoinjoinSession.bind(null, account),
+        restoreSession: coinjoinActions.restoreCoinjoinSession.bind(null, account),
+        stopSession: modalActions.openModal.bind(null, { type: 'cancel-coinjoin' }),
     });
     const { coinjoin } = useSelector(state => state.wallet);
 
@@ -55,7 +60,12 @@ export const BalanceSection = ({ account }: BalanceSectionProps) => {
             <BalancePrivacyBreakdown />
 
             {session ? (
-                <CoinjoinStatus session={session} />
+                <CoinjoinStatus
+                    session={session}
+                    pauseSession={actions.pauseSession}
+                    restoreSession={actions.restoreSession}
+                    stopSession={actions.stopSession}
+                />
             ) : (
                 <AnonymizeButton
                     onClick={goToSetup}

--- a/packages/suite/src/reducers/wallet/coinjoinReducer.ts
+++ b/packages/suite/src/reducers/wallet/coinjoinReducer.ts
@@ -94,6 +94,31 @@ const stopSession = (
     }
 };
 
+const pauseSession = (
+    draft: CoinjoinState,
+    payload: ExtractActionPayload<typeof COINJOIN.SESSION_PAUSE>,
+) => {
+    const account = draft.accounts.find(a => a.key === payload.accountKey);
+    if (!account || !account.session) return;
+
+    delete account.session.phase;
+    account.session.registeredUtxos = [];
+    account.session.paused = true;
+    account.session.timeEnded = Date.now();
+};
+
+const restoreSession = (
+    draft: CoinjoinState,
+    payload: ExtractActionPayload<typeof COINJOIN.SESSION_RESTORE>,
+) => {
+    const account = draft.accounts.find(a => a.key === payload.accountKey);
+    if (!account || !account.session) return;
+
+    delete account.session.paused;
+    delete account.session.timeEnded;
+    account.session.timeCreated = Date.now();
+};
+
 const saveCheckpoint = (
     draft: CoinjoinState,
     action: Extract<Action, { type: typeof COINJOIN.ACCOUNT_DISCOVERY_PROGRESS }>,
@@ -158,6 +183,13 @@ export const coinjoinReducer = (
                 break;
             case COINJOIN.CLIENT_STATUS:
                 updateClientStatus(draft, action.payload);
+                break;
+
+            case COINJOIN.SESSION_PAUSE:
+                pauseSession(draft, action.payload);
+                break;
+            case COINJOIN.SESSION_RESTORE:
+                restoreSession(draft, action.payload);
                 break;
 
             // no default

--- a/suite-common/wallet-types/src/coinjoin.ts
+++ b/suite-common/wallet-types/src/coinjoin.ts
@@ -25,6 +25,7 @@ export interface CoinjoinSession extends CoinjoinSessionParameters {
     registeredUtxos: string[]; // list of utxos (outpoints) registered in session
     timeCreated: number; // timestamp when was created
     timeEnded?: number; // timestamp when was finished
+    paused?: boolean; // current state
     phase?: RoundPhase; // current phase enum
     deadline: string | number; // estimated time for phase change
     signedRounds: string[]; // already signed rounds


### PR DESCRIPTION
Prerequisite for [coinjoin branch](https://github.com/trezor/trezor-suite/pull/6485)
- unregister account from CoinjoinClinet on pauseSession, register account to CoinjoinCient on restoreSession
- modify `CoinjoinSession.timeEnded` field to determine if current session is paused or not
- pause running session on application reload (if account is remembered)
- implement actions in CoinjoinStatus component
- fixed closing "cancel coinjoin" modal after confirmation

## To discuss:
- [ ] should we use `CoinjoinSession.timeEnded` or create new field `CoinjoinSession.paused` or something else?
- [ ] top panel `CoinjoinStatusBar` should reflect this state, is it designed?