### PR TITLE
fix(suite-native): avoid building flipper for release build

### DIFF
--- a/suite-native/app/android/app/src/release/io/trezor/suite/ReactNativeFlipper.java
+++ b/suite-native/app/android/app/src/release/io/trezor/suite/ReactNativeFlipper.java
@@ -1,0 +1,21 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * <p>This source code is licensed under the MIT license found in the LICENSE file in the root
+ * directory of this source tree.
+ */
+package io.trezor.suite;
+
+import android.content.Context;
+import com.facebook.react.ReactInstanceManager;
+
+/**
+ * Class responsible of loading Flipper inside your React Native application. This is the release
+ * flavor of it so it's empty as we don't want to load Flipper.
+ */
+public class ReactNativeFlipper {
+  public static void initializeFlipper(Context context, ReactInstanceManager reactInstanceManager) {
+    // Do nothing as we don't want to initialize Flipper on Release.
+  }
+}
+suite-native/app/android/app/src/release/java/io/trezor/suite/ReactNativeFlipper.java


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Failing action for release build on android https://github.com/trezor/trezor-suite/actions/runs/4468384664/jobs/7849061275

<img width="1036" alt="Screenshot 2023-03-20 at 16 29 42" src="https://user-images.githubusercontent.com/36101761/226389193-16b4789c-87c4-4f39-8c7a-c399e96676d9.png">

Issue with proposed fix: https://github.com/facebook/react-native/issues/36060

It's possible that this will fail as well because of duplicated class ReactNativeFlipper as mentioned in the issue comment. In that case we'd need to remove `stag/` directory as well. 


## Related Issue

Resolve <!--- link the issue here -->

## Screenshots:
