### PR TITLE
fix(suite): Tor enabled when misbehaving

### DIFF
--- a/packages/suite/src/utils/suite/tor.ts
+++ b/packages/suite/src/utils/suite/tor.ts
@@ -32,6 +32,8 @@ export const isOnionUrl = (url: string) => {
 export const getIsTorEnabled = (torStatus: TorStatus) => {
     switch (torStatus) {
         case TorStatus.Enabled:
+        case TorStatus.Misbehaving:
+            // When Tor is in status Misbehaving means network is not behaving properly but still enabled.
             return true;
 
         case TorStatus.Enabling:


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

When Tor was in state Misbehaving the UI thought it was not enabled. Considering Misbehaving status as enabled.
