### PR TITLE
chore: move getFreePort to @trezor/node-utils

### DIFF
--- a/packages/node-utils/src/getFreePort.ts
+++ b/packages/node-utils/src/getFreePort.ts
@@ -1,6 +1,5 @@
 import net from 'net';
 
-// TODO: this could be added to @trezor/utils but considering is only for nodejs
 export const getFreePort = (): Promise<number> =>
     new Promise<number>((resolve, reject) => {
         const server = net.createServer();

--- a/packages/node-utils/src/index.ts
+++ b/packages/node-utils/src/index.ts
@@ -1,1 +1,2 @@
 export { ensureDirectoryExists } from './ensureDirectoryExists';
+export { getFreePort } from './getFreePort';

--- a/packages/suite-desktop/src/libs/processes/CoinjoinProcess.ts
+++ b/packages/suite-desktop/src/libs/processes/CoinjoinProcess.ts
@@ -1,5 +1,6 @@
+import { getFreePort } from '@trezor/node-utils';
+
 import { BaseProcess, Status } from './BaseProcess';
-import { getFreePort } from '../getFreePort';
 
 export class CoinjoinProcess extends BaseProcess {
     port = 37128; // Default port, that is going to be updated when starting the process.

--- a/packages/suite-desktop/src/modules/tor.ts
+++ b/packages/suite-desktop/src/modules/tor.ts
@@ -8,10 +8,10 @@ import path from 'path';
 import { TorStatus, BootstrapTorEvent, HandshakeTorModule } from '@trezor/suite-desktop-api';
 import { BootstrapEvent } from '@trezor/request-manager';
 import TrezorConnect from '@trezor/connect';
+import { getFreePort } from '@trezor/node-utils';
 
 import { TorProcess, TorProcessStatus } from '../libs/processes/TorProcess';
 import { app, ipcMain } from '../typed-electron';
-import { getFreePort } from '../libs/getFreePort';
 
 import type { Dependencies } from './index';
 


### PR DESCRIPTION
this is defined on couple of places so moving into a sharable package should help