### PR TITLE
nightly urls and duplicate message ids

### DIFF
--- a/packages/suite/src/support/messages.ts
+++ b/packages/suite/src/support/messages.ts
@@ -4029,7 +4029,7 @@ export default defineMessages({
         dynamic: true,
     },
     TR_CHECK_RECOVERY_SEED_DESC_TR: {
-        id: 'TR_CHECK_RECOVERY_SEED_DESC_TT',
+        id: 'TR_CHECK_RECOVERY_SEED_DESC_TR',
         defaultMessage:
             'Your recovery seed (wallet backup) is entered using the Trezor Model R buttons. This avoids exposing any of your sensitive information to a potentially insecure computer or web browser.',
         dynamic: true,

--- a/packages/urls/src/urls.ts
+++ b/packages/urls/src/urls.ts
@@ -25,12 +25,14 @@ export const SUITE_FIRMWARE_URL = 'https://suite.trezor.io/web/firmware/';
 export const SUITE_UDEV_URL = 'https://suite.trezor.io/web/udev/';
 
 export const HELP_CENTER_PIN_URL = 'https://trezor.io/learn/a/pin-protection-on-trezor-devices';
-export const HELP_CENTER_DRY_RUN_T1_URL =
-    'https://trezor.io/learn/a/test-recovery-seed-on-trezor-model-one';
-export const HELP_CENTER_DRY_RUN_TT_URL =
-    'https://trezor.io/learn/a/test-recovery-seed-on-trezor-model-t';
-export const HELP_CENTER_DRY_RUN_TR_URL =
-    'https://trezor.io/learn/a/test-recovery-seed-on-trezor-model-r';
+// todo: these are not used anywhere, commenting out because of this check
+// https://gitlab.com/satoshilabs/trezor/trezor-suite/-/jobs/3567617048
+// export const HELP_CENTER_DRY_RUN_T1_URL =
+//     'https://trezor.io/learn/a/test-recovery-seed-on-trezor-model-one';
+// export const HELP_CENTER_DRY_RUN_TT_URL =
+//     'https://trezor.io/learn/a/test-recovery-seed-on-trezor-model-t';
+// export const HELP_CENTER_DRY_RUN_TR_URL =
+//     'https://trezor.io/learn/a/test-recovery-seed-on-trezor-model-r';
 export const HELP_CENTER_PASSPHRASE_URL =
     'https://trezor.io/learn/a/passphrases-and-hidden-wallets';
 export const HELP_CENTER_RECOVERY_SEED_URL = 'https://trezor.io/learn/a/how-to-use-a-recovery-seed';


### PR DESCRIPTION
couple of nighlly jobs are failing 

![image](https://user-images.githubusercontent.com/30367552/211149961-3e08d540-f7c1-45c7-b77a-132978b60713.png)

These urls return 404

export const HELP_CENTER_DRY_RUN_T1_URL =
    'https://trezor.io/learn/a/test-recovery-seed-on-trezor-model-one';
export const HELP_CENTER_DRY_RUN_TT_URL =
    'https://trezor.io/learn/a/test-recovery-seed-on-trezor-model-t';
export const HELP_CENTER_DRY_RUN_TR_URL =
    'https://trezor.io/learn/a/test-recovery-seed-on-trezor-model-r';
export const HELP_CENTER_PASSPHRASE_URL =

but we can not simply ignore them since it is used also here https://github.com/trezor/trezor-suite/blob/develop/packages/suite/src/utils/suite/device.ts#L263. Maybe we plan to deploy these? 