### PR TITLE
Enhance UI of loading new CoinJoin account

### DIFF
--- a/packages/suite/src/actions/wallet/__fixtures__/coinjoinAccountActions.ts
+++ b/packages/suite/src/actions/wallet/__fixtures__/coinjoinAccountActions.ts
@@ -41,7 +41,10 @@ export const createCoinjoinAccount = [
             actions: [
                 '@coinjoin/client-enable',
                 '@coinjoin/client-enable-success',
+                '@coinjoin/account-preloading',
                 notificationsActions.addToast.type,
+                '@coinjoin/account-preloading',
+                '@coinjoin/client-disable',
             ],
         },
     },
@@ -65,7 +68,12 @@ export const createCoinjoinAccount = [
             bip43Path: "m/10025'/1'/i'/1'",
         },
         result: {
-            actions: [notificationsActions.addToast.type],
+            actions: [
+                '@coinjoin/account-preloading',
+                notificationsActions.addToast.type,
+                '@coinjoin/account-preloading',
+                '@coinjoin/client-disable',
+            ],
         },
     },
     {
@@ -97,8 +105,10 @@ export const createCoinjoinAccount = [
         },
         result: {
             actions: [
+                '@coinjoin/account-preloading',
                 accountsActions.createAccount.type,
                 '@coinjoin/account-create',
+                '@coinjoin/account-preloading',
                 accountsActions.startCoinjoinAccountSync.type,
                 accountsActions.endCoinjoinAccountSync.type,
             ],

--- a/packages/suite/src/actions/wallet/constants/coinjoinConstants.ts
+++ b/packages/suite/src/actions/wallet/constants/coinjoinConstants.ts
@@ -6,6 +6,7 @@ export const ACCOUNT_AUTHORIZE_SUCCESS = '@coinjoin/account-authorize-success';
 export const ACCOUNT_AUTHORIZE_FAILED = '@coinjoin/account-authorize-failed';
 export const ACCOUNT_UNREGISTER = '@coinjoin/account-unregister';
 export const ACCOUNT_DISCOVERY_PROGRESS = '@coinjoin/account-discovery-progress';
+export const ACCOUNT_PRELOADING = '@coinjoin/account-preloading';
 
 export const CLIENT_ENABLE = '@coinjoin/client-enable';
 export const CLIENT_DISABLE = '@coinjoin/client-disable';

--- a/packages/suite/src/actions/wallet/selectedAccountActions.ts
+++ b/packages/suite/src/actions/wallet/selectedAccountActions.ts
@@ -148,6 +148,7 @@ const getAccountState = (state: AppState): SelectedAccountStatus => {
                     status: 'loading',
                     loader: 'account-loading',
                     account,
+                    params,
                 };
             }
             if (account.status === 'error') {
@@ -194,6 +195,7 @@ const getAccountState = (state: AppState): SelectedAccountStatus => {
         return {
             status: 'loading',
             loader: 'account-loading',
+            params,
         };
     }
 

--- a/packages/suite/src/components/wallet/AccountTopPanel/index.tsx
+++ b/packages/suite/src/components/wallet/AccountTopPanel/index.tsx
@@ -1,5 +1,7 @@
 import React from 'react';
 import styled from 'styled-components';
+import { NetworkSymbol } from '@suite-common/wallet-config';
+import { Account } from '@wallet-types';
 import { CoinLogo, H1, H3 } from '@trezor/components';
 import {
     Ticker,
@@ -29,32 +31,45 @@ const FiatBalanceWrapper = styled(H3)`
 
 interface AccountTopPanelSkeletonProps {
     animate?: boolean;
+    account?: Account;
+    symbol?: NetworkSymbol;
 }
 
-const AccountTopPanelSkeleton = ({ animate }: AccountTopPanelSkeletonProps) => (
+const AccountTopPanelSkeleton = ({ animate, account, symbol }: AccountTopPanelSkeletonProps) => (
     <AppNavigationPanel
         maxWidth="small"
-        title={<SkeletonRectangle width="260px" height="28px" animate={animate} />}
+        title={
+            account ? (
+                <AccountLabeling account={account} />
+            ) : (
+                <SkeletonRectangle width="260px" height="28px" animate={animate} />
+            )
+        }
         navigation={<AccountNavigation />}
     >
         <Stack margin="6px 0px 0px 0px" childMargin="0px 0px 8px 0px">
-            <SkeletonCircle size="24px" />
+            {symbol ? <CoinLogo size={24} symbol={symbol} /> : <SkeletonCircle size="24px" />}
 
             <Balance noMargin>
-                <SkeletonRectangle width="160px" height="24px" />
+                <SkeletonRectangle width="160px" height="24px" animate={animate} />
             </Balance>
         </Stack>
     </AppNavigationPanel>
 );
 
 export const AccountTopPanel = () => {
-    const selectedAccount = useSelector(state => state.wallet.selectedAccount);
+    const { account, loader, status } = useSelector(state => state.wallet.selectedAccount);
 
-    if (selectedAccount.status !== 'loaded') {
-        return <AccountTopPanelSkeleton animate={selectedAccount.loader === 'account-loading'} />;
+    if (status !== 'loaded' || !account) {
+        return (
+            <AccountTopPanelSkeleton
+                animate={loader === 'account-loading'}
+                account={account}
+                symbol={account?.symbol}
+            />
+        );
     }
 
-    const { account } = selectedAccount;
     const { symbol, formattedBalance } = account;
 
     return (

--- a/packages/suite/src/components/wallet/AccountsMenu/AccountGroup.tsx
+++ b/packages/suite/src/components/wallet/AccountsMenu/AccountGroup.tsx
@@ -65,17 +65,25 @@ export const AccountGroup = forwardRef(
         const wrapperRef = useRef<HTMLDivElement>(null);
         const [isOpen, setIsOpen] = useState(props.hasBalance || props.keepOpen);
         const [previouslyOpen, setPreviouslyOpen] = useState(isOpen); // used to follow props changes without unnecessary rerenders
+        const [previouslyHasBalance, setPreviouslyHasBalance] = useState(props.hasBalance); // used to follow props changes without unnecessary rerenders
         const [animatedIcon, setAnimatedIcon] = useState(false);
 
-        // follow props change (example: add new coin/account which has balance but group is closed)
-        if ((props.keepOpen || props.hasBalance) && !previouslyOpen) {
+        if (props.keepOpen && !previouslyOpen) {
             setPreviouslyOpen(true);
+            setIsOpen(true);
+        }
+
+        if (props.hasBalance && !previouslyHasBalance) {
+            setPreviouslyHasBalance(true);
             setIsOpen(true);
         }
 
         const onClick = () => {
             setIsOpen(!isOpen);
             setAnimatedIcon(true);
+            if (isOpen) {
+                setPreviouslyOpen(false);
+            }
         };
 
         // Group needs to be wrapped into container (div)

--- a/packages/suite/src/reducers/wallet/coinjoinReducer.ts
+++ b/packages/suite/src/reducers/wallet/coinjoinReducer.ts
@@ -30,6 +30,7 @@ export interface CoinjoinClientInstance {
 export interface CoinjoinState {
     accounts: CoinjoinAccount[];
     clients: PartialRecord<Account['symbol'], CoinjoinClientInstance>;
+    isPreloading?: boolean;
 }
 
 export type CoinjoinRootState = {
@@ -41,6 +42,7 @@ export type CoinjoinRootState = {
 const initialState: CoinjoinState = {
     accounts: [],
     clients: {},
+    isPreloading: false,
 };
 
 type ExtractActionPayload<A> = Extract<Action, { type: A }> extends { type: A; payload: infer P }
@@ -51,6 +53,7 @@ const createAccount = (
     draft: CoinjoinState,
     { account, targetAnonymity }: ExtractActionPayload<typeof COINJOIN.ACCOUNT_CREATE>,
 ) => {
+    draft.isPreloading = false;
     const exists = draft.accounts.find(a => a.key === account.key);
     if (exists) return;
     draft.accounts.push({
@@ -265,6 +268,9 @@ export const coinjoinReducer = (
                 break;
             case COINJOIN.ACCOUNT_DISCOVERY_PROGRESS:
                 saveCheckpoint(draft, action);
+                break;
+            case COINJOIN.ACCOUNT_PRELOADING:
+                draft.isPreloading = action.payload.isPreloading;
                 break;
 
             case COINJOIN.CLIENT_ENABLE_SUCCESS:

--- a/suite-common/wallet-types/src/selectedAccount.ts
+++ b/suite-common/wallet-types/src/selectedAccount.ts
@@ -24,7 +24,7 @@ export interface SelectedAccountLoading {
     account?: Account;
     network?: Network;
     discovery?: Discovery;
-    params?: undefined;
+    params?: WalletParams;
 }
 
 export interface SelectedAccountLoaded {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Add coinjoin preloading state for the period when new CoinJoin account is requested but not yet created (there is a ButtonRequest for unlocking CoinJoin path so Add Account modal is closed but CoinJoin account not yet created and there is couple seconds delay).

Until the account is created, skeleton is shown.
Once account is created, it's automatically selected.

## Related Issue

Resolve https://github.com/trezor/trezor-suite/issues/6785

## Screenshots (if appropriate):

![image](https://user-images.githubusercontent.com/3729633/201924101-d66ef62f-c80d-45fe-99a0-a214e95ae76f.png)
