### PR TITLE
chore: exit tests properly

### DIFF
--- a/packages/connect/e2e/run.ts
+++ b/packages/connect/e2e/run.ts
@@ -80,7 +80,9 @@ const getEmulatorOptions = (availableFirmwares: Firmwares) => {
 
     if (process.argv[2] === 'node') {
         // @ts-expect-error
-        runCLI(argv, [__dirname]);
+        const { results } = await runCLI(argv, [__dirname]);
+
+        process.exit(results.numFailedTests);
     } else if (process.argv[2] === 'web') {
         const { parseConfig } = karma.config;
         const { Server } = karma;

--- a/packages/transport/e2e/run.ts
+++ b/packages/transport/e2e/run.ts
@@ -9,5 +9,7 @@ import argv from './jest.config';
     await TrezorUserEnvLink.connect();
 
     // @ts-expect-error
-    runCLI(argv, [__dirname]);
+    const { results } = runCLI(argv, [__dirname]);
+
+    process.exit(results.numFailedTests);
 })();


### PR DESCRIPTION
this micro change should exit tests that are ran using jets `runCLI` 