### PR TITLE
test: npm install connect

### DIFF
--- a/ci/utils.yml
+++ b/ci/utils.yml
@@ -59,3 +59,21 @@ media duplicates:
   when: manual
   except:
     <<: *run_everything_rules
+
+# validate that connect installation (outside monorepo) using npm works
+.install connect:
+  stage: utils
+  needs: []
+  script:
+    - ./packages/connect/e2e/test-npm-install.sh
+
+install connect nightly:
+  extends: .install connect
+  only:
+    <<: *run_everything_rules
+
+install connect manual:
+  extends: .install connect
+  when: manual
+  except:
+    <<: *run_everything_rules

--- a/packages/connect/e2e/test-npm-install.sh
+++ b/packages/connect/e2e/test-npm-install.sh
@@ -1,0 +1,15 @@
+#!/usr/bin/env bash
+
+# validate that installing connect package using npm works
+
+set -e
+
+trap "cd .. && rm -rf connect-implementation" EXIT
+
+npm --version
+node --version
+
+mkdir connect-implementation
+cd connect-implementation
+npm init -y
+npm install @trezor/connect


### PR DESCRIPTION
based on this report #8156

[ci: test connect installation using npm](https://github.com/trezor/trezor-suite/commit/0cbab4bd4bacc8133860135837afa09715382a60) just adds some simple test that should be run in nightly jobs to check that connect can be installed with npm