### PR TITLE
chore(blockchain-link): Use types generated automatically from Blockbook

### DIFF
--- a/packages/blockchain-link/src/types/blockbook-api.d.ts
+++ b/packages/blockchain-link/src/types/blockbook-api.d.ts
@@ -1,0 +1,407 @@
+/* Do not change, this code is generated from Golang structs */
+
+export interface APIError {
+    Text: string;
+    Public: boolean;
+}
+export interface AddressAlias {
+    Type: string;
+    Alias: string;
+}
+export interface EthereumInternalTransfer {
+    type: number;
+    from: string;
+    to: string;
+    value?: string;
+}
+export interface EthereumParsedInputParam {
+    type: string;
+    values?: string[];
+}
+export interface EthereumParsedInputData {
+    methodId: string;
+    name: string;
+    function?: string;
+    params?: EthereumParsedInputParam[];
+}
+export interface EthereumSpecific {
+    type?: number;
+    createdContract?: string;
+    status: number;
+    error?: string;
+    nonce: number;
+    gasLimit?: string;
+    gasUsed?: string;
+    gasPrice?: string;
+    data?: string;
+    parsedData?: EthereumParsedInputData;
+    internalTransfers?: EthereumInternalTransfer[];
+}
+export interface MultiTokenValue {
+    id?: string;
+    value?: string;
+}
+export interface TokenTransfer {
+    type: string;
+    from: string;
+    to: string;
+    contract: string;
+    name: string;
+    symbol: string;
+    decimals: number;
+    value?: string;
+    multiTokenValues?: MultiTokenValue[];
+}
+export interface Vout {
+    value?: string;
+    n: number;
+    spent?: boolean;
+    spentTxId?: string;
+    spentIndex?: number;
+    spentHeight?: number;
+    hex?: string;
+    asm?: string;
+    addresses: string[];
+    isAddress: boolean;
+    isOwn?: boolean;
+    type?: string;
+}
+export interface Vin {
+    txid?: string;
+    vout?: number;
+    sequence?: number;
+    n: number;
+    addresses?: string[];
+    isAddress: boolean;
+    isOwn?: boolean;
+    value?: string;
+    hex?: string;
+    asm?: string;
+    coinbase?: string;
+}
+export interface Tx {
+    txid: string;
+    version?: number;
+    lockTime?: number;
+    vin: Vin[];
+    vout: Vout[];
+    blockHash?: string;
+    blockHeight: number;
+    confirmations: number;
+    confirmationETABlocks?: number;
+    confirmationETASeconds?: number;
+    blockTime: number;
+    size?: number;
+    vsize?: number;
+    value?: string;
+    valueIn?: string;
+    fees?: string;
+    hex?: string;
+    rbf?: boolean;
+    coinSpecificData?: any;
+    tokenTransfers?: TokenTransfer[];
+    ethereumSpecific?: EthereumSpecific;
+    addressAliases?: { [key: string]: AddressAlias };
+}
+export interface FeeStats {
+    txCount: number;
+    totalFeesSat?: string;
+    averageFeePerKb: number;
+    decilesFeePerKb: number[];
+}
+export interface ContractInfo {
+    type: string;
+    contract: string;
+    name: string;
+    symbol: string;
+    decimals: number;
+    createdInBlock?: number;
+    destructedInBlock?: number;
+}
+export interface Token {
+    type: 'XPUBAddress' | 'ERC20' | 'ERC721' | 'ERC1155';
+    name: string;
+    path?: string;
+    contract?: string;
+    transfers: number;
+    symbol?: string;
+    decimals?: number;
+    balance?: string;
+    baseValue?: number;
+    secondaryValue?: number;
+    ids?: string[];
+    multiTokenValues?: MultiTokenValue[];
+    totalReceived?: string;
+    totalSent?: string;
+}
+export interface Address {
+    page?: number;
+    totalPages?: number;
+    itemsOnPage?: number;
+    address: string;
+    balance?: string;
+    totalReceived?: string;
+    totalSent?: string;
+    unconfirmedBalance?: string;
+    unconfirmedTxs: number;
+    txs: number;
+    nonTokenTxs?: number;
+    internalTxs?: number;
+    transactions?: Tx[];
+    txids?: string[];
+    nonce?: string;
+    usedTokens?: number;
+    tokens?: Token[];
+    secondaryValue?: number;
+    tokensBaseValue?: number;
+    tokensSecondaryValue?: number;
+    totalBaseValue?: number;
+    totalSecondaryValue?: number;
+    contractInfo?: ContractInfo;
+    erc20Contract?: ContractInfo;
+    addressAliases?: { [key: string]: AddressAlias };
+}
+export interface Utxo {
+    txid: string;
+    vout: number;
+    value?: string;
+    height?: number;
+    confirmations: number;
+    address?: string;
+    path?: string;
+    lockTime?: number;
+    coinbase?: boolean;
+}
+export interface BalanceHistory {
+    time: number;
+    txs: number;
+    received?: string;
+    sent?: string;
+    sentToSelf?: string;
+    rates?: { [key: string]: number };
+    txid?: string;
+}
+export interface BlockInfo {
+    Hash: string;
+    Time: number;
+    Txs: number;
+    Size: number;
+    Height: number;
+}
+export interface Blocks {
+    page?: number;
+    totalPages?: number;
+    itemsOnPage?: number;
+    blocks: BlockInfo[];
+}
+export interface Block {
+    page?: number;
+    totalPages?: number;
+    itemsOnPage?: number;
+    hash: string;
+    previousBlockHash?: string;
+    nextBlockHash?: string;
+    height: number;
+    confirmations: number;
+    size: number;
+    time?: number;
+    version: string;
+    merkleRoot: string;
+    nonce: string;
+    bits: string;
+    difficulty: string;
+    tx?: string[];
+    txCount: number;
+    txs?: Tx[];
+    addressAliases?: { [key: string]: AddressAlias };
+}
+export interface BlockRaw {
+    hex: string;
+}
+export interface BackendInfo {
+    error?: string;
+    chain?: string;
+    blocks?: number;
+    headers?: number;
+    bestBlockHash?: string;
+    difficulty?: string;
+    sizeOnDisk?: number;
+    version?: string;
+    subversion?: string;
+    protocolVersion?: string;
+    timeOffset?: number;
+    warnings?: string;
+    consensus_version?: string;
+    consensus?: any;
+}
+export interface InternalStateColumn {
+    name: string;
+    version: number;
+    rows: number;
+    keyBytes: number;
+    valueBytes: number;
+    updated: string;
+}
+export interface BlockbookInfo {
+    coin: string;
+    host: string;
+    version: string;
+    gitCommit: string;
+    buildTime: string;
+    syncMode: boolean;
+    initialSync: boolean;
+    inSync: boolean;
+    bestHeight: number;
+    lastBlockTime: string;
+    inSyncMempool: boolean;
+    lastMempoolTime: string;
+    mempoolSize: number;
+    decimals: number;
+    dbSize: number;
+    hasFiatRates?: boolean;
+    hasTokenFiatRates?: boolean;
+    currentFiatRatesTime?: string;
+    historicalFiatRatesTime?: string;
+    historicalTokenFiatRatesTime?: string;
+    dbSizeFromColumns?: number;
+    dbColumns?: InternalStateColumn[];
+    about: string;
+}
+export interface SystemInfo {
+    blockbook?: BlockbookInfo;
+    backend?: BackendInfo;
+}
+export interface FiatTicker {
+    ts?: number;
+    rates: { [key: string]: number };
+    error?: string;
+}
+export interface FiatTickers {
+    tickers: FiatTicker[];
+}
+export interface AvailableVsCurrencies {
+    ts?: number;
+    available_currencies: string[];
+    error?: string;
+}
+export interface WsReq {
+    id: string;
+    method:
+        | 'getAccountInfo'
+        | 'getInfo'
+        | 'getBlockHash'
+        | 'getAccountUtxo'
+        | 'getBalanceHistory'
+        | 'getTransaction'
+        | 'getTransactionSpecific'
+        | 'estimateFee'
+        | 'sendTransaction'
+        | 'subscribeNewBlock'
+        | 'unsubscribeNewBlock'
+        | 'subscribeNewTransaction'
+        | 'unsubscribeNewTransaction'
+        | 'subscribeAddresses'
+        | 'unsubscribeAddresses'
+        | 'subscribeFiatRates'
+        | 'unsubscribeFiatRates'
+        | 'ping'
+        | 'getCurrentFiatRates'
+        | 'getFiatRatesForTimestamps'
+        | 'getFiatRatesTickersList';
+    params: any;
+}
+export interface WsRes {
+    id: string;
+    data: any;
+}
+export interface WsAccountInfoReq {
+    descriptor: string;
+    details?: 'basic' | 'tokens' | 'tokenBalances' | 'txids' | 'txslight' | 'txs';
+    tokens?: 'derived' | 'used' | 'nonzero';
+    pageSize?: number;
+    page?: number;
+    from?: number;
+    to?: number;
+    contractFilter?: string;
+    secondaryCurrency?: string;
+    gap?: number;
+}
+export interface WsBackendInfo {
+    version?: string;
+    subversion?: string;
+    consensus_version?: string;
+    consensus?: any;
+}
+export interface WsInfoRes {
+    name: string;
+    shortcut: string;
+    decimals: number;
+    version: string;
+    bestHeight: number;
+    bestHash: string;
+    block0Hash: string;
+    testnet: boolean;
+    backend: WsBackendInfo;
+}
+export interface WsBlockHashReq {
+    height: number;
+}
+export interface WsBlockHashRes {
+    hash: string;
+}
+export interface WsAccountUtxoReq {
+    descriptor: string;
+}
+export interface WsBalanceHistoryReq {
+    descriptor: string;
+    from?: number;
+    to?: number;
+    currencies?: string[];
+    gap?: number;
+    groupBy?: number;
+}
+export interface WsTransactionReq {
+    txid: string;
+}
+export interface WsTransactionSpecificReq {
+    txid: string;
+}
+export interface WsEstimateFeeReq {
+    blocks?: number[];
+    specific?: {
+        conservative?: boolean;
+        txsize?: number;
+        from?: string;
+        to?: string;
+        data?: string;
+        value?: string;
+    };
+}
+export interface WsEstimateFeeRes {
+    feePerTx?: string;
+    feePerUnit?: string;
+    feeLimit?: string;
+}
+export interface WsSendTransactionReq {
+    hex: string;
+}
+export interface WsSubscribeAddressesReq {
+    addresses: string[];
+}
+export interface WsSubscribeFiatRatesReq {
+    currency?: string;
+    tokens?: string[];
+}
+export interface WsCurrentFiatRatesReq {
+    currencies?: string[];
+    token?: string;
+}
+export interface WsFiatRatesForTimestampsReq {
+    timestamps: number[];
+    currencies?: string[];
+    token?: string;
+}
+export interface WsFiatRatesTickersListReq {
+    timestamp?: number;
+    token?: string;
+}

