### PR TITLE
Few more rounds needed when CoinJoin ends

### DIFF
--- a/packages/suite/src/actions/suite/modalActions.ts
+++ b/packages/suite/src/actions/suite/modalActions.ts
@@ -152,6 +152,9 @@ export type UserContextPayload =
     | {
           type: 'coinjoin-success';
           relatedAccountKey: string;
+      }
+    | {
+          type: 'more-rounds-needed';
       };
 
 export type ModalAction =

--- a/packages/suite/src/actions/wallet/coinjoinClientActions.ts
+++ b/packages/suite/src/actions/wallet/coinjoinClientActions.ts
@@ -8,12 +8,14 @@ import {
 } from '@trezor/coinjoin';
 import { arrayDistinct } from '@trezor/utils';
 import * as COINJOIN from './constants/coinjoinConstants';
-import { prepareCoinjoinTransaction } from '@wallet-utils/coinjoinUtils';
+import { breakdownCoinjoinBalance, prepareCoinjoinTransaction } from '@wallet-utils/coinjoinUtils';
 import { CoinjoinClientService } from '@suite/services/coinjoin/coinjoinClient';
 import { Dispatch, GetState } from '@suite-types';
 import { Account, CoinjoinServerEnvironment, RoundPhase } from '@suite-common/wallet-types';
 import { onCancel as closeModal, openModal } from '@suite-actions/modalActions';
 import { notificationsActions } from '@suite-common/toast-notifications';
+import { selectAccountByKey } from '@suite-common/wallet-core';
+import { isZero } from '@suite-common/wallet-utils';
 
 const clientEnable = (symbol: Account['symbol']) =>
     ({
@@ -179,7 +181,8 @@ export const setBusyScreen =
 export const onCoinjoinRoundChanged =
     ({ round }: CoinjoinRoundEvent) =>
     (dispatch: Dispatch, getState: GetState) => {
-        const { accounts } = getState().wallet.coinjoin;
+        const state = getState();
+        const { accounts } = state.wallet.coinjoin;
         // collect all account.keys from the round including failed one
         const accountKeys = round.inputs
             .concat(round.failed)
@@ -202,15 +205,13 @@ export const onCoinjoinRoundChanged =
         // round event is triggered multiple times. like at the beginning and at the end of round process
         // critical actions should be triggered only once
         if (phaseChanged) {
-            const relatedAccountKey = coinjoinAccountsWithSession[0].key; // since all accounts share the round, any key can be used
-
             if (round.phase === RoundPhase.ConnectionConfirmation) {
                 dispatch(setBusyScreen(accountKeys, round.roundDeadline - Date.now()));
 
                 dispatch(
                     openModal({
                         type: 'critical-coinjoin-phase',
-                        relatedAccountKey,
+                        relatedAccountKey: coinjoinAccountsWithSession[0].key, // since all accounts share the round, any key can be used,
                     }),
                 );
             }
@@ -224,11 +225,27 @@ export const onCoinjoinRoundChanged =
                 );
 
                 if (completedSessions.length > 0) {
+                    const moreRoundsNeeded = completedSessions.some(({ key, targetAnonymity }) => {
+                        const account = selectAccountByKey(state, key);
+
+                        const { notAnonymized } = breakdownCoinjoinBalance({
+                            anonymitySet: account?.addresses?.anonymitySet,
+                            targetAnonymity,
+                            utxos: account?.utxo,
+                        });
+
+                        return !isZero(notAnonymized);
+                    });
+
                     dispatch(
-                        openModal({
-                            type: 'coinjoin-success',
-                            relatedAccountKey,
-                        }),
+                        openModal(
+                            moreRoundsNeeded
+                                ? { type: 'more-rounds-needed' }
+                                : {
+                                      type: 'coinjoin-success',
+                                      relatedAccountKey: completedSessions[0].key,
+                                  },
+                        ),
                     );
                     completedSessions.forEach(({ key }) => {
                         dispatch(clientSessionCompleted(key));

--- a/packages/suite/src/components/suite/ModalSwitcher/UserContextModal.tsx
+++ b/packages/suite/src/components/suite/ModalSwitcher/UserContextModal.tsx
@@ -33,6 +33,7 @@ import {
     CancelCoinjoin,
     CriticalCoinjoinPhase,
     CoinjoinSuccess,
+    MoreRoundsNeeded,
 } from '@suite-components/modals';
 
 import type { AcquiredDevice } from '@suite-types';
@@ -162,6 +163,8 @@ export const UserContextModal = ({
             return <CriticalCoinjoinPhase relatedAccountKey={payload.relatedAccountKey} />;
         case 'coinjoin-success':
             return <CoinjoinSuccess relatedAccountKey={payload.relatedAccountKey} />;
+        case 'more-rounds-needed':
+            return <MoreRoundsNeeded />;
 
         default:
             return null;

--- a/packages/suite/src/components/suite/modals/CancelCoinjoin.tsx
+++ b/packages/suite/src/components/suite/modals/CancelCoinjoin.tsx
@@ -8,7 +8,7 @@ import { useDispatch } from 'react-redux';
 import { stopCoinjoinSession } from '@wallet-actions/coinjoinAccountActions';
 
 const StyledModal = styled(Modal)`
-    width: 430px;
+    width: 435px;
 `;
 
 const StyledButton = styled(Button)`

--- a/packages/suite/src/components/suite/modals/CoinjoinSuccess.tsx
+++ b/packages/suite/src/components/suite/modals/CoinjoinSuccess.tsx
@@ -1,6 +1,8 @@
 import React from 'react';
 import styled from 'styled-components';
 import { useDispatch } from 'react-redux';
+import { transparentize } from 'polished';
+
 import { Button, Icon, useTheme, variables } from '@trezor/components';
 import { selectAccountByKey } from '@suite-common/wallet-core';
 import { WalletParams } from '@suite-common/wallet-types';
@@ -11,7 +13,7 @@ import { onCancel as closeModal } from '@suite-actions/modalActions';
 import { Modal, Translation } from '..';
 
 const StyledModal = styled(Modal)`
-    width: 430px;
+    width: 435px;
 `;
 
 const StyledButton = styled(Button)`
@@ -23,7 +25,7 @@ const StyledIcon = styled(Icon)`
     height: 84px;
     margin: 12px auto 32px;
     border-radius: 50%;
-    background: ${({ theme }) => theme.BG_GREY};
+    background: ${({ theme }) => transparentize(0.9, theme.BG_GREEN)};
 `;
 
 const Heading = styled.h3`
@@ -32,6 +34,11 @@ const Heading = styled.h3`
     line-height: 32px;
     font-weight: ${variables.FONT_WEIGHT.MEDIUM};
     color: ${({ theme }) => theme.TYPE_GREEN};
+`;
+
+const Text = styled.p`
+    color: ${({ theme }) => theme.TYPE_LIGHT_GREY};
+    font-weight: ${variables.FONT_WEIGHT.MEDIUM};
 `;
 
 interface CoinjoinSuccessProps {
@@ -51,6 +58,7 @@ export const CoinjoinSuccess = ({ relatedAccountKey }: CoinjoinSuccessProps) => 
 
     const { symbol, index, accountType } = relatedAccount;
 
+    const close = () => dispatch(closeModal());
     const navigateToRelatedAccount = () => {
         dispatch(closeModal());
         dispatch(
@@ -77,7 +85,7 @@ export const CoinjoinSuccess = ({ relatedAccountKey }: CoinjoinSuccessProps) => 
         <StyledModal
             bottomBar={
                 <>
-                    <StyledButton variant="secondary" onClick={() => dispatch(closeModal())}>
+                    <StyledButton variant="secondary" onClick={close}>
                         <Translation id="TR_DISMISS" />
                     </StyledButton>
                     {!isOnAccountPage && (
@@ -93,6 +101,9 @@ export const CoinjoinSuccess = ({ relatedAccountKey }: CoinjoinSuccessProps) => 
             <Heading>
                 <Translation id="TR_COINJOIN_COMPLETED" />
             </Heading>
+            <Text>
+                <Translation id="TR_COINJOIN_COMPLETED_DESCRIPTION" />
+            </Text>
         </StyledModal>
     );
 };

--- a/packages/suite/src/components/suite/modals/MoreRoundsNeeded.tsx
+++ b/packages/suite/src/components/suite/modals/MoreRoundsNeeded.tsx
@@ -1,0 +1,62 @@
+import React from 'react';
+import styled from 'styled-components';
+import { useDispatch } from 'react-redux';
+import { Button, Icon, useTheme, variables } from '@trezor/components';
+import { onCancel as closeModal } from '@suite-actions/modalActions';
+import { Modal, Translation } from '..';
+
+const StyledModal = styled(Modal)`
+    width: 435px;
+`;
+
+const StyledButton = styled(Button)`
+    flex: 1;
+`;
+
+const StyledIcon = styled(Icon)`
+    width: 84px;
+    height: 84px;
+    margin: 12px auto 32px;
+    border-radius: 50%;
+    background: ${({ theme }) => theme.BG_GREY};
+`;
+
+const Text = styled.p`
+    color: ${({ theme }) => theme.TYPE_LIGHT_GREY};
+    font-weight: ${variables.FONT_WEIGHT.MEDIUM};
+`;
+
+const Heading = styled.h3`
+    font-size: 32px;
+    font-weight: ${variables.FONT_WEIGHT.MEDIUM};
+    line-height: 32px;
+    margin: 10px 0 22px 0;
+`;
+
+export const MoreRoundsNeeded = () => {
+    const theme = useTheme();
+    const dispatch = useDispatch();
+
+    const close = () => dispatch(closeModal());
+
+    return (
+        <StyledModal
+            bottomBar={
+                <StyledButton variant="secondary" onClick={close}>
+                    <Translation id="TR_OK" />
+                </StyledButton>
+            }
+        >
+            <StyledIcon icon="CONFETTI_SUCCESS" size={32} color={theme.TYPE_DARK_GREY} />
+            <Text>
+                <Translation id="TR_COINJOIN_ENDED" />
+            </Text>
+            <Heading>
+                <Translation id="TR_MORE_ROUNDS_NEEDED" />
+            </Heading>
+            <Text>
+                <Translation id="TR_MORE_ROUNDS_NEEDED_DESCRIPTION" />
+            </Text>
+        </StyledModal>
+    );
+};

--- a/packages/suite/src/components/suite/modals/index.tsx
+++ b/packages/suite/src/components/suite/modals/index.tsx
@@ -38,3 +38,4 @@ export { TorLoading } from './TorLoading';
 export { CancelCoinjoin } from './CancelCoinjoin';
 export { CriticalCoinjoinPhase } from './CriticalCoinjoinPhase';
 export { CoinjoinSuccess } from './CoinjoinSuccess';
+export { MoreRoundsNeeded } from './MoreRoundsNeeded';

--- a/packages/suite/src/support/messages.ts
+++ b/packages/suite/src/support/messages.ts
@@ -7367,6 +7367,31 @@ export default defineMessages({
         id: 'TR_COINJOIN_COMPLETED',
         defaultMessage: 'Coinjoin successfully completed!',
     },
+    TR_COINJOIN_COMPLETED_DESCRIPTION: {
+        id: 'TR_COINJOIN_COMPLETED_DESCRIPTION',
+        defaultMessage: 'All your funds were successfully coinjoined',
+    },
+    TR_COINJOIN_ENDED: {
+        id: 'TR_COINJOIN_ENDED',
+        description: 'Modal subheading when coinjoin ends',
+        defaultMessage: 'Coinjoin ended',
+    },
+    TR_MORE_ROUNDS_NEEDED: {
+        id: 'TR_MORE_ROUNDS_NEEDED',
+        description: 'Modal heading when coinjoin ends',
+        defaultMessage: 'Few more rounds needed',
+    },
+    TR_MORE_ROUNDS_NEEDED_DESCRIPTION: {
+        id: 'TR_MORE_ROUNDS_NEEDED_DESCRIPTION',
+        description: 'Modal description when coinjoin ends',
+        defaultMessage:
+            'We were not able to bring you desired anonymity within reserved rounds. Please run another CoinJoin. You will not pay any service fee twice.',
+    },
+    TR_OK: {
+        id: 'TR_OK',
+        description: 'Button text',
+        defaultMessage: 'OK',
+    },
     TR_COINJOIN_ANONYMITY_LEVEL_SETUP_TITLE: {
         id: 'TR_COINJOIN_ANONYMITY_LEVEL_SETUP_TITLE',
         defaultMessage: 'Desired anonymity level',


### PR DESCRIPTION
## Description

- When CoinJoin ends and there are still some non-private funds, an appropriate modal is shown.
- Success modal is still shown when all funds are private, I just added some text.


What is different from design:
- It does not show the amount that was mixed because it is hard to calculate (there can be transactions happening during mixing).
- Secondary buttons are green, not grey - this will change later with a global redesign.

## Related Issue

Resolve #7001 

## Screenshots:
![Screenshot 2022-12-06 at 14 07 52](https://user-images.githubusercontent.com/42465546/205932259-7572233e-376b-4400-92e1-56ceee83c80b.png)

![Screenshot 2022-12-06 at 14 08 47](https://user-images.githubusercontent.com/42465546/205932223-65049162-35a6-4f87-a613-5dddd57e645b.png)
