### PR TITLE
feat(suite-native): add dev button for prod as well

### DIFF
--- a/suite-native/module-dev-utils/src/components/CopyLogsButton.tsx
+++ b/suite-native/module-dev-utils/src/components/CopyLogsButton.tsx
@@ -1,0 +1,17 @@
+import React from 'react';
+import { useSelector } from 'react-redux';
+
+import { selectLogs } from '@suite-common/logger';
+import { useCopyToClipboard } from '@suite-native/helpers';
+import { Button } from '@suite-native/atoms';
+
+export const CopyLogsButton = () => {
+    const logs = useSelector(selectLogs);
+    const copyToClipboard = useCopyToClipboard();
+
+    const handleCopy = async () => {
+        await copyToClipboard(JSON.stringify(logs), 'Logs copied');
+    };
+
+    return <Button onPress={handleCopy}>Copy logs</Button>;
+};

--- a/suite-native/module-dev-utils/src/components/Logs.tsx
+++ b/suite-native/module-dev-utils/src/components/Logs.tsx
@@ -1,0 +1,34 @@
+import React, { useState } from 'react';
+import { useSelector } from 'react-redux';
+
+import { selectLogs } from '@suite-common/logger';
+import { Box, Card, CheckBox, Stack, Text } from '@suite-native/atoms';
+
+import { CopyLogsButton } from './CopyLogsButton';
+
+export const Logs = () => {
+    const logs = useSelector(selectLogs);
+    const [areLogsVisible, setAreLogsVisible] = useState(false);
+
+    return (
+        <>
+            <Card>
+                <Box flexDirection="row" justifyContent="space-between">
+                    <Text>Show logs</Text>
+                    <CheckBox
+                        isChecked={areLogsVisible}
+                        onChange={() => setAreLogsVisible(!areLogsVisible)}
+                    />
+                </Box>
+            </Card>
+            {areLogsVisible && (
+                <Stack>
+                    <CopyLogsButton />
+                    <Box>
+                        <Text>{JSON.stringify(logs)}</Text>
+                    </Box>
+                </Stack>
+            )}
+        </>
+    );
+};

--- a/suite-native/module-dev-utils/src/components/ProductionDevInfo.tsx
+++ b/suite-native/module-dev-utils/src/components/ProductionDevInfo.tsx
@@ -1,0 +1,15 @@
+import React from 'react';
+
+import { Card, VStack } from '@suite-native/atoms';
+
+import { CopyLogsButton } from './CopyLogsButton';
+import { BuildInfo } from './BuildInfo';
+
+export const ProductionDevInfo = () => (
+    <Card>
+        <VStack spacing="medium">
+            <CopyLogsButton />
+            <BuildInfo />
+        </VStack>
+    </Card>
+);

--- a/suite-native/module-dev-utils/src/components/RenderingUtils.tsx
+++ b/suite-native/module-dev-utils/src/components/RenderingUtils.tsx
@@ -1,0 +1,50 @@
+import React from 'react';
+import { TouchableOpacity } from 'react-native';
+
+import { Box, Card, CheckBox, Text, useDebugView } from '@suite-native/atoms';
+
+const DevCheckBoxListItem = ({
+    title,
+    onPress,
+    isChecked,
+}: {
+    title: string;
+    onPress: () => void;
+    isChecked: boolean;
+}) => (
+    <TouchableOpacity onPress={onPress}>
+        <Box
+            flexDirection="row"
+            justifyContent="space-between"
+            alignItems="center"
+            paddingVertical="small"
+        >
+            <Text variant="body">{title}</Text>
+            <CheckBox isChecked={isChecked} onChange={onPress} />
+        </Box>
+    </TouchableOpacity>
+);
+
+export const RenderingUtils = () => {
+    const {
+        toggleFlashOnRerender,
+        toggleRerenderCount,
+        isFlashOnRerenderEnabled,
+        isRerenderCountEnabled,
+    } = useDebugView();
+
+    return (
+        <Card>
+            <DevCheckBoxListItem
+                title="Flash on rerender"
+                onPress={toggleFlashOnRerender}
+                isChecked={isFlashOnRerenderEnabled}
+            />
+            <DevCheckBoxListItem
+                title="Show rerender count"
+                onPress={toggleRerenderCount}
+                isChecked={isRerenderCountEnabled}
+            />
+        </Card>
+    );
+};

