### PR TITLE
fix(android): fix crashing build because of jcenteral shutdown

### DIFF
--- a/.github/workflows/suite-native_develop_ci.yml
+++ b/.github/workflows/suite-native_develop_ci.yml
@@ -5,7 +5,6 @@ on:
     branches:
       - develop
     paths:
-      - "packages/suite-*/**"
       - "suite-native/**"
       - "packages/icons/**"
   workflow_dispatch:

--- a/ci/build.yml
+++ b/ci/build.yml
@@ -249,21 +249,6 @@ suite-desktop build windows codesign:
       - latest*.yml
     expire_in: 7 days
 
-suite-native build android:
-  image: $CI_DEPENDENCY_PROXY_DIRECT_GROUP_IMAGE_PREFIX/vdovhanych/react-native-android:5.5
-  stage: build
-  interruptible: true
-  # todo: fix failing build
-  allow_failure: true
-  script:
-    - yarn install --immutable
-    - yarn workspace @trezor/suite-native build:android
-    - mv suite-native/app/android/app/build/outputs/apk/dev/debug/app-dev-debug.apk .
-  artifacts:
-    expire_in: 7 day
-    paths:
-      - app-release.apk
-
 .connect-explorer build base:
   stage: build
   interruptible: true

--- a/suite-native/app/android/build.gradle
+++ b/suite-native/app/android/build.gradle
@@ -7,11 +7,6 @@ buildscript {
         minSdkVersion = 26
         compileSdkVersion = 31
         targetSdkVersion = 31
-        ndkVersion = "21.4.7075529"
-    }
-    repositories {
-        google()
-        mavenCentral()
         if (System.properties['os.arch'] == "aarch64") {
             // For M1 Users we need to use the NDK 24 which added support for aarch64
             ndkVersion = "24.0.8215888"
@@ -19,6 +14,10 @@ buildscript {
             // Otherwise we default to the side-by-side NDK version from AGP.
             ndkVersion = "21.4.7075529"
         }
+    }
+    repositories {
+        google()
+        mavenCentral()
     }
     dependencies {
         classpath("com.android.tools.build:gradle:7.2.1")
@@ -32,6 +31,16 @@ buildscript {
 
 allprojects {
     repositories {
+        // This fix should be removed once https://github.com/Shopify/react-native-skia/pull/1040 is merged
+        all { ArtifactRepository repo ->
+            if(repo instanceof MavenArtifactRepository){
+                def url = repo.url.toString()
+                if (url.startsWith('https://jcenter.bintray.com/')) {
+                    remove repo
+                }
+            }
+        }
+        // end of temp fix
         maven {
             // All of React Native (JS, Obj-C sources, Android binaries) is installed from npm
             url("$rootDir/../../../node_modules/react-native/android")


### PR DESCRIPTION
Patch for skia is just temporary, already prepared PR for them that will fix it.