### PR TITLE
feat: coinjoin account birthdate discovery optimisation

### DIFF
--- a/packages/coinjoin/src/backend/CoinjoinBackendClient.ts
+++ b/packages/coinjoin/src/backend/CoinjoinBackendClient.ts
@@ -47,8 +47,27 @@ export class CoinjoinBackendClient {
         return this.fetchFromBlockbook({ identity, ...options }, 'getBlock', height);
     }
 
+    fetchBlockHash(height: number, options?: RequestOptions): Promise<string> {
+        return this.fetchFromBlockbook({ ...options }, 'getBlockHash', height).then(
+            ({ hash }) => hash,
+        );
+    }
+
     fetchTransaction(txid: string, options?: RequestOptions): Promise<BlockbookTransaction> {
         return this.fetchFromBlockbook(options, 'getTransaction', txid);
+    }
+
+    fetchNetworkInfo(options?: RequestOptions) {
+        return this.fetchFromBlockbook(options, 'getServerInfo');
+    }
+
+    fetchAddress(address: string, page?: number, pageSize = 10, options?: RequestOptions) {
+        return this.fetchFromBlockbook(options, 'getAccountInfo', {
+            descriptor: address,
+            details: 'txs',
+            pageSize,
+            page,
+        });
     }
 
     private reconnect = async () => {

--- a/packages/coinjoin/src/backend/CoinjoinWebsocketController.ts
+++ b/packages/coinjoin/src/backend/CoinjoinWebsocketController.ts
@@ -2,7 +2,10 @@ import { BlockbookAPI } from '@trezor/blockchain-link/lib/workers/blockbook/webs
 
 import type { Logger } from '../types';
 
-export type BlockbookWS = Pick<BlockbookAPI, 'getBlock' | 'getTransaction'>;
+export type BlockbookWS = Pick<
+    BlockbookAPI,
+    'getBlock' | 'getTransaction' | 'getAccountInfo' | 'getServerInfo' | 'getBlockHash'
+>;
 
 type SocketId = `${string}@${string}`;
 

--- a/packages/coinjoin/src/types/backend.ts
+++ b/packages/coinjoin/src/types/backend.ts
@@ -23,6 +23,7 @@ export type BlockbookBlock = {
     totalPages: number;
     height: number;
     txs: BlockbookTransaction[];
+    hash: string;
 };
 
 export type BlockFilter = {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->
This changes the checkpoint for coinjoin account discovery. Till now it was using a hard-coded block height. This PR makes that checkpoint dynamic based on when first transaction was received in the account.

* Assumes the first address in coinjoin is used, we should update the way suite behave so it enforces use of the first address in coinjoin account before revealing the next one.

## Related Issue

Resolve https://github.com/trezor/trezor-suite/issues/7633

