### PR TITLE
Feat: pause/resume coinjoin when out of sync

### DIFF
--- a/packages/suite/src/actions/wallet/__fixtures__/coinjoinAccountActions.ts
+++ b/packages/suite/src/actions/wallet/__fixtures__/coinjoinAccountActions.ts
@@ -251,3 +251,20 @@ export const restoreCoinjoinAccounts = [
         },
     },
 ];
+
+export const restoreCoinjoinSession = [
+    {
+        description: 'restore one paused coinjoin session',
+        client: 'btc',
+        state: {
+            accounts: [ACCOUNT],
+            coinjoin: {
+                accounts: [{ key: ACCOUNT.key, session: { ...SESSION, paused: true } }],
+            },
+        },
+        param: '12345',
+        result: {
+            actions: [COINJOIN.SESSION_RESTORE],
+        },
+    },
+];

--- a/packages/suite/src/actions/wallet/__tests__/coinjoinAccountActions.test.ts
+++ b/packages/suite/src/actions/wallet/__tests__/coinjoinAccountActions.test.ts
@@ -159,4 +159,20 @@ describe('coinjoinAccountActions', () => {
             expect(actions.map(a => a.type)).toEqual(f.result.actions);
         });
     });
+
+    fixtures.restoreCoinjoinSession.forEach(f => {
+        it(`restoreCoinjoinSession: ${f.description}`, async () => {
+            const store = initStore(f.state as Wallet);
+
+            if (f.client) {
+                await CoinjoinService.createInstance(f.client as any);
+            }
+
+            await store.dispatch(coinjoinAccountActions.restoreCoinjoinSession(f.param));
+
+            const actions = store.getActions();
+
+            expect(actions.map(a => a.type)).toEqual(f.result.actions);
+        });
+    });
 });

--- a/packages/suite/src/reducers/wallet/coinjoinReducer.ts
+++ b/packages/suite/src/reducers/wallet/coinjoinReducer.ts
@@ -11,13 +11,12 @@ import {
     breakdownCoinjoinBalance,
     calculateAnonymityProgress,
     getEstimatedTimePerRound,
-    getIsCoinjoinOutOfSync,
     getRoundPhaseFromSessionPhase,
     transformCoinjoinStatus,
 } from '@wallet-utils/coinjoinUtils';
 import { ESTIMATED_ROUNDS_FAIL_RATE_BUFFER, DEFAULT_CLIENT_STATUS } from '@suite/services/coinjoin';
 import { selectSelectedAccount, selectSelectedAccountParams } from './selectedAccountReducer';
-import { selectDebug, selectDeviceState, selectTorState } from '@suite-reducers/suiteReducer';
+import { selectDebug, selectTorState } from '@suite-reducers/suiteReducer';
 import { selectAccountByKey } from '@suite-common/wallet-core';
 
 export interface CoinjoinClientFeeRatesMedians {

--- a/packages/suite/src/reducers/wallet/coinjoinReducer.ts
+++ b/packages/suite/src/reducers/wallet/coinjoinReducer.ts
@@ -11,12 +11,13 @@ import {
     breakdownCoinjoinBalance,
     calculateAnonymityProgress,
     getEstimatedTimePerRound,
+    getIsCoinjoinOutOfSync,
     getRoundPhaseFromSessionPhase,
     transformCoinjoinStatus,
 } from '@wallet-utils/coinjoinUtils';
 import { ESTIMATED_ROUNDS_FAIL_RATE_BUFFER, DEFAULT_CLIENT_STATUS } from '@suite/services/coinjoin';
 import { selectSelectedAccount, selectSelectedAccountParams } from './selectedAccountReducer';
-import { selectDebug, selectTorState } from '@suite-reducers/suiteReducer';
+import { selectDebug, selectDeviceState, selectTorState } from '@suite-reducers/suiteReducer';
 import { selectAccountByKey } from '@suite-common/wallet-core';
 
 export interface CoinjoinClientFeeRatesMedians {
@@ -459,4 +460,23 @@ export const selectIsCoinjoinBlockedByTor = createSelector(
 
 export const selectIsAnySessionInCriticalPhase = createSelector(selectCoinjoinAccounts, accounts =>
     accounts.some(acc => (acc.session?.roundPhase ?? 0) > 0),
+);
+
+export const selectIsAccountWithSessionInCriticalPhaseByAccountKey = createSelector(
+    [selectCoinjoinAccountByKey],
+    coinjoinAccount => (coinjoinAccount?.session?.roundPhase ?? 0) > 0,
+);
+
+export const selectIsAccountWithSessionByAccountKey = createSelector(
+    [selectCoinjoinAccounts, (_state: CoinjoinRootState, accountKey: string) => accountKey],
+    (coinjoinAccounts, accountKey) =>
+        coinjoinAccounts.find(a => a.key === accountKey && a.session && !a.session.paused),
+);
+
+export const selectIsAccountWithPausedSessionInterruptedByAccountKey = createSelector(
+    [selectCoinjoinAccountByKey],
+    coinjoinAccount =>
+        coinjoinAccount?.session &&
+        coinjoinAccount.session.paused &&
+        coinjoinAccount.session.interrupted,
 );


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Pause/Resume running CoinJoin when account is out of sync and the rest of the conditions allow coinjoin to be resumed.

## Related Issue

Resolve https://github.com/trezor/trezor-suite/issues/6890

