### PR TITLE
connect - blockbook fiat rates, token param

### DIFF
--- a/packages/blockchain-link-types/src/params.ts
+++ b/packages/blockchain-link-types/src/params.ts
@@ -8,15 +8,18 @@ export interface AccountBalanceHistoryParams {
 
 export interface GetCurrentFiatRatesParams {
     currencies?: string[];
+    token?: string;
 }
 
 export interface GetFiatRatesForTimestampsParams {
     timestamps: number[];
     currencies?: string[];
+    token?: string;
 }
 
 export interface GetFiatRatesTickersListParams {
     timestamp?: number;
+    token?: string;
 }
 
 export interface EstimateFeeParams {

--- a/packages/blockchain-link/CHANGELOG.md
+++ b/packages/blockchain-link/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 2.1.9 [not released]
+
+-   feat: add `token` param to to `GetCurrentFiatRates`, `GetFiatRatesForTimestamps` and `GetFiatRatesTickersList` methods
+
 # 2.1.8
 
 -   fix(suite-native): cardano websocket (#7722)

--- a/packages/blockchain-link/src/ui/index.html
+++ b/packages/blockchain-link/src/ui/index.html
@@ -134,11 +134,23 @@
                 class="form-input"
                 type="text"
             />
+            <input
+                id="get-fiat-rates-ticker-list-token"
+                class="form-input"
+                type="text"
+                placeholder="token (contract address)"
+            />
             <button id="get-fiat-rates-ticker-list" class="btn">Get available tickers</button>
         </div>
         <div class="row">
             <label>Get current fiat rates</label>
             <input id="get-current-fiat-rates-currency" class="form-input" type="text" />
+            <input
+                id="get-current-fiat-rates-token"
+                class="form-input"
+                type="text"
+                placeholder="token (contract address)"
+            />
             <button id="get-current-fiat-rates" class="btn">Get fiat rates</button>
         </div>
 
@@ -151,6 +163,13 @@
                 class="form-input"
                 type="text"
             />
+            <input
+                id="get-fiat-rates-for-timestamps-token"
+                class="form-input"
+                type="text"
+                placeholder="token (contract address)"
+            />
+
             <button id="get-fiat-rates-for-timestamps" class="btn">
                 Get fiat rates for timestamps
             </button>

--- a/packages/blockchain-link/src/ui/index.ui.ts
+++ b/packages/blockchain-link/src/ui/index.ui.ts
@@ -174,6 +174,10 @@ const handleClick = (event: MouseEvent) => {
                             getInputValue('get-current-fiat-rates-currency') !== ''
                                 ? getInputValue('get-current-fiat-rates-currency').split(',')
                                 : undefined,
+                        token:
+                            getInputValue('get-current-fiat-rates-token') !== ''
+                                ? getInputValue('get-current-fiat-rates-token')
+                                : undefined,
                     })
                     .then(onResponse)
                     .catch(onError);
@@ -193,6 +197,10 @@ const handleClick = (event: MouseEvent) => {
                         currencies:
                             getInputValue('get-fiat-rates-for-timestamps-currency') !== ''
                                 ? getInputValue('get-fiat-rates-for-timestamps-currency').split(',')
+                                : undefined,
+                        token:
+                            getInputValue('get-fiat-rates-for-timestamps-token') !== ''
+                                ? getInputValue('get-fiat-rates-for-timestamps-token')
                                 : undefined,
                     })
                     .then(onResponse)
@@ -230,6 +238,10 @@ const handleClick = (event: MouseEvent) => {
                             getInputValue('get-fiat-rates-ticker-list-timestamp'),
                             10,
                         ),
+                        token:
+                            getInputValue('get-fiat-rates-ticker-list-token') !== ''
+                                ? getInputValue('get-fiat-rates-ticker-list-token')
+                                : undefined,
                     })
                     .then(onResponse)
                     .catch(onError);

--- a/packages/connect/CHANGELOG.md
+++ b/packages/connect/CHANGELOG.md
@@ -5,6 +5,7 @@
     -   `getInfo` returns `intermediaryVersion` needed for T1 and removed `latest` param. 'release' always return latest version for T1 so it means abandoning the concept of incremental updates for T1.
 -   chore(rollout): remove FW rollout feature completely
 -   feat: signTransaction now returns `signedTransaction` which can be used for visualization purposes before notification about pending transaction from blockchain is received.
+-   feat(blockchain): `blockchainGetCurrentFiatRates` and `blockchainGetFiatRatesForTimestamps` now accept additional `token` parameter
 
 # 9.0.7
 

--- a/packages/connect/src/api/blockchainGetCurrentFiatRates.ts
+++ b/packages/connect/src/api/blockchainGetCurrentFiatRates.ts
@@ -10,6 +10,7 @@ import type { CoinInfo } from '../types';
 type Params = {
     coinInfo: CoinInfo;
     currencies: Payload<'blockchainGetCurrentFiatRates'>['currencies'];
+    token: Payload<'blockchainGetCurrentFiatRates'>['token'];
 };
 
 export default class BlockchainGetCurrentFiatRates extends AbstractMethod<
@@ -25,6 +26,7 @@ export default class BlockchainGetCurrentFiatRates extends AbstractMethod<
         // validate incoming parameters
         validateParams(payload, [
             { name: 'currencies', type: 'array', required: false },
+            { name: 'token', type: 'string' },
             { name: 'coin', type: 'string', required: true },
         ]);
 
@@ -37,12 +39,16 @@ export default class BlockchainGetCurrentFiatRates extends AbstractMethod<
 
         this.params = {
             currencies: payload.currencies,
+            token: payload.token,
             coinInfo,
         };
     }
 
     async run() {
         const backend = await initBlockchain(this.params.coinInfo, this.postMessage);
-        return backend.getCurrentFiatRates({ currencies: this.params.currencies });
+        return backend.getCurrentFiatRates({
+            currencies: this.params.currencies,
+            token: this.params.token,
+        });
     }
 }

--- a/packages/connect/src/api/blockchainGetFiatRatesForTimestamps.ts
+++ b/packages/connect/src/api/blockchainGetFiatRatesForTimestamps.ts
@@ -10,6 +10,7 @@ import type { CoinInfo } from '../types';
 type Params = {
     coinInfo: CoinInfo;
     timestamps: Payload<'blockchainGetFiatRatesForTimestamps'>['timestamps'];
+    token: Payload<'blockchainGetFiatRatesForTimestamps'>['token'];
 };
 
 export default class BlockchainGetFiatRatesForTimestamps extends AbstractMethod<
@@ -25,6 +26,7 @@ export default class BlockchainGetFiatRatesForTimestamps extends AbstractMethod<
         // validate incoming parameters
         validateParams(payload, [
             { name: 'timestamps', type: 'array', required: true },
+            { name: 'token', type: 'string' },
             { name: 'coin', type: 'string', required: true },
         ]);
 
@@ -37,12 +39,16 @@ export default class BlockchainGetFiatRatesForTimestamps extends AbstractMethod<
 
         this.params = {
             timestamps: payload.timestamps,
+            token: payload.token,
             coinInfo,
         };
     }
 
     async run() {
         const backend = await initBlockchain(this.params.coinInfo, this.postMessage);
-        return backend.getFiatRatesForTimestamps({ timestamps: this.params.timestamps });
+        return backend.getFiatRatesForTimestamps({
+            timestamps: this.params.timestamps,
+            token: this.params.token,
+        });
     }
 }

--- a/packages/connect/src/backend/Blockchain.ts
+++ b/packages/connect/src/backend/Blockchain.ts
@@ -137,11 +137,11 @@ export class Blockchain {
         return Promise.all(txs.map(id => this.link.getTransaction(id)));
     }
 
-    getCurrentFiatRates(params: { currencies?: string[] }) {
+    getCurrentFiatRates(params: { currencies?: string[]; token?: string }) {
         return this.link.getCurrentFiatRates(params);
     }
 
-    getFiatRatesForTimestamps(params: { timestamps: number[] }) {
+    getFiatRatesForTimestamps(params: { timestamps: number[]; token?: string }) {
         return this.link.getFiatRatesForTimestamps(params);
     }
 


### PR DESCRIPTION
I only tested it using UI provided by `yarn workspace `@trezor/blockchain-link dev` which I extended in the first commit - [feat(blockchain-link): add token param to blockbook fiat methods](https://github.com/trezor/trezor-suite/pull/7897/commits/aa2a6fda2749cfb4b552a78d70530ee1dbb65600)

Connect implementation is done kind of blidly in the second commit
[feat(connect): add token param to blockchain fiat methods](https://github.com/trezor/trezor-suite/pull/7897/commits/ca9ff6898c0d7a3900c399841660c4534003cdb4) but I believe it should work.

@Nodonisko might want to have a look wheteher it satisfies his needs 

resolve #7866