### PR TITLE
Feat: coinjoin prepending txs

### DIFF
--- a/packages/coinjoin/src/backend/CoinjoinBackend.ts
+++ b/packages/coinjoin/src/backend/CoinjoinBackend.ts
@@ -7,6 +7,7 @@ import { DISCOVERY_LOOKOUT } from '../constants';
 import { scanAccount } from './scanAccount';
 import { scanAddress } from './scanAddress';
 import { getAccountInfo } from './getAccountInfo';
+import { createPendingTransaction } from './createPendingTx';
 import { getNetwork } from '../utils/settingsUtils';
 import type { CoinjoinBackendSettings, LogEvent, Logger, LogLevel } from '../types';
 import type {
@@ -138,6 +139,10 @@ export class CoinjoinBackend extends EventEmitter {
             network: this.network,
         });
         return Promise.resolve(addressInfo);
+    }
+
+    createPendingTransaction(...args: Parameters<typeof createPendingTransaction>) {
+        return Promise.resolve(createPendingTransaction(...args));
     }
 
     cancel() {

--- a/packages/coinjoin/src/backend/createPendingTx.ts
+++ b/packages/coinjoin/src/backend/createPendingTx.ts
@@ -1,0 +1,42 @@
+import { transformTransaction } from '@trezor/blockchain-link/lib/workers/blockbook/utils';
+
+import type { BroadcastedTransactionDetails } from '../types';
+import type { Transaction, AccountAddresses } from '../types/backend';
+
+// create pending transaction, the result of successfully broadcasted CoinjoinRound
+export const createPendingTransaction = (
+    { descriptor, addresses }: { descriptor: string; addresses?: AccountAddresses },
+    txData: BroadcastedTransactionDetails,
+): Transaction => {
+    const valueIn = txData.inputs.reduce((sum, input) => sum + input.amount, 0);
+    const value = txData.outputs.reduce((sum, outputs) => sum + outputs.amount, 0);
+    const fees = valueIn - value;
+    const blockbookTx = {
+        txid: txData.txid,
+        hex: txData.hex,
+        blockHeight: -1,
+        blockTime: Math.floor(Date.now() / 1000),
+        confirmations: 0,
+        vsize: txData.vsize,
+        size: txData.size,
+        value: value.toString(),
+        valueIn: valueIn.toString(),
+        fees: fees.toString(),
+        vin: txData.inputs.map((input, n) => ({
+            txid: input.hash,
+            n,
+            vout: input.index,
+            isAddress: true,
+            addresses: [input.address],
+            value: input.amount.toString(),
+        })),
+        vout: txData.outputs.map((output, n) => ({
+            n,
+            isAddress: true,
+            addresses: [output.address],
+            value: output.amount.toString(),
+        })),
+    };
+
+    return transformTransaction(descriptor, addresses, blockbookTx);
+};

--- a/packages/coinjoin/src/client/round/transactionSigning.ts
+++ b/packages/coinjoin/src/client/round/transactionSigning.ts
@@ -40,20 +40,19 @@ const getTransactionData = (
 
     const inputs = registeredInputs
         .sort((a, b) => sortInputs(a.coin, b.coin))
-        .map(input => {
-            const { index, hash } = readOutpoint(input.coin.outpoint);
-            const internal = myInputsInRound.find(a =>
-                compareOutpoint(a.outpoint, input.coin.outpoint),
-            );
-
+        .map(({ coin, ownershipProof }) => {
+            const { index, hash } = readOutpoint(coin.outpoint);
+            const internal = myInputsInRound.find(a => compareOutpoint(a.outpoint, coin.outpoint));
+            const address = getAddressFromScriptPubKey(coin.txOut.scriptPubKey, options.network);
             return {
                 path: internal?.path,
-                outpoint: internal?.outpoint || input.coin.outpoint, // NOTE: internal outpoints are in lowercase, coordinators in uppercase
+                outpoint: internal?.outpoint || coin.outpoint, // NOTE: internal outpoints are in lowercase, coordinators in uppercase
                 hash,
                 index,
-                amount: input.coin.txOut.value,
-                scriptPubKey: prefixScriptPubKey(input.coin.txOut.scriptPubKey),
-                ownershipProof: input.ownershipProof,
+                amount: coin.txOut.value,
+                address,
+                scriptPubKey: prefixScriptPubKey(coin.txOut.scriptPubKey),
+                ownershipProof,
                 commitmentData: round.commitmentData,
             };
         });

--- a/packages/coinjoin/src/types/index.ts
+++ b/packages/coinjoin/src/types/index.ts
@@ -17,6 +17,13 @@ export interface CoinjoinClientSettings extends BaseSettings {
     middlewareUrl: string;
 }
 
+export type {
+    ScanAddressProgress,
+    ScanAddressCheckpoint,
+    ScanAccountProgress,
+    ScanAccountCheckpoint,
+} from './backend';
+
 export * from './account';
 export * from './client';
 export * from './round';

--- a/packages/coinjoin/src/types/round.ts
+++ b/packages/coinjoin/src/types/round.ts
@@ -19,26 +19,29 @@ export interface SerializedCoinjoinRound {
     addresses: AccountAddress[]; // list of addresses (outputs) used in this round in outputRegistration phase
     phaseDeadline: number; // deadline is inaccurate, phase may change earlier
     roundDeadline: number; // deadline is inaccurate,round may end earlier
+    broadcastedTxDetails?: BroadcastedTransactionDetails; // calculated from tx data and witnesses from coordinator
 }
 
 export interface CoinjoinRoundEvent {
     round: SerializedCoinjoinRound;
 }
 
-interface CoinjoinTxInputs {
+export interface CoinjoinTxInputs {
     path?: string;
     outpoint: string;
     amount: number;
     hash: string;
     index: number;
     commitmentData: string;
+    address: string;
     scriptPubKey: string;
     ownershipProof: string;
 }
 
-interface CoinjoinTxOutputs {
+export interface CoinjoinTxOutputs {
     path?: string;
     address: string;
+    scriptPubKey: string;
     amount: number;
 }
 
@@ -46,6 +49,14 @@ export interface CoinjoinTransactionData {
     inputs: CoinjoinTxInputs[];
     outputs: CoinjoinTxOutputs[];
     affiliateRequest: CoinjoinAffiliateRequest;
+}
+
+export interface BroadcastedTransactionDetails extends CoinjoinTransactionData {
+    txid: string;
+    hash: string;
+    hex: string;
+    size: number;
+    vsize: number;
 }
 
 export interface CoinjoinTransactionLiquidityClue {

--- a/packages/suite/src/actions/wallet/__fixtures__/coinjoinClientActions.ts
+++ b/packages/suite/src/actions/wallet/__fixtures__/coinjoinClientActions.ts
@@ -148,6 +148,8 @@ export const onCoinjoinRoundChanged = [
         },
         params: {
             phase: 4,
+            endRoundState: 4,
+            broadcastedTxDetails: { txid: 'abcd' },
             inputs: [{ accountKey: 'a' }],
             failed: [],
             roundDeadline: Date.now() + 1000,
@@ -155,6 +157,7 @@ export const onCoinjoinRoundChanged = [
         result: {
             actions: [
                 COINJOIN.SESSION_ROUND_CHANGED,
+                COINJOIN.SESSION_TX_BROADCASTED,
                 MODAL.OPEN_USER_CONTEXT,
                 COINJOIN.SESSION_COMPLETED,
             ],
@@ -181,6 +184,7 @@ export const onCoinjoinRoundChanged = [
         },
         params: {
             phase: 4,
+            endRoundState: 2,
             inputs: [{ accountKey: 'a' }],
             failed: [],
             roundDeadline: Date.now() + 1000,
@@ -188,6 +192,7 @@ export const onCoinjoinRoundChanged = [
         result: {
             actions: [
                 COINJOIN.SESSION_ROUND_CHANGED,
+                COINJOIN.SESSION_TX_FAILED,
                 MODAL.OPEN_USER_CONTEXT,
                 COINJOIN.SESSION_COMPLETED,
             ],
@@ -245,6 +250,8 @@ export const onCoinjoinRoundChanged = [
             },
             {
                 phase: 4,
+                endRoundState: 4,
+                broadcastedTxDetails: { txid: 'abcd' },
                 inputs: [{ accountKey: 'a' }],
                 failed: [],
                 roundDeadline: Date.now() + 1000,
@@ -259,6 +266,7 @@ export const onCoinjoinRoundChanged = [
                 COINJOIN.SESSION_ROUND_CHANGED,
                 COINJOIN.SESSION_ROUND_CHANGED,
                 MODAL.CLOSE,
+                COINJOIN.SESSION_TX_BROADCASTED,
                 MODAL.OPEN_USER_CONTEXT,
                 COINJOIN.SESSION_COMPLETED,
             ],

--- a/packages/suite/src/actions/wallet/constants/coinjoinConstants.ts
+++ b/packages/suite/src/actions/wallet/constants/coinjoinConstants.ts
@@ -16,13 +16,15 @@ export const CLIENT_ENABLE_FAILED = '@coinjoin/client-enable-failed';
 export const CLIENT_STATUS = '@coinjoin/client-status';
 export const CLIENT_SESSION_PHASE = '@coinjoin/session-phase';
 
+export const SESSION_STARTING = '@coinjoin/session-starting';
 export const SESSION_PAUSE = '@coinjoin/session-pause';
 export const SESSION_RESTORE = '@coinjoin/session-restore';
 export const SESSION_ROUND_CHANGED = '@coinjoin/session-round-changed';
 export const SESSION_COMPLETED = '@coinjoin/session-completed';
 export const SESSION_OWNERSHIP = '@coinjoin/session-ownership';
 export const SESSION_TX_SIGNED = '@coinjoin/session-tx-signed';
-export const SESSION_STARTING = '@coinjoin/session-starting';
+export const SESSION_TX_BROADCASTED = '@coinjoin/session-tx-broadcasted';
+export const SESSION_TX_FAILED = '@coinjoin/session-tx-failed';
 
 export const SET_DEBUG_SETTINGS = '@coinjoin/set-debug-settings';
 

--- a/packages/suite/src/reducers/wallet/coinjoinReducer.ts
+++ b/packages/suite/src/reducers/wallet/coinjoinReducer.ts
@@ -161,7 +161,7 @@ const updateSession = (
     }
 };
 
-const signSession = (
+const sessionTxSigned = (
     draft: CoinjoinState,
     payload: ExtractActionPayload<typeof COINJOIN.SESSION_TX_SIGNED>,
 ) => {
@@ -413,7 +413,7 @@ export const coinjoinReducer = (
                 completeSession(draft, action.payload);
                 break;
             case COINJOIN.SESSION_TX_SIGNED:
-                signSession(draft, action.payload);
+                sessionTxSigned(draft, action.payload);
                 break;
             case COINJOIN.SESSION_STARTING:
                 updateSessionStarting(draft, action.payload);

--- a/packages/suite/src/types/wallet/coinjoin.ts
+++ b/packages/suite/src/types/wallet/coinjoin.ts
@@ -4,9 +4,9 @@ import { PartialRecord } from '@trezor/type-utils';
 // @trezor/coinjoin package is meant to be imported dynamically
 // importing types is safe, but importing an enum thru index will bundle whole lib
 import { RegisterAccountParams } from '@trezor/coinjoin';
-import { RoundPhase, SessionPhase } from '@trezor/coinjoin/src/enums';
+import { RoundPhase, SessionPhase, EndRoundState } from '@trezor/coinjoin/src/enums';
 
-export { RoundPhase, SessionPhase };
+export { RoundPhase, SessionPhase, EndRoundState };
 
 export interface CoinjoinSessionParameters {
     targetAnonymity: number;

--- a/suite-common/wallet-core/src/transactions/transactionsActions.ts
+++ b/suite-common/wallet-core/src/transactions/transactionsActions.ts
@@ -36,7 +36,7 @@ const addTransaction = createAction(
         page,
         perPage,
     }: {
-        transactions: AccountTransaction[];
+        transactions: (AccountTransaction & Partial<WalletAccountTransaction>)[];
         account: Account;
         page?: number;
         perPage?: number;

--- a/suite-common/wallet-types/src/transaction.ts
+++ b/suite-common/wallet-types/src/transaction.ts
@@ -184,6 +184,10 @@ export interface WalletAccountTransaction extends AccountTransaction {
     symbol: NetworkSymbol;
     rates?: TimestampedRates['rates'];
     rbfParams?: RbfTransactionParams;
+    /**
+     * prepending txs have deadline (blockHeight) when they should be removed from UI
+     */
+    deadline?: number;
 }
 
 export interface SignTransactionData {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

hand in hand with https://github.com/trezor/trezor-suite/pull/7630

Create prepending transaction  from currently signed coinjoin transaction (broadcasted by coordinator)

## Changes

- `CoinjoinClient` optionally returns `BroadcastedTransactionDetails` (if transaction was broadcasted successfully)  with data required to create prepending transaction.

- `CoinjoinBackend.createPendingTransaction` creates prepending transaction from tx data.

- `suite` dispatches two new actions: `SESSION_TX_BROADCASTED` and `SESSION_TX_FAILED` (could be used in the future to catch and report to analytics)

- `coinjoinMiddleware` catches  `SESSION_TX_BROADCASTED` action and creates new prepending tx using `CoinjoinBackend.createPendingTreansaction`

- `coinjoinMiddleware` catches `addTransaction` action with `deadline` (prepending) and updates `AccountInfo`  (addresses, utxos, anonymityLevels, balances...)

## Related issue
Partial https://github.com/trezor/trezor-suite/issues/6658
