### PR TITLE
Add loading transaction tooltip to coin control

### DIFF
--- a/packages/components/src/components/loaders/FluidSpinner.tsx
+++ b/packages/components/src/components/loaders/FluidSpinner.tsx
@@ -6,6 +6,7 @@ interface FluidSpinnerProps {
     size: number;
     strokeWidth?: number;
     color?: string;
+    className?: string;
 }
 
 const Wrapper = styled.div<FluidSpinnerProps>`
@@ -40,8 +41,8 @@ const Wrapper = styled.div<FluidSpinnerProps>`
     }
 `;
 
-export const FluidSpinner = ({ size, strokeWidth, color }: FluidSpinnerProps) => (
-    <Wrapper size={size} strokeWidth={strokeWidth} color={color}>
+export const FluidSpinner = ({ size, strokeWidth, color, className }: FluidSpinnerProps) => (
+    <Wrapper size={size} strokeWidth={strokeWidth} color={color} className={className}>
         <div />
         <div />
         <div />

--- a/packages/suite/src/components/wallet/CoinControl/UtxoSelection.tsx
+++ b/packages/suite/src/components/wallet/CoinControl/UtxoSelection.tsx
@@ -107,7 +107,7 @@ const TransactionDetail = styled.button`
     }
 `;
 
-const IconWrapper = styled.div`
+const StyledFluidSpinner = styled(FluidSpinner)`
     margin-right: 8px;
 `;
 
@@ -196,9 +196,7 @@ export const UtxoSelection = ({ isChecked, transaction, utxo }: UtxoSelectionPro
                     {transaction ? (
                         <TransactionTimestamp showDate transaction={transaction} />
                     ) : (
-                        <IconWrapper>
-                            <FluidSpinner color={theme.TYPE_LIGHT_GREY} size={14} />
-                        </IconWrapper>
+                        <StyledFluidSpinner color={theme.TYPE_LIGHT_GREY} size={14} />
                     )}
                     {anonymity && (
                         <>

--- a/packages/suite/src/components/wallet/CoinControl/UtxoSelection.tsx
+++ b/packages/suite/src/components/wallet/CoinControl/UtxoSelection.tsx
@@ -7,7 +7,7 @@ import * as modalActions from '@suite-actions/modalActions';
 import { FiatValue, FormattedCryptoAmount, MetadataLabeling, Translation } from '@suite-components';
 import { formatNetworkAmount, getUtxoOutpoint } from '@suite-common/wallet-utils';
 import { useActions, useSelector } from '@suite-hooks';
-import { useTheme, Checkbox, FluidSpinner, variables } from '@trezor/components';
+import { useTheme, Checkbox, FluidSpinner, Tooltip, variables } from '@trezor/components';
 import type { AccountUtxo } from '@trezor/connect';
 import { TransactionTimestamp, UtxoAnonymity } from '@wallet-components';
 import { UtxoTag } from '@wallet-components/CoinControl/UtxoTag';
@@ -196,7 +196,13 @@ export const UtxoSelection = ({ isChecked, transaction, utxo }: UtxoSelectionPro
                     {transaction ? (
                         <TransactionTimestamp showDate transaction={transaction} />
                     ) : (
-                        <StyledFluidSpinner color={theme.TYPE_LIGHT_GREY} size={14} />
+                        <Tooltip
+                            interactive={false}
+                            cursor="pointer"
+                            content={<Translation id="TR_LOADING_TRANSACTION_DETAILS" />}
+                        >
+                            <StyledFluidSpinner color={theme.TYPE_LIGHT_GREY} size={14} />
+                        </Tooltip>
                     )}
                     {anonymity && (
                         <>

--- a/packages/suite/src/support/messages.ts
+++ b/packages/suite/src/support/messages.ts
@@ -5606,6 +5606,11 @@ export default defineMessages({
         defaultMessage: 'There are no spendable UTXOs in your account.',
         description: 'Message showing in Coin control section',
     },
+    TR_LOADING_TRANSACTION_DETAILS: {
+        id: 'TR_LOADING_TRANSACTION_DETAILS',
+        defaultMessage: 'Loading transaction details',
+        description: 'Tooltip over a spinner icon in Coin control section',
+    },
     TR_REGISTERED_FOR_COINJOIN: {
         id: 'TR_REGISTERED_FOR_COINJOIN',
         defaultMessage: 'Registered in CoinJoin',


### PR DESCRIPTION
## Description

5e88e50bd058758e80d4b2f12c2389dd205c1d5d: as suggested by @prusnak, adding a tooltip to the spinner which is displayed in coin control `UtxoSelection` until transaction data is fetched and `TransactionTimestamp` can be displayed.
9dfd283683833a3ffcfb7cb6d7ea9d24bab50629: adds `className` prop to `FluidSpinner`; this just makes it easier to style `FluidSpinner` and prevents small bugs like in `CoinJoinStatus` where it is used as a styled component but the styles are not applied.

## Screenshots:
tooltip
![Screenshot 2022-12-02 at 14 50 35](https://user-images.githubusercontent.com/42465546/205328670-cef4af86-b0bb-4e77-9177-441977a2afc6.png)
`CoinJoinStatus` loader before (without opacity applied):
![Screenshot 2022-12-02 at 16 24 51](https://user-images.githubusercontent.com/42465546/205329036-f24fd2c3-080b-48c9-8e51-b8fdc1f64b79.png)
after:
![Screenshot 2022-12-02 at 16 24 24](https://user-images.githubusercontent.com/42465546/205329030-b44ebd3f-ba65-431f-9406-8ddf9cf47fbb.png)

**QA:** The loading state in coin control may be hard to replicate manually. It can be done more easily on an account with many UTXOs and long transaction history, but I wouldn't bother too much.
