### PR TITLE
New FW receive flow

### DIFF
--- a/packages/suite/src/actions/wallet/__fixtures__/receiveActions.ts
+++ b/packages/suite/src/actions/wallet/__fixtures__/receiveActions.ts
@@ -157,6 +157,7 @@ export default [
             actions: [
                 { type: connectInitThunk.pending.type, payload: undefined },
                 { type: connectInitThunk.fulfilled.type, payload: undefined },
+                { type: MODAL.CLOSE },
                 {
                     type: notificationsActions.addToast.type,
                     payload: {
@@ -230,6 +231,7 @@ export default [
                 { type: connectInitThunk.fulfilled.type, payload: undefined },
                 { type: SUITE.LOCK_DEVICE, payload: true },
                 { type: SUITE.LOCK_DEVICE, payload: false },
+                { type: MODAL.CLOSE },
                 {
                     type: notificationsActions.addToast.type,
                     payload: { type: 'verify-address-error', error: 'Runtime error' },
@@ -254,6 +256,7 @@ export default [
                 { type: connectInitThunk.fulfilled.type, payload: undefined },
                 { type: SUITE.LOCK_DEVICE, payload: true },
                 { type: SUITE.LOCK_DEVICE, payload: false },
+                { type: MODAL.CLOSE },
             ],
         },
     },

--- a/packages/suite/src/actions/wallet/receiveActions.ts
+++ b/packages/suite/src/actions/wallet/receiveActions.ts
@@ -148,15 +148,7 @@ export const showAddress =
                 address,
             });
         } else {
-            // we are blocking close event in the modal reducer.
-            // On failed action we need to close it manually
-            const currentModal = getState().modal;
-            if (
-                currentModal.context === '@modal/context-user' &&
-                currentModal.payload.type === 'address'
-            ) {
-                dispatch(modalActions.onCancel());
-            }
+            dispatch(modalActions.onCancel());
             // special case: device no-backup permissions not granted
             if (response.payload.code === 'Method_PermissionsNotGranted') return;
 


### PR DESCRIPTION
## Description
Minimal change to fix issue #7698. Now all possible modals are explicitly closed when `TrezorConnect.getAddress` is unsuccessful, not only the `address` one.

More optional changes (refactoring mostly) are in followup PR #7964.

## Related issue
Resolve #7698