### PR TITLE
fix(suite-native): crypto amount formatter optional ellipsis

### DIFF
--- a/suite-common/formatters/src/formatters/prepareCryptoAmountFormatter.ts
+++ b/suite-common/formatters/src/formatters/prepareCryptoAmountFormatter.ts
@@ -15,14 +15,17 @@ export type CryptoAmountFormatterDataContext = {
     withSymbol?: boolean;
     isBalance?: boolean;
     maxDisplayedDecimals?: number;
+    isEllipsisAppended?: boolean;
 };
 
-const truncateDecimals = (value: string, maxDecimals: number) => {
+const truncateDecimals = (value: string, maxDecimals: number, isEllipsisAppended: boolean) => {
     const parts = value.split('.');
     const [integerPart, fractionalPart] = parts;
 
     if (fractionalPart && fractionalPart.length > maxDecimals) {
-        return `${integerPart}.${fractionalPart.slice(0, maxDecimals)}…`;
+        return `${integerPart}.${fractionalPart.slice(0, maxDecimals)}${
+            isEllipsisAppended ? '...' : ''
+        }`;
     }
 
     return value;
@@ -34,7 +37,16 @@ const COINS_WITH_SATS = ['btc', 'test'] satisfies NetworkSymbol[];
 
 export const prepareCryptoAmountFormatter = (config: FormatterConfig) =>
     makeFormatter<CryptoAmountFormatterInputValue, string, CryptoAmountFormatterDataContext>(
-        (value, { symbol, isBalance = false, withSymbol = true, maxDisplayedDecimals = 8 }) => {
+        (
+            value,
+            {
+                symbol,
+                isBalance = false,
+                withSymbol = true,
+                maxDisplayedDecimals = 8,
+                isEllipsisAppended = true,
+            },
+        ) => {
             const { bitcoinAmountUnit } = config;
 
             // TS thinks that symbol is undefined, but it's required in type CryptoAmountFormatterDataContext so it's safe to use "!"
@@ -63,7 +75,11 @@ export const prepareCryptoAmountFormatter = (config: FormatterConfig) =>
             }
 
             if (maxDisplayedDecimals) {
-                formattedValue = truncateDecimals(formattedValue, maxDisplayedDecimals);
+                formattedValue = truncateDecimals(
+                    formattedValue,
+                    maxDisplayedDecimals,
+                    isEllipsisAppended,
+                );
             }
 
             if (withSymbol) {

--- a/suite-common/formatters/src/formatters/prepareCryptoAmountFormatter.ts
+++ b/suite-common/formatters/src/formatters/prepareCryptoAmountFormatter.ts
@@ -24,7 +24,7 @@ const truncateDecimals = (value: string, maxDecimals: number, isEllipsisAppended
 
     if (fractionalPart && fractionalPart.length > maxDecimals) {
         return `${integerPart}.${fractionalPart.slice(0, maxDecimals)}${
-            isEllipsisAppended ? '...' : ''
+            isEllipsisAppended ? '…' : ''
         }`;
     }
 

--- a/suite-common/formatters/src/formatters/tests/prepareCryptoAmountFormatter.test.ts
+++ b/suite-common/formatters/src/formatters/tests/prepareCryptoAmountFormatter.test.ts
@@ -55,13 +55,14 @@ describe('CryptoAmountFormatter', () => {
             ).toBe('0.02063870… ETH');
         });
 
-        it('ETH balance with symbol + truncate decimals', () => {
+        it('ETH balance with symbol + truncate decimals + hide ellipsis', () => {
             expect(
                 CryptoAmountFormatter.format('0.020638700284758254', {
                     symbol: 'eth',
                     isBalance: true,
+                    isEllipsisAppended: false,
                 }),
-            ).toBe('0.02063870… ETH');
+            ).toBe('0.02063870 ETH');
         });
 
         it('ETH balance with units', () => {

--- a/suite-native/formatters/src/components/CryptoAmountFormatter.tsx
+++ b/suite-native/formatters/src/components/CryptoAmountFormatter.tsx
@@ -28,7 +28,12 @@ export const CryptoAmountFormatter = ({
 
     if (!value) return <EmptyAmountText />;
 
-    const formattedValue = formatter.format(value, { isBalance, symbol: network });
+    const formattedValue = formatter.format(value, {
+        isBalance,
+        symbol: network,
+        maxDisplayedDecimals: undefined,
+        isEllipsisAppended: false,
+    });
 
     return (
         <AmountText


### PR DESCRIPTION
## Description

An option to turn off the ellipsis append in CryptoAmountFormatter was created.

## Related Issue

Resolve [#8186](https://github.com/trezor/trezor-suite/issues/8168)

## Screenshots:
![Snímek obrazovky 2023-04-21 v 16 54 54](https://user-images.githubusercontent.com/26143964/233667868-4d81a1e6-2e83-4a97-99a9-0127a1348da0.png)
