### PR TITLE
Add network symbol to anonymity gain report

### DIFF
--- a/packages/suite-analytics/src/types/events.ts
+++ b/packages/suite-analytics/src/types/events.ts
@@ -145,6 +145,7 @@ export type SuiteAnalyticsEvent =
     | {
           type: EventType.CoinjoinAnonymityGain;
           payload: {
+              networkSymbol: string;
               value: number;
           };
       }

--- a/packages/suite/src/middlewares/suite/analyticsMiddleware.ts
+++ b/packages/suite/src/middlewares/suite/analyticsMiddleware.ts
@@ -17,7 +17,10 @@ import {
     isDeviceInBootloaderMode,
 } from '@trezor/device-utils';
 import { analyticsActions } from '@suite-common/analytics';
-import { selectAnonymityGainToReportByAccountKey } from '@wallet-reducers/coinjoinReducer';
+import {
+    selectAnonymityGainToReportByAccountKey,
+    selectCoinjoinAccountByKey,
+} from '@wallet-reducers/coinjoinReducer';
 import { updateLastAnonymityReportTimestamp } from '@wallet-actions/coinjoinAccountActions';
 
 /*
@@ -183,15 +186,22 @@ const analyticsMiddleware =
             case COINJOIN.SESSION_COMPLETED:
             case COINJOIN.SESSION_PAUSE:
             case COINJOIN.ACCOUNT_UNREGISTER: {
+                const coinjoinAccount = selectCoinjoinAccountByKey(
+                    state,
+                    action.payload.accountKey,
+                );
                 const anonymityGainToReport = selectAnonymityGainToReportByAccountKey(
                     state,
                     action.payload.accountKey,
                 );
-                if (anonymityGainToReport !== null) {
+                if (coinjoinAccount && anonymityGainToReport !== null) {
                     analytics.report(
                         {
                             type: EventType.CoinjoinAnonymityGain,
-                            payload: { value: anonymityGainToReport },
+                            payload: {
+                                networkSymbol: coinjoinAccount.symbol,
+                                value: anonymityGainToReport,
+                            },
                         },
                         { anonymize: true },
                     );

--- a/packages/suite/src/reducers/wallet/coinjoinReducer.ts
+++ b/packages/suite/src/reducers/wallet/coinjoinReducer.ts
@@ -773,9 +773,10 @@ export const selectAnonymityGainToReportByAccountKey = (
     }
 
     // Report average value. Reporting values per round would compromise data privacy.
-    return (
-        gainsToReport.reduce((total, current) => total + current.level, 0) / gainsToReport.length
-    );
+    const average =
+        gainsToReport.reduce((total, current) => total + current.level, 0) / gainsToReport.length;
+
+    return parseFloat(average.toFixed(3));
 };
 
 export const selectRoundsLeftByAccountKey = (state: CoinjoinRootState, accountKey: AccountKey) => {


### PR DESCRIPTION
An improvement/fix to anonymity reporting:
- round average anonymity gain to three decimals
- report network symbol to distinguish results between testnet/mainnet

Related to https://github.com/trezor/trezor-suite/issues/7381

![Screenshot 2023-04-17 at 15 13 45](https://user-images.githubusercontent.com/42465546/232494693-efa9e479-140a-465b-acf7-396453be4ec3.png)

**QA:** When anonymity gains are reported, `networkSymbol` is part of the payload. `value` is rounded to max 3 decimals.