### PR TITLE
feat(message-system): update suite link

### DIFF
--- a/packages/message-system/src/config/config.v1.json
+++ b/packages/message-system/src/config/config.v1.json
@@ -1,20 +1,20 @@
 {
     "version": 1,
-    "timestamp": "2022-10-13T00:00:00+00:00",
-    "sequence": 16,
+    "timestamp": "2022-11-28T00:00:00+00:00",
+    "sequence": 17,
     "actions": [
         {
             "conditions": [
                 {
                     "environment": {
-                        "desktop": "<22.9.3",
+                        "desktop": "<22.11.1",
                         "mobile": "!",
                         "web": "!"
                     }
                 }
             ],
             "message": {
-                "id": "a99d0ad4-3bab-4630-9352-fd17a518153f",
+                "id": "a99d0ad4-3bab-4660-9352-fd17a518153f",
                 "priority": 91,
                 "dismissible": true,
                 "variant": "warning",
@@ -29,7 +29,7 @@
                 },
                 "cta": {
                     "action": "external-link",
-                    "link": "https://suite.trezor.io/",
+                    "link": "https://trezor.io/trezor-suite",
                     "label": {
                         "en-GB": "Go to suite.trezor.io",
                         "en": "Go to suite.trezor.io",


### PR DESCRIPTION
## Description

- When removing `broken USB on Android` banner. I forgot to update the sequence number, so the banner was still showing up to people, who did not dismiss the banner.
- Updated link to `Trezor Suite` + version required to show prompt to update the app

## Related Issue

https://satoshilabs.slack.com/archives/CKYFBT2C9/p1669389509741189
