### PR TITLE
Fix/codesign runtime

### DIFF
--- a/packages/suite-desktop/electron-builder-config.js
+++ b/packages/suite-desktop/electron-builder-config.js
@@ -15,7 +15,6 @@ module.exports = {
     productName: 'Trezor Suite',
     copyright: 'Copyright © ${author}',
     asar: true,
-    electronVersion: '23.1.1',
     directories: {
         output: 'build-electron',
     },

--- a/packages/suite-desktop/scripts/build.ts
+++ b/packages/suite-desktop/scripts/build.ts
@@ -97,6 +97,7 @@ build({
         'process.env.VERSION': JSON.stringify(suiteVersion),
         'process.env.SENTRY_RELEASE': JSON.stringify(sentryRelease),
         'process.env.SUITE_TYPE': JSON.stringify(PROJECT),
+        'process.env.IS_CODESIGN_BUILD': JSON.stringify(IS_CODESIGN_BUILD),
     },
     inject: [path.join(__dirname, 'build-inject.ts')],
     plugins: useMocks ? [mockPlugin] : [],


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

- Do not define `electronVersion` we are packaging for explicitly to prevent unnecessary conflicts on electron update.
See https://www.electron.build/configuration/configuration.html#Configuration-electronVersion We forgot to update that number during last electron update...

-  always decide codesign env in buildtime not runtime, It is used from https://github.com/trezor/trezor-suite/blob/eaec217b313692c6cc289009ab0e5f7007396f0d/suite-common/suite-utils/src/build.ts#L3 in runtime to decide app title. 

## Related Issue

Resolve https://github.com/trezor/trezor-suite/issues/8019

## Screenshots:
Title for codesign build:
<img width="159" alt="image" src="https://user-images.githubusercontent.com/3729633/230136802-9011f950-04b8-4ba5-8438-fd53e761eb4d.png">


