### PR TITLE
fix(suite): remove non-null assertion from wallet account utils

### DIFF
--- a/suite-common/wallet-utils/src/accountUtils.ts
+++ b/suite-common/wallet-utils/src/accountUtils.ts
@@ -568,21 +568,21 @@ export const isAccountOutdated = (account: Account, freshInfo: AccountInfo) => {
     // different sequence or balance
     const changedRipple =
         account.networkType === 'ripple' &&
-        (freshInfo.misc!.sequence !== account.misc.sequence ||
+        (freshInfo.misc?.sequence !== account.misc.sequence ||
             freshInfo.balance !== account.balance ||
-            freshInfo.misc!.reserve !== account.misc.reserve);
+            freshInfo.misc?.reserve !== account.misc.reserve);
 
     const changedEthereum =
-        account.networkType === 'ethereum' && freshInfo.misc!.nonce !== account.misc.nonce;
+        account.networkType === 'ethereum' && freshInfo.misc?.nonce !== account.misc.nonce;
 
     const changedCardano =
         account.networkType === 'cardano' &&
         // stake address (de)registration
-        (freshInfo.misc!.staking?.isActive !== account.misc.staking.isActive ||
+        (freshInfo.misc?.staking?.isActive !== account.misc.staking.isActive ||
             // changed rewards amount (rewards are distributed every epoch (5 days))
-            freshInfo.misc!.staking?.rewards !== account.misc.staking.rewards ||
+            freshInfo.misc?.staking?.rewards !== account.misc.staking.rewards ||
             // changed stake pool
-            freshInfo.misc!.staking?.poolId !== account.misc.staking.poolId);
+            freshInfo.misc?.staking?.poolId !== account.misc.staking.poolId);
 
     return (
         changedTxCountOfflineFresh ||
@@ -603,6 +603,7 @@ export const getAccountSpecific = (
     if (networkType === 'ripple') {
         return {
             networkType,
+            // todo: shouldn't we move these fallbacks to blockchain-link?
             misc: {
                 sequence: misc && misc.sequence ? misc.sequence : 0,
                 reserve: misc && misc.reserve ? misc.reserve : '0',


### PR DESCRIPTION
this could fix #7605 (haven't tested it yet) cc @matejkriz 

we still should check if blockbook `0.4.0` did not introduce changes that could break something with eth

also check my note on line 606. Tldr suite is providing its own fallback here and it could potentially be part of blockchain-link but I don't know if it does not goes against our data-drive philosophy cc @marekrjpolak 