### PR TITLE
Feat: tor status management and user notification

### DIFF
--- a/packages/components/src/components/Image/images.ts
+++ b/packages/components/src/components/Image/images.ts
@@ -58,8 +58,6 @@ export const PNG_IMAGES = {
     UNDERSTAND_2x: 'Understand@2x.png',
     WALLET: 'Wallet.png',
     WALLET_2x: 'Wallet@2x.png',
-    TOR_ENABLING: 'TorEnabling.png',
-    TOR_ENABLING_2x: 'TorEnabling@2x.png',
     COINJOIN_MESS: 'CoinjoinMess.png',
     DONT_DISCONNECT_T: 'DontDisconnectT.png',
     DONT_DISCONNECT_T_2x: 'DontDisconnectT@2x.png',

--- a/packages/request-manager/src/events/bootstrap.ts
+++ b/packages/request-manager/src/events/bootstrap.ts
@@ -21,12 +21,15 @@ export const bootstrapParser = (message: string): BootstrapEvent[] => {
     return clientStatusGroups.map(clientStatus => {
         const clientStatusParsed = statusParser(clientStatus);
         return {
+            type: 'progress',
             progress: clientStatusParsed?.groups?.progress ?? '',
             summary: clientStatusParsed?.groups?.summary ?? '',
         };
     });
 };
 
-export enum BootstrapEventProgress {
-    Done = '100',
-}
+export const BOOTSTRAP_EVENT_PROGRESS = {
+    ConnectingToRelay: '5',
+    Done: '100',
+} as const;
+export type BootstrapEventProgress = keyof typeof BOOTSTRAP_EVENT_PROGRESS;

--- a/packages/request-manager/src/httpPool.ts
+++ b/packages/request-manager/src/httpPool.ts
@@ -1,0 +1,73 @@
+import http from 'http';
+import { getWeakRandomId } from '@trezor/utils';
+import { InterceptorOptions } from './types';
+
+interface RequestData {
+    id: string;
+    requestTime: number;
+    host: string;
+}
+
+export class RequestPool {
+    requestPool: RequestData[] = [];
+    requestTimeoutLimit = 1000 * 10;
+    isNetworkMisbehaving = false;
+    interceptorOptions: InterceptorOptions;
+
+    constructor(interceptorOptions: InterceptorOptions) {
+        this.interceptorOptions = interceptorOptions;
+    }
+
+    removeRequest(id: string) {
+        this.requestPool = this.requestPool.filter(req => req.id !== id);
+    }
+
+    addRequest(request: http.ClientRequest) {
+        const id = getWeakRandomId(10);
+        const { host } = request;
+        this.requestPool.push({
+            id,
+            requestTime: new Date().getTime(),
+            host,
+        });
+        request.on('response', (response: http.IncomingMessage) => {
+            const requestFromPool = this.requestPool.find(req => req.id === id);
+            if (requestFromPool) {
+                const timeRequestTook = new Date().getTime() - requestFromPool.requestTime;
+                const { statusCode } = response;
+
+                this.isNetworkMisbehaving = timeRequestTook > this.requestTimeoutLimit;
+                if (this.isNetworkMisbehaving) {
+                    this.interceptorOptions.handler({
+                        type: 'NETWORK_MISBEHAVING',
+                    });
+                }
+                this.interceptorOptions.handler({
+                    type: 'INTERCEPTED_RESPONSE',
+                    host: requestFromPool.host,
+                    time: timeRequestTook,
+                    statusCode,
+                });
+                this.removeRequest(id);
+            }
+        });
+
+        request.on('error', (error: Error) => {
+            const isProxyConnectionTimedout = error.message.includes('Proxy connection timed out');
+            const isProxyRejectedConnection = error.message.includes(
+                'Socks5 proxy rejected connection',
+            );
+            let errorType: 'ERROR' | 'ERROR_PROXY_TIMEOUT' | 'ERROR_PROXY_REJECTED' = 'ERROR';
+            if (isProxyConnectionTimedout) {
+                errorType = 'ERROR_PROXY_TIMEOUT';
+            } else if (isProxyRejectedConnection) {
+                errorType = 'ERROR_PROXY_REJECTED';
+            }
+
+            this.interceptorOptions.handler({
+                type: errorType,
+            });
+            this.removeRequest(id);
+        });
+    }
+}

--- a/packages/request-manager/src/index.ts
+++ b/packages/request-manager/src/index.ts
@@ -1,4 +1,5 @@
 export { TorController } from './controller';
 export { createInterceptor } from './interceptor';
-export type { InterceptedEvent } from './types';
+export type { InterceptedEvent, BootstrapEvent, TorControllerStatus } from './types';
+export { TOR_CONTROLLER_STATUS } from './types';
 export { TorIdentities } from './torIdentities';

--- a/packages/request-manager/src/interceptor.ts
+++ b/packages/request-manager/src/interceptor.ts
@@ -2,14 +2,9 @@ import net from 'net';
 import http from 'http';
 import https from 'https';
 import tls from 'tls';
-import { InterceptedEvent } from './types';
 import { TorIdentities } from './torIdentities';
-
-type InterceptorOptions = {
-    handler: (event: InterceptedEvent) => void;
-    getIsTorEnabled: () => boolean;
-    isDevEnv?: boolean;
-};
+import { InterceptorOptions } from './types';
+import { RequestPool } from './httpPool';
 
 const getIdentityName = (proxyAuthorization?: http.OutgoingHttpHeader) => {
     let identity;
@@ -65,6 +60,7 @@ const interceptNetSocketConnect = (interceptorOptions: InterceptorOptions) => {
         }
 
         interceptorOptions.handler({
+            type: 'INTERCEPTED_REQUEST',
             method: 'net.Socket.connect',
             details,
         });
@@ -79,6 +75,7 @@ const interceptNetConnect = (interceptorOptions: InterceptorOptions) => {
     net.connect = function (...args) {
         const [connectArguments] = args;
         interceptorOptions.handler({
+            type: 'INTERCEPTED_REQUEST',
             method: 'net.connect',
             details: (connectArguments as any).host,
         });
@@ -114,6 +111,7 @@ const overloadHttpRequest = (
         if (!isTorEnabled && overloadedOptions.agent) {
             if (interceptorOptions.isDevEnv) {
                 interceptorOptions.handler({
+                    type: 'INTERCEPTED_REQUEST',
                     method: 'http.request',
                     details: `Conditionally allowed request with Proxy-Authorization ${requestedUrl}`,
                 });
@@ -121,6 +119,7 @@ const overloadHttpRequest = (
                 delete overloadedOptions.agent;
             } else {
                 interceptorOptions.handler({
+                    type: 'INTERCEPTED_REQUEST',
                     method: 'http.request',
                     details: `Request blocked ${requestedUrl}`,
                 });
@@ -134,6 +133,7 @@ const overloadHttpRequest = (
         }
 
         interceptorOptions.handler({
+            type: 'INTERCEPTED_REQUEST',
             method: 'http.request',
             details: `${requestedUrl} with agent ${!!overloadedOptions.agent}`,
         });
@@ -149,7 +149,9 @@ const interceptHttp = (interceptorOptions: InterceptorOptions, requestPool: Requ
     http.request = (...args) => {
         const overload = overloadHttpRequest(interceptorOptions, ...args);
         if (overload) {
-            return originalHttpRequest(...overload);
+            const request = originalHttpRequest(...overload);
+            requestPool.addRequest(request);
+            return request;
         }
 
         // In cases that are not considered above we pass the args as they came.
@@ -163,7 +165,9 @@ const interceptHttps = (interceptorOptions: InterceptorOptions, requestPool: Req
     https.request = (...args) => {
         const overload = overloadHttpRequest(interceptorOptions, ...args);
         if (overload) {
-            return originalHttpsRequest(...overload);
+            const request = originalHttpsRequest(...overload);
+            requestPool.addRequest(request);
+            return request;
         }
 
         // In cases that are not considered above we pass the args as they came.
@@ -176,16 +180,23 @@ const interceptTlsConnect = (interceptorOptions: InterceptorOptions) => {
 
     tls.connect = function (...args) {
         const [options] = args as any;
-        interceptorOptions.handler({ method: 'tls.connect', details: options.servername });
+        interceptorOptions.handler({
+            type: 'INTERCEPTED_REQUEST',
+            method: 'tls.connect',
+            details: options.servername,
+        });
         // @ts-expect-error
         return originalTlsConnect.apply(this, args);
     };
 };
 
 export const createInterceptor = (interceptorOptions: InterceptorOptions) => {
+    const requestPool = new RequestPool(interceptorOptions);
     interceptNetSocketConnect(interceptorOptions);
     interceptNetConnect(interceptorOptions);
-    interceptHttp(interceptorOptions);
-    interceptHttps(interceptorOptions);
+    interceptHttp(interceptorOptions, requestPool);
+    interceptHttps(interceptorOptions, requestPool);
     interceptTlsConnect(interceptorOptions);
+
+    return { requestPool };
 };

--- a/packages/request-manager/src/interceptor.ts
+++ b/packages/request-manager/src/interceptor.ts
@@ -143,7 +143,7 @@ const overloadHttpRequest = (
     }
 };
 
-const interceptHttp = (interceptorOptions: InterceptorOptions) => {
+const interceptHttp = (interceptorOptions: InterceptorOptions, requestPool: RequestPool) => {
     const originalHttpRequest = http.request;
 
     http.request = (...args) => {
@@ -157,7 +157,7 @@ const interceptHttp = (interceptorOptions: InterceptorOptions) => {
     };
 };
 
-const interceptHttps = (interceptorOptions: InterceptorOptions) => {
+const interceptHttps = (interceptorOptions: InterceptorOptions, requestPool: RequestPool) => {
     const originalHttpsRequest = https.request;
 
     https.request = (...args) => {

--- a/packages/request-manager/src/types.ts
+++ b/packages/request-manager/src/types.ts
@@ -39,3 +39,10 @@ export type InterceptorOptions = {
     getIsTorEnabled: () => boolean;
     isDevEnv?: boolean;
 };
+
+export const TOR_CONTROLLER_STATUS = {
+    Bootstrapping: 'Bootstrapping',
+    Stopped: 'Stopped',
+    CircuitEstablished: 'CircuitEstablished',
+} as const;
+export type TorControllerStatus = keyof typeof TOR_CONTROLLER_STATUS;

--- a/packages/request-manager/src/types.ts
+++ b/packages/request-manager/src/types.ts
@@ -5,12 +5,37 @@ export interface TorConnectionOptions {
     torDataDir: string;
 }
 
-export type BootstrapEvent = {
-    progress: string | undefined;
-    summary: string | undefined;
-};
+export type BootstrapEvent =
+    | {
+          type: 'slow';
+      }
+    | {
+          type: 'progress';
+          progress: string;
+          summary?: string;
+      };
 
-export interface InterceptedEvent {
-    method: string;
-    details: string;
-}
+export type InterceptedEvent =
+    | {
+          type: 'INTERCEPTED_REQUEST';
+          method: string;
+          details: string;
+      }
+    | {
+          type: 'INTERCEPTED_RESPONSE';
+          host: string;
+          time: number;
+          statusCode: number | undefined;
+      }
+    | {
+          type: 'NETWORK_MISBEHAVING';
+      }
+    | {
+          type: 'ERROR' | 'ERROR_PROXY_TIMEOUT' | 'ERROR_PROXY_REJECTED';
+      };
+
+export type InterceptorOptions = {
+    handler: (event: InterceptedEvent) => void;
+    getIsTorEnabled: () => boolean;
+    isDevEnv?: boolean;
+};

--- a/packages/suite-desktop-api/src/api.ts
+++ b/packages/suite-desktop-api/src/api.ts
@@ -10,6 +10,7 @@ import {
     InvokeResult,
     BootstrapTorEvent,
     HandshakeTorModule,
+    TorStatusEvent,
 } from './messages';
 
 // Event messages from renderer to main process
@@ -48,7 +49,7 @@ export interface RendererChannels {
     'spend/message': Partial<MessageEvent>;
 
     // tor
-    'tor/status': boolean;
+    'tor/status': TorStatusEvent;
     'tor/bootstrap': BootstrapTorEvent;
 
     // custom protocol

--- a/packages/suite-desktop-api/src/enums.ts
+++ b/packages/suite-desktop-api/src/enums.ts
@@ -1,0 +1,8 @@
+export enum TorStatus {
+    Enabled = 'Enabled',
+    Disabled = 'Disabled',
+    Disabling = 'Disabling',
+    Enabling = 'Enabling',
+    Error = 'Error',
+    Misbehaving = 'Misbehaving',
+}

--- a/packages/suite-desktop-api/src/main.ts
+++ b/packages/suite-desktop-api/src/main.ts
@@ -17,4 +17,6 @@ export type {
     HandshakeElectron,
     HandshakeEvent,
     BootstrapTorEvent,
+    TorStatusEventType,
+    TorStatusEvent,
 } from './messages';

--- a/packages/suite-desktop-api/src/main.ts
+++ b/packages/suite-desktop-api/src/main.ts
@@ -17,6 +17,8 @@ export type {
     HandshakeElectron,
     HandshakeEvent,
     BootstrapTorEvent,
-    TorStatusEventType,
     TorStatusEvent,
+    HandshakeTorModule,
 } from './messages';
+
+export { TorStatus } from './enums';

--- a/packages/suite-desktop-api/src/messages.ts
+++ b/packages/suite-desktop-api/src/messages.ts
@@ -2,7 +2,25 @@ import { ExtractUndefined } from './methods';
 
 export type SuiteThemeVariant = 'light' | 'dark' | 'system';
 
+export const TOR_STATUS_EVENT_TYPE = {
+    Enabled: 'Enabled',
+    Disabled: 'Disabled',
+    Disabling: 'Disabling',
+    Bootstrapping: 'Bootstrapping',
+    Misbehaving: 'Misbehaving',
+    Error: 'Error',
+} as const;
+export type TorStatusEventType = keyof typeof TOR_STATUS_EVENT_TYPE;
+
+export type TorStatusEvent = {
+    type: TorStatusEventType;
+    message?: string;
+};
+
 export type BootstrapTorEvent =
+    | {
+          type: 'slow';
+      }
     | {
           type: 'progress';
           summary: string;

--- a/packages/suite-desktop-api/src/messages.ts
+++ b/packages/suite-desktop-api/src/messages.ts
@@ -1,19 +1,10 @@
+import { TorStatus } from './enums';
 import { ExtractUndefined } from './methods';
 
 export type SuiteThemeVariant = 'light' | 'dark' | 'system';
 
-export const TOR_STATUS_EVENT_TYPE = {
-    Enabled: 'Enabled',
-    Disabled: 'Disabled',
-    Disabling: 'Disabling',
-    Bootstrapping: 'Bootstrapping',
-    Misbehaving: 'Misbehaving',
-    Error: 'Error',
-} as const;
-export type TorStatusEventType = keyof typeof TOR_STATUS_EVENT_TYPE;
-
 export type TorStatusEvent = {
-    type: TorStatusEventType;
+    type: TorStatus;
     message?: string;
 };
 

--- a/packages/suite-desktop-ui/src/support/screens/TorLoadingScreen.tsx
+++ b/packages/suite-desktop-ui/src/support/screens/TorLoadingScreen.tsx
@@ -1,12 +1,11 @@
-import React, { useState, useEffect } from 'react';
+import React from 'react';
 
 import styled from 'styled-components';
 import { ThemeProvider } from '@suite-support/ThemeProvider';
-import { TorStatus } from '@suite-types';
-import { Translation, TorLoader } from '@suite-components';
+import { TorLoader } from '@suite-components';
+import { useTor } from '@suite-support/useTor';
 
-import { Button, Modal } from '@trezor/components';
-import { desktopApi, BootstrapTorEvent } from '@trezor/suite-desktop-api';
+import { Modal } from '@trezor/components';
 
 const Wrapper = styled.div`
     height: 100%;
@@ -21,96 +20,17 @@ const StyledModal = styled(Modal)`
     max-width: 600px;
 `;
 
-const StyledButton = styled(Button)`
-    width: 150px;
-`;
-
 interface TorLoadingScreenProps {
     callback: (value?: unknown) => void;
 }
 
 export const TorLoadingScreen = ({ callback }: TorLoadingScreenProps) => {
-    const [torStatus, setTorStatus] = useState<TorStatus>(TorStatus.Enabling);
-    const [progress, setProgress] = useState<number>(0);
-
-    useEffect(() => {
-        desktopApi.on('tor/bootstrap', (bootstrapEvent: BootstrapTorEvent) => {
-            if (bootstrapEvent.type === 'error') {
-                setTorStatus(TorStatus.Error);
-            }
-
-            if (bootstrapEvent.type !== 'progress') {
-                return;
-            }
-
-            if (bootstrapEvent.type === 'progress' && bootstrapEvent.progress.current) {
-                setProgress(bootstrapEvent.progress.current);
-
-                if (bootstrapEvent.progress.current === bootstrapEvent.progress.total) {
-                    setTorStatus(TorStatus.Enabled);
-                    callback();
-                } else {
-                    setTorStatus(TorStatus.Enabling);
-                }
-            }
-        });
-
-        return () => desktopApi.removeAllListeners('tor/bootstrap');
-    }, [torStatus, callback]);
-
-    const tryAgain = async () => {
-        setProgress(0);
-        setTorStatus(TorStatus.Enabling);
-
-        const torLoaded = await desktopApi.toggleTor(true);
-
-        if (!torLoaded.success) {
-            setTorStatus(TorStatus.Error);
-        }
-    };
-
-    const disableTor = async () => {
-        let fakeProgress = 0;
-
-        setTorStatus(TorStatus.Disabling);
-
-        desktopApi.removeAllListeners('tor/bootstrap');
-        desktopApi.toggleTor(false);
-
-        // This is a total fake progress, otherwise it would be too fast for user.
-        await new Promise(resolve => {
-            const interval = setInterval(() => {
-                if (fakeProgress === 100) {
-                    clearInterval(interval);
-                    return resolve(null);
-                }
-
-                fakeProgress += 10;
-                setProgress(fakeProgress);
-            }, 300);
-        });
-
-        callback();
-    };
+    useTor();
 
     return (
         <ThemeProvider>
             <Wrapper data-test="@tor-loading-screen">
-                <StyledModal
-                    bottomBar={
-                        torStatus === TorStatus.Error && (
-                            <StyledButton
-                                data-test="@tor-loading-screen/try-again-button"
-                                icon="REFRESH"
-                                onClick={tryAgain}
-                            >
-                                <Translation id="TR_TRY_AGAIN" />
-                            </StyledButton>
-                        )
-                    }
-                >
-                    <TorLoader torStatus={torStatus} progress={progress} disableTor={disableTor} />
-                </StyledModal>
+                <TorLoader ModalWrapper={StyledModal} callback={callback} />
             </Wrapper>
         </ThemeProvider>
     );

--- a/packages/suite-desktop/src/modules/request-interceptor.ts
+++ b/packages/suite-desktop/src/modules/request-interceptor.ts
@@ -12,13 +12,25 @@ import { isDevEnv } from '@suite-common/suite-utils';
 
 import { Module } from './index';
 
-export const init: Module = ({ store }) => {
+export const init: Module = ({ mainWindow, store }) => {
     const { logger } = global;
 
     const options = {
         handler: (event: InterceptedEvent) => {
-            if (event.method && event.details) {
+            if (event.type === 'INTERCEPTED_REQUEST') {
                 logger.debug('request-interceptor', `${event.method} - ${event.details}`);
+            }
+            if (event.type === 'INTERCEPTED_RESPONSE') {
+                logger.debug(
+                    'request-interceptor',
+                    `request to ${event.host} took ${event.time}ms and responded with status code ${event.statusCode}`,
+                );
+            }
+            if (event.type === 'NETWORK_MISBEHAVING') {
+                logger.debug('request-interceptor', 'networks is misbehaving');
+                mainWindow.webContents.send('tor/status', {
+                    type: 'Misbehaving',
+                });
             }
         },
         getIsTorEnabled: () => store.getTorSettings().running,

--- a/packages/suite-desktop/src/modules/request-interceptor.ts
+++ b/packages/suite-desktop/src/modules/request-interceptor.ts
@@ -9,6 +9,7 @@
  */
 import { createInterceptor, InterceptedEvent } from '@trezor/request-manager';
 import { isDevEnv } from '@suite-common/suite-utils';
+import { TorStatus } from '@trezor/suite-desktop-api';
 
 import { Module } from './index';
 
@@ -29,7 +30,7 @@ export const init: Module = ({ mainWindow, store }) => {
             if (event.type === 'NETWORK_MISBEHAVING') {
                 logger.debug('request-interceptor', 'networks is misbehaving');
                 mainWindow.webContents.send('tor/status', {
-                    type: 'Misbehaving',
+                    type: TorStatus.Misbehaving,
                 });
             }
         },

--- a/packages/suite-desktop/src/modules/tor.ts
+++ b/packages/suite-desktop/src/modules/tor.ts
@@ -3,14 +3,9 @@
  */
 import { captureException } from '@sentry/electron';
 import { session } from 'electron';
-import {
-    BootstrapTorEvent,
-    HandshakeTorModule,
-    TorStatusEventType,
-    TOR_STATUS_EVENT_TYPE,
-} from 'packages/suite-desktop-api/lib/messages';
-import { BootstrapEvent } from 'packages/request-manager/lib/types';
 
+import { TorStatus, BootstrapTorEvent, HandshakeTorModule } from '@trezor/suite-desktop-api';
+import { BootstrapEvent } from '@trezor/request-manager';
 import TrezorConnect from '@trezor/connect';
 
 import { TorProcess, TorProcessStatus } from '../libs/processes/TorProcess';
@@ -55,16 +50,16 @@ const load = async ({ mainWindow, store }: Dependencies) => {
         shouldEnableTor ? { proxy: `socks://${address}` } : { proxy: '' };
 
     const handleTorProcessStatus = (status: TorProcessStatus) => {
-        let type: TorStatusEventType;
+        let type: TorStatus;
 
         if (!status.process) {
-            type = TOR_STATUS_EVENT_TYPE.Disabled;
+            type = TorStatus.Disabled;
         } else if (status.isBootstrapping) {
-            type = TOR_STATUS_EVENT_TYPE.Bootstrapping;
+            type = TorStatus.Enabling;
         } else if (status.service) {
-            type = TOR_STATUS_EVENT_TYPE.Enabled;
+            type = TorStatus.Enabled;
         } else {
-            type = TOR_STATUS_EVENT_TYPE.Disabled;
+            type = TorStatus.Disabled;
         }
         mainWindow.webContents.send('tor/status', {
             type,
@@ -123,7 +118,7 @@ const load = async ({ mainWindow, store }: Dependencies) => {
             }
         } else {
             mainWindow.webContents.send('tor/status', {
-                type: TOR_STATUS_EVENT_TYPE.Disabling,
+                type: TorStatus.Disabling,
             });
             setProxy('');
             tor.torController.stop();

--- a/packages/suite/src/actions/suite/__fixtures__/suiteActions.ts
+++ b/packages/suite/src/actions/suite/__fixtures__/suiteActions.ts
@@ -1,9 +1,9 @@
 import { DEVICE, TRANSPORT } from '@trezor/connect';
 import { SUITE, MODAL } from '@suite-actions/constants';
 import { DISCOVERY } from '@wallet-actions/constants';
-import { TorStatus } from '@suite-types';
 import * as suiteActions from '../suiteActions';
 import { notificationsActions } from '@suite-common/toast-notifications';
+import { TorStatus } from '@suite-types';
 
 const { getSuiteDevice, getConnectDevice } = global.JestMocks;
 

--- a/packages/suite/src/actions/suite/constants/suiteConstants.ts
+++ b/packages/suite/src/actions/suite/constants/suiteConstants.ts
@@ -17,6 +17,7 @@ export const SET_DEBUG_MODE = '@suite/set-debug-mode';
 export const SET_FLAG = '@suite/set-flag';
 export const ONLINE_STATUS = '@suite/online-status';
 export const TOR_STATUS = '@suite/tor-status';
+export const TOR_BOOTSTRAP = '@suite/tor-bootstrap';
 export const ONION_LINKS = '@suite/onion-links';
 export const APP_CHANGED = '@suite/app-changed';
 export const ADD_BUTTON_REQUEST = '@suite/add-button-request';

--- a/packages/suite/src/actions/suite/suiteActions.ts
+++ b/packages/suite/src/actions/suite/suiteActions.ts
@@ -1,6 +1,7 @@
 import TrezorConnect, { Device, DEVICE } from '@trezor/connect';
 import { analytics, EventType } from '@trezor/suite-analytics';
 import { desktopApi, HandshakeElectron } from '@trezor/suite-desktop-api';
+import { TorStatus } from '@suite-types';
 
 import * as comparisonUtils from '@suite-utils/comparisonUtils';
 import * as deviceUtils from '@suite-utils/device';
@@ -10,7 +11,6 @@ import { sortByTimestamp } from '@suite-utils/device';
 import { notificationsActions } from '@suite-common/toast-notifications';
 import * as modalActions from '@suite-actions/modalActions';
 import * as firmwareActions from '@firmware-actions/firmwareActions';
-import { TorBootstrap, TorStatus } from '@suite-types';
 import { SUITE, METADATA } from './constants';
 import type { Locale } from '@suite-config/languages';
 import type {
@@ -20,6 +20,7 @@ import type {
     TrezorDevice,
     ButtonRequest,
     AppState,
+    TorBootstrap,
 } from '@suite-types';
 import { DebugModeOptions, AutodetectSettings, selectTorState } from '@suite-reducers/suiteReducer';
 import type { TranslationKey } from '@suite-components/Translation/components/BaseTranslation';

--- a/packages/suite/src/components/suite/NotificationRenderer/index.tsx
+++ b/packages/suite/src/components/suite/NotificationRenderer/index.tsx
@@ -48,7 +48,8 @@ const info = (
     notification: NotificationRendererProps['notification'],
     messageId: ExtendedMessageDescriptor['id'],
     values: ExtendedMessageDescriptor['values'] = {},
-) => simple(View, notification, 'info', messageId, values);
+    icon?: NotificationViewProps['icon'],
+) => simple(View, notification, 'info', messageId, values, icon);
 
 const NotificationRenderer = ({ notification, render }: NotificationRendererProps) => {
     switch (notification.type) {
@@ -136,6 +137,14 @@ const NotificationRenderer = ({ notification, render }: NotificationRendererProp
             });
         case 'tor-toggle-error':
             return error(render, notification, notification.error);
+        case 'tor-is-slow':
+            return info(
+                render,
+                notification,
+                'TR_TOR_IS_SLOW_MESSAGE',
+                { br: () => <br /> },
+                'TOR',
+            );
         case 'coin-scheme-protocol':
             return <CoinProtocolRenderer render={render} notification={notification} />;
         case 'tx-received':

--- a/packages/suite/src/components/suite/TorLoader.tsx
+++ b/packages/suite/src/components/suite/TorLoader.tsx
@@ -1,14 +1,12 @@
 import React from 'react';
 import styled from 'styled-components';
 
-import { Button, Progress, Image, variables } from '@trezor/components';
+import { Button, Progress, Icon, variables } from '@trezor/components';
 import { TorStatus } from '@suite-types';
 import { Translation } from '@suite-components/Translation';
 
-const StyledImage = styled(Image)`
+const StyledIcon = styled(Icon)`
     margin-bottom: 28px;
-    width: auto;
-    height: 110px;
 `;
 
 const Text = styled.h2`
@@ -92,7 +90,7 @@ export const TorLoader = ({ torStatus, progress, disableTor }: TorLoaderProps) =
     return (
         <>
             <MessageWrapper>
-                <StyledImage image="TOR_ENABLING" />
+                <StyledIcon icon="TOR" size={110} />
                 <Text>
                     <Translation id={message} />
                 </Text>

--- a/packages/suite/src/components/suite/TorLoader/TorProgressBar.tsx
+++ b/packages/suite/src/components/suite/TorLoader/TorProgressBar.tsx
@@ -4,8 +4,15 @@ import styled from 'styled-components';
 import { Button, Progress, Icon, variables } from '@trezor/components';
 import { Translation } from '@suite-components/Translation';
 
-const StyledIcon = styled(Icon)`
+const IconWrapper = styled.div`
+    width: 120px;
+    height: 120px;
+    border-radius: 50%;
     margin-bottom: 28px;
+    background: ${({ theme }) => theme.BG_GREY};
+    display: flex;
+    align-items: center;
+    justify-content: center;
 `;
 
 const Text = styled.h2`
@@ -29,6 +36,7 @@ const MessageWrapper = styled.div`
 
 const MessageSlowWrapper = styled(MessageWrapper)`
     flex-direction: row;
+    margin-top: 28px;
 `;
 
 const DisableButton = styled(Button)`
@@ -64,6 +72,7 @@ const StyledProgress = styled(Progress)`
 const ProgressWrapper = styled.div`
     display: flex;
     align-items: center;
+    background: ${({ theme }) => theme.BG_GREY};
     border-radius: 8px;
     width: 100%;
     min-height: 45px;
@@ -101,7 +110,9 @@ export const TorProgressBar = ({
     return (
         <>
             <MessageWrapper>
-                <StyledIcon icon="TOR" size={110} />
+                <IconWrapper>
+                    <Icon icon="TOR" size={80} />
+                </IconWrapper>
                 <Text>
                     <Translation id={message} />
                 </Text>

--- a/packages/suite/src/components/suite/TorLoader/TorProgressBar.tsx
+++ b/packages/suite/src/components/suite/TorLoader/TorProgressBar.tsx
@@ -2,7 +2,6 @@ import React from 'react';
 import styled from 'styled-components';
 
 import { Button, Progress, Icon, variables } from '@trezor/components';
-import { TorStatus } from '@suite-types';
 import { Translation } from '@suite-components/Translation';
 
 const StyledIcon = styled(Icon)`
@@ -26,6 +25,10 @@ const MessageWrapper = styled.div`
     align-items: center;
     justify-content: center;
     margin-bottom: 28px;
+`;
+
+const MessageSlowWrapper = styled(MessageWrapper)`
+    flex-direction: row;
 `;
 
 const DisableButton = styled(Button)`
@@ -72,18 +75,26 @@ const ProgressMessage = styled.div`
     font-weight: ${variables.FONT_WEIGHT.MEDIUM};
 `;
 
-interface TorLoaderProps {
-    torStatus: TorStatus;
+interface TorProgressBarProps {
+    isTorError: boolean;
+    isTorDisabling: boolean;
+    isTorBootstrapSlow: boolean;
     progress: number;
     disableTor: () => void;
 }
 
-export const TorLoader = ({ torStatus, progress, disableTor }: TorLoaderProps) => {
+export const TorProgressBar = ({
+    isTorError,
+    isTorDisabling,
+    isTorBootstrapSlow,
+    progress,
+    disableTor,
+}: TorProgressBarProps) => {
     let message: 'TR_ENABLING_TOR' | 'TR_ENABLING_TOR_FAILED' | 'TR_DISABLING_TOR' =
         'TR_ENABLING_TOR';
-    if (torStatus === TorStatus.Error) {
+    if (isTorError) {
         message = 'TR_ENABLING_TOR_FAILED';
-    } else if (torStatus === TorStatus.Disabling) {
+    } else if (isTorDisabling) {
         message = 'TR_DISABLING_TOR';
     }
 
@@ -98,13 +109,10 @@ export const TorLoader = ({ torStatus, progress, disableTor }: TorLoaderProps) =
 
             <InfoWrapper>
                 <ProgressWrapper>
-                    <StyledProgress
-                        isRed={torStatus === TorStatus.Error}
-                        value={torStatus === TorStatus.Error ? 100 : progress}
-                    />
+                    <StyledProgress isRed={isTorError} value={isTorError ? 100 : progress} />
 
                     <ProgressMessage>
-                        {torStatus === TorStatus.Error ? (
+                        {isTorError ? (
                             <Translation id="TR_FAILED" />
                         ) : (
                             <Percentage>{progress} %</Percentage>
@@ -112,7 +120,7 @@ export const TorLoader = ({ torStatus, progress, disableTor }: TorLoaderProps) =
                     </ProgressMessage>
                 </ProgressWrapper>
 
-                {torStatus !== TorStatus.Disabling && (
+                {!isTorDisabling && (
                     <DisableButton
                         data-test="@tor-loading-screen/disable-button"
                         variant="secondary"
@@ -122,6 +130,12 @@ export const TorLoader = ({ torStatus, progress, disableTor }: TorLoaderProps) =
                     </DisableButton>
                 )}
             </InfoWrapper>
+
+            {isTorBootstrapSlow && (
+                <MessageSlowWrapper>
+                    <Translation id="TR_TOR_IS_SLOW_MESSAGE" values={{ br: () => ' ' }} />
+                </MessageSlowWrapper>
+            )}
         </>
     );
 };

--- a/packages/suite/src/components/suite/TorLoader/index.tsx
+++ b/packages/suite/src/components/suite/TorLoader/index.tsx
@@ -2,6 +2,7 @@ import React, { useState, useEffect, ComponentType } from 'react';
 
 import styled from 'styled-components';
 import { TorStatus } from '@suite-types';
+
 import { Translation } from '@suite-components';
 import { useActions, useSelector } from '@suite-hooks';
 import { selectTorState } from '@suite-reducers/suiteReducer';

--- a/packages/suite/src/components/suite/TorLoader/index.tsx
+++ b/packages/suite/src/components/suite/TorLoader/index.tsx
@@ -1,0 +1,110 @@
+import React, { useState, useEffect, ComponentType } from 'react';
+
+import styled from 'styled-components';
+import { TorStatus } from '@suite-types';
+import { Translation } from '@suite-components';
+import { useActions, useSelector } from '@suite-hooks';
+import { selectTorState } from '@suite-reducers/suiteReducer';
+import * as suiteActions from '@suite-actions/suiteActions';
+
+import { Button, ModalProps } from '@trezor/components';
+import { TorProgressBar } from './TorProgressBar';
+
+const StyledButton = styled(Button)`
+    width: 150px;
+`;
+
+interface TorLoadingScreenProps {
+    ModalWrapper: ComponentType<ModalProps>;
+    callback: (value: boolean) => void;
+}
+
+export const TorLoader = ({ callback, ModalWrapper }: TorLoadingScreenProps) => {
+    const [progress, setProgress] = useState<number>(0);
+    // We create a local `isDisabling` flag to make the fake disabling,
+    // since if we use Tor state, the information is real about the Tor state
+    // and we want to show user the fake loading feedback.
+    const [isDisabling, setIsDisabling] = useState<boolean>(false);
+    const { torBootstrap, isTorError } = useSelector(selectTorState);
+
+    const { toggleTor, updateTorStatus } = useActions({
+        toggleTor: suiteActions.toggleTor,
+        updateTorStatus: suiteActions.updateTorStatus,
+    });
+
+    useEffect(() => {
+        // When Tor is disabling there might still be some bootstrap event coming but
+        // we will ignore them since when disabling started there is no way back in this component
+        // We only relay on fakeProgress when disabling.
+        if (isDisabling) {
+            return;
+        }
+        if (progress === 100) {
+            setProgress(0);
+        }
+        if (torBootstrap && torBootstrap.current) {
+            setProgress(torBootstrap.current);
+            if (torBootstrap.current === torBootstrap.total) {
+                updateTorStatus(TorStatus.Enabled);
+                callback(true);
+            }
+        }
+    }, [progress, torBootstrap, callback, updateTorStatus, isDisabling]);
+
+    const tryAgain = async () => {
+        setProgress(0);
+        updateTorStatus(TorStatus.Enabling);
+
+        try {
+            await toggleTor(true);
+        } catch {
+            updateTorStatus(TorStatus.Error);
+        }
+    };
+
+    const disableTor = async () => {
+        setIsDisabling(true);
+        let fakeProgress = 0;
+        // We do not wait until toggleTor is done since we want to display fake progress.
+        toggleTor(false);
+
+        // This is a total fake progress, otherwise it would be too fast for user.
+        await new Promise(resolve => {
+            const interval = setInterval(() => {
+                if (fakeProgress === 100) {
+                    clearInterval(interval);
+                    return resolve(null);
+                }
+
+                fakeProgress += 10;
+                setProgress(fakeProgress);
+            }, 300);
+        });
+
+        callback(false);
+    };
+
+    return (
+        <ModalWrapper
+            bottomBar={
+                isTorError && (
+                    <StyledButton
+                        data-test="@tor-loading-screen/try-again-button"
+                        icon="REFRESH"
+                        onClick={tryAgain}
+                    >
+                        <Translation id="TR_TRY_AGAIN" />
+                    </StyledButton>
+                )
+            }
+        >
+            <TorProgressBar
+                isTorError={isTorError}
+                isTorDisabling={isDisabling}
+                isTorBootstrapSlow={!!torBootstrap?.isSlow}
+                progress={progress}
+                disableTor={disableTor}
+            />
+        </ModalWrapper>
+    );
+};

--- a/packages/suite/src/components/suite/modals/AddAccount/components/AddCoinJoinAccountButton.tsx
+++ b/packages/suite/src/components/suite/modals/AddAccount/components/AddCoinJoinAccountButton.tsx
@@ -4,13 +4,13 @@ import { useSelector, useActions } from '@suite-hooks';
 import { useDispatch } from 'react-redux';
 import { createCoinjoinAccount } from '@wallet-actions/coinjoinAccountActions';
 import { DEFAULT_TARGET_ANONYMITY } from '@suite/services/coinjoin';
+import * as suiteActions from '@suite-actions/suiteActions';
 import * as modalActions from '@suite-actions/modalActions';
 import { Account, Network, NetworkSymbol } from '@wallet-types';
 import { UnavailableCapabilities } from '@trezor/connect';
 import { AddButton } from './AddButton';
 import { isDesktop } from '@suite-utils/env';
 import { isDevEnv } from '@suite-common/suite-utils';
-import { desktopApi } from '@trezor/suite-desktop-api';
 import { Dispatch } from '@suite-types';
 import { RequestEnableTorResponse } from '@suite-components/modals/RequestEnableTor';
 import { selectTorState } from '@suite-reducers/suiteReducer';
@@ -56,7 +56,12 @@ export const AddCoinJoinAccountButton = ({ network }: AddCoinJoinAccountProps) =
     const device = useSelector(state => state.suite.device);
     const accounts = useSelector(state => state.wallet.accounts);
 
-    const action = useActions({ createCoinjoinAccount, requestEnableTorAction });
+    const action = useActions({
+        createCoinjoinAccount,
+        requestEnableTorAction,
+        toggleTor: suiteActions.toggleTor,
+    });
+
     const dispatch = useDispatch();
 
     if (!device) {
@@ -104,7 +109,7 @@ export const AddCoinJoinAccountButton = ({ network }: AddCoinJoinAccountProps) =
             }
 
             // Triggering Tor process and displaying Tor loading to give user feedback of Tor progress.
-            desktopApi.toggleTor(true);
+            action.toggleTor(true);
             const isTorLoaded = await dispatch(
                 modalActions.openDeferredModal({ type: 'tor-loading' }),
             );

--- a/packages/suite/src/components/suite/modals/TorLoading.tsx
+++ b/packages/suite/src/components/suite/modals/TorLoading.tsx
@@ -1,11 +1,7 @@
-import React, { useState, useEffect } from 'react';
+import React from 'react';
 import styled from 'styled-components';
 
-import { desktopApi, BootstrapTorEvent } from '@trezor/suite-desktop-api';
-import { Button } from '@trezor/components';
-import { TorStatus } from '@suite-types';
-import { TorLoader, Modal, Translation } from '@suite-components';
-
+import { TorLoader, Modal } from '@suite-components';
 import type { UserContextPayload } from '@suite-actions/modalActions';
 
 const SmallModal = styled(Modal)`
@@ -17,84 +13,14 @@ type RequestEnableTorProps = Omit<Extract<UserContextPayload, { type: 'tor-loadi
 };
 
 export const TorLoading = ({ onCancel, decision }: RequestEnableTorProps) => {
-    const [torStatus, setTorStatus] = useState<TorStatus>(TorStatus.Enabling);
-    const [progress, setProgress] = useState<number>(0);
-
-    useEffect(() => {
-        desktopApi.on('tor/bootstrap', (bootstrapEvent: BootstrapTorEvent) => {
-            if (bootstrapEvent.type === 'error') {
-                setTorStatus(TorStatus.Error);
-            }
-
-            if (bootstrapEvent.type !== 'progress') {
-                return;
-            }
-
-            if (bootstrapEvent.type === 'progress' && bootstrapEvent.progress.current) {
-                setProgress(bootstrapEvent.progress.current);
-
-                if (bootstrapEvent.progress.current === bootstrapEvent.progress.total) {
-                    setTorStatus(TorStatus.Enabled);
-                    decision.resolve(true);
-                } else {
-                    setTorStatus(TorStatus.Enabling);
-                }
-            }
-        });
-
-        return () => desktopApi.removeAllListeners('tor/bootstrap');
-    }, [torStatus, decision]);
-
-    const tryAgain = async () => {
-        setProgress(0);
-        setTorStatus(TorStatus.Enabling);
-
-        const torLoaded = await desktopApi.toggleTor(true);
-
-        if (!torLoaded.success) {
-            setTorStatus(TorStatus.Error);
+    const callback = (result: boolean) => {
+        if (result) {
+            decision.resolve(true);
+            return;
         }
-    };
 
-    const disableTor = async () => {
-        let fakeProgress = 0;
-
-        setTorStatus(TorStatus.Disabling);
-
-        desktopApi.removeAllListeners('tor/bootstrap');
-        desktopApi.toggleTor(false);
-
-        // This is a total fake progress, otherwise it would be too fast for user.
-        await new Promise(resolve => {
-            const interval = setInterval(() => {
-                if (fakeProgress === 100) {
-                    clearInterval(interval);
-                    return resolve(null);
-                }
-
-                fakeProgress += 10;
-                setProgress(fakeProgress);
-            }, 300);
-        });
-
-        decision.resolve(false);
         onCancel();
+        decision.resolve(false);
     };
-
-    return (
-        <>
-            <SmallModal
-                heading={<Translation id="TR_TOR_ENABLE" />}
-                bottomBar={
-                    torStatus === TorStatus.Error && (
-                        <Button icon="REFRESH" onClick={tryAgain}>
-                            <Translation id="TR_TRY_AGAIN" />
-                        </Button>
-                    )
-                }
-            >
-                <TorLoader torStatus={torStatus} progress={progress} disableTor={disableTor} />
-            </SmallModal>
-        </>
-    );
+    return <TorLoader ModalWrapper={SmallModal} callback={callback} />;
 };

--- a/packages/suite/src/reducers/suite/suiteReducer.ts
+++ b/packages/suite/src/reducers/suite/suiteReducer.ts
@@ -1,10 +1,11 @@
 import produce from 'immer';
 import { TRANSPORT, TransportInfo } from '@trezor/connect';
 import { SuiteThemeVariant } from '@trezor/suite-desktop-api';
+import { Action, TrezorDevice, Lock, TorBootstrap, TorStatus } from '@suite-types';
+
 import { variables } from '@trezor/components';
 import { SUITE, STORAGE } from '@suite-actions/constants';
 import { DISCOVERY } from '@wallet-actions/constants';
-import { Action, TrezorDevice, Lock, TorStatus, TorBootstrap } from '@suite-types';
 import type { Locale } from '@suite-config/languages';
 import { isWeb } from '@suite-utils/env';
 import { getWindowWidth } from '@trezor/env-utils';

--- a/packages/suite/src/reducers/suite/suiteReducer.ts
+++ b/packages/suite/src/reducers/suite/suiteReducer.ts
@@ -4,7 +4,7 @@ import { SuiteThemeVariant } from '@trezor/suite-desktop-api';
 import { variables } from '@trezor/components';
 import { SUITE, STORAGE } from '@suite-actions/constants';
 import { DISCOVERY } from '@wallet-actions/constants';
-import { Action, TrezorDevice, Lock, TorStatus } from '@suite-types';
+import { Action, TrezorDevice, Lock, TorStatus, TorBootstrap } from '@suite-types';
 import type { Locale } from '@suite-config/languages';
 import { isWeb } from '@suite-utils/env';
 import { getWindowWidth } from '@trezor/env-utils';
@@ -14,9 +14,9 @@ import type { OAuthServerEnvironment } from '@suite-types/metadata';
 import type { InvityServerEnvironment } from '@suite-common/invity';
 import type { CoinjoinServerEnvironment } from '@wallet-types/coinjoin';
 import { createSelector } from '@reduxjs/toolkit';
-import { getIsTorEnabled, getIsTorLoading } from '@suite-utils/tor';
 import { getDeviceModel } from '@trezor/device-utils';
 import { getStatus } from '@suite-utils/device';
+import { getIsTorEnabled, getIsTorLoading } from '@suite-utils/tor';
 
 export interface SuiteRootState {
     suite: SuiteState;
@@ -73,6 +73,7 @@ export interface SuiteSettings {
 export interface SuiteState {
     online: boolean;
     torStatus: TorStatus;
+    torBootstrap: TorBootstrap | null;
     lifecycle: SuiteLifecycle;
     transport?: Partial<TransportInfo>;
     device?: TrezorDevice;
@@ -84,6 +85,7 @@ export interface SuiteState {
 const initialState: SuiteState = {
     online: true,
     torStatus: TorStatus.Disabled,
+    torBootstrap: null,
     lifecycle: { status: 'initial' },
     locks: [],
     flags: {
@@ -205,6 +207,10 @@ const suiteReducer = (state: SuiteState = initialState, action: Action): SuiteSt
                 draft.torStatus = action.payload;
                 break;
 
+            case SUITE.TOR_BOOTSTRAP:
+                draft.torBootstrap = action.payload;
+                break;
+
             case SUITE.ONION_LINKS:
                 draft.settings.torOnionLinks = action.payload;
                 break;
@@ -241,9 +247,15 @@ const suiteReducer = (state: SuiteState = initialState, action: Action): SuiteSt
 
 export const selectTorState = createSelector(
     (state: SuiteRootState) => state.suite.torStatus,
-    torStatus => ({
+    (state: SuiteRootState) => state.suite.torBootstrap,
+    (torStatus, torBootstrap) => ({
         isTorEnabled: getIsTorEnabled(torStatus),
         isTorLoading: getIsTorLoading(torStatus),
+        isTorError: torStatus === TorStatus.Error,
+        isTorDisabling: torStatus === TorStatus.Disabling,
+        isTorDisabled: torStatus === TorStatus.Disabled,
+        isTorEnabling: torStatus === TorStatus.Enabling,
+        torBootstrap,
     }),
 );
 

--- a/packages/suite/src/support/messages.ts
+++ b/packages/suite/src/support/messages.ts
@@ -7122,6 +7122,10 @@ export default defineMessages({
         id: 'TR_DISABLING_TOR',
         defaultMessage: 'Disabling Tor',
     },
+    TR_TOR_IS_SLOW_MESSAGE: {
+        id: 'TR_TOR_IS_SLOW_MESSAGE',
+        defaultMessage: 'Tor is connecting to the network.<br></br>Hang in there.',
+    },
     TR_CUSTOM_FIRMWARE_GITHUB: {
         id: 'TR_CUSTOM_FIRMWARE_GITHUB',
         defaultMessage: 'You can find all official releases on',

--- a/packages/suite/src/support/suite/useTor.tsx
+++ b/packages/suite/src/support/suite/useTor.tsx
@@ -1,11 +1,12 @@
 import { useEffect } from 'react';
 import { desktopApi, BootstrapTorEvent, TorStatusEvent } from '@trezor/suite-desktop-api';
+import { TorStatus } from '@suite-types';
+
 import { useActions, useSelector } from '@suite-hooks';
 import { getIsTorDomain } from '@suite-utils/tor';
 import * as suiteActions from '@suite-actions/suiteActions';
 import { isWeb, isDesktop } from '@suite-utils/env';
 import { getLocationHostname } from '@trezor/env-utils';
-import { TorStatus } from '@suite-types';
 import { selectTorState } from '@suite-reducers/suiteReducer';
 import { notificationsActions } from '@suite-common/toast-notifications';
 
@@ -29,28 +30,13 @@ export const useTor = () => {
         if (isDesktop()) {
             desktopApi.on('tor/status', (newStatus: TorStatusEvent) => {
                 const { type } = newStatus;
-                switch (type) {
-                    case 'Bootstrapping':
-                        updateTorStatus(TorStatus.Enabling);
-                        break;
-                    case 'Enabled':
-                        updateTorStatus(TorStatus.Enabled);
-                        break;
-                    case 'Disabling':
-                        updateTorStatus(TorStatus.Disabling);
-                        break;
-                    case 'Disabled':
-                        updateTorStatus(TorStatus.Disabled);
-                        break;
-                    case 'Misbehaving':
-                        // When network is slow for some reason but still working we display toast message
-                        // to let the user know that it is going to take some time but it's working.
-                        addToast({
-                            type: 'tor-is-slow',
-                        });
-                        break;
-                    default:
-                        updateTorStatus(TorStatus.Error);
+                updateTorStatus(type);
+                if (type === TorStatus.Misbehaving) {
+                    // When network is slow for some reason but still working we display toast message
+                    // to let the user know that it is going to take some time but it's working.
+                    addToast({
+                        type: 'tor-is-slow',
+                    });
                 }
             });
         }

--- a/packages/suite/src/types/suite/index.ts
+++ b/packages/suite/src/types/suite/index.ts
@@ -102,14 +102,7 @@ export type ForegroundAppProps = {
 
 export type ToastNotificationVariant = 'success' | 'info' | 'warning' | 'error' | 'transparent';
 
-export enum TorStatus {
-    Disabled = 'Disabled',
-    Enabling = 'Enabling',
-    Disabling = 'Disabling',
-    Enabled = 'Enabled',
-    Error = 'Error',
-}
-
+export { TorStatus } from '@trezor/suite-desktop-api/src/enums';
 export interface TorBootstrap {
     current: number;
     total: number;

--- a/packages/suite/src/types/suite/index.ts
+++ b/packages/suite/src/types/suite/index.ts
@@ -110,6 +110,12 @@ export enum TorStatus {
     Error = 'Error',
 }
 
+export interface TorBootstrap {
+    current: number;
+    total: number;
+    isSlow?: boolean;
+}
+
 export enum FirmwareType {
     BitcoinOnly = 'Bitcoin-only',
     Universal = 'Universal',

--- a/suite-common/toast-notifications/src/types.ts
+++ b/suite-common/toast-notifications/src/types.ts
@@ -115,6 +115,9 @@ export type ToastPayload = (
           type: 'tor-toggle-error';
           error: TranslationKey;
       }
+    | {
+          type: 'tor-is-slow';
+      }
 ) &
     NotificationOptions;
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
This PR introduces improvements in Tor status management:
* Request-manager -> The httpPool allow us to intercept http responses and track time they took and based on that get notification that Tor requests are being slow but they are still working
* Request-manager -> Not it is able to provide more accurate information of the Tor status
* Suite-desktop -> Tor module with Tor process are providing status information directly from Tor controller to the renderer
* Suite -> Not useTor is the hook that mainly modify Tor status directly from events from Tor module
* Suite -> Tor loaders logic is now unified in one component and it takes all state logic from redurcers directly instead of relying on its own local component state.


## Related Issue

Resolve https://github.com/trezor/trezor-suite/issues/7004  
Resolve https://github.com/trezor/trezor-suite/issues/6843

## Screenshots:

![image](https://user-images.githubusercontent.com/5362163/211994810-826c1d72-090c-49ad-95bc-e4c990775928.png)



