### PR TITLE
fix(suite-native): fix navigation redirects

### DIFF
--- a/suite-native/module-accounts-import/src/components/AccountImportSummaryForm.tsx
+++ b/suite-native/module-accounts-import/src/components/AccountImportSummaryForm.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import { useDispatch, useSelector } from 'react-redux';
 
+import { CommonActions } from '@react-navigation/native';
 import { A } from '@mobily/ts-belt';
 import { useNavigation } from '@react-navigation/core';
 
@@ -13,7 +14,6 @@ import { HIDDEN_DEVICE_STATE } from '@suite-native/module-devices';
 import {
     AccountsImportStackParamList,
     AccountsImportStackRoutes,
-    AppTabsRoutes,
     HomeStackRoutes,
     RootStackParamList,
     RootStackRoutes,
@@ -75,12 +75,20 @@ export const AccountImportSummaryForm = ({
                 coin: networkSymbol,
             }),
         );
-        navigation.navigate(RootStackRoutes.AppTabs, {
-            screen: AppTabsRoutes.HomeStack,
-            params: {
-                screen: HomeStackRoutes.Home,
-            },
-        });
+
+        navigation.dispatch(
+            CommonActions.reset({
+                index: 0,
+                routes: [
+                    {
+                        name: RootStackRoutes.AppTabs,
+                        params: {
+                            screen: HomeStackRoutes.Home,
+                        },
+                    },
+                ],
+            }),
+        );
     });
 
     const shouldDisplayEthereumAccountTokens =

--- a/suite-native/module-accounts-import/src/components/AccountImportSummaryForm.tsx
+++ b/suite-native/module-accounts-import/src/components/AccountImportSummaryForm.tsx
@@ -76,19 +76,19 @@ export const AccountImportSummaryForm = ({
             }),
         );
 
-        navigation.dispatch(
-            CommonActions.reset({
-                index: 0,
-                routes: [
-                    {
-                        name: RootStackRoutes.AppTabs,
-                        params: {
-                            screen: HomeStackRoutes.Home,
-                        },
+        navigation.reset({
+            index: 0,
+            routes: [
+                {
+                    // Needs to be fixed with useNavigation types.
+                    // @ts-expect-error
+                    name: RootStackRoutes.AppTabs,
+                    params: {
+                        screen: HomeStackRoutes.Home,
                     },
-                ],
-            }),
-        );
+                },
+            ],
+        });
     });
 
     const shouldDisplayEthereumAccountTokens =

--- a/suite-native/module-accounts-import/src/components/AccountImportSummaryForm.tsx
+++ b/suite-native/module-accounts-import/src/components/AccountImportSummaryForm.tsx
@@ -1,7 +1,6 @@
 import React from 'react';
 import { useDispatch, useSelector } from 'react-redux';
 
-import { CommonActions } from '@react-navigation/native';
 import { A } from '@mobily/ts-belt';
 import { useNavigation } from '@react-navigation/core';
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
After importing, navigation is reset so that app doesn't take previous screens from onboarding into account.

## Related Issue

Resolve #8056

## Screenshots:

https://user-images.githubusercontent.com/36101761/232418924-72fbe6ab-586e-4032-8861-096b1af0420b.mov

