### PR TITLE
chore(connect): async TrezorConnect.dispose

### DIFF
--- a/packages/connect-web/src/index.ts
+++ b/packages/connect-web/src/index.ts
@@ -65,6 +65,7 @@ const dispose = () => {
     if (_popupManager) {
         _popupManager.close();
     }
+    return Promise.resolve(undefined);
 };
 
 const cancel = (error?: string) => {

--- a/packages/connect/e2e/tests/api/init.test.ts
+++ b/packages/connect/e2e/tests/api/init.test.ts
@@ -4,8 +4,8 @@ import TrezorConnect from '@trezor/connect';
 const INIT_ERROR = { code: 'Init_ManifestMissing' };
 
 describe('TrezorConnect.init', () => {
-    afterEach(() => {
-        TrezorConnect.dispose();
+    afterEach(async () => {
+        await TrezorConnect.dispose();
     });
 
     beforeAll(() => {

--- a/packages/connect/e2e/tests/device/authorizeCoinJoin.test.ts
+++ b/packages/connect/e2e/tests/device/authorizeCoinJoin.test.ts
@@ -19,7 +19,8 @@ describe('TrezorConnect.authorizeCoinJoin', () => {
 
     beforeEach(async () => {
         // restart connect for each test (working with event listeners)
-        TrezorConnect.dispose();
+        await TrezorConnect.dispose();
+
         await initTrezorConnect(controller, { debug: false });
 
         TrezorConnect.on('DEVICE_EVENT', ev => {
@@ -29,9 +30,9 @@ describe('TrezorConnect.authorizeCoinJoin', () => {
         });
     });
 
-    afterAll(() => {
+    afterAll(async () => {
         controller.dispose();
-        TrezorConnect.dispose();
+        await TrezorConnect.dispose();
     });
 
     conditionalTest(['1', '<2.5.3'], 'Coinjoin success', async () => {

--- a/packages/connect/e2e/tests/device/methods.test.ts
+++ b/packages/connect/e2e/tests/device/methods.test.ts
@@ -26,18 +26,19 @@ type TestCase = {
 };
 
 describe(`TrezorConnect methods`, () => {
-    afterAll(done => {
+    afterAll(() => {
         // reset controller at the end
         if (controller) {
             controller.dispose();
             controller = undefined;
         }
-        done();
     });
 
     fixtures.forEach((testCase: TestCase) => {
         describe(`TrezorConnect.${testCase.method}`, () => {
             beforeAll(async () => {
+                await TrezorConnect.dispose();
+
                 try {
                     if (!controller) {
                         controller = getController(testCase.method);
@@ -49,17 +50,10 @@ describe(`TrezorConnect methods`, () => {
                     await setup(controller, testCase.setup);
 
                     await initTrezorConnect(controller);
-                    // done();
                 } catch (error) {
                     console.log('Controller WS init error', error);
-                    // done(error);
                 }
             }, 40000);
-
-            afterAll(done => {
-                TrezorConnect.dispose();
-                done();
-            });
 
             testCase.tests.forEach(t => {
                 // check if test should be skipped on current configuration
@@ -99,7 +93,6 @@ describe(`TrezorConnect methods`, () => {
                         }
 
                         expect(result).toMatchObject(expected);
-                        // done();
                     },
                     t.customTimeout || 20000,
                 );

--- a/packages/connect/e2e/tests/device/passphrase.test.ts
+++ b/packages/connect/e2e/tests/device/passphrase.test.ts
@@ -26,9 +26,9 @@ describe('TrezorConnect passphrase', () => {
         await initTrezorConnect(controller, { debug: false });
     });
 
-    afterAll(() => {
+    afterAll(async () => {
         controller.dispose();
-        TrezorConnect.dispose();
+        await TrezorConnect.dispose();
     });
 
     // firmware after passphrase redesign

--- a/packages/connect/e2e/tests/device/setBusy.test.ts
+++ b/packages/connect/e2e/tests/device/setBusy.test.ts
@@ -16,9 +16,9 @@ describe('TrezorConnect.setBusy', () => {
         await initTrezorConnect(controller);
     });
 
-    afterAll(() => {
+    afterAll(async () => {
         controller.dispose();
-        TrezorConnect.dispose();
+        await TrezorConnect.dispose();
     });
 
     conditionalTest(['1', '<2.5.3'], 'setBusy timeout', async () => {

--- a/packages/connect/e2e/tests/device/unlockPath.test.ts
+++ b/packages/connect/e2e/tests/device/unlockPath.test.ts
@@ -13,9 +13,9 @@ describe('TrezorConnect.unlockPath', () => {
         await initTrezorConnect(controller);
     });
 
-    afterAll(() => {
+    afterAll(async () => {
         controller.dispose();
-        TrezorConnect.dispose();
+        await TrezorConnect.dispose();
     });
 
     conditionalTest(['1', '<2.5.3'], 'Unlock SLIP-25 + getAddress', async () => {

--- a/packages/connect/src/core/index.ts
+++ b/packages/connect/src/core/index.ts
@@ -969,12 +969,12 @@ export class Core extends EventEmitter {
         handleMessage(message, isTrustedOrigin);
     }
 
-    dispose() {
-        if (_deviceList) {
-            _deviceList.dispose();
-        }
+    async dispose() {
         disposeBackend();
         this.removeAllListeners();
+        if (_deviceList) {
+            await _deviceList.dispose();
+        }
     }
 
     getCurrentMethod() {
@@ -1055,7 +1055,7 @@ const disableWebUSBTransport = async () => {
 
     try {
         // disconnect previous device list
-        _deviceList.dispose();
+        await _deviceList.dispose();
         // and init with new settings, without webusb
         await initDeviceList(settings);
     } catch (error) {

--- a/packages/connect/src/device/Device.ts
+++ b/packages/connect/src/device/Device.ts
@@ -684,7 +684,8 @@ export class Device extends EventEmitter {
                 if (this.commands) {
                     this.commands.cancel();
                 }
-                this.transport.release(this.activitySessionID, true, false);
+
+                return this.transport.release(this.activitySessionID, true);
             } catch (err) {
                 // empty
             }

--- a/packages/connect/src/device/DeviceList.ts
+++ b/packages/connect/src/device/DeviceList.ts
@@ -275,12 +275,17 @@ export class DeviceList extends EventEmitter {
         };
     }
 
-    dispose() {
+    async dispose() {
         this.removeAllListeners();
 
         if (this.stream) {
             this.stream.stop();
         }
+        // release all devices
+        await Promise.all(this.allDevices().map(device => device.dispose()));
+
+        // now we can be relatively sure that release calls have been dispatched
+        // and we can safely kill all async subscriptions in transport layer
         if (this.transport) {
             this.transport.stop();
         }
@@ -288,8 +293,6 @@ export class DeviceList extends EventEmitter {
             this.fetchController.abort();
             this.fetchController = null;
         }
-
-        this.allDevices().forEach(device => device.dispose());
     }
 
     disconnectDevices() {

--- a/packages/connect/src/index.ts
+++ b/packages/connect/src/index.ts
@@ -41,11 +41,11 @@ const manifest = (data: Manifest) => {
     });
 };
 
-const dispose = () => {
+const dispose = async () => {
     eventEmitter.removeAllListeners();
     _settings = parseConnectSettings();
     if (_core) {
-        _core.dispose();
+        await _core.dispose();
         _core = null;
     }
 };

--- a/packages/connect/src/types/api/dispose.ts
+++ b/packages/connect/src/types/api/dispose.ts
@@ -1,1 +1,1 @@
-export declare function dispose(): void;
+export declare function dispose(): Promise<void>;

--- a/packages/transport/src/types/index.ts
+++ b/packages/transport/src/types/index.ts
@@ -22,7 +22,7 @@ export type Transport = {
     enumerate(): Promise<Array<TrezorDeviceInfoWithSession>>;
     listen(old?: Array<TrezorDeviceInfoWithSession>): Promise<Array<TrezorDeviceInfoWithSession>>;
     acquire(input: AcquireInput, debugLink: boolean): Promise<string>;
-    release(session: string, onclose: boolean, debugLink: boolean): Promise<void>;
+    release(session: string, onclose: boolean, debugLink?: boolean): Promise<void>;
     configure(signedData: JSON | string): Promise<void>;
     call(
         session: string,


### PR DESCRIPTION
sort of followup for this https://github.com/trezor/trezor-suite/compare/develop...connect-reload-release, it was incomplete.

TrezorConnect.dispose should be awaitable and should ensure that once it resolves, all devices have been released so that no orphaned session persists after TrezorConnect is reinitialized.

This should help in tests - we were historicaly bypassing this by reseting bridge before each test. From users perspective you should see less "unacquired device" screens"

you can compare this branch and current production with these steps :
1. use bridge. for webusb this might be relevant only if there are multiple active tabs
1. open suite with passphrase enabled
1. wait for passphrase dialog
1. reload
1. observe. in production, you get almost always "unacquired device". here you should be fine


part of #6509