### PR TITLE
fix(suite-native): eth item layout without tokens

### DIFF
--- a/suite-native/accounts/src/components/AccountListItem.tsx
+++ b/suite-native/accounts/src/components/AccountListItem.tsx
@@ -17,10 +17,11 @@ import { SettingsSliceRootState } from '@suite-native/module-settings';
 
 export type AccountListItemProps = {
     account: Account;
+    areTokensDisplayed?: boolean;
 };
 
-const accountListItemStyle = prepareNativeStyle<{ isAccountWithTokens: boolean }>(
-    (utils, { isAccountWithTokens }) => ({
+const accountListItemStyle = prepareNativeStyle<{ isAccountContainingTokens: boolean }>(
+    (utils, { isAccountContainingTokens }) => ({
         flexDirection: 'row',
         justifyContent: 'space-between',
         alignItem: 'center',
@@ -28,7 +29,7 @@ const accountListItemStyle = prepareNativeStyle<{ isAccountWithTokens: boolean }
         padding: utils.spacings.medium,
         borderRadius: utils.borders.radii.medium,
         extend: {
-            condition: isAccountWithTokens,
+            condition: isAccountContainingTokens,
             style: {
                 paddingBottom: 0,
             },
@@ -47,7 +48,7 @@ export const valuesContainerStyle = prepareNativeStyle(utils => ({
     paddingLeft: utils.spacings.small,
 }));
 
-export const AccountListItem = ({ account }: AccountListItemProps) => {
+export const AccountListItem = ({ account, areTokensDisplayed = false }: AccountListItemProps) => {
     const { applyStyle } = useNativeStyles();
     const accountLabel = useSelector((state: AccountsRootState) =>
         selectAccountLabel(state, account.key),
@@ -64,7 +65,7 @@ export const AccountListItem = ({ account }: AccountListItemProps) => {
     return (
         <Box
             style={applyStyle(accountListItemStyle, {
-                isAccountWithTokens,
+                isAccountContainingTokens: areTokensDisplayed && isAccountWithTokens,
             })}
         >
             <Box flexDirection="row" alignItems="center" flex={1}>

--- a/suite-native/accounts/src/components/AccountListItemInteractive.tsx
+++ b/suite-native/accounts/src/components/AccountListItemInteractive.tsx
@@ -10,17 +10,23 @@ import { TokenList } from './TokenList';
 
 interface AccountListItemInteractiveProps extends AccountListItemProps {
     onSelectAccount: (accountKey: AccountKey, tokenSymbol?: TokenSymbol) => void;
+    areTokensDisplayed: boolean;
 }
 
 export const AccountListItemInteractive = ({
     account,
     onSelectAccount,
+    areTokensDisplayed,
 }: AccountListItemInteractiveProps) => (
     <Box>
         <TouchableOpacity onPress={() => onSelectAccount(account.key)}>
-            <AccountListItem key={account.key} account={account} />
+            <AccountListItem
+                key={account.key}
+                account={account}
+                areTokensDisplayed={areTokensDisplayed}
+            />
         </TouchableOpacity>
-        {isEthereumAccountSymbol(account.symbol) && (
+        {areTokensDisplayed && isEthereumAccountSymbol(account.symbol) && (
             <TokenList accountKey={account.key} onSelectAccount={onSelectAccount} />
         )}
     </Box>

--- a/suite-native/accounts/src/components/AccountsList.tsx
+++ b/suite-native/accounts/src/components/AccountsList.tsx
@@ -12,9 +12,10 @@ import { AccountsListGroup } from './AccountsListGroup';
 
 type AccountsListProps = {
     onSelectAccount: (accountKey: AccountKey, tokenSymbol?: EthereumTokenSymbol) => void;
+    areTokensDisplayed: boolean;
 };
 
-export const AccountsList = ({ onSelectAccount }: AccountsListProps) => {
+export const AccountsList = ({ onSelectAccount, areTokensDisplayed }: AccountsListProps) => {
     const accountsSymbols = useSelector(selectAccountsSymbols);
     const accounts = useSelector(selectAccounts);
 
@@ -23,7 +24,12 @@ export const AccountsList = ({ onSelectAccount }: AccountsListProps) => {
     return (
         <>
             {accountsSymbols.map(symbol => (
-                <AccountsListGroup key={symbol} symbol={symbol} onSelectAccount={onSelectAccount} />
+                <AccountsListGroup
+                    key={symbol}
+                    symbol={symbol}
+                    onSelectAccount={onSelectAccount}
+                    areTokensDisplayed={areTokensDisplayed}
+                />
             ))}
         </>
     );

--- a/suite-native/accounts/src/components/AccountsListGroup.tsx
+++ b/suite-native/accounts/src/components/AccountsListGroup.tsx
@@ -13,6 +13,7 @@ import { AccountListItemInteractive } from './AccountListItemInteractive';
 type AccountsListGroupProps = {
     symbol: NetworkSymbol;
     onSelectAccount: (accountKey: AccountKey, tokenSymbol?: EthereumTokenSymbol) => void;
+    areTokensDisplayed: boolean;
 };
 
 const accountListGroupStyle = prepareNativeStyle(utils => ({
@@ -21,7 +22,11 @@ const accountListGroupStyle = prepareNativeStyle(utils => ({
     marginBottom: utils.spacings.small,
 }));
 
-export const AccountsListGroup = ({ symbol, onSelectAccount }: AccountsListGroupProps) => {
+export const AccountsListGroup = ({
+    symbol,
+    onSelectAccount,
+    areTokensDisplayed,
+}: AccountsListGroupProps) => {
     const { applyStyle } = useNativeStyles();
     const symbols = useMemo(() => [symbol], [symbol]);
     const accounts = useSelector((state: AccountsRootState) =>
@@ -36,6 +41,7 @@ export const AccountsListGroup = ({ symbol, onSelectAccount }: AccountsListGroup
                     key={account.key}
                     account={account}
                     onSelectAccount={onSelectAccount}
+                    areTokensDisplayed={areTokensDisplayed}
                 />
             ))}
         </Box>

--- a/suite-native/module-accounts/src/screens/AccountsScreen.tsx
+++ b/suite-native/module-accounts/src/screens/AccountsScreen.tsx
@@ -27,7 +27,7 @@ export const AccountsScreen = () => {
 
     return (
         <Screen header={<AccountsScreenHeader />}>
-            <AccountsList onSelectAccount={handleSelectAccount} />
+            <AccountsList onSelectAccount={handleSelectAccount} areTokensDisplayed />
         </Screen>
     );
 };

--- a/suite-native/module-send-receive/src/screens/ReceiveAccountsScreen.tsx
+++ b/suite-native/module-send-receive/src/screens/ReceiveAccountsScreen.tsx
@@ -18,7 +18,7 @@ export const ReceiveAccountsScreen = ({
 
     return (
         <Screen header={<ScreenHeader content="Receive to" hasGoBackIcon={false} />}>
-            <AccountsList onSelectAccount={navigateToReceiveScreen} />
+            <AccountsList onSelectAccount={navigateToReceiveScreen} areTokensDisplayed={false} />
         </Screen>
     );
 };


### PR DESCRIPTION
## Description

- eth account list item has correct padding if does not  render tokens

## Screenshots:

https://user-images.githubusercontent.com/26143964/234296145-cbaa8caa-2f1b-4699-93ac-62a75804cee8.mov

