### PR TITLE
fix(coinjoin): selectRound occasionally picks blame round as candidate

### DIFF
--- a/packages/coinjoin/src/client/round/selectRound.ts
+++ b/packages/coinjoin/src/client/round/selectRound.ts
@@ -319,7 +319,7 @@ export const selectInputsForRound = async ({
 
     // get index of Round with maximum possble utxos
     const roundIndex = sumUtxosInRounds.findIndex(count => count === maxUtxosInRound);
-    const selectedRound = roundCandidates[roundIndex];
+    const selectedRound = normalRounds[roundIndex];
 
     // setup new Round
     accountCandidates.forEach((account, accountIndex) => {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
seen in testing logs

`selectRound` occasionally picks blame round as candidate because round index was used on unsorted array.

result: `InputNotWhitelisted` error in `input-registration`, nothing critical
