### PR TITLE
 fix formating of negative decimal numbers

### DIFF
--- a/packages/suite/src/components/suite/FormattedCryptoAmount.tsx
+++ b/packages/suite/src/components/suite/FormattedCryptoAmount.tsx
@@ -64,7 +64,7 @@ export const FormattedCryptoAmount = ({
 
     const content = (
         <Container className={className}>
-            {signValue && <Sign value={signValue} />}
+            {!!signValue && <Sign value={signValue} />}
 
             <Value data-test={dataTest}>{formattedValue}</Value>
 

--- a/suite-common/wallet-utils/src/__tests__/localizeNumber.test.ts
+++ b/suite-common/wallet-utils/src/__tests__/localizeNumber.test.ts
@@ -37,7 +37,14 @@ describe('localizeNumber', () => {
 
     it('formats negative numbers', () => {
         expect(localizeNumber(-123456789)).toStrictEqual('-123,456,789');
+        expect(localizeNumber(-123456789.111)).toStrictEqual('-123,456,789.111');
         expect(localizeNumber(-0.42)).toStrictEqual('-0.42');
+        expect(localizeNumber('-123456789')).toStrictEqual('-123,456,789');
+        expect(localizeNumber('-123456789.111')).toStrictEqual('-123,456,789.111');
+        expect(localizeNumber('-0.42')).toStrictEqual('-0.42');
+        expect(localizeNumber(new BigNumber('-123456789'))).toStrictEqual('-123,456,789');
+        expect(localizeNumber(new BigNumber('-123456789.111'))).toStrictEqual('-123,456,789.111');
+        expect(localizeNumber(new BigNumber('-0.42'))).toStrictEqual('-0.42');
     });
 
     it('formats string decimals', () => {

--- a/suite-common/wallet-utils/src/__tests__/localizeNumber.test.ts
+++ b/suite-common/wallet-utils/src/__tests__/localizeNumber.test.ts
@@ -35,6 +35,11 @@ describe('localizeNumber', () => {
         expect(() => localizeNumber(123456789, 'en', 3, 2)).toThrowError();
     });
 
+    it('formats negative numbers', () => {
+        expect(localizeNumber(-123456789)).toStrictEqual('-123,456,789');
+        expect(localizeNumber(-0.42)).toStrictEqual('-0.42');
+    });
+
     it('formats string decimals', () => {
         expect(localizeNumber('1112222222222233333333334444444444')).toStrictEqual(
             '1,112,222,222,222,233,333,333,334,444,444,444',

--- a/suite-common/wallet-utils/src/localizeNumber.ts
+++ b/suite-common/wallet-utils/src/localizeNumber.ts
@@ -29,10 +29,14 @@ export const localizeNumber = (
         minimumFractionDigits: minDecimals,
     })
         .format(decimalNumber)
-        .slice(1); // remove leading zero
+        .slice(amount.isNegative() ? 2 : 1); // remove leading zero and minus sign i.e. -0.123 -> .123, 0.123 -> .123
 
     const isDecimalNumber =
         minDecimals > 0 || new BigNumber(formattedDecimalNumber).decimalPlaces() !== 0;
 
-    return formattedWholeNumber + (isDecimalNumber ? formattedDecimalNumber : '');
+    const hasNegativeZero = amount.isNegative() && wholeNumber === BigInt(0);
+
+    return `${hasNegativeZero ? '-' : ''}${formattedWholeNumber}${
+        isDecimalNumber ? formattedDecimalNumber : ''
+    }`;
 };


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Formatting of negative decimal numbers was broken. `-` was removed instead of 0 so it let to `00.1` insead of `-0.1` or `10.1` instead of `-1.1`. 

## Related Issue

Resolve https://github.com/trezor/trezor-suite/issues/6295

## Screenshots:
<img width="663" alt="image" src="https://user-images.githubusercontent.com/3729633/204002803-f8ba25fe-3df4-4427-8c66-fba35fad25d2.png">

before the fix:
<img width="602" alt="image" src="https://user-images.githubusercontent.com/3729633/203979840-38e52bf7-aa04-431a-9d56-bb73d9226c60.png">

