### PR TITLE
Fix/connect analytics

### DIFF
--- a/packages/analytics/package.json
+++ b/packages/analytics/package.json
@@ -4,11 +4,12 @@
     "private": true,
     "license": "See LICENSE.md in repo root",
     "sideEffects": false,
-    "main": "src/index",
+    "main": "lib/index",
     "scripts": {
         "lint:js": "yarn g:eslint '**/*.{ts,tsx,js}'",
         "test:unit": "jest -c ../../jest.config.base.js",
-        "type-check": "tsc --build"
+        "type-check": "tsc --build",
+        "build:lib": "rimraf lib && yarn tsc --build ./tsconfig.lib.json"
     },
     "dependencies": {
         "@trezor/utils": "*"

--- a/packages/analytics/tsconfig.lib.json
+++ b/packages/analytics/tsconfig.lib.json
@@ -1,0 +1,8 @@
+{
+    "extends": "../../tsconfig.lib.json",
+    "compilerOptions": {
+        "outDir": "./lib",
+        "esModuleInterop": false
+    },
+    "include": ["./src"]
+}

--- a/packages/connect-analytics/package.json
+++ b/packages/connect-analytics/package.json
@@ -4,10 +4,11 @@
     "private": true,
     "license": "See LICENSE.md in repo root",
     "sideEffects": false,
-    "main": "src/index",
+    "main": "lib/index",
     "scripts": {
         "lint:js": "yarn g:eslint '**/*.{ts,tsx,js}'",
-        "type-check": "tsc --build"
+        "type-check": "tsc --build",
+        "build:lib": "rimraf lib && yarn tsc --build ./tsconfig.lib.json"
     },
     "dependencies": {
         "@trezor/analytics": "*"

--- a/packages/connect-analytics/tsconfig.lib.json
+++ b/packages/connect-analytics/tsconfig.lib.json
@@ -1,0 +1,8 @@
+{
+    "extends": "../../tsconfig.lib.json",
+    "compilerOptions": {
+        "outDir": "./lib",
+        "esModuleInterop": false
+    },
+    "include": ["./src"]
+}

--- a/packages/connect/package.json
+++ b/packages/connect/package.json
@@ -50,6 +50,7 @@
     },
     "dependencies": {
         "@trezor/blockchain-link": "^2.1.5",
+        "@trezor/connect-analytics": "*",
         "@trezor/connect-common": "0.0.10",
         "@trezor/device-utils": "*",
         "@trezor/transport": "^1.1.5",

--- a/packages/connect/src/core/index.ts
+++ b/packages/connect/src/core/index.ts
@@ -2,7 +2,7 @@
 import EventEmitter from 'events';
 import { DataManager } from '../data/DataManager';
 import { DeviceList } from '../device/DeviceList';
-// import { enhancePostMessageWithAnalytics } from '../data/analyticsInfo';
+import { enhancePostMessageWithAnalytics } from '../data/analyticsInfo';
 
 import { ERRORS } from '../constants';
 
@@ -362,8 +362,8 @@ export const onCall = async (message: CoreMessage) => {
         throw error;
     }
 
-    // method.postMessage = (message: CoreMessage) =>
-    //     enhancePostMessageWithAnalytics(postMessage, message, { device });
+    method.postMessage = (message: CoreMessage) =>
+        enhancePostMessageWithAnalytics(postMessage, message, { device });
 
     method.setDevice(device);
 

--- a/packages/connect/src/data/analyticsInfo.ts
+++ b/packages/connect/src/data/analyticsInfo.ts
@@ -1,0 +1,52 @@
+/* eslint-disable no-case-declarations */
+import { EventType } from '@trezor/connect-analytics';
+import {
+    getBootloaderHash,
+    getBootloaderVersion,
+    getDeviceMode,
+    getDeviceModel,
+    getFirmwareRevision,
+    getFirmwareType,
+    getFirmwareVersion,
+} from '@trezor/device-utils';
+import { CoreMessage, PostMessage, UI_REQUEST } from '../events';
+import type { Device } from '../device/Device';
+
+export const enhancePostMessageWithAnalytics = (
+    callback: PostMessage,
+    message: CoreMessage,
+    data: { device?: Device },
+) => {
+    switch (message.type) {
+        case UI_REQUEST.REQUEST_CONFIRMATION:
+            const { device } = data;
+
+            callback({
+                ...message,
+                payload: {
+                    ...message.payload,
+                    analytics: {
+                        type: EventType.DeviceSelected,
+                        payload: {
+                            mode: getDeviceMode(device),
+                            pinProtection: device?.features.pin_protection || '',
+                            passphraseProtection: device?.features.passphrase_protection || '',
+                            backupType: device?.features.backup_type || 'Bip39',
+                            language: device?.features.language || '',
+                            model: getDeviceModel(device),
+                            vendor: device?.features.vendor || '',
+                            firmware: getFirmwareVersion(device),
+                            firmwareRevision: getFirmwareRevision(device),
+                            firmwareType: getFirmwareType(device),
+                            bootloaderHash: getBootloaderHash(device),
+                            bootloaderVersion: getBootloaderVersion(device),
+                        },
+                    },
+                },
+            });
+            break;
+
+        default:
+            callback(message);
+    }
+};

--- a/packages/connect/src/events/ui-request.ts
+++ b/packages/connect/src/events/ui-request.ts
@@ -1,7 +1,7 @@
 /*
  * messages to UI emitted as UI_EVENT
  */
-// import type { EventTypeDeviceSelected } from '@trezor/connect-analytics';
+import type { EventTypeDeviceSelected } from '@trezor/connect-analytics';
 
 import type { PROTO } from '../constants';
 import type { TransportDisableWebUSB } from './transport';
@@ -173,8 +173,7 @@ export interface UiRequestConfirmation {
             className: string;
             label: string;
         };
-        // analytics?: EventTypeDeviceSelected;
-        analytics?: any;
+        analytics?: EventTypeDeviceSelected;
     };
 }
 

