### PR TITLE
fix(suite-desktop): workaround to prevent react-native to be bundled in desktop app

### DIFF
--- a/packages/env-utils/package.json
+++ b/packages/env-utils/package.json
@@ -11,8 +11,6 @@
         "build:lib": "rimraf ./lib && yarn tsc --build tsconfig.lib.json"
     },
     "dependencies": {
-        "expo-localization": "^14.1.1",
-        "react-native": "0.71.7",
         "ua-parser-js": "^1.0.34"
     },
     "devDependencies": {

--- a/packages/env-utils/src/envUtils.native.ts
+++ b/packages/env-utils/src/envUtils.native.ts
@@ -1,3 +1,5 @@
+/* eslint-disable import/no-extraneous-dependencies -- react-native and expo-localization have been excluded from the package.json file as a workaround, ensuring that they are not bundled with the suite-desktop app  */
+
 import { Dimensions, Platform } from 'react-native';
 
 import { getLocales } from 'expo-localization';

--- a/yarn.lock
+++ b/yarn.lock
@@ -7879,8 +7879,6 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@trezor/env-utils@workspace:packages/env-utils"
   dependencies:
-    expo-localization: ^14.1.1
-    react-native: 0.71.7
     rimraf: ^4.4.1
     typescript: 4.9.5
     ua-parser-js: ^1.0.34


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Since https://github.com/trezor/trezor-suite/commit/ea9bfc97874530407373eebae4cf8d928d4f74e1 that introduced @trezor/env-utils in connect-common, react-native was bundled in desktop app. 

This workaround prevent it by not listing react-native as dependency of env-utils. It's used only in the native part of the package and react-native is always present in suite-native so it's relatively safe.

The ultimate solution would be to start building electron layer and get rid of [the exclusion list ](https://github.com/trezor/trezor-suite/blob/develop/packages/suite-desktop/electron-builder-config.js/#L21-L67) for good.

## Related Issue

Resolve https://github.com/trezor/trezor-suite/issues/8340

