### PR TITLE
fix(suite): fix number input not reflecting form changes properly

### DIFF
--- a/packages/components/src/components/form/SelectBar/index.tsx
+++ b/packages/components/src/components/form/SelectBar/index.tsx
@@ -40,10 +40,10 @@ const Options = styled.div<{ isInLine: boolean }>`
     }
 `;
 
-const Option = styled.div<{ isSelected: boolean; isInLine: boolean }>`
+const Option = styled.div<{ isSelected: boolean }>`
     display: flex;
     flex: 1;
-    justify-content: ${({ isInLine }) => !isInLine && 'center'};
+    justify-content: center;
     align-items: center;
     margin: 4px 0;
     padding: 0 14px;
@@ -140,7 +140,6 @@ export const SelectBar: <V extends ValueTypes>(props: SelectBarProps<V>) => JSX.
                                 ? selectedOptionIn === option.value
                                 : false
                         }
-                        isInLine={isInLine}
                         data-test={`select-bar/${String(option.value)}`}
                     >
                         {option.label}

--- a/packages/suite/src/components/suite/NumberInput.tsx
+++ b/packages/suite/src/components/suite/NumberInput.tsx
@@ -29,10 +29,14 @@ const getLocaleSeparatorCharCodes = (locale: Locale) => ({
 const cleanValueString = (value: string, locale: Locale) => {
     const { decimalSeparator, thousandsSeparator } = getLocaleSeparators(locale);
 
-    const cleanedValue = value
+    let cleanedValue = value
         .replace(/\s/g, '')
         .replaceAll(thousandsSeparator, '')
         .replaceAll(decimalSeparator, '.');
+
+    if (cleanedValue.startsWith('.')) {
+        cleanedValue = `0${cleanedValue}`;
+    }
 
     return cleanedValue;
 };

--- a/packages/suite/src/components/suite/NumberInput.tsx
+++ b/packages/suite/src/components/suite/NumberInput.tsx
@@ -175,7 +175,7 @@ export const NumberInput = ({
 
             const { groupSeparatorCharCode } = getLocaleSeparatorCharCodes(locale);
             const previousDisplayValue = previousDisplayValueRef.current;
-            // CMD+D on Mac
+            // Ctrl+D on Mac
             const isDeleteKeyUsed =
                 pressedKey === 'Delete' || pressedKey.toLocaleLowerCase() === 'd';
             // handle deleting a thousands separator with a DEL key,
@@ -296,7 +296,9 @@ export const NumberInput = ({
             }
 
             const resultString = value.substring(0, selectionStart) + value.substring(selectionEnd);
-            handleChange(resultString);
+            // needed for cursor repositioning logic in handleChange() to function
+            inputRef.current.value = resultString;
+            inputRef.current.selectionStart = selectionStart;
             handleChange(resultString);
         },
         [handleCopy, handleChange, inputRef],
@@ -374,7 +376,6 @@ export const NumberInput = ({
         (e: React.KeyboardEvent<HTMLInputElement>) => {
             const pressedKey = e.key;
             setPressedKey(pressedKey);
-            console.log(pressedKey);
 
             if (['ArrowLeft', 'ArrowRight'].includes(pressedKey)) {
                 handleKeyNav(e);

--- a/packages/suite/src/components/suite/NumberInput.tsx
+++ b/packages/suite/src/components/suite/NumberInput.tsx
@@ -70,6 +70,7 @@ export const NumberInput = ({
     ...props
 }: NumberInputProps) => {
     const locale = useSelector(state => state.suite.settings.language);
+    const [pressedKey, setPressedKey] = useState('');
 
     const {
         field: { value, onChange, ref: inputRef, ...controlProps },
@@ -168,6 +169,27 @@ export const NumberInput = ({
                 return;
             }
 
+            // read cursor position before formatting
+            let { selectionStart: cursorPosition } = inputRef.current;
+            if (cursorPosition === null) return;
+
+            const { groupSeparatorCharCode } = getLocaleSeparatorCharCodes(locale);
+            const previousDisplayValue = previousDisplayValueRef.current;
+            // CMD+D on Mac
+            const isDeleteKeyUsed =
+                pressedKey === 'Delete' || pressedKey.toLocaleLowerCase() === 'd';
+            // handle deleting a thousands separator with a DEL key,
+            // otherwise the number instantly gets formatted back to having that separator
+            if (inputValue.length < previousDisplayValue.length && isDeleteKeyUsed) {
+                const deletedCharacterCode = previousDisplayValue.charCodeAt(cursorPosition);
+                // is not needed for numbers without group separators (≤3 chars)
+                if (deletedCharacterCode === groupSeparatorCharCode && inputValue.length > 3) {
+                    inputValue =
+                        previousDisplayValue.substring(0, cursorPosition) +
+                        previousDisplayValue.substring(cursorPosition + 2);
+                }
+            }
+
             // make the string compliant with Number
             const cleanInput = cleanValueString(inputValue, locale);
 
@@ -177,25 +199,6 @@ export const NumberInput = ({
                 Number.isNaN(Number(cleanInput))
             ) {
                 return;
-            }
-
-            // read cursor position before formatting
-            let { selectionStart } = inputRef.current;
-            if (selectionStart === null) return;
-
-            const { groupSeparatorCharCode } = getLocaleSeparatorCharCodes(locale);
-            const previousDisplayValue = previousDisplayValueRef.current;
-
-            // handle deleting a thousands separator with a DEL key (should not be possible with a Backspace),
-            // otherwise the number instantly gets formatted back to having that separator
-            if (inputValue.length < previousDisplayValue.length) {
-                const deletedCharacterCode = previousDisplayValue.charCodeAt(selectionStart);
-                // is not needed for nimbers without gropu separators (≤3 chars)
-                if (deletedCharacterCode === groupSeparatorCharCode && inputValue.length > 3) {
-                    inputValue =
-                        previousDisplayValue.substring(0, selectionStart) +
-                        previousDisplayValue.substring(selectionStart + 2);
-                }
             }
 
             // format and set display value
@@ -228,19 +231,34 @@ export const NumberInput = ({
             const lengthDelta = formattedValueLength - currentValueLength;
             if (
                 lengthDelta > 0 &&
-                selectionStart !== 1 &&
-                formattedValue.charCodeAt(selectionStart) !== groupSeparatorCharCode
+                cursorPosition !== 1 &&
+                formattedValue.charCodeAt(cursorPosition) !== groupSeparatorCharCode
             ) {
-                selectionStart += lengthDelta;
+                cursorPosition += lengthDelta;
                 // do not move the cursor if it was at the beginning already
-            } else if (lengthDelta < 0 && selectionStart !== 0) {
-                selectionStart += lengthDelta;
+            } else if (lengthDelta < 0 && cursorPosition !== 0 && !isDeleteKeyUsed) {
+                cursorPosition += lengthDelta;
+                // handle some undesirable cases when deleting with delete key
+            } else if (
+                formattedValue.charCodeAt(cursorPosition - 1) === groupSeparatorCharCode &&
+                isDeleteKeyUsed
+            ) {
+                cursorPosition += 1;
             }
 
             // make sure the cursor stays in the right place after formatting
-            inputRef.current.setSelectionRange(selectionStart, selectionStart);
+            inputRef.current.setSelectionRange(cursorPosition, cursorPosition);
         },
-        [formatDisplayValue, locale, onChange, onChangeCallback, inputRef, invalid, rules],
+        [
+            formatDisplayValue,
+            locale,
+            onChange,
+            onChangeCallback,
+            inputRef,
+            invalid,
+            rules,
+            pressedKey,
+        ],
     );
 
     // copy the non-formatted value
@@ -251,7 +269,7 @@ export const NumberInput = ({
             }
 
             const { selectionStart, selectionEnd, value } = inputRef.current;
-            if (selectionStart === null || selectionEnd == null) {
+            if (selectionStart === null || selectionEnd === null) {
                 return;
             }
 
@@ -273,11 +291,12 @@ export const NumberInput = ({
             }
 
             const { selectionStart, selectionEnd, value } = inputRef.current;
-            if (selectionStart === null || selectionEnd == null) {
+            if (selectionStart === null || selectionEnd === null) {
                 return;
             }
 
             const resultString = value.substring(0, selectionStart) + value.substring(selectionEnd);
+            handleChange(resultString);
             handleChange(resultString);
         },
         [handleCopy, handleChange, inputRef],
@@ -319,9 +338,26 @@ export const NumberInput = ({
     );
 
     // do not allow putting the cursor after group separators
-    const handleClick = useCallback(() => {
-        handleCursorShift(-1, -1);
-    }, [handleCursorShift]);
+    const handleSelect = useCallback(() => {
+        if (!inputRef.current) {
+            return;
+        }
+
+        const { selectionStart, selectionEnd, value } = inputRef.current;
+        if (selectionStart === selectionEnd) {
+            handleCursorShift(-1, -1);
+        }
+
+        if (selectionStart === null || selectionEnd === null) {
+            return;
+        }
+        const selectedPart = value.substring(selectionStart, selectionEnd);
+        const { groupSeparatorCharCode } = getLocaleSeparatorCharCodes(locale);
+        // do not allow selecting group separators to avoid unwanted behavior
+        if (selectedPart.length === 1 && selectedPart.charCodeAt(0) === groupSeparatorCharCode) {
+            inputRef.current.selectionEnd = selectionStart;
+        }
+    }, [handleCursorShift, inputRef, locale]);
 
     // jump over group separators when navigatind the input
     const handleKeyNav = useCallback(
@@ -337,6 +373,8 @@ export const NumberInput = ({
     const handleKeyDown = useCallback(
         (e: React.KeyboardEvent<HTMLInputElement>) => {
             const pressedKey = e.key;
+            setPressedKey(pressedKey);
+            console.log(pressedKey);
 
             if (['ArrowLeft', 'ArrowRight'].includes(pressedKey)) {
                 handleKeyNav(e);
@@ -359,7 +397,7 @@ export const NumberInput = ({
             innerRef={inputRef}
             value={displayValue}
             inputMode="decimal"
-            onSelect={handleClick}
+            onSelect={handleSelect}
             onKeyDown={handleKeyDown}
             onBeforeInput={handleOnBeforeInput}
             onChange={e => handleChange(e.target.value)}

--- a/packages/suite/src/components/wallet/Fees/components/CustomFee.tsx
+++ b/packages/suite/src/components/wallet/Fees/components/CustomFee.tsx
@@ -30,6 +30,8 @@ const Col = styled.div<{ singleCol?: boolean }>`
     ${({ singleCol }) =>
         singleCol &&
         css`
+            max-width: 300px;
+
             ${variables.SCREEN_QUERY.BELOW_LAPTOP} {
                 max-width: 100%;
             }

--- a/packages/suite/src/components/wallet/Fees/index.tsx
+++ b/packages/suite/src/components/wallet/Fees/index.tsx
@@ -33,6 +33,14 @@ const SelectBarWrapper = styled.div<{ desktop?: boolean }>`
     display: flex; /* necessary for the <SelectBar> not to be stretched over full column width */
     margin: ${({ desktop }) => (desktop ? '0px' : '8px 20px 20px 0')};
 
+    ${variables.SCREEN_QUERY.BELOW_LAPTOP} {
+        width: 100%;
+
+        > div {
+            width: 100%;
+        }
+    }
+
     ${variables.SCREEN_QUERY.MOBILE} {
         margin: 8px 0px 20px;
     }

--- a/packages/suite/src/hooks/wallet/useSendFormFields.ts
+++ b/packages/suite/src/hooks/wallet/useSendFormFields.ts
@@ -24,11 +24,19 @@ export const useSendFormFields = ({
     clearErrors,
     fiatRates,
     network,
+    errors,
 }: Props) => {
     const { shouldSendInSats } = useBitcoinAmountUnit(network.symbol);
 
     const calculateFiat = useCallback(
         (outputIndex: number, amount?: string) => {
+            const outputError = errors.outputs ? errors.outputs[outputIndex] : undefined;
+            const error = outputError ? outputError.amount : undefined;
+
+            if (error) {
+                amount = undefined;
+            }
+
             const { outputs } = getValues();
             const output = outputs ? outputs[outputIndex] : undefined;
             if (!output || output.type !== 'payment') return;
@@ -58,7 +66,7 @@ export const useSendFormFields = ({
                 setValue(inputName, fiatValue, { shouldValidate: true });
             }
         },
-        [getValues, setValue, fiatRates, shouldSendInSats, network.symbol],
+        [getValues, setValue, fiatRates, shouldSendInSats, network.symbol, errors],
     );
 
     const setAmount = useCallback(

--- a/packages/suite/src/views/wallet/send/components/Outputs/components/Amount/index.tsx
+++ b/packages/suite/src/views/wallet/send/components/Outputs/components/Amount/index.tsx
@@ -166,10 +166,10 @@ export const Amount = ({ output, outputId }: Props) => {
             }
 
             // calculate or reset Fiat value
-            calculateFiat(outputId, !error ? value : undefined);
+            calculateFiat(outputId, value);
             composeTransaction(inputName);
         },
-        [setValue, calculateFiat, composeTransaction, error, inputName, isSetMaxActive, outputId],
+        [setValue, calculateFiat, composeTransaction, inputName, isSetMaxActive, outputId],
     );
 
     const cryptoAmountRules = useMemo<TypedValidationRules>(


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

* the Fiat field (as well as any other place with a similar pattern of handlers) is properly reacting to the Amount field changes

It's an ugly solution, I was not sure there is another quick one. Basically, inputs hooked onto the `react-hook-form` should ideally not have complex `onChange` logic, and rather use the `watch` method to ensure that the form state is fully updated. If you log the `error` in `handleInputChange` in the current code, you will see that the value there is outdated. Between updating memoized callbacks and form state some time passes and `handleInputChange` is not called with a new `errors` state. Could be avoided by using `watch`. But since I do not know where else this bug occurs I went for a more universal but ugly solution.

If anyone have any ideas – they are definitely welcome!  @matejkriz @Nodonisko @komret 

Related: https://github.com/trezor/trezor-suite/issues/5928
Related: [#7984](https://github.com/trezor/trezor-suite/issues/7984)