### PR TITLE
Feat/cj issuance graph

### DIFF
--- a/packages/coinjoin/src/client/round/outputDecomposition.ts
+++ b/packages/coinjoin/src/client/round/outputDecomposition.ts
@@ -1,4 +1,3 @@
-/* eslint-disable no-await-in-loop */
 import { getWeakRandomId } from '@trezor/utils';
 
 import * as coordinator from '../coordinator';
@@ -11,126 +10,20 @@ import type { CoinjoinRound, CoinjoinRoundOptions } from '../CoinjoinRound';
 /**
  * RoundPhase: 2, step 1
  *
- * - Join all registered inputs Credentials in to one, grouped by accountKey
  * - Calculate output amounts
+ * - Combine registered Credentials in to outputs grouped by accountKey
  */
-
-const joinInputsCredentials = async (
-    round: CoinjoinRound,
-    accountKey: string,
-    inputs: Alice[],
-    options: CoinjoinRoundOptions,
-) => {
-    const { roundParameters } = round;
-    const { signal, coordinatorUrl, middlewareUrl } = options;
-
-    let amountCredentials = inputs[0].confirmedAmountCredentials!;
-    let vsizeCredentials = inputs[0].confirmedVsizeCredentials!;
-    const { inputSize, outputSize } = inputs[0];
-
-    options.log(
-        `Joining Credentials for account ~~${accountKey}~~. Total inputs: ${inputs.length}`,
-    );
-
-    if (inputs.length === 1) {
-        return {
-            accountKey,
-            amountCredentials,
-            vsizeCredentials,
-            inputSize,
-            outputSize,
-        };
-    }
-
-    for (let i = 1; i < inputs.length; i++) {
-        const current = inputs[i];
-        if (current.error) {
-            options.log(
-                `Trying to join input with error. ~~${current.outpoint}~~ ${current.error}`,
-            );
-            throw current.error;
-        }
-        options.log(
-            `Joining${i} ${current.confirmedAmountCredentials![0].value} ${
-                current.confirmedAmountCredentials![1].value
-            } ${amountCredentials[0].value} ${amountCredentials[1].value} `,
-        );
-        // TODO: do not exceed roundParameters.maxAmountCredentialValue
-        const realAmountCredentials = await middleware.getRealCredentials(
-            [current.confirmedAmountCredentials![0].value + amountCredentials[0].value, 0],
-            [current.confirmedAmountCredentials![0], amountCredentials[0]],
-            round.amountCredentialIssuerParameters,
-            roundParameters.maxAmountCredentialValue,
-            { signal, baseUrl: middlewareUrl },
-        );
-        // TODO: do not exceed roundParameters.maxVsizeCredentialValue
-        const realVsizeCredentials = await middleware.getRealCredentials(
-            [vsizeCredentials[0].value, vsizeCredentials[1].value],
-            [vsizeCredentials[0], vsizeCredentials[1]],
-            round.vsizeCredentialIssuerParameters,
-            roundParameters.maxVsizeCredentialValue,
-            { signal, baseUrl: middlewareUrl },
-        );
-
-        const zeroAmountCredentials = await middleware.getZeroCredentials(
-            round.amountCredentialIssuerParameters,
-            { signal, baseUrl: middlewareUrl },
-        );
-        const zeroVsizeCredentials = await middleware.getZeroCredentials(
-            round.vsizeCredentialIssuerParameters,
-            { signal, baseUrl: middlewareUrl },
-        );
-
-        // TODO: delay
-        // use random identity for each request
-        const joinedIssuance = await coordinator.credentialIssuance(
-            round.id,
-            realAmountCredentials,
-            realVsizeCredentials,
-            zeroAmountCredentials,
-            zeroVsizeCredentials,
-            {
-                signal,
-                baseUrl: coordinatorUrl,
-                identity: getWeakRandomId(10),
-                delay: 0,
-                deadline: round.phaseDeadline,
-            },
-        );
-
-        amountCredentials = await middleware.getCredentials(
-            round.amountCredentialIssuerParameters,
-            joinedIssuance.realAmountCredentials,
-            realAmountCredentials.credentialsResponseValidation,
-            { signal, baseUrl: middlewareUrl },
-        );
-        vsizeCredentials = await middleware.getCredentials(
-            round.vsizeCredentialIssuerParameters,
-            joinedIssuance.realVsizeCredentials,
-            realVsizeCredentials.credentialsResponseValidation,
-            { signal, baseUrl: middlewareUrl },
-        );
-    }
-
-    return {
-        accountKey,
-        amountCredentials,
-        vsizeCredentials,
-        inputSize,
-        outputSize,
-    };
-};
 
 interface GetOutputAmountsParams {
     round: CoinjoinRound;
     options: CoinjoinRoundOptions;
     accountKey: string;
+    availableVsize: number;
     inputSize: number;
     outputSize: number;
-    availableVsize: number;
 }
 
-export const getOutputAmounts = async (params: GetOutputAmountsParams) => {
+const getOutputAmounts = async (params: GetOutputAmountsParams) => {
     const { round, accountKey, outputSize, options } = params;
     const { roundParameters } = round;
     const { signal, middlewareUrl } = options;
@@ -167,7 +60,7 @@ export const getOutputAmounts = async (params: GetOutputAmountsParams) => {
         },
         { signal, baseUrl: middlewareUrl },
     );
-    options.log(`Decompose amounts: ${outputAmounts.join('')}`);
+    options.log(`Decompose amounts: ${outputAmounts.join(',')}`);
     return outputAmounts.map(amount => {
         const miningFee = Math.floor((outputSize * roundParameters.miningFeeRate) / 1000);
         const coordinatorFee = 0; // NOTE: middleware issue https://github.com/zkSNACKs/WalletWasabi/issues/8814 should be `amount > plebsDontPayThreshold ? Math.floor(roundParameters.coordinationFeeRate.rate * amount) : 0` but middleware does not considerate coordinationFeeRate and plebs for external amounts
@@ -175,12 +68,318 @@ export const getOutputAmounts = async (params: GetOutputAmountsParams) => {
     });
 };
 
-export interface DecomposedOutputs {
+interface CredentialIssuanceParams {
+    round: CoinjoinRound;
+    amountToRequest: [number, number];
+    vsizeToRequest: [number, number];
+    amountCredentials: [middleware.Credentials, middleware.Credentials];
+    vsizeCredentials: [middleware.Credentials, middleware.Credentials];
+    options: CoinjoinRoundOptions;
+}
+
+// join or split Credentials to requested values
+// returns new pairs of Credentials:
+// `output` - what was requested
+// `change` - whats left and could be used later
+// both pairs contains [Value, ZeroValue]
+const credentialIssuance = async (params: CredentialIssuanceParams) => {
+    const { round, amountToRequest, amountCredentials, vsizeToRequest, vsizeCredentials } = params;
+    const { roundParameters } = round;
+    const { signal, coordinatorUrl, middlewareUrl, log } = params.options;
+
+    log('Joining credentials');
+    log(`Amount ${amountCredentials.map(c => c.value).join(',')} to ${amountToRequest.join(',')}`);
+    log(`Vsize ${vsizeCredentials.map(c => c.value).join(',')} to ${vsizeToRequest.join(',')}`);
+
+    // Credentials are always joined in pairs
+    if (
+        (!amountCredentials && !vsizeCredentials) ||
+        (amountCredentials && amountCredentials.length < 2) ||
+        (vsizeCredentials && vsizeCredentials.length < 2)
+    )
+        throw new Error('Not enough Credentials to join');
+
+    const issuanceAmountCredentials = await middleware.getRealCredentials(
+        amountToRequest,
+        amountCredentials,
+        round.amountCredentialIssuerParameters,
+        roundParameters.maxAmountCredentialValue,
+        { signal, baseUrl: middlewareUrl },
+    );
+    const issuanceVsizeCredentials = await middleware.getRealCredentials(
+        vsizeToRequest,
+        vsizeCredentials,
+        round.vsizeCredentialIssuerParameters,
+        roundParameters.maxVsizeCredentialValue,
+        { signal, baseUrl: middlewareUrl },
+    );
+
+    const zeroAmountCredentials = await middleware.getZeroCredentials(
+        round.amountCredentialIssuerParameters,
+        { signal, baseUrl: middlewareUrl },
+    );
+    const zeroVsizeCredentials = await middleware.getZeroCredentials(
+        round.vsizeCredentialIssuerParameters,
+        { signal, baseUrl: middlewareUrl },
+    );
+
+    // use random identity for each request
+    const issuanceData = await coordinator.credentialIssuance(
+        round.id,
+        issuanceAmountCredentials,
+        issuanceVsizeCredentials,
+        zeroAmountCredentials,
+        zeroVsizeCredentials,
+        {
+            signal,
+            baseUrl: coordinatorUrl,
+            identity: getWeakRandomId(10),
+            delay: 0,
+            deadline: round.phaseDeadline,
+        },
+    );
+
+    // create credentials for output
+    const amountCredentialsOut = await middleware.getCredentials(
+        round.amountCredentialIssuerParameters,
+        issuanceData.realAmountCredentials,
+        issuanceAmountCredentials.credentialsResponseValidation,
+        { signal, baseUrl: middlewareUrl },
+    );
+    const vsizeCredentialsOut = await middleware.getCredentials(
+        round.vsizeCredentialIssuerParameters,
+        issuanceData.realVsizeCredentials,
+        issuanceVsizeCredentials.credentialsResponseValidation,
+        { signal, baseUrl: middlewareUrl },
+    );
+
+    // create zero credentials
+    const zeroAmountCredentialsOut = await middleware.getCredentials(
+        round.amountCredentialIssuerParameters,
+        issuanceData.zeroAmountCredentials,
+        zeroAmountCredentials.credentialsResponseValidation,
+        { signal, baseUrl: middlewareUrl },
+    );
+    const zeroVsizeCredentialsOut = await middleware.getCredentials(
+        round.vsizeCredentialIssuerParameters,
+        issuanceData.zeroVsizeCredentials,
+        zeroVsizeCredentials.credentialsResponseValidation,
+        { signal, baseUrl: middlewareUrl },
+    );
+
+    // return pairs of new credentials
+    // requested Credentials
+    const output = {
+        amountCredentials: [amountCredentialsOut[0], zeroAmountCredentialsOut[0]],
+        vsizeCredentials: [vsizeCredentialsOut[0], zeroVsizeCredentialsOut[0]],
+    };
+
+    // or change output should be returned to pool
+    // change Credentials
+    const change = {
+        amountCredentials: [amountCredentialsOut[1], zeroAmountCredentialsOut[1]],
+        vsizeCredentials: [vsizeCredentialsOut[1], zeroVsizeCredentialsOut[1]],
+    };
+
+    log(`Output amount credentials: ${output.amountCredentials.map(c => c.value).join(',')}`);
+    log(`Output vsize credentials: ${output.vsizeCredentials.map(c => c.value).join(',')}`);
+    log(`Change amount credentials: ${change.amountCredentials.map(c => c.value).join(',')}`);
+    log(`Change vsize credentials: ${change.vsizeCredentials.map(c => c.value).join(',')}`);
+
+    return {
+        output,
+        change,
+    };
+};
+
+const findCredentialsForTarget = (
+    target: number,
+    credentials: middleware.Credentials[],
+    maxValue: number,
+): [middleware.Credentials, middleware.Credentials] | undefined => {
+    // sort descending. higher possibility for match
+    const sorted = credentials.sort((a, b) => (a.value > b.value ? -1 : 1));
+
+    // find one Credential big enough to cover requested target
+    const bigCredential = sorted.find(cre => cre.value >= target);
+    if (bigCredential) {
+        // try find a pair to produce change Credential used in next iteration
+        // always try to pair with greatest Credential or at least 0 value Credential
+        const changeValue = bigCredential.value - target;
+        const pair = sorted.find(
+            cre => cre !== bigCredential && cre.value + changeValue <= maxValue,
+        );
+        if (pair) {
+            return [bigCredential, pair];
+        }
+        // this should never happen but just in case
+        throw new Error('Missing pair for credential');
+    }
+
+    // one Credential is not enough. try to find pair to cover requested target
+    const candidate = sorted
+        .map((cre, index) => {
+            // always try to pair with greatest Credential to produce greatest possible change
+            const pair = sorted
+                .slice(index + 1)
+                .find(p => p.value + cre.value >= target && p.value + cre.value <= maxValue);
+
+            if (pair) {
+                return [cre, pair];
+            }
+            return [];
+        })
+        .find(pair => pair.length === 2);
+
+    return candidate ? [candidate[0], candidate[1]] : undefined;
+};
+
+interface Bob {
+    accountKey: string;
+    amount: number;
+    amountCredentials: middleware.Credentials[];
+    vsizeCredentials: middleware.Credentials[];
+}
+
+interface CreateOutputsCredentials {
+    round: CoinjoinRound;
+    options: CoinjoinRoundOptions;
     accountKey: string;
     outputSize: number;
     amounts: number[];
     amountCredentials: middleware.Credentials[];
     vsizeCredentials: middleware.Credentials[];
+    result: Bob[];
+}
+
+const createOutputsCredentials = async (params: CreateOutputsCredentials): Promise<Bob[]> => {
+    const { round, amounts, outputSize, amountCredentials, vsizeCredentials, options } = params;
+    const { roundParameters } = round;
+
+    // sort amounts ascending. smaller amounts should produce bigger change Credentials for next iteration
+    const sorted = amounts.sort((a, b) => a - b);
+
+    // try to find Credentials for each amount
+    const amountsWithCredentials = sorted.map(amount => ({
+        amount,
+        credentials: findCredentialsForTarget(
+            amount,
+            amountCredentials,
+            roundParameters.maxAmountCredentialValue,
+        ),
+    }));
+
+    // get first available set and spilt in to output and change
+    const amountPair = amountsWithCredentials.find(c => c.credentials);
+    const vsizePair = findCredentialsForTarget(
+        outputSize,
+        vsizeCredentials,
+        round.roundParameters.maxVsizeCredentialValue,
+    );
+
+    if (amountPair?.credentials && vsizePair) {
+        const availableAmount = sumCredentials(amountPair.credentials);
+        const availableVsize = sumCredentials(vsizePair);
+        const joined = await credentialIssuance({
+            ...params,
+            amountToRequest: [amountPair.amount, availableAmount - amountPair.amount],
+            amountCredentials: amountPair.credentials,
+            vsizeToRequest: [outputSize, availableVsize - outputSize],
+            vsizeCredentials: vsizePair,
+        });
+
+        // create Bob
+        const result = params.result.concat({
+            accountKey: params.accountKey,
+            amount: amountPair.amount,
+            amountCredentials: joined.output.amountCredentials,
+            vsizeCredentials: joined.output.vsizeCredentials,
+        });
+
+        // remove amount from list
+        const amountIndex = amounts.findIndex(a => a === amountPair.amount);
+        const updatedAmounts = amounts.slice(0);
+        updatedAmounts.splice(amountIndex, 1);
+
+        // update credentials list:
+        // - remove joined Credentials used by credentialIssuance process
+        // - add **change** Credentials back to available stack
+        const updatedAmountCredentials = amountCredentials
+            .filter(cre => !amountPair.credentials?.includes(cre))
+            .concat(joined.change.amountCredentials);
+        const updatedVsizeCredentials = vsizeCredentials
+            .filter(cre => !vsizePair.includes(cre))
+            .concat(joined.change.vsizeCredentials);
+
+        if (updatedAmounts.length === 0) {
+            // no more amounts, check whats left
+            const amountDust = sumCredentials(updatedAmountCredentials);
+            const vsizeDust = sumCredentials(updatedVsizeCredentials);
+
+            options.log(`Amount dust: ${amountDust}`);
+            options.log(`Vsize dust: ${vsizeDust}`);
+            options.log('Decomposition completed');
+
+            return result.sort((a, b) => (a.amount > b.amount ? -1 : 1));
+        }
+
+        // try to create another output
+        return createOutputsCredentials({
+            ...params,
+            amounts: updatedAmounts,
+            amountCredentials: updatedAmountCredentials,
+            vsizeCredentials: updatedVsizeCredentials,
+            result,
+        });
+    }
+
+    const amountToJoin = findCredentialsForTarget(
+        0,
+        amountCredentials,
+        roundParameters.maxAmountCredentialValue,
+    );
+    const vsizeToJoin = findCredentialsForTarget(
+        0,
+        vsizeCredentials,
+        roundParameters.maxVsizeCredentialValue,
+    );
+
+    if (!amountToJoin || !vsizeToJoin) {
+        // this should never happen but just in case
+        throw new Error('Missing credentials to join');
+    }
+
+    const availableAmount = sumCredentials(amountToJoin);
+    const availableVsize = sumCredentials(vsizeToJoin);
+    const joined = await credentialIssuance({
+        ...params,
+        amountToRequest: [availableAmount, 0],
+        amountCredentials: amountToJoin,
+        vsizeToRequest: [availableVsize, 0],
+        vsizeCredentials: vsizeToJoin,
+    });
+
+    // update credentials list:
+    // - remove joined Credentials used by credentialIssuance process
+    // - add **output** Credentials to available stack
+    const updatedAmountCredentials = amountCredentials
+        .filter(cre => !amountToJoin.includes(cre))
+        .concat(joined.output.amountCredentials);
+    const updatedVsizeCredentials = vsizeCredentials
+        .filter(cre => !vsizeToJoin.includes(cre))
+        .concat(joined.output.vsizeCredentials);
+
+    // try again with updated Credentials
+    return createOutputsCredentials({
+        ...params,
+        amountCredentials: updatedAmountCredentials,
+        vsizeCredentials: updatedVsizeCredentials,
+    });
+};
+
+export interface DecomposedOutputs {
+    accountKey: string;
+    outputs: Bob[];
 }
 
 export const outputDecomposition = async (
@@ -201,17 +400,12 @@ export const outputDecomposition = async (
 
     options.log(`Decompose ${Object.keys(groupInputsByAccount).length} accounts`);
 
-    // join inputs Credentials for each account separately
-    const joinedCredentials = await Promise.all(
-        Object.keys(groupInputsByAccount).map(accountKey =>
-            joinInputsCredentials(round, accountKey, groupInputsByAccount[accountKey], options),
-        ),
-    );
-
     // calculate amounts
     const outputAmounts = await Promise.all(
-        joinedCredentials.map(({ vsizeCredentials, inputSize, outputSize, accountKey }) => {
-            const availableVsize = sumCredentials(vsizeCredentials);
+        Object.values(groupInputsByAccount).map(inputs => {
+            const allVsizeCredentials = inputs.flatMap(i => i.confirmedVsizeCredentials!);
+            const availableVsize = sumCredentials(allVsizeCredentials);
+            const { accountKey, inputSize, outputSize } = inputs[0]; // all inputs belongs to the same account (key, size)
             return getOutputAmounts({
                 round,
                 accountKey,
@@ -223,15 +417,36 @@ export const outputDecomposition = async (
         }),
     );
 
+    // join inputs Credentials for each account separately
+    const joinedCredentials = await Promise.all(
+        Object.keys(groupInputsByAccount).map((accountKey, index) => {
+            if (!outputAmounts[index]) throw new Error(`Missing amounts at index ${index}`);
+
+            options.log(`Create outputs: ${outputAmounts[index].join(',')}`);
+            const inputs = groupInputsByAccount[accountKey];
+            const amountCredentials = inputs.flatMap(i => i.confirmedAmountCredentials!);
+            const vsizeCredentials = inputs.flatMap(i => i.confirmedVsizeCredentials!);
+            const result = createOutputsCredentials({
+                round,
+                accountKey,
+                outputSize: inputs[0].outputSize, // all inputs are using same script type (size),
+                amounts: outputAmounts[index],
+                amountCredentials,
+                vsizeCredentials,
+                options,
+                result: [],
+            });
+            return result;
+        }),
+    );
+
     // combine everything into DecomposedOutputs objects and return the result to outputRegistration
     return Object.keys(groupInputsByAccount).map((accountKey, index) => {
         if (!joinedCredentials[index])
             throw new Error(`Missing joined credentials at index ${index}`);
-        if (!outputAmounts[index]) throw new Error(`Missing amounts at index ${index}`);
         return {
-            ...joinedCredentials[index],
             accountKey,
-            amounts: outputAmounts[index],
+            outputs: joinedCredentials[index],
         };
     });
 };

--- a/packages/coinjoin/src/utils/roundUtils.ts
+++ b/packages/coinjoin/src/utils/roundUtils.ts
@@ -156,4 +156,4 @@ export const compareOutpoint = (a: string, b: string) =>
     Buffer.from(a, 'hex').compare(Buffer.from(b, 'hex')) === 0;
 
 // sum input Credentials
-export const sumCredentials = (c: Credentials[]) => c[0].value + c[1].value;
+export const sumCredentials = (c: Credentials[]) => c.reduce((sum, cre) => sum + cre.value, 0);

--- a/packages/coinjoin/tests/client/outputDecomposition.test.ts
+++ b/packages/coinjoin/tests/client/outputDecomposition.test.ts
@@ -1,0 +1,89 @@
+import { outputDecomposition } from '../../src/client/round/outputDecomposition';
+import { createServer } from '../mocks/server';
+import { createInput } from '../fixtures/input.fixture';
+import { outputDecomposition as fixtures } from '../fixtures/outputDecomposition.fixture';
+import { createCoinjoinRound, INPUT_ADDED_EVENT } from '../fixtures/round.fixture';
+
+let server: Awaited<ReturnType<typeof createServer>>;
+
+describe('outputRegistration', () => {
+    beforeAll(async () => {
+        server = await createServer();
+    });
+
+    beforeEach(() => {
+        server?.removeAllListeners('test-request');
+    });
+
+    afterAll(() => {
+        if (server) server.close();
+    });
+
+    it('outputDecomposition fails. missing data in input', async () => {
+        await expect(
+            outputDecomposition(
+                createCoinjoinRound([createInput('account-A', 'A1')], {
+                    ...server?.requestOptions,
+                    round: {
+                        phase: 3,
+                    },
+                }),
+                server?.requestOptions,
+            ),
+        ).rejects.toThrow('Missing confirmed credentials');
+    });
+
+    fixtures.forEach(f => {
+        it(`outputDecomposition ${f.description}`, async () => {
+            const spy = jest.fn();
+            server?.addListener('test-request', ({ url, resolve }) => {
+                if (url.endsWith('/get-outputs-amounts')) {
+                    resolve({
+                        outputAmounts: f.outputAmounts,
+                    });
+                }
+                if (url.endsWith('/credential-issuance')) {
+                    spy();
+                }
+                resolve();
+            });
+
+            // NOTE: scriptPubKey is only used to calculate external output size, it can be reused for all inputs
+            const scriptPubKey =
+                '1 6a6daebd9abae25cdd376b811190163eb00c58e87da1867ba8546229098231c3';
+            const inputs = f.inputs.map(i => createInput(...(i as Parameters<typeof createInput>)));
+            const events: any[] = inputs.map(i => ({
+                Type: 'InputAdded',
+                coin: {
+                    outpoint: i.outpoint,
+                    txOut: {
+                        scriptPubKey,
+                        value: i.amount,
+                    },
+                },
+            }));
+
+            const response = await outputDecomposition(
+                createCoinjoinRound(inputs, {
+                    ...server?.requestOptions,
+                    round: {
+                        phase: 3,
+                        coinjoinState: {
+                            Type: '',
+                            events: [...events, INPUT_ADDED_EVENT],
+                        },
+                    },
+                    roundParameters: f.roundParameters,
+                }),
+                server?.requestOptions,
+            );
+
+            expect(response.length).toBe(f.result.length);
+            response.forEach((r, i) => {
+                expect(r.outputs.length).toBe(f.result[i].outputs.length);
+                expect(r).toMatchObject(f.result[i]);
+            });
+            expect(spy).toBeCalledTimes(f.credentialIssuanceCalls);
+        });
+    });
+});

--- a/packages/coinjoin/tests/fixtures/outputDecomposition.fixture.ts
+++ b/packages/coinjoin/tests/fixtures/outputDecomposition.fixture.ts
@@ -1,0 +1,156 @@
+export const outputDecomposition = [
+    {
+        description: 'maximum outputs from one input',
+        outputAmounts: [10000, 6556, 5000, 8100],
+        inputs: [
+            [
+                'account-A',
+                'A00000000000000000000000000000000000000000000000000000000000000001000000',
+                {
+                    confirmedAmountCredentials: [{ value: 30000 }, { value: 0 }],
+                    confirmedVsizeCredentials: [{ value: 197 }, { value: 0 }],
+                },
+            ],
+        ],
+        roundParameters: {
+            miningFeeRate: 2000,
+        },
+        result: [
+            {
+                outputs: [
+                    {
+                        amount: 10086,
+                        amountCredentials: [{ value: 10086 }, { value: 0 }],
+                        vsizeCredentials: [{ value: 43 }, { value: 0 }],
+                    },
+                    {
+                        amount: 8186,
+                        amountCredentials: [{ value: 8186 }, { value: 0 }],
+                        vsizeCredentials: [{ value: 43 }, { value: 0 }],
+                    },
+                    {
+                        amount: 6642,
+                        amountCredentials: [{ value: 6642 }, { value: 0 }],
+                        vsizeCredentials: [{ value: 43 }, { value: 0 }],
+                    },
+                    {
+                        amount: 5086,
+                        amountCredentials: [{ value: 5086 }, { value: 0 }],
+                        vsizeCredentials: [{ value: 43 }, { value: 0 }],
+                    },
+                ],
+            },
+        ],
+        credentialIssuanceCalls: 4, // called 4 times to split outputs
+    },
+    {
+        description: 'one output from multiple inputs',
+        outputAmounts: [19000],
+        inputs: [
+            [
+                'account-A',
+                'A00000000000000000000000000000000000000000000000000000000000000001000000',
+                {
+                    confirmedAmountCredentials: [{ value: 5000 }, { value: 0 }],
+                    confirmedVsizeCredentials: [{ value: 197 }, { value: 0 }],
+                },
+            ],
+            [
+                'account-A',
+                'A00000000000000000000000000000000000000000000000000000000000000002000000',
+                {
+                    confirmedAmountCredentials: [{ value: 5000 }, { value: 0 }],
+                    confirmedVsizeCredentials: [{ value: 197 }, { value: 0 }],
+                },
+            ],
+            [
+                'account-A',
+                'A00000000000000000000000000000000000000000000000000000000000000003000000',
+                {
+                    confirmedAmountCredentials: [{ value: 5000 }, { value: 0 }],
+                    confirmedVsizeCredentials: [{ value: 197 }, { value: 0 }],
+                },
+            ],
+            [
+                'account-A',
+                'A00000000000000000000000000000000000000000000000000000000000000004000000',
+                {
+                    confirmedAmountCredentials: [{ value: 5000 }, { value: 0 }],
+                    confirmedVsizeCredentials: [{ value: 197 }, { value: 0 }],
+                },
+            ],
+        ],
+        roundParameters: {
+            miningFeeRate: 2000,
+        },
+        result: [
+            {
+                outputs: [
+                    {
+                        amount: 19086,
+                        amountCredentials: [{ value: 19086 }, { value: 0 }],
+                        vsizeCredentials: [{ value: 43 }, { value: 0 }],
+                    },
+                ],
+            },
+        ],
+        credentialIssuanceCalls: 3, // called 3 times to join 4 inputs
+    },
+    {
+        description: 'dropping dust on multiple accounts',
+        outputAmounts: [5000],
+        inputs: [
+            [
+                'account-A',
+                'A00000000000000000000000000000000000000000000000000000000000000001000000',
+                {
+                    confirmedAmountCredentials: [{ value: 10000 }, { value: 0 }],
+                    confirmedVsizeCredentials: [{ value: 197 }, { value: 0 }],
+                },
+            ],
+            [
+                'account-A',
+                'A00000000000000000000000000000000000000000000000000000000000000002000000',
+                {
+                    confirmedAmountCredentials: [{ value: 10000 }, { value: 0 }],
+                    confirmedVsizeCredentials: [{ value: 197 }, { value: 0 }],
+                },
+            ],
+            [
+                'account-B',
+                'B00000000000000000000000000000000000000000000000000000000000000001000000',
+                {
+                    confirmedAmountCredentials: [{ value: 10000 }, { value: 0 }],
+                    confirmedVsizeCredentials: [{ value: 197 }, { value: 0 }],
+                },
+            ],
+        ],
+        roundParameters: {
+            miningFeeRate: 2000,
+            maxAmountCredentialValue: 10000,
+        },
+        result: [
+            {
+                accountKey: 'account-A',
+                outputs: [
+                    {
+                        amount: 5086,
+                        amountCredentials: [{ value: 5086 }, { value: 0 }],
+                        vsizeCredentials: [{ value: 43 }, { value: 0 }],
+                    },
+                ],
+            },
+            {
+                accountKey: 'account-B',
+                outputs: [
+                    {
+                        amount: 5086,
+                        amountCredentials: [{ value: 5086 }, { value: 0 }],
+                        vsizeCredentials: [{ value: 43 }, { value: 0 }],
+                    },
+                ],
+            },
+        ],
+        credentialIssuanceCalls: 2, // called 2 times, once for each account
+    },
+];

--- a/packages/coinjoin/tests/fixtures/round.fixture.ts
+++ b/packages/coinjoin/tests/fixtures/round.fixture.ts
@@ -38,6 +38,19 @@ export const ROUND_CREATION_EVENT = {
     },
 };
 
+// random P2WPKH external input
+export const INPUT_ADDED_EVENT = {
+    Type: 'InputAdded',
+    coin: {
+        outpoint: 'AABBCCDD001123344000000000000000000000000000000000000000000000000000000',
+        txOut: {
+            scriptPubKey: '0 751e76e8199196d454941c45d1b3a323f1433bd6',
+            value: 5000,
+        },
+    },
+    ownershipProof: '',
+};
+
 export const FEE_RATE_MEDIANS = [
     {
         timeFrame: '1d 0h 1m 0s',


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Solution already tested in [coinjoin daily build](https://github.com/trezor/trezor-suite/commits/CJ-latest) branch

Phase 3, part 1 `outputDecomposition`
Implementation of missing part called "issuance graph"

After successful input confirmation each input receives Credentials for `amount` and `vsize` where:
- `amount` is an utxo value reduced by mining fee and coordinator fee (optionally)
- `vsize` is available "virtual space" for outputs in transaction. typically you can create 4 outputs from 1 input.

**Credentials are always provided in pairs [VALUE_CREDENTIAL, ZERO_CREDENTIALS]**

#### Credentials properties
- Credentials are always provided in pairs and because of the nature of coordinator they needs to be sent in pairs (in `/credential-issuance` and `/output-registration` requests)
- Credentials value are limited/restricted by **maxCredentialValue** defined on coordinator.
- Credentials may be combined (joined/sliced) into a different Credentials using coordinator `/credential-issuance` request.
> using combinations: [VALUE, ZERO] or [VALUE, VALUE] or [ZERO, ZERO] or [ZERO, VALUE]


Pseudo code example:
```
const cre1 = [{ value: 5000 }, { value: 0 }];
const cre2 = [{ value: 5000 }, { value: 0 }];

// join two values to requested output and change
const join1 = (cre1, cre2) => ({ 
    output: [{ value: 8000 }, { value: 0 }],
    change: [{ value: 2000 }, { value: 0 }]
});

const join2 = (cre1, cre2) => ({ 
    output: [{ value: 10000 }, { value: 0 }],
    change: [{ value: 0000 }, { value: 0 }]
});

// split one big to two smaller values
const split = (cre1) => [{ value: 2000 }, { value: 3000 }];

```

### How input Credentials are combined into output Credentials
Output amounts are calculated by middleware `/get-outputs-amounts` and the goal of this algorithm is to create set of Credentials to match requested values.
output Credentials (called **Bob**) should look the same as input Credentials (Alice)
```
Bob {
    amount: [outputAmount + miningFee, ZERO_CREDENTIALS],
    vsize: [outputSize, ZERO_CREDENTIALS]
}
```

Process flow:
- sort requested output amounts in ascending and available Credentials values in descending order
- decide which Credentials should be used to create output, pick the best pair of Credentials to produce requested output **and** greatest possible change which will be used in next iteration increasing probability of match.
- call middleware to get zero-knowledge data (params of `/credential-issuance`)
- call coordinator `/credential-issuance`
- call middleware to process data from coordinator
- group received Credentials into `output` and `change` Credentials
- put output Credentials aside
- return change Credentials back to pool of available Credentials
- go back to step 2 and try to create another output

Example of process flow (splitting)
![issuance](https://user-images.githubusercontent.com/3435913/207276334-35d475fd-910a-4a0c-81ae-b9fea2470252.png)

Example of process flow (joining)
![issuance-2](https://user-images.githubusercontent.com/3435913/207276543-513b18e4-fb3a-4532-a8bc-673724ae769e.png)
