### PR TITLE
fix(suite-desktop): node utils to electron external dependencies

### DIFF
--- a/packages/suite-desktop/package.json
+++ b/packages/suite-desktop/package.json
@@ -37,6 +37,7 @@
         "@trezor/connect": "workspace:9.0.7",
         "@trezor/connect-common": "workspace:*",
         "@trezor/ipc-proxy": "workspace:*",
+        "@trezor/message-system": "workspace:^",
         "@trezor/node-utils": "workspace:*",
         "@trezor/request-manager": "workspace:*",
         "@trezor/suite-desktop-api": "workspace:*",

--- a/packages/suite-desktop/scripts/build.ts
+++ b/packages/suite-desktop/scripts/build.ts
@@ -60,7 +60,12 @@ console.log(`[Electron Build] Using mocks: ${useMocks}`);
 // All local packages that doesn't have "build:libs" and used in packages/suite-desktop/src
 // must be built and not included in electron node_modules, because they are in TS.
 // Normal src/ folder is fine, because it's builded by webpack.
-const builtTrezorDependencies = ['@trezor/ipc-proxy', '@trezor/urls', '@trezor/utils'];
+const builtTrezorDependencies = [
+    '@trezor/ipc-proxy',
+    '@trezor/urls',
+    '@trezor/utils',
+    '@trezor/node-utils',
+];
 
 const dependencies = Object.keys(pkg.dependencies).filter(
     name => !(name.startsWith('@suite-common/') || builtTrezorDependencies.includes(name)),

--- a/packages/suite-desktop/tsconfig.json
+++ b/packages/suite-desktop/tsconfig.json
@@ -17,6 +17,7 @@
         { "path": "../connect" },
         { "path": "../connect-common" },
         { "path": "../ipc-proxy" },
+        { "path": "../message-system" },
         { "path": "../node-utils" },
         { "path": "../request-manager" },
         { "path": "../suite-desktop-api" },

--- a/yarn.lock
+++ b/yarn.lock
@@ -8017,7 +8017,7 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@trezor/message-system@workspace:*, @trezor/message-system@workspace:packages/message-system":
+"@trezor/message-system@workspace:*, @trezor/message-system@workspace:^, @trezor/message-system@workspace:packages/message-system":
   version: 0.0.0-use.local
   resolution: "@trezor/message-system@workspace:packages/message-system"
   dependencies:
@@ -8237,6 +8237,7 @@ __metadata:
     "@trezor/connect": "workspace:9.0.7"
     "@trezor/connect-common": "workspace:*"
     "@trezor/ipc-proxy": "workspace:*"
+    "@trezor/message-system": "workspace:^"
     "@trezor/node-utils": "workspace:*"
     "@trezor/request-manager": "workspace:*"
     "@trezor/suite-desktop-api": "workspace:*"


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Fixes suite-desktop from error loading new dependency `@trezor/node-utils` that was breaking the app from starting.