### PR TITLE
feat(coinjoin): disable coinjoin for T1, older firmwares and web

### DIFF
--- a/packages/suite/src/components/suite/modals/AddAccount/components/AccountTypeDescription.tsx
+++ b/packages/suite/src/components/suite/modals/AddAccount/components/AccountTypeDescription.tsx
@@ -5,27 +5,38 @@ import { Network } from '@wallet-types';
 import { Translation, TrezorLink } from '@suite-components';
 import { getAccountTypeDesc, getAccountTypeUrl } from '@suite-common/wallet-utils';
 
-const Info = styled(P)`
+const Info = styled(P).attrs(() => ({
+    size: 'small',
+    textAlign: 'left',
+}))`
     color: ${props => props.theme.TYPE_LIGHT_GREY};
     margin: 20px 0;
 `;
 
-interface Props {
-    network: Network;
-    accountTypes?: Network[];
+interface AccountTypeDescriptionProps {
+    bip43Path: Network['bip43Path'];
+    hasMultipleAccountTypes: boolean;
 }
 
-export const AccountTypeDescription = ({ network, accountTypes }: Props) => {
-    if (!accountTypes || accountTypes.length <= 1) return null;
-    const accountTypeUrl = getAccountTypeUrl(network.bip43Path);
-    const accountTypeDesc = getAccountTypeDesc(network.bip43Path);
+export const AccountTypeDescription = ({
+    bip43Path,
+    hasMultipleAccountTypes,
+}: AccountTypeDescriptionProps) => {
+    if (!hasMultipleAccountTypes) return null;
+    const accountTypeUrl = getAccountTypeUrl(bip43Path);
+    const accountTypeDesc = getAccountTypeDesc(bip43Path);
 
     return (
-        <Info size="small" textAlign="left">
-            <Translation id={accountTypeDesc} />{' '}
-            <TrezorLink icon="EXTERNAL_LINK" href={accountTypeUrl} size="small">
-                <Translation id="TR_LEARN_MORE" />
-            </TrezorLink>
+        <Info>
+            <Translation id={accountTypeDesc} />
+            {accountTypeUrl && (
+                <>
+                    {' '}
+                    <TrezorLink icon="EXTERNAL_LINK" href={accountTypeUrl} size="small">
+                        <Translation id="TR_LEARN_MORE" />
+                    </TrezorLink>
+                </>
+            )}
         </Info>
     );
 };

--- a/packages/suite/src/components/suite/modals/AddAccount/components/AccountTypeSelect.tsx
+++ b/packages/suite/src/components/suite/modals/AddAccount/components/AccountTypeSelect.tsx
@@ -1,11 +1,10 @@
 import React from 'react';
 import styled from 'styled-components';
-import { P, Select, variables } from '@trezor/components';
+import { Select, variables } from '@trezor/components';
 import { Translation } from '@suite-components/Translation';
 import { getAccountTypeName, getAccountTypeTech } from '@suite-common/wallet-utils';
 import { AccountTypeDescription } from './AccountTypeDescription';
-import type { UnavailableCapabilities } from '@trezor/connect';
-import type { Network } from '@wallet-types';
+import { Network } from '@wallet-types';
 
 const LabelWrapper = styled.div`
     display: flex;
@@ -20,11 +19,6 @@ const TypeInfo = styled.div`
     font-size: ${variables.FONT_SIZE.TINY};
     color: ${props => props.theme.TYPE_LIGHT_GREY};
     margin-left: 1ch;
-`;
-
-const UnavailableInfo = styled(P)`
-    color: ${props => props.theme.TYPE_LIGHT_GREY};
-    margin: 20px 0;
 `;
 
 const buildAccountTypeOption = (network: Network) =>
@@ -44,20 +38,19 @@ const formatLabel = (option: Option) => (
     </LabelWrapper>
 );
 
