### PR TITLE
Fix: Tor notifications improvements

### DIFF
--- a/packages/suite/src/support/suite/useTor.tsx
+++ b/packages/suite/src/support/suite/useTor.tsx
@@ -11,11 +11,11 @@ import { selectTorState } from '@suite-reducers/suiteReducer';
 import { notificationsActions } from '@suite-common/toast-notifications';
 
 export const useTor = () => {
-    const { updateTorStatus, setTorBootstrap, setTorBootstrapSlow, addToast } = useActions({
+    const { updateTorStatus, setTorBootstrap, setTorBootstrapSlow, addToastOnce } = useActions({
         updateTorStatus: suiteActions.updateTorStatus,
         setTorBootstrap: suiteActions.setTorBootstrap,
         setTorBootstrapSlow: suiteActions.setTorBootstrapSlow,
-        addToast: notificationsActions.addToast,
+        addToastOnce: notificationsActions.addToastOnce,
     });
     const { torBootstrap, isTorEnabling } = useSelector(selectTorState);
 
@@ -34,7 +34,7 @@ export const useTor = () => {
                 if (type === TorStatus.Misbehaving) {
                     // When network is slow for some reason but still working we display toast message
                     // to let the user know that it is going to take some time but it's working.
-                    addToast({
+                    addToastOnce({
                         type: 'tor-is-slow',
                     });
                 }
@@ -42,7 +42,7 @@ export const useTor = () => {
         }
 
         return () => desktopApi.removeAllListeners('tor/status');
-    }, [updateTorStatus, torBootstrap, addToast]);
+    }, [updateTorStatus, torBootstrap, addToastOnce]);
 
     useEffect(() => {
         desktopApi.on('tor/bootstrap', (bootstrapEvent: BootstrapTorEvent) => {

--- a/suite-common/toast-notifications/src/notificationsActions.ts
+++ b/suite-common/toast-notifications/src/notificationsActions.ts
@@ -2,6 +2,7 @@ import { createAction } from '@reduxjs/toolkit';
 
 import { createActionWithExtraDeps } from '@suite-common/redux-utils';
 
+import { selectVisibleNotificationsByType } from './notificationsSelectors';
 import { NotificationEntry, NotificationEventPayload, ToastPayload } from './types';
 
 export const ACTION_PREFIX = '@common/in-app-notifications';
@@ -37,6 +38,18 @@ export const addToast = createActionWithExtraDeps(
     }),
 );
 
+// Adds a Toast if there is not one of same type visible.
+export const addToastOnce = createActionWithExtraDeps(
+    `${ACTION_PREFIX}/addToastOnce`,
+    (payload: ToastPayload, { getState, dispatch }): NotificationEntry | undefined => {
+        const notifications = selectVisibleNotificationsByType(getState(), payload.type);
+        if (notifications.length > 0) {
+            return;
+        }
+        return dispatch(addToast(payload));
+    },
+);
+
 export const addEvent = createActionWithExtraDeps(
     `${ACTION_PREFIX}/addEvent`,
     (payload: NotificationEventPayload, { getState, extra }): NotificationEntry => ({
@@ -53,4 +66,5 @@ export const notificationsActions = {
     remove,
     addToast,
     addEvent,
+    addToastOnce,
 };

--- a/suite-common/toast-notifications/src/notificationsReducer.ts
+++ b/suite-common/toast-notifications/src/notificationsReducer.ts
@@ -1,13 +1,7 @@
 import { createReducer, isAnyOf } from '@reduxjs/toolkit';
 
 import { notificationsActions } from './notificationsActions';
-import { NotificationEntry } from './types';
-
-export type NotificationsState = NotificationEntry[];
-
-export type NotificationsRootState = {
-    notifications: NotificationsState;
-};
+import { NotificationsState } from './types';
 
 const initialState: NotificationsState = [];
 

--- a/suite-common/toast-notifications/src/notificationsSelectors.ts
+++ b/suite-common/toast-notifications/src/notificationsSelectors.ts
@@ -1,3 +1,17 @@
-import type { NotificationsRootState } from './notificationsReducer';
+import { createSelector } from '@reduxjs/toolkit';
+
+import { NotificationsRootState, NotificationsState, ToastPayload } from './types';
 
 export const selectNotifications = (state: NotificationsRootState) => state.notifications;
+
+export const selectVisibleNotificationsByType = createSelector(
+    [
+        selectNotifications,
+        (_state: NotificationsRootState, notificationType: ToastPayload[keyof ToastPayload]) =>
+            notificationType,
+    ],
+    (notifications: NotificationsState, notificationType) =>
+        notifications.filter(
+            notification => notification.type === notificationType && !notification.closed,
+        ),
+);

--- a/suite-common/toast-notifications/src/tests/notificationsReducer.test.ts
+++ b/suite-common/toast-notifications/src/tests/notificationsReducer.test.ts
@@ -1,13 +1,10 @@
 import { configureMockStore } from '@suite-common/test-utils';
 
 import { notificationsActions } from '../notificationsActions';
-import {
-    notificationsReducer,
-    NotificationsRootState,
-    NotificationsState,
-} from '../notificationsReducer';
+import { notificationsReducer } from '../notificationsReducer';
 import { selectNotifications } from '../notificationsSelectors';
 import { removeAccountEventsThunk, removeTransactionEventsThunk } from '../notificationsThunks';
+import { NotificationsRootState, NotificationsState } from '../types';
 
 interface InitStoreArgs {
     preloadedState?: NotificationsRootState;

--- a/suite-common/toast-notifications/src/types.ts
+++ b/suite-common/toast-notifications/src/types.ts
@@ -157,3 +157,9 @@ export type EventNotification = { context: 'event' } & CommonNotificationPayload
     NotificationEventPayload;
 
 export type NotificationEntry = ToastNotification | EventNotification;
+
+export type NotificationsState = NotificationEntry[];
+
+export type NotificationsRootState = {
+    notifications: NotificationsState;
+};


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
* a35d7affab4c9080832ae6cff092058e297e5fb9 - creates new action for notifications that close notification if there is one with same type visible.
* dd09cbe3bb30c9d2242cc8f75c804a2890f59f71 - use addToastOnce when Tor gets notification that it is slow. So the UI does not display many Toast messages with the same information at once.

Closes https://github.com/trezor/trezor-suite/issues/7436

