### PR TITLE
fix(suite-tor): synchronize Tor status when reloading

### DIFF
--- a/packages/suite/src/support/suite/useTor.tsx
+++ b/packages/suite/src/support/suite/useTor.tsx
@@ -39,9 +39,12 @@ export const useTor = () => {
                     });
                 }
             });
+            if (!isTorEnabling) {
+                desktopApi.getTorStatus();
+            }
             return () => desktopApi.removeAllListeners('tor/status');
         }
-    }, [updateTorStatus, torBootstrap, addToastOnce]);
+    }, [updateTorStatus, torBootstrap, addToastOnce, isTorEnabling]);
 
     useEffect(() => {
         if (isDesktop()) {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Make Tor status synchronize when it is not bootstrapping and reloads for example.