### PR TITLE
ci: update coinjoin-backend ports and docs

### DIFF
--- a/docker/docker-compose.coinjoin-backend.yml
+++ b/docker/docker-compose.coinjoin-backend.yml
@@ -3,6 +3,7 @@ services:
   coinjoin-backend:
     image: ghcr.io/trezor/coinjoin-backend:latest
     ports:
+      - "8080:8080"
       - "8081:8081"
       - "19121:19121"
     volumes:

--- a/docs/features/coinjoin.md
+++ b/docs/features/coinjoin.md
@@ -1,10 +1,10 @@
 # Coinjoin service is suite
 
-**Note: Coinjoin is still in development mode and will not work with official firmware release**
-
 ## Development
 
 For development and e2e purposes you can use local version of coinjoin backend (`Regtest` only).
+
+**VPN is required for communication with affiliate server**
 
 1. run `./docker/docker-coinjoin-backend.sh`
 
@@ -12,16 +12,14 @@ For development and e2e purposes you can use local version of coinjoin backend (
     >
     > Pull and run docker image of https://github.com/trezor/coinjoin-backend
     >
-    > Backend control panel (faucet) should be accessible at `http://localhost:8081/`
+    > Backend control panel (faucet) should be accessible at `http://localhost:8080/`
 
 1. Run suite, go to settings and enable `Debug mode` (click 5 times on the "Settings" header)
 
-1. go to Settings > Crypto tab and enable `Bitcoin Regtest` and set custom backend to `http://localhost:19121/`
+1. go to Settings > Crypto tab and enable `Bitcoin Regtest` and set custom backend to `http://localhost:19121/` (default)
 
     > Optionally disable other coins
     >
     > Coinjoin accounts are not using this backend but you want to have all Regtest accounts synchronized with the same bitcoind
-
-1. go to Settings > Debug tab and change "Coinjoin Regtest server" to "localhost"
 
 1. Access coinjoin account


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Following recent changes in [coinjoin-backend](https://github.com/trezor/coinjoin-backend/pull/18) and [suite](https://github.com/trezor/trezor-suite/pull/7986)

`coinjoin-backend` is updated and should be working on mac M1