### PR TITLE
feat(message-system,coinjoin): hide coinjoin by debug menu

### DIFF
--- a/packages/message-system/src/config/config.v1.json
+++ b/packages/message-system/src/config/config.v1.json
@@ -1,15 +1,15 @@
 {
     "version": 1,
-    "timestamp": "2023-02-22T00:00:00+00:00",
-    "sequence": 24,
+    "timestamp": "2023-03-07T00:00:00+00:00",
+    "sequence": 25,
     "actions": [
         {
             "conditions": [
                 {
                     "environment": {
-                        "desktop": ">=23.3.0",
+                        "desktop": ">=23.3.1",
                         "mobile": "!",
-                        "web": ">=23.3.0"
+                        "web": ">=23.3.1"
                     }
                 }
             ],
@@ -31,21 +31,21 @@
                     {
                         "domain": "coinjoin",
                         "flag": true,
+                        "isPublic": false,
                         "averageAnonymityGainPerRound": 5,
                         "roundsFailRateBuffer": 10,
                         "roundsDurationInHours": 1
                     }
-                ],
-                "context": { "domain": "accounts.coinjoin" }
+                ]
             }
         },
         {
             "conditions": [
                 {
                     "environment": {
-                        "desktop": "<23.2.2",
+                        "desktop": "<23.3.1",
                         "mobile": "!",
-                        "web": "<23.2.2"
+                        "web": "<23.3.1"
                     }
                 }
             ],


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Hide coinjoin again under debug menu - coinjoin account type is visible in add account modal only if debug menu is activated.
