### PR TITLE
test(request-manager): manually test Tor identities

### DIFF
--- a/packages/request-manager/e2e/identities-stress.ts
+++ b/packages/request-manager/e2e/identities-stress.ts
@@ -1,0 +1,95 @@
+import path from 'path';
+import fetch, { Response } from 'node-fetch';
+import { createInterceptor, TorController, TorIdentities } from '../src';
+import { torRunner } from './torRunner';
+
+// The purpose of this script is to allow "manual" testing Tor identities changing some parameters.
+// Run it like:
+// yarn workspace @trezor/request-manager test:stress
+// While running this you can run the command below to check that everything is going throw Tor
+// watch -n 1 "lsof -i TCP | grep node"
+
+const host = 'localhost';
+const port = 38835;
+const controlPort = 35527;
+const processId = process.pid;
+const torDataDir = path.join(__dirname, 'tmp');
+const ipRegex = /\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3}/;
+
+const INTERCEPTOR = {
+    handler: () => {},
+    getIsTorEnabled: () => true,
+};
+
+const testGetUrlHttps = 'https://check.torproject.org/';
+
+const amountOfIdentities = 20;
+const intervalBetweenRequests = 1000 * 20;
+
+(async () => {
+    // Callback in in createInterceptor should return true in order for the request to use Tor.
+    createInterceptor(INTERCEPTOR);
+
+    console.log('Starting Tor.');
+    // Starting Tor controller to make sure that Tor is running.
+    const torController = new TorController({
+        host,
+        port,
+        controlPort,
+        torDataDir,
+    });
+    const torParams = torController.getTorConfiguration(processId);
+    // Starting Tor process from binary.
+    torRunner({
+        torParams,
+    });
+
+    TorIdentities.init(torController);
+    // Waiting for Tor to be ready to accept successful connections.
+    await torController.waitUntilAlive();
+    console.log('Tor is ready to be used.');
+
+    // Create identities
+    const identities: string[] = [];
+    for (let identity = 0; identity < amountOfIdentities; identity++) {
+        console.log('identity', identity);
+        identities.push(`Basic ${identity}`);
+    }
+
+    const makeRequests = async (identities: any) => {
+        const promises: Promise<Response>[] = identities.map((identity: string) => {
+            console.log('identity', identity);
+            return fetch(testGetUrlHttps, {
+                headers: { 'Proxy-Authorization': identity },
+            });
+        });
+
+        // Call the identities request
+        const responseIdentities = await Promise.all(promises);
+        // Parse requests
+        const requests = responseIdentities.map(async response => {
+            const text: any = await response.text();
+            const ip = text.match(ipRegex)[0];
+            return {
+                ip,
+            };
+        });
+        return Promise.all(requests);
+    };
+
+    try {
+        const ips = await makeRequests(identities);
+        console.log('ips', ips);
+    } catch (error) {
+        console.error(error);
+    }
+
+    setInterval(async () => {
+        try {
+            const ips = await makeRequests(identities);
+            console.log('ips', ips);
+        } catch (error) {
+            console.error(error);
+        }
+    }, intervalBetweenRequests);
+})();

--- a/packages/request-manager/package.json
+++ b/packages/request-manager/package.json
@@ -13,7 +13,8 @@
         "lint:js": "yarn g:eslint '**/*.{ts,tsx,js}'",
         "test:e2e": "jest --runInBand -c ../../jest.config.base.js",
         "type-check": "tsc --build tsconfig.json",
-        "build:lib": "rimraf ./lib && yarn tsc --build tsconfig.lib.json"
+        "build:lib": "rimraf ./lib && yarn tsc --build tsconfig.lib.json",
+        "test:stress": "ts-node  -O '{\"module\": \"commonjs\"}' ./e2e/identities-stress.ts"
     },
     "dependencies": {
         "@trezor/utils": "workspace:*",
@@ -23,6 +24,7 @@
     "devDependencies": {
         "jest": "^26.6.3",
         "rimraf": "^3.0.2",
+        "ts-node": "^10.9.1",
         "typescript": "4.9.3"
     }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -7245,6 +7245,7 @@ __metadata:
     jest: ^26.6.3
     rimraf: ^3.0.2
     socks-proxy-agent: 6.1.1
+    ts-node: ^10.9.1
     typescript: 4.9.3
   languageName: unknown
   linkType: soft


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
I created this script to allow testing Tor identities by trying to stress them in a similar way that CoinJoin is doing. Many identities each sending a request during a period of time.

The testing is being done for 3 different interval requests of 1, 20 and 35 minutes, during a period of time of 2  hours. 
The were 0 errors during testing process. 
For interval requests of 1 minute the identities where keeping the same IP which probably means it was same circuit, instead for interval requests of 35 minutes the IPs of the same identity (username and password) where changing which makes sense since the lasting time of the circuits by configuration is 30 minutes.

I do not really think that testing this way makes much sense to find issues that would lead to improvements. But the script to test Tor manually has become already useful for me in other features so I can run Tor and do some quick tests, so  I think it is nice to have it as a testing script.

<!--- Describe your changes in detail -->

## Related Issue

Resolve https://github.com/trezor/trezor-suite/issues/6838

