### PR TITLE
fix(request-manager): Tor bootstrap starts with fist event received

### DIFF
--- a/packages/request-manager/src/controller.ts
+++ b/packages/request-manager/src/controller.ts
@@ -134,9 +134,10 @@ export class TorController extends EventEmitter {
         const bootstrap: BootstrapEvent[] = bootstrapParser(message);
         bootstrap.forEach(event => {
             if (event.type !== 'progress') return;
-            if (event.progress === BOOTSTRAP_EVENT_PROGRESS.ConnectingToRelay) {
-                // We consider that bootstrap has started when first event come from ControlPort.
-                // If we do not receive this first event, we can consider there is something going wrong and
+            if (event.progress && !this.getIsBootstrapping()) {
+                // We consider that bootstrap has started when we receive any bootstrap event and
+                // Tor is not bootstrapping yet.
+                // If we do not receive any bootstrapping event, we can consider there is something going wrong and
                 // an error will be thrown when `maxTriesWaiting` is reached in `waitUntilAlive`.
                 this.startBootstrap();
             }

--- a/packages/request-manager/src/events/bootstrap.ts
+++ b/packages/request-manager/src/events/bootstrap.ts
@@ -29,7 +29,6 @@ export const bootstrapParser = (message: string): BootstrapEvent[] => {
 };
 
 export const BOOTSTRAP_EVENT_PROGRESS = {
-    ConnectingToRelay: '5',
     Done: '100',
 } as const;
 export type BootstrapEventProgress = keyof typeof BOOTSTRAP_EVENT_PROGRESS;


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Tor in practice is not always sending the first phase event. Or it starts too fast that we are not getting it when subscribing to the event. So we now will be setting bootstrap status when we receive any bootstrap event, not only the expected first one.
