### PR TITLE
fix(connect): add missing currencies param for getFiatRatesForTimestamps

### DIFF
--- a/packages/connect/src/api/blockchainGetFiatRatesForTimestamps.ts
+++ b/packages/connect/src/api/blockchainGetFiatRatesForTimestamps.ts
@@ -9,6 +9,7 @@ import type { CoinInfo } from '../types';
 
 type Params = {
     coinInfo: CoinInfo;
+    currencies: Payload<'blockchainGetFiatRatesForTimestamps'>['currencies'];
     timestamps: Payload<'blockchainGetFiatRatesForTimestamps'>['timestamps'];
     token: Payload<'blockchainGetFiatRatesForTimestamps'>['token'];
 };
@@ -25,6 +26,7 @@ export default class BlockchainGetFiatRatesForTimestamps extends AbstractMethod<
 
         // validate incoming parameters
         validateParams(payload, [
+            { name: 'currencies', type: 'array', required: false },
             { name: 'timestamps', type: 'array', required: true },
             { name: 'token', type: 'string' },
             { name: 'coin', type: 'string', required: true },
@@ -38,6 +40,7 @@ export default class BlockchainGetFiatRatesForTimestamps extends AbstractMethod<
         isBackendSupported(coinInfo);
 
         this.params = {
+            currencies: payload.currencies,
             timestamps: payload.timestamps,
             token: payload.token,
             coinInfo,
@@ -47,6 +50,7 @@ export default class BlockchainGetFiatRatesForTimestamps extends AbstractMethod<
     async run() {
         const backend = await initBlockchain(this.params.coinInfo, this.postMessage);
         return backend.getFiatRatesForTimestamps({
+            currencies: this.params.currencies,
             timestamps: this.params.timestamps,
             token: this.params.token,
         });

--- a/packages/connect/src/backend/Blockchain.ts
+++ b/packages/connect/src/backend/Blockchain.ts
@@ -141,7 +141,11 @@ export class Blockchain {
         return this.link.getCurrentFiatRates(params);
     }
 
-    getFiatRatesForTimestamps(params: { timestamps: number[]; token?: string }) {
+    getFiatRatesForTimestamps(params: {
+        currencies?: string[];
+        timestamps: number[];
+        token?: string;
+    }) {
         return this.link.getFiatRatesForTimestamps(params);
     }
 


### PR DESCRIPTION
:<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 11d7c47</samp>

This pull request adds the ability to fetch fiat rates for specific currencies in the `blockchainGetFiatRatesForTimestamps` method of the `connect` package. It modifies the types and parameters of the methods in the `Blockchain.ts` and `blockchainGetFiatRatesForTimestamps.ts` files to support the new feature.