### PR TITLE
Fix/follow up ethereum definitions

### DIFF
--- a/packages/connect/src/api/ethereum/ethereumDefinitions.ts
+++ b/packages/connect/src/api/ethereum/ethereumDefinitions.ts
@@ -1,29 +1,25 @@
 import fetch from 'cross-fetch';
 
 import { EthereumDefinitions } from '@trezor/transport/lib/types/messages';
-import { fromHardened } from '../../utils/pathUtils';
-
-const getSlip44ByPath = (path: number[]) => fromHardened(path[1]);
 
 /**
  * For given chainId and optionally contractAddress download ethereum definitions for transaction signing.
  * Definitions are only required to display correct information on display. If definitions
  * are not provided UNKNOWN is shown. This means that should this method fail we only log this but don't return error.
  */
-export const getEthereumDefinitions = async (
-    chainId: number | undefined,
-    path?: number[],
-    contractAddress?: string,
-) => {
+export const getEthereumDefinitions = async ({
+    chainId,
+    slip44,
+    contractAddress,
+}: {
+    chainId: number | undefined;
+    slip44?: number;
+    contractAddress?: string;
+}) => {
     const definitions: EthereumDefinitions = {};
 
-    let slip44;
-    if (!chainId && path) {
-        slip44 = getSlip44ByPath(path);
-    }
-
     if (!chainId && !slip44) {
-        throw new Error('argument chainId or slip44 path is required');
+        throw new Error('argument chainId or slip44 is required');
     }
 
     try {

--- a/packages/connect/src/api/ethereumGetAddress.ts
+++ b/packages/connect/src/api/ethereumGetAddress.ts
@@ -2,7 +2,7 @@
 
 import { AbstractMethod, MethodReturnType } from '../core/AbstractMethod';
 import { validateParams, getFirmwareRange } from './common/paramsValidator';
-import { validatePath, getSerializedPath } from '../utils/pathUtils';
+import { validatePath, getSerializedPath, getSlip44ByPath } from '../utils/pathUtils';
 import { getNetworkLabel } from '../utils/ethereumUtils';
 import { getEthereumNetwork, getUniqueNetworks } from '../data/coinInfo';
 import { stripHexPrefix } from '../utils/formatUtils';
@@ -143,10 +143,11 @@ export default class EthereumGetAddress extends AbstractMethod<'ethereumGetAddre
 
         for (let i = 0; i < this.params.length; i++) {
             const batch = this.params[i];
-            const definitions = await getEthereumDefinitions(
-                batch?.network?.chainId,
-                batch.address_n,
-            );
+            const slip44 = getSlip44ByPath(batch.address_n);
+            const definitions = await getEthereumDefinitions({
+                chainId: batch?.network?.chainId,
+                slip44,
+            });
 
             const definitionParams = {
                 ...(definitions.encoded_network && {
@@ -160,7 +161,7 @@ export default class EthereumGetAddress extends AbstractMethod<'ethereumGetAddre
                 const silent = await this._call({
                     ...batch,
                     ...definitionParams,
-                    show_display: true,
+                    show_display: false,
                 });
                 if (typeof batch.address === 'string') {
                     if (

--- a/packages/connect/src/api/ethereumSignTransaction.ts
+++ b/packages/connect/src/api/ethereumSignTransaction.ts
@@ -2,7 +2,7 @@
 
 import { AbstractMethod } from '../core/AbstractMethod';
 import { validateParams, getFirmwareRange } from './common/paramsValidator';
-import { validatePath } from '../utils/pathUtils';
+import { getSlip44ByPath, validatePath } from '../utils/pathUtils';
 import { getEthereumNetwork } from '../data/coinInfo';
 import { getNetworkLabel } from '../utils/ethereumUtils';
 import { stripHexPrefix } from '../utils/formatUtils';
@@ -112,11 +112,12 @@ export default class EthereumSignTransaction extends AbstractMethod<
     async run() {
         const { tx } = this.params;
 
-        const definitions = await getEthereumDefinitions(
-            tx.chainId,
-            this.params.path,
-            tx.data ? tx.to : undefined,
-        );
+        const slip44 = getSlip44ByPath(this.params.path);
+        const definitions = await getEthereumDefinitions({
+            chainId: tx.chainId,
+            slip44,
+            contractAddress: tx.data ? tx.to : undefined,
+        });
 
         return tx.type === 'eip1559'
             ? helper.ethereumSignTxEIP1559(

--- a/packages/connect/src/utils/pathUtils.ts
+++ b/packages/connect/src/utils/pathUtils.ts
@@ -6,6 +6,7 @@ import type { CoinInfo } from '../types';
 export const HD_HARDENED = 0x80000000;
 export const toHardened = (n: number) => (n | HD_HARDENED) >>> 0;
 export const fromHardened = (n: number) => (n & ~HD_HARDENED) >>> 0;
+export const getSlip44ByPath = (path: number[]) => fromHardened(path[1]);
 
 const PATH_NOT_VALID = ERRORS.TypedError('Method_InvalidParameter', 'Not a valid path');
 const PATH_NEGATIVE_VALUES = ERRORS.TypedError(


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Follow up of https://github.com/trezor/trezor-suite/pull/8113 so `getEthereumDefinitions` takes slip44 instead of the whole path.

## Related Issue
* Resolves https://github.com/trezor/trezor-suite/issues/8146

* https://github.com/trezor/trezor-suite/issues/8094
