### PR TITLE
chore(translations): stop reusing same branch for every crowdin sync

### DIFF
--- a/.github/workflows/crowdin_sync.yml
+++ b/.github/workflows/crowdin_sync.yml
@@ -12,22 +12,24 @@ jobs:
         uses: actions/setup-node@v3
         with:
           node-version-file: ".nvmrc"
+      - name: Set current timestamp as env variable
+        run: echo "NOW=$(date +'%s')" >> $GITHUB_ENV
 
       - name: Run crowdin sync
         run: |
           npm install -g yarn && yarn install
           git config --global user.name "trezor-ci"
           git config --global user.email "${{ secrets.TREZOR_BOT_EMAIL }}"
-          git checkout -B trezor-ci/crowdin-sync
+          git checkout -B ${{ env.BRANCH_NAME }}
           yarn workspace @trezor/suite translations:download --token=${{ secrets.CROWDIN_PERSONAL_TOKEN }}
           yarn workspace @trezor/suite translations:backport-en
           yarn workspace @trezor/suite translations:format
           yarn workspace @trezor/suite translations:extract
           cat packages/suite-data/files/translations/master.json
           yarn workspace @trezor/suite translations:upload --token=${{ secrets.CROWDIN_PERSONAL_TOKEN }}
-          git add . && git commit -m "chore: crowdin translation update" && git push origin trezor-ci/crowdin-sync -f
+          git add . && git commit -m "chore: crowdin translation update" && git push origin ${{ env.BRANCH_NAME }} -f
           gh config set prompt disabled
           gh pr create --repo trezor/trezor-suite --title "Crowdin translations update" --body "Automatically generated PR for updating crowdin translations." --base develop --label translations
         env:
           GITHUB_TOKEN: ${{ secrets.TREZOR_BOT_TOKEN }}
-          CROWDIN_PERSONAL_TOKEN: ${{ secrets.CROWDIN_PERSONAL_TOKEN }}
+          BRANCH_NAME: trezor-ci/crowdin-sync-${{ env.NOW }}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Github checks on Crowdin sync PR often get stuck - waiting for status to be reported. I suspect overuse of the same branch is to blame. Let's try to put date in the branch name.

Also removing CROWDIN_PERSONAL_TOKEN ENV, because it's not used (referenced directly from secrets everywhere)