### PR TITLE
fix(connect): eth definition contract lowercase

### DIFF
--- a/packages/connect/src/api/ethereum/ethereumDefinitions.ts
+++ b/packages/connect/src/api/ethereum/ethereumDefinitions.ts
@@ -26,8 +26,10 @@ export const getEthereumDefinitions = async (chainId: number, contractAddress?: 
 
     try {
         if (contractAddress) {
+            // Contract address has to be in lowercase in order to be found in eth-definitions.
+            const lowerCaseContractAddress = contractAddress.toLowerCase();
             const tokenDefinition = await fetch(
-                `https://data.trezor.io/firmware/eth-definitions/chain-id/${chainId}/token-${contractAddress}.dat`,
+                `https://data.trezor.io/firmware/eth-definitions/chain-id/${chainId}/token-${lowerCaseContractAddress}.dat`,
             );
             if (tokenDefinition.status === 200) {
                 definitions.encoded_token = await tokenDefinition.arrayBuffer();


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->
It makes request to contract for eth definitions always lowercase.

## Related Issue

Related to https://github.com/trezor/trezor-suite/issues/6442

