### PR TITLE
Feat/strict round select

### DIFF
--- a/packages/coinjoin/src/client/round/selectRound.ts
+++ b/packages/coinjoin/src/client/round/selectRound.ts
@@ -135,6 +135,18 @@ export const selectUtxoForRound = async (
                         scriptType: account.scriptType,
                         anonymitySet: utxo.anonymityLevel,
                     }));
+
+                    // skip Round candidate if fees are greater than allowed by account
+                    if (
+                        roundParameters.miningFeeRate > account.maxFeePerKvbyte ||
+                        roundParameters.coordinationFeeRate.rate > account.maxCoordinatorFeeRate
+                    ) {
+                        options.log(
+                            `Skipping round ~~${round.id}~~ for ~~${account.accountKey}~~. Fees to high ${roundParameters.miningFeeRate} ${roundParameters.coordinationFeeRate.rate}`,
+                        );
+                        return [];
+                    }
+
                     // TODO: check account maxMining rate vs round miningRate + maxCoordinator rate vs round coordinationFeeRate
                     // ...finally call CoinjoinRound + Account + Round combination on middleware
                     return middleware
@@ -153,7 +165,7 @@ export const selectUtxoForRound = async (
     const sumUtxosInRounds = utxoSelection.map(acc => acc.reduce((a, b) => a + b.length, 0));
     const maxUtxosInRound = Math.max(...sumUtxosInRounds);
     if (maxUtxosInRound < 1) {
-        options.log('No results for selectUtxoForRound');
+        options.log('No results from selectUtxoForRound');
         return;
     }
 

--- a/packages/suite/src/services/coinjoin/config.ts
+++ b/packages/suite/src/services/coinjoin/config.ts
@@ -88,6 +88,10 @@ export const DEFAULT_MAX_MINING_FEE = 3;
 // TODO: this value is supplied by the coordinator, but not saved yet; replace the hard-coded value with data fetched from coordinator
 export const UTXO_AMOUNT_THRESHOLD_FOR_COINJOIN = 5000;
 
+// coordinator fee rate from status format (0.003)
+// firmware format (300 000 = 0.003 * 10 ** 8)
+export const COORDINATOR_FEE_RATE_MULTIPLIER = 10 ** 8;
+
 export const getCoinjoinConfig = (
     network: NetworkSymbol,
     environment?: CoinjoinServerEnvironment,

--- a/packages/suite/src/views/wallet/anonymize/components/CoinjoinSetupStrategies.tsx
+++ b/packages/suite/src/views/wallet/anonymize/components/CoinjoinSetupStrategies.tsx
@@ -112,7 +112,7 @@ export const CoinjoinSetupStrategies = ({ account }: CoinjoinSetupStrategiesProp
     const toggleTermsConfirmation = () => setTermsConfirmed(current => !current);
     const anonymize = () =>
         actions.startCoinjoinSession(account, {
-            maxCoordinatorFeeRate: coordinatorData.coordinatorFeeRate * 10 ** 8, // transform to a format used by firmware (from percent/100 to 10**6 percent)
+            maxCoordinatorFeeRate: coordinatorData.coordinatorFeeRate,
             maxFeePerKvbyte:
                 (isCustom ? customMaxFee : coordinatorData.feeRatesMedians[strategy]) * 1000, // transform to kvB
             maxRounds,


### PR DESCRIPTION
First fix for coinjoin :) probably needs to be cherry-picked

I've totally missed round fees validation in `selectRound` phase

if you set low custom fee rate in coinjoin setup (lower than 129)  selectRound should skip rounds with higher rates