### PR TITLE
chore(deps): unify typescript to 4.9.5 in all packages

### DIFF
--- a/packages/coinjoin/package.json
+++ b/packages/coinjoin/package.json
@@ -43,6 +43,6 @@
     "devDependencies": {
         "jest": "^26.6.3",
         "rimraf": "^4.1.2",
-        "typescript": "4.7.4"
+        "typescript": "4.9.5"
     }
 }

--- a/packages/connect-analytics/package.json
+++ b/packages/connect-analytics/package.json
@@ -14,6 +14,6 @@
         "@trezor/analytics": "workspace:*"
     },
     "devDependencies": {
-        "typescript": "4.7.4"
+        "typescript": "4.9.5"
     }
 }

--- a/packages/crypto-utils/package.json
+++ b/packages/crypto-utils/package.json
@@ -8,5 +8,8 @@
     "scripts": {
         "lint:js": "yarn g:eslint '**/*.{ts,tsx,js}'",
         "type-check": "tsc --build"
+    },
+    "devDependencies": {
+        "typescript": "4.9.5"
     }
 }

--- a/packages/device-utils/package.json
+++ b/packages/device-utils/package.json
@@ -12,6 +12,6 @@
         "build:lib": "rimraf lib && yarn tsc --build ./tsconfig.lib.json"
     },
     "devDependencies": {
-        "typescript": "4.7.4"
+        "typescript": "4.9.5"
     }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -7502,7 +7502,7 @@ __metadata:
     jest: ^26.6.3
     n64: ^0.2.10
     rimraf: ^4.1.2
-    typescript: 4.7.4
+    typescript: 4.9.5
   languageName: unknown
   linkType: soft
 
@@ -7561,7 +7561,7 @@ __metadata:
   resolution: "@trezor/connect-analytics@workspace:packages/connect-analytics"
   dependencies:
     "@trezor/analytics": "workspace:*"
-    typescript: 4.7.4
+    typescript: 4.9.5
   languageName: unknown
   linkType: soft
 
@@ -7766,6 +7766,8 @@ __metadata:
 "@trezor/crypto-utils@workspace:*, @trezor/crypto-utils@workspace:packages/crypto-utils":
   version: 0.0.0-use.local
   resolution: "@trezor/crypto-utils@workspace:packages/crypto-utils"
+  dependencies:
+    typescript: 4.9.5
   languageName: unknown
   linkType: soft
 
@@ -7773,7 +7775,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@trezor/device-utils@workspace:packages/device-utils"
   dependencies:
-    typescript: 4.7.4
+    typescript: 4.9.5
   languageName: unknown
   linkType: soft
 


### PR DESCRIPTION
changing some left over "typescript": "4.7.4" to "typescript": "4.9.5"

Hope 4.7.4 was not left there intentionally? I don't see a reason for it.