### PR TITLE
test(connect): add TrezorConnect.cancel test

### DIFF
--- a/.github/workflows/connect-test.yml
+++ b/.github/workflows/connect-test.yml
@@ -44,7 +44,7 @@ jobs:
     needs: [build]
     uses: ./.github/workflows/connect-test-params.yml
     with:
-      test-pattern: "init authorizeCoinjoin passphrase unlockPath setBusy override"
+      test-pattern: "init authorizeCoinjoin passphrase unlockPath setBusy override cancel"
 
   management:
     needs: [build]

--- a/ci/test.yml
+++ b/ci/test.yml
@@ -287,7 +287,7 @@ connect-popup manual:
   parallel:
     matrix:
       - TESTS_ENVIRONMENT: ["node", "web"]
-        TESTS_PATTERN: "init authorizeCoinjoin passphrase unlockPath setBusy"
+        TESTS_PATTERN: "init authorizeCoinjoin passphrase unlockPath setBusy cancel"
         TESTS_FIRMWARE: ["2-master", "2.2.0"]
         # todo:
         # TESTS_NODE_VERSION: ["12", "14", "16"]

--- a/packages/connect/e2e/tests/device/cancel.test.ts
+++ b/packages/connect/e2e/tests/device/cancel.test.ts
@@ -1,0 +1,36 @@
+/* eslint-disable import/no-named-as-default */
+
+import TrezorConnect from '../../../src';
+
+const { getController, setup, initTrezorConnect } = global.Trezor;
+
+const controller = getController('setBusy');
+
+describe('TrezorConnect cancel', () => {
+    beforeAll(async () => {
+        await setup(controller, { mnemonic: 'mnemonic_all' });
+        await initTrezorConnect(controller);
+    });
+
+    afterAll(async () => {
+        controller.dispose();
+        await TrezorConnect.dispose();
+    });
+
+    it(`TrezorConnect.getAddress() -> TrezorConnect.cancel()`, async () => {
+        TrezorConnect.getAddress({
+            path: "m/44'/1'/0'/0/0",
+        }).then(response => {
+            expect(response).toEqual({ code: 'Method_Cancel', error: 'Meow from trezor-connect' });
+        });
+
+        await new Promise(resolve => {
+            TrezorConnect.on('button', event => {
+                if (event.code === 'ButtonRequest_Address') {
+                    TrezorConnect.cancel('Meow from trezor-connect');
+                }
+                resolve(undefined);
+            });
+        });
+    });
+});


### PR DESCRIPTION
while reviewing #6509 I found that we don't have any connect test for TrezorConnect.cancel method which has somewhat specific handling compared to other methods. 