### PR TITLE
fix(suite): do not remove tx from notifications on tx remove

### DIFF
--- a/packages/suite/src/middlewares/suite/eventsMiddleware.ts
+++ b/packages/suite/src/middlewares/suite/eventsMiddleware.ts
@@ -1,14 +1,10 @@
 import { MiddlewareAPI } from 'redux';
 import { DEVICE } from '@trezor/connect';
 import { SUITE } from '@suite-actions/constants';
-import {
-    notificationsActions,
-    removeAccountEventsThunk,
-    removeTransactionEventsThunk,
-} from '@suite-common/toast-notifications';
+import { notificationsActions, removeAccountEventsThunk } from '@suite-common/toast-notifications';
 import * as deviceUtils from '@suite-utils/device';
 import { AppState, Action, Dispatch } from '@suite-types';
-import { accountsActions, transactionsActions } from '@suite-common/wallet-core';
+import { accountsActions } from '@suite-common/wallet-core';
 
 /*
  * Middleware for event notifications.
@@ -93,11 +89,6 @@ const eventsMiddleware =
                     api.dispatch(notificationsActions.remove(toRemove));
                 }
             });
-        }
-
-        if (transactionsActions.removeTransaction.match(action)) {
-            const { txs } = action.payload;
-            api.dispatch(removeTransactionEventsThunk(txs));
         }
 
         if (accountsActions.removeAccount.match(action)) {


### PR DESCRIPTION
## Description

- the bug occurred when we added pre-pending txs. When pending tx was downloaded from mempool, the prepending tx was removed and with that also notification
- there was a discussion, that we will not remove txs from notification even though they are deleted from mempool because it makes sense to keep the record
- txs are correctly removed on removing account / disconnecting device (any other ideas when we want to remove txs?)
- it was introduced here without any issue and description https://github.com/trezor/trezor-suite/pull/1279
## Related Issue

close #8459

## Screenshots:
![Screenshot 2023-05-16 at 10 27 13](https://github.com/trezor/trezor-suite/assets/33235762/eba995a1-44b4-45fe-9071-bb8304862336)

## TODO:
- [x] Should we add `release` tag?
- [x] Should we add it to cherrypicks?