### PR TITLE
chore(connect): switch to node env in jest

### DIFF
--- a/packages/connect/jest.config.js
+++ b/packages/connect/jest.config.js
@@ -2,8 +2,7 @@ const { testPathIgnorePatterns } = require('../../jest.config.base');
 
 module.exports = {
     preset: '../../jest.config.base.js',
-    // TODO: https://github.com/trezor/trezor-suite/issues/5319
-    testEnvironment: 'jsdom',
+    testEnvironment: 'node',
     collectCoverage: true,
     setupFiles: ['<rootDir>/setupJest.ts'],
     testPathIgnorePatterns: [...testPathIgnorePatterns, 'e2e'],

--- a/packages/connect/src/data/__tests__/connectSettings.test.ts
+++ b/packages/connect/src/data/__tests__/connectSettings.test.ts
@@ -1,16 +1,6 @@
-import { corsValidator, parseConnectSettings } from '../connectSettings';
-
-declare let window: any; // window.location types doesn't allow deleting/overriding location
+import { corsValidator } from '../connectSettings';
 
 describe('data/connectSettings', () => {
-    const { location } = window;
-    beforeAll(() => {
-        delete window.location;
-    });
-    afterAll(() => {
-        window.location = location; // restore default
-    });
-
     it('corsValidator', () => {
         expect(corsValidator('https://connect.trezor.io/9-beta/')).toBeDefined();
         expect(corsValidator('https://az-AZ_123.trezor.io/')).toBeDefined();


### PR DESCRIPTION
after couple of PRs from recent days, we are finally able to move away from jsdom env in unit tests in connect

resolve #5319