### PR TITLE
Fix `removeEventListener` logic in renderer interface of `ipc-proxy`

### DIFF
--- a/packages/ipc-proxy/CHANGELOG.md
+++ b/packages/ipc-proxy/CHANGELOG.md
@@ -1,0 +1,6 @@
+# 1.0.1
+
+-   most of the proxy logic was moved from preload context (`exposeIpcProxy` entry point) to renderer context (`createIpcProxy` entry point) which allows to compare listener functions by reference (unlike in preload context)
+-   in `window.ipcProxy` there is now exposed only small `IpcProxyApi` object instead of whole proxy factory
+
+# 1.0.0

--- a/packages/ipc-proxy/README.md
+++ b/packages/ipc-proxy/README.md
@@ -16,9 +16,9 @@ When you want to have different implementations of the same interface in electro
 
 Usage examples: @trezor/connect and @trezor/coinjoin in @trezor/suite-desktop
 
-`ipcRenderer.on` listener callback function contains additional param at position 0. (Electron.IpcRendererEvent)
+<strike>`ipcRenderer.on` listener callback function contains additional param at position 0. (Electron.IpcRendererEvent)
 web callback implementations are not expecting this param therefore `real listener function` needs to be wrapped by another function to strip this param.
-both `real` and `wrapped` listeners references are stored in electron preload context and used as accordingly.
+both `real` and `wrapped` listeners references are stored in electron preload context and used as accordingly.</strike> _Not true, since 1.0.1 listeners are stored in renderer context_
 
 using `ipcRenderer.invoke` and `ipcRenderer.on` event listener and may results with race conditions (possible electron bug)
 expected: set-listener > START > progress > progress > progress > RESULT

--- a/packages/ipc-proxy/package.json
+++ b/packages/ipc-proxy/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@trezor/ipc-proxy",
-    "version": "1.0.0",
+    "version": "1.0.1",
     "author": "Trezor <info@trezor.io>",
     "homepage": "https://github.com/trezor/trezor-suite/packages/ipc-proxy",
     "description": "Electron ipc proxy",

--- a/packages/ipc-proxy/src/proxy-generator.ts
+++ b/packages/ipc-proxy/src/proxy-generator.ts
@@ -1,3 +1,5 @@
+import type { IpcProxyApi } from './types';
+
 // partial Electron.IpcRendererEvent
 type IpcCallback = (event: any, ...args: any[]) => void;
 
@@ -12,205 +14,83 @@ interface IpcRenderer {
     invoke: (channel: string, ...args: any[]) => Promise<any>;
 }
 
