### PR TITLE
fix(suite-native): cardano websocket

### DIFF
--- a/packages/blockchain-link/src/utils/ws-native.ts
+++ b/packages/blockchain-link/src/utils/ws-native.ts
@@ -17,7 +17,7 @@ class WSWrapper extends EventEmitter {
 
         // React Native WebSocket is able to accept headers compared to the native browser `WebSocket`.
         // @ts-expect-error
-        this._ws = new WebSocket(url, '', {
+        this._ws = new WebSocket(url, ['wss'], {
             headers: {
                 'User-Agent': 'Trezor Suite Native',
             },

--- a/suite-native/module-accounts-import/src/components/DevXpub.tsx
+++ b/suite-native/module-accounts-import/src/components/DevXpub.tsx
@@ -19,6 +19,7 @@ const devXpubs: Partial<Record<NetworkSymbol, string>> = {
     dgb: 'ypub6X7pNV6ouYFiDGHjxCtbnV9EaCdq5uyVysMbR5Q79LHa3SWV93J7ubun37EJhfFQqsSGQBfz3UrAzNtYNhb5JsoPJbNKvbF9wKxBjgxfXkH',
     zec: 'xpub6CQdEahwhKRSn9BFc7oWpzNoeqG2ygv3xdofyk7He93NMjvDpGvcQ2o4dZfBNXpqzKydaHp5rhXRT3zYhRYJAErXxarH37f9hgRZ6UPiqfg',
     eth: '0x62270860B9a5337e46bE8563c512c9137AFa0384', // Public key, not xpub
+    ada: 'd507c8f866691bd96e131334c355188b1a1d0b2fa0ab11545075aab332d77d9eb19657ad13ee581b56b0f8d744d66ca356b93d42fe176b3de007d53e9c4c4e7a',
 };
 
 export const DevXpub = ({ symbol, onSelect }: DevXpubProps) => {


### PR DESCRIPTION
Due to a wrong websocket initialization, the Cardano backend blockfrost was unable to connect. Fixed in this commit.

Fix #7517