### PR TITLE
test(connect): legacy results for eth get address fixtures

### DIFF
--- a/packages/connect/e2e/__fixtures__/ethereumGetAddress.ts
+++ b/packages/connect/e2e/__fixtures__/ethereumGetAddress.ts
@@ -8,6 +8,18 @@ const legacyResults = {
             success: false,
         },
     ],
+    GoChain: [
+        {
+            rules: ['>2.5.3'],
+            success: false, // Forbidden key path
+        },
+    ],
+    Wanchain: [
+        {
+            rules: ['>2.5.3'],
+            success: false, // Forbidden key path
+        },
+    ],
 };
 
 export default {

--- a/packages/connect/e2e/jest.setup.js
+++ b/packages/connect/e2e/jest.setup.js
@@ -1,6 +1,6 @@
 const { TX_CACHE } = require('./__txcache__');
 
-jest.setTimeout(20000);
+jest.setTimeout(30000);
 
 // Always mock blockchain-link worker unless it's explicitly required not to.
 if (process.env.TESTS_USE_WS_CACHE === 'true') {

--- a/packages/connect/e2e/karma.setup.js
+++ b/packages/connect/e2e/karma.setup.js
@@ -1,4 +1,4 @@
-jasmine.DEFAULT_TIMEOUT_INTERVAL = 20000;
+jasmine.DEFAULT_TIMEOUT_INTERVAL = 30000;
 
 // jest vs jasmine matchers compatibility:
 // - jasmine is missing "toMatchObject" matcher (deeply partial matching)


### PR DESCRIPTION
[test(connect): legacy results for eth get address fixtures](https://github.com/trezor/trezor-suite/pull/8091/commits/9f9745f6a3a09896e478143e5b89a6011ebd694e) adapting fixtures for 2.6.0 firmware, see more here. https://satoshilabs.slack.com/archives/CL1D61PQF/p1681397070918599 we should not forget implementing sending definitions also for EthereumGetAddress. cc @karliatto 
[test(connect): increase timeout to 30000](https://github.com/trezor/trezor-suite/pull/8091/commits/b915c6f32e84087c10839dd78427fc524f343294) some of the tests take very [close to 20seconds which is the limit](https://gitlab.com/satoshilabs/trezor/trezor-suite/-/jobs/3926708440#L2819) so I suggest increasing default timeout to 30 seconds. The only disadvantage is that if there is some fatal problem that causes tests to timeout, entire job will take longer, but on the other hand we should be safe from occasional failures due to reaching current timeout.
