### PR TITLE
CJ mempool txs filters

### DIFF
--- a/packages/blockchain-link-types/src/blockbook.ts
+++ b/packages/blockchain-link-types/src/blockbook.ts
@@ -43,6 +43,15 @@ export interface Block {
     txs: Transaction[];
 }
 
+export interface MempoolFiltersParams {
+    scriptType: 'taproot';
+    fromTimestamp?: number;
+}
+
+export interface MempoolFilters {
+    entries?: { [txid: string]: string };
+}
+
 // XPUBAddress, ERC20, ERC721, ERC1155 - blockbook generated type (Token) is not strict enough
 export type XPUBAddress = {
     type: 'XPUBAddress';
@@ -180,6 +189,10 @@ export interface AvailableCurrencies {
 declare function FSend(method: 'getInfo'): Promise<ServerInfo>;
 declare function FSend(method: 'getBlockHash', params: { height: number }): Promise<BlockHash>;
 declare function FSend(method: 'getBlock', params: { id: string }): Promise<Block>;
+declare function FSend(
+    method: 'getMempoolFilters',
+    params: MempoolFiltersParams,
+): Promise<MempoolFilters>;
 declare function FSend(method: 'getAccountInfo', params: AccountInfoParams): Promise<AccountInfo>;
 declare function FSend(method: 'getAccountUtxo', params: AccountUtxoParams): Promise<AccountUtxo>;
 declare function FSend(method: 'getTransaction', params: { txid: string }): Promise<Transaction>;

--- a/packages/blockchain-link/src/workers/blockbook/websocket.ts
+++ b/packages/blockchain-link/src/workers/blockbook/websocket.ts
@@ -284,6 +284,10 @@ export class BlockbookAPI extends EventEmitter {
         return this.send('getBlock', { id: `${block}` });
     }
 
+    getMempoolFilters(fromTimestamp?: number) {
+        return this.send('getMempoolFilters', { fromTimestamp, scriptType: 'taproot' });
+    }
+
     getAccountInfo(payload: AccountInfoParams) {
         return this.send('getAccountInfo', payload);
     }

--- a/packages/coinjoin/src/backend/CoinjoinBackend.ts
+++ b/packages/coinjoin/src/backend/CoinjoinBackend.ts
@@ -73,6 +73,7 @@ export class CoinjoinBackend extends EventEmitter {
         this.client = new CoinjoinBackendClient({ ...settings, logger });
         this.mempool = new CoinjoinMempoolController({
             client: this.client,
+            network: this.network,
             filter: tx => isTaprootTx(tx, this.network),
             logger,
         });

--- a/packages/coinjoin/src/backend/CoinjoinBackendClient.ts
+++ b/packages/coinjoin/src/backend/CoinjoinBackendClient.ts
@@ -73,9 +73,13 @@ export class CoinjoinBackendClient {
     }
 
     fetchMempoolFilters(timestamp?: number, options?: RequestOptions) {
-        return this.fetchFromBlockbook(options, 'getMempoolFilters', timestamp).then(
-            ({ entries }) => entries ?? {},
-        );
+        this.logger?.info('fetchMempoolFilters START');
+        return this.fetchFromBlockbook(options, 'getMempoolFilters', timestamp)
+            .then(({ entries }) => entries ?? {})
+            .then(res => {
+                this.logger?.info('fetchMempoolFilters END');
+                return res;
+            });
     }
 
     private reconnect = async () => {

--- a/packages/coinjoin/src/backend/CoinjoinBackendClient.ts
+++ b/packages/coinjoin/src/backend/CoinjoinBackendClient.ts
@@ -54,7 +54,9 @@ export class CoinjoinBackendClient {
     }
 
     fetchTransaction(txid: string, options?: RequestOptions): Promise<BlockbookTransaction> {
-        return this.fetchFromBlockbook(options, 'getTransaction', txid);
+        const lastCharCode = txid.charCodeAt(txid.length - 1);
+        const identity = this.identitiesBlockbook[lastCharCode & 0x3]; // Works only when identities.length === 4
+        return this.fetchFromBlockbook({ identity, ...options }, 'getTransaction', txid);
     }
 
     fetchNetworkInfo(options?: RequestOptions) {
@@ -68,6 +70,12 @@ export class CoinjoinBackendClient {
             pageSize,
             page,
         });
+    }
+
+    fetchMempoolFilters(timestamp?: number, options?: RequestOptions) {
+        return this.fetchFromBlockbook(options, 'getMempoolFilters', timestamp).then(
+            ({ entries }) => entries ?? {},
+        );
     }
 
     private reconnect = async () => {

--- a/packages/coinjoin/src/backend/CoinjoinMempoolController.ts
+++ b/packages/coinjoin/src/backend/CoinjoinMempoolController.ts
@@ -61,15 +61,19 @@ export class CoinjoinMempoolController implements MempoolController {
     async init(addresses: string[]) {
         const filters = await this.client.fetchMempoolFilters();
         const scripts = addresses.map(addr => getMempoolAddressScript(addr, this.network));
+        this.logger?.info(`mempool filtering ${Object.keys(filters).length} txs START`);
         const txids = Object.entries(filters)
             .filter(([txid, filter]) => {
                 const isMatch = getMempoolFilter(filter, txid);
                 return scripts.some(isMatch);
             })
             .map(([txid]) => txid);
+        this.logger?.info('mempool filtering END');
+        this.logger?.info(`init fetching ${txids.length} txs START`);
         await promiseAllSequence(
             txids.map(txid => () => this.client.fetchTransaction(txid).then(this.onTx)),
         );
+        this.logger?.info('init fetching txs END');
         this.lastPurge = new Date().getTime();
     }
 

--- a/packages/coinjoin/src/backend/CoinjoinWebsocketController.ts
+++ b/packages/coinjoin/src/backend/CoinjoinWebsocketController.ts
@@ -4,7 +4,12 @@ import type { Logger } from '../types';
 
 export type BlockbookWS = Pick<
     BlockbookAPI,
-    'getBlock' | 'getTransaction' | 'getAccountInfo' | 'getServerInfo' | 'getBlockHash'
+    | 'getBlock'
+    | 'getTransaction'
+    | 'getAccountInfo'
+    | 'getServerInfo'
+    | 'getBlockHash'
+    | 'getMempoolFilters'
 >;
 
 type SocketId = `${string}@${string}`;

--- a/packages/coinjoin/src/backend/filters.ts
+++ b/packages/coinjoin/src/backend/filters.ts
@@ -24,6 +24,9 @@ export const getBlockAddressScript = (address: string, network: Network) => {
     return Buffer.concat([Buffer.from([script.length + 6]), script]);
 };
 
+export const getMempoolAddressScript = (address: string, network: Network) =>
+    addressBjs.toOutputScript(address, network);
+
 const getFilter = (filterHex: string, keyBuffer: Buffer) => {
     const filter = createFilter(Buffer.from(filterHex, 'hex'));
     const key = keyBuffer.slice(0, KEY_SIZE);
@@ -32,3 +35,6 @@ const getFilter = (filterHex: string, keyBuffer: Buffer) => {
 
 export const getBlockFilter = (filterHex: string, blockHash: string) =>
     getFilter(filterHex, Buffer.from(blockHash, 'hex').reverse());
+
+export const getMempoolFilter = (filterHex: string, txid: string) =>
+    getFilter(filterHex, Buffer.from(txid, 'hex'));

--- a/packages/coinjoin/src/backend/scanAccount.ts
+++ b/packages/coinjoin/src/backend/scanAccount.ts
@@ -1,6 +1,6 @@
 import { transformTransaction } from '@trezor/blockchain-link-utils/lib/blockbook';
 
-import { getAddressScript, getFilter } from './filters';
+import { getBlockAddressScript, getBlockFilter } from './filters';
 import { doesTxContainAddress, deriveAddresses } from './backendUtils';
 import type {
     Transaction,
@@ -60,7 +60,7 @@ export const scanAccount = async (
                 ({ address, path }) => ({
                     address,
                     path,
-                    script: getAddressScript(address, network),
+                    script: getBlockAddressScript(address, network),
                 }),
             );
 
@@ -77,7 +77,7 @@ export const scanAccount = async (
     const everyFilter = filters.getFilterIterator({ checkpoints }, { abortSignal });
     // eslint-disable-next-line no-restricted-syntax
     for await (const { filter, blockHash, blockHeight, progress } of everyFilter) {
-        const isMatch = getFilter(filter, blockHash);
+        const isMatch = getBlockFilter(filter, blockHash);
 
         let block: BlockbookBlock | undefined;
         const lazyBlock = async () =>

--- a/packages/coinjoin/src/backend/scanAccount.ts
+++ b/packages/coinjoin/src/backend/scanAccount.ts
@@ -118,15 +118,16 @@ export const scanAccount = async (
 
     let pending: Transaction[] = [];
     if (mempool) {
+        const addresses = receive.concat(change).map(({ address }) => address);
+
         if (mempool.status === 'stopped') {
             await mempool.start();
+            await mempool.init(addresses);
         } else {
             await mempool.update();
         }
 
-        pending = mempool
-            .getTransactions(receive.concat(change).map(({ address }) => address))
-            .map(transformTx(xpub, receive, change));
+        pending = mempool.getTransactions(addresses).map(transformTx(xpub, receive, change));
     }
 
     const cache = {

--- a/packages/coinjoin/src/backend/scanAddress.ts
+++ b/packages/coinjoin/src/backend/scanAddress.ts
@@ -42,6 +42,7 @@ export const scanAddress = async (
     if (mempool) {
         if (mempool.status === 'stopped') {
             await mempool.start();
+            await mempool.init([address]);
         } else {
             await mempool.update();
         }

--- a/packages/coinjoin/src/backend/scanAddress.ts
+++ b/packages/coinjoin/src/backend/scanAddress.ts
@@ -1,6 +1,6 @@
 import { transformTransaction } from '@trezor/blockchain-link-utils/lib/blockbook';
 
-import { getAddressScript, getFilter } from './filters';
+import { getBlockAddressScript, getBlockFilter } from './filters';
 import { doesTxContainAddress } from './backendUtils';
 import type {
     Transaction,
@@ -15,7 +15,7 @@ export const scanAddress = async (
     { client, network, filters, mempool, abortSignal, onProgress }: ScanAddressContext,
 ): Promise<ScanAddressResult> => {
     const address = params.descriptor;
-    const script = getAddressScript(address, network);
+    const script = getBlockAddressScript(address, network);
     const { checkpoints } = params;
     let checkpoint = checkpoints[0];
 
@@ -23,7 +23,7 @@ export const scanAddress = async (
     // eslint-disable-next-line no-restricted-syntax
     for await (const { filter, blockHash, blockHeight, progress } of everyFilter) {
         checkpoint = { blockHash, blockHeight };
-        const isMatch = getFilter(filter, blockHash);
+        const isMatch = getBlockFilter(filter, blockHash);
         if (isMatch(script)) {
             const block = await client.fetchBlock(blockHeight);
             const blockTxs = block.txs.filter(doesTxContainAddress(address));

--- a/packages/coinjoin/src/constants.ts
+++ b/packages/coinjoin/src/constants.ts
@@ -34,6 +34,10 @@ export const HTTP_REQUEST_GAP = 1000;
 // special timeout for quite large filter batches downloaded over tor
 export const FILTERS_REQUEST_TIMEOUT = 300000;
 
+// After how many ms should mempool be purged again
+// (= large request for all mempool txids and throwing away all unincluded)
+export const MEMPOOL_PURGE_CYCLE = 10 * 60 * 1000;
+
 // timeout for CoinjoinRound currently running process
 export const ROUND_PHASE_PROCESS_TIMEOUT = 10000;
 

--- a/packages/coinjoin/src/types/backend.ts
+++ b/packages/coinjoin/src/types/backend.ts
@@ -135,7 +135,7 @@ export type FilterClient = Pick<CoinjoinBackendClient, 'fetchFilters'>;
 
 export type MempoolClient = Pick<
     CoinjoinBackendClient,
-    'fetchMempoolTxids' | 'fetchTransaction' | 'subscribeMempoolTxs' | 'unsubscribeMempoolTxs'
+    'fetchMempoolFilters' | 'fetchTransaction' | 'subscribeMempoolTxs' | 'unsubscribeMempoolTxs'
 >;
 
 export type AddressInfo = AccountInfoBase & {

--- a/packages/coinjoin/tests/backend/CoinjoinMempoolController.test.ts
+++ b/packages/coinjoin/tests/backend/CoinjoinMempoolController.test.ts
@@ -22,7 +22,7 @@ describe('CoinjoinMempoolController', () => {
         TXS.forEach(client.fireTx.bind(client));
         expect(mempool.getTransactions()).toEqual(TXS);
         expect(mempool.getTransactions([ADDRESS])).toEqual(TXS_MATCH);
-        await mempool.update();
+        await mempool.update(true);
         expect(mempool.getTransactions()).toEqual([]);
     });
 
@@ -35,20 +35,20 @@ describe('CoinjoinMempoolController', () => {
         expect(mempool.getTransactions()).toEqual([TXS[2], TXS[3]]);
 
         client.setMempoolTxs([TXS[1], TXS[2], TXS[3]]);
-        await mempool.update();
+        await mempool.update(true);
         expect(mempool.getTransactions()).toEqual([TXS[2], TXS[3]]);
 
         [TXS[4]].forEach(client.fireTx.bind(client));
         client.setMempoolTxs([TXS[3], TXS[4], TXS[5]]);
-        await mempool.update();
+        await mempool.update(true);
         expect(mempool.getTransactions()).toEqual([TXS[3], TXS[4]]);
 
         [TXS[5]].forEach(client.fireTx.bind(client));
-        await mempool.update();
+        await mempool.update(true);
         expect(mempool.getTransactions()).toEqual([TXS[3], TXS[4], TXS[5]]);
 
         client.setMempoolTxs([TXS[0], TXS[1]]);
-        await mempool.update();
+        await mempool.update(true);
         expect(mempool.getTransactions()).toEqual([]);
     });
 

--- a/packages/coinjoin/tests/backend/CoinjoinMempoolController.test.ts
+++ b/packages/coinjoin/tests/backend/CoinjoinMempoolController.test.ts
@@ -1,3 +1,5 @@
+import { networks } from '@trezor/utxo-lib';
+
 import { CoinjoinMempoolController } from '../../src/backend/CoinjoinMempoolController';
 import { MockMempoolClient } from '../mocks/MockMempoolClient';
 import { BLOCKS, SEGWIT_RECEIVE_ADDRESSES } from '../fixtures/methods.fixture';
@@ -12,7 +14,7 @@ describe('CoinjoinMempoolController', () => {
 
     beforeEach(() => {
         client.clear();
-        mempool = new CoinjoinMempoolController({ client });
+        mempool = new CoinjoinMempoolController({ client, network: networks.regtest });
     });
 
     it('All at once', async () => {
@@ -53,7 +55,13 @@ describe('CoinjoinMempoolController', () => {
     it('Filtering', async () => {
         mempool = new CoinjoinMempoolController({
             client,
-            filter: ({ txid }) => ['txid_2', 'txid_4', 'txid_5'].includes(txid),
+            network: networks.regtest,
+            filter: ({ txid }) =>
+                [
+                    '22222222222222222222222222222222',
+                    '44444444444444444444444444444444',
+                    '55555555555555555555555555555555',
+                ].includes(txid),
         });
         await mempool.start();
         TXS.forEach(client.fireTx.bind(client));

--- a/packages/coinjoin/tests/backend/filters.test.ts
+++ b/packages/coinjoin/tests/backend/filters.test.ts
@@ -1,6 +1,11 @@
 import { networks } from '@trezor/utxo-lib';
 
-import { getBlockAddressScript, getBlockFilter } from '../../src/backend/filters';
+import {
+    getBlockAddressScript,
+    getBlockFilter,
+    getMempoolAddressScript,
+    getMempoolFilter,
+} from '../../src/backend/filters';
 
 const NETWORK = networks.regtest;
 
@@ -71,88 +76,153 @@ const BLOCK_163 = {
     hash: '36d01c975372c363d94f0e9e22e8a61a6a52e3408c98920ef1587b024ec487e3',
 };
 
+// from blockbook repo
+const MEMPOOL_FILTERS = [
+    [
+        'taproot',
+        '86336c62a63f509a278624e3f400cdd50838d035a44e0af8a7d6d133c04cc2d2',
+        '0235dddcce5d60',
+        [
+            'bc1pgeqrcq5capal83ypxczmypjdhk4d9wwcea4k66c7ghe07p2qt97sqh8sy5',
+            'bc1p7en40zu9hmf9d3luh8evmfyg655pu5k2gtna6j7zr623f9tz7z0stfnwav',
+        ],
+    ],
+    [
+        'taproot multiple',
+        '86336c62a63f509a278624e3f400cdd50838d035a44e0af8a7d6d133c04cc2d2',
+        '071143e4ad12730965a5247ac15db8c81c89b0bc',
+        [
+            'bc1pp3752xgfy39w30kggy8vvn0u68x8afwqmq6p96jzr8ffrcvjxgrqrny93y',
+            'bc1p5ldsz3zxnjxrwf4xluf4qu7u839c204ptacwe2k0vzfk8s63mwts3njuwr',
+            'bc1pgeqrcq5capal83ypxczmypjdhk4d9wwcea4k66c7ghe07p2qt97sqh8sy5',
+            'bc1pn2eqtq8h0e7dvahcjm7p098haqrpalquuay572a3vgzjv24p90dszxzg40',
+            'bc1p7en40zu9hmf9d3luh8evmfyg655pu5k2gtna6j7zr623f9tz7z0stfnwav',
+            'bc1pzdq7tfvrznvfhn66m54j5683pxkatma34em5lgeuvyk6xy0jtyzqjt48z3',
+            'bc1pg2edtspjk6pzp07k6n3xhsq4z20pdr58ug40wsllm3ekwz9h6dpq77lhu9',
+        ],
+    ],
+    [
+        'taproot duplicities',
+        '33a03f983b47725bbdd6045f2d5ee0d95dce08eaaf7104759758aabd8af27d34',
+        '01778db0',
+        ['bc1px2k5tu5mfq23ekkwncz5apx6ccw2nr0rne25r8t8zk7nu035ryxqn9ge8p'],
+    ],
+    [
+        'partial taproot',
+        '86336c62a63f509a278624e3f400cdd50838d035a44e0af8a7d6d133c04cc2d2',
+        '011aeee8',
+        ['bc1pgeqrcq5capal83ypxczmypjdhk4d9wwcea4k66c7ghe07p2qt97sqh8sy5'],
+    ],
+] as const;
+
+const MEMPOOL_ADDRS_MISS = [
+    'bc1ptxs597p3fnpd8gwut5p467ulsydae3rp9z75hd99w8k3ljr9g9rqx6ynaw',
+    'bc1plca7n9vs7d906nwlqyvk0d0jxnxss6x7w3x2y879quuvj8xn3p3s7vrrl2',
+    'bc1pks4em3l8vg4zyk5xpcmgygh7elkhu03z3fqj48a2a2lv948cn4hsyltl3h',
+    'bc1pvlme5mvcme0mqvfxknqr4mmcajthd9c9vqwknfghgvnsdt0ghtyquf66nq',
+    'bc1pu4kdwq4jvpk3psqt6tw38fax7l20xj8y6gtzdgm9dj2amgy6t77sn420ak',
+];
+
 describe('Golomb filtering', () => {
-    it('Receive address as input', () => {
-        const script = getBlockAddressScript(COINJOIN_RECEIVE_0, NETWORK);
-        const filter = getBlockFilter(BLOCK_108.filter, BLOCK_108.hash);
-        expect(filter(script)).toBe(true);
+    describe('Block filters', () => {
+        it('Receive address as input', () => {
+            const script = getBlockAddressScript(COINJOIN_RECEIVE_0, NETWORK);
+            const filter = getBlockFilter(BLOCK_108.filter, BLOCK_108.hash);
+            expect(filter(script)).toBe(true);
+        });
+
+        it('Receive address as output', () => {
+            const script = getBlockAddressScript(COINJOIN_RECEIVE_0, NETWORK);
+            const filter = getBlockFilter(BLOCK_106.filter, BLOCK_106.hash);
+            expect(filter(script)).toBe(true);
+        });
+
+        it('Receive address nowhere', () => {
+            const script = getBlockAddressScript(COINJOIN_RECEIVE_0, NETWORK);
+            const filter = getBlockFilter(BLOCK_109.filter, BLOCK_109.hash);
+            expect(filter(script)).toBe(false);
+        });
+
+        it('Change address as input', () => {
+            const script = getBlockAddressScript(COINJOIN_CHANGE_0, NETWORK);
+            const filter = getBlockFilter(BLOCK_109.filter, BLOCK_109.hash);
+            expect(filter(script)).toBe(true);
+        });
+
+        it('Change address as output', () => {
+            const script = getBlockAddressScript(COINJOIN_CHANGE_0, NETWORK);
+            const filter = getBlockFilter(BLOCK_108.filter, BLOCK_108.hash);
+            expect(filter(script)).toBe(true);
+        });
+
+        it('Change address nowhere', () => {
+            const script = getBlockAddressScript(COINJOIN_CHANGE_0, NETWORK);
+            const filter = getBlockFilter(BLOCK_106.filter, BLOCK_106.hash);
+            expect(filter(script)).toBe(false);
+        });
+
+        it('Bech32 receive address as input', () => {
+            const script = getBlockAddressScript(BECH32_RECEIVE_0, NETWORK);
+            const filter = getBlockFilter(BLOCK_158.filter, BLOCK_158.hash);
+            expect(filter(script)).toBe(true);
+        });
+
+        it('Bech32 receive address as output', () => {
+            const script = getBlockAddressScript(BECH32_RECEIVE_0, NETWORK);
+            const filter = getBlockFilter(BLOCK_157.filter, BLOCK_157.hash);
+            expect(filter(script)).toBe(true);
+        });
+
+        it('Bech32 change address as input', () => {
+            const script = getBlockAddressScript(BECH32_CHANGE_0, NETWORK);
+            const filter = getBlockFilter(BLOCK_160.filter, BLOCK_160.hash);
+            expect(filter(script)).toBe(true);
+        });
+
+        it('Bech32 change address as output', () => {
+            const script = getBlockAddressScript(BECH32_CHANGE_0, NETWORK);
+            const filter = getBlockFilter(BLOCK_159.filter, BLOCK_159.hash);
+            expect(filter(script)).toBe(true);
+        });
+
+        it('Taproot receive address as input', () => {
+            const script = getBlockAddressScript(TAPROOT_RECEIVE_0, NETWORK);
+            const filter = getBlockFilter(BLOCK_162.filter, BLOCK_162.hash);
+            expect(filter(script)).toBe(true);
+        });
+
+        it('Taproot receive address as output', () => {
+            const script = getBlockAddressScript(TAPROOT_RECEIVE_0, NETWORK);
+            const filter = getBlockFilter(BLOCK_161.filter, BLOCK_161.hash);
+            expect(filter(script)).toBe(true);
+        });
+
+        it('Taproot change address as input', () => {
+            const script = getBlockAddressScript(TAPROOT_CHANGE_0, NETWORK);
+            const filter = getBlockFilter(BLOCK_163.filter, BLOCK_163.hash);
+            expect(filter(script)).toBe(true);
+        });
+
+        it('Taproot change address as output', () => {
+            const script = getBlockAddressScript(TAPROOT_CHANGE_0, NETWORK);
+            const filter = getBlockFilter(BLOCK_162.filter, BLOCK_162.hash);
+            expect(filter(script)).toBe(true);
+        });
     });
 
-    it('Receive address as output', () => {
-        const script = getBlockAddressScript(COINJOIN_RECEIVE_0, NETWORK);
-        const filter = getBlockFilter(BLOCK_106.filter, BLOCK_106.hash);
-        expect(filter(script)).toBe(true);
-    });
-
-    it('Receive address nowhere', () => {
-        const script = getBlockAddressScript(COINJOIN_RECEIVE_0, NETWORK);
-        const filter = getBlockFilter(BLOCK_109.filter, BLOCK_109.hash);
-        expect(filter(script)).toBe(false);
-    });
-
-    it('Change address as input', () => {
-        const script = getBlockAddressScript(COINJOIN_CHANGE_0, NETWORK);
-        const filter = getBlockFilter(BLOCK_109.filter, BLOCK_109.hash);
-        expect(filter(script)).toBe(true);
-    });
-
-    it('Change address as output', () => {
-        const script = getBlockAddressScript(COINJOIN_CHANGE_0, NETWORK);
-        const filter = getBlockFilter(BLOCK_108.filter, BLOCK_108.hash);
-        expect(filter(script)).toBe(true);
-    });
-
-    it('Change address nowhere', () => {
-        const script = getBlockAddressScript(COINJOIN_CHANGE_0, NETWORK);
-        const filter = getBlockFilter(BLOCK_106.filter, BLOCK_106.hash);
-        expect(filter(script)).toBe(false);
-    });
-
-    it('Bech32 receive address as input', () => {
-        const script = getBlockAddressScript(BECH32_RECEIVE_0, NETWORK);
-        const filter = getBlockFilter(BLOCK_158.filter, BLOCK_158.hash);
-        expect(filter(script)).toBe(true);
-    });
-
-    it('Bech32 receive address as output', () => {
-        const script = getBlockAddressScript(BECH32_RECEIVE_0, NETWORK);
-        const filter = getBlockFilter(BLOCK_157.filter, BLOCK_157.hash);
-        expect(filter(script)).toBe(true);
-    });
-
-    it('Bech32 change address as input', () => {
-        const script = getBlockAddressScript(BECH32_CHANGE_0, NETWORK);
-        const filter = getBlockFilter(BLOCK_160.filter, BLOCK_160.hash);
-        expect(filter(script)).toBe(true);
-    });
-
-    it('Bech32 change address as output', () => {
-        const script = getBlockAddressScript(BECH32_CHANGE_0, NETWORK);
-        const filter = getBlockFilter(BLOCK_159.filter, BLOCK_159.hash);
-        expect(filter(script)).toBe(true);
-    });
-
-    it('Taproot receive address as input', () => {
-        const script = getBlockAddressScript(TAPROOT_RECEIVE_0, NETWORK);
-        const filter = getBlockFilter(BLOCK_162.filter, BLOCK_162.hash);
-        expect(filter(script)).toBe(true);
-    });
-
-    it('Taproot receive address as output', () => {
-        const script = getBlockAddressScript(TAPROOT_RECEIVE_0, NETWORK);
-        const filter = getBlockFilter(BLOCK_161.filter, BLOCK_161.hash);
-        expect(filter(script)).toBe(true);
-    });
-
-    it('Taproot change address as input', () => {
-        const script = getBlockAddressScript(TAPROOT_CHANGE_0, NETWORK);
-        const filter = getBlockFilter(BLOCK_163.filter, BLOCK_163.hash);
-        expect(filter(script)).toBe(true);
-    });
-
-    it('Taproot change address as output', () => {
-        const script = getBlockAddressScript(TAPROOT_CHANGE_0, NETWORK);
-        const filter = getBlockFilter(BLOCK_162.filter, BLOCK_162.hash);
-        expect(filter(script)).toBe(true);
+    describe('Mempool filters', () => {
+        MEMPOOL_FILTERS.forEach(([desc, txid, filterHex, hits]) => {
+            it(desc, () => {
+                const filter = getMempoolFilter(filterHex, txid);
+                hits.forEach(hit => {
+                    const script = getMempoolAddressScript(hit, networks.bitcoin);
+                    expect(filter(script)).toBe(true);
+                });
+                MEMPOOL_ADDRS_MISS.forEach(miss => {
+                    const script = getMempoolAddressScript(miss, networks.bitcoin);
+                    expect(filter(script)).toBe(false);
+                });
+            });
+        });
     });
 });

--- a/packages/coinjoin/tests/backend/filters.test.ts
+++ b/packages/coinjoin/tests/backend/filters.test.ts
@@ -1,6 +1,6 @@
 import { networks } from '@trezor/utxo-lib';
 
-import { getAddressScript, getFilter } from '../../src/backend/filters';
+import { getBlockAddressScript, getBlockFilter } from '../../src/backend/filters';
 
 const NETWORK = networks.regtest;
 
@@ -73,86 +73,86 @@ const BLOCK_163 = {
 
 describe('Golomb filtering', () => {
     it('Receive address as input', () => {
-        const script = getAddressScript(COINJOIN_RECEIVE_0, NETWORK);
-        const filter = getFilter(BLOCK_108.filter, BLOCK_108.hash);
+        const script = getBlockAddressScript(COINJOIN_RECEIVE_0, NETWORK);
+        const filter = getBlockFilter(BLOCK_108.filter, BLOCK_108.hash);
         expect(filter(script)).toBe(true);
     });
 
     it('Receive address as output', () => {
-        const script = getAddressScript(COINJOIN_RECEIVE_0, NETWORK);
-        const filter = getFilter(BLOCK_106.filter, BLOCK_106.hash);
+        const script = getBlockAddressScript(COINJOIN_RECEIVE_0, NETWORK);
+        const filter = getBlockFilter(BLOCK_106.filter, BLOCK_106.hash);
         expect(filter(script)).toBe(true);
     });
 
     it('Receive address nowhere', () => {
-        const script = getAddressScript(COINJOIN_RECEIVE_0, NETWORK);
-        const filter = getFilter(BLOCK_109.filter, BLOCK_109.hash);
+        const script = getBlockAddressScript(COINJOIN_RECEIVE_0, NETWORK);
+        const filter = getBlockFilter(BLOCK_109.filter, BLOCK_109.hash);
         expect(filter(script)).toBe(false);
     });
 
     it('Change address as input', () => {
-        const script = getAddressScript(COINJOIN_CHANGE_0, NETWORK);
-        const filter = getFilter(BLOCK_109.filter, BLOCK_109.hash);
+        const script = getBlockAddressScript(COINJOIN_CHANGE_0, NETWORK);
+        const filter = getBlockFilter(BLOCK_109.filter, BLOCK_109.hash);
         expect(filter(script)).toBe(true);
     });
 
     it('Change address as output', () => {
-        const script = getAddressScript(COINJOIN_CHANGE_0, NETWORK);
-        const filter = getFilter(BLOCK_108.filter, BLOCK_108.hash);
+        const script = getBlockAddressScript(COINJOIN_CHANGE_0, NETWORK);
+        const filter = getBlockFilter(BLOCK_108.filter, BLOCK_108.hash);
         expect(filter(script)).toBe(true);
     });
 
     it('Change address nowhere', () => {
-        const script = getAddressScript(COINJOIN_CHANGE_0, NETWORK);
-        const filter = getFilter(BLOCK_106.filter, BLOCK_106.hash);
+        const script = getBlockAddressScript(COINJOIN_CHANGE_0, NETWORK);
+        const filter = getBlockFilter(BLOCK_106.filter, BLOCK_106.hash);
         expect(filter(script)).toBe(false);
     });
 
     it('Bech32 receive address as input', () => {
-        const script = getAddressScript(BECH32_RECEIVE_0, NETWORK);
-        const filter = getFilter(BLOCK_158.filter, BLOCK_158.hash);
+        const script = getBlockAddressScript(BECH32_RECEIVE_0, NETWORK);
+        const filter = getBlockFilter(BLOCK_158.filter, BLOCK_158.hash);
         expect(filter(script)).toBe(true);
     });
 
     it('Bech32 receive address as output', () => {
-        const script = getAddressScript(BECH32_RECEIVE_0, NETWORK);
-        const filter = getFilter(BLOCK_157.filter, BLOCK_157.hash);
+        const script = getBlockAddressScript(BECH32_RECEIVE_0, NETWORK);
+        const filter = getBlockFilter(BLOCK_157.filter, BLOCK_157.hash);
         expect(filter(script)).toBe(true);
     });
 
     it('Bech32 change address as input', () => {
-        const script = getAddressScript(BECH32_CHANGE_0, NETWORK);
-        const filter = getFilter(BLOCK_160.filter, BLOCK_160.hash);
+        const script = getBlockAddressScript(BECH32_CHANGE_0, NETWORK);
+        const filter = getBlockFilter(BLOCK_160.filter, BLOCK_160.hash);
         expect(filter(script)).toBe(true);
     });
 
     it('Bech32 change address as output', () => {
-        const script = getAddressScript(BECH32_CHANGE_0, NETWORK);
-        const filter = getFilter(BLOCK_159.filter, BLOCK_159.hash);
+        const script = getBlockAddressScript(BECH32_CHANGE_0, NETWORK);
+        const filter = getBlockFilter(BLOCK_159.filter, BLOCK_159.hash);
         expect(filter(script)).toBe(true);
     });
 
     it('Taproot receive address as input', () => {
-        const script = getAddressScript(TAPROOT_RECEIVE_0, NETWORK);
-        const filter = getFilter(BLOCK_162.filter, BLOCK_162.hash);
+        const script = getBlockAddressScript(TAPROOT_RECEIVE_0, NETWORK);
+        const filter = getBlockFilter(BLOCK_162.filter, BLOCK_162.hash);
         expect(filter(script)).toBe(true);
     });
 
     it('Taproot receive address as output', () => {
-        const script = getAddressScript(TAPROOT_RECEIVE_0, NETWORK);
-        const filter = getFilter(BLOCK_161.filter, BLOCK_161.hash);
+        const script = getBlockAddressScript(TAPROOT_RECEIVE_0, NETWORK);
+        const filter = getBlockFilter(BLOCK_161.filter, BLOCK_161.hash);
         expect(filter(script)).toBe(true);
     });
 
     it('Taproot change address as input', () => {
-        const script = getAddressScript(TAPROOT_CHANGE_0, NETWORK);
-        const filter = getFilter(BLOCK_163.filter, BLOCK_163.hash);
+        const script = getBlockAddressScript(TAPROOT_CHANGE_0, NETWORK);
+        const filter = getBlockFilter(BLOCK_163.filter, BLOCK_163.hash);
         expect(filter(script)).toBe(true);
     });
 
     it('Taproot change address as output', () => {
-        const script = getAddressScript(TAPROOT_CHANGE_0, NETWORK);
-        const filter = getFilter(BLOCK_162.filter, BLOCK_162.hash);
+        const script = getBlockAddressScript(TAPROOT_CHANGE_0, NETWORK);
+        const filter = getBlockFilter(BLOCK_162.filter, BLOCK_162.hash);
         expect(filter(script)).toBe(true);
     });
 });

--- a/packages/coinjoin/tests/backend/methods.test.ts
+++ b/packages/coinjoin/tests/backend/methods.test.ts
@@ -48,7 +48,7 @@ describe(`CoinjoinBackend methods`, () => {
             baseBlockHash: FIXTURES.BASE_HASH,
             baseBlockHeight: FIXTURES.BASE_HEIGHT,
         }),
-        mempool: new CoinjoinMempoolController({ client }),
+        mempool: new CoinjoinMempoolController({ client, network: networks.regtest }),
         network: networks.regtest,
         onProgress,
     });
@@ -120,7 +120,7 @@ describe(`CoinjoinBackend methods`, () => {
         let txs: Transaction[] = [];
 
         // Only four blocks are known,
-        // txid_4 is in mempool
+        // tx 44444444444444444444444444444444 is in mempool
         client.setFixture(FIXTURES.BLOCKS.slice(0, 4), [FIXTURES.TX_4_PENDING]);
 
         const half = await scanAccount(

--- a/packages/coinjoin/tests/fixtures/methods.fixture.ts
+++ b/packages/coinjoin/tests/fixtures/methods.fixture.ts
@@ -29,7 +29,8 @@ export const BLOCKS = [
         previousBlockHash: BASE_HASH,
         txs: [
             {
-                txid: 'txid_1',
+                txid: '11111111111111111111111111111111',
+                filter: '03928f707d3166a2ea',
                 blockHeight: 1,
                 blockTime: 1337,
                 value: '1578597058',
@@ -68,7 +69,8 @@ export const BLOCKS = [
         previousBlockHash: '09f69854a4572575e2a8af0dea70ff5efd46957e2cb60e81c0d760098ab48b44',
         txs: [
             {
-                txid: 'txid_2',
+                txid: '22222222222222222222222222222222',
+                filter: '021944359ad6e0',
                 blockHeight: 2,
                 blockTime: 1337,
                 value: '999999890',
@@ -79,7 +81,7 @@ export const BLOCKS = [
                         addresses: ['bcrt1qkvwu9g3k2pdxewfqr7syz89r3gj557l374sg5v'],
                         isAddress: true,
                         value: '1000000000',
-                        txid: 'txid_1',
+                        txid: '11111111111111111111111111111111',
                         vout: 1,
                     },
                 ],
@@ -109,7 +111,8 @@ export const BLOCKS = [
         previousBlockHash: '295578a3c8eb87736a5e657b06a0933f7ec5f82c43f8418fdb38f74c0fc066c7',
         txs: [
             {
-                txid: 'txid_3',
+                txid: '33333333333333333333333333333333',
+                filter: '031e20cd856d4fa3f1',
                 blockHeight: 4,
                 blockTime: 1337,
                 value: '999999858',
@@ -158,7 +161,8 @@ export const BLOCKS = [
         previousBlockHash: '2c2c65aad93eebe235955e170913fd6558453dd999a4ded6249bbdc9d54da1f7',
         txs: [
             {
-                txid: 'txid_4',
+                txid: '44444444444444444444444444444444',
+                filter: '034a680453fcd11cf180',
                 blockHeight: 6,
                 blockTime: 1337,
                 value: '999999749',
@@ -169,7 +173,7 @@ export const BLOCKS = [
                         addresses: ['bcrt1qldlynaqp0hy4zc2aag3pkenzvxy65saej0huey'],
                         isAddress: true,
                         value: '999999890',
-                        txid: 'txid_2',
+                        txid: '22222222222222222222222222222222',
                     },
                 ],
                 vout: [
@@ -198,7 +202,8 @@ export const BLOCKS = [
         previousBlockHash: '5021a2185f27ad04d45f1b53c873b2231311aea99e0f1d7a6252167540b9db4c',
         txs: [
             {
-                txid: 'txid_5',
+                txid: '55555555555555555555555555555555',
+                filter: '0262fbd3058600',
                 blockHeight: 7,
                 blockTime: 1337,
                 value: '999999571',
@@ -209,14 +214,14 @@ export const BLOCKS = [
                         addresses: ['bcrt1qkvwu9g3k2pdxewfqr7syz89r3gj557l374sg5v'],
                         isAddress: true,
                         value: '547',
-                        txid: 'txid_4',
+                        txid: '44444444444444444444444444444444',
                     },
                     {
                         n: 1,
                         addresses: ['bcrt1qejqxwzfld7zr6mf7ygqy5s5se5xq7vmt8ntmj0'],
                         isAddress: true,
                         value: '999999202',
-                        txid: 'txid_4',
+                        txid: '44444444444444444444444444444444',
                         vout: 1,
                     },
                 ],
@@ -238,7 +243,8 @@ export const BLOCKS = [
         previousBlockHash: '01d37c4490e9ddaf6b5c886eaa215b8d0b658c93ea42cfd871b226f606672c0b',
         txs: [
             {
-                txid: 'txid_6',
+                txid: '66666666666666666666666666666666',
+                filter: '0256bf6979ccc0',
                 blockHeight: 8,
                 blockTime: 1337,
                 value: '999999212',
@@ -666,7 +672,7 @@ export const SEGWIT_XPUB_RESULT = {
         transactions: [
             {
                 type: 'recv',
-                txid: 'txid_6',
+                txid: '66666666666666666666666666666666',
                 blockTime: 1337,
                 blockHeight: 8,
                 amount: '999999212',
@@ -708,7 +714,7 @@ export const SEGWIT_XPUB_RESULT = {
             },
             {
                 type: 'self',
-                txid: 'txid_5',
+                txid: '55555555555555555555555555555555',
                 blockTime: 1337,
                 blockHeight: 7,
                 amount: '178',
@@ -754,7 +760,7 @@ export const SEGWIT_XPUB_RESULT = {
             },
             {
                 type: 'self',
-                txid: 'txid_4',
+                txid: '44444444444444444444444444444444',
                 blockTime: 1337,
                 blockHeight: 6,
                 amount: '141',
@@ -801,7 +807,7 @@ export const SEGWIT_XPUB_RESULT = {
             },
             {
                 type: 'recv',
-                txid: 'txid_3',
+                txid: '33333333333333333333333333333333',
                 blockTime: 1337,
                 blockHeight: 4,
                 amount: '547',
@@ -853,7 +859,7 @@ export const SEGWIT_XPUB_RESULT = {
             },
             {
                 type: 'self',
-                txid: 'txid_2',
+                txid: '22222222222222222222222222222222',
                 blockTime: 1337,
                 blockHeight: 2,
                 amount: '110',
@@ -893,7 +899,7 @@ export const SEGWIT_XPUB_RESULT = {
             },
             {
                 type: 'recv',
-                txid: 'txid_1',
+                txid: '11111111111111111111111111111111',
                 blockTime: 1337,
                 blockHeight: 1,
                 amount: '1000000000',
@@ -947,7 +953,7 @@ export const SEGWIT_XPUB_RESULT = {
         {
             address: 'bcrt1qkvwu9g3k2pdxewfqr7syz89r3gj557l374sg5v',
             path: "m/84'/1'/0'/0/0",
-            txid: 'txid_3',
+            txid: '33333333333333333333333333333333',
             vout: 0,
             blockHeight: 4,
             amount: '547',
@@ -956,7 +962,7 @@ export const SEGWIT_XPUB_RESULT = {
         {
             address: 'bcrt1qkvwu9g3k2pdxewfqr7syz89r3gj557l374sg5v',
             path: "m/84'/1'/0'/0/0",
-            txid: 'txid_5',
+            txid: '55555555555555555555555555555555',
             vout: 0,
             blockHeight: 7,
             amount: '999999571',
@@ -965,7 +971,7 @@ export const SEGWIT_XPUB_RESULT = {
         {
             address: 'bcrt1qkvwu9g3k2pdxewfqr7syz89r3gj557l374sg5v',
             path: "m/84'/1'/0'/0/0",
-            txid: 'txid_6',
+            txid: '66666666666666666666666666666666',
             vout: 0,
             blockHeight: 8,
             amount: '999999212',
@@ -1013,7 +1019,7 @@ export const SEGWIT_XPUB_RESULT_HALF = {
     utxo: [
         utxo,
         {
-            txid: 'txid_4',
+            txid: '44444444444444444444444444444444',
             vout: 0,
             address: 'bcrt1qkvwu9g3k2pdxewfqr7syz89r3gj557l374sg5v',
             path: "m/84'/1'/0'/0/0",
@@ -1022,7 +1028,7 @@ export const SEGWIT_XPUB_RESULT_HALF = {
             amount: '547',
         },
         {
-            txid: 'txid_4',
+            txid: '44444444444444444444444444444444',
             vout: 1,
             address: 'bcrt1qejqxwzfld7zr6mf7ygqy5s5se5xq7vmt8ntmj0',
             path: "m/84'/1'/0'/1/0",

--- a/packages/coinjoin/tests/mocks/MockMempoolClient.ts
+++ b/packages/coinjoin/tests/mocks/MockMempoolClient.ts
@@ -1,25 +1,27 @@
 import type { BlockbookTransaction, MempoolClient } from '../../src/types/backend';
 
-type MockTx = Pick<BlockbookTransaction, 'txid' | 'vin' | 'vout'>;
+type MockTx = Pick<BlockbookTransaction, 'txid' | 'vin' | 'vout'> & { filter: string };
 
 export class MockMempoolClient implements MempoolClient {
-    private mempoolTxids: string[] = [];
+    private mempoolTxs: MockTx[] = [];
 
     clear() {
-        this.mempoolTxids = [];
+        this.mempoolTxs = [];
         this.listener = undefined;
     }
 
     setMempoolTxs(txs: MockTx[]) {
-        this.mempoolTxids = txs.map(tx => tx.txid);
+        this.mempoolTxs = txs;
     }
 
     fireTx(tx: MockTx) {
-        this.listener?.(tx as BlockbookTransaction);
+        this.listener?.(tx as unknown as BlockbookTransaction);
     }
 
     fetchMempoolFilters() {
-        return Promise.resolve(Object.fromEntries(this.mempoolTxids.map(txid => [txid, ''])));
+        return Promise.resolve(
+            Object.fromEntries(this.mempoolTxs.map(({ txid, filter }) => [txid, filter])),
+        );
     }
 
     fetchTransaction() {

--- a/packages/coinjoin/tests/mocks/MockMempoolClient.ts
+++ b/packages/coinjoin/tests/mocks/MockMempoolClient.ts
@@ -18,8 +18,8 @@ export class MockMempoolClient implements MempoolClient {
         this.listener?.(tx as BlockbookTransaction);
     }
 
-    fetchMempoolTxids() {
-        return Promise.resolve(this.mempoolTxids);
+    fetchMempoolFilters() {
+        return Promise.resolve(Object.fromEntries(this.mempoolTxids.map(txid => [txid, ''])));
     }
 
     fetchTransaction() {

--- a/packages/suite/src/services/coinjoin/config.ts
+++ b/packages/suite/src/services/coinjoin/config.ts
@@ -22,11 +22,14 @@ export const COINJOIN_NETWORKS: PartialRecord<NetworkSymbol, ServerEnvironment> 
             coordinatorUrl: 'https://wasabiwallet.io/wabisabi/',
             wabisabiBackendUrl: 'https://wasabiwallet.io/',
             blockbookUrls: [
+                /*
                 'https://btc1.trezor.io',
                 'https://btc2.trezor.io',
                 'https://btc3.trezor.io',
                 'https://btc4.trezor.io',
                 'https://btc5.trezor.io',
+                */
+                'https://staging-btc.trezor.io',
             ],
             /* 28.02.2023 */
             baseBlockHeight: 778666,


### PR DESCRIPTION
## Description

On mainnet works only on [staging](https://staging-btc.trezor.io) Blockbook without Tor, **we have to wait until production Blockbooks are updated**.

- https://github.com/trezor/trezor-suite/pull/8438/commits/930a00bb2ca6696ed2f471eebd7f25b51f036027 - `getMempoolFilters` method support in `@trezor/blockchain-link`
- https://github.com/trezor/trezor-suite/pull/8438/commits/7dd5c1f19bddfaad0738b8add75e91334c20420e - refactoring of golomb filters in `@trezor/coinjoin` package, as a preparation for following commit
- https://github.com/trezor/trezor-suite/pull/8438/commits/2b1e452a34a0d4d4ab7f37a9cfa126fd1fcd3711 - added support for mempool filtering in `@trezor/coinjoin` package (filter construction is a bit different than in block filters)
- https://github.com/trezor/trezor-suite/pull/8438/commits/30f3643f5be973a147c227540d35d55b5665a699 - replace `fetchMempoolTxids` (wabisabi method) with `fetchMempoolFilters` (blockbook method); added `mempool.init()` method for initial syncing of mempool
- https://github.com/trezor/trezor-suite/pull/8438/commits/36b6b52911dab927a6ff78ca97a867c9106d9070 - **OPTIONAL** purge the mempool every 10 minutes (and not on every 1-minute update, as the mempool filter request is potentially quite big)
- https://github.com/trezor/trezor-suite/pull/8438/commits/60b58afbd44b61a8e26adac5af909f3caa592857 - **TEMPORARY** set backends to dev ones; added some logs

## Related Issue

Resolve #8344

## Todos / Issues / Followups
- only txs with filter hit are fetched, add decoys?