### PR TITLE
fix(ci): remove dependenci_check

### DIFF
--- a/ci/scripts/check-npm-dependencies.js
+++ b/ci/scripts/check-npm-dependencies.js
@@ -1,94 +1,36 @@
-/* eslint-disable camelcase */
 /**
  * node check-npm-dependencies.js <package_name>
  */
-
+const { promisify } = require('util');
 const fs = require('fs');
 const path = require('path');
-const child_process = require('child_process');
+
+const readdir = promisify(fs.readdir);
+const { checkPackageDependencies } = require('./npm-dependencies-helper');
 
 const rootPath = path.join(__dirname, '..', '..');
 const packagesPath = path.join(rootPath, 'packages');
 
-const packages = fs.readdirSync(packagesPath, {
-    encoding: 'utf-8',
-});
+const args = process.argv.slice(2);
 
-const ROOT = path.join(__dirname, '..', '..');
+if (args.length < 1) throw new Error('Check npm dependencies requires 1 parameter: package name');
+const [packageName] = args;
 
-const updateNeeded = [];
-const errors = [];
-
-const checkPackageDependencies = packageName => {
-    const rawPackageJSON = fs.readFileSync(
-        path.join(ROOT, 'packages', packageName, 'package.json'),
-    );
-
-    const packageJSON = JSON.parse(rawPackageJSON);
-    const { dependencies, devDependencies } = packageJSON;
-
-    const allDependnecies = { ...dependencies, ...devDependencies };
-    if (!Object.keys(allDependnecies)) {
-        return;
-    }
-
-    Object.entries(allDependnecies).forEach(([dependency, version]) => {
-        // is not a dependency released from monorepo. we don't care
-        if (!dependency.startsWith('@trezor')) {
-            return;
-        }
-
-        const [_prefix, name] = dependency.split('/');
-        const PACKAGE_PATH = path.join(ROOT, 'packages', name);
-        // check local package
-        const packResultRaw = child_process.spawnSync('npm', ['pack', '--dry-run', '--json'], {
-            encoding: 'utf-8',
-            cwd: PACKAGE_PATH,
-        }).stdout;
-
-        const packResultJSON = JSON.parse(packResultRaw);
-        const localChecksum = packResultJSON[0].shasum;
-
-        // check remote package
-        const { stderr, stdout: viewResultRaw } = child_process.spawnSync(
-            'npm',
-            ['view', '--json'],
-            {
-                encoding: 'utf-8',
-                cwd: PACKAGE_PATH,
-            },
-        );
-
-        if (stderr) {
-            errors.push(name);
-            return;
-        }
-
-        const viewResultJSON = JSON.parse(viewResultRaw);
-        if (viewResultJSON.error) {
-            return;
-        }
-
-        const remoteChecksum = viewResultJSON[dependency].dist.shasum;
-
-        if (localChecksum !== remoteChecksum) {
-            // if the checked dependency is already in the array, remove it and push it to the end of array
-            // this way, the final array should be sorted in order in which that dependencies listed there
-            // should be released from the last to the first
-            const index = updateNeeded.findIndex(lib => lib === dependency);
-            if (index > -1) {
-                updateNeeded.splice(index, 1);
-            }
-            updateNeeded.push(dependency);
-        }
-
-        checkPackageDependencies(name);
+(async () => {
+    const packages = await readdir(packagesPath, {
+        encoding: 'utf-8',
     });
 
-    return {
-        update: updateNeeded,
-        errors,
-    };
-};
+    if (!packages.includes(packageName)) {
+        throw new Error(`provided package name: ${packageName} must be one of ${packages}`);
+    }
 
-module.exports = { checkPackageDependencies };
+    const checkResult = checkPackageDependencies(packageName);
+
+    if (checkResult.errors.length > 0) {
+        const errorMessage = `Deps error. one of the dependencies likely needs to be published for the first time: ${checkResult.errors.join(
+            ', ',
+        )}`;
+        throw Error(errorMessage);
+    }
+})();

--- a/ci/scripts/connect-release-init.js
+++ b/ci/scripts/connect-release-init.js
@@ -2,7 +2,7 @@ const child_process = require('child_process');
 const path = require('path');
 const fs = require('fs');
 
-const { checkPackageDependencies } = require('./check-npm-dependencies');
+const { checkPackageDependencies } = require('./npm-dependencies-helper');
 
 const args = process.argv.slice(2);
 

--- a/ci/scripts/npm-dependencies-helper.js
+++ b/ci/scripts/npm-dependencies-helper.js
@@ -1,0 +1,91 @@
+/* eslint-disable camelcase */
+
+const fs = require('fs');
+const path = require('path');
+const child_process = require('child_process');
+
+const rootPath = path.join(__dirname, '..', '..');
+const packagesPath = path.join(rootPath, 'packages');
+
+const packages = fs.readdirSync(packagesPath, {
+    encoding: 'utf-8',
+});
+
+const ROOT = path.join(__dirname, '..', '..');
+
+const updateNeeded = [];
+const errors = [];
+
+const checkPackageDependencies = packageName => {
+    const rawPackageJSON = fs.readFileSync(
+        path.join(ROOT, 'packages', packageName, 'package.json'),
+    );
+
+    const packageJSON = JSON.parse(rawPackageJSON);
+    const { dependencies, devDependencies } = packageJSON;
+
+    const allDependnecies = { ...dependencies, ...devDependencies };
+    if (!Object.keys(allDependnecies)) {
+        return;
+    }
+
+    Object.entries(allDependnecies).forEach(([dependency, version]) => {
+        // is not a dependency released from monorepo. we don't care
+        if (!dependency.startsWith('@trezor')) {
+            return;
+        }
+
+        const [_prefix, name] = dependency.split('/');
+        const PACKAGE_PATH = path.join(ROOT, 'packages', name);
+        // check local package
+        const packResultRaw = child_process.spawnSync('npm', ['pack', '--dry-run', '--json'], {
+            encoding: 'utf-8',
+            cwd: PACKAGE_PATH,
+        }).stdout;
+
+        const packResultJSON = JSON.parse(packResultRaw);
+        const localChecksum = packResultJSON[0].shasum;
+
+        // check remote package
+        const { stderr, stdout: viewResultRaw } = child_process.spawnSync(
+            'npm',
+            ['view', '--json'],
+            {
+                encoding: 'utf-8',
+                cwd: PACKAGE_PATH,
+            },
+        );
+
+        if (stderr) {
+            errors.push(name);
+            return;
+        }
+
+        const viewResultJSON = JSON.parse(viewResultRaw);
+        if (viewResultJSON.error) {
+            return;
+        }
+
+        const remoteChecksum = viewResultJSON[dependency].dist.shasum;
+
+        if (localChecksum !== remoteChecksum) {
+            // if the checked dependency is already in the array, remove it and push it to the end of array
+            // this way, the final array should be sorted in order in which that dependencies listed there
+            // should be released from the last to the first
+            const index = updateNeeded.findIndex(lib => lib === dependency);
+            if (index > -1) {
+                updateNeeded.splice(index, 1);
+            }
+            updateNeeded.push(dependency);
+        }
+
+        checkPackageDependencies(name);
+    });
+
+    return {
+        update: updateNeeded,
+        errors,
+    };
+};
+
+module.exports = { checkPackageDependencies };


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Due to latest changes in `ci/scripts/check-npm-dependencies` by this PR https://github.com/trezor/trezor-suite/pull/8454 this job is not doing anything.  Becuase that script is now just importing the function `checkPackageDependencies` and not running it with arguments provided from as it was.

The part that was running it for `connect`  https://github.com/trezor/trezor-suite/blob/develop/ci/scripts/connect-release-init.js#L43

But  the part that was running it for `connect-web` is not run anywhere.

If we want to run it we should create a new js script that imports `checkPackageDependencies` and call it with `connect-web` or change things in a different way.


## Related Issue

Resolve https://github.com/trezor/trezor-suite/issues/8537
