### PR TITLE
Fix auto-update stuck on 100%

### DIFF
--- a/packages/suite-desktop/src/modules/auto-updater.ts
+++ b/packages/suite-desktop/src/modules/auto-updater.ts
@@ -43,7 +43,6 @@ export const init: Module = ({ mainWindow, store }) => {
 
     let isManualCheck = false;
     let updateCancellationToken: CancellationToken;
-    let errorHappened = false;
 
     // Prevent downloading an update unless user explicitly asks for it.
     autoUpdater.autoDownload = false;
@@ -121,7 +120,6 @@ export const init: Module = ({ mainWindow, store }) => {
     });
 
     autoUpdater.on('error', (err: Error) => {
-        errorHappened = true;
         logger.error('auto-updater', `An error happened: ${err.toString()}`);
         mainWindow.webContents.send('update/error', err);
     });
@@ -138,11 +136,6 @@ export const init: Module = ({ mainWindow, store }) => {
 
     autoUpdater.on('update-downloaded', async (info: UpdateDownloadedEvent) => {
         const { version, releaseDate, downloadedFile, releaseNotes } = info;
-
-        if (errorHappened) {
-            logger.info('auto-updater', 'An error happened. Stopping auto-update.');
-            return;
-        }
 
         logger.info('auto-updater', [
             'Update downloaded:',


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

- The condition probably solved some flow, but we don't know what exactly and not ideally (UI gets stuck on 100% downloaded). And it can stop auto-update process, that can be sucessfull. At least every new attempt for auto-update after some error.

## Screenshots:
![Screenshot 2023-05-17 at 8 01 21](https://github.com/trezor/trezor-suite/assets/3729633/8d1d59ce-19b9-476d-a3b0-4e1edfe3f7ea)

