### PR TITLE
feat(blockchain-link): add getBlock method

### DIFF
--- a/packages/blockchain-link/src/constants/messages.ts
+++ b/packages/blockchain-link/src/constants/messages.ts
@@ -8,6 +8,7 @@ export const GET_FIAT_RATES_FOR_TIMESTAMPS = 'm_get_fiat_rates_for_timestamps';
 export const GET_ACCOUNT_BALANCE_HISTORY = 'm_get_account_balance_history';
 export const GET_FIAT_RATES_TICKERS_LIST = 'm_get_fiat_rates_tickers_list';
 export const GET_BLOCK_HASH = 'm_get_block_hash';
+export const GET_BLOCK = 'm_get_block';
 export const GET_ACCOUNT_INFO = 'm_get_account_info';
 export const GET_ACCOUNT_UTXO = 'm_get_account_utxo';
 export const GET_TRANSACTION = 'm_get_transaction';

--- a/packages/blockchain-link/src/constants/responses.ts
+++ b/packages/blockchain-link/src/constants/responses.ts
@@ -3,6 +3,7 @@ export const ERROR = 'r_error'; // exception: this could be also emitted as even
 export const CONNECT = 'r_connect';
 export const GET_INFO = 'r_info';
 export const GET_BLOCK_HASH = 'r_get_block_hash';
+export const GET_BLOCK = 'r_get_block';
 export const GET_CURRENT_FIAT_RATES = 'r_get_current_fiat_rates';
 export const GET_FIAT_RATES_FOR_TIMESTAMPS = 'r_get_fiat_rates_for_timestamps';
 export const GET_FIAT_RATES_TICKERS_LIST = 'r_GET_FIAT_RATES_TICKERS_LIST';

--- a/packages/blockchain-link/src/index.ts
+++ b/packages/blockchain-link/src/index.ts
@@ -126,6 +126,16 @@ class BlockchainLink extends EventEmitter {
         });
     }
 
