### PR TITLE
chore(react-native): Remove old coins from supported networks by the app

### DIFF
--- a/suite-native/config/src/enabledNetworks.ts
+++ b/suite-native/config/src/enabledNetworks.ts
@@ -1,4 +1,6 @@
-import { networks, NetworkSymbol } from '@suite-common/wallet-config';
+import { networks, NetworkSymbol, getMainnets, getTestnets } from '@suite-common/wallet-config';
+
+const deprecatedNetworks = ['dash', 'btg', 'dgb', 'nmc', 'vtc'];
 
 // ordering defined by product - it is done according to the data about the coins and usage of them in Desktop Suite
 export const mainnetsOrder: NetworkSymbol[] = [
@@ -20,4 +22,13 @@ export const mainnetsOrder: NetworkSymbol[] = [
 
 export const testnetsOrder: NetworkSymbol[] = ['test', 'regtest', 'tgor', 'trop', 'tada', 'txrp'];
 
-export const enabledNetworks: NetworkSymbol[] = Object.keys(networks) as NetworkSymbol[];
+export const enabledNetworks: NetworkSymbol[] = Object.keys(networks).filter(
+    network => !deprecatedNetworks.includes(network),
+) as NetworkSymbol[];
+
+export const enabledMainnets = getMainnets().filter(network =>
+    enabledNetworks.includes(network.symbol),
+);
+export const enabledTestnets = getTestnets().filter(network =>
+    enabledNetworks.includes(network.symbol),
+);

--- a/suite-native/module-accounts-import/src/components/SelectableNetworkList.tsx
+++ b/suite-native/module-accounts-import/src/components/SelectableNetworkList.tsx
@@ -3,14 +3,13 @@ import React from 'react';
 import { A, pipe } from '@mobily/ts-belt';
 
 import { Box, Card, Text, VStack } from '@suite-native/atoms';
+import { Network, networks, NetworkSymbol } from '@suite-common/wallet-config';
 import {
-    Network,
-    networks,
-    NetworkSymbol,
-    getMainnets,
-    getTestnets,
-} from '@suite-common/wallet-config';
-import { mainnetsOrder, testnetsOrder } from '@suite-native/config';
+    mainnetsOrder,
+    testnetsOrder,
+    enabledMainnets,
+    enabledTestnets,
+} from '@suite-native/config';
 import { prepareNativeStyle, useNativeStyles } from '@trezor/styles';
 
 import { SelectableNetworkItem } from './SelectableNetworkItem';
@@ -37,8 +36,8 @@ const mapAndSortNetworkItems = (networkItems: Network[], networkOrder: NetworkSy
         A.sort((a, b) => (a.order > b.order ? 1 : -1)),
     );
 
-const sortedMainnetsNetworks = mapAndSortNetworkItems(getMainnets(), mainnetsOrder);
-const sortedTestnetNetworks = mapAndSortNetworkItems(getTestnets(), testnetsOrder);
+const sortedMainnetsNetworks = mapAndSortNetworkItems(enabledMainnets, mainnetsOrder);
+const sortedTestnetNetworks = mapAndSortNetworkItems(enabledTestnets, testnetsOrder);
 
 export const SelectableNetworkList = ({ onSelectItem }: SelectableAssetListProps) => {
     const { applyStyle } = useNativeStyles();


### PR DESCRIPTION
## Description

Remove the possibility to import these coins as they are agreed to be obsolete: 
- Dash
- Bitcoin Gold
- Digibyte
- Namecoin
- Vertcoin

This is only for the mobile app right now. Desktop is not modified.

## Related Issue

Resolve https://github.com/trezor/trezor-suite/issues/7227