### PR TITLE
ci: allow_failure for suite-native build android

### DIFF
--- a/ci/build.yml
+++ b/ci/build.yml
@@ -253,6 +253,8 @@ suite-native build android:
   image: $CI_DEPENDENCY_PROXY_DIRECT_GROUP_IMAGE_PREFIX/vdovhanych/react-native-android:5.5
   stage: build
   interruptible: true
+  # todo: fix failing build
+  allow_failure: true
   script:
     - yarn install --immutable
     - yarn workspace @trezor/suite-native build:android


### PR DESCRIPTION
do not block CI until this is fixed