### PR TITLE
feat(tor): stop automatic replacement of clearnet links by onion links

### DIFF
--- a/packages/connect/src/api/setProxy.ts
+++ b/packages/connect/src/api/setProxy.ts
@@ -11,16 +11,14 @@ export default class SetProxy extends AbstractMethod<'setProxy'> {
         this.useDevice = false;
         this.useUi = false;
 
-        validateParams(this.payload, [{ name: 'useOnionLinks', type: 'boolean' }]);
+        validateParams(this.payload, []);
     }
 
     async run() {
-        const { proxy, useOnionLinks } = DataManager.getSettings();
-        const isChanged =
-            proxy !== this.payload.proxy || useOnionLinks !== this.payload.useOnionLinks;
+        const { proxy } = DataManager.getSettings();
+        const isChanged = proxy !== this.payload.proxy;
         if (isChanged) {
             DataManager.settings.proxy = this.payload.proxy;
-            DataManager.settings.useOnionLinks = this.payload.useOnionLinks;
             await reconnectAllBackends();
         }
 

--- a/packages/connect/src/backend/BackendManager.ts
+++ b/packages/connect/src/backend/BackendManager.ts
@@ -1,4 +1,3 @@
-import { config } from '../data/config';
 import { DataManager } from '../data/DataManager';
 import { ERRORS } from '../constants';
 import { Blockchain, BlockchainOptions } from './Blockchain';
@@ -31,10 +30,6 @@ export class BackendManager {
                 postMessage,
                 debug: DataManager.getSettings('debug'),
                 proxy: DataManager.getSettings('proxy'),
-                onionDomains:
-                    DataManager.getSettings('useOnionLinks') && !this.custom[coinInfo.shortcut]
-                        ? config.onionDomains
-                        : undefined,
                 onConnected: url => this.setPreferred(coinInfo.shortcut, url),
                 onDisconnected: () => this.remove(coinInfo.shortcut),
             });

--- a/packages/connect/src/events/blockchain.ts
+++ b/packages/connect/src/events/blockchain.ts
@@ -13,7 +13,6 @@ export const BLOCKCHAIN = {
 
 export interface BlockchainInfo extends ServerInfo {
     coin: CoinInfo;
-    cleanUrl?: string;
     misc?: {
         reserve?: string;
     };

--- a/packages/connect/src/types/api/__tests__/misc.ts
+++ b/packages/connect/src/types/api/__tests__/misc.ts
@@ -81,9 +81,8 @@ export const setProxy = async (api: TrezorConnect) => {
             username: 'johndoe',
             timeout: 100000,
         },
-        useOnionLinks: true,
     });
-    api.setProxy({ proxy: 'socks://localhost:9050', useOnionLinks: true });
+    api.setProxy({ proxy: 'socks://localhost:9050' });
     api.setProxy({ proxy: undefined });
 
     // @ts-expect-error

--- a/packages/connect/src/types/api/setProxy.ts
+++ b/packages/connect/src/types/api/setProxy.ts
@@ -8,7 +8,6 @@ import type { Proxy } from '../settings';
 
 export type SetProxy = {
     proxy: Proxy;
-    useOnionLinks?: boolean;
 };
 
 export declare function setProxy(params: CommonParams & SetProxy): Response<PROTO.Success>;

--- a/packages/connect/src/types/settings.ts
+++ b/packages/connect/src/types/settings.ts
@@ -33,5 +33,4 @@ export interface ConnectSettings {
     env: 'node' | 'web' | 'webextension' | 'electron' | 'react-native';
     timestamp: number;
     proxy?: Proxy;
-    useOnionLinks?: boolean;
 }

--- a/packages/suite-desktop/src/modules/tor.ts
+++ b/packages/suite-desktop/src/modules/tor.ts
@@ -46,12 +46,7 @@ const load = async ({ mainWindow, store }: Dependencies) => {
     };
 
     const getProxySettings = (shouldEnableTor: boolean) =>
