### PR TITLE
Connect test fixture

### DIFF
--- a/.github/workflows/connect-test.yml
+++ b/.github/workflows/connect-test.yml
@@ -10,6 +10,7 @@ on:
       - "packages/utxo-lib"
       - "packages/utils"
       - "docker"
+      - "submodules/trezor-common"
 
 jobs:
   # todo: meaning of 'build' job is questionable. only 'web' tests use part of this jobs output

--- a/packages/connect/e2e/__fixtures__/ethereumGetAddress.ts
+++ b/packages/connect/e2e/__fixtures__/ethereumGetAddress.ts
@@ -1,13 +1,24 @@
 import commonFixtures from '../../../../submodules/trezor-common/tests/fixtures/ethereum/getaddress.json';
 
+const legacyResults = {
+    'Ledger Live legacy path': [
+        {
+            // 'Forbidden key path' below these versions
+            rules: ['<2.5.4', '<1.12.2'],
+            success: false,
+        },
+    ],
+};
+
 export default {
     method: 'ethereumGetAddress',
     setup: {
         mnemonic: commonFixtures.setup.mnemonic,
     },
-    tests: commonFixtures.tests.flatMap(({ parameters: params, result }) => ({
+    tests: commonFixtures.tests.flatMap(({ parameters: params, result, name }) => ({
         description: params.path,
         params,
         result,
+        legacyResults: name ? legacyResults[name] : undefined,
     })),
 };

--- a/packages/connect/e2e/__fixtures__/ethereumSignMessage.ts
+++ b/packages/connect/e2e/__fixtures__/ethereumSignMessage.ts
@@ -1,19 +1,39 @@
+import { arrayPartition } from '@trezor/utils';
 import commonFixtures from '../../../../submodules/trezor-common/tests/fixtures/ethereum/signmessage.json';
+
+const [standardPathFixtures, nonstandardPathFixtures] = arrayPartition(
+    commonFixtures.tests,
+    ({ parameters }) => parameters.path.startsWith("m/44'/60'"),
+);
 
 export default {
     method: 'ethereumSignMessage',
     setup: {
         mnemonic: commonFixtures.setup.mnemonic,
     },
-    tests: commonFixtures.tests.flatMap(({ parameters, result }) => ({
-        description: `${parameters.path} ${parameters.msg.substring(0, 30)}...`,
-        params: {
-            path: parameters.path,
-            message: parameters.msg,
-        },
-        result: {
-            address: result.address,
-            signature: result.sig,
-        },
-    })),
+    tests: [
+        ...standardPathFixtures.flatMap(({ parameters, result }) => ({
+            description: `${parameters.path} ${parameters.msg.substring(0, 30)}...`,
+            params: {
+                path: parameters.path,
+                message: parameters.msg,
+            },
+            result: {
+                address: result.address,
+                signature: result.sig,
+            },
+        })),
+        ...nonstandardPathFixtures.flatMap(({ parameters }) => ({
+            description: `non standard path ${parameters.path} => Forbidden key path`,
+            params: {
+                path: parameters.path,
+                message: parameters.msg,
+            },
+            // {
+            // "code": "Failure_DataError",
+            // "error": "Forbidden key path",
+            // }
+            result: false,
+        })),
+    ],
 };

--- a/packages/connect/e2e/__fixtures__/ethereumSignTransaction.ts
+++ b/packages/connect/e2e/__fixtures__/ethereumSignTransaction.ts
@@ -1,5 +1,15 @@
 import commonFixtures from '../../../../submodules/trezor-common/tests/fixtures/ethereum/sign_tx.json';
 
+const legacyResults = {
+    'Ledger Live legacy path': [
+        {
+            // 'Forbidden key path' below these versions
+            rules: ['<2.5.4', '<1.12.2'],
+            success: false,
+        },
+    ],
+};
+
 export default {
     method: 'ethereumSignTransaction',
     setup: {
@@ -25,6 +35,7 @@ export default {
                     s: `0x${result.sig_s}`,
                     v: `0x${result.sig_v.toString(16)}`,
                 },
+                legacyResults: legacyResults[name],
             };
 
             if (parameters.data) {

--- a/packages/connect/e2e/__fixtures__/ethereumSignTransactionEip155.ts
+++ b/packages/connect/e2e/__fixtures__/ethereumSignTransactionEip155.ts
@@ -11,6 +11,13 @@ const legacyResults = {
             },
         },
     ],
+    'Ledger Live legacy path': [
+        {
+            // 'Forbidden key path' below these versions
+            rules: ['<2.5.4', '<1.12.2'],
+            success: false,
+        },
+    ],
 };
 
 export default {

--- a/packages/connect/e2e/__fixtures__/ethereumSignTransactionEip1559.ts
+++ b/packages/connect/e2e/__fixtures__/ethereumSignTransactionEip1559.ts
@@ -1,6 +1,16 @@
 import commonFixtures from '../../../../submodules/trezor-common/tests/fixtures/ethereum/sign_tx_eip1559.json';
 
-const legacyResults = [
+const legacyResults = {
+    'Ledger Live legacy path': [
+        {
+            // 'Forbidden key path' below these versions
+            rules: ['<2.5.4', '<1.12.2'],
+            success: false,
+        },
+    ],
+};
+
+const legacyResultsCommon = [
     {
         // ethereumSignTransactionEip1559 not supported below this version
         rules: ['<2.4.2', '<1.10.4'],
@@ -33,7 +43,8 @@ export default {
                 s: `0x${result.sig_s}`,
                 v: `0x${result.sig_v.toString(16)}`,
             },
-            legacyResults,
+            legacyResults: legacyResults[name] || legacyResultsCommon,
+
             // weird behavior on 2.2.0, always the first test times out with some emulator
             // error. the other tests that follow do pass.
             skip: ['2.2.0'],


### PR DESCRIPTION
https://github.com/trezor/trezor-suite/pull/7860 this introduced some new fixtures to ethereum

[feat(ci): run connect tests on submodules update](https://github.com/trezor/trezor-suite/commit/4fbaf9556d8d0fcaabdfa27b0290d80ec0464201) - run connect tests each time we update submodule to prevent this in the future
[test(connect): fix legacy params for eth sign test](https://github.com/trezor/trezor-suite/commit/a178409844a7fade66182fcdb1d1f691ebc5081e) - set legacyResults for this fixture 