### PR TITLE
fix(coinjoin): prevent meaningless warning on slider

### DIFF
--- a/packages/components/src/components/form/Range/Range.tsx
+++ b/packages/components/src/components/form/Range/Range.tsx
@@ -27,7 +27,7 @@ type RangeProps = {
     className?: string;
     max?: number;
     min?: number;
-    step?: number;
+    step?: string;
     onChange: React.ChangeEventHandler<HTMLInputElement>;
     thumbStyle?: CSSObject;
     trackStyle?: CSSObject;

--- a/packages/suite/src/components/wallet/PrivacyAccount/AnonymityLevelSlider.tsx
+++ b/packages/suite/src/components/wallet/PrivacyAccount/AnonymityLevelSlider.tsx
@@ -104,7 +104,7 @@ export const AnonymityLevelSlider = ({ className }: AnonymityLevelSliderProps) =
                 value={sliderPosition}
                 onChange={handleSliderChange}
                 trackStyle={trackStyle}
-                step={0.1}
+                step="any"
             />
             <LabelsWrapper>
                 <Label>1</Label>


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

There were native HTML warning that makes no sense in our case. step="any" should prevent that and it even sound better to me than arbitrary number like 0.1 

## Related Issue

Resolve https://github.com/trezor/trezor-suite/issues/6800

## Screenshots (if appropriate):
this should no more appear:
![image](https://user-images.githubusercontent.com/3729633/200011905-600ac81e-da64-4e41-a8b3-1ef8427869c4.png)
please try it! it wasn't easy to reproduce for me