### PR TITLE
feat(connect): phishing detect

### DIFF
--- a/packages/connect-popup/jest.config.js
+++ b/packages/connect-popup/jest.config.js
@@ -1,0 +1,7 @@
+const { testPathIgnorePatterns } = require('../../jest.config.base');
+
+module.exports = {
+    preset: '../../jest.config.base.js',
+    collectCoverage: true,
+    testPathIgnorePatterns: [...testPathIgnorePatterns, 'e2e'],
+};

--- a/packages/connect-popup/package.json
+++ b/packages/connect-popup/package.json
@@ -11,7 +11,6 @@
         "test:e2e": "yarn xvfb-maybe -- playwright test --config=./e2e/playwright.config.ts"
     },
     "dependencies": {
-        "@trezor/components": "workspace:*",
         "@trezor/connect": "workspace:9.0.6",
         "@trezor/connect-analytics": "workspace:*",
         "@trezor/connect-ui": "workspace:*",
@@ -22,7 +21,6 @@
         "@playwright/test": "^1.30.0",
         "@trezor/trezor-user-env-link": "workspace:*",
         "@types/react": "18.0.27",
-        "@types/styled-components": "^5.1.25",
         "jest": "^26.6.3",
         "playwright": "^1.30.0",
         "rimraf": "^4.1.2",

--- a/packages/connect-popup/package.json
+++ b/packages/connect-popup/package.json
@@ -8,14 +8,16 @@
         "type-check": "tsc --build",
         "dev": "rimraf build && TS_NODE_PROJECT=\"tsconfig.json\" yarn webpack --config ./webpack/dev.webpack.config.ts",
         "build": "rimraf build && TS_NODE_PROJECT=\"tsconfig.json\" yarn webpack --config ./webpack/prod.webpack.config.ts",
-        "test:e2e": "yarn xvfb-maybe -- playwright test --config=./e2e/playwright.config.ts"
+        "test:e2e": "yarn xvfb-maybe -- playwright test --config=./e2e/playwright.config.ts",
+        "test:unit": "jest"
     },
     "dependencies": {
         "@trezor/connect": "workspace:9.0.6",
         "@trezor/connect-analytics": "workspace:*",
         "@trezor/connect-ui": "workspace:*",
         "@trezor/crypto-utils": "workspace:*",
-        "@trezor/urls": "workspace:*"
+        "@trezor/urls": "workspace:*",
+        "eth-phishing-detect": "^1.2.0"
     },
     "devDependencies": {
         "@playwright/test": "^1.30.0",

--- a/packages/connect-popup/src/index.tsx
+++ b/packages/connect-popup/src/index.tsx
@@ -20,6 +20,7 @@ import {
     postMessageToParent,
     renderConnectUI,
 } from './view/common';
+import { isPhishingDomain } from './utils/isPhishingDomain';
 
 let handshakeTimeout: ReturnType<typeof setTimeout>;
 
@@ -211,6 +212,10 @@ const handshake = (handshake: PopupHandshake) => {
             transportVersion: payload.transport?.version,
         },
     });
