### PR TITLE
feat(suite): update info note & badge text parsing according to the new format

### DIFF
--- a/packages/suite/src/components/wallet/CoinmarketTag/index.tsx
+++ b/packages/suite/src/components/wallet/CoinmarketTag/index.tsx
@@ -8,7 +8,7 @@ const TagRow = styled.div`
 
 const Tag = styled.div`
     margin: 0 16px 2px 16px;
-    padding: 0 8px;
+    padding: 3px 8px 0 8px;
     border-radius: 8px;
     background: ${props => props.theme.TYPE_ORANGE};
     color: ${props => props.theme.TYPE_WHITE};

--- a/packages/suite/src/utils/wallet/coinmarket/__tests__/coinmarketUtils.test.ts
+++ b/packages/suite/src/utils/wallet/coinmarket/__tests__/coinmarketUtils.test.ts
@@ -77,13 +77,33 @@ describe('coinmarket utils', () => {
     });
 
     it('getTagAndInfoNote', () => {
-        expect(getTagAndInfoNote({})).toStrictEqual({ infoNote: undefined });
-        expect(getTagAndInfoNote({ infoNote: '' })).toStrictEqual({ infoNote: '' });
-        expect(getTagAndInfoNote({ infoNote: 'Foo' })).toStrictEqual({ infoNote: 'Foo' });
-        expect(getTagAndInfoNote({ infoNote: ' #Foo' })).toStrictEqual({ infoNote: ' #Foo' });
-        expect(getTagAndInfoNote({ infoNote: 'Foo#Bar' })).toStrictEqual({ infoNote: 'Foo#Bar' });
-        expect(getTagAndInfoNote({ infoNote: '#Foo' })).toStrictEqual({ tag: 'Foo' });
-        expect(getTagAndInfoNote({ infoNote: '# Foo' })).toStrictEqual({ tag: ' Foo' });
-        expect(getTagAndInfoNote({ infoNote: '##Bar' })).toStrictEqual({ tag: '#Bar' });
+        expect(getTagAndInfoNote({})).toStrictEqual({ infoNote: '', tag: '' });
+        expect(getTagAndInfoNote({ infoNote: '' })).toStrictEqual({ infoNote: '', tag: '' });
+        expect(getTagAndInfoNote({ infoNote: 'Foo' })).toStrictEqual({ infoNote: 'Foo', tag: '' });
+        expect(getTagAndInfoNote({ infoNote: ' #Foo' })).toStrictEqual({
+            infoNote: '',
+            tag: 'Foo',
+        });
+        expect(getTagAndInfoNote({ infoNote: 'Foo#Bar' })).toStrictEqual({
+            infoNote: 'Foo#Bar',
+            tag: '',
+        });
+        expect(getTagAndInfoNote({ infoNote: '#Foo' })).toStrictEqual({ infoNote: '', tag: 'Foo' });
+        expect(getTagAndInfoNote({ infoNote: '# Foo' })).toStrictEqual({
+            infoNote: '',
+            tag: ' Foo',
+        });
+        expect(getTagAndInfoNote({ infoNote: '##Bar' })).toStrictEqual({
+            infoNote: 'Bar',
+            tag: '',
+        });
+        expect(getTagAndInfoNote({ infoNote: '#Foo#Bar' })).toStrictEqual({
+            infoNote: 'Bar',
+            tag: 'Foo',
+        });
+        expect(getTagAndInfoNote({ infoNote: '  #Foo#Bar \t' })).toStrictEqual({
+            infoNote: 'Bar',
+            tag: 'Foo',
+        });
     });
 });

--- a/packages/suite/src/utils/wallet/coinmarket/coinmarketUtils.ts
+++ b/packages/suite/src/utils/wallet/coinmarket/coinmarketUtils.ts
@@ -157,8 +157,19 @@ export const mapTestnetSymbol = (symbol: Network['symbol']) => {
 };
 
 export const getTagAndInfoNote = (quote: { infoNote?: string }) => {
-    if (quote.infoNote?.startsWith('#')) {
-        return { tag: quote.infoNote.substring(1) };
+    let tag = '';
+    let infoNote = (quote?.infoNote || '').trim();
+    if (infoNote.startsWith('#')) {
+        const splitNote = infoNote?.split('#') || [];
+        if (splitNote.length === 3) {
+            // infoNote contains "#badge_text#info_note_text"
+            [, tag, infoNote] = splitNote;
+        } else if (splitNote.length === 2) {
+            // infoNote contains "#badge_text"
+            infoNote = '';
+            tag = splitNote.pop() || '';
+        }
     }
-    return { infoNote: quote.infoNote };
+
+    return { tag, infoNote };
 };


### PR DESCRIPTION
## Description

Info notes returned by Invity backend can now contain both info note text, and a badge text.
I've also added a little padding to the badge so that the text appears centered.

In the screenshot below, there are two info notes - one with just the badge, and another one with both badge and an info note text.
Here's how their info notes looked like before parsing:

Mercuryo:
```
#BADGE ONLY
```

Simplex:
```
#BADGE#🚀 Enjoy 0% fees on this rate until September 14!
```

Info notes with no `#` separators are treated as classic text-only info notes without badges.

## Related Issue

none

## Screenshots:
![image](https://user-images.githubusercontent.com/15896005/216477714-a8be7268-9233-478f-878d-7f0d01e200c4.png)
