### PR TITLE
CoinJoin - Store discovery progress to storage

### DIFF
--- a/packages/coinjoin/src/backend/CoinjoinFilterController.ts
+++ b/packages/coinjoin/src/backend/CoinjoinFilterController.ts
@@ -1,4 +1,4 @@
-import { FILTERS_BATCH_SIZE } from '../constants';
+import { FILTERS_BATCH_SIZE, PROGRESS_BATCH_SIZE_MIN, PROGRESS_BATCH_SIZE_MAX } from '../constants';
 import type {
     FilterClient,
     FilterController,
@@ -11,32 +11,55 @@ export class CoinjoinFilterController implements FilterController {
     private readonly client;
     private readonly baseBlockHash;
 
-    private bestHeight: number;
-    get bestBlockHeight() {
-        return this.bestHeight;
-    }
-
     constructor(client: FilterClient, { baseBlockHash }: CoinjoinBackendSettings) {
         this.client = client;
         this.baseBlockHash = baseBlockHash;
-        this.bestHeight = -1;
+    }
+
+    /**
+     * Returns number of blocks which must be scanned to change the discovery progress by 1 %,
+     * clamped by PROGRESS_BATCH_SIZE_MIN (so progress is not signalled too often)
+     * and PROGRESS_BATCH_SIZE_MAX (so there isn't too big gap between two progress signallings)
+     */
+    private getProgressBatchSize(firstBlock: number, bestBlock: number) {
+        const percent = Math.ceil((bestBlock - firstBlock) / 100);
+        return Math.min(Math.max(percent, PROGRESS_BATCH_SIZE_MIN), PROGRESS_BATCH_SIZE_MAX);
     }
 
     async *getFilterIterator(params?: FilterControllerParams, context?: FilterControllerContext) {
-        const batchSize = params?.batchSize ?? FILTERS_BATCH_SIZE;
-        let knownBlockHash = params?.fromHash ?? this.baseBlockHash;
-        while (knownBlockHash) {
+        const filterBatchSize = params?.batchSize ?? FILTERS_BATCH_SIZE;
+
+        let counter = 0;
+        let filterBatch = await this.client.fetchFilters(
+            params?.fromHash ?? this.baseBlockHash,
+            filterBatchSize,
+            { signal: context?.abortSignal },
+        );
+
+        const firstBlockHeight = filterBatch.filters[0]?.blockHeight;
+
+        while (filterBatch.filters.length) {
+            const { bestHeight, filters } = filterBatch;
+            const progressBatchSize = this.getProgressBatchSize(firstBlockHeight, bestHeight);
+            for (let i = 0; i < filters.length; ++i) {
+                const filter = filters[i];
+                let progress;
+                if (++counter >= progressBatchSize) {
+                    counter = 0;
+                    progress =
+                        (filter.blockHeight - firstBlockHeight) / (bestHeight - firstBlockHeight);
+                }
+                yield {
+                    ...filter,
+                    progress,
+                };
+            }
             // eslint-disable-next-line no-await-in-loop
-            const { bestHeight, filters } = await this.client.fetchFilters(
-                knownBlockHash,
-                batchSize,
+            filterBatch = await this.client.fetchFilters(
+                filters[filters.length - 1].blockHash,
+                filterBatchSize,
                 { signal: context?.abortSignal },
             );
-            this.bestHeight = bestHeight;
-            for (let i = 0; i < filters.length; ++i) {
-                yield filters[i];
-            }
-            knownBlockHash = filters[filters.length - 1]?.blockHash;
         }
     }
 }

--- a/packages/coinjoin/src/backend/scanAddress.ts
+++ b/packages/coinjoin/src/backend/scanAddress.ts
@@ -22,7 +22,7 @@ export const scanAddress = async (
         { abortSignal },
     );
     // eslint-disable-next-line no-restricted-syntax
-    for await (const { filter, blockHash, blockHeight } of everyFilter) {
+    for await (const { filter, blockHash, blockHeight, progress } of everyFilter) {
         checkpoint = { blockHash, blockHeight };
         const isMatch = getFilter(filter, blockHash);
         if (isMatch(script)) {
@@ -35,6 +35,7 @@ export const scanAddress = async (
             onProgress({
                 checkpoint,
                 transactions,
+                info: { progress },
             });
         }
     }

--- a/packages/coinjoin/src/constants.ts
+++ b/packages/coinjoin/src/constants.ts
@@ -1,4 +1,11 @@
+// Maximum number of filters requested from backend in one request
 export const FILTERS_BATCH_SIZE = 100;
+
+// Minimum number of blocks after which 'progress' event is fired by scanAccount
+export const PROGRESS_BATCH_SIZE_MIN = 10;
+
+// Maximum number of blocks after which 'progress' event is fired by scanAccount
+export const PROGRESS_BATCH_SIZE_MAX = 10000;
 
 export const DISCOVERY_LOOKOUT = 20;
 

--- a/packages/coinjoin/src/types/backend.ts
+++ b/packages/coinjoin/src/types/backend.ts
@@ -107,12 +107,15 @@ export type FilterControllerContext = {
     abortSignal?: AbortSignal;
 };
 
+type IteratedBlockFilter = BlockFilter & {
+    progress?: number;
+};
+
 export interface FilterController {
-    get bestBlockHeight(): number;
     getFilterIterator(
         params?: FilterControllerParams,
         context?: FilterControllerContext,
-    ): AsyncGenerator<BlockFilter>;
+    ): AsyncGenerator<IteratedBlockFilter>;
 }
 
 export type FilterClient = Pick<CoinjoinBackendClient, 'fetchFilters'>;

--- a/packages/coinjoin/tests/backend/CoinjoinFilterController.test.ts
+++ b/packages/coinjoin/tests/backend/CoinjoinFilterController.test.ts
@@ -13,8 +13,6 @@ const FILTERS: BlockFilter[] = mockFilterSequence(
     COINJOIN_BACKEND_SETTINGS.baseBlockHash,
 );
 
-const BEST_HEIGHT = FILTER_COUNT + COINJOIN_BACKEND_SETTINGS.baseBlockHeight;
-
 const FIXTURES = [
     {
         description: 'From start',
@@ -55,8 +53,7 @@ describe('CoinjoinFilterController', () => {
                 const iterator = controller.getFilterIterator(params);
                 const received = [];
                 // eslint-disable-next-line no-restricted-syntax
-                for await (const b of iterator) {
-                    expect(controller.bestBlockHeight).toBe(BEST_HEIGHT);
+                for await (const { progress, ...b } of iterator) {
                     received.push(b);
                 }
                 expect(received).toEqual(expected);

--- a/packages/suite/src/components/wallet/WalletLayout/index.tsx
+++ b/packages/suite/src/components/wallet/WalletLayout/index.tsx
@@ -43,7 +43,7 @@ type ProgressInfo = {
 };
 
 const AccountLoadingProgress = ({ account: { account } }: Pick<WalletLayoutProps, 'account'>) => {
-    const [progress, setProgress] = useState<ProgressInfo>();
+    const [progress, setProgress] = useState<ProgressInfo>({});
 
     const { symbol: network, backendType, descriptor } = account || {};
 
@@ -53,23 +53,23 @@ const AccountLoadingProgress = ({ account: { account } }: Pick<WalletLayoutProps
         const backend = CoinjoinBackendService.getInstance(network);
         if (!backend) return;
 
-        const onProgress = ({ info }: { info?: ProgressInfo }) => setProgress(info);
+        const onProgress = ({ info }: { info?: ProgressInfo }) => info && setProgress(info);
         backend.on(`progress/${descriptor}`, onProgress);
         return () => {
             backend.off(`progress/${descriptor}`, onProgress);
         };
     }, [network, backendType, descriptor]);
 
-    const value = progress?.progress ?? 0;
+    const value = progress.progress ?? 0;
 
-    return progress ? (
+    return (
         <>
             <Progress max={1} value={value} />
             <p>
                 {Math.floor(100 * value)} % {progress.message}
             </p>
         </>
-    ) : null;
+    );
 };
 
 export const WalletLayout = ({

--- a/packages/suite/src/middlewares/wallet/storageMiddleware.ts
+++ b/packages/suite/src/middlewares/wallet/storageMiddleware.ts
@@ -224,6 +224,7 @@ const storageMiddleware = (api: MiddlewareAPI<Dispatch, AppState>) => {
                     break;
 
                 case COINJOIN.ACCOUNT_CREATE:
+                case COINJOIN.ACCOUNT_DISCOVERY_PROGRESS:
                     api.dispatch(storageActions.saveCoinjoinAccount(action.payload.account.key));
                     break;
                 case COINJOIN.ACCOUNT_AUTHORIZE_SUCCESS:


### PR DESCRIPTION
## Description

With remembered device, CoinJoin discovery progress ('checkpoint') wasn't stored into storage immediately when changed. Now it should be.

https://github.com/trezor/trezor-suite/commit/5887512634274dc7c1379d52e477ed2f71c52126 - `CoinjoinFilterController` is now responsible for signalling progress, but only when relevant (change by 1 %, clamped); `progress` event is fired from `scanAccount` only when there are transactions found in the block or when progress is signalled by the `CoinjoinFilterController`
https://github.com/trezor/trezor-suite/commit/6ec07b4fe4bdf72bf1250e20e66023047865a3fc - coinjoin account data is stored into storage whenever `progress` event is fired from `CoinjoinBackend`
