### PR TITLE
Revert "temp(coinjoin): TEMPORARY staging-btc backend"

### DIFF
--- a/packages/coinjoin/src/backend/CoinjoinBackendClient.ts
+++ b/packages/coinjoin/src/backend/CoinjoinBackendClient.ts
@@ -73,13 +73,9 @@ export class CoinjoinBackendClient {
     }
 
     fetchMempoolFilters(timestamp?: number, options?: RequestOptions) {
-        this.logger?.info('fetchMempoolFilters START');
-        return this.fetchFromBlockbook(options, 'getMempoolFilters', timestamp)
-            .then(({ entries }) => entries ?? {})
-            .then(res => {
-                this.logger?.info('fetchMempoolFilters END');
-                return res;
-            });
+        return this.fetchFromBlockbook(options, 'getMempoolFilters', timestamp).then(
+            ({ entries }) => entries ?? {},
+        );
     }
 
     private reconnect = async () => {

--- a/packages/coinjoin/src/backend/CoinjoinMempoolController.ts
+++ b/packages/coinjoin/src/backend/CoinjoinMempoolController.ts
@@ -61,19 +61,15 @@ export class CoinjoinMempoolController implements MempoolController {
     async init(addresses: string[]) {
         const filters = await this.client.fetchMempoolFilters();
         const scripts = addresses.map(addr => getMempoolAddressScript(addr, this.network));
-        this.logger?.info(`mempool filtering ${Object.keys(filters).length} txs START`);
         const txids = Object.entries(filters)
             .filter(([txid, filter]) => {
                 const isMatch = getMempoolFilter(filter, txid);
                 return scripts.some(isMatch);
             })
             .map(([txid]) => txid);
-        this.logger?.info('mempool filtering END');
-        this.logger?.info(`init fetching ${txids.length} txs START`);
         await promiseAllSequence(
             txids.map(txid => () => this.client.fetchTransaction(txid).then(this.onTx)),
         );
-        this.logger?.info('init fetching txs END');
         this.lastPurge = new Date().getTime();
     }
 

--- a/packages/suite/src/services/coinjoin/config.ts
+++ b/packages/suite/src/services/coinjoin/config.ts
@@ -22,14 +22,11 @@ export const COINJOIN_NETWORKS: PartialRecord<NetworkSymbol, ServerEnvironment> 
             coordinatorUrl: 'https://wasabiwallet.io/wabisabi/',
             wabisabiBackendUrl: 'https://wasabiwallet.io/',
             blockbookUrls: [
-                /*
                 'https://btc1.trezor.io',
                 'https://btc2.trezor.io',
                 'https://btc3.trezor.io',
                 'https://btc4.trezor.io',
                 'https://btc5.trezor.io',
-                */
-                'https://staging-btc.trezor.io',
             ],
             /* 28.02.2023 */
             baseBlockHeight: 778666,


### PR DESCRIPTION
## Description

This reverts commit db2e2557912289d03de7def6fdc4c72b5df39b87.

Reallow `btc1`-`btc5` backends for CJ accounts, removed in #8438.
