### PR TITLE
fix(suite): show a correct cj wheel state when some utxos have anonymity

### DIFF
--- a/packages/suite/src/reducers/wallet/coinjoinReducer.ts
+++ b/packages/suite/src/reducers/wallet/coinjoinReducer.ts
@@ -839,9 +839,10 @@ export const selectCoinjoinSessionBlockerByAccountKey = memoizeWithArgs(
 
 // memoise() was causing incorrect return from the selector
 export const selectCurrentCoinjoinWheelStates = (state: CoinjoinRootState) => {
-    const { anonymized, notAnonymized } = selectCurrentCoinjoinBalanceBreakdown(state);
+    const { notAnonymized } = selectCurrentCoinjoinBalanceBreakdown(state);
     const session = selectCurrentCoinjoinSession(state);
     const { key, balance } = selectSelectedAccount(state) || {};
+    const sessionProgress = selectSessionProgressByAccountKey(state, key || '');
 
     const coinjoinSessionBlocker = selectCoinjoinSessionBlockerByAccountKey(state, key || '');
 
@@ -854,7 +855,7 @@ export const selectCurrentCoinjoinWheelStates = (state: CoinjoinRootState) => {
 
     // account states
     const isAccountEmpty = !balance || balance === '0';
-    const isNonePrivate = anonymized === '0';
+    const isNonePrivate = sessionProgress === 0;
     const isAllPrivate = notAnonymized === '0';
     const isCoinjoinUneco = !!balance && new BigNumber(balance).lt(UNECONOMICAL_COINJOIN_THRESHOLD);
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

* show a correct Coinjoin wheel state when some UTXOs have anonymity

## Related Issue

Resolve [#7811](https://github.com/trezor/trezor-suite/issues/7811)

## Screenshots:

<img width="600" alt="image" src="https://user-images.githubusercontent.com/45338719/230646663-47a1b86e-87f8-4e0b-bd53-1513c7706813.png">

