### PR TITLE
fix(suite): transaction signs

### DIFF
--- a/packages/suite/src/components/suite/Sign/index.tsx
+++ b/packages/suite/src/components/suite/Sign/index.tsx
@@ -32,17 +32,17 @@ export const Sign = ({
         return null;
     }
 
-    const isValuePos = isSignValuePositive(value);
+    const isValuePositive = isSignValuePositive(value);
 
     if (placeholderOnly) {
         return <StyledSign color="transparent">+</StyledSign>;
     }
 
-    if (isValuePos) {
+    if (isValuePositive) {
         return <StyledSign color={grayscale ? defaultColor : theme.TYPE_GREEN}>+</StyledSign>;
     }
 
-    if (!isValuePos && showMinusSign) {
+    if (!isValuePositive && showMinusSign) {
         return <StyledSign color={grayscale ? defaultColor : theme.TYPE_RED}>–</StyledSign>;
     }
     return null;

--- a/packages/suite/src/components/suite/TransactionsGraph/components/CustomTooltipAccount.tsx
+++ b/packages/suite/src/components/suite/TransactionsGraph/components/CustomTooltipAccount.tsx
@@ -10,6 +10,7 @@ import { Formatters, useFormatters } from '@suite-common/formatters';
 import { Props as GraphProps, CryptoGraphProps } from '../definitions';
 import { CustomTooltipBase } from './CustomTooltipBase';
 import { CommonAggregatedHistory } from '../../../../types/wallet/graph';
+import { SignOperator } from '@suite-common/suite-types';
 
 const StyledCryptoAmount = styled(FormattedCryptoAmount)`
     margin-right: 2px;
@@ -20,7 +21,7 @@ const formatAmount = (
     symbol: NetworkSymbol,
     fiatAmount: string | undefined,
     localCurrency: string | undefined,
-    sign: 'pos' | 'neg',
+    sign: SignOperator,
     formatters: Formatters,
 ) => {
     const { FiatAmountFormatter } = formatters;
@@ -90,7 +91,7 @@ export const CustomTooltipAccount = ({
                 symbol,
                 sentFiat,
                 localCurrency,
-                'neg',
+                'negative',
                 formatters,
             )}
             receivedAmount={formatAmount(
@@ -98,7 +99,7 @@ export const CustomTooltipAccount = ({
                 symbol,
                 receivedFiat,
                 localCurrency,
-                'pos',
+                'positive',
                 formatters,
             )}
             balance={

--- a/packages/suite/src/components/wallet/TransactionItem/components/Target.tsx
+++ b/packages/suite/src/components/wallet/TransactionItem/components/Target.tsx
@@ -22,6 +22,7 @@ import { BaseTargetLayout } from './BaseTargetLayout';
 import { copyToClipboard } from '@trezor/dom-utils';
 import { AccountMetadata } from '@suite-types/metadata';
 import { ExtendedMessageDescriptor } from '@suite-types';
+import { SignOperator } from '@suite-common/suite-types';
 
 export const StyledCryptoAmount = styled(FormattedCryptoAmount)`
     width: 100%;
@@ -173,7 +174,7 @@ export const CustomRow = ({
     ...baseLayoutProps
 }: {
     amount: string;
-    sign: 'pos' | 'neg';
+    sign: SignOperator;
     title: ExtendedMessageDescriptor['id'];
     transaction: WalletAccountTransaction;
     useFiatValues?: boolean;
@@ -214,7 +215,7 @@ export const FeeRow = ({
     <CustomRow
         {...baseLayoutProps}
         title="FEE"
-        sign="neg"
+        sign="negative"
         amount={fee}
         transaction={transaction}
         useFiatValues={useFiatValues}
@@ -235,7 +236,7 @@ export const WithdrawalRow = ({
     <CustomRow
         {...baseLayoutProps}
         title="TR_TX_WITHDRAWAL"
-        sign="pos"
+        sign="positive"
         amount={formatCardanoWithdrawal(transaction) ?? '0'}
         transaction={transaction}
         useFiatValues={useFiatValues}
@@ -256,7 +257,7 @@ export const DepositRow = ({
     <CustomRow
         {...baseLayoutProps}
         title="TR_TX_DEPOSIT"
-        sign="neg"
+        sign="negative"
         amount={formatCardanoDeposit(transaction) ?? '0'}
         transaction={transaction}
         useFiatValues={useFiatValues}

--- a/packages/suite/src/components/wallet/TransactionItem/components/TransactionHeading.tsx
+++ b/packages/suite/src/components/wallet/TransactionItem/components/TransactionHeading.tsx
@@ -132,7 +132,7 @@ export const TransactionHeading = ({
             <StyledCryptoAmount
                 value={formatNetworkAmount(transaction.fee, transaction.symbol)}
                 symbol={transaction.symbol}
-                signValue="neg"
+                signValue="negative"
                 isZeroValuePhishing={isZeroValuePhishing}
             />
         );

--- a/packages/suite/src/views/wallet/transactions/components/TransactionSummary/components/SummaryCards/components/InfoCard.tsx
+++ b/packages/suite/src/views/wallet/transactions/components/TransactionSummary/components/SummaryCards/components/InfoCard.tsx
@@ -99,7 +99,7 @@ export const InfoCard = (props: InfoCardProps) => {
                         {props.isNumeric && props.secondaryValue && (
                             <StyledHiddenPlaceholder>
                                 <Value>
-                                    <Sign value="pos" placeholderOnly />
+                                    <Sign value="positive" placeholderOnly />
                                     <SecondaryValueWrapper>
                                         {props.secondaryValue}
                                     </SecondaryValueWrapper>

--- a/suite-common/suite-types/src/sign.ts
+++ b/suite-common/suite-types/src/sign.ts
@@ -1,3 +1,5 @@
 import BigNumber from 'bignumber.js';
 
-export type SignValue = string | BigNumber | number | 'positive' | 'negative' | null;
+export type SignOperator = 'positive' | 'negative';
+
+export type SignValue = string | BigNumber | number | SignOperator | null;

--- a/suite-common/wallet-utils/src/transactionUtils.ts
+++ b/suite-common/wallet-utils/src/transactionUtils.ts
@@ -9,6 +9,7 @@ import {
 } from '@suite-common/wallet-types';
 import { AccountMetadata } from '@suite-common/metadata-types';
 import { AccountAddress, AccountTransaction } from '@trezor/connect';
+import { SignOperator } from '@suite-common/suite-types';
 
 import { formatAmount, formatNetworkAmount } from './accountUtils';
 import { toFiatCurrency } from './fiatConverterUtils';
@@ -355,12 +356,14 @@ export const analyzeTransactions = (fresh: AccountTransaction[], known: AccountT
 
 // getTxOperation is used with types WalletAccountTransaction and ArrayElement<WalletAccountTransaction['tokens']
 // the only interesting field is 'type', which has compatible string literal union in both types
-export const getTxOperation = (tx: { type: WalletAccountTransaction['type'] }) => {
+export const getTxOperation = (tx: {
+    type: WalletAccountTransaction['type'];
+}): SignOperator | null => {
     if (tx.type === 'sent' || tx.type === 'self' || tx.type === 'failed') {
-        return 'neg';
+        return 'negative';
     }
     if (tx.type === 'recv') {
-        return 'pos';
+        return 'positive';
     }
     return null;
 };
@@ -680,7 +683,7 @@ const numberSearchFilter = (
     return (
         targetAmounts.filter(targetAmount => {
             let bnTargetAmount = new BigNumber(targetAmount);
-            if (op === 'neg') {
+            if (op === 'negative') {
                 bnTargetAmount = bnTargetAmount.negated();
             }
 


### PR DESCRIPTION
## Description

All transactions were shown with `-` sign as there was a mix of `pos`/`neg` and `positive`/`negative` values

## Related Issue

[Slack](https://satoshilabs.slack.com/archives/CKZHV2G13/p1677868551197569)
Broken by https://github.com/trezor/trezor-suite/commit/2c0e404f45410f74b556b0f24884732de97103a9

## Screenshots:
Before:
![Screenshot 2023-03-06 at 9 20 48](https://user-images.githubusercontent.com/33235762/223055381-692acc66-ce73-4bd7-bd56-0f063e48dc22.png)

Now:
![Screenshot 2023-03-06 at 9 19 26](https://user-images.githubusercontent.com/33235762/223055357-b86c6ae1-67d5-446d-84b7-73ee25913acb.png)
