### PR TITLE
CJ: do not register to round if affiliate server is not running 

### DIFF
--- a/packages/coinjoin/src/client/CoinjoinClient.ts
+++ b/packages/coinjoin/src/client/CoinjoinClient.ts
@@ -53,6 +53,7 @@ export class CoinjoinClient extends EventEmitter {
             }
         });
         this.status.on('exception', event => this.emit('exception', event));
+        this.status.on('affiliate-server', event => this.onAffiliateServerStatus(event));
 
         this.prison = new CoinjoinPrison();
     }
@@ -185,6 +186,10 @@ export class CoinjoinClient extends EventEmitter {
         this.emit('session-phase', event);
     }
 
+    private onAffiliateServerStatus(status: boolean) {
+        this.rounds.map(r => r.onAffiliateServerStatus(status));
+    }
+
     private async onStatusUpdate({
         changed,
         rounds,
@@ -212,6 +217,7 @@ export class CoinjoinClient extends EventEmitter {
                 statusRounds: rounds,
                 coinjoinRounds: this.rounds,
                 prison: this.prison,
+                runningAffiliateServer: this.status.isAffiliateServerRunning(),
                 options: {
                     network: this.network,
                     signal: this.abortController.signal,

--- a/packages/coinjoin/src/client/CoinjoinClient.ts
+++ b/packages/coinjoin/src/client/CoinjoinClient.ts
@@ -207,12 +207,12 @@ export class CoinjoinClient extends EventEmitter {
 
         // there are no CoinjoinRounds to process? try to create new one
         if (roundsToProcess.length === 0) {
-            const newRound = await CoinjoinRound.create(
-                this.accounts,
-                rounds,
-                this.rounds,
-                this.prison,
-                {
+            const newRound = await CoinjoinRound.create({
+                accounts: this.accounts,
+                statusRounds: rounds,
+                coinjoinRounds: this.rounds,
+                prison: this.prison,
+                options: {
                     network: this.network,
                     signal: this.abortController.signal,
                     coordinatorName: this.settings.coordinatorName,
@@ -222,7 +222,7 @@ export class CoinjoinClient extends EventEmitter {
                     setSessionPhase: (sessionPhase: CoinjoinClientEvents['session-phase']) =>
                         this.setSessionPhase(sessionPhase),
                 },
-            );
+            });
 
             if (newRound) {
                 // try to release all inmates detained due to blame round

--- a/packages/coinjoin/src/client/CoinjoinRound.ts
+++ b/packages/coinjoin/src/client/CoinjoinRound.ts
@@ -82,6 +82,14 @@ const createRoundLock = (mainSignal: AbortSignal) => {
     };
 };
 
+interface CreateRoundProps {
+    accounts: Account[];
+    statusRounds: Round[];
+    coinjoinRounds: CoinjoinRound[];
+    prison: CoinjoinPrison;
+    options: CoinjoinRoundOptions;
+}
+
 export class CoinjoinRound extends EventEmitter {
     private lock?: ReturnType<typeof createRoundLock>;
     private options: CoinjoinRoundOptions;
@@ -141,22 +149,16 @@ export class CoinjoinRound extends EventEmitter {
         });
     }
 
-    static create(
-        accounts: Account[],
-        statusRounds: Round[],
-        coinjoinRounds: CoinjoinRound[],
-        prison: CoinjoinPrison,
-        options: CoinjoinRoundOptions,
-    ) {
-        return selectRound(
-            (...args: ConstructorParameters<typeof CoinjoinRound>) => new CoinjoinRound(...args),
-            (...args: ConstructorParameters<typeof Alice>) => new Alice(...args),
+    static create({ accounts, statusRounds, coinjoinRounds, prison, options }: CreateRoundProps) {
+        return selectRound({
+            roundGenerator: (...args) => new CoinjoinRound(...args),
+            aliceGenerator: (...args) => new Alice(...args),
             accounts,
             statusRounds,
             coinjoinRounds,
             prison,
             options,
-        );
+        });
     }
 
     async onPhaseChange(changed: Round) {

--- a/packages/coinjoin/src/client/round/selectRound.ts
+++ b/packages/coinjoin/src/client/round/selectRound.ts
@@ -23,6 +23,7 @@ export interface SelectRoundProps {
     coinjoinRounds: CoinjoinRound[];
     prison: CoinjoinPrison;
     options: CoinjoinRoundOptions;
+    runningAffiliateServer: boolean;
 }
 
 // Basic preselect CoinjoinRound candidates
@@ -346,6 +347,7 @@ export const selectRound = async ({
     coinjoinRounds,
     prison,
     options,
+    runningAffiliateServer,
 }: SelectRoundProps) => {
     const { log, setSessionPhase } = options;
 
@@ -353,6 +355,15 @@ export const selectRound = async ({
     const unregisteredAccountKeys = unregisteredAccounts.map(({ accountKey }) => accountKey);
 
     log('Looking for rounds');
+    if (!runningAffiliateServer) {
+        log('Affiliate server is not running. Round selection ignored');
+        setSessionPhase({
+            phase: SessionPhase.AffiliateServerOffline,
+            accountKeys: unregisteredAccountKeys,
+        });
+        return;
+    }
+
     setSessionPhase({ phase: SessionPhase.RoundSearch, accountKeys: unregisteredAccountKeys });
     const roundCandidates = getRoundCandidates({
         roundGenerator,

--- a/packages/coinjoin/src/enums.ts
+++ b/packages/coinjoin/src/enums.ts
@@ -8,6 +8,7 @@ export enum SessionPhase {
     AccountMissingUtxos = 15,
     SkippingRound = 16,
     RetryingRoundPairing = 17,
+    AffiliateServerOffline = 18,
 
     // RoundPhase.ConnectionConfirmation
     AwaitingConfirmation = 21,

--- a/packages/coinjoin/tests/client/selectRound.test.ts
+++ b/packages/coinjoin/tests/client/selectRound.test.ts
@@ -338,6 +338,7 @@ describe('selectRound', () => {
             coinjoinRounds: [],
             prison,
             options: server?.requestOptions,
+            runningAffiliateServer: true,
         });
 
         expect(spy).toBeCalledTimes(9);
@@ -385,6 +386,7 @@ describe('selectRound', () => {
             coinjoinRounds: [],
             prison,
             options: server?.requestOptions,
+            runningAffiliateServer: true,
         });
 
         expect(spy).toBeCalledTimes(0); // middleware was not called, detained inputs were used
@@ -407,6 +409,7 @@ describe('selectRound', () => {
             coinjoinRounds: [],
             prison,
             options: server?.requestOptions,
+            runningAffiliateServer: true,
         });
         expect(result).toBeUndefined();
 
@@ -419,6 +422,7 @@ describe('selectRound', () => {
             coinjoinRounds: [],
             prison,
             options: server?.requestOptions,
+            runningAffiliateServer: true,
         });
         expect(result2).toBeUndefined();
 
@@ -431,6 +435,7 @@ describe('selectRound', () => {
             coinjoinRounds: [],
             prison,
             options: server?.requestOptions,
+            runningAffiliateServer: true,
         });
         expect(result3).toBeUndefined();
     });

--- a/packages/suite/src/constants/suite/coinjoin.ts
+++ b/packages/suite/src/constants/suite/coinjoin.ts
@@ -17,6 +17,7 @@ export const SESSION_PHASE_MESSAGES: Record<SessionPhase, TranslationKey> = {
     [SessionPhase.AccountMissingUtxos]: 'TR_SESSION_PHASE_15_MESSAGE',
     [SessionPhase.SkippingRound]: 'TR_SESSION_PHASE_16_MESSAGE',
     [SessionPhase.RetryingRoundPairing]: 'TR_SESSION_PHASE_17_MESSAGE',
+    [SessionPhase.AffiliateServerOffline]: 'TR_SESSION_PHASE_18_MESSAGE',
     [SessionPhase.AwaitingConfirmation]: 'TR_SESSION_PHASE_21_MESSAGE',
     [SessionPhase.AwaitingOthersConfirmation]: 'TR_SESSION_PHASE_22_MESSAGE',
     [SessionPhase.RegisteringOutputs]: 'TR_SESSION_PHASE_31_MESSAGE',

--- a/packages/suite/src/support/messages.ts
+++ b/packages/suite/src/support/messages.ts
@@ -7745,6 +7745,10 @@ export default defineMessages({
         id: 'TR_SESSION_PHASE_17_MESSAGE',
         defaultMessage: 'Pairing failed, retrying',
     },
+    TR_SESSION_PHASE_18_MESSAGE: {
+        id: 'TR_SESSION_PHASE_18_MESSAGE',
+        defaultMessage: 'The coinjoin service is temporarily unavailable',
+    },
     TR_SESSION_PHASE_21_MESSAGE: {
         id: 'TR_SESSION_PHASE_21_MESSAGE',
         defaultMessage: 'Confirming availability',


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Follow up for affiliate server integration. 
Check if `status.affiliateInformation.runningAffiliateServers` contains `trezor` key and do not create new round if it's not.
Round without affiliateRequest is designed to fail, so do not even bother. But since this state is not persistent it doesn't mean that current coinjoin session should be ended/errored, suite should just wait for the status update and try again, it should be there eventually (or not if we decide to shut down it purposely)

Displays new message in suite coinjoin status


First commit is partial followup of https://github.com/trezor/trezor-suite/issues/6698 (Review followups)

## How to test it
It requires local build of [coinjoin-backend](https://github.com/trezor/coinjoin-backend) and [coinjoin-affiliate-server](https://github.com/trezor/coinjoin-affiliate-server)

Suite debug setting Coinjoin regtest server should be set to `localhost`

`coinjoin-backend/configuration/wallet-wasabi/backend/WabiSabiConfig.json` file needs to be edited to:
```
"AffiliateServers": {
    "trezor": "http://127.0.0.1:1080"
}
```
then `make build` and `make start` should crate and run coinjoin-backend docker image

at this point affiliate server is not running and it's not visible in status

send yourself some coins using facet http://localhost:8080/ and start coinjoin, you should see message from screenshot below.

run affiliate server and wait, after some time coinjoin process should start
```
KEY_FILE=./examples/key python3 ./coinjoin-affiliate-server --bind-address 127.0.0.1 --bind-port 1080 --allow-testnet --debug
```

## Related Issue

Resolve https://github.com/trezor/trezor-suite/issues/7478

## Screenshots:


![Screenshot from 2023-01-27 17-15-30](https://user-images.githubusercontent.com/3435913/215140577-43f34d02-3e46-4d12-a24b-08aa801698fb.png)
