### PR TITLE
handling coinjoin round in suite (part1)

### DIFF
--- a/packages/coinjoin/src/client/CoinjoinClient.ts
+++ b/packages/coinjoin/src/client/CoinjoinClient.ts
@@ -2,12 +2,21 @@ import { EventEmitter } from 'events';
 
 import { Status } from './Status';
 import { Account } from './Account';
+import { CoinjoinRound } from './CoinjoinRound';
 import { getNetwork } from '../utils/settingsUtils';
-import type { CoinjoinClientSettings, RegisterAccountParams } from '../types';
-import type { CoinjoinStatusEvent } from '../types/client';
+import type {
+    CoinjoinClientSettings,
+    RegisterAccountParams,
+    CoinjoinStatusEvent,
+    CoinjoinRoundEvent,
+    CoinjoinRequestEvent,
+    CoinjoinResponseEvent,
+} from '../types';
 
 interface Events {
     status: CoinjoinStatusEvent;
+    round: CoinjoinRoundEvent;
+    request: CoinjoinRequestEvent[];
     exception: string;
 }
 
@@ -23,7 +32,8 @@ export class CoinjoinClient extends EventEmitter {
     private network;
     private abortController: AbortController; // used for interruption
     private status: Status;
-    private accounts: Account[] = [];
+    private accounts: Account[] = []; // list of registered accounts
+    private rounds: CoinjoinRound[] = []; // list of active rounds
 
     constructor(settings: CoinjoinClientSettings) {
         super();
@@ -76,11 +86,21 @@ export class CoinjoinClient extends EventEmitter {
     updateAccount(account: RegisterAccountParams) {
         const accountToUpdate = this.accounts.find(a => a.accountKey === account.accountKey);
         if (accountToUpdate) {
+            this.rounds.forEach(round => round.updateAccount(account));
+
             accountToUpdate.update(account);
+
+            // try to trigger registration immediately without waiting for Status change
+            this.onStatusUpdate({
+                rounds: this.status.rounds,
+                changed: [],
+            });
         }
     }
 
     unregisterAccount(accountKey: string) {
+        this.rounds.forEach(round => round.unregisterAccount(accountKey));
+
         this.accounts = this.accounts.filter(a => a.accountKey !== accountKey);
 
         // iterate Status less frequently
@@ -89,10 +109,90 @@ export class CoinjoinClient extends EventEmitter {
         }
     }
 
-    resolveRequest() {}
+    resolveRequest(response: CoinjoinResponseEvent[]) {
+        const { rounds } = this.status;
+        const changed: typeof rounds = [];
+        response.forEach(event => {
+            const currentRound = this.rounds.find(r => r.id === event.roundId);
+            if (currentRound) {
+                currentRound.resolveRequest(event);
+                const statusRound = this.status.rounds.find(r => r.id === event.roundId);
+                if (statusRound) {
+                    changed.push(statusRound);
+                }
+            }
+        });
 
-    private onStatusUpdate({ changed, rounds }: Pick<CoinjoinStatusEvent, 'changed' | 'rounds'>) {
-        // To be implemented soon
-        if (changed && rounds) return Promise.resolve();
+        // trigger round processing
+        this.onStatusUpdate({ rounds, changed });
+    }
+
+    private async onStatusUpdate({
+        changed,
+        rounds,
+    }: Pick<CoinjoinStatusEvent, 'changed' | 'rounds'>) {
+        // find all CoinjoinRounds changed by Status
+        const roundsToProcess = await Promise.all(
+            changed.flatMap(round => {
+                const currentRound = this.rounds.find(r => r.id === round.id);
+                if (currentRound) {
+                    // try to finish/interrupt current running process on changed round (if any)
+                    // and update fresh data from Status
+                    return currentRound.onPhaseChange(round);
+                }
+                return [];
+            }),
+        );
+
+        // there are no CoinjoinRounds to process? try to create new one
+        if (roundsToProcess.length === 0) {
+            const newRound = await CoinjoinRound.create(this.accounts, rounds, this.rounds, {
+                signal: this.abortController.signal,
+                coordinatorName: this.settings.coordinatorName,
+                coordinatorUrl: this.settings.coordinatorUrl,
+                middlewareUrl: this.settings.middlewareUrl,
+                log: (..._args: any[]) => {}, // TODO: log
+            });
+            if (newRound) {
+                roundsToProcess.push(newRound);
+                if (!this.rounds.find(r => r.id === newRound.id)) {
+                    newRound.on('changed', event => this.emit('round', event));
+                    newRound.on('ended', ({ round }) => {
+                        round.inputs.concat(round.failed).forEach(input => {
+                            // remove identities from Status
+                            this.status.removeIdentity(input.outpoint);
+                        });
+                        // remove round from the list
+                        this.rounds = this.rounds.filter(r => r.id !== newRound.id);
+                        // set Status mode
+                        if (this.rounds.length === 0) {
+                            this.status.setMode(this.accounts.length > 0 ? 'enabled' : 'idle');
+                        }
+                    });
+                    // add new round to the list
+                    this.rounds.push(newRound);
+                }
+            }
+        }
+
+        // process rounds
+        const processedRounds = await Promise.all(
+            roundsToProcess.map(round => {
+                // add new identity to Status
+                round.inputs.forEach(u => {
+                    this.status.addIdentity(u.outpoint);
+                });
+                this.status.setMode('registered');
+
+                // wait for the result
+                return round.process(this.accounts);
+            }),
+        );
+
+        // check for wallet requests
+        const requests = processedRounds.flatMap(round => round.getRequest() || []);
+        if (requests.length > 0) {
+            this.emit('request', requests);
+        }
     }
 }

--- a/packages/coinjoin/src/client/CoinjoinRound.ts
+++ b/packages/coinjoin/src/client/CoinjoinRound.ts
@@ -1,0 +1,272 @@
+import { EventEmitter } from 'events';
+
+import { arrayPartition } from '@trezor/utils';
+
+import {
+    getCommitmentData,
+    getRoundParameters,
+    getCoinjoinRoundDeadlines,
+} from '../utils/roundUtils';
+import { AccountAddress, RegisterAccountParams } from '../types/account';
+import {
+    SerializedCoinjoinRound,
+    CoinjoinRoundEvent,
+    CoinjoinTransactionData,
+    CoinjoinRequestEvent,
+    CoinjoinResponseEvent,
+} from '../types/round';
+import { RoundPhase, Round, CoinjoinRoundParameters } from '../types/coordinator';
+import type { Account } from './Account';
+
+export interface CoinjoinRoundOptions {
+    signal: AbortSignal;
+    coordinatorName: string;
+    coordinatorUrl: string;
+    middlewareUrl: string;
+    log: (...args: any[]) => any;
+}
+
+interface Events {
+    ended: CoinjoinRoundEvent;
+    changed: CoinjoinRoundEvent;
+}
+
+export declare interface CoinjoinRound {
+    on<K extends keyof Events>(type: K, listener: (event: Events[K]) => void): this;
+    off<K extends keyof Events>(type: K, listener: (event: Events[K]) => void): this;
+    emit<K extends keyof Events>(type: K, ...args: Events[K][]): boolean;
+    removeAllListeners<K extends keyof Events>(type?: K): this;
+}
+
+const createRoundLock = (mainSignal: AbortSignal) => {
+    let localResolve: () => void = () => {};
+    let localReject: (e?: Error) => void = () => {};
+
+    const promise: Promise<void> = new Promise((resolve, reject) => {
+        localResolve = resolve;
+        localReject = reject;
+    });
+
+    const localAbort = new AbortController();
+    mainSignal.addEventListener('abort', () => {
+        localAbort.abort();
+    });
+
+    return {
+        resolve: localResolve,
+        reject: localReject,
+        abort: localAbort.abort.bind(localAbort),
+        signal: localAbort.signal,
+        promise,
+    };
+};
+
+// Temporary. Alice will be added in next PR
+interface Alice {
+    path: string;
+    accountKey: string;
+    outpoint: string;
+    error?: Error;
+}
+
+export class CoinjoinRound extends EventEmitter implements SerializedCoinjoinRound {
+    private lock?: ReturnType<typeof createRoundLock>;
+    private options: CoinjoinRoundOptions;
+
+    // partial coordinator.Round
+    id: string;
+    phase: RoundPhase;
+    coinjoinState: Round['coinjoinState'];
+    inputRegistrationEnd: string;
+    amountCredentialIssuerParameters: Round['amountCredentialIssuerParameters'];
+    vsizeCredentialIssuerParameters: Round['vsizeCredentialIssuerParameters'];
+    //
+    roundParameters: CoinjoinRoundParameters;
+    inputs: Alice[] = []; // list of registered inputs
+    failed: Alice[] = []; // list of failed inputs
+    phaseDeadline: number; // deadline is inaccurate, phase may change earlier
+    roundDeadline: number; // deadline is inaccurate,round may end earlier
+    commitmentData: string; // commitment data used for ownership proof and witness requests
+    addresses: AccountAddress[] = []; // list of addresses (outputs) used in this round in outputRegistration phase
+    transactionData?: CoinjoinTransactionData; // transaction to sign
+
+    constructor(round: Round, options: CoinjoinRoundOptions) {
+        super();
+        this.id = round.id;
+        this.phase = 0;
+        this.coinjoinState = round.coinjoinState;
+        this.inputRegistrationEnd = round.inputRegistrationEnd;
+        this.amountCredentialIssuerParameters = round.amountCredentialIssuerParameters;
+        this.vsizeCredentialIssuerParameters = round.vsizeCredentialIssuerParameters;
+        const roundParameters = getRoundParameters(round);
+        if (!roundParameters) {
+            throw new Error('Missing CoinjoinRound roundParameters');
+        }
+        this.roundParameters = roundParameters;
+        this.commitmentData = getCommitmentData(options.coordinatorName, round.id);
+        const { phaseDeadline, roundDeadline } = getCoinjoinRoundDeadlines(this as any);
+        this.phaseDeadline = phaseDeadline;
+        this.roundDeadline = roundDeadline;
+        this.options = options;
+    }
+
+    static create(
+        accounts: Account[],
+        statusRounds: Round[],
+        coinjoinRounds: CoinjoinRound[],
+        options: CoinjoinRoundOptions,
+    ) {
+        // TODO: this code will be removed with "selectRound" implementation
+        if (coinjoinRounds.find(r => r.id === 'fakeroundid') || accounts.length === 0) {
+            return;
+        }
+        const firstRound = statusRounds.find(r => r.phase === RoundPhase.InputRegistration);
+        if (!firstRound) return;
+        const round = new CoinjoinRound(firstRound, options);
+
+        round.startFakeRoundLifecycle(firstRound, accounts[0]);
+        return Promise.resolve(round);
+    }
+
+    // temporary code to run Round lifecycle without actual coinjoining
+    startFakeRoundLifecycle(round: Round, account: Account) {
+        console.warn('Create fake round');
+        this.id = 'fakeroundid';
+        this.inputs = account.utxos.map(u => ({
+            outpoint: u.outpoint,
+            path: u.path,
+            accountKey: account.accountKey,
+        }));
+        let currentPhase = 0;
+        const timeoutFn = async () => {
+            await this.onPhaseChange({ ...round, phase: currentPhase });
+            await this.process([]);
+
+            currentPhase++;
+            if (this.failed.length === 0 && currentPhase <= RoundPhase.Ended) {
+                setTimeout(() => timeoutFn(), 10000);
+            }
+        };
+
+        timeoutFn();
+    }
+
+    async onPhaseChange(changed: Round) {
+        // if round is currently locked interrupt running process
+        if (this.lock) {
+            this.options.log(`Aborting round ${this.id}`);
+            this.lock.abort();
+            await this.lock.promise;
+        }
+
+        if (this.phase === RoundPhase.Ended) return this;
+
+        // update data from status
+        this.phase = changed.phase;
+        this.coinjoinState = changed.coinjoinState;
+        const { phaseDeadline, roundDeadline } = getCoinjoinRoundDeadlines(this);
+        this.phaseDeadline = phaseDeadline;
+        this.roundDeadline = roundDeadline;
+
+        this.emit('changed', { round: this.toSerialized() });
+
+        return this;
+    }
+
+    async process(accounts: Account[]) {
+        const { log } = this.options;
+        if (this.inputs.length === 0) {
+            log('Trying to process round without inputs');
+            return this;
+        }
+        await this.processPhase(accounts);
+
+        const [inputs, failed] = arrayPartition(this.inputs, input => !!input.error);
+        this.inputs = inputs;
+        this.failed = failed;
+
+        this.emit('changed', { round: this.toSerialized() });
+
+        if (this.inputs.length === 0 || this.phase === RoundPhase.Ended) {
+            this.phase = RoundPhase.Ended;
+            this.emit('ended', { round: this });
+        }
+
+        this.lock?.resolve();
+        this.lock = undefined;
+
+        return this;
+    }
+
+    private processPhase(_accounts: Account[]) {
+        this.lock = createRoundLock(this.options.signal);
+        // try to run process on CoinjoinRound
+        return new Promise(resolve => setTimeout(() => resolve(this), 2000));
+    }
+
+    getRequest(): CoinjoinRequestEvent | void {
+        // TODO
+    }
+
+    resolveRequest(_: CoinjoinResponseEvent) {
+        // TODO
+    }
+
+    updateAccount(account: RegisterAccountParams) {
+        // find registered inputs related to Account
+        const affectedInputs = this.inputs.filter(input => input.accountKey === account.accountKey);
+        // find inputs which are no longer in utxos set
+        const spentInputs = affectedInputs.filter(
+            input => !account.utxos.find(u => u.outpoint === input.outpoint),
+        );
+        // set error on each input
+        spentInputs.forEach(input => (input.error = new Error('Spent')));
+
+        this.breakRound(spentInputs);
+    }
+
+    unregisterAccount(accountKey: string) {
+        // find registered inputs related to Account
+        const affectedInputs = this.inputs.filter(input => input.accountKey === accountKey);
+        // set error on each input
+        affectedInputs.forEach(input => (input.error = new Error('Unregistered')));
+
+        this.breakRound(affectedInputs);
+    }
+
+    // decide if round process should be interrupted by Account change
+    private breakRound(inputs: Alice[]) {
+        if (inputs.length > 0) {
+            if (this.phase > RoundPhase.InputRegistration) {
+                // unregistered in critical phase, breaking the round
+                this.lock?.abort();
+            }
+            if (inputs.length === this.inputs.length) {
+                // no more inputs left in round, breaking the round
+                this.lock?.abort();
+            }
+        }
+    }
+
+    // serialize class
+    // data emitted in "round" event
+    toSerialized(): SerializedCoinjoinRound {
+        return {
+            id: this.id,
+            phase: this.phase,
+            inputs: this.inputs.map(i => ({
+                outpoint: i.outpoint,
+                accountKey: i.accountKey,
+                path: i.path,
+            })),
+            failed: this.failed.map(i => ({
+                outpoint: i.outpoint,
+                accountKey: i.accountKey,
+                path: i.path,
+            })),
+            addresses: this.addresses,
+            phaseDeadline: this.phaseDeadline,
+            roundDeadline: this.roundDeadline,
+        };
+    }
+}

--- a/packages/coinjoin/src/constants.ts
+++ b/packages/coinjoin/src/constants.ts
@@ -7,3 +7,7 @@ export const STATUS_TIMEOUT = {
     enabled: 30000, // account is registered but utxo was not paired with Round
     registered: 10000, // utxo is registered in Round
 } as const;
+
+// add 2 sec. offset to round.inputRegistrationEnd to prevent race conditions
+// we are expecting phase to change but server didn't propagate it yet
+export const ROUND_REGISTRATION_END_OFFSET = 2000;

--- a/packages/coinjoin/src/types/coordinator.ts
+++ b/packages/coinjoin/src/types/coordinator.ts
@@ -57,35 +57,37 @@ export interface CoordinatorFeeRate {
     plebsDontPayThreshold: number;
 }
 
+export interface CoinjoinRoundParameters {
+    network: string;
+    miningFeeRate: number;
+    coordinationFeeRate: {
+        rate: number;
+        plebsDontPayThreshold: number;
+    };
+    maxSuggestedAmount: number;
+    minInputCountByRound: number;
+    maxInputCountByRound: number;
+    allowedInputAmounts: AllowedRange;
+    allowedOutputAmounts: AllowedRange;
+    allowedInputScriptTypes: AllowedScriptTypes[];
+    allowedOutputScriptTypes: AllowedScriptTypes[];
+    standardInputRegistrationTimeout: string;
+    connectionConfirmationTimeout: string;
+    outputRegistrationTimeout: string;
+    transactionSigningTimeout: string;
+    blameInputRegistrationTimeout: string;
+    minAmountCredentialValue: number;
+    maxAmountCredentialValue: number;
+    initialInputVsizeAllocation: number;
+    maxVsizeCredentialValue: number;
+    maxVsizeAllocationPerAlice: number;
+    maxTransactionSize: number;
+    minRelayTxFee: number;
+}
+
 export interface CoinjoinRoundCreatedEvent {
     Type: 'RoundCreated';
-    roundParameters: {
-        network: string;
-        miningFeeRate: number;
-        coordinationFeeRate: {
-            rate: number;
-            plebsDontPayThreshold: number;
-        };
-        maxSuggestedAmount: number;
-        minInputCountByRound: number;
-        maxInputCountByRound: number;
-        allowedInputAmounts: AllowedRange;
-        allowedOutputAmounts: AllowedRange;
-        allowedInputScriptTypes: AllowedScriptTypes[];
-        allowedOutputScriptTypes: AllowedScriptTypes[];
-        standardInputRegistrationTimeout: string;
-        connectionConfirmationTimeout: string;
-        outputRegistrationTimeout: string;
-        transactionSigningTimeout: string;
-        blameInputRegistrationTimeout: string;
-        minAmountCredentialValue: number;
-        maxAmountCredentialValue: number;
-        initialInputVsizeAllocation: number;
-        maxVsizeCredentialValue: number;
-        maxVsizeAllocationPerAlice: number;
-        maxTransactionSize: number;
-        minRelayTxFee: number;
-    };
+    roundParameters: CoinjoinRoundParameters;
 }
 
 export interface CoinjoinInput {

--- a/packages/coinjoin/src/types/index.ts
+++ b/packages/coinjoin/src/types/index.ts
@@ -18,3 +18,4 @@ export interface CoinjoinClientSettings extends BaseSettings {
 
 export * from './account';
 export * from './client';
+export * from './round';

--- a/packages/coinjoin/src/types/round.ts
+++ b/packages/coinjoin/src/types/round.ts
@@ -1,0 +1,89 @@
+import { AccountAddress } from './account';
+import { RoundPhase, TxPaymentRequest } from './coordinator';
+
+export interface SerializedAlice {
+    accountKey: string;
+    path: string;
+    outpoint: string;
+}
+
+export interface SerializedCoinjoinRound {
+    id: string;
+    phase: RoundPhase;
+    inputs: SerializedAlice[]; // list of registered inputs
+    failed: SerializedAlice[]; // list of failed inputs
+    addresses: AccountAddress[]; // list of addresses (outputs) used in this round in outputRegistration phase
+    phaseDeadline: number; // deadline is inaccurate, phase may change earlier
+    roundDeadline: number; // deadline is inaccurate,round may end earlier
+}
+
+export interface CoinjoinRoundEvent {
+    round: SerializedCoinjoinRound;
+}
+
+interface CoinjoinTxInputs {
+    path?: string;
+    outpoint: string;
+    amount: number;
+    commitmentData: string;
+    scriptPubKey: string;
+    ownershipProof: string;
+}
+
+interface CoinjoinTxOutputs {
+    path?: string;
+    address: string;
+    amount: number;
+}
+
+export interface CoinjoinTransactionData {
+    inputs: CoinjoinTxInputs[];
+    outputs: CoinjoinTxOutputs[];
+    paymentRequest: TxPaymentRequest;
+}
+
+export interface CoinjoinRequestOwnershipEvent {
+    type: 'ownership';
+    roundId: string;
+    inputs: SerializedAlice[];
+    commitmentData: string;
+}
+
+export interface CoinjoinRequestWitnessEvent {
+    type: 'witness';
+    roundId: string;
+    inputs: SerializedAlice[];
+    transaction: CoinjoinTransactionData;
+}
+
+export type CoinjoinRequestEvent = CoinjoinRequestOwnershipEvent | CoinjoinRequestWitnessEvent;
+
+export interface CoinjoinResponseOwnership {
+    outpoint: string;
+    ownershipProof: string;
+}
+
+export interface CoinjoinResponseWitness {
+    outpoint: string;
+    witness: string;
+    witnessIndex: number;
+}
+
+export interface CoinjoinResponseWithError {
+    outpoint: string;
+    error: string;
+}
+
+export interface CoinjoinResponseOwnershipEvent {
+    type: 'ownership';
+    roundId: string;
+    inputs: (CoinjoinResponseOwnership | CoinjoinResponseWithError)[];
+}
+
+export interface CoinjoinResponseWitnessEvent {
+    type: 'witness';
+    roundId: string;
+    inputs: (CoinjoinResponseWitness | CoinjoinResponseWithError)[];
+}
+
+export type CoinjoinResponseEvent = CoinjoinResponseOwnershipEvent | CoinjoinResponseWitnessEvent;

--- a/packages/coinjoin/tests/client/Status.test.ts
+++ b/packages/coinjoin/tests/client/Status.test.ts
@@ -1,4 +1,5 @@
 import { Status } from '../../src/client/Status';
+import { ROUND_REGISTRATION_END_OFFSET } from '../../src/constants';
 import { createServer, Server } from '../mocks/server';
 import { DEFAULT_ROUND } from '../fixtures/round.fixture';
 
@@ -161,7 +162,7 @@ describe('Status', () => {
         status.setMode('enabled');
         await status.start();
 
-        await waitForStatus(600); // wait 0.6 sec (inputRegistrationEnd)
+        await waitForStatus(ROUND_REGISTRATION_END_OFFSET + 600); // wait 0.6 sec + offset (inputRegistrationEnd)
 
         expect(requestListener).toHaveBeenCalledTimes(2); // status fetched twice, because Round.inputRegistrationEnd timeout < STATUS_TIMEOUT.enabled
         expect(onUpdateListener).toHaveBeenCalledTimes(1); // status changed only once
@@ -188,18 +189,17 @@ describe('Status', () => {
 
         expect(requestListener).toHaveBeenCalledTimes(3);
         expect(onUpdateListener).toHaveBeenCalledTimes(2);
-
-        await waitForStatus(2100); // wait 2 sec (connectionConfirmationTimeout 5 sec - 3 sec from previous tick)
+        await waitForStatus(3100); // wait 3 sec of STATUS_TIMEOUT.enabled  < connectionConfirmationTimeout 5 sec
 
         expect(requestListener).toHaveBeenCalledTimes(4);
         expect(onUpdateListener).toHaveBeenCalledTimes(3);
 
-        await waitForStatus(2100); // wait 2 sec (outputRegistrationTimeout)
+        await waitForStatus(2100); // wait 2 sec of outputRegistrationTimeout < STATUS_TIMEOUT.enabled 3 sec
 
         expect(requestListener).toHaveBeenCalledTimes(5);
         expect(onUpdateListener).toHaveBeenCalledTimes(4);
 
-        await waitForStatus(2500); // wait 2 sec (transactionSigningTimeout)
+        await waitForStatus(2100); // wait 2 sec of transactionSigningTimeout < STATUS_TIMEOUT.enabled 3 sec
 
         expect(requestListener).toHaveBeenCalledTimes(6);
         expect(onUpdateListener).toHaveBeenCalledTimes(5);

--- a/packages/coinjoin/tests/utils/roundUtils.test.ts
+++ b/packages/coinjoin/tests/utils/roundUtils.test.ts
@@ -1,7 +1,14 @@
-import { readTimeSpan, estimatePhaseDeadline } from '../../src/utils/roundUtils';
+import { getCommitmentData, readTimeSpan, estimatePhaseDeadline } from '../../src/utils/roundUtils';
+import { ROUND_REGISTRATION_END_OFFSET } from '../../src/constants';
 import { DEFAULT_ROUND } from '../fixtures/round.fixture';
 
 describe('roundUtils', () => {
+    it('getCommitmentData', () => {
+        expect(getCommitmentData('CoinJoinCoordinatorIdentifier', '001234')).toEqual(
+            '1d436f696e4a6f696e436f6f7264696e61746f724964656e746966696572001234',
+        );
+    });
+
     it('readTimeSpan', () => {
         expect(readTimeSpan('0d 0h 0m 1s')).toEqual(1000);
         expect(readTimeSpan('1d 0h 0m 0s')).toEqual(24 * 60 * 60000);
@@ -11,35 +18,62 @@ describe('roundUtils', () => {
     });
 
     it('estimatePhaseDeadline', () => {
-        const base = new Date(DEFAULT_ROUND.inputRegistrationEnd).getTime();
+        const round = {
+            ...DEFAULT_ROUND,
+            coinjoinState: {
+                events: [
+                    {
+                        Type: 'RoundCreated',
+                        roundParameters: {
+                            connectionConfirmationTimeout: '0d 0h 1m 0s',
+                            outputRegistrationTimeout: '0d 0h 2m 0s',
+                            transactionSigningTimeout: '0d 0h 3m 0s',
+                        },
+                    },
+                ],
+            },
+        } as typeof DEFAULT_ROUND;
+
+        const base = new Date(round.inputRegistrationEnd).getTime() + ROUND_REGISTRATION_END_OFFSET;
         expect(estimatePhaseDeadline(DEFAULT_ROUND)).toEqual(base);
 
-        expect(
+        // result may vary +-5 milliseconds
+        const expectInRange = (result: number, expected: number) => {
+            expect(result).toBeGreaterThanOrEqual(expected - 5);
+            expect(result).toBeLessThan(expected + 5);
+        };
+
+        const timeouts = 60000; // each phase timeout of DEFAULT_ROUND is set to 1 min.
+        expectInRange(
             estimatePhaseDeadline({
-                ...DEFAULT_ROUND,
+                ...round,
                 phase: 1,
             }),
-        ).toEqual(base + 60000);
+            Date.now() + timeouts,
+        );
 
-        expect(
+        expectInRange(
             estimatePhaseDeadline({
-                ...DEFAULT_ROUND,
+                ...round,
                 phase: 2,
             }),
-        ).toEqual(base + 60000 * 2);
+            Date.now() + timeouts * 2,
+        );
 
-        expect(
+        expectInRange(
             estimatePhaseDeadline({
-                ...DEFAULT_ROUND,
+                ...round,
                 phase: 3,
             }),
-        ).toEqual(base + 60000 * 3);
+            Date.now() + timeouts * 3,
+        );
 
-        expect(
+        expectInRange(
             estimatePhaseDeadline({
-                ...DEFAULT_ROUND,
+                ...round,
                 phase: 4,
             }),
-        ).toEqual(0);
+            Date.now(),
+        );
     });
 });

--- a/packages/suite/src/actions/wallet/constants/coinjoinConstants.ts
+++ b/packages/suite/src/actions/wallet/constants/coinjoinConstants.ts
@@ -15,3 +15,5 @@ export const CLIENT_STATUS = '@coinjoin/client-status';
 
 export const SESSION_PAUSE = '@coinjoin/session-pause';
 export const SESSION_RESTORE = '@coinjoin/session-restore';
+export const SESSION_ROUND_CHANGED = '@coinjoin/session-round-changed';
+export const SESSION_COMPLETED = '@coinjoin/session-completed';


### PR DESCRIPTION
another stuff cherry-picked element from [coinjoin branch](https://github.com/trezor/trezor-suite/pull/6485)

adding `CoinjoinRound` and it's lifecycle thru `onPhaseChange` and `process`.

_NOTE: for easier implementation purposes after account registration fake `CoinjoinRound` will be created and it will iterate thru all it's `phases`l dispatching `round` event to suite every 10 seconds until it ends_

also i guess its a prerequisite to checkout working of [critical modal branch](https://github.com/trezor/trezor-suite/pull/6636) cc @dahaca 

## changes

i decided to change `estimatePhaseDeadline` utility to get two values: when phase will end and when whole round will end depending on current phase

## CoinjoinRound description

`CoinjoinRound` class is created by status change (in the future it will use dedicated conditions to pick round and utxos)

after creation it reference is stored in `CoinjoinClient` until it emit "ended" event 

on each status change `CoinjoinRound` is processed and returns itself as a result

`CoinjoinRound` can be interrupted by:
- updateAccount (spent utxos)
- unregisterAccount
- coinjoin disable (forgetting wallet etc)
- any other inner error (implementation on the way see  [coinjoin branch](https://github.com/trezor/trezor-suite/pull/6485)