### PR TITLE
Enable all blockbook backends for CJ

### DIFF
--- a/packages/suite/src/services/coinjoin/config.ts
+++ b/packages/suite/src/services/coinjoin/config.ts
@@ -21,7 +21,13 @@ export const COINJOIN_NETWORKS: PartialRecord<NetworkSymbol, ServerEnvironment> 
             coordinatorName: 'CoinJoinCoordinatorIdentifier',
             coordinatorUrl: 'https://wasabiwallet.io/wabisabi/',
             wabisabiBackendUrl: 'https://wasabiwallet.io/',
-            blockbookUrls: ['https://btc4.trezor.io'],
+            blockbookUrls: [
+                'https://btc1.trezor.io',
+                'https://btc2.trezor.io',
+                'https://btc3.trezor.io',
+                'https://btc4.trezor.io',
+                'https://btc5.trezor.io',
+            ],
             /* 28.02.2023 */
             baseBlockHeight: 778666,
             baseBlockHash: '000000000000000000054d1ca4a160dd37541d776ccc34af955dbfcd3b2405f6',


### PR DESCRIPTION
## Description

Until now only `btc4.trezor.io` was enabled for Coinjoin account as the other instances weren't updated. Now all the instances (btc1 to btc5) are enabled.