### PR TITLE
fix(suite): make the empty account info section non-collapsible

### DIFF
--- a/packages/suite/src/actions/suite/constants/suiteConstants.ts
+++ b/packages/suite/src/actions/suite/constants/suiteConstants.ts
@@ -24,7 +24,6 @@ export const ADD_BUTTON_REQUEST = '@suite/add-button-request';
 export const SET_PROCESS_MODE = '@suite/set-process-mode';
 export const SET_THEME = '@suite/set-theme';
 export const SET_AUTODETECT = '@suite/set-autodetect';
-export const SHOW_COINJOIN_EXPLANATION = '@suite/show-coinjoin-explanation';
 export const COINJOIN_CEX_WARNING = '@suite/coinjoin-cex-warning';
 export const LOCK_UI = '@suite/lock-ui';
 export const LOCK_DEVICE = '@suite/lock-device';

--- a/packages/suite/src/actions/suite/storageActions.ts
+++ b/packages/suite/src/actions/suite/storageActions.ts
@@ -57,7 +57,6 @@ export const saveCoinjoinAccount =
 const removeCoinjoinRelatedSetting = (state: AppState) => {
     const settings = { ...state.suite.settings };
 
-    settings.isCoinjoinExplanationHidden = false;
     settings.isCoinjoinCexWarningHidden = false;
 
     db.addItem(

--- a/packages/suite/src/actions/suite/suiteActions.ts
+++ b/packages/suite/src/actions/suite/suiteActions.ts
@@ -60,7 +60,6 @@ export type SuiteAction =
     | { type: typeof SUITE.TOR_STATUS; payload: TorStatus }
     | { type: typeof SUITE.TOR_BOOTSTRAP; payload: TorBootstrap | null }
     | { type: typeof SUITE.ONION_LINKS; payload: boolean }
-    | { type: typeof SUITE.SHOW_COINJOIN_EXPLANATION; payload: boolean }
     | { type: typeof SUITE.COINJOIN_CEX_WARNING; payload: boolean }
     | { type: typeof SUITE.LOCK_UI; payload: boolean }
     | ReturnType<typeof lockDevice>
@@ -274,15 +273,6 @@ export const setTorBootstrapSlow =
             payload,
         });
     };
