### PR TITLE
feat(analytics): track usage of uri handler

### DIFF
--- a/packages/suite-analytics/src/constants.ts
+++ b/packages/suite-analytics/src/constants.ts
@@ -15,6 +15,8 @@ export enum EventType {
     TransportType = 'transport-type',
     AppUpdate = 'app-update',
 
+    AppUriHandler = 'app/uri-handler',
+
     DeviceConnect = 'device-connect',
     DeviceDisconnect = 'device-disconnect',
     DeviceUpdateFirmware = 'device-update-firmware',

--- a/packages/suite-analytics/src/types/events.ts
+++ b/packages/suite-analytics/src/types/events.ts
@@ -45,6 +45,13 @@ export type SuiteAnalyticsEvent =
           payload: AppUpdateEvent;
       }
     | {
+          type: EventType.AppUriHandler;
+          payload: {
+              scheme: string;
+              isAmountPresent: boolean;
+          };
+      }
+    | {
           type: EventType.DeviceConnect;
           payload: {
               mode: 'normal' | 'bootloader' | 'initialize' | 'seedless';

--- a/packages/suite/src/utils/suite/protocol.ts
+++ b/packages/suite/src/utils/suite/protocol.ts
@@ -1,5 +1,6 @@
 import { PROTOCOL_SCHEME } from '@suite-constants/protocol';
 import { parseQuery, parseUri } from './parseUri';
+import { analytics, EventType } from '@trezor/suite-analytics';
 
 export type CoinProtocolInfo = {
     scheme: PROTOCOL_SCHEME;
@@ -23,6 +24,14 @@ export const getProtocolInfo = (uri: string): CoinProtocolInfo | null => {
             if (!pathname && !host) return null; // address may be in pathname (regular bitcoin:addr) or host (bitcoin://addr)
             const floatAmount = Number.parseFloat(params.amount ?? '');
             const amount = !Number.isNaN(floatAmount) && floatAmount > 0 ? floatAmount : undefined;
+
+            analytics.report({
+                type: EventType.AppUriHandler,
+                payload: {
+                    scheme,
+                    isAmountPresent: amount !== undefined,
+                },
+            });
 
             return {
                 scheme,


### PR DESCRIPTION
## Description

- track usage of uri handlers
- only possible if `address` is specified, otherwise it is not propagated to renderer
- track `scheme` and if `amount` is defined, `address` always is 🔝 

https://www.notion.so/satoshilabs/c63bdab01b704b099cab3bbb3227e1b1?v=406d107d6d584577a47d7580e8b2df89&p=70f48fecacc340d082d77a1315347394&pm=s

## Related Issue

closes #6187

## Screenshots:

<img width="601" alt="Screenshot 2023-01-02 at 18 08 25" src="https://user-images.githubusercontent.com/33235762/210261585-c540ec26-c4b2-4809-a268-2445a16e2603.png">
<img width="597" alt="Screenshot 2023-01-02 at 18 08 33" src="https://user-images.githubusercontent.com/33235762/210261586-83a293f3-8cf8-419b-a818-98b238d786ac.png">

