### PR TITLE
Fix of 1-block reorg on CJ account

### DIFF
--- a/packages/suite/src/actions/wallet/coinjoinAccountActions.ts
+++ b/packages/suite/src/actions/wallet/coinjoinAccountActions.ts
@@ -238,7 +238,12 @@ const coinjoinAccountCheckReorg =
     (dispatch: Dispatch, getState: GetState) => {
         const state = getState();
         const previousCheckpoint = selectCoinjoinAccountByKey(state, account.key)?.checkpoints?.[0];
-        if (previousCheckpoint && checkpoint.blockHeight < previousCheckpoint.blockHeight) {
+        if (!previousCheckpoint) return;
+        if (
+            checkpoint.blockHeight < previousCheckpoint.blockHeight ||
+            (checkpoint.blockHeight === previousCheckpoint.blockHeight &&
+                checkpoint.blockHash !== previousCheckpoint.blockHash)
+        ) {
             const txs = getAccountTransactions(
                 account.key,
                 state.wallet.transactions.transactions,


### PR DESCRIPTION
## Description

When reorg happens, CJ account should throw away all affected transactions. Until now it happened only when new checkpoint was 'older' (= smaller block height) than the best known checkpoint. Now it should work even when the new checkpoint has the same block height but different block hash (= 1-block reorg).

## Commits

https://github.com/trezor/trezor-suite/commit/c4d120a12d60de4107d6ac5d37e0b7d119b65c5a - `scanAccount` unit test added which checks whether new checkpoint is emitted when reorg happens
https://github.com/trezor/trezor-suite/commit/367db6b82fb21aaf0c734e99145e4908291466d0 - changed condition for transaction reorg