### PR TITLE
feat(coinjoin): always allow at least 8 max rounds

### DIFF
--- a/packages/suite/src/components/suite/modals/AddAccount/components/AddCoinJoinAccountButton.tsx
+++ b/packages/suite/src/components/suite/modals/AddAccount/components/AddCoinJoinAccountButton.tsx
@@ -3,6 +3,7 @@ import { Translation } from '@suite-components';
 import { useSelector, useActions } from '@suite-hooks';
 import { useDispatch } from 'react-redux';
 import { createCoinjoinAccount } from '@wallet-actions/coinjoinAccountActions';
+import { DEFAULT_TARGET_ANONYMITY } from '@suite/services/coinjoin/config';
 import * as modalActions from '@suite-actions/modalActions';
 import { Account, Network, NetworkSymbol } from '@wallet-types';
 import { UnavailableCapabilities } from '@trezor/connect';
@@ -77,7 +78,7 @@ export const AddCoinJoinAccountButton = ({ network }: AddCoinJoinAccountProps) =
 
     const onCreateCoinjoinAccountClick = async () => {
         const createAccount = async () => {
-            await action.createCoinjoinAccount(network, 10);
+            await action.createCoinjoinAccount(network, DEFAULT_TARGET_ANONYMITY);
             setIsLoading(false);
         };
 

--- a/packages/suite/src/reducers/wallet/coinjoinReducer.ts
+++ b/packages/suite/src/reducers/wallet/coinjoinReducer.ts
@@ -10,6 +10,7 @@ import {
     getEstimatedTimePerRound,
     transformCoinjoinStatus,
 } from '@wallet-utils/coinjoinUtils';
+import { ESTIMATED_ROUNDS_FAIL_RATE_BUFFER } from '@suite/services/coinjoin/config';
 import { selectSelectedAccount } from './selectedAccountReducer';
 import { CoinjoinStatusEvent } from '@trezor/coinjoin';
 
@@ -95,7 +96,10 @@ const updateSession = (
     const { signedRounds, maxRounds, skipRounds } = account.session;
     const { phase, phaseDeadline, roundDeadline } = round;
 
-    const roundsLeft = maxRounds - signedRounds.length - (typeof phase === 'number' ? 1 : 0);
+    const roundsLeft =
+        Math.ceil(maxRounds / ESTIMATED_ROUNDS_FAIL_RATE_BUFFER) -
+        signedRounds.length -
+        (typeof phase === 'number' ? 1 : 0);
     const timeLeftTillRoundEnd = roundDeadline - Date.now();
 
     const timePerRoundInMilliseconds = getEstimatedTimePerRound(!!skipRounds) * 3600000;

--- a/packages/suite/src/services/coinjoin/config.ts
+++ b/packages/suite/src/services/coinjoin/config.ts
@@ -86,6 +86,8 @@ export const COINJOIN_NETWORKS: PartialRecord<NetworkSymbol, ServerEnvironment> 
 
 // coinjoin strategy constants
 export const ESTIMATED_ANONYMITY_GAINED_PER_ROUND = 10;
+export const ESTIMATED_ROUNDS_FAIL_RATE_BUFFER = 2.5;
+export const ESTIMATED_MIN_ROUNDS_NEEDED = 8;
 export const ESTIMATED_HOURS_PER_ROUND_WITHOUT_SKIPPING_ROUNDS = 1;
 export const ESTIMATED_HOURS_PER_ROUND_WITH_SKIPPING_ROUNDS = 2.5;
 export const ESTIMATED_HOURS_BUFFER_MODIFIER = 0.25;

--- a/packages/suite/src/services/coinjoin/config.ts
+++ b/packages/suite/src/services/coinjoin/config.ts
@@ -98,6 +98,8 @@ export const DEFAULT_MAX_MINING_FEE = 3;
 // firmware format (300 000 = 0.003 * 10 ** 8)
 export const COORDINATOR_FEE_RATE_MULTIPLIER = 10 ** 8;
 
+export const DEFAULT_TARGET_ANONYMITY = 10;
+
 export const getCoinjoinConfig = (
     network: NetworkSymbol,
     environment?: CoinjoinServerEnvironment,

--- a/packages/suite/src/utils/wallet/__fixtures__/coinjoinUtils.ts
+++ b/packages/suite/src/utils/wallet/__fixtures__/coinjoinUtils.ts
@@ -1,0 +1,110 @@
+import {
+    DEFAULT_TARGET_ANONYMITY,
+    ESTIMATED_MIN_ROUNDS_NEEDED,
+} from '../../../services/coinjoin/config';
+
+export const getMaxRounds = [
+    {
+        description: 'default target anonymity',
+        params: {
+            targetAnonymity: DEFAULT_TARGET_ANONYMITY,
+            anonymitySet: {
+                one: 1,
+                two: 100,
+                three: 30,
+                four: 5,
+            },
+        },
+        result: 8,
+    },
+    {
+        description: 'default target anonymity every utxos with some anonymity',
+        params: {
+            targetAnonymity: DEFAULT_TARGET_ANONYMITY,
+            anonymitySet: {
+                one: 5,
+                two: 100,
+                three: 30,
+            },
+        },
+        result: 8,
+    },
+    {
+        description: 'no target anonymity',
+        params: {
+            targetAnonymity: 1,
+            anonymitySet: {
+                one: 5,
+                two: 100,
+                three: 30,
+                four: 1,
+            },
+        },
+        result: ESTIMATED_MIN_ROUNDS_NEEDED,
+    },
+    {
+        description: 'highest target anonymity',
+        params: {
+            targetAnonymity: 100,
+            anonymitySet: {
+                one: 1,
+                two: 100,
+                three: 30,
+            },
+        },
+        result: 25,
+    },
+    {
+        description: 'target anonymity achieved',
+        params: {
+            targetAnonymity: DEFAULT_TARGET_ANONYMITY,
+            anonymitySet: {
+                one: DEFAULT_TARGET_ANONYMITY,
+            },
+        },
+        result: ESTIMATED_MIN_ROUNDS_NEEDED,
+    },
+    {
+        description: 'target anonymity surpassed',
+        params: {
+            targetAnonymity: DEFAULT_TARGET_ANONYMITY,
+            anonymitySet: {
+                one: DEFAULT_TARGET_ANONYMITY + 1,
+                two: 100,
+            },
+        },
+        result: ESTIMATED_MIN_ROUNDS_NEEDED,
+    },
+    {
+        description: 'anonymity set with undefined value',
+        params: {
+            targetAnonymity: DEFAULT_TARGET_ANONYMITY,
+            anonymitySet: {
+                one: undefined,
+                two: 100,
+                three: 30,
+            },
+        },
+        result: 8,
+    },
+    {
+        description: 'anonymity set with 0 value',
+        params: {
+            targetAnonymity: DEFAULT_TARGET_ANONYMITY,
+            anonymitySet: {
+                one: 0,
+                two: 100,
+                three: 30,
+            },
+        },
+        result: 8,
+    },
+    {
+        description: 'anonymity set empty',
+        params: {
+            targetAnonymity: DEFAULT_TARGET_ANONYMITY,
+            anonymitySet: {},
+        },
+        result: 8,
+    },
+];

--- a/packages/suite/src/utils/wallet/__tests__/coinjoinUtils.test.ts
+++ b/packages/suite/src/utils/wallet/__tests__/coinjoinUtils.test.ts
@@ -1,4 +1,5 @@
 import * as coinjoinUtils from '../coinjoinUtils';
+import * as fixtures from '../__fixtures__/coinjoinUtils';
 
 describe('breakdownCoinjoinBalance', () => {
     const commonUtxo = {
@@ -86,5 +87,15 @@ describe('getSessionDeadlineFormat', () => {
         );
 
         expect(result).toEqual(['seconds']);
+    });
+});
+
+describe('getMaxRounds', () => {
+    fixtures.getMaxRounds.forEach(f => {
+        it(f.description, () => {
+            expect(
+                coinjoinUtils.getMaxRounds(f.params.targetAnonymity, f.params.anonymitySet),
+            ).toEqual(f.result);
+        });
     });
 });

--- a/packages/suite/src/utils/wallet/coinjoinUtils.ts
+++ b/packages/suite/src/utils/wallet/coinjoinUtils.ts
@@ -9,6 +9,8 @@ import {
 } from '@suite-common/wallet-types';
 import {
     ESTIMATED_ANONYMITY_GAINED_PER_ROUND,
+    ESTIMATED_MIN_ROUNDS_NEEDED,
+    ESTIMATED_ROUNDS_FAIL_RATE_BUFFER,
     ESTIMATED_HOURS_PER_ROUND_WITHOUT_SKIPPING_ROUNDS,
     ESTIMATED_HOURS_PER_ROUND_WITH_SKIPPING_ROUNDS,
 } from '@suite/services/coinjoin/config';
@@ -151,7 +153,11 @@ export const getRegisterAccountParams = (
 export const getMaxRounds = (targetAnonymity: number, anonymitySet: AnonymitySet) => {
     // fallback to 1 if any value is undefined or the object is empty
     const lowestAnonymity = Math.min(...(Object.values(anonymitySet).map(item => item ?? 1) || 1));
-    return Math.ceil((targetAnonymity - lowestAnonymity) / ESTIMATED_ANONYMITY_GAINED_PER_ROUND);
+    const estimatedRoundsCount = Math.ceil(
+        ((targetAnonymity - lowestAnonymity) / ESTIMATED_ANONYMITY_GAINED_PER_ROUND) *
+            ESTIMATED_ROUNDS_FAIL_RATE_BUFFER,
+    );
+    return Math.max(estimatedRoundsCount, ESTIMATED_MIN_ROUNDS_NEEDED);
 };
 
 // get time estimate in hours per round

--- a/packages/suite/src/views/wallet/anonymize/components/CoinjoinSessionDetail.tsx
+++ b/packages/suite/src/views/wallet/anonymize/components/CoinjoinSessionDetail.tsx
@@ -1,7 +1,10 @@
 import React from 'react';
 import styled from 'styled-components';
 
-import { ESTIMATED_HOURS_BUFFER_MODIFIER } from '@suite/services/coinjoin/config';
+import {
+    ESTIMATED_HOURS_BUFFER_MODIFIER,
+    ESTIMATED_ROUNDS_FAIL_RATE_BUFFER,
+} from '@suite/services/coinjoin/config';
 import { getEstimatedTimePerRound } from '@wallet-utils/coinjoinUtils';
 import { Translation } from '@suite-components';
 import { DetailRow } from './DetailRow';
@@ -24,7 +27,8 @@ export const CoinjoinSessionDetail = ({
     maxFee,
     skipRounds,
 }: CoinjoinSessionDetailProps) => {
-    const estimatedTime = maxRounds * getEstimatedTimePerRound(!!skipRounds);
+    const estimatedTime =
+        (maxRounds / ESTIMATED_ROUNDS_FAIL_RATE_BUFFER) * getEstimatedTimePerRound(!!skipRounds);
     const timeBuffer = estimatedTime * ESTIMATED_HOURS_BUFFER_MODIFIER;
     const maxEstimatedTime = Math.ceil(estimatedTime + timeBuffer);
     const minEstimatedTime = Math.floor(estimatedTime - timeBuffer);


### PR DESCRIPTION

<!--- Provide a general summary of your changes in the Title above -->

## Description

- Allow at least 8 max rounds. We could reduce that later if we see that lower number is sufficient.
- Lower the estimated anonymity gained per round to count with ruined rounds. Let's say for now that 1 of 3 rounds should be sucessful.
<!--- Describe your changes in detail -->

## Related Issue

Resolve https://github.com/trezor/trezor-suite/issues/6863

## Screenshots (if appropriate):
<img width="643" alt="image" src="https://user-images.githubusercontent.com/3729633/201060586-cf34c333-d09c-438b-bc1d-c25119ee6e94.png">

