### PR TITLE
fix(connect): fix outdated browser breaking change

### DIFF
--- a/ci/test.yml
+++ b/ci/test.yml
@@ -224,8 +224,7 @@ transport manual:
     matrix:
       - TEST_FILE: ["methods"]
       - TEST_FILE: ["popup-close"]
-      # unchained test is failing, should be debugged outside of main pipeline and re-enabled again
-      # - TEST_FILE: ["unchained"]
+      - TEST_FILE: ["unchained"]
       - TEST_FILE: ["browser-support"]
 
 connect-popup:

--- a/packages/connect-popup/e2e/tests/unchained.test.ts
+++ b/packages/connect-popup/e2e/tests/unchained.test.ts
@@ -7,7 +7,7 @@ const connectUrl = process.env.URL
     ? process.env.URL.replace('connect-explorer', 'connect')
     : 'https://connect.trezor.io/9/';
 
-const url = `https://unchained-capital.github.io/caravan?trezor-connect-src=${connectUrl}#/test`;
+const url = `https://unchained-capital.github.io/caravan?trezor-connect-src=${connectUrl}`;
 
 test.beforeAll(async () => {
     await TrezorUserEnvLink.connect();
@@ -151,6 +151,7 @@ test('Verify unchained test suite', async ({ browser }) => {
     const page = await context.newPage();
     const keystoreInput = '#keystore-select';
     await page.goto(url);
+    await page.getByRole('link', { name: 'tested' }).click();
     await page.locator(keystoreInput).click();
     // select trezor
     await page.locator('[data-value="trezor"]').click();

--- a/packages/connect-popup/package.json
+++ b/packages/connect-popup/package.json
@@ -16,6 +16,7 @@
         "@trezor/connect-analytics": "workspace:*",
         "@trezor/connect-ui": "workspace:*",
         "@trezor/crypto-utils": "workspace:*",
+        "@trezor/env-utils": "workspace:*",
         "@trezor/urls": "workspace:*",
         "eth-phishing-detect": "^1.2.0"
     },

--- a/packages/connect-popup/src/index.tsx
+++ b/packages/connect-popup/src/index.tsx
@@ -9,7 +9,9 @@ import {
     PopupEvent,
     PopupInit,
     PopupHandshake,
+    SystemInfo,
 } from '@trezor/connect';
+import { config } from '@trezor/connect/lib/data/config';
 
 import { reactEventBus } from '@trezor/connect-ui/src/utils/eventBus';
 import { analytics, EventType } from '@trezor/connect-analytics';
@@ -24,6 +26,35 @@ import {
     postMessage,
 } from './view/common';
 import { isPhishingDomain } from './utils/isPhishingDomain';
+import { getBrowserVersion, getBrowserName, getDeviceType, getOsFamily } from '@trezor/env-utils';
+
+// FIXME!!!
+// this is copy paste hotfix from connect-iframe package
+// why: systemInfo is sent in POPUP.INIT message from connect-web/src/popup. And this was added in 9.0.8.
+// In case implementator has earlier version, systemInfo does not come. One of results is that popup displays
+// outdated browser.
+const getSystemInfo = (supportedBrowsers: { [key: string]: { version: number } }): SystemInfo => {
+    const browserName = getBrowserName();
+    const browserVersion = getBrowserVersion();
+    const supportedBrowser = browserName ? supportedBrowsers[browserName.toLowerCase()] : undefined;
+    const outdatedBrowser = supportedBrowser
+        ? supportedBrowser.version > parseInt(browserVersion, 10)
+        : false;
+    const mobile = getDeviceType() === 'mobile';
+    const supportedMobile = mobile ? typeof navigator.usb !== 'undefined' : true;
+    const supported = !!(supportedBrowser && !outdatedBrowser && supportedMobile);
+
+    return {
+        os: {
+            family: getOsFamily(),
+            mobile,
+        },
+        browser: {
+            supported,
+            outdated: outdatedBrowser,
+        },
+    };
+};
 
 let handshakeTimeout: ReturnType<typeof setTimeout>;
 
@@ -181,6 +212,11 @@ const handleMessage = (event: MessageEvent<PopupEvent | UiEvent>) => {
 // handle POPUP.INIT message from window.opener
 const init = async (payload: PopupInit['payload']) => {
     if (!payload) return;
+
+    if (!payload.systemInfo) {
+        payload.systemInfo = getSystemInfo(config.supportedBrowsers);
+    }
+
     try {
         initMessageChannel(payload, handleMessage);
         // reset loading hash

--- a/packages/connect-popup/tsconfig.json
+++ b/packages/connect-popup/tsconfig.json
@@ -10,6 +10,7 @@
         { "path": "../connect-analytics" },
         { "path": "../connect-ui" },
         { "path": "../crypto-utils" },
+        { "path": "../env-utils" },
         { "path": "../urls" },
         { "path": "../node-utils" },
         { "path": "../trezor-user-env-link" }

--- a/yarn.lock
+++ b/yarn.lock
@@ -7738,6 +7738,7 @@ __metadata:
     "@trezor/connect-analytics": "workspace:*"
     "@trezor/connect-ui": "workspace:*"
     "@trezor/crypto-utils": "workspace:*"
+    "@trezor/env-utils": "workspace:*"
     "@trezor/node-utils": "workspace:*"
     "@trezor/trezor-user-env-link": "workspace:*"
     "@trezor/urls": "workspace:*"


### PR DESCRIPTION
[test(connect-popup): enable unchained test](https://github.com/trezor/trezor-suite/pull/8170/commits/9b5419787c1bfcfb3f1737e1ad6172e4051f4f6a) enables tests that would have caught the bug I am fixing here now, if it was online

[fix(connect-popup): systemInfo](https://github.com/trezor/trezor-suite/pull/8170/commits/59c913e8548a10efa8c0ddb52710fd421c30f562) fixes [broken backwards compatibility](https://github.com/trezor/trezor-suite/pull/7844). Data used in popup to decide whether browser is outdated is now sent from the code that is part of npm package, this means that unless update, this data is missing in popup.html.

### QA testing tips: 

- run packages/connect-examples/browser-inline-script
- to simulate bug http://127.0.0.1:8080/?trezor-connect-src=https://connect.trezor.io/9.0.8/
- to see bug fix http://127.0.0.1:8080/?trezor-connect-src=https://suite.corp.sldev.cz/connect/connect-debug-outdated/