### PR TITLE
Coinjoin should be paused when Tor disable

### DIFF
--- a/packages/suite/src/actions/wallet/coinjoinAccountActions.ts
+++ b/packages/suite/src/actions/wallet/coinjoinAccountActions.ts
@@ -93,11 +93,12 @@ const coinjoinAccountPreloading = (isPreloading: boolean) =>
         },
     } as const);
 
-const coinjoinSessionPause = (accountKey: string) =>
+const coinjoinSessionPause = (accountKey: string, interrupted: boolean) =>
     ({
         type: COINJOIN.SESSION_PAUSE,
         payload: {
             accountKey,
+            interrupted,
         },
     } as const);
 
@@ -471,13 +472,13 @@ export const startCoinjoinSession =
 
 // called from coinjoin account UI or exceptions like device disconnection, forget wallet/account etc.
 export const pauseCoinjoinSession =
-    (accountKey: string) => (dispatch: Dispatch, getState: GetState) => {
+    (accountKey: string, interrupted = false) =>
+    (dispatch: Dispatch, getState: GetState) => {
         const account = selectAccountByKey(getState(), accountKey);
 
         if (!account) {
             return;
         }
-
         // get @trezor/coinjoin client if available
         const client = getCoinjoinClient(account.symbol);
 
@@ -485,7 +486,7 @@ export const pauseCoinjoinSession =
         client?.unregisterAccount(accountKey);
 
         // dispatch data to reducer
-        dispatch(coinjoinSessionPause(accountKey));
+        dispatch(coinjoinSessionPause(accountKey, interrupted));
     };
 
 export const pauseCoinjoinSessionByDeviceId =
@@ -512,7 +513,7 @@ export const pauseCoinjoinSessionByDeviceId =
                 client?.unregisterAccount(account.key);
 
                 // dispatch data to reducer
-                dispatch(coinjoinSessionPause(account.key));
+                dispatch(coinjoinSessionPause(account.key, false));
             }
         });
     };
@@ -584,6 +585,42 @@ export const restoreCoinjoinSession =
                 }),
             );
         }
+    };
+
+export const pauseInterruptAllCoinjoinSessions = () => (dispatch: Dispatch, getState: GetState) => {
+    const {
+        wallet: { accounts, coinjoin },
+    } = getState();
+
+    const coinjoinAccounts = accounts.filter(a => a.accountType === 'coinjoin');
+
+    coinjoinAccounts.forEach(account => {
+        const isAccountWithSession = coinjoin.accounts.find(
+            a => a.key === account.key && a.session && !a.session.paused,
+        );
+        if (isAccountWithSession) {
+            dispatch(pauseCoinjoinSession(account.key, true));
+        }
+    });
+};
+
+export const restoreAllInterruptedCoinjoinSession =
+    () => (dispatch: Dispatch, getState: GetState) => {
+        const {
+            wallet: { accounts, coinjoin },
+        } = getState();
+
+        const coinjoinAccounts = accounts.filter(a => a.accountType === 'coinjoin');
+
+        coinjoinAccounts.forEach(account => {
+            const isAccountWithPausedSessionInterrupted = coinjoin.accounts.find(
+                a =>
+                    a.key === account.key && a.session && a.session.paused && a.session.interrupted,
+            );
+            if (isAccountWithPausedSessionInterrupted) {
+                dispatch(restoreCoinjoinSession(account.key));
+            }
+        });
     };
 
 // called from coinjoin account UI or exceptions like device disconnection, forget wallet/account etc.

--- a/packages/suite/src/components/wallet/AccountAnnouncement/TorDisconnected.tsx
+++ b/packages/suite/src/components/wallet/AccountAnnouncement/TorDisconnected.tsx
@@ -1,0 +1,35 @@
+import React from 'react';
+import { NotificationCard, Translation } from '@suite-components';
+import { useActions, useSelector } from '@suite-hooks';
+import * as suiteActions from '@suite-actions/suiteActions';
+import { selectTorState } from '@suite-reducers/suiteReducer';
+
+export const TorDisconnected = () => {
+    const { isTorLoading } = useSelector(selectTorState);
+
+    const { toggleTor } = useActions({
+        toggleTor: suiteActions.toggleTor,
+    });
+
+    return (
+        <NotificationCard
+            variant="warning"
+            button={{
+                onClick: () => toggleTor(true),
+                isLoading: isTorLoading,
+                children: isTorLoading ? (
+                    <Translation id="TR_ENABLING_TOR" />
+                ) : (
+                    <Translation id="TR_TOR_ENABLE" />
+                ),
+            }}
+        >
+            <Translation
+                id="TR_TOR_REQUEST_ENABLE_FOR_COIN_JOIN_TITLE"
+                values={{
+                    b: chunks => <b>{chunks}</b>,
+                }}
+            />
+        </NotificationCard>
+    );
+};

