### PR TITLE
feat(suite): improve countdown timer behavior when it is out of time

### DIFF
--- a/packages/suite/src/components/suite/CoinjoinStatusBar.tsx
+++ b/packages/suite/src/components/suite/CoinjoinStatusBar.tsx
@@ -153,6 +153,7 @@ export const CoinjoinStatusBar = ({ accountKey, session, isSingle }: CoinjoinSta
                         values={{
                             time: (
                                 <CountdownTimer
+                                    isApproximate
                                     deadline={phaseDeadline}
                                     format={getPhaseTimerFormat(phaseDeadline)}
                                 />

--- a/packages/suite/src/components/suite/CountdownTimer.tsx
+++ b/packages/suite/src/components/suite/CountdownTimer.tsx
@@ -1,16 +1,19 @@
 import React, { useEffect, useState } from 'react';
 import { useLocales } from '@suite-hooks/useLocales';
 import { formatTimeLeft } from '@suite-utils/formatTimeLeft';
+import { Translation } from './Translation';
 
 interface TimerProps {
     deadline: number | string;
     format?: Array<keyof Duration>;
+    isApproximate?: boolean;
     className?: string;
 }
 
 export const CountdownTimer = ({
     deadline,
     format = ['hours', 'minutes'],
+    isApproximate,
     className,
 }: TimerProps) => {
     const locale = useLocales();
@@ -18,14 +21,27 @@ export const CountdownTimer = ({
     const [timeLeftString, setTimeLeftString] = useState(
         formatTimeLeft(new Date(deadline), locale, format),
     );
+    const [isPastDeadline, setIsPastDeadline] = useState(false);
 
     useEffect(() => {
         const interval = setInterval(() => {
+            setIsPastDeadline(new Date(deadline).getTime() <= Date.now() + 1000);
+
             setTimeLeftString(formatTimeLeft(new Date(deadline), locale, format));
         }, 100);
 
         return () => clearInterval(interval);
     }, [deadline, locale, format]);
 
-    return <span className={className}>{timeLeftString}</span>;
+    return (
+        <span className={className}>
+            {!isPastDeadline && isApproximate && '~'}
+
+            {isPastDeadline && isApproximate ? (
+                <Translation id="TR_TIMER_PAST_DEADLINE" />
+            ) : (
+                timeLeftString
+            )}
+        </span>
+    );
 };

--- a/packages/suite/src/components/suite/modals/CriticalCoinjoinPhase/PhaseProgress.tsx
+++ b/packages/suite/src/components/suite/modals/CriticalCoinjoinPhase/PhaseProgress.tsx
@@ -102,8 +102,8 @@ export const PhaseProgress = ({ currentPhase, phaseDeadline }: PhaseProgressProp
 
         {phaseDeadline && (
             <TimerCointainer>
-                ~
                 <CountdownTimer
+                    isApproximate
                     deadline={phaseDeadline}
                     format={getPhaseTimerFormat(phaseDeadline)}
                 />

--- a/packages/suite/src/components/wallet/CoinjoinSummary/CoinjoinStatus.tsx
+++ b/packages/suite/src/components/wallet/CoinjoinSummary/CoinjoinStatus.tsx
@@ -285,6 +285,7 @@ export const CoinjoinStatus = ({
                     <Translation id={COINJOIN_PHASE_MESSAGES[phase]} />
                     <p>
                         <CountdownTimer
+                            isApproximate
                             deadline={phaseDeadline}
                             format={getPhaseTimerFormat(phaseDeadline)}
                         />

--- a/packages/suite/src/support/messages.ts
+++ b/packages/suite/src/support/messages.ts
@@ -7714,4 +7714,8 @@ export default defineMessages({
         id: 'TR_COINJOIN_FACT_TEN',
         defaultMessage: 'Fun Coinjoin fact #10',
     },
+    TR_TIMER_PAST_DEADLINE: {
+        id: 'TR_TIMER_PAST_DEADLINE',
+        defaultMessage: 'Almost there...',
+    },
 });


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

* show "almost there..." instead of "0 seconds" when a timer has ran out of time and has `isApproximate`

## Related Issue

Resolve [#6909](https://github.com/trezor/trezor-suite/issues/6909)

## Screenshots:

<img width="140" alt="image" src="https://user-images.githubusercontent.com/45338719/201990370-90283238-41ab-4ad9-bfb5-a35cec487fd4.png">

