### PR TITLE
Feat: Logger in a shared worker for connect

### DIFF
--- a/ci/test.yml
+++ b/ci/test.yml
@@ -226,6 +226,7 @@ transport manual:
       - TEST_FILE: ["popup-close.test"]
       - TEST_FILE: ["popup-error-page.test"]
       - TEST_FILE: ["passphrase.test"]
+      - TEST_FILE: ["log-page.test"]
       - TEST_FILE: ["unchained.test"]
       - TEST_FILE: ["browser-support.test"]
       - TEST_FILE: ["install-bridge.test"]

--- a/packages/connect-iframe/src/index.ts
+++ b/packages/connect-iframe/src/index.ts
@@ -38,6 +38,9 @@ let _core: Core | undefined;
 
 // custom log
 const _log = initLog('IFrame');
+// `connectWebLog` does not log in original console, used just as proxy to shared logger
+// that's why it is not enabled.
+const connectWebLog = initLog('@trezor/connect-web', false);
 
 let _popupMessagePort: (MessagePort | BroadcastChannel) | undefined;
 
@@ -56,6 +59,16 @@ const handleMessage = (event: PostMessageEvent) => {
         postMessage(createResponseMessage(id, false, { error }));
         postMessage(createPopupMessage(POPUP.CANCEL_POPUP_REQUEST));
     };
+
+    if (data.type === IFRAME.LOG && data.payload.prefix === '@trezor/connect-web') {
+        const { level, prefix, message } = data.payload;
+        if (Array.isArray(message)) {
+            connectWebLog.addMessage(level, prefix, ...message);
+        } else {
+            connectWebLog.addMessage(level, message);
+        }
+        return;
+    }
 
     // respond to call
     // TODO: instead of error _core should be initialized automatically

--- a/packages/connect-iframe/src/index.ts
+++ b/packages/connect-iframe/src/index.ts
@@ -32,11 +32,13 @@ import { suggestUdevInstaller } from '@trezor/connect/src/data/udevInfo';
 import { storage, getSystemInfo, getInstallerPackage } from '@trezor/connect-common';
 import { parseConnectSettings, isOriginWhitelisted } from './connectSettings';
 import { analytics, EventType } from '@trezor/connect-analytics';
+import { logWriterFactory } from './logWriter';
 
 let _core: Core | undefined;
 
 // custom log
 const _log = initLog('IFrame');
+
 let _popupMessagePort: (MessagePort | BroadcastChannel) | undefined;
 
 // Wrapper which listens to events from Core
