### PR TITLE
Disable selection of UTXOs registered for coinjoin

### DIFF
--- a/packages/components/src/components/form/Checkbox/index.tsx
+++ b/packages/components/src/components/form/Checkbox/index.tsx
@@ -28,8 +28,12 @@ const IconWrapper = styled.div<
     max-width: 24px;
     height: 24px;
     border-radius: 4px;
-    background: ${({ $color, isChecked, theme }) =>
-        isChecked ? $color || theme.BG_GREEN : theme.BG_WHITE};
+    background: ${({ $color, isChecked, isDisabled, theme }) => {
+        if (isDisabled) {
+            return theme.BG_GREY;
+        }
+        return isChecked ? $color || theme.BG_GREEN : theme.BG_WHITE;
+    }};
     border: 2px solid
         ${({ $color, isChecked, theme }) =>
             isChecked ? $color || theme.BG_GREEN : theme.STROKE_GREY};
@@ -57,7 +61,7 @@ const handleKeyboard = (
     event: React.KeyboardEvent<HTMLElement>,
     onClick: CheckboxProps['onClick'],
 ) => {
-    if (event.code === KEYBOARD_CODE.SPACE) {
+    if (onClick && event.code === KEYBOARD_CODE.SPACE) {
         onClick(event);
     }
 };
@@ -66,7 +70,7 @@ export interface CheckboxProps extends React.HTMLAttributes<HTMLDivElement> {
     color?: string;
     isChecked?: boolean;
     isDisabled?: boolean;
-    onClick: (
+    onClick?: (
         event: React.KeyboardEvent<HTMLElement> | React.MouseEvent<HTMLElement> | null,
     ) => any;
 }

--- a/packages/suite/src/support/messages.ts
+++ b/packages/suite/src/support/messages.ts
@@ -5674,7 +5674,7 @@ export default defineMessages({
     },
     TR_REGISTERED_FOR_COINJOIN: {
         id: 'TR_REGISTERED_FOR_COINJOIN',
-        defaultMessage: 'Registered in CoinJoin',
+        defaultMessage: 'Registered in CoinJoin, temporarily unavailable for sending.',
         description: 'Tooltip over an icon in Coin control section',
     },
     TR_AMOUNT_TOO_SMALL_FOR_COINJOIN: {


### PR DESCRIPTION
## Description

Checkbox is disabled while the UTXO is registered for an upcoming coinjoin round. The data about registered UTXOs will be available when #7323 is merged. I used the icon which indicates coinjoin transaction in history instead of the one presented in the issue to be more consistent.

## Related Issue

Resolve #7351

## Screenshots:
https://user-images.githubusercontent.com/42465546/212722401-3fc81770-38b0-48d3-bcd3-55a6aab195cc.mov

