### PR TITLE
Fix `removeTransaction` action bug

### DIFF
--- a/packages/suite/src/reducers/wallet/__tests__/transactionReducer.test.ts
+++ b/packages/suite/src/reducers/wallet/__tests__/transactionReducer.test.ts
@@ -71,6 +71,25 @@ describe('transaction reducer', () => {
         });
     });
 
+    it('remove transactions (incl. nonexistent)', () => {
+        const account = testAccounts[0];
+        const [tx1, tx2] = testTransactions[account.key];
+        const txsToRemove = [
+            tx2,
+            { ...tx1, txid: 'deadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeef' },
+        ];
+
+        expect(
+            reducer(
+                { ...transactionsInitialState, transactions: testTransactions },
+                {
+                    type: transactionsActions.removeTransaction.type,
+                    payload: { account, txs: txsToRemove },
+                },
+            ).transactions[account.key],
+        ).toEqual([tx1]);
+    });
+
     it('add transactions', () => {
         const account = testAccounts[0];
         const { key } = account;

--- a/suite-common/wallet-core/src/transactions/transactionsReducer.ts
+++ b/suite-common/wallet-core/src/transactions/transactionsReducer.ts
@@ -79,11 +79,10 @@ export const prepareTransactionsReducer = createReducerWithExtraDeps(
             })
             .addCase(transactionsActions.removeTransaction, (state, { payload }) => {
                 const { account, txs } = payload;
-                const transactions = state.transactions[account.key] || [];
-                txs.forEach(tx => {
-                    const index = transactions.findIndex(t => t.txid === tx.txid);
-                    transactions.splice(index, 1);
-                });
+                const transactions = state.transactions[account.key];
+                state.transactions[account.key] = transactions?.filter(
+                    tx => !txs.some(t => t.txid === tx.txid),
+                );
             })
             .addCase(transactionsActions.addTransaction, (state, { payload }) => {
                 const { transactions, account, page, perPage } = payload;


### PR DESCRIPTION
## Description

Fixes ancient bug where `removeTransaction` action removes unrelated transactions from the end of array when asked for removal of non-existent transactions (see `array.splice(-1, 1)`).