### PR TITLE
fix(connect): release before reloading

### DIFF
--- a/packages/connect/src/device/DeviceList.ts
+++ b/packages/connect/src/device/DeviceList.ts
@@ -281,15 +281,16 @@ export class DeviceList extends EventEmitter {
         if (this.stream) {
             this.stream.stop();
         }
-        if (this.transport) {
-            this.transport.stop();
-        }
-        if (this.fetchController) {
-            this.fetchController.abort();
-            this.fetchController = null;
-        }
-
         this.allDevices().forEach(device => device.dispose());
+        setTimeout(() => {
+            if (this.transport) {
+                this.transport.stop();
+            }
+            if (this.fetchController) {
+                this.fetchController.abort();
+                this.fetchController = null;
+            }
+        }, 1);
     }
 
     disconnectDevices() {


### PR DESCRIPTION
BEFORE
1. connect device with passprhase
2. wait for passphrase dialog to appear
3. reload window
4. see "unacquired device screen"

AFTER:

1. connect device with passprhase
2. wait for passphrase dialog to appear
3. reload window
4. all good, no unacquired device

Why
- when we know suite is about to reload (window unload event), we want to release all devices that have a session. this code was already there but it was run in wrong order. this little change should fix it. 

I found this while doing #6509 

maybe @trezor/qa test it a bit before merging. low priority. no stress. 
- testing url: https://suite.corp.sldev.cz/suite-web/connect-reload-release/web/
- focus on bridge transport. but please also try webusb
- make sure you don't have any other suites running 