### PR TITLE
Add 'out-of-sync' state for CoinJoin account

### DIFF
--- a/packages/suite/src/components/wallet/AccountAnnouncement/AccountOutOfSync.tsx
+++ b/packages/suite/src/components/wallet/AccountAnnouncement/AccountOutOfSync.tsx
@@ -1,0 +1,10 @@
+import React from 'react';
+import { NotificationCard, Translation } from '@suite-components';
+
+const AccountOutOfSync = () => (
+    <NotificationCard variant="warning">
+        <Translation id="TR_ACCOUNT_OUT_OF_SYNC" />
+    </NotificationCard>
+);
+
+export default AccountOutOfSync;

--- a/packages/suite/src/components/wallet/AccountAnnouncement/index.tsx
+++ b/packages/suite/src/components/wallet/AccountAnnouncement/index.tsx
@@ -5,6 +5,7 @@ import { Account } from '@wallet-types/index';
 
 import XRPReserve from './XRPReserve';
 import AccountImported from './AccountImported';
+import AccountOutOfSync from './AccountOutOfSync';
 
 const AnnouncementsWrapper = styled.div`
     display: flex;
@@ -34,6 +35,10 @@ export const AccountAnnouncement = ({ account }: AccountAnnouncementProps) => {
 
     if (account.imported) {
         notifications.push(<AccountImported key="imported" />);
+    }
+
+    if (account.backendType === 'coinjoin' && account.status === 'out-of-sync') {
+        notifications.push(<AccountOutOfSync key="out-of-sync" />);
     }
 
     if (notifications.length === 0) {

--- a/packages/suite/src/components/wallet/WalletLayout/components/CoinjoinAccountDiscoveryProgress/index.tsx
+++ b/packages/suite/src/components/wallet/WalletLayout/components/CoinjoinAccountDiscoveryProgress/index.tsx
@@ -1,7 +1,6 @@
 import React from 'react';
 import styled, { useTheme } from 'styled-components';
 import { H3, Icon, variables } from '@trezor/components';
-import { CoinjoinSummaryHeader } from '@wallet-components';
 import { Card, Translation } from '@suite-components';
 import { AccountLoadingProgress } from './AccountLoadingProgress';
 import { RotatingFacts } from './RotatingFacts';
@@ -11,6 +10,7 @@ const Container = styled(Card)`
     align-items: center;
     padding-top: 36px;
     padding-bottom: 36px;
+    margin-bottom: 24px;
 `;
 
 const FactHeading = styled.div`
@@ -31,23 +31,19 @@ export const CoinjoinAccountDiscoveryProgress = () => {
     const theme = useTheme();
 
     return (
-        <>
-            <CoinjoinSummaryHeader />
+        <Container>
+            <H3>
+                <Translation id="TR_LOADING_FUNDS" />
+            </H3>
 
-            <Container>
-                <H3>
-                    <Translation id="TR_LOADING_FUNDS" />
-                </H3>
+            <AccountLoadingProgress />
 
-                <AccountLoadingProgress />
+            <FactHeading>
+                <SparksIcon icon="EXPERIMENTAL" size={13} color={theme.TYPE_ORANGE} />
+                <Translation id="TR_COINJOIN_FACT_TITLE" />
+            </FactHeading>
 
-                <FactHeading>
-                    <SparksIcon icon="EXPERIMENTAL" size={13} color={theme.TYPE_ORANGE} />
-                    <Translation id="TR_COINJOIN_FACT_TITLE" />
-                </FactHeading>
-
-                <RotatingFacts />
-            </Container>
-        </>
+            <RotatingFacts />
+        </Container>
     );
 };

--- a/packages/suite/src/support/extraDependencies.ts
+++ b/packages/suite/src/support/extraDependencies.ts
@@ -73,7 +73,12 @@ export const extraDependencies: ExtraDependencies = {
                 state.transactions[k][item.order] = item.tx;
             });
         },
-        storageLoadAccounts: (_, { payload }: StorageLoadAction) => payload.accounts,
+        storageLoadAccounts: (_, { payload }: StorageLoadAction) =>
+            payload.accounts.map(acc =>
+                acc.backendType === 'coinjoin' && acc.status === 'ready'
+                    ? { ...acc, status: 'out-of-sync' }
+                    : acc,
+            ),
         storageLoadFiatRates: (state: FiatRatesState, { payload }: StorageLoadAction) => {
             state.coins = payload.fiatRates;
         },

