### PR TITLE
fix(coinjoin): limit available vsize before output decomposition

### DIFF
--- a/packages/coinjoin/src/client/round/outputRegistration.ts
+++ b/packages/coinjoin/src/client/round/outputRegistration.ts
@@ -130,7 +130,7 @@ export const outputRegistration = async (
     try {
         round.setSessionPhase(SessionPhase.RegisteringOutputs);
         // decompose output amounts for all registered inputs grouped by Account
-        const decomposedGroup = await outputDecomposition(round, options);
+        const decomposedGroup = await outputDecomposition(round, accounts, options);
 
         // collect all used addresses
         // try to register outputs for each account (each input in account group)

--- a/packages/coinjoin/tests/client/outputDecomposition.test.ts
+++ b/packages/coinjoin/tests/client/outputDecomposition.test.ts
@@ -28,6 +28,7 @@ describe('outputRegistration', () => {
                         phase: 3,
                     },
                 }),
+                [],
                 server?.requestOptions,
             ),
         ).rejects.toThrow('Missing confirmed credentials');
@@ -36,8 +37,10 @@ describe('outputRegistration', () => {
     fixtures.forEach(f => {
         it(`outputDecomposition ${f.description}`, async () => {
             const spy = jest.fn();
-            server?.addListener('test-request', ({ url, resolve }) => {
+            const availableVsize: number[] = [];
+            server?.addListener('test-request', ({ url, resolve, data }) => {
                 if (url.endsWith('/get-outputs-amounts')) {
+                    availableVsize.push(data.availableVsize);
                     resolve({
                         outputAmounts: f.outputAmounts,
                     });
@@ -75,6 +78,7 @@ describe('outputRegistration', () => {
                     },
                     roundParameters: f.roundParameters,
                 }),
+                f.accounts,
                 server?.requestOptions,
             );
 
@@ -83,6 +87,7 @@ describe('outputRegistration', () => {
                 expect(r.outputs.length).toBe(f.result[i].outputs.length);
                 expect(r).toMatchObject(f.result[i]);
             });
+            expect(availableVsize).toEqual(f.availableVsize);
             expect(spy).toBeCalledTimes(f.credentialIssuanceCalls);
         });
     });

--- a/packages/coinjoin/tests/client/selectRound.test.ts
+++ b/packages/coinjoin/tests/client/selectRound.test.ts
@@ -314,7 +314,7 @@ describe('selectRound', () => {
                     utxos: [{ outpoint: 'AA', amount: 1001, anonymityLevel: 1 }],
                 },
             ],
-            options: { ...server?.requestOptions, logger: console },
+            options: server?.requestOptions,
         });
 
         expect(spy).toBeCalledTimes(1); // middleware was called once

--- a/packages/coinjoin/tests/fixtures/outputDecomposition.fixture.ts
+++ b/packages/coinjoin/tests/fixtures/outputDecomposition.fixture.ts
@@ -1,3 +1,10 @@
+export const ACCOUNT = {
+    accountKey: 'account-A',
+    changeAddresses: new Array(50).fill({
+        address: 'bc1pkeah0fx2ex3jc337twlqcm9lh2eusm94j5vw2eshvczku6n7sjwqrfyfj2',
+    }),
+} as any; // as Account
+
 export const outputDecomposition = [
     {
         description: 'maximum outputs from one input',
@@ -12,6 +19,7 @@ export const outputDecomposition = [
                 },
             ],
         ],
+        accounts: [ACCOUNT],
         roundParameters: {
             miningFeeRate: 2000,
         },
@@ -41,6 +49,7 @@ export const outputDecomposition = [
                 ],
             },
         ],
+        availableVsize: [197],
         credentialIssuanceCalls: 4, // called 4 times to split outputs
     },
     {
@@ -80,6 +89,7 @@ export const outputDecomposition = [
                 },
             ],
         ],
+        accounts: [ACCOUNT],
         roundParameters: {
             miningFeeRate: 2000,
         },
@@ -94,6 +104,7 @@ export const outputDecomposition = [
                 ],
             },
         ],
+        availableVsize: [788], // 197 * 4
         credentialIssuanceCalls: 3, // called 3 times to join 4 inputs
     },
     {
@@ -125,6 +136,7 @@ export const outputDecomposition = [
                 },
             ],
         ],
+        accounts: [ACCOUNT, { ...ACCOUNT, accountKey: 'account-B' }],
         roundParameters: {
             miningFeeRate: 2000,
             maxAmountCredentialValue: 10000,
@@ -151,6 +163,38 @@ export const outputDecomposition = [
                 ],
             },
         ],
+        availableVsize: [394, 197], // 197 * 2 (account-A), 197 (account-B)
         credentialIssuanceCalls: 2, // called 2 times, once for each account
+    },
+    {
+        description: 'availableVsize limited by changeAddresses',
+        outputAmounts: [20000],
+        inputs: [
+            [
+                'account-A',
+                'A00000000000000000000000000000000000000000000000000000000000000001000000',
+                {
+                    confirmedAmountCredentials: [{ value: 30000 }, { value: 0 }],
+                    confirmedVsizeCredentials: [{ value: 197 }, { value: 0 }],
+                },
+            ],
+        ],
+        accounts: [{ ...ACCOUNT, changeAddresses: [{ address: '1' }] }],
+        roundParameters: {
+            miningFeeRate: 2000,
+        },
+        result: [
+            {
+                outputs: [
+                    {
+                        amount: 20086,
+                        amountCredentials: [{ value: 20086 }, { value: 0 }],
+                        vsizeCredentials: [{ value: 43 }, { value: 0 }],
+                    },
+                ],
+            },
+        ],
+        availableVsize: [43], // availableVsize is limited because only 1 change address is available
+        credentialIssuanceCalls: 1,
     },
 ];


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

followup for https://github.com/trezor/trezor-suite/commit/867ba2705c702c1b413b526d396292263de4e21c

limit vsize (number of outputs) in case when `availableVsize` is greater than `availableAddresses`.

Example:

for each registered input user receives 197 vsize (it is enough to register ~4.5 outputs)
currently it's possible to register 10 inputs (will be increased to 20) - therefore theoretically available vsize is enough to create 45 outputs in one round (90 outputs after increasing)

reducing available vsize prevents from decomposition of amount which cannot be registered as output (because account doesnt have enough available addresses)
