### PR TITLE
fix(connect): validate device state using DoPreauthorized message

### DIFF
--- a/packages/connect/src/api/signTransaction.ts
+++ b/packages/connect/src/api/signTransaction.ts
@@ -36,7 +36,6 @@ type Params = {
     options: TransactionOptions;
     coinInfo: BitcoinNetworkInfo;
     push: boolean;
-    preauthorized?: boolean;
     unlockPath?: PROTO.UnlockPath;
 };
 
@@ -84,6 +83,7 @@ export default class SignTransaction extends AbstractMethod<'signTransaction', P
         }
         // set required firmware from coinInfo support
         this.firmwareRange = getFirmwareRange(this.name, coinInfo, this.firmwareRange);
+        this.preauthorized = payload.preauthorized;
         this.info = getLabel('Sign #NETWORK transaction', coinInfo);
 
         const inputs = validateTrezorInputs(payload.inputs, coinInfo);
@@ -129,7 +129,6 @@ export default class SignTransaction extends AbstractMethod<'signTransaction', P
             },
             coinInfo,
             push: typeof payload.push === 'boolean' ? payload.push : false,
-            preauthorized: payload.preauthorized,
             unlockPath: payload.unlockPath,
         };
 
@@ -190,8 +189,8 @@ export default class SignTransaction extends AbstractMethod<'signTransaction', P
             refTxs = params.refTxs;
         }
 
-        if (params.preauthorized) {
-            await device.getCommands().typedCall('DoPreauthorized', 'PreauthorizedRequest', {});
+        if (this.preauthorized) {
+            await device.getCommands().preauthorize(true);
         } else if (params.unlockPath) {
             await device.getCommands().unlockPath(params.unlockPath);
         }

--- a/packages/connect/src/core/AbstractMethod.ts
+++ b/packages/connect/src/core/AbstractMethod.ts
@@ -57,6 +57,8 @@ export abstract class AbstractMethod<Name extends CallMethodPayload['method'], P
 
     useDeviceState: boolean; // should validate device state?
 
+    preauthorized?: boolean; // another variant of device state validation
+
     useEmptyPassphrase: boolean;
 
     allowSeedlessDevice: boolean;

--- a/packages/connect/src/core/index.ts
+++ b/packages/connect/src/core/index.ts
@@ -517,7 +517,7 @@ export const onCall = async (message: CoreMessage) => {
             // Make sure that device will display pin/passphrase
             try {
                 const invalidDeviceState = method.useDeviceState
-                    ? await device.validateState(method.network)
+                    ? await device.validateState(method.network, method.preauthorized)
                     : undefined;
                 if (invalidDeviceState) {
                     if (isUsingPopup) {

--- a/packages/connect/src/device/DeviceCommands.ts
+++ b/packages/connect/src/device/DeviceCommands.ts
@@ -337,6 +337,16 @@ export class DeviceCommands {
         };
     }
 
+    async preauthorize(throwError: boolean) {
+        try {
+            await this.typedCall('DoPreauthorized', 'PreauthorizedRequest', {});
+            return true;
+        } catch (error) {
+            if (throwError) throw error;
+            return false;
+        }
+    }
+
     getDeviceState(networkType?: string) {
         // cardano backwards compatibility. we only need this for firmware before initialize.derive_cardano message was introduced
         if (!this.device.atLeast('2.4.3')) {

--- a/packages/suite/src/actions/wallet/coinjoinClientActions.ts
+++ b/packages/suite/src/actions/wallet/coinjoinClientActions.ts
@@ -383,7 +383,7 @@ export const signCoinjoinTx =
                 coinjoinRequest: tx.coinjoinRequest,
                 coin: network,
                 preauthorized: true,
-                serialized: false,
+                serialize: false,
                 unlockPath,
             });
 
@@ -419,6 +419,11 @@ export const signCoinjoinTx =
             (promise, params) => promise.then(() => signTx(params)),
             Promise.resolve(),
         );
+
+        // disable busy screen
+        await dispatch(setBusyScreen(Object.keys(groupUtxosByAccount)));
+        // and close 'critical-coinjoin-phase' modal
+        dispatch(closeModal());
 
         // finally walk thru all requested utxos and find not resolved
         request.inputs.forEach(utxo => {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

- validate device state using `DoPreauthorized` message.
> Do not request pin if device is locked and requested method is preauthorized (authorizeConjoin, getOwnershipProof, signTransaction)

- disable critical modal and busy screen from device after signing transaction
> Additional fix of typo in connect params: serialized != serialize

## Related issues
resolve https://github.com/trezor/trezor-suite/issues/6828 and https://github.com/trezor/trezor-suite/issues/6833
