### PR TITLE
feat(suite-native): add api key to app store

### DIFF
--- a/suite-native/app/ios/fastlane/Fastfile
+++ b/suite-native/app/ios/fastlane/Fastfile
@@ -165,6 +165,7 @@ platform :ios do
 
   desc "Sign, build and push a new build to App Store"
   private_lane :build_to_app_store do |options|
+    api_key = lane_context[SharedValues::APP_STORE_CONNECT_API_KEY]
     prepare_distribution_signing
     build_app_to_distribute(scheme: options[:scheme], export_method: options[:export_method])
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Production lane was missing `api_key` variable. Set it up so it's same as on staging since it's the same key that's used.

## Related Issue

Resolve <!--- link the issue here -->

## Screenshots:
