### PR TITLE
fix(connect-popup): loader tuning

### DIFF
--- a/packages/connect-popup/src/index.tsx
+++ b/packages/connect-popup/src/index.tsx
@@ -42,7 +42,6 @@ const escapeHtml = (payload: any) => {
 // handle messages from window.opener and iframe
 const handleMessage = (event: MessageEvent<PopupEvent | UiEvent>) => {
     const { data } = event;
-
     if (!data) return;
 
     // This is message from the window.opener
@@ -101,13 +100,9 @@ const handleMessage = (event: MessageEvent<PopupEvent | UiEvent>) => {
     }
 
     // otherwise we still render in legacy way
-    // dispatch empty message to instruct the "reactified"
-    // part of app to hide the main content
-    reactEventBus.dispatch();
-
     switch (message.type) {
         case UI_REQUEST.LOADING:
-            // case UI.REQUEST_UI_WINDOW :
+        case UI_REQUEST.REQUEST_UI_WINDOW:
             showView('loader');
             break;
         case UI_REQUEST.SELECT_DEVICE:
@@ -198,7 +193,9 @@ const init = async (payload: PopupInit['payload']) => {
     try {
         // render react view
         await renderConnectUI();
+        reactEventBus.dispatch({ type: 'waiting-for-iframe-init' });
         await initMessageChannel(payload, handleMessage);
+        reactEventBus.dispatch({ type: 'waiting-for-iframe-handshake' });
     } catch (error) {
         postMessageToParent(createPopupMessage(POPUP.ERROR, { error: error.message }));
     }

--- a/packages/connect-popup/src/static/popup.html
+++ b/packages/connect-popup/src/static/popup.html
@@ -30,7 +30,7 @@
             <div id="react" style="min-width: 35vw"></div>
             <section id="container">
                 <div class="loader">
-                    <p>Initiating...</p>
+                    <p></p>
                     <svg class="circular" viewBox="25 25 50 50" preserveAspectRatio="xMidYMid">
                         <circle
                             class="route"

--- a/packages/connect-popup/src/view/common.tsx
+++ b/packages/connect-popup/src/view/common.tsx
@@ -230,6 +230,7 @@ export const renderConnectUI = () => {
         </StyleSheetWrapper>
     );
 
+    clearLegacyView();
     root.render(Component);
 
     return new Promise(resolve => {

--- a/packages/connect-ui/src/components/Loader.tsx
+++ b/packages/connect-ui/src/components/Loader.tsx
@@ -1,45 +1,74 @@
 import React from 'react';
 
-import styled from 'styled-components';
+import styled, { keyframes } from 'styled-components';
+
+const StyledLoaderWrapper = styled.div`
+    display: flex;
+    flex-direction: column;
+    justify-content: center;
+    align-items: center;
+`;
+
+const rotateAnimation = keyframes`
+  100% {
+    transform: rotate(360deg);
+  }
+`;
+
+const dashAnimation = keyframes`
+  0% {
+    stroke-dasharray: 1, 200;
+    stroke-dashoffset: 0;
+  }
+  50% {
+    stroke-dasharray: 89, 200;
+    stroke-dashoffset: -35;
+  }
+  100% {
+    stroke-dasharray: 89, 200;
+    stroke-dashoffset: -124;
+  }
+`;
 
 const StyledLoader = styled.div`
-    .loader {
-        position: relative;
-        width: 130px;
-        height: 130px;
-        display: flex;
-        justify-content: center;
-        align-items: center;
-        align-self: center;
-        color: #757575;
-    }
-    .loader .circular {
-        padding-top: 0px;
-        width: 130px;
-        height: 130px;
-        animation: rotate 2s linear infinite;
-        transform-origin: center center;
-        position: absolute;
-    }
-    .loader .circular .route {
-        stroke: #f2f2f2;
-    }
-    .loader .circular .path {
-        stroke-dasharray: 1, 200;
-        stroke-dashoffset: 0;
-        animation: dash 1.5s ease-in-out infinite, color 6s ease-in-out infinite;
-        stroke-linecap: round;
-    }
+    position: relative;
+    width: 130px;
+    height: 130px;
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    align-self: center;
+    color: #757575;
+
     @media screen and (min-width: 768px) {
-        .loader {
-            width: 160px;
-            height: 160px;
-        }
-        .loader .circular {
-            width: 160px;
-            height: 160px;
-        }
+        width: 160px;
+        height: 160px;
     }
+`;
+
+const Circular = styled.div`
+    padding-top: 0px;
+    width: 100%;
+    height: 100%;
+    animation: ${rotateAnimation} 2s linear infinite;
+    animation-delay: 200ms;
+    transition-delay: 200ms;
+    transform-origin: center center;
+    position: absolute;
+`;
+
+const Route = styled.circle`
+    stroke: #f2f2f2;
+`;
+
+const Path = styled.circle`
+    stroke-dasharray: 1, 200;
+    stroke-dashoffset: 0;
+    animation: ${dashAnimation} 1.5s ease-in-out infinite, color 6s ease-in-out infinite;
+    animation-delay: 200ms;
+    transition-delay: 200ms;
+    stroke-linecap: round;
+
     @keyframes color {
         100%,
         0% {
@@ -56,52 +85,47 @@ const StyledLoader = styled.div`
             stroke: #009546;
         }
     }
-    @keyframes rotate {
-        100% {
-            transform: rotate(360deg);
-        }
-    }
-    @keyframes dash {
-        0% {
-            stroke-dasharray: 1, 200;
-            stroke-dashoffset: 0;
-        }
-        50% {
-            stroke-dasharray: 89, 200;
-            stroke-dashoffset: -35;
-        }
-        100% {
-            stroke-dasharray: 89, 200;
-            stroke-dashoffset: -124;
-        }
-    }
 `;
 
-export const Loader = () => (
-    <StyledLoader>
-        <div className="loader">
-            Loading...
-            <svg className="circular" viewBox="25 25 50 50" preserveAspectRatio="xMidYMid">
-                <circle
-                    className="route"
-                    cx="50"
-                    cy="50"
-                    r="20"
-                    fill="none"
-                    stroke=""
-                    strokeWidth="1"
-                    strokeMiterlimit="10"
-                />
-                <circle
-                    className="path"
-                    cx="50"
-                    cy="50"
-                    r="20"
-                    fill="none"
-                    strokeWidth="1"
-                    strokeMiterlimit="10"
-                />
-            </svg>
+const Message = styled.div`
+    color: #757575;
+    size: 9px;
+`;
+
+interface LoaderProps {
+    message?: string;
+}
+export const Loader = ({ message }: LoaderProps) => (
+    <StyledLoaderWrapper>
+        <StyledLoader>
+            <Circular>
+                <svg
+                    xmlns="http://www.w3.org/2000/svg"
+                    viewBox="25 25 50 50"
+                    preserveAspectRatio="xMidYMid"
+                >
+                    <Route
+                        cx="50"
+                        cy="50"
+                        r="20"
+                        fill="none"
+                        stroke=""
+                        strokeWidth="1"
+                        strokeMiterlimit="10"
+                    />
+                    <Path
+                        cx="50"
+                        cy="50"
+                        r="20"
+                        fill="none"
+                        strokeWidth="1"
+                        strokeMiterlimit="10"
+                    />
+                </svg>
+            </Circular>
+        </StyledLoader>
+        <div>
+            <Message>{message}</Message>
         </div>
-    </StyledLoader>
+    </StyledLoaderWrapper>
 );

--- a/packages/connect-ui/src/index.tsx
+++ b/packages/connect-ui/src/index.tsx
@@ -72,8 +72,14 @@ export const ConnectUI = ({ postMessage, clearLegacyView }: ConnectUIProps) => {
         } else {
             // messages[0] could be null. in that case, legacy view is rendered
             switch (messages[0]?.type) {
+                case 'waiting-for-iframe-init':
+                    component = <Loader message="waiting for host to load" />;
+                    break;
+                case 'waiting-for-iframe-handshake':
+                    component = <Loader message="waiting for handshake from host" />;
+                    break;
                 case 'popup-handshake':
-                    component = <Loader />;
+                    component = <Loader message="ready" />;
                     break;
                 case UI.TRANSPORT:
                     component = <Transport />;

--- a/packages/connect-ui/src/utils/eventBus.ts
+++ b/packages/connect-ui/src/utils/eventBus.ts
@@ -14,7 +14,9 @@ export type ConnectUIEventProps =
     | { type: typeof UI_REQUEST.FIRMWARE_OUTDATED; device: Device }
     // connect-popup events
     | { type: 'phishing-domain' }
-    | { type: 'connect-ui-rendered' };
+    | { type: 'connect-ui-rendered' }
+    | { type: 'waiting-for-iframe-handshake' }
+    | { type: 'waiting-for-iframe-init' };
 
 const reactChannel = 'react';
 

--- a/packages/connect/CHANGELOG.md
+++ b/packages/connect/CHANGELOG.md
@@ -1,3 +1,8 @@
+# 9.0.10
+
+-   fix(connect-popup): fix connect-popup in firefox
+-   feat(connect-popup): tiny visual updates, added loading messages based on communication with iframe
+
 # 9.0.9
 
 -   fix(connect): prevent .asArray of undefined runtime error


### PR DESCRIPTION
- ~~This should fix connect-popup in firefox. The problem is that broadcast channel is available, and popup in firefox tries to use it, but messages from popup (eg. POPUP.HANDSHAKE) never reach iframe or maybe other way round.
So, if there is already a fallback in place but it becomes active only if BroadcastChannel is undefined. Now popup/iframe will resort to the fallbackish style also in case when initial handshake does not happen within 2 seconds.~~ done in https://github.com/trezor/trezor-suite/pull/8436
- added some context messages below loader component. should anything get stuck, we will at least know how far the process went.

### Testing tips:
- you need to have iframe and "host" on different origins. test it wherever you want, it could even be current production, but point it to this branch using trezor-connect-src, for example https://connect.trezor.io/9/?trezor-connect-src=http://localhost:8088/#/method/getPublicKey

cc @Hannsek 


resolve https://github.com/trezor/trezor-suite/issues/5644