### PR TITLE
chore(connect): disable experimental_features in atuhorizeCoinjoin

### DIFF
--- a/packages/connect/e2e/tests/device/authorizeCoinJoin.test.ts
+++ b/packages/connect/e2e/tests/device/authorizeCoinJoin.test.ts
@@ -9,9 +9,6 @@ describe('TrezorConnect.authorizeCoinJoin', () => {
     beforeAll(async () => {
         await setup(controller, {
             mnemonic: 'mnemonic_all',
-            settings: {
-                experimental_features: true,
-            },
         });
     });
 

--- a/packages/connect/src/api/authorizeCoinJoin.ts
+++ b/packages/connect/src/api/authorizeCoinJoin.ts
@@ -43,10 +43,6 @@ export default class AuthorizeCoinJoin extends AbstractMethod<
 
     async run() {
         const cmd = this.device.getCommands();
-        if (!this.device.features.experimental_features) {
-            // enable experimental features
-            await cmd.typedCall('ApplySettings', 'Success', { experimental_features: true });
-        }
 
         if (this.params.preauthorized) {
             try {


### PR DESCRIPTION
Related to https://github.com/trezor/trezor-suite/pull/6485
 `experimental_features` are no longer required by TrezorConnect.authorizeConjoin