### PR TITLE
Fix account syncing pre-check

### DIFF
--- a/packages/blockchain-link-types/src/blockbook-api.ts
+++ b/packages/blockchain-link-types/src/blockbook-api.ts
@@ -145,6 +145,7 @@ export interface Address {
     unconfirmedBalance: string;
     unconfirmedTxs: number;
     txs: number;
+    addrTxCount?: number;
     nonTokenTxs?: number;
     internalTxs?: number;
     transactions?: Tx[];

--- a/packages/blockchain-link-types/src/blockbook.ts
+++ b/packages/blockchain-link-types/src/blockbook.ts
@@ -82,6 +82,7 @@ export interface AccountInfo {
     totalReceived: string;
     totalSent: string;
     txs: number;
+    addrTxCount?: number;
     unconfirmedBalance: string;
     unconfirmedTxs: number;
     page?: number;

--- a/packages/blockchain-link-types/src/common.ts
+++ b/packages/blockchain-link-types/src/common.ts
@@ -188,6 +188,7 @@ export interface AccountInfo {
         unconfirmed: number; // unconfirmed transactions
         transactions?: Transaction[]; // list of transactions
         txids?: string[]; // not implemented
+        addrTxCount?: number; // number of confirmed address/transaction pairs, only for bitcoin-like
     };
     misc?: {
         // ETH

--- a/packages/blockchain-link-utils/src/blockbook.ts
+++ b/packages/blockchain-link-utils/src/blockbook.ts
@@ -365,6 +365,7 @@ export const transformAccountInfo = (payload: BlockbookAccountInfo): AccountInfo
         tokens,
         addresses,
         history: {
+            addrTxCount: payload.addrTxCount,
             total: payload.txs,
             tokens:
                 typeof payload.nonTokenTxs === 'number'

--- a/packages/suite/src/actions/wallet/__fixtures__/blockchainActions.ts
+++ b/packages/suite/src/actions/wallet/__fixtures__/blockchainActions.ts
@@ -34,7 +34,7 @@ const parseTx = (data: any) => ({
 
 const analyzeTransactionsExtended = [
     {
-        result: [blockchainActions.synced.type],
+        result: [accountsActions.updateAccount.type, blockchainActions.synced.type],
     },
     {
         result: [
@@ -63,7 +63,7 @@ const analyzeTransactionsExtended = [
         },
     },
     {
-        result: [blockchainActions.synced.type],
+        result: [accountsActions.updateAccount.type, blockchainActions.synced.type],
         resultTxs: {
             'xpub-btc-deviceState': [{ blockHeight: undefined, blockHash: '1', txid: '1' }],
         },
@@ -230,6 +230,7 @@ export const onBlock = analyzeTransactions
             },
             {
                 history: {
+                    total: 1,
                     transactions: f.fresh.slice().map((t: any) => parseTx(t)),
                 },
             },

--- a/suite-common/wallet-utils/src/accountUtils.ts
+++ b/suite-common/wallet-utils/src/accountUtils.ts
@@ -486,10 +486,12 @@ export const enhanceHistory = ({
     total,
     unconfirmed,
     tokens,
+    addrTxCount,
 }: AccountInfo['history']): Account['history'] => ({
     total,
     unconfirmed,
     tokens,
+    addrTxCount,
 });
 
 export const getAccountFiatBalance = (
@@ -549,8 +551,16 @@ export const isTestnet = (symbol: NetworkSymbol) => {
 };
 
 export const isAccountOutdated = (account: Account, freshInfo: AccountInfo) => {
-    // confirmed tx count is different than before
-    if (account.history.total !== freshInfo.history.total) return true;
+    if (
+        // if backend/coin supports addrTxCount, compare it instead of total
+        typeof freshInfo.history.addrTxCount === 'number'
+            ? // addrTxCount (address/tx pairs) is different than before
+              account.history.addrTxCount !== freshInfo.history.addrTxCount
+            : // confirmed tx count is different than before
+              // (unreliable for different getAccountInfo levels, that's why addrTxCount was added)
+              account.history.total !== freshInfo.history.total
+    )
+        return true;
 
     // unconfirmed tx count is different than before
     if (account.history.unconfirmed !== freshInfo.history.unconfirmed) return true;

--- a/suite-common/wallet-utils/src/accountUtils.ts
+++ b/suite-common/wallet-utils/src/accountUtils.ts
@@ -549,47 +549,34 @@ export const isTestnet = (symbol: NetworkSymbol) => {
 };
 
 export const isAccountOutdated = (account: Account, freshInfo: AccountInfo) => {
-    // changed transaction count when app is running during tx confirmation
-    const changedTxCountOnline =
-        freshInfo.history.total + (freshInfo.history.unconfirmed || 0) >
-        account.history.total + (account.history.unconfirmed || 0);
+    // confirmed tx count is different than before
+    if (account.history.total !== freshInfo.history.total) return true;
 
-    // changed transaction count when app was closed before tx confirmation
-    const changedTxCountOffline =
-        freshInfo.history.total > account.history.total &&
-        (freshInfo.history.unconfirmed || 0) < (account.history.unconfirmed || 0);
+    // unconfirmed tx count is different than before
+    if (account.history.unconfirmed !== freshInfo.history.unconfirmed) return true;
 
-    // changed transaction count when app was closed during tx confirmation and account was empty
-    const changedTxCountOfflineFresh =
-        freshInfo.history.total === 0 && freshInfo.history.unconfirmed;
-
-    // different sequence or balance
-    const changedRipple =
-        account.networkType === 'ripple' &&
-        (freshInfo.misc!.sequence !== account.misc.sequence ||
-            freshInfo.balance !== account.balance ||
-            freshInfo.misc!.reserve !== account.misc.reserve);
-
-    const changedEthereum =
-        account.networkType === 'ethereum' && freshInfo.misc!.nonce !== account.misc.nonce;
-
-    const changedCardano =
-        account.networkType === 'cardano' &&
-        // stake address (de)registration
-        (freshInfo.misc!.staking?.isActive !== account.misc.staking.isActive ||
-            // changed rewards amount (rewards are distributed every epoch (5 days))
-            freshInfo.misc!.staking?.rewards !== account.misc.staking.rewards ||
-            // changed stake pool
-            freshInfo.misc!.staking?.poolId !== account.misc.staking.poolId);
-
-    return (
-        changedTxCountOfflineFresh ||
-        changedTxCountOffline ||
-        changedTxCountOnline ||
-        changedCardano ||
-        changedRipple ||
-        changedEthereum
-    );
+    switch (account.networkType) {
+        case 'ripple':
+            // different sequence or balance
+            return (
+                freshInfo.misc!.sequence !== account.misc.sequence ||
+                freshInfo.balance !== account.balance ||
+                freshInfo.misc!.reserve !== account.misc.reserve
+            );
+        case 'ethereum':
+            return freshInfo.misc!.nonce !== account.misc.nonce;
+        case 'cardano':
+            return (
+                // stake address (de)registration
+                freshInfo.misc!.staking?.isActive !== account.misc.staking.isActive ||
+                // changed rewards amount (rewards are distributed every epoch (5 days))
+                freshInfo.misc!.staking?.rewards !== account.misc.staking.rewards ||
+                // changed stake pool
+                freshInfo.misc!.staking?.poolId !== account.misc.staking.poolId
+            );
+        default:
+            return false;
+    }
 };
 
 // Used in accountActions and failed accounts


### PR DESCRIPTION
## Description

During account sync, `basic` info level is requested first, and only when anything changed, full `txs` info level is requested. Unfortunately, [tx count in basic has different meaning than in txs](https://github.com/trezor/trezor-suite/issues/8137#issuecomment-1516538041), therefore full sync had been always performed for almost every non-empty bitcoin-like account. Lately, `addrTxCount` has been added into Blockbook's response, which should be the same across all the levels.

- https://github.com/trezor/trezor-suite/pull/8590/commits/f56c206ee029406cc2f6eba83c87b38148607a42 - optional `addrTxCount` added to blockchain-link types and propagated where needed
- https://github.com/trezor/trezor-suite/pull/8590/commits/ec2354210ce08c120a0bec8edccec574c9aacf31 - refactoring of `isAccountOutdated` util, without `addrTxCount` yet
  - network-specific conditions switch-ified, without any change in logic
  - kinda obscure tx count conditions reduced to comparing confirmed/unconfirmed tx count separately (which, if anything, could increase the full syncs count, but definitely not decrease it, and it couldn't be worse than the current state)
- https://github.com/trezor/trezor-suite/pull/8590/commits/c04b3a783ad574bdc742a3f35d3ae906fc58b2f9 - `addrTxCount` compared instead of `total` in `isAccountOutdated` whenever received from backend (so not for shitcoins or outdated blockbooks)

## Related Issue

Resolves #8137
Resolves #8338 

## QA

Please test
- that accounts don't perform full sync every minute (too unpleasant to test, so let's just say they don't and move on)
- that accounts do perform full sync when needed (basically that both pending and confirmed transactions appear in UI when they should, exactly as we're used to)