### PR TITLE
fix(suite-native): zlib mocked up from node.js implementation

### DIFF
--- a/suite-common/wallet-utils/src/sendFormUtils.native.ts
+++ b/suite-common/wallet-utils/src/sendFormUtils.native.ts
@@ -1,4 +1,0 @@
-// Note: This is hotfix for sendFormUtils as there are things that make mobile app crash on local development
-// zlib is required in @ethereumjs and is not supported in mobile app. This file will prevent that package from being included in the bundle.
-
-export {};

--- a/suite-native/app/ios/Podfile.lock
+++ b/suite-native/app/ios/Podfile.lock
@@ -111,9 +111,9 @@ PODS:
     - FlipperKit/FlipperKitNetworkPlugin
   - fmt (6.2.1)
   - glog (0.3.5)
-  - hermes-engine (0.71.7):
-    - hermes-engine/Pre-built (= 0.71.7)
-  - hermes-engine/Pre-built (0.71.7)
+  - hermes-engine (0.71.8):
+    - hermes-engine/Pre-built (= 0.71.8)
+  - hermes-engine/Pre-built (0.71.8)
   - libevent (2.1.12)
   - lottie-ios (3.4.4)
   - lottie-react-native (5.1.5):
@@ -797,7 +797,7 @@ SPEC CHECKSUMS:
   FlipperKit: cbdee19bdd4e7f05472a66ce290f1b729ba3cb86
   fmt: ff9d55029c625d3757ed641535fd4a75fedc7ce9
   glog: 04b94705f318337d7ead9e6d17c019bd9b1f6b1b
-  hermes-engine: 4438d2b8bf8bebaba1b1ac0451160bab59e491f8
+  hermes-engine: 47986d26692ae75ee7a17ab049caee8864f855de
   libevent: 4049cae6c81cdb3654a443be001fb9bdceff7913
   lottie-ios: 8f97d3271e155c2d688875c29cd3c74908aef5f8
   lottie-react-native: 3e722c63015fdb9c27638b0a77969fc412067c18

--- a/suite-native/app/metro.config.js
+++ b/suite-native/app/metro.config.js
@@ -19,6 +19,7 @@ module.exports = makeMetroConfig({
             stream: nodejs.stream,
             https: nodejs.https,
             http: nodejs.http,
+            zlib: nodejs.zlib,
         },
     },
 });


### PR DESCRIPTION
- Zlib imported to Metro from Node.js implementation. 
- As a coproduct fixes the problem with the FeeFormatter function === `undefined` reported by Sentry.

## Related Issue

Resolve #8560 
Resolve #8578 