-interface IpcListener {
-    realEventName: string;
-    realListener: (...args: any[]) => any; // Real listener function
-    ipcEventName: string;
-}
-
-// ipc listeners manager
-// ipcRenderer.on listener callback contains additional param at position 0. (Electron.IpcRendererEvent)
-// suite is not expecting this param therefore "real" listener needs to be wrapped by a function where this param is omitted.
-// both "real" and "wrapped" listeners references are stored and used as callbacks and removed by remove listener process.
-
-const listenersManager = () => {
-    const ipcListeners: IpcListener[] = [];
-
-    const addIpcListener = (
-        realEventName: string,
-        realListener: IpcListener['realListener'],
-        ipcEventName: string,
-    ) => {
-        ipcListeners.push({
-            realEventName,
-            realListener,
-            ipcEventName,
-        });
-    };
-
-    const removeIpcListener = (
-        realEventName: string,
-        realListener?: IpcListener['realListener'],
-    ) => {
-        if (!realListener) {
-            let i = ipcListeners.findIndex(item => item.realEventName === realEventName);
-            while (i >= 0) {
-                ipcListeners.splice(i, 1);
-                i = ipcListeners.findIndex(item => item.realEventName === realEventName);
-            }
-            return;
-        }
-        const listener = ipcListeners.find(
-            item =>
-                item.realEventName === realEventName &&
-                item.realListener.toString() === realListener.toString(),
-        );
-        if (listener) {
-            ipcListeners.splice(ipcListeners.indexOf(listener), 1);
-        }
-    };
-
-    return {
-        ipcListeners,
-        addIpcListener,
-        removeIpcListener,
-    };
-};
-
-export const getIpcMethods = (
-    ipcRenderer: IpcRenderer,
-    channelName: string,
-    constructorParams: any,
-) => {
-    const { ipcListeners, addIpcListener, removeIpcListener } = listenersManager();
-
-    const prefix = `${channelName}/${(Date.now() + Math.random()).toString(36)}`;
-
-    let created = false;
-    const init = async () => {
-        if (created) return true;
-        // Handshake with electron main
-
-        await ipcRenderer.invoke(`${channelName}/create`, [prefix, constructorParams]);
-        created = true;
-    };
-
-    const addListener = (eventName: string, listener: any) => {
-        const ipcEventName = `${prefix}/event-listener/${eventName}`;
-        addIpcListener(eventName, listener, ipcEventName);
-
-        if (ipcRenderer.listenerCount(ipcEventName) === 0) {
-            // use only one ipc listener and resolve realListeners here
-            ipcRenderer.send(`${prefix}/add-listener`, [eventName, ipcEventName]);
-            ipcRenderer.on(ipcEventName, (_, event) => {
-                ipcListeners
-                    .filter(l => l.ipcEventName === ipcEventName)
-                    .forEach(l => l.realListener(...event));
-            });
-        }
-    };
-
-    const removeListener = (eventName: string, listener: any) => {
-        const ipcEventName = `${prefix}/event-listener/${eventName}`;
-        removeIpcListener(eventName, listener);
-
-        if (ipcListeners.filter(l => l.ipcEventName === ipcEventName).length === 0) {
-            ipcRenderer.removeAllListeners(ipcEventName);
-            ipcRenderer.send(`${prefix}/remove-listener`, [eventName, ipcEventName]);
-        }
-    };
-
+const createIpcProxyApi = (ipcRenderer: IpcRenderer, validChannels: string[]): IpcProxyApi => {
     let requestId = 0;
 
-    // It would be easier to use ipcRenderer.invoke and return a promise directly from API[method]
-    // read more in ./proxy-handler
-    const request =
-        (method: string) =>
-        (...args: any[]) =>
-            new Promise<any>((resolve, reject) => {
-                requestId++;
-                const responseEvent = `${prefix}/response/${requestId}`;
-                ipcRenderer.once(responseEvent, (_, response) => {
-                    // success/failure is wrapped in object. see ipcProxyHandler
-                    if (response.success) {
-                        resolve(response.payload);
-                    } else {
-                        reject(response.error);
-                    }
-                });
-                ipcRenderer.send(`${prefix}/request`, [responseEvent, method, args]);
-            });
+    const validateChannel = (channelName: string): true => {
+        if (!validChannels.includes(channelName))
+            throw new Error(`Proxy name ${channelName} not registered in electron preload`);
+        return true;
+    };
 
-    const invoke =
-        (method: string) =>
-        (...args: any[]) =>
-            ipcRenderer.invoke(`${prefix}/invoke`, [method, ...args]);
+    const create = (channelName: string, instanceId: string, constructorParams: any) =>
+        validateChannel(channelName) &&
+        ipcRenderer.invoke(`${channelName}/create`, [
+            `${channelName}/${instanceId}`,
+            constructorParams,
+        ]);
+
+    const request = (channelName: string, instanceId: string, method: string, args: any[]) =>
+        validateChannel(channelName) &&
+        new Promise<any>((resolve, reject) => {
+            requestId++;
+            const responseEvent = `${channelName}/${instanceId}/response/${requestId}`;
+            ipcRenderer.once(responseEvent, (_, response) => {
+                // success/failure is wrapped in object. see ipcProxyHandler
+                if (response.success) {
+                    resolve(response.payload);
+                } else {
+                    reject(response.error);
+                }
+            });
+            ipcRenderer.send(`${channelName}/${instanceId}/request`, [responseEvent, method, args]);
+        });
+
+    const invoke = (channelName: string, instanceId: string, method: string, args: any[]) =>
+        validateChannel(channelName) &&
+        ipcRenderer.invoke(`${channelName}/${instanceId}/invoke`, [method, ...args]);
+
+    const setHandler = (
+        channelName: string,
+        instanceId: string,
+        eventName: string,
+        listener: any,
+    ) => {
+        validateChannel(channelName);
+        const ipcEventName = `${channelName}/${instanceId}/event-listener/${eventName}`;
+        if (ipcRenderer.listenerCount(ipcEventName)) {
+            ipcRenderer.removeAllListeners(ipcEventName);
+        } else {
+            ipcRenderer.send(`${channelName}/${instanceId}/add-listener`, [
+                eventName,
+                ipcEventName,
+            ]);
+        }
+        ipcRenderer.on(ipcEventName, (_, event) => listener(event));
+    };
+
+    const clearHandler = (channelName: string, instanceId: string, eventName: string) => {
+        validateChannel(channelName);
+        const ipcEventName = `${channelName}/${instanceId}/event-listener/${eventName}`;
+        ipcRenderer.removeAllListeners(ipcEventName);
+        ipcRenderer.send(`${channelName}/${instanceId}/remove-listener`, [eventName, ipcEventName]);
+    };
 
     return {
-        prefix,
-        init,
-        addListener,
-        removeListener,
+        create,
         request,
         invoke,
+        setHandler,
+        clearHandler,
     };
-};
-
-const factory = async (
-    ipcRenderer: IpcRenderer,
-    validChannels: string[],
-    channelName: string,
-    ...constructorParams: any[]
-) => {
-    if (!validChannels.includes(channelName))
-        throw new Error(`Proxy name ${channelName} not registered in electron preload`);
-
-    const { prefix, init, addListener, removeListener, request } = getIpcMethods(
-        ipcRenderer,
-        channelName,
-        constructorParams,
-    );
-
-    // try to handshake electron main layer (See ./proxy-handler)
-    await init();
-
-    const target: Record<string, any> = {
-        _ipcProxy: prefix,
-    };
-
-    // define Proxy-like object
-    // Proxy cannot be used directly in electron preload context see ./proxy
-    const proxy: ProxyHandler<typeof target> = {
-        get: (proxyTarget, name: string) => {
-            // exclude promise-like methods. they presence may be checked since the whole process is async
-            if (['then', 'catch', 'finally'].includes(name)) return undefined;
-
-            if (proxyTarget[name]) {
-                return proxyTarget[name];
-            }
-
-            // handle event-emitter-like methods
-            if (name === 'on') {
-                proxyTarget[name] = addListener;
-                return proxyTarget[name];
-            }
-
-            if (['off', 'removeAllListeners'].includes(name)) {
-                proxyTarget[name] = removeListener;
-                return proxyTarget[name];
-            }
-
-            proxyTarget[name] = request(name);
-            return proxyTarget[name];
-        },
-    };
-
-    return { target, proxy };
 };
 
 interface IpcProxyGeneratorOptions {
     proxyName?: string; // needs to be also set in `createIpcProxy` if changed here (see ./proxy)
 }
 
-// This should be used only in electron preload context.
-// returns [string, factoryFunction] params of electron contextBridge.exposeInMainWorld function
 export const exposeIpcProxy = (
     ipcRenderer: IpcRenderer,
     validChannels: string[] = [],
     options: IpcProxyGeneratorOptions = {},
-) =>
-    [
-        options.proxyName || 'ipcProxy', // name used in window object see ./proxy
-        (channelName: string, ...constructorParams: any[]) =>
-            factory(ipcRenderer, validChannels, channelName, ...constructorParams),
-    ] as const;
+) => [options.proxyName || 'ipcProxy', createIpcProxyApi(ipcRenderer, validChannels)] as const;

