### PR TITLE
Make use of Note component

### DIFF
--- a/packages/components/src/components/Note/Note.stories.tsx
+++ b/packages/components/src/components/Note/Note.stories.tsx
@@ -12,7 +12,12 @@ export default {
         className: {
             control: false,
         },
+        color: {
+            control: 'color',
+        },
     },
 };
 
-export const Basic: ComponentStory<typeof Note> = args => <Note>{args.children}</Note>;
+export const Basic: ComponentStory<typeof Note> = args => (
+    <Note color={args.color}>{args.children}</Note>
+);

--- a/packages/components/src/components/Note/Note.tsx
+++ b/packages/components/src/components/Note/Note.tsx
@@ -1,30 +1,39 @@
 import React from 'react';
-import styled from 'styled-components';
+import styled, { useTheme } from 'styled-components';
 
 import { Icon } from '../Icon';
 import { FONT_SIZE, FONT_WEIGHT } from '../../config/variables';
 
 const Row = styled.div`
-    align-items: center;
     display: flex;
     gap: 6px;
 `;
 
-const P = styled.p`
-    color: ${({ theme }) => theme.TYPE_LIGHT_GREY};
+const InfoIcon = styled(Icon)`
+    margin-top: 1px;
+`;
+
+const P = styled.p<{ $color?: string }>`
+    color: ${({ $color }) => $color};
     font-size: ${FONT_SIZE.SMALL};
     font-weight: ${FONT_WEIGHT.MEDIUM};
