### PR TITLE
fix(suite-native): crypto amount formatter decimals

### DIFF
--- a/suite-native/accounts/src/components/AccountListItem.tsx
+++ b/suite-native/accounts/src/components/AccountListItem.tsx
@@ -88,6 +88,8 @@ export const AccountListItem = ({ account }: AccountListItemProps) => {
                     value={account.balance}
                     network={account.symbol}
                     isBalance={false}
+                    numberOfLines={1}
+                    adjustsFontSizeToFit
                 />
             </Box>
         </Box>

--- a/suite-native/formatters/src/components/CryptoAmountFormatter.tsx
+++ b/suite-native/formatters/src/components/CryptoAmountFormatter.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 
 import { TextProps } from '@suite-native/atoms';
 import { useFormatters } from '@suite-common/formatters';
-import { NetworkSymbol } from '@suite-common/wallet-config';
+import { networks, NetworkSymbol } from '@suite-common/wallet-config';
 
 import { FormatterProps } from '../types';
 import { EmptyAmountText } from './EmptyAmountText';
@@ -28,10 +28,12 @@ export const CryptoAmountFormatter = ({
 
     if (!value) return <EmptyAmountText />;
 
+    const maxDisplayedDecimals = networks[network].decimals;
+
     const formattedValue = formatter.format(value, {
         isBalance,
+        maxDisplayedDecimals,
         symbol: network,
-        maxDisplayedDecimals: undefined,
         isEllipsisAppended: false,
     });
 

--- a/suite-native/transactions/src/components/TransactionsList/TransactionListItem.tsx
+++ b/suite-native/transactions/src/components/TransactionsList/TransactionListItem.tsx
@@ -64,6 +64,8 @@ export const TransactionListItemValues = ({
                 value={transaction.amount}
                 network={transaction.symbol}
                 isBalance={false}
+                numberOfLines={1}
+                adjustsFontSizeToFit
             />
         </>
     );


### PR DESCRIPTION
## Description

- crypto amount formatter reflects network config max decimals

## Related Issue

Fixes #8168 

## Screenshots:
<div style="display: flex;">
<img width="250" alt="Snímek obrazovky 2023-04-25 v 12 11 46" src="https://user-images.githubusercontent.com/26143964/234247243-e8c2bfd2-1618-4d5b-8e18-efcd22ae1b4c.png">
<img width="250" alt="Snímek obrazovky 2023-04-25 v 12 11 02" src="https://user-images.githubusercontent.com/26143964/234247254-e126d7d9-86e6-44a5-a825-752519a3d9f2.png">
</div>
