### PR TITLE
nitpics, docs..

### DIFF
--- a/ci/utils.yml
+++ b/ci/utils.yml
@@ -66,7 +66,7 @@ media duplicates:
   needs: []
   script:
     - ./packages/connect/e2e/test-npm-install.sh
-    - ./packages/connect/e2e/test-yarn.install.sh
+    - ./packages/connect/e2e/test-yarn-install.sh
 
 install connect nightly:
   extends: .install connect

--- a/packages/connect/e2e/README.md
+++ b/packages/connect/e2e/README.md
@@ -17,26 +17,6 @@ you may use the following params:
 -i <in case -p methods, use -i to filter one connect method, such as -i binanceGetAddress>
 ```
 
-or
-
-```
-yarn workspace @trezor/integration-tests test:connect
-```
-
-## karma tests
-
-Testing `./packages/connect-iframe/build` directory in browser environment.
-
-```
-./docker/docker-connect-test-karma.sh
-```
-
-or
-
-```
-yarn workspace @trezor/integration-tests test:connect:karma
-```
-
 ## Transactions cache
 
 Bitcoin-like coins `signTransaction` method require additional data about transactions referenced from used inputs.

--- a/packages/connect/e2e/__fixtures__/cardanoSignTransaction.ts
+++ b/packages/connect/e2e/__fixtures__/cardanoSignTransaction.ts
@@ -1655,6 +1655,7 @@ export default {
 
         {
             description: 'signWithEverythingSetExceptPoolRegistrationCertificate',
+            customTimeout: 40000,
             params: {
                 inputs: [
                     {

--- a/packages/connect/e2e/karma.config.js
+++ b/packages/connect/e2e/karma.config.js
@@ -22,6 +22,8 @@ module.exports = config => {
         hostname: 'localhost',
         port: 8099,
         autoWatch: false,
+        // to debug locally set single run to false and go to http://localhost:8099/debug.html
+        // for local changes to take effect build connect-iframe and connect-web
         singleRun: true,
 
         client: {


### PR DESCRIPTION
[ci: fix typo in test-yarn-install.sh script](https://github.com/trezor/trezor-suite/commit/efe100637fbfa289c12ad4e7523ce380842d04db) just a typo fix
[chore(connect): update docs](https://github.com/trezor/trezor-suite/commit/d648c30c1c3ece6d81d661ffa8ec422cd4bcc540) - removing docs that is no longer relevant
4cd23bb7d58885d07372e8bce0760735b63ca913 - this test takes commonly 19 seconds to finish which is an observation affected by survivor bias of course. those tests that failed becuase they reach  20 seconds were not taken into account. 
d841e6961e49419942abbaf7e9a1ea6b1b3d213a - just adding notes for my future self how to debug local karma tests