### PR TITLE
Disable banned utxo tag for non-coinjoin accounts

### DIFF
--- a/packages/suite/src/components/wallet/CoinControl/UtxoSelection.tsx
+++ b/packages/suite/src/components/wallet/CoinControl/UtxoSelection.tsx
@@ -144,7 +144,9 @@ export const UtxoSelection = ({ isChecked, transaction, utxo }: UtxoSelectionPro
         coordinatorData && new BigNumber(utxo.amount).lt(coordinatorData.allowedInputAmounts.min);
     const amountTooBigForCoinjoin =
         coordinatorData && new BigNumber(utxo.amount).gt(coordinatorData.allowedInputAmounts.max);
-    const isUnavailableForCoinjoin = amountTooSmallForCoinjoin || amountTooBigForCoinjoin; // TODO: add blacklisted UTXOs - https://github.com/trezor/trezor-suite/issues/6757
+    const isUnavailableForCoinjoin =
+        account.accountType === 'coinjoin' &&
+        (amountTooSmallForCoinjoin || amountTooBigForCoinjoin); // TODO: add blacklisted UTXOs - https://github.com/trezor/trezor-suite/issues/6757
     const unavailableMessage = amountTooSmallForCoinjoin
         ? 'TR_AMOUNT_TOO_SMALL_FOR_COINJOIN'
         : 'TR_AMOUNT_TOO_BIG_FOR_COINJOIN';


### PR DESCRIPTION
## Description

Fixes condition to display banned UTXO tag so that it is only displayed in CoinJoin accounts.

## Related Issue

Resolve #6900

![Screenshot 2022-11-14 at 17 30 29](https://user-images.githubusercontent.com/42465546/201713811-2a55533e-4428-47e9-af96-eac888ba6151.png)