-interface Props {
+interface AccountTypeSelectProps {
     network: Network;
     accountTypes: Network[];
     onSelectAccountType: (network: Network) => void;
-    unavailableCapabilities?: UnavailableCapabilities;
 }
 
 export const AccountTypeSelect = ({
     network,
     accountTypes,
     onSelectAccountType,
-    unavailableCapabilities,
-}: Props) => {
+}: AccountTypeSelectProps) => {
     const options = accountTypes.map(buildAccountTypeOption);
+
     return (
         <>
             <Select
@@ -70,13 +63,10 @@ export const AccountTypeSelect = ({
                 formatOptionLabel={formatLabel}
                 onChange={(option: Option) => onSelectAccountType(option.value)}
             />
-            {unavailableCapabilities && unavailableCapabilities[network.accountType!] ? (
-                <UnavailableInfo size="small" textAlign="left">
-                    <Translation id="TR_ACCOUNT_TYPE_BIP86_NOT_SUPPORTED" />
-                </UnavailableInfo>
-            ) : (
-                <AccountTypeDescription network={network} accountTypes={accountTypes} />
-            )}
+            <AccountTypeDescription
+                bip43Path={network.bip43Path}
+                hasMultipleAccountTypes={accountTypes && accountTypes?.length > 1}
+            />
         </>
     );
 };

--- a/packages/suite/src/components/suite/modals/AddAccount/index.tsx
+++ b/packages/suite/src/components/suite/modals/AddAccount/index.tsx
@@ -194,7 +194,6 @@ export const AddAccount = ({ device, onCancel, symbol, noRedirect }: Props) => {
                             network={selectedNetwork}
                             accountTypes={accountTypes}
                             onSelectAccountType={selectNetwork}
-                            unavailableCapabilities={device.unavailableCapabilities}
                         />
                     )}
 

--- a/packages/suite/src/support/messages.ts
+++ b/packages/suite/src/support/messages.ts
@@ -3532,10 +3532,21 @@ export default defineMessages({
         id: 'TR_ACCOUNT_DETAILS_XPUB_BUTTON',
         defaultMessage: 'Show public key',
     },
-    TR_ACCOUNT_TYPE_BIP86_NOT_SUPPORTED: {
-        id: 'TR_ACCOUNT_TYPE_BIP86_NOT_SUPPORTED',
-        defaultMessage:
-            'Current firmware does not support Taproot. Please update your Trezor firmware to enable this feature.',
+    TR_ACCOUNT_TYPE_NO_CAPABILITY: {
+        id: 'TR_ACCOUNT_TYPE_NO_CAPABILITY',
+        defaultMessage: 'Not supported.',
+    },
+    TR_ACCOUNT_TYPE_NO_SUPPORT_T1: {
+        id: 'TR_ACCOUNT_TYPE_NO_SUPPORT_T1',
+        defaultMessage: 'This Account Type is not supported on Trezor Model One.',
+    },
+    TR_ACCOUNT_TYPE_NO_SUPPORT_T2: {
+        id: 'TR_ACCOUNT_TYPE_NO_SUPPORT_T2',
+        defaultMessage: 'This Account Type is not supported on Trezor Model T.',
+    },
+    TR_ACCOUNT_TYPE_UPDATE_REQUIRED: {
+        id: 'TR_ACCOUNT_TYPE_UPDATE_REQUIRED',
+        defaultMessage: 'Please update device firmware to enable this Account Type.',
     },
     TR_ACCOUNT_TYPE_BIP86_NAME: {
         id: 'TR_ACCOUNT_TYPE_BIP86_NAME',
@@ -4090,6 +4101,22 @@ export default defineMessages({
     MODAL_ADD_ACCOUNT_LIMIT_EXCEEDED: {
         id: 'MODAL_ADD_ACCOUNT_LIMIT_EXCEEDED',
         defaultMessage: 'The maximum allowed number of accounts has been created. ',
+    },
+    MODAL_ADD_ACCOUNT_COINJOIN_LIMIT_EXCEEDED: {
+        id: 'MODAL_ADD_ACCOUNT_COINJOIN_LIMIT_EXCEEDED',
+        defaultMessage: 'You can have only one CoinJoin account per wallet.',
+    },
+    MODAL_ADD_ACCOUNT_COINJOIN_NO_SUPPORT: {
+        id: 'MODAL_ADD_ACCOUNT_COINJOIN_NO_SUPPORT',
+        defaultMessage: 'CoinJoin is supported only on Trezor Model T',
+    },
+    MODAL_ADD_ACCOUNT_COINJOIN_UPDATE_REQUIRED: {
+        id: 'MODAL_ADD_ACCOUNT_COINJOIN_UPDATE_REQUIRED',
+        defaultMessage: 'Please update your Firmware to enable the CoinJoin feature.',
+    },
+    MODAL_ADD_ACCOUNT_COINJOIN_DESKTOP_ONLY: {
+        id: 'MODAL_ADD_ACCOUNT_COINJOIN_DESKTOP_ONLY',
+        defaultMessage: 'CoinJoin account only available on Trezor Suite desktop app.',
     },
     TR_DEVICE_IN_RECOVERY_MODE: {
         id: 'TR_DEVICE_IN_RECOVERY_MODE',


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Disable adding CoinJoin account with Trezor 1, on web or with older FW version (in this order).

I'm not very satisfied with the copy and design (duplication of the warning under select input and in tooltip on disabled button) but I don't want to change it too much right now. 

@hynek-jina @b-irving could you please check the copy? Screenshots with all the states are attached. 

<!--- Describe your changes in detail -->

## Related Issue

Resolve https://github.com/trezor/trezor-suite/issues/6609, https://github.com/trezor/trezor-suite/issues/6661, https://github.com/trezor/trezor-suite/issues/6662

## Screenshots:
Trezor One connected:
<img width="571" alt="image" src="https://user-images.githubusercontent.com/3729633/199006282-d4549ab0-b603-40e3-8503-76344ea4895f.png">


In web version of Suite:
<img width="572" alt="image" src="https://user-images.githubusercontent.com/3729633/199008506-895e3700-8766-48cf-864d-93bfd3d44227.png">

Trezor T connected with older FW (anything below 2.5.3)
<img width="574" alt="image" src="https://user-images.githubusercontent.com/3729633/199008985-fdbe6e28-af3b-4c7b-8743-e0153e83717e.png">

Happy path - Trezor T with FW 2.5.3 or later connected in Desktop app:
<img width="569" alt="image" src="https://user-images.githubusercontent.com/3729633/199008631-7c718e32-4d2f-4557-8f8d-5fddf221d01b.png">



Taproot on older not supported FW:
<img width="570" alt="image" src="https://user-images.githubusercontent.com/3729633/199007847-02958f7a-9071-4254-a9f1-0b70bd9c737e.png">



