### PR TITLE
fix(coinjoin): do not assign errors on undefined inputs

### DIFF
--- a/packages/coinjoin/src/client/round/inputRegistration.ts
+++ b/packages/coinjoin/src/client/round/inputRegistration.ts
@@ -178,12 +178,13 @@ export const inputRegistration = async (
     options.log(`inputRegistration: ~~${round.id}~~`);
     round.setSessionPhase(SessionPhase.CoinRegistration);
 
+    const { inputs } = round;
     await Promise.allSettled(
-        round.inputs.map(input => registerInput(round, input, prison, options)),
+        inputs.map(input => registerInput(round, input, prison, options)),
     ).then(result =>
         result.forEach((r, i) => {
             if (r.status !== 'fulfilled') {
-                round.inputs[i].setError(r.reason);
+                inputs[i].setError(r.reason);
             }
         }),
     );

--- a/packages/coinjoin/src/client/round/transactionSigning.ts
+++ b/packages/coinjoin/src/client/round/transactionSigning.ts
@@ -172,14 +172,14 @@ export const transactionSigning = async (
         }
 
         round.setSessionPhase(SessionPhase.SendingSignature);
-        await Promise.allSettled(
-            round.inputs.map(input => sendTxSignature(round, input, options)),
-        ).then(result =>
-            result.forEach((r, i) => {
-                if (r.status !== 'fulfilled') {
-                    round.inputs[i].setError(r.reason);
-                }
-            }),
+        const { inputs } = round;
+        await Promise.allSettled(inputs.map(input => sendTxSignature(round, input, options))).then(
+            result =>
+                result.forEach((r, i) => {
+                    if (r.status !== 'fulfilled') {
+                        inputs[i].setError(r.reason);
+                    }
+                }),
         );
     } catch (error) {
         // NOTE: if anything goes wrong in this process this Round will be corrupted for all the users


### PR DESCRIPTION
Do not assign errors to inputs using array iterator, it might happen that `round.inputs` is empty, for example on account unregisration:

- account unregistration > remove all inputs from round > round processing throw error > error cannot be assigned on input[index] because it's gone

## Related Issue

Resolve https://github.com/trezor/trezor-suite/issues/7382

