### PR TITLE
Make Suite update modal non-cancellable during auto-update

### DIFF
--- a/packages/components/src/components/Modal/index.tsx
+++ b/packages/components/src/components/Modal/index.tsx
@@ -185,14 +185,6 @@ interface ModalProps {
     'data-test'?: string;
 }
 
-type ModalSubcomponents = {
-    Header: typeof Header;
-    Body: typeof Body;
-    Description: typeof Description;
-    Content: typeof Content;
-    BottomBar: typeof BottomBar;
-};
-
 const Modal = ({
     children,
     heading,
@@ -302,7 +294,7 @@ const Modal = ({
                     </Header>
                 )}
 
-                {heading && showProgressBar && (
+                {showProgressBar && (
                     <Progress value={currentProgressBarStep} max={totalProgressBarSteps} />
                 )}
 

--- a/packages/suite-desktop-ui/src/support/DesktopUpdater/Available.tsx
+++ b/packages/suite-desktop-ui/src/support/DesktopUpdater/Available.tsx
@@ -100,10 +100,11 @@ const getVersionName = ({ latestVersion, prerelease }: VersionNameProps): string
 
 interface AvailableProps {
     hideWindow: () => void;
+    isCancelable: boolean;
     latest?: UpdateInfo;
 }
 
-export const Available = ({ hideWindow, latest }: AvailableProps) => {
+export const Available = ({ hideWindow, isCancelable, latest }: AvailableProps) => {
     const { download } = useActions({
         download: desktopUpdateActions.download,
     });
@@ -116,7 +117,7 @@ export const Available = ({ hideWindow, latest }: AvailableProps) => {
     return (
         <StyledModal
             heading={<Translation id="TR_UPDATE_MODAL_AVAILABLE_HEADING" />}
-            isCancelable
+            isCancelable={isCancelable}
             onCancel={hideWindow}
             bottomBar={
                 <>

--- a/packages/suite-desktop-ui/src/support/DesktopUpdater/Downloading.tsx
+++ b/packages/suite-desktop-ui/src/support/DesktopUpdater/Downloading.tsx
@@ -5,15 +5,9 @@ import { Translation, Modal } from '@suite-components';
 
 import { UpdateProgress } from '@trezor/suite-desktop-api';
 import { bytesToHumanReadable } from '@trezor/utils';
-import { H2, variables } from '@trezor/components';
+import { Button, H2, variables } from '@trezor/components';
 
 import { Row } from './styles';
-
-const ModalHeadingWrapper = styled.div`
-    display: flex;
-    width: 100%;
-    justify-content: space-between;
-`;
 
 const DownloadWrapper = styled(Row)`
     margin-top: 16px;
@@ -38,6 +32,10 @@ const Text = styled(H2)`
     font-weight: ${variables.FONT_WEIGHT.MEDIUM};
 `;
 
+const StyledButton = styled(Button)`
+    margin: 21px 0;
+`;
+
 interface DownloadingProps {
     hideWindow: () => void;
     progress?: UpdateProgress;
@@ -47,6 +45,7 @@ const ellipsisArray = new Array(3).fill('.');
 
 export const Downloading = ({ hideWindow, progress }: DownloadingProps) => {
     const [step, setStep] = useState(0);
+
     useEffect(() => {
         const timer = setTimeout(() => setStep(step > 2 ? 0 : step + 1), 300);
         return () => clearTimeout(timer);
@@ -54,14 +53,18 @@ export const Downloading = ({ hideWindow, progress }: DownloadingProps) => {
 
     return (
         <Modal
-            heading={
-                <ModalHeadingWrapper>
-                    <Translation id="TR_UPDATE_MODAL_DOWNLOADING_UPDATE" />
-                </ModalHeadingWrapper>
-            }
+            headerComponents={[
+                <StyledButton
+                    variant="secondary"
+                    icon="CROSS"
+                    alignIcon="right"
+                    onClick={hideWindow}
+                >
+                    <Translation id="TR_BACKGROUND_DOWNLOAD" />
+                </StyledButton>,
+            ]}
             currentProgressBarStep={progress?.percent || 0}
             totalProgressBarSteps={100}
-            isCancelable
             onCancel={hideWindow}
         >
             <DownloadWrapper>

--- a/packages/suite-desktop-ui/src/support/DesktopUpdater/Ready.tsx
+++ b/packages/suite-desktop-ui/src/support/DesktopUpdater/Ready.tsx
@@ -23,9 +23,10 @@ const StyledModal = styled(Modal)`
 
 interface ReadyProps {
     hideWindow: () => void;
+    isCancelable: boolean;
 }
 
-export const Ready = ({ hideWindow }: ReadyProps) => {
+export const Ready = ({ hideWindow, isCancelable }: ReadyProps) => {
     const { installUpdate } = useActions({
         installUpdate: desktopUpdateActions.installUpdate,
     });
@@ -38,7 +39,7 @@ export const Ready = ({ hideWindow }: ReadyProps) => {
     return (
         <StyledModal
             heading={<Translation id="TR_UPDATE_MODAL_UPDATE_DOWNLOADED" />}
-            isCancelable
+            isCancelable={isCancelable}
             onCancel={installOnQuit}
             bottomBar={
                 <>

--- a/packages/suite/src/reducers/suite/routerReducer.ts
+++ b/packages/suite/src/reducers/suite/routerReducer.ts
@@ -51,4 +51,6 @@ const routerReducer = (state: RouterState = initialState, action: Action): Route
 
 export const selectRouterParams = (state: RouterRootState) => state.router.params;
 
+export const selectRouteName = (state: RouterRootState) => state.router.route?.name;
+
 export default routerReducer;

--- a/packages/suite/src/support/messages.ts
+++ b/packages/suite/src/support/messages.ts
@@ -6298,6 +6298,10 @@ export default defineMessages({
         id: 'TR_UPDATE_MODAL_UPDATE_ON_QUIT',
         defaultMessage: 'Update on quit',
     },
+    TR_BACKGROUND_DOWNLOAD: {
+        id: 'TR_BACKGROUND_DOWNLOAD',
+        defaultMessage: 'Download in the background',
+    },
     TR_MANAGE: {
         id: 'TR_MANAGE',
         defaultMessage: 'manage',
@@ -6309,10 +6313,6 @@ export default defineMessages({
     TR_CHANGELOG_ON_GITHUB: {
         id: 'TR_CHANGELOG_ON_GITHUB',
         defaultMessage: 'Changelog on GitHub',
-    },
-    TR_UPDATE_MODAL_DOWNLOADING_UPDATE: {
-        id: 'TR_UPDATE_MODAL_DOWNLOADING_UPDATE',
-        defaultMessage: 'Downloading update',
     },
     TR_UPDATE_MODAL_UPDATE_DOWNLOADED: {
         id: 'TR_UPDATE_MODAL_UPDATE_DOWNLOADED',

--- a/packages/suite/src/views/backup/index.tsx
+++ b/packages/suite/src/views/backup/index.tsx
@@ -60,18 +60,16 @@ const CloseButton = ({ onClick, variant }: CloseButtonProps) => (
 );
 
 const getModalHeading = (backupStatus: BackupStatus) => {
-    if (backupStatus === 'initial') {
-        return <Translation id="TR_CREATE_BACKUP" />;
+    switch (backupStatus) {
+        case 'initial':
+            return <Translation id="TR_CREATE_BACKUP" />;
+        case 'finished':
+            return <Translation id="TR_BACKUP_CREATED" />;
+        case 'error':
+            return <Translation id="TOAST_BACKUP_FAILED" />;
+        default:
+            return null;
     }
-
-    if (backupStatus === 'finished') {
-        return <Translation id="TR_BACKUP_CREATED" />;
-    }
-
-    if (backupStatus === 'error') {
-        return <Translation id="TOAST_BACKUP_FAILED" />;
-    }
-    return null;
 };
 
 const getEdgeCaseModalHeading = (unfinishedBackup: boolean) => {
@@ -91,8 +89,10 @@ export const Backup = ({ cancelable, onCancel }: ForegroundAppProps) => {
     const dispatch = useDispatch();
 
     const nonErrorBackupStatuses = ['initial', 'in-progress', 'finished'] as const;
-
     const isDeviceUnavailable = !device || !device.features || !device.connected;
+    const currentProgressBarStep = nonErrorBackupStatuses.some(status => status === backup.status)
+        ? nonErrorBackupStatuses.findIndex(s => s === backup.status) + 1
+        : undefined;
 
     if (isDeviceUnavailable) {
         return (
@@ -154,7 +154,7 @@ export const Backup = ({ cancelable, onCancel }: ForegroundAppProps) => {
             data-test="@backup"
             heading={getModalHeading(backup.status)}
             totalProgressBarSteps={nonErrorBackupStatuses.length}
-            currentProgressBarStep={nonErrorBackupStatuses.findIndex(s => s === backup.status) + 1}
+            currentProgressBarStep={currentProgressBarStep}
             bottomBar={
                 <>
                     {backup.status === 'initial' && (


### PR DESCRIPTION
## Description

Set `isCancellable` to false when current `route.name` is not `settings-index`. The goal is to make the update non-cancellable if it was opened by `autoUpdater` because the user might not expect it to close on click outside and this can lead to some confusion during auto-update. The route is used in the condition because the modal is not aware what opened it. I added a button to keep the option of downloading in the background.

I could not figure out how to fully test it without a signed version. I was only able to test it partially by lowering the app version in `package.json` and building the app as described in `suite-desktop` README. But download fails as the app is not signed. See the video. (There is an error toast not captured in the video.)

The wallet modal still opens right after the download ends, it is not ideal, but I don't know about a better solution.

## Related Issue

Resolve #6655

## Screenshots:

https://user-images.githubusercontent.com/42465546/224301872-ef830de6-4a9b-42bd-9aa1-ad2f15bc599c.mov

