### PR TITLE
coinjoin: implement blame rounds

### DIFF
--- a/packages/coinjoin/src/client/CoinjoinClient.ts
+++ b/packages/coinjoin/src/client/CoinjoinClient.ts
@@ -215,6 +215,9 @@ export class CoinjoinClient extends EventEmitter {
             );
 
             if (newRound) {
+                // try to release all inmates detained due to blame round
+                this.prison.releaseBlameOfInmates(newRound.blameOf);
+
                 roundsToProcess.push(newRound);
                 if (!this.rounds.find(r => r.id === newRound.id)) {
                     newRound.on('changed', event => this.emit('round', event));

--- a/packages/coinjoin/src/client/CoinjoinPrison.ts
+++ b/packages/coinjoin/src/client/CoinjoinPrison.ts
@@ -35,6 +35,23 @@ export class CoinjoinPrison {
         return this.inmates.find(i => i.id === id);
     }
 
+    detainForBlameRound(ids: string[], roundId: string) {
+        ids.forEach(id => {
+            this.detain(id, {
+                reason: 'blameOf',
+                roundId,
+            });
+        });
+    }
+
+    getBlameOfInmates() {
+        return this.inmates.filter(i => i.reason === 'blameOf');
+    }
+
+    releaseBlameOfInmates(roundId: string) {
+        this.inmates = this.inmates.filter(inmate => inmate.roundId !== roundId);
+    }
+
     // called on each status change before rounds are processed
     release() {
         const now = Date.now();

--- a/packages/coinjoin/src/client/round/outputRegistration.ts
+++ b/packages/coinjoin/src/client/round/outputRegistration.ts
@@ -73,8 +73,8 @@ const registerOutput = async (
                     error.message === coordinator.WabiSabiProtocolErrorCode.AlreadyRegisteredScript
                 ) {
                     prison.detain(address.scriptPubKey, {
-                        roundId: round.id,
                         reason: error.message,
+                        sentenceEnd: Infinity, // this address should never be recycled
                     });
                     return tryToRegisterOutput();
                 }

--- a/packages/coinjoin/src/enums.ts
+++ b/packages/coinjoin/src/enums.ts
@@ -14,4 +14,6 @@ export enum EndRoundState {
     TransactionBroadcasted = 4,
     NotAllAlicesSign = 5,
     AbortedNotEnoughAlicesSigned = 6,
+    AbortedNotAllAlicesConfirmed = 7,
+    AbortedLoadBalancing = 8,
 }

--- a/packages/suite/src/actions/wallet/coinjoinClientActions.ts
+++ b/packages/suite/src/actions/wallet/coinjoinClientActions.ts
@@ -6,7 +6,7 @@ import {
     CoinjoinRequestEvent,
     CoinjoinResponseEvent,
 } from '@trezor/coinjoin';
-import { arrayDistinct } from '@trezor/utils';
+import { arrayDistinct, arrayToDictionary } from '@trezor/utils';
 import * as COINJOIN from './constants/coinjoinConstants';
 import { breakdownCoinjoinBalance, prepareCoinjoinTransaction } from '@wallet-utils/coinjoinUtils';
 import { CoinjoinClientService } from '@suite/services/coinjoin/coinjoinClient';
@@ -280,15 +280,10 @@ export const getOwnershipProof =
         };
 
         // group utxos by account
-        const groupUtxosByAccount = request.inputs.reduce<Record<string, typeof request.inputs>>(
-            (result, utxo) => {
-                if (!result[utxo.accountKey]) {
-                    result[utxo.accountKey] = [];
-                }
-                result[utxo.accountKey].push(utxo);
-                return result;
-            },
-            {},
+        const groupUtxosByAccount = arrayToDictionary(
+            request.inputs,
+            utxo => utxo.accountKey,
+            true,
         );
 
         // prepare array of parameters for TrezorConnect, grouped by TrezorDevice
@@ -381,15 +376,10 @@ export const signCoinjoinTx =
         };
 
         // group utxos by account
-        const groupUtxosByAccount = request.inputs.reduce<Record<string, typeof request.inputs>>(
-            (result, utxo) => {
-                if (!result[utxo.accountKey]) {
-                    result[utxo.accountKey] = [];
-                }
-                result[utxo.accountKey].push(utxo);
-                return result;
-            },
-            {},
+        const groupUtxosByAccount = arrayToDictionary(
+            request.inputs,
+            utxo => utxo.accountKey,
+            true,
         );
 
         const groupParamsByDevice = Object.keys(groupUtxosByAccount).flatMap(key => {

--- a/packages/utils/src/arrayToDictionary.ts
+++ b/packages/utils/src/arrayToDictionary.ts
@@ -1,32 +1,50 @@
+type DictionaryKey = string | number;
+type GetKey<T> = (item: T) => unknown;
+type Key<Fn extends GetKey<any>, R = ReturnType<Fn>> = R extends DictionaryKey ? R : never;
 type ArrayToDictionary = {
-    <T>(array: T[], getKey: (item: T) => string | number, multiple?: false): { [key: string]: T };
-    <T>(array: T[], getKey: (item: T) => string | number, multiple: true): { [key: string]: T[] };
+    <T, Fn extends GetKey<T>>(array: T[], getKey: Fn, multiple?: false): Record<Key<Fn>, T>;
+    <T, Fn extends GetKey<T>>(array: T[], getKey: Fn, multiple: true): Record<Key<Fn>, T[]>;
 };
 
 /**
  * @param array Array to be converted to dictionary
  * @param getKey Function extracting string from an array item T, which will become its
  * key in the dictionary (if not unique, latter item could replace the former one)
+ * Item will not be added to dictionary if key is not defined
  * @param multiple If true, dictionary values are arrays of all items with the given key
  * @returns Dictionary object with array items as values
  */
-export const arrayToDictionary: ArrayToDictionary = <T>(
+
+const validateKey = (key: unknown): key is DictionaryKey => {
+    if (['string', 'number'].includes(typeof key)) {
+        return true;
+    }
+    return false;
+};
+
+export const arrayToDictionary: ArrayToDictionary = <T, Fn extends GetKey<T>>(
     array: T[],
-    getKey: (item: T) => string | number,
+    getKey: Fn,
     multiple?: boolean,
 ) =>
     multiple
-        ? array.reduce<{ [key: string]: T[] }>(
-              (prev, cur) => ({
-                  ...prev,
-                  [getKey(cur)]: [...(prev[getKey(cur)] ?? []), cur],
-              }),
-              {},
-          )
-        : array.reduce<{ [key: string]: T }>(
-              (prev, cur) => ({
-                  ...prev,
-                  [getKey(cur)]: cur,
-              }),
-              {},
-          );
+        ? array.reduce<Record<DictionaryKey, T[]>>((prev, cur) => {
+              const key = getKey(cur);
+              if (validateKey(key)) {
+                  return {
+                      ...prev,
+                      [key]: [...(prev[key] ?? []), cur],
+                  };
+              }
+              return prev;
+          }, {})
+        : array.reduce<Record<DictionaryKey, T>>((prev, cur) => {
+              const key = getKey(cur);
+              if (validateKey(key)) {
+                  return {
+                      ...prev,
+                      [key]: cur,
+                  };
+              }
+              return prev;
+          }, {});

--- a/packages/utils/tests/arrayToDictionary.test.ts
+++ b/packages/utils/tests/arrayToDictionary.test.ts
@@ -52,6 +52,76 @@ describe('arrayToDictionary', () => {
         });
     });
 
+    it('array to dictionary with strongly typed optional number keys', () => {
+        const array = [
+            { value: 1, name: 'a' } as const,
+            { value: 2, name: 'b' } as const,
+            { value: 3, name: 'c' } as const,
+            { value: 4, name: 'b' } as const,
+        ];
+        const dictionary = arrayToDictionary(
+            array,
+            e => (e.value !== 2 ? e.value : undefined),
+            true,
+        );
+        expect(dictionary).toStrictEqual({
+            1: [{ value: 1, name: 'a' }],
+            3: [{ value: 3, name: 'c' }],
+            4: [{ value: 4, name: 'b' }],
+        });
+
+        // @ts-expect-error "2" key is not expected (skipped)
+        expect(dictionary[2]).toBe(undefined);
+        // @ts-expect-error string key is not expected
+        expect(dictionary.a).toBe(undefined);
+    });
+
+    it('array to multidictionary with strongly typed optional string keys', () => {
+        const array = [
+            { value: 1, name: 'a' } as const,
+            { value: 2, name: 'b' } as const,
+            { value: 3, name: 'skip' } as const,
+            { value: 4, name: 'b' } as const,
+            { value: 5, name: 'skip' } as const,
+        ];
+        const dictionary = arrayToDictionary(
+            array,
+            e => (e.name !== 'skip' ? e.name : undefined),
+            true,
+        );
+        expect(dictionary).toStrictEqual({
+            a: [{ value: 1, name: 'a' }],
+            b: [
+                { value: 2, name: 'b' },
+                { value: 4, name: 'b' },
+            ],
+        });
+
+        // @ts-expect-error "skip" key is not expected (skipped)
+        expect(dictionary.skip).toBe(undefined);
+        // @ts-expect-error number key is not expected
+        expect(dictionary[1]).toBe(undefined);
+    });
+
+    it('array with mixed keys', () => {
+        const array = ['a', 'b', 0, 1];
+        const dictionary = arrayToDictionary(array, e => e);
+        expect(dictionary).toStrictEqual({
+            a: 'a',
+            b: 'b',
+            0: 0,
+            1: 1,
+        });
+        expect(dictionary.a).toEqual('a');
+        expect(dictionary[0]).toEqual(0);
+    });
+
+    it('array with invalid keys returned from getKey callback', () => {
+        const array = ['a', 'b', 'c'];
+        const dictionary = arrayToDictionary(array, e => (e === 'a' ? { foo: 1 } : null));
+        expect(dictionary).toStrictEqual({});
+    });
+
     it('array with calculated keys', () => {
         const array = ['aalpha', 'bbeta', 'ggamma', 'ddelta'];
         const dictionary = arrayToDictionary(array, e => e.toUpperCase().slice(1));


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

If currently signed round ends with `NotAllAlicesSign` exception detain used inputs and outputs to be used again in blame round.

Blame round is a specific round dedicated **only** for participants who correctly sign previously failed round.
Participants who didn't sign or new participants will not be accepted. (will receive `InputNotWhitelisted` error during input-registration) 

#### Additional changes
`arrayToDictionary` required some tweaks to make it useful in my case (optional keys)
while doing so i've also added:
- strongly typed keys feature
> before: the key was always `string` even if `number` was acceptable return type of `getKey` callback
> now: dictionary key type is deducted from the return type of `getKey` callback
- getKey result runtime validation

`arrayToDictionary` still needs some type fixes regarding accepted params ([1, 2, 3] as const)

- code hygiene commit, using `arrayToDictionary` in few coinjoin related actions

## Related Issue

Resolve #7181

## Screenshots:
