### PR TITLE
Fix/suite desktop localbackend

### DIFF
--- a/packages/request-manager/src/types.ts
+++ b/packages/request-manager/src/types.ts
@@ -38,6 +38,7 @@ export type InterceptorOptions = {
     handler: (event: InterceptedEvent) => void;
     getIsTorEnabled: () => boolean;
     isDevEnv?: boolean;
+    whitelistedHosts?: string[];
 };
 
 export const TOR_CONTROLLER_STATUS = {

--- a/packages/suite-desktop/src/modules/request-interceptor.ts
+++ b/packages/suite-desktop/src/modules/request-interceptor.ts
@@ -36,6 +36,7 @@ export const init: Module = ({ mainWindow, store }) => {
         },
         getIsTorEnabled: () => store.getTorSettings().running,
         isDevEnv,
+        whitelistedHosts: ['127.0.0.1', 'localhost', '.sldev.cz'],
     };
 
     createInterceptor(options);

--- a/packages/suite/src/services/coinjoin/config.ts
+++ b/packages/suite/src/services/coinjoin/config.ts
@@ -97,26 +97,13 @@ export const COINJOIN_NETWORKS: PartialRecord<NetworkSymbol, ServerEnvironment> 
         },
     },
     regtest: {
-        public: {
-            network: 'regtest',
-            coordinatorName: 'CoinJoinCoordinatorIdentifier',
-            coordinatorUrl: 'https://dev-coinjoin.trezor.io/backend/wabisabi/',
-            // backend settings
-            wabisabiBackendUrl: 'https://dev-coinjoin.trezor.io/backend/',
-            blockbookUrls: ['https://dev-coinjoin.trezor.io/blockbook'],
-            baseBlockHeight: 0,
-            baseBlockHash: '0f9188f13cb7b2c71f2a335e3a4fc328bf5beb436012afca590b1a11466e2206',
-            filtersBatchSize: 5000,
-            // client settings
-            middlewareUrl: 'https://dev-coinjoin.trezor.io/client/',
-        },
         localhost: {
             network: 'regtest',
             coordinatorName: 'CoinJoinCoordinatorIdentifier',
             coordinatorUrl: 'http://localhost:8081/backend/wabisabi/',
             // backend settings
             wabisabiBackendUrl: 'http://localhost:8081/backend/',
-            blockbookUrls: ['http://localhost:8081/blockbook'],
+            blockbookUrls: ['http://localhost:19121'],
             baseBlockHeight: 0,
             baseBlockHash: '0f9188f13cb7b2c71f2a335e3a4fc328bf5beb436012afca590b1a11466e2206',
             filtersBatchSize: 5000,

--- a/packages/suite/src/views/settings/debug/CoinjoinApi.tsx
+++ b/packages/suite/src/views/settings/debug/CoinjoinApi.tsx
@@ -38,6 +38,7 @@ const CoordinatorServer = ({ symbol, environments, value, onChange }: Coordinato
             />
             <ActionColumn>
                 <StyledActionSelect
+                    isDisabled={options.length < 2}
                     onChange={({ value }) => onChange(symbol, value)}
                     value={selectedOption}
                     options={options}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

- Fix for not working localhost and *.sldev.cz custom backends in `suite-desktop` when TOR is enabled
  Added configurable `whitelistedHosts` option to request interceptor
  Allow untrusted certificates for whitelisted domains (sldev)
  
- removed unused CJ environment (regtest public)
