### PR TITLE
fix(suite-desktop): fix codesign app title

### DIFF
--- a/packages/suite-desktop/scripts/build.ts
+++ b/packages/suite-desktop/scripts/build.ts
@@ -98,7 +98,7 @@ build({
         'process.env.VERSION': JSON.stringify(suiteVersion),
         'process.env.SENTRY_RELEASE': JSON.stringify(sentryRelease),
         'process.env.SUITE_TYPE': JSON.stringify(PROJECT),
-        'process.env.IS_CODESIGN_BUILD': JSON.stringify(isCodesignBuild),
+        'process.env.IS_CODESIGN_BUILD': `"${isCodesignBuild}"`, // to keep it as string "true"/"false" and not boolean
     },
     inject: [path.join(__dirname, 'build-inject.ts')],
     plugins: useMocks ? [mockPlugin] : [],


### PR DESCRIPTION

## Description

It looks like esbuild define plugin works different than webpack DefinePlugin and boolean has to be wrapped in extra "" to keep it as string

## Related Issue

Resolve #8019

## Screenshots:
<img width="776" alt="image" src="https://user-images.githubusercontent.com/3729633/231227142-e0ab54fa-6e32-4271-aa35-f57ff5beaf4b.png">

