### PR TITLE
Fix Tor start when adding CJ account

### DIFF
--- a/packages/suite/src/components/suite/modals/AddAccount/components/AddCoinjoinAccountButton.tsx
+++ b/packages/suite/src/components/suite/modals/AddAccount/components/AddCoinjoinAccountButton.tsx
@@ -1,4 +1,5 @@
 import React, { useState } from 'react';
+import { createTimeoutPromise } from '@trezor/utils';
 import { Translation } from '@suite-components';
 import { useSelector, useActions, useDispatch } from '@suite-hooks';
 import { createCoinjoinAccount } from '@wallet-actions/coinjoinAccountActions';
@@ -125,6 +126,7 @@ export const AddCoinjoinAccountButton = ({ network }: AddCoinjoinAccountProps) =
             // When Tor was not loaded it means there was an error or user canceled it, stop the coinjoin account activation.
             if (!isTorLoaded) return;
         }
+        await createTimeoutPromise(1000); // TODO fix properly: https://github.com/trezor/trezor-suite/issues/6902
         await createAccount();
     };
 

--- a/packages/suite/src/components/suite/modals/TorLoading.tsx
+++ b/packages/suite/src/components/suite/modals/TorLoading.tsx
@@ -14,13 +14,8 @@ type RequestEnableTorProps = Omit<Extract<UserContextPayload, { type: 'tor-loadi
 
 export const TorLoading = ({ onCancel, decision }: RequestEnableTorProps) => {
     const callback = (result: boolean) => {
-        if (result) {
-            decision.resolve(true);
-            return;
-        }
-
         onCancel();
-        decision.resolve(false);
+        decision.resolve(result);
     };
     return <TorLoader ModalWrapper={SmallModal} callback={callback} />;
 };


### PR DESCRIPTION
## Description

When trying to add CJ account and start Tor immediately before, sometimes the Tor progress modal stays hanging forever and `status is missing` is notified.

- https://github.com/trezor/trezor-suite/pull/8400/commits/5e009f1badac928ec1283c645c54a03e3e55613f - closes Tor progress modal immediately after success (and not only after failure)
- https://github.com/trezor/trezor-suite/pull/8400/commits/a0292e45c3e9a329fc5a7d1050b88f42b318ff5e - waits 1000 ms after Tor loading before creating CJ account (should be resolved properly in #6902)

## Related Issue

Should resolve #8380 in a bit dirty way.

## Note

The issue is present only outside dev environment (`process.env.NODE_ENV !== 'development'`), otherwise coordinator requests are passed even without Tor, just with `Conditionally allowed request` log message.
