### PR TITLE
Fix: device call in progress while coinjoin session is running

### DIFF
--- a/packages/coinjoin/src/client/CoinjoinClient.ts
+++ b/packages/coinjoin/src/client/CoinjoinClient.ts
@@ -256,7 +256,7 @@ export class CoinjoinClient extends EventEmitter {
                 this.status.setMode('registered');
 
                 // wait for the result
-                return round.process(this.accounts, this.prison);
+                return round.process(this.accounts);
             }),
         );
 

--- a/packages/coinjoin/src/client/round/selectRound.ts
+++ b/packages/coinjoin/src/client/round/selectRound.ts
@@ -33,7 +33,8 @@ export const getRoundCandidates = ({
     statusRounds,
     coinjoinRounds,
     options,
-}: Pick<SelectRoundProps, 'roundGenerator' | 'statusRounds' | 'coinjoinRounds' | 'options'>) => {
+    prison,
+}: Omit<SelectRoundProps, 'aliceGenerator' | 'accounts' | 'runningAffiliateServer'>) => {
     const now = Date.now();
     return statusRounds
         .filter(
@@ -47,7 +48,7 @@ export const getRoundCandidates = ({
             if (current) return current;
             // try to create new CoinjoinRound
             try {
-                return roundGenerator(round, options);
+                return roundGenerator(round, prison, options);
             } catch (e) {
                 // constructor fails on invalid round data (highly unlikely)
                 return [];
@@ -372,6 +373,7 @@ export const selectRound = async ({
         statusRounds,
         coinjoinRounds,
         options,
+        prison,
     });
     if (roundCandidates.length < 1) {
         logger.log('No suitable rounds');

--- a/packages/coinjoin/src/client/round/selectRound.ts
+++ b/packages/coinjoin/src/client/round/selectRound.ts
@@ -99,6 +99,12 @@ export const getAccountCandidates = ({
         const { accountKey } = account;
         // TODO: double-check account max signed rounds, should be done by suite tho
 
+        // account was detained
+        if (prison.isDetained(accountKey)) {
+            logger.log(`Account ~~${accountKey}~~ detained`);
+            return [];
+        }
+
         const blameOfUtxos = arrayToDictionary(
             account.utxos,
             utxo => {

--- a/packages/coinjoin/src/constants.ts
+++ b/packages/coinjoin/src/constants.ts
@@ -39,6 +39,9 @@ export const FILTERS_REQUEST_TIMEOUT = 300000;
 // timeout for CoinjoinRound currently running process
 export const ROUND_PHASE_PROCESS_TIMEOUT = 10000;
 
+// timeout between account/round creation
+export const ACCOUNT_BUSY_TIMEOUT = 30000;
+
 // fallback values for status request
 // usage of these values is extremely unlikely, there would have to be a change in the coordinator's API
 export const PLEBS_DONT_PAY_THRESHOLD = 1000000;

--- a/packages/coinjoin/tests/client/CoinjoinRound.test.ts
+++ b/packages/coinjoin/tests/client/CoinjoinRound.test.ts
@@ -3,12 +3,9 @@ import * as trezorUtils from '@trezor/utils';
 import { createServer } from '../mocks/server';
 import { DEFAULT_ROUND, createCoinjoinRound } from '../fixtures/round.fixture';
 import { createInput } from '../fixtures/input.fixture';
-import { CoinjoinPrison } from '../../src/client/CoinjoinPrison';
 import * as CONSTANTS from '../../src/constants';
 
 let server: Awaited<ReturnType<typeof createServer>>;
-
-const PRISON = new CoinjoinPrison();
 
 // mock random delay function
 jest.mock('@trezor/utils', () => {
@@ -86,7 +83,7 @@ describe(`CoinjoinRound`, () => {
         );
 
         // process but not wait for the result
-        round.process([], PRISON);
+        round.process([]);
 
         // input-registration is now set with delay ~0.8 sec.
         // we want to change phase earlier
@@ -107,7 +104,7 @@ describe(`CoinjoinRound`, () => {
         expect(registrationSpy).toBeCalledTimes(2); // two registrations
         expect(confirmationSpy).toBeCalledTimes(0); // no confirmations yet
 
-        await round.process([], PRISON);
+        await round.process([]);
         round.inputs.forEach(input => {
             expect(input.error).toBeUndefined();
             expect(input.confirmationData).not.toBeUndefined();
@@ -146,7 +143,7 @@ describe(`CoinjoinRound`, () => {
         );
 
         // process phase 0 but not wait for the result
-        round.process([], PRISON);
+        round.process([]);
 
         // input-registration will respond in  ~2 sec.
         // we want to change phase earlier
@@ -165,7 +162,7 @@ describe(`CoinjoinRound`, () => {
         });
 
         // process phase 1
-        await round.process([], PRISON);
+        await round.process([]);
 
         expect(round.inputs.length).toBe(0); // no valid inputs, requests aborted
         expect(round.failed.length).toBe(0); // no errored inputs, inputs with errors in inputRegistration are not passed further
@@ -197,7 +194,7 @@ describe(`CoinjoinRound`, () => {
         );
 
         // process but not wait for the result
-        round.process([], PRISON);
+        round.process([]);
 
         // we want to change phase before input-registration response
         await new Promise(resolve => setTimeout(resolve, 500));

--- a/packages/coinjoin/tests/client/inputRegistration.test.ts
+++ b/packages/coinjoin/tests/client/inputRegistration.test.ts
@@ -1,12 +1,9 @@
-import { CoinjoinPrison } from '../../src/client/CoinjoinPrison';
 import { inputRegistration } from '../../src/client/round/inputRegistration';
 import { createServer } from '../mocks/server';
 import { createInput } from '../fixtures/input.fixture';
 import { createCoinjoinRound } from '../fixtures/round.fixture';
 
 let server: Awaited<ReturnType<typeof createServer>>;
-
-const prison = new CoinjoinPrison();
 
 // mock random delay function
 jest.mock('@trezor/utils', () => {
@@ -39,7 +36,6 @@ describe('inputRegistration', () => {
                 [createInput('account-A', 'A1'), createInput('account-B', 'B1')],
                 server?.requestOptions,
             ),
-            prison,
             server?.requestOptions,
         );
 
@@ -60,7 +56,6 @@ describe('inputRegistration', () => {
                     round: { phaseDeadline: Date.now() + 3000 },
                 },
             ),
-            prison,
             server?.requestOptions,
         );
 
@@ -137,7 +132,6 @@ describe('inputRegistration', () => {
                     round: { phaseDeadline: Date.now() + 3000 },
                 },
             ),
-            prison,
             server?.requestOptions,
         );
 
@@ -192,7 +186,6 @@ describe('inputRegistration', () => {
                     round: { phaseDeadline: Date.now() + 3000 },
                 },
             ),
-            prison,
             server?.requestOptions,
         );
 
@@ -232,7 +225,6 @@ describe('inputRegistration', () => {
                     round: { phaseDeadline: Date.now() + 3000 },
                 },
             ),
-            prison,
             server?.requestOptions,
         );
 
@@ -253,7 +245,6 @@ describe('inputRegistration', () => {
                 [createInput('account-A', 'A1', { ownershipProof: '01A1' })],
                 server?.requestOptions,
             ),
-            prison,
             server?.requestOptions,
         );
         // input have registrationData but also have an error and should be excluded
@@ -281,7 +272,6 @@ describe('inputRegistration', () => {
                     connectionConfirmationTimeout: '0d 0h 0m 5s',
                 },
             }),
-            prison,
             server?.requestOptions,
         );
 
@@ -307,7 +297,6 @@ describe('inputRegistration', () => {
                     connectionConfirmationTimeout: '0d 0h 0m 4s',
                 },
             }),
-            prison,
             server?.requestOptions,
         );
 
@@ -337,8 +326,7 @@ describe('inputRegistration', () => {
                     connectionConfirmationTimeout: '0d 0h 0m 2s',
                 },
             }),
-            prison,
-            { ...server?.requestOptions },
+            server?.requestOptions,
         );
 
         expect(response.inputs[0].registrationData).toMatchObject({ aliceId: expect.any(String) });

--- a/packages/coinjoin/tests/client/outputRegistration.test.ts
+++ b/packages/coinjoin/tests/client/outputRegistration.test.ts
@@ -1,12 +1,9 @@
-import { CoinjoinPrison } from '../../src/client/CoinjoinPrison';
 import { outputRegistration } from '../../src/client/round/outputRegistration';
 import { createServer } from '../mocks/server';
 import { createInput } from '../fixtures/input.fixture';
 import { createCoinjoinRound } from '../fixtures/round.fixture';
 
 let server: Awaited<ReturnType<typeof createServer>>;
-
-const prison = new CoinjoinPrison();
 
 describe('outputRegistration', () => {
     beforeAll(async () => {
@@ -30,7 +27,6 @@ describe('outputRegistration', () => {
                 },
             }),
             [],
-            prison,
             server?.requestOptions,
         );
         expect(response.inputs[0].error?.message).toMatch(/Missing confirmed credentials/);

--- a/packages/coinjoin/tests/client/selectRound.test.ts
+++ b/packages/coinjoin/tests/client/selectRound.test.ts
@@ -41,6 +41,7 @@ describe('selectRound', () => {
     it('no available candidates in status Rounds', async () => {
         const result = await getRoundCandidates({
             roundGenerator,
+            prison,
             statusRounds: [{ phase: 1 }, { phase: 0, inputRegistrationEnd: new Date() }] as any,
             coinjoinRounds: [],
             options: server?.requestOptions,
@@ -51,6 +52,7 @@ describe('selectRound', () => {
     it('CoinjoinRound creation failed on status Round without RoundCreated event', async () => {
         const result = await getRoundCandidates({
             roundGenerator,
+            prison,
             statusRounds: [
                 {
                     ...DEFAULT_ROUND,
@@ -66,9 +68,10 @@ describe('selectRound', () => {
     });
 
     it('select existing CoinjoinRound', () => {
-        const cjRound = new CoinjoinRound(DEFAULT_ROUND, server?.requestOptions);
+        const cjRound = new CoinjoinRound(DEFAULT_ROUND, prison, server?.requestOptions);
         const result = getRoundCandidates({
             roundGenerator,
+            prison,
             statusRounds: [DEFAULT_ROUND],
             coinjoinRounds: [cjRound],
             options: server?.requestOptions,

--- a/packages/coinjoin/tests/fixtures/round.fixture.ts
+++ b/packages/coinjoin/tests/fixtures/round.fixture.ts
@@ -1,4 +1,5 @@
 import { CoinjoinRound } from '../../src/client/CoinjoinRound';
+import { CoinjoinPrison } from '../../src/client/CoinjoinPrison';
 import { Round } from '../../src/types/coordinator';
 import { ROUND_SELECTION_REGISTRATION_OFFSET } from '../../src/constants';
 
@@ -98,15 +99,23 @@ export const STATUS_EVENT = {
     coinJoinFeeRateMedians: FEE_RATE_MEDIANS,
 };
 
-type CJRoundOptions = ConstructorParameters<typeof CoinjoinRound>[1];
+type CJRoundArgs = ConstructorParameters<typeof CoinjoinRound>;
+type CJRoundOptions = CJRoundArgs[2];
 interface CreateCoinjoinRoundOptions extends CJRoundOptions {
     statusRound?: Partial<Round>;
     round?: Partial<CoinjoinRound>;
+    prison?: CJRoundArgs[1];
     roundParameters?: Partial<CoinjoinRound['roundParameters']>;
 }
 export const createCoinjoinRound = (
     inputs: CoinjoinRound['inputs'],
-    { statusRound, round: roundOptions, roundParameters, ...options }: CreateCoinjoinRoundOptions,
+    {
+        statusRound,
+        round: roundOptions,
+        roundParameters,
+        prison,
+        ...options
+    }: CreateCoinjoinRoundOptions,
 ) => {
     const R = { ...DEFAULT_ROUND };
     if (statusRound) {
@@ -116,7 +125,7 @@ export const createCoinjoinRound = (
         });
     }
 
-    const round = new CoinjoinRound(R, options);
+    const round = new CoinjoinRound(R, prison || new CoinjoinPrison(), options);
     round.inputs = inputs;
 
     if (roundOptions) {

--- a/packages/suite/src/actions/wallet/__fixtures__/coinjoinClientActions.ts
+++ b/packages/suite/src/actions/wallet/__fixtures__/coinjoinClientActions.ts
@@ -155,7 +155,6 @@ export const onCoinjoinRoundChanged = [
         result: {
             actions: [
                 COINJOIN.SESSION_ROUND_CHANGED,
-                MODAL.CLOSE,
                 MODAL.OPEN_USER_CONTEXT,
                 COINJOIN.SESSION_COMPLETED,
             ],
@@ -189,7 +188,6 @@ export const onCoinjoinRoundChanged = [
         result: {
             actions: [
                 COINJOIN.SESSION_ROUND_CHANGED,
-                MODAL.CLOSE,
                 MODAL.OPEN_USER_CONTEXT,
                 COINJOIN.SESSION_COMPLETED,
             ],

--- a/packages/suite/src/actions/wallet/__tests__/coinjoinClientActions.test.ts
+++ b/packages/suite/src/actions/wallet/__tests__/coinjoinClientActions.test.ts
@@ -6,6 +6,7 @@ import { accountsReducer } from '@wallet-reducers';
 import { coinjoinReducer } from '@wallet-reducers/coinjoinReducer';
 import selectedAccountReducer from '@wallet-reducers/selectedAccountReducer';
 import messageSystemReducer from '@suite-reducers/messageSystemReducer';
+import modalReducer from '@suite-reducers/modalReducer';
 import {
     initCoinjoinService,
     onCoinjoinRoundChanged,
@@ -38,7 +39,7 @@ const rootReducer = combineReducers({
         {},
     ),
     devices: createReducer([fixtures.DEVICE], {}),
-    modal: () => ({}),
+    modal: modalReducer,
     messageSystem: messageSystemReducer,
     wallet: combineReducers({
         coinjoin: coinjoinReducer,

--- a/packages/suite/src/actions/wallet/coinjoinAccountActions.ts
+++ b/packages/suite/src/actions/wallet/coinjoinAccountActions.ts
@@ -1,6 +1,7 @@
 import TrezorConnect from '@trezor/connect';
 import type { ScanAccountProgress } from '@trezor/coinjoin/lib/types/backend';
 import { promiseAllSequence } from '@trezor/utils';
+import { SUITE } from '@suite-actions/constants';
 import * as COINJOIN from './constants/coinjoinConstants';
 import { goto } from '../suite/routerActions';
 import { notificationsActions } from '@suite-common/toast-notifications';
@@ -596,7 +597,7 @@ export const restoreCoinjoinSession =
     (accountKey: string) => async (dispatch: Dispatch, getState: GetState) => {
         // TODO: check if device is connected, passphrase is authorized...
         const state = getState();
-        const { device } = state.suite;
+        const { device, locks } = state.suite;
         const account = selectAccountByKey(state, accountKey);
 
         if (!account) {
@@ -613,7 +614,11 @@ export const restoreCoinjoinSession =
         };
 
         if (!device?.connected) {
-            return errorToast('Device is disconnected');
+            return errorToast('Device disconnected');
+        }
+
+        if (locks.includes(SUITE.LOCK_TYPE.DEVICE)) {
+            return errorToast('Device locked');
         }
 
         // get @trezor/coinjoin client if available

--- a/packages/suite/src/actions/wallet/coinjoinClientActions.ts
+++ b/packages/suite/src/actions/wallet/coinjoinClientActions.ts
@@ -201,6 +201,13 @@ export const setBusyScreen =
         );
     };
 
+export const closeCriticalPhaseModal = () => (dispatch: Dispatch, getState: GetState) => {
+    const { modal } = getState();
+    if ('payload' in modal && modal.payload.type === 'critical-coinjoin-phase') {
+        dispatch(closeModal());
+    }
+};
+
 export const onCoinjoinRoundChanged =
     ({ round }: CoinjoinRoundEvent) =>
     async (dispatch: Dispatch, getState: GetState) => {
@@ -257,7 +264,7 @@ export const onCoinjoinRoundChanged =
 
             if (round.phase === RoundPhase.Ended) {
                 await dispatch(setBusyScreen(accountKeys));
-                dispatch(closeModal());
+                dispatch(closeCriticalPhaseModal());
 
                 const completedSessions = coinjoinAccountsWithSession.filter(
                     ({ session }) => session?.signedRounds?.length === session?.maxRounds,
@@ -533,7 +540,7 @@ export const signCoinjoinTx =
         // disable busy screen
         await dispatch(setBusyScreen(Object.keys(groupUtxosByAccount)));
         // and close 'critical-coinjoin-phase' modal
-        dispatch(closeModal());
+        dispatch(closeCriticalPhaseModal());
 
         // finally walk thru all requested utxos and find not resolved
         request.inputs.forEach(utxo => {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Fix for "device call in progress"  issues during coinjoin session.

1. When device is used/locked before round registration (requesting ownership proof)
2. When device is used/locked before round goes into critical phase

## How to test it

Run local version of coinjoin-backend, add Coinjoin account,

Case 1.
- send yourself **one** utxo
- start coinjoin session
- go to receive tab, click on show address button
- wait and watch logs (it might take few minutes)

Result: Address window will not be interrupted, CJ round will never be created until currently running operation (address) is not resolved

Case 2.
- send yourself **second** utxo
- watch logs util you see message like: 
  ```
  Found account candidate tr([5c9e...147145:1 with 2 inputs
  Trying to register...
  ```
- then go to receive tab, click on show address button
- wait and watch logs, suite and the device

Result: Critical phase modal is shown, address is no longer displayed on the device, request was interrupted
