### PR TITLE
Request manager refactoring

### DIFF
--- a/packages/request-manager/e2e/identities-stress.ts
+++ b/packages/request-manager/e2e/identities-stress.ts
@@ -1,5 +1,5 @@
 import path from 'path';
-import { createInterceptor, TorController, TorIdentities } from '../src';
+import { createInterceptor, TorController } from '../src';
 import { torRunner } from './torRunner';
 
 // The purpose of this script is to allow "manual" testing Tor identities changing some parameters.
@@ -17,7 +17,7 @@ const ipRegex = /\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3}/;
 
 const INTERCEPTOR = {
     handler: () => {},
-    getIsTorEnabled: () => true,
+    getTorSettings: () => ({ running: true, host, port }),
 };
 
 const testGetUrlHttps = 'https://check.torproject.org/';
@@ -43,7 +43,6 @@ const intervalBetweenRequests = 1000 * 20;
         torParams,
     });
 
-    TorIdentities.init(torController);
     // Waiting for Tor to be ready to accept successful connections.
     await torController.waitUntilAlive();
     console.log('Tor is ready to be used.');

--- a/packages/request-manager/src/torIdentities.ts
+++ b/packages/request-manager/src/torIdentities.ts
@@ -1,22 +1,20 @@
 import { SocksProxyAgent } from 'socks-proxy-agent';
-import { TorController } from './controller';
+import type { TorSettings } from './types';
 
 export class TorIdentities {
-    static torController: TorController;
-    static identities: { [key: string]: SocksProxyAgent };
+    private readonly getTorSettings: () => TorSettings;
+    private readonly identities: { [key: string]: SocksProxyAgent };
 
-    public static init(torController: TorController) {
-        this.torController = torController;
+    constructor(getTorSettings: () => TorSettings) {
+        this.getTorSettings = getTorSettings;
         this.identities = {};
-        // When initializing create default identity, so it is ready to use.
-        this.getIdentity('default');
     }
 
-    public static getIdentity(identity: string, timeout?: number): SocksProxyAgent {
-        if (!this.torController) {
-            throw new Error('TorIdentities is not initialized');
-        }
-
+    public getIdentity(
+        identity: string,
+        timeout?: number,
+        protocol?: 'http' | 'https',
+    ): SocksProxyAgent {
         const [user, password] = identity.split(':');
 
         if (this.identities[user] && password) {
@@ -25,16 +23,26 @@ export class TorIdentities {
             delete this.identities[user];
         }
 
+        const { host, port } = this.getTorSettings();
+
+        // TODO clean agents when host/port changes?
+
         if (!this.identities[user]) {
             this.identities[user] = new SocksProxyAgent({
-                hostname: this.torController.options.host,
-                port: this.torController.options.port,
+                hostname: host,
+                port,
                 userId: user,
                 password: password || user,
                 timeout,
             });
         }
 
-        return this.identities[user];
+        const agent = this.identities[user];
+
+        // @sentry/node (used in suite-desktop) is wrapping each outgoing request
+        // and requires protocol to be explicitly set to https while using TOR + https/wss address combination
+        if (protocol) agent.protocol = `${protocol}:`;
+
+        return agent;
     }
 }

--- a/packages/request-manager/src/types.ts
+++ b/packages/request-manager/src/types.ts
@@ -34,10 +34,16 @@ export type InterceptedEvent =
           type: 'ERROR' | 'ERROR_PROXY_TIMEOUT' | 'ERROR_PROXY_REJECTED';
       };
 
+export type TorSettings = {
+    host?: string;
+    port?: number;
+    running: boolean;
+};
+
 export type InterceptorOptions = {
     handler: (event: InterceptedEvent) => void;
-    getIsTorEnabled: () => boolean;
-    isDevEnv?: boolean;
+    getTorSettings: () => TorSettings;
+    allowTorBypass?: boolean;
     whitelistedHosts?: string[];
 };
 

--- a/packages/suite-desktop/src/index.d.ts
+++ b/packages/suite-desktop/src/index.d.ts
@@ -69,20 +69,6 @@ declare interface RequestInterceptor {
     offBeforeRequest(listener: BeforeRequestListener): void;
 }
 
-// Store
-declare interface LocalStore {
-    getWinBounds(): WinBounds;
-    setWinBounds(winBound: WinBounds): void;
-    getUpdateSettings(): UpdateSettings;
-    setUpdateSettings(updateSettings: UpdateSettings): void;
-    getTorSettings(): TorSettings;
-    setTorSettings(torSettings: TorSettings): void;
-    clear(): void;
-    // todo: this is a never ending story, should we model it as transport? processes? bridge?
-    getBridgeSettings(): BridgeSettings;
-    setBridgeSettings(bridgeSettings: BridgeSettings): void;
-}
-
 declare type WinBounds = {
     height: number;
     width: number;
@@ -99,20 +85,15 @@ declare type UpdateSettings = {
     allowPrerelease: boolean;
 };
 
-declare type TorSettings = {
-    /**
-     * True when tor should be enabled.
-     * Doesn't necessarily mean that the bundled tor is running
-     * as that depends on the address as well.
-     */
-    running: boolean;
-    /**
-     * Address of the tor process through which traffic is routed.
-     * If it's anything other than the default one assume user
-     * wants to use their own tor instance and don't run the bundled one.
-     */
-    address: string;
-};
+declare type TorSettings =
+    | {
+          running: false; // Tor should be disabled
+      }
+    | {
+          running: true; // Tor should be enabled
+          host: string; // Hostname of the tor process through which traffic is routed
+          port: number; // Port of the tor process through which traffic is routed
+      };
 
 declare type BridgeSettings = {
     /**

--- a/packages/suite-desktop/src/libs/processes/TorProcess.ts
+++ b/packages/suite-desktop/src/libs/processes/TorProcess.ts
@@ -1,4 +1,4 @@
-import { TorController, TorIdentities, TOR_CONTROLLER_STATUS } from '@trezor/request-manager';
+import { TorController, TOR_CONTROLLER_STATUS } from '@trezor/request-manager';
 
 import { BaseProcess, Status } from './BaseProcess';
 
@@ -48,10 +48,7 @@ export class TorProcess extends BaseProcess {
         const torConfiguration = this.torController.getTorConfiguration(electronProcessId);
 
         await super.start(torConfiguration);
-        // Initialize TorIdentities with TorController so requests are intercepted to use Tor.
-        // `TorIdentities` needs to be initialized with `TorController` because it needs to know the
-        // `host` and `port` of the Tor process to create SocksProxyAgent.
-        TorIdentities.init(this.torController);
+
         return this.torController.waitUntilAlive();
     }
 }

--- a/packages/suite-desktop/src/libs/store.ts
+++ b/packages/suite-desktop/src/libs/store.ts
@@ -4,9 +4,11 @@ import { SuiteThemeVariant } from '@trezor/suite-desktop-api';
 
 import { getInitialWindowSize } from './screen';
 
+type OnDidChangeCallback<T> = (newValue?: T, oldValue?: T) => void;
+
 export class Store {
     private static instance: Store;
-    private store: ElectronStore<{
+    private readonly store: ElectronStore<{
         winBounds: WinBounds;
         updateSettings: UpdateSettings;
         themeSettings: SuiteThemeVariant;
@@ -54,13 +56,15 @@ export class Store {
     }
 
     public getTorSettings() {
-        return this.store.get('torSettings', {
-            running: false,
-            address: '',
-        });
+        return this.store.get('torSettings', { running: false });
     }
+
     public setTorSettings(torSettings: TorSettings) {
         this.store.set('torSettings', torSettings);
+    }
+
+    public onTorSettingsChange(callback: OnDidChangeCallback<TorSettings>) {
+        return this.store.onDidChange('torSettings', callback);
     }
 
     public getBridgeSettings() {

--- a/packages/suite-desktop/src/modules/index.ts
+++ b/packages/suite-desktop/src/modules/index.ts
@@ -7,6 +7,7 @@ import { isDevEnv } from '@suite-common/suite-utils';
 import type { HandshakeClient } from '@trezor/suite-desktop-api';
 
 import { StrictBrowserWindow } from '../typed-electron';
+import type { Store } from '../libs/store';
 
 // General modules (both dev & prod)
 const MODULES = [
@@ -41,7 +42,7 @@ const MODULES = [
 
 export type Dependencies = {
     mainWindow: StrictBrowserWindow;
-    store: LocalStore;
+    store: Store;
     interceptor: RequestInterceptor;
 };
 

--- a/packages/suite-desktop/src/modules/request-interceptor.ts
+++ b/packages/suite-desktop/src/modules/request-interceptor.ts
@@ -34,8 +34,8 @@ export const init: Module = ({ mainWindow, store }) => {
                 });
             }
         },
-        getIsTorEnabled: () => store.getTorSettings().running,
-        isDevEnv,
+        getTorSettings: () => store.getTorSettings(),
+        allowTorBypass: isDevEnv,
         whitelistedHosts: ['127.0.0.1', 'localhost', '.sldev.cz'],
     };
 

--- a/packages/suite-desktop/src/modules/trezor-connect.ts
+++ b/packages/suite-desktop/src/modules/trezor-connect.ts
@@ -14,7 +14,7 @@ export const init: Module = ({ store }) => {
     const setProxy = (ifRunning = false) => {
         const tor = store.getTorSettings();
         if (ifRunning && !tor.running) return Promise.resolve();
-        const payload = tor.running ? { proxy: `socks://${tor.address}` } : { proxy: '' };
+        const payload = tor.running ? { proxy: `socks://${tor.host}:${tor.port}` } : { proxy: '' };
         logger.info(SERVICE_NAME, `${tor.running ? 'Enable' : 'Disable'} proxy ${payload.proxy}`);
         return TrezorConnect.setProxy(payload);
     };


### PR DESCRIPTION
## Description

In order to use `createInterceptor` from `@trezor/request-manager` in background processes without the need to initialize `TorController` as well, little refactoring was needed.

## Commits

- https://github.com/trezor/trezor-suite/pull/8271/commits/e9d405fa5faa15bfd99689e7ea7c51c179a1f89d
  - remove `LocalStore` from global types as it seemed to be unused
  - `TorSettings` are now stored as _running, host, port_ instead of _running, address_ (migration hopefully not needed)
  - added `onTorSettingsChange` to listen to changes in Tor settings
- https://github.com/trezor/trezor-suite/pull/8271/commits/eb75f404bcbeb0d8080411f9d7185e3dc6b489c8
  - `TorIdentities` isn't singleton anymore (instantiated in `createInterceptor` instead) and is independent on `TorController` (replaced by `getTorSettings` func)
  - `createInterceptor` now takes `getTorSettings` instead of `getIsTorEnabled` (adding host and port)
  - `isDevEnv` renamed to `warnOnly`
- https://github.com/trezor/trezor-suite/pull/8271/commits/713a9a269949c1efe5c2a2759a9d06091a94e31e
  - tests fixed

## Related Issue

Prerequisite for #8034