### PR TITLE
fix(coinjoin): allow coinjoin start with outdated FW

### DIFF
--- a/packages/suite/src/reducers/wallet/coinjoinReducer.ts
+++ b/packages/suite/src/reducers/wallet/coinjoinReducer.ts
@@ -825,7 +825,7 @@ export const selectCoinjoinSessionBlockerByAccountKey = (
     if (selectIsCoinjoinBlockedByTor(state)) {
         return 'TOR_DISABLED';
     }
-    if (selectDeviceState(state) !== 'connected') {
+    if (!['connected', 'firmware-recommended'].includes(selectDeviceState(state) ?? '')) {
         return 'DEVICE_DISCONNECTED';
     }
     const account = selectAccountByKey(state, accountKey);


### PR DESCRIPTION


<!--- Provide a general summary of your changes in the Title above -->

## Description

Currently if the FW version is not the latest available, coinjoin is blocked with tooltip message `Unavailable. Associated device is disconnected.` even though the FW supports coinjoin, it's just "outdated".

For now it will be resolved via message-system (coinjoin with FW 2.5.3) will be disabled. But this change still has to be merged for future FW releases.

## Related Issue

Resolve https://satoshilabs.slack.com/archives/C048XFAKL10/p1681717015830979

## Screenshots:
bug with FW 2.5.3 in Suite that has FW 2.6.0 available:
![image](https://user-images.githubusercontent.com/3729633/232460494-92af4432-2198-4cb3-b02d-e926b4fb72c7.png)

