### PR TITLE
Feat/cj disable small utxos

### DIFF
--- a/packages/coinjoin/src/client/Status.ts
+++ b/packages/coinjoin/src/client/Status.ts
@@ -1,7 +1,7 @@
 import { EventEmitter } from 'events';
 
 import * as coordinator from './coordinator';
-import { findNearestDeadline, getDataFromRounds } from '../utils/roundUtils';
+import { findNearestDeadline, transformStatus } from '../utils/roundUtils';
 import { STATUS_TIMEOUT } from '../constants';
 import { RoundPhase } from '../enums';
 import { CoinjoinClientSettings, CoinjoinStatusEvent } from '../types';
@@ -138,10 +138,8 @@ export class Status extends EventEmitter {
 
         if (changed.length) {
             const statusEvent = {
-                rounds: status.roundStates,
                 changed,
-                feeRatesMedians: status.coinJoinFeeRateMedians,
-                ...getDataFromRounds(status.roundStates),
+                ...transformStatus(status),
             };
             this.emit('update', statusEvent);
             return statusEvent;

--- a/packages/coinjoin/src/index.ts
+++ b/packages/coinjoin/src/index.ts
@@ -1,3 +1,4 @@
 export { CoinjoinBackend } from './backend/CoinjoinBackend';
 export { CoinjoinClient } from './client/CoinjoinClient';
+export { getInputSize, getOutputSize } from './utils/coordinatorUtils';
 export * from './types';

--- a/packages/coinjoin/src/types/client.ts
+++ b/packages/coinjoin/src/types/client.ts
@@ -1,11 +1,11 @@
 import { SessionPhase } from '../enums';
-import { AllowedRange, CoordinationFeeRate, FeeRateMedians, Round } from './coordinator';
+import { AllowedRange, CoordinationFeeRate, Round } from './coordinator';
 import { CoinjoinRequestEvent, CoinjoinRoundEvent } from './round';
 
 export interface CoinjoinStatusEvent {
     rounds: Round[];
     changed: Round[];
-    feeRatesMedians: FeeRateMedians[];
+    feeRatesMedians: { fast: number; recommended: number };
     coordinationFeeRate: CoordinationFeeRate;
     allowedInputAmounts: AllowedRange;
 }

--- a/packages/coinjoin/src/utils/roundUtils.ts
+++ b/packages/coinjoin/src/utils/roundUtils.ts
@@ -162,7 +162,7 @@ const getDataFromRounds = (rounds: Round[]) => {
  * Transform from coordinator format to coinjoinReducer format `CoinjoinClientFeeRatesMedians`
  * array => object { name: value-in-vBytes }
  */
-const transformFeeRatesMedians = (medians: CoinjoinStatus['coinJoinFeeRateMedians']) => {
+export const transformFeeRatesMedians = (medians: CoinjoinStatus['coinJoinFeeRateMedians']) => {
     const [fast, recommended] = medians.map(m => m.medianFeeRate);
     // convert from kvBytes (kilo virtual bytes) to vBytes (how the value is displayed in UI)
     const kvB2vB = (v: number) => (v ? Math.round(v / 1000) : 1);

--- a/packages/coinjoin/tests/client/Status.test.ts
+++ b/packages/coinjoin/tests/client/Status.test.ts
@@ -1,7 +1,12 @@
 import { Status } from '../../src/client/Status';
 import { ROUND_REGISTRATION_END_OFFSET, STATUS_TIMEOUT } from '../../src/constants';
 import { createServer } from '../mocks/server';
-import { DEFAULT_ROUND, ROUND_CREATION_EVENT, AFFILIATE_INFO } from '../fixtures/round.fixture';
+import {
+    AFFILIATE_INFO,
+    DEFAULT_ROUND,
+    STATUS_EVENT,
+    ROUND_CREATION_EVENT,
+} from '../fixtures/round.fixture';
 
 let server: Awaited<ReturnType<typeof createServer>>;
 
@@ -131,15 +136,15 @@ describe('Status', () => {
         server?.addListener('test-request', ({ resolve }) => {
             if (request === 6) {
                 resolve({
+                    ...STATUS_EVENT,
                     roundStates: [{ ...DEFAULT_ROUND, phase: 1 }],
-                    affiliateInformation: AFFILIATE_INFO,
                 });
             } else {
                 setTimeout(
                     () => {
                         resolve({
+                            ...STATUS_EVENT,
                             roundStates: [DEFAULT_ROUND],
-                            affiliateInformation: AFFILIATE_INFO,
                         });
                     },
                     request % 2 === 0 ? 5000 : 0, // timeout error on every second request
@@ -196,8 +201,8 @@ describe('Status', () => {
         server?.addListener('test-request', ({ url, resolve }) => {
             if (url.endsWith('/status')) {
                 resolve({
+                    ...STATUS_EVENT,
                     roundStates: [round],
-                    affiliateInformation: AFFILIATE_INFO,
                 });
             }
             resolve();
@@ -217,6 +222,7 @@ describe('Status', () => {
                 round.phase++;
                 if (round.phase <= 4) {
                     resolve({
+                        ...STATUS_EVENT,
                         roundStates: [
                             round,
                             {
@@ -225,13 +231,11 @@ describe('Status', () => {
                                 phase: 2, // intentionally keep it in one phase, see pendingRound explanation below
                             },
                         ],
-                        affiliateInformation: AFFILIATE_INFO,
                     });
                 } else {
                     // remove all rounds from state
                     resolve({
-                        roundStates: [],
-                        affiliateInformation: AFFILIATE_INFO,
+                        ...STATUS_EVENT,
                     });
                 }
             }
@@ -299,6 +303,7 @@ describe('Status', () => {
                     // start sending coinjoinRequests after third iteration
                     const coinjoinRequests = { [round.id]: { trezor: affiliateData } };
                     resolve({
+                        ...STATUS_EVENT,
                         roundStates: [round],
                         affiliateInformation: {
                             ...AFFILIATE_INFO,
@@ -307,8 +312,8 @@ describe('Status', () => {
                     });
                 } else {
                     resolve({
+                        ...STATUS_EVENT,
                         roundStates: [round],
-                        affiliateInformation: AFFILIATE_INFO,
                     });
                 }
             }

--- a/packages/coinjoin/tests/fixtures/round.fixture.ts
+++ b/packages/coinjoin/tests/fixtures/round.fixture.ts
@@ -88,7 +88,7 @@ export const DEFAULT_ROUND = {
 } as Round;
 
 export const AFFILIATE_INFO = {
-    runningAffiliateServers: ['trezor'],
+    runningAffiliateServers: ['trezor' as const],
     coinjoinRequests: {},
 };
 
@@ -134,4 +134,22 @@ export const createCoinjoinRound = (
     }
 
     return round;
+};
+
+export const FEE_RATE_RESULTS = {
+    fast: 258,
+    recommended: 129,
+};
+
+export const STATUS_TRANSFORMED = {
+    feeRatesMedians: FEE_RATE_RESULTS,
+    allowedInputAmounts: {
+        max: 134375000000,
+        min: 5000,
+    },
+    rounds: [],
+    coordinationFeeRate: {
+        plebsDontPayThreshold: 1000000,
+        rate: 0.003,
+    },
 };

--- a/packages/coinjoin/tests/fixtures/round.fixture.ts
+++ b/packages/coinjoin/tests/fixtures/round.fixture.ts
@@ -92,6 +92,12 @@ export const AFFILIATE_INFO = {
     coinjoinRequests: {},
 };
 
+export const STATUS_EVENT = {
+    roundStates: [],
+    affiliateInformation: AFFILIATE_INFO,
+    coinJoinFeeRateMedians: FEE_RATE_MEDIANS,
+};
+
 type CJRoundOptions = ConstructorParameters<typeof CoinjoinRound>[1];
 interface CreateCoinjoinRoundOptions extends CJRoundOptions {
     statusRound?: Partial<Round>;

--- a/packages/coinjoin/tests/utils/roundUtils.test.ts
+++ b/packages/coinjoin/tests/utils/roundUtils.test.ts
@@ -1,6 +1,18 @@
-import { getCommitmentData, readTimeSpan, estimatePhaseDeadline } from '../../src/utils/roundUtils';
+import {
+    getCommitmentData,
+    readTimeSpan,
+    estimatePhaseDeadline,
+    transformFeeRatesMedians,
+    transformStatus,
+} from '../../src/utils/roundUtils';
 import { ROUND_REGISTRATION_END_OFFSET } from '../../src/constants';
-import { DEFAULT_ROUND } from '../fixtures/round.fixture';
+import {
+    DEFAULT_ROUND,
+    FEE_RATE_MEDIANS,
+    FEE_RATE_RESULTS,
+    STATUS_EVENT,
+    STATUS_TRANSFORMED,
+} from '../fixtures/round.fixture';
 
 describe('roundUtils', () => {
     it('getCommitmentData', () => {
@@ -75,5 +87,21 @@ describe('roundUtils', () => {
             }),
             Date.now(),
         );
+    });
+
+    describe('transformFeeRatesMedians', () => {
+        it('transform correctly', () => {
+            const feeRatesMedians = transformFeeRatesMedians(FEE_RATE_MEDIANS);
+
+            expect(feeRatesMedians).toEqual(FEE_RATE_RESULTS);
+        });
+    });
+
+    describe('transformStatus', () => {
+        it('transform correctly', () => {
+            const feeRatesMedians = transformStatus(STATUS_EVENT);
+
+            expect(feeRatesMedians).toEqual(STATUS_TRANSFORMED);
+        });
     });
 });

--- a/packages/suite/src/actions/wallet/__tests__/coinjoinAccountActions.test.ts
+++ b/packages/suite/src/actions/wallet/__tests__/coinjoinAccountActions.test.ts
@@ -24,6 +24,7 @@ jest.mock('@suite/services/coinjoin/coinjoinService', () => {
                     rounds: [{ id: '00', phase: 0 }],
                     feeRatesMedians: [],
                     coordinatorFeeRate: 0.003,
+                    allowedInputAmounts: { min: 5000, max: 134375000000 },
                 }),
             ),
             registerAccount: jest.fn(),

--- a/packages/suite/src/components/wallet/CoinjoinSummary/AnonymizeButton.tsx
+++ b/packages/suite/src/components/wallet/CoinjoinSummary/AnonymizeButton.tsx
@@ -1,0 +1,77 @@
+import React from 'react';
+import styled from 'styled-components';
+import { useDispatch } from 'react-redux';
+
+import { goto } from '@suite-actions/routerActions';
+import { Card, Translation } from '@suite-components';
+import { useSelector } from '@suite-hooks';
+import { TooltipButton } from '@trezor/components';
+import {
+    selectIsCoinjoinBlockedByTor,
+} from '@wallet-reducers/coinjoinReducer';
+import {
+    Feature,
+    selectIsFeatureDisabled,
+    selectFeatureMessageContent,
+} from '@suite-reducers/messageSystemReducer';
+
+export const Container = styled(Card)`
+    flex-direction: row;
+    justify-content: space-between;
+    width: 100%;
+    height: 150px;
+    align-items: center;
+`;
+
+const Button = styled(TooltipButton)`
+    justify-content: space-between;
+    width: 154px;
+    height: 46px;
+    margin-right: 10px;
+    padding: 9px 18px;
+`;
+
+interface AnonymizeButtonProps {
+    accountKey: string;
+}
+
+export const AnonymizeButton = ({ accountKey }: AnonymizeButtonProps) => {
+    const isCoinjoinBlockedByTor = useSelector(selectIsCoinjoinBlockedByTor);
+
+    const isCoinJoinDisabledByFeatureFlag = useSelector(state =>
+        selectIsFeatureDisabled(state, Feature.coinjoin),
+    );
+    const featureMessageContent = useSelector(state =>
+        selectFeatureMessageContent(state, Feature.coinjoin),
+    );
+
+    const dispatch = useDispatch();
+
+    const isDisabled =
+        isCoinJoinDisabledByFeatureFlag ||
+        isCoinjoinBlockedByTor;
+
+    const goToSetup = () => dispatch(goto('wallet-anonymize', { preserveParams: true }));
+
+    const getTooltipContent = () => {
+        if (isCoinJoinDisabledByFeatureFlag && featureMessageContent) {
+            return featureMessageContent;
+        }
+        if (isCoinjoinBlockedByTor) {
+            return <Translation id="TR_UNAVAILABLE_COINJOIN_TOR_DISABLE_TOOLTIP" />;
+        }
+    };
+
+    return (
+        <Button
+            onClick={goToSetup}
+            icon="ARROW_RIGHT_LONG"
+            isDisabled={isDisabled}
+            alignIcon="right"
+            size={16}
+            tooltipContent={getTooltipContent()}
+        >
+            <Translation id="TR_ANONYMIZE" />
+        </Button>
+    );
+};

--- a/packages/suite/src/components/wallet/CoinjoinSummary/AnonymizeButton.tsx
+++ b/packages/suite/src/components/wallet/CoinjoinSummary/AnonymizeButton.tsx
@@ -8,6 +8,7 @@ import { useSelector } from '@suite-hooks';
 import { TooltipButton } from '@trezor/components';
 import {
     selectIsCoinjoinBlockedByTor,
+    selectIsCoinjoinBlockedByAmountsTooSmall,
 } from '@wallet-reducers/coinjoinReducer';
 import {
     Feature,
@@ -37,6 +38,9 @@ interface AnonymizeButtonProps {
 
 export const AnonymizeButton = ({ accountKey }: AnonymizeButtonProps) => {
     const isCoinjoinBlockedByTor = useSelector(selectIsCoinjoinBlockedByTor);
+    const isCoinjoinBlockedByAmountsTooSmall = useSelector(state =>
+        selectIsCoinjoinBlockedByAmountsTooSmall(state, accountKey),
+    );
 
     const isCoinJoinDisabledByFeatureFlag = useSelector(state =>
         selectIsFeatureDisabled(state, Feature.coinjoin),
@@ -49,6 +53,7 @@ export const AnonymizeButton = ({ accountKey }: AnonymizeButtonProps) => {
 
     const isDisabled =
         isCoinJoinDisabledByFeatureFlag ||
+        isCoinjoinBlockedByAmountsTooSmall ||
         isCoinjoinBlockedByTor;
 
     const goToSetup = () => dispatch(goto('wallet-anonymize', { preserveParams: true }));
@@ -59,6 +64,9 @@ export const AnonymizeButton = ({ accountKey }: AnonymizeButtonProps) => {
         }
         if (isCoinjoinBlockedByTor) {
             return <Translation id="TR_UNAVAILABLE_COINJOIN_TOR_DISABLE_TOOLTIP" />;
+        }
+        if (isCoinjoinBlockedByAmountsTooSmall) {
+            return <Translation id="TR_UNAVAILABLE_COINJOIN_AMOUNTS_TOO_SMALL" />;
         }
     };
 

--- a/packages/suite/src/components/wallet/CoinjoinSummary/AnonymizedIndicator.tsx
+++ b/packages/suite/src/components/wallet/CoinjoinSummary/AnonymizedIndicator.tsx
@@ -1,0 +1,27 @@
+import React from 'react';
+import styled from 'styled-components';
+
+import { Translation } from '@suite-components';
+import { variables, Image } from '@trezor/components';
+
+const Container = styled.div`
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    margin-right: 32px;
+`;
+
+const AmomymizedMessage = styled.span`
+    color: ${({ theme }) => theme.TYPE_GREEN};
+    font-size: ${variables.FONT_SIZE.SMALL};
+    font-weight: ${variables.FONT_WEIGHT.MEDIUM};
+`;
+
+export const AnonymizedIndicator = () => (
+    <Container>
+        <Image image="CHECK_SHIELD" width={90} />
+        <AmomymizedMessage>
+            <Translation id="TR_ALL_FUNDS_ANONYMIZED" />
+        </AmomymizedMessage>
+    </Container>
+);

--- a/packages/suite/src/components/wallet/CoinjoinSummary/BalanceSection.tsx
+++ b/packages/suite/src/components/wallet/CoinjoinSummary/BalanceSection.tsx
@@ -1,23 +1,16 @@
 import React from 'react';
 import styled from 'styled-components';
-import { useDispatch } from 'react-redux';
 
-import { goto } from '@suite-actions/routerActions';
-import { Card, Translation } from '@suite-components';
+import { Card } from '@suite-components';
 import { useSelector } from '@suite-hooks';
-import { variables, TooltipButton, Image } from '@trezor/components';
 import {
     selectCoinjoinAccountByKey,
     selectCurrentCoinjoinBalanceBreakdown,
-    selectIsCoinjoinBlockedByTor,
 } from '@wallet-reducers/coinjoinReducer';
 import { BalancePrivacyBreakdown } from './BalancePrivacyBreakdown';
+import { AnonymizedIndicator } from './AnonymizedIndicator';
+import { AnonymizeButton } from './AnonymizeButton';
 import { CoinjoinStatus } from './CoinjoinStatus';
-import {
-    Feature,
-    selectIsFeatureDisabled,
-    selectFeatureMessageContent,
-} from '@suite-reducers/messageSystemReducer';
 
 export const Container = styled(Card)`
     flex-direction: row;
@@ -27,27 +20,6 @@ export const Container = styled(Card)`
     align-items: center;
 `;
 
-const AnonymizeButton = styled(TooltipButton)`
-    justify-content: space-between;
-    width: 154px;
-    height: 46px;
-    margin-right: 10px;
-    padding: 9px 18px;
-`;
-
-const AnonymizedIndicator = styled.div`
-    display: flex;
-    flex-direction: column;
-    align-items: center;
-    margin-right: 32px;
-`;
-
-const AmomymizedMessage = styled.span`
-    color: ${({ theme }) => theme.TYPE_GREEN};
-    font-size: ${variables.FONT_SIZE.SMALL};
-    font-weight: ${variables.FONT_WEIGHT.MEDIUM};
-`;
-
 interface BalanceSectionProps {
     accountKey: string;
 }
@@ -55,28 +27,8 @@ interface BalanceSectionProps {
 export const BalanceSection = ({ accountKey }: BalanceSectionProps) => {
     const coinjoinAccount = useSelector(state => selectCoinjoinAccountByKey(state, accountKey));
     const { notAnonymized } = useSelector(selectCurrentCoinjoinBalanceBreakdown);
-    const isCoinjoinBlockedByTor = useSelector(selectIsCoinjoinBlockedByTor);
-    const isCoinJoinDisabledByFeatureFlag = useSelector(state =>
-        selectIsFeatureDisabled(state, Feature.coinjoin),
-    );
-    const featureMessageContent = useSelector(state =>
-        selectFeatureMessageContent(state, Feature.coinjoin),
-    );
-
-    const dispatch = useDispatch();
 
     const allAnonymized = notAnonymized === '0';
-
-    const goToSetup = () => dispatch(goto('wallet-anonymize', { preserveParams: true }));
-
-    const getTooltipContent = () => {
-        if (isCoinJoinDisabledByFeatureFlag && featureMessageContent) {
-            return featureMessageContent;
-        }
-        if (isCoinjoinBlockedByTor) {
-            return <Translation id="TR_UNAVAILABLE_COINJOIN_TOR_DISABLE_TOOLTIP" />;
-        }
-    };
 
     const getRightSideComponent = () => {
         if (coinjoinAccount?.session) {
@@ -84,28 +36,10 @@ export const BalanceSection = ({ accountKey }: BalanceSectionProps) => {
         }
 
         if (allAnonymized) {
-            return (
-                <AnonymizedIndicator>
-                    <Image image="CHECK_SHIELD" width={90} />
-                    <AmomymizedMessage>
-                        <Translation id="TR_ALL_FUNDS_ANONYMIZED" />
-                    </AmomymizedMessage>
-                </AnonymizedIndicator>
-            );
+            return <AnonymizedIndicator />;
         }
 
-        return (
-            <AnonymizeButton
-                onClick={goToSetup}
-                icon="ARROW_RIGHT_LONG"
-                isDisabled={isCoinJoinDisabledByFeatureFlag || isCoinjoinBlockedByTor}
-                alignIcon="right"
-                size={16}
-                tooltipContent={getTooltipContent()}
-            >
-                <Translation id="TR_ANONYMIZE" />
-            </AnonymizeButton>
-        );
+        return <AnonymizeButton accountKey={accountKey} />;
     };
 
     return (

--- a/packages/suite/src/reducers/wallet/__fixtures__/coinjoinReducer.ts
+++ b/packages/suite/src/reducers/wallet/__fixtures__/coinjoinReducer.ts
@@ -1,0 +1,166 @@
+import { COINJOIN } from '@wallet-actions/constants';
+import { initialState } from '@wallet-reducers/coinjoinReducer';
+import { SessionPhase } from '@wallet-types/coinjoin';
+
+const account = {
+    key: 'A',
+    symbol: 'test',
+    targetAnonymity: 20,
+    previousSessions: [],
+    session: {
+        maxCoordinatorFeeRate: 0.003,
+        maxFeePerKvbyte: 2000,
+        maxRounds: 8,
+        skipRounds: [4, 5],
+        targetAnonymity: 20,
+        timeCreated: 1674818299886,
+        sessionPhaseQueue: [],
+        registeredUtxos: [],
+        signedRounds: [],
+        paused: true,
+        interrupted: false,
+        timeEnded: 1674818338720,
+    },
+};
+
+export default [
+    {
+        description: 'updateSessionPhase initial',
+        initialState: {
+            ...initialState,
+            accounts: [account],
+        },
+        actions: [
+            {
+                type: COINJOIN.CLIENT_SESSION_PHASE,
+                payload: {
+                    phase: SessionPhase.RoundSearch,
+                    accountKeys: ['A'],
+                },
+            },
+        ],
+        result: {
+            ...initialState,
+            accounts: [
+                {
+                    ...account,
+                    session: {
+                        ...account.session,
+                        sessionPhaseQueue: [SessionPhase.RoundSearch],
+                    },
+                },
+            ],
+        },
+    },
+    {
+        description: 'updateSessionPhase duplicate',
+        initialState: {
+            ...initialState,
+            accounts: [
+                {
+                    ...account,
+                    session: {
+                        ...account.session,
+                        sessionPhaseQueue: [SessionPhase.RoundSearch],
+                    },
+                },
+            ],
+        },
+        actions: [
+            {
+                type: COINJOIN.CLIENT_SESSION_PHASE,
+                payload: {
+                    phase: SessionPhase.RoundSearch,
+                    accountKeys: ['A'],
+                },
+            },
+        ],
+        result: {
+            ...initialState,
+            accounts: [
+                {
+                    ...account,
+                    session: {
+                        ...account.session,
+                        sessionPhaseQueue: [SessionPhase.RoundSearch],
+                    },
+                },
+            ],
+        },
+    },
+    {
+        description: 'updateSessionPhase previous',
+        initialState: {
+            ...initialState,
+            accounts: [
+                {
+                    ...account,
+                    session: {
+                        ...account.session,
+                        sessionPhaseQueue: [SessionPhase.AwaitingOthersConfirmation],
+                    },
+                },
+            ],
+        },
+        actions: [
+            {
+                type: COINJOIN.CLIENT_SESSION_PHASE,
+                payload: {
+                    phase: SessionPhase.AwaitingConfirmation,
+                    accountKeys: ['A'],
+                },
+            },
+        ],
+        result: {
+            ...initialState,
+            accounts: [
+                {
+                    ...account,
+                    session: {
+                        ...account.session,
+                        sessionPhaseQueue: [SessionPhase.AwaitingOthersConfirmation],
+                    },
+                },
+            ],
+        },
+    },
+    {
+        description: 'updateSessionPhase previous from first round',
+        initialState: {
+            ...initialState,
+            accounts: [
+                {
+                    ...account,
+                    session: {
+                        ...account.session,
+                        sessionPhaseQueue: [SessionPhase.AwaitingOthersConfirmation],
+                    },
+                },
+            ],
+        },
+        actions: [
+            {
+                type: COINJOIN.CLIENT_SESSION_PHASE,
+                payload: {
+                    phase: SessionPhase.RoundSearch,
+                    accountKeys: ['A'],
+                },
+            },
+        ],
+        result: {
+            ...initialState,
+            accounts: [
+                {
+                    ...account,
+                    session: {
+                        ...account.session,
+                        sessionPhaseQueue: [
+                            SessionPhase.AwaitingOthersConfirmation,
+                            SessionPhase.RoundSearch,
+                        ],
+                    },
+                },
+            ],
+        },
+    },
+];

--- a/packages/suite/src/reducers/wallet/__tests__/coinjoinReducer.test.ts
+++ b/packages/suite/src/reducers/wallet/__tests__/coinjoinReducer.test.ts
@@ -1,0 +1,16 @@
+import { coinjoinReducer, CoinjoinState } from '../coinjoinReducer';
+import fixtures from '../__fixtures__/coinjoinReducer';
+
+import type { Action } from '@suite-types';
+
+describe('Coinjoin reducer', () => {
+    fixtures.forEach(f => {
+        it(f.description, () => {
+            let state = f.initialState as unknown as CoinjoinState;
+            f.actions.forEach(a => {
+                state = coinjoinReducer(state, a as Action);
+            });
+            expect(state).toEqual(f.result);
+        });
+    });
+});

--- a/packages/suite/src/reducers/wallet/coinjoinReducer.ts
+++ b/packages/suite/src/reducers/wallet/coinjoinReducer.ts
@@ -23,17 +23,13 @@ import {
 import { selectTorState, SuiteRootState } from '@suite-reducers/suiteReducer';
 import { AccountsRootState, selectAccountByKey } from '@suite-common/wallet-core';
 
-export interface CoinjoinClientFeeRatesMedians {
-    fast: number;
-    recommended: number;
-}
-
-export interface CoinjoinClientInstance {
-    status: 'loading' | 'loaded';
+export interface CoinjoinClientInstance
+    extends Pick<
+        CoinjoinStatusEvent,
+        'coordinationFeeRate' | 'allowedInputAmounts' | 'feeRatesMedians'
+    > {
     rounds: { id: string; phase: RoundPhase }[]; // store only slice of Round in reducer. may be extended in the future
-    feeRatesMedians: CoinjoinClientFeeRatesMedians;
-    coordinationFeeRate: CoinjoinStatusEvent['coordinationFeeRate'];
-    allowedInputAmounts: CoinjoinStatusEvent['allowedInputAmounts'];
+    status: 'loading' | 'loaded';
 }
 
 export interface CoinjoinState {

--- a/packages/suite/src/reducers/wallet/coinjoinReducer.ts
+++ b/packages/suite/src/reducers/wallet/coinjoinReducer.ts
@@ -48,7 +48,7 @@ export type CoinjoinRootState = {
     SelectedAccountRootState &
     SuiteRootState;
 
-const initialState: CoinjoinState = {
+export const initialState: CoinjoinState = {
     accounts: [],
     clients: {},
     isPreloading: false,

--- a/packages/suite/src/services/coinjoin/config.ts
+++ b/packages/suite/src/services/coinjoin/config.ts
@@ -128,7 +128,10 @@ export const DEFAULT_CLIENT_STATUS = {
         rate: COORDINATOR_FEE_RATE,
         plebsDontPayThreshold: PLEBS_DONT_PAY_THRESHOLD,
     },
-    allowedInputAmounts: { min: MIN_ALLOWED_AMOUNT, max: MAX_ALLOWED_AMOUNT },
+    allowedInputAmounts: {
+        min: MIN_ALLOWED_AMOUNT,
+        max: MAX_ALLOWED_AMOUNT,
+    },
 };
 
 export const getCoinjoinConfig = (

--- a/packages/suite/src/support/messages.ts
+++ b/packages/suite/src/support/messages.ts
@@ -3894,6 +3894,10 @@ export default defineMessages({
         id: 'TR_UNAVAILABLE_COINJOIN_NO_INTERNET',
         defaultMessage: 'Unavailable. No internet connection.',
     },
+    TR_UNAVAILABLE_COINJOIN_AMOUNTS_TOO_SMALL: {
+        id: 'TR_UNAVAILABLE_COINJOIN_AMOUNTS_TOO_SMALL',
+        defaultMessage: 'Too small amounts to be used in coinjoin.',
+    },
     TR_ONION_BACKEND_TOR_NEEDED: {
         id: 'TR_ONION_BACKEND_TOR_NEEDED',
         defaultMessage:

--- a/packages/suite/src/utils/wallet/__fixtures__/coinjoinUtils.ts
+++ b/packages/suite/src/utils/wallet/__fixtures__/coinjoinUtils.ts
@@ -142,6 +142,20 @@ export const calculateProgressParams: Array<{
         },
         result: 0,
     },
+    {
+        params: {
+            ...baseCalculateProgressParams,
+            targetAnonymity: 1,
+            anonymitySet: { one: 10 },
+            utxos: [
+                {
+                    address: 'one',
+                    ...baseUtxo,
+                },
+            ],
+        },
+        result: 100,
+    },
 ];
 
 export const getMaxRounds = [

--- a/packages/suite/src/utils/wallet/coinjoinUtils.ts
+++ b/packages/suite/src/utils/wallet/coinjoinUtils.ts
@@ -109,31 +109,16 @@ export const calculateAnonymityProgress = ({
         .toNumber();
 };
 
-/**
- * Transform from coordinator format to coinjoinReducer format `CoinjoinClientFeeRatesMedians`
- * array => object { name: value-in-vBytes }
- */
-export const transformFeeRatesMedians = (medians: CoinjoinStatusEvent['feeRatesMedians']) => {
-    const [fast, recommended] = medians.map(m => m.medianFeeRate);
-    // convert from kvBytes (kilo virtual bytes) to vBytes (how the value is displayed in UI)
-    const kvB2vB = (v: number) => (v ? Math.round(v / 1000) : 1);
-
-    return {
-        fast: kvB2vB(fast) * 2, // NOTE: this calculation will be smarter once have enough data
-        recommended: kvB2vB(recommended),
-    };
-};
-
-/**
- * Transform from coordinator format to coinjoinReducer format `CoinjoinClientInstance`
- * - coordinatorFeeRate: multiply the amount registered for coinjoin by this value to get the total fee
- * - feeRatesMedians: array => object with values in kvBytes
- */
-export const transformCoinjoinStatus = (event: CoinjoinStatusEvent) => ({
-    rounds: event.rounds.map(r => ({ id: r.id, phase: r.phase })),
-    coordinationFeeRate: event.coordinationFeeRate,
-    feeRatesMedians: transformFeeRatesMedians(event.feeRatesMedians),
-    allowedInputAmounts: event.allowedInputAmounts,
+export const transformCoinjoinStatus = ({
+    coordinationFeeRate,
+    feeRatesMedians,
+    allowedInputAmounts,
+    rounds,
+}: CoinjoinStatusEvent) => ({
+    coordinationFeeRate,
+    feeRatesMedians,
+    allowedInputAmounts,
+    rounds: rounds.map(({ id, phase }) => ({ id, phase })),
 });
 
 // convert suite account type to @trezor/coinjoin RegisterAccountParams scriptType


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

- Calculate the minimal UTXO size suitable for coinjoin in selector.
- Disable coinjoin start if there are no UTXO big enough.
- BalanceSection split to more components because it was already too complex.

## Related Issue

Resolve https://github.com/trezor/trezor-suite/issues/7099

## Screenshots:
<img width="703" alt="image" src="https://user-images.githubusercontent.com/3729633/213715359-a76393c1-f7ed-408d-901c-8931e3c7f100.png">

