### PR TITLE
Prevent coinjoin session from automaticcally restoring on Suite start

### DIFF
--- a/packages/suite/src/utils/suite/storage.ts
+++ b/packages/suite/src/utils/suite/storage.ts
@@ -1,6 +1,7 @@
 import { AcquiredDevice } from '@suite-types';
 import { Discovery } from '@wallet-reducers/discoveryReducer';
 import { connectInitThunk } from '@suite-common/connect-init';
+import { CoinjoinAccount } from '@wallet-types/coinjoin';
 
 /**
  * Strip unserializable fields from Discovery (eg. promises)
@@ -23,6 +24,20 @@ export const serializeDevice = (device: AcquiredDevice, forceRemember?: true) =>
     };
     if (forceRemember) sd.forceRemember = true;
     return sd;
+};
+
+/**
+ * Serialize coinjoin session so that it is always saved as paused to prevent it from automatically restoring when Suite starts.
+ */
+export const serializeCoinjoinSession = (coinjoinAccount: CoinjoinAccount) => {
+    if (coinjoinAccount.session) {
+        const { interrupted, starting, ...pausedSession } = {
+            ...coinjoinAccount.session,
+            paused: true,
+        };
+        return { ...coinjoinAccount, session: pausedSession };
+    }
+    return coinjoinAccount;
 };
 
 /**


### PR DESCRIPTION
## Description

Always save a session as `paused`.

## Related Issue

Resolve #7693
