### PR TITLE
fix(suite): add heading to firmware installation modals to fix close button position and unify with other modals

### DIFF
--- a/packages/suite/src/views/firmware/index.tsx
+++ b/packages/suite/src/views/firmware/index.tsx
@@ -34,16 +34,6 @@ const Wrapper = styled.div<{ isWithTopPadding: boolean }>`
 const StyledModal = styled(Modal)`
     width: 620px;
     min-height: 540px;
-
-    > ${Modal.Body} {
-        padding: 0;
-        margin-top: 0;
-        height: 100%;
-
-        > * {
-            height: 100%;
-        }
-    }
 `;
 
 type FirmwareProps = {
@@ -178,6 +168,7 @@ export const Firmware = ({ shouldSwitchFirmwareType }: FirmwareProps) => {
             }
             onCancel={onClose}
             data-test="@firmware"
+            heading={<Translation id="TR_INSTALL_FIRMWARE" />}
         >
             <Wrapper isWithTopPadding={!isCancelable}>{Component}</Wrapper>
         </StyledModal>


### PR DESCRIPTION

<!--- Provide a general summary of your changes in the Title above -->

## Description

fix close button position on firmware installation modals by adding header title (unification with other modals)


## Related Issue

Resolve https://github.com/trezor/trezor-suite/issues/6831

## Screenshots (if appropriate):
before:
![image](https://user-images.githubusercontent.com/3729633/200533072-920bb1e7-3384-4442-9e14-e5aed4e9ce93.png)

after:
![image](https://user-images.githubusercontent.com/3729633/200533123-8ffe9ace-03c7-414e-8fac-5a4227831d1d.png)
![image](https://user-images.githubusercontent.com/3729633/200533166-54282ae1-0074-448f-ad9f-346ad6f03089.png)
![image](https://user-images.githubusercontent.com/3729633/200533213-02f13cf4-f7b7-41d4-96f1-35f2558cff10.png)
![image](https://user-images.githubusercontent.com/3729633/200533234-92d245b6-c889-475e-ae84-cc35a75499e5.png)
![image](https://user-images.githubusercontent.com/3729633/200533266-ec8781e0-0c17-4cfa-9429-8861cdee72ed.png)
![image](https://user-images.githubusercontent.com/3729633/200533313-85af8260-1795-4a8a-a5b3-7c22c6cb1a78.png)

