### PR TITLE
fix(coinjoin): Status exceptions and request timeout

### DIFF
--- a/packages/coinjoin/src/client/CoinjoinClient.ts
+++ b/packages/coinjoin/src/client/CoinjoinClient.ts
@@ -57,7 +57,7 @@ export class CoinjoinClient extends EventEmitter {
                 this.emit('status', event);
             }
         });
-        this.status.on('exception', event => this.emit('exception', event));
+        this.status.on('log', ({ level, payload }) => this.logger[level](payload));
         this.status.on('affiliate-server', event => this.onAffiliateServerStatus(event));
 
         this.prison = new CoinjoinPrison();

--- a/packages/coinjoin/src/types/client.ts
+++ b/packages/coinjoin/src/types/client.ts
@@ -15,7 +15,6 @@ export interface CoinjoinClientEvents {
     status: CoinjoinStatusEvent;
     round: CoinjoinRoundEvent;
     request: CoinjoinRequestEvent[];
-    exception: string;
     log: LogEvent;
     'session-phase': {
         phase: SessionPhase;

--- a/packages/coinjoin/src/utils/roundUtils.ts
+++ b/packages/coinjoin/src/utils/roundUtils.ts
@@ -135,10 +135,11 @@ export const estimatePhaseDeadline = (round: Round) => {
 
 export const findNearestDeadline = (rounds: Round[]) => {
     const now = Date.now();
-    const deadlines = rounds
-        .map(r => estimatePhaseDeadline(r))
-        .filter(r => r) // skip 0/undefined
-        .map(r => new Date(r).getTime() - now);
+    const deadlines = rounds.map(r => {
+        const phaseDeadline = estimatePhaseDeadline(r);
+        const timeLeft = phaseDeadline ? new Date(phaseDeadline).getTime() - now : 0;
+        return timeLeft > 0 ? timeLeft : now;
+    });
 
     return Math.min(...deadlines);
 };


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

should fix or at least narrow down the issue from sentry: "No registered outputs for round"

## What is happening?

I believe we have some runtime error near `transformStatus/getDataFromRounds` and when it happens `status` in not updated (does not emit "update" event)
Status processing was wrapped in try catch but message was not propagated to log, therefore we don't know exactly what is causing the error

## Changes

- `Status` emits `log` events which are propagated to suite log
- `Status` emits `error` if `transformStatus` fails in runtime (errors are logged to sentry)
- `Status.rounds` are reassigned **only** after successful update
- fixed `findNearestDeadline` fn, should help with delay and "almost there" screen before critical phase
