### PR TITLE
fixes cherrypicked from #8140

### DIFF
--- a/packages/blockchain-link-utils/src/ripple.ts
+++ b/packages/blockchain-link-utils/src/ripple.ts
@@ -20,7 +20,13 @@ export const transformServerInfo = (payload: any) => ({
 //     return txs.concat(unique);
 // };
 
+// https://bitcoin.stackexchange.com/questions/23061/ripple-ledger-time-format/23065#23065
+const BLOCKTIME_OFFSET = 946684800;
+
 export const transformTransaction = (descriptor: string, tx: any): Transaction => {
+    const blockTime =
+        typeof tx.date === 'number' && tx.date > 0 ? tx.date + BLOCKTIME_OFFSET : tx.date;
+
     if (tx.TransactionType !== 'Payment') {
         // TODO: https://github.com/ripple/ripple-lib/blob/develop/docs/index.md#transaction-types
         return {
@@ -28,7 +34,7 @@ export const transformTransaction = (descriptor: string, tx: any): Transaction =
             txid: tx.hash,
             amount: '0',
             fee: '0',
-            blockTime: tx.date,
+            blockTime,
             blockHeight: tx.ledger_index,
             blockHash: tx.hash,
             targets: [],
@@ -53,7 +59,7 @@ export const transformTransaction = (descriptor: string, tx: any): Transaction =
         type,
 
         txid: tx.hash,
-        blockTime: tx.date,
+        blockTime,
         blockHeight: tx.ledger_index,
         blockHash: tx.hash,
 

--- a/packages/blockchain-link/tests/unit/fixtures/getAccountInfo-ripple.ts
+++ b/packages/blockchain-link/tests/unit/fixtures/getAccountInfo-ripple.ts
@@ -180,7 +180,7 @@ export default [
                         type: 'sent',
                         txid: '33F2085B0EF572376335716521E412CF611C4124B1088E5CCED48A7901CAF95E',
                         blockHeight: 47570158,
-                        blockTime: 612363551,
+                        blockTime: 1559048351,
                         blockHash:
                             '33F2085B0EF572376335716521E412CF611C4124B1088E5CCED48A7901CAF95E',
                         amount: '5718112',
@@ -207,7 +207,7 @@ export default [
                         type: 'recv',
                         txid: '533A8A2EDBCE914159C5491429763FD39A1F0F19E0F82800C3B7909B67B166A7',
                         blockHeight: 47455208,
-                        blockTime: 611932692,
+                        blockTime: 1558617492,
                         blockHash:
                             '533A8A2EDBCE914159C5491429763FD39A1F0F19E0F82800C3B7909B67B166A7',
                         amount: '25718124',

--- a/packages/coinjoin/tests/client/analyzeTransactions.test.ts
+++ b/packages/coinjoin/tests/client/analyzeTransactions.test.ts
@@ -7,7 +7,8 @@ let server: Awaited<ReturnType<typeof createServer>>;
 
 // create simplified transaction
 const generateTx = (vin: any[], vout: any[]) => {
-    const r = (v: any) => ({
+    const mapVinVout = (v: any) => ({
+        isAddress: typeof v.isAddress === 'boolean' ? v.isAddress : true,
         addresses: [v.address],
         value: v.value,
         isAccountOwned: v.isAccountOwned,
@@ -15,8 +16,8 @@ const generateTx = (vin: any[], vout: any[]) => {
 
     return {
         details: {
-            vin: vin.map(r),
-            vout: vout.map(r),
+            vin: vin.map(mapVinVout),
+            vout: vout.map(mapVinVout),
         },
     } as any;
 };
@@ -84,6 +85,13 @@ describe('analyzeTransactions', () => {
                     {
                         address: 'bcrt1pssj2qdyxm446ckkj2y22uu8l4wdtwjdqhtwk5uef0glazv69pfnsnza9gz',
                         value: 190,
+                    },
+                    // this output will be ignored
+                    {
+                        isAddress: false,
+                        value: 0,
+                        addresses: ['OP_RETURN (coinjoin)'],
+                        hex: '636f696e6a6f696e',
                     },
                 ],
             ),

--- a/packages/connect/src/api/signTransaction.ts
+++ b/packages/connect/src/api/signTransaction.ts
@@ -25,7 +25,7 @@ import {
     verifyTicketTx,
     createPendingTransaction,
 } from './bitcoin';
-import type { BitcoinNetworkInfo, AccountAddresses, AccountUtxo } from '../types';
+import type { BitcoinNetworkInfo, AccountAddresses } from '../types';
 import type { RefTransaction, TransactionOptions } from '../types/api/bitcoin';
 
 type Params = {
@@ -35,7 +35,6 @@ type Params = {
     coinjoinRequest?: PROTO.CoinJoinRequest;
     refTxs?: RefTransaction[];
     addresses?: AccountAddresses;
-    utxo?: AccountUtxo[];
     options: TransactionOptions;
     coinInfo: BitcoinNetworkInfo;
     push: boolean;
@@ -117,7 +116,6 @@ export default class SignTransaction extends AbstractMethod<'signTransaction', P
             paymentRequests: payload.paymentRequests || [],
             refTxs,
             addresses: payload.account ? payload.account.addresses : undefined,
-            utxo: payload.account ? payload.account.utxo : undefined,
             options: {
                 lock_time: payload.locktime,
                 timestamp: payload.timestamp,
@@ -243,9 +241,8 @@ export default class SignTransaction extends AbstractMethod<'signTransaction', P
             }
         }
 
-        if (bitcoinTx && params.addresses && params.utxo) {
+        if (bitcoinTx && params.addresses) {
             response.signedTransaction = createPendingTransaction(bitcoinTx, {
-                utxo: params.utxo,
                 addresses: params.addresses,
                 inputs: params.inputs,
                 outputs: params.outputs,

--- a/packages/connect/src/types/api/__tests__/bitcoin.ts
+++ b/packages/connect/src/types/api/__tests__/bitcoin.ts
@@ -370,17 +370,6 @@ export const signTransaction = async (api: TrezorConnect) => {
                 unused: [],
                 change: [{ path: 'm/44', address: 'a', transfers: 0 }],
             },
-            utxo: [
-                {
-                    txid: '00000',
-                    vout: 1,
-                    amount: '100',
-                    address: '',
-                    path: 'm/44',
-                    blockHeight: 1,
-                    confirmations: 0,
-                },
-            ],
         },
         coin: 'btc',
         locktime: 0,

--- a/packages/connect/src/types/api/bitcoin/index.ts
+++ b/packages/connect/src/types/api/bitcoin/index.ts
@@ -2,8 +2,6 @@ import type { PROTO } from '../../../constants';
 import type { AccountAddresses } from '@trezor/blockchain-link';
 import type { Transaction as BlockbookTransaction } from '@trezor/blockchain-link-types/lib/blockbook';
 
-import { AccountUtxo } from '../../account';
-
 // signMessage
 
 export interface SignMessage {
@@ -69,7 +67,6 @@ export interface SignTransaction {
     refTxs?: RefTransaction[];
     account?: {
         addresses: AccountAddresses;
-        utxo: AccountUtxo[];
     };
     coin: string;
     locktime?: number;

--- a/packages/suite/src/actions/wallet/send/sendFormBitcoinActions.ts
+++ b/packages/suite/src/actions/wallet/send/sendFormBitcoinActions.ts
@@ -264,7 +264,6 @@ export const signTransaction =
             outputs: transaction.outputs,
             account: {
                 addresses: account.addresses!,
-                utxo: account.utxo!,
             },
             coin: account.symbol,
             ...signEnhancement,

--- a/suite-common/wallet-utils/src/transactionUtils.ts
+++ b/suite-common/wallet-utils/src/transactionUtils.ts
@@ -608,11 +608,6 @@ export const enhanceTransaction = (
     deviceState: account.deviceState,
     symbol: account.symbol,
     ...origTx,
-    // https://bitcoin.stackexchange.com/questions/23061/ripple-ledger-time-format/23065#23065
-    blockTime:
-        account.networkType === 'ripple' && origTx.blockTime
-            ? origTx.blockTime + 946684800
-            : origTx.blockTime,
     rbfParams: getRbfParams(origTx, account),
 });
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Since [rbf in coinjoin account](https://github.com/trezor/trezor-suite/pull/8140) is not going to be enabled im cherrypicking commits with fixes:

- move ripple blocktime fix from suite to blockchain-link
- TrezorConnect.signTransaction > createPendingTx should not rely on utxos, in case of rbf utxo might not be there
- fix for coinjoin `analyzeTransactions` when tx contains opreturn output

