### PR TITLE
fix(suite): show cex warning in coinjoin account only

### DIFF
--- a/packages/suite/src/views/wallet/receive/index.tsx
+++ b/packages/suite/src/views/wallet/receive/index.tsx
@@ -38,12 +38,13 @@ const Receive = () => {
     }
 
     const disabled = !!device.authConfirm;
+    const showCexWarning = account?.accountType === 'coinjoin' && !isCexWarningHidden;
 
     return (
         <WalletLayout title="TR_NAV_RECEIVE" account={selectedAccount}>
             <WalletLayoutHeader title="TR_NAV_RECEIVE" />
 
-            {!isCexWarningHidden && <CoinjoinCexWarning />}
+            {showCexWarning && <CoinjoinCexWarning />}
 
             <FreshAddress
                 account={account}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Show the CEX warning only in coinjoin account.

## Related Issue

Fix https://github.com/trezor/trezor-suite/issues/7168

