### PR TITLE
feat(suite): add transports menu in debug

### DIFF
--- a/packages/suite-desktop-api/src/api.ts
+++ b/packages/suite-desktop-api/src/api.ts
@@ -11,6 +11,7 @@ import {
     BootstrapTorEvent,
     HandshakeTorModule,
     TorStatusEvent,
+    Status,
 } from './messages';
 
 // Event messages from renderer to main process
@@ -55,6 +56,9 @@ export interface RendererChannels {
     // custom protocol
     'protocol/open': string;
 
+    // bridge
+    'bridge/status': Status;
+
     'handshake/event': HandshakeEvent;
 }
 
@@ -69,6 +73,8 @@ export interface InvokeChannels {
     'metadata/write': (options: { file: string; content: string }) => InvokeResult;
     'server/request-address': (route: string) => string | undefined;
     'tor/toggle': (shouldEnableTor: boolean) => InvokeResult;
+    'bridge/toggle': () => InvokeResult;
+    'bridge/get-status': () => InvokeResult<Status>;
     'user-data/clear': () => InvokeResult;
     'user-data/open': (directory?: string) => InvokeResult;
     'udev/install': () => InvokeResult;
@@ -116,4 +122,7 @@ export interface DesktopApi {
     installUdevRules: DesktopApiInvoke<'udev/install'>;
     // Logger
     configLogger: DesktopApiSend<'logger/config'>;
+    // Bridge
+    getBridgeStatus: DesktopApiInvoke<'bridge/get-status'>;
+    toggleBridge: DesktopApiInvoke<'bridge/toggle'>;
 }

--- a/packages/suite-desktop-api/src/factory.ts
+++ b/packages/suite-desktop-api/src/factory.ts
@@ -115,5 +115,9 @@ export const factory = <R extends StrictIpcRenderer<any>>(ipcRenderer?: R): Desk
         configLogger: config => {
             ipcRenderer.send('logger/config', config);
         },
+
+        getBridgeStatus: () => ipcRenderer.invoke('bridge/get-status'),
+
+        toggleBridge: () => ipcRenderer.invoke('bridge/toggle'),
     };
 };

--- a/packages/suite-desktop-api/src/messages.ts
+++ b/packages/suite-desktop-api/src/messages.ts
@@ -96,6 +96,12 @@ export type UpdateProgress = Partial<{
     verifying: boolean;
 }>;
 
+// todo: suite-desktop-api does not suite-desktop dependency but we could reuse lot of types from there I guess
+export type Status = {
+    service: boolean;
+    process: boolean;
+};
+
 export type InvokeResult<Payload = undefined> = ExtractUndefined<Payload> extends undefined
     ? { success: true; payload?: Payload } | { success: false; error: string; code?: string }
     : { success: true; payload: Payload } | { success: false; error: string; code?: string };

--- a/packages/suite-desktop-api/src/validation.ts
+++ b/packages/suite-desktop-api/src/validation.ts
@@ -36,5 +36,6 @@ const validChannels: Array<keyof RendererChannels> = [
     'tor/bootstrap',
     'protocol/open',
     'handshake/event',
+    'bridge/status',
 ];
 export const isValidChannel = (channel: any) => validChannels.includes(channel);

