### PR TITLE
Fix/connect override param

### DIFF
--- a/.github/workflows/connect-test.yml
+++ b/.github/workflows/connect-test.yml
@@ -43,7 +43,7 @@ jobs:
     needs: [build]
     uses: ./.github/workflows/connect-test-params.yml
     with:
-      test-pattern: "init authorizeCoinjoin passphrase unlockPath setBusy"
+      test-pattern: "init authorizeCoinjoin passphrase unlockPath setBusy override"
 
   management:
     needs: [build]

--- a/docs/packages/connect/methods/commonParams.md
+++ b/docs/packages/connect/methods/commonParams.md
@@ -20,3 +20,4 @@ All common parameters are optional.
     -   Wallet calls `getPublicKey` with `useCardanoDerivation=false`, passhprase is entered, seed derived
     -   Wallet calls `cardanoGetPublicKey`.
     -   At this moment user will be prompted to enter passhprase again.
+-   `override` - _optional_ `boolean` Interrupt previous call, if any.

--- a/packages/connect/e2e/tests/device/override.test.ts
+++ b/packages/connect/e2e/tests/device/override.test.ts
@@ -1,0 +1,37 @@
+import TrezorConnect from '@trezor/connect';
+
+const { getController, setup, initTrezorConnect } = global.Trezor;
+
+const controller = getController('setBusy');
+
+describe('TrezorConnect override param', () => {
+    beforeAll(async () => {
+        await setup(controller, { mnemonic: 'mnemonic_all' });
+        await initTrezorConnect(controller);
+    });
+
+    afterAll(async () => {
+        controller.dispose();
+        await TrezorConnect.dispose();
+    });
+
+    it('override previous call', async () => {
+        TrezorConnect.getAddress({
+            path: "m/44'/1'/0'/0/0",
+        }).then(response => {
+            expect(response.success).toBe(false);
+            // TODO: received error depends on timeout below
+            // expect(response.payload).toMatchObject({ code: 'Method_Override' });
+        });
+
+        // TODO: immediate call causes race condition in bridge http request, test might be flaky
+        // requires AbortController implementation in @trezor/transport to cancel current request to bridge (acquire process)
+        await new Promise(resolve => setTimeout(resolve, 1000));
+
+        const address = await TrezorConnect.getAddress({
+            path: "m/44'/1'/0'/0/0",
+            override: true,
+        });
+        expect(address.success).toBe(true);
+    });
+});

--- a/packages/connect/src/device/Device.ts
+++ b/packages/connect/src/device/Device.ts
@@ -233,8 +233,7 @@ export class Device extends EventEmitter {
         }
 
         if (this.runPromise) {
-            this.runPromise.reject(error);
-            this.runPromise = null;
+            await this.interruptionFromUser(error);
         }
 
         if (!this.keepSession && this.deferredActions[DEVICE.RELEASE]) {

--- a/packages/connect/src/device/DeviceCommands.ts
+++ b/packages/connect/src/device/DeviceCommands.ts
@@ -707,11 +707,11 @@ export class DeviceCommands {
         if (name === 'BridgeTransport' && versionCompare(version, '2.0.28') < 1) {
             await this.device.legacyForceRelease();
         } else {
-            await this.transport.post(this.sessionId, 'Cancel', {}, false);
+            await this.transport.post(this.sessionId, 'Cancel', {}, false).catch(() => {});
             // post does not read back from usb stack. this means that there is a pending message left
             // and we need to remove it so that it does not interfere with the next transport call.
             // see DeviceCommands.typedCall
-            await this.transport.read(this.sessionId, false);
+            await this.transport.read(this.sessionId, false).catch(() => {});
         }
     }
 }

--- a/packages/connect/src/types/params.ts
+++ b/packages/connect/src/types/params.ts
@@ -10,6 +10,7 @@ export interface CommonParams {
     useEventListener?: boolean; // this param is set automatically in factory
     allowSeedlessDevice?: boolean;
     keepSession?: boolean;
+    override?: boolean;
     skipFinalReload?: boolean;
     useCardanoDerivation?: boolean;
 }

--- a/packages/trezor-user-env-link/src/websocket-client.ts
+++ b/packages/trezor-user-env-link/src/websocket-client.ts
@@ -16,6 +16,13 @@ const NOT_INITIALIZED = new Error('websocket_not_initialized');
 const DEFAULT_TIMEOUT = 5 * 60 * 1000;
 const DEFAULT_PING_TIMEOUT = 50 * 1000;
 
+// breaking change in node 17, ip6 is preferred by default
+// localhost is not resolved correctly on certain machines
+const USER_ENV_URL = {
+    WEBSOCKET: `ws://127.0.0.1:9001/`,
+    DASHBOARD: `http://127.0.0.1:9002`,
+};
+
 interface Options {
     pingTimeout?: number;
     url?: string;
@@ -51,7 +58,7 @@ class TrezorUserEnvLinkClass extends EventEmitter {
         this.setMaxListeners(Infinity);
         this.options = {
             ...options,
-            url: options.url || 'ws://localhost:9001/',
+            url: options.url || USER_ENV_URL.WEBSOCKET,
         };
 
         this.api = api(this);
@@ -281,7 +288,7 @@ class TrezorUserEnvLinkClass extends EventEmitter {
                 await delay(1000);
 
                 try {
-                    const res = await fetch('http://localhost:9002');
+                    const res = await fetch(USER_ENV_URL.DASHBOARD);
                     if (res.status === 200) {
                         console.log('trezor-user-env is online');
                         return resolve();


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

- fix connect e2e with `trezor-user-env` running locally (-d option)
- fix, document and test `override` param
