### PR TITLE
CJ account discovery fixes

### DIFF
--- a/packages/coinjoin/src/backend/CoinjoinBackendClient.ts
+++ b/packages/coinjoin/src/backend/CoinjoinBackendClient.ts
@@ -8,7 +8,7 @@ import type {
     BlockbookTransaction,
 } from '../types/backend';
 import type { CoinjoinBackendSettings } from '../types';
-import { HTTP_REQUEST_TIMEOUT } from '../constants';
+import { GRADUAL_HTTP_REQUEST_TIMEOUTS } from '../constants';
 
 type CoinjoinBackendClientSettings = CoinjoinBackendSettings & {
     timeout?: number;
@@ -141,6 +141,10 @@ export class CoinjoinBackendClient {
         throw new Error(`${response.status}: ${response.statusText}`);
     }
 
+    private readonly defaultOptions = {
+        attempts: GRADUAL_HTTP_REQUEST_TIMEOUTS.map(timeout => ({ timeout })),
+    };
+
     protected scheduleGet<T>(
         backend: CoinjoinBackendClient['blockbook' | 'wabisabi'],
         handler: (r: Response) => Promise<T>,
@@ -154,7 +158,7 @@ export class CoinjoinBackendClient {
                     .call(this, { ...options, signal }) // "global" signal is overriden by signal passed from scheduleAction
                     .get(path, query)
                     .then(handler.bind(this)),
-            { attempts: 3, timeout: HTTP_REQUEST_TIMEOUT, ...options }, // default attempts/timeout could be overriden by options
+            { ...this.defaultOptions, ...options }, // default attempts/timeout could be overriden by options
         );
     }
 

--- a/packages/coinjoin/src/constants.ts
+++ b/packages/coinjoin/src/constants.ts
@@ -28,6 +28,9 @@ export const ROUND_SELECTION_REGISTRATION_OFFSET = 30000;
 // custom timeout for http requests (default is 50000 ms)
 export const HTTP_REQUEST_TIMEOUT = 35000;
 
+// used in backend client for gradually prolonging request timeout
+export const GRADUAL_HTTP_REQUEST_TIMEOUTS = [20000, 40000, 60000] as const;
+
 // timeout for CoinjoinRound currently running process
 export const ROUND_PHASE_PROCESS_TIMEOUT = 10000;
 

--- a/packages/suite/src/support/extraDependencies.ts
+++ b/packages/suite/src/support/extraDependencies.ts
@@ -14,6 +14,7 @@ import * as walletSettingsActions from '@settings-actions/walletSettingsActions'
 import { selectIsPendingTransportEvent } from '@suite-reducers/deviceReducer';
 import * as suiteActions from '../actions/suite/suiteActions';
 import { resolveStaticPath } from '@trezor/utils';
+import { fixLoadedCoinjoinAccount } from '@wallet-utils/coinjoinUtils';
 
 const connectSrc = resolveStaticPath('connect/');
 // 'https://localhost:8088/';
@@ -73,9 +74,7 @@ export const extraDependencies: ExtraDependencies = {
         },
         storageLoadAccounts: (_, { payload }: StorageLoadAction) =>
             payload.accounts.map(acc =>
-                acc.backendType === 'coinjoin' && acc.status === 'ready'
-                    ? { ...acc, status: 'out-of-sync' }
-                    : acc,
+                acc.backendType === 'coinjoin' ? fixLoadedCoinjoinAccount(acc) : acc,
             ),
         storageLoadFiatRates: (state: FiatRatesState, { payload }: StorageLoadAction) => {
             state.coins = payload.fiatRates;

--- a/packages/suite/src/utils/wallet/coinjoinUtils.ts
+++ b/packages/suite/src/utils/wallet/coinjoinUtils.ts
@@ -315,3 +315,25 @@ export const getFirstSessionPhaseFromRoundPhase = (roundPhase?: RoundPhase): Ses
 
 export const getAccountProgressHandle = (account: Account) =>
     createHash('sha256').update(account.key).digest('hex').slice(0, 16);
+
+export const fixLoadedCoinjoinAccount = ({
+    status,
+    ...account
+}: Extract<Account, { backendType: 'coinjoin' }>): Extract<
+    Account,
+    { backendType: 'coinjoin' }
+> => {
+    let statusFixed;
+
+    // If account had been successfully discovered before stored, it should be out-of-sync after loading
+    if (status === 'ready') statusFixed = 'out-of-sync' as const;
+    // If account was in error state (= never successfully discovered before), we could fall back to initial
+    else if (status === 'error') statusFixed = 'initial' as const;
+    else statusFixed = status;
+
+    return {
+        ...account,
+        status: statusFixed,
+        syncing: undefined, // If account was syncing when stored, we have to remove the flag
+    };
+};

--- a/packages/utils/src/scheduleAction.ts
+++ b/packages/utils/src/scheduleAction.ts
@@ -1,13 +1,18 @@
 export type ScheduledAction<T> = (signal?: AbortSignal) => Promise<T>;
 
+type AttemptParams = {
+    timeout?: number; // How many ms wait for a single action attempt (default = indefinitely)
+    gap?: number; // How many ms wait before the next attempt (default = none)
+};
+
 export type ScheduleActionParams = {
     delay?: number; // How many ms wait before calling action for the first time (default = none)
     deadline?: number; // Timestamp in which all attempts are rejected (default = none)
-    attempts?: number; // How many attempts before failure (default = one, or infinite when deadline is set)
-    timeout?: number; // How many ms wait for a single action attempt (default = indefinitely)
-    gap?: number; // How many ms wait between two consecutive attempts (default = none)
+    attempts?:
+        | number // How many attempts before failure (default = one, or infinite when deadline is set)
+        | AttemptParams[]; // Array of timeouts and gaps for every attempt (length = attempt count)
     signal?: AbortSignal;
-};
+} & AttemptParams; // Ignored when attempts is AttemptParams[]
 
 const abortedBySignal = () => new Error('Aborted by signal');
 const abortedByDeadline = () => new Error('Aborted by deadline');
@@ -66,22 +71,28 @@ const resolveAction = async <T>(action: ScheduledAction<T>, clear: AbortSignal) 
 
 const attemptLoop = async <T>(
     attempts: number,
-    attempt: ScheduledAction<T>,
-    failure: () => Promise<void>,
+    attempt: (attempt: number, signal: AbortSignal) => Promise<T>,
+    failure: (attempt: number) => Promise<void>,
     clear: AbortSignal,
 ) => {
     // Tries only (attempts - 1) times, because the last attempt throws its error
     for (let a = 0; a < attempts - 1; a++) {
         if (clear.aborted) break;
+        const aborter = new AbortController();
+        const onClear = () => aborter.abort();
+        clear.addEventListener('abort', onClear);
         try {
             // eslint-disable-next-line no-await-in-loop
-            return await attempt();
+            return await attempt(a, aborter.signal);
         } catch {
+            onClear();
             // eslint-disable-next-line no-await-in-loop
-            await failure();
+            await failure(a);
+        } finally {
+            clear.removeEventListener('abort', onClear);
         }
     }
-    return clear.aborted ? Promise.reject() : attempt();
+    return clear.aborted ? Promise.reject() : attempt(attempts - 1, clear);
 };
 
 export const scheduleAction = async <T>(
@@ -90,9 +101,14 @@ export const scheduleAction = async <T>(
 ) => {
     const { signal, delay, attempts, timeout, deadline, gap } = params;
     const deadlineMs = deadline && deadline - Date.now();
-    const attemptCount = attempts ?? (deadline ? Infinity : 1);
+    const attemptCount = Array.isArray(attempts)
+        ? attempts.length
+        : attempts ?? (deadline ? Infinity : 1);
     const clearAborter = new AbortController();
     const clear = clearAborter.signal;
+    const getParams = Array.isArray(attempts)
+        ? (attempt: number) => attempts[attempt]
+        : () => ({ timeout, gap });
 
     try {
         return await Promise.race([
@@ -101,12 +117,12 @@ export const scheduleAction = async <T>(
             resolveAfterMs(delay, clear).then(() =>
                 attemptLoop(
                     attemptCount,
-                    () =>
+                    (attempt, abort) =>
                         Promise.race([
-                            rejectAfterMs(timeout, abortedByTimeout, clear),
-                            resolveAction(action, clear),
+                            rejectAfterMs(getParams(attempt).timeout, abortedByTimeout, clear),
+                            resolveAction(action, abort),
                         ]),
-                    () => resolveAfterMs(gap ?? 0, clear),
+                    attempt => resolveAfterMs(getParams(attempt).gap ?? 0, clear),
                     clear,
                 ),
             ),


### PR DESCRIPTION
Should fix occasional non-syncing remembered CJ accounts and improve some timeouts a bit.

https://github.com/trezor/trezor-suite/pull/7510/commits/ba49a154789ca5850d7f376c05f080510e5d7781 - `syncing` flag of CJ accounts is now unset right after loading from db so periodical sync works as expected. Also, `error` status is converted to `initial` so there is never `Account discovery error` right after starting Suite and opening remembered CJ account. (**cherry-pick candidate**)

https://github.com/trezor/trezor-suite/pull/7510/commits/8eb72244edad9a18dc3af3ea6c9352916c90b40b - `scheduleAction` utility now allows to define different `timeout` (and/or `gap`) for every attempt

https://github.com/trezor/trezor-suite/pull/7510/commits/54a16bb2a579c26c7e5dd8bc3cb83aee8b0b1450 - based on previous commit, requests in CJ discovery now have increasing `timeout` so every next attempt has more time to finish successfuly.

### What to test
- that CJ discovery still works in general
- that when Suite is turned off while remembered CJ account is syncing, this account will successfully sync again