### PR TITLE
fix(suite): delete cj accounts from the db storage when a device is forgotten

### DIFF
--- a/packages/suite/src/actions/suite/storageActions.ts
+++ b/packages/suite/src/actions/suite/storageActions.ts
@@ -116,6 +116,7 @@ export const forgetDevice = (device: TrezorDevice) => async (_: Dispatch, getSta
             promises.concat(
                 [removeAccountDraft(account)],
                 FormDraftPrefixKeyValues.map(prefix => removeAccountFormDraft(prefix, account.key)),
+                removeCoinjoinAccount(account.key),
             ),
         [] as Promise<void>[],
     );


### PR DESCRIPTION


<!--- Provide a general summary of your changes in the Title above -->

## Description

Previously CJ accounts were not deleted from the db storage, which let to desynchronization between `wallet.coinjoin` and `wallet.accounts` on app reload. 

## Related Issue

Resolve #6892
