### PR TITLE
chore: deletion of unused Lerna config

### DIFF
--- a/lerna.json
+++ b/lerna.json
@@ -1,6 +1,0 @@
-{
-    "packages": ["packages/*", "suite-native/*", "suite-common/*", "scripts"],
-    "npmClient": "yarn",
-    "useWorkspaces": true,
-    "version": "independent"
-}


### PR DESCRIPTION
Lerna was changed for Nx. Its config is obsolete and should not be part of the repo anymore.
