### PR TITLE
Fix user dir path usage for windows

### DIFF
--- a/packages/suite-desktop/src/app.ts
+++ b/packages/suite-desktop/src/app.ts
@@ -1,5 +1,4 @@
 import path from 'path';
-import fs from 'fs';
 import { app, BrowserWindow, session } from 'electron';
 import { init as initSentry, ElectronOptions, IPCMode } from '@sentry/electron';
 
@@ -13,6 +12,7 @@ import * as store from './libs/store';
 import { MIN_HEIGHT, MIN_WIDTH } from './libs/screen';
 import { getBuildInfo, getComputerInfo } from './libs/info';
 import { restartApp } from './libs/app-utils';
+import { clearAppCache } from './libs/user-data';
 import { initModules } from './modules';
 import { init as initTorModule } from './modules/tor';
 import { createInterceptor } from './libs/request-interceptor';
@@ -30,13 +30,6 @@ global.logger = logger;
 global.resourcesPath = isDevEnv
     ? path.join(__dirname, '..', 'build', 'static')
     : process.resourcesPath;
-
-const clearAppCache = () =>
-    new Promise<void>((resolve, reject) => {
-        const appFolder = process.env.PKGNAME!.replace('/', path.sep);
-        const cachePath = path.join(app.getPath('appData'), appFolder, 'Cache');
-        fs.rm(cachePath, { recursive: true }, err => (err ? reject(err) : resolve()));
-    });
 
 const createMainWindow = (winBounds: WinBounds) => {
     const mainWindow = new BrowserWindow({

--- a/packages/suite-desktop/src/modules/tor.ts
+++ b/packages/suite-desktop/src/modules/tor.ts
@@ -3,6 +3,7 @@
  */
 import { captureException } from '@sentry/electron';
 import { session } from 'electron';
+import path from 'path';
 
 import { TorStatus, BootstrapTorEvent, HandshakeTorModule } from '@trezor/suite-desktop-api';
 import { BootstrapEvent } from '@trezor/request-manager';
@@ -20,8 +21,7 @@ const load = async ({ mainWindow, store }: Dependencies) => {
     const port = await getFreePort();
     const address = `${host}:${port}`;
     const controlPort = await getFreePort();
-    const userData = app.getPath('userData');
-    const torDataDir = `${userData}/tor`;
+    const torDataDir = path.join(app.getPath('userData'), 'tor');
 
     /**
      * Merges given TorSettings with settings already present in the store,

--- a/packages/suite-desktop/src/modules/udev-install.ts
+++ b/packages/suite-desktop/src/modules/udev-install.ts
@@ -22,8 +22,8 @@ export const init: Module = () => {
     ipcMain.handle('udev/install', async () => {
         const { logger, resourcesPath } = global;
         const resourceRules = path.join(resourcesPath, `bin/udev/${FILE_NAME}`);
-        const userRules = `${app.getPath('userData')}/${FILE_NAME}`;
-        const distRules = `/etc/udev/rules.d/${FILE_NAME}`;
+        const userRules = path.join(app.getPath('userData'), FILE_NAME);
+        const distRules = path.join('/etc/udev/rules.d/', FILE_NAME);
 
         logger.info('udev', `Installing ${resourceRules} > ${userRules} > ${distRules}`);
 


### PR DESCRIPTION


<!--- Provide a general summary of your changes in the Title above -->

## Description

Always use path method to normalize path for all platforms.
It's not necessary if fs methods like mkdir is used, but if we show the path in the UI or use it to call electron method it's   required.

<!--- Describe your changes in detail -->

## Related Issue

Resolve https://github.com/trezor/trezor-suite/issues/7466

## Screenshots:
