### PR TITLE
ci: disable failing unchained test

### DIFF
--- a/ci/test.yml
+++ b/ci/test.yml
@@ -224,7 +224,8 @@ transport manual:
     matrix:
       - TEST_FILE: ["methods"]
       - TEST_FILE: ["popup-close"]
-      - TEST_FILE: ["unchained"]
+      # unchained test is failing, should be debugged outside of main pipeline and re-enabled again
+      # - TEST_FILE: ["unchained"]
       - TEST_FILE: ["browser-support"]
 
 connect-popup:


### PR DESCRIPTION
this works for me locally but for some reason not in CI. also it is quite hard to debug since trace.zip is about 8mbs and playwright trace-viewer has problem visualizing it. somebody should find a way around this. for me it does not make sense to have a failing test in the pipeline for couple of months which has been reality now. 