### PR TITLE
fix(suite-native): github workflow lane

### DIFF
--- a/.github/workflows/suite-native_production_ci.yml
+++ b/.github/workflows/suite-native_production_ci.yml
@@ -118,4 +118,4 @@ jobs:
         # builds and publishes the app
         run: |
           bundle install
-          bundle exec fastlane ios staging
+          bundle exec fastlane ios production


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Lane is currently defined like this: 
```
  lane :production do
    build_to_app_store(scheme: "Release", export_method: "app-store")
```
This means that we need to call production lane in production workflow instead staging

Fastlane docs:
`Every time you run fastlane, use bundle exec fastlane [lane]`
