### PR TITLE
fix(connect): get rid of webusb option deprecation warning

### DIFF
--- a/packages/connect/src/data/connectSettings.ts
+++ b/packages/connect/src/data/connectSettings.ts
@@ -25,8 +25,6 @@ const initialSettings: ConnectSettings = {
     popup: true,
     popupSrc: `${DEFAULT_DOMAIN}popup.html`,
     webusbSrc: `${DEFAULT_DOMAIN}webusb.html`,
-    // deprecated, use transports instead
-    webusb: true,
     transports: undefined,
     pendingTransportEvent: true,
     supportedBrowser:


### PR DESCRIPTION
You can now see a warning about using deprecated `webusb` option in TrezorConnect.init is Suite. 

We should still accept this option but it should not be filled in as default in connectSettings because it would then cause this warning to appear. This change should be pretty safe, all required fallbacks and defaults are present in other places and connect logic now depends on `transports: ('BridgeTransport' | 'WebUsbTransport')[]` option