### PR TITLE
feat(suite): reflect loading tor status when enabling coinjoin

### DIFF
--- a/packages/components/src/components/buttons/Button/index.tsx
+++ b/packages/components/src/components/buttons/Button/index.tsx
@@ -225,8 +225,12 @@ export const Button = React.forwardRef(
             </IconWrapper>
         ) : null;
         const Loader = (
-            <IconWrapper alignIcon={alignIcon} hasLabel={hasLabel}>
-                <FluidSpinner size={10} color={color} />
+            <IconWrapper alignIcon={alignIcon} variant={variant} hasLabel={hasLabel}>
+                <FluidSpinner
+                    size={getIconSize(variant, hasLabel) - 1}
+                    color={color}
+                    strokeWidth={2}
+                />
             </IconWrapper>
         );
         return (

--- a/packages/suite/src/components/suite/Banners/MessageSystemBanner.tsx
+++ b/packages/suite/src/components/suite/Banners/MessageSystemBanner.tsx
@@ -5,10 +5,11 @@ import { variables } from '@trezor/components';
 import * as routerActions from '@suite-actions/routerActions';
 import * as messageSystemActions from '@suite-actions/messageSystemActions';
 import { useActions, useSelector } from '@suite-hooks';
-import { getIsTorEnabled, getTorUrlIfAvailable } from '@suite-utils/tor';
+import { getTorUrlIfAvailable } from '@suite-utils/tor';
 import { Banner } from './Banner';
 
 import type { Message } from '@trezor/message-system';
+import { selectTorState } from '@suite-reducers/suiteReducer';
 
 const BannerOnTop = styled(Banner)`
     position: relative;
@@ -22,9 +23,9 @@ type Props = {
 const MessageSystemBanner = ({ message }: Props) => {
     const { cta, variant, id, content, dismissible } = message;
 
-    const { language, isTorEnabled, torOnionLinks } = useSelector(state => ({
+    const { isTorEnabled } = useSelector(selectTorState);
+    const { language, torOnionLinks } = useSelector(state => ({
         language: state.suite.settings.language,
-        isTorEnabled: getIsTorEnabled(state.suite.torStatus),
         torOnionLinks: state.suite.settings.torOnionLinks,
     }));
 

--- a/packages/suite/src/components/suite/NavigationBar/components/NavigationActions/index.tsx
+++ b/packages/suite/src/components/suite/NavigationBar/components/NavigationActions/index.tsx
@@ -16,10 +16,10 @@ import { NavSettings } from './components/NavSettings';
 import { variables } from '@trezor/components';
 import { NavBackends } from './components/NavBackends';
 import { useGuide } from '@guide-hooks/useGuide';
-import { getIsTorEnabled, getIsTorLoading } from '@suite-utils/tor';
 import { SettingsAnchor } from '@suite-constants/anchors';
 
 import type { Route } from '@suite-types';
+import { selectTorState } from '@suite-reducers/suiteReducer';
 
 const Wrapper = styled.div`
     display: flex;
@@ -65,12 +65,12 @@ export const NavigationActions = ({
     closeMainNavigation,
     isMobileLayout,
 }: NavigationActionsProps) => {
-    const { activeApp, notifications, discreetMode, torStatus, allowPrerelease, enabledNetworks } =
+    const { isTorEnabled, isTorLoading } = useSelector(selectTorState);
+    const { activeApp, notifications, discreetMode, allowPrerelease, enabledNetworks } =
         useSelector(state => ({
             activeApp: state.router.app,
             notifications: state.notifications,
             discreetMode: state.wallet.settings.discreetMode,
-            torStatus: state.suite.torStatus,
             theme: state.suite.settings.theme,
             allowPrerelease: state.desktopUpdate.allowPrerelease,
             enabledNetworks: state.wallet.settings.enabledNetworks,
@@ -105,9 +105,6 @@ export const NavigationActions = ({
     const customBackends = useCustomBackends().filter(backend =>
         enabledNetworks.includes(backend.coin),
     );
-
-    const isTorEnabled = getIsTorEnabled(torStatus);
-    const isTorLoading = getIsTorLoading(torStatus);
 
     return (
         <WrapperComponent>

--- a/packages/suite/src/components/suite/modals/AddAccount/components/AddCoinJoinAccountButton.tsx
+++ b/packages/suite/src/components/suite/modals/AddAccount/components/AddCoinJoinAccountButton.tsx
@@ -8,12 +8,12 @@ import * as modalActions from '@suite-actions/modalActions';
 import { Account, Network, NetworkSymbol } from '@wallet-types';
 import { UnavailableCapabilities } from '@trezor/connect';
 import { AddButton } from './AddButton';
-import { getIsTorEnabled } from '@suite-utils/tor';
 import { isDesktop } from '@suite-utils/env';
 import { isDevEnv } from '@suite-common/suite-utils';
 import { desktopApi } from '@trezor/suite-desktop-api';
 import { Dispatch } from '@suite-types';
 import { RequestEnableTorResponse } from '@suite-components/modals/RequestEnableTor';
+import { selectTorState } from '@suite-reducers/suiteReducer';
 
 interface VerifyAvailabilityProps {
     coinjoinAccounts: Account[];
@@ -52,7 +52,7 @@ const requestEnableTorAction = () => (dispatch: Dispatch) =>
 export const AddCoinJoinAccountButton = ({ network }: AddCoinJoinAccountProps) => {
     const [isLoading, setIsLoading] = useState(false);
 
-    const isTorEnabled = useSelector(state => getIsTorEnabled(state.suite.torStatus));
+    const { isTorEnabled } = useSelector(selectTorState);
     const device = useSelector(state => state.suite.device);
     const accounts = useSelector(state => state.wallet.accounts);
 

--- a/packages/suite/src/components/suite/modals/AdvancedCoinSettings/components/CustomBackends.tsx
+++ b/packages/suite/src/components/suite/modals/AdvancedCoinSettings/components/CustomBackends.tsx
@@ -6,12 +6,13 @@ import InputError from '@wallet-components/InputError';
 import { useSelector, useActions } from '@suite-hooks';
 import { toggleTor as toggleTorAction } from '@suite-actions/suiteActions';
 import { useDefaultUrls, useBackendsForm } from '@settings-hooks/backends';
-import { getIsTorEnabled, toTorUrl } from '@suite-utils/tor';
+import { toTorUrl } from '@suite-utils/tor';
 import ConnectionInfo from './ConnectionInfo';
 import { BackendInput } from './BackendInput';
 import { BackendTypeSelect } from './BackendTypeSelect';
 import { TorModal, TorResult } from './TorModal';
 import type { Network } from '@wallet-types';
+import { selectTorState } from '@suite-reducers/suiteReducer';
 
 const Wrapper = styled.div`
     display: flex;
@@ -67,10 +68,8 @@ interface CustomBackendsProps {
 }
 
 export const CustomBackends = ({ network, onCancel }: CustomBackendsProps) => {
-    const { blockchain, isTorEnabled } = useSelector(state => ({
-        blockchain: state.wallet.blockchain,
-        isTorEnabled: getIsTorEnabled(state.suite.torStatus),
-    }));
+    const { isTorEnabled } = useSelector(selectTorState);
+    const blockchain = useSelector(state => state.wallet.blockchain);
     const [torModalOpen, setTorModalOpen] = useState(false);
 
     const { toggleTor } = useActions({

--- a/packages/suite/src/components/suite/modals/RequestEnableTor.tsx
+++ b/packages/suite/src/components/suite/modals/RequestEnableTor.tsx
@@ -1,10 +1,11 @@
-import React from 'react';
+import React, { useEffect } from 'react';
 import styled from 'styled-components';
 import { Button, P } from '@trezor/components';
 import { Modal, Translation } from '@suite-components';
 import { UserContextPayload } from '@suite-actions/modalActions';
 import { isDevEnv } from '@suite-common/suite-utils';
 import { useSelector } from '@suite-hooks';
+import { selectTorState } from '@suite-reducers/suiteReducer';
 
 const SmallModal = styled(Modal)`
     width: 560px;
@@ -31,9 +32,15 @@ export enum RequestEnableTorResponse {
 }
 
 export const RequestEnableTor = ({ onCancel, decision }: RequestEnableTorProps) => {
-    const { debug } = useSelector(state => ({
-        debug: state.suite.settings.debug,
-    }));
+    const debug = useSelector(state => state.suite.settings.debug);
+    const { isTorLoading, isTorEnabled } = useSelector(selectTorState);
+
+    useEffect(() => {
+        if (isTorEnabled) {
+            decision.resolve(RequestEnableTorResponse.Skip);
+            onCancel();
+        }
+    }, [isTorEnabled, decision, onCancel]);
 
     const onEnableTor = () => {
         decision.resolve(RequestEnableTorResponse.Continue);
@@ -72,8 +79,18 @@ export const RequestEnableTor = ({ onCancel, decision }: RequestEnableTorProps) 
                         <Button variant="secondary" onClick={onCancel}>
                             <Translation id="TR_TOR_REQUEST_ENABLE_FOR_COIN_JOIN_LEAVE" />
                         </Button>
-                        <Button variant="primary" onClick={onEnableTor}>
-                            <Translation id="TR_TOR_ENABLE" />
+
+                        <Button
+                            variant="primary"
+                            onClick={onEnableTor}
+                            isLoading={isTorLoading}
+                            isDisabled={isTorLoading}
+                        >
+                            {isTorLoading ? (
+                                <Translation id="TR_ENABLING_TOR" />
+                            ) : (
+                                <Translation id="TR_TOR_ENABLE" />
+                            )}
                         </Button>
                     </>
                 }

--- a/packages/suite/src/components/wallet/AccountTopPanel/index.tsx
+++ b/packages/suite/src/components/wallet/AccountTopPanel/index.tsx
@@ -34,7 +34,7 @@ interface AccountTopPanelSkeletonProps {
 const AccountTopPanelSkeleton = ({ animate }: AccountTopPanelSkeletonProps) => (
     <AppNavigationPanel
         maxWidth="small"
-        title={<SkeletonRectangle width="260px" height="26px" animate={animate} />}
+        title={<SkeletonRectangle width="260px" height="28px" animate={animate} />}
         navigation={<AccountNavigation />}
     >
         <Stack margin="6px 0px 0px 0px" childMargin="0px 0px 8px 0px">

--- a/packages/suite/src/hooks/suite/useExternalLink.ts
+++ b/packages/suite/src/hooks/suite/useExternalLink.ts
@@ -1,15 +1,14 @@
 import { useMemo } from 'react';
 import { useSelector } from '@suite-hooks';
-import { getIsTorEnabled, getTorUrlIfAvailable } from '@suite-utils/tor';
+import { getTorUrlIfAvailable } from '@suite-utils/tor';
+import { selectTorState } from '@suite-reducers/suiteReducer';
 
 /**
  * Returns plain url or onion url if available and tor is active
  */
 export const useExternalLink = (originalUrl?: string) => {
-    const { isTorEnabled, torOnionLinks } = useSelector(state => ({
-        isTorEnabled: getIsTorEnabled(state.suite.torStatus),
-        torOnionLinks: state.suite.settings.torOnionLinks,
-    }));
+    const { isTorEnabled } = useSelector(selectTorState);
+    const torOnionLinks = useSelector(state => state.suite.settings.torOnionLinks);
 
     const url = useMemo(() => {
         if (originalUrl && isTorEnabled && torOnionLinks) {

--- a/packages/suite/src/reducers/suite/suiteReducer.ts
+++ b/packages/suite/src/reducers/suite/suiteReducer.ts
@@ -13,6 +13,12 @@ import { getNumberFromPixelString } from '@trezor/utils';
 import type { OAuthServerEnvironment } from '@suite-types/metadata';
 import type { InvityServerEnvironment } from '@wallet-types/invity';
 import type { CoinjoinServerEnvironment } from '@suite-common/wallet-types';
+import { createSelector } from '@reduxjs/toolkit';
+import { getIsTorEnabled, getIsTorLoading } from '@suite-utils/tor';
+
+export interface SuiteRootState {
+    suite: SuiteState;
+}
 
 export interface DebugModeOptions {
     invityServerEnvironment?: InvityServerEnvironment;
@@ -232,5 +238,13 @@ const suiteReducer = (state: SuiteState = initialState, action: Action): SuiteSt
             // no default
         }
     });
+
+export const selectTorState = createSelector(
+    (state: SuiteRootState) => state.suite.torStatus,
+    torStatus => ({
+        isTorEnabled: getIsTorEnabled(torStatus),
+        isTorLoading: getIsTorLoading(torStatus),
+    }),
+);
 
 export default suiteReducer;

--- a/packages/suite/src/support/suite/useTor.tsx
+++ b/packages/suite/src/support/suite/useTor.tsx
@@ -1,14 +1,15 @@
 import { useEffect } from 'react';
 import { desktopApi } from '@trezor/suite-desktop-api';
 import { useActions, useSelector } from '@suite-hooks';
-import { baseFetch, getIsTorEnabled, getIsTorDomain, torFetch } from '@suite-utils/tor';
+import { baseFetch, getIsTorDomain, torFetch } from '@suite-utils/tor';
 import * as suiteActions from '@suite-actions/suiteActions';
 import { isWeb, isDesktop } from '@suite-utils/env';
 import { getLocationHostname } from '@trezor/env-utils';
 import { TorStatus } from '@suite-types';
+import { selectTorState } from '@suite-reducers/suiteReducer';
 
 export const useTor = () => {
-    const isTorEnabled = useSelector(state => getIsTorEnabled(state.suite.torStatus));
+    const { isTorEnabled } = useSelector(selectTorState);
 
     const { updateTorStatus } = useActions({
         updateTorStatus: suiteActions.updateTorStatus,

--- a/packages/suite/src/views/suite/bridge/index.tsx
+++ b/packages/suite/src/views/suite/bridge/index.tsx
@@ -6,7 +6,7 @@ import { Button, P, Link, Select, Image, useTheme, variables, Loader } from '@tr
 import * as routerActions from '@suite-actions/routerActions';
 import { isDesktop, isWeb } from '@suite-utils/env';
 import { useSelector, useActions } from '@suite-hooks';
-import { getIsTorEnabled } from '@suite-utils/tor';
+import { selectTorState } from '@suite-reducers/suiteReducer';
 
 const Content = styled.div`
     display: flex;
@@ -96,15 +96,14 @@ interface Installer {
 }
 
 export const InstallBridge = () => {
+    const { isTorEnabled } = useSelector(selectTorState);
+    const transport = useSelector(state => state.suite.transport);
+    const [selectedTarget, setSelectedTarget] = useState<Installer | null>(null);
+
+    const theme = useTheme();
     const actions = useActions({
         goto: routerActions.goto,
     });
-    const { isTorEnabled, transport } = useSelector(state => ({
-        isTorEnabled: getIsTorEnabled(state.suite.torStatus),
-        transport: state.suite.transport,
-    }));
-    const theme = useTheme();
-    const [selectedTarget, setSelectedTarget] = useState<Installer | null>(null);
 
     const installers: Installer[] =
         transport && transport.bridge


### PR DESCRIPTION

## Description

* UI now reflects if Tor is enabling in the "enable Tor for coinjoin" modal. Modal automatically closes when Tor gets enabled and the process continues normally.
* minor UI enhancements

## Related Issue

Resolve [#6852](https://github.com/trezor/trezor-suite/issues/6852)

## Screenshots:

<img width="602" alt="image" src="https://user-images.githubusercontent.com/45338719/201732967-2b4254a7-473f-4b80-b912-4095d5cbe3c3.png">
