### PR TITLE
fix(suite-native): account balance text variant

### DIFF
--- a/suite-native/module-accounts/src/components/AccountBalance.tsx
+++ b/suite-native/module-accounts/src/components/AccountBalance.tsx
@@ -58,7 +58,11 @@ export const AccountBalance = ({ accountKey }: AccountBalanceProps) => {
                     />
                 </Box>
                 <Box>
-                    <FiatAmountFormatter value={selectedPoint.value} network={account.symbol} />
+                    <FiatAmountFormatter
+                        value={selectedPoint.value}
+                        network={account.symbol}
+                        variant="titleLarge"
+                    />
                 </Box>
             </Box>
             <Box marginBottom="large">


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Fix account detail account balance text variant according to figma.

## Related Issue

Resolve <!--- link the issue here -->

## Screenshots:
Before: 
<img width="440" alt="image" src="https://user-images.githubusercontent.com/36101761/219487154-f754efae-47a3-4270-a39d-1ffe8f13e91d.png">

After: 
<img width="442" alt="image" src="https://user-images.githubusercontent.com/36101761/219487065-496a48d2-d270-454f-933c-5ee02b1e6271.png">

