### PR TITLE
feat: enter pin modal with device label

### DIFF
--- a/packages/suite/src/components/suite/modals/Pin.tsx
+++ b/packages/suite/src/components/suite/modals/Pin.tsx
@@ -38,7 +38,12 @@ export const Pin = ({ device, ...rest }: PinProps) => {
 
     return (
         <StyledModal
-            heading={<Translation id="TR_ENTER_PIN" />}
+            heading={
+                <Translation
+                    id="TR_ENTER_PIN_ON_DEVICE_LABEL"
+                    values={{ deviceLabel: device.label }}
+                />
+            }
             description={<Translation id="TR_THE_PIN_LAYOUT_IS_DISPLAYED" />}
             {...rest}
             data-test="@modal/pin"

--- a/packages/suite/src/support/messages.ts
+++ b/packages/suite/src/support/messages.ts
@@ -2363,6 +2363,10 @@ export default defineMessages({
         description: 'Button. Submit PIN',
         id: 'TR_ENTER_PIN',
     },
+    TR_ENTER_PIN_ON_DEVICE_LABEL: {
+        defaultMessage: 'Enter PIN on {deviceLabel}',
+        id: 'TR_ENTER_PIN_ON_DEVICE_LABEL',
+    },
     TR_ENTER_SEED_WORDS_INSTRUCTION: {
         defaultMessage:
             'Enter the words from your seed here in the order displayed on your device. ',


### PR DESCRIPTION
lowhanging resolve #7269 not sure if product will come up with something different. We display device label in the same way for passphrase modal too.

![image](https://user-images.githubusercontent.com/30367552/211072172-7537d31c-b6cf-4983-b3c1-9d06604a7f39.png)

![image](https://user-images.githubusercontent.com/30367552/211072632-a154b20c-228c-441a-bd7d-fb81030263e4.png)
