### PR TITLE
Feat/connect reauthorize coinjoin

### DIFF
--- a/docs/packages/connect/methods/authorizeCoinJoin.md
+++ b/docs/packages/connect/methods/authorizeCoinJoin.md
@@ -35,6 +35,8 @@ const result = await TrezorConnect.authorizeCoinJoin(params);
     > used to distinguish between various address formats (non-segwit, segwit, etc.)
 -   `amountUnit` — _optional_ `PROTO.AmountUnit`
     > show amounts in
+-   `preauthorized` — _optional_
+    > Check if device session is already preauthorized and take no further action if so
 
 ### Example:
 

--- a/packages/connect/e2e/tests/device/passphrase.test.ts
+++ b/packages/connect/e2e/tests/device/passphrase.test.ts
@@ -21,12 +21,14 @@ describe('TrezorConnect passphrase', () => {
     beforeAll(async () => {
         await setup(controller, {
             mnemonic: 'mnemonic_all',
-            passphrase_protection: true,
+            use_passphrase: true, // note: this will not work with 2-master and user-env
         });
         await initTrezorConnect(controller, { debug: false });
+        await TrezorConnect.applySettings({ use_passphrase: true });
     });
 
-    afterAll(() => {
+    afterAll(async () => {
+        await TrezorConnect.applySettings({ use_passphrase: false });
         controller.dispose();
         TrezorConnect.dispose();
     });

--- a/packages/connect/src/types/api/authorizeCoinJoin.ts
+++ b/packages/connect/src/types/api/authorizeCoinJoin.ts
@@ -10,6 +10,7 @@ export interface AuthorizeCoinJoin {
     coin?: string;
     scriptType?: PROTO.InternalInputScriptType;
     amountUnit?: PROTO.AmountUnit;
+    preauthorized?: boolean;
 }
 
 export declare function authorizeCoinJoin(


### PR DESCRIPTION
## Description

add `preauthorized` option to `TrezorConnect.authorizeCoinjoin` method
`preauthorized: boolean` - optional default undefined

When set to true Trezor will check if it is already preautorized and skip authorization if so

## Related Issue

Prerequisite for [coinjoin](https://github.com/trezor/trezor-suite/pull/6485)

Fix for failing tests in connect should be done in user-env https://github.com/trezor/trezor-user-env/issues/202
