### PR TITLE
feat(message-system, coinjoin): keep coinjoin hidden for T1

### DIFF
--- a/packages/message-system/src/config/config.v1.json
+++ b/packages/message-system/src/config/config.v1.json
@@ -1,8 +1,54 @@
 {
     "version": 1,
     "timestamp": "2023-05-24T00:00:00+00:00",
-    "sequence": 35,
+    "sequence": 36,
     "actions": [
+        {
+            "conditions": [
+                {
+                    "devices": [
+                        {
+                            "model": "1",
+                            "firmware": "*",
+                            "bootloader": "*",
+                            "variant": "*",
+                            "firmwareRevision": "*",
+                            "vendor": "*"
+                        }
+                    ],
+                    "environment": {
+                        "desktop": ">=23.1.0",
+                        "mobile": "!",
+                        "web": "!"
+                    }
+                }
+            ],
+            "message": {
+                "id": "6f793f82-5e13-492f-803c-2d5Fsdcc3cd1",
+                "priority": 93,
+                "dismissible": false,
+                "variant": "warning",
+                "category": ["feature"],
+                "content": {
+                    "en-GB": "Coinjoin not publicly available on T1",
+                    "en": "Coinjoin not publicly available on T1",
+                    "es": "Coinjoin not publicly available on T1",
+                    "cs": "Coinjoin not publicly available on T1",
+                    "ru": "Coinjoin not publicly available on T1",
+                    "ja": "Coinjoin not publicly available on T1。"
+                },
+                "feature": [
+                    {
+                        "flag": true,
+                        "domain": "coinjoin",
+                        "isPublic": false,
+                        "averageAnonymityGainPerRound": 0.34,
+                        "roundsFailRateBuffer": 10,
+                        "roundsDurationInHours": 3
+                    }
+                ]
+            }
+        },
         {
             "conditions": [
                 {


### PR DESCRIPTION

<!--- Provide a general summary of your changes in the Title above -->

## Description

- Coinjoin for T1 available only in debug mode.
- Constants config (averageAnonymityGainPerRound etc.) duplicated to set them properly for T1 in debug mode.


