### PR TITLE
Working mainnet CJ discovery

### DIFF
--- a/packages/coinjoin/src/backend/CoinjoinBackendClient.ts
+++ b/packages/coinjoin/src/backend/CoinjoinBackendClient.ts
@@ -8,7 +8,7 @@ import type {
     BlockbookTransaction,
 } from '../types/backend';
 import type { CoinjoinBackendSettings, Logger } from '../types';
-import { GRADUAL_HTTP_REQUEST_SCHEDULE } from '../constants';
+import { FILTERS_REQUEST_TIMEOUT, HTTP_REQUEST_GAP, HTTP_REQUEST_TIMEOUT } from '../constants';
 
 type CoinjoinBackendClientSettings = CoinjoinBackendSettings & {
     timeout?: number;
@@ -91,7 +91,7 @@ export class CoinjoinBackendClient {
         return this.scheduleGet(
             this.wabisabi,
             this.handleFiltersResponse,
-            options,
+            { ...options, timeout: FILTERS_REQUEST_TIMEOUT },
             'Blockchain/filters',
             { bestKnownBlockHash, count },
         );
@@ -161,7 +161,7 @@ export class CoinjoinBackendClient {
                         this.logger?.error(error?.message);
                         throw error;
                     }),
-            { attempts: GRADUAL_HTTP_REQUEST_SCHEDULE, ...options }, // default attempts/timeout could be overriden by options
+            { attempts: 3, timeout: HTTP_REQUEST_TIMEOUT, gap: HTTP_REQUEST_GAP, ...options }, // default attempts/timeout could be overriden by options
         );
     }
 

--- a/packages/coinjoin/src/constants.ts
+++ b/packages/coinjoin/src/constants.ts
@@ -28,12 +28,11 @@ export const ROUND_SELECTION_REGISTRATION_OFFSET = 30000;
 // custom timeout for http requests (default is 50000 ms)
 export const HTTP_REQUEST_TIMEOUT = 35000;
 
-// used in backend client for gradually prolonging request timeout and gap
-export const GRADUAL_HTTP_REQUEST_SCHEDULE = [
-    { timeout: 20000, gap: 1000 },
-    { timeout: 40000, gap: 5000 },
-    { timeout: 60000, gap: 10000 },
-] as const;
+// gap (in ms) between two attempts of the same http request
+export const HTTP_REQUEST_GAP = 1000;
+
+// special timeout for quite large filter batches downloaded over tor
+export const FILTERS_REQUEST_TIMEOUT = 300000;
 
 // timeout for CoinjoinRound currently running process
 export const ROUND_PHASE_PROCESS_TIMEOUT = 10000;


### PR DESCRIPTION
## Description

Given that filter batch requests over Tor take a loooot of time, timeout was set to 5 minutes for them. With this fix, mainnet CJ discovery should work over Blockbook's REST API (still without mempool).

Rewriting to websockets is on the way.