### PR TITLE
fix(mobile): fix strange fix rates #8198

### DIFF
--- a/suite-common/wallet-config/src/networksConfig.ts
+++ b/suite-common/wallet-config/src/networksConfig.ts
@@ -3,12 +3,12 @@ import type { Keys, Without } from '@trezor/type-utils';
 import { DeviceModel } from '@trezor/device-utils';
 
 export const networks = {
-    // Bitcoin
     btc: {
         name: 'Bitcoin',
         networkType: 'bitcoin',
         bip43Path: "m/84'/0'/i'",
         decimals: 8,
+        testnet: false,
         explorer: {
             tx: 'https://btc1.trezor.io/tx/',
             account: 'https://btc1.trezor.io/xpub/',
@@ -34,12 +34,12 @@ export const networks = {
             },
         },
     },
-    // Litecoin
     ltc: {
         name: 'Litecoin',
         networkType: 'bitcoin',
         bip43Path: "m/84'/2'/i'",
         decimals: 8,
+        testnet: false,
         explorer: {
             tx: 'https://ltc1.trezor.io/tx/',
             account: 'https://ltc1.trezor.io/xpub/',
@@ -56,13 +56,13 @@ export const networks = {
             },
         },
     },
-    // Ethereum
     eth: {
         name: 'Ethereum',
         networkType: 'ethereum',
         chainId: 1,
         bip43Path: "m/44'/60'/0'/0/i",
         decimals: 18,
+        testnet: false,
         explorer: {
             tx: 'https://eth1.trezor.io/tx/',
             account: 'https://eth1.trezor.io/address/',
@@ -81,6 +81,7 @@ export const networks = {
         chainId: 61,
         bip43Path: "m/44'/61'/0'/0/i",
         decimals: 18,
+        testnet: false,
         explorer: {
             tx: 'https://etc1.trezor.io/tx/',
             account: 'https://etc1.trezor.io/address/',
@@ -97,6 +98,7 @@ export const networks = {
         networkType: 'ripple',
         bip43Path: "m/44'/144'/i'/0/0",
         decimals: 6,
+        testnet: false,
         explorer: {
             tx: 'https://xrpscan.com/tx/',
             account: 'https://xrpscan.com/account/',
@@ -111,6 +113,7 @@ export const networks = {
         networkType: 'bitcoin',
         bip43Path: "m/44'/145'/i'",
         decimals: 8,
+        testnet: false,
         explorer: {
             tx: 'https://bch1.trezor.io/tx/',
             account: 'https://bch1.trezor.io/xpub/',
@@ -125,6 +128,7 @@ export const networks = {
         networkType: 'bitcoin',
         bip43Path: "m/49'/156'/i'",
         decimals: 8,
+        testnet: false,
         explorer: {
             tx: 'https://btg1.trezor.io/tx/',
             account: 'https://btg1.trezor.io/xpub/',
@@ -143,6 +147,7 @@ export const networks = {
         networkType: 'bitcoin',
         bip43Path: "m/44'/5'/i'",
         decimals: 8,
+        testnet: false,
         explorer: {
             tx: 'https://dash1.trezor.io/tx/',
             account: 'https://dash1.trezor.io/xpub/',
@@ -157,6 +162,7 @@ export const networks = {
         networkType: 'bitcoin',
         bip43Path: "m/49'/20'/i'",
         decimals: 8,
+        testnet: false,
         explorer: {
             tx: 'https://dgb1.trezor.io/tx/',
             account: 'https://dgb1.trezor.io/xpub/',
@@ -175,6 +181,7 @@ export const networks = {
         networkType: 'bitcoin',
         bip43Path: "m/44'/3'/i'",
         decimals: 8,
+        testnet: false,
         explorer: {
             tx: 'https://doge1.trezor.io/tx/',
             account: 'https://doge1.trezor.io/xpub/',
@@ -189,6 +196,7 @@ export const networks = {
         networkType: 'bitcoin',
         bip43Path: "m/44'/7'/i'",
         decimals: 8,
+        testnet: false,
         explorer: {
             tx: 'https://nmc1.trezor.io/tx/',
             account: 'https://nmc1.trezor.io/xpub/',
@@ -203,6 +211,7 @@ export const networks = {
         networkType: 'bitcoin',
         bip43Path: "m/84'/28'/i'",
         decimals: 8,
+        testnet: false,
         explorer: {
             tx: 'https://vtc1.trezor.io/tx/',
             account: 'https://vtc1.trezor.io/xpub/',
@@ -224,6 +233,7 @@ export const networks = {
         networkType: 'bitcoin',
         bip43Path: "m/44'/133'/i'",
         decimals: 8,
+        testnet: false,
         explorer: {
             tx: 'https://zec1.trezor.io/tx/',
             account: 'https://zec1.trezor.io/xpub/',

--- a/suite-native/assets/src/assetsSelectors.ts
+++ b/suite-native/assets/src/assetsSelectors.ts
@@ -1,7 +1,7 @@
 import BigNumber from 'bignumber.js';
 import { memoize } from 'proxy-memoize';
 
-import { Network, networksCompatibility, NetworkSymbol } from '@suite-common/wallet-config';
+import { networks, NetworkSymbol } from '@suite-common/wallet-config';
 import { selectAccounts, AccountsRootState } from '@suite-common/wallet-core';
 import { selectCoinsLegacy, FiatRatesRootState } from '@suite-native/fiat-rates';
 import { toFiatCurrency } from '@suite-common/wallet-utils';
@@ -12,7 +12,7 @@ type FormattedAssets = Partial<Record<NetworkSymbol, BigNumber>>;
 
 export interface AssetType {
     symbol: NetworkSymbol;
-    network: Network;
+    network: (typeof networks)[NetworkSymbol];
     assetBalance: BigNumber;
     fiatBalance: string;
 }
@@ -51,13 +51,7 @@ export const selectAssetsWithBalances = memoize((state: AssetsRootState) => {
 
     return networksWithAssets
         .map((networkSymbol: NetworkSymbol) => {
-            const network = networksCompatibility.find(
-                n => n.symbol === networkSymbol && !n.accountType,
-            );
-            if (!network) {
-                console.error('unknown network', networkSymbol);
-                return;
-            }
+            const network = networks[networkSymbol];
 
             const currentFiatRates = coins.find(
                 f => f.symbol.toLowerCase() === networkSymbol.toLowerCase(),

--- a/suite-native/assets/src/tests/fixtures/assets.ts
+++ b/suite-native/assets/src/tests/fixtures/assets.ts
@@ -1,66 +1,25 @@
 import BigNumber from 'bignumber.js';
 
+import { networks } from '@suite-common/wallet-config';
+
 import { AssetType } from '../../assetsSelectors';
 
 export const assetsFixtureZeroBalance: AssetType[] = [
     {
         symbol: 'btc',
-        network: {
-            symbol: 'btc',
-            name: 'Bitcoin',
-            networkType: 'bitcoin',
-            bip43Path: "m/84'/0'/i'",
-            decimals: 8,
-            explorer: {
-                tx: 'https://btc1.trezor.io/tx/',
-                account: 'https://btc1.trezor.io/xpub/',
-                address: 'https://btc1.trezor.io/address/',
-            },
-            features: ['rbf', 'sign-verify', 'amount-unit'],
-            customBackends: ['blockbook', 'electrum'],
-        },
+        network: networks.btc,
         assetBalance: BigNumber(0),
         fiatBalance: '0.00',
     },
     {
         symbol: 'eth',
-        network: {
-            symbol: 'eth',
-            name: 'Ethereum',
-            networkType: 'ethereum',
-            chainId: 1,
-            bip43Path: "m/44'/60'/0'/0/i",
-            decimals: 18,
-            explorer: {
-                tx: 'https://eth1.trezor.io/tx/',
-                account: 'https://eth1.trezor.io/address/',
-                address: 'https://eth1.trezor.io/address/',
-                nft: 'https://eth1.trezor.io/nft/',
-            },
-            features: ['rbf', 'sign-verify', 'tokens'],
-            label: 'TR_NETWORK_ETHEREUM_LABEL',
-            tooltip: 'TR_NETWORK_ETHEREUM_TOOLTIP',
-            customBackends: ['blockbook'],
-        },
+        network: networks.eth,
         assetBalance: BigNumber(0),
         fiatBalance: '0.00',
     },
     {
         symbol: 'ltc',
-        network: {
-            symbol: 'ltc',
-            name: 'Litecoin',
-            networkType: 'bitcoin',
-            bip43Path: "m/84'/2'/i'",
-            decimals: 8,
-            explorer: {
-                tx: 'https://ltc1.trezor.io/tx/',
-                account: 'https://ltc1.trezor.io/xpub/',
-                address: 'https://ltc1.trezor.io/address/',
-            },
-            features: ['sign-verify'],
-            customBackends: ['blockbook'],
-        },
+        network: networks.ltc,
         assetBalance: BigNumber(0),
         fiatBalance: '0.00',
     },
@@ -69,62 +28,19 @@ export const assetsFixtureZeroBalance: AssetType[] = [
 export const assetsFixtureWithBalance: AssetType[] = [
     {
         symbol: 'btc',
-        network: {
-            symbol: 'btc',
-            name: 'Bitcoin',
-            networkType: 'bitcoin',
-            bip43Path: "m/84'/0'/i'",
-            decimals: 8,
-            explorer: {
-                tx: 'https://btc1.trezor.io/tx/',
-                account: 'https://btc1.trezor.io/xpub/',
-                address: 'https://btc1.trezor.io/address/',
-            },
-            features: ['rbf', 'sign-verify', 'amount-unit'],
-            customBackends: ['blockbook', 'electrum'],
-        },
+        network: networks.btc,
         assetBalance: BigNumber(0.00569722),
         fiatBalance: '98.26',
     },
     {
         symbol: 'eth',
-        network: {
-            symbol: 'eth',
-            name: 'Ethereum',
-            networkType: 'ethereum',
-            chainId: 1,
-            bip43Path: "m/44'/60'/0'/0/i",
-            decimals: 18,
-            explorer: {
-                tx: 'https://eth1.trezor.io/tx/',
-                account: 'https://eth1.trezor.io/address/',
-                address: 'https://eth1.trezor.io/address/',
-                nft: 'https://eth1.trezor.io/nft/',
-            },
-            features: ['rbf', 'sign-verify', 'tokens'],
-            label: 'TR_NETWORK_ETHEREUM_LABEL',
-            tooltip: 'TR_NETWORK_ETHEREUM_TOOLTIP',
-            customBackends: ['blockbook'],
-        },
+        network: networks.eth,
         assetBalance: BigNumber(0.02142776807619),
         fiatBalance: '28.25',
     },
     {
         symbol: 'ltc',
-        network: {
-            symbol: 'ltc',
-            name: 'Litecoin',
-            networkType: 'bitcoin',
-            bip43Path: "m/84'/2'/i'",
-            decimals: 8,
-            explorer: {
-                tx: 'https://ltc1.trezor.io/tx/',
-                account: 'https://ltc1.trezor.io/xpub/',
-                address: 'https://ltc1.trezor.io/address/',
-            },
-            features: ['sign-verify'],
-            customBackends: ['blockbook'],
-        },
+        network: networks.ltc,
         assetBalance: BigNumber(0),
         fiatBalance: '0.00',
     },
@@ -133,20 +49,7 @@ export const assetsFixtureWithBalance: AssetType[] = [
 export const assetsFixtureSingleAsset: AssetType[] = [
     {
         symbol: 'btc',
-        network: {
-            symbol: 'btc',
-            name: 'Bitcoin',
-            networkType: 'bitcoin',
-            bip43Path: "m/84'/0'/i'",
-            decimals: 8,
-            explorer: {
-                tx: 'https://btc1.trezor.io/tx/',
-                account: 'https://btc1.trezor.io/xpub/',
-                address: 'https://btc1.trezor.io/address/',
-            },
-            features: ['rbf', 'sign-verify', 'amount-unit'],
-            customBackends: ['blockbook', 'electrum'],
-        },
+        network: networks.btc,
         assetBalance: BigNumber(0.00569722),
         fiatBalance: '98.26',
     },


### PR DESCRIPTION
Fallback from coingecko provided some ETH fiat rate instead of token rate.

Also prevent fetch for `testnet `coins.

## Description

<!--- Describe your changes in detail -->

## Related Issue

Resolve #8198 

## Screenshots:
