### PR TITLE
Add z-index to DayHeader

### DIFF
--- a/packages/components/src/config/variables.ts
+++ b/packages/components/src/config/variables.ts
@@ -54,6 +54,7 @@ export const Z_INDEX = {
     EXPANDABLE_NAVIGATION: 20, // above PAGE_HEADER to spread over it
     PAGE_HEADER: 11, // above STICKY_BAR to hide it when the page is on top
     STICKY_BAR: 10, // above page content to scroll over it
+    SECONDARY_STICKY_BAR: 9, // below STICKY_BAR so that it can hide beneath it when no longer needed
     BASE: 1, // above static content to be fully visible
 } as const;
 

--- a/packages/suite/src/views/wallet/transactions/components/TransactionList/components/DayHeader/index.tsx
+++ b/packages/suite/src/views/wallet/transactions/components/TransactionList/components/DayHeader/index.tsx
@@ -12,7 +12,7 @@ import { SECONDARY_PANEL_HEIGHT } from '@suite-components/AppNavigation';
 const Wrapper = styled.div`
     display: flex;
     position: sticky;
-    background: ${props => props.theme.BG_GREY};
+    background: ${({ theme }) => theme.BG_GREY};
     top: ${SECONDARY_PANEL_HEIGHT};
     align-items: center;
     justify-content: space-between;
@@ -20,11 +20,12 @@ const Wrapper = styled.div`
     padding-top: 8px;
     padding-bottom: 8px;
     padding-right: 24px;
+    z-index: ${variables.Z_INDEX.SECONDARY_STICKY_BAR};
 `;
 
 const Col = styled(HiddenPlaceholder)`
     font-size: ${variables.FONT_SIZE.SMALL};
-    color: ${props => props.theme.TYPE_LIGHT_GREY};
+    color: ${({ theme }) => theme.TYPE_LIGHT_GREY};
     font-weight: ${variables.FONT_WEIGHT.DEMI_BOLD};
     text-transform: uppercase;
 `;
@@ -35,7 +36,7 @@ const ColDate = styled(Col)`
 `;
 
 const ColPending = styled(Col)`
-    color: ${props => props.theme.TYPE_ORANGE};
+    color: ${({ theme }) => theme.TYPE_ORANGE};
     font-variant-numeric: tabular-nums;
 `;
 
@@ -61,7 +62,7 @@ interface Props {
     isHovered?: boolean;
 }
 
-const DayHeader = ({
+export const DayHeader = ({
     dateKey,
     symbol,
     totalAmount,
@@ -74,6 +75,7 @@ const DayHeader = ({
 
     const parsedDate = parseTransactionDateKey(dateKey);
     const showFiatValue = !isTestnet(symbol);
+
     return (
         <Wrapper>
             {dateKey === 'pending' ? (
@@ -98,7 +100,6 @@ const DayHeader = ({
                     {showFiatValue && (
                         <ColFiat>
                             <HiddenPlaceholder>
-                                {/* {<>≈ </>} */}
                                 {totalFiatAmountPerDay.gte(0) && <span>+</span>}
                                 <FiatAmountFormatter
                                     currency={localCurrency}
@@ -112,5 +113,3 @@ const DayHeader = ({
         </Wrapper>
     );
 };
-
-export default DayHeader;

--- a/packages/suite/src/views/wallet/transactions/components/TransactionList/components/TransactionsGroup/index.tsx
+++ b/packages/suite/src/views/wallet/transactions/components/TransactionList/components/TransactionsGroup/index.tsx
@@ -1,7 +1,7 @@
 import React, { useState } from 'react';
 import styled from 'styled-components';
 import { Network, WalletAccountTransaction } from '@wallet-types';
-import DayHeader from '../DayHeader';
+import { DayHeader } from '../DayHeader';
 import { sumTransactions, sumTransactionsFiat } from '@suite-common/wallet-utils';
 
 const TransactionsGroupWrapper = styled.div`


### PR DESCRIPTION
## Description
Bug was probably caused by applying `position: relative` to the icon wrapper.

## Screenshots:
before:
![Screenshot 2023-03-06 at 18 59 01](https://user-images.githubusercontent.com/42465546/223192681-17defaba-864a-49e1-be75-98467909aa96.png)
after:
![Screenshot 2023-03-06 at 18 58 12](https://user-images.githubusercontent.com/42465546/223192656-fe21e676-b804-4ed5-9078-f6fbb38fbdf1.png)
