### PR TITLE
fix(suite-native): bottom sheet pan gesture close

### DIFF
--- a/suite-native/app/ios/Podfile.lock
+++ b/suite-native/app/ios/Podfile.lock
@@ -496,7 +496,7 @@ PODS:
     - React-perflogger (= 0.71.5)
   - RNGestureHandler (2.9.0):
     - React-Core
-  - RNReanimated (3.0.1):
+  - RNReanimated (3.0.2):
     - DoubleConversion
     - FBLazyVector
     - FBReactNativeSpec
@@ -837,7 +837,7 @@ SPEC CHECKSUMS:
   React-runtimeexecutor: 511f4301d85daf85abface9afb8d2df2d49f87d3
   ReactCommon: 4f43b72066f27bfe1f63838c61763f59e7112536
   RNGestureHandler: 071d7a9ad81e8b83fe7663b303d132406a7d8f39
-  RNReanimated: 01715fef3a1153cb70c1efcff60b7b26580b9a8a
+  RNReanimated: 3e2ae8e5e62b407bbbde98d3a9cec92a75245154
   RNScreens: ea4cd3a853063cda19a4e3c28d2e52180c80f4eb
   RNSentry: ef53abfde32e4cddbf09d00b5c71907bd5177158
   RNSVG: c1e76b81c76cdcd34b4e1188852892dc280eb902

--- a/suite-native/atoms/src/Sheet/BottomSheet.tsx
+++ b/suite-native/atoms/src/Sheet/BottomSheet.tsx
@@ -77,39 +77,39 @@ export const BottomSheet = ({
             <Animated.View
                 style={[animatedSheetWithOverlayStyle, applyStyle(sheetWithOverlayStyle)]}
             >
-                <Animated.View
-                    style={[
-                        animatedSheetWrapperStyle,
-                        applyStyle(sheetWrapperStyle, {
-                            insetBottom: insets.bottom,
-                        }),
-                    ]}
+                <PanGestureHandler
+                    enabled={isCloseScrollEnabled}
+                    ref={panGestureRef.current}
+                    activeOffsetY={5}
+                    failOffsetY={-5}
+                    onGestureEvent={panGestureEvent}
                 >
-                    <BottomSheetHeader
-                        title={title}
-                        subtitle={subtitle}
-                        onCloseSheet={closeSheetAnimated}
-                    />
-                    <ScrollView
-                        ref={scrollViewRef.current}
-                        waitFor={
-                            isCloseScrollEnabled ? panGestureRef.current : scrollViewRef.current
-                        }
-                        onScroll={scrollEvent}
+                    <Animated.View
+                        style={[
+                            animatedSheetWrapperStyle,
+                            applyStyle(sheetWrapperStyle, {
+                                insetBottom: insets.bottom,
+                            }),
+                        ]}
                     >
-                        <PanGestureHandler
-                            enabled={isCloseScrollEnabled}
-                            ref={panGestureRef.current}
-                            activeOffsetY={5}
-                            failOffsetY={-5}
-                            onGestureEvent={panGestureEvent}
+                        <BottomSheetHeader
+                            title={title}
+                            subtitle={subtitle}
+                            onCloseSheet={closeSheetAnimated}
+                        />
+                        <ScrollView
+                            ref={scrollViewRef.current}
+                            waitFor={
+                                isCloseScrollEnabled ? panGestureRef.current : scrollViewRef.current
+                            }
+                            onScroll={scrollEvent}
                         >
                             <Animated.View>
                                 <Box paddingHorizontal="medium">{children}</Box>
                             </Animated.View>
-                        </PanGestureHandler>
-                    </ScrollView>
-                </Animated.View>
+                        </ScrollView>
+                    </Animated.View>
+                </PanGestureHandler>
             </Animated.View>
         </BottomSheetContainer>
     );

--- a/suite-native/atoms/src/Sheet/useBottomSheetAnimation.ts
+++ b/suite-native/atoms/src/Sheet/useBottomSheetAnimation.ts
@@ -66,29 +66,29 @@ export const useBottomSheetAnimation = ({
         ],
     }));
 
-    const closeSheetAnimated = useCallback(() => {
-        'worklet';
-
-        return new Promise((resolve, _) => {
-            translatePanY.value = withTiming(SCREEN_HEIGHT, {
-                duration: ANIMATION_DURATION,
-                easing: Easing.out(Easing.cubic),
-            });
-            animatedTransparency.value = withTiming(
-                0,
-                {
+    const closeSheetAnimated = useCallback(
+        () =>
+            new Promise((resolve, _) => {
+                translatePanY.value = withTiming(SCREEN_HEIGHT, {
                     duration: ANIMATION_DURATION,
                     easing: Easing.out(Easing.cubic),
-                },
-                () => {
-                    if (onClose) runOnJS(onClose)(false);
-                    if (setIsCloseScrollEnabled) runOnJS(setIsCloseScrollEnabled)(true);
-                },
-            );
+                });
+                animatedTransparency.value = withTiming(
+                    0,
+                    {
+                        duration: ANIMATION_DURATION,
+                        easing: Easing.out(Easing.cubic),
+                    },
+                    () => {
+                        if (onClose) runOnJS(onClose)(false);
+                        if (setIsCloseScrollEnabled) runOnJS(setIsCloseScrollEnabled)(true);
+                    },
+                );
 
-            setTimeout(resolve, ANIMATION_DURATION);
-        });
-    }, [translatePanY, animatedTransparency, onClose, setIsCloseScrollEnabled]);
+                setTimeout(resolve, ANIMATION_DURATION);
+            }),
+        [translatePanY, animatedTransparency, onClose, setIsCloseScrollEnabled],
+    );
 
     const openSheetAnimated = useCallback(() => {
         'worklet';
@@ -124,7 +124,7 @@ export const useBottomSheetAnimation = ({
         onEnd: event => {
             const { translationY, velocityY } = event;
             if (translationY > 50 && velocityY > 2) {
-                closeSheetAnimated();
+                runOnJS(closeSheetAnimated)();
             } else {
                 openSheetAnimated();
             }


### PR DESCRIPTION
## Description

### <samp>🤖 Generated by Copilot at b041ce8</samp>

The pull request improves the bottom sheet component in the native app by fixing a bug with the swipe gesture. It changes the `PanGestureHandler` position in `BottomSheet.tsx` to make BottomSheetHeader also a part of gesture handler.

## Related Issue

Resolve #7958.

## Screenshots:
