### PR TITLE
fix(suite): pin and passphrase modal cancellable

### DIFF
--- a/packages/components/src/components/Passphrase/PassphraseTypeCard.tsx
+++ b/packages/components/src/components/Passphrase/PassphraseTypeCard.tsx
@@ -157,11 +157,6 @@ const Content = styled.div`
     font-size: ${variables.FONT_SIZE.SMALL};
 `;
 
-const RetryButton = styled(Button)`
-    align-self: center;
-    margin-top: 16px;
-`;
-
 type PassphraseTypeCardProps = {
     title?: React.ReactNode;
     description?: React.ReactNode;
@@ -171,7 +166,6 @@ type PassphraseTypeCardProps = {
     singleColModal?: boolean;
     authConfirmation?: boolean;
     onSubmit: (value: string, passphraseOnDevice?: boolean) => void;
-    recreateWallet?: () => void;
     learnMoreTooltipOnClick?: TooltipProps['guideAnchor'];
     learnMoreTooltipAppendTo?: TooltipProps['appendTo'];
 };
@@ -426,17 +420,6 @@ export const PassphraseTypeCard = (props: PassphraseTypeCardProps) => {
                                     defaultMessage="Enter passphrase on Trezor"
                                 />
                             </OnDeviceActionButton>
-                        )}
-                        {/* Try again button shows while confirming a passphrase */}
-                        {props.recreateWallet && (
-                            <RetryButton
-                                variant="tertiary"
-                                icon="ARROW_LEFT"
-                                color={theme.TYPE_LIGHT_GREY}
-                                onClick={props.recreateWallet}
-                            >
-                                <FormattedMessage id="TR_TRY_AGAIN" defaultMessage="Try again" />
-                            </RetryButton>
                         )}
                     </Actions>
                 )}

--- a/packages/suite/src/actions/suite/modalActions.ts
+++ b/packages/suite/src/actions/suite/modalActions.ts
@@ -190,10 +190,6 @@ export const onPinSubmit = (payload: string) => () => {
     TrezorConnect.uiResponse({ type: UI.RECEIVE_PIN, payload });
 };
 
-export const onPinCancel = () => () => {
-    TrezorConnect.cancel('pin-cancelled');
-};
-
 /**
  * Called from <PassphraseModal /> component
  * Sends passphrase to `@trezor/connect`

--- a/packages/suite/src/components/suite/ModalSwitcher/DeviceContextModal.tsx
+++ b/packages/suite/src/components/suite/ModalSwitcher/DeviceContextModal.tsx
@@ -1,8 +1,7 @@
 import React from 'react';
 import { UI } from '@trezor/connect';
-import { onPinCancel } from '@suite-actions/modalActions';
 import { MODAL } from '@suite-actions/constants';
-import { useSelector, useActions } from '@suite-hooks';
+import { useSelector } from '@suite-hooks';
 import {
     Pin,
     PinInvalid,
@@ -24,13 +23,12 @@ export const DeviceContextModal = ({
     renderer,
 }: ReduxModalProps<typeof MODAL.CONTEXT_DEVICE>) => {
     const device = useSelector(state => state.suite.device);
-    const actions = useActions({ onPinCancel });
     if (!device) return null;
 
     switch (windowType) {
         // T1 firmware
         case UI.REQUEST_PIN:
-            return <Pin device={device} onCancel={actions.onPinCancel} renderer={renderer} />;
+            return <Pin device={device} renderer={renderer} />;
         // T1 firmware
         case UI.INVALID_PIN:
             return <PinInvalid device={device} renderer={renderer} />;

--- a/packages/suite/src/components/suite/PinInput/index.tsx
+++ b/packages/suite/src/components/suite/PinInput/index.tsx
@@ -71,8 +71,6 @@ const PinInput = ({ isSubmitting, onPinSubmit }: Props) => {
 
     useEffect(() => {
         const keyboardHandler = (event: KeyboardEvent) => {
-            event.preventDefault();
-
             switch (event.code) {
                 case KEYBOARD_CODE.ENTER:
                 case KEYBOARD_CODE.NUMPAD_ENTER:

--- a/packages/suite/src/components/suite/modals/Passphrase/index.tsx
+++ b/packages/suite/src/components/suite/modals/Passphrase/index.tsx
@@ -33,7 +33,7 @@ const Divider = styled.div`
 `;
 
 const TinyModal = styled(Modal)`
-    width: 360px;
+    width: 450px;
 `;
 
 const SmallModal = styled(Modal)`
@@ -63,6 +63,8 @@ export const Passphrase = ({ device }: Props) => {
 
     const dispatch = useDispatch();
 
+    const onCancel = () => TrezorConnect.cancel();
+
     const onSubmit = useCallback(
         (value: string, passphraseOnDevice?: boolean) => {
             setSubmitted(true);
@@ -91,6 +93,9 @@ export const Passphrase = ({ device }: Props) => {
                         <Translation id="TR_CONFIRM_EMPTY_HIDDEN_WALLET" />
                     )
                 }
+                isCancelable
+                onCancel={onCancel}
+                onBackClick={authConfirmation ? onRecreate : undefined}
                 description={
                     !authConfirmation ? (
                         <Translation id="TR_UNLOCK" />
@@ -102,7 +107,6 @@ export const Passphrase = ({ device }: Props) => {
                 <PassphraseTypeCard
                     type="hidden"
                     authConfirmation={authConfirmation}
-                    recreateWallet={authConfirmation ? onRecreate : undefined}
                     submitLabel={<Translation id="TR_CONFIRM_PASSPHRASE" />}
                     offerPassphraseOnDevice={onDeviceOffer}
                     onSubmit={onSubmit}
@@ -125,6 +129,8 @@ export const Passphrase = ({ device }: Props) => {
             <TinyModal
                 heading={<Translation id="TR_PASSPHRASE_HIDDEN_WALLET" />}
                 description={<Translation id="TR_HIDDEN_WALLET_MODAL_DESCRIPTION" />}
+                isCancelable
+                onCancel={onCancel}
             >
                 <PassphraseTypeCard
                     title={<Translation id="TR_WALLET_SELECTION_HIDDEN_WALLET" />}
@@ -148,7 +154,11 @@ export const Passphrase = ({ device }: Props) => {
 
     // show 2-column modal for selecting between standard and hidden wallets
     return (
-        <SmallModal isCancelable={false} heading={<Translation id="TR_SELECT_WALLET_TO_ACCESS" />}>
+        <SmallModal
+            isCancelable
+            onCancel={onCancel}
+            heading={<Translation id="TR_SELECT_WALLET_TO_ACCESS" />}
+        >
             <Wrapper>
                 <WalletsWrapper>
                     <PassphraseTypeCard

--- a/packages/suite/src/components/suite/modals/Pin.tsx
+++ b/packages/suite/src/components/suite/modals/Pin.tsx
@@ -3,6 +3,7 @@ import styled from 'styled-components';
 import { Translation, Modal, ModalProps } from '@suite-components';
 import { PinMatrix, PIN_MATRIX_MAX_WIDTH } from '@suite-components/PinMatrix';
 import { TrezorDevice } from '@suite-types';
+import TrezorConnect from '@trezor/connect';
 
 const StyledModal = styled(Modal)<{ $isExtended: boolean }>`
     width: unset;
@@ -26,6 +27,8 @@ export const Pin = ({ device, ...rest }: PinProps) => {
 
     if (!device.features) return null;
 
+    const onCancel = () => TrezorConnect.cancel('pin-cancelled');
+
     // 3 cases when we want to show left column
     // 1) and 2) - Setting a new pin: 1 entry, 2nd (confirmation) entry
     // 3) Invalid pin (It doesn't seem to work anymore) instead separate PinMismatch modal is shown
@@ -45,9 +48,11 @@ export const Pin = ({ device, ...rest }: PinProps) => {
                 />
             }
             description={<Translation id="TR_THE_PIN_LAYOUT_IS_DISPLAYED" />}
-            {...rest}
+            onCancel={onCancel}
+            isCancelable
             data-test="@modal/pin"
             $isExtended={isExtended}
+            {...rest}
         >
             <PinMatrix device={device} hideExplanation={!isExtended} invalid={invalidCounter > 0} />
         </StyledModal>

--- a/packages/suite/src/components/wallet/AccountException/index.tsx
+++ b/packages/suite/src/components/wallet/AccountException/index.tsx
@@ -14,7 +14,6 @@ const Wrapper = styled.div`
     display: flex;
     flex-direction: column;
     align-items: center;
-    justify-content: center;
     height: 100%;
 `;
 

--- a/packages/suite/src/views/dashboard/components/AssetsCard/index.tsx
+++ b/packages/suite/src/views/dashboard/components/AssetsCard/index.tsx
@@ -66,6 +66,10 @@ const StyledAddAccountButton = styled(Button)`
     margin-left: 20px;
 `;
 
+const StyledIcon = styled(Icon)`
+    margin-right: 4px;
+`;
+
 interface assetType {
     symbol: string;
     network: Network;
@@ -187,12 +191,7 @@ const AssetsCard = () => {
 
                     {isError && (
                         <InfoMessage>
-                            <Icon
-                                style={{ paddingRight: '4px', paddingBottom: '2px' }}
-                                icon="WARNING"
-                                color={theme.TYPE_RED}
-                                size={14}
-                            />
+                            <StyledIcon icon="WARNING" color={theme.TYPE_RED} size={14} />
                             <Translation id="TR_DASHBOARD_ASSETS_ERROR" />
                         </InfoMessage>
                     )}


### PR DESCRIPTION
## Description

- cancellable pin
- cancellable wallet and hidden wallet
- closable app when pin modal opened

## Related Issue

closes #6941
closes #6643 (confirm on device abort is skipped for now, it's too generic)

## Screenshots:
![Screenshot 2023-04-26 at 9 38 57](https://user-images.githubusercontent.com/33235762/234504060-19715134-c195-431a-b6cd-f6cf1c27bd43.png)
![Screenshot 2023-04-26 at 9 39 46](https://user-images.githubusercontent.com/33235762/234504241-86f9e371-3687-4de3-be34-9bcd9670de07.png)
![Screenshot 2023-04-26 at 9 40 20](https://user-images.githubusercontent.com/33235762/234504392-c4f460d0-c55a-44ce-a314-f12eb9d7684d.png)
![Screenshot 2023-04-26 at 9 41 11](https://user-images.githubusercontent.com/33235762/234504583-93fb75ae-cfa5-47df-a8e0-5a4ee67d4f50.png)
![Screenshot 2023-04-26 at 13 24 41](https://user-images.githubusercontent.com/33235762/234564186-f92fb50b-533f-4207-a85f-000e41733511.png)
![Screenshot 2023-04-26 at 13 24 56](https://user-images.githubusercontent.com/33235762/234564192-213eba05-bca1-4f03-81c3-90c75ff8b3a0.png)
![Screenshot 2023-04-26 at 13 25 57](https://user-images.githubusercontent.com/33235762/234564193-1403f3d5-55ea-4844-b485-5eadce1cc48d.png)
![Screenshot 2023-04-26 at 13 43 17](https://user-images.githubusercontent.com/33235762/234564701-67a16656-0e44-42a7-a050-47fabba75c04.png)
