### PR TITLE
chore(suite): limit SignValue type so type-check catches more errors

### DIFF
--- a/packages/suite/src/components/suite/modals/TransactionDetail/components/ChangeFee/components/AffectedTransactions/index.tsx
+++ b/packages/suite/src/components/suite/modals/TransactionDetail/components/ChangeFee/components/AffectedTransactions/index.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import styled from 'styled-components';
+import BigNumber from 'bignumber.js';
 import { Icon, Button, useTheme, variables } from '@trezor/components';
 import { formatNetworkAmount } from '@suite-common/wallet-utils';
 import { FormattedCryptoAmount, Sign, Translation, FormattedDate } from '@suite-components';
@@ -109,7 +110,7 @@ const AffectedTransactions = ({ showChained }: { showChained: () => void }) => {
                             </Txid>
                             <Amount>
                                 <Sign
-                                    value={amount}
+                                    value={new BigNumber(amount)}
                                     grayscale
                                     grayscaleColor={theme.TYPE_LIGHT_GREY}
                                 />

--- a/packages/suite/src/components/wallet/TransactionItem/components/CoinjoinBatchItem.tsx
+++ b/packages/suite/src/components/wallet/TransactionItem/components/CoinjoinBatchItem.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import styled, { css } from 'styled-components';
+import BigNumber from 'bignumber.js';
 
 import {
     formatNetworkAmount,
@@ -50,6 +51,9 @@ const RoundRow = styled.div`
 
 const Round = ({ transaction }: { transaction: WalletAccountTransaction }) => {
     const { openModal } = useActions({ openModal: modalActions.openModal });
+
+    const transactionAmount = new BigNumber(transaction.amount);
+
     return (
         <RoundRow
             onClick={() =>
@@ -76,13 +80,11 @@ const Round = ({ transaction }: { transaction: WalletAccountTransaction }) => {
                 amount={
                     <CryptoAmount
                         value={formatNetworkAmount(
-                            transaction.amount.startsWith('-')
-                                ? transaction.amount.slice(1)
-                                : transaction.amount,
+                            transactionAmount.abs().toString(),
                             transaction.symbol,
                         )}
                         symbol={transaction.symbol}
-                        signValue={transaction.amount}
+                        signValue={transactionAmount}
                     />
                 }
                 isFirst

--- a/packages/suite/src/components/wallet/TransactionItem/components/Target.tsx
+++ b/packages/suite/src/components/wallet/TransactionItem/components/Target.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import styled from 'styled-components';
+import BigNumber from 'bignumber.js';
 import { variables } from '@trezor/components';
 import { getIsZeroValuePhishing } from '@suite-common/suite-utils';
 import { FiatValue, Translation, MetadataLabeling, FormattedCryptoAmount } from '@suite-components';
@@ -282,9 +283,7 @@ export const CoinjoinRow = ({
             useFiatValues ? (
                 <FiatValue
                     amount={formatNetworkAmount(
-                        transaction.amount.startsWith('-')
-                            ? transaction.amount.slice(1)
-                            : transaction.amount,
+                        new BigNumber(transaction.amount).abs().toString(),
                         transaction.symbol,
                     )}
                     symbol={transaction.symbol}

--- a/packages/suite/src/components/wallet/TransactionItem/components/TransactionHeading.tsx
+++ b/packages/suite/src/components/wallet/TransactionItem/components/TransactionHeading.tsx
@@ -13,6 +13,7 @@ import {
 } from '@suite-common/wallet-utils';
 import { TransactionHeader } from './TransactionHeader';
 import { WalletAccountTransaction } from '@wallet-types';
+import BigNumber from 'bignumber.js';
 
 const Wrapper = styled.span`
     display: flex;
@@ -103,6 +104,7 @@ export const TransactionHeading = ({
         const operation = !isTokenTransaction
             ? getTxOperation(transaction)
             : getTxOperation(transfer);
+
         amount = targetAmount && (
             <StyledCryptoAmount
                 value={targetAmount}
@@ -114,14 +116,14 @@ export const TransactionHeading = ({
     }
 
     if (transaction.type === 'joint') {
-        const abs = transaction.amount.startsWith('-')
-            ? transaction.amount.slice(1)
-            : transaction.amount;
+        const transactionAmount = new BigNumber(transaction.amount);
+        const abs = transactionAmount.abs().toString();
+
         amount = (
             <StyledCryptoAmount
                 value={formatNetworkAmount(abs, transaction.symbol)}
                 symbol={transaction.symbol}
-                signValue={transaction.amount}
+                signValue={transactionAmount}
                 isZeroValuePhishing={isZeroValuePhishing}
             />
         );

--- a/suite-common/formatters/src/utils/sign.ts
+++ b/suite-common/formatters/src/utils/sign.ts
@@ -1,5 +1,3 @@
-import BigNumber from 'bignumber.js';
-
 import { SignValue } from '@suite-common/suite-types';
 
 export const isSignValuePositive = (value: SignValue) => {
@@ -15,5 +13,5 @@ export const isSignValuePositive = (value: SignValue) => {
         return false;
     }
 
-    return new BigNumber(value).gte(0);
+    return value.gte(0);
 };

--- a/suite-common/suite-types/src/sign.ts
+++ b/suite-common/suite-types/src/sign.ts
@@ -2,4 +2,4 @@ import BigNumber from 'bignumber.js';
 
 export type SignOperator = 'positive' | 'negative';
 
-export type SignValue = string | BigNumber | number | SignOperator | null;
+export type SignValue = SignOperator | BigNumber | null;


### PR DESCRIPTION
## Description

- do not allow `string` sign value so that `type-check` can find out incorrect values

## Related Issue

[Restrict](https://github.com/trezor/trezor-suite/pull/7770#issuecomment-1455816610)

## Screenshots:
