### PR TITLE
Feat: presistent CoinjoinPrison

### DIFF
--- a/packages/coinjoin/src/client/CoinjoinClient.ts
+++ b/packages/coinjoin/src/client/CoinjoinClient.ts
@@ -90,12 +90,20 @@ export class CoinjoinClient extends TypedEmitter<CoinjoinClientEvents> {
         }
         this.logger.info(`Register account ~~${account.accountKey}~~`);
 
-        // iterate Status more frequently
-        if (this.accounts.length === 0) {
-            this.status.setMode('enabled');
-        }
+        const candidate = new Account(account, this.network);
+        // walk thru all status Rounds and search in for accounts inputs/outputs which are not supposed to be there. (interrupted round)
+        // detain them if they are not already detained
+        const detained = candidate.findDetainedElements(this.status.rounds);
+        detained.forEach(item => {
+            if (!this.prison.isDetained(item)) {
+                this.prison.detain(item);
+            }
+        });
 
-        this.accounts.push(new Account(account, this.network));
+        this.accounts.push(candidate);
+
+        // iterate Status more frequently
+        this.status.setMode('enabled');
 
         // try to trigger registration immediately without waiting for Status change
         this.onStatusUpdate({

--- a/packages/coinjoin/src/client/CoinjoinClient.ts
+++ b/packages/coinjoin/src/client/CoinjoinClient.ts
@@ -44,7 +44,8 @@ export class CoinjoinClient extends TypedEmitter<CoinjoinClientEvents> {
         this.status.on('log', ({ level, payload }) => this.logger[level](payload));
         this.status.on('affiliate-server', event => this.onAffiliateServerStatus(event));
 
-        this.prison = new CoinjoinPrison();
+        this.prison = new CoinjoinPrison(settings.prison);
+        this.prison.on('change', data => this.emit('prison', data));
     }
 
     enable() {

--- a/packages/coinjoin/src/client/CoinjoinPrison.ts
+++ b/packages/coinjoin/src/client/CoinjoinPrison.ts
@@ -1,39 +1,62 @@
+import { TypedEmitter } from '@trezor/utils/lib/typedEventEmitter';
+
+import { CoinjoinPrisonInmate, CoinjoinPrisonEvents } from '../types/client';
 import { WabiSabiProtocolErrorCode } from '../enums';
 
-export interface PrisonInmate {
-    id: string; // AccountUtxo/Alice.outpoint or AccountAddress scriptPubKey
-    sentenceStart: number;
-    sentenceEnd: number;
-    errorCode?: WabiSabiProtocolErrorCode | 'blameOf';
-    reason?: string;
+export interface DetainOptions {
     roundId?: string;
-}
-
-export interface PrisonOptions {
-    roundId?: string;
-    errorCode?: PrisonInmate['errorCode'];
-    reason?: PrisonInmate['reason'];
+    errorCode?: CoinjoinPrisonInmate['errorCode'];
+    reason?: CoinjoinPrisonInmate['reason'];
     sentenceEnd?: number;
 }
 
 // Errored or currently registered inputs and addresses are sent here
 // inspiration: WalletWasabi/WabiSabi/Backend/Banning/Prison.cs
 
-export class CoinjoinPrison {
-    inmates: PrisonInmate[] = [];
+export class CoinjoinPrison extends TypedEmitter<CoinjoinPrisonEvents> {
+    inmates: CoinjoinPrisonInmate[] = [];
+    private changeEventThrottle:
+        | ReturnType<typeof setImmediate>
+        | ReturnType<typeof setTimeout>
+        | undefined;
 
-    detain(id: string, options: PrisonOptions = {}) {
+    constructor(initialState: CoinjoinPrisonInmate[] = []) {
+        super();
+        this.inmates = initialState;
+    }
+
+    private dispatchChange() {
+        // throttle change events. might be emitted one after another (example: multiple detentions in loop after round end)
+        const emitFn = () => {
+            this.changeEventThrottle = undefined;
+            this.emit('change', { prison: this.inmates });
+        };
+
+        if (typeof setImmediate !== 'undefined') {
+            clearImmediate(this.changeEventThrottle as NodeJS.Immediate);
+            this.changeEventThrottle = setImmediate(emitFn);
+        } else {
+            clearTimeout(this.changeEventThrottle as NodeJS.Timeout);
+            this.changeEventThrottle = setTimeout(emitFn, 0);
+        }
+    }
+
+    detain(id: string, options: DetainOptions = {}) {
         const sentenceStart = Date.now();
         const sentenceEnd = Date.now() + (options.sentenceEnd ? options.sentenceEnd : 6 * 60000);
 
-        this.inmates.push({
-            id,
-            sentenceEnd,
-            sentenceStart,
-            errorCode: options.errorCode,
-            reason: options.reason,
-            roundId: options.roundId,
-        });
+        this.inmates = this.inmates
+            .filter(i => i.id !== id)
+            .concat({
+                id,
+                sentenceEnd,
+                sentenceStart,
+                errorCode: options.errorCode,
+                reason: options.reason,
+                roundId: options.roundId,
+            });
+
+        this.dispatchChange();
     }
 
     isDetained(id: string) {
@@ -55,6 +78,8 @@ export class CoinjoinPrison {
 
     releaseBlameOfInmates(roundId: string) {
         this.inmates = this.inmates.filter(inmate => inmate.roundId !== roundId);
+
+        this.dispatchChange();
     }
 
     // release inputs detained by successful input-registration
@@ -66,11 +91,18 @@ export class CoinjoinPrison {
                     inmate.errorCode === WabiSabiProtocolErrorCode.AliceAlreadyRegistered
                 ),
         );
+
+        this.dispatchChange();
     }
 
     // called on each status change before rounds are processed
     release() {
         const now = Date.now();
+        const prevLen = this.inmates.length;
         this.inmates = this.inmates.filter(inmate => inmate.sentenceEnd > now);
+
+        if (prevLen !== this.inmates.length) {
+            this.dispatchChange();
+        }
     }
 }

--- a/packages/coinjoin/src/client/round/endedRound.ts
+++ b/packages/coinjoin/src/client/round/endedRound.ts
@@ -49,22 +49,21 @@ export const ended = (round: CoinjoinRound, { logger, network }: CoinjoinRoundOp
             logger.error(`Round not signed. This should never happen.`);
         }
         inputs.forEach(input =>
-            prison.detain(input.outpoint, {
+            prison.detain(input, {
                 roundId: id,
                 errorCode: WabiSabiProtocolErrorCode.InputBanned,
             }),
         );
     } else if (endRoundState === EndRoundState.NotAllAlicesSign) {
         logger.info('Awaiting blame round');
-        const inmates = inputs.map(i => i.outpoint).concat(addresses.map(a => a.scriptPubKey));
 
-        prison.detainForBlameRound(inmates, id);
+        prison.detainForBlameRound([...inputs, ...addresses], id);
     } else if (endRoundState === EndRoundState.AbortedNotEnoughAlices) {
         prison.releaseRegisteredInmates(id);
     } else if (endRoundState === EndRoundState.TransactionBroadcasted) {
         // detain all signed inputs and addresses forever
         inputs.forEach(input =>
-            prison.detain(input.outpoint, {
+            prison.detain(input, {
                 roundId: id,
                 errorCode: WabiSabiProtocolErrorCode.InputSpent,
                 sentenceEnd: Infinity,
@@ -72,7 +71,7 @@ export const ended = (round: CoinjoinRound, { logger, network }: CoinjoinRoundOp
         );
 
         addresses.forEach(addr =>
-            prison.detain(addr.scriptPubKey, {
+            prison.detain(addr, {
                 roundId: id,
                 errorCode: WabiSabiProtocolErrorCode.AlreadyRegisteredScript,
                 sentenceEnd: Infinity,

--- a/packages/coinjoin/src/client/round/inputRegistration.ts
+++ b/packages/coinjoin/src/client/round/inputRegistration.ts
@@ -87,7 +87,7 @@ const registerInput = async (
                     signal.dispatchEvent(new Event('abort'));
                 }
                 if (error.errorCode === WabiSabiProtocolErrorCode.InputBanned) {
-                    round.prison.detain(input.outpoint, {
+                    round.prison.detain(input, {
                         errorCode: WabiSabiProtocolErrorCode.InputBanned,
                         sentenceEnd: 60 * 60 * 1000, // try again in an hour
                     });
@@ -95,7 +95,7 @@ const registerInput = async (
                 if (error.errorCode === WabiSabiProtocolErrorCode.InputLongBanned) {
                     // track blacklist ban if it happens
                     logger.error(error.message);
-                    round.prison.detain(input.outpoint, {
+                    round.prison.detain(input, {
                         errorCode: WabiSabiProtocolErrorCode.InputLongBanned,
                         sentenceEnd: Infinity, // forever locked
                     });
@@ -120,7 +120,7 @@ const registerInput = async (
     // store RegistrationData and affiliateFlag
     input.setRegistrationData(registrationData, coordinatorFee > 0);
     // and put input to prison
-    round.prison.detain(input.outpoint, {
+    round.prison.detain(input, {
         roundId: round.id,
         errorCode: WabiSabiProtocolErrorCode.AliceAlreadyRegistered,
     });

--- a/packages/coinjoin/src/client/round/selectRound.ts
+++ b/packages/coinjoin/src/client/round/selectRound.ts
@@ -84,9 +84,6 @@ export const getAccountCandidates = ({
     prison,
     options: { logger, setSessionPhase },
 }: Pick<SelectRoundProps, 'accounts' | 'coinjoinRounds' | 'prison' | 'options'>) => {
-    // TODO: walk thru all Round[] and search in round events for account input/output scriptPubKey which are not supposed to be there (interrupted round)
-    // if they are in phase 0 put them to prison to cool off so they registration on coordinator will timeout naturally, otherwise prison for longer, they will be banned
-
     // collect outpoints of all currently registered inputs in CoinjoinRounds + inputs in prison
     const registeredOutpoints = coinjoinRounds
         .flatMap(round => round.inputs.concat(round.failed).map(u => u.outpoint))

--- a/packages/coinjoin/src/types/client.ts
+++ b/packages/coinjoin/src/types/client.ts
@@ -28,7 +28,9 @@ export interface CoinjoinPrisonEvents {
 }
 
 export interface CoinjoinPrisonInmate {
-    id: string; // AccountUtxo/Alice.outpoint or AccountAddress scriptPubKey
+    type: 'input' | 'output' | 'account';
+    accountKey: string;
+    id: string; // AccountUtxo/Alice.outpoint or AccountAddress scriptPubKey or Account key
     sentenceStart: number;
     sentenceEnd: number;
     errorCode?: WabiSabiProtocolErrorCode | 'blameOf';

--- a/packages/coinjoin/src/types/client.ts
+++ b/packages/coinjoin/src/types/client.ts
@@ -1,4 +1,4 @@
-import { SessionPhase } from '../enums';
+import { SessionPhase, WabiSabiProtocolErrorCode } from '../enums';
 import { AllowedRange, CoordinationFeeRate, Round } from './coordinator';
 import { CoinjoinRequestEvent, CoinjoinRoundEvent } from './round';
 import { LogEvent } from './logger';
@@ -13,6 +13,7 @@ export interface CoinjoinStatusEvent {
 
 export interface CoinjoinClientEvents {
     status: CoinjoinStatusEvent;
+    prison: CoinjoinPrisonEvents['change'];
     round: CoinjoinRoundEvent;
     request: CoinjoinRequestEvent[];
     log: LogEvent;
@@ -20,4 +21,17 @@ export interface CoinjoinClientEvents {
         phase: SessionPhase;
         accountKeys: string[];
     };
+}
+
+export interface CoinjoinPrisonEvents {
+    change: { prison: CoinjoinPrisonInmate[] };
+}
+
+export interface CoinjoinPrisonInmate {
+    id: string; // AccountUtxo/Alice.outpoint or AccountAddress scriptPubKey
+    sentenceStart: number;
+    sentenceEnd: number;
+    errorCode?: WabiSabiProtocolErrorCode | 'blameOf';
+    reason?: string;
+    roundId?: string;
 }

--- a/packages/coinjoin/src/types/index.ts
+++ b/packages/coinjoin/src/types/index.ts
@@ -1,3 +1,5 @@
+import { CoinjoinPrisonInmate } from './client';
+
 interface BaseSettings {
     network: 'btc' | 'test' | 'regtest';
     coordinatorUrl: string;
@@ -15,6 +17,7 @@ export interface CoinjoinBackendSettings extends BaseSettings {
 export interface CoinjoinClientSettings extends BaseSettings {
     coordinatorName: string; // identifier used in commitment data and ownership proof
     middlewareUrl: string;
+    prison?: CoinjoinPrisonInmate[];
 }
 
 export type {

--- a/packages/coinjoin/tests/client/CoinjoinClient.test.ts
+++ b/packages/coinjoin/tests/client/CoinjoinClient.test.ts
@@ -1,10 +1,11 @@
 import { CoinjoinClient } from '../../src';
+import { CoinjoinPrison } from '../../src/client/CoinjoinPrison';
 import { createServer } from '../mocks/server';
 import { AFFILIATE_INFO, DEFAULT_ROUND, FEE_RATE_MEDIANS } from '../fixtures/round.fixture';
 
-let server: Awaited<ReturnType<typeof createServer>>;
-
 describe(`CoinjoinClient`, () => {
+    let server: Awaited<ReturnType<typeof createServer>>;
+
     beforeAll(async () => {
         server = await createServer();
     });
@@ -14,7 +15,7 @@ describe(`CoinjoinClient`, () => {
     });
 
     afterAll(() => {
-        if (server) server.close();
+        server?.close();
     });
 
     it('enable success', async () => {
@@ -36,5 +37,178 @@ describe(`CoinjoinClient`, () => {
         expect(status?.coordinationFeeRate.rate).toBeGreaterThan(0);
 
         cli.disable();
+    });
+
+    it('registerAccount and detain registered inputs/outputs from Status', async () => {
+        server?.addListener('test-request', ({ url, resolve }) => {
+            if (url.endsWith('/status')) {
+                resolve({
+                    coinJoinFeeRateMedians: FEE_RATE_MEDIANS,
+                    affiliateInformation: AFFILIATE_INFO,
+                    roundStates: [
+                        DEFAULT_ROUND,
+                        {
+                            ...DEFAULT_ROUND,
+                            id: '8080808080808080808080808080808080808080808080808080808080808080',
+                            phase: 1,
+                            coinjoinState: {
+                                events: [
+                                    {
+                                        Type: 'InputAdded',
+                                        coin: {
+                                            outpoint:
+                                                'AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA00000000',
+                                            txOut: {
+                                                scriptPubKey:
+                                                    '51208b0bc63a6c9c4459fe510d7c42c8dade5e8070ca623a9aed9086a7d21a3423b2',
+                                                value: 10000,
+                                            },
+                                        },
+                                    },
+                                    {
+                                        Type: 'OutputAdded',
+                                        output: {
+                                            scriptPubKey:
+                                                '1 0ffeae3fbd08c25521369afbb6d7dacec99f3b24b6113c2fe497bede04723789',
+                                            value: 8000,
+                                        },
+                                    },
+                                ],
+                            },
+                        },
+                        {
+                            ...DEFAULT_ROUND,
+                            id: '9090909090909090909090909090909090909090909090909090909090909090',
+                            phase: 2,
+                            coinjoinState: {
+                                events: [
+                                    {
+                                        Type: 'InputAdded',
+                                        coin: {
+                                            outpoint:
+                                                'BBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBB00000000',
+                                            txOut: {
+                                                scriptPubKey:
+                                                    '51208b0bc63a6c9c4459fe510d7c42c8dade5e8070ca623a9aed9086a7d21a3423b2',
+                                                value: 10000,
+                                            },
+                                        },
+                                    },
+                                    {
+                                        Type: 'OutputAdded',
+                                        output: {
+                                            scriptPubKey:
+                                                '1 a52d19f3baa0000803d228a67307439c66bbaca8929ce889305e0445b5febad7',
+                                            value: 8000,
+                                        },
+                                    },
+                                ],
+                            },
+                        },
+                    ],
+                });
+            }
+            resolve();
+        });
+
+        const spyIsDetained = jest.spyOn(CoinjoinPrison.prototype, 'isDetained');
+        const spyDetain = jest.spyOn(CoinjoinPrison.prototype, 'detain');
+
+        // initialize Client with persistent Prison
+        const cli = new CoinjoinClient({
+            ...server?.requestOptions,
+            prison: [
+                {
+                    accountKey: 'account-A',
+                    type: 'input',
+                    id: 'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa00000000',
+                    sentenceStart: Date.now() - 1000000,
+                    sentenceEnd: Date.now() + 1000000,
+                },
+                {
+                    accountKey: 'account-A',
+                    type: 'output',
+                    id: 'tb1ppll2u0aaprp92gfkntamd476emye7weykcgnctlyj7lduprjx7ys9jn7w3',
+                    sentenceStart: Date.now() - 1000000,
+                    sentenceEnd: Date.now() + 1000000,
+                },
+            ],
+        });
+
+        await cli.enable();
+
+        // set prison event listener
+        const prisonEventPromise = new Promise<void>(resolve => {
+            cli.on('prison', event => {
+                cli.unregisterAccount('account-A');
+                cli.disable();
+
+                expect(event.prison.length).toEqual(4); // 4 elements are detained at the end
+                resolve();
+            });
+        });
+
+        cli.registerAccount({
+            accountKey: 'account-A',
+            scriptType: 'Taproot',
+            targetAnonymity: 10,
+            rawLiquidityClue: 0,
+            maxFeePerKvbyte: 1,
+            maxCoordinatorFeeRate: 1,
+            maxRounds: 10,
+            utxos: [
+                // 1. this utxo is registered in 1st Round and already detained in prison
+                {
+                    path: "m/10025'/1'/0'/1'/0/0",
+                    outpoint:
+                        'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa00000000',
+                    address: 'tb1ppxzlcdeawkpyg5q85lepuhsructwkxpgtxt5pcdq3hnfp0v372qq3tfr6s',
+                    amount: 10000,
+                    anonymityLevel: 0,
+                },
+                // 2. this utxo is registered in 2nd Round and will be detained from the Status
+                {
+                    path: "m/10025'/1'/0'/1'/0/1",
+                    outpoint:
+                        'bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb00000000',
+                    address: 'tb1p3v9uvwnvn3z9nlj3p47y9jx6me0gqux2vgaf4mvss6nayx35yweqq5sjj2',
+                    amount: 10000,
+                    anonymityLevel: 0,
+                },
+                {
+                    path: "m/10025'/1'/0'/1'/0/2",
+                    outpoint:
+                        'cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc00000000',
+                    address: 'tb1phrhxq2tc9uj5eh0n62ag506ax8kgrfvrkdnqj6nlvvsdejkwe2hqgcyw9j',
+                    amount: 6000,
+                    anonymityLevel: 0,
+                },
+            ],
+            changeAddresses: [
+                // 1. this output is registered in 1st Round and already detained in prison
+                {
+                    path: "m/10025'/1'/0'/1'/1/0",
+                    address: 'tb1ppll2u0aaprp92gfkntamd476emye7weykcgnctlyj7lduprjx7ys9jn7w3',
+                },
+                // 2. this output is registered in 2nd Round and will be detained from the Status
+                {
+                    path: "m/10025'/1'/0'/1'/1/1",
+                    address: 'tb1p55k3nua65qqqsq7j9zn8xp6rn3ntht9gj2ww3zfstczytd07htts3txmh9',
+                },
+                {
+                    path: "m/10025'/1'/0'/1'/1/2",
+                    address: 'tb1p4jf9crt5gh57h2spvfht4zwjtnre700uvs4u63l2g2huchrk2dms4lm6kv',
+                },
+            ],
+        });
+
+        // register the same account just for coverage
+        expect(() => cli.registerAccount({ accountKey: 'account-A' } as any)).toThrow();
+
+        expect(spyIsDetained.mock.calls.length).toEqual(4); // isDetained was checked 4 times
+        expect(spyDetain.mock.calls.length).toEqual(2); // but only 2 new inmates were added
+
+        // wait for prison event
+        await prisonEventPromise;
     });
 });

--- a/packages/coinjoin/tests/client/CoinjoinRound.test.ts
+++ b/packages/coinjoin/tests/client/CoinjoinRound.test.ts
@@ -73,7 +73,14 @@ describe(`CoinjoinRound`, () => {
                 logger,
                 round: {
                     phase: 3,
-                    addresses: [{ address: 'doesnt matter', path: '', scriptPubKey: '' }],
+                    addresses: [
+                        {
+                            accountKey: 'account-A',
+                            address: 'doesnt matter',
+                            path: '',
+                            scriptPubKey: '',
+                        },
+                    ],
                 },
             },
         );

--- a/packages/coinjoin/tests/client/endedRound.test.ts
+++ b/packages/coinjoin/tests/client/endedRound.test.ts
@@ -312,10 +312,13 @@ describe('ended', () => {
         );
 
         // NOTE: registered inputs are detained by inputRegistration process
-        round.prison.detain('0'.repeat(72), {
-            roundId: round.id,
-            errorCode: WabiSabiProtocolErrorCode.AliceAlreadyRegistered,
-        });
+        round.prison.detain(
+            { accountKey: 'account-A', outpoint: '0'.repeat(72) },
+            {
+                roundId: round.id,
+                errorCode: WabiSabiProtocolErrorCode.AliceAlreadyRegistered,
+            },
+        );
 
         ended(round, options);
 

--- a/packages/coinjoin/tests/client/selectRound.test.ts
+++ b/packages/coinjoin/tests/client/selectRound.test.ts
@@ -113,7 +113,7 @@ describe('selectRound', () => {
     });
 
     it('utxo in prison', () => {
-        prison.detain('Ba99ed');
+        prison.detain({ accountKey: ACCOUNT.accountKey, outpoint: 'Ba99ed' });
 
         const result = getAccountCandidates({
             accounts: [{ ...ACCOUNT, utxos: [{ outpoint: 'Ba99ed', anonymityLevel: 1 }] }],
@@ -526,7 +526,13 @@ describe('selectRound', () => {
 
         const blameOf = '1'.repeat(64);
 
-        prison.detainForBlameRound(['AA', 'AB'], blameOf);
+        prison.detainForBlameRound(
+            [
+                { accountKey: 'account-A', outpoint: 'AA' },
+                { accountKey: 'account-A', outpoint: 'AB' },
+            ],
+            blameOf,
+        );
 
         const result = await selectRound({
             roundGenerator,
@@ -562,9 +568,18 @@ describe('selectRound', () => {
     });
 
     it('too many blocked utxos', async () => {
-        prison.detain('A0', { errorCode: WabiSabiProtocolErrorCode.InputBanned });
-        prison.detain('A1', { errorCode: WabiSabiProtocolErrorCode.InputBanned });
-        prison.detain('A9', { errorCode: WabiSabiProtocolErrorCode.InputLongBanned });
+        prison.detain(
+            { outpoint: 'A0', accountKey: ACCOUNT.key },
+            { errorCode: WabiSabiProtocolErrorCode.InputBanned },
+        );
+        prison.detain(
+            { outpoint: 'A1', accountKey: ACCOUNT.key },
+            { errorCode: WabiSabiProtocolErrorCode.InputBanned },
+        );
+        prison.detain(
+            { outpoint: 'A9', accountKey: ACCOUNT.key },
+            { errorCode: WabiSabiProtocolErrorCode.InputLongBanned },
+        );
 
         const setSessionPhaseMock = jest.fn();
 

--- a/packages/suite/src/actions/wallet/__fixtures__/mockCoinjoinService.ts
+++ b/packages/suite/src/actions/wallet/__fixtures__/mockCoinjoinService.ts
@@ -51,11 +51,11 @@ export const mockCoinjoinService = () => {
         CoinjoinService: {
             getInstance: jest.fn((symbol: string) => clients[symbol]),
             getInstances: jest.fn(() => Object.values(clients)),
-            createInstance: jest.fn((symbol: string) => {
-                if (!allowed.includes(symbol)) throw new Error('Client not supported');
-                if (clients[symbol]) return clients[symbol];
-                const instance = getMockedInstance(symbol);
-                clients[symbol] = instance;
+            createInstance: jest.fn(({ network }: { network: string }) => {
+                if (!allowed.includes(network)) throw new Error('Client not supported');
+                if (clients[network]) return clients[network];
+                const instance = getMockedInstance(network);
+                clients[network] = instance;
                 return instance;
             }),
             removeInstance: jest.fn((symbol: string) => {

--- a/packages/suite/src/actions/wallet/__tests__/coinjoinAccountActions.test.ts
+++ b/packages/suite/src/actions/wallet/__tests__/coinjoinAccountActions.test.ts
@@ -102,7 +102,7 @@ describe('coinjoinAccountActions', () => {
             const store = initStore(f.state as Wallet);
 
             if (f.client) {
-                await CoinjoinService.createInstance(f.client as any);
+                await CoinjoinService.createInstance({ network: f.client as any });
             }
 
             await store.dispatch(coinjoinAccountActions.stopCoinjoinSession(f.param));
@@ -128,7 +128,7 @@ describe('coinjoinAccountActions', () => {
             const store = initStore(f.state as Wallet);
 
             if (f.client) {
-                await CoinjoinService.createInstance(f.client as any);
+                await CoinjoinService.createInstance({ network: f.client as any });
             }
 
             await store.dispatch(coinjoinAccountActions.restoreCoinjoinSession(f.param));

--- a/packages/suite/src/actions/wallet/constants/coinjoinConstants.ts
+++ b/packages/suite/src/actions/wallet/constants/coinjoinConstants.ts
@@ -20,6 +20,7 @@ export const CLIENT_ENABLE_SUCCESS = '@coinjoin/client-enable-success';
 export const CLIENT_ENABLE_FAILED = '@coinjoin/client-enable-failed';
 export const CLIENT_STATUS = '@coinjoin/client-status';
 export const CLIENT_SESSION_PHASE = '@coinjoin/session-phase';
+export const CLIENT_PRISON_EVENT = '@coinjoin/prison-event';
 
 export const SESSION_STARTING = '@coinjoin/session-starting';
 export const SESSION_PAUSE = '@coinjoin/session-pause';

--- a/packages/suite/src/hooks/wallet/form/useExcludedUtxos.ts
+++ b/packages/suite/src/hooks/wallet/form/useExcludedUtxos.ts
@@ -1,12 +1,10 @@
 import { useMemo } from 'react';
 
 import { Account } from '@suite-common/wallet-types';
-import { getExcludedUtxos } from '@suite-common/wallet-utils';
+import { getExcludedUtxos, GetExcludedUtxosProps } from '@suite-common/wallet-utils';
 
-interface UseExcludedUtxosProps {
+interface UseExcludedUtxosProps extends GetExcludedUtxosProps {
     account: Account;
-    dustLimit?: number;
-    targetAnonymity?: number;
 }
 
 /**
@@ -14,7 +12,12 @@ interface UseExcludedUtxosProps {
  * Returns utxos which should be automatically excluded while composingTransaction.
  * Response format: { utxo_outpoint: exclusion_reason }
  */
-export const useExcludedUtxos = ({ account, dustLimit, targetAnonymity }: UseExcludedUtxosProps) =>
+export const useExcludedUtxos = ({
+    account,
+    dustLimit,
+    targetAnonymity,
+    prison,
+}: UseExcludedUtxosProps) =>
     useMemo(
         () =>
             getExcludedUtxos({
@@ -22,6 +25,7 @@ export const useExcludedUtxos = ({ account, dustLimit, targetAnonymity }: UseExc
                 anonymitySet: account.addresses?.anonymitySet,
                 dustLimit,
                 targetAnonymity,
+                prison,
             }),
-        [account.utxo, account.addresses?.anonymitySet, dustLimit, targetAnonymity],
+        [account.utxo, account.addresses?.anonymitySet, dustLimit, targetAnonymity, prison],
     );

--- a/packages/suite/src/hooks/wallet/useSendForm.ts
+++ b/packages/suite/src/hooks/wallet/useSendForm.ts
@@ -43,6 +43,7 @@ export interface SendFormProps {
     sendRaw?: boolean;
     metadataEnabled: boolean;
     targetAnonymity?: number;
+    prison?: Record<string, unknown>;
 }
 // Props of @wallet-hooks/useSendForm (selectedAccount should be loaded)
 export interface UseSendFormProps extends SendFormProps {
@@ -162,6 +163,7 @@ export const useSendForm = (props: UseSendFormProps): SendContextValues => {
         account: state.account,
         dustLimit: state.coinFees.dustLimit,
         targetAnonymity: props.targetAnonymity,
+        prison: props.prison,
     });
 
     // declare sendFormUtils, sub-hook of useSendForm
@@ -184,6 +186,7 @@ export const useSendForm = (props: UseSendFormProps): SendContextValues => {
         ...useFormMethods,
         state,
         account: props.selectedAccount.account,
+        prison: props.prison,
         excludedUtxos,
         updateContext,
         setAmount: sendFormUtils.setAmount,

--- a/packages/suite/src/hooks/wallet/useSendFormCompose.ts
+++ b/packages/suite/src/hooks/wallet/useSendFormCompose.ts
@@ -23,6 +23,7 @@ type Props = UseFormMethods<FormState> & {
     updateContext: SendContextValues['updateContext'];
     setAmount: (index: number, amount: string) => void;
     targetAnonymity?: number;
+    prison?: Record<string, unknown>;
 };
 
 // This hook should be used only as a sub-hook of `useSendForm`
@@ -37,6 +38,7 @@ export const useSendFormCompose = ({
     excludedUtxos,
     updateContext,
     setAmount,
+    prison,
 }: Props) => {
     const [composedLevels, setComposedLevels] =
         useState<SendContextValues['composedLevels']>(undefined);
@@ -63,12 +65,21 @@ export const useSendFormCompose = ({
                 network: state.network,
                 feeInfo: state.feeInfo,
                 excludedUtxos,
+                prison,
             });
 
             setComposedLevels(result);
             updateContext({ isLoading: false, isDirty: true }); // isDirty needs to be set again, "state" is cached in updateContext callback
         },
-        [account, excludedUtxos, state.network, state.feeInfo, composeTransaction, updateContext],
+        [
+            account,
+            prison,
+            excludedUtxos,
+            state.network,
+            state.feeInfo,
+            composeTransaction,
+            updateContext,
+        ],
     );
 
     // called from composeRequest useEffect

--- a/packages/suite/src/middlewares/wallet/__tests__/coinjoinMiddleware.test.ts
+++ b/packages/suite/src/middlewares/wallet/__tests__/coinjoinMiddleware.test.ts
@@ -93,7 +93,7 @@ describe('coinjoinMiddleware', () => {
             }
 
             if (f.client) {
-                await CoinjoinService.createInstance(f.client);
+                await CoinjoinService.createInstance({ network: f.client });
             }
 
             store.dispatch(f.action);

--- a/packages/suite/src/middlewares/wallet/storageMiddleware.ts
+++ b/packages/suite/src/middlewares/wallet/storageMiddleware.ts
@@ -246,6 +246,18 @@ const storageMiddleware = (api: MiddlewareAPI<Dispatch, AppState>) => {
                     }
                     break;
                 }
+                case COINJOIN.CLIENT_PRISON_EVENT: {
+                    const affectedAccounts = action.payload.map(inmate => inmate.accountKey);
+                    const state = api.getState();
+                    affectedAccounts.forEach(key => {
+                        const account = selectAccountByKey(state, key);
+                        const device = account && findAccountDevice(account, state.devices);
+                        if (device && isDeviceRemembered(device)) {
+                            api.dispatch(storageActions.saveCoinjoinAccount(key));
+                        }
+                    });
+                    break;
+                }
 
                 default:
                     break;

--- a/packages/suite/src/reducers/wallet/coinjoinReducer.ts
+++ b/packages/suite/src/reducers/wallet/coinjoinReducer.ts
@@ -375,6 +375,26 @@ const updateClientStatus = (
     };
 };
 
+const updateAccountPrison = (
+    draft: CoinjoinState,
+    payload: ExtractActionPayload<typeof COINJOIN.CLIENT_PRISON_EVENT>,
+) => {
+    draft.accounts.forEach(account => {
+        const accountPrison = payload.filter(inmate => inmate.accountKey === account.key);
+        account.prison = accountPrison.reduce<NonNullable<CoinjoinAccount['prison']>>(
+            (prison, inmate) => {
+                if (['input', 'output'].includes(inmate.type)) {
+                    // remove duplicated info (id, accountKey)
+                    const { id, accountKey, ...rest } = inmate;
+                    prison[id] = rest;
+                }
+                return prison;
+            },
+            {},
+        );
+    });
+};
+
 const updateSessionPhase = (
     draft: CoinjoinState,
     payload: ExtractActionPayload<typeof COINJOIN.CLIENT_SESSION_PHASE>,
@@ -533,6 +553,9 @@ export const coinjoinReducer = (
                 break;
             case COINJOIN.CLIENT_STATUS:
                 updateClientStatus(draft, action.payload);
+                break;
+            case COINJOIN.CLIENT_PRISON_EVENT:
+                updateAccountPrison(draft, action.payload);
                 break;
             case COINJOIN.CLIENT_SESSION_PHASE:
                 updateSessionPhase(draft, action.payload);

--- a/packages/suite/src/reducers/wallet/coinjoinReducer.ts
+++ b/packages/suite/src/reducers/wallet/coinjoinReducer.ts
@@ -669,6 +669,28 @@ export const selectCurrentCoinjoinBalanceBreakdown = (state: CoinjoinRootState) 
     return balanceBreakdown;
 };
 
+export const selectPrisonByAccountKey = (state: CoinjoinRootState, accountKey: AccountKey) => {
+    const coinjoinAccount = selectCoinjoinAccountByKey(state, accountKey);
+    if (!coinjoinAccount) return;
+    return coinjoinAccount.prison;
+};
+
+export const selectBlockedUtxosByAccountKey = (
+    state: CoinjoinRootState,
+    accountKey: AccountKey,
+) => {
+    const prison = selectPrisonByAccountKey(state, accountKey);
+    if (!prison) return;
+    return Object.keys(prison).reduce<typeof prison>((result, key) => {
+        const inmate = prison[key];
+        // select **only** inmates with assigned roundId (signed in current round or promised to future blaming round)
+        if (inmate.roundId) {
+            result[key] = inmate;
+        }
+        return result;
+    }, {});
+};
+
 export const selectSessionProgressByAccountKey = (
     state: CoinjoinRootState,
     accountKey: AccountKey,

--- a/packages/suite/src/services/coinjoin/coinjoinService.ts
+++ b/packages/suite/src/services/coinjoin/coinjoinService.ts
@@ -1,4 +1,4 @@
-import { CoinjoinBackend, CoinjoinClient } from '@trezor/coinjoin';
+import { CoinjoinBackend, CoinjoinClient, CoinjoinPrisonInmate } from '@trezor/coinjoin';
 import { createIpcProxy } from '@trezor/ipc-proxy';
 import { PartialRecord } from '@trezor/type-utils';
 import { isDesktop } from '@trezor/env-utils';
@@ -6,8 +6,7 @@ import { CoinjoinServerEnvironment } from 'src/types/wallet/coinjoin';
 import { NetworkSymbol } from 'src/types/wallet';
 import { getCoinjoinConfig } from './config';
 
-const loadInstance = (network: NetworkSymbol, environment?: CoinjoinServerEnvironment) => {
-    const settings = getCoinjoinConfig(network, environment);
+const loadInstance = (settings: ReturnType<typeof getCoinjoinConfig>) => {
     if (isDesktop()) {
         return Promise.all([
             createIpcProxy<CoinjoinBackend>('CoinjoinBackend', { target: { settings } }, settings),
@@ -27,9 +26,18 @@ export interface CoinjoinServiceInstance {
 export class CoinjoinService {
     private static instances: PartialRecord<NetworkSymbol, CoinjoinServiceInstance> = {};
 
-    static async createInstance(network: NetworkSymbol, environment?: CoinjoinServerEnvironment) {
+    static async createInstance({
+        network,
+        prison,
+        environment,
+    }: {
+        network: NetworkSymbol;
+        prison?: CoinjoinPrisonInmate[];
+        environment?: CoinjoinServerEnvironment;
+    }) {
         if (this.instances[network]) return this.instances[network] as CoinjoinServiceInstance;
-        const [backend, client] = await loadInstance(network, environment);
+        const settings = getCoinjoinConfig(network, environment);
+        const [backend, client] = await loadInstance({ ...settings, prison });
         const instance = { backend, client };
         if (!isDesktop()) {
             // display client log directly in console

--- a/packages/suite/src/types/wallet/coinjoin.ts
+++ b/packages/suite/src/types/wallet/coinjoin.ts
@@ -3,10 +3,15 @@ import { PartialRecord } from '@trezor/type-utils';
 
 // @trezor/coinjoin package is meant to be imported dynamically
 // importing types is safe, but importing an enum thru index will bundle whole lib
-import { RegisterAccountParams } from '@trezor/coinjoin';
-import { RoundPhase, SessionPhase, EndRoundState } from '@trezor/coinjoin/src/enums';
+import { RegisterAccountParams, CoinjoinPrisonInmate } from '@trezor/coinjoin';
+import {
+    RoundPhase,
+    SessionPhase,
+    EndRoundState,
+    WabiSabiProtocolErrorCode,
+} from '@trezor/coinjoin/src/enums';
 
-export { RoundPhase, SessionPhase, EndRoundState };
+export { RoundPhase, SessionPhase, EndRoundState, WabiSabiProtocolErrorCode };
 
 export interface CoinjoinSetup {
     targetAnonymity: number;
@@ -67,6 +72,7 @@ export interface CoinjoinAccount {
     checkpoints?: CoinjoinDiscoveryCheckpoint[];
     anonymityGains?: AnonymityGains;
     transactionCandidates?: CoinjoinTxCandidate[];
+    prison?: Record<string, Omit<CoinjoinPrisonInmate, 'id' | 'accountKey'>>;
 }
 
 export type CoinjoinServerEnvironment = 'public' | 'staging' | 'localhost';

--- a/suite-common/wallet-types/src/sendForm.ts
+++ b/suite-common/wallet-types/src/sendForm.ts
@@ -46,7 +46,7 @@ export type FormState = {
     selectedUtxos: AccountUtxo[];
 };
 
-export type ExcludedUtxos = Record<string, 'low-anonymity' | 'dust' | undefined>;
+export type ExcludedUtxos = Record<string, 'low-anonymity' | 'dust' | 'prison' | undefined>;
 
 // local state of @wallet-hooks/useSendForm
 export type UseSendFormState = {
@@ -69,6 +69,7 @@ export interface ComposeActionContext {
     network: Network;
     feeInfo: FeeInfo;
     excludedUtxos?: ExcludedUtxos;
+    prison?: Record<string, unknown>;
 }
 
 export interface UtxoSelectionContext {

--- a/suite-common/wallet-utils/src/sendFormUtils.ts
+++ b/suite-common/wallet-utils/src/sendFormUtils.ts
@@ -441,6 +441,7 @@ export interface GetExcludedUtxosProps {
     anonymitySet?: NonNullable<Account['addresses']>['anonymitySet'];
     dustLimit?: number;
     targetAnonymity?: number;
+    prison?: Record<string, unknown>;
 }
 
 export const getExcludedUtxos = ({
@@ -448,6 +449,7 @@ export const getExcludedUtxos = ({
     anonymitySet,
     dustLimit,
     targetAnonymity,
+    prison,
 }: GetExcludedUtxosProps) => {
     // exclude utxos from default composeTransaction process (see sendFormBitcoinActions)
     // utxos are stored as dictionary where:
@@ -458,7 +460,9 @@ export const getExcludedUtxos = ({
     utxos?.forEach(utxo => {
         const outpoint = getUtxoOutpoint(utxo);
         const anonymity = (anonymitySet && anonymitySet[utxo.address]) || 1;
-        if (new BigNumber(utxo.amount).lte(Number(dustLimit))) {
+        if (prison && prison[outpoint]) {
+            excludedUtxos[outpoint] = 'prison';
+        } else if (new BigNumber(utxo.amount).lte(Number(dustLimit))) {
             // is lower than dust limit
             excludedUtxos[outpoint] = 'dust';
         } else if (anonymity < (targetAnonymity || 1)) {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

- emit `prison` events from `CoinjoinClient` to suite
  event is emitted on each `CoinjoinPrison` change (with throttling)
  
- refactoring `CoinjoinPrison`
  `detain` function accepts object with assigned `accountKey` (utxo/output/account)

- fix missing part. detain inputs/outputs that are already registered in some Round.

- handle `prison` event in suite and store data related to `CoinjoinAccount`
  stored data are used not only to decide what is blocked/available but also to initialize `CoinjoinClient` after suite reload

- exclude currently imprisoned utxos/addresses from send form

## Related Issues

https://github.com/trezor/trezor-suite/issues/8372
