### PR TITLE
Add link to bitcoin-only article

### DIFF
--- a/packages/suite/src/views/settings/device/FirmwareTypeChange.tsx
+++ b/packages/suite/src/views/settings/device/FirmwareTypeChange.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
-import styled, { useTheme } from 'styled-components';
+import styled from 'styled-components';
 
-import { Translation } from '@suite-components';
+import { Translation, TrezorLink } from '@suite-components';
 import { ActionButton, ActionColumn, SectionItem, TextColumn } from '@suite-components/Settings';
 import { useDevice, useActions } from '@suite-hooks';
 import * as routerActions from '@suite-actions/routerActions';
@@ -9,6 +9,7 @@ import { Button } from '@trezor/components';
 import { useAnchor } from '@suite-hooks/useAnchor';
 import { SettingsAnchor } from '@suite-constants/anchors';
 import { getFirmwareType, getFirmwareVersion } from '@trezor/device-utils';
+import { HELP_FIRMWARE_TYPE } from '@trezor/urls';
 
 const Version = styled.div`
     span {
@@ -31,7 +32,6 @@ export const FirmwareTypeChange = ({ isDeviceLocked }: FirmwareTypeProps) => {
         goto: routerActions.goto,
     });
 
-    const theme = useTheme();
     const { anchorRef, shouldHighlight } = useAnchor(SettingsAnchor.FirmwareType);
 
     if (!device?.features) {
@@ -64,15 +64,15 @@ export const FirmwareTypeChange = ({ isDeviceLocked }: FirmwareTypeProps) => {
                                 id="TR_YOUR_FIRMWARE_TYPE"
                                 values={{
                                     version: (
-                                        <Button
-                                            variant="tertiary"
-                                            // icon={revision ? 'EXTERNAL_LINK' : undefined}
-                                            // alignIcon="right"
-                                            color={theme.TYPE_DARK_GREY} // TODO: remove when an article is added
-                                            disabled // TODO: this should link to an article in knowledge base or guide in the future
-                                        >
-                                            {currentFwType}
-                                        </Button>
+                                        <TrezorLink href={HELP_FIRMWARE_TYPE} variant="nostyle">
+                                            <Button
+                                                variant="tertiary"
+                                                icon="EXTERNAL_LINK"
+                                                alignIcon="right"
+                                            >
+                                                {currentFwType}
+                                            </Button>
+                                        </TrezorLink>
                                     ),
                                 }}
                             />

--- a/packages/urls/src/urls.ts
+++ b/packages/urls/src/urls.ts
@@ -53,6 +53,7 @@ export const HELP_CENTER_FAILED_BACKUP_URL = 'https://trezor.io/support/a/trezor
 export const HELP_CENTER_ADVANCED_RECOVERY_URL =
     'https://trezor.io/learn/a/advanced-recovery-on-trezor-model-one';
 export const HELP_CENTER_XPUB_URL = 'https://trezor.io/learn/a/trezor-suite-app-public-keys-xpub';
+export const HELP_FIRMWARE_TYPE = 'https://trezor.io/learn/a/bitcoin-only-firmware-on-trezor';
 
 export const SOCIAL_TWITTER_URL = 'https://twitter.com/trezor';
 export const SOCIAL_FACEBOOK_URL = 'https://www.facebook.com/trezor.io';


### PR DESCRIPTION
## Description

Adds a link to an [article](https://trezor.io/learn/a/bitcoin-only-firmware-on-trezor) from settings. The button was originally disabled and not wrapped in `TrezorLink` because the article hasn't been published by the time the firmware type switch was added.

## Screenshots:

![Screenshot 2022-12-05 at 15 11 03](https://user-images.githubusercontent.com/42465546/205658917-fd030072-321b-4ffb-801c-d68926baff1c.png)

**QA:** Nothing besides the link.