### PR TITLE
chore(utxo-lib): update bs58check bitcoin lib

### DIFF
--- a/packages/utxo-lib/package.json
+++ b/packages/utxo-lib/package.json
@@ -45,7 +45,7 @@
         "blakejs": "^1.2.1",
         "bn.js": "^5.2.1",
         "bs58": "^5.0.0",
-        "bs58check": "^2.1.2",
+        "bs58check": "^3.0.1",
         "create-hash": "^1.2.0",
         "create-hmac": "^1.1.7",
         "int64-buffer": "^1.0.1",

--- a/packages/utxo-lib/src/bip32.ts
+++ b/packages/utxo-lib/src/bip32.ts
@@ -333,9 +333,11 @@ class BIP32 implements BIP32Interface {
 }
 
 export function fromBase58(inString: string, network?: Network): BIP32Interface {
-    const buffer = isNetworkType('decred', network)
-        ? bs58check.decodeBlake256Key(inString)
-        : bs58check.decode(inString, network);
+    const buffer = Buffer.from(
+        isNetworkType('decred', network)
+            ? bs58check.decodeBlake256Key(inString)
+            : bs58check.decode(inString, network),
+    );
     if (buffer.length !== 78) throw new TypeError('Invalid buffer length');
     network = network || BITCOIN;
 

--- a/packages/utxo-lib/src/bs58check.ts
+++ b/packages/utxo-lib/src/bs58check.ts
@@ -56,9 +56,9 @@ export function decodeAddress(address: string, network = BITCOIN_NETWORK) {
     let payload: Buffer;
     if (isNetworkType('bitcoinCash', network)) {
         if (!bchaddrjs.isCashAddress(address)) throw Error(`${address} is not a cash address`);
-        payload = bs58check.decode(bchaddrjs.toLegacyAddress(address));
+        payload = Buffer.from(bs58check.decode(bchaddrjs.toLegacyAddress(address)));
     } else {
-        payload = decode(address, network);
+        payload = Buffer.from(decode(address, network));
     }
 
     // TODO: 4.0.0, move to "toOutputScript"

--- a/yarn.lock
+++ b/yarn.lock
@@ -4356,6 +4356,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@noble/hashes@npm:^1.2.0":
+  version: 1.3.0
+  resolution: "@noble/hashes@npm:1.3.0"
+  checksum: d7ddb6d7c60f1ce1f87facbbef5b724cdea536fc9e7f59ae96e0fc9de96c8f1a2ae2bdedbce10f7dcc621338dfef8533daa73c873f2b5c87fa1a4e05a95c2e2e
+  languageName: node
+  linkType: hard
+
 "@noble/hashes@npm:~1.1.1":
   version: 1.1.3
   resolution: "@noble/hashes@npm:1.1.3"
@@ -8622,7 +8629,7 @@ __metadata:
     blakejs: ^1.2.1
     bn.js: ^5.2.1
     bs58: ^5.0.0
-    bs58check: ^2.1.2
+    bs58check: ^3.0.1
     create-hash: ^1.2.0
     create-hmac: ^1.1.7
     int64-buffer: ^1.0.1
@@ -12597,6 +12604,16 @@ __metadata:
     create-hash: ^1.1.0
     safe-buffer: ^5.1.2
   checksum: 43bdf08a5dd04581b78f040bc4169480e17008da482ffe2a6507327bbc4fc5c28de0501f7faf22901cfe57fbca79cbb202ca529003fedb4cb8dccd265b38e54d
+  languageName: node
+  linkType: hard
+
+"bs58check@npm:^3.0.1":
+  version: 3.0.1
+  resolution: "bs58check@npm:3.0.1"
+  dependencies:
+    "@noble/hashes": ^1.2.0
+    bs58: ^5.0.0
+  checksum: dbbecc7a09f3836e821149266c864c4bbd545539cea43c35f23f4c3c46b54c86c52b65d224b9ea2e916fa6d93bd2ce9fac5b6c6bfcf19621a9c209a5602f71c8
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Description

- Bitcoin signing has to be checked properly, because this library was updated after 5 years and there is no changelog

https://www.npmjs.com/package/bs58check?activeTab=versions
https://github.com/bitcoinjs/bs58check

## Related Issue

[Notion](https://www.notion.so/Dependency-Management-1b5bf845aa1f4ca7b9d57ea9ccd3fe63?p=f8968e809d634c0baa818470bcae824b&pm=s)

## Screenshots:
