### PR TITLE
feat(analytics): coin control usage analytics

### DIFF
--- a/packages/suite-analytics/src/types/events.ts
+++ b/packages/suite-analytics/src/types/events.ts
@@ -150,6 +150,8 @@ export type SuiteAnalyticsEvent =
               ethereumNonce: boolean;
               rippleDestinationTag: boolean;
               selectedFee: string;
+              isCoinControlEnabled: boolean;
+              hasCoinControlBeenOpened: boolean;
           };
       }
     | {

--- a/packages/suite/src/components/suite/modals/ReviewTransaction/components/OutputList.tsx
+++ b/packages/suite/src/components/suite/modals/ReviewTransaction/components/OutputList.tsx
@@ -103,7 +103,8 @@ const OutputList = ({
     isRbfAction,
 }: OutputListProps) => {
     const { symbol } = account;
-    const { options, selectedFee } = precomposedForm;
+    const { options, selectedFee, isCoinControlEnabled, hasCoinControlBeenOpened } =
+        precomposedForm;
     const broadcastEnabled = options.includes('broadcast');
 
     const reportTransactionCreatedEvent = (action: 'sent' | 'copied' | 'downloaded' | 'replaced') =>
@@ -124,6 +125,8 @@ const OutputList = ({
                 rippleDestinationTag: !!options.includes('rippleDestinationTag'),
                 ethereumNonce: !!options.includes('ethereumNonce'),
                 selectedFee: selectedFee || 'normal',
+                isCoinControlEnabled,
+                hasCoinControlBeenOpened,
             },
         });
 

--- a/packages/suite/src/views/wallet/send/components/Options/components/BitcoinOptions/index.tsx
+++ b/packages/suite/src/views/wallet/send/components/Options/components/BitcoinOptions/index.tsx
@@ -54,6 +54,7 @@ export const BitcoinOptions = () => {
         toggleOption,
         composeTransaction,
         resetDefaultValue,
+        setValue,
     } = useSendFormContext();
 
     const options = useWatch<FormOptions[]>({
@@ -67,7 +68,10 @@ export const BitcoinOptions = () => {
     const utxoSelectionEnabled = options.includes('utxoSelection');
     const broadcastEnabled = options.includes('broadcast');
 
-    const toggleUtxoSelection = () => toggleOption('utxoSelection');
+    const toggleUtxoSelection = () => {
+        setValue('hasCoinControlBeenOpened', true); // required for analytics
+        toggleOption('utxoSelection');
+    };
 
     return (
         <Wrapper>

--- a/suite-common/wallet-constants/src/sendForm.ts
+++ b/suite-common/wallet-constants/src/sendForm.ts
@@ -40,6 +40,7 @@ export const DEFAULT_VALUES = {
     rippleDestinationTag: '',
     outputs: [],
     isCoinControlEnabled: false,
+    hasCoinControlBeenOpened: false,
 } as const;
 
 // Time-to-live (TTL) in cardano represents a slot, or deadline by which a transaction must be submitted.

--- a/suite-common/wallet-types/src/sendForm.ts
+++ b/suite-common/wallet-types/src/sendForm.ts
@@ -42,6 +42,7 @@ export type FormState = {
     rippleDestinationTag?: string;
     rbfParams?: RbfTransactionParams;
     isCoinControlEnabled: boolean;
+    hasCoinControlBeenOpened: boolean;
     selectedUtxos: AccountUtxo[];
 };
 // local state of @wallet-hooks/useSendForm


### PR DESCRIPTION
## Description

- tracks info if user used coin control and if he at least checked his utxos
- i added `hasCoinControlBeenOpened` attribute to send form state as in my opinion, it does not make sense to create new state for it.

https://www.notion.so/satoshilabs/e19845789ccb47a0baf36d7f8463f196?v=2183c8228ebb4df38f358d1b2744e1b8&p=d4c4be9ca4504270b940292076c59672&pm=s

## Related Issue

closes #6959

## Screenshots:
No coin control
<img width="273" alt="Screenshot 2023-01-03 at 10 44 15" src="https://user-images.githubusercontent.com/33235762/210332977-850c37f6-66ad-4ff8-afb8-cc92872d5cdc.png">
Coin control open (unused)
<img width="295" alt="Screenshot 2023-01-03 at 10 52 56" src="https://user-images.githubusercontent.com/33235762/210334309-b4c8953f-d87e-4612-bed3-a9810cfff74d.png">
Coin control opened and closed (unused)
<img width="295" alt="Screenshot 2023-01-03 at 10 53 21" src="https://user-images.githubusercontent.com/33235762/210334366-6716ee66-f30b-4ebf-8d79-282ceecc22a2.png">
Coin control opened and used
<img width="383" alt="Screenshot 2023-01-03 at 10 54 16" src="https://user-images.githubusercontent.com/33235762/210334524-5f68b9f0-d221-46ae-a5ce-e25563906181.png">

EDIT: `hasCoinControlBeenEnabled` changed to `hasCoinControlBeenOpened`