### PR TITLE
fix(connect): missing model in old T1

### DIFF
--- a/packages/connect/src/device/Device.ts
+++ b/packages/connect/src/device/Device.ts
@@ -488,6 +488,11 @@ export class Device extends EventEmitter {
         const revision = parseRevision(feat);
         feat.revision = revision;
 
+        // old T1 is missing features.model
+        if (!feat.model && feat.major_version === 1) {
+            feat.model = '1';
+        }
+
         this.features = feat;
         this.featuresNeedsReload = false;
 


### PR DESCRIPTION
## Description

- old T1 fw does not report model

## Related Issue

Part of #6567

## Screenshots:
Before:
![Screenshot 2022-12-12 at 17 55 40](https://user-images.githubusercontent.com/33235762/207273575-66cdea4d-3d6f-460c-832a-d0eed3fa6a1a.png)
Now:
![Screenshot 2022-12-12 at 17 54 45](https://user-images.githubusercontent.com/33235762/207273570-a2ab9377-0961-47cf-b0c5-cc927ab6d57f.png)


