### PR TITLE
fix(coinjoin): output-registration request delay

### DIFF
--- a/packages/coinjoin/src/client/Alice.ts
+++ b/packages/coinjoin/src/client/Alice.ts
@@ -27,6 +27,7 @@ export class Alice {
     registrationData?: RegistrationData; // data from inputRegistration phase
     realAmountCredentials?: RealCredentials; // data from inputRegistration phase
     realVsizeCredentials?: RealCredentials; // data from inputRegistration phase
+    confirmationDeadline = 0;
     confirmationData?: ConfirmationData; // data from connectionConfirmation phase
     confirmedAmountCredentials?: Credentials[]; // data from connectionConfirmation phase
     confirmedVsizeCredentials?: Credentials[]; // data from connectionConfirmation phase


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
After successful input-registration (green) connect-confirmation (yellow) needs to be called to prevent AliceTimeout error on coordinator.

#### Desired state:
Keep constant time distance between input-registration and connection-confirmation requests regardless of Round phase.

#### Current state:
- when coordinator changes Round phase from 0 to 1 all inputs are confirmed immediately
- side effect: `confirmationInterval` was using own/custom interval instead of "native" delay feature of  coordinatorRequest/scheduleAction


![connection-confirmation](https://user-images.githubusercontent.com/3435913/204348156-419ddf02-76ae-46da-abd9-254556b8ded4.png)


