### PR TITLE
fix(suite): fix wrong margin on the label when it is being changed

### DIFF
--- a/packages/suite/src/components/suite/Labeling/components/Metadata/MetadataLabeling.tsx
+++ b/packages/suite/src/components/suite/Labeling/components/Metadata/MetadataLabeling.tsx
@@ -48,7 +48,8 @@ const LabelButton = styled(Button)`
 `;
 
 const ActionButton = styled(Button)<{ isValueVisible?: boolean; isVisible?: boolean }>`
-    margin-left: ${({ isValueVisible, isVisible }) => (isValueVisible || !isVisible) && '12px'};
+    margin-left: ${({ isValueVisible, isVisible, isLoading }) =>
+        (isValueVisible || !isVisible || isLoading) && '12px'};
     visibility: ${({ isVisible }) => (isVisible ? 'visible' : 'hidden')};
     /* hack to keep button in place to prevent vertical jumping (if used display: none) */
     width: ${({ isVisible }) => (isVisible ? 'auto' : '0')};


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Previously the margin was set incorrectly and the label was jumping after it's finished loading.
