### PR TITLE
End coinjoin when anonymity reached

### DIFF
--- a/packages/suite/src/actions/wallet/__fixtures__/coinjoinClientActions.ts
+++ b/packages/suite/src/actions/wallet/__fixtures__/coinjoinClientActions.ts
@@ -195,11 +195,18 @@ export const onCoinjoinRoundChanged = [
         },
     },
     {
-        description: 'Multiple events',
+        description: 'Multiple events - coinjoin ends at max rounds',
         connect: undefined,
         state: {
             devices: [{ ...DEVICE, features: { busy: true } }],
-            accounts: [{ key: 'a', deviceState: 'device-state' }],
+            accounts: [
+                {
+                    key: 'a',
+                    deviceState: 'device-state',
+                    addresses: { anonymitySet: { address: 1 } },
+                    utxo: [{ address: 'address' }],
+                },
+            ],
             selectedAccount: { key: 'a' },
             coinjoin: {
                 accounts: [

--- a/packages/suite/src/components/suite/ModalSwitcher/UserContextModal.tsx
+++ b/packages/suite/src/components/suite/ModalSwitcher/UserContextModal.tsx
@@ -40,7 +40,7 @@ import type { AcquiredDevice } from '@suite-types';
 import type { ReduxModalProps } from './types';
 import { DisableTorStopCoinjoin } from '@suite-components/modals/DisableTorStopCoinjoin';
 
-/** Modals opened as result of user action */
+/** Modals opened as a result of user action */
 export const UserContextModal = ({
     payload,
     renderer,

--- a/packages/suite/src/components/wallet/CoinjoinSummary/CoinjoinStatus.tsx
+++ b/packages/suite/src/components/wallet/CoinjoinSummary/CoinjoinStatus.tsx
@@ -1,4 +1,4 @@
-import React, { useMemo, useRef, useState, useCallback } from 'react';
+import React, { useCallback, useMemo, useRef, useState } from 'react';
 import { useDispatch } from 'react-redux';
 import styled, { css } from 'styled-components';
 import { lighten } from 'polished';

--- a/packages/suite/src/reducers/wallet/coinjoinReducer.ts
+++ b/packages/suite/src/reducers/wallet/coinjoinReducer.ts
@@ -572,7 +572,7 @@ export const selectMinAllowedInputWithFee = memoizeWithArgs(
     },
 );
 
-export const selectAreUtxosTooSmallByAccountKey = memoizeWithArgs(
+export const selectIsNothingToAnonymizeByAccountKey = memoizeWithArgs(
     (state: CoinjoinRootState, accountKey: AccountKey) => {
         const minAllowedInputWithFee = selectMinAllowedInputWithFee(state, accountKey);
         const account = selectAccountByKey(state, accountKey);
@@ -672,7 +672,7 @@ export const selectCoinjoinSessionBlockerByAccountKey = memoizeWithArgs(
         if (!state.suite.online) {
             return 'OFFLINE';
         }
-        if (selectAreUtxosTooSmallByAccountKey(state, accountKey)) {
+        if (selectIsNothingToAnonymizeByAccountKey(state, accountKey)) {
             return 'NOTHING_TO_ANONYMIZE';
         }
         if (selectIsCoinjoinBlockedByTor(state)) {


### PR DESCRIPTION
## Description

f2865d95cfd401863ec9467aa7655c601e5d1aae - update account at the end of each coinjoin round and check utxos; end coinjoin session and show success modal if there is nothing more to coinjoin (i.e all UTXOs with large enough amount have reached target anonymity).

- I noticed that the event for the final round phase is fired twice. I don't think it causes any problems so far, but can it be prevented somehow?

7ea390106e0032a75cafc91e3757399d9114e177 - end coinjoin session when all non-private UTXOs are spent during a (paused) coinjoin session. I added this to an effect in `CoinjoinStatus` for simplicity as the check happens there already and the component opens right after spending coins.

## Related Issue

Resolve #7471

## Screenshots:
![Screenshot 2023-02-21 at 10 49 35](https://user-images.githubusercontent.com/42465546/220362665-b6271f17-e006-410b-9882-8d9d7df6e2c1.png)

