### PR TITLE
Feat/coinjoin final

### DIFF
--- a/packages/coinjoin/jest.config.js
+++ b/packages/coinjoin/jest.config.js
@@ -1,3 +1,5 @@
 module.exports = {
     preset: '../../jest.config.base.js',
+    // waiting for jest update https://github.com/trezor/trezor-suite/issues/6025
+    // testEnvironment: 'node', ReferenceError: AbortController is not defined
 };

--- a/packages/coinjoin/src/client/Account.ts
+++ b/packages/coinjoin/src/client/Account.ts
@@ -27,6 +27,7 @@ export class Account {
     maxCoordinatorFeeRate: number;
     maxRounds: number;
     skipRounds?: [number, number];
+    skipRoundCounter = 0;
     signedRounds: string[] = [];
 
     constructor(account: RegisterAccountParams, network: Network) {

--- a/packages/coinjoin/src/client/Alice.ts
+++ b/packages/coinjoin/src/client/Alice.ts
@@ -1,0 +1,59 @@
+import { getInputSize, getOutputSize } from '../utils/coordinatorUtils';
+import {
+    AllowedScriptTypes,
+    RegistrationData,
+    ConfirmationData,
+    RealCredentials,
+} from '../types/coordinator';
+import { AccountUtxo } from '../types/account';
+import { Credentials } from '../types/middleware';
+import { SerializedAlice, CoinjoinRequestEvent } from '../types/round';
+
+interface AlicePendingRequest {
+    type: CoinjoinRequestEvent['type'];
+    timestamp: number;
+}
+
+export class Alice {
+    path: string; // utxo derivation path
+    outpoint: string;
+    amount: number;
+    inputSize: number;
+    outputSize: number;
+    accountKey: string; // Account.accountKey
+    scriptType: AllowedScriptTypes; // input scripType
+    requested?: AlicePendingRequest; // pending request sent to wallet (Suite)
+    ownershipProof?: string; // data used in inputRegistration phase, received as response to RequestEvent, provided by wallet (Suite)
+    registrationData?: RegistrationData; // data from inputRegistration phase
+    realAmountCredentials?: RealCredentials; // data from inputRegistration phase
+    realVsizeCredentials?: RealCredentials; // data from inputRegistration phase
+    confirmationData?: ConfirmationData; // data from connectionConfirmation phase
+    confirmedAmountCredentials?: Credentials[]; // data from connectionConfirmation phase
+    confirmedVsizeCredentials?: Credentials[]; // data from connectionConfirmation phase
+    witness?: string; // received as response to RequestEvent, provided by wallet (Suite)
+    witnessIndex?: number; // received as response to RequestEvent, provided by wallet (Suite)
+    error?: Error;
+
+    constructor(accountKey: string, scriptType: AllowedScriptTypes, utxo: AccountUtxo) {
+        this.accountKey = accountKey;
+        this.scriptType = scriptType;
+        this.path = utxo.path;
+        this.outpoint = utxo.outpoint;
+        this.amount = utxo.amount;
+        this.inputSize = getInputSize(scriptType);
+        this.outputSize = getOutputSize(scriptType);
+    }
+
+    setError(error: Error) {
+        this.error = error;
+    }
+
+    // serialize class
+    toSerialized(): SerializedAlice {
+        return {
+            accountKey: this.accountKey,
+            path: this.path,
+            outpoint: this.outpoint,
+        };
+    }
+}

--- a/packages/coinjoin/src/client/Alice.ts
+++ b/packages/coinjoin/src/client/Alice.ts
@@ -1,4 +1,4 @@
-import { getInputSize, getOutputSize } from '../utils/coordinatorUtils';
+import { getInputSize, getOutputSize, getWitnessFromSignature } from '../utils/coordinatorUtils';
 import {
     AllowedScriptTypes,
     RegistrationData,
@@ -85,6 +85,11 @@ export class Alice {
     setConfirmedCredentials(amount: Credentials[], vsize: Credentials[]) {
         this.confirmedAmountCredentials = amount;
         this.confirmedVsizeCredentials = vsize;
+    }
+
+    setWitness(signature: string, index: number) {
+        this.witness = getWitnessFromSignature(signature);
+        this.witnessIndex = index;
     }
 
     // serialize class

--- a/packages/coinjoin/src/client/Alice.ts
+++ b/packages/coinjoin/src/client/Alice.ts
@@ -48,6 +48,45 @@ export class Alice {
         this.error = error;
     }
 
+    setRequest(type: AlicePendingRequest['type']): SerializedAlice;
+    setRequest(): undefined;
+    setRequest(type?: AlicePendingRequest['type']) {
+        if (type) {
+            this.requested = {
+                type,
+                timestamp: Date.now(),
+            };
+            return {
+                accountKey: this.accountKey,
+                path: this.path,
+                outpoint: this.outpoint,
+            };
+        }
+        this.requested = undefined;
+    }
+
+    setOwnershipProof(proof: string) {
+        this.ownershipProof = proof;
+    }
+
+    setRegistrationData(data: RegistrationData) {
+        this.registrationData = data;
+    }
+
+    setRealCredentials(amount: RealCredentials, vsize: RealCredentials) {
+        this.realAmountCredentials = amount;
+        this.realVsizeCredentials = vsize;
+    }
+
+    setConfirmationData(data: ConfirmationData) {
+        this.confirmationData = data;
+    }
+
+    setConfirmedCredentials(amount: Credentials[], vsize: Credentials[]) {
+        this.confirmedAmountCredentials = amount;
+        this.confirmedVsizeCredentials = vsize;
+    }
+
     // serialize class
     toSerialized(): SerializedAlice {
         return {

--- a/packages/coinjoin/src/client/CoinjoinPrison.ts
+++ b/packages/coinjoin/src/client/CoinjoinPrison.ts
@@ -1,0 +1,43 @@
+export interface PrisonInmate {
+    id: string; // AccountUtxo/Alice.outpoint or AccountAddress scriptPubKey
+    sentenceStart: number;
+    sentenceEnd: number;
+    reason?: string;
+    roundId?: string;
+}
+
+export interface PrisonOptions {
+    roundId?: string;
+    reason?: string;
+    sentenceEnd?: number;
+}
+
+// Errored or currently registered inputs and addresses are sent here
+// inspiration: WalletWasabi/WabiSabi/Backend/Banning/Prison.cs
+
+export class CoinjoinPrison {
+    inmates: PrisonInmate[] = [];
+
+    detain(id: string, options: PrisonOptions = {}) {
+        const sentenceStart = Date.now();
+        const sentenceEnd = Date.now() + (options.sentenceEnd ? options.sentenceEnd : 6 * 60000);
+
+        this.inmates.push({
+            id,
+            sentenceEnd,
+            sentenceStart,
+            reason: options.reason,
+            roundId: options.roundId,
+        });
+    }
+
+    isDetained(id: string) {
+        return this.inmates.find(i => i.id === id);
+    }
+
+    // called on each status change before rounds are processed
+    release() {
+        const now = Date.now();
+        this.inmates = this.inmates.filter(inmate => inmate.sentenceEnd > now);
+    }
+}

--- a/packages/coinjoin/src/client/CoinjoinRound.ts
+++ b/packages/coinjoin/src/client/CoinjoinRound.ts
@@ -203,11 +203,38 @@ export class CoinjoinRound extends EventEmitter implements SerializedCoinjoinRou
     }
 
     getRequest(): CoinjoinRequestEvent | void {
-        // TODO
+        if (this.phase === RoundPhase.InputRegistration) {
+            const inputs = this.inputs.filter(input => !input.ownershipProof && !input.requested);
+            if (inputs.length > 0) {
+                inputs.forEach(input => {
+                    this.options.log(`Requesting ownership for ~~${input.outpoint}~~`);
+                    input.setRequest('ownership');
+                });
+                return {
+                    type: 'ownership',
+                    roundId: this.id,
+                    inputs,
+                    commitmentData: this.commitmentData,
+                };
+            }
+        }
     }
 
-    resolveRequest(_: CoinjoinResponseEvent) {
-        // TODO
+    resolveRequest({ type, inputs }: CoinjoinResponseEvent) {
+        const { log } = this.options;
+        inputs.forEach(i => {
+            const input = this.inputs.find(a => a.outpoint === i.outpoint);
+            if (!input) return;
+            // reset request in input
+            input.setRequest();
+            if ('error' in i) {
+                log(`Resolving ${type} request for ~~${i.outpoint}~~ with error. ${i.error}`);
+                input.setError(new Error(i.error));
+            } else if ('ownershipProof' in i) {
+                log(`Resolving ${type} request for ~~${i.outpoint}~~`);
+                input.setOwnershipProof(i.ownershipProof);
+            }
+        });
     }
 
     updateAccount(account: RegisterAccountParams) {

--- a/packages/coinjoin/src/client/CoinjoinRound.ts
+++ b/packages/coinjoin/src/client/CoinjoinRound.ts
@@ -1,6 +1,7 @@
 import { EventEmitter } from 'events';
 
 import { arrayPartition } from '@trezor/utils';
+import { Network } from '@trezor/utxo-lib';
 
 import {
     getCommitmentData,
@@ -15,15 +16,28 @@ import {
     CoinjoinRequestEvent,
     CoinjoinResponseEvent,
 } from '../types/round';
-import { RoundPhase, Round, CoinjoinRoundParameters } from '../types/coordinator';
-import type { Account } from './Account';
+import {
+    RoundPhase,
+    Round,
+    CoinjoinRoundParameters,
+    WabiSabiProtocolErrorCode,
+} from '../types/coordinator';
+import { Account } from './Account';
+import { Alice } from './Alice';
+import { CoinjoinPrison } from './CoinjoinPrison';
+import { selectRound } from './round/selectRound';
+import { inputRegistration } from './round/inputRegistration';
+import { connectionConfirmation } from './round/connectionConfirmation';
+import { outputRegistration } from './round/outputRegistration';
+import { transactionSigning } from './round/transactionSigning';
 
 export interface CoinjoinRoundOptions {
+    network: Network;
     signal: AbortSignal;
     coordinatorName: string;
     coordinatorUrl: string;
     middlewareUrl: string;
-    log: (...args: any[]) => any;
+    log: (message: string) => void;
 }
 
 interface Events {
@@ -60,14 +74,6 @@ const createRoundLock = (mainSignal: AbortSignal) => {
         promise,
     };
 };
-
-// Temporary. Alice will be added in next PR
-interface Alice {
-    path: string;
-    accountKey: string;
-    outpoint: string;
-    error?: Error;
-}
 
 export class CoinjoinRound extends EventEmitter implements SerializedCoinjoinRound {
     private lock?: ReturnType<typeof createRoundLock>;
@@ -114,41 +120,18 @@ export class CoinjoinRound extends EventEmitter implements SerializedCoinjoinRou
         accounts: Account[],
         statusRounds: Round[],
         coinjoinRounds: CoinjoinRound[],
+        prison: CoinjoinPrison,
         options: CoinjoinRoundOptions,
     ) {
-        // TODO: this code will be removed with "selectRound" implementation
-        if (coinjoinRounds.find(r => r.id === 'fakeroundid') || accounts.length === 0) {
-            return;
-        }
-        const firstRound = statusRounds.find(r => r.phase === RoundPhase.InputRegistration);
-        if (!firstRound) return;
-        const round = new CoinjoinRound(firstRound, options);
-
-        round.startFakeRoundLifecycle(firstRound, accounts[0]);
-        return Promise.resolve(round);
-    }
-
-    // temporary code to run Round lifecycle without actual coinjoining
-    startFakeRoundLifecycle(round: Round, account: Account) {
-        console.warn('Create fake round');
-        this.id = 'fakeroundid';
-        this.inputs = account.utxos.map(u => ({
-            outpoint: u.outpoint,
-            path: u.path,
-            accountKey: account.accountKey,
-        }));
-        let currentPhase = 0;
-        const timeoutFn = async () => {
-            await this.onPhaseChange({ ...round, phase: currentPhase });
-            await this.process([]);
-
-            currentPhase++;
-            if (this.failed.length === 0 && currentPhase <= RoundPhase.Ended) {
-                setTimeout(() => timeoutFn(), 10000);
-            }
-        };
-
-        timeoutFn();
+        return selectRound(
+            (...args: ConstructorParameters<typeof CoinjoinRound>) => new CoinjoinRound(...args),
+            (...args: ConstructorParameters<typeof Alice>) => new Alice(...args),
+            accounts,
+            statusRounds,
+            coinjoinRounds,
+            prison,
+            options,
+        );
     }
 
     async onPhaseChange(changed: Round) {
@@ -173,15 +156,18 @@ export class CoinjoinRound extends EventEmitter implements SerializedCoinjoinRou
         return this;
     }
 
-    async process(accounts: Account[]) {
+    async process(accounts: Account[], prison: CoinjoinPrison) {
         const { log } = this.options;
         if (this.inputs.length === 0) {
             log('Trying to process round without inputs');
             return this;
         }
-        await this.processPhase(accounts);
+        await this.processPhase(accounts, prison);
 
         const [inputs, failed] = arrayPartition(this.inputs, input => !input.error);
+        failed.forEach(input =>
+            prison.detain(input.outpoint, { roundId: this.id, reason: input.error?.message }),
+        );
         this.inputs = inputs;
         this.failed = this.failed.concat(...failed);
 
@@ -198,10 +184,22 @@ export class CoinjoinRound extends EventEmitter implements SerializedCoinjoinRou
         return this;
     }
 
-    private processPhase(_accounts: Account[]) {
+    private processPhase(accounts: Account[], prison: CoinjoinPrison) {
         this.lock = createRoundLock(this.options.signal);
+        const processOptions = { ...this.options, signal: this.lock.signal };
         // try to run process on CoinjoinRound
-        return new Promise(resolve => setTimeout(() => resolve(this), 2000));
+        switch (this.phase) {
+            case RoundPhase.InputRegistration:
+                return inputRegistration(this, prison, processOptions);
+            case RoundPhase.ConnectionConfirmation:
+                return connectionConfirmation(this, processOptions);
+            case RoundPhase.OutputRegistration:
+                return outputRegistration(this, accounts, prison, processOptions);
+            case RoundPhase.TransactionSigning:
+                return transactionSigning(this, processOptions);
+            default:
+                return Promise.resolve(this);
+        }
     }
 
     getRequest(): CoinjoinRequestEvent | void {
@@ -220,7 +218,9 @@ export class CoinjoinRound extends EventEmitter implements SerializedCoinjoinRou
             input => !account.utxos.find(u => u.outpoint === input.outpoint),
         );
         // set error on each input
-        spentInputs.forEach(input => (input.error = new Error('Spent')));
+        spentInputs.forEach(input =>
+            input.setError(new Error(WabiSabiProtocolErrorCode.InputSpent)),
+        ); // TODO: error same as wasabi coordinator?
 
         this.breakRound(spentInputs);
     }
@@ -229,7 +229,7 @@ export class CoinjoinRound extends EventEmitter implements SerializedCoinjoinRou
         // find registered inputs related to Account
         const affectedInputs = this.inputs.filter(input => input.accountKey === accountKey);
         // set error on each input
-        affectedInputs.forEach(input => (input.error = new Error('Unregistered')));
+        affectedInputs.forEach(input => input.setError(new Error('Unregistered account')));
 
         this.breakRound(affectedInputs);
     }
@@ -248,22 +248,26 @@ export class CoinjoinRound extends EventEmitter implements SerializedCoinjoinRou
         }
     }
 
+    // forced by CoinjoinClient.disable. stop processes if any
+    end() {
+        this.options.log(`Aborting round ${this.id}`);
+        this.lock?.abort();
+
+        this.phase = RoundPhase.Ended;
+        this.inputs = [];
+        this.failed = [];
+        this.addresses = [];
+        this.removeAllListeners();
+    }
+
     // serialize class
     // data emitted in "round" event
     toSerialized(): SerializedCoinjoinRound {
         return {
             id: this.id,
             phase: this.phase,
-            inputs: this.inputs.map(i => ({
-                outpoint: i.outpoint,
-                accountKey: i.accountKey,
-                path: i.path,
-            })),
-            failed: this.failed.map(i => ({
-                outpoint: i.outpoint,
-                accountKey: i.accountKey,
-                path: i.path,
-            })),
+            inputs: this.inputs.map(i => i.toSerialized()),
+            failed: this.failed.map(i => i.toSerialized()),
             addresses: this.addresses,
             phaseDeadline: this.phaseDeadline,
             roundDeadline: this.roundDeadline,

--- a/packages/coinjoin/src/client/coordinator.ts
+++ b/packages/coinjoin/src/client/coordinator.ts
@@ -136,6 +136,9 @@ export const transactionSignature = (
         { ...options, parseJson: false },
     );
 
+// reexport all coordinator types
+export * from '../types/coordinator';
+
 /**
  * @deprecated This request will be done by coordinator
  */

--- a/packages/coinjoin/src/client/coordinator.ts
+++ b/packages/coinjoin/src/client/coordinator.ts
@@ -6,7 +6,8 @@ import {
     ConfirmationData,
     IssuanceData,
     RegistrationData,
-    TxPaymentRequest,
+    CoinjoinAffiliateTx,
+    CoinjoinAffiliateRequest,
 } from '../types/coordinator';
 
 export const getStatus = async (options: RequestOptions) => {
@@ -142,16 +143,8 @@ export * from '../types/coordinator';
 /**
  * @deprecated This request will be done by coordinator
  */
-export const getPaymentRequest = (
-    name: string,
-    outputs: { amount: number; address: string }[],
-    options: RequestOptions,
-) =>
-    request<TxPaymentRequest>(
-        'payment-request',
-        {
-            recipient_name: name,
-            outputs,
-        },
-        options,
-    );
+export const getAffiliateRequest = (tx: CoinjoinAffiliateTx, options: RequestOptions) =>
+    request<CoinjoinAffiliateRequest>('get_coinjoin_request_suite', tx, {
+        ...options,
+        baseUrl: 'https://dev-coinjoin-affiliate.trezor.io/',
+    });

--- a/packages/coinjoin/src/client/middleware.ts
+++ b/packages/coinjoin/src/client/middleware.ts
@@ -117,3 +117,6 @@ export const analyzeTransactions = async (
     const data = await request<AnalyzeResult>('analyze-transaction', { transactions }, options);
     return data.results;
 };
+
+// reexport all middleware types
+export * from '../types/middleware';

--- a/packages/coinjoin/src/client/round/connectionConfirmation.ts
+++ b/packages/coinjoin/src/client/round/connectionConfirmation.ts
@@ -1,0 +1,22 @@
+import type { CoinjoinRound, CoinjoinRoundOptions } from '../CoinjoinRound';
+
+export const connectionConfirmation = async (
+    round: CoinjoinRound,
+    options: CoinjoinRoundOptions,
+) => {
+    options.log(`connectionConfirmation: ${round.id}`);
+
+    await Promise.allSettled(
+        round.inputs.map(
+            input => new Promise(resolve => setTimeout(() => resolve([input, options]), 2000)),
+        ),
+    ).then(result =>
+        result.forEach((r, i) => {
+            if (r.status !== 'fulfilled') {
+                round.inputs[i].setError(r.reason);
+            }
+        }),
+    );
+
+    return round;
+};

--- a/packages/coinjoin/src/client/round/connectionConfirmation.ts
+++ b/packages/coinjoin/src/client/round/connectionConfirmation.ts
@@ -1,21 +1,155 @@
+import * as coordinator from '../coordinator';
+import * as middleware from '../middleware';
+import { readTimeSpan } from '../../utils/roundUtils';
+import type { Alice } from '../Alice';
 import type { CoinjoinRound, CoinjoinRoundOptions } from '../CoinjoinRound';
+
+/**
+ * usage in RoundPhase: 0, InputRegistration
+ * Try to confirm registered input in InputRegistration phase
+ *
+ * usage in RoundPhase: 1, ConnectionConfirmation
+ * Try to confirm registered input in CoinjoinRound
+ * - if input doesn't have registrationData, throw error
+ * - if input does have ownershipProof but it's already registered, throw error
+ * - if Round phase did change before registration, abort remaining awaited registration (if any)
+ */
+
+const confirmInput = async (
+    round: CoinjoinRound,
+    input: Alice,
+    options: CoinjoinRoundOptions,
+): Promise<Alice> => {
+    if (input.error) {
+        options.log(`Trying to confirm input with error ${input.error}`);
+        throw input.error;
+    }
+    if (!input.registrationData || !input.realAmountCredentials || !input.realVsizeCredentials) {
+        throw new Error(`Trying to confirm unregistered input ~~${input.outpoint}~~`);
+    }
+    if (input.confirmationData) {
+        options.log(`Input ~~${input.outpoint}~~ already confirmed. Skipping.`);
+        return input;
+    }
+
+    const { signal, coordinatorUrl, middlewareUrl, log } = options;
+
+    const zeroAmountCredentials = await middleware.getZeroCredentials(
+        round.amountCredentialIssuerParameters,
+        { signal, baseUrl: middlewareUrl },
+    );
+    const zeroVsizeCredentials = await middleware.getZeroCredentials(
+        round.vsizeCredentialIssuerParameters,
+        { signal, baseUrl: middlewareUrl },
+    );
+
+    const delay = 0; // TODO: delay cannot be longer than last confirmationInterval tick
+    log(`Confirming ~~${input.outpoint}~~ to ~~${round.id}~~ with delay ${delay}ms`);
+
+    const confirmationData = await coordinator.connectionConfirmation(
+        round.id,
+        input.registrationData.aliceId,
+        input.realAmountCredentials,
+        input.realVsizeCredentials,
+        zeroAmountCredentials,
+        zeroVsizeCredentials,
+        { signal, baseUrl: coordinatorUrl, identity: input.outpoint, delay },
+    );
+
+    // stop here if it's confirmationInterval at phase 0
+    if (round.phase === coordinator.RoundPhase.InputRegistration) {
+        return input;
+    }
+
+    const confirmedAmountCredentials = await middleware.getCredentials(
+        round.amountCredentialIssuerParameters,
+        confirmationData.realAmountCredentials,
+        input.realAmountCredentials.credentialsResponseValidation,
+        { baseUrl: middlewareUrl }, // NOTE: post processing intentionally without abort signal (should not be aborted)
+    );
+    const confirmedVsizeCredentials = await middleware.getCredentials(
+        round.vsizeCredentialIssuerParameters,
+        confirmationData.realVsizeCredentials,
+        input.realVsizeCredentials.credentialsResponseValidation,
+        { baseUrl: middlewareUrl }, // NOTE: post processing intentionally without abort signal (should not be aborted)
+    );
+
+    log(`Confirmed ${input.outpoint} in ${round.id}`);
+
+    input.setConfirmationData(confirmationData);
+    input.setConfirmedCredentials(confirmedAmountCredentials, confirmedVsizeCredentials);
+
+    return input;
+};
+
+// Because of the nature of coordinator registration process requires (after successfully registration)
+// to call `/connection-confirmation` in intervals less than connectionConfirmationTimeout * 0.9 to prevent AliceTimeout error on coordinator
+export const confirmationInterval = (
+    round: CoinjoinRound,
+    input: Alice,
+    options: CoinjoinRoundOptions,
+) => {
+    const { phaseDeadline } = round;
+    const timeoutDeadline = Math.floor(
+        readTimeSpan(round.roundParameters.connectionConfirmationTimeout) * 0.5, // TODO: constant
+    );
+    let timeLeft = phaseDeadline - Date.now();
+    if (timeLeft < timeoutDeadline || options.signal.aborted) {
+        options.log(
+            `Ignoring confirmation interval for ~~${input.outpoint}~~. Deadline ${timeLeft}`,
+        );
+        return input;
+    }
+
+    options.log(`Setting confirmation interval for ~~${input.outpoint}~~. Deadline ${timeLeft}ms`);
+
+    return new Promise<Alice>(resolve => {
+        let timeout: ReturnType<typeof setTimeout>;
+        const timeoutFn = async () => {
+            try {
+                await confirmInput(round, input, options);
+                timeLeft = phaseDeadline - Date.now();
+                options.log(
+                    `Confirmation interval for ~~${input.outpoint}~~. Time left ${timeLeft}ms.`,
+                );
+                if (timeLeft > timeoutDeadline) {
+                    timeout = setTimeout(timeoutFn, timeoutDeadline);
+                } else {
+                    // Alice timeout should be ok now
+                    resolve(input);
+                }
+            } catch (error) {
+                options.log(`Confirmation interval with error ${error.message}`);
+                // do nothing. it will be processed by next phase in CoinjoinRound.processPhase
+                resolve(input);
+            }
+        };
+
+        timeout = setTimeout(timeoutFn, timeoutDeadline);
+
+        options.signal.addEventListener('abort', () => {
+            options.log(`Confirmation interval aborted`);
+            clearTimeout(timeout);
+            resolve(input); // same as above, do not throw errors from interval
+        });
+    });
+};
 
 export const connectionConfirmation = async (
     round: CoinjoinRound,
     options: CoinjoinRoundOptions,
 ) => {
-    options.log(`connectionConfirmation: ${round.id}`);
+    // try to confirm each input
+    // failed inputs will be excluded from this round, successful will continue to phase: 2 (outputRegistration)
+    options.log(`connectionConfirmation: ~~${round.id}~~`);
 
-    await Promise.allSettled(
-        round.inputs.map(
-            input => new Promise(resolve => setTimeout(() => resolve([input, options]), 2000)),
-        ),
-    ).then(result =>
-        result.forEach((r, i) => {
-            if (r.status !== 'fulfilled') {
-                round.inputs[i].setError(r.reason);
-            }
-        }),
+    await Promise.allSettled(round.inputs.map(input => confirmInput(round, input, options))).then(
+        result =>
+            result.forEach((r, i) => {
+                if (r.status !== 'fulfilled') {
+                    round.inputs[i].setError(r.reason);
+                }
+            }),
     );
 
     return round;

--- a/packages/coinjoin/src/client/round/inputRegistration.ts
+++ b/packages/coinjoin/src/client/round/inputRegistration.ts
@@ -1,0 +1,36 @@
+import type { Alice } from '../Alice';
+import type { CoinjoinPrison } from '../CoinjoinPrison';
+import type { CoinjoinRound, CoinjoinRoundOptions } from '../CoinjoinRound';
+
+const registerInput = async (
+    round: CoinjoinRound,
+    input: Alice,
+    prison: CoinjoinPrison,
+    options: CoinjoinRoundOptions,
+): Promise<Alice> => {
+    // TODO: process will be added in upcoming PR
+    await new Promise(resolve => setTimeout(() => resolve([round, prison, options]), 2000));
+    return input;
+};
+
+export const inputRegistration = async (
+    round: CoinjoinRound,
+    prison: CoinjoinPrison,
+    options: CoinjoinRoundOptions,
+) => {
+    // try to register each input
+    // failed inputs will be excluded from this round, successful will continue to phase: 1 (connectionConfirmation)
+    options.log(`inputRegistration: ${round.id}`);
+
+    await Promise.allSettled(
+        round.inputs.map(input => registerInput(round, input, prison, options)),
+    ).then(result =>
+        result.forEach((r, i) => {
+            if (r.status !== 'fulfilled') {
+                round.inputs[i].setError(r.reason);
+            }
+        }),
+    );
+
+    return round;
+};

--- a/packages/coinjoin/src/client/round/inputRegistration.ts
+++ b/packages/coinjoin/src/client/round/inputRegistration.ts
@@ -1,6 +1,22 @@
+import { getRandomNumberInRange } from '@trezor/utils';
+
+import * as coordinator from '../coordinator';
+import * as middleware from '../middleware';
+import { confirmationInterval } from './connectionConfirmation';
+import { ROUND_SELECTION_REGISTRATION_OFFSET } from '../../constants';
 import type { Alice } from '../Alice';
 import type { CoinjoinPrison } from '../CoinjoinPrison';
 import type { CoinjoinRound, CoinjoinRoundOptions } from '../CoinjoinRound';
+
+/**
+ * RoundPhase: 0, InputRegistration
+ *
+ * Try to register available input in to CoinjoinRound
+ * - if input doesn't have ownershipProof ask wallet to provide it
+ * - if input does have ownershipProof but it's already registered, throw error
+ * - if Round phase did change before registration, abort remaining awaited registration (if any)
+ * - if Round inputRegistrationEnd value is greater than connectionConfirmationTimeout periodically call confirmInput ping to coordinator
+ */
 
 const registerInput = async (
     round: CoinjoinRound,
@@ -8,9 +24,146 @@ const registerInput = async (
     prison: CoinjoinPrison,
     options: CoinjoinRoundOptions,
 ): Promise<Alice> => {
-    // TODO: process will be added in upcoming PR
-    await new Promise(resolve => setTimeout(() => resolve([round, prison, options]), 2000));
-    return input;
+    if (input.error) {
+        options.log(`Trying to register input with error ${input.error}`);
+        throw input.error;
+    }
+    // stop here and request for ownership proof from the wallet
+    if (!input.ownershipProof) {
+        options.log(`Waiting for ~~${input.outpoint}~~ ownership proof`);
+        return input;
+    }
+
+    if (input.registrationData) {
+        options.log(`Input ~~${input.outpoint}~~ already registered. Skipping.`);
+        return input;
+    }
+
+    const { signal, coordinatorUrl, middlewareUrl } = options;
+
+    // request ZeroCredentials from the middleware. use them in coordinator.inputRegistration
+    const zeroAmountCredentials = await middleware.getZeroCredentials(
+        round.amountCredentialIssuerParameters,
+        { signal, baseUrl: middlewareUrl },
+    );
+    const zeroVsizeCredentials = await middleware.getZeroCredentials(
+        round.vsizeCredentialIssuerParameters,
+        { signal, baseUrl: middlewareUrl },
+    );
+
+    // setup random delay for registration request. we want each input to be registered in different time as different TOR identity
+    // note that this may cause that the input will not be registered if phase change before expected deadline
+    const deadline = round.phaseDeadline - Date.now() - ROUND_SELECTION_REGISTRATION_OFFSET;
+    const delay = deadline > 0 ? getRandomNumberInRange(0, deadline) : 0;
+    options.log(
+        `Trying to register ~~${input.outpoint}~~ to ~~${round.id}~~ with delay ${delay}ms`,
+    );
+
+    // register input in coordinator
+    const registrationData = await coordinator
+        .inputRegistration(
+            round.id,
+            input.outpoint,
+            input.ownershipProof,
+            zeroAmountCredentials,
+            zeroVsizeCredentials,
+            {
+                signal,
+                baseUrl: coordinatorUrl,
+                identity: input.outpoint,
+                delay,
+            },
+        )
+        .catch(error => {
+            options.log(
+                `Registration ~~${input.outpoint}~~ to ~~${round.id}~~ failed: ${error.message}`,
+            );
+            // catch specific error
+            if (error.message === coordinator.WabiSabiProtocolErrorCode.WrongPhase) {
+                // abort remaining delayed candidates to register (if exists) registration is not going to happen for them anyway
+                signal.dispatchEvent(new Event('abort'));
+            }
+            throw error;
+        });
+
+    // store RegistrationData
+    input.setRegistrationData(registrationData);
+    // and put input to prison
+    prison.detain(input.outpoint, {
+        roundId: round.id,
+        reason: coordinator.WabiSabiProtocolErrorCode.AliceAlreadyRegistered,
+    });
+
+    // NOTE: RegistrationData processing on middleware is intentionally not using abort signal
+    // should not be aborted if round phase was immediately changed after registration (triggered by Status change)
+    try {
+        // process RegistrationData received from coordinator
+        // get Credentials and use them in middleware.getRealCredentials
+        const amountCredentials = await middleware.getCredentials(
+            round.amountCredentialIssuerParameters,
+            registrationData.amountCredentials,
+            zeroAmountCredentials.credentialsResponseValidation,
+            { baseUrl: middlewareUrl }, // NOTE: without abort signal (should not be aborted)
+        );
+        const vsizeCredentials = await middleware.getCredentials(
+            round.vsizeCredentialIssuerParameters,
+            registrationData.vsizeCredentials,
+            zeroVsizeCredentials.credentialsResponseValidation,
+            { baseUrl: middlewareUrl }, // NOTE: without abort signal (should not be aborted)
+        );
+
+        // Calculate mining and coordinator fee
+        // coordinator fee is 0 if input is remixed or amount is lower than plebsDontPayThreshold value
+        const { roundParameters } = round;
+        const coordinatorFee =
+            input.amount > roundParameters.coordinationFeeRate.plebsDontPayThreshold &&
+            !registrationData.isPayingZeroCoordinationFee
+                ? Math.floor(roundParameters.coordinationFeeRate.rate * input.amount)
+                : 0;
+
+        const miningFee = Math.floor((input.inputSize * roundParameters.miningFeeRate) / 1000);
+        const amount = input.amount - coordinatorFee - miningFee;
+        const vsize = roundParameters.maxVsizeAllocationPerAlice - input.inputSize;
+
+        // use Credentials to get RealCredentials. use them in outputConfirmation
+        const realAmountCredentials = await middleware.getRealCredentials(
+            [amount, 0],
+            amountCredentials,
+            round.amountCredentialIssuerParameters,
+            roundParameters.maxAmountCredentialValue,
+            { baseUrl: middlewareUrl },
+        );
+        const realVsizeCredentials = await middleware.getRealCredentials(
+            [vsize, 0],
+            vsizeCredentials,
+            round.vsizeCredentialIssuerParameters,
+            roundParameters.maxVsizeCredentialValue,
+            { baseUrl: middlewareUrl },
+        );
+
+        options.log(
+            `Registration ~~${input.outpoint}~~ to ~~${round.id}~~ successful. aliceId: ${registrationData.aliceId}`,
+        );
+        options.log(
+            `~~${input.outpoint}~~ will pay ${coordinatorFee} coordinator fee and ${miningFee} mining fee`,
+        );
+
+        // store RealCredentials
+        input.setRealCredentials(realAmountCredentials, realVsizeCredentials);
+
+        // set confirmation interval
+        return confirmationInterval(round, input, options);
+    } catch (error) {
+        // TODO: try to unregister if post processing fails?
+        // await coordinator.inputUnregistration(round.id, registrationData.aliceId, {
+        //     // signal,
+        //     baseUrl: coordinatorUrl,
+        //     identity: input.outpoint,
+        // });
+
+        input.setError(error);
+        return input;
+    }
 };
 
 export const inputRegistration = async (
@@ -20,7 +173,7 @@ export const inputRegistration = async (
 ) => {
     // try to register each input
     // failed inputs will be excluded from this round, successful will continue to phase: 1 (connectionConfirmation)
-    options.log(`inputRegistration: ${round.id}`);
+    options.log(`inputRegistration: ~~${round.id}~~`);
 
     await Promise.allSettled(
         round.inputs.map(input => registerInput(round, input, prison, options)),

--- a/packages/coinjoin/src/client/round/outputDecomposition.ts
+++ b/packages/coinjoin/src/client/round/outputDecomposition.ts
@@ -1,0 +1,218 @@
+/* eslint-disable no-await-in-loop */
+import { getWeakRandomId } from '@trezor/utils';
+
+import * as coordinator from '../coordinator';
+import * as middleware from '../middleware';
+import { getRoundEvents, compareOutpoint, sumCredentials } from '../../utils/roundUtils';
+import { getExternalOutputSize } from '../../utils/coordinatorUtils';
+import type { Alice } from '../Alice';
+import type { CoinjoinRound, CoinjoinRoundOptions } from '../CoinjoinRound';
+
+/**
+ * RoundPhase: 2, step 1
+ *
+ * - Join all registered inputs Credentials in to one, grouped by accountKey
+ * - Calculate output amounts
+ */
+
+const joinInputsCredentials = async (
+    round: CoinjoinRound,
+    accountKey: string,
+    inputs: Alice[],
+    options: CoinjoinRoundOptions,
+) => {
+    const { roundParameters } = round;
+    const { signal, coordinatorUrl, middlewareUrl } = options;
+
+    let amountCredentials = inputs[0].confirmedAmountCredentials!;
+    let vsizeCredentials = inputs[0].confirmedVsizeCredentials!;
+    let { outputSize } = inputs[0];
+
+    options.log(
+        `Joining Credentials for account ~~${accountKey}~~. Total inputs: ${inputs.length}`,
+    );
+
+    if (inputs.length === 1) {
+        return {
+            accountKey,
+            amountCredentials,
+            vsizeCredentials,
+            outputSize,
+        };
+    }
+
+    for (let i = 1; i < inputs.length; i++) {
+        const current = inputs[i];
+        if (current.error) {
+            options.log(
+                `Trying to join input with error. ~~${current.outpoint}~~ ${current.error}`,
+            );
+            throw current.error;
+        }
+        options.log(
+            `Joining${i} ${current.confirmedAmountCredentials![0].value} ${
+                current.confirmedAmountCredentials![1].value
+            } ${amountCredentials[0].value} ${amountCredentials[1].value} `,
+        );
+        // TODO: do not exceed roundParameters.maxAmountCredentialValue
+        const realAmountCredentials = await middleware.getRealCredentials(
+            [current.confirmedAmountCredentials![0].value + amountCredentials[0].value, 0],
+            [current.confirmedAmountCredentials![0], amountCredentials[0]],
+            round.amountCredentialIssuerParameters,
+            roundParameters.maxAmountCredentialValue,
+            { signal, baseUrl: middlewareUrl },
+        );
+        // TODO: do not exceed roundParameters.maxVsizeCredentialValue
+        const realVsizeCredentials = await middleware.getRealCredentials(
+            [vsizeCredentials[0].value, vsizeCredentials[1].value],
+            [vsizeCredentials[0], vsizeCredentials[1]],
+            round.vsizeCredentialIssuerParameters,
+            roundParameters.maxVsizeCredentialValue,
+            { signal, baseUrl: middlewareUrl },
+        );
+
+        const zeroAmountCredentials = await middleware.getZeroCredentials(
+            round.amountCredentialIssuerParameters,
+            { signal, baseUrl: middlewareUrl },
+        );
+        const zeroVsizeCredentials = await middleware.getZeroCredentials(
+            round.vsizeCredentialIssuerParameters,
+            { signal, baseUrl: middlewareUrl },
+        );
+
+        // TODO: delay
+        // use random identity for each request
+        const joinedIssuance = await coordinator.credentialIssuance(
+            round.id,
+            realAmountCredentials,
+            realVsizeCredentials,
+            zeroAmountCredentials,
+            zeroVsizeCredentials,
+            { signal, baseUrl: coordinatorUrl, identity: getWeakRandomId(10), delay: 0 },
+        );
+
+        amountCredentials = await middleware.getCredentials(
+            round.amountCredentialIssuerParameters,
+            joinedIssuance.realAmountCredentials,
+            realAmountCredentials.credentialsResponseValidation,
+            { signal, baseUrl: middlewareUrl },
+        );
+        vsizeCredentials = await middleware.getCredentials(
+            round.vsizeCredentialIssuerParameters,
+            joinedIssuance.realVsizeCredentials,
+            realVsizeCredentials.credentialsResponseValidation,
+            { signal, baseUrl: middlewareUrl },
+        );
+        outputSize = Math.max(outputSize, current.outputSize);
+    }
+
+    return {
+        accountKey,
+        amountCredentials,
+        vsizeCredentials,
+        outputSize,
+    };
+};
+
+export const getOutputAmounts = async (
+    round: CoinjoinRound,
+    accountKey: string,
+    availableVsize: number,
+    outputSize: number,
+    options: CoinjoinRoundOptions,
+) => {
+    const { roundParameters } = round;
+    const { signal, middlewareUrl } = options;
+
+    const registeredInputs = getRoundEvents('InputAdded', round.coinjoinState.events);
+    const internalAmounts: number[] = [];
+    const externalAmounts: number[] = [];
+
+    registeredInputs.forEach(i => {
+        const internal = round.inputs.find(
+            input =>
+                input.accountKey === accountKey && compareOutpoint(input.outpoint, i.coin.outpoint),
+        );
+        if (internal) {
+            internalAmounts.push(internal.confirmedAmountCredentials![0].value);
+        } else {
+            const size = getExternalOutputSize(i.coin.txOut.scriptPubKey);
+            const miningFee = Math.floor((size * roundParameters.miningFeeRate) / 1000);
+            const coordinatorFee = Math.floor(
+                roundParameters.coordinationFeeRate.rate * i.coin.txOut.value,
+            );
+            externalAmounts.push(i.coin.txOut.value - coordinatorFee - miningFee);
+        }
+    });
+    const outputAmounts = await middleware.decomposeAmounts(
+        {
+            feeRate: roundParameters.miningFeeRate,
+            allowedOutputAmounts: roundParameters.allowedOutputAmounts,
+        },
+        outputSize,
+        availableVsize, // TODO: sum all available vsize and use chunks in output registration (increase nr of outputs)
+        internalAmounts,
+        externalAmounts,
+        { signal, baseUrl: middlewareUrl },
+    );
+    options.log(`Decompose amounts: ${outputAmounts.join('')}`);
+    return outputAmounts.map(amount => {
+        const miningFee = Math.floor((outputSize * roundParameters.miningFeeRate) / 1000);
+        const coordinatorFee = 0; // TODO: middleware issue. should be `amount > plebsDontPayThreshold ? Math.floor(roundParameters.coordinationFeeRate.rate * amount) : 0` but middleware does not considerate coordinationFeeRate and plebs
+        return amount + coordinatorFee + miningFee;
+    });
+};
+
+export interface DecomposedOutputs {
+    accountKey: string;
+    outputSize: number;
+    amounts: number[];
+    amountCredentials: middleware.Credentials[];
+    vsizeCredentials: middleware.Credentials[];
+}
+
+export const outputDecomposition = async (
+    round: CoinjoinRound,
+    options: CoinjoinRoundOptions,
+): Promise<DecomposedOutputs[]> => {
+    // group inputs by accountKeys
+    const groupInputsByAccount = round.inputs.reduce((result, input) => {
+        if (!result[input.accountKey]) {
+            result[input.accountKey] = [];
+        }
+        if (!input.confirmedAmountCredentials || !input.confirmedVsizeCredentials) {
+            throw new Error(`Missing confirmed credentials for ~~${input.outpoint}~~`);
+        }
+        result[input.accountKey].push(input);
+        return result;
+    }, {} as Record<string, Alice[]>);
+
+    options.log(`Decompose ${Object.keys(groupInputsByAccount).length} accounts`);
+
+    // join inputs Credentials for each account separately
+    const joinedCredentials = await Promise.all(
+        Object.keys(groupInputsByAccount).map(accountKey =>
+            joinInputsCredentials(round, accountKey, groupInputsByAccount[accountKey], options),
+        ),
+    );
+
+    // calculate amounts
+    const outputAmounts = await Promise.all(
+        joinedCredentials.map(({ vsizeCredentials, outputSize, accountKey }) => {
+            const availableVsize = sumCredentials(vsizeCredentials);
+            return getOutputAmounts(round, accountKey, availableVsize, outputSize, options);
+        }),
+    );
+
+    // combine everything into DecomposedOutputs objects and return the result to outputRegistration
+    return Object.keys(groupInputsByAccount).map((accountKey, index) => {
+        if (!joinedCredentials[index])
+            throw new Error(`Missing joined credentials at index ${index}`);
+        if (!outputAmounts[index]) throw new Error(`Missing amounts at index ${index}`);
+        return {
+            ...joinedCredentials[index],
+            accountKey,
+            amounts: outputAmounts[index],
+        };
+    });
+};

--- a/packages/coinjoin/src/client/round/outputRegistration.ts
+++ b/packages/coinjoin/src/client/round/outputRegistration.ts
@@ -1,0 +1,29 @@
+import type { Account } from '../Account';
+import type { CoinjoinPrison } from '../CoinjoinPrison';
+import type { CoinjoinRound, CoinjoinRoundOptions } from '../CoinjoinRound';
+
+export const outputRegistration = async (
+    round: CoinjoinRound,
+    accounts: Account[],
+    prison: CoinjoinPrison,
+    options: CoinjoinRoundOptions,
+) => {
+    options.log(`outputRegistration: ${round.id}`);
+
+    await Promise.allSettled(
+        round.inputs.map(
+            input =>
+                new Promise(resolve =>
+                    setTimeout(() => resolve([input, accounts, prison, options]), 2000),
+                ),
+        ),
+    ).then(result =>
+        result.forEach((r, i) => {
+            if (r.status !== 'fulfilled') {
+                round.inputs[i].setError(r.reason);
+            }
+        }),
+    );
+
+    return round;
+};

--- a/packages/coinjoin/src/client/round/outputRegistration.ts
+++ b/packages/coinjoin/src/client/round/outputRegistration.ts
@@ -1,6 +1,177 @@
+import { getWeakRandomId } from '@trezor/utils';
+
+import * as coordinator from '../coordinator';
+import * as middleware from '../middleware';
+import { outputDecomposition } from './outputDecomposition';
+import { sumCredentials } from '../../utils/roundUtils';
 import type { Account } from '../Account';
+import type { Alice } from '../Alice';
 import type { CoinjoinPrison } from '../CoinjoinPrison';
 import type { CoinjoinRound, CoinjoinRoundOptions } from '../CoinjoinRound';
+import type { AccountAddress } from '../../types';
+
+/**
+ * RoundPhase: 2, OutputRegistration
+ *
+ * Process steps:
+ * - Calculate output amounts using middleware (see ./outputDecomposition)
+ * - Join all input Credentials in to one using coordinator /credential-issuance (see ./outputDecomposition)
+ * - Decompose joined Credentials into calculated amounts using coordinator /credential-issuance
+ * - Register decomposed Credentials as outputs using coordinator /output-registration
+ * - Finally call /ready-to-sign on coordinator for each input
+ */
+
+const registerOutput = async (
+    round: CoinjoinRound,
+    outputSize: number,
+    outputAddress: AccountAddress[],
+    outputAmount: number,
+    amountCredentials: middleware.Credentials[],
+    vsizeCredentials: middleware.Credentials[],
+    prison: CoinjoinPrison,
+    options: CoinjoinRoundOptions,
+) => {
+    const { roundParameters } = round;
+    const { signal, coordinatorUrl, middlewareUrl } = options;
+
+    const availableAmount = sumCredentials(amountCredentials);
+    const availableVsize = sumCredentials(vsizeCredentials);
+    options.log(`registerOutput amount ${availableAmount}`);
+    options.log(`registerOutput vsize ${availableVsize}`);
+    const issuanceAmountCredentials = await middleware.getRealCredentials(
+        [outputAmount, availableAmount - outputAmount],
+        amountCredentials,
+        round.amountCredentialIssuerParameters,
+        roundParameters.maxAmountCredentialValue,
+        { signal, baseUrl: middlewareUrl },
+    );
+    const issuanceVsizeCredentials = await middleware.getRealCredentials(
+        [outputSize, availableVsize - outputSize],
+        vsizeCredentials,
+        round.vsizeCredentialIssuerParameters,
+        roundParameters.maxVsizeCredentialValue,
+        { signal, baseUrl: middlewareUrl },
+    );
+
+    const zeroAmountCredentials = await middleware.getZeroCredentials(
+        round.amountCredentialIssuerParameters,
+        { signal, baseUrl: middlewareUrl },
+    );
+    const zeroVsizeCredentials = await middleware.getZeroCredentials(
+        round.vsizeCredentialIssuerParameters,
+        { signal, baseUrl: middlewareUrl },
+    );
+
+    // TODO: delay
+    // use random identity
+    const issuanceData = await coordinator.credentialIssuance(
+        round.id,
+        issuanceAmountCredentials,
+        issuanceVsizeCredentials,
+        zeroAmountCredentials,
+        zeroVsizeCredentials,
+        { signal, baseUrl: coordinatorUrl, identity: getWeakRandomId(10), delay: 0 },
+    );
+
+    const amountCredentialsOut = await middleware.getCredentials(
+        round.amountCredentialIssuerParameters,
+        issuanceData.realAmountCredentials,
+        issuanceAmountCredentials.credentialsResponseValidation,
+        { signal, baseUrl: middlewareUrl },
+    );
+    const vsizeCredentialsOut = await middleware.getCredentials(
+        round.vsizeCredentialIssuerParameters,
+        issuanceData.realVsizeCredentials,
+        issuanceVsizeCredentials.credentialsResponseValidation,
+        { signal, baseUrl: middlewareUrl },
+    );
+
+    const zeroAmountCredentialsOut = await middleware.getCredentials(
+        round.amountCredentialIssuerParameters,
+        issuanceData.zeroAmountCredentials,
+        zeroAmountCredentials.credentialsResponseValidation,
+        { signal, baseUrl: middlewareUrl },
+    );
+
+    const zeroVsizeCredentialsOut = await middleware.getCredentials(
+        round.vsizeCredentialIssuerParameters,
+        issuanceData.zeroVsizeCredentials,
+        zeroVsizeCredentials.credentialsResponseValidation,
+        { signal, baseUrl: middlewareUrl },
+    );
+
+    const outputAmountCredentials = await middleware.getRealCredentials(
+        [0, 0],
+        [amountCredentialsOut[0], zeroAmountCredentialsOut[0]],
+        round.amountCredentialIssuerParameters,
+        roundParameters.maxAmountCredentialValue,
+        { signal, baseUrl: middlewareUrl },
+    );
+    const outputVsizeCredentials = await middleware.getRealCredentials(
+        [vsizeCredentialsOut[0].value - outputSize, 0],
+        [vsizeCredentialsOut[0], zeroVsizeCredentialsOut[0]],
+        round.vsizeCredentialIssuerParameters,
+        roundParameters.maxVsizeCredentialValue,
+        { signal, baseUrl: middlewareUrl },
+    );
+
+    // TODO: tricky, if for some reason AlreadyRegisteredScript is called then we have 2 options:
+    // - try again with different address and link my new address with old address (privacy loss against coordinator?)
+    // - intentionally stop output registrations for all other credentials. Question: which input will be banned if i call readyToSign on each anyway? is it better to break here and not to proceed to signing?
+    const tryToRegisterOutput = (): Promise<AccountAddress> => {
+        const address = outputAddress.find(a => !prison.isDetained(a.scriptPubKey));
+        if (!address) {
+            throw new Error('No change address available');
+        }
+
+        return coordinator
+            .outputRegistration(
+                round.id,
+                address,
+                outputAmountCredentials,
+                outputVsizeCredentials,
+                { signal, baseUrl: coordinatorUrl, identity: getWeakRandomId(10) },
+            )
+            .then(() => address)
+            .catch(error => {
+                if (
+                    error.message === coordinator.WabiSabiProtocolErrorCode.AlreadyRegisteredScript
+                ) {
+                    prison.detain(address.scriptPubKey, {
+                        roundId: round.id,
+                        reason: error.message,
+                    });
+                    return tryToRegisterOutput();
+                }
+                throw error;
+            });
+    };
+
+    const address = await tryToRegisterOutput();
+    prison.detain(address.scriptPubKey, {
+        roundId: round.id,
+        reason: coordinator.WabiSabiProtocolErrorCode.AlreadyRegisteredScript,
+    });
+
+    return {
+        address,
+        amountCredentials: [amountCredentialsOut[1], zeroAmountCredentialsOut[1]],
+        vsizeCredentials: [vsizeCredentialsOut[1], zeroVsizeCredentialsOut[1]],
+    };
+};
+
+// TODO: delay
+const readyToSign = (
+    round: CoinjoinRound,
+    input: Alice,
+    { signal, coordinatorUrl }: CoinjoinRoundOptions,
+) =>
+    coordinator.readyToSign(round.id, input.registrationData!.aliceId, {
+        signal,
+        baseUrl: coordinatorUrl,
+        identity: input.outpoint, // NOTE: recycle input identity
+        delay: 0,
+    });
 
 export const outputRegistration = async (
     round: CoinjoinRound,
@@ -8,22 +179,54 @@ export const outputRegistration = async (
     prison: CoinjoinPrison,
     options: CoinjoinRoundOptions,
 ) => {
-    options.log(`outputRegistration: ${round.id}`);
+    // TODO:
+    // - decide if there is only 1 account registered should i abaddon this round and blame it on some "youngest" input?
+    // - maybe if there is only 1 account inputs are so "far away" from each other that it is wort to mix anyway?
+    try {
+        // decompose output amounts for all registered inputs grouped by Account
+        const decomposedGroup = await outputDecomposition(round, options);
 
-    await Promise.allSettled(
-        round.inputs.map(
-            input =>
-                new Promise(resolve =>
-                    setTimeout(() => resolve([input, accounts, prison, options]), 2000),
-                ),
-        ),
-    ).then(result =>
-        result.forEach((r, i) => {
-            if (r.status !== 'fulfilled') {
-                round.inputs[i].setError(r.reason);
+        // collect all used addresses
+        const usedAddresses: AccountAddress[] = [];
+        // try to register outputs for each account (each input in account group)
+        for (let group = 0; group < decomposedGroup.length; group++) {
+            const { amounts, accountKey, outputSize } = decomposedGroup[group];
+            const account = accounts.find(a => a.accountKey === accountKey);
+            if (!account) throw new Error(`Unknown account ~~${accountKey}~~`);
+            const { changeAddresses } = account;
+            let { amountCredentials, vsizeCredentials } = decomposedGroup[group];
+            for (let index = 0; index < amounts.length; index++) {
+                if (!amounts[index]) throw new Error(`Unknown amount at index ${index}`);
+                // TODO: no not proceed if one of output fails (do not sign!!)
+                // eslint-disable-next-line no-await-in-loop
+                const result = await registerOutput(
+                    round,
+                    outputSize,
+                    changeAddresses,
+                    amounts[index],
+                    amountCredentials,
+                    vsizeCredentials,
+                    prison,
+                    options,
+                );
+                usedAddresses.push(result.address);
+                amountCredentials = result.amountCredentials;
+                vsizeCredentials = result.vsizeCredentials;
             }
-        }),
-    );
+        }
 
+        // inform coordinator that each registered input is ready to sign
+        await Promise.all(round.inputs.map(input => readyToSign(round, input, options)));
+        options.log(`Ready to sign ~~${round.id}~~`);
+
+        round.addresses = usedAddresses;
+    } catch (error) {
+        // NOTE: if anything goes wrong in this process this Round will be corrupted for all the users
+        // registered inputs will probably be banned
+        const message = `Output registration in ~~${round.id}~~ failed: ${error.message}`;
+        options.log(message);
+
+        round.inputs.forEach(input => input.setError(new Error(message)));
+    }
     return round;
 };

--- a/packages/coinjoin/src/client/round/selectRound.ts
+++ b/packages/coinjoin/src/client/round/selectRound.ts
@@ -1,0 +1,232 @@
+import { Account } from '../Account';
+import { Alice } from '../Alice';
+import type { CoinjoinRound, CoinjoinRoundOptions } from '../CoinjoinRound';
+import { CoinjoinPrison } from '../CoinjoinPrison';
+import * as middleware from '../middleware';
+import { RoundPhase, Round } from '../coordinator';
+import { ROUND_SELECTION_REGISTRATION_OFFSET } from '../../constants';
+
+export type CoinjoinRoundGenerator = (
+    ...args: ConstructorParameters<typeof CoinjoinRound>
+) => CoinjoinRound;
+
+export type AliceGenerator = (...args: ConstructorParameters<typeof Alice>) => Alice;
+
+// Basic preselect CoinjoinRound candidates
+// reuse existing CoinjoinRounds or create new one
+export const getRoundCandidates = (
+    generator: CoinjoinRoundGenerator,
+    statusRounds: Round[],
+    currentRounds: CoinjoinRound[],
+    options: CoinjoinRoundOptions,
+) => {
+    const now = Date.now();
+    return statusRounds
+        .filter(
+            round =>
+                round.phase === RoundPhase.InputRegistration &&
+                new Date(round.inputRegistrationEnd).getTime() - now >
+                    ROUND_SELECTION_REGISTRATION_OFFSET,
+        )
+        .flatMap(round => {
+            const current = currentRounds.find(r => r.id === round.id);
+            if (current) return current;
+            // try to create new CoinjoinRound
+            try {
+                return generator(round, options);
+            } catch (e) {
+                // constructor fails on invalid round data (highly unlikely)
+                return [];
+            }
+        });
+};
+
+// Basic preselect Accounts
+// exclude Account.utxos which are registered in CoinjoinRounds or detained in CoinjoinPrison
+export const getAccountCandidates = (
+    accounts: Account[],
+    _statusRounds: Round[],
+    currentRounds: CoinjoinRound[],
+    prison: CoinjoinPrison,
+    { log }: CoinjoinRoundOptions,
+) => {
+    // TODO: walk thru all Round[] and search in round events for account input/output scriptPubKey which are not supposed to be there (interrupted round)
+    // if they are in phase 0 put them to prison to cool off so they registration on coordinator will timeout naturally, otherwise prison for longer, they will be banned
+
+    // collect outpoints of all currently registered inputs in CoinjoinRounds + inputs in prison
+    const registeredOutpoints = currentRounds
+        .flatMap(round => round.inputs.concat(round.failed).map(u => u.outpoint))
+        .concat(prison.inmates.map(i => i.id));
+
+    return accounts.flatMap(account => {
+        // skip account registered to critical rounds
+        const { accountKey } = account;
+        const isAccountAlreadyRegistered = currentRounds.find(
+            round =>
+                round.phase !== RoundPhase.Ended &&
+                round.inputs.find(input => input.accountKey === accountKey),
+        );
+
+        if (isAccountAlreadyRegistered) {
+            log(`Skipping candidate ~~${accountKey}~~. Already registered to round`);
+            return [];
+        }
+
+        // TODO: double-check account max signed rounds, should be done by suite tho
+
+        // exclude account utxos which are unavailable
+        const utxos = account.utxos.filter(utxo => !registeredOutpoints.includes(utxo.outpoint));
+        if (utxos.length > 0) {
+            if (account.skipRounds) {
+                const [low, high] = account.skipRounds;
+                // skip reached lower limit
+                // or skip randomly (20% chance with [4, 5] settings)
+                if (account.skipRoundCounter >= low || Math.random() > low / high) {
+                    account.skipRoundCounter = 0;
+                    log(`Random skip candidate ~~${accountKey}~~`);
+                    return [];
+                }
+                account.skipRoundCounter++;
+            }
+
+            log(`Found account candidate ~~${accountKey}~~ with ${utxos.length} inputs`);
+            return {
+                ...account,
+                utxos,
+            };
+        }
+
+        log(
+            `Skipping candidate ~~${accountKey}~~. Utxos ${utxos.length} of ${account.utxos.length}`,
+        );
+        return [];
+    });
+};
+
+// Use middleware algorithm to process preselected CoinjoinRounds and Accounts
+export const selectUtxoForRound = async (
+    generator: AliceGenerator,
+    roundCandidates: CoinjoinRound[],
+    accountCandidates: ReturnType<typeof getAccountCandidates>,
+    options: CoinjoinRoundOptions,
+) => {
+    // utxoSelection shape: array_of_rounds[ array_of_accounts[ array_of_useful_account_utxo_indexes[] ] ]
+    // example for 2 roundCandidates with 3 accountCandidates: [ [ [], [], [0, 1, 2] ], [ [3], [], [0, 1, 2] ] ]
+    // each account/utxo set needs to be calculated separately because of different targetAnonymity
+    const utxoSelection = await Promise.all(
+        // for each CoinjoinRound...
+        roundCandidates.map(round => {
+            // ...create set of parameters
+            const { roundParameters } = round;
+            const roundConstants = {
+                miningFeeRate: roundParameters.miningFeeRate,
+                coordinationFeeRate: roundParameters.coordinationFeeRate,
+                allowedInputAmounts: roundParameters.allowedInputAmounts,
+                allowedOutputAmounts: roundParameters.allowedOutputAmounts,
+                allowedInputTypes: roundParameters.allowedInputScriptTypes,
+            };
+            return Promise.all(
+                // ...and for each Account
+                accountCandidates.map(account => {
+                    // ...also create set of parameters (utxos)
+                    const utxos = account.utxos.map(utxo => ({
+                        outpoint: utxo.outpoint,
+                        amount: utxo.amount,
+                        scriptType: account.scriptType,
+                        anonymitySet: utxo.anonymityLevel,
+                    }));
+                    // TODO: check account maxMining rate vs round miningRate + maxCoordinator rate vs round coordinationFeeRate
+                    // ...finally call CoinjoinRound + Account + Round combination on middleware
+                    return middleware
+                        .selectUtxoForRound(roundConstants, utxos, account.targetAnonymity, {
+                            signal: options.signal,
+                            baseUrl: options.middlewareUrl,
+                        })
+                        .then(indices => indices.filter(i => utxos[i])) // filter valid existing indices
+                        .catch(() => [] as number[]); // return empty response on error, TODO: should we provide preselected rounds/account anyway?
+                }),
+            );
+        }),
+    );
+
+    // find Round with maximum possible utxos
+    const sumUtxosInRounds = utxoSelection.map(acc => acc.reduce((a, b) => a + b.length, 0));
+    const maxUtxosInRound = Math.max(...sumUtxosInRounds);
+    if (maxUtxosInRound < 1) {
+        options.log('No results for selectUtxoForRound');
+        return;
+    }
+
+    // get index of Round with maximum possble utxos
+    const roundIndex = sumUtxosInRounds.findIndex(count => count === maxUtxosInRound);
+    const selectedRound = roundCandidates[roundIndex];
+
+    // setup new Round
+    accountCandidates.forEach((account, accountIndex) => {
+        // find utxos assigned to this Round and Account
+        const utxoIndexes = utxoSelection[roundIndex][accountIndex];
+        const selectedUtxos = utxoIndexes.map(utxoIndex => account.utxos[utxoIndex]);
+        if (selectedUtxos.length > 0) {
+            // create new Alice(s) and add it to CoinjoinRound
+            selectedRound.inputs.push(
+                ...selectedUtxos.map(utxo =>
+                    generator(account.accountKey, account.scriptType, utxo),
+                ),
+            );
+        }
+    });
+
+    return selectedRound;
+};
+
+export const selectRound = async (
+    roundGenerator: CoinjoinRoundGenerator,
+    aliceGenerator: AliceGenerator,
+    accounts: Account[],
+    statusRounds: Round[],
+    currentRounds: CoinjoinRound[],
+    prison: CoinjoinPrison,
+    options: CoinjoinRoundOptions,
+) => {
+    const { log } = options;
+
+    log('Looking for rounds');
+    const roundCandidates = getRoundCandidates(
+        roundGenerator,
+        statusRounds,
+        currentRounds,
+        options,
+    );
+    if (roundCandidates.length < 1) {
+        log('No suitable rounds');
+        return;
+    }
+
+    log('Looking for accounts');
+    const accountCandidates = getAccountCandidates(
+        accounts,
+        statusRounds,
+        currentRounds,
+        prison,
+        options,
+    );
+    if (accountCandidates.length < 1) {
+        log('No suitable accounts');
+        return;
+    }
+
+    log(`Looking for utxos`);
+    const newRound = await selectUtxoForRound(
+        aliceGenerator,
+        roundCandidates,
+        accountCandidates,
+        options,
+    );
+    if (!newRound) {
+        log('No suitable utxos');
+        return;
+    }
+
+    log(`Created new round ~~${newRound.id}~~ with ${newRound.inputs.length} inputs`);
+    return newRound;
+};

--- a/packages/coinjoin/src/client/round/transactionSigning.ts
+++ b/packages/coinjoin/src/client/round/transactionSigning.ts
@@ -1,22 +1,155 @@
+import * as coordinator from '../coordinator';
+import { getRoundEvents, compareOutpoint } from '../../utils/roundUtils';
+import {
+    mergePubkeys,
+    sortInputs,
+    sortOutputs,
+    readOutpoint,
+    prefixScriptPubKey,
+    getAddressFromScriptPubKey,
+} from '../../utils/coordinatorUtils';
+import type { Alice } from '../Alice';
 import type { CoinjoinRound, CoinjoinRoundOptions } from '../CoinjoinRound';
+import type { CoinjoinTransactionData } from '../../types';
+
+const getTransactionData = async (
+    round: CoinjoinRound,
+    options: CoinjoinRoundOptions,
+): Promise<CoinjoinTransactionData> => {
+    const registeredInputs = getRoundEvents('InputAdded', round.coinjoinState.events);
+    const registeredOutputs = mergePubkeys(
+        getRoundEvents('OutputAdded', round.coinjoinState.events),
+    );
+    const myInputsInRound = round.inputs;
+    const myOutputsInRound = round.addresses;
+
+    if (!myOutputsInRound || myOutputsInRound.length < 1) {
+        throw new Error(`No registered outputs for round ${round.id}`);
+    }
+
+    if (registeredInputs.length < myInputsInRound.length) {
+        throw new Error(`Inconsistent data. Unexpected sum of registered inputs.`);
+    }
+
+    if (registeredOutputs.length < myOutputsInRound.length) {
+        throw new Error(`Inconsistent data. Unexpected sum of registered outputs.`);
+    }
+
+    const inputs = registeredInputs
+        .sort((a, b) => sortInputs(a.coin, b.coin))
+        .map(input => {
+            const { index, hash } = readOutpoint(input.coin.outpoint);
+            const internal = myInputsInRound.find(a =>
+                compareOutpoint(a.outpoint, input.coin.outpoint),
+            );
+
+            return {
+                path: internal?.path,
+                outpoint: internal?.outpoint || input.coin.outpoint, // NOTE: internal outpoints are in lowercase, coordinators in uppercase
+                hash,
+                index,
+                amount: input.coin.txOut.value,
+                scriptPubKey: prefixScriptPubKey(input.coin.txOut.scriptPubKey),
+                ownershipProof: input.coin.ownershipProof,
+                commitmentData: round.commitmentData,
+            };
+        });
+
+    const outputs = registeredOutputs
+        .sort((a, b) => sortOutputs(a.output, b.output))
+        .map(({ output }) => {
+            const internalOutput = myOutputsInRound.find(
+                o => output.scriptPubKey === o.scriptPubKey,
+            );
+            const address = getAddressFromScriptPubKey(output.scriptPubKey, options.network);
+            return {
+                path: internalOutput?.path,
+                address,
+                amount: output.value,
+                scriptPubKey: prefixScriptPubKey(output.scriptPubKey),
+            };
+        });
+
+    // TODO: affiliate request should be done by coordinator
+    const affiliateRequest = await coordinator.getAffiliateRequest(
+        {
+            inputs: inputs.map(i => ({
+                prevout: { hash: i.hash, index: i.index },
+                script_pubkey: i.scriptPubKey,
+            })),
+            outputs: outputs.map(i => ({
+                amount: i.amount,
+                script_pubkey: i.scriptPubKey,
+            })),
+        },
+        { signal: options.signal },
+    );
+
+    return {
+        inputs,
+        outputs,
+        affiliateRequest,
+    };
+};
+
+// TODO: delay
+// TODO: notify wallet about success and create "pending account" state in suite
+const sendTxSignature = async (
+    round: CoinjoinRound,
+    input: Alice,
+    { signal, coordinatorUrl }: CoinjoinRoundOptions,
+) => {
+    await coordinator.transactionSignature(round.id, input.witnessIndex!, input.witness!, {
+        signal,
+        baseUrl: coordinatorUrl,
+        identity: input.outpoint, // NOTE: recycle input identity
+        delay: 0,
+    });
+    return input;
+};
 
 export const transactionSigning = async (
     round: CoinjoinRound,
     options: CoinjoinRoundOptions,
 ): Promise<CoinjoinRound> => {
-    options.log(`transactionSigning: ${round.id}`);
+    const inputsWithError = round.inputs.filter(input => input.error);
+    if (inputsWithError.length > 0) {
+        options.log('Trying to sign input with assigned error');
+        return round;
+    }
 
-    await Promise.allSettled(
-        round.inputs.map(
-            input => new Promise(resolve => setTimeout(() => resolve([input, options]), 2000)),
-        ),
-    ).then(result =>
-        result.forEach((r, i) => {
-            if (r.status !== 'fulfilled') {
-                round.inputs[i].setError(r.reason);
+    try {
+        const inputsWithoutWitness = round.inputs.filter(input => !input.witness);
+        if (inputsWithoutWitness.length > 0) {
+            const alreadyRequested = inputsWithoutWitness.find(input => input.requested);
+            if (alreadyRequested) {
+                options.log(
+                    `Trying to sign but request was not fulfilled yet ${inputsWithoutWitness.length}`,
+                );
+                throw new Error('Wittiness not provided');
             }
-        }),
-    );
+            const transactionData = await getTransactionData(round, options);
+            round.transactionData = transactionData;
+            return round;
+        }
 
+        await Promise.allSettled(
+            round.inputs.map(input => sendTxSignature(round, input, options)),
+        ).then(result =>
+            result.forEach((r, i) => {
+                if (r.status !== 'fulfilled') {
+                    round.inputs[i].setError(r.reason);
+                }
+            }),
+        );
+    } catch (error) {
+        // NOTE: if anything goes wrong in this process this Round will be corrupted for all the users
+        // registered inputs will probably be banned
+        round.inputs.forEach(input =>
+            input.setError(new Error(`transactionSigning failed: ${error.message}`)),
+        );
+    }
+
+    options.log(`Round ${round.id} signed successfully`);
     return round;
 };

--- a/packages/coinjoin/src/client/round/transactionSigning.ts
+++ b/packages/coinjoin/src/client/round/transactionSigning.ts
@@ -1,0 +1,22 @@
+import type { CoinjoinRound, CoinjoinRoundOptions } from '../CoinjoinRound';
+
+export const transactionSigning = async (
+    round: CoinjoinRound,
+    options: CoinjoinRoundOptions,
+): Promise<CoinjoinRound> => {
+    options.log(`transactionSigning: ${round.id}`);
+
+    await Promise.allSettled(
+        round.inputs.map(
+            input => new Promise(resolve => setTimeout(() => resolve([input, options]), 2000)),
+        ),
+    ).then(result =>
+        result.forEach((r, i) => {
+            if (r.status !== 'fulfilled') {
+                round.inputs[i].setError(r.reason);
+            }
+        }),
+    );
+
+    return round;
+};

--- a/packages/coinjoin/src/constants.ts
+++ b/packages/coinjoin/src/constants.ts
@@ -18,3 +18,6 @@ export const STATUS_TIMEOUT = {
 // add 2 sec. offset to round.inputRegistrationEnd to prevent race conditions
 // we are expecting phase to change but server didn't propagate it yet
 export const ROUND_REGISTRATION_END_OFFSET = 2000;
+
+// do not register into Round if round.inputRegistrationEnd is below offset
+export const ROUND_SELECTION_REGISTRATION_OFFSET = 30000;

--- a/packages/coinjoin/src/types/coordinator.ts
+++ b/packages/coinjoin/src/types/coordinator.ts
@@ -173,3 +173,42 @@ export interface TxPaymentRequest {
     recipient_name: string;
     signature: string;
 }
+
+// errors from coordinator in string based format (see ./utils/http coordinatorRequest errorCode handling)
+export enum WabiSabiProtocolErrorCode {
+    RoundNotFound = 'RoundNotFound',
+    WrongPhase = 'WrongPhase',
+    InputSpent = 'InputSpent',
+    InputUnconfirmed = 'InputUnconfirmed',
+    InputImmature = 'InputImmature',
+    WrongOwnershipProof = 'WrongOwnershipProof',
+    TooManyInputs = 'TooManyInputs',
+    NotEnoughFunds = 'NotEnoughFunds',
+    TooMuchFunds = 'TooMuchFunds',
+    NonUniqueInputs = 'NonUniqueInputs',
+    InputBanned = 'InputBanned',
+    InputLongBanned = 'InputLongBanned',
+    InputNotWhitelisted = 'InputNotWhitelisted',
+    AliceNotFound = 'AliceNotFound',
+    IncorrectRequestedVsizeCredentials = 'IncorrectRequestedVsizeCredentials',
+    TooMuchVsize = 'TooMuchVsize',
+    ScriptNotAllowed = 'ScriptNotAllowed',
+    IncorrectRequestedAmountCredentials = 'IncorrectRequestedAmountCredentials',
+    WrongCoinjoinSignature = 'WrongCoinjoinSignature',
+    SignatureTooLong = 'SignatureTooLong',
+    AliceAlreadyRegistered = 'AliceAlreadyRegistered',
+    NonStandardInput = 'NonStandardInput',
+    NonStandardOutput = 'NonStandardOutput',
+    WitnessAlreadyProvided = 'WitnessAlreadyProvided',
+    InsufficientFees = 'InsufficientFees',
+    SizeLimitExceeded = 'SizeLimitExceeded',
+    DustOutput = 'DustOutput',
+    UneconomicalInput = 'UneconomicalInput',
+    VsizeQuotaExceeded = 'VsizeQuotaExceeded',
+    DeltaNotZero = 'DeltaNotZero',
+    WrongNumberOfCreds = 'WrongNumberOfCreds',
+    CryptoException = 'CryptoException',
+    AliceAlreadySignalled = 'AliceAlreadySignalled',
+    AliceAlreadyConfirmedConnection = 'AliceAlreadyConfirmedConnection',
+    AlreadyRegisteredScript = 'AlreadyRegisteredScript',
+}

--- a/packages/coinjoin/src/types/coordinator.ts
+++ b/packages/coinjoin/src/types/coordinator.ts
@@ -168,12 +168,6 @@ export interface Round {
     inputRegistrationEnd: string;
 }
 
-export interface TxPaymentRequest {
-    amount: number;
-    recipient_name: string;
-    signature: string;
-}
-
 // errors from coordinator in string based format (see ./utils/http coordinatorRequest errorCode handling)
 export enum WabiSabiProtocolErrorCode {
     RoundNotFound = 'RoundNotFound',
@@ -211,4 +205,33 @@ export enum WabiSabiProtocolErrorCode {
     AliceAlreadySignalled = 'AliceAlreadySignalled',
     AliceAlreadyConfirmedConnection = 'AliceAlreadyConfirmedConnection',
     AlreadyRegisteredScript = 'AlreadyRegisteredScript',
+}
+
+// types and below should be removed after affiliate server implementation on coordinator
+
+interface AffiliateRequestInputs {
+    prevout: {
+        hash: string;
+        index: number;
+    };
+    script_pubkey: string;
+}
+
+interface AffiliateRequestOutputs {
+    amount: number;
+    script_pubkey: string;
+}
+
+export interface CoinjoinAffiliateTx {
+    inputs: AffiliateRequestInputs[];
+    outputs: AffiliateRequestOutputs[];
+}
+
+export interface CoinjoinAffiliateRequest {
+    fee_rate: number;
+    no_fee_threshold: number;
+    min_registrable_amount: number;
+    mask_public_key: string;
+    coinjoin_flags_array: number[];
+    signature: string;
 }

--- a/packages/coinjoin/src/types/round.ts
+++ b/packages/coinjoin/src/types/round.ts
@@ -1,5 +1,5 @@
 import { AccountAddress } from './account';
-import { RoundPhase, TxPaymentRequest } from './coordinator';
+import { RoundPhase, CoinjoinAffiliateRequest } from './coordinator';
 
 export interface SerializedAlice {
     accountKey: string;
@@ -25,6 +25,8 @@ interface CoinjoinTxInputs {
     path?: string;
     outpoint: string;
     amount: number;
+    hash: string;
+    index: number;
     commitmentData: string;
     scriptPubKey: string;
     ownershipProof: string;
@@ -39,7 +41,7 @@ interface CoinjoinTxOutputs {
 export interface CoinjoinTransactionData {
     inputs: CoinjoinTxInputs[];
     outputs: CoinjoinTxOutputs[];
-    paymentRequest: TxPaymentRequest;
+    affiliateRequest: CoinjoinAffiliateRequest;
 }
 
 export interface CoinjoinRequestOwnershipEvent {
@@ -49,14 +51,14 @@ export interface CoinjoinRequestOwnershipEvent {
     commitmentData: string;
 }
 
-export interface CoinjoinRequestWitnessEvent {
-    type: 'witness';
+export interface CoinjoinRequestSignatureEvent {
+    type: 'signature';
     roundId: string;
     inputs: SerializedAlice[];
     transaction: CoinjoinTransactionData;
 }
 
-export type CoinjoinRequestEvent = CoinjoinRequestOwnershipEvent | CoinjoinRequestWitnessEvent;
+export type CoinjoinRequestEvent = CoinjoinRequestOwnershipEvent | CoinjoinRequestSignatureEvent;
 
 export interface CoinjoinResponseOwnership {
     outpoint: string;
@@ -65,8 +67,8 @@ export interface CoinjoinResponseOwnership {
 
 export interface CoinjoinResponseWitness {
     outpoint: string;
-    witness: string;
-    witnessIndex: number;
+    signature: string;
+    index: number;
 }
 
 export interface CoinjoinResponseWithError {
@@ -80,10 +82,10 @@ export interface CoinjoinResponseOwnershipEvent {
     inputs: (CoinjoinResponseOwnership | CoinjoinResponseWithError)[];
 }
 
-export interface CoinjoinResponseWitnessEvent {
-    type: 'witness';
+export interface CoinjoinResponseSignatureEvent {
+    type: 'signature';
     roundId: string;
     inputs: (CoinjoinResponseWitness | CoinjoinResponseWithError)[];
 }
 
-export type CoinjoinResponseEvent = CoinjoinResponseOwnershipEvent | CoinjoinResponseWitnessEvent;
+export type CoinjoinResponseEvent = CoinjoinResponseOwnershipEvent | CoinjoinResponseSignatureEvent;

--- a/packages/coinjoin/src/utils/coordinatorUtils.ts
+++ b/packages/coinjoin/src/utils/coordinatorUtils.ts
@@ -31,3 +31,17 @@ export const getScriptPubKeyFromAddress = (
 
     throw new Error('Unsupported scriptType');
 };
+
+// return WabiSabi coordinator config constants
+export const getInputSize = (type: AllowedScriptTypes) => {
+    if (type === 'Taproot') return 58;
+    if (type === 'P2WPKH') return 68;
+    throw new Error('Unsupported scriptType');
+};
+
+// return WabiSabi coordinator config constants
+export const getOutputSize = (type: AllowedScriptTypes) => {
+    if (type === 'Taproot') return 43;
+    if (type === 'P2WPKH') return 31;
+    throw new Error('Unsupported scriptType');
+};

--- a/packages/coinjoin/src/utils/coordinatorUtils.ts
+++ b/packages/coinjoin/src/utils/coordinatorUtils.ts
@@ -32,6 +32,18 @@ export const getScriptPubKeyFromAddress = (
     throw new Error('Unsupported scriptType');
 };
 
+// check WabiSabi.scriptPubKey format by OP and return AllowedScriptType
+export const getScriptTypeFromScriptPubKey = (scriptPubKey: string): AllowedScriptTypes => {
+    if (scriptPubKey.startsWith('0 ')) {
+        return 'P2WPKH';
+    }
+    if (scriptPubKey.startsWith('1 ')) {
+        return 'Taproot';
+    }
+
+    throw new Error('Unsupported scriptType');
+};
+
 // return WabiSabi coordinator config constants
 export const getInputSize = (type: AllowedScriptTypes) => {
     if (type === 'Taproot') return 58;
@@ -44,4 +56,9 @@ export const getOutputSize = (type: AllowedScriptTypes) => {
     if (type === 'Taproot') return 43;
     if (type === 'P2WPKH') return 31;
     throw new Error('Unsupported scriptType');
+};
+
+export const getExternalOutputSize = (scriptPubKey: string) => {
+    const type = getScriptTypeFromScriptPubKey(scriptPubKey);
+    return getOutputSize(type);
 };

--- a/packages/coinjoin/src/utils/coordinatorUtils.ts
+++ b/packages/coinjoin/src/utils/coordinatorUtils.ts
@@ -1,6 +1,17 @@
-import { payments, Network } from '@trezor/utxo-lib';
+import {
+    payments,
+    address as baddress,
+    script as bscript,
+    bufferutils,
+    Network,
+} from '@trezor/utxo-lib';
 
-import { AllowedScriptTypes } from '../types/coordinator';
+import {
+    AllowedScriptTypes,
+    CoinjoinOutputAddedEvent,
+    CoinjoinInput,
+    CoinjoinOutput,
+} from '../types/coordinator';
 
 // WabiSabi coordinator is using custom format of address scriptPubKey
 // utxo-lib format: `OP_0 {sha256(redeemScript)}`, `OP_1 {witnessProgram}`
@@ -44,6 +55,22 @@ export const getScriptTypeFromScriptPubKey = (scriptPubKey: string): AllowedScri
     throw new Error('Unsupported scriptType');
 };
 
+// return WabiSabi.scriptPubKey in utxo-lib format (see getScriptPubKeyFromAddress)
+// return as hex string or as buffer
+export function prefixScriptPubKey(scriptPubKey: string, useHex?: boolean): string;
+export function prefixScriptPubKey(scriptPubKey: string, useHex: false): Buffer;
+export function prefixScriptPubKey(scriptPubKey: string, useHex = true) {
+    const [OP, hash] = scriptPubKey.split(' ');
+    const script = bscript.fromASM(`OP_${OP} ${hash}`);
+    return useHex ? script.toString('hex') : script;
+}
+
+// return address from WabiSabi.scriptPubKey
+export const getAddressFromScriptPubKey = (scriptPubKey: string, network: Network) => {
+    const script = prefixScriptPubKey(scriptPubKey, false);
+    return baddress.fromOutputScript(script, network);
+};
+
 // return WabiSabi coordinator config constants
 export const getInputSize = (type: AllowedScriptTypes) => {
     if (type === 'Taproot') return 58;
@@ -61,4 +88,73 @@ export const getOutputSize = (type: AllowedScriptTypes) => {
 export const getExternalOutputSize = (scriptPubKey: string) => {
     const type = getScriptTypeFromScriptPubKey(scriptPubKey);
     return getOutputSize(type);
+};
+
+// read index, hash and txid from input `outpoint`
+export const readOutpoint = (outpoint: string) => {
+    const reader = new bufferutils.BufferReader(Buffer.from(outpoint, 'hex'));
+    const txid = reader.readSlice(32);
+    const index = reader.readUInt32();
+    const hash = bufferutils.reverseBuffer(txid).toString('hex');
+    return { index, hash, txid: txid.toString('hex') };
+};
+
+// WalletWasabi/WalletWasabi/Helpers/ByteArrayComparer.cs
+const compareByteArray = (left: Buffer, right: Buffer) => {
+    if (!left && !right) return 0;
+    if (!left) return 1;
+    if (!right) return -1;
+
+    const min = Math.min(left.length, right.length);
+    for (let i = 0; i < min; i++) {
+        if (left[i] < right[i]) return -1;
+        if (left[i] > right[i]) return 1;
+    }
+    return left.length - right.length;
+};
+
+// WalletWasabi/WalletWasabi/WabiSabi/Models/MultipartyTransaction/SigningState.cs
+// merge outputs with the same scriptPubKey's
+export const mergePubkeys = (outputs: CoinjoinOutputAddedEvent[]) =>
+    outputs.reduce((a, item) => {
+        const duplicates = outputs.filter(o => o.output.scriptPubKey === item.output.scriptPubKey);
+        if (duplicates.length > 1) {
+            if (a.find(o => o.output.scriptPubKey === item.output.scriptPubKey)) return a;
+            const value = duplicates.reduce((v, b) => v + b.output.value, 0);
+            return a.concat({ ...item, output: { ...item.output, value } });
+        }
+        return a.concat(item);
+    }, [] as CoinjoinOutputAddedEvent[]);
+
+// WalletWasabi/WalletWasabi/WabiSabi/Models/MultipartyTransaction/SigningState.cs
+export const sortInputs = (a: CoinjoinInput, b: CoinjoinInput) => {
+    if (a.txOut.value === b.txOut.value) {
+        return compareByteArray(Buffer.from(a.outpoint), Buffer.from(b.outpoint));
+    }
+
+    return b.txOut.value - a.txOut.value;
+};
+
+// WalletWasabi/WalletWasabi/WabiSabi/Models/MultipartyTransaction/SigningState.cs
+export const sortOutputs = (a: CoinjoinOutput, b: CoinjoinOutput) => {
+    if (a.value === b.value)
+        return compareByteArray(Buffer.from(a.scriptPubKey), Buffer.from(b.scriptPubKey));
+    return b.value - a.value;
+};
+
+// Transform transaction signature to witness, based on @trezor/utxo-lib/Transaction.getWitness
+// bip-0141 format: chunks size + (chunk[i].size + chunk[i]),
+export const getWitnessFromSignature = (signature: string) => {
+    const chunks = [Buffer.from(signature, 'hex')]; // NOTE: Trezor signature = only one chunk
+    const getChunkSize = (n: number) => {
+        const buf = Buffer.allocUnsafe(1);
+        buf.writeUInt8(n);
+        return buf;
+    };
+    const prefixedChunks = chunks.reduce(
+        (arr, chunk) => arr.concat([getChunkSize(chunk.length), chunk]),
+        [getChunkSize(chunks.length)],
+    );
+
+    return Buffer.concat(prefixedChunks).toString('hex');
 };

--- a/packages/coinjoin/src/utils/roundUtils.ts
+++ b/packages/coinjoin/src/utils/roundUtils.ts
@@ -5,6 +5,7 @@ import {
     CoinjoinStateEvent,
     CoinjoinRoundParameters,
 } from '../types/coordinator';
+import { Credentials } from '../types/middleware';
 
 export const getRoundEvents = <T extends CoinjoinStateEvent['Type']>(
     type: T,
@@ -141,3 +142,9 @@ export const getCoordinatorFeeRate = (rounds: Round[]) => {
 
     return Math.max(...rates);
 };
+
+export const compareOutpoint = (a: string, b: string) =>
+    Buffer.from(a, 'hex').compare(Buffer.from(b, 'hex')) === 0;
+
+// sum input Credentials
+export const sumCredentials = (c: Credentials[]) => c[0].value + c[1].value;

--- a/packages/coinjoin/tests/client/connectionConfirmation.test.ts
+++ b/packages/coinjoin/tests/client/connectionConfirmation.test.ts
@@ -1,0 +1,94 @@
+import { connectionConfirmation } from '../../src/client/round/connectionConfirmation';
+import { createServer, Server } from '../mocks/server';
+import { createInput } from '../fixtures/input.fixture';
+import { createCoinjoinRound } from '../fixtures/round.fixture';
+
+let server: Server | undefined;
+
+jest.mock('@trezor/utils', () => {
+    const originalModule = jest.requireActual('@trezor/utils');
+    return {
+        __esModule: true,
+        ...originalModule,
+        getRandomNumberInRange: () => 0,
+    };
+});
+
+describe('connectionConfirmation', () => {
+    beforeAll(async () => {
+        server = await createServer();
+    });
+
+    beforeEach(() => {
+        server?.removeAllListeners('test-request');
+    });
+
+    afterAll(() => {
+        if (server) server.close();
+    });
+
+    it('try to confirm without registrationData', async () => {
+        const response = await connectionConfirmation(
+            createCoinjoinRound(
+                [createInput('account-A', 'A1'), createInput('account-B', 'B1')],
+                server?.requestOptions,
+            ),
+            server?.requestOptions,
+        );
+        response.inputs.forEach(input => {
+            expect(input.error?.message).toMatch(/confirm unregistered input/);
+        });
+    });
+
+    it('error in coordinator connection-confirmation', async () => {
+        server?.addListener('test-request', ({ url, data }, req, res) => {
+            if (url.includes('connection-confirmation')) {
+                if (data.aliceId === '01A2-01a2') {
+                    res.writeHead(404);
+                    res.end();
+                }
+            }
+            req.emit('test-response');
+        });
+        const response = await connectionConfirmation(
+            createCoinjoinRound(
+                [
+                    createInput('account-A', 'A1', {
+                        registrationData: {
+                            aliceId: '01A1-01a1',
+                        },
+                        realAmountCredentials: {},
+                        realVsizeCredentials: {},
+                    }),
+                    createInput('account-A', 'A2', {
+                        registrationData: {
+                            aliceId: '01A2-01a2',
+                        },
+                        realAmountCredentials: {},
+                        realVsizeCredentials: {},
+                    }),
+                    createInput('account-A', 'A3', {
+                        registrationData: {
+                            aliceId: '01A3-01a3',
+                        },
+                        realAmountCredentials: {},
+                        realVsizeCredentials: {},
+                    }),
+                ],
+                {
+                    ...server?.requestOptions,
+                    round: { phase: 1, id: '01' },
+                },
+            ),
+            server?.requestOptions,
+        );
+
+        response.inputs.forEach(input => {
+            if (input.outpoint === 'A2') {
+                expect(input.error?.message).toMatch(/Not Found/);
+            } else {
+                expect(input.confirmationData).toEqual(expect.any(Object));
+            }
+        });
+    });
+});

--- a/packages/coinjoin/tests/client/inputRegistration.test.ts
+++ b/packages/coinjoin/tests/client/inputRegistration.test.ts
@@ -1,0 +1,239 @@
+import { CoinjoinPrison } from '../../src/client/CoinjoinPrison';
+import { inputRegistration } from '../../src/client/round/inputRegistration';
+import { createServer, Server } from '../mocks/server';
+import { createInput } from '../fixtures/input.fixture';
+import { createCoinjoinRound } from '../fixtures/round.fixture';
+
+let server: Server | undefined;
+
+const prison = new CoinjoinPrison();
+
+// mock random delay function
+jest.mock('@trezor/utils', () => {
+    const originalModule = jest.requireActual('@trezor/utils');
+    return {
+        __esModule: true,
+        ...originalModule,
+        getRandomNumberInRange: () => 0,
+    };
+});
+
+describe('inputRegistration', () => {
+    beforeAll(async () => {
+        server = await createServer();
+        // jest.spyOn('@trezor/utils', 'getRandomNumberInRange').mockImplementation(() => {});
+    });
+
+    beforeEach(() => {
+        server?.removeAllListeners('test-request');
+    });
+
+    afterAll(() => {
+        jest.clearAllMocks();
+        if (server) server.close();
+    });
+
+    it('try to register without ownership proof', async () => {
+        const response = await inputRegistration(
+            createCoinjoinRound(
+                [createInput('account-A', 'A1'), createInput('account-B', 'B1')],
+                server?.requestOptions,
+            ),
+            prison,
+            server?.requestOptions,
+        );
+
+        response.inputs.forEach(input => {
+            expect(input.ownershipProof).toBe(undefined);
+        });
+    });
+
+    it('register success', async () => {
+        const response = await inputRegistration(
+            createCoinjoinRound(
+                [
+                    createInput('account-A', 'A1', { ownershipProof: '01A1' }),
+                    createInput('account-B', 'B1', { ownershipProof: '01B1' }),
+                ],
+                {
+                    ...server?.requestOptions,
+                    round: { phaseDeadline: 0 },
+                },
+            ),
+            prison,
+            server?.requestOptions,
+        );
+
+        response.inputs.forEach(input => {
+            expect(input.ownershipProof).toEqual(expect.any(String));
+            expect(input.registrationData).toMatchObject({ aliceId: expect.any(String) });
+            expect(input.realAmountCredentials).toEqual(expect.any(Object));
+            expect(input.realVsizeCredentials).toEqual(expect.any(Object));
+        });
+    });
+
+    it('fees calculation for P2WPKH and Taproot (remix/coordinator/plebs)', async () => {
+        server?.addListener('test-request', ({ url, data }, req, _res) => {
+            let response: any;
+            if (
+                url.endsWith('/input-registration') &&
+                (data.input === 'A1' || data.input === 'B1')
+            ) {
+                // first input from each account is remixed (no coordinator fee)
+                response = {
+                    aliceId: data.input,
+                    isPayingZeroCoordinationFee: true,
+                };
+            } else if (url.endsWith('/create-request')) {
+                response = {
+                    realCredentialsRequestData: {
+                        credentialsRequest: {
+                            delta: data.amountsToRequest[0],
+                        },
+                    },
+                };
+            }
+            req.emit('test-response', response);
+        });
+
+        const response = await inputRegistration(
+            createCoinjoinRound(
+                [
+                    createInput('account-P2WPKH', 'A1', {
+                        accountType: 'P2WPKH',
+                        ownershipProof: '01A1',
+                        amount: 123456789,
+                    }),
+                    createInput('account-P2WPKH', 'A2', {
+                        accountType: 'P2WPKH',
+                        ownershipProof: '01A2',
+                        amount: 123456789,
+                    }),
+                    createInput('account-P2WPKH', 'A3', {
+                        accountType: 'P2WPKH',
+                        ownershipProof: '01A3',
+                        amount: 999999,
+                    }),
+
+                    //
+                    createInput('account-Taproot', 'B1', {
+                        accountType: 'Taproot',
+                        ownershipProof: '01B1',
+                        amount: 123456789,
+                    }),
+                    createInput('account-Taproot', 'B2', {
+                        accountType: 'Taproot',
+                        ownershipProof: '01B2',
+                        amount: 123456789,
+                    }),
+                    createInput('account-Taproot', 'B3', {
+                        accountType: 'Taproot',
+                        ownershipProof: '01B3',
+                        amount: 999999,
+                    }),
+                ],
+                {
+                    ...server?.requestOptions,
+                    round: { phaseDeadline: 0 },
+                },
+            ),
+            prison,
+            server?.requestOptions,
+        );
+
+        response.inputs.forEach(input => {
+            if (input.outpoint === 'A1') {
+                expect(input.realAmountCredentials?.credentialsRequest.delta).toEqual(123448017); // remix
+                expect(input.realVsizeCredentials?.credentialsRequest.delta).toEqual(187);
+            }
+            if (input.outpoint === 'B1') {
+                expect(input.realAmountCredentials?.credentialsRequest.delta).toEqual(123449307); // remix
+                expect(input.realVsizeCredentials?.credentialsRequest.delta).toEqual(197);
+            }
+
+            if (input.outpoint === 'A2') {
+                expect(input.realAmountCredentials?.credentialsRequest.delta).toEqual(123077647); // coordinator fee
+                expect(input.realVsizeCredentials?.credentialsRequest.delta).toEqual(187);
+            }
+            if (input.outpoint === 'B2') {
+                expect(input.realAmountCredentials?.credentialsRequest.delta).toEqual(123078937); // coordinator fee
+                expect(input.realVsizeCredentials?.credentialsRequest.delta).toEqual(197);
+            }
+
+            if (input.outpoint === 'A3') {
+                expect(input.realAmountCredentials?.credentialsRequest.delta).toEqual(991227); // plebs
+                expect(input.realVsizeCredentials?.credentialsRequest.delta).toEqual(187);
+            }
+            if (input.outpoint === 'B3') {
+                expect(input.realAmountCredentials?.credentialsRequest.delta).toEqual(992517); // plebs
+                expect(input.realVsizeCredentials?.credentialsRequest.delta).toEqual(197);
+            }
+        });
+    });
+
+    it('error in coordinator input-registration', async () => {
+        server?.addListener('test-request', ({ url, data }, req, res) => {
+            if (url.endsWith('/input-registration')) {
+                if (data.ownershipProof === '01A2') {
+                    res.statusCode = 500;
+                    res.setHeader('Content-Type', 'application/json');
+                    res.write(JSON.stringify({ error: 'ExpectedRuntimeError' }));
+                    res.end();
+                }
+            }
+            req.emit('test-response');
+        });
+        const response = await inputRegistration(
+            createCoinjoinRound(
+                [
+                    createInput('account-A', 'A1', { ownershipProof: '01A1' }),
+                    createInput('account-A', 'A2', { ownershipProof: '01A2' }),
+                    createInput('account-A', 'A3', { ownershipProof: '01A3' }),
+                ],
+                {
+                    ...server?.requestOptions,
+                    round: { phaseDeadline: 0 },
+                },
+            ),
+            prison,
+            server?.requestOptions,
+        );
+
+        response.inputs.forEach(input => {
+            if (input.outpoint === 'A1') {
+                expect(input.registrationData).toMatchObject({ aliceId: expect.any(String) });
+            }
+
+            if (input.outpoint === 'A2') {
+                expect(input.error?.message).toMatch(/ExpectedRuntimeError/);
+            }
+
+            if (input.outpoint === 'A3') {
+                expect(input.registrationData).toMatchObject({ aliceId: expect.any(String) });
+            }
+        });
+    });
+
+    it('error in middleware after successful registration (input should be unregistered while still can)', async () => {
+        server?.addListener('test-request', ({ url }, req, res) => {
+            if (url.endsWith('/create-request')) {
+                res.statusCode = 500;
+                res.setHeader('Content-Type', 'application/json');
+                res.write(JSON.stringify({ error: 'ExpectedRuntimeError' }));
+                res.end();
+            }
+            req.emit('test-response');
+        });
+        const response = await inputRegistration(
+            createCoinjoinRound(
+                [createInput('account-A', 'A1', { ownershipProof: '01A1' })],
+                server?.requestOptions,
+            ),
+            prison,
+            server?.requestOptions,
+        );
+        // input have registrationData but also have an error and should be excluded
+        expect(response.inputs[0].registrationData).toMatchObject({ aliceId: expect.any(String) });
+        expect(response.inputs[0].error?.message).toMatch(/ExpectedRuntimeError/);
+    });
+});

--- a/packages/coinjoin/tests/client/outputRegistration.test.ts
+++ b/packages/coinjoin/tests/client/outputRegistration.test.ts
@@ -1,0 +1,50 @@
+import { CoinjoinPrison } from '../../src/client/CoinjoinPrison';
+import { outputRegistration } from '../../src/client/round/outputRegistration';
+import { createServer, Server } from '../mocks/server';
+import { createInput } from '../fixtures/input.fixture';
+import { createCoinjoinRound } from '../fixtures/round.fixture';
+
+let server: Server | undefined;
+
+const prison = new CoinjoinPrison();
+
+describe('outputRegistration', () => {
+    beforeAll(async () => {
+        server = await createServer();
+    });
+
+    beforeEach(() => {
+        server?.removeAllListeners('test-request');
+    });
+
+    afterAll(() => {
+        if (server) server.close();
+    });
+
+    it('fails on joining credentials (missing data in input)', async () => {
+        const response = await outputRegistration(
+            createCoinjoinRound([createInput('account-A', 'A1')], {
+                ...server?.requestOptions,
+                round: {
+                    phase: 3,
+                },
+            }),
+            [],
+            prison,
+            server?.requestOptions,
+        );
+        expect(response.inputs[0].error?.message).toMatch(/Missing confirmed credentials/);
+    });
+
+    // it('joinInputsCredentials', async () => {
+    //     const cli = await joinInputsCredentials({
+    //         round: {},
+    //         inputs: [
+    //             { aliceId: '1', newAmountCredentials: { value: 1 } },
+    //             { aliceId: '2', newAmountCredentials: { value: 2 } },
+    //             { aliceId: '3', newAmountCredentials: { value: 3 } },
+    //             { aliceId: '4', newAmountCredentials: { value: 4 } },
+    //         ],
+    //     });
+    // });
+});

--- a/packages/coinjoin/tests/client/selectRound.test.ts
+++ b/packages/coinjoin/tests/client/selectRound.test.ts
@@ -1,0 +1,329 @@
+import { Alice } from '../../src/client/Alice';
+import { CoinjoinRound } from '../../src/client/CoinjoinRound';
+import { CoinjoinPrison } from '../../src/client/CoinjoinPrison';
+import {
+    getRoundCandidates,
+    getAccountCandidates,
+    selectUtxoForRound,
+    selectRound,
+    AliceGenerator,
+    CoinjoinRoundGenerator,
+} from '../../src/client/round/selectRound';
+import { DEFAULT_ROUND, ROUND_CREATION_EVENT } from '../fixtures/round.fixture';
+import { createServer, Server } from '../mocks/server';
+
+let server: Server | undefined;
+
+// first two params of `selectRound` are always the same
+const GENERATORS: [CoinjoinRoundGenerator, AliceGenerator] = [
+    (...args) => new CoinjoinRound(...args),
+    (...args) => new Alice(...args),
+];
+
+const PRISON = new CoinjoinPrison();
+
+describe('selectRound', () => {
+    beforeAll(async () => {
+        server = await createServer();
+    });
+
+    beforeEach(() => {
+        server?.removeAllListeners('test-request');
+    });
+
+    afterAll(() => {
+        jest.clearAllMocks();
+        if (server) server.close();
+    });
+
+    it('no available candidates in status Rounds', async () => {
+        const result = await getRoundCandidates(
+            GENERATORS[0],
+            [{ phase: 1 }, { phase: 0, inputRegistrationEnd: new Date() }] as any,
+            [],
+            server?.requestOptions,
+        );
+        expect(result).toEqual([]);
+    });
+
+    it('CoinjoinRound creation failed on status Round without RoundCreated event', async () => {
+        const result = await getRoundCandidates(
+            GENERATORS[0],
+            [
+                {
+                    ...DEFAULT_ROUND,
+                    coinjoinState: {
+                        events: [],
+                    },
+                },
+            ] as any,
+            [],
+            server?.requestOptions,
+        );
+        expect(result).toEqual([]);
+    });
+
+    it('select existing CoinjoinRound', () => {
+        const cjRound = new CoinjoinRound(DEFAULT_ROUND, server?.requestOptions);
+        const result = getRoundCandidates(
+            GENERATORS[0],
+            [DEFAULT_ROUND],
+            [cjRound],
+            server?.requestOptions,
+        );
+        expect(result[0]).toBe(cjRound);
+    });
+
+    it('no available Accounts', () => {
+        const result = getAccountCandidates([], [], [], PRISON, server?.requestOptions);
+        expect(result).toEqual([]);
+    });
+
+    it('no available utxos', () => {
+        const result = getAccountCandidates(
+            [{ utxos: [] }] as any,
+            [],
+            [],
+            PRISON,
+            server?.requestOptions,
+        );
+        expect(result).toEqual([]);
+    });
+
+    it('utxo in prison', () => {
+        PRISON.detain('Ba99ed');
+
+        const result = getAccountCandidates(
+            [{ utxos: [{ outpoint: 'Ba99ed' }] }] as any,
+            [],
+            [],
+            PRISON,
+            server?.requestOptions,
+        );
+        expect(result).toEqual([]);
+    });
+
+    it('utxo already registered in CoinjoinRound', () => {
+        const result = getAccountCandidates(
+            [{ utxos: [{ outpoint: 'AA' }] }] as any,
+            [],
+            [
+                {
+                    id: '00',
+                    inputs: [{ outpoint: 'AA' }],
+                    failed: [],
+                },
+            ] as any,
+            PRISON,
+            server?.requestOptions,
+        );
+        expect(result).toEqual([]);
+    });
+
+    it('Account already registered in CoinjoinRound', () => {
+        const result = getAccountCandidates(
+            [{ accountKey: 'account-A', utxos: [{ outpoint: 'AA' }, { outpoint: 'AB' }] }] as any,
+            [],
+            [
+                {
+                    id: '03',
+                    inputs: [{ accountKey: 'account-A', outpoint: 'AA' }],
+                    failed: [{ outpoint: 'Fa17ed' }],
+                },
+            ] as any,
+            PRISON,
+            server?.requestOptions,
+        );
+        expect(result).toEqual([]);
+    });
+
+    it('Account skipping rounds', () => {
+        const account = [
+            {
+                accountKey: 'account-A',
+                skipRounds: [4, 5],
+                skipRoundCounter: 0,
+                utxos: [{ outpoint: 'AA' }, { outpoint: 'AB' }],
+            },
+        ];
+
+        // iterate 5 times
+        const result = new Array(5)
+            .fill(0, 0, 5)
+            .flatMap(() =>
+                getAccountCandidates(account as any, [], [], PRISON, server?.requestOptions),
+            );
+
+        // skipped at least once
+        expect(result.length).toBeLessThan(5); // should be 4 but there is always 20% chance that will be 3
+    });
+
+    it('middleware/select-utxo-for-round throws error', async () => {
+        // mock server response
+        // return error for each round with miningFeeRate: 1 (second round in fixture)
+        // for other rounds return invalid indices
+        const spy = jest.fn();
+        server?.addListener('test-request', ({ url, data }, req, res) => {
+            if (url.endsWith('/select-utxo-for-round')) {
+                spy();
+                if (data.constants.miningFeeRate === 1) {
+                    res.statusCode = 500;
+                    res.setHeader('Content-Type', 'application/json');
+                    res.write(JSON.stringify({ error: 'ExpectedRuntimeError' }));
+                    res.end();
+                    req.emit('test-response');
+                } else {
+                    req.emit('test-response', {
+                        indices: [5], // non existing indices (utxo indexes)
+                    });
+                }
+            }
+        });
+
+        const result = await selectUtxoForRound(
+            GENERATORS[1],
+            [
+                {
+                    id: '01',
+                    roundParameters: ROUND_CREATION_EVENT.roundParameters,
+                } as any,
+                {
+                    id: '02',
+                    roundParameters: { ...ROUND_CREATION_EVENT.roundParameters, miningFeeRate: 1 },
+                } as any,
+                {
+                    id: '03',
+                    roundParameters: ROUND_CREATION_EVENT.roundParameters,
+                } as any,
+            ],
+            [
+                { accountKey: 'account1', utxos: [{ outpoint: 'AA', amount: 100 }] },
+                { accountKey: 'account2', utxos: [{ outpoint: 'BA', amount: 100 }] },
+            ] as any,
+            server?.requestOptions,
+        );
+
+        expect(spy).toBeCalledTimes(6);
+        expect(result).toBeUndefined();
+    });
+
+    it('Success. new CoinjoinRound created', async () => {
+        // dummy mock of /select-utxo-for-round
+        // pick utxo which amount is greater than miningFeeRate + 1000
+        const spy = jest.fn();
+        server?.addListener('test-request', ({ url, data }, req, _res) => {
+            let response: any;
+            if (url.endsWith('/select-utxo-for-round')) {
+                spy();
+                const indices = data.utxos.flatMap((utxo: any, i: number) => {
+                    if (utxo.amount < 1000 + data.constants.miningFeeRate) return [];
+                    return i;
+                });
+
+                response = {
+                    indices,
+                };
+            }
+            req.emit('test-response', response);
+        });
+
+        const roundWithMiningFee = (miningFeeRate: number) => ({
+            ...DEFAULT_ROUND,
+            coinjoinState: {
+                events: [
+                    {
+                        ...ROUND_CREATION_EVENT,
+                        roundParameters: {
+                            ...ROUND_CREATION_EVENT.roundParameters,
+                            miningFeeRate,
+                        },
+                    },
+                ],
+            },
+        });
+
+        const result = await selectRound(
+            ...GENERATORS,
+            [
+                {
+                    accountKey: 'account-A',
+                    scriptType: 'Taproot',
+                    utxos: [
+                        { outpoint: 'AA', amount: 20000 }, // this will be picked by all rounds
+                        { outpoint: 'AB', amount: 1001 }, // this will be picked only by round "02"
+                        { outpoint: 'AC', amount: 1010 }, // this will be picked by round "02" and "03" rounds
+                    ],
+                },
+                {
+                    accountKey: 'account-B',
+                    scriptType: 'Taproot',
+                    utxos: [{ outpoint: 'BA', amount: 900 }], // this will not be picked by any round
+                },
+                {
+                    accountKey: 'account-C',
+                    scriptType: 'Taproot',
+                    utxos: [{ outpoint: 'CA', amount: 2000 }], // this will be picked by all rounds
+                },
+            ] as any,
+            [
+                {
+                    ...roundWithMiningFee(20),
+                    id: '01',
+                },
+                {
+                    ...roundWithMiningFee(1),
+                    id: '02',
+                },
+                {
+                    ...roundWithMiningFee(10),
+                    id: '03',
+                },
+            ] as any,
+            [],
+            PRISON,
+            server?.requestOptions,
+        );
+
+        expect(spy).toBeCalledTimes(9);
+
+        ['AA', 'AB', 'AC', 'CA'].forEach((outpoint, index) => {
+            expect(result!.inputs[index].outpoint).toEqual(outpoint);
+        });
+
+        expect(result).toMatchObject({
+            id: '02', // this round contains most utxo candidates
+            phase: 0,
+            roundParameters: { miningFeeRate: 1 },
+            commitmentData: expect.any(String),
+        });
+    });
+
+    // all tested above, this is just for coverage
+    it('selectRound without results', async () => {
+        // no rounds
+        const result = await selectRound(...GENERATORS, [], [], [], PRISON, server?.requestOptions);
+        expect(result).toBeUndefined();
+
+        // no accounts
+        const result2 = await selectRound(
+            ...GENERATORS,
+            [],
+            [DEFAULT_ROUND],
+            [],
+            PRISON,
+            server?.requestOptions,
+        );
+        expect(result2).toBeUndefined();
+
+        // no result from middleware
+        const result3 = await selectRound(
+            ...GENERATORS,
+            [{ utxos: [{ outpoint: 'AA' }] }] as any,
+            [DEFAULT_ROUND],
+            [],
+            PRISON,
+            server?.requestOptions,
+        );
+        expect(result3).toBeUndefined();
+    });
+});

--- a/packages/coinjoin/tests/client/transactionSigning.test.ts
+++ b/packages/coinjoin/tests/client/transactionSigning.test.ts
@@ -1,0 +1,154 @@
+import { transactionSigning } from '../../src/client/round/transactionSigning';
+import { createServer, Server } from '../mocks/server';
+import { createInput } from '../fixtures/input.fixture';
+
+let server: Server | undefined;
+
+// Temporary mock until affiliate request will be moved to coordinator
+jest.mock('cross-fetch', () => {
+    const originalModule = jest.requireActual('cross-fetch');
+    return {
+        __esModule: true,
+        ...originalModule,
+        default: (url: string, ...rest: any[]) => {
+            if (url.includes('get_coinjoin_request_suite')) {
+                return {
+                    ok: true,
+                    headers: { get: () => 'json' },
+                    text: () => Promise.resolve(JSON.stringify({ fee_rate: 0.003 })),
+                };
+            }
+            return originalModule.default(url, ...rest);
+        },
+    };
+});
+
+describe('transactionSigning', () => {
+    beforeAll(async () => {
+        server = await createServer();
+    });
+
+    beforeEach(() => {
+        server?.removeAllListeners('test-request');
+    });
+
+    afterAll(() => {
+        if (server) server.close();
+    });
+
+    it('affiliate-request', async () => {
+        const response = await transactionSigning(
+            {
+                id: '01',
+                phase: 3,
+                inputs: [
+                    createInput(
+                        'account-A',
+                        '1b5b1feea4dfed4253db5f639011a744a337b25a67975310439233bd8a1dc49f00000000',
+                    ),
+                    createInput(
+                        'account-A',
+                        '1b5b1feea4dfed4253db5f639011a744a337b25a67975310439233bd8a1dc49f00000000',
+                    ),
+                ],
+                addresses: [
+                    {
+                        scriptPubKey:
+                            '51206a6daebd9abae25cdd376b811190163eb00c58e87da1867ba8546229098231c3',
+                    },
+                ],
+                coinjoinState: {
+                    // test vectors from connect signTransactionPaymentRequest
+                    events: [
+                        {
+                            Type: 'InputAdded',
+                            coin: {
+                                outpoint:
+                                    '1B5B1FEEA4DFED4253DB5F639011A744A337B25A67975310439233BD8A1DC49F00000000',
+                                txOut: {
+                                    scriptPubKey:
+                                        '1 6a6daebd9abae25cdd376b811190163eb00c58e87da1867ba8546229098231c3',
+                                    value: 12300000,
+                                },
+                            },
+                        },
+                        {
+                            Type: 'InputAdded',
+                            coin: {
+                                outpoint:
+                                    '1B5B1FEEA4DFED4253DB5F639011A744A337B25A67975310439233BD8A1DC49F00000000',
+                                txOut: {
+                                    scriptPubKey:
+                                        '1 6a6daebd9abae25cdd376b811190163eb00c58e87da1867ba8546229098231c3',
+                                    value: 12300000,
+                                },
+                            },
+                        },
+                        {
+                            Type: 'OutputAdded',
+                            output: {
+                                scriptPubKey:
+                                    '1 b899b1962f24757bf8f641d125a88944d1541272cc86da7815ff7899e368b2d4',
+                                value: 2000000,
+                            },
+                        },
+                        {
+                            Type: 'OutputAdded',
+                            output: {
+                                scriptPubKey:
+                                    '1 b67b77a4cac9a32c463e5bbe0c6cbfbab3c86cb59518e5661766056e6a7e849c',
+                                value: 12300000 - 5000000 - 2000000 - 11000,
+                            },
+                        },
+                    ],
+                },
+            } as any,
+            server?.requestOptions,
+        );
+        expect(response).toMatchObject({
+            transactionData: {
+                affiliateRequest: {
+                    fee_rate: 0.003,
+                },
+            },
+        });
+    });
+
+    // it('try to sign input with error', async () => {
+    //     const response = await transactionSigning(
+    //         {
+    //             id: '00',
+    //             phase: 3,
+    //             accounts: {
+    //                 account1: {
+    //                     utxos: [{ outpoint: 'AA', error: 'Error from previous phase' }],
+    //                 },
+    //             },
+    //             coinjoinState: {
+    //                 events: [],
+    //             },
+    //         } as any,
+    //         server?.requestOptions,
+    //     );
+    //     expect(response).toMatchObject({
+    //         id: '00',
+    //         accounts: {
+    //             account1: {
+    //                 utxos: [{ outpoint: 'AA', error: 'Error from previous phase' }],
+    //             },
+    //         },
+    //     });
+    // });
+
+    // it('signed', async () => {
+    //     const response = await transactionSigning({
+    //         round: {
+    //             coinjoinState: {
+    //                 events: [],
+    //             },
+    //         },
+    //         inputs: [{ phase: 5, witness: '0102' }],
+    //     } as any);
+    //     expect(response).toMatchObject({ inputs: [{ phase: 7 }] });
+    // });
+});

--- a/packages/coinjoin/tests/fixtures/input.fixture.ts
+++ b/packages/coinjoin/tests/fixtures/input.fixture.ts
@@ -1,0 +1,21 @@
+import { Alice } from '../../src/client/Alice';
+
+export const createInput = (
+    accountKey: string,
+    outpoint: string,
+    options?: Record<string, any>,
+) => {
+    const input = new Alice(accountKey, options?.accountType || 'Taproot', {
+        outpoint,
+        path: 'm/10025',
+        amount: options?.amount || 1,
+        anonymityLevel: 1,
+    });
+    if (options) {
+        Object.keys(options).forEach(key => {
+            // @ts-expect-error key-value unsolvable problem
+            input[key] = options[key];
+        });
+    }
+    return input;
+};

--- a/packages/coinjoin/tests/fixtures/round.fixture.ts
+++ b/packages/coinjoin/tests/fixtures/round.fixture.ts
@@ -1,3 +1,4 @@
+import { CoinjoinRound } from '../../src/client/CoinjoinRound';
 import { Round } from '../../src/types/coordinator';
 import { ROUND_SELECTION_REGISTRATION_OFFSET } from '../../src/constants';
 
@@ -57,3 +58,41 @@ export const DEFAULT_ROUND = {
         Date.now() + ROUND_SELECTION_REGISTRATION_OFFSET * 2,
     ).toUTCString(),
 } as Round;
+
+type CJRoundOptions = ConstructorParameters<typeof CoinjoinRound>[1];
+interface CreateCoinjoinRoundOptions extends CJRoundOptions {
+    statusRound?: Partial<Round>;
+    round?: Partial<CoinjoinRound>;
+    roundParameters?: Partial<CoinjoinRound['roundParameters']>;
+}
+export const createCoinjoinRound = (
+    inputs: CoinjoinRound['inputs'],
+    { statusRound, round: roundOptions, roundParameters, ...options }: CreateCoinjoinRoundOptions,
+) => {
+    const R = { ...DEFAULT_ROUND };
+    if (statusRound) {
+        Object.keys(statusRound).forEach(key => {
+            // @ts-expect-error key-value unsolvable problem
+            R[key] = statusRound[key];
+        });
+    }
+
+    const round = new CoinjoinRound(R, options);
+    round.inputs = inputs;
+
+    if (roundOptions) {
+        Object.keys(roundOptions).forEach(key => {
+            // @ts-expect-error key-value unsolvable problem
+            round[key] = roundOptions[key];
+        });
+    }
+
+    if (roundParameters) {
+        round.roundParameters = {
+            ...round.roundParameters,
+            ...roundParameters,
+        };
+    }
+
+    return round;
+};

--- a/packages/coinjoin/tests/fixtures/round.fixture.ts
+++ b/packages/coinjoin/tests/fixtures/round.fixture.ts
@@ -1,4 +1,41 @@
 import { Round } from '../../src/types/coordinator';
+import { ROUND_SELECTION_REGISTRATION_OFFSET } from '../../src/constants';
+
+export const ROUND_CREATION_EVENT = {
+    Type: 'RoundCreated' as const,
+    roundParameters: {
+        miningFeeRate: 129000,
+        coordinationFeeRate: {
+            rate: 0.003,
+            plebsDontPayThreshold: 1000000,
+        },
+        allowedInputAmounts: {
+            min: 5000,
+            max: 134375000000,
+        },
+        allowedOutputAmounts: {
+            min: 5000,
+            max: 134375000000,
+        },
+        allowedInputScriptTypes: ['P2WPKH', 'Taproot'],
+        allowedOutputScriptTypes: ['P2WPKH', 'Taproot'],
+        standardInputRegistrationTimeout: '0d 0h 1m 0s',
+        connectionConfirmationTimeout: '0d 0h 1m 0s',
+        outputRegistrationTimeout: '0d 0h 1m 0s',
+        transactionSigningTimeout: '0d 0h 1m 0s',
+        blameInputRegistrationTimeout: '0d 0h 1m 0s',
+        maxSuggestedAmount: 1000000000,
+        minInputCountByRound: 2,
+        maxInputCountByRound: 10,
+        minAmountCredentialValue: 5000,
+        maxAmountCredentialValue: 134375000000,
+        initialInputVsizeAllocation: 99942,
+        maxVsizeCredentialValue: 255,
+        maxVsizeAllocationPerAlice: 255,
+        maxTransactionSize: 100000,
+        minRelayTxFee: 1000,
+    },
+};
 
 export const DEFAULT_ROUND = {
     id: '80b4e3efd1aedeb7b140d605946ca5662241d6829b6018bb0eee58c9ac929fce',
@@ -14,43 +51,9 @@ export const DEFAULT_ROUND = {
     phase: 0,
     endRoundState: 0,
     coinjoinState: {
-        events: [
-            {
-                Type: 'RoundCreated',
-                roundParameters: {
-                    miningFeeRate: 129000,
-                    coordinationFeeRate: {
-                        rate: 0.003,
-                        plebsDontPayThreshold: 1000000,
-                    },
-                    allowedInputAmounts: {
-                        min: 5000,
-                        max: 134375000000,
-                    },
-                    allowedOutputAmounts: {
-                        min: 5000,
-                        max: 134375000000,
-                    },
-                    allowedInputScriptTypes: ['P2WPKH', 'Taproot'],
-                    allowedOutputScriptTypes: ['P2WPKH', 'Taproot'],
-                    standardInputRegistrationTimeout: '0d 0h 1m 0s',
-                    connectionConfirmationTimeout: '0d 0h 1m 0s',
-                    outputRegistrationTimeout: '0d 0h 1m 0s',
-                    transactionSigningTimeout: '0d 0h 1m 0s',
-                    blameInputRegistrationTimeout: '0d 0h 1m 0s',
-                    maxSuggestedAmount: 1000000000,
-                    minInputCountByRound: 2,
-                    maxInputCountByRound: 10,
-                    minAmountCredentialValue: 5000,
-                    maxAmountCredentialValue: 134375000000,
-                    initialInputVsizeAllocation: 99942,
-                    maxVsizeCredentialValue: 255,
-                    maxVsizeAllocationPerAlice: 255,
-                    maxTransactionSize: 100000,
-                    minRelayTxFee: 1000,
-                },
-            },
-        ],
+        events: [ROUND_CREATION_EVENT],
     },
-    inputRegistrationEnd: new Date().toUTCString() + 10000,
+    inputRegistrationEnd: new Date(
+        Date.now() + ROUND_SELECTION_REGISTRATION_OFFSET * 2,
+    ).toUTCString(),
 } as Round;

--- a/packages/suite/src/actions/wallet/__fixtures__/coinjoinClientActions.ts
+++ b/packages/suite/src/actions/wallet/__fixtures__/coinjoinClientActions.ts
@@ -197,3 +197,305 @@ export const onCoinjoinRoundChanged = [
         },
     },
 ];
+
+export const onCoinjoinClientRequest = [
+    {
+        description: 'getOwnershipProof success with 3 accounts, 2 passphrases, 2 physical devices',
+        connect: [
+            {
+                success: true,
+                payload: [
+                    { ownership_proof: 'AA0011' },
+                    { ownership_proof: 'AB0011' },
+                    { ownership_proof: 'AC0011' }, // this was not requested, will be ignored
+                ],
+            },
+            {
+                success: true,
+                payload: [{ ownership_proof: 'BA0011' }, { ownership_proof: 'BB0011' }],
+            },
+            {
+                success: true,
+                payload: [{ ownership_proof: 'CA0011' }, { ownership_proof: 'CB0011' }],
+            },
+        ],
+        state: {
+            devices: [
+                DEVICE,
+                { ...DEVICE, state: 'device-state-2' },
+                { ...DEVICE, state: 'device-2-state', id: '2' },
+            ],
+            accounts: [
+                { key: 'account-A', deviceState: 'device-state', utxo: [{}, {}] },
+                { key: 'account-B', deviceState: 'device-state-2', utxo: [{}, {}] },
+                { key: 'account-C', deviceState: 'device-2-state', utxo: [{}, {}] },
+            ],
+            coinjoin: {
+                accounts: [
+                    { key: 'account-A', session: {} },
+                    { key: 'account-B', session: {} },
+                    { key: 'account-C', session: {} },
+                ],
+            },
+        },
+        params: [
+            {
+                type: 'ownership',
+                roundId: '11',
+                inputs: [
+                    { accountKey: 'account-A', path: 'm/10025', outpoint: 'AA' },
+                    { accountKey: 'account-A', path: 'm/10025', outpoint: 'AB' },
+                    { accountKey: 'account-B', path: 'm/10025', outpoint: 'BA' },
+                    { accountKey: 'account-B', path: 'm/10025', outpoint: 'BB' },
+                    { accountKey: 'account-C', path: 'm/10025', outpoint: 'CA' },
+                    { accountKey: 'account-C', path: 'm/10025', outpoint: 'CB' },
+                ],
+                commitmentDate: '0011',
+            },
+        ],
+        result: {
+            trezorConnectCalledTimes: 3,
+            response: [
+                {
+                    type: 'ownership',
+                    inputs: [
+                        { outpoint: 'AA', ownershipProof: 'AA0011' },
+                        { outpoint: 'AB', ownershipProof: 'AB0011' },
+                        { outpoint: 'BA', ownershipProof: 'BA0011' },
+                        { outpoint: 'BB', ownershipProof: 'BB0011' },
+                        { outpoint: 'CA', ownershipProof: 'CA0011' },
+                        { outpoint: 'CB', ownershipProof: 'CB0011' },
+                    ],
+                },
+            ],
+        },
+    },
+];
+
+export const signCoinjoinTx = [
+    {
+        description: 'signCoinjoinTx success with 3 accounts, 2 passphrases, 2 physical devices',
+        connect: [
+            // connect responses order, first physical device id: 2, device-2-state
+            {
+                success: true,
+                payload: {
+                    signatures: ['', '', '05'], // account-A
+                },
+            },
+            // then physical device id: 1, device-state
+            {
+                success: true,
+                payload: {
+                    signatures: ['01', '', ''], // account-B
+                },
+            },
+            // then physical device id: 1, device-state-2
+            {
+                success: true,
+                payload: {
+                    signatures: ['', '02', ''], // account-C
+                },
+            },
+        ],
+        state: {
+            devices: [
+                DEVICE,
+                { ...DEVICE, state: 'device-state-2' },
+                { ...DEVICE, state: 'device-2-state', id: '2' },
+            ],
+            accounts: [
+                {
+                    key: 'account-A',
+                    deviceState: 'device-state',
+                    utxo: [
+                        {
+                            txid: '123400000000000000000000000000000000000000000000000000000000dbca',
+                            vout: 5,
+                        },
+                    ],
+                    addresses: {
+                        change: [{ address: 'A1' }, { address: 'A2' }],
+                    },
+                },
+                {
+                    key: 'account-B',
+                    deviceState: 'device-state-2',
+                    utxo: [
+                        {
+                            txid: '123400000000000000000000000000000000000000000000000000000000dbca',
+                            vout: 1,
+                        },
+                    ],
+                    addresses: {
+                        change: [{ address: 'B1' }, { address: 'B2' }],
+                    },
+                },
+                {
+                    key: 'account-C',
+                    deviceState: 'device-2-state',
+                    utxo: [
+                        {
+                            txid: '123400000000000000000000000000000000000000000000000000000000dbca',
+                            vout: 2,
+                        },
+                    ],
+                    addresses: {
+                        change: [{ address: 'C1' }, { address: 'C2' }],
+                    },
+                },
+            ],
+            coinjoin: {
+                clients: {},
+                accounts: [
+                    { key: 'account-A', session: { signedRounds: [] }, unlockPath: {} },
+                    { key: 'account-B', session: { signedRounds: [] }, unlockPath: {} },
+                    { key: 'account-C', session: { signedRounds: [] }, unlockPath: {} },
+                ],
+            },
+        },
+        params: {
+            type: 'signature',
+            roundId: '1',
+            inputs: [
+                {
+                    accountKey: 'account-A',
+                    outpoint:
+                        'cadb00000000000000000000000000000000000000000000000000000000341205000000',
+                    path: 'm/10025',
+                },
+                {
+                    accountKey: 'account-B',
+                    outpoint:
+                        'cadb00000000000000000000000000000000000000000000000000000000341201000000',
+                    path: 'm/10025',
+                },
+                {
+                    accountKey: 'account-C',
+                    outpoint:
+                        'cadb00000000000000000000000000000000000000000000000000000000341202000000',
+                    path: 'm/10025',
+                },
+            ],
+            transaction: {
+                inputs: [
+                    // NOTE: inputs/outputs order may be sorted differently than signing order, they are sorted by coordinator rules
+                    // while signing be done by param.inputs order
+                    {
+                        outpoint:
+                            'cadb00000000000000000000000000000000000000000000000000000000341201000000', // account-C
+                        path: 'm/10025',
+                        amount: 1000000,
+                        commitmentData: '',
+                        scriptPubKey: '',
+                    },
+                    {
+                        outpoint:
+                            'cadb00000000000000000000000000000000000000000000000000000000341202000000', // account-A
+                        path: 'm/10025',
+                        amount: 1000000,
+                        commitmentData: '',
+                        scriptPubKey: '',
+                    },
+                    {
+                        outpoint:
+                            'cadb00000000000000000000000000000000000000000000000000000000341205000000', // account-B
+                        path: 'm/10025',
+                        amount: 1000000,
+                        commitmentData: '',
+                        scriptPubKey: '',
+                    },
+                ],
+                outputs: [
+                    { address: 'A1', path: 'm/10025', amount: 500000 }, // account-A
+                    { address: 'B2', path: 'm/10025', amount: 499500 }, // account-B
+                    { address: 'A2', path: 'm/10025', amount: 499500 }, // account-A
+                    { address: 'C1', path: 'm/10025', amount: 500000 }, // accounCt-C
+                    { address: 'B1', path: 'm/10025', amount: 500000 }, // account-B
+                    { address: 'C2', path: 'm/10025', amount: 499500 }, // account-C
+                ],
+                affiliateRequest: {
+                    coinjoin_flags_array: [],
+                },
+            },
+        },
+        result: {
+            actions: [],
+            trezorConnectCalledTimes: 3,
+            trezorConnectCalledWith: [
+                {
+                    inputs: [
+                        { script_type: 'EXTERNAL' },
+                        { script_type: 'EXTERNAL' },
+                        { script_type: 'SPENDTAPROOT' }, // account-A
+                    ],
+                    outputs: [
+                        { script_type: 'PAYTOTAPROOT' }, // account-A
+                        { script_type: 'PAYTOADDRESS' },
+                        { script_type: 'PAYTOTAPROOT' }, // account-A
+                        { script_type: 'PAYTOADDRESS' },
+                        { script_type: 'PAYTOADDRESS' },
+                        { script_type: 'PAYTOADDRESS' },
+                    ],
+                },
+                // account-B
+                {
+                    inputs: [
+                        { script_type: 'SPENDTAPROOT' }, // account-B
+                        { script_type: 'EXTERNAL' },
+                        { script_type: 'EXTERNAL' },
+                    ],
+                    outputs: [
+                        { script_type: 'PAYTOADDRESS' },
+                        { script_type: 'PAYTOTAPROOT' }, // account-B
+                        { script_type: 'PAYTOADDRESS' },
+                        { script_type: 'PAYTOADDRESS' },
+                        { script_type: 'PAYTOTAPROOT' }, // account-B
+                        { script_type: 'PAYTOADDRESS' },
+                    ],
+                },
+                // account-C
+                {
+                    inputs: [
+                        { script_type: 'EXTERNAL' },
+                        { script_type: 'SPENDTAPROOT' }, // account-C
+                        { script_type: 'EXTERNAL' },
+                    ],
+                    outputs: [
+                        { script_type: 'PAYTOADDRESS' },
+                        { script_type: 'PAYTOADDRESS' },
+                        { script_type: 'PAYTOADDRESS' },
+                        { script_type: 'PAYTOTAPROOT' }, // account-C
+                        { script_type: 'PAYTOADDRESS' },
+                        { script_type: 'PAYTOTAPROOT' }, // account-C
+                    ],
+                },
+            ],
+            // this will be sent back to @trezor/coinjoin
+            response: {
+                type: 'signature',
+                roundId: '1',
+                inputs: [
+                    {
+                        outpoint:
+                            'cadb00000000000000000000000000000000000000000000000000000000341205000000',
+                        signature: '05',
+                        index: 2,
+                    },
+                    {
+                        outpoint:
+                            'cadb00000000000000000000000000000000000000000000000000000000341201000000',
+                        signature: '01',
+                        index: 0,
+                    },
+                    {
+                        outpoint:
+                            'cadb00000000000000000000000000000000000000000000000000000000341202000000',
+                        signature: '02',
+                        index: 1,
+                    },
+                ],
+            },
+        },
+    },
+];

--- a/packages/suite/src/actions/wallet/coinjoinClientActions.ts
+++ b/packages/suite/src/actions/wallet/coinjoinClientActions.ts
@@ -92,6 +92,15 @@ const clientSessionSignTransaction = (accountKey: string, roundId: string) =>
         },
     } as const);
 
+const clientLog = (symbol: Account['symbol'], message: string) =>
+    ({
+        type: COINJOIN.CLIENT_LOG,
+        payload: {
+            symbol,
+            message,
+        },
+    } as const);
+
 export type CoinjoinClientAction =
     | ReturnType<typeof clientEnable>
     | ReturnType<typeof clientDisable>
@@ -101,7 +110,8 @@ export type CoinjoinClientAction =
     | ReturnType<typeof clientSessionRoundChanged>
     | ReturnType<typeof clientSessionCompleted>
     | ReturnType<typeof clientSessionOwnership>
-    | ReturnType<typeof clientSessionSignTransaction>;
+    | ReturnType<typeof clientSessionSignTransaction>
+    | ReturnType<typeof clientLog>;
 
 /**
  * Show "do not disconnect" screen on Trezor.
@@ -460,6 +470,8 @@ export const initCoinjoinClient =
                 const response = await dispatch(onCoinjoinClientRequest(data));
                 client.resolveRequest(response);
             });
+            // handle log
+            client.on('log', message => dispatch(clientLog(symbol, message)));
             dispatch(clientEnableSuccess(symbol, status));
             return client;
         } catch (error) {

--- a/packages/suite/src/actions/wallet/constants/coinjoinConstants.ts
+++ b/packages/suite/src/actions/wallet/constants/coinjoinConstants.ts
@@ -12,6 +12,7 @@ export const CLIENT_DISABLE = '@coinjoin/client-disable';
 export const CLIENT_ENABLE_SUCCESS = '@coinjoin/client-enable-success';
 export const CLIENT_ENABLE_FAILED = '@coinjoin/client-enable-failed';
 export const CLIENT_STATUS = '@coinjoin/client-status';
+export const CLIENT_LOG = '@coinjoin/client-log';
 
 export const SESSION_PAUSE = '@coinjoin/session-pause';
 export const SESSION_RESTORE = '@coinjoin/session-restore';

--- a/packages/suite/src/actions/wallet/constants/coinjoinConstants.ts
+++ b/packages/suite/src/actions/wallet/constants/coinjoinConstants.ts
@@ -17,3 +17,5 @@ export const SESSION_PAUSE = '@coinjoin/session-pause';
 export const SESSION_RESTORE = '@coinjoin/session-restore';
 export const SESSION_ROUND_CHANGED = '@coinjoin/session-round-changed';
 export const SESSION_COMPLETED = '@coinjoin/session-completed';
+export const SESSION_OWNERSHIP = '@coinjoin/session-ownership';
+export const SESSION_TX_SIGNED = '@coinjoin/session-tx-signed';

--- a/packages/suite/src/components/wallet/CoinjoinSummary/CoinjoinLog.tsx
+++ b/packages/suite/src/components/wallet/CoinjoinSummary/CoinjoinLog.tsx
@@ -1,0 +1,73 @@
+import React, { createRef } from 'react';
+import styled from 'styled-components';
+import { Button, CollapsibleBox } from '@trezor/components';
+import { copyToClipboard } from '@trezor/dom-utils';
+import { Translation } from '@suite-components';
+import { useSelector } from '@suite-hooks';
+
+const LogWrapper = styled.div`
+    margin: 10px 0px;
+    max-height: 250px;
+    overflow: auto;
+`;
+
+const ActionsWrapper = styled.div`
+    display: flex;
+    flex-direction: row;
+    padding-bottom: 6px;
+`;
+
+const LogRow = styled.div`
+    display: flex;
+    flex-direction: row;
+    justify-content: space-between;
+    padding-bottom: 6px;
+`;
+
+export const CoinjoinLog = () => {
+    const htmlElement = createRef<HTMLDivElement>();
+    const { account, coinjoin, debug } = useSelector(state => ({
+        account: state.wallet.selectedAccount.account,
+        coinjoin: state.wallet.coinjoin,
+        debug: state.suite.settings.debug,
+    }));
+
+    if (!debug || !account || !coinjoin.clients[account.symbol]) return null;
+
+    const { log } = coinjoin.clients[account.symbol]!; // note: checked above
+
+    const copy = () => {
+        copyToClipboard(JSON.stringify(log), htmlElement.current);
+    };
+    const download = () => {
+        const element = document.createElement('a');
+        element.setAttribute(
+            'href',
+            `data:text/plain;charset=utf-8,${encodeURIComponent(JSON.stringify(log))}`,
+        );
+        element.setAttribute('download', 'coinjoin-log.txt');
+        element.style.display = 'none';
+        document.body.appendChild(element);
+        element.click();
+        document.body.removeChild(element);
+    };
+    return (
+        <CollapsibleBox opened={false} heading="Coinjoin debug log" variant="small">
+            <ActionsWrapper ref={htmlElement}>
+                <Button variant="tertiary" onClick={download}>
+                    <Translation id="TR_EXPORT_TO_FILE" />
+                </Button>
+                <Button variant="tertiary" onClick={copy}>
+                    <Translation id="TR_COPY_TO_CLIPBOARD" />
+                </Button>
+            </ActionsWrapper>
+            <LogWrapper>
+                {log.map(l => (
+                    <LogRow key={l.time + l.value}>
+                        {new Date(l.time).toLocaleTimeString('en-EN', { hour12: false })} {l.value}
+                    </LogRow>
+                ))}
+            </LogWrapper>
+        </CollapsibleBox>
+    );
+};

--- a/packages/suite/src/components/wallet/CoinjoinSummary/index.tsx
+++ b/packages/suite/src/components/wallet/CoinjoinSummary/index.tsx
@@ -5,6 +5,7 @@ import { Account } from '@suite-common/wallet-types';
 import { AnonymityChart } from './AnonymityChart';
 import { BalanceSection } from './BalanceSection';
 import { SummaryHeader } from './SummaryHeader';
+import { CoinjoinLog } from './CoinjoinLog';
 
 const Container = styled.div`
     width: 100%;
@@ -21,5 +22,7 @@ export const CoinjoinSummary = ({ account }: CoinjoinSummaryProps) => (
         <BalanceSection account={account} />
 
         <AnonymityChart />
+
+        <CoinjoinLog />
     </Container>
 );

--- a/packages/suite/src/reducers/wallet/coinjoinReducer.ts
+++ b/packages/suite/src/reducers/wallet/coinjoinReducer.ts
@@ -96,6 +96,18 @@ const updateSession = (
     }
 };
 
+const signSession = (
+    draft: CoinjoinState,
+    payload: ExtractActionPayload<typeof COINJOIN.SESSION_TX_SIGNED>,
+) => {
+    const account = draft.accounts.find(a => a.key === payload.accountKey);
+    if (!account || !account.session) return;
+    account.session = {
+        ...account.session,
+        signedRounds: account.session.signedRounds.concat(payload.roundId),
+    };
+};
+
 const completeSession = (
     draft: CoinjoinState,
     payload: ExtractActionPayload<typeof COINJOIN.SESSION_COMPLETED>,
@@ -228,6 +240,10 @@ export const coinjoinReducer = (
                 break;
             case COINJOIN.SESSION_COMPLETED:
                 completeSession(draft, action.payload);
+                break;
+
+            case COINJOIN.SESSION_TX_SIGNED:
+                signSession(draft, action.payload);
                 break;
 
             // no default

--- a/packages/suite/src/reducers/wallet/coinjoinReducer.ts
+++ b/packages/suite/src/reducers/wallet/coinjoinReducer.ts
@@ -17,6 +17,7 @@ export interface CoinjoinClientInstance {
     rounds: { id: string; phase: RoundPhase }[]; // store only slice of Round in reducer. may be extended in the future
     feeRatesMedians: CoinjoinClientFeeRatesMedians;
     coordinatorFeeRate: number;
+    log: { time: number; value: string }[];
 }
 
 export interface CoinjoinState {
@@ -178,16 +179,40 @@ const createClient = (
 ) => {
     const exists = draft.clients[payload.symbol];
     if (exists) return;
-    draft.clients[payload.symbol] = transformCoinjoinStatus(payload.status);
+    draft.clients[payload.symbol] = {
+        ...transformCoinjoinStatus(payload.status),
+        log: [],
+    };
 };
 
 const updateClientStatus = (
     draft: CoinjoinState,
     payload: ExtractActionPayload<typeof COINJOIN.CLIENT_STATUS>,
 ) => {
-    const exists = draft.clients[payload.symbol];
-    if (!exists) return;
-    draft.clients[payload.symbol] = transformCoinjoinStatus(payload.status);
+    const client = draft.clients[payload.symbol];
+    if (!client) return;
+    draft.clients[payload.symbol] = {
+        ...client,
+        ...transformCoinjoinStatus(payload.status),
+    };
+};
+
+const handleClientLog = (
+    draft: CoinjoinState,
+    payload: ExtractActionPayload<typeof COINJOIN.CLIENT_LOG>,
+) => {
+    const client = draft.clients[payload.symbol];
+    if (!client) return;
+
+    // put message at 1st position
+    client.log.unshift({
+        time: Date.now(),
+        value: payload.message,
+    });
+    // keep max 200 messages
+    if (client.log.length > 200) {
+        client.log = client.log.slice(200, client.log.length);
+    }
 };
 
 export const coinjoinReducer = (
@@ -245,6 +270,11 @@ export const coinjoinReducer = (
             case COINJOIN.SESSION_TX_SIGNED:
                 signSession(draft, action.payload);
                 break;
+
+            case COINJOIN.CLIENT_LOG: {
+                handleClientLog(draft, action.payload);
+                break;
+            }
 
             // no default
         }

--- a/packages/suite/src/utils/wallet/coinjoinUtils.ts
+++ b/packages/suite/src/utils/wallet/coinjoinUtils.ts
@@ -1,6 +1,9 @@
 import BigNumber from 'bignumber.js';
-
-import { CoinjoinStatusEvent, RegisterAccountParams } from '@trezor/coinjoin';
+import {
+    CoinjoinStatusEvent,
+    RegisterAccountParams,
+    CoinjoinTransactionData,
+} from '@trezor/coinjoin';
 import { getUtxoOutpoint, getBip43Type } from '@suite-common/wallet-utils';
 import { Account, CoinjoinSessionParameters } from '@suite-common/wallet-types';
 import {
@@ -150,3 +153,76 @@ export const getEstimatedTimePerRound = (skipRounds: boolean) =>
     skipRounds
         ? ESTIMATED_HOURS_PER_ROUND_WITH_SKIPPING_ROUNDS
         : ESTIMATED_HOURS_PER_ROUND_WITHOUT_SKIPPING_ROUNDS;
+
+/**
+ * Transform @trezor/coinjoin CoinjoinRequestEvent.CoinjoinTransactionData to @trezor/connect signTransaction params
+ * Params are profiled by account since multiple account can participate in one CoinjoinRound
+ */
+export const prepareCoinjoinTransaction = (
+    account: Account,
+    transaction: CoinjoinTransactionData,
+) => {
+    const inputScriptType = account.accountType === 'normal' ? 'SPENDWITNESS' : 'SPENDTAPROOT';
+    const outputScriptType = account.accountType === 'normal' ? 'PAYTOWITNESS' : 'PAYTOTAPROOT';
+    const isInternalInput = (input: CoinjoinTransactionData['inputs'][0]) =>
+        input.path && account.utxo?.find(u => getUtxoOutpoint(u) === input.outpoint);
+    const isInternalOutput = (output: CoinjoinTransactionData['outputs'][0]) =>
+        output.path && account.addresses?.change.find(a => a.address === output.address);
+
+    // TODO: early validation of inputs/outputs before it's sent to Trezor to not waste signing count
+
+    const { affiliateRequest } = transaction;
+
+    const tx = {
+        inputs: transaction.inputs.map((input, index) => {
+            const flags = affiliateRequest.coinjoin_flags_array[index];
+            if (isInternalInput(input)) {
+                return {
+                    script_type: inputScriptType,
+                    address_n: input.path!,
+                    prev_hash: input.hash,
+                    prev_index: input.index,
+                    amount: input.amount,
+                    coinjoin_flags: flags,
+                };
+            }
+
+            return {
+                address_n: undefined,
+                script_type: 'EXTERNAL' as const,
+                prev_hash: input.hash,
+                prev_index: input.index,
+                amount: input.amount,
+                script_pubkey: input.scriptPubKey,
+                ownership_proof: input.ownershipProof,
+                commitment_data: input.commitmentData,
+                coinjoin_flags: flags,
+            };
+        }),
+        outputs: transaction.outputs.map(output => {
+            if (isInternalOutput(output)) {
+                return {
+                    address_n: output.path! as any,
+                    amount: output.amount,
+                    script_type: outputScriptType,
+                };
+            }
+            return {
+                address: output.address,
+                amount: output.amount,
+                script_type: 'PAYTOADDRESS' as const,
+            };
+        }),
+    };
+
+    return {
+        ...tx,
+        coinjoinRequest: {
+            fee_rate: affiliateRequest.fee_rate,
+            no_fee_threshold: affiliateRequest.no_fee_threshold,
+            min_registrable_amount: affiliateRequest.min_registrable_amount,
+            mask_public_key: affiliateRequest.mask_public_key,
+            signature: affiliateRequest.signature,
+        },
+    };
+};

--- a/suite-common/test-utils/src/mocks.ts
+++ b/suite-common/test-utils/src/mocks.ts
@@ -336,6 +336,11 @@ const getTrezorConnect = <M>(methods?: M) => {
                 ...getFixture(),
                 _params,
             })),
+            getOwnershipProof: jest.fn(async _params => ({
+                success: false,
+                ...getFixture(),
+                _params,
+            })),
             composeTransaction: jest.fn(async _params => {
                 const fixture = getFixture();
                 if (fixture && typeof fixture.delay === 'number') {


### PR DESCRIPTION
The missing part of https://github.com/trezor/trezor-suite/pull/6485

### Real coinjoin round process implementation

Commits are ordered by phase:
1. Round selection
> Pick right set of utxos to coordinator status rounds using coinjoin middleware binary
2. Input registration and connection confirmation
> Together because they are related to each other, input once registered needs to be constantly confirmed (more in code comments)
> @trezor/coinjoin requests for `ownership` is emitted from here
3. Output registration
> Join inputs credentials, calculate output amounts, split joined credentials and register outputs. ufff :)
4. Transaction signing
> Collect all inputs/outputs from coordinator status, sort, decide which are internal, temporary request affiliate server 
> @trezor/coinjoin requests for `signature` is emitted from here
> suite provides signatures in next commit
5. resolve @trezor/coinjoin requests in suite

