### PR TITLE
chore(suite-native): Add support for all tx type

### DIFF
--- a/suite-native/transactions/src/components/TransactionDetail/TransactionDetailHeader.tsx
+++ b/suite-native/transactions/src/components/TransactionDetail/TransactionDetailHeader.tsx
@@ -36,23 +36,19 @@ const transactionTypeInfo = {
     },
     self: {
         text: 'Self',
-        iconName: 'send',
     },
     joint: {
         text: 'Joint',
-        iconName: 'send',
     },
     failed: {
         text: 'Failed',
-        iconName: 'send',
     },
     unknown: {
         text: 'Unknown',
-        iconName: 'send',
     },
 } as const satisfies Record<
     TransactionType,
-    RequireAllOrNone<TransactionTypeInfo, 'sign' | 'signColor'>
+    RequireAllOrNone<TransactionTypeInfo, 'sign' | 'signColor' | 'iconName'>
 >;
 
 export const TransactionDetailHeader = ({
@@ -62,7 +58,7 @@ export const TransactionDetailHeader = ({
 }: TransactionDetailHeaderProps) => {
     const { FiatAmountFormatter } = useFormatters();
 
-    const { text, iconName } = transactionTypeInfo[type];
+    const { text } = transactionTypeInfo[type];
 
     const hasTransactionSign = type === 'sent' || type === 'recv';
 
@@ -72,7 +68,9 @@ export const TransactionDetailHeader = ({
                 <Text variant="hint" color="gray600">
                     {text}
                 </Text>
-                <Icon name={iconName} color="gray600" size="medium" />
+                {hasTransactionSign && (
+                    <Icon name={transactionTypeInfo[type].iconName} color="gray600" size="medium" />
+                )}
             </Box>
             <Box flexDirection="row">
                 {hasTransactionSign && (

--- a/suite-native/transactions/src/components/TransactionDetail/TransactionDetailHeader.tsx
+++ b/suite-native/transactions/src/components/TransactionDetail/TransactionDetailHeader.tsx
@@ -15,8 +15,8 @@ type TransactionDetailHeaderProps = {
 type TransactionTypeInfo = {
     text: string;
     iconName: IconName;
-    sign: string;
-    signColor: Color;
+    sign?: string;
+    signColor?: Color;
 };
 
 const transactionTypeInfo = {
@@ -32,7 +32,31 @@ const transactionTypeInfo = {
         sign: '-',
         signColor: 'red',
     },
-} as const satisfies Partial<Record<TransactionType, TransactionTypeInfo>>;
+    self: {
+        text: 'Self',
+        iconName: 'send',
+        sign: '',
+        signColor: '',
+    },
+    joint: {
+        text: 'Joint',
+        iconName: 'send',
+        sign: '',
+        signColor: '',
+    },
+    failed: {
+        text: 'Failed',
+        iconName: 'send',
+        sign: '',
+        signColor: '',
+    },
+    unknown: {
+        text: 'Unknown',
+        iconName: 'send',
+        sign: '',
+        signColor: '',
+    },
+} as const satisfies Record<TransactionType, TransactionTypeInfo>;
 
 export const TransactionDetailHeader = ({
     type,
@@ -41,6 +65,8 @@ export const TransactionDetailHeader = ({
 }: TransactionDetailHeaderProps) => {
     const { FiatAmountFormatter } = useFormatters();
 
+    const { signColor, sign, text, iconName } = transactionTypeInfo[type];
+
     if (type !== 'recv' && type !== 'sent')
         return <ErrorMessage errorMessage={`Unknown transaction type ${type}.`} />;
 
@@ -48,14 +74,16 @@ export const TransactionDetailHeader = ({
         <Box alignItems="center">
             <Box flexDirection="row" alignItems="center" marginBottom="small">
                 <Text variant="hint" color="gray600">
-                    {transactionTypeInfo[type].text}
+                    {text}
                 </Text>
-                <Icon name={transactionTypeInfo[type].iconName} color="gray600" size="medium" />
+                <Icon name={iconName} color="gray600" size="medium" />
             </Box>
             <Box flexDirection="row">
-                <Text variant="titleMedium" color={transactionTypeInfo[type].signColor}>
-                    {transactionTypeInfo[type].sign}
-                </Text>
+                {sign && signColor && (
+                    <Text variant="titleMedium" color={signColor}>
+                        {sign}
+                    </Text>
+                )}
                 <DiscreetText typography="titleMedium">{amount}</DiscreetText>
             </Box>
             <DiscreetText typography="label" color="gray700">

--- a/suite-native/transactions/src/components/TransactionDetail/TransactionDetailHeader.tsx
+++ b/suite-native/transactions/src/components/TransactionDetail/TransactionDetailHeader.tsx
@@ -35,26 +35,26 @@ const transactionTypeInfo = {
     self: {
         text: 'Self',
         iconName: 'send',
-        sign: '',
-        signColor: '',
+        sign: ' ',
+        signColor: 'gray200',
     },
     joint: {
         text: 'Joint',
         iconName: 'send',
-        sign: '',
-        signColor: '',
+        sign: ' ',
+        signColor: 'gray200',
     },
     failed: {
         text: 'Failed',
         iconName: 'send',
-        sign: '',
-        signColor: '',
+        sign: ' ',
+        signColor: 'gray200',
     },
     unknown: {
         text: 'Unknown',
         iconName: 'send',
-        sign: '',
-        signColor: '',
+        sign: ' ',
+        signColor: 'gray200',
     },
 } as const satisfies Record<TransactionType, TransactionTypeInfo>;
 

--- a/suite-native/transactions/src/components/TransactionDetail/TransactionDetailHeader.tsx
+++ b/suite-native/transactions/src/components/TransactionDetail/TransactionDetailHeader.tsx
@@ -1,6 +1,8 @@
 import React from 'react';
 
-import { Box, DiscreetText, ErrorMessage, Text } from '@suite-native/atoms';
+import { RequireAllOrNone } from 'type-fest';
+
+import { Box, DiscreetText, Text } from '@suite-native/atoms';
 import { Icon, IconName } from '@trezor/icons';
 import { TransactionType } from '@suite-common/wallet-types';
 import { useFormatters } from '@suite-common/formatters';
@@ -35,28 +37,23 @@ const transactionTypeInfo = {
     self: {
         text: 'Self',
         iconName: 'send',
-        sign: ' ',
-        signColor: 'gray200',
     },
     joint: {
         text: 'Joint',
         iconName: 'send',
-        sign: ' ',
-        signColor: 'gray200',
     },
     failed: {
         text: 'Failed',
         iconName: 'send',
-        sign: ' ',
-        signColor: 'gray200',
     },
     unknown: {
         text: 'Unknown',
         iconName: 'send',
-        sign: ' ',
-        signColor: 'gray200',
     },
-} as const satisfies Record<TransactionType, TransactionTypeInfo>;
+} as const satisfies Record<
+    TransactionType,
+    RequireAllOrNone<TransactionTypeInfo, 'sign' | 'signColor'>
+>;
 
 export const TransactionDetailHeader = ({
     type,
@@ -65,10 +62,9 @@ export const TransactionDetailHeader = ({
 }: TransactionDetailHeaderProps) => {
     const { FiatAmountFormatter } = useFormatters();
 
-    const { signColor, sign, text, iconName } = transactionTypeInfo[type];
+    const { text, iconName } = transactionTypeInfo[type];
 
-    if (type !== 'recv' && type !== 'sent')
-        return <ErrorMessage errorMessage={`Unknown transaction type ${type}.`} />;
+    const hasTransactionSign = type === 'sent' || type === 'recv';
 
     return (
         <Box alignItems="center">
@@ -79,9 +75,9 @@ export const TransactionDetailHeader = ({
                 <Icon name={iconName} color="gray600" size="medium" />
             </Box>
             <Box flexDirection="row">
-                {sign && signColor && (
-                    <Text variant="titleMedium" color={signColor}>
-                        {sign}
+                {hasTransactionSign && (
+                    <Text variant="titleMedium" color={transactionTypeInfo[type].signColor}>
+                        {transactionTypeInfo[type].sign}
                     </Text>
                 )}
                 <DiscreetText typography="titleMedium">{amount}</DiscreetText>

--- a/suite-native/transactions/src/components/TransactionsList/TransactionListItemIcon.tsx
+++ b/suite-native/transactions/src/components/TransactionsList/TransactionListItemIcon.tsx
@@ -10,9 +10,13 @@ type TransactionListItemIconProps = {
     transactionType: TransactionType;
 };
 
-const transactionIconMap: Partial<Record<TransactionType, IconName>> = {
+const transactionIconMap: Record<TransactionType, IconName> = {
     recv: 'receive',
     sent: 'send',
+    joint: 'placeholder',
+    self: 'placeholder',
+    failed: 'placeholder',
+    unknown: 'placeholder',
 };
 
 const transactionIconStyle = prepareNativeStyle(utils => ({
@@ -38,7 +42,7 @@ export const TransactionListItemIcon = ({
         <Box>
             <Box style={applyStyle(transactionIconStyle)}>
                 <Icon
-                    name={transactionIconMap[transactionType] ?? 'placeholder'}
+                    name={transactionIconMap[transactionType]}
                     color="gray600"
                     size="mediumLarge"
                 />


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Added missing transaction types for detail header. Missing types were added just as text so there are no errors but icon name, sign and signColor were excluded from these transaction types as they are not currently needed / defined by UX.

## Related Issue

Resolve https://github.com/trezor/trezor-suite/issues/7481
