### PR TITLE
fix: connect cannot read asArray of undefined

### DIFF
--- a/ci/test.yml
+++ b/ci/test.yml
@@ -226,6 +226,7 @@ transport manual:
       - TEST_FILE: ["popup-close"]
       - TEST_FILE: ["unchained"]
       - TEST_FILE: ["browser-support"]
+      - TEST_FILE: ["install-bridge"]
 
 connect-popup:
   extends: .e2e connect-popup

--- a/packages/connect-popup/e2e/tests/install-bridge.test.ts
+++ b/packages/connect-popup/e2e/tests/install-bridge.test.ts
@@ -1,0 +1,25 @@
+import { test, expect, Page } from '@playwright/test';
+import { TrezorUserEnvLink } from '@trezor/trezor-user-env-link';
+
+const url = process.env.URL || 'http://localhost:8088/';
+
+let popup: Page;
+
+test.beforeAll(async () => {
+    await TrezorUserEnvLink.connect();
+    await TrezorUserEnvLink.api.stopBridge();
+    await TrezorUserEnvLink.api.stopEmu();
+});
+
+test('if bridge is not running, connect popup renders "install bridge" screen', async ({
+    page,
+}) => {
+    await page.goto(`${url}#/method/verifyMessage`);
+
+    [popup] = await Promise.all([
+        page.waitForEvent('popup'),
+        page.click("button[data-test='@submit-button']"),
+    ]);
+
+    await expect(popup.getByRole('heading', { name: 'Install Bridge' })).toBeVisible();
+});

--- a/packages/connect/src/core/index.ts
+++ b/packages/connect/src/core/index.ts
@@ -240,6 +240,11 @@ const initDevice = async (method: AbstractMethod) => {
         // wait for popup handshake
         await getPopupPromise().promise;
 
+        // there is await above, _deviceList might have been set to undefined.
+        if (!_deviceList) {
+            throw ERRORS.TypedError('Transport_Missing');
+        }
+
         // check again for available devices
         // there is a possible race condition before popup open
         const devices = _deviceList.asArray();


### PR DESCRIPTION
occasionally, connect retuns runtime errror `cannot read .asArray of undefined`. This is a race condition which happens if you have `transportReconnect:true` and bridge off. When re-initiliazing `_deviceList` it is set to undefined at one moment and when winds are (un)favorable access to _deviceList might be invoked. 

How to reproduce:
1. go to https://connect.trezor.io/9/#/method/getPublicKey 
2. turn off bridge
3. click getPublicKey
4. have luck

The fix is basically doing the same as you can see on the line 210. This is later handled in catch block on line 362 -> which results into displaying "install bridge page" correctly.

