### PR TITLE
Unify coinjoin name - small caps everywhere

### DIFF
--- a/.github/workflows/connect-test.yml
+++ b/.github/workflows/connect-test.yml
@@ -43,7 +43,7 @@ jobs:
     needs: [build]
     uses: ./.github/workflows/connect-test-params.yml
     with:
-      test-pattern: "init authorizeCoinJoin passphrase unlockPath setBusy"
+      test-pattern: "init authorizeCoinjoin passphrase unlockPath setBusy"
 
   management:
     needs: [build]

--- a/ci/test.yml
+++ b/ci/test.yml
@@ -283,7 +283,7 @@ connect-popup manual:
   parallel:
     matrix:
       - TESTS_ENVIRONMENT: ["node", "web"]
-        TESTS_PATTERN: "init authorizeCoinJoin passphrase unlockPath setBusy"
+        TESTS_PATTERN: "init authorizeCoinjoin passphrase unlockPath setBusy"
         TESTS_FIRMWARE: ["2-master", "2.2.0"]
         # todo:
         # TESTS_NODE_VERSION: ["12", "14", "16"]

--- a/docs/SUMMARY.md
+++ b/docs/SUMMARY.md
@@ -37,7 +37,7 @@
             -   [pushTransaction](./packages/connect/methods/pushTransaction.md)
             -   [signMessage](./packages/connect/methods/signMessage.md)
             -   [verifyMessage](./packages/connect/methods/verifyMessage.md)
-            -   [authorizeCoinJoin](./packages/connect/methods/authorizeCoinJoin.md)
+            -   [authorizeCoinjoin](./packages/connect/methods/authorizeCoinjoin.md)
             -   [ethereumGetAddress](./packages/connect/methods/ethereumGetAddress.md)
             -   [ethereumSignTransaction](./packages/connect/methods/ethereumSignTransaction.md)
             -   [ethereumSignMessage](./packages/connect/methods/ethereumSignMessage.md)

