### PR TITLE
fix(mobile): rates are correctly fetched when currency is changed

### DIFF
--- a/suite-common/redux-utils/src/extraDependenciesType.ts
+++ b/suite-common/redux-utils/src/extraDependenciesType.ts
@@ -1,4 +1,4 @@
-import { ActionCreatorWithPreparedPayload } from '@reduxjs/toolkit';
+import { ActionCreatorWithPayload, ActionCreatorWithPreparedPayload } from '@reduxjs/toolkit';
 
 import { Account, FeeInfo } from '@suite-common/wallet-types';
 import { NetworkSymbol } from '@suite-common/wallet-config';
@@ -41,12 +41,16 @@ export type ExtraDependencies = {
     actions: {
         setAccountLoadedMetadata: ActionCreatorWithPreparedPayload<[payload: Account], Account>;
         setAccountAddMetadata: ActionCreatorWithPreparedPayload<[payload: Account], Account>;
-        setWalletSettingsLocalCurrency: ActionCreatorWithPreparedPayload<
-            [localCurrency: FiatCurrencyCode],
-            {
-                localCurrency: FiatCurrencyCode;
-            }
-        >;
+        setWalletSettingsLocalCurrency:
+            | ActionCreatorWithPreparedPayload<
+                  [localCurrency: FiatCurrencyCode],
+                  {
+                      localCurrency: FiatCurrencyCode;
+                  }
+              >
+            | ActionCreatorWithPayload<{
+                  localCurrency: FiatCurrencyCode;
+              }>;
         changeWalletSettingsNetworks: ActionCreatorWithPreparedPayload<
             [payload: NetworkSymbol[]],
             NetworkSymbol[]

--- a/suite-native/app/src/initActions.ts
+++ b/suite-native/app/src/initActions.ts
@@ -7,30 +7,39 @@ import { initAnalyticsThunk } from '@suite-native/analytics';
 import { periodicFetchFiatRatesThunk } from '@suite-native/fiat-rates';
 
 import { setIsAppReady, setIsConnectInitialized } from '../../state/src/appSlice';
+import { selectFiatCurrencyCode } from '@suite-native/module-settings';
 
 let isAlreadyInitialized = false;
 
-export const applicationInit = createThunk(`@app/init-actions`, async (_, { dispatch }) => {
-    if (isAlreadyInitialized) {
-        return;
-    }
+export const applicationInit = createThunk(
+    `@app/init-actions`,
+    async (_, { dispatch, getState }) => {
+        if (isAlreadyInitialized) {
+            return;
+        }
 
-    try {
-        dispatch(initAnalyticsThunk());
+        try {
+            dispatch(initAnalyticsThunk());
 
-        await dispatch(connectInitThunk()).unwrap();
+            await dispatch(connectInitThunk()).unwrap();
 
-        dispatch(setIsConnectInitialized(true));
+            dispatch(setIsConnectInitialized(true));
 
-        dispatch(initBlockchainThunk()).unwrap();
+            dispatch(initBlockchainThunk()).unwrap();
 
-        dispatch(periodicFetchFiatRatesThunk({ rateType: 'current' }));
-    } catch (error) {
-        Alert.alert('Error', error?.message ?? 'Unknown error');
-        console.error(error.message);
-    } finally {
-        // Tell the application to render
-        dispatch(setIsAppReady(true));
-        isAlreadyInitialized = true;
-    }
-});
+            dispatch(
+                periodicFetchFiatRatesThunk({
+                    rateType: 'current',
+                    localCurrency: selectFiatCurrencyCode(getState()),
+                }),
+            );
+        } catch (error) {
+            Alert.alert('Error', error?.message ?? 'Unknown error');
+            console.error(error.message);
+        } finally {
+            // Tell the application to render
+            dispatch(setIsAppReady(true));
+            isAlreadyInitialized = true;
+        }
+    },
+);

--- a/suite-native/fiat-rates/src/fiatRatesMiddleware.ts
+++ b/suite-native/fiat-rates/src/fiatRatesMiddleware.ts
@@ -15,7 +15,12 @@ export const prepareFiatRatesMiddleware = createMiddlewareWithExtraDeps(
         } = extra;
 
         if (isAnyOf(accountsActions.updateAccount, accountsActions.createAccount)(action)) {
-            dispatch(fetchFiatRatesThunk({ rateType: 'current' }));
+            dispatch(
+                fetchFiatRatesThunk({
+                    rateType: 'current',
+                    localCurrency: selectLocalCurrency(getState()),
+                }),
+            );
             // dispatch(fetchFiatRatesThunk({ rateType: 'lastWeek' }));
         }
 
@@ -32,15 +37,22 @@ export const prepareFiatRatesMiddleware = createMiddlewareWithExtraDeps(
         }
 
         if (setWalletSettingsLocalCurrency.match(action)) {
-            dispatch(fetchFiatRatesThunk({ rateType: 'lastWeek' }));
-            // dispatch(fetchFiatRatesThunk({ rateType: 'current' }));
+            const { localCurrency } = action.payload;
+            // dispatch(fetchFiatRatesThunk({ rateType: 'lastWeek' }));
+            // We need to pass localCurrency as a parameter, because it is not yet updated in the store
+            dispatch(fetchFiatRatesThunk({ rateType: 'current', localCurrency }));
         }
 
         if (blockchainActions.connected.match(action)) {
             // TODO: verify if this is necessary, it should work only based on addTransaction action
             // just to be safe, refetch historical rates for transactions stored without these rates
             // dispatch(updateMissingTxFiatRatesThunk());
-            dispatch(fetchFiatRatesThunk({ rateType: 'current' }));
+            dispatch(
+                fetchFiatRatesThunk({
+                    rateType: 'current',
+                    localCurrency: selectLocalCurrency(getState()),
+                }),
+            );
         }
 
         return next(action);

--- a/suite-native/fiat-rates/src/fiatRatesReducer.ts
+++ b/suite-native/fiat-rates/src/fiatRatesReducer.ts
@@ -14,8 +14,8 @@ export const prepareFiatRatesReducer = createReducerWithExtraDeps(
     (builder, extra) => {
         builder
             .addCase(updateFiatRatesThunk.pending, (state, action) => {
-                const { ticker, fiatCurrency, rateType = 'current' } = action.meta.arg;
-                const fiatRateKey = getFiatRateKeyFromTicker(ticker, fiatCurrency);
+                const { ticker, localCurrency, rateType = 'current' } = action.meta.arg;
+                const fiatRateKey = getFiatRateKeyFromTicker(ticker, localCurrency);
                 let currentRate = state[rateType]?.[fiatRateKey];
 
                 if (currentRate) {
@@ -30,7 +30,7 @@ export const prepareFiatRatesReducer = createReducerWithExtraDeps(
                         isLoading: true,
                         error: null,
                         ticker,
-                        locale: fiatCurrency,
+                        locale: localCurrency,
                     };
                 }
                 state[rateType][fiatRateKey] = currentRate;
@@ -38,8 +38,8 @@ export const prepareFiatRatesReducer = createReducerWithExtraDeps(
             .addCase(updateFiatRatesThunk.fulfilled, (state, action) => {
                 if (!action.payload) return;
 
-                const { ticker, fiatCurrency, rateType = 'current' } = action.meta.arg;
-                const fiatRateKey = getFiatRateKeyFromTicker(ticker, fiatCurrency);
+                const { ticker, localCurrency, rateType = 'current' } = action.meta.arg;
+                const fiatRateKey = getFiatRateKeyFromTicker(ticker, localCurrency);
 
                 const currentRate = state[rateType]?.[fiatRateKey];
 
@@ -55,8 +55,8 @@ export const prepareFiatRatesReducer = createReducerWithExtraDeps(
                 };
             })
             .addCase(updateFiatRatesThunk.rejected, (state, action) => {
-                const { ticker, fiatCurrency, rateType = 'current' } = action.meta.arg;
-                const fiatRateKey = getFiatRateKeyFromTicker(ticker, fiatCurrency);
+                const { ticker, localCurrency, rateType = 'current' } = action.meta.arg;
+                const fiatRateKey = getFiatRateKeyFromTicker(ticker, localCurrency);
                 const currentRate = state[rateType]?.[fiatRateKey];
 
                 // To prevent race condition someone will remove rate from state while fetching for example (during currency change etc.)
@@ -66,7 +66,7 @@ export const prepareFiatRatesReducer = createReducerWithExtraDeps(
                     ...currentRate,
                     isLoading: false,
                     error: action.error.message || `Failed to update ${ticker.symbol} fiat rate.`,
-                    locale: fiatCurrency,
+                    locale: localCurrency,
                 };
             })
             // TODO: migration for desktop?

--- a/suite-native/module-accounts-import/src/screens/AccountImportLoadingScreen.tsx
+++ b/suite-native/module-accounts-import/src/screens/AccountImportLoadingScreen.tsx
@@ -65,7 +65,7 @@ export const AccountImportLoadingScreen = ({
                             symbol: networkSymbol,
                         },
                         rateType: 'current',
-                        fiatCurrency,
+                        localCurrency: fiatCurrency,
                     }),
                 ),
             ]);
@@ -83,7 +83,7 @@ export const AccountImportLoadingScreen = ({
                                         tokenAddress: token.address as TokenAddress,
                                     },
                                     rateType: 'current',
-                                    fiatCurrency,
+                                    localCurrency: fiatCurrency,
                                 }),
                             );
                         });

