### PR TITLE
feat(coinjoin): rename coinjoin account type

### DIFF
--- a/packages/suite-desktop/e2e/tests/coinjoin.test.ts
+++ b/packages/suite-desktop/e2e/tests/coinjoin.test.ts
@@ -58,7 +58,7 @@ const addCoinjoinAccount = async (window: Page) => {
     await window.click('[data-test="@settings/wallet/network/regtest"]');
     await window.click('[data-test="@add-account-type/select/input"]', { trial: true });
     await window.click('[data-test="@add-account-type/select/input"]');
-    await window.click('[data-test="@add-account-type/select/option/Bitcoin Regtest (PEA)"]');
+    await window.click('[data-test="@add-account-type/select/option/Bitcoin Regtest (CoinJoin)"]');
     await window.click('[data-test="@add-account"]');
 
     await window.click('[data-test="@request-enable-tor-modal/skip-button"]');

--- a/suite-common/wallet-config/src/networksConfig.ts
+++ b/suite-common/wallet-config/src/networksConfig.ts
@@ -236,7 +236,7 @@ export const networks = {
         customBackends: ['blockbook', 'electrum'],
         accountTypes: {
             coinjoin: {
-                name: 'Bitcoin Testnet (PEA)',
+                name: 'Bitcoin Testnet (CoinJoin)',
                 bip43Path: "m/10025'/1'/i'/1'", // https://github.com/satoshilabs/slips/blob/master/slip-0025.md#public-key-derivation
                 backendType: 'coinjoin', // use non-standard backend
                 features: ['amount-unit'], // no rbf, no sign-verify
@@ -271,7 +271,7 @@ export const networks = {
         customBackends: ['blockbook', 'electrum'],
         accountTypes: {
             coinjoin: {
-                name: 'Bitcoin Regtest (PEA)',
+                name: 'Bitcoin Regtest (CoinJoin)',
                 bip43Path: "m/10025'/1'/i'/1'", // https://github.com/satoshilabs/slips/blob/master/slip-0025.md#public-key-derivation
                 backendType: 'coinjoin', // use non-standard backend
                 features: ['amount-unit'], // no rbf, no sign-verify


### PR DESCRIPTION
- We stop using PEA (Privacy Enhanced Account) and using CoinJoin instead

<!--- Provide a general summary of your changes in the Title above -->



## Screenshots (if appropriate):
<img width="570" alt="image" src="https://user-images.githubusercontent.com/3729633/201666294-48acad5c-327a-4a06-bfe1-c1e197ccc6bf.png">
