### PR TITLE
fix(suite): all coins available in coins section when no fw device

### DIFF
--- a/packages/suite/src/components/suite/CoinsGroup/CoinsList.tsx
+++ b/packages/suite/src/components/suite/CoinsGroup/CoinsList.tsx
@@ -50,7 +50,9 @@ const CoinsList = ({
 
                 const supportField = deviceModel && support?.[deviceModel];
                 const supportedBySuite =
-                    !supportField || versionUtils.isNewerOrEqual(firmwareVersion, supportField);
+                    !firmwareVersion ||
+                    !supportField ||
+                    versionUtils.isNewerOrEqual(firmwareVersion, supportField);
 
                 let unavailable = device?.unavailableCapabilities?.[symbol];
                 if (!supportedBySuite) {


### PR DESCRIPTION
## Description

- `firmwareVersion` was `undefined` so it failed on 
<img width="473" alt="Screenshot 2023-04-05 at 10 52 45" src="https://user-images.githubusercontent.com/33235762/230031731-2d871c55-e8a6-41de-9189-6789ddd20232.png">

## Related Issue

closes #7998

## Screenshots:
![Screenshot 2023-04-05 at 10 51 35](https://user-images.githubusercontent.com/33235762/230031441-6cff609a-6e1f-4c01-9cf8-34a20a3bd518.png)
