### PR TITLE
fix(coinjoin): ending Round when not signed

### DIFF
--- a/packages/coinjoin/src/client/round/endedRound.ts
+++ b/packages/coinjoin/src/client/round/endedRound.ts
@@ -1,0 +1,90 @@
+import { enumUtils } from '@trezor/utils';
+
+import type { CoinjoinRound, CoinjoinRoundOptions } from '../CoinjoinRound';
+import { EndRoundState } from '../../enums';
+import { WabiSabiProtocolErrorCode } from '../../types/coordinator';
+import { getBroadcastedTxDetails } from '../../utils/roundUtils';
+
+/**
+ * RoundPhase: 4, Ending
+ *
+ * Process endRoundState:
+ * - check if Round was signed successfully by this instance and throw error if not
+ * - catch blame round
+ * - catch transaction broadcasted
+ */
+
+export const ended = (round: CoinjoinRound, { logger, network }: CoinjoinRoundOptions) => {
+    const { id, endRoundState, inputs, addresses, prison } = round;
+    const endRoundKey = enumUtils.getKeyByValue(EndRoundState, round.endRoundState);
+    logger.info(`Ending round ~~${round.id}~~. End state: ${endRoundKey}`);
+
+    // check if Round was not signed by this instance.
+    // possible edge cases:
+    // - Round awaits for affiliateData from the Status but data are not provided before transactionSigningTimeout.
+    // - Round in critical phase awaits for Status phase change but update is not provided because of network problems.
+    // Round ends and this instance is to blame for it.
+    // inputs will probably be banned even if there was no error while processing.
+    if (
+        [EndRoundState.NotAllAlicesSign, EndRoundState.AbortedNotEnoughAlicesSigned].includes(
+            endRoundState,
+        ) &&
+        !round.isSignedSuccessfully()
+    ) {
+        // check reasons:
+        if (inputs.some(i => !i.confirmationData)) {
+            // no confirmed inputs
+            logger.error('Round not signed. Missing confirmed inputs.');
+        } else if (addresses.length === 0) {
+            // no registered outputs
+            logger.error('Round not signed. Missing outputs.');
+        } else if (!round.affiliateRequest) {
+            // missing affiliateRequest
+            logger.error('Round not signed. Missing affiliate request.');
+        } else if (inputs.some(i => !i.witness)) {
+            // no signed inputs
+            logger.error('Round not signed. Missing signed inputs.');
+        } else {
+            // not signed because of other reason however
+            logger.error(`Round not signed. This should never happen.`);
+        }
+        inputs.forEach(input =>
+            prison.detain(input.outpoint, {
+                roundId: id,
+                reason: WabiSabiProtocolErrorCode.InputBanned,
+            }),
+        );
+    } else if (endRoundState === EndRoundState.NotAllAlicesSign) {
+        logger.info('Awaiting blame round');
+        const inmates = inputs.map(i => i.outpoint).concat(addresses.map(a => a.scriptPubKey));
+
+        prison.detainForBlameRound(inmates, id);
+    } else if (endRoundState === EndRoundState.AbortedNotEnoughAlices) {
+        prison.releaseRegisteredInmates(id);
+    } else if (endRoundState === EndRoundState.TransactionBroadcasted) {
+        // detain all signed inputs and addresses forever
+        inputs.forEach(input =>
+            prison.detain(input.outpoint, {
+                roundId: id,
+                reason: WabiSabiProtocolErrorCode.InputSpent,
+                sentenceEnd: Infinity,
+            }),
+        );
+
+        addresses.forEach(addr =>
+            prison.detain(addr.scriptPubKey, {
+                roundId: id,
+                reason: WabiSabiProtocolErrorCode.AlreadyRegisteredScript,
+                sentenceEnd: Infinity,
+            }),
+        );
+
+        round.broadcastedTxDetails = getBroadcastedTxDetails({
+            coinjoinState: round.coinjoinState,
+            transactionData: round.transactionData,
+            network,
+        });
+    }
+
+    return round;
+};

