### PR TITLE
fix(suite): coinjoin setup skip rounds

### DIFF
--- a/packages/suite/src/views/wallet/anonymize/components/CoinjoinSetupStrategies.tsx
+++ b/packages/suite/src/views/wallet/anonymize/components/CoinjoinSetupStrategies.tsx
@@ -159,7 +159,7 @@ export const CoinjoinSetupStrategies = ({ account }: CoinjoinSetupStrategiesProp
                 (isCustom ? customMaxFee : coordinatorData.feeRatesMedians[strategy]) * 1000, // transform to kvB
             maxRounds,
             skipRounds:
-                customSkipRounds || strategy === 'recommended'
+                (strategy === 'custom' && customSkipRounds) || strategy === 'recommended'
                     ? RECOMMENDED_SKIP_ROUNDS
                     : undefined,
             targetAnonymity,


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

`customSkipRounds` is set to true by default but should set to true **only** when entering "custom" setup and set to false when leaving "custom" setup

alternatively we can change skipRounds condition to
```
skipRounds:
                (strategy === 'custom' && customSkipRounds) || strategy === 'recommended'
                    ? RECOMMENDED_SKIP_ROUNDS
                    : undefined
                    
```

i dont have preference which fix is better


## Related Issue

Resolve https://github.com/trezor/trezor-suite/issues/7421
