### PR TITLE
chore(npm): fix yarn publish command and prevent using npm

### DIFF
--- a/ci/npm-deploy.yml
+++ b/ci/npm-deploy.yml
@@ -54,7 +54,7 @@ beta deploy npm:
   <<: *packages_matrix
   script:
     - nix-shell --run "node ./ci/scripts/check-version $PACKAGE $CI_COMMIT_BRANCH beta"
-    - nix-shell --run "yarn && cd ./packages/$PACKAGE && yarn publish --tag beta"
+    - nix-shell --run "yarn && cd ./packages/$PACKAGE && yarn npm publish --tag beta"
 
 deploy npm:
   extends: .deploy npm base
@@ -62,7 +62,7 @@ deploy npm:
   <<: *packages_matrix
   script:
     - nix-shell --run "node ./ci/scripts/check-version $PACKAGE $CI_COMMIT_BRANCH latest"
-    - nix-shell --run "yarn && cd ./packages/${PACKAGE} && yarn publish"
+    - nix-shell --run "yarn && cd ./packages/${PACKAGE} && yarn npm publish"
 
 beta deploy npm connect:
   extends: .deploy npm base
@@ -71,7 +71,7 @@ beta deploy npm connect:
       - /^beta-release\//
   <<: *packages_matrix_connect
   script:
-    - nix-shell --run "yarn && cd ./packages/$PACKAGE && yarn publish --tag beta"
+    - nix-shell --run "yarn && cd ./packages/$PACKAGE && yarn npm publish --tag beta"
 
 deploy npm connect:
   extends: .deploy npm base
@@ -80,4 +80,4 @@ deploy npm connect:
       - /^npm-release\//
   <<: *packages_matrix_connect
   script:
-    - nix-shell --run "cd ./packages/${PACKAGE} && yarn publish"
+    - nix-shell --run "cd ./packages/${PACKAGE} && yarn npm publish"

--- a/docs/releases/npm-packages.md
+++ b/docs/releases/npm-packages.md
@@ -1,6 +1,6 @@
 # Publishing @trezor package to npm registry
 
