### PR TITLE
fix(suite): fix utxos displayed per page in coin control

### DIFF
--- a/packages/suite/src/views/wallet/send/components/Options/components/BitcoinOptions/components/CoinControl.tsx
+++ b/packages/suite/src/views/wallet/send/components/Options/components/BitcoinOptions/components/CoinControl.tsx
@@ -138,7 +138,11 @@ export const CoinControl = ({ close }: CoinControlProps) => {
     ].map(utxoCategory => {
         const lastIndexOnPage = currentPage * utxosPerPage - previousItemsLength;
         previousItemsLength += utxoCategory.length;
-        return utxoCategory.slice(lastIndexOnPage - utxosPerPage, lastIndexOnPage);
+        // avoid negative values which may cause unintended results
+        return utxoCategory.slice(
+            Math.max(0, lastIndexOnPage - utxosPerPage),
+            Math.max(0, lastIndexOnPage),
+        );
     });
     const isCoinjoinAccount = account.accountType === 'coinjoin';
     const hasEligibleUtxos = spendableUtxos.length + lowAnonymityUtxos.length > 0;


### PR DESCRIPTION
## Description

The original algorithm to determine UTXOs displayed on page sometimes rendered incorrect results when there were negative numbers supplied as arguments to the `slice()` method. This change replaces negative values with `0`.

## Related Issue

Resolve #6803 
