### PR TITLE
feat(suite-native): show logs

### DIFF
--- a/suite-native/module-dev-utils/package.json
+++ b/suite-native/module-dev-utils/package.json
@@ -13,8 +13,10 @@
     "dependencies": {
         "@react-navigation/core": "^6.2.2",
         "@react-navigation/stack": "^6.2.2",
+        "@suite-common/logger": "workspace:*",
         "@suite-native/atoms": "workspace:*",
         "@suite-native/config": "workspace:*",
+        "@suite-native/helpers": "workspace:*",
         "@suite-native/module-settings": "workspace:*",
         "@suite-native/navigation": "workspace:*",
         "@suite-native/storage": "workspace:*",
@@ -22,7 +24,8 @@
         "@trezor/styles": "workspace:*",
         "@trezor/theme": "workspace:*",
         "react": "18.2.0",
-        "react-native": "0.70.5"
+        "react-native": "0.70.5",
+        "react-redux": "7.2.2"
     },
     "devDependencies": {
         "jest": "^26.6.3",

--- a/suite-native/module-dev-utils/src/screens/DevUtilsScreen.tsx
+++ b/suite-native/module-dev-utils/src/screens/DevUtilsScreen.tsx
@@ -104,9 +104,15 @@ export const DevUtilsScreen = ({
                             />
                         </Card>
 
-                        <Button onPress={() => setAreLogsVisible(!areLogsVisible)}>
-                            {!areLogsVisible ? 'Show Logs' : 'Hide Logs'}
-                        </Button>
+                        <Card>
+                            <Box flexDirection="row" justifyContent="space-between">
+                                <Text>Show logs</Text>
+                                <CheckBox
+                                    isChecked={areLogsVisible}
+                                    onChange={() => setAreLogsVisible(!areLogsVisible)}
+                                />
+                            </Box>
+                        </Card>
                         <Button onPress={() => navigation.navigate(DevUtilsStackRoutes.Demo)}>
                             See Component Demo
                         </Button>

--- a/suite-native/module-dev-utils/src/screens/DevUtilsScreen.tsx
+++ b/suite-native/module-dev-utils/src/screens/DevUtilsScreen.tsx
@@ -1,5 +1,6 @@
-import React from 'react';
+import React, { useState } from 'react';
 import { TouchableOpacity } from 'react-native';
+import { useSelector } from 'react-redux';
 
 import { isDebugEnv, isDevelopOrDebugEnv } from '@suite-native/config';
 import { Box, Button, Card, CheckBox, Text, useDebugView, VStack } from '@suite-native/atoms';
@@ -10,6 +11,8 @@ import {
     DevUtilsStackRoutes,
 } from '@suite-native/navigation';
 import { purgeStorage, useStoragePersistor } from '@suite-native/storage';
+import { selectLogs } from '@suite-common/logger';
+import { useCopyToClipboard } from '@suite-native/helpers';
 
 import { BuildInfo } from '../components/BuildInfo';
 
@@ -35,6 +38,22 @@ const DevCheckBoxListItem = ({
     </TouchableOpacity>
 );
 
+const Log = () => {
+    const logs = useSelector(selectLogs);
+    const copyToClipboard = useCopyToClipboard();
+
+    const handleCopy = async () => {
+        await copyToClipboard(JSON.stringify(logs), 'Logs copied to clipboard.');
+    };
+
+    return (
+        <Box>
+            <Text>{JSON.stringify(logs)}</Text>
+            <Button onPress={handleCopy}>Copy</Button>
+        </Box>
+    );
+};
+
 export const DevUtilsScreen = ({
     navigation,
 }: StackProps<DevUtilsStackParamList, DevUtilsStackRoutes.DevUtils>) => {
@@ -45,6 +64,7 @@ export const DevUtilsScreen = ({
         isFlashOnRerenderEnabled,
         isRerenderCountEnabled,
     } = useDebugView();
+    const [areLogsVisible, setAreLogsVisible] = useState(false);
 
     const handleResetStorage = () => {
         purgeStorage(persistor);
@@ -84,12 +104,17 @@ export const DevUtilsScreen = ({
                             />
                         </Card>
 
+                        <Button onPress={() => setAreLogsVisible(!areLogsVisible)}>
+                            {!areLogsVisible ? 'Show Logs' : 'Hide Logs'}
+                        </Button>
                         <Button onPress={() => navigation.navigate(DevUtilsStackRoutes.Demo)}>
                             See Component Demo
                         </Button>
                         <Button colorScheme="primary" onPress={handleResetStorage}>
                             Reset storage
                         </Button>
+
+                        {areLogsVisible && <Log />}
                     </VStack>
                 </Box>
             ) : null}

--- a/suite-native/module-dev-utils/tsconfig.json
+++ b/suite-native/module-dev-utils/tsconfig.json
@@ -2,8 +2,10 @@
     "extends": "../../tsconfig.json",
     "compilerOptions": { "outDir": "libDev" },
     "references": [
+        { "path": "../../suite-common/logger" },
         { "path": "../atoms" },
         { "path": "../config" },
+        { "path": "../helpers" },
         { "path": "../module-settings" },
         { "path": "../navigation" },
         { "path": "../storage" },

--- a/yarn.lock
+++ b/yarn.lock
@@ -6553,8 +6553,10 @@ __metadata:
   dependencies:
     "@react-navigation/core": ^6.2.2
     "@react-navigation/stack": ^6.2.2
+    "@suite-common/logger": "workspace:*"
     "@suite-native/atoms": "workspace:*"
     "@suite-native/config": "workspace:*"
+    "@suite-native/helpers": "workspace:*"
     "@suite-native/module-settings": "workspace:*"
     "@suite-native/navigation": "workspace:*"
     "@suite-native/storage": "workspace:*"
@@ -6564,6 +6566,7 @@ __metadata:
     jest: ^26.6.3
     react: 18.2.0
     react-native: 0.70.5
+    react-redux: 7.2.2
     typescript: 4.9.3
   languageName: unknown
   linkType: soft


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Add logs as plain strings to dev utils in the mobile app. Logs can be copied to clipboard.

## Related Issue
No need for issue nor testing as this will be expanded to be able to export logs in future.

## Screenshots:
<img width="414" alt="image" src="https://user-images.githubusercontent.com/36101761/217515551-14c0995b-ce74-4776-9c08-eabe15e2cb57.png">
<img width="412" alt="image" src="https://user-images.githubusercontent.com/36101761/217515609-7018966e-24b9-4e04-b84e-80f77c0ced86.png">

