### PR TITLE
feat(@trezor/utils): device utils

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,7 @@
 | [@trezor/connect-plugin-stellar](./packages/connect-plugin-stellar)   | plugin for 3rd party Stellar wallets         |
 | [@trezor/connect-popup](./packages/connect-popup)                     | UI for 3rd party implementations             |
 | [@trezor/connect-web](./packages/connect-web)                         | 3rd party interface entrypoint for browser   |
+| [@trezor/device-utils](./packages/device-utils)                       | shared device utility functions              |
 | [@trezor/integration-tests](./packages/integration-tests)             | cross-packages e2e tests                     |
 | [@trezor/message-system](./packages/message-system)                   | message system config and sign logic         |
 | [@trezor/request-manager](./packages/request-manager)                 | improved communication with Tor              |

--- a/packages/device-utils/README.md
+++ b/packages/device-utils/README.md
@@ -1,0 +1,3 @@
+# @trezor/device-utils
+
+A collection of trezor device utils that are intended to be used across trezor-suite monorepo.

--- a/packages/device-utils/package.json
+++ b/packages/device-utils/package.json
@@ -1,0 +1,13 @@
+{
+    "name": "@trezor/device-utils",
+    "version": "1.0.0",
+    "private": true,
+    "license": "See LICENSE.md in repo root",
+    "sideEffects": false,
+    "main": "src/index",
+    "scripts": {
+        "lint:js": "yarn g:eslint '**/*.{ts,tsx,js}'",
+        "test:unit": "jest -c ../../jest.config.base.js --passWithNoTests",
+        "type-check": "tsc --build"
+    }
+}

--- a/packages/device-utils/src/bootloaderUtils.ts
+++ b/packages/device-utils/src/bootloaderUtils.ts
@@ -1,0 +1,18 @@
+import { PartialDevice } from './types';
+import { isDeviceInBootloaderMode } from './modeUtils';
+
+export const getBootloaderHash = (device?: PartialDevice) =>
+    device?.features?.bootloader_hash || '';
+
+export const getBootloaderVersion = (device?: PartialDevice) => {
+    if (!device?.features) {
+        return '';
+    }
+    const { features } = device;
+
+    if (isDeviceInBootloaderMode(device) && features.major_version) {
+        return `${features.major_version}.${features.minor_version}.${features.patch_version}`;
+    }
+
+    return '';
+};

--- a/packages/device-utils/src/firmwareUtils.ts
+++ b/packages/device-utils/src/firmwareUtils.ts
@@ -1,0 +1,26 @@
+import { PartialDevice } from './types';
+import { isDeviceInBootloaderMode } from './modeUtils';
+
+export const getFirmwareRevision = (device?: PartialDevice) => device?.features?.revision || '';
+
+export const getFirmwareVersion = (device?: PartialDevice) => {
+    if (!device?.features) {
+        return '';
+    }
+    const { features } = device;
+
+    if (isDeviceInBootloaderMode(device)) {
+        return features.fw_major
+            ? `${features.fw_major}.${features.fw_minor}.${features.fw_patch}`
+            : '';
+    }
+
+    return `${features.major_version}.${features.minor_version}.${features.patch_version}`;
+};
+
+export const getFirmwareType = (device?: PartialDevice) => {
+    if (isDeviceInBootloaderMode(device)) {
+        return '';
+    }
+    return device?.firmwareType === 'bitcoin-only' ? 'Bitcoin-only' : 'Universal';
+};

--- a/packages/device-utils/src/index.ts
+++ b/packages/device-utils/src/index.ts
@@ -1,0 +1,4 @@
+export * from './firmwareUtils';
+export * from './bootloaderUtils';
+export * from './modelUtils';
+export * from './modeUtils';

--- a/packages/device-utils/src/modeUtils.ts
+++ b/packages/device-utils/src/modeUtils.ts
@@ -1,0 +1,11 @@
+import { PartialDevice } from './types';
+
+export const isDeviceInBootloaderMode = (device?: PartialDevice) =>
+    !!device?.features?.bootloader_mode;
+
+export const getDeviceMode = (device?: PartialDevice) => {
+    if (device?.features?.bootloader_mode) return 'bootloader';
+    if (!device?.features?.initialized) return 'initialize';
+    if (device?.features?.no_backup) return 'seedless';
+    return 'normal';
+};

--- a/packages/device-utils/src/modelUtils.ts
+++ b/packages/device-utils/src/modelUtils.ts
@@ -1,0 +1,6 @@
+import { PartialDevice } from './types';
+
+export const getDeviceModel = (device: PartialDevice): 'T' | '1' => {
+    const { features } = device;
+    return typeof features?.major_version === 'number' && features?.major_version > 1 ? 'T' : '1';
+};

