### PR TITLE
test(connect): fix setup - fallback firmware

### DIFF
--- a/packages/connect/e2e/run.ts
+++ b/packages/connect/e2e/run.ts
@@ -36,7 +36,10 @@ const getEmulatorOptions = (availableFirmwares: Firmwares) => {
     if (firmwareArg === '1-latest') {
         Object.assign(emulatorStartOpts, { version: latest1 });
     }
-
+    // no firmwareArg and not loading from url at the same time - provide fallback
+    if (!firmwareArg && !firmwareUrl) {
+        Object.assign(emulatorStartOpts, { version: latest2 });
+    }
     if (firmwareUrl) {
         Object.assign(emulatorStartOpts, {
             type: 'emulator-start-from-url',


### PR DESCRIPTION
Forgot to provide some fallback for cases when no firmware is specified for tests