### PR TITLE
Fetch all pages from `/block` endpoint in CJ accounts

### DIFF
--- a/packages/coinjoin/src/types/backend.ts
+++ b/packages/coinjoin/src/types/backend.ts
@@ -19,6 +19,8 @@ export type { BlockbookTransaction, VinVout, EnhancedVinVout };
 export type { Address, Utxo, Transaction, AccountAddresses };
 
 export type BlockbookBlock = {
+    page: number;
+    totalPages: number;
     height: number;
     txs: BlockbookTransaction[];
 };

--- a/packages/coinjoin/tests/fixtures/methods.fixture.ts
+++ b/packages/coinjoin/tests/fixtures/methods.fixture.ts
@@ -27,6 +27,8 @@ export const BLOCKS = [
         hash: '09f69854a4572575e2a8af0dea70ff5efd46957e2cb60e81c0d760098ab48b44',
         filter: '01656c90', // receive 1 out
         previousBlockHash: BASE_HASH,
+        page: 1,
+        totalPages: 1,
         txs: [
             {
                 txid: 'txid_1',
@@ -66,6 +68,8 @@ export const BLOCKS = [
         hash: '5513d63651bbb32985b54fa9e0e530553e3e9cebdd10feae7f019c04edb80f61',
         filter: '0298ad7857d0c0', // receive 1 in, receive 2 out
         previousBlockHash: '09f69854a4572575e2a8af0dea70ff5efd46957e2cb60e81c0d760098ab48b44',
+        page: 1,
+        totalPages: 1,
         txs: [
             {
                 txid: 'txid_2',
@@ -100,6 +104,8 @@ export const BLOCKS = [
         hash: '295578a3c8eb87736a5e657b06a0933f7ec5f82c43f8418fdb38f74c0fc066c7',
         filter: '0802a1103e91e638632d0f148d8c4618cc6118aeaad3d0', // nothing
         previousBlockHash: '5513d63651bbb32985b54fa9e0e530553e3e9cebdd10feae7f019c04edb80f61',
+        page: 1,
+        totalPages: 1,
         txs: [],
     },
     {
@@ -107,6 +113,8 @@ export const BLOCKS = [
         hash: '12de06b8ae4bbc660e3f565c876c606f5a1bd3463364c6abfc882b5ff6dd86e3',
         filter: '03018bfa4d4731ee2480', // receive 1 out
         previousBlockHash: '295578a3c8eb87736a5e657b06a0933f7ec5f82c43f8418fdb38f74c0fc066c7',
+        page: 1,
+        totalPages: 1,
         txs: [
             {
                 txid: 'txid_3',
@@ -149,6 +157,8 @@ export const BLOCKS = [
         hash: '2c2c65aad93eebe235955e170913fd6558453dd999a4ded6249bbdc9d54da1f7',
         filter: '08a4afd740dddb6185ca00666d22a55fc9252008f9cda0', // nothing
         previousBlockHash: '12de06b8ae4bbc660e3f565c876c606f5a1bd3463364c6abfc882b5ff6dd86e3',
+        page: 1,
+        totalPages: 1,
         txs: [],
     },
     {
@@ -156,6 +166,8 @@ export const BLOCKS = [
         hash: '5021a2185f27ad04d45f1b53c873b2231311aea99e0f1d7a6252167540b9db4c',
         filter: '03a69058941e6f5fc1', // receive 2 in, receive 1 out, change 1 out'
         previousBlockHash: '2c2c65aad93eebe235955e170913fd6558453dd999a4ded6249bbdc9d54da1f7',
+        page: 1,
+        totalPages: 1,
         txs: [
             {
                 txid: 'txid_4',
@@ -196,6 +208,8 @@ export const BLOCKS = [
         hash: '01d37c4490e9ddaf6b5c886eaa215b8d0b658c93ea42cfd871b226f606672c0b',
         filter: '023eee59053e40', // receive 1 in, change 1 in, receive 1 out'
         previousBlockHash: '5021a2185f27ad04d45f1b53c873b2231311aea99e0f1d7a6252167540b9db4c',
+        page: 1,
+        totalPages: 1,
         txs: [
             {
                 txid: 'txid_5',
@@ -236,6 +250,18 @@ export const BLOCKS = [
         hash: '36d01c975372c363d94f0e9e22e8a61a6a52e3408c98920ef1587b024ec487e3',
         filter: '02782a5165c980', // receive 1 out
         previousBlockHash: '01d37c4490e9ddaf6b5c886eaa215b8d0b658c93ea42cfd871b226f606672c0b',
+        page: 1,
+        totalPages: 2,
+        txs: [],
+    },
+    // Second block with height 8 but page 2 to simulate Blockbook pagination
+    {
+        height: 8,
+        hash: '36d01c975372c363d94f0e9e22e8a61a6a52e3408c98920ef1587b024ec487e3',
+        filter: '02782a5165c980', // receive 1 out
+        previousBlockHash: '01d37c4490e9ddaf6b5c886eaa215b8d0b658c93ea42cfd871b226f606672c0b',
+        page: 2,
+        totalPages: 2,
         txs: [
             {
                 txid: 'txid_6',

--- a/packages/coinjoin/tests/mocks/MockBackendClient.ts
+++ b/packages/coinjoin/tests/mocks/MockBackendClient.ts
@@ -13,6 +13,8 @@ type BlockFixture = {
     previousBlockHash: string;
     filter: string;
     txs: TransactionFixture[];
+    page: number;
+    totalPages: number;
 };
 
 export class MockBackendClient extends CoinjoinBackendClient {
@@ -64,6 +66,7 @@ export class MockBackendClient extends CoinjoinBackendClient {
                     return this.mockResponse(200, {
                         bestHeight: -1,
                         filters: this.blocks
+                            .filter(({ page }) => page === 1)
                             .slice(from, from + count)
                             .map(
                                 ({ height, hash, filter, previousBlockHash }) =>
@@ -82,7 +85,7 @@ export class MockBackendClient extends CoinjoinBackendClient {
     }
 
     protected blockbook(): MockEndpoint {
-        const parseGet = (path: string) => {
+        const parseGet = (path: string, query?: Record<string, any>) => {
             const [what, which] = path.split('/');
             switch (what) {
                 case 'tx': {
@@ -91,7 +94,8 @@ export class MockBackendClient extends CoinjoinBackendClient {
                 }
                 case 'block': {
                     const height = parseInt(which, 10);
-                    const block = this.blocks.find(b => b.height === height);
+                    const page = query?.page ?? 1;
+                    const block = this.blocks.find(b => b.height === height && b.page === page);
                     return block ? this.mockResponse(200, block) : this.mockResponse(404);
                 }
                 default:


### PR DESCRIPTION
## Description

Currently, during CJ acount discovery, only first page of transactions is always downloaded from Blockbook's `/block` endpoint. As there is practically never more than 1000 (= the page size) transactions in one testnet block, everything worked correctly so far.

This PR should make possible to switch to mainnet (where there is usually more than 1000 txs per block) by fetching all the pages with recently added `fetchBlockPage` method and putting them together in `fetchBlock` method.

## Related Issue

Resolve #7420