-
-export const toggleCoinjoinExplanation = () => (dispatch: Dispatch, getState: GetState) => {
-    const currentState = getState().suite.settings.isCoinjoinExplanationHidden;
-
-    dispatch({
-        type: SUITE.SHOW_COINJOIN_EXPLANATION,
-        payload: !currentState,
-    });
-};
 
 export const hideCoinjoinCexWarning = () => (dispatch: Dispatch) =>
     dispatch({

--- a/packages/suite/src/components/wallet/CoinjoinExplanation/index.tsx
+++ b/packages/suite/src/components/wallet/CoinjoinExplanation/index.tsx
@@ -1,17 +1,24 @@
 import React from 'react';
 import styled from 'styled-components';
-import { useDispatch } from 'react-redux';
 import { darken } from 'polished';
-import { Button, CollapsibleBox, Icon, variables } from '@trezor/components';
+import { Button, Icon, variables } from '@trezor/components';
 import { HELP_CENTER_COINJOIN_URL } from '@trezor/urls';
 import { Translation, TrezorLink } from '@suite-components';
-import { useSelector } from '@suite-hooks/useSelector';
-import { toggleCoinjoinExplanation } from '@suite-actions/suiteActions';
 import { ProcessStep, ProcessStepProps } from './ProcessStep';
 
-const Container = styled(CollapsibleBox)`
+const Container = styled.div`
+    padding: 20px 20px 16px;
     border-radius: 14px;
     background: ${({ theme }) => theme.STROKE_GREY};
+`;
+
+const Heading = styled.div`
+    display: flex;
+    align-items: center;
+    margin-bottom: 18px;
+    font-size: ${variables.FONT_SIZE.SMALL};
+    font-weight: ${variables.FONT_WEIGHT.MEDIUM};
+    color: ${({ theme }) => theme.TYPE_LIGHT_GREY};
 `;
 
 const QuestionIcon = styled(Icon)`
@@ -75,42 +82,25 @@ const STEPS: Array<Omit<ProcessStepProps, 'number'>> = [
     },
 ];
 
-export const CoinjoinExplanation = () => {
-    const isCoinjoinExplanationHidden = useSelector(
-        state => state.suite.settings.isCoinjoinExplanationHidden,
-    );
+export const CoinjoinExplanation = () => (
+    <Container>
+        <Heading>
+            <QuestionIcon icon="QUESTION" size={15} />
+            <Translation id="TR_COINJOIN_EXPLANATION_TITLE" />
+        </Heading>
 
-    const dispatch = useDispatch();
+        <Steps>
+            {STEPS.map((step, index) => (
+                <ProcessStep number={index + 1} key={step.image} {...step} />
+            ))}
+        </Steps>
 
-    return (
-        <Container
-            heading={
-                <>
-                    <QuestionIcon icon="QUESTION" size={15} />
-                    <Translation id="TR_COINJOIN_EXPLANATION_TITLE" />
-                </>
-            }
-            opened={!isCoinjoinExplanationHidden}
-            onCollapse={() => dispatch(toggleCoinjoinExplanation())}
-            variant="small"
-        >
-            <Steps>
-                {STEPS.map((step, index) => (
-                    <ProcessStep number={index + 1} key={step.image} {...step} />
-                ))}
-            </Steps>
-
-            <ButtonContainer>
-                <TrezorLink href={HELP_CENTER_COINJOIN_URL} variant="nostyle">
-                    <StyledButton icon="EXTERNAL_LINK">
-                        <Translation id="TR_LEARN_MORE" />
-                    </StyledButton>
-                </TrezorLink>
-
-                <Button onClick={() => dispatch(toggleCoinjoinExplanation())}>
-                    <Translation id="TR_GOT_IT" />
-                </Button>
-            </ButtonContainer>
-        </Container>
-    );
-};
+        <ButtonContainer>
+            <TrezorLink href={HELP_CENTER_COINJOIN_URL} variant="nostyle">
+                <StyledButton icon="EXTERNAL_LINK">
+                    <Translation id="TR_LEARN_MORE" />
+                </StyledButton>
+            </TrezorLink>
+        </ButtonContainer>
+    </Container>
+);

--- a/packages/suite/src/middlewares/wallet/storageMiddleware.ts
+++ b/packages/suite/src/middlewares/wallet/storageMiddleware.ts
@@ -164,7 +164,6 @@ const storageMiddleware = (api: MiddlewareAPI<Dispatch, AppState>) => {
                 case SUITE.SET_AUTODETECT:
                     api.dispatch(storageActions.saveSuiteSettings());
                     break;
-                case SUITE.SHOW_COINJOIN_EXPLANATION:
                 case SUITE.COINJOIN_CEX_WARNING: {
                     const isWalletRemembered = api.getState().suite.device?.remember;
 

--- a/packages/suite/src/reducers/suite/suiteReducer.ts
+++ b/packages/suite/src/reducers/suite/suiteReducer.ts
@@ -1,4 +1,5 @@
 import produce from 'immer';
+import { memoizeWithArgs, memoize } from 'proxy-memoize';
 import { TRANSPORT, TransportInfo, ConnectSettings } from '@trezor/connect';
 import { SuiteThemeVariant } from '@trezor/suite-desktop-api';
 import { Action, TrezorDevice, Lock, TorBootstrap, TorStatus } from '@suite-types';
@@ -16,7 +17,6 @@ import type { InvityServerEnvironment } from '@suite-common/invity';
 import { getDeviceModel } from '@trezor/device-utils';
 import { getStatus } from '@suite-utils/device';
 import { getIsTorEnabled, getIsTorLoading } from '@suite-utils/tor';
-import { memoizeWithArgs, memoize } from 'proxy-memoize';
 
 export interface SuiteRootState {
     suite: SuiteState;
@@ -65,7 +65,6 @@ export interface SuiteSettings {
     };
     language: Locale;
     torOnionLinks: boolean;
-    isCoinjoinExplanationHidden: boolean;
     isCoinjoinCexWarningHidden: boolean;
     debug: DebugModeOptions;
     autodetect: AutodetectSettings;
@@ -108,7 +107,6 @@ const initialState: SuiteState = {
         },
         language: ensureLocale('en'),
         torOnionLinks: isWeb(),
-        isCoinjoinExplanationHidden: false,
         isCoinjoinCexWarningHidden: false,
         debug: {
             invityServerEnvironment: undefined,
@@ -218,9 +216,6 @@ const suiteReducer = (state: SuiteState = initialState, action: Action): SuiteSt
                 draft.settings.torOnionLinks = action.payload;
                 break;
 
-            case SUITE.SHOW_COINJOIN_EXPLANATION:
-                draft.settings.isCoinjoinExplanationHidden = action.payload;
-                break;
             case SUITE.COINJOIN_CEX_WARNING:
                 draft.settings.isCoinjoinCexWarningHidden = action.payload;
                 break;


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

* make the empty account info section non-collapsible

## Related Issue

Resolve [#7012](https://github.com/trezor/trezor-suite/issues/7012)

## Screenshots:

<img width="600" alt="image" src="https://user-images.githubusercontent.com/45338719/217259044-29fc8933-bb48-471c-872e-ac399a2a37a9.png">
