### PR TITLE
Sort CoinJoin txs from the same block correctly

### DIFF
--- a/packages/blockchain-link/src/workers/electrum/methods/getAccountInfo.ts
+++ b/packages/blockchain-link/src/workers/electrum/methods/getAccountInfo.ts
@@ -1,4 +1,5 @@
 import { discovery } from '@trezor/utxo-lib';
+import { sortTxsFromLatest } from '../../utils';
 import { Api, tryGetScripthash, discoverAddress, AddressHistory, getTransactions } from '../utils';
 import { transformTransaction } from '../../blockbook/utils';
 import type { ElectrumAPI } from '../../../types/electrum';
@@ -14,15 +15,6 @@ type AddressInfo = Omit<AddressHistory, 'scripthash'> & {
     confirmed: number;
     unconfirmed: number;
 };
-
-const isNonNegative = (n: number | undefined): n is number => (n ?? -1) >= 0;
-
-export const sortTxsFromLatest = (
-    { blockHeight: a }: { blockHeight?: number },
-    { blockHeight: b }: { blockHeight?: number },
-) =>
-    (isNonNegative(b) ? b : Number.MAX_SAFE_INTEGER) -
-    (isNonNegative(a) ? a : Number.MAX_SAFE_INTEGER);
 
 const getBalances =
     (client: ElectrumAPI) =>

--- a/packages/blockchain-link/src/workers/utils.ts
+++ b/packages/blockchain-link/src/workers/utils.ts
@@ -1,6 +1,6 @@
 import BigNumber from 'bignumber.js';
 import { isNotUndefined, parseHostname } from '@trezor/utils';
-import type { EnhancedVinVout } from '../types';
+import type { Transaction, EnhancedVinVout } from '../types';
 import type { VinVout } from '../types/blockbook';
 
 export type Addresses = ({ address: string } | string)[] | string;
@@ -64,3 +64,16 @@ export const prioritizeEndpoints = (urls: string[]) =>
         })
         .sort(([, a], [, b]) => b - a)
         .map(([url]) => url);
+
+const adjustHeight = (n: number | undefined) =>
+    n === undefined || n <= 0 ? Number.MAX_SAFE_INTEGER : n;
+
+export const sortTxsFromLatest = (txA: Transaction, txB: Transaction) => {
+    const a = adjustHeight(txA.blockHeight);
+    const b = adjustHeight(txB.blockHeight);
+    if (a === b) {
+        if (txA.details.vin.some(({ txid }) => txid === txB.txid)) return -1;
+        if (txB.details.vin.some(({ txid }) => txid === txA.txid)) return 1;
+    }
+    return b - a;
+};

--- a/packages/coinjoin/src/backend/getAccountInfo.ts
+++ b/packages/coinjoin/src/backend/getAccountInfo.ts
@@ -1,8 +1,6 @@
 import type { Network } from '@trezor/utxo-lib';
-import {
-    sumAddressValues,
-    sortTxsFromLatest,
-} from '@trezor/blockchain-link/lib/workers/electrum/methods/getAccountInfo';
+import { sortTxsFromLatest } from '@trezor/blockchain-link/lib/workers/utils';
+import { sumAddressValues } from '@trezor/blockchain-link/lib/workers/electrum/methods/getAccountInfo';
 
 import { isTxConfirmed, doesTxContainAddress, deriveAddresses } from './backendUtils';
 import type {


### PR DESCRIPTION
## Description

Transactions from the same block (or pending txs) are now ordered so that tx which spends output of another tx come after it, which should fix e.g. identifying utxos.