--- a/suite-native/module-dev-utils/src/screens/DemoScreen.tsx
+++ b/suite-native/module-dev-utils/src/screens/DemoScreen.tsx
@@ -32,6 +32,7 @@ import {
     icons,
 } from '@trezor/icons';
 import { CoinsSettings } from '@suite-native/module-settings';
+import { isDevelopOrDebugEnv } from '@suite-native/config';
 
 const inputStackStyle = prepareNativeStyle(utils => ({
     borderRadius: utils.borders.radii.medium,
@@ -62,6 +63,8 @@ export const DemoScreen = () => {
     const handleRadioPress = (value: string | number) => {
         setRadioChecked(value.toString());
     };
+
+    if (!isDevelopOrDebugEnv()) return null;
 
     return (
         <Screen header={<ScreenHeader />}>

--- a/suite-native/module-dev-utils/src/screens/DevUtilsScreen.tsx
+++ b/suite-native/module-dev-utils/src/screens/DevUtilsScreen.tsx
@@ -21,8 +21,8 @@ export const DevUtilsScreen = ({
 }: StackProps<DevUtilsStackParamList, DevUtilsStackRoutes.DevUtils>) => {
     const persistor = useStoragePersistor();
 
-    const handleResetStorage = async () => {
-        await purgeStorage(persistor);
+    const handleResetStorage = () => {
+        purgeStorage(persistor);
     };
 
     return (

--- a/suite-native/module-dev-utils/src/screens/DevUtilsScreen.tsx
+++ b/suite-native/module-dev-utils/src/screens/DevUtilsScreen.tsx
@@ -1,9 +1,7 @@
-import React, { useState } from 'react';
-import { TouchableOpacity } from 'react-native';
-import { useSelector } from 'react-redux';
+import React from 'react';
 
 import { isDebugEnv, isDevelopOrDebugEnv } from '@suite-native/config';
-import { Box, Button, Card, CheckBox, Text, useDebugView, VStack } from '@suite-native/atoms';
+import { Box, Button, VStack } from '@suite-native/atoms';
 import {
     Screen,
     StackProps,
@@ -12,130 +10,39 @@ import {
     ScreenHeader,
 } from '@suite-native/navigation';
 import { purgeStorage, useStoragePersistor } from '@suite-native/storage';
-import { selectLogs } from '@suite-common/logger';
-import { useCopyToClipboard } from '@suite-native/helpers';
 
 import { BuildInfo } from '../components/BuildInfo';
-
-const DevCheckBoxListItem = ({
-    title,
-    onPress,
-    isChecked,
-}: {
-    title: string;
-    onPress: () => void;
-    isChecked: boolean;
-}) => (
-    <TouchableOpacity onPress={onPress}>
-        <Box
-            flexDirection="row"
-            justifyContent="space-between"
-            alignItems="center"
-            paddingVertical="small"
-        >
-            <Text variant="body">{title}</Text>
-            <CheckBox isChecked={isChecked} onChange={onPress} />
-        </Box>
-    </TouchableOpacity>
-);
-
-const CopyLogsButton = () => {
-    const logs = useSelector(selectLogs);
-    const copyToClipboard = useCopyToClipboard();
-
-    const handleCopy = async () => {
-        await copyToClipboard(JSON.stringify(logs), 'Logs copied');
-    };
-
-    return <Button onPress={handleCopy}>Copy logs</Button>;
-};
-
-const Logs = () => {
-    const logs = useSelector(selectLogs);
-    return (
-        <Box>
-            <Text>{JSON.stringify(logs)}</Text>
-        </Box>
-    );
-};
+import { Logs } from '../components/Logs';
+import { RenderingUtils } from '../components/RenderingUtils';
+import { ProductionDevInfo } from '../components/ProductionDevInfo';
 
 export const DevUtilsScreen = ({
     navigation,
 }: StackProps<DevUtilsStackParamList, DevUtilsStackRoutes.DevUtils>) => {
     const persistor = useStoragePersistor();
-    const {
-        toggleFlashOnRerender,
-        toggleRerenderCount,
-        isFlashOnRerenderEnabled,
-        isRerenderCountEnabled,
-    } = useDebugView();
-    const [areLogsVisible, setAreLogsVisible] = useState(false);
 
-    const handleResetStorage = () => {
-        purgeStorage(persistor);
+    const handleResetStorage = async () => {
+        await purgeStorage(persistor);
     };
 
     return (
         <Screen header={<ScreenHeader title="DEV utils" hasGoBackIcon />}>
             {isDevelopOrDebugEnv() ? (
                 <Box marginBottom="large">
-                    <Box
-                        flexDirection="row"
-                        justifyContent="space-between"
-                        alignItems="center"
-                        marginBottom="large"
-                    >
-                        <Box>
-                            <Text color="textSubdued" variant="hint">
-                                This section is shown only in local and develop builds! (Not in
-                                staging and production environments)
-                            </Text>
-                        </Box>
-                    </Box>
                     <VStack spacing="medium">
                         {!isDebugEnv() && <BuildInfo />}
-
-                        <Card>
-                            <DevCheckBoxListItem
-                                title="Flash on rerender"
-                                onPress={toggleFlashOnRerender}
-                                isChecked={isFlashOnRerenderEnabled}
-                            />
-                            <DevCheckBoxListItem
-                                title="Show rerender count"
-                                onPress={toggleRerenderCount}
-                                isChecked={isRerenderCountEnabled}
-                            />
-                        </Card>
-
+                        <RenderingUtils />
                         <Button onPress={() => navigation.navigate(DevUtilsStackRoutes.Demo)}>
                             See Component Demo
                         </Button>
                         <Button colorScheme="primary" onPress={handleResetStorage}>
                             Reset storage
                         </Button>
-                        <CopyLogsButton />
-
-                        <Card>
-                            <Box flexDirection="row" justifyContent="space-between">
-                                <Text>Show logs</Text>
-                                <CheckBox
-                                    isChecked={areLogsVisible}
-                                    onChange={() => setAreLogsVisible(!areLogsVisible)}
-                                />
-                            </Box>
-                        </Card>
-
-                        {areLogsVisible && <Logs />}
+                        <Logs />
                     </VStack>
                 </Box>
             ) : (
-                <Card>
-                    <VStack spacing="medium">
-                        <CopyLogsButton />
-                        <BuildInfo />
-                    </VStack>
-                </Card>
+                <ProductionDevInfo />
             )}
         </Screen>
     );

--- a/suite-native/module-dev-utils/src/screens/DevUtilsScreen.tsx
+++ b/suite-native/module-dev-utils/src/screens/DevUtilsScreen.tsx
@@ -129,7 +129,14 @@ export const DevUtilsScreen = ({
                         {areLogsVisible && <Logs />}
                     </VStack>
                 </Box>
-            ) : null}
+            ) : (
+                <Card>
+                    <VStack spacing="medium">
+                        <CopyLogsButton />
+                        <BuildInfo />
+                    </VStack>
+                </Card>
+            )}
         </Screen>
     );
 };

--- a/suite-native/module-settings/package.json
+++ b/suite-native/module-settings/package.json
@@ -23,6 +23,7 @@
         "@suite-native/config": "workspace:*",
         "@suite-native/link": "workspace:*",
         "@suite-native/navigation": "workspace:*",
+        "@suite-native/storage": "workspace:*",
         "@suite-native/theme": "workspace:*",
         "@trezor/connect": "workspace:9.0.7",
         "@trezor/icons": "workspace:*",

--- a/suite-native/module-settings/package.json
+++ b/suite-native/module-settings/package.json
@@ -28,6 +28,7 @@
         "@trezor/icons": "workspace:*",
         "@trezor/styles": "workspace:*",
         "@trezor/theme": "workspace:*",
+        "jotai": "1.9.1",
         "react": "18.2.0",
         "react-native": "0.71.5",
         "react-redux": "8.0.5"

--- a/suite-native/module-settings/src/components/ApplicationSettings.tsx
+++ b/suite-native/module-settings/src/components/ApplicationSettings.tsx
@@ -1,8 +1,7 @@
 import React from 'react';
-import { Pressable } from 'react-native';
 
-import { atom, useAtom } from 'jotai';
 import { useNavigation } from '@react-navigation/core';
+import { useAtom } from 'jotai';
 
 import {
     SettingsStackRoutes,
@@ -11,29 +10,13 @@ import {
     RootStackParamList,
     RootStackRoutes,
 } from '@suite-native/navigation';
-import { Text } from '@suite-native/atoms';
-import { isDevelopOrDebugEnv } from '@suite-native/config';
-import { prepareNativeStyle, useNativeStyles } from '@trezor/styles';
 
 import { SettingsSection } from './SettingsSection';
 import { SettingsSectionItem } from './SettingsSectionItem';
-
-const devButtonStyle = prepareNativeStyle(() => ({
-    position: 'absolute',
-    zIndex: 1,
-    top: 0,
-    right: 0,
-    width: 50,
-    height: 50,
-}));
-
-const isDevButtonVisibleAtom = atom<boolean>(false);
-
-let tapsCount = 0;
+import { isDevButtonVisibleAtom } from './ProductionDebug';
 
 export const ApplicationSettings = () => {
-    const { applyStyle } = useNativeStyles();
-    const [isVisible, setIsDevButtonVisible] = useAtom(isDevButtonVisibleAtom);
+    const [isDevButtonVisible] = useAtom(isDevButtonVisibleAtom);
 
     const navigation =
         useNavigation<
@@ -48,24 +31,10 @@ export const ApplicationSettings = () => {
         navigation.navigate(routeName);
     };
 
-    const handleTapsCount = () => {
-        if (tapsCount < 7) {
-            tapsCount++;
-        }
-        if (tapsCount === 7) {
-            setIsDevButtonVisible(true);
-        }
-    };
-
-    const shouldShowDevButton = isDevelopOrDebugEnv() || isVisible;
-
     return (
         <>
-            <Pressable style={applyStyle(devButtonStyle)} onPress={handleTapsCount}>
-                <Text> </Text>
-            </Pressable>
             <SettingsSection title="Application">
-                {shouldShowDevButton && (
+                {isDevButtonVisible && (
                     <SettingsSectionItem
                         iconName="placeholder"
                         title="DEV utils"

--- a/suite-native/module-settings/src/components/ApplicationSettings.tsx
+++ b/suite-native/module-settings/src/components/ApplicationSettings.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 
 import { useNavigation } from '@react-navigation/core';
-import { useAtom } from 'jotai';
+import { useAtomValue } from 'jotai';
 
 import {
     SettingsStackRoutes,
@@ -16,7 +16,7 @@ import { SettingsSectionItem } from './SettingsSectionItem';
 import { isDevButtonVisibleAtom } from './ProductionDebug';
 
 export const ApplicationSettings = () => {
-    const [isDevButtonVisible] = useAtom(isDevButtonVisibleAtom);
+    const isDevButtonVisible = useAtomValue(isDevButtonVisibleAtom);
 
     const navigation =
         useNavigation<

--- a/suite-native/module-settings/src/components/ApplicationSettings.tsx
+++ b/suite-native/module-settings/src/components/ApplicationSettings.tsx
@@ -1,5 +1,7 @@
 import React from 'react';
+import { Pressable } from 'react-native';
 
+import { atom, useAtom } from 'jotai';
 import { useNavigation } from '@react-navigation/core';
 
 import {
@@ -9,12 +11,30 @@ import {
     RootStackParamList,
     RootStackRoutes,
 } from '@suite-native/navigation';
+import { Text } from '@suite-native/atoms';
 import { isDevelopOrDebugEnv } from '@suite-native/config';
+import { prepareNativeStyle, useNativeStyles } from '@trezor/styles';
 
 import { SettingsSection } from './SettingsSection';
 import { SettingsSectionItem } from './SettingsSectionItem';
 
+const devButtonStyle = prepareNativeStyle(() => ({
+    position: 'absolute',
+    zIndex: 1,
+    top: 0,
+    right: 0,
+    width: 50,
+    height: 50,
+}));
+
+const isDevButtonVisibleAtom = atom<boolean>(false);
+
+let tapsCount = 0;
+
 export const ApplicationSettings = () => {
+    const { applyStyle } = useNativeStyles();
+    const [isVisible, setIsDevButtonVisible] = useAtom(isDevButtonVisibleAtom);
+
     const navigation =
         useNavigation<
             StackToStackCompositeNavigationProps<
@@ -28,34 +48,50 @@ export const ApplicationSettings = () => {
         navigation.navigate(routeName);
     };
 
+    const handleTapsCount = () => {
+        if (tapsCount < 7) {
+            tapsCount++;
+        }
+        if (tapsCount === 7) {
+            setIsDevButtonVisible(true);
+        }
+    };
+
+    const shouldShowDevButton = isDevelopOrDebugEnv() || isVisible;
+
     return (
-        <SettingsSection title="Application">
-            {isDevelopOrDebugEnv() && (
+        <>
+            <Pressable style={applyStyle(devButtonStyle)} onPress={handleTapsCount}>
+                <Text> </Text>
+            </Pressable>
+            <SettingsSection title="Application">
+                {shouldShowDevButton && (
+                    <SettingsSectionItem
+                        iconName="placeholder"
+                        title="DEV utils"
+                        subtitle="Only for devs and internal testers."
+                        onPress={() => navigation.navigate(RootStackRoutes.DevUtilsStack)}
+                    />
+                )}
                 <SettingsSectionItem
-                    iconName="placeholder"
-                    title="DEV utils"
-                    subtitle="Only for devs and internal testers."
-                    onPress={() => navigation.navigate(RootStackRoutes.DevUtilsStack)}
+                    iconName="flag"
+                    title="Localisation"
+                    subtitle="Currency, Bitcoin units"
+                    onPress={() => handleNavigation(SettingsStackRoutes.SettingsLocalisation)}
                 />
-            )}
-            <SettingsSectionItem
-                iconName="flag"
-                title="Localisation"
-                subtitle="Currency, Bitcoin units"
-                onPress={() => handleNavigation(SettingsStackRoutes.SettingsLocalisation)}
-            />
-            <SettingsSectionItem
-                title="Customization"
-                iconName="palette"
-                subtitle="Color scheme"
-                onPress={() => handleNavigation(SettingsStackRoutes.SettingsCustomization)}
-            />
-            <SettingsSectionItem
-                title="Privacy & Security"
-                iconName="eye"
-                subtitle="Analytics, Discreet mode"
-                onPress={() => handleNavigation(SettingsStackRoutes.SettingsPrivacyAndSecurity)}
-            />
-        </SettingsSection>
+                <SettingsSectionItem
+                    title="Customization"
+                    iconName="palette"
+                    subtitle="Color scheme"
+                    onPress={() => handleNavigation(SettingsStackRoutes.SettingsCustomization)}
+                />
+                <SettingsSectionItem
+                    title="Privacy & Security"
+                    iconName="eye"
+                    subtitle="Analytics, Discreet mode"
+                    onPress={() => handleNavigation(SettingsStackRoutes.SettingsPrivacyAndSecurity)}
+                />
+            </SettingsSection>
+        </>
     );
 };

--- a/suite-native/module-settings/src/components/ColorSchemePickerItem.tsx
+++ b/suite-native/module-settings/src/components/ColorSchemePickerItem.tsx
@@ -59,8 +59,8 @@ export const ColorSchemePickerItem = ({ colorScheme }: ColorSchemePickerItemProp
 
     const colorVariant = colorScheme === 'system' ? systemColorScheme : colorScheme;
 
-    const handleSchemePress = () => {
-        setUserColorScheme(colorScheme);
+    const handleSchemePress = async () => {
+        await setUserColorScheme(colorScheme);
     };
 
     return (

--- a/suite-native/module-settings/src/components/ProductionDebug.tsx
+++ b/suite-native/module-settings/src/components/ProductionDebug.tsx
@@ -1,0 +1,32 @@
+import React, { ReactNode } from 'react';
+import { Pressable } from 'react-native';
+
+import { useAtom } from 'jotai';
+
+import { isDevelopOrDebugEnv } from '@suite-native/config';
+import { atomWithUnecryptedStorage } from '@suite-native/storage';
+
+type ProductionDebugProps = {
+    children: ReactNode;
+};
+
+let tapsCount = 0;
+export const isDevButtonVisibleAtom = atomWithUnecryptedStorage<boolean>(
+    'isDevUtilsScreenVisible',
+    isDevelopOrDebugEnv(),
+);
+
+export const ProductionDebug = ({ children }: ProductionDebugProps) => {
+    const [_, setIsDevButtonVisible] = useAtom(isDevButtonVisibleAtom);
+
+    const handleTapsCount = async () => {
+        if (tapsCount < 7) {
+            tapsCount++;
+        }
+        if (tapsCount === 7) {
+            await setIsDevButtonVisible(true);
+        }
+    };
+
+    return <Pressable onPress={handleTapsCount}>{children}</Pressable>;
+};

--- a/suite-native/module-settings/src/components/ProductionDebug.tsx
+++ b/suite-native/module-settings/src/components/ProductionDebug.tsx
@@ -1,7 +1,7 @@
 import React, { ReactNode } from 'react';
 import { Pressable } from 'react-native';
 
-import { useAtom } from 'jotai';
+import { useSetAtom } from 'jotai';
 
 import { isDevelopOrDebugEnv } from '@suite-native/config';
 import { atomWithUnecryptedStorage } from '@suite-native/storage';
@@ -17,14 +17,14 @@ export const isDevButtonVisibleAtom = atomWithUnecryptedStorage<boolean>(
 );
 
 export const ProductionDebug = ({ children }: ProductionDebugProps) => {
-    const [_, setIsDevButtonVisible] = useAtom(isDevButtonVisibleAtom);
+    const setIsDevButtonVisible = useSetAtom(isDevButtonVisibleAtom);
 
-    const handleTapsCount = async () => {
+    const handleTapsCount = () => {
         if (tapsCount < 7) {
             tapsCount++;
         }
         if (tapsCount === 7) {
-            await setIsDevButtonVisible(true);
+            setIsDevButtonVisible(true);
         }
     };
 

--- a/suite-native/module-settings/src/screens/SettingsAboutUsScreen.tsx
+++ b/suite-native/module-settings/src/screens/SettingsAboutUsScreen.tsx
@@ -8,6 +8,15 @@ import { getAppVersion, getBuildVersionNumber, getCommitHash } from '@suite-nati
 import { useOpenLink } from '@suite-native/link';
 
 import { AboutUsBanners } from '../components/AboutUsBanners';
+import { ProductionDebug } from '../components/ProductionDebug';
+
+const CommitHashWithDevMenu = () => (
+    <ProductionDebug>
+        <Text variant="hint" color="textDisabled">
+            Commit hash: {getCommitHash()}
+        </Text>
+    </ProductionDebug>
+);
 
 export const SettingsAboutUsScreen = () => {
     const openLink = useOpenLink();
@@ -49,11 +58,7 @@ export const SettingsAboutUsScreen = () => {
                             Version: {`${getAppVersion()} (${getBuildVersionNumber()})`}
                         </Text>
                     )}
-                    {hasCommitHash && (
-                        <Text variant="hint" color="textDisabled">
-                            Commit hash: {getCommitHash()}
-                        </Text>
-                    )}
+                    {(hasCommitHash || true) && <CommitHashWithDevMenu />}
                 </Box>
             </VStack>
         </Screen>

--- a/suite-native/module-settings/tsconfig.json
+++ b/suite-native/module-settings/tsconfig.json
@@ -13,6 +13,7 @@
         { "path": "../config" },
         { "path": "../link" },
         { "path": "../navigation" },
+        { "path": "../storage" },
         { "path": "../theme" },
         { "path": "../../packages/connect" },
         { "path": "../../packages/icons" },

--- a/yarn.lock
+++ b/yarn.lock
@@ -7038,6 +7038,7 @@ __metadata:
     "@suite-native/config": "workspace:*"
     "@suite-native/link": "workspace:*"
     "@suite-native/navigation": "workspace:*"
+    "@suite-native/storage": "workspace:*"
     "@suite-native/theme": "workspace:*"
     "@trezor/connect": "workspace:9.0.7"
     "@trezor/icons": "workspace:*"

--- a/yarn.lock
+++ b/yarn.lock
@@ -7043,6 +7043,7 @@ __metadata:
     "@trezor/icons": "workspace:*"
     "@trezor/styles": "workspace:*"
     "@trezor/theme": "workspace:*"
+    jotai: 1.9.1
     react: 18.2.0
     react-native: 0.71.5
     react-redux: 8.0.5


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 564357f</samp>

*  Add a production debug feature that allows the user to enable the dev utils button by tapping seven times on the commit hash text in the settings screens 
* Refactor the dev utils screen to use modular components for rendering the logs, the rendering utils, and the production dev info


## Related Issue

Resolve https://github.com/trezor/trezor-suite/issues/7334


