### PR TITLE
chore: replace reselect with proxy-memoize

### DIFF
--- a/packages/suite/package.json
+++ b/packages/suite/package.json
@@ -71,6 +71,7 @@
         "pako": "^1.0.11",
         "pdfmake": "^0.2.6",
         "polished": "^4.2.2",
+        "proxy-memoize": "^2.0.0",
         "qrcode.react": "^3.1.0",
         "react": "18.2.0",
         "react-dom": "18.2.0",

--- a/packages/suite/src/reducers/wallet/discoveryReducer.ts
+++ b/packages/suite/src/reducers/wallet/discoveryReducer.ts
@@ -1,5 +1,5 @@
 import produce from 'immer';
-import { createSelector } from '@reduxjs/toolkit';
+import { memoize } from 'proxy-memoize';
 import { DISCOVERY } from '@wallet-actions/constants';
 import { STORAGE } from '@suite-actions/constants';
 import { createDeferred } from '@trezor/utils';
@@ -96,11 +96,12 @@ export const selectDiscoveryForDevice = (state: RootState) =>
  * Helper selector called from components
  * return `true` if discovery process is running/completed and `authConfirm` is required
  */
-export const selectIsDiscoveryAuthConfirmationRequired = createSelector(
-    selectDiscoveryForDevice,
-    discovery =>
+export const selectIsDiscoveryAuthConfirmationRequired = memoize((state: RootState) => {
+    const discovery = selectDiscoveryForDevice(state);
+    return (
         discovery &&
         discovery.authConfirm &&
         (discovery.status < DISCOVERY.STATUS.STOPPING ||
-            discovery.status === DISCOVERY.STATUS.COMPLETED),
-);
+            discovery.status === DISCOVERY.STATUS.COMPLETED)
+    );
+});

--- a/suite-native/accounts/src/components/AccountsList.tsx
+++ b/suite-native/accounts/src/components/AccountsList.tsx
@@ -4,11 +4,7 @@ import { useSelector } from 'react-redux';
 import { A } from '@mobily/ts-belt';
 
 import { Text } from '@suite-native/atoms';
-import {
-    AccountsRootState,
-    selectAccounts,
-    selectAccountsSymbols,
-} from '@suite-common/wallet-core';
+import { selectAccounts, selectAccountsSymbols } from '@suite-common/wallet-core';
 
 import { AccountsListGroup } from './AccountsListGroup';
 
