### PR TITLE
Feature/eth acc with tokens

### DIFF
--- a/packages/suite-analytics/src/constants.ts
+++ b/packages/suite-analytics/src/constants.ts
@@ -26,6 +26,7 @@ export enum EventType {
     CreateBackup = 'create-backup',
 
     AccountsStatus = 'accounts/status',
+    AccountsTokensStatus = 'accounts/tokens-status',
     AccountsNonZeroBalance = 'accounts/non-zero-balance',
     AccountsNewAccount = 'accounts/new-account',
     AddToken = 'add-token',

--- a/packages/suite-analytics/src/types/events.ts
+++ b/packages/suite-analytics/src/types/events.ts
@@ -102,6 +102,12 @@ export type SuiteAnalyticsEvent =
           };
       }
     | {
+          type: EventType.AccountsTokensStatus;
+          payload: {
+              [key: string]: number;
+          };
+      }
+    | {
           type: EventType.AccountsNewAccount;
           payload: {
               type: string;

--- a/packages/suite/src/middlewares/suite/analyticsMiddleware.ts
+++ b/packages/suite/src/middlewares/suite/analyticsMiddleware.ts
@@ -105,7 +105,15 @@ const analyticsMiddleware =
                     }, {});
 
                 const accountsWithNonZeroBalance = state.wallet.accounts
-                    .filter(account => new BigNumber(account.balance).gt(0))
+                    .filter(
+                        account =>
+                            new BigNumber(account.balance).gt(0) ||
+                            new BigNumber(
+                                (account.tokens || []).filter(token =>
+                                    new BigNumber(token.balance || 0).gt(0),
+                                ).length,
+                            ).gt(0),
+                    )
                     .reduce((acc: { [key: string]: number }, obj) => {
                         const id = `${obj.symbol}_${obj.accountType}`;
                         acc[id] = (acc[id] || 0) + 1;

--- a/packages/suite/src/middlewares/suite/analyticsMiddleware.ts
+++ b/packages/suite/src/middlewares/suite/analyticsMiddleware.ts
@@ -112,6 +112,13 @@ const analyticsMiddleware =
                         return acc;
                     }, {});
 
+                const accountsWithTokens = state.wallet.accounts
+                    .filter(account => new BigNumber((account.tokens || []).length).gt(0))
+                    .reduce((acc: { [key: string]: number }, obj) => {
+                        acc[obj.symbol] = (acc[obj.symbol] || 0) + 1;
+                        return acc;
+                    }, {});
+
                 analytics.report({
                     type: EventType.AccountsStatus,
                     payload: { ...accountsWithTransactions },
@@ -120,6 +127,11 @@ const analyticsMiddleware =
                 analytics.report({
                     type: EventType.AccountsNonZeroBalance,
                     payload: { ...accountsWithNonZeroBalance },
+                });
+
+                analytics.report({
+                    type: EventType.AccountsTokensStatus,
+                    payload: { ...accountsWithTokens },
                 });
                 break;
             }

--- a/packages/suite/src/utils/suite/__fixtures__/anchor.ts
+++ b/packages/suite/src/utils/suite/__fixtures__/anchor.ts
@@ -1,0 +1,51 @@
+import { testMocks } from '@suite-common/test-utils';
+
+export const findAnchorTransactionPage = [
+    {
+        testName: 'no anchor',
+        transactions: [
+            testMocks.getWalletTransaction({
+                txid: 'txid1',
+                symbol: 'btc',
+            }),
+            testMocks.getWalletTransaction({
+                txid: 'txid2',
+                symbol: 'btc',
+            }),
+        ],
+        transactionsPerPage: 1,
+        result: 1,
+    },
+    {
+        testName: 'tx on page 2',
+        transactions: [
+            testMocks.getWalletTransaction({
+                txid: 'txid1',
+                symbol: 'btc',
+            }),
+            testMocks.getWalletTransaction({
+                txid: 'txid2',
+                symbol: 'btc',
+            }),
+        ],
+        transactionsPerPage: 1,
+        anchor: '@account/transaction/txid2',
+        result: 2,
+    },
+    {
+        testName: 'tx not found',
+        transactions: [
+            testMocks.getWalletTransaction({
+                txid: 'txid1',
+                symbol: 'btc',
+            }),
+            testMocks.getWalletTransaction({
+                txid: 'txid2',
+                symbol: 'btc',
+            }),
+        ],
+        transactionsPerPage: 1,
+        anchor: '@account/transaction/txid3',
+        result: 1,
+    },
+];

--- a/packages/suite/src/utils/suite/__tests__/anchor.test.ts
+++ b/packages/suite/src/utils/suite/__tests__/anchor.test.ts
@@ -1,7 +1,20 @@
 import * as anchorUtils from '../anchor';
+import * as fixtures from '../__fixtures__/anchor';
 
 describe('anchor utils', () => {
     test('getDefaultBackendType', () => {
         expect(anchorUtils.getTxAnchor('txid')).toBe('@account/transaction/txid');
+    });
+
+    fixtures.findAnchorTransactionPage.forEach(f => {
+        it(`findAnchorTransactionPage ${f.testName}`, () => {
+            expect(
+                anchorUtils.findAnchorTransactionPage(
+                    f.transactions,
+                    f.transactionsPerPage,
+                    f.anchor,
+                ),
+            ).toEqual(f.result);
+        });
     });
 });


### PR DESCRIPTION
## Description

- track how many accounts of each coin have token history `accounts/tokens-status`
- use also token balance for `accounts/non-zero-balance` event 

https://www.notion.so/satoshilabs/c63bdab01b704b099cab3bbb3227e1b1?v=406d107d6d584577a47d7580e8b2df89&p=25b286a743374a5291caf17f52169dcd&pm=s

## Related Issue

closes #6264

## Screenshots:
<img width="345" alt="210250172-bd77cde5-04ec-4d01-9291-6902a641d43f" src="https://user-images.githubusercontent.com/33235762/210254324-4d37acce-2eef-4bc3-b970-ab17476ef5cc.png">
