### PR TITLE
feat(suite): display round skip chance correctly

### DIFF
--- a/packages/suite/src/support/messages.ts
+++ b/packages/suite/src/support/messages.ts
@@ -7266,11 +7266,6 @@ export default defineMessages({
         description: 'Max number of coinjoin rounds',
         defaultMessage: 'max {rounds}',
     },
-    TR_SKIP_ROUNDS_VALUE: {
-        id: 'TR_SKIP_ROUNDS_VALUE',
-        description: 'Average ratio of skipped coinjoin rounds',
-        defaultMessage: 'avg. {part} out of {total}',
-    },
     TR_NONE: {
         id: 'TR_NONE',
         description: 'Skipped coinjoin rounds',
@@ -7693,5 +7688,9 @@ export default defineMessages({
     TR_ALL_FUNDS_ANONYMIZED: {
         id: 'TR_ALL_FUNDS_ANONYMIZED',
         defaultMessage: 'All funds private',
+    },
+    TR_SKIP_ROUNDS_CHANCE: {
+        id: 'TR_SKIP_ROUNDS_CHANCE',
+        defaultMessage: '{value}% chance',
     },
 });

--- a/packages/suite/src/views/wallet/anonymize/components/CoinjoinSessionDetail.tsx
+++ b/packages/suite/src/views/wallet/anonymize/components/CoinjoinSessionDetail.tsx
@@ -34,6 +34,10 @@ export const CoinjoinSessionDetail = ({
     const minEstimatedTime = Math.floor(estimatedTime - timeBuffer);
     const maxMiningFeeValue = `${maxFee} sat/vB`;
 
+    const skippingChance = skipRounds
+        ? Math.round((1 - skipRounds[0] / skipRounds[1]) * 100)
+        : undefined;
+
     return (
         <dl>
             <DetailRow
@@ -53,10 +57,10 @@ export const CoinjoinSessionDetail = ({
             <DetailRow
                 term={<Translation id="TR_SKIP_ROUNDS" />}
                 value={
-                    skipRounds ? (
+                    skippingChance ? (
                         <Translation
-                            id="TR_SKIP_ROUNDS_VALUE"
-                            values={{ part: skipRounds[0], total: skipRounds[1] }}
+                            id="TR_SKIP_ROUNDS_CHANCE"
+                            values={{ value: skippingChance }}
                         />
                     ) : (
                         <Translation id="TR_NONE" />


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Previously the value for "skip rounds" on the coinjoin setup screen was confusing and didn't properly explain what was goin on. Not anymore.

## Screenshots:

<img width="689" alt="image" src="https://user-images.githubusercontent.com/45338719/210261770-5806e663-5221-4e9c-b83c-9ae0395f01db.png">

