### PR TITLE
Feat: warn user that coinjoin will stop when Tor disable

### DIFF
--- a/packages/suite/src/actions/suite/modalActions.ts
+++ b/packages/suite/src/actions/suite/modalActions.ts
@@ -135,6 +135,10 @@ export type UserContextPayload =
           decision: Deferred<RequestEnableTorResponse>;
       }
     | {
+          type: 'disable-tor-stop-coinjoin';
+          decision: Deferred<boolean>;
+      }
+    | {
           type: 'tor-loading';
           decision: Deferred<boolean>;
       }
@@ -231,6 +235,7 @@ type DeferredModals = Extract<
             | 'qr-reader'
             | 'disable-tor'
             | 'request-enable-tor'
+            | 'disable-tor-stop-coinjoin'
             | 'tor-loading'
             | 'review-transaction'
             | 'import-transaction'

--- a/packages/suite/src/components/suite/ModalSwitcher/UserContextModal.tsx
+++ b/packages/suite/src/components/suite/ModalSwitcher/UserContextModal.tsx
@@ -37,6 +37,7 @@ import {
 
 import type { AcquiredDevice } from '@suite-types';
 import type { ReduxModalProps } from './types';
+import { DisableTorStopCoinjoin } from '@suite-components/modals/DisableTorStopCoinjoin';
 
 /** Modals opened as result of user action */
 export const UserContextModal = ({
@@ -151,6 +152,8 @@ export const UserContextModal = ({
             return <DisableTor decision={payload.decision} onCancel={onCancel} />;
         case 'request-enable-tor':
             return <RequestEnableTor decision={payload.decision} onCancel={onCancel} />;
+        case 'disable-tor-stop-coinjoin':
+            return <DisableTorStopCoinjoin decision={payload.decision} onCancel={onCancel} />;
         case 'tor-loading':
             return <TorLoading decision={payload.decision} onCancel={onCancel} />;
         case 'cancel-coinjoin':

--- a/packages/suite/src/components/suite/modals/DisableTorStopCoinjoin.tsx
+++ b/packages/suite/src/components/suite/modals/DisableTorStopCoinjoin.tsx
@@ -1,0 +1,70 @@
+import React from 'react';
+import styled from 'styled-components';
+import { Button, P } from '@trezor/components';
+import { Modal, Translation } from '@suite-components';
+import { UserContextPayload } from '@suite-actions/modalActions';
+
+const SmallModal = styled(Modal)`
+    width: 560px;
+`;
+
+const Description = styled(P)`
+    text-align: left;
+    margin-bottom: 16px;
+`;
+
+const ItalicDescription = styled(Description)`
+    font-style: italic;
+`;
+
+type DisableTorStopCoinjoinProps = {
+    decision: Extract<UserContextPayload, { type: 'disable-tor-stop-coinjoin' }>['decision'];
+    onCancel: () => void;
+};
+
+export const DisableTorStopCoinjoin = ({ onCancel, decision }: DisableTorStopCoinjoinProps) => {
+    const onKeepRunningTor = () => {
+        decision.resolve(true);
+        onCancel();
+    };
+
+    const onStopRunningTor = () => {
+        decision.resolve(false);
+        onCancel();
+    };
+
+    return (
+        <>
+            <SmallModal
+                isCancelable
+                onCancel={onKeepRunningTor}
+                isHeadingCentered
+                heading={<Translation id="TR_TOR_DISABLE" />}
+                bottomBar={
+                    <>
+                        <Button variant="secondary" onClick={onStopRunningTor}>
+                            <Translation id="TR_TOR_STOP" />
+                        </Button>
+                        <Button variant="primary" onClick={onKeepRunningTor}>
+                            <Translation id="TR_TOR_KEEP_RUNNING" />
+                        </Button>
+                    </>
+                }
+            >
+                <>
+                    <Description>
+                        <Translation
+                            id="TR_TOR_REQUEST_ENABLE_FOR_COIN_JOIN_TITLE"
+                            values={{
+                                b: chunks => <b>{chunks}</b>,
+                            }}
+                        />
+                    </Description>
+                    <ItalicDescription>
+                        <Translation id="TR_TOR_KEEP_RUNNING_FOR_COIN_JOIN_SUBTITLE" />
+                    </ItalicDescription>
+                </>
+            </SmallModal>
+        </>
+    );
+};

--- a/packages/suite/src/support/messages.ts
+++ b/packages/suite/src/support/messages.ts
@@ -3770,6 +3770,14 @@ export default defineMessages({
         id: 'TR_TOR_ENABLE',
         defaultMessage: 'Enable Tor',
     },
+    TR_TOR_KEEP_RUNNING: {
+        id: 'TR_TOR_KEEP_RUNNING',
+        defaultMessage: 'Keep running Tor',
+    },
+    TR_TOR_STOP: {
+        id: 'TR_TOR_STOP',
+        defaultMessage: 'Stop Tor',
+    },
     TR_TOR_DISABLE: {
         id: 'TR_TOR_DISABLE',
         defaultMessage: 'Disable Tor',
@@ -3845,6 +3853,11 @@ export default defineMessages({
     TR_TOR_REQUEST_ENABLE_FOR_COIN_JOIN_SUBTITLE: {
         id: 'TR_TOR_REQUEST_ENABLE_FOR_COIN_JOIN_SUBTITLE',
         defaultMessage: "Please select 'Enable Tor' to continue or 'Leave' to quit the process.",
+    },
+    TR_TOR_KEEP_RUNNING_FOR_COIN_JOIN_SUBTITLE: {
+        id: 'TR_TOR_KEEP_RUNNING_FOR_COIN_JOIN_SUBTITLE',
+        defaultMessage:
+            "Please select 'Keep running Tor' to continue or 'Stop Tor' to quit the CoinJoin process.",
     },
     TR_TOR_REQUEST_ENABLE_FOR_COIN_JOIN_LEAVE: {
         id: 'TR_TOR_REQUEST_ENABLE_FOR_COIN_JOIN_LEAVE',


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Warn user If he disconnects Tor, that he will not be able to access CoinJoin account.

## Related Issue

Related https://github.com/trezor/trezor-suite/issues/6418

## Screenshots (if appropriate):
![image](https://user-images.githubusercontent.com/5362163/199034187-089ea142-41bf-4d25-a4b8-1a992c0cf311.png)
