### PR TITLE
test(connect-popup): fix e2e test for 2.6.0

### DIFF
--- a/packages/connect-popup/e2e/tests/unchained.test.ts
+++ b/packages/connect-popup/e2e/tests/unchained.test.ts
@@ -91,9 +91,28 @@ const signTransaction = async (page: Page, iteration: number) => {
     await popup.waitForSelector('//p[contains(., "Check recipient")]', {
         state: 'visible',
         timeout: 40000,
+        strict: false,
     });
-    await TrezorUserEnvLink.send({ type: 'emulator-press-yes' });
-    await TrezorUserEnvLink.send({ type: 'emulator-press-yes' });
+    let confirmOnTrezorScreenStilVisible = true;
+    while (confirmOnTrezorScreenStilVisible) {
+        try {
+            await popup.waitForSelector('//p[contains(., "Check recipient")]', {
+                state: 'visible',
+                timeout: 501,
+                strict: false,
+            });
+            await TrezorUserEnvLink.send({ type: 'emulator-press-yes' });
+            await popup.waitForTimeout(501);
+        } catch (err) {
+            confirmOnTrezorScreenStilVisible = false;
+        }
+    }
+
+    await popup.waitForSelector('//p[contains(., "Follow instructions on your device")]', {
+        state: 'visible',
+        timeout: 501,
+        strict: false,
+    });
     await TrezorUserEnvLink.send({ type: 'emulator-press-yes' });
     await assertSuccess(page);
 };
@@ -123,7 +142,7 @@ test.beforeEach(async () => {
  * 4. execute all 19 tests
  */
 test('Verify unchained test suite', async ({ browser }) => {
-    test.slow();
+    test.setTimeout(1000 * 60 * 3);
 
     const context = await browser.newContext({
         userAgent:


### PR DESCRIPTION
this should fix faling e2e test. it was caused by changed number of button requests in 2.6.0 fw. this change should make the test independend of number of button requests for easier maintanance in the future. 