### PR TITLE
feat(suite-native): Add number of accounts per asset

### DIFF
--- a/suite-common/wallet-core/src/accounts/accountsReducer.ts
+++ b/suite-common/wallet-core/src/accounts/accountsReducer.ts
@@ -1,5 +1,5 @@
 import { createSelector, isAnyOf } from '@reduxjs/toolkit';
-import { A } from '@mobily/ts-belt';
+import { A, pipe } from '@mobily/ts-belt';
 
 import { createReducerWithExtraDeps } from '@suite-common/redux-utils';
 import { enhanceHistory, isUtxoBased } from '@suite-common/wallet-utils';
@@ -173,4 +173,15 @@ export const selectAccountByDescriptor = createSelector(
     (_state: AccountsRootState, accountDescriptor: string) => accountDescriptor,
     (accounts, accountDescriptor): Account | null =>
         A.find(accounts, account => account.descriptor === accountDescriptor) ?? null,
+);
+
+export const selectAccountsAmountPerSymbol = createSelector(
+    selectAccounts,
+    (_state: AccountsRootState, networkSymbol: NetworkSymbol) => networkSymbol,
+    (accounts, networkSymbol): number =>
+        pipe(
+            accounts,
+            A.filter(account => account.symbol === networkSymbol),
+            A.length,
+        ),
 );

--- a/suite-native/assets/src/components/AssetItem.tsx
+++ b/suite-native/assets/src/components/AssetItem.tsx
@@ -1,11 +1,13 @@
 import React from 'react';
 import { TouchableOpacity } from 'react-native';
+import { useSelector } from 'react-redux';
 
-import { CryptoIcon, CryptoIconName } from '@trezor/icons';
+import { CryptoIcon, CryptoIconName, Icon } from '@trezor/icons';
 import { prepareNativeStyle, useNativeStyles } from '@trezor/styles';
 import { useFormatters } from '@suite-common/formatters';
 import { NetworkSymbol } from '@suite-common/wallet-config';
 import { Box, Text } from '@suite-native/atoms';
+import { AccountsRootState, selectAccountsAmountPerSymbol } from '@suite-common/wallet-core';
 
 type AssetItemProps = {
     cryptoCurrencySymbol: NetworkSymbol;
@@ -29,6 +31,10 @@ const assetContentStyle = prepareNativeStyle(() => ({
     marginLeft: 10,
 }));
 
+const iconStyle = prepareNativeStyle(() => ({
+    marginRight: 6,
+}));
+
 export const AssetItem = ({
     cryptoCurrencySymbol,
     cryptoCurrencyValue,
@@ -38,6 +44,9 @@ export const AssetItem = ({
     onPress,
 }: AssetItemProps) => {
     const { applyStyle } = useNativeStyles();
+    const accountsPerAsset = useSelector((state: AccountsRootState) =>
+        selectAccountsAmountPerSymbol(state, cryptoCurrencySymbol),
+    );
     const { CryptoAmountFormatter, FiatAmountFormatter } = useFormatters();
 
     return (
@@ -45,13 +54,16 @@ export const AssetItem = ({
             <Box style={applyStyle(assetItemWrapperStyle)}>
                 <CryptoIcon name={iconName} size="large" />
                 <Box style={applyStyle(assetContentStyle)}>
-                    <Box
-                        flexDirection="row"
-                        flex={1}
-                        justifyContent="space-between"
-                        alignItems="center"
-                    >
+                    <Box flex={1} justifyContent="space-between" alignItems="flex-start">
                         <Text>{cryptoCurrencyName}</Text>
+                        <Box flexDirection="row" alignItems="center">
+                            <Box style={applyStyle(iconStyle)}>
+                                <Icon size="medium" color="gray600" name="standardWallet" />
+                            </Box>
+                            <Text variant="hint" color="gray600">
+                                {accountsPerAsset}
+                            </Text>
+                        </Box>
                     </Box>
                     <Box alignItems="flex-end">
                         <Text>{FiatAmountFormatter.format(fiatBalance)}</Text>


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Add number of accounts per asset in dashboard view.

## Related Issue

Resolve #6732

## Screenshots (if appropriate):
<img width="284" alt="image" src="https://user-images.githubusercontent.com/36101761/201864837-4e427ea9-11e5-44d1-bfde-d8f6e8f40cbb.png">
