### PR TITLE
test(e2e): keep bridge version when calling setupEmu

### DIFF
--- a/packages/trezor-user-env-link/src/api.ts
+++ b/packages/trezor-user-env-link/src/api.ts
@@ -35,6 +35,10 @@ interface ReadAndConfirmShamirMnemonicEmu {
     threshold: number;
 }
 
+// remember which version was bridge last started with and reuse it on other places where
+// bridge is started and stopped implicitly (setupEmu)
+let bridgeVersion: string | undefined;
+
 export const api = (controller: any) => ({
     setupEmu: async (options: SetupEmu) => {
         const defaults = {
@@ -56,7 +60,7 @@ export const api = (controller: any) => ({
             ...defaults,
             ...options,
         });
-        await controller.send({ type: 'bridge-start' });
+        await controller.send({ type: 'bridge-start', version: bridgeVersion });
         return null;
     },
     sendToAddressAndMineBlock: async (options: SendToAddressAndMineBlock) => {
@@ -74,6 +78,7 @@ export const api = (controller: any) => ({
         return null;
     },
     startBridge: async (version?: string) => {
+        bridgeVersion = version;
         await controller.send({ type: 'bridge-start', version });
         return null;
     },


### PR DESCRIPTION
minor fix for e2e tests. calling trezorUserEnvLink.api.startEmu effectivelly restarted bridge with the latest version. If you wanted to use another bridge version in your test, this was making your life harder. 

might be related to https://github.com/trezor/trezor-suite/issues/7119 (might solve the "bridge restarting" problem)

imho safu to merge, failing due to https://github.com/trezor/trezor-suite/issues/7131