### PR TITLE
suite-desktop tests coinjoin

### DIFF
--- a/ci/test.yml
+++ b/ci/test.yml
@@ -121,7 +121,9 @@ suite web 2-master manual:
   dependencies:
     - install
   variables:
+    COMPOSE_PROJECT_NAME: $CI_JOB_ID # for unique containers
     COMPOSE_FILE: ./docker/docker-compose.suite-desktop-ci.yml
+    TEST_FILE: $TEST_FILE
   before_script:
     - docker login $CI_DEPENDENCY_PROXY_SERVER -u $CI_DEPENDENCY_PROXY_USER -p $CI_DEPENDENCY_PROXY_PASSWORD
   script:
@@ -131,8 +133,7 @@ suite web 2-master manual:
     - yarn workspace @trezor/message-system sign-config
     - yarn workspace @trezor/suite-desktop build:linux
     - docker-compose pull
-    - docker-compose up -d trezor-user-env-unix
-    - docker-compose up -d electrum-regtest
+    - docker-compose up -d ${CONTAINERS}
     - docker-compose run test-run
   after_script:
     - docker-compose down
@@ -141,8 +142,16 @@ suite web 2-master manual:
     expire_in: 7 days
     when: always
     paths:
-      - ./packages/integration-tests/projects/suite-desktop/screenshots
+      - ./packages/suite-desktop/e2e/screenshots
   interruptible: true
+  parallel:
+    matrix:
+      - TEST_FILE: ["spawn-tor", "spawn-bridge"]
+        CONTAINERS: "trezor-user-env-unix"
+      - TEST_FILE: ["electrum"]
+        CONTAINERS: "trezor-user-env-unix electrum-regtest"
+      - TEST_FILE: ["coinjoin"]
+        CONTAINERS: "trezor-user-env-unix coinjoin-backend"
 
 suite desktop:
   extends: .e2e desktop

--- a/docker/docker-compose.suite-desktop-ci.yml
+++ b/docker/docker-compose.suite-desktop-ci.yml
@@ -7,12 +7,14 @@ services:
       - XDG_RUNTIME_DIR=/var/tmp
 
   test-run:
+    environment:
+      - TEST_FILE=$TEST_FILE
     image: registry.gitlab.com/satoshilabs/trezor/trezor-suite/base:latest
     container_name: desktop-test-runner
     ipc: host
     network_mode: service:trezor-user-env-unix
     working_dir: /trezor-suite
-    command: bash -c "yarn workspace @trezor/suite-desktop test:e2e"
+    command: bash -c "yarn workspace @trezor/suite-desktop test:e2e $TEST_FILE"
     volumes:
       - ../:/trezor-suite
 
@@ -21,3 +23,9 @@ services:
     volumes:
       - ../:/trezor-suite
     network_mode: service:trezor-user-env-unix
+
+  coinjoin-backend:
+    image: ghcr.io/trezor/coinjoin-backend:latest
+    network_mode: service:trezor-user-env-unix
+    volumes:
+      - ../:/coinjoin-backend

--- a/docker/docker-compose.suite-desktop-test.yml
+++ b/docker/docker-compose.suite-desktop-test.yml
@@ -11,12 +11,13 @@ services:
     environment:
       - DISPLAY=$DISPLAY
       - LOCAL_USER_ID=$LOCAL_USER_ID
+      - TEST_FILE=$TEST_FILE
     image: registry.gitlab.com/satoshilabs/trezor/trezor-suite/base:latest
     container_name: desktop-test-runner
     ipc: host
     network_mode: service:trezor-user-env-unix
     working_dir: /trezor-suite
-    command: bash -c "yarn workspace @trezor/suite-desktop test:e2e"
+    command: bash -c "yarn workspace @trezor/suite-desktop test:e2e $TEST_FILE"
     volumes:
       - ../:/trezor-suite
       - /tmp/.X11-unix:/tmp/.X11-unix:rw

--- a/docker/docker-compose.suite-desktop-test.yml
+++ b/docker/docker-compose.suite-desktop-test.yml
@@ -27,3 +27,9 @@ services:
     volumes:
       - ../:/trezor-suite
     network_mode: service:trezor-user-env-unix
+
+  coinjoin-backend:
+    image: ghcr.io/trezor/coinjoin-backend:latest
+    network_mode: service:trezor-user-env-unix
+    volumes:
+      - ../:/coinjoin-backend

--- a/docker/docker-suite-desktop-test.sh
+++ b/docker/docker-suite-desktop-test.sh
@@ -7,5 +7,6 @@ set -e
 xhost +
 LOCAL_USER_ID="$(id -u "$USER")"
 export LOCAL_USER_ID
+export TEST_FILE=$1
 
 docker-compose -f ./docker/docker-compose.suite-desktop-test.yml up --build --abort-on-container-exit --force-recreate

--- a/packages/suite-desktop/e2e/playwright.config.ts
+++ b/packages/suite-desktop/e2e/playwright.config.ts
@@ -6,6 +6,7 @@ const config: PlaywrightTestConfig = {
     workers: 1, // to disable parallelism between test files
     use: {
         headless: true,
+        trace: 'retain-on-failure',
     },
 };
 

--- a/packages/suite-desktop/e2e/playwright.config.ts
+++ b/packages/suite-desktop/e2e/playwright.config.ts
@@ -2,7 +2,6 @@ import type { PlaywrightTestConfig } from '@playwright/test';
 
 const config: PlaywrightTestConfig = {
     testDir: 'tests',
-    timeout: 360000, // tests can take long, especially due to Tor
     workers: 1, // to disable parallelism between test files
     use: {
         headless: true,

--- a/packages/suite-desktop/e2e/support/regtest.ts
+++ b/packages/suite-desktop/e2e/support/regtest.ts
@@ -1,0 +1,48 @@
+/* eslint-disable no-console, no-await-in-loop */
+
+// TODO: future coinjoin-backend-link package? similar to trezor-user-env-link
+
+import fetch from 'node-fetch';
+
+export const sendToAddress = ({ address, amount }: { address: string; amount: string }) =>
+    fetch('http://localhost:8081/send_to_address', {
+        headers: {
+            'content-type': 'application/x-www-form-urlencoded',
+        },
+        body: `amount=${amount}&address=${address}`,
+        method: 'POST',
+    });
+
+export const generateBlock = () =>
+    fetch('http://localhost:8081/generate_block', {
+        method: 'GET',
+    });
+
+export const waitForCoinjoinBackend = () =>
+    // eslint-disable-next-line no-async-promise-executor
+    new Promise<void>(async (resolve, reject) => {
+        const limit = 60;
+        const error = '';
+
+        console.log('waiting for coinjoin backend');
+
+        for (let i = 0; i < limit; i++) {
+            if (i === limit - 1) {
+                console.log(`waiting for coinjoin backend: ${error}\n`);
+            }
+
+            await new Promise(resolve => setTimeout(() => resolve(undefined), 1000));
+
+            try {
+                const res = await fetch('http://localhost:8081');
+                if (res.status === 200) {
+                    console.log('coinjoin backend is online');
+                    return resolve();
+                }
+            } catch (err) {
+                process.stdout.write('.');
+            }
+        }
+
+        reject(error);
+    });

--- a/packages/suite-desktop/e2e/tests/coinjoin.test.ts
+++ b/packages/suite-desktop/e2e/tests/coinjoin.test.ts
@@ -1,0 +1,84 @@
+/* eslint-disable no-await-in-loop */
+
+import { Page, test as testPlaywright } from '@playwright/test';
+
+import { TrezorUserEnvLink } from '@trezor/trezor-user-env-link';
+
+import { patchBinaries, launchSuite } from '../support/common';
+import { sendToAddress, generateBlock, waitForCoinjoinBackend } from '../support/regtest';
+
+const enableCoinjoinInSettings = async (window: Page) => {
+    await window.click('[data-test="@suite/menu/settings"]');
+
+    // enable debug
+    for (let i = 0; i < 5; i++) {
+        await window.click('[data-test="@settings/menu/title"]');
+    }
+
+    // go to debug menu
+    await window.click('[data-test="@settings/menu/debug"]');
+
+    // change regtest server source to localhost
+    await window.click('[data-test="@settings/coinjoin-server-select/input"]', { trial: true });
+    await window.click('[data-test="@settings/coinjoin-server-select/input"]');
+    await window.click('[data-test="@settings/coinjoin-server-select/option/localhost"]');
+
+    // go to coins menu
+    await window.click('[data-test="@settings/menu/wallet"]');
+    await window.click('[data-test="@settings/wallet/network/btc"]'); // disable btc
+    await window.click('[data-test="@settings/wallet/network/regtest"]'); // enable regtest
+
+    // open advance settings for regtest
+    await window.click('[data-test="@settings/wallet/network/regtest/advance"]');
+    await window.click('[data-test="@settings/advance/button/save"]');
+};
+
+testPlaywright.describe('Coinjoin', () => {
+    testPlaywright.beforeAll(async () => {
+        // todo: some problems with path in dev and production and tests. tldr tests are expecting
+        // binaries somewhere where they are not, so I copy them to that place. Maybe I find a
+        // better solution later
+        await patchBinaries();
+
+        await TrezorUserEnvLink.api.trezorUserEnvConnect();
+        await waitForCoinjoinBackend();
+        await TrezorUserEnvLink.api.stopBridge();
+        await TrezorUserEnvLink.api.startEmu({ wipe: true });
+        await TrezorUserEnvLink.api.setupEmu({
+            needs_backup: false,
+            mnemonic: 'all all all all all all all all all all all all',
+        });
+    });
+
+    testPlaywright('Prepare prerequisites for coinjoining', async () => {
+        for (let i = 0; i < 10; i++) {
+            await sendToAddress({
+                amount: '1',
+                address: 'bcrt1qkvwu9g3k2pdxewfqr7syz89r3gj557l374sg5v',
+            });
+            await generateBlock();
+        }
+
+        const suite = await launchSuite();
+
+        await suite.window.click('[data-test="@onboarding/continue-button"]');
+        await suite.window.click('[data-test="@onboarding/exit-app-button"]');
+
+        await suite.window.waitForSelector('[data-test="@dashboard/graph"]');
+
+        await enableCoinjoinInSettings(suite.window);
+
+        await suite.window.click('[data-test="@suite/menu/wallet-index"]');
+
+        await suite.window.click('[data-test="@account-menu/add-account"]');
+        await suite.window.click('[data-test="@settings/wallet/network/regtest"]');
+
+        await suite.window.click('[data-test="@add-account-type/select/input"]', { trial: true });
+        await suite.window.click('[data-test="@add-account-type/select/input"]');
+        await suite.window.click(
+            '[data-test="@add-account-type/select/option/Bitcoin Regtest (PEA)"]',
+        );
+
+        await suite.window.click('[data-test="@add-account"]');
+    });
+});

--- a/packages/suite-desktop/e2e/tests/spawn-tor.test.ts
+++ b/packages/suite-desktop/e2e/tests/spawn-tor.test.ts
@@ -3,7 +3,7 @@ import { Page, test as testPlaywright, expect as expectPlaywright } from '@playw
 import { patchBinaries, launchSuite } from '../support/common';
 import { NetworkAnalyzer } from '../support/networkAnalyzer';
 
-const timeout = 100 * 1000; // 100 seconds, because it takes a while to start tor.
+const timeout = 1000 * 60 * 5; // 5 minutes because it takes a while to start tor.
 
 const turnOnTorInSettings = async (window: Page, shouldEnableTor = true) => {
     await window.click('[data-test="@suite/menu/settings"]');
@@ -40,6 +40,8 @@ testPlaywright.describe('Tor loading screen', () => {
     });
 
     testPlaywright('Tor loading screen: happy path', async () => {
+        testPlaywright.setTimeout(timeout);
+
         let suite = await launchSuite();
 
         await turnOnTorInSettings(suite.window);
@@ -60,6 +62,8 @@ testPlaywright.describe('Tor loading screen', () => {
     testPlaywright(
         'Tor loading screen: making sure that all the request go throw Tor',
         async () => {
+            testPlaywright.setTimeout(timeout);
+
             const networkAnalyzer = new NetworkAnalyzer();
 
             let suite = await launchSuite();
@@ -88,6 +92,8 @@ testPlaywright.describe('Tor loading screen', () => {
     );
 
     testPlaywright('Tor loading screen: disable tor while loading', async () => {
+        testPlaywright.setTimeout(timeout);
+
         let suite = await launchSuite();
 
         await turnOnTorInSettings(suite.window);

--- a/packages/suite/src/views/settings/debug/CoinjoinApi.tsx
+++ b/packages/suite/src/views/settings/debug/CoinjoinApi.tsx
@@ -41,6 +41,7 @@ export const CoinjoinApi = () => {
                     onChange={handleChange}
                     value={selectedOption}
                     options={options}
+                    data-test="@settings/coinjoin-server-select"
                 />
             </ActionColumn>
         </SectionItem>


### PR DESCRIPTION
- add coinjoin test. so far only preparation, enable debug, send regtests, add coinjoin account. there will be followup based on coinjoin branch later
-  `./docker/docker-suite-desktop-test.sh coinjoin` to run only coinjoin test. something like --testPathPattern but without testPathPattern
- desktop tests matrix
- tor is probably still flaky, but it was even before this. At least, it now runs in a separate job, isolated, so it does not spoil test results for other tests. not sure if this is due to the ongoing ddos on tor network or something else. Maybe we should investigate  and do something about it as it will affect also coinjoin tests in the end :( cc @karliatto 

![image](https://user-images.githubusercontent.com/30367552/197779805-26c5e5a7-dd54-4262-af38-fe04ba8377e8.png)

resolves #6663
related #6659