### PR TITLE
fix(coinmarket): add missing translation keys to DCA nad P2P

### DIFF
--- a/packages/suite/src/support/messages.ts
+++ b/packages/suite/src/support/messages.ts
@@ -1082,7 +1082,7 @@ export default defineMessages({
     },
     TR_P2P_RECEIVING_ADDRESS_STEP: {
         defaultMessage: 'Receiving address',
-        id: 'TR_P2P_CONFIRM_SEND_STEP',
+        id: 'TR_P2P_RECEIVING_ADDRESS_STEP',
     },
     TR_P2P_GET_STARTED_INTRO: {
         defaultMessage:
@@ -1186,9 +1186,33 @@ export default defineMessages({
         defaultMessage: 'Frequency',
         id: 'TR_SAVINGS_SETUP_PAYMENT_FREQUENCY_LABEL',
     },
+    TR_SAVINGS_SETUP_PAYMENT_FREQUENCY_DAILY: {
+        defaultMessage: 'Daily',
+        id: 'TR_SAVINGS_SETUP_PAYMENT_FREQUENCY_DAILY',
+    },
+    TR_SAVINGS_SETUP_PAYMENT_FREQUENCY_WEEKLY: {
+        defaultMessage: 'Weekly',
+        id: 'TR_SAVINGS_SETUP_PAYMENT_FREQUENCY_WEEKLY',
+    },
+    TR_SAVINGS_SETUP_PAYMENT_FREQUENCY_BIWEEKLY: {
+        defaultMessage: 'Biweekly',
+        id: 'TR_SAVINGS_SETUP_PAYMENT_FREQUENCY_BIWEEKLY',
+    },
+    TR_SAVINGS_SETUP_PAYMENT_FREQUENCY_MONTHLY: {
+        defaultMessage: 'Monthly',
+        id: 'TR_SAVINGS_SETUP_PAYMENT_FREQUENCY_MONTHLY',
+    },
+    TR_SAVINGS_SETUP_PAYMENT_FREQUENCY_QUARTERLY: {
+        defaultMessage: 'Quarterly',
+        id: 'TR_SAVINGS_SETUP_PAYMENT_FREQUENCY_QUARTERLY',
+    },
     TR_SAVINGS_SETUP_FIAT_AMOUNT_LABEL: {
         defaultMessage: 'Amount',
         id: 'TR_SAVINGS_SETUP_FIAT_AMOUNT_LABEL',
+    },
+    TR_SAVINGS_SETUP_FIAT_AMOUNT_CUSTOM: {
+        defaultMessage: 'Custom',
+        id: 'TR_SAVINGS_SETUP_FIAT_AMOUNT_CUSTOM',
     },
     TR_SAVINGS_SETUP_RECEIVING_ADDRESS: {
         defaultMessage: 'Receiving address',

--- a/packages/suite/src/types/wallet/coinmarketCommonTypes.ts
+++ b/packages/suite/src/types/wallet/coinmarketCommonTypes.ts
@@ -31,3 +31,5 @@ export type Option = { value: string; label: string };
 export type CountryOption = { value: FlagProps['country']; label: string };
 export type DefaultCountryOption = { value: string; label?: string };
 export type TranslationOption = { value: string; label?: ReactElement };
+
+export type PaymentFrequencyOption = Option & { label: JSX.Element };

--- a/packages/suite/src/types/wallet/coinmarketSavingsSetup.ts
+++ b/packages/suite/src/types/wallet/coinmarketSavingsSetup.ts
@@ -2,7 +2,7 @@ import type { PaymentFrequency } from 'invity-api';
 import type { WithSelectedAccountLoadedProps } from '@wallet-components';
 import type { TypedValidationRules } from '@wallet-types/form';
 import type { UseFormMethods } from 'react-hook-form';
-import type { CountryOption, Option } from '@wallet-types/coinmarketCommonTypes';
+import type { CountryOption, PaymentFrequencyOption } from '@wallet-types/coinmarketCommonTypes';
 import type { Account } from '@wallet-types';
 
 export type UseSavingsSetupProps = WithSelectedAccountLoadedProps;
@@ -26,7 +26,7 @@ export type SavingsSetupContextValues = Omit<UseFormMethods<SavingsSetupFormStat
     account: Account;
     canConfirmSetup: boolean;
     isSubmitting: boolean;
-    paymentFrequencyOptions: Option[];
+    paymentFrequencyOptions: PaymentFrequencyOption[];
     paymentAmounts: string[];
     minimumPaymentAmountLimit?: number;
     maximumPaymentAmountLimit?: number;
@@ -38,3 +38,10 @@ export type SavingsSetupContextValues = Omit<UseFormMethods<SavingsSetupFormStat
     userCountry?: string;
     defaultCountryOption?: CountryOption;
 };
+
+export type PaymentFrequencyTranslationId =
+    | 'TR_SAVINGS_SETUP_PAYMENT_FREQUENCY_DAILY'
+    | 'TR_SAVINGS_SETUP_PAYMENT_FREQUENCY_WEEKLY'
+    | 'TR_SAVINGS_SETUP_PAYMENT_FREQUENCY_BIWEEKLY'
+    | 'TR_SAVINGS_SETUP_PAYMENT_FREQUENCY_MONTHLY'
+    | 'TR_SAVINGS_SETUP_PAYMENT_FREQUENCY_QUARTERLY';

--- a/packages/suite/src/utils/wallet/coinmarket/__tests__/savingsUtils.test.ts
+++ b/packages/suite/src/utils/wallet/coinmarket/__tests__/savingsUtils.test.ts
@@ -1,3 +1,4 @@
+import { Translation } from '@suite-components/Translation';
 import { CustomPaymentAmountKey } from '@wallet-constants/coinmarket/savings';
 import {
     calculateAnnualSavings,
@@ -74,11 +75,26 @@ describe('coinmarket/savings utils', () => {
                 setupPaymentFrequencies: ['Daily', 'Weekly', 'Biweekly', 'Monthly', 'Quarterly'],
             }),
         ).toStrictEqual([
-            { label: 'Daily', value: 'Daily' },
-            { label: 'Weekly', value: 'Weekly' },
-            { label: 'Biweekly', value: 'Biweekly' },
-            { label: 'Monthly', value: 'Monthly' },
-            { label: 'Quarterly', value: 'Quarterly' },
+            {
+                label: Translation({ id: 'TR_SAVINGS_SETUP_PAYMENT_FREQUENCY_DAILY' }),
+                value: 'Daily',
+            },
+            {
+                label: Translation({ id: 'TR_SAVINGS_SETUP_PAYMENT_FREQUENCY_WEEKLY' }),
+                value: 'Weekly',
+            },
+            {
+                label: Translation({ id: 'TR_SAVINGS_SETUP_PAYMENT_FREQUENCY_BIWEEKLY' }),
+                value: 'Biweekly',
+            },
+            {
+                label: Translation({ id: 'TR_SAVINGS_SETUP_PAYMENT_FREQUENCY_MONTHLY' }),
+                value: 'Monthly',
+            },
+            {
+                label: Translation({ id: 'TR_SAVINGS_SETUP_PAYMENT_FREQUENCY_QUARTERLY' }),
+                value: 'Quarterly',
+            },
         ]);
     });
 });

