### PR TITLE
feat(suite-native): qrcode brightened up

### DIFF
--- a/suite-native/app/ios/Podfile.lock
+++ b/suite-native/app/ios/Podfile.lock
@@ -19,6 +19,8 @@ PODS:
     - React-Core
   - Expo (48.0.1):
     - ExpoModulesCore
+  - ExpoBrightness (11.3.0):
+    - ExpoModulesCore
   - ExpoClipboard (4.1.1):
     - ExpoModulesCore
   - ExpoLocalization (14.1.1):
@@ -534,6 +536,7 @@ DEPENDENCIES:
   - EXConstants (from `../../../node_modules/expo-constants/ios`)
   - EXImageLoader (from `../../../node_modules/expo-image-loader/ios`)
   - Expo (from `../../../node_modules/expo`)
+  - ExpoBrightness (from `../../../node_modules/expo-brightness/ios`)
   - ExpoClipboard (from `../../../node_modules/expo-clipboard/ios`)
   - ExpoLocalization (from `../../../node_modules/expo-localization/ios`)
   - ExpoModulesCore (from `../../../node_modules/expo-modules-core`)
@@ -652,6 +655,8 @@ EXTERNAL SOURCES:
     :path: "../../../node_modules/expo-image-loader/ios"
   Expo:
     :path: "../../../node_modules/expo"
+  ExpoBrightness:
+    :path: "../../../node_modules/expo-brightness/ios"
   ExpoClipboard:
     :path: "../../../node_modules/expo-clipboard/ios"
   ExpoLocalization:
@@ -765,6 +770,7 @@ SPEC CHECKSUMS:
   EXConstants: f348da07e21b23d2b085e270d7b74f282df1a7d9
   EXImageLoader: fd053169a8ee932dd83bf1fe5487a50c26d27c2b
   Expo: 79deb55f33fab1b232232868a74713772943238d
+  ExpoBrightness: 13a6108d77641ad310b7873438a0260f9eedfe5c
   ExpoClipboard: 8a36a8376ab93df9050c14577e9e0fcb805e9114
   ExpoLocalization: f26cd431ad9ea3533c5b08c4fabd879176a794bb
   ExpoModulesCore: 79392ab654019ea3aadeae308919c3d9dd97879c

--- a/suite-native/app/package.json
+++ b/suite-native/app/package.json
@@ -73,6 +73,7 @@
         "basil-ws-flipper": "^0.2.8",
         "expo": "48.0.1",
         "expo-barcode-scanner": "^12.3.1",
+        "expo-brightness": "^11.2.1",
         "expo-clipboard": "^4.1.1",
         "expo-localization": "^14.1.1",
         "expo-navigation-bar": "^2.1.1",

--- a/suite-native/qr-code/package.json
+++ b/suite-native/qr-code/package.json
@@ -18,6 +18,7 @@
         "@trezor/styles": "workspace:*",
         "@trezor/theme": "workspace:*",
         "expo-barcode-scanner": "^12.3.1",
+        "expo-brightness": "^11.2.1",
         "react": "18.2.0",
         "react-native": "0.71.7",
         "react-qr-code": "2.0.8"

--- a/suite-native/qr-code/src/components/AddressQRCode.tsx
+++ b/suite-native/qr-code/src/components/AddressQRCode.tsx
@@ -1,19 +1,18 @@
 import React from 'react';
 import { Alert, Share } from 'react-native';
 
-import { Button, ButtonBackgroundElevation, VStack } from '@suite-native/atoms';
+import { Box, Text, Button, ButtonBackgroundElevation, VStack } from '@suite-native/atoms';
 import { prepareNativeStyle, useNativeStyles } from '@trezor/styles';
 
 import { QRCode } from './QRCode';
-import { QRCodeCopyAndShareButton } from './QRCodeCopyAndShareButton';
+import { QRCodeCopyButton } from './QRCodeCopyButton';
 
 type AddressQRCodeProps = {
-    onCopy: () => void;
-    data?: string;
-    onCopyMessage?: string;
-    isShareEnabled?: boolean;
+    address: string;
     backgroundElevation?: ButtonBackgroundElevation;
 };
+
+const ON_COPY_MESSAGE = 'Address copied';
 
 const actionButtonsStyle = prepareNativeStyle(_ => ({
     alignItems: 'center',
@@ -21,47 +20,42 @@ const actionButtonsStyle = prepareNativeStyle(_ => ({
     flexDirection: 'row',
 }));
 
-export const AddressQRCode = ({
-    onCopy,
-    data,
-    onCopyMessage = 'Address copied',
-    isShareEnabled = false,
-    backgroundElevation = '0',
-}: AddressQRCodeProps) => {
+const splitStringByFourCharacters = (input: string) => input.match(/(.{4})/g)?.join(' ');
+
+export const AddressQRCode = ({ address, backgroundElevation = '0' }: AddressQRCodeProps) => {
     const { applyStyle } = useNativeStyles();
 
-    if (!data) return null;
-
-    const handleSharedata = async () => {
+    const handleShareData = async () => {
         try {
             await Share.share({
-                message: data,
+                message: address,
             });
         } catch (error) {
             Alert.alert('Something went wrong.', error.message);
         }
     };
 
+    const formattedAddress = splitStringByFourCharacters(address);
+
     return (
         <>
-            <QRCode data={data} />
+            <QRCode data={address} />
+            <Box margin="small" alignItems="center" justifyContent="center">
+                <Text variant="titleSmall" align="center">
+                    {formattedAddress}
+                </Text>
+            </Box>
             <VStack spacing="small">
-                {isShareEnabled && (
-                    <Button
-                        iconRight="share"
-                        size="large"
-                        colorScheme={`tertiaryElevation${backgroundElevation}`}
-                        onPress={handleSharedata}
-                        style={applyStyle(actionButtonsStyle)}
-                    >
-                        Share
-                    </Button>
-                )}
-                <QRCodeCopyAndShareButton
-                    data={data}
-                    onCopyMessage={onCopyMessage}
-                    onCopy={onCopy}
-                />
+                <Button
+                    iconRight="share"
+                    size="large"
+                    colorScheme={`tertiaryElevation${backgroundElevation}`}
+                    onPress={handleShareData}
+                    style={applyStyle(actionButtonsStyle)}
+                >
+                    Share
+                </Button>
+                <QRCodeCopyButton data={address} onCopyMessage={ON_COPY_MESSAGE} />
             </VStack>
         </>
     );

--- a/suite-native/qr-code/src/components/QRCode.tsx
+++ b/suite-native/qr-code/src/components/QRCode.tsx
@@ -1,17 +1,24 @@
-import React from 'react';
-import { View } from 'react-native';
+import React, { useEffect, useState } from 'react';
+import { Dimensions, View } from 'react-native';
 import ReactQRCode from 'react-qr-code';
 
+import * as Brightness from 'expo-brightness';
+
 import { prepareNativeStyle, useNativeStyles } from '@trezor/styles';
-import { Box, Text } from '@suite-native/atoms';
+import { Box } from '@suite-native/atoms';
 import { colorVariants } from '@trezor/theme';
 
 type QRCodeProps = {
     data: string;
 };
 
-export const QRCODE_SIZE = 197;
-export const QRCODE_PADDING = 12;
+const SCREEN_WIDTH = Dimensions.get('screen').width;
+
+const MAX_QRCODE_SIZE = 250;
+const QRCODE_PADDING = 12;
+
+const QRCODE_SIZE =
+    SCREEN_WIDTH < MAX_QRCODE_SIZE + QRCODE_PADDING ? SCREEN_WIDTH : MAX_QRCODE_SIZE;
 
 const qrCodeContainerStyle = prepareNativeStyle(_ => ({
     width: QRCODE_SIZE + QRCODE_PADDING,
@@ -23,6 +30,26 @@ const qrCodeContainerStyle = prepareNativeStyle(_ => ({
 
 export const QRCode = ({ data }: QRCodeProps) => {
     const { applyStyle } = useNativeStyles();
+    const [originalBrightnessValue, setOriginalBrightnessValue] = useState<number>();
+
+    useEffect(() => {
+        const storeBrightnessValue = async () => {
+            const brightnessValue = await Brightness.getBrightnessAsync();
+            setOriginalBrightnessValue(brightnessValue);
+        };
+
+        // Set brightness to maximum and store the original value.
+        storeBrightnessValue();
+        Brightness.setBrightnessAsync(1);
+    }, []);
+
+    useEffect(
+        // Restore the original brightness value when the QR code is unmounted.
+        () => () => {
+            if (originalBrightnessValue) Brightness.setBrightnessAsync(originalBrightnessValue);
+        },
+        [originalBrightnessValue],
+    );
 
     return (
         <Box alignItems="center">
@@ -35,10 +62,6 @@ export const QRCode = ({ data }: QRCodeProps) => {
                     value={data}
                 />
             </View>
-
-            <Box margin="small" alignItems="center" justifyContent="center">
-                <Text variant="body">{data}</Text>
-            </Box>
         </Box>
     );
 };

--- a/suite-native/qr-code/src/components/QRCodeCopyButton.tsx
+++ b/suite-native/qr-code/src/components/QRCodeCopyButton.tsx
@@ -5,25 +5,25 @@ import { useCopyToClipboard } from '@suite-native/helpers';
 
 type QRCodeCopyAndShareButtonProps = {
     data: string;
+    onCopy?: () => void;
     onCopyMessage: string;
-    onCopy: () => void;
 };
 
-export const QRCodeCopyAndShareButton = ({
+export const QRCodeCopyButton = ({
     data,
-    onCopyMessage,
     onCopy,
+    onCopyMessage,
 }: QRCodeCopyAndShareButtonProps) => {
     const copyToClipboard = useCopyToClipboard();
 
-    const handleCopyAndClose = async () => {
+    const handleCopy = async () => {
         await copyToClipboard(data, onCopyMessage);
-        onCopy();
+        onCopy?.();
     };
 
     return (
-        <Button size="large" onPress={handleCopyAndClose}>
-            Copy & Close
+        <Button size="large" onPress={handleCopy}>
+            Copy
         </Button>
     );
 };

--- a/suite-native/qr-code/src/components/XpubQRCode.tsx
+++ b/suite-native/qr-code/src/components/XpubQRCode.tsx
@@ -1,23 +1,17 @@
 import React, { useState } from 'react';
 
-import { Box, Button, Stack } from '@suite-native/atoms';
-import { prepareNativeStyle, useNativeStyles } from '@trezor/styles';
+import { Box, Text, Button, Stack } from '@suite-native/atoms';
 import { NetworkSymbol } from '@suite-common/wallet-config';
 
 import { QRCode } from './QRCode';
-import { QRCodeCopyAndShareButton } from './QRCodeCopyAndShareButton';
+import { QRCodeCopyButton } from './QRCodeCopyButton';
 import { XpubOverlayWarning } from './XpubQRCodeWarningOverlay';
 
 type XpubQRCodeProps = {
     onCopy: () => void;
     data?: string;
     networkSymbol: NetworkSymbol;
-    onCopyMessage?: string;
 };
-
-const qrcodeWrapperStyle = prepareNativeStyle(_ => ({
-    position: 'relative',
-}));
 
 const networkSymbolHasXpub = (networkSymbol: NetworkSymbol) => {
     // These coins don't have XPUB but public address instead
@@ -25,44 +19,43 @@ const networkSymbolHasXpub = (networkSymbol: NetworkSymbol) => {
     return true;
 };
 
-export const XpubQRCode = ({
-    data,
-    networkSymbol,
-    onCopy,
-    onCopyMessage = 'XPUB copied',
-}: XpubQRCodeProps) => {
-    const { applyStyle } = useNativeStyles();
+export const XpubQRCode = ({ data, networkSymbol, onCopy }: XpubQRCodeProps) => {
     const [isAllowedToShowXpub, setIsAllowedToShowXpub] = useState(
         !networkSymbolHasXpub(networkSymbol),
     );
 
     if (!data) return null;
 
-    const handleCopy = () => {
+    const handleHideXpub = () => {
         setIsAllowedToShowXpub(false);
         onCopy();
     };
 
     const copyMessage = networkSymbolHasXpub(networkSymbol)
-        ? onCopyMessage
+        ? 'XPUB copied'
         : 'Public address copied';
 
     return (
         <Stack spacing="medium">
-            <Box style={applyStyle(qrcodeWrapperStyle)}>
-                {!isAllowedToShowXpub && <XpubOverlayWarning />}
-                <QRCode data={data} />
-            </Box>
-            {!isAllowedToShowXpub ? (
-                <Button iconLeft="eye" onPress={() => setIsAllowedToShowXpub(true)}>
-                    Show public key
-                </Button>
+            {isAllowedToShowXpub ? (
+                <>
+                    <QRCode data={data} />
+                    <Box margin="small" alignItems="center" justifyContent="center">
+                        <Text align="center">{data}</Text>
+                    </Box>
+                    <QRCodeCopyButton
+                        data={data}
+                        onCopyMessage={copyMessage}
+                        onCopy={handleHideXpub}
+                    />
+                </>
             ) : (
-                <QRCodeCopyAndShareButton
-                    data={data}
-                    onCopyMessage={copyMessage}
-                    onCopy={handleCopy}
-                />
+                <>
+                    <XpubOverlayWarning />
+                    <Button iconLeft="eye" onPress={() => setIsAllowedToShowXpub(true)}>
+                        Show public key
+                    </Button>
+                </>
             )}
         </Stack>
     );

--- a/suite-native/qr-code/src/components/XpubQRCodeWarningOverlay.tsx
+++ b/suite-native/qr-code/src/components/XpubQRCodeWarningOverlay.tsx
@@ -6,9 +6,6 @@ import { prepareNativeStyle, useNativeStyles } from '@trezor/styles';
 const overlayStyle = prepareNativeStyle(utils => ({
     justifyContent: 'center',
     alignItems: 'center',
-    width: '100%',
-    position: 'absolute',
-    zIndex: 1,
     padding: utils.spacings.medium,
 }));
 

--- a/suite-native/receive/src/components/ReceiveAccount.tsx
+++ b/suite-native/receive/src/components/ReceiveAccount.tsx
@@ -1,7 +1,6 @@
 import React, { useState } from 'react';
 import { useSelector } from 'react-redux';
 
-import { useNavigation } from '@react-navigation/native';
 import { G } from '@mobily/ts-belt';
 
 import { Box, ErrorMessage, Text, VStack } from '@suite-native/atoms';
@@ -21,7 +20,6 @@ type AccountReceiveProps = {
 };
 
 export const ReceiveAccount = ({ accountKey, tokenContract }: AccountReceiveProps) => {
-    const navigation = useNavigation();
     const [isAddressVisible, setIsAddressVisible] = useState(false);
 
     const account = useSelector((state: AccountsRootState) =>
@@ -62,11 +60,7 @@ export const ReceiveAccount = ({ accountKey, tokenContract }: AccountReceiveProp
                 </Text>
             </Box>
             {isAddressVisible ? (
-                <ReceiveAddress
-                    accountKey={accountKey}
-                    onClose={navigation.goBack}
-                    backgroundElevation="1"
-                />
+                <ReceiveAddress accountKey={accountKey} backgroundElevation="1" />
             ) : (
                 <ReceiveTextHint onShowAddress={handleShowAddress} />
             )}

--- a/suite-native/receive/src/components/ReceiveAddress.tsx
+++ b/suite-native/receive/src/components/ReceiveAddress.tsx
@@ -2,7 +2,7 @@ import React, { useMemo, useState } from 'react';
 import { useSelector } from 'react-redux';
 
 import { AddressQRCode } from '@suite-native/qr-code';
-import { Card, ButtonBackgroundElevation } from '@suite-native/atoms';
+import { Card, ButtonBackgroundElevation, ErrorMessage } from '@suite-native/atoms';
 import {
     TransactionsRootState,
     AccountsRootState,
@@ -14,15 +14,10 @@ import { getFirstFreshAddress } from '@suite-common/wallet-utils';
 
 type ReceiveAddressProps = {
     accountKey: string;
-    onClose: () => void;
     backgroundElevation?: ButtonBackgroundElevation;
 };
 
-export const ReceiveAddress = ({
-    accountKey,
-    onClose,
-    backgroundElevation = '0',
-}: ReceiveAddressProps) => {
+export const ReceiveAddress = ({ accountKey, backgroundElevation = '0' }: ReceiveAddressProps) => {
     const [freshAddressError, setFreshAddressError] = useState();
 
     const account = useSelector((state: AccountsRootState) =>
@@ -46,24 +41,15 @@ export const ReceiveAddress = ({
         }
     }, [account, pendingAddresses, isAccountUtxoBased]);
 
-    const handleClose = () => {
-        if (freshAddress) {
-            onClose();
-        }
-    };
+    if (!freshAddress || freshAddressError)
+        return <ErrorMessage errorMessage="Something went wrong" />;
 
     return (
         <Card>
-            {!freshAddressError ? (
-                <AddressQRCode
-                    data={freshAddress?.address}
-                    onCopy={handleClose}
-                    isShareEnabled
-                    backgroundElevation={backgroundElevation}
-                />
-            ) : (
-                'Something went wrong...'
-            )}
+            <AddressQRCode
+                address={freshAddress.address}
+                backgroundElevation={backgroundElevation}
+            />
         </Card>
     );
 };

--- a/yarn.lock
+++ b/yarn.lock
@@ -7195,6 +7195,7 @@ __metadata:
     "@trezor/styles": "workspace:*"
     "@trezor/theme": "workspace:*"
     expo-barcode-scanner: ^12.3.1
+    expo-brightness: ^11.2.1
     react: 18.2.0
     react-native: 0.71.7
     react-qr-code: 2.0.8
@@ -8219,6 +8220,7 @@ __metadata:
     basil-ws-flipper: ^0.2.8
     expo: 48.0.1
     expo-barcode-scanner: ^12.3.1
+    expo-brightness: ^11.2.1
     expo-clipboard: ^4.1.1
     expo-localization: ^14.1.1
     expo-navigation-bar: ^2.1.1
@@ -17303,6 +17305,15 @@ __metadata:
   peerDependencies:
     expo: "*"
   checksum: ffad04c32a45a36d2dff6ffc4e51fe192a69dc92f50967eee1bacc0756018e6e79ccb7732b4ee6d32fddfcfab3eaff73c90643b1e8230ebfeca23b1f77567935
+  languageName: node
+  linkType: hard
+
+"expo-brightness@npm:^11.2.1":
+  version: 11.3.0
+  resolution: "expo-brightness@npm:11.3.0"
+  peerDependencies:
+    expo: "*"
+  checksum: 8b4054ffa5383bbdd6b75147f0fcbbad01702e1b553c22969ec3540a3f9cecac87d5589bc4aa33db4b2802c40924615fc32b0d4ea8d214a8877c6ab90a226364
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Description

- qr code make the screen brighter when shown
- receive address qrcode text made bigger and separated by four characters
- fix of xpub qrcode value overflow

## Related Issue

Resolve #8040
Resolve #8494

## Screenshots:
<img width="250" alt="Screenshot 2023-05-17 at 12 17 49" src="https://github.com/trezor/trezor-suite/assets/26143964/d3a7c6d5-ef05-42ab-9425-69c73a034336">
<img width="250" alt="Screenshot 2023-05-17 at 12 19 48" src="https://github.com/trezor/trezor-suite/assets/26143964/88f20dbd-7f25-4b62-8350-843f07b45825">