--- a/packages/coinjoin/src/client/round/transactionSigning.ts
+++ b/packages/coinjoin/src/client/round/transactionSigning.ts
@@ -153,7 +153,7 @@ export const transactionSigning = async (
     }
 
     if (!round.affiliateRequest) {
-        logger.error(`Missing affiliate request. Waiting for status`);
+        logger.warn(`Missing affiliate request. Waiting for status`);
         round.setSessionPhase(SessionPhase.AwaitingCoinjoinTransaction);
         return round;
     }
@@ -178,6 +178,7 @@ export const transactionSigning = async (
 
         await Promise.all(round.inputs.map(input => sendTxSignature(round, input, options)));
 
+        round.signedSuccessfully();
         round.setSessionPhase(SessionPhase.AwaitingOtherSignatures);
         logger.info(`Round ${round.id} signed successfully`);
     } catch (error) {

--- a/packages/coinjoin/tests/client/CoinjoinRound.test.ts
+++ b/packages/coinjoin/tests/client/CoinjoinRound.test.ts
@@ -5,8 +5,6 @@ import { DEFAULT_ROUND, createCoinjoinRound } from '../fixtures/round.fixture';
 import { createInput } from '../fixtures/input.fixture';
 import * as CONSTANTS from '../../src/constants';
 
-let server: Awaited<ReturnType<typeof createServer>>;
-
 // mock random delay function
 jest.mock('@trezor/utils', () => {
     const originalModule = jest.requireActual('@trezor/utils');
@@ -19,7 +17,7 @@ jest.mock('@trezor/utils', () => {
 
 // mock ROUND_PHASE_PROCESS_TIMEOUT, use getter to mock individually for each test
 jest.mock('../../src/constants', () => {
-    const originalModule = jest.requireActual('@trezor/utils');
+    const originalModule = jest.requireActual('../../src/constants');
     return {
         __esModule: true,
         ...originalModule,
@@ -33,17 +31,95 @@ jest.mock('../../src/constants', () => {
 });
 
 describe(`CoinjoinRound`, () => {
+    let server: Awaited<ReturnType<typeof createServer>>;
+    const logger = {
+        warn: jest.fn(),
+        info: jest.fn(),
+        error: jest.fn(),
+        debug: jest.fn(),
+    };
+
     beforeAll(async () => {
         server = await createServer();
     });
 
-    beforeEach(() => {
-        server.removeAllListeners('test-request');
+    afterEach(() => {
+        jest.clearAllMocks();
+        server?.removeAllListeners('test-request');
     });
 
     afterAll(() => {
-        server.close();
-        jest.clearAllMocks();
+        server?.close();
+    });
+
+    it('catch not signed Round (missing affiliate request)', async () => {
+        // create CoinjoinRound in phase 3 (TransactionSigning)
+        const round = createCoinjoinRound(
+            [
+                createInput('account-A', 'A1', {
+                    ownershipProof: '01A1',
+                    registrationData: {
+                        aliceId: '01A1-01a1',
+                    },
+                    realAmountCredentials: {},
+                    realVsizeCredentials: {},
+                    confirmationData: {},
+                    confirmedAmountCredentials: {},
+                    confirmedVsizeCredentials: {},
+                }),
+            ],
+            {
+                ...server?.requestOptions,
+                logger,
+                round: {
+                    phase: 3,
+                    addresses: [{ address: 'doesnt matter', path: '', scriptPubKey: '' }],
+                },
+            },
+        );
+        // tx not signed, waiting for affiliate request
+        await round.process([]);
+
+        // change phase to Ended
+        await round.onPhaseChange({ ...DEFAULT_ROUND, phase: 4, endRoundState: 5 });
+
+        await round.process([]);
+
+        expect(logger.error).toBeCalledTimes(1);
+        expect(logger.error).toBeCalledWith(expect.stringMatching(/Missing affiliate request/));
+    });
+
+    it('catch failed Round', async () => {
+        // create CoinjoinRound in phase 2 (OutputRegistration)
+        const round = createCoinjoinRound(
+            [
+                createInput('account-A', 'A1', {
+                    ownershipProof: '01A1',
+                    registrationData: {
+                        aliceId: '01A1-01a1',
+                    },
+                    realAmountCredentials: {},
+                    realVsizeCredentials: {},
+                    confirmationData: {},
+                    confirmedAmountCredentials: {},
+                    confirmedVsizeCredentials: {},
+                }),
+            ],
+            {
+                ...server?.requestOptions,
+                logger,
+                round: {
+                    phase: 2,
+                    affiliateRequest: Buffer.from('0'.repeat(97 * 2 + 4), 'hex').toString('base64'),
+                },
+            },
+        );
+
+        // process phase (will throw error Missing credentials to join)
+        await round.process([]);
+
+        expect(logger.error).toBeCalledTimes(1);
+        expect(logger.error).toBeCalledWith(expect.stringMatching(/Output registration failed/));
     });
 
     it('onPhaseChange lock cool off resolved', async () => {

--- a/packages/coinjoin/tests/client/endedRound.test.ts
+++ b/packages/coinjoin/tests/client/endedRound.test.ts
@@ -1,0 +1,361 @@
+import { networks } from '@trezor/utxo-lib';
+
+import { RoundPhase, EndRoundState } from '../../src/enums';
+import { ended } from '../../src/client/round/endedRound';
+import { createInput } from '../fixtures/input.fixture';
+import { createCoinjoinRound } from '../fixtures/round.fixture';
+
+describe('ended', () => {
+    const logger = {
+        warn: jest.fn(),
+        info: jest.fn(),
+        error: jest.fn(),
+        debug: jest.fn(),
+    };
+
+    const options: any = {
+        coordinatorName: 'CoinJoinCoordinatorIdentifier',
+        logger,
+        network: networks.bitcoin,
+    };
+
+    beforeAll(async () => {});
+
+    beforeEach(() => {
+        jest.clearAllMocks();
+    });
+
+    afterAll(() => {});
+
+    it('NotAllAlicesSign by this instance (missing confirmed inputs)', () => {
+        const round = createCoinjoinRound(
+            [
+                createInput('account-A', 'A1', {
+                    ownershipProof: '01A1',
+                    registrationData: {
+                        aliceId: '01A1-01a1',
+                    },
+                    realAmountCredentials: {},
+                    realVsizeCredentials: {},
+                }),
+            ],
+            {
+                ...options,
+                round: {
+                    phase: RoundPhase.Ended,
+                    endRoundState: EndRoundState.NotAllAlicesSign,
+                },
+            },
+        );
+
+        ended(round, options);
+
+        expect(logger.error).toBeCalledTimes(1);
+        expect(logger.error).toBeCalledWith(expect.stringMatching(/Missing confirmed inputs/));
+        expect(round.prison.inmates.length).toEqual(1);
+    });
+
+    it('NotAllAlicesSign by this instance (missing outputs)', () => {
+        const round = createCoinjoinRound(
+            [
+                createInput('account-A', 'A1', {
+                    ownershipProof: '01A1',
+                    registrationData: {
+                        aliceId: '01A1-01a1',
+                    },
+                    realAmountCredentials: {},
+                    realVsizeCredentials: {},
+                    confirmationData: {},
+                    confirmedAmountCredentials: {},
+                    confirmedVsizeCredentials: {},
+                }),
+            ],
+            {
+                ...options,
+                round: {
+                    phase: RoundPhase.Ended,
+                    endRoundState: EndRoundState.NotAllAlicesSign,
+                },
+            },
+        );
+
+        ended(round, options);
+
+        expect(logger.error).toBeCalledTimes(1);
+        expect(logger.error).toBeCalledWith(expect.stringMatching(/Missing outputs/));
+        expect(round.prison.inmates.length).toEqual(1);
+    });
+
+    it('NotAllAlicesSign by this instance (missing affiliate request)', () => {
+        const round = createCoinjoinRound(
+            [
+                createInput('account-A', 'A1', {
+                    ownershipProof: '01A1',
+                    registrationData: {
+                        aliceId: '01A1-01a1',
+                    },
+                    realAmountCredentials: {},
+                    realVsizeCredentials: {},
+                    confirmationData: {},
+                    confirmedAmountCredentials: {},
+                    confirmedVsizeCredentials: {},
+                }),
+            ],
+            {
+                ...options,
+                logger,
+                round: {
+                    phase: RoundPhase.Ended,
+                    endRoundState: EndRoundState.NotAllAlicesSign,
+                    addresses: [
+                        {
+                            address:
+                                'bc1pkeah0fx2ex3jc337twlqcm9lh2eusm94j5vw2eshvczku6n7sjwqrfyfj2',
+                            path: '',
+                            scriptPubKey: '',
+                        },
+                    ],
+                },
+            },
+        );
+
+        ended(round, options);
+
+        expect(logger.error).toBeCalledTimes(1);
+        expect(logger.error).toBeCalledWith(expect.stringMatching(/Missing affiliate request/));
+        expect(round.prison.inmates.length).toEqual(1);
+    });
+
+    it('NotAllAlicesSign by this instance (missing witnesses)', () => {
+        // create CoinjoinRound in phase 1 (ConnectionConfirmation)
+        const round = createCoinjoinRound(
+            [
+                createInput('account-A', 'A1', {
+                    ownershipProof: '01A1',
+                    registrationData: {
+                        aliceId: '01A1-01a1',
+                    },
+                    realAmountCredentials: {},
+                    realVsizeCredentials: {},
+                    confirmationData: {},
+                    confirmedAmountCredentials: {},
+                    confirmedVsizeCredentials: {},
+                }),
+            ],
+            {
+                ...options,
+                round: {
+                    phase: RoundPhase.Ended,
+                    endRoundState: EndRoundState.NotAllAlicesSign,
+                    addresses: [
+                        {
+                            address:
+                                'bc1pkeah0fx2ex3jc337twlqcm9lh2eusm94j5vw2eshvczku6n7sjwqrfyfj2',
+                            path: '',
+                            scriptPubKey: '',
+                        },
+                    ],
+                    affiliateRequest: Buffer.from('0'.repeat(97 * 2 + 4), 'hex').toString('base64'),
+                },
+            },
+        );
+
+        ended(round, options);
+
+        expect(logger.error).toBeCalledTimes(1);
+        expect(logger.error).toBeCalledWith(expect.stringMatching(/Missing signed inputs/));
+        expect(round.prison.inmates.length).toEqual(1);
+    });
+
+    it('NotAllAlicesSign by this instance (other)', () => {
+        const round = createCoinjoinRound(
+            [
+                createInput('account-A', 'A1', {
+                    ownershipProof: '01A1',
+                    registrationData: {
+                        aliceId: '01A1-01a1',
+                    },
+                    realAmountCredentials: {},
+                    realVsizeCredentials: {},
+                    confirmationData: {},
+                    confirmedAmountCredentials: {},
+                    confirmedVsizeCredentials: {},
+                    witness: '0'.repeat(97 * 2 + 4),
+                }),
+            ],
+            {
+                ...options,
+                round: {
+                    phase: RoundPhase.Ended,
+                    endRoundState: EndRoundState.NotAllAlicesSign,
+                    addresses: [
+                        {
+                            address:
+                                'bc1pkeah0fx2ex3jc337twlqcm9lh2eusm94j5vw2eshvczku6n7sjwqrfyfj2',
+                            path: '',
+                            scriptPubKey: '',
+                        },
+                    ],
+                    affiliateRequest: Buffer.from('0'.repeat(97 * 2 + 4), 'hex').toString('base64'),
+                },
+            },
+        );
+
+        ended(round, options);
+
+        expect(logger.error).toBeCalledTimes(1);
+        expect(logger.error).toBeCalledWith(expect.stringMatching(/This should never happen/));
+        expect(round.prison.inmates.length).toEqual(1);
+    });
+
+    it('AbortedNotEnoughAlicesSigned by other instance (no blame round)', () => {
+        const round = createCoinjoinRound(
+            [
+                createInput('account-A', '0'.repeat(72), {
+                    ownershipProof: '01A1',
+                    registrationData: {
+                        aliceId: '01A1-01a1',
+                    },
+                    realAmountCredentials: {},
+                    realVsizeCredentials: {},
+                    confirmationData: {},
+                    confirmedAmountCredentials: {},
+                    confirmedVsizeCredentials: {},
+                    witness: '0'.repeat(97 * 2 + 4),
+                }),
+            ],
+            {
+                ...options,
+                round: {
+                    phase: RoundPhase.Ended,
+                    signed: true,
+                    endRoundState: EndRoundState.AbortedNotEnoughAlicesSigned,
+                    addresses: [
+                        {
+                            address:
+                                'bc1pkeah0fx2ex3jc337twlqcm9lh2eusm94j5vw2eshvczku6n7sjwqrfyfj2',
+                            path: '',
+                            scriptPubKey: '',
+                        },
+                    ],
+                    affiliateRequest: Buffer.from('0'.repeat(97 * 2 + 4), 'hex').toString('base64'),
+                },
+            },
+        );
+
+        ended(round, options);
+
+        expect(logger.error).toBeCalledTimes(0);
+        expect(round.prison.inmates.length).toEqual(0);
+    });
+
+    it('NotAllAlicesSign by other instance (wait for blame round)', () => {
+        const round = createCoinjoinRound(
+            [
+                createInput('account-A', '0'.repeat(72), {
+                    ownershipProof: '01A1',
+                    registrationData: {
+                        aliceId: '01A1-01a1',
+                    },
+                    realAmountCredentials: {},
+                    realVsizeCredentials: {},
+                    confirmationData: {},
+                    confirmedAmountCredentials: {},
+                    confirmedVsizeCredentials: {},
+                    witness: '0'.repeat(97 * 2 + 4),
+                }),
+            ],
+            {
+                ...options,
+                round: {
+                    phase: RoundPhase.Ended,
+                    signed: true,
+                    endRoundState: EndRoundState.NotAllAlicesSign,
+                    addresses: [
+                        {
+                            address:
+                                'bc1pkeah0fx2ex3jc337twlqcm9lh2eusm94j5vw2eshvczku6n7sjwqrfyfj2',
+                            path: '',
+                            scriptPubKey: '',
+                        },
+                    ],
+                    affiliateRequest: Buffer.from('0'.repeat(97 * 2 + 4), 'hex').toString('base64'),
+                },
+            },
+        );
+
+        ended(round, options);
+
+        expect(logger.error).toBeCalledTimes(0);
+        expect(round.prison.inmates.length).toEqual(2); // input and address (output) detained
+    });
+
+    it('AbortedNotEnoughAlices', () => {
+        const round = createCoinjoinRound(
+            [
+                createInput('account-A', '0'.repeat(72), {
+                    ownershipProof: '01A1',
+                    registrationData: {
+                        aliceId: '01A1-01a1',
+                    },
+                    realAmountCredentials: {},
+                    realVsizeCredentials: {},
+                }),
+            ],
+            {
+                ...options,
+                round: {
+                    phase: RoundPhase.Ended,
+                    endRoundState: EndRoundState.AbortedNotEnoughAlices,
+                },
+            },
+        );
+
+        // NOTE: registered inputs are detained by inputRegistration process
+        round.prison.detain('0'.repeat(72), {
+            roundId: round.id,
+            reason: 'AliceAlreadyRegistered',
+        });
+
+        ended(round, options);
+
+        expect(logger.error).toBeCalledTimes(0);
+        expect(round.prison.inmates.length).toEqual(0); // input released from detention
+    });
+
+    it('TransactionBroadcasted', () => {
+        const round = createCoinjoinRound(
+            [
+                createInput('account-A', '0'.repeat(72), {
+                    ownershipProof: '01A1',
+                    registrationData: {
+                        aliceId: '01A1-01a1',
+                    },
+                    realAmountCredentials: {},
+                    realVsizeCredentials: {},
+                }),
+            ],
+            {
+                ...options,
+                round: {
+                    phase: RoundPhase.Ended,
+                    endRoundState: EndRoundState.TransactionBroadcasted,
+                    addresses: [
+                        {
+                            address:
+                                'bc1pkeah0fx2ex3jc337twlqcm9lh2eusm94j5vw2eshvczku6n7sjwqrfyfj2',
+                            path: '',
+                            scriptPubKey:
+                                '1 b67b77a4cac9a32c463e5bbe0c6cbfbab3c86cb59518e5661766056e6a7e849c',
+                        },
+                    ],
+                },
+            },
+        );
+
+        ended(round, options);
+
+        expect(logger.error).toBeCalledTimes(0);
+        expect(round.prison.inmates.length).toEqual(2); // input and output detained forever
+    });
+});


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

- Moving `endRoundState` validation from `CoinjoinRound` to standalone file `./round/endedRound` similar to other phases processing
- Fix reporting errors from failed rounds
- more tests


<!--- Describe your changes in detail -->
