### PR TITLE
CJ mempool subscription

### DIFF
--- a/packages/blockchain-link/src/workers/blockbook/websocket.ts
+++ b/packages/blockchain-link/src/workers/blockbook/websocket.ts
@@ -123,7 +123,7 @@ export class BlockbookAPI extends EventEmitter {
     }
 
     onError() {
-        this.dispose();
+        this.onClose();
     }
 
     send: Send = (method, params = {}) => {
@@ -227,7 +227,7 @@ export class BlockbookAPI extends EventEmitter {
             ws.setMaxListeners(Infinity);
         }
         ws.once('error', error => {
-            this.dispose();
+            this.onClose();
             dfd.reject(new CustomError('websocket_runtime_error', error.message));
         });
         ws.on('open', () => {
@@ -256,8 +256,8 @@ export class BlockbookAPI extends EventEmitter {
         ws.on('error', this.onError.bind(this));
         ws.on('message', this.onmessage.bind(this));
         ws.on('close', () => {
+            this.onClose();
             this.emit('disconnected');
-            this.dispose();
         });
     }
 
@@ -265,7 +265,6 @@ export class BlockbookAPI extends EventEmitter {
         if (this.ws) {
             this.ws.close();
         }
-        // this.dispose();
     }
 
     isConnected() {
@@ -423,7 +422,7 @@ export class BlockbookAPI extends EventEmitter {
         return { subscribed: false };
     }
 
-    dispose() {
+    private onClose() {
         if (this.pingTimeout) {
             clearTimeout(this.pingTimeout);
         }
@@ -438,7 +437,10 @@ export class BlockbookAPI extends EventEmitter {
         if (ws) {
             ws.removeAllListeners();
         }
+    }
 
+    dispose() {
+        this.onClose();
         this.removeAllListeners();
     }
 }

--- a/packages/coinjoin/src/backend/CoinjoinBackend.ts
+++ b/packages/coinjoin/src/backend/CoinjoinBackend.ts
@@ -69,11 +69,7 @@ export class CoinjoinBackend extends EventEmitter {
         this.settings = Object.freeze(settings);
         this.network = getNetwork(settings.network);
         this.client = new CoinjoinBackendClient({ ...settings, logger: this.getLogger() });
-
-        this.mempool =
-            settings.network === 'btc' // mempool scanning is temporarily turned off for mainnet
-                ? undefined
-                : new CoinjoinMempoolController(this.client);
+        this.mempool = new CoinjoinMempoolController(this.client);
     }
 
     scanAccount({ descriptor, progressHandle, checkpoints, cache }: ScanAccountParams) {

--- a/packages/coinjoin/src/backend/CoinjoinBackend.ts
+++ b/packages/coinjoin/src/backend/CoinjoinBackend.ts
@@ -8,6 +8,7 @@ import { scanAccount } from './scanAccount';
 import { scanAddress } from './scanAddress';
 import { getAccountInfo } from './getAccountInfo';
 import { createPendingTransaction } from './createPendingTx';
+import { isTaprootTx } from './backendUtils';
 import { getNetwork } from '../utils/settingsUtils';
 import type { CoinjoinBackendSettings, LogEvent, Logger, LogLevel } from '../types';
 import type {
@@ -69,7 +70,10 @@ export class CoinjoinBackend extends EventEmitter {
         this.settings = Object.freeze(settings);
         this.network = getNetwork(settings.network);
         this.client = new CoinjoinBackendClient({ ...settings, logger: this.getLogger() });
-        this.mempool = new CoinjoinMempoolController(this.client);
+        this.mempool = new CoinjoinMempoolController({
+            client: this.client,
+            filter: tx => isTaprootTx(tx, this.network),
+        });
     }
 
     scanAccount({ descriptor, progressHandle, checkpoints, cache }: ScanAccountParams) {

--- a/packages/coinjoin/src/backend/CoinjoinBackend.ts
+++ b/packages/coinjoin/src/backend/CoinjoinBackend.ts
@@ -149,6 +149,11 @@ export class CoinjoinBackend extends EventEmitter {
         this.abortController?.abort();
     }
 
+    disable() {
+        this.abortController?.abort();
+        this.mempool.stop();
+    }
+
     private getCheckpoints(checkpoints?: ScanAccountCheckpoint[]): ScanAccountCheckpoint[];
     private getCheckpoints(checkpoints?: ScanAddressCheckpoint[]): ScanAddressCheckpoint[];
     private getCheckpoints(checkpoints: any[] = []) {

--- a/packages/coinjoin/src/backend/CoinjoinMempoolController.ts
+++ b/packages/coinjoin/src/backend/CoinjoinMempoolController.ts
@@ -1,40 +1,59 @@
-import { isNotUndefined, promiseAllSequence } from '@trezor/utils';
+/* eslint no-underscore-dangle: ["error", { "allowAfterThis": true }] */
 
 import type { BlockbookTransaction, MempoolClient } from '../types/backend';
 import { doesTxContainAddress } from './backendUtils';
 
+type MempoolStatus = 'stopped' | 'running';
+
 export type MempoolController = {
+    get status(): MempoolStatus;
+    start(): Promise<void>;
     update(): Promise<void>;
     getTransactions(addresses: string[]): BlockbookTransaction[];
 };
 
 export class CoinjoinMempoolController implements MempoolController {
     private readonly client;
-    private mempool: { [txid: string]: BlockbookTransaction };
+    private readonly mempool;
+    private readonly onTx;
+    private _status: MempoolStatus;
+
+    get status() {
+        return this._status;
+    }
 
     constructor(client: MempoolClient) {
         this.client = client;
-        this.mempool = {};
+        this.mempool = new Map<string, BlockbookTransaction>();
+        this.onTx = (tx: BlockbookTransaction) => this.mempool.set(tx.txid, tx);
+        this._status = 'stopped';
+    }
+
+    async start() {
+        if (this._status === 'running') return;
+        await this.client.subscribeMempoolTxs(this.onTx);
+        this._status = 'running';
+    }
+
+    async stop() {
+        if (this._status === 'stopped') return;
+        await this.client.unsubscribeMempoolTxs(this.onTx);
+        this._status = 'stopped';
     }
 
     async update() {
-        const txids = await this.client.fetchMempoolTxids();
-        const entries = await promiseAllSequence(
-            txids.map(
-                txid => () =>
-                    this.mempool[txid]
-                        ? Promise.resolve(this.mempool[txid])
-                        : this.client.fetchTransaction(txid).catch(() => undefined),
-            ),
-        )
-            .then(txs => txs.filter(isNotUndefined)) // Failed fetchTransaction could be ignored
-            .then(txs => txs.map(tx => [tx.txid, tx] as const));
-        this.mempool = Object.fromEntries(entries);
+        const mempoolTxids = await this.client.fetchMempoolTxids();
+        const keepTxids = mempoolTxids.filter(txid => this.mempool.has(txid));
+        const removeTxids = Array.from(this.mempool.keys()).filter(
+            txid => !keepTxids.includes(txid),
+        );
+        removeTxids.forEach(txid => this.mempool.delete(txid));
     }
 
-    getTransactions(addresses: string[]) {
-        return Object.values(this.mempool).filter(tx =>
-            addresses.some(address => doesTxContainAddress(address)(tx)),
-        );
+    getTransactions(addresses?: string[]) {
+        const txs = Array.from(this.mempool.values());
+        return !addresses
+            ? txs
+            : txs.filter(tx => addresses.some(address => doesTxContainAddress(address)(tx)));
     }
 }

--- a/packages/coinjoin/src/backend/CoinjoinWebsocketController.ts
+++ b/packages/coinjoin/src/backend/CoinjoinWebsocketController.ts
@@ -20,7 +20,7 @@ export class CoinjoinWebsocketController {
         this.logger = logger;
     }
 
-    async getOrCreate(url: string, identity = this.defaultIdentity): Promise<BlockbookWS> {
+    async getOrCreate(url: string, identity = this.defaultIdentity): Promise<BlockbookAPI> {
         const socketId = this.getSocketId(url, identity);
         let socket = this.sockets[socketId];
         if (!socket) {
@@ -31,13 +31,11 @@ export class CoinjoinWebsocketController {
             this.sockets[socketId] = socket;
         }
         if (!socket.isConnected()) {
-            this.logger?.log(`WS OPEN ${socketId}`);
             await socket.connect();
-            const onDisconnected = () => {
+            this.logger?.log(`WS OPENED ${socketId}`);
+            socket.once('disconnected', () => {
                 this.logger?.log(`WS CLOSED ${socketId}`);
-                socket.off('disconnected', onDisconnected);
-            };
-            socket.on('disconnected', onDisconnected);
+            });
         }
         return socket;
     }

--- a/packages/coinjoin/src/backend/scanAccount.ts
+++ b/packages/coinjoin/src/backend/scanAccount.ts
@@ -118,7 +118,11 @@ export const scanAccount = async (
 
     let pending: Transaction[] = [];
     if (mempool) {
-        await mempool.update();
+        if (mempool.status === 'stopped') {
+            await mempool.start();
+        } else {
+            await mempool.update();
+        }
 
         pending = mempool
             .getTransactions(receive.concat(change).map(({ address }) => address))

--- a/packages/coinjoin/src/backend/scanAddress.ts
+++ b/packages/coinjoin/src/backend/scanAddress.ts
@@ -40,7 +40,11 @@ export const scanAddress = async (
     let pending: Transaction[] = [];
 
     if (mempool) {
-        await mempool.update();
+        if (mempool.status === 'stopped') {
+            await mempool.start();
+        } else {
+            await mempool.update();
+        }
 
         pending = mempool
             .getTransactions([address])

--- a/packages/coinjoin/src/types/backend.ts
+++ b/packages/coinjoin/src/types/backend.ts
@@ -132,7 +132,10 @@ export interface FilterController {
 
 export type FilterClient = Pick<CoinjoinBackendClient, 'fetchFilters'>;
 
-export type MempoolClient = Pick<CoinjoinBackendClient, 'fetchMempoolTxids' | 'fetchTransaction'>;
+export type MempoolClient = Pick<
+    CoinjoinBackendClient,
+    'fetchMempoolTxids' | 'fetchTransaction' | 'subscribeMempoolTxs' | 'unsubscribeMempoolTxs'
+>;
 
 export type AddressInfo = AccountInfoBase & {
     history: AccountInfoBase['history'] & {

--- a/packages/coinjoin/tests/backend/CoinjoinMempoolController.test.ts
+++ b/packages/coinjoin/tests/backend/CoinjoinMempoolController.test.ts
@@ -12,7 +12,7 @@ describe('CoinjoinMempoolController', () => {
 
     beforeEach(() => {
         client.clear();
-        mempool = new CoinjoinMempoolController(client);
+        mempool = new CoinjoinMempoolController({ client });
     });
 
     it('All at once', async () => {
@@ -48,5 +48,15 @@ describe('CoinjoinMempoolController', () => {
         client.setMempoolTxs([TXS[0], TXS[1]]);
         await mempool.update();
         expect(mempool.getTransactions()).toEqual([]);
+    });
+
+    it('Filtering', async () => {
+        mempool = new CoinjoinMempoolController({
+            client,
+            filter: ({ txid }) => ['txid_2', 'txid_4', 'txid_5'].includes(txid),
+        });
+        await mempool.start();
+        TXS.forEach(client.fireTx.bind(client));
+        expect(mempool.getTransactions()).toEqual([TXS[1], TXS[3], TXS[4]]);
     });
 });

--- a/packages/coinjoin/tests/backend/backendUtils.test.ts
+++ b/packages/coinjoin/tests/backend/backendUtils.test.ts
@@ -1,10 +1,22 @@
-import { deriveAddresses as deriveAddressesOriginal } from '@trezor/utxo-lib';
+import { deriveAddresses as deriveAddressesOriginal, networks } from '@trezor/utxo-lib';
 
-import { deriveAddresses } from '../../src/backend/backendUtils';
-import { SEGWIT_XPUB } from '../fixtures/methods.fixture';
+import { deriveAddresses, isTaprootTx, doesTxContainAddress } from '../../src/backend/backendUtils';
+import { SEGWIT_XPUB, SEGWIT_RECEIVE_ADDRESSES } from '../fixtures/methods.fixture';
 
 const PARAMS = [SEGWIT_XPUB, 'receive', 0, 10] as const;
 const ADDRESSES = deriveAddressesOriginal(...PARAMS);
+
+const TAPROOT_ADDRESS = 'bcrt1pswrqtykue8r89t9u4rprjs0gt4qzkdfuursfnvqaa3f2yql07zmq2fdmpx';
+
+const NON_TAPROOT_TX = {
+    vin: [{ addresses: SEGWIT_RECEIVE_ADDRESSES.slice(1, 3) }, {}, { addresses: [] }],
+    vout: [{ addresses: [SEGWIT_RECEIVE_ADDRESSES[0]] }],
+};
+
+const TAPROOT_TX = {
+    ...NON_TAPROOT_TX,
+    vout: [{ addresses: [TAPROOT_ADDRESS] }, ...NON_TAPROOT_TX.vout],
+};
 
 describe('backendUtils', () => {
     describe('deriveAddresses', () => {
@@ -36,6 +48,26 @@ describe('backendUtils', () => {
             expect(deriveAddresses(ADDRESSES.slice(0, 5), SEGWIT_XPUB, 'receive', 3, 5)).toEqual(
                 ADDRESSES.slice(3, 8),
             );
+        });
+    });
+
+    describe('isTaprootTx', () => {
+        it('taproot tx', () => {
+            expect(isTaprootTx(TAPROOT_TX, networks.regtest)).toBe(true);
+        });
+
+        it('non-taproot tx', () => {
+            expect(isTaprootTx(NON_TAPROOT_TX, networks.regtest)).toBe(false);
+        });
+    });
+
+    describe('doesTxContainAddress', () => {
+        it('containing', () => {
+            expect(doesTxContainAddress(TAPROOT_ADDRESS)(TAPROOT_TX)).toBe(true);
+        });
+
+        it('not containing', () => {
+            expect(doesTxContainAddress(TAPROOT_ADDRESS)(NON_TAPROOT_TX)).toBe(false);
         });
     });
 });

--- a/packages/coinjoin/tests/backend/methods.test.ts
+++ b/packages/coinjoin/tests/backend/methods.test.ts
@@ -26,7 +26,6 @@ describe(`CoinjoinBackend methods`, () => {
     const client = new MockBackendClient();
     const fetchFiltersMock = jest.spyOn(client, 'fetchFilters');
     const fetchBlockMock = jest.spyOn(client, 'fetchBlock');
-    const fetchTxMock = jest.spyOn(client, 'fetchTransaction');
 
     const getRequestedFilters = () =>
         Promise.all(fetchFiltersMock.mock.results.map(res => res.value)).then(
@@ -38,12 +37,6 @@ describe(`CoinjoinBackend methods`, () => {
 
     const getRequestedBlocks = () =>
         fetchBlockMock.mock.calls
-            .map(call => call[0])
-            .filter(arrayDistinct)
-            .sort();
-
-    const getRequestedTxs = () =>
-        fetchTxMock.mock.calls
             .map(call => call[0])
             .filter(arrayDistinct)
             .sort();
@@ -63,7 +56,6 @@ describe(`CoinjoinBackend methods`, () => {
     beforeEach(() => {
         fetchFiltersMock.mockClear();
         fetchBlockMock.mockClear();
-        fetchTxMock.mockClear();
         client.setFixture(FIXTURES.BLOCKS);
     });
 
@@ -160,11 +152,6 @@ describe(`CoinjoinBackend methods`, () => {
         expect(halfBlocks).toEqual([1, 2, 4]);
         fetchBlockMock.mockClear();
 
-        // Should request only txid_4 transaction from mempool
-        const halfTxs = getRequestedTxs();
-        expect(halfTxs).toEqual([FIXTURES.TX_4_PENDING.txid]);
-        fetchTxMock.mockClear();
-
         // All blocks are known
         client.setFixture(FIXTURES.BLOCKS);
 
@@ -194,10 +181,6 @@ describe(`CoinjoinBackend methods`, () => {
         // Should request only blocks after the fourth one (except the fifth which is empty)
         const restBlocks = getRequestedBlocks();
         expect(restBlocks).toEqual([6, 7, 8]);
-
-        // Shouldn't request any transaction from mempool
-        const restTxs = getRequestedTxs();
-        expect(restTxs).toEqual([]);
     });
 
     it('scanAccount 1-block reorg', async () => {

--- a/packages/coinjoin/tests/backend/methods.test.ts
+++ b/packages/coinjoin/tests/backend/methods.test.ts
@@ -48,7 +48,7 @@ describe(`CoinjoinBackend methods`, () => {
             baseBlockHash: FIXTURES.BASE_HASH,
             baseBlockHeight: FIXTURES.BASE_HEIGHT,
         }),
-        mempool: new CoinjoinMempoolController(client),
+        mempool: new CoinjoinMempoolController({ client }),
         network: networks.regtest,
         onProgress,
     });

--- a/packages/coinjoin/tests/mocks/MockBackendClient.ts
+++ b/packages/coinjoin/tests/mocks/MockBackendClient.ts
@@ -1,3 +1,5 @@
+import type { Transaction } from '@trezor/blockchain-link-types/lib/blockbook';
+
 import { CoinjoinBackendClient } from '../../src/backend/CoinjoinBackendClient';
 import { COINJOIN_BACKEND_SETTINGS } from '../fixtures/config.fixture';
 import type { BlockbookWS } from '../../src/backend/CoinjoinWebsocketController';
@@ -90,5 +92,10 @@ export class MockBackendClient extends CoinjoinBackendClient {
             // no default
         }
         throw new Error('not found');
+    }
+
+    subscribeMempoolTxs(listener: (tx: Transaction) => void) {
+        this.mempool.forEach(tx => listener(tx as Transaction));
+        return Promise.resolve();
     }
 }

--- a/packages/suite-desktop/src/modules/coinjoin.ts
+++ b/packages/suite-desktop/src/modules/coinjoin.ts
@@ -133,7 +133,7 @@ export const init: Module = ({ mainWindow }) => {
         );
 
         const dispose = () => {
-            backends.forEach(b => b.cancel());
+            backends.forEach(b => b.disable());
             backends.splice(0, backends.length);
 
             clients.forEach(cli => {

--- a/packages/suite/src/services/coinjoin/coinjoinService.ts
+++ b/packages/suite/src/services/coinjoin/coinjoinService.ts
@@ -51,7 +51,7 @@ export class CoinjoinService {
     static removeInstance(network: NetworkSymbol) {
         const instance = this.instances[network];
         if (instance) {
-            instance.backend.cancel();
+            instance.backend.disable();
             instance.client.disable();
             delete this.instances[network];
         }


### PR DESCRIPTION
## Description

Using new blockbook's feature to subscribe to all added mempool transactions via websocket, which finally allows to enable mempool on mainnet CJ accounts.

## Commits

https://github.com/trezor/trezor-suite/pull/7817/commits/9defd15ebf77cc7c760c412e6555907d0c5052e3 - allows to reconnect to websocket right after `disconnected` event was emitted. Before that, disposing was in progress even after that event, and moreover, it unsubscribed all event listeners at the end. Now, event listeners are unsubscribed only when `dispose` is explicitly called from outside.

https://github.com/trezor/trezor-suite/pull/7817/commits/d039c8764e265d80d014e319486f839497be8e38 - changed `CoinjoinMempoolController` logic so it's started when used for the first time, subscribes to the mempool transactions, and whenever `update` is called during every consecutive sync, transactions with txid not in wabisabi `mempool-hashes` response are discarded. Moreover, `CoinjoinBackendClient` tries to keep the websocket still opened & subscribed and reconnects immediately after any problem.

https://github.com/trezor/trezor-suite/pull/7817/commits/56ac81bc462a6d77af7345014d70df86ff277fed - unit tests are adjusted to the new changes

https://github.com/trezor/trezor-suite/pull/7817/commits/86ea3ce96dcd25c03cc8eb3741f0578b8bb1e396 - mempool reallowed for mainnet CJ accounts

https://github.com/trezor/trezor-suite/pull/7817/commits/b9fa56b497708e7a1c6254be99c789df494a9cf5 - transactions without any taproot address on either input or output are immediately discarded as they're not useful for CJ account

https://github.com/trezor/trezor-suite/pull/7817/commits/36d3e8b032ceda18b386d4f3726819c622a0a3c5 - unit tests adjusted to taproot filtering

https://github.com/trezor/trezor-suite/pull/7817/commits/a09e5289177f5b3b0a30955665d5d5c5a04cbc45 - logging stuff, **REMOVE BEFORE MERGING**


