### PR TITLE
chore(connect): remove parse-uri dependency

### DIFF
--- a/packages/connect/package.json
+++ b/packages/connect/package.json
@@ -58,7 +58,6 @@
         "blakejs": "^1.2.1",
         "cross-fetch": "^3.1.5",
         "events": "^3.3.0",
-        "parse-uri": "1.0.7",
         "randombytes": "2.1.0",
         "tslib": "2.5.0"
     },

--- a/packages/connect/src/core/AbstractMethod.ts
+++ b/packages/connect/src/core/AbstractMethod.ts
@@ -15,6 +15,7 @@ import {
 } from '../events';
 import { Deferred } from '../utils/deferred';
 import { versionCompare } from '../utils/versionUtils';
+import { getHost } from '../utils/urlUtils';
 import type { Device } from '../device/Device';
 import type { FirmwareRange } from '../types';
 
@@ -285,6 +286,17 @@ export abstract class AbstractMethod<Name extends CallMethodPayload['method'], P
             } else {
                 return UI.FIRMWARE_NOT_COMPATIBLE;
             }
+        }
+    }
+
+    isManagementRestricted() {
+        const { popup, origin } = DataManager.getSettings();
+        if (popup && this.requiredPermissions.includes('management')) {
+            const host = getHost(origin);
+            const allowed = DataManager.getConfig().management.find(
+                item => item.origin === host || item.origin === origin,
+            );
+            return !allowed;
         }
     }
 

--- a/packages/connect/src/core/index.ts
+++ b/packages/connect/src/core/index.ts
@@ -338,11 +338,7 @@ export const onCall = async (message: CoreMessage) => {
         await initTransport(DataManager.getSettings());
     }
 
-    if (
-        isUsingPopup &&
-        method.requiredPermissions.includes('management') &&
-        !DataManager.isManagementAllowed()
-    ) {
+    if (method.isManagementRestricted()) {
         postMessage(createPopupMessage(POPUP.CANCEL_POPUP_REQUEST));
         postMessage(
             createResponseMessage(responseID, false, {

--- a/packages/connect/src/data/DataManager.ts
+++ b/packages/connect/src/data/DataManager.ts
@@ -1,6 +1,5 @@
 // origin: https://github.com/trezor/connect/blob/develop/src/js/data/DataManager.js
 
-import parseUri from 'parse-uri';
 import { httpRequest } from '../utils/assets';
 import { parseCoinsJson } from './coinInfo';
 import { parseFirmware } from './firmwareInfo';
@@ -46,20 +45,6 @@ export class DataManager {
         return this.messages;
     }
 
-    static isManagementAllowed() {
-        const uri = parseUri(this.settings.origin ?? '');
-        if (uri && typeof uri.host === 'string') {
-            const parts = uri.host.split('.');
-            if (parts.length > 2) {
-                // subdomain
-                uri.host = parts.slice(parts.length - 2, parts.length).join('.');
-            }
-            return config.management.find(
-                item => item.origin === this.settings.origin || item.origin === uri.host,
-            );
-        }
-    }
-
     static getSettings(key?: undefined): ConnectSettings;
     static getSettings<T extends keyof ConnectSettings>(key: T): ConnectSettings[T];
     static getSettings(key?: keyof ConnectSettings) {
@@ -68,5 +53,9 @@ export class DataManager {
             return this.settings[key];
         }
         return this.settings;
+    }
+
+    static getConfig() {
+        return config;
     }
 }

--- a/packages/connect/src/data/__tests__/DataManager.test.ts
+++ b/packages/connect/src/data/__tests__/DataManager.test.ts
@@ -35,10 +35,6 @@ describe('data/DataManager', () => {
         }
     });
 
-    test('isManagementAllowed', () => {
-        expect(DataManager.isManagementAllowed()).toEqual(undefined);
-    });
-
     test('getSettings', () => {
         expect(DataManager.getSettings('connectSrc')).toEqual(settings.connectSrc);
         expect(DataManager.getSettings()).toEqual(settings);

--- a/packages/connect/src/utils/__tests__/urlUtils.test.ts
+++ b/packages/connect/src/utils/__tests__/urlUtils.test.ts
@@ -1,37 +1,46 @@
-import * as utils from '../urlUtils';
+import { getOrigin, getHost, getOnionDomain } from '../urlUtils';
 
 describe('utils/urlUtils', () => {
     it('getOrigin', () => {
-        expect(utils.getOrigin('file://index.html')).toEqual('file://');
-        expect(utils.getOrigin('https://trezor.io')).toEqual('https://trezor.io');
-        expect(utils.getOrigin('https://connect.trezor.io')).toEqual('https://connect.trezor.io');
-        expect(utils.getOrigin('https://foo.connect.trezor.io/9/?query=1#hash2')).toEqual(
+        expect(getOrigin('file://index.html')).toEqual('file://');
+        expect(getOrigin('https://trezor.io')).toEqual('https://trezor.io');
+        expect(getOrigin('https://connect.trezor.io')).toEqual('https://connect.trezor.io');
+        expect(getOrigin('https://foo.connect.trezor.io/9/?query=1#hash2')).toEqual(
             'https://foo.connect.trezor.io',
         );
 
-        // @ts-expect-error: invalid param
-        expect(utils.getOrigin(undefined)).toEqual('unknown');
-        // @ts-expect-error: invalid param
-        expect(utils.getOrigin(null)).toEqual('unknown');
-        // @ts-expect-error: invalid param
-        expect(utils.getOrigin({})).toEqual('unknown');
+        expect(getOrigin(undefined)).toEqual('unknown');
+        expect(getOrigin(null)).toEqual('unknown');
+        expect(getOrigin({})).toEqual('unknown');
+    });
+
+    it('getHost', () => {
+        expect(getHost('http://localhost:8088/')).toEqual('localhost');
+        expect(getHost('file://index.html')).toEqual(undefined);
+        expect(getHost('https://trezor.io')).toEqual('trezor.io');
+        expect(getHost('https://connect.trezor.io')).toEqual('trezor.io');
+        expect(getHost('https://foo.connect.trezor.io/9/?query=1#hash2')).toEqual('trezor.io');
+
+        expect(getHost(undefined)).toEqual(undefined);
+        expect(getHost(null)).toEqual(undefined);
+        expect(getHost({})).toEqual(undefined);
     });
 
     it('getOnionDomain', () => {
         const dict = {
             'trezor.io': 'trezor.onion',
         };
-        // expect(utils.getOnionDomain('trezor.io', dict)).toEqual('trezor.io');
-        expect(utils.getOnionDomain('https://trezor.io', dict)).toEqual('http://trezor.onion');
-        expect(utils.getOnionDomain('http://trezor.io', dict)).toEqual('http://trezor.onion');
-        expect(utils.getOnionDomain('http://connect.trezor.io', dict)).toEqual(
+        // expect(getOnionDomain('trezor.io', dict)).toEqual('trezor.io');
+        expect(getOnionDomain('https://trezor.io', dict)).toEqual('http://trezor.onion');
+        expect(getOnionDomain('http://trezor.io', dict)).toEqual('http://trezor.onion');
+        expect(getOnionDomain('http://connect.trezor.io', dict)).toEqual(
             'http://connect.trezor.onion',
         );
-        expect(
-            utils.getOnionDomain('http://foo.bar.connect.trezor.io/9/?query=1#hash2', dict),
-        ).toEqual('http://foo.bar.connect.trezor.onion/9/?query=1#hash2');
-        expect(utils.getOnionDomain('wss://trezor.io', dict)).toEqual('ws://trezor.onion');
-        expect(utils.getOnionDomain('ws://foo.bar.trezor.io/?foo=bar', dict)).toEqual(
+        expect(getOnionDomain('http://foo.bar.connect.trezor.io/9/?query=1#hash2', dict)).toEqual(
+            'http://foo.bar.connect.trezor.onion/9/?query=1#hash2',
+        );
+        expect(getOnionDomain('wss://trezor.io', dict)).toEqual('ws://trezor.onion');
+        expect(getOnionDomain('ws://foo.bar.trezor.io/?foo=bar', dict)).toEqual(
             'ws://foo.bar.trezor.onion/?foo=bar',
         );
     });

--- a/packages/connect/src/utils/urlUtils.ts
+++ b/packages/connect/src/utils/urlUtils.ts
@@ -1,16 +1,15 @@
 // origin: https://github.com/trezor/connect/blob/develop/src/js/utils/urlUtils.js
 
-export const getOrigin = (url: string) => {
+export const getOrigin = (url: unknown) => {
     if (typeof url !== 'string') return 'unknown';
     if (url.indexOf('file://') === 0) return 'file://';
-    // eslint-disable-next-line no-useless-escape
-    const parts = url.match(/^.+\:\/\/[^\/]+/);
-    return Array.isArray(parts) && parts.length > 0 ? parts[0] : 'unknown';
+    const [origin] = url.match(/^https?:\/\/[^/]+/) ?? [];
+    return origin ?? 'unknown';
 };
 
-export const getHost = (url: string) => {
-    const origin = getOrigin(url);
-    const [_, uri] = getOrigin(origin).split('//');
+export const getHost = (url: unknown) => {
+    if (typeof url !== 'string') return;
+    const [, , uri] = url.match(/^(https?):\/\/([^:/]+)?/i) ?? [];
     if (uri) {
         const parts = uri.split('.');
         return parts.length > 2

--- a/yarn.lock
+++ b/yarn.lock
@@ -7964,7 +7964,6 @@ __metadata:
     karma-jasmine-async: ^0.0.1
     karma-sourcemap-loader: ^0.4.0
     karma-webpack: ^5.0.0
-    parse-uri: 1.0.7
     randombytes: 2.1.0
     rimraf: ^4.1.2
     ts-loader: ^9.4.2
@@ -26428,13 +26427,6 @@ __metadata:
   dependencies:
     pngjs: ^3.3.0
   checksum: 0c6b6c42c8830cd16f6f9e9aedafd53111c0ad2ff350ba79c629996887567558f5639ad0c95764f96f7acd1f9ff63d4ac73737e80efa3911a6de9839ee520c96
-  languageName: node
-  linkType: hard
-
-"parse-uri@npm:1.0.7":
-  version: 1.0.7
-  resolution: "parse-uri@npm:1.0.7"
-  checksum: 0d4386a586bda98bcdd041f9b1a7e9a6c16bc2ab198c90531f2d169eb2eb520477cc059a75c5cf0695eb3c9e69ff6b90793d07781ab83e2de1cbb255ec66e37f
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Remove `parse-uri` dependency from `@trezor/connect` package.
Utility replaced by regex which was already there (getOnionDomain)

`DataManager.isManagementAllowed` move to `AbstractMethod.isManagementRestricted`

