### PR TITLE
Fix/connect setbusy

### DIFF
--- a/packages/connect/e2e/common.setup.js
+++ b/packages/connect/e2e/common.setup.js
@@ -31,7 +31,9 @@ const setup = async (TrezorUserEnvLink, options) => {
 
     if (
         state.mnemonic === options.mnemonic &&
-        JSON.stringify(state.settings) === JSON.stringify(options.settings)
+        state.passphrase_protection === options.passphrase_protection &&
+        JSON.stringify(state.settings) === JSON.stringify(options.settings) &&
+        !options.settings?.auto_lock_delay_ms // if device lock itself between test cases test will end timeout. user-env changes required (pin_sequence) https://github.com/trezor/trezor-user-env/pull/205
     ) {
         return true;
     }
@@ -46,7 +48,6 @@ const setup = async (TrezorUserEnvLink, options) => {
     // the test using the same transport
     await TrezorUserEnvLink.api.stopBridge();
 
-    console.log('start emu!!!', emulatorStartOpts);
     await TrezorUserEnvLink.api.startEmu(emulatorStartOpts);
 
     const mnemonic =

--- a/packages/connect/e2e/karma.setup.js
+++ b/packages/connect/e2e/karma.setup.js
@@ -1,6 +1,8 @@
 jasmine.DEFAULT_TIMEOUT_INTERVAL = 20000;
 
-// jasmine is missing "toMatchObject" matcher (deeply partial matching)
+// jest vs jasmine matchers compatibility:
+// - jasmine is missing "toMatchObject" matcher (deeply partial matching)
+// - jest.toBeCalledTimes === jasmine.matchers.toHaveBeenCalledTimes
 jasmine.getEnv().beforeAll(() => {
     jasmine.addMatchers({
         toMatchObject: _obj => ({
@@ -44,6 +46,7 @@ jasmine.getEnv().beforeAll(() => {
                 return success;
             },
         }),
+        toBeCalledTimes: jasmine.matchers.toHaveBeenCalledTimes,
     });
 });
 

--- a/packages/connect/e2e/tests/device/setBusy.test.ts
+++ b/packages/connect/e2e/tests/device/setBusy.test.ts
@@ -8,6 +8,10 @@ describe('TrezorConnect.setBusy', () => {
     beforeAll(async () => {
         await setup(controller, {
             mnemonic: 'mnemonic_all',
+            pin: '1234',
+            settings: {
+                auto_lock_delay_ms: 10000,
+            },
         });
         await initTrezorConnect(controller);
     });
@@ -18,22 +22,24 @@ describe('TrezorConnect.setBusy', () => {
     });
 
     conditionalTest(['1', '<2.5.3'], 'setBusy timeout', async () => {
-        const busy = await TrezorConnect.setBusy({
-            expiry_ms: 5000,
+        let busy = false;
+        TrezorConnect.on('DEVICE_EVENT', event => {
+            if ('features' in event.payload) {
+                busy = event.payload.features!.busy!;
+            }
         });
-        if (!busy.success) throw new Error(busy.payload.error);
+        const setBusy = await TrezorConnect.setBusy({
+            expiry_ms: 3000,
+            keepSession: true, // keep session
+        });
+        if (!setBusy.success) throw new Error(setBusy.payload.error);
 
-        let features: Awaited<ReturnType<typeof TrezorConnect.getFeatures>>;
-
-        features = await TrezorConnect.getFeatures();
-        if (!features.success) throw new Error(features.payload.error);
-        // is busy
-        expect(features.payload.busy).toBe(true);
+        expect(busy).toBe(true);
 
         // wait for expiry
-        await new Promise(resolve => setTimeout(resolve, 5000));
+        await new Promise(resolve => setTimeout(resolve, 3000));
 
-        features = await TrezorConnect.getFeatures();
+        const features = await TrezorConnect.getFeatures();
         if (!features.success) throw new Error(features.payload.error);
         expect(features.payload.busy).toBe(false);
     });
@@ -57,5 +63,31 @@ describe('TrezorConnect.setBusy', () => {
         if (!features.success) throw new Error(features.payload.error);
         // not busy
         expect(features.payload.busy).toBe(false);
+    });
+
+    conditionalTest(['1', '<2.5.3'], 'setBusy with autolock', async () => {
+        await new Promise(resolve => setTimeout(resolve, 11000)); // wait for auto-lock
+
+        let busy = false;
+        TrezorConnect.on('DEVICE_EVENT', event => {
+            if ('features' in event.payload) {
+                busy = event.payload.features!.busy!;
+            }
+        });
+
+        const setBusy = await TrezorConnect.setBusy({
+            expiry_ms: 15000,
+            keepSession: true, // keep session
+        });
+        if (!setBusy.success) throw new Error(setBusy.payload.error);
+
+        expect(busy).toBe(true);
+
+        await new Promise(resolve => setTimeout(resolve, 1000)); // cool off
+
+        // reset expiry
+        await TrezorConnect.setBusy({});
+
+        expect(busy).toBe(false);
     });
 });

--- a/packages/connect/src/api/setBusy.ts
+++ b/packages/connect/src/api/setBusy.ts
@@ -1,4 +1,5 @@
 import { AbstractMethod } from '../core/AbstractMethod';
+import { DEVICE, createDeviceMessage } from '../events';
 import { PROTO } from '../constants';
 import { getFirmwareRange, validateParams } from './common/paramsValidator';
 
@@ -6,7 +7,6 @@ export default class SetBusy extends AbstractMethod<'setBusy', PROTO.SetBusy> {
     init() {
         this.useDeviceState = false;
         this.requiredPermissions = ['management'];
-        this.keepSession = true; // TODO: device-changed will not be emitted. followup: https://github.com/trezor/trezor-suite/issues/6446
 
         const { payload } = this;
 
@@ -25,6 +25,14 @@ export default class SetBusy extends AbstractMethod<'setBusy', PROTO.SetBusy> {
     async run() {
         const cmd = this.device.getCommands();
         const { message } = await cmd.typedCall('SetBusy', 'Success', this.params);
+        if (this.keepSession && !!this.params.expiry_ms) {
+            // NOTE: DEVICE.CHANGED will not be emitted because session is not released
+            // change device features and trigger event manually
+            // followup: https://github.com/trezor/trezor-suite/issues/6446
+            this.device.features.busy = true;
+            this.postMessage(createDeviceMessage(DEVICE.CHANGED, this.device.toMessageObject()));
+        }
+
         return message;
     }
 }

--- a/packages/suite/src/actions/wallet/__fixtures__/coinjoinClientActions.ts
+++ b/packages/suite/src/actions/wallet/__fixtures__/coinjoinClientActions.ts
@@ -2,7 +2,7 @@ import { testMocks } from '@suite-common/test-utils';
 import * as MODAL from '@suite-actions/constants/modalConstants';
 import * as COINJOIN from '@wallet-actions/constants/coinjoinConstants';
 
-const DEVICE = testMocks.getSuiteDevice({ state: 'device-state', connected: true });
+export const DEVICE = testMocks.getSuiteDevice({ state: 'device-state', connected: true });
 
 export const onCoinjoinRoundChanged = [
     {
@@ -123,6 +123,7 @@ export const onCoinjoinRoundChanged = [
         description: 'Phase 4. (end) TrezorConnect.setBusy called',
         connect: undefined,
         state: {
+            devices: [{ ...DEVICE, features: { busy: true } }],
             accounts: [{ key: 'a', deviceState: 'device-state' }],
             coinjoin: {
                 accounts: [
@@ -152,9 +153,42 @@ export const onCoinjoinRoundChanged = [
         },
     },
     {
+        description: 'Phase 4. (end) TrezorConnect.setBusy not called (device is not busy)',
+        connect: undefined,
+        state: {
+            devices: [{ ...DEVICE, features: { busy: false } }],
+            accounts: [{ key: 'a', deviceState: 'device-state' }],
+            coinjoin: {
+                accounts: [
+                    {
+                        key: 'a',
+                        session: { signedRounds: ['1', '2'], maxRounds: 2 },
+                        previousSessions: [],
+                    },
+                ],
+            },
+        },
+        params: {
+            phase: 4,
+            inputs: [{ accountKey: 'a' }],
+            failed: [],
+            roundDeadline: Date.now() + 1000,
+        },
+        result: {
+            actions: [
+                COINJOIN.SESSION_ROUND_CHANGED,
+                MODAL.CLOSE,
+                MODAL.OPEN_USER_CONTEXT,
+                COINJOIN.SESSION_COMPLETED,
+            ],
+            trezorConnectCalledTimes: 0,
+        },
+    },
+    {
         description: 'Multiple events',
         connect: undefined,
         state: {
+            devices: [{ ...DEVICE, features: { busy: true } }],
             accounts: [{ key: 'a', deviceState: 'device-state' }],
             coinjoin: {
                 accounts: [

--- a/packages/suite/src/actions/wallet/__tests__/coinjoinClientActions.test.ts
+++ b/packages/suite/src/actions/wallet/__tests__/coinjoinClientActions.test.ts
@@ -1,5 +1,5 @@
 import { combineReducers, createReducer } from '@reduxjs/toolkit';
-import { configureMockStore, testMocks } from '@suite-common/test-utils';
+import { configureMockStore } from '@suite-common/test-utils';
 
 import { accountsReducer } from '@wallet-reducers';
 import { coinjoinReducer } from '@wallet-reducers/coinjoinReducer';
@@ -14,20 +14,18 @@ jest.mock('@trezor/connect', () => global.JestMocks.getTrezorConnect({}));
 // eslint-disable-next-line @typescript-eslint/no-var-requires
 const TrezorConnect = require('@trezor/connect').default;
 
-const DEVICE = testMocks.getSuiteDevice({ state: 'device-state', connected: true });
-
 const rootReducer = combineReducers({
     suite: createReducer(
         {
             locks: [],
-            device: DEVICE,
+            device: fixtures.DEVICE,
             settings: {
                 debug: {},
             },
         },
         {},
     ),
-    devices: createReducer([DEVICE], {}),
+    devices: createReducer([fixtures.DEVICE], {}),
     modal: () => ({}),
     wallet: combineReducers({
         coinjoin: coinjoinReducer,

--- a/packages/suite/src/reducers/suite/deviceReducer.ts
+++ b/packages/suite/src/reducers/suite/deviceReducer.ts
@@ -40,8 +40,9 @@ const merge = (device: AcquiredDevice, upcoming: Partial<AcquiredDevice>): Trezo
         ...(upcoming.features && isUnlocked(upcoming.features)
             ? upcoming.features
             : device.features),
-        // ...except for `unlocked` which should reflect the actual state of the device.
+        // ...except for `unlocked` and `busy` which should reflect the actual state of the device.
         unlocked: upcoming.features ? upcoming.features.unlocked : null,
+        busy: upcoming.features?.busy,
     },
 });
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

- emit `device-changed` event after `TrezorConnect.setBusy`
- prevent "devicecall in progress" error by not calling  `TrezorConnect.setBusy` when device is not busy 
- reduce number of button requests in authorizeCoinjoin test, following: https://github.com/trezor/trezor-firmware/pull/2613 and also fixing karma test matchers: `jest.fn vs jasmine.createSpy` and  `jest.toBeCalledTimes vs jasmine.toHaveBeenCalledTimes`


resolve https://github.com/trezor/trezor-suite/issues/6939