--- a/packages/device-utils/src/types/index.ts
+++ b/packages/device-utils/src/types/index.ts
@@ -1,0 +1,18 @@
+// define required device attributes here to avoid dependencies
+// can be replaced in the future when we create a device types package
+export type PartialDevice = Partial<{
+    features: {
+        bootloader_mode: boolean | null;
+        bootloader_hash: string | null;
+        revision: string | null;
+        major_version: number | null;
+        minor_version: number | null;
+        patch_version: number | null;
+        fw_major: number | null;
+        fw_minor: number | null;
+        fw_patch: number | null;
+        initialized: boolean | null;
+        no_backup: boolean | null;
+    };
+    firmwareType: string | null;
+}>;

--- a/packages/device-utils/tsconfig.json
+++ b/packages/device-utils/tsconfig.json
@@ -1,0 +1,5 @@
+{
+    "extends": "../../tsconfig.json",
+    "compilerOptions": { "outDir": "libDev" },
+    "references": []
+}

--- a/packages/suite/package.json
+++ b/packages/suite/package.json
@@ -46,6 +46,7 @@
         "@trezor/components": "*",
         "@trezor/connect": "9.0.3",
         "@trezor/crypto-utils": "*",
+        "@trezor/device-utils": "*",
         "@trezor/dom-utils": "*",
         "@trezor/env-utils": "*",
         "@trezor/message-system": "*",

--- a/packages/suite/src/actions/firmware/firmwareActions.ts
+++ b/packages/suite/src/actions/firmware/firmwareActions.ts
@@ -1,14 +1,14 @@
 import TrezorConnect, { Device, Unsuccessful } from '@trezor/connect';
 import { analytics, EventType } from '@trezor/suite-analytics';
+import { resolveStaticPath } from '@trezor/utils';
 
 import { FIRMWARE } from '@firmware-actions/constants';
-import { getBootloaderVersion, getFwVersion } from '@suite-utils/device';
 import { isDesktop } from '@suite-utils/env';
-import { resolveStaticPath } from '@trezor/utils';
 import { addToast } from '@suite-actions/notificationActions';
 
 import { Dispatch, GetState, AppState, AcquiredDevice, FirmwareType } from '@suite-types';
 import type { Await } from '@trezor/type-utils';
