### PR TITLE
device events in popup test

### DIFF
--- a/packages/connect-examples/browser-inline-script/index.html
+++ b/packages/connect-examples/browser-inline-script/index.html
@@ -20,13 +20,44 @@
                     path: "m/49'/0'/0'/0/0",
                     coin: 'btc',
                 }).then(res => {
-                    console.info(res);
-                    document.getElementById('result').innerText = JSON.stringify(res);
+                    appendLog('calls', JSON.stringify(res));
                 });
+            };
+
+            window.TrezorConnect.on('DEVICE_EVENT', function (event) {
+                console.log('event', event);
+                appendLog(
+                    'events',
+                    JSON.stringify({
+                        type: event.type,
+                        device: event.payload.type, // applies for device events
+                        code: event.payload.code, // applies for button events
+                        payload: '(...redacted)',
+                    }),
+                );
+            });
+
+            let logNumber = 1;
+            appendLog = function (id, log) {
+                const record = document.createElement('div');
+                record.className = id;
+                record.innerText = id + ' ' + logNumber + ' ' + log;
+                document.getElementById(id).appendChild(record);
+                logNumber++;
             };
         </script>
 
         <button onclick="trezorGetAddress()">Get address</button>
-        <div id="result"></div>
+
+        <div style="display: flex; flex-direction: row; overflow-wrap: anywhere">
+            <div style="flex: 1; margin: 10px">
+                <div>calls</div>
+                <div id="calls"></div>
+            </div>
+            <div style="flex: 1; margin: 10px">
+                <div>events</div>
+                <div id="events"></div>
+            </div>
+        </div>
     </body>
 </html>

--- a/packages/connect-web/e2e/tests/init.test.ts
+++ b/packages/connect-web/e2e/tests/init.test.ts
@@ -17,7 +17,6 @@ const fixtures = [
     },
     {
         params: {
-            versionChannel: undefined,
             connectSrc: 'https://connect.trezor.io/9.0.1/',
         },
         result: 'https://connect.trezor.io/9.0.1/iframe.html',
@@ -42,7 +41,6 @@ fixtures.forEach(f => {
                         email: 'developer@xyz.com',
                         appUrl: 'http://your.application.com',
                     },
-                    versionChannel: '${f.params.versionChannel}',
                     connectSrc: '${f.params.connectSrc}'
                 });
         `,


### PR DESCRIPTION
I wanted to add tests for #6509 that were supposed to check device events (device-connect, device-changed, device-disconnect). It turned out that the way I started doing it is not the way how it can be done*1, but I feel like this code is useful, so opening this PR. Changes here: 

- improves browser-inline-script connect example
- uses this example in end-to-end test that checks  whether DEVICE_EVENTS are fired based on permissions are granted by user or not
- adds setup to run these tests locally
- removes unused param from packages/connect-web/e2e/tests/init.test.ts

Note that these tests are not run in CI yet, because they are partly overlapping with packages/connect-popup/e2e and packages/connect/e2e. Maybe this is the time to think about consolidation. 

cc @ondracja 

___

1 I need to simulate 2 clients connecting at the same time. The problem is that opening another popup cleans up everything that might be running in the first popup/client. So I basically need to test this in suite, or maybe create another package, connect-web-without-iframe and test it there.

