### PR TITLE
chore(gitlab): prolongue expiration period for codesign desktop builds

### DIFF
--- a/ci/build.yml
+++ b/ci/build.yml
@@ -138,7 +138,7 @@ suite-desktop build mac codesign:
     paths:
       - ${artifact}
       - latest*.yml
-    expire_in: 7 days
+    expire_in: 30 days
 
 ## Suite desktop Linux app
 suite-desktop build linux:
@@ -177,7 +177,7 @@ suite-desktop build linux codesign:
     paths:
       - ${artifact}
       - latest*.yml
-    expire_in: 7 days
+    expire_in: 30 days
 
 ## Suite desktop Windows app
 suite-desktop build windows:
@@ -219,7 +219,7 @@ suite-desktop build windows codesign:
     paths:
       - ${artifact}
       - latest*.yml
-    expire_in: 7 days
+    expire_in: 30 days
 
 .connect-explorer build base:
   stage: build


### PR DESCRIPTION


<!--- Provide a general summary of your changes in the Title above -->

## Description

- From time to time we need older builds for testing (especially auto-update). At least 2 weaks to have builds available from freeze till release in regular case, 30 days are with a reserve.
<!--- Describe your changes in detail -->

