### PR TITLE
Fix Ropsten removal migrations

### DIFF
--- a/packages/suite/src/storage/migrations/index.ts
+++ b/packages/suite/src/storage/migrations/index.ts
@@ -775,5 +775,10 @@ export const migrate: OnUpgradeFunc<SuiteDBSchema> = async (
             // eslint-disable-next-line no-await-in-loop
             discoveryCursor = await discoveryCursor.continue();
         }
+
+        // remove trop from backend settings
+        const backendSettings = transaction.objectStore('backendSettings');
+        // @ts-expect-error
+        backendSettings.delete('trop');
     }
 };

--- a/packages/suite/src/storage/migrations/index.ts
+++ b/packages/suite/src/storage/migrations/index.ts
@@ -708,6 +708,8 @@ export const migrate: OnUpgradeFunc<SuiteDBSchema> = async (
                     // @ts-expect-error
                     delete token.address;
                 });
+                // eslint-disable-next-line no-await-in-loop
+                await txsCursor.update(tx);
             }
 
             // eslint-disable-next-line no-await-in-loop
@@ -731,6 +733,8 @@ export const migrate: OnUpgradeFunc<SuiteDBSchema> = async (
                     // @ts-expect-error
                     delete token.address;
                 });
+                // eslint-disable-next-line no-await-in-loop
+                await accountsCursor.update(account);
             }
 
             // eslint-disable-next-line no-await-in-loop

--- a/packages/suite/src/support/extraDependencies.ts
+++ b/packages/suite/src/support/extraDependencies.ts
@@ -60,7 +60,10 @@ export const extraDependencies: ExtraDependencies = {
     reducers: {
         storageLoadBlockchain: (state: BlockchainState, { payload }: StorageLoadAction) => {
             payload.backendSettings.forEach(backend => {
-                state[backend.key].backends = backend.value;
+                const blockchain = state[backend.key];
+                if (blockchain) {
+                    blockchain.backends = backend.value;
+                }
             });
         },
         storageLoadTransactions: (state: TransactionsState, { payload }: StorageLoadAction) => {


### PR DESCRIPTION
## Description

- fix updates in migration v36
- remove TROP backend settings as part of migration v36
- check that network still exists when loading backend settings from storage

## Related Issue

Resolve #8375
