### PR TITLE
Fix coinjoin pausing while device is locked

### DIFF
--- a/packages/suite/src/actions/wallet/__fixtures__/coinjoinAccountActions.ts
+++ b/packages/suite/src/actions/wallet/__fixtures__/coinjoinAccountActions.ts
@@ -158,9 +158,11 @@ export const startCoinjoinSession = [
             actions: [
                 COINJOIN.CLIENT_ENABLE,
                 COINJOIN.CLIENT_ENABLE_SUCCESS,
+                COINJOIN.SESSION_STARTING,
                 COINJOIN.ACCOUNT_AUTHORIZE,
                 COINJOIN.ACCOUNT_AUTHORIZE_FAILED,
                 notificationsActions.addToast.type,
+                COINJOIN.SESSION_STARTING,
             ],
         },
     },
@@ -182,8 +184,10 @@ export const startCoinjoinSession = [
             actions: [
                 COINJOIN.CLIENT_ENABLE,
                 COINJOIN.CLIENT_ENABLE_SUCCESS,
+                COINJOIN.SESSION_STARTING,
                 COINJOIN.ACCOUNT_AUTHORIZE,
                 COINJOIN.ACCOUNT_AUTHORIZE_SUCCESS,
+                COINJOIN.SESSION_STARTING,
             ],
         },
     },
@@ -264,7 +268,11 @@ export const restoreCoinjoinSession = [
         },
         param: '12345',
         result: {
-            actions: [COINJOIN.SESSION_RESTORE],
+            actions: [
+                COINJOIN.SESSION_STARTING,
+                COINJOIN.SESSION_RESTORE,
+                COINJOIN.SESSION_STARTING,
+            ],
         },
     },
 ];

--- a/packages/suite/src/actions/wallet/constants/coinjoinConstants.ts
+++ b/packages/suite/src/actions/wallet/constants/coinjoinConstants.ts
@@ -22,5 +22,6 @@ export const SESSION_ROUND_CHANGED = '@coinjoin/session-round-changed';
 export const SESSION_COMPLETED = '@coinjoin/session-completed';
 export const SESSION_OWNERSHIP = '@coinjoin/session-ownership';
 export const SESSION_TX_SIGNED = '@coinjoin/session-tx-signed';
+export const SESSION_STARTING = '@coinjoin/session-starting';
 
 export const SET_DEBUG_SETTINGS = '@coinjoin/set-debug-settings';

--- a/packages/suite/src/reducers/wallet/coinjoinReducer.ts
+++ b/packages/suite/src/reducers/wallet/coinjoinReducer.ts
@@ -157,6 +157,22 @@ const signSession = (
     };
 };
 