+import { getFirmwareVersion, getBootloaderVersion } from '@trezor/device-utils';
 
 export type FirmwareAction =
     | {
@@ -75,7 +75,7 @@ const firmwareInstall =
 
         const fromFwVersion =
             prevDevice && prevDevice.features && prevDevice.firmware !== 'none'
-                ? getFwVersion(prevDevice)
+                ? getFirmwareVersion(prevDevice)
                 : 'none';
         const fromBlVersion = getBootloaderVersion(device);
 

--- a/packages/suite/src/components/firmware/FirmwareInitial.tsx
+++ b/packages/suite/src/components/firmware/FirmwareInitial.tsx
@@ -11,7 +11,8 @@ import { Translation } from '@suite-components';
 import { useDevice, useFirmware, useOnboarding, useSelector } from '@suite-hooks';
 import { ReconnectDevicePrompt, InstallButton, FirmwareOffer } from '@firmware-components';
 import { FirmwareType, TrezorDevice } from '@suite-types';
-import { getFwVersion, getFwUpdateVersion } from '@suite-utils/device';
+import { getFwUpdateVersion } from '@suite-utils/device';
+import { getFirmwareVersion } from '@trezor/device-utils';
 
 const InfoRow = styled.div`
     align-items: center;
@@ -123,7 +124,7 @@ export const FirmwareInitial = ({
 
     // Bitcoin-only firmware is only available on T2 from v2.0.8 - older devices must first upgrade to 2.1.1 which does not have a Bitcoin-only variant
     const isBitcoinOnlyAvailable = !!device.firmwareRelease?.release.url_bitcoinonly;
-    const currentFwVersion = getFwVersion(device);
+    const currentFwVersion = getFirmwareVersion(device);
     const availableFwVersion = getFwUpdateVersion(device);
     const hasLatestAvailableFw = !!(
         availableFwVersion &&

--- a/packages/suite/src/components/firmware/FirmwareOffer.tsx
+++ b/packages/suite/src/components/firmware/FirmwareOffer.tsx
@@ -2,13 +2,8 @@ import React from 'react';
 import styled from 'styled-components';
 import { Button, Icon, Tooltip, variables } from '@trezor/components';
 import { Translation, TrezorLink } from '@suite-components';
-import {
-    getChangelogUrl,
-    getFwType,
-    getFwUpdateVersion,
-    getFwVersion,
-    parseFirmwareChangelog,
-} from '@suite-utils/device';
+import { getFirmwareType, getFirmwareVersion } from '@trezor/device-utils';
+import { getChangelogUrl, getFwUpdateVersion, parseFirmwareChangelog } from '@suite-utils/device';
 import { useFirmware } from '@suite-hooks';
 import { AcquiredDevice, FirmwareType } from '@suite-types';
 
@@ -96,7 +91,7 @@ interface Props {
 const FirmwareOffer = ({ device, customFirmware, targetFirmwareType }: Props) => {
     const { targetType } = useFirmware();
 
-    const currentVersion = device.firmware !== 'none' ? getFwVersion(device) : undefined;
+    const currentVersion = device.firmware !== 'none' ? getFirmwareVersion(device) : undefined;
 
     const newVersion = customFirmware ? (
         <Translation id="TR_CUSTOM_FIRMWARE_VERSION" />
@@ -106,7 +101,7 @@ const FirmwareOffer = ({ device, customFirmware, targetFirmwareType }: Props) =>
 
     const parsedChangelog =
         !customFirmware && parseFirmwareChangelog(device.features, device.firmwareRelease);
-    const previousFirmwareType = `${getFwType(device)} `;
+    const previousFirmwareType = `${getFirmwareType(device)} `;
     const nextFirmwareType = targetFirmwareType || targetType;
     const formattedNextFirmwareType = nextFirmwareType ? `${nextFirmwareType} ` : '';
     const changelogUrl = getChangelogUrl(device);

--- a/packages/suite/src/components/firmware/ReconnectDevicePrompt.tsx
+++ b/packages/suite/src/components/firmware/ReconnectDevicePrompt.tsx
@@ -1,13 +1,13 @@
 import React from 'react';
 import styled, { css } from 'styled-components';
 import * as semver from 'semver';
+import { getDeviceModel, getFirmwareVersion } from '@trezor/device-utils';
 
 import { H1, Button, ConfirmOnDevice, variables } from '@trezor/components';
 import { Modal, Translation, WebUsbButton } from '@suite-components';
 import { DeviceConfirmImage } from '@suite-components/images/DeviceConfirmImage';
 import { DeviceAnimation } from '@onboarding-components/DeviceAnimation';
 import { useDevice, useFirmware } from '@suite-hooks';
-import { getDeviceModel, getFwVersion } from '@suite/utils/suite/device';
 import {
     useRebootRequest,
     RebootRequestedMode,
@@ -155,7 +155,7 @@ const ReconnectLabel = ({
     requestedMode: RebootRequestedMode;
     device?: TrezorDevice;
 }) => {
-    const deviceFwVersion = device?.features ? getFwVersion(device) : '';
+    const deviceFwVersion = device?.features ? getFirmwareVersion(device) : '';
     const deviceModel = device?.features ? getDeviceModel(device) : 'T';
 
     if (requestedMode === 'bootloader') {

--- a/packages/suite/src/components/guide/Feedback.tsx
+++ b/packages/suite/src/components/guide/Feedback.tsx
@@ -1,6 +1,7 @@
 import React, { useCallback, useEffect } from 'react';
 import styled, { css } from 'styled-components';
 import { analytics, EventType } from '@trezor/suite-analytics';
+import { getFirmwareType, getFirmwareVersion } from '@trezor/device-utils';
 
 import { CharacterCount, Translation } from '@suite-components';
 import { Textarea, Select, variables, Button, CollapsibleBox } from '@trezor/components';
@@ -10,8 +11,6 @@ import { ViewWrapper, Header, Content } from '@guide-components';
 import { Rating, FeedbackCategory, FeedbackType, UserData } from '@suite-common/suite-types';
 import { getEnvironment } from '@suite-utils/env';
 import { getUserAgent, getWindowHeight, getWindowWidth, getOsName } from '@trezor/env-utils';
-
-import { getFwType, getFwVersion } from '@suite-utils/device';
 
 const Headline = styled.div`
     font-size: ${variables.FONT_SIZE.TINY};
@@ -174,7 +173,7 @@ export const Feedback = ({ type }: FeedbackProps) => {
 
     let firmwareType = '';
     if (device?.features) {
-        firmwareType = getFwType(device);
+        firmwareType = getFirmwareType(device);
     }
 
     const onSubmit = useCallback(() => {
@@ -186,7 +185,7 @@ export const Feedback = ({ type }: FeedbackProps) => {
             suite_revision: process.env.COMMITHASH || '',
             window_dimensions: `${getWindowWidth()}x${getWindowHeight()}`,
             device_type: device?.features?.model || '',
-            firmware_version: device?.features ? getFwVersion(device) : '',
+            firmware_version: device?.features ? getFirmwareVersion(device) : '',
             firmware_revision: device?.features?.revision || '',
             firmware_type: firmwareType,
         };

--- a/packages/suite/src/components/guide/SupportFeedbackSelection.tsx
+++ b/packages/suite/src/components/guide/SupportFeedbackSelection.tsx
@@ -3,17 +3,17 @@ import { darken } from 'polished';
 import styled from 'styled-components';
 import { TREZOR_FORUM_URL, TREZOR_SUPPORT_URL } from '@trezor/urls';
 import { analytics, EventType } from '@trezor/suite-analytics';
+import { resolveStaticPath } from '@trezor/utils';
 
 import { Translation } from '@suite-components';
 import * as guideActions from '@suite-actions/guideActions';
 import { useActions, useSelector } from '@suite-hooks';
 import { Icon, Link, variables } from '@trezor/components';
 import { isDevEnv } from '@suite-common/suite-utils';
-import { resolveStaticPath } from '@trezor/utils';
-import { getFwVersion } from '@suite-utils/device';
 import { ViewWrapper, Header, Content } from '@guide-components';
 import { isDesktop } from '@suite-utils/env';
 import { UpdateState } from '@suite-reducers/desktopUpdateReducer';
+import { getFirmwareVersion } from '@trezor/device-utils';
 
 const Section = styled.div`
     & + & {
@@ -115,7 +115,7 @@ export const SupportFeedbackSelection = () => {
 
     const firmwareUpToDate = device?.firmware === 'valid';
     const firmwareVersion = device?.features ? (
-        getFwVersion(device) || <Translation id="TR_DEVICE_FW_UNKNOWN" />
+        getFirmwareVersion(device) || <Translation id="TR_DEVICE_FW_UNKNOWN" />
     ) : (
         <Translation id="TR_DEVICE_NOT_CONNECTED" />
     );

--- a/packages/suite/src/components/onboarding/DeviceAnimation/index.tsx
+++ b/packages/suite/src/components/onboarding/DeviceAnimation/index.tsx
@@ -2,11 +2,12 @@ import styled, { css } from 'styled-components';
 import React, { useEffect, useRef, useState } from 'react';
 import Lottie, { LottieOptions } from 'lottie-react';
 import * as semver from 'semver';
-import { useTheme } from '@trezor/components';
 import { resolveStaticPath } from '@trezor/utils';
-import { getDeviceModel, getFwVersion } from '@suite-utils/device';
+
+import { useTheme } from '@trezor/components';
 
 import type { TrezorDevice } from '@suite/types/suite';
+import { getDeviceModel, getFirmwareVersion } from '@trezor/device-utils';
 
 const Wrapper = styled.div<{ size?: number; shape?: Shape }>`
     width: 100%;
@@ -82,7 +83,7 @@ export const DeviceAnimation = ({
     const deviceModel = device?.features && getDeviceModel(device) === '1' ? '1' : 't';
 
     // T1 bootloader before firmware version 1.8.0 can only be invoked by holding both buttons
-    const deviceFwVersion = device?.features ? getFwVersion(device) : '';
+    const deviceFwVersion = device?.features ? getFirmwareVersion(device) : '';
     let animationType = type;
     if (
         type === 'BOOTLOADER' &&

--- a/packages/suite/src/components/suite/HomescreenGallery/index.tsx
+++ b/packages/suite/src/components/suite/HomescreenGallery/index.tsx
@@ -1,14 +1,14 @@
 import React from 'react';
 import styled from 'styled-components';
 import { analytics, EventType } from '@trezor/suite-analytics';
+import { resolveStaticPath } from '@trezor/utils';
 
 import { homescreensT1, homescreensT2 } from '@suite-constants';
-import { resolveStaticPath } from '@trezor/utils';
 import * as deviceSettingsActions from '@settings-actions/deviceSettingsActions';
 import { elementToHomescreen } from '@suite-utils/homescreen';
 import { AcquiredDevice } from '@suite-types';
 import { useActions } from '@suite-hooks';
-import { getDeviceModel } from '@suite-utils/device';
+import { getDeviceModel } from '@trezor/device-utils';
 
 type AnyImageName = typeof homescreensT1[number] | typeof homescreensT2[number];
 

--- a/packages/suite/src/components/suite/images/DeviceConfirmImage.tsx
+++ b/packages/suite/src/components/suite/images/DeviceConfirmImage.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 import { TrezorDevice } from '@suite-types';
 import { Image, ImageProps } from '@trezor/components';
 import { ImageType } from '@trezor/components/src/components/Image/Image';
-import { getDeviceModel } from '@suite-utils/device';
+import { getDeviceModel } from '@trezor/device-utils';
 
 const getImage = (majorVersion: '1' | 'T'): ImageType => {
     switch (majorVersion) {

--- a/packages/suite/src/hooks/firmware/useRebootRequest.ts
+++ b/packages/suite/src/hooks/firmware/useRebootRequest.ts
@@ -1,6 +1,6 @@
 import { useState, useEffect } from 'react';
 import { valid, satisfies } from 'semver';
-import { getFwVersion } from '@suite-utils/device';
+import { getFirmwareVersion } from '@trezor/device-utils';
 import type { TrezorDevice } from '@suite-types';
 import { useActions } from '@suite-hooks';
 import * as firmwareActions from '@firmware-actions/firmwareActions';
@@ -24,7 +24,7 @@ export const useRebootRequest = (
     // then the 'automatic' method is enabled.
     const [method, setMethod] = useState<RebootMethod>(() => {
         if (!device?.connected || !device?.features) return 'manual';
-        const deviceFwVersion = getFwVersion(device);
+        const deviceFwVersion = getFirmwareVersion(device);
         return requestedMode === 'bootloader' &&
             valid(deviceFwVersion) &&
             satisfies(deviceFwVersion, '>=1.10.0 <2.0.0')

--- a/packages/suite/src/middlewares/suite/analyticsMiddleware.ts
+++ b/packages/suite/src/middlewares/suite/analyticsMiddleware.ts
@@ -1,17 +1,17 @@
 import { MiddlewareAPI } from 'redux';
 import BigNumber from 'bignumber.js';
+import {
+    getBootloaderHash,
+    getBootloaderVersion,
+    getFirmwareRevision,
+    getFirmwareVersion,
+    isDeviceInBootloaderMode,
+} from '@trezor/device-utils';
 import { TRANSPORT, DEVICE } from '@trezor/connect';
 import { analytics, EventType } from '@trezor/suite-analytics';
 import { SUITE, ROUTER, ANALYTICS } from '@suite-actions/constants';
 import { DISCOVERY } from '@wallet-actions/constants';
-import {
-    getPhysicalDeviceCount,
-    getFwVersion,
-    isDeviceInBootloader,
-    getBootloaderVersion,
-    getFwRevision,
-    getBootloaderHash,
-} from '@suite-utils/device';
+import { getPhysicalDeviceCount } from '@suite-utils/device';
 import { getSuiteReadyPayload, redactTransactionIdFromAnchor } from '@suite-utils/analytics';
 
 import type { AppState, Action, Dispatch } from '@suite-types';
@@ -62,13 +62,13 @@ const analyticsMiddleware =
 
                 if (!features || !mode) return;
 
-                if (!isDeviceInBootloader(action.payload)) {
+                if (!isDeviceInBootloaderMode(action.payload)) {
                     analytics.report({
                         type: EventType.DeviceConnect,
                         payload: {
                             mode,
-                            firmware: getFwVersion(action.payload),
-                            firmwareRevision: getFwRevision(action.payload),
+                            firmware: getFirmwareVersion(action.payload),
+                            firmwareRevision: getFirmwareRevision(action.payload),
                             bootloaderHash: getBootloaderHash(action.payload),
                             backup_type: features.backup_type || 'Bip39',
                             pin_protection: features.pin_protection,
@@ -85,7 +85,7 @@ const analyticsMiddleware =
                         type: EventType.DeviceConnect,
                         payload: {
                             mode: 'bootloader',
-                            firmware: getFwVersion(action.payload),
+                            firmware: getFirmwareVersion(action.payload),
                             bootloader: getBootloaderVersion(action.payload),
                         },
                     });

--- a/packages/suite/src/middlewares/suite/sentryMiddleware.ts
+++ b/packages/suite/src/middlewares/suite/sentryMiddleware.ts
@@ -2,6 +2,7 @@ import { MiddlewareAPI } from 'redux';
 import { DEVICE, TRANSPORT } from '@trezor/connect';
 import { WALLET_SETTINGS } from '@settings-actions/constants';
 import * as walletSettingsActions from '@settings-actions/walletSettingsActions';
+import { getBootloaderVersion, getFirmwareVersion } from '@trezor/device-utils';
 
 import {
     SUITE,
@@ -12,7 +13,6 @@ import {
     MODAL,
     PROTOCOL,
 } from '@suite-actions/constants';
-import { getFwVersion, getBootloaderVersion } from '@suite-utils/device';
 import { getSuiteReadyPayload } from '@suite-utils/analytics';
 import { addSentryBreadcrumb, setSentryContext, setSentryTag } from '@suite-utils/sentry';
 
@@ -89,7 +89,7 @@ const sentryMiddleware =
 
                 setSentryContext(deviceContextName, {
                     mode,
-                    firmware: getFwVersion(action.payload),
+                    firmware: getFirmwareVersion(action.payload),
                     isBitcoinOnly: action.payload.firmwareType === 'bitcoin-only',
                     bootloader: getBootloaderVersion(action.payload),
                     model: features.model,

--- a/packages/suite/src/services/github.ts
+++ b/packages/suite/src/services/github.ts
@@ -1,4 +1,5 @@
-import { getFwType, getFwVersion, getDeviceModel } from '@suite-utils/device';
+import { getDeviceModel, getFirmwareType, getFirmwareVersion } from '@trezor/device-utils';
+
 import { isDesktop } from '@suite-utils/env';
 import { getUserAgent, getScreenWidth, getScreenHeight } from '@trezor/env-utils';
 import type { TrezorDevice } from '@suite-types';
@@ -14,7 +15,7 @@ const getDeviceInfo = (device?: TrezorDevice) => {
     if (!device?.features) {
         return '';
     }
-    return `model ${getDeviceModel(device)} ${getFwVersion(device)} ${getFwType(
+    return `model ${getDeviceModel(device)} ${getFirmwareVersion(device)} ${getFirmwareType(
         device,
     )} (revision ${device.features.revision})`;
 };

--- a/packages/suite/src/utils/firmware/index.ts
+++ b/packages/suite/src/utils/firmware/index.ts
@@ -1,6 +1,6 @@
 import { valid, satisfies } from 'semver';
 import type { AppState, TrezorDevice, ExtendedMessageDescriptor } from '@suite-types';
-import { getDeviceModel, getFwVersion } from '@suite-utils/device';
+import { getDeviceModel, getFirmwareVersion } from '@trezor/device-utils';
 
 export const getFormattedFingerprint = (fingerprint: string) =>
     [
@@ -81,7 +81,7 @@ export const validateFirmware = (
     }
 
     const deviceModel = getDeviceModel(device);
-    const deviceVersion = getFwVersion(device);
+    const deviceVersion = getFirmwareVersion(device);
     const format = parseFirmwareFormat(fw);
 
     if (!format) {

--- a/packages/suite/src/utils/suite/__fixtures__/device.ts
+++ b/packages/suite/src/utils/suite/__fixtures__/device.ts
@@ -161,7 +161,7 @@ const isSelectedInstance = [
     },
 ];
 
-const getVersion = [
+const getDeviceModel = [
     {
         description: `model T`,
         device: SUITE_DEVICE,
@@ -751,7 +751,7 @@ export default {
     isDeviceAccessible,
     isSelectedDevice,
     isSelectedInstance,
-    getVersion,
+    getDeviceModel,
     getNewInstanceNumber,
     getNewWalletNumber,
     findInstanceIndex,

--- a/packages/suite/src/utils/suite/__tests__/device.test.ts
+++ b/packages/suite/src/utils/suite/__tests__/device.test.ts
@@ -1,4 +1,5 @@
 import * as utils from '@suite-utils/device';
+import { getDeviceModel } from '@trezor/device-utils';
 import { AcquiredDevice } from '@suite-types';
 import fixtures from '../__fixtures__/device';
 
@@ -38,10 +39,11 @@ describe('isSelectedInstance', () => {
     });
 });
 
-describe('getVersion', () => {
-    fixtures.getVersion.forEach(f => {
+// getDeviceModel is not part of suite package. However, tests are dependant on definitions from suite package.
+describe('getDeviceModel', () => {
+    fixtures.getDeviceModel.forEach(f => {
         it(f.description, () => {
-            const instance = utils.getDeviceModel(f.device);
+            const instance = getDeviceModel(f.device);
             expect(instance).toEqual(f.result);
         });
     });

--- a/packages/suite/src/utils/suite/device.ts
+++ b/packages/suite/src/utils/suite/device.ts
@@ -1,5 +1,6 @@
-import { Device, KnownDevice, UnavailableCapability } from '@trezor/connect';
-import { TrezorDevice, AcquiredDevice, FirmwareType } from '@suite-types';
+import { Device, UnavailableCapability } from '@trezor/connect';
+import { TrezorDevice, AcquiredDevice } from '@suite-types';
+import { getDeviceModel } from '@trezor/device-utils';
 
 /**
  * Used in Welcome step in Onboarding
@@ -128,54 +129,6 @@ export const isSelectedDevice = (selected?: TrezorDevice | Device, device?: Trez
     if (!selected || !device) return false;
     if (!selected.id || selected.mode === 'bootloader') return selected.path === device.path;
     return selected.id === device.id;
-};
-
-export const isDeviceInBootloader = (device?: KnownDevice) => !!device?.features.bootloader_mode;
-
-export const getDeviceModel = (device: TrezorDevice): 'T' | '1' => {
-    const { features } = device;
-    return features && features.major_version > 1 ? 'T' : '1';
-};
-
-export const getFwRevision = (device?: KnownDevice) => device?.features.revision || '';
-
-export const getBootloaderHash = (device?: KnownDevice) => device?.features.bootloader_hash || '';
-
-export const getBootloaderVersion = (device?: KnownDevice) => {
-    if (!device?.features) {
-        return '';
-    }
-    const { features } = device;
-
-    if (isDeviceInBootloader(device) && features.major_version) {
-        return `${features.major_version}.${features.minor_version}.${features.patch_version}`;
-    }
-
-    return '';
-};
-
-export const getFwVersion = (device?: KnownDevice) => {
-    if (!device?.features) {
-        return '';
-    }
-    const { features } = device;
-
-    if (isDeviceInBootloader(device)) {
-        return features.fw_major
-            ? `${features.fw_major}.${features.fw_minor}.${features.fw_patch}`
-            : '';
-    }
-
-    return `${features.major_version}.${features.minor_version}.${features.patch_version}`;
-};
-
-export const getFwType = (device: KnownDevice) => {
-    if (isDeviceInBootloader(device)) {
-        return '';
-    }
-    return device.firmwareType === 'bitcoin-only'
-        ? FirmwareType.BitcoinOnly
-        : FirmwareType.Universal;
 };
 
 export const supportIntermediary = (features: TrezorDevice['features']) =>

--- a/packages/suite/src/utils/suite/logsUtils.ts
+++ b/packages/suite/src/utils/suite/logsUtils.ts
@@ -17,18 +17,18 @@ import {
     getWindowHeight,
     getWindowWidth,
 } from '@trezor/env-utils';
-import { getIsTorEnabled } from '@suite-utils/tor';
-import { DeepPartial } from '@trezor/type-utils';
-import { accountsActions } from '@suite-common/wallet-core';
 import {
     getBootloaderHash,
     getBootloaderVersion,
     getDeviceModel,
-    getFwRevision,
-    getFwType,
-    getFwVersion,
-    getPhysicalDeviceUniqueIds,
-} from './device';
+    getFirmwareRevision,
+    getFirmwareType,
+    getFirmwareVersion,
+} from '@trezor/device-utils';
+import { getIsTorEnabled } from '@suite-utils/tor';
+import { DeepPartial } from '@trezor/type-utils';
+import { accountsActions } from '@suite-common/wallet-core';
+import { getPhysicalDeviceUniqueIds } from './device';
 
 export const REDACTED_REPLACEMENT = '[redacted]';
 
@@ -212,9 +212,9 @@ export const getApplicationInfo = (state: AppState, hideSensitiveInfo: boolean) 
             connected: device.connected,
             passphraseProtection: device.features?.passphrase_protection,
             model: getDeviceModel(device),
-            firmware: device.features ? getFwVersion(device) : '',
-            firmwareRevision: device.features ? getFwRevision(device) : '',
-            firmwareType: device.features ? getFwType(device) : '',
+            firmware: device.features ? getFirmwareVersion(device) : '',
+            firmwareRevision: device.features ? getFirmwareRevision(device) : '',
+            firmwareType: device.features ? getFirmwareType(device) : '',
             bootloader: device.features ? getBootloaderVersion(device) : '',
             bootloaderHash: device.features ? getBootloaderHash(device) : '',
             numberOfWallets:

--- a/packages/suite/src/utils/suite/messageSystem.ts
+++ b/packages/suite/src/utils/suite/messageSystem.ts
@@ -1,8 +1,13 @@
 import * as semver from 'semver';
+import {
+    getBootloaderVersion,
+    getDeviceModel,
+    getFirmwareRevision,
+    getFirmwareVersion,
+} from '@trezor/device-utils';
 
 import { getEnvironment } from '@suite-utils/env';
 import { getBrowserName, getBrowserVersion, getOsName, getOsVersion } from '@trezor/env-utils';
-import { getBootloaderVersion, getDeviceModel, getFwRevision, getFwVersion } from './device';
 
 import type { TransportInfo } from '@trezor/connect';
 
@@ -119,9 +124,9 @@ export const validateDeviceCompatibility = (
         return false;
     }
 
-    const deviceFwVersion = getFwVersion(device);
+    const deviceFwVersion = getFirmwareVersion(device);
     const deviceBootloaderVersion = getBootloaderVersion(device);
-    const deviceFwRevision = getFwRevision(device);
+    const deviceFwRevision = getFirmwareRevision(device);
     const deviceFwVariant = device.firmwareType === 'bitcoin-only' ? 'bitcoin-only' : 'regular';
     const deviceModel = getDeviceModel(device).toLowerCase();
     const deviceVendor = device.features.vendor.toLowerCase();

--- a/packages/suite/src/views/onboarding/steps/Final/index.tsx
+++ b/packages/suite/src/views/onboarding/steps/Final/index.tsx
@@ -9,7 +9,7 @@ import { DeviceAnimation, OnboardingStepBox } from '@onboarding-components';
 import { useActions, useDevice, useOnboarding, useSelector } from '@suite-hooks';
 import * as deviceSettingsActions from '@settings-actions/deviceSettingsActions';
 import { DEFAULT_LABEL, MAX_LABEL_LENGTH } from '@suite-constants/device';
-import { getDeviceModel } from '@suite-utils/device';
+import { getDeviceModel } from '@trezor/device-utils';
 
 const Option = styled.div`
     display: flex;

--- a/packages/suite/src/views/onboarding/steps/Firmware/index.tsx
+++ b/packages/suite/src/views/onboarding/steps/Firmware/index.tsx
@@ -10,7 +10,7 @@ import {
 } from '@firmware-components';
 import { useSelector, useFirmware, useOnboarding } from '@suite-hooks';
 import { TrezorDevice } from '@suite-types';
-import { getFwType, getFwVersion } from '@suite-utils/device';
+import { getFirmwareType, getFirmwareVersion } from '@trezor/device-utils';
 
 const FirmwareStep = () => {
     const { device } = useSelector(state => ({
@@ -78,7 +78,10 @@ const FirmwareStep = () => {
                 description={
                     <Translation
                         id="TR_FIRMWARE_INSTALLED_TEXT"
-                        values={{ type: getFwType(device), version: getFwVersion(device) }}
+                        values={{
+                            type: getFirmwareType(device),
+                            version: getFirmwareVersion(device),
+                        }}
                     />
                 }
                 innerActions={

--- a/packages/suite/src/views/settings/device/FirmwareTypeChange.tsx
+++ b/packages/suite/src/views/settings/device/FirmwareTypeChange.tsx
@@ -5,10 +5,10 @@ import { Translation } from '@suite-components';
 import { ActionButton, ActionColumn, SectionItem, TextColumn } from '@suite-components/Settings';
 import { useDevice, useActions } from '@suite-hooks';
 import * as routerActions from '@suite-actions/routerActions';
-import { getFwType, getFwVersion } from '@suite-utils/device';
 import { Button } from '@trezor/components';
 import { useAnchor } from '@suite-hooks/useAnchor';
 import { SettingsAnchor } from '@suite-constants/anchors';
+import { getFirmwareType, getFirmwareVersion } from '@trezor/device-utils';
 
 const Version = styled.div`
     span {
@@ -38,8 +38,8 @@ export const FirmwareTypeChange = ({ isDeviceLocked }: FirmwareTypeProps) => {
         return null;
     }
 
-    const currentFwVersion = getFwVersion(device);
-    const currentFwType = getFwType(device);
+    const currentFwVersion = getFirmwareVersion(device);
+    const currentFwType = getFirmwareType(device);
     const actionButtonId =
         device.firmwareType === 'bitcoin-only' ? 'TR_SWITCH_TO_UNIVERSAL' : 'TR_SWITCH_TO_BITCOIN';
 

--- a/packages/suite/src/views/settings/device/FirmwareVersion.tsx
+++ b/packages/suite/src/views/settings/device/FirmwareVersion.tsx
@@ -1,11 +1,12 @@
 import React from 'react';
 import styled from 'styled-components';
+import { getFirmwareVersion } from '@trezor/device-utils';
 
 import { Translation, TrezorLink } from '@suite-components';
 import { ActionButton, ActionColumn, SectionItem, TextColumn } from '@suite-components/Settings';
 import { useDevice, useActions } from '@suite-hooks';
 import * as routerActions from '@suite-actions/routerActions';
-import { getChangelogUrl, getFwVersion, getFwUpdateVersion } from '@suite-utils/device';
+import { getChangelogUrl, getFwUpdateVersion } from '@suite-utils/device';
 import { Button, Tooltip } from '@trezor/components';
 import { AcquiredDevice } from '@suite-types';
 import { useAnchor } from '@suite-hooks/useAnchor';
@@ -65,7 +66,7 @@ export const FirmwareVersion = ({ isDeviceLocked }: FirmwareVersionProps) => {
         return null;
     }
 
-    const currentFwVersion = getFwVersion(device);
+    const currentFwVersion = getFirmwareVersion(device);
     const availableFwVersion = getFwUpdateVersion(device);
     const { revision } = device.features;
     const changelogUrl = getChangelogUrl(device, revision);

--- a/packages/suite/src/views/settings/device/Homescreen.tsx
+++ b/packages/suite/src/views/settings/device/Homescreen.tsx
@@ -9,7 +9,7 @@ import { variables } from '@trezor/components';
 import { useDevice, useActions } from '@suite-hooks';
 import * as modalActions from '@suite-actions/modalActions';
 import * as deviceSettingsActions from '@settings-actions/deviceSettingsActions';
-import { getDeviceModel } from '@suite-utils/device';
+import { getDeviceModel } from '@trezor/device-utils';
 import {
     elementToHomescreen,
     fileToDataUrl,

--- a/packages/suite/src/views/settings/device/SettingsDevice.tsx
+++ b/packages/suite/src/views/settings/device/SettingsDevice.tsx
@@ -5,8 +5,9 @@ import type { TransportInfo } from '@trezor/connect';
 import { SettingsLayout } from '@settings-components';
 import { Translation } from '@suite-components';
 import { SettingsSection, DeviceBanner } from '@suite-components/Settings';
-import { getDeviceModel, isDeviceRemembered } from '@suite-utils/device';
+import { isDeviceRemembered } from '@suite-utils/device';
 import { useDevice, useSelector } from '@suite-hooks';
+import { getDeviceModel } from '@trezor/device-utils';
 
 import { BackupRecoverySeed } from './BackupRecoverySeed';
 import { BackupFailed } from './BackupFailed';

--- a/packages/suite/tsconfig.json
+++ b/packages/suite/tsconfig.json
@@ -66,6 +66,7 @@
         { "path": "../components" },
         { "path": "../connect" },
         { "path": "../crypto-utils" },
+        { "path": "../device-utils" },
         { "path": "../dom-utils" },
         { "path": "../env-utils" },
         { "path": "../message-system" },

--- a/yarn.lock
+++ b/yarn.lock
@@ -7301,6 +7301,12 @@ __metadata:
   languageName: unknown
   linkType: soft
 
+"@trezor/device-utils@*, @trezor/device-utils@workspace:packages/device-utils":
+  version: 0.0.0-use.local
+  resolution: "@trezor/device-utils@workspace:packages/device-utils"
+  languageName: unknown
+  linkType: soft
+
 "@trezor/dom-utils@*, @trezor/dom-utils@workspace:packages/dom-utils":
   version: 0.0.0-use.local
   resolution: "@trezor/dom-utils@workspace:packages/dom-utils"
@@ -7765,6 +7771,7 @@ __metadata:
     "@trezor/components": "*"
     "@trezor/connect": 9.0.3
     "@trezor/crypto-utils": "*"
+    "@trezor/device-utils": "*"
     "@trezor/dom-utils": "*"
     "@trezor/env-utils": "*"
     "@trezor/message-system": "*"


### PR DESCRIPTION
## Description

- new package for device utils, some device utils moved from suite package
- done because I need them in connect for analytics
- for now, I moved only the most common ones which operate mostly only with device features 
- i believe in the future we can use those utils also in connect core
- I will refactor/extend it/test it during R model preparation

## Related Issue

Required for #5397