--- a/packages/blockchain-link/src/types/blockbook.ts
+++ b/packages/blockchain-link/src/types/blockbook.ts
@@ -7,6 +7,20 @@ import type {
     AccountInfoParams,
 } from './params';
 import type { AccountBalanceHistory, FiatRates } from './common';
+import {
+    Address,
+    Token,
+    Tx,
+    Vin,
+    Vout,
+    WsAccountUtxoReq,
+    WsBlockHashReq,
+    WsEstimateFeeRes,
+    WsSendTransactionReq,
+    WsSubscribeAddressesReq,
+    WsSubscribeFiatRatesReq,
+    WsTransactionReq,
+} from './blockbook-api';
 
 export interface Subscribe {
     subscribed: boolean;
@@ -35,46 +49,59 @@ export interface BlockHash {
     hash: string;
 }
 
-export interface XPUBAddress {
-    type: 'XPUBAddress';
-    name: string;
-    path: string;
-    transfers: number;
-    balance: string;
-    totalSent: string;
-    totalReceived: string;
-}
+// export interface XPUBAddress {
+//     type: 'XPUBAddress';
+//     name: string;
+//     path: string;
+//     transfers: number;
+//     balance: string;
+//     totalSent: string;
+//     totalReceived: string;
+// }
 
-export interface ERC20 {
-    type: 'ERC20';
-    name?: string;
-    symbol?: string;
+export type XPUBAddress = Required<
+    Pick<Token, 'name' | 'path' | 'transfers' | 'balance' | 'totalSent' | 'totalReceived'>
+> & { type: 'XPUBAddress' };
+
+export type EVMToken = Pick<Token, 'name' | 'symbol' | 'decimals' | 'transfers'> & {
     contract: string;
-    balance?: string;
-    decimals?: number;
-}
+};
 
-export interface AccountInfo {
-    address: string;
-    balance: string;
-    totalReceived: string;
-    totalSent: string;
-    txs: number;
-    unconfirmedBalance: string;
-    unconfirmedTxs: number;
-    page?: number;
-    itemsOnPage: number;
-    totalPages: number;
-    nonTokenTxs?: number;
-    transactions?: Transaction[];
-    nonce?: string;
-    tokens?: (XPUBAddress | ERC20)[];
+export type ERC20 = EVMToken &
+    Pick<Token, 'balance' | 'baseValue' | 'secondaryValue'> & { type: 'ERC20' };
+
+export type ERC721 = EVMToken & Pick<Token, 'ids'> & { type: 'ERC721' };
+
+export type ERC1155 = EVMToken & Pick<Token, 'multiTokenValues'> & { type: 'ERC1155' };
+
+// export interface AccountInfo {
+//     address: string;
+//     balance: string;
+//     totalReceived: string;
+//     totalSent: string;
+//     txs: number;
+//     unconfirmedBalance: string;
+//     unconfirmedTxs: number;
+//     page?: number;
+//     itemsOnPage: number;
+//     totalPages: number;
+//     nonTokenTxs?: number;
+//     transactions?: Transaction[];
+//     nonce?: string;
+//     tokens?: (XPUBAddress | ERC20)[];
+//     erc20Contract?: ERC20;
+// }
+
+export type AccountInfo = Address & {
+    tokens?: (XPUBAddress | ERC20 | ERC721 | ERC1155)[];
     erc20Contract?: ERC20;
-}
+};
 
-export interface AccountUtxoParams {
-    descriptor: string;
-}
+// export interface AccountUtxoParams {
+//     descriptor: string;
+// }
+
+export type AccountUtxoParams = WsAccountUtxoReq;
 
 export type AccountUtxo = {
     txid: string;
@@ -87,62 +114,68 @@ export type AccountUtxo = {
     coinbase?: boolean;
 }[];
 
-export interface VinVout {
-    n: number;
-    addresses?: string[];
-    isAddress: boolean;
-    value?: string;
-    coinbase?: string;
-    txid?: string;
-    vout?: number;
-    sequence?: number;
-    hex?: string;
-}
+// export interface VinVout {
+//     n: number;
+//     addresses?: string[];
+//     isAddress: boolean;
+//     value?: string;
+//     coinbase?: string;
+//     txid?: string;
+//     vout?: number;
+//     sequence?: number;
+//     hex?: string;
+// }
 
-export interface Transaction {
-    txid: string;
-    version?: number;
-    vin: VinVout[];
-    vout: VinVout[];
-    blockHeight: number;
-    blockHash?: string;
-    confirmations: number;
-    blockTime: number;
-    value: string;
-    valueIn: string;
-    fees: string;
-    hex: string;
-    lockTime?: number;
-    vsize?: number;
-    size?: number;
-    ethereumSpecific?: {
-        status: number;
-        nonce: number;
-        data?: string;
-        gasLimit: number;
-        gasUsed?: number;
-        gasPrice: string;
-    };
-    tokenTransfers?: {
-        from?: string;
-        to?: string;
-        value: string;
-        token: string;
-        name: string;
-        symbol: string;
-        decimals?: number;
-    }[];
-}
+export type VinVout = Vin | Vout;
+
+// export interface Transaction {
+//     txid: string;
+//     version?: number;
+//     vin: VinVout[];
+//     vout: VinVout[];
+//     blockHeight: number;
+//     blockHash?: string;
+//     confirmations: number;
+//     blockTime: number;
+//     value: string;
+//     valueIn: string;
+//     fees: string;
+//     hex: string;
+//     lockTime?: number;
+//     vsize?: number;
+//     size?: number;
+//     ethereumSpecific?: {
+//         status: number;
+//         nonce: number;
+//         data?: string;
+//         gasLimit: number;
+//         gasUsed?: number;
+//         gasPrice: string;
+//     };
+//     tokenTransfers?: {
+//         from?: string;
+//         to?: string;
+//         value: string;
+//         token: string;
+//         name: string;
+//         symbol: string;
+//         decimals?: number;
+//     }[];
+// }
+
+export type Transaction = Tx;
 
 export interface Push {
     result: string;
 }
 
-export type Fee = {
-    feePerUnit: string;
-    feePerTx?: string;
-    feeLimit?: string;
-}[];
+// export type Fee = {
+//     feePerUnit: string;
+//     feePerTx?: string;
+//     feeLimit?: string;
+// }[];
+
+export type Fee = WsEstimateFeeRes[];
 
 export interface BlockNotification {
     height: number;
@@ -178,11 +211,11 @@ export interface AvailableCurrencies {
 }
 
 declare function FSend(method: 'getInfo'): Promise<ServerInfo>;
-declare function FSend(method: 'getBlockHash', params: { height: number }): Promise<BlockHash>;
+declare function FSend(method: 'getBlockHash', params: WsBlockHashReq): Promise<BlockHash>;
 declare function FSend(method: 'getAccountInfo', params: AccountInfoParams): Promise<AccountInfo>;
 declare function FSend(method: 'getAccountUtxo', params: AccountUtxoParams): Promise<AccountUtxo>;
-declare function FSend(method: 'getTransaction', params: { txid: string }): Promise<Transaction>;
-declare function FSend(method: 'sendTransaction', params: { hex: string }): Promise<Push>;
+declare function FSend(method: 'getTransaction', params: WsTransactionReq): Promise<Transaction>;
+declare function FSend(method: 'sendTransaction', params: WsSendTransactionReq): Promise<Push>;
 declare function FSend(
     method: 'getBalanceHistory',
     params: AccountBalanceHistoryParams,
@@ -202,14 +235,14 @@ declare function FSend(
 declare function FSend(method: 'estimateFee', params: EstimateFeeParams): Promise<Fee>;
 declare function FSend(
     method: 'subscribeAddresses',
-    params: { addresses: string[] },
+    params: WsSubscribeAddressesReq,
 ): Promise<Subscribe>;
 declare function FSend(method: 'unsubscribeAddresses'): Promise<Subscribe>;
 declare function FSend(method: 'subscribeNewBlock'): Promise<Subscribe>;
 declare function FSend(method: 'unsubscribeNewBlock'): Promise<Subscribe>;
 declare function FSend(
     method: 'subscribeFiatRates',
-    params: { currency?: string },
+    params: WsSubscribeFiatRatesReq,
 ): Promise<Subscribe>;
 declare function FSend(method: 'unsubscribeFiatRates'): Promise<Subscribe>;
 declare function FSend(method: 'subscribeNewTransaction'): Promise<Subscribe>;

--- a/packages/blockchain-link/src/types/params.ts
+++ b/packages/blockchain-link/src/types/params.ts
@@ -1,46 +1,63 @@
-export interface AccountBalanceHistoryParams {
-    descriptor: string;
-    from?: number;
-    to?: number;
-    currencies?: string[];
-    groupBy?: number;
-}
+import {
+    WsAccountInfoReq,
+    WsBalanceHistoryReq,
+    WsCurrentFiatRatesReq,
+    WsEstimateFeeReq,
+    WsFiatRatesForTimestampsReq,
+} from './blockbook-api';
 
-export interface GetCurrentFiatRatesParams {
-    currencies?: string[];
-}
+// export interface AccountBalanceHistoryParams {
+//     descriptor: string;
+//     from?: number;
+//     to?: number;
+//     currencies?: string[];
+//     groupBy?: number;
+// }
 
-export interface GetFiatRatesForTimestampsParams {
-    timestamps: number[];
-    currencies?: string[];
-}
+export type AccountBalanceHistoryParams = WsBalanceHistoryReq;
+
+// export interface GetCurrentFiatRatesParams {
+//     currencies?: string[];
+// }
+
+export type GetCurrentFiatRatesParams = WsCurrentFiatRatesReq;
+
+// export interface GetFiatRatesForTimestampsParams {
+//     timestamps: number[];
+//     currencies?: string[];
+// }
+
+export type GetFiatRatesForTimestampsParams = WsFiatRatesForTimestampsReq;
 
 export interface GetFiatRatesTickersListParams {
     timestamp?: number;
 }
 
-export interface EstimateFeeParams {
-    blocks?: number[];
-    specific?: {
-        conservative?: boolean; // btc
-        txsize?: number; // btc transaction size
-        from?: string; // eth from
-        to?: string; // eth to
-        data?: string; // eth tx data
-        value?: string; // eth tx amount
-    };
-}
+// export interface EstimateFeeParams {
+//     blocks?: number[];
+//     specific?: {
+//         conservative?: boolean; // btc
+//         txsize?: number; // btc transaction size
+//         from?: string; // eth from
+//         to?: string; // eth to
+//         data?: string; // eth tx data
+//         value?: string; // eth tx amount
+//     };
+// }
 
-export interface AccountInfoParams {
-    descriptor: string; // address or xpub
-    details?: 'basic' | 'tokens' | 'tokenBalances' | 'txids' | 'txs'; // depth, default: 'basic'
-    tokens?: 'nonzero' | 'used' | 'derived'; // blockbook only, default: 'derived' - show all derived addresses, 'used' - show only used addresses, 'nonzero' - show only address with balance
-    page?: number; // blockbook only, page index
-    pageSize?: number; // how many transactions on page
-    from?: number; // from block
-    to?: number; // to block
-    contractFilter?: string; // blockbook only, ethereum token filter
-    gap?: number; // blockbook only, derived addresses gap
+export type EstimateFeeParams = WsEstimateFeeReq;
+
+export interface AccountInfoParams extends WsAccountInfoReq {
+    // descriptor: string; // address or xpub
+    // details?: 'basic' | 'tokens' | 'tokenBalances' | 'txids' | 'txs'; // depth, default: 'basic'
+    // tokens?: 'nonzero' | 'used' | 'derived'; // blockbook only, default: 'derived' - show all derived addresses, 'used' - show only used addresses, 'nonzero' - show only address with balance
+    // page?: number; // blockbook only, page index
+    // pageSize?: number; // how many transactions on page
+    // from?: number; // from block
+    // to?: number; // to block
+    // contractFilter?: string; // blockbook only, ethereum token filter
+    // gap?: number; // blockbook only, derived addresses gap
+
     // since ripple-lib cannot use pages "marker" is used as first unknown point in history (block and sequence of transaction)
     marker?: {
         ledger: number;


### PR DESCRIPTION
As requested, I have added automatic generation of TS types from Blockbook (this commit https://github.com/trezor/blockbook/commit/3509efab8fcf9390240f45bc2c181330ff385e8c) to the file `blockbook-api.d.ts`. 

I copied this file to the Suite repository and used the generated types as a base of the types which were before completely manually created. I commented out and not yet removed completely the manual types as there are some minor incompatibilities (mainly different optional parameters), which cause problems in `packages/blockchain-link/src/workers/blockbook/utils.ts`. Also, I added definitions for other token types (ERC721 and ERC1155) that the new Blockbook supports.

Could you please try to resolve the issues? In some cases (like `tx.fees`) it would be possible to change the optionality in Blockbook, however in other cases I think it actually points to a real problem, like not handling the possibly undefined `unconfirmedBalance`.
