### PR TITLE
chore(connect-examples): update webextension example

### DIFF
--- a/packages/connect-examples/webextension/manifest.json
+++ b/packages/connect-examples/webextension/manifest.json
@@ -17,7 +17,7 @@
     "content_scripts": [
         {
             "matches": ["*://connect.trezor.io/9/popup.html"],
-            "js": ["./node_modules/@trezor/connect-web/lib/webextension/trezor-content-script.js"]
+            "js": ["./vendor/trezor-content-script.js"]
         }
     ],
     "web_accessible_resources": ["icons/48.png"]

--- a/packages/connect-examples/webextension/package.json
+++ b/packages/connect-examples/webextension/package.json
@@ -2,8 +2,5 @@
     "name": "connect-example-webextension",
     "version": "1.0.0",
     "private": true,
-    "scripts": {},
-    "dependencies": {
-        "@trezor/connect-web": "workspace:9.0.6"
-    }
+    "dependencies": {}
 }

--- a/packages/connect-examples/webextension/update.js
+++ b/packages/connect-examples/webextension/update.js
@@ -7,16 +7,25 @@ const path = require('path');
 const fetch = require('node-fetch');
 
 const vendorPath = path.join(__dirname, 'vendor');
+const inlineScriptPath = path.join(vendorPath, 'trezor-connect.js');
+const usbPermissionsScriptPath = path.join(vendorPath, 'trezor-usb-permissions.js');
+const contentScriptPath = path.join(vendorPath, 'trezor-content-script.js');
 
-if (fs.existsSync(vendorPath)) {
-    fs.rmdirSync(vendorPath);
-    fs.mkdirSync(vendorPath);
-} else {
+if (!fs.existsSync(vendorPath)) {
     fs.mkdirSync(vendorPath);
 }
+
+[inlineScriptPath, contentScriptPath, usbPermissionsScriptPath].forEach(path => {
+    if (fs.existsSync(path)) {
+        fs.rmSync(path);
+    }
+});
 
 fetch('https://connect.trezor.io/9/trezor-connect.js')
     .then(response => response.text())
     .then(text => fs.writeFileSync(path.join(__dirname, 'vendor', 'trezor-connect.js'), text));
 
-// todo: copy trezor-usb-permissions?
+const srcPath = path.join(__dirname, '../../connect-web/src/webextension');
+
+fs.copyFileSync(path.join(srcPath, 'trezor-content-script.js'), contentScriptPath);
+fs.copyFileSync(path.join(srcPath, 'trezor-usb-permissions.js'), usbPermissionsScriptPath);


### PR DESCRIPTION
updating webextension example to use the latest connect and to actually work. please @karliatto check it out, it is based on your report from last week.

## QA
this does not affect production but you could try to make webextension locally based on  readme in `packages/connect-examples/webextension/README.md`. This will be useful in the future testing of connect