### PR TITLE
fix(ci): remove fastlane hotfix

### DIFF
--- a/suite-native/app/ios/fastlane/Fastfile
+++ b/suite-native/app/ios/fastlane/Fastfile
@@ -4,9 +4,6 @@ skip_docs
 IOS_PROJECT = File.join(IOS_PATH, "TrezorSuite.xcodeproj").freeze
 IOS_PROJECT_WORKSPACE = File.join(IOS_PATH, "TrezorSuite.xcworkspace").freeze
 
-# https://github.com/fastlane/fastlane/issues/20741
-ENV['ITMSTRANSPORTER_FORCE_ITMS_PACKAGE_UPLOAD'] = "true"
-
 platform :ios do
 
   before_all do |lane|


### PR DESCRIPTION
This hotfix is no longer necessary in latest version and it causing fail to upload IPA to app store.