### PR TITLE
fix(suite): improve wording when the phase timer runs out of time

### DIFF
--- a/packages/suite/src/components/suite/CoinjoinStatusBar.tsx
+++ b/packages/suite/src/components/suite/CoinjoinStatusBar.tsx
@@ -126,6 +126,8 @@ export const CoinjoinStatusBar = ({ accountKey, session, isSingle }: CoinjoinSta
         ),
     );
 
+    const isPastDeadline = new Date(phaseDeadline).getTime() <= Date.now() + 1000;
+
     return (
         <Container>
             <StyledProgressPie progress={progress} />
@@ -151,7 +153,9 @@ export const CoinjoinStatusBar = ({ accountKey, session, isSingle }: CoinjoinSta
                     <Translation
                         id="TR_COINJOIN_ROUND_COUNTDOWN"
                         values={{
-                            time: (
+                            time: isPastDeadline ? (
+                                <Translation id="TR_COINJOIN_ROUND_COUNTDOWN_OVERTIME" />
+                            ) : (
                                 <CountdownTimer
                                     isApproximate
                                     deadline={phaseDeadline}

--- a/packages/suite/src/support/messages.ts
+++ b/packages/suite/src/support/messages.ts
@@ -7089,6 +7089,11 @@ export default defineMessages({
         id: 'TR_COINJOIN_ROUND_COUNTDOWN',
         defaultMessage: 'Next transaction signing starts in {time}',
     },
+    TR_COINJOIN_ROUND_COUNTDOWN_OVERTIME: {
+        id: 'TR_COINJOIN_ROUND_COUNTDOWN_OVERTIME',
+        defaultMessage: 'a moment',
+        description: 'when TR_COINJOIN_ROUND_COUNTDOWN runs out of time',
+    },
     TR_VIEW: {
         id: 'TR_VIEW',
         defaultMessage: 'View',


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

* improve wording when the phase timer runs out of time

## Related Issue

Resolve #6909

## Screenshots:

<img width="567" alt="image" src="https://user-images.githubusercontent.com/45338719/203556883-30e9ee65-d441-43ab-b77e-4d859ed52661.png">

