### PR TITLE
test(coinjoin): strongly typed MockedServer

### DIFF
--- a/packages/coinjoin/tests/client/analyzeTransactions.test.ts
+++ b/packages/coinjoin/tests/client/analyzeTransactions.test.ts
@@ -1,9 +1,9 @@
 import { networks } from '@trezor/utxo-lib';
 
 import { analyzeTransactions } from '../../src/client/analyzeTransactions';
-import { createServer, Server } from '../mocks/server';
+import { createServer } from '../mocks/server';
 
-let server: Server | undefined;
+let server: Awaited<ReturnType<typeof createServer>>;
 
 // create simplified transaction
 const generateTx = (vin: any[], vout: any[]) => {
@@ -53,14 +53,13 @@ describe('analyzeTransactions', () => {
     });
 
     it('Regtest: simple analyze', async () => {
-        server?.addListener('test-request', ({ url, data }, req, _res) => {
-            let response: any;
+        server?.addListener('test-request', ({ url, data, resolve }) => {
             if (url.endsWith('/analyze-transaction')) {
-                response = {
+                resolve({
                     results: calcAnonymity(data.transactions),
-                };
+                });
             }
-            req.emit('test-response', response);
+            resolve();
         });
 
         const txHistory = [

--- a/packages/coinjoin/tests/client/outputRegistration.test.ts
+++ b/packages/coinjoin/tests/client/outputRegistration.test.ts
@@ -1,10 +1,10 @@
 import { CoinjoinPrison } from '../../src/client/CoinjoinPrison';
 import { outputRegistration } from '../../src/client/round/outputRegistration';
-import { createServer, Server } from '../mocks/server';
+import { createServer } from '../mocks/server';
 import { createInput } from '../fixtures/input.fixture';
 import { createCoinjoinRound } from '../fixtures/round.fixture';
 
-let server: Server | undefined;
+let server: Awaited<ReturnType<typeof createServer>>;
 
 const prison = new CoinjoinPrison();
 

--- a/packages/coinjoin/tests/client/transactionSigning.test.ts
+++ b/packages/coinjoin/tests/client/transactionSigning.test.ts
@@ -1,8 +1,10 @@
+import { networks } from '@trezor/utxo-lib';
+
 import { transactionSigning } from '../../src/client/round/transactionSigning';
-import { createServer, Server } from '../mocks/server';
+import { createServer } from '../mocks/server';
 import { createInput } from '../fixtures/input.fixture';
 
-let server: Server | undefined;
+let server: Awaited<ReturnType<typeof createServer>>;
 
 // Temporary mock until affiliate request will be moved to coordinator
 jest.mock('cross-fetch', () => {
@@ -104,7 +106,7 @@ describe('transactionSigning', () => {
                     ],
                 },
             } as any,
-            server?.requestOptions,
+            { ...server?.requestOptions, network: networks.bitcoin },
         );
         expect(response).toMatchObject({
             transactionData: {

--- a/packages/coinjoin/tests/fixtures/round.fixture.ts
+++ b/packages/coinjoin/tests/fixtures/round.fixture.ts
@@ -38,6 +38,21 @@ export const ROUND_CREATION_EVENT = {
     },
 };
 
+export const FEE_RATE_MEDIANS = [
+    {
+        timeFrame: '1d 0h 1m 0s',
+        medianFeeRate: 129000,
+    },
+    {
+        timeFrame: '7d 0h 1m 0s',
+        medianFeeRate: 129000,
+    },
+    {
+        timeFrame: '31d 0h 1m 0s',
+        medianFeeRate: 129000,
+    },
+];
+
 export const DEFAULT_ROUND = {
     id: '80b4e3efd1aedeb7b140d605946ca5662241d6829b6018bb0eee58c9ac929fce',
     blameOf: '0000000000000000000000000000000000000000000000000000000000000000',


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Better server for coinjoin unit tests:
- strongly typed events and responses
- using callbacks (resolve/reject) to produce server response from test case
- `/status` default response is never empty