### PR TITLE
feat(suite-native): copy to clipboard toast displayed on android

### DIFF
--- a/suite-native/helpers/src/hooks/useCopyToClipboard.ts
+++ b/suite-native/helpers/src/hooks/useCopyToClipboard.ts
@@ -1,5 +1,4 @@
 import { useCallback } from 'react';
-import { Platform } from 'react-native';
 
 import * as Clipboard from 'expo-clipboard';
 
@@ -12,14 +11,11 @@ export function useCopyToClipboard() {
         async (value: string, toastMessage?: string) => {
             await Clipboard.setStringAsync(value);
 
-            if (Platform.OS === 'ios') {
-                // Android is showing it's own copy-to-clipboard toast message
-                showToast({
-                    variant: 'default',
-                    message: toastMessage ?? 'Copied to clipboard.',
-                    icon: 'copy',
-                });
-            }
+            showToast({
+                variant: 'default',
+                message: toastMessage ?? 'Copied to clipboard.',
+                icon: 'copy',
+            });
         },
         [showToast],
     );


### PR DESCRIPTION
## Description

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at fc1db1e</samp>

Removed platform check for showing toast message on clipboard copy. Copy toast message displayed on the both platforms.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at fc1db1e</samp>

> _`platform` check gone_
> _toast message for all devices_
> _winter of feedback_

