### PR TITLE
chore(coinjoin): update affiliateRequest format

### DIFF
--- a/packages/coinjoin/src/client/round/transactionSigning.ts
+++ b/packages/coinjoin/src/client/round/transactionSigning.ts
@@ -76,7 +76,7 @@ const getTransactionData = (
     return {
         inputs,
         outputs,
-        affiliateRequest: getAffiliateRequest(round.affiliateRequest),
+        affiliateRequest: getAffiliateRequest(round.roundParameters, round.affiliateRequest),
     };
 };
 

--- a/packages/coinjoin/tests/client/transactionSigning.test.ts
+++ b/packages/coinjoin/tests/client/transactionSigning.test.ts
@@ -3,6 +3,7 @@ import { networks } from '@trezor/utxo-lib';
 import { transactionSigning } from '../../src/client/round/transactionSigning';
 import { createServer } from '../mocks/server';
 import { createInput } from '../fixtures/input.fixture';
+import { ROUND_CREATION_EVENT } from '../fixtures/round.fixture';
 
 let server: Awaited<ReturnType<typeof createServer>>;
 
@@ -11,8 +12,8 @@ const COINJOIN_REQUEST = {
     min_registrable_amount: 5000,
     no_fee_threshold: 1000000,
     coinjoin_flags_array: [0, 0],
-    mask_public_key: '0000',
-    signature: '0000',
+    mask_public_key: '0'.repeat(33 * 2),
+    signature: '0'.repeat(64 * 2),
 };
 
 describe('transactionSigning', () => {
@@ -38,9 +39,7 @@ describe('transactionSigning', () => {
 
         const response = await transactionSigning(
             {
-                affiliateRequest: Buffer.from(JSON.stringify(COINJOIN_REQUEST), 'utf-8').toString(
-                    'base64',
-                ),
+                affiliateRequest: Buffer.from('0'.repeat(97 * 2 + 4), 'hex').toString('base64'),
                 id: '01',
                 phase: 3,
                 inputs: [
@@ -61,7 +60,7 @@ describe('transactionSigning', () => {
                     },
                 ],
                 roundParameters: {
-                    maxSuggestedAmount: 123456789,
+                    ...ROUND_CREATION_EVENT.roundParameters,
                 },
                 coinjoinState: {
                     // test vectors from connect signTransactionPaymentRequest

--- a/packages/coinjoin/tests/utils/roundUtils.test.ts
+++ b/packages/coinjoin/tests/utils/roundUtils.test.ts
@@ -3,6 +3,7 @@ import {
     readTimeSpan,
     estimatePhaseDeadline,
     transformStatus,
+    getAffiliateRequest,
 } from '../../src/utils/roundUtils';
 import { ROUND_REGISTRATION_END_OFFSET } from '../../src/constants';
 import { DEFAULT_ROUND, STATUS_EVENT, STATUS_TRANSFORMED } from '../fixtures/round.fixture';
@@ -87,6 +88,35 @@ describe('roundUtils', () => {
             const status = transformStatus(STATUS_EVENT);
 
             expect(status).toEqual(STATUS_TRANSFORMED);
+        });
+    });
+
+    // fixtures: https://github.com/trezor/coinjoin-affiliate-server/blob/coordinator-integration/tests/test_response.py
+    it('getAffiliateRequest', () => {
+        const response = getAffiliateRequest(
+            {
+                coordinationFeeRate: {
+                    rate: 0.005,
+                    plebsDontPayThreshold: 1000000,
+                },
+                allowedInputAmounts: {
+                    min: 5000,
+                    max: 134375000000,
+                },
+            } as any, // incomplete roundParams
+            Buffer.from(
+                '03026113a614bd0b3b193ab33de3b0376d48bf1f87931b08543bfd23d7a0616f65106bf94e6c325e3f9a8627ac6a8ebe71f322edcde26b43add515d81fc306a309a914ff0e7cfc75b05fc1cddbb60f0f5594642991a23f19b4a4794000d4169db20101',
+                'hex',
+            ).toString('base64'),
+        );
+        expect(response).toEqual({
+            fee_rate: 500000,
+            min_registrable_amount: 5000,
+            no_fee_threshold: 1000000,
+            mask_public_key: '03026113a614bd0b3b193ab33de3b0376d48bf1f87931b08543bfd23d7a0616f65',
+            signature:
+                '106bf94e6c325e3f9a8627ac6a8ebe71f322edcde26b43add515d81fc306a309a914ff0e7cfc75b05fc1cddbb60f0f5594642991a23f19b4a4794000d4169db2',
+            coinjoin_flags_array: [1, 1],
         });
     });
 });


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Affiliate request provided by coordinator format change from stringified json to hex whre:
first 33 bytes is `mask_public_key` following by 64 bytes `signature` a each remaining byte as a element of `coinjoin_flags_array`