### PR TITLE
fix(suite-native): token fiat rates formatter

### DIFF
--- a/suite-native/formatters/src/components/EthereumTokenToFiatAmountFormatter.tsx
+++ b/suite-native/formatters/src/components/EthereumTokenToFiatAmountFormatter.tsx
@@ -37,8 +37,8 @@ export const EthereumTokenToFiatAmountFormatter = ({
     const fiatCurrency = useSelector(selectFiatCurrency);
     const { FiatAmountFormatter } = useFormatters();
 
-    const rates = coins.find(coin => coin.symbol === ethereumToken.toLocaleLowerCase())?.current
-        ?.rates;
+    const rates = coins.find(coin => coin.symbol.toLowerCase() === ethereumToken.toLowerCase())
+        ?.current?.rates;
 
     if (!rates) return <EmptyAmountText />;
 


### PR DESCRIPTION
## Description

fiat rates for tokens are visible again.