+const updateSessionStarting = (
+    draft: CoinjoinState,
+    payload: ExtractActionPayload<typeof COINJOIN.SESSION_STARTING>,
+) => {
+    const account = draft.accounts.find(a => a.key === payload.accountKey);
+    if (!account || !account.session) return;
+    if (payload.isStarting) {
+        account.session = {
+            ...account.session,
+            starting: payload.isStarting,
+        };
+    } else {
+        delete account.session.starting;
+    }
+};
+
 const completeSession = (
     draft: CoinjoinState,
     payload: ExtractActionPayload<typeof COINJOIN.SESSION_COMPLETED>,
@@ -380,9 +396,11 @@ export const coinjoinReducer = (
             case COINJOIN.SESSION_COMPLETED:
                 completeSession(draft, action.payload);
                 break;
-
             case COINJOIN.SESSION_TX_SIGNED:
                 signSession(draft, action.payload);
+                break;
+            case COINJOIN.SESSION_STARTING:
+                updateSessionStarting(draft, action.payload);
                 break;
 
             // no default

--- a/packages/suite/src/support/messages.ts
+++ b/packages/suite/src/support/messages.ts
@@ -7374,10 +7374,6 @@ export default defineMessages({
         id: 'TR_RESUMING',
         defaultMessage: 'Resuming',
     },
-    TR_PAUSING: {
-        id: 'TR_PAUSING',
-        defaultMessage: 'Pausing',
-    },
     TR_COINJOIN_RUNNING: {
         id: 'TR_COINJOIN_RUNNING',
         defaultMessage: 'Coinjoin running',

--- a/packages/suite/src/types/wallet/coinjoin.ts
+++ b/packages/suite/src/types/wallet/coinjoin.ts
@@ -22,6 +22,7 @@ export interface CoinjoinSession extends CoinjoinSessionParameters {
     timeEnded?: number; // timestamp when was finished
     paused?: boolean; // current state
     interrupted?: boolean; // it was paused by force
+    starting?: boolean; // is coinjoin session (re)starting, i.e. initiated but not yet running
     sessionPhaseQueue: Array<SessionPhase>;
     roundPhase?: RoundPhase; // current phase enum
     roundPhaseDeadline?: string | number; // estimated time for phase change

--- a/packages/suite/src/views/wallet/send/index.tsx
+++ b/packages/suite/src/views/wallet/send/index.tsx
@@ -1,13 +1,8 @@
-import React, { useEffect, useState } from 'react';
-import { useDispatch } from 'react-redux';
+import React from 'react';
 import styled from 'styled-components';
 
 import { Card } from '@suite-components';
 import { useSelector } from '@suite-hooks';
-import {
-    pauseCoinjoinSession,
-    restoreCoinjoinSession,
-} from '@wallet-actions/coinjoinAccountActions';
 import { WalletLayout } from '@wallet-components';
 import { useSendForm, SendContext, UseSendFormProps } from '@wallet-hooks/useSendForm';
 import { selectCoinjoinAccountByKey } from '@wallet-reducers/coinjoinReducer';
@@ -34,33 +29,11 @@ interface SendLoadedProps extends UseSendFormProps {
 // separated to call `useSendForm` hook at top level
 // children are only for test purposes, this prop is not available in regular build
 const SendLoaded = ({ children, ...props }: SendLoadedProps) => {
-    const [isCoinjoinPausedAutomatically, setIsCoinjoinPausedAutomatically] = useState(false);
-
     const coinjoinAccount = useSelector(state =>
         selectCoinjoinAccountByKey(state, props.selectedAccount.account.key),
     );
 
-    const dispatch = useDispatch();
-
     const sendContextValues = useSendForm({ ...props, coinjoinAccount });
-
-    const accountKey = props.selectedAccount.account.key;
-    const accountType = props.selectedAccount.account?.accountType;
-    const isSessionPaused = coinjoinAccount?.session?.paused;
-
-    // pause coinjoin when send form is open to avoid changing UTXOs while preparing transaction or breaking a coinjoin round
-    // automatically resume coinjoin upon leaving the send form
-    useEffect(() => {
-        if (accountType === 'coinjoin' && !isSessionPaused && !isCoinjoinPausedAutomatically) {
-            dispatch(pauseCoinjoinSession(accountKey));
-            setIsCoinjoinPausedAutomatically(true);
-        }
-        return () => {
-            if (isCoinjoinPausedAutomatically && isSessionPaused) {
-                dispatch(restoreCoinjoinSession(accountKey));
-            }
-        };
-    }, [accountKey, accountType, dispatch, isCoinjoinPausedAutomatically, isSessionPaused]);
 
     return (
         <WalletLayout title="TR_NAV_SEND" account={props.selectedAccount}>


### PR DESCRIPTION
## Description

When coinjoin session was paused shortly after it had been resumed (or started), it sometimes resulted in an error: `Device call in progress`. This error is caused by `connect` being occupied with another action and lead to the new action being discarded (i.e. coinjoin did not pause or in other case did not restore as reported in #7484).

This has been solved 1) on the main page by disabling the resume button while device is locked (515d458c14462d3088de3d0885f4bc611d695950), and 2) on closing/opening send form by moving the logic to `coinjoinMiddleware` and making sure the action is called once device is not locked 5740e2ef4e22f632d1150e6bb8aaaa4da047018a.

The `starting` property was added to `session` to prevent pausing or restoring the session while it is already being restored. This prevents an error which was sometimes visible in the console: `Trying to register account that already exists`

The conditions for restoring coinjoin session in `coinjoinMiddleware` have been unified into `checkIsCoinjoinResumeBlocked`. This adds some new conditions and also fixes this repeating condition which seems to be wrong. @karliatto please check this part out.
```ts
const isCoinjoinResumeAllowed = !isCoinJoinBlockedByTor || isDeviceConnected;
```

## Related Issue

Resolve #7484

## Screenshots:
Same error as described in #7484, but on the main page (tackled by 515d458c14462d3088de3d0885f4bc611d695950):
https://user-images.githubusercontent.com/42465546/216056362-7845781a-25ca-419f-9964-841651ca90d0.mov