### PR TITLE
fix(suite): add fallback value for lowestAnonymity

### DIFF
--- a/packages/suite/src/utils/wallet/coinjoinUtils.ts
+++ b/packages/suite/src/utils/wallet/coinjoinUtils.ts
@@ -140,7 +140,8 @@ export const getMaxRounds = (
     targetAnonymity: number,
     anonymitySet: Record<string, number | undefined>,
 ) => {
-    const lowestAnonymity = Math.min(...Object.values(anonymitySet).map(item => item ?? 1));
+    // fallback to 1 if any value is undefined or the object is empty
+    const lowestAnonymity = Math.min(...(Object.values(anonymitySet).map(item => item ?? 1) || 1));
     return Math.ceil((targetAnonymity - lowestAnonymity) / ESTIMATED_ANONYMITY_GAINED_PER_ROUND);
 };
 


### PR DESCRIPTION
## Description

Provide a fallback value of `1` for `lowestAnonymity` variable in `getMaxRounds` util. Without the fallback, if the `anonymitySet` argument was `{}`, the util returned incorrect value (`-Infinity`). In theory, `anonymitySet` should never be an empty object when coinjoin is available, but @mroz22 somehow got into this state during development. It was probably set [here](https://github.com/trezor/trezor-suite/blob/20159af6c91247d769232aa257ec10cd741d1426/packages/suite/src/actions/wallet/coinjoinClientActions.ts#L236) due to missing transaction history. Fallback value seems like a safer solution than throwing an error.

In other words, when lowest anonimity among UTXOs cannot be determined, use the lowest possible value, i.e. `1`.

## Screenshots (if appropriate):
Screenshot of the bug:
![image](https://user-images.githubusercontent.com/42465546/199262030-08080ace-d7c3-45b0-98e1-469e3709b741.png)

**QA:** I don't know how to reproduce the bug.
