### PR TITLE
fix(suite-native): receive address shows tail

### DIFF
--- a/suite-native/qr-code/package.json
+++ b/suite-native/qr-code/package.json
@@ -10,6 +10,7 @@
         "type-check": "tsc --build"
     },
     "dependencies": {
+        "@mobily/ts-belt": "^3.13.1",
         "@react-navigation/core": "^6.4.6",
         "@suite-common/icons": "workspace:*",
         "@suite-common/wallet-config": "workspace:*",

--- a/suite-native/qr-code/src/components/AddressQRCode.tsx
+++ b/suite-native/qr-code/src/components/AddressQRCode.tsx
@@ -1,6 +1,8 @@
 import React from 'react';
 import { Alert, Share } from 'react-native';
 
+import { pipe, S, A } from '@mobily/ts-belt';
+
 import { Box, Text, Button, ButtonBackgroundElevation, VStack } from '@suite-native/atoms';
 import { prepareNativeStyle, useNativeStyles } from '@trezor/styles';
 
@@ -20,7 +22,8 @@ const actionButtonsStyle = prepareNativeStyle(_ => ({
     flexDirection: 'row',
 }));
 
-const splitStringByFourCharacters = (input: string) => input.match(/(.{4})/g)?.join(' ');
+const splitStringByFourCharacters = (address: string) =>
+    pipe(address, S.splitByRe(/(.{4})/g), A.join(' '));
 
 export const AddressQRCode = ({ address, backgroundElevation = '0' }: AddressQRCodeProps) => {
     const { applyStyle } = useNativeStyles();

--- a/yarn.lock
+++ b/yarn.lock
@@ -7056,6 +7056,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@suite-native/qr-code@workspace:suite-native/qr-code"
   dependencies:
+    "@mobily/ts-belt": ^3.13.1
     "@react-navigation/core": ^6.4.6
     "@suite-common/icons": "workspace:*"
     "@suite-common/wallet-config": "workspace:*"


### PR DESCRIPTION
The last characters of receive address are not hidden anymore. Resolves problem found by QA team: https://github.com/trezor/trezor-suite/issues/8040#issuecomment-1564003687



## Related Issue

Resolve #8040 

## Screenshots:
![Screenshot 2023-05-29 at 11 23 32](https://github.com/trezor/trezor-suite/assets/26143964/285f3e22-bc22-442f-ad13-b0c3fd1416de)
