### PR TITLE
feat(suite-native): acordion fade in animation

### DIFF
--- a/suite-native/atoms/src/AccordionItem.tsx
+++ b/suite-native/atoms/src/AccordionItem.tsx
@@ -1,10 +1,11 @@
 import React, { useState } from 'react';
-import { Pressable, View } from 'react-native';
+import { Pressable } from 'react-native';
 import Animated, {
     Easing,
     useAnimatedStyle,
     useSharedValue,
     withTiming,
+    withDelay,
 } from 'react-native-reanimated';
 
 import { Icon } from '@trezor/icons';
@@ -24,16 +25,21 @@ const triggerStyle = prepareNativeStyle(utils => ({
     paddingVertical: utils.spacings.small,
 }));
 
-const ANIMATION_DURATION = 500;
+const ANIMATION_DURATION = 250;
 
 export const AccordionItem = ({ title, content }: AccordionItemProps) => {
     const { applyStyle } = useNativeStyles();
     const [isOpen, setIsOpen] = useState(false);
     const height = useSharedValue(0);
+    const textOpacity = useSharedValue(0);
 
-    const animationStyle = useAnimatedStyle(() => ({
+    const accordionAnimationStyle = useAnimatedStyle(() => ({
         height: `${height.value}%`,
         overflow: 'hidden',
+    }));
+
+    const textAnimationStyle = useAnimatedStyle(() => ({
+        opacity: textOpacity.value,
     }));
 
     const toggleOpen = () => {
@@ -42,11 +48,19 @@ export const AccordionItem = ({ title, content }: AccordionItemProps) => {
                 duration: ANIMATION_DURATION,
                 easing: Easing.ease,
             });
+            textOpacity.value = withDelay(
+                ANIMATION_DURATION,
+                withTiming(1, { duration: ANIMATION_DURATION }),
+            );
         } else {
-            height.value = withTiming(0, {
-                duration: ANIMATION_DURATION,
-                easing: Easing.out(Easing.cubic),
-            });
+            textOpacity.value = withTiming(0, { duration: ANIMATION_DURATION });
+            height.value = withDelay(
+                ANIMATION_DURATION,
+                withTiming(1, {
+                    duration: ANIMATION_DURATION,
+                    easing: Easing.out(Easing.cubic),
+                }),
+            );
         }
         setIsOpen(!isOpen);
     };
@@ -59,10 +73,10 @@ export const AccordionItem = ({ title, content }: AccordionItemProps) => {
                     <Icon name="plusCircle" color="iconPrimaryDefault" />
                 </Box>
                 <Box flexDirection="row">
-                    <Animated.View style={animationStyle}>
-                        <View>
+                    <Animated.View style={accordionAnimationStyle}>
+                        <Animated.View style={textAnimationStyle}>
                             <Text>{content}</Text>
-                        </View>
+                        </Animated.View>
                     </Animated.View>
                 </Box>
             </Box>


### PR DESCRIPTION


## Description
During filling out FAQ content I've noticed that on the accordion opening, the text is strangely travelling around the paragraph. I've added a simple fade in animation to prevent this appearance.

## Screenshots:

### Before:

https://user-images.githubusercontent.com/26143964/226900295-a7bde8be-4745-493e-87f8-ec9316fd8449.mov

### After:

https://user-images.githubusercontent.com/26143964/226900336-2e7ab0aa-83ef-4041-b7b8-c332a431dacb.mov

