### PR TITLE
Improved CJ discovery logging

### DIFF
--- a/packages/coinjoin/src/backend/CoinjoinBackend.ts
+++ b/packages/coinjoin/src/backend/CoinjoinBackend.ts
@@ -178,7 +178,7 @@ export class CoinjoinBackend extends EventEmitter {
         const emit = (level: LogLevel) => (payload: string) => this.emit('log', { level, payload });
         return {
             debug: emit('debug'),
-            log: emit('log'),
+            info: emit('info'),
             warn: emit('warn'),
             error: emit('error'),
         };

--- a/packages/coinjoin/src/backend/CoinjoinBackend.ts
+++ b/packages/coinjoin/src/backend/CoinjoinBackend.ts
@@ -69,10 +69,12 @@ export class CoinjoinBackend extends EventEmitter {
         super();
         this.settings = Object.freeze(settings);
         this.network = getNetwork(settings.network);
-        this.client = new CoinjoinBackendClient({ ...settings, logger: this.getLogger() });
+        const logger = this.getLogger();
+        this.client = new CoinjoinBackendClient({ ...settings, logger });
         this.mempool = new CoinjoinMempoolController({
             client: this.client,
             filter: tx => isTaprootTx(tx, this.network),
+            logger,
         });
     }
 

--- a/packages/coinjoin/src/backend/CoinjoinBackendClient.ts
+++ b/packages/coinjoin/src/backend/CoinjoinBackendClient.ts
@@ -100,7 +100,7 @@ export class CoinjoinBackendClient {
         const url = this.blockbookUrls[this.blockbookRequestId++ % this.blockbookUrls.length];
         const identity = options?.identity;
         const api = await this.websockets.getOrCreate(url, identity);
-        this.logger?.log(`WS ${method} ${params} ${this.websockets.getSocketId(url, identity)}`);
+        this.logger?.debug(`WS ${method} ${params} ${this.websockets.getSocketId(url, identity)}`);
         return (api[method] as any).apply(api, params);
     }
 
@@ -189,7 +189,7 @@ export class CoinjoinBackendClient {
     protected wabisabiGet(path: string, query?: Record<string, any>, options?: RequestOptions) {
         const url = `${this.wabisabiUrl}/${path}`;
         const identity = this.identityWabisabi;
-        this.logger?.log(`GET ${url}${query ? `?${new URLSearchParams(query)}` : ''}`);
+        this.logger?.debug(`GET ${url}${query ? `?${new URLSearchParams(query)}` : ''}`);
         return httpGet(url, query, { identity, ...options });
     }
 }

--- a/packages/coinjoin/src/backend/CoinjoinWebsocketController.ts
+++ b/packages/coinjoin/src/backend/CoinjoinWebsocketController.ts
@@ -32,9 +32,9 @@ export class CoinjoinWebsocketController {
         }
         if (!socket.isConnected()) {
             await socket.connect();
-            this.logger?.log(`WS OPENED ${socketId}`);
+            this.logger?.debug(`WS OPENED ${socketId}`);
             socket.once('disconnected', () => {
-                this.logger?.log(`WS CLOSED ${socketId}`);
+                this.logger?.debug(`WS CLOSED ${socketId}`);
             });
         }
         return socket;

--- a/packages/coinjoin/src/client/CoinjoinClient.ts
+++ b/packages/coinjoin/src/client/CoinjoinClient.ts
@@ -103,7 +103,7 @@ export class CoinjoinClient extends EventEmitter {
         if (this.accounts.find(a => a.accountKey === account.accountKey)) {
             throw new Error('Trying to register account that already exists');
         }
-        this.logger.log(`Register account ~~${account.accountKey}~~`);
+        this.logger.info(`Register account ~~${account.accountKey}~~`);
 
         // iterate Status more frequently
         if (this.accounts.length === 0) {
@@ -120,7 +120,7 @@ export class CoinjoinClient extends EventEmitter {
     }
 
     updateAccount(account: RegisterAccountParams) {
-        this.logger.log(`Update account ~~${account.accountKey}~~`);
+        this.logger.info(`Update account ~~${account.accountKey}~~`);
         const accountToUpdate = this.accounts.find(a => a.accountKey === account.accountKey);
         if (accountToUpdate) {
             this.rounds.forEach(round => round.updateAccount(account));
@@ -136,7 +136,7 @@ export class CoinjoinClient extends EventEmitter {
     }
 
     unregisterAccount(accountKey: string) {
-        this.logger.log(`Unregister account ~~${accountKey}~~`);
+        this.logger.info(`Unregister account ~~${accountKey}~~`);
         this.rounds.forEach(round => {
             round.unregisterAccount(accountKey);
         });
@@ -273,7 +273,7 @@ export class CoinjoinClient extends EventEmitter {
             this.emit('log', { level, payload: redacted(payload) });
         return {
             debug: emit('debug'),
-            log: emit('log'),
+            info: emit('info'),
             warn: emit('warn'),
             error: emit('error'),
         };

--- a/packages/coinjoin/src/client/CoinjoinRound.ts
+++ b/packages/coinjoin/src/client/CoinjoinRound.ts
@@ -194,7 +194,7 @@ export class CoinjoinRound extends EventEmitter {
             if (!shouldCoolOff) {
                 await unlock();
             } else {
-                this.logger.log(
+                this.logger.info(
                     `Waiting for round ${this.id} to cool off ${ROUND_PHASE_PROCESS_TIMEOUT}ms`,
                 );
                 // either process will finish gracefully or will be aborted
@@ -224,7 +224,7 @@ export class CoinjoinRound extends EventEmitter {
     }
 
     async process(accounts: Account[]) {
-        const { log } = this.logger;
+        const { info: log } = this.logger;
         if (this.inputs.length === 0) {
             log('Trying to process round without inputs');
             return this;
@@ -326,7 +326,7 @@ export class CoinjoinRound extends EventEmitter {
             const inputs = this.inputs.filter(input => !input.ownershipProof && !input.requested);
             if (inputs.length > 0) {
                 inputs.forEach(input => {
-                    this.logger.log(`Requesting ownership for ~~${input.outpoint}~~`);
+                    this.logger.info(`Requesting ownership for ~~${input.outpoint}~~`);
                     input.setRequest('ownership');
                 });
                 return {
@@ -342,7 +342,7 @@ export class CoinjoinRound extends EventEmitter {
             if (inputs.length > 0 && this.transactionData && this.liquidityClues) {
                 this.setSessionPhase(SessionPhase.TransactionSigning);
                 inputs.forEach(input => {
-                    this.logger.log(`Requesting witness for ~~${input.outpoint}~~`);
+                    this.logger.info(`Requesting witness for ~~${input.outpoint}~~`);
                     input.setRequest('signature');
                 });
                 return {
@@ -357,7 +357,7 @@ export class CoinjoinRound extends EventEmitter {
     }
 
     resolveRequest({ type, inputs }: CoinjoinResponseEvent) {
-        const { log } = this.logger;
+        const { info: log } = this.logger;
         inputs.forEach(i => {
             const input = this.inputs.find(a => a.outpoint === i.outpoint);
             if (!input) return;
@@ -428,7 +428,7 @@ export class CoinjoinRound extends EventEmitter {
             // if affiliate server goes offline try to abort round if it's not in critical phase.
             // if round is in critical phase, there is noting much we can do...
             // ...we need to continue and hope that server will become online before transaction signing phase
-            this.logger.log(`Affiliate server offline. Aborting round ${this.id}`);
+            this.logger.info(`Affiliate server offline. Aborting round ${this.id}`);
             this.lock?.abort();
             this.inputs.forEach(i => i.clearConfirmationInterval());
         }
@@ -436,7 +436,7 @@ export class CoinjoinRound extends EventEmitter {
 
     // forced by CoinjoinClient.disable. stop processes if any
     end() {
-        this.logger.log(`Aborting round ${this.id}`);
+        this.logger.info(`Aborting round ${this.id}`);
         this.lock?.abort();
 
         this.inputs.forEach(i => i.clearConfirmationInterval());

--- a/packages/coinjoin/src/client/round/connectionConfirmation.ts
+++ b/packages/coinjoin/src/client/round/connectionConfirmation.ts
@@ -30,7 +30,7 @@ const confirmInput = async (
         throw new Error(`Trying to confirm unregistered input ~~${input.outpoint}~~`);
     }
     if (input.confirmedAmountCredentials && input.confirmedVsizeCredentials) {
-        options.logger.log(`Input ~~${input.outpoint}~~ already confirmed. Skipping.`);
+        options.logger.info(`Input ~~${input.outpoint}~~ already confirmed. Skipping.`);
         return input;
     }
 
@@ -54,7 +54,7 @@ const confirmInput = async (
     const deadline =
         round.phaseDeadline + readTimeSpan(round.roundParameters.connectionConfirmationTimeout);
 
-    logger.log(
+    logger.info(
         `Confirming ~~${input.outpoint}~~ to ~~${round.id}~~ phase ${round.phase} with delay ${delay}ms and deadline ${deadline}`,
     );
 
@@ -74,7 +74,7 @@ const confirmInput = async (
         !confirmationData.realAmountCredentials ||
         !confirmationData.realVsizeCredentials
     ) {
-        logger.log(`Confirmed in phase ${round.phase} ~~${input.outpoint}~~ in ~~${round.id}~~`);
+        logger.info(`Confirmed in phase ${round.phase} ~~${input.outpoint}~~ in ~~${round.id}~~`);
         return input;
     }
 
@@ -91,7 +91,7 @@ const confirmInput = async (
         { baseUrl: middlewareUrl }, // NOTE: post processing intentionally without abort signal (should not be aborted)
     );
 
-    logger.log(`Confirmed ~~${input.outpoint}~~ in ~~${round.id}~~`);
+    logger.info(`Confirmed ~~${input.outpoint}~~ in ~~${round.id}~~`);
 
     input.setConfirmationData(confirmationData);
     input.setConfirmedCredentials(confirmedAmountCredentials, confirmedVsizeCredentials);
@@ -117,13 +117,15 @@ export const confirmationInterval = (
     const promise = new Promise<Alice>(resolve => {
         const { logger } = options;
         const done = () => {
-            logger.log(`Confirmation interval for ~~${input.outpoint}~~ completed`);
+            logger.info(`Confirmation interval for ~~${input.outpoint}~~ completed`);
             resolve(input);
         };
 
         const timeoutFn = async () => {
             const delay = Math.max(intervalDelay - requestLatency, 0);
-            logger.log(`Setting confirmation interval for ~~${input.outpoint}~~. Delay ${delay}ms`);
+            logger.info(
+                `Setting confirmation interval for ~~${input.outpoint}~~. Delay ${delay}ms`,
+            );
 
             try {
                 const start = Date.now() + delay;
@@ -169,7 +171,7 @@ export const connectionConfirmation = async (
 ) => {
     // try to confirm each input
     // failed inputs will be excluded from this round, successful will continue to phase: 2 (outputRegistration)
-    options.logger.log(`connectionConfirmation: ~~${round.id}~~`);
+    options.logger.info(`connectionConfirmation: ~~${round.id}~~`);
     round.setSessionPhase(SessionPhase.AwaitingConfirmation);
 
     const { inputs } = round;

--- a/packages/coinjoin/src/client/round/inputRegistration.ts
+++ b/packages/coinjoin/src/client/round/inputRegistration.ts
@@ -30,12 +30,12 @@ const registerInput = async (
     }
     // stop here and request for ownership proof from the wallet
     if (!input.ownershipProof) {
-        logger.log(`Waiting for ~~${input.outpoint}~~ ownership proof`);
+        logger.info(`Waiting for ~~${input.outpoint}~~ ownership proof`);
         return input;
     }
 
     if (input.registrationData) {
-        logger.log(`Input ~~${input.outpoint}~~ already registered. Skipping.`);
+        logger.info(`Input ~~${input.outpoint}~~ already registered. Skipping.`);
         return input;
     }
 
@@ -55,7 +55,7 @@ const registerInput = async (
     // note that this may cause that the input will not be registered if phase change before expected deadline
     const deadline = round.phaseDeadline - Date.now() - ROUND_SELECTION_REGISTRATION_OFFSET;
     const delay = deadline > 0 ? getRandomNumberInRange(0, deadline) : 0;
-    logger.log(
+    logger.info(
         `Trying to register ~~${input.outpoint}~~ to ~~${round.id}~~ with delay ${delay}ms and deadline ${round.phaseDeadline}`,
     );
 
@@ -141,10 +141,10 @@ const registerInput = async (
             { baseUrl: middlewareUrl },
         );
 
-        logger.log(
+        logger.info(
             `Registration ~~${input.outpoint}~~ to ~~${round.id}~~ successful. aliceId: ${registrationData.aliceId}`,
         );
-        logger.log(
+        logger.info(
             `~~${input.outpoint}~~ will pay ${coordinatorFee} coordinator fee and ${miningFee} mining fee`,
         );
 
@@ -170,7 +170,7 @@ const registerInput = async (
 export const inputRegistration = async (round: CoinjoinRound, options: CoinjoinRoundOptions) => {
     // try to register each input
     // failed inputs will be excluded from this round, successful will continue to phase: 1 (connectionConfirmation)
-    options.logger.log(`inputRegistration: ~~${round.id}~~`);
+    options.logger.info(`inputRegistration: ~~${round.id}~~`);
     round.setSessionPhase(SessionPhase.CoinRegistration);
 
     const { inputs } = round;

--- a/packages/coinjoin/src/client/round/outputDecomposition.ts
+++ b/packages/coinjoin/src/client/round/outputDecomposition.ts
@@ -47,8 +47,8 @@ const getOutputAmounts = async (params: GetOutputAmountsParams) => {
             externalAmounts.push(i.coin.txOut.value - coordinatorFee - miningFee);
         }
     });
-    logger.log(`Internal inputs: ${internalAmounts.join(',')}`);
-    logger.log(`External inputs: ${externalAmounts.join(',')}`);
+    logger.info(`Internal inputs: ${internalAmounts.join(',')}`);
+    logger.info(`External inputs: ${externalAmounts.join(',')}`);
 
     const outputAmounts = await middleware.getOutputsAmounts(
         {
@@ -62,7 +62,7 @@ const getOutputAmounts = async (params: GetOutputAmountsParams) => {
         },
         { signal, baseUrl: middlewareUrl },
     );
-    logger.log(`Decompose amounts: ${outputAmounts.join(',')}`);
+    logger.info(`Decompose amounts: ${outputAmounts.join(',')}`);
     return outputAmounts.map(amount => {
         const miningFee = Math.floor((outputSize * roundParameters.miningFeeRate) / 1000);
         const coordinatorFee = 0; // NOTE: middleware issue https://github.com/zkSNACKs/WalletWasabi/issues/8814 should be `amount > plebsDontPayThreshold ? Math.floor(roundParameters.coordinationFeeRate.rate * amount) : 0` but middleware does not considerate coordinationFeeRate and plebs for external amounts
@@ -89,11 +89,11 @@ const credentialIssuance = async (params: CredentialIssuanceParams) => {
     const { roundParameters } = round;
     const { signal, coordinatorUrl, middlewareUrl, logger } = params.options;
 
-    logger.log('Joining credentials');
-    logger.log(
+    logger.info('Joining credentials');
+    logger.info(
         `Amount ${amountCredentials.map(c => c.value).join(',')} to ${amountToRequest.join(',')}`,
     );
-    logger.log(
+    logger.info(
         `Vsize ${vsizeCredentials.map(c => c.value).join(',')} to ${vsizeToRequest.join(',')}`,
     );
 
@@ -187,14 +187,14 @@ const credentialIssuance = async (params: CredentialIssuanceParams) => {
         vsizeCredentials: [vsizeCredentialsOut[1], zeroVsizeCredentialsOut[1]],
     };
 
-    logger.log(
+    logger.info(
         `Output amount credentials: ${output.amountCredentials.map(c => c.value).join(',')}`,
     );
-    logger.log(`Output vsize credentials: ${output.vsizeCredentials.map(c => c.value).join(',')}`);
-    logger.log(
+    logger.info(`Output vsize credentials: ${output.vsizeCredentials.map(c => c.value).join(',')}`);
+    logger.info(
         `Change amount credentials: ${change.amountCredentials.map(c => c.value).join(',')}`,
     );
-    logger.log(`Change vsize credentials: ${change.vsizeCredentials.map(c => c.value).join(',')}`);
+    logger.info(`Change vsize credentials: ${change.vsizeCredentials.map(c => c.value).join(',')}`);
 
     return {
         output,
@@ -326,9 +326,9 @@ const createOutputsCredentials = async (params: CreateOutputsCredentials): Promi
             const amountDust = sumCredentials(updatedAmountCredentials);
             const vsizeDust = sumCredentials(updatedVsizeCredentials);
 
-            options.logger.log(`Amount dust: ${amountDust}`);
-            options.logger.log(`Vsize dust: ${vsizeDust}`);
-            options.logger.log('Decomposition completed');
+            options.logger.info(`Amount dust: ${amountDust}`);
+            options.logger.info(`Vsize dust: ${vsizeDust}`);
+            options.logger.info('Decomposition completed');
 
             return result.sort((a, b) => (a.amount > b.amount ? -1 : 1));
         }
@@ -410,7 +410,7 @@ export const outputDecomposition = async (
 
     const { logger } = options;
 
-    logger.log(`Decompose ${Object.keys(groupInputsByAccount).length} accounts`);
+    logger.info(`Decompose ${Object.keys(groupInputsByAccount).length} accounts`);
 
     // calculate amounts
     const outputAmounts = await Promise.all(
@@ -434,7 +434,7 @@ export const outputDecomposition = async (
         Object.keys(groupInputsByAccount).map((accountKey, index) => {
             if (!outputAmounts[index]) throw new Error(`Missing amounts at index ${index}`);
 
-            logger.log(`Create outputs: ${outputAmounts[index].join(',')}`);
+            logger.info(`Create outputs: ${outputAmounts[index].join(',')}`);
             const inputs = groupInputsByAccount[accountKey];
             const amountCredentials = inputs.flatMap(i => i.confirmedAmountCredentials!);
             const vsizeCredentials = inputs.flatMap(i => i.confirmedVsizeCredentials!);

--- a/packages/coinjoin/src/client/round/outputRegistration.ts
+++ b/packages/coinjoin/src/client/round/outputRegistration.ts
@@ -115,7 +115,7 @@ export const outputRegistration = async (
 ) => {
     const { logger } = options;
 
-    logger.log(`outputRegistration: ~~${round.id}~~`);
+    logger.info(`outputRegistration: ~~${round.id}~~`);
     // TODO:
     // - decide if there is only 1 account registered should i abaddon this round and blame it on some "youngest" input?
     // - maybe if there is only 1 account inputs are so "far away" from each other that it is wort to mix anyway?
@@ -148,7 +148,7 @@ export const outputRegistration = async (
         round.setSessionPhase(SessionPhase.AwaitingOthersOutputs);
         // inform coordinator that each registered input is ready to sign
         await Promise.all(round.inputs.map(input => readyToSign(round, input, options)));
-        logger.log(`Ready to sign ~~${round.id}~~`);
+        logger.info(`Ready to sign ~~${round.id}~~`);
     } catch (error) {
         // NOTE: if anything goes wrong in this process this Round will be corrupted for all the users
         // registered inputs will probably be banned

--- a/packages/coinjoin/src/client/round/transactionSigning.ts
+++ b/packages/coinjoin/src/client/round/transactionSigning.ts
@@ -136,7 +136,7 @@ export const transactionSigning = async (
 ): Promise<CoinjoinRound> => {
     const { logger } = options;
 
-    logger.log(`transactionSigning: ~~${round.id}~~`);
+    logger.info(`transactionSigning: ~~${round.id}~~`);
 
     const inputsWithError = round.inputs.filter(input => input.error);
     if (inputsWithError.length > 0) {
@@ -179,7 +179,7 @@ export const transactionSigning = async (
         await Promise.all(round.inputs.map(input => sendTxSignature(round, input, options)));
 
         round.setSessionPhase(SessionPhase.AwaitingOtherSignatures);
-        logger.log(`Round ${round.id} signed successfully`);
+        logger.info(`Round ${round.id} signed successfully`);
     } catch (error) {
         // NOTE: if anything goes wrong in this process this Round will be corrupted for all the users
         // registered inputs will probably be banned

--- a/packages/coinjoin/src/types/logger.ts
+++ b/packages/coinjoin/src/types/logger.ts
@@ -1,6 +1,6 @@
 export interface Logger {
     debug(message: string): void;
-    log(message: string): void;
+    info(message: string): void;
     warn(message: string): void;
     error(message: string): void;
 }

--- a/packages/coinjoin/tests/mocks/server.ts
+++ b/packages/coinjoin/tests/mocks/server.ts
@@ -242,7 +242,7 @@ export const createServer = async () => {
         signal: new AbortController().signal,
         logger: {
             debug: () => {},
-            log: () => {},
+            info: () => {},
             warn: () => {},
             error: () => {},
         },

--- a/packages/coinjoin/tests/tools/anonymity-test.ts
+++ b/packages/coinjoin/tests/tools/anonymity-test.ts
@@ -96,7 +96,7 @@ const CACHE_PARAMS = `${CACHE_DIR}/anonymityScoreParams.json`;
         signal: new AbortController().signal,
         logger: {
             debug: () => {},
-            log: () => {},
+            info: () => {},
             warn: () => {},
             error: () => {},
         },

--- a/packages/suite-desktop/src/modules/coinjoin.ts
+++ b/packages/suite-desktop/src/modules/coinjoin.ts
@@ -33,6 +33,9 @@ export const init: Module = ({ mainWindow }) => {
     const backendProxyOptions: IpcProxyHandlerOptions<CoinjoinBackend> = {
         onCreateInstance: (settings: ConstructorParameters<typeof CoinjoinBackend>[0]) => {
             const backend = new CoinjoinBackend(settings);
+            backend.on('log', ({ level, payload }) => {
+                logger[level](SERVICE_NAME, `${BACKEND_CHANNEL} ${payload}`);
+            });
             backends.push(backend);
             return {
                 onRequest: (method, params) => {

--- a/packages/suite/src/middlewares/wallet/coinjoinMiddleware.ts
+++ b/packages/suite/src/middlewares/wallet/coinjoinMiddleware.ts
@@ -56,6 +56,10 @@ export const coinjoinMiddleware =
             return action;
         }
 
+        if (action.type === SUITE.INIT) {
+            api.dispatch(coinjoinAccountActions.logCoinjoinAccounts());
+        }
+
         // propagate action to reducers
         next(action);
 

--- a/packages/suite/src/utils/wallet/coinjoinUtils.ts
+++ b/packages/suite/src/utils/wallet/coinjoinUtils.ts
@@ -296,7 +296,7 @@ export const getRoundPhaseFromSessionPhase = (sessionPhase: SessionPhase): Round
 export const getFirstSessionPhaseFromRoundPhase = (roundPhase?: RoundPhase): SessionPhase =>
     Number(`${(roundPhase || 0) + 1}1`);
 
-export const getAccountProgressHandle = (account: Account) =>
+export const getAccountProgressHandle = (account: Pick<Account, 'key'>) =>
     createHash('sha256').update(account.key).digest('hex').slice(0, 16);
 
 export const fixLoadedCoinjoinAccount = ({


### PR DESCRIPTION
## Description
To be able to better debug coinjoin discovery issues, logging was improved a bit.

## Commits
- https://github.com/trezor/trezor-suite/pull/7878/commits/a98df3c17052917dbc7ae6a072df109b1a1ad995 - mempool transactions incoming via ws are now logged (after filtering, so only the taproot ones)
- https://github.com/trezor/trezor-suite/pull/7878/commits/8fdf288e22feb3a6e7452d558656f6d6a6a14f5c - `log` log level in `@trezor/coinjoin` package was changed to `info`, so it's consistent with the `@trezor/suite-desktop` logger and still a subset of common console methods
- https://github.com/trezor/trezor-suite/pull/7878/commits/4223693a359a90487fb1f7a0f62f24bdfeab13e7 - refactoring of suite-desktop logging, mostly so there aren't repeated strings
- https://github.com/trezor/trezor-suite/pull/7878/commits/1d665273f4d83e9e5bcece1ed9e2bbde2ac67cc0 - renderer-to-main log transfer cleaned up a bit (mostly ignoring redux action logs) so `--log-ui` flag can be useful again
- https://github.com/trezor/trezor-suite/pull/7878/commits/1a2b3c25990c4f9f5d78ab32c72ee7a5ab5e3aa4 - `CoinjoinBackend` is now automatically logged (in the same way as `CoinjoinClient`) in `@trezor/suite-desktop` module
- https://github.com/trezor/trezor-suite/pull/7878/commits/8ee4e031f8f9d1a8fcd45d01400e04a21c62ec4b - improved logging of coinjoin account lifecycle in suite so we know when cj account is created/remembered/inconsistent or when there is a reorg; not sure about logging to console, but it should be useful with `--log-ui` flag