### PR TITLE
feat(suite): configure coinjoin strategies

### DIFF
--- a/packages/suite/src/components/wallet/CoinjoinSummary/BalanceSection.tsx
+++ b/packages/suite/src/components/wallet/CoinjoinSummary/BalanceSection.tsx
@@ -4,7 +4,7 @@ import styled from 'styled-components';
 import { goto } from '@suite-actions/routerActions';
 import * as coinjoinActions from '@wallet-actions/coinjoinAccountActions';
 import * as modalActions from '@suite-actions/modalActions';
-import { Account, CoinjoinSession } from '@suite-common/wallet-types';
+import { Account } from '@suite-common/wallet-types';
 import { Card, Translation } from '@suite-components';
 import { useActions, useSelector } from '@suite-hooks';
 import { Button } from '@trezor/components';
@@ -25,18 +25,6 @@ const AnonymizeButton = styled(Button)`
     height: 46px;
     padding: 9px 18px;
 `;
-
-// temporary for easy testing
-// @ts-expect-error
-const mockSession: CoinjoinSession = {
-    maxRounds: 10,
-    signedRounds: ['1', '1', '1'],
-    timeCreated: 1203040234,
-    deadline: 1234712054,
-    targetAnonymity: 1,
-    maxFeePerKvbyte: 2,
-    maxCoordinatorFeeRate: 3,
-};
 
 interface BalanceSectionProps {
     account: Account;

--- a/packages/suite/src/components/wallet/CoinjoinSummary/CoinjoinStatus.tsx
+++ b/packages/suite/src/components/wallet/CoinjoinSummary/CoinjoinStatus.tsx
@@ -5,6 +5,7 @@ import { CoinjoinSession, RoundPhase } from '@suite-common/wallet-types';
 import { Translation } from '@suite-components/Translation';
 import { CountdownTimer } from '@suite-components';
 import { COINJOIN_PHASE_MESSAGES } from '@suite-constants/coinjoin';
+import { getEstimatedTimePerRound } from '@wallet-utils/coinjoinUtils';
 
 const Container = styled.div`
     position: relative;
@@ -124,7 +125,10 @@ export const CoinjoinStatus = ({
     const menuRef = useRef<HTMLUListElement & { close: () => void }>(null);
     const theme = useTheme();
 
-    const timeLeft = `${(session.maxRounds - session.signedRounds.length) * 2.5}h`; // approximately 2.5h per round
+    const timeLeft = `${
+        (session.maxRounds - session.signedRounds.length) *
+        getEstimatedTimePerRound(!!session.skipRounds)
+    }h`;
     const progress = session.signedRounds.length / (session.maxRounds / 100);
 
     const togglePause = useCallback(async () => {

--- a/packages/suite/src/reducers/wallet/coinjoinReducer.ts
+++ b/packages/suite/src/reducers/wallet/coinjoinReducer.ts
@@ -11,7 +11,6 @@ import { selectSelectedAccount } from './selectedAccountReducer';
 export interface CoinjoinClientFeeRatesMedians {
     fast: number;
     recommended: number;
-    slow: number;
 }
 
 export interface CoinjoinClientInstance {

--- a/packages/suite/src/services/coinjoin/config.ts
+++ b/packages/suite/src/services/coinjoin/config.ts
@@ -24,7 +24,7 @@ export const COINJOIN_NETWORKS: PartialRecord<NetworkSymbol, ServerEnvironment> 
             // client settings
             middlewareUrl: 'https://dev-coinjoin.trezor.io/Cryptography/',
             // suite settings
-            percentageFee: '0.03',
+            percentageFee: '0.3',
         },
         localhost: {
             network: 'regtest',
@@ -38,8 +38,25 @@ export const COINJOIN_NETWORKS: PartialRecord<NetworkSymbol, ServerEnvironment> 
             // client settings
             middlewareUrl: 'http://localhost:8081/Cryptography/',
             // suite settings
-            percentageFee: '0.03',
+            percentageFee: '0.3',
         },
+    },
+};
+
+export const COINJOIN_STRATEGIES = {
+    recommended: {
+        estimatedTime: [8, 16] as [number, number],
+        maxRounds: 10,
+        skipRounds: [4, 5] as [number, number],
+    },
+    fast: {
+        estimatedTime: [2, 14] as [number, number],
+        maxRounds: 3,
+        skipRounds: null,
+    },
+    custom: {
+        estimatedTime: [2, 4] as [number, number],
+        maxRounds: 15,
     },
 };
 

--- a/packages/suite/src/services/coinjoin/config.ts
+++ b/packages/suite/src/services/coinjoin/config.ts
@@ -43,22 +43,13 @@ export const COINJOIN_NETWORKS: PartialRecord<NetworkSymbol, ServerEnvironment> 
     },
 };
 
-export const COINJOIN_STRATEGIES = {
-    recommended: {
-        estimatedTime: [8, 16] as [number, number],
-        maxRounds: 10,
-        skipRounds: [4, 5] as [number, number],
-    },
-    fast: {
-        estimatedTime: [2, 14] as [number, number],
-        maxRounds: 3,
-        skipRounds: null,
-    },
-    custom: {
-        estimatedTime: [2, 4] as [number, number],
-        maxRounds: 15,
-    },
-};
+// coinjoin strategy constants
+export const ESTIMATED_ANONYMITY_GAINED_PER_ROUND = 10;
+export const ESTIMATED_HOURS_PER_ROUND_WITHOUT_SKIPPING_ROUNDS = 1;
+export const ESTIMATED_HOURS_PER_ROUND_WITH_SKIPPING_ROUNDS = 2.5;
+export const ESTIMATED_HOURS_BUFFER_MODIFIER = 0.25;
+export const RECOMMENDED_SKIP_ROUNDS = [4, 5] as [number, number];
+export const DEFAULT_MAX_MINING_FEE = 3;
 
 export const getCoinjoinConfig = (
     network: NetworkSymbol,

--- a/packages/suite/src/services/coinjoin/config.ts
+++ b/packages/suite/src/services/coinjoin/config.ts
@@ -3,10 +3,7 @@ import type { PartialRecord } from '@trezor/type-utils';
 import type { CoinjoinServerEnvironment } from '@suite-common/wallet-types';
 import type { NetworkSymbol } from '@wallet-types';
 
-type CoinjoinNetworksConfig = CoinjoinBackendSettings &
-    CoinjoinClientSettings & {
-        percentageFee: string;
-    };
+type CoinjoinNetworksConfig = CoinjoinBackendSettings & CoinjoinClientSettings;
 
 type ServerEnvironment = PartialRecord<CoinjoinServerEnvironment, CoinjoinNetworksConfig>;
 
@@ -23,8 +20,6 @@ export const COINJOIN_NETWORKS: PartialRecord<NetworkSymbol, ServerEnvironment> 
             baseBlockHash: '0f9188f13cb7b2c71f2a335e3a4fc328bf5beb436012afca590b1a11466e2206',
             // client settings
             middlewareUrl: 'https://dev-coinjoin.trezor.io/Cryptography/',
-            // suite settings
-            percentageFee: '0.3',
         },
         localhost: {
             network: 'regtest',
@@ -37,8 +32,6 @@ export const COINJOIN_NETWORKS: PartialRecord<NetworkSymbol, ServerEnvironment> 
             baseBlockHash: '0f9188f13cb7b2c71f2a335e3a4fc328bf5beb436012afca590b1a11466e2206',
             // client settings
             middlewareUrl: 'http://localhost:8081/Cryptography/',
-            // suite settings
-            percentageFee: '0.3',
         },
     },
 };

--- a/packages/suite/src/utils/wallet/coinjoinUtils.ts
+++ b/packages/suite/src/utils/wallet/coinjoinUtils.ts
@@ -61,24 +61,24 @@ export const breakdownCoinjoinBalance = ({
  * array => object { name: value-in-vBytes }
  */
 export const transformFeeRatesMedians = (medians: CoinjoinStatusEvent['feeRatesMedians']) => {
-    const [fast, recommended, slow] = medians.map(m => m.medianFeeRate);
-    // convert from kvBytes (kilo virtual bytes) to vBytes
+    const [fast, recommended] = medians.map(m => m.medianFeeRate);
+    // convert from kvBytes (kilo virtual bytes) to vBytes (how the value is displayed in UI)
     const kvB2vB = (v: number) => (v ? Math.round(v / 1000) : 1);
+
     return {
         fast: kvB2vB(fast) * 2, // NOTE: this calculation will be smarter once have enough data
         recommended: kvB2vB(recommended),
-        slow: kvB2vB(slow),
     };
 };
 
 /**
  * Transform from coordinator format to coinjoinReducer format `CoinjoinClientInstance`
- * - coordinatorFeeRate: multiplied by 10. representation of percentage value
- * - feeRatesMedians: array => object with values in vBytes
+ * - coordinatorFeeRate: multiply the amount registered for coinjoin by this value to get the total fee
+ * - feeRatesMedians: array => object with values in kvBytes
  */
 export const transformCoinjoinStatus = (event: CoinjoinStatusEvent) => ({
     rounds: event.rounds.map(r => ({ id: r.id, phase: r.phase })),
-    coordinatorFeeRate: event.coordinatorFeeRate * 10,
+    coordinatorFeeRate: event.coordinatorFeeRate,
     feeRatesMedians: transformFeeRatesMedians(event.feeRatesMedians),
 });
 

--- a/packages/suite/src/utils/wallet/coinjoinUtils.ts
+++ b/packages/suite/src/utils/wallet/coinjoinUtils.ts
@@ -1,7 +1,13 @@
 import BigNumber from 'bignumber.js';
+
 import { CoinjoinStatusEvent, RegisterAccountParams } from '@trezor/coinjoin';
 import { getUtxoOutpoint, getBip43Type } from '@suite-common/wallet-utils';
 import { Account, CoinjoinSessionParameters } from '@suite-common/wallet-types';
+import {
+    ESTIMATED_ANONYMITY_GAINED_PER_ROUND,
+    ESTIMATED_HOURS_PER_ROUND_WITHOUT_SKIPPING_ROUNDS,
+    ESTIMATED_HOURS_PER_ROUND_WITH_SKIPPING_ROUNDS,
+} from '@suite/services/coinjoin/config';
 
 export type CoinjoinBalanceBreakdown = {
     notAnonymized: string;
@@ -128,3 +134,18 @@ export const getRegisterAccountParams = (
     utxos: getCoinjoinAccountUtxos(account.utxo, account.addresses?.anonymitySet),
     changeAddresses: getCoinjoinAccountAddresses(account.addresses),
 });
+
+// calculate max rounds from anonymity levels
+export const getMaxRounds = (
+    targetAnonymity: number,
+    anonymitySet: Record<string, number | undefined>,
+) => {
+    const lowestAnonymity = Math.min(...Object.values(anonymitySet).map(item => item ?? 1));
+    return Math.ceil((targetAnonymity - lowestAnonymity) / ESTIMATED_ANONYMITY_GAINED_PER_ROUND);
+};
+
+// get time estimate in hours per round
+export const getEstimatedTimePerRound = (skipRounds: boolean) =>
+    skipRounds
+        ? ESTIMATED_HOURS_PER_ROUND_WITH_SKIPPING_ROUNDS
+        : ESTIMATED_HOURS_PER_ROUND_WITHOUT_SKIPPING_ROUNDS;

--- a/packages/suite/src/views/wallet/anonymize/components/CoinjoinCustomStrategy.tsx
+++ b/packages/suite/src/views/wallet/anonymize/components/CoinjoinCustomStrategy.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import styled from 'styled-components';
 
-import { COINJOIN_STRATEGIES } from '@suite/services/coinjoin/config';
+import { RECOMMENDED_SKIP_ROUNDS } from '@suite/services/coinjoin/config';
 import { Translation } from '@suite-components';
 import { Button, P, Range, Switch, variables } from '@trezor/components';
 import { CoinjoinSessionDetail } from './CoinjoinSessionDetail';
@@ -98,6 +98,7 @@ const StyledSwitch = styled(Switch)`
 
 interface CoinjoinCustomStrategyProps {
     maxFee: number;
+    maxRounds: number;
     reset: () => void;
     setMaxFee: React.Dispatch<React.SetStateAction<number>>;
     setSkipRounds: React.Dispatch<React.SetStateAction<boolean>>;
@@ -106,11 +107,13 @@ interface CoinjoinCustomStrategyProps {
 
 export const CoinjoinCustomStrategy = ({
     maxFee,
+    maxRounds,
     reset,
     setMaxFee,
     setSkipRounds,
     skipRounds,
 }: CoinjoinCustomStrategyProps) => {
+    const skipRoundsValue = skipRounds ? RECOMMENDED_SKIP_ROUNDS : null;
     const trackStyle = {
         background:
             'linear-gradient(270deg, #bf6767 0%, #c8b882 18.73%, #c8b883 36.25%, #95cda5 43.99%,#2a9649 100%)',
@@ -158,12 +161,9 @@ export const CoinjoinCustomStrategy = ({
                         <Translation id="TR_OVERVIEW" />
                     </DetailHeading>
                     <CoinjoinSessionDetail
-                        maxRounds={COINJOIN_STRATEGIES.custom.maxRounds}
+                        maxRounds={maxRounds}
                         maxFee={maxFee}
-                        hours={COINJOIN_STRATEGIES.custom.estimatedTime}
-                        skipRounds={
-                            COINJOIN_STRATEGIES[skipRounds ? 'recommended' : 'fast'].skipRounds
-                        }
+                        skipRounds={skipRoundsValue}
                     />
                 </DetailWrapper>
             </MiddleRow>

--- a/packages/suite/src/views/wallet/anonymize/components/CoinjoinCustomStrategy.tsx
+++ b/packages/suite/src/views/wallet/anonymize/components/CoinjoinCustomStrategy.tsx
@@ -1,6 +1,7 @@
-import React, { useState } from 'react';
+import React from 'react';
 import styled from 'styled-components';
 
+import { COINJOIN_STRATEGIES } from '@suite/services/coinjoin/config';
 import { Translation } from '@suite-components';
 import { Button, P, Range, Switch, variables } from '@trezor/components';
 import { CoinjoinSessionDetail } from './CoinjoinSessionDetail';
@@ -96,13 +97,20 @@ const StyledSwitch = styled(Switch)`
 `;
 
 interface CoinjoinCustomStrategyProps {
+    maxFee: number;
     reset: () => void;
+    setMaxFee: React.Dispatch<React.SetStateAction<number>>;
+    setSkipRounds: React.Dispatch<React.SetStateAction<boolean>>;
+    skipRounds: boolean;
 }
 
-export const CoinjoinCustomStrategy = ({ reset }: CoinjoinCustomStrategyProps) => {
-    const [maxFee, setMaxFee] = useState(3);
-    const [skipRounds, setSkipRounds] = useState(true);
-
+export const CoinjoinCustomStrategy = ({
+    maxFee,
+    reset,
+    setMaxFee,
+    setSkipRounds,
+    skipRounds,
+}: CoinjoinCustomStrategyProps) => {
     const trackStyle = {
         background:
             'linear-gradient(270deg, #bf6767 0%, #c8b882 18.73%, #c8b883 36.25%, #95cda5 43.99%,#2a9649 100%)',
@@ -150,10 +158,12 @@ export const CoinjoinCustomStrategy = ({ reset }: CoinjoinCustomStrategyProps) =
                         <Translation id="TR_OVERVIEW" />
                     </DetailHeading>
                     <CoinjoinSessionDetail
-                        maxRounds={15}
+                        maxRounds={COINJOIN_STRATEGIES.custom.maxRounds}
                         maxFee={maxFee}
-                        hours={[2, 4]}
-                        skipRounds={skipRounds ? [4, 5] : null}
+                        hours={COINJOIN_STRATEGIES.custom.estimatedTime}
+                        skipRounds={
+                            COINJOIN_STRATEGIES[skipRounds ? 'recommended' : 'fast'].skipRounds
+                        }
                     />
                 </DetailWrapper>
             </MiddleRow>

--- a/packages/suite/src/views/wallet/anonymize/components/CoinjoinDefaultStrategy.tsx
+++ b/packages/suite/src/views/wallet/anonymize/components/CoinjoinDefaultStrategy.tsx
@@ -1,8 +1,10 @@
 import React from 'react';
 import styled from 'styled-components';
 
+import { COINJOIN_STRATEGIES } from '@suite/services/coinjoin/config';
 import { Translation } from '@suite-components';
 import { Button, P, variables } from '@trezor/components';
+import { CoinjoinClientFeeRatesMedians } from '@wallet-reducers/coinjoinReducer';
 import { RadioFrame } from './RadioFrame';
 import { CoinjoinSessionDetail } from './CoinjoinSessionDetail';
 
@@ -29,31 +31,16 @@ const Text = styled(P)`
     margin: 20px 0;
 `;
 
-// Parameters sent to TrezorConnect.authorizeCoinjoin method
-// TODO: replace with dynamic values
-export const COINJOIN_STRATEGIES = {
-    recommended: {
-        maxRounds: 10,
-        targetAnonymity: 80,
-        maxFeePerKvbyte: 129000,
-        maxCoordinatorFeeRate: 0.003 * 10 ** 10, // 0.003 from coordinator
-    },
-    fast: {
-        maxRounds: 3,
-        targetAnonymity: 40,
-        maxFeePerKvbyte: 129000,
-        maxCoordinatorFeeRate: 0.003 * 10 ** 10, // 0.003 from coordinator
-    },
-};
-
-export type CoinJoinStrategy = keyof typeof COINJOIN_STRATEGIES | 'custom';
+export type CoinJoinStrategy = keyof typeof COINJOIN_STRATEGIES;
 
 interface CoinjoinDefaultStrategyProps {
+    feeRatesMedians: CoinjoinClientFeeRatesMedians;
     setStrategy: React.Dispatch<React.SetStateAction<CoinJoinStrategy>>;
     strategy: CoinJoinStrategy;
 }
 
 export const CoinjoinDefaultStrategy = ({
+    feeRatesMedians,
     strategy,
     setStrategy,
 }: CoinjoinDefaultStrategyProps) => {
@@ -86,9 +73,9 @@ export const CoinjoinDefaultStrategy = ({
                 >
                     <CoinjoinSessionDetail
                         maxRounds={COINJOIN_STRATEGIES.recommended.maxRounds}
-                        maxFee={3}
-                        hours={[8, 16]}
-                        skipRounds={[4, 5]}
+                        maxFee={feeRatesMedians.recommended}
+                        hours={COINJOIN_STRATEGIES.recommended.estimatedTime}
+                        skipRounds={COINJOIN_STRATEGIES.recommended.skipRounds}
                     />
                 </RadioFrame>
                 <RadioFrame
@@ -99,9 +86,9 @@ export const CoinjoinDefaultStrategy = ({
                 >
                     <CoinjoinSessionDetail
                         maxRounds={COINJOIN_STRATEGIES.fast.maxRounds}
-                        maxFee={10}
-                        hours={[2, 14]}
-                        skipRounds={null}
+                        maxFee={feeRatesMedians.fast}
+                        hours={COINJOIN_STRATEGIES.fast.estimatedTime}
+                        skipRounds={COINJOIN_STRATEGIES.fast.skipRounds}
                     />
                 </RadioFrame>
             </ButtonRow>

--- a/packages/suite/src/views/wallet/anonymize/components/CoinjoinDefaultStrategy.tsx
+++ b/packages/suite/src/views/wallet/anonymize/components/CoinjoinDefaultStrategy.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import styled from 'styled-components';
 
-import { COINJOIN_STRATEGIES } from '@suite/services/coinjoin/config';
+import { RECOMMENDED_SKIP_ROUNDS } from '@suite/services/coinjoin/config';
 import { Translation } from '@suite-components';
 import { Button, P, variables } from '@trezor/components';
 import { CoinjoinClientFeeRatesMedians } from '@wallet-reducers/coinjoinReducer';
@@ -31,21 +31,22 @@ const Text = styled(P)`
     margin: 20px 0;
 `;
 
-export type CoinJoinStrategy = keyof typeof COINJOIN_STRATEGIES;
+export type CoinJoinStrategy = 'custom' | 'fast' | 'recommended';
 
 interface CoinjoinDefaultStrategyProps {
     feeRatesMedians: CoinjoinClientFeeRatesMedians;
+    maxRounds: number;
     setStrategy: React.Dispatch<React.SetStateAction<CoinJoinStrategy>>;
     strategy: CoinJoinStrategy;
 }
 
 export const CoinjoinDefaultStrategy = ({
     feeRatesMedians,
+    maxRounds,
     strategy,
     setStrategy,
 }: CoinjoinDefaultStrategyProps) => {
     const isRecommended = strategy === 'recommended';
-    const isFast = strategy === 'fast';
 
     const setCustom = () => setStrategy('custom');
     const setRecommended = () => setStrategy('recommended');
@@ -72,23 +73,21 @@ export const CoinjoinDefaultStrategy = ({
                     onClick={setRecommended}
                 >
                     <CoinjoinSessionDetail
-                        maxRounds={COINJOIN_STRATEGIES.recommended.maxRounds}
+                        maxRounds={maxRounds}
                         maxFee={feeRatesMedians.recommended}
-                        hours={COINJOIN_STRATEGIES.recommended.estimatedTime}
-                        skipRounds={COINJOIN_STRATEGIES.recommended.skipRounds}
+                        skipRounds={RECOMMENDED_SKIP_ROUNDS}
                     />
                 </RadioFrame>
                 <RadioFrame
                     heading="TR_FAST"
                     subheading="TR_FAST_SUBHEADING"
-                    isSelected={isFast}
+                    isSelected={!isRecommended}
                     onClick={setFast}
                 >
                     <CoinjoinSessionDetail
-                        maxRounds={COINJOIN_STRATEGIES.fast.maxRounds}
+                        maxRounds={maxRounds}
                         maxFee={feeRatesMedians.fast}
-                        hours={COINJOIN_STRATEGIES.fast.estimatedTime}
-                        skipRounds={COINJOIN_STRATEGIES.fast.skipRounds}
+                        skipRounds={null}
                     />
                 </RadioFrame>
             </ButtonRow>

--- a/packages/suite/src/views/wallet/anonymize/components/CoinjoinSessionDetail.tsx
+++ b/packages/suite/src/views/wallet/anonymize/components/CoinjoinSessionDetail.tsx
@@ -1,6 +1,8 @@
 import React from 'react';
 import styled from 'styled-components';
 
+import { ESTIMATED_HOURS_BUFFER_MODIFIER } from '@suite/services/coinjoin/config';
+import { getEstimatedTimePerRound } from '@wallet-utils/coinjoinUtils';
 import { Translation } from '@suite-components';
 import { DetailRow } from './DetailRow';
 
@@ -12,52 +14,58 @@ const Separator = styled.hr`
 `;
 
 interface CoinjoinSessionDetailProps {
-    hours: [number, number];
     maxFee: number;
     maxRounds: number;
     skipRounds: [number, number] | null;
 }
 
 export const CoinjoinSessionDetail = ({
-    hours,
     maxRounds,
     maxFee,
     skipRounds,
-}: CoinjoinSessionDetailProps) => (
-    <dl>
-        <DetailRow
-            term={<Translation id="TR_ESTIMATED_TIME" />}
-            value={
-                <Translation
-                    id="TR_ESTIMATED_TIME_VALUE"
-                    values={{ max: hours[1], min: hours[0] }}
-                />
-            }
-        />
-        <DetailRow
-            term={<Translation id="TR_ROUNDS" />}
-            value={<Translation id="TR_ROUNDS_VALUE" values={{ rounds: maxRounds }} />}
-            tooltipMessage="TR_ROUNDS_TOOLTIP"
-        />
-        <DetailRow
-            term={<Translation id="TR_SKIP_ROUNDS" />}
-            value={
-                skipRounds ? (
+}: CoinjoinSessionDetailProps) => {
+    const estimatedTime = maxRounds * getEstimatedTimePerRound(!!skipRounds);
+    const timeBuffer = estimatedTime * ESTIMATED_HOURS_BUFFER_MODIFIER;
+    const maxEstimatedTime = Math.ceil(estimatedTime + timeBuffer);
+    const minEstimatedTime = Math.floor(estimatedTime - timeBuffer);
+    const maxMiningFeeValue = `${maxFee} sat/vB`;
+
+    return (
+        <dl>
+            <DetailRow
+                term={<Translation id="TR_ESTIMATED_TIME" />}
+                value={
                     <Translation
-                        id="TR_SKIP_ROUNDS_VALUE"
-                        values={{ part: skipRounds[0], total: skipRounds[1] }}
+                        id="TR_ESTIMATED_TIME_VALUE"
+                        values={{ max: maxEstimatedTime, min: minEstimatedTime }}
                     />
-                ) : (
-                    <Translation id="TR_NONE" />
-                )
-            }
-            tooltipMessage="TR_SKIP_ROUNDS_TOOLTIP"
-        />
-        <Separator />
-        <DetailRow
-            term={<Translation id="TR_MAX_MINING_FEE" />}
-            value={`${maxFee} sat/vB`}
-            tooltipMessage="TR_MAX_MINING_FEE_TOOLTIP"
-        />
-    </dl>
-);
+                }
+            />
+            <DetailRow
+                term={<Translation id="TR_ROUNDS" />}
+                value={<Translation id="TR_ROUNDS_VALUE" values={{ rounds: maxRounds }} />}
+                tooltipMessage="TR_ROUNDS_TOOLTIP"
+            />
+            <DetailRow
+                term={<Translation id="TR_SKIP_ROUNDS" />}
+                value={
+                    skipRounds ? (
+                        <Translation
+                            id="TR_SKIP_ROUNDS_VALUE"
+                            values={{ part: skipRounds[0], total: skipRounds[1] }}
+                        />
+                    ) : (
+                        <Translation id="TR_NONE" />
+                    )
+                }
+                tooltipMessage="TR_SKIP_ROUNDS_TOOLTIP"
+            />
+            <Separator />
+            <DetailRow
+                term={<Translation id="TR_MAX_MINING_FEE" />}
+                value={maxMiningFeeValue}
+                tooltipMessage="TR_MAX_MINING_FEE_TOOLTIP"
+            />
+        </dl>
+    );
+};

--- a/packages/suite/src/views/wallet/anonymize/index.tsx
+++ b/packages/suite/src/views/wallet/anonymize/index.tsx
@@ -21,7 +21,7 @@ const Anonymize = () => {
                     <WalletLayoutHeader title="TR_NAV_ANONYMIZE">
                         <StyledAnonymityLevelSetup />
                     </WalletLayoutHeader>
-                    <CoinjoinSetupStrategies selectedAccount={selectedAccount} />
+                    <CoinjoinSetupStrategies account={selectedAccount.account} />
                 </>
             )}
         </WalletLayout>

--- a/packages/suite/src/views/wallet/anonymize/index.tsx
+++ b/packages/suite/src/views/wallet/anonymize/index.tsx
@@ -16,11 +16,13 @@ const Anonymize = () => {
 
     return (
         <WalletLayout title="TR_NAV_ANONYMIZE" account={selectedAccount}>
-            <WalletLayoutHeader title="TR_NAV_ANONYMIZE">
-                <StyledAnonymityLevelSetup />
-            </WalletLayoutHeader>
-            {selectedAccount.account && (
-                <CoinjoinSetupStrategies account={selectedAccount.account} />
+            {selectedAccount.status === 'loaded' && (
+                <>
+                    <WalletLayoutHeader title="TR_NAV_ANONYMIZE">
+                        <StyledAnonymityLevelSetup />
+                    </WalletLayoutHeader>
+                    <CoinjoinSetupStrategies selectedAccount={selectedAccount} />
+                </>
             )}
         </WalletLayout>
     );

--- a/packages/suite/src/views/wallet/transactions/components/CoinjoinAccountEmpty.tsx
+++ b/packages/suite/src/views/wallet/transactions/components/CoinjoinAccountEmpty.tsx
@@ -1,9 +1,10 @@
 import React from 'react';
 import styled from 'styled-components';
 import { useDispatch } from 'react-redux';
+
+import { useSelector } from '@suite-hooks';
 import { Account } from '@wallet-types';
 import { Button, Card, H2, Image, P, variables } from '@trezor/components';
-import { getCoinjoinConfig } from '@suite/services/coinjoin/config';
 import { Translation } from '@suite-components/Translation';
 import { goto } from '@suite-actions/routerActions';
 
@@ -33,7 +34,7 @@ interface CoinjoinAccountEmptyProps {
 }
 
 export const CoinjoinAccountEmpty = ({ account }: CoinjoinAccountEmptyProps) => {
-    const { percentageFee } = getCoinjoinConfig(account.symbol);
+    const coordinatorData = useSelector(state => state.wallet.coinjoin.clients[account.symbol]);
 
     const dispatch = useDispatch();
 
@@ -49,12 +50,14 @@ export const CoinjoinAccountEmpty = ({ account }: CoinjoinAccountEmptyProps) => 
                 <Translation id="TR_COINJOIN_ACCESS_ACCOUNT_STEP_INITIAL_DESCRIPTION" />
             </AccountDescription>
 
-            <FeeText>
-                <Translation
-                    id="TR_COINJOIN_ACCESS_ACCOUNT_STEP_INITIAL_FEE_MESSAGE"
-                    values={{ fee: percentageFee }}
-                />
-            </FeeText>
+            {coordinatorData && (
+                <FeeText>
+                    <Translation
+                        id="TR_COINJOIN_ACCESS_ACCOUNT_STEP_INITIAL_FEE_MESSAGE"
+                        values={{ fee: coordinatorData.coordinatorFeeRate * 100 }}
+                    />
+                </FeeText>
+            )}
 
             <Button onClick={() => dispatch(goto('wallet-receive', { preserveParams: true }))}>
                 <Translation


### PR DESCRIPTION
Display real values in CoinJoin Strategy.

## Description
This PR is aimed at displaying values received from coordinator (max mining fee) or config (estimated time, max rounds, skip rounds) or both (coordinator fee rate - see discussion in #6563) and feeding them to `TrezorConnect.authorizeCoinjoin`. Some things need to be defined/confirmed before send the PR for review:

1) The Service fee displayed is a simple calculation of `notAnonymized` x `coordinatorFeeRate`. This might be incorrect, coins with anonymity > 1 will not incur any coordinator fee IIRC. Are there any instructions for rounding the fee amount to whole satoshis or should standard rounding be applied?
2) The time estimates for `recommended`, `fast` and `custom` strategy need to be defined. For `custom` strategy, there needs to be some sort of calculation or the value should be omitted.
3) Max rounds for each strategy need to be defined, the current values are probably not final. It is not customizable in `custom` strategy.
4) The range in `custom` strategy only allows values between 1 and 100, while the current `recommended` value is 129.
5) Max mining fee is duplicated in `custom` strategy - green value above range + the grey box.

## Related Issue

Resolve #6625

## Screenshots (if appropriate):
![Screenshot 2022-10-21 at 23 28 14](https://user-images.githubusercontent.com/42465546/197291461-0fd80d62-d02b-4c37-8cd5-97b93bf70c0f.png)
