### PR TITLE
chore(env-utils): build:libs

### DIFF
--- a/ci/npm-deploy.yml
+++ b/ci/npm-deploy.yml
@@ -15,6 +15,7 @@
             "analytics",
             "connect-analytics",
             "type-utils",
+            "env-utils",
           ]
 
 .packages_matrix_connect: &packages_matrix_connect

--- a/packages/env-utils/package.json
+++ b/packages/env-utils/package.json
@@ -4,14 +4,19 @@
     "private": true,
     "license": "See LICENSE.md in repo root",
     "sideEffects": false,
-    "main": "src/index",
+    "main": "lib/index",
     "scripts": {
         "lint:js": "yarn g:eslint '**/*.{ts,tsx,js}'",
-        "type-check": "tsc --build"
+        "type-check": "tsc --build tsconfig.json",
+        "build:lib": "rimraf ./lib && yarn tsc --build tsconfig.lib.json"
     },
     "dependencies": {
         "expo-localization": "^14.1.1",
         "react-native": "0.71.7",
         "ua-parser-js": "^1.0.34"
+    },
+    "devDependencies": {
+        "rimraf": "^4.4.1",
+        "typescript": "4.9.5"
     }
 }

--- a/packages/env-utils/tsconfig.lib.json
+++ b/packages/env-utils/tsconfig.lib.json
@@ -1,0 +1,7 @@
+{
+    "extends": "../../tsconfig.lib.json",
+    "compilerOptions": {
+        "outDir": "lib"
+    },
+    "include": ["./src"]
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -7850,6 +7850,8 @@ __metadata:
   dependencies:
     expo-localization: ^14.1.1
     react-native: 0.71.7
+    rimraf: ^4.4.1
+    typescript: 4.9.5
     ua-parser-js: ^1.0.34
   languageName: unknown
   linkType: soft


### PR DESCRIPTION
- env-utils will require npm release, cc @karliatto 
- this also fixes suite-desktop build as a side effect https://gitlab.com/satoshilabs/trezor/trezor-suite/-/jobs/4196893546