### PR TITLE
Allow full CJ rescan from account details

### DIFF
--- a/packages/suite/src/actions/wallet/__fixtures__/coinjoinAccountActions.ts
+++ b/packages/suite/src/actions/wallet/__fixtures__/coinjoinAccountActions.ts
@@ -121,6 +121,7 @@ export const createCoinjoinAccount = [
                 COINJOIN.CLIENT_ENABLE_SUCCESS,
                 COINJOIN.ACCOUNT_PRELOADING,
                 accountsActions.createAccount.type,
+                COINJOIN.ACCOUNT_DISCOVERY_RESET,
                 COINJOIN.ACCOUNT_PRELOADING,
                 accountsActions.startCoinjoinAccountSync.type,
                 COINJOIN.ACCOUNT_DISCOVERY_PROGRESS,

--- a/packages/suite/src/actions/wallet/__fixtures__/mockCoinjoinService.ts
+++ b/packages/suite/src/actions/wallet/__fixtures__/mockCoinjoinService.ts
@@ -41,6 +41,7 @@ export const mockCoinjoinService = () => {
                     change: [],
                 },
             })),
+            getAccountCheckpoint: jest.fn(() => undefined),
         };
         return { client, backend };
     };

--- a/packages/suite/src/actions/wallet/constants/coinjoinConstants.ts
+++ b/packages/suite/src/actions/wallet/constants/coinjoinConstants.ts
@@ -6,6 +6,7 @@ export const ACCOUNT_AUTHORIZE = '@coinjoin/account-authorize';
 export const ACCOUNT_AUTHORIZE_SUCCESS = '@coinjoin/account-authorize-success';
 export const ACCOUNT_AUTHORIZE_FAILED = '@coinjoin/account-authorize-failed';
 export const ACCOUNT_UNREGISTER = '@coinjoin/account-unregister';
+export const ACCOUNT_DISCOVERY_RESET = '@coinjoin/account-discovery-reset';
 export const ACCOUNT_DISCOVERY_PROGRESS = '@coinjoin/account-discovery-progress';
 export const ACCOUNT_PRELOADING = '@coinjoin/account-preloading';
 export const ACCOUNT_SET_LIQUIDITY_CLUE = '@coinjoin/account-set-liquidity-clue';

--- a/packages/suite/src/components/wallet/PrivacyAccount/RescanAccount.tsx
+++ b/packages/suite/src/components/wallet/PrivacyAccount/RescanAccount.tsx
@@ -1,0 +1,30 @@
+import React from 'react';
+import { ActionButton, ActionColumn, TextColumn, Row } from '@suite-components/Settings';
+import { Translation } from '@suite-components';
+import { useDispatch } from '@suite-hooks/useDispatch';
+import { rescanCoinjoinAccount } from '@wallet-actions/coinjoinAccountActions';
+import type { Account } from '@wallet-types';
+
+type RescanAccountProps = {
+    account: Extract<Account, { backendType: 'coinjoin' }>;
+};
+
+export const RescanAccount = ({ account }: RescanAccountProps) => {
+    const dispatch = useDispatch();
+    return (
+        <Row>
+            <TextColumn
+                title={<Translation id="TR_COINJOIN_ACCOUNT_RESCAN_TITLE" />}
+                description={<Translation id="TR_COINJOIN_ACCOUNT_RESCAN_DESCRIPTION" />}
+            />
+            <ActionColumn>
+                <ActionButton
+                    isDisabled={account.status === 'initial' || account.syncing}
+                    onClick={() => dispatch(rescanCoinjoinAccount(account.key, true))}
+                >
+                    <Translation id="TR_COINJOIN_ACCOUNT_RESCAN_ACTION" />
+                </ActionButton>
+            </ActionColumn>
+        </Row>
+    );
+};

--- a/packages/suite/src/middlewares/wallet/storageMiddleware.ts
+++ b/packages/suite/src/middlewares/wallet/storageMiddleware.ts
@@ -224,6 +224,7 @@ const storageMiddleware = (api: MiddlewareAPI<Dispatch, AppState>) => {
                     api.dispatch(storageActions.saveFirmware());
                     break;
 
+                case COINJOIN.ACCOUNT_DISCOVERY_RESET:
                 case COINJOIN.ACCOUNT_DISCOVERY_PROGRESS:
                 case COINJOIN.ACCOUNT_AUTHORIZE_SUCCESS:
                 case COINJOIN.ACCOUNT_UNREGISTER:

--- a/packages/suite/src/reducers/wallet/coinjoinReducer.ts
+++ b/packages/suite/src/reducers/wallet/coinjoinReducer.ts
@@ -479,6 +479,15 @@ export const coinjoinReducer = (
             case COINJOIN.ACCOUNT_UNREGISTER:
                 stopSession(draft, action.payload);
                 break;
+            case COINJOIN.ACCOUNT_DISCOVERY_RESET: {
+                const account = getAccount(draft, action.payload.accountKey);
+                if (account) {
+                    account.checkpoints = action.payload.checkpoint
+                        ? [action.payload.checkpoint]
+                        : [];
+                }
+                break;
+            }
             case COINJOIN.ACCOUNT_DISCOVERY_PROGRESS:
                 saveCheckpoint(draft, action.payload);
                 break;

--- a/packages/suite/src/support/messages.ts
+++ b/packages/suite/src/support/messages.ts
@@ -7552,6 +7552,19 @@ export default defineMessages({
         description: 'value including unit i.e. 5 hours 15 minutes, firstValue for handling plural',
         defaultMessage: '{value} {firstValue, plural, one {left} other {left}}',
     },
+    TR_COINJOIN_ACCOUNT_RESCAN_TITLE: {
+        id: 'TR_COINJOIN_ACCOUNT_RESCAN_TITLE',
+        defaultMessage: 'Rescan account',
+    },
+    TR_COINJOIN_ACCOUNT_RESCAN_DESCRIPTION: {
+        id: 'TR_COINJOIN_ACCOUNT_RESCAN_DESCRIPTION',
+        defaultMessage:
+            'In case of incorrect transaction history, you can fully rescan the account without optimizations. It may take more time than usual.',
+    },
+    TR_COINJOIN_ACCOUNT_RESCAN_ACTION: {
+        id: 'TR_COINJOIN_ACCOUNT_RESCAN_ACTION',
+        defaultMessage: 'Rescan account',
+    },
     TR_LOADING_FUNDS: {
         id: 'TR_LOADING_FUNDS',
         defaultMessage: 'Loading Funds...',

--- a/packages/suite/src/views/wallet/details/index.tsx
+++ b/packages/suite/src/views/wallet/details/index.tsx
@@ -18,6 +18,7 @@ import { CARD_PADDING_SIZE } from '@suite-constants/layout';
 import { NETWORKS } from '@wallet-config';
 import { CoinjoinLogs } from '@wallet-components/PrivacyAccount/CoinjoinLogs';
 import { CoinjoinSetup } from '@wallet-components/PrivacyAccount/CoinjoinSetup';
+import { RescanAccount } from '@wallet-components/PrivacyAccount/RescanAccount';
 
 const Heading = styled.h3`
     color: ${({ theme }) => theme.TYPE_LIGHT_GREY};
@@ -93,7 +94,7 @@ const Details = () => {
     const accountTypeUrl = getAccountTypeUrl(account.path);
     const accountTypeDesc = getAccountTypeDesc(account.path);
 
-    const isCoinjoinAccount = account.accountType === 'coinjoin';
+    const isCoinjoinAccount = account.backendType === 'coinjoin';
 
     return (
         <WalletLayout
@@ -131,7 +132,7 @@ const Details = () => {
                             </P>
                         </AccountTypeLabel>
                     </Row>
-                    {!isCoinjoinAccount && (
+                    {!isCoinjoinAccount ? (
                         <Row>
                             <TextColumn
                                 title={<Translation id="TR_ACCOUNT_DETAILS_XPUB_HEADER" />}
@@ -160,6 +161,8 @@ const Details = () => {
                                 </ActionButton>
                             </ActionColumn>
                         </Row>
+                    ) : (
+                        <RescanAccount account={account} />
                     )}
                 </StyledCard>
 


### PR DESCRIPTION
## Description

Allow users to rescan their CJ account history in case of any inconsistency by a single click, with possibility to bypass birthdate optimization and scan from defined base block instead.

## Commits

- https://github.com/trezor/trezor-suite/pull/8614/commits/92a140e740469dcb093b5dbb2455032bbbfcf96a - make `getAccountCheckpoint` method in `CoinjoinBackend` public and don't use it automatically in `scanAccount`
- https://github.com/trezor/trezor-suite/pull/8614/commits/cd85eea0259be3ac561b7b99eef21dc421183971 - implement `ACCOUNT_DISCOVERY_RESET` action in Suite for replacing stored checkpoints with given one (or none at all); set account checkpoint in `createCoinjoinAccount` as default one
- https://github.com/trezor/trezor-suite/pull/8614/commits/f68c9a42117ad462042f7e372950559e45d3d5c7 - add `rescanCoinjoinAccount` thunk to reset CJ account data and checkpoints and start rescanning (possibly without birthdate optimization); add `Rescan account` section to CJ account details
- https://github.com/trezor/trezor-suite/pull/8614/commits/eb151b1818447af550f5ab5482bbd858006831d6 - fixing unit tests

## Screenshots:

**Open for discussion** (I completely made it up)

<img width="640" alt="image" src="https://github.com/trezor/trezor-suite/assets/3729633/6589dc2b-16ff-4de1-b406-8e1c5246e596">

