### PR TITLE
fix: 30 sec for timeout tor is slow

### DIFF
--- a/packages/request-manager/src/httpPool.ts
+++ b/packages/request-manager/src/httpPool.ts
@@ -10,7 +10,7 @@ interface RequestData {
 
 export class RequestPool {
     requestPool: RequestData[] = [];
-    requestTimeoutLimit = 1000 * 10;
+    requestTimeoutLimit = 1000 * 30;
     isNetworkMisbehaving = false;
     interceptorOptions: InterceptorOptions;
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Making tor is slow when request takes more than 30 seconds.
