### PR TITLE
fix(connect): fix type of return value in Stellar plugin.

### DIFF
--- a/packages/connect-plugin-stellar/src/index.ts
+++ b/packages/connect-plugin-stellar/src/index.ts
@@ -65,7 +65,7 @@ const transformMemo = (memo: Memo) => {
         case StellarSdk.MemoText:
             return { type: 1, text: memo.value!.toString('utf-8') };
         case StellarSdk.MemoID:
-            return { type: 2, id: memo.value };
+            return { type: 2, id: memo.value!.toString('utf-8') };
         case StellarSdk.MemoHash:
             // stringify is not necessary, Buffer is also accepted
             return { type: 3, hash: memo.value!.toString('hex') };


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->


## Description

The types of the parameters returned by transformTransaction do not match the types of the parameters required by stellarSignTransaction.

When the Memo type is Id, the value must always be a string, see:
https://github.com/stellar/js-stellar-base/blob/f508a02f239df9810a35e3704d2081dbdf05a3c9/types/index.d.ts#L186

Here is the type definition for the parameters required by stellarSignTransaction:
https://github.com/trezor/trezor-suite/blob/55e06137276ee44ce70a15308b9f534b6c2b85fd/packages/connect/src/types/api/stellar/index.ts#L164

