### PR TITLE
fix(connect-web): fix imports from connect

### DIFF
--- a/ci/build.yml
+++ b/ci/build.yml
@@ -256,6 +256,7 @@ connect-web build:
     - git submodule update --init --recursive
     - yarn install --immutable
     - yarn workspace @trezor/connect-web build
+    - ./packages/connect-web/scripts/check-inline-build-size.sh
     - yarn workspace @trezor/connect-iframe build
     - yarn workspace @trezor/connect-popup build
   artifacts:

--- a/packages/connect-web/scripts/check-inline-build-size.sh
+++ b/packages/connect-web/scripts/check-inline-build-size.sh
@@ -1,0 +1,22 @@
+#!/usr/bin/env bash
+
+set -e
+
+echo "trezor-connect.js size check"
+
+parent_path=$( cd "$(dirname "${BASH_SOURCE[0]}")" ; pwd -P )
+
+du -h "$parent_path/../build/trezor-connect.js"
+
+SIZE_S=$(du -s "$parent_path/../build/trezor-connect.js" | cut -f1)
+# at time of creating this script size was 320
+# if you have considerably more, there is a chance that you accidentally included
+# parts of code that shouldn't be in this build.
+if [[ "$SIZE_S" -gt 400 ]]
+then
+    echo "suspiciously large build detected!"
+    exit 1;
+else
+    echo "size seems ok"
+fi
+

--- a/packages/connect-web/src/iframe/index.ts
+++ b/packages/connect-web/src/iframe/index.ts
@@ -1,7 +1,7 @@
 // origin: https://github.com/trezor/connect/blob/develop/src/js/iframe/builder.js
 
 import { createDeferred, Deferred } from '@trezor/utils';
-import { IFRAME, ERRORS, ConnectSettings } from '@trezor/connect/lib/index';
+import { IFRAME, ERRORS, ConnectSettings } from '@trezor/connect/lib/exports';
 import { getOrigin } from '@trezor/connect/lib/utils/urlUtils';
 import css from './inlineStyles';
 

--- a/packages/connect-web/src/popup/index.ts
+++ b/packages/connect-web/src/popup/index.ts
@@ -9,7 +9,7 @@ import {
     ConnectSettings,
     CoreMessage,
     IFrameLoaded,
-} from '@trezor/connect/lib/index';
+} from '@trezor/connect/lib/exports';
 import { getOrigin } from '@trezor/connect/lib/utils/urlUtils';
 import { showPopupRequest } from './showPopupRequest';
 


### PR DESCRIPTION
this should fix the problem reported #8506

[fix(connect-web): fix imports from connect](https://github.com/trezor/trezor-suite/pull/8508/commits/05e18808f90e4d496dd8545fde5d754fba255c59) shoudl remove all imports from connect-web package that caused importing from connect core
[ci(connect): add inline-script size check](https://github.com/trezor/trezor-suite/pull/8508/commits/ad23f57427c3dd05d25d6c901801ffedacb3c4b2) adds some not very clever check that could prevent accidental bundling of stuff in the future