### PR TITLE
Halve filter batch sizes in CJ config

### DIFF
--- a/packages/coinjoin/src/backend/CoinjoinFilterController.ts
+++ b/packages/coinjoin/src/backend/CoinjoinFilterController.ts
@@ -1,4 +1,4 @@
-import { FILTERS_BATCH_SIZE, PROGRESS_BATCH_SIZE_MIN, PROGRESS_BATCH_SIZE_MAX } from '../constants';
+import { PROGRESS_BATCH_SIZE_MIN, PROGRESS_BATCH_SIZE_MAX } from '../constants';
 import type {
     FilterClient,
     FilterController,
@@ -17,7 +17,7 @@ export class CoinjoinFilterController implements FilterController {
         { baseBlockHash, baseBlockHeight, filtersBatchSize }: CoinjoinBackendSettings,
     ) {
         this.client = client;
-        this.batchSize = filtersBatchSize ?? FILTERS_BATCH_SIZE;
+        this.batchSize = filtersBatchSize;
         this.baseBlock = {
             blockHash: baseBlockHash,
             blockHeight: baseBlockHeight,

--- a/packages/coinjoin/src/constants.ts
+++ b/packages/coinjoin/src/constants.ts
@@ -1,8 +1,3 @@
-// Maximum number of filters requested from backend in one request
-// TODO post MVP: unify filters batch size with wabisabi or implement filters on blockbooks
-// https://github.com/trezor/trezor-suite/issues/7182#issuecomment-1438182493
-export const FILTERS_BATCH_SIZE = 10000 / 2;
-
 // Minimum number of blocks after which 'progress' event is fired by scanAccount
 export const PROGRESS_BATCH_SIZE_MIN = 10;
 

--- a/packages/coinjoin/src/types/index.ts
+++ b/packages/coinjoin/src/types/index.ts
@@ -8,7 +8,7 @@ export interface CoinjoinBackendSettings extends BaseSettings {
     blockbookUrls: readonly string[];
     baseBlockHeight: number;
     baseBlockHash: string;
-    filtersBatchSize?: number;
+    filtersBatchSize: number;
     storagePath?: string;
 }
 

--- a/packages/coinjoin/tests/fixtures/config.fixture.ts
+++ b/packages/coinjoin/tests/fixtures/config.fixture.ts
@@ -5,4 +5,5 @@ export const COINJOIN_BACKEND_SETTINGS = {
     blockbookUrls: ['http://localhost:8081/blockbook/api/v2'],
     baseBlockHeight: 0,
     baseBlockHash: '0f9188f13cb7b2c71f2a335e3a4fc328bf5beb436012afca590b1a11466e2206',
+    filtersBatchSize: 1000,
 } as const;

--- a/packages/suite/src/services/coinjoin/config.ts
+++ b/packages/suite/src/services/coinjoin/config.ts
@@ -31,7 +31,9 @@ export const COINJOIN_NETWORKS: PartialRecord<NetworkSymbol, ServerEnvironment> 
             /* 31.01.2023 */
             baseBlockHeight: 774460,
             baseBlockHash: '0000000000000000000013be741eb25cece368611509ac013332c2af7ce027ac',
-            filtersBatchSize: 1000,
+            // TODO post MVP: unify filters batch size with wabisabi or implement filters on blockbooks
+            // https://github.com/trezor/trezor-suite/issues/7182#issuecomment-1438182493
+            filtersBatchSize: 500,
             middlewareUrl: 'http://localhost:8081/',
         },
     },
@@ -83,7 +85,7 @@ export const COINJOIN_NETWORKS: PartialRecord<NetworkSymbol, ServerEnvironment> 
             baseBlockHeight: 2349000,
             baseBlockHash: '0000000000000014af3e6e1a3f0a24be7bc65998b9bc01e4a05b134a89d304bf',
             /* */
-            filtersBatchSize: 10000,
+            filtersBatchSize: 5000,
             // client settings
             middlewareUrl: 'http://localhost:8081/',
         },
@@ -96,7 +98,7 @@ export const COINJOIN_NETWORKS: PartialRecord<NetworkSymbol, ServerEnvironment> 
             blockbookUrls: ['https://tbtc1.trezor.io/api/v2', 'https://tbtc2.trezor.io/api/v2'],
             baseBlockHeight: 2349000,
             baseBlockHash: '0000000000000014af3e6e1a3f0a24be7bc65998b9bc01e4a05b134a89d304bf',
-            filtersBatchSize: 10000,
+            filtersBatchSize: 5000,
             // client settings
             middlewareUrl: 'http://localhost:8081/',
         },
@@ -111,7 +113,7 @@ export const COINJOIN_NETWORKS: PartialRecord<NetworkSymbol, ServerEnvironment> 
             blockbookUrls: ['https://dev-coinjoin.trezor.io/blockbook/api/v2'],
             baseBlockHeight: 0,
             baseBlockHash: '0f9188f13cb7b2c71f2a335e3a4fc328bf5beb436012afca590b1a11466e2206',
-            filtersBatchSize: 10000,
+            filtersBatchSize: 5000,
             // client settings
             middlewareUrl: 'https://dev-coinjoin.trezor.io/client/',
         },
@@ -124,7 +126,7 @@ export const COINJOIN_NETWORKS: PartialRecord<NetworkSymbol, ServerEnvironment> 
             blockbookUrls: ['http://localhost:8081/blockbook/api/v2'],
             baseBlockHeight: 0,
             baseBlockHash: '0f9188f13cb7b2c71f2a335e3a4fc328bf5beb436012afca590b1a11466e2206',
-            filtersBatchSize: 10000,
+            filtersBatchSize: 5000,
             // client settings
             middlewareUrl: 'http://localhost:8081/client/',
         },


### PR DESCRIPTION
## Description

As #7677 halved only default filter batch size, this PR halves actual values in current CJ configs.
