### PR TITLE
ci: fix check_release_commit_messages.sh script

### DIFF
--- a/ci/scripts/check_release_commit_messages.sh
+++ b/ci/scripts/check_release_commit_messages.sh
@@ -11,11 +11,11 @@ do
     echo "Checking $commit"
 
     # The commit message must contain either
-    # 1. "cherry-picked from [some commit in develop]"
+    # 1. "cherry picked from ([some commit in develop])"
     # shellcheck disable=SC2076
     if [[ $message =~ "(cherry picked from commit" ]]; then
       # remove last ")" and extract commit hash
-      develop_commit=$($message | tr ' ' '\n' | tail -1 | sed 's/)$//')
+      develop_commit=$(echo "$message" | tr ' ' '\n' | tail -1 | sed 's/)$//')
       # check if develop really contains this commit hash
       if [[ $(git branch -a --contains "$develop_commit" | grep --only-matching "remotes/origin/develop") == "remotes/origin/develop" ]]; then
         continue


### PR DESCRIPTION
`check_release_commit_messages.sh` keeps getting errors in CI altough messages should be fine. see https://gitlab.com/satoshilabs/trezor/trezor-suite/-/jobs/4253861752.

There were some recent changes by @matejkriz in 31bf176a958bceb9509b15e1da31ad2f79be84c4 so maybe he can help

I made some changes that make it work for me locally (using bash not zsh)

how to test:
- git checkout release/connect-v9
- git cherry-pick 3cf1eab3d8a2672692235c44b17974fe4d63b7f5
- ./ci/scripts/check_release_commit_messages.sh

would appreciate testing by someone using zsh


