### PR TITLE
feat(suite-native): chill theme removed

### DIFF
--- a/packages/theme/src/colors.ts
+++ b/packages/theme/src/colors.ts
@@ -1,51 +1,84 @@
 import { CSSColor } from './types';
 
-export const defaultColorVariant = {
-    green: '#00854D',
-    forest: '#0F6148',
-
-    yellow: '#F7BF2F',
-    blue: '#0078AC',
-    red: '#CD4949',
-
-    // standard theme is defined here, because this object is used as default type shape of colors
-    gray1000: '#141414',
-    gray900: '#1F1F1F',
-    gray800: '#333333',
-    gray700: '#545454',
-    gray600: '#757575',
-    gray500: '#AFAFAF',
-    gray400: '#CBCBCB',
-    gray300: '#E2E2E2',
-    gray200: '#EEEEEE',
-    gray100: '#F6F6F6',
-    gray0: '#FFFFFF',
-} as const;
-
-export type Color = keyof typeof defaultColorVariant;
-
-export type Colors = Record<Color, CSSColor>;
-
 export const colorVariants = {
     standard: {
-        ...defaultColorVariant,
-    },
-    chill: {
-        ...defaultColorVariant,
-        gray1000: '#1B1A19',
-        gray900: '#1E1D1D',
-        gray800: '#353432',
-        gray700: '#54524E',
-        gray600: '#7B7974',
-        gray500: '#A7A59C',
-        gray400: '#D8D3C8',
-        gray300: '#F0EDE6',
-        gray200: '#F5F3EF',
-        gray100: '#FAF8F3',
-        gray0: '#ECECEC',
+        forest: '#0F6148',
+        forest100: '#EDFCF8',
+        forest200: '#CEF7EB',
+        forest700: '#189A73',
+        forest800: '#0F6148',
+        forest900: '#0A4231',
+
+        green: '#00854D',
+        green100: '#EBFFF7',
+        green200: '#C7FFE8',
+        green700: '#00B368',
+        green800: '#00854D',
+        green900: '#004D2D',
+
+        blue: '#0078AC',
+        blue100: '#EBF9FF',
+        blue200: '#C7EEFF',
+        blue600: '#0078AC',
+        blue700: '#004766',
+
+        red: '#CD4949',
+        red100: '#FBEFEF',
+        red200: '#F3D3D3',
+        red600: '#CD4949',
+        red700: '#B83333',
+
+        yellow: '#F7BF2F',
+        yellow100: '#FEF9EB',
+        yellow200: '#FDEEC9',
+        yellow600: '#F7BF2F',
+        yellow700: '#E2A508',
+
+        gray1000: '#171717',
+        gray900: '#1F1F1F',
+        gray800: '#333333',
+        gray700: '#545454',
+        gray600: '#757575',
+        gray500: '#AFAFAF',
+        gray400: '#CBCBCB',
+        gray300: '#E2E2E2',
+        gray200: '#EEEEEE',
+        gray100: '#F6F6F6',
+        gray0: '#FFFFFF',
     },
     dark: {
-        ...defaultColorVariant,
+        forest: '#61DBB7',
+        forest100: '#0D211B',
+        forest200: '#0E2F25',
+        forest700: '#2ECC9C',
+        forest800: '#61DBB7',
+        forest900: '#A7F1DB',
+
+        green: '#2FBC81',
+        green100: '#092519',
+        green200: '#0C3122',
+        green700: '#259365',
+        green800: '#2FBC81',
+        green900: '#74DCB1',
+
+        blue: '#1A6E92',
+        blue100: '#071D27',
+        blue200: '#092734',
+        blue600: '#1A6E92',
+        blue700: '#1F83AD',
+
+        red: '#AC3E3E',
+        red100: '#220C0C',
+        red200: '#2D1010',
+        red600: '#AC3E3E',
+        red700: '#C25656',
+
+        yellow: '#CB9B20',
+        yellow100: '#281E06',
+        yellow200: '#352808',
+        yellow600: '#CB9B20',
+        yellow700: '#E0B138',
+
         gray1000: '#FFFFFF',
         gray900: '#F4F4F4',
         gray800: '#E1E1E1',
@@ -59,5 +92,9 @@ export const colorVariants = {
         gray0: '#000000',
     },
 } as const;
+
+export type Color = keyof typeof colorVariants.standard;
+
+export type Colors = Record<Color, CSSColor>;
 
 export type ThemeColorVariant = keyof typeof colorVariants;

--- a/suite-native/app/src/StylesProvider.tsx
+++ b/suite-native/app/src/StylesProvider.tsx
@@ -12,7 +12,7 @@ type StylesProviderProps = {
 
 const renderer = createRenderer();
 
-const DEFAULT_COLOR_VARIANT: ThemeColorVariant = 'chill';
+const DEFAULT_COLOR_VARIANT: ThemeColorVariant = 'standard';
 
 const getColorVariant = (
     systemColorScheme: ReturnType<typeof useColorScheme>,

--- a/suite-native/module-settings/src/components/ColorSchemePicker.tsx
+++ b/suite-native/module-settings/src/components/ColorSchemePicker.tsx
@@ -18,10 +18,7 @@ export const ColorSchemePicker = () => {
             <Text>Color Scheme</Text>
             <HStack style={applyStyle(stackStyle)} spacing="small">
                 <ColorSchemePickerItem colorScheme="standard" />
-                <ColorSchemePickerItem colorScheme="chill" />
                 <ColorSchemePickerItem colorScheme="dark" />
-            </HStack>
-            <HStack style={applyStyle(stackStyle)} spacing="small">
                 <ColorSchemePickerItem colorScheme="system" />
             </HStack>
         </VStack>

--- a/suite-native/module-settings/src/components/ColorSchemePickerItem.tsx
+++ b/suite-native/module-settings/src/components/ColorSchemePickerItem.tsx
@@ -57,7 +57,7 @@ const useGetSystemColorVariant = (): ThemeColorVariant => {
     if (colorScheme === 'dark') {
         return 'dark';
     }
-    return 'chill';
+    return 'standard';
 };
 
 export const ColorSchemePickerItem = ({ colorScheme }: ColorSchemePickerItemProps) => {

--- a/suite-native/qr-code/src/components/QRCode.tsx
+++ b/suite-native/qr-code/src/components/QRCode.tsx
@@ -6,7 +6,7 @@ import * as Clipboard from 'expo-clipboard';
 
 import { prepareNativeStyle, useNativeStyles } from '@trezor/styles';
 import { Box, Button, HStack, Text } from '@suite-native/atoms';
-import { defaultColorVariant } from '@trezor/theme';
+import { colorVariants } from '@trezor/theme';
 
 type QRCodeProps = {
     data?: string;
@@ -53,8 +53,8 @@ export const QRCode = ({ data, onCopy }: QRCodeProps) => {
             <View style={applyStyle(qrCodeStyle)}>
                 {data && (
                     <ReactQRCode
-                        bgColor={defaultColorVariant.gray0}
-                        fgColor={defaultColorVariant.gray900}
+                        bgColor={colorVariants.standard.gray0}
+                        fgColor={colorVariants.standard.gray900}
                         level="Q"
                         size={QRCODE_SIZE}
                         value={data}

--- a/suite-native/test-utils/src/Provider.tsx
+++ b/suite-native/test-utils/src/Provider.tsx
@@ -8,7 +8,7 @@ type ProviderProps = {
     children: React.ReactNode;
 };
 const renderer = createRenderer();
-const theme = prepareNativeTheme({ colorVariant: 'chill' });
+const theme = prepareNativeTheme({ colorVariant: 'standard' });
 
 export const Provider = ({ children }: ProviderProps) => (
     <SafeAreaProvider>


### PR DESCRIPTION
## Description
The chill theme variant was removed according to design: https://www.figma.com/file/BlVnxNzUqrZkbhHgezLczh/%5BDesign-Handover%5D-MVP?node-id=4196%3A18262&t=faECEbNdp50etmYC-4.

closes #7084

## Screenshot
<img width="390" alt="Screenshot 2023-01-12 at 8 49 50" src="https://user-images.githubusercontent.com/26143964/212008495-adc7cd31-7e50-4698-805b-e565f71f9744.png">

