### PR TITLE
UI overflow glitches

### DIFF
--- a/suite-native/accounts/src/components/AccountListItem.tsx
+++ b/suite-native/accounts/src/components/AccountListItem.tsx
@@ -15,6 +15,9 @@ export type AccountListItemProps = {
 
 const accountListItemStyle = prepareNativeStyle<{ isAccountWithTokens: boolean }>(
     (utils, { isAccountWithTokens }) => ({
+        flexDirection: 'row',
+        justifyContent: 'space-between',
+        alignItem: 'center',
         backgroundColor: utils.colors.backgroundSurfaceElevation1,
         padding: utils.spacings.medium,
         borderRadius: utils.borders.radii.medium,
@@ -27,6 +30,17 @@ const accountListItemStyle = prepareNativeStyle<{ isAccountWithTokens: boolean }
     }),
 );
 
+export const accountTitleStyle = prepareNativeStyle(_ => ({
+    flexShrink: 1,
+}));
+
+export const valuesContainerStyle = prepareNativeStyle(utils => ({
+    maxWidth: '40%',
+    flexShrink: 0,
+    alignItems: 'flex-end',
+    paddingLeft: utils.spacings.small,
+}));
+
 export const AccountListItem = ({ account }: AccountListItemProps) => {
     const { applyStyle } = useNativeStyles();
     const accountLabel = useSelector((state: AccountsRootState) =>
@@ -38,20 +52,18 @@ export const AccountListItem = ({ account }: AccountListItemProps) => {
 
     return (
         <Box
-            flexDirection="row"
-            justifyContent="space-between"
-            alignItems="center"
             style={applyStyle(accountListItemStyle, {
                 isAccountWithTokens,
             })}
         >
-            <Box flexDirection="row">
-                <Box marginRight="small">
+            <Box flexDirection="row" alignItems="center" flex={1}>
+                <Box marginRight="medium">
                     <CryptoIcon name={account.symbol} />
                 </Box>
-                <Text>{accountLabel}</Text>
+                <Text style={applyStyle(accountTitleStyle)}>{accountLabel}</Text>
             </Box>
-            <Box alignItems="flex-end">
+
+            <Box style={applyStyle(valuesContainerStyle)}>
                 <CryptoToFiatAmountFormatter
                     value={account.availableBalance}
                     network={account.symbol}

--- a/suite-native/accounts/src/components/TokenListItem.tsx
+++ b/suite-native/accounts/src/components/TokenListItem.tsx
@@ -11,6 +11,8 @@ import { EthereumTokenSymbol, getEthereumTokenIconName } from '@suite-native/eth
 import { prepareNativeStyle, useNativeStyles } from '@trezor/styles';
 import { AccountKey } from '@suite-common/wallet-types';
 
+import { accountTitleStyle, valuesContainerStyle } from './AccountListItem';
+
 type TokenListItemProps = {
     balance: string;
     isLast: boolean;
@@ -66,13 +68,13 @@ export const TokenListItem = ({
                     alignItems="center"
                     style={applyStyle(tokenListItemStyle, { isLast })}
                 >
-                    <Box flexDirection="row">
+                    <Box flex={1} flexDirection="row" alignItems="center">
                         <Box marginRight="small">
                             <EthereumTokenIcon name={iconName} />
                         </Box>
-                        <Text>{label}</Text>
+                        <Text style={applyStyle(accountTitleStyle)}>{label}</Text>
                     </Box>
-                    <Box alignItems="flex-end">
+                    <Box style={applyStyle(valuesContainerStyle)}>
                         <EthereumTokenToFiatAmountFormatter
                             value={balance}
                             ethereumToken={symbol}

--- a/suite-native/atoms/src/Button/IconButton.tsx
+++ b/suite-native/atoms/src/Button/IconButton.tsx
@@ -94,9 +94,11 @@ export const IconButton = ({
                     >
                         <Icon name={iconName} color={iconColor} size={size} />
                     </Animated.View>
-                    <Text variant="label" color="textSubdued">
-                        {title}
-                    </Text>
+                    {title && (
+                        <Text variant="label" color="textSubdued">
+                            {title}
+                        </Text>
+                    )}
                 </Box>
             </Pressable>
         </Box>

--- a/suite-native/atoms/src/DiscreetText.tsx
+++ b/suite-native/atoms/src/DiscreetText.tsx
@@ -8,7 +8,6 @@ import { Color, typographyStylesBase } from '@trezor/theme';
 import { prepareNativeStyle, useNativeStyles } from '@trezor/styles';
 
 import { Text, TextProps } from './Text';
-import { Box } from './Box';
 
 type DiscreetTextProps = TextProps & {
     children?: string | null;
@@ -66,6 +65,8 @@ export const DiscreetText = ({
     children = '',
     color = 'textDefault',
     variant = 'body',
+    numberOfLines,
+    ellipsizeMode,
     ...restTextProps
 }: DiscreetTextProps) => {
     const { applyStyle } = useNativeStyles();
@@ -81,7 +82,11 @@ export const DiscreetText = ({
     if (!children) return null;
 
     return (
-        <Box style={applyStyle(discreetTextContainer, { lineHeight })}>
+        <Text
+            style={applyStyle(discreetTextContainer, { lineHeight })}
+            numberOfLines={numberOfLines}
+            ellipsizeMode={ellipsizeMode}
+        >
             {isDiscreetMode && (
                 <DiscreetCanvas
                     width={width}
@@ -103,6 +108,6 @@ export const DiscreetText = ({
             >
                 {children}
             </Text>
-        </Box>
+        </Text>
     );
 };

--- a/suite-native/atoms/src/DiscreetText.tsx
+++ b/suite-native/atoms/src/DiscreetText.tsx
@@ -46,11 +46,6 @@ export const DiscreetCanvas = ({ width, height, fontSize, text, color }: Discree
         </Canvas>
     );
 };
-
-const discreetTextContainer = prepareNativeStyle<{ lineHeight: number }>((_, { lineHeight }) => ({
-    height: lineHeight,
-}));
-
 const textStyle = prepareNativeStyle<{ isDiscreetMode: boolean }>((_, { isDiscreetMode }) => ({
     extend: {
         condition: isDiscreetMode,
@@ -67,6 +62,7 @@ export const DiscreetText = ({
     variant = 'body',
     numberOfLines,
     ellipsizeMode,
+    adjustsFontSizeToFit,
     ...restTextProps
 }: DiscreetTextProps) => {
     const { applyStyle } = useNativeStyles();
@@ -83,9 +79,10 @@ export const DiscreetText = ({
 
     return (
         <Text
-            style={applyStyle(discreetTextContainer, { lineHeight })}
+            variant={variant}
             numberOfLines={numberOfLines}
             ellipsizeMode={ellipsizeMode}
+            adjustsFontSizeToFit={adjustsFontSizeToFit}
         >
             {isDiscreetMode && (
                 <DiscreetCanvas

--- a/suite-native/atoms/src/TextDivider.tsx
+++ b/suite-native/atoms/src/TextDivider.tsx
@@ -16,7 +16,7 @@ const textDividerStyle = prepareNativeStyle(utils => ({
     flexDirection: 'row',
     justifyContent: 'space-between',
     alignItems: 'center',
-    marginBottom: utils.spacings.extraLarge,
+    marginBottom: utils.spacings.medium,
 }));
 
 export const TextDivider = ({ title, style }: TextDividerProps) => {

--- a/suite-native/formatters/package.json
+++ b/suite-native/formatters/package.json
@@ -21,6 +21,7 @@
         "@suite-native/ethereum-tokens": "workspace:*",
         "@suite-native/module-settings": "workspace:*",
         "@trezor/blockchain-link": "workspace:*",
+        "@trezor/styles": "workspace:*",
         "bignumber.js": "^9.1.1",
         "react": "18.2.0",
         "react-redux": "8.0.5"

--- a/suite-native/formatters/package.json
+++ b/suite-native/formatters/package.json
@@ -24,6 +24,7 @@
         "@trezor/styles": "workspace:*",
         "bignumber.js": "^9.1.1",
         "react": "18.2.0",
+        "react-native": "0.71.5",
         "react-redux": "8.0.5"
     }
 }

--- a/suite-native/formatters/src/components/AccountAddressFormatter.tsx
+++ b/suite-native/formatters/src/components/AccountAddressFormatter.tsx
@@ -4,18 +4,34 @@ import { useSelector } from 'react-redux';
 import { AccountsRootState, selectAccountLabel } from '@suite-common/wallet-core';
 import { Text, TextProps } from '@suite-native/atoms';
 import { AccountKey } from '@suite-common/wallet-types';
+import { prepareNativeStyle, useNativeStyles, mergeNativeStyleObjects } from '@trezor/styles';
 
 import { FormatterProps } from '../types';
 
 type AccountAddressFormatterProps = FormatterProps<AccountKey> & TextProps;
 
-export const AccountAddressFormatter = ({ value, ...rest }: AccountAddressFormatterProps) => {
+const addressStyle = prepareNativeStyle(_ => ({
+    // ellipsizeMode="middle" is not working  on Android with negative letterSpacing defined in @trezor/theme typography.
+    letterSpacing: 0,
+}));
+
+export const AccountAddressFormatter = ({
+    value,
+    style,
+    ...rest
+}: AccountAddressFormatterProps) => {
+    const { applyStyle } = useNativeStyles();
     const accountLabel = useSelector((state: AccountsRootState) =>
         selectAccountLabel(state, value),
     );
 
+    const baseAddressStyle = applyStyle(addressStyle);
+    const mergedAddressStyle = style
+        ? mergeNativeStyleObjects([style, baseAddressStyle])
+        : baseAddressStyle;
+
     return (
-        <Text numberOfLines={1} ellipsizeMode="middle" {...rest}>
+        <Text numberOfLines={1} ellipsizeMode="middle" style={mergedAddressStyle} {...rest}>
             {accountLabel || value}
         </Text>
     );

--- a/suite-native/formatters/src/components/AccountAddressFormatter.tsx
+++ b/suite-native/formatters/src/components/AccountAddressFormatter.tsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import { Platform } from 'react-native';
 import { useSelector } from 'react-redux';
 
 import { AccountsRootState, selectAccountLabel } from '@suite-common/wallet-core';
@@ -11,8 +12,13 @@ import { FormatterProps } from '../types';
 type AccountAddressFormatterProps = FormatterProps<AccountKey> & TextProps;
 
 const addressStyle = prepareNativeStyle(_ => ({
-    // ellipsizeMode="middle" is not working  on Android with negative letterSpacing defined in @trezor/theme typography.
-    letterSpacing: 0,
+    // ellipsizeMode="middle" is not working on Android with negative letterSpacing defined in @trezor/theme typography.
+    extend: {
+        condition: Platform.OS === 'android',
+        style: {
+            letterSpacing: 0,
+        },
+    },
 }));
 
 export const AccountAddressFormatter = ({

--- a/suite-native/formatters/src/components/EthereumTokenAmountFormatter.tsx
+++ b/suite-native/formatters/src/components/EthereumTokenAmountFormatter.tsx
@@ -1,11 +1,10 @@
 import React from 'react';
 
-import { Box, Text, TextProps } from '@suite-native/atoms';
+import { TextProps } from '@suite-native/atoms';
 import { EthereumTokenSymbol } from '@suite-native/ethereum-tokens';
 import { localizeNumber } from '@suite-common/wallet-utils';
 
 import { FormatterProps } from '../types';
-import { EthereumTokenSymbolFormatter } from './EthereumTokenSymbolFormatter';
 import { AmountText } from './AmountText';
 import { convertTokenValueToDecimal } from '../utils';
 
@@ -26,24 +25,19 @@ export const EthereumTokenAmountFormatter = ({
     ...rest
 }: EthereumTokenAmountFormatterProps) => {
     const decimalValue = convertTokenValueToDecimal(value, decimals);
-    const formattedValue = localizeNumber(decimalValue);
+
+    const formattedSymbol = ethereumToken.toUpperCase();
+    const formattedValue = `${localizeNumber(decimalValue)} ${formattedSymbol}`;
 
     return (
-        <Box flexDirection="row">
-            <AmountText
-                value={formattedValue}
-                isDiscreetText={isDiscreetText}
-                variant={variant}
-                color={color}
-                {...rest}
-            />
-            <Text> </Text>
-            <EthereumTokenSymbolFormatter
-                ethereumSymbol={ethereumToken}
-                variant={variant}
-                color={color}
-                {...rest}
-            />
-        </Box>
+        <AmountText
+            value={formattedValue}
+            isDiscreetText={isDiscreetText}
+            variant={variant}
+            color={color}
+            numberOfLines={1}
+            ellipsizeMode="tail"
+            {...rest}
+        />
     );
 };

--- a/suite-native/formatters/src/components/EthereumTokenToFiatAmountFormatter.tsx
+++ b/suite-native/formatters/src/components/EthereumTokenToFiatAmountFormatter.tsx
@@ -1,22 +1,25 @@
 import React from 'react';
 import { useSelector } from 'react-redux';
 
-import { TextProps } from '@suite-native/atoms';
+import { TextProps, Text } from '@suite-native/atoms';
 import { selectCoins } from '@suite-common/wallet-core';
 import { selectFiatCurrency } from '@suite-native/module-settings';
 import { toFiatCurrency } from '@suite-common/wallet-utils';
 import { useFormatters } from '@suite-common/formatters';
 import { EthereumTokenSymbol } from '@suite-native/ethereum-tokens';
+import { SignValue } from '@suite-common/suite-types';
 
 import { FormatterProps } from '../types';
 import { EmptyAmountText } from './EmptyAmountText';
 import { AmountText } from './AmountText';
 import { convertTokenValueToDecimal } from '../utils';
+import { SignValueFormatter } from './SignValueFormatter';
 
 type EthereumTokenToFiatAmountFormatterProps = {
     ethereumToken: EthereumTokenSymbol;
     isDiscreetText?: boolean;
     decimals?: number;
+    signValue?: SignValue;
 } & FormatterProps<number | string> &
     TextProps;
 
@@ -25,6 +28,7 @@ export const EthereumTokenToFiatAmountFormatter = ({
     ethereumToken,
     isDiscreetText = true,
     decimals = 0,
+    signValue,
     ...rest
 }: EthereumTokenToFiatAmountFormatterProps) => {
     const coins = useSelector(selectCoins);
@@ -39,5 +43,10 @@ export const EthereumTokenToFiatAmountFormatter = ({
     const fiatValue = toFiatCurrency(decimalValue.toString(), fiatCurrency.label, rates, 2);
     const formattedFiatValue = FiatAmountFormatter.format(fiatValue ?? 0);
 
-    return <AmountText value={formattedFiatValue} isDiscreetText={isDiscreetText} {...rest} />;
+    return (
+        <Text ellipsizeMode="tail" numberOfLines={1}>
+            {signValue && <SignValueFormatter value={signValue} />}
+            <AmountText value={formattedFiatValue} isDiscreetText={isDiscreetText} {...rest} />
+        </Text>
+    );
 };

--- a/suite-native/formatters/tsconfig.json
+++ b/suite-native/formatters/tsconfig.json
@@ -25,6 +25,7 @@
         { "path": "../module-settings" },
         {
             "path": "../../packages/blockchain-link"
-        }
+        },
+        { "path": "../../packages/styles" }
     ]
 }

--- a/suite-native/module-accounts-import/src/screens/XpubScanScreen.tsx
+++ b/suite-native/module-accounts-import/src/screens/XpubScanScreen.tsx
@@ -3,7 +3,7 @@ import { View } from 'react-native';
 
 import { useFocusEffect } from '@react-navigation/native';
 
-import { Button, Card, TextDivider, VStack } from '@suite-native/atoms';
+import { Box, Button, Card, TextDivider, VStack } from '@suite-native/atoms';
 import { isDevelopOrDebugEnv } from '@suite-native/config';
 import { Form, TextInputField, useForm } from '@suite-native/forms';
 import {
@@ -29,10 +29,10 @@ const networkTypeToInputLabelMap: Record<NetworkType, string> = {
     ripple: 'Enter receive address manually',
 };
 
-const cameraStyle = prepareNativeStyle(_ => ({
+const cameraStyle = prepareNativeStyle(utils => ({
     alignItems: 'center',
     marginTop: 20,
-    marginBottom: 45,
+    marginBottom: utils.spacings.medium,
 }));
 
 const xpubFormValidationSchema = yup.object({
@@ -109,28 +109,31 @@ export const XpubScanScreen = ({
                     onPressActionButton={() => navigation.goBack()}
                 />
             </Card>
-            <View style={applyStyle(cameraStyle)}>
-                <XpubImportSection
-                    onRequestCamera={handleRequestCamera}
-                    networkSymbol={networkSymbol}
-                />
-            </View>
-            <TextDivider title="OR" />
-            <Form form={form}>
-                <VStack spacing="medium">
-                    <TextInputField name="xpubAddress" label={inputLabel} />
-                    <Button
-                        onPress={onXpubFormSubmit}
-                        size="large"
-                        isDisabled={!watchXpubAddress?.length}
-                    >
-                        Confirm
-                    </Button>
-                </VStack>
-            </Form>
-            {isDevelopOrDebugEnv() && (
-                <DevXpub symbol={networkSymbol} onSelect={goToAccountImportScreen} />
-            )}
+            <Box marginHorizontal="medium">
+                <View style={applyStyle(cameraStyle)}>
+                    <XpubImportSection
+                        onRequestCamera={handleRequestCamera}
+                        networkSymbol={networkSymbol}
+                    />
+                </View>
+
+                <TextDivider title="OR" />
+                <Form form={form}>
+                    <VStack spacing="medium">
+                        <TextInputField name="xpubAddress" label={inputLabel} />
+                        <Button
+                            onPress={onXpubFormSubmit}
+                            size="large"
+                            isDisabled={!watchXpubAddress?.length}
+                        >
+                            Confirm
+                        </Button>
+                    </VStack>
+                </Form>
+                {isDevelopOrDebugEnv() && (
+                    <DevXpub symbol={networkSymbol} onSelect={goToAccountImportScreen} />
+                )}
+            </Box>
         </Screen>
     );
 };

--- a/suite-native/module-accounts/src/components/AccountDetailGraphHeader.tsx
+++ b/suite-native/module-accounts/src/components/AccountDetailGraphHeader.tsx
@@ -44,7 +44,13 @@ const hasPriceIncreasedAtom = atom(get => {
 const CryptoBalance = ({ accountSymbol }: { accountSymbol: NetworkSymbol }) => {
     const selectedPoint = useAtomValue(selectedPointAtom);
 
-    return <CryptoAmountFormatter value={selectedPoint.cryptoBalance} network={accountSymbol} />;
+    return (
+        <CryptoAmountFormatter
+            value={selectedPoint.cryptoBalance}
+            network={accountSymbol}
+            adjustsFontSizeToFit
+        />
+    );
 };
 
 const FiatBalance = ({ accountSymbol }: { accountSymbol: NetworkSymbol }) => {
@@ -55,6 +61,8 @@ const FiatBalance = ({ accountSymbol }: { accountSymbol: NetworkSymbol }) => {
             value={String(selectedPoint.value)}
             network={accountSymbol}
             variant="titleLarge"
+            adjustsFontSizeToFit
+            numberOfLines={1}
         />
     );
 };

--- a/suite-native/module-accounts/src/components/AccountDetailScreenHeader.tsx
+++ b/suite-native/module-accounts/src/components/AccountDetailScreenHeader.tsx
@@ -11,7 +11,6 @@ import {
     ScreenHeader,
     StackToStackCompositeNavigationProps,
 } from '@suite-native/navigation';
-import { prepareNativeStyle, useNativeStyles } from '@trezor/styles';
 
 type AccountDetailScreenHeaderProps = {
     accountLabel?: string;
@@ -25,16 +24,11 @@ type AccountDetailNavigationProps = StackToStackCompositeNavigationProps<
     RootStackParamList
 >;
 
-const headerStyle = prepareNativeStyle(utils => ({
-    paddingHorizontal: utils.spacings.medium,
-}));
-
 export const AccountDetailScreenHeader = ({
     accountLabel,
     accountKey,
     tokenName,
 }: AccountDetailScreenHeaderProps) => {
-    const { applyStyle } = useNativeStyles();
     const navigation = useNavigation<AccountDetailNavigationProps>();
 
     const handleSettingsNavigation = () => {
@@ -58,7 +52,7 @@ export const AccountDetailScreenHeader = ({
                     />
                 )
             }
-            style={applyStyle(headerStyle)}
+            titleVariant="body"
             title={accountTitle}
         />
     );

--- a/suite-native/module-accounts/src/screens/AccountDetailScreen.tsx
+++ b/suite-native/module-accounts/src/screens/AccountDetailScreen.tsx
@@ -64,7 +64,6 @@ export const AccountDetailScreen = memo(
                         tokenName={token?.name}
                     />
                 }
-                customHorizontalPadding={0}
                 isScrollable={false}
             >
                 <TransactionList

--- a/suite-native/module-accounts/src/screens/AccountSettingsScreen.tsx
+++ b/suite-native/module-accounts/src/screens/AccountSettingsScreen.tsx
@@ -93,6 +93,7 @@ export const AccountSettingsScreen = ({
                 <ScreenHeader
                     title={accountLabel}
                     rightIcon={<AccountRenameButton accountKey={accountKey} />}
+                    titleVariant="body"
                 />
             }
         >

--- a/suite-native/module-accounts/src/screens/AccountsScreen.tsx
+++ b/suite-native/module-accounts/src/screens/AccountsScreen.tsx
@@ -7,7 +7,6 @@ import {
     StackProps,
 } from '@suite-native/navigation';
 import { AccountsList } from '@suite-native/accounts';
-import { nativeSpacings } from '@trezor/theme';
 import { AccountKey } from '@suite-common/wallet-types';
 import { EthereumTokenSymbol } from '@suite-native/ethereum-tokens';
 
@@ -24,12 +23,7 @@ export const AccountsScreen = ({
     };
 
     return (
-        <Screen
-            customHorizontalPadding={nativeSpacings.small}
-            customVerticalPadding={nativeSpacings.small}
-            header={<AccountsScreenHeader />}
-            hasDivider
-        >
+        <Screen header={<AccountsScreenHeader />}>
             <AccountsList onSelectAccount={handleSelectAccount} />
         </Screen>
     );

--- a/suite-native/module-home/src/components/PortfolioGraphHeader.tsx
+++ b/suite-native/module-home/src/components/PortfolioGraphHeader.tsx
@@ -40,7 +40,7 @@ const Balance = () => {
 
     return (
         <FiatAmountFormatter
-            value={`${String(`${point.value}`)}`}
+            value={String(point.value)}
             variant="titleLarge"
             color="textDefault"
             numberOfLines={1}

--- a/suite-native/module-home/src/components/PortfolioGraphHeader.tsx
+++ b/suite-native/module-home/src/components/PortfolioGraphHeader.tsx
@@ -39,7 +39,13 @@ const Balance = () => {
     const point = useAtomValue(selectedPointAtom);
 
     return (
-        <FiatAmountFormatter value={String(point.value)} variant="titleLarge" color="textDefault" />
+        <FiatAmountFormatter
+            value={`${String(`${point.value}`)}`}
+            variant="titleLarge"
+            color="textDefault"
+            numberOfLines={1}
+            adjustsFontSizeToFit
+        />
     );
 };
 
@@ -53,9 +59,7 @@ export const PortfolioGraphHeader = () => {
                 <Text color="textSubdued" variant="hint" style={applyStyle(headerStyle)}>
                     My portfolio balance
                 </Text>
-                <Text variant="titleLarge">
-                    <Balance />
-                </Text>
+                <Balance />
                 <Box flexDirection="row" alignItems="center">
                     <Box marginRight="small">
                         <Text variant="hint" color="textSubdued">

--- a/suite-native/navigation/src/components/Screen.tsx
+++ b/suite-native/navigation/src/components/Screen.tsx
@@ -56,8 +56,8 @@ export const Screen = ({
     isScrollable = true,
     hasStatusBar = true,
     backgroundColor = 'backgroundSurfaceElevation0',
-    customVerticalPadding = nativeSpacings.medium,
-    customHorizontalPadding = nativeSpacings.medium,
+    customVerticalPadding = nativeSpacings.small,
+    customHorizontalPadding = nativeSpacings.small,
 }: ScreenProps) => {
     const {
         applyStyle,

--- a/suite-native/navigation/src/components/ScreenHeader.tsx
+++ b/suite-native/navigation/src/components/ScreenHeader.tsx
@@ -4,7 +4,8 @@ import { View } from 'react-native';
 import { useNavigation } from '@react-navigation/native';
 
 import { NativeStyleObject, prepareNativeStyle, useNativeStyles } from '@trezor/styles';
-import { IconButton, StepsProgressBar, Text } from '@suite-native/atoms';
+import { Box, IconButton, StepsProgressBar, Text } from '@suite-native/atoms';
+import { TypographyStyle } from '@trezor/theme';
 
 type ScreenHeaderWithIconsProps = {
     leftIcon?: ReactNode;
@@ -14,15 +15,17 @@ type ScreenHeaderWithIconsProps = {
     hasGoBackIcon?: boolean;
     numberOfSteps?: number;
     activeStep?: number;
+    titleVariant?: TypographyStyle;
 };
 
 const ICON_SIZE = 48;
 
-const screenHeaderStyle = prepareNativeStyle(() => ({
+const screenHeaderStyle = prepareNativeStyle(utils => ({
     flexDirection: 'row',
     alignItems: 'center',
     justifyContent: 'space-between',
     height: ICON_SIZE,
+    marginHorizontal: utils.spacings.small,
 }));
 
 const iconWrapperStyle = prepareNativeStyle(() => ({
@@ -30,10 +33,10 @@ const iconWrapperStyle = prepareNativeStyle(() => ({
     height: ICON_SIZE,
 }));
 
-const progressBarWrapperStyle = prepareNativeStyle(() => ({
+const progressBarWrapperStyle = prepareNativeStyle(utils => ({
     height: ICON_SIZE,
     alignItems: 'center',
-    paddingTop: 7,
+    paddingTop: utils.spacings.small,
     justifyContent: 'space-between',
 }));
 
@@ -56,6 +59,7 @@ export const ScreenHeader = ({
     title,
     numberOfSteps,
     activeStep,
+    titleVariant = 'titleSmall',
     hasGoBackIcon = true,
 }: ScreenHeaderWithIconsProps) => {
     const { applyStyle } = useNativeStyles();
@@ -67,14 +71,18 @@ export const ScreenHeader = ({
             <View style={applyStyle(iconWrapperStyle)}>
                 {shouldDisplayGoBackButton ? <GoBackIcon /> : leftIcon}
             </View>
-            {activeStep && numberOfSteps ? (
-                <View style={applyStyle(progressBarWrapperStyle)}>
-                    <StepsProgressBar numberOfSteps={numberOfSteps} activeStep={activeStep} />
-                    {title && <Text variant="titleSmall">{title}</Text>}
-                </View>
-            ) : (
-                <>{title && <Text variant="titleSmall">{title}</Text>}</>
-            )}
+            <Box flex={1} marginHorizontal="large" alignItems="center">
+                {activeStep && numberOfSteps ? (
+                    <View style={applyStyle(progressBarWrapperStyle)}>
+                        <StepsProgressBar numberOfSteps={numberOfSteps} activeStep={activeStep} />
+                        {title && <Text variant={titleVariant}>{title}</Text>}
+                    </View>
+                ) : (
+                    <Text variant={titleVariant} numberOfLines={1} ellipsizeMode="tail">
+                        {title}
+                    </Text>
+                )}
+            </Box>
 
             <View style={applyStyle(iconWrapperStyle)}>{rightIcon}</View>
         </View>

--- a/suite-native/transactions/src/components/TransactionDetail/TransactionDetailAddressesSection.tsx
+++ b/suite-native/transactions/src/components/TransactionDetail/TransactionDetailAddressesSection.tsx
@@ -27,7 +27,7 @@ const hiddenTransactionsCountStyle = prepareNativeStyle(utils => ({
 }));
 
 const addressTextStyle = prepareNativeStyle(_ => ({
-    maxWidth: 160,
+    maxWidth: '80%',
 }));
 
 const stepperDotWrapperStyle = prepareNativeStyle(utils => ({

--- a/suite-native/transactions/src/components/TransactionDetail/TransactionDetailHeader.tsx
+++ b/suite-native/transactions/src/components/TransactionDetail/TransactionDetailHeader.tsx
@@ -75,7 +75,6 @@ export const TransactionDetailHeader = ({ transaction }: TransactionDetailHeader
                     isBalance={false}
                     variant="titleMedium"
                     color="textDefault"
-                    signValue={signValueMap[transaction.type]}
                 />
             </Text>
             {transaction.rates && (

--- a/suite-native/transactions/src/components/TransactionDetail/TransactionDetailHeader.tsx
+++ b/suite-native/transactions/src/components/TransactionDetail/TransactionDetailHeader.tsx
@@ -67,7 +67,7 @@ export const TransactionDetailHeader = ({ transaction }: TransactionDetailHeader
                     />
                 )}
             </Box>
-            <Box flexDirection="row">
+            <Text variant="titleMedium" numberOfLines={1} adjustsFontSizeToFit>
                 <SignValueFormatter value={signValueMap[transaction.type]} variant="titleMedium" />
                 <CryptoAmountFormatter
                     value={transaction.amount}
@@ -75,8 +75,9 @@ export const TransactionDetailHeader = ({ transaction }: TransactionDetailHeader
                     isBalance={false}
                     variant="titleMedium"
                     color="textDefault"
+                    signValue={signValueMap[transaction.type]}
                 />
-            </Box>
+            </Text>
             {transaction.rates && (
                 <Box flexDirection="row">
                     <Text>≈ </Text>

--- a/suite-native/transactions/src/components/TransactionsList/TokenTransferListItem.tsx
+++ b/suite-native/transactions/src/components/TransactionsList/TokenTransferListItem.tsx
@@ -8,6 +8,7 @@ import {
 } from '@suite-native/formatters';
 
 import { TransactionListItemContainer } from './TransactionListItemContainer';
+import { signValueMap } from './TransactionListItem';
 
 type TokenTransferListItemProps = {
     txid: string;
@@ -34,6 +35,7 @@ export const TokenTransferListItem = memo(
                     value={tokenTransfer.amount}
                     ethereumToken={tokenSymbol}
                     decimals={tokenTransfer.decimals}
+                    signValue={signValueMap[tokenTransfer.type]}
                 />
                 <EthereumTokenAmountFormatter
                     value={tokenTransfer.amount}

--- a/suite-native/transactions/src/components/TransactionsList/TransactionListGroupTitle.tsx
+++ b/suite-native/transactions/src/components/TransactionsList/TransactionListGroupTitle.tsx
@@ -11,7 +11,7 @@ type TransactionListGroupProps = {
 
 const dateTextStyle = prepareNativeStyle(utils => ({
     marginVertical: utils.spacings.medium,
-    marginHorizontal: utils.spacings.large,
+    marginHorizontal: utils.spacings.medium,
 }));
 
 export const TransactionListGroupTitle = ({ monthKey }: TransactionListGroupProps) => {

--- a/suite-native/transactions/src/components/TransactionsList/TransactionListItemContainer.tsx
+++ b/suite-native/transactions/src/components/TransactionsList/TransactionListItemContainer.tsx
@@ -78,9 +78,16 @@ const transactionListItemContainerStyle = prepareNativeStyle<TransactionListItem
 );
 
 const descriptionBoxStyle = prepareNativeStyle(_ => ({
+    flex: 1,
     flexDirection: 'row',
     alignItems: 'center',
-    maxWidth: '60%',
+}));
+
+const valuesContainerStyle = prepareNativeStyle(utils => ({
+    flexShrink: 0,
+    alignItems: 'flex-end',
+    marginLeft: utils.spacings.small,
+    maxWidth: '40%',
 }));
 
 export const TransactionListItemContainer = memo(
@@ -127,7 +134,7 @@ export const TransactionListItemContainer = memo(
                         </Text>
                     </Box>
                 </Box>
-                <Box alignItems="flex-end">{children}</Box>
+                <Box style={applyStyle(valuesContainerStyle)}>{children}</Box>
             </TouchableOpacity>
         );
     },

--- a/yarn.lock
+++ b/yarn.lock
@@ -6790,6 +6790,7 @@ __metadata:
     "@trezor/styles": "workspace:*"
     bignumber.js: ^9.1.1
     react: 18.2.0
+    react-native: 0.71.5
     react-redux: 8.0.5
   languageName: unknown
   linkType: soft

--- a/yarn.lock
+++ b/yarn.lock
@@ -6787,6 +6787,7 @@ __metadata:
     "@suite-native/ethereum-tokens": "workspace:*"
     "@suite-native/module-settings": "workspace:*"
     "@trezor/blockchain-link": "workspace:*"
+    "@trezor/styles": "workspace:*"
     bignumber.js: ^9.1.1
     react: 18.2.0
     react-redux: 8.0.5


### PR DESCRIPTION
Batch of UI bug fixes:

- header amount values change the font size to always fit the screen (portfolio graph, asset detail graph, transaction detail)
- account and transaction lists adjust it's contents layout to always fit
- screen headers are tail cropped if too long
- shortened addresses android glitch fixed
- other minor UI improvements

## Related Issue

Resolve #6770 

## Screenshots:

### Header amount values change the font size to always fit the screen:

<div style="flex-direction: row">
<img width="250" alt="Screenshot 2023-03-07 at 8 49 27" src="https://user-images.githubusercontent.com/26143964/230608326-37b3a0a3-2246-4b53-bfdd-fd27047851d5.png">

<img width="250" alt="Screenshot 2023-03-07 at 8 49 27" src="https://user-images.githubusercontent.com/26143964/230608331-e43b9778-0536-4f1d-9544-0cbbafb3d7df.png">

<img width="250" alt="Screenshot 2023-03-07 at 8 49 27" src="https://user-images.githubusercontent.com/26143964/230608333-4f984611-7bca-49a6-890c-2e38a4fae6ee.png">
</div>

### Account and transaction lists adjust it's contents layout to always fit:

<div>
<img width="250" alt="Screenshot 2023-03-07 at 8 49 27" src="https://user-images.githubusercontent.com/26143964/230609174-84342455-15f3-453a-b1cb-2c721272c984.png">

</div>

### Screen headers are tail cropped if too long:
<div>
<img width="250" alt="Screenshot 2023-03-07 at 8 49 27" src="https://user-images.githubusercontent.com/26143964/230609486-d906dada-42f9-47ca-a0f2-48f95ccf9dfc.png"/>

<img width="250" alt="Screenshot 2023-03-07 at 8 49 27" src="https://user-images.githubusercontent.com/26143964/230609609-0d858aba-ec90-4f13-8aaf-cdbcaab8a153.png"/>
</div>

### Shortened addresses android glitch fixed:
<img width="250" alt="Screenshot 2023-03-07 at 8 49 27" src="https://user-images.githubusercontent.com/26143964/230609822-c8ea58f8-7b84-4ee7-bc47-f2f7ce5022f4.png"/>