--- a/packages/connect/tsconfig.json
+++ b/packages/connect/tsconfig.json
@@ -4,6 +4,7 @@
     "include": ["../../submodules/trezor-common"],
     "references": [
         { "path": "../blockchain-link" },
+        { "path": "../connect-analytics" },
         { "path": "../connect-common" },
         { "path": "../device-utils" },
         { "path": "../transport" },

--- a/packages/device-utils/package.json
+++ b/packages/device-utils/package.json
@@ -4,10 +4,14 @@
     "private": true,
     "license": "See LICENSE.md in repo root",
     "sideEffects": false,
-    "main": "src/index",
+    "main": "lib/index",
     "scripts": {
         "lint:js": "yarn g:eslint '**/*.{ts,tsx,js}'",
         "test:unit": "jest -c ../../jest.config.base.js --passWithNoTests",
-        "type-check": "tsc --build"
+        "type-check": "tsc --build",
+        "build:lib": "rimraf lib && yarn tsc --build ./tsconfig.lib.json"
+    },
+    "devDependencies": {
+        "typescript": "4.7.4"
     }
 }

--- a/packages/device-utils/tsconfig.lib.json
+++ b/packages/device-utils/tsconfig.lib.json
@@ -1,0 +1,8 @@
+{
+    "extends": "../../tsconfig.lib.json",
+    "compilerOptions": {
+        "outDir": "./lib",
+        "esModuleInterop": false
+    },
+    "include": ["./src"]
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -7590,6 +7590,7 @@ __metadata:
   resolution: "@trezor/connect@workspace:packages/connect"
   dependencies:
     "@trezor/blockchain-link": ^2.1.5
+    "@trezor/connect-analytics": "*"
     "@trezor/connect-common": 0.0.10
     "@trezor/device-utils": "*"
     "@trezor/transport": ^1.1.5

--- a/yarn.lock
+++ b/yarn.lock
@@ -7631,6 +7631,8 @@ __metadata:
 "@trezor/device-utils@*, @trezor/device-utils@workspace:packages/device-utils":
   version: 0.0.0-use.local
   resolution: "@trezor/device-utils@workspace:packages/device-utils"
+  dependencies:
+    typescript: 4.7.4
   languageName: unknown
   linkType: soft
 


### PR DESCRIPTION
## Description

- Unfortunately, we need to `build:lib` three new packages to make it work properly in the electron layer. Those packages are used by `connect`, which is also `build:lib`ed, in `suite-desktop`
- It has to be in `node_modules` folder so we cannot use `build.ts` in `suite-desktop`

## Related Issue

Reverts and fixes https://github.com/trezor/trezor-suite/pull/7015