--- a/suite-native/module-settings/src/components/CurrencySelector.tsx
+++ b/suite-native/module-settings/src/components/CurrencySelector.tsx
@@ -17,8 +17,8 @@ export const CurrencySelector = () => {
     const selectedFiatCurrency = useSelector(selectFiatCurrency);
     const dispatch = useDispatch();
 
-    const handleSelectCurrency = (value: FiatCurrencyCode) => {
-        dispatch(setFiatCurrency(value));
+    const handleSelectCurrency = (localCurrency: FiatCurrencyCode) => {
+        dispatch(setFiatCurrency({ localCurrency }));
     };
 
     return (

--- a/suite-native/module-settings/src/slice.ts
+++ b/suite-native/module-settings/src/slice.ts
@@ -32,8 +32,11 @@ export const appSettingsSlice = createSlice({
     name: 'appSettings',
     initialState: appSettingsInitialState,
     reducers: {
-        setFiatCurrency: (state, { payload }: PayloadAction<FiatCurrencyCode>) => {
-            state.fiatCurrency = fiatCurrencies[payload];
+        setFiatCurrency: (
+            state,
+            { payload: { localCurrency } }: PayloadAction<{ localCurrency: FiatCurrencyCode }>,
+        ) => {
+            state.fiatCurrency = fiatCurrencies[localCurrency];
         },
         setIsOnboardingFinished: state => {
             state.isOnboardingFinished = true;

--- a/suite-native/state/src/extraDependencies.ts
+++ b/suite-native/state/src/extraDependencies.ts
@@ -2,7 +2,7 @@ import { ExtraDependencies } from '@suite-common/redux-utils';
 import { extraDependenciesMock } from '@suite-common/test-utils';
 import { enabledNetworks } from '@suite-native/config';
 import { selectDevices } from '@suite-native/module-devices';
-import { selectFiatCurrencyCode } from '@suite-native/module-settings';
+import { selectFiatCurrencyCode, setFiatCurrency } from '@suite-native/module-settings';
 import { PROTO } from '@trezor/connect';
 import { mergeDeepObject } from '@trezor/utils';
 
@@ -14,7 +14,9 @@ export const extraDependencies: ExtraDependencies = mergeDeepObject(extraDepende
         selectDevices,
     } as Partial<ExtraDependencies['selectors']>,
     thunks: {} as Partial<ExtraDependencies['thunks']>,
-    actions: {} as Partial<ExtraDependencies['actions']>,
+    actions: {
+        setWalletSettingsLocalCurrency: setFiatCurrency,
+    } as Partial<ExtraDependencies['actions']>,
     actionTypes: {} as Partial<ExtraDependencies['actionTypes']>,
     reducers: {} as Partial<ExtraDependencies['reducers']>,
     utils: {} as Partial<ExtraDependencies['utils']>,


### PR DESCRIPTION
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at a13ee18</samp>

Refactored the native suite to use the user's local currency for fetching and updating fiat rates, instead of a default one. Updated the types and formats of the `setFiatCurrency` action creator and its related components and thunks. Renamed `fiatCurrency` to `localCurrency` in various places for clarity and consistency.