### PR TITLE
Disable Anonymize button when there is nothing to coinjoin

### DIFF
--- a/packages/suite/src/components/wallet/CoinjoinSummary/BalancePrivacyBreakdown.tsx
+++ b/packages/suite/src/components/wallet/CoinjoinSummary/BalancePrivacyBreakdown.tsx
@@ -30,13 +30,12 @@ const CheckIcon = styled(Icon)`
 
 export const BalancePrivacyBreakdown = () => {
     const currentAccount = useSelector(selectSelectedAccount);
-    const balanceBreakdown = useSelector(selectCurrentCoinjoinBalanceBreakdown);
+    const { anonymized, anonymizing, notAnonymized } = useSelector(
+        selectCurrentCoinjoinBalanceBreakdown,
+    );
     const currentSession = useSelector(selectCurrentCoinjoinSession);
 
     const theme = useTheme();
-
-    const notPrivateAmount = balanceBreakdown.notAnonymized;
-    const privateAmount = balanceBreakdown.anonymized;
 
     const isSessionRunning = !!currentSession;
 
@@ -49,16 +48,16 @@ export const BalancePrivacyBreakdown = () => {
             <CryptoAmountWithHeader
                 header={<Translation id="TR_NOT_PRIVATE" />}
                 headerIcon={<Icon icon="CROSS" size={15} />}
-                value={notPrivateAmount}
+                value={notAnonymized}
                 symbol={currentAccount?.symbol}
-                color={!isZero(notPrivateAmount || '0') ? undefined : theme.TYPE_LIGHT_GREY}
+                color={!isZero(notAnonymized || '0') ? undefined : theme.TYPE_LIGHT_GREY}
             />
 
             {isSessionRunning && (
                 <CryptoAmountWithHeader
                     header={<Translation id="TR_ANONYMIZING" />}
                     headerIcon={<Icon icon="SHUFFLE" size={15} />}
-                    value={balanceBreakdown.anonymizing}
+                    value={anonymizing}
                     symbol={currentAccount?.symbol}
                 />
             )}
@@ -70,9 +69,9 @@ export const BalancePrivacyBreakdown = () => {
                     </PrivateBalanceHeading>
                 }
                 headerIcon={<CheckIcon icon="CHECK" size={19} color={theme.TYPE_GREEN} />}
-                value={privateAmount}
+                value={anonymized}
                 symbol={currentAccount?.symbol}
-                color={!isZero(privateAmount || '0') ? theme.TYPE_GREEN : theme.TYPE_LIGHT_GREY}
+                color={!isZero(anonymized || '0') ? theme.TYPE_GREEN : theme.TYPE_LIGHT_GREY}
             />
         </Container>
     );

--- a/packages/suite/src/components/wallet/CoinjoinSummary/BalanceSection.tsx
+++ b/packages/suite/src/components/wallet/CoinjoinSummary/BalanceSection.tsx
@@ -40,6 +40,8 @@ export const BalanceSection = ({ account }: BalanceSectionProps) => {
     });
     const coinjoinAccount = useSelector(state => selectCoinjoinAccountByKey(state, account.key));
 
+    const accountHasZeroBalance = account.availableBalance === '0';
+
     const goToSetup = () => actions.goto('wallet-anonymize', { preserveParams: true });
 
     return (
@@ -56,6 +58,7 @@ export const BalanceSection = ({ account }: BalanceSectionProps) => {
             ) : (
                 <AnonymizeButton
                     onClick={goToSetup}
+                    disabled={accountHasZeroBalance}
                     icon="ARROW_RIGHT_LONG"
                     alignIcon="right"
                     size={16}

--- a/packages/suite/src/support/messages.ts
+++ b/packages/suite/src/support/messages.ts
@@ -7469,10 +7469,15 @@ export default defineMessages({
         description: 'Button initializing coinjoin',
         defaultMessage: 'Anonymize',
     },
-    TR_ANONYMISATION_BUTTON_DISABLED: {
-        id: 'TR_ANONYMISATION_BUTTON_DISABLED',
+    TR_CONFIRM_CONDITIONS: {
+        id: 'TR_CONFIRM_CONDITIONS',
         description: 'Tooltip content for disabled button in coinjoin section',
         defaultMessage: 'Confirm the conditions before you proceed.',
+    },
+    TR_NOTHING_TO_ANONYMIZE: {
+        id: 'TR_NOTHING_TO_ANONYMIZE',
+        description: 'Tooltip content for disabled button in coinjoin section',
+        defaultMessage: 'Nothing to anonymize. Add funds or increase target anonymity.',
     },
     TR_CUSTOM_SETUP: {
         id: 'TR_CUSTOM_SETUP',

--- a/packages/suite/src/support/messages.ts
+++ b/packages/suite/src/support/messages.ts
@@ -7477,7 +7477,7 @@ export default defineMessages({
     TR_NOTHING_TO_ANONYMIZE: {
         id: 'TR_NOTHING_TO_ANONYMIZE',
         description: 'Tooltip content for disabled button in coinjoin section',
-        defaultMessage: 'Nothing to anonymize. Add funds or increase target anonymity.',
+        defaultMessage: 'Nothing to anonymize',
     },
     TR_CUSTOM_SETUP: {
         id: 'TR_CUSTOM_SETUP',

--- a/packages/suite/src/views/wallet/anonymize/components/CoinjoinSetupStrategies.tsx
+++ b/packages/suite/src/views/wallet/anonymize/components/CoinjoinSetupStrategies.tsx
@@ -97,7 +97,12 @@ export const CoinjoinSetupStrategies = ({ account }: CoinjoinSetupStrategiesProp
     const maxRounds = getMaxRounds(targetAnonymity, account.addresses.anonymitySet);
     const isCustom = strategy === 'custom';
     const allChecked = connectedConfirmed && termsConfirmed;
+    const allAnonymized = notAnonymized === '0';
     const fee = new BigNumber(notAnonymized).times(coordinatorData.coordinatorFeeRate).toString();
+    const isDisabled = !allChecked || allAnonymized;
+    const buttonTooltipMessage = allAnonymized
+        ? 'TR_NOTHING_TO_ANONYMIZE'
+        : 'TR_CONFIRM_CONDITIONS';
 
     const reset = () => {
         setStrategy('recommended');
@@ -204,10 +209,8 @@ export const CoinjoinSetupStrategies = ({ account }: CoinjoinSetupStrategiesProp
 
             <StyledTooltipButton
                 onClick={anonymize}
-                isDisabled={!allChecked}
-                tooltipContent={
-                    !allChecked && <Translation id="TR_ANONYMISATION_BUTTON_DISABLED" />
-                }
+                isDisabled={isDisabled}
+                tooltipContent={isDisabled && <Translation id={buttonTooltipMessage} />}
             >
                 <Translation id="TR_ANONYMIZE" />
             </StyledTooltipButton>


### PR DESCRIPTION
## Description

ddf2dab81821bb18d14a65c27e1934fb0df4b679 disables the button on main page when there is no `availableBalance`. Anonymity is not checked here because it may be changed on the following strategy page. there is no tooltip, but it should be self-explanatory. I was not entirely sure whether I should check `availableBalance` or `balance`, though.

c88151cea9f50ca15861a52edb6f6ea0e4315bcf disables the button starting coinjoin if there are no non-private funds. The tooltip instructs the user to add funds or increase anonymity level if they want to coinjoin.

## Related Issue

Resolve #6818

## Screenshots (if appropriate):
Main page:
<img width="648" alt="image" src="https://user-images.githubusercontent.com/3729633/200794298-101c51ac-74f1-4d17-b8ea-2af3ff2e8d02.png">

Strategy:
<img width="629" alt="image" src="https://user-images.githubusercontent.com/3729633/200794228-44a67753-37d0-41ae-b274-8d68e00dcf35.png">
