### PR TITLE
extend coinjoin logs

### DIFF
--- a/packages/coinjoin/src/backend/CoinjoinBackend.ts
+++ b/packages/coinjoin/src/backend/CoinjoinBackend.ts
@@ -8,7 +8,7 @@ import { scanAccount } from './scanAccount';
 import { scanAddress } from './scanAddress';
 import { getAccountInfo } from './getAccountInfo';
 import { getNetwork } from '../utils/settingsUtils';
-import type { CoinjoinBackendSettings } from '../types';
+import type { CoinjoinBackendSettings, LogEvent, Logger, LogLevel } from '../types';
 import type {
     ScanAddressParams,
     ScanAccountParams,
@@ -20,7 +20,7 @@ import type {
 } from '../types/backend';
 
 interface SimpleEvents {
-    log: string;
+    log: LogEvent;
 }
 
 interface DescriptorEvents {
@@ -67,7 +67,7 @@ export class CoinjoinBackend extends EventEmitter {
         super();
         this.settings = Object.freeze(settings);
         this.network = getNetwork(settings.network);
-        this.client = new CoinjoinBackendClient({ ...settings, log: this.log.bind(this) });
+        this.client = new CoinjoinBackendClient({ ...settings, logger: this.getLogger() });
         this.mempool = new CoinjoinMempoolController(this.client);
     }
 
@@ -158,7 +158,13 @@ export class CoinjoinBackend extends EventEmitter {
             });
     }
 
-    private log(message: string) {
-        this.emit('log', message);
+    private getLogger(): Logger {
+        const emit = (level: LogLevel) => (payload: string) => this.emit('log', { level, payload });
+        return {
+            debug: emit('debug'),
+            log: emit('log'),
+            warn: emit('warn'),
+            error: emit('error'),
+        };
     }
 }

