### PR TITLE
feat(connect): add requestWebUsbDevice method

### DIFF
--- a/packages/connect-web/src/index.ts
+++ b/packages/connect-web/src/index.ts
@@ -25,6 +25,7 @@ import {
 } from '@trezor/connect/lib/exports';
 import { factory } from '@trezor/connect/lib/factory';
 import { initLog } from '@trezor/connect/lib/utils/debug';
+import { config } from '@trezor/connect/lib/data/config';
 
 import * as iframe from './iframe';
 import * as popup from './popup';
@@ -295,6 +296,22 @@ const disableWebUSB = () => {
     });
 };
 
+/**
+ * Initiate device pairing procedure.
+ */
+const requestWebUSBDevice = async () => {
+    try {
+        await window.navigator.usb.requestDevice({ filters: config.webusb });
+        iframe.postMessage({
+            event: UI_EVENT,
+            type: TRANSPORT.REQUEST_DEVICE,
+        });
+    } catch (_err) {
+        // user hits cancel gets "DOMException: No device selected."
+        // no need to log this
+    }
+};
+
 const TrezorConnect = factory({
     eventEmitter,
     manifest,
@@ -304,6 +321,7 @@ const TrezorConnect = factory({
     uiResponse,
     renderWebUSBButton,
     disableWebUSB,
+    requestWebUSBDevice,
     cancel,
     dispose,
 });

--- a/packages/connect/src/core/index.ts
+++ b/packages/connect/src/core/index.ts
@@ -160,6 +160,16 @@ export const handleMessage = (message: CoreMessage, isTrustedOrigin = false) => 
             disableWebUSBTransport();
             break;
 
+        case TRANSPORT.REQUEST_DEVICE:
+            /**
+             * after pairing with device is requested in native context, for example see
+             * requestWebUSBDevice in connect-web/src/index, this is used to trigger transport
+             * enumeration
+             */
+            // todo: enable when it is needed
+            // _deviceList?.enumerate();
+            break;
+
         // messages from UI (popup/modal...)
         case UI.RECEIVE_DEVICE:
         case UI.RECEIVE_CONFIRMATION:

--- a/packages/connect/src/events/transport.ts
+++ b/packages/connect/src/events/transport.ts
@@ -7,7 +7,7 @@ export const TRANSPORT = {
     ERROR: 'transport-error',
     UPDATE: 'transport-update',
     STREAM: 'transport-stream',
-    REQUEST: 'transport-request_device',
+    REQUEST_DEVICE: 'transport-request_device',
     DISABLE_WEBUSB: 'transport-disable_webusb',
     START_PENDING: 'transport-start_pending',
 } as const;
@@ -61,6 +61,11 @@ export type TransportEvent =
 
 export interface TransportDisableWebUSB {
     type: typeof TRANSPORT.DISABLE_WEBUSB;
+    payload?: undefined;
+}
+
+export interface TransportRequestWebUSBDevice {
+    type: typeof TRANSPORT.REQUEST_DEVICE;
     payload?: undefined;
 }
 

--- a/packages/connect/src/events/ui-request.ts
+++ b/packages/connect/src/events/ui-request.ts
@@ -4,7 +4,7 @@
 import type { EventTypeDeviceSelected } from '@trezor/connect-analytics';
 
 import type { PROTO } from '../constants';
-import type { TransportDisableWebUSB } from './transport';
+import type { TransportDisableWebUSB, TransportRequestWebUSBDevice } from './transport';
 import type { Device, CoinInfo, BitcoinNetworkInfo } from '../types';
 import type { DiscoveryAccountType, DiscoveryAccount, SelectFeeLevel } from '../types/account';
 import type { MessageFactoryFn } from '../types/utils';
@@ -266,7 +266,8 @@ export type UiEvent =
     | FirmwareException
     | UiRequestAddressValidation
     | UiRequestSetOperation
-    | TransportDisableWebUSB;
+    | TransportDisableWebUSB
+    | TransportRequestWebUSBDevice;
 
 export type UiEventMessage = UiEvent & { event: typeof UI_EVENT };
 

--- a/packages/connect/src/factory.ts
+++ b/packages/connect/src/factory.ts
@@ -12,6 +12,7 @@ interface Dependencies {
     uiResponse: TrezorConnect['uiResponse'];
     renderWebUSBButton: TrezorConnect['renderWebUSBButton'];
     disableWebUSB: TrezorConnect['disableWebUSB'];
+    requestWebUSBDevice: TrezorConnect['requestWebUSBDevice'];
     cancel: TrezorConnect['cancel'];
     dispose: TrezorConnect['dispose'];
 }
@@ -25,6 +26,7 @@ export const factory = ({
     uiResponse,
     renderWebUSBButton,
     disableWebUSB,
+    requestWebUSBDevice,
     cancel,
     dispose,
 }: Dependencies): TrezorConnect => {
@@ -240,6 +242,8 @@ export const factory = ({
         renderWebUSBButton,
 
         disableWebUSB,
+
+        requestWebUSBDevice,
     };
     return api;
 };

--- a/packages/connect/src/index-browser.ts
+++ b/packages/connect/src/index-browser.ts
@@ -17,6 +17,7 @@ const TrezorConnect = factory({
     init: fallback,
     call: fallback,
     requestLogin: fallback,
+    requestWebUSBDevice: fallback,
     uiResponse: fallback,
     renderWebUSBButton: fallback,
     disableWebUSB: fallback,

--- a/packages/connect/src/index.ts
+++ b/packages/connect/src/index.ts
@@ -246,6 +246,10 @@ const disableWebUSB = () => {
     throw ERRORS.TypedError('Method_InvalidPackage');
 };
 
+const requestWebUSBDevice = () => {
+    throw ERRORS.TypedError('Method_InvalidPackage');
+};
+
 const TrezorConnect = factory({
     eventEmitter,
     manifest,
@@ -255,6 +259,7 @@ const TrezorConnect = factory({
     uiResponse,
     renderWebUSBButton,
     disableWebUSB,
+    requestWebUSBDevice,
     cancel,
     dispose,
 });

--- a/packages/connect/src/types/api/index.ts
+++ b/packages/connect/src/types/api/index.ts
@@ -57,6 +57,7 @@ import { recoveryDevice } from './recoveryDevice';
 import { removeAllListeners } from './removeAllListeners';
 import { renderWebUSBButton } from './renderWebUSBButton';
 import { requestLogin } from './requestLogin';
+import { requestWebUSBDevice } from './requestWebUSBDevice';
 import { resetDevice } from './resetDevice';
 import { rippleGetAddress } from './rippleGetAddress';
 import { rippleSignTransaction } from './rippleSignTransaction';
@@ -156,6 +157,8 @@ export interface TrezorConnect {
 
     // https://github.com/trezor/trezor-suite/blob/develop/docs/packages/connect/methods/disableWebUSB.md
     disableWebUSB: typeof disableWebUSB;
+
+    requestWebUSBDevice: typeof requestWebUSBDevice;
 
     // https://github.com/trezor/trezor-suite/blob/develop/docs/packages/connect/methods/dispose.md
     dispose: typeof dispose;

--- a/packages/connect/src/types/api/requestWebUSBDevice.ts
+++ b/packages/connect/src/types/api/requestWebUSBDevice.ts
@@ -1,0 +1,1 @@
+export declare function requestWebUSBDevice(): void;

--- a/packages/suite/src/components/suite/WebUsbButton/index.tsx
+++ b/packages/suite/src/components/suite/WebUsbButton/index.tsx
@@ -1,19 +1,15 @@
 import React from 'react';
+import TrezorConnect from '@trezor/connect';
 import { Button, ButtonProps } from '@trezor/components';
 import { Translation } from '@suite-components';
-import { config } from '@trezor/connect/lib/data/config';
 
 export const WebUsbButton = (props: ButtonProps) => (
     <Button
         {...props}
         icon="SEARCH"
-        onClick={async e => {
+        onClick={e => {
             e.stopPropagation();
-            try {
-                await navigator.usb.requestDevice({ filters: config.webusb });
-            } catch (error) {
-                console.error(error);
-            }
+            TrezorConnect.requestWebUSBDevice();
         }}
     >
         <Translation id="TR_CHECK_FOR_DEVICES" />


### PR DESCRIPTION
Part of #6509 

Two reasons for this:
1. `packages/suite/src/components/suite/WebUsbButton/index.tsx` was touching navigator.usb directly and it has no connection to  @trezor/transport interanl logic. This does not feel right and is hard to follow
2. webusb transport logic now runs enumaration in a forever loop. this is a sideffect that makes pairing work now. I would like to change it and make use of connection events instead. This means I need a way how to force enumeration after paring (`packages/connect-web/src/index.ts`)