### PR TITLE
test(connect): ethereumSignTypedData to use ethereum definition

### DIFF
--- a/packages/connect/e2e/__fixtures__/ethereumSignTypedData.ts
+++ b/packages/connect/e2e/__fixtures__/ethereumSignTypedData.ts
@@ -2,7 +2,33 @@
 // @ts-ignore
 import commonFixtures from '../../../../submodules/trezor-common/tests/fixtures/ethereum/sign_typed_data.json';
 
-const fixtures = commonFixtures.tests
+const ethereumDefinitionFixture = [
+    {
+        name: 'Wanchain',
+        comment: 'Test ethereum definitions with path that is not included in device',
+        parameters: {
+            path: "m/44'/5718350'/0'/0/0",
+            metamask_v4_compat: true,
+            data: {
+                types: {
+                    EIP712Domain: [],
+                },
+                primaryType: 'EIP712Domain',
+                message: {},
+                domain: {},
+            },
+            message_hash: null,
+            domain_separator_hash:
+                '0x6192106f129ce05c9075d319c1fa6ea9b3ae37cbd0c1ef92e2be7137bb07baa1',
+        },
+        result: {
+            address: '0xe432a7533D689ceed00B7EE91d9368b8A1693bD2',
+            sig: '0xeaa70ecee5866fe463ecc03befecdbe04420b460cb872fa3179134572d4c5b454ab09ec98689b53ba1c652fcae8aa8fbd63186ee856649d8ecef6f9b31304b7d1c',
+        },
+    },
+];
+
+const fixtures = [...ethereumDefinitionFixture, ...commonFixtures.tests]
     .filter(
         f =>
             // TODO: probably newly added fixtures to trezor-common


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Adding fixup test for ethereumSignTypedData.

## Related Issue
Follow up https://github.com/trezor/trezor-suite/pull/8175 https://github.com/trezor/trezor-suite/issues/6442

## Screenshots:
