### PR TITLE
CJ discovery over websockets

### DIFF
--- a/packages/coinjoin/src/backend/CoinjoinBackendClient.ts
+++ b/packages/coinjoin/src/backend/CoinjoinBackendClient.ts
@@ -1,4 +1,4 @@
-import { scheduleAction } from '@trezor/utils';
+import { scheduleAction, arrayShuffle } from '@trezor/utils';
 
 import { httpGet, RequestOptions } from '../utils/http';
 import type {
@@ -35,7 +35,7 @@ export class CoinjoinBackendClient {
     constructor(settings: CoinjoinBackendClientSettings) {
         this.logger = settings.logger;
         this.wabisabiUrl = `${settings.wabisabiBackendUrl}api/v4/btc`;
-        this.blockbookUrls = settings.blockbookUrls;
+        this.blockbookUrls = arrayShuffle(settings.blockbookUrls);
         this.blockbookRequestId = Math.floor(Math.random() * settings.blockbookUrls.length);
         this.websockets = new CoinjoinWebsocketController(settings);
     }

--- a/packages/coinjoin/src/backend/CoinjoinMempoolController.ts
+++ b/packages/coinjoin/src/backend/CoinjoinMempoolController.ts
@@ -1,3 +1,5 @@
+import { isNotUndefined, promiseAllSequence } from '@trezor/utils';
+
 import type { BlockbookTransaction, MempoolClient } from '../types/backend';
 import { doesTxContainAddress } from './backendUtils';
 
@@ -5,9 +7,6 @@ export type MempoolController = {
     update(): Promise<void>;
     getTransactions(addresses: string[]): BlockbookTransaction[];
 };
-
-const isFulfilled = <T>(promise: PromiseSettledResult<T>): promise is PromiseFulfilledResult<T> =>
-    promise.status === 'fulfilled';
 
 export class CoinjoinMempoolController implements MempoolController {
     private readonly client;
@@ -20,18 +19,16 @@ export class CoinjoinMempoolController implements MempoolController {
 
     async update() {
         const txids = await this.client.fetchMempoolTxids();
-        const entries = await Promise.allSettled(
-            txids.map(async txid => {
-                const tx =
-                    this.mempool[txid] ??
-                    (await this.client.fetchTransaction(txid, {
-                        identity: this.client.getIdentityForBlock(undefined),
-                    }));
-                return [txid, tx] as const;
-            }),
+        const entries = await promiseAllSequence(
+            txids.map(
+                txid => () =>
+                    this.mempool[txid]
+                        ? Promise.resolve(this.mempool[txid])
+                        : this.client.fetchTransaction(txid).catch(() => undefined),
+            ),
         )
-            .then(promises => promises.filter(isFulfilled)) // Failed fetchTransaction could be ignored
-            .then(promises => promises.map(({ value }) => value));
+            .then(txs => txs.filter(isNotUndefined)) // Failed fetchTransaction could be ignored
+            .then(txs => txs.map(tx => [tx.txid, tx] as const));
         this.mempool = Object.fromEntries(entries);
     }
 

--- a/packages/coinjoin/src/backend/CoinjoinWebsocketController.ts
+++ b/packages/coinjoin/src/backend/CoinjoinWebsocketController.ts
@@ -1,0 +1,48 @@
+import { BlockbookAPI } from '@trezor/blockchain-link/lib/workers/blockbook/websocket';
+
+import type { Logger } from '../types';
+
+export type BlockbookWS = Pick<BlockbookAPI, 'getBlock' | 'getTransaction'>;
+
+type SocketId = `${string}@${string}`;
+
+type CoinjoinWebsocketControllerSettings = {
+    logger?: Logger;
+};
+
+export class CoinjoinWebsocketController {
+    private readonly defaultIdentity = 'Default';
+
+    protected readonly sockets: { [id: SocketId]: BlockbookAPI } = {};
+    protected readonly logger;
+
+    constructor({ logger }: CoinjoinWebsocketControllerSettings) {
+        this.logger = logger;
+    }
+
+    async getOrCreate(url: string, identity = this.defaultIdentity): Promise<BlockbookWS> {
+        const socketId = this.getSocketId(url, identity);
+        let socket = this.sockets[socketId];
+        if (!socket) {
+            socket = new BlockbookAPI({
+                url,
+                headers: { 'Proxy-Authorization': `Basic ${identity}` },
+            });
+            this.sockets[socketId] = socket;
+        }
+        if (!socket.isConnected()) {
+            this.logger?.log(`WS OPEN ${socketId}`);
+            await socket.connect();
+            const onDisconnected = () => {
+                this.logger?.log(`WS CLOSED ${socketId}`);
+                socket.off('disconnected', onDisconnected);
+            };
+            socket.on('disconnected', onDisconnected);
+        }
+        return socket;
+    }
+
+    getSocketId(url: string, identity = this.defaultIdentity): SocketId {
+        return `${identity}@${url}`;
+    }
+}

--- a/packages/coinjoin/src/backend/backendUtils.ts
+++ b/packages/coinjoin/src/backend/backendUtils.ts
@@ -1,11 +1,6 @@
-import BigNumber from 'bignumber.js';
+import { deriveAddresses as deriveNewAddresses } from '@trezor/utxo-lib';
 
-import { deriveAddresses as deriveNewAddresses, Network } from '@trezor/utxo-lib';
-import { getTransactionVbytes } from '@trezor/utxo-lib/lib/vsize';
-import { promiseAllSequence } from '@trezor/utils';
-
-import type { CoinjoinBackendClient } from './CoinjoinBackendClient';
-import type { VinVout, Transaction, PrederivedAddress } from '../types/backend';
+import type { VinVout, PrederivedAddress } from '../types/backend';
 
 export const isTxConfirmed = ({ blockHeight = -1 }: { blockHeight?: number }) => blockHeight > 0;
 
@@ -31,31 +26,3 @@ export const deriveAddresses = (
         : [];
     return prederived.slice(fromPrederived, fromPrederived + countPrederived).concat(derived);
 };
-
-/** @deprecated Temporary workaround, should be removed before releasing */
-export const fixTx = (
-    transactions: Transaction[],
-    client: CoinjoinBackendClient,
-    network: Network,
-) =>
-    // must be sequential in order not to hit backend's rate limiter
-    promiseAllSequence(
-        transactions.map(tx => async () => {
-            const fetched = await client.fetchTransaction(tx.txid, {
-                identity: client.getIdentityForBlock(tx.blockHeight),
-            });
-            // tx.vsize missing in transactions from /block endpoint
-            tx.vsize = getTransactionVbytes(tx.details, network);
-            tx.feeRate = new BigNumber(tx.fee).div(tx.vsize).decimalPlaces(2).toString();
-            // tx.size and tx.hex missing in transactions from /block endpoint
-            tx.details.size =
-                fetched.size || typeof fetched.hex === 'string' ? fetched.hex.length / 2 : 0;
-            // vin.vout a vin.txid missing in transctions from /block endpoint
-            tx.details.vin.forEach(vin => {
-                if (!vin.isAccountOwned) return;
-                vin.txid = fetched.vin[vin.n].txid;
-                vin.vout = fetched.vin[vin.n].vout;
-                vin.coinbase = fetched.vin[vin.n].coinbase;
-            });
-        }),
-    );

--- a/packages/coinjoin/src/backend/getAccountUtxo.ts
+++ b/packages/coinjoin/src/backend/getAccountUtxo.ts
@@ -7,7 +7,7 @@ type AddressPaths = {
 };
 
 const isCoinbaseUtxo = (tx: Transaction) =>
-    tx.details.vin.length === 1 && !!tx.details.vin[0].coinbase;
+    tx.details.vin.length === 1 && !tx.details.vin[0].isAddress && !tx.details.vin[0].txid;
 
 const getHeightData = (tx: Transaction) =>
     tx.blockHeight && tx.blockHeight > 0

--- a/packages/coinjoin/src/backend/scanAccount.ts
+++ b/packages/coinjoin/src/backend/scanAccount.ts
@@ -1,7 +1,7 @@
 import { transformTransaction } from '@trezor/blockchain-link/lib/workers/blockbook/utils';
 
 import { getAddressScript, getFilter } from './filters';
-import { doesTxContainAddress, deriveAddresses, fixTx } from './backendUtils';
+import { doesTxContainAddress, deriveAddresses } from './backendUtils';
 import type {
     Transaction,
     AccountAddress,
@@ -108,8 +108,6 @@ export const scanAccount = async (
         };
 
         txs.clear();
-
-        await fixTx(transactions, client, network);
 
         if (progress !== undefined) {
             onProgress({ checkpoint, transactions, info: { progress } });

--- a/packages/coinjoin/src/backend/scanAddress.ts
+++ b/packages/coinjoin/src/backend/scanAddress.ts
@@ -1,7 +1,7 @@
 import { transformTransaction } from '@trezor/blockchain-link/lib/workers/blockbook/utils';
 
 import { getAddressScript, getFilter } from './filters';
-import { doesTxContainAddress, fixTx } from './backendUtils';
+import { doesTxContainAddress } from './backendUtils';
 import type {
     Transaction,
     ScanAddressParams,
@@ -28,8 +28,6 @@ export const scanAddress = async (
             const block = await client.fetchBlock(blockHeight);
             const blockTxs = block.txs.filter(doesTxContainAddress(address));
             const transactions = blockTxs.map(tx => transformTransaction(address, undefined, tx));
-
-            await fixTx(transactions, client, network);
 
             onProgress({
                 checkpoint,

--- a/packages/coinjoin/src/types/backend.ts
+++ b/packages/coinjoin/src/types/backend.ts
@@ -132,10 +132,7 @@ export interface FilterController {
 
 export type FilterClient = Pick<CoinjoinBackendClient, 'fetchFilters'>;
 
-export type MempoolClient = Pick<
-    CoinjoinBackendClient,
-    'fetchMempoolTxids' | 'fetchTransaction' | 'getIdentityForBlock'
->;
+export type MempoolClient = Pick<CoinjoinBackendClient, 'fetchMempoolTxids' | 'fetchTransaction'>;
 
 export type AddressInfo = AccountInfoBase & {
     history: AccountInfoBase['history'] & {

--- a/packages/coinjoin/tests/backend/CoinjoinBackendClient.test.ts
+++ b/packages/coinjoin/tests/backend/CoinjoinBackendClient.test.ts
@@ -31,15 +31,18 @@ describe('CoinjoinBackendClient', () => {
             getSocketId: () => undefined,
         };
 
+        const shuffledBackends = (client as any).blockbookUrls as string[];
+        expect(shuffledBackends.slice().sort()).toEqual(BLOCKBOOKS.slice().sort());
+
         await client.fetchBlock(123456);
-        let prevIndex = BLOCKBOOKS.indexOf(lastBackend);
+        let prevIndex = shuffledBackends.indexOf(lastBackend);
         expect(prevIndex).toBeGreaterThanOrEqual(0);
 
         for (let i = 0; i < 10; ++i) {
             // eslint-disable-next-line no-await-in-loop
             await client.fetchBlock(123456);
-            const index = BLOCKBOOKS.indexOf(lastBackend);
-            expect(index).toEqual((prevIndex + 1) % BLOCKBOOKS.length);
+            const index = shuffledBackends.indexOf(lastBackend);
+            expect(index).toEqual((prevIndex + 1) % shuffledBackends.length);
             prevIndex = index;
         }
     });

--- a/packages/coinjoin/tests/backend/CoinjoinBackendClient.test.ts
+++ b/packages/coinjoin/tests/backend/CoinjoinBackendClient.test.ts
@@ -1,5 +1,4 @@
 import { CoinjoinBackendClient } from '../../src/backend/CoinjoinBackendClient';
-import * as http from '../../src/utils/http';
 import { COINJOIN_BACKEND_SETTINGS } from '../fixtures/config.fixture';
 
 const ZERO_HASH = '0f9188f13cb7b2c71f2a335e3a4fc328bf5beb436012afca590b1a11466e2206';
@@ -15,7 +14,7 @@ const BLOCKBOOKS = ['bb_A', 'bb_B', 'bb_C', 'bb_D', 'bb_E', 'bb_F', 'bb_G'];
 describe('CoinjoinBackendClient', () => {
     let client: CoinjoinBackendClient;
 
-    beforeAll(() => {
+    beforeEach(() => {
         client = new CoinjoinBackendClient({
             ...COINJOIN_BACKEND_SETTINGS,
             blockbookUrls: BLOCKBOOKS,
@@ -24,14 +23,13 @@ describe('CoinjoinBackendClient', () => {
 
     it.only('blockbook backends rotation', async () => {
         let lastBackend = '';
-
-        jest.spyOn(http, 'httpGet').mockImplementation(url => {
-            [lastBackend] = url.split('/');
-            return Promise.resolve({
-                status: 200,
-                json: () => Promise.resolve({ totalPages: 1, txs: [] }),
-            } as Response);
-        });
+        (client as any).websockets = {
+            getOrCreate: (url: string) => {
+                [lastBackend] = (url as string).split('/');
+                return new Proxy({}, { get: (_, b) => b !== 'then' && (() => undefined) });
+            },
+            getSocketId: () => undefined,
+        };
 
         await client.fetchBlock(123456);
         let prevIndex = BLOCKBOOKS.indexOf(lastBackend);
@@ -82,15 +80,6 @@ describe('CoinjoinBackendClient', () => {
 
     it('fetchBlock not found', async () => {
         await expect(client.fetchBlock(999)).rejects.toThrow(/^400:/);
-    });
-
-    it('fetchBlocks success', async () => {
-        const blocks = await client.fetchBlocks([1, 7, 4]);
-        expect(blocks).toMatchObject([{ height: 1 }, { height: 7 }, { height: 4 }]);
-    });
-
-    it('fetchBlocks not found', async () => {
-        await expect(client.fetchBlocks([1, 999, 222])).rejects.toThrow(/^400:/);
     });
 
     it('fetchTransaction success', async () => {

--- a/packages/coinjoin/tests/backend/methods.test.ts
+++ b/packages/coinjoin/tests/backend/methods.test.ts
@@ -160,10 +160,9 @@ describe(`CoinjoinBackend methods`, () => {
         expect(halfBlocks).toEqual([1, 2, 4]);
         fetchBlockMock.mockClear();
 
-        // Should request only txid_4 transaction from mempool,
-        // but currently requests all the transactions (TEMPORARY FIX)
+        // Should request only txid_4 transaction from mempool
         const halfTxs = getRequestedTxs();
-        expect(halfTxs).toEqual(['txid_1', 'txid_2', 'txid_3', FIXTURES.TX_4_PENDING.txid]);
+        expect(halfTxs).toEqual([FIXTURES.TX_4_PENDING.txid]);
         fetchTxMock.mockClear();
 
         // All blocks are known
@@ -197,8 +196,7 @@ describe(`CoinjoinBackend methods`, () => {
         expect(restBlocks).toEqual([6, 7, 8]);
 
         // Shouldn't request any transaction from mempool
-        // but currently requests all the transactions (TEMPORARY FIX)
         const restTxs = getRequestedTxs();
-        expect(restTxs).toEqual(['txid_4', 'txid_5', 'txid_6']);
+        expect(restTxs).toEqual([]);
     });
 });

--- a/packages/coinjoin/tests/fixtures/methods.fixture.ts
+++ b/packages/coinjoin/tests/fixtures/methods.fixture.ts
@@ -27,8 +27,6 @@ export const BLOCKS = [
         hash: '09f69854a4572575e2a8af0dea70ff5efd46957e2cb60e81c0d760098ab48b44',
         filter: '01656c90', // receive 1 out
         previousBlockHash: BASE_HASH,
-        page: 1,
-        totalPages: 1,
         txs: [
             {
                 txid: 'txid_1',
@@ -68,8 +66,6 @@ export const BLOCKS = [
         hash: '5513d63651bbb32985b54fa9e0e530553e3e9cebdd10feae7f019c04edb80f61',
         filter: '0298ad7857d0c0', // receive 1 in, receive 2 out
         previousBlockHash: '09f69854a4572575e2a8af0dea70ff5efd46957e2cb60e81c0d760098ab48b44',
-        page: 1,
-        totalPages: 1,
         txs: [
             {
                 txid: 'txid_2',
@@ -104,8 +100,6 @@ export const BLOCKS = [
         hash: '295578a3c8eb87736a5e657b06a0933f7ec5f82c43f8418fdb38f74c0fc066c7',
         filter: '0802a1103e91e638632d0f148d8c4618cc6118aeaad3d0', // nothing
         previousBlockHash: '5513d63651bbb32985b54fa9e0e530553e3e9cebdd10feae7f019c04edb80f61',
-        page: 1,
-        totalPages: 1,
         txs: [],
     },
     {
@@ -113,8 +107,6 @@ export const BLOCKS = [
         hash: '12de06b8ae4bbc660e3f565c876c606f5a1bd3463364c6abfc882b5ff6dd86e3',
         filter: '03018bfa4d4731ee2480', // receive 1 out
         previousBlockHash: '295578a3c8eb87736a5e657b06a0933f7ec5f82c43f8418fdb38f74c0fc066c7',
-        page: 1,
-        totalPages: 1,
         txs: [
             {
                 txid: 'txid_3',
@@ -157,8 +149,6 @@ export const BLOCKS = [
         hash: '2c2c65aad93eebe235955e170913fd6558453dd999a4ded6249bbdc9d54da1f7',
         filter: '08a4afd740dddb6185ca00666d22a55fc9252008f9cda0', // nothing
         previousBlockHash: '12de06b8ae4bbc660e3f565c876c606f5a1bd3463364c6abfc882b5ff6dd86e3',
-        page: 1,
-        totalPages: 1,
         txs: [],
     },
     {
@@ -166,8 +156,6 @@ export const BLOCKS = [
         hash: '5021a2185f27ad04d45f1b53c873b2231311aea99e0f1d7a6252167540b9db4c',
         filter: '03a69058941e6f5fc1', // receive 2 in, receive 1 out, change 1 out'
         previousBlockHash: '2c2c65aad93eebe235955e170913fd6558453dd999a4ded6249bbdc9d54da1f7',
-        page: 1,
-        totalPages: 1,
         txs: [
             {
                 txid: 'txid_4',
@@ -208,8 +196,6 @@ export const BLOCKS = [
         hash: '01d37c4490e9ddaf6b5c886eaa215b8d0b658c93ea42cfd871b226f606672c0b',
         filter: '023eee59053e40', // receive 1 in, change 1 in, receive 1 out'
         previousBlockHash: '5021a2185f27ad04d45f1b53c873b2231311aea99e0f1d7a6252167540b9db4c',
-        page: 1,
-        totalPages: 1,
         txs: [
             {
                 txid: 'txid_5',
@@ -250,18 +236,6 @@ export const BLOCKS = [
         hash: '36d01c975372c363d94f0e9e22e8a61a6a52e3408c98920ef1587b024ec487e3',
         filter: '02782a5165c980', // receive 1 out
         previousBlockHash: '01d37c4490e9ddaf6b5c886eaa215b8d0b658c93ea42cfd871b226f606672c0b',
-        page: 1,
-        totalPages: 2,
-        txs: [],
-    },
-    // Second block with height 8 but page 2 to simulate Blockbook pagination
-    {
-        height: 8,
-        hash: '36d01c975372c363d94f0e9e22e8a61a6a52e3408c98920ef1587b024ec487e3',
-        filter: '02782a5165c980', // receive 1 out
-        previousBlockHash: '01d37c4490e9ddaf6b5c886eaa215b8d0b658c93ea42cfd871b226f606672c0b',
-        page: 2,
-        totalPages: 2,
         txs: [
             {
                 txid: 'txid_6',

--- a/packages/coinjoin/tests/mocks/MockMempoolClient.ts
+++ b/packages/coinjoin/tests/mocks/MockMempoolClient.ts
@@ -11,10 +11,6 @@ export class MockMempoolClient implements MempoolClient {
         this.fetched = [];
     }
 
-    getIdentityForBlock() {
-        return 'default';
-    }
-
     fetchMempoolTxids() {
         return Promise.resolve(this.transactions.map(tx => tx.txid));
     }

--- a/packages/coinjoin/tests/tools/discovery.ts
+++ b/packages/coinjoin/tests/tools/discovery.ts
@@ -30,15 +30,23 @@ export const getAccountInfo = async ({
     const backend = new CoinjoinBackend(config);
     const transactions: Parameters<(typeof backend)['getAccountInfo']>[1] = [];
 
-    backend.on('log', ({ level, payload }) => console[level]('🌐', payload));
+    backend.on('log', ({ level, payload }) =>
+        console[level]('🌐', new Date().toLocaleTimeString(), payload),
+    );
 
     backend.on(`progress/${descriptor}`, e => {
         transactions.push(...e.transactions);
         if (e.info?.progress)
-            console.log('⌛', e.info.progress, `(block: ${e.checkpoint.blockHeight})`);
+            console.log(
+                '⌛',
+                new Date().toLocaleTimeString(),
+                e.info.progress,
+                `(block: ${e.checkpoint.blockHeight})`,
+            );
         if (e.transactions.length)
             console.log(
                 '🎯',
+                new Date().toLocaleTimeString(),
                 `${e.transactions.length} txs`,
                 `(block: ${e.checkpoint.blockHeight})`,
             );

--- a/packages/suite/src/services/coinjoin/config.ts
+++ b/packages/suite/src/services/coinjoin/config.ts
@@ -21,13 +21,7 @@ export const COINJOIN_NETWORKS: PartialRecord<NetworkSymbol, ServerEnvironment> 
             coordinatorName: 'CoinJoinCoordinatorIdentifier',
             coordinatorUrl: 'https://wasabiwallet.io/wabisabi/',
             wabisabiBackendUrl: 'https://wasabiwallet.io/',
-            blockbookUrls: [
-                'https://btc1.trezor.io/api/v2',
-                'https://btc2.trezor.io/api/v2',
-                'https://btc3.trezor.io/api/v2',
-                'https://btc4.trezor.io/api/v2',
-                'https://btc5.trezor.io/api/v2',
-            ],
+            blockbookUrls: ['https://btc4.trezor.io'],
             /* 28.02.2023 */
             baseBlockHeight: 778666,
             baseBlockHash: '000000000000000000054d1ca4a160dd37541d776ccc34af955dbfcd3b2405f6',
@@ -52,7 +46,7 @@ export const COINJOIN_NETWORKS: PartialRecord<NetworkSymbol, ServerEnvironment> 
             coordinatorUrl: 'https://wasabiwallet.co/wabisabi/',
             // backend settings
             wabisabiBackendUrl: 'https://wasabiwallet.co/',
-            blockbookUrls: ['https://tbtc1.trezor.io/api/v2', 'https://tbtc2.trezor.io/api/v2'],
+            blockbookUrls: ['https://tbtc1.trezor.io', 'https://tbtc2.trezor.io'],
             /* */
             /* onion addresses *
             coordinatorUrl:
@@ -95,7 +89,7 @@ export const COINJOIN_NETWORKS: PartialRecord<NetworkSymbol, ServerEnvironment> 
             coordinatorUrl: 'https://dev-coinjoin-testnet.trezor.io/wabisabi/',
             // backend settings
             wabisabiBackendUrl: 'https://dev-coinjoin-testnet.trezor.io/',
-            blockbookUrls: ['https://tbtc1.trezor.io/api/v2', 'https://tbtc2.trezor.io/api/v2'],
+            blockbookUrls: ['https://tbtc1.trezor.io', 'https://tbtc2.trezor.io'],
             baseBlockHeight: 2349000,
             baseBlockHash: '0000000000000014af3e6e1a3f0a24be7bc65998b9bc01e4a05b134a89d304bf',
             filtersBatchSize: 5000,
@@ -110,7 +104,7 @@ export const COINJOIN_NETWORKS: PartialRecord<NetworkSymbol, ServerEnvironment> 
             coordinatorUrl: 'https://dev-coinjoin.trezor.io/backend/wabisabi/',
             // backend settings
             wabisabiBackendUrl: 'https://dev-coinjoin.trezor.io/backend/',
-            blockbookUrls: ['https://dev-coinjoin.trezor.io/blockbook/api/v2'],
+            blockbookUrls: ['https://dev-coinjoin.trezor.io/blockbook'],
             baseBlockHeight: 0,
             baseBlockHash: '0f9188f13cb7b2c71f2a335e3a4fc328bf5beb436012afca590b1a11466e2206',
             filtersBatchSize: 5000,
@@ -123,7 +117,7 @@ export const COINJOIN_NETWORKS: PartialRecord<NetworkSymbol, ServerEnvironment> 
             coordinatorUrl: 'http://localhost:8081/backend/wabisabi/',
             // backend settings
             wabisabiBackendUrl: 'http://localhost:8081/backend/',
-            blockbookUrls: ['http://localhost:8081/blockbook/api/v2'],
+            blockbookUrls: ['http://localhost:8081/blockbook'],
             baseBlockHeight: 0,
             baseBlockHash: '0f9188f13cb7b2c71f2a335e3a4fc328bf5beb436012afca590b1a11466e2206',
             filtersBatchSize: 5000,

--- a/packages/utils/src/arrayShuffle.ts
+++ b/packages/utils/src/arrayShuffle.ts
@@ -1,0 +1,12 @@
+/**
+ * Randomly shuffles the elements in an array. This method
+ * does not mutate the original array.
+ */
+export const arrayShuffle = <T>(array: readonly T[]) => {
+    const shuffled = array.slice();
+    for (let i = shuffled.length - 1; i > 0; i--) {
+        const j = Math.floor(Math.random() * (i + 1));
+        [shuffled[i], shuffled[j]] = [shuffled[j], shuffled[i]];
+    }
+    return shuffled;
+};

--- a/packages/utils/src/index.ts
+++ b/packages/utils/src/index.ts
@@ -1,6 +1,7 @@
 export * from './abortablePromise';
 export * from './arrayDistinct';
 export * from './arrayPartition';
+export * from './arrayShuffle';
 export * from './arrayToDictionary';
 export * as bufferUtils from './bufferUtils';
 export * from './bytesToHumanReadable';

--- a/packages/utils/tests/arrayShuffle.test.ts
+++ b/packages/utils/tests/arrayShuffle.test.ts
@@ -1,0 +1,24 @@
+import { arrayShuffle } from '../src/arrayShuffle';
+
+const KEYS = ['a', 'b', 'c', 'd', 'e'];
+const SAMPLES = 10000;
+const TOLERANCE = 0.1;
+const EXPECTED = SAMPLES / KEYS.length;
+
+describe('arrayShuffle', () => {
+    it('shuffles randomly', () => {
+        const samples = Object.fromEntries(KEYS.map(key => [key, new Array(KEYS.length).fill(0)]));
+        for (let sample = 0; sample < SAMPLES; ++sample) {
+            const shuffled = arrayShuffle(KEYS);
+            for (let i = 0; i < shuffled.length; ++i) {
+                samples[shuffled[i]][i]++;
+            }
+        }
+        KEYS.forEach(key =>
+            samples[key].forEach(count => {
+                expect(count).toBeGreaterThanOrEqual((1 - TOLERANCE) * EXPECTED);
+                expect(count).toBeLessThanOrEqual((1 + TOLERANCE) * EXPECTED);
+            }),
+        );
+    });
+});


### PR DESCRIPTION
## Description

Optimize Coinjoin account discovery by replacing REST communication with Blockbook by websockets.

**WARNING**: Requires updated Blockbook backends, currently only `tbtc1.trezor.io` and `tbtc2.trezor.io` for testnet and `btc4.trezor.io` for mainnet are available.

## Commits

- https://github.com/trezor/trezor-suite/pull/7719/commits/8fad6aa2b9937d4fa2ac44c1055569cc58aae96f - small fixes in blockbook's websocket
  - fixed import for reusing in coinjoin package
  - it's possible to pass headers from outside (for `Proxy-Authorization`)
  - fixed race condition when `api.connect()` method runs twice in parallel
- https://github.com/trezor/trezor-suite/pull/7719/commits/fad93eca1fbf7fb38ae2d9356ebe2547bf381f84 - util for shuffling an array randomly added to `@trezor/utils`
- https://github.com/trezor/trezor-suite/pull/7719/commits/0fa25d9c31d8964d00f62194b598500bbc209df6 - removed redundant `fixTx` calls from cj discovery, could be used right after Blockbook's block endpoint will return txs with the missing data
- https://github.com/trezor/trezor-suite/pull/7719/commits/2026e4df3b31f96c509ecbd22fb2c498b23ca19c - `CoinjoinBackendClient` reworked so it uses websockets rather than REST api
  - no block pagination needed as ws returns all the block transactions at once
  - `CoinjoinWebsocketController` is responsible for (re)opening websockets based on backend url and required identity
  - refactored
- https://github.com/trezor/trezor-suite/pull/7719/commits/9cf16f34f8b997720c0fdefd5b9b092a18445b05 - tests adjusted to the new changes
- https://github.com/trezor/trezor-suite/pull/7719/commits/580f792d69ed366412fbfbc8f8dff8de88e62756 - the order of Blockbook backends in `CoinjoinBackendClient` is shuffled first
  - so it's not always e.g. btc1 -> btc2 -> btc3 -> btc4 -> btc5 -> btc1 ...
- https://github.com/trezor/trezor-suite/pull/7719/commits/122ce4e6a2ea40a647f21eba02fd0bc2cabbb607 - **should be removed before merging**
  - urls in config changed to updated backends
  - logging of network communication in Suite renderer console

## Questions
- <strike>websockets `keepAlive` and/or `timeout` smaller or greater?</strike> As it is.

## Related Issue

#7526
