### PR TITLE
fix(connect): respect useEmptyPassphrase param in cipherKeyValue method

### DIFF
--- a/packages/connect/src/api/cipherKeyValue.ts
+++ b/packages/connect/src/api/cipherKeyValue.ts
@@ -15,14 +15,16 @@ export default class CipherKeyValue extends AbstractMethod<
     init() {
         this.requiredPermissions = ['read', 'write'];
         this.firmwareRange = getFirmwareRange(this.name, null, this.firmwareRange);
-        this.info = 'Cypher key value';
-        this.useEmptyPassphrase = true;
+        this.info = 'Cipher key value';
 
         // create a bundle with only one batch if bundle doesn't exists
         this.hasBundle = !!this.payload.bundle;
         const payload = !this.payload.bundle
             ? { ...this.payload, bundle: [this.payload] }
             : this.payload;
+
+        this.useEmptyPassphrase =
+            typeof payload.useEmptyPassphrase === 'boolean' ? payload.useEmptyPassphrase : true;
 
         // validate bundle type
         validateParams(payload, [{ name: 'bundle', type: 'array' }]);


### PR DESCRIPTION


<!--- Provide a general summary of your changes in the Title above -->

## Description

* fix inability to enable labeling from a hidden wallet

## Related Issue

Resolve https://github.com/trezor/trezor-suite/issues/8250