-    margin-top: 2px;
 `;
 
 interface NoteProps {
     children: React.ReactNode;
     className?: string;
+    color?: string;
 }
 
-export const Note = ({ children, className }: NoteProps) => (
-    <Row className={className}>
-        <Icon icon="INFO" size={14} />
-        <P>{children}</P>
-    </Row>
-);
+export const Note = ({ children, className, color }: NoteProps) => {
+    const theme = useTheme();
+
+    const noteColor = color || theme.TYPE_LIGHT_GREY;
+
+    return (
+        <Row className={className}>
+            <InfoIcon icon="INFO" size={14} color={noteColor} />
+            <P $color={noteColor}>{children}</P>
+        </Row>
+    );
+};

--- a/packages/suite/src/components/firmware/FirmwareInitial.tsx
+++ b/packages/suite/src/components/firmware/FirmwareInitial.tsx
@@ -1,7 +1,7 @@
 import React, { useEffect, useState } from 'react';
 import styled from 'styled-components';
 
-import { useTheme, Icon } from '@trezor/components';
+import { Note } from '@trezor/components';
 import {
     ConnectDevicePromptManager,
     OnboardingStepBox,
@@ -14,13 +14,11 @@ import { FirmwareType, TrezorDevice } from '@suite-types';
 import { getFwUpdateVersion } from '@suite-utils/device';
 import { getFirmwareVersion, getDeviceModel } from '@trezor/device-utils';
 
-const InfoRow = styled.div`
+const Description = styled.div`
     align-items: center;
     display: flex;
-    font-weight: 600;
-    gap: 4px;
-    margin: 8px auto 0 auto;
-    max-width: max-content;
+    flex-direction: column;
+    gap: 16px;
 `;
 
 const ButtonRow = styled.div`
@@ -91,7 +89,6 @@ export const FirmwareInitial = ({
     const { device: liveDevice } = useDevice();
     const { setStatus, status } = useFirmware();
     const { goToNextStep, updateAnalytics } = useOnboarding();
-    const theme = useTheme();
     const devices = useSelector(state => state.devices);
 
     // todo: move to utils device.ts
@@ -153,13 +150,12 @@ export const FirmwareInitial = ({
         content = {
             heading: <Translation id="TR_INSTALL_BITCOIN_FW" />,
             description: (
-                <>
+                <Description>
                     <Translation id="TR_FIRMWARE_SUBHEADING_BITCOIN" />
-                    <InfoRow>
-                        <Icon size={12} color={theme.TYPE_LIGHT_GREY} icon="INFO" />
+                    <Note>
                         <Translation id="TR_CHANGE_FIRMWARE_TYPE_ANYTIME" />
-                    </InfoRow>
-                </>
+                    </Note>
+                </Description>
             ),
             body: cachedDevice?.firmwareRelease ? (
                 <FirmwareOffer device={cachedDevice} />

--- a/packages/suite/src/components/wallet/Fees/components/CustomFee.tsx
+++ b/packages/suite/src/components/wallet/Fees/components/CustomFee.tsx
@@ -1,8 +1,8 @@
 import React from 'react';
 import BigNumber from 'bignumber.js';
-import styled, { css, useTheme } from 'styled-components';
+import styled, { css } from 'styled-components';
 import { UseFormMethods } from 'react-hook-form';
-import { Input, Button, variables, Icon } from '@trezor/components';
+import { Input, Button, Note, variables } from '@trezor/components';
 import { FeeLevel } from '@trezor/connect';
 import { Translation } from '@suite-components';
 import { InputError } from '@wallet-components';
@@ -67,18 +67,6 @@ const StyledButton = styled(Button)`
     background: none;
 `;
 
-const FeeRateWarning = styled.div`
-    display: flex;
-    align-items: center;
-    font-size: ${variables.FONT_SIZE.TINY};
-    font-weight: ${variables.FONT_WEIGHT.MEDIUM};
-    color: ${({ theme }) => theme.TYPE_LIGHT_GREY};
-
-    > :first-child {
-        margin-right: 8px;
-    }
-`;
-
 // feeLimit error notification button
 const SetDefaultLimit = ({ onClick }: { onClick: () => void }) => (
     <ButtonWrapper>
@@ -128,8 +116,6 @@ export const CustomFee = ({
     composedFeePerByte,
 }: CustomFeeProps) => {
     const { maxFee, minFee } = feeInfo;
-
-    const theme = useTheme();
 
     const feePerUnitValue = getValues(FEE_PER_UNIT);
     const feeLimitValue = getValues(FEE_LIMIT);
@@ -262,10 +248,9 @@ export const CustomFee = ({
             </Wrapper>
 
             {isComposedFeeRateDifferent && networkType === 'bitcoin' && (
-                <FeeRateWarning>
-                    <Icon icon="INFO" size={12} color={theme.TYPE_LIGHTER_GREY} />
+                <Note>
                     <Translation id="TR_FEE_ROUNDING_WARNING" />
-                </FeeRateWarning>
+                </Note>
             )}
         </div>
     );

--- a/packages/suite/src/components/wallet/PrivacyAccount/AnonymityLevelSlider.tsx
+++ b/packages/suite/src/components/wallet/PrivacyAccount/AnonymityLevelSlider.tsx
@@ -1,7 +1,7 @@
 import React, { useCallback, ChangeEventHandler, useMemo } from 'react';
 import styled, { css } from 'styled-components';
 import { AnimatePresence, HTMLMotionProps, motion } from 'framer-motion';
-import { Range, Warning, useTheme, motionEasing, Icon, variables } from '@trezor/components';
+import { Range, Warning, useTheme, motionEasing, Icon, Note } from '@trezor/components';
 import { Translation } from '@suite-components';
 import { useAnonymityStatus } from '@suite-hooks';
 import { AnonymityStatus } from '@suite-constants/coinjoin';
@@ -30,21 +30,13 @@ const Label = styled.span`
     }
 `;
 
-const DisabledMessage = styled.div`
+const StyledNote = styled(Note)`
     position: absolute;
-    display: inline-flex;
-    align-items: center;
-    justify-content: center;
-    width: 100%;
-    height: 100%;
-    color: ${({ theme }) => theme.TYPE_DARK_GREY};
-    font-weight: ${variables.FONT_WEIGHT.MEDIUM};
+    left: 50%;
+    top: 50%;
+    transform: translate(-50%, -50%);
     backdrop-filter: grayscale(0.5);
     filter: ${({ theme }) => `drop-shadow(0px 0px 8px ${theme.BG_LIGHT_GREY})`};
-
-    > :first-child {
-        margin-right: 6px;
-    }
 `;
 
 const RedText = styled.span`
@@ -193,10 +185,9 @@ export const AnonymityLevelSlider = ({
             </AnimatePresence>
 
             {isSessionActive && (
-                <DisabledMessage>
-                    <Icon icon="INFO" size={14} color={theme.TYPE_DARK_GREY} />
+                <StyledNote color={theme.TYPE_DARK_GREY}>
                     <Translation id="TR_DISABLED_ANONYMITY_CHANGE_MESSAGE" />
-                </DisabledMessage>
+                </StyledNote>
             )}
         </Container>
     );

--- a/packages/suite/src/views/wallet/coinmarket/p2p/form/P2pInfo.tsx
+++ b/packages/suite/src/views/wallet/coinmarket/p2p/form/P2pInfo.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import styled from 'styled-components';
 import { Translation } from '@suite-components';
-import { Icon, Tooltip, variables } from '@trezor/components';
+import { Note, Tooltip, variables } from '@trezor/components';
 
 const Wrapper = styled.div`
     display: flex;