--- a/packages/suite/src/utils/wallet/coinmarket/savingsUtils.ts
+++ b/packages/suite/src/utils/wallet/coinmarket/savingsUtils.ts
@@ -5,9 +5,11 @@ import {
 } from '@wallet-constants/coinmarket/savings';
 import type { CurrentFiatRates } from '@wallet-types/fiatRates';
 import BigNumber from 'bignumber.js';
-import type { Option } from '@wallet-types/coinmarketCommonTypes';
+import type { PaymentFrequencyOption } from '@wallet-types/coinmarketCommonTypes';
 import { isDesktop } from '@suite-utils/env';
 import { desktopApi } from '@trezor/suite-desktop-api';
+import { Translation } from '@suite-components/Translation';
+import type { PaymentFrequencyTranslationId } from '@wallet-types/coinmarketSavingsSetup';
 
 export const getStatusMessage = (status: SavingsTradeItemStatus) => {
     switch (status) {
@@ -71,13 +73,20 @@ export const calculateAnnualSavings = (
     };
 };
 
+const paymentFrequencyTranslationsIds: Record<PaymentFrequency, PaymentFrequencyTranslationId> = {
+    Daily: 'TR_SAVINGS_SETUP_PAYMENT_FREQUENCY_DAILY',
+    Biweekly: 'TR_SAVINGS_SETUP_PAYMENT_FREQUENCY_BIWEEKLY',
+    Weekly: 'TR_SAVINGS_SETUP_PAYMENT_FREQUENCY_WEEKLY',
+    Monthly: 'TR_SAVINGS_SETUP_PAYMENT_FREQUENCY_MONTHLY',
+    Quarterly: 'TR_SAVINGS_SETUP_PAYMENT_FREQUENCY_QUARTERLY',
+};
 export const getPaymentFrequencyOptions = (selectedProvider?: SavingsProviderInfo) =>
     selectedProvider?.setupPaymentFrequencies.map(
         paymentFrequency =>
             ({
-                label: paymentFrequency,
+                label: Translation({ id: paymentFrequencyTranslationsIds[paymentFrequency] }),
                 value: paymentFrequency,
-            } as Option),
+            } as PaymentFrequencyOption),
     ) ?? [];
 
 export const createReturnLink = async () => {

--- a/packages/suite/src/views/wallet/coinmarket/savings/setup/components/FiatAmount/index.tsx
+++ b/packages/suite/src/views/wallet/coinmarket/savings/setup/components/FiatAmount/index.tsx
@@ -68,7 +68,7 @@ const FiatAmount = ({
                         maximumFractionDigits={0}
                     />
                 ) : (
-                    amount
+                    <Translation id="TR_SAVINGS_SETUP_FIAT_AMOUNT_CUSTOM" />
                 ),
                 value: amount,
             })),


### PR DESCRIPTION

## Description
Create new savings frequency translations and custom amount translation. Fix p2p already existing translation id.

## Related Issue

#7051 
