### PR TITLE
fix(suite-native): hide receive address on leaving screen

### DIFF
--- a/suite-native/module-send-receive/src/screens/ReceiveScreen.tsx
+++ b/suite-native/module-send-receive/src/screens/ReceiveScreen.tsx
@@ -1,5 +1,7 @@
-import React, { useState } from 'react';
+import React, { useEffect, useState } from 'react';
 import { useSelector } from 'react-redux';
+
+import { useIsFocused } from '@react-navigation/native';
 
 import { Box, ErrorMessage, Text, VStack } from '@suite-native/atoms';
 import { AccountListItem } from '@suite-native/accounts';
@@ -23,15 +25,22 @@ export const ReceiveScreen = ({
     navigation,
 }: StackProps<SendReceiveStackParamList, SendReceiveStackRoutes.Receive>) => {
     const [addressIsVisible, setAddressIsVisible] = useState(false);
-    const { accountKey, tokenSymbol } = route.params;
+    const isScreenFocused = useIsFocused();
 
+    const { accountKey, tokenSymbol } = route.params;
     const account = useSelector((state: AccountsRootState) =>
         selectAccountByKey(state, accountKey),
     );
-
     const token = useSelector((state: AccountsRootState) =>
         selectEthereumAccountToken(state, accountKey, tokenSymbol),
     );
+
+    useEffect(() => {
+        // Hide address when user leaves the screen
+        if (!isScreenFocused) {
+            setAddressIsVisible(false);
+        }
+    }, [isScreenFocused]);
 
     if (!account) return <ErrorMessage errorMessage={`Account ${accountKey} not found.`} />;
 


### PR DESCRIPTION
## Description

Whenever the user leaves the receive screen with the revealed receive address, it hides automatically.

## Related Issue

Related to #8287 

https://user-images.githubusercontent.com/26143964/235418659-3d2a2191-082c-4571-b2cf-8f47633e7bd2.mov

