### PR TITLE
fix(suite-native): separate id of unecrypted storage

### DIFF
--- a/suite-native/storage/src/atomWithUnecryptedStorage.ts
+++ b/suite-native/storage/src/atomWithUnecryptedStorage.ts
@@ -2,10 +2,10 @@ import { MMKV } from 'react-native-mmkv';
 
 import { atomWithStorage, createJSONStorage } from 'jotai/utils';
 
-import { MMKV_STORAGE_ID } from './storage';
+const UNECRYPTED_STORAGE_ID = 'trezorSuite-app-unecrypted-storage';
 
 const unecryptedJotaiStorage = new MMKV({
-    id: MMKV_STORAGE_ID,
+    id: UNECRYPTED_STORAGE_ID,
 });
 function getItem<T>(key: string): T | null {
     const value = unecryptedJotaiStorage.getString(key);

--- a/suite-native/storage/src/storage.ts
+++ b/suite-native/storage/src/storage.ts
@@ -6,8 +6,7 @@ import * as SecureStore from 'expo-secure-store';
 import { Persistor, Storage } from 'redux-persist';
 
 const ENCRYPTION_KEY = 'STORAGE_ENCRYPTION_KEY';
-
-export const MMKV_STORAGE_ID = 'trezorSuite-app-storage';
+const ENCRYPTED_STORAGE_ID = 'trezorSuite-app-storage';
 
 export const purgeStorage = async (persistor: Persistor) => {
     await persistor.purge();
@@ -30,7 +29,7 @@ export const initMmkvStorage = async (): Promise<Storage> => {
     const encryptionKey = await retrieveStorageEncryptionKey();
 
     const encryptedStorage = new MMKV({
-        id: MMKV_STORAGE_ID,
+        id: ENCRYPTED_STORAGE_ID,
         encryptionKey,
     });
 


### PR DESCRIPTION
Resolve an issue with reset redux persistent storage after an update.