### PR TITLE
fix(suite-native): camera access alert hiden on undetermined status

### DIFF
--- a/suite-native/qr-code/src/components/CameraPermissionError.tsx
+++ b/suite-native/qr-code/src/components/CameraPermissionError.tsx
@@ -1,12 +1,9 @@
 import React from 'react';
 
-import { PermissionStatus } from 'expo-barcode-scanner';
-
 import { Box, Button, Text } from '@suite-native/atoms';
 import { prepareNativeStyle, useNativeStyles } from '@trezor/styles';
 
 type CameraPermissionErrorProps = {
-    permissionStatus: PermissionStatus;
     onPermissionRequest: () => void;
 };
 
@@ -18,21 +15,13 @@ const grantPermissionButtonStyle = prepareNativeStyle(({ spacings }) => ({
     marginTop: spacings.large,
 }));
 
-export const CameraPermissionError = ({
-    permissionStatus,
-    onPermissionRequest,
-}: CameraPermissionErrorProps) => {
+export const CameraPermissionError = ({ onPermissionRequest }: CameraPermissionErrorProps) => {
     const { applyStyle } = useNativeStyles();
 
     return (
         <Box style={applyStyle(permissionTextContainerStyle)}>
-            <Text align="center">Camera access denied. {permissionStatus}</Text>
-            {permissionStatus === PermissionStatus.DENIED && (
-                <Text align="center">Please allow camera access in your device settings.</Text>
-            )}
-            {permissionStatus === PermissionStatus.UNDETERMINED && (
-                <Text align="center">Please allow camera access to your camera. </Text>
-            )}
+            <Text align="center">Camera access denied.</Text>
+            <Text align="center">Please allow camera access in your device settings.</Text>
 
             <Button onPress={onPermissionRequest} style={applyStyle(grantPermissionButtonStyle)}>
                 Grant permission

--- a/suite-native/qr-code/src/components/QRCodeScanner.tsx
+++ b/suite-native/qr-code/src/components/QRCodeScanner.tsx
@@ -51,21 +51,23 @@ export const QRCodeScanner = ({ onCodeScanned }: QRCodeScannerProps) => {
         );
     }
 
-    if (cameraPermissionStatus === PermissionStatus.GRANTED) {
-        return (
-            <BarCodeScanner
-                onBarCodeScanned={scanned ? undefined : handleBarCodeScanned}
-                barCodeTypes={barCodeTypes}
-                style={applyStyle(cameraStyle)}
-                type="back"
-            />
-        );
-    }
+    switch (cameraPermissionStatus) {
+        // If the status is "UNDETERMINED" the expo-barcode-scanner library shows a native permission dialog itself.
+        case PermissionStatus.UNDETERMINED:
+            return null;
 
-    return (
-        <CameraPermissionError
-            onPermissionRequest={requestCameraPermission}
-            permissionStatus={cameraPermissionStatus}
-        />
-    );
+        case PermissionStatus.GRANTED:
+            return (
+                <BarCodeScanner
+                    onBarCodeScanned={scanned ? undefined : handleBarCodeScanned}
+                    barCodeTypes={barCodeTypes}
+                    style={applyStyle(cameraStyle)}
+                    type="back"
+                />
+            );
+
+        case PermissionStatus.DENIED:
+        default:
+            return <CameraPermissionError onPermissionRequest={requestCameraPermission} />;
+    }
 };


### PR DESCRIPTION
## Description

Refactored the QR code scanner components to hide its content on the "UNDETERMINED" status of camera permission. On Undetermined status is a native dialogue displayed by `expo-barcode-scanner` library. 
