### PR TITLE
chore(ci): ensure that every commit in release branch is in default branch or marked properly

### DIFF
--- a/ci/releases.yml
+++ b/ci/releases.yml
@@ -2,6 +2,7 @@
 suite codesign deploy staging-suite:
   stage: deploy to staging
   needs:
+    - release commit messages
     - suite-web build stable codesign
     - suite-desktop build mac codesign
     - suite-desktop build linux codesign
@@ -33,6 +34,7 @@ suite codesign deploy staging-suite:
 suite-desktop deploy autoupdate test:
   stage: deploy to dev
   needs:
+    - release commit messages
     - suite-desktop build mac codesign
     - suite-desktop build linux codesign
     - suite-desktop build windows codesign
@@ -53,6 +55,7 @@ suite-desktop deploy autoupdate test:
 suite-desktop github release:
   stage: deploy to production
   needs:
+    - release commit messages
     - suite-desktop build mac codesign
     - suite-desktop build linux codesign
     - suite-desktop build windows codesign
@@ -72,10 +75,11 @@ suite-desktop github release:
     - deploy
 
 release commit messages:
-  stage: deploy to staging
+  stage: setup environment
   only:
     refs:
       - /^release\//
+      - codesign
   script:
     - ci/scripts/check_release_commit_messages.sh
 
@@ -127,6 +131,7 @@ connect v9 deploy production:
     - connect-web build
     - connect-explorer build
   needs:
+    - release commit messages
     - connect-web build
     - connect-explorer build
   before_script: []

--- a/ci/scripts/check_release_commit_messages.sh
+++ b/ci/scripts/check_release_commit_messages.sh
@@ -15,7 +15,7 @@ do
     # shellcheck disable=SC2076
     if [[ $message =~ "(cherry picked from commit" ]]; then
       # remove last ")" and extract commit hash
-      develop_commit=$(echo "${message:0:-1}" | tr ' ' '\n' | tail -1)
+      develop_commit=$($message | tr ' ' '\n' | tail -1 | sed 's/)$//')
       # check if develop really contains this commit hash
       if [[ $(git branch -a --contains "$develop_commit" | grep --only-matching "remotes/origin/develop") == "remotes/origin/develop" ]]; then
         continue
@@ -29,8 +29,13 @@ do
     fi
 
     fail=1
-    echo "FAILURE! Neither 'cherry picked from..' nor '[RELEASE ONLY]' substring found in this commit message."
+    echo "FAILURE! Neither 'cherry picked from..' nor '[RELEASE ONLY]' substring found in commit message of $commit"
 done
 
-echo "ALL OK"
+if (( fail == 0 )); then
+  echo "ALL OK"
+else
+  echo "FAILURE! Some commit messages are not valid."
+fi
+
 exit $fail


### PR DESCRIPTION
## Description

Commit message check script was there but possibly skipped (if any test failed which should not be ignored, but!) and not blocking anything. Now it's more strict and fixed to be able to run it locally.