### PR TITLE
refactor(suite-native): rounded icon

### DIFF
--- a/packages/icons/package.json
+++ b/packages/icons/package.json
@@ -12,6 +12,7 @@
     },
     "dependencies": {
         "@shopify/react-native-skia": "0.1.173",
+        "@suite-common/wallet-types": "workspace:*",
         "@trezor/styles": "workspace:*",
         "@trezor/theme": "workspace:*",
         "react": "18.2.0",

--- a/packages/icons/src/index.ts
+++ b/packages/icons/src/index.ts
@@ -1,4 +1,5 @@
 export * from './icons';
+export * from './types';
 export * from './components/CryptoIcon';
 export * from './components/EthereumTokenIcon';
 export * from './components/CryptoIconWithPercentage';

--- a/packages/icons/src/types.ts
+++ b/packages/icons/src/types.ts
@@ -1,3 +1,3 @@
 import { CryptoIconName, EthereumTokenIconName, FlagIconName, IconName } from './icons';
 
-export type IconNames = IconName | CryptoIconName | EthereumTokenIconName | FlagIconName;
+export type AnyIconName = IconName | CryptoIconName | EthereumTokenIconName | FlagIconName;

--- a/packages/icons/src/types.ts
+++ b/packages/icons/src/types.ts
@@ -1,0 +1,3 @@
+import { CryptoIconName, EthereumTokenIconName, FlagIconName, IconName } from './icons';
+
+export type IconNames = IconName | CryptoIconName | EthereumTokenIconName | FlagIconName;

--- a/packages/icons/src/utils.ts
+++ b/packages/icons/src/utils.ts
@@ -1,3 +1,5 @@
+import { EthereumTokenSymbol } from '@suite-common/wallet-types';
+
 import {
     CryptoIconName,
     cryptoIcons,
@@ -18,14 +20,14 @@ export const isIconType = (iconName: IconNames): iconName is IconName => iconNam
 export const isFlagIconType = (iconName: IconNames): iconName is FlagIconName =>
     iconName in flagIcons;
 
-export const isEthereumTokenIconType = (iconName: IconNames): iconName is EthereumTokenIconName =>
-    iconName in ethereumTokenIcons;
-
-// TODO refactor - in rounded icon, this will be needed and needs to be improved
-//  because now if we don't have this icon, the condition there will fallback wrong
-export const getEthereumTokenIcon = (iconName: IconNames) => {
-    if (isEthereumTokenIconType(iconName)) {
-        return iconName;
+// First we check whether the name is in the list of Ethereum token symbols.
+// Since we cannot guarantee this, if it's not, we default to the 'erc20' icon.
+// Then we check whether the name is in the list of Ethereum token icons.
+const getIsEthereumTokenIconUploaded = (name: EthereumTokenSymbol) =>
+    (name in ethereumTokenIcons ? name : 'erc20') as EthereumTokenIconName;
+export const isEthereumTokenIconType = (iconName: IconNames): iconName is EthereumTokenIconName => {
+    if (!getIsEthereumTokenIconUploaded(iconName as EthereumTokenSymbol)) {
+        return 'erc20' in ethereumTokenIcons;
     }
-    return 'erc20';
+    return iconName in ethereumTokenIcons;
 };

--- a/packages/icons/src/utils.ts
+++ b/packages/icons/src/utils.ts
@@ -20,3 +20,12 @@ export const isFlagIconType = (iconName: IconNames): iconName is FlagIconName =>
 
 export const isEthereumTokenIconType = (iconName: IconNames): iconName is EthereumTokenIconName =>
     iconName in ethereumTokenIcons;
+
+// TODO refactor - in rounded icon, this will be needed and needs to be improved
+//  because now if we don't have this icon, the condition there will fallback wrong
+export const getEthereumTokenIcon = (iconName: IconNames) => {
+    if (isEthereumTokenIconType(iconName)) {
+        return iconName;
+    }
+    return 'erc20';
+};

--- a/packages/icons/src/utils.ts
+++ b/packages/icons/src/utils.ts
@@ -10,14 +10,14 @@ import {
     IconName,
     icons,
 } from './icons';
-import { IconNames } from './types';
+import { AnyIconName } from './types';
 
-export const isCryptoIconType = (iconName: IconNames): iconName is CryptoIconName =>
+export const isCryptoIconType = (iconName: AnyIconName): iconName is CryptoIconName =>
     iconName in cryptoIcons;
 
-export const isIconType = (iconName: IconNames): iconName is IconName => iconName in icons;
+export const isIconType = (iconName: AnyIconName): iconName is IconName => iconName in icons;
 
-export const isFlagIconType = (iconName: IconNames): iconName is FlagIconName =>
+export const isFlagIconType = (iconName: AnyIconName): iconName is FlagIconName =>
     iconName in flagIcons;
 
 // First we check whether the name is in the list of Ethereum token symbols.
@@ -25,7 +25,9 @@ export const isFlagIconType = (iconName: IconNames): iconName is FlagIconName =>
 // Then we check whether the name is in the list of Ethereum token icons.
 const getIsEthereumTokenIconUploaded = (name: EthereumTokenSymbol) =>
     (name in ethereumTokenIcons ? name : 'erc20') as EthereumTokenIconName;
-export const isEthereumTokenIconType = (iconName: IconNames): iconName is EthereumTokenIconName => {
+export const isEthereumTokenIconType = (
+    iconName: AnyIconName,
+): iconName is EthereumTokenIconName => {
     if (!getIsEthereumTokenIconUploaded(iconName as EthereumTokenSymbol)) {
         return 'erc20' in ethereumTokenIcons;
     }

--- a/packages/icons/src/utils.ts
+++ b/packages/icons/src/utils.ts
@@ -1,8 +1,22 @@
-import { CryptoIconName, cryptoIcons, FlagIconName, flagIcons } from './icons';
+import {
+    CryptoIconName,
+    cryptoIcons,
+    EthereumTokenIconName,
+    ethereumTokenIcons,
+    FlagIconName,
+    flagIcons,
+    IconName,
+    icons,
+} from './icons';
+import { IconNames } from './types';
 
-export const isCryptoIconType = (
-    iconName: CryptoIconName | FlagIconName,
-): iconName is CryptoIconName => iconName in cryptoIcons;
+export const isCryptoIconType = (iconName: IconNames): iconName is CryptoIconName =>
+    iconName in cryptoIcons;
 
-export const isFlagIconType = (iconName: CryptoIconName | FlagIconName): iconName is FlagIconName =>
+export const isIconType = (iconName: IconNames): iconName is IconName => iconName in icons;
+
+export const isFlagIconType = (iconName: IconNames): iconName is FlagIconName =>
     iconName in flagIcons;
+
+export const isEthereumTokenIconType = (iconName: IconNames): iconName is EthereumTokenIconName =>
+    iconName in ethereumTokenIcons;

--- a/packages/icons/tsconfig.json
+++ b/packages/icons/tsconfig.json
@@ -2,6 +2,9 @@
     "extends": "../../tsconfig.json",
     "compilerOptions": { "outDir": "libDev" },
     "references": [
+        {
+            "path": "../../suite-common/wallet-types"
+        },
         { "path": "../styles" },
         { "path": "../theme" }
     ]

--- a/suite-common/wallet-types/src/account.ts
+++ b/suite-common/wallet-types/src/account.ts
@@ -4,6 +4,8 @@ import { AccountInfo, PROTO } from '@trezor/connect';
 export type MetadataItem = string;
 export type XpubAddress = string;
 
+export type EthereumTokenSymbol = string & { __type: 'EthereumTokenSymbol' };
+
 export interface AccountMetadata {
     key: string; // legacy xpub format (btc-like coins) or account descriptor (other coins)
     fileName: string; // file name in dropbox

--- a/suite-common/wallet-types/src/ethereumTokenSymbol.ts
+++ b/suite-common/wallet-types/src/ethereumTokenSymbol.ts
@@ -1,1 +1,0 @@
-export type EthereumTokenSymbol = string & { __type: 'EthereumTokenSymbol' };

--- a/suite-common/wallet-types/src/ethereumTokenSymbol.ts
+++ b/suite-common/wallet-types/src/ethereumTokenSymbol.ts
@@ -1,0 +1,1 @@
+export type EthereumTokenSymbol = string & { __type: 'EthereumTokenSymbol' };

--- a/suite-common/wallet-types/src/index.ts
+++ b/suite-common/wallet-types/src/index.ts
@@ -9,3 +9,4 @@ export * from './sendForm';
 export * from './settings';
 export * from './selectedAccount';
 export * from './transaction';
+export * from './ethereumTokenSymbol';

--- a/suite-common/wallet-types/src/index.ts
+++ b/suite-common/wallet-types/src/index.ts
@@ -9,4 +9,3 @@ export * from './sendForm';
 export * from './settings';
 export * from './selectedAccount';
 export * from './transaction';
-export * from './ethereumTokenSymbol';

--- a/suite-native/accounts/src/components/TokenListItem.tsx
+++ b/suite-native/accounts/src/components/TokenListItem.tsx
@@ -4,7 +4,7 @@ import { TouchableOpacity } from 'react-native';
 import { BottomSheet, Box, Text } from '@suite-native/atoms';
 import { Icon, IconSize } from '@trezor/icons';
 import { EthereumTokenAmountFormatter, TokenToFiatAmountFormatter } from '@suite-native/formatters';
-import { EthereumTokenSymbol } from '@suite-native/ethereum-tokens';
+import { EthereumTokenSymbol } from '@suite-common/wallet-types';
 import { prepareNativeStyle, useNativeStyles } from '@trezor/styles';
 
 type TokenListItemProps = {

--- a/suite-native/atoms/src/ListItem/ListItemIcon.tsx
+++ b/suite-native/atoms/src/ListItem/ListItemIcon.tsx
@@ -1,7 +1,6 @@
 import React from 'react';
 
-import { Icon, IconName } from '@trezor/icons';
-import { prepareNativeStyle, useNativeStyles } from '@trezor/styles';
+import { IconName } from '@trezor/icons';
 
 import { Box } from '../Box';
 import { RoundedIcon } from '../RoundedIcon';
@@ -10,22 +9,13 @@ type ListItemIconProps = {
     iconName: IconName;
 };
 
-const listItemIconStyle = prepareNativeStyle(utils => ({
-    height: 48,
-    width: 48,
-    borderRadius: utils.borders.radii.round,
-    backgroundColor: utils.colors.backgroundSurfaceElevation2,
-}));
-
-export const ListItemIcon = ({ iconName }: ListItemIconProps) => {
-    const { applyStyle } = useNativeStyles();
-
-    return (
-        <Box justifyContent="center" alignItems="center" marginRight="medium">
-            <Box justifyContent="center" alignItems="center" style={applyStyle(listItemIconStyle)}>
-                <Icon name={iconName} color="iconSubdued" />
-            </Box>
-            <RoundedIcon name={iconName} backgroundColor="backgroundSurfaceElevation2" />
-        </Box>
-    );
-};
+export const ListItemIcon = ({ iconName }: ListItemIconProps) => (
+    <Box justifyContent="center" alignItems="center" marginRight="medium">
+        <RoundedIcon
+            name={iconName}
+            backgroundColor="backgroundSurfaceElevation2"
+            iconColor="iconSubdued"
+        />
+        <RoundedIcon name={iconName} backgroundColor="backgroundSurfaceElevation2" />
+    </Box>
+);

--- a/suite-native/atoms/src/ListItem/ListItemIcon.tsx
+++ b/suite-native/atoms/src/ListItem/ListItemIcon.tsx
@@ -4,6 +4,7 @@ import { Icon, IconName } from '@trezor/icons';
 import { prepareNativeStyle, useNativeStyles } from '@trezor/styles';
 
 import { Box } from '../Box';
+import { RoundedIcon } from '../RoundedIcon';
 
 type ListItemIconProps = {
     iconName: IconName;
@@ -24,6 +25,7 @@ export const ListItemIcon = ({ iconName }: ListItemIconProps) => {
             <Box justifyContent="center" alignItems="center" style={applyStyle(listItemIconStyle)}>
                 <Icon name={iconName} color="iconSubdued" />
             </Box>
+            <RoundedIcon name={iconName} backgroundColor="backgroundSurfaceElevation2" />
         </Box>
     );
 };

--- a/suite-native/atoms/src/RoundedIcon.tsx
+++ b/suite-native/atoms/src/RoundedIcon.tsx
@@ -7,7 +7,7 @@ import {
     EthereumTokenIcon,
     FlagIcon,
     Icon,
-    IconNames,
+    AnyIconName,
     isCryptoIconType,
     isEthereumTokenIconType,
     isFlagIconType,
@@ -17,7 +17,7 @@ import {
 import { Box } from './Box';
 
 type RoundedIconProps = {
-    name: IconNames;
+    name: AnyIconName;
     backgroundColor: Color;
     iconColor?: Color;
 };

--- a/suite-native/atoms/src/RoundedIcon.tsx
+++ b/suite-native/atoms/src/RoundedIcon.tsx
@@ -1,0 +1,52 @@
+import React from 'react';
+
+import { Color } from '@trezor/theme';
+import { prepareNativeStyle, useNativeStyles } from '@trezor/styles';
+import {
+    CryptoIcon,
+    EthereumTokenIcon,
+    FlagIcon,
+    Icon,
+    IconNames,
+    isCryptoIconType,
+    isEthereumTokenIconType,
+    isFlagIconType,
+    isIconType,
+} from '@trezor/icons';
+
+import { Box } from './Box';
+
+type RoundedIconProps = {
+    name: IconNames;
+    backgroundColor: Color;
+    iconColor?: Color;
+};
+
+const DEFAULT_ICON_SIZE = 48;
+const roundedIconStyle = prepareNativeStyle<{ backgroundColor: Color }>(
+    (utils, { backgroundColor }) => ({
+        justifyContent: 'center',
+        alignItems: 'center',
+        width: DEFAULT_ICON_SIZE,
+        height: DEFAULT_ICON_SIZE,
+        backgroundColor: utils.colors[backgroundColor],
+        borderRadius: utils.borders.radii.round,
+    }),
+);
+
+export const RoundedIcon = ({
+    name,
+    backgroundColor,
+    iconColor = 'iconDefault',
+}: RoundedIconProps) => {
+    const { applyStyle } = useNativeStyles();
+
+    return (
+        <Box style={applyStyle(roundedIconStyle, { backgroundColor })}>
+            {isCryptoIconType(name) && <CryptoIcon name={name} />}
+            {isIconType(name) && <Icon name={name} color={iconColor} />}
+            {isFlagIconType(name) && <FlagIcon name={name} />}
+            {isEthereumTokenIconType(name) && <EthereumTokenIcon name={name} />}
+        </Box>
+    );
+};

--- a/suite-native/atoms/src/RoundedIcon.tsx
+++ b/suite-native/atoms/src/RoundedIcon.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { ReactNode } from 'react';
 
 import { Color } from '@trezor/theme';
 import { prepareNativeStyle, useNativeStyles } from '@trezor/styles';
@@ -41,12 +41,21 @@ export const RoundedIcon = ({
 }: RoundedIconProps) => {
     const { applyStyle } = useNativeStyles();
 
-    return (
-        <Box style={applyStyle(roundedIconStyle, { backgroundColor })}>
-            {isCryptoIconType(name) && <CryptoIcon name={name} />}
-            {isIconType(name) && <Icon name={name} color={iconColor} />}
-            {isFlagIconType(name) && <FlagIcon name={name} />}
-            {isEthereumTokenIconType(name) && <EthereumTokenIcon name={name} />}
-        </Box>
-    );
+    const getIconByName = (): ReactNode | null => {
+        if (isCryptoIconType(name)) {
+            return <CryptoIcon name={name} />;
+        }
+        if (isIconType(name)) {
+            return <Icon name={name} color={iconColor} />;
+        }
+        if (isFlagIconType(name)) {
+            return <FlagIcon name={name} />;
+        }
+        if (isEthereumTokenIconType(name)) {
+            return <EthereumTokenIcon name={name} />;
+        }
+        return null;
+    };
+
+    return <Box style={applyStyle(roundedIconStyle, { backgroundColor })}>{getIconByName()}</Box>;
 };

--- a/suite-native/atoms/src/index.ts
+++ b/suite-native/atoms/src/index.ts
@@ -20,7 +20,7 @@ export * from './Button/IconButton';
 export * from './Select/Select';
 export * from './Select/SelectItem';
 export * from './Stack';
-
+export * from './RoundedIcon';
 export * from './Divider';
 export * from './TextDivider';
 export * from './ProgressBar';

--- a/suite-native/ethereum-tokens/package.json
+++ b/suite-native/ethereum-tokens/package.json
@@ -14,6 +14,7 @@
         "@mobily/ts-belt": "^3.13.1",
         "@suite-common/wallet-config": "workspace:*",
         "@suite-common/wallet-core": "workspace:*",
+        "@suite-common/wallet-types": "workspace:*",
         "@trezor/blockchain-link": "workspace:*"
     }
 }

--- a/suite-native/ethereum-tokens/src/types.ts
+++ b/suite-native/ethereum-tokens/src/types.ts
@@ -1,6 +1,5 @@
 import { TokenInfo } from '@trezor/blockchain-link';
-
-export type EthereumTokenSymbol = string & { __type: 'EthereumTokenSymbol' };
+import { EthereumTokenSymbol } from '@suite-common/wallet-types';
 
 export type EthereumTokenAccountWithBalance = Omit<TokenInfo, 'balance'> & {
     balance: string;

--- a/suite-native/ethereum-tokens/tsconfig.json
+++ b/suite-native/ethereum-tokens/tsconfig.json
@@ -9,6 +9,9 @@
             "path": "../../suite-common/wallet-core"
         },
         {
+            "path": "../../suite-common/wallet-types"
+        },
+        {
             "path": "../../packages/blockchain-link"
         }
     ]

--- a/suite-native/formatters/src/components/EthereumTokenAmountFormatter.tsx
+++ b/suite-native/formatters/src/components/EthereumTokenAmountFormatter.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 
 import { Box, Text, TextProps } from '@suite-native/atoms';
-import { EthereumTokenSymbol } from '@suite-native/ethereum-tokens';
+import { EthereumTokenSymbol } from '@suite-common/wallet-types';
 import { localizeNumber } from '@suite-common/wallet-utils';
 
 import { FormatterProps } from '../types';

--- a/suite-native/formatters/src/components/EthereumTokenSymbolFormatter.tsx
+++ b/suite-native/formatters/src/components/EthereumTokenSymbolFormatter.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 
 import { Text, TextProps } from '@suite-native/atoms';
-import { EthereumTokenSymbol } from '@suite-native/ethereum-tokens';
+import { EthereumTokenSymbol } from '@suite-common/wallet-types';
 
 type EthereumTokenSymbolFormatterProps = {
     ethereumSymbol: EthereumTokenSymbol;

--- a/suite-native/formatters/src/components/TokenToFiatAmountFormatter.tsx
+++ b/suite-native/formatters/src/components/TokenToFiatAmountFormatter.tsx
@@ -6,7 +6,7 @@ import { selectCoins } from '@suite-common/wallet-core';
 import { selectFiatCurrency } from '@suite-native/module-settings';
 import { toFiatCurrency } from '@suite-common/wallet-utils';
 import { useFormatters } from '@suite-common/formatters';
-import { EthereumTokenSymbol } from '@suite-native/ethereum-tokens';
+import { EthereumTokenSymbol } from '@suite-common/wallet-types';
 
 import { FormatterProps } from '../types';
 import { EmptyAmountText } from './EmptyAmountText';

--- a/suite-native/module-accounts-import/src/components/AccountImportEthereumTokens.tsx
+++ b/suite-native/module-accounts-import/src/components/AccountImportEthereumTokens.tsx
@@ -3,8 +3,9 @@ import React from 'react';
 import { A } from '@mobily/ts-belt';
 
 import { Box, VStack, Text } from '@suite-native/atoms';
-import { EthereumTokenSymbol, filterTokenHasBalance } from '@suite-native/ethereum-tokens';
+import { filterTokenHasBalance } from '@suite-native/ethereum-tokens';
 import { TokenInfo } from '@trezor/blockchain-link-types';
+import { EthereumTokenSymbol } from '@suite-common/wallet-types';
 
 import { EthereumTokenInfo } from './EthereumTokenInfo';
 

--- a/suite-native/module-accounts-import/src/components/EthereumTokenInfo.tsx
+++ b/suite-native/module-accounts-import/src/components/EthereumTokenInfo.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 
 import { EthereumTokenIcon, EthereumTokenIconName } from '@trezor/icons';
 import { EthereumTokenAmountFormatter, TokenToFiatAmountFormatter } from '@suite-native/formatters';
-import { EthereumTokenSymbol } from '@suite-native/ethereum-tokens';
+import { EthereumTokenSymbol } from '@suite-common/wallet-types';
 
 import { AccountImportOverviewCard } from './AccountImportOverviewCard';
 

--- a/suite-native/module-accounts-import/src/components/SelectableNetworkItem.tsx
+++ b/suite-native/module-accounts-import/src/components/SelectableNetworkItem.tsx
@@ -1,9 +1,9 @@
 import React from 'react';
 import { TouchableOpacity } from 'react-native';
 
-import { CryptoIcon, CryptoIconName } from '@trezor/icons';
+import { CryptoIconName } from '@trezor/icons';
 import { prepareNativeStyle, useNativeStyles } from '@trezor/styles';
-import { Box, Button, Text } from '@suite-native/atoms';
+import { Box, Button, RoundedIcon, Text } from '@suite-native/atoms';
 import { NetworkSymbol } from '@suite-common/wallet-config';
 import { useFormatters } from '@suite-common/formatters';
 
@@ -21,15 +21,6 @@ const selectableAssetContentStyle = prepareNativeStyle(() => ({
     justifyContent: 'space-between',
     flex: 1,
     marginLeft: 12,
-}));
-
-const cryptoIconStyle = prepareNativeStyle(utils => ({
-    height: 48,
-    width: 48,
-    borderRadius: utils.borders.radii.round,
-    backgroundColor: utils.colors.backgroundSurfaceElevation2,
-    justifyContent: 'center',
-    alignItems: 'center',
 }));
 
 export const SelectableNetworkItem = ({
@@ -51,9 +42,7 @@ export const SelectableNetworkItem = ({
         <TouchableOpacity disabled={!onPress} onPress={handlePress}>
             <Box flexDirection="row" alignItems="center">
                 <Box justifyContent="center" alignItems="center">
-                    <Box style={applyStyle(cryptoIconStyle)}>
-                        <CryptoIcon name={iconName} />
-                    </Box>
+                    <RoundedIcon name={iconName} backgroundColor="backgroundSurfaceElevation2" />
                 </Box>
                 <Box style={applyStyle(selectableAssetContentStyle)}>
                     <Box flex={1} justifyContent="space-between" alignItems="flex-start">

--- a/suite-native/module-settings/src/components/TouchableSwitchRow.tsx
+++ b/suite-native/module-settings/src/components/TouchableSwitchRow.tsx
@@ -1,8 +1,8 @@
 import React, { ReactNode } from 'react';
 import { TouchableOpacity } from 'react-native';
 
-import { Box, Text, Switch } from '@suite-native/atoms';
-import { Icon, IconName } from '@trezor/icons';
+import { Box, Text, Switch, RoundedIcon } from '@suite-native/atoms';
+import { IconName } from '@trezor/icons';
 import { prepareNativeStyle, useNativeStyles } from '@trezor/styles';
 
 type TouchableSwitchRowProps = {
@@ -19,18 +19,6 @@ const textStyle = prepareNativeStyle(_ => ({
 
 const contentStyle = prepareNativeStyle(_ => ({
     maxWidth: '70%',
-}));
-
-const ICON_SIZE = 48;
-const iconWrapperStyle = prepareNativeStyle(utils => ({
-    display: 'flex',
-    justifyContent: 'center',
-    alignItems: 'center',
-    width: ICON_SIZE,
-    height: ICON_SIZE,
-    borderRadius: utils.borders.radii.round,
-    backgroundColor: utils.colors.backgroundSurfaceElevation0,
-    padding: utils.spacings.medium,
 }));
 
 export const TouchableSwitchRow = ({
@@ -55,8 +43,12 @@ export const TouchableSwitchRow = ({
                 marginVertical="medium"
             >
                 <Box style={applyStyle(contentStyle)} flexDirection="row">
-                    <Box style={applyStyle(iconWrapperStyle)}>
-                        <Icon color="iconSubdued" name={iconName} />
+                    <Box padding="medium">
+                        <RoundedIcon
+                            name={iconName}
+                            iconColor="iconSubdued"
+                            backgroundColor="backgroundSurfaceElevation0"
+                        />
                     </Box>
                     <Box alignItems="flex-start" style={applyStyle(textStyle)}>
                         <Text>{text}</Text>

--- a/yarn.lock
+++ b/yarn.lock
@@ -7010,6 +7010,7 @@ __metadata:
     "@mobily/ts-belt": ^3.13.1
     "@suite-common/wallet-config": "workspace:*"
     "@suite-common/wallet-core": "workspace:*"
+    "@suite-common/wallet-types": "workspace:*"
     "@trezor/blockchain-link": "workspace:*"
   languageName: unknown
   linkType: soft
@@ -8015,6 +8016,7 @@ __metadata:
   resolution: "@trezor/icons@workspace:packages/icons"
   dependencies:
     "@shopify/react-native-skia": 0.1.173
+    "@suite-common/wallet-types": "workspace:*"
     "@trezor/styles": "workspace:*"
     "@trezor/theme": "workspace:*"
     jest: ^26.6.3


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

- Remove duplications of Icon styles by adding rounded icon component - easily extendible for the future
- Move ethereum token branded type to `suite-common/wallet-types` so that it can be used globally
- Create type predicates for icons so it's easier to distinguish them in code

## Related Issue

Resolve <!--- link the issue here -->

## Screenshots:
