### PR TITLE
feat(analytics): queue

### DIFF
--- a/packages/analytics/src/types.ts
+++ b/packages/analytics/src/types.ts
@@ -12,6 +12,8 @@ export type InitOptions = {
         onEnable?: () => void;
         onDisable?: () => void;
     };
+    /* after analytics is enabled, report events happened before enablement */
+    useQueue?: boolean;
 };
 
 export type Event = {


### PR DESCRIPTION
## Description

Some events in connect are reported before a user can accept analytics (who opened connect - manifest, device model info,..)
To be able to make statistics from those events, it would be nice to store them and report them after a user accepts the analytics. If he does not, events are discarded.

## Related Issue

Required for #5397
