### PR TITLE
Connect release init script improvements

### DIFF
--- a/ci/scripts/connect-release-init.js
+++ b/ci/scripts/connect-release-init.js
@@ -62,7 +62,7 @@ const initConnectRelease = () => {
                 'log',
                 '--oneline',
                 '--max-count',
-                '10',
+                '1000',
                 '--pretty=tformat:"-   %s (%h)"',
                 '--',
                 `./packages/${packageName}`,

--- a/ci/scripts/connect-release-init.js
+++ b/ci/scripts/connect-release-init.js
@@ -1,3 +1,5 @@
+/* eslint-disable camelcase */
+
 const child_process = require('child_process');
 const path = require('path');
 const fs = require('fs');
@@ -46,7 +48,7 @@ const initConnectRelease = () => {
     const errors = checkResult.errors.map(package => package.replace('@trezor/', ''));
 
     if (update) {
-        for (let packageName of update) {
+        update.forEach(packageName => {
             const PACKAGE_PATH = path.join(ROOT, 'packages', packageName);
             const PACKAGE_JSON_PATH = path.join(PACKAGE_PATH, 'package.json');
 
@@ -71,12 +73,12 @@ const initConnectRelease = () => {
             const CHANGELOG_PATH = path.join(PACKAGE_PATH, 'CHANGELOG.md');
 
             const newCommits = [];
-            for (let commit of commitsArr) {
+            commitsArr.forEach(commit => {
                 if (commit.includes(`npm-release: @trezor/${packageName}`)) {
-                    break;
+                    return;
                 }
                 newCommits.push(commit.replaceAll('"', ''));
-            }
+            });
 
             if (newCommits.length) {
                 if (!fs.existsSync(CHANGELOG_PATH)) {
@@ -95,7 +97,7 @@ const initConnectRelease = () => {
                 path: PACKAGE_PATH,
                 message: `npm-release: @trezor/${packageName} ${version}`,
             });
-        }
+        });
     }
 
     exec('yarn', ['workspace', '@trezor/connect', 'version:patch']);


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

* e9b29871ec39be4d456d11d5752825a3a56f5d86 -  Little syntax changes in `ci/scripts/connect-release-init.js` so eslint does not complain.
* 61ee68e54dfa422e2b6018201eb5996689d56cc3 - Check 1000 last commit instead of 10
* 9282e1cc15fd6d206e997b531e2303c9602e2a8c - add comment to help connect changelog creation 

## Related Issue

Related https://github.com/trezor/trezor-suite/issues/8537