### PR TITLE
fix(nx): always build all libs for validation to prevent false positives

### DIFF
--- a/package.json
+++ b/package.json
@@ -61,7 +61,7 @@
         "refs": "yarn update-project-references",
         "types": "yarn type-check",
         "messages": "yarn msg-system-sign-config",
-        "validate": "yarn verify-project-references && yarn nx:lint:js && yarn nx:lint:styles && yarn nx:build:libs && yarn nx:type-check && yarn nx:test-unit && yarn check-workspace-resolutions"
+        "validate": "yarn verify-project-references && yarn nx:lint:js && yarn nx:lint:styles && yarn build:libs && yarn nx:type-check && yarn nx:test-unit && yarn check-workspace-resolutions"
     },
     "lint-staged": {
         "packages/**/*.{ts,tsx}": [


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Always build all for validation instead of just affected to prevent false positives like https://github.com/trezor/trezor-suite/actions/runs/4605566208/jobs/8137761741?pr=7980#step:15:174

@Nodonisko do you have any better idea how to solve it, please? I don't understand why type check of suite-desktop is failing on missing file not referenced from suite-desktop package 🤔 