### PR TITLE
fix(ci): fix getting private/public JWS keys for message-system during builds

### DIFF
--- a/packages/suite-build/configs/base.webpack.config.ts
+++ b/packages/suite-build/configs/base.webpack.config.ts
@@ -12,9 +12,9 @@ import {
     isAnalyzing,
     isCodesignBuild,
     sentryAuthToken,
+    publicKey,
 } from '../utils/env';
 import { getRevision } from '../utils/git';
-import JWS_PUBLIC_KEY from '../utils/codesign';
 import { getPathForProject } from '../utils/path';
 // Get Suite App version from the Suite package.json
 import { suiteVersion } from '../../suite/package.json';
@@ -166,7 +166,7 @@ const config: webpack.Configuration = {
             'process.env.VERSION': JSON.stringify(suiteVersion),
             'process.env.COMMITHASH': JSON.stringify(gitRevision),
             'process.env.ASSET_PREFIX': JSON.stringify(assetPrefix),
-            'process.env.PUBLIC_KEY': JSON.stringify(JWS_PUBLIC_KEY),
+            'process.env.PUBLIC_KEY': JSON.stringify(publicKey),
             'process.env.CODESIGN_BUILD': isCodesignBuild,
             'process.env.SENTRY_RELEASE': JSON.stringify(sentryRelease),
         }),

--- a/packages/suite-build/utils/codesign.ts
+++ b/packages/suite-build/utils/codesign.ts
@@ -1,10 +1,26 @@
-import { isCodesignBuild } from './env';
+import fs from 'fs';
 
-console.log(`Bundling ${isCodesignBuild ? 'production' : 'develop'} public key.`);
-const JWS_PUBLIC_KEY = isCodesignBuild
-    ? process.env.JWS_PUBLIC_KEY_ENV ?? ''
-    : `-----BEGIN PUBLIC KEY-----
+// There must be no extra spaces at the beginning of the line.
+const devPublicKey = `-----BEGIN PUBLIC KEY-----
 MFYwEAYHKoZIzj0CAQYFK4EEAAoDQgAEbSUHJlr17+NywPS/w+xMkp3dSD8eWXSuAfFKwonZPe5fL63kISipJC+eJP7Mad0WxgyJoiMsZCV6BZPK2jIFdg==
 -----END PUBLIC KEY-----`;
 
-export default JWS_PUBLIC_KEY;
+export const getPublicKey = () => {
+    const isCodesignBuild = process.env.IS_CODESIGN_BUILD === 'true';
+    console.log(`Bundling ${isCodesignBuild ? 'production' : 'develop'} public key.`);
+
+    if (!isCodesignBuild) {
+        return devPublicKey;
+    }
+
+    const keyEnv = process.env.JWS_PUBLIC_KEY_ENV; // available on GitHub
+    const keyFile = process.env.JWS_PUBLIC_KEY_FILE; // available on GitLab
+
+    const publicKey = keyEnv || (keyFile && fs.readFileSync(keyFile, 'utf-8'));
+
+    if (!publicKey) {
+        throw new Error('Missing public key!');
+    }
+
+    return publicKey;
+};

--- a/packages/suite-build/utils/env.ts
+++ b/packages/suite-build/utils/env.ts
@@ -1,4 +1,5 @@
 import type { Project } from './constants';
+import { getPublicKey } from './codesign';
 
 const {
     PROJECT,
@@ -17,6 +18,7 @@ const isCodesignBuild = IS_CODESIGN_BUILD === 'true';
 const launchElectron = LAUNCH_ELECTRON === 'true';
 const assetPrefix = ASSET_PREFIX || '';
 const sentryAuthToken = SENTRY_AUTH_TOKEN;
+const publicKey = getPublicKey();
 
 export {
     isAnalyzing,
@@ -26,4 +28,5 @@ export {
     assetPrefix,
     project,
     sentryAuthToken,
+    publicKey,
 };


### PR DESCRIPTION

## Description

Recently we introduced releasing message-system config from github actions instead of gitlab pipeline:
https://github.com/trezor/trezor-suite/pull/7179

But there is a difference in environment variables:
- gitlab have private/public keys in file (because of masking it from logs)
- github have it directly in env variables

We still need to keep the signing of message-system config in gitlab, because we need to build a Suite with signed config.

So this PR is about supporting both of those CI environments.

## Related Issue

Failing codesign gitlab pipeline https://gitlab.com/satoshilabs/trezor/trezor-suite/-/pipelines/763183678