--- a/packages/ipc-proxy/src/proxy.ts
+++ b/packages/ipc-proxy/src/proxy.ts
@@ -1,8 +1,63 @@
-import type { IpcProxyGenerator } from './types';
+import type { IpcProxyApi } from './types';
 
-const getIpcProxy = <T>(proxyName: string): IpcProxyGenerator<T> | undefined =>
+const getIpcProxyApi = (proxyName: string): IpcProxyApi | undefined =>
     // @ts-expect-error this is the only window reference. not worth typing in global scope
     typeof window !== 'undefined' ? window[proxyName] : undefined;
+
+const getIpcMethods = (ipcProxy: IpcProxyApi, channelName: string, instanceId: string) => {
+    let listeners: { eventName: string; listener: (...args: any[]) => any }[] = [];
+    let created = false;
+
+    const create = async (constructorParams: any) => {
+        if (created) return true;
+        // Handshake with electron main
+        await ipcProxy.create(channelName, instanceId, constructorParams);
+        created = true;
+    };
+
+    // It would be easier to use ipcRenderer.invoke and return a promise directly from API[method]
+    // read more in ./proxy-handler
+    const request =
+        (method: string) =>
+        (...args: any[]) =>
+            ipcProxy.request(channelName, instanceId, method, args);
+
+    const invoke =
+        (method: string) =>
+        (...args: any[]) =>
+            ipcProxy.invoke(channelName, instanceId, method, args);
+
+    const setOrClearHandler = (eventName: string) => {
+        const eventListeners = listeners.filter(l => l.eventName === eventName);
+        if (eventListeners.length) {
+            ipcProxy.setHandler(channelName, instanceId, eventName, (event: any) =>
+                eventListeners.forEach(l => l.listener(...event)),
+            );
+        } else {
+            ipcProxy.clearHandler(channelName, instanceId, eventName);
+        }
+    };
+
+    const addListener = (eventName: string, listener: any) => {
+        listeners.push({ eventName, listener });
+        setOrClearHandler(eventName);
+    };
+
+    const removeListener = (eventName: string, listener?: any) => {
+        listeners = listeners.filter(
+            l => l.eventName !== eventName || (listener && l.listener !== listener),
+        );
+        setOrClearHandler(eventName);
+    };
+
+    return {
+        create,
+        request,
+        invoke,
+        addListener,
+        removeListener,
+    };
+};
 
 interface IpcProxyOptions {
     proxyName?: string; // needs to be also set in `exposeIpcProxy` if changed here (see ./proxy-generator)
@@ -11,23 +66,61 @@ interface IpcProxyOptions {
 
 // This should be used only in electron renderer context.
 // `Proxy` object cannot be defined and returned from electron preload native code context.
-export const createIpcProxy = async <T>(
+export const createIpcProxy = async <T extends object>(
     channelName: string, // declared in `exposeIpcProxy` (see ./proxy-generator)
     options: IpcProxyOptions = {},
     ...constructorParams: any[] // constructor of <T> params, could be undefined
 ): Promise<T> => {
     const proxyName = options?.proxyName || 'ipcProxy';
-    const generator = getIpcProxy<T>(proxyName);
-    if (!generator) {
+
+    const ipcProxyApi = getIpcProxyApi(proxyName);
+    if (!ipcProxyApi) {
         throw new Error(`${proxyName} not found`);
     }
-    const { target, proxy } = await generator(channelName, ...constructorParams);
-    return new Proxy(
-        { ...target, ...options.target },
-        {
-            // NOTE: pass only serializable object, params of `ProxyHandler` (target, name) to electron preload context.
-            // `receiver` parameter (3rd) is an instance of Proxy object and could not be serialized
-            get: (t, n) => proxy.get(t, n),
-        },
+
+    const instanceId = (Date.now() + Math.random()).toString(36);
+
+    const { create, request, addListener, removeListener } = getIpcMethods(
+        ipcProxyApi,
+        channelName,
+        instanceId,
     );
+
+    // try to handshake electron main layer (See ./proxy-handler)
+    await create(constructorParams);
+
+    const prefix = `${channelName}/${instanceId}`;
+
+    const target = { _ipcProxy: prefix, ...options.target } as T;
+
+    const proxyHandler: ProxyHandler<T> = {
+        // NOTE: pass only serializable object, params of `ProxyHandler` (target, name) to electron preload context.
+        // `receiver` parameter (3rd) is an instance of Proxy object and could not be serialized
+        get: (proxyTarget: any, name) => {
+            if (typeof name === 'symbol') return proxyTarget[name];
+
+            // exclude promise-like methods. they presence may be checked since the whole process is async
+            if (['then', 'catch', 'finally'].includes(name)) return undefined;
+
+            if (proxyTarget[name]) {
+                return proxyTarget[name];
+            }
+
+            // handle event-emitter-like methods
+            if (name === 'on') {
+                proxyTarget[name] = addListener;
+                return proxyTarget[name];
+            }
+
+            if (name === 'off' || name === 'removeAllListeners') {
+                proxyTarget[name] = removeListener;
+                return proxyTarget[name];
+            }
+
+            proxyTarget[name] = request(name);
+            return proxyTarget[name];
+        },
+    };
+
+    return new Proxy(target, proxyHandler);
 };

--- a/packages/ipc-proxy/src/types.ts
+++ b/packages/ipc-proxy/src/types.ts
@@ -9,3 +9,11 @@ export type IpcProxyGenerator<T> = (
         get(target: T, p: string | symbol): any;
     };
 }>;
+
+export type IpcProxyApi = {
+    create: (channelName: string, instanceId: string, constructorParams: any) => Promise<any>;
+    request: (channelName: string, instanceId: string, method: string, args: any[]) => Promise<any>;
+    invoke: (channelName: string, instanceId: string, method: string, args: any[]) => Promise<any>;
+    setHandler: (channelName: string, instanceId: string, eventName: string, handler: any) => void;
+    clearHandler: (channelName: string, instanceId: string, eventName: string) => void;
+};


### PR DESCRIPTION
## Description
In `ipc-proxy`, listener functions were handled in the preload context, which prevented their correct unsubscribing (it wasn't possible to use reference equality and `toString()` always returned `function() { [native code] }`, so the first listener function was usually removed instead of the correct one).

Now the logic was moved to the renderer context, where it's possible to check reference equality as usual.

## Related Issue
Resolve #8020 and possibly even others.