--- a/packages/suite/src/support/messages.ts
+++ b/packages/suite/src/support/messages.ts
@@ -77,6 +77,10 @@ export default defineMessages({
         defaultMessage: 'Account does not exist',
         id: 'TR_ACCOUNT_EXCEPTION_NOT_EXIST',
     },
+    TR_ACCOUNT_OUT_OF_SYNC: {
+        defaultMessage: 'Account is possibly out-of-sync',
+        id: 'TR_ACCOUNT_OUT_OF_SYNC',
+    },
     TR_ACCOUNT_IMPORTED_ANNOUNCEMENT: {
         defaultMessage:
             'A watch-only account is a public address you’ve imported into your wallet, allowing the wallet to watch for outputs but not spend them.',

--- a/packages/suite/src/views/wallet/transactions/components/CoinjoinAccountEmpty.tsx
+++ b/packages/suite/src/views/wallet/transactions/components/CoinjoinAccountEmpty.tsx
@@ -7,6 +7,7 @@ import { Account } from '@wallet-types';
 import { Button, Card, H2, Image, P, variables } from '@trezor/components';
 import { Translation } from '@suite-components/Translation';
 import { goto } from '@suite-actions/routerActions';
+import { CoinjoinSummaryHeader } from '@wallet-components/index';
 
 const Container = styled(Card)`
     align-items: center;
@@ -39,32 +40,35 @@ export const CoinjoinAccountEmpty = ({ account }: CoinjoinAccountEmptyProps) => 
     const dispatch = useDispatch();
 
     return (
-        <Container>
-            <Image image="COINJOIN_MESS" width={300} />
+        <>
+            <CoinjoinSummaryHeader />
+            <Container>
+                <Image image="COINJOIN_MESS" width={300} />
 
-            <Heading>
-                <Translation id="TR_COINJOIN_ACCESS_ACCOUNT_STEP_INITIAL_TITLE" />
-            </Heading>
+                <Heading>
+                    <Translation id="TR_COINJOIN_ACCESS_ACCOUNT_STEP_INITIAL_TITLE" />
+                </Heading>
 
-            <AccountDescription>
-                <Translation id="TR_COINJOIN_ACCESS_ACCOUNT_STEP_INITIAL_DESCRIPTION" />
-            </AccountDescription>
+                <AccountDescription>
+                    <Translation id="TR_COINJOIN_ACCESS_ACCOUNT_STEP_INITIAL_DESCRIPTION" />
+                </AccountDescription>
 
-            {coordinatorData && (
-                <FeeText>
+                {coordinatorData && (
+                    <FeeText>
+                        <Translation
+                            id="TR_COINJOIN_ACCESS_ACCOUNT_STEP_INITIAL_FEE_MESSAGE"
+                            values={{ fee: coordinatorData.coordinationFeeRate.rate * 100 }}
+                        />
+                    </FeeText>
+                )}
+
+                <Button onClick={() => dispatch(goto('wallet-receive', { preserveParams: true }))}>
                     <Translation
-                        id="TR_COINJOIN_ACCESS_ACCOUNT_STEP_INITIAL_FEE_MESSAGE"
-                        values={{ fee: coordinatorData.coordinationFeeRate.rate * 100 }}
+                        id="TR_RECEIVE_NETWORK"
+                        values={{ network: account.symbol.toUpperCase() }}
                     />
-                </FeeText>
-            )}
-
-            <Button onClick={() => dispatch(goto('wallet-receive', { preserveParams: true }))}>
-                <Translation
-                    id="TR_RECEIVE_NETWORK"
-                    values={{ network: account.symbol.toUpperCase() }}
-                />
-            </Button>
-        </Container>
+                </Button>
+            </Container>
+        </>
     );
 };

--- a/packages/suite/src/views/wallet/transactions/index.tsx
+++ b/packages/suite/src/views/wallet/transactions/index.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { WalletLayout, CoinjoinSummaryHeader } from '@wallet-components';
+import { WalletLayout } from '@wallet-components';
 import { getAccountTransactions } from '@suite-common/wallet-utils';
 import { useSelector } from '@suite-hooks';
 import { AppState } from '@suite-types';
@@ -11,6 +11,7 @@ import { AccountEmpty } from './components/AccountEmpty';
 import { CoinjoinAccountEmpty } from './components/CoinjoinAccountEmpty';
 import { TransactionList } from './components/TransactionList';
 import { TransactionSummary } from './components/TransactionSummary';
+import { CoinjoinAccountDiscoveryProgress } from '@wallet-components/WalletLayout/components/CoinjoinAccountDiscoveryProgress';
 
 interface LayoutProps {
     selectedAccount: AppState['wallet']['selectedAccount'];
@@ -18,19 +19,15 @@ interface LayoutProps {
     showEmptyHeaderPlaceholder?: boolean;
 }
 
-const Layout = ({ selectedAccount, showEmptyHeaderPlaceholder = false, children }: LayoutProps) => {
-    if (selectedAccount.status !== 'loaded') return null;
-
-    return (
-        <WalletLayout
-            title="TR_NAV_TRANSACTIONS"
-            account={selectedAccount}
-            showEmptyHeaderPlaceholder={showEmptyHeaderPlaceholder}
-        >
-            {children}
-        </WalletLayout>
-    );
-};
+const Layout = ({ selectedAccount, showEmptyHeaderPlaceholder = false, children }: LayoutProps) => (
+    <WalletLayout
+        title="TR_NAV_TRANSACTIONS"
+        account={selectedAccount}
+        showEmptyHeaderPlaceholder={showEmptyHeaderPlaceholder}
+    >
+        {children}
+    </WalletLayout>
+);
 
 const Transactions = () => {
     const transactionsIsLoading = useSelector(selectIsLoadingTransactions);
@@ -40,22 +37,41 @@ const Transactions = () => {
     }));
 
     if (selectedAccount.status !== 'loaded') {
-        return <WalletLayout title="TR_NAV_TRANSACTIONS" account={selectedAccount} />;
+        return <Layout selectedAccount={selectedAccount} />;
     }
 
     const { account } = selectedAccount;
 
     const accountTransactions = getAccountTransactions(account.key, transactions.transactions);
-    const isCoinjoinAccount = account.accountType === 'coinjoin';
+
+    if (account.backendType === 'coinjoin') {
+        const isLoading = account.status === 'out-of-sync' && !!account.syncing;
+        const isEmpty = !accountTransactions.length;
+        return (
+            <Layout selectedAccount={selectedAccount}>
+                {isLoading && <CoinjoinAccountDiscoveryProgress />}
+                {!isEmpty && (
+                    <>
+                        <CoinjoinSummary accountKey={account.key} />
+                        <TransactionList
+                            account={account}
+                            transactions={accountTransactions}
+                            symbol={account.symbol}
+                            isLoading={transactionsIsLoading}
+                        />
+                    </>
+                )}
+                {isEmpty && !isLoading && (
+                    <CoinjoinAccountEmpty account={selectedAccount.account} />
+                )}
+            </Layout>
+        );
+    }
 
     if (accountTransactions.length > 0 || transactionsIsLoading) {
         return (
             <Layout selectedAccount={selectedAccount}>
-                {account.networkType !== 'ripple' && account.accountType !== 'coinjoin' && (
-                    <TransactionSummary account={account} />
-                )}
-
-                {isCoinjoinAccount && <CoinjoinSummary accountKey={account.key} />}
+                {account.networkType !== 'ripple' && <TransactionSummary account={account} />}
 
                 <TransactionList
                     account={account}
@@ -69,25 +85,14 @@ const Transactions = () => {
 
     if (account.empty) {
         return (
-            <Layout
-                selectedAccount={selectedAccount}
-                showEmptyHeaderPlaceholder={!isCoinjoinAccount}
-            >
-                {isCoinjoinAccount ? (
-                    <>
-                        <CoinjoinSummaryHeader />
-                        <CoinjoinAccountEmpty account={selectedAccount.account} />
-                    </>
-                ) : (
-                    <AccountEmpty account={selectedAccount.account} />
-                )}
+            <Layout selectedAccount={selectedAccount} showEmptyHeaderPlaceholder>
+                <AccountEmpty account={selectedAccount.account} />
             </Layout>
         );
     }
 
     return (
-        <Layout selectedAccount={selectedAccount} showEmptyHeaderPlaceholder={!isCoinjoinAccount}>
-            {isCoinjoinAccount && <CoinjoinSummaryHeader />}
+        <Layout selectedAccount={selectedAccount} showEmptyHeaderPlaceholder>
             <NoTransactions account={account} />
         </Layout>
     );

--- a/suite-common/wallet-types/src/account.ts
+++ b/suite-common/wallet-types/src/account.ts
@@ -53,7 +53,7 @@ export type AccountBackendSpecific =
       }
     | {
           backendType: Extract<BackendType, 'coinjoin'>;
-          status: 'initial' | 'ready' | 'error';
+          status: 'initial' | 'ready' | 'error' | 'out-of-sync';
           syncing?: boolean;
       };
 


### PR DESCRIPTION
## Description

When CoinJoin account sync throws an error or the account was just loaded from db, it has `out-of-sync` status set. With this status,
- a) `Account is possibly out-of-sync` warning banner is shown in account detail (as an explanation why some actions could be disabled) and
- b) CoinJoin account loader is shown whenever the sync is running (as it could take more time than usual 1-block sync).

**All suggestions are warmly welcome!** 

## Screenshots

![image](https://user-images.githubusercontent.com/26326960/207066899-c41a872b-e4a7-4502-b82b-95c0d6579ea8.png)
