### PR TITLE
nix: add WabiSabiClientLibrary shared libs

### DIFF
--- a/shell.nix
+++ b/shell.nix
@@ -36,6 +36,10 @@ in
       Cocoa
       CoreServices
     ]);
+
+    # for WalletWasabi.WabiSabiClientLibrary
+    LD_LIBRARY_PATH = "${gcc}/lib:${openssl.out}/lib:${zlib}/lib:${stdenv.cc.cc.lib}/lib";
+
     shellHook = ''
       export NODE_OPTIONS=--max_old_space_size=4096
       export CURDIR="$(pwd)"


### PR DESCRIPTION
add shared libs to `LD_LIBRARY_PATH`

running `WalletWasabi.WabiSabiClientLibrary` still requires some tweaking

### easiest and ugly
Create /lib64 dir with symlink on the root of file system
```
sudo mkdir -p /lib64
sudo ln -sf $(cat $NIX_CC/nix-support/dynamic-linker) /lib64
```

### or worst :)
This will cause git changes of binary file
```
patchelf --set-interpreter "$(cat $NIX_CC/nix-support/dynamic-linker)" ./packages/suite-data/files/bin/coinjoin/linux-x64/WalletWasabi.WabiSabiClientLibrary
```


