### PR TITLE
feat(coinjoin): maxMiningFeeModifier configurable remotly via message system

### DIFF
--- a/packages/suite/src/actions/wallet/coinjoinAccountActions.ts
+++ b/packages/suite/src/actions/wallet/coinjoinAccountActions.ts
@@ -176,10 +176,12 @@ export const updateCoinjoinConfig = ({
     averageAnonymityGainPerRound,
     roundsFailRateBuffer,
     roundsDurationInHours,
+    maxMiningFeeModifier,
 }: {
     averageAnonymityGainPerRound: number;
     roundsFailRateBuffer: number;
     roundsDurationInHours: number;
+    maxMiningFeeModifier: number;
 }) =>
     ({
         type: COINJOIN.UPDATE_CONFIG,
@@ -187,6 +189,7 @@ export const updateCoinjoinConfig = ({
             averageAnonymityGainPerRound,
             roundsFailRateBuffer,
             roundsDurationInHours,
+            maxMiningFeeModifier,
         },
     } as const);
 

--- a/packages/suite/src/actions/wallet/coinjoinAccountActions.ts
+++ b/packages/suite/src/actions/wallet/coinjoinAccountActions.ts
@@ -177,11 +177,13 @@ export const updateCoinjoinConfig = ({
     roundsFailRateBuffer,
     roundsDurationInHours,
     maxMiningFeeModifier,
+    maxFeePerVbyte,
 }: {
     averageAnonymityGainPerRound: number;
     roundsFailRateBuffer: number;
     roundsDurationInHours: number;
     maxMiningFeeModifier: number;
+    maxFeePerVbyte?: number;
 }) =>
     ({
         type: COINJOIN.UPDATE_CONFIG,
@@ -190,6 +192,7 @@ export const updateCoinjoinConfig = ({
             roundsFailRateBuffer,
             roundsDurationInHours,
             maxMiningFeeModifier,
+            maxFeePerVbyte,
         },
     } as const);
 

--- a/packages/suite/src/middlewares/wallet/coinjoinMiddleware.ts
+++ b/packages/suite/src/middlewares/wallet/coinjoinMiddleware.ts
@@ -249,7 +249,7 @@ export const coinjoinMiddleware =
                     (key: keyof CoinjoinConfig) => {
                         const value = Number(incomingConfig[key]);
 
-                        if (!Number.isNaN(value) && typeof config[key] !== 'undefined') {
+                        if (!Number.isNaN(value)) {
                             config[key] = value;
                         }
                     },

--- a/packages/suite/src/reducers/wallet/coinjoinReducer.ts
+++ b/packages/suite/src/reducers/wallet/coinjoinReducer.ts
@@ -39,6 +39,7 @@ import {
     DEFAULT_TARGET_ANONYMITY,
     SKIP_ROUNDS_BY_DEFAULT,
     FEE_RATE_MEDIAN_FALLBACK,
+    MAX_MINING_FEE_MODIFIER,
 } from '@suite/services/coinjoin';
 import { accountsActions, AccountsRootState, selectAccountByKey } from '@suite-common/wallet-core';
 import {
@@ -83,6 +84,7 @@ export const initialState: CoinjoinState = {
         averageAnonymityGainPerRound: ESTIMATED_ANONYMITY_GAINED_PER_ROUND,
         roundsFailRateBuffer: ESTIMATED_ROUNDS_FAIL_RATE_BUFFER,
         roundsDurationInHours: ESTIMATED_HOURS_PER_ROUND,
+        maxMiningFeeModifier: MAX_MINING_FEE_MODIFIER,
     },
 };
 
@@ -129,8 +131,9 @@ const updateSetupOption = (
     } else {
         const client = draft.clients[account.symbol];
         const feeRateMedian = client?.feeRateMedian || FEE_RATE_MEDIAN_FALLBACK;
+        const { maxMiningFeeModifier } = draft.config;
         account.setup = {
-            maxFeePerVbyte: getMaxFeePerVbyte(feeRateMedian),
+            maxFeePerVbyte: getMaxFeePerVbyte(feeRateMedian, maxMiningFeeModifier),
             skipRounds: SKIP_ROUNDS_BY_DEFAULT,
             targetAnonymity: DEFAULT_TARGET_ANONYMITY,
         };
@@ -545,6 +548,9 @@ export const selectRoundsDurationInHours = (state: CoinjoinRootState) =>
 export const selectRoundsFailRateBuffer = (state: CoinjoinRootState) =>
     state.wallet.coinjoin.config.roundsFailRateBuffer;
 
+export const selectMaxMiningFeeModifier = (state: CoinjoinRootState) =>
+    state.wallet.coinjoin.config.maxMiningFeeModifier;
+
 export const selectCoinjoinAccountByKey = memoizeWithArgs(
     (state: CoinjoinRootState, accountKey: AccountKey) => {
         const coinjoinAccounts = selectCoinjoinAccounts(state);
@@ -681,7 +687,8 @@ export const selectDefaultMaxMiningFeeByAccountKey = (
     accountKey: AccountKey,
 ) => {
     const feeRateMedian = selectfeeRateMedianByAccountKey(state, accountKey);
-    return getMaxFeePerVbyte(feeRateMedian);
+    const maxMiningFeeModifier = selectMaxMiningFeeModifier(state);
+    return getMaxFeePerVbyte(feeRateMedian, maxMiningFeeModifier);
 };
 
 export const selectMinAllowedInputWithFee = (state: CoinjoinRootState, accountKey: AccountKey) => {

--- a/packages/suite/src/reducers/wallet/coinjoinReducer.ts
+++ b/packages/suite/src/reducers/wallet/coinjoinReducer.ts
@@ -85,6 +85,7 @@ export const initialState: CoinjoinState = {
         roundsFailRateBuffer: ESTIMATED_ROUNDS_FAIL_RATE_BUFFER,
         roundsDurationInHours: ESTIMATED_HOURS_PER_ROUND,
         maxMiningFeeModifier: MAX_MINING_FEE_MODIFIER,
+        maxFeePerVbyte: undefined,
     },
 };
 
@@ -551,6 +552,9 @@ export const selectRoundsFailRateBuffer = (state: CoinjoinRootState) =>
 export const selectMaxMiningFeeModifier = (state: CoinjoinRootState) =>
     state.wallet.coinjoin.config.maxMiningFeeModifier;
 
+export const selectMaxMiningFeeConfig = (state: CoinjoinRootState) =>
+    state.wallet.coinjoin.config.maxFeePerVbyte;
+
 export const selectCoinjoinAccountByKey = memoizeWithArgs(
     (state: CoinjoinRootState, accountKey: AccountKey) => {
         const coinjoinAccounts = selectCoinjoinAccounts(state);
@@ -688,7 +692,8 @@ export const selectDefaultMaxMiningFeeByAccountKey = (
 ) => {
     const feeRateMedian = selectfeeRateMedianByAccountKey(state, accountKey);
     const maxMiningFeeModifier = selectMaxMiningFeeModifier(state);
-    return getMaxFeePerVbyte(feeRateMedian, maxMiningFeeModifier);
+    const maxMiningFeeConfig = selectMaxMiningFeeConfig(state); // value defined in message system config has priority over default value (but not over custom value set by user)
+    return maxMiningFeeConfig ?? getMaxFeePerVbyte(feeRateMedian, maxMiningFeeModifier);
 };
 
 export const selectMinAllowedInputWithFee = (state: CoinjoinRootState, accountKey: AccountKey) => {

--- a/packages/suite/src/types/wallet/coinjoin.ts
+++ b/packages/suite/src/types/wallet/coinjoin.ts
@@ -75,4 +75,5 @@ export interface CoinjoinConfig {
     averageAnonymityGainPerRound: number;
     roundsFailRateBuffer: number;
     roundsDurationInHours: number;
+    maxMiningFeeModifier: number;
 }

--- a/packages/suite/src/types/wallet/coinjoin.ts
+++ b/packages/suite/src/types/wallet/coinjoin.ts
@@ -76,4 +76,5 @@ export interface CoinjoinConfig {
     roundsFailRateBuffer: number;
     roundsDurationInHours: number;
     maxMiningFeeModifier: number;
+    maxFeePerVbyte?: number;
 }

--- a/packages/suite/src/utils/wallet/coinjoinUtils.ts
+++ b/packages/suite/src/utils/wallet/coinjoinUtils.ts
@@ -8,7 +8,6 @@ import {
     ANONYMITY_GAINS_HINDSIGHT_COUNT,
     ANONYMITY_GAINS_HINDSIGHT_DAYS,
     ESTIMATED_MIN_ROUNDS_NEEDED,
-    MAX_MINING_FEE_MODIFIER,
     SKIP_ROUNDS_VALUE_WHEN_ENABLED,
 } from '@suite/services/coinjoin/config';
 import {
@@ -195,8 +194,8 @@ export const getMaxRounds = (roundsNeeded: number, roundsFailRateBuffer: number)
 export const getSkipRounds = (enabled: boolean) =>
     enabled ? SKIP_ROUNDS_VALUE_WHEN_ENABLED : undefined;
 
-export const getMaxFeePerVbyte = (weeklyMedian: number) =>
-    Math.round(weeklyMedian * MAX_MINING_FEE_MODIFIER);
+export const getMaxFeePerVbyte = (weeklyMedian: number, maxMiningFeeModifier: number) =>
+    Math.round(weeklyMedian * maxMiningFeeModifier);
 
 // get time estimate in millisecond per round
 export const getEstimatedTimePerRound = (


### PR DESCRIPTION

<!--- Provide a general summary of your changes in the Title above -->

## Description

Make `maxMiningFeeModifier` and `maxFeePerVbyte` configurable via message system. 

`maxFeePerVbyte` is optional and has priority over default max mining fee calculated from median.

## Related Issue

Resolve https://github.com/trezor/trezor-suite/issues/8322

