### PR TITLE
Feat: send form + utxos registered in coinjoin

### DIFF
--- a/packages/components/src/components/form/Checkbox/index.tsx
+++ b/packages/components/src/components/form/Checkbox/index.tsx
@@ -28,8 +28,12 @@ const IconWrapper = styled.div<
     max-width: 24px;
     height: 24px;
     border-radius: 4px;
-    background: ${({ $color, isChecked, theme }) =>
-        isChecked ? $color || theme.BG_GREEN : theme.BG_WHITE};
+    background: ${({ $color, isChecked, isDisabled, theme }) => {
+        if (isDisabled) {
+            return theme.BG_GREY;
+        }
+        return isChecked ? $color || theme.BG_GREEN : theme.BG_WHITE;
+    }};
     border: 2px solid
         ${({ $color, isChecked, theme }) =>
             isChecked ? $color || theme.BG_GREEN : theme.STROKE_GREY};

--- a/packages/suite/src/actions/wallet/send/sendFormBitcoinActions.ts
+++ b/packages/suite/src/actions/wallet/send/sendFormBitcoinActions.ts
@@ -11,15 +11,15 @@ import {
 import { BTC_RBF_SEQUENCE, BTC_LOCKTIME_SEQUENCE } from '@suite-common/wallet-constants';
 import {
     FormState,
-    UseSendFormState,
+    ComposeActionContext,
     PrecomposedLevels,
     PrecomposedTransaction,
     PrecomposedTransactionFinal,
-} from '@wallet-types/sendForm';
+} from '@suite-common/wallet-types';
 import { Dispatch, GetState } from '@suite-types';
 
 export const composeTransaction =
-    (formValues: FormState, formState: UseSendFormState) =>
+    (formValues: FormState, formState: ComposeActionContext) =>
     async (dispatch: Dispatch, getState: GetState) => {
         const { account, excludedUtxos, feeInfo } = formState;
 
@@ -166,6 +166,7 @@ export const composeTransaction =
                 const getErrorMessage = () => {
                     const isLowAnonymity =
                         account.accountType === 'coinjoin' &&
+                        excludedUtxos &&
                         !!Object.values(excludedUtxos).filter(reason => reason === 'low-anonymity')
                             .length;
 

--- a/packages/suite/src/actions/wallet/send/sendFormCardanoActions.ts
+++ b/packages/suite/src/actions/wallet/send/sendFormCardanoActions.ts
@@ -14,14 +14,14 @@ import {
 import { notificationsActions } from '@suite-common/toast-notifications';
 import {
     FormState,
-    UseSendFormState,
+    ComposeActionContext,
     PrecomposedLevelsCardano,
     PrecomposedTransactionFinalCardano,
-} from '@wallet-types/sendForm';
+} from '@suite-common/wallet-types';
 import { Dispatch, GetState } from '@suite-types';
 
 export const composeTransaction =
-    (formValues: FormState, formState: UseSendFormState) =>
+    (formValues: FormState, formState: ComposeActionContext) =>
     async (dispatch: Dispatch): Promise<PrecomposedLevelsCardano | undefined> => {
         const { account, feeInfo } = formState;
         const changeAddress = getChangeAddressParameters(account);

--- a/packages/suite/src/actions/wallet/send/sendFormEthereumActions.ts
+++ b/packages/suite/src/actions/wallet/send/sendFormEthereumActions.ts
@@ -17,12 +17,12 @@ import {
 import { ETH_DEFAULT_GAS_LIMIT, ERC20_GAS_LIMIT } from '@suite-common/wallet-constants';
 import {
     FormState,
-    UseSendFormState,
+    ComposeActionContext,
     PrecomposedLevels,
     PrecomposedTransaction,
     PrecomposedTransactionFinal,
     ExternalOutput,
-} from '@wallet-types/sendForm';
+} from '@suite-common/wallet-types';
 import { Dispatch, GetState } from '@suite-types';
 
 const calculate = (
@@ -102,7 +102,7 @@ const calculate = (
 };
 
 export const composeTransaction =
-    (formValues: FormState, formState: UseSendFormState) => async () => {
+    (formValues: FormState, formState: ComposeActionContext) => async () => {
         const { account, network, feeInfo } = formState;
         const composeOutputs = getExternalComposeOutput(formValues, account, network);
         if (!composeOutputs) return; // no valid Output

--- a/packages/suite/src/actions/wallet/send/sendFormRippleActions.ts
+++ b/packages/suite/src/actions/wallet/send/sendFormRippleActions.ts
@@ -11,12 +11,12 @@ import {
 import { XRP_FLAG } from '@suite-common/wallet-constants';
 import {
     FormState,
-    UseSendFormState,
+    ComposeActionContext,
     PrecomposedLevels,
     PrecomposedTransaction,
     PrecomposedTransactionFinal,
     ExternalOutput,
-} from '@wallet-types/sendForm';
+} from '@suite-common/wallet-types';
 import { Dispatch, GetState } from '@suite-types';
 
 const calculate = (
@@ -84,7 +84,7 @@ const calculate = (
 };
 
 export const composeTransaction =
-    (formValues: FormState, formState: UseSendFormState) => async () => {
+    (formValues: FormState, formState: ComposeActionContext) => async () => {
         const { account, network, feeInfo } = formState;
         const composeOutputs = getExternalComposeOutput(formValues, account, network);
         if (!composeOutputs) return; // no valid Output

--- a/packages/suite/src/actions/wallet/sendFormActions.ts
+++ b/packages/suite/src/actions/wallet/sendFormActions.ts
@@ -25,10 +25,10 @@ import { Dispatch, GetState } from '@suite-types';
 import { Account } from '@wallet-types';
 import {
     FormState,
-    UseSendFormState,
+    ComposeActionContext,
     PrecomposedTransactionFinal,
     PrecomposedTransactionFinalCardano,
-} from '@wallet-types/sendForm';
+} from '@suite-common/wallet-types';
 import * as sendFormBitcoinActions from './send/sendFormBitcoinActions';
 import * as sendFormEthereumActions from './send/sendFormEthereumActions';
 import * as sendFormRippleActions from './send/sendFormRippleActions';
@@ -167,7 +167,7 @@ export const convertDrafts = () => (dispatch: Dispatch, getState: GetState) => {
 };
 
 export const composeTransaction =
-    (formValues: FormState, formState: UseSendFormState) => (dispatch: Dispatch) => {
+    (formValues: FormState, formState: ComposeActionContext) => (dispatch: Dispatch) => {
         const { account } = formState;
         if (account.networkType === 'bitcoin') {
             return dispatch(sendFormBitcoinActions.composeTransaction(formValues, formState));

--- a/packages/suite/src/components/wallet/CoinControl/UtxoSelection.tsx
+++ b/packages/suite/src/components/wallet/CoinControl/UtxoSelection.tsx
@@ -125,7 +125,11 @@ interface UtxoSelectionProps {
 }
 
 export const UtxoSelection = ({ isChecked, transaction, utxo }: UtxoSelectionProps) => {
-    const { account, network, selectedUtxos, toggleUtxoSelection } = useSendFormContext();
+    const {
+        account,
+        network,
+        utxoSelection: { selectedUtxos, toggleUtxoSelection },
+    } = useSendFormContext();
 
     const coordinatorData = useSelector(state => state.wallet.coinjoin.clients[account.symbol]);
     const device = useSelector(state => state.suite.device);

--- a/packages/suite/src/components/wallet/CoinControl/UtxoSelection.tsx
+++ b/packages/suite/src/components/wallet/CoinControl/UtxoSelection.tsx
@@ -145,7 +145,7 @@ export const UtxoSelection = ({ isChecked, transaction, utxo }: UtxoSelectionPro
         coordinatorData && new BigNumber(utxo.amount).gt(coordinatorData.allowedInputAmounts.max);
     const isUnavailableForCoinjoin =
         account.accountType === 'coinjoin' &&
-        (amountTooSmallForCoinjoin || amountTooBigForCoinjoin); // TODO: add blacklisted UTXOs - https://github.com/trezor/trezor-suite/issues/6757
+        (amountTooSmallForCoinjoin || amountTooBigForCoinjoin);
     const unavailableMessage = amountTooSmallForCoinjoin
         ? 'TR_AMOUNT_TOO_SMALL_FOR_COINJOIN'
         : 'TR_AMOUNT_TOO_BIG_FOR_COINJOIN';

--- a/packages/suite/src/components/wallet/CoinControl/UtxoSelectionList.tsx
+++ b/packages/suite/src/components/wallet/CoinControl/UtxoSelectionList.tsx
@@ -57,7 +57,10 @@ export const UtxoSelectionList = ({
     utxos,
     withHeader,
 }: Props) => {
-    const { account, composedInputs, isCoinControlEnabled, selectedUtxos } = useSendFormContext();
+    const {
+        account,
+        utxoSelection: { composedInputs, isCoinControlEnabled, selectedUtxos },
+    } = useSendFormContext();
 
     const accountTransactions = useSelector(state => selectAccountTransactions(state, account.key));
 

--- a/packages/suite/src/hooks/wallet/__tests__/useExcludedUtxos.test.tsx
+++ b/packages/suite/src/hooks/wallet/__tests__/useExcludedUtxos.test.tsx
@@ -1,0 +1,163 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import { testMocks } from '@suite-common/test-utils';
+import { useExcludedUtxos } from '../form/useExcludedUtxos';
+import * as walletUtils from '@suite-common/wallet-utils';
+
+type Props = Parameters<typeof useExcludedUtxos>[0];
+
+const ACCOUNT = testMocks.getWalletAccount({
+    addresses: {
+        change: [],
+        used: [],
+        unused: [],
+        anonymitySet: { AA01: 1, AA02: 10 },
+    },
+    utxo: [
+        testMocks.getUtxo({
+            amount: '1000',
+            address: 'AA01',
+            txid: '0000000000000000000000000000000000000000000000000000000000000001',
+            vout: 1,
+        }),
+        testMocks.getUtxo({
+            amount: '1000',
+            address: 'AA02',
+            txid: '0000000000000000000000000000000000000000000000000000000000000002',
+            vout: 2,
+        }),
+    ],
+});
+
+const CJ_ACCOUNT: any = {
+    targetAnonymity: 10,
+};
+
+const PROPS: Props = {
+    account: ACCOUNT,
+    dustLimit: testMocks.fee.dustLimit,
+    targetAnonymity: CJ_ACCOUNT.targetAnonymity,
+};
+
+const initialProps = (): Props => JSON.parse(JSON.stringify(PROPS));
+
+const Component = (props: Props) => {
+    const excludedUtxos = useExcludedUtxos(props);
+    const renderCount = React.useRef(0);
+    const [count, setCount] = React.useState(0);
+
+    React.useEffect(() => {
+        renderCount.current++;
+        setCount(renderCount.current);
+    }, [excludedUtxos]);
+
+    return (
+        <div>
+            <div data-testid="renders">{count}</div>
+            {Object.keys(excludedUtxos).map(key => (
+                <div key={key} data-testid="utxo">
+                    {excludedUtxos[key]}
+                </div>
+            ))}
+        </div>
+    );
+};
+
+const getRenders = () => Number(screen.getByTestId('renders').innerHTML);
+
+// mock getExcludedUtxos so we can count calls
+jest.mock('@suite-common/wallet-utils', () => {
+    const originalModule = jest.requireActual('@suite-common/wallet-utils');
+    return {
+        __esModule: true,
+        ...originalModule,
+        getExcludedUtxos: jest.fn((...args: any[]) => originalModule.getExcludedUtxos(...args)),
+    };
+});
+
+describe('useExcludedUtxos', () => {
+    beforeEach(() => {
+        jest.clearAllMocks();
+    });
+
+    it('changing account props', () => {
+        const props = initialProps();
+        if (!props.account.addresses) throw new Error('invalid props');
+
+        const { unmount, rerender } = render(<Component {...props} />);
+        expect(walletUtils.getExcludedUtxos).toBeCalledTimes(1);
+        expect(screen.getAllByTestId('utxo').length).toBe(1);
+        expect(getRenders()).toBe(1);
+
+        props.account.utxo = [
+            ...props.account.utxo!,
+            testMocks.getUtxo({
+                amount: '1000',
+                address: 'AA03',
+                txid: '0000000000000000000000000000000000000000000000000000000000000003',
+                vout: 3,
+            }),
+        ];
+
+        rerender(<Component {...props} />);
+        expect(walletUtils.getExcludedUtxos).toBeCalledTimes(2);
+        expect(screen.getAllByTestId('utxo').length).toBe(2);
+        expect(getRenders()).toBe(2);
+
+        props.account.addresses.anonymitySet = { AA01: 10, AA02: 10, AA03: 10 };
+        rerender(<Component {...props} />);
+        expect(walletUtils.getExcludedUtxos).toBeCalledTimes(3);
+        expect(getRenders()).toBe(3);
+        expect(() => screen.getAllByTestId('utxo')).toThrow('Unable to find an element');
+
+        delete props.account.addresses.anonymitySet;
+        rerender(<Component {...props} />);
+        expect(walletUtils.getExcludedUtxos).toBeCalledTimes(4);
+        expect(getRenders()).toBe(4);
+        expect(screen.getAllByTestId('utxo').length).toBe(3); // default anonymitySet is used
+
+        props.account.balance = '1000';
+        rerender(<Component {...props} />);
+        expect(walletUtils.getExcludedUtxos).toBeCalledTimes(4); // changing balance should not trigger calculation
+        expect(getRenders()).toBe(4);
+
+        unmount();
+    });
+
+    it('changing target anonymity', () => {
+        const props = initialProps();
+        if (!props.targetAnonymity) throw new Error('invalid props');
+
+        const { unmount, rerender } = render(<Component {...props} />);
+        expect(walletUtils.getExcludedUtxos).toBeCalledTimes(1);
+        expect(screen.getAllByText('low-anonymity').length).toBe(1);
+        expect(getRenders()).toBe(1);
+
+        props.targetAnonymity = 1;
+        rerender(<Component {...props} />);
+        expect(walletUtils.getExcludedUtxos).toBeCalledTimes(2);
+        expect(getRenders()).toBe(2);
+        expect(() => screen.getAllByTestId('utxo')).toThrow('Unable to find an element');
+
+        unmount();
+    });
+
+    it('changing dust limit', () => {
+        const props = initialProps();
+
+        props.dustLimit = 20000;
+
+        const { unmount, rerender } = render(<Component {...props} />);
+        expect(walletUtils.getExcludedUtxos).toBeCalledTimes(1);
+        expect(getRenders()).toBe(1);
+        expect(screen.getAllByText('dust').length).toBe(2);
+
+        props.dustLimit = 100;
+        rerender(<Component {...props} />);
+        expect(walletUtils.getExcludedUtxos).toBeCalledTimes(2);
+        expect(getRenders()).toBe(2);
+        expect(() => screen.getAllByText('dust')).toThrow('Unable to find an element');
+
+        unmount();
+    });
+});

--- a/packages/suite/src/hooks/wallet/form/useCompose.ts
+++ b/packages/suite/src/hooks/wallet/form/useCompose.ts
@@ -7,17 +7,16 @@ import { findComposeErrors } from '@suite-common/wallet-utils';
 import {
     FormState,
     UseSendFormState,
+    ComposeActionContext,
     SendContextValues,
     PrecomposedTransaction,
     PrecomposedTransactionCardano,
     PrecomposedLevels,
     PrecomposedLevelsCardano,
-} from '@wallet-types/sendForm';
+} from '@suite-common/wallet-types';
 
 type Props = UseFormMethods<FormState> & {
-    // TODO: params required by sendFormActions (not the whole UseSendFormState), refactor both in the next PR
-    state?: Pick<UseSendFormState, 'account' | 'network' | 'feeInfo'> &
-        Partial<Pick<UseSendFormState, 'excludedUtxos'>>;
+    state?: ComposeActionContext;
     defaultField?: string;
 };
 
@@ -54,7 +53,7 @@ export const useCompose = ({
         const composeInner = async () => {
             if (Object.keys(errors).length > 0) return;
             const values = getValues();
-            const result = await composeAction(values, state as UseSendFormState);
+            const result = await composeAction(values, state);
             return result;
         };
 

--- a/packages/suite/src/hooks/wallet/form/useExcludedUtxos.ts
+++ b/packages/suite/src/hooks/wallet/form/useExcludedUtxos.ts
@@ -1,0 +1,27 @@
+import { useMemo } from 'react';
+
+import { Account } from '@suite-common/wallet-types';
+import { getExcludedUtxos } from '@suite-common/wallet-utils';
+
+interface UseExcludedUtxosProps {
+    account: Account;
+    dustLimit?: number;
+    targetAnonymity?: number;
+}
+
+/**
+ * Shareable sub-hook used in useSendForm and useRbfForm
+ * Returns utxos which should be automatically excluded while composingTransaction.
+ * Response format: { utxo_outpoint: exclusion_reason }
+ */
+export const useExcludedUtxos = ({ account, dustLimit, targetAnonymity }: UseExcludedUtxosProps) =>
+    useMemo(
+        () =>
+            getExcludedUtxos({
+                utxos: account.utxo,
+                anonymitySet: account.addresses?.anonymitySet,
+                dustLimit,
+                targetAnonymity,
+            }),
+        [account.utxo, account.addresses?.anonymitySet, dustLimit, targetAnonymity],
+    );

--- a/packages/suite/src/hooks/wallet/form/useUtxoSelection.ts
+++ b/packages/suite/src/hooks/wallet/form/useUtxoSelection.ts
@@ -1,12 +1,13 @@
 import { useEffect, useMemo } from 'react';
 import { UseFormMethods } from 'react-hook-form';
 
-import { UseSendFormState } from '@suite-common/wallet-types';
+import { UseSendFormState, ExcludedUtxos } from '@suite-common/wallet-types';
 import type { AccountUtxo, PROTO } from '@trezor/connect';
 import { getUtxoOutpoint } from '@suite-common/wallet-utils';
 
 type Props = UseFormMethods &
-    Pick<UseSendFormState, 'account' | 'composedLevels' | 'excludedUtxos'> & {
+    Pick<UseSendFormState, 'account' | 'composedLevels'> & {
+        excludedUtxos: ExcludedUtxos;
         composeRequest: (field?: string) => void;
     };
 

--- a/packages/suite/src/hooks/wallet/form/useUtxoSelection.ts
+++ b/packages/suite/src/hooks/wallet/form/useUtxoSelection.ts
@@ -1,7 +1,7 @@
 import { useEffect, useMemo } from 'react';
 import { UseFormMethods } from 'react-hook-form';
 
-import { UseSendFormState, ExcludedUtxos } from '@suite-common/wallet-types';
+import { UseSendFormState, ExcludedUtxos, UtxoSelectionContext } from '@suite-common/wallet-types';
 import type { AccountUtxo, PROTO } from '@trezor/connect';
 import { getUtxoOutpoint } from '@suite-common/wallet-utils';
 
@@ -19,7 +19,7 @@ export const useUtxoSelection = ({
     register,
     setValue,
     watch,
-}: Props) => {
+}: Props): UtxoSelectionContext => {
     // register custom form field (without HTMLElement)
     useEffect(() => {
         register({ name: 'isCoinControlEnabled', type: 'custom' });
@@ -147,6 +147,7 @@ export const useUtxoSelection = ({
     };
 
     return {
+        excludedUtxos,
         allUtxosSelected,
         anonymityWarningChecked,
         composedInputs,

--- a/packages/suite/src/hooks/wallet/useRbfForm.ts
+++ b/packages/suite/src/hooks/wallet/useRbfForm.ts
@@ -2,14 +2,14 @@ import BigNumber from 'bignumber.js';
 import { createContext, useContext, useState, useEffect } from 'react';
 import { useForm } from 'react-hook-form';
 import { useSelector } from '@suite-hooks';
-import { getExcludedUtxos, getFeeLevels } from '@suite-common/wallet-utils';
 import { DEFAULT_PAYMENT, DEFAULT_OPRETURN, DEFAULT_VALUES } from '@suite-common/wallet-constants';
+import { TypedValidationRules } from '@suite-common/wallet-types';
+import { getExcludedUtxos, getFeeLevels } from '@suite-common/wallet-utils';
 import { Account, WalletAccountTransaction } from '@wallet-types';
 import { FormState, FeeInfo } from '@wallet-types/sendForm';
 import { useFees } from './form/useFees';
 import { useCompose } from './form/useCompose';
 import { useBitcoinAmountUnit } from './useBitcoinAmountUnit';
-import { TypedValidationRules } from '@suite-common/wallet-types';
 
 export type Props = {
     tx: WalletAccountTransaction;
@@ -120,11 +120,12 @@ const useRbfState = ({ tx, finalize, chainedTxs }: Props, currentState: boolean)
     // find coinjoin account related to current account
     const coinjoinAccount = coinjoinAccounts.find(a => a.key === selectedAccount.account.key);
 
-    const excludedUtxos = getExcludedUtxos(
-        rbfAccount,
-        coinFees?.dustLimit,
-        coinjoinAccount?.targetAnonymity,
-    );
+    const excludedUtxos = getExcludedUtxos({
+        utxos: rbfAccount.utxo,
+        dustLimit: coinFees.dustLimit,
+        anonymitySet: rbfAccount.addresses?.anonymitySet,
+        targetAnonymity: coinjoinAccount?.targetAnonymity,
+    });
 
     return {
         account: rbfAccount,

--- a/packages/suite/src/hooks/wallet/useSendForm.ts
+++ b/packages/suite/src/hooks/wallet/useSendForm.ts
@@ -380,10 +380,9 @@ export const useSendForm = (props: UseSendFormProps): SendContextValues => {
         loadTransaction,
         signTransaction: sign,
         setDraftSaveRequest,
+        utxoSelection,
         ...sendFormUtils,
         ...sendFormOutputs,
-        ...utxoSelection,
-        excludedUtxos,
     };
 };
 

--- a/packages/suite/src/hooks/wallet/useSendForm.ts
+++ b/packages/suite/src/hooks/wallet/useSendForm.ts
@@ -184,6 +184,7 @@ export const useSendForm = (props: UseSendFormProps): SendContextValues => {
         ...useFormMethods,
         state,
         account: props.selectedAccount.account,
+        excludedUtxos,
         updateContext,
         setAmount: sendFormUtils.setAmount,
     });

--- a/packages/suite/src/hooks/wallet/useSendFormCompose.ts
+++ b/packages/suite/src/hooks/wallet/useSendFormCompose.ts
@@ -13,7 +13,7 @@ import { useAsyncDebounce } from '@trezor/react-utils';
 import { useActions } from '@suite-hooks';
 import { isChanged } from '@suite-utils/comparisonUtils';
 import * as sendFormActions from '@wallet-actions/sendFormActions';
-import { findComposeErrors, getExcludedUtxos } from '@suite-common/wallet-utils';
+import { findComposeErrors } from '@suite-common/wallet-utils';
 
 type Props = UseFormMethods<FormState> & {
     state: UseSendFormState;
@@ -34,7 +34,6 @@ export const useSendFormCompose = ({
     account,
     updateContext,
     setAmount,
-    targetAnonymity,
 }: Props) => {
     const [composedLevels, setComposedLevels] =
         useState<SendContextValues['composedLevels']>(undefined);
@@ -244,9 +243,8 @@ export const useSendFormCompose = ({
     );
 
     // handle props.account change:
-    // - update context state (state.account, state.excludedUtxos)
+    // - update context state (state.account)
     // - compose transaction with new data
-    // excludedUtxos need to be updated in case a new UTXO appears
     useEffect(() => {
         if (
             !isChanged(
@@ -258,11 +256,8 @@ export const useSendFormCompose = ({
             return; // account didn't change
         }
         if (!state.isDirty) {
-            // there was no interaction with the form, just update account and excludedUtxos
-            updateContext({
-                account,
-                excludedUtxos: getExcludedUtxos(account, state.feeInfo.dustLimit, targetAnonymity),
-            });
+            // there was no interaction with the form, just update state.account
+            updateContext({ account });
             return;
         }
 
@@ -278,11 +273,7 @@ export const useSendFormCompose = ({
             clearErrors(composeErrors);
         }
         // start composing
-        updateContext({
-            account,
-            excludedUtxos: getExcludedUtxos(account, state.feeInfo.dustLimit, targetAnonymity),
-            isLoading: true,
-        });
+        updateContext({ account, isLoading: true });
     }, [
         state.account,
         state.feeInfo.dustLimit,
@@ -290,7 +281,6 @@ export const useSendFormCompose = ({
         account,
         clearErrors,
         errors,
-        targetAnonymity,
         updateContext,
     ]);
 

--- a/packages/suite/src/reducers/wallet/__fixtures__/coinjoinReducer.ts
+++ b/packages/suite/src/reducers/wallet/__fixtures__/coinjoinReducer.ts
@@ -15,7 +15,6 @@ const account = {
         targetAnonymity: 20,
         timeCreated: 1674818299886,
         sessionPhaseQueue: [],
-        registeredUtxos: [],
         signedRounds: [],
         paused: true,
         interrupted: false,

--- a/packages/suite/src/reducers/wallet/coinjoinReducer.ts
+++ b/packages/suite/src/reducers/wallet/coinjoinReducer.ts
@@ -102,7 +102,6 @@ const createSession = (
         ...payload.params,
         timeCreated: Date.now(),
         sessionPhaseQueue: [],
-        registeredUtxos: [],
         signedRounds: [],
     };
 };
@@ -214,7 +213,6 @@ const pauseSession = (
     delete account.session.roundPhase;
     delete account.session.sessionDeadline;
     account.session.sessionPhaseQueue = [];
-    account.session.registeredUtxos = [];
     account.session.paused = true;
     account.session.interrupted = payload.interrupted;
     account.session.timeEnded = Date.now();

--- a/packages/suite/src/types/wallet/coinjoin.ts
+++ b/packages/suite/src/types/wallet/coinjoin.ts
@@ -17,7 +17,6 @@ export interface CoinjoinSessionParameters {
 }
 
 export interface CoinjoinSession extends CoinjoinSessionParameters {
-    registeredUtxos: string[]; // list of utxos (outpoints) registered in session
     timeCreated: number; // timestamp when was created
     timeEnded?: number; // timestamp when was finished
     paused?: boolean; // current state

--- a/packages/suite/src/views/wallet/send/components/Options/components/BitcoinOptions/components/CoinControl.tsx
+++ b/packages/suite/src/views/wallet/send/components/Options/components/BitcoinOptions/components/CoinControl.tsx
@@ -73,19 +73,21 @@ export const CoinControl = ({ close }: CoinControlProps) => {
 
     const {
         account,
-        allUtxosSelected,
-        composedInputs,
-        dustUtxos,
         errors,
         getDefaultValue,
-        isCoinControlEnabled,
-        lowAnonymityUtxos,
         network,
         outputs,
-        selectedUtxos,
-        spendableUtxos,
-        toggleCheckAllUtxos,
-        toggleCoinControl,
+        utxoSelection: {
+            allUtxosSelected,
+            composedInputs,
+            dustUtxos,
+            isCoinControlEnabled,
+            lowAnonymityUtxos,
+            selectedUtxos,
+            spendableUtxos,
+            toggleCheckAllUtxos,
+            toggleCoinControl,
+        },
     } = useSendFormContext();
 
     const { shouldSendInSats } = useBitcoinAmountUnit(account.symbol);

--- a/packages/suite/src/views/wallet/send/components/Options/components/BitcoinOptions/index.tsx
+++ b/packages/suite/src/views/wallet/send/components/Options/components/BitcoinOptions/index.tsx
@@ -49,7 +49,7 @@ export const BitcoinOptions = () => {
         network,
         addOutput,
         control,
-        isCoinControlEnabled,
+        utxoSelection: { isCoinControlEnabled },
         getDefaultValue,
         toggleOption,
         composeTransaction,

--- a/packages/suite/src/views/wallet/send/components/ReviewButton.tsx
+++ b/packages/suite/src/views/wallet/send/components/ReviewButton.tsx
@@ -56,7 +56,6 @@ const SecondLine = styled.p`
 export const ReviewButton = () => {
     const { device, isLocked } = useDevice();
     const {
-        anonymityWarningChecked,
         control,
         errors,
         online,
@@ -64,11 +63,14 @@ export const ReviewButton = () => {
         signTransaction,
         getValues,
         getDefaultValue,
-        toggleAnonymityWarning,
         toggleOption,
         composedLevels,
-        isCoinControlEnabled,
-        isLowAnonymityUtxoSelected,
+        utxoSelection: {
+            anonymityWarningChecked,
+            isCoinControlEnabled,
+            isLowAnonymityUtxoSelected,
+            toggleAnonymityWarning,
+        },
     } = useSendFormContext();
 
     const options = useWatch<FormOptions[]>({

--- a/suite-common/wallet-types/src/sendForm.ts
+++ b/suite-common/wallet-types/src/sendForm.ts
@@ -124,18 +124,5 @@ export type SendContextValues = Omit<UseFormMethods<FormState>, 'register'> &
         // useSendFormCompose
         setDraftSaveRequest: React.Dispatch<React.SetStateAction<boolean>>;
         // UTXO selection
-        excludedUtxos: ExcludedUtxos;
-        allUtxosSelected: boolean;
-        composedInputs: PROTO.TxInputType[];
-        dustUtxos: AccountUtxo[];
-        isCoinControlEnabled: boolean;
-        lowAnonymityUtxos: AccountUtxo[];
-        selectedUtxos: AccountUtxo[];
-        spendableUtxos: AccountUtxo[];
-        isLowAnonymityUtxoSelected: boolean;
-        anonymityWarningChecked: boolean;
-        toggleAnonymityWarning: () => void;
-        toggleCheckAllUtxos: () => void;
-        toggleCoinControl: () => void;
-        toggleUtxoSelection: (utxo: AccountUtxo) => void;
+        utxoSelection: UtxoSelectionContext;
     };

--- a/suite-common/wallet-types/src/sendForm.ts
+++ b/suite-common/wallet-types/src/sendForm.ts
@@ -45,10 +45,12 @@ export type FormState = {
     hasCoinControlBeenOpened: boolean;
     selectedUtxos: AccountUtxo[];
 };
+
+export type ExcludedUtxos = Record<string, 'low-anonymity' | 'dust' | undefined>;
+
 // local state of @wallet-hooks/useSendForm
 export type UseSendFormState = {
     account: Account;
-    excludedUtxos: Record<string, 'low-anonymity' | 'dust' | 'unconfirmed' | undefined>;
     network: Network;
     coinFees: FeeInfo;
     feeInfo: FeeInfo;
@@ -61,6 +63,30 @@ export type UseSendFormState = {
     online: boolean;
     metadataEnabled: boolean;
 };
+
+export interface ComposeActionContext {
+    account: Account;
+    network: Network;
+    feeInfo: FeeInfo;
+    excludedUtxos?: ExcludedUtxos;
+}
+
+export interface UtxoSelectionContext {
+    excludedUtxos: ExcludedUtxos;
+    allUtxosSelected: boolean;
+    composedInputs: PROTO.TxInputType[];
+    dustUtxos: AccountUtxo[];
+    isCoinControlEnabled: boolean;
+    lowAnonymityUtxos: AccountUtxo[];
+    selectedUtxos: AccountUtxo[];
+    spendableUtxos: AccountUtxo[];
+    isLowAnonymityUtxoSelected: boolean;
+    anonymityWarningChecked: boolean;
+    toggleAnonymityWarning: () => void;
+    toggleCheckAllUtxos: () => void;
+    toggleCoinControl: () => void;
+    toggleUtxoSelection: (utxo: AccountUtxo) => void;
+}
 
 // strongly typed UseFormMethods.getValues with fallback value
 export interface GetDefaultValue {
@@ -98,6 +124,7 @@ export type SendContextValues = Omit<UseFormMethods<FormState>, 'register'> &
         // useSendFormCompose
         setDraftSaveRequest: React.Dispatch<React.SetStateAction<boolean>>;
         // UTXO selection
+        excludedUtxos: ExcludedUtxos;
         allUtxosSelected: boolean;
         composedInputs: PROTO.TxInputType[];
         dustUtxos: AccountUtxo[];

--- a/suite-common/wallet-utils/src/__tests__/sendFormUtils.test.ts
+++ b/suite-common/wallet-utils/src/__tests__/sendFormUtils.test.ts
@@ -392,11 +392,14 @@ describe('sendForm utils', () => {
             amount: '2',
             vout: 4,
         });
-        const coinjoinAccount = getWalletAccount({
-            addresses: { anonymitySet: { one: 1, two: 2 }, change: [], used: [], unused: [] },
-            utxo: [dustUtxo, lowAnonymityDustUtxo, lowAnonymityUtxo, spendableUtxo],
+
+        const excludedUtxos = getExcludedUtxos({
+            utxos: [dustUtxo, lowAnonymityDustUtxo, lowAnonymityUtxo, spendableUtxo],
+            anonymitySet: { one: 1, two: 2 },
+            targetAnonymity: 2,
+            dustLimit: 1,
         });
-        const excludedUtxos = getExcludedUtxos(coinjoinAccount, 1, 2);
+
         expect(excludedUtxos[getUtxoOutpoint(dustUtxo)]).toBe('dust');
         expect(excludedUtxos[getUtxoOutpoint(lowAnonymityDustUtxo)]).toBe('dust');
         expect(excludedUtxos[getUtxoOutpoint(lowAnonymityUtxo)]).toBe('low-anonymity');


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

1.  ~adding registered utxos to `excludedUtxos`~
-  `excludedUtxos` calculation moved to standalone hook `useExcludedUtxos` and used in send form (replacement for https://github.com/trezor/trezor-suite/commit/52a5cc27e62e35927a88b8e1c3eb6da6cefc2604)
- `getExcludedUtxos` utility returns new reason, utxos which are currently registered in coinjoin
- tests of `useExcludedUtxos` to make sure that values are updated (or not) expectedly
> Explanation: before that getExcludedUtxos was called in 3 different places, sometimes unnecessarily. Now it is called only if certain parts of props were changed. 
~> Additional benefit: this hook can be used in `useRbfForm` as well, to be done in https://github.com/trezor/trezor-suite/issues/7184~

~2.WIP implementation of coinjoinUtxos in CoinControl. cc @komret~
~- [ ] manual selection (checkbox) for regisered utxo should be disabled~
~- [ ] decision, separate group or only marked as it is prepared? send form actions requires to have registered utxo in excludedUtxos, but in UI it might have jumping side effect when utxo is moved from one group to another (low-anonymity > registered)~

~3. assigning values to CoinjoinSession~

4. implement forgotten TODO (commented in useCompose hook) which is also a partial preparation for updating `react-hook-form` [PR](https://github.com/trezor/trezor-suite/pull/7018)
> sendForm(*)Actions should use specific set of data: ComposeActionContext (im opened for discussion regarding the name) instead of `UseSendFormState` (invity and rbf forms doesnt use it - therefore `excludedUtxos` is undefined there)

## Related Issue

Resolve #6895
