### PR TITLE
Send max an NumberInput

### DIFF
--- a/packages/suite/src/components/suite/NumberInput.tsx
+++ b/packages/suite/src/components/suite/NumberInput.tsx
@@ -138,26 +138,14 @@ export const NumberInput = ({
     );
 
     useLayoutEffect(() => {
-        if (!value || !previousFormValueRef.current) {
-            return;
-        }
-
-        const cleanPrevFormValue = cleanValueString(previousFormValueRef.current, locale);
-        const cleanFormValue = cleanValueString(value, locale);
+        const cleanPrevFormValue = cleanValueString(previousFormValueRef.current ?? '', locale);
+        const cleanFormValue = cleanValueString(value ?? '', locale);
         const cleanPrevDisplayValue = cleanValueString(previousDisplayValueRef.current, locale);
         const cleanDisplayValue = cleanValueString(displayValue, locale);
-
         if (cleanPrevFormValue !== cleanFormValue && cleanPrevDisplayValue === cleanDisplayValue) {
-            formatDisplayValue(value);
+            formatDisplayValue(value ?? '');
         }
-    }, [
-        previousFormValueRef,
-        previousDisplayValueRef,
-        formatDisplayValue,
-        displayValue,
-        value,
-        locale,
-    ]);
+    }, [formatDisplayValue, displayValue, value, locale]);
 
     const handleChange = useCallback(
         (inputValue: string) => {

--- a/packages/suite/src/reducers/wallet/coinjoinReducer.ts
+++ b/packages/suite/src/reducers/wallet/coinjoinReducer.ts
@@ -599,14 +599,14 @@ export const selectCurrentCoinjoinSession = memoize((state: CoinjoinRootState) =
     return session;
 });
 
-export const selectCurrentTargetAnonymity = memoize((state: CoinjoinRootState) => {
+export const selectCurrentTargetAnonymity = (state: CoinjoinRootState) => {
     const selectedAccount = selectSelectedAccount(state);
     const targetAnonymity = selectedAccount
         ? selectTargetAnonymityByAccountKey(state, selectedAccount.key)
         : undefined;
 
     return targetAnonymity;
-});
+};
 
 export const selectIsCoinjoinBlockedByTor = memoize((state: CoinjoinRootState) => {
     const { isTorEnabled } = selectTorState(state);


### PR DESCRIPTION
## Description

8898e543cbe37a5d977d979d497564823ff921eb: Remove condition to enable formatting `displayValue` when previous `value` was falsy. Remove ref dependences which are unnecessary IMO. There is no bug in coinjoin-specific send form (as I originally thought) - if there are no anonymous coins, send-max does not fill any value and warning is shown.
d1283457059a538fdd604a65df51c6d3c7ecf413 - while testing the above, I noticed a redundant memoization which caused incorrect distribution into categories in CoinControl after `targetAnonymity` was adjusted in coinjoin setup. Memoization has been removed.

## Related Issue

Resolve #7967
