### PR TITLE
feat(coinjoin): allow coinjoin account outside debug mode

### DIFF
--- a/packages/suite/src/components/suite/modals/AddAccount/index.tsx
+++ b/packages/suite/src/components/suite/modals/AddAccount/index.tsx
@@ -125,8 +125,6 @@ export const AddAccount = ({ device, onCancel, symbol, noRedirect }: Props) => {
     const accountTypes =
         selectedNetworkEnabled && selectedNetwork?.networkType === 'bitcoin'
             ? NETWORKS.filter(n => n.symbol === selectedNetwork.symbol)
-                  // All coinjoin accounts currently visible only in debug mode
-                  .filter(n => n.backendType !== 'coinjoin' || debug.showDebugMenu)
             : undefined;
 
     const onEnableAccount = (account: Account) => {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Coinjoin is no more hidden in debug mode. Still not available in browser (except regtest on local). Logs are still stored locally automatically only in debug mode.

## Related Issue

Resolve https://github.com/trezor/trezor-suite/issues/7031

## Screenshots:

Just a reminder how it looks on web (or with old FW/ model 1/already having coinjoin account):
<img width="565" alt="image" src="https://user-images.githubusercontent.com/3729633/221830067-7642863d-be98-4dd5-853b-a032c4aa8985.png">


