### PR TITLE
Pause coinjoin while in send form

### DIFF
--- a/packages/suite/src/components/wallet/CoinControl/UtxoSelection.tsx
+++ b/packages/suite/src/components/wallet/CoinControl/UtxoSelection.tsx
@@ -5,14 +5,13 @@ import { darken } from 'polished';
 
 import * as modalActions from '@suite-actions/modalActions';
 import { FiatValue, FormattedCryptoAmount, MetadataLabeling, Translation } from '@suite-components';
-import { formatNetworkAmount, getUtxoOutpoint } from '@suite-common/wallet-utils';
+import { formatNetworkAmount } from '@suite-common/wallet-utils';
 import { useActions, useSelector } from '@suite-hooks';
 import { useTheme, Checkbox, FluidSpinner, Tooltip, variables } from '@trezor/components';
 import type { AccountUtxo } from '@trezor/connect';
 import { TransactionTimestamp, UtxoAnonymity } from '@wallet-components';
 import { UtxoTag } from '@wallet-components/CoinControl/UtxoTag';
 import { useSendFormContext } from '@wallet-hooks';
-import { selectCoinjoinAccountByKey } from '@wallet-reducers/coinjoinReducer';
 import { WalletAccountTransaction } from '@wallet-types';
 
 const VisibleOnHover = styled.div<{ alwaysVisible?: boolean }>`
@@ -130,7 +129,6 @@ export const UtxoSelection = ({ isChecked, transaction, utxo }: UtxoSelectionPro
 
     const coordinatorData = useSelector(state => state.wallet.coinjoin.clients[account.symbol]);
     const device = useSelector(state => state.suite.device);
-    const coinjoinAccount = useSelector(state => selectCoinjoinAccountByKey(state, account.key));
     // selecting metadata from store rather than send form context which does not update on metadata change
     const outputLabels = useSelector(
         state => state.wallet.selectedAccount.account?.metadata.outputLabels,
@@ -141,9 +139,6 @@ export const UtxoSelection = ({ isChecked, transaction, utxo }: UtxoSelectionPro
 
     const theme = useTheme();
 
-    const isRegisteredForCoinjoin = coinjoinAccount?.session?.registeredUtxos.includes(
-        getUtxoOutpoint(utxo),
-    );
     const amountTooSmallForCoinjoin =
         coordinatorData && new BigNumber(utxo.amount).lt(coordinatorData.allowedInputAmounts.min);
     const amountTooBigForCoinjoin =
@@ -180,9 +175,6 @@ export const UtxoSelection = ({ isChecked, transaction, utxo }: UtxoSelectionPro
                 <Row>
                     {isPendingTransaction && (
                         <UtxoTag tooltipMessage="TR_IN_PENDING_TRANSACTION" icon="CLOCK" />
-                    )}
-                    {isRegisteredForCoinjoin && (
-                        <UtxoTag tooltipMessage="TR_REGISTERED_FOR_COINJOIN" icon="SHUFFLE" />
                     )}
                     {isUnavailableForCoinjoin && (
                         <UtxoTag tooltipMessage={unavailableMessage} icon="BLOCKED" />

--- a/packages/suite/src/hooks/wallet/form/useUtxoSelection.ts
+++ b/packages/suite/src/hooks/wallet/form/useUtxoSelection.ts
@@ -35,10 +35,6 @@ export const useUtxoSelection = ({
     // manually selected UTXOs
     const selectedUtxos: AccountUtxo[] = watch('selectedUtxos') || [];
 
-    // is the UTXO manually selected?
-    const isSelected = (utxo: AccountUtxo) =>
-        selectedUtxos.some(selected => selected.txid === utxo.txid && selected.vout === utxo.vout);
-
     const spendableUtxos: AccountUtxo[] = [];
     const lowAnonymityUtxos: AccountUtxo[] = [];
     const dustUtxos: AccountUtxo[] = [];
@@ -61,7 +57,9 @@ export const useUtxoSelection = ({
         [];
 
     // are all UTXOs in the top category selected?
-    const allUtxosSelected = !!topCategory?.every(isSelected);
+    const allUtxosSelected = !!topCategory?.every((utxo: AccountUtxo) =>
+        selectedUtxos.some(selected => selected.txid === utxo.txid && selected.vout === utxo.vout),
+    );
 
     // transaction composed for the fee level chosen by the user
     const composedLevel = composedLevels?.[selectedFee || 'normal'];

--- a/packages/suite/src/support/messages.ts
+++ b/packages/suite/src/support/messages.ts
@@ -5659,11 +5659,6 @@ export default defineMessages({
         defaultMessage: 'Loading transaction details',
         description: 'Tooltip over a spinner icon in Coin control section',
     },
-    TR_REGISTERED_FOR_COINJOIN: {
-        id: 'TR_REGISTERED_FOR_COINJOIN',
-        defaultMessage: 'Registered in CoinJoin',
-        description: 'Tooltip over an icon in Coin control section',
-    },
     TR_AMOUNT_TOO_SMALL_FOR_COINJOIN: {
         id: 'TR_AMOUNT_TOO_SMALL_FOR_COINJOIN',
         defaultMessage: 'Not suitable for CoinJoin - amount too small',

--- a/suite-common/wallet-utils/src/sendFormUtils.ts
+++ b/suite-common/wallet-utils/src/sendFormUtils.ts
@@ -453,10 +453,6 @@ export const getExcludedUtxos = (
         } else if (anonymity < (targetAnonymity || 1)) {
             // didn't reach desired anonymity (coinjoin account)
             excludedUtxos[outpoint] = 'low-anonymity';
-        } else if (!utxo.confirmations) {
-            // is unconfirmed
-            // TODO: this is a new feature
-            // excludedUtxos[outpoint] = 'unconfirmed';
         }
     });
     return excludedUtxos;


### PR DESCRIPTION
## Description
When coinjoin is running and send form of the corresponding account is open, coinjoin is paused to avoid changing UTXOs while preparing transaction or breaking a coinjoin round. Coinjoin automatically resumes upon closing the form. 2c303bc523430824a7bbf0ad72ebdf6cb7c912b9

As the coinjoin is paused, there is no need for a `isRegisteredInConjoin` tag: 100ee07c96a2d6eddfc3c132f1374b9426f958f2

## Related Issue

Resolve #7416
