### PR TITLE
CoinJoin - multiple CJ accounts interference fix

### DIFF
--- a/packages/coinjoin/src/backend/CoinjoinBackend.ts
+++ b/packages/coinjoin/src/backend/CoinjoinBackend.ts
@@ -21,11 +21,22 @@ interface Events {
     progress: ScanAccountProgress;
 }
 
+type EventType<K extends keyof Events, D extends string> = `${K}/${D}`;
+
 export declare interface CoinjoinBackend {
-    on<K extends keyof Events>(type: K, listener: (event: Events[K]) => void): this;
-    off<K extends keyof Events>(type: K, listener: (event: Events[K]) => void): this;
-    emit<K extends keyof Events>(type: K, ...args: Events[K][]): boolean;
-    removeAllListeners<K extends keyof Events>(type?: K): this;
+    on<K extends keyof Events, D extends string>(
+        type: EventType<K, D>,
+        listener: (event: Events[K]) => void,
+    ): this;
+    off<K extends keyof Events, D extends string>(
+        type: EventType<K, D>,
+        listener: (event: Events[K]) => void,
+    ): this;
+    emit<K extends keyof Events, D extends string>(
+        type: EventType<K, D>,
+        ...args: Events[K][]
+    ): boolean;
+    removeAllListeners<K extends keyof Events, D extends string>(type?: EventType<K, D>): this;
 }
 
 export class CoinjoinBackend extends EventEmitter {
@@ -57,7 +68,7 @@ export class CoinjoinBackend extends EventEmitter {
                 abortSignal: this.abortController.signal,
                 filters,
                 mempool: this.mempool,
-                onProgress: progress => this.emit('progress', progress),
+                onProgress: progress => this.emit(`progress/${descriptor}`, progress),
             },
         );
     }
@@ -75,7 +86,7 @@ export class CoinjoinBackend extends EventEmitter {
                 filters,
                 mempool: this.mempool,
                 onProgress: progress =>
-                    this.emit('progress', {
+                    this.emit(`progress/${descriptor}`, {
                         ...progress,
                         // TODO resolve this correctly
                         checkpoint: { ...progress.checkpoint, receiveCount: -1, changeCount: -1 },

--- a/packages/suite/src/actions/wallet/coinjoinAccountActions.ts
+++ b/packages/suite/src/actions/wallet/coinjoinAccountActions.ts
@@ -139,7 +139,7 @@ export const fetchAndUpdateAccount =
         if (!api) throw new Error('CoinjoinBackendService api not found');
 
         try {
-            api.on('progress', onProgress);
+            api.on(`progress/${account.descriptor}`, onProgress);
 
             const { pending, checkpoint } = await api.scanAccount({
                 descriptor: account.descriptor,
@@ -186,7 +186,7 @@ export const fetchAndUpdateAccount =
                 ),
             );
         } finally {
-            api.off('progress', onProgress);
+            api.off(`progress/${account.descriptor}`, onProgress);
         }
     };
 

--- a/packages/suite/src/components/wallet/WalletLayout/index.tsx
+++ b/packages/suite/src/components/wallet/WalletLayout/index.tsx
@@ -43,8 +43,7 @@ type ProgressInfo = {
 };
 
 const AccountLoadingProgress = ({ account: { account } }: Pick<WalletLayoutProps, 'account'>) => {
-    const network = account?.symbol;
-    const backendType = account?.backendType;
+    const { symbol: network, backendType, descriptor } = account || {};
     const [progress, setProgress] = useState<ProgressInfo>();
 
     useEffect(() => {
@@ -52,11 +51,11 @@ const AccountLoadingProgress = ({ account: { account } }: Pick<WalletLayoutProps
         const backend = CoinjoinBackendService.getInstance(network);
         if (!backend) return;
         const onProgress = ({ info }: { info?: ProgressInfo }) => setProgress(info);
-        backend.on('progress', onProgress);
+        backend.on(`progress/${descriptor}`, onProgress);
         return () => {
-            backend.off('progress', onProgress);
+            backend.off(`progress/${descriptor}`, onProgress);
         };
-    }, [network, backendType]);
+    }, [network, backendType, descriptor]);
 
     return progress ? (
         <>


### PR DESCRIPTION
## Description

When multiple CJ accounts are remembered (e.g. on standard and hidden wallet), their data (txs, utxos...) are mixed together when syncing.

In this fix, account `descriptor` is added to `progress` event type which should resolve the issue.
