### PR TITLE
Report network ('btc' | 'test' | 'regtest') to sentry together with coinjoin error

### DIFF
--- a/packages/suite-desktop/src/modules/coinjoin.ts
+++ b/packages/suite-desktop/src/modules/coinjoin.ts
@@ -5,7 +5,7 @@
 import { app, ipcMain } from 'electron';
 import { captureMessage, withScope } from '@sentry/electron';
 
-import { coinjoinReportTag } from '@suite-common/sentry';
+import { coinjoinReportTag, coinjoinNetworktTag } from '@suite-common/sentry';
 import { createIpcProxyHandler, IpcProxyHandlerOptions } from '@trezor/ipc-proxy';
 import { CoinjoinBackend, CoinjoinClient } from '@trezor/coinjoin';
 
@@ -61,6 +61,7 @@ export const init: Module = ({ mainWindow }) => {
                     withScope(scope => {
                         scope.clear(); // scope is also cleared in beforeSend sentry handler, this is just to be safe.
                         scope.setTag(coinjoinReportTag, true);
+                        scope.setTag(coinjoinNetworktTag, settings.network);
                         captureMessage(payload, scope);
                     });
                 }

--- a/suite-common/sentry/src/index.ts
+++ b/suite-common/sentry/src/index.ts
@@ -6,6 +6,7 @@ import { redactUserPathFromString } from '@trezor/utils';
 
 export const allowReportTag = 'allowReport';
 export const coinjoinReportTag = 'coinjoinReport';
+export const coinjoinNetworktTag = 'coinjoinNetwork';
 
 /**
  * Full user path could be part of reported error in some cases and we want to actively filter username out.
@@ -51,6 +52,7 @@ const beforeSend: Options['beforeSend'] = event => {
             level: event.level,
             tags: {
                 coinjoinReport: true,
+                coinjoinNetworktTag: event.tags?.[coinjoinNetworktTag],
             },
         };
     }


### PR DESCRIPTION


<!--- Provide a general summary of your changes in the Title above -->

## Description

- So we can distinguish between maninnet/testnet.
- possible values of `coinjoinNetworkTag`: `'btc' | 'test' | 'regtest'`


## Screenshots:
![image](https://user-images.githubusercontent.com/3729633/221904938-fd043b6b-2efb-40c0-a6da-479ba0d063fd.png)
https://satoshilabs.sentry.io/issues/3964061802