### PR TITLE
Feat/connect CoinjoinRequest

### DIFF
--- a/docs/packages/connect/methods/authorizeCoinJoin.md
+++ b/docs/packages/connect/methods/authorizeCoinJoin.md
@@ -37,6 +37,8 @@ const result = await TrezorConnect.authorizeCoinJoin(params);
     > show amounts in
 -   `preauthorized` — _optional_
     > Check if device session is already preauthorized and take no further action if so
+-   `coinjoinRequest` — _optional_ `PROTO.CoinJoinRequest`
+    > Signing request for a CoinJoin transaction
 
 ### Example:
 
@@ -44,7 +46,7 @@ const result = await TrezorConnect.authorizeCoinJoin(params);
 TrezorConnect.authorizeCoinJoin({
     path: "m/10086'/0'/0'",
     maxRounds: 3,
-    maxCoordinatorFeeRate: 5000000, // 5% => 0.05 * 10**8;
+    maxCoordinatorFeeRate: 500000, // 0.5% => 0.005 * 10**8;
     maxFeePerKvbyte: 3500,
     scriptType: 'SPENDWITNESS',
 });

--- a/packages/connect/src/api/bitcoin/inputs.ts
+++ b/packages/connect/src/api/bitcoin/inputs.ts
@@ -31,6 +31,7 @@ export const validateTrezorInputs = (
                 { name: 'script_type', type: 'string' },
                 { name: 'sequence', type: 'number' },
                 { name: 'multisig', type: 'object' },
+                { name: 'coinjoin_flags', type: 'number' },
             ]);
 
             if (input.script_type === 'EXTERNAL') {

--- a/packages/connect/src/api/signTransaction.ts
+++ b/packages/connect/src/api/signTransaction.ts
@@ -30,6 +30,7 @@ type Params = {
     inputs: PROTO.TxInputType[];
     outputs: PROTO.TxOutputType[];
     paymentRequests: PROTO.TxAckPaymentRequest[];
+    coinjoinRequest?: PROTO.CoinJoinRequest;
     refTxs?: RefTransaction[];
     addresses?: AccountAddresses;
     options: TransactionOptions;
@@ -52,6 +53,7 @@ export default class SignTransaction extends AbstractMethod<'signTransaction', P
             { name: 'inputs', type: 'array', required: true },
             { name: 'outputs', type: 'array', required: true },
             { name: 'paymentRequests', type: 'array', allowEmpty: true },
+            { name: 'coinjoinRequest', type: 'object' },
             { name: 'refTxs', type: 'array', allowEmpty: true },
             { name: 'account', type: 'object' },
             { name: 'locktime', type: 'number' },
@@ -123,6 +125,7 @@ export default class SignTransaction extends AbstractMethod<'signTransaction', P
                 decred_staking_ticket: payload.decredStakingTicket,
                 amount_unit: payload.amountUnit,
                 serialize: payload.serialize,
+                coinjoin_request: payload.coinjoinRequest,
             },
             coinInfo,
             push: typeof payload.push === 'boolean' ? payload.push : false,

--- a/packages/connect/src/types/api/bitcoin/index.ts
+++ b/packages/connect/src/types/api/bitcoin/index.ts
@@ -56,6 +56,7 @@ export interface TransactionOptions {
     decred_staking_ticket?: boolean;
     amount_unit?: PROTO.AmountUnit;
     serialize?: boolean;
+    coinjoin_request?: PROTO.CoinJoinRequest;
 }
 
 export interface SignTransaction {
@@ -80,6 +81,7 @@ export interface SignTransaction {
     amountUnit?: PROTO.AmountUnit;
     unlockPath?: PROTO.UnlockPath;
     serialize?: boolean;
+    coinjoinRequest?: PROTO.CoinJoinRequest;
 }
 
 export type SignedTransaction = {

--- a/packages/suite/src/views/wallet/anonymize/components/CoinjoinSetupStrategies.tsx
+++ b/packages/suite/src/views/wallet/anonymize/components/CoinjoinSetupStrategies.tsx
@@ -112,7 +112,7 @@ export const CoinjoinSetupStrategies = ({ account }: CoinjoinSetupStrategiesProp
     const toggleTermsConfirmation = () => setTermsConfirmed(current => !current);
     const anonymize = () =>
         actions.startCoinjoinSession(account, {
-            maxCoordinatorFeeRate: coordinatorData.coordinatorFeeRate * 10 ** 10, // transform to a format firmware can work with
+            maxCoordinatorFeeRate: coordinatorData.coordinatorFeeRate * 10 ** 8, // transform to a format used by firmware
             maxFeePerKvbyte:
                 (isCustom ? customMaxFee : coordinatorData.feeRatesMedians[strategy]) * 1000, // transform to kvB
             maxRounds,

--- a/packages/transport/messages.json
+++ b/packages/transport/messages.json
@@ -616,6 +616,41 @@
                     "options": {
                         "default": true
                     }
+                },
+                "coinjoin_request": {
+                    "type": "CoinJoinRequest",
+                    "id": 14
+                }
+            },
+            "nested": {
+                "CoinJoinRequest": {
+                    "fields": {
+                        "fee_rate": {
+                            "rule": "required",
+                            "type": "uint32",
+                            "id": 1
+                        },
+                        "no_fee_threshold": {
+                            "rule": "required",
+                            "type": "uint64",
+                            "id": 2
+                        },
+                        "min_registrable_amount": {
+                            "rule": "required",
+                            "type": "uint64",
+                            "id": 3
+                        },
+                        "mask_public_key": {
+                            "rule": "required",
+                            "type": "bytes",
+                            "id": 4
+                        },
+                        "signature": {
+                            "rule": "required",
+                            "type": "bytes",
+                            "id": 5
+                        }
+                    }
                 }
             }
         },
@@ -839,6 +874,13 @@
                                 "script_pubkey": {
                                     "type": "bytes",
                                     "id": 19
+                                },
+                                "coinjoin_flags": {
+                                    "type": "uint32",
+                                    "id": 20,
+                                    "options": {
+                                        "default": 0
+                                    }
                                 }
                             }
                         },
@@ -993,6 +1035,13 @@
                 "script_pubkey": {
                     "type": "bytes",
                     "id": 19
+                },
+                "coinjoin_flags": {
+                    "type": "uint32",
+                    "id": 20,
+                    "options": {
+                        "default": 0
+                    }
                 }
             }
         },

--- a/packages/transport/scripts/protobuf-patches/TxInputType.js
+++ b/packages/transport/scripts/protobuf-patches/TxInputType.js
@@ -15,6 +15,7 @@ type CommonTxInputType = {
     orig_index?: number, // RBF
     decred_staking_spend?: DecredStakingSpendType,
     script_pubkey?: string, // required if script_type=EXTERNAL
+    coinjoin_flags?: number, // bit field of CoinJoin-specific flags
     script_sig?: string, // used by EXTERNAL, depending on script_pubkey
     witness?: string, // used by EXTERNAL, depending on script_pubkey
     ownership_proof?: string, // used by EXTERNAL, depending on script_pubkey

--- a/packages/transport/src/types/messages.ts
+++ b/packages/transport/src/types/messages.ts
@@ -226,6 +226,14 @@ export type VerifyMessage = {
     coin_name?: string;
 };
 
+export type CoinJoinRequest = {
+    fee_rate: number;
+    no_fee_threshold: number;
+    min_registrable_amount: number;
+    mask_public_key: string;
+    signature: string;
+};
+
 // SignTx
 export type SignTx = {
     outputs_count: number;
@@ -241,6 +249,7 @@ export type SignTx = {
     amount_unit?: AmountUnit;
     decred_staking_ticket?: boolean;
     serialize?: boolean;
+    coinjoin_request?: CoinJoinRequest;
 };
 
 export enum Enum_RequestType {
@@ -292,6 +301,7 @@ type CommonTxInputType = {
     orig_index?: number; // RBF
     decred_staking_spend?: DecredStakingSpendType;
     script_pubkey?: string; // required if script_type=EXTERNAL
+    coinjoin_flags?: number; // bit field of CoinJoin-specific flags
     script_sig?: string; // used by EXTERNAL, depending on script_pubkey
     witness?: string; // used by EXTERNAL, depending on script_pubkey
     ownership_proof?: string; // used by EXTERNAL, depending on script_pubkey
@@ -2174,6 +2184,7 @@ export type MessageType = {
     SignMessage: SignMessage;
     MessageSignature: MessageSignature;
     VerifyMessage: VerifyMessage;
+    CoinJoinRequest: CoinJoinRequest;
     SignTx: SignTx;
     TxRequestDetailsType: TxRequestDetailsType;
     TxRequestSerializedType: TxRequestSerializedType;


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Surprising last minute change of formats. Prerequisite for [coinjoin](https://github.com/trezor/trezor-suite/pull/6485)

Following [recent changes](https://github.com/trezor/trezor-firmware/pull/2577) in FW 
- add CoinjoinRequest protobuf message (trezor-common not synced yet therefore added manually)
- use CoinjoinRequest in `TrezorConnect.signTransaction` method. Test fixtures taken from mentioned FW branch
- use new format of `maxCoordinatorFeeRate` value sent to Trezor `10 ** 10` => `10 ** 8` (cherry picked from [here](https://github.com/trezor/trezor-suite/pull/6691))
