### PR TITLE
Increase default max mining fee by modifier

### DIFF
--- a/packages/coinjoin/src/constants.ts
+++ b/packages/coinjoin/src/constants.ts
@@ -39,11 +39,11 @@ export const ACCOUNT_BUSY_TIMEOUT = 30000;
 
 // fallback values for status request
 // usage of these values is extremely unlikely, there would have to be a change in the coordinator's API
-export const PLEBS_DONT_PAY_THRESHOLD = 1000000;
-export const COORDINATOR_FEE_RATE = 0.003;
-export const MIN_ALLOWED_AMOUNT = 5000;
-export const MAX_ALLOWED_AMOUNT = 134375000000;
-export const MAX_MINING_FEE = 2;
+export const PLEBS_DONT_PAY_THRESHOLD_FALLBACK = 1000000;
+export const COORDINATOR_FEE_RATE_FALLBACK = 0.003;
+export const MIN_ALLOWED_AMOUNT_FALLBACK = 5000;
+export const MAX_ALLOWED_AMOUNT_FALLBACK = 134375000000;
+export const MAX_MINING_FEE_FALLBACK = 2;
 
 // affiliation flag:
 // - sent coordinator/ready-to-sign request **only** when Alice pays coordination fee

--- a/packages/coinjoin/src/constants.ts
+++ b/packages/coinjoin/src/constants.ts
@@ -43,9 +43,12 @@ export const PLEBS_DONT_PAY_THRESHOLD = 1000000;
 export const COORDINATOR_FEE_RATE = 0.003;
 export const MIN_ALLOWED_AMOUNT = 5000;
 export const MAX_ALLOWED_AMOUNT = 134375000000;
-export const MAX_MINING_FEE = 1;
+export const MAX_MINING_FEE = 2;
 
 // affiliation flag:
 // - sent coordinator/ready-to-sign request **only** when Alice pays coordination fee
 // - check if Trezor affiliate server is running in status.affiliateInformation.runningAffiliateServers
 export const AFFILIATION_ID = 'trezor';
+
+// modifier applied to a median fee rate to set default max mining fee
+export const MAX_MINING_FEE_MODIFIER = 2.5;

