### PR TITLE
Fix change address detection

### DIFF
--- a/packages/suite/src/components/wallet/CoinControl/UtxoSelection.tsx
+++ b/packages/suite/src/components/wallet/CoinControl/UtxoSelection.tsx
@@ -148,7 +148,7 @@ export const UtxoSelection = ({ isChecked, transaction, utxo }: UtxoSelectionPro
     const unavailableMessage = amountTooSmallForCoinjoin
         ? 'TR_AMOUNT_TOO_SMALL_FOR_COINJOIN'
         : 'TR_AMOUNT_TOO_BIG_FOR_COINJOIN';
-    const isChangeAddress = utxo.path.split('/')[4] === '1';
+    const isChangeAddress = utxo.path.split('/').at(-2) === '1'; // change address always has a 1 on the penultimate level of the derivation path
     const amountInBtc = (Number(utxo.amount) / 10 ** network.decimals).toString();
     const outputLabel = account.metadata.outputLabels?.[utxo.txid]?.[utxo.vout];
     const isLabelingPossible = device?.metadata.status === 'enabled' || device?.connected;


### PR DESCRIPTION
## Description

Previously used change address detection in coin control did not work on a CoinJoin account because its derivation path is longer. This PR fixes the detection by going from the end of the derivation path.

## Screenshots (if appropriate):
![Screenshot 2022-11-14 at 13 11 48](https://user-images.githubusercontent.com/42465546/201656979-e6e8778d-84a9-4ccf-b963-8c405128e47d.png)

**QA:** Change address should be correctly detected in each type of account.