--- a/docs/packages/connect/methods.md
+++ b/docs/packages/connect/methods.md
@@ -27,7 +27,7 @@ Every method require an [`Object`](https://developer.mozilla.org/en-US/docs/Web/
 -   [TrezorConnect.pushTransaction](methods/pushTransaction.md)
 -   [TrezorConnect.signMessage](methods/signMessage.md)
 -   [TrezorConnect.verifyMessage](methods/verifyMessage.md)
--   [TrezorConnect.authorizeCoinJoin](methods/authorizeCoinJoin.md)
+-   [TrezorConnect.authorizeCoinjoin](methods/authorizeCoinjoin.md)
 
 ## Ethereum
 

--- a/docs/packages/connect/methods/authorizeCoinJoin.md
+++ b/docs/packages/connect/methods/authorizeCoinJoin.md
@@ -1,4 +1,4 @@
-## Bitcoin: authorize Coinjoin
+## Bitcoin: authorize coinjoin
 
 Allow device to do preauthorized operations in `signTransaction` and `getOwnershipProof` methods without further user interaction.
 
@@ -38,7 +38,7 @@ const result = await TrezorConnect.authorizeCoinJoin(params);
 -   `preauthorized` — _optional_
     > Check if device session is already preauthorized and take no further action if so
 -   `coinjoinRequest` — _optional_ `PROTO.CoinJoinRequest`
-    > Signing request for a CoinJoin transaction
+    > Signing request for a coinjoin transaction
 
 ### Example:
 

--- a/docs/packages/connect/methods/authorizeCoinjoin.md
+++ b/docs/packages/connect/methods/authorizeCoinjoin.md
@@ -5,7 +5,7 @@ Allow device to do preauthorized operations in `signTransaction` and `getOwnersh
 Permission persists until physical device disconnection or `maxRounds` limit is reached.
 
 ```javascript
-const result = await TrezorConnect.authorizeCoinJoin(params);
+const result = await TrezorConnect.authorizeCoinjoin(params);
 ```
 
 > :warning: **This feature is experimental! Do not use it in production!**
@@ -43,7 +43,7 @@ const result = await TrezorConnect.authorizeCoinJoin(params);
 ### Example:
 
 ```javascript
-TrezorConnect.authorizeCoinJoin({
+TrezorConnect.authorizeCoinjoin({
     path: "m/10086'/0'/0'",
     maxRounds: 3,
     maxCoordinatorFeeRate: 500000, // 0.5% => 0.005 * 10**8;

--- a/docs/packages/connect/methods/getOwnershipProof.md
+++ b/docs/packages/connect/methods/getOwnershipProof.md
@@ -23,7 +23,7 @@ const result = await TrezorConnect.getOwnershipProof(params);
 -   `ownershipIds` — _optional_ `Array<string>`
 -   `commitmentData` — _optional_ `string`
 -   `multisig` — _optional_ `MultisigRedeemScriptType`
--   `preauthorized` — _optional_ `boolean` [read more](./authorizeCoinJoin.md)
+-   `preauthorized` — _optional_ `boolean` [read more](./authorizeCoinjoin.md)
 
 #### Exporting bundle of proofs
 

--- a/packages/coinjoin/src/types/coordinator.ts
+++ b/packages/coinjoin/src/types/coordinator.ts
@@ -5,7 +5,7 @@ export type AffiliationFlag = typeof AFFILIATION_FLAG;
 
 export interface CoinjoinStatus {
     roundStates: Round[];
-    coinJoinFeeRateMedians: FeeRateMedians[];
+    coinjoinFeeRateMedians: FeeRateMedians[];
     affiliateInformation?: {
         runningAffiliateServers: AffiliationFlag[];
         coinjoinRequests: Record<string, Record<AffiliationFlag, string>>;

--- a/packages/coinjoin/src/utils/roundUtils.ts
+++ b/packages/coinjoin/src/utils/roundUtils.ts
@@ -165,15 +165,15 @@ const getDataFromRounds = (rounds: Round[]) => {
  * - maxMiningFee: array => value in kvBytes
  */
 export const transformStatus = ({
-    coinJoinFeeRateMedians,
+    coinjoinFeeRateMedians,
     roundStates: rounds,
 }: CoinjoinStatus) => {
     const { allowedInputAmounts, coordinationFeeRate } = getDataFromRounds(rounds);
-    // coinJoinFeeRateMedians include an array of medians per day, week and month - we take the second (week) median as the recommended fee rate
-    const recommendedMedian = coinJoinFeeRateMedians[1];
+    // coinjoinFeeRateMedians include an array of medians per day, week and month - we take the second (week) median as the recommended fee rate
+    const recommendedMedian = coinjoinFeeRateMedians[1];
     // the value is converted from kvBytes (kilo virtual bytes) to vBytes (how the value is displayed in UI)
     const maxMiningFee = recommendedMedian
-        ? Math.round(coinJoinFeeRateMedians[1].medianFeeRate / 1000)
+        ? Math.round(coinjoinFeeRateMedians[1].medianFeeRate / 1000)
         : MAX_MINING_FEE;
 
     return {

--- a/packages/coinjoin/tests/client/CoinjoinClient.test.ts
+++ b/packages/coinjoin/tests/client/CoinjoinClient.test.ts
@@ -22,7 +22,7 @@ describe(`CoinjoinClient`, () => {
             if (url.endsWith('/status')) {
                 resolve({
                     roundStates: [DEFAULT_ROUND],
-                    coinJoinFeeRateMedians: [],
+                    coinjoinFeeRateMedians: [],
                     affiliateInformation: AFFILIATE_INFO,
                 });
             }

--- a/packages/coinjoin/tests/fixtures/round.fixture.ts
+++ b/packages/coinjoin/tests/fixtures/round.fixture.ts
@@ -95,7 +95,7 @@ export const AFFILIATE_INFO = {
 export const STATUS_EVENT = {
     roundStates: [],
     affiliateInformation: AFFILIATE_INFO,
-    coinJoinFeeRateMedians: FEE_RATE_MEDIANS,
+    coinjoinFeeRateMedians: FEE_RATE_MEDIANS,
 };
 
 type CJRoundOptions = ConstructorParameters<typeof CoinjoinRound>[1];

--- a/packages/coinjoin/tests/mocks/server.ts
+++ b/packages/coinjoin/tests/mocks/server.ts
@@ -67,7 +67,7 @@ const DEFAULT = {
     // coordinator
     status: {
         roundStates: [DEFAULT_ROUND],
-        coinJoinFeeRateMedians: FEE_RATE_MEDIANS,
+        coinjoinFeeRateMedians: FEE_RATE_MEDIANS,
         affiliateInformation: AFFILIATE_INFO,
     },
     'input-registration': {

--- a/packages/connect-common/files/firmware/2/releases.json
+++ b/packages/connect-common/files/firmware/2/releases.json
@@ -10,7 +10,7 @@
         "fingerprint": "4f57dca1abc1a60d82c4fef7c96e86d784fc7a1e5e3da724dd2ae4d14c6350bf",
         "fingerprint_bitcoinonly": "c094c84ba958129885fa725ee6ddb781b580fd2c7851e83aef9054ba4a10526c",
         "notes": "https://blog.trezor.io/trezor-suite-and-trezor-model-t-firmware-update-november-2022-a0b30bb0abf5",
-        "changelog": "* Add SLIP-0025 CoinJoin accounts. \n* Show red error header when Trezor doesn't see USB data connection. \n* Add support for Zcash unified addresses. \n* Show fee rate when replacing transaction. \n* Optimize the signing of BTC transactions. \n* Support for Cardano CIP-36 governance registration format. \n* Extend decimals of fee rate to 2 digits. \n* Display only “sat” instead of “sat BTC”. \n* Fix sending XMR transaction to an integrated address. \n* Fix XMR primary address display."
+        "changelog": "* Add SLIP-0025 coinjoin accounts. \n* Show red error header when Trezor doesn't see USB data connection. \n* Add support for Zcash unified addresses. \n* Show fee rate when replacing transaction. \n* Optimize the signing of BTC transactions. \n* Support for Cardano CIP-36 governance registration format. \n* Extend decimals of fee rate to 2 digits. \n* Display only “sat” instead of “sat BTC”. \n* Fix sending XMR transaction to an integrated address. \n* Fix XMR primary address display."
     },
     {
         "required": false,

--- a/packages/connect/CHANGELOG.md
+++ b/packages/connect/CHANGELOG.md
@@ -22,7 +22,7 @@
 -   added `setBusy` method
 -   added `goerli` (TGOR) coin support
 -   added `serialize` and `coinjoinRequest` option to `signTransaction` method
--   added `preauthorized` option to `authorizeCoinJoin` method
+-   added `preauthorized` option to `authorizeCoinjoin` method
 -   Cardano: added support for [CIP36 Catalyst registration format](https://cips.cardano.org/cips/cip36/) in `cardanoSignTransaction` method
     -   `auxiliaryData.catalystRegistrationParameters` is deprecated, use `auxiliaryData.governanceRegistrationParameters` instead
 
@@ -69,6 +69,6 @@
 
 -   `getOwnershipId` method
 -   `getOwnershipProof` method
--   `authorizeCoinJoin` method
+-   `authorizeCoinjoin` method
 -   `getFirmwareHash` method
 -   [support for babbage features in cardano](https://github.com/trezor/trezor-suite/commit/efe9c78a2f74a1b7653b3fddf6cca35ba38d3ae9)

--- a/packages/connect/e2e/tests/device/authorizeCoinjoin.test.ts
+++ b/packages/connect/e2e/tests/device/authorizeCoinjoin.test.ts
@@ -6,7 +6,7 @@ const { ADDRESS_N } = global.TestUtils;
 
 const controller = getController('applyFlags');
 
-describe('TrezorConnect.authorizeCoinJoin', () => {
+describe('TrezorConnect.authorizeCoinjoin', () => {
     beforeAll(async () => {
         await setup(controller, {
             mnemonic: 'mnemonic_all',
@@ -42,7 +42,7 @@ describe('TrezorConnect.authorizeCoinJoin', () => {
         });
         if (!unlockPath.success) throw new Error(unlockPath.payload.error);
 
-        const auth = await TrezorConnect.authorizeCoinJoin({
+        const auth = await TrezorConnect.authorizeCoinjoin({
             coordinator: 'www.example.com',
             maxRounds: 2,
             maxCoordinatorFeeRate: 500000, // 5% => 0.005 * 10**8;
@@ -241,7 +241,7 @@ describe('TrezorConnect.authorizeCoinJoin', () => {
         TrezorConnect.on('button', spy);
 
         // authorize no passphrase wallet
-        await TrezorConnect.authorizeCoinJoin({
+        await TrezorConnect.authorizeCoinjoin({
             ...params,
             device: { instance: 0, state: walletDefault.payload.state },
             useEmptyPassphrase: true,
@@ -250,7 +250,7 @@ describe('TrezorConnect.authorizeCoinJoin', () => {
         expect(spy).toBeCalledTimes(1 * confirmationScreensCount);
 
         // re-authorize
-        await TrezorConnect.authorizeCoinJoin({
+        await TrezorConnect.authorizeCoinjoin({
             ...params,
             device: { instance: 0, state: walletDefault.payload.state },
             useEmptyPassphrase: true,
@@ -260,7 +260,7 @@ describe('TrezorConnect.authorizeCoinJoin', () => {
         expect(spy).toBeCalledTimes(1 * confirmationScreensCount); // no more button requests
 
         // authorize passphrase wallet
-        await TrezorConnect.authorizeCoinJoin({
+        await TrezorConnect.authorizeCoinjoin({
             ...params,
             device: { instance: 1, state: walletA.payload.state },
         });
@@ -268,14 +268,14 @@ describe('TrezorConnect.authorizeCoinJoin', () => {
         expect(spy).toBeCalledTimes(2 * confirmationScreensCount);
 
         // re-authorize passphrase wallet
-        await TrezorConnect.authorizeCoinJoin({
+        await TrezorConnect.authorizeCoinjoin({
             ...params,
             device: { instance: 1, state: walletA.payload.state },
             preauthorized: true,
         });
 
         // re-authorize no passphrase wallet again
-        await TrezorConnect.authorizeCoinJoin({
+        await TrezorConnect.authorizeCoinjoin({
             ...params,
             device: { instance: 0, state: walletDefault.payload.state },
             useEmptyPassphrase: true,
@@ -283,7 +283,7 @@ describe('TrezorConnect.authorizeCoinJoin', () => {
         });
 
         // re-authorize passphrase wallet again
-        await TrezorConnect.authorizeCoinJoin({
+        await TrezorConnect.authorizeCoinjoin({
             ...params,
             device: { instance: 1, state: walletA.payload.state },
             preauthorized: true,

--- a/packages/connect/src/api/authorizeCoinjoin.ts
+++ b/packages/connect/src/api/authorizeCoinjoin.ts
@@ -4,8 +4,8 @@ import { validatePath, getScriptType } from '../utils/pathUtils';
 import { getBitcoinNetwork } from '../data/coinInfo';
 import { PROTO } from '../constants';
 
-export default class AuthorizeCoinJoin extends AbstractMethod<
-    'authorizeCoinJoin',
+export default class AuthorizeCoinjoin extends AbstractMethod<
+    'authorizeCoinjoin',
     PROTO.AuthorizeCoinJoin
 > {
     init() {

--- a/packages/connect/src/api/index.ts
+++ b/packages/connect/src/api/index.ts
@@ -1,6 +1,6 @@
 export { default as applyFlags } from './applyFlags';
 export { default as applySettings } from './applySettings';
-export { default as authorizeCoinJoin } from './authorizeCoinJoin';
+export { default as authorizeCoinjoin } from './authorizeCoinjoin';
 export { default as backupDevice } from './backupDevice';
 export { default as binanceGetAddress } from './binanceGetAddress';
 export { default as binanceGetPublicKey } from './binanceGetPublicKey';

--- a/packages/connect/src/data/config.ts
+++ b/packages/connect/src/data/config.ts
@@ -182,7 +182,7 @@ export const config = {
         },
         {
             capabilities: ['coinjoin'],
-            methods: ['authorizeCoinJoin', 'getOwnershipId', 'getOwnershipProof'],
+            methods: ['authorizeCoinjoin', 'getOwnershipId', 'getOwnershipProof'],
             min: ['0', '2.5.3'],
         },
     ],

--- a/packages/connect/src/factory.ts
+++ b/packages/connect/src/factory.ts
@@ -217,7 +217,7 @@ export const factory = ({
 
         applySettings: params => call({ ...params, method: 'applySettings' }),
 
-        authorizeCoinJoin: params => call({ ...params, method: 'authorizeCoinJoin' }),
+        authorizeCoinjoin: params => call({ ...params, method: 'authorizeCoinjoin' }),
 
         backupDevice: params => call({ ...params, method: 'backupDevice' }),
 

--- a/packages/connect/src/types/api/__tests__/bitcoin.ts
+++ b/packages/connect/src/types/api/__tests__/bitcoin.ts
@@ -687,8 +687,8 @@ export const getOwnershipProof = async (api: TrezorConnect) => {
     api.getOwnershipProof({ coin_name: 'btc' });
 };
 
-export const authorizeCoinJoin = async (api: TrezorConnect) => {
-    const result = await api.authorizeCoinJoin({
+export const authorizeCoinjoin = async (api: TrezorConnect) => {
+    const result = await api.authorizeCoinjoin({
         path: 'm/44',
         coordinator: 'TrezorCoinjoinCoordinator',
         maxRounds: 1,
@@ -700,7 +700,7 @@ export const authorizeCoinJoin = async (api: TrezorConnect) => {
         payload.message.toLowerCase();
     }
 
-    api.authorizeCoinJoin({
+    api.authorizeCoinjoin({
         path: 'm/44',
         coordinator: 'TrezorCoinjoinCoordinator',
         maxRounds: 1,
@@ -712,9 +712,9 @@ export const authorizeCoinJoin = async (api: TrezorConnect) => {
     });
 
     // @ts-expect-error incomplete params
-    api.authorizeCoinJoin({ path: 'm/44', coordinator: '' });
+    api.authorizeCoinjoin({ path: 'm/44', coordinator: '' });
     // @ts-expect-error incomplete params
-    api.authorizeCoinJoin({ path: 'm/44', maxRounds: 1 });
+    api.authorizeCoinjoin({ path: 'm/44', maxRounds: 1 });
     // @ts-expect-error incomplete params
-    api.authorizeCoinJoin({ coordinator: '', maxCoordinatorFeeRate: 1 });
+    api.authorizeCoinjoin({ coordinator: '', maxCoordinatorFeeRate: 1 });
 };

--- a/packages/connect/src/types/api/authorizeCoinjoin.ts
+++ b/packages/connect/src/types/api/authorizeCoinjoin.ts
@@ -1,7 +1,7 @@
 import type { PROTO } from '../../constants';
 import type { Params, Response } from '../params';
 
-export interface AuthorizeCoinJoin {
+export interface AuthorizeCoinjoin {
     path: string | number[];
     coordinator: string;
     maxRounds: number;
@@ -13,6 +13,6 @@ export interface AuthorizeCoinJoin {
     preauthorized?: boolean;
 }
 
-export declare function authorizeCoinJoin(
-    params: Params<AuthorizeCoinJoin>,
+export declare function authorizeCoinjoin(
+    params: Params<AuthorizeCoinjoin>,
 ): Response<PROTO.Success>;

--- a/packages/connect/src/types/api/index.ts
+++ b/packages/connect/src/types/api/index.ts
@@ -1,6 +1,6 @@
 import { applyFlags } from './applyFlags';
 import { applySettings } from './applySettings';
-import { authorizeCoinJoin } from './authorizeCoinJoin';
+import { authorizeCoinjoin } from './authorizeCoinjoin';
 import { backupDevice } from './backupDevice';
 import { binanceGetAddress } from './binanceGetAddress';
 import { binanceGetPublicKey } from './binanceGetPublicKey';
@@ -83,8 +83,8 @@ export interface TrezorConnect {
     // https://github.com/trezor/trezor-suite/blob/develop/docs/packages/connect/methods/applySettings.md
     applySettings: typeof applySettings;
 
-    // https://github.com/trezor/trezor-suite/blob/develop/docs/packages/connect/methods/authorizeCoinJoin.md
-    authorizeCoinJoin: typeof authorizeCoinJoin;
+    // https://github.com/trezor/trezor-suite/blob/develop/docs/packages/connect/methods/authorizeCoinjoin.md
+    authorizeCoinjoin: typeof authorizeCoinjoin;
 
     // https://github.com/trezor/trezor-suite/blob/develop/docs/packages/connect/methods/backupDevice.md
     backupDevice: typeof backupDevice;

--- a/packages/message-system/src/config/config.v1.json
+++ b/packages/message-system/src/config/config.v1.json
@@ -48,12 +48,12 @@
                 "variant": "warning",
                 "category": "context",
                 "content": {
-                    "en-GB": "CoinJoin account is currently in testing phase.",
-                    "en": "CoinJoin account is currently in testing phase.",
-                    "es": "La cuenta CoinJoin se encuentra actualmente en fase de pruebas.",
-                    "cs": "CoinJoin účet je zatím ve fázi testování.",
-                    "ru": "Счет CoinJoin в настоящее время находится на стадии тестирования.",
-                    "ja": "CoinJoinのアカウントは現在テスト段階です。"
+                    "en-GB": "Coinjoin account is currently in testing phase.",
+                    "en": "Coinjoin account is currently in testing phase.",
+                    "es": "La cuenta Coinjoin se encuentra actualmente en fase de pruebas.",
+                    "cs": "Coinjoin účet je zatím ve fázi testování.",
+                    "ru": "Счет Coinjoin в настоящее время находится на стадии тестирования.",
+                    "ja": "Coinjoinのアカウントは現在テスト段階です。"
                 },
                 "context": { "domain": "accounts.coinjoin" }
             }

--- a/packages/suite-desktop/e2e/tests/coinjoin.test.ts
+++ b/packages/suite-desktop/e2e/tests/coinjoin.test.ts
@@ -73,7 +73,7 @@ const addCoinjoinAccount = async (window: Page) => {
     await window.click('[data-test="@settings/wallet/network/regtest"]');
     await window.click('[data-test="@add-account-type/select/input"]', { trial: true });
     await window.click('[data-test="@add-account-type/select/input"]');
-    await window.click('[data-test="@add-account-type/select/option/Bitcoin Regtest (CoinJoin)"]');
+    await window.click('[data-test="@add-account-type/select/option/Bitcoin Regtest"]');
     await window.click('[data-test="@add-account"]');
 
     await window.screenshot({ path: './test-results/1.png', fullPage: true, type: 'png' });

--- a/packages/suite-web/e2e/support/commands.ts
+++ b/packages/suite-web/e2e/support/commands.ts
@@ -107,10 +107,7 @@ declare global {
             }) => Chainable<Subject>;
             skipOn: (nameOrFlag: string | boolean, cb?: () => void) => Cypress.Chainable<any>;
             onlyOn: (nameOrFlag: string | boolean, cb?: () => void) => Cypress.Chainable<any>;
-            createAccountFromMyAccounts: (
-                coin: string,
-                accountNameAdd: string,
-            ) => Chainable<Subject>;
+            createAccountFromMyAccounts: (coin: string, label: string) => Chainable<Subject>;
             interceptInvityApi: () => void;
         }
     }

--- a/packages/suite-web/e2e/support/utils/shortcuts.ts
+++ b/packages/suite-web/e2e/support/utils/shortcuts.ts
@@ -90,7 +90,7 @@ export const enableRegtestAndGetCoins = ({ payments = [] }) => {
     cy.task('mineBlocks', { block_amount: 1 });
 };
 
-export const createAccountFromMyAccounts = (coin: string, accountNameAdd: string) => {
+export const createAccountFromMyAccounts = (coin: string, label: string) => {
     cy.getTestElement('@wallet/discovery-progress-bar', { timeout: 30000 }).should('not.exist');
     cy.getTestElement('@account-menu/add-account').should('be.visible').click();
     // if (cy.getTestElement('@modal').should('be.visible')) {
@@ -99,6 +99,6 @@ export const createAccountFromMyAccounts = (coin: string, accountNameAdd: string
     cy.getTestElement('@modal').should('be.visible');
     cy.get(`[data-test="@settings/wallet/network/${coin}"]`).should('be.visible').click();
     cy.getTestElement('@add-account-type/select/input').click();
-    cy.get(`[data-test="@add-account-type/select/option/${accountNameAdd}"]`).click();
+    cy.get(`[data-test="@add-account-type/select/option/${label}"]`).click();
     cy.getTestElement('@add-account').click();
 };

--- a/packages/suite-web/e2e/tests/wallet/add-account-types.test.ts
+++ b/packages/suite-web/e2e/tests/wallet/add-account-types.test.ts
@@ -39,10 +39,10 @@ describe('Account types suite', () => {
         //
         const coin: NetworkSymbol = 'btc';
         const accsArray = [
-            { type: 'normal', coinAccountName: 'Bitcoin' },
-            { type: 'taproot', coinAccountName: 'Bitcoin (Taproot)' },
-            { type: 'segwit', coinAccountName: 'Bitcoin (Legacy Segwit)' },
-            { type: 'legacy', coinAccountName: 'Bitcoin (Legacy)' },
+            { type: 'normal' },
+            { type: 'taproot' },
+            { type: 'segwit' },
+            { type: 'legacy' },
         ];
 
         //
@@ -51,7 +51,7 @@ describe('Account types suite', () => {
 
         onTopBar.openAccounts();
         onAccountsPage.clickAllAccountArrows();
-        accsArray.forEach(({ type, coinAccountName }: { type: string; coinAccountName: string }) =>
+        accsArray.forEach(({ type }: { type: string }) =>
             // for a specific type of BTC acc, get the current number of accounts
             cy
                 .get(`[type="${type}"] > [data-test^="@account-menu/${coin}/${type}/"]`)
@@ -59,7 +59,7 @@ describe('Account types suite', () => {
                     const numberOfAccounts1 = specificAccounts.length;
 
                     // for a specific type of BTC acc, add a new acc
-                    cy.createAccountFromMyAccounts(coin, coinAccountName);
+                    cy.createAccountFromMyAccounts(coin, type);
 
                     // for a specific type of BTC acc, get the current number of accounts again for comparison
                     cy.get(`[type="${type}"] > [data-test^="@account-menu/${coin}/${type}/"]`).then(
@@ -94,11 +94,7 @@ describe('Account types suite', () => {
         // Test preparation
         //
         const coin: NetworkSymbol = 'ltc';
-        const accsArray = [
-            { type: 'normal', coinAccountName: 'Litecoin' },
-            { type: 'segwit', coinAccountName: 'Litecoin (segwit)' },
-            { type: 'legacy', coinAccountName: 'Litecoin (legacy)' },
-        ];
+        const accsArray = [{ type: 'normal' }, { type: 'segwit' }, { type: 'legacy' }];
 
         //
         // Test execution
@@ -113,12 +109,12 @@ describe('Account types suite', () => {
         cy.discoveryShouldFinish();
         onAccountsPage.clickAllAccountArrows();
 
-        accsArray.forEach(({ type, coinAccountName }: { type: string; coinAccountName: string }) =>
+        accsArray.forEach(({ type }: { type: string }) =>
             cy
                 .get(`[type="${type}"] > [data-test^="@account-menu/${coin}/${type}/"]`)
                 .then(specificAccounts => {
                     const numberOfAccounts1 = specificAccounts.length;
-                    cy.createAccountFromMyAccounts(coin, coinAccountName);
+                    cy.createAccountFromMyAccounts(coin, type);
                     cy.get(`[type="${type}"] > [data-test^="@account-menu/${coin}/${type}/"]`).then(
                         specificAccounts => {
                             const numberOfAccounts2 = specificAccounts.length;

--- a/packages/suite/src/actions/wallet/__fixtures__/coinjoinAccountActions.ts
+++ b/packages/suite/src/actions/wallet/__fixtures__/coinjoinAccountActions.ts
@@ -15,7 +15,7 @@ const SESSION = { signedRounds: [] as string[], maxRounds: 10 };
 
 export const createCoinjoinAccount = [
     {
-        description: 'unsupported Coinjoin client',
+        description: 'unsupported coinjoin client',
         params: {
             symbol: 'ltc', // only btc is supported in tests
             networkType: 'bitcoin',

--- a/packages/suite/src/actions/wallet/coinjoinAccountActions.ts
+++ b/packages/suite/src/actions/wallet/coinjoinAccountActions.ts
@@ -443,7 +443,7 @@ const authorizeCoinjoin =
         // authorize coinjoin session on Trezor
         dispatch(coinjoinAccountAuthorize(account.key));
 
-        const auth = await TrezorConnect.authorizeCoinJoin({
+        const auth = await TrezorConnect.authorizeCoinjoin({
             device,
             useEmptyPassphrase: device?.useEmptyPassphrase,
             path: account.path,
@@ -595,7 +595,7 @@ export const restoreCoinjoinSession =
 
         dispatch(coinjoinSessionStarting(accountKey, true));
 
-        const auth = await TrezorConnect.authorizeCoinJoin({
+        const auth = await TrezorConnect.authorizeCoinjoin({
             device,
             useEmptyPassphrase: device?.useEmptyPassphrase,
             path: account.path,

--- a/packages/suite/src/components/suite/AccountLabel.tsx
+++ b/packages/suite/src/components/suite/AccountLabel.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import styled from 'styled-components';
-import { getTitleForNetwork, getTitleForCoinJoinAccount } from '@suite-common/wallet-utils';
+import { getTitleForNetwork, getTitleForCoinjoinAccount } from '@suite-common/wallet-utils';
 import { Translation } from '@suite-components';
 import { Account } from '@wallet-types';
 
@@ -28,7 +28,7 @@ export const AccountLabel = ({
     }
 
     if (accountType === 'coinjoin') {
-        return <Translation id={getTitleForCoinJoinAccount(symbol)} />;
+        return <Translation id={getTitleForCoinjoinAccount(symbol)} />;
     }
 
     return (

--- a/packages/suite/src/components/suite/modals/AddAccount/components/AccountTypeSelect.tsx
+++ b/packages/suite/src/components/suite/modals/AddAccount/components/AccountTypeSelect.tsx
@@ -24,7 +24,7 @@ const TypeInfo = styled.div`
 const buildAccountTypeOption = (network: Network) =>
     ({
         value: network,
-        label: network.name,
+        label: network.accountType || 'normal',
     } as const);
 
 type Option = ReturnType<typeof buildAccountTypeOption>;

--- a/packages/suite/src/components/suite/modals/AddAccount/components/AddAccountButton.tsx
+++ b/packages/suite/src/components/suite/modals/AddAccount/components/AddAccountButton.tsx
@@ -3,7 +3,7 @@ import { analytics, EventType } from '@trezor/suite-analytics';
 import { Account, Network } from '@wallet-types';
 import { UnavailableCapability } from '@trezor/connect';
 import { Translation } from '@suite-components';
-import { AddCoinJoinAccountButton } from './AddCoinJoinAccountButton';
+import { AddCoinjoinAccountButton } from './AddCoinjoinAccountButton';
 import { AddButton } from './AddButton';
 import { useAccountSearch, useSelector } from '@suite-hooks';
 
@@ -109,7 +109,7 @@ export const AddAccountButton = ({
 }: AddAccountButtonProps) => {
     switch (network.accountType) {
         case 'coinjoin':
-            return <AddCoinJoinAccountButton network={network} />;
+            return <AddCoinjoinAccountButton network={network} />;
         default:
             return (
                 <AddDefaultAccountButton

--- a/packages/suite/src/components/suite/modals/AddAccount/components/AddCoinJoinAccountButton.tsx
+++ b/packages/suite/src/components/suite/modals/AddAccount/components/AddCoinJoinAccountButton.tsx
@@ -33,7 +33,7 @@ const verifyAvailability = ({
     if (capability === 'no-support') {
         return <Translation id="MODAL_ADD_ACCOUNT_COINJOIN_NO_SUPPORT" />;
     }
-    // regtest CoinJoin account enabled in web app for development
+    // regtest coinjoin account enabled in web app for development
     if (!isDesktop() && !(isDevEnv && symbol === 'regtest')) {
         return <Translation id="MODAL_ADD_ACCOUNT_COINJOIN_DESKTOP_ONLY" />;
     }

--- a/packages/suite/src/components/suite/modals/AddAccount/components/AddCoinjoinAccountButton.tsx
+++ b/packages/suite/src/components/suite/modals/AddAccount/components/AddCoinjoinAccountButton.tsx
@@ -42,14 +42,14 @@ const verifyAvailability = ({
     }
 };
 
-interface AddCoinJoinAccountProps {
+interface AddCoinjoinAccountProps {
     network: Network;
 }
 
 const requestEnableTorAction = () => (dispatch: Dispatch) =>
     dispatch(modalActions.openDeferredModal({ type: 'request-enable-tor' }));
 
-export const AddCoinJoinAccountButton = ({ network }: AddCoinJoinAccountProps) => {
+export const AddCoinjoinAccountButton = ({ network }: AddCoinjoinAccountProps) => {
     const [isLoading, setIsLoading] = useState(false);
 
     const { isTorEnabled } = useSelector(selectTorState);

--- a/packages/suite/src/components/wallet/AccountAnnouncement/CoinjoinContextMessage.tsx
+++ b/packages/suite/src/components/wallet/AccountAnnouncement/CoinjoinContextMessage.tsx
@@ -5,11 +5,11 @@ import { useSelector } from '@suite-hooks';
 import { Context, selectContextMessageContent } from '@suite-reducers/messageSystemReducer';
 import { Account } from '@wallet-types';
 
-type CoinJoinContextMessageProps = {
+type CoinjoinContextMessageProps = {
     account?: Account;
 };
 
-export const CoinJoinContextMessage = ({ account }: CoinJoinContextMessageProps) => {
+export const CoinjoinContextMessage = ({ account }: CoinjoinContextMessageProps) => {
     const message = useSelector(state => selectContextMessageContent(state, Context.coinjoin));
 
     return account?.accountType === 'coinjoin' && message ? (

--- a/packages/suite/src/components/wallet/AccountsMenu/AccountItem.tsx
+++ b/packages/suite/src/components/wallet/AccountsMenu/AccountItem.tsx
@@ -140,7 +140,7 @@ export const AccountItem = forwardRef(
         const isTokensCountShown =
             ['cardano', 'ethereum'].includes(networkType) && !!tokens?.length;
 
-        // Show skeleton instead of zero balance during CoinJoin initial discovery
+        // Show skeleton instead of zero balance during coinjoin initial discovery
         const isBalanceShown = account.backendType !== 'coinjoin' || account.status !== 'initial';
 
         const dataTestKey = `@account-menu/${symbol}/${accountType}/${index}`;

--- a/packages/suite/src/components/wallet/CoinjoinSummary/AnonymizeButton.tsx
+++ b/packages/suite/src/components/wallet/CoinjoinSummary/AnonymizeButton.tsx
@@ -42,7 +42,7 @@ export const AnonymizeButton = ({ accountKey }: AnonymizeButtonProps) => {
         selectIsCoinjoinBlockedByAmountsTooSmall(state, accountKey),
     );
 
-    const isCoinJoinDisabledByFeatureFlag = useSelector(state =>
+    const isCoinjoinDisabledByFeatureFlag = useSelector(state =>
         selectIsFeatureDisabled(state, Feature.coinjoin),
     );
     const featureMessageContent = useSelector(state =>
@@ -52,14 +52,14 @@ export const AnonymizeButton = ({ accountKey }: AnonymizeButtonProps) => {
     const dispatch = useDispatch();
 
     const isDisabled =
-        isCoinJoinDisabledByFeatureFlag ||
+        isCoinjoinDisabledByFeatureFlag ||
         isCoinjoinBlockedByAmountsTooSmall ||
         isCoinjoinBlockedByTor;
 
     const goToSetup = () => dispatch(goto('wallet-anonymize', { preserveParams: true }));
 
     const getTooltipContent = () => {
-        if (isCoinJoinDisabledByFeatureFlag && featureMessageContent) {
+        if (isCoinjoinDisabledByFeatureFlag && featureMessageContent) {
             return featureMessageContent;
         }
         if (isCoinjoinBlockedByTor) {

--- a/packages/suite/src/components/wallet/PrivacyAccount/CoinjoinLogs.tsx
+++ b/packages/suite/src/components/wallet/PrivacyAccount/CoinjoinLogs.tsx
@@ -6,7 +6,7 @@ import { Translation } from '@suite-components';
 import { Card } from '@trezor/components';
 import { useSelector } from '@suite-hooks/useSelector';
 import { useAnchor } from '@suite-hooks/useAnchor';
-import { CoinJoinLogsAnchor } from '@suite-constants/anchors';
+import { CoinjoinLogsAnchor } from '@suite-constants/anchors';
 import { anchorOutlineStyles } from '@suite-utils/anchor';
 
 const SetupCard = styled(Card)<{ shouldHighlight?: boolean }>`
@@ -18,9 +18,9 @@ const SetupCard = styled(Card)<{ shouldHighlight?: boolean }>`
     ${anchorOutlineStyles}
 `;
 
-export const CoinJoinLogs = () => {
+export const CoinjoinLogs = () => {
     const showDebugMenu = useSelector(state => state.suite.settings.debug.showDebugMenu);
-    const { anchorRef, shouldHighlight } = useAnchor(CoinJoinLogsAnchor);
+    const { anchorRef, shouldHighlight } = useAnchor(CoinjoinLogsAnchor);
 
     if (!showDebugMenu) return null;
 

--- a/packages/suite/src/components/wallet/WalletLayout/components/AccountBanners.tsx
+++ b/packages/suite/src/components/wallet/WalletLayout/components/AccountBanners.tsx
@@ -10,7 +10,7 @@ import { XRPReserve } from '../../AccountAnnouncement/XRPReserve';
 import { AccountImported } from '../../AccountAnnouncement/AccountImported';
 import { AccountOutOfSync } from '../../AccountAnnouncement/AccountOutOfSync';
 import { TorDisconnected } from '../../AccountAnnouncement/TorDisconnected';
-import { CoinJoinContextMessage } from '../../AccountAnnouncement/CoinJoinContextMessage';
+import { CoinjoinContextMessage } from '../../AccountAnnouncement/CoinjoinContextMessage';
 
 const BannersWrapper = styled.div`
     display: flex;
@@ -27,7 +27,7 @@ type AccountBannersProps = {
 
 export const AccountBanners = ({ account }: AccountBannersProps) => (
     <BannersWrapper>
-        <CoinJoinContextMessage account={account} />
+        <CoinjoinContextMessage account={account} />
         <AuthConfirmFailed />
         <BackendDisconnected />
         <DeviceUnavailable />

--- a/packages/suite/src/constants/suite/anchors.ts
+++ b/packages/suite/src/constants/suite/anchors.ts
@@ -42,6 +42,6 @@ export const enum SettingsAnchor {
 
 export const AccountTransactionBaseAnchor = '@account/transaction';
 
-export const CoinJoinLogsAnchor = '@coinjoin/logs';
+export const CoinjoinLogsAnchor = '@coinjoin/logs';
 
 export type AnchorType = SettingsAnchor | string;

--- a/packages/suite/src/hooks/coinjoin/useBlockedCoinjoinResume.ts
+++ b/packages/suite/src/hooks/coinjoin/useBlockedCoinjoinResume.ts
@@ -10,8 +10,8 @@ import { selectIsCoinjoinBlockedByTor } from '@wallet-reducers/coinjoinReducer';
 import { getIsCoinjoinOutOfSync } from '@wallet-utils/coinjoinUtils';
 
 export const useBlockedCoinjoinResume = () => {
-    const isCoinJoinBlockedByTor = useSelector(selectIsCoinjoinBlockedByTor);
-    const isCoinJoinDisabledByFeatureFlag = useSelector(state =>
+    const isCoinjoinBlockedByTor = useSelector(selectIsCoinjoinBlockedByTor);
+    const isCoinjoinDisabledByFeatureFlag = useSelector(state =>
         selectIsFeatureDisabled(state, Feature.coinjoin),
     );
     const featureMessageContent = useSelector(state =>
@@ -29,7 +29,7 @@ export const useBlockedCoinjoinResume = () => {
 
     if (!online) {
         coinjoinResumeBlockedMessageId = 'TR_UNAVAILABLE_COINJOIN_NO_INTERNET';
-    } else if (isCoinJoinBlockedByTor) {
+    } else if (isCoinjoinBlockedByTor) {
         coinjoinResumeBlockedMessageId = 'TR_UNAVAILABLE_COINJOIN_TOR_DISABLE_TOOLTIP';
     } else if (isDeviceDisconnected) {
         coinjoinResumeBlockedMessageId = 'TR_UNAVAILABLE_COINJOIN_DEVICE_DISCONNECTED';
@@ -38,11 +38,11 @@ export const useBlockedCoinjoinResume = () => {
     }
 
     const isCoinjoinResumeBlocked =
-        isCoinJoinBlockedByTor ||
+        isCoinjoinBlockedByTor ||
         isDeviceDisconnected ||
         isAccountOutOfSync ||
         !online ||
-        isCoinJoinDisabledByFeatureFlag;
+        isCoinjoinDisabledByFeatureFlag;
 
     return {
         coinjoinResumeBlockedMessageId,

--- a/packages/suite/src/middlewares/wallet/coinjoinMiddleware.ts
+++ b/packages/suite/src/middlewares/wallet/coinjoinMiddleware.ts
@@ -32,16 +32,16 @@ export const coinjoinMiddleware =
         const isCoinjoinSessionBlockedGlobally = (state: AppState) => {
             const deviceStatus = selectDeviceState(state);
             const isDeviceDisconnected = deviceStatus !== 'connected';
-            const isCoinJoinBlockedByTor = selectIsCoinjoinBlockedByTor(state);
-            const isCoinJoinDisabledByFeatureFlag = selectIsFeatureDisabled(
+            const isCoinjoinBlockedByTor = selectIsCoinjoinBlockedByTor(state);
+            const isCoinjoinDisabledByFeatureFlag = selectIsFeatureDisabled(
                 state,
                 Feature.coinjoin,
             );
             const isCoinjoinBlockedByRoute = state.router.route?.name === 'wallet-send';
             return (
                 isDeviceDisconnected ||
-                isCoinJoinBlockedByTor ||
-                isCoinJoinDisabledByFeatureFlag ||
+                isCoinjoinBlockedByTor ||
+                isCoinjoinDisabledByFeatureFlag ||
                 isCoinjoinBlockedByRoute ||
                 !state.suite.online
             );
@@ -174,12 +174,12 @@ export const coinjoinMiddleware =
         ) {
             const state = api.getState();
 
-            const isCoinJoinDisabledByFeatureFlag = selectIsFeatureDisabled(
+            const isCoinjoinDisabledByFeatureFlag = selectIsFeatureDisabled(
                 state,
                 Feature.coinjoin,
             );
 
-            if (isCoinJoinDisabledByFeatureFlag) {
+            if (isCoinjoinDisabledByFeatureFlag) {
                 const isAnySessionInCriticalPhase = selectIsAnySessionInCriticalPhase(state);
                 const hasCriticalPhaseJustEnded =
                     action.type === SESSION_ROUND_CHANGED &&

--- a/packages/suite/src/support/messages.ts
+++ b/packages/suite/src/support/messages.ts
@@ -7690,7 +7690,7 @@ export default defineMessages({
     },
     TR_UNAVAILABLE_WHILE_LOADING: {
         id: 'TR_UNAVAILABLE_WHILE_LOADING',
-        description: 'CoinJoin account navigation button tooltip during discovery',
+        description: 'Coinjoin account navigation button tooltip during discovery',
         defaultMessage: 'Unavailable while loading',
     },
     TR_VIEW_ALL: {

--- a/packages/suite/src/views/settings/debug/CoinjoinApi.tsx
+++ b/packages/suite/src/views/settings/debug/CoinjoinApi.tsx
@@ -92,7 +92,7 @@ export const CoinjoinApi = () => {
             <SectionItem data-test="@settings/debug/coinjoin-allow-no-tor">
                 <TextColumn
                     title="Allow no Tor"
-                    description="Normally, Coinjoin is allowed only when Tor is running. You may allow coinjoin without running Tor"
+                    description="Normally, coinjoin is allowed only when Tor is running. You may allow coinjoin without running Tor"
                 />
                 <ActionColumn>
                     <Switch

--- a/packages/suite/src/views/wallet/anonymize/components/CoinjoinConfirmation.tsx
+++ b/packages/suite/src/views/wallet/anonymize/components/CoinjoinConfirmation.tsx
@@ -106,8 +106,8 @@ export const CoinjoinConfirmation = ({ account }: CoinjoinConfirmationProps) => 
     const targetAnonymity = useSelector(selectCurrentTargetAnonymity);
     const { notAnonymized } = useSelector(selectCurrentCoinjoinBalanceBreakdown);
     const { isLocked } = useDevice();
-    const isCoinJoinBlockedByTor = useSelector(selectIsCoinjoinBlockedByTor);
-    const isCoinJoinDisabledByFeatureFlag = useSelector(state =>
+    const isCoinjoinBlockedByTor = useSelector(selectIsCoinjoinBlockedByTor);
+    const isCoinjoinDisabledByFeatureFlag = useSelector(state =>
         selectIsFeatureDisabled(state, Feature.coinjoin),
     );
     const featureMessageContent = useSelector(state =>
@@ -136,17 +136,17 @@ export const CoinjoinConfirmation = ({ account }: CoinjoinConfirmationProps) => 
         !termsConfirmed ||
         allAnonymized ||
         deviceIsLockedOrDisconnected ||
-        isCoinJoinBlockedByTor ||
-        isCoinJoinDisabledByFeatureFlag;
+        isCoinjoinBlockedByTor ||
+        isCoinjoinDisabledByFeatureFlag;
 
     const getButtonTooltipMessage = () => {
-        if (isCoinJoinDisabledByFeatureFlag && featureMessageContent) {
+        if (isCoinjoinDisabledByFeatureFlag && featureMessageContent) {
             return featureMessageContent;
         }
         if (deviceIsLockedOrDisconnected) {
             return <Translation id="TR_UNAVAILABLE_COINJOIN_DEVICE_DISCONNECTED" />;
         }
-        if (isCoinJoinBlockedByTor) {
+        if (isCoinjoinBlockedByTor) {
             return <Translation id="TR_UNAVAILABLE_COINJOIN_TOR_DISABLE_TOOLTIP" />;
         }
         if (allAnonymized) {

--- a/packages/suite/src/views/wallet/details/index.tsx
+++ b/packages/suite/src/views/wallet/details/index.tsx
@@ -16,7 +16,7 @@ import { ActionColumn, Row, TextColumn, ActionButton } from '@suite-components/S
 import { CARD_PADDING_SIZE } from '@suite-constants/layout';
 import { NETWORKS } from '@wallet-config';
 import { AnonymityLevelSetupCard } from '@wallet-components/PrivacyAccount/AnonymityLevelSetupCard';
-import { CoinJoinLogs } from '@wallet-components/PrivacyAccount/CoinJoinLogs';
+import { CoinjoinLogs } from '@wallet-components/PrivacyAccount/CoinjoinLogs';
 
 const AccountTypeLabel = styled.div`
     display: flex;
@@ -139,7 +139,7 @@ const Details = () => {
                 )}
             </StyledCard>
 
-            {isCoinjoinAccount && <CoinJoinLogs />}
+            {isCoinjoinAccount && <CoinjoinLogs />}
         </WalletLayout>
     );
 };

--- a/packages/suite/src/views/wallet/transactions/components/TransactionList/components/Actions/components/ExportAction.tsx
+++ b/packages/suite/src/views/wallet/transactions/components/TransactionList/components/Actions/components/ExportAction.tsx
@@ -10,7 +10,7 @@ import { exportTransactionsThunk, fetchTransactionsThunk } from '@suite-common/w
 import { ExportFileType } from '@suite-common/wallet-types';
 import { Account } from '@wallet-types';
 import { isFeatureFlagEnabled } from '@suite-common/suite-utils';
-import { getTitleForNetwork, getTitleForCoinJoinAccount } from '@suite-common/wallet-utils';
+import { getTitleForNetwork, getTitleForCoinjoinAccount } from '@suite-common/wallet-utils';
 
 export interface ExportActionProps {
     account: Account;
@@ -28,7 +28,7 @@ export const ExportAction = ({ account }: ExportActionProps) => {
 
     const getAccountTitle = useCallback(() => {
         if (account.accountType === 'coinjoin') {
-            return translationString(getTitleForCoinJoinAccount(account.symbol));
+            return translationString(getTitleForCoinjoinAccount(account.symbol));
         }
         return translationString('LABELING_ACCOUNT', {
             networkName: translationString(getTitleForNetwork(account.symbol)),

--- a/packages/transport/scripts/protobuf-patches/TxInputType.js
+++ b/packages/transport/scripts/protobuf-patches/TxInputType.js
@@ -15,7 +15,7 @@ type CommonTxInputType = {
     orig_index?: number, // RBF
     decred_staking_spend?: DecredStakingSpendType,
     script_pubkey?: string, // required if script_type=EXTERNAL
-    coinjoin_flags?: number, // bit field of CoinJoin-specific flags
+    coinjoin_flags?: number, // bit field of coinjoin-specific flags
     script_sig?: string, // used by EXTERNAL, depending on script_pubkey
     witness?: string, // used by EXTERNAL, depending on script_pubkey
     ownership_proof?: string, // used by EXTERNAL, depending on script_pubkey

--- a/packages/transport/src/types/messages.ts
+++ b/packages/transport/src/types/messages.ts
@@ -301,7 +301,7 @@ type CommonTxInputType = {
     orig_index?: number; // RBF
     decred_staking_spend?: DecredStakingSpendType;
     script_pubkey?: string; // required if script_type=EXTERNAL
-    coinjoin_flags?: number; // bit field of CoinJoin-specific flags
+    coinjoin_flags?: number; // bit field of coinjoin-specific flags
     script_sig?: string; // used by EXTERNAL, depending on script_pubkey
     witness?: string; // used by EXTERNAL, depending on script_pubkey
     ownership_proof?: string; // used by EXTERNAL, depending on script_pubkey

--- a/suite-common/connect-init/src/connectInitThunks.ts
+++ b/suite-common/connect-init/src/connectInitThunks.ts
@@ -62,7 +62,7 @@ export const connectInitThunk = createThunk(
             'backupDevice',
             'recoveryDevice',
             'checkFirmwareAuthenticity',
-            'authorizeCoinJoin',
+            'authorizeCoinjoin',
             'getOwnershipProof',
             'setBusy',
         ] as const;

--- a/suite-common/test-utils/src/mocks.ts
+++ b/suite-common/test-utils/src/mocks.ts
@@ -285,7 +285,7 @@ const getTrezorConnect = <M>(methods?: M) => {
                 ...getFixture(),
                 _params,
             })),
-            authorizeCoinJoin: jest.fn(async _params => ({
+            authorizeCoinjoin: jest.fn(async _params => ({
                 success: false,
                 ...getFixture(),
                 _params,

--- a/suite-common/wallet-config/src/networksConfig.ts
+++ b/suite-common/wallet-config/src/networksConfig.ts
@@ -17,22 +17,18 @@ export const networks = {
         customBackends: ['blockbook', 'electrum'],
         accountTypes: {
             coinjoin: {
-                name: 'Bitcoin (CoinJoin)',
                 bip43Path: "m/10025'/0'/i'/1'", // https://github.com/satoshilabs/slips/blob/master/slip-0025.md#public-key-derivation
                 backendType: 'coinjoin', // use non-standard backend
                 features: ['amount-unit'], // no rbf, no sign-verify
             },
             taproot: {
-                name: 'Bitcoin (Taproot)',
                 bip43Path: "m/86'/0'/i'",
                 features: ['rbf', 'amount-unit'], // no sign-verify
             },
             segwit: {
-                name: 'Bitcoin (Legacy Segwit)',
                 bip43Path: "m/49'/0'/i'",
             },
             legacy: {
-                name: 'Bitcoin (Legacy)',
                 bip43Path: "m/44'/0'/i'",
             },
         },
@@ -51,11 +47,9 @@ export const networks = {
         customBackends: ['blockbook'],
         accountTypes: {
             segwit: {
-                name: 'Litecoin (segwit)',
                 bip43Path: "m/49'/2'/i'",
             },
             legacy: {
-                name: 'Litecoin (legacy)',
                 bip43Path: "m/44'/2'/i'",
             },
         },
@@ -130,7 +124,6 @@ export const networks = {
         customBackends: ['blockbook'],
         accountTypes: {
             legacy: {
-                name: 'Bitcoin Gold (legacy)',
                 bip43Path: "m/44'/156'/i'",
             },
         },
@@ -161,7 +154,6 @@ export const networks = {
         customBackends: ['blockbook'],
         accountTypes: {
             legacy: {
-                name: 'DigiByte (legacy)',
                 bip43Path: "m/44'/20'/i'",
             },
         },
@@ -205,11 +197,9 @@ export const networks = {
         customBackends: ['blockbook'],
         accountTypes: {
             segwit: {
-                name: 'Vertcoin (segwit)',
                 bip43Path: "m/49'/28'/i'",
             },
             legacy: {
-                name: 'Vertcoin (legacy)',
                 bip43Path: "m/44'/28'/i'",
             },
         },
@@ -243,22 +233,18 @@ export const networks = {
         customBackends: ['blockbook', 'electrum'],
         accountTypes: {
             coinjoin: {
-                name: 'Bitcoin Testnet (CoinJoin)',
                 bip43Path: "m/10025'/1'/i'/1'", // https://github.com/satoshilabs/slips/blob/master/slip-0025.md#public-key-derivation
                 backendType: 'coinjoin', // use non-standard backend
                 features: ['amount-unit'], // no rbf, no sign-verify
             },
             taproot: {
-                name: 'Bitcoin Testnet (taproot)',
                 bip43Path: "m/86'/1'/i'",
                 features: ['rbf', 'amount-unit'], // no sign-verify
             },
             segwit: {
-                name: 'Bitcoin Testnet (segwit)',
                 bip43Path: "m/49'/1'/i'",
             },
             legacy: {
-                name: 'Bitcoin Testnet (legacy)',
                 bip43Path: "m/44'/1'/i'",
             },
         },
@@ -278,22 +264,18 @@ export const networks = {
         customBackends: ['blockbook', 'electrum'],
         accountTypes: {
             coinjoin: {
-                name: 'Bitcoin Regtest (CoinJoin)',
                 bip43Path: "m/10025'/1'/i'/1'", // https://github.com/satoshilabs/slips/blob/master/slip-0025.md#public-key-derivation
                 backendType: 'coinjoin', // use non-standard backend
                 features: ['amount-unit'], // no rbf, no sign-verify
             },
             taproot: {
-                name: 'Bitcoin Regtest (taproot)',
                 bip43Path: "m/86'/1'/i'",
                 features: ['rbf', 'amount-unit'], // no sign-verify
             },
             segwit: {
-                name: 'Bitcoin Regtest (segwit)',
                 bip43Path: "m/49'/1'/i'",
             },
             legacy: {
-                name: 'Bitcoin Regtest (legacy)',
                 bip43Path: "m/44'/1'/i'",
             },
         },

--- a/suite-common/wallet-utils/src/__tests__/accountUtils.test.ts
+++ b/suite-common/wallet-utils/src/__tests__/accountUtils.test.ts
@@ -12,7 +12,7 @@ import {
     getFirstFreshAddress,
     getNetwork,
     getTitleForNetwork,
-    getTitleForCoinJoinAccount,
+    getTitleForCoinjoinAccount,
     getUtxoFromSignedTransaction,
     getNetworkFeatures,
     hasNetworkFeatures,
@@ -72,7 +72,7 @@ describe('account utils', () => {
     describe('get title for coinjoin accounts', () => {
         fixtures.accountTitleCoinjoinFixture.forEach((fixture: any) => {
             it(fixture.symbol, () => {
-                expect(getTitleForCoinJoinAccount(fixture.symbol)).toBe(fixture.title);
+                expect(getTitleForCoinjoinAccount(fixture.symbol)).toBe(fixture.title);
             });
         });
     });
@@ -237,7 +237,7 @@ describe('account utils', () => {
 
         const ethAcc = testMocks.getWalletAccount();
 
-        const coinJoinAcc = testMocks.getWalletAccount({
+        const coinjoinAcc = testMocks.getWalletAccount({
             networkType: 'bitcoin',
             symbol: 'regtest',
             accountType: 'coinjoin',
@@ -246,7 +246,7 @@ describe('account utils', () => {
         expect(getNetworkFeatures(btcAcc)).toEqual(['rbf', 'sign-verify', 'amount-unit']);
         expect(getNetworkFeatures(btcTaprootAcc)).toEqual(['rbf', 'amount-unit']);
         expect(getNetworkFeatures(ethAcc)).toEqual(['rbf', 'sign-verify', 'tokens']);
-        expect(getNetworkFeatures(coinJoinAcc)).toEqual(['amount-unit']);
+        expect(getNetworkFeatures(coinjoinAcc)).toEqual(['amount-unit']);
     });
 
     it('hasNetworkFeatures', () => {

--- a/suite-common/wallet-utils/src/accountUtils.ts
+++ b/suite-common/wallet-utils/src/accountUtils.ts
@@ -93,7 +93,7 @@ export const getFiatValue = (amount: string, rate: string, fixedTo = 2) => {
     return fiatValue;
 };
 
-export const getTitleForCoinJoinAccount = (symbol: NetworkSymbol) => {
+export const getTitleForCoinjoinAccount = (symbol: NetworkSymbol) => {
     switch (symbol.toLowerCase()) {
         case 'btc':
             return 'TR_NETWORK_COINJOIN_BITCOIN';


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

- remove account type names from Suite
  - They are used only in New Account modal in badge where it is duplicit in UI and meant to be deleted long time ago https://github.com/trezor/trezor-suite/issues/4067
- Unify coinjoin naming - small caps everywhere
 
## Related Issue

Resolve https://github.com/trezor/trezor-suite/issues/7365#issuecomment-1418883921

## Screenshots:
before:
<img src="https://user-images.githubusercontent.com/3729633/217003029-a5372648-b0a4-4b36-8d82-e4d04680ac01.png" width="300px" />
after:
<img src="https://user-images.githubusercontent.com/3729633/217003049-92694120-1094-4829-8bc2-8782db11dec0.png" width="300px" />
