### PR TITLE
ci: cleanup

### DIFF
--- a/ci/deploy.yml
+++ b/ci/deploy.yml
@@ -83,36 +83,6 @@ msg-system deploy sldev:
     - aws cloudfront create-invalidation --distribution-id ${AWS_CLOUDFRONT_ID} --paths '/config/develop/*'
   interruptible: true
 
-.connect-explorer deploy dev base:
-  stage: deploy to dev
-  variables:
-    DEPLOY_DIRECTORY: ${DEPLOY_BASE_DIR}/connect-explorer/${CI_BUILD_REF_NAME}
-  environment:
-    name: ${CI_BUILD_REF_NAME}
-    url: $BASE_REVIEW_URL/${CI_BUILD_REF_NAME}
-  before_script: []
-  script:
-    - mkdir -p ${DEPLOY_DIRECTORY}/connect-explorer
-    - rsync --delete -va packages/connect-explorer/build/ "${DEPLOY_DIRECTORY}/"
-  tags:
-    - deploy
-  interruptible: true
-
-connect-explorer deploy sldev:
-  extends: .connect-explorer deploy dev base
-  needs:
-    - connect-explorer build
-  only:
-    <<: *run_connect_rules
-
-connect-explorer deploy dev manual:
-  extends: .connect-explorer deploy dev base
-  needs:
-    - connect-explorer build
-  except:
-    <<: *run_everything_rules
-  when: manual
-
 # connect deploy to dev
 connect deploy to dev:
   stage: deploy to dev

--- a/ci/deploy.yml
+++ b/ci/deploy.yml
@@ -53,20 +53,6 @@ suite-desktop deploy sldev:
     - deploy
   interruptible: true
 
-# # Suite native deploy to dev
-# suite-native deploy sldev:
-#   stage: deploy to dev
-#   only:
-#     <<: *run_everything_rules
-#   variables:
-#     DEPLOY_DIRECTORY: ${DEPLOY_BASE_DIR}/suite-native/${CI_BUILD_REF_NAME}
-#   script:
-#     - mkdir -p ${DEPLOY_DIRECTORY}
-#     - rsync --delete -va app-release.apk "${DEPLOY_DIRECTORY}/"
-#   tags:
-#     - deploy
-# TODO: Disabled until the new suite native build is introduced. Fix this deploy job after.
-
 # Messaging system deploy to dev
 msg-system deploy sldev:
   stage: deploy to dev
@@ -126,14 +112,11 @@ connect deploy to dev:
 .run_components_rules: &run_components_rules
   refs:
     - develop
-    - releases
     - schedules
-    - /^release\//
     - /^run\//
   changes:
     - packages/components
     - packages/components-storybook
-    - yarn.lock
 
 # Deploy
 
@@ -164,15 +147,3 @@ components storybook deploy dev manual:
   when: manual
   except:
     <<: *run_components_rules
-# components-storybook test snapshots:
-#   stage: integration testing
-#   script:
-#     - npx cypress install
-#     - CYPRESS_baseUrl=${DEV_SERVER_URL}/components-storybook/${CI_BUILD_REF_NAME} yarn workspace @trezor/integration-tests test:components-storybook
-#   artifacts:
-#     expire_in: 7 days
-#     when: always
-#     paths:
-#       - /builds/satoshilabs/trezor/trezor-suite/packages/integration-tests/projects/components-storybook/snapshots
-#       - /builds/satoshilabs/trezor/trezor-suite/packages/integration-tests/projects/components-storybook/screenshots
-#   needs: []

--- a/packages/components/README.md
+++ b/packages/components/README.md
@@ -1,10 +1,10 @@
 # @trezor/components
 
-This repository contains components, images and hooks that do not depend on Suite-specific context, i.e. can be used in other Trezor-related projects as well. So far, they have only been used in Suite.
+This repository contains components, images and hooks that do not depend on Suite-specific context, i.e. can be used in other Trezor-related projects as well. So far, they have only been used in Suite and @trezor/connect-ui.
 
 ## Storybook
 
-Each component can be inspected separately in [Storybook](https://storybook.js.org/). Stories are deployed automatically by pipeline via `storybook-build` command to https://suite.corp.sldev.cz/components/develop. To see your local changes, run Storybook locally:
+Each component can be inspected separately in [Storybook](https://storybook.js.org/). Stories are deployed automatically by a nightly pipeline via `storybook-build` command to https://suite.corp.sldev.cz/components/develop. To see your local changes, run Storybook locally:
 
 `yarn workspace @trezor/components storybook`
 


### PR DESCRIPTION
[ci: remove connect-explorer deploy](https://github.com/trezor/trezor-suite/commit/37cf5e0857adf3788f3849d0c586d25759be0eb6) - this is not used anymore, can be safely removed. there is another job that builds all connect related packages

[ci: remove components deploy](https://github.com/trezor/trezor-suite/commit/01ebf4b1f235e6a06e6a3558cf04745c1ebaf173) please shout out if needed, but it seems to me that it is not. I am even not seeing any builds for storybook from later than 2  years ago.