### PR TITLE
fix(suite): disable coinjoin account sync in critical phase

### DIFF
--- a/packages/suite/src/actions/wallet/coinjoinAccountActions.ts
+++ b/packages/suite/src/actions/wallet/coinjoinAccountActions.ts
@@ -189,6 +189,8 @@ const coinjoinAccountAddTransactions =
 export const fetchAndUpdateAccount =
     (account: Account) => async (dispatch: Dispatch, getState: GetState) => {
         if (account.backendType !== 'coinjoin' || account.syncing) return;
+        // do not sync if any account CoinjoinSession is in critical phase
+        if (getState().wallet.coinjoin.accounts.some(acc => (acc.session?.phase ?? 0) > 0)) return;
 
         const api = CoinjoinBackendService.getInstance(account.symbol);
         if (!api) return;


### PR DESCRIPTION
## Description

tested in [coinjoin daily build](https://github.com/trezor/trezor-suite/commits/CJ-latest) branch

Do not sync account/mempool if **any** coinjoin session is in critical phase.
Syncing produces a lot of http requests and this leads to random timeouts and problems with TOR sockets when they are needed the most (communication with coordinator)
