### PR TITLE
Loading fix in AddCoinJoinAccountButton

### DIFF
--- a/packages/suite/src/components/suite/modals/AddAccount/components/AddCoinJoinAccountButton.tsx
+++ b/packages/suite/src/components/suite/modals/AddAccount/components/AddCoinJoinAccountButton.tsx
@@ -72,6 +72,11 @@ export const AddCoinJoinAccountButton = ({ network }: AddCoinJoinAccountProps) =
     });
 
     const onCreateCoinjoinAccountClick = async () => {
+        const createAccount = async () => {
+            await action.createCoinjoinAccount(network, 80);
+            setIsLoading(false);
+        };
+
         setIsLoading(true);
         // Checking if Tor is enable and if not open modal to force the user to enable it to use coinjoin.
         // Tor only works in desktop so checking we are running desktop.
@@ -89,7 +94,7 @@ export const AddCoinJoinAccountButton = ({ network }: AddCoinJoinAccountProps) =
                 return;
             }
             if (continueWithTor === RequestEnableTorResponse.Skip) {
-                action.createCoinjoinAccount(network, 80);
+                await createAccount();
                 return;
             }
 
@@ -101,7 +106,7 @@ export const AddCoinJoinAccountButton = ({ network }: AddCoinJoinAccountProps) =
             // When Tor was not loaded it means there was an error or user canceled it, stop the coinjoin account activation.
             if (!isTorLoaded) return;
         }
-        action.createCoinjoinAccount(network, 80);
+        await createAccount();
     };
 
     return (


### PR DESCRIPTION
## Description

Set `isLoading` to `false` when `createCoinjoinAccount` fails. Otherwise, a loading spinner stays there indefinitely which is confusing. This is just handling an edge case. I mocked failure of the `/status` call be throwing an error [here](https://github.com/trezor/trezor-suite/blob/develop/packages/coinjoin/src/client/coordinator.ts#L20). There is no way to test it without modifying code or interrupting the request.

## Screenshots (if appropriate):
Before:
![chrome-capture-2022-10-1 (1)](https://user-images.githubusercontent.com/42465546/199271400-171ee554-1dc1-4d7b-a1b0-1b7f5fc385f5.gif)
After:
![chrome-capture-2022-10-1](https://user-images.githubusercontent.com/42465546/199271519-605a1575-e36b-41f4-94f0-da894f3ef381.gif)