+    /** Get block of given height or hash */
+    getBlock(
+        payload: MessageTypes.GetBlock['payload'],
+    ): Promise<ResponseTypes.GetBlock['payload']> {
+        return this.sendMessage({
+            type: MESSAGES.GET_BLOCK,
+            payload,
+        });
+    }
+
     /** Get info about an account, eg. derived addresses, balance, transaction history etc. */
     getAccountInfo(
         payload: MessageTypes.GetAccountInfo['payload'],

--- a/packages/blockchain-link/src/types/blockbook.ts
+++ b/packages/blockchain-link/src/types/blockbook.ts
@@ -35,6 +35,16 @@ export interface BlockHash {
     hash: string;
 }
 
+export interface Block {
+    page: number;
+    totalPages: number;
+    itemsOnPage: number;
+    hash: string;
+    height: number;
+    txCount: number;
+    txs: Transaction[];
+}
+
 export interface XPUBAddress {
     type: 'XPUBAddress';
     name: string;
@@ -179,6 +189,7 @@ export interface AvailableCurrencies {
 
 declare function FSend(method: 'getInfo'): Promise<ServerInfo>;
 declare function FSend(method: 'getBlockHash', params: { height: number }): Promise<BlockHash>;
+declare function FSend(method: 'getBlock', params: { id: string }): Promise<Block>;
 declare function FSend(method: 'getAccountInfo', params: AccountInfoParams): Promise<AccountInfo>;
 declare function FSend(method: 'getAccountUtxo', params: AccountUtxoParams): Promise<AccountUtxo>;
 declare function FSend(method: 'getTransaction', params: { txid: string }): Promise<Transaction>;

--- a/packages/blockchain-link/src/types/messages.ts
+++ b/packages/blockchain-link/src/types/messages.ts
@@ -27,6 +27,11 @@ export interface GetBlockHash {
     payload: number;
 }
 
+export interface GetBlock {
+    type: typeof MESSAGES.GET_BLOCK;
+    payload: number | string; // height or hash
+}
+
 export interface GetAccountInfo {
     type: typeof MESSAGES.GET_ACCOUNT_INFO;
     payload: AccountInfoParams;
@@ -124,6 +129,7 @@ export type Message =
     | ChannelMessage<Disconnect>
     | ChannelMessage<GetInfo>
     | ChannelMessage<GetBlockHash>
+    | ChannelMessage<GetBlock>
     | ChannelMessage<GetAccountInfo>
     | ChannelMessage<GetAccountUtxo>
     | ChannelMessage<GetTransaction>

--- a/packages/blockchain-link/src/types/responses.ts
+++ b/packages/blockchain-link/src/types/responses.ts
@@ -10,7 +10,7 @@ import type {
     AccountBalanceHistory,
     ChannelMessage,
 } from './common';
-import type { MempoolTransactionNotification } from './blockbook';
+import type { MempoolTransactionNotification, Block } from './blockbook';
 
 // messages sent from worker to blockchain.js
 
@@ -35,6 +35,11 @@ export interface GetInfo {
 export interface GetBlockHash {
     type: typeof RESPONSES.GET_BLOCK_HASH;
     payload: string;
+}
+
+export interface GetBlock {
+    type: typeof RESPONSES.GET_BLOCK;
+    payload: Block;
 }
 
 export interface GetAccountInfo {
@@ -154,6 +159,7 @@ export type Response =
     | ChannelMessage<Connect>
     | ChannelMessage<GetInfo>
     | ChannelMessage<GetBlockHash>
+    | ChannelMessage<GetBlock>
     | ChannelMessage<GetAccountInfo>
     | ChannelMessage<GetAccountUtxo>
     | ChannelMessage<GetTransaction>

--- a/packages/blockchain-link/src/ui/index.html
+++ b/packages/blockchain-link/src/ui/index.html
@@ -115,6 +115,11 @@
             <input id="blockhash-number" class="form-input" type="text" />
             <button id="get-blockhash" class="btn">Get block hash</button>
         </div>
+        <div class="row">
+            <label>Block number/hash</label>
+            <input id="block-id" class="form-input" type="text" />
+            <button id="get-block" class="btn">Get block</button>
+        </div>
         <div class="row" id="notification-fiat-rates">
             <label>Subscribe Fiat Rates</label>
             <input id="subscribe-fiat-rates-currency" class="form-input" type="text" />

--- a/packages/blockchain-link/src/ui/index.ui.ts
+++ b/packages/blockchain-link/src/ui/index.ui.ts
@@ -141,6 +141,10 @@ const handleClick = (event: MouseEvent) => {
                 .catch(onError);
             break;
 
+        case 'get-block':
+            blockchain.getBlock(getInputValue('block-id')).then(onResponse).catch(onError);
+            break;
+
         case 'subscribe-fiat-rates':
             blockchain
                 .subscribe({

--- a/packages/blockchain-link/src/workers/blockbook/index.ts
+++ b/packages/blockchain-link/src/workers/blockbook/index.ts
@@ -36,6 +36,15 @@ const getBlockHash = async (request: Request<MessageTypes.GetBlockHash>) => {
     } as const;
 };
 
+const getBlock = async (request: Request<MessageTypes.GetBlock>) => {
+    const api = await request.connect();
+    const info = await api.getBlock(request.payload);
+    return {
+        type: RESPONSES.GET_BLOCK,
+        payload: info,
+    } as const;
+};
+
 const getAccountInfo = async (request: Request<MessageTypes.GetAccountInfo>) => {
     const { payload } = request;
     const api = await request.connect();
@@ -355,6 +364,8 @@ const onRequest = (request: Request<Message>) => {
             return getInfo(request);
         case MESSAGES.GET_BLOCK_HASH:
             return getBlockHash(request);
+        case MESSAGES.GET_BLOCK:
+            return getBlock(request);
         case MESSAGES.GET_ACCOUNT_INFO:
             return getAccountInfo(request);
         case MESSAGES.GET_ACCOUNT_UTXO:

--- a/packages/blockchain-link/src/workers/blockbook/websocket.ts
+++ b/packages/blockchain-link/src/workers/blockbook/websocket.ts
@@ -265,6 +265,10 @@ export class BlockbookAPI extends EventEmitter {
         return this.send('getBlockHash', { height: block });
     }
 
+    getBlock(block: number | string) {
+        return this.send('getBlock', { id: `${block}` });
+    }
+
     getAccountInfo(payload: AccountInfoParams) {
         return this.send('getAccountInfo', payload);
     }


### PR DESCRIPTION
## Description
Add new `getBlock` method to Blockbook's websocket API.

Currently not supported on production Blockbooks, but could be tested at `https://blockbook-dev.corp.sldev.cz:19130/` (testnet).