### PR TITLE
Derive new addresses based on pending txs in CJ

### DIFF
--- a/packages/coinjoin/src/backend/CoinjoinAddressController.ts
+++ b/packages/coinjoin/src/backend/CoinjoinAddressController.ts
@@ -1,0 +1,66 @@
+import type { Network } from '@trezor/utxo-lib';
+
+import { deriveAddresses } from './backendUtils';
+import { getBlockAddressScript } from './filters';
+import type { PrederivedAddress, AccountAddress } from '../types/backend';
+
+type BareAddress = {
+    address: string;
+};
+
+export interface AddressController {
+    addresses: BareAddress[];
+    analyze<T>(
+        getTxs: (address: BareAddress) => Promise<T[]>,
+        onTxs?: (txs: T[]) => void,
+    ): Promise<void>;
+    analyze<T>(getTxs: (address: BareAddress) => T[], onTxs?: (txs: T[]) => void): void;
+}
+
+export class CoinjoinAddressController implements AddressController {
+    private readonly deriveMore;
+    private readonly lookout;
+    private readonly derived;
+
+    get addresses() {
+        return this.derived;
+    }
+
+    constructor(
+        xpub: string,
+        type: 'receive' | 'change',
+        lookout: number,
+        network: Network,
+        initialCount: number,
+        prederived?: PrederivedAddress[],
+    ) {
+        this.lookout = lookout;
+        this.deriveMore = (from: number, count: number) =>
+            deriveAddresses(prederived, xpub, type, from, count, network).map(
+                ({ address, path }) => ({
+                    address,
+                    path,
+                    script: getBlockAddressScript(address, network),
+                }),
+            );
+        this.derived = this.deriveMore(0, initialCount);
+    }
+
+    async analyze<T>(
+        getTxs: (address: AccountAddress) => T[] | Promise<T[]>,
+        onTxs?: (txs: T[]) => void,
+    ) {
+        for (let i = 0; i < this.derived.length; ++i) {
+            const maybePromise = getTxs(this.derived[i]);
+            // eslint-disable-next-line no-await-in-loop
+            const txs = 'then' in maybePromise ? await maybePromise : maybePromise;
+            if (txs.length) {
+                onTxs?.(txs);
+                const missing = this.lookout + i + 1 - this.derived.length;
+                if (missing > 0) {
+                    this.derived.push(...this.deriveMore(this.derived.length, missing));
+                }
+            }
+        }
+    }
+}

--- a/packages/coinjoin/src/backend/CoinjoinBackend.ts
+++ b/packages/coinjoin/src/backend/CoinjoinBackend.ts
@@ -8,7 +8,7 @@ import { scanAccount } from './scanAccount';
 import { scanAddress } from './scanAddress';
 import { getAccountInfo } from './getAccountInfo';
 import { createPendingTransaction } from './createPendingTx';
-import { deriveAddresses, isTaprootTx } from './backendUtils';
+import { deriveAddresses, isTaprootAddress } from './backendUtils';
 import { getNetwork } from '../utils/settingsUtils';
 import type { CoinjoinBackendSettings, LogEvent, Logger, LogLevel } from '../types';
 import type {
@@ -44,7 +44,7 @@ export class CoinjoinBackend extends TypedEmitter<Events> {
         this.mempool = new CoinjoinMempoolController({
             client: this.client,
             network: this.network,
-            filter: tx => isTaprootTx(tx, this.network),
+            filter: address => isTaprootAddress(address, this.network),
             logger,
         });
     }

--- a/packages/coinjoin/src/backend/CoinjoinBackend.ts
+++ b/packages/coinjoin/src/backend/CoinjoinBackend.ts
@@ -3,7 +3,7 @@ import { TypedEmitter } from '@trezor/utils/lib/typedEventEmitter';
 import { CoinjoinBackendClient } from './CoinjoinBackendClient';
 import { CoinjoinFilterController } from './CoinjoinFilterController';
 import { CoinjoinMempoolController } from './CoinjoinMempoolController';
-import { DISCOVERY_LOOKOUT } from '../constants';
+import { DISCOVERY_LOOKOUT, DISCOVERY_LOOKOUT_EXTENDED } from '../constants';
 import { scanAccount } from './scanAccount';
 import { scanAddress } from './scanAddress';
 import { getAccountInfo } from './getAccountInfo';
@@ -154,7 +154,7 @@ export class CoinjoinBackend extends TypedEmitter<Events> {
                 blockHash: this.settings.baseBlockHash,
                 blockHeight: this.settings.baseBlockHeight,
                 receiveCount: DISCOVERY_LOOKOUT,
-                changeCount: DISCOVERY_LOOKOUT,
+                changeCount: DISCOVERY_LOOKOUT_EXTENDED,
             });
     }
 
