### PR TITLE
Feat/connect: signTransaction serialize option

### DIFF
--- a/docs/packages/connect/methods/signTransaction.md
+++ b/docs/packages/connect/methods/signTransaction.md
@@ -36,6 +36,7 @@ const result = await TrezorConnect.signTransaction(params);
 -   `amountUnit` — _optional_ `PROTO.AmountUnit`
     > show amounts in BTC, mBTC, uBTC, sat
 -   `unlockPath` - _optional_ [PROTO.UnlockPath](https://github.com/trezor/trezor-suite/blob/develop/packages/transport/src/types/messages.ts), the result of [TrezorConnect.unlockPath](./unlockPath.md) method.
+-   `serialize` - _optional_ `boolean`, default `true` serialize the full transaction, as opposed to only outputting the signatures
 
 ### Example
 

--- a/packages/connect/e2e/tests/device/authorizeCoinJoin.test.ts
+++ b/packages/connect/e2e/tests/device/authorizeCoinJoin.test.ts
@@ -134,6 +134,7 @@ describe('TrezorConnect.authorizeCoinJoin', () => {
             coin: 'testnet',
             preauthorized: true,
             unlockPath: unlockPath.payload, // NOTE: unlock path is required for validation, it will be removed in future
+            serialize: false,
         };
 
         // ButtonRequests during signing is not emitted because of preauthorization
@@ -144,12 +145,7 @@ describe('TrezorConnect.authorizeCoinJoin', () => {
                 undefined,
                 'c017fce789fa8db54a2ae032012d2dd6d7c76cc1c1a6f00e29b86acbf93022da8aa559009a574792c7b09b2535d288d6e03c6ed169902ed8c4c97626a83fbc11',
             ],
-            witnesses: [
-                undefined,
-                '0140c017fce789fa8db54a2ae032012d2dd6d7c76cc1c1a6f00e29b86acbf93022da8aa559009a574792c7b09b2535d288d6e03c6ed169902ed8c4c97626a83fbc11',
-            ],
-            serializedTx:
-                '010000000001028abbd1cf69e00fbf60fa3ba475dccdbdba4a859ffa6bfd1ee820a75b1be2b7e50000000000ffffffff0ab6ad3ba09261cfb4fa1d3680cb19332a8fe4d9de9ea89aa565bd83a2c082f90100000000ffffffff0550c3000000000000225120e0458118b80a08042d84c4f0356d86863fe2bffc034e839c166ad4e8da7e26ef50c3000000000000225120bdb100a4e7ba327d364642dc653b9e6b51783bde6ea0df2ccbc1a78e3cc1329511e56d0000000000225120c5c7c63798b59dc16e97d916011e99da5799d1b3dd81c2f2e93392477417e71e72bf00000000000022512062fdf14323b9ccda6f5b03c5c2c28e35839a3909a2e14d32b595c63d53c7b88f51900000000000001976a914a579388225827d9f2fe9014add644487808c695d88ac000140c017fce789fa8db54a2ae032012d2dd6d7c76cc1c1a6f00e29b86acbf93022da8aa559009a574792c7b09b2535d288d6e03c6ed169902ed8c4c97626a83fbc1100000000',
+            serializedTx: '',
         });
 
         // sign again ...

--- a/packages/connect/src/api/signTransaction.ts
+++ b/packages/connect/src/api/signTransaction.ts
@@ -66,6 +66,7 @@ export default class SignTransaction extends AbstractMethod<'signTransaction', P
             { name: 'preauthorized', type: 'boolean' },
             { name: 'amountUnit', type: ['number', 'string'] },
             { name: 'unlockPath', type: 'object' },
+            { name: 'serialize', type: 'boolean' },
         ]);
 
         if (payload.unlockPath) {
@@ -121,6 +122,7 @@ export default class SignTransaction extends AbstractMethod<'signTransaction', P
                 branch_id: payload.branchId,
                 decred_staking_ticket: payload.decredStakingTicket,
                 amount_unit: payload.amountUnit,
+                serialize: payload.serialize,
             },
             coinInfo,
             push: typeof payload.push === 'boolean' ? payload.push : false,
@@ -197,6 +199,11 @@ export default class SignTransaction extends AbstractMethod<'signTransaction', P
             refTxs,
             typedCall: device.getCommands().typedCall.bind(device.getCommands()),
         });
+
+        // return only signatures, using option `serialize: false`
+        if (!response.serializedTx) {
+            return response;
+        }
 
         if (params.options.decred_staking_ticket) {
             await verifyTicketTx(

--- a/packages/connect/src/types/api/bitcoin/index.ts
+++ b/packages/connect/src/types/api/bitcoin/index.ts
@@ -55,6 +55,7 @@ export interface TransactionOptions {
     branch_id?: number;
     decred_staking_ticket?: boolean;
     amount_unit?: PROTO.AmountUnit;
+    serialize?: boolean;
 }
 
 export interface SignTransaction {
@@ -78,6 +79,7 @@ export interface SignTransaction {
     preauthorized?: boolean;
     amountUnit?: PROTO.AmountUnit;
     unlockPath?: PROTO.UnlockPath;
+    serialize?: boolean;
 }
 
 export type SignedTransaction = {

--- a/packages/transport/messages.json
+++ b/packages/transport/messages.json
@@ -609,6 +609,13 @@
                     "options": {
                         "default": false
                     }
+                },
+                "serialize": {
+                    "type": "bool",
+                    "id": 13,
+                    "options": {
+                        "default": true
+                    }
                 }
             }
         },

--- a/packages/transport/src/types/messages.ts
+++ b/packages/transport/src/types/messages.ts
@@ -240,6 +240,7 @@ export type SignTx = {
     branch_id?: number;
     amount_unit?: AmountUnit;
     decred_staking_ticket?: boolean;
+    serialize?: boolean;
 };
 
 export enum Enum_RequestType {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Following [trezor-firmware feature](https://github.com/trezor/trezor-firmware/pull/2507), add `serialize` option to `TrezorConnect.signTransaction` method
`serialize: boolean` - default true in protobuf

When set to false Trezor will skip tx serialization (faster signing) and returns only tx signatures
## Related Issue

Prerequisite for [coinjoin](https://github.com/trezor/trezor-suite/pull/6485)