--- a/packages/suite/src/components/wallet/AccountAnnouncement/TorDisconnected.tsx
+++ b/packages/suite/src/components/wallet/AccountAnnouncement/TorDisconnected.tsx
@@ -3,13 +3,16 @@ import { NotificationCard, Translation } from '@suite-components';
 import { useActions, useSelector } from '@suite-hooks';
 import * as suiteActions from '@suite-actions/suiteActions';
 import { selectTorState } from '@suite-reducers/suiteReducer';
+import { selectIsCoinjoinBlockedByTor } from '@wallet-reducers/coinjoinReducer';
 
 export const TorDisconnected = () => {
     const { isTorLoading } = useSelector(selectTorState);
-
+    const isCoinjoinBlockedByTor = useSelector(selectIsCoinjoinBlockedByTor);
     const { toggleTor } = useActions({
         toggleTor: suiteActions.toggleTor,
     });
+
+    if (!isCoinjoinBlockedByTor) return null;
 
     return (
         <NotificationCard

--- a/packages/suite/src/components/wallet/CoinjoinSummary/BalanceSection.tsx
+++ b/packages/suite/src/components/wallet/CoinjoinSummary/BalanceSection.tsx
@@ -5,10 +5,11 @@ import { useDispatch } from 'react-redux';
 import { goto } from '@suite-actions/routerActions';
 import { Card, Translation } from '@suite-components';
 import { useSelector } from '@suite-hooks';
-import { Button, variables } from '@trezor/components';
+import { variables, TooltipButton } from '@trezor/components';
 import {
     selectCoinjoinAccountByKey,
     selectCurrentCoinjoinBalanceBreakdown,
+    selectIsCoinjoinBlockedByTor,
 } from '@wallet-reducers/coinjoinReducer';
 import { BalancePrivacyBreakdown } from './BalancePrivacyBreakdown';
 import { CoinjoinStatus } from './CoinjoinStatus';
@@ -21,7 +22,7 @@ const Container = styled(Card)`
     margin-bottom: 10px;
 `;
 
-const AnonymizeButton = styled(Button)`
+const AnonymizeButton = styled(TooltipButton)`
     justify-content: space-between;
     width: 154px;
     height: 46px;
@@ -41,6 +42,7 @@ interface BalanceSectionProps {
 export const BalanceSection = ({ accountKey }: BalanceSectionProps) => {
     const coinjoinAccount = useSelector(state => selectCoinjoinAccountByKey(state, accountKey));
     const { notAnonymized } = useSelector(selectCurrentCoinjoinBalanceBreakdown);
+    const isCoinJoinBlocked = useSelector(selectIsCoinjoinBlockedByTor);
 
     const dispatch = useDispatch();
 
@@ -65,8 +67,14 @@ export const BalanceSection = ({ accountKey }: BalanceSectionProps) => {
             <AnonymizeButton
                 onClick={goToSetup}
                 icon="ARROW_RIGHT_LONG"
+                isDisabled={isCoinJoinBlocked}
                 alignIcon="right"
                 size={16}
+                tooltipContent={
+                    isCoinJoinBlocked && (
+                        <Translation id="TR_UNAVAILABLE_COINJOIN_TOR_DISABLE_TOOLTIP" />
+                    )
+                }
             >
                 <Translation id="TR_ANONYMIZE" />
             </AnonymizeButton>

--- a/packages/suite/src/components/wallet/WalletLayout/components/AccountBanners.tsx
+++ b/packages/suite/src/components/wallet/WalletLayout/components/AccountBanners.tsx
@@ -9,6 +9,7 @@ import DeviceUnavailable from '../../AccountMode/DeviceUnavailable';
 import XRPReserve from '../../AccountAnnouncement/XRPReserve';
 import AccountImported from '../../AccountAnnouncement/AccountImported';
 import AccountOutOfSync from '../../AccountAnnouncement/AccountOutOfSync';
+import { TorDisconnected } from '@wallet-components/AccountAnnouncement/TorDisconnected';
 
 const BannersWrapper = styled.div`
     display: flex;
@@ -28,6 +29,7 @@ export const AccountBanners = ({ account }: AccountBannersProps) => (
         <AuthConfirmFailed />
         <BackendDisconnected />
         <DeviceUnavailable />
+        <TorDisconnected />
         <XRPReserve account={account} />
         <AccountImported account={account} />
         <AccountOutOfSync account={account} />

--- a/packages/suite/src/middlewares/wallet/coinjoinMiddleware.ts
+++ b/packages/suite/src/middlewares/wallet/coinjoinMiddleware.ts
@@ -69,5 +69,15 @@ export const coinjoinMiddleware =
             }
         }
 
+        if (action.type === SUITE.TOR_STATUS) {
+            if (['Disabling', 'Disabled', 'Error'].includes(action.payload)) {
+                api.dispatch(coinjoinAccountActions.pauseInterruptAllCoinjoinSessions());
+            }
+            // We restore sessions that were interrupted when successfully Enabled, not when Enabling.
+            if (action.payload === 'Enabled') {
+                api.dispatch(coinjoinAccountActions.restoreAllInterruptedCoinjoinSession());
+            }
+        }
+
         return action;
     };

--- a/packages/suite/src/reducers/suite/suiteReducer.ts
+++ b/packages/suite/src/reducers/suite/suiteReducer.ts
@@ -245,4 +245,9 @@ export const selectTorState = createSelector(
     }),
 );
 
+export const selectDebug = createSelector(
+    (state: SuiteRootState) => state.suite.settings.debug,
+    debug => debug,
+);
+
 export default suiteReducer;

--- a/packages/suite/src/reducers/wallet/coinjoinReducer.ts
+++ b/packages/suite/src/reducers/wallet/coinjoinReducer.ts
@@ -11,8 +11,9 @@ import {
     transformCoinjoinStatus,
 } from '@wallet-utils/coinjoinUtils';
 import { ESTIMATED_ROUNDS_FAIL_RATE_BUFFER } from '@suite/services/coinjoin/config';
-import { selectSelectedAccount } from './selectedAccountReducer';
+import { selectSelectedAccount, selectSelectedAccountParams } from './selectedAccountReducer';
 import { CoinjoinStatusEvent } from '@trezor/coinjoin';
+import { selectDebug, selectTorState } from '@suite-reducers/suiteReducer';
 
 export interface CoinjoinClientFeeRatesMedians {
     fast: number;
@@ -366,5 +367,20 @@ export const selectCurrentTargetAnonymity = createSelector(
         const { targetAnonymity } = currentCoinjoinAccount || {};
 
         return targetAnonymity;
+    },
+);
+
+export const selectIsCoinjoinBlockedByTor = createSelector(
+    [selectSelectedAccountParams, selectTorState, selectDebug],
+    (accountParams, { isTorEnabled }, debug) => {
+        if (!accountParams) {
+            return false;
+        }
+
+        if (debug.coinjoinAllowNoTor) {
+            return false;
+        }
+
+        return accountParams.accountType === 'coinjoin' && !isTorEnabled;
     },
 );

--- a/packages/suite/src/reducers/wallet/coinjoinReducer.ts
+++ b/packages/suite/src/reducers/wallet/coinjoinReducer.ts
@@ -175,6 +175,7 @@ const pauseSession = (
     delete account.session.sessionDeadline;
     account.session.registeredUtxos = [];
     account.session.paused = true;
+    account.session.interrupted = payload.interrupted;
     account.session.timeEnded = Date.now();
 };
 
@@ -186,6 +187,7 @@ const restoreSession = (
     if (!account || !account.session) return;
 
     delete account.session.paused;
+    delete account.session.interrupted;
     delete account.session.timeEnded;
     account.session.timeCreated = Date.now();
 };

--- a/packages/suite/src/reducers/wallet/selectedAccountReducer.ts
+++ b/packages/suite/src/reducers/wallet/selectedAccountReducer.ts
@@ -23,4 +23,7 @@ const selectedAccountReducer = (state: State = initialState, action: Action): St
 export const selectSelectedAccount = (state: SelectedAccountRootState) =>
     state.wallet.selectedAccount.account;
 
+export const selectSelectedAccountParams = (state: SelectedAccountRootState) =>
+    state.wallet.selectedAccount.params;
+
 export default selectedAccountReducer;

--- a/packages/suite/src/support/messages.ts
+++ b/packages/suite/src/support/messages.ts
@@ -3870,6 +3870,10 @@ export default defineMessages({
         id: 'TR_TOR_DISABLE_ONIONS_ONLY_NO_MORE_DESCRIPTION',
         defaultMessage: 'You can safely disable Tor now.',
     },
+    TR_UNAVAILABLE_COINJOIN_TOR_DISABLE_TOOLTIP: {
+        id: 'TR_UNAVAILABLE_COINJOIN_TOR_DISABLE_TOOLTIP',
+        defaultMessage: 'Unavailable. Tor is disabled.',
+    },
     TR_ONION_BACKEND_TOR_NEEDED: {
         id: 'TR_ONION_BACKEND_TOR_NEEDED',
         defaultMessage:

--- a/packages/suite/src/views/wallet/anonymize/components/CoinjoinSetupStrategies.tsx
+++ b/packages/suite/src/views/wallet/anonymize/components/CoinjoinSetupStrategies.tsx
@@ -15,6 +15,7 @@ import { CryptoAmountWithHeader } from '@wallet-components/PrivacyAccount/Crypto
 import {
     selectCurrentCoinjoinBalanceBreakdown,
     selectCurrentTargetAnonymity,
+    selectIsCoinjoinBlockedByTor,
 } from '@wallet-reducers/coinjoinReducer';
 import { calculateServiceFee, getMaxRounds } from '@wallet-utils/coinjoinUtils';
 import { CoinjoinCustomStrategy } from './CoinjoinCustomStrategy';
@@ -86,6 +87,7 @@ export const CoinjoinSetupStrategies = ({ account }: CoinjoinSetupStrategiesProp
     const { notAnonymized } = useSelector(selectCurrentCoinjoinBalanceBreakdown);
     const accountTransactions = useSelector(state => selectAccountTransactions(state, account.key));
     const { isLocked } = useDevice();
+    const isCoinJoinBlockedByTor = useSelector(selectIsCoinjoinBlockedByTor);
 
     const anonymitySet = account.addresses?.anonymitySet;
 
@@ -109,10 +111,16 @@ export const CoinjoinSetupStrategies = ({ account }: CoinjoinSetupStrategiesProp
     const isCustom = strategy === 'custom';
     const allChecked = connectedConfirmed && termsConfirmed;
     const allAnonymized = notAnonymized === '0';
-    const isDisabled = !allChecked || allAnonymized || isLocked(false);
+    const isDisabled = !allChecked || allAnonymized || isLocked(false) || isCoinJoinBlockedByTor;
 
-    let buttonTooltipMessage: 'TR_NOTHING_TO_ANONYMIZE' | 'TR_CONFIRM_CONDITIONS' | undefined;
-    if (allAnonymized) {
+    let buttonTooltipMessage:
+        | 'TR_NOTHING_TO_ANONYMIZE'
+        | 'TR_CONFIRM_CONDITIONS'
+        | 'TR_UNAVAILABLE_COINJOIN_TOR_DISABLE_TOOLTIP'
+        | undefined;
+    if (isCoinJoinBlockedByTor) {
+        buttonTooltipMessage = 'TR_UNAVAILABLE_COINJOIN_TOR_DISABLE_TOOLTIP';
+    } else if (allAnonymized) {
         buttonTooltipMessage = 'TR_NOTHING_TO_ANONYMIZE';
     } else if (!termsConfirmed) {
         buttonTooltipMessage = 'TR_CONFIRM_CONDITIONS';

--- a/suite-common/wallet-types/src/coinjoin.ts
+++ b/suite-common/wallet-types/src/coinjoin.ts
@@ -26,6 +26,7 @@ export interface CoinjoinSession extends CoinjoinSessionParameters {
     timeCreated: number; // timestamp when was created
     timeEnded?: number; // timestamp when was finished
     paused?: boolean; // current state
+    interrupted?: boolean; // it was paused by force
     phase?: RoundPhase; // current phase enum
     phaseDeadline: string | number; // estimated time for phase change
     sessionDeadline?: string | number; // estimated time for a session's end


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Pause CoinJoin sessions when after creating CoinJoin account Tor is disable.
* Pause running CoinJoin when Tor is disable (because of user action or for any other reason)
* When user goes to CoinJoin account a banner explaining that CoinJoin is paused because of Tor being disable
* The button pause/resume in CoinJoin account should be disable



## Related Issue

Resolve https://github.com/trezor/trezor-suite/issues/6418

## Screenshots (if appropriate):
![image](https://user-images.githubusercontent.com/5362163/204305468-c5b896dc-a806-4579-b34d-dda26fefbb98.png)
![image](https://user-images.githubusercontent.com/5362163/205286485-499484eb-2828-4a69-bacf-13b0c221cbfe.png)

