### PR TITLE
fix(coinjoin): emit CoinjoinRound `changed` event before async phase

### DIFF
--- a/packages/coinjoin/src/client/CoinjoinRound.ts
+++ b/packages/coinjoin/src/client/CoinjoinRound.ts
@@ -212,7 +212,10 @@ export class CoinjoinRound extends EventEmitter {
         this.roundDeadline = roundDeadline;
         this.affiliateRequest = changed.affiliateRequest;
 
-        this.emit('changed', { round: this.toSerialized() });
+        // NOTE: emit changed event before each async phase
+        if (changed.phase !== RoundPhase.Ended) {
+            this.emit('changed', { round: this.toSerialized() });
+        }
 
         return this;
     }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Fix for undesired behavior of CoinjoinClient phase change event reported byt @komret [in this PR](https://github.com/trezor/trezor-suite/pull/7680) and i've also experience while implementing [pre-pending txs](https://github.com/trezor/trezor-suite/pull/7305)

By design `change` event is dispatched before **and** after phase is processed.
Example: 
```
going to phase 1 (critcal) > [emit change] > async phase processing (confirming) > [emit change]
```

Unfortunately this behavior is undesired when phase is changed to `Ended`,
CoinjoinClient emits event **before** processing, suite handles it and [reset](https://github.com/trezor/trezor-suite/blob/develop/packages/suite/src/reducers/wallet/coinjoinReducer.ts#L159) CoinjoinSession.roundPhase field,
Next event emitted **after** processing is resolving [this condition](https://github.com/trezor/trezor-suite/blob/develop/packages/suite/src/actions/wallet/coinjoinClientActions.ts#L232) as `true` triggering whole action flow again. 


Emitting this event  **before** processing is not necessary for `Ended` case, so i'm excluding it

