### PR TITLE
fix: missing symbol in erc tokens list if name matches symbol

### DIFF
--- a/packages/suite/src/views/wallet/tokens/components/TokenList.tsx
+++ b/packages/suite/src/views/wallet/tokens/components/TokenList.tsx
@@ -74,14 +74,21 @@ export const TokenList = ({ tokens, explorerUrl, isTestnet, networkType }: Token
     return (
         <Wrapper isTestnet={isTestnet} noPadding>
             {tokens.map(t => {
-                const noName = !t.symbol || t.symbol.toLowerCase() === t.name?.toLowerCase();
+                // In Cardano token name is optional and in there is no symbol.
+                // However, if Cardano token doesn't have a name on blockchain, its TokenInfo has both name
+                // and symbol props set to a token fingerprint (done in blockchain-link) and we
+                // don't want to render it twice.
+                // In ethereum we are fine with rendering symbol - name even if they are the same.
+                const symbolMatchesName =
+                    networkType === 'cardano' && t.symbol?.toLowerCase() === t.name?.toLowerCase();
+                const noSymbol = !t.symbol || symbolMatchesName;
 
                 return (
                     <Fragment key={t.address}>
                         <Col isTestnet={isTestnet}>
-                            {!noName && <TokenSymbol>{t.symbol}</TokenSymbol>}
+                            {!noSymbol && <TokenSymbol>{t.symbol}</TokenSymbol>}
                             <TokenName>
-                                {!noName && ` - `}
+                                {!noSymbol && ` - `}
                                 {t.name}
                             </TokenName>
                         </Col>


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
fixing ui bug introduced in [cardano pr](https://github.com/trezor/trezor-suite/commit/8fed4ff9336a4f9c7eef5d7ef29943c66208ad12#diff-7fe91df0275ac2c521d22ab6ced2f427b7d7eac291ce8641db79cd8197d7a987), if erc token name matches its symbol then the symbol was no longer rendered in tokens tab.

@komret I can't assign you :)
## Related Issue

Resolve  https://github.com/trezor/trezor-suite/issues/6952

## Screenshots:
