### PR TITLE
fix(suite-data): enable new GitBook image syntax for Guide categories

### DIFF
--- a/packages/suite-data/src/guide/parser.ts
+++ b/packages/suite-data/src/guide/parser.ts
@@ -2,6 +2,7 @@ import { join } from 'path';
 import * as fs from 'fs-extra';
 
 import { GITBOOK_ASSETS_DIR_PREFIX } from './constants';
+import { transformImagesMarkdown } from './transformer';
 import type { GuideNode, GuideCategory } from '@suite-common/suite-types';
 
 /** @returns true if given path is a directory. */
@@ -48,9 +49,9 @@ export class Parser {
         const doc = fs.readFileSync(join(path, 'README.md'));
 
         // Match image file name from markdown image syntax
-        const image = doc
-            .toString()
-            .match(new RegExp(`(?<=${GITBOOK_ASSETS_DIR_PREFIX}/)(.*?)(?=\\))`))?.[0]
+        // The regex matches markdown syntax for images originally used by GitBook, so the markdown is transformed first - this way it is compatible with both versions of image syntax.
+        const image = transformImagesMarkdown(doc.toString())
+            .match(new RegExp(`(?<=${GITBOOK_ASSETS_DIR_PREFIX}/)(.*)(?=\\))`))?.[0]
             // even non-special characters are escaped in markdown, they are escaped again if used in JSON
             // which creates unnecessary backslash which is then converted to slash in browser and breaks the image url
             ?.replace(/\\/g, '');

--- a/packages/suite-data/src/guide/transformer.ts
+++ b/packages/suite-data/src/guide/transformer.ts
@@ -13,7 +13,7 @@ const clean = (markdown: string): string => markdown.replace(/^---\n.*?\n---\n/s
  *
  * <figure><img src=".gitbook/assets/example.png" alt=""><figcaption></figcaption></figure> to ![](.gitbook/assets/example.png)
  */
-const transformImagesMarkdown = (markdown: string) =>
+export const transformImagesMarkdown = (markdown: string) =>
     markdown.replace(
         /<figure><img src="([^"]+)" alt=""><figcaption><\/figcaption><\/figure>/g,
         '![]($1)',


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->
https://github.com/trezor/trezor-suite/pull/8428 fixed images in Guide pages, but not in category tiles. This PR fixes that.

## Related Issue

Resolve https://github.com/trezor/trezor-suite-guide/issues/4

## Screenshots
Guide 2.0 with the new image syntax:
![Screenshot 2023-05-17 at 13 34 01](https://github.com/trezor/trezor-suite/assets/42465546/b2b90993-af73-4f64-9448-59dccf83049d)

QA: This has no effect on the current guide as the syntax has been replaced manually by https://github.com/trezor/trezor-suite-guide/commit/177c50cfc833bcfad487f0cceeb5e64bbf5b9b87, but it removes the need to do such manual fixes in the future.