### PR TITLE
Fix: catch tor errors in coinjoin coordinator requests

### DIFF
--- a/packages/request-manager/src/interceptor.ts
+++ b/packages/request-manager/src/interceptor.ts
@@ -27,7 +27,8 @@ const getIdentityName = (proxyAuthorization?: http.OutgoingHttpHeader) => {
     return undefined;
 };
 
-const getAgent = (identityName?: string) => TorIdentities.getIdentity(identityName || 'default');
+const getAgent = (identityName?: string, timeout?: number) =>
+    TorIdentities.getIdentity(identityName || 'default', timeout);
 
 const getAuthorizationOptions = (options: http.RequestOptions) => {
     // Use Proxy-Authorization header to define proxy identity
@@ -37,7 +38,7 @@ const getAuthorizationOptions = (options: http.RequestOptions) => {
         // In the case that `Proxy-Authorization` was used for identity information we remove it.
         delete options.headers['Proxy-Authorization'];
         // Create proxy agent for the request
-        options.agent = getAgent(identityName);
+        options.agent = getAgent(identityName, options.timeout);
     }
     return options;
 };
@@ -129,7 +130,7 @@ const overloadHttpRequest = (
 
         // add default proxy agent
         if (isTorEnabled && !overloadedOptions.agent) {
-            overloadedOptions.agent = getAgent();
+            overloadedOptions.agent = getAgent('default', overloadedOptions.timeout);
         }
 
         interceptorOptions.handler({

--- a/packages/request-manager/src/torIdentities.ts
+++ b/packages/request-manager/src/torIdentities.ts
@@ -12,7 +12,7 @@ export class TorIdentities {
         this.getIdentity('default');
     }
 
-    public static getIdentity(identity: string): SocksProxyAgent {
+    public static getIdentity(identity: string, timeout?: number): SocksProxyAgent {
         if (!this.torController) {
             throw new Error('TorIdentities is not initialized');
         }
@@ -31,6 +31,7 @@ export class TorIdentities {
                 port: this.torController.options.port,
                 userId: user,
                 password: password || user,
+                timeout,
             });
         }
 


### PR DESCRIPTION
## Description

- Catch specific errors from tor (socks5 lib) switch circuit and retry 
> I believe this should be done in @trezor/request-manager since those errors are related to TOR/Socks5

- Pass http request timeout to SocksProxyAgent
> otherwise one request is using two different timeouts, one in fetch one in agent

### Follow up #7151