### PR TITLE
tests(suite): fix errors in unit tests

### DIFF
--- a/packages/suite/src/actions/firmware/__tests__/firmwareActions.test.ts
+++ b/packages/suite/src/actions/firmware/__tests__/firmwareActions.test.ts
@@ -58,6 +58,8 @@ jest.mock('@trezor/connect', () => {
     };
 });
 
+jest.mock('@trezor/suite-analytics', () => global.JestMocks.getAnalytics());
+
 export const getInitialState = (override?: InitialState): any => {
     const suite = override ? override.suite : undefined;
     const devices = override ? override.devices : [];

--- a/packages/suite/src/actions/settings/__tests__/deviceSettingsActions.test.ts
+++ b/packages/suite/src/actions/settings/__tests__/deviceSettingsActions.test.ts
@@ -47,6 +47,8 @@ jest.mock('@trezor/connect', () => {
     };
 });
 
+jest.mock('@trezor/suite-analytics', () => global.JestMocks.getAnalytics());
+
 const DEVICE = getSuiteDevice({ path: '1', connected: true });
 
 type State = {

--- a/packages/suite/src/actions/settings/__tests__/walletSettingsActions.test.ts
+++ b/packages/suite/src/actions/settings/__tests__/walletSettingsActions.test.ts
@@ -27,6 +27,8 @@ const initStore = (state: State) => {
     return store;
 };
 
+jest.mock('@trezor/suite-analytics', () => global.JestMocks.getAnalytics());
+
 describe('walletSettings Actions', () => {
     fixtures.forEach(f => {
         it(f.description, async () => {

--- a/packages/suite/src/actions/suite/__tests__/metadataActions.test.ts
+++ b/packages/suite/src/actions/suite/__tests__/metadataActions.test.ts
@@ -41,6 +41,8 @@ jest.mock('@trezor/connect', () => {
     };
 });
 
+jest.mock('@trezor/suite-analytics', () => global.JestMocks.getAnalytics());
+
 // @ts-expect-error declare fetch (used in Dropbox constructor)
 global.fetch = () => {};
 

--- a/packages/suite/src/actions/suite/__tests__/protocolActions.test.ts
+++ b/packages/suite/src/actions/suite/__tests__/protocolActions.test.ts
@@ -5,6 +5,8 @@ import * as protocolActions from '../protocolActions';
 import * as protocolConstants from '../constants/protocolConstants';
 import { PROTOCOL_SCHEME } from '@suite-constants/protocol';
 
+jest.mock('@trezor/suite-analytics', () => global.JestMocks.getAnalytics());
+
 export const getInitialState = (state?: ProtocolState) => ({
     protocol: {
         ...protocolReducer(undefined, { type: 'foo' } as any),

--- a/packages/suite/src/actions/suite/__tests__/storageActions.test.ts
+++ b/packages/suite/src/actions/suite/__tests__/storageActions.test.ts
@@ -16,6 +16,7 @@ import discoveryReducer from '@wallet-reducers/discoveryReducer';
 import sendFormReducer from '@wallet-reducers/sendFormReducer';
 import graphReducer from '@wallet-reducers/graphReducer';
 import storageMiddleware from '@wallet-middlewares/storageMiddleware';
+import { coinjoinReducer } from '@wallet-reducers/coinjoinReducer';
 import { getAccountTransactions, getAccountIdentifier } from '@suite-common/wallet-utils';
 import { AppState } from '@suite-types';
 import { SETTINGS } from '@suite/config/suite';
@@ -82,7 +83,14 @@ type PartialState = Pick<AppState, 'suite' | 'devices'> & {
     wallet: Partial<
         Pick<
             AppState['wallet'],
-            'accounts' | 'settings' | 'discovery' | 'send' | 'transactions' | 'graph' | 'fiat'
+            | 'accounts'
+            | 'coinjoin'
+            | 'settings'
+            | 'discovery'
+            | 'send'
+            | 'transactions'
+            | 'graph'
+            | 'fiat'
         >
     >;
 };
@@ -99,6 +107,10 @@ export const getInitialState = (prevState?: Partial<PartialState>, action?: any)
     wallet: {
         accounts: accountsReducer(
             prevState && prevState.wallet ? prevState.wallet.accounts : undefined,
+            action || ({ type: 'foo' } as any),
+        ),
+        coinjoin: coinjoinReducer(
+            prevState && prevState.wallet ? prevState.wallet.coinjoin : undefined,
             action || ({ type: 'foo' } as any),
         ),
         settings: walletSettingsReducer(

--- a/packages/suite/src/actions/wallet/__tests__/coinjoinAccountActions.test.ts
+++ b/packages/suite/src/actions/wallet/__tests__/coinjoinAccountActions.test.ts
@@ -76,6 +76,7 @@ describe('coinjoinAccountActions', () => {
         it(`createCoinjoinAccount: ${f.description}`, async () => {
             const store = initStore();
             TrezorConnect.setTestFixtures(f.connect);
+            jest.spyOn(console, 'log').mockImplementation(() => {});
 
             await store.dispatch(coinjoinAccountActions.createCoinjoinAccount(f.params as any)); // params are incomplete
 

--- a/packages/suite/src/hooks/wallet/__tests__/useRbfForm.test.tsx
+++ b/packages/suite/src/hooks/wallet/__tests__/useRbfForm.test.tsx
@@ -110,6 +110,8 @@ describe('useRbfForm hook', () => {
                 appUrl: '@trezor/suite',
             },
         });
+
+        jest.spyOn(window, 'scrollTo').mockImplementation(() => {});
     });
     afterAll(async () => {
         await TrezorConnect.dispose();

--- a/packages/suite/src/middlewares/suite/__tests__/firmwareMiddleware.test.ts
+++ b/packages/suite/src/middlewares/suite/__tests__/firmwareMiddleware.test.ts
@@ -57,6 +57,9 @@ const initStore = (state: State) => {
     return store;
 };
 
+jest.mock('@trezor/suite-analytics', () => global.JestMocks.getAnalytics());
+jest.spyOn(console, 'warn').mockImplementation(() => {});
+
 describe('firmware middleware', () => {
     it('if status === "unplug" disconnecting device results in status "reconnect-in-normal"', async () => {
         const store = initStore(

--- a/packages/suite/src/support/tests/setupJest.ts
+++ b/packages/suite/src/support/tests/setupJest.ts
@@ -28,6 +28,7 @@ declare global {
         getWalletAccount: typeof testMocks.getWalletAccount;
         getWalletTransaction: typeof testMocks.getWalletTransaction;
         getTrezorConnect: typeof testMocks.getTrezorConnect;
+        getAnalytics: typeof testMocks.getAnalytics;
         getMessageSystemConfig: typeof testMocks.getMessageSystemConfig;
         getGuideNode: typeof testMocks.getGuideNode;
         intlMock: typeof testMocks.intlMock;
@@ -42,6 +43,7 @@ global.JestMocks = {
     getWalletAccount: testMocks.getWalletAccount,
     getWalletTransaction: testMocks.getWalletTransaction,
     getTrezorConnect: testMocks.getTrezorConnect,
+    getAnalytics: testMocks.getAnalytics,
     getMessageSystemConfig: testMocks.getMessageSystemConfig,
     getGuideNode: testMocks.getGuideNode,
     intlMock: testMocks.intlMock,

--- a/packages/suite/src/utils/suite/__tests__/protocol.test.ts
+++ b/packages/suite/src/utils/suite/__tests__/protocol.test.ts
@@ -1,6 +1,8 @@
 import { getProtocolInfo, isProtocolScheme } from '@suite-utils/protocol';
 import * as fixtures from '../__fixtures__/protocol';
 
+jest.mock('@trezor/suite-analytics', () => global.JestMocks.getAnalytics());
+
 describe('getProtocolInfo', () => {
     fixtures.getProtocolInfo.forEach(f => {
         it(f.description, () => {

--- a/suite-common/test-utils/src/mocks.ts
+++ b/suite-common/test-utils/src/mocks.ts
@@ -398,6 +398,18 @@ const getTrezorConnect = <M>(methods?: M) => {
     };
 };
 
+// Mocked @trezor/suite-analytics package used in various tests
+const getAnalytics = () => {
+    const originalModule = jest.requireActual('@trezor/suite-analytics');
+    return {
+        __esModule: true, // this property makes it work
+        ...originalModule,
+        analytics: {
+            report: jest.fn(),
+        },
+    };
+};
+
 const getMessageSystemConfig = (
     root?: Partial<MessageSystem>,
     action1?: Partial<Action>,
@@ -663,6 +675,7 @@ export const testMocks = {
     getSuiteDevice,
     getWalletTransaction,
     getTrezorConnect,
+    getAnalytics,
     getMessageSystemConfig,
     getGuideNode,
     getUtxo,


### PR DESCRIPTION

<!--- Provide a general summary of your changes in the Title above -->

## Description

The amount of errors in suite test:unit is to damn high!

- mock `@trezor/suite-analytics`
- add missing reducer in storageActions
- add missing window.scrollTo
- mock console warn/log
