### PR TITLE
chore(coinjoin): update jest@29.5.0

### DIFF
--- a/packages/coinjoin/jest.config.js
+++ b/packages/coinjoin/jest.config.js
@@ -1,5 +1,4 @@
 module.exports = {
     preset: '../../jest.config.base.js',
-    // waiting for jest update https://github.com/trezor/trezor-suite/issues/6025
-    // testEnvironment: 'node', ReferenceError: AbortController is not defined
+    testEnvironment: 'node',
 };

--- a/packages/coinjoin/package.json
+++ b/packages/coinjoin/package.json
@@ -22,7 +22,7 @@
     "types": "lib/index.d.ts",
     "scripts": {
         "lint": "eslint '**/*.{ts,js}'",
-        "test:unit": "jest",
+        "test:unit": "jest --version && jest",
         "test:discovery": "tsx ./tests/tools/discovery-test.ts",
         "test:anonymity": "tsx ./tests/tools/anonymity-test.ts",
         "type-check": "tsc --build",
@@ -41,7 +41,7 @@
         "n64": "^0.2.10"
     },
     "devDependencies": {
-        "jest": "^26.6.3",
+        "jest": "^29.5.0",
         "rimraf": "^4.4.1",
         "typescript": "4.9.5"
     }

--- a/yarn.lock
+++ b/yarn.lock
@@ -7538,7 +7538,7 @@ __metadata:
     cross-fetch: ^3.1.5
     events: ^3.3.0
     golomb: 1.2.0
-    jest: ^26.6.3
+    jest: ^29.5.0
     n64: ^0.2.10
     rimraf: ^4.4.1
     typescript: 4.9.5


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Update jest 29 in `@trezor/coinjoin` package

Minor fixes:
- async tests cannot use done callback
> Test functions cannot both take a 'done' callback and return something. Either use a 'done' callback, or return a promise.
- input-registration test fix
> Jest did not exit one second after the test run has completed.

Waiting for update of `@types/jest` to resolve ts-expect-error in code, related to https://github.com/trezor/trezor-suite/issues/6025
 