### PR TITLE
Various CJ mempool fixes

### DIFF
--- a/packages/coinjoin/src/backend/CoinjoinMempoolController.ts
+++ b/packages/coinjoin/src/backend/CoinjoinMempoolController.ts
@@ -144,7 +144,6 @@ export class CoinjoinMempoolController implements MempoolController {
     async update(force?: boolean) {
         const now = new Date().getTime();
         if (now - this.lastPurge < MEMPOOL_PURGE_CYCLE && !force) return;
-        this.lastPurge = now;
 
         const mempoolTxids = await this.client
             .fetchMempoolFilters()
@@ -154,6 +153,8 @@ export class CoinjoinMempoolController implements MempoolController {
             txid => !keepTxids.includes(txid),
         );
         removeTxids.forEach(this.onTxRemove);
+
+        this.lastPurge = now;
     }
 
     getTransactions(...addressControllers: AddressController[]) {

--- a/packages/coinjoin/src/backend/CoinjoinWebsocketController.ts
+++ b/packages/coinjoin/src/backend/CoinjoinWebsocketController.ts
@@ -1,5 +1,6 @@
 import { BlockbookAPI } from '@trezor/blockchain-link/lib/workers/blockbook/websocket';
 
+import { WS_MESSAGE_TIMEOUT } from '../constants';
 import type { Logger } from '../types';
 
 export type BlockbookWS = Pick<
@@ -33,6 +34,7 @@ export class CoinjoinWebsocketController {
         let socket = this.sockets[socketId];
         if (!socket) {
             socket = new BlockbookAPI({
+                timeout: WS_MESSAGE_TIMEOUT,
                 url,
                 headers: { 'Proxy-Authorization': `Basic ${identity}` },
             });

--- a/packages/coinjoin/src/constants.ts
+++ b/packages/coinjoin/src/constants.ts
@@ -25,6 +25,9 @@ export const ROUND_SELECTION_REGISTRATION_OFFSET = 30000;
 // max output count
 export const ROUND_SELECTION_MAX_OUTPUTS = 20;
 
+// custom timeout for websocket messages
+export const WS_MESSAGE_TIMEOUT = 60000;
+
 // custom timeout for http requests (default is 50000 ms)
 export const HTTP_REQUEST_TIMEOUT = 35000;
 


### PR DESCRIPTION
## Description

- https://github.com/trezor/trezor-suite/pull/8636/commits/1d3da5dc55cb942662cb4fa860e399df806c1785 - websocket timeout increased from default 20s to 60s (so large `getMempoolFilters` messages can safely make it through Tor without ruining whole sync)
- https://github.com/trezor/trezor-suite/pull/8636/commits/22f8eaa60dd58c3f93877c58236f6509d4ef0153 - `lastPurge` in `CoinjoinMempoolController` is set only after successful purge