### PR TITLE
Fix missing fee rate in coinjoin account transactions

### DIFF
--- a/packages/coinjoin/src/backend/scanAccount.ts
+++ b/packages/coinjoin/src/backend/scanAccount.ts
@@ -1,7 +1,7 @@
 import { transformTransaction } from '@trezor/blockchain-link/lib/workers/blockbook/utils';
 
 import { getAddressScript, getFilter } from './filters';
-import { doesTxContainAddress, deriveAddresses, fixTxInputs } from './backendUtils';
+import { doesTxContainAddress, deriveAddresses, fixTx } from './backendUtils';
 import type {
     AccountAddress,
     BlockbookBlock,
@@ -109,7 +109,7 @@ export const scanAccount = async (
 
         txs.clear();
 
-        await fixTxInputs(transactions, client);
+        await fixTx(transactions, client);
 
         if (transactions.length || progress) {
             onProgress({

--- a/packages/coinjoin/src/backend/scanAccount.ts
+++ b/packages/coinjoin/src/backend/scanAccount.ts
@@ -126,8 +126,6 @@ export const scanAccount = async (
         .getTransactions(receive.concat(change).map(({ address }) => address))
         .map(transformTx(xpub, receive, change));
 
-    await fixTxInputs(pending, client);
-
     const cache = {
         receivePrederived: receive.map(({ address, path }) => ({ address, path })),
         changePrederived: change.map(({ address, path }) => ({ address, path })),

--- a/packages/coinjoin/src/backend/scanAddress.ts
+++ b/packages/coinjoin/src/backend/scanAddress.ts
@@ -1,7 +1,7 @@
 import { transformTransaction } from '@trezor/blockchain-link/lib/workers/blockbook/utils';
 
 import { getAddressScript, getFilter } from './filters';
-import { doesTxContainAddress, fixTxInputs } from './backendUtils';
+import { doesTxContainAddress, fixTx } from './backendUtils';
 import type {
     ScanAddressParams,
     ScanAddressCheckpoint,
@@ -30,7 +30,7 @@ export const scanAddress = async (
             const blockTxs = block.txs.filter(doesTxContainAddress(address));
             const transactions = blockTxs.map(tx => transformTransaction(address, undefined, tx));
 
-            await fixTxInputs(transactions, client);
+            await fixTx(transactions, client);
 
             onProgress({
                 checkpoint,

--- a/packages/coinjoin/src/backend/scanAddress.ts
+++ b/packages/coinjoin/src/backend/scanAddress.ts
@@ -46,8 +46,6 @@ export const scanAddress = async (
         .getTransactions([address])
         .map(tx => transformTransaction(address, undefined, tx));
 
-    await fixTxInputs(pending, client);
-
     return {
         pending,
         checkpoint,

--- a/packages/coinjoin/tests/backend/methods.test.ts
+++ b/packages/coinjoin/tests/backend/methods.test.ts
@@ -155,10 +155,10 @@ describe(`CoinjoinBackend methods`, () => {
         expect(halfBlocks).toEqual([1, 2, 4]);
         fetchBlockMock.mockClear();
 
-        // Should request only txid_4 transaction from mempool
-        // and txid_2 because it has account's inputs (TEMPORARY FIX)
+        // Should request only txid_4 transaction from mempool,
+        // but currently requests all the transactions (TEMPORARY FIX)
         const halfTxs = getRequestedTxs();
-        expect(halfTxs).toEqual(['txid_2', FIXTURES.TX_4_PENDING.txid]);
+        expect(halfTxs).toEqual(['txid_1', 'txid_2', 'txid_3', FIXTURES.TX_4_PENDING.txid]);
         fetchTxMock.mockClear();
 
         // All blocks are known
@@ -192,8 +192,8 @@ describe(`CoinjoinBackend methods`, () => {
         expect(restBlocks).toEqual([6, 7, 8]);
 
         // Shouldn't request any transaction from mempool
-        // and txid_4 and txid_5 because they have account's inputs (TEMPORARY FIX)
+        // but currently requests all the transactions (TEMPORARY FIX)
         const restTxs = getRequestedTxs();
-        expect(restTxs).toEqual(['txid_4', 'txid_5']);
+        expect(restTxs).toEqual(['txid_4', 'txid_5', 'txid_6']);
     });
 });


### PR DESCRIPTION
## Description

Transactions fetched from Blockbook's `/block` endpoint don't have all the fields (now specifically `vsize`, `size` and `hex`) needed for calculating fee rate. Given that their inputs are already being enhanced by data fetched from `/tx` endpoint, these missing fields were added or calculated (in the same way as in [transformTransaction](https://github.com/trezor/trezor-suite/blob/541b6e5b76349b0747ba3d5110e7b47546dce8c1/packages/blockchain-link/src/workers/blockbook/utils.ts#L91)) as well.
