### PR TITLE
chore(blockchain-link-types): use generated types from blockbook

### DIFF
--- a/packages/blockchain-link-types/src/blockbook-api.ts
+++ b/packages/blockchain-link-types/src/blockbook-api.ts
@@ -1,0 +1,407 @@
+/* Do not change, this code is generated from Golang structs */
+
+export interface APIError {
+    Text: string;
+    Public: boolean;
+}
+export interface AddressAlias {
+    Type: string;
+    Alias: string;
+}
+export interface EthereumInternalTransfer {
+    type: number;
+    from: string;
+    to: string;
+    value?: string;
+}
+export interface EthereumParsedInputParam {
+    type: string;
+    values?: string[];
+}
+export interface EthereumParsedInputData {
+    methodId: string;
+    name: string;
+    function?: string;
+    params?: EthereumParsedInputParam[];
+}
+export interface EthereumSpecific {
+    type?: number;
+    createdContract?: string;
+    status: number;
+    error?: string;
+    nonce: number;
+    gasLimit?: string;
+    gasUsed?: string;
+    gasPrice?: string;
+    data?: string;
+    parsedData?: EthereumParsedInputData;
+    internalTransfers?: EthereumInternalTransfer[];
+}
+export interface MultiTokenValue {
+    id?: string;
+    value?: string;
+}
+export interface TokenTransfer {
+    type: string;
+    from: string;
+    to: string;
+    contract: string;
+    name: string;
+    symbol: string;
+    decimals: number;
+    value?: string;
+    multiTokenValues?: MultiTokenValue[];
+}
+export interface Vout {
+    value?: string;
+    n: number;
+    spent?: boolean;
+    spentTxId?: string;
+    spentIndex?: number;
+    spentHeight?: number;
+    hex?: string;
+    asm?: string;
+    addresses: string[];
+    isAddress: boolean;
+    isOwn?: boolean;
+    type?: string;
+}
+export interface Vin {
+    txid?: string;
+    vout?: number;
+    sequence?: number;
+    n: number;
+    addresses?: string[];
+    isAddress: boolean;
+    isOwn?: boolean;
+    value?: string;
+    hex?: string;
+    asm?: string;
+    coinbase?: string;
+}
+export interface Tx {
+    txid: string;
+    version?: number;
+    lockTime?: number;
+    vin: Vin[];
+    vout: Vout[];
+    blockHash?: string;
+    blockHeight: number;
+    confirmations: number;
+    confirmationETABlocks?: number;
+    confirmationETASeconds?: number;
+    blockTime: number;
+    size?: number;
+    vsize?: number;
+    value?: string;
+    valueIn?: string;
+    fees?: string;
+    hex?: string;
+    rbf?: boolean;
+    coinSpecificData?: any;
+    tokenTransfers?: TokenTransfer[];
+    ethereumSpecific?: EthereumSpecific;
+    addressAliases?: { [key: string]: AddressAlias };
+}
+export interface FeeStats {
+    txCount: number;
+    totalFeesSat?: string;
+    averageFeePerKb: number;
+    decilesFeePerKb: number[];
+}
+export interface ContractInfo {
+    type: string;
+    contract: string;
+    name: string;
+    symbol: string;
+    decimals: number;
+    createdInBlock?: number;
+    destructedInBlock?: number;
+}
+export interface Token {
+    type: 'XPUBAddress' | 'ERC20' | 'ERC721' | 'ERC1155';
+    name: string;
+    path?: string;
+    contract?: string;
+    transfers: number;
+    symbol?: string;
+    decimals?: number;
+    balance?: string;
+    baseValue?: number;
+    secondaryValue?: number;
+    ids?: string[];
+    multiTokenValues?: MultiTokenValue[];
+    totalReceived?: string;
+    totalSent?: string;
+}
+export interface Address {
+    page?: number;
+    totalPages?: number;
+    itemsOnPage?: number;
+    address: string;
+    balance?: string;
+    totalReceived?: string;
+    totalSent?: string;
+    unconfirmedBalance?: string;
+    unconfirmedTxs: number;
+    txs: number;
+    nonTokenTxs?: number;
+    internalTxs?: number;
+    transactions?: Tx[];
+    txids?: string[];
+    nonce?: string;
+    usedTokens?: number;
+    tokens?: Token[];
+    secondaryValue?: number;
+    tokensBaseValue?: number;
+    tokensSecondaryValue?: number;
+    totalBaseValue?: number;
+    totalSecondaryValue?: number;
+    contractInfo?: ContractInfo;
+    erc20Contract?: ContractInfo;
+    addressAliases?: { [key: string]: AddressAlias };
+}
+export interface Utxo {
+    txid: string;
+    vout: number;
+    value?: string;
+    height?: number;
+    confirmations: number;
+    address?: string;
+    path?: string;
+    lockTime?: number;
+    coinbase?: boolean;
+}
+export interface BalanceHistory {
+    time: number;
+    txs: number;
+    received?: string;
+    sent?: string;
+    sentToSelf?: string;
+    rates?: { [key: string]: number };
+    txid?: string;
+}
+export interface BlockInfo {
+    Hash: string;
+    Time: number;
+    Txs: number;
+    Size: number;
+    Height: number;
+}
+export interface Blocks {
+    page?: number;
+    totalPages?: number;
+    itemsOnPage?: number;
+    blocks: BlockInfo[];
+}
+export interface Block {
+    page?: number;
+    totalPages?: number;
+    itemsOnPage?: number;
+    hash: string;
+    previousBlockHash?: string;
+    nextBlockHash?: string;
+    height: number;
+    confirmations: number;
+    size: number;
+    time?: number;
+    version: string;
+    merkleRoot: string;
+    nonce: string;
+    bits: string;
+    difficulty: string;
+    tx?: string[];
+    txCount: number;
+    txs?: Tx[];
+    addressAliases?: { [key: string]: AddressAlias };
+}
+export interface BlockRaw {
+    hex: string;
+}
+export interface BackendInfo {
+    error?: string;
+    chain?: string;
+    blocks?: number;
+    headers?: number;
+    bestBlockHash?: string;
+    difficulty?: string;
+    sizeOnDisk?: number;
+    version?: string;
+    subversion?: string;
+    protocolVersion?: string;
+    timeOffset?: number;
+    warnings?: string;
+    consensus_version?: string;
+    consensus?: any;
+}
+export interface InternalStateColumn {
+    name: string;
+    version: number;
+    rows: number;
+    keyBytes: number;
+    valueBytes: number;
+    updated: string;
+}
+export interface BlockbookInfo {
+    coin: string;
+    host: string;
+    version: string;
+    gitCommit: string;
+    buildTime: string;
+    syncMode: boolean;
+    initialSync: boolean;
+    inSync: boolean;
+    bestHeight: number;
+    lastBlockTime: string;
+    inSyncMempool: boolean;
+    lastMempoolTime: string;
+    mempoolSize: number;
+    decimals: number;
+    dbSize: number;
+    hasFiatRates?: boolean;
+    hasTokenFiatRates?: boolean;
+    currentFiatRatesTime?: string;
+    historicalFiatRatesTime?: string;
+    historicalTokenFiatRatesTime?: string;
+    dbSizeFromColumns?: number;
+    dbColumns?: InternalStateColumn[];
+    about: string;
+}
+export interface SystemInfo {
+    blockbook?: BlockbookInfo;
+    backend?: BackendInfo;
+}
+export interface FiatTicker {
+    ts?: number;
+    rates: { [key: string]: number };
+    error?: string;
+}
+export interface FiatTickers {
+    tickers: FiatTicker[];
+}
+export interface AvailableVsCurrencies {
+    ts?: number;
+    available_currencies: string[];
+    error?: string;
+}
+export interface WsReq {
+    id: string;
+    method:
+        | 'getAccountInfo'
+        | 'getInfo'
+        | 'getBlockHash'
+        | 'getAccountUtxo'
+        | 'getBalanceHistory'
+        | 'getTransaction'
+        | 'getTransactionSpecific'
+        | 'estimateFee'
+        | 'sendTransaction'
+        | 'subscribeNewBlock'
+        | 'unsubscribeNewBlock'
+        | 'subscribeNewTransaction'
+        | 'unsubscribeNewTransaction'
+        | 'subscribeAddresses'
+        | 'unsubscribeAddresses'
+        | 'subscribeFiatRates'
+        | 'unsubscribeFiatRates'
+        | 'ping'
+        | 'getCurrentFiatRates'
+        | 'getFiatRatesForTimestamps'
+        | 'getFiatRatesTickersList';
+    params: any;
+}
+export interface WsRes {
+    id: string;
+    data: any;
+}
+export interface WsAccountInfoReq {
+    descriptor: string;
+    details?: 'basic' | 'tokens' | 'tokenBalances' | 'txids' | 'txslight' | 'txs';
+    tokens?: 'derived' | 'used' | 'nonzero';
+    pageSize?: number;
+    page?: number;
+    from?: number;
+    to?: number;
+    contractFilter?: string;
+    secondaryCurrency?: string;
+    gap?: number;
+}
+export interface WsBackendInfo {
+    version?: string;
+    subversion?: string;
+    consensus_version?: string;
+    consensus?: any;
+}
+export interface WsInfoRes {
+    name: string;
+    shortcut: string;
+    decimals: number;
+    version: string;
+    bestHeight: number;
+    bestHash: string;
+    block0Hash: string;
+    testnet: boolean;
+    backend: WsBackendInfo;
+}
+export interface WsBlockHashReq {
+    height: number;
+}
+export interface WsBlockHashRes {
+    hash: string;
+}
+export interface WsAccountUtxoReq {
+    descriptor: string;
+}
+export interface WsBalanceHistoryReq {
+    descriptor: string;
+    from?: number;
+    to?: number;
+    currencies?: string[];
+    gap?: number;
+    groupBy?: number;
+}
+export interface WsTransactionReq {
+    txid: string;
+}
+export interface WsTransactionSpecificReq {
+    txid: string;
+}
+export interface WsEstimateFeeReq {
+    blocks?: number[];
+    specific?: {
+        conservative?: boolean;
+        txsize?: number;
+        from?: string;
+        to?: string;
+        data?: string;
+        value?: string;
+    };
+}
+export interface WsEstimateFeeRes {
+    feePerTx?: string;
+    feePerUnit?: string;
+    feeLimit?: string;
+}
+export interface WsSendTransactionReq {
+    hex: string;
+}
+export interface WsSubscribeAddressesReq {
+    addresses: string[];
+}
+export interface WsSubscribeFiatRatesReq {
+    currency?: string;
+    tokens?: string[];
+}
+export interface WsCurrentFiatRatesReq {
+    currencies?: string[];
+    token?: string;
+}
+export interface WsFiatRatesForTimestampsReq {
+    timestamps: number[];
+    currencies?: string[];
+    token?: string;
+}
+export interface WsFiatRatesTickersListReq {
+    timestamp?: number;
+    token?: string;
+}