@@ -293,7 +295,7 @@ const init = async (payload: IFrameInit['payload'], origin: string) => {
 
     try {
         // initialize core
-        _core = await initCore(parsedSettings);
+        _core = await initCore(parsedSettings, logWriterFactory);
         _core.on(CORE_EVENT, postMessage);
 
         // initialize transport and wait for the first transport event (start or error)

--- a/packages/connect-iframe/src/logWriter.ts
+++ b/packages/connect-iframe/src/logWriter.ts
@@ -1,0 +1,10 @@
+// @ts-expect-error (typescript does not know this is worker constructor, this is done by webpack)
+import LogWorker from './sharedLoggerWorker';
+import { LogMessage, LogWriter } from '@trezor/connect/src/utils/debug';
+
+const logWorker = new LogWorker();
+logWorker.port.start();
+
+export const logWriterFactory = (): LogWriter => ({
+    add: (message: LogMessage) => logWorker.port.postMessage({ type: 'add-log', data: message }),
+});

--- a/packages/connect-iframe/src/sharedLoggerWorker.ts
+++ b/packages/connect-iframe/src/sharedLoggerWorker.ts
@@ -1,0 +1,51 @@
+/// <reference lib="webworker" />
+
+import { LogMessage } from '@trezor/connect/src/utils/debug';
+
+export interface LogEntry {
+    type: 'add-log' | 'get-logs' | 'subscribe';
+    data: LogMessage;
+}
+
+const ports: MessagePort[] = [];
+const subscriberPorts: MessagePort[] = [];
+const messages: LogMessage[] = [];
+
+const MAX_ENTRIES = 1000;
+
+function handleMessage(event: MessageEvent<LogMessage>, port: MessagePort) {
+    const { type, data } = event;
+    switch (type) {
+        case 'add-log':
+            messages.push(data);
+            if (messages.length > MAX_ENTRIES) {
+                messages.shift();
+            }
+            if (subscriberPorts.length > 0) {
+                subscriberPorts.forEach(subscriberPort => {
+                    subscriberPort.postMessage({ type: 'log-entry', payload: data });
+                });
+            }
+            break;
+        case 'get-logs':
+            port.postMessage({ type: 'get-logs', payload: messages });
+            break;
+        case 'subscribe':
+            subscriberPorts.push(port);
+            break;
+        default:
+    }
+}
+
+// eslint-disable-next-line no-restricted-globals
+(self as unknown as SharedWorkerGlobalScope).addEventListener('connect', event => {
+    const port = event.ports[0];
+
+    ports.push(port);
+
+    port.addEventListener('message', eventMessage => {
+        handleMessage(eventMessage.data, port);
+    });
+
+    port.start();
+});

--- a/packages/connect-iframe/webpack/prod.webpack.config.ts
+++ b/packages/connect-iframe/webpack/prod.webpack.config.ts
@@ -45,6 +45,27 @@ const config: webpack.Configuration = {
                 },
             },
             {
+                test: /sharedLoggerWorker.ts/i,
+                use: [
+                    {
+                        loader: 'worker-loader',
+                        options: {
+                            worker: 'SharedWorker',
+                            // TODO: we are not using contenthash here because we want to use that worker from
+                            // different environments (iframe, popup, connect-web, etc.) and we would not know the
+                            // name of the file.
+                            filename: './workers/shared-logger-worker.js',
+                        },
+                    },
+                    {
+                        loader: 'babel-loader',
+                        options: {
+                            presets: ['@babel/preset-typescript'],
+                        },
+                    },
+                ],
+            },
+            {
                 test: /\workers\/blockbook\/index/i,
                 loader: 'worker-loader',
                 options: {

--- a/packages/connect-popup/e2e/support/helpers.ts
+++ b/packages/connect-popup/e2e/support/helpers.ts
@@ -16,3 +16,7 @@ export const findElementByDataTest = async (page: Page, dataTest: string, timeou
     await page.waitForSelector(`[data-test='${dataTest}']`, { state: 'visible', timeout });
     return page.$(`[data-test='${dataTest}']`);
 };
+
+export const log = (...val: string[]) => {
+    console.log(`[===]`, ...val);
+};

--- a/packages/connect-popup/e2e/tests/log-page.test.ts
+++ b/packages/connect-popup/e2e/tests/log-page.test.ts
@@ -1,0 +1,85 @@
+import { test, Page, expect } from '@playwright/test';
+import { TrezorUserEnvLink } from '@trezor/trezor-user-env-link';
+
+import fs from 'fs';
+import { log } from '../support/helpers';
+
+const url = process.env.URL || 'http://localhost:8088/';
+const bridgeVersion = '2.0.31';
+
+test.beforeAll(async () => {
+    await TrezorUserEnvLink.connect();
+});
+
+// popup window reference
+let popup: Page;
+
+test('log page should contain logs from shared worker', async ({ page, context }) => {
+    const errorLogs: any[] = [];
+    page.on('console', message => {
+        if (message.type() === 'error') {
+            errorLogs.push(message.text());
+        }
+    });
+    await TrezorUserEnvLink.api.stopBridge();
+    await TrezorUserEnvLink.api.stopEmu();
+    await TrezorUserEnvLink.api.startEmu({
+        wipe: true,
+    });
+    await TrezorUserEnvLink.api.setupEmu({
+        mnemonic: 'alcohol woman abuse must during monitor noble actual mixed trade anger aisle',
+        pin: '',
+        passphrase_protection: false,
+        label: 'My Trevor',
+        needs_backup: false,
+    });
+    await TrezorUserEnvLink.api.startBridge(bridgeVersion);
+
+    log(`go to: ${url}#/method/verifyMessage`);
+    await page.goto(`${url}#/method/verifyMessage`);
+    [popup] = await Promise.all([
+        page.waitForEvent('popup'),
+        page.click("button[data-test='@submit-button']"),
+    ]);
+    await popup.waitForLoadState('load');
+    log(`loaded: ${url}#/method/verifyMessage`);
+    // Open new tab to go to log.html
+    const logsPage = await context.newPage();
+
+    log(`go to: ${url}log.html`);
+    await logsPage.goto(`${url}log.html`);
+    await logsPage.waitForLoadState('load');
+    log(`loaded: ${url}log.html`);
+
+    log('clicking download button and waiting for download to start');
+    const [download] = await Promise.all([
+        logsPage.waitForEvent('download'), // wait for download to start
+        logsPage.click("button[data-test='@log-container/download-button']"),
+    ]);
+
+    log('download started');
+
+    const downloadPath = '/tmp/trezor-connect-test-log.txt';
+    log(`saving to: ${downloadPath}`);
+    await download.saveAs(downloadPath);
+
+    log('checking if file exists');
+    fs.existsSync(downloadPath);
+    log('file exists');
+
+    log('reading file');
+    const data = fs.readFileSync(downloadPath, 'utf8');
+    log('file read');
+
+    // It should be parsable JSON
+    const parsedData = JSON.parse(data);
+
+    expect(parsedData.length).toBeGreaterThan(0);
+    await download.delete();
+
+    // TODO: this should be fix.
+    expect(errorLogs.length).toBe(1);
+    expect(errorLogs[0]).toContain(
+        'Failed to load resource: the server responded with a status of 404 (Not Found)',
+    );
+});

--- a/packages/connect-popup/e2e/tests/log-page.test.ts
+++ b/packages/connect-popup/e2e/tests/log-page.test.ts
@@ -77,9 +77,7 @@ test('log page should contain logs from shared worker', async ({ page, context }
     expect(parsedData.length).toBeGreaterThan(0);
     await download.delete();
 
-    // TODO: this should be fix.
-    expect(errorLogs.length).toBe(1);
-    expect(errorLogs[0]).toContain(
-        'Failed to load resource: the server responded with a status of 404 (Not Found)',
-    );
+    // We want to shout out when there is an error in console, specifically when there is an error
+    // when postMessage is not able to serialize the message, because of circular reference or other.
+    expect(errorLogs.length).toBe(0);
 });

--- a/packages/connect-popup/e2e/tests/methods.test.ts
+++ b/packages/connect-popup/e2e/tests/methods.test.ts
@@ -7,13 +7,10 @@ import { TrezorUserEnvLink } from '@trezor/trezor-user-env-link';
 import { fixtures } from './__fixtures__/methods';
 import { buildOverview } from '../support/buildOverview';
 import { ensureDirectoryExists } from '@trezor/node-utils';
+import { log } from '../support/helpers';
 
 const url = process.env.URL || 'http://localhost:8088/';
 const emuScreenshots: Record<string, string> = {};
-
-const log = (...val: string[]) => {
-    console.log(`[===]`, ...val);
-};
 
 const screenshotEmu = async (path: string) => {
     const { response } = await TrezorUserEnvLink.send({

--- a/packages/connect-popup/package.json
+++ b/packages/connect-popup/package.json
@@ -12,6 +12,7 @@
         "test:unit": "jest"
     },
     "dependencies": {
+        "@trezor/components": "workspace:*",
         "@trezor/connect": "workspace:*",
         "@trezor/connect-analytics": "workspace:*",
         "@trezor/connect-common": "workspace:*",

--- a/packages/connect-popup/src/index.tsx
+++ b/packages/connect-popup/src/index.tsx
@@ -12,7 +12,7 @@ import {
     MethodResponseMessage,
 } from '@trezor/connect';
 import { config } from '@trezor/connect/lib/data/config';
-import { initLog, initSharedLogger } from '@trezor/connect/lib/utils/debug';
+import { initLog } from '@trezor/connect/lib/utils/debug';
 
 import { reactEventBus } from '@trezor/connect-ui/src/utils/eventBus';
 import { analytics, EventType } from '@trezor/connect-analytics';
@@ -27,6 +27,7 @@ import {
     renderConnectUI,
 } from './view/common';
 import { isPhishingDomain } from './utils/isPhishingDomain';
+import { initSharedLogger } from './utils/debug';
 
 const log = initLog('@trezor/connect-popup');
 initSharedLogger('./workers/shared-logger-worker.js');

--- a/packages/connect-popup/src/index.tsx
+++ b/packages/connect-popup/src/index.tsx
@@ -12,6 +12,7 @@ import {
     MethodResponseMessage,
 } from '@trezor/connect';
 import { config } from '@trezor/connect/lib/data/config';
+import { initLog, initSharedLogger } from '@trezor/connect/lib/utils/debug';
 
 import { reactEventBus } from '@trezor/connect-ui/src/utils/eventBus';
 import { analytics, EventType } from '@trezor/connect-analytics';
@@ -26,6 +27,9 @@ import {
     renderConnectUI,
 } from './view/common';
 import { isPhishingDomain } from './utils/isPhishingDomain';
+
+const log = initLog('@trezor/connect-popup');
+initSharedLogger('./workers/shared-logger-worker.js');
 
 let handshakeTimeout: ReturnType<typeof setTimeout>;
 
@@ -216,6 +220,8 @@ const handleMessage = (
 
 // handle POPUP.INIT message from window.opener
 const init = async (payload: PopupInit['payload']) => {
+    log.debug('popup init');
+
     if (!payload) return;
 
     if (!payload.systemInfo) {
@@ -254,6 +260,7 @@ const handshake = (handshake: PopupHandshake) => {
     if (isPhishingDomain(payload.settings.origin || '')) {
         reactEventBus.dispatch({ type: 'phishing-domain' });
     }
+    log.debug('handshake done');
 };
 
 const onLoad = () => {

--- a/packages/connect-popup/src/log.tsx
+++ b/packages/connect-popup/src/log.tsx
@@ -1,0 +1,115 @@
+import React, { useEffect, useState } from 'react';
+import { createRoot } from 'react-dom/client';
+
+import { ObjectInspector } from 'react-inspector';
+
+const MAX_ENTRIES = 1000;
+
+const DownloadButton = ({ array, filename }: { array: any[]; filename: string }) => {
+    const buttonStyle = {
+        backgroundColor: '#01b757',
+        color: '#ffffff',
+        fontSize: '14px',
+        padding: '12px',
+        border: 'none',
+        borderRadius: '4px',
+        cursor: 'pointer',
+        width: '200px',
+        margin: '10px 0',
+    };
+
+    const downloadArrayAsFile = () => {
+        const data = JSON.stringify(array, null, 2);
+        const blob = new Blob([data], { type: 'application/json' });
+
+        // Temporary anchor element.
+        const a = document.createElement('a');
+        a.href = URL.createObjectURL(blob);
+        a.download = filename;
+        document.body.appendChild(a);
+
+        // Programmatically trigger a click event on the anchor element.
+        a.click();
+
+        // Remove the anchor element from the document body.
+        document.body.removeChild(a);
+
+        URL.revokeObjectURL(a.href);
+    };
+
+    return (
+        <button
+            data-test="@log-container/download-button"
+            type="button"
+            style={buttonStyle}
+            onClick={downloadArrayAsFile}
+        >
+            Download Logs
+        </button>
+    );
+};
+
+const useLogWorker = (setLogs: React.Dispatch<React.SetStateAction<any[]>>) => {
+    const logWorker = new SharedWorker('./workers/shared-logger-worker.js');
+    useEffect(() => {
+        logWorker.port.onmessage = function (event) {
+            const { data } = event;
+            switch (data.type) {
+                case 'get-logs':
+                    setLogs(data.payload);
+                    break;
+                case 'log-entry':
+                    setLogs(prevLogs => {
+                        if (prevLogs.length > MAX_ENTRIES) {
+                            prevLogs.shift();
+                        }
+                        return [...prevLogs, data.payload];
+                    });
+                    break;
+                default:
+            }
+        };
+
+        logWorker.port.postMessage({ type: 'get-logs' });
+        logWorker.port.postMessage({ type: 'subscribe' });
+
+        // eslint-disable-next-line react-hooks/exhaustive-deps
+    }, []);
+
+    return logWorker;
+};
+
+const Inspector = () => {
+    const [logs, setLogs] = useState<any[]>([]);
+    useLogWorker(setLogs);
+
+    return (
+        <>
+            {logs.length > 0 ? (
+                <>
+                    <DownloadButton array={logs} filename="trezor-connect-logs.json" />
+                    <ObjectInspector expandLevel={2} data={logs} />
+                </>
+            ) : (
+                <p>No logs yet.</p>
+            )}
+        </>
+    );
+};
+
+const App = () => (
+    <>
+        <h1>TrezorConnect Logger</h1>
+        <Inspector />
+    </>
+);
+
+const renderUI = () => {
+    const logReact = document.getElementById('log-react');
+    const root = createRoot(logReact!);
+    const Component = <App />;
+
+    root.render(Component);
+};
+
+renderUI();

--- a/packages/connect-popup/src/static/log.html
+++ b/packages/connect-popup/src/static/log.html
@@ -1,0 +1,63 @@
+<!DOCTYPE html>
+<html lang="en">
+    <head>
+        <meta charset="UTF-8" />
+        <meta http-equiv="X-UA-Compatible" content="IE=Edge" />
+        <meta
+            name="viewport"
+            content="width=device-width,initial-scale=1.0,maximum-scale=1.0,user-scalable=0"
+        />
+        <title>TrezorConnect | Trezor</title>
+        <meta name="description" content="" />
+        <meta name="keywords" content="" />
+        <meta name="author" content="Trezor info@trezor.io" />
+        <meta name="robots" content="noindex, nofollow" />
+        <meta name="title" content="Trezor Connect" />
+        <meta name="theme-color" content="#ffffff" />
+        <meta http-equiv="Pragma" content="no-cache" />
+        <meta http-equiv="Expires" content="-1" />
+        <link href="./popup.css" rel="stylesheet" />
+
+        <!-- suite-like fonts -->
+        <link media="all" rel="stylesheet" href="./fonts/fonts.css" />
+    </head>
+    <body>
+        <h1>TrezorConnect Logger</h1>
+        <div id="logContainer"></div>
+
+        <script type="text/javascript">
+            const logWorker = new SharedWorker('./workers/shared-logger-worker.js');
+
+            function initiateLogs(logArray) {
+                // Create HTML entries for each item in the logArray
+                logArray.forEach(log => {
+                    // Create a log entry container
+                    const logEntry = document.createElement('div');
+                    logEntry.classList.add('log-entry');
+                    logEntry.style = log.css;
+                    logEntry.textContent = JSON.stringify(log, '', 2);
+
+                    // Append the log entry to the logContainer
+                    logContainer.appendChild(logEntry);
+                });
+            }
+
+            logWorker.port.onmessage = function (event) {
+                const { data } = event;
+                switch (data.type) {
+                    case 'get-logs':
+                        initiateLogs(data.payload);
+                        break;
+                    case 'log-entry':
+                        initiateLogs([data.payload]);
+                        break;
+                }
+                // Handle the incoming message from the shared worker
+                const logArray = event.data;
+            };
+
+            logWorker.port.postMessage({ type: 'get-logs' });
+            logWorker.port.postMessage({ type: 'subscribe' });
+        </script>
+    </body>
+</html>

--- a/packages/connect-popup/src/static/log.html
+++ b/packages/connect-popup/src/static/log.html
@@ -23,7 +23,7 @@
     </head>
     <body>
         <h1>TrezorConnect Logger</h1>
-        <div id="logContainer"></div>
+        <div data-test="@log-container" id="logContainer"></div>
 
         <script type="text/javascript">
             const logWorker = new SharedWorker('./workers/shared-logger-worker.js');

--- a/packages/connect-popup/src/static/log.html
+++ b/packages/connect-popup/src/static/log.html
@@ -22,42 +22,14 @@
         <link media="all" rel="stylesheet" href="./fonts/fonts.css" />
     </head>
     <body>
-        <h1>TrezorConnect Logger</h1>
-        <div data-test="@log-container" id="logContainer"></div>
+        <div id="debug-react"></div>
 
-        <script type="text/javascript">
-            const logWorker = new SharedWorker('./workers/shared-logger-worker.js');
-
-            function initiateLogs(logArray) {
-                // Create HTML entries for each item in the logArray
-                logArray.forEach(log => {
-                    // Create a log entry container
-                    const logEntry = document.createElement('div');
-                    logEntry.classList.add('log-entry');
-                    logEntry.style = log.css;
-                    logEntry.textContent = JSON.stringify(log, '', 2);
-
-                    // Append the log entry to the logContainer
-                    logContainer.appendChild(logEntry);
-                });
-            }
-
-            logWorker.port.onmessage = function (event) {
-                const { data } = event;
-                switch (data.type) {
-                    case 'get-logs':
-                        initiateLogs(data.payload);
-                        break;
-                    case 'log-entry':
-                        initiateLogs([data.payload]);
-                        break;
-                }
-                // Handle the incoming message from the shared worker
-                const logArray = event.data;
-            };
-
-            logWorker.port.postMessage({ type: 'get-logs' });
-            logWorker.port.postMessage({ type: 'subscribe' });
+        <script type="text/javascript" async="false">
+            const logScript = document.createElement('script');
+            logScript.setAttribute('type', 'text/javascript');
+            logScript.setAttribute('src', '<%= htmlWebpackPlugin.files.js[0] %>');
+            logScript.setAttribute('async', 'false');
+            document.body.appendChild(logScript);
         </script>
     </body>
 </html>

--- a/packages/connect-popup/src/utils/debug.ts
+++ b/packages/connect-popup/src/utils/debug.ts
@@ -1,0 +1,10 @@
+import { LogMessage, LogWriter, setLogWriter } from '@trezor/connect/src/utils/debug';
+
+export const initSharedLogger = (workerSrc: string) => {
+    const worker = new SharedWorker(workerSrc);
+    worker.port.start();
+    const logWriterFactory = (): LogWriter => ({
+        add: (message: LogMessage) => worker.port.postMessage({ type: 'add-log', data: message }),
+    });
+    setLogWriter(logWriterFactory);
+};

--- a/packages/connect-popup/tsconfig.json
+++ b/packages/connect-popup/tsconfig.json
@@ -6,6 +6,7 @@
     },
     "include": [".", "**/*.json"],
     "references": [
+        { "path": "../components" },
         { "path": "../connect" },
         { "path": "../connect-analytics" },
         { "path": "../connect-common" },

--- a/packages/connect-popup/webpack/prod.webpack.config.ts
+++ b/packages/connect-popup/webpack/prod.webpack.config.ts
@@ -17,6 +17,7 @@ const config: webpack.Configuration = {
     mode: 'production',
     entry: {
         popup: path.resolve(__dirname, '../src/index.tsx'),
+        log: path.resolve(__dirname, '../src/log.tsx'),
     },
     output: {
         filename: 'js/[name].[contenthash].js',
@@ -86,7 +87,7 @@ const config: webpack.Configuration = {
             urls: URLS,
         }),
         new HtmlWebpackPlugin({
-            chunks: ['popup'],
+            chunks: ['log'],
             template: `${STATIC_SRC}/log.html`,
             filename: 'log.html',
             inject: false,

--- a/packages/connect-popup/webpack/prod.webpack.config.ts
+++ b/packages/connect-popup/webpack/prod.webpack.config.ts
@@ -85,6 +85,14 @@ const config: webpack.Configuration = {
             minify: false,
             urls: URLS,
         }),
+        new HtmlWebpackPlugin({
+            chunks: ['popup'],
+            template: `${STATIC_SRC}/log.html`,
+            filename: 'log.html',
+            inject: false,
+            minify: false,
+            urls: URLS,
+        }),
         new CopyPlugin({
             patterns: [
                 {

--- a/packages/connect-web/src/iframe/index.ts
+++ b/packages/connect-web/src/iframe/index.ts
@@ -1,8 +1,9 @@
 // origin: https://github.com/trezor/connect/blob/develop/src/js/iframe/builder.js
 
 import { createDeferred, Deferred } from '@trezor/utils';
-import { IFRAME, ERRORS, ConnectSettings } from '@trezor/connect/lib/exports';
+import { IFRAME, UI_EVENT, ERRORS, ConnectSettings } from '@trezor/connect/lib/exports';
 import { getOrigin } from '@trezor/connect/lib/utils/urlUtils';
+import { setLogWriter, LogMessage, LogWriter } from '@trezor/connect/lib/utils/debug';
 import css from './inlineStyles';
 
 /* eslint-disable import/no-mutable-exports */
@@ -191,4 +192,17 @@ export const postMessage = (message: any, usePromise = true) => {
 
 export const clearTimeout = () => {
     window.clearTimeout(timeout);
+};
+
+export const initIframeLogger = () => {
+    const logWriterFactory = (): LogWriter => ({
+        add: (message: LogMessage) => {
+            postMessage({
+                event: UI_EVENT,
+                type: IFRAME.LOG,
+                payload: message,
+            });
+        },
+    });
+    setLogWriter(logWriterFactory);
 };

--- a/packages/connect-web/src/index.ts
+++ b/packages/connect-web/src/index.ts
@@ -23,7 +23,7 @@ import {
     CallMethod,
 } from '@trezor/connect/lib/exports';
 import { factory } from '@trezor/connect/lib/factory';
-import { initLog } from '@trezor/connect/lib/utils/debug';
+import { initLog, initSharedLogger } from '@trezor/connect/lib/utils/debug';
 import { config } from '@trezor/connect/lib/data/config';
 
 import * as iframe from './iframe';
@@ -32,7 +32,7 @@ import webUSBButton from './webusb/button';
 import { parseConnectSettings } from './connectSettings';
 
 const eventEmitter = new EventEmitter();
-const _log = initLog('@trezor/connect');
+const _log = initLog('@trezor/connect-web');
 
 let _settings = parseConnectSettings();
 let _popupManager: popup.PopupManager | undefined;
@@ -143,6 +143,9 @@ const init = async (settings: Partial<ConnectSettings> = {}): Promise<void> => {
     }
 
     _settings = parseConnectSettings({ ..._settings, ...settings });
+    if (_settings.connectSrc) {
+        initSharedLogger(`${_settings.connectSrc}workers/shared-logger-worker.js`);
+    }
 
     if (!_settings.manifest) {
         throw ERRORS.TypedError('Init_ManifestMissing');

--- a/packages/connect-web/src/index.ts
+++ b/packages/connect-web/src/index.ts
@@ -133,7 +133,7 @@ const handleMessage = (messageEvent: PostMessageEvent) => {
             break;
 
         default:
-            _log.log('Undefined message', message.event, messageEvent);
+            _log.log('Undefined message', message.event, messageEvent.data);
     }
 };
 

--- a/packages/connect-web/src/index.ts
+++ b/packages/connect-web/src/index.ts
@@ -23,7 +23,7 @@ import {
     CallMethod,
 } from '@trezor/connect/lib/exports';
 import { factory } from '@trezor/connect/lib/factory';
-import { initLog, initSharedLogger } from '@trezor/connect/lib/utils/debug';
+import { initLog } from '@trezor/connect/lib/utils/debug';
 import { config } from '@trezor/connect/lib/data/config';
 
 import * as iframe from './iframe';
@@ -143,11 +143,6 @@ const init = async (settings: Partial<ConnectSettings> = {}): Promise<void> => {
     }
 
     _settings = parseConnectSettings({ ..._settings, ...settings });
-    if (_settings.connectSrc && window.location.origin === _settings.connectSrc) {
-        // When connect-web is running in a web extension environment or in third-party service
-        // shared logger is in different domain so it cannot be loaded from the same origin as connectSrc (iframe).
-        initSharedLogger(`${_settings.connectSrc}workers/shared-logger-worker.js`);
-    }
 
     if (!_settings.manifest) {
         throw ERRORS.TypedError('Init_ManifestMissing');
@@ -168,6 +163,8 @@ const init = async (settings: Partial<ConnectSettings> = {}): Promise<void> => {
         _popupManager = initPopupManager();
     }
 
+    // connect-web is running in third-party domain so we use iframe to pass logs to shared worker.
+    iframe.initIframeLogger();
     _log.enabled = !!_settings.debug;
 
     window.addEventListener('message', handleMessage);

--- a/packages/connect-web/src/index.ts
+++ b/packages/connect-web/src/index.ts
@@ -143,7 +143,9 @@ const init = async (settings: Partial<ConnectSettings> = {}): Promise<void> => {
     }
 
     _settings = parseConnectSettings({ ..._settings, ...settings });
-    if (_settings.connectSrc) {
+    if (_settings.connectSrc && window.location.origin === _settings.connectSrc) {
+        // When connect-web is running in a web extension environment or in third-party service
+        // shared logger is in different domain so it cannot be loaded from the same origin as connectSrc (iframe).
         initSharedLogger(`${_settings.connectSrc}workers/shared-logger-worker.js`);
     }
 

--- a/packages/connect/src/core/index.ts
+++ b/packages/connect/src/core/index.ts
@@ -31,7 +31,7 @@ import {
 } from '../events';
 import { getMethod } from './method';
 import { resolveAfter } from '../utils/promiseUtils';
-import { initLog, enableLog, setLogWriter } from '../utils/debug';
+import { initLog, enableLog, setLogWriter, LogWriter } from '../utils/debug';
 import { dispose as disposeBackend } from '../backend/BlockchainLink';
 import { InteractionTimeout } from '../utils/interactionTimeout';
 
@@ -1018,9 +1018,9 @@ export class Core extends EventEmitter {
  * @returns {Promise<Core>}
  * @memberof Core
  */
-export const initCore = async (settings: ConnectSettings, logWriter?: any) => {
-    if (logWriter) {
-        setLogWriter(logWriter);
+export const initCore = async (settings: ConnectSettings, logWriterFactory?: () => LogWriter) => {
+    if (logWriterFactory) {
+        setLogWriter(logWriterFactory);
     }
     try {
         await DataManager.load(settings);

--- a/packages/connect/src/core/index.ts
+++ b/packages/connect/src/core/index.ts
@@ -31,7 +31,7 @@ import {
 } from '../events';
 import { getMethod } from './method';
 import { resolveAfter } from '../utils/promiseUtils';
-import { initLog, enableLog } from '../utils/debug';
+import { initLog, enableLog, setLogWriter } from '../utils/debug';
 import { dispose as disposeBackend } from '../backend/BlockchainLink';
 import { InteractionTimeout } from '../utils/interactionTimeout';
 
@@ -1018,7 +1018,10 @@ export class Core extends EventEmitter {
  * @returns {Promise<Core>}
  * @memberof Core
  */
-export const initCore = async (settings: ConnectSettings) => {
+export const initCore = async (settings: ConnectSettings, logWriter?: any) => {
+    if (logWriter) {
+        setLogWriter(logWriter);
+    }
     try {
         await DataManager.load(settings);
         enableLog(DataManager.getSettings('debug'));

--- a/packages/connect/src/device/DeviceList.ts
+++ b/packages/connect/src/device/DeviceList.ts
@@ -219,7 +219,7 @@ export class DeviceList extends TypedEmitter<DeviceListEvents> {
                         // have the intention of acquiring it again)
                         // and if the device is still reelased and has never been acquired before, acquire it here.
                         if (!device.isUsed() && device.isUnacquired() && !device.isInconsistent()) {
-                            _log.debug('Create device from unacquired', device);
+                            _log.debug('Create device from unacquired', device.toMessageObject());
                             await this._createAndSaveDevice(descriptor);
                         }
                     }
@@ -244,7 +244,7 @@ export class DeviceList extends TypedEmitter<DeviceListEvents> {
                     d.forEach(descriptor => {
                         const path = descriptor.path.toString();
                         const device = this.devices[path];
-                        _log.debug('Event', e, device);
+                        _log.debug('Event', e, device.toMessageObject());
                         if (device) {
                             this.emit(e, device.toMessageObject());
                         }

--- a/packages/connect/src/events/iframe.ts
+++ b/packages/connect/src/events/iframe.ts
@@ -1,6 +1,7 @@
 import { UI_EVENT } from './ui-request';
 import type { ConnectSettings, SystemInfo } from '../types';
 import type { MessageFactoryFn } from '../types/utils';
+import { LogMessage } from '../utils/debug';
 
 export const IFRAME = {
     // Message called from iframe.html inline script before "window.onload" event. This is first message from iframe to window.opener.
@@ -13,6 +14,8 @@ export const IFRAME = {
     ERROR: 'iframe-error',
     // Message from window.opener to iframe. Call method
     CALL: 'iframe-call',
+    // Message from third party window to iframe to add log to shared worker logger.
+    LOG: 'iframe-log',
 } as const;
 
 export interface IFrameError {
@@ -39,10 +42,16 @@ export interface IFrameInit {
     };
 }
 
+export interface IFrameLogRequest {
+    type: typeof IFRAME.LOG;
+    payload: LogMessage;
+}
+
 export type IFrameEvent =
     | { type: typeof IFRAME.BOOTSTRAP; payload?: typeof undefined }
     | IFrameLoaded
     | IFrameInit
+    | IFrameLogRequest
     | IFrameError;
 
 export type IFrameEventMessage = IFrameEvent & { event: typeof UI_EVENT };

--- a/packages/connect/src/utils/debug.ts
+++ b/packages/connect/src/utils/debug.ts
@@ -41,7 +41,7 @@ class Log {
     enabled: boolean;
     css: string;
     messages: LogMessage[];
-    logWriter: any;
+    logWriter: LogWriter | undefined;
 
     constructor(prefix: string, enabled: boolean, logWriter?: LogWriter) {
         this.prefix = prefix;
@@ -70,8 +70,7 @@ class Log {
             } catch (err) {
                 // If this error happens it probably means that we are logging an object with a circular reference.
                 // If there is any `device` logged, do it with `device.toMessageObject()` instead.
-                // TODO: maybe we should shout out this error to make sure we do not pass circular references to the log.
-                console.error('There was an error adding log message', err);
+                console.error('There was an error adding log message', err, message);
             }
         }
         if (this.messages.length > MAX_ENTRIES) {
@@ -117,18 +116,18 @@ class Log {
 }
 
 const _logs: { [k: string]: Log } = {};
-let writer: any;
+let writer: LogWriter | undefined;
 
 export const initLog = (prefix: string, enabled?: boolean, logWriter?: LogWriter) => {
-    const finalWriter = logWriter || writer;
-    const instance = new Log(prefix, !!enabled, finalWriter);
+    const instanceWriter = logWriter || writer;
+    const instance = new Log(prefix, !!enabled, instanceWriter);
     _logs[prefix] = instance;
     return instance;
 };
 
-export const setLogWriter = (logWriter: any) => {
+export const setLogWriter = (logWriterFactory: () => LogWriter) => {
     Object.keys(_logs).forEach(key => {
-        writer = logWriter();
+        writer = logWriterFactory();
         _logs[key].setWriter(writer);
     });
 };
@@ -152,15 +151,4 @@ export const getLog = () => {
     });
     logs.sort((a, b) => a.timestamp - b.timestamp);
     return logs;
-};
-
-export const initSharedLogger = (connectSrc: string) => {
-    const workerUrl = `${connectSrc}workers/shared-logger-worker.js`;
-    const worker = new SharedWorker(workerUrl);
-    worker.port.start();
-    const logWriterFactory = (): LogWriter => ({
-        add: (message: LogMessage) =>
-            worker.port.postMessage({ type: 'add-log', data: JSON.parse(JSON.stringify(message)) }),
-    });
-    setLogWriter(logWriterFactory);
 };

--- a/packages/connect/src/utils/debug.ts
+++ b/packages/connect/src/utils/debug.ts
@@ -1,71 +1,133 @@
 // origin: https://github.com/trezor/connect/blob/develop/src/js/utils/debug.js
 /* eslint-disable no-console */
 
+const green = '#bada55';
+const blue = '#20abd8';
+const orange = '#f4a744';
+const yellow = '#fbd948';
+
 const colors: Record<string, string> = {
+    // blue, npm package related
+    '@trezor/connect': `color: ${blue}; background: #000;`,
+    '@trezor/connect-web': `color: ${blue}; background: #000;`,
     // orange, api related
-    '@trezor/connect': 'color: #f4a742; background: #000;',
-    IFrame: 'color: #f4a742; background: #000;',
-    Core: 'color: #f4a742; background: #000;',
+    IFrame: `color: ${orange}; background: #000;`,
+    Core: `color: ${orange}; background: #000;`,
     // green, device related
-    DescriptorStream: 'color: #77ab59; background: #000;',
-    DeviceList: 'color: #77ab59; background: #000;',
-    Device: 'color: #bada55; background: #000;',
-    DeviceCommands: 'color: #bada55; background: #000;',
-    '@trezor/transport': 'color: #bada55; background: #000;',
+    DeviceList: `color: ${green}; background: #000;`,
+    Device: `color: ${green}; background: #000;`,
+    DeviceCommands: `color: ${green}; background: #000;`,
+    '@trezor/transport': `color: ${green}; background: #000;`,
+    InteractionTimeout: `color: ${green}; background: #000;`,
+    // yellow, ui related
+    '@trezor/connect-popup': `color: ${yellow}; background: #000;`,
 };
 
-type LogMessage = {
+export type LogMessage = {
     level: string;
     prefix: string;
     message: any[];
     timestamp: number;
 };
 
+export type LogWriter = {
+    add: (message: LogMessage) => void;
+};
+
 const MAX_ENTRIES = 100;
+
+const stringify = (obj: Record<string, any>) => {
+    let cache: string[] = [];
+    const str = JSON.stringify(obj, (_key, value) => {
+        if (typeof value === 'object' && value !== null) {
+            if (cache.indexOf(value) !== -1) {
+                // Circular reference found, discard key
+                return;
+            }
+            // Store value in our collection
+            cache.push(value);
+        }
+        return value;
+    });
+    cache = [];
+    return str;
+};
 
 class Log {
     prefix: string;
     enabled: boolean;
     css: string;
     messages: LogMessage[];
+    logWriter: any;
 
-    constructor(prefix: string, enabled: boolean) {
+    constructor(prefix: string, enabled: boolean, logWriter?: LogWriter) {
         this.prefix = prefix;
         this.enabled = enabled;
         this.messages = [];
         this.css = typeof window !== 'undefined' && colors[prefix] ? colors[prefix] : '';
+        if (logWriter) {
+            this.logWriter = logWriter;
+        }
     }
 
     addMessage(level: string, prefix: string, ...args: any[]) {
-        this.messages.push({
+        const message = {
             level,
             prefix,
+            css: this.css,
             message: args,
             timestamp: Date.now(),
-        });
+        };
+
+        if (this.logWriter) {
+            const { level, prefix, timestamp, ...rest } = message;
+
+            // todo: this method calls post postMessage which serializes object passed in ...args.
+            // if there is cyclic dependency, it simply dies.
+            // this is probably not the right place to call stringify.
+            // on the other hand, catching here is probably the right place to do to make sure that
+            // this not-essential mechanism does not break everything when broken.
+            try {
+                this.logWriter.add({
+                    level,
+                    prefix,
+                    timestamp,
+                    message: JSON.parse(stringify(rest)),
+                });
+            } catch (err) {
+                // If this error happens it probably means that we are logging an object with a circular reference.
+                // If there is any `device` logged, do it with `device.toMessageObject()` instead.
+                // TODO: maybe we should shout out this error to make sure we do not pass circular references to the log.
+                console.error('There was an error adding log message', err);
+            }
+        }
         if (this.messages.length > MAX_ENTRIES) {
             this.messages.shift();
         }
     }
 
+    setWriter(logWriter: any) {
+        this.logWriter = logWriter;
+    }
+
     log(...args: any[]) {
         this.addMessage('log', this.prefix, ...args);
         if (this.enabled) {
-            console.log(this.prefix, ...args);
+            console.log(`%c${this.prefix}`, this.css, ...args);
         }
     }
 
     error(...args: any[]) {
         this.addMessage('error', this.prefix, ...args);
         if (this.enabled) {
-            console.error(this.prefix, ...args);
+            console.error(`%c${this.prefix}`, this.css, ...args);
         }
     }
 
     warn(...args: any[]) {
         this.addMessage('warn', this.prefix, ...args);
         if (this.enabled) {
-            console.warn(this.prefix, ...args);
+            console.warn(`%c${this.prefix}`, this.css, ...args);
         }
     }
 
@@ -82,11 +144,20 @@ class Log {
 }
 
 const _logs: { [k: string]: Log } = {};
+let writer: any;
 
-export const initLog = (prefix: string, enabled?: boolean) => {
-    const instance = new Log(prefix, !!enabled);
+export const initLog = (prefix: string, enabled?: boolean, logWriter?: LogWriter) => {
+    const finalWriter = logWriter || writer;
+    const instance = new Log(prefix, !!enabled, finalWriter);
     _logs[prefix] = instance;
     return instance;
+};
+
+export const setLogWriter = (logWriter: any) => {
+    Object.keys(_logs).forEach(key => {
+        writer = logWriter();
+        _logs[key].setWriter(writer);
+    });
 };
 
 export const enableLog = (enabled?: boolean) => {
@@ -108,4 +179,15 @@ export const getLog = () => {
     });
     logs.sort((a, b) => a.timestamp - b.timestamp);
     return logs;
+};
+
+export const initSharedLogger = (connectSrc: string) => {
+    const workerUrl = `${connectSrc}workers/shared-logger-worker.js`;
+    const worker = new SharedWorker(workerUrl);
+    worker.port.start();
+    const logWriterFactory = (): LogWriter => ({
+        add: (message: LogMessage) =>
+            worker.port.postMessage({ type: 'add-log', data: JSON.parse(JSON.stringify(message)) }),
+    });
+    setLogWriter(logWriterFactory);
 };

--- a/yarn.lock
+++ b/yarn.lock
@@ -9410,6 +9410,7 @@ __metadata:
   resolution: "@trezor/connect-popup@workspace:packages/connect-popup"
   dependencies:
     "@playwright/test": ^1.35.1
+    "@trezor/components": "workspace:*"
     "@trezor/connect": "workspace:*"
     "@trezor/connect-analytics": "workspace:*"
     "@trezor/connect-common": "workspace:*"


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Creates a Shared Worker for connect logs that works on different connect environment that are sharing the same domain.
Collecting those logs in a Shared Worker allow us to display them in http://localhost:8088/log.html for debugging.
It displays the logs in an interactive objects list and allows the user to downloads them with a "Download button".

## How to test
It is possible that this could slowdown some communication with popup and make popup timeout in some situations. I would test making repeated use of popup like getting address and once completed getting it again multiple times.


## Related Issue
Related to https://github.com/trezor/trezor-suite/issues/8445

## Screenshots:
![image](https://github.com/trezor/trezor-suite/assets/5362163/3d8b5953-3e00-4378-a8b7-3fe447e81cb9)



And logs can be inspected in the developer console:
![image](https://github.com/trezor/trezor-suite/assets/5362163/506a5155-5785-4ce4-91f5-ad15f72a5a85)





