### PR TITLE
feat(connect-cardano): allow external reward addresses in governance registrations

### DIFF
--- a/docs/packages/connect/methods/cardanoSignTransaction.md
+++ b/docs/packages/connect/methods/cardanoSignTransaction.md
@@ -321,7 +321,7 @@ TrezorConnect.cardanoSignTransaction({
             format: CardanoCVoteRegistrationFormat.CIP36,
             delegations: [
                 {
-                    votingPublicKey:
+                    votePublicKey:
                         '1af8fa0b754ff99253d983894e63a2b09cbb56c833ba18c3384210163f63dcfc',
                     weight: 1,
                 },

--- a/docs/packages/connect/methods/cardanoSignTransaction.md
+++ b/docs/packages/connect/methods/cardanoSignTransaction.md
@@ -112,7 +112,7 @@ Trezor supports signing transactions with auxiliary data containing a vote key r
 
 Trezor does not support the 1694 derivation paths at the moment.
 
-The reward address can be provided either as a `rewardAddress` string or as a `rewardAddressParameters` object. For the smoothest user experience, we recommend providing `rewardAddressParameters` of a BASE address owned by the device.
+The payment address to receive rewards can be provided either as a `paymentAddress` string or as a `paymentAddressParameters` object. For the smoothest user experience, we recommend providing `paymentAddressParameters` of a BASE address owned by the device.
 
 ### Transaction examples
 
@@ -312,7 +312,7 @@ TrezorConnect.cardanoSignTransaction({
     auxiliaryData: {
         cVoteRegistrationParameters: {
             stakingPath: "m/1852'/1815'/0'/2/0",
-            rewardAddressParameters: {
+            paymentAddressParameters: {
                 addressType: CardanoAddressType.BASE,
                 path: "m/1852'/1815'/0'/0/0",
                 stakingPath: "m/1852'/1815'/0'/2/0",

--- a/docs/packages/connect/methods/cardanoSignTransaction.md
+++ b/docs/packages/connect/methods/cardanoSignTransaction.md
@@ -103,11 +103,11 @@ Trezor supports signing of stake pool registration certificates as a pool owner.
 1. The transaction inputs must all be external, i.e. path must be either undefined or null
 1. Exactly one owner should be passed as a staking path and the rest of owners should be passed as bech32-encoded reward addresses
 
-### Governance registration (Catalyst and other)
+### CIP-36 vote key registration (Catalyst and other)
 
-Trezor supports signing transactions with auxiliary data containing a governance registration. Governance registrations used to follow [CIP-15](https://cips.cardano.org/cips/cip15/), which has been superseded by [CIP-36](https://cips.cardano.org/cips/cip36/). Currently, Trezor supports both CIP-15 and CIP-36 formats, the intended standard can be specified in the `format` field (with CIP-15 being the default). They differ in the following:
+Trezor supports signing transactions with auxiliary data containing a vote key registration. Vote key registrations used to follow [CIP-15](https://cips.cardano.org/cips/cip15/), which has been superseded by [CIP-36](https://cips.cardano.org/cips/cip36/). Currently, Trezor supports both CIP-15 and CIP-36 formats, the intended standard can be specified in the `format` field (with CIP-15 being the default). They differ in the following:
 
--   CIP-36 allows delegating the voting power to several voting public keys with different voting power ([CardanoGovernanceRegistrationDelegation](https://github.com/trezor/trezor-suite/blob/develop/packages/connect/src/types/api/cardano/index.ts)) as an alternative to providing only a single voting public key. Note that Trezor Firmware supports at most 32 delegations in a single governance registration.
+-   CIP-36 allows delegating the voting power to several vote public keys with different voting power ([CardanoCVoteRegistrationDelegation](https://github.com/trezor/trezor-suite/blob/develop/packages/connect/src/types/api/cardano/index.ts)) as an alternative to providing only a single vote public key. Note that Trezor Firmware supports at most 32 delegations in a single registration.
 -   CIP-36 registrations contain the [votingPurpose](https://github.com/trezor/trezor-suite/blob/develop/packages/connect/src/types/api/cardano/index.ts) field. The value 0 is intended for Catalyst voting and the value 1 is intended for other purposes. If no value is provided, Trezor serializes 0 by default (if the CIP-36 format is used).
 
 Trezor does not support the 1694 derivation paths at the moment.
@@ -288,7 +288,7 @@ TrezorConnect.cardanoSignTransaction({
 });
 ```
 
-#### Governance voting key registration
+#### CIP-36 vote key registration
 
 ```javascript
 TrezorConnect.cardanoSignTransaction({
@@ -310,7 +310,7 @@ TrezorConnect.cardanoSignTransaction({
     fee: '42',
     ttl: '10',
     auxiliaryData: {
-        governanceRegistrationParameters: {
+        cVoteRegistrationParameters: {
             stakingPath: "m/1852'/1815'/0'/2/0",
             rewardAddressParameters: {
                 addressType: CardanoAddressType.BASE,
@@ -318,7 +318,7 @@ TrezorConnect.cardanoSignTransaction({
                 stakingPath: "m/1852'/1815'/0'/2/0",
             },
             nonce: '22634813',
-            format: CardanoGovernanceRegistrationFormat.CIP36,
+            format: CardanoCVoteRegistrationFormat.CIP36,
             delegations: [
                 {
                     votingPublicKey:
@@ -589,7 +589,7 @@ Example:
             type: 1,
             auxiliaryDataHash:
                 'a943e9166f1bb6d767b175384d3bd7d23645170df36fc1861fbf344135d8e120',
-            governanceSignature:
+            cVoteRegistrationSignature:
                 '74f27d877bbb4a5fc4f7c56869905c11f70bad0af3de24b23afaa1d024e750930f434ecc4b73e5d1723c2cb8548e8bf6098ac876487b3a6ed0891cb76994d409',
         },
     }

--- a/docs/packages/connect/methods/cardanoSignTransaction.md
+++ b/docs/packages/connect/methods/cardanoSignTransaction.md
@@ -112,6 +112,8 @@ Trezor supports signing transactions with auxiliary data containing a governance
 
 Trezor does not support the 1694 derivation paths at the moment.
 
+The reward address can be provided either as a `rewardAddress` string or as a `rewardAddressParameters` object. For the smoothest user experience, we recommend providing `rewardAddressParameters` of a BASE address owned by the device.
+
 ### Transaction examples
 
 #### Ordinary transaction
@@ -309,13 +311,21 @@ TrezorConnect.cardanoSignTransaction({
     ttl: '10',
     auxiliaryData: {
         governanceRegistrationParameters: {
-            votingPublicKey: '1af8fa0b754ff99253d983894e63a2b09cbb56c833ba18c3384210163f63dcfc',
             stakingPath: "m/1852'/1815'/0'/2/0",
             rewardAddressParameters: {
-                addressType: CardanoAddressType.REWARD,
+                addressType: CardanoAddressType.BASE,
+                path: "m/1852'/1815'/0'/0/0",
                 stakingPath: "m/1852'/1815'/0'/2/0",
             },
             nonce: '22634813',
+            format: CardanoGovernanceRegistrationFormat.CIP36,
+            delegations: [
+                {
+                    votingPublicKey:
+                        '1af8fa0b754ff99253d983894e63a2b09cbb56c833ba18c3384210163f63dcfc',
+                    weight: 1,
+                },
+            ],
         },
     },
     protocolMagic: 764824073,

--- a/packages/connect/e2e/__fixtures__/cardanoSignTransaction.ts
+++ b/packages/connect/e2e/__fixtures__/cardanoSignTransaction.ts
@@ -421,8 +421,8 @@ const legacyResults = {
         rules: ['<2.5.3', '1'],
         payload: false,
     },
-    beforeCIP36RegistrationExternalRewardAddress: {
-        // older FW doesn't support reward address given as a string in vote key registrations
+    beforeCIP36RegistrationExternalPaymentAddress: {
+        // older FW doesn't support payment address given as a string in vote key registrations
         rules: ['<2.5.4', '1'],
         payload: false,
     },
@@ -851,7 +851,7 @@ export default {
                         votingPublicKey:
                             '1af8fa0b754ff99253d983894e63a2b09cbb56c833ba18c3384210163f63dcfc',
                         stakingPath: "m/1852'/1815'/0'/2/0",
-                        rewardAddressParameters: {
+                        paymentAddressParameters: {
                             addressType: CardanoAddressType.REWARD,
                             path: "m/1852'/1815'/0'/2/0",
                         },
@@ -896,7 +896,7 @@ export default {
                         votingPublicKey:
                             '1af8fa0b754ff99253d983894e63a2b09cbb56c833ba18c3384210163f63dcfc',
                         stakingPath: "m/1852'/1815'/0'/2/0",
-                        rewardAddressParameters: {
+                        paymentAddressParameters: {
                             addressType: CardanoAddressType.REWARD,
                             stakingPath: "m/1852'/1815'/0'/2/0",
                         },
@@ -939,7 +939,7 @@ export default {
                 auxiliaryData: {
                     cVoteRegistrationParameters: {
                         stakingPath: "m/1852'/1815'/0'/2/0",
-                        rewardAddressParameters: {
+                        paymentAddressParameters: {
                             addressType: CardanoAddressType.BASE,
                             path: "m/1852'/1815'/0'/0/0",
                             stakingPath: "m/1852'/1815'/0'/2/0",
@@ -996,7 +996,7 @@ export default {
                 auxiliaryData: {
                     cVoteRegistrationParameters: {
                         stakingPath: "m/1852'/1815'/0'/2/0",
-                        rewardAddressParameters: {
+                        paymentAddressParameters: {
                             addressType: CardanoAddressType.BASE,
                             path: "m/1852'/1815'/0'/0/0",
                             stakingPath: "m/1852'/1815'/0'/2/0",
@@ -1040,7 +1040,7 @@ export default {
         },
 
         {
-            description: 'signTransactionWithCIP36RegistrationAndExternalRewardAddress',
+            description: 'signTransactionWithCIP36RegistrationAndExternalPaymentAddress',
             params: {
                 inputs: [SAMPLE_INPUTS.shelley_input],
                 outputs: [SAMPLE_OUTPUTS.simple_shelley_output],
@@ -1058,7 +1058,7 @@ export default {
                                 weight: 1,
                             },
                         ],
-                        rewardAddress:
+                        paymentAddress:
                             'addr1q84sh2j72ux0l03fxndjnhctdg7hcppsaejafsa84vh7lwgmcs5wgus8qt4atk45lvt4xfxpjtwfhdmvchdf2m3u3hlsd5tq5r',
                     },
                 },
@@ -1085,7 +1085,7 @@ export default {
                         'ba05ac525e5dcc74e5a6cdbb7fb111d8e21163d79fe76777a5b730fe93512f09415f6f7b4904b12c6f12fe33b6c553d9889beb024299fa1256a0d3e98c8ff203',
                 },
             },
-            legacyResults: [legacyResults.beforeCIP36RegistrationExternalRewardAddress],
+            legacyResults: [legacyResults.beforeCIP36RegistrationExternalPaymentAddress],
         },
 
         {
@@ -1774,7 +1774,7 @@ export default {
                 auxiliaryData: {
                     cVoteRegistrationParameters: {
                         stakingPath: "m/1852'/1815'/0'/2/0",
-                        rewardAddressParameters: {
+                        paymentAddressParameters: {
                             addressType: CardanoAddressType.BASE,
                             path: "m/1852'/1815'/0'/0/0",
                             stakingPath: "m/1852'/1815'/0'/2/0",

--- a/packages/connect/e2e/__fixtures__/cardanoSignTransaction.ts
+++ b/packages/connect/e2e/__fixtures__/cardanoSignTransaction.ts
@@ -848,7 +848,7 @@ export default {
                 ttl: TTL,
                 auxiliaryData: {
                     cVoteRegistrationParameters: {
-                        votingPublicKey:
+                        votePublicKey:
                             '1af8fa0b754ff99253d983894e63a2b09cbb56c833ba18c3384210163f63dcfc',
                         stakingPath: "m/1852'/1815'/0'/2/0",
                         paymentAddressParameters: {
@@ -893,7 +893,7 @@ export default {
                 ttl: TTL,
                 auxiliaryData: {
                     cVoteRegistrationParameters: {
-                        votingPublicKey:
+                        votePublicKey:
                             '1af8fa0b754ff99253d983894e63a2b09cbb56c833ba18c3384210163f63dcfc',
                         stakingPath: "m/1852'/1815'/0'/2/0",
                         paymentAddressParameters: {
@@ -948,12 +948,12 @@ export default {
                         format: CardanoCVoteRegistrationFormat.CIP36,
                         delegations: [
                             {
-                                votingPublicKey:
+                                votePublicKey:
                                     '1af8fa0b754ff99253d983894e63a2b09cbb56c833ba18c3384210163f63dcfc',
                                 weight: 1,
                             },
                             {
-                                votingPublicKey:
+                                votePublicKey:
                                     '2af8fa0b754ff99253d983894e63a2b09cbb56c833ba18c3384210163f63dcfc',
                                 weight: 2,
                             },
@@ -1005,7 +1005,7 @@ export default {
                         format: CardanoCVoteRegistrationFormat.CIP36,
                         delegations: [
                             {
-                                votingPublicKey:
+                                votePublicKey:
                                     '1af8fa0b754ff99253d983894e63a2b09cbb56c833ba18c3384210163f63dcfc',
                                 weight: 1,
                             },
@@ -1053,7 +1053,7 @@ export default {
                         format: CardanoCVoteRegistrationFormat.CIP36,
                         delegations: [
                             {
-                                votingPublicKey:
+                                votePublicKey:
                                     '1af8fa0b754ff99253d983894e63a2b09cbb56c833ba18c3384210163f63dcfc',
                                 weight: 1,
                             },
@@ -1783,7 +1783,7 @@ export default {
                         format: CardanoCVoteRegistrationFormat.CIP36,
                         delegations: [
                             {
-                                votingPublicKey:
+                                votePublicKey:
                                     '1af8fa0b754ff99253d983894e63a2b09cbb56c833ba18c3384210163f63dcfc',
                                 weight: 1,
                             },

--- a/packages/connect/e2e/__fixtures__/cardanoSignTransaction.ts
+++ b/packages/connect/e2e/__fixtures__/cardanoSignTransaction.ts
@@ -421,6 +421,11 @@ const legacyResults = {
         rules: ['<2.5.3', '1'],
         payload: false,
     },
+    GovernanceRegistrationExternalRewardAddress: {
+        // older FW doesn't support reward address given as a string in governance registrations
+        rules: ['<2.5.4', '1'],
+        payload: false,
+    },
 };
 
 export default {
@@ -1033,6 +1038,55 @@ export default {
                 },
             },
             legacyResults: [legacyResults.beforeGovernanceRegistrationCIP36],
+        },
+
+        {
+            description: 'signTransactionWithCIP36GovernanceRegistrationAndExternalRewardAddress',
+            params: {
+                inputs: [SAMPLE_INPUTS.shelley_input],
+                outputs: [SAMPLE_OUTPUTS.simple_shelley_output],
+                fee: FEE,
+                ttl: TTL,
+                auxiliaryData: {
+                    governanceRegistrationParameters: {
+                        stakingPath: "m/1852'/1815'/0'/2/0",
+                        nonce: '22634813',
+                        format: CardanoGovernanceRegistrationFormat.CIP36,
+                        delegations: [
+                            {
+                                votingPublicKey:
+                                    '1af8fa0b754ff99253d983894e63a2b09cbb56c833ba18c3384210163f63dcfc',
+                                weight: 1,
+                            },
+                        ],
+                        rewardAddress:
+                            'addr1q84sh2j72ux0l03fxndjnhctdg7hcppsaejafsa84vh7lwgmcs5wgus8qt4atk45lvt4xfxpjtwfhdmvchdf2m3u3hlsd5tq5r',
+                    },
+                },
+                protocolMagic: PROTOCOL_MAGICS.mainnet,
+                networkId: NETWORK_IDS.mainnet,
+                signingMode: CardanoTxSigningMode.ORDINARY_TRANSACTION,
+            },
+            result: {
+                hash: 'a5c5506777fb62aa98e6c45f1c85ab9ddf706a1f199e777c43f2288a6b4fdcab',
+                witnesses: [
+                    {
+                        type: 1,
+                        pubKey: '5d010cf16fdeff40955633d6c565f3844a288a24967cf6b76acbeb271b4f13c1',
+                        signature:
+                            '98e68184bc090fe95c461bd8d26b462861d382dbfce051bc9cb04a7d51c2ba293960e19ac9099c6d10912c89a3102fcd958c31e87eb9e142136b6411ab55f107',
+                        chainCode: null,
+                    },
+                ],
+                auxiliaryDataSupplement: {
+                    type: 1,
+                    auxiliaryDataHash:
+                        '3830a90f2c5dc23ddd478cefcb8642f0b36afa77769239146d9cba83ed196e41',
+                    governanceSignature:
+                        'ba05ac525e5dcc74e5a6cdbb7fb111d8e21163d79fe76777a5b730fe93512f09415f6f7b4904b12c6f12fe33b6c553d9889beb024299fa1256a0d3e98c8ff203',
+                },
+            },
+            legacyResults: [legacyResults.GovernanceRegistrationExternalRewardAddress],
         },
 
         {

--- a/packages/connect/e2e/__fixtures__/cardanoSignTransaction.ts
+++ b/packages/connect/e2e/__fixtures__/cardanoSignTransaction.ts
@@ -1,7 +1,7 @@
 import { NETWORK_IDS, PROTOCOL_MAGICS } from '@trezor/connect/lib/constants/cardano';
 import {
     CardanoAddressType,
-    CardanoGovernanceRegistrationFormat,
+    CardanoCVoteRegistrationFormat,
     CardanoCertificateType,
     CardanoTxOutputSerializationFormat,
     CardanoTxSigningMode,
@@ -416,13 +416,13 @@ const legacyResults = {
         rules: ['<2.5.2', '1'],
         payload: false,
     },
-    beforeGovernanceRegistrationCIP36: {
-        // older FW doesn't support CIP36 governance registration format
+    beforeCIP36Registration: {
+        // older FW doesn't support CIP36 registration format
         rules: ['<2.5.3', '1'],
         payload: false,
     },
-    GovernanceRegistrationExternalRewardAddress: {
-        // older FW doesn't support reward address given as a string in governance registrations
+    beforeCIP36RegistrationExternalRewardAddress: {
+        // older FW doesn't support reward address given as a string in vote key registrations
         rules: ['<2.5.4', '1'],
         payload: false,
     },
@@ -840,14 +840,14 @@ export default {
         },
 
         {
-            description: 'signGovernanceVotingRegistrationWithPath',
+            description: 'signCVoteRegistrationWithPath',
             params: {
                 inputs: [SAMPLE_INPUTS.shelley_input],
                 outputs: [SAMPLE_OUTPUTS.simple_shelley_output],
                 fee: FEE,
                 ttl: TTL,
                 auxiliaryData: {
-                    governanceRegistrationParameters: {
+                    cVoteRegistrationParameters: {
                         votingPublicKey:
                             '1af8fa0b754ff99253d983894e63a2b09cbb56c833ba18c3384210163f63dcfc',
                         stakingPath: "m/1852'/1815'/0'/2/0",
@@ -877,7 +877,7 @@ export default {
                     type: 1,
                     auxiliaryDataHash:
                         'b712ad07750007ba68d7558abeeab103b36a09133062ba9fa6611953085d9137',
-                    governanceSignature:
+                    cVoteRegistrationSignature:
                         'ed3335aead65c665ceee21f2549c0ef4c9137b94c13fa642bea4a2c24e44e7f1ee06b47e14151efcf8d5569a404260c01f277b3ba516b5826a15c8ba2c97f70c',
                 },
             },
@@ -885,14 +885,14 @@ export default {
         },
 
         {
-            description: 'signGovernanceVotingRegistrationWithStakingPath',
+            description: 'signCVoteRegistrationWithStakingPath',
             params: {
                 inputs: [SAMPLE_INPUTS.shelley_input],
                 outputs: [SAMPLE_OUTPUTS.simple_shelley_output],
                 fee: FEE,
                 ttl: TTL,
                 auxiliaryData: {
-                    governanceRegistrationParameters: {
+                    cVoteRegistrationParameters: {
                         votingPublicKey:
                             '1af8fa0b754ff99253d983894e63a2b09cbb56c833ba18c3384210163f63dcfc',
                         stakingPath: "m/1852'/1815'/0'/2/0",
@@ -922,7 +922,7 @@ export default {
                     type: 1,
                     auxiliaryDataHash:
                         'b712ad07750007ba68d7558abeeab103b36a09133062ba9fa6611953085d9137',
-                    governanceSignature:
+                    cVoteRegistrationSignature:
                         'ed3335aead65c665ceee21f2549c0ef4c9137b94c13fa642bea4a2c24e44e7f1ee06b47e14151efcf8d5569a404260c01f277b3ba516b5826a15c8ba2c97f70c',
                 },
             },
@@ -930,15 +930,14 @@ export default {
         },
 
         {
-            description:
-                'signTransactionWithCIP36GovernanceRegistrationAndVotingPurposeNotSpecified',
+            description: 'signTransactionWithCIP36RegistrationAndVotingPurposeNotSpecified',
             params: {
                 inputs: [SAMPLE_INPUTS.shelley_input],
                 outputs: [SAMPLE_OUTPUTS.simple_shelley_output],
                 fee: FEE,
                 ttl: TTL,
                 auxiliaryData: {
-                    governanceRegistrationParameters: {
+                    cVoteRegistrationParameters: {
                         stakingPath: "m/1852'/1815'/0'/2/0",
                         rewardAddressParameters: {
                             addressType: CardanoAddressType.BASE,
@@ -946,7 +945,7 @@ export default {
                             stakingPath: "m/1852'/1815'/0'/2/0",
                         },
                         nonce: '22634813',
-                        format: CardanoGovernanceRegistrationFormat.CIP36,
+                        format: CardanoCVoteRegistrationFormat.CIP36,
                         delegations: [
                             {
                                 votingPublicKey:
@@ -980,22 +979,22 @@ export default {
                     type: 1,
                     auxiliaryDataHash:
                         '9d4c00f5b5b67760931fd7ed9850ff8e14dcdf957685191ab4bc755c52f0ed56',
-                    governanceSignature:
+                    cVoteRegistrationSignature:
                         '2671b8e668ffce235647ac89deda6cc222e7b31a3d44606c2723fcf711b29f9af1e30b0c6b4f87ba37ddf9f6adf0226c39c09e655255890644a3dc4e64c3a001',
                 },
             },
-            legacyResults: [legacyResults.beforeGovernanceRegistrationCIP36],
+            legacyResults: [legacyResults.beforeCIP36Registration],
         },
 
         {
-            description: 'signTransactionWithCIP36GovernanceRegistrationAndOtherVotingPurpose',
+            description: 'signTransactionWithCIP36RegistrationAndOtherVotingPurpose',
             params: {
                 inputs: [SAMPLE_INPUTS.shelley_input],
                 outputs: [SAMPLE_OUTPUTS.simple_shelley_output],
                 fee: FEE,
                 ttl: TTL,
                 auxiliaryData: {
-                    governanceRegistrationParameters: {
+                    cVoteRegistrationParameters: {
                         stakingPath: "m/1852'/1815'/0'/2/0",
                         rewardAddressParameters: {
                             addressType: CardanoAddressType.BASE,
@@ -1003,7 +1002,7 @@ export default {
                             stakingPath: "m/1852'/1815'/0'/2/0",
                         },
                         nonce: '22634813',
-                        format: CardanoGovernanceRegistrationFormat.CIP36,
+                        format: CardanoCVoteRegistrationFormat.CIP36,
                         delegations: [
                             {
                                 votingPublicKey:
@@ -1033,25 +1032,25 @@ export default {
                     type: 1,
                     auxiliaryDataHash:
                         '28b7ffa6800833bdfe5421739eaa21d4a49cde1d84e762b147001169f7c0a385',
-                    governanceSignature:
+                    cVoteRegistrationSignature:
                         'ebc00c615f988c6fc2e132d4419a719f04bbec56fe2569a00746a9e9b0d6e5bdd0809515cb2522c773c991c5ae39834403654d36b37e70b14897c0e98c8c0a0c',
                 },
             },
-            legacyResults: [legacyResults.beforeGovernanceRegistrationCIP36],
+            legacyResults: [legacyResults.beforeCIP36Registration],
         },
 
         {
-            description: 'signTransactionWithCIP36GovernanceRegistrationAndExternalRewardAddress',
+            description: 'signTransactionWithCIP36RegistrationAndExternalRewardAddress',
             params: {
                 inputs: [SAMPLE_INPUTS.shelley_input],
                 outputs: [SAMPLE_OUTPUTS.simple_shelley_output],
                 fee: FEE,
                 ttl: TTL,
                 auxiliaryData: {
-                    governanceRegistrationParameters: {
+                    cVoteRegistrationParameters: {
                         stakingPath: "m/1852'/1815'/0'/2/0",
                         nonce: '22634813',
-                        format: CardanoGovernanceRegistrationFormat.CIP36,
+                        format: CardanoCVoteRegistrationFormat.CIP36,
                         delegations: [
                             {
                                 votingPublicKey:
@@ -1082,11 +1081,11 @@ export default {
                     type: 1,
                     auxiliaryDataHash:
                         '3830a90f2c5dc23ddd478cefcb8642f0b36afa77769239146d9cba83ed196e41',
-                    governanceSignature:
+                    cVoteRegistrationSignature:
                         'ba05ac525e5dcc74e5a6cdbb7fb111d8e21163d79fe76777a5b730fe93512f09415f6f7b4904b12c6f12fe33b6c553d9889beb024299fa1256a0d3e98c8ff203',
                 },
             },
-            legacyResults: [legacyResults.GovernanceRegistrationExternalRewardAddress],
+            legacyResults: [legacyResults.beforeCIP36RegistrationExternalRewardAddress],
         },
 
         {
@@ -1773,7 +1772,7 @@ export default {
                 ],
                 withdrawals: [SAMPLE_WITHDRAWALS.basic],
                 auxiliaryData: {
-                    governanceRegistrationParameters: {
+                    cVoteRegistrationParameters: {
                         stakingPath: "m/1852'/1815'/0'/2/0",
                         rewardAddressParameters: {
                             addressType: CardanoAddressType.BASE,
@@ -1781,7 +1780,7 @@ export default {
                             stakingPath: "m/1852'/1815'/0'/2/0",
                         },
                         nonce: '22634813',
-                        format: CardanoGovernanceRegistrationFormat.CIP36,
+                        format: CardanoCVoteRegistrationFormat.CIP36,
                         delegations: [
                             {
                                 votingPublicKey:
@@ -1832,11 +1831,11 @@ export default {
                     type: 1,
                     auxiliaryDataHash:
                         '544c9ae849c82e31224865ff936decc6160047409eee4a6b4178b729fe3d286c',
-                    governanceSignature:
+                    cVoteRegistrationSignature:
                         '3064949c9f186138f95e228075d0119dd5cb50e1b7e75d24d569fa547e018a597615da7c79a39ca8e394ee1ba8acb83e70be80f37e69aef3b86e7c4a6bd44903',
                 },
             },
-            legacyResults: [legacyResults.beforeGovernanceRegistrationCIP36],
+            legacyResults: [legacyResults.beforeCIP36Registration],
         },
 
         {

--- a/packages/connect/src/api/cardano/cardanoAuxiliaryData.ts
+++ b/packages/connect/src/api/cardano/cardanoAuxiliaryData.ts
@@ -20,13 +20,20 @@ const MAX_DELEGATION_COUNT = 32;
 const transformDelegation = (
     delegation: CardanoCVoteRegistrationDelegation,
 ): PROTO.CardanoCVoteRegistrationDelegation => {
+    // @ts-expect-error votingPublicKey is a legacy param kept for backward compatibility (for now)
+    if (delegation.votingPublicKey) {
+        console.warn('Please use votePublicKey instead of votingPublicKey.');
+        // @ts-expect-error
+        delegation.votePublicKey = delegation.votingPublicKey;
+    }
+
     validateParams(delegation, [
-        { name: 'votingPublicKey', type: 'string', required: true },
+        { name: 'votePublicKey', type: 'string', required: true },
         { name: 'weight', type: 'uint', required: true },
     ]);
 
     return {
-        voting_public_key: delegation.votingPublicKey,
+        vote_public_key: delegation.votePublicKey,
         weight: delegation.weight,
     };
 };
@@ -34,7 +41,15 @@ const transformDelegation = (
 const transformCvoteRegistrationParameters = (
     cVoteRegistrationParameters: CardanoCVoteRegistrationParameters,
 ): PROTO.CardanoCVoteRegistrationParametersType => {
-    // @ts-expect-error rewardAddressParameters is a legacy param kept for backward compatibility (for now)
+    // votingPublicKey and rewardAddressParameters
+    // are legacy params kept for backward compatibility (for now)
+    // @ts-expect-error
+    if (cVoteRegistrationParameters.votingPublicKey) {
+        console.warn('Please use votePublicKey instead of votingPublicKey.');
+        // @ts-expect-error
+        cVoteRegistrationParameters.votePublicKey = cVoteRegistrationParameters.votingPublicKey;
+    }
+    // @ts-expect-error
     if (cVoteRegistrationParameters.rewardAddressParameters) {
         console.warn('Please use paymentAddressParameters instead of rewardAddressParameters.');
         cVoteRegistrationParameters.paymentAddressParameters =
@@ -43,7 +58,7 @@ const transformCvoteRegistrationParameters = (
     }
 
     validateParams(cVoteRegistrationParameters, [
-        { name: 'votingPublicKey', type: 'string' },
+        { name: 'votePublicKey', type: 'string' },
         { name: 'stakingPath', required: true },
         { name: 'nonce', type: 'uint', required: true },
         { name: 'format', type: 'number' },
@@ -65,7 +80,7 @@ const transformCvoteRegistrationParameters = (
     }
 
     return {
-        voting_public_key: cVoteRegistrationParameters.votingPublicKey,
+        vote_public_key: cVoteRegistrationParameters.votePublicKey,
         staking_path: validatePath(cVoteRegistrationParameters.stakingPath, 3),
         payment_address_parameters: paymentAddressParameters
             ? addressParametersToProto(paymentAddressParameters)

--- a/packages/connect/src/api/cardano/cardanoAuxiliaryData.ts
+++ b/packages/connect/src/api/cardano/cardanoAuxiliaryData.ts
@@ -41,8 +41,12 @@ const transformGovernanceRegistrationParameters = (
         { name: 'format', type: 'number' },
         { name: 'delegations', type: 'array', allowEmpty: true },
         { name: 'votingPurpose', type: 'uint' },
+        { name: 'address', type: 'string' },
     ]);
-    validateAddressParameters(governanceRegistrationParameters.rewardAddressParameters);
+    const { rewardAddressParameters } = governanceRegistrationParameters;
+    if (rewardAddressParameters) {
+        validateAddressParameters(rewardAddressParameters);
+    }
 
     const { delegations } = governanceRegistrationParameters;
     if (delegations && delegations.length > MAX_DELEGATION_COUNT) {
@@ -55,13 +59,14 @@ const transformGovernanceRegistrationParameters = (
     return {
         voting_public_key: governanceRegistrationParameters.votingPublicKey,
         staking_path: validatePath(governanceRegistrationParameters.stakingPath, 3),
-        reward_address_parameters: addressParametersToProto(
-            governanceRegistrationParameters.rewardAddressParameters,
-        ),
+        reward_address_parameters: rewardAddressParameters
+            ? addressParametersToProto(rewardAddressParameters)
+            : undefined,
         nonce: governanceRegistrationParameters.nonce,
         format: governanceRegistrationParameters.format,
         delegations: delegations?.map(transformDelegation),
         voting_purpose: governanceRegistrationParameters.votingPurpose,
+        reward_address: governanceRegistrationParameters.rewardAddress,
     };
 };
 
@@ -93,7 +98,7 @@ export const modifyAuxiliaryDataForBackwardsCompatibility = (
     auxiliary_data: PROTO.CardanoTxAuxiliaryData,
 ): PROTO.CardanoTxAuxiliaryData => {
     const { governance_registration_parameters } = auxiliary_data;
-    if (governance_registration_parameters) {
+    if (governance_registration_parameters?.reward_address_parameters) {
         governance_registration_parameters.reward_address_parameters =
             modifyAddressParametersForBackwardsCompatibility(
                 device,

--- a/packages/connect/src/api/cardanoSignTransaction.ts
+++ b/packages/connect/src/api/cardanoSignTransaction.ts
@@ -45,6 +45,7 @@ const CardanoSignTransactionFeatures = Object.freeze({
     KeyHashStakeCredential: ['0', '2.4.4'],
     Babbage: ['0', '2.5.2'],
     GovernanceRegistrationCIP36: ['0', '2.5.3'],
+    GovernanceRegistrationExternalRewardAddress: ['0', '2.5.4'],
 });
 
 export type CardanoSignTransactionParams = {
@@ -331,7 +332,7 @@ export default class CardanoSignTransaction extends AbstractMethod<
         }
 
         if (params.auxiliaryData?.governance_registration_parameters) {
-            const { format, delegations, voting_purpose } =
+            const { format, delegations, voting_purpose, reward_address } =
                 params.auxiliaryData.governance_registration_parameters;
             if (
                 format === PROTO.CardanoGovernanceRegistrationFormat.CIP36 ||
@@ -339,6 +340,10 @@ export default class CardanoSignTransaction extends AbstractMethod<
                 voting_purpose != null
             ) {
                 this._ensureFeatureIsSupported('GovernanceRegistrationCIP36');
+            }
+
+            if (reward_address) {
+                this._ensureFeatureIsSupported('GovernanceRegistrationExternalRewardAddress');
             }
         }
     }

--- a/packages/connect/src/api/cardanoSignTransaction.ts
+++ b/packages/connect/src/api/cardanoSignTransaction.ts
@@ -45,7 +45,7 @@ const CardanoSignTransactionFeatures = Object.freeze({
     KeyHashStakeCredential: ['0', '2.4.4'],
     Babbage: ['0', '2.5.2'],
     CIP36Registration: ['0', '2.5.3'],
-    CIP36RegistrationExternalRewardAddress: ['0', '2.5.4'],
+    CIP36RegistrationExternalPaymentAddress: ['0', '2.5.4'],
 });
 
 export type CardanoSignTransactionParams = {
@@ -343,7 +343,7 @@ export default class CardanoSignTransaction extends AbstractMethod<
         }
 
         if (params.auxiliaryData?.cvote_registration_parameters) {
-            const { format, delegations, voting_purpose, reward_address } =
+            const { format, delegations, voting_purpose, payment_address } =
                 params.auxiliaryData.cvote_registration_parameters;
             if (
                 format === PROTO.CardanoCVoteRegistrationFormat.CIP36 ||
@@ -353,8 +353,8 @@ export default class CardanoSignTransaction extends AbstractMethod<
                 this._ensureFeatureIsSupported('CIP36Registration');
             }
 
-            if (reward_address) {
-                this._ensureFeatureIsSupported('CIP36RegistrationExternalRewardAddress');
+            if (payment_address) {
+                this._ensureFeatureIsSupported('CIP36RegistrationExternalPaymentAddress');
             }
         }
     }

--- a/packages/connect/src/types/api/__tests__/cardano.ts
+++ b/packages/connect/src/types/api/__tests__/cardano.ts
@@ -2,7 +2,7 @@ import { TrezorConnect, PROTO } from '../../..';
 
 const {
     CardanoAddressType,
-    CardanoGovernanceRegistrationFormat,
+    CardanoCVoteRegistrationFormat,
     CardanoCertificateType,
     CardanoNativeScriptHashDisplayFormat,
     CardanoNativeScriptType,
@@ -322,7 +322,7 @@ export const cardanoSignTransaction = async (api: TrezorConnect) => {
         ],
         auxiliaryData: {
             hash: 'aaff00..',
-            governanceRegistrationParameters: {
+            cVoteRegistrationParameters: {
                 votingPublicKey: 'aaff00..',
                 stakingPath: 'm/44',
                 rewardAddressParameters: {
@@ -337,7 +337,7 @@ export const cardanoSignTransaction = async (api: TrezorConnect) => {
                     },
                 },
                 nonce: '0',
-                format: CardanoGovernanceRegistrationFormat.CIP36,
+                format: CardanoCVoteRegistrationFormat.CIP36,
                 delegations: [
                     {
                         votingPublicKey: 'aaff00..',
@@ -414,10 +414,10 @@ export const cardanoSignTransaction = async (api: TrezorConnect) => {
         });
         const { auxiliaryDataSupplement } = payload;
         if (auxiliaryDataSupplement) {
-            const { type, auxiliaryDataHash, governanceSignature } = auxiliaryDataSupplement;
+            const { type, auxiliaryDataHash, cVoteRegistrationSignature } = auxiliaryDataSupplement;
             type.toFixed();
             auxiliaryDataHash.toLowerCase();
-            governanceSignature?.toLowerCase();
+            cVoteRegistrationSignature?.toLowerCase();
         }
     }
 };

--- a/packages/connect/src/types/api/__tests__/cardano.ts
+++ b/packages/connect/src/types/api/__tests__/cardano.ts
@@ -323,7 +323,7 @@ export const cardanoSignTransaction = async (api: TrezorConnect) => {
         auxiliaryData: {
             hash: 'aaff00..',
             cVoteRegistrationParameters: {
-                votingPublicKey: 'aaff00..',
+                votePublicKey: 'aaff00..',
                 stakingPath: 'm/44',
                 paymentAddressParameters: {
                     addressType: CardanoAddressType.REWARD,
@@ -340,7 +340,7 @@ export const cardanoSignTransaction = async (api: TrezorConnect) => {
                 format: CardanoCVoteRegistrationFormat.CIP36,
                 delegations: [
                     {
-                        votingPublicKey: 'aaff00..',
+                        votePublicKey: 'aaff00..',
                         weight: 1,
                     },
                 ],

--- a/packages/connect/src/types/api/__tests__/cardano.ts
+++ b/packages/connect/src/types/api/__tests__/cardano.ts
@@ -325,7 +325,7 @@ export const cardanoSignTransaction = async (api: TrezorConnect) => {
             cVoteRegistrationParameters: {
                 votingPublicKey: 'aaff00..',
                 stakingPath: 'm/44',
-                rewardAddressParameters: {
+                paymentAddressParameters: {
                     addressType: CardanoAddressType.REWARD,
                     path: 'm/44',
                     stakingPath: 'm/44',
@@ -345,7 +345,7 @@ export const cardanoSignTransaction = async (api: TrezorConnect) => {
                     },
                 ],
                 votingPurpose: 0,
-                rewardAddress: 'Ae2..',
+                paymentAddress: 'Ae2..',
             },
         },
         additionalWitnessRequests: ['m/44'],

--- a/packages/connect/src/types/api/__tests__/cardano.ts
+++ b/packages/connect/src/types/api/__tests__/cardano.ts
@@ -345,6 +345,7 @@ export const cardanoSignTransaction = async (api: TrezorConnect) => {
                     },
                 ],
                 votingPurpose: 0,
+                rewardAddress: 'Ae2..',
             },
         },
         additionalWitnessRequests: ['m/44'],

--- a/packages/connect/src/types/api/cardano/index.ts
+++ b/packages/connect/src/types/api/cardano/index.ts
@@ -174,12 +174,12 @@ export interface CardanoReferenceInput {
 }
 
 export interface CardanoCVoteRegistrationDelegation {
-    votingPublicKey: string;
+    votePublicKey: string;
     weight: number;
 }
 
 export interface CardanoCVoteRegistrationParameters {
-    votingPublicKey?: string;
+    votePublicKey?: string;
     stakingPath: string | number[];
     paymentAddressParameters?: CardanoAddressParameters;
     nonce: string;

--- a/packages/connect/src/types/api/cardano/index.ts
+++ b/packages/connect/src/types/api/cardano/index.ts
@@ -181,12 +181,12 @@ export interface CardanoCVoteRegistrationDelegation {
 export interface CardanoCVoteRegistrationParameters {
     votingPublicKey?: string;
     stakingPath: string | number[];
-    rewardAddressParameters?: CardanoAddressParameters;
+    paymentAddressParameters?: CardanoAddressParameters;
     nonce: string;
     format?: PROTO.CardanoCVoteRegistrationFormat;
     delegations?: CardanoCVoteRegistrationDelegation[];
     votingPurpose?: number;
-    rewardAddress?: string;
+    paymentAddress?: string;
 }
 
 export interface CardanoAuxiliaryData {

--- a/packages/connect/src/types/api/cardano/index.ts
+++ b/packages/connect/src/types/api/cardano/index.ts
@@ -181,11 +181,12 @@ export interface CardanoGovernanceRegistrationDelegation {
 export interface CardanoGovernanceRegistrationParameters {
     votingPublicKey?: string;
     stakingPath: string | number[];
-    rewardAddressParameters: CardanoAddressParameters;
+    rewardAddressParameters?: CardanoAddressParameters;
     nonce: string;
     format?: PROTO.CardanoGovernanceRegistrationFormat;
     delegations?: CardanoGovernanceRegistrationDelegation[];
     votingPurpose?: number;
+    rewardAddress?: string;
 }
 
 export interface CardanoAuxiliaryData {

--- a/packages/connect/src/types/api/cardano/index.ts
+++ b/packages/connect/src/types/api/cardano/index.ts
@@ -173,25 +173,25 @@ export interface CardanoReferenceInput {
     prev_index: number;
 }
 
-export interface CardanoGovernanceRegistrationDelegation {
+export interface CardanoCVoteRegistrationDelegation {
     votingPublicKey: string;
     weight: number;
 }
 
-export interface CardanoGovernanceRegistrationParameters {
+export interface CardanoCVoteRegistrationParameters {
     votingPublicKey?: string;
     stakingPath: string | number[];
     rewardAddressParameters?: CardanoAddressParameters;
     nonce: string;
-    format?: PROTO.CardanoGovernanceRegistrationFormat;
-    delegations?: CardanoGovernanceRegistrationDelegation[];
+    format?: PROTO.CardanoCVoteRegistrationFormat;
+    delegations?: CardanoCVoteRegistrationDelegation[];
     votingPurpose?: number;
     rewardAddress?: string;
 }
 
 export interface CardanoAuxiliaryData {
     hash?: string;
-    governanceRegistrationParameters?: CardanoGovernanceRegistrationParameters;
+    cVoteRegistrationParameters?: CardanoCVoteRegistrationParameters;
 }
 
 export interface CardanoSignTransaction {
@@ -228,7 +228,7 @@ export interface CardanoSignedTxWitness {
 export interface CardanoAuxiliaryDataSupplement {
     type: PROTO.CardanoTxAuxiliaryDataSupplementType;
     auxiliaryDataHash: string;
-    governanceSignature?: string;
+    cVoteRegistrationSignature?: string;
 }
 
 export interface CardanoSignedTxData {

--- a/packages/transport/messages.json
+++ b/packages/transport/messages.json
@@ -2274,7 +2274,6 @@
                     }
                 },
                 "reward_address_parameters": {
-                    "rule": "required",
                     "type": "CardanoAddressParametersType",
                     "id": 3
                 },
@@ -2298,6 +2297,10 @@
                 "voting_purpose": {
                     "type": "uint64",
                     "id": 7
+                },
+                "reward_address": {
+                    "type": "string",
+                    "id": 8
                 }
             }
         },

--- a/packages/transport/messages.json
+++ b/packages/transport/messages.json
@@ -2247,7 +2247,7 @@
         },
         "CardanoCVoteRegistrationDelegation": {
             "fields": {
-                "voting_public_key": {
+                "vote_public_key": {
                     "rule": "required",
                     "type": "bytes",
                     "id": 1
@@ -2261,7 +2261,7 @@
         },
         "CardanoCVoteRegistrationParametersType": {
             "fields": {
-                "voting_public_key": {
+                "vote_public_key": {
                     "type": "bytes",
                     "id": 1
                 },

--- a/packages/transport/messages.json
+++ b/packages/transport/messages.json
@@ -2273,7 +2273,7 @@
                         "packed": false
                     }
                 },
-                "reward_address_parameters": {
+                "payment_address_parameters": {
                     "type": "CardanoAddressParametersType",
                     "id": 3
                 },
@@ -2298,7 +2298,7 @@
                     "type": "uint64",
                     "id": 7
                 },
-                "reward_address": {
+                "payment_address": {
                     "type": "string",
                     "id": 8
                 }

--- a/packages/transport/messages.json
+++ b/packages/transport/messages.json
@@ -1634,10 +1634,10 @@
         "CardanoTxAuxiliaryDataSupplementType": {
             "values": {
                 "NONE": 0,
-                "GOVERNANCE_REGISTRATION_SIGNATURE": 1
+                "CVOTE_REGISTRATION_SIGNATURE": 1
             }
         },
-        "CardanoGovernanceRegistrationFormat": {
+        "CardanoCVoteRegistrationFormat": {
             "values": {
                 "CIP15": 0,
                 "CIP36": 1
@@ -2245,7 +2245,7 @@
                 }
             }
         },
-        "CardanoGovernanceRegistrationDelegation": {
+        "CardanoCVoteRegistrationDelegation": {
             "fields": {
                 "voting_public_key": {
                     "rule": "required",
@@ -2259,7 +2259,7 @@
                 }
             }
         },
-        "CardanoGovernanceRegistrationParametersType": {
+        "CardanoCVoteRegistrationParametersType": {
             "fields": {
                 "voting_public_key": {
                     "type": "bytes",
@@ -2283,7 +2283,7 @@
                     "id": 4
                 },
                 "format": {
-                    "type": "CardanoGovernanceRegistrationFormat",
+                    "type": "CardanoCVoteRegistrationFormat",
                     "id": 5,
                     "options": {
                         "default": "CIP15"
@@ -2291,7 +2291,7 @@
                 },
                 "delegations": {
                     "rule": "repeated",
-                    "type": "CardanoGovernanceRegistrationDelegation",
+                    "type": "CardanoCVoteRegistrationDelegation",
                     "id": 6
                 },
                 "voting_purpose": {
@@ -2306,8 +2306,8 @@
         },
         "CardanoTxAuxiliaryData": {
             "fields": {
-                "governance_registration_parameters": {
-                    "type": "CardanoGovernanceRegistrationParametersType",
+                "cvote_registration_parameters": {
+                    "type": "CardanoCVoteRegistrationParametersType",
                     "id": 1
                 },
                 "hash": {
@@ -2383,7 +2383,7 @@
                     "type": "bytes",
                     "id": 2
                 },
-                "governance_signature": {
+                "cvote_registration_signature": {
                     "type": "bytes",
                     "id": 3
                 }

--- a/packages/transport/scripts/protobuf-patches/index.js
+++ b/packages/transport/scripts/protobuf-patches/index.js
@@ -20,7 +20,7 @@ const RULE_PATCH = {
     'CardanoNativeScript.scripts': 'optional',
     'CardanoNativeScript.key_path': 'optional',
     'CardanoTxRequiredSigner.key_path': 'optional',
-    'CardanoGovernanceRegistrationParametersType.delegations': 'optional',
+    'CardanoCVoteRegistrationParametersType.delegations': 'optional',
     'Success.message': 'required', // didn't find use case where it's not sent
     'SignedIdentity.address': 'required',
     'EosAuthorizationKey.key': 'required', // its valid to be undefined according to implementation/tests
@@ -112,9 +112,9 @@ const TYPE_PATCH = {
     'Features.experimental_features': 'boolean | null',
     'HDNodePathType.node': 'HDNodeType | string',
     'FirmwareUpload.payload': 'Buffer | ArrayBuffer',
-    'CardanoGovernanceRegistrationDelegation.weight': UINT_TYPE,
-    'CardanoGovernanceRegistrationParametersType.nonce': UINT_TYPE,
-    'CardanoGovernanceRegistrationParametersType.voting_purpose': UINT_TYPE,
+    'CardanoCVoteRegistrationDelegation.weight': UINT_TYPE,
+    'CardanoCVoteRegistrationParametersType.nonce': UINT_TYPE,
+    'CardanoCVoteRegistrationParametersType.voting_purpose': UINT_TYPE,
     'CardanoPoolParametersType.pledge': UINT_TYPE,
     'CardanoPoolParametersType.cost': UINT_TYPE,
     'CardanoPoolParametersType.margin_numerator': UINT_TYPE,

--- a/packages/transport/src/types/messages.ts
+++ b/packages/transport/src/types/messages.ts
@@ -624,10 +624,10 @@ export enum CardanoPoolRelayType {
 
 export enum CardanoTxAuxiliaryDataSupplementType {
     NONE = 0,
-    GOVERNANCE_REGISTRATION_SIGNATURE = 1,
+    CVOTE_REGISTRATION_SIGNATURE = 1,
 }
 
-export enum CardanoGovernanceRegistrationFormat {
+export enum CardanoCVoteRegistrationFormat {
     CIP15 = 0,
     CIP36 = 1,
 }
@@ -831,27 +831,27 @@ export type CardanoTxWithdrawal = {
     key_hash?: string;
 };
 
-// CardanoGovernanceRegistrationDelegation
-export type CardanoGovernanceRegistrationDelegation = {
+// CardanoCVoteRegistrationDelegation
+export type CardanoCVoteRegistrationDelegation = {
     voting_public_key: string;
     weight: UintType;
 };
 
-// CardanoGovernanceRegistrationParametersType
-export type CardanoGovernanceRegistrationParametersType = {
+// CardanoCVoteRegistrationParametersType
+export type CardanoCVoteRegistrationParametersType = {
     voting_public_key?: string;
     staking_path: number[];
     reward_address_parameters?: CardanoAddressParametersType;
     nonce: UintType;
-    format?: CardanoGovernanceRegistrationFormat;
-    delegations?: CardanoGovernanceRegistrationDelegation[];
+    format?: CardanoCVoteRegistrationFormat;
+    delegations?: CardanoCVoteRegistrationDelegation[];
     voting_purpose?: UintType;
     reward_address?: string;
 };
 
 // CardanoTxAuxiliaryData
 export type CardanoTxAuxiliaryData = {
-    governance_registration_parameters?: CardanoGovernanceRegistrationParametersType;
+    cvote_registration_parameters?: CardanoCVoteRegistrationParametersType;
     hash?: string;
 };
 
@@ -885,7 +885,7 @@ export type CardanoTxItemAck = {};
 export type CardanoTxAuxiliaryDataSupplement = {
     type: CardanoTxAuxiliaryDataSupplementType;
     auxiliary_data_hash?: string;
-    governance_signature?: string;
+    cvote_registration_signature?: string;
 };
 
 // CardanoTxWitnessRequest
@@ -2256,8 +2256,8 @@ export type MessageType = {
     CardanoPoolParametersType: CardanoPoolParametersType;
     CardanoTxCertificate: CardanoTxCertificate;
     CardanoTxWithdrawal: CardanoTxWithdrawal;
-    CardanoGovernanceRegistrationDelegation: CardanoGovernanceRegistrationDelegation;
-    CardanoGovernanceRegistrationParametersType: CardanoGovernanceRegistrationParametersType;
+    CardanoCVoteRegistrationDelegation: CardanoCVoteRegistrationDelegation;
+    CardanoCVoteRegistrationParametersType: CardanoCVoteRegistrationParametersType;
     CardanoTxAuxiliaryData: CardanoTxAuxiliaryData;
     CardanoTxMint: CardanoTxMint;
     CardanoTxCollateralInput: CardanoTxCollateralInput;

--- a/packages/transport/src/types/messages.ts
+++ b/packages/transport/src/types/messages.ts
@@ -841,12 +841,12 @@ export type CardanoCVoteRegistrationDelegation = {
 export type CardanoCVoteRegistrationParametersType = {
     voting_public_key?: string;
     staking_path: number[];
-    reward_address_parameters?: CardanoAddressParametersType;
+    payment_address_parameters?: CardanoAddressParametersType;
     nonce: UintType;
     format?: CardanoCVoteRegistrationFormat;
     delegations?: CardanoCVoteRegistrationDelegation[];
     voting_purpose?: UintType;
-    reward_address?: string;
+    payment_address?: string;
 };
 
 // CardanoTxAuxiliaryData

--- a/packages/transport/src/types/messages.ts
+++ b/packages/transport/src/types/messages.ts
@@ -841,11 +841,12 @@ export type CardanoGovernanceRegistrationDelegation = {
 export type CardanoGovernanceRegistrationParametersType = {
     voting_public_key?: string;
     staking_path: number[];
-    reward_address_parameters: CardanoAddressParametersType;
+    reward_address_parameters?: CardanoAddressParametersType;
     nonce: UintType;
     format?: CardanoGovernanceRegistrationFormat;
     delegations?: CardanoGovernanceRegistrationDelegation[];
     voting_purpose?: UintType;
+    reward_address?: string;
 };
 
 // CardanoTxAuxiliaryData

--- a/packages/transport/src/types/messages.ts
+++ b/packages/transport/src/types/messages.ts
@@ -833,13 +833,13 @@ export type CardanoTxWithdrawal = {
 
 // CardanoCVoteRegistrationDelegation
 export type CardanoCVoteRegistrationDelegation = {
-    voting_public_key: string;
+    vote_public_key: string;
     weight: UintType;
 };
 
 // CardanoCVoteRegistrationParametersType
 export type CardanoCVoteRegistrationParametersType = {
-    voting_public_key?: string;
+    vote_public_key?: string;
     staking_path: number[];
     payment_address_parameters?: CardanoAddressParametersType;
     nonce: UintType;


### PR DESCRIPTION
The corresponding firmware PR is [here](https://github.com/trezor/trezor-firmware/pull/2692). Changes in Cardano [CIP-36](https://cips.cardano.org/cips/cip36/) vote key registrations:
- The address to receive voting rewards can be provided as an address string (`paymentAddress`) instead of address parameters.
- Renamed identifiers (initiated by clarifications in CIP-36, context e.g. [here](https://github.com/cardano-foundation/CIPs/pull/373) and [here](https://github.com/cardano-foundation/CIPs/pull/427)):
  - `governance` replaced by `cVote` (all occurences)
  - `rewardAddressParameters` replaced by `paymentAddressParameters`
  - `votingPublicKey` replaced by `votePublicKey`  

  The changes are also present in the public API, but I kept silent support for the old names, like we did in https://github.com/trezor/trezor-suite/pull/6735 when we replaced `catalyst` by `governance` (I know that the renaming frequency is a bit unfortunate, but the Cardano terminology seems to be still evolving). Is this alright or would you prefer a different solution?