### PR TITLE
chore(suite-native): Remove import another assets in onboarding

### DIFF
--- a/suite-native/module-accounts-import/src/components/AccountImportDetail.tsx
+++ b/suite-native/module-accounts-import/src/components/AccountImportDetail.tsx
@@ -29,10 +29,6 @@ type AccountImportDetailProps = {
     accountInfo: AccountInfo;
 };
 
-const importAnotherButtonStyle = prepareNativeStyle(utils => ({
-    marginTop: utils.spacings.large,
-    marginBottom: utils.spacings.medium,
-}));
 const contentWrapperStyle = prepareNativeStyle(_ => ({
     width: '100%',
     flex: 1,
@@ -100,14 +96,6 @@ export const AccountImportDetail = ({ networkSymbol, accountInfo }: AccountImpor
                         currencySymbol={networkSymbol}
                     />
                     <Divider />
-                    <Button
-                        style={applyStyle(importAnotherButtonStyle)}
-                        onPress={() => navigation.goBack()}
-                        size="large"
-                        colorScheme="gray"
-                    >
-                        Import another
-                    </Button>
                     <Button
                         onPress={handleImportAccount}
                         size="large"


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Remove button to import another asset in onboarding since this could be confusing in onboarding right now until we have functionality for importing multiple assets within single import flow. This is done by @mnuky's request from #6729 


## Screenshots (if appropriate):
<img width="275" alt="image" src="https://user-images.githubusercontent.com/36101761/199452670-0101de63-5af3-49a9-b927-60c84983cc96.png">
