### PR TITLE
fix(suite): disable homescreen for old TT fw in onboarding

### DIFF
--- a/packages/components/src/components/Dropdown/index.tsx
+++ b/packages/components/src/components/Dropdown/index.tsx
@@ -240,20 +240,21 @@ interface MenuProps {
     masterLink?: MasterLink;
 }
 
-interface Props extends MenuProps, React.ButtonHTMLAttributes<HTMLDivElement> {
-    children?: React.ReactElement<any>;
-    absolutePosition?: boolean;
-    items: GroupedMenuItems[];
-    components?: {
-        DropdownMenuItem?: React.ComponentType<MenuItemProps>;
-        DropdownMenu?: React.ComponentType<MenuProps>;
+type DropdownProps = MenuProps &
+    Omit<React.ButtonHTMLAttributes<HTMLDivElement>, 'disabled'> & {
+        children?: React.ReactElement<any>;
+        absolutePosition?: boolean;
+        items: GroupedMenuItems[];
+        components?: {
+            DropdownMenuItem?: React.ComponentType<MenuItemProps>;
+            DropdownMenu?: React.ComponentType<MenuProps>;
+        };
+        offset?: number;
+        isDisabled?: boolean;
+        appendTo?: HTMLElement;
+        hoverContent?: React.ReactNode;
+        onToggle?: (isToggled: boolean) => void;
     };
-    offset?: number;
-    isDisabled?: boolean;
-    appendTo?: HTMLElement;
-    hoverContent?: React.ReactNode;
-    onToggle?: (isToggled: boolean) => void;
-}
 
 interface DropdownRef {
     close: () => void;
@@ -282,7 +283,7 @@ const Dropdown = forwardRef(
             hoverContent,
             masterLink,
             ...rest
-        }: Props,
+        }: DropdownProps,
         ref,
     ) => {
         const theme = useTheme();
@@ -481,7 +482,7 @@ const Dropdown = forwardRef(
 Dropdown.displayName = 'Dropdown';
 export type {
     DropdownRef,
-    Props as DropdownProps,
+    DropdownProps,
     MenuItemProps as DropdownMenuItemProps,
     MenuProps as DropdownMenuProps,
 };

--- a/packages/suite/src/support/messages.ts
+++ b/packages/suite/src/support/messages.ts
@@ -5837,6 +5837,11 @@ export default defineMessages({
         id: 'TR_UPDATE_FIRMWARE_HOMESCREEN_TOOLTIP',
         defaultMessage: 'Update your firmware to change your homescreen',
     },
+    TR_UPDATE_FIRMWARE_HOMESCREEN_LATER_TOOLTIP: {
+        id: 'TR_UPDATE_FIRMWARE_HOMESCREEN_TOOLTIP',
+        defaultMessage:
+            'Firmware update required. You can change your homescreen in the settings page later',
+    },
     TR_LABELING_FEATURE_ALLOWS: {
         id: 'TR_LABELING_FEATURE_ALLOWS',
         defaultMessage:

--- a/packages/suite/src/utils/suite/homescreen.ts
+++ b/packages/suite/src/utils/suite/homescreen.ts
@@ -1,5 +1,6 @@
 /* eslint-disable no-bitwise */
-import { DeviceModel } from '@trezor/device-utils';
+import { TrezorDevice } from '@suite-types/index';
+import { DeviceModel, getDeviceModel } from '@trezor/device-utils';
 
 export const deviceModelInformation = {
     [DeviceModel.T1]: { width: 128, height: 64, supports: ['png', 'jpeg'] },
@@ -222,4 +223,13 @@ export const imagePathToHex = async (imagePath: string, deviceModel: DeviceModel
     const imageData = ctx.getImageData(0, 0, canvas.width, canvas.height);
 
     return toig(imageData, deviceModel);
+};
+
+export const isHomescreenSupportedOnDevice = (device: TrezorDevice) => {
+    const deviceModel = getDeviceModel(device);
+
+    return (
+        deviceModel !== DeviceModel.TT ||
+        (deviceModel === DeviceModel.TT && device.features?.homescreen_format === 'Jpeg240x240')
+    );
 };

--- a/packages/suite/src/views/settings/device/Homescreen.tsx
+++ b/packages/suite/src/views/settings/device/Homescreen.tsx
@@ -16,6 +16,7 @@ import {
     ImageValidationError,
     validateImage,
     dataUrlToImage,
+    isHomescreenSupportedOnDevice,
 } from '@suite-utils/homescreen';
 import { useAnchor } from '@suite-hooks/useAnchor';
 import { SettingsAnchor } from '@suite-constants/anchors';
@@ -108,9 +109,7 @@ export const Homescreen = ({ isDeviceLocked }: HomescreenProps) => {
         resetUpload();
     };
 
-    const isSupportedHomescreen =
-        deviceModel !== DeviceModel.TT ||
-        (deviceModel === DeviceModel.TT && device.features.homescreen_format === 'Jpeg240x240');
+    const isSupportedHomescreen = isHomescreenSupportedOnDevice(device);
 
     return (
         <>


### PR DESCRIPTION
## Description

- disable homescreen button in onboarding last step if fw TT is old
- hiding looked bad because of the bottom line

## Related Issue

Hynek was lazy to create an issue

## Screenshots:
Old fw:
<img width="944" alt="Screenshot 2023-04-14 at 10 59 12" src="https://user-images.githubusercontent.com/33235762/232000798-4639256e-3522-44c8-98e4-f313a2bfd2bf.png">
<img width="939" alt="Screenshot 2023-04-14 at 10 59 20" src="https://user-images.githubusercontent.com/33235762/232000853-d3a1f380-bbf9-4245-a312-799665a3a8f7.png">
Current fw:
<img width="1062" alt="Screenshot 2023-04-14 at 11 03 40" src="https://user-images.githubusercontent.com/33235762/232000941-c5604fea-b490-4ce0-9b20-fb638691bb9b.png">
