### PR TITLE
fix(suite-native): camera permissions

### DIFF
--- a/suite-native/app/ios/TrezorSuite/Info.plist
+++ b/suite-native/app/ios/TrezorSuite/Info.plist
@@ -38,7 +38,7 @@
 		</dict>
 	</dict>
 	<key>NSCameraUsageDescription</key>
-	<string>$(PRODUCT_NAME) needs access to your Camera.</string>
+	<string>$(PRODUCT_NAME) needs access to your Camera to scan your XPUB.</string>
 	<key>NSLocationWhenInUseUsageDescription</key>
 	<string></string>
 	<key>UIAppFonts</key>


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Mobile app rejected in app store:
```

We noticed that your app requests the user’s consent to access the camera, but doesn’t sufficiently explain the use of the camera in the purpose string.

To help users make informed decisions about how their data is used, permission request alerts need to explain and include an example of how your app will use the requested information.
```

This should solve the issue.

## Related Issue

Resolve <!--- link the issue here -->

## Screenshots:
