### PR TITLE
Remember (pre)pending transactions in storage

### DIFF
--- a/packages/suite/src/actions/suite/storageActions.ts
+++ b/packages/suite/src/actions/suite/storageActions.ts
@@ -204,13 +204,8 @@ export const saveAccountTransactions =
         const allTxs = getState().wallet.transactions.transactions;
         const accTxs = allTxs[account.key] || [];
 
-        // wrap confirmed txs and add its order inside the array
-        const orderedTxs = accTxs
-            .filter(t => (t.blockHeight || 0) > 0)
-            .map((accTx, i) => ({
-                tx: accTx,
-                order: i,
-            }));
+        // wrap txs and add its order inside the array
+        const orderedTxs = accTxs.map((tx, order) => ({ tx, order }));
         return db.addItems('txs', orderedTxs, true);
     };
 

--- a/suite-common/wallet-core/src/transactions/transactionsReducer.ts
+++ b/suite-common/wallet-core/src/transactions/transactionsReducer.ts
@@ -114,7 +114,8 @@ export const prepareTransactionsReducer = createReducerWithExtraDeps(
                         if (
                             ((existingTx.blockHeight ?? 0) <= 0 &&
                                 (transaction.blockHeight ?? 0) > 0) ||
-                            (!existingTx.blockTime && transaction.blockTime)
+                            (!existingTx.blockTime && transaction.blockTime) ||
+                            (existingTx.deadline && !transaction.deadline)
                         ) {
                             // pending tx got confirmed (blockHeight changed from undefined/0 to a number > 0)
                             accountTxs[existingTxIndex] = { ...transaction };

--- a/suite-common/wallet-utils/src/transactionUtils.ts
+++ b/suite-common/wallet-utils/src/transactionUtils.ts
@@ -294,15 +294,10 @@ export const analyzeTransactions = (
         };
     }
 
-    const [knownPrepending, knownRest] = arrayPartition(known, tx => {
-        if ('deadline' in tx) return true;
-        return false;
-    });
+    const [knownPrepending, knownRest] = arrayPartition(known, tx => 'deadline' in tx);
 
     const removePrepending = knownPrepending.filter(
-        tx =>
-            ('deadline' in tx && tx.deadline && tx?.deadline < blockHeight) ||
-            fresh.find(fTx => fTx.txid === tx.txid),
+        tx => (tx.deadline && tx.deadline < blockHeight) || fresh.find(fTx => fTx.txid === tx.txid),
     );
     // If there are no known confirmed txs
     // remove all known and add all fresh


### PR DESCRIPTION
## Description

When account is remembered, even pending and prepending transactions should be stored now.

## Commits

- https://github.com/trezor/trezor-suite/pull/7977/commits/34366437b053b8e636bd27f0f09036213b57f496 - removes condition that unconfirmed txs shouldn't be stored to the storage
- https://github.com/trezor/trezor-suite/pull/7977/commits/4ee7a72f912e3418c042026f4c213d310e5a681f - refactoring; allow to overwrite prepending tx with the same pending tx in `transactionsReducer`; extract the logic of prepending txs cleaning in `coinjoinAccountActions` to `cleanPendingTransactions` action

## Related Issue

Resolve #7973.