### PR TITLE
refactor(connect): parsing and validation of ConnectSettings

### DIFF
--- a/packages/connect-iframe/package.json
+++ b/packages/connect-iframe/package.json
@@ -7,7 +7,8 @@
         "build": "rimraf build && TS_NODE_PROJECT=\"tsconfig.json\" yarn webpack --config ./webpack/prod.webpack.config.ts",
         "___NOTE__": "iframe build is one of the prerequisites of suite-web. build:lib script provides it together with other libraries",
         "build:lib": "yarn build",
-        "type-check": "tsc --build tsconfig.json"
+        "type-check": "tsc --build tsconfig.json",
+        "test:unit": "jest -c ../../jest.config.base.js"
     },
     "devDependencies": {
         "@trezor/connect": "workspace:9.0.7",

--- a/packages/connect-iframe/src/connectSettings.ts
+++ b/packages/connect-iframe/src/connectSettings.ts
@@ -1,0 +1,81 @@
+import { parseConnectSettings as parseSettings, ConnectSettings } from '@trezor/connect';
+import { config } from '@trezor/connect/src/data/config';
+import { DEFAULT_PRIORITY } from '@trezor/connect/src/data/connectSettings';
+import { getHost } from '@trezor/connect/src/utils/urlUtils';
+
+export const isOriginWhitelisted = (origin: string) => {
+    const host = getHost(origin);
+    return config.whitelist.find(item => item.origin === origin || item.origin === host);
+};
+
+const getPriority = (whitelist?: (typeof config)['whitelist'][0]) => {
+    if (whitelist) {
+        return whitelist.priority;
+    }
+    return DEFAULT_PRIORITY;
+};
+
+const getHostLabel = (origin: string) => config.knownHosts.find(host => host.origin === origin);
+
+/**
+ * Receive settings from @trezor/connect-web hosted on 3rd party domain and validate sensitive values (origin, popup etc.)
+ * Returned settings are considered as safe since this script runs on trusted domain.
+ * @param input Partial<ConnectSettings>
+ */
+export const parseConnectSettings = (
+    input: Partial<ConnectSettings> = {},
+    origin: string,
+): ConnectSettings => {
+    const settings = parseSettings(input);
+
+    // occasionally received origin is a stringified "null" or empty string. rename it to avoid confusion
+    settings.origin = !origin || origin === 'null' ? 'unknown' : origin;
+
+    // check if iframe is running on localhost
+    const isLocalhost = window?.location?.hostname === 'localhost';
+    // check if origin is whitelisted
+    const whitelist = isOriginWhitelisted(settings.origin);
+
+    settings.trustedHost = (isLocalhost || !!whitelist) && !settings.popup;
+
+    // ensure that popup will be used
+    if (!settings.trustedHost) {
+        settings.popup = true;
+    }
+
+    // ensure that debug is disabled
+    if (!settings.trustedHost && !whitelist && !isLocalhost) {
+        settings.debug = false;
+    }
+
+    settings.priority = getPriority(whitelist);
+
+    let disableWebUsb = false;
+    // disable webusb on local files
+    if (window?.location?.protocol === 'file:') {
+        settings.origin = `file://${window.location.pathname}`;
+        settings.webusb = false;
+        disableWebUsb = true;
+    }
+
+    // hotfix webusb + chrome:72, allow webextensions
+    if (settings.popup && settings.env !== 'webextension') {
+        disableWebUsb = true;
+        settings.webusb = false;
+    }
+
+    if (disableWebUsb) {
+        // allow all but WebUsbTransport
+        settings.transports = settings.transports?.filter(
+            (transport: string) => transport !== 'WebUsbTransport',
+        );
+    }
+
+    const knownHost = getHostLabel(settings.extension || settings.origin || '');
+    if (knownHost) {
+        settings.hostLabel = knownHost.label;
+        settings.hostIcon = knownHost.icon;
+    }
+
+    return settings;
+};

--- a/packages/connect-iframe/tests/connectSettings.test.ts
+++ b/packages/connect-iframe/tests/connectSettings.test.ts
@@ -1,0 +1,96 @@
+import { parseConnectSettings } from '../src/connectSettings';
+
+declare let window: any; // Window['location'] types doesn't allow location mocks
+
+describe('connect-iframe parseConnectSettings', () => {
+    const { location } = window;
+    beforeEach(() => {
+        delete window.location;
+        window.location = {
+            protocol: 'https:',
+            hostname: 'connect.trezor.io',
+            href: 'https://connect.trezor.io',
+            toString: () => 'https://connect.trezor.io',
+        };
+    });
+    afterAll(() => {
+        window.location = location; // restore default
+    });
+
+    it('WebUsbTransport disabled for file:// protocol', () => {
+        window.location = {
+            protocol: 'file:',
+            pathname: '/User/local-path',
+        };
+        expect(parseConnectSettings({ transports: ['WebUsbTransport'] }, '')).toMatchObject({
+            transports: [],
+            origin: 'file:///User/local-path',
+        });
+    });
+
+    it('WebUsbTransport disabled in popup mode', () => {
+        expect(parseConnectSettings({ transports: ['WebUsbTransport'] }, '')).toMatchObject({
+            transports: [],
+        });
+
+        expect(
+            parseConnectSettings({ transports: ['WebUsbTransport'], env: 'webextension' }, ''),
+        ).toMatchObject({
+            transports: ['WebUsbTransport'],
+        });
+    });
+
+    it('trustedHost + popup + debug (iframe localhost location)', () => {
+        window.location = {
+            protocol: 'http:',
+            hostname: 'localhost',
+        };
+
+        expect(parseConnectSettings({ popup: false, debug: true }, '')).toMatchObject({
+            trustedHost: true,
+            popup: false,
+            debug: true,
+        });
+
+        expect(parseConnectSettings({ popup: true, debug: true }, '')).toMatchObject({
+            trustedHost: false,
+            popup: true,
+            debug: true,
+        });
+    });
+
+    it('trustedHost + popup + debug (iframe online location)', () => {
+        expect(
+            parseConnectSettings({ popup: false, debug: true }, 'https://connect.trezor.io'),
+        ).toMatchObject({
+            trustedHost: true,
+            popup: false,
+            debug: true,
+        });
+
+        expect(
+            parseConnectSettings({ popup: true, debug: true }, 'https://connect.trezor.io'),
+        ).toMatchObject({
+            trustedHost: false,
+            popup: true,
+            debug: true, // because of whitelisted origin
+        });
+
+        expect(parseConnectSettings({ popup: false, debug: true }, '')).toMatchObject({
+            trustedHost: false,
+            popup: true,
+            debug: false,
+        });
+    });
+
+    it('priority', () => {
+        expect(parseConnectSettings({}, 'https://connect.trezor.io')).toMatchObject({
+            origin: 'https://connect.trezor.io',
+            priority: 0,
+        });
+        expect(parseConnectSettings({}, 'https://3rdparty.site')).toMatchObject({
+            origin: 'https://3rdparty.site',
+            priority: 2,
+        });
+    });
+});

--- a/packages/connect-iframe/tsconfig.json
+++ b/packages/connect-iframe/tsconfig.json
@@ -2,7 +2,7 @@
     "extends": "../../tsconfig.json",
     "compilerOptions": {
         "outDir": "./libDev",
-        "types": ["web"]
+        "types": ["web", "jest"]
     },
     "references": [{ "path": "../connect" }],
     "ts-node": {

--- a/packages/connect-web/jest.config.js
+++ b/packages/connect-web/jest.config.js
@@ -1,3 +1,5 @@
 module.exports = {
     preset: '../../jest.config.base.js',
+    testMatch: ['**/tests/*.test.ts'],
+    testPathIgnorePatterns: ['e2e'],
 };

--- a/packages/connect-web/package.json
+++ b/packages/connect-web/package.json
@@ -28,6 +28,7 @@
         "predev": "node webpack/generate_dev_cert.js",
         "lint:js": "yarn g:eslint '**/*.{ts,tsx,js}'",
         "type-check": "tsc --build",
+        "test:unit": "jest",
         "build:lib": "rimraf ./lib && yarn tsc --build tsconfig.lib.json",
         "dev": "rimraf build && TS_NODE_PROJECT=\"tsconfig.lib.json\" yarn webpack --config ./webpack/dev.webpack.config.ts",
         "build:inline": "TS_NODE_PROJECT=\"tsconfig.lib.json\" webpack --config ./webpack/inline.webpack.config.ts",

--- a/packages/connect-web/src/connectSettings.ts
+++ b/packages/connect-web/src/connectSettings.ts
@@ -1,0 +1,63 @@
+import {
+    parseConnectSettings as parseSettings,
+    ConnectSettings,
+} from '@trezor/connect/lib/exports';
+
+export const getEnv = () => {
+    if (typeof chrome !== 'undefined' && typeof chrome.runtime?.onConnect !== 'undefined') {
+        return 'webextension';
+    }
+    if (typeof navigator !== 'undefined') {
+        if (
+            typeof navigator.product === 'string' &&
+            navigator.product.toLowerCase() === 'reactnative'
+        ) {
+            return 'react-native';
+        }
+        const userAgent = navigator.userAgent.toLowerCase();
+        if (userAgent.indexOf(' electron/') > -1) {
+            return 'electron';
+        }
+    }
+    return 'web';
+};
+
+declare let global: any;
+
+/**
+ * Settings from host
+ * @param input Partial<ConnectSettings>
+ */
+export const parseConnectSettings = (input: Partial<ConnectSettings> = {}): ConnectSettings => {
+    const settings = { popup: true, ...input };
+    // For debugging purposes `connectSrc` could be defined in `global.__TREZOR_CONNECT_SRC` variable
+    let globalSrc: string | undefined;
+    if (typeof window !== 'undefined') {
+        // @ts-expect-error not defined in globals outside of the package
+        globalSrc = window.__TREZOR_CONNECT_SRC;
+    } else if (typeof global !== 'undefined') {
+        globalSrc = global.__TREZOR_CONNECT_SRC;
+    }
+    if (typeof globalSrc === 'string') {
+        settings.connectSrc = globalSrc;
+        settings.debug = true;
+    }
+
+    // For debugging purposes `connectSrc` could be defined in url query of hosting page. Usage:
+    // https://3rdparty-page.com/?trezor-connect-src=https://localhost:8088/
+    if (typeof window !== 'undefined' && typeof window.location?.search === 'string') {
+        const vars = window.location.search.split('&');
+        const customUrl = vars.find(v => v.indexOf('trezor-connect-src') >= 0);
+        if (customUrl) {
+            const [, connectSrc] = customUrl.split('=');
+            settings.connectSrc = decodeURIComponent(connectSrc);
+            settings.debug = true;
+        }
+    }
+
+    if (typeof input.env !== 'string') {
+        settings.env = getEnv();
+    }
+
+    return parseSettings(settings);
+};

--- a/packages/connect-web/src/index.ts
+++ b/packages/connect-web/src/index.ts
@@ -14,7 +14,6 @@ import {
     BLOCKCHAIN_EVENT,
     TRANSPORT,
     parseMessage,
-    parseConnectSettings,
     createUiMessage,
     createErrorMessage,
     ConnectSettings,
@@ -30,6 +29,7 @@ import { config } from '@trezor/connect/lib/data/config';
 import * as iframe from './iframe';
 import * as popup from './popup';
 import webUSBButton from './webusb/button';
+import { parseConnectSettings } from './connectSettings';
 
 const eventEmitter = new EventEmitter();
 const _log = initLog('@trezor/connect');

--- a/packages/connect-web/tests/connectSettings.test.ts
+++ b/packages/connect-web/tests/connectSettings.test.ts
@@ -1,0 +1,60 @@
+import { parseConnectSettings } from '../src/connectSettings';
+
+declare let window: any; // Window['location'] types doesn't allow location mocks
+
+describe('connect-web parseConnectSettings', () => {
+    const { location } = window;
+    beforeEach(() => {
+        delete window.location;
+        window.location = {
+            protocol: 'https:',
+            hostname: 'connect.trezor.io',
+            href: 'https://connect.trezor.io',
+            toString: () => 'https://connect.trezor.io',
+        };
+    });
+    afterAll(() => {
+        window.location = location; // restore default
+    });
+
+    it('parseConnectSettings: connect src in location.search', () => {
+        window.location = { search: 'trezor-connect-src=https://connect.trezor.io/beta.1/' };
+        expect(parseConnectSettings({}).connectSrc).toEqual('https://connect.trezor.io/beta.1/');
+
+        window.location = {
+            search: 'foo=bar&trezor-connect-src=https://connect.trezor.io/beta.2/',
+        };
+        expect(parseConnectSettings({}).connectSrc).toEqual('https://connect.trezor.io/beta.2/');
+
+        window.location = {
+            search: 'trezor-connect-src=https://connect.trezor.io/beta.3/&foo=bar',
+        };
+        expect(parseConnectSettings({}).connectSrc).toEqual('https://connect.trezor.io/beta.3/');
+
+        window.location = {
+            search: 'trezor-connect-src=https%3A%2F%2Fconnect.trezor.io%2Fbeta.encoded%2F',
+        }; // encoded
+        expect(parseConnectSettings({}).connectSrc).toEqual(
+            'https://connect.trezor.io/beta.encoded/',
+        );
+
+        window.location = { search: 'trezor-connect-src=https://connect-beta.trezor.oi/beta.3/' }; // invalid domain "io"
+        expect(parseConnectSettings({}).connectSrc).toEqual(undefined);
+    });
+
+    it('parseConnectSettings: connect src in window/global scope', () => {
+        window.__TREZOR_CONNECT_SRC = 'https://connect.trezor.io/beta.4/';
+        expect(parseConnectSettings({}).connectSrc).toEqual('https://connect.trezor.io/beta.4/');
+
+        window.__TREZOR_CONNECT_SRC = 'https://connect-beta.trezor.oi/beta.4/'; // invalid domain
+        expect(parseConnectSettings({}).connectSrc).toEqual(undefined);
+
+        delete window.__TREZOR_CONNECT_SRC; // restore
+
+        // @ts-expect-error
+        global.window = undefined;
+        global.__TREZOR_CONNECT_SRC = 'https://connect.trezor.io/beta.5/';
+        expect(parseConnectSettings({}).connectSrc).toEqual('https://connect.trezor.io/beta.5/');
+        delete global.__TREZOR_CONNECT_SRC; // restore
+    });
+});

--- a/packages/connect/src/api/setProxy.ts
+++ b/packages/connect/src/api/setProxy.ts
@@ -18,7 +18,7 @@ export default class SetProxy extends AbstractMethod<'setProxy'> {
         const { proxy } = DataManager.getSettings();
         const isChanged = proxy !== this.payload.proxy;
         if (isChanged) {
-            DataManager.settings.proxy = this.payload.proxy;
+            DataManager.getSettings().proxy = this.payload.proxy;
             await reconnectAllBackends();
         }
 

--- a/packages/connect/src/data/DataManager.ts
+++ b/packages/connect/src/data/DataManager.ts
@@ -2,7 +2,6 @@
 
 import parseUri from 'parse-uri';
 import { httpRequest } from '../utils/assets';
-import { DEFAULT_PRIORITY } from './connectSettings';
 import { parseCoinsJson } from './coinInfo';
 import { parseFirmware } from './firmwareInfo';
 import { parseBridgeJSON } from './transportInfo';
@@ -15,47 +14,12 @@ type AssetCollection = { [key: string]: JSON };
 export class DataManager {
     static assets: AssetCollection = {};
 
-    static settings: ConnectSettings;
-
+    private static settings: ConnectSettings;
     private static messages: JSON;
 
     static async load(settings: ConnectSettings, withAssets = true) {
         const ts = settings.env === 'web' ? `?r=${settings.timestamp}` : '';
         this.settings = settings;
-
-        // check if origin is localhost or trusted
-        const isLocalhost =
-            typeof window !== 'undefined' && window.location
-                ? window.location.hostname === 'localhost'
-                : true;
-        const whitelist = DataManager.isWhitelisted(this.settings.origin || '');
-        this.settings.trustedHost = (isLocalhost || !!whitelist) && !this.settings.popup;
-        // ensure that popup will be used
-        if (!this.settings.trustedHost) {
-            this.settings.popup = true;
-        }
-        // ensure that debug is disabled
-        if (!this.settings.trustedHost && !whitelist) {
-            this.settings.debug = false;
-        }
-
-        this.settings.priority = DataManager.getPriority(whitelist);
-
-        const knownHost = DataManager.getHostLabel(
-            this.settings.extension || this.settings.origin || '',
-        );
-        if (knownHost) {
-            this.settings.hostLabel = knownHost.label;
-            this.settings.hostIcon = knownHost.icon;
-        }
-
-        // hotfix webusb + chrome:72, allow webextensions
-        if (this.settings.popup && this.settings.env !== 'webextension') {
-            // allow all but WebUsbTransport
-            this.settings.transports = this.settings.transports?.filter(
-                (transport: string) => transport !== 'WebUsbTransport',
-            );
-        }
 
         if (!withAssets) return;
 
@@ -82,20 +46,6 @@ export class DataManager {
         return this.messages;
     }
 
-    static isWhitelisted(origin: string) {
-        const uri = parseUri(origin);
-        if (uri && typeof uri.host === 'string') {
-            const parts = uri.host.split('.');
-            if (parts.length > 2) {
-                // subdomain
-                uri.host = parts.slice(parts.length - 2, parts.length).join('.');
-            }
-            return config.whitelist.find(
-                item => item.origin === origin || item.origin === uri.host,
-            );
-        }
-    }
-
     static isManagementAllowed() {
         const uri = parseUri(this.settings.origin ?? '');
         if (uri && typeof uri.host === 'string') {
@@ -108,17 +58,6 @@ export class DataManager {
                 item => item.origin === this.settings.origin || item.origin === uri.host,
             );
         }
-    }
-
-    static getPriority(whitelist?: (typeof config)['whitelist'][0]) {
-        if (whitelist) {
-            return whitelist.priority;
-        }
-        return DEFAULT_PRIORITY;
-    }
-
-    static getHostLabel(origin: string) {
-        return config.knownHosts.find(host => host.origin === origin);
     }
 
     static getSettings(key?: undefined): ConnectSettings;

--- a/packages/connect/src/data/__tests__/DataManager.test.ts
+++ b/packages/connect/src/data/__tests__/DataManager.test.ts
@@ -35,28 +35,8 @@ describe('data/DataManager', () => {
         }
     });
 
-    test('isWhitelisted', () => {
-        expect(DataManager.isWhitelisted('https://trezor.io')).toEqual({
-            origin: 'trezor.io',
-            priority: 0,
-        });
-        expect(DataManager.isWhitelisted('http://github.com')).toEqual(undefined);
-    });
-
     test('isManagementAllowed', () => {
         expect(DataManager.isManagementAllowed()).toEqual(undefined);
-    });
-
-    test('getPriority', () => {
-        expect(DataManager.getPriority()).toEqual(2);
-    });
-
-    test('getHostLabel', () => {
-        expect(DataManager.getHostLabel('webextension@metamask.io')).toEqual({
-            icon: '',
-            label: 'MetaMask',
-            origin: 'webextension@metamask.io',
-        });
     });
 
     test('getSettings', () => {

--- a/packages/connect/src/data/__tests__/connectSettings.test.ts
+++ b/packages/connect/src/data/__tests__/connectSettings.test.ts
@@ -43,45 +43,4 @@ describe('data/connectSettings', () => {
         expect(corsValidator(1)).not.toBeDefined();
         expect(corsValidator('https://other-domain.com/connect.trezor.io/9/')).not.toBeDefined();
     });
-
-    it('parseConnectSettings: custom connect src', () => {
-        window.location = { search: 'trezor-connect-src=https://connect.trezor.io/beta.1/' };
-        expect(parseConnectSettings({}).connectSrc).toEqual('https://connect.trezor.io/beta.1/');
-
-        window.location = {
-            search: 'foo=bar&trezor-connect-src=https://connect.trezor.io/beta.2/',
-        };
-        expect(parseConnectSettings({}).connectSrc).toEqual('https://connect.trezor.io/beta.2/');
-
-        window.location = {
-            search: 'trezor-connect-src=https://connect.trezor.io/beta.3/&foo=bar',
-        };
-        expect(parseConnectSettings({}).connectSrc).toEqual('https://connect.trezor.io/beta.3/');
-
-        window.location = {
-            search: 'trezor-connect-src=https%3A%2F%2Fconnect.trezor.io%2Fbeta.encoded%2F',
-        }; // encoded
-        expect(parseConnectSettings({}).connectSrc).toEqual(
-            'https://connect.trezor.io/beta.encoded/',
-        );
-
-        window.location = { search: 'trezor-connect-src=https://connect-beta.trezor.oi/beta.3/' }; // invalid domain "io"
-        expect(parseConnectSettings({}).connectSrc).toEqual(undefined);
-
-        delete window.location.search; // restore
-
-        window.__TREZOR_CONNECT_SRC = 'https://connect.trezor.io/beta.4/';
-        expect(parseConnectSettings({}).connectSrc).toEqual('https://connect.trezor.io/beta.4/');
-
-        window.__TREZOR_CONNECT_SRC = 'https://connect-beta.trezor.oi/beta.4/'; // invalid domain
-        expect(parseConnectSettings({}).connectSrc).toEqual(undefined);
-
-        delete window.__TREZOR_CONNECT_SRC; // restore
-
-        // @ts-expect-error
-        global.window = undefined;
-        global.__TREZOR_CONNECT_SRC = 'https://connect.trezor.io/beta.5/';
-        expect(parseConnectSettings({}).connectSrc).toEqual('https://connect.trezor.io/beta.5/');
-        delete global.__TREZOR_CONNECT_SRC; // restore
-    });
 });

--- a/packages/connect/src/device/DeviceList.ts
+++ b/packages/connect/src/device/DeviceList.ts
@@ -82,8 +82,8 @@ export class DeviceList extends EventEmitter {
     constructor() {
         super();
 
-        const { env } = DataManager.settings;
-        let { transports: transportSettings } = DataManager.settings;
+        const env = DataManager.getSettings('env');
+        let transportSettings = DataManager.getSettings('transports');
 
         const transports: Transport[] = [];
 

--- a/packages/connect/src/global.d.ts
+++ b/packages/connect/src/global.d.ts
@@ -1,9 +1,0 @@
-// Globals
-declare namespace globalThis {
-    // eslint-disable-next-line no-var, vars-on-top
-    var __TREZOR_CONNECT_SRC: string | undefined;
-}
-
-interface Window {
-    __TREZOR_CONNECT_SRC?: string;
-}

--- a/packages/connect/src/index.ts
+++ b/packages/connect/src/index.ts
@@ -130,11 +130,7 @@ const init = async (settings: Partial<ConnectSettings> = {}) => {
     if (_core) {
         throw ERRORS.TypedError('Init_AlreadyInitialized');
     }
-    _settings = parseConnectSettings({ ..._settings, ...settings });
-    // set defaults for node
-    _settings.origin = 'http://node.trezor.io/';
-    _settings.popup = false;
-    _settings.env = 'node';
+    _settings = parseConnectSettings({ ..._settings, ...settings, popup: false });
 
     if (!_settings.manifest) {
         throw ERRORS.TypedError('Init_ManifestMissing');

--- a/packages/connect/src/utils/urlUtils.ts
+++ b/packages/connect/src/utils/urlUtils.ts
@@ -8,6 +8,18 @@ export const getOrigin = (url: string) => {
     return Array.isArray(parts) && parts.length > 0 ? parts[0] : 'unknown';
 };
 
+export const getHost = (url: string) => {
+    const origin = getOrigin(url);
+    const [_, uri] = getOrigin(origin).split('//');
+    if (uri) {
+        const parts = uri.split('.');
+        return parts.length > 2
+            ? // slice subdomain
+              parts.slice(parts.length - 2, parts.length).join('.')
+            : uri;
+    }
+};
+
 export const getOnionDomain = <T extends string | string[]>(
     url: T,
     dict: { [domain: string]: string },


### PR DESCRIPTION
## Description

move window related `ConnectSettings` code to the right packages:

`@trezor/connect-web` - reading `__TREZOR_CONNECT_SRC` and/or `url?trezor-connect-src=` from window
`@trezor/connect-iframe` - validation and additional web related checks
`@trezor/connect` - simple validation, default env set to `node`

## Related Issue
related https://github.com/trezor/trezor-suite/issues/5319
