### PR TITLE
Fix/cmd on win with coinjoin

### DIFF
--- a/packages/suite-desktop/src/libs/processes/BaseProcess.ts
+++ b/packages/suite-desktop/src/libs/processes/BaseProcess.ts
@@ -1,5 +1,5 @@
 import path from 'path';
-import { spawn, ChildProcess, IOType } from 'child_process';
+import { spawn, ChildProcess } from 'child_process';
 
 import { isDevEnv } from '@suite-common/suite-utils';
 
@@ -19,7 +19,6 @@ export type Options = {
     startupCooldown?: number;
     stopKillWait?: number;
     autoRestart?: number;
-    stdio?: [IOType, IOType, IOType];
 };
 
 const defaultOptions: Options = {
@@ -139,7 +138,7 @@ export abstract class BaseProcess {
             this.process = spawn(processPath, params, {
                 cwd: processDir,
                 env: processEnv,
-                stdio: this.options.stdio || ['ignore', 'ignore', 'ignore'],
+                stdio: ['ignore', 'ignore', 'ignore'],
             });
             this.process.on('error', err => this.onError(err));
             this.process.on('exit', code => this.onExit(code));

--- a/packages/suite-desktop/src/libs/processes/CoinjoinProcess.ts
+++ b/packages/suite-desktop/src/libs/processes/CoinjoinProcess.ts
@@ -7,7 +7,6 @@ export class CoinjoinProcess extends BaseProcess {
     constructor() {
         super('coinjoin', 'WalletWasabi.WabiSabiClientLibrary', {
             autoRestart: 0,
-            stdio: ['inherit', 'inherit', 'inherit'],
         });
     }
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Revert logging from coinjoin middleware. There were no more logging anyway in last two versions of middleware. And it just causes the issue on Win.

We should consider using `utilityProcess` instead of child_process in BaseProcess, but it need Electron update.
https://github.com/trezor/trezor-suite/issues/7427

## Related Issue

Resolve https://github.com/trezor/trezor-suite/issues/7375