--- a/packages/suite-desktop/src/index.d.ts
+++ b/packages/suite-desktop/src/index.d.ts
@@ -78,6 +78,9 @@ declare interface LocalStore {
     getTorSettings(): TorSettings;
     setTorSettings(torSettings: TorSettings): void;
     clear(): void;
+    // todo: this is a never ending story, should we model it as transport? processes? bridge?
+    getBridgeSettings(): BridgeSettings;
+    setBridgeSettings(bridgeSettings: BridgeSettings): void;
 }
 
 declare type WinBounds = {
@@ -109,4 +112,11 @@ declare type TorSettings = {
      * wants to use their own tor instance and don't run the bundled one.
      */
     address: string;
+};
+
+declare type BridgeSettings = {
+    /**
+     * Should bridge process be spawned on application startup
+     */
+    startOnStartup: boolean;
 };

--- a/packages/suite-desktop/src/libs/store.ts
+++ b/packages/suite-desktop/src/libs/store.ts
@@ -10,6 +10,7 @@ const store = new Store<{
     updateSettings: UpdateSettings;
     themeSettings: SuiteThemeVariant;
     torSettings: TorSettings;
+    bridgeSettings: BridgeSettings;
 }>();
 
 export const getWinBounds = () => store.get('winBounds', getInitialWindowSize());
@@ -38,6 +39,15 @@ export const getTorSettings = () =>
     });
 
 export const setTorSettings = (torSettings: TorSettings) => store.set('torSettings', torSettings);
+
+export const getBridgeSettings = () =>
+    store.get('bridgeSettings', {
+        startOnStartup: true,
+    });
+
+export const setBridgeSettings = (bridgeSettings: BridgeSettings) => {
+    store.set('bridgeSettings', bridgeSettings);
+};
 
 /** Deletes all items from the store. */
 export const clear = () => store.clear();

--- a/packages/suite-desktop/src/modules/bridge.ts
+++ b/packages/suite-desktop/src/modules/bridge.ts
@@ -1,17 +1,29 @@
 /**
  * Bridge runner
  */
-import { app } from 'electron';
+import { app, ipcMain } from '../typed-electron';
 
 import { BridgeProcess } from '../libs/processes/BridgeProcess';
 import { b2t } from '../libs/utils';
 
-import type { Module } from './index';
+import type { Module, Dependencies } from './index';
 
 const bridgeDev = app.commandLine.hasSwitch('bridge-dev');
 const bridgeTest = app.commandLine.hasSwitch('bridge-test');
 
-const load = async () => {
+const handleBridgeStatus = async (
+    bridge: BridgeProcess,
+    mainWindow: Dependencies['mainWindow'],
+) => {
+    logger.info('bridge', `Getting status`);
+    const status = await bridge.status();
+    logger.info('bridge', `Toggling bridge. Status: ${JSON.stringify(status)}`);
+
+    mainWindow.webContents.send('bridge/status', status);
+    return status;
+};
+
+const load = async ({ store, mainWindow }: Dependencies) => {
     const { logger } = global;
     const bridge = new BridgeProcess();
 
@@ -19,6 +31,37 @@ const load = async () => {
         logger.info('bridge', 'Stopping (app quit)');
         bridge.stop();
     });
+
+    ipcMain.handle('bridge/toggle', async (_: unknown) => {
+        const status = await handleBridgeStatus(bridge, mainWindow);
+        try {
+            if (status.service) {
+                await bridge.stop();
+                store.setBridgeSettings({ startOnStartup: false });
+            } else {
+                await bridge.start();
+                store.setBridgeSettings({ startOnStartup: true });
+            }
+            return { success: true };
+        } catch (error) {
+            return { success: false, error };
+        } finally {
+            handleBridgeStatus(bridge, mainWindow);
+        }
+    });
+
+    ipcMain.handle('bridge/get-status', async () => {
+        try {
+            const status = await bridge.status();
+            return { success: true, payload: status };
+        } catch (error) {
+            return { success: false, error };
+        }
+    });
+
+    if (!store.getBridgeSettings().startOnStartup) {
+        return;
+    }
 
     try {
         logger.info('bridge', `Starting (Dev: ${b2t(bridgeDev)})`);
@@ -29,17 +72,18 @@ const load = async () => {
         } else {
             await bridge.start();
         }
+        handleBridgeStatus(bridge, mainWindow);
     } catch (err) {
         logger.error('bridge', `Start failed: ${err.message}`);
     }
 };
 
-export const init: Module = () => {
+export const init: Module = dependencies => {
     let loaded = false;
     return () => {
         if (loaded) return;
         loaded = true;
         // TODO intentionally not awaited to mimic previous behavior, resolve later!
-        load();
+        load(dependencies);
     };
 };

--- a/packages/suite/src/views/settings/debug/Processes.tsx
+++ b/packages/suite/src/views/settings/debug/Processes.tsx
@@ -1,0 +1,76 @@
+import React, { useEffect, useState, useMemo } from 'react';
+import { Checkbox } from '@trezor/components';
+import { desktopApi } from '@trezor/suite-desktop-api';
+
+import { ActionColumn, SectionItem, TextColumn } from '@suite-components/Settings';
+
+interface Process {
+    service: boolean;
+    process: boolean;
+}
+
+export const Processes = () => {
+    const [bridgeProcess, setBridgeProcess] = useState<Process>({ service: false, process: false });
+
+    const items = useMemo(
+        () => [
+            {
+                name: 'Bridge',
+                // todo:
+                // would be nice to have something like
+                // desktopApi.toggleProcess('bridge');
+                onToggle: () => desktopApi.toggleBridge(),
+                isChecked: bridgeProcess.process === true,
+            },
+        ],
+        [bridgeProcess],
+    );
+
+    useEffect(() => {
+        // todo:
+        // would be nice to have something like
+        // desktopApi.getProcessesStatus()...
+        desktopApi.getBridgeStatus().then(result => {
+            if (result.success) {
+                setBridgeProcess(result.payload);
+            }
+        });
+
+        // todo:
+        // would be nice to have something like
+        // desktopApi.on('process-status-change, (process) => {
+        //   process.name === 'bridge'...
+        // })
+        desktopApi.on('bridge/status', (status: Process) => {
+            setBridgeProcess(status);
+        });
+
+        return () => {
+            desktopApi.removeAllListeners('bridge/status');
+        };
+    }, []);
+
+    return (
+        <>
+            <SectionItem data-test="@settings/debug/processes">
+                <TextColumn
+                    title="Processes"
+                    description="You may control subprocesses launched by Trezor Suite in this panel"
+                />
+            </SectionItem>
+            {items.map(item => (
+                <SectionItem data-test={`@settings/debug/processes/${item.name}`} key={item.name}>
+                    <TextColumn title={item.name} />
+                    <ActionColumn>
+                        <Checkbox
+                            isChecked={item.isChecked}
+                            onClick={() => {
+                                item.onToggle();
+                            }}
+                        />
+                    </ActionColumn>
+                </SectionItem>
+            ))}
+        </>
+    );
+};

--- a/packages/suite/src/views/settings/debug/SettingsDebug.tsx
+++ b/packages/suite/src/views/settings/debug/SettingsDebug.tsx
@@ -12,6 +12,8 @@ import { InvityApi } from './InvityApi';
 import { CoinjoinApi } from './CoinjoinApi';
 import { OAuthApi } from './OAuthApi';
 import { CheckFirmwareAuthenticity } from './CheckFirmwareAuthenticity';
+import { Transport } from './Transport';
+import { Processes } from './Processes';
 
 export const SettingsDebug = () => (
     <SettingsLayout>
@@ -38,6 +40,14 @@ export const SettingsDebug = () => (
         </SettingsSection>
         <SettingsSection title="Testing">
             <ThrowTestingError />
+        </SettingsSection>
+        {!isWeb() && (
+            <SettingsSection title="Processes">
+                <Processes />
+            </SettingsSection>
+        )}
+        <SettingsSection title="Transports">
+            <Transport />
         </SettingsSection>
     </SettingsLayout>
 );

--- a/packages/suite/src/views/settings/debug/Transport.tsx
+++ b/packages/suite/src/views/settings/debug/Transport.tsx
@@ -1,0 +1,92 @@
+import React, { useEffect, useState, useMemo } from 'react';
+
+import { Checkbox } from '@trezor/components';
+import { isDesktop } from '@suite-utils/env';
+import { useSelector, useActions } from '@suite-hooks';
+import * as suiteActions from '@suite-actions/suiteActions';
+import { DebugModeOptions } from '@suite/reducers/suite/suiteReducer';
+import { ArrayElement } from '@trezor/type-utils';
+import TrezorConnect, { ConnectSettings } from '@trezor/connect';
+
+import { ActionColumn, SectionItem, TextColumn } from '@suite-components/Settings';
+
+type TransportMenuItem = {
+    name: ArrayElement<NonNullable<DebugModeOptions['transports']>>;
+    // user has marked this transport as requested, @trezor/connect should try to use it
+    requested?: boolean;
+    // @trezor/connect is actively using this transport
+    active?: boolean;
+};
+
+export const Transport = () => {
+    const [connectSettings, setConnectSettings] = useState<ConnectSettings>();
+
+    useEffect(() => {
+        TrezorConnect.getSettings().then(result => {
+            if (!result.success) return;
+            setConnectSettings(result.payload);
+        });
+    }, []);
+
+    const { debug } = useSelector(state => ({
+        debug: state.suite.settings.debug,
+    }));
+
+    // fallback [] to avoid need of migration.
+    const debugTransports = useMemo(() => debug.transports || [], [debug.transports]);
+
+    const transports: TransportMenuItem[] = useMemo(() => {
+        const transports: TransportMenuItem['name'][] = ['BridgeTransport'];
+
+        if (isDesktop()) {
+            // todo: enable after nodeusb is merged
+            // transports.push('NodeUsbTransport');
+        } else {
+            transports.push('WebUsbTransport');
+        }
+
+        return transports.map(transport => ({
+            requested: debugTransports.includes(transport),
+            active: connectSettings?.transports?.includes(transport),
+            name: transport,
+        }));
+    }, [connectSettings, debugTransports]);
+
+    const { setDebugMode } = useActions({
+        setDebugMode: suiteActions.setDebugMode,
+    });
+
+    return (
+        <>
+            <SectionItem data-test="@settings/debug/transport">
+                <TextColumn
+                    title="Transports"
+                    description="You may override TrezorConnect default settings here. Select preferred transports that are to be used. You will need to reload after changes"
+                />
+            </SectionItem>
+            {/* todo: make it drag and drop sortable */}
+            {transports.map(transport => (
+                <SectionItem
+                    data-test={`@settings/debug/transport/${transport.name}`}
+                    key={transport.name}
+                >
+                    <TextColumn title={`${transport.name} ${transport.active ? '(Active)' : ''}`} />
+                    <ActionColumn>
+                        <Checkbox
+                            isChecked={transport.requested}
+                            onClick={() => {
+                                const nextTransports = debugTransports.includes(transport.name)
+                                    ? debugTransports.filter(t => t !== transport.name)
+                                    : [...debugTransports, transport.name];
+
+                                setDebugMode({
+                                    transports: nextTransports,
+                                });
+                            }}
+                        />
+                    </ActionColumn>
+                </SectionItem>
+            ))}
+        </>
+    );
+};


### PR DESCRIPTION
part of part of https://github.com/trezor/trezor-suite/pull/6509. needs to be based on https://github.com/trezor/trezor-suite/pull/7411

this is not finished but since I would like to discuss few todos I have left in the code I am moving this into 'to be reviewed' column

motivation: 
- at the moment, bridge is spawned automatically whenever suite starts. with the advent of nodeusb, which I believe we wan't to keep somewhere behind debug flag for testing, we need a way how to override this behaviour.

adds: 
- way to stop/start bridge from debug UI
- customize TrezorConnect.init transports parameter from debug UI 

possible improvements/followups:
- create a generalized way how to start/stop other process in suite
- creeate a way how to restart trezor connect without restarting suite

![image](https://user-images.githubusercontent.com/30367552/214286982-48e85ff1-03ac-4a14-be1f-8f8279c97260.png)


