### PR TITLE
feat(suite): change the default target anonymity level to 5

### DIFF
--- a/packages/suite/src/components/wallet/PrivacyAccount/AnonymityLevelSlider.tsx
+++ b/packages/suite/src/components/wallet/PrivacyAccount/AnonymityLevelSlider.tsx
@@ -102,9 +102,9 @@ export const AnonymityLevelSlider = ({
         background: `\
             linear-gradient(270deg,\
                 ${theme.GRADIENT_SLIDER_GREEN_START} 0%,\
-                ${theme.GRADIENT_SLIDER_GREEN_END} 45%,\
-                ${theme.GRADIENT_SLIDER_YELLOW_START} 55%,\
-                ${theme.GRADIENT_SLIDER_YELLOW_END} 60%,\
+                ${theme.GRADIENT_SLIDER_GREEN_END} 60%,\
+                ${theme.GRADIENT_SLIDER_YELLOW_START} 70%,\
+                ${theme.GRADIENT_SLIDER_YELLOW_END} 85%,\
                 ${theme.GRADIENT_SLIDER_RED_END} 100%\
             );`,
     };

--- a/packages/suite/src/services/coinjoin/config.ts
+++ b/packages/suite/src/services/coinjoin/config.ts
@@ -157,7 +157,7 @@ export const CLIENT_STATUS_FALLBACK = {
 // firmware format (300 000 = 0.003 * 10 ** 8)
 export const COORDINATOR_FEE_RATE_MULTIPLIER = 10 ** 8;
 
-export const DEFAULT_TARGET_ANONYMITY = 10;
+export const DEFAULT_TARGET_ANONYMITY = 5;
 
 export const getCoinjoinConfig = (
     network: NetworkSymbol,


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

*  change the default target anonymity level to 5

I was considering writing a migration for remembered CJ accounts but there's no way to determine if `10` was the default one or the one users actually wanted.

## Related Issue

Resolve #7730

