### PR TITLE
Fix length of descriptor fingerprint

### DIFF
--- a/packages/connect/src/device/DeviceCommands.ts
+++ b/packages/connect/src/device/DeviceCommands.ts
@@ -208,7 +208,9 @@ export class DeviceCommands {
 
         if (isTaprootPath(path)) {
             // wrap regular xpub into bitcoind native descriptor
-            const fingerprint = Number(publicKey.root_fingerprint || 0).toString(16);
+            const fingerprint = Number(publicKey.root_fingerprint || 0)
+                .toString(16)
+                .padStart(8, '0');
             const descriptorPath = `${fingerprint}${response.serializedPath.substring(1)}`;
             response.xpubSegwit = `tr([${descriptorPath}]${response.xpub}/<0;1>/*)`;
         }


### PR DESCRIPTION
## Description

Added leading zeros to ensure that fingerprint in descriptor for taproot accounts always has 8 characters (based on [descriptor spec](https://github.com/bitcoin/bitcoin/blob/master/doc/descriptors.md)).