### PR TITLE
Metadata fixes and docs update

### DIFF
--- a/docs/features/metadata.md
+++ b/docs/features/metadata.md
@@ -1,7 +1,9 @@
 # Metadata (labeling)
 
-Metadata is a feature which allows the user to associate persistent data with their accounts, transactions, addresses or even hidden wallets.
+Metadata is a feature that allows the user to associate persistent data with their wallets, accounts, receive addresses, and outputs.
 Trezor Suite refers to metadata as to "labeling" in the user interface.
+
+For non-technical introduction, see [Trezor Learn](https://trezor.io/learn/a/labels-in-trezor-suite-app).
 
 ## Data stores
 
@@ -11,9 +13,9 @@ Because Trezor Suite is not a typical application with a backend server, data mu
 -   Google Drive
 -   Local file system (desktop only)
 
-Planned to be supported in the future:
+### Google Drive specifics
 
--   SD card
+Google Drive authentication has differing implementations for desktop and web version of Suite. For security reasons, Google does not allow the _authorization code flow_ for web apps, thus only allowing the user of web Suite to log in via the _implicit flow_ with an access token lasting for lasts one hour. _Authorization code flow_ used in the desktop app leverages a refresh token to enable the user to stay logged in permanently while using desktop Suite. To implement this flow, we had to establish an authorization backend holding a `client_secret`, see [@trezor/auth-server](https://github.com/trezor/trezor-suite/tree/develop/packages/auth-server).
 
 ## Data structure in store
 
@@ -47,7 +49,7 @@ account metadata example
 
 ### version 2.0.0 (future)
 
-Each record will have timestamp which will allow user to resolve potential conflicts
+Each record will have timestamp which will allow user to resolve potential conflicts. (Implementation not currently planned.)
 
 ## Data encryption
 
@@ -115,6 +117,19 @@ Account has metadata property which is an object of following shape:
   accountLabel: string
 }
 ```
+
+## Where metadata can be set
+
+-   Wallet label is set in the modal where wallet is selected.
+-   Account label is set in account header.
+-   Receiving address label is set in the receive address list.
+-   Output label is set in send form address field, coin control or transaction history
+
+Note that transaction history displays output label and address next to each other. Receive address is replaced by its label if it is defined. If output label is not set, only an address (or its label) is displayed in transaction history.
+
+Wallet and account labels can also be displayed in other places in Suite as read-only, i.e. in send form when sending to an address belonging to another discovered wallet or account.
+
+Device name set in device settings is not part of metadata.
 
 ## User stories
 

--- a/packages/suite/src/components/suite/Labeling/components/Metadata/MetadataLabeling.tsx
+++ b/packages/suite/src/components/suite/Labeling/components/Metadata/MetadataLabeling.tsx
@@ -46,8 +46,8 @@ const LabelButton = styled(Button)`
     overflow: hidden;
 `;
 
-const ActionButton = styled(Button)<{ isVisible?: boolean }>`
-    margin-left: ${({ isVisible }) => !isVisible && '14px'};
+const ActionButton = styled(Button)<{ isValueVisible?: boolean; isVisible?: boolean }>`
+    margin-left: ${({ isValueVisible, isVisible }) => (isValueVisible || !isVisible) && '12px'};
     visibility: ${({ isVisible }) => (isVisible ? 'visible' : 'hidden')};
     /* hack to keep button in place to prevent vertical jumping (if used display: none) */
     width: ${({ isVisible }) => (isVisible ? 'auto' : '0')};
@@ -343,6 +343,7 @@ export const MetadataLabeling = (props: Props) => {
                             isLoading={actionButtonsDisabled}
                             isDisabled={actionButtonsDisabled}
                             isVisible={isVisible}
+                            isValueVisible={!!props.payload.value}
                             onClick={e => {
                                 e.stopPropagation();
                                 // by clicking on add label button, metadata.editing field is set

--- a/packages/suite/src/components/wallet/CoinControl/UtxoSelection.tsx
+++ b/packages/suite/src/components/wallet/CoinControl/UtxoSelection.tsx
@@ -131,6 +131,10 @@ export const UtxoSelection = ({ isChecked, transaction, utxo }: UtxoSelectionPro
     const coordinatorData = useSelector(state => state.wallet.coinjoin.clients[account.symbol]);
     const device = useSelector(state => state.suite.device);
     const coinjoinAccount = useSelector(state => selectCoinjoinAccountByKey(state, account.key));
+    // selecting metadata from store rather than send form context which does not update on metadata change
+    const outputLabels = useSelector(
+        state => state.wallet.selectedAccount.account?.metadata.outputLabels,
+    );
     const { openModal } = useActions({
         openModal: modalActions.openModal,
     });
@@ -153,7 +157,7 @@ export const UtxoSelection = ({ isChecked, transaction, utxo }: UtxoSelectionPro
     const isPendingTransaction = utxo.confirmations === 0;
     const isChangeAddress = utxo.path.split('/').at(-2) === '1'; // change address always has a 1 on the penultimate level of the derivation path
     const amountInBtc = (Number(utxo.amount) / 10 ** network.decimals).toString();
-    const outputLabel = account.metadata.outputLabels?.[utxo.txid]?.[utxo.vout];
+    const outputLabel = outputLabels?.[utxo.txid]?.[utxo.vout];
     const isLabelingPossible = device?.metadata.status === 'enabled' || device?.connected;
     const anonymity = account.addresses?.anonymitySet?.[utxo.address];
 


### PR DESCRIPTION
## Description

c6a76c65c0b5f9ec3e6215a0c19adb4688a19d4b adds missing margin to the *Add label* button (see below, the two buttons are right next to each other when loading)
236aa88c7f9a9fcd243fa62cc396b533acf7f1b7 fixes label in coin control not updating immediately (see below, I have to close the form and reopen it for the change to propagate)
b1d0c493fa65e2bb905ee13657b377a1bb90f7e3 updates metadata docs

## Screenshots:
before:
![chrome-capture-2022-11-6 (1)](https://user-images.githubusercontent.com/42465546/206018700-0e8b06b4-78f2-44f4-958d-848145bd9f94.gif)

after:
![chrome-capture-2022-11-6](https://user-images.githubusercontent.com/42465546/206018642-5696d7f7-d569-4440-a1ad-c036119e8d29.gif)

