### PR TITLE
fix(coinjoin): accept only known request codes from coordinator

### DIFF
--- a/packages/coinjoin/src/client/coordinator.ts
+++ b/packages/coinjoin/src/client/coordinator.ts
@@ -48,7 +48,7 @@ export const inputUnregistration = (roundId: string, aliceId: string, options: R
             roundId,
             aliceId,
         },
-        { ...options, parseJson: false },
+        options,
     );
 
 export const connectionConfirmation = (
@@ -108,7 +108,7 @@ export const outputRegistration = (
             amountCredentialRequests: amountCredentials.credentialsRequest,
             vsizeCredentialRequests: vsizeCredentials.credentialsRequest,
         },
-        { ...options, parseJson: false },
+        options,
     );
 
 export const readyToSign = (roundId: string, aliceId: string, options: RequestOptions) =>
@@ -118,7 +118,7 @@ export const readyToSign = (roundId: string, aliceId: string, options: RequestOp
             roundId,
             aliceId,
         },
-        { ...options, parseJson: false },
+        options,
     );
 
 export const transactionSignature = (
@@ -134,7 +134,7 @@ export const transactionSignature = (
             inputIndex,
             witness,
         },
-        { ...options, parseJson: false },
+        options,
     );
 
 // reexport all coordinator types

--- a/packages/coinjoin/tests/client/transactionSigning.test.ts
+++ b/packages/coinjoin/tests/client/transactionSigning.test.ts
@@ -13,6 +13,7 @@ jest.mock('cross-fetch', () => {
         default: (url: string, ...rest: any[]) => {
             if (url.includes('get_coinjoin_request_suite')) {
                 return {
+                    status: 200,
                     ok: true,
                     headers: { get: () => 'json' },
                     text: () => Promise.resolve(JSON.stringify({ fee_rate: 0.003 })),

--- a/packages/coinjoin/tests/mocks/server.ts
+++ b/packages/coinjoin/tests/mocks/server.ts
@@ -44,9 +44,10 @@ const DEFAULT = {
         },
     },
     'credential-issuance': {},
-    'output-registration': {},
-    'ready-to-sign': {},
-    'transaction-signature': {},
+    'output-registration': '',
+    'ready-to-sign': '',
+    'transaction-signature': '',
+    'input-unregistration': '',
 };
 
 export const getFreePort = () =>
@@ -65,15 +66,24 @@ export const getFreePort = () =>
 const handleRequest = (req: http.IncomingMessage, res: http.ServerResponse, testResponse?: any) => {
     if (res.writableEnded) return; // send default response if res.end wasn't called in test
 
-    res.setHeader('Content-Type', 'application/json');
     if (testResponse) {
+        res.setHeader('Content-Type', 'application/json');
         res.write(JSON.stringify(testResponse));
         res.end();
         return;
     }
+
     const url = req.url?.split('/').pop();
-    const data = DEFAULT[url as keyof typeof DEFAULT] || {};
-    res.write(JSON.stringify(data));
+    const data = DEFAULT[url as keyof typeof DEFAULT] ?? {};
+    if (typeof data === 'string') {
+        // not all coordinator responses are in json format
+        res.setHeader('Content-Type', 'text/xml');
+        res.write(data);
+    } else {
+        res.setHeader('Content-Type', 'application/json');
+        res.write(JSON.stringify(data));
+    }
+
     res.end();
 };
 

--- a/packages/request-manager/e2e/interceptor.test.ts
+++ b/packages/request-manager/e2e/interceptor.test.ts
@@ -98,6 +98,21 @@ describe('Interceptor', () => {
             expect(iPIdentitieA).toEqual(iPIdentitieA2);
             // Check if identities are different when using different identity.
             expect(iPIdentitieA).not.toEqual(iPIdentitieB);
+
+            // reset existing circuit using identity with password
+            const identityB2 = await fetch(testGetUrlHttps, {
+                headers: { 'Proxy-Authorization': 'Basic user:password' },
+            });
+            const iPIdentitieB2 = ((await identityB2.text()) as any).match(ipRegex)[0];
+            // ip for "user" did change
+            expect(iPIdentitieB2).not.toEqual(iPIdentitieB);
+            // continue using new circuit
+            const identityB3 = await fetch(testGetUrlHttps, {
+                headers: { 'Proxy-Authorization': 'Basic user' },
+            });
+            const iPIdentitieB3 = ((await identityB3.text()) as any).match(ipRegex)[0];
+            // same ip after change
+            expect(iPIdentitieB3).toEqual(iPIdentitieB2);
         });
     });
 

--- a/packages/request-manager/src/torIdentities.ts
+++ b/packages/request-manager/src/torIdentities.ts
@@ -16,14 +16,24 @@ export class TorIdentities {
         if (!this.torController) {
             throw new Error('TorIdentities is not initialized');
         }
-        if (!this.identities[identity]) {
-            this.identities[identity] = new SocksProxyAgent({
+
+        const [user, password] = identity.split(':');
+
+        if (this.identities[user] && password) {
+            // looks like destroy does nothing, but just in case
+            this.identities[user].destroy();
+            delete this.identities[user];
+        }
+
+        if (!this.identities[user]) {
+            this.identities[user] = new SocksProxyAgent({
                 hostname: this.torController.options.host,
                 port: this.torController.options.port,
-                userId: identity,
-                password: identity,
+                userId: user,
+                password: password || user,
             });
         }
-        return this.identities[identity];
+
+        return this.identities[user];
     }
 }

--- a/packages/suite-desktop/src/modules/request-interceptor.ts
+++ b/packages/suite-desktop/src/modules/request-interceptor.ts
@@ -8,6 +8,7 @@
  * whereas request-filter logs and filters allowed requests from electron renderer process.
  */
 import { createInterceptor, InterceptedEvent } from '@trezor/request-manager';
+import { isDevEnv } from '@suite-common/suite-utils';
 
 import { Module } from './index';
 
@@ -21,6 +22,7 @@ export const init: Module = ({ store }) => {
             }
         },
         getIsTorEnabled: () => store.getTorSettings().running,
+        isDevEnv,
     };
 
     createInterceptor(options);


### PR DESCRIPTION
happens yesterday. Coordinator request was blocked by cloudlflare (probably because of tor) and returned: 403. Forbidden witch some cloudflare captcha html page:

`
{"time":1668102029359,"value":"Registration 6fb4e868...02000000 to 4c90ee87...fee86bad failed: https://dev-coinjoin-testnet.trezor.io/WabiSabi/input-registration Forbidden: <!DOCTYPE html>\n<html lang=\"en-US\">\n<head>\n    <title>Just a moment...</title>\n    <meta http-equiv=\"Content-Type\" content=\"text/html; charset=UTF-8\">\n    <meta http-equiv=\"X-UA-Compatible\" content=\"IE=Edge\">\n..... dev-coinjoin-testnet.trezor.io needs to review the security of your connection before proceeding....
`

## Solution

Only listed request codes should be threated as valid, other codes should try to repeat the request

## Additional changes
- json parsing decision should be done by response content-type not by options (removed `parseJson`)
- modified server responses (not all coordinator requests returns json)


## Edit

i've ended up doing some changes in request-manager package. CC @karliatto 

- block requests with Proxy-Authorization header when TOR is disabled
> Cleanup in code (types), one function to cover both http and https interception cases

- change identity when password is provided
> Workaround for 403, if this error happens during coinjoin process try to change circuit and try again

## Issues
- resolves https://github.com/trezor/trezor-suite/issues/6674