### PR TITLE
chore: lint and ts fix

### DIFF
--- a/packages/blockchain-link/src/index.ts
+++ b/packages/blockchain-link/src/index.ts
@@ -329,7 +329,7 @@ class BlockchainLink extends EventEmitter {
 
 export default BlockchainLink;
 
-export type BlockchainLinkInterface = typeof BlockchainLink['prototype'];
+export type BlockchainLinkInterface = (typeof BlockchainLink)['prototype'];
 
 export type BlockchainLinkParams<T extends keyof BlockchainLinkInterface> =
     BlockchainLinkInterface[T] extends (...args: any[]) => any

--- a/packages/components/src/components/typography/Heading/index.tsx
+++ b/packages/components/src/components/typography/Heading/index.tsx
@@ -5,7 +5,7 @@ import { NEUE_FONT_SIZE, FONT_WEIGHT, FONT_SIZE } from '../../../config/variable
 export interface Props {
     textAlign?: 'left' | 'center' | 'right' | 'justify';
     noMargin?: boolean;
-    fontWeight?: typeof FONT_WEIGHT[keyof typeof FONT_WEIGHT];
+    fontWeight?: (typeof FONT_WEIGHT)[keyof typeof FONT_WEIGHT];
 }
 
 const textAlignStyle = css`

--- a/packages/connect-explorer/src/actions/trezorConnectActions.ts
+++ b/packages/connect-explorer/src/actions/trezorConnectActions.ts
@@ -4,7 +4,7 @@ import TrezorConnect, { DEVICE, DEVICE_EVENT, TRANSPORT_EVENT } from '@trezor/co
 import { TrezorConnectDevice, Dispatch } from '../types';
 import * as ACTIONS from './index';
 
-type ConnectOptions = Parameters<typeof TrezorConnect['init']>[0];
+type ConnectOptions = Parameters<(typeof TrezorConnect)['init']>[0];
 export type TrezorConnectAction =
     | { type: typeof ACTIONS.ON_SELECT_DEVICE; path: string }
     | { type: typeof DEVICE.CONNECT; device: TrezorConnectDevice }
@@ -20,7 +20,7 @@ export function onSelectDevice(path: string) {
 }
 
 export const init =
-    (options: Partial<Parameters<typeof TrezorConnect['init']>[0]> = {}) =>
+    (options: Partial<Parameters<(typeof TrezorConnect)['init']>[0]> = {}) =>
     async (dispatch: Dispatch) => {
         window.TrezorConnect = TrezorConnect;
 

--- a/packages/connect-explorer/src/reducers/trezorConnectReducer.ts
+++ b/packages/connect-explorer/src/reducers/trezorConnectReducer.ts
@@ -5,7 +5,7 @@ import { TrezorConnectDevice, Action } from '../types';
 type ConnectState = {
     devices: TrezorConnectDevice[];
     selectedDevice?: string;
-    options?: Parameters<typeof TrezorConnect['init']>[0];
+    options?: Parameters<(typeof TrezorConnect)['init']>[0];
 };
 
 const initialState: ConnectState = {

--- a/packages/connect-ui/src/index.tsx
+++ b/packages/connect-ui/src/index.tsx
@@ -1,4 +1,5 @@
 import React, { useCallback, useEffect, useState, useMemo } from 'react';
+
 import styled from 'styled-components';
 
 import { PostMessage, UI, PopupHandshake, UI_REQUEST } from '@trezor/connect';

--- a/packages/connect/src/data/DataManager.ts
+++ b/packages/connect/src/data/DataManager.ts
@@ -110,7 +110,7 @@ export class DataManager {
         }
     }
 
-    static getPriority(whitelist?: typeof config['whitelist'][0]) {
+    static getPriority(whitelist?: (typeof config)['whitelist'][0]) {
         if (whitelist) {
             return whitelist.priority;
         }

--- a/packages/suite-build/utils/constants.ts
+++ b/packages/suite-build/utils/constants.ts
@@ -1,5 +1,5 @@
 export const PROJECTS = ['web', 'desktop'] as const;
-export type Project = typeof PROJECTS[number];
+export type Project = (typeof PROJECTS)[number];
 
 export const DEV_PORTS: { [key in Project]: number } = {
     web: 8000,

--- a/packages/suite-desktop/src/libs/logger.ts
+++ b/packages/suite-desktop/src/libs/logger.ts
@@ -10,7 +10,7 @@ import { getBuildInfo, getComputerInfo } from './info';
 
 const logLevels = ['mute', 'error', 'warn', 'info', 'debug'] as const;
 
-export type LogLevel = typeof logLevels[number];
+export type LogLevel = (typeof logLevels)[number];
 const isLogLevel = (level: string): level is LogLevel =>
     !!level && logLevels.includes(level as LogLevel);
 

--- a/packages/suite-desktop/src/modules/bridge.ts
+++ b/packages/suite-desktop/src/modules/bridge.ts
@@ -2,7 +2,6 @@
  * Bridge runner
  */
 import { app, ipcMain } from '../typed-electron';
-
 import { BridgeProcess } from '../libs/processes/BridgeProcess';
 import { b2t } from '../libs/utils';
 

--- a/packages/suite-web/e2e/cypress.config.ts
+++ b/packages/suite-web/e2e/cypress.config.ts
@@ -29,7 +29,7 @@ const ensureRdpPort = (args: any[]) => {
 
 let port = 0;
 let client: any = null;
-let blockbook: Awaited<ReturnType<typeof blockbookMock['start']>> | undefined;
+let blockbook: Awaited<ReturnType<(typeof blockbookMock)['start']>> | undefined;
 
 // // add snapshot plugin
 // addMatchImageSnapshotPlugin(on);

--- a/packages/suite-web/e2e/support/commands.ts
+++ b/packages/suite-web/e2e/support/commands.ts
@@ -90,7 +90,7 @@ declare global {
             resetDb: typeof resetDb;
             // todo: better types, this is not 100% correct as this fn may get more args from
             // cypress-image-snapshot lib
-            matchImageSnapshot: typeof cy['screenshot'];
+            matchImageSnapshot: (typeof cy)['screenshot'];
             onboardingShouldLoad: () => Chainable<Subject>;
             dashboardShouldLoad: () => Chainable<Subject>;
             discoveryShouldFinish: () => Chainable<Subject>;

--- a/packages/suite/src/components/suite/HomescreenGallery/index.tsx
+++ b/packages/suite/src/components/suite/HomescreenGallery/index.tsx
@@ -10,7 +10,7 @@ import { AcquiredDevice } from '@suite-types';
 import { useActions } from '@suite-hooks';
 import { DeviceModel, getDeviceModel } from '@trezor/device-utils';
 
-type AnyImageName = typeof homescreensBW64x128[number] | typeof homescreensColor128x128[number];
+type AnyImageName = (typeof homescreensBW64x128)[number] | (typeof homescreensColor128x128)[number];
 
 const Wrapper = styled.div`
     display: flex;

--- a/packages/suite/src/components/wallet/TransactionItem/index.tsx
+++ b/packages/suite/src/components/wallet/TransactionItem/index.tsx
@@ -126,7 +126,7 @@ const TransactionItem = React.memo(
         // ethereum tx has either targets or transfers
         // cardano tx can have both at the same time
         const allOutputs: (
-            | { type: 'token'; payload: typeof tokens[number] }
+            | { type: 'token'; payload: (typeof tokens)[number] }
             | { type: 'target'; payload: WalletAccountTransaction['targets'][number] }
         )[] =
             transaction.type === 'self'

--- a/packages/suite/src/reducers/suite/messageSystemReducer.ts
+++ b/packages/suite/src/reducers/suite/messageSystemReducer.ts
@@ -17,13 +17,13 @@ export const Feature = {
     coinjoin: 'coinjoin',
 } as const;
 
-type FeatureDomain = typeof Feature[keyof typeof Feature];
+type FeatureDomain = (typeof Feature)[keyof typeof Feature];
 
 export const Context = {
     coinjoin: 'accounts.coinjoin',
 } as const;
 
-type ContextDomain = typeof Context[keyof typeof Context];
+type ContextDomain = (typeof Context)[keyof typeof Context];
 
 export type MessageSystemState = {
     config: MessageSystem | null;

--- a/packages/suite/src/services/suite/metadata/DropboxProvider.ts
+++ b/packages/suite/src/services/suite/metadata/DropboxProvider.ts
@@ -64,7 +64,6 @@ class DropboxProvider extends AbstractMetadataProvider {
 
         try {
             // dropbox supports authorization code flow for both web and desktop
-            // @ts-expect-error dropbox lib types url as String object, but it is primite string
             const { code } = await extractCredentialsFromAuthorizationFlow(url);
 
             if (!code)
@@ -72,7 +71,6 @@ class DropboxProvider extends AbstractMetadataProvider {
 
             const { result } = await this.auth.getAccessTokenFromCode(redirectUrl, code);
 
-            // @ts-expect-error dropbox lib types result as Object, but access_token & refresh_token are available there as strings
             const { access_token: accessToken, refresh_token: refreshToken } = result;
 
             this.auth.setAccessToken(accessToken);
@@ -137,7 +135,6 @@ class DropboxProvider extends AbstractMetadataProvider {
                         path: match!.metadata.metadata.path_lower!,
                     });
 
-                    // @ts-expect-error fileBlob is missing in dropbox lib types file, but it is available
                     const ab = await result.fileBlob.arrayBuffer();
 
                     return this.ok(Buffer.from(ab));

--- a/packages/suite/src/types/suite/index.ts
+++ b/packages/suite/src/types/suite/index.ts
@@ -45,10 +45,10 @@ export type {
 type TrezorConnectEvents = TransportEvent | UiEvent | DeviceEvent | BlockchainEvent;
 
 export type TransactionAction = ReturnType<
-    typeof transactionsActions[keyof typeof transactionsActions]
+    (typeof transactionsActions)[keyof typeof transactionsActions]
 >;
 export type NotificationAction = ReturnType<
-    typeof notificationsActions[keyof typeof notificationsActions]
+    (typeof notificationsActions)[keyof typeof notificationsActions]
 >;
 
 // all actions from all apps used to properly type Dispatch.

--- a/packages/suite/src/types/wallet/index.ts
+++ b/packages/suite/src/types/wallet/index.ts
@@ -54,9 +54,9 @@ export type { WalletParams } from '@suite-utils/router';
 this action union types are bad, we need it only for legacy reason.
 (old redux and redux/toolkit action type compatibility e.g. in middlewares)
  */
-type AccountsAction = ReturnType<typeof accountsActions[keyof typeof accountsActions]>;
-type FiatRatesAction = ReturnType<typeof fiatRatesActions[keyof typeof fiatRatesActions]>;
-type BlockchainAction = ReturnType<typeof blockchainActions[keyof typeof blockchainActions]>;
+type AccountsAction = ReturnType<(typeof accountsActions)[keyof typeof accountsActions]>;
+type FiatRatesAction = ReturnType<(typeof fiatRatesActions)[keyof typeof fiatRatesActions]>;
+type BlockchainAction = ReturnType<(typeof blockchainActions)[keyof typeof blockchainActions]>;
 
 export type WalletAction =
     | BlockchainAction

--- a/packages/suite/src/utils/suite/__tests__/homescreen.test.ts
+++ b/packages/suite/src/utils/suite/__tests__/homescreen.test.ts
@@ -56,9 +56,9 @@ const imgHashFixtures = [
 ] as const;
 
 interface Fixture {
-    img: typeof imgHashFixtures[number]['img'];
-    model: typeof imgHashFixtures[number]['model'];
-    hexHash: typeof imgHashFixtures[number]['hexHash'];
+    img: (typeof imgHashFixtures)[number]['img'];
+    model: (typeof imgHashFixtures)[number]['model'];
+    hexHash: (typeof imgHashFixtures)[number]['hexHash'];
 }
 
 describe('homescreen', () => {

--- a/packages/theme/src/fontWeights.ts
+++ b/packages/theme/src/fontWeights.ts
@@ -5,5 +5,5 @@ export const fontWeights = {
 } as const;
 
 export type FontWeight = keyof typeof fontWeights;
-export type FontWeightValue = typeof fontWeights[FontWeight];
+export type FontWeightValue = (typeof fontWeights)[FontWeight];
 export type FontWeights = Record<FontWeight, FontWeightValue>;

--- a/packages/utils/tests/arrayPartition.test.ts
+++ b/packages/utils/tests/arrayPartition.test.ts
@@ -53,7 +53,8 @@ describe('arrayPartition', () => {
 
         it('partition with type predicate', () => {
             const foobars = [{ foo: 1 }, { bar: 3 }, { bar: 2 }, { foo: 4 }];
-            const isFoo = (item: typeof foobars[number]): item is { foo: number } => 'foo' in item;
+            const isFoo = (item: (typeof foobars)[number]): item is { foo: number } =>
+                'foo' in item;
             const [foos, bars] = arrayPartition(foobars, isFoo);
             expect(foos).toEqual([{ foo: 1 }, { foo: 4 }]);
             expect(bars).toEqual([{ bar: 3 }, { bar: 2 }]);

--- a/packages/utxo-lib/src/derivation.ts
+++ b/packages/utxo-lib/src/derivation.ts
@@ -30,7 +30,7 @@ const BIP32_PURPOSES = {
 } as const;
 
 type VersionBytes = keyof typeof BIP32_PAYMENT_TYPES;
-type PaymentType = typeof BIP32_PAYMENT_TYPES[VersionBytes] | 'p2tr';
+type PaymentType = (typeof BIP32_PAYMENT_TYPES)[VersionBytes] | 'p2tr';
 
 const validateVersion = (version: number): version is VersionBytes =>
     !!BIP32_PAYMENT_TYPES[version as VersionBytes];

--- a/packages/utxo-lib/src/payments/p2tr.ts
+++ b/packages/utxo-lib/src/payments/p2tr.ts
@@ -18,7 +18,7 @@ const { OPS } = bscript;
  */
 
 const TAGS = ['TapLeaf', 'TapBranch', 'TapTweak', 'KeyAgg list', 'KeyAgg coefficient'] as const;
-type TaggedHashPrefix = typeof TAGS[number];
+type TaggedHashPrefix = (typeof TAGS)[number];
 /** An object mapping tags to their tagged hash prefix of [SHA256(tag) | SHA256(tag)] */
 const TAGGED_HASH_PREFIXES = TAGS.reduce((obj, tag) => {
     const tagHash = bcrypto.sha256(Buffer.from(tag));

--- a/suite-common/suite-config/src/fiat.ts
+++ b/suite-common/suite-config/src/fiat.ts
@@ -48,7 +48,7 @@ export const fiatCurrencies = {
 } as const;
 
 export type FiatCurrencyCode = keyof typeof fiatCurrencies;
-export type FiatCurrency = typeof fiatCurrencies[FiatCurrencyCode];
+export type FiatCurrency = (typeof fiatCurrencies)[FiatCurrencyCode];
 
 /**
  * @deprecated Please use fiatCurrencies object instead

--- a/suite-common/wallet-config/src/networksConfig.ts
+++ b/suite-common/wallet-config/src/networksConfig.ts
@@ -390,8 +390,8 @@ export const TREZOR_CONNECT_BACKENDS = ['blockbook', 'electrum', 'ripple', 'bloc
 export const NON_STANDARD_BACKENDS = ['coinjoin'] as const;
 
 export type BackendType =
-    | typeof TREZOR_CONNECT_BACKENDS[number]
-    | typeof NON_STANDARD_BACKENDS[number];
+    | (typeof TREZOR_CONNECT_BACKENDS)[number]
+    | (typeof NON_STANDARD_BACKENDS)[number];
 
 type Networks = typeof networks;
 export type NetworkSymbol = keyof Networks;

--- a/suite-common/wallet-types/src/backend.ts
+++ b/suite-common/wallet-types/src/backend.ts
@@ -13,7 +13,7 @@ export type BlockbookUrl = {
 export type BackendType = 'blockbook' | 'electrum' | 'ripple' | 'blockfrost';
 
 export type CustomBackend = {
-    coin: typeof networksCompatibility[number]['symbol'];
+    coin: (typeof networksCompatibility)[number]['symbol'];
     type: BackendType;
     urls: string[];
 };

--- a/suite-common/wallet-types/src/form.ts
+++ b/suite-common/wallet-types/src/form.ts
@@ -23,5 +23,5 @@ export type TypedFieldError =
           message?: ExtendedMessageDescriptor['id'] | ExtendedMessageDescriptor | ReactElement;
       };
 
-export type FormDraftKeyPrefix = typeof FormDraftPrefixKeyValues[number];
+export type FormDraftKeyPrefix = (typeof FormDraftPrefixKeyValues)[number];
 export type FormDraft = Record<string, any>;

--- a/suite-common/wallet-types/src/polling.ts
+++ b/suite-common/wallet-types/src/polling.ts
@@ -1,6 +1,6 @@
 import type { PollingPrefixKeyValues } from '@suite-common/wallet-constants';
 
-export type PollingKeyPrefix = typeof PollingPrefixKeyValues[number];
+export type PollingKeyPrefix = (typeof PollingPrefixKeyValues)[number];
 export type PollingKey = `${PollingKeyPrefix}/${string}`;
 export type Polling = {
     pollingFunction: () => void;

--- a/suite-common/wallet-utils/src/transactionUtils.ts
+++ b/suite-common/wallet-utils/src/transactionUtils.ts
@@ -669,7 +669,7 @@ const searchOperators = ['<', '>', '=', '!='] as const;
 const numberSearchFilter = (
     transaction: WalletAccountTransaction,
     amount: BigNumber,
-    operator: typeof searchOperators[number],
+    operator: (typeof searchOperators)[number],
 ) => {
     const targetAmounts = getTargetAmounts(transaction);
     const op = getTxOperation(transaction);

--- a/suite-native/atoms/src/Box.tsx
+++ b/suite-native/atoms/src/Box.tsx
@@ -36,14 +36,14 @@ const spacingStylePropsKeys = [
     'padding',
 ] as const;
 
-type SpacingStyleProps = Partial<Record<typeof spacingStylePropsKeys[number], Spacing>>;
-type LayoutStyleProps = Partial<Pick<ViewStyle, typeof layoutStylePropsKeys[number]>>;
+type SpacingStyleProps = Partial<Record<(typeof spacingStylePropsKeys)[number], Spacing>>;
+type LayoutStyleProps = Partial<Pick<ViewStyle, (typeof layoutStylePropsKeys)[number]>>;
 
 export interface BoxProps extends Omit<ViewProps, 'style'>, LayoutStyleProps, SpacingStyleProps {
     style?: NativeStyleObject;
 }
 
-type BoxStyleProps = Record<typeof spacingStylePropsKeys[number], number> & LayoutStyleProps;
+type BoxStyleProps = Record<(typeof spacingStylePropsKeys)[number], number> & LayoutStyleProps;
 
 const boxStyle = prepareNativeStyle<BoxStyleProps>((_utils, { ...styles }) => ({
     ...styles,


### PR DESCRIPTION
Has something changed recently? 
when I run `yarn lint:js --fix` 
this [diff](5943fadf768083bc958d48d1157e97af52381b00) is produced

also yarn type-check does not pass  without [f43fdec](https://github.com/trezor/trezor-suite/pull/7638/commits/f43fdec24f5087087bf56d1effafa4444ddecc1e)

