### PR TITLE
feat(message-system, coinjoin): increase the roundsFailRateBuffer and disable coinjoin for Suite below 23.2.2

### DIFF
--- a/packages/message-system/src/config/config.v1.json
+++ b/packages/message-system/src/config/config.v1.json
@@ -1,7 +1,7 @@
 {
     "version": 1,
-    "timestamp": "2023-03-08T00:00:00+00:00",
-    "sequence": 23,
+    "timestamp": "2023-02-22T00:00:00+00:00",
+    "sequence": 24,
     "actions": [
         {
             "conditions": [
@@ -32,7 +32,7 @@
                         "domain": "coinjoin",
                         "flag": true,
                         "averageAnonymityGainPerRound": 5,
-                        "roundsFailRateBuffer": 3.5,
+                        "roundsFailRateBuffer": 10,
                         "roundsDurationInHours": 1
                     }
                 ],
@@ -43,9 +43,9 @@
             "conditions": [
                 {
                     "environment": {
-                        "desktop": "<23.2.1",
+                        "desktop": "<23.2.2",
                         "mobile": "!",
-                        "web": "<23.2.1"
+                        "web": "<23.2.2"
                     }
                 }
             ],


### PR DESCRIPTION
new coinjoin params:
```
"averageAnonymityGainPerRound": 5,
"roundsFailRateBuffer": 10,
"roundsDurationInHours": 1
```

coinjoin disabled for Suite < 23.2.2
