### PR TITLE
Feat: dealing with coinjoin blocked utxos

### DIFF
--- a/packages/coinjoin/src/client/round/inputRegistration.ts
+++ b/packages/coinjoin/src/client/round/inputRegistration.ts
@@ -86,9 +86,19 @@ const registerInput = async (
                     // abort remaining delayed candidates to register (if exists) registration is not going to happen for them anyway
                     signal.dispatchEvent(new Event('abort'));
                 }
+                if (error.errorCode === WabiSabiProtocolErrorCode.InputBanned) {
+                    round.prison.detain(input.outpoint, {
+                        errorCode: WabiSabiProtocolErrorCode.InputBanned,
+                        sentenceEnd: 60 * 60 * 1000, // try again in an hour
+                    });
+                }
                 if (error.errorCode === WabiSabiProtocolErrorCode.InputLongBanned) {
                     // track blacklist ban if it happens
                     logger.error(error.message);
+                    round.prison.detain(input.outpoint, {
+                        errorCode: WabiSabiProtocolErrorCode.InputLongBanned,
+                        sentenceEnd: Infinity, // forever locked
+                    });
                 }
             }
 

--- a/packages/coinjoin/src/enums.ts
+++ b/packages/coinjoin/src/enums.ts
@@ -10,6 +10,7 @@ export enum SessionPhase {
     RetryingRoundPairing = 153,
     AffiliateServerOffline = 154,
     CriticalError = 155,
+    BlockedUtxos = 156,
 
     // RoundPhase.ConnectionConfirmation
     AwaitingConfirmation = 201,

--- a/packages/suite/src/constants/suite/coinjoin.ts
+++ b/packages/suite/src/constants/suite/coinjoin.ts
@@ -19,6 +19,7 @@ export const SESSION_PHASE_MESSAGES: Record<SessionPhase, TranslationKey> = {
     [SessionPhase.RetryingRoundPairing]: 'TR_SESSION_ERROR_PHASE_RETRYING_PAIRING',
     [SessionPhase.AffiliateServerOffline]: 'TR_SESSION_ERROR_PHASE_AFFILIATE_SERVERS_OFFLINE',
     [SessionPhase.CriticalError]: 'TR_SESSION_ERROR_PHASE_CRITICAL_ERROR',
+    [SessionPhase.BlockedUtxos]: 'TR_SESSION_ERROR_PHASE_BLOCKED_UTXOS',
     [SessionPhase.AwaitingConfirmation]: 'TR_SESSION_PHASE_AWAITING_CONFIRMATION',
     [SessionPhase.AwaitingOthersConfirmation]: 'TR_SESSION_PHASE_WAITING_FOR_OTHERS',
     [SessionPhase.RegisteringOutputs]: 'TR_SESSION_PHASE_REGISTERING_OUTPUTS',

--- a/packages/suite/src/support/messages.ts
+++ b/packages/suite/src/support/messages.ts
@@ -7786,6 +7786,11 @@ export default defineMessages({
         defaultMessage: 'Critical error, stopping coinjoin.',
         description: '29 symbols max',
     },
+    TR_SESSION_ERROR_PHASE_BLOCKED_UTXOS: {
+        id: 'TR_SESSION_ERROR_PHASE_BLOCKED_UTXOS',
+        defaultMessage: 'Coinjoin temporarily unavailable',
+        description: 'Some of utxos are temporary banned, disable session for a while',
+    },
     TR_SESSION_PHASE_AWAITING_CONFIRMATION: {
         id: 'TR_SESSION_PHASE_AWAITING_CONFIRMATION',
         defaultMessage: 'Confirming availability',


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Based on https://github.com/trezor/trezor-suite/pull/8416

Some of the utxos might be temporary banned (for max 6 hours)

If the ratio of banned utxos is higher than 40% of total utxos **or** sum of banned utxos amounts is greater than  40% of all amounts then account should not be registered in to round until the ratio becomes lower (depending on `sentenceEnd` in coinjoin prison)

New `SessionPhase` enum is added (BlockedUtxos) and handled in suite (translations)

## Related Issue

Resolve https://github.com/trezor/trezor-suite/issues/8394

## Screenshots:
<img width="667" alt="image" src="https://github.com/trezor/trezor-suite/assets/3729633/6f7cada9-cd21-49fa-bf37-b72538401bd0">

