### PR TITLE
fix: prevent coinjoin account from starting discovery if Tor is disable

### DIFF
--- a/packages/suite/src/components/wallet/AccountAnnouncement/TorDisconnected.tsx
+++ b/packages/suite/src/components/wallet/AccountAnnouncement/TorDisconnected.tsx
@@ -3,11 +3,11 @@ import { NotificationCard, Translation } from '@suite-components';
 import { useActions, useSelector } from '@suite-hooks';
 import * as suiteActions from '@suite-actions/suiteActions';
 import { selectTorState } from '@suite-reducers/suiteReducer';
-import { selectIsCoinjoinBlockedByTor } from '@wallet-reducers/coinjoinReducer';
+import { selectIsCoinjoinSelectedAccountBlockedByTor } from '@wallet-reducers/coinjoinReducer';
 
 export const TorDisconnected = () => {
     const { isTorLoading } = useSelector(selectTorState);
-    const isCoinjoinBlockedByTor = useSelector(selectIsCoinjoinBlockedByTor);
+    const isCoinjoinBlockedByTor = useSelector(selectIsCoinjoinSelectedAccountBlockedByTor);
     const { toggleTor } = useActions({
         toggleTor: suiteActions.toggleTor,
     });

--- a/packages/suite/src/components/wallet/CoinjoinSummary/AnonymizeButton.tsx
+++ b/packages/suite/src/components/wallet/CoinjoinSummary/AnonymizeButton.tsx
@@ -7,7 +7,7 @@ import { Card, Translation } from '@suite-components';
 import { useSelector } from '@suite-hooks';
 import { TooltipButton } from '@trezor/components';
 import {
-    selectIsCoinjoinBlockedByTor,
+    selectIsCoinjoinSelectedAccountBlockedByTor,
     selectIsCoinjoinBlockedByAmountsTooSmall,
 } from '@wallet-reducers/coinjoinReducer';
 import {
@@ -37,7 +37,7 @@ interface AnonymizeButtonProps {
 }
 
 export const AnonymizeButton = ({ accountKey }: AnonymizeButtonProps) => {
-    const isCoinjoinBlockedByTor = useSelector(selectIsCoinjoinBlockedByTor);
+    const isCoinjoinBlockedByTor = useSelector(selectIsCoinjoinSelectedAccountBlockedByTor);
     const isCoinjoinBlockedByAmountsTooSmall = useSelector(state =>
         selectIsCoinjoinBlockedByAmountsTooSmall(state, accountKey),
     );

--- a/packages/suite/src/hooks/coinjoin/useBlockedCoinjoinResume.ts
+++ b/packages/suite/src/hooks/coinjoin/useBlockedCoinjoinResume.ts
@@ -6,11 +6,11 @@ import {
     selectIsFeatureDisabled,
 } from '@suite-reducers/messageSystemReducer';
 import { selectDeviceState } from '@suite-reducers/suiteReducer';
-import { selectIsCoinjoinBlockedByTor } from '@wallet-reducers/coinjoinReducer';
+import { selectIsCoinjoinSelectedAccountBlockedByTor } from '@wallet-reducers/coinjoinReducer';
 import { getIsCoinjoinOutOfSync } from '@wallet-utils/coinjoinUtils';
 
 export const useBlockedCoinjoinResume = () => {
-    const isCoinjoinBlockedByTor = useSelector(selectIsCoinjoinBlockedByTor);
+    const isCoinjoinBlockedByTor = useSelector(selectIsCoinjoinSelectedAccountBlockedByTor);
     const isCoinjoinDisabledByFeatureFlag = useSelector(state =>
         selectIsFeatureDisabled(state, Feature.coinjoin),
     );

--- a/packages/suite/src/reducers/wallet/coinjoinReducer.ts
+++ b/packages/suite/src/reducers/wallet/coinjoinReducer.ts
@@ -498,7 +498,17 @@ export const selectCurrentTargetAnonymity = memoize((state: CoinjoinRootState) =
     return targetAnonymity;
 });
 
-export const selectIsCoinjoinBlockedByTor = memoize((state: CoinjoinRootState) => {
+export const selectIsCoinjoinGloballyBlockedByTor = memoize((state: CoinjoinRootState) => {
+    const { isTorEnabled } = selectTorState(state);
+
+    if (state.wallet.coinjoin.debug?.coinjoinAllowNoTor) {
+        return false;
+    }
+
+    return !isTorEnabled;
+});
+
+export const selectIsCoinjoinSelectedAccountBlockedByTor = memoize((state: CoinjoinRootState) => {
     const accountParams = selectSelectedAccountParams(state);
     const { isTorEnabled } = selectTorState(state);
 

--- a/packages/suite/src/views/wallet/anonymize/components/CoinjoinConfirmation.tsx
+++ b/packages/suite/src/views/wallet/anonymize/components/CoinjoinConfirmation.tsx
@@ -13,7 +13,7 @@ import { startCoinjoinSession } from '@wallet-actions/coinjoinAccountActions';
 import {
     selectCurrentCoinjoinBalanceBreakdown,
     selectCurrentTargetAnonymity,
-    selectIsCoinjoinBlockedByTor,
+    selectIsCoinjoinSelectedAccountBlockedByTor,
 } from '@wallet-reducers/coinjoinReducer';
 import { getMaxRounds } from '@wallet-utils/coinjoinUtils';
 import {
@@ -107,7 +107,7 @@ export const CoinjoinConfirmation = ({ account }: CoinjoinConfirmationProps) => 
     const targetAnonymity = useSelector(selectCurrentTargetAnonymity);
     const { notAnonymized } = useSelector(selectCurrentCoinjoinBalanceBreakdown);
     const { isLocked } = useDevice();
-    const isCoinjoinBlockedByTor = useSelector(selectIsCoinjoinBlockedByTor);
+    const isCoinjoinBlockedByTor = useSelector(selectIsCoinjoinSelectedAccountBlockedByTor);
     const isCoinjoinDisabledByFeatureFlag = useSelector(state =>
         selectIsFeatureDisabled(state, Feature.coinjoin),
     );


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
When starting app with remember coinjoin account and Tor disable, the discovery is going to start with a Noisy coinjoin notification. This PR prevents coinjoin account discovery from starting if Tor is not enable.

* 20a8390d50bd233a5a52fda50b6a77e4c4cd70c8 - new selector that allow select Tor is disable for coinjoin without account.
* b96e81290b09049fbd9c8b6d960b416c94b5ce99 - preventing coinjoin discovery start when Tor is disable for coinjoin.

## Related Issue

Resolve https://github.com/trezor/trezor-suite/issues/7485

