### PR TITLE
Fix skeleton vertical alignment and margin

### DIFF
--- a/packages/suite/src/components/wallet/AccountTopPanel/index.tsx
+++ b/packages/suite/src/components/wallet/AccountTopPanel/index.tsx
@@ -42,16 +42,16 @@ const AccountTopPanelSkeleton = ({ animate, account, symbol }: AccountTopPanelSk
             account ? (
                 <AccountLabeling account={account} />
             ) : (
-                <SkeletonRectangle width="260px" height="28px" animate={animate} />
+                <SkeletonRectangle width="260px" height="34px" animate={animate} />
             )
         }
         navigation={<AccountNavigation />}
     >
-        <Stack margin="6px 0px 0px 0px" childMargin="0px 0px 8px 0px">
+        <Stack alignItems="center">
             {symbol ? <CoinLogo size={24} symbol={symbol} /> : <SkeletonCircle size="24px" />}
 
             <Balance noMargin>
-                <SkeletonRectangle width="160px" height="24px" animate={animate} />
+                <SkeletonRectangle width="160px" height="32px" animate={animate} />
             </Balance>
         </Stack>
     </AppNavigationPanel>


### PR DESCRIPTION
## Description

Skeleton for account name and balance had different margin/height/alignment than the elements they substitute. You can see the top bar move when you switch accounts during CoinJoin account discovery.

## Screenshots:
before:
![chrome-capture-2022-11-2 (2)](https://user-images.githubusercontent.com/42465546/205282616-a5644e9f-5bcc-438d-ab82-8e02423df405.gif)
after:
![chrome-capture-2022-11-2](https://user-images.githubusercontent.com/42465546/205283281-274bc04f-99c9-48d2-8760-e352e9d6368d.gif)



