### PR TITLE
Update excludedUtxos on every account update in send form

### DIFF
--- a/packages/suite/src/actions/wallet/send/sendFormBitcoinActions.ts
+++ b/packages/suite/src/actions/wallet/send/sendFormBitcoinActions.ts
@@ -21,7 +21,7 @@ import { Dispatch, GetState } from '@suite-types';
 export const composeTransaction =
     (formValues: FormState, formState: UseSendFormState) =>
     async (dispatch: Dispatch, getState: GetState) => {
-        const { account, feeInfo } = formState;
+        const { account, excludedUtxos, feeInfo } = formState;
 
         const {
             settings: { bitcoinAmountUnit },
@@ -75,7 +75,6 @@ export const composeTransaction =
         // exclude unspendable utxos if coin control is not enabled
         // unspendable utxos are defined in `useSendForm` hook
         let availableUtxo = account.utxo;
-        const { excludedUtxos } = formState;
         if (
             !formValues.isCoinControlEnabled &&
             excludedUtxos &&

--- a/suite-common/test-utils/src/mocks.ts
+++ b/suite-common/test-utils/src/mocks.ts
@@ -1,7 +1,7 @@
 /* WARNING! This file should be imported ONLY in tests! */
 /* eslint-disable require-await */
 
-import { Device, Features } from '@trezor/connect';
+import { AccountUtxo, Device, Features } from '@trezor/connect';
 import { TrezorDevice, GuideNode, GuidePage, GuideCategory } from '@suite-common/suite-types';
 import { MessageSystem, Action } from '@trezor/message-system';
 import {
@@ -636,6 +636,17 @@ const getGuideNode = (type: string, id?: string): GuideNode => {
     return result;
 };
 
+const getUtxo = (utxo: Partial<AccountUtxo>): AccountUtxo => ({
+    address: 'tb1q4nytpy37cuz8yndtfqpau4nzsva0jh787ny3yg',
+    amount: '1',
+    blockHeight: 590093,
+    confirmations: 1,
+    path: "m/44'/60'/0'/0/1",
+    txid: '7e58757f43015242c0efa29447bea4583336f2358fdff587b52bbe040ad8982a',
+    vout: 1,
+    ...utxo,
+});
+
 const fee: FeeInfo = {
     blockTime: 1565797979,
     blockHeight: 590093,
@@ -679,6 +690,7 @@ export const testMocks = {
     getTrezorConnect,
     getMessageSystemConfig,
     getGuideNode,
+    getUtxo,
     fee,
     intlMock,
     mockedBlockchainNetworks,


### PR DESCRIPTION
## Description

Previously, `excludedUtxos` were only set during initial render of send form within `getStateFromProps`. However, if a UTXO was added while the send form was open (i.e. when `account` updates), `excludedUtxos` did not update. Coin control is dependant on `excludedUtxos` to organize UTXOs into categories and a UTXO missing from `excludedUtxos` always falls into the default category, thus causing the bug reported in #6906. This could have also lead to bugs in `sendFormBitcoinActions.composeTransaction`, which also relies on `excludedUtxos`, but those have not been reported.

To fix it, I added a `getExcludedUtxos` util and `state.excludedUtxos` is now updated any time `state.account` updates.

I find it weird to keep `excludedUtxos` in send form `state`, but I kept this behaviour as it was designed by @szymonlesisz. I assume it was implemented this way because `composeTransaction` takes `state` as a parameter and we want to avoid extra parameters. Same could be said about other properties of `state`.

## Related Issue

Resolve #6906
