### PR TITLE
Temporarily disable mempool for mainnet CJ accounts

### DIFF
--- a/packages/coinjoin/src/backend/CoinjoinBackend.ts
+++ b/packages/coinjoin/src/backend/CoinjoinBackend.ts
@@ -68,7 +68,11 @@ export class CoinjoinBackend extends EventEmitter {
         this.settings = Object.freeze(settings);
         this.network = getNetwork(settings.network);
         this.client = new CoinjoinBackendClient({ ...settings, logger: this.getLogger() });
-        this.mempool = new CoinjoinMempoolController(this.client);
+
+        this.mempool =
+            settings.network === 'btc' // mempool scanning is temporarily turned off for mainnet
+                ? undefined
+                : new CoinjoinMempoolController(this.client);
     }
 
     scanAccount({ descriptor, progressHandle, checkpoints, cache }: ScanAccountParams) {

--- a/packages/coinjoin/src/backend/scanAccount.ts
+++ b/packages/coinjoin/src/backend/scanAccount.ts
@@ -3,6 +3,7 @@ import { transformTransaction } from '@trezor/blockchain-link/lib/workers/blockb
 import { getAddressScript, getFilter } from './filters';
 import { doesTxContainAddress, deriveAddresses, fixTx } from './backendUtils';
 import type {
+    Transaction,
     AccountAddress,
     BlockbookBlock,
     BlockbookTransaction,
@@ -117,11 +118,14 @@ export const scanAccount = async (
         }
     }
 
-    await mempool.update();
+    let pending: Transaction[] = [];
+    if (mempool) {
+        await mempool.update();
 
-    const pending = mempool
-        .getTransactions(receive.concat(change).map(({ address }) => address))
-        .map(transformTx(xpub, receive, change));
+        pending = mempool
+            .getTransactions(receive.concat(change).map(({ address }) => address))
+            .map(transformTx(xpub, receive, change));
+    }
 
     const cache = {
         receivePrederived: receive.map(({ address, path }) => ({ address, path })),

--- a/packages/coinjoin/src/backend/scanAddress.ts
+++ b/packages/coinjoin/src/backend/scanAddress.ts
@@ -3,6 +3,7 @@ import { transformTransaction } from '@trezor/blockchain-link/lib/workers/blockb
 import { getAddressScript, getFilter } from './filters';
 import { doesTxContainAddress, fixTx } from './backendUtils';
 import type {
+    Transaction,
     ScanAddressParams,
     ScanAddressCheckpoint,
     ScanAddressContext,
@@ -38,11 +39,15 @@ export const scanAddress = async (
         }
     }
 
-    await mempool.update();
+    let pending: Transaction[] = [];
 
-    const pending = mempool
-        .getTransactions([address])
-        .map(tx => transformTransaction(address, undefined, tx));
+    if (mempool) {
+        await mempool.update();
+
+        pending = mempool
+            .getTransactions([address])
+            .map(tx => transformTransaction(address, undefined, tx));
+    }
 
     return {
         pending,

--- a/packages/coinjoin/src/types/backend.ts
+++ b/packages/coinjoin/src/types/backend.ts
@@ -50,7 +50,7 @@ type MethodContext = {
 
 type ScanContext<T> = MethodContext & {
     filters: FilterController;
-    mempool: MempoolController;
+    mempool?: MempoolController;
     onProgress: (progress: T) => void;
 };
 


### PR DESCRIPTION
## Description

Since current mempool discovery works ok on testnet but is not performant enough for mainnet lets disable it until this is resolved.

Taken from #7630 and refactored a bit, prepending txs had been left there until finished.