### PR TITLE
fix(suite-native): info plist mic update

### DIFF
--- a/suite-native/app/ios/TrezorSuite/Info.plist
+++ b/suite-native/app/ios/TrezorSuite/Info.plist
@@ -70,5 +70,7 @@
 	</array>
 	<key>UIViewControllerBasedStatusBarAppearance</key>
 	<false/>
+	<key>NSMicrophoneUsageDescription</key>
+    <string>This app does not require access to the microphone.</string>
 </dict>
 </plist>


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Expo AV needs microphone access as shown here https://docs.expo.dev/versions/latest/sdk/audio/#recording-sounds

Without proper comment in `Info.plist`, the app cannot be released. This should solve it.

Fixed according to: https://github.com/expo/expo/issues/11532

## Related Issue

Resolve <!--- link the issue here -->

## Screenshots:
