### PR TITLE
Improve coinjoin service fee calculation

### DIFF
--- a/packages/blockchain-link/src/index.ts
+++ b/packages/blockchain-link/src/index.ts
@@ -351,6 +351,7 @@ export type {
     AccountAddresses,
     AccountInfo,
     AccountBalanceHistory,
+    AnonymitySet,
     BlockchainSettings,
     FiatRates,
     ServerInfo,

--- a/packages/blockchain-link/src/types/common.ts
+++ b/packages/blockchain-link/src/types/common.ts
@@ -122,6 +122,8 @@ export interface Transaction {
 
 /* Account */
 
+export type AnonymitySet = Record<string, number | undefined>;
+
 export interface Address {
     address: string;
     path: string;
@@ -138,7 +140,7 @@ export interface AccountAddresses {
     unused: Address[];
     // NOTE: anonymitySet currently is not calculated by @trezor/blockchain-link
     // format: key -> address, value -> anonymityLevel
-    anonymitySet?: Record<string, number | undefined>;
+    anonymitySet?: AnonymitySet;
 }
 
 export interface Utxo {

--- a/packages/coinjoin/src/client/round/inputRegistration.ts
+++ b/packages/coinjoin/src/client/round/inputRegistration.ts
@@ -114,7 +114,7 @@ const registerInput = async (
         );
 
         // Calculate mining and coordinator fee
-        // coordinator fee is 0 if input is remixed or amount is lower than plebsDontPayThreshold value
+        // coordinator fee is 0 if input is remixed or amount is lower than or equal to plebsDontPayThreshold value
         const { roundParameters } = round;
         const coordinatorFee =
             input.amount > roundParameters.coordinationFeeRate.plebsDontPayThreshold &&

--- a/packages/coinjoin/src/client/round/selectRound.ts
+++ b/packages/coinjoin/src/client/round/selectRound.ts
@@ -123,7 +123,7 @@ export const selectUtxoForRound = async (
             const { roundParameters } = round;
             const roundConstants = {
                 miningFeeRate: roundParameters.miningFeeRate,
-                coordinationFeeRate: roundParameters.coordinationFeeRate,
+                coordinationFeeRate: roundParameters.coordinationFeeRate.rate,
                 allowedInputAmounts: roundParameters.allowedInputAmounts,
                 allowedOutputAmounts: roundParameters.allowedOutputAmounts,
                 allowedInputTypes: roundParameters.allowedInputScriptTypes,

--- a/packages/coinjoin/src/constants.ts
+++ b/packages/coinjoin/src/constants.ts
@@ -27,6 +27,7 @@ export const HTTP_REQUEST_TIMEOUT = 35000;
 
 // fallback values for status request
 // usage of these values is extremely unlikely, there would have to be a change in the coordinator's API
-export const MAX_COORDINATOR_FEE_RATE = 0.003;
+export const PLEBS_DONT_PAY_THRESHOLD = 1000000;
+export const COORDINATOR_FEE_RATE = 0.003;
 export const MIN_ALLOWED_AMOUNT = 5000;
 export const MAX_ALLOWED_AMOUNT = 134375000000;

--- a/packages/coinjoin/src/types/client.ts
+++ b/packages/coinjoin/src/types/client.ts
@@ -1,9 +1,9 @@
-import { AllowedRange, Round, FeeRateMedians } from './coordinator';
+import { AllowedRange, CoordinationFeeRate, FeeRateMedians, Round } from './coordinator';
 
 export interface CoinjoinStatusEvent {
     rounds: Round[];
     changed: Round[];
     feeRatesMedians: FeeRateMedians[];
-    coordinatorFeeRate: number;
+    coordinationFeeRate: CoordinationFeeRate;
     allowedInputAmounts: AllowedRange;
 }

--- a/packages/coinjoin/src/types/coordinator.ts
+++ b/packages/coinjoin/src/types/coordinator.ts
@@ -52,7 +52,7 @@ export interface RegistrationData {
     isPayingZeroCoordinationFee: boolean;
 }
 
-export interface CoordinatorFeeRate {
+export interface CoordinationFeeRate {
     rate: number;
     plebsDontPayThreshold: number;
 }
@@ -60,10 +60,7 @@ export interface CoordinatorFeeRate {
 export interface CoinjoinRoundParameters {
     network: string;
     miningFeeRate: number;
-    coordinationFeeRate: {
-        rate: number;
-        plebsDontPayThreshold: number;
-    };
+    coordinationFeeRate: CoordinationFeeRate;
     maxSuggestedAmount: number;
     minInputCountByRound: number;
     maxInputCountByRound: number;

--- a/packages/coinjoin/src/utils/roundUtils.ts
+++ b/packages/coinjoin/src/utils/roundUtils.ts
@@ -1,7 +1,8 @@
 import {
-    MAX_COORDINATOR_FEE_RATE,
+    COORDINATOR_FEE_RATE,
     MAX_ALLOWED_AMOUNT,
     MIN_ALLOWED_AMOUNT,
+    PLEBS_DONT_PAY_THRESHOLD,
     ROUND_REGISTRATION_END_OFFSET,
 } from '../constants';
 import {
@@ -138,24 +139,18 @@ export const findNearestDeadline = (rounds: Round[]) => {
 
 // iterate Status and find relevant round data
 export const getDataFromRounds = (rounds: Round[]) => {
-    const [coordinatorFeeRates, maxAllowedAmounts, minAllowedAmounts] = rounds.reduce(
-        ([previousRates, previousMax, previousMin], round) => {
-            const roundParameters = getRoundParameters(round);
-            if (roundParameters) {
-                previousRates.push(roundParameters.coordinationFeeRate.rate);
-                previousMax.push(roundParameters.allowedInputAmounts.max);
-                previousMin.push(roundParameters.allowedInputAmounts.min);
-            }
-            return [previousRates, previousMax, previousMin];
-        },
-        [[], [], []] as number[][],
-    );
+    const roundParameters = getRoundParameters(rounds[rounds.length - 1]);
 
     return {
-        coordinatorFeeRate: Math.max(...coordinatorFeeRates) ?? MAX_COORDINATOR_FEE_RATE,
+        coordinationFeeRate: {
+            plebsDontPayThreshold:
+                roundParameters?.coordinationFeeRate.plebsDontPayThreshold ??
+                PLEBS_DONT_PAY_THRESHOLD,
+            rate: roundParameters?.coordinationFeeRate.rate ?? COORDINATOR_FEE_RATE,
+        },
         allowedInputAmounts: {
-            min: Math.min(...minAllowedAmounts) ?? MIN_ALLOWED_AMOUNT,
-            max: Math.max(...maxAllowedAmounts) ?? MAX_ALLOWED_AMOUNT,
+            max: roundParameters?.allowedInputAmounts.max ?? MAX_ALLOWED_AMOUNT,
+            min: roundParameters?.allowedInputAmounts.min ?? MIN_ALLOWED_AMOUNT,
         },
     };
 };

--- a/packages/coinjoin/src/utils/roundUtils.ts
+++ b/packages/coinjoin/src/utils/roundUtils.ts
@@ -137,9 +137,10 @@ export const findNearestDeadline = (rounds: Round[]) => {
     return Math.min(...deadlines);
 };
 
-// iterate Status and find relevant round data
+// get relevant round data from the most recent round
 export const getDataFromRounds = (rounds: Round[]) => {
-    const roundParameters = getRoundParameters(rounds[rounds.length - 1]);
+    const lastRound = rounds.at(-1);
+    const roundParameters = lastRound && getRoundParameters(lastRound);
 
     return {
         coordinationFeeRate: {

--- a/packages/coinjoin/tests/client/CoinjoinClient.test.ts
+++ b/packages/coinjoin/tests/client/CoinjoinClient.test.ts
@@ -37,7 +37,7 @@ describe(`CoinjoinClient`, () => {
 
         const status = await cli.enable();
         expect(status?.rounds.length).toBeGreaterThan(0);
-        expect(status?.coordinatorFeeRate).toBeGreaterThan(0);
+        expect(status?.coordinationFeeRate.rate).toBeGreaterThan(0);
 
         cli.disable();
     });

--- a/packages/suite/src/components/suite/modals/TransactionDetail/components/IODetails.tsx
+++ b/packages/suite/src/components/suite/modals/TransactionDetail/components/IODetails.tsx
@@ -1,10 +1,12 @@
 import React from 'react';
 import styled, { css } from 'styled-components';
-import { Icon, useTheme, variables, CollapsibleBox } from '@trezor/components';
+
 import { WalletAccountTransaction } from '@suite-common/wallet-types';
 import { formatNetworkAmount } from '@suite-common/wallet-utils';
 import { FormattedCryptoAmount, HiddenPlaceholder, Translation } from '@suite-components';
 import { useSelector } from '@suite-hooks/useSelector';
+import { AnonymitySet } from '@trezor/blockchain-link';
+import { Icon, useTheme, variables, CollapsibleBox } from '@trezor/components';
 import { UtxoAnonymity } from '@wallet-components';
 
 export const blurFix = css`
@@ -79,7 +81,7 @@ const IOGridRow = ({
     tx: { symbol },
     vinvout: { isAccountOwned, addresses, value },
 }: {
-    anonymitySet?: Record<string, number | undefined>;
+    anonymitySet?: AnonymitySet;
     tx: WalletAccountTransaction;
     vinvout: EnhancedVinVout;
 }) => {

--- a/packages/suite/src/components/wallet/CoinControl/UtxoSelectionList.tsx
+++ b/packages/suite/src/components/wallet/CoinControl/UtxoSelectionList.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 import styled from 'styled-components';
 import { transparentize } from 'polished';
 
-import { getAccountTransactions } from '@suite-common/wallet-utils';
+import { selectAccountTransactions } from '@suite-common/wallet-core';
 import { useSelector } from '@suite-hooks';
 import { Icon, variables, IconType } from '@trezor/components';
 import type { AccountUtxo } from '@trezor/connect';
@@ -57,13 +57,9 @@ export const UtxoSelectionList = ({
     utxos,
     withHeader,
 }: Props) => {
-    const { transactions } = useSelector(state => ({
-        transactions: state.wallet.transactions,
-    }));
-
     const { account, composedInputs, isCoinControlEnabled, selectedUtxos } = useSendFormContext();
 
-    const accountTransactions = getAccountTransactions(account.key, transactions.transactions);
+    const accountTransactions = useSelector(state => selectAccountTransactions(state, account.key));
 
     const isChecked = (utxo: AccountUtxo) =>
         isCoinControlEnabled

--- a/packages/suite/src/reducers/wallet/coinjoinReducer.ts
+++ b/packages/suite/src/reducers/wallet/coinjoinReducer.ts
@@ -21,7 +21,7 @@ export interface CoinjoinClientFeeRatesMedians {
 export interface CoinjoinClientInstance {
     rounds: { id: string; phase: RoundPhase }[]; // store only slice of Round in reducer. may be extended in the future
     feeRatesMedians: CoinjoinClientFeeRatesMedians;
-    coordinatorFeeRate: number;
+    coordinationFeeRate: CoinjoinStatusEvent['coordinationFeeRate'];
     allowedInputAmounts: CoinjoinStatusEvent['allowedInputAmounts'];
     log: { time: number; value: string }[];
 }

--- a/packages/suite/src/utils/wallet/coinjoinUtils.ts
+++ b/packages/suite/src/utils/wallet/coinjoinUtils.ts
@@ -87,7 +87,7 @@ export const transformFeeRatesMedians = (medians: CoinjoinStatusEvent['feeRatesM
  */
 export const transformCoinjoinStatus = (event: CoinjoinStatusEvent) => ({
     rounds: event.rounds.map(r => ({ id: r.id, phase: r.phase })),
-    coordinatorFeeRate: event.coordinatorFeeRate,
+    coordinationFeeRate: event.coordinationFeeRate,
     feeRatesMedians: transformFeeRatesMedians(event.feeRatesMedians),
     allowedInputAmounts: event.allowedInputAmounts,
 });

--- a/packages/suite/src/views/wallet/transactions/components/CoinjoinAccountEmpty.tsx
+++ b/packages/suite/src/views/wallet/transactions/components/CoinjoinAccountEmpty.tsx
@@ -54,7 +54,7 @@ export const CoinjoinAccountEmpty = ({ account }: CoinjoinAccountEmptyProps) => 
                 <FeeText>
                     <Translation
                         id="TR_COINJOIN_ACCESS_ACCOUNT_STEP_INITIAL_FEE_MESSAGE"
-                        values={{ fee: coordinatorData.coordinatorFeeRate * 100 }}
+                        values={{ fee: coordinatorData.coordinationFeeRate.rate * 100 }}
                     />
                 </FeeText>
             )}


### PR DESCRIPTION
## Description

Service fee is not calculated from the total amount, but from individual UTXOs and rounded down.
Some UTXOs do not induce service fees:
- UTXOs not exceeding `plebsDontPayThreshold` value received from coordinator
- already coinjoined UTXOs (determined from anonymity level and history)
- Friends don't pay  (UTXOs parents have been coinjoined) - not implemented because data are not available

## Related Issue

Resolve #6821, #6786

## Screenshots (if appropriate):
![Screenshot 2022-11-08 at 16 46 02](https://user-images.githubusercontent.com/42465546/200610733-e1e507a8-80e1-403d-85c0-a49b1fc95f67.png)
