### PR TITLE
Fix cardano send - tx hash mismatch, duplicate output in review modal

### DIFF
--- a/packages/suite/package.json
+++ b/packages/suite/package.json
@@ -21,7 +21,7 @@
     "dependencies": {
         "@ethereumjs/common": "^2.6.5",
         "@ethereumjs/tx": "^3.5.2",
-        "@fivebinaries/coin-selection": "2.0.0-beta.10",
+        "@fivebinaries/coin-selection": "2.1.0",
         "@hookform/resolvers": "1.3.8",
         "@reduxjs/toolkit": "^1.8.4",
         "@sentry/minimal": "6.17.2",

--- a/packages/suite/src/components/suite/modals/ReviewTransaction/index.tsx
+++ b/packages/suite/src/components/suite/modals/ReviewTransaction/index.tsx
@@ -122,17 +122,23 @@ export const ReviewTransaction = ({ decision }: ReviewTransactionProps) => {
             // iterate only through "external" outputs (change output has addressParameters field instead of address)
             if ('address' in o) {
                 const tokenBundle = getCardanoTokenBundle(account, o)?.[0]; // send form supports one token per output
+
+                // each output will include certain amount of ADA (cardano token outputs require ADA)
                 outputs.push({
                     type: 'regular',
                     label: o.address,
                     value: o.amount,
                 });
-                outputs.push({
-                    type: 'regular',
-                    label: o.address,
-                    value: tokenBundle ? tokenBundle.balance ?? '0' : o.amount,
-                    token: tokenBundle,
-                });
+
+                // if the output also includes a token then we need to render another row with the token
+                if (tokenBundle) {
+                    outputs.push({
+                        type: 'regular',
+                        label: o.address,
+                        value: tokenBundle.balance ?? '0',
+                        token: tokenBundle,
+                    });
+                }
             }
         });
     } else {

--- a/yarn.lock
+++ b/yarn.lock
@@ -2122,10 +2122,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@emurgo/cardano-serialization-lib-browser@npm:^10.0.0-beta.8":
-  version: 10.2.0
-  resolution: "@emurgo/cardano-serialization-lib-browser@npm:10.2.0"
-  checksum: cd726113e3a2f0707be57eb9e1e1b6970e0c476f04cd6e019398660da56f3280cf49cbcbe9a66e1d2c01361dd2ae5cc7c26541595318037776c5388307ce24e9
+"@emurgo/cardano-serialization-lib-browser@npm:^11.0.0":
+  version: 11.1.0
+  resolution: "@emurgo/cardano-serialization-lib-browser@npm:11.1.0"
+  checksum: a4d412cb36aedf0f01124faa65b2366ddbe929d5d4a57b66811d2b3964677d50d32d8c29c9bc37827a4fc2377ae1a2b544113b105f13caf50bc1b69eaaa8afdc
   languageName: node
   linkType: hard
 
@@ -2292,12 +2292,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@fivebinaries/coin-selection@npm:2.0.0-beta.10":
-  version: 2.0.0-beta.10
-  resolution: "@fivebinaries/coin-selection@npm:2.0.0-beta.10"
+"@fivebinaries/coin-selection@npm:2.1.0":
+  version: 2.1.0
+  resolution: "@fivebinaries/coin-selection@npm:2.1.0"
   dependencies:
-    "@emurgo/cardano-serialization-lib-browser": ^10.0.0-beta.8
-  checksum: b4f1aabde5546fabb6e264ea73649409aa5e4bb37fd3b7f97df9411c1eb69efed03e6492b36a407599dbcfc6cbcb9cdd46bd9368002df0d88e10449bf4a176b1
+    "@emurgo/cardano-serialization-lib-browser": ^11.0.0
+  checksum: cc1bba39deeac04648d313d76f434418f24afd8a6f5d3b9c8a3589840937521c50c9013a91fd4fb2e8bfe05b9bd2bf0d57d6fa6b3e457795ad1a389584baa11a
   languageName: node
   linkType: hard
 
@@ -7760,7 +7760,7 @@ __metadata:
     "@crowdin/cli": ^3.7.10
     "@ethereumjs/common": ^2.6.5
     "@ethereumjs/tx": ^3.5.2
-    "@fivebinaries/coin-selection": 2.0.0-beta.10
+    "@fivebinaries/coin-selection": 2.1.0
     "@formatjs/cli": ^3.0.5
     "@hookform/resolvers": 1.3.8
     "@reduxjs/toolkit": ^1.8.4


### PR DESCRIPTION
## Description

### Tx hash mismatch
Inputs passed to `TrezorConnect.cardanoSignTransaction` could be in different order than inputs in transaction CBOR (serialized by `@fivebinaries/coin-selection` lib) resulting in mismatch between tx hash computed by trezor firmware and the coin-selection lib. This has been [fixed in new version of the lib](https://github.com/fivebinaries/coin-selection/blob/master/CHANGELOG.MD#210---2022-11-22), which always reorders returned utxos to match the actual inputs order in serialized CBOR. 

So basically for the issue to occur 2 conditions need to be met 
- more than 1 input in the tx 
- during coin selection utxos had to be inserted in CBOR in different order than they were initially passed to the lib (there was a chance that the order would stay the same)

### Duplicate output in review modal
Also fixed UI bug (first commit) in review modal - while sending ADA (no tokens) the same output was rendered twice (looks like the bug wasn't reported).

## Related Issue
Resolve https://github.com/trezor/trezor-suite/issues/6945

## Screenshots (if appropriate):
(screen only for the UI bug - 1. commit)
![photo_2022-11-22 11 41 52](https://user-images.githubusercontent.com/6961901/203294017-b871cbca-d1e5-4411-8a4d-adeda5d92da0.jpeg)
