### PR TITLE
feat(suite): replace 'popup closed' error message with 'cancelled'

### DIFF
--- a/packages/suite/src/components/onboarding/OnboardingStepBox.tsx
+++ b/packages/suite/src/components/onboarding/OnboardingStepBox.tsx
@@ -69,7 +69,9 @@ export const OnboardingStepBox = ({
                     <ConfirmOnDevice
                         title={<Translation id="TR_CONFIRM_ON_TREZOR" />}
                         deviceModel={deviceModel}
-                        onCancel={isActionAbortable ? () => TrezorConnect.cancel() : undefined}
+                        onCancel={
+                            isActionAbortable ? () => TrezorConnect.cancel('cancelled') : undefined
+                        }
                     />
                 )}
             </ConfirmWrapper>

--- a/packages/suite/src/components/onboarding/OnboardingStepBox.tsx
+++ b/packages/suite/src/components/onboarding/OnboardingStepBox.tsx
@@ -10,6 +10,8 @@ import {
 } from '@trezor/components';
 import { Translation } from '@suite-components';
 import { DeviceModel } from '@trezor/device-utils';
+import { useIntl } from 'react-intl';
+import messages from '@suite/support/messages';
 
 const ConfirmWrapper = styled.div`
     margin-bottom: 20px;
@@ -60,38 +62,47 @@ export const OnboardingStepBox = ({
     nested,
     children,
     ...rest
-}: OnboardingStepBoxProps) => (
-    <>
-        <StyledBackdrop show={!!deviceModel && !disableConfirmWrapper} />
-        {!disableConfirmWrapper && (
-            <ConfirmWrapper data-test="@onboarding/confirm-on-device">
-                {deviceModel && (
-                    <ConfirmOnDevice
-                        title={<Translation id="TR_CONFIRM_ON_TREZOR" />}
-                        deviceModel={deviceModel}
-                        onCancel={
-                            isActionAbortable ? () => TrezorConnect.cancel('cancelled') : undefined
-                        }
-                    />
-                )}
-            </ConfirmWrapper>
-        )}
+}: OnboardingStepBoxProps) => {
+    const intl = useIntl();
 
-        <CollapsibleCard
-            image={image}
-            heading={heading}
-            description={description}
-            nested={nested}
-            {...rest}
-        >
-            {(children || innerActions) && (
-                <>
-                    {children}
-                    {innerActions && <InnerActions>{innerActions}</InnerActions>}
-                </>
+    return (
+        <>
+            <StyledBackdrop show={!!deviceModel && !disableConfirmWrapper} />
+            {!disableConfirmWrapper && (
+                <ConfirmWrapper data-test="@onboarding/confirm-on-device">
+                    {deviceModel && (
+                        <ConfirmOnDevice
+                            title={<Translation id="TR_CONFIRM_ON_TREZOR" />}
+                            deviceModel={deviceModel}
+                            onCancel={
+                                isActionAbortable
+                                    ? () =>
+                                          TrezorConnect.cancel(
+                                              intl.formatMessage(messages.TR_CANCELLED),
+                                          )
+                                    : undefined
+                            }
+                        />
+                    )}
+                </ConfirmWrapper>
             )}
-        </CollapsibleCard>
 
-        {outerActions && <OuterActions smallMargin={nested}>{outerActions}</OuterActions>}
-    </>
-);
+            <CollapsibleCard
+                image={image}
+                heading={heading}
+                description={description}
+                nested={nested}
+                {...rest}
+            >
+                {(children || innerActions) && (
+                    <>
+                        {children}
+                        {innerActions && <InnerActions>{innerActions}</InnerActions>}
+                    </>
+                )}
+            </CollapsibleCard>
+
+            {outerActions && <OuterActions smallMargin={nested}>{outerActions}</OuterActions>}
+        </>
+    );
+};

--- a/packages/suite/src/components/suite/Modal/DevicePromptModal.tsx
+++ b/packages/suite/src/components/suite/Modal/DevicePromptModal.tsx
@@ -135,7 +135,7 @@ const DevicePromptModalRenderer = ({
     isConfirmed,
     pillTitle,
     isAbortable = true,
-    onAbort = () => TrezorConnect.cancel(),
+    onAbort = () => TrezorConnect.cancel('cancelled'),
     ...rest
 }: DevicePromptModalProps) => {
     const deviceModel = useDeviceModel();

--- a/packages/suite/src/components/suite/Modal/DevicePromptModal.tsx
+++ b/packages/suite/src/components/suite/Modal/DevicePromptModal.tsx
@@ -17,6 +17,8 @@ import { Modal } from '.';
 import { useDeviceModel } from '@suite-hooks/useDeviceModel';
 import { selectIsActionAbortable } from '@suite-reducers/suiteReducer';
 import { useSelector } from '@suite-hooks/useSelector';
+import { useIntl } from 'react-intl';
+import messages from '@suite/support/messages';
 
 const StyledTrezorModal = styled(TrezorModal)`
     ${Modal.Header} {
@@ -135,7 +137,7 @@ const DevicePromptModalRenderer = ({
     isConfirmed,
     pillTitle,
     isAbortable = true,
-    onAbort = () => TrezorConnect.cancel('cancelled'),
+    onAbort,
     ...rest
 }: DevicePromptModalProps) => {
     const deviceModel = useDeviceModel();
@@ -143,6 +145,12 @@ const DevicePromptModalRenderer = ({
 
     // duplicated because headerComponents should receive undefined if isAbortable === false
     const isActionAbortable = useSelector(selectIsActionAbortable) || isAbortable;
+
+    const intl = useIntl();
+
+    if (!onAbort) {
+        onAbort = () => TrezorConnect.cancel(intl.formatMessage(messages.TR_CANCELLED));
+    }
 
     if (!modalTarget) return null;
 

--- a/packages/suite/src/components/suite/modals/Passphrase/index.tsx
+++ b/packages/suite/src/components/suite/modals/Passphrase/index.tsx
@@ -63,7 +63,7 @@ export const Passphrase = ({ device }: Props) => {
 
     const dispatch = useDispatch();
 
-    const onCancel = () => TrezorConnect.cancel();
+    const onCancel = () => TrezorConnect.cancel('cancelled');
 
     const onSubmit = useCallback(
         (value: string, passphraseOnDevice?: boolean) => {

--- a/packages/suite/src/components/suite/modals/Passphrase/index.tsx
+++ b/packages/suite/src/components/suite/modals/Passphrase/index.tsx
@@ -9,6 +9,8 @@ import * as deviceUtils from '@suite-utils/device';
 import { Translation, Modal } from '@suite-components';
 import type { TrezorDevice } from '@suite-types';
 import { OpenGuideFromTooltip } from '@guide-components';
+import { useIntl } from 'react-intl';
+import messages from '@suite/support/messages';
 
 const Wrapper = styled.div<{ authConfirmation?: boolean }>`
     display: flex;
@@ -63,7 +65,9 @@ export const Passphrase = ({ device }: Props) => {
 
     const dispatch = useDispatch();
 
-    const onCancel = () => TrezorConnect.cancel('cancelled');
+    const intl = useIntl();
+
+    const onCancel = () => TrezorConnect.cancel(intl.formatMessage(messages.TR_CANCELLED));
 
     const onSubmit = useCallback(
         (value: string, passphraseOnDevice?: boolean) => {

--- a/packages/suite/src/components/suite/modals/Word.tsx
+++ b/packages/suite/src/components/suite/modals/Word.tsx
@@ -2,27 +2,33 @@ import React from 'react';
 import TrezorConnect from '@trezor/connect';
 import { Translation, WordInput, Modal, ModalProps } from '@suite-components';
 import styled from 'styled-components';
+import { useIntl } from 'react-intl';
+import messages from '@suite/support/messages';
 
 const StyledModal = styled(Modal)`
     min-height: 450px;
 `;
 
-export const Word = (props: ModalProps) => (
-    <StyledModal
-        data-test="@recovery/word"
-        heading={<Translation id="TR_FOLLOW_INSTRUCTIONS_ON_DEVICE" />}
-        description={
-            <>
-                <Translation id="TR_ENTER_SEED_WORDS_INSTRUCTION" />{' '}
-                <Translation id="TR_RANDOM_SEED_WORDS_DISCLAIMER" />
-            </>
-        }
-        onCancel={() => TrezorConnect.cancel('cancelled')}
-        isCancelable
-        totalProgressBarSteps={5}
-        currentProgressBarStep={4}
-        {...props}
-    >
-        <WordInput />
-    </StyledModal>
-);
+export const Word = (props: ModalProps) => {
+    const intl = useIntl();
+
+    return (
+        <StyledModal
+            data-test="@recovery/word"
+            heading={<Translation id="TR_FOLLOW_INSTRUCTIONS_ON_DEVICE" />}
+            description={
+                <>
+                    <Translation id="TR_ENTER_SEED_WORDS_INSTRUCTION" />{' '}
+                    <Translation id="TR_RANDOM_SEED_WORDS_DISCLAIMER" />
+                </>
+            }
+            onCancel={() => TrezorConnect.cancel(intl.formatMessage(messages.TR_CANCELLED))}
+            isCancelable
+            totalProgressBarSteps={5}
+            currentProgressBarStep={4}
+            {...props}
+        >
+            <WordInput />
+        </StyledModal>
+    );
+};

--- a/packages/suite/src/components/suite/modals/Word.tsx
+++ b/packages/suite/src/components/suite/modals/Word.tsx
@@ -17,7 +17,7 @@ export const Word = (props: ModalProps) => (
                 <Translation id="TR_RANDOM_SEED_WORDS_DISCLAIMER" />
             </>
         }
-        onCancel={() => TrezorConnect.cancel()}
+        onCancel={() => TrezorConnect.cancel('cancelled')}
         isCancelable
         totalProgressBarSteps={5}
         currentProgressBarStep={4}

--- a/packages/suite/src/components/suite/modals/WordAdvanced.tsx
+++ b/packages/suite/src/components/suite/modals/WordAdvanced.tsx
@@ -27,7 +27,7 @@ export const WordAdvanced = ({ count, ...rest }: WordAdvancedProps) => (
     <StyledModal
         heading={<Translation id="TR_FOLLOW_INSTRUCTIONS_ON_DEVICE" />}
         description={<Translation id="TR_ADVANCED_RECOVERY_TEXT" />}
-        onCancel={() => TrezorConnect.cancel()}
+        onCancel={() => TrezorConnect.cancel('cancelled')}
         isCancelable
         totalProgressBarSteps={5}
         currentProgressBarStep={4}

--- a/packages/suite/src/components/suite/modals/WordAdvanced.tsx
+++ b/packages/suite/src/components/suite/modals/WordAdvanced.tsx
@@ -4,6 +4,8 @@ import TrezorConnect from '@trezor/connect';
 import { P } from '@trezor/components';
 import { HELP_CENTER_ADVANCED_RECOVERY_URL } from '@trezor/urls';
 import { Translation, WordInputAdvanced, TrezorLink, Modal, ModalProps } from '@suite-components';
+import { useIntl } from 'react-intl';
+import messages from '@suite/support/messages';
 
 const ContentWrapper = styled.div`
     display: flex;
@@ -23,26 +25,30 @@ interface WordAdvancedProps extends ModalProps {
     count: 6 | 9;
 }
 
-export const WordAdvanced = ({ count, ...rest }: WordAdvancedProps) => (
-    <StyledModal
-        heading={<Translation id="TR_FOLLOW_INSTRUCTIONS_ON_DEVICE" />}
-        description={<Translation id="TR_ADVANCED_RECOVERY_TEXT" />}
-        onCancel={() => TrezorConnect.cancel('cancelled')}
-        isCancelable
-        totalProgressBarSteps={5}
-        currentProgressBarStep={4}
-        {...rest}
-    >
-        <ContentWrapper>
-            <WordInputAdvanced count={count} />
-            <BottomText>
-                <P size="tiny">
-                    <Translation id="TR_ADVANCED_RECOVERY_NOT_SURE" />{' '}
-                    <TrezorLink size="tiny" href={HELP_CENTER_ADVANCED_RECOVERY_URL}>
-                        <Translation id="TR_LEARN_MORE" />
-                    </TrezorLink>
-                </P>
-            </BottomText>
-        </ContentWrapper>
-    </StyledModal>
-);
+export const WordAdvanced = ({ count, ...rest }: WordAdvancedProps) => {
+    const intl = useIntl();
+
+    return (
+        <StyledModal
+            heading={<Translation id="TR_FOLLOW_INSTRUCTIONS_ON_DEVICE" />}
+            description={<Translation id="TR_ADVANCED_RECOVERY_TEXT" />}
+            onCancel={() => TrezorConnect.cancel(intl.formatMessage(messages.TR_CANCELLED))}
+            isCancelable
+            totalProgressBarSteps={5}
+            currentProgressBarStep={4}
+            {...rest}
+        >
+            <ContentWrapper>
+                <WordInputAdvanced count={count} />
+                <BottomText>
+                    <P size="tiny">
+                        <Translation id="TR_ADVANCED_RECOVERY_NOT_SURE" />{' '}
+                        <TrezorLink size="tiny" href={HELP_CENTER_ADVANCED_RECOVERY_URL}>
+                            <Translation id="TR_LEARN_MORE" />
+                        </TrezorLink>
+                    </P>
+                </BottomText>
+            </ContentWrapper>
+        </StyledModal>
+    );
+};

--- a/packages/suite/src/support/messages.ts
+++ b/packages/suite/src/support/messages.ts
@@ -4106,6 +4106,10 @@ export default defineMessages({
         id: 'TR_CANCEL',
         defaultMessage: 'Cancel',
     },
+    TR_CANCELLED: {
+        id: 'TR_CANCELLED',
+        defaultMessage: 'Cancelled',
+    },
     TR_FOLLOW_INSTRUCTIONS_ON_DEVICE: {
         id: 'TR_FOLLOW_INSTRUCTIONS_ON_DEVICE',
         defaultMessage: 'Check your Trezor screen',

--- a/packages/suite/src/views/recovery/index.tsx
+++ b/packages/suite/src/views/recovery/index.tsx
@@ -12,6 +12,8 @@ import { InstructionStep } from '@suite-components/InstructionStep';
 import { getCheckBackupUrl } from '@suite-utils/device';
 import { DeviceModel, getDeviceModel, pickByDeviceModel } from '@trezor/device-utils';
 import TrezorConnect from '@trezor/connect';
+import { useIntl } from 'react-intl';
+import messages from '@suite/support/messages';
 
 const StyledModal = styled(Modal)`
     min-height: 450px;
@@ -69,6 +71,8 @@ export const Recovery = ({ onCancel }: ForegroundAppProps) => {
     });
     const { device, isLocked } = useDevice();
     const [understood, setUnderstood] = useState(false);
+
+    const intl = useIntl();
 
     const onSetWordsCount = (count: WordCount) => {
         actions.setWordsCount(count);
@@ -259,7 +263,7 @@ export const Recovery = ({ onCancel }: ForegroundAppProps) => {
             isCancelable
             onCancel={() => {
                 if (['in-progress', 'waiting-for-confirmation'].includes(recovery.status)) {
-                    TrezorConnect.cancel('cancelled');
+                    TrezorConnect.cancel(intl.formatMessage(messages.TR_CANCELLED));
                 } else {
                     onCancel();
                 }

--- a/packages/suite/src/views/recovery/index.tsx
+++ b/packages/suite/src/views/recovery/index.tsx
@@ -259,7 +259,7 @@ export const Recovery = ({ onCancel }: ForegroundAppProps) => {
             isCancelable
             onCancel={() => {
                 if (['in-progress', 'waiting-for-confirmation'].includes(recovery.status)) {
-                    TrezorConnect.cancel();
+                    TrezorConnect.cancel('cancelled');
                 } else {
                     onCancel();
                 }


### PR DESCRIPTION
nitpick. now, whenever we cancel something on device and there is no argument passed to TrezorConnect.cancel method, user sees something like "popup closed".  I think that this is not the righ wording, and I would even argue that we should not show "error" message at all. 

we could also send a translated string so that we don't see outputs such as "Chyba: cancelled"