@@ -10,37 +10,34 @@ const Wrapper = styled.div`
     color: ${({ theme }) => theme.TYPE_LIGHT_GREY};
 `;
 
-const StyledIcon = styled(Icon)`
-    margin-right: 8px;
-`;
-
 const StyledTooltip = styled(Tooltip)`
     display: inline-block;
 `;
 
 export const P2pInfo = () => (
     <Wrapper>
-        <StyledIcon icon="INFO" size={16} />
-        <Translation
-            id="TR_P2P_INFO"
-            values={{
-                peerToPeer: (
-                    <StyledTooltip
-                        content={<Translation id="TR_P2P_INFO_PEER_TO_PEER_TOOLTIP" />}
-                        dashed
-                    >
-                        <Translation id="TR_P2P_INFO_PEER_TO_PEER" />
-                    </StyledTooltip>
-                ),
-                multisigEscrow: (
-                    <StyledTooltip
-                        content={<Translation id="TR_P2P_INFO_MULTISIG_ESCROW_TOOLTIP" />}
-                        dashed
-                    >
-                        <Translation id="TR_P2P_INFO_MULTISIG_ESCROW" />
-                    </StyledTooltip>
-                ),
-            }}
-        />
+        <Note>
+            <Translation
+                id="TR_P2P_INFO"
+                values={{
+                    peerToPeer: (
+                        <StyledTooltip
+                            content={<Translation id="TR_P2P_INFO_PEER_TO_PEER_TOOLTIP" />}
+                            dashed
+                        >
+                            <Translation id="TR_P2P_INFO_PEER_TO_PEER" />
+                        </StyledTooltip>
+                    ),
+                    multisigEscrow: (
+                        <StyledTooltip
+                            content={<Translation id="TR_P2P_INFO_MULTISIG_ESCROW_TOOLTIP" />}
+                            dashed
+                        >
+                            <Translation id="TR_P2P_INFO_MULTISIG_ESCROW" />
+                        </StyledTooltip>
+                    ),
+                }}
+            />
+        </Note>
     </Wrapper>
 );

--- a/packages/suite/src/views/wallet/coinmarket/spend/components/Spend/index.tsx
+++ b/packages/suite/src/views/wallet/coinmarket/spend/components/Spend/index.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import styled from 'styled-components';
-import { Icon, Button } from '@trezor/components';
+
+import { Button, Note } from '@trezor/components';
 import { Translation } from '@suite-components';
 import { isDesktop } from '@suite-utils/env';
 import { useCoinmarketSpendContext } from '@wallet-hooks/useCoinmarketSpend';
