### PR TITLE
Reorg support in CoinJoin discovery

### DIFF
--- a/packages/coinjoin/src/backend/CoinjoinFilterController.ts
+++ b/packages/coinjoin/src/backend/CoinjoinFilterController.ts
@@ -9,11 +9,14 @@ import type { CoinjoinBackendSettings } from '../types';
 
 export class CoinjoinFilterController implements FilterController {
     private readonly client;
-    private readonly baseBlockHash;
+    private readonly baseBlock;
 
-    constructor(client: FilterClient, { baseBlockHash }: CoinjoinBackendSettings) {
+    constructor(client: FilterClient, { baseBlockHash, baseBlockHeight }: CoinjoinBackendSettings) {
         this.client = client;
-        this.baseBlockHash = baseBlockHash;
+        this.baseBlock = {
+            blockHash: baseBlockHash,
+            blockHeight: baseBlockHeight,
+        };
     }
 
     /**
@@ -31,7 +34,7 @@ export class CoinjoinFilterController implements FilterController {
 
         let counter = 0;
         let filterBatch = await this.client.fetchFilters(
-            params?.fromHash ?? this.baseBlockHash,
+            (params?.checkpoints?.[0] ?? this.baseBlock).blockHash,
             filterBatchSize,
             { signal: context?.abortSignal },
         );

--- a/packages/coinjoin/src/backend/CoinjoinFilterController.ts
+++ b/packages/coinjoin/src/backend/CoinjoinFilterController.ts
@@ -36,9 +36,10 @@ export class CoinjoinFilterController implements FilterController {
             { signal: context?.abortSignal },
         );
 
-        const firstBlockHeight = filterBatch.filters[0]?.blockHeight;
+        const firstBlockHeight =
+            filterBatch.status === 'ok' ? filterBatch.filters[0]?.blockHeight : -1;
 
-        while (filterBatch.filters.length) {
+        while (filterBatch.status === 'ok') {
             const { bestHeight, filters } = filterBatch;
             const progressBatchSize = this.getProgressBatchSize(firstBlockHeight, bestHeight);
             for (let i = 0; i < filters.length; ++i) {
@@ -60,6 +61,10 @@ export class CoinjoinFilterController implements FilterController {
                 filterBatchSize,
                 { signal: context?.abortSignal },
             );
+        }
+
+        if (filterBatch.status === 'not-found') {
+            throw new Error('Block not found');
         }
     }
 }

--- a/packages/coinjoin/src/backend/scanAccount.ts
+++ b/packages/coinjoin/src/backend/scanAccount.ts
@@ -109,12 +109,10 @@ export const scanAccount = async (
 
         await fixTx(transactions, client);
 
-        if (transactions.length || progress) {
-            onProgress({
-                checkpoint,
-                transactions,
-                info: progress ? { progress } : undefined,
-            });
+        if (progress !== undefined) {
+            onProgress({ checkpoint, transactions, info: { progress } });
+        } else if (transactions.length) {
+            onProgress({ checkpoint, transactions });
         }
     }
 

--- a/packages/coinjoin/src/backend/scanAddress.ts
+++ b/packages/coinjoin/src/backend/scanAddress.ts
@@ -10,17 +10,15 @@ import type {
 } from '../types/backend';
 
 export const scanAddress = async (
-    params: ScanAddressParams & { checkpoint: ScanAddressCheckpoint },
+    params: ScanAddressParams & { checkpoints: ScanAddressCheckpoint[] },
     { client, network, filters, mempool, abortSignal, onProgress }: ScanAddressContext,
 ): Promise<ScanAddressResult> => {
     const address = params.descriptor;
     const script = getAddressScript(address, network);
-    let { checkpoint } = params;
+    const { checkpoints } = params;
+    let checkpoint = checkpoints[0];
 
-    const everyFilter = filters.getFilterIterator(
-        { fromHash: checkpoint.blockHash },
-        { abortSignal },
-    );
+    const everyFilter = filters.getFilterIterator({ checkpoints }, { abortSignal });
     // eslint-disable-next-line no-restricted-syntax
     for await (const { filter, blockHash, blockHeight, progress } of everyFilter) {
         checkpoint = { blockHash, blockHeight };

--- a/packages/coinjoin/src/types/backend.ts
+++ b/packages/coinjoin/src/types/backend.ts
@@ -31,10 +31,14 @@ export type BlockFilter = {
     blockTime: number;
 };
 
-export type BlockFilterResponse = {
-    bestHeight: number;
-    filters: BlockFilter[];
-};
+export type BlockFilterResponse =
+    | { status: 'up-to-date' }
+    | { status: 'not-found' }
+    | {
+          status: 'ok';
+          bestHeight: number;
+          filters: BlockFilter[];
+      };
 
 type MethodContext = {
     client: CoinjoinBackendClient;

--- a/packages/coinjoin/src/types/backend.ts
+++ b/packages/coinjoin/src/types/backend.ts
@@ -83,13 +83,13 @@ export type ScanAccountProgress = ScanProgress<ScanAccountCheckpoint>;
 
 export type ScanAccountParams = {
     descriptor: string;
-    checkpoint?: ScanAccountCheckpoint;
+    checkpoints?: ScanAccountCheckpoint[];
     cache?: AccountCache;
 };
 
 export type ScanAddressParams = {
     descriptor: string;
-    checkpoint?: ScanAddressCheckpoint;
+    checkpoints?: ScanAddressCheckpoint[];
 };
 
 export type ScanAccountResult = {
@@ -104,7 +104,10 @@ export type ScanAddressResult = {
 };
 
 export type FilterControllerParams = {
-    fromHash?: string;
+    checkpoints?: {
+        blockHeight: number;
+        blockHash: string;
+    }[];
     batchSize?: number;
 };
 

--- a/packages/coinjoin/tests/backend/CoinjoinBackendClient.test.ts
+++ b/packages/coinjoin/tests/backend/CoinjoinBackendClient.test.ts
@@ -17,23 +17,23 @@ describe.skip('CoinjoinBackendClient', () => {
     });
 
     it('fetchFilters success', async () => {
-        const { filters } = await client.fetchFilters(ZERO_HASH, 10);
-        expect(filters.length).toBe(10);
+        const response = await client.fetchFilters(ZERO_HASH, 10);
+        expect(response.status).toBe('ok');
+        expect((response as any).filters.length).toBe(10);
     });
 
     it('fetchFilters tip', async () => {
-        const { filters } = await client.fetchFilters(TIP_HASH, 10);
-        expect(filters.length).toBe(0);
+        const { status } = await client.fetchFilters(TIP_HASH, 10);
+        expect(status).toBe('up-to-date');
+    });
+
+    it('fetchFilters not found', async () => {
+        const { status } = await client.fetchFilters(NONEXISTENT_HASH, 10);
+        expect(status).toBe('not-found');
     });
 
     it('fetchFilters bad params', async () => {
         await expect(client.fetchFilters(TIP_HASH, -1)).rejects.toThrow(/^400:/);
-    });
-
-    it('fetchFilters not found', async () => {
-        await expect(client.fetchFilters(NONEXISTENT_HASH, 10)).rejects.toThrow(
-            new RegExp(`404:.*${NONEXISTENT_HASH}`),
-        );
     });
 
     it('fetchFilters malformed', async () => {

--- a/packages/coinjoin/tests/backend/CoinjoinFilterController.test.ts
+++ b/packages/coinjoin/tests/backend/CoinjoinFilterController.test.ts
@@ -25,7 +25,12 @@ const FIXTURES = [
         description: 'From middle',
         params: {
             batchSize: 5,
-            fromHash: FILTERS[FILTER_MIDDLE].prevHash,
+            checkpoints: [
+                {
+                    blockHash: FILTERS[FILTER_MIDDLE - 1].blockHash,
+                    blockHeight: FILTERS[FILTER_MIDDLE - 1].blockHeight,
+                },
+            ],
         },
         expected: FILTERS.slice(FILTER_MIDDLE),
     },
@@ -33,7 +38,12 @@ const FIXTURES = [
         description: 'Not found',
         params: {
             batchSize: 5,
-            fromHash: 'foo',
+            checkpoints: [
+                {
+                    blockHash: 'foo',
+                    blockHeight: 42,
+                },
+            ],
         },
         error: 'not found',
     },

--- a/packages/coinjoin/tests/backend/CoinjoinFilterController.test.ts
+++ b/packages/coinjoin/tests/backend/CoinjoinFilterController.test.ts
@@ -35,7 +35,7 @@ const FIXTURES = [
             batchSize: 5,
             fromHash: 'foo',
         },
-        expected: [],
+        error: 'not found',
     },
 ];
 
@@ -47,16 +47,20 @@ describe('CoinjoinFilterController', () => {
     });
 
     describe('Filter controller', () => {
-        FIXTURES.forEach(({ description, params, expected }) => {
+        FIXTURES.forEach(({ description, params, expected, error }) => {
             it(description, async () => {
                 const controller = new CoinjoinFilterController(client, COINJOIN_BACKEND_SETTINGS);
                 const iterator = controller.getFilterIterator(params);
-                const received = [];
-                // eslint-disable-next-line no-restricted-syntax
-                for await (const { progress, ...b } of iterator) {
-                    received.push(b);
+                if (error) {
+                    await expect(() => iterator.next()).rejects.toThrow(error);
+                } else {
+                    const received = [];
+                    // eslint-disable-next-line no-restricted-syntax
+                    for await (const { progress, ...b } of iterator) {
+                        received.push(b);
+                    }
+                    expect(received).toEqual(expected);
                 }
-                expect(received).toEqual(expected);
             });
         });
     });

--- a/packages/coinjoin/tests/backend/methods.test.ts
+++ b/packages/coinjoin/tests/backend/methods.test.ts
@@ -73,7 +73,7 @@ describe(`CoinjoinBackend methods`, () => {
         const { pending } = await scanAddress(
             {
                 descriptor: FIXTURES.SEGWIT_RECEIVE_ADDRESSES[0],
-                checkpoint: EMPTY_CHECKPOINT,
+                checkpoints: [EMPTY_CHECKPOINT],
             },
             getContext(progress => {
                 txs = txs.concat(progress.transactions);
@@ -101,7 +101,7 @@ describe(`CoinjoinBackend methods`, () => {
         const { pending, checkpoint } = await scanAccount(
             {
                 descriptor: FIXTURES.SEGWIT_XPUB,
-                checkpoint: EMPTY_CHECKPOINT,
+                checkpoints: [EMPTY_CHECKPOINT],
             },
             getContext(progress => {
                 txs = txs.concat(progress.transactions);
@@ -134,7 +134,7 @@ describe(`CoinjoinBackend methods`, () => {
         const half = await scanAccount(
             {
                 descriptor: FIXTURES.SEGWIT_XPUB,
-                checkpoint: EMPTY_CHECKPOINT,
+                checkpoints: [EMPTY_CHECKPOINT],
             },
             getContext(progress => {
                 txs = txs.concat(progress.transactions);
@@ -172,7 +172,7 @@ describe(`CoinjoinBackend methods`, () => {
         const full = await scanAccount(
             {
                 descriptor: FIXTURES.SEGWIT_XPUB,
-                checkpoint: half.checkpoint,
+                checkpoints: [half.checkpoint],
             },
             getContext(progress => {
                 txs = txs.concat(progress.transactions);

--- a/packages/coinjoin/tests/backend/methods.test.ts
+++ b/packages/coinjoin/tests/backend/methods.test.ts
@@ -19,6 +19,9 @@ const EMPTY_CHECKPOINT = {
     changeCount: DISCOVERY_LOOKOUT,
 };
 
+const hasFilters = (r: BlockFilterResponse): r is Extract<BlockFilterResponse, { status: 'ok' }> =>
+    r.status === 'ok';
+
 describe(`CoinjoinBackend methods`, () => {
     const client = new MockBackendClient();
     const fetchFiltersMock = jest.spyOn(client, 'fetchFilters');
@@ -28,7 +31,9 @@ describe(`CoinjoinBackend methods`, () => {
     const getRequestedFilters = () =>
         Promise.all(fetchFiltersMock.mock.results.map(res => res.value)).then(
             (response: BlockFilterResponse[]) =>
-                response.flatMap(res => res.filters.map(filter => filter.blockHeight as number)),
+                response
+                    .filter(hasFilters)
+                    .flatMap(res => res.filters.map(filter => filter.blockHeight as number)),
         );
 
     const getRequestedBlocks = () =>

--- a/packages/coinjoin/tests/mocks/MockFilterClient.ts
+++ b/packages/coinjoin/tests/mocks/MockFilterClient.ts
@@ -1,9 +1,9 @@
 import type { BlockFilter, FilterClient } from '../../src/types/backend';
 
 export class MockFilterClient implements FilterClient {
-    private readonly filters;
+    private filters: BlockFilter[] = [];
 
-    constructor(filters: BlockFilter[]) {
+    setFixture(filters: BlockFilter[]) {
         this.filters = filters;
     }
 

--- a/packages/coinjoin/tests/mocks/MockFilterClient.ts
+++ b/packages/coinjoin/tests/mocks/MockFilterClient.ts
@@ -1,19 +1,24 @@
 import type { BlockFilter, FilterClient } from '../../src/types/backend';
 
 export class MockFilterClient implements FilterClient {
-    private bestHeight;
     private readonly filters;
 
     constructor(filters: BlockFilter[]) {
         this.filters = filters;
-        this.bestHeight = this.filters[this.filters.length - 1].blockHeight;
     }
 
-    fetchFilters(knownHash: string, count: number) {
+    fetchFilters(knownHash: string, count: number): ReturnType<FilterClient['fetchFilters']> {
+        const tip = this.filters[this.filters.length - 1];
+        if (knownHash === tip.blockHash) {
+            return Promise.resolve({ status: 'up-to-date' });
+        }
         const from = this.filters.findIndex(f => f.prevHash === knownHash);
-        return Promise.resolve({
-            bestHeight: this.bestHeight,
-            filters: from < 0 ? [] : this.filters.slice(from, from + count),
-        });
+        return from < 0
+            ? Promise.resolve({ status: 'not-found' })
+            : Promise.resolve({
+                  status: 'ok',
+                  bestHeight: tip.blockHeight,
+                  filters: this.filters.slice(from, from + count),
+              });
     }
 }

--- a/packages/suite/src/reducers/wallet/coinjoinReducer.ts
+++ b/packages/suite/src/reducers/wallet/coinjoinReducer.ts
@@ -190,13 +190,18 @@ const restoreSession = (
     account.session.timeCreated = Date.now();
 };
 
+// Should store at most 3 latest checkpoints, from latest to oldest
 const saveCheckpoint = (
     draft: CoinjoinState,
     action: Extract<Action, { type: typeof COINJOIN.ACCOUNT_DISCOVERY_PROGRESS }>,
 ) => {
     const account = draft.accounts.find(a => a.key === action.payload.account.key);
     if (!account) return;
-    account.checkpoint = action.payload.progress.checkpoint;
+    const checkpointNew = action.payload.progress.checkpoint;
+    const checkpoints = (account.checkpoints ?? [])
+        .filter(({ blockHeight }) => blockHeight < checkpointNew.blockHeight)
+        .slice(0, 2);
+    account.checkpoints = [checkpointNew, ...checkpoints];
 };
 
 const createClient = (

--- a/suite-common/wallet-types/src/coinjoin.ts
+++ b/suite-common/wallet-types/src/coinjoin.ts
@@ -45,5 +45,5 @@ export interface CoinjoinAccount {
     targetAnonymity: number; // anonymity set by the user
     session?: CoinjoinSession; // current/active authorized session
     previousSessions: CoinjoinSession[]; // history
-    checkpoint?: CoinjoinDiscoveryCheckpoint;
+    checkpoints?: CoinjoinDiscoveryCheckpoint[];
 }


### PR DESCRIPTION
## Description

https://github.com/trezor/trezor-suite/pull/6994/commits/d8cf4bb3f9ed19c5d72ffa2cc1179c7ff77baf60 - return `ok`, `up-to-date `and `not-found` statuses from `fetchFilters`, to be able to handle reorgs
https://github.com/trezor/trezor-suite/pull/6994/commits/e5100d2b387ea37cfe6cc9869ed3dd949f1e9630 - pass array of checkpoints to `scanAccount` -> `CoinjoinFilterController` instead of single checkpoint
https://github.com/trezor/trezor-suite/pull/6994/commits/ec5b5364cb358def79ceaa4977c867b6e82447cd - implement reorgs (finding checkpoint from which it's possible to fetch filters) in CoinjoinFilterController
https://github.com/trezor/trezor-suite/pull/6994/commits/5c5626450a4850064183a3779bc99fa591ea6b66 - storing up to 3 checkpoints in Suite; discarding transactions when older than latest known checkpoint is received; `isAccountOutdated` replaced by comparing `transactions` array with its previous version

## Related Issue

Resolve #6889