--- a/packages/blockchain-link-types/src/blockbook-api.ts
+++ b/packages/blockchain-link-types/src/blockbook-api.ts
@@ -38,8 +38,8 @@ export interface EthereumSpecific {
     internalTransfers?: EthereumInternalTransfer[];
 }
 export interface MultiTokenValue {
-    id?: string;
-    value?: string;
+    id: string; // changed manually. originally id?: string
+    value: string; // changed manually. originaly value?: string
 }
 export interface TokenTransfer {
     type: string;

--- a/packages/blockchain-link-types/src/blockbook-api.ts
+++ b/packages/blockchain-link-types/src/blockbook-api.ts
@@ -12,7 +12,7 @@ export interface EthereumInternalTransfer {
     type: number;
     from: string;
     to: string;
-    value?: string;
+    value: string;
 }
 export interface EthereumParsedInputParam {
     type: string;
@@ -30,16 +30,16 @@ export interface EthereumSpecific {
     status: number;
     error?: string;
     nonce: number;
-    gasLimit?: string;
-    gasUsed?: string;
-    gasPrice?: string;
+    gasLimit: number;
+    gasUsed?: number;
+    gasPrice: string;
     data?: string;
     parsedData?: EthereumParsedInputData;
     internalTransfers?: EthereumInternalTransfer[];
 }
 export interface MultiTokenValue {
-    id: string; // changed manually. originally id?: string
-    value: string; // changed manually. originaly value?: string
+    id?: string;
+    value?: string;
 }
 export interface TokenTransfer {
     type: string;
@@ -93,7 +93,7 @@ export interface Tx {
     blockTime: number;
     size?: number;
     vsize?: number;
-    value?: string;
+    value: string;
     valueIn?: string;
     fees?: string;
     hex?: string;
@@ -105,7 +105,7 @@ export interface Tx {
 }
 export interface FeeStats {
     txCount: number;
-    totalFeesSat?: string;
+    totalFeesSat: string;
     averageFeePerKb: number;
     decilesFeePerKb: number[];
 }
@@ -139,10 +139,10 @@ export interface Address {
     totalPages?: number;
     itemsOnPage?: number;
     address: string;
-    balance?: string;
+    balance: string;
     totalReceived?: string;
     totalSent?: string;
-    unconfirmedBalance?: string;
+    unconfirmedBalance: string;
     unconfirmedTxs: number;
     txs: number;
     nonTokenTxs?: number;
@@ -164,7 +164,7 @@ export interface Address {
 export interface Utxo {
     txid: string;
     vout: number;
-    value?: string;
+    value: string;
     height?: number;
     confirmations: number;
     address?: string;
@@ -175,9 +175,9 @@ export interface Utxo {
 export interface BalanceHistory {
     time: number;
     txs: number;
-    received?: string;
-    sent?: string;
-    sentToSelf?: string;
+    received: string;
+    sent: string;
+    sentToSelf: string;
     rates?: { [key: string]: number };
     txid?: string;
 }
@@ -268,8 +268,8 @@ export interface BlockbookInfo {
     about: string;
 }
 export interface SystemInfo {
-    blockbook?: BlockbookInfo;
-    backend?: BackendInfo;
+    blockbook: BlockbookInfo;
+    backend: BackendInfo;
 }
 export interface FiatTicker {
     ts?: number;
@@ -290,6 +290,7 @@ export interface WsReq {
         | 'getAccountInfo'
         | 'getInfo'
         | 'getBlockHash'
+        | 'getBlock'
         | 'getAccountUtxo'
         | 'getBalanceHistory'
         | 'getTransaction'
@@ -348,6 +349,11 @@ export interface WsBlockHashReq {
 }
 export interface WsBlockHashRes {
     hash: string;
+}
+export interface WsBlockReq {
+    id: string;
+    pageSize?: number;
+    page?: number;
 }
 export interface WsAccountUtxoReq {
     descriptor: string;

--- a/packages/blockchain-link-types/src/blockbook.ts
+++ b/packages/blockchain-link-types/src/blockbook.ts
@@ -11,6 +11,7 @@ import {
     Vin,
     Vout,
     Utxo as BlockbookUtxo,
+    WsInfoRes,
 } from './blockbook-api';
 
 type OptionalKey<M, K extends keyof M> = Omit<M, K> & Partial<Pick<M, K>>;
@@ -22,24 +23,7 @@ export interface Subscribe {
     subscribed: boolean;
 }
 
-export interface ServerInfo {
-    bestHash: string;
-    bestHeight: number;
-    block0Hash: string;
-    decimals: number;
-    name: string;
-    shortcut: string;
-    testnet: boolean;
-    version: string;
-    backend?: {
-        subversion: string;
-        version: string;
-        consensus?: {
-            chaintip: string;
-            nextblock: string;
-        };
-    };
-}
+export type ServerInfo = WsInfoRes;
 
 export interface BlockHash {
     hash: string;

--- a/packages/blockchain-link-types/src/blockbook.ts
+++ b/packages/blockchain-link-types/src/blockbook.ts
@@ -7,6 +7,12 @@ import type {
     AccountInfoParams,
 } from './params';
 import type { AccountBalanceHistory, FiatRates, TokenStandard } from './common';
+import {
+    Vin,
+    Vout,
+} from './blockbook-api';
+
+type OptionalKey<M, K extends keyof M> = Omit<M, K> & Partial<Pick<M, K>>;
 
 export interface Subscribe {
     subscribed: boolean;
@@ -97,17 +103,7 @@ export type AccountUtxo = {
     coinbase?: boolean;
 }[];
 
-export interface VinVout {
-    n: number;
-    addresses?: string[];
-    isAddress: boolean;
-    value?: string;
-    coinbase?: string;
-    txid?: string;
-    vout?: number;
-    sequence?: number;
-    hex?: string;
-}
+export type VinVout = OptionalKey<Vin & Vout, 'addresses'>;
 
 export interface EthereumInternalTransfer {
     type: number;

--- a/packages/blockchain-link-types/src/blockbook.ts
+++ b/packages/blockchain-link-types/src/blockbook.ts
@@ -13,12 +13,17 @@ import {
     Utxo as BlockbookUtxo,
     WsInfoRes,
     WsBlockHashRes,
+    Block as BlockbookBlock,
 } from './blockbook-api';
 
 type OptionalKey<M, K extends keyof M> = Omit<M, K> & Partial<Pick<M, K>>;
 type RequiredKey<M, K extends keyof M> = Omit<M, K> & Required<Pick<M, K>>;
 
 export type AccountUtxo = RequiredKey<BlockbookUtxo, 'address' | 'height' | 'value' | 'path'>[];
+
+export type Block = Omit<BlockbookBlock, 'txs'> & {
+    txs?: Transaction[];
+};
 
 export interface Subscribe {
     subscribed: boolean;
@@ -27,16 +32,6 @@ export interface Subscribe {
 export type ServerInfo = WsInfoRes;
 
 export type BlockHash = WsBlockHashRes;
-
-export interface Block {
-    page: number;
-    totalPages: number;
-    itemsOnPage: number;
-    hash: string;
-    height: number;
-    txCount: number;
-    txs: Transaction[];
-}
 
 export interface XPUBAddress {
     type: 'XPUBAddress';

--- a/packages/blockchain-link-types/src/blockbook.ts
+++ b/packages/blockchain-link-types/src/blockbook.ts
@@ -16,6 +16,7 @@ import {
     Block as BlockbookBlock,
     Tx as BlockbookTx,
     TokenTransfer as BlockbookTokenTransfer,
+    Token as BlockbookToken,
 } from './blockbook-api';
 
 type OptionalKey<M, K extends keyof M> = Omit<M, K> & Partial<Pick<M, K>>;
@@ -35,6 +36,7 @@ export type ServerInfo = WsInfoRes;
 
 export type BlockHash = WsBlockHashRes;
 
+// XPUBAddress, ERC20,ERC721,ERC1155 - blockbook generated type (Token) is not strict enough
 export interface XPUBAddress {
     type: 'XPUBAddress';
     name: string;
@@ -44,7 +46,6 @@ export interface XPUBAddress {
     totalSent: string;
     totalReceived: string;
 }
-
 export interface ERC20 {
     type: 'ERC20';
     name?: string;
@@ -53,6 +54,12 @@ export interface ERC20 {
     balance?: string;
     decimals?: number;
 }
+export type ERC721 = Omit<BlockbookToken, 'type'> & {
+    type: 'ERC721';
+};
+export type ERC1155 = Omit<BlockbookToken, 'type'> & {
+    type: 'ERC1155';
+};
 
 export interface AccountInfo {
     address: string;
@@ -68,7 +75,7 @@ export interface AccountInfo {
     nonTokenTxs?: number;
     transactions?: Transaction[];
     nonce?: string;
-    tokens?: (XPUBAddress | ERC20)[];
+    tokens?: (XPUBAddress | ERC20 | ERC721 | ERC1155)[];
     erc20Contract?: ERC20;
 }
 

--- a/packages/blockchain-link-types/src/blockbook.ts
+++ b/packages/blockchain-link-types/src/blockbook.ts
@@ -10,9 +10,13 @@ import type { AccountBalanceHistory, FiatRates, TokenStandard } from './common';
 import {
     Vin,
     Vout,
+    Utxo as BlockbookUtxo,
 } from './blockbook-api';
 
 type OptionalKey<M, K extends keyof M> = Omit<M, K> & Partial<Pick<M, K>>;
+type RequiredKey<M, K extends keyof M> = Omit<M, K> & Required<Pick<M, K>>;
+
+export type AccountUtxo = RequiredKey<BlockbookUtxo, 'address' | 'height' | 'value' | 'path'>[];
 
 export interface Subscribe {
     subscribed: boolean;
@@ -91,17 +95,6 @@ export interface AccountInfo {
 export interface AccountUtxoParams {
     descriptor: string;
 }
-
-export type AccountUtxo = {
-    txid: string;
-    vout: number;
-    value: string;
-    height: number;
-    address: string;
-    path: string;
-    confirmations: number;
-    coinbase?: boolean;
-}[];
 
 export type VinVout = OptionalKey<Vin & Vout, 'addresses'>;
 

--- a/packages/blockchain-link-types/src/blockbook.ts
+++ b/packages/blockchain-link-types/src/blockbook.ts
@@ -12,6 +12,7 @@ import {
     Vout,
     Utxo as BlockbookUtxo,
     WsInfoRes,
+    WsBlockHashRes,
 } from './blockbook-api';
 
 type OptionalKey<M, K extends keyof M> = Omit<M, K> & Partial<Pick<M, K>>;
@@ -25,9 +26,7 @@ export interface Subscribe {
 
 export type ServerInfo = WsInfoRes;
 
-export interface BlockHash {
-    hash: string;
-}
+export type BlockHash = WsBlockHashRes;
 
 export interface Block {
     page: number;

--- a/packages/blockchain-link-types/src/blockbook.ts
+++ b/packages/blockchain-link-types/src/blockbook.ts
@@ -14,6 +14,8 @@ import {
     WsInfoRes,
     WsBlockHashRes,
     Block as BlockbookBlock,
+    Tx as BlockbookTx,
+    TokenTransfer as BlockbookTokenTransfer,
 } from './blockbook-api';
 
 type OptionalKey<M, K extends keyof M> = Omit<M, K> & Partial<Pick<M, K>>;
@@ -76,62 +78,11 @@ export interface AccountUtxoParams {
 
 export type VinVout = OptionalKey<Vin & Vout, 'addresses'>;
 
-export interface EthereumInternalTransfer {
-    type: number;
-    from: string;
-    to: string;
-    value?: string;
-}
-
-export interface Transaction {
-    txid: string;
-    version?: number;
+export type Transaction = Omit<BlockbookTx, 'vin' | 'vout' | 'tokenTransfers'> & {
     vin: VinVout[];
     vout: VinVout[];
-    blockHeight: number;
-    blockHash?: string;
-    confirmations: number;
-    blockTime: number;
-    value: string;
-    valueIn: string;
-    fees: string;
-    hex: string;
-    lockTime?: number;
-    vsize?: number;
-    size?: number;
-    ethereumSpecific?: {
-        type?: number;
-        status: number;
-        nonce: number;
-        data?: string;
-        gasLimit: number;
-        gasUsed?: number;
-        gasPrice: string;
-        createdContract?: string;
-        parsedData?: {
-            data?: string;
-            methodId?: string;
-            method?: string;
-            name?: string;
-            parameters: Array<{ key: string; value: Array<string> }>;
-        };
-        internalTransfers?: EthereumInternalTransfer[];
-    };
-    tokenTransfers?: {
-        from: string;
-        to: string;
-        value?: string;
-        contract: string;
-        name: string;
-        symbol: string;
-        decimals: number;
-        type: TokenStandard;
-        multiTokenValues?: Array<{
-            id: string;
-            value: string;
-        }>;
-    }[];
-}
+    tokenTransfers?: (Omit<BlockbookTokenTransfer, 'type'> & { type: TokenStandard })[];
+};
 
 export interface Push {
     result: string;

--- a/packages/blockchain-link-types/src/blockbook.ts
+++ b/packages/blockchain-link-types/src/blockbook.ts
@@ -17,6 +17,7 @@ import {
     Tx as BlockbookTx,
     TokenTransfer as BlockbookTokenTransfer,
     Token as BlockbookToken,
+    Address as BlockbookAddress,
 } from './blockbook-api';
 
 type OptionalKey<M, K extends keyof M> = Omit<M, K> & Partial<Pick<M, K>>;
@@ -61,23 +62,16 @@ export type ERC1155 = Omit<BlockbookToken, 'type'> & {
     type: 'ERC1155';
 };
 
-export interface AccountInfo {
-    address: string;
-    balance: string;
-    totalReceived: string;
-    totalSent: string;
-    txs: number;
-    unconfirmedBalance: string;
-    unconfirmedTxs: number;
-    page?: number;
-    itemsOnPage: number;
-    totalPages: number;
-    nonTokenTxs?: number;
-    transactions?: Transaction[];
-    nonce?: string;
+export type AccountInfo = Omit<
+    RequiredKey<
+        BlockbookAddress,
+        'totalPages' | 'unconfirmedBalance' | 'totalSent' | 'totalReceived'
+    >,
+    'tokens' | 'transactions'
+> & {
     tokens?: (XPUBAddress | ERC20 | ERC721 | ERC1155)[];
-    erc20Contract?: ERC20;
-}
+    transactions?: Transaction[];
+};
 
 export interface AccountUtxoParams {
     descriptor: string;

--- a/packages/blockchain-link-utils/src/blockbook.ts
+++ b/packages/blockchain-link-utils/src/blockbook.ts
@@ -170,7 +170,7 @@ export const transformTransaction = (
 
     if (tx.ethereumSpecific?.createdContract) {
         type = 'contract';
-        amount = tx.value;
+        amount = tx.value ?? '0';
         targets = [];
     } else if (myInputs.length) {
         // Some input is mine -> sent, self or joint
@@ -192,7 +192,7 @@ export const transformTransaction = (
                 : outputs.filter(isNonChangeOutput);
             amount =
                 !outputs.length || tx.ethereumSpecific
-                    ? tx.value
+                    ? tx.value ?? '0'
                     : new BigNumber(myTotalInput)
                           .minus(myTotalOutput)
                           .minus(tx.fees ?? '0')
@@ -201,7 +201,7 @@ export const transformTransaction = (
             // All inputs & outputs are mine -> self
 
             type = 'self';
-            amount = tx.fees;
+            amount = tx.fees ?? '0';
             const intentionalOutputs = outputs.filter(isNonChangeOutput);
             targets = intentionalOutputs.length ? intentionalOutputs : outputs;
         }
@@ -222,7 +222,7 @@ export const transformTransaction = (
     } else {
         // No input or output is mine -> unknown
         type = 'unknown';
-        amount = tx.value;
+        amount = tx.value ?? '0';
         targets = [];
     }
 
@@ -234,10 +234,10 @@ export const transformTransaction = (
 
     const fee =
         tx.ethereumSpecific && !tx.ethereumSpecific.gasUsed
-            ? new BigNumber(tx.ethereumSpecific.gasPrice)
-                  .times(tx.ethereumSpecific.gasLimit)
+            ? new BigNumber(tx.ethereumSpecific.gasPrice ?? '0')
+                  .times(tx.ethereumSpecific.gasLimit ?? '0')
                   .toString()
-            : tx.fees;
+            : tx.fees ?? '0';
 
     // some instances of bb don't send vsize yet
     const feeRate = tx.vsize
@@ -245,7 +245,7 @@ export const transformTransaction = (
         : undefined;
 
     // some instances of bb don't send size yet
-    const size = tx.size || typeof tx.hex === 'string' ? tx.hex.length / 2 : 0;
+    const size = tx.size || typeof tx.hex === 'string' ? tx.hex!.length / 2 : 0;
 
     return {
         type,

--- a/packages/blockchain-link-utils/src/blockbook.ts
+++ b/packages/blockchain-link-utils/src/blockbook.ts
@@ -326,7 +326,11 @@ export const transformAddresses = (
 
 export const transformAccountInfo = (payload: BlockbookAccountInfo): AccountInfo => {
     let page;
-    if (typeof payload.page === 'number') {
+    if (
+        typeof payload.page === 'number' &&
+        typeof payload.itemsOnPage === 'number' &&
+        typeof payload.totalPages === 'number'
+    ) {
         page = {
             index: payload.page,
             size: payload.itemsOnPage,
@@ -337,8 +341,10 @@ export const transformAccountInfo = (payload: BlockbookAccountInfo): AccountInfo
     if (typeof payload.nonce === 'string') {
         misc.nonce = payload.nonce;
     }
+    // todo: deprecated field
     if (payload.erc20Contract) {
         const token = transformTokenInfo([
+            // @ts-expect-error (deprecated)
             { ...payload.erc20Contract, type: payload.erc20Contract.type || 'ERC20' },
         ]);
         if (token) {
@@ -356,16 +362,16 @@ export const transformAccountInfo = (payload: BlockbookAccountInfo): AccountInfo
     // reduce or increase availableBalance
     const availableBalance =
         !unconfirmed.isNaN() && !unconfirmed.isZero()
-            ? unconfirmed.plus(payload.balance).toString()
-            : payload.balance;
+            ? unconfirmed.plus(payload.balance ?? '0').toString()
+            : payload.balance ?? '0';
     const empty =
         payload.txs === 0 &&
         payload.unconfirmedTxs === 0 &&
-        new BigNumber(availableBalance).isZero();
+        new BigNumber(availableBalance ?? '0').isZero();
 
     return {
         descriptor,
-        balance: payload.balance,
+        balance: payload.balance ?? '0',
         availableBalance,
         empty,
         tokens,

--- a/packages/blockchain-link-utils/src/tests/fixtures/blockbook.ts
+++ b/packages/blockchain-link-utils/src/tests/fixtures/blockbook.ts
@@ -654,8 +654,8 @@ export const transformTransaction: {
             ],
             ethereumSpecific: {
                 status: 1,
-                gasLimit: 21000,
-                gasUsed: 21000,
+                gasLimit: '21000',
+                gasUsed: '21000',
                 gasPrice: '3',
             },
             ...FEES,
@@ -687,7 +687,7 @@ export const transformTransaction: {
             ],
             ethereumSpecific: {
                 status: 1,
-                gasLimit: 21000,
+                gasLimit: '21000',
                 gasPrice: '3',
             },
             ...FEES,

--- a/packages/coinjoin/src/backend/scanAccount.ts
+++ b/packages/coinjoin/src/backend/scanAccount.ts
@@ -35,7 +35,7 @@ const analyzeAddresses = async (
         if (isMatch(script)) {
             // eslint-disable-next-line no-await-in-loop
             const block = await getBlock();
-            const transactions = block.txs.filter(doesTxContainAddress(address));
+            const transactions = block.txs?.filter(doesTxContainAddress(address)) || [];
             if (transactions.length) {
                 transactions.forEach(txs.add, txs);
                 const missing = lookout + i + 1 - addrs.length;

--- a/packages/coinjoin/src/backend/scanAddress.ts
+++ b/packages/coinjoin/src/backend/scanAddress.ts
@@ -26,7 +26,7 @@ export const scanAddress = async (
         const isMatch = getFilter(filter, blockHash);
         if (isMatch(script)) {
             const block = await client.fetchBlock(blockHeight);
-            const blockTxs = block.txs.filter(doesTxContainAddress(address));
+            const blockTxs = block.txs?.filter(doesTxContainAddress(address)) || [];
             const transactions = blockTxs.map(tx => transformTransaction(address, undefined, tx));
 
             onProgress({

--- a/packages/coinjoin/src/types/backend.ts
+++ b/packages/coinjoin/src/types/backend.ts
@@ -10,6 +10,7 @@ import type {
 import type {
     Transaction as BlockbookTransaction,
     VinVout,
+    Block,
 } from '@trezor/blockchain-link-types/lib/blockbook';
 
 import type { CoinjoinBackendClient } from '../backend/CoinjoinBackendClient';
@@ -18,12 +19,7 @@ import type { MempoolController } from '../backend/CoinjoinMempoolController';
 export type { BlockbookTransaction, VinVout, EnhancedVinVout };
 export type { Address, Utxo, Transaction, AccountAddresses };
 
-export type BlockbookBlock = {
-    page: number;
-    totalPages: number;
-    height: number;
-    txs: BlockbookTransaction[];
-};
+export type BlockbookBlock = Block;
 
 export type BlockFilter = {
     blockHeight: number;

--- a/packages/connect/src/api/bitcoin/refTx.ts
+++ b/packages/connect/src/api/bitcoin/refTx.ts
@@ -86,7 +86,7 @@ export const transformOrigTransactions = (
     txs.flatMap(raw => {
         if (coinInfo.type !== 'bitcoin' || raw.type !== 'blockbook' || !addresses) return [];
         const { hex, vin, vout } = raw.tx;
-        const tx = BitcoinJsTransaction.fromHex(hex, { network: coinInfo.network });
+        const tx = BitcoinJsTransaction.fromHex(hex!, { network: coinInfo.network });
         const inputAddresses = addresses.used.concat(addresses.change).concat(addresses.unused);
 
         // inputs, required by TXORIGINPUT (TxAckInput) request from Trezor
@@ -183,7 +183,7 @@ export const transformReferencedTransactions = (
     txs.flatMap(raw => {
         if (coinInfo.type !== 'bitcoin' || raw.type !== 'blockbook') return [];
         const { hex } = raw.tx;
-        const tx = BitcoinJsTransaction.fromHex(hex, { network: coinInfo.network });
+        const tx = BitcoinJsTransaction.fromHex(hex!, { network: coinInfo.network });
 
         // inputs, required by TXINPUT (TxAckPrevInput) request from Trezor
         const inputsMap = (input: BitcoinJsInput) => ({

--- a/packages/suite/src/components/suite/modals/TransactionDetail/components/BasicDetails.tsx
+++ b/packages/suite/src/components/suite/modals/TransactionDetail/components/BasicDetails.tsx
@@ -306,9 +306,10 @@ export const BasicDetails = ({ tx, confirmations, network, explorerUrl }: BasicD
                             <StyledIcon icon="GAS" size={10} />
                             <Translation id="TR_GAS_PRICE" />
                         </Title>
-                        <Value>{`${fromWei(tx.ethereumSpecific.gasPrice, 'gwei')} ${getFeeUnits(
-                            'ethereum',
-                        )}`}</Value>
+                        <Value>{`${fromWei(
+                            tx.ethereumSpecific.gasPrice ?? '0',
+                            'gwei',
+                        )} ${getFeeUnits('ethereum')}`}</Value>
 
                         <Title>
                             <IconPlaceholder>#</IconPlaceholder>

--- a/packages/suite/src/storage/migrations/index.ts
+++ b/packages/suite/src/storage/migrations/index.ts
@@ -574,6 +574,7 @@ export const migrate: OnUpgradeFunc<SuiteDBSchema> = async (
                 ethereumSpecific: origTx.ethereumSpecific
                     ? {
                           ...origTx.ethereumSpecific,
+                          // @ts-expect-error
                           gasPrice: toWei(origTx.ethereumSpecific.gasPrice, 'gwei'),
                       }
                     : undefined,

--- a/suite-common/wallet-utils/src/exportTransactions.ts
+++ b/suite-common/wallet-utils/src/exportTransactions.ts
@@ -98,7 +98,7 @@ const formatAmounts =
         ethereumSpecific: tx.ethereumSpecific
             ? {
                   ...tx.ethereumSpecific,
-                  gasPrice: fromWei(tx.ethereumSpecific.gasPrice, 'gwei'),
+                  gasPrice: fromWei(tx.ethereumSpecific.gasPrice ?? '0', 'gwei'),
               }
             : undefined,
         cardanoSpecific: tx.cardanoSpecific

--- a/suite-common/wallet-utils/src/transactionUtils.ts
+++ b/suite-common/wallet-utils/src/transactionUtils.ts
@@ -508,7 +508,7 @@ const getEthereumRbfParams = (
         ],
         ethereumNonce: tx.ethereumSpecific.nonce,
         ethereumData,
-        feeRate: fromWei(tx.ethereumSpecific.gasPrice, 'gwei'),
+        feeRate: fromWei(tx.ethereumSpecific.gasPrice ?? '0', 'gwei'),
         baseFee: 0, // irrelevant
     };
 };

--- a/suite-native/transactions/src/components/TransactionDetail/TransactionDetailParametersSheet.tsx
+++ b/suite-native/transactions/src/components/TransactionDetail/TransactionDetailParametersSheet.tsx
@@ -51,7 +51,7 @@ const EthereumParameters = ({ gasLimit, gasUsed, gasPrice, nonce }: EthereumPara
         {/* TODO: The `gasPrice` parameter should be handled inside of a fee formatter. */}
         {/* https://github.com/trezor/trezor-suite/issues/7385 */}
         <TransactionDetailRow title="Gas price">
-            {`${fromWei(gasPrice, 'gwei')} ${getFeeUnits('ethereum')}`}
+            {`${fromWei(gasPrice ?? '0', 'gwei')} ${getFeeUnits('ethereum')}`}
         </TransactionDetailRow>
         <TransactionDetailRow title="Nonce">{nonce}</TransactionDetailRow>
     </>


### PR DESCRIPTION
based on https://github.com/trezor/trezor-suite/pull/7695 I decided to open a new PR since there were some breaking changes recently, hope @martinboehm  does not mind. 

Made some progress, still draftish 

In [chore(blockchain-link-types): tx](https://github.com/trezor/trezor-suite/pull/7855/commits/866af82fca3f26822a08089d77fe3db53f312d45) I made some changes to the generated file. Not sure if it makes sense to have array of objects of shape `{id?: string, value?: string}`. Cant it possibly be some imperfection of types generation? 
