### PR TITLE
introduce TrezorConnect.init transports param

### DIFF
--- a/docs/packages/connect/methods/init.md
+++ b/docs/packages/connect/methods/init.md
@@ -18,7 +18,9 @@ const result = await TrezorConnect.init(params);
 -   `interactionTimeout` - _optional_ `number`, default `600`. Time in seconds after which popup automatically closes.
 -   `lazyLoad` - _optional_ `boolean`, default `false`. Postpone iframe creation until TrezorConnect is called for the first time.
 -   `popup` - _optional_ `boolean`, default `true`. Projects running on trusted domains (trezor.io) are not required to use popup. For other domains this option is ignored.
--   `webusb` — _optional_ `boolean`, default `true`. Allow webusb.
+-   `transports` — \_optional `'(BridgeTransport' | 'WebUsbTransport)[]'`, Array of transports that should be use. If not provided, TrezorConnect will chose a reasonable
+    default based on your environment.
+-   `webusb` — _deprecated_ `boolean`, default `true`. Allow webusb. Deprecated, you should use `transports` instead.
 
 ### Result
 

--- a/packages/analytics/README.md
+++ b/packages/analytics/README.md
@@ -32,7 +32,7 @@ Which tracks:
   c_instance_id: 'qlT0xL2XKV',
   c_session_id: 'FZjilOYQic',
   c_timestamp: 1624893047903,
-  type: 'bridge',
+  type: 'BridgeTransport',
   version: '2.0.30'
 }
 ```

--- a/packages/analytics/src/tests/fixtures/encodeDataToQueryString.ts
+++ b/packages/analytics/src/tests/fixtures/encodeDataToQueryString.ts
@@ -8,13 +8,13 @@ export default [
         data: {
             type: 'transport-type',
             payload: {
-                type: 'bridge',
+                type: 'BridgeTransport',
                 version: '2',
             },
         },
         encoded: `c_v=1.18&c_type=transport-type&c_commit=abcdef&c_instance_id=1&c_session_id=2&c_timestamp=${new Date(
             '2021-04-01T12:10:00.000Z',
-        ).getTime()}&c_message_id=random&type=bridge&version=2`,
+        ).getTime()}&c_message_id=random&type=BridgeTransport&version=2`,
     },
     {
         currentDate: '2021-04-02T12:10:00.000Z',

--- a/packages/connect-examples/electron-main-process/src/trezor-connect-ipc.js
+++ b/packages/connect-examples/electron-main-process/src/trezor-connect-ipc.js
@@ -92,7 +92,6 @@ exports.initTrezorConnect = sender => {
 
     TrezorConnect.init({
         popup: false, // render your own UI
-        webusb: false, // webusb is not supported in electron
         debug: false, // see what's going on inside connect
         // lazyLoad: true, // set to "false" (default) if you want to start communication with bridge on application start (and detect connected device right away)
         // set it to "true", then trezor-connect will not be initialized until you call some TrezorConnect.method()
@@ -101,6 +100,7 @@ exports.initTrezorConnect = sender => {
             email: 'email@developer.com',
             appUrl: 'electron-app-boilerplate',
         },
+        transports: ['BridgeTransport'],
     })
         .then(() => {
             sender.send('trezor-connect', 'TrezorConnect is ready!');

--- a/packages/connect-examples/electron-renderer-with-assets/src/renderer.js
+++ b/packages/connect-examples/electron-renderer-with-assets/src/renderer.js
@@ -101,7 +101,6 @@ console.log('TrezorConnect', TrezorConnect);
 TrezorConnect.init({
     connectSrc: 'trezor-connect-bundled/',
     popup: false, // render your own UI
-    webusb: false, // webusb is not supported in electron
     debug: false, // see what's going on inside connect
     // lazyLoad: true, // set to "false" (default) if you want to start communication with bridge on application start (and detect connected device right away)
     // set it to "true", then @trezor/connect will not be initialized until you call some TrezorConnect.method()
@@ -110,6 +109,7 @@ TrezorConnect.init({
         email: 'email@developer.com',
         appUrl: 'electron-app-boilerplate',
     },
+    transports: ['BridgeTransport'],
 })
     .then(() => {
         printLog('TrezorConnect is ready!');

--- a/packages/connect-examples/electron-renderer-with-popup/src/renderer.js
+++ b/packages/connect-examples/electron-renderer-with-popup/src/renderer.js
@@ -24,7 +24,6 @@ TrezorConnect.on('DEVICE_EVENT', event => {
 
 // Initialize TrezorConnect
 TrezorConnect.init({
-    webusb: false, // webusb is not supported in electron
     debug: false, // see whats going on inside iframe
     lazyLoad: true, // set to "false" (default) if you want to start communication with bridge on application start (and detect connected device right away)
     // set it to "true", then @trezor/connect will not be initialized until you call some TrezorConnect.method()
@@ -33,6 +32,7 @@ TrezorConnect.init({
         email: 'email@developer.com',
         appUrl: 'electron-app-boilerplate',
     },
+    transports: ['BridgeTransport'],
 })
     .then(() => {
         printLog('TrezorConnect is ready!');

--- a/packages/connect-web/src/iframe/index.ts
+++ b/packages/connect-web/src/iframe/index.ts
@@ -89,6 +89,9 @@ export const init = async (settings: ConnectSettings) => {
 
     instance.setAttribute('src', src);
     if (settings.webusb) {
+        console.warn('webusb option is deprecated. use `transports: ["WebUsbTransport"] instead`');
+    }
+    if (settings.webusb || settings.transports?.includes('WebUsbTransport')) {
         instance.setAttribute('allow', 'usb');
     }
 

--- a/packages/connect-web/src/index.ts
+++ b/packages/connect-web/src/index.ts
@@ -148,6 +148,11 @@ const init = async (settings: Partial<ConnectSettings> = {}): Promise<void> => {
         throw ERRORS.TypedError('Init_ManifestMissing');
     }
 
+    // defaults for connect-web
+    if (!_settings.transports?.length) {
+        _settings.transports = ['BridgeTransport', 'WebUsbTransport'];
+    }
+
     if (_settings.lazyLoad) {
         // reset "lazyLoad" after first use
         _settings.lazyLoad = false;

--- a/packages/connect/e2e/common.setup.js
+++ b/packages/connect/e2e/common.setup.js
@@ -109,7 +109,7 @@ const initTrezorConnect = async (TrezorUserEnvLink, options) => {
             appUrl: 'tests.connect.trezor.io',
             email: 'tests@connect.trezor.io',
         },
-        webusb: false,
+        transports: ['BridgeTransport'],
         debug: false,
         popup: false,
         pendingTransportEvent: true,

--- a/packages/connect/src/core/index.ts
+++ b/packages/connect/src/core/index.ts
@@ -211,7 +211,7 @@ const initDevice = async (method: AbstractMethod) => {
         throw ERRORS.TypedError('Transport_Missing');
     }
 
-    const isWebUsb = _deviceList.transportType() === 'WebUsbPlugin';
+    const isWebUsb = _deviceList.transportType() === 'WebUsbTransport';
     let device: Device | typeof undefined;
     let showDeviceSelection = isWebUsb;
     if (method.devicePath) {
@@ -847,7 +847,7 @@ const handleDeviceSelectionChanges = (interruptDevice?: DeviceTyped) => {
     const uiPromise = findUiPromise(UI.RECEIVE_DEVICE);
     if (uiPromise && _deviceList) {
         const list = _deviceList.asArray();
-        const isWebUsb = _deviceList.transportType().indexOf('webusb') >= 0;
+        const isWebUsb = _deviceList.transportType() === 'WebUsbTransport';
 
         if (list.length === 1 && !isWebUsb) {
             // there is only one device. use it
@@ -1048,10 +1048,16 @@ export const initTransport = async (settings: ConnectSettings) => {
 
 const disableWebUSBTransport = async () => {
     if (!_deviceList) return;
-    if (_deviceList.transportType() !== 'WebUsbPlugin') return;
+    if (_deviceList.transportType() !== 'WebUsbTransport') return;
     // override settings
     const settings = DataManager.getSettings();
-    settings.webusb = false;
+
+    if (settings.transports?.includes('WebUsbTransport')) {
+        settings.transports.splice(settings.transports.indexOf('WebUsbTransport'));
+    }
+    if (!settings.transports?.includes('BridgeTransport')) {
+        settings.transports!.unshift('BridgeTransport');
+    }
 
     try {
         // disconnect previous device list

--- a/packages/connect/src/data/connectSettings.ts
+++ b/packages/connect/src/data/connectSettings.ts
@@ -25,7 +25,9 @@ const initialSettings: ConnectSettings = {
     popup: true,
     popupSrc: `${DEFAULT_DOMAIN}popup.html`,
     webusbSrc: `${DEFAULT_DOMAIN}webusb.html`,
+    // deprecated, use transports instead
     webusb: true,
+    transports: undefined,
     pendingTransportEvent: true,
     supportedBrowser:
         typeof navigator !== 'undefined' ? !/Trident|MSIE|Edge/.test(navigator.userAgent) : true, // TODO: https://github.com/trezor/trezor-suite/issues/5319
@@ -147,8 +149,13 @@ export const parseConnectSettings = (input: Partial<ConnectSettings> = {}) => {
         settings.transportReconnect = input.transportReconnect;
     }
 
+    // deprecated, settings.transport should be used instead
     if (typeof input.webusb === 'boolean') {
         settings.webusb = input.webusb;
+    }
+
+    if (Array.isArray(input.transports)) {
+        settings.transports = input.transports;
     }
 
     if (typeof input.popup === 'boolean') {

--- a/packages/connect/src/device/DeviceCommands.ts
+++ b/packages/connect/src/device/DeviceCommands.ts
@@ -703,12 +703,8 @@ export class DeviceCommands {
          * Bridge version =< 2.0.28 has a bug that doesn't permit it to cancel
          * user interactions in progress, so we have to do it manually.
          */
-        const { activeName, version } = this.transport;
-        if (
-            activeName &&
-            activeName === 'BridgeTransport' &&
-            versionCompare(version, '2.0.28') < 1
-        ) {
+        const { name, version } = this.transport;
+        if (name === 'BridgeTransport' && versionCompare(version, '2.0.28') < 1) {
             await this.device.legacyForceRelease();
         } else {
             await this.transport.post(this.sessionId, 'Cancel', {}, false);

--- a/packages/connect/src/events/transport.ts
+++ b/packages/connect/src/events/transport.ts
@@ -1,5 +1,6 @@
 import { serializeError } from '../constants/errors';
 import type { MessageFactoryFn } from '../types/utils';
+import type { Transport } from '@trezor/transport';
 
 export const TRANSPORT_EVENT = 'TRANSPORT_EVENT';
 export const TRANSPORT = {
@@ -37,7 +38,7 @@ export interface UdevInfo {
 }
 
 export interface TransportInfo {
-    type: string;
+    type: Transport['name'];
     version: string;
     outdated: boolean;
     bridge?: BridgeInfo;

--- a/packages/connect/src/index.ts
+++ b/packages/connect/src/index.ts
@@ -140,6 +140,11 @@ const init = async (settings: Partial<ConnectSettings> = {}) => {
         throw ERRORS.TypedError('Init_ManifestMissing');
     }
 
+    if (!_settings.transports?.length) {
+        // default fallback for node
+        _settings.transports = ['BridgeTransport'];
+    }
+
     if (_settings.lazyLoad) {
         // reset "lazyLoad" after first use
         _settings.lazyLoad = false;
@@ -148,7 +153,6 @@ const init = async (settings: Partial<ConnectSettings> = {}) => {
 
     _core = await initCore(_settings);
     _core.on(CORE_EVENT, handleMessage);
-
     await initTransport(_settings);
 };
 

--- a/packages/connect/src/types/settings.ts
+++ b/packages/connect/src/types/settings.ts
@@ -1,4 +1,5 @@
 import type { BlockchainSettings } from '@trezor/blockchain-link';
+import type { Transport } from '@trezor/transport';
 
 export interface Manifest {
     appUrl: string;
@@ -15,7 +16,8 @@ export interface ConnectSettings {
     hostIcon?: string;
     popup?: boolean;
     transportReconnect?: boolean;
-    webusb?: boolean;
+    webusb?: boolean; // deprecated
+    transports?: Transport['name'][];
     pendingTransportEvent?: boolean;
     lazyLoad?: boolean;
     interactionTimeout?: number;

--- a/packages/suite/src/actions/suite/__fixtures__/suiteActions.ts
+++ b/packages/suite/src/actions/suite/__fixtures__/suiteActions.ts
@@ -131,14 +131,14 @@ const reducerActions = [
             {
                 type: TRANSPORT.START,
                 payload: {
-                    type: 'bridge',
+                    type: 'BridgeTransport',
                 },
             },
         ],
         result: [
             {
                 transport: {
-                    type: 'bridge',
+                    type: 'BridgeTransport',
                 },
             },
         ],

--- a/packages/suite/src/components/suite/Modal/DevicePromptModal.tsx
+++ b/packages/suite/src/components/suite/Modal/DevicePromptModal.tsx
@@ -102,7 +102,7 @@ export const AbortButton = ({ onAbort, className }: AbortButtonProps) => {
 
     // checks compatability for use in other places
     const isActionAbortable =
-        transport?.type === 'bridge'
+        transport?.type === 'BridgeTransport'
             ? versionUtils.isNewerOrEqual(transport?.version as string, '2.0.31')
             : true; // Works via WebUSB
 
@@ -149,7 +149,7 @@ const DevicePromptModalRenderer = ({
 
     // duplicated because headerComponents should receive undefined if isAbortable === false
     const isActionAbortable =
-        transport?.type === 'bridge'
+        transport?.type === 'BridgeTransport'
             ? isAbortable && versionUtils.isNewerOrEqual(transport?.version as string, '2.0.31')
             : isAbortable; // Works via WebUSB
 

--- a/packages/suite/src/components/suite/Preloader/__tests__/Preloader.test.tsx
+++ b/packages/suite/src/components/suite/Preloader/__tests__/Preloader.test.tsx
@@ -150,7 +150,7 @@ describe('Preloader component', () => {
         const store = initStore(
             getInitialState({
                 suite: {
-                    transport: { type: 'bridge' },
+                    transport: { type: 'BridgeTransport' },
                 },
             }),
         );
@@ -166,7 +166,7 @@ describe('Preloader component', () => {
         const store = initStore(
             getInitialState({
                 suite: {
-                    transport: { type: 'WebUsbPlugin' },
+                    transport: { type: 'WebUsbTransport' },
                 },
             }),
         );
@@ -182,7 +182,7 @@ describe('Preloader component', () => {
         const store = initStore(
             getInitialState({
                 suite: {
-                    transport: { type: 'bridge' },
+                    transport: { type: 'BridgeTransport' },
                     device: { type: 'unacquired' },
                 },
             }),
@@ -199,7 +199,7 @@ describe('Preloader component', () => {
         const store = initStore(
             getInitialState({
                 suite: {
-                    transport: { type: 'WebUsbPlugin' },
+                    transport: { type: 'WebUsbTransport' },
                     device: { type: 'unreadable', error: 'LIBUSB_ERROR_ACCESS' },
                 },
             }),
@@ -218,7 +218,7 @@ describe('Preloader component', () => {
         const store = initStore(
             getInitialState({
                 suite: {
-                    transport: { type: 'bridge' },
+                    transport: { type: 'BridgeTransport' },
                     device: { type: 'unreadable', error: 'LIBUSB_ERROR_ACCESS' },
                 },
             }),
@@ -237,7 +237,7 @@ describe('Preloader component', () => {
         const store = initStore(
             getInitialState({
                 suite: {
-                    transport: { type: 'bridge' },
+                    transport: { type: 'BridgeTransport' },
                     device: { type: 'unreadable', error: 'LIBUSB_ERROR_ACCESS' },
                 },
             }),
@@ -254,7 +254,7 @@ describe('Preloader component', () => {
         const store = initStore(
             getInitialState({
                 suite: {
-                    transport: { type: 'bridge' },
+                    transport: { type: 'BridgeTransport' },
                     device: { type: 'unreadable', error: 'Unexpected error' },
                 },
             }),
@@ -271,7 +271,7 @@ describe('Preloader component', () => {
         const store = initStore(
             getInitialState({
                 suite: {
-                    transport: { type: 'bridge' },
+                    transport: { type: 'BridgeTransport' },
                     device: { features: null },
                 },
             }),
@@ -288,7 +288,7 @@ describe('Preloader component', () => {
         const store = initStore(
             getInitialState({
                 suite: {
-                    transport: { type: 'bridge' },
+                    transport: { type: 'BridgeTransport' },
                     device: { mode: 'seedless', features: {} },
                 },
             }),
@@ -306,7 +306,7 @@ describe('Preloader component', () => {
         const store = initStore(
             getInitialState({
                 suite: {
-                    transport: { type: 'bridge' },
+                    transport: { type: 'BridgeTransport' },
                     device: { features: { recovery_mode: true } },
                 },
             }),
@@ -324,7 +324,7 @@ describe('Preloader component', () => {
         const store = initStore(
             getInitialState({
                 suite: {
-                    transport: { type: 'bridge' },
+                    transport: { type: 'BridgeTransport' },
                     device: { mode: 'initialize', features: {} },
                 },
             }),
@@ -342,7 +342,7 @@ describe('Preloader component', () => {
         const store = initStore(
             getInitialState({
                 suite: {
-                    transport: { type: 'bridge' },
+                    transport: { type: 'BridgeTransport' },
                     device: { mode: 'bootloader', features: { firmware_present: true } },
                 },
             }),
@@ -360,7 +360,7 @@ describe('Preloader component', () => {
         const store = initStore(
             getInitialState({
                 suite: {
-                    transport: { type: 'bridge' },
+                    transport: { type: 'BridgeTransport' },
                     device: { mode: 'bootloader', features: { firmware_present: false } },
                 },
             }),
@@ -378,7 +378,7 @@ describe('Preloader component', () => {
         const store = initStore(
             getInitialState({
                 suite: {
-                    transport: { type: 'bridge' },
+                    transport: { type: 'BridgeTransport' },
                     device: { firmware: 'required', features: {} },
                 },
             }),

--- a/packages/suite/src/hooks/wallet/__tests__/useRbfForm.test.tsx
+++ b/packages/suite/src/hooks/wallet/__tests__/useRbfForm.test.tsx
@@ -103,7 +103,6 @@ const Component = ({ callback }: { callback: TestCallback }) => {
 describe('useRbfForm hook', () => {
     beforeAll(async () => {
         await TrezorConnect.init({
-            webusb: false,
             transportReconnect: false,
             pendingTransportEvent: false,
             manifest: {

--- a/packages/suite/src/reducers/suite/suiteReducer.ts
+++ b/packages/suite/src/reducers/suite/suiteReducer.ts
@@ -1,5 +1,5 @@
 import produce from 'immer';
-import { TRANSPORT, TransportInfo } from '@trezor/connect';
+import { TRANSPORT, TransportInfo, ConnectSettings } from '@trezor/connect';
 import { SuiteThemeVariant } from '@trezor/suite-desktop-api';
 import { Action, TrezorDevice, Lock, TorBootstrap, TorStatus } from '@suite-types';
 
@@ -27,6 +27,7 @@ export interface DebugModeOptions {
     oauthServerEnvironment?: OAuthServerEnvironment;
     showDebugMenu: boolean;
     checkFirmwareAuthenticity: boolean;
+    transports: ConnectSettings['transports'];
 }
 
 export interface AutodetectSettings {
@@ -113,6 +114,7 @@ const initialState: SuiteState = {
             invityServerEnvironment: undefined,
             showDebugMenu: false,
             checkFirmwareAuthenticity: false,
+            transports: [],
         },
         autodetect: {
             language: true,

--- a/packages/suite/src/services/github.ts
+++ b/packages/suite/src/services/github.ts
@@ -27,7 +27,9 @@ const getTransportInfo = (transport?: Partial<TransportInfo>) => {
     if (!transport?.type) {
         return 'N/A';
     }
-    return transport?.type === 'bridge' ? `${transport.type} ${transport.version}` : transport.type;
+    return transport?.type === 'BridgeTransport'
+        ? `${transport.type} ${transport.version}`
+        : transport.type;
 };
 
 export const openGithubIssue = ({ device, transport }: DebugInfo) => {

--- a/packages/suite/src/support/extraDependencies.ts
+++ b/packages/suite/src/support/extraDependencies.ts
@@ -13,7 +13,6 @@ import * as cardanoStakingActions from '@wallet-actions/cardanoStakingActions';
 import * as walletSettingsActions from '@settings-actions/walletSettingsActions';
 import { selectIsPendingTransportEvent } from '@suite-reducers/deviceReducer';
 import * as suiteActions from '../actions/suite/suiteActions';
-import { isWeb } from '@suite-utils/env';
 import { resolveStaticPath } from '@trezor/utils';
 
 const connectSrc = resolveStaticPath('connect/');
@@ -25,7 +24,6 @@ const connectInitSettings = {
     transportReconnect: true,
     debug: false,
     popup: false,
-    webusb: isWeb(),
     manifest: {
         email: 'info@trezor.io',
         appUrl: '@trezor/suite',

--- a/packages/suite/src/utils/suite/__tests__/transport.test.ts
+++ b/packages/suite/src/utils/suite/__tests__/transport.test.ts
@@ -4,14 +4,14 @@ const fixtures = [
     {
         description: `Transport is webusb`,
         transport: {
-            type: 'WebUsbPlugin',
+            type: 'WebUsbTransport',
         },
         result: true,
     },
     {
         description: `Transport is not webusb (bridge)`,
         transport: {
-            type: 'bridge',
+            type: 'BridgeTransport',
         },
         result: false,
     },
@@ -20,7 +20,7 @@ const fixtures = [
         transport: undefined,
         result: false,
     },
-];
+] as const;
 
 describe('transport', () => {
     fixtures.forEach(f => {

--- a/packages/suite/src/utils/suite/messageSystem.ts
+++ b/packages/suite/src/utils/suite/messageSystem.ts
@@ -109,7 +109,17 @@ export const validateTransportCompatibility = (
     const { version } = transport;
     const type = transport.type.toLowerCase();
 
-    return validateVersionCompatibility(transportCondition, type, version);
+    // transport names were changed in https://github.com/trezor/trezor-suite/pull/7411
+    // to avoid breaking changes with v1 messaging system schema, we introduce this translation
+    let legacyTransportType: 'bridge' | 'webusbplugin' | undefined;
+
+    if (type === 'BridgeTransport') {
+        legacyTransportType = 'bridge';
+    } else if (type === 'WebUsbTransport') {
+        legacyTransportType = 'webusbplugin';
+    }
+
+    return validateVersionCompatibility(transportCondition, legacyTransportType || type, version);
 };
 
 export const validateDeviceCompatibility = (

--- a/packages/suite/src/utils/suite/transport.ts
+++ b/packages/suite/src/utils/suite/transport.ts
@@ -1,4 +1,4 @@
 import { AppState } from '@suite-types';
 
 export const isWebUsb = (transport?: AppState['suite']['transport']) =>
-    !!(transport && transport.type && transport.type === 'WebUsbPlugin');
+    !!(transport && transport.type && transport.type === 'WebUsbTransport');

--- a/packages/suite/src/views/suite/bridge/index.tsx
+++ b/packages/suite/src/views/suite/bridge/index.tsx
@@ -117,7 +117,7 @@ export const InstallBridge = () => {
 
     const preferredTarget = installers.find(i => i.preferred === true);
     const data = {
-        currentVersion: transport?.type === 'bridge' ? transport!.version : null,
+        currentVersion: transport?.type === 'BridgeTransport' ? transport!.version : null,
         latestVersion: transport?.bridge ? transport.bridge.version.join('.') : null,
         installers,
         target: preferredTarget || installers[0],

--- a/packages/transport/src/lowlevel/withSharedConnections.ts
+++ b/packages/transport/src/lowlevel/withSharedConnections.ts
@@ -117,7 +117,7 @@ export default class LowlevelTransportWithSharedConnections {
     defereds: { [id: number]: Deferred<MessageFromSharedWorker> } = {};
     isOutdated = false;
     latestId = 0;
-    name = 'LowlevelTransportWithSharedConnections';
+    name = 'WebUsbTransport';
     plugin: LowlevelTransportSharedPlugin;
     requestNeeded = false;
     sharedWorker: null | SharedWorker = null;


### PR DESCRIPTION
part of #6509 

- introduce a new param to `init` method. this will allow us to decide if we want to use bridge or nodeusb or any other transport that comes in the future
- apart from adding new param this PR also unifies weird transport namas aka `plugin` and `bridge` 
