### PR TITLE
coinjoin minor fixes

### DIFF
--- a/packages/coinjoin/src/client/CoinjoinRound.ts
+++ b/packages/coinjoin/src/client/CoinjoinRound.ts
@@ -110,6 +110,7 @@ export class CoinjoinRound extends TypedEmitter<Events> {
     roundDeadline: number; // deadline is inaccurate,round may end earlier
     commitmentData: string; // commitment data used for ownership proof and witness requests
     addresses: AccountAddress[] = []; // list of addresses (outputs) used in this round in outputRegistration phase
+    transactionSignTries: number[] = []; // timestamps for processing transactionSigning phase
     transactionData?: CoinjoinTransactionData; // transaction to sign
     broadcastedTxDetails?: BroadcastedTransactionDetails; // transaction broadcasted
     liquidityClues?: CoinjoinTransactionLiquidityClue[]; // updated liquidity clues
@@ -200,12 +201,15 @@ export class CoinjoinRound extends TypedEmitter<Events> {
         if (this.phase === RoundPhase.Ended) return this;
 
         // update data from status
-        this.phase = changed.phase;
-        this.endRoundState = changed.endRoundState;
-        this.coinjoinState = changed.coinjoinState;
-        const { phaseDeadline, roundDeadline } = getCoinjoinRoundDeadlines(this);
-        this.phaseDeadline = phaseDeadline;
-        this.roundDeadline = roundDeadline;
+        if (this.phase !== changed.phase) {
+            this.phase = changed.phase;
+            this.endRoundState = changed.endRoundState;
+            this.coinjoinState = changed.coinjoinState;
+            const { phaseDeadline, roundDeadline } = getCoinjoinRoundDeadlines(this);
+            this.phaseDeadline = phaseDeadline;
+            this.roundDeadline = roundDeadline;
+        }
+
         // update affiliateRequest once and keep the value
         // affiliateData are removed from the status once phase is changed to Ended
         if (!this.affiliateRequest && changed.affiliateRequest) {

--- a/packages/coinjoin/src/client/Status.ts
+++ b/packages/coinjoin/src/client/Status.ts
@@ -52,11 +52,7 @@ export class Status extends TypedEmitter<StatusEvents> {
                 const known = this.rounds.find(prevRound => prevRound.id === nextRound.id);
                 if (!known) return true; // new phase
                 if (nextRound.phase === known.phase + 1) return true; // expected update
-                if (
-                    nextRound.phase === RoundPhase.TransactionSigning &&
-                    !known.affiliateRequest &&
-                    nextRound.affiliateRequest
-                ) {
+                if (nextRound.phase === RoundPhase.TransactionSigning && !known.affiliateRequest) {
                     return true; // affiliateRequest is propagated asynchronously, might be added after phase change
                 }
 

--- a/packages/coinjoin/src/client/round/endedRound.ts
+++ b/packages/coinjoin/src/client/round/endedRound.ts
@@ -39,7 +39,8 @@ export const ended = (round: CoinjoinRound, { logger, network }: CoinjoinRoundOp
             logger.error('Round not signed. Missing outputs.');
         } else if (!round.affiliateRequest) {
             // missing affiliateRequest
-            logger.error('Round not signed. Missing affiliate request.');
+            const times = round.transactionSignTries.join(',');
+            logger.error(`Round not signed. Missing affiliate request. Status fetched at ${times}`);
         } else if (inputs.some(i => !i.witness)) {
             // no signed inputs
             logger.error('Round not signed. Missing signed inputs.');

--- a/packages/coinjoin/src/client/round/transactionSigning.ts
+++ b/packages/coinjoin/src/client/round/transactionSigning.ts
@@ -155,6 +155,7 @@ export const transactionSigning = async (
     if (!round.affiliateRequest) {
         logger.warn(`Missing affiliate request. Waiting for status`);
         round.setSessionPhase(SessionPhase.AwaitingCoinjoinTransaction);
+        round.transactionSignTries.push(Date.now());
         return round;
     }
 

--- a/packages/coinjoin/tests/client/Status.test.ts
+++ b/packages/coinjoin/tests/client/Status.test.ts
@@ -300,9 +300,9 @@ describe('Status', () => {
         await fastForward(STATUS_TIMEOUT.enabled);
 
         expect(coordinatorRequestSpy).toHaveBeenCalledTimes(4); // status fetched 4 times
-        expect(onUpdateListener).toHaveBeenCalledTimes(2); // status changed twice, affiliateData added at 3rd iteration
+        expect(onUpdateListener).toHaveBeenCalledTimes(4); // affiliateData added at 3rd iteration
 
-        expect(onUpdateListener.mock.calls[1][0]).toMatchObject({
+        expect(onUpdateListener.mock.calls[3][0]).toMatchObject({
             changed: [{ affiliateRequest: affiliateDataBase64 }],
         });
     });


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

- skip round if amount of any utxo selected by middleware is greater than maxSuggestedAmount
  following WalletWasabi code
  
- log timestamps when round is in TransactionSigning phase but affiliateRequest is missing
  debugging error logged by sentry