### PR TITLE
No retroactive abort in scheduleAction utils

### DIFF
--- a/packages/utils/tests/scheduleAction.test.ts
+++ b/packages/utils/tests/scheduleAction.test.ts
@@ -137,4 +137,15 @@ describe('scheduleAction', () => {
 
         expect(spy).toBeCalledTimes(2);
     });
+
+    it("don't abort after success", async () => {
+        let signal: AbortSignal | undefined;
+        const action = (sig?: AbortSignal) => {
+            signal = sig;
+            return Promise.resolve(true);
+        };
+        const result = await scheduleAction(action, {});
+        expect(result).toBe(true);
+        expect(signal?.aborted).toBe(false);
+    });
 });


### PR DESCRIPTION
## Description

`action` passed to `scheduleAction` could've been aborted after it was successfully resolved (as it shared the clear abort signal). It should be fixed now.