### PR TITLE
Disable account navigation during discovery

### DIFF
--- a/packages/components/src/components/Dropdown/index.tsx
+++ b/packages/components/src/components/Dropdown/index.tsx
@@ -188,12 +188,12 @@ const IconRight = styled.div`
     }
 `;
 
-const MoreIcon = styled(Icon)`
+const MoreIcon = styled(Icon)<{ $isDisabled?: boolean }>`
     transition: background 0.1s;
     border-radius: 6px;
 
     :hover {
-        background: ${({ theme }) => theme.STROKE_GREY};
+        background: ${({ $isDisabled, theme }) => !$isDisabled && theme.STROKE_GREY};
     }
 `;
 
@@ -379,6 +379,7 @@ const Dropdown = forwardRef(
                 size={24}
                 icon="MORE"
                 color={!isDisabled ? theme.TYPE_DARK_GREY : theme.TYPE_LIGHT_GREY}
+                $isDisabled={isDisabled}
                 onClick={
                     !isDisabled
                         ? e => {

--- a/packages/suite/src/components/suite/AppNavigation.tsx
+++ b/packages/suite/src/components/suite/AppNavigation.tsx
@@ -131,7 +131,7 @@ const MenuElement = styled.div<{ isActive: boolean }>`
 const StyledNavLink = styled.div<{ isActive: boolean; isNavigationDisabled: boolean }>`
     padding: 9px 12px;
     cursor: ${({ isActive, isNavigationDisabled }) =>
-        isActive && isNavigationDisabled ? 'pointer' : 'default'};
+        isActive || isNavigationDisabled ? 'default' : 'pointer'};
     opacity: ${({ isActive, isNavigationDisabled }) => !isActive && isNavigationDisabled && '.5'};
 `;
 
@@ -168,10 +168,10 @@ const StyledDropdown = styled(Dropdown)<{ isDisabled: boolean }>`
     > :first-child {
         width: 100%;
         height: 100%;
-    }
 
-    :hover {
-        background: ${({ isDisabled, theme }) => !isDisabled && theme.BG_SECONDARY_HOVER};
+        :hover {
+            background: ${({ isDisabled, theme }) => !isDisabled && theme.BG_SECONDARY_HOVER};
+        }
     }
 `;
 
@@ -227,8 +227,8 @@ export const AppNavigation = ({ items, primaryContent, maxWidth, inView }: Props
     const secondary = useRef<HTMLDivElement>(null);
 
     const routeName = useSelector(state => state.router.route?.name);
-    const { screenWidth } = useSelector(state => state.resize);
-    const { selectedAccount } = useSelector(state => state.wallet);
+    const screenWidth = useSelector(state => state.resize.screenWidth);
+    const selectedAccount = useSelector(state => state.wallet.selectedAccount);
 
     const theme = useTheme();
 

--- a/packages/suite/src/components/suite/AppNavigationTooltip.tsx
+++ b/packages/suite/src/components/suite/AppNavigationTooltip.tsx
@@ -1,0 +1,29 @@
+import React from 'react';
+
+import { Translation } from '@suite-components';
+import { useSelector } from '@suite-hooks';
+import { Tooltip } from '@trezor/components';
+
+interface AppNavigationTooltipProps {
+    children: React.ReactNode;
+    isActiveTab?: boolean;
+}
+
+export const AppNavigationTooltip = ({ children, isActiveTab }: AppNavigationTooltipProps) => {
+    const { selectedAccount } = useSelector(state => state.wallet);
+
+    const isAccountLoading = selectedAccount.status === 'loading';
+
+    return (
+        <Tooltip
+            content={
+                isAccountLoading &&
+                !isActiveTab && <Translation id="TR_UNAVAILABLE_WHILE_LOADING" />
+            }
+            interactive={false}
+            cursor="default"
+        >
+            <>{children}</>
+        </Tooltip>
+    );
+};

--- a/packages/suite/src/components/suite/index.tsx
+++ b/packages/suite/src/components/suite/index.tsx
@@ -20,6 +20,7 @@ import TransactionsGraph from './TransactionsGraph';
 
 import DeviceInvalidModeLayout from './DeviceInvalidModeLayout';
 import { AppNavigationPanel } from './AppNavigationPanel';
+import { AppNavigationTooltip } from './AppNavigationTooltip';
 import { AppNavigation } from './AppNavigation';
 import Ticker from './Ticker';
 import { Translation } from './Translation';
@@ -81,6 +82,7 @@ export {
     QuestionTooltip,
     TransactionsGraph,
     AppNavigationPanel,
+    AppNavigationTooltip,
     AppNavigation,
     FormattedCryptoAmount,
     Ticker,

--- a/packages/suite/src/support/messages.ts
+++ b/packages/suite/src/support/messages.ts
@@ -7502,4 +7502,9 @@ export default defineMessages({
         id: 'TR_TIMER_PAST_DEADLINE',
         defaultMessage: 'Almost there...',
     },
+    TR_UNAVAILABLE_WHILE_LOADING: {
+        id: 'TR_UNAVAILABLE_WHILE_LOADING',
+        description: 'CoinJoin account navigation button tooltip during discovery',
+        defaultMessage: 'Unavailable while loading',
+    },
 });


### PR DESCRIPTION
## Description

0f1d904aafbe08a7a1bd6beb2f493b4c081c350a disables all buttons/links for account navigation in the top bar during account discovery. This is needed for CoinJoin account where discovery takes a long time.
4856982336d42a240337b36b52da2dad6b7dc73c is a small UI fix - I noticed the `:hover` style was not applied because the selector is on a wrong element.

## Related Issue

Resolve #6912 
## Screenshots:
Disabled buttons and tooltips during discovery:
![chrome-capture-2022-11-2 (3)](https://user-images.githubusercontent.com/42465546/205300353-4f464d7f-ee48-4517-8867-86602c942881.gif)
Hover background color on `itemsSecondaryWithExtra` before and after:
![Screenshot 2022-12-02 at 13 59 38](https://user-images.githubusercontent.com/42465546/205300567-f949c999-8567-429d-b6f5-7454ddb2cccd.png)
![Screenshot 2022-12-02 at 13 58 44](https://user-images.githubusercontent.com/42465546/205300590-0e80b7b0-4ddc-4656-9161-2eaabeffe4a6.png)

