### PR TITLE
Fix multiple CJ middlewares starting in parallel

### DIFF
--- a/packages/suite-desktop/src/libs/processes/CoinjoinProcess.ts
+++ b/packages/suite-desktop/src/libs/processes/CoinjoinProcess.ts
@@ -1,24 +1,20 @@
-import { getFreePort } from '@trezor/node-utils';
-
 import { BaseProcess, Status } from './BaseProcess';
 
 export class CoinjoinProcess extends BaseProcess {
-    port = 37128; // Default port, that is going to be updated when starting the process.
+    private readonly port;
 
-    constructor() {
+    constructor(port = 37128) {
         super('coinjoin', 'WalletWasabi.WabiSabiClientLibrary', {
             autoRestart: 0,
         });
+        this.port = port;
     }
 
     getUrl() {
         return `http://localhost:${this.port}/`;
     }
 
-    async getPort() {
-        if (!(await this.status()).process) {
-            this.port = await getFreePort();
-        }
+    getPort() {
         return this.port;
     }
 

--- a/packages/utils/src/getSynchronize.ts
+++ b/packages/utils/src/getSynchronize.ts
@@ -1,0 +1,25 @@
+/**
+ * Ensures that all async actions passed to the returned function are called
+ * immediately one after another, without interfering with each other.
+ *
+ * Example:
+ *
+ * ```
+ * const synchronize = getSynchronize();
+ * synchronize(() => asyncAction1());
+ * synchronize(() => asyncAction2());
+ * ```
+ */
+export const getSynchronize = () => {
+    let lock: Promise<any> | undefined;
+
+    return <T>(action: () => T | Promise<T>): Promise<T> => {
+        lock = (lock ?? Promise.resolve())
+            .catch(() => {})
+            .then(action)
+            .finally(() => {
+                lock = undefined;
+            });
+        return lock;
+    };
+};

--- a/packages/utils/src/index.ts
+++ b/packages/utils/src/index.ts
@@ -12,6 +12,7 @@ export * from './createTimeoutPromise';
 export * as enumUtils from './enumUtils';
 export * from './getNumberFromPixelString';
 export * from './getRandomNumberInRange';
+export * from './getSynchronize';
 export * from './getWeakRandomId';
 export * from './hasUppercaseLetter';
 export * from './isAscii';

--- a/packages/utils/tests/getSynchronize.test.ts
+++ b/packages/utils/tests/getSynchronize.test.ts
@@ -1,0 +1,55 @@
+import { getSynchronize } from '../src/getSynchronize';
+
+const delay = (ms: number) => new Promise(resolve => setTimeout(resolve, ms));
+
+const fail = (reason: string) => {
+    throw new Error(reason);
+};
+
+describe('getSynchronize', () => {
+    let state: any;
+    let synchronize: ReturnType<typeof getSynchronize>;
+
+    const sequence = async (...seq: [any, number][]) => {
+        // eslint-disable-next-line no-restricted-syntax
+        for (const [str, ms] of seq) {
+            state = str;
+            // eslint-disable-next-line no-await-in-loop
+            await delay(ms);
+            expect(state).toBe(str);
+        }
+    };
+
+    const sync = (value: any) => (state = value);
+
+    beforeEach(() => {
+        state = 'init';
+        synchronize = getSynchronize();
+    });
+
+    it('basic', async () => {
+        await Promise.all([
+            synchronize(() => sequence(['init', 3], [42, 9], [null, 3])),
+            synchronize(() => sequence(['init', 5], ['boo', 3], [{ foo: 'bar' }, 6])),
+            synchronize(() => sequence([undefined, 8], [[1, 2, 3], 4], [NaN, 2])),
+        ]);
+    });
+
+    it('sync X async', async () => {
+        await Promise.all([
+            expect(synchronize(() => sync('foo'))).resolves.toBe('foo'),
+            synchronize(() => sequence([0, 3], ['a', 5])),
+            expect(synchronize(() => sync([null, null]))).resolves.toStrictEqual([null, null]),
+        ]);
+    });
+
+    it('with errors', async () => {
+        await Promise.all([
+            synchronize(() => sequence(['a', 9])),
+            expect(synchronize(() => delay(5).then(() => fail('err')))).rejects.toThrow('err'),
+            synchronize(() => sequence(['b', 11])),
+            expect(synchronize(() => fail('err'))).rejects.toThrow('err'),
+            synchronize(() => sequence(['c', 7])),
+        ]);
+    });
+});


### PR DESCRIPTION
## Description

When CJ account was remembered for two different coins (btc + tbtc), middleware process tried to start twice in parallel, which resulted in unexpected behavior. Now middleware process creating/starting/stopping is serialized which should resolve most of the issues.

## Related Issue

Should resolve `Process WalletWasabi.WabiSabiClientLibrary not started` error from #8380