### PR TITLE
prerelease @trezor/connect 9.0.7 [1/2]

### DIFF
--- a/docs/releases/connect-prerelease.md
+++ b/docs/releases/connect-prerelease.md
@@ -1,6 +1,5 @@
 ## @trezor/connect prerelease
 
 -   [x] Bump version in all @trezor/connect\* packages (except plugin packages). `yarn workspace @trezor/connect version:<beta|patch|minor|major>`
--   [ ] Make sure you have released all npm dependencies. If unsure run `node ./ci/scripts/check-npm-dependencies.js connect`. Please note that this script will report unreleased
-        dependencies even for changes that do not affect runtime (READMEs etc.) If there are any unreleased npm dependencies you should [release them](./npm-packages.md)
+-   [ ] Make sure you have released all npm dependencies. If unsure run `node ./ci/scripts/check-npm-dependencies.js connect`. Please note that this script will report unreleased dependencies even for changes that do not affect runtime (READMEs etc.) If there are any unreleased npm dependencies you should [release them](./npm-packages.md)
 -   [ ] Make sure [CHANGELOG](https://github.com/trezor/trezor-suite/blob/develop/packages/connect/CHANGELOG.md) file has been updated

--- a/packages/blockchain-link/CHANGELOG.md
+++ b/packages/blockchain-link/CHANGELOG.md
@@ -1,3 +1,9 @@
+# 2.1.8
+
+-   fix(suite-native): cardano websocket (#7722)
+-   feat(blockchain-link): add getBlock method
+-   feat(blockchain-link): add mempool subscription
+
 # 2.1.7
 
 -   feat: cardano preview testnet

--- a/packages/blockchain-link/package.json
+++ b/packages/blockchain-link/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@trezor/blockchain-link",
-    "version": "2.1.7",
+    "version": "2.1.8",
     "author": "Trezor <info@trezor.io>",
     "homepage": "https://github.com/trezor/trezor-suite/tree/develop/packages/blockchain-link",
     "description": "High-level javascript interface for blockchain communication",
@@ -64,8 +64,8 @@
         "worker-loader": "^3.0.8"
     },
     "dependencies": {
-        "@trezor/utils": "workspace:^9.0.5",
-        "@trezor/utxo-lib": "workspace:^1.0.3",
+        "@trezor/utils": "workspace:^9.0.6",
+        "@trezor/utxo-lib": "workspace:^1.0.4",
         "@types/web": "^0.0.91",
         "bignumber.js": "^9.1.1",
         "events": "^3.3.0",

--- a/packages/connect-common/CHANGELOG.md
+++ b/packages/connect-common/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 0.0.12
+
+-   feat: cardano preview testnet
+
 # 0.0.11
 
 -   refactor storage

--- a/packages/connect-common/package.json
+++ b/packages/connect-common/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@trezor/connect-common",
-    "version": "0.0.11",
+    "version": "0.0.12",
     "author": "Trezor <info@trezor.io>",
     "homepage": "https://github.com/trezor/trezor-suite/tree/develop/packages/connect-common",
     "keywords": [

--- a/packages/connect-examples/electron-main-process/package.json
+++ b/packages/connect-examples/electron-main-process/package.json
@@ -53,7 +53,7 @@
         }
     },
     "dependencies": {
-        "@trezor/connect": "workspace:9.0.6"
+        "@trezor/connect": "workspace:9.0.7"
     },
     "devDependencies": {
         "electron": "20.3.12",

--- a/packages/connect-examples/electron-renderer-with-assets/package.json
+++ b/packages/connect-examples/electron-renderer-with-assets/package.json
@@ -57,7 +57,7 @@
         }
     },
     "devDependencies": {
-        "@trezor/connect": "workspace:9.0.6",
+        "@trezor/connect": "workspace:9.0.7",
         "babel-loader": "^9.1.2",
         "concurrently": "^7.6.0",
         "copy-webpack-plugin": "^11.0.0",

--- a/packages/connect-examples/node/package.json
+++ b/packages/connect-examples/node/package.json
@@ -8,6 +8,6 @@
         "start": "node index.js"
     },
     "dependencies": {
-        "@trezor/connect": "workspace:9.0.6"
+        "@trezor/connect": "workspace:9.0.7"
     }
 }

