### PR TITLE
fix(invity): handling of login request from partner in buy/sell

### DIFF
--- a/packages/suite/src/hooks/wallet/useCoinmarketSellOffers.ts
+++ b/packages/suite/src/hooks/wallet/useCoinmarketSellOffers.ts
@@ -165,7 +165,7 @@ export const useOffers = ({ selectedAccount }: UseOffersProps) => {
         });
         setCallInProgress(false);
         if (response) {
-            if (response.trade.error) {
+            if (response.trade.error && response.trade.status !== 'LOGIN_REQUEST') {
                 console.log(`[doSellTrade] ${response.trade.error}`);
                 addNotification({
                     type: 'error',

--- a/packages/suite/src/support/messages.ts
+++ b/packages/suite/src/support/messages.ts
@@ -1553,6 +1553,10 @@ export default defineMessages({
         id: 'TR_BUY_GET_THIS_OFFER',
         defaultMessage: 'Get this deal',
     },
+    TR_LOGIN_PROCEED: {
+        id: 'TR_LOGIN_PROCEED',
+        defaultMessage: 'Proceed',
+    },
     TR_OFFER_ERROR_MINIMUM_CRYPTO: {
         defaultMessage:
             'The chosen amount of {amount} is lower than the accepted minimum of {min}.',

--- a/packages/suite/src/views/wallet/coinmarket/buy/offers/Offers/List/Quote/index.tsx
+++ b/packages/suite/src/views/wallet/coinmarket/buy/offers/Offers/List/Quote/index.tsx
@@ -251,13 +251,19 @@ const Quote = ({ className, quote, wantCrypto }: Props) => {
                     </Left>
                 )}
                 <Right>
-                    <StyledButton
-                        isDisabled={!!quote.error}
-                        onClick={() => selectQuote(quote)}
-                        data-test="@coinmarket/buy/offers/get-this-deal-button"
-                    >
-                        <Translation id="TR_BUY_GET_THIS_OFFER" />
-                    </StyledButton>
+                    {quote.status === 'LOGIN_REQUEST' ? (
+                        <StyledButton onClick={() => selectQuote(quote)}>
+                            <Translation id="TR_LOGIN_PROCEED" />
+                        </StyledButton>
+                    ) : (
+                        <StyledButton
+                            isDisabled={!!quote.error}
+                            onClick={() => selectQuote(quote)}
+                            data-test="@coinmarket/buy/offers/get-this-deal-button"
+                        >
+                            <Translation id="TR_BUY_GET_THIS_OFFER" />
+                        </StyledButton>
+                    )}
                 </Right>
             </Main>
             <Details>

--- a/packages/suite/src/views/wallet/coinmarket/sell/offers/Offers/List/Quote/index.tsx
+++ b/packages/suite/src/views/wallet/coinmarket/sell/offers/Offers/List/Quote/index.tsx
@@ -263,15 +263,21 @@ const Quote = ({ className, quote, amountInCrypto }: Props) => {
                     </Left>
                 )}
                 <Right>
-                    <StyledButton isDisabled={!!quote.error} onClick={() => selectQuote(quote)}>
-                        <Translation
-                            id={
-                                needToRegisterOrVerifyBankAccount(quote)
-                                    ? 'TR_SELL_REGISTER'
-                                    : 'TR_SELL_GET_THIS_OFFER'
-                            }
-                        />
-                    </StyledButton>
+                    {quote.status === 'LOGIN_REQUEST' ? (
+                        <StyledButton onClick={() => selectQuote(quote)}>
+                            <Translation id="TR_LOGIN_PROCEED" />
+                        </StyledButton>
+                    ) : (
+                        <StyledButton isDisabled={!!quote.error} onClick={() => selectQuote(quote)}>
+                            <Translation
+                                id={
+                                    needToRegisterOrVerifyBankAccount(quote)
+                                        ? 'TR_SELL_REGISTER'
+                                        : 'TR_SELL_GET_THIS_OFFER'
+                                }
+                            />
+                        </StyledButton>
+                    )}
                 </Right>
             </Main>
             <Details>


### PR DESCRIPTION
This PR fixes an edge case in buy and sell crypto. When the user is registering at the partner site and the registration process is unfinished (for example by user going back to the Suite), the parter is returning error that the registration must be finished before the user can continue. Unfortunately the quote had a disabled button `Get this deal` in this case, which left the user without any simple mean how to resolve the situation, see picture before the fix:

<img width="900" alt="image" src="https://user-images.githubusercontent.com/11609674/208911687-0a1f06da-e123-4825-93f3-2fed3f1925d9.png">

After the fix, there is an enabled button `Proceed`, which leads to the partner's site where the situation can be resolved.

<img width="905" alt="image" src="https://user-images.githubusercontent.com/11609674/208910978-f45c1985-cd74-412a-9741-31c57e85cc2e.png">