+
+    if (isPhishingDomain(payload.settings.origin || '')) {
+        reactEventBus.dispatch({ type: 'phishing-domain' });
+    }
 };
 
 const onLoad = () => {

--- a/packages/connect-popup/src/types/eth-phishing-detect.d.ts
+++ b/packages/connect-popup/src/types/eth-phishing-detect.d.ts
@@ -1,0 +1,3 @@
+declare module 'eth-phishing-detect' {
+    export default function (domain: string): boolean;
+}

--- a/packages/connect-popup/src/utils/isPhishingDomain.test.ts
+++ b/packages/connect-popup/src/utils/isPhishingDomain.test.ts
@@ -1,0 +1,11 @@
+import { isPhishingDomain } from './isPhishingDomain';
+
+describe('isPhishingDomain', () => {
+    const good = ['trezor.io', 'connect.trezor.io'];
+
+    good.forEach(domain => {
+        it(`ok: ${domain}`, () => {
+            expect(isPhishingDomain(domain)).toEqual(false);
+        });
+    });
+});

--- a/packages/connect-popup/src/utils/isPhishingDomain.ts
+++ b/packages/connect-popup/src/utils/isPhishingDomain.ts
@@ -1,0 +1,3 @@
+import checkForPhishing from 'eth-phishing-detect';
+
+export const isPhishingDomain = (domain: string): boolean => checkForPhishing(domain);

--- a/packages/connect-popup/tsconfig.json
+++ b/packages/connect-popup/tsconfig.json
@@ -2,7 +2,7 @@
     "extends": "../../tsconfig.json",
     "compilerOptions": {
         "outDir": "./libDev",
-        "types": ["web"]
+        "types": ["web", "jest"]
     },
     "include": [".", "**/*.json"],
     "references": [

--- a/packages/connect-popup/tsconfig.json
+++ b/packages/connect-popup/tsconfig.json
@@ -6,7 +6,6 @@
     },
     "include": [".", "**/*.json"],
     "references": [
-        { "path": "../components" },
         { "path": "../connect" },
         { "path": "../connect-analytics" },
         { "path": "../connect-ui" },

--- a/packages/connect-popup/webpack/prod.webpack.config.ts
+++ b/packages/connect-popup/webpack/prod.webpack.config.ts
@@ -53,15 +53,6 @@ export default {
                 test: /\.(gif|jpe?g|png|svg)$/,
                 type: 'asset/resource',
             },
-            // resolving framer-motion in @trezor/components
-            // https://github.com/react-dnd/react-dnd/issues/3425
-            // todo: not sure, if it should be done like this and if yes, maybe I should add this to the previous rule?
-            {
-                test: /\.m?js$/,
-                resolve: {
-                    fullySpecified: false,
-                },
-            },
         ],
     },
     resolve: {

--- a/packages/connect-ui/src/components/Notification.tsx
+++ b/packages/connect-ui/src/components/Notification.tsx
@@ -71,7 +71,7 @@ interface NotificationProps {
     header: string;
     body: string;
     variant: 'warning' | 'danger';
-    cta: {
+    cta?: {
         desc: string;
         url: string;
     };
@@ -100,16 +100,18 @@ const Notification = ({ header, body, cta, variant }: NotificationProps) => {
                 <NotificationBody>
                     <div>{body}</div>
                 </NotificationBody>
-                <NotificationCta>
-                    <StyledButton
-                        onClick={() => {
-                            window.open(cta.url);
-                            window.close();
-                        }}
-                    >
-                        {cta.desc}
-                    </StyledButton>
-                </NotificationCta>
+                {cta && (
+                    <NotificationCta>
+                        <StyledButton
+                            onClick={() => {
+                                window.open(cta.url);
+                                window.close();
+                            }}
+                        >
+                            {cta.desc}
+                        </StyledButton>
+                    </NotificationCta>
+                )}
             </NotificationRightCol>
         </NotificationBox>
     );
@@ -146,15 +148,14 @@ export const BridgeUpdateNotification = () => (
     />
 );
 
-// todo: not used yet, need to sync with product
 export const SuspiciousOriginNotification = () => (
     <Notification
         variant="danger"
         header="Danger"
-        body="Suspicious 3rd party application. Proceed on your own risk"
-        cta={{
-            desc: 'Learn more',
-            url: 'todo:',
-        }}
+        body="You are interacting with a suspicious 3rd party application. If you continue your coins might be in danger. Proceed at your own risk"
+        // cta={{
+        //     desc: 'Learn more',
+        //     url: 'todo: some explanation to trezor-wiki about phishing would be useful',
+        // }}
     />
 );

--- a/packages/connect-ui/src/index.tsx
+++ b/packages/connect-ui/src/index.tsx
@@ -20,6 +20,7 @@ import {
     FirmwareUpdateNotification,
     BackupNotification,
     BridgeUpdateNotification,
+    SuspiciousOriginNotification,
 } from './components/Notification';
 
 const Layout = styled.div`
@@ -86,12 +87,16 @@ export const ConnectUI = ({ postMessage, clearLegacyView }: ConnectUIProps) => {
         // notifications
         const notifications: React.ReactNode[] = [];
         messages.forEach(message => {
-            if (message?.type === 'popup-handshake' && message?.payload?.transport?.outdated) {
-                notifications.push(<BridgeUpdateNotification key="bridge-outdated" />);
+            if (message?.type === 'popup-handshake') {
+                if (message.payload?.transport?.outdated) {
+                    notifications.push(<BridgeUpdateNotification key="bridge-outdated" />);
+                }
             } else if (message?.type === UI_REQUEST.FIRMWARE_OUTDATED) {
                 notifications.push(<FirmwareUpdateNotification key={message.type} />);
             } else if (message?.type === UI_REQUEST.DEVICE_NEEDS_BACKUP) {
                 notifications.push(<BackupNotification key={message.type} />);
+            } else if (message?.type === 'phishing-domain') {
+                notifications.push(<SuspiciousOriginNotification key={message.type} />);
             }
             return notifications;
         });

--- a/packages/connect-ui/src/utils/eventBus.ts
+++ b/packages/connect-ui/src/utils/eventBus.ts
@@ -5,12 +5,15 @@ import { PassphraseEventProps } from '../views/Passphrase';
 import { ErrorViewProps } from '../views/Error';
 
 export type ConnectUIEventProps =
+    // connect-core events
     | TransportEventProps
     | PassphraseEventProps
     | ErrorViewProps
     | PopupHandshake
     | { type: typeof UI_REQUEST.DEVICE_NEEDS_BACKUP; device: Device }
-    | { type: typeof UI_REQUEST.FIRMWARE_OUTDATED; device: Device };
+    | { type: typeof UI_REQUEST.FIRMWARE_OUTDATED; device: Device }
+    // connect-popup events
+    | { type: 'phishing-domain' };
 
 const reactChannel = 'react';
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -7358,6 +7358,7 @@ __metadata:
     "@trezor/trezor-user-env-link": "workspace:*"
     "@trezor/urls": "workspace:*"
     "@types/react": 18.0.27
+    eth-phishing-detect: ^1.2.0
     jest: ^26.6.3
     playwright: ^1.30.0
     rimraf: ^4.1.2
@@ -16476,6 +16477,15 @@ __metadata:
   version: 1.8.1
   resolution: "etag@npm:1.8.1"
   checksum: 571aeb3dbe0f2bbd4e4fadbdb44f325fc75335cd5f6f6b6a091e6a06a9f25ed5392f0863c5442acb0646787446e816f13cbfc6edce5b07658541dff573cab1ff
+  languageName: node
+  linkType: hard
+
+"eth-phishing-detect@npm:^1.2.0":
+  version: 1.2.0
+  resolution: "eth-phishing-detect@npm:1.2.0"
+  dependencies:
+    fast-levenshtein: ^2.0.6
+  checksum: 66a6a7c249ec8494e0360663596ce980ca75747cd202c47732eca0bfc7a97c6debbae359842e4f3e4ac7e6c44ab1f7f091c3aa7baa330449d3c1b7cc58608b71
   languageName: node
   linkType: hard
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -7351,7 +7351,6 @@ __metadata:
   resolution: "@trezor/connect-popup@workspace:packages/connect-popup"
   dependencies:
     "@playwright/test": ^1.30.0
-    "@trezor/components": "workspace:*"
     "@trezor/connect": "workspace:9.0.6"
     "@trezor/connect-analytics": "workspace:*"
     "@trezor/connect-ui": "workspace:*"
@@ -7359,7 +7358,6 @@ __metadata:
     "@trezor/trezor-user-env-link": "workspace:*"
     "@trezor/urls": "workspace:*"
     "@types/react": 18.0.27
-    "@types/styled-components": ^5.1.25
     jest: ^26.6.3
     playwright: ^1.30.0
     rimraf: ^4.1.2


### PR DESCRIPTION
## Description

This PR is one step in building protective measures against phishing for 3rd party trezor users. It checks origin against the blacklist provided by https://github.com/MetaMask/eth-phishing-detect and in case of positive result displays notification. Please consider this as the first step, I expect further iteration on this, but I would like to deliver at least some degree of protection rather fast.

Followups: 
- design @Hannsek maybe red? 
- maybe it should not be notification but it should block entire flow? 
- blacklist is now baked into connect. This means connect lags behind updates to this list. Maybe we could mirror it somewhere on trezor.io nightly and connect could featch updated blacklist.  

Discussion: 
- ~~should phishing domain detection logic be part of core? In fact, it is relevant only for web and maybe webextension based environments. With this in  mind one might suggest implementing it into @trezor/connect-popup or maybe @trezor/connect-ui package directly. But I'd say that @trezor/connect-popup should be responsible only for opening/communicating with popup. And @trezor/connect-ui should also be dumb without much logic.~~ no, should not. moved to @trezor/connect-popup package


## QA
- not much to test, normally, you absolutely should not see this new notification
- there is a build that shows this notification always https://suite.corp.sldev.cz/connect/connect-phishing-detect-true/ for reference

## Related Issue
based on #7399
resolve #7372 

## Screenshots:

![image](https://user-images.githubusercontent.com/30367552/215469520-7173c814-42f0-4ec4-a19a-bc31b661bb22.png)
