### PR TITLE
Report anonymity gains and improve coinjoin time estimates

### DIFF
--- a/packages/analytics/src/types.ts
+++ b/packages/analytics/src/types.ts
@@ -22,3 +22,8 @@ export type Event = {
         [key: string]: string | string[] | number | number[] | boolean | null;
     };
 };
+
+export type ReportConfig = {
+    anonymize?: boolean; // Log event without session and instance ID to prevent linking it to other events.
+    force?: boolean; // Log event while analytics are not enabled.
+};

--- a/packages/connect-ui/src/utils/analytics.ts
+++ b/packages/connect-ui/src/utils/analytics.ts
@@ -33,7 +33,10 @@ const onEnable = () => {
 
 const onDisable = () => {
     saveTrackingEnablement(false);
-    analytics.report({ type: EventType.SettingsTracking, payload: { value: false } }, true);
+    analytics.report(
+        { type: EventType.SettingsTracking, payload: { value: false } },
+        { force: true },
+    );
 };
 
 export const initAnalytics = () => {

--- a/packages/suite-analytics/README.md
+++ b/packages/suite-analytics/README.md
@@ -67,7 +67,7 @@ From Suite version 22.10.1, analytics uses Suite versioning. That means, that an
 
 ## Changelog
 
-Add a record of change to [Notion](https://www.notion.so/satoshilabs/Changelog-Suite-1551ab666b1943f080ff56ffc6896d12d). Please use a format of previous records.
+Add a record of change to [Notion](https://www.notion.so/satoshilabs/Changelog-Suite-1551ab666b1943f080ff56ffc6896d12). Please use a format of previous records.
 
 ## Company table
 

--- a/packages/suite-analytics/src/constants.ts
+++ b/packages/suite-analytics/src/constants.ts
@@ -38,6 +38,8 @@ export enum EventType {
     TransactionCreated = 'transaction-created',
     SendRawTransaction = 'send-raw-transaction',
 
+    CoinjoinAnonymityGain = 'coinjoin/anonymity-gain',
+
     MenuNotificationsToggle = 'menu/notifications/toggle',
     MenuToggleDiscreet = 'menu/toggle-discreet',
 

--- a/packages/suite-analytics/src/types/events.ts
+++ b/packages/suite-analytics/src/types/events.ts
@@ -143,6 +143,12 @@ export type SuiteAnalyticsEvent =
           };
       }
     | {
+          type: EventType.CoinjoinAnonymityGain;
+          payload: {
+              value: number;
+          };
+      }
+    | {
           type: EventType.AccountsTransactionsExport;
           payload: {
               symbol: string;

--- a/packages/suite/src/actions/suite/analyticsActions.ts
+++ b/packages/suite/src/actions/suite/analyticsActions.ts
@@ -25,7 +25,10 @@ export const enableAnalyticsThunk = () => (dispatch: Dispatch) => {
 };
 
 export const disableAnalyticsThunk = () => (dispatch: Dispatch) => {
-    analytics.report({ type: EventType.SettingsAnalytics, payload: { value: false } }, true);
+    analytics.report(
+        { type: EventType.SettingsAnalytics, payload: { value: false } },
+        { force: true },
+    );
     allowSentryReport(false);
 
     dispatch(analyticsActions.disableAnalytics());

--- a/packages/suite/src/actions/wallet/coinjoinClientActions.ts
+++ b/packages/suite/src/actions/wallet/coinjoinClientActions.ts
@@ -28,8 +28,8 @@ import {
 import { onCancel as closeModal, openModal } from '@suite-actions/modalActions';
 import { notificationsActions } from '@suite-common/toast-notifications';
 import {
-    selectRoundsNeeded,
-    selectRoundsLeft,
+    selectRoundsNeededByAccountKey,
+    selectRoundsLeftByAccountKey,
     selectRoundsDurationInHours,
     selectCoinjoinAccounts,
 } from '@wallet-reducers/coinjoinReducer';
@@ -296,8 +296,8 @@ export const onCoinjoinRoundChanged =
                     roundsDurationInHours,
                     account.session?.skipRounds,
                 ),
-                roundsLeft: selectRoundsLeft(state, account.key),
-                roundsNeeded: selectRoundsNeeded(state, account.key),
+                roundsLeft: selectRoundsLeftByAccountKey(state, account.key),
+                roundsNeeded: selectRoundsNeededByAccountKey(state, account.key),
             });
 
             // notify reducers

--- a/packages/suite/src/actions/wallet/constants/coinjoinConstants.ts
+++ b/packages/suite/src/actions/wallet/constants/coinjoinConstants.ts
@@ -9,6 +9,9 @@ export const ACCOUNT_UNREGISTER = '@coinjoin/account-unregister';
 export const ACCOUNT_DISCOVERY_PROGRESS = '@coinjoin/account-discovery-progress';
 export const ACCOUNT_PRELOADING = '@coinjoin/account-preloading';
 export const ACCOUNT_SET_LIQUIDITY_CLUE = '@coinjoin/account-set-liquidity-clue';
+export const ACCOUNT_ADD_ANONYMITY_LEVEL = '@coinjoin/account-add-anonymity-level';
+export const ACCOUNT_UPDATE_LAST_REPORT_TIMESTAMP =
+    '@coinjoin/account-update-last-report-timestamp';
 
 export const CLIENT_ENABLE = '@coinjoin/client-enable';
 export const CLIENT_DISABLE = '@coinjoin/client-disable';

--- a/packages/suite/src/services/coinjoin/config.ts
+++ b/packages/suite/src/services/coinjoin/config.ts
@@ -151,6 +151,12 @@ export const CLIENT_STATUS_FALLBACK = {
     },
 };
 
+// Estimating anonymity gain per round:
+// How many previous coinjoin transactions are taken into account
+export const ANONYMITY_GAINS_HINDSIGHT_COUNT = 10;
+// What are the oldest coinjoin transactions taken into account
+export const ANONYMITY_GAINS_HINDSIGHT_DAYS = 30;
+
 export const getCoinjoinConfig = (
     network: NetworkSymbol,
     environment?: CoinjoinServerEnvironment,

--- a/packages/suite/src/types/wallet/coinjoin.ts
+++ b/packages/suite/src/types/wallet/coinjoin.ts
@@ -43,6 +43,16 @@ export interface CoinjoinDiscoveryCheckpoint {
     changeCount: number;
 }
 
+export interface AnonymityGainPerRound {
+    level: number;
+    timestamp: number;
+}
+
+export interface AnonymityGains {
+    history: AnonymityGainPerRound[];
+    lastReportTimestamp?: number;
+}
+
 export interface CoinjoinAccount {
     key: string; // reference to wallet Account.key
     symbol: NetworkSymbol;
@@ -51,6 +61,7 @@ export interface CoinjoinAccount {
     session?: CoinjoinSession; // current/active authorized session
     previousSessions: CoinjoinSession[]; // history
     checkpoints?: CoinjoinDiscoveryCheckpoint[];
+    anonymityGains?: AnonymityGains;
 }
 
 export type CoinjoinServerEnvironment = 'public' | 'staging' | 'localhost';

--- a/packages/suite/src/utils/wallet/__fixtures__/coinjoinUtils.ts
+++ b/packages/suite/src/utils/wallet/__fixtures__/coinjoinUtils.ts
@@ -1,3 +1,4 @@
+import { ANONYMITY_GAINS_HINDSIGHT_COUNT } from '@suite/services/coinjoin';
 import * as coinjoinUtils from '../coinjoinUtils';
 
 const baseUtxo = {
@@ -152,4 +153,28 @@ export const calculateProgressParams: Array<{
         },
         result: 100,
     },
+];
+
+export const cleanAnonymityGains: Array<{
+    params: Parameters<typeof coinjoinUtils.cleanAnonymityGains>[0];
+    resultLength: number;
+}> = [
+    {
+        params: new Array(ANONYMITY_GAINS_HINDSIGHT_COUNT + 1).fill({
+            level: 3,
+            timestamp: Date.now(),
+        }),
+        resultLength: ANONYMITY_GAINS_HINDSIGHT_COUNT,
+    },
+    { params: [{ level: 3, timestamp: 0 }], resultLength: 0 },
+];
+
+export const averageAnonymityGainsParams: Array<{
+    params: Parameters<typeof coinjoinUtils.calculateAverageAnonymityGainPerRound>;
+    checkResult: (average: number) => boolean;
+}> = [
+    { params: [2, [{ level: 3, timestamp: Date.now() }]], checkResult: x => x > 2 },
+    { params: [2, [{ level: 1, timestamp: Date.now() }]], checkResult: x => x < 2 },
+    { params: [2, [{ level: 2, timestamp: Date.now() }]], checkResult: x => x === 2 },
+    { params: [2, undefined], checkResult: x => x === 2 },
 ];

--- a/packages/suite/src/utils/wallet/__tests__/coinjoinUtils.test.ts
+++ b/packages/suite/src/utils/wallet/__tests__/coinjoinUtils.test.ts
@@ -21,3 +21,23 @@ describe('calculateAnonymityProgress', () => {
         });
     });
 });
+
+describe('cleanAnonymityGains', () => {
+    it('cleans correctly', () => {
+        fixtures.cleanAnonymityGains.forEach(({ params, resultLength }) => {
+            const records = coinjoinUtils.cleanAnonymityGains(params);
+
+            expect(records).toHaveLength(resultLength);
+        });
+    });
+});
+
+describe('calculateAverageAnonymityGainPerRound', () => {
+    it('calculates correctly', () => {
+        fixtures.averageAnonymityGainsParams.forEach(({ params, checkResult }) => {
+            const average = coinjoinUtils.calculateAverageAnonymityGainPerRound(...params);
+
+            expect(checkResult(average)).toBe(true);
+        });
+    });
+});

--- a/packages/suite/src/views/wallet/anonymize/components/CoinjoinConfirmation.tsx
+++ b/packages/suite/src/views/wallet/anonymize/components/CoinjoinConfirmation.tsx
@@ -10,7 +10,7 @@ import { DATA_TOS_URL, ZKSNACKS_TERMS_URL } from '@trezor/urls';
 import { startCoinjoinSession } from '@wallet-actions/coinjoinAccountActions';
 import {
     selectCurrentTargetAnonymity,
-    selectRoundsNeeded,
+    selectRoundsNeededByAccountKey,
     selectRoundsFailRateBuffer,
     selectCoinjoinClient,
     selectCoinjoinAccountByKey,
@@ -116,7 +116,7 @@ export const CoinjoinConfirmation = ({ account }: CoinjoinConfirmationProps) => 
     const coinjoinAccount = useSelector(state => selectCoinjoinAccountByKey(state, account.key));
     const coinjoinClient = useSelector(state => selectCoinjoinClient(state, account.key));
     const targetAnonymity = useSelector(selectCurrentTargetAnonymity);
-    const roundsNeeded = useSelector(state => selectRoundsNeeded(state, account.key));
+    const roundsNeeded = useSelector(state => selectRoundsNeededByAccountKey(state, account.key));
     const roundsFailRateBuffer = useSelector(selectRoundsFailRateBuffer);
     const defaultMaxMiningFee = useSelector(state =>
         selectDefaultMaxMiningFeeByAccountKey(state, account.key),

--- a/suite-native/analytics/src/analyticsThunks.ts
+++ b/suite-native/analytics/src/analyticsThunks.ts
@@ -25,7 +25,10 @@ export const enableAnalyticsThunk = createThunk(
 export const disableAnalyticsThunk = createThunk(
     `${ACTION_PREFIX}/disableAnalyticsThunk`,
     (_, { dispatch }) => {
-        analytics.report({ type: EventType.SettingsAnalytics, payload: { value: false } }, true);
+        analytics.report(
+            { type: EventType.SettingsAnalytics, payload: { value: false } },
+            { force: true },
+        );
         dispatch(analyticsActions.disableAnalytics());
     },
 );


### PR DESCRIPTION
## Description
- allow `@trezor/analytics` to exclude `session_id` and `instance_id` so that coinjoin-related logs cannot be linked to other logs in the analytics
- add `coinjoin/anonymity-gain` event to `@trezor/suite-analytics` to report anonymity changes between rounds
- implement logic in `@trezor/suite` to store anonymity gains, report them, and use them to calculate time estimates for coinjoin sessions

## Related Issue

Resolve #7381
