### PR TITLE
fix(suite-native): remove precheck

### DIFF
--- a/suite-native/app/ios/fastlane/Fastfile
+++ b/suite-native/app/ios/fastlane/Fastfile
@@ -171,6 +171,7 @@ platform :ios do
 
     upload_to_app_store(
         api_key: api_key,
+        run_precheck_before_submit: false,
         force: true, # not to generate HTML report
         reject_if_possible: true, # if the app is already waiting for the review and not reviewing yet, cancel it
         skip_metadata: false,


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Don't run precheck for upload to app store. Failed build here: https://github.com/trezor/trezor-suite/actions/runs/4542907087/jobs/8006919034

Error: [13:12:23]: Precheck cannot check In-app purchases with the App Store Connect API Key (yet). Exclude In-app purchases from precheck, disable the precheck step in your build step, or use Apple ID login


## Related Issue

Resolve <!--- link the issue here -->

## Screenshots:
