### PR TITLE
chore: move deprecated url to suite web landing

### DIFF
--- a/packages/suite-web-landing/components/Download/index.tsx
+++ b/packages/suite-web-landing/components/Download/index.tsx
@@ -1,11 +1,13 @@
 import React, { useState, useEffect } from 'react';
 import styled from 'styled-components';
-import { TREZOR_SIGNING_KEY_URL, WIKI_HOW_TO_RUN_URL } from '@trezor/urls';
+import { WIKI_HOW_TO_RUN_URL } from '@trezor/urls';
 import { Button, Dropdown, Icon, colors, variables, Link } from '@trezor/components';
 import { IconType } from '@trezor/components/src/support/types';
 import Translation from '../Translation';
 import { Platform, getPlatform } from '../../utils/navigator';
 import { versionUtils } from '@trezor/utils';
+
+export const TREZOR_SIGNING_KEY_URL = 'https://trezor.io/security/satoshilabs-2021-signing-key.asc';
 
 const StyledDropdown = styled(Dropdown)`
     height: 100%;

--- a/packages/urls/src/urls.ts
+++ b/packages/urls/src/urls.ts
@@ -7,7 +7,6 @@ export const TREZOR_COINS_URL = 'https://trezor.io/coins/';
 export const TREZOR_SUPPORT_URL = 'https://trezor.io/support/';
 export const TREZOR_RESELLERS_URL = 'https://trezor.io/resellers/';
 export const TREZOR_PASSWORDS_URL = 'https://trezor.io/passwords/';
-export const TREZOR_SIGNING_KEY_URL = 'https://trezor.io/security/satoshilabs-2021-signing-key.asc';
 export const TREZOR_TROUBLESHOOTING_URL = 'https://trezor.io/support/#technical-technical-issues';
 export const TREZOR_WALLET_ACCESS_URL =
     'https://trezor.io/support/technical/i-cannot-access-the-wallet/';


### PR DESCRIPTION
All the urls in `packages/urls/src/urls.ts` are checked regularly. `const TREZOR_SIGNING_KEY_URL = 'https://trezor.io/security/satoshilabs-2021-signing-key.asc';` does not exist anymore which is causing our CI check to fail. But it does not matter since it is used only in suite-web-landing which is not published anymore