### PR TITLE
Simplify anonymity level indicator

### DIFF
--- a/packages/suite/src/components/wallet/PrivacyAccount/AnonymityLevelIndicator.tsx
+++ b/packages/suite/src/components/wallet/PrivacyAccount/AnonymityLevelIndicator.tsx
@@ -9,6 +9,7 @@ import { AnonymityStatus } from '@suite-constants/coinjoin';
 const Container = styled.div`
     display: flex;
     align-items: center;
+    gap: 6px;
     justify-content: space-between;
     padding: 6px 10px;
     border-radius: 8px;
@@ -29,7 +30,7 @@ const Container = styled.div`
 `;
 
 const Values = styled.div`
-    min-width: 64px;
+    min-width: 50px;
 `;
 
 const AnonymityLevel = styled.p`
@@ -91,12 +92,7 @@ export const AnonymityLevelIndicator = forwardRef<HTMLDivElement, AnonymityLevel
                 <Icon icon="USERS" />
 
                 <Values>
-                    <AnonymityLevel>
-                        <Translation
-                            id="TR_COINJOIN_ANONYMITY_LEVEL_INDICATOR"
-                            values={{ anonymity: targetAnonymity }}
-                        />
-                    </AnonymityLevel>
+                    <AnonymityLevel>{targetAnonymity}</AnonymityLevel>
                     <AnonymityStatusLabel
                         color={getAnonymityStatusColor({ theme, anonymityStatus })}
                     >

--- a/packages/suite/src/components/wallet/PrivacyAccount/UtxoAnonymity.tsx
+++ b/packages/suite/src/components/wallet/PrivacyAccount/UtxoAnonymity.tsx
@@ -1,17 +1,19 @@
 import React from 'react';
 import styled from 'styled-components';
 
-import { Translation } from '@suite-components';
 import { Icon, variables } from '@trezor/components';
 
 const Wrapper = styled.div`
     align-items: center;
-    color: ${({ theme }) => theme.TYPE_LIGHT_GREY};
     display: flex;
+    gap: 6px;
+`;
+
+const AnonymityLevel = styled.span`
+    color: ${({ theme }) => theme.TYPE_LIGHT_GREY};
     font-size: ${variables.FONT_SIZE.SMALL};
     font-variant-numeric: tabular-nums;
     font-weight: ${variables.FONT_WEIGHT.MEDIUM};
-    gap: 6px;
 `;
 
 interface UtxoAnonymityProps {
@@ -21,6 +23,6 @@ interface UtxoAnonymityProps {
 export const UtxoAnonymity = ({ anonymity }: UtxoAnonymityProps) => (
     <Wrapper>
         <Icon icon="USERS" size={20} />
-        <Translation id="TR_COINJOIN_ANONYMITY_LEVEL_INDICATOR" values={{ anonymity }} />
+        <AnonymityLevel>{anonymity}</AnonymityLevel>
     </Wrapper>
 );

--- a/packages/suite/src/support/messages.ts
+++ b/packages/suite/src/support/messages.ts
@@ -7384,10 +7384,6 @@ export default defineMessages({
         id: 'TR_COINJOIN_ANONYMITY_LEVEL_SETUP_DESCRIPTION',
         defaultMessage: 'Shows the number of people with whom your resources are indistinguishable',
     },
-    TR_COINJOIN_ANONYMITY_LEVEL_INDICATOR: {
-        id: 'TR_COINJOIN_ANONYMITY_LEVEL_INDICATOR',
-        defaultMessage: '1 in {anonymity}',
-    },
     TR_ANONYMITY_LEVEL_BAD: {
         id: 'TR_ANONYMITY_LEVEL_BAD',
         defaultMessage: 'BAD',


### PR DESCRIPTION
## Description

Display anonymity level as _X_ rather than _1 in X_.

## Related Issue

Resolve #7013

## Screenshots:
coinjoin settings:
![Screenshot 2022-11-25 at 16 26 01](https://user-images.githubusercontent.com/42465546/204016452-be620572-cbf8-435b-a9d1-44dce4d7e938.png)
transaction detail:
![Screenshot 2022-11-25 at 16 26 17](https://user-images.githubusercontent.com/42465546/204016469-58a9ae98-1f2f-4e14-baa1-1b48942834e5.png)
coin control:
![Screenshot 2022-11-25 at 16 26 33](https://user-images.githubusercontent.com/42465546/204016489-5fc74f39-9b1a-48f1-a099-402957221faf.png)

