### PR TITLE
feat(send-form): import label

### DIFF
--- a/packages/suite-web/e2e/fixtures/btcTest.csv
+++ b/packages/suite-web/e2e/fixtures/btcTest.csv
@@ -1,3 +1,3 @@
-address,amount,currency
-bc1qfcjv620stvtzjeelg26ncgww8ks49zy8lracjz,0.31337,BTC
+address,amount,currency,label
+bc1qfcjv620stvtzjeelg26ncgww8ks49zy8lracjz,0.31337,BTC,meow
 bc1quqgq44wq0zjh6d920zs42nsy4n4ev5vt8nxke4,0.1,USD

--- a/packages/suite/src/hooks/wallet/useSendFormImport.ts
+++ b/packages/suite/src/hooks/wallet/useSendFormImport.ts
@@ -32,6 +32,10 @@ export const useSendFormImport = ({ network, tokens, localCurrencyOption, fiatRa
                 address: item.address || '',
             };
 
+            if (item.label) {
+                output.label = item.label;
+            }
+
             // currency is specified in csv
             if (item.currency) {
                 // sanitize csv data


### PR DESCRIPTION
turned out to be really low hanging. few notes: test should be extended. My initial intention was to switch from btc to regtest in this test, import from csv with labels, send tx and validate that there are really associated labels in transactions list but this turned out to be complicated since I couldn't see fiat rates with regtest. Are they gone or what? 

resolves #5770

test: https://gitlab.com/satoshilabs/trezor/trezor-suite/-/jobs/3397705934/artifacts/file/packages/suite-web/e2e/videos/import-btc-csv.test.ts.mp4