### PR TITLE
fix(suite-native): android font weight

### DIFF
--- a/packages/theme/package.json
+++ b/packages/theme/package.json
@@ -11,6 +11,7 @@
         "generate-colors": "yarn tsx ./scripts/generateColors.ts"
     },
     "dependencies": {
+        "@mobily/ts-belt": "^3.13.1",
         "csstype": "^3.1.2",
         "prettier": "2.8.7"
     },

--- a/packages/theme/src/fontFamilies.ts
+++ b/packages/theme/src/fontFamilies.ts
@@ -4,8 +4,11 @@ export const fontFamilies = {
 
 export type FontFamilies = typeof fontFamilies;
 
-export const nativeFontFamilies: Record<keyof typeof fontFamilies, string> = {
-    base: 'TTSatoshi-Regular',
+export const nativeFontFamilies = {
+    medium: 'TTSatoshi-Medium',
+    semiBold: 'TTSatoshi-DemiBold',
 } as const;
 
 export type NativeFontFamilies = typeof nativeFontFamilies;
+
+export type NativeFont = NativeFontFamilies[keyof NativeFontFamilies];

--- a/suite-native/module-dev-utils/src/screens/DemoScreen.tsx
+++ b/suite-native/module-dev-utils/src/screens/DemoScreen.tsx
@@ -36,11 +36,23 @@ import {
 } from '@trezor/icons';
 import { CoinsSettings } from '@suite-native/module-settings';
 import { isDevelopOrDebugEnv } from '@suite-native/config';
+import { TypographyStyle } from '@trezor/theme';
 
 const inputStackStyle = prepareNativeStyle(utils => ({
     borderRadius: utils.borders.radii.medium,
     padding: utils.spacings.small,
 }));
+
+const textVariants: TypographyStyle[] = [
+    'titleLarge',
+    'titleMedium',
+    'titleSmall',
+    'highlight',
+    'body',
+    'callout',
+    'hint',
+    'label',
+];
 
 export const DemoScreen = () => {
     const { applyStyle } = useNativeStyles();
@@ -90,6 +102,14 @@ export const DemoScreen = () => {
                     </HStack>
                 </VStack>
                 <Divider />
+                <VStack>
+                    <Text variant="titleSmall">Text:</Text>
+                    {textVariants.map(variant => (
+                        <Text variant={variant} key={variant}>
+                            {variant}
+                        </Text>
+                    ))}
+                </VStack>
                 <VStack>
                     <Text variant="titleSmall">Button:</Text>
                     {buttonColorSchemes.map(buttonScheme => (

--- a/yarn.lock
+++ b/yarn.lock
@@ -8379,6 +8379,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@trezor/theme@workspace:packages/theme"
   dependencies:
+    "@mobily/ts-belt": ^3.13.1
     csstype: ^3.1.2
     jest: ^26.6.3
     prettier: 2.8.7


### PR DESCRIPTION
## Description
Font weight style prop was not reflected on Android. FontWeight style was removed from the style object and substituted by specific font reflecting the weight itself.


## Screenshots:

### Before
![Snímek obrazovky 2023-04-17 v 8 30 21](https://user-images.githubusercontent.com/26143964/232413177-c1910043-69d0-4491-b836-13946a2185c0.png)

### After
![Snímek obrazovky 2023-04-17 v 8 25 34](https://user-images.githubusercontent.com/26143964/232413197-dd4d0d72-857b-4196-8b43-9a43b3566962.png)
