### PR TITLE
fix(suite-native): clipboard toast message shown only on ios

### DIFF
--- a/suite-native/helpers/package.json
+++ b/suite-native/helpers/package.json
@@ -13,6 +13,7 @@
     "dependencies": {
         "expo-clipboard": "^4.0.1",
         "react": "18.2.0",
+        "react-native": "0.70.5",
         "react-native-root-toast": "^3.3.1"
     }
 }

--- a/suite-native/helpers/src/hooks/useCopyToClipboard.tsx
+++ b/suite-native/helpers/src/hooks/useCopyToClipboard.tsx
@@ -1,4 +1,5 @@
 import { useCallback } from 'react';
+import { Platform } from 'react-native';
 import Toast from 'react-native-root-toast'; // TODO: Remove when is our own notification UI ready.
 
 import * as Clipboard from 'expo-clipboard';
@@ -7,8 +8,11 @@ export function useCopyToClipboard() {
     const copyToClipboard = useCallback(async (value: string, toastMessage?: string) => {
         await Clipboard.setStringAsync(value);
 
-        // TODO: Replace with our own notification UI when ready.
-        Toast.show(toastMessage ?? 'Copied to clipboard.');
+        if (Platform.OS === 'ios') {
+            // Android is showing it's own copy-to-clipboard toast message
+            // TODO: Replace with our own notification UI when ready.
+            Toast.show(toastMessage ?? 'Copied to clipboard.');
+        }
     }, []);
     return copyToClipboard;
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -6428,6 +6428,7 @@ __metadata:
   dependencies:
     expo-clipboard: ^4.0.1
     react: 18.2.0
+    react-native: 0.70.5
     react-native-root-toast: ^3.3.1
   languageName: unknown
   linkType: soft


### PR DESCRIPTION
Clipboard toast message displayed only on iOS.
Since Android shows toast message on copy-to-clipobord by default, our custom message will be hidden.

fixes #7331