### PR TITLE
feat(suite): Calculate session progress based of how much is anonymized

### DIFF
--- a/packages/suite/src/components/suite/CoinjoinStatusBar.tsx
+++ b/packages/suite/src/components/suite/CoinjoinStatusBar.tsx
@@ -10,12 +10,13 @@ import { selectDevice } from '@suite-actions/suiteActions';
 import { goto } from '@suite-actions/routerActions';
 import { useSelector } from '@suite-hooks/useSelector';
 import { STATUS as DiscoveryStatus } from '@wallet-actions/constants/discoveryConstants';
-import { calculateSessionProgress, getPhaseTimerFormat } from '@wallet-utils/coinjoinUtils';
+import { getPhaseTimerFormat } from '@wallet-utils/coinjoinUtils';
 import { selectRouterParams } from '@suite-reducers/routerReducer';
 import { CountdownTimer } from './CountdownTimer';
 import { WalletLabeling } from './Labeling';
 import { ProgressPie } from './ProgressPie';
 import { Translation } from './Translation';
+import { selectSessionProgressByAccountKey } from '@wallet-reducers/coinjoinReducer';
 
 const SPACING = 6;
 
@@ -63,7 +64,9 @@ export const CoinjoinStatusBar = ({ accountKey, session, isSingle }: CoinjoinSta
     const selectedDevice = useSelector(state => state.suite.device);
     const routerParams = useSelector(selectRouterParams);
     const discovery = useSelector(state => state.wallet.discovery);
-
+    const sessionProgress = useSelector(state =>
+        selectSessionProgressByAccountKey(state, accountKey),
+    );
     const dispatch = useDispatch();
 
     if (!relatedAccount) {
@@ -96,7 +99,6 @@ export const CoinjoinStatusBar = ({ accountKey, session, isSingle }: CoinjoinSta
     };
 
     const { phase, signedRounds, maxRounds, phaseDeadline, sessionDeadline, paused } = session;
-    const progress = calculateSessionProgress(signedRounds, maxRounds);
 
     const getSessionStatusMessage = () => {
         if (paused) {
@@ -131,7 +133,7 @@ export const CoinjoinStatusBar = ({ accountKey, session, isSingle }: CoinjoinSta
 
     return (
         <Container>
-            <StyledProgressPie progress={progress} />
+            <StyledProgressPie progress={sessionProgress} />
 
             <StatusText>
                 {getSessionStatusMessage()}

--- a/packages/suite/src/components/wallet/CoinjoinSummary/CoinjoinStatus.tsx
+++ b/packages/suite/src/components/wallet/CoinjoinSummary/CoinjoinStatus.tsx
@@ -15,11 +15,7 @@ import { Translation } from '@suite-components/Translation';
 import { CountdownTimer } from '@suite-components';
 
 import { COINJOIN_PHASE_MESSAGES } from '@suite-constants/coinjoin';
-import {
-    calculateSessionProgress,
-    getPhaseTimerFormat,
-    getSessionDeadlineFormat,
-} from '@wallet-utils/coinjoinUtils';
+import { getPhaseTimerFormat, getSessionDeadlineFormat } from '@wallet-utils/coinjoinUtils';
 import { useDispatch } from 'react-redux';
 import {
     pauseCoinjoinSession,
@@ -27,7 +23,10 @@ import {
     stopCoinjoinSession,
 } from '@wallet-actions/coinjoinAccountActions';
 import { useSelector } from '@suite-hooks';
-import { selectIsCoinjoinBlockedByTor } from '@wallet-reducers/coinjoinReducer';
+import {
+    selectIsCoinjoinBlockedByTor,
+    selectSessionProgressByAccountKey,
+} from '@wallet-reducers/coinjoinReducer';
 
 const Container = styled.div`
     position: relative;
@@ -153,17 +152,19 @@ interface CoinjoinStatusProps {
 }
 
 export const CoinjoinStatus = ({ session, accountKey }: CoinjoinStatusProps) => {
+    const isCoinJoinBlockedByTor = useSelector(selectIsCoinjoinBlockedByTor);
+    const sessionProgress = useSelector(state =>
+        selectSessionProgressByAccountKey(state, accountKey),
+    );
     const [isLoading, setIsLoading] = useState(false);
     const [isWheelHovered, setIsWheelHovered] = useState(false);
-    const isCoinJoinBlockedByTor = useSelector(selectIsCoinjoinBlockedByTor);
 
     const menuRef = useRef<HTMLUListElement & { close: () => void }>(null);
     const theme = useTheme();
     const dispatch = useDispatch();
 
-    const { maxRounds, signedRounds, paused, phaseDeadline, sessionDeadline, phase } = session;
+    const { paused, phaseDeadline, sessionDeadline, phase } = session;
 
-    const progress = calculateSessionProgress(signedRounds, maxRounds);
     const isPaused = !!paused;
 
     const togglePause = useCallback(async () => {
@@ -335,7 +336,7 @@ export const CoinjoinStatus = ({ session, accountKey }: CoinjoinStatusProps) => 
         <Container>
             <SessionControlsMenu alignMenu="right" items={menuItems} ref={menuRef} />
             <ProgressWheel
-                progress={progress}
+                progress={sessionProgress}
                 isPaused={isPaused}
                 isLoading={isLoading}
                 isResumeDisable={isCoinJoinBlockedByTor}

--- a/packages/suite/src/utils/wallet/coinjoinUtils.ts
+++ b/packages/suite/src/utils/wallet/coinjoinUtils.ts
@@ -258,11 +258,6 @@ export const getPhaseTimerFormat = (deadline: CoinjoinSession['phaseDeadline']) 
     return formatToUse;
 };
 
-export const calculateSessionProgress = (
-    signedRounds: CoinjoinSession['signedRounds'],
-    maxRounds: CoinjoinSession['maxRounds'],
-) => signedRounds.length / (maxRounds / 100);
-
 export const calculateServiceFee = (
     utxos: AccountUtxo[],
     coordinationFeeRate: CoinjoinStatusEvent['coordinationFeeRate'],


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Instead of indicating how many rounds have passed the progress indicators in the status bar and status secion in the wallet show the share of funds which reached the desired anonymity level
## Related Issue

Resolve [#7108](https://github.com/trezor/trezor-suite/issues/7108)

## Screenshots:

The round progress was 7/8

<img width="500" alt="Screenshot 2022-12-27 at 14 37 45" src="https://user-images.githubusercontent.com/45338719/209722808-e3efff90-4cb7-4303-a370-f0eb4ab812b4.png">
<img width="500" alt="Screenshot 2022-12-27 at 14 45 13" src="https://user-images.githubusercontent.com/45338719/209722810-d7d878b4-547c-4bd1-984a-c22fef56765c.png">
