### PR TITLE
Ci translation duplications in validation

### DIFF
--- a/.github/workflows/validation.yml
+++ b/.github/workflows/validation.yml
@@ -53,3 +53,5 @@ jobs:
         run: yarn nx:lint:styles
       - name: unit tests
         run: yarn nx:test-unit
+      - name: translation duplicates
+        run: yarn workspace @trezor/suite translations:list-duplicates

--- a/ci/utils.yml
+++ b/ci/utils.yml
@@ -22,24 +22,6 @@ urls health:
   except:
     <<: *run_everything_rules
 
-.translations duplicates:
-  stage: utils
-  needs: []
-  script:
-    - yarn install --immutable
-    - yarn workspace @trezor/suite translations:list-duplicates
-
-translations duplicates nightly:
-  extends: .translations duplicates
-  only:
-    <<: *run_everything_rules
-
-translations duplicates:
-  extends: .translations duplicates
-  when: manual
-  except:
-    <<: *run_everything_rules
-
 .translations unused:
   stage: utils
   needs: []

--- a/packages/suite/src/support/messages.ts
+++ b/packages/suite/src/support/messages.ts
@@ -5838,7 +5838,7 @@ export default defineMessages({
         defaultMessage: 'Update your firmware to change your homescreen',
     },
     TR_UPDATE_FIRMWARE_HOMESCREEN_LATER_TOOLTIP: {
-        id: 'TR_UPDATE_FIRMWARE_HOMESCREEN_TOOLTIP',
+        id: 'TR_UPDATE_FIRMWARE_HOMESCREEN_LATER_TOOLTIP',
         defaultMessage:
             'Firmware update required. You can change your homescreen in the settings page later',
     },


### PR DESCRIPTION
there is a utility script which throws if there is a translation record in messages.json which does not have exactly same id and key. it is run nightly, and detects someting time to time 
https://gitlab.com/satoshilabs/trezor/trezor-suite/-/jobs/4152462835
but since it takes only a couple of seconds to complete, I'd argue that it might be run also in validation phase? 