### PR TITLE
fix(suite-native): graph-axis-label-visible

### DIFF
--- a/suite-native/graph/src/components/AxisLabel.tsx
+++ b/suite-native/graph/src/components/AxisLabel.tsx
@@ -11,7 +11,7 @@ type AxisLabelProps = {
 };
 
 const axisLabelStyle = prepareNativeStyle<Pick<AxisLabelProps, 'x'>>((_, { x }) => ({
-    position: 'relative',
+    position: 'absolute',
     left: `${x}%`,
 }));
 


### PR DESCRIPTION
Graph axis labels are not cropped anymore.

## Related Issue

Fixes #7814

## Screenshots:

### Before 
<img width="472" alt="Screenshot 2023-03-22 at 9 31 57" src="https://user-images.githubusercontent.com/26143964/226864815-e6a0b8eb-d3a2-4c27-9005-59a8d0060937.png">

### After
<img width="472" alt="Screenshot 2023-03-22 at 9 32 09" src="https://user-images.githubusercontent.com/26143964/226864856-a709f05d-4d67-4061-94fc-b72a89d2db69.png">
