### PR TITLE
fix(suite-native): analytics init

### DIFF
--- a/packages/analytics/src/types.ts
+++ b/packages/analytics/src/types.ts
@@ -1,6 +1,6 @@
-export type App = 'suite' | 'connect' | 'mobile';
+export type App = 'suite' | 'connect';
 
-export type Environment = 'desktop' | 'web';
+export type Environment = 'desktop' | 'web' | 'mobile';
 
 export type InitOptions = {
     sessionId?: string;

--- a/suite-native/analytics/src/analytics.ts
+++ b/suite-native/analytics/src/analytics.ts
@@ -3,7 +3,7 @@ import { Analytics } from '@trezor/analytics';
 
 import { SuiteNativeAnalyticsEvent } from './events';
 
-export const analytics = new Analytics<SuiteNativeAnalyticsEvent>(getAppVersion(), 'mobile');
+export const analytics = new Analytics<SuiteNativeAnalyticsEvent>(getAppVersion(), 'suite');
 
 if (isDebugEnv()) {
     // Do not send analytics in development

--- a/suite-native/analytics/src/analyticsThunks.ts
+++ b/suite-native/analytics/src/analyticsThunks.ts
@@ -46,6 +46,7 @@ export const initAnalyticsThunk = createThunk(
         analytics.init(userAllowedTracking, {
             instanceId,
             sessionId,
+            environment: 'mobile',
             commitId: getCommitHash(),
             isDev: isDevelopEnv(),
             callbacks: {


### PR DESCRIPTION
## Description

Suite-native analytics are now initialized with the correct `environment: "mobile"` parameter. Analytics should finally be reported from our builds 🎉.

