### PR TITLE
fix(coinjoin): revert coinJoinFeeRateMedians caps because it's a value from coordinator

### DIFF
--- a/packages/coinjoin/src/types/coordinator.ts
+++ b/packages/coinjoin/src/types/coordinator.ts
@@ -5,7 +5,7 @@ export type AffiliationFlag = typeof AFFILIATION_FLAG;
 
 export interface CoinjoinStatus {
     roundStates: Round[];
-    coinjoinFeeRateMedians: FeeRateMedians[];
+    coinJoinFeeRateMedians: FeeRateMedians[];
     affiliateInformation?: {
         runningAffiliateServers: AffiliationFlag[];
         coinjoinRequests: Record<string, Record<AffiliationFlag, string>>;

--- a/packages/coinjoin/src/utils/roundUtils.ts
+++ b/packages/coinjoin/src/utils/roundUtils.ts
@@ -165,15 +165,15 @@ const getDataFromRounds = (rounds: Round[]) => {
  * - maxMiningFee: array => value in kvBytes
  */
 export const transformStatus = ({
-    coinjoinFeeRateMedians,
+    coinJoinFeeRateMedians,
     roundStates: rounds,
 }: CoinjoinStatus) => {
     const { allowedInputAmounts, coordinationFeeRate } = getDataFromRounds(rounds);
-    // coinjoinFeeRateMedians include an array of medians per day, week and month - we take the second (week) median as the recommended fee rate
-    const recommendedMedian = coinjoinFeeRateMedians[1];
+    // coinJoinFeeRateMedians include an array of medians per day, week and month - we take the second (week) median as the recommended fee rate
+    const recommendedMedian = coinJoinFeeRateMedians[1];
     // the value is converted from kvBytes (kilo virtual bytes) to vBytes (how the value is displayed in UI)
     const maxMiningFee = recommendedMedian
-        ? Math.round(coinjoinFeeRateMedians[1].medianFeeRate / 1000)
+        ? Math.round(coinJoinFeeRateMedians[1].medianFeeRate / 1000)
         : MAX_MINING_FEE;
 
     return {

--- a/packages/coinjoin/tests/client/CoinjoinClient.test.ts
+++ b/packages/coinjoin/tests/client/CoinjoinClient.test.ts
@@ -22,7 +22,7 @@ describe(`CoinjoinClient`, () => {
             if (url.endsWith('/status')) {
                 resolve({
                     roundStates: [DEFAULT_ROUND],
-                    coinjoinFeeRateMedians: [],
+                    coinJoinFeeRateMedians: [],
                     affiliateInformation: AFFILIATE_INFO,
                 });
             }

--- a/packages/coinjoin/tests/fixtures/round.fixture.ts
+++ b/packages/coinjoin/tests/fixtures/round.fixture.ts
@@ -95,7 +95,7 @@ export const AFFILIATE_INFO = {
 export const STATUS_EVENT = {
     roundStates: [],
     affiliateInformation: AFFILIATE_INFO,
-    coinjoinFeeRateMedians: FEE_RATE_MEDIANS,
+    coinJoinFeeRateMedians: FEE_RATE_MEDIANS,
 };
 
 type CJRoundOptions = ConstructorParameters<typeof CoinjoinRound>[1];

--- a/packages/coinjoin/tests/mocks/server.ts
+++ b/packages/coinjoin/tests/mocks/server.ts
@@ -67,7 +67,7 @@ const DEFAULT = {
     // coordinator
     status: {
         roundStates: [DEFAULT_ROUND],
-        coinjoinFeeRateMedians: FEE_RATE_MEDIANS,
+        coinJoinFeeRateMedians: FEE_RATE_MEDIANS,
         affiliateInformation: AFFILIATE_INFO,
     },
     'input-registration': {


### PR DESCRIPTION

## Description

`coinJoinFeeRateMedians` can't be changed to `coinjoinFeeRateMedians` in Suite because it comes from coordinator
