### PR TITLE
feat(suite-native): Add keyboard aware scrollview

### DIFF
--- a/suite-native/navigation/package.json
+++ b/suite-native/navigation/package.json
@@ -22,6 +22,7 @@
         "@trezor/theme": "*",
         "react": "18.2.0",
         "react-native": "0.70.3",
+        "react-native-keyboard-aware-scroll-view": "^0.9.5",
         "react-native-safe-area-context": "^4.3.1"
     },
     "devDependencies": {

--- a/suite-native/navigation/src/components/ScreenContent.tsx
+++ b/suite-native/navigation/src/components/ScreenContent.tsx
@@ -1,6 +1,6 @@
 import React, { ReactNode } from 'react';
-import { ScrollView } from 'react-native';
 import { EdgeInsets, useSafeAreaInsets } from 'react-native-safe-area-context';
+import { KeyboardAwareScrollView } from 'react-native-keyboard-aware-scroll-view';
 
 import { prepareNativeStyle, useNativeStyles } from '@trezor/styles';
 import { Box } from '@suite-native/atoms';
@@ -45,8 +45,11 @@ export const ScreenContent = ({
     if (!isScrollable) return <Box style={screenStyle}>{children}</Box>;
 
     return (
-        <ScrollView contentInsetAdjustmentBehavior="automatic" contentContainerStyle={screenStyle}>
+        <KeyboardAwareScrollView
+            contentInsetAdjustmentBehavior="automatic"
+            contentContainerStyle={screenStyle}
+        >
             {children}
-        </ScrollView>
+        </KeyboardAwareScrollView>
     );
 };

--- a/yarn.lock
+++ b/yarn.lock
@@ -6776,6 +6776,7 @@ __metadata:
     jest: ^26.6.3
     react: 18.2.0
     react-native: 0.70.3
+    react-native-keyboard-aware-scroll-view: ^0.9.5
     react-native-safe-area-context: ^4.3.1
     typescript: 4.7.4
   languageName: unknown
@@ -28104,6 +28105,27 @@ __metadata:
     react-native-gesture-handler: ">=2"
     react-native-reanimated: ">=2"
   checksum: ec9e4bf7a6d4ff28d0c465deeee16a40331fa0e8d899ecb2a9bdf2542aa5105c984e404654b965ff80d20dd870804867cfd7fc9638c9c5cd429ffa10dd987803
+  languageName: node
+  linkType: hard
+
+"react-native-iphone-x-helper@npm:^1.0.3":
+  version: 1.3.1
+  resolution: "react-native-iphone-x-helper@npm:1.3.1"
+  peerDependencies:
+    react-native: ">=0.42.0"
+  checksum: 024376646009a966e33e12fc2358751830818b0fb73b1c601a64eb5e490d2dc43eec23668991b985a8c412a84d087f20eb45bb9b593567c08b66e741b7bddda5
+  languageName: node
+  linkType: hard
+
+"react-native-keyboard-aware-scroll-view@npm:^0.9.5":
+  version: 0.9.5
+  resolution: "react-native-keyboard-aware-scroll-view@npm:0.9.5"
+  dependencies:
+    prop-types: ^15.6.2
+    react-native-iphone-x-helper: ^1.0.3
+  peerDependencies:
+    react-native: ">=0.48.4"
+  checksum: 5eec2aedb886213dfed4c8428a443b565dce80ba9fcf5897171e4c8829d4dd64c5011ac004d93f29adfc83ad6f88c2838d1a5b45255dc4a49bd1c0a169245800
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Adds library that imports HOC that wraps all main scrolling components and allows for KeyboardAvoidingView. Currently it's only usage is the ScreenContent component for generic screen.

## Related Issue

Resolve [Implement Keyboard Avoiding for inputs#6318](https://github.com/trezor/trezor-suite/issues/6318)