### PR TITLE
Fix/android navbar

### DIFF
--- a/suite-native/app/package.json
+++ b/suite-native/app/package.json
@@ -72,6 +72,7 @@
         "expo-barcode-scanner": "^12.3.1",
         "expo-clipboard": "^4.1.1",
         "expo-localization": "^14.1.1",
+        "expo-navigation-bar": "^2.1.1",
         "expo-random": "^13.1.1",
         "expo-secure-store": "^12.1.1",
         "expo-splash-screen": "0.18.1",

--- a/suite-native/atoms/src/Sheet/BottomSheetContainer.tsx
+++ b/suite-native/atoms/src/Sheet/BottomSheetContainer.tsx
@@ -1,12 +1,16 @@
 import React, { ReactNode } from 'react';
-import { Modal as RNModal } from 'react-native';
+import { KeyboardAvoidingView, Modal as RNModal, Platform } from 'react-native';
 import { gestureHandlerRootHOC } from 'react-native-gesture-handler';
+
+import { prepareNativeStyle, useNativeStyles } from '@trezor/styles';
 
 type SheetProps = {
     children: ReactNode;
     isVisible: boolean;
     onClose: () => void;
 };
+
+const ContentWrapperStyle = prepareNativeStyle(_ => ({ flex: 1 }));
 
 /**
  * On Android RNGH does not work by default because modals are not located under React Native Root view in native hierarchy.
@@ -18,8 +22,18 @@ const BottomSheetGestureHandler = gestureHandlerRootHOC<{ children: ReactNode }>
     <>{children}</>
 ));
 
-export const BottomSheetContainer = ({ children, isVisible, onClose }: SheetProps) => (
-    <RNModal transparent visible={isVisible} onRequestClose={onClose}>
-        <BottomSheetGestureHandler>{children}</BottomSheetGestureHandler>
-    </RNModal>
-);
+export const BottomSheetContainer = ({ children, isVisible, onClose }: SheetProps) => {
+    const { applyStyle } = useNativeStyles();
+    return (
+        <RNModal transparent visible={isVisible} onRequestClose={onClose}>
+            <BottomSheetGestureHandler>
+                <KeyboardAvoidingView
+                    behavior={Platform.OS === 'ios' ? 'padding' : 'height'}
+                    style={applyStyle(ContentWrapperStyle)}
+                >
+                    {children}
+                </KeyboardAvoidingView>
+            </BottomSheetGestureHandler>
+        </RNModal>
+    );
+};

--- a/suite-native/atoms/src/Sheet/useBottomSheetAnimation.ts
+++ b/suite-native/atoms/src/Sheet/useBottomSheetAnimation.ts
@@ -6,7 +6,6 @@ import {
     useAnimatedStyle,
     useSharedValue,
     withTiming,
-    useAnimatedKeyboard,
 } from 'react-native-reanimated';
 import { useCallback, useEffect } from 'react';
 import { PanGestureHandlerGestureEvent } from 'react-native-gesture-handler';
@@ -38,7 +37,6 @@ export const useBottomSheetAnimation = ({
     const colorOverlay = utils.transparentize(0.3, utils.colors.backgroundNeutralBold);
     const translatePanY = useSharedValue(SCREEN_HEIGHT);
     const animatedTransparency = useSharedValue(transparency);
-    const keyboard = useAnimatedKeyboard();
 
     useEffect(() => {
         animatedTransparency.value = withTiming(transparency, {
@@ -61,7 +59,7 @@ export const useBottomSheetAnimation = ({
     const animatedSheetWrapperStyle = useAnimatedStyle(() => ({
         transform: [
             {
-                translateY: translatePanY.value - keyboard.height.value,
+                translateY: translatePanY.value,
             },
         ],
     }));

--- a/suite-native/navigation/package.json
+++ b/suite-native/navigation/package.json
@@ -22,6 +22,7 @@
         "@trezor/icons": "workspace:*",
         "@trezor/styles": "workspace:*",
         "@trezor/theme": "workspace:*",
+        "expo-navigation-bar": "^2.1.1",
         "expo-system-ui": "2.2.1",
         "react": "18.2.0",
         "react-native": "0.71.5",

--- a/suite-native/navigation/src/components/Screen.tsx
+++ b/suite-native/navigation/src/components/Screen.tsx
@@ -1,8 +1,9 @@
 import React, { ReactNode, useEffect, useContext } from 'react';
-import { StatusBar, View } from 'react-native';
+import { Platform, StatusBar, View } from 'react-native';
 import { useSafeAreaInsets, EdgeInsets } from 'react-native-safe-area-context';
 
 import * as SystemUI from 'expo-system-ui';
+import * as NavigationBar from 'expo-navigation-bar';
 import { BottomTabBarHeightContext } from '@react-navigation/bottom-tabs';
 
 import { prepareNativeStyle, useNativeStyles } from '@trezor/styles';
@@ -72,7 +73,12 @@ export const Screen = ({
     useEffect(() => {
         // this prevents some weird flashing of splash screen on Android during screen transitions
         SystemUI.setBackgroundColorAsync(backgroundCSSColor);
-    }, [backgroundCSSColor]);
+
+        if (Platform.OS === 'android') {
+            NavigationBar.setBackgroundColorAsync(backgroundCSSColor);
+            NavigationBar.setButtonStyleAsync(isDarkColor(backgroundCSSColor) ? 'light' : 'dark');
+        }
+    }, [backgroundCSSColor, isDarkColor]);
 
     return (
         <View

--- a/suite-native/navigation/src/components/TabBar.tsx
+++ b/suite-native/navigation/src/components/TabBar.tsx
@@ -12,29 +12,35 @@ import { TabsOptions } from '../types';
 interface TabBarProps extends BottomTabBarProps {
     tabItemOptions: TabsOptions;
 }
-
-export const TAB_BAR_HEIGHT = 86;
-const tabBarStyle = prepareNativeStyle<{ insetLeft: number; insetRight: number }>(
-    (utils, { insetLeft, insetRight }) => ({
-        height: TAB_BAR_HEIGHT,
-        width: '100%',
-        backgroundColor: utils.colors.backgroundSurfaceElevation0,
-        borderTopColor: utils.colors.borderOnElevation0,
-        borderTopWidth: utils.borders.widths.small,
-        flexDirection: 'row',
-        justifyContent: 'space-between',
-        alignItems: 'flex-start',
-        paddingLeft: Math.max(insetLeft, 20),
-        paddingRight: Math.max(insetRight, 20),
-    }),
-);
+const tabBarStyle = prepareNativeStyle<{
+    insetLeft: number;
+    insetRight: number;
+    insetsBottom: number;
+}>((utils, { insetLeft, insetRight, insetsBottom }) => ({
+    width: '100%',
+    backgroundColor: utils.colors.backgroundSurfaceElevation0,
+    borderTopColor: utils.colors.borderOnElevation0,
+    borderTopWidth: utils.borders.widths.small,
+    flexDirection: 'row',
+    justifyContent: 'space-between',
+    alignItems: 'flex-start',
+    paddingLeft: Math.max(insetLeft, 20),
+    paddingRight: Math.max(insetRight, 20),
+    paddingBottom: insetsBottom,
+}));
 
 export const TabBar = ({ state, navigation, tabItemOptions }: TabBarProps) => {
     const { applyStyle } = useNativeStyles();
     const insets = useSafeAreaInsets();
 
     return (
-        <Box style={applyStyle(tabBarStyle, { insetLeft: insets.left, insetRight: insets.right })}>
+        <Box
+            style={applyStyle(tabBarStyle, {
+                insetLeft: insets.left,
+                insetRight: insets.right,
+                insetsBottom: insets.bottom,
+            })}
+        >
             {state.routes.map((route, index) => {
                 const isFocused = state.index === index;
                 const { routeName, iconName, label, params } = tabItemOptions[route.name];

--- a/suite-native/navigation/src/components/TabBarItem.tsx
+++ b/suite-native/navigation/src/components/TabBarItem.tsx
@@ -14,14 +14,14 @@ type TabBarItemProps = {
 
 const tabBarItemStyle = prepareNativeStyle(_ => ({
     flex: 1,
-    marginTop: 11,
     alignItems: 'center',
     justifyContent: 'center',
 }));
 
-const tabBarItemContainerStyle = prepareNativeStyle(_ => ({
+const tabBarItemContainerStyle = prepareNativeStyle(utils => ({
     justifyContent: 'center',
     alignItems: 'center',
+    paddingTop: utils.spacings.small,
 }));
 
 const TAB_BAR_ITEM_HORIZONTAL_HIT_SLOP = 15;

--- a/yarn.lock
+++ b/yarn.lock
@@ -7145,6 +7145,7 @@ __metadata:
     "@trezor/icons": "workspace:*"
     "@trezor/styles": "workspace:*"
     "@trezor/theme": "workspace:*"
+    expo-navigation-bar: ^2.1.1
     expo-system-ui: 2.2.1
     react: 18.2.0
     react-native: 0.71.5
@@ -8182,6 +8183,7 @@ __metadata:
     expo-barcode-scanner: ^12.3.1
     expo-clipboard: ^4.1.1
     expo-localization: ^14.1.1
+    expo-navigation-bar: ^2.1.1
     expo-random: ^13.1.1
     expo-secure-store: ^12.1.1
     expo-splash-screen: 0.18.1
@@ -17339,6 +17341,18 @@ __metadata:
     compare-versions: ^3.4.0
     invariant: ^2.2.4
   checksum: 7f0e18c33151dced735e30513b62b389211dc6c8e734fbbb2625427733dd76a53594fda792569778ce07493255657e0106c2d51b11407c474146b4e44ab582cc
+  languageName: node
+  linkType: hard
+
+"expo-navigation-bar@npm:^2.1.1":
+  version: 2.1.1
+  resolution: "expo-navigation-bar@npm:2.1.1"
+  dependencies:
+    "@react-native/normalize-color": ^2.0.0
+    debug: ^4.3.2
+  peerDependencies:
+    expo: "*"
+  checksum: 5b58145c28816523dc1bcb9413352718e75fdd4b5af30d0ac0d0a7c99a2dacfbbfaf6ed64a6f037621692fc1db817b19a00fc0d80b6b95a2da816cc327f2e26e
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Description
- android navigation resize bug fixed
  -  BottomSheet was using `useAnimatedKeyboard` hook which is only [experimental for Android](https://www.reanimated2.com/docs/next/api/hooks/useAnimatedKeyboard). This hook was removed and used KeyboardAvoidingView instead.
- bottom tab bar made responsive and  centered
- android bottom navigation bar changes color according to app color theme
## Related Issue

Resolve #8065 

## Screenshots:
### before:
![image](https://user-images.githubusercontent.com/26143964/231737478-e5de3396-d93f-4d0c-b927-d24847e8fed3.png)
### after:

![Snímek obrazovky 2023-04-13 v 12 57 16](https://user-images.githubusercontent.com/26143964/231738247-4656e11b-cb9a-407c-b884-851e25641eca.png)

