### PR TITLE
fix(suite): avoid mutating children in GuideHint, fix styles

### DIFF
--- a/packages/suite/src/components/guide/GuideHint.tsx
+++ b/packages/suite/src/components/guide/GuideHint.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import styled from 'styled-components';
 
-import { Warning, variables } from '@trezor/components';
+import { Warning } from '@trezor/components';
 
 const StyledWarning = styled(Warning)`
     background: ${({ theme }) => theme.BG_GREY};
@@ -9,14 +9,15 @@ const StyledWarning = styled(Warning)`
     gap: 10px;
     padding: 10px;
 
+    :not(:last-child) {
+        margin-bottom: 16px;
+    }
     a {
         display: inline; /* Allow linebreaks inside links as the space is quite narrow. */
     }
-    p {
+    /* Provide a more specific selector to override paragraph style on parent. */
+    p:last-child {
         margin: 0;
-    }
-    strong {
-        font-weight: ${variables.FONT_WEIGHT.DEMI_BOLD};
     }
 `;
 
@@ -29,25 +30,41 @@ const REGEX = new RegExp(`^(${BULB_EMOJI}|${WARNING_EMOJI})\\s*`);
 // The displayed variant is determined by an emoji at the start of the markdown quote.
 export const GuideHint = ({ children }: React.BlockquoteHTMLAttributes<HTMLQuoteElement>) => {
     // We dig the message from children to check for an emoji indicating the component variant.
-    // There should be three children, with the first and the last being just newline characters.
-    // The middle one is a ReactElement whose children are the content of the message (array of strings and ReactElements in case of links).
+    // There should be three children, with the first and the last being just newline characters - we filter them out as invalid elements.
+    // The middle one is a ReactElement whose children are the content of the message (array of strings and ReactElements - a, strong etc.).
     // The first element is the start of the message which should hold the emoji.
-    const message: string[] | undefined = (children as React.ReactElement[])?.[1]?.props?.children;
-
-    // This must be checked before the message is transformed.
+    const message: string[] | undefined = React.Children.map(children, child => {
+        if (React.isValidElement(child)) {
+            return child.props.children;
+        }
+        return false;
+    })?.filter(child => !!child);
     const variant = message?.[0]?.startsWith(WARNING_EMOJI) ? 'warning' : 'learn';
 
+    let updatedMessage: string[] | undefined;
     if (message?.[0]) {
-        // Assigning to message does mutate the children object as it is a reference to an array within the object.
-        message[0] = message[0].replace(REGEX, '');
+        // Copy the array and mutate the first element so that it does not affect the original array nested in the children prop
+        updatedMessage = [...message];
+        updatedMessage[0] = updatedMessage[0].replace(REGEX, '');
     } else {
         // If the object does not have the expected format, log an error but display the component anyway.
         console.error('Unexpected variant of Guide hint.');
     }
 
+    // Clone the children to avoid mutating them and prevent weird bugs.
+    const clonedChildren = React.Children.map(children, child => {
+        if (React.isValidElement(child)) {
+            return React.cloneElement(child, {
+                ...child.props,
+                children: updatedMessage || child.props.children,
+            });
+        }
+        return child;
+    });
+
     return (
         <StyledWarning withIcon variant={variant}>
-            {children}
+            {clonedChildren}
         </StyledWarning>
     );
 };

--- a/packages/suite/src/components/guide/GuideMarkdown.tsx
+++ b/packages/suite/src/components/guide/GuideMarkdown.tsx
@@ -58,6 +58,9 @@ const StyledMarkdown = styled.div`
     img {
         max-width: 100%;
     }
+    strong {
+        font-weight: ${variables.FONT_WEIGHT.DEMI_BOLD};
+    }
 `;
 
 interface GuideMarkdownProps {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->
I am sorry @tomasklim, had to add some fixes to the Guide hints.

Styles:
- added `margin-bottom` to the container
- fixed selector for `p`
- returned the `font-weight` reduction to default to be consistent with the rest of the guide and keep the emphasis

Component:
I noticed some weird behaviour with hot reloading (Warning changing to Hint), so I removed the children mutation to be safe.

Related to https://github.com/trezor/trezor-suite/pull/8538

## Screenshots:
#### before:
![Screenshot 2023-05-23 at 15 52 15](https://github.com/trezor/trezor-suite/assets/42465546/f489d173-b0ba-46e7-8bcf-9423dea10185)
### after:
![Screenshot 2023-05-23 at 15 50 21](https://github.com/trezor/trezor-suite/assets/42465546/40f00a3b-23c2-4116-8a18-f153da4f033e)

