### PR TITLE
feat(suite): access allowedInputAmounts from coinjoin status

### DIFF
--- a/packages/coinjoin/src/client/Status.ts
+++ b/packages/coinjoin/src/client/Status.ts
@@ -1,7 +1,7 @@
 import { EventEmitter } from 'events';
 
 import * as coordinator from './coordinator';
-import { findNearestDeadline, getCoordinatorFeeRate } from '../utils/roundUtils';
+import { findNearestDeadline, getDataFromRounds } from '../utils/roundUtils';
 import { STATUS_TIMEOUT } from '../constants';
 import { CoinjoinClientSettings, CoinjoinStatusEvent } from '../types';
 import { Round, RoundPhase } from '../types/coordinator';
@@ -114,7 +114,7 @@ export class Status extends EventEmitter {
                     rounds: status.roundStates,
                     changed,
                     feeRatesMedians: status.coinJoinFeeRateMedians,
-                    coordinatorFeeRate: getCoordinatorFeeRate(status.roundStates),
+                    ...getDataFromRounds(status.roundStates),
                 };
                 this.emit('update', statusEvent);
                 return statusEvent;

--- a/packages/coinjoin/src/constants.ts
+++ b/packages/coinjoin/src/constants.ts
@@ -21,3 +21,9 @@ export const ROUND_REGISTRATION_END_OFFSET = 2000;
 
 // do not register into Round if round.inputRegistrationEnd is below offset
 export const ROUND_SELECTION_REGISTRATION_OFFSET = 30000;
+
+// fallback values for status request
+// usage of these values is extremely unlikely, there would have to be a change in the coordinator's API
+export const MAX_COORDINATOR_FEE_RATE = 0.003;
+export const MIN_ALLOWED_AMOUNT = 5000;
+export const MAX_ALLOWED_AMOUNT = 134375000000;

--- a/packages/coinjoin/src/types/client.ts
+++ b/packages/coinjoin/src/types/client.ts
@@ -1,8 +1,9 @@
-import { Round, FeeRateMedians } from './coordinator';
+import { AllowedRange, Round, FeeRateMedians } from './coordinator';
 
 export interface CoinjoinStatusEvent {
     rounds: Round[];
     changed: Round[];
     feeRatesMedians: FeeRateMedians[];
     coordinatorFeeRate: number;
+    allowedInputAmounts: AllowedRange;
 }

--- a/packages/coinjoin/tests/client/Status.test.ts
+++ b/packages/coinjoin/tests/client/Status.test.ts
@@ -139,6 +139,7 @@ describe('Status', () => {
                     {
                         Type: 'RoundCreated',
                         roundParameters: {
+                            allowedInputAmounts: {},
                             coordinationFeeRate: {},
                             connectionConfirmationTimeout: '0d 0h 0m 5s',
                             outputRegistrationTimeout: '0d 0h 0m 2s',

--- a/packages/suite/src/reducers/wallet/coinjoinReducer.ts
+++ b/packages/suite/src/reducers/wallet/coinjoinReducer.ts
@@ -11,6 +11,7 @@ import {
     transformCoinjoinStatus,
 } from '@wallet-utils/coinjoinUtils';
 import { selectSelectedAccount } from './selectedAccountReducer';
+import { CoinjoinStatusEvent } from '@trezor/coinjoin';
 
 export interface CoinjoinClientFeeRatesMedians {
     fast: number;
@@ -21,6 +22,7 @@ export interface CoinjoinClientInstance {
     rounds: { id: string; phase: RoundPhase }[]; // store only slice of Round in reducer. may be extended in the future
     feeRatesMedians: CoinjoinClientFeeRatesMedians;
     coordinatorFeeRate: number;
+    allowedInputAmounts: CoinjoinStatusEvent['allowedInputAmounts'];
     log: { time: number; value: string }[];
 }
 

--- a/packages/suite/src/services/coinjoin/config.ts
+++ b/packages/suite/src/services/coinjoin/config.ts
@@ -84,10 +84,6 @@ export const ESTIMATED_HOURS_BUFFER_MODIFIER = 0.25;
 export const RECOMMENDED_SKIP_ROUNDS = [4, 5] as [number, number];
 export const DEFAULT_MAX_MINING_FEE = 3;
 
-// lowest amount of satoshis in UTXO allowed for coinjoin
-// TODO: this value is supplied by the coordinator, but not saved yet; replace the hard-coded value with data fetched from coordinator
-export const UTXO_AMOUNT_THRESHOLD_FOR_COINJOIN = 5000;
-
 // coordinator fee rate from status format (0.003)
 // firmware format (300 000 = 0.003 * 10 ** 8)
 export const COORDINATOR_FEE_RATE_MULTIPLIER = 10 ** 8;

--- a/packages/suite/src/support/messages.ts
+++ b/packages/suite/src/support/messages.ts
@@ -5622,9 +5622,14 @@ export default defineMessages({
         defaultMessage: 'Registered in CoinJoin',
         description: 'Tooltip over an icon in Coin control section',
     },
-    TR_UNAVAILABLE_FOR_COINJOIN: {
-        id: 'TR_UNAVAILABLE_FOR_COINJOIN',
-        defaultMessage: 'Not available for CoinJoin - amount too small',
+    TR_AMOUNT_TOO_SMALL_FOR_COINJOIN: {
+        id: 'TR_AMOUNT_TOO_SMALL_FOR_COINJOIN',
+        defaultMessage: 'Not available for CoinJoin - amount too small.',
+        description: 'Tooltip over an icon in Coin control section',
+    },
+    TR_AMOUNT_TOO_BIG_FOR_COINJOIN: {
+        id: 'TR_AMOUNT_TOO_BIG_FOR_COINJOIN',
+        defaultMessage: 'Not available for CoinJoin - amount too big.',
         description: 'Tooltip over an icon in Coin control section',
     },
     TR_CHANGE_ADDRESS_TOOLTIP: {

--- a/packages/suite/src/utils/wallet/coinjoinUtils.ts
+++ b/packages/suite/src/utils/wallet/coinjoinUtils.ts
@@ -89,6 +89,7 @@ export const transformCoinjoinStatus = (event: CoinjoinStatusEvent) => ({
     rounds: event.rounds.map(r => ({ id: r.id, phase: r.phase })),
     coordinatorFeeRate: event.coordinatorFeeRate,
     feeRatesMedians: transformFeeRatesMedians(event.feeRatesMedians),
+    allowedInputAmounts: event.allowedInputAmounts,
 });
 
 // convert suite account type to @trezor/coinjoin RegisterAccountParams scriptType


### PR DESCRIPTION
## Description

- replace hard-coded value for minimum UTXO amount available for CoinJoin with data received from coordinator
- add max amount value as well

## Related Issue

Resolve #6756 

## Screenshots (if appropriate):
![Screenshot 2022-11-02 at 18 01 20](https://user-images.githubusercontent.com/42465546/199554046-55ada134-ac20-492c-83ae-ba79c3426a01.png)
