### PR TITLE
feat: handle madclicking in coinjoin UI

### DIFF
--- a/suite-common/connect-init/src/connectInitThunks.ts
+++ b/suite-common/connect-init/src/connectInitThunks.ts
@@ -62,6 +62,9 @@ export const connectInitThunk = createThunk(
             'backupDevice',
             'recoveryDevice',
             'checkFirmwareAuthenticity',
+            'authorizeCoinJoin',
+            'getOwnershipProof',
+            'setBusy',
         ] as const;
 
         wrappedMethods.forEach(key => {


### PR DESCRIPTION
disallow multiple clicks on "Anonymize" button (TrezorConnect.authorizeCoinJoin) to prevent "device call in progress errors". 

do  you guys have any ideas where this might need to be fixed too? 

resolve  #6748
