### PR TITLE
Fail silently when mempool tx not found in CJ

### DIFF
--- a/packages/coinjoin/src/backend/CoinjoinMempoolController.ts
+++ b/packages/coinjoin/src/backend/CoinjoinMempoolController.ts
@@ -68,7 +68,13 @@ export class CoinjoinMempoolController implements MempoolController {
             })
             .map(([txid]) => txid);
         await promiseAllSequence(
-            txids.map(txid => () => this.client.fetchTransaction(txid).then(this.onTx)),
+            txids.map(
+                txid => () =>
+                    this.client
+                        .fetchTransaction(txid)
+                        .then(this.onTx)
+                        .catch(() => {}), // Missing txs can be ignored
+            ),
         );
         this.lastPurge = new Date().getTime();
     }


### PR DESCRIPTION
## Description

In CJ account mempool sync, there are some cases when it's valid to ignore `tx not found` error (tx was bumped/purged between mempool filter request and tx request, for example). Let's just fail silently instead of throwing an error which causes the entire discovery to fail.
