### PR TITLE
fix(coinmarket): fix handling in progress states of savings flow

### DIFF
--- a/packages/suite/src/actions/wallet/pollingActions.ts
+++ b/packages/suite/src/actions/wallet/pollingActions.ts
@@ -39,6 +39,9 @@ export const request = (key: PollingKey, timeoutId?: number): PollingAction => (
     timeoutId,
 });
 
+export const isPolling = (key: PollingKey) => (_: Dispatch, getState: GetState) =>
+    !!getState().wallet.pollings[key];
+
 export const stopPolling = (key: PollingKey) => (dispatch: Dispatch, getState: GetState) => {
     const polling = getState().wallet.pollings[key];
     if (polling?.timeoutId) {

--- a/packages/suite/src/constants/wallet/coinmarket/savings.ts
+++ b/packages/suite/src/constants/wallet/coinmarket/savings.ts
@@ -1,10 +1,10 @@
 import type { PaymentFrequency } from 'invity-api';
 
 export const CustomPaymentAmountKey = 'Custom';
-export const KYCStatusPollingIntervalMilliseconds = 15_000;
-export const KYCStatusPollingMaxCount = 50;
+export const KYCStatusPollingIntervalMilliseconds = 5_000;
+export const KYCStatusPollingMaxCount = 300;
 export const SavingsTradePollingIntervalMilliseconds = 5_000;
-export const SavingsTradePollingMaxCount = 50;
+export const SavingsTradePollingMaxCount = 300;
 export const PaymentFrequencyAnnualCoefficient: Record<PaymentFrequency, number> = {
     Daily: 365,
     Weekly: 52,

--- a/packages/suite/src/hooks/wallet/useCoinmarketSavingsSetupContinue.ts
+++ b/packages/suite/src/hooks/wallet/useCoinmarketSavingsSetupContinue.ts
@@ -10,6 +10,7 @@ import { getUnusedAddressFromAccount } from '@wallet-utils/coinmarket/coinmarket
 import { CustomPaymentAmountKey } from '@wallet-constants/coinmarket/savings';
 import * as coinmarketSavingsActions from '@wallet-actions/coinmarketSavingsActions';
 import * as coinmarketCommonActions from '@wallet-actions/coinmarket/coinmarketCommonActions';
+import * as pollingActions from '@wallet-actions/pollingActions';
 import {
     calculateAnnualSavings,
     getFiatAmountEffective,
@@ -42,9 +43,10 @@ export const useSavingsSetupContinue = ({
         kycFinalStatus: state.wallet.coinmarket.savings.kycFinalStatus,
     }));
 
-    const { loadInvityData, saveSavingsTradeResponse } = useActions({
+    const { loadInvityData, saveSavingsTradeResponse, isPolling } = useActions({
         loadInvityData: coinmarketCommonActions.loadInvityData,
         saveSavingsTradeResponse: coinmarketSavingsActions.saveSavingsTradeResponse,
+        isPolling: pollingActions.isPolling,
     });
 
     const { navigateToSavingsPaymentInfo, navigateToSavingsOverview } =
@@ -52,7 +54,9 @@ export const useSavingsSetupContinue = ({
 
     const { removeDraft } = useFormDraft('coinmarket-savings-setup-request');
 
-    const isSavingsTradeLoadingEffective = !providers || isSavingsTradeLoading;
+    const pollingKey = `coinmarket-savings-trade/${account.descriptor}` as const;
+    const isSavingsTradeLoadingEffective =
+        (!providers || isSavingsTradeLoading) && !isPolling(pollingKey);
 
     useEffect(() => {
         loadInvityData();

--- a/packages/suite/src/hooks/wallet/useCoinmarketSavingsSetupWaiting.ts
+++ b/packages/suite/src/hooks/wallet/useCoinmarketSavingsSetupWaiting.ts
@@ -7,59 +7,114 @@ import { useActions, useSelector } from '@suite-hooks';
 import { useCoinmarketNavigation } from '@wallet-hooks/useCoinmarketNavigation';
 import { useFormDraft } from '@wallet-hooks/useFormDraft';
 import * as coinmarketCommonActions from '@wallet-actions/coinmarket/coinmarketCommonActions';
+import * as coinmarketSavingsActions from '@wallet-actions/coinmarketSavingsActions';
 import * as pollingActions from '@wallet-actions/pollingActions';
+import {
+    SavingsTradePollingIntervalMilliseconds,
+    SavingsTradePollingMaxCount,
+} from '@wallet-constants/coinmarket/savings';
+import invityAPI, { SavingsTradeKYCFinalStatuses } from '@suite-services/invityAPI';
+import { createReturnLink } from '@wallet-utils/coinmarket/savingsUtils';
 import { isDesktop } from '@suite-utils/env';
 
 export const useCoinmarketSavingsSetupWaiting = ({
     selectedAccount,
 }: UseCoinmarketSavingsSetupWaitingProps): UseCoinmarketSavingsSetupWaitingValues => {
     const { account } = selectedAccount;
-    const { savingsTrade, kycFinalStatus } = useSelector(state => ({
+    const { savingsTrade } = useSelector(state => ({
         savingsTrade: state.wallet.coinmarket.savings.savingsTrade,
-        kycFinalStatus: state.wallet.coinmarket.savings.kycFinalStatus,
     }));
-    const { submitRequestForm, stopPolling } = useActions({
-        submitRequestForm: coinmarketCommonActions.submitRequestForm,
-        stopPolling: pollingActions.stopPolling,
-    });
+    const { loadSavingsTrade, submitRequestForm, startPolling, stopPolling, isPolling } =
+        useActions({
+            loadSavingsTrade: coinmarketSavingsActions.loadSavingsTrade,
+            submitRequestForm: coinmarketCommonActions.submitRequestForm,
+            startPolling: pollingActions.startPolling,
+            stopPolling: pollingActions.stopPolling,
+            isPolling: pollingActions.isPolling,
+        });
 
     const { navigateToSavingsSetup, navigateToSavingsSetupContinue } =
         useCoinmarketNavigation(account);
 
-    const { getDraft } = useFormDraft('coinmarket-savings-setup-request');
+    const { getDraft, saveDraft } = useFormDraft('coinmarket-savings-setup-request');
 
     useEffect(() => {
         if (savingsTrade?.status === 'SetSavingsParameters') {
             navigateToSavingsSetup();
+            return;
         }
-    }, [navigateToSavingsSetup, savingsTrade?.status]);
-
-    useEffect(() => {
-        if (kycFinalStatus && ['Failed', 'Error'].includes(kycFinalStatus)) {
-            if (isDesktop()) {
-                stopPolling(`coinmarket-savings-trade/${account.descriptor}`);
-            }
+        if (
+            savingsTrade?.kycStatus &&
+            SavingsTradeKYCFinalStatuses.includes(savingsTrade.kycStatus)
+        ) {
             navigateToSavingsSetupContinue();
         }
-    }, [account.descriptor, kycFinalStatus, navigateToSavingsSetupContinue, stopPolling]);
+    }, [
+        navigateToSavingsSetup,
+        navigateToSavingsSetupContinue,
+        savingsTrade,
+        savingsTrade?.kycStatus,
+        savingsTrade?.status,
+    ]);
 
-    // TODO:
-    /** Edge case scenario for Suite Web
-     * - user started savings flow
-     * - user uploaded KYC documents on Invity web
-     * - user opened new tab in browser with Suite
-     * - user sees "waiting" page in Suite
-     * - user finishes flow on Invity web
-     * - user still sees "waiting" page
-     * -> user should see "setup continue" page instead of "waiting" page
-     */
+    useEffect(() => {
+        const pollingKey = `coinmarket-savings-trade/${account.descriptor}` as const;
+        if (!isPolling(pollingKey)) {
+            // NOTE: Suite Desktop and Web application might be still open -> start polling savings trade,
+            // so the user sees refreshed UI after successful completion of savings flow on Invity.io page,
+            // and show screen "Waiting for completion on Invity.io web page.".
+            startPolling(
+                pollingKey,
+                () => loadSavingsTrade(),
+                SavingsTradePollingIntervalMilliseconds,
+                SavingsTradePollingMaxCount,
+            );
+        }
+    }, [account.descriptor, isPolling, loadSavingsTrade, startPolling, stopPolling]);
 
-    const handleGoToInvity = useCallback(() => {
+    const handleGoToInvity = useCallback(async () => {
         const form = getDraft(account.descriptor) as Parameters<typeof submitRequestForm>[0];
         if (form) {
             submitRequestForm(form);
+        } else if (
+            savingsTrade?.fiatStringAmount &&
+            savingsTrade.country &&
+            savingsTrade.cryptoCurrency &&
+            savingsTrade.fiatCurrency &&
+            savingsTrade.paymentFrequency
+        ) {
+            const formResponse = await invityAPI.initSavingsTrade({
+                amount: savingsTrade.fiatStringAmount,
+                country: savingsTrade.country,
+                cryptoCurrency: savingsTrade.cryptoCurrency,
+                exchange: savingsTrade.exchange,
+                fiatCurrency: savingsTrade.fiatCurrency,
+                paymentFrequency: savingsTrade.paymentFrequency,
+                returnUrl: await createReturnLink(),
+            });
+            if (formResponse?.form) {
+                saveDraft(account.descriptor, formResponse.form);
+                if (!isDesktop()) {
+                    submitRequestForm(formResponse?.form);
+                }
+            }
+        } else {
+            // NOTE: Fallback - we don't want to leave user here if no draft exists.
+            navigateToSavingsSetup();
         }
-    }, [account.descriptor, getDraft, submitRequestForm]);
+    }, [
+        account.descriptor,
+        getDraft,
+        navigateToSavingsSetup,
+        saveDraft,
+        savingsTrade?.country,
+        savingsTrade?.cryptoCurrency,
+        savingsTrade?.exchange,
+        savingsTrade?.fiatCurrency,
+        savingsTrade?.fiatStringAmount,
+        savingsTrade?.paymentFrequency,
+        submitRequestForm,
+    ]);
 
     return {
         handleGoToInvity,

--- a/packages/suite/src/middlewares/wallet/coinmarketSavingsMiddleware.ts
+++ b/packages/suite/src/middlewares/wallet/coinmarketSavingsMiddleware.ts
@@ -53,8 +53,6 @@ const coinmarketSavingsMiddleware =
                                     ),
                                 ),
                             );
-                        } else {
-                            api.dispatch(coinmarketSavingsActions.setSelectedProvider(undefined));
                         }
                     }
                 });

--- a/packages/suite/src/support/messages.ts
+++ b/packages/suite/src/support/messages.ts
@@ -1375,6 +1375,19 @@ export default defineMessages({
         defaultMessage: 'Go to Invity',
         id: 'TR_SAVINGS_SETUP_WAITING_BUTTON_LABEL',
     },
+    TR_SAVINGS_SETUP_ALL_FEES_INCLUDED: {
+        defaultMessage: 'All fees included',
+        id: 'TR_SAVINGS_SETUP_ALL_FEES_INCLUDED',
+    },
+    TR_SAVINGS_FEES_TOOLTIP: {
+        defaultMessage:
+            "What you see is what you'll get—the amount shown is the final amount you'll be charged. Here is detailed {feesOverviewLink}.",
+        id: 'TR_SAVINGS_FEES_TOOLTIP',
+    },
+    TR_SAVINGS_FEES_TOOLTIP_FEES_LINK: {
+        defaultMessage: 'schedule of fees',
+        id: 'TR_SAVINGS_FEES_TOOLTIP_FEES_LINK',
+    },
     TR_BUY_FOOTER_TEXT_1: {
         defaultMessage:
             'Invity is a comparison tool that connects you to the best exchange providers. They only use location in order to show the most relevant offers.',

--- a/packages/suite/src/views/wallet/coinmarket/savings/setup/components/AllFeesIncluded.tsx
+++ b/packages/suite/src/views/wallet/coinmarket/savings/setup/components/AllFeesIncluded.tsx
@@ -1,0 +1,47 @@
+import React from 'react';
+import styled from 'styled-components';
+import { variables, Tooltip, Link } from '@trezor/components';
+import { Translation } from '@suite-components';
+
+const StyledTooltip = styled(Tooltip)`
+    display: inline-block;
+`;
+
+const StyledLink = styled(Link)`
+    background: none !important;
+    border: none;
+    padding: 0 !important;
+    cursor: pointer;
+    color: ${({ theme }) => theme.TYPE_LIGHTER_GREY};
+    font-size: ${variables.FONT_SIZE.SMALL};
+    font-weight: ${variables.FONT_WEIGHT.MEDIUM};
+    display: inline;
+    align-items: center;
+    text-decoration: underline;
+
+    :hover {
+        opacity: 0.8;
+    }
+`;
+
+const AllFeesIncluded = () => (
+    <StyledTooltip
+        content={
+            <Translation
+                id="TR_SAVINGS_FEES_TOOLTIP"
+                values={{
+                    feesOverviewLink: (
+                        <StyledLink href="https://blog.invity.io/schedule-of-fees">
+                            <Translation id="TR_SAVINGS_FEES_TOOLTIP_FEES_LINK" />
+                        </StyledLink>
+                    ),
+                }}
+            />
+        }
+        dashed
+    >
+        <Translation id="TR_SAVINGS_SETUP_ALL_FEES_INCLUDED" values={{}} />
+    </StyledTooltip>
+);
+
+export default AllFeesIncluded;

--- a/packages/suite/src/views/wallet/coinmarket/savings/setup/continue/index.tsx
+++ b/packages/suite/src/views/wallet/coinmarket/savings/setup/continue/index.tsx
@@ -14,6 +14,7 @@ import { Translation } from '@suite-components';
 import { AddressOptions } from '@wallet-views/coinmarket/common/AddressOptions';
 import FiatAmount from '../components/FiatAmount';
 import Summary from '../components/Summary';
+import AllFeesIncluded from '../components/AllFeesIncluded';
 
 const Header = styled.div`
     font-weight: 500;
@@ -122,6 +123,7 @@ const CoinmarketSavingsSetupContinue = (props: WithSelectedAccountLoadedProps) =
                 fiatAmount={fiatAmount}
                 fiatCurrency={fiatCurrency}
             />
+            <AllFeesIncluded />
             <Summary
                 accountSymbol={account.symbol}
                 annualSavingsCryptoAmount={annualSavingsCryptoAmount}

--- a/packages/suite/src/views/wallet/coinmarket/savings/setup/index.tsx
+++ b/packages/suite/src/views/wallet/coinmarket/savings/setup/index.tsx
@@ -12,6 +12,7 @@ import FiatAmount from './components/FiatAmount';
 import Summary from './components/Summary';
 import { NoProviders, StyledSelectBar } from '@wallet-views/coinmarket';
 import { getTitleForNetwork } from '@suite-common/wallet-utils';
+import AllFeesIncluded from './components/AllFeesIncluded';
 
 const Header = styled.div`
     font-weight: 500;
@@ -213,6 +214,8 @@ const CoinmarketSavingsSetup = (props: WithSelectedAccountLoadedProps) => {
                         fiatAmount={fiatAmount}
                         fiatCurrency={fiatCurrency}
                     />
+
+                    <AllFeesIncluded />
 
                     <Summary
                         accountSymbol={account.symbol}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
This PR fixes behavior of savings flow in Suite Web and Desktop version as well.
- fixes behavior of button "Go to Invity" - now it does react to user's click
- fixes blinking savings setup due to polling savings trade
- prolongs polling to 25 mins (the savings flow can take longer time due to user's identity document check)
- adds UI to better communicate savings fees ("All fees included" with tooltip and link leading to Invity blog)
<!--- Describe your changes in detail -->

## Related Issue
#6303 
