### PR TITLE
Tests: e2e test for Web extension MV3

### DIFF
--- a/packages/connect-examples/webextension-mv3/connect-manager.html
+++ b/packages/connect-examples/webextension-mv3/connect-manager.html
@@ -7,8 +7,8 @@
     </head>
     <body>
         <button id="tab">New tab</button>
-        <button id="get-features">Get features</button>
-        <button id="get-address">Get address</button>
+        <button id="get-features" data-test="get-features">Get features</button>
+        <button id="get-address" data-test="get-address">Get address</button>
         <div id="result"></div>
         <!-- TODO: try to load changing content security policy -->
         <!-- https://developer.chrome.com/docs/extensions/mv3/manifest/content_security_policy/ -->

--- a/packages/connect-examples/webextension-mv3/manifest.json
+++ b/packages/connect-examples/webextension-mv3/manifest.json
@@ -10,5 +10,8 @@
             "matches": ["*://connect.trezor.io/9/popup.html"],
             "js": ["./vendor/trezor-content-script.js"]
         }
-    ]
+    ],
+    "background": {
+        "service_worker": "serviceWorker.js"
+    }
 }

--- a/packages/connect-examples/webextension-mv3/serviceWorker.js
+++ b/packages/connect-examples/webextension-mv3/serviceWorker.js
@@ -1,0 +1,2 @@
+// empty file so there is a service worker loaded in the extension and id can be used for the e2e tests.
+// https://playwright.dev/docs/chrome-extensions#testing

--- a/packages/connect-webextension/.eslintrc.js
+++ b/packages/connect-webextension/.eslintrc.js
@@ -2,7 +2,7 @@ module.exports = {
     rules: {
         'import/no-extraneous-dependencies': [
             'error',
-            { devDependencies: ['**/*.test.ts', '*config.ts'] },
+            { devDependencies: ['**/*.test.ts', '**/*config.ts'] },
         ],
     },
 };

--- a/packages/connect-webextension/e2e/playwright.config.ts
+++ b/packages/connect-webextension/e2e/playwright.config.ts
@@ -4,7 +4,7 @@ export const config: PlaywrightTestConfig = {
     testDir: 'e2e',
     retries: 0,
     workers: 1, // to disable parallelism between test files
-    timeout: 30000 * 1000,
+    timeout: 30 * 1000,
     use: {
         headless: process.env.HEADLESS === 'true',
         ignoreHTTPSErrors: true,

--- a/packages/connect-webextension/e2e/webextension.test.ts
+++ b/packages/connect-webextension/e2e/webextension.test.ts
@@ -6,17 +6,12 @@ import { chromium } from 'playwright';
 import { TrezorUserEnvLink } from '@trezor/trezor-user-env-link';
 import { ensureDirectoryExists } from '@trezor/node-utils';
 
-const delay = (time: number) =>
-    new Promise(resolve => {
-        setTimeout(resolve, time);
-    });
-
 let dir: string;
 test.beforeAll(async () => {
     dir = await ensureDirectoryExists('./screenshots/web-extension');
 });
 
-test('Basic web extension functionality', async () => {
+test('Basic web extension MV2', async () => {
     await TrezorUserEnvLink.connect();
     await TrezorUserEnvLink.send({
         type: 'bridge-stop',
@@ -61,13 +56,13 @@ test('Basic web extension functionality', async () => {
             `--load-extension=${pathToExtension}`,
         ],
     });
-    await delay(1000);
+
     const page = await browserContext.newPage();
 
     // https://github.com/microsoft/playwright/issues/5593#issuecomment-949813218
     await page.goto('chrome://inspect/#extensions');
 
-    await page.screenshot({ path: `${dir}/web-extension-1.png` });
+    await page.screenshot({ path: `${dir}/web-extension-mv2-1.png` });
 
     const url = await page.evaluate(
         () =>
@@ -92,6 +87,92 @@ test('Basic web extension functionality', async () => {
         timeout: 40000,
     });
     await popup.click("button[data-test='@analytics/continue-button']");
+
+    await popup.waitForSelector('button.confirm', { state: 'visible', timeout: 40000 });
+    await popup.click('button.confirm');
+
+    await popup.waitForSelector('.export-address >> visible=true');
+    await popup.locator('button.confirm >> visible=true').click();
+
+    await popup.waitForSelector('text=3AnYTd2FGxJLNKL1AzxfW3FJMntp9D2KKX');
+
+    await Promise.all([
+        popup.waitForEvent('close'),
+        TrezorUserEnvLink.send({ type: 'emulator-press-yes' }),
+    ]);
+
+    await browserContext.close();
+});
+
+test('Basic web extension MV3', async () => {
+    await TrezorUserEnvLink.connect();
+    await TrezorUserEnvLink.send({
+        type: 'bridge-stop',
+    });
+    await TrezorUserEnvLink.send({
+        type: 'emulator-stop',
+    });
+    await TrezorUserEnvLink.send({
+        type: 'emulator-start',
+        wipe: true,
+    });
+    await TrezorUserEnvLink.send({
+        type: 'emulator-setup',
+        mnemonic: 'alcohol woman abuse must during monitor noble actual mixed trade anger aisle',
+        pin: '',
+        passphrase_protection: false,
+        label: 'My Trevor',
+        needs_backup: false,
+    });
+    await TrezorUserEnvLink.send({
+        type: 'bridge-start',
+    });
+
+    const pathToExtension = path.join(
+        __dirname,
+        '..',
+        '..',
+        'connect-examples',
+        'webextension-mv3',
+    );
+
+    const userDataDir = '/tmp/test-user-data-dir';
+    const browserContext = await chromium.launchPersistentContext(userDataDir, {
+        // https://playwright.dev/docs/chrome-extensions#headless-mode
+        // By default, Chrome's headless mode in Playwright does not support Chrome extensions.
+        // To overcome this limitation, you can run Chrome's persistent context with a new headless mode.
+        // using `--headless=new`
+        headless: false,
+        args: [
+            process.env.HEADLESS === 'true' ? `--headless=new` : '', // the new headless arg for chrome v109+. Use '--headless=chrome' as arg for browsers v94-108.
+            `--disable-extensions-except=${pathToExtension}`,
+            `--load-extension=${pathToExtension}`,
+        ],
+    });
+    const page = await browserContext.newPage();
+
+    // https://playwright.dev/docs/chrome-extensions#testing
+    // It looks like the only way to get extension ID from a MV3 web extension in playwright is having serviceworker loaded.
+    let [background] = browserContext.serviceWorkers();
+    if (!background) background = await browserContext.waitForEvent('serviceworker');
+
+    const extensionId = background.url().split('/')[2];
+    expect(extensionId).toBeTruthy();
+
+    await page.goto(`chrome-extension://${extensionId}/connect-manager.html`);
+    await page.screenshot({ path: `${dir}/web-extension-mv3-1.png` });
+
+    await (await page.waitForSelector("button[data-test='get-address']")).click();
+
+    const popup = await browserContext.waitForEvent('page');
+    await popup.waitForLoadState('load');
+
+    // There is not analytics button since this test is after the MV2 that already clicked it and the container is not pruned after.
+    // await popup.waitForSelector("button[data-test='@analytics/continue-button']", {
+    //     state: 'visible',
+    //     timeout: 40000,
+    // });
+    // await popup.click("button[data-test='@analytics/continue-button']");
 
     await popup.waitForSelector('button.confirm', { state: 'visible', timeout: 40000 });
     await popup.click('button.confirm');

--- a/packages/connect-webextension/package.json
+++ b/packages/connect-webextension/package.json
@@ -4,7 +4,7 @@
     "private": true,
     "scripts": {
         "lint:js": "yarn g:eslint '**/*.{ts,tsx,js}'",
-        "test:e2e": "yarn xvfb-maybe -- playwright test --config=./playwright.config.ts"
+        "test:e2e": "yarn xvfb-maybe -- playwright test --config=./e2e/playwright.config.ts"
     },
     "devDependencies": {
         "@playwright/test": "^1.32.1",


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

This PR extends e2e tests for web extension testing also Manifest V3 example from `connect-examples`.

It was necessary to add an empty service worker to the example so playwright can get the extension ID and then use it to operate programmatically in the tests.

