### PR TITLE
Strip temporary session properties when it is saved

### DIFF
--- a/packages/suite/src/utils/suite/storage.ts
+++ b/packages/suite/src/utils/suite/storage.ts
@@ -31,9 +31,10 @@ export const serializeDevice = (device: AcquiredDevice, forceRemember?: true) =>
  */
 export const serializeCoinjoinSession = (coinjoinAccount: CoinjoinAccount) => {
     if (coinjoinAccount.session) {
-        const { interrupted, starting, ...pausedSession } = {
+        const { interrupted, roundPhase, sessionDeadline, starting, ...pausedSession } = {
             ...coinjoinAccount.session,
             paused: true,
+            sessionPhaseQueue: [],
         };
         return { ...coinjoinAccount, session: pausedSession };
     }


### PR DESCRIPTION
## Description

Follow-up to #7750. I realised more properties should be stripped to get closer to the state after `pauseSession` action has been called. Only `session.timeEnded` cannot be set here, but it is not used anyway. This fixes the bug in screenshot (there should not be a time estimate for a paused session).

## Related Issue
https://github.com/trezor/trezor-suite/issues/7693

## Screenshots:
![Screenshot 2023-03-02 at 12 17 36](https://user-images.githubusercontent.com/42465546/222414722-4f7e188e-908a-43b9-b41a-2d8187cc32e8.png)
