### PR TITLE
popup tests fixes

### DIFF
--- a/packages/connect-popup/e2e/tests/__fixtures__/methods.ts
+++ b/packages/connect-popup/e2e/tests/__fixtures__/methods.ts
@@ -232,7 +232,7 @@ const signMessage = [
         device: initializedDevice,
         views: [
             {
-                selector: '.info-panel', // does not have a special screen
+                selector: '[data-test="@info-panel"]', // does not have a special screen
                 screenshot: {
                     name: 'sign-message',
                 },
@@ -241,7 +241,7 @@ const signMessage = [
                 },
             },
             {
-                selector: '.info-panel',
+                selector: '[data-test="@info-panel"]',
                 nextEmu: {
                     type: 'emulator-press-yes',
                 },
@@ -434,7 +434,7 @@ const ethereumSignTypedData = [
         device: initializedDevice,
         views: [
             {
-                selector: '.info-panel',
+                selector: '[data-test="@info-panel"]',
                 screenshot: {
                     name: 'sign-message',
                 },
@@ -443,7 +443,7 @@ const ethereumSignTypedData = [
                 },
             },
             {
-                selector: '.info-panel',
+                selector: '[data-test="@info-panel"]',
                 screenshot: {
                     name: 'sign-message',
                 },
@@ -452,7 +452,7 @@ const ethereumSignTypedData = [
                 },
             },
             {
-                selector: '.info-panel',
+                selector: '[data-test="@info-panel"]',
                 nextEmu: {
                     type: 'emulator-press-yes',
                 },

--- a/packages/connect-popup/e2e/tests/popup-close.test.ts
+++ b/packages/connect-popup/e2e/tests/popup-close.test.ts
@@ -48,7 +48,6 @@ test.beforeAll(async () => {
             needs_backup: false,
         });
         await TrezorUserEnvLink.api.startBridge(bridgeVersion);
-
         await page.goto(`${url}#/method/verifyMessage`);
         await page.waitForSelector("button[data-test='@submit-button']", { state: 'visible' });
 
@@ -131,7 +130,7 @@ test.beforeAll(async () => {
 
         if (bridgeVersion === '2.0.31') {
             expect(responses[12].url).toEqual('http://127.0.0.1:21325/post/2');
-            await page.waitForSelector('text=Failure_ActionCancelled');
+            await page.waitForSelector('text=Method_Interrupted');
         }
     });
 

--- a/packages/connect-ui/src/components/InfoPanel.tsx
+++ b/packages/connect-ui/src/components/InfoPanel.tsx
@@ -72,7 +72,7 @@ interface InfoPanelProps {
 
 export const InfoPanel = ({ method, origin, topSlot }: InfoPanelProps) => (
     <>
-        <Aside>
+        <Aside data-test="@info-panel">
             {/*  notifications appear hear */}
             {topSlot && topSlot}
 


### PR DESCRIPTION
changes here b45b3a21df2b9a809b6dd55ba0db5a2f8f00fc01 were also detected by popup tests. Now, when user manually closes popup, it returns different error. Previously it was `Failure_ActionCancelled`, which should be reserved for cancelling action on device. Now it is `Method_Interrupted` which is actually correct.

changes here 1d22bdbc5badcb6d953e8dd13743fb8b6b193ce4 broke some of the `methods.test.ts` 