### PR TITLE
fix(suite-native): label offset

### DIFF
--- a/suite-native/graph/src/components/AxisLabel.tsx
+++ b/suite-native/graph/src/components/AxisLabel.tsx
@@ -31,8 +31,7 @@ export const AxisLabel = ({ x, value }: AxisLabelProps) => {
     const labelOffset = useMemo(() => {
         if (x !== MAX_CLAMP_VALUE || !textWidth) return x;
         const textWidthPercentage = (textWidth / Dimensions.get('window').width) * 100;
-        // Divide the percentage width by 2 as there is no need to move it all of the widths way
-        return x - textWidthPercentage / 2;
+        return x - textWidthPercentage;
     }, [textWidth, x]);
 
     if (isDiscreetMode) return null;


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
If value of top axis label will be 90 (highest portfolio value is the one at the end of date range), we will offset it by elements width. This should prevent component reaching out of wrappers bounds.

## Related Issue

Resolve <!--- link the issue here -->

## Screenshots:
<img width="417" alt="image" src="https://user-images.githubusercontent.com/36101761/232490543-017bc15a-57f4-4c32-9a87-87e58c59c7ec.png">
