### PR TITLE
fix(coinjoin): allow all methods used by coinjoin for T1

### DIFF
--- a/packages/connect/src/api/setBusy.ts
+++ b/packages/connect/src/api/setBusy.ts
@@ -12,10 +12,7 @@ export default class SetBusy extends AbstractMethod<'setBusy', PROTO.SetBusy> {
 
         validateParams(payload, [{ name: 'expiry_ms', type: 'number' }]);
 
-        this.firmwareRange = getFirmwareRange(this.name, null, {
-            1: { min: '0', max: '0' },
-            2: { min: '2.5.3', max: '0' },
-        });
+        this.firmwareRange = getFirmwareRange(this.name, undefined, this.firmwareRange);
 
         this.params = {
             expiry_ms: payload.expiry_ms,

--- a/packages/connect/src/api/unlockPath.ts
+++ b/packages/connect/src/api/unlockPath.ts
@@ -7,10 +7,7 @@ export default class UnlockPath extends AbstractMethod<'unlockPath', PROTO.Unloc
     init() {
         this.requiredPermissions = ['read'];
         this.skipFinalReload = true;
-        this.firmwareRange = getFirmwareRange(this.name, null, {
-            1: { min: '1.12.1', max: '0' },
-            2: { min: '2.5.3', max: '0' },
-        });
+        this.firmwareRange = getFirmwareRange(this.name, undefined, this.firmwareRange);
 
         const { payload } = this;
 

--- a/packages/connect/src/data/config.ts
+++ b/packages/connect/src/data/config.ts
@@ -182,7 +182,13 @@ export const config = {
         },
         {
             capabilities: ['coinjoin'],
-            methods: ['authorizeCoinjoin', 'getOwnershipId', 'getOwnershipProof'],
+            methods: [
+                'authorizeCoinjoin',
+                'getOwnershipId',
+                'getOwnershipProof',
+                'setBusy',
+                'unlockPath',
+            ],
             min: ['1.12.1', '2.5.3'],
         },
     ],


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

`setBusy` method has to be allowed for T1 too

possibly fix `ERROR(@trezor/coinjoin): Trying to sign input with assigned error Locked` 

## Related Issue

Resolve https://github.com/trezor/trezor-suite/issues/7807

