### PR TITLE
Move deprecated Storybook option to config

### DIFF
--- a/ci/build.yml
+++ b/ci/build.yml
@@ -270,10 +270,7 @@ connect-web build:
 .run_components_rules: &run_components_rules
   refs:
     - develop
-    - releases
     - schedules
-    - /^release\//
-    - /^run\//
   changes:
     - packages/components
     - packages/components-storybook

--- a/ci/deploy.yml
+++ b/ci/deploy.yml
@@ -113,10 +113,10 @@ connect deploy to dev:
   refs:
     - develop
     - schedules
-    - /^run\//
   changes:
     - packages/components
     - packages/components-storybook
+    - yarn.lock
 
 # Deploy
 

--- a/packages/components/.storybook/main.js
+++ b/packages/components/.storybook/main.js
@@ -19,4 +19,5 @@ module.exports = {
     core: {
         builder: 'webpack5',
     },
+    staticDirs: ['../public'],
 };

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -13,8 +13,8 @@
         "lint-fix": "npx eslint ./src --fix",
         "type-check": "tsc --build tsconfig.json",
         "type-check:watch": "yarn type-check -- --watch",
-        "storybook": "start-storybook -s ./public -p 9003 -c .storybook",
-        "storybook-build": "build-storybook -s ./public -c .storybook -o .build-storybook"
+        "storybook": "start-storybook -p 9003 -c .storybook",
+        "storybook-build": "build-storybook -c .storybook -o .build-storybook"
     },
     "dependencies": {
         "@tippyjs/react": "^4.2.6",


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Gets rid of a deprecation warning. Docs: https://github.com/storybookjs/storybook/blob/next/MIGRATION.md#deprecated---static-dir-cli-flag