-`yarn publish` could be done manually on [gitlab CI](https://gitlab.com/satoshilabs/trezor/trezor-suite/-/pipelines/) in `deploy npm` phase.
+`yarn npm publish` should be done only on [gitlab CI](https://gitlab.com/satoshilabs/trezor/trezor-suite/-/pipelines/) in `deploy npm` phase.
 
 ### Purpose
 

--- a/packages/blockchain-link/package.json
+++ b/packages/blockchain-link/package.json
@@ -4,6 +4,7 @@
     "author": "Trezor <info@trezor.io>",
     "homepage": "https://github.com/trezor/trezor-suite/tree/develop/packages/blockchain-link",
     "description": "High-level javascript interface for blockchain communication",
+    "npmPublishAccess": "public",
     "license": "SEE LICENSE IN LICENSE.md",
     "repository": {
         "type": "git",
@@ -46,7 +47,9 @@
         "lint:js": "yarn g:eslint '**/*.{ts,tsx,js}'",
         "test:unit": "jest --verbose -c jest.config.unit.js",
         "test:integration": "jest -c jest.config.integration.js",
-        "type-check": "tsc --build tsconfig.json"
+        "type-check": "tsc --build tsconfig.json",
+        "prepublishOnly": "yarn tsx ../../scripts/prepublishNPM.js",
+        "prepublish": "yarn tsx ../../scripts/prepublish.js"
     },
     "devDependencies": {
         "html-webpack-plugin": "^5.5.0",

--- a/packages/connect-common/package.json
+++ b/packages/connect-common/package.json
@@ -14,6 +14,7 @@
     "bugs": {
         "url": "https://github.com/trezor/trezor-suite/issues"
     },
+    "npmPublishAccess": "public",
     "license": "SEE LICENSE IN LICENSE.md",
     "description": "Collection of assets and utils used by trezor-connect library.",
     "main": "./lib/index.js",
@@ -30,7 +31,9 @@
         "lint:js": "yarn g:eslint '**/*.{ts,tsx,js}'",
         "test:unit": "jest --coverage",
         "build:lib": "rimraf lib && yarn tsc --build ./tsconfig.lib.json",
-        "type-check": "tsc --build tsconfig.json"
+        "type-check": "tsc --build tsconfig.json",
+        "prepublishOnly": "yarn tsx ../../scripts/prepublishNPM.js",
+        "prepublish": "yarn tsx ../../scripts/prepublish.js"
     },
     "devDependencies": {
         "jest": "^26.6.3",

--- a/packages/connect-web/package.json
+++ b/packages/connect-web/package.json
@@ -4,6 +4,7 @@
     "author": "Trezor <info@trezor.io>",
     "homepage": "https://github.com/trezor/trezor-suite/tree/develop/packages/connect-web",
     "description": "High-level javascript interface for Trezor hardware wallet.",
+    "npmPublishAccess": "public",
     "license": "SEE LICENSE IN LICENSE.md",
     "repository": {
         "type": "git",
@@ -32,7 +33,9 @@
         "build:inline": "TS_NODE_PROJECT=\"tsconfig.lib.json\" webpack --config ./webpack/inline.webpack.config.ts",
         "build:webextension": "TS_NODE_PROJECT=\"tsconfig.lib.json\" yarn webpack --config ./webpack/prod.webpack.config.ts",
         "build": "rimraf build && yarn build:inline && yarn build:webextension",
-        "test:e2e": "yarn xvfb-maybe -- playwright test --config=./e2e/playwright.config.ts"
+        "test:e2e": "yarn xvfb-maybe -- playwright test --config=./e2e/playwright.config.ts",
+        "prepublishOnly": "yarn tsx ../../scripts/prepublishNPM.js",
+        "prepublish": "yarn tsx ../../scripts/prepublish.js"
     },
     "dependencies": {
         "@trezor/connect": "9.0.4",

--- a/packages/connect/package.json
+++ b/packages/connect/package.json
@@ -4,6 +4,7 @@
     "author": "Trezor <info@trezor.io>",
     "homepage": "https://github.com/trezor/trezor-suite/tree/develop/packages/connect",
     "description": "High-level javascript interface for Trezor hardware wallet.",
+    "npmPublishAccess": "public",
     "license": "SEE LICENSE IN LICENSE.md",
     "repository": {
         "type": "git",
@@ -43,7 +44,9 @@
         "version:minor": "tsx scripts/bump-version.ts minor",
         "version:major": "tsx scripts/bump-version.ts major",
         "test:e2e:web": "ts-node -O '{\"module\": \"commonjs\"}' ./e2e/run.ts web",
-        "test:e2e:node": "ts-node -O '{\"module\": \"commonjs\"}' ./e2e/run.ts node"
+        "test:e2e:node": "ts-node -O '{\"module\": \"commonjs\"}' ./e2e/run.ts node",
+        "prepublishOnly": "yarn tsx ../../scripts/prepublishNPM.js",
+        "prepublish": "yarn tsx ../../scripts/prepublish.js"
     },
     "dependencies": {
         "@trezor/blockchain-link": "^2.1.5",

--- a/packages/transport-native/package.json
+++ b/packages/transport-native/package.json
@@ -4,6 +4,7 @@
     "author": "Trezor.io",
     "homepage": "https://github.com/trezor/trezor-suite/tree/develop/packages/transport-native",
     "description": "Trezor device transport layer for React Native",
+    "npmPublishAccess": "public",
     "main": "lib/commonjs/index",
     "module": "lib/module/index",
     "types": "lib/typescript/index.d.ts",
@@ -25,7 +26,9 @@
     ],
     "scripts": {
         "type-check": "tsc --build tsconfig.json",
-        "lint:js": "yarn g:eslint '**/*.{ts,tsx,js}'"
+        "lint:js": "yarn g:eslint '**/*.{ts,tsx,js}'",
+        "prepublishOnly": "yarn tsx ../../scripts/prepublishNPM.js",
+        "prepublish": "yarn tsx ../../scripts/prepublish.js"
     },
     "keywords": [
         "Trezor",

--- a/packages/transport/package.json
+++ b/packages/transport/package.json
@@ -2,6 +2,7 @@
     "name": "@trezor/transport",
     "version": "1.1.5",
     "description": "Low level library facilitating protocol buffers based communication with Trezor devices",
+    "npmPublishAccess": "public",
     "license": "SEE LICENSE IN LICENSE.md",
     "repository": {
         "type": "git",
@@ -31,7 +32,9 @@
         "test:unit": "jest",
         "test:e2e": "ts-node -O '{\"module\": \"commonjs\", \"esModuleInterop\": true}' ./e2e/run.ts",
         "example:bridge": "jest --verbose -c jest.config.e2e.js --testPathPattern bridge.integration",
-        "update:protobuf": "./scripts/protobuf-build.sh && yarn prettier --write \"{messages.json,src/types/messages.ts}\""
+        "update:protobuf": "./scripts/protobuf-build.sh && yarn prettier --write \"{messages.json,src/types/messages.ts}\"",
+        "prepublishOnly": "yarn tsx ../../scripts/prepublishNPM.js",
+        "prepublish": "yarn tsx ../../scripts/prepublish.js"
     },
     "devDependencies": {
         "@trezor/trezor-user-env-link": "*",

--- a/packages/utils/package.json
+++ b/packages/utils/package.json
@@ -4,6 +4,7 @@
     "author": "Trezor <info@trezor.io>",
     "homepage": "https://github.com/trezor/trezor-suite/tree/develop/packages/utils",
     "description": "A collection of typescript utils that are intended to be used across trezor-suite monorepo.",
+    "npmPublishAccess": "public",
     "license": "SEE LICENSE IN LICENSE.md",
     "repository": {
         "type": "git",
@@ -22,7 +23,9 @@
         "lint:js": "yarn g:eslint '**/*.{ts,tsx,js}'",
         "test:unit": "jest --verbose -c ../../jest.config.base.js",
         "type-check": "tsc --build tsconfig.json",
-        "build:lib": "rimraf ./lib && yarn tsc --build tsconfig.lib.json"
+        "build:lib": "rimraf ./lib && yarn tsc --build tsconfig.lib.json",
+        "prepublishOnly": "yarn tsx ../../scripts/prepublishNPM.js",
+        "prepublish": "yarn tsx ../../scripts/prepublish.js"
     },
     "devDependencies": {
         "jest": "^26.6.3",

--- a/packages/utxo-lib/package.json
+++ b/packages/utxo-lib/package.json
@@ -4,6 +4,7 @@
     "author": "Trezor <info@trezor.io>",
     "homepage": "https://github.com/trezor/trezor-suite/tree/develop/packages/utxo-lib",
     "description": "Client-side Bitcoin-like JavaScript library",
+    "npmPublishAccess": "public",
     "license": "SEE LICENSE IN LICENSE.md",
     "repository": {
         "type": "git",
@@ -30,7 +31,9 @@
         "lint:js": "yarn g:eslint '**/*.{ts,tsx,js}'",
         "test:unit": "jest --verbose -c jest.config.js",
         "type-check": "tsc --build tsconfig.json",
-        "build:lib": "rimraf lib && yarn tsc --build ./tsconfig.lib.json"
+        "build:lib": "rimraf lib && yarn tsc --build ./tsconfig.lib.json",
+        "prepublishOnly": "yarn tsx ../../scripts/prepublishNPM.js",
+        "prepublish": "yarn tsx ../../scripts/prepublish.js"
     },
     "dependencies": {
         "@trezor/utils": "^9.0.3",

--- a/scripts/prepublish.js
+++ b/scripts/prepublish.js
@@ -1,0 +1,4 @@
+if (!process.env.CI) {
+    console.log('DO NOT TRY TO PUBLISH FROM YOUR LOCAL MACHINE! Publish only from CI.');
+    process.exit(1);
+}

--- a/scripts/prepublishNPM.js
+++ b/scripts/prepublishNPM.js
@@ -1,0 +1,5 @@
+console.log(
+    `Publish only from CI!
+DO NOT USE npm publish, use yarn npm publish instead! npm publish does not handle workspace ranges - see https://yarnpkg.com/features/workspaces#publishing-workspaces`,
+);
+process.exit(1);


### PR DESCRIPTION

<!--- Provide a general summary of your changes in the Title above -->

## Description

- There is no yarn publish command, it's called yarn npm publish.
- prepublishOnly script is called only on npm publish command that we don't want to use `npm publish` at all.
- prepublish script start checking if you run it from CI.

I also considered to add some warning if you try to use yarn with --dry-run param but it's already implemented in yarn v3 (`Unknown Syntax Error: Unsupported option name ("--dry-run")`)

