### PR TITLE
refactor: Coinjoin Status fetch schedule based on deadline 

### DIFF
--- a/packages/coinjoin/src/client/CoinjoinClient.ts
+++ b/packages/coinjoin/src/client/CoinjoinClient.ts
@@ -224,12 +224,16 @@ export class CoinjoinClient extends EventEmitter {
 
                 roundsToProcess.push(newRound);
                 if (!this.rounds.find(r => r.id === newRound.id)) {
+                    // start follow round in Status
+                    this.status.startFollowRound(newRound);
                     newRound.on('changed', event => this.emit('round', event));
                     newRound.on('ended', ({ round }) => {
                         round.inputs.concat(round.failed).forEach(input => {
                             // remove identities from Status
                             this.status.removeIdentity(input.outpoint);
                         });
+                        // stop follow round in Status
+                        this.status.stopFollowRound(round.id);
                         // remove round from the list
                         this.rounds = this.rounds.filter(r => r.id !== newRound.id);
                         // set Status mode

--- a/packages/coinjoin/src/client/Status.ts
+++ b/packages/coinjoin/src/client/Status.ts
@@ -1,7 +1,7 @@
 import { EventEmitter } from 'events';
 
 import * as coordinator from './coordinator';
-import { findNearestDeadline, transformStatus } from '../utils/roundUtils';
+import { transformStatus } from '../utils/roundUtils';
 import { STATUS_TIMEOUT } from '../constants';
 import { RoundPhase } from '../enums';
 import { CoinjoinClientSettings, CoinjoinStatusEvent, LogEvent } from '../types';
@@ -15,6 +15,13 @@ interface StatusEvents {
     'affiliate-server': boolean;
 }
 
+// partial CoinjoinRound
+interface RegisteredRound {
+    id: string;
+    phaseDeadline: number;
+    inputs: { outpoint: string }[];
+}
+
 export declare interface Status {
     on<K extends keyof StatusEvents>(type: K, listener: (event: StatusEvents[K]) => void): this;
     off<K extends keyof StatusEvents>(type: K, listener: (event: StatusEvents[K]) => void): this;
@@ -26,6 +33,7 @@ export class Status extends EventEmitter {
     timestamp = 0;
     nextTimestamp = 0;
     rounds: Round[] = [];
+    private registeredRound: RegisteredRound[] = [];
     mode: StatusMode = 'idle';
     private settings: CoinjoinClientSettings;
     private abortController: AbortController;
@@ -112,6 +120,18 @@ export class Status extends EventEmitter {
         this.identities = this.identities.filter(i => i !== id);
     }
 
+    startFollowRound(round: RegisteredRound) {
+        if (!this.registeredRound.find(r => r.id === round.id)) {
+            this.log('debug', `Status start following round ~~${round.id}~~`);
+            this.registeredRound.push(round);
+        }
+    }
+
+    stopFollowRound(id: string) {
+        this.log('debug', `Status stop following round ~${id}~`);
+        this.registeredRound = this.registeredRound.filter(r => r.id !== id);
+    }
+
     private clearStatusTimeout() {
         if (this.statusTimeout) clearTimeout(this.statusTimeout);
         this.statusTimeout = undefined;
@@ -120,14 +140,22 @@ export class Status extends EventEmitter {
     private setStatusTimeout() {
         if (!this.enabled) return;
 
-        const nearestDeadline = findNearestDeadline(this.rounds);
-        // TODO: add timeout randomness?
+        const defaultTimeout = STATUS_TIMEOUT[this.mode];
+        const half = defaultTimeout / 2;
+
+        // get deadlines from registered rounds
+        // set minimum deadline to half of defaultTimeout to avoid http request overflow
+        const nearestDeadlines = this.registeredRound
+            .map(r => r.phaseDeadline - Date.now())
+            .map(r => Math.max(r, half));
+
         const timeout =
-            this.mode !== 'idle' && nearestDeadline > 0
-                ? Math.min(nearestDeadline, STATUS_TIMEOUT[this.mode])
-                : STATUS_TIMEOUT[this.mode];
+            this.mode !== 'idle' ? Math.min(...nearestDeadlines, defaultTimeout) : defaultTimeout;
+
         this.timestamp = Date.now();
         this.nextTimestamp = this.timestamp + timeout;
+
+        this.log('debug', `Next status fetch in ${timeout}ms`);
 
         this.statusTimeout = setTimeout(() => {
             this.getStatus().then(() => {

--- a/packages/coinjoin/src/utils/roundUtils.ts
+++ b/packages/coinjoin/src/utils/roundUtils.ts
@@ -111,7 +111,8 @@ export const getCoinjoinRoundDeadlines = (round: PartialCoinjoinRound) => {
                     deadline + readTimeSpan(round.roundParameters.transactionSigningTimeout),
             };
         }
-        case RoundPhase.TransactionSigning: {
+        case RoundPhase.TransactionSigning:
+        case RoundPhase.Ended: {
             const deadline = now + readTimeSpan(round.roundParameters.transactionSigningTimeout);
             return {
                 phaseDeadline: deadline,

--- a/packages/coinjoin/tests/utils/roundUtils.test.ts
+++ b/packages/coinjoin/tests/utils/roundUtils.test.ts
@@ -79,7 +79,7 @@ describe('roundUtils', () => {
                 ...round,
                 phase: 4,
             }),
-            Date.now(),
+            Date.now() + timeouts * 3,
         );
     });
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
active `CoinjoinRound.phaseDeadline` is followed by `Status`. Status is scheduling own fetch timeout using following logic:

1. phaseDeadline < STATUS_TIMEOUT.enabled / 2 ? `timeout = STATUS_TIMEOUT.enabled / 2`
2. phaseDeadline >  STATUS_TIMEOUT.enabled / 2 && phaseDeadline < STATUS_TIMEOUT.enabled ?  `timeout = phaseDeadline`
3. phaseDeadline >  STATUS_TIMEOUT.enabled?  `timeout = STATUS_TIMEOUT.enabled`


## Commits

1. add shared Status.log function and fix missing `changed` event on unexpected phase change
2. add Status following round logic, refactor Status tests and use `jest fake timers` which is not only more reliable but also reduces execution time from ~43 sec to ~3 sec(!!!)
3. fix round deadline estimation for round with phase `Ended`
