### PR TITLE
fix(graph): Add zero fiat rates fallback for coins without ticker config

### DIFF
--- a/suite-native/module-home/src/components/PortfolioGraph.tsx
+++ b/suite-native/module-home/src/components/PortfolioGraph.tsx
@@ -2,6 +2,7 @@ import React, { useCallback, useEffect, useMemo, useState } from 'react';
 import { useDispatch, useSelector } from 'react-redux';
 
 import { useAtom } from 'jotai';
+import { useFocusEffect } from '@react-navigation/native';
 
 import {
     enhanceGraphPoints,
@@ -51,9 +52,11 @@ export const PortfolioGraph = () => {
         );
     }, [selectedTimeFrame, fiatCurrency, dispatch]);
 
-    useEffect(() => {
+    const fetchGraphPoints = useCallback(() => {
         handleFetchGraphPoints();
     }, [handleFetchGraphPoints]);
+
+    useFocusEffect(fetchGraphPoints);
 
     const handleSelectTimeFrame = useCallback((timeFrame: LineGraphTimeFrameValues) => {
         setSelectedTimeFrame(timeFrame);


### PR DESCRIPTION
Fix for BTC TEST (and other coins without ticker config). Fallback to 0 fiat currency rates.

Also added a focus effect for the portfolio graph because graph was not re-fetched after redirecting from asset import to portfolio screen.

Resolve [6802](https://github.com/trezor/trezor-suite/issues/6802)