--- a/packages/connect-explorer/package.json
+++ b/packages/connect-explorer/package.json
@@ -10,7 +10,7 @@
     },
     "dependencies": {
         "@trezor/components": "workspace:*",
-        "@trezor/connect-web": "workspace:9.0.6",
+        "@trezor/connect-web": "workspace:9.0.7",
         "markdown-it": "^13.0.1",
         "markdown-it-link-attributes": "^4.0.1",
         "markdown-it-replace-link": "^1.2.0",

--- a/packages/connect-iframe/package.json
+++ b/packages/connect-iframe/package.json
@@ -10,7 +10,7 @@
         "type-check": "tsc --build tsconfig.json"
     },
     "devDependencies": {
-        "@trezor/connect": "workspace:9.0.6",
+        "@trezor/connect": "workspace:9.0.7",
         "copy-webpack-plugin": "^11.0.0",
         "html-webpack-plugin": "^5.5.0",
         "jest": "^26.6.3",

--- a/packages/connect-popup/package.json
+++ b/packages/connect-popup/package.json
@@ -12,7 +12,7 @@
         "test:unit": "jest"
     },
     "dependencies": {
-        "@trezor/connect": "workspace:9.0.6",
+        "@trezor/connect": "workspace:9.0.7",
         "@trezor/connect-analytics": "workspace:*",
         "@trezor/connect-ui": "workspace:*",
         "@trezor/crypto-utils": "workspace:*",

--- a/packages/connect-ui/package.json
+++ b/packages/connect-ui/package.json
@@ -12,7 +12,7 @@
     },
     "dependencies": {
         "@trezor/components": "workspace:*",
-        "@trezor/connect": "workspace:9.0.6",
+        "@trezor/connect": "workspace:9.0.7",
         "@trezor/connect-analytics": "workspace:*",
         "@trezor/connect-common": "workspace:*",
         "@trezor/env-utils": "workspace:*",

--- a/packages/connect-web/package.json
+++ b/packages/connect-web/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@trezor/connect-web",
-    "version": "9.0.6",
+    "version": "9.0.7",
     "author": "Trezor <info@trezor.io>",
     "homepage": "https://github.com/trezor/trezor-suite/tree/develop/packages/connect-web",
     "description": "High-level javascript interface for Trezor hardware wallet.",
@@ -38,8 +38,8 @@
         "prepublish": "yarn tsx ../../scripts/prepublish.js"
     },
     "dependencies": {
-        "@trezor/connect": "workspace:9.0.6",
-        "@trezor/utils": "workspace:^9.0.5",
+        "@trezor/connect": "workspace:9.0.7",
+        "@trezor/utils": "workspace:^9.0.6",
         "events": "^3.3.0"
     },
     "devDependencies": {

--- a/packages/connect-web/src/webextension/trezor-usb-permissions.js
+++ b/packages/connect-web/src/webextension/trezor-usb-permissions.js
@@ -1,4 +1,4 @@
-const VERSION = '9.0.6';
+const VERSION = '9.0.7';
 const versionN = VERSION.split('.').map(s => parseInt(s, 10));
 // const DIRECTORY = `${ versionN[0] }${ (versionN[1] > 0 ? `.${versionN[1]}` : '') }/`;
 const DIRECTORY = `${versionN[0]}/`;

--- a/packages/connect/CHANGELOG.md
+++ b/packages/connect/CHANGELOG.md
@@ -1,3 +1,10 @@
+# 9.0.7
+
+-   feat(connect-ui): connect UI will now display a warning in case it was opened by an application listed in https://github.com/MetaMask/eth-phishing-detect (#7488)
+-   fix(connect-ui): set max pin input length to 50 instead of 9 (#7668)
+-   fix(connect): ltc spending problem (#7666)
+-   change(connect): TrezorConnect.init `webusb` option is now deprecated. It was replaced with `transports` param `('BridgeTransport' | 'WebUsbTransport')[]`. (#7411)
+
 # 9.0.6
 
 -   fix: list tslib as direct dependency

--- a/packages/connect/README.md
+++ b/packages/connect/README.md
@@ -1,6 +1,6 @@
 # @trezor/connect
 
-API version 9.0.6
+API version 9.0.7
 
 [![Build Status](https://github.com/trezor/trezor-suite/actions/workflows/connect-test.yml/badge.svg)](https://github.com/trezor/trezor-suite/actions/workflows/connect-test.yml)
 [![NPM](https://img.shields.io/npm/v/@trezor/connect.svg)](https://www.npmjs.org/package/@trezor/connect)

--- a/packages/connect/package.json
+++ b/packages/connect/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@trezor/connect",
-    "version": "9.0.6",
+    "version": "9.0.7",
     "author": "Trezor <info@trezor.io>",
     "homepage": "https://github.com/trezor/trezor-suite/tree/develop/packages/connect",
     "description": "High-level javascript interface for Trezor hardware wallet.",
@@ -49,11 +49,11 @@
         "prepublish": "yarn tsx ../../scripts/prepublish.js"
     },
     "dependencies": {
-        "@trezor/blockchain-link": "workspace:^2.1.7",
-        "@trezor/connect-common": "workspace:0.0.11",
-        "@trezor/transport": "workspace:^1.1.7",
-        "@trezor/utils": "workspace:^9.0.5",
-        "@trezor/utxo-lib": "workspace:^1.0.3",
+        "@trezor/blockchain-link": "workspace:^2.1.8",
+        "@trezor/connect-common": "workspace:0.0.12",
+        "@trezor/transport": "workspace:^1.1.8",
+        "@trezor/utils": "workspace:^9.0.6",
+        "@trezor/utxo-lib": "workspace:^1.0.4",
         "bignumber.js": "^9.1.1",
         "blakejs": "^1.2.1",
         "bowser": "^2.11.0",

--- a/packages/connect/src/data/version.ts
+++ b/packages/connect/src/data/version.ts
@@ -1,4 +1,4 @@
-export const VERSION = '9.0.6';
+export const VERSION = '9.0.7';
 
 const versionN = VERSION.split('.').map(s => parseInt(s, 10));
 

--- a/packages/suite-desktop-ui/package.json
+++ b/packages/suite-desktop-ui/package.json
@@ -16,7 +16,7 @@
         "@suite-common/formatters": "workspace:*",
         "@suite-common/sentry": "workspace:*",
         "@trezor/components": "workspace:*",
-        "@trezor/connect": "workspace:9.0.6",
+        "@trezor/connect": "workspace:9.0.7",
         "@trezor/ipc-proxy": "workspace:*",
         "@trezor/suite": "workspace:*",
         "@trezor/suite-analytics": "workspace:*",

--- a/packages/suite-desktop/package.json
+++ b/packages/suite-desktop/package.json
@@ -222,7 +222,7 @@
         "@suite-common/suite-types": "workspace:*",
         "@suite-common/suite-utils": "workspace:*",
         "@trezor/coinjoin": "workspace:*",
-        "@trezor/connect": "workspace:9.0.6",
+        "@trezor/connect": "workspace:9.0.7",
         "@trezor/connect-common": "workspace:*",
         "@trezor/ipc-proxy": "workspace:*",
         "@trezor/request-manager": "workspace:*",

--- a/packages/suite/package.json
+++ b/packages/suite/package.json
@@ -48,7 +48,7 @@
         "@trezor/analytics": "workspace:*",
         "@trezor/coinjoin": "workspace:*",
         "@trezor/components": "workspace:*",
-        "@trezor/connect": "workspace:9.0.6",
+        "@trezor/connect": "workspace:9.0.7",
         "@trezor/crypto-utils": "workspace:*",
         "@trezor/device-utils": "workspace:*",
         "@trezor/dom-utils": "workspace:*",

--- a/packages/transport/CHANGELOG.md
+++ b/packages/transport/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 1.1.8
+
+-   chore(connect;transport): connect.init add transports param; rename transports
+
 # 1.1.7
 
 -   Code cleanup, sharing constants with @trezor/connect

--- a/packages/transport/package.json
+++ b/packages/transport/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@trezor/transport",
-    "version": "1.1.7",
+    "version": "1.1.8",
     "description": "Low level library facilitating protocol buffers based communication with Trezor devices",
     "npmPublishAccess": "public",
     "license": "SEE LICENSE IN LICENSE.md",
@@ -47,7 +47,7 @@
         "typescript": "4.9.5"
     },
     "dependencies": {
-        "@trezor/utils": "workspace:^9.0.5",
+        "@trezor/utils": "workspace:^9.0.6",
         "bytebuffer": "^5.0.1",
         "json-stable-stringify": "^1.0.2",
         "long": "^4.0.0",

--- a/packages/utils/CHANGELOG.md
+++ b/packages/utils/CHANGELOG.md
@@ -1,3 +1,8 @@
+# 9.0.6
+
+-   fix(utils): scheduleAction readonly param
+-   feat(utils): scheduleAction with variable timeouts
+
 # 9.0.5
 
 -   feat(utils): add promiseAllSequence util

--- a/packages/utils/package.json
+++ b/packages/utils/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@trezor/utils",
-    "version": "9.0.5",
+    "version": "9.0.6",
     "author": "Trezor <info@trezor.io>",
     "homepage": "https://github.com/trezor/trezor-suite/tree/develop/packages/utils",
     "description": "A collection of typescript utils that are intended to be used across trezor-suite monorepo.",

--- a/packages/utxo-lib/CHANGELOG.md
+++ b/packages/utxo-lib/CHANGELOG.md
@@ -1,3 +1,9 @@
+# 1.0.4
+
+-   fix(utxo-lib): ltc deserialize without advanced marker
+-   feat(utxo-lib): add getTransactionVbytes util
+-   feat(utxo-lib): add getAddressType util
+
 # 1.0.3
 
 -   chore: remove unused skipUtxoSelection

--- a/packages/utxo-lib/package.json
+++ b/packages/utxo-lib/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@trezor/utxo-lib",
-    "version": "1.0.3",
+    "version": "1.0.4",
     "author": "Trezor <info@trezor.io>",
     "homepage": "https://github.com/trezor/trezor-suite/tree/develop/packages/utxo-lib",
     "description": "Client-side Bitcoin-like JavaScript library",
@@ -36,7 +36,7 @@
         "prepublish": "yarn tsx ../../scripts/prepublish.js"
     },
     "dependencies": {
-        "@trezor/utils": "workspace:^9.0.5",
+        "@trezor/utils": "workspace:^9.0.6",
         "bchaddrjs": "^0.5.2",
         "bech32": "^2.0.0",
         "bip66": "^1.1.5",

--- a/suite-common/connect-init/package.json
+++ b/suite-common/connect-init/package.json
@@ -16,7 +16,7 @@
         "@suite-common/redux-utils": "workspace:*",
         "@suite-common/suite-types": "workspace:*",
         "@suite-common/test-utils": "workspace:*",
-        "@trezor/connect": "workspace:9.0.6",
+        "@trezor/connect": "workspace:9.0.7",
         "@trezor/utils": "workspace:*"
     },
     "devDependencies": {

--- a/suite-common/formatters/package.json
+++ b/suite-common/formatters/package.json
@@ -20,7 +20,7 @@
         "@suite-common/wallet-core": "workspace:*",
         "@suite-common/wallet-types": "workspace:*",
         "@suite-common/wallet-utils": "workspace:*",
-        "@trezor/connect": "workspace:9.0.6",
+        "@trezor/connect": "workspace:9.0.7",
         "bignumber.js": "^9.1.1",
         "react": "18.2.0",
         "react-intl": "^6.2.8",

--- a/suite-common/graph/package.json
+++ b/suite-common/graph/package.json
@@ -20,7 +20,7 @@
         "@suite-common/wallet-types": "workspace:*",
         "@suite-common/wallet-utils": "workspace:*",
         "@trezor/blockchain-link": "workspace:*",
-        "@trezor/connect": "workspace:9.0.6",
+        "@trezor/connect": "workspace:9.0.7",
         "bignumber.js": "^9.1.1",
         "date-fns": "^2.29.3",
         "react": "18.2.0",

--- a/suite-common/redux-utils/package.json
+++ b/suite-common/redux-utils/package.json
@@ -16,7 +16,7 @@
         "@suite-common/suite-types": "workspace:*",
         "@suite-common/wallet-config": "workspace:*",
         "@suite-common/wallet-types": "workspace:*",
-        "@trezor/connect": "workspace:9.0.6",
+        "@trezor/connect": "workspace:9.0.7",
         "react": "18.2.0",
         "react-redux": "8.0.5",
         "redux": "^4.2.1"

--- a/suite-common/suite-constants/package.json
+++ b/suite-common/suite-constants/package.json
@@ -11,7 +11,7 @@
     },
     "dependencies": {
         "@suite-common/wallet-config": "workspace:*",
-        "@trezor/connect": "workspace:9.0.6"
+        "@trezor/connect": "workspace:9.0.7"
     },
     "devDependencies": {
         "jest": "^26.6.3",

--- a/suite-common/suite-types/package.json
+++ b/suite-common/suite-types/package.json
@@ -14,7 +14,7 @@
         "@suite-common/metadata-types": "workspace:*",
         "@suite-common/wallet-config": "workspace:*",
         "@trezor/analytics": "workspace:*",
-        "@trezor/connect": "workspace:9.0.6",
+        "@trezor/connect": "workspace:9.0.7",
         "bignumber.js": "^9.1.1"
     },
     "devDependencies": {

--- a/suite-common/test-utils/package.json
+++ b/suite-common/test-utils/package.json
@@ -16,7 +16,7 @@
         "@suite-common/suite-types": "workspace:*",
         "@suite-common/wallet-config": "workspace:*",
         "@suite-common/wallet-types": "workspace:*",
-        "@trezor/connect": "workspace:9.0.6",
+        "@trezor/connect": "workspace:9.0.7",
         "@trezor/device-utils": "workspace:*",
         "@trezor/message-system": "workspace:*",
         "@trezor/utils": "workspace:*",

--- a/suite-common/toast-notifications/package.json
+++ b/suite-common/toast-notifications/package.json
@@ -18,7 +18,7 @@
         "@suite-common/suite-types": "workspace:*",
         "@suite-common/test-utils": "workspace:*",
         "@suite-common/wallet-config": "workspace:*",
-        "@trezor/connect": "workspace:9.0.6"
+        "@trezor/connect": "workspace:9.0.7"
     },
     "devDependencies": {
         "jest": "^26.6.3",

--- a/suite-common/wallet-core/package.json
+++ b/suite-common/wallet-core/package.json
@@ -23,7 +23,7 @@
         "@suite-common/wallet-config": "workspace:*",
         "@suite-common/wallet-types": "workspace:*",
         "@suite-common/wallet-utils": "workspace:*",
-        "@trezor/connect": "workspace:9.0.6",
+        "@trezor/connect": "workspace:9.0.7",
         "@trezor/type-utils": "workspace:*",
         "@trezor/utils": "workspace:*",
         "date-fns": "^2.29.3",

--- a/suite-common/wallet-types/package.json
+++ b/suite-common/wallet-types/package.json
@@ -14,7 +14,7 @@
         "@suite-common/suite-config": "workspace:*",
         "@suite-common/wallet-config": "workspace:*",
         "@suite-common/wallet-constants": "workspace:*",
-        "@trezor/connect": "workspace:9.0.6",
+        "@trezor/connect": "workspace:9.0.7",
         "@trezor/type-utils": "workspace:*",
         "@trezor/utils": "workspace:*",
         "react": "18.2.0",

--- a/suite-common/wallet-utils/package.json
+++ b/suite-common/wallet-utils/package.json
@@ -24,7 +24,7 @@
         "@suite-common/wallet-config": "workspace:*",
         "@suite-common/wallet-constants": "workspace:*",
         "@suite-common/wallet-types": "workspace:*",
-        "@trezor/connect": "workspace:9.0.6",
+        "@trezor/connect": "workspace:9.0.7",
         "@trezor/urls": "workspace:*",
         "@trezor/utils": "workspace:*",
         "bignumber.js": "^9.1.1",

--- a/suite-native/app/package.json
+++ b/suite-native/app/package.json
@@ -54,7 +54,7 @@
         "@suite-native/state": "workspace:*",
         "@suite-native/storage": "workspace:*",
         "@suite-native/transactions": "workspace:*",
-        "@trezor/connect": "workspace:9.0.6",
+        "@trezor/connect": "workspace:9.0.7",
         "@trezor/icons": "workspace:*",
         "@trezor/styles": "workspace:*",
         "@trezor/suite-data": "workspace:*",

--- a/suite-native/module-accounts-import/package.json
+++ b/suite-native/module-accounts-import/package.json
@@ -34,7 +34,7 @@
         "@suite-native/navigation": "workspace:*",
         "@suite-native/qr-code": "workspace:*",
         "@suite-native/video-assets": "workspace:*",
-        "@trezor/connect": "workspace:9.0.6",
+        "@trezor/connect": "workspace:9.0.7",
         "@trezor/icons": "workspace:*",
         "@trezor/styles": "workspace:*",
         "@trezor/validation": "workspace:*",

--- a/suite-native/state/package.json
+++ b/suite-native/state/package.json
@@ -21,7 +21,7 @@
         "@suite-native/module-devices": "workspace:*",
         "@suite-native/module-settings": "workspace:*",
         "@suite-native/storage": "workspace:*",
-        "@trezor/connect": "workspace:9.0.6",
+        "@trezor/connect": "workspace:9.0.7",
         "@trezor/utils": "workspace:*",
         "react": "18.2.0",
         "react-redux": "8.0.5",

--- a/yarn.lock
+++ b/yarn.lock
@@ -6238,7 +6238,7 @@ __metadata:
     "@suite-common/redux-utils": "workspace:*"
     "@suite-common/suite-types": "workspace:*"
     "@suite-common/test-utils": "workspace:*"
-    "@trezor/connect": "workspace:9.0.6"
+    "@trezor/connect": "workspace:9.0.7"
     "@trezor/utils": "workspace:*"
     jest: ^26.6.3
     redux-mock-store: ^1.5.4
@@ -6272,7 +6272,7 @@ __metadata:
     "@suite-common/wallet-core": "workspace:*"
     "@suite-common/wallet-types": "workspace:*"
     "@suite-common/wallet-utils": "workspace:*"
-    "@trezor/connect": "workspace:9.0.6"
+    "@trezor/connect": "workspace:9.0.7"
     bignumber.js: ^9.1.1
     jest: ^26.6.3
     react: 18.2.0
@@ -6295,7 +6295,7 @@ __metadata:
     "@suite-common/wallet-types": "workspace:*"
     "@suite-common/wallet-utils": "workspace:*"
     "@trezor/blockchain-link": "workspace:*"
-    "@trezor/connect": "workspace:9.0.6"
+    "@trezor/connect": "workspace:9.0.7"
     bignumber.js: ^9.1.1
     date-fns: ^2.29.3
     react: 18.2.0
@@ -6353,7 +6353,7 @@ __metadata:
     "@suite-common/suite-types": "workspace:*"
     "@suite-common/wallet-config": "workspace:*"
     "@suite-common/wallet-types": "workspace:*"
-    "@trezor/connect": "workspace:9.0.6"
+    "@trezor/connect": "workspace:9.0.7"
     jest: ^26.6.3
     react: 18.2.0
     react-redux: 8.0.5
@@ -6389,7 +6389,7 @@ __metadata:
   resolution: "@suite-common/suite-constants@workspace:suite-common/suite-constants"
   dependencies:
     "@suite-common/wallet-config": "workspace:*"
-    "@trezor/connect": "workspace:9.0.6"
+    "@trezor/connect": "workspace:9.0.7"
     jest: ^26.6.3
     typescript: 4.9.5
   languageName: unknown
@@ -6403,7 +6403,7 @@ __metadata:
     "@suite-common/metadata-types": "workspace:*"
     "@suite-common/wallet-config": "workspace:*"
     "@trezor/analytics": "workspace:*"
-    "@trezor/connect": "workspace:9.0.6"
+    "@trezor/connect": "workspace:9.0.7"
     bignumber.js: ^9.1.1
     jest: ^26.6.3
     typescript: 4.9.5
@@ -6436,7 +6436,7 @@ __metadata:
     "@suite-common/suite-types": "workspace:*"
     "@suite-common/wallet-config": "workspace:*"
     "@suite-common/wallet-types": "workspace:*"
-    "@trezor/connect": "workspace:9.0.6"
+    "@trezor/connect": "workspace:9.0.7"
     "@trezor/device-utils": "workspace:*"
     "@trezor/message-system": "workspace:*"
     "@trezor/utils": "workspace:*"
@@ -6460,7 +6460,7 @@ __metadata:
     "@suite-common/suite-types": "workspace:*"
     "@suite-common/test-utils": "workspace:*"
     "@suite-common/wallet-config": "workspace:*"
-    "@trezor/connect": "workspace:9.0.6"
+    "@trezor/connect": "workspace:9.0.7"
     jest: ^26.6.3
     typescript: 4.9.5
   languageName: unknown
@@ -6503,7 +6503,7 @@ __metadata:
     "@suite-common/wallet-config": "workspace:*"
     "@suite-common/wallet-types": "workspace:*"
     "@suite-common/wallet-utils": "workspace:*"
-    "@trezor/connect": "workspace:9.0.6"
+    "@trezor/connect": "workspace:9.0.7"
     "@trezor/type-utils": "workspace:*"
     "@trezor/utils": "workspace:*"
     date-fns: ^2.29.3
@@ -6521,7 +6521,7 @@ __metadata:
     "@suite-common/suite-config": "workspace:*"
     "@suite-common/wallet-config": "workspace:*"
     "@suite-common/wallet-constants": "workspace:*"
-    "@trezor/connect": "workspace:9.0.6"
+    "@trezor/connect": "workspace:9.0.7"
     "@trezor/type-utils": "workspace:*"
     "@trezor/utils": "workspace:*"
     jest: ^26.6.3
@@ -6547,7 +6547,7 @@ __metadata:
     "@suite-common/wallet-config": "workspace:*"
     "@suite-common/wallet-constants": "workspace:*"
     "@suite-common/wallet-types": "workspace:*"
-    "@trezor/connect": "workspace:9.0.6"
+    "@trezor/connect": "workspace:9.0.7"
     "@trezor/urls": "workspace:*"
     "@trezor/utils": "workspace:*"
     "@types/pdfmake": ^0.2.2
@@ -6756,7 +6756,7 @@ __metadata:
     "@suite-native/navigation": "workspace:*"
     "@suite-native/qr-code": "workspace:*"
     "@suite-native/video-assets": "workspace:*"
-    "@trezor/connect": "workspace:9.0.6"
+    "@trezor/connect": "workspace:9.0.7"
     "@trezor/icons": "workspace:*"
     "@trezor/styles": "workspace:*"
     "@trezor/validation": "workspace:*"
@@ -6971,7 +6971,7 @@ __metadata:
     "@suite-native/module-devices": "workspace:*"
     "@suite-native/module-settings": "workspace:*"
     "@suite-native/storage": "workspace:*"
-    "@trezor/connect": "workspace:9.0.6"
+    "@trezor/connect": "workspace:9.0.7"
     "@trezor/utils": "workspace:*"
     react: 18.2.0
     react-redux: 8.0.5
@@ -7183,12 +7183,12 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@trezor/blockchain-link@workspace:*, @trezor/blockchain-link@workspace:^2.1.7, @trezor/blockchain-link@workspace:packages/blockchain-link":
+"@trezor/blockchain-link@workspace:*, @trezor/blockchain-link@workspace:^2.1.8, @trezor/blockchain-link@workspace:packages/blockchain-link":
   version: 0.0.0-use.local
   resolution: "@trezor/blockchain-link@workspace:packages/blockchain-link"
   dependencies:
-    "@trezor/utils": "workspace:^9.0.5"
-    "@trezor/utxo-lib": "workspace:^1.0.3"
+    "@trezor/utils": "workspace:^9.0.6"
+    "@trezor/utxo-lib": "workspace:^1.0.4"
     "@types/web": ^0.0.91
     bignumber.js: ^9.1.1
     events: ^3.3.0
@@ -7285,7 +7285,7 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@trezor/connect-common@workspace:*, @trezor/connect-common@workspace:0.0.11, @trezor/connect-common@workspace:packages/connect-common":
+"@trezor/connect-common@workspace:*, @trezor/connect-common@workspace:0.0.12, @trezor/connect-common@workspace:packages/connect-common":
   version: 0.0.0-use.local
   resolution: "@trezor/connect-common@workspace:packages/connect-common"
   dependencies:
@@ -7301,7 +7301,7 @@ __metadata:
   resolution: "@trezor/connect-explorer@workspace:packages/connect-explorer"
   dependencies:
     "@trezor/components": "workspace:*"
-    "@trezor/connect-web": "workspace:9.0.6"
+    "@trezor/connect-web": "workspace:9.0.7"
     "@types/markdown-it": ^12.2.3
     "@types/markdown-it-link-attributes": ^3.0.1
     "@types/react-router": ^5.1.20
@@ -7336,7 +7336,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@trezor/connect-iframe@workspace:packages/connect-iframe"
   dependencies:
-    "@trezor/connect": "workspace:9.0.6"
+    "@trezor/connect": "workspace:9.0.7"
     copy-webpack-plugin: ^11.0.0
     html-webpack-plugin: ^5.5.0
     jest: ^26.6.3
@@ -7382,7 +7382,7 @@ __metadata:
   resolution: "@trezor/connect-popup@workspace:packages/connect-popup"
   dependencies:
     "@playwright/test": ^1.30.0
-    "@trezor/connect": "workspace:9.0.6"
+    "@trezor/connect": "workspace:9.0.7"
     "@trezor/connect-analytics": "workspace:*"
     "@trezor/connect-ui": "workspace:*"
     "@trezor/crypto-utils": "workspace:*"
@@ -7409,7 +7409,7 @@ __metadata:
   resolution: "@trezor/connect-ui@workspace:packages/connect-ui"
   dependencies:
     "@trezor/components": "workspace:*"
-    "@trezor/connect": "workspace:9.0.6"
+    "@trezor/connect": "workspace:9.0.7"
     "@trezor/connect-analytics": "workspace:*"
     "@trezor/connect-common": "workspace:*"
     "@trezor/env-utils": "workspace:*"
@@ -7425,12 +7425,12 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@trezor/connect-web@workspace:9.0.6, @trezor/connect-web@workspace:packages/connect-web":
+"@trezor/connect-web@workspace:9.0.7, @trezor/connect-web@workspace:packages/connect-web":
   version: 0.0.0-use.local
   resolution: "@trezor/connect-web@workspace:packages/connect-web"
   dependencies:
-    "@trezor/connect": "workspace:9.0.6"
-    "@trezor/utils": "workspace:^9.0.5"
+    "@trezor/connect": "workspace:9.0.7"
+    "@trezor/utils": "workspace:^9.0.6"
     "@types/chrome": ^0.0.212
     "@types/w3c-web-usb": ^1.0.5
     events: ^3.3.0
@@ -7445,17 +7445,17 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@trezor/connect@workspace:*, @trezor/connect@workspace:9.0.6, @trezor/connect@workspace:packages/connect":
+"@trezor/connect@workspace:*, @trezor/connect@workspace:9.0.7, @trezor/connect@workspace:packages/connect":
   version: 0.0.0-use.local
   resolution: "@trezor/connect@workspace:packages/connect"
   dependencies:
-    "@trezor/blockchain-link": "workspace:^2.1.7"
+    "@trezor/blockchain-link": "workspace:^2.1.8"
     "@trezor/connect-analytics": "workspace:*"
-    "@trezor/connect-common": "workspace:0.0.11"
-    "@trezor/transport": "workspace:^1.1.7"
+    "@trezor/connect-common": "workspace:0.0.12"
+    "@trezor/transport": "workspace:^1.1.8"
     "@trezor/trezor-user-env-link": "workspace:*"
-    "@trezor/utils": "workspace:^9.0.5"
-    "@trezor/utxo-lib": "workspace:^1.0.3"
+    "@trezor/utils": "workspace:^9.0.6"
+    "@trezor/utxo-lib": "workspace:^1.0.4"
     "@types/karma": ^6.3.3
     "@types/parse-uri": ^1.0.0
     "@types/randombytes": ^2.0.0
@@ -7727,7 +7727,7 @@ __metadata:
     "@suite-common/formatters": "workspace:*"
     "@suite-common/sentry": "workspace:*"
     "@trezor/components": "workspace:*"
-    "@trezor/connect": "workspace:9.0.6"
+    "@trezor/connect": "workspace:9.0.7"
     "@trezor/ipc-proxy": "workspace:*"
     "@trezor/suite": "workspace:*"
     "@trezor/suite-analytics": "workspace:*"
@@ -7759,7 +7759,7 @@ __metadata:
     "@suite-common/suite-types": "workspace:*"
     "@suite-common/suite-utils": "workspace:*"
     "@trezor/coinjoin": "workspace:*"
-    "@trezor/connect": "workspace:9.0.6"
+    "@trezor/connect": "workspace:9.0.7"
     "@trezor/connect-common": "workspace:*"
     "@trezor/ipc-proxy": "workspace:*"
     "@trezor/request-manager": "workspace:*"
@@ -7822,7 +7822,7 @@ __metadata:
     "@suite-native/state": "workspace:*"
     "@suite-native/storage": "workspace:*"
     "@suite-native/transactions": "workspace:*"
-    "@trezor/connect": "workspace:9.0.6"
+    "@trezor/connect": "workspace:9.0.7"
     "@trezor/icons": "workspace:*"
     "@trezor/styles": "workspace:*"
     "@trezor/suite-data": "workspace:*"
@@ -7952,7 +7952,7 @@ __metadata:
     "@trezor/analytics": "workspace:*"
     "@trezor/coinjoin": "workspace:*"
     "@trezor/components": "workspace:*"
-    "@trezor/connect": "workspace:9.0.6"
+    "@trezor/connect": "workspace:9.0.7"
     "@trezor/crypto-utils": "workspace:*"
     "@trezor/device-utils": "workspace:*"
     "@trezor/dom-utils": "workspace:*"
@@ -8065,12 +8065,12 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@trezor/transport@workspace:^1.1.7, @trezor/transport@workspace:packages/transport":
+"@trezor/transport@workspace:^1.1.8, @trezor/transport@workspace:packages/transport":
   version: 0.0.0-use.local
   resolution: "@trezor/transport@workspace:packages/transport"
   dependencies:
     "@trezor/trezor-user-env-link": "workspace:*"
-    "@trezor/utils": "workspace:^9.0.5"
+    "@trezor/utils": "workspace:^9.0.6"
     "@types/bytebuffer": ^5.0.44
     "@types/w3c-web-usb": ^1.0.6
     bytebuffer: ^5.0.1
@@ -8115,7 +8115,7 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@trezor/utils@workspace:*, @trezor/utils@workspace:^9.0.5, @trezor/utils@workspace:packages/utils":
+"@trezor/utils@workspace:*, @trezor/utils@workspace:^9.0.6, @trezor/utils@workspace:packages/utils":
   version: 0.0.0-use.local
   resolution: "@trezor/utils@workspace:packages/utils"
   dependencies:
@@ -8126,11 +8126,11 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@trezor/utxo-lib@workspace:*, @trezor/utxo-lib@workspace:^1.0.3, @trezor/utxo-lib@workspace:packages/utxo-lib":
+"@trezor/utxo-lib@workspace:*, @trezor/utxo-lib@workspace:^1.0.4, @trezor/utxo-lib@workspace:packages/utxo-lib":
   version: 0.0.0-use.local
   resolution: "@trezor/utxo-lib@workspace:packages/utxo-lib"
   dependencies:
-    "@trezor/utils": "workspace:^9.0.5"
+    "@trezor/utils": "workspace:^9.0.6"
     "@types/bchaddrjs": ^0.4.0
     "@types/bs58": ^4.0.1
     "@types/bs58check": ^2.1.0


### PR DESCRIPTION
## @trezor/connect prerelease

-   [x] Bump version in all @trezor/connect\* packages (except plugin packages). `yarn workspace @trezor/connect version:<beta|patch|minor|major>`
-   [x] Make sure you have released all npm dependencies. If unsure run `node ./ci/scripts/check-npm-dependencies.js connect`. Please note that this script will report unreleased
        dependencies even for changes that do not affect runtime (READMEs etc.) If there are any unreleased npm dependencies you should [release them](./npm-packages.md)
-   [x] Make sure [CHANGELOG](https://github.com/trezor/trezor-suite/blob/develop/packages/connect/CHANGELOG.md) file has been updated
