### PR TITLE
pending txs support in e2e tests

### DIFF
--- a/packages/suite-web/e2e/cypress.config.ts
+++ b/packages/suite-web/e2e/cypress.config.ts
@@ -46,6 +46,9 @@ let blockbook: Awaited<ReturnType<(typeof blockbookMock)['start']>> | undefined;
 //     return launchOptions;
 // });
 
+// simple memory key-value store
+const store: { [key: string]: any } = {};
+
 export default defineConfig({
     e2e: {
         specPattern: '**/*.test.{js,jsx,ts,tsx}',
@@ -210,6 +213,13 @@ export default defineConfig({
                         blockbook.stop();
                     }
                     return null;
+                },
+                set({ key, value }: { key: string; value: any }) {
+                    store[key] = value;
+                    return null;
+                },
+                get({ key }: { key: string }): any {
+                    return store[key];
                 },
                 ...TrezorUserEnvLink.api,
             });

--- a/packages/suite-web/e2e/tests/wallet/pending-transactions.test.ts
+++ b/packages/suite-web/e2e/tests/wallet/pending-transactions.test.ts
@@ -1,0 +1,105 @@
+// @group:wallet
+// @retry=2
+
+describe('Use regtest to test pending transactions', () => {
+    const ADDRESS_ACCOUNT_1_INDEX_1 = 'bcrt1qkvwu9g3k2pdxewfqr7syz89r3gj557l374sg5v';
+    const ADDRESS_ACCOUNT_2_INDEX_1 = 'bcrt1q7r9yvcdgcl6wmtta58yxf29a8kc96jkyyk8fsw';
+    const ADDRESS_ACCOUNT_3_INDEX_1 = 'bcrt1q3j2fqzfqndv4gxhf9q0nvvxgceur8mhum8xpwj'; // miner
+
+    beforeEach(() => {
+        cy.task('startEmu', { wipe: true });
+        cy.task('setupEmu', {
+            mnemonic: 'all all all all all all all all all all all all',
+        });
+        cy.task('startBridge');
+        cy.viewport(1080, 1440).resetDb();
+        cy.prefixedVisit('/settings/coins');
+        cy.passThroughInitialRun();
+        cy.toggleDebugModeInSettings();
+        cy.getTestElement('@settings/wallet/network/btc').click({ force: true });
+        cy.getTestElement('@settings/wallet/network/regtest').click({ force: true });
+        // send 1 regtest bitcoin to first address in the derivation path
+        [
+            { address: ADDRESS_ACCOUNT_1_INDEX_1, amount: 10 },
+            { address: ADDRESS_ACCOUNT_2_INDEX_1, amount: 10 },
+        ].forEach(payment => {
+            cy.task('sendToAddressAndMineBlock', {
+                address: payment.address,
+                btc_amount: payment.amount,
+            });
+        });
+        cy.task('mineBlocks', { block_amount: 1 });
+    });
+
+    it('send couple of pending txs and check that they are pending until mined', () => {
+        cy.getTestElement('@suite/menu/wallet-index').click();
+        cy.discoveryShouldFinish();
+        cy.getTestElement('@account-menu/regtest/normal/0/label').click();
+
+        // create 2 transactions (one self, one fund another account of mine)
+        [ADDRESS_ACCOUNT_1_INDEX_1, ADDRESS_ACCOUNT_2_INDEX_1].forEach((address, index) => {
+            cy.getTestElement('@wallet/menu/wallet-send').click();
+            cy.getTestElement('outputs[0].amount').type('0.3');
+            cy.getTestElement('outputs[0].address').type(address);
+            cy.getTestElement('@send/review-button').click();
+            cy.getTestElement('@prompts/confirm-on-device');
+            cy.task('pressYes');
+            cy.task('pressYes');
+            cy.task('pressYes');
+            cy.getTestElement('@modal/send').click();
+            cy.getTestElement('@transaction-group/pending/count').contains(index + 1);
+            cy.getTestElement('@wallet/accounts/transaction-list/group/0').within(() => {
+                cy.getTestElement(`@transaction-item/0/heading`).click({
+                    scrollBehavior: 'bottom',
+                });
+            });
+            cy.getTestElement('@tx-detail/txid-value').then($el => {
+                cy.task('set', { key: address, value: $el.text() });
+            });
+
+            cy.getTestElement('@modal/close-button').click();
+        });
+
+        // account 1 has 2 pending transactions (self and sent)
+        cy.getTestElement('@wallet/accounts/transaction-list/group/0').within(() => {
+            cy.getTestElement('@transaction-item/0/heading').contains('Sending REGTEST');
+            cy.getTestElement('@transaction-item/1/heading').contains('Sending REGTEST to myself');
+        });
+
+        // account 2 has 1 pending transaction (receive)
+        cy.getTestElement('@account-menu/regtest/normal/1').click();
+        cy.getTestElement('@wallet/accounts/transaction-list/group/0').within(() => {
+            cy.getTestElement('@transaction-item/0/heading').contains('Receiving REGTEST');
+        });
+
+        // while observing account 1, sent transaction is mined
+        cy.getTestElement('@account-menu/regtest/normal/0').click();
+        cy.getTestElement('@wallet/accounts/transaction-list/group/0').within(() => {
+            cy.getTestElement('@transaction-item/0/heading').contains('Sending REGTEST');
+            cy.getTestElement('@transaction-item/1/heading').contains('Sending REGTEST to myself');
+        });
+
+        // mine the "not-self" transaction
+        cy.task('get', { key: ADDRESS_ACCOUNT_2_INDEX_1 }).then(txid => {
+            cy.wait(1000);
+            cy.task('generateBlock', {
+                address: ADDRESS_ACCOUNT_3_INDEX_1,
+                txids: [txid],
+            });
+        });
+
+        // which causes sent transaction to disappear, self transaction stays
+        cy.getTestElement('@wallet/accounts/transaction-list/group/0').within(() => {
+            cy.getTestElement('@transaction-item/0/heading').contains('Sending REGTEST to myself');
+            cy.getTestElement('@transaction-group/pending/count').contains(1);
+        });
+
+        // receive pending transaction on account2 is now mined as well
+        cy.getTestElement('@account-menu/regtest/normal/1').click();
+        cy.getTestElement('@wallet/accounts/transaction-list/group/0').within(() => {
+            cy.getTestElement(`@transaction-item/0/heading`).contains('Received REGTEST');
+        });
+    });
+});
+
+export {};

--- a/packages/suite/src/components/suite/HiddenPlaceholder/index.tsx
+++ b/packages/suite/src/components/suite/HiddenPlaceholder/index.tsx
@@ -24,16 +24,23 @@ interface HiddenPlaceholderProps {
     intensity?: number;
     children: React.ReactNode;
     className?: string;
+    ['data-test']?: string;
 }
 
 export const HiddenPlaceholder = ({
     children,
     intensity = 5,
     className,
+    ...rest
 }: HiddenPlaceholderProps) => {
     const discreetMode = useSelector(state => state.wallet.settings.discreetMode);
     return (
-        <Wrapper discreetMode={discreetMode} intensity={intensity} className={className}>
+        <Wrapper
+            discreetMode={discreetMode}
+            intensity={intensity}
+            className={className}
+            data-test={rest['data-test']}
+        >
             {children}
         </Wrapper>
     );

--- a/packages/suite/src/components/suite/modals/TransactionDetail/components/BasicDetails.tsx
+++ b/packages/suite/src/components/suite/modals/TransactionDetail/components/BasicDetails.tsx
@@ -260,7 +260,7 @@ export const BasicDetails = ({ tx, confirmations, network, explorerUrl }: BasicD
                 </Title>
 
                 <TxidValue>
-                    <TransactionId>{tx.txid}</TransactionId>
+                    <TransactionId data-test="@tx-detail/txid-value">{tx.txid}</TransactionId>
 
                     <TrezorLink size="tiny" variant="nostyle" href={`${explorerUrl}${tx.txid}`}>
                         <Tooltip content={<Translation id="TR_OPEN_IN_BLOCK_EXPLORER" />}>

--- a/packages/suite/src/components/suite/modals/TransactionDetail/components/ChainedTxs.tsx
+++ b/packages/suite/src/components/suite/modals/TransactionDetail/components/ChainedTxs.tsx
@@ -31,7 +31,7 @@ interface ChainedTxsProps {
 
 export const ChainedTxs = ({ txs, network, explorerUrl }: ChainedTxsProps) => (
     <Wrapper>
-        {txs.map(tx => (
+        {txs.map((tx, index) => (
             <StyledTrezorLink key={tx.txid} href={`${explorerUrl}${tx.txid}`} variant="nostyle">
                 <ChainedTransactionItem
                     key={tx.txid}
@@ -40,6 +40,7 @@ export const ChainedTxs = ({ txs, network, explorerUrl }: ChainedTxsProps) => (
                     isPending
                     isActionDisabled
                     accountKey={`${tx.descriptor}-${tx.symbol}-${tx.deviceState}`}
+                    index={index}
                 />
             </StyledTrezorLink>
         ))}

--- a/packages/suite/src/components/wallet/TransactionItem/components/TransactionHeading.tsx
+++ b/packages/suite/src/components/wallet/TransactionItem/components/TransactionHeading.tsx
@@ -66,6 +66,7 @@ interface TransactionHeadingProps {
     txItemIsHovered: boolean;
     nestedItemIsHovered: boolean;
     onClick: () => void;
+    dataTestBase: string;
 }
 
 export const TransactionHeading = ({
@@ -75,6 +76,7 @@ export const TransactionHeading = ({
     txItemIsHovered,
     nestedItemIsHovered,
     onClick,
+    dataTestBase,
 }: TransactionHeadingProps) => {
     const [headingIsHovered, setHeadingIsHovered] = useState(false);
 
@@ -143,7 +145,7 @@ export const TransactionHeading = ({
                 onMouseLeave={() => setHeadingIsHovered(false)}
                 onClick={onClick}
             >
-                <HeadingWrapper>
+                <HeadingWrapper data-test={`${dataTestBase}/heading`}>
                     {isZeroValuePhishing && (
                         <TooltipSymbol
                             content={

--- a/packages/suite/src/components/wallet/TransactionItem/index.tsx
+++ b/packages/suite/src/components/wallet/TransactionItem/index.tsx
@@ -90,6 +90,7 @@ interface TransactionItemProps {
     accountKey: string;
     network: Network;
     className?: string;
+    index: number;
 }
 
 const TransactionItem = React.memo(
@@ -101,6 +102,7 @@ const TransactionItem = React.memo(
         isPending,
         network,
         className,
+        index,
     }: TransactionItemProps) => {
         const { type, targets, tokens } = transaction;
         const [limit, setLimit] = useState(0);
@@ -152,6 +154,7 @@ const TransactionItem = React.memo(
         };
 
         const isZeroValuePhishing = getIsZeroValuePhishing(transaction);
+        const dataTestBase = `@transaction-item/${index}`;
 
         // we are using slightly different layout for 1 targets txs to better match the design
         // the only difference is that crypto amount is in the same row as tx heading/description
@@ -188,6 +191,7 @@ const TransactionItem = React.memo(
                                 txItemIsHovered={txItemIsHovered}
                                 nestedItemIsHovered={nestedItemIsHovered}
                                 onClick={() => openTxDetailsModal()}
+                                dataTestBase={dataTestBase}
                             />
                         </Description>
                         <NextRow>

--- a/packages/suite/src/views/wallet/transactions/components/TransactionList/components/DayHeader/index.tsx
+++ b/packages/suite/src/views/wallet/transactions/components/TransactionList/components/DayHeader/index.tsx
@@ -77,7 +77,7 @@ const DayHeader = ({
     return (
         <Wrapper>
             {dateKey === 'pending' ? (
-                <ColPending>
+                <ColPending data-test="@transaction-group/pending/count">
                     <Translation id="TR_PENDING_TX_HEADING" values={{ count: txsCount }} /> •{' '}
                     {txsCount}
                 </ColPending>

--- a/packages/suite/src/views/wallet/transactions/components/TransactionList/components/TransactionsGroup/index.tsx
+++ b/packages/suite/src/views/wallet/transactions/components/TransactionList/components/TransactionsGroup/index.tsx
@@ -23,6 +23,7 @@ interface Props {
     children?: React.ReactNode;
     symbol: Network['symbol'];
     localCurrency: string;
+    index: number;
 }
 
 const TransactionsGroup = ({
@@ -31,6 +32,7 @@ const TransactionsGroup = ({
     transactions,
     localCurrency,
     children,
+    index,
     ...rest
 }: Props) => {
     const [isHovered, setIsHovered] = useState(false);
@@ -40,7 +42,7 @@ const TransactionsGroup = ({
         <TransactionsGroupWrapper
             key={dateKey}
             onMouseEnter={() => setIsHovered(true)}
-            data-test="@wallet/accounts/transaction-list"
+            data-test={`@wallet/accounts/transaction-list/group/${index}`}
             onMouseLeave={() => setIsHovered(false)}
             {...rest}
         >

--- a/packages/suite/src/views/wallet/transactions/components/TransactionList/index.tsx
+++ b/packages/suite/src/views/wallet/transactions/components/TransactionList/index.tsx
@@ -125,7 +125,7 @@ export const TransactionList = ({
 
     const listItems = useMemo(
         () =>
-            Object.entries(transactionsByDate).map(([dateKey, value]) => {
+            Object.entries(transactionsByDate).map(([dateKey, value], groupIndex) => {
                 const isPending = dateKey === 'pending';
 
                 return (
@@ -135,8 +135,9 @@ export const TransactionList = ({
                         symbol={symbol}
                         transactions={value}
                         localCurrency={localCurrency}
+                        index={groupIndex}
                     >
-                        {groupJointTransactions(value).map(item =>
+                        {groupJointTransactions(value).map((item, index) =>
                             item.type === 'joint-batch' ? (
                                 <CoinjoinBatchItem
                                     key={item.rounds[0].txid}
@@ -152,6 +153,7 @@ export const TransactionList = ({
                                     accountMetadata={account.metadata}
                                     accountKey={account.key}
                                     network={network!}
+                                    index={index}
                                 />
                             ),
                         )}
@@ -181,6 +183,7 @@ export const TransactionList = ({
                     setSelectedPage={setSelectedPage}
                 />
             }
+            data-test="@wallet/accounts/transaction-list"
         >
             {/* TODO: show this skeleton also while searching in txs */}
             {isLoading ? (

--- a/packages/trezor-user-env-link/src/api.ts
+++ b/packages/trezor-user-env-link/src/api.ts
@@ -26,6 +26,11 @@ interface MineBlocks {
     block_amount: number;
 }
 
+interface GenerateBlock {
+    address: string;
+    txids: string[];
+}
+
 interface ApplySettings {
     passphrase_always_on_device?: boolean;
 }
@@ -73,6 +78,13 @@ export const api = (controller: any) => ({
     mineBlocks: async (options: MineBlocks) => {
         await controller.send({
             type: 'regtest-mine-blocks',
+            ...options,
+        });
+        return null;
+    },
+    generateBlock: async (options: GenerateBlock) => {
+        await controller.send({
+            type: 'regtest-generateblock',
             ...options,
         });
         return null;


### PR DESCRIPTION
- [x] prerequisite https://github.com/trezor/trezor-user-env/pull/213 which adds a way how to control which transactions should be mined in a new block. 

adding support for testing pending txs useful when adding pre-pending txs in https://github.com/trezor/trezor-suite/pull/7630