--- a/packages/coinjoin/src/utils/roundUtils.ts
+++ b/packages/coinjoin/src/utils/roundUtils.ts
@@ -7,6 +7,7 @@ import {
     MIN_ALLOWED_AMOUNT,
     PLEBS_DONT_PAY_THRESHOLD,
     ROUND_REGISTRATION_END_OFFSET,
+    MAX_MINING_FEE_MODIFIER,
 } from '../constants';
 import { RoundPhase } from '../enums';
 import {
@@ -172,10 +173,10 @@ export const transformStatus = ({
 }: CoinjoinStatus) => {
     const { allowedInputAmounts, coordinationFeeRate } = getDataFromRounds(rounds);
     // coinJoinFeeRateMedians include an array of medians per day, week and month - we take the second (week) median as the recommended fee rate
-    const recommendedMedian = coinJoinFeeRateMedians[1];
+    const weeklyMedian = coinJoinFeeRateMedians[1];
     // the value is converted from kvBytes (kilo virtual bytes) to vBytes (how the value is displayed in UI)
-    const maxMiningFee = recommendedMedian
-        ? Math.round(coinJoinFeeRateMedians[1].medianFeeRate / 1000)
+    const maxMiningFee = weeklyMedian
+        ? Math.round((coinJoinFeeRateMedians[1].medianFeeRate * MAX_MINING_FEE_MODIFIER) / 1000)
         : MAX_MINING_FEE;
 
     return {

--- a/packages/coinjoin/src/utils/roundUtils.ts
+++ b/packages/coinjoin/src/utils/roundUtils.ts
@@ -1,11 +1,11 @@
 import { bufferutils } from '@trezor/utxo-lib';
 
 import {
-    COORDINATOR_FEE_RATE,
-    MAX_MINING_FEE,
-    MAX_ALLOWED_AMOUNT,
-    MIN_ALLOWED_AMOUNT,
-    PLEBS_DONT_PAY_THRESHOLD,
+    COORDINATOR_FEE_RATE_FALLBACK,
+    MAX_MINING_FEE_FALLBACK,
+    MAX_ALLOWED_AMOUNT_FALLBACK,
+    MIN_ALLOWED_AMOUNT_FALLBACK,
+    PLEBS_DONT_PAY_THRESHOLD_FALLBACK,
     ROUND_REGISTRATION_END_OFFSET,
     MAX_MINING_FEE_MODIFIER,
 } from '../constants';
@@ -152,12 +152,12 @@ const getDataFromRounds = (rounds: Round[]) => {
         coordinationFeeRate: {
             plebsDontPayThreshold:
                 roundParameters?.coordinationFeeRate.plebsDontPayThreshold ??
-                PLEBS_DONT_PAY_THRESHOLD,
-            rate: roundParameters?.coordinationFeeRate.rate ?? COORDINATOR_FEE_RATE,
+                PLEBS_DONT_PAY_THRESHOLD_FALLBACK,
+            rate: roundParameters?.coordinationFeeRate.rate ?? COORDINATOR_FEE_RATE_FALLBACK,
         },
         allowedInputAmounts: {
-            max: roundParameters?.allowedInputAmounts.max ?? MAX_ALLOWED_AMOUNT,
-            min: roundParameters?.allowedInputAmounts.min ?? MIN_ALLOWED_AMOUNT,
+            max: roundParameters?.allowedInputAmounts.max ?? MAX_ALLOWED_AMOUNT_FALLBACK,
+            min: roundParameters?.allowedInputAmounts.min ?? MIN_ALLOWED_AMOUNT_FALLBACK,
         },
     };
 };
@@ -177,7 +177,7 @@ export const transformStatus = ({
     // the value is converted from kvBytes (kilo virtual bytes) to vBytes (how the value is displayed in UI)
     const maxMiningFee = weeklyMedian
         ? Math.round((coinJoinFeeRateMedians[1].medianFeeRate * MAX_MINING_FEE_MODIFIER) / 1000)
-        : MAX_MINING_FEE;
+        : MAX_MINING_FEE_FALLBACK;
 
     return {
         rounds,

--- a/packages/coinjoin/tests/fixtures/round.fixture.ts
+++ b/packages/coinjoin/tests/fixtures/round.fixture.ts
@@ -146,7 +146,7 @@ export const createCoinjoinRound = (
 };
 
 export const STATUS_TRANSFORMED = {
-    maxMiningFee: 129,
+    maxMiningFee: 323,
     allowedInputAmounts: {
         max: 134375000000,
         min: 5000,

--- a/packages/suite/src/reducers/wallet/coinjoinReducer.ts
+++ b/packages/suite/src/reducers/wallet/coinjoinReducer.ts
@@ -27,7 +27,7 @@ import {
     transformCoinjoinStatus,
 } from '@wallet-utils/coinjoinUtils';
 import {
-    DEFAULT_CLIENT_STATUS,
+    CLIENT_STATUS_FALLBACK,
     ESTIMATED_ANONYMITY_GAINED_PER_ROUND,
     MIN_ANONYMITY_GAINED_PER_ROUND,
     ESTIMATED_ROUNDS_FAIL_RATE_BUFFER,
@@ -269,7 +269,7 @@ const initClient = (
     const exists = draft.clients[payload.symbol];
     if (exists) return;
     draft.clients[payload.symbol] = {
-        ...DEFAULT_CLIENT_STATUS,
+        ...CLIENT_STATUS_FALLBACK,
         status: 'loading',
     };
 };
@@ -564,7 +564,7 @@ export const selectIsAccountWithSessionByAccountKey = memoizeWithArgs(
 export const selectMinAllowedInputWithFee = memoizeWithArgs(
     (state: CoinjoinRootState, accountKey: AccountKey) => {
         const coinjoinClient = selectCoinjoinClient(state, accountKey);
-        const status = coinjoinClient || DEFAULT_CLIENT_STATUS;
+        const status = coinjoinClient || CLIENT_STATUS_FALLBACK;
         const minAllowedInput = status.allowedInputAmounts.min;
         const txSize = getInputSize('Taproot') + getOutputSize('Taproot');
 

--- a/packages/suite/src/services/coinjoin/config.ts
+++ b/packages/suite/src/services/coinjoin/config.ts
@@ -140,7 +140,6 @@ export const ESTIMATED_ROUNDS_FAIL_RATE_BUFFER = 2.5;
 export const ESTIMATED_MIN_ROUNDS_NEEDED = 4;
 export const ESTIMATED_HOURS_PER_ROUND = 1;
 export const RECOMMENDED_SKIP_ROUNDS = undefined; // temporary disabled for testing purposes // [4, 5] as [number, number];
-export const DEFAULT_MAX_MINING_FEE = 3;
 export const CLIENT_STATUS_FALLBACK = {
     rounds: [],
     maxMiningFee: MAX_MINING_FEE_FALLBACK,

--- a/packages/suite/src/services/coinjoin/config.ts
+++ b/packages/suite/src/services/coinjoin/config.ts
@@ -1,9 +1,9 @@
 import {
-    PLEBS_DONT_PAY_THRESHOLD,
-    COORDINATOR_FEE_RATE,
-    MIN_ALLOWED_AMOUNT,
-    MAX_ALLOWED_AMOUNT,
-    MAX_MINING_FEE,
+    PLEBS_DONT_PAY_THRESHOLD_FALLBACK,
+    COORDINATOR_FEE_RATE_FALLBACK,
+    MIN_ALLOWED_AMOUNT_FALLBACK,
+    MAX_ALLOWED_AMOUNT_FALLBACK,
+    MAX_MINING_FEE_FALLBACK,
 } from '@trezor/coinjoin/src/constants';
 import type { CoinjoinBackendSettings, CoinjoinClientSettings } from '@trezor/coinjoin';
 import type { PartialRecord } from '@trezor/type-utils';
@@ -141,25 +141,24 @@ export const ESTIMATED_MIN_ROUNDS_NEEDED = 4;
 export const ESTIMATED_HOURS_PER_ROUND = 1;
 export const RECOMMENDED_SKIP_ROUNDS = undefined; // temporary disabled for testing purposes // [4, 5] as [number, number];
 export const DEFAULT_MAX_MINING_FEE = 3;
+export const CLIENT_STATUS_FALLBACK = {
+    rounds: [],
+    maxMiningFee: MAX_MINING_FEE_FALLBACK,
+    coordinationFeeRate: {
+        rate: COORDINATOR_FEE_RATE_FALLBACK,
+        plebsDontPayThreshold: PLEBS_DONT_PAY_THRESHOLD_FALLBACK,
+    },
+    allowedInputAmounts: {
+        min: MIN_ALLOWED_AMOUNT_FALLBACK,
+        max: MAX_ALLOWED_AMOUNT_FALLBACK,
+    },
+};
 
 // coordinator fee rate from status format (0.003)
 // firmware format (300 000 = 0.003 * 10 ** 8)
 export const COORDINATOR_FEE_RATE_MULTIPLIER = 10 ** 8;
 
 export const DEFAULT_TARGET_ANONYMITY = 10;
-
-export const DEFAULT_CLIENT_STATUS = {
-    rounds: [],
-    maxMiningFee: MAX_MINING_FEE,
-    coordinationFeeRate: {
-        rate: COORDINATOR_FEE_RATE,
-        plebsDontPayThreshold: PLEBS_DONT_PAY_THRESHOLD,
-    },
-    allowedInputAmounts: {
-        min: MIN_ALLOWED_AMOUNT,
-        max: MAX_ALLOWED_AMOUNT,
-    },
-};
 
 export const getCoinjoinConfig = (
     network: NetworkSymbol,


### PR DESCRIPTION
## Description

Add a multiplier to aways set max mining fee for coinjoin above weekly median value so that users can enter rounds more frequently. The multiplier is currently set to 2.5.

## Related Issue

Resolve #7738