### PR TITLE
Feat: not closing popup when error in debug mode

### DIFF
--- a/ci/test.yml
+++ b/ci/test.yml
@@ -224,6 +224,7 @@ transport manual:
     matrix:
       - TEST_FILE: ["methods"]
       - TEST_FILE: ["popup-close"]
+      - TEST_FILE: ["popup-error-page"]
       - TEST_FILE: ["unchained"]
       - TEST_FILE: ["browser-support"]
       - TEST_FILE: ["install-bridge"]

--- a/packages/connect-popup/e2e/tests/popup-close.test.ts
+++ b/packages/connect-popup/e2e/tests/popup-close.test.ts
@@ -139,8 +139,6 @@ test.beforeAll(async () => {
     }) => {
         // user canceled dialog on device
         await TrezorUserEnvLink.send({ type: 'emulator-press-no' });
-        await releasePromise!.promise;
-        await popupClosedPromise;
         await page.waitForTimeout(WAIT_AFTER_TEST);
 
         responses.forEach(response => {
@@ -148,6 +146,10 @@ test.beforeAll(async () => {
             // no post endpoint is used
             expect(response.url).not.toContain('post');
         });
+
+        await popup.click("button[data-test='@connect-ui/error-close-button']");
+        await releasePromise!.promise;
+        await popupClosedPromise;
 
         await page.waitForSelector('text=Failure_ActionCancelled');
     });
@@ -157,8 +159,6 @@ test.beforeAll(async () => {
     }) => {
         // user canceled interaction on device
         await TrezorUserEnvLink.api.stopEmu();
-        await releasePromise!.promise;
-        await popupClosedPromise;
         await page.waitForTimeout(WAIT_AFTER_TEST);
 
         responses.forEach(response => {
@@ -170,6 +170,10 @@ test.beforeAll(async () => {
             url: 'http://127.0.0.1:21325/call/2',
             status: 400,
         });
+
+        await popup.click("button[data-test='@connect-ui/error-close-button']");
+        await releasePromise!.promise;
+        await popupClosedPromise;
 
         await page.waitForSelector('text=device disconnected during action');
 
@@ -207,10 +211,10 @@ test.beforeAll(async () => {
     // just like the previous skipped test.
     // request: http://127.0.0.1:21325/call/3
     // response {"error":"closed device"}
-    test.skip(`popup is reloaded by user. bridge version ${bridgeVersion}`, async () => {
+    test(`popup is reloaded by user. bridge version ${bridgeVersion}`, async () => {
         await popup.reload();
         // after popup is reload, communication is lost, there is only infinite loader
-        await popup.waitForSelector('.loader');
+        await popup.waitForSelector('div[data-test="@connect-ui/loader"]');
         // todo: there is no message into client about the fact that popup was unloaded
     });
 });

--- a/packages/connect-popup/e2e/tests/popup-error-page.test.ts
+++ b/packages/connect-popup/e2e/tests/popup-error-page.test.ts
@@ -1,0 +1,50 @@
+import { test, Page } from '@playwright/test';
+import { TrezorUserEnvLink } from '@trezor/trezor-user-env-link';
+
+const url = process.env.URL || 'http://localhost:8088/';
+const bridgeVersion = '2.0.31';
+
+test.beforeAll(async () => {
+    await TrezorUserEnvLink.connect();
+});
+
+// popup window reference
+let popup: Page;
+
+// Debug mode does not have to be enable since it is default in connect-explorer
+test('popup should display error page when device disconnected and debug mode', async ({
+    page,
+}) => {
+    await TrezorUserEnvLink.api.stopBridge();
+    await TrezorUserEnvLink.api.stopEmu();
+    await TrezorUserEnvLink.api.startEmu({
+        wipe: true,
+    });
+    await TrezorUserEnvLink.api.setupEmu({
+        mnemonic: 'alcohol woman abuse must during monitor noble actual mixed trade anger aisle',
+        pin: '',
+        passphrase_protection: false,
+        label: 'My Trevor',
+        needs_backup: false,
+    });
+    await TrezorUserEnvLink.api.startBridge(bridgeVersion);
+
+    await page.goto(`${url}#/method/verifyMessage`);
+    await page.waitForSelector("button[data-test='@submit-button']", { state: 'visible' });
+    [popup] = await Promise.all([
+        page.waitForEvent('popup'),
+        page.click("button[data-test='@submit-button']"),
+    ]);
+
+    await popup.waitForSelector("button[data-test='@analytics/continue-button']", {
+        state: 'visible',
+        timeout: 40000,
+    });
+    await popup.click("button[data-test='@analytics/continue-button']");
+
+    await popup.waitForSelector("div[data-test='@permissions']");
+
+    await TrezorUserEnvLink.api.stopEmu();
+
+    await popup.waitForSelector("div[data-test='@connect-ui/error']");
+});

--- a/packages/connect-popup/src/index.tsx
+++ b/packages/connect-popup/src/index.tsx
@@ -46,7 +46,7 @@ const handleMessage = (
     event: MessageEvent<
         | PopupEvent
         | UiEvent
-        | (Omit<MethodResponseMessage, 'payload'> & { payload?: { error: string } })
+        | (Omit<MethodResponseMessage, 'payload'> & { payload?: { error: string; code?: string } })
     >,
 ) => {
     const { data } = event;
@@ -58,7 +58,11 @@ const handleMessage = (
         return;
     }
 
-    if (data.type === RESPONSE_EVENT && !data.success) {
+    if (
+        data.type === RESPONSE_EVENT &&
+        !data.success &&
+        data.payload?.code !== 'Transport_Missing'
+    ) {
         const errorMessage = data.payload?.error || 'Unknown error';
         reactEventBus.dispatch({
             type: 'error',

--- a/packages/connect-popup/src/static/popup.html
+++ b/packages/connect-popup/src/static/popup.html
@@ -23,8 +23,8 @@
     </head>
     <body>
         <main>
-            <!-- 
-                give react slot min-width of left panel (InfoPanel) which is not 
+            <!--
+                give react slot min-width of left panel (InfoPanel) which is not
                 loaded yet to prevent loader from "jumping"
              -->
             <div id="react" style="min-width: 35vw"></div>
@@ -481,7 +481,7 @@
             <!-- invalid passphrase: END -->
 
             <!-- Permissions -->
-            <div class="permissions">
+            <div data-test="@permissions" class="permissions">
                 <h3>Allow<span class="host-name"></span>permissions to:</h3>
 
                 <div class="list-wrapper">

--- a/packages/connect-ui/src/components/Loader.tsx
+++ b/packages/connect-ui/src/components/Loader.tsx
@@ -96,7 +96,7 @@ interface LoaderProps {
     message?: string;
 }
 export const Loader = ({ message }: LoaderProps) => (
-    <StyledLoaderWrapper>
+    <StyledLoaderWrapper data-test="@connect-ui/loader">
         <StyledLoader>
             <Circular>
                 <svg

--- a/packages/connect-ui/src/views/Error.tsx
+++ b/packages/connect-ui/src/views/Error.tsx
@@ -15,9 +15,11 @@ const WhiteCollapsibleBox = styled(CollapsibleBox)`
 export interface ErrorViewProps {
     type: 'error';
     detail: // errors that might arise when using connect-ui with connect-popup
-    | 'handshake-timeout' // communication was not established in a set time period
+    | 'response-event-error' // Error coming from connect RESPONSE_EVENT
+        | 'handshake-timeout' // communication was not established in a set time period
         | 'iframe-failure'; // another (legacy) error, this is sent from popupManager (host) to popup. it means basically the same like handshake-timeout but we might be notified earlier
     // future errors when using connect-ui in different contexts
+    message?: string;
 }
 
 const StepsOrderedList = styled.ol`
@@ -135,6 +137,16 @@ const getTroubleshootingTips = (props: ErrorViewProps) => {
         }
     }
 
+    if (props.detail === 'response-event-error') {
+        tips.push({
+            icon: 'QUESTION',
+            title: 'There was an error',
+            detail: {
+                steps: [<Step>{props.message}</Step>],
+            },
+        });
+    }
+
     if (!tips.length) {
         tips.push({
             icon: 'QUESTION',
@@ -202,7 +214,7 @@ const HeadingH1 = styled.div`
 `;
 
 export const ErrorView = (props: ErrorViewProps) => (
-    <View>
+    <View data-test="@connect-ui/error">
         <InnerWrapper>
             <H>Error</H>
             <Text>You can try the following steps to solve the problem</Text>
@@ -231,7 +243,11 @@ export const ErrorView = (props: ErrorViewProps) => (
                 ))}
             </TipsContainer>
 
-            <Button variant="primary" onClick={() => window.close()}>
+            <Button
+                data-test="@connect-ui/error-close-button"
+                variant="primary"
+                onClick={() => window.close()}
+            >
                 Close
             </Button>
         </InnerWrapper>

--- a/packages/connect-web/src/popup/index.ts
+++ b/packages/connect-web/src/popup/index.ts
@@ -13,7 +13,7 @@ import {
 import { getOrigin } from '@trezor/connect/lib/utils/urlUtils';
 import { showPopupRequest } from './showPopupRequest';
 
-// const POPUP_REQUEST_TIMEOUT = 602;
+// Event `POPUP_REQUEST_TIMEOUT` is used to close Popup window when there was no handshake from iframe.
 const POPUP_REQUEST_TIMEOUT = 850;
 const POPUP_CLOSE_INTERVAL = 500;
 const POPUP_OPEN_TIMEOUT = 3000;
@@ -315,17 +315,17 @@ export class PopupManager extends EventEmitter {
             this.extensionTabId = 0;
         }
 
-        if (this.popupWindow) {
-            if (this.settings.env === 'webextension') {
-                // @ts-expect-error
-                let _e = chrome.runtime.lastError;
+        if (!this.popupWindow) return;
 
-                chrome.tabs.remove(this.popupWindow.id, () => {
-                    _e = chrome.runtime.lastError;
-                });
-            } else {
-                this.popupWindow.close();
-            }
+        if (this.settings.env === 'webextension') {
+            // @ts-expect-error
+            let _e = chrome.runtime.lastError;
+
+            chrome.tabs.remove(this.popupWindow.id, () => {
+                _e = chrome.runtime.lastError;
+            });
+        } else if (!this.settings.debug) {
+            this.popupWindow.close();
             this.popupWindow = null;
         }
     }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

* Make popup not close when there is an error and connect was initialized in debug mode
* Change logic in iframe so only events going to host/parent/3rd-party are whitelisted instead of logic based on filtering what goes to popup. Since popup is a trezor.io domain and therefore trusted environment.
* Use `RESPONSE_EVENT` in popup to know what is the issue and display the error coming from connect in an error page instead of closing without giving any information.

## Related Issue

Resolve https://github.com/trezor/trezor-suite/issues/8082
## Screenshots:
