### PR TITLE
fix(suite): fee display and calculation in day headers

### DIFF
--- a/packages/suite/src/components/suite/modals/TransactionDetail/components/AmountDetails.tsx
+++ b/packages/suite/src/components/suite/modals/TransactionDetail/components/AmountDetails.tsx
@@ -11,6 +11,7 @@ import {
     formatNetworkAmount,
     getTxOperation,
     isNftTokenTransfer,
+    isTxOwned,
 } from '@suite-common/wallet-utils';
 import BigNumber from 'bignumber.js';
 import { FormattedNftAmount } from '@suite-components/FormattedNftAmount';
@@ -228,7 +229,7 @@ export const AmountDetails = ({ tx, isTestnet }: AmountDetailsProps) => {
                 ))}
 
                 {/* TX FEE */}
-                {tx.type !== 'recv' && (
+                {isTxOwned(tx) && (
                     <AmountRow
                         firstColumn={<Translation id="TR_TX_FEE" />}
                         secondColumn={

--- a/packages/suite/src/components/suite/modals/TransactionDetail/components/IODetails.tsx
+++ b/packages/suite/src/components/suite/modals/TransactionDetail/components/IODetails.tsx
@@ -77,14 +77,7 @@ const GridItem = styled.div<{ isAccountOwned?: boolean }>`
     font-weight: ${variables.FONT_WEIGHT.MEDIUM};
     font-size: ${variables.NEUE_FONT_SIZE.TINY};
     color: ${({ theme }) => theme.TYPE_LIGHT_GREY};
-
-    :nth-child(3n + 1) {
-        max-width: 290px;
-    }
-
-    :nth-child(3n + 3) {
-        max-width: 290px;
-    }
+    max-width: 290px;
 
     & + & {
         margin-top: 10px;

--- a/packages/suite/src/components/wallet/TransactionItem/index.tsx
+++ b/packages/suite/src/components/wallet/TransactionItem/index.tsx
@@ -128,14 +128,11 @@ const TransactionItem = React.memo(
             | { type: 'token'; payload: (typeof tokens)[number] }
             | { type: 'internal'; payload: (typeof internalTransfers)[number] }
             | { type: 'target'; payload: WalletAccountTransaction['targets'][number] }
-        )[] =
-            transaction.type === 'self'
-                ? [...targets.map(t => ({ type: 'target' as const, payload: t }))]
-                : [
-                      ...targets.map(t => ({ type: 'target' as const, payload: t })),
-                      ...internalTransfers.map(t => ({ type: 'internal' as const, payload: t })),
-                      ...tokens.map(t => ({ type: 'token' as const, payload: t })),
-                  ];
+        )[] = [
+            ...targets.map(t => ({ type: 'target' as const, payload: t })),
+            ...internalTransfers.map(t => ({ type: 'internal' as const, payload: t })),
+            ...tokens.map(t => ({ type: 'token' as const, payload: t })),
+        ];
 
         const previewTargets = allOutputs.slice(0, DEFAULT_LIMIT);
         const isExpandable = allOutputs.length - DEFAULT_LIMIT > 0;

--- a/packages/suite/src/components/wallet/TransactionItem/index.tsx
+++ b/packages/suite/src/components/wallet/TransactionItem/index.tsx
@@ -114,7 +114,7 @@ const TransactionItem = React.memo(
             (!tokens.length && !internalTransfers.length && !targets.length) || type === 'failed';
 
         const fee = formatNetworkAmount(transaction.fee, transaction.symbol);
-        const showFeeRow = isTxOwned(transaction) && type !== 'joint' && fee !== '0';
+        const showFeeRow = isTxOwned(transaction) && type !== 'joint';
 
         const [txItemIsHovered, setTxItemIsHovered] = useState(false);
         const [nestedItemIsHovered, setNestedItemIsHovered] = useState(false);

--- a/packages/suite/src/components/wallet/TransactionItem/index.tsx
+++ b/packages/suite/src/components/wallet/TransactionItem/index.tsx
@@ -7,7 +7,7 @@ import { getIsZeroValuePhishing } from '@suite-common/suite-utils';
 import { Translation } from '@suite-components';
 import { useActions } from '@suite-hooks';
 import * as modalActions from '@suite-actions/modalActions';
-import { formatNetworkAmount, isTestnet } from '@suite-common/wallet-utils';
+import { formatNetworkAmount, isTestnet, isTxOwned } from '@suite-common/wallet-utils';
 import { AccountMetadata } from '@suite-types/metadata';
 import { Network, WalletAccountTransaction } from '@wallet-types';
 import { TransactionTypeIcon } from './components/TransactionTypeIcon';
@@ -114,7 +114,7 @@ const TransactionItem = React.memo(
             (!tokens.length && !internalTransfers.length && !targets.length) || type === 'failed';
 
         const fee = formatNetworkAmount(transaction.fee, transaction.symbol);
-        const showFeeRow = !isUnknown && type !== 'recv' && type !== 'joint' && fee !== '0';
+        const showFeeRow = isTxOwned(transaction) && type !== 'joint' && fee !== '0';
 
         const [txItemIsHovered, setTxItemIsHovered] = useState(false);
         const [nestedItemIsHovered, setNestedItemIsHovered] = useState(false);
@@ -124,8 +124,6 @@ const TransactionItem = React.memo(
         );
 
         // join together regular targets, internal and token transfers
-        // ethereum tx has either targets or transfers
-        // cardano tx can have both at the same time
         const allOutputs: (
             | { type: 'token'; payload: (typeof tokens)[number] }
             | { type: 'internal'; payload: (typeof internalTransfers)[number] }
@@ -138,6 +136,7 @@ const TransactionItem = React.memo(
                       ...internalTransfers.map(t => ({ type: 'internal' as const, payload: t })),
                       ...tokens.map(t => ({ type: 'token' as const, payload: t })),
                   ];
+
         const previewTargets = allOutputs.slice(0, DEFAULT_LIMIT);
         const isExpandable = allOutputs.length - DEFAULT_LIMIT > 0;
         const toExpand = allOutputs.length - DEFAULT_LIMIT - limit;


### PR DESCRIPTION
## Description

- at least one vin should be `vin.isOwn` then tx is signed by me
- shows token/internal transfers in case of `tx.type` is `self`
- show fee if zero, extremely rare case, looks like a bug in Suite when sent tx has no fee

## Related Issue

closes #7907

## Screenshots:
not mine tx has no fee
![Screenshot 2023-04-27 at 16 37 29](https://user-images.githubusercontent.com/33235762/234896958-070275dd-8b6c-45b6-807e-ac0a167552b0.png)

mine tx with zero fee has fee
![Screenshot 2023-05-02 at 15 15 51](https://user-images.githubusercontent.com/33235762/235677319-3d2a907c-b9ea-42bc-9886-123ba3c4e7be.png)
