### PR TITLE
fix(message-syste): fix fetching of remote message system config

### DIFF
--- a/packages/suite/src/actions/suite/messageSystemActions.ts
+++ b/packages/suite/src/actions/suite/messageSystemActions.ts
@@ -49,16 +49,22 @@ const fetchConfig = () => async (dispatch: Dispatch, getState: GetState) => {
             let isRemote = true;
 
             try {
-                const response = await scheduleAction(
-                    signal => fetch(MESSAGE_SYSTEM.CONFIG_URL_REMOTE, { signal }),
+                await scheduleAction(
+                    async signal => {
+                        const response = await fetch(MESSAGE_SYSTEM.CONFIG_URL_REMOTE, { signal });
+
+                        if (!response.ok) {
+                            throw Error(response.statusText);
+                        }
+
+                        jwsResponse = await response.text();
+                    },
                     { timeout: MESSAGE_SYSTEM.FETCH_TIMEOUT },
                 );
 
-                if (!response.ok) {
-                    throw Error(response.statusText);
+                if (!jwsResponse) {
+                    throw Error('Parsing of response failed');
                 }
-
-                jwsResponse = await response.text();
             } catch (error) {
                 console.error(`Fetching of remote JWS config failed: ${error}`);
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

- It has been always aborted by scheduleAction util even if the request suceeded.

Parsing of the response has to be inside scheduleAction callback too, because the request is always aborted in `finalize` block of scheduleAction so otherwise parsing of the response fail even if the request passed.

## Screenshots:
![image](https://user-images.githubusercontent.com/3729633/206215968-0a6039ec-a0b0-44bc-89cb-60aefd8ef2b3.png)

