### PR TITLE
Lowered privacy gain expectation based on analytics

### DIFF
--- a/packages/message-system/src/config/config.v1.json
+++ b/packages/message-system/src/config/config.v1.json
@@ -1,7 +1,7 @@
 {
     "version": 1,
     "timestamp": "2023-04-17T00:00:00+00:00",
-    "sequence": 27,
+    "sequence": 28,
     "actions": [
         {
             "conditions": [
@@ -75,7 +75,7 @@
                         "domain": "coinjoin",
                         "flag": true,
                         "isPublic": true,
-                        "averageAnonymityGainPerRound": 2,
+                        "averageAnonymityGainPerRound": 1,
                         "roundsFailRateBuffer": 10,
                         "roundsDurationInHours": 1
                     }


### PR DESCRIPTION
Change from 2 to 1.
_Average is `1.07`, median is `0.44`_

It could affect: https://github.com/trezor/trezor-suite/issues/8062