### PR TITLE
fix(suite-desktop): use hardcoded app id in notarize

### DIFF
--- a/packages/suite-desktop/scripts/notarize.ts
+++ b/packages/suite-desktop/scripts/notarize.ts
@@ -3,8 +3,6 @@
 
 const { notarize } = require('@electron/notarize');
 
-const pkg = require('../package.json');
-
 // @ts-expect-error cannot import AfterPackContext as type using require
 exports.default = context => {
     const { electronPlatformName, appOutDir } = context;
@@ -23,7 +21,7 @@ exports.default = context => {
     console.log(`notarizing ${appPath} ...`);
 
     return notarize({
-        appBundleId: pkg.build.appId,
+        appBundleId: 'io.trezor.TrezorSuite',
         appPath,
         appleId: process.env.APPLEID,
         appleIdPassword: process.env.APPLEIDPASS,


### PR DESCRIPTION


<!--- Provide a general summary of your changes in the Title above -->

## Description

App id has been moved from package json to electron builder config. It's ok to have this hardcoded, we really don't want to notarize anything else.


Will fix codesign pipeline for mac: https://gitlab.com/satoshilabs/trezor/trezor-suite/-/jobs/4058699153