### PR TITLE
Fix occasionally failing CJ discovery

### DIFF
--- a/packages/suite/src/actions/suite/storageActions.ts
+++ b/packages/suite/src/actions/suite/storageActions.ts
@@ -52,10 +52,8 @@ export const removeAccountDraft = async (account: Account) => {
 
 export const saveCoinjoinAccount =
     (accountKey: string) => async (_: Dispatch, getState: GetState) => {
-        const state = getState();
-        const { device } = state.suite;
-        const coinjoinAccount = selectCoinjoinAccountByKey(state, accountKey);
-        if (!device?.remember || !coinjoinAccount || !(await db.isAccessible())) return;
+        const coinjoinAccount = selectCoinjoinAccountByKey(getState(), accountKey);
+        if (!coinjoinAccount || !(await db.isAccessible())) return;
         return db.addItem(
             'coinjoinAccounts',
             serializeCoinjoinSession(coinjoinAccount),

--- a/packages/suite/src/actions/wallet/coinjoinAccountActions.ts
+++ b/packages/suite/src/actions/wallet/coinjoinAccountActions.ts
@@ -36,7 +36,8 @@ const coinjoinAccountCreate = (account: Account) =>
     ({
         type: COINJOIN.ACCOUNT_CREATE,
         payload: {
-            account,
+            accountKey: account.key,
+            symbol: account.symbol,
         },
     } as const);
 

--- a/packages/suite/src/actions/wallet/coinjoinAccountActions.ts
+++ b/packages/suite/src/actions/wallet/coinjoinAccountActions.ts
@@ -145,11 +145,11 @@ const coinjoinSessionRestore = (accountKey: string) =>
         },
     } as const);
 
-const coinjoinAccountDiscoveryProgress = (account: Account, progress: ScanAccountProgress) =>
+const coinjoinAccountDiscoveryProgress = (accountKey: string, progress: ScanAccountProgress) =>
     ({
         type: COINJOIN.ACCOUNT_DISCOVERY_PROGRESS,
         payload: {
-            account,
+            accountKey,
             progress,
         },
     } as const);
@@ -377,7 +377,7 @@ export const fetchAndUpdateAccount =
                 coinjoinAccountAddTransactions({ account, transactions: progress.transactions }),
             );
             // store current checkpoint (and all account data to db if remembered)
-            dispatch(coinjoinAccountDiscoveryProgress(account, progress));
+            dispatch(coinjoinAccountDiscoveryProgress(account.key, progress));
         };
 
         const progressHandle = getAccountProgressHandle(account);

--- a/packages/suite/src/middlewares/wallet/storageMiddleware.ts
+++ b/packages/suite/src/middlewares/wallet/storageMiddleware.ts
@@ -234,9 +234,9 @@ const storageMiddleware = (api: MiddlewareAPI<Dispatch, AppState>) => {
                     break;
 
                 case COINJOIN.ACCOUNT_CREATE:
-                case COINJOIN.ACCOUNT_DISCOVERY_PROGRESS:
                     api.dispatch(storageActions.saveCoinjoinAccount(action.payload.account.key));
                     break;
+                case COINJOIN.ACCOUNT_DISCOVERY_PROGRESS:
                 case COINJOIN.ACCOUNT_AUTHORIZE_SUCCESS:
                 case COINJOIN.ACCOUNT_UNREGISTER:
                 case COINJOIN.ACCOUNT_UPDATE_SETUP_OPTION:

--- a/packages/suite/src/middlewares/wallet/storageMiddleware.ts
+++ b/packages/suite/src/middlewares/wallet/storageMiddleware.ts
@@ -234,8 +234,6 @@ const storageMiddleware = (api: MiddlewareAPI<Dispatch, AppState>) => {
                     break;
 
                 case COINJOIN.ACCOUNT_CREATE:
-                    api.dispatch(storageActions.saveCoinjoinAccount(action.payload.account.key));
-                    break;
                 case COINJOIN.ACCOUNT_DISCOVERY_PROGRESS:
                 case COINJOIN.ACCOUNT_AUTHORIZE_SUCCESS:
                 case COINJOIN.ACCOUNT_UNREGISTER:

--- a/packages/suite/src/reducers/wallet/coinjoinReducer.ts
+++ b/packages/suite/src/reducers/wallet/coinjoinReducer.ts
@@ -95,9 +95,7 @@ const createAccount = (
     { accountKey, symbol }: ExtractActionPayload<typeof COINJOIN.ACCOUNT_CREATE>,
 ) => {
     draft.isPreloading = false;
-    const exists = draft.accounts.find(a => a.key === accountKey);
-    if (exists) return;
-    draft.accounts.push({
+    const coinjoinAccount = {
         key: accountKey,
         symbol,
         rawLiquidityClue: null, // NOTE: liquidity clue is calculated from tx history. default value is `null`
@@ -105,7 +103,10 @@ const createAccount = (
         maxFeePerKvbyte: MAX_MINING_FEE_FALLBACK,
         skipRounds: DEFAULT_SKIP_ROUNDS,
         previousSessions: [],
-    });
+    };
+    const index = draft.accounts.findIndex(a => a.key === accountKey);
+    if (index < 0) draft.accounts.push(coinjoinAccount);
+    else draft.accounts[index] = coinjoinAccount;
 };
 
 const setLiquidityClue = (

--- a/packages/suite/src/reducers/wallet/coinjoinReducer.ts
+++ b/packages/suite/src/reducers/wallet/coinjoinReducer.ts
@@ -297,7 +297,7 @@ const saveCheckpoint = (
     draft: CoinjoinState,
     action: Extract<Action, { type: typeof COINJOIN.ACCOUNT_DISCOVERY_PROGRESS }>,
 ) => {
-    const account = draft.accounts.find(a => a.key === action.payload.account.key);
+    const account = draft.accounts.find(a => a.key === action.payload.accountKey);
     if (!account) return;
     const checkpointNew = action.payload.progress.checkpoint;
     const checkpoints = (account.checkpoints ?? [])

--- a/packages/suite/src/reducers/wallet/coinjoinReducer.ts
+++ b/packages/suite/src/reducers/wallet/coinjoinReducer.ts
@@ -92,14 +92,14 @@ type ExtractActionPayload<A> = Extract<Action, { type: A }> extends { type: A; p
 
 const createAccount = (
     draft: CoinjoinState,
-    { account }: ExtractActionPayload<typeof COINJOIN.ACCOUNT_CREATE>,
+    { accountKey, symbol }: ExtractActionPayload<typeof COINJOIN.ACCOUNT_CREATE>,
 ) => {
     draft.isPreloading = false;
-    const exists = draft.accounts.find(a => a.key === account.key);
+    const exists = draft.accounts.find(a => a.key === accountKey);
     if (exists) return;
     draft.accounts.push({
-        key: account.key,
-        symbol: account.symbol,
+        key: accountKey,
+        symbol,
         rawLiquidityClue: null, // NOTE: liquidity clue is calculated from tx history. default value is `null`
         targetAnonymity: DEFAULT_TARGET_ANONYMITY,
         maxFeePerKvbyte: MAX_MINING_FEE_FALLBACK,


### PR DESCRIPTION
## Description

Fixes bug where CJ discovery checkpoints were occasionally stored even for non-remembered accounts which prevented their future successful discovery.

## Related issues
Could resolve #6811.
Could resolve #7338.
Optional followup #7865.

## Commits
- https://github.com/trezor/trezor-suite/pull/7859/commits/5909626582d48ff88c5a706119cd91cba7b67640 - refactor, unify `ACCOUNT_DISCOVERY_PROGRESS` payload with other coinjoin actions
- https://github.com/trezor/trezor-suite/pull/7859/commits/ecf27e52e8edf6c5639fc24e18bb9dd38737eff7 - refactor, unify `ACCOUNT_CREATE` payload with other coinjoin actions
- https://github.com/trezor/trezor-suite/pull/7859/commits/25f4a73566d14b67dfd897f6ceda4660b77492e9 - move device remember check from `storageActions` to `storageMiddleware` (more consistent with other actions) and fix the check so it cares about account's device rather than currently selected device
- https://github.com/trezor/trezor-suite/pull/7859/commits/ee94b31dcdc3f83afcfbc2ade1e06a026eb4469b - override coinjoin account data (incl. checkpoints) if account is created, which should prevent the problem from above even if it wasn't fixed

## QA

1. Have one remembered wallet with CJ account (but it should work even without it)
2. Add another non-remembered wallet
3. Add CJ account on it (with history or you won't see any difference)
4. During initial discovery, switch to the remembered wallet
5. Stay there until the non-remembered CJ account discovery is finished
6. Turn the Suite off and on again
7. Add the non-remembered wallet and its CJ account again
8. Wait for the discovery to finish
    1. Before this fix, the account was incorrectly empty
    2. Now it should be correctly discovered