-        shouldEnableTor
-            ? {
-                  proxy: `socks://${address}`,
-                  useOnionLinks: true,
-              }
-            : { proxy: '', useOnionLinks: false };
+        shouldEnableTor ? { proxy: `socks://${address}` } : { proxy: '' };
 
     const setupTor = async (settings: TorSettings) => {
         const shouldEnableTor = settings.running;

--- a/packages/suite-desktop/src/modules/trezor-connect.ts
+++ b/packages/suite-desktop/src/modules/trezor-connect.ts
@@ -14,12 +14,7 @@ export const init: Module = ({ store }) => {
     const setProxy = (ifRunning = false) => {
         const tor = store.getTorSettings();
         if (ifRunning && !tor.running) return Promise.resolve();
-        const payload = tor.running
-            ? {
-                  proxy: `socks://${tor.address}`,
-                  useOnionLinks: true,
-              }
-            : { proxy: '', useOnionLinks: false };
+        const payload = tor.running ? { proxy: `socks://${tor.address}` } : { proxy: '' };
         logger.info(SERVICE_NAME, `${tor.running ? 'Enable' : 'Disable'} proxy ${payload.proxy}`);
         return TrezorConnect.setProxy(payload);
     };

--- a/packages/suite/src/actions/suite/suiteActions.ts
+++ b/packages/suite/src/actions/suite/suiteActions.ts
@@ -4,7 +4,7 @@ import { desktopApi, HandshakeElectron } from '@trezor/suite-desktop-api';
 
 import * as comparisonUtils from '@suite-utils/comparisonUtils';
 import * as deviceUtils from '@suite-utils/device';
-import { baseFetch, getIsTorLoading, isOnionUrl, torFetch } from '@suite-utils/tor';
+import { getIsTorLoading, isOnionUrl } from '@suite-utils/tor';
 import { getCustomBackends } from '@suite-common/wallet-utils';
 import { sortByTimestamp } from '@suite-utils/device';
 import { notificationsActions } from '@suite-common/toast-notifications';
@@ -184,8 +184,6 @@ export const toggleTor =
         const ipcResponse = await desktopApi.toggleTor(shouldEnable);
 
         if (ipcResponse.success) {
-            window.fetch = shouldEnable ? torFetch : baseFetch;
-
             const newStatus = shouldEnable ? TorStatus.Enabled : TorStatus.Disabled;
 
             dispatch(updateTorStatus(newStatus));

--- a/packages/suite/src/components/suite/modals/AdvancedCoinSettings/components/CustomBackends.tsx
+++ b/packages/suite/src/components/suite/modals/AdvancedCoinSettings/components/CustomBackends.tsx
@@ -6,7 +6,6 @@ import InputError from '@wallet-components/InputError';
 import { useSelector, useActions } from '@suite-hooks';
 import { toggleTor as toggleTorAction } from '@suite-actions/suiteActions';
 import { useDefaultUrls, useBackendsForm } from '@settings-hooks/backends';
-import { toTorUrl } from '@suite-utils/tor';
 import ConnectionInfo from './ConnectionInfo';
 import { BackendInput } from './BackendInput';
 import { BackendTypeSelect } from './BackendTypeSelect';
@@ -139,17 +138,14 @@ export const CustomBackends = ({ network, onCancel }: CustomBackendsProps) => {
 
                 <BackendTypeSelect network={network} value={type} onChange={changeType} />
 
-                {(editable ? urls : defaultUrls).map(u => {
-                    const url = isTorEnabled && !editable ? toTorUrl(u) : u;
-                    return (
-                        <BackendInput
-                            key={url}
-                            url={url}
-                            active={url === blockchain[coin]?.url}
-                            onRemove={editable ? () => removeUrl(u) : undefined}
-                        />
-                    );
-                })}
+                {(editable ? urls : defaultUrls).map(url => (
+                    <BackendInput
+                        key={url}
+                        url={url}
+                        active={url === blockchain[coin]?.url}
+                        onRemove={editable ? () => removeUrl(url) : undefined}
+                    />
+                ))}
 
                 {editable && (
                     <Input

--- a/packages/suite/src/support/suite/useTor.tsx
+++ b/packages/suite/src/support/suite/useTor.tsx
@@ -1,23 +1,16 @@
 import { useEffect } from 'react';
 import { desktopApi } from '@trezor/suite-desktop-api';
-import { useActions, useSelector } from '@suite-hooks';
-import { baseFetch, getIsTorDomain, torFetch } from '@suite-utils/tor';
+import { useActions } from '@suite-hooks';
+import { getIsTorDomain } from '@suite-utils/tor';
 import * as suiteActions from '@suite-actions/suiteActions';
 import { isWeb, isDesktop } from '@suite-utils/env';
 import { getLocationHostname } from '@trezor/env-utils';
 import { TorStatus } from '@suite-types';
-import { selectTorState } from '@suite-reducers/suiteReducer';
 
 export const useTor = () => {
-    const { isTorEnabled } = useSelector(selectTorState);
-
     const { updateTorStatus } = useActions({
         updateTorStatus: suiteActions.updateTorStatus,
     });
-
-    useEffect(() => {
-        window.fetch = isTorEnabled ? torFetch : baseFetch;
-    }, [isTorEnabled]);
 
     useEffect(() => {
         if (isWeb()) {

--- a/packages/suite/src/utils/suite/__tests__/tor.test.ts
+++ b/packages/suite/src/utils/suite/__tests__/tor.test.ts
@@ -1,5 +1,5 @@
 import { TOR_URLS } from '@trezor/urls';
-import { getTorUrlIfAvailable, getIsTorDomain, isOnionUrl, toTorUrl } from '@suite-utils/tor';
+import { getTorUrlIfAvailable, getIsTorDomain, isOnionUrl } from '@suite-utils/tor';
 
 describe('tor', () => {
     beforeAll(() => {
@@ -99,27 +99,6 @@ describe('tor', () => {
         fixtures.forEach(f => {
             it(f.desc, () => {
                 expect(isOnionUrl(f.in)).toEqual(f.out);
-            });
-        });
-    });
-
-    describe('toTorUrl', () => {
-        const fixtures = [
-            {
-                desc: 'returns tor url',
-                in: 'https://trezor.io',
-                out: `http://${TOR_URLS['trezor.io']}`,
-            },
-            {
-                desc: 'returns original url',
-                in: 'https://google.com',
-                out: 'https://google.com',
-            },
-        ];
-
-        fixtures.forEach(f => {
-            it(f.desc, () => {
-                expect(toTorUrl(f.in)).toEqual(f.out);
             });
         });
     });

--- a/packages/suite/src/utils/suite/tor.ts
+++ b/packages/suite/src/utils/suite/tor.ts
@@ -22,30 +22,11 @@ export const getTorUrlIfAvailable = (url: string) => {
     return `http://${subdomain ?? ''}${onionDomain}${rest ?? ''}`;
 };
 
-export const toTorUrl = (url: string) => {
-    const torUrl = getTorUrlIfAvailable(url);
-    if (!torUrl) {
-        console.warn(`tor url is not available for ${url}`);
-        return url;
-    }
-    return torUrl;
-};
-
 export const getIsTorDomain = (domain: string) => domain.endsWith('.onion');
 
 export const isOnionUrl = (url: string) => {
     const hostname = parseHostname(url);
     return !!hostname && getIsTorDomain(hostname);
-};
-
-export const baseFetch = window.fetch;
-
-export const torFetch = (input: RequestInfo | URL, init?: RequestInit | undefined) => {
-    if (typeof input === 'string') {
-        input = toTorUrl(input);
-    }
-
-    return baseFetch(input, init);
 };
 
 export const getIsTorEnabled = (torStatus: TorStatus) => {


### PR DESCRIPTION
## Description **(UPDATED)**

<strike>This is just kickoff so far</strike>, replacement of explorer links and backend links has to be removed from Connect.

In the current state of the Tor network, it's more stable to use clearnet via Tor. For the user, the privacy is the same and trezor.io servers don't need to be hidden.

https://github.com/trezor/trezor-suite/pull/7117/commits/c5a22e6824c9bcd54b68b8423426da9f9846712c + https://github.com/trezor/trezor-suite/pull/7117/commits/48ced953082bb67830d8077031c0e54203fbad36 + https://github.com/trezor/trezor-suite/pull/7117/commits/d55c2191639f6ae945f05f258238bd17eae677d7 - clearnet addresses shouldn't be translated to onion addresses in web and electron anymore
https://github.com/trezor/trezor-suite/pull/7117/commits/aced76b4adece1bf1dbe42c6cb1f437eb20edd4b - `useOnionLinks` is never sent to `TrezorConnect.setProxy`, therefore clearnet backend addresses should never be translated
https://github.com/trezor/trezor-suite/pull/7117/commits/71c964ae950efd067923d5c1c27d0a4ed5aadbb2 - **OPTIONAL** - aggressive removal of `useOnionLinks` and clearnet/onion translation functionality from `@trezor/connect`

## QA

Please apart of obvious features test **[especially that even the clearnet backends are accessed over Tor when it's turned on](https://github.com/trezor/trezor-suite/issues/7076#issuecomment-1331959614)**. I hope it shouldn't be affected by these changes but there's no such thing as being too paranoid.

## Related Issue

Resolve https://github.com/trezor/trezor-suite/issues/7076

Should also resolve https://github.com/trezor/trezor-suite/issues/4508