@@ -16,10 +17,6 @@ const ProviderInfo = styled.div`
     align-items: center;
     margin-bottom: 15px;
     color: ${props => props.theme.TYPE_LIGHT_GREY};
-`;
-
-const StyledIcon = styled(Icon)`
-    padding-right: 4px;
 `;
 
 const IframeWrapper = styled.div`
@@ -40,21 +37,9 @@ const WebContent = styled.div`
 
 const IframeContent = styled.div``;
 
-const WebInfo = styled.div`
-    display: flex;
-    justify-content: center;
-`;
-
 const StyledButton = styled(Button)`
     margin-top: 25px;
 `;
-
-const Left = styled.div`
-    padding-right: 5px;
-    display: flex;
-`;
-
-const Right = styled.div``;
 
 const CoinmarketSpend = () => {
     const { isLoading, noProviders, voucherSiteUrl, openWindow, setShowLeaveModal } =
@@ -74,12 +59,9 @@ const CoinmarketSpend = () => {
                     {showIframe && (
                         <IframeContent>
                             <ProviderInfo>
-                                <Left>
-                                    <StyledIcon icon="INFO" />
-                                </Left>
-                                <Right>
+                                <Note>
                                     <Translation id="TR_SPEND_PROVIDER_CONTENT" />
-                                </Right>
+                                </Note>
                             </ProviderInfo>
                             <IframeWrapper>
                                 <iframe
@@ -98,14 +80,9 @@ const CoinmarketSpend = () => {
                     )}
                     {!showIframe && (
                         <WebContent>
-                            <WebInfo>
-                                <Left>
-                                    <StyledIcon icon="INFO" />
-                                </Left>
-                                <Right>
-                                    <Translation id="TR_SPEND_PROVIDER_CONTENT_WINDOW" />
-                                </Right>
-                            </WebInfo>
+                            <Note>
+                                <Translation id="TR_SPEND_PROVIDER_CONTENT_WINDOW" />
+                            </Note>
                             <StyledButton
                                 variant="primary"
                                 onClick={() => {


### PR DESCRIPTION
## Description

Unify typography and simplify code by using the new [Note](https://suite.corp.sldev.cz/components/develop/?path=/story/note--basic) component.

## Screenshots:
Before:
![Screenshot 2023-02-07 at 18 34 40](https://user-images.githubusercontent.com/42465546/217531107-ee6854b5-30f0-45d0-9b20-008cb355fc48.png)
![Screenshot 2023-02-07 at 18 38 58](https://user-images.githubusercontent.com/42465546/217531133-10167c21-b16d-4d77-b08d-95c8d0509bda.png)
![Screenshot 2023-02-07 at 19 04 18](https://user-images.githubusercontent.com/42465546/217531156-02f273f9-2ba4-4bd8-a436-eba77e255917.png)
![Screenshot 2023-02-08 at 12 01 57](https://user-images.githubusercontent.com/42465546/217531172-83270d23-48e7-4fa2-a314-1e04b02f19ca.png)
![Screenshot 2023-02-08 at 13 15 33](https://user-images.githubusercontent.com/42465546/217531188-9fcb6d92-c7cd-47a8-bb01-fc4999fdea95.png)
After:
![Screenshot 2023-02-07 at 18 36 10](https://user-images.githubusercontent.com/42465546/217531220-6b555d4e-8418-407c-879e-fffbe629d33d.png)
![Screenshot 2023-02-07 at 18 51 07](https://user-images.githubusercontent.com/42465546/217531250-1377e544-51f6-4556-add0-077647c8c1d2.png)
![Screenshot 2023-02-07 at 19 11 52](https://user-images.githubusercontent.com/42465546/217531269-ae4b556c-acc6-452b-8d11-63f69cdcf831.png)
![Screenshot 2023-02-08 at 13 13 46](https://user-images.githubusercontent.com/42465546/217531293-89b42568-df8e-413e-abea-c3445bbc6593.png)
![Screenshot 2023-02-08 at 13 17 36](https://user-images.githubusercontent.com/42465546/217531310-cf7c89b0-9fd6-476d-afad-17640578ddba.png)

**QA:** Nothing should change except small visual elements of the notes (size, positioning).

