### PR TITLE
fix(scripts): update minimatch

### DIFF
--- a/scripts/package.json
+++ b/scripts/package.json
@@ -10,7 +10,7 @@
         "@mobily/ts-belt": "^3.11.0",
         "chalk": "^4.1.2",
         "fs-extra": "^10.1.0",
-        "minimatch": "^3.0.4",
+        "minimatch": "^3.1.2",
         "prettier": "^2.7.1",
         "sort-package-json": "^1.54.0",
         "yargs": "17.5.1"

--- a/yarn.lock
+++ b/yarn.lock
@@ -7386,7 +7386,7 @@ __metadata:
     chalk: ^4.1.2
     fs-extra: ^10.1.0
     jest: ^26.6.3
-    minimatch: ^3.0.4
+    minimatch: ^3.1.2
     prettier: ^2.7.1
     sort-package-json: ^1.54.0
     typescript: 4.7.4
@@ -15016,7 +15016,7 @@ __metadata:
     buffer-equal: 1.0.0
     colors: 1.0.3
     commander: 2.9.0
-    minimatch: 3.0.4
+    minimatch: ^3.0.4
   bin:
     dircompare: src/cli/dircompare.js
   checksum: 16710bcb640b0edb753c6ecf10440c20a073588d797f624288601c52bca64a1f8c4dcd474d1fb7fda3595361b7cf528dee856140d83ecdaa19ba5695112d1209
@@ -24214,25 +24214,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"minimatch@npm:3.0.4":
-  version: 3.0.4
-  resolution: "minimatch@npm:3.0.4"
-  dependencies:
-    brace-expansion: ^1.1.7
-  checksum: 66ac295f8a7b59788000ea3749938b0970344c841750abd96694f80269b926ebcafad3deeb3f1da2522978b119e6ae3a5869b63b13a7859a456b3408bd18a078
-  languageName: node
-  linkType: hard
-
-"minimatch@npm:3.0.5":
-  version: 3.0.5
-  resolution: "minimatch@npm:3.0.5"
-  dependencies:
-    brace-expansion: ^1.1.7
-  checksum: a3b84b426eafca947741b864502cee02860c4e7b145de11ad98775cfcf3066fef422583bc0ffce0952ddf4750c1ccf4220b1556430d4ce10139f66247d87d69e
-  languageName: node
-  linkType: hard
-
-"minimatch@npm:^3.0.2, minimatch@npm:^3.0.4, minimatch@npm:^3.1.1, minimatch@npm:^3.1.2":
+"minimatch@npm:^3.0.2, minimatch@npm:^3.0.4, minimatch@npm:^3.0.5, minimatch@npm:^3.1.1, minimatch@npm:^3.1.2":
   version: 3.1.2
   resolution: "minimatch@npm:3.1.2"
   dependencies:
@@ -25296,7 +25278,7 @@ __metadata:
     ignore: ^5.0.4
     js-yaml: 4.1.0
     jsonc-parser: 3.0.0
-    minimatch: 3.0.5
+    minimatch: ^3.0.5
     npm-run-path: ^4.0.1
     open: ^8.4.0
     semver: 7.3.4


### PR DESCRIPTION
## Description

Update `minimatch` to get rid of https://github.com/trezor/trezor-suite/security/dependabot/121
