### PR TITLE
refactor(suite-native): print mocked values of extra dependencies onl…

### DIFF
--- a/suite-common/test-utils/src/extraDependenciesMock.ts
+++ b/suite-common/test-utils/src/extraDependenciesMock.ts
@@ -5,11 +5,16 @@ import { PROTO } from '@trezor/connect';
 
 import { testMocks } from './mocks';
 
+const mockedConsoleAlreadyPrinted: string[] = [];
+
 const mockedConsoleLog = (...args: any) => {
     // we don't want to see console.log in tests because it's too noisy
-    if (process.env.NODE_ENV !== 'test') {
+    if (process.env.NODE_ENV !== 'test' && !mockedConsoleAlreadyPrinted.includes(args[0])) {
         // eslint-disable-next-line no-console
         console.log(...args);
+
+        // print every log only once
+        mockedConsoleAlreadyPrinted.push(args[0]);
     }
 };
 


### PR DESCRIPTION
The console stdout was flooded with extra dependency mocks logs. This revision controls each mock to be written out only once.
