### PR TITLE
feat(suite-native): show xpub in account detail

### DIFF
--- a/suite-native/module-accounts/src/screens/AccountDetailSettings.tsx
+++ b/suite-native/module-accounts/src/screens/AccountDetailSettings.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useState } from 'react';
 import { useDispatch, useSelector } from 'react-redux';
 
 import { useNavigation } from '@react-navigation/native';
@@ -11,7 +11,7 @@ import {
     StackNavigationProps,
     StackProps,
 } from '@suite-native/navigation';
-import { Box, Button, Text } from '@suite-native/atoms';
+import { BottomSheet, Box, Button, Text, VStack } from '@suite-native/atoms';
 import {
     accountsActions,
     AccountsRootState,
@@ -23,6 +23,7 @@ export const AccountDetailSettings = ({
     route,
 }: StackProps<AccountsStackParamList, AccountsStackRoutes.AccountDetailSettings>) => {
     const { accountKey } = route.params;
+    const [isXpubVisible, setIsXpubVisible] = useState(false);
     const navigation =
         useNavigation<
             StackNavigationProps<AccountsStackParamList, AccountsStackRoutes.AccountDetailSettings>
@@ -47,9 +48,17 @@ export const AccountDetailSettings = ({
             <Box marginBottom="large">
                 <Text variant="titleMedium">{accountName}</Text>
             </Box>
-            <Button onPress={handleRemoveAccount} colorScheme="gray">
-                Remove Account
-            </Button>
+            <VStack spacing="small">
+                <Button onPress={() => setIsXpubVisible(true)} colorScheme="gray">
+                    Show Xpub
+                </Button>
+                <Button onPress={handleRemoveAccount} colorScheme="gray">
+                    Remove Account
+                </Button>
+            </VStack>
+            <BottomSheet isVisible={isXpubVisible} onVisibilityChange={setIsXpubVisible}>
+                <Text>{account.descriptor}</Text>
+            </BottomSheet>
         </Screen>
     );
 };


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Simple text render of xpub in bottom sheet. Designs are not yet ready but for testing purposes it's a good idea to at least be able to see the actual xpub there. 

## Related Issue

Resolve https://github.com/trezor/trezor-suite/issues/6999

## Screenshots:
<img width="315" alt="image" src="https://user-images.githubusercontent.com/36101761/205071271-78181c6a-411c-4173-aed9-c269c09c3efb.png">
<img width="309" alt="image" src="https://user-images.githubusercontent.com/36101761/205071317-97d403e9-861f-4fdb-8e21-70e26d0a58ee.png">
