### PR TITLE
Progress handle used instead of descriptor in coinjoin discovery

### DIFF
--- a/packages/coinjoin/src/backend/CoinjoinBackend.ts
+++ b/packages/coinjoin/src/backend/CoinjoinBackend.ts
@@ -71,7 +71,7 @@ export class CoinjoinBackend extends EventEmitter {
         this.mempool = new CoinjoinMempoolController(this.client);
     }
 
-    scanAccount({ descriptor, checkpoints, cache }: ScanAccountParams) {
+    scanAccount({ descriptor, progressHandle, checkpoints, cache }: ScanAccountParams) {
         this.abortController = new AbortController();
         const filters = new CoinjoinFilterController(this.client, this.settings);
 
@@ -83,12 +83,13 @@ export class CoinjoinBackend extends EventEmitter {
                 abortSignal: this.abortController.signal,
                 filters,
                 mempool: this.mempool,
-                onProgress: progress => this.emit(`progress/${descriptor}`, progress),
+                onProgress: progress =>
+                    this.emit(`progress/${progressHandle ?? descriptor}`, progress),
             },
         );
     }
 
-    scanAddress({ descriptor, checkpoints }: ScanAddressParams) {
+    scanAddress({ descriptor, progressHandle, checkpoints }: ScanAddressParams) {
         this.abortController = new AbortController();
         const filters = new CoinjoinFilterController(this.client, this.settings);
 
@@ -101,7 +102,7 @@ export class CoinjoinBackend extends EventEmitter {
                 filters,
                 mempool: this.mempool,
                 onProgress: progress =>
-                    this.emit(`progress/${descriptor}`, {
+                    this.emit(`progress/${progressHandle ?? descriptor}`, {
                         ...progress,
                         // TODO resolve this correctly
                         checkpoint: { ...progress.checkpoint, receiveCount: -1, changeCount: -1 },

--- a/packages/coinjoin/src/types/backend.ts
+++ b/packages/coinjoin/src/types/backend.ts
@@ -83,12 +83,14 @@ export type ScanAccountProgress = ScanProgress<ScanAccountCheckpoint>;
 
 export type ScanAccountParams = {
     descriptor: string;
+    progressHandle?: string;
     checkpoints?: ScanAccountCheckpoint[];
     cache?: AccountCache;
 };
 
 export type ScanAddressParams = {
     descriptor: string;
+    progressHandle?: string;
     checkpoints?: ScanAddressCheckpoint[];
 };
 

--- a/packages/suite/src/components/wallet/WalletLayout/components/CoinjoinAccountDiscoveryProgress/AccountLoadingProgress.tsx
+++ b/packages/suite/src/components/wallet/WalletLayout/components/CoinjoinAccountDiscoveryProgress/AccountLoadingProgress.tsx
@@ -4,6 +4,7 @@ import { Progress } from '@trezor/components';
 import { CoinjoinService } from '@suite/services/coinjoin';
 import { selectSelectedAccount } from '@wallet-reducers/selectedAccountReducer';
 import { useSelector } from '@suite-hooks/useSelector';
+import { getAccountProgressHandle } from '@wallet-utils/coinjoinUtils';
 
 const DiscoveryProgress = styled(Progress)`
     max-width: 440px;
@@ -19,7 +20,8 @@ export const AccountLoadingProgress = () => {
     const selectedAccount = useSelector(selectSelectedAccount);
     const [progress, setProgress] = useState<ProgressInfo>({});
 
-    const { symbol: network, backendType, descriptor } = selectedAccount || {};
+    const { symbol: network, backendType } = selectedAccount || {};
+    const progressHandle = selectedAccount && getAccountProgressHandle(selectedAccount);
 
     useEffect(() => {
         if (!network || backendType !== 'coinjoin') {
@@ -34,12 +36,12 @@ export const AccountLoadingProgress = () => {
 
         const onProgress = ({ info }: { info?: ProgressInfo }) => info && setProgress(info);
 
-        api.backend.on(`progress/${descriptor}`, onProgress);
+        api.backend.on(`progress/${progressHandle}`, onProgress);
 
         return () => {
-            api.backend.off(`progress/${descriptor}`, onProgress);
+            api.backend.off(`progress/${progressHandle}`, onProgress);
         };
-    }, [network, backendType, descriptor]);
+    }, [network, backendType, progressHandle]);
 
     const value = progress.progress ?? 0;
 

--- a/packages/suite/src/utils/wallet/coinjoinUtils.ts
+++ b/packages/suite/src/utils/wallet/coinjoinUtils.ts
@@ -1,4 +1,5 @@
 import BigNumber from 'bignumber.js';
+import { createHash } from 'crypto';
 
 import { getUtxoOutpoint, getBip43Type } from '@suite-common/wallet-utils';
 import {
@@ -355,3 +356,6 @@ export const getRoundPhaseFromSessionPhase = (sessionPhase: SessionPhase): Round
 
 export const getFirstSessionPhaseFromRoundPhase = (roundPhase?: RoundPhase): SessionPhase =>
     Number(`${(roundPhase || 0) + 1}1`);
+
+export const getAccountProgressHandle = (account: Account) =>
+    createHash('sha256').update(account.key).digest('hex').slice(0, 16);


### PR DESCRIPTION
## Description

During coinjoin's `scanAccount`, Suite listened to the progress events by account's descriptor. Therefore,

- there could be a collision between two `scanAccount`s running in parallel e.g. when both testnet & regtest accounts with the same descriptor were enabled (or two identical accounts from two different devices, ...), and
- event names were sometimes logged which could theoretically leak xpubs.

Now, `scanAccount` optionally takes `progressHandle` created by hashing `account.key` (= `descriptor` + `coin` + `device`) and uses it instead of the descriptor, which resolves both issues.