### PR TITLE
Fee rate median and max mining fee fixes

### DIFF
--- a/packages/coinjoin/src/constants.ts
+++ b/packages/coinjoin/src/constants.ts
@@ -43,12 +43,8 @@ export const PLEBS_DONT_PAY_THRESHOLD_FALLBACK = 1000000;
 export const COORDINATOR_FEE_RATE_FALLBACK = 0.003;
 export const MIN_ALLOWED_AMOUNT_FALLBACK = 5000;
 export const MAX_ALLOWED_AMOUNT_FALLBACK = 134375000000;
-export const WEEKLY_FEE_RATE_MEDIAN_FALLBACK = 2;
 
 // affiliation flag:
 // - sent coordinator/ready-to-sign request **only** when Alice pays coordination fee
 // - check if Trezor affiliate server is running in status.affiliateInformation.runningAffiliateServers
 export const AFFILIATION_ID = 'trezor';
-
-// modifier applied to a median fee rate to set default max mining fee
-export const MAX_MINING_FEE_MODIFIER = 2.5;

--- a/packages/coinjoin/src/constants.ts
+++ b/packages/coinjoin/src/constants.ts
@@ -43,7 +43,7 @@ export const PLEBS_DONT_PAY_THRESHOLD_FALLBACK = 1000000;
 export const COORDINATOR_FEE_RATE_FALLBACK = 0.003;
 export const MIN_ALLOWED_AMOUNT_FALLBACK = 5000;
 export const MAX_ALLOWED_AMOUNT_FALLBACK = 134375000000;
-export const MAX_MINING_FEE_FALLBACK = 3;
+export const WEEKLY_FEE_RATE_MEDIAN_FALLBACK = 2;
 
 // affiliation flag:
 // - sent coordinator/ready-to-sign request **only** when Alice pays coordination fee

--- a/packages/coinjoin/src/types/client.ts
+++ b/packages/coinjoin/src/types/client.ts
@@ -6,7 +6,7 @@ import { LogEvent } from './logger';
 export interface CoinjoinStatusEvent {
     rounds: Round[];
     changed: Round[];
-    maxMiningFee: number;
+    weeklyFeeRateMedian: number;
     coordinationFeeRate: CoordinationFeeRate;
     allowedInputAmounts: AllowedRange;
 }

--- a/packages/coinjoin/src/utils/roundUtils.ts
+++ b/packages/coinjoin/src/utils/roundUtils.ts
@@ -2,12 +2,10 @@ import { bufferutils, Transaction, Network } from '@trezor/utxo-lib';
 
 import {
     COORDINATOR_FEE_RATE_FALLBACK,
-    MAX_MINING_FEE_FALLBACK,
     MAX_ALLOWED_AMOUNT_FALLBACK,
     MIN_ALLOWED_AMOUNT_FALLBACK,
     PLEBS_DONT_PAY_THRESHOLD_FALLBACK,
     ROUND_REGISTRATION_END_OFFSET,
-    MAX_MINING_FEE_MODIFIER,
 } from '../constants';
 import { RoundPhase } from '../enums';
 import { CoinjoinTransactionData } from '../types';
@@ -168,23 +166,20 @@ const getDataFromRounds = (rounds: Round[]) => {
 /**
  * Transform from coordinator format to coinjoinReducer format `CoinjoinClientInstance`
  * - coordinatorFeeRate: multiply the amount registered for coinjoin by this value to get the total fee
- * - maxMiningFee: array => value in kvBytes
+ * - weeklyFeeRateMedian: array => value in kvBytes
  */
 export const transformStatus = ({
     coinJoinFeeRateMedians,
     roundStates: rounds,
 }: CoinjoinStatus) => {
     const { allowedInputAmounts, coordinationFeeRate } = getDataFromRounds(rounds);
-    // coinJoinFeeRateMedians include an array of medians per day, week and month - we take the second (week) median as the recommended fee rate
-    const weeklyMedian = coinJoinFeeRateMedians[1];
-    // the value is converted from kvBytes (kilo virtual bytes) to vBytes (how the value is displayed in UI)
-    const maxMiningFee = weeklyMedian
-        ? Math.round((coinJoinFeeRateMedians[1].medianFeeRate * MAX_MINING_FEE_MODIFIER) / 1000)
-        : MAX_MINING_FEE_FALLBACK;
+    // coinJoinFeeRateMedians include an array of medians per day, week and month - we take the second (week) median as the recommended fee rate.
+    // The value is converted from kvBytes (kilo virtual bytes) to vBytes (how the value is displayed in UI).
+    const weeklyFeeRateMedian = Math.round(coinJoinFeeRateMedians[1].medianFeeRate / 1000);
 
     return {
         rounds,
-        maxMiningFee,
+        weeklyFeeRateMedian,
         coordinationFeeRate,
         allowedInputAmounts,
     };

--- a/packages/coinjoin/tests/client/CoinjoinClient.test.ts
+++ b/packages/coinjoin/tests/client/CoinjoinClient.test.ts
@@ -1,6 +1,6 @@
 import { CoinjoinClient } from '../../src';
 import { createServer } from '../mocks/server';
-import { DEFAULT_ROUND, AFFILIATE_INFO } from '../fixtures/round.fixture';
+import { AFFILIATE_INFO, DEFAULT_ROUND, FEE_RATE_MEDIANS } from '../fixtures/round.fixture';
 
 let server: Awaited<ReturnType<typeof createServer>>;
 
@@ -22,7 +22,7 @@ describe(`CoinjoinClient`, () => {
             if (url.endsWith('/status')) {
                 resolve({
                     roundStates: [DEFAULT_ROUND],
-                    coinJoinFeeRateMedians: [],
+                    coinJoinFeeRateMedians: FEE_RATE_MEDIANS,
                     affiliateInformation: AFFILIATE_INFO,
                 });
             }

--- a/packages/coinjoin/tests/fixtures/round.fixture.ts
+++ b/packages/coinjoin/tests/fixtures/round.fixture.ts
@@ -146,7 +146,7 @@ export const createCoinjoinRound = (
 };
 
 export const STATUS_TRANSFORMED = {
-    weeklyFeeRateMedian: 323,
+    weeklyFeeRateMedian: 129,
     allowedInputAmounts: {
         max: 134375000000,
         min: 5000,

--- a/packages/coinjoin/tests/fixtures/round.fixture.ts
+++ b/packages/coinjoin/tests/fixtures/round.fixture.ts
@@ -146,7 +146,7 @@ export const createCoinjoinRound = (
 };
 
 export const STATUS_TRANSFORMED = {
-    maxMiningFee: 323,
+    weeklyFeeRateMedian: 323,
     allowedInputAmounts: {
         max: 134375000000,
         min: 5000,

--- a/packages/suite/src/actions/wallet/__fixtures__/mockCoinjoinService.ts
+++ b/packages/suite/src/actions/wallet/__fixtures__/mockCoinjoinService.ts
@@ -10,7 +10,7 @@ export const mockCoinjoinService = () => {
             enable: jest.fn(() =>
                 Promise.resolve({
                     rounds: [{ id: '00', phase: 0 }],
-                    maxMiningFee: 0,
+                    weeklyFeeRateMedian: 0,
                     coordinatorFeeRate: 0.003,
                     allowedInputAmounts: { min: 5000, max: 134375000000 },
                 }),

--- a/packages/suite/src/components/wallet/PrivacyAccount/MaxMiningFeeSetup.tsx
+++ b/packages/suite/src/components/wallet/PrivacyAccount/MaxMiningFeeSetup.tsx
@@ -17,6 +17,8 @@ const labels = [min, max / 2, max].map(number => ({
     value: `${number} ${unit}`,
 }));
 
+const getPercentage = (value: number) => ((value - min) / (max - min)) * 100;
+
 interface MaxMiningFeeSetupProps {
     accountKey: string;
     maxMiningFee: number;
@@ -38,16 +40,16 @@ export const MaxMiningFeeSetup = ({ accountKey, maxMiningFee }: MaxMiningFeeSetu
         dispatch(coinjoinAccountUpdateMaxMiningFee(accountKey, value));
     };
 
-    const maxMiningFeeRangePercentage = defaultMaxMiningFee / (max / 100) + min;
-    const green = maxMiningFeeRangePercentage > 100 ? 100 : maxMiningFeeRangePercentage;
+    const weeklyFeeRateMedianPercentage = getPercentage(weeklyFeeRateMedian);
+    const defaultMaxMiningFeePercentage = getPercentage(defaultMaxMiningFee);
 
     const trackStyle = {
         background: `\
             linear-gradient(90deg,\
                 ${theme.GRADIENT_SLIDER_RED_END} 0%,\
-                ${theme.GRADIENT_SLIDER_YELLOW_END} ${weeklyFeeRateMedian / 1.1}%,\
-                ${theme.GRADIENT_SLIDER_YELLOW_START} ${weeklyFeeRateMedian}%,\
-                ${theme.GRADIENT_SLIDER_GREEN_END} ${green}%,\
+                ${theme.GRADIENT_SLIDER_YELLOW_END} ${weeklyFeeRateMedianPercentage / 1.1}%,\
+                ${theme.GRADIENT_SLIDER_YELLOW_START} ${weeklyFeeRateMedianPercentage}%,\
+                ${theme.GRADIENT_SLIDER_GREEN_END} ${defaultMaxMiningFeePercentage}%,\
                 ${theme.GRADIENT_SLIDER_GREEN_START} 100%\
             );`,
     };

--- a/packages/suite/src/services/coinjoin/config.ts
+++ b/packages/suite/src/services/coinjoin/config.ts
@@ -3,7 +3,6 @@ import {
     COORDINATOR_FEE_RATE_FALLBACK,
     MIN_ALLOWED_AMOUNT_FALLBACK,
     MAX_ALLOWED_AMOUNT_FALLBACK,
-    MAX_MINING_FEE_FALLBACK,
 } from '@trezor/coinjoin/src/constants';
 import type { CoinjoinBackendSettings, CoinjoinClientSettings } from '@trezor/coinjoin';
 import type { PartialRecord } from '@trezor/type-utils';
@@ -127,17 +126,21 @@ export const COINJOIN_NETWORKS: PartialRecord<NetworkSymbol, ServerEnvironment> 
     },
 };
 
-// coinjoin strategy constants
 export const ESTIMATED_ANONYMITY_GAINED_PER_ROUND = 10; // initial value replaced by config via message-system in state.wallet.coinjoin.config.averageAnonymityGainPerRound
 export const MIN_ANONYMITY_GAINED_PER_ROUND = 0.1; // the minimum anonymity gain per coinjoin round that is used to avoid division by zero when computing roundsNeeded.
 export const ESTIMATED_ROUNDS_FAIL_RATE_BUFFER = 2.5;
 export const ESTIMATED_MIN_ROUNDS_NEEDED = 4;
 export const ESTIMATED_HOURS_PER_ROUND = 1;
 export const UNECONOMICAL_COINJOIN_THRESHOLD = 1_000_000;
-
+export const COORDINATOR_FEE_RATE_MULTIPLIER = 10 ** 8; // coordinator fee rate from status format (0.003) - firmware format (300 000 = 0.003 * 10 ** 8)
+export const DEFAULT_TARGET_ANONYMITY = 5;
+export const SKIP_ROUNDS_BY_DEFAULT = false;
+export const SKIP_ROUNDS_VALUE_WHEN_ENABLED = [4, 5] as [number, number];
+export const WEEKLY_FEE_RATE_MEDIAN_FALLBACK = 2;
+export const MAX_MINING_FEE_MODIFIER = 2.5; // modifier applied to a median fee rate to set default max mining fee rate per vbyte
 export const CLIENT_STATUS_FALLBACK = {
     rounds: [],
-    maxMiningFee: MAX_MINING_FEE_FALLBACK,
+    weeklyFeeRateMedian: WEEKLY_FEE_RATE_MEDIAN_FALLBACK,
     coordinationFeeRate: {
         rate: COORDINATOR_FEE_RATE_FALLBACK,
         plebsDontPayThreshold: PLEBS_DONT_PAY_THRESHOLD_FALLBACK,
@@ -147,13 +150,6 @@ export const CLIENT_STATUS_FALLBACK = {
         max: MAX_ALLOWED_AMOUNT_FALLBACK,
     },
 };
-export const DEFAULT_TARGET_ANONYMITY = 5;
-export const SKIP_ROUNDS_BY_DEFAULT = false;
-export const SKIP_ROUNDS_VALUE_WHEN_ENABLED = [4, 5] as [number, number];
-
-// coordinator fee rate from status format (0.003)
-// firmware format (300 000 = 0.003 * 10 ** 8)
-export const COORDINATOR_FEE_RATE_MULTIPLIER = 10 ** 8;
 
 export const getCoinjoinConfig = (
     network: NetworkSymbol,

--- a/packages/suite/src/utils/wallet/coinjoinUtils.ts
+++ b/packages/suite/src/utils/wallet/coinjoinUtils.ts
@@ -6,6 +6,7 @@ import { getUtxoOutpoint, getBip43Type } from '@suite-common/wallet-utils';
 import { Account, SelectedAccountStatus } from '@suite-common/wallet-types';
 import {
     ESTIMATED_MIN_ROUNDS_NEEDED,
+    MAX_MINING_FEE_MODIFIER,
     SKIP_ROUNDS_VALUE_WHEN_ENABLED,
 } from '@suite/services/coinjoin/config';
 import { CoinjoinSessionParameters, RoundPhase, SessionPhase } from '@wallet-types/coinjoin';
@@ -105,12 +106,12 @@ export const calculateAnonymityProgress = ({
 
 export const transformCoinjoinStatus = ({
     coordinationFeeRate,
-    maxMiningFee,
+    weeklyFeeRateMedian,
     allowedInputAmounts,
     rounds,
 }: CoinjoinStatusEvent) => ({
     coordinationFeeRate,
-    maxMiningFee,
+    weeklyFeeRateMedian,
     allowedInputAmounts,
     rounds: rounds.map(({ id, phase }) => ({ id, phase })),
 });
@@ -181,6 +182,9 @@ export const getMaxRounds = (roundsNeeded: number, roundsFailRateBuffer: number)
 // transform boolean to skip rounds value used by @trezor/coinjoin
 export const getSkipRounds = (enabled: boolean) =>
     enabled ? SKIP_ROUNDS_VALUE_WHEN_ENABLED : undefined;
+
+export const getMaxFeePerVbyte = (weeklyMedian: number) =>
+    Math.round(weeklyMedian * MAX_MINING_FEE_MODIFIER);
 
 // get time estimate in millisecond per round
 export const getEstimatedTimePerRound = (

--- a/packages/suite/src/views/wallet/details/index.tsx
+++ b/packages/suite/src/views/wallet/details/index.tsx
@@ -23,6 +23,7 @@ const Heading = styled.h3`
     color: ${({ theme }) => theme.TYPE_LIGHT_GREY};
     font-size: ${variables.FONT_SIZE.SMALL};
     font-weight: ${variables.FONT_WEIGHT.DEMI_BOLD};
+    margin: 14px 0 4px 0;
     text-transform: uppercase;
 `;
 
@@ -97,7 +98,7 @@ const Details = () => {
         <WalletLayout
             title="TR_ACCOUNT_DETAILS_HEADER"
             account={selectedAccount}
-            showEmptyHeaderPlaceholder
+            showEmptyHeaderPlaceholder={!isCoinjoinAccount}
         >
             <Cards>
                 {isCoinjoinAccount && (


### PR DESCRIPTION
## Description

This PR fixes some bugs I made in #7782 and and #7743 😅 

fa5d5e82b4da6bef83ab0ca65e19befcc1c6eca0: Default max mining fee is derived from weekly fee rate median. I originally assumed the fee rate median will not be used otherwise, so I only saved the derived `maxMiningFee`. This assumption was wrong because the median should be used in `selectMinAllowedInputWithFee` and `MaxMiningFeeSetup` range gradient. This commit replaces `maxMiningFee` with `weeklyFeeRateMedian` in `CoinjoinStatusEvent`.

b509b1a51b3e7c04628bb02787b386652dd106af: This commit applies the changes made in `@trezor/coinjoin` to `@trezor/suite`, thus fixing the calculation in `selectMinAllowedInputWithFee`. It also makes sure to always round the `maxFeePerVbyte` value so that it cannot result in fractions of satoshis. Also some minor refactoring.

f3fd94f755ea65a1692949af077bad606acbabd6: Improved gradient percentage calculation in `MaxMiningFeeSetup`.

24272048ff32a0533fcd233985b542cad3abaa06: Minor layout change to align cards between tabs in coinjoin account.

**QA:** This is mostly code improvement subtly affecting minimum UTXO amount for coinjoin and range styles. Starting coinjoin is still disabled with `Amounts are too small for coinjoin` when each non-private UTXO is too small, i.e. below 5000 sat + fee. Previously, the default max mining fee was used as a fee estimate - this was now replaced with fee rate median, the difference is usually a few hundred sats.