### PR TITLE
Fix/cj missing change addresses

### DIFF
--- a/packages/coinjoin/src/client/analyzeTransactions.ts
+++ b/packages/coinjoin/src/client/analyzeTransactions.ts
@@ -91,8 +91,8 @@ export const getAnonymityScores = async (
             dict[address] = anonymitySet;
             return dict;
         }, {} as Record<string, number>);
-    } catch {
-        options.logger.error(`Error calculating anonymity levels`);
+    } catch (error) {
+        options.logger.error(`Error calculating anonymity levels. ${error}`);
     }
 };
 

--- a/packages/coinjoin/src/client/round/inputRegistration.ts
+++ b/packages/coinjoin/src/client/round/inputRegistration.ts
@@ -84,6 +84,10 @@ const registerInput = async (
                 // abort remaining delayed candidates to register (if exists) registration is not going to happen for them anyway
                 signal.dispatchEvent(new Event('abort'));
             }
+            if (error.message === coordinator.WabiSabiProtocolErrorCode.InputLongBanned) {
+                // track blacklist ban if it happens
+                logger.error('InputLongBanned');
+            }
             throw error;
         });
 

--- a/packages/coinjoin/src/client/round/outputRegistration.ts
+++ b/packages/coinjoin/src/client/round/outputRegistration.ts
@@ -50,7 +50,9 @@ const registerOutput = async (
     const tryToRegisterOutput = (): Promise<AccountAddress> => {
         const address = outputAddress.find(a => !round.prison.isDetained(a.scriptPubKey));
         if (!address) {
-            logger.error(`No change address available`);
+            logger.error(
+                `No change address available. Used: ${round.addresses.length}. Total: ${outputAddress.length}`,
+            );
             throw new Error('No change address available');
         }
 

--- a/packages/coinjoin/src/client/round/outputRegistration.ts
+++ b/packages/coinjoin/src/client/round/outputRegistration.ts
@@ -81,6 +81,11 @@ const registerOutput = async (
                     });
                     return tryToRegisterOutput();
                 }
+                if (error.message === coordinator.WabiSabiProtocolErrorCode.NotEnoughFunds) {
+                    logger.error(
+                        `NotEnoughFunds. Amount: ${amountCredentials[0].value} Delta: ${outputAmountCredentials.credentialsRequest.delta} FeeRate: ${roundParameters.miningFeeRate}`,
+                    );
+                }
                 throw error;
             });
     };

--- a/packages/coinjoin/src/constants.ts
+++ b/packages/coinjoin/src/constants.ts
@@ -22,6 +22,9 @@ export const ROUND_REGISTRATION_END_OFFSET = 2000;
 // do not register into Round if round.inputRegistrationEnd is below offset
 export const ROUND_SELECTION_REGISTRATION_OFFSET = 30000;
 
+// max output count
+export const ROUND_SELECTION_MAX_OUTPUTS = 20;
+
 // custom timeout for http requests (default is 50000 ms)
 export const HTTP_REQUEST_TIMEOUT = 35000;
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

- do not register to round if available change addresses length is lower than 25 (sentry issue "No change address available")
- extend critical error messages:
  - middleware error message from `getAnonymityScores` (returns meaningful messages since v11)
  - log amount, delta and feeRate in `NotEnoughFunds` (sentry)
  - log total number of change addresses in `No change address available` (sentry)
  - log time of process of sending signatures `WrongPhase` issue in transactionSigning phase (sentry)
  - log `InputLongBanned` in inputRegistration phase