--- a/packages/coinjoin/src/client/Alice.ts
+++ b/packages/coinjoin/src/client/Alice.ts
@@ -28,6 +28,7 @@ export class Alice {
     accountKey: string; // Account.accountKey
     scriptType: AllowedScriptTypes; // input scripType
     requested?: AlicePendingRequest; // pending request sent to wallet (Suite)
+    resolved: AlicePendingRequest[] = []; // resolved requests received from wallet (Suite)
     ownershipProof?: string; // data used in inputRegistration phase, received as response to RequestEvent, provided by wallet (Suite)
     registrationData?: RegistrationData; // data from inputRegistration phase
     affiliationFlag?: boolean; // affiliation flag is used in /ready-to-sign request **only** when Alice pays coordination fee
@@ -55,21 +56,30 @@ export class Alice {
         this.error = error;
     }
 
-    setRequest(type: AlicePendingRequest['type']): SerializedAlice;
-    setRequest(): undefined;
-    setRequest(type?: AlicePendingRequest['type']) {
-        if (type) {
-            this.requested = {
-                type,
-                timestamp: Date.now(),
-            };
-            return {
-                accountKey: this.accountKey,
-                path: this.path,
-                outpoint: this.outpoint,
-            };
+    setRequest(type: AlicePendingRequest['type']): SerializedAlice {
+        this.requested = {
+            type,
+            timestamp: Date.now(),
+        };
+        return {
+            accountKey: this.accountKey,
+            path: this.path,
+            outpoint: this.outpoint,
+        };
+    }
+
+    resolveRequest() {
+        if (this.requested) {
+            this.resolved.push({
+                type: this.requested.type,
+                timestamp: Date.now() - this.requested.timestamp,
+            });
+            this.requested = undefined;
         }
-        this.requested = undefined;
+    }
+
+    getResolvedRequest(type: AlicePendingRequest['type']) {
+        return this.resolved.find(r => r.type === type);
     }
 
     setOwnershipProof(proof: string) {

--- a/packages/coinjoin/src/client/CoinjoinClient.ts
+++ b/packages/coinjoin/src/client/CoinjoinClient.ts
@@ -277,4 +277,14 @@ export class CoinjoinClient extends EventEmitter {
             error: emit('error'),
         };
     }
+
+    getRounds() {
+        return this.rounds.map(round => round.toSerialized());
+    }
+
+    getRoundsInCriticalPhase() {
+        return this.rounds.flatMap(round =>
+            round.isInCriticalPhase() ? round.toSerialized() : [],
+        );
+    }
 }

--- a/packages/coinjoin/src/client/CoinjoinRound.ts
+++ b/packages/coinjoin/src/client/CoinjoinRound.ts
@@ -345,7 +345,7 @@ export class CoinjoinRound extends EventEmitter {
             const input = this.inputs.find(a => a.outpoint === i.outpoint);
             if (!input) return;
             // reset request in input
-            input.setRequest();
+            input.resolveRequest();
             if ('error' in i) {
                 log(`Resolving ${type} request for ~~${i.outpoint}~~ with error. ${i.error}`);
                 input.setError(new Error(i.error));

--- a/packages/coinjoin/src/client/CoinjoinRound.ts
+++ b/packages/coinjoin/src/client/CoinjoinRound.ts
@@ -440,4 +440,8 @@ export class CoinjoinRound extends EventEmitter {
             roundDeadline: this.roundDeadline,
         };
     }
+
+    isInCriticalPhase() {
+        return this.phase > RoundPhase.InputRegistration && this.phase < RoundPhase.Ended;
+    }
 }

--- a/packages/coinjoin/src/client/round/inputRegistration.ts
+++ b/packages/coinjoin/src/client/round/inputRegistration.ts
@@ -25,18 +25,19 @@ const registerInput = async (
     prison: CoinjoinPrison,
     options: CoinjoinRoundOptions,
 ): Promise<Alice> => {
+    const { logger } = options;
     if (input.error) {
-        options.log(`Trying to register input with error ${input.error}`);
+        logger.warn(`Trying to register input with error ${input.error}`);
         throw input.error;
     }
     // stop here and request for ownership proof from the wallet
     if (!input.ownershipProof) {
-        options.log(`Waiting for ~~${input.outpoint}~~ ownership proof`);
+        logger.log(`Waiting for ~~${input.outpoint}~~ ownership proof`);
         return input;
     }
 
     if (input.registrationData) {
-        options.log(`Input ~~${input.outpoint}~~ already registered. Skipping.`);
+        logger.log(`Input ~~${input.outpoint}~~ already registered. Skipping.`);
         return input;
     }
 
@@ -56,7 +57,7 @@ const registerInput = async (
     // note that this may cause that the input will not be registered if phase change before expected deadline
     const deadline = round.phaseDeadline - Date.now() - ROUND_SELECTION_REGISTRATION_OFFSET;
     const delay = deadline > 0 ? getRandomNumberInRange(0, deadline) : 0;
-    options.log(
+    logger.log(
         `Trying to register ~~${input.outpoint}~~ to ~~${round.id}~~ with delay ${delay}ms and deadline ${round.phaseDeadline}`,
     );
 
@@ -77,7 +78,7 @@ const registerInput = async (
             },
         )
         .catch(error => {
-            options.log(
+            logger.warn(
                 `Registration ~~${input.outpoint}~~ to ~~${round.id}~~ failed: ${error.message}`,
             );
             // catch specific error
@@ -142,10 +143,10 @@ const registerInput = async (
             { baseUrl: middlewareUrl },
         );
 
-        options.log(
+        logger.log(
             `Registration ~~${input.outpoint}~~ to ~~${round.id}~~ successful. aliceId: ${registrationData.aliceId}`,
         );
-        options.log(
+        logger.log(
             `~~${input.outpoint}~~ will pay ${coordinatorFee} coordinator fee and ${miningFee} mining fee`,
         );
 
@@ -175,7 +176,7 @@ export const inputRegistration = async (
 ) => {
     // try to register each input
     // failed inputs will be excluded from this round, successful will continue to phase: 1 (connectionConfirmation)
-    options.log(`inputRegistration: ~~${round.id}~~`);
+    options.logger.log(`inputRegistration: ~~${round.id}~~`);
     round.setSessionPhase(SessionPhase.CoinRegistration);
 
     const { inputs } = round;

--- a/packages/coinjoin/src/client/round/transactionSigning.ts
+++ b/packages/coinjoin/src/client/round/transactionSigning.ts
@@ -184,8 +184,14 @@ export const transactionSigning = async (
     } catch (error) {
         // NOTE: if anything goes wrong in this process this Round will be corrupted for all the users
         // registered inputs will probably be banned
+        const resolvedTime = round.inputs.map(i => {
+            const res = i.getResolvedRequest('signature');
+            return res?.timestamp || 'unresolved';
+        });
         round.setSessionPhase(SessionPhase.SignatureFailed);
-        logger.error(`Round signing failed: ${error.message}`);
+        logger.error(
+            `Round signing failed. Resolved time ${resolvedTime.join(',')}. with ${error.message}`,
+        );
 
         round.inputs.forEach(input => input.setError(error));
     }

--- a/packages/coinjoin/src/types/client.ts
+++ b/packages/coinjoin/src/types/client.ts
@@ -1,6 +1,7 @@
 import { SessionPhase } from '../enums';
 import { AllowedRange, CoordinationFeeRate, Round } from './coordinator';
 import { CoinjoinRequestEvent, CoinjoinRoundEvent } from './round';
+import { LogEvent } from './logger';
 
 export interface CoinjoinStatusEvent {
     rounds: Round[];
@@ -15,7 +16,7 @@ export interface CoinjoinClientEvents {
     round: CoinjoinRoundEvent;
     request: CoinjoinRequestEvent[];
     exception: string;
-    log: string;
+    log: LogEvent;
     'session-phase': {
         phase: SessionPhase;
         accountKeys: string[];

--- a/packages/coinjoin/src/types/index.ts
+++ b/packages/coinjoin/src/types/index.ts
@@ -20,3 +20,4 @@ export interface CoinjoinClientSettings extends BaseSettings {
 export * from './account';
 export * from './client';
 export * from './round';
+export * from './logger';

--- a/packages/coinjoin/src/types/logger.ts
+++ b/packages/coinjoin/src/types/logger.ts
@@ -1,0 +1,13 @@
+export interface Logger {
+    debug(message: string): void;
+    log(message: string): void;
+    warn(message: string): void;
+    error(message: string): void;
+}
+
+export type LogLevel = keyof Logger;
+
+export type LogEvent = {
+    level: LogLevel;
+    payload: string;
+};

--- a/packages/coinjoin/src/utils/redacted.ts
+++ b/packages/coinjoin/src/utils/redacted.ts
@@ -1,0 +1,13 @@
+// redact log messages with sensitive data wrapped in ~~ ~~ pattern
+export const redacted = (message: string) =>
+    typeof message === 'string'
+        ? message.replace(/(~~([^~~]+)~~)/g, match => {
+              if (match.length > 16) {
+                  return `${match.substring(2, 10)}...${match.substring(
+                      match.length - 10,
+                      match.length - 2,
+                  )}`;
+              }
+              return `[redacted]`;
+          })
+        : `${message}`;

--- a/packages/coinjoin/tests/mocks/server.ts
+++ b/packages/coinjoin/tests/mocks/server.ts
@@ -3,6 +3,7 @@ import * as http from 'http';
 
 import { DEFAULT_ROUND, FEE_RATE_MEDIANS, AFFILIATE_INFO } from '../fixtures/round.fixture';
 import { CoinjoinClientEvents } from '../../src/types/client';
+import { Logger } from '../../src/types/logger';
 
 // Mock coordinator and middleware responses
 
@@ -199,7 +200,7 @@ export interface MockedServer extends Exclude<http.Server, 'addListener'> {
         coordinatorUrl: string;
         middlewareUrl: string;
         signal: AbortSignal;
-        log: (message: string) => any;
+        logger: Logger;
         setSessionPhase: (event: CoinjoinClientEvents['session-phase']) => void;
     };
     addListener: MockedServerEvents;
@@ -239,7 +240,12 @@ export const createServer = async () => {
         coordinatorUrl: `http://localhost:${port}/`,
         middlewareUrl: `http://localhost:${port}/`,
         signal: new AbortController().signal,
-        log: () => {},
+        logger: {
+            debug: () => {},
+            log: () => {},
+            warn: () => {},
+            error: () => {},
+        },
         setSessionPhase: () => null,
     };
 

--- a/packages/coinjoin/tests/tools/discovery.ts
+++ b/packages/coinjoin/tests/tools/discovery.ts
@@ -30,9 +30,7 @@ export const getAccountInfo = async ({
     const backend = new CoinjoinBackend(config);
     const transactions: Parameters<(typeof backend)['getAccountInfo']>[1] = [];
 
-    backend.on('log', message => {
-        console.log('🌐', message);
-    });
+    backend.on('log', ({ level, payload }) => console[level]('🌐', payload));
 
     backend.on(`progress/${descriptor}`, e => {
         transactions.push(...e.transactions);

--- a/packages/coinjoin/tests/utils/redacted.test.ts
+++ b/packages/coinjoin/tests/utils/redacted.test.ts
@@ -1,0 +1,19 @@
+import { redacted } from '../../src/utils/redacted';
+
+test('redacted', () => {
+    expect(redacted('~~bcrt1qejqxwzfld7zr6mf7ygqy5s5se5xq7vmt8ntmj0~~')).toEqual(
+        'bcrt1qej...mt8ntmj0',
+    );
+
+    expect(
+        redacted('addr: ~~bcrt1qejqxwzfld7zr6mf7ygqy5s5se5xq7vmt8ntmj0~~ in the middle'),
+    ).toEqual('addr: bcrt1qej...mt8ntmj0 in the middle');
+
+    expect(redacted('not redacted')).toEqual('not redacted');
+
+    // @ts-expect-error
+    expect(redacted({ message: 'not a string' })).toEqual('[object Object]');
+
+    // @ts-expect-error
+    expect(redacted(undefined)).toEqual('undefined');
+});

--- a/packages/suite-desktop/src/modules/coinjoin.ts
+++ b/packages/suite-desktop/src/modules/coinjoin.ts
@@ -54,7 +54,14 @@ export const init: Module = ({ mainWindow }) => {
             // override default url in coinjoin settings
             settings.middlewareUrl = coinjoinMiddleware.getUrl();
             const client = new CoinjoinClient(settings);
-            client.on('log', message => logger.debug(SERVICE_NAME, message));
+            client.on('log', ({ level, payload }) => {
+                if (level === 'log') {
+                    // suite-desktop logger doesn't have "log", using "debug" instead
+                    logger.debug(SERVICE_NAME, payload);
+                } else {
+                    logger[level](SERVICE_NAME, payload);
+                }
+            });
             clients.push(client);
             return {
                 onRequest: async (method, params) => {

--- a/packages/suite-desktop/src/modules/coinjoin.ts
+++ b/packages/suite-desktop/src/modules/coinjoin.ts
@@ -118,7 +118,16 @@ export const init: Module = ({ mainWindow }) => {
             backends.forEach(b => b.cancel());
             backends.splice(0, backends.length);
 
-            clients.forEach(c => c.disable());
+            clients.forEach(cli => {
+                // emit unexpected app close before disabling the client
+                if (cli.getRoundsInCriticalPhase().length > 0) {
+                    cli.emit('log', {
+                        level: 'error',
+                        payload: 'Suite closed in critical phase',
+                    });
+                }
+                cli.disable();
+            });
             clients.splice(0, clients.length);
 
             unregisterBackendProxy();

--- a/packages/suite/src/actions/wallet/__fixtures__/coinjoinAccountActions.ts
+++ b/packages/suite/src/actions/wallet/__fixtures__/coinjoinAccountActions.ts
@@ -11,6 +11,11 @@ const ACCOUNT: Partial<Account> = {
     key: '12345',
 };
 
+const CJ_ACCOUNT = {
+    key: ACCOUNT.key,
+    symbol: ACCOUNT.symbol,
+};
+
 const SESSION = { signedRounds: [] as string[], maxRounds: 10 };
 
 export const createCoinjoinAccount = [
@@ -150,7 +155,7 @@ export const startCoinjoinSession = [
         },
         state: {
             coinjoin: {
-                accounts: [{ key: ACCOUNT.key }],
+                accounts: [CJ_ACCOUNT],
             },
         },
         params: ACCOUNT,
@@ -176,7 +181,7 @@ export const startCoinjoinSession = [
         },
         state: {
             coinjoin: {
-                accounts: [{ key: ACCOUNT.key }],
+                accounts: [CJ_ACCOUNT],
             },
         },
         params: ACCOUNT,
@@ -236,10 +241,10 @@ export const restoreCoinjoinAccounts = [
             coinjoin: {
                 clients: {},
                 accounts: [
-                    { key: 'account-2', session: { ...SESSION, paused: true } },
-                    { key: 'account-B', session: { ...SESSION, paused: true } },
-                    { key: 'account-A', session: SESSION },
-                    { key: 'account-1', session: { ...SESSION, paused: true } },
+                    { key: 'account-2', symbol: 'regtest', session: { ...SESSION, paused: true } },
+                    { key: 'account-B', symbol: 'regtest', session: { ...SESSION, paused: true } },
+                    { key: 'account-A', symbol: 'btc', session: SESSION },
+                    { key: 'account-1', symbol: 'btc', session: { ...SESSION, paused: true } },
                 ],
             },
         },
@@ -263,7 +268,7 @@ export const restoreCoinjoinSession = [
         state: {
             accounts: [ACCOUNT],
             coinjoin: {
-                accounts: [{ key: ACCOUNT.key, session: { ...SESSION, paused: true } }],
+                accounts: [{ ...CJ_ACCOUNT, session: { ...SESSION, paused: true } }],
             },
         },
         param: '12345',

--- a/packages/suite/src/actions/wallet/__fixtures__/coinjoinClientActions.ts
+++ b/packages/suite/src/actions/wallet/__fixtures__/coinjoinClientActions.ts
@@ -2,7 +2,12 @@ import { testMocks } from '@suite-common/test-utils';
 import * as MODAL from '@suite-actions/constants/modalConstants';
 import * as COINJOIN from '@wallet-actions/constants/coinjoinConstants';
 
-export const DEVICE = testMocks.getSuiteDevice({ state: 'device-state', connected: true });
+export const DEVICE = testMocks.getSuiteDevice({
+    state: 'device-state',
+    connected: true,
+    available: true,
+    remember: true,
+});
 
 const SESSION = { signedRounds: [] as string[], maxRounds: 10 };
 

--- a/packages/suite/src/actions/wallet/__fixtures__/mockCoinjoinService.ts
+++ b/packages/suite/src/actions/wallet/__fixtures__/mockCoinjoinService.ts
@@ -1,0 +1,48 @@
+export const mockCoinjoinService = () => {
+    const allowed = ['btc', 'test'];
+    const clients: Record<string, any> = {}; // @trezor/coinjoin CoinjoinClient
+    const getMockedInstance = (network: string) => {
+        const client = {
+            settings: { coordinatorName: '', network },
+            on: jest.fn(),
+            off: jest.fn(),
+            emit: jest.fn(),
+            enable: jest.fn(() =>
+                Promise.resolve({
+                    rounds: [{ id: '00', phase: 0 }],
+                    maxMiningFee: 0,
+                    coordinatorFeeRate: 0.003,
+                    allowedInputAmounts: { min: 5000, max: 134375000000 },
+                }),
+            ),
+            registerAccount: jest.fn(),
+            unregisterAccount: jest.fn(),
+            updateAccount: jest.fn(),
+        };
+        const backend = {
+            on: jest.fn(),
+            off: jest.fn(),
+            cancel: jest.fn(),
+            scanAccount: jest.fn(() => Promise.reject(new Error('TODO: implement me'))),
+        };
+        return { client, backend };
+    };
+
+    return {
+        // for test purposes enable only btc network
+        CoinjoinService: {
+            getInstance: jest.fn((symbol: string) => clients[symbol]),
+            getInstances: jest.fn(() => Object.values(clients)),
+            createInstance: jest.fn((symbol: string) => {
+                if (!allowed.includes(symbol)) throw new Error('Client not supported');
+                if (clients[symbol]) return clients[symbol];
+                const instance = getMockedInstance(symbol);
+                clients[symbol] = instance;
+                return instance;
+            }),
+            removeInstance: jest.fn((symbol: string) => {
+                delete clients[symbol];
+            }),
+        },
+    };
+};

--- a/packages/suite/src/actions/wallet/__tests__/coinjoinAccountActions.test.ts
+++ b/packages/suite/src/actions/wallet/__tests__/coinjoinAccountActions.test.ts
@@ -12,51 +12,8 @@ jest.mock('@trezor/connect', () => global.JestMocks.getTrezorConnect({}));
 const TrezorConnect = require('@trezor/connect').default;
 
 jest.mock('@suite/services/coinjoin/coinjoinService', () => {
-    const allowed = ['btc', 'test'];
-    const clients: Record<string, any> = {}; // @trezor/coinjoin CoinjoinClient
-    const getMockedInstance = (network: string) => {
-        const client = {
-            settings: { coordinatorName: '', network },
-            on: jest.fn(),
-            off: jest.fn(),
-            enable: jest.fn(() =>
-                Promise.resolve({
-                    rounds: [{ id: '00', phase: 0 }],
-                    maxMiningFee: 0,
-                    coordinatorFeeRate: 0.003,
-                    allowedInputAmounts: { min: 5000, max: 134375000000 },
-                }),
-            ),
-            registerAccount: jest.fn(),
-            unregisterAccount: jest.fn(),
-            updateAccount: jest.fn(),
-        };
-        const backend = {
-            on: jest.fn(),
-            off: jest.fn(),
-            cancel: jest.fn(),
-            scanAccount: jest.fn(() => Promise.reject(new Error('TODO: implement me'))),
-        };
-        return { client, backend };
-    };
-
-    return {
-        // for test purposes enable only btc network
-        CoinjoinService: {
-            getInstance: (symbol: string) => clients[symbol],
-            getInstances: () => Object.values(clients),
-            createInstance: (symbol: string) => {
-                if (!allowed.includes(symbol)) throw new Error('Client not supported');
-                if (clients[symbol]) return clients[symbol];
-                const instance = getMockedInstance(symbol);
-                clients[symbol] = instance;
-                return instance;
-            },
-            removeInstance: (symbol: string) => {
-                delete clients[symbol];
-            },
-        },
-    };
+    const mock = jest.requireActual('../__fixtures__/mockCoinjoinService');
+    return mock.mockCoinjoinService();
 });
 
 const DEVICE = testMocks.getSuiteDevice({ state: 'device-state', connected: true });

--- a/packages/suite/src/actions/wallet/coinjoinClientActions.ts
+++ b/packages/suite/src/actions/wallet/coinjoinClientActions.ts
@@ -385,6 +385,23 @@ export const getOwnershipProof =
         return response;
     };
 
+interface ClientEmitExceptionOptions {
+    symbol?: Account['symbol'];
+}
+
+// use CoinjoinClient emitter to log/throw exceptions
+// exceptions will be reported to sentry in suite-desktop build
+export const clientEmitException =
+    (reason: string, options: ClientEmitExceptionOptions = {}) =>
+    () => {
+        (options.symbol
+            ? [CoinjoinService.getInstance(options.symbol)]
+            : CoinjoinService.getInstances()
+        ).forEach(instance => {
+            instance?.client.emit('log', { level: 'error', payload: reason });
+        });
+    };
+
 export const signCoinjoinTx =
     (request: Extract<CoinjoinRequestEvent, { type: 'signature' }>) =>
     async (dispatch: Dispatch, getState: GetState) => {

--- a/packages/suite/src/services/coinjoin/coinjoinService.ts
+++ b/packages/suite/src/services/coinjoin/coinjoinService.ts
@@ -33,7 +33,7 @@ export class CoinjoinService {
         const instance = { backend, client };
         if (!isDesktop()) {
             // display client log directly in console
-            client.on('log', console.log);
+            client.on('log', ({ level, payload }) => console[level](payload));
         }
 
         this.instances[network] = instance;

--- a/suite-common/sentry/src/index.ts
+++ b/suite-common/sentry/src/index.ts
@@ -5,6 +5,7 @@ import { isDevEnv } from '@suite-common/suite-utils';
 import { redactUserPathFromString } from '@trezor/utils';
 
 export const allowReportTag = 'allowReport';
+export const coinjoinReportTag = 'coinjoinReport';
 
 /**
  * Full user path could be part of reported error in some cases and we want to actively filter username out.
@@ -40,6 +41,18 @@ const beforeSend: Options['beforeSend'] = event => {
     // allow report error without breadcrumbs before confirm status is loaded (@storage/loaded)
     if (typeof allowReport === 'undefined') {
         delete event.breadcrumbs;
+    }
+
+    // send only what is really necessary from coinjoin
+    if (event.tags?.[coinjoinReportTag]) {
+        return {
+            message: event.message,
+            release: event.release,
+            level: event.level,
+            tags: {
+                coinjoinReport: true,
+            },
+        };
     }
 
     return redactUserPath(event);

--- a/suite-common/test-utils/src/mocks.ts
+++ b/suite-common/test-utils/src/mocks.ts
@@ -269,10 +269,11 @@ const getTrezorConnect = <M>(methods?: M) => {
         return fixtures;
     };
 
-    const { PROTO } = jest.requireActual('@trezor/connect');
+    const originalModule = jest.requireActual('@trezor/connect');
 
     return {
         __esModule: true, // export as module
+        ...originalModule,
         default: {
             // define mocked TrezorConnect methods
             init: () => {},
@@ -404,23 +405,6 @@ const getTrezorConnect = <M>(methods?: M) => {
             },
             ...methods,
         },
-        DEVICE_EVENT: 'DEVICE_EVENT',
-        UI_EVENT: 'UI_EVENT',
-        TRANSPORT_EVENT: 'TRANSPORT_EVENT',
-        BLOCKCHAIN_EVENT: 'BLOCKCHAIN_EVENT',
-        DEVICE: {},
-        BLOCKCHAIN: {
-            CONNECT: 'blockchain-connect',
-            BLOCK: 'blockchain-block',
-            NOTIFICATION: 'blockchain-notification',
-            ERROR: 'blockchain-error',
-        },
-        TRANSPORT: {},
-        UI: {
-            REQUEST_PIN: 'ui-request_pin',
-            REQUEST_BUTTON: 'ui-request_button',
-        },
-        PROTO,
     };
 };
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

- [feat(coinjoin): extend CoinjoinBackend logging](https://github.com/trezor/trezor-suite/commit/01b093d34560874d94b1399213d97699d7f33ba0)
  logger extension cherrypicked from https://github.com/trezor/trezor-suite/pull/7571 as inpiration
  CoinjoinBackend emits `log` event  as object `{ level: 'log' | 'warn' | 'error' | 'debug', payload: string }`
- [feat(coinjoin): extend CoinjoinClient logging](https://github.com/trezor/trezor-suite/commit/752c0afe438c44135f094207b54a057120d735cc)
  Doing the same for `CoinjoinClient` with additional redaction of sensitive messages
- [feat(coinjoin): add CoinjoinClient.getRoundsInCriticalPhase method](https://github.com/trezor/trezor-suite/commit/ca9d88c284539b81e18407ba24c160deb1c52c5c)
  add new method to CoinjoinClient, used in following commit (emit CoinjoinClient exceptions)
- [chore(suite): handle extended CoinjoinClient events](https://github.com/trezor/trezor-suite/commit/d3ab012aab2faf8d38c3e996bb4efaa2e3758e50)
  self explanatory
- [chore(suite): emit CoinjoinClient exceptions](https://github.com/trezor/trezor-suite/commit/ad51abfce12c956efcbb99b11ab596819faa3a59)
  emit certain CoinjoinClient errors from suite renderer
 - tests of coinjoinClientActions
   create and use shared mock of `coinjoinService`
   test exceptions emitted from actions and coinjoinMiddleware
 
 - [x] log errors to sentry
 All coinjoin errors can be found in Sentry using [`coinjoinReport:True ` filter](https://satoshilabs.sentry.io/issues/?query=is%3Aunresolved+coinjoinReport%3ATrue&referrer=issue-list&statsPeriod=14d). 
 Example: https://satoshilabs.sentry.io/share/issue/98a40a38d0f94191b1eaa64e337ec28d/

## List of exceptions:

- [x] [suite renderer coinjoinMiddleware] Internet disconnection during the critical phase.
- [x] [suite renderer coinjoinMiddleware] Tor failure during the critical phase.
- [x] [suite desktop main] Forced Suite shutdown during the critical phase.
- [x] [suite renderer action] Trezor disconnection during the critical phase.
- [x] [coinjoin transactionSigning] Trezor error during signing (including the error message), e.g. Invalid signature in CoinJoin request or Invalid external input.
- [x] [coinjoin transactionSigning] Trezor takes too long to sign, i.e. Suite cannot return the transaction signature within the deadline.
> It's hard to tell if signature was not sent in time because of Trezor signing process or network failure or any other reason.
> we will just log signTransaction time for each failed round

- [x] [request-manager] Big latency in Tor. (Not sure if we have a way to detect this on the client side, but let's try.)
> timeouted requests will be logged automatically in each phase


- [x] [coinjoin outputRegistration] Change address already used, coordinator rejects output address with AlreadyRegisteredScript
- [x] [coinjoin outputRegistration] Not enough change addresses available, extending change addresses derived gap, result of error above
- [x] [coinjoin transactionSigning] Coordinator did not provide affiliateRequest.
  


<!--- Describe your changes in detail -->

## Related Issue

Resolve https://github.com/trezor/trezor-suite/issues/7376
