### PR TITLE
fix(suite-data): downgrade bridge binaries for mac to 2.0.27 [DO NOT MERGE]

### DIFF
--- a/packages/suite-data/files/bin/bridge/mac-arm64/trezord
+++ b/packages/suite-data/files/bin/bridge/mac-arm64/trezord
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:e133b5cbc86cb6acfe0e822d9c93af71eb26236cab40d59e3be27579d5363ed9
-size 7846690
+oid sha256:b6b726b49e85f299d91ce86c8398d78ab74b1526c5779b3fea0c518eff8bb701
+size 9697284

--- a/packages/suite-data/files/bin/bridge/mac-x64/trezord
+++ b/packages/suite-data/files/bin/bridge/mac-x64/trezord
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:6dd4f9892aaf3667bb014eab8e0b529e541c06874dea501ca7ee5f1f187fa588
-size 8165240
+oid sha256:b6b726b49e85f299d91ce86c8398d78ab74b1526c5779b3fea0c518eff8bb701
+size 9697284


### PR DESCRIPTION
Do not merge this, we should consider doing just [RELEASE ONLY] commit on release branch as it is a temporary workaround.
 
## Description

As a workaround for issue with latest macOS 13.3 bridge show 1 device as 2 devices.



## Related Issue

Resolve https://github.com/trezor/trezor-suite/issues/8012

## Screenshots:
<img width="533" alt="image" src="https://user-images.githubusercontent.com/3729633/231468376-3598421d-8792-4f8e-8e90-2533d772fcb5.png">

