### PR TITLE
test(connect-popup): add unsupported browser test

### DIFF
--- a/ci/test.yml
+++ b/ci/test.yml
@@ -222,6 +222,7 @@ transport manual:
       - TEST_FILE: ["methods"]
       - TEST_FILE: ["popup-close"]
       - TEST_FILE: ["unchained"]
+      - TEST_FILE: ["browser-support"]
 
 connect-popup:
   extends: .e2e connect-popup

--- a/packages/connect-popup/e2e/support/ensureScreenshotsDir.ts
+++ b/packages/connect-popup/e2e/support/ensureScreenshotsDir.ts
@@ -1,0 +1,13 @@
+import fs from 'fs';
+
+export const ensureScreenshotsDir = (screenshotsPath: string) => {
+    const path = screenshotsPath.replace(' ', '-');
+
+    const dir = `./e2e/screenshots/${path}`;
+
+    if (!fs.existsSync(dir)) {
+        fs.mkdirSync(dir, { recursive: true });
+    }
+
+    return dir;
+};

--- a/packages/connect-popup/e2e/tests/browser-support.test.ts
+++ b/packages/connect-popup/e2e/tests/browser-support.test.ts
@@ -1,0 +1,61 @@
+import { test, expect, Page } from '@playwright/test';
+
+import { ensureScreenshotsDir } from '../support/ensureScreenshotsDir';
+
+const url = process.env.URL || 'http://localhost:8088/';
+
+let dir: string;
+let popup: Page;
+
+test.beforeAll(() => {
+    dir = ensureScreenshotsDir('unsupported-browser');
+});
+
+test.afterEach(async () => {
+    await popup.close();
+});
+
+const openPopup = async (page: Page) => {
+    await page.waitForSelector("button[data-test='@submit-button']", { state: 'visible' });
+    return (
+        await Promise.all([
+            // It is important to call waitForEvent before click to set up waiting.
+            page.waitForEvent('popup'),
+            // Opens popup.
+            page.click("button[data-test='@submit-button']"),
+        ])
+    )[0];
+};
+
+test('unsupported-browser', async ({ browser }) => {
+    const context = await browser.newContext({
+        userAgent:
+            'Mozilla/5.0 (Mobile; Windows Phone 8.1; Android 4.0; ARM; Trident/7.0; Touch; rv:11.0; IEMobile/11.0; NOKIA; Lumia 635) like iPhone OS 7_0_3 Mac OS X AppleWebKit/537 (KHTML, like Gecko) Mobile Safari/537',
+    });
+    const page = await context.newPage();
+    await page.goto(`${url}#/method/getPublicKey`);
+    await page.waitForSelector("button[data-test='@submit-button']", { state: 'visible' });
+    popup = await openPopup(page);
+    await popup.waitForSelector('text=Unsupported browser');
+    await popup.screenshot({ path: `${dir}/unsupported-browser.png` });
+});
+
+test('outdated-browser', async ({ browser }) => {
+    const context = await browser.newContext({
+        userAgent:
+            'Mozilla/5.0 (Macintosh; Intel Mac OS X 10.15; rv:100.0) Gecko/20100101 Firefox/50.0',
+    });
+    const page = await context.newPage();
+    await page.goto(`${url}#/method/getPublicKey`);
+    await page.waitForSelector("button[data-test='@submit-button']", { state: 'visible' });
+    popup = await openPopup(page);
+    await popup.waitForLoadState('load');
+    await popup.waitForSelector('text=Outdated browser');
+    // no react is rendering yet only browser check
+    expect(await popup.locator('#reactRenderIn').count()).toEqual(0);
+    await popup.screenshot({ path: `${dir}/outdated-browser-1.png` });
+    await popup.click('text=I acknowledge and wish to continue');
+    // only after this check react renders
+    await popup.waitForSelector('#reactRenderIn');
+    await popup.screenshot({ path: `${dir}/outdated-browser-2.png` });
+});

--- a/packages/connect-popup/e2e/tests/methods.test.ts
+++ b/packages/connect-popup/e2e/tests/methods.test.ts
@@ -2,28 +2,17 @@
 /* eslint-disable no-restricted-syntax */
 
 import { test } from '@playwright/test';
-import fs from 'fs';
 
 import { TrezorUserEnvLink } from '@trezor/trezor-user-env-link';
 import { fixtures } from './__fixtures__/methods';
 import { buildOverview } from '../support/buildOverview';
+import { ensureScreenshotsDir } from '../support/ensureScreenshotsDir';
 
 const url = process.env.URL || 'http://localhost:8088/';
-const SCREENSHOTS_DIR = './e2e/screenshots';
 const emuScreenshots: Record<string, string> = {};
 
 const log = (...val: string[]) => {
     console.log(`[===]`, ...val);
-};
-
-const ensureScreenshotsDir = () => {
-    // todo: do this only on local. we need to keep files there in case of flakiness reruns
-    if (fs.existsSync(SCREENSHOTS_DIR)) {
-        // fs.rmSync(SCREENSHOTS_DIR, { recursive: true });
-        // fs.mkdirSync(SCREENSHOTS_DIR, { recursive: true });
-    } else {
-        fs.mkdirSync(SCREENSHOTS_DIR, { recursive: true });
-    }
 };
 
 const screenshotEmu = async (path: string) => {
@@ -35,7 +24,6 @@ const screenshotEmu = async (path: string) => {
 
 test.beforeAll(async () => {
     await TrezorUserEnvLink.connect();
-    ensureScreenshotsDir();
 });
 
 test.afterAll(() => {
@@ -71,11 +59,7 @@ fixtures.forEach(f => {
             await TrezorUserEnvLink.api.startBridge();
         }
 
-        const screenshotsPath = `${SCREENSHOTS_DIR}/${f.url}`;
-
-        if (!fs.existsSync(screenshotsPath)) {
-            fs.mkdirSync(screenshotsPath);
-        }
+        const screenshotsPath = ensureScreenshotsDir(f.url);
 
         await page.goto(`${url}#/method/${f.url}`);
 

--- a/packages/connect-popup/src/view/common.tsx
+++ b/packages/connect-popup/src/view/common.tsx
@@ -179,4 +179,12 @@ export const renderConnectUI = () => {
     );
 
     root.render(Component);
+
+    return new Promise(resolve => {
+        reactEventBus.on(event => {
+            if (event.type === 'connect-ui-rendered') {
+                resolve(undefined);
+            }
+        });
+    });
 };

--- a/packages/connect-ui/src/index.tsx
+++ b/packages/connect-ui/src/index.tsx
@@ -57,7 +57,10 @@ export const ConnectUI = ({ postMessage, clearLegacyView }: ConnectUIProps) => {
         return () => reactEventBus.remove(listener);
     }, [listener]);
 
-    useEffect(() => initAnalytics(), []);
+    useEffect(() => {
+        reactEventBus.dispatch({ type: 'connect-ui-rendered' });
+        initAnalytics();
+    }, []);
 
     const [Component, Notifications] = useMemo(() => {
         let component: React.ReactNode | null;

--- a/packages/connect-ui/src/utils/eventBus.ts
+++ b/packages/connect-ui/src/utils/eventBus.ts
@@ -13,7 +13,8 @@ export type ConnectUIEventProps =
     | { type: typeof UI_REQUEST.DEVICE_NEEDS_BACKUP; device: Device }
     | { type: typeof UI_REQUEST.FIRMWARE_OUTDATED; device: Device }
     // connect-popup events
-    | { type: 'phishing-domain' };
+    | { type: 'phishing-domain' }
+    | { type: 'connect-ui-rendered' };
 
 const reactChannel = 'react';
 


### PR DESCRIPTION
- [test(connect-popup): browser support](https://github.com/trezor/trezor-suite/pull/7857/commits/c96cf2829559bb1c661fb1973cb319bb2a9f22d8) adds tests for refactoring done in #7844. Test seems to be [passing](https://gitlab.com/satoshilabs/trezor/trezor-suite/-/jobs/3950790808)
-  [fix(connect-popup): dont render react before browser-detect](https://github.com/trezor/trezor-suite/pull/7857/commits/6ffcbe280664e73da8ae6c357f325bd653177f70) fixes a small bug when the "react" part of UI was rendered together with browser detection. It doesn't make any sense imho, now react is mounted only after browser is supported

Did some tiny refactoring related to screenshots, seems like I did not break anything https://satoshilabs.gitlab.io/-/trezor/trezor-suite/-/jobs/3950790803/artifacts/packages/connect-popup/connect-popup-overview.html

### screenshots 
- https://gitlab.com/satoshilabs/trezor/trezor-suite/-/jobs/3950586680/artifacts/file/packages/connect-popup/e2e/screenshots/unsupported-browser/outdated-browser-1.png
- https://gitlab.com/satoshilabs/trezor/trezor-suite/-/jobs/3950586680/artifacts/file/packages/connect-popup/e2e/screenshots/unsupported-browser/outdated-browser-2.png
- https://gitlab.com/satoshilabs/trezor/trezor-suite/-/jobs/3950586680/artifacts/file/packages/connect-popup/e2e/screenshots/unsupported-browser/unsupported-browser.png
