### PR TITLE
feat(coinjoin): use daily median instead of weekly as base for coinjoin mining fee

### DIFF
--- a/packages/coinjoin/src/types/client.ts
+++ b/packages/coinjoin/src/types/client.ts
@@ -6,7 +6,7 @@ import { LogEvent } from './logger';
 export interface CoinjoinStatusEvent {
     rounds: Round[];
     changed: Round[];
-    weeklyFeeRateMedian: number;
+    feeRateMedian: number;
     coordinationFeeRate: CoordinationFeeRate;
     allowedInputAmounts: AllowedRange;
 }

--- a/packages/coinjoin/src/utils/roundUtils.ts
+++ b/packages/coinjoin/src/utils/roundUtils.ts
@@ -167,20 +167,20 @@ const getDataFromRounds = (rounds: Round[]) => {
 /**
  * Transform from coordinator format to coinjoinReducer format `CoinjoinClientInstance`
  * - coordinatorFeeRate: multiply the amount registered for coinjoin by this value to get the total fee
- * - weeklyFeeRateMedian: array => value in kvBytes
+ * - feeRateMedian: array => value in kvBytes
  */
 export const transformStatus = ({
     coinJoinFeeRateMedians,
     roundStates: rounds,
 }: CoinjoinStatus) => {
     const { allowedInputAmounts, coordinationFeeRate } = getDataFromRounds(rounds);
-    // coinJoinFeeRateMedians include an array of medians per day, week and month - we take the second (week) median as the recommended fee rate.
+    // coinJoinFeeRateMedians include an array of medians per day, week and month - we take the first (day) median as the recommended fee rate base.
     // The value is converted from kvBytes (kilo virtual bytes) to vBytes (how the value is displayed in UI).
-    const weeklyFeeRateMedian = Math.round(coinJoinFeeRateMedians[1].medianFeeRate / 1000);
+    const feeRateMedian = Math.round(coinJoinFeeRateMedians[0].medianFeeRate / 1000);
 
     return {
         rounds,
-        weeklyFeeRateMedian,
+        feeRateMedian,
         coordinationFeeRate,
         allowedInputAmounts,
     };

--- a/packages/coinjoin/tests/fixtures/round.fixture.ts
+++ b/packages/coinjoin/tests/fixtures/round.fixture.ts
@@ -146,7 +146,7 @@ export const createCoinjoinRound = (
 };
 
 export const STATUS_TRANSFORMED = {
-    weeklyFeeRateMedian: 129,
+    feeRateMedian: 129,
     allowedInputAmounts: {
         max: 134375000000,
         min: 5000,

--- a/packages/suite/src/actions/wallet/__fixtures__/mockCoinjoinService.ts
+++ b/packages/suite/src/actions/wallet/__fixtures__/mockCoinjoinService.ts
@@ -10,7 +10,7 @@ export const mockCoinjoinService = () => {
             enable: jest.fn(() =>
                 Promise.resolve({
                     rounds: [{ id: '00', phase: 0 }],
-                    weeklyFeeRateMedian: 0,
+                    feeRateMedian: 0,
                     coordinatorFeeRate: 0.003,
                     allowedInputAmounts: { min: 5000, max: 134375000000 },
                 }),

--- a/packages/suite/src/components/wallet/PrivacyAccount/MaxMiningFeeSetup.tsx
+++ b/packages/suite/src/components/wallet/PrivacyAccount/MaxMiningFeeSetup.tsx
@@ -7,7 +7,7 @@ import { coinjoinAccountUpdateMaxMiningFee } from '@wallet-actions/coinjoinAccou
 import { SetupSlider } from './SetupSlider';
 import {
     selectDefaultMaxMiningFeeByAccountKey,
-    selectWeeklyFeeRateMedianByAccountKey,
+    selectfeeRateMedianByAccountKey,
 } from '@wallet-reducers/coinjoinReducer';
 
 const min = 1;
@@ -25,9 +25,7 @@ interface MaxMiningFeeSetupProps {
 }
 
 export const MaxMiningFeeSetup = ({ accountKey, maxMiningFee }: MaxMiningFeeSetupProps) => {
-    const weeklyFeeRateMedian = useSelector(state =>
-        selectWeeklyFeeRateMedianByAccountKey(state, accountKey),
-    );
+    const feeRateMedian = useSelector(state => selectfeeRateMedianByAccountKey(state, accountKey));
     const defaultMaxMiningFee = useSelector(state =>
         selectDefaultMaxMiningFeeByAccountKey(state, accountKey),
     );
@@ -40,15 +38,15 @@ export const MaxMiningFeeSetup = ({ accountKey, maxMiningFee }: MaxMiningFeeSetu
         dispatch(coinjoinAccountUpdateMaxMiningFee(accountKey, value));
     };
 
-    const weeklyFeeRateMedianPercentage = getPercentage(weeklyFeeRateMedian);
+    const feeRateMedianPercentage = getPercentage(feeRateMedian);
     const defaultMaxMiningFeePercentage = getPercentage(defaultMaxMiningFee);
 
     const trackStyle = {
         background: `\
             linear-gradient(90deg,\
                 ${theme.GRADIENT_SLIDER_RED_END} 0%,\
-                ${theme.GRADIENT_SLIDER_YELLOW_END} ${weeklyFeeRateMedianPercentage / 1.1}%,\
-                ${theme.GRADIENT_SLIDER_YELLOW_START} ${weeklyFeeRateMedianPercentage}%,\
+                ${theme.GRADIENT_SLIDER_YELLOW_END} ${feeRateMedianPercentage / 1.1}%,\
+                ${theme.GRADIENT_SLIDER_YELLOW_START} ${feeRateMedianPercentage}%,\
                 ${theme.GRADIENT_SLIDER_GREEN_END} ${defaultMaxMiningFeePercentage}%,\
                 ${theme.GRADIENT_SLIDER_GREEN_START} 100%\
             );`,

--- a/packages/suite/src/services/coinjoin/config.ts
+++ b/packages/suite/src/services/coinjoin/config.ts
@@ -132,11 +132,11 @@ export const COORDINATOR_FEE_RATE_MULTIPLIER = 10 ** 8; // coordinator fee rate 
 export const DEFAULT_TARGET_ANONYMITY = 5;
 export const SKIP_ROUNDS_BY_DEFAULT = false;
 export const SKIP_ROUNDS_VALUE_WHEN_ENABLED = [4, 5] as [number, number];
-export const WEEKLY_FEE_RATE_MEDIAN_FALLBACK = 2;
+export const FEE_RATE_MEDIAN_FALLBACK = 2;
 export const MAX_MINING_FEE_MODIFIER = 2.5; // modifier applied to a median fee rate to set default max mining fee rate per vbyte
 export const CLIENT_STATUS_FALLBACK = {
     rounds: [],
-    weeklyFeeRateMedian: WEEKLY_FEE_RATE_MEDIAN_FALLBACK,
+    feeRateMedian: FEE_RATE_MEDIAN_FALLBACK,
     coordinationFeeRate: {
         rate: COORDINATOR_FEE_RATE_FALLBACK,
         plebsDontPayThreshold: PLEBS_DONT_PAY_THRESHOLD_FALLBACK,

--- a/packages/suite/src/utils/wallet/coinjoinUtils.ts
+++ b/packages/suite/src/utils/wallet/coinjoinUtils.ts
@@ -114,12 +114,12 @@ export const calculateAnonymityProgress = ({
 
 export const transformCoinjoinStatus = ({
     coordinationFeeRate,
-    weeklyFeeRateMedian,
+    feeRateMedian,
     allowedInputAmounts,
     rounds,
 }: CoinjoinStatusEvent) => ({
     coordinationFeeRate,
-    weeklyFeeRateMedian,
+    feeRateMedian,
     allowedInputAmounts,
     rounds: rounds.map(({ id, phase }) => ({ id, phase })),
 });


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

- If the fee rises to more than two and a half times within a week, no one with the default settings will get into the rounds.

- [ ] Consider to move MAX_MINING_FEE_MODIFIER to redux and message system config so we can change that multiplier remotely if needed.

current values from coordinator 2023-05-01T09:38:24.146Z
```json
[
  {
    "timeFrame": "1d 0h 0m 0s",
    "medianFeeRate": 8013
  },
  {
    "timeFrame": "7d 0h 0m 0s",
    "medianFeeRate": 3653
  },
  {
    "timeFrame": "30d 0h 0m 0s",
    "medianFeeRate": 4636
  }
]
```
