### PR TITLE
Add link to trezor.io KB disclosure article

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,7 +78,7 @@ Using [Conventional Commits](COMMITS.md) is strongly recommended and might be en
 
 ## Security vulnerability disclosure
 
-Please report suspected security vulnerabilities in private to [security@satoshilabs.com](mailto:security@satoshilabs.com), also see [the disclosure section on the Trezor.io website](https://trezor.io/security/). Please do NOT create publicly viewable issues for suspected security vulnerabilities.
+Please report suspected security vulnerabilities in private to [security@satoshilabs.com](mailto:security@satoshilabs.com), also see [the disclosure section on the Trezor.io website](https://trezor.io/support/a/how-to-report-a-security-issue). Please do NOT create publicly viewable issues for suspected security vulnerabilities.
 
 ## IDE specific settings
 


### PR DESCRIPTION
Changes the link from trezor.io/security to https://trezor.io/support/a/how-to-report-a-security-issue which is more concrete. We need to improve this further, but it will do for now as a "hotfix".