### PR TITLE
test(connect): throw error if requested tx cache is not available

### DIFF
--- a/packages/connect/e2e/__txcache__/index.js
+++ b/packages/connect/e2e/__txcache__/index.js
@@ -39,7 +39,12 @@ const CACHE = cacheFiles(path.resolve(__dirname));
 
 const TX_CACHE = (txs, force = false) => {
     if (process.env.TESTS_USE_TX_CACHE === 'false' && !force) return [];
-    return txs.map(hash => CACHE[hash]);
+    return txs.map(hash => {
+        if (!CACHE[hash]) {
+            throw Error(`TX_CACHE for ${hash} is undefined`);
+        }
+        return CACHE[hash];
+    });
 };
 
 module.exports = {


### PR DESCRIPTION
nitpickish fix. if you try to use tx_cache and it is not available, it sets refTxs to [undefined], which is unexpected and causes runtime errors which you might start debugging only to find out that problem is in fixtures.