### PR TITLE
feat(coinjoin, message-system): add possibility to hide adding coinjoin account remotely via message system

### DIFF
--- a/packages/message-system/src/schema/config.schema.v1.json
+++ b/packages/message-system/src/schema/config.schema.v1.json
@@ -296,6 +296,9 @@
                                         },
                                         "flag": {
                                             "type": "boolean"
+                                        },
+                                        "isPublic": {
+                                            "type": "boolean"
                                         }
                                     },
                                     "additionalProperties": true

--- a/packages/suite/src/reducers/wallet/coinjoinReducer.ts
+++ b/packages/suite/src/reducers/wallet/coinjoinReducer.ts
@@ -38,6 +38,7 @@ import {
     Feature,
     MessageSystemRootState,
     selectIsFeatureDisabled,
+    selectFeatureConfig,
 } from '@suite-reducers/messageSystemReducer';
 import { SelectedAccountRootState, selectSelectedAccount } from './selectedAccountReducer';
 
@@ -741,3 +742,8 @@ export const selectCurrentSessionDeadlineInfo = memoize((state: CoinjoinRootStat
         sessionDeadline,
     };
 });
+
+// Return true if it's not explicitly set to false in the message-system config.
+export const selectIsPublic = memoize(
+    (state: CoinjoinRootState) => selectFeatureConfig(state, Feature.coinjoin)?.isPublic !== false,
+);


### PR DESCRIPTION


<!--- Provide a general summary of your changes in the Title above -->

## Description

So we can hide coinjoin under debug menu without creating another build for QA and we can technically release it at any time.
