### PR TITLE
Fix excessive memory usage with Sentry in dev

### DIFF
--- a/packages/suite-desktop/src/preload.ts
+++ b/packages/suite-desktop/src/preload.ts
@@ -3,7 +3,7 @@ import { contextBridge, ipcRenderer } from 'electron';
 import { exposeIpcProxy } from '@trezor/ipc-proxy';
 import { getDesktopApi } from '@trezor/suite-desktop-api';
 
-import '@sentry/electron/preload';
+import '@sentry/electron/preload'; // With this only IPCMode.Classic is ever taken into account
 
 contextBridge.exposeInMainWorld(
     ...exposeIpcProxy(ipcRenderer, ['TrezorConnect', 'CoinjoinBackend', 'CoinjoinClient']),

--- a/suite-common/sentry/src/index.ts
+++ b/suite-common/sentry/src/index.ts
@@ -67,8 +67,9 @@ const beforeBreadcrumb: Options['beforeBreadcrumb'] = breadcrumb => {
         breadcrumb.data?.url?.contains('data.trezor.io/suite/log');
     const isImageFetch =
         breadcrumb.category === 'xhr' && breadcrumb.data?.url?.contains('/assets/');
+    const isConsole = breadcrumb.category === 'console';
 
-    if (isAnalytics || isImageFetch) {
+    if (isAnalytics || isImageFetch || isConsole) {
         return null;
     }
     return breadcrumb;


### PR DESCRIPTION
When Sentry is active, every console log is set as a breadcrumb into its scope. In dev mode, every redux action is logged into console, including previous and next app state. Because of this, Suite with Sentry in dev mode consumes huge amount of memory and occasionally crashes with out of memory exception.

This PR omits console logs from automatic breadcrumbs which should resolve the issue.

Cc: @STew790 