### PR TITLE
fix(suite-native): remove bottom padding

### DIFF
--- a/suite-native/transactions/src/components/TransactionsList/TransactionList.tsx
+++ b/suite-native/transactions/src/components/TransactionsList/TransactionList.tsx
@@ -7,7 +7,6 @@ import { AccountKey, WalletAccountTransaction } from '@suite-common/wallet-types
 import { groupTransactionsByDate, MonthKey } from '@suite-common/wallet-utils';
 import { selectIsLoadingTransactions } from '@suite-common/wallet-core';
 import { Box, Loader } from '@suite-native/atoms';
-import { TAB_BAR_HEIGHT } from '@suite-native/navigation';
 
 import { TransactionListGroupTitle } from './TransactionListGroupTitle';
 import { TransactionListItem } from './TransactionListItem';
@@ -53,7 +52,6 @@ export const TX_PER_PAGE = 25;
 // The box doesn't seem to be stopped visually by tab bar and SectionList cmp cannot be inside ScrollView cmp
 // That's why we add padding bottom to avoid style clash.
 const listWrapperStyle = prepareNativeStyle(_ => ({
-    paddingBottom: TAB_BAR_HEIGHT,
     height: '100%',
 }));
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Fixes bug with bottom padding at transaction list.

## Related Issue

Resolve <!--- link the issue here -->

## Screenshots:
<img width="339" alt="image" src="https://user-images.githubusercontent.com/36101761/226571077-d9a239b9-d912-4b50-9858-37f162e90c0b.png">
