### PR TITLE
Propagate coinjoin setup values to startCoinjoinSession

### DIFF
--- a/packages/suite/src/actions/wallet/coinjoinAccountActions.ts
+++ b/packages/suite/src/actions/wallet/coinjoinAccountActions.ts
@@ -58,12 +58,12 @@ export const coinjoinAccountUpdateAnonymity = (accountKey: string, targetAnonymi
         },
     } as const);
 
-export const coinjoinAccountUpdateMaxMiningFee = (accountKey: string, maxFeePerKvbyte: number) =>
+export const coinjoinAccountUpdateMaxMiningFee = (accountKey: string, maxFeePerVbyte: number) =>
     ({
         type: COINJOIN.ACCOUNT_UPDATE_MAX_MING_FEE,
         payload: {
             accountKey,
-            maxFeePerKvbyte,
+            maxFeePerVbyte,
         },
     } as const);
 

--- a/packages/suite/src/components/wallet/PrivacyAccount/CoinjoinSetup.tsx
+++ b/packages/suite/src/components/wallet/PrivacyAccount/CoinjoinSetup.tsx
@@ -47,7 +47,7 @@ export const CoinjoinSetup = ({ accountKey }: CoinjoinSetupProps) => {
     const hasSession = !!coinjoinAccount.session;
 
     const handleSetupOptionChange = (isRecommended: boolean) => {
-        if (!!coinjoinAccount.customSetup === isRecommended) {
+        if (!!coinjoinAccount.setup === isRecommended) {
             dispatch(coinjoinAccountUpdateSetupOption(accountKey, isRecommended));
         }
     };
@@ -64,22 +64,22 @@ export const CoinjoinSetup = ({ accountKey }: CoinjoinSetupProps) => {
             <SetupContainer>
                 <SetupOptions>
                     <RadioButton
-                        isChecked={!coinjoinAccount.customSetup}
+                        isChecked={!coinjoinAccount.setup}
                         onClick={setRecommendedSetup}
                         disabled={hasSession}
                     >
                         <Translation id="TR_RECOMMENDED" />
                     </RadioButton>
                     <RadioButton
-                        isChecked={coinjoinAccount.customSetup}
+                        isChecked={!!coinjoinAccount.setup}
                         onClick={setCustomSetup}
                         disabled={hasSession}
                     >
                         <Translation id="TR_CUSTOM" />
                     </RadioButton>
                 </SetupOptions>
-                <AnimatePresence initial={!coinjoinAccount.customSetup}>
-                    {coinjoinAccount.customSetup && (
+                <AnimatePresence initial={!coinjoinAccount.setup}>
+                    {coinjoinAccount.setup && (
                         <motion.div
                             {...motionAnimation.expand}
                             transition={{ duration: 0.4, ease: motionEasing.transition }}
@@ -87,15 +87,15 @@ export const CoinjoinSetup = ({ accountKey }: CoinjoinSetupProps) => {
                             <CustomSetup>
                                 <AnonymityLevelSetup
                                     accountKey={accountKey}
-                                    targetAnonymity={coinjoinAccount.targetAnonymity}
+                                    targetAnonymity={coinjoinAccount.setup.targetAnonymity}
                                 />
                                 <MaxMiningFeeSetup
                                     accountKey={accountKey}
-                                    maxMiningFee={coinjoinAccount.maxFeePerKvbyte}
+                                    maxMiningFee={coinjoinAccount.setup.maxFeePerVbyte}
                                 />
                                 <SkipRoundsSetup
                                     accountKey={accountKey}
-                                    skipRounds={!!coinjoinAccount.skipRounds}
+                                    skipRounds={coinjoinAccount.setup.skipRounds}
                                 />
                             </CustomSetup>
                         </motion.div>

--- a/packages/suite/src/components/wallet/PrivacyAccount/MaxMiningFeeSetup.tsx
+++ b/packages/suite/src/components/wallet/PrivacyAccount/MaxMiningFeeSetup.tsx
@@ -17,7 +17,7 @@ const labels = [min, max / 2, max].map(number => ({
 
 interface MaxMiningFeeSetupProps {
     accountKey: string;
-    maxMiningFee: number;
+    maxMiningFee?: number;
 }
 
 export const MaxMiningFeeSetup = ({ accountKey, maxMiningFee }: MaxMiningFeeSetupProps) => {
@@ -53,7 +53,7 @@ export const MaxMiningFeeSetup = ({ accountKey, maxMiningFee }: MaxMiningFeeSetu
             heading={<Translation id="TR_MAX_MINING_FEE" />}
             description={<Translation id="TR_MINING_FEE_NOTE" />}
             onChange={updateMaxMiningFee}
-            value={maxMiningFee}
+            value={maxMiningFee ?? coinjoinClient?.maxMiningFee ?? MAX_MINING_FEE_FALLBACK}
             min={min}
             max={max}
             unit={unit}

--- a/packages/suite/src/hooks/wallet/useRbfForm.ts
+++ b/packages/suite/src/hooks/wallet/useRbfForm.ts
@@ -10,6 +10,7 @@ import { FormState, FeeInfo } from '@wallet-types/sendForm';
 import { useFees } from './form/useFees';
 import { useCompose } from './form/useCompose';
 import { useBitcoinAmountUnit } from './useBitcoinAmountUnit';
+import { selectCurrentTargetAnonymity } from '@wallet-reducers/coinjoinReducer';
 
 export type Props = {
     tx: WalletAccountTransaction;
@@ -58,8 +59,8 @@ const getFeeInfo = (
 
 const useRbfState = ({ tx, finalize, chainedTxs }: Props, currentState: boolean) => {
     const selectedAccount = useSelector(state => state.wallet.selectedAccount);
-    const coinjoinAccounts = useSelector(state => state.wallet.coinjoin.accounts);
     const fees = useSelector(state => state.wallet.fees);
+    const targetAnonymity = useSelector(selectCurrentTargetAnonymity);
 
     const { areSatsDisplayed } = useBitcoinAmountUnit();
 
@@ -117,14 +118,11 @@ const useRbfState = ({ tx, finalize, chainedTxs }: Props, currentState: boolean)
         baseFee,
     };
 
-    // find coinjoin account related to current account
-    const coinjoinAccount = coinjoinAccounts.find(a => a.key === selectedAccount.account.key);
-
     const excludedUtxos = getExcludedUtxos({
         utxos: rbfAccount.utxo,
         dustLimit: coinFees.dustLimit,
         anonymitySet: rbfAccount.addresses?.anonymitySet,
-        targetAnonymity: coinjoinAccount?.targetAnonymity,
+        targetAnonymity,
     });
 
     return {

--- a/packages/suite/src/hooks/wallet/useSendForm.ts
+++ b/packages/suite/src/hooks/wallet/useSendForm.ts
@@ -36,13 +36,13 @@ SendContext.displayName = 'SendContext';
 // Props of @wallet-views/send/index
 export interface SendFormProps {
     selectedAccount: AppState['wallet']['selectedAccount'];
-    coinjoinAccount?: AppState['wallet']['coinjoin']['accounts'][number];
     fiat: AppState['wallet']['fiat'];
     localCurrency: AppState['wallet']['settings']['localCurrency'];
     fees: AppState['wallet']['fees'];
     online: boolean;
     sendRaw?: boolean;
     metadataEnabled: boolean;
+    targetAnonymity?: number;
 }
 // Props of @wallet-hooks/useSendForm (selectedAccount should be loaded)
 export interface UseSendFormProps extends SendFormProps {
@@ -161,7 +161,7 @@ export const useSendForm = (props: UseSendFormProps): SendContextValues => {
     const excludedUtxos = useExcludedUtxos({
         account: state.account,
         dustLimit: state.coinFees.dustLimit,
-        targetAnonymity: props.coinjoinAccount?.targetAnonymity,
+        targetAnonymity: props.targetAnonymity,
     });
 
     // declare sendFormUtils, sub-hook of useSendForm

--- a/packages/suite/src/middlewares/wallet/__fixtures__/coinjoinMiddleware.ts
+++ b/packages/suite/src/middlewares/wallet/__fixtures__/coinjoinMiddleware.ts
@@ -41,7 +41,9 @@ const ACCOUNT_B = { ...ACCOUNT_A, deviceState: 'device-B-state', key: 'account-B
 const COINJOIN_ACCOUNT_A = {
     key: 'account-A-key',
     session: { signedRounds: [] as string[] },
-    targetAnonymity: 2,
+    setup: {
+        targetAnonymity: 2,
+    },
 } as CoinjoinAccount;
 const COINJOIN_ACCOUNT_B = {
     ...COINJOIN_ACCOUNT_A,

--- a/packages/suite/src/services/coinjoin/config.ts
+++ b/packages/suite/src/services/coinjoin/config.ts
@@ -133,7 +133,6 @@ export const MIN_ANONYMITY_GAINED_PER_ROUND = 0.1; // the minimum anonymity gain
 export const ESTIMATED_ROUNDS_FAIL_RATE_BUFFER = 2.5;
 export const ESTIMATED_MIN_ROUNDS_NEEDED = 4;
 export const ESTIMATED_HOURS_PER_ROUND = 1;
-export const RECOMMENDED_SKIP_ROUNDS = undefined; // temporary disabled for testing purposes // [4, 5] as [number, number];
 export const UNECONOMICAL_COINJOIN_THRESHOLD = 1_000_000;
 
 export const CLIENT_STATUS_FALLBACK = {

--- a/packages/suite/src/types/wallet/coinjoin.ts
+++ b/packages/suite/src/types/wallet/coinjoin.ts
@@ -8,6 +8,12 @@ import { RoundPhase, SessionPhase, EndRoundState } from '@trezor/coinjoin/src/en
 
 export { RoundPhase, SessionPhase, EndRoundState };
 
+export interface CoinjoinSetup {
+    targetAnonymity: number;
+    maxFeePerVbyte: number;
+    skipRounds: boolean;
+}
+
 export interface CoinjoinSessionParameters {
     targetAnonymity: number;
     maxRounds: number;
@@ -40,10 +46,7 @@ export interface CoinjoinDiscoveryCheckpoint {
 export interface CoinjoinAccount {
     key: string; // reference to wallet Account.key
     symbol: NetworkSymbol;
-    customSetup?: boolean;
-    targetAnonymity: number; // anonymity set by the user
-    maxFeePerKvbyte: number;
-    skipRounds?: [number, number];
+    setup?: CoinjoinSetup; // unless enabled, account uses default (recommended) values
     rawLiquidityClue: RegisterAccountParams['rawLiquidityClue'];
     session?: CoinjoinSession; // current/active authorized session
     previousSessions: CoinjoinSession[]; // history

--- a/packages/suite/src/utils/wallet/coinjoinUtils.ts
+++ b/packages/suite/src/utils/wallet/coinjoinUtils.ts
@@ -4,7 +4,10 @@ import hoursToMilliseconds from 'date-fns/hoursToMilliseconds';
 
 import { getUtxoOutpoint, getBip43Type } from '@suite-common/wallet-utils';
 import { Account, SelectedAccountStatus } from '@suite-common/wallet-types';
-import { ESTIMATED_MIN_ROUNDS_NEEDED } from '@suite/services/coinjoin/config';
+import {
+    ESTIMATED_MIN_ROUNDS_NEEDED,
+    SKIP_ROUNDS_VALUE_WHEN_ENABLED,
+} from '@suite/services/coinjoin/config';
 import { CoinjoinSessionParameters, RoundPhase, SessionPhase } from '@wallet-types/coinjoin';
 import { AnonymitySet } from '@trezor/blockchain-link';
 import {
@@ -174,6 +177,10 @@ export const getMaxRounds = (roundsNeeded: number, roundsFailRateBuffer: number)
 
     return Math.max(estimatedRoundsCount, ESTIMATED_MIN_ROUNDS_NEEDED);
 };
+
+// transform boolean to skip rounds value used by @trezor/coinjoin
+export const getSkipRounds = (enabled: boolean) =>
+    enabled ? SKIP_ROUNDS_VALUE_WHEN_ENABLED : undefined;
 
 // get time estimate in millisecond per round
 export const getEstimatedTimePerRound = (

--- a/packages/suite/src/views/wallet/send/index.tsx
+++ b/packages/suite/src/views/wallet/send/index.tsx
@@ -5,7 +5,6 @@ import { Card } from '@suite-components';
 import { useSelector } from '@suite-hooks';
 import { WalletLayout } from '@wallet-components';
 import { useSendForm, SendContext, UseSendFormProps } from '@wallet-hooks/useSendForm';
-import { selectCoinjoinAccountByKey } from '@wallet-reducers/coinjoinReducer';
 import { Header } from './components/Header';
 import Outputs from './components/Outputs';
 import Options from './components/Options';
@@ -13,6 +12,7 @@ import { SendFees } from './components/Fees';
 import { TotalSent } from './components/TotalSent';
 import { ReviewButton } from './components/ReviewButton';
 import Raw from './components/Raw';
+import { selectCurrentTargetAnonymity } from '@wallet-reducers/coinjoinReducer';
 
 const StyledCard = styled(Card)`
     display: flex;
@@ -29,11 +29,7 @@ interface SendLoadedProps extends UseSendFormProps {
 // separated to call `useSendForm` hook at top level
 // children are only for test purposes, this prop is not available in regular build
 const SendLoaded = ({ children, ...props }: SendLoadedProps) => {
-    const coinjoinAccount = useSelector(state =>
-        selectCoinjoinAccountByKey(state, props.selectedAccount.account.key),
-    );
-
-    const sendContextValues = useSendForm({ ...props, coinjoinAccount });
+    const sendContextValues = useSendForm({ ...props });
 
     return (
         <WalletLayout title="TR_NAV_SEND" account={props.selectedAccount}>
@@ -69,6 +65,7 @@ const Send = ({ children }: SendProps) => {
         online: state.suite.online,
         sendRaw: state.wallet.send.sendRaw,
         metadataEnabled: state.metadata.enabled && !!state.metadata.provider,
+        targetAnonymity: selectCurrentTargetAnonymity(state),
     }));
     const selectedAccount = useSelector(state => state.wallet.selectedAccount);
 


### PR DESCRIPTION
## Description

Bug noticed by @hynek-jina 

Coinjoin setup for `maxMiningFee` and `skipRounds` not ignored anymore.

**QA:** Please check that coinjoin session skips rounds when the setting is on. Max mining fee is confirmed on Trezor when coinjoin starts and should correspond to the value in custom setup.