### PR TITLE
fix(node-utils): dir path can't be dasherized as a whole

### DIFF
--- a/packages/node-utils/src/ensureDirectoryExists.ts
+++ b/packages/node-utils/src/ensureDirectoryExists.ts
@@ -5,9 +5,8 @@ const exists = promisify(fs.exists);
 const mkdir = promisify(fs.mkdir);
 
 export const ensureDirectoryExists = async (dir: string) => {
-    const dasherizedDir = dir.replace(' ', '-');
-    if (!(await exists(dasherizedDir))) {
-        await mkdir(dasherizedDir, { recursive: true });
+    if (!(await exists(dir))) {
+        await mkdir(dir, { recursive: true });
     }
-    return dasherizedDir;
+    return dir;
 };

--- a/packages/suite-desktop/scripts/build.ts
+++ b/packages/suite-desktop/scripts/build.ts
@@ -7,7 +7,10 @@ import { build, PluginBuild } from 'esbuild';
 
 import uriSchemes from '../uriSchemes.json';
 import pkg from '../package.json';
-import { suiteVersion } from '../../suite/package.json';
+
+// To prevent unnecessary type check of whole suite package. It's a static file so require is
+// eslint-disable-next-line @typescript-eslint/no-var-requires
+const { suiteVersion } = require('../../suite/package.json');
 
 const { NODE_ENV, USE_MOCKS, IS_CODESIGN_BUILD } = process.env;
 const PROJECT = 'desktop';

--- a/packages/suite-desktop/scripts/tsconfig.json
+++ b/packages/suite-desktop/scripts/tsconfig.json
@@ -6,7 +6,6 @@
     },
     "include": ["."],
     "references": [
-        { "path": "../../suite-desktop" },
-        { "path": "../../suite" }
+        { "path": "../../suite-desktop" }
     ]
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

There could be existing path that contains spaces and you need to create just a subfolder of that existing folder.
i.e. `~/Library/Application Support/@trezor/suite-desktop-local`

## Related Issue

Resolve https://github.com/trezor/trezor-suite/issues/7972
