### PR TITLE
Analyze coinjoin transactions aka calculate anonymity

### DIFF
--- a/packages/coinjoin/src/client/CoinjoinClient.ts
+++ b/packages/coinjoin/src/client/CoinjoinClient.ts
@@ -4,6 +4,7 @@ import { Status } from './Status';
 import { Account } from './Account';
 import { CoinjoinRound } from './CoinjoinRound';
 import { getNetwork } from '../utils/settingsUtils';
+import { analyzeTransactions } from './analyzeTransactions';
 import type {
     CoinjoinClientSettings,
     RegisterAccountParams,
@@ -62,6 +63,18 @@ export class CoinjoinClient extends EventEmitter {
         this.removeAllListeners();
         this.abortController.abort();
         this.status.stop();
+    }
+
+    /**
+     * Get transactions from CoinjoinBackend.getAccountInfo and calculate anonymity in middleware.
+     * Returns { key => value } where `key` is an address and `value` is an anonymity level of that address
+     */
+    analyzeTransactions(txs: Parameters<typeof analyzeTransactions>[0]) {
+        return analyzeTransactions(txs, {
+            network: this.network,
+            middlewareUrl: this.settings.middlewareUrl,
+            signal: this.abortController.signal,
+        });
     }
 
     registerAccount(account: RegisterAccountParams) {

--- a/packages/coinjoin/src/client/analyzeTransactions.ts
+++ b/packages/coinjoin/src/client/analyzeTransactions.ts
@@ -1,0 +1,70 @@
+import { address as addressBjs, Network } from '@trezor/utxo-lib';
+import { arrayPartition } from '@trezor/utils';
+
+import * as middleware from './middleware';
+import { Transaction, EnhancedVinVout } from '../types/backend';
+import {
+    AnalyzeTransactionDetails,
+    AnalyzeInternalVinVout,
+    AnalyzeExternalVinVout,
+} from '../types/middleware';
+
+interface AnalyzeTransactionsOptions {
+    network: Network;
+    middlewareUrl: string;
+    signal: AbortSignal;
+}
+
+const transformVinVout = (vinvout: EnhancedVinVout, network: Network) => {
+    if (!vinvout.addresses || vinvout.addresses.length > 1) {
+        throw new Error(`Unsupported address ${vinvout.addresses?.join('')}`);
+    }
+    const address = vinvout.addresses[0];
+    const value = Number(vinvout.value);
+
+    if (vinvout.isAccountOwned) return { address, value } as AnalyzeInternalVinVout;
+
+    const scriptPubKey = addressBjs.toOutputScript(address, network).toString('hex');
+    return {
+        scriptPubKey,
+        value,
+    } as AnalyzeExternalVinVout;
+};
+
+/**
+ * Get transactions from CoinjoinBackend.getAccountInfo and calculate anonymity in middleware.
+ * Returns { key => value } where `key` is an address and `value` is an anonymity level of that address
+ */
+export const analyzeTransactions = async (
+    transactions: Transaction[],
+    options: AnalyzeTransactionsOptions,
+) => {
+    const params = transactions.map(tx => {
+        const [internalInputs, externalInputs] = arrayPartition(
+            tx.details.vin.map(vin => transformVinVout(vin, options.network)),
+            vin => 'address' in vin,
+        );
+
+        const [internalOutputs, externalOutputs] = arrayPartition(
+            tx.details.vout.map(vout => transformVinVout(vout, options.network)),
+            vout => 'address' in vout,
+        );
+
+        return {
+            internalInputs,
+            externalInputs,
+            internalOutputs,
+            externalOutputs,
+        } as AnalyzeTransactionDetails;
+    });
+
+    const result = await middleware.analyzeTransactions(params, {
+        baseUrl: options.middlewareUrl,
+        signal: options.signal,
+    });
+
+    return result.reduce((dict, { address, anonymitySet }) => {
+        dict[address] = anonymitySet;
+        return dict;
+    }, {} as Record<string, number>);
+};

--- a/packages/coinjoin/src/client/middleware.ts
+++ b/packages/coinjoin/src/client/middleware.ts
@@ -1,0 +1,119 @@
+import { coordinatorRequest as request, RequestOptions } from '../utils/http';
+import {
+    AllowedRange,
+    AllowedScriptTypes,
+    IssuerParameter,
+    ZeroCredentials,
+    RealCredentials,
+    CredentialsResponseValidation,
+} from '../types/coordinator';
+import {
+    Credentials,
+    UtxoForRound,
+    AnalyzeTransactionDetails,
+    AnalyzeResult,
+} from '../types/middleware';
+
+export const getRealCredentials = async (
+    amountsToRequest: number[],
+    credentialsToPresent: Credentials[],
+    credentialIssuerParameters: IssuerParameter,
+    maxCredentialValue: number,
+    options: RequestOptions,
+) => {
+    const data = await request<{ realCredentialsRequestData: RealCredentials }>(
+        'create-request',
+        {
+            amountsToRequest,
+            credentialIssuerParameters,
+            maxCredentialValue,
+            credentialsToPresent,
+        },
+        options,
+    );
+    return data.realCredentialsRequestData;
+};
+
+export const getZeroCredentials = async (issuer: IssuerParameter, options: RequestOptions) => {
+    const data = await request<{ zeroCredentialsRequestData: ZeroCredentials }>(
+        'create-request-for-zero-amount',
+        {
+            credentialIssuerParameters: issuer,
+        },
+        options,
+    );
+    return data.zeroCredentialsRequestData;
+};
+
+export const getCredentials = async (
+    credentialIssuerParameters: IssuerParameter,
+    registrationResponse: RealCredentials,
+    registrationValidationData: CredentialsResponseValidation,
+    options: RequestOptions,
+) => {
+    const data = await request<{ credentials: Credentials[] }>(
+        'handle-response',
+        {
+            credentialIssuerParameters,
+            registrationResponse,
+            registrationValidationData,
+        },
+        options,
+    );
+    return data.credentials;
+};
+
+export const decomposeAmounts = async (
+    constants: { feeRate: number; allowedOutputAmounts: AllowedRange },
+    outputSize: number,
+    availableVsize: number,
+    internalAmounts: number[],
+    externalAmounts: number[],
+    options: RequestOptions,
+) => {
+    const data = await request<{ outputAmounts: number[] }>(
+        'decompose-amounts',
+        {
+            constants,
+            outputSize,
+            availableVsize,
+            internalAmounts,
+            externalAmounts,
+            strategy: 'minimum_cost',
+        },
+        options,
+    );
+    return data.outputAmounts;
+};
+
+export const selectUtxoForRound = async (
+    constants: {
+        allowedInputTypes: AllowedScriptTypes[];
+        coordinationFeeRate: any;
+        miningFeeRate: number;
+        allowedInputAmounts: AllowedRange;
+        allowedOutputAmounts: AllowedRange;
+    },
+    utxos: UtxoForRound[],
+    anonScoreTarget: number,
+    options: RequestOptions,
+) => {
+    const data = await request<{ indices: number[] }>(
+        'select-utxo-for-round',
+        {
+            utxos,
+            constants,
+            anonScoreTarget,
+        },
+        options,
+    );
+    return data.indices;
+};
+
+export const analyzeTransactions = async (
+    transactions: AnalyzeTransactionDetails[],
+    options: RequestOptions,
+) => {
+    const data = await request<AnalyzeResult>('analyze-transaction', { transactions }, options);
+    return data.results;
+};

--- a/packages/coinjoin/src/types/backend.ts
+++ b/packages/coinjoin/src/types/backend.ts
@@ -5,6 +5,7 @@ import type {
     Transaction,
     AccountAddresses,
     AccountInfo as AccountInfoBase,
+    EnhancedVinVout,
 } from '@trezor/blockchain-link/lib/types';
 import type {
     Transaction as BlockbookTransaction,
@@ -14,7 +15,7 @@ import type {
 import type { CoinjoinBackendClient } from '../backend/CoinjoinBackendClient';
 import type { MempoolController } from '../backend/CoinjoinMempoolController';
 
-export type { BlockbookTransaction, VinVout };
+export type { BlockbookTransaction, VinVout, EnhancedVinVout };
 export type { Address, Utxo, Transaction, AccountAddresses };
 
 export type BlockbookBlock = {

--- a/packages/coinjoin/src/types/middleware.ts
+++ b/packages/coinjoin/src/types/middleware.ts
@@ -1,0 +1,40 @@
+import { AllowedScriptTypes } from './coordinator';
+
+export interface Credentials {
+    value: number;
+    randomness: string;
+    mac: {
+        t: string;
+    };
+}
+
+export type UtxoForRound = {
+    outpoint: string;
+    amount: number;
+    scriptType: AllowedScriptTypes;
+    anonymitySet: number;
+};
+
+export interface AnalyzeInternalVinVout {
+    address: string;
+    value: number;
+}
+
+export interface AnalyzeExternalVinVout {
+    scriptPubKey: string;
+    value: number;
+}
+
+export interface AnalyzeTransactionDetails {
+    internalInputs: AnalyzeInternalVinVout[];
+    internalOutputs: AnalyzeInternalVinVout[];
+    externalInputs: AnalyzeExternalVinVout[];
+    externalOutputs: AnalyzeExternalVinVout[];
+}
+
+export interface AnalyzeResult {
+    results: {
+        address: string;
+        anonymitySet: number;
+    }[];
+}

--- a/packages/coinjoin/tests/client/analyzeTransactions.test.ts
+++ b/packages/coinjoin/tests/client/analyzeTransactions.test.ts
@@ -1,0 +1,117 @@
+import { networks } from '@trezor/utxo-lib';
+
+import { analyzeTransactions } from '../../src/client/analyzeTransactions';
+import { createServer, Server } from '../mocks/server';
+
+let server: Server | undefined;
+
+// create simplified transaction
+const generateTx = (vin: any[], vout: any[]) => {
+    const r = (v: any) => ({
+        addresses: [v.address],
+        value: v.value,
+        isAccountOwned: v.isAccountOwned,
+    });
+
+    return {
+        details: {
+            vin: vin.map(r),
+            vout: vout.map(r),
+        },
+    } as any;
+};
+
+// dummy anonymity calculation, 1 point in anonymitySet for each occurrence in tx history
+const calcAnonymity = (transactions: any[]) => {
+    const anonymity: Record<string, number> = {};
+    const calc = (vinvout: any) => {
+        if (typeof anonymity[vinvout.address] === 'number') {
+            anonymity[vinvout.address] += 1;
+        } else {
+            anonymity[vinvout.address] = 1;
+        }
+    };
+    transactions.forEach((tx: any) => {
+        tx.internalInputs.forEach(calc);
+        tx.internalOutputs.forEach(calc);
+    });
+
+    return Object.keys(anonymity).map(address => ({ address, anonymitySet: anonymity[address] }));
+};
+
+describe('analyzeTransactions', () => {
+    beforeAll(async () => {
+        server = await createServer();
+    });
+
+    beforeEach(() => {
+        server?.removeAllListeners('test-request');
+    });
+
+    afterAll(() => {
+        if (server) server.close();
+    });
+
+    it('Regtest: simple analyze', async () => {
+        server?.addListener('test-request', ({ url, data }, req, _res) => {
+            let response: any;
+            if (url.endsWith('/analyze-transaction')) {
+                response = {
+                    results: calcAnonymity(data.transactions),
+                };
+            }
+            req.emit('test-response', response);
+        });
+
+        const txHistory = [
+            generateTx(
+                [
+                    {
+                        address: 'bcrt1p9av3jgcyjkwlh6gevvdn95a6vzyfqz962ulm57fc9mjuptg0usls0qvqvk',
+                        value: 100,
+                        isAccountOwned: true,
+                    },
+                    {
+                        address: 'bcrt1ptxf8hxfzqgxr3fz3junehwu0fef80u5e8lw684fkka585kzne6ms6dv5zt',
+                        value: 200,
+                    },
+                ],
+                [
+                    {
+                        address: 'bcrt1pksq9t85p4lect9ra8frvsn3f358lpkwtmlcgcup8aqaxcvnr4ylqglgdfp',
+                        value: 90,
+                        isAccountOwned: true,
+                    },
+                    {
+                        address: 'bcrt1pssj2qdyxm446ckkj2y22uu8l4wdtwjdqhtwk5uef0glazv69pfnsnza9gz',
+                        value: 190,
+                    },
+                ],
+            ),
+            generateTx(
+                [
+                    {
+                        address: 'bcrt1pksq9t85p4lect9ra8frvsn3f358lpkwtmlcgcup8aqaxcvnr4ylqglgdfp',
+                        value: 90,
+                        isAccountOwned: true,
+                    },
+                ],
+                [
+                    {
+                        address: 'bcrt1pssj2qdyxm446ckkj2y22uu8l4wdtwjdqhtwk5uef0glazv69pfnsnza9gz',
+                        value: 80,
+                    },
+                ],
+            ),
+        ];
+
+        const response = await analyzeTransactions(txHistory, {
+            ...server?.requestOptions,
+            network: networks.regtest,
+        });
+        expect(response).toMatchObject({
+            bcrt1p9av3jgcyjkwlh6gevvdn95a6vzyfqz962ulm57fc9mjuptg0usls0qvqvk: 1,
+            bcrt1pksq9t85p4lect9ra8frvsn3f358lpkwtmlcgcup8aqaxcvnr4ylqglgdfp: 2, // occurred twice => greater anonymity
+        });
+    });
+});

--- a/packages/coinjoin/tests/mocks/server.ts
+++ b/packages/coinjoin/tests/mocks/server.ts
@@ -6,7 +6,7 @@ import * as http from 'http';
 const DEFAULT = {
     // middleware
     'analyze-transaction': {
-        results: {},
+        results: [],
     },
     'select-utxo-for-round': {
         indices: [],

--- a/packages/suite/src/actions/wallet/coinjoinAccountActions.ts
+++ b/packages/suite/src/actions/wallet/coinjoinAccountActions.ts
@@ -203,7 +203,7 @@ export const fetchAndUpdateAccount =
             if (isAccountOutdated(account, accountInfo) || isInitialUpdate) {
                 // calculate account anonymity set in CoinjoinClient
                 const accountInfoWithAnonymitySet = await dispatch(
-                    analyzeTransactions(accountInfo),
+                    analyzeTransactions(accountInfo, account.symbol),
                 );
 
                 dispatch(accountsActions.updateAccount(account, accountInfoWithAnonymitySet));


### PR DESCRIPTION
Using coinjoin middleware binary to calculate utxo anonymity. anonymity is a data source for https://github.com/trezor/trezor-suite/issues/6584

- 1st commit
Adding middleware module, same as existing coordinator module provides set of functions to be called on middleware binary

- 2nd commit
Adding `analyzeTransaction` module/function 
It's not really a client/phase related but neither backend related function.
Should be called after account discovery if account did change

- 3rd commit
Replace fake implementation with the real one, leaving fallback to `1` just in case