### PR TITLE
Move analytics call to toggleRememberDevice actin creator

### DIFF
--- a/packages/suite/src/actions/suite/__tests__/suiteActions.test.ts
+++ b/packages/suite/src/actions/suite/__tests__/suiteActions.test.ts
@@ -309,9 +309,6 @@ describe('Suite Actions', () => {
     // just for coverage
     it('misc', () => {
         const SUITE_DEVICE = getSuiteDevice({ path: '1' });
-        expect(suiteActions.toggleRememberDevice(SUITE_DEVICE)).toMatchObject({
-            type: SUITE.REMEMBER_DEVICE,
-        });
         expect(suiteActions.forgetDevice(SUITE_DEVICE)).toMatchObject({
             type: SUITE.FORGET_DEVICE,
         });

--- a/packages/suite/src/actions/suite/suiteActions.ts
+++ b/packages/suite/src/actions/suite/suiteActions.ts
@@ -379,13 +379,19 @@ export const selectDevice =
  *
  * Use `forgetDevice` to forget a device regardless if its current state.
  */
-export const toggleRememberDevice = (payload: TrezorDevice, forceRemember?: true): SuiteAction => ({
-    type: SUITE.REMEMBER_DEVICE,
-    payload,
-    remember: !payload.remember || !!forceRemember,
-    // if device is already remembered, do not force it, it would remove the remember on return to suite
-    forceRemember: payload.remember ? undefined : forceRemember,
-});
+export const toggleRememberDevice =
+    (payload: TrezorDevice, forceRemember?: true) => (dispatch: Dispatch) => {
+        analytics.report({
+            type: payload.remember ? EventType.SwitchDeviceForget : EventType.SwitchDeviceRemember,
+        });
+        return dispatch({
+            type: SUITE.REMEMBER_DEVICE,
+            payload,
+            remember: !payload.remember || !!forceRemember,
+            // if device is already remembered, do not force it, it would remove the remember on return to suite
+            forceRemember: payload.remember ? undefined : forceRemember,
+        });
+    };
 
 export const forgetDevice = (payload: TrezorDevice): SuiteAction => ({
     type: SUITE.FORGET_DEVICE,

--- a/packages/suite/src/components/suite/SwitchDevice/components/WalletInstance.tsx
+++ b/packages/suite/src/components/suite/SwitchDevice/components/WalletInstance.tsx
@@ -185,14 +185,7 @@ export const WalletInstance = ({
                     <SwitchCol>
                         <Switch
                             isChecked={!!instance.remember}
-                            onChange={() => {
-                                toggleRememberDevice(instance);
-                                analytics.report({
-                                    type: instance.remember
-                                        ? EventType.SwitchDeviceForget
-                                        : EventType.SwitchDeviceRemember,
-                                });
-                            }}
+                            onChange={() => toggleRememberDevice(instance)}
                             dataTest={`${dataTestBase}/toggle-remember-switch`}
                         />
                     </SwitchCol>


### PR DESCRIPTION
## Description

A follow-up to #7453. The `analytics` call was moved to be called every time a wallet is remembered (or un-remembered).

This means it is also called inside `submitRequestForm` in Invity part, not 100% sure that is correct.

Similarly, `forgetDevice` action is also logged only inside the `WalletInstance` component (I did not touch that yet).

**QA:** Remember wallet action should be logged into analytics whether it is called from the wallet modal or from the coinjoin discovery screen.
