### PR TITLE
Fix change address reuse in pending transactions

### DIFF
--- a/suite-common/wallet-core/src/accounts/accountsActions.ts
+++ b/suite-common/wallet-core/src/accounts/accountsActions.ts
@@ -74,11 +74,7 @@ const createAccount = createAction(
                 discoveryItem.coin,
             ),
             tokens: enhanceTokens(accountInfo.tokens),
-            addresses: enhanceAddresses(
-                accountInfo.addresses,
-                discoveryItem.networkType,
-                discoveryItem.index,
-            ),
+            addresses: enhanceAddresses(accountInfo, discoveryItem),
             utxo: enhanceUtxo(accountInfo.utxo, discoveryItem.networkType, discoveryItem.index),
             history: accountInfo.history,
             metadata: {
@@ -113,11 +109,7 @@ const updateAccount = createAction(
                         account.symbol,
                     ),
                     utxo: enhanceUtxo(accountInfo.utxo, account.networkType, account.index),
-                    addresses: enhanceAddresses(
-                        accountInfo.addresses,
-                        account.networkType,
-                        account.index,
-                    ),
+                    addresses: enhanceAddresses(accountInfo, account),
                     tokens: enhanceTokens(accountInfo.tokens),
                     ...getAccountSpecific(accountInfo, account.networkType),
                 },


### PR DESCRIPTION
## Description

Only takes into account pending txs. No prepending txs support yet.

## Related Issue

Could resolve #6381
Could resolve #6894