### PR TITLE
handling coinjoin round in suite (part2)

### DIFF
--- a/packages/coinjoin/src/client/CoinjoinRound.ts
+++ b/packages/coinjoin/src/client/CoinjoinRound.ts
@@ -181,9 +181,9 @@ export class CoinjoinRound extends EventEmitter implements SerializedCoinjoinRou
         }
         await this.processPhase(accounts);
 
-        const [inputs, failed] = arrayPartition(this.inputs, input => !!input.error);
+        const [inputs, failed] = arrayPartition(this.inputs, input => !input.error);
         this.inputs = inputs;
-        this.failed = failed;
+        this.failed = this.failed.concat(...failed);
 
         this.emit('changed', { round: this.toSerialized() });
 

--- a/packages/suite/src/actions/wallet/__fixtures__/coinjoinClientActions.ts
+++ b/packages/suite/src/actions/wallet/__fixtures__/coinjoinClientActions.ts
@@ -1,0 +1,186 @@
+import { testMocks } from '@suite-common/test-utils';
+import * as COINJOIN from '@wallet-actions/constants/coinjoinConstants';
+
+const DEVICE = testMocks.getSuiteDevice({ state: 'device-state', connected: true });
+
+export const onCoinjoinRoundChanged = [
+    {
+        description: 'Phase 0. No associated coinjoin accounts',
+        connect: undefined,
+        state: {
+            coinjoin: {
+                accounts: [
+                    { key: 'a', session: {} },
+                    { key: 'b' }, // account b exists but without session
+                ],
+            },
+        },
+        params: {
+            phase: 0,
+            inputs: [{ accountKey: 'b' }, { accountKey: 'c' }],
+            failed: [],
+        },
+        result: {
+            actions: [],
+        },
+    },
+    {
+        description: 'Phase 1. (critical) TrezorConnect.setBusy not called. Device not found',
+        connect: undefined,
+        state: {
+            accounts: [{ key: 'a', deviceState: 'device-state-2' }],
+            coinjoin: {
+                accounts: [{ key: 'a', session: {} }],
+            },
+        },
+        params: {
+            phase: 1,
+            inputs: [{ accountKey: 'a' }],
+            failed: [],
+        },
+        result: {
+            actions: [COINJOIN.SESSION_ROUND_CHANGED],
+            trezorConnectCalledTimes: 0,
+        },
+    },
+    {
+        description:
+            'Phase 1. (critical) TrezorConnect.setBusy called once (2 passphrases on 1 device)',
+        connect: undefined,
+        state: {
+            accounts: [
+                { key: 'a', deviceState: 'device-state' },
+                { key: 'b', deviceState: 'device-state-2' },
+            ],
+            coinjoin: {
+                accounts: [
+                    { key: 'a', session: {} },
+                    { key: 'b', session: {} },
+                ],
+            },
+        },
+        params: [
+            {
+                phase: 1,
+                inputs: [{ accountKey: 'a' }],
+                failed: [],
+                roundDeadline: Date.now() + 1000,
+            },
+            {
+                phase: 1, // TrezorConnect called only once because second event has same phase
+                inputs: [{ accountKey: 'a' }],
+                failed: [],
+                roundDeadline: Date.now() + 1000,
+            },
+        ],
+        result: {
+            actions: [COINJOIN.SESSION_ROUND_CHANGED, COINJOIN.SESSION_ROUND_CHANGED],
+            trezorConnectCalledTimes: 1,
+            trezorConnectCallsWith: { expiry_ms: expect.any(Number) }, // ~1000
+        },
+    },
+    {
+        description: 'Phase 1. (critical) TrezorConnect.setBusy called on two physical devices',
+        connect: undefined,
+        state: {
+            devices: [DEVICE, { ...DEVICE, state: 'device-state-2', id: '2' }],
+            accounts: [
+                { key: 'a', deviceState: 'device-state' },
+                { key: 'b', deviceState: 'device-state-2' },
+            ],
+            coinjoin: {
+                accounts: [
+                    { key: 'a', session: {} },
+                    { key: 'b', session: {} },
+                ],
+            },
+        },
+        params: [
+            {
+                phase: 1,
+                inputs: [{ accountKey: 'a' }, { accountKey: 'b' }],
+                failed: [],
+                roundDeadline: Date.now() + 1000,
+            },
+        ],
+        result: {
+            actions: [COINJOIN.SESSION_ROUND_CHANGED, COINJOIN.SESSION_ROUND_CHANGED],
+            trezorConnectCalledTimes: 2,
+            trezorConnectCallsWith: { expiry_ms: expect.any(Number) }, // ~1000
+        },
+    },
+    {
+        description: 'Phase 4. (end) TrezorConnect.setBusy called',
+        connect: undefined,
+        state: {
+            accounts: [{ key: 'a', deviceState: 'device-state' }],
+            coinjoin: {
+                accounts: [{ key: 'a', session: {} }],
+            },
+        },
+        params: {
+            phase: 4,
+            inputs: [{ accountKey: 'a' }],
+            failed: [],
+            roundDeadline: Date.now() + 1000,
+        },
+        result: {
+            actions: [COINJOIN.SESSION_ROUND_CHANGED],
+            trezorConnectCalledTimes: 1,
+            trezorConnectCallsWith: { expiry_ms: undefined },
+        },
+    },
+    {
+        description: 'Multiple events',
+        connect: undefined,
+        state: {
+            accounts: [{ key: 'a', deviceState: 'device-state' }],
+            coinjoin: {
+                accounts: [{ key: 'a', session: {} }],
+            },
+        },
+        params: [
+            {
+                phase: 0,
+                inputs: [{ accountKey: 'a' }],
+                failed: [],
+                roundDeadline: Date.now() + 1000,
+            },
+            {
+                phase: 1,
+                inputs: [{ accountKey: 'a' }],
+                failed: [],
+                roundDeadline: Date.now() + 1000,
+            },
+            {
+                phase: 2,
+                inputs: [{ accountKey: 'a' }],
+                failed: [],
+                roundDeadline: Date.now() + 1000,
+            },
+            {
+                phase: 3,
+                inputs: [{ accountKey: 'a' }],
+                failed: [],
+                roundDeadline: Date.now() + 1000,
+            },
+            {
+                phase: 4,
+                inputs: [{ accountKey: 'a' }],
+                failed: [],
+                roundDeadline: Date.now() + 1000,
+            },
+        ],
+        result: {
+            actions: [
+                COINJOIN.SESSION_ROUND_CHANGED,
+                COINJOIN.SESSION_ROUND_CHANGED,
+                COINJOIN.SESSION_ROUND_CHANGED,
+                COINJOIN.SESSION_ROUND_CHANGED,
+                COINJOIN.SESSION_ROUND_CHANGED,
+            ],
+            trezorConnectCalledTimes: 2,
+            trezorConnectCallsWith: { expiry_ms: undefined },
+        },
+    },
+];

--- a/packages/suite/src/actions/wallet/__tests__/coinjoinClientActions.test.ts
+++ b/packages/suite/src/actions/wallet/__tests__/coinjoinClientActions.test.ts
@@ -1,0 +1,96 @@
+import { combineReducers, createReducer } from '@reduxjs/toolkit';
+import { configureMockStore, testMocks } from '@suite-common/test-utils';
+
+import { accountsReducer } from '@wallet-reducers';
+import { coinjoinReducer } from '@wallet-reducers/coinjoinReducer';
+import { onCoinjoinRoundChanged } from '../coinjoinClientActions';
+import * as fixtures from '../__fixtures__/coinjoinClientActions';
+
+jest.mock('@trezor/connect', () => global.JestMocks.getTrezorConnect({}));
+// eslint-disable-next-line @typescript-eslint/no-var-requires
+const TrezorConnect = require('@trezor/connect').default;
+
+const DEVICE = testMocks.getSuiteDevice({ state: 'device-state', connected: true });
+
+const rootReducer = combineReducers({
+    suite: createReducer(
+        {
+            locks: [],
+            device: DEVICE,
+            settings: {
+                debug: {},
+            },
+        },
+        {},
+    ),
+    devices: createReducer([DEVICE], {}),
+    modal: () => ({}),
+    wallet: combineReducers({
+        coinjoin: coinjoinReducer,
+        accounts: accountsReducer,
+    }),
+});
+
+type State = ReturnType<typeof rootReducer>;
+type Wallet = Partial<State['wallet']> & { devices?: State['devices'] };
+
+const initStore = ({ accounts, coinjoin, devices }: Wallet = {}) => {
+    // TODO: didn't found better way how to generate initial state or pass it dynamically to rootReducer creator
+    const preloadedState: State = JSON.parse(
+        JSON.stringify(rootReducer(undefined, { type: 'init' })),
+    );
+    if (devices) {
+        preloadedState.devices = devices;
+    }
+    if (accounts) {
+        preloadedState.wallet.accounts = accounts;
+    }
+    if (coinjoin) {
+        preloadedState.wallet.coinjoin = {
+            ...preloadedState.wallet.coinjoin,
+            ...coinjoin,
+        };
+    }
+    // State != suite AppState, therefore <any>
+    const store = configureMockStore<any>({ reducer: rootReducer, preloadedState });
+    return store;
+};
+
+describe('coinjoinClientActions', () => {
+    afterEach(() => {
+        jest.clearAllMocks();
+    });
+
+    fixtures.onCoinjoinRoundChanged.forEach(f => {
+        it(`onCoinjoinRoundChanged: ${f.description}`, async () => {
+            const store = initStore(f.state as Wallet);
+            TrezorConnect.setTestFixtures(f.connect);
+
+            if (Array.isArray(f.params)) {
+                await Promise.all(
+                    f.params.map(p =>
+                        store.dispatch(
+                            onCoinjoinRoundChanged({ round: p as any }), // params are incomplete
+                        ),
+                    ),
+                );
+            } else {
+                await store.dispatch(
+                    onCoinjoinRoundChanged({ round: f.params as any }), // params are incomplete
+                );
+            }
+
+            const actions = store.getActions();
+            expect(actions.map(a => a.type)).toEqual(f.result.actions);
+
+            if (typeof f.result.trezorConnectCalledTimes === 'number') {
+                expect(TrezorConnect.setBusy).toBeCalledTimes(f.result.trezorConnectCalledTimes);
+            }
+            if (f.result.trezorConnectCallsWith) {
+                expect(TrezorConnect.setBusy).toHaveBeenLastCalledWith(
+                    expect.objectContaining(f.result.trezorConnectCallsWith),
+                );
+            }
+        });
+    });
+});

--- a/suite-common/test-utils/src/configureMockStore.ts
+++ b/suite-common/test-utils/src/configureMockStore.ts
@@ -30,8 +30,8 @@ export function configureMockStore<S = any, A extends Action = AnyAction>({
 } = {}) {
     let actions: A[] = [];
 
-    const actionLoggerMiddleware = createMiddleware((action, { next }) => {
-        actions.push(action as any);
+    const actionLoggerMiddleware = createMiddleware<A>((action, { next }) => {
+        actions.push(action);
 
         return next(action);
     });

--- a/suite-common/test-utils/src/mocks.ts
+++ b/suite-common/test-utils/src/mocks.ts
@@ -343,6 +343,11 @@ const getTrezorConnect = <M>(methods?: M) => {
                 }
                 return { success: false, payload: { error: 'error' }, ...fixture, _params };
             }),
+            setBusy: jest.fn(async _params => ({
+                success: true,
+                ...getFixture(),
+                _params,
+            })),
             signTransaction: jest.fn(async _params => ({
                 success: false,
                 payload: { error: 'error' },


### PR DESCRIPTION
~~based on https://github.com/trezor/trezor-suite/pull/6648, only 3rd commit is relevant~~

As usual it meant to be small and growing every hour :)

### commit 1:
- fix from base branch, i've used new (for me) suggested utility and implement it wrongly

### commit 2:
cherry-picked from  [coinjoin branch](https://github.com/trezor/trezor-suite/pull/6485)

- display busy screen on Trezor  when `CoinjoinRound` enters critical phase
- reset busy screen when `CoinjoinRound` ends

### commit 3:

- adding unit test s, CI complains about low coverage
- i guess this is our first test using `configureMockStore` + preloaded reducers, i didnt know how to do it better than clone rootReducer and modify fields, any suggestions @Nodonisko ?