### PR TITLE
chore(ci): add github action to prepare release and test branches

### DIFF
--- a/.github/workflows/prepare-release.yml
+++ b/.github/workflows/prepare-release.yml
@@ -1,0 +1,82 @@
+name: Prepare release
+
+on:
+  workflow_dispatch:
+
+jobs:
+  prepare-release:
+    runs-on: ubuntu-latest
+
+    env:
+      GITHUB_TOKEN: ${{ secrets.TREZOR_BOT_TOKEN }}
+      FILEPATH: ./packages/suite/package.json
+      MAIN_BRANCH: develop
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+          ref: ${{ env.MAIN_BRANCH }}
+
+      - name: Calculate versions
+        id: calculate-versions
+        run: |
+          CURRENT_VERSION=$(jq -r '.suiteVersion' < packages/suite/package.json)
+          CURRENT_VERSION_YEAR=$(echo $CURRENT_VERSION | cut -d '.' -f 1)
+          CURRENT_VERSION_MONTH=$(echo $CURRENT_VERSION | cut -d '.' -f 2)
+
+          RELEASE_VERSION="$CURRENT_VERSION_YEAR.$CURRENT_VERSION_MONTH.1"
+          TEST_UPGRADE_VERSION="$((CURRENT_VERSION_YEAR+10)).$CURRENT_VERSION_MONTH.1"
+          TEST_DOWNGRADE_VERSION="0.$CURRENT_VERSION_YEAR.$CURRENT_VERSION_MONTH"
+
+          if [ $CURRENT_VERSION_MONTH == 12 ]; then
+            NEXT_VERSION_YEAR=$(($CURRENT_VERSION_YEAR+1))
+            NEXT_VERSION_MONTH=1
+          else
+            NEXT_VERSION_YEAR=$CURRENT_VERSION_YEAR
+            NEXT_VERSION_MONTH=$(($CURRENT_VERSION_MONTH+1))
+          fi
+          BETA_VERSION="$NEXT_VERSION_YEAR.$NEXT_VERSION_MONTH.0"
+
+          echo "release_version=$RELEASE_VERSION" >> $GITHUB_OUTPUT
+          echo "test_upgrade_version=$TEST_UPGRADE_VERSION" >> $GITHUB_OUTPUT
+          echo "test_downgrade_version=$TEST_DOWNGRADE_VERSION" >> $GITHUB_OUTPUT
+          echo "beta_version=$BETA_VERSION" >> $GITHUB_OUTPUT
+
+      - name: Set Git config
+        run: |
+          git config user.name "trezor-ci"
+          git config user.email "${{ secrets.TREZOR_BOT_EMAIL }}"
+          git config push.autoSetupRemote true
+
+      - name: Prepare release branch
+        run: |
+          git switch -c release/${{ steps.calculate-versions.outputs.release_version }} $MAIN_BRANCH
+          sed -i -E 's/^(\s*"suiteVersion": ")[^"]*(".*$)/\1'${{ steps.calculate-versions.outputs.release_version }}'\2/' $FILEPATH
+          git commit -am "chore(suite): bump Suite version to ${{ steps.calculate-versions.outputs.release_version }} [RELEASE ONLY]"
+          git push
+
+      - name: Prepare test upgrade branch
+        run: |
+          git switch -c release/${{ steps.calculate-versions.outputs.test_upgrade_version }} $MAIN_BRANCH
+          sed -i -E 's/^(\s*"suiteVersion": ")[^"]*(".*$)/\1'${{ steps.calculate-versions.outputs.test_upgrade_version }}'\2/' $FILEPATH
+          git commit -am "chore(suite): set Suite version to ${{ steps.calculate-versions.outputs.test_upgrade_version }} for testing [RELEASE ONLY]"
+          git push
+
+      - name: Prepare test downgrade branch
+        run: |
+          git switch -c release/${{ steps.calculate-versions.outputs.test_downgrade_version }} $MAIN_BRANCH
+          sed -i -E 's/^(\s*"suiteVersion": ")[^"]*(".*$)/\1'${{ steps.calculate-versions.outputs.test_downgrade_version }}'\2/' $FILEPATH
+          git commit -am "chore(suite): set Suite version to ${{ steps.calculate-versions.outputs.test_downgrade_version }} for testing [RELEASE ONLY]"
+          git push
+
+      - name: Bump beta version
+        run: |
+          git switch -c chore/bump-suite-version-${{ steps.calculate-versions.outputs.beta_version }} $MAIN_BRANCH
+          sed -i -E 's/^(\s*"suiteVersion": ")[^"]*(".*$)/\1'${{ steps.calculate-versions.outputs.beta_version }}'\2/' $FILEPATH
+          git commit -am "chore(suite): bump beta version to ${{ steps.calculate-versions.outputs.beta_version }}"
+          git push
+
+      - name: Create pull request
+        run: gh pr create --base $MAIN_BRANCH --title "Bump beta version"  --body "Automatically generated PR to bump beta Suite version"


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

A Github action for branch preparation and version update for a release. It automates all the steps needed to create the first release candidate as described [here](https://www.notion.so/satoshilabs/6d76732183a74563a628bad60c2d4e08?v=9721ca815ca0465e82125fc0b2162fdd&p=3cd8cb7974564f308fed3f7cd76cae3d&pm=s), except the very last one. The action is triggered manually from the `Actions` tab. I tried it from my [fork](https://github.com/komret/trezor-suite-1), where you can see the resulting branches and pull request. The code is not too DRY as I did not find a satisfactory way to reuse logic in a GitHub action.

## Related Issue

https://github.com/trezor/trezor-suite/issues/7299
