### PR TITLE
chore(ci): enable to rebase and squash fixups by comment in PR

### DIFF
--- a/.github/workflows/bot-rebase.yml
+++ b/.github/workflows/bot-rebase.yml
@@ -1,0 +1,23 @@
+name: "[Bot] rebase pull request"
+
+on:
+  issue_comment:
+    types: [created]
+
+jobs:
+  rebase-pr:
+    name: Rebase pull request
+    runs-on: ubuntu-latest
+    if: github.event.issue.pull_request != '' && contains(github.event.comment.body, '/rebase')
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+          token: ${{ secrets.TREZOR_BOT_TOKEN }}
+      - name: Auto rebase pull request
+        uses: cirrus-actions/rebase@1.8
+        with:
+          autosquash: true
+        env:
+          GITHUB_TOKEN: ${{ secrets.TREZOR_BOT_TOKEN }}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Enable autosquash the fixups from the PR just by adding comment `/rebase`. 

If you approve the PR and there are no conflicts but it includes some fixup commits, you could use it to be able to merge the PR without waiting for the author to rebase the PR 🎉 

## Screenshot
![image](https://user-images.githubusercontent.com/3729633/212719807-149b56f6-0eda-486e-a6c4-f41ddda4c921.png)



