### PR TITLE
Non-blocking CJ discovery using Electron's `utilityProcess`

### DIFF
--- a/packages/suite-desktop/scripts/build.ts
+++ b/packages/suite-desktop/scripts/build.ts
@@ -36,6 +36,9 @@ const sentryRelease = `${suiteVersion}.${PROJECT}${
 const modulePath = path.join(source, 'modules');
 const modules = glob.sync(`${modulePath}/**/*.ts`).map(m => `modules${m.replace(modulePath, '')}`);
 
+const threadPath = path.join(source, 'threads');
+const threads = glob.sync(`${threadPath}/**/*.ts`).map(u => `threads${u.replace(threadPath, '')}`);
+
 // Prepare mock plugin with files from the mocks folder
 const mockPath = path.join(source, 'mocks');
 const mocks = glob
@@ -81,7 +84,7 @@ const electronExternalDependencies = [...dependencies, ...devDependencies];
 // TODO: maybe desktop-api could be built too?
 
 build({
-    entryPoints: ['app.ts', 'preload.ts', ...modules].map(f => path.join(source, f)),
+    entryPoints: ['app.ts', 'preload.ts', ...modules, ...threads].map(f => path.join(source, f)),
     platform: 'node',
     bundle: true,
     target: 'node18.12.1', // Electron 23

--- a/packages/suite-desktop/src/libs/thread-proxy.ts
+++ b/packages/suite-desktop/src/libs/thread-proxy.ts
@@ -1,0 +1,117 @@
+import path from 'path';
+import { EventEmitter } from 'events';
+import { UtilityProcess, utilityProcess } from 'electron';
+
+import { createDeferred, Deferred, promiseAllSequence } from '@trezor/utils';
+
+import { isValidThreadResponse, isValidThreadEvent, ThreadRequestType } from './thread';
+
+const THREADS_DIR_PATH = path.join(__dirname, '..', 'threads');
+
+type ThreadProxySettings = {
+    name: string;
+    keepAlive?: boolean;
+};
+
+export class ThreadProxy<_Target extends object> extends EventEmitter {
+    private readonly settings;
+    private utility: UtilityProcess | undefined;
+
+    get running() {
+        return !!this.utility;
+    }
+
+    constructor(settings: ThreadProxySettings) {
+        super();
+        this.settings = Object.freeze(settings);
+    }
+
+    async run(params: any): Promise<true> {
+        if (this.utility) throw new Error('Process already running');
+        const utilityPath = path.join(THREADS_DIR_PATH, `${this.settings.name}.js`);
+        const utility = utilityProcess.fork(utilityPath);
+        await new Promise((resolve, reject) => {
+            utility.once('spawn', resolve);
+            utility.once('exit', reject);
+        });
+        utility.once('exit', this.clean.bind(this));
+        utility.on('message', this.onMessage.bind(this));
+        this.utility = utility;
+        try {
+            await this.sendMessage('init', params);
+            await promiseAllSequence(
+                this.eventNames().map(event => () => this.sendMessage('subscribe', { event })),
+            );
+            if (this.settings.keepAlive) {
+                utility.removeAllListeners('exit');
+                utility.once('exit', () => {
+                    this.clean();
+                    return this.run(params);
+                });
+            }
+            return true;
+        } catch (e) {
+            this.utility.kill();
+            throw e;
+        }
+    }
+
+    dispose() {
+        this.emit('disposed');
+        super.removeAllListeners();
+        const { utility } = this;
+        utility?.removeAllListeners();
+        this.clean();
+        return utility?.kill() ?? false;
+    }
+
+    request(method: string, params: any[]) {
+        return this.sendMessage('call', { method, params });
+    }
+
+    on(event: string | symbol, listener: (...args: any[]) => void) {
+        super.on(event, listener);
+        this.sendMessage('subscribe', { event });
+        return this;
+    }
+
+    removeAllListeners(event?: string | symbol | undefined) {
+        super.removeAllListeners(event);
+        this.sendMessage('unsubscribe', { event });
+        return this;
+    }
+
+    private messageId = 0;
+    private readonly promises = new Map<number, Deferred<any>>();
+
+    private sendMessage(type: ThreadRequestType, payload?: any) {
+        if (!this.utility) throw new Error('Process not running');
+        const id = this.messageId++;
+        const dfd = createDeferred<any, number>(id);
+        this.promises.set(id, dfd);
+        this.utility.postMessage({ id, type, payload });
+        return dfd.promise;
+    }
+
+    private onMessage(message: any) {
+        if (isValidThreadResponse(message)) {
+            const promise = this.promises.get(message.id);
+            if (promise) {
+                this.promises.delete(message.id);
+                if (message.success) {
+                    promise.resolve(message.payload);
+                } else {
+                    promise.reject(new Error(message.error));
+                }
+            }
+        } else if (isValidThreadEvent(message)) {
+            this.emit(message.event, message.payload);
+        }
+    }
+
+    private clean() {
+        this.promises.forEach(({ reject }) => reject(new Error('Process exited')));
+        this.promises.clear();
+        this.utility = undefined;
+    }
+}

--- a/packages/suite-desktop/src/libs/thread.ts
+++ b/packages/suite-desktop/src/libs/thread.ts
@@ -1,0 +1,81 @@
+import { EventEmitter } from 'events';
+
+export type ThreadRequestType = 'init' | 'call' | 'subscribe' | 'unsubscribe';
+
+export type ThreadRequest = {
+    id: number;
+    type: ThreadRequestType;
+    payload: any;
+};
+
+export type ThreadResponse =
+    | {
+          id: number;
+          success: true;
+          payload: any;
+      }
+    | {
+          id: number;
+          success: false;
+          error: string;
+      };
+
+export type ThreadEvent = {
+    event: string;
+    payload?: any;
+};
+
+const isValidThreadRequest = (req: any): req is ThreadRequest =>
+    typeof req === 'object' && typeof req?.id === 'number' && typeof req.type === 'string';
+
+export const isValidThreadResponse = (res: any): res is ThreadResponse =>
+    typeof res === 'object' &&
+    typeof res?.id === 'number' &&
+    (res.success || typeof res.error === 'string');
+
+export const isValidThreadEvent = (ev: any): ev is ThreadEvent =>
+    typeof ev === 'object' && typeof ev?.event === 'string';
+
+const respond = (id: number, payload: any = undefined) =>
+    process.parentPort.postMessage({ id, payload, success: true });
+
+const fail = (id: number, error: string) =>
+    process.parentPort.postMessage({ id, error, success: false });
+
+const fire = (event: string, payload: any) => process.parentPort.postMessage({ event, payload });
+
+export const createThread = <P, T extends EventEmitter>(init: (params: P) => T | Promise<T>) => {
+    let obj: T;
+
+    process.parentPort.on('message', async ({ data }) => {
+        if (!isValidThreadRequest(data)) return;
+        try {
+            switch (data.type) {
+                case 'init':
+                    obj = await init(data.payload);
+                    return respond(data.id);
+                case 'call': {
+                    const { method, params } = data.payload;
+                    const result = await (obj as any)[method](...params);
+                    return respond(data.id, result);
+                }
+                case 'subscribe': {
+                    const { event } = data.payload;
+                    if (!obj.listenerCount(event)) {
+                        obj.on(event, payload => fire(event, payload));
+                    }
+                    return respond(data.id);
+                }
+                case 'unsubscribe': {
+                    const { event } = data.payload;
+                    obj.removeAllListeners(event);
+                    return respond(data.id);
+                }
+                default:
+                    break;
+            }
+        } catch (e) {
+            return fail(data.id, e.message);
+        }
+    });
+};

--- a/packages/suite-desktop/src/libs/thread.ts
+++ b/packages/suite-desktop/src/libs/thread.ts
@@ -44,6 +44,15 @@ const fail = (id: number, error: string) =>
 
 const fire = (event: string, payload: any) => process.parentPort.postMessage({ event, payload });
 
+/**
+ * Utility process helper. Use only in a file inside `suite-desktop/src/threads`.
+ *
+ * Creates event-emitter-like object in Electron's utility process and allows
+ * to communicate with it by `call`, `subscribe` and `unsubscribe` messages.
+ *
+ * @param init 'Constructor' function which will create the object from parameters
+ * received with `init` message
+ */
 export const createThread = <P, T extends EventEmitter>(init: (params: P) => T | Promise<T>) => {
     let obj: T;
 

--- a/packages/suite-desktop/src/threads/coinjoin-backend.ts
+++ b/packages/suite-desktop/src/threads/coinjoin-backend.ts
@@ -1,0 +1,7 @@
+import { CoinjoinBackend, CoinjoinBackendSettings } from '@trezor/coinjoin';
+
+import { createThread } from '../libs/thread';
+
+const init = (settings: CoinjoinBackendSettings) => new CoinjoinBackend(settings);
+
+createThread(init);

--- a/packages/suite-desktop/src/threads/coinjoin-backend.ts
+++ b/packages/suite-desktop/src/threads/coinjoin-backend.ts
@@ -1,7 +1,42 @@
+import { createInterceptor } from '@trezor/request-manager';
 import { CoinjoinBackend, CoinjoinBackendSettings } from '@trezor/coinjoin';
+import { isDevEnv } from '@suite-common/suite-utils';
 
 import { createThread } from '../libs/thread';
 
-const init = (settings: CoinjoinBackendSettings) => new CoinjoinBackend(settings);
+type BackgroundCoinjoinBackendSettings = CoinjoinBackendSettings & {
+    torSettings: TorSettings;
+};
+
+/**
+ * Extending CoinjoinBackend class is kind of ugly hack
+ * which nevertheless allows us to easily receive
+ * `setTorSettings` messages from main process using ThreadProxy
+ */
+class BackgroundCoinjoinBackend extends CoinjoinBackend {
+    torSettings;
+
+    constructor({ torSettings, ...settings }: BackgroundCoinjoinBackendSettings) {
+        super(settings);
+        this.torSettings = torSettings;
+    }
+
+    public setTorSettings(torSettings: TorSettings) {
+        this.torSettings = torSettings;
+    }
+}
+
+const init = (settings: BackgroundCoinjoinBackendSettings) => {
+    const backend = new BackgroundCoinjoinBackend(settings);
+
+    createInterceptor({
+        handler: () => {},
+        getTorSettings: () => backend.torSettings,
+        allowTorBypass: isDevEnv,
+        whitelistedHosts: ['127.0.0.1', 'localhost', '.sldev.cz'],
+    });
+
+    return backend;
+};
 
 createThread(init);


### PR DESCRIPTION
## Description
Implements general mechanism for running processes in the background threads (or [Electron utility processes](https://www.electronjs.org/docs/latest/api/utility-process)) and uses it for non-blocking CJ discovery. Seems to be working nicely, but careful testing is of course needed.

## What must be ensured
- that the app is responding as usual even during CJ discovery
- that CJ account syncing will not break even after intensive work + long time + multiple instances...
- that CJ discovery recovers even when the process is killed from outside
- that it works on all three platforms, dev + build + signed build, ...
- **that everything goes through Tor**

## Related
<strike>Merge after https://github.com/trezor/trezor-suite/pull/8271 (first three commits of this PR)</strike>