### PR TITLE
fix(connect): cancel timers, error handling

### DIFF
--- a/packages/connect/src/api/composeTransaction.ts
+++ b/packages/connect/src/api/composeTransaction.ts
@@ -274,7 +274,7 @@ export default class ComposeTransaction extends AbstractMethod<'composeTransacti
         discovery.stop();
 
         if (!discovery.completed) {
-            await resolveAfter(501); // temporary solution, TODO: immediately resolve will cause "device call in progress"
+            await resolveAfter(501).promise; // temporary solution, TODO: immediately resolve will cause "device call in progress"
         }
 
         const account = discovery.accounts[uiResp.payload];
@@ -306,7 +306,7 @@ export default class ComposeTransaction extends AbstractMethod<'composeTransacti
             // show error view
             this.postMessage(createUiMessage(UI.INSUFFICIENT_FUNDS));
             // wait few seconds...
-            await resolveAfter(2000, null);
+            await resolveAfter(2000, null).promise;
             // and go back to discovery
             return 'change-account';
         }

--- a/packages/connect/src/api/getAccountInfo.ts
+++ b/packages/connect/src/api/getAccountInfo.ts
@@ -383,7 +383,7 @@ export default class GetAccountInfo extends AbstractMethod<'getAccountInfo', Req
         const account = discovery.accounts[uiResp.payload];
 
         if (!discovery.completed) {
-            await resolveAfter(501); // temporary solution, TODO: immediately resolve will cause "device call in progress"
+            await resolveAfter(501).promise; // temporary solution, TODO: immediately resolve will cause "device call in progress"
         }
 
         // get account info from backend

--- a/packages/connect/src/device/DescriptorStream.ts
+++ b/packages/connect/src/device/DescriptorStream.ts
@@ -137,7 +137,7 @@ export class DescriptorStream extends EventEmitter {
             logger.debug('Listen error', 'timestamp', time, typeof error);
 
             if (time > 1100) {
-                await resolveAfter(1000, null);
+                await resolveAfter(1000, null).promise;
                 if (this.listening) this.listen();
             } else {
                 logger.warn('Transport error');

--- a/packages/connect/src/device/Device.ts
+++ b/packages/connect/src/device/Device.ts
@@ -329,7 +329,6 @@ export class Device extends EventEmitter {
             await this.getFeatures();
         }
 
-        // await resolveAfter(2000, null);
         if (
             (!this.keepSession && typeof options.keepSession !== 'boolean') ||
             options.keepSession === false

--- a/packages/connect/src/device/DeviceList.ts
+++ b/packages/connect/src/device/DeviceList.ts
@@ -405,7 +405,7 @@ class CreateDeviceHandler {
                 // most common error - someone else took the device at the same time
                 this._handleUsedElsewhere();
             } else {
-                await resolveAfter(501, null);
+                await resolveAfter(501, null).promise;
                 await this.handle();
             }
         }
@@ -499,7 +499,7 @@ class DiffHandler {
             const penalty = this.list.getAuthPenalty();
             _log.debug('Connected', priority, penalty, descriptor.session, this.list.devices);
             if (priority || penalty) {
-                await resolveAfter(501 + penalty + 100 * priority, null);
+                await resolveAfter(501 + penalty + 100 * priority, null).promise;
             }
             if (descriptor.session == null) {
                 await this.list._createAndSaveDevice(descriptor);
@@ -528,7 +528,7 @@ class DiffHandler {
             if (device) {
                 if (device.isUnacquired() && !device.isInconsistent()) {
                     // wait for publish changes
-                    await resolveAfter(501, null);
+                    await resolveAfter(501, null).promise;
                     _log.debug('Create device from unacquired', device);
                     await this.list._createAndSaveDevice(descriptor);
                 }

--- a/packages/connect/src/device/DeviceList.ts
+++ b/packages/connect/src/device/DeviceList.ts
@@ -381,7 +381,7 @@ class CreateDeviceHandler {
         } catch (error) {
             _log.debug('Cannot create device', error);
 
-            if (error.code === 'Device_NotFound') {
+            if (error.code === 'Device_NotFound' || error.message === 'device not found') {
                 // do nothing
                 // it's a race condition between "device_changed" and "device_disconnected"
             } else if (
@@ -390,7 +390,7 @@ class CreateDeviceHandler {
             ) {
                 this.list.enumerate();
                 this._handleUsedElsewhere();
-            } else if (error.message.indexOf(ERRORS.LIBUSB_ERROR_MESSAGE) >= 0) {
+            } else if (error.message?.indexOf(ERRORS.LIBUSB_ERROR_MESSAGE) >= 0) {
                 // catch one of trezord LIBUSB_ERRORs
                 const device = this.list._createUnreadableDevice(
                     this.list.creatingDevicesDescriptors[this.path],

--- a/packages/connect/src/utils/promiseUtils.ts
+++ b/packages/connect/src/utils/promiseUtils.ts
@@ -1,6 +1,9 @@
 // origin: https://github.com/trezor/connect/blob/develop/src/js/utils/promiseUtils.js
 
-export const resolveAfter = (msec: number, value?: any) =>
-    new Promise<any>(resolve => {
-        setTimeout(resolve, msec, value);
+export const resolveAfter = (msec: number, value?: any) => {
+    let timeout: ReturnType<typeof setTimeout> | undefined;
+    const promise = new Promise<any>(resolve => {
+        timeout = setTimeout(resolve, msec, value);
     });
+    return { promise, timeout };
+};


### PR DESCRIPTION
## Description

Couple of small connect related fixes

[fix(connect): cancel timout between deviceList init on TrezorConnect.…](https://github.com/trezor/trezor-suite/commit/0434d4b9f6aab37866fab7cf3bc208cd2c2ce20a). This timer was not cancelled properly. In node (suite-desktop), it is now possible to initiate multiple unintended deviceList initiation loops, adding one every time app is reloaded which happens because of running timer which blocks event loop from stopping. There are couple of other places where this could in theory happen too, but they are far less probable, so I'd let them to be fixed properly later.
[fix(connect): fix error handling in deviceList create device handler](https://github.com/trezor/trezor-suite/commit/180d35df9ae5e6a13d4db494de88f59a338f01f7) - small fixes in error handling based on sentry reports and observations
