### PR TITLE
preparing connect 9.0.6 release

### DIFF
--- a/packages/blockchain-link/package.json
+++ b/packages/blockchain-link/package.json
@@ -66,7 +66,7 @@
     },
     "dependencies": {
         "@trezor/utils": "workspace:^9.0.4",
-        "@trezor/utxo-lib": "workspace:^1.0.2",
+        "@trezor/utxo-lib": "workspace:^1.0.3",
         "@types/web": "^0.0.80",
         "bignumber.js": "^9.1.0",
         "events": "^3.3.0",

--- a/packages/connect-popup/src/index.tsx
+++ b/packages/connect-popup/src/index.tsx
@@ -240,8 +240,7 @@ const onLoad = () => {
                 type: 'error',
                 detail: 'handshake-timeout',
             }),
-        // todo: increase timeout, now set low for testing
-        30 * 1000,
+        90 * 1000,
     );
 };
 

--- a/packages/connect/package.json
+++ b/packages/connect/package.json
@@ -60,7 +60,8 @@
         "cross-fetch": "^3.1.5",
         "events": "^3.3.0",
         "parse-uri": "1.0.7",
-        "randombytes": "2.1.0"
+        "randombytes": "2.1.0",
+        "tslib": "2.5.0"
     },
     "devDependencies": {
         "@trezor/connect-analytics": "workspace:*",

--- a/packages/connect/package.json
+++ b/packages/connect/package.json
@@ -53,7 +53,7 @@
         "@trezor/connect-common": "workspace:0.0.11",
         "@trezor/transport": "workspace:^1.1.6",
         "@trezor/utils": "workspace:^9.0.4",
-        "@trezor/utxo-lib": "workspace:^1.0.2",
+        "@trezor/utxo-lib": "workspace:^1.0.3",
         "bignumber.js": "^9.1.0",
         "blakejs": "^1.2.1",
         "bowser": "^2.11.0",

--- a/packages/connect/package.json
+++ b/packages/connect/package.json
@@ -51,7 +51,7 @@
     "dependencies": {
         "@trezor/blockchain-link": "workspace:^2.1.6",
         "@trezor/connect-common": "workspace:0.0.11",
-        "@trezor/transport": "workspace:^1.1.6",
+        "@trezor/transport": "workspace:^1.1.7",
         "@trezor/utils": "workspace:^9.0.4",
         "@trezor/utxo-lib": "workspace:^1.0.3",
         "bignumber.js": "^9.1.0",

--- a/packages/connect/tsconfig.lib.json
+++ b/packages/connect/tsconfig.lib.json
@@ -3,6 +3,8 @@
     "compilerOptions": {
         "outDir": "lib",
         "target": "es2019",
+        // note: do not remove tslib from package.json. It might seem that it is not used
+        // but it is required due to importHelpers: true
         "importHelpers": true
     },
     "include": ["./src"]

--- a/packages/transport/CHANGELOG.md
+++ b/packages/transport/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 1.1.7
+
+-   Code cleanup, sharing constants with @trezor/connect
+
 # 1.1.6
 
 -   Dependencies: typescript 4.9

--- a/packages/transport/package.json
+++ b/packages/transport/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@trezor/transport",
-    "version": "1.1.6",
+    "version": "1.1.7",
     "description": "Low level library facilitating protocol buffers based communication with Trezor devices",
     "npmPublishAccess": "public",
     "license": "SEE LICENSE IN LICENSE.md",

--- a/packages/utxo-lib/CHANGELOG.md
+++ b/packages/utxo-lib/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 1.0.3
+
+-   chore: remove unused skipUtxoSelection
+
 # 1.0.2
 
 -   fix output sorting with amount above MAX_SAFE_INTEGER

--- a/packages/utxo-lib/package.json
+++ b/packages/utxo-lib/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@trezor/utxo-lib",
-    "version": "1.0.2",
+    "version": "1.0.3",
     "author": "Trezor <info@trezor.io>",
     "homepage": "https://github.com/trezor/trezor-suite/tree/develop/packages/utxo-lib",
     "description": "Client-side Bitcoin-like JavaScript library",

--- a/yarn.lock
+++ b/yarn.lock
@@ -7159,6 +7159,7 @@ __metadata:
     randombytes: 2.1.0
     rimraf: ^3.0.2
     ts-node: ^10.9.1
+    tslib: 2.5.0
     tsx: ^3.8.2
     typescript: 4.9.3
   languageName: unknown
@@ -31072,10 +31073,17 @@ __metadata:
   languageName: node
   linkType: hard
 
-"tslib@npm:2.4.0, tslib@npm:^2.0.0, tslib@npm:^2.0.1, tslib@npm:^2.0.3, tslib@npm:^2.1.0, tslib@npm:^2.3.0, tslib@npm:^2.3.1, tslib@npm:^2.4.0":
+"tslib@npm:2.4.0":
   version: 2.4.0
   resolution: "tslib@npm:2.4.0"
   checksum: 8c4aa6a3c5a754bf76aefc38026134180c053b7bd2f81338cb5e5ebf96fefa0f417bff221592bf801077f5bf990562f6264fecbc42cd3309b33872cb6fc3b113
+  languageName: node
+  linkType: hard
+
+"tslib@npm:2.5.0, tslib@npm:^2.0.0, tslib@npm:^2.0.1, tslib@npm:^2.0.3, tslib@npm:^2.1.0, tslib@npm:^2.3.0, tslib@npm:^2.3.1, tslib@npm:^2.4.0":
+  version: 2.5.0
+  resolution: "tslib@npm:2.5.0"
+  checksum: ae3ed5f9ce29932d049908ebfdf21b3a003a85653a9a140d614da6b767a93ef94f460e52c3d787f0e4f383546981713f165037dc2274df212ea9f8a4541004e1
   languageName: node
   linkType: hard
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -6865,7 +6865,7 @@ __metadata:
   resolution: "@trezor/blockchain-link@workspace:packages/blockchain-link"
   dependencies:
     "@trezor/utils": "workspace:^9.0.4"
-    "@trezor/utxo-lib": "workspace:^1.0.2"
+    "@trezor/utxo-lib": "workspace:^1.0.3"
     "@types/web": ^0.0.80
     bignumber.js: ^9.1.0
     events: ^3.3.0
@@ -7138,7 +7138,7 @@ __metadata:
     "@trezor/transport": "workspace:^1.1.6"
     "@trezor/trezor-user-env-link": "workspace:*"
     "@trezor/utils": "workspace:^9.0.4"
-    "@trezor/utxo-lib": "workspace:^1.0.2"
+    "@trezor/utxo-lib": "workspace:^1.0.3"
     "@types/karma": ^6.3.3
     "@types/parse-uri": ^1.0.0
     "@types/randombytes": ^2.0.0
@@ -7802,7 +7802,7 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@trezor/utxo-lib@workspace:*, @trezor/utxo-lib@workspace:^1.0.2, @trezor/utxo-lib@workspace:packages/utxo-lib":
+"@trezor/utxo-lib@workspace:*, @trezor/utxo-lib@workspace:^1.0.3, @trezor/utxo-lib@workspace:packages/utxo-lib":
   version: 0.0.0-use.local
   resolution: "@trezor/utxo-lib@workspace:packages/utxo-lib"
   dependencies:

--- a/yarn.lock
+++ b/yarn.lock
@@ -7135,7 +7135,7 @@ __metadata:
     "@trezor/blockchain-link": "workspace:^2.1.6"
     "@trezor/connect-analytics": "workspace:*"
     "@trezor/connect-common": "workspace:0.0.11"
-    "@trezor/transport": "workspace:^1.1.6"
+    "@trezor/transport": "workspace:^1.1.7"
     "@trezor/trezor-user-env-link": "workspace:*"
     "@trezor/utils": "workspace:^9.0.4"
     "@trezor/utxo-lib": "workspace:^1.0.3"
@@ -7741,7 +7741,7 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@trezor/transport@workspace:^1.1.6, @trezor/transport@workspace:packages/transport":
+"@trezor/transport@workspace:^1.1.7, @trezor/transport@workspace:packages/transport":
   version: 0.0.0-use.local
   resolution: "@trezor/transport@workspace:packages/transport"
   dependencies:


### PR DESCRIPTION
- when importHelpers is set to true, tslib needs to be installed. due to this missing connect at the moment works only for projects that already have tslib in their dependencies
- errors screen in popup appears after 30 seconds if handshake does not happen. This could be troublesome for people using slow interent connections. 