@@ -167,7 +167,7 @@ export class CoinjoinBackend extends TypedEmitter<Events> {
                 blockHash: networkInfo.bestHash,
                 blockHeight: networkInfo.bestHeight,
                 receiveCount: DISCOVERY_LOOKOUT,
-                changeCount: DISCOVERY_LOOKOUT,
+                changeCount: DISCOVERY_LOOKOUT_EXTENDED,
             };
         }
 
@@ -185,7 +185,7 @@ export class CoinjoinBackend extends TypedEmitter<Events> {
             blockHash,
             blockHeight,
             receiveCount: DISCOVERY_LOOKOUT,
-            changeCount: DISCOVERY_LOOKOUT,
+            changeCount: DISCOVERY_LOOKOUT_EXTENDED,
         };
     }
 

--- a/packages/coinjoin/src/backend/scanAccount.ts
+++ b/packages/coinjoin/src/backend/scanAccount.ts
@@ -1,7 +1,8 @@
 import { transformTransaction } from '@trezor/blockchain-link-utils/lib/blockbook';
 
-import { getBlockAddressScript, getBlockFilter } from './filters';
-import { doesTxContainAddress, deriveAddresses } from './backendUtils';
+import { getBlockFilter } from './filters';
+import { doesTxContainAddress } from './backendUtils';
+import { CoinjoinAddressController } from './CoinjoinAddressController';
 import type {
     Transaction,
     AccountAddress,
@@ -11,7 +12,6 @@ import type {
     ScanAccountCheckpoint,
     ScanAccountContext,
     ScanAccountResult,
-    PrederivedAddress,
 } from '../types/backend';
 import { DISCOVERY_LOOKOUT, DISCOVERY_LOOKOUT_EXTENDED } from '../constants';
 
@@ -21,54 +21,30 @@ const transformTx =
         // It doesn't matter for transformTransaction which receive addrs are used and which are unused
         transformTransaction(xpub, { used: receive, unused: [], change }, tx);
 
-const analyzeAddresses = async (
-    addresses: AccountAddress[],
-    isMatch: (script: Buffer) => boolean,
-    getBlock: () => Promise<BlockbookBlock>,
-    deriveMore: (from: number, count: number) => AccountAddress[],
-    txs: Set<BlockbookTransaction>,
-    lookout = DISCOVERY_LOOKOUT,
-): Promise<AccountAddress[]> => {
-    let addrs = addresses;
-    for (let i = 0; i < addrs.length; ++i) {
-        const { address, script } = addrs[i];
-        if (isMatch(script)) {
-            // eslint-disable-next-line no-await-in-loop
-            const block = await getBlock();
-            const transactions = block.txs.filter(doesTxContainAddress(address));
-            if (transactions.length) {
-                transactions.forEach(txs.add, txs);
-                const missing = lookout + i + 1 - addrs.length;
-                if (missing > 0) {
-                    addrs = addrs.concat(deriveMore(addrs.length, missing));
-                }
-            }
-        }
-    }
-    return addrs;
-};
-
 export const scanAccount = async (
     params: ScanAccountParams & { checkpoints: ScanAccountCheckpoint[] },
     { client, network, filters, mempool, abortSignal, onProgress }: ScanAccountContext,
 ): Promise<ScanAccountResult> => {
     const xpub = params.descriptor;
-    const deriveMore =
-        (type: 'receive' | 'change', prederived?: PrederivedAddress[]) =>
-        (from: number, count: number) =>
-            deriveAddresses(prederived, xpub, type, from, count, network).map(
-                ({ address, path }) => ({
-                    address,
-                    path,
-                    script: getBlockAddressScript(address, network),
-                }),
-            );
-
     const { checkpoints } = params;
-    const { receiveCount, changeCount } = checkpoints[0];
-    const { receivePrederived, changePrederived } = params.cache ?? {};
-    let receive: AccountAddress[] = deriveMore('receive', receivePrederived)(0, receiveCount);
-    let change: AccountAddress[] = deriveMore('change', changePrederived)(0, changeCount);
+
+    const receive = new CoinjoinAddressController(
+        xpub,
+        'receive',
+        DISCOVERY_LOOKOUT,
+        network,
+        checkpoints[0].receiveCount,
+        params.cache?.receivePrederived,
+    );
+
+    const change = new CoinjoinAddressController(
+        xpub,
+        'change',
+        DISCOVERY_LOOKOUT_EXTENDED,
+        network,
+        checkpoints[0].changeCount,
+        params.cache?.changePrederived,
+    );
 
     let checkpoint = checkpoints[0];
 
@@ -80,31 +56,30 @@ export const scanAccount = async (
         const isMatch = getBlockFilter(filter, blockHash);
 
         let block: BlockbookBlock | undefined;
-        const lazyBlock = async () =>
-            block ?? (block = await client.fetchBlock(blockHeight, { signal: abortSignal }));
+        const findTxs = async ({ script, address }: AccountAddress) => {
+            if (isMatch(script)) {
+                if (!block) {
+                    block = await client.fetchBlock(blockHeight, { signal: abortSignal });
+                }
+                return block.txs.filter(doesTxContainAddress(address));
+            }
+            return [];
+        };
 
-        receive = await analyzeAddresses(
-            receive,
-            isMatch,
-            lazyBlock,
-            deriveMore('receive', receivePrederived),
-            txs,
-        );
-        change = await analyzeAddresses(
-            change,
-            isMatch,
-            lazyBlock,
-            deriveMore('change', changePrederived),
-            txs,
-            DISCOVERY_LOOKOUT_EXTENDED,
-        );
+        const onTxs = (transactions: BlockbookTransaction[]) => transactions.forEach(txs.add, txs);
 
-        const transactions = Array.from(txs, transformTx(xpub, receive, change));
+        await receive.analyze(findTxs, onTxs);
+        await change.analyze(findTxs, onTxs);
+
+        const transactions = Array.from(
+            txs,
+            transformTx(xpub, receive.addresses, change.addresses),
+        );
         checkpoint = {
             blockHash,
             blockHeight,
-            receiveCount: receive.length,
-            changeCount: change.length,
+            receiveCount: receive.addresses.length,
+            changeCount: change.addresses.length,
         };
 
         txs.clear();
@@ -118,7 +93,7 @@ export const scanAccount = async (
 
     let pending: Transaction[] = [];
     if (mempool) {
-        const addresses = receive.concat(change).map(({ address }) => address);
+        const addresses = receive.addresses.concat(change.addresses).map(({ address }) => address);
 
         if (mempool.status === 'stopped') {
             await mempool.start();
@@ -127,12 +102,14 @@ export const scanAccount = async (
             await mempool.update();
         }
 
-        pending = mempool.getTransactions(addresses).map(transformTx(xpub, receive, change));
+        pending = mempool
+            .getTransactions(addresses)
+            .map(transformTx(xpub, receive.addresses, change.addresses));
     }
 
     const cache = {
-        receivePrederived: receive.map(({ address, path }) => ({ address, path })),
-        changePrederived: change.map(({ address, path }) => ({ address, path })),
+        receivePrederived: receive.addresses.map(({ address, path }) => ({ address, path })),
+        changePrederived: change.addresses.map(({ address, path }) => ({ address, path })),
     };
 
     return {

--- a/packages/coinjoin/tests/backend/CoinjoinAddressController.test.ts
+++ b/packages/coinjoin/tests/backend/CoinjoinAddressController.test.ts
@@ -1,0 +1,65 @@
+import { networks } from '@trezor/utxo-lib';
+
+import {
+    AddressController,
+    CoinjoinAddressController,
+} from '../../src/backend/CoinjoinAddressController';
+import { SEGWIT_XPUB, SEGWIT_RECEIVE_ADDRESSES } from '../fixtures/methods.fixture';
+
+const getAddress = ({ address }: { address: string }) => address;
+
+const LOOKOUT = 3;
+const INITIAL_COUNT = 2;
+
+describe('CoinjoinAddressController', () => {
+    let controller: AddressController;
+
+    beforeEach(() => {
+        controller = new CoinjoinAddressController(
+            SEGWIT_XPUB,
+            'receive',
+            LOOKOUT,
+            networks.regtest,
+            INITIAL_COUNT,
+        );
+    });
+
+    it('empty', () => {
+        expect(controller.addresses.map(getAddress)).toStrictEqual(
+            SEGWIT_RECEIVE_ADDRESSES.slice(0, INITIAL_COUNT),
+        );
+        controller.analyze(() => []);
+        expect(controller.addresses.map(getAddress)).toStrictEqual(
+            SEGWIT_RECEIVE_ADDRESSES.slice(0, INITIAL_COUNT),
+        );
+    });
+
+    it('derive more', () => {
+        controller.analyze(({ address }) =>
+            address === SEGWIT_RECEIVE_ADDRESSES[1] ? [true] : [],
+        );
+        expect(controller.addresses.map(getAddress)).toStrictEqual(SEGWIT_RECEIVE_ADDRESSES);
+    });
+
+    it('derive more async', async () => {
+        await controller.analyze(({ address }) =>
+            new Promise(resolve => setTimeout(resolve, 1)).then(() =>
+                address === SEGWIT_RECEIVE_ADDRESSES[1] ? [true] : [],
+            ),
+        );
+        expect(controller.addresses.map(getAddress)).toStrictEqual(SEGWIT_RECEIVE_ADDRESSES);
+    });
+
+    it('collect txs', () => {
+        const result: number[] = [];
+        controller.analyze(
+            ({ address }) => {
+                const index = SEGWIT_RECEIVE_ADDRESSES.indexOf(address);
+                return index % 2 === 0 ? [index] : [];
+            },
+            (txs: number[]) => result.push(...txs),
+        );
+        expect(controller.addresses.length).toBe(SEGWIT_RECEIVE_ADDRESSES.length + LOOKOUT);
+        expect(result).toStrictEqual([0, 2, 4]);
+    });
+});

--- a/packages/coinjoin/tests/backend/CoinjoinMempoolController.test.ts
+++ b/packages/coinjoin/tests/backend/CoinjoinMempoolController.test.ts
@@ -2,7 +2,11 @@ import { networks } from '@trezor/utxo-lib';
 
 import { CoinjoinMempoolController } from '../../src/backend/CoinjoinMempoolController';
 import { MockMempoolClient } from '../mocks/MockMempoolClient';
-import { BLOCKS, SEGWIT_RECEIVE_ADDRESSES } from '../fixtures/methods.fixture';
+import {
+    BLOCKS,
+    SEGWIT_CHANGE_ADDRESSES,
+    SEGWIT_RECEIVE_ADDRESSES,
+} from '../fixtures/methods.fixture';
 
 const TXS = BLOCKS.flatMap(block => block.txs); // There is 6 of them
 const ADDRESS = SEGWIT_RECEIVE_ADDRESSES[1];
@@ -56,12 +60,8 @@ describe('CoinjoinMempoolController', () => {
         mempool = new CoinjoinMempoolController({
             client,
             network: networks.regtest,
-            filter: ({ txid }) =>
-                [
-                    '22222222222222222222222222222222',
-                    '44444444444444444444444444444444',
-                    '55555555555555555555555555555555',
-                ].includes(txid),
+            filter: address =>
+                address === SEGWIT_RECEIVE_ADDRESSES[1] || address === SEGWIT_CHANGE_ADDRESSES[0],
         });
         await mempool.start();
         TXS.forEach(client.fireTx.bind(client));

--- a/packages/coinjoin/tests/backend/methods.test.ts
+++ b/packages/coinjoin/tests/backend/methods.test.ts
@@ -231,4 +231,40 @@ describe(`CoinjoinBackend methods`, () => {
         expect(progresses).toHaveLength(1);
         expect(progresses[0]).toEqual(cp3);
     });
+
+    it('scanAccount derive pending', async () => {
+        client.setFixture([{ ...FIXTURES.BLOCKS[0], txs: [] }]);
+
+        const scan1 = await scanAccount(
+            { descriptor: FIXTURES.SEGWIT_XPUB, checkpoints: [EMPTY_CHECKPOINT] },
+            getContext(() => {}),
+        );
+
+        const info1 = getAccountInfo({
+            descriptor: FIXTURES.SEGWIT_XPUB,
+            network: networks.regtest,
+            transactions: scan1.pending,
+            checkpoint: scan1.checkpoint,
+        });
+
+        expect(scan1.checkpoint.receiveCount).toBe(20);
+        expect(info1.addresses.unused.length).toBe(20);
+
+        client.setFixture([{ ...FIXTURES.BLOCKS[0], txs: [] }], [FIXTURES.TX_4_PENDING]);
+
+        const scan2 = await scanAccount(
+            { descriptor: FIXTURES.SEGWIT_XPUB, checkpoints: [scan1.checkpoint] },
+            getContext(() => {}),
+        );
+
+        const info2 = getAccountInfo({
+            descriptor: FIXTURES.SEGWIT_XPUB,
+            network: networks.regtest,
+            transactions: scan2.pending,
+            checkpoint: scan2.checkpoint,
+        });
+
+        expect(scan2.checkpoint.receiveCount).toBe(22);
+        expect(info2.addresses.unused.length).toBe(22);
+    });
 });

--- a/packages/coinjoin/tests/fixtures/methods.fixture.ts
+++ b/packages/coinjoin/tests/fixtures/methods.fixture.ts
@@ -1009,7 +1009,7 @@ export const SEGWIT_XPUB_RESULT_HALF = {
             },
             { ...used2, balance: '999999890', received: '999999890', sent: '0', transfers: 1 },
         ],
-        change: [{ ...change1, transfers: 0 }, ...change.slice(0, 19)],
+        change: [{ ...change1, transfers: 0 }, ...change],
     },
     history: {
         total: 3,

--- a/packages/coinjoin/tests/mocks/MockMempoolClient.ts
+++ b/packages/coinjoin/tests/mocks/MockMempoolClient.ts
@@ -24,8 +24,11 @@ export class MockMempoolClient implements MempoolClient {
         );
     }
 
-    fetchTransaction() {
-        return Promise.reject();
+    fetchTransaction(txid: string) {
+        const tx = this.mempoolTxs.find(t => t.txid === txid);
+        return tx
+            ? Promise.resolve(tx as unknown as BlockbookTransaction)
+            : Promise.reject(new Error('not found'));
     }
 
     private listener?: (tx: BlockbookTransaction) => void;


### PR DESCRIPTION
## Description

- https://github.com/trezor/trezor-suite/pull/8401/commits/f551c1f6c30e708617b7f66ee24c1e92a531657d - change address gap increased to 50 from the start (and not only after first match)
- https://github.com/trezor/trezor-suite/pull/8401/commits/f32feb635340ac9fffdfc362f8d4c22706d01e0b - `MempoolController` internal structure optimization; txs are now searched through 2 levels: `address -> txid[]` and `txid -> tx`, which is much faster when queried for addresses
- https://github.com/trezor/trezor-suite/pull/8401/commits/ece17ec39c68521d8d52befbb9db7769d729c4f8 - implements `CoinjoinAddressController` which handles derived addresses and proper gap; use it in `scanAccount`
- https://github.com/trezor/trezor-suite/pull/8401/commits/6310113a4e0a4e1da1a5ae1d547fff4a08ed96b7 - adds `CoinjoinAddressController` support to `CoinjoinMempoolController`, meaning that unused address gap is preserved


## Related Issue

Should resolve #8341
