### PR TITLE
Fix/connect web test

### DIFF
--- a/packages/connect-web/package.json
+++ b/packages/connect-web/package.json
@@ -34,7 +34,7 @@
         "build:inline": "TS_NODE_PROJECT=\"tsconfig.lib.json\" webpack --config ./webpack/inline.webpack.config.ts",
         "build:webextension": "TS_NODE_PROJECT=\"tsconfig.lib.json\" yarn webpack --config ./webpack/prod.webpack.config.ts",
         "build": "rimraf build && yarn build:inline && yarn build:webextension",
-        "test:e2e": "yarn xvfb-maybe -- playwright test --config=./e2e/playwright.config.ts",
+        "test:e2e": "yarn playwright install && yarn xvfb-maybe -- playwright test --config=./e2e/playwright.config.ts",
         "prepublishOnly": "yarn tsx ../../scripts/prepublishNPM.js",
         "prepublish": "yarn tsx ../../scripts/prepublish.js"
     },


### PR DESCRIPTION
## Description

Before:
https://gitlab.com/satoshilabs/trezor/trezor-suite/-/jobs/4332944935

After:
https://gitlab.com/satoshilabs/trezor/trezor-suite/-/jobs/4340314908

In the other playwright tests, there is 
`command: bash -c "npx playwright install && yarn workspace @trezor/connect-popup test:e2e $TEST_FILE"`
However, in connect-web, we do not have `.yml` for `playwright`

## Related Issue

@mroz22's annoyance
