### PR TITLE
chore(connect): move trusted messages validation from core to iframe

### DIFF
--- a/packages/connect-iframe/src/index.ts
+++ b/packages/connect-iframe/src/index.ts
@@ -7,6 +7,7 @@ import {
     UI_EVENT,
     DEVICE_EVENT,
     TRANSPORT_EVENT,
+    TRANSPORT,
     POPUP,
     IFRAME,
     UI,
@@ -119,9 +120,21 @@ const handleMessage = (event: PostMessageEvent) => {
     event.preventDefault();
     event.stopImmediatePropagation();
 
+    const safeMessages: CoreMessage['type'][] = [
+        IFRAME.CALL,
+        POPUP.CLOSED,
+        // UI.CHANGE_SETTINGS,
+        UI.LOGIN_CHALLENGE_RESPONSE,
+        TRANSPORT.DISABLE_WEBUSB,
+    ];
+
+    if (!isTrustedDomain && safeMessages.indexOf(message.type) === -1) {
+        return;
+    }
+
     // pass data to Core
     if (_core) {
-        _core.handleMessage(message, isTrustedDomain);
+        _core.handleMessage(message);
     }
 };
 
@@ -136,7 +149,7 @@ const postMessage = (message: CoreMessage) => {
     // popup handshake is resolved automatically
     if (!usingPopup) {
         if (_core && message.type === UI.REQUEST_UI_WINDOW) {
-            _core.handleMessage({ event: UI_EVENT, type: POPUP.HANDSHAKE }, true);
+            _core.handleMessage({ event: UI_EVENT, type: POPUP.HANDSHAKE });
             return;
         }
         if (message.type === POPUP.CANCEL_POPUP_REQUEST) {

--- a/packages/connect/src/core/index.ts
+++ b/packages/connect/src/core/index.ts
@@ -126,24 +126,11 @@ const removeUiPromise = (promise: Deferred<any>) => {
 /**
  * Handle incoming message.
  * @param {CoreMessage} message
- * @param {boolean} isTrustedOrigin
  * @returns {void}
  * @memberof Core
  */
-export const handleMessage = (message: CoreMessage, isTrustedOrigin = false) => {
-    _log.debug('handleMessage', isTrustedOrigin, message);
-
-    const safeMessages: CoreMessage['type'][] = [
-        IFRAME.CALL,
-        POPUP.CLOSED,
-        // UI.CHANGE_SETTINGS,
-        UI.LOGIN_CHALLENGE_RESPONSE,
-        TRANSPORT.DISABLE_WEBUSB,
-    ];
-
-    if (!isTrustedOrigin && safeMessages.indexOf(message.type) === -1) {
-        return;
-    }
+export const handleMessage = (message: CoreMessage) => {
+    _log.debug('handleMessage', message);
 
     switch (message.type) {
         case POPUP.HANDSHAKE:
@@ -970,8 +957,8 @@ const initDeviceList = async (settings: ConnectSettings) => {
  * @memberof Core
  */
 export class Core extends EventEmitter {
-    handleMessage(message: any, isTrustedOrigin: boolean) {
-        handleMessage(message, isTrustedOrigin);
+    handleMessage(message: any) {
+        handleMessage(message);
     }
 
     async dispose() {

--- a/packages/connect/src/index.ts
+++ b/packages/connect/src/index.ts
@@ -58,7 +58,7 @@ const handleMessage = (message: CoreMessage) => {
     if (!_core) return;
 
     if (type === UI.REQUEST_UI_WINDOW) {
-        _core.handleMessage({ event: UI_EVENT, type: POPUP.HANDSHAKE }, true);
+        _core.handleMessage({ event: UI_EVENT, type: POPUP.HANDSHAKE });
         return;
     }
 
@@ -119,11 +119,11 @@ function postMessage(message: PostMessage, usePromise = true) {
         _messageID++;
         messagePromises[_messageID] = createDeferred();
         const { promise } = messagePromises[_messageID];
-        _core.handleMessage({ ...message, id: _messageID }, true);
+        _core.handleMessage({ ...message, id: _messageID });
         return promise;
     }
 
-    _core.handleMessage(message, true);
+    _core.handleMessage(message);
 }
 
 const init = async (settings: Partial<ConnectSettings> = {}) => {
@@ -181,7 +181,7 @@ const uiResponse = (response: UiResponseEvent) => {
         throw ERRORS.TypedError('Init_NotInitialized');
     }
     const { type, payload } = response;
-    _core.handleMessage({ event: UI_EVENT, type, payload }, true);
+    _core.handleMessage({ event: UI_EVENT, type, payload });
 };
 
 const requestLogin = async (params: any) => {
@@ -194,23 +194,17 @@ const requestLogin = async (params: any) => {
             if (data && data.type === UI.LOGIN_CHALLENGE_REQUEST) {
                 try {
                     const payload = await callback();
-                    _core?.handleMessage(
-                        {
-                            event: UI_EVENT,
-                            type: UI.LOGIN_CHALLENGE_RESPONSE,
-                            payload,
-                        },
-                        true,
-                    );
+                    _core?.handleMessage({
+                        event: UI_EVENT,
+                        type: UI.LOGIN_CHALLENGE_RESPONSE,
+                        payload,
+                    });
                 } catch (error) {
-                    _core?.handleMessage(
-                        {
-                            event: UI_EVENT,
-                            type: UI.LOGIN_CHALLENGE_RESPONSE,
-                            payload: error.message,
-                        },
-                        true,
-                    );
+                    _core?.handleMessage({
+                        event: UI_EVENT,
+                        type: UI.LOGIN_CHALLENGE_RESPONSE,
+                        payload: error.message,
+                    });
                 }
             }
         };


### PR DESCRIPTION
while reviewing #8447 I noted something completely unrelated 💡 

imho messages validation based on trusted domain should not be concern of connect-core so I moved this code to connect-iframe. this PR should be pure refactoring, just moving stuff from one place to another.