### PR TITLE
feat(suite): disable coinjoin resume if something wrong

### DIFF
--- a/packages/suite/src/hooks/coinjoin/useBlockedCoinjoinResume.ts
+++ b/packages/suite/src/hooks/coinjoin/useBlockedCoinjoinResume.ts
@@ -1,0 +1,39 @@
+import { useSelector } from '@suite-hooks';
+import { selectDeviceState } from '@suite-reducers/suiteReducer';
+import { selectIsCoinjoinBlockedByTor } from '@wallet-reducers/coinjoinReducer';
+import { getIsCoinjoinOutOfSync } from '@wallet-utils/coinjoinUtils';
+
+export const useBlockedCoinjoinResume = () => {
+    const isCoinJoinBlockedByTor = useSelector(selectIsCoinjoinBlockedByTor);
+    const { selectedAccount, online } = useSelector(state => ({
+        selectedAccount: state.wallet.selectedAccount,
+        online: state.suite.online,
+    }));
+    const isAccountOutOfSync = getIsCoinjoinOutOfSync(selectedAccount);
+    const deviceStatus = useSelector(selectDeviceState);
+    const isDeviceDisconnected = deviceStatus !== 'connected';
+
+    let coinjoinResumeBlockedMessageId:
+        | 'TR_UNAVAILABLE_COINJOIN_TOR_DISABLE_TOOLTIP'
+        | 'TR_UNAVAILABLE_COINJOIN_DEVICE_DISCONNECTED'
+        | 'TR_UNAVAILABLE_COINJOIN_ACCOUNT_OUT_OF_SYNC'
+        | 'TR_UNAVAILABLE_COINJOIN_NO_INTERNET' = 'TR_UNAVAILABLE_COINJOIN_NO_INTERNET';
+
+    if (!online) {
+        coinjoinResumeBlockedMessageId = 'TR_UNAVAILABLE_COINJOIN_NO_INTERNET';
+    } else if (isCoinJoinBlockedByTor) {
+        coinjoinResumeBlockedMessageId = 'TR_UNAVAILABLE_COINJOIN_TOR_DISABLE_TOOLTIP';
+    } else if (isDeviceDisconnected) {
+        coinjoinResumeBlockedMessageId = 'TR_UNAVAILABLE_COINJOIN_DEVICE_DISCONNECTED';
+    } else if (isAccountOutOfSync) {
+        coinjoinResumeBlockedMessageId = 'TR_UNAVAILABLE_COINJOIN_ACCOUNT_OUT_OF_SYNC';
+    }
+
+    const isCoinjoinResumeBlocked =
+        isCoinJoinBlockedByTor || isDeviceDisconnected || isAccountOutOfSync || !online;
+
+    return {
+        coinjoinResumeBlockedMessageId,
+        isCoinjoinResumeBlocked,
+    };
+};

--- a/packages/suite/src/reducers/suite/suiteReducer.ts
+++ b/packages/suite/src/reducers/suite/suiteReducer.ts
@@ -16,6 +16,7 @@ import type { CoinjoinServerEnvironment } from '@wallet-types/coinjoin';
 import { createSelector } from '@reduxjs/toolkit';
 import { getIsTorEnabled, getIsTorLoading } from '@suite-utils/tor';
 import { getDeviceModel } from '@trezor/device-utils';
+import { getStatus } from '@suite-utils/device';
 
 export interface SuiteRootState {
     suite: SuiteState;
@@ -244,6 +245,11 @@ export const selectTorState = createSelector(
         isTorEnabled: getIsTorEnabled(torStatus),
         isTorLoading: getIsTorLoading(torStatus),
     }),
+);
+
+export const selectDeviceState = createSelector(
+    (state: SuiteRootState) => state.suite.device,
+    device => device && getStatus(device),
 );
 
 export const selectDebug = (state: SuiteRootState) => state.suite.settings.debug;

--- a/packages/suite/src/support/messages.ts
+++ b/packages/suite/src/support/messages.ts
@@ -3878,6 +3878,18 @@ export default defineMessages({
         id: 'TR_UNAVAILABLE_COINJOIN_TOR_DISABLE_TOOLTIP',
         defaultMessage: 'Unavailable. Tor is disabled.',
     },
+    TR_UNAVAILABLE_COINJOIN_DEVICE_DISCONNECTED: {
+        id: 'TR_UNAVAILABLE_COINJOIN_DEVICE_DISCONNECTED',
+        defaultMessage: 'Unavailable. Device is disconnected.',
+    },
+    TR_UNAVAILABLE_COINJOIN_ACCOUNT_OUT_OF_SYNC: {
+        id: 'TR_UNAVAILABLE_COINJOIN_ACCOUNT_OUT_OF_SYNC',
+        defaultMessage: 'Unavailable. Account is possibly out-of-sync.',
+    },
+    TR_UNAVAILABLE_COINJOIN_NO_INTERNET: {
+        id: 'TR_UNAVAILABLE_COINJOIN_NO_INTERNET',
+        defaultMessage: 'Unavailable. No internet connection.',
+    },
     TR_ONION_BACKEND_TOR_NEEDED: {
         id: 'TR_ONION_BACKEND_TOR_NEEDED',
         defaultMessage:

--- a/packages/suite/src/utils/wallet/coinjoinUtils.ts
+++ b/packages/suite/src/utils/wallet/coinjoinUtils.ts
@@ -1,7 +1,11 @@
 import BigNumber from 'bignumber.js';
 
 import { getUtxoOutpoint, getBip43Type } from '@suite-common/wallet-utils';
-import { Account, WalletAccountTransaction } from '@suite-common/wallet-types';
+import {
+    Account,
+    SelectedAccountStatus,
+    WalletAccountTransaction,
+} from '@suite-common/wallet-types';
 import { CoinjoinSession, CoinjoinSessionParameters } from '@wallet-types/coinjoin';
 import {
     ESTIMATED_ANONYMITY_GAINED_PER_ROUND,
@@ -280,4 +284,12 @@ export const calculateServiceFee = (
             new BigNumber(0),
         )
         .toString();
+};
+
+export const getIsCoinjoinOutOfSync = (selectedAccount: SelectedAccountStatus) => {
+    if (selectedAccount.status !== 'loaded') return true;
+    const { account } = selectedAccount;
+    if (account.backendType === 'coinjoin') {
+        return account.status === 'out-of-sync';
+    }
 };


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

User shouldn't be able to resume CoinJoin if there is some problem

    * Backend disconnected
    * No internet connection
    * No Tor connection (it was already implemented)
    * Device disconnected
    
## Related Issue

Resolve https://github.com/trezor/trezor-suite/issues/6908