@@ -18,7 +14,7 @@ type AccountsListProps = {
 
 export const AccountsList = ({ onSelectAccount }: AccountsListProps) => {
     const accountsSymbols = useSelector(selectAccountsSymbols);
-    const accounts = useSelector((state: AccountsRootState) => selectAccounts(state));
+    const accounts = useSelector(selectAccounts);
 
     if (A.isEmpty(accounts)) return <Text>No accounts found.</Text>;
 

--- a/suite-native/accounts/src/components/AccountsListGroup.tsx
+++ b/suite-native/accounts/src/components/AccountsListGroup.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useMemo } from 'react';
 import { useSelector } from 'react-redux';
 
 import { Box } from '@suite-native/atoms';
@@ -21,8 +21,10 @@ const accountListGroupStyle = prepareNativeStyle(utils => ({
 
 export const AccountsListGroup = ({ symbol, onSelectAccount }: AccountsListGroupProps) => {
     const { applyStyle } = useNativeStyles();
+    const symbols = useMemo(() => [symbol], [symbol]);
     const accounts = useSelector((state: AccountsRootState) =>
-        selectAccountsByNetworkSymbols(state, [symbol]),
+        // we need to memoize [symbol] array to prevent re-renders with every state change
+        selectAccountsByNetworkSymbols(state, symbols),
     );
 
     return (

--- a/suite-native/assets/package.json
+++ b/suite-native/assets/package.json
@@ -12,7 +12,6 @@
     },
     "dependencies": {
         "@react-navigation/native": "^6.0.11",
-        "@reduxjs/toolkit": "1.8.3",
         "@suite-common/formatters": "workspace:*",
         "@suite-common/suite-config": "workspace:*",
         "@suite-common/wallet-config": "workspace:*",
@@ -22,11 +21,11 @@
         "@suite-native/atoms": "workspace:*",
         "@suite-native/module-settings": "workspace:*",
         "@suite-native/navigation": "workspace:*",
-        "@suite-native/state": "workspace:*",
         "@trezor/icons": "workspace:*",
         "@trezor/styles": "workspace:*",
         "@trezor/theme": "workspace:*",
         "bignumber.js": "^9.1.0",
+        "proxy-memoize": "^2.0.0",
         "react": "^18.2.0",
         "react-native": "0.70.5",
         "react-redux": "7.2.2"

--- a/suite-native/assets/src/components/Assets.tsx
+++ b/suite-native/assets/src/components/Assets.tsx
@@ -16,7 +16,6 @@ import {
 } from '@suite-native/navigation';
 import { networks } from '@suite-common/wallet-config';
 import { selectFiatCurrency } from '@suite-native/module-settings';
-import { RootState } from '@suite-native/state';
 
 import { AssetItem } from './AssetItem';
 import { selectAssetsWithBalances } from '../assetsSelectors';
@@ -36,8 +35,8 @@ export const Assets = () => {
     const navigation = useNavigation<HomeAssetsNavigationProp>();
     const { applyStyle } = useNativeStyles();
     const fiatCurrency = useSelector(selectFiatCurrency);
-    const assetsData = useSelector((state: RootState) =>
-        selectAssetsWithBalances(state, fiatCurrency.label),
+    const assetsData = useSelector((state: any) =>
+        selectAssetsWithBalances(fiatCurrency.label, state),
     );
 
     const assetsDataWithPercentage = useMemo(
@@ -50,12 +49,14 @@ export const Assets = () => {
     };
 
     const handleImportAssets = () => {
+        // TODO: move this to Dashboard screen directly
         navigation.navigate(RootStackRoutes.AccountsImport, {
             screen: AccountsImportStackRoutes.SelectNetwork,
         });
     };
 
     const handleShowAssetsAccounts = () => {
+        // TODO: move this to Dashboard screen directly
         navigation.navigate(RootStackRoutes.AppTabs, {
             screen: AppTabsRoutes.AccountsStack,
             params: {

--- a/suite-native/assets/tsconfig.json
+++ b/suite-native/assets/tsconfig.json
@@ -23,7 +23,6 @@
         { "path": "../atoms" },
         { "path": "../module-settings" },
         { "path": "../navigation" },
-        { "path": "../state" },
         { "path": "../../packages/icons" },
         { "path": "../../packages/styles" },
         { "path": "../../packages/theme" }

--- a/suite-native/atoms/src/DebugView.tsx
+++ b/suite-native/atoms/src/DebugView.tsx
@@ -17,8 +17,8 @@ import { Text } from './Text';
 
 const FLASH_DURATION = 300;
 // set these to true if you are debugging rerenders locally
-const FLASH_ON_RERENDER = false;
-const RERENDER_COUNT_ENABLED = false;
+const FLASH_ON_RERENDER = true;
+const RERENDER_COUNT_ENABLED = true;
 
 const isFlashOnRerenderEnabledAtom = atom(FLASH_ON_RERENDER);
 const isRerenderCountEnabledAtom = atom(RERENDER_COUNT_ENABLED);

--- a/suite-native/transactions/src/screens/TransactionDetailScreen.tsx
+++ b/suite-native/transactions/src/screens/TransactionDetailScreen.tsx
@@ -34,7 +34,7 @@ export const TransactionDetailScreen = ({
 }: StackProps<RootStackParamList, RootStackRoutes.TransactionDetail>) => {
     const { applyStyle, utils } = useNativeStyles();
     const { txid } = route.params;
-    const transaction = useSelector(selectTransactionByTxid(txid));
+    const transaction = useSelector((state: any) => selectTransactionByTxid(txid, state));
     const blockchainExplorer = useSelector((state: BlockchainRootState) =>
         selectBlockchainExplorerBySymbol(state, transaction?.symbol),
     );

--- a/yarn.lock
+++ b/yarn.lock
@@ -6324,7 +6324,6 @@ __metadata:
   resolution: "@suite-native/assets@workspace:suite-native/assets"
   dependencies:
     "@react-navigation/native": ^6.0.11
-    "@reduxjs/toolkit": 1.8.3
     "@suite-common/formatters": "workspace:*"
     "@suite-common/suite-config": "workspace:*"
     "@suite-common/wallet-config": "workspace:*"
@@ -6334,12 +6333,12 @@ __metadata:
     "@suite-native/atoms": "workspace:*"
     "@suite-native/module-settings": "workspace:*"
     "@suite-native/navigation": "workspace:*"
-    "@suite-native/state": "workspace:*"
     "@trezor/icons": "workspace:*"
     "@trezor/styles": "workspace:*"
     "@trezor/theme": "workspace:*"
     bignumber.js: ^9.1.0
     jest: ^26.6.3
+    proxy-memoize: ^2.0.0
     react: ^18.2.0
     react-native: 0.70.5
     react-redux: 7.2.2
@@ -7664,6 +7663,7 @@ __metadata:
     pdfmake: ^0.2.6
     polished: ^4.2.2
     prettier: 2.8.0
+    proxy-memoize: ^2.0.0
     qrcode.react: ^3.1.0
     react: 18.2.0
     react-dom: 18.2.0
@@ -26007,11 +26007,11 @@ __metadata:
   linkType: hard
 
 "proxy-memoize@npm:^2.0.0":
-  version: 2.0.1
-  resolution: "proxy-memoize@npm:2.0.1"
+  version: 2.0.0
+  resolution: "proxy-memoize@npm:2.0.0"
   dependencies:
     proxy-compare: 2.4.0
-  checksum: 4851411fcc9b4410555321f64d6a87fc287b88a4821e926bc264947edf77ecf7a6ee12534fa3a324efa2431ce81ea0383d5d1785f6cbf6661ad1be2b0d7e31d8
+  checksum: 248b236600baee0b7dd0c094527e5700f2055d30ccc4d49ba422395a6ad578c9c1fd55962451870d5dfe21ad464691f23e06f2d3af6e3fa70bdfd9d400f5318b
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Reselect have too complicated API (specifically defining multiple selectors as depedency with multiple extra input params), `proxy-memoize` is really straightforward and it should be more performant because of using proxy only on really used properties.

Another major issue with `reselect` was that when we needed to pass extra parametr except `state` like `txid` or `accountKey` it has tendency to rerender with every `state` change, which has disastrous consequences for performance especially on mobile.

Some reading:
- [proxy-memoize docs](https://github.com/dai-shi/proxy-memoize)
- [redux docs - selectors](https://redux.js.org/usage/deriving-data-selectors#proxy-memoize)
