### PR TITLE
fix(suite): fw versions in fw install modal

### DIFF
--- a/packages/suite/src/components/firmware/FirmwareOffer.tsx
+++ b/packages/suite/src/components/firmware/FirmwareOffer.tsx
@@ -12,6 +12,7 @@ import { AcquiredDevice, FirmwareType } from '@suite-types';
 const FwVersionWrapper = styled.div`
     display: flex;
     width: 100%;
+    max-width: 364px;
     justify-content: space-between;
     align-items: center;
     padding: 16px 0px;
@@ -20,6 +21,10 @@ const FwVersionWrapper = styled.div`
 const FwVersion = styled.div`
     font-weight: ${variables.FONT_WEIGHT.MEDIUM};
     text-align: center;
+
+    &:only-child {
+        margin: 0 auto;
+    }
 `;
 
 const Version = styled.div<{ isNew?: boolean }>`


### PR DESCRIPTION
## Description

- Make the wrapper narrower
- Center single version item

## Related Issue

fix #7187 caused by #7079

## Screenshots:
![Screenshot 2022-12-12 at 17 14 36](https://user-images.githubusercontent.com/33235762/207097902-02978700-1a92-473a-b42e-4df6565f2a38.png)
![Screenshot 2022-12-12 at 17 20 01](https://user-images.githubusercontent.com/33235762/207097906-81b42458-8461-4373-bcee-60b5b5016cdd.png)
