### PR TITLE
fix(suite): do not unregister from coinjoin on SUITE.OFFLINE event

### DIFF
--- a/packages/suite/src/middlewares/wallet/coinjoinMiddleware.ts
+++ b/packages/suite/src/middlewares/wallet/coinjoinMiddleware.ts
@@ -161,8 +161,10 @@ export const coinjoinMiddleware =
                             'Suite offline in critical phase',
                         ),
                     );
+                } else {
+                    // pause **only** if not in critical phase
+                    api.dispatch(coinjoinAccountActions.interruptAllCoinjoinSessions());
                 }
-                api.dispatch(coinjoinAccountActions.interruptAllCoinjoinSessions());
             } else if (action.payload === true) {
                 api.dispatch(coinjoinAccountActions.restoreInterruptedCoinjoinSessions());
             }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Removing unwanted behavior when suite goes offline. Happens to me a couple of times also reported few times in sentry.

The problem is that `SUITE.ONLINE_STATUS` is sometimes randomly triggered by unstable (?) connection only for a few seconds (suite goes offline for like ~1 sec)

![Screenshot from 2023-05-09 11-29-08](https://user-images.githubusercontent.com/3435913/237056165-230eebaf-0b56-4409-8fb2-6a274b4d5db3.png)


When it happens in critical phase account will be unregistered in the middle of the round and break the round for all participants.

It's much safer to leave it be and hope that the connection will eventually be restored, potential errors (no internet) will be handled by each CoinjoinClient request