### PR TITLE
fix(suite): Ethereum tx bump fee

### DIFF
--- a/packages/blockchain-link-types/src/blockbook.ts
+++ b/packages/blockchain-link-types/src/blockbook.ts
@@ -137,7 +137,7 @@ export interface Transaction {
         from?: string;
         to?: string;
         value: string;
-        token: string;
+        contract: string;
         name: string;
         symbol: string;
         decimals?: number;

--- a/packages/blockchain-link-utils/src/blockbook.ts
+++ b/packages/blockchain-link-utils/src/blockbook.ts
@@ -74,7 +74,7 @@ export const filterTokenTransfers = (
                 type,
                 name: tr.name,
                 symbol: tr.symbol,
-                address: tr.token,
+                address: tr.contract,
                 decimals: tr.decimals || 0,
                 amount: tr.value,
                 from: tr.from,

--- a/packages/blockchain-link-utils/src/tests/fixtures/blockbook.ts
+++ b/packages/blockchain-link-utils/src/tests/fixtures/blockbook.ts
@@ -23,7 +23,7 @@ const tOut = {
 const tIn = {
     name: 'Token name',
     symbol: 'TN',
-    token: '0x0',
+    contract: '0x0',
     value: '0',
 };
 

--- a/packages/suite/src/hooks/wallet/useRbfForm.ts
+++ b/packages/suite/src/hooks/wallet/useRbfForm.ts
@@ -62,7 +62,7 @@ const useRbfState = ({ tx, finalize, chainedTxs }: Props, currentState: boolean)
     const fees = useSelector(state => state.wallet.fees);
     const targetAnonymity = useSelector(selectCurrentTargetAnonymity);
 
-    const { areSatsDisplayed } = useBitcoinAmountUnit();
+    const { shouldSendInSats } = useBitcoinAmountUnit();
 
     // do not calculate if currentState is already set (prevent re-renders)
     if (selectedAccount.status !== 'loaded' || !tx.rbfParams || currentState) return;
@@ -102,7 +102,7 @@ const useRbfState = ({ tx, finalize, chainedTxs }: Props, currentState: boolean)
         return {
             ...DEFAULT_PAYMENT,
             address: o.address,
-            amount: areSatsDisplayed ? o.amount : o.formattedAmount,
+            amount: shouldSendInSats ? o.amount : o.formattedAmount,
             token: o.token,
         };
     });


### PR DESCRIPTION
## Description

- bump ETH transactions with low fee when satoshis are enabled
- bump ERC-20 tx fee

**Test in desktop app!!!**

## Related Issue

fix #7779
fix #7808
fix #7864

## Screenshots:

<img width="744" alt="Screenshot 2023-03-28 at 14 28 55" src="https://user-images.githubusercontent.com/33235762/228252526-01ccd4cb-f60e-40b3-a1db-9832b890b7ef.png">

<img width="763" alt="Screenshot 2023-03-28 at 16 50 03" src="https://user-images.githubusercontent.com/33235762/228294784-b63d197f-a6f2-4215-89cc-4b09a95d0be0.png">

