### PR TITLE
fix(suite-native): change support link

### DIFF
--- a/suite-native/module-settings/src/screens/SettingsFAQScreen.tsx
+++ b/suite-native/module-settings/src/screens/SettingsFAQScreen.tsx
@@ -17,7 +17,9 @@ export const SettingsFAQScreen = () => {
                         <Text numberOfLines={3} variant="titleSmall">
                             Need more help?
                         </Text>
-                        <Button onPress={() => openLink('https://trezor.io/support')}>
+                        <Button
+                            onPress={() => openLink('https://trezor.io/learn/c/trezor-suite-lite')}
+                        >
                             Contact support
                         </Button>
                     </VStack>


### PR DESCRIPTION
The link on the Get Help settings page changed.
## Related Issue

Resolve #8270 