### PR TITLE
Fix: pause coinjoin session on device disconnect

### DIFF
--- a/packages/coinjoin/src/client/Alice.ts
+++ b/packages/coinjoin/src/client/Alice.ts
@@ -98,6 +98,7 @@ export class Alice {
             accountKey: this.accountKey,
             path: this.path,
             outpoint: this.outpoint,
+            error: this.error?.message,
         };
     }
 }

--- a/packages/coinjoin/src/client/CoinjoinClient.ts
+++ b/packages/coinjoin/src/client/CoinjoinClient.ts
@@ -89,6 +89,7 @@ export class CoinjoinClient extends EventEmitter {
         if (this.accounts.find(a => a.accountKey === account.accountKey)) {
             throw new Error('Trying to register account that already exists');
         }
+        this.log(`Register account ~~${account.accountKey}~~`);
 
         // iterate Status more frequently
         if (this.accounts.length === 0) {
@@ -105,6 +106,7 @@ export class CoinjoinClient extends EventEmitter {
     }
 
     updateAccount(account: RegisterAccountParams) {
+        this.log(`Update account ~~${account.accountKey}~~`);
         const accountToUpdate = this.accounts.find(a => a.accountKey === account.accountKey);
         if (accountToUpdate) {
             this.rounds.forEach(round => round.updateAccount(account));
@@ -120,7 +122,10 @@ export class CoinjoinClient extends EventEmitter {
     }
 
     unregisterAccount(accountKey: string) {
-        this.rounds.forEach(round => round.unregisterAccount(accountKey));
+        this.log(`Unregister account ~~${accountKey}~~`);
+        this.rounds.forEach(round => {
+            round.unregisterAccount(accountKey);
+        });
 
         this.accounts = this.accounts.filter(a => a.accountKey !== accountKey);
 

--- a/packages/coinjoin/src/client/CoinjoinRound.ts
+++ b/packages/coinjoin/src/client/CoinjoinRound.ts
@@ -82,7 +82,7 @@ const createRoundLock = (mainSignal: AbortSignal) => {
     };
 };
 
-export class CoinjoinRound extends EventEmitter implements SerializedCoinjoinRound {
+export class CoinjoinRound extends EventEmitter {
     private lock?: ReturnType<typeof createRoundLock>;
     private options: CoinjoinRoundOptions;
 
@@ -182,7 +182,7 @@ export class CoinjoinRound extends EventEmitter implements SerializedCoinjoinRou
 
         if (this.inputs.length === 0 || this.phase === RoundPhase.Ended) {
             this.phase = RoundPhase.Ended;
-            this.emit('ended', { round: this });
+            this.emit('ended', { round: this.toSerialized() });
         }
 
         this.lock?.resolve();
@@ -220,7 +220,7 @@ export class CoinjoinRound extends EventEmitter implements SerializedCoinjoinRou
                 return {
                     type: 'ownership',
                     roundId: this.id,
-                    inputs,
+                    inputs: inputs.map(i => i.toSerialized()),
                     commitmentData: this.commitmentData,
                 };
             }
@@ -235,7 +235,7 @@ export class CoinjoinRound extends EventEmitter implements SerializedCoinjoinRou
                 return {
                     type: 'signature',
                     roundId: this.id,
-                    inputs,
+                    inputs: inputs.map(i => i.toSerialized()),
                     transaction: this.transactionData,
                 };
             }

--- a/packages/coinjoin/src/client/round/selectRound.ts
+++ b/packages/coinjoin/src/client/round/selectRound.ts
@@ -81,7 +81,10 @@ export const getAccountCandidates = (
                 const [low, high] = account.skipRounds;
                 // skip reached lower limit
                 // or skip randomly (20% chance with [4, 5] settings)
-                if (account.skipRoundCounter >= low || Math.random() > low / high) {
+                if (
+                    account.skipRoundCounter >= low ||
+                    (account.skipRoundCounter > 0 && Math.random() > low / high)
+                ) {
                     account.skipRoundCounter = 0;
                     log(`Random skip candidate ~~${accountKey}~~`);
                     return [];

--- a/packages/coinjoin/src/types/round.ts
+++ b/packages/coinjoin/src/types/round.ts
@@ -5,6 +5,7 @@ export interface SerializedAlice {
     accountKey: string;
     path: string;
     outpoint: string;
+    error?: string;
 }
 
 export interface SerializedCoinjoinRound {

--- a/packages/suite/src/actions/wallet/__fixtures__/coinjoinClientActions.ts
+++ b/packages/suite/src/actions/wallet/__fixtures__/coinjoinClientActions.ts
@@ -125,7 +125,13 @@ export const onCoinjoinRoundChanged = [
         state: {
             accounts: [{ key: 'a', deviceState: 'device-state' }],
             coinjoin: {
-                accounts: [{ key: 'a', session: { signedRounds: ['1', '2'], maxRounds: 2 } }],
+                accounts: [
+                    {
+                        key: 'a',
+                        session: { signedRounds: ['1', '2'], maxRounds: 2 },
+                        previousSessions: [],
+                    },
+                ],
             },
         },
         params: {
@@ -135,7 +141,12 @@ export const onCoinjoinRoundChanged = [
             roundDeadline: Date.now() + 1000,
         },
         result: {
-            actions: [COINJOIN.SESSION_ROUND_CHANGED, MODAL.CLOSE, MODAL.OPEN_USER_CONTEXT],
+            actions: [
+                COINJOIN.SESSION_ROUND_CHANGED,
+                MODAL.CLOSE,
+                MODAL.OPEN_USER_CONTEXT,
+                COINJOIN.SESSION_COMPLETED,
+            ],
             trezorConnectCalledTimes: 1,
             trezorConnectCallsWith: { expiry_ms: undefined },
         },
@@ -146,7 +157,13 @@ export const onCoinjoinRoundChanged = [
         state: {
             accounts: [{ key: 'a', deviceState: 'device-state' }],
             coinjoin: {
-                accounts: [{ key: 'a', session: { signedRounds: ['1', '2'], maxRounds: 2 } }],
+                accounts: [
+                    {
+                        key: 'a',
+                        session: { signedRounds: ['1', '2'], maxRounds: 2 },
+                        previousSessions: [],
+                    },
+                ],
             },
         },
         params: [
@@ -191,6 +208,7 @@ export const onCoinjoinRoundChanged = [
                 COINJOIN.SESSION_ROUND_CHANGED,
                 MODAL.CLOSE,
                 MODAL.OPEN_USER_CONTEXT,
+                COINJOIN.SESSION_COMPLETED,
             ],
             trezorConnectCalledTimes: 2,
             trezorConnectCallsWith: { expiry_ms: undefined },

--- a/packages/suite/src/middlewares/wallet/coinjoinMiddleware.ts
+++ b/packages/suite/src/middlewares/wallet/coinjoinMiddleware.ts
@@ -1,5 +1,5 @@
 import type { MiddlewareAPI } from 'redux';
-import { UI } from '@trezor/connect';
+import { UI, DEVICE } from '@trezor/connect';
 import { SUITE, ROUTER } from '@suite-actions/constants';
 import { DISCOVERY } from '@wallet-actions/constants';
 import * as coinjoinAccountActions from '@wallet-actions/coinjoinAccountActions';
@@ -49,6 +49,10 @@ export const coinjoinMiddleware =
                     api.dispatch(coinjoinAccountActions.fetchAndUpdateAccount(a)),
                 );
             }
+        }
+
+        if (action.type === DEVICE.DISCONNECT && action.payload.id) {
+            api.dispatch(coinjoinAccountActions.pauseCoinjoinSessionByDeviceId(action.payload.id));
         }
 
         if (blockchainActions.synced.match(action)) {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Few small and two important fixes:

- remove dangling event listeners from abort signals
- propagate errors in `SerializedAlice` to suite
- do not randomly skip rounds on first attempt, its annoying
- forgotten commit: account unregistration after last signed round (session completed)
- fix: pause coinjoin session on device disconnection

## Related Issue

Resolve https://github.com/trezor/trezor-suite/issues/6826

