### PR TITLE
Fix/guide images

### DIFF
--- a/packages/suite-data/src/guide/transformer.ts
+++ b/packages/suite-data/src/guide/transformer.ts
@@ -1,3 +1,4 @@
+import { pipe } from '@mobily/ts-belt';
 import { join } from 'path';
 import * as fs from 'fs-extra';
 
@@ -5,15 +6,26 @@ import { resolveStaticPath } from '@trezor/utils';
 import { GuideNode } from '@suite-common/suite-types';
 
 /** Removes the front-matter from beginning of a string. */
-const clean = (md: string): string => md.replace(/^---\n.*?\n---\n/s, '');
+const clean = (markdown: string): string => markdown.replace(/^---\n.*?\n---\n/s, '');
+
+/**
+ * Transforms HTML notation produced by GitBook to stadard markdown which can be parsed by react-markdown lib.
+ *
+ * <figure><img src=".gitbook/assets/example.png" alt=""><figcaption></figcaption></figure> to ![](.gitbook/assets/example.png)
+ */
+const transformImagesMarkdown = (markdown: string) =>
+    markdown.replace(
+        /<figure><img src="([^"]+)" alt=""><figcaption><\/figcaption><\/figure>/g,
+        '![]($1)',
+    );
 
 /**
  * Transforms GitBook images path to Suite images path.
  *
  * ![](../../.gitbook/assets/example.png) to ![](static/guide/assets/example.png)
  */
-const transformImagesPath = (md: string): string =>
-    md.replace(/(?<=\]\()(.*?)(?=\/assets)/g, resolveStaticPath('/guide'));
+const transformImagesPath = (markdown: string) =>
+    markdown.replace(/(?<=\]\()(.*?)(?=\/assets)/g, resolveStaticPath('/guide'));
 
 /**
  * Given index of GitBook content transforms the content
@@ -34,8 +46,12 @@ export const transform = (node: GuideNode, source: string, destination: string) 
     } else {
         node.locales.forEach(locale => {
             const markdown = fs.readFileSync(join(source, locale, node.id)).toString();
-            const transformedMarkdown = transformImagesPath(clean(markdown));
-
+            const transformedMarkdown = pipe(
+                markdown,
+                clean,
+                transformImagesMarkdown,
+                transformImagesPath,
+            );
             fs.writeFileSync(join(destination, locale, node.id), transformedMarkdown);
         });
     }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

GitBook has changed its notation of images in markdown and `react-markdown` lib cannot interpret it. We had to fix it manually in the past for each image. This change replaces the notation in Suite so that it can be parsed.

Also, my first use of `pipe` 👀 
<!--- Describe your changes in detail -->

## Related Issue

Resolve https://github.com/trezor/trezor-suite-guide/issues/4
