### PR TITLE
chore(message-system): prolongs too strict fetch timeout for message-system

### DIFF
--- a/packages/suite/src/actions/suite/constants/messageSystemConstants.ts
+++ b/packages/suite/src/actions/suite/constants/messageSystemConstants.ts
@@ -13,7 +13,7 @@ export const DISMISS_MESSAGE = '@message-system/dismiss-message';
  */
 export const FETCH_INTERVAL = 60_000; // 1 minute in milliseconds
 export const FETCH_CHECK_INTERVAL = 30_000;
-export const FETCH_TIMEOUT = 8_000;
+export const FETCH_TIMEOUT = 30_000;
 
 /*
  * Bump version in case the new version of message system is not backward compatible.


### PR DESCRIPTION
## Description

8s was too strict, often failing. 30s is more reasonable especially with Tor.

See Sentry reports [Fetching of remote JWS config failed: Error: Aborted by timeout](https://satoshilabs.sentry.io/share/issue/22139b600759465caab5a9ee16b92e97/) (new reports filtered out by inbound filters)
