### PR TITLE
fix(suite): fix filename for transactions export

### DIFF
--- a/packages/suite/src/views/wallet/transactions/components/TransactionList/components/Actions/components/ExportAction.tsx
+++ b/packages/suite/src/views/wallet/transactions/components/TransactionList/components/Actions/components/ExportAction.tsx
@@ -25,6 +25,17 @@ export const ExportAction = ({ account }: ExportActionProps) => {
     });
 
     const [isExportRunning, setIsExportRunning] = useState(false);
+
+    const getAccountTitle = useCallback(() => {
+        if (account.accountType === 'coinjoin') {
+            return translationString(getTitleForCoinJoinAccount(account.symbol));
+        }
+        return translationString('LABELING_ACCOUNT', {
+            networkName: translationString(getTitleForNetwork(account.symbol)),
+            index: account.index + 1,
+        });
+    }, [account, translationString]);
+
     const runExport = useCallback(
         async (type: ExportFileType) => {
             if (isExportRunning) {
@@ -48,13 +59,7 @@ export const ExportAction = ({ account }: ExportActionProps) => {
                     noLoading: true,
                     recursive: true,
                 });
-                const accountName =
-                    account.metadata.accountLabel || account.accountType === 'coinjoin'
-                        ? translationString(getTitleForCoinJoinAccount(account.symbol))
-                        : translationString('LABELING_ACCOUNT', {
-                              networkName: translationString(getTitleForNetwork(account.symbol)),
-                              index: account.index + 1,
-                          });
+                const accountName = account.metadata.accountLabel || getAccountTitle();
                 await exportTransactions({ account, accountName, type });
             } catch (error) {
                 console.error('Export transaction failed: ', error);
@@ -73,6 +78,7 @@ export const ExportAction = ({ account }: ExportActionProps) => {
             exportTransactions,
             addToast,
             translationString,
+            getAccountTitle,
         ],
     );
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Fix the bug when any account with label has transation export file named by coinjoin 🐞 

<!--- Describe your changes in detail -->

## Related Issue

Fixes https://github.com/trezor/trezor-suite/issues/7389

## Screenshots:
default account with label:
<img width="822" alt="image" src="https://user-images.githubusercontent.com/3729633/212672461-bbcab019-8938-4076-9ebc-1bfdc09e1c29.png">

default account without label:
<img width="823" alt="image" src="https://user-images.githubusercontent.com/3729633/212672511-6e8645de-5b65-417b-a031-51fdb9fd1ed8.png">


