### PR TITLE
chore(metadata): new data structure in suite

### DIFF
--- a/packages/suite/jest.config.js
+++ b/packages/suite/jest.config.js
@@ -46,7 +46,7 @@ module.exports = {
     coverageThreshold: {
         global: {
             statements: 65,
-            branches: 56,
+            branches: 55,
             functions: 62,
             lines: 66,
         },

--- a/packages/suite/src/actions/suite/__fixtures__/metadataActions.ts
+++ b/packages/suite/src/actions/suite/__fixtures__/metadataActions.ts
@@ -1,38 +1,30 @@
 import { METADATA, SUITE } from 'src/actions/suite/constants';
-import * as metadataActions from 'src/actions/suite/metadataActions';
 
 const setDeviceMetadataKey = [
     {
         description: `Metadata not enabled`,
         initialState: {
-            metadata: { enabled: false },
+            metadata: { enabled: false, providers: [] },
         },
     },
     {
         description: `Device without state`,
         initialState: {
-            metadata: { enabled: true },
+            metadata: { enabled: true, providers: [] },
             device: { state: undefined },
         },
     },
     {
         description: `Device not connected (remembered)`,
         initialState: {
-            metadata: { enabled: true },
+            metadata: { enabled: true, providers: [] },
             device: { state: 'device-state', connected: false, metadata: { status: 'disabled' } },
         },
     },
-    // {
-    //     description: `Device metadata cancelled`,
-    //     initialState: {
-    //         metadata: { enabled: true },
-    //         device: { state: 'device-state', metadata: { status: 'cancelled' } },
-    //     },
-    // },
     {
         description: `Device metadata already enabled`,
         initialState: {
-            metadata: { enabled: true },
+            metadata: { enabled: true, providers: [] },
             device: { state: 'device-state', metadata: { status: 'enabled' } },
         },
     },
@@ -42,7 +34,7 @@ const setDeviceMetadataKey = [
             success: false,
         },
         initialState: {
-            metadata: { enabled: true },
+            metadata: { enabled: true, providers: [] },
             device: { state: 'device-state', connected: true, metadata: { status: 'disabled' } },
         },
         result: [
@@ -69,7 +61,7 @@ const setDeviceMetadataKey = [
     {
         description: `Master key successfully generated`,
         initialState: {
-            metadata: { enabled: true },
+            metadata: { enabled: true, providers: [] },
             device: { state: 'device-state', connected: true, metadata: { status: 'disabled' } },
         },
         result: [
@@ -86,17 +78,20 @@ const setDeviceMetadataKey = [
             },
         ],
     },
-
     {
         description: `Master key successfully generated, provider already connected`,
         initialState: {
             metadata: {
                 enabled: true,
-                provider: {
-                    type: 'dropbox',
-                    user: 'User Name',
-                    tokens: { refreshToken: 'oauth-token' },
-                },
+                selectedProvider: { labels: '' },
+                providers: [
+                    {
+                        type: 'dropbox',
+                        user: 'User Name',
+                        tokens: { refreshToken: 'oauth-token' },
+                        providers: [],
+                    },
+                ],
             },
             device: { state: 'device-state', connected: true, metadata: { status: 'disabled' } },
         },
@@ -106,10 +101,13 @@ const setDeviceMetadataKey = [
                 payload: {
                     deviceState: 'device-state',
                     metadata: {
-                        aesKey: 'bc37a9a8c6cfa6ab2f75b384df2745895d75f2c572a195ccff59ae9958aaf0e8',
-                        fileName:
-                            'c734ff5106c4910aa3444f3672cc2c82d8cb4595f0527be672d8b100ed82908f',
                         key: '20c8bf0701213cdcf4c2f56fd0096c1772322d42fb9c4d0ddf6bb122d713d2f3',
+
+                        1: {
+                            fileName:
+                                'c734ff5106c4910aa3444f3672cc2c82d8cb4595f0527be672d8b100ed82908f',
+                            aesKey: 'bc37a9a8c6cfa6ab2f75b384df2745895d75f2c572a195ccff59ae9958aaf0e8',
+                        },
                         status: 'enabled',
                     },
                 },
@@ -118,9 +116,11 @@ const setDeviceMetadataKey = [
                 type: SUITE.UPDATE_SELECTED_DEVICE,
                 payload: {
                     metadata: {
-                        aesKey: 'bc37a9a8c6cfa6ab2f75b384df2745895d75f2c572a195ccff59ae9958aaf0e8',
-                        fileName:
-                            'c734ff5106c4910aa3444f3672cc2c82d8cb4595f0527be672d8b100ed82908f',
+                        1: {
+                            aesKey: 'bc37a9a8c6cfa6ab2f75b384df2745895d75f2c572a195ccff59ae9958aaf0e8',
+                            fileName:
+                                'c734ff5106c4910aa3444f3672cc2c82d8cb4595f0527be672d8b100ed82908f',
+                        },
                         key: '20c8bf0701213cdcf4c2f56fd0096c1772322d42fb9c4d0ddf6bb122d713d2f3',
                         status: 'enabled',
                     },
@@ -135,7 +135,7 @@ const setAccountMetadataKey = [
     {
         description: `Device without master key`,
         initialState: {
-            device: { metadata: { status: 'disabled' } },
+            device: { metadata: { status: 'disabled', providers: [] } },
         },
         account: { key: 'account-key' },
         result: { key: 'account-key' },
@@ -147,6 +147,7 @@ const setAccountMetadataKey = [
                 metadata: {
                     status: 'enabled',
                     key: '20c8bf0701213cdcf4c2f56fd0096c1772322d42fb9c4d0ddf6bb122d713d2f3',
+                    providers: [],
                 },
             },
         },
@@ -157,33 +158,21 @@ const setAccountMetadataKey = [
         },
         result: {
             metadata: {
-                fileName: '828652b66f2e6f919fbb7fe4c9609d4891ed531c6fac4c28441e53ebe577ac85',
-                aesKey: '9bc3736f0b45cd681854a724b5bba67b9da1e50bc9983fd2dd56e53e74b75480',
+                1: {
+                    fileName:
+                        '828652b66f2e6f919fbb7fe4c9609d4891ed531c6fac4c28441e53ebe577ac85.mtdt',
+                    aesKey: '9bc3736f0b45cd681854a724b5bba67b9da1e50bc9983fd2dd56e53e74b75480',
+                },
             },
         },
     },
 ];
 
 const addDeviceMetadata = [
-    // {
-    //     description: `Without provider`,
-    //     initialState: {
-    //         metadata: {},
-    //     },
-    //     params: {},
-    // },
-    // {
-    //     description: `Unknown provider`,
-    //     initialState: {
-    //         metadata: { provider: { type: 'unknown-provider' } },
-    //     },
-    //     params: {},
-    //     result: undefined,
-    // },
     {
         description: `Without device`,
         initialState: {
-            metadata: { provider: { type: 'dropbox', key: 'A' } },
+            metadata: { selectedProvider: { type: 'dropbox', key: 'A' }, providers: [] },
             device: { state: undefined },
         },
         params: { type: 'walletLabel', deviceState: 'device-state' },
@@ -192,22 +181,22 @@ const addDeviceMetadata = [
     {
         description: `Add walletLabel`,
         initialState: {
-            metadata: { provider: { type: 'dropbox', key: 'A' } },
+            metadata: { selectedProvider: { type: 'dropbox', key: 'A' }, providers: [] },
             device: {
                 state: 'device-state',
                 metadata: {
-                    aesKey: 'eb0f1f0238c7fa8018c6101f4e887b871ce07b99d01d5ea57089b82f93149557',
-                    fileName: '039fe833cba71d84b7bf4c99d44468ee48e311e741cbfcd6daf5263f584ef9f6',
+                    1: {
+                        aesKey: 'eb0f1f0238c7fa8018c6101f4e887b871ce07b99d01d5ea57089b82f93149557',
+                        fileName:
+                            '039fe833cba71d84b7bf4c99d44468ee48e311e741cbfcd6daf5263f584ef9f6',
+                    },
                     key: 'CKValue',
                     status: 'enabled',
                 },
             },
         },
         params: { type: 'walletLabel', deviceState: 'device-state', value: 'Custom label' },
-        result: {
-            type: METADATA.WALLET_ADD,
-            payload: { deviceState: 'device-state', walletLabel: 'Custom label' },
-        },
+        result: {},
     },
 ];
 
@@ -215,7 +204,9 @@ const addAccountMetadata = [
     {
         description: `Without provider`,
         initialState: {
-            metadata: {},
+            metadata: {
+                providers: [],
+            },
         },
         params: {},
         result: undefined,
@@ -223,7 +214,10 @@ const addAccountMetadata = [
     {
         description: `Without account`,
         initialState: {
-            metadata: { provider: { type: 'dropbox', key: 'A' } },
+            metadata: {
+                selectedProvider: { labels: 'clientId' },
+                providers: [{ type: 'dropbox', data: {}, clientId: 'clientId' }],
+            },
         },
         params: {},
         result: undefined,
@@ -231,15 +225,34 @@ const addAccountMetadata = [
     {
         description: `add outputLabel`,
         initialState: {
-            metadata: { provider: { type: 'dropbox', key: 'A' } },
+            metadata: {
+                selectedProvider: { labels: 'clientId' },
+                providers: [
+                    {
+                        type: 'dropbox',
+                        data: {
+                            a: {
+                                outputLabels: {},
+                                addressLabels: {},
+                                accountLabel: '',
+                            },
+                        },
+                        clientId: 'clientId',
+                    },
+                ],
+            },
             device: {
-                metadata: { status: 'enabled', key: 'B' },
+                metadata: {
+                    status: 'enabled',
+                },
             },
             accounts: [
                 {
                     metadata: {
-                        aesKey: '9bc3736f0b45cd681854a724b5bba67b9da1e50bc9983fd2dd56e53e74b75480',
-                        outputLabels: {},
+                        [METADATA.ENCRYPTION_VERSION]: {
+                            aesKey: '9bc3736f0b45cd681854a724b5bba67b9da1e50bc9983fd2dd56e53e74b75480',
+                            fileName: 'a',
+                        },
                     },
                 },
             ],
@@ -250,34 +263,56 @@ const addAccountMetadata = [
             outputIndex: 0,
             value: 'Foo',
         },
-        result: {
-            type: metadataActions.setAccountAdd.type,
-            payload: {
-                metadata: {
-                    outputLabels: {
-                        TXID: {
-                            0: 'Foo',
+        result: [
+            {
+                type: '@metadata/set-data',
+                payload: {
+                    provider: {
+                        type: 'dropbox',
+                        data: { a: { outputLabels: {}, addressLabels: {}, accountLabel: '' } },
+                        clientId: 'clientId',
+                    },
+                    data: {
+                        a: {
+                            outputLabels: { TXID: { '0': 'Foo' } },
+                            addressLabels: {},
+                            accountLabel: '',
                         },
                     },
                 },
             },
-        },
+        ],
     },
     {
         description: `remove outputLabel`,
         initialState: {
-            metadata: { provider: { type: 'dropbox', key: 'A' } },
+            metadata: {
+                selectedProvider: { labels: 'clientId' },
+                providers: [
+                    {
+                        type: 'dropbox',
+                        data: {
+                            'filename-123': {
+                                outputLabels: {
+                                    TXID: {
+                                        0: 'Foo',
+                                    },
+                                },
+                            },
+                        },
+                        clientId: 'clientId',
+                    },
+                ],
+            },
             device: {
                 metadata: { status: 'enabled', key: 'B' },
             },
             accounts: [
                 {
                     metadata: {
-                        aesKey: '9bc3736f0b45cd681854a724b5bba67b9da1e50bc9983fd2dd56e53e74b75480',
-                        outputLabels: {
-                            TXID: {
-                                0: 'Foo',
-                            },
+                        1: {
+                            aesKey: '9bc3736f0b45cd681854a724b5bba67b9da1e50bc9983fd2dd56e53e74b75480',
+                            fileName: 'filename-123',
                         },
                     },
                 },
@@ -289,18 +324,21 @@ const addAccountMetadata = [
             outputIndex: 0,
             value: '', // empty string removes value
         },
-        result: {
-            type: metadataActions.setAccountAdd.type,
-            payload: {
-                metadata: {
-                    outputLabels: {
-                        TXID: {
-                            0: 'Foo',
+        result: [
+            
+                {
+                    payload: {
+                        data: { 'filename-123': { outputLabels: {} } },
+                        provider: {
+                            clientId: 'clientId',
+                            data: { 'filename-123': { outputLabels: { TXID: { '0': 'Foo' } } } },
+                            type: 'dropbox',
                         },
                     },
+                    type: '@metadata/set-data',
                 },
-            },
-        },
+            
+        ],
     },
 ];
 
@@ -317,11 +355,12 @@ const fetchMetadata = [
         initialState: {
             metadata: {
                 enabled: true,
-                provider: {
+                selectedProvider: {
                     tokens: { refreshToken: 'foo' },
                     type: 'google',
                     user: 'batman',
                 },
+                providers: [],
             },
             device: { state: 'device-state', metadata: { status: 'cancelled' } },
             accounts: [],
@@ -333,11 +372,12 @@ const fetchMetadata = [
         initialState: {
             metadata: {
                 enabled: true,
-                provider: {
+                selectedProvider: {
                     type: 'dropbox',
                     user: 'User Name',
                     tokens: { refreshToken: 'oauth-token' },
                 },
+                providers: [],
             },
             device: {
                 state: 'mkUHEWSY9zaq4A4RjicJSPSPPxZ1dr2CfF@B45F1224E1EFDEE921BE328F:undefined',
@@ -368,16 +408,25 @@ const connectProvider = [
         initialState: {
             metadata: undefined,
         },
-        params: 'dropbox',
+        params: { type: 'dropbox' },
         result: [
             {
-                type: '@metadata/set-provider',
+                type: '@metadata/add-provider',
                 payload: {
                     type: 'dropbox',
                     tokens: { refreshToken: 'token-haf-mnau' },
                     user: 'haf',
                     isCloud: true,
+                    clientId: 'wg0yz2pbgjyhoda',
+                    data: {},
                 },
+            },
+            {
+                payload: {
+                    clientId: 'wg0yz2pbgjyhoda',
+                    dataType: 'labels',
+                },
+                type: '@metadata/set-selected-provider',
             },
         ],
     },
@@ -389,7 +438,7 @@ const addMetadata = [
     {
         description: 'device without state',
         initialState: {
-            metadata: { enabled: true },
+            metadata: { enabled: true, providers: [] },
             device: {
                 state: undefined,
             },
@@ -402,11 +451,12 @@ const addMetadata = [
         initialState: {
             metadata: {
                 enabled: true,
-                provider: {
+                selectedProvider: {
                     type: 'dropbox',
                     user: 'User Name',
                     tokens: { refreshToken: 'oauth-token' },
                 },
+                providers: [],
             },
             device: {
                 state: 'mmcGdEpTPqgQNRHqf3gmB5uDsEoPo2d3tp@46CE52D1ED50A900687D6BA2:undefined',
@@ -426,11 +476,12 @@ const addMetadata = [
         initialState: {
             metadata: {
                 enabled: true,
-                provider: {
+                selectedProvider: {
                     type: 'dropbox',
                     user: 'User Name',
                     tokens: { refreshToken: 'oauth-token' },
                 },
+                providers: [],
             },
             device: {
                 state: 'mmcGdEpTPqgQNRHqf3gmB5uDsEoPo2d3tp@46CE52D1ED50A900687D6BA2:undefined',
@@ -451,7 +502,7 @@ export const enableMetadata = [
     {
         description: 'enable metadata',
         initialState: {
-            metadata: { enabled: true },
+            metadata: { enabled: true, providers: [] },
         },
         result: [
             {
@@ -465,7 +516,7 @@ export const disableMetadata = [
     {
         description: 'disable metadata',
         initialState: {
-            metadata: { enabled: true },
+            metadata: { enabled: true, providers: [] },
             device: {
                 state: undefined,
             },
@@ -490,15 +541,37 @@ const init = [
         description: 'metadata already enabled',
         initialState: {
             device: { state: 'device-state', metadata: { status: 'enabled' } },
-            metadata: { enabled: true, provider: { type: 'dropbox' } },
+            metadata: { enabled: true, selectedProvider: {}, providers: [] },
         },
-        result: [],
+        result: [
+            { type: '@metadata/set-initiating', payload: true },
+            {
+                type: '@modal/open-user-context',
+                payload: { type: 'metadata-provider', decision: { promise: {} } },
+            },
+            {
+                type: '@metadata/add-provider',
+                payload: {
+                    type: 'dropbox',
+                    isCloud: true,
+                    tokens: { refreshToken: 'token' },
+                    user: 'power-user',
+                    clientId: 'meow',
+                    data: {},
+                },
+            },
+            {
+                type: '@metadata/set-selected-provider',
+                payload: { dataType: 'labels', clientId: 'wg0yz2pbgjyhoda' },
+            },
+            { type: '@metadata/set-initiating', payload: false },
+        ],
     },
     {
         description: 'metadata not enabled',
         initialState: {
             device: { state: 'device-state', connected: true, metadata: { status: 'disabled' } },
-            metadata: { enabled: false },
+            metadata: { enabled: false, providers: [], selectedProvider: {} },
             suite: { online: true },
         },
         params: true,
@@ -507,32 +580,53 @@ const init = [
             { type: '@metadata/set-initiating', payload: true },
             {
                 type: '@metadata/set-device-metadata',
-                payload: { deviceState: 'device-state' },
-            },
-            {
-                type: '@suite/update-selected-device',
-                payload: { state: 'device-state' },
-            },
-            {
-                type: '@modal/open-user-context',
-                payload: { type: 'metadata-provider' },
-            },
-            {
-                type: '@metadata/set-provider',
                 payload: {
-                    type: 'dropbox',
-                    tokens: { refreshToken: 'token' },
-                    user: 'power-user',
-                    isCloud: true,
+                    deviceState: 'device-state',
+                    metadata: {
+                        '1': {
+                            fileName:
+                                'c734ff5106c4910aa3444f3672cc2c82d8cb4595f0527be672d8b100ed82908f',
+                            aesKey: 'bc37a9a8c6cfa6ab2f75b384df2745895d75f2c572a195ccff59ae9958aaf0e8',
+                        },
+                        status: 'enabled',
+                        key: '20c8bf0701213cdcf4c2f56fd0096c1772322d42fb9c4d0ddf6bb122d713d2f3',
+                    },
                 },
             },
             {
-                type: '@metadata/wallet-loaded',
-                payload: { deviceState: 'device-state', walletLabel: '' },
+                type: '@suite/update-selected-device',
+                payload: {
+                    state: 'device-state',
+                    connected: true,
+                    metadata: {
+                        '1': {
+                            fileName:
+                                'c734ff5106c4910aa3444f3672cc2c82d8cb4595f0527be672d8b100ed82908f',
+                            aesKey: 'bc37a9a8c6cfa6ab2f75b384df2745895d75f2c572a195ccff59ae9958aaf0e8',
+                        },
+                        status: 'enabled',
+                        key: '20c8bf0701213cdcf4c2f56fd0096c1772322d42fb9c4d0ddf6bb122d713d2f3',
+                    },
+                },
             },
             {
-                type: '@suite/update-selected-device',
-                payload: { state: 'device-state' },
+                type: '@modal/open-user-context',
+                payload: { type: 'metadata-provider', decision: { promise: {} } },
+            },
+            {
+                type: '@metadata/add-provider',
+                payload: {
+                    type: 'dropbox',
+                    isCloud: true,
+                    tokens: { refreshToken: 'token' },
+                    user: 'power-user',
+                    clientId: 'meow',
+                    data: {},
+                },
+            },
+            {
+                type: '@metadata/set-selected-provider',
+                payload: { dataType: 'labels', clientId: 'wg0yz2pbgjyhoda' },
             },
             { type: '@metadata/set-initiating', payload: false },
         ],

--- a/packages/suite/src/actions/suite/__fixtures__/metadataActions.ts
+++ b/packages/suite/src/actions/suite/__fixtures__/metadataActions.ts
@@ -325,19 +325,17 @@ const addAccountMetadata = [
             value: '', // empty string removes value
         },
         result: [
-            
-                {
-                    payload: {
-                        data: { 'filename-123': { outputLabels: {} } },
-                        provider: {
-                            clientId: 'clientId',
-                            data: { 'filename-123': { outputLabels: { TXID: { '0': 'Foo' } } } },
-                            type: 'dropbox',
-                        },
+            {
+                payload: {
+                    data: { 'filename-123': { outputLabels: {} } },
+                    provider: {
+                        clientId: 'clientId',
+                        data: { 'filename-123': { outputLabels: { TXID: { '0': 'Foo' } } } },
+                        type: 'dropbox',
                     },
-                    type: '@metadata/set-data',
                 },
-            
+                type: '@metadata/set-data',
+            },
         ],
     },
 ];

--- a/packages/suite/src/actions/suite/__tests__/metadataActions.test.ts
+++ b/packages/suite/src/actions/suite/__tests__/metadataActions.test.ts
@@ -101,7 +101,7 @@ const initStore = (state: State) => {
             // automatically resolve modal decision
             switch (action.payload.type) {
                 case 'metadata-provider':
-                    await store.dispatch(metadataActions.connectProvider('dropbox'));
+                    await store.dispatch(metadataActions.connectProvider({ type: 'dropbox' }));
                     action.payload.decision.resolve(true);
                     break;
                 default:
@@ -163,8 +163,12 @@ describe('Metadata Actions', () => {
             const store = initStore(getInitialState(f.initialState));
             // @ts-expect-error, params
             await store.dispatch(metadataActions.addAccountMetadata(f.params));
+
+            const result = store.getActions();
             if (!f.result) {
-                expect(store.getActions().length).toEqual(0);
+                expect(result.length).toEqual(0);
+            } else {
+                expect(result).toEqual(f.result);
             }
         });
     });
@@ -203,6 +207,7 @@ describe('Metadata Actions', () => {
                             refreshToken: 'token',
                         },
                         user: 'power-user',
+                        clientId: 'meow',
                     },
                 });
 

--- a/packages/suite/src/actions/suite/constants/metadataConstants.ts
+++ b/packages/suite/src/actions/suite/constants/metadataConstants.ts
@@ -1,15 +1,17 @@
+import { MetadataEncryptionVersion } from '@suite-common/metadata-types';
+
 export const ENABLE = '@metadata/enable';
 export const DISABLE = '@metadata/disable';
 export const SET_READY = '@metadata/set-ready';
 export const CANCELLED = '@metadata/cancelled';
 export const SET_DEVICE_METADATA = '@metadata/set-device-metadata';
-export const SET_PROVIDER = '@metadata/set-provider';
-export const WALLET_LOADED = '@metadata/wallet-loaded';
-export const WALLET_ADD = '@metadata/wallet-loaded';
-export const ACCOUNT_LOADED = '@metadata/account-loaded';
+export const ADD_PROVIDER = '@metadata/add-provider';
+export const REMOVE_PROVIDER = '@metadata/remove-provider';
 export const ACCOUNT_ADD = '@metadata/account-add';
 export const SET_EDITING = '@metadata/set-editing';
 export const SET_INITIATING = '@metadata/set-initiating';
+export const SET_DATA = '@metadata/set-data';
+export const SET_SELECTED_PROVIDER = '@metadata/set-selected-provider';
 
 // todo: use in metadataActions, currently migration is not implemented yet
 export const METADATA_VERSION = '2.0.0';
@@ -36,3 +38,5 @@ export const GOOGLE_IMPLICIT_FLOW_CLIENT_ID =
 
 // dropbox allows authorization code flow for both web and desktop without client secret
 export const DROPBOX_CLIENT_ID = 'wg0yz2pbgjyhoda';
+
+export const ENCRYPTION_VERSION: MetadataEncryptionVersion = 1;

--- a/packages/suite/src/actions/suite/metadataActions.ts
+++ b/packages/suite/src/actions/suite/metadataActions.ts
@@ -75,7 +75,10 @@ const createProviderInstance = (
 ) => {
     switch (type) {
         case 'dropbox':
-            return new DropboxProvider({ token: tokens?.refreshToken, clientId: METADATA.DROPBOX_CLIENT_ID });
+            return new DropboxProvider({
+                token: tokens?.refreshToken,
+                clientId: METADATA.DROPBOX_CLIENT_ID,
+            });
         case 'google':
             return new GoogleProvider(tokens, environment);
         case 'fileSystem':
@@ -323,7 +326,11 @@ export const fetchMetadata =
             }
             const { fileName, aesKey } = device.metadata[METADATA.ENCRYPTION_VERSION] || {};
             if (!fileName || !aesKey) {
-                return reject(new Error(`filename or aesKey of version ${METADATA.ENCRYPTION_VERSION} does not exist for device ${device.path}`));
+                return reject(
+                    new Error(
+                        `filename or aesKey of version ${METADATA.ENCRYPTION_VERSION} does not exist for device ${device.path}`,
+                    ),
+                );
             }
             return providerInstance.getFileContent(fileName).then(result => {
                 // ts-stuff
@@ -339,7 +346,7 @@ export const fetchMetadata =
                 const json = { walletLabel: '' };
                 if (result.payload) {
                     try {
-                        const decryptedData =metadataUtils.decrypt(
+                        const decryptedData = metadataUtils.decrypt(
                             metadataUtils.arrayBufferToBuffer(result.payload),
                             aesKey,
                         );
@@ -372,7 +379,9 @@ export const fetchMetadata =
             if (!provider) return; // ts
             const { fileName, aesKey } = account.metadata[METADATA.ENCRYPTION_VERSION] || {};
             if (!fileName || !aesKey) {
-                console.error(`filename or aesKey of version ${METADATA.ENCRYPTION_VERSION} does not exist for account ${account.path}`);
+                console.error(
+                    `filename or aesKey of version ${METADATA.ENCRYPTION_VERSION} does not exist for account ${account.path}`,
+                );
                 return;
             }
             const response = await providerInstance.getFileContent(fileName);
@@ -387,7 +396,7 @@ export const fetchMetadata =
                 try {
                     // we found associated metadata file for given account, decrypt it
                     // and save its metadata into reducer;
-                    const decryptedData =metadataUtils.decrypt(
+                    const decryptedData = metadataUtils.decrypt(
                         metadataUtils.arrayBufferToBuffer(response.payload),
                         aesKey,
                     );
@@ -509,12 +518,11 @@ export const selectProvider =
 export const connectProvider =
     ({ type, dataType = 'labels' }: { type: MetadataProviderType; dataType?: DataType }) =>
     async (dispatch: Dispatch, getState: GetState) => {
-        
         const providerInstance = createProviderInstance(
-                type,
-                {},
-                getState().suite.settings.debug.oauthServerEnvironment,
-            );
+            type,
+            {},
+            getState().suite.settings.debug.oauthServerEnvironment,
+        );
 
         const isConnected = await providerInstance.isConnected();
         if (!isConnected) {
@@ -652,9 +660,11 @@ export const addAccountMetadata =
         const metadata = fileName ? provider.data[fileName] : undefined;
 
         if (!fileName) {
-            throw new Error(`filename of version ${METADATA.ENCRYPTION_VERSION} does not exist for account ${account.path}`);
+            throw new Error(
+                `filename of version ${METADATA.ENCRYPTION_VERSION} does not exist for account ${account.path}`,
+            );
         }
-        
+
         const nextMetadata = metadata
             ? JSON.parse(JSON.stringify(metadata))
             : {

--- a/packages/suite/src/actions/suite/modalActions.ts
+++ b/packages/suite/src/actions/suite/modalActions.ts
@@ -2,6 +2,7 @@ import TrezorConnect, { UI } from '@trezor/connect';
 import { createDeferred, Deferred, DeferredResponse } from '@trezor/utils';
 import { MODAL, SUITE } from 'src/actions/suite/constants';
 import { Route, Dispatch, GetState, TrezorDevice } from 'src/types/suite';
+import { AccountLabels } from 'src/types/suite/metadata';
 import { Account, NetworkSymbol, WalletAccountTransaction } from 'src/types/wallet';
 import { RequestEnableTorResponse } from 'src/components/suite/modals/RequestEnableTor';
 
@@ -35,7 +36,7 @@ export type UserContextPayload =
           value: string;
           accountIndex: number;
           symbol: NetworkSymbol;
-          accountLabel: Account['metadata']['accountLabel'];
+          accountLabel: AccountLabels['accountLabel'];
           isConfirmed?: boolean;
           isCancelable?: boolean;
       }

--- a/packages/suite/src/actions/suite/storageActions.ts
+++ b/packages/suite/src/actions/suite/storageActions.ts
@@ -328,7 +328,11 @@ export const saveMetadata = () => async (_dispatch: Dispatch, getState: GetState
     const { metadata } = getState();
     db.addItem(
         'metadata',
-        { provider: metadata.provider, enabled: metadata.enabled },
+        {
+            providers: metadata.providers,
+            enabled: metadata.enabled,
+            selectedProvider: metadata.selectedProvider,
+        },
         'state',
         true,
     );

--- a/packages/suite/src/actions/suite/suiteActions.ts
+++ b/packages/suite/src/actions/suite/suiteActions.ts
@@ -514,8 +514,6 @@ const actions = [
     SUITE.REMEMBER_DEVICE,
     SUITE.FORGET_DEVICE,
     METADATA.SET_DEVICE_METADATA,
-    METADATA.WALLET_LOADED,
-    METADATA.WALLET_ADD,
     ...Object.values(DEVICE).filter(v => typeof v === 'string'),
 ];
 

--- a/packages/suite/src/actions/wallet/__tests__/discoveryActions.test.ts
+++ b/packages/suite/src/actions/wallet/__tests__/discoveryActions.test.ts
@@ -177,7 +177,7 @@ export const getInitialState = (device = SUITE_DEVICE) => ({
         device,
     },
     devices: [device],
-    metadata: { enabled: false }, // don't use labeling in unit:tests
+    metadata: { enabled: false, providers: [] }, // don't use labeling in unit:tests
     wallet: {
         discovery: discoveryReducer(undefined, { type: 'foo' } as any),
         accounts: accountsReducer(undefined, { type: 'foo' } as any),

--- a/packages/suite/src/actions/wallet/__tests__/publicKeyActions.test.ts
+++ b/packages/suite/src/actions/wallet/__tests__/publicKeyActions.test.ts
@@ -61,17 +61,20 @@ jest.mock('@trezor/connect', () => {
     };
 });
 
+const device = testMocks.getSuiteDevice({
+    state: 'device-state',
+    connected: true,
+    available: true,
+});
+
 const rootReducer = combineReducers({
     suite: createReducer(
         {
-            device: testMocks.getSuiteDevice({
-                state: 'device-state',
-                connected: true,
-                available: true,
-            }),
+            device,
         },
         () => ({}),
     ),
+    devices: createReducer([device], () => {}),
     wallet: combineReducers({
         selectedAccount: createReducer(
             {
@@ -82,7 +85,17 @@ const rootReducer = combineReducers({
             },
             () => ({}),
         ),
+        accounts: createReducer([{ metadata: {}, networkType: 'bitcoin' }], () => {}),
     }),
+
+    metadata: createReducer(
+        {
+            providers: [],
+            selectedProvider: {},
+            enabled: false,
+        },
+        () => ({}),
+    ),
 });
 
 interface StateOverrides {

--- a/packages/suite/src/actions/wallet/coinmarket/__fixtures__/coinmarketCommonActions/accounts.ts
+++ b/packages/suite/src/actions/wallet/coinmarket/__fixtures__/coinmarketCommonActions/accounts.ts
@@ -33,10 +33,10 @@ export const BTC_ACCOUNT: Account = {
     },
     metadata: {
         key: 'C5B245DD2B69C7291',
-        fileName: '',
-        aesKey: '',
-        outputLabels: {},
-        addressLabels: {},
+        1: {
+            fileName: '',
+            aesKey: '',
+        },
     },
     page: undefined,
     misc: undefined,
@@ -70,10 +70,10 @@ export const ETH_ACCOUNT: Account = {
     },
     metadata: {
         key: 'C5B245DD2B69C7291',
-        fileName: '',
-        aesKey: '',
-        outputLabels: {},
-        addressLabels: {},
+        1: {
+            fileName: '',
+            aesKey: '',
+        },
     },
     page: undefined,
     misc: { nonce: '1' },
@@ -107,10 +107,10 @@ export const XRP_ACCOUNT: Account = {
     },
     metadata: {
         key: 'C5B245DD2B69C7291',
-        fileName: '',
-        aesKey: '',
-        outputLabels: {},
-        addressLabels: {},
+        1: {
+            fileName: '',
+            aesKey: '',
+        },
     },
     page: undefined,
     misc: {

--- a/packages/suite/src/actions/wallet/coinmarket/__fixtures__/coinmarketCommonActions/store.ts
+++ b/packages/suite/src/actions/wallet/coinmarket/__fixtures__/coinmarketCommonActions/store.ts
@@ -36,10 +36,10 @@ export const ACCOUNT: Account = {
     },
     metadata: {
         key: 'C5B245DD2B69C7291',
-        fileName: '',
-        aesKey: '',
-        outputLabels: {},
-        addressLabels: {},
+        1: {
+            fileName: '',
+            aesKey: '',
+        },
     },
     page: undefined,
     misc: undefined,

--- a/packages/suite/src/actions/wallet/discoveryActions.ts
+++ b/packages/suite/src/actions/wallet/discoveryActions.ts
@@ -390,7 +390,7 @@ export const start =
         }
 
         const { deviceState, authConfirm } = discovery;
-        const shouldInitMetadata = metadata.enabled;
+        const shouldInitMetadata = metadata.enabled && device.metadata.status === 'disabled';
 
         // start process
         if (

--- a/packages/suite/src/actions/wallet/discoveryActions.ts
+++ b/packages/suite/src/actions/wallet/discoveryActions.ts
@@ -390,7 +390,7 @@ export const start =
         }
 
         const { deviceState, authConfirm } = discovery;
-        const metadataEnabled = metadata.enabled && device.metadata.status === 'disabled';
+        const shouldInitMetadata = metadata.enabled;
 
         // start process
         if (
@@ -399,7 +399,7 @@ export const start =
         ) {
             // metadata are enabled in settings but metadata master key does not exist for this device
             // try to generate device metadata master key if passphrase is not used
-            if (!authConfirm && metadataEnabled) {
+            if (!authConfirm && shouldInitMetadata) {
                 await dispatch(metadataActions.init());
             }
 
@@ -481,7 +481,7 @@ export const start =
         const onBundleProgress = (event: ProgressEvent) => {
             const { progress } = event;
             // pass more parameters to handler
-            dispatch(handleProgress(event, deviceState, bundle[progress], metadataEnabled));
+            dispatch(handleProgress(event, deviceState, bundle[progress], shouldInitMetadata));
         };
 
         TrezorConnect.on<AccountInfo | null>(UI.BUNDLE_PROGRESS, onBundleProgress);
@@ -505,7 +505,7 @@ export const start =
             // try generate metadata keys before next bundle request
             // otherwise metadata request will be processed in `metadataMiddleware` after auth confirmation
             if (
-                metadataEnabled &&
+                shouldInitMetadata &&
                 authConfirm &&
                 currentDiscovery.authConfirm &&
                 result.payload.find(a => a && !a.empty)

--- a/packages/suite/src/actions/wallet/publicKeyActions.ts
+++ b/packages/suite/src/actions/wallet/publicKeyActions.ts
@@ -2,13 +2,14 @@ import * as modalActions from 'src/actions/suite/modalActions';
 import { notificationsActions } from '@suite-common/toast-notifications';
 import { GetState, Dispatch } from 'src/types/suite';
 import TrezorConnect, { Success, Unsuccessful } from '@trezor/connect';
+import { selectLabelingDataForSelectedAccount } from 'src/reducers/suite/metadataReducer';
 
 export const openXpubModal =
     (params?: Pick<Extract<modalActions.UserContextPayload, { type: 'xpub' }>, 'isConfirmed'>) =>
     (dispatch: Dispatch, getState: GetState) => {
         const { device } = getState().suite;
         const { account } = getState().wallet.selectedAccount;
-
+        const { accountLabel } = selectLabelingDataForSelectedAccount(getState());
         if (!device || !account) return;
 
         dispatch(
@@ -18,7 +19,7 @@ export const openXpubModal =
                 value: account.descriptor,
                 accountIndex: account.index,
                 symbol: account.symbol,
-                accountLabel: account.metadata.accountLabel,
+                accountLabel,
                 ...params,
             }),
         );

--- a/packages/suite/src/actions/wallet/selectedAccountActions.ts
+++ b/packages/suite/src/actions/wallet/selectedAccountActions.ts
@@ -158,7 +158,6 @@ const actions = [
     ROUTER.LOCATION_CHANGE,
     SUITE.SELECT_DEVICE,
     SUITE.UPDATE_SELECTED_DEVICE,
-    metadataActions.setAccountLoaded.type,
     metadataActions.setAccountAdd.type,
     accountsActions.createAccount.type,
     accountsActions.removeAccount.type,

--- a/packages/suite/src/components/suite/Labeling/components/AccountLabeling.tsx
+++ b/packages/suite/src/components/suite/Labeling/components/AccountLabeling.tsx
@@ -5,6 +5,7 @@ import { AccountLabel } from 'src/components/suite';
 import { Account as WalletAccount } from 'src/types/wallet';
 import { useSelector } from 'src/hooks/suite';
 import { WalletLabeling } from './WalletLabeling';
+import { selectLabelingDataForAccount } from 'src/reducers/suite/metadataReducer';
 
 interface AccountProps {
     account: WalletAccount | WalletAccount[];
@@ -14,16 +15,18 @@ export const AccountLabeling = ({ account }: AccountProps) => {
     const { device, devices } = useSelector(state => ({
         device: state.suite.device,
         devices: state.devices,
+        metadata: state.metadata,
     }));
     const accounts = !Array.isArray(account) ? [account] : account;
+    const { symbol, index, accountType, key } = accounts[0];
+
+    const labels = useSelector(state => selectLabelingDataForAccount(state, key));
 
     if (accounts.length < 1) return null;
 
-    const { metadata, symbol, index, accountType } = accounts[0];
-
     const accountLabel = (
         <AccountLabel
-            accountLabel={metadata?.accountLabel}
+            accountLabel={labels.accountLabel}
             accountType={accountType}
             symbol={symbol}
             index={index}

--- a/packages/suite/src/components/suite/Labeling/components/WalletLabeling.tsx
+++ b/packages/suite/src/components/suite/Labeling/components/WalletLabeling.tsx
@@ -1,6 +1,9 @@
 import React from 'react';
+
 import { TrezorDevice } from 'src/types/suite';
 import { useTranslation } from 'src/hooks/suite/useTranslation';
+import { useSelector } from 'src/hooks/suite/useSelector';
+import { selectLabelingDataForWallet } from 'src/reducers/suite/metadataReducer';
 
 interface WalletLabellingProps {
     device: TrezorDevice;
@@ -9,10 +12,11 @@ interface WalletLabellingProps {
 
 export const WalletLabeling = ({ device, shouldUseDeviceLabel }: WalletLabellingProps) => {
     const { translationString } = useTranslation();
+    const { walletLabel } = useSelector(state => selectLabelingDataForWallet(state, device.state));
 
-    let label: string | null = null;
-    if (device.metadata.status === 'enabled' && device.metadata.walletLabel) {
-        label = device.metadata.walletLabel;
+    let label: string | undefined;
+    if (device.metadata.status === 'enabled' && walletLabel) {
+        label = walletLabel;
     } else if (device.state) {
         label = device.useEmptyPassphrase
             ? translationString('TR_NO_PASSPHRASE_WALLET')
@@ -22,6 +26,8 @@ export const WalletLabeling = ({ device, shouldUseDeviceLabel }: WalletLabelling
     if (shouldUseDeviceLabel) {
         return <>{`${device.label} ${label}`}</>;
     }
+
+    if (!label) return null;
 
     return <span>{label}</span>;
 };

--- a/packages/suite/src/components/suite/ModalSwitcher/DeviceContextModal.tsx
+++ b/packages/suite/src/components/suite/ModalSwitcher/DeviceContextModal.tsx
@@ -20,6 +20,7 @@ import {
     ConfirmXpub,
 } from 'src/components/suite/modals';
 import { selectSelectedAccount } from 'src/reducers/wallet/selectedAccountReducer';
+import { selectLabelingDataForSelectedAccount } from 'src/reducers/suite/metadataReducer';
 
 import type { ReduxModalProps } from './types';
 
@@ -31,7 +32,7 @@ export const DeviceContextModal = ({
 }: ReduxModalProps<typeof MODAL.CONTEXT_DEVICE>) => {
     const device = useSelector(state => state.suite.device);
     const account = useSelector(selectSelectedAccount);
-
+    const { accountLabel } = useSelector(selectLabelingDataForSelectedAccount);
     const intl = useIntl();
 
     if (!device) return null;
@@ -103,7 +104,7 @@ export const DeviceContextModal = ({
                     value={account.descriptor}
                     symbol={account.symbol}
                     accountIndex={account.index}
-                    accountLabel={account.metadata.accountLabel}
+                    accountLabel={accountLabel}
                     onCancel={abort}
                 />
             ) : null;

--- a/packages/suite/src/components/suite/SwitchDevice/components/WalletInstance.tsx
+++ b/packages/suite/src/components/suite/SwitchDevice/components/WalletInstance.tsx
@@ -11,6 +11,7 @@ import {
 } from 'src/components/suite';
 import { useSelector, useActions } from 'src/hooks/suite';
 import { TrezorDevice, AcquiredDevice } from 'src/types/suite';
+import { selectLabelingDataForWallet } from 'src/reducers/suite/metadataReducer';
 
 import { useFormatters } from '@suite-common/formatters';
 import { Switch, Box, Icon, useTheme, variables } from '@trezor/components';
@@ -124,7 +125,9 @@ export const WalletInstance = ({
     const accountsCount = deviceAccounts.length;
     const instanceBalance = getTotalFiatBalance(deviceAccounts, localCurrency, fiat.coins);
     const isSelected = enabled && selected && !!discoveryProcess;
-
+    const { walletLabel } = useSelector(state =>
+        selectLabelingDataForWallet(state, instance.state),
+    );
     const dataTestBase = `@switch-device/wallet-on-index/${index}`;
 
     return (
@@ -148,9 +151,7 @@ export const WalletInstance = ({
                                     deviceState: instance.state,
                                     defaultValue: instance.state,
                                     value:
-                                        instance?.metadata.status === 'enabled'
-                                            ? instance.metadata.walletLabel
-                                            : '',
+                                        instance?.metadata.status === 'enabled' ? walletLabel : '',
                                 }}
                             />
                         ) : (

--- a/packages/suite/src/components/suite/modals/ReviewTransaction/components/Summary.tsx
+++ b/packages/suite/src/components/suite/modals/ReviewTransaction/components/Summary.tsx
@@ -9,6 +9,7 @@ import { Account, Network } from 'src/types/wallet';
 import { formatDuration, isFeatureFlagEnabled } from '@suite-common/suite-utils';
 import { PrecomposedTransactionFinal, TxFinalCardano } from 'src/types/wallet/sendForm';
 import { useSelector } from 'src/hooks/suite/useSelector';
+import { selectLabelingDataForSelectedAccount } from 'src/reducers/suite/metadataReducer';
 
 const Wrapper = styled.div`
     padding: 20px 15px 12px;
@@ -209,7 +210,7 @@ const Summary = ({
     ) as string;
 
     const theme = useTheme();
-    const { symbol, metadata, accountType, index } = account;
+    const { symbol, accountType, index } = account;
 
     const { feePerByte } = tx;
     const spentWithoutFee = !tx.token ? new BigNumber(tx.totalSpent).minus(tx.fee).toString() : '';
@@ -220,7 +221,7 @@ const Summary = ({
     const formFeeRate = drafts[currentAccountKey]?.feePerUnit;
     const isFeeCustom = drafts[currentAccountKey]?.selectedFee === 'custom';
     const isComposedFeeRateDifferent = isFeeCustom && formFeeRate !== feePerByte;
-
+    const { accountLabel } = useSelector(selectLabelingDataForSelectedAccount);
     return (
         <Wrapper>
             <SummaryHead>
@@ -243,7 +244,7 @@ const Summary = ({
                 <AccountWrapper>
                     <Icon size={12} color={theme.TYPE_DARK_GREY} icon="WALLET" />
                     <AccountLabel
-                        accountLabel={metadata?.accountLabel}
+                        accountLabel={accountLabel}
                         accountType={accountType}
                         symbol={symbol}
                         index={index}

--- a/packages/suite/src/components/suite/modals/confirm/ConfirmXpub.tsx
+++ b/packages/suite/src/components/suite/modals/confirm/ConfirmXpub.tsx
@@ -2,13 +2,14 @@ import React from 'react';
 
 import { Translation } from 'src/components/suite';
 import { ConfirmValueOnDevice, ConfirmDeviceScreenProps } from './ConfirmValueOnDevice';
-import { Account, NetworkSymbol } from 'src/types/wallet/index';
+import { NetworkSymbol } from 'src/types/wallet/index';
+import { AccountLabels } from 'src/types/suite/metadata';
 
 interface ConfirmXpubProps
     extends Pick<ConfirmDeviceScreenProps, 'device' | 'isConfirmed' | 'onCancel' | 'value'> {
     accountIndex: number;
     symbol: NetworkSymbol;
-    accountLabel: Account['metadata']['accountLabel'];
+    accountLabel: AccountLabels['accountLabel'];
 }
 
 export const ConfirmXpub = ({ accountIndex, symbol, accountLabel, ...props }: ConfirmXpubProps) => (

--- a/packages/suite/src/components/suite/modals/metadata/MetadataProvider/index.tsx
+++ b/packages/suite/src/components/suite/modals/metadata/MetadataProvider/index.tsx
@@ -62,7 +62,7 @@ export const MetadataProvider = ({ onCancel, decision }: MetadataProviderProps) 
 
     const connect = async (type: MetadataProviderType) => {
         setIsLoading(type);
-        const result = await connectProvider(type);
+        const result = await connectProvider({ type });
         // window close indicates user action, user knows what happened, no need to show an error message
         if (result === 'window closed') {
             setIsLoading('');

--- a/packages/suite/src/components/wallet/AccountTopPanel/index.tsx
+++ b/packages/suite/src/components/wallet/AccountTopPanel/index.tsx
@@ -16,6 +16,7 @@ import { Stack, SkeletonCircle, SkeletonRectangle } from 'src/components/suite/S
 import { useSelector } from 'src/hooks/suite';
 import { isTestnet } from '@suite-common/wallet-utils';
 import { AccountNavigation } from './AccountNavigation';
+import { selectLabelingDataForSelectedAccount } from 'src/reducers/suite/metadataReducer';
 
 const Balance = styled(H1)`
     height: 32px;
@@ -59,7 +60,7 @@ const AccountTopPanelSkeleton = ({ animate, account, symbol }: AccountTopPanelSk
 
 export const AccountTopPanel = () => {
     const { account, loader, status } = useSelector(state => state.wallet.selectedAccount);
-
+    const selectedAccountLabels = useSelector(selectLabelingDataForSelectedAccount);
     if (status !== 'loaded' || !account) {
         return (
             <AccountTopPanelSkeleton
@@ -82,7 +83,7 @@ export const AccountTopPanel = () => {
                         type: 'accountLabel',
                         accountKey: account.key,
                         defaultValue: account.path,
-                        value: account?.metadata.accountLabel,
+                        value: selectedAccountLabels.accountLabel,
                     }}
                 />
             }

--- a/packages/suite/src/components/wallet/AccountsMenu/AccountItem.tsx
+++ b/packages/suite/src/components/wallet/AccountsMenu/AccountItem.tsx
@@ -4,11 +4,12 @@ import styled from 'styled-components';
 import { isTestnet } from '@suite-common/wallet-utils';
 import { AccountLabel, FiatValue } from 'src/components/suite';
 import { Stack, SkeletonRectangle } from 'src/components/suite/Skeleton';
-import { useActions, useLoadingSkeleton } from 'src/hooks/suite';
+import { useActions, useLoadingSkeleton, useSelector } from 'src/hooks/suite';
 import { CoinBalance } from 'src/components/wallet';
 import { Account } from 'src/types/wallet';
 import * as routerActions from 'src/actions/suite/routerActions';
 import { TokensCount } from './TokensCount';
+import { selectLabelingDataForAccount } from 'src/reducers/suite/metadataReducer';
 
 const activeClassName = 'selected';
 interface WrapperProps {
@@ -115,8 +116,7 @@ export const AccountItem = forwardRef(
 
         const { shouldAnimate } = useLoadingSkeleton();
 
-        const { accountType, formattedBalance, index, metadata, networkType, symbol, tokens } =
-            account;
+        const { accountType, formattedBalance, index, networkType, symbol, tokens } = account;
 
         const accountRouteParams = useMemo(
             () => ({
@@ -144,6 +144,9 @@ export const AccountItem = forwardRef(
         const isBalanceShown = account.backendType !== 'coinjoin' || account.status !== 'initial';
 
         const dataTestKey = `@account-menu/${symbol}/${accountType}/${index}`;
+        const { accountLabel } = useSelector(state =>
+            selectLabelingDataForAccount(state, account.key),
+        );
 
         return (
             <Wrapper selected={selected} type={accountType} ref={ref}>
@@ -161,7 +164,7 @@ export const AccountItem = forwardRef(
                         <Row>
                             <AccountName data-test={`${dataTestKey}/label`}>
                                 <AccountLabel
-                                    accountLabel={metadata.accountLabel}
+                                    accountLabel={accountLabel}
                                     accountType={accountType}
                                     symbol={symbol}
                                     index={index}

--- a/packages/suite/src/components/wallet/AccountsMenu/index.tsx
+++ b/packages/suite/src/components/wallet/AccountsMenu/index.tsx
@@ -11,6 +11,7 @@ import { AccountSearchBox } from './AccountSearchBox';
 import { AccountGroup } from './AccountGroup';
 import { AccountItem } from './AccountItem';
 import { AccountItemSkeleton } from './AccountItemSkeleton';
+import { selectLabelingDataForSelectedAccount } from 'src/reducers/suite/metadataReducer';
 
 const Wrapper = styled.div<{ isInline?: boolean }>`
     display: flex;
@@ -126,6 +127,7 @@ export const AccountsMenu = ({ isMenuInline }: AccountsMenuProps) => {
     const accounts = useSelector(state => state.wallet.accounts);
     const selectedAccount = useSelector(state => state.wallet.selectedAccount);
     const coinjoinIsPreloading = useSelector(state => state.wallet.coinjoin.isPreloading);
+    const { accountLabel } = useSelector(selectLabelingDataForSelectedAccount);
 
     const [isExpanded, setIsExpanded] = useState(false);
     const [animatedIcon, setAnimatedIcon] = useState(false);
@@ -163,7 +165,7 @@ export const AccountsMenu = ({ isMenuInline }: AccountsMenuProps) => {
     const list = sortByCoin(accounts.filter(a => a.deviceState === device.state).concat(failed));
     const filteredAccounts =
         searchString || coinFilter
-            ? list.filter(a => accountSearchFn(a, searchString, coinFilter))
+            ? list.filter(a => accountSearchFn(a, searchString, coinFilter, accountLabel))
             : list;
     // always show first "normal" account even if they are empty
     const normalAccounts = filteredAccounts.filter(

--- a/packages/suite/src/components/wallet/CoinControl/UtxoSelection.tsx
+++ b/packages/suite/src/components/wallet/CoinControl/UtxoSelection.tsx
@@ -18,6 +18,7 @@ import { TransactionTimestamp, UtxoAnonymity } from 'src/components/wallet';
 import { UtxoTag } from 'src/components/wallet/CoinControl/UtxoTag';
 import { useSendFormContext } from 'src/hooks/wallet';
 import { WalletAccountTransaction } from 'src/types/wallet';
+import { selectLabelingDataForSelectedAccount } from 'src/reducers/suite/metadataReducer';
 
 const VisibleOnHover = styled.div<{ alwaysVisible?: boolean }>`
     display: ${({ alwaysVisible }) => (alwaysVisible ? 'contents' : 'none')};
@@ -139,9 +140,8 @@ export const UtxoSelection = ({ isChecked, transaction, utxo }: UtxoSelectionPro
     const coordinatorData = useSelector(state => state.wallet.coinjoin.clients[account.symbol]);
     const device = useSelector(state => state.suite.device);
     // selecting metadata from store rather than send form context which does not update on metadata change
-    const outputLabels = useSelector(
-        state => state.wallet.selectedAccount.account?.metadata.outputLabels,
-    );
+    const { outputLabels } = useSelector(selectLabelingDataForSelectedAccount);
+
     const { openModal } = useActions({
         openModal: modalActions.openModal,
     });

--- a/packages/suite/src/components/wallet/TransactionItem/components/Target.tsx
+++ b/packages/suite/src/components/wallet/TransactionItem/components/Target.tsx
@@ -17,7 +17,7 @@ import { TokenTransferAddressLabel } from './TokenTransferAddressLabel';
 import { TargetAddressLabel } from './TargetAddressLabel';
 import { BaseTargetLayout } from './BaseTargetLayout';
 import { copyToClipboard } from '@trezor/dom-utils';
-import { AccountMetadata } from 'src/types/suite/metadata';
+import { AccountLabels } from 'src/types/suite/metadata';
 import { StyledFormattedCryptoAmount, StyledFormattedNftAmount } from './CommonComponents';
 
 interface BaseTransfer {
@@ -110,7 +110,7 @@ interface TargetProps extends BaseTransfer {
     target: ArrayElement<WalletAccountTransaction['targets']>;
     transaction: WalletAccountTransaction;
     accountKey: string;
-    accountMetadata?: AccountMetadata;
+    accountMetadata?: AccountLabels;
     isActionDisabled?: boolean;
 }
 
@@ -125,7 +125,8 @@ export const Target = ({
     const targetAmount = getTargetAmount(target, transaction);
     const operation = getTxOperation(transaction.type);
     const { addNotification } = useActions({ addNotification: notificationsActions.addToast });
-    const targetMetadata = accountMetadata?.outputLabels?.[transaction.txid]?.[target.n];
+    const { outputLabels } = accountMetadata || {};
+    const targetMetadata = outputLabels?.[transaction.txid]?.[target.n];
 
     return (
         <BaseTargetLayout

--- a/packages/suite/src/components/wallet/TransactionItem/components/TargetAddressLabel.tsx
+++ b/packages/suite/src/components/wallet/TransactionItem/components/TargetAddressLabel.tsx
@@ -3,7 +3,7 @@ import styled from 'styled-components';
 import { WalletAccountTransaction } from 'src/types/wallet';
 import { ArrayElement } from '@trezor/type-utils';
 import { Translation, AddressLabeling } from 'src/components/suite';
-import { AccountMetadata } from 'src/types/suite/metadata';
+import { AccountLabels } from 'src/types/suite/metadata';
 
 const TruncatedSpan = styled.span<{ isBlurred?: boolean }>`
     overflow: hidden;
@@ -13,7 +13,7 @@ const TruncatedSpan = styled.span<{ isBlurred?: boolean }>`
 interface TargetAddressLabelProps {
     target: ArrayElement<WalletAccountTransaction['targets']>;
     type: WalletAccountTransaction['type'];
-    accountMetadata?: AccountMetadata;
+    accountMetadata?: AccountLabels;
 }
 
 export const TargetAddressLabel = ({ target, type, accountMetadata }: TargetAddressLabelProps) => {

--- a/packages/suite/src/components/wallet/TransactionItem/index.tsx
+++ b/packages/suite/src/components/wallet/TransactionItem/index.tsx
@@ -8,7 +8,7 @@ import { Translation } from 'src/components/suite';
 import { useActions } from 'src/hooks/suite';
 import * as modalActions from 'src/actions/suite/modalActions';
 import { formatNetworkAmount, isTestnet, isTxFeePaid } from '@suite-common/wallet-utils';
-import { AccountMetadata } from 'src/types/suite/metadata';
+import { AccountLabels } from 'src/types/suite/metadata';
 import { Network, WalletAccountTransaction } from 'src/types/wallet';
 import { TransactionTypeIcon } from './components/TransactionTypeIcon';
 import { TransactionHeading } from './components/TransactionHeading';
@@ -81,7 +81,7 @@ interface TransactionItemProps {
     transaction: WalletAccountTransaction;
     isPending: boolean;
     isActionDisabled?: boolean; // Used in "chained transactions" transaction detail modal
-    accountMetadata?: AccountMetadata;
+    accountMetadata?: AccountLabels;
     accountKey: string;
     network: Network;
     className?: string;

--- a/packages/suite/src/hooks/wallet/__fixtures__/useSendForm.ts
+++ b/packages/suite/src/hooks/wallet/__fixtures__/useSendForm.ts
@@ -69,6 +69,7 @@ export const BTC_ACCOUNT = {
         formattedBalance: '1000 BTC',
         utxo: Object.values(UTXO),
         history: {},
+        metadata: {},
     },
     network: { networkType: 'bitcoin', symbol: 'btc', decimals: 8, features: ['rbf'] },
 };

--- a/packages/suite/src/hooks/wallet/__tests__/useSendForm.test.tsx
+++ b/packages/suite/src/hooks/wallet/__tests__/useSendForm.test.tsx
@@ -71,7 +71,7 @@ export const getInitialState = ({
     devices: [],
     resize: resizeReducer(undefined, { type: 'foo' } as any),
     guide: {},
-    metadata: { enabled: false },
+    metadata: { enabled: false, providers: [], selectedProvider: {} },
     router: {},
     modal: {},
 });

--- a/packages/suite/src/middlewares/suite/logsMiddleware.ts
+++ b/packages/suite/src/middlewares/suite/logsMiddleware.ts
@@ -90,7 +90,7 @@ const log =
                     }),
                 );
                 break;
-            case METADATA.SET_PROVIDER:
+            case METADATA.ADD_PROVIDER:
                 api.dispatch(
                     addLog({
                         type: action.type,

--- a/packages/suite/src/middlewares/suite/sentryMiddleware.ts
+++ b/packages/suite/src/middlewares/suite/sentryMiddleware.ts
@@ -45,7 +45,7 @@ const breadcrumbActions = [
     discoveryActions.completeDiscovery.type,
     SUITE.UPDATE_SELECTED_DEVICE,
     SUITE.REMEMBER_DEVICE,
-    METADATA.SET_PROVIDER,
+    METADATA.ADD_PROVIDER,
     walletSettingsActions.changeNetworks.type,
     TRANSPORT.START,
     TRANSPORT.ERROR,

--- a/packages/suite/src/middlewares/wallet/storageMiddleware.ts
+++ b/packages/suite/src/middlewares/wallet/storageMiddleware.ts
@@ -55,7 +55,7 @@ const storageMiddleware = (api: MiddlewareAPI<Dispatch, AppState>) => {
                 action.payload.forEach(storageActions.removeAccountWithDependencies(api.getState));
             }
 
-            if (isAnyOf(metadataActions.setAccountLoaded, metadataActions.setAccountAdd)(action)) {
+            if (isAnyOf(metadataActions.setAccountAdd)(action)) {
                 const device = findAccountDevice(action.payload, api.getState().devices);
                 // if device is remembered, and there is a change in account.metadata (metadataActions.setAccountLoaded), update database
                 if (isDeviceRemembered(device)) {
@@ -218,7 +218,8 @@ const storageMiddleware = (api: MiddlewareAPI<Dispatch, AppState>) => {
                 }
                 case METADATA.ENABLE:
                 case METADATA.DISABLE:
-                case METADATA.SET_PROVIDER:
+                case METADATA.ADD_PROVIDER:
+                case METADATA.REMOVE_PROVIDER:
                     api.dispatch(storageActions.saveMetadata());
                     break;
 

--- a/packages/suite/src/reducers/suite/deviceReducer.ts
+++ b/packages/suite/src/reducers/suite/deviceReducer.ts
@@ -379,18 +379,9 @@ const addButtonRequest = (
 
 const setMetadata = (draft: State, state: string, metadata: TrezorDevice['metadata']) => {
     const index = draft.findIndex(d => d.state === state);
-    if (!draft[index]) return;
-    // update state
-    draft[index].metadata = metadata;
-};
-
-const updateMetadata = (draft: State, state: string, walletLabel?: string) => {
-    const index = draft.findIndex(d => d.state === state);
-    if (!draft[index]) return;
-    const { metadata } = draft[index];
-    if (metadata.status !== 'enabled') return;
-    // update state
-    metadata.walletLabel = walletLabel;
+    const device = draft[index];
+    if (!device) return;
+    device.metadata = metadata;
 };
 
 const deviceReducer = (state: State = initialState, action: Action): State =>
@@ -437,10 +428,6 @@ const deviceReducer = (state: State = initialState, action: Action): State =>
                 break;
             case METADATA.SET_DEVICE_METADATA:
                 setMetadata(draft, action.payload.deviceState, action.payload.metadata);
-                break;
-            case METADATA.WALLET_LOADED:
-            case METADATA.WALLET_ADD:
-                updateMetadata(draft, action.payload.deviceState, action.payload.walletLabel);
                 break;
             // no default
         }

--- a/packages/suite/src/reducers/suite/metadataReducer.ts
+++ b/packages/suite/src/reducers/suite/metadataReducer.ts
@@ -98,8 +98,9 @@ export const selectLabelingDataForSelectedAccount = (state: {
     const { selectedAccount } = state.wallet;
 
     const metadataKeys = selectedAccount?.account?.metadata[METADATA.ENCRYPTION_VERSION];
-    if (!metadataKeys || !metadataKeys.fileName || !provider?.data[metadataKeys.fileName])
+    if (!metadataKeys || !metadataKeys.fileName || !provider?.data[metadataKeys.fileName]) {
         return initialAccountLabels;
+    }
 
     return provider.data[metadataKeys.fileName] as AccountLabels;
 };

--- a/packages/suite/src/reducers/wallet/__fixtures__/transactionConstants.ts
+++ b/packages/suite/src/reducers/wallet/__fixtures__/transactionConstants.ts
@@ -67,10 +67,10 @@ export const accounts: CommonAccount[] = [
         },
         metadata: {
             key: 'xpub6DDUPHpUo4pcy43iJeZjbSVWGav1SMMmuWdMHiGtkK8rhKmfbomtkwW6GKs1GGAKehT6QRocrmda3WWxXawpjmwaUHfFRXuKrXSapdckEYF',
-            fileName: '',
-            aesKey: '',
-            outputLabels: {},
-            addressLabels: {},
+            1: {
+                fileName: '',
+                aesKey: '',
+            },
         },
         networkType: 'bitcoin',
         page: {
@@ -139,10 +139,10 @@ export const accounts: CommonAccount[] = [
         },
         metadata: {
             key: 'xpub6Bw885JisRbcKmowfBvMmCxaFHodKn1VpmRmctmJJoM8D4DzyP4qJv8ZdD9V9r3SSGjmK2KJEDnvLH6f1Q4HrobEvnCeKydNvf1eir3RHZk',
-            fileName: '',
-            aesKey: '',
-            outputLabels: {},
-            addressLabels: {},
+            1: {
+                fileName: '',
+                aesKey: '',
+            },
         },
         networkType: 'bitcoin',
         page: {

--- a/packages/suite/src/services/suite/metadata/FileSystemProvider.ts
+++ b/packages/suite/src/services/suite/metadata/FileSystemProvider.ts
@@ -7,6 +7,10 @@ class FileSystemProvider extends AbstractMetadataProvider {
         super('fileSystem');
     }
 
+    get clientId() {
+        return this.type;
+    }
+
     connect() {
         return Promise.resolve(this.ok());
     }
@@ -22,11 +26,12 @@ class FileSystemProvider extends AbstractMetadataProvider {
             isCloud: this.isCloud,
             tokens: {},
             user: '',
+            clientId: this.clientId,
         });
     }
 
     async getFileContent(file: string) {
-        const result = await desktopApi.metadataRead({ file: `${file}.mtdt` });
+        const result = await desktopApi.metadataRead({ file });
         if (!result.success && result.code !== 'ENOENT') {
             return this.error('PROVIDER_ERROR', result.error);
         }
@@ -37,7 +42,7 @@ class FileSystemProvider extends AbstractMetadataProvider {
         const hex = content.toString('hex');
 
         const result = await desktopApi.metadataWrite({
-            file: `${file}.mtdt`,
+            file,
             content: hex,
         });
         if (!result.success) {

--- a/packages/suite/src/services/suite/metadata/GoogleProvider.ts
+++ b/packages/suite/src/services/suite/metadata/GoogleProvider.ts
@@ -9,6 +9,10 @@ class GoogleProvider extends AbstractMetadataProvider {
         GoogleClient.init(tokens, environment);
     }
 
+    get clientId() {
+        return GoogleClient.clientId;
+    }
+
     async connect() {
         try {
             await GoogleClient.authorize();
@@ -36,7 +40,7 @@ class GoogleProvider extends AbstractMetadataProvider {
 
     async getFileContent(file: string) {
         try {
-            const id = await GoogleClient.getIdByName(`${file}.mtdt`);
+            const id = await GoogleClient.getIdByName(file);
             if (!id) {
                 return this.ok(undefined);
             }
@@ -66,12 +70,12 @@ class GoogleProvider extends AbstractMetadataProvider {
         try {
             // search for file by name with forceReload=true parameter to make sure that we do not save
             // two files with the same name but different ids
-            const id = await GoogleClient.getIdByName(`${file}.mtdt`, true);
+            const id = await GoogleClient.getIdByName(file, true);
             if (id) {
                 await GoogleClient.update(
                     {
                         body: {
-                            name: `${file}.mtdt`,
+                            name: file,
                             mimeType: 'text/plain;charset=UTF-8',
                         },
                     },
@@ -83,7 +87,7 @@ class GoogleProvider extends AbstractMetadataProvider {
             await GoogleClient.create(
                 {
                     body: {
-                        name: `${file}.mtdt`,
+                        name: file,
                         mimeType: 'text/plain;charset=UTF-8',
                         parents: ['appDataFolder'],
                     },
@@ -127,6 +131,7 @@ class GoogleProvider extends AbstractMetadataProvider {
                     refreshToken: GoogleClient.refreshToken,
                 },
                 user: response.user.displayName,
+                clientId: this.clientId,
             } as const);
         } catch (err) {
             return this.handleProviderError(err);

--- a/packages/suite/src/storage/CHANGELOG.md
+++ b/packages/suite/src/storage/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Storage changelog
 
+## 38
+
+-   `metadata.provider` replaced with array of `metadata.providers`
+-   `metadata.selectedProvider` field added to select from `metadata.providers`
+-   labeling data are no longer stored with labelable entities (devices, accounts) but are to be found under `metadata.providers[].data`
+-   labeling data (that were previously stored withing accounts/devices object) are not migrated
+    but since data are fetched from providers (which are migrated) it should affect only users that update their suite and use it offline at the same time
+
 ## 37
 
 -   remove persisted coinjoin sessions

--- a/packages/suite/src/storage/index.ts
+++ b/packages/suite/src/storage/index.ts
@@ -4,7 +4,7 @@ import { migrate } from './migrations';
 
 import type { SuiteDBSchema } from './definitions';
 
-const VERSION = 37; // don't forget to add migration and CHANGELOG when changing versions!
+const VERSION = 38; // don't forget to add migration and CHANGELOG when changing versions!
 
 /**
  *  If the object stores don't already exist then creates them.

--- a/packages/suite/src/support/extraDependencies.ts
+++ b/packages/suite/src/support/extraDependencies.ts
@@ -48,7 +48,6 @@ export const extraDependencies: ExtraDependencies = {
         selectDebugSettings: (state: AppState) => state.suite.settings.debug,
     },
     actions: {
-        setAccountLoadedMetadata: metadataActions.setAccountLoaded,
         setAccountAddMetadata: metadataActions.setAccountAdd,
         setWalletSettingsLocalCurrency: walletSettingsActions.setLocalCurrency,
         changeWalletSettingsNetworks: walletSettingsActions.changeNetworks,

--- a/packages/suite/src/utils/suite/analytics.ts
+++ b/packages/suite/src/utils/suite/analytics.ts
@@ -41,7 +41,11 @@ export const getSuiteReadyPayload = (state: AppState) => ({
     screenHeight: getScreenHeight(),
     platformLanguages: getPlatformLanguages().join(','),
     tor: getIsTorEnabled(state.suite.torStatus),
-    labeling: state.metadata.enabled ? state.metadata.provider?.type || 'missing-provider' : '',
+    // todo: duplicated with suite/src/utils/suite/logUtils
+    labeling: state.metadata.enabled
+        ? state.metadata.providers.find(p => p.clientId === state.metadata.selectedProvider.labels)
+              ?.type || 'missing-provider'
+        : '',
     rememberedStandardWallets: state.devices.filter(d => d.remember && d.useEmptyPassphrase).length,
     rememberedHiddenWallets: state.devices.filter(d => d.remember && !d.useEmptyPassphrase).length,
     theme: state.suite.settings.theme.variant,

--- a/packages/suite/src/utils/suite/logsUtils.ts
+++ b/packages/suite/src/utils/suite/logsUtils.ts
@@ -33,6 +33,7 @@ import { accountsActions } from '@suite-common/wallet-core';
 
 import { getPhysicalDeviceUniqueIds } from './device';
 import { discoveryActions } from 'src/actions/wallet/discoveryActions';
+import { selectLabelingDataForWallet } from 'src/reducers/suite/metadataReducer';
 
 export const REDACTED_REPLACEMENT = '[redacted]';
 
@@ -194,7 +195,11 @@ export const getApplicationInfo = (state: AppState, hideSensitiveInfo: boolean) 
     discreetMode: state.wallet.settings.discreetMode,
     tor: getIsTorEnabled(state.suite.torStatus),
     torOnionLinks: state.suite.settings.torOnionLinks,
-    labeling: state.metadata.enabled ? state.metadata.provider?.type || 'missing-provider' : '',
+    // todo: duplicated with suite/src/utils/suite/analytics
+    labeling: state.metadata.enabled
+        ? state.metadata.providers.find(p => p.clientId === state.metadata.selectedProvider.labels)
+              ?.type || 'missing-provider'
+        : '',
     analytics: state.analytics.enabled,
     instanceId: hideSensitiveInfo ? REDACTED_REPLACEMENT : state.analytics.instanceId,
     sessionId: hideSensitiveInfo ? REDACTED_REPLACEMENT : state.analytics.sessionId,
@@ -234,7 +239,7 @@ export const getApplicationInfo = (state: AppState, hideSensitiveInfo: boolean) 
             device.metadata.status === 'enabled'
                 ? hideSensitiveInfo
                     ? REDACTED_REPLACEMENT
-                    : device.metadata.walletLabel
+                    : selectLabelingDataForWallet(state).walletLabel
                 : '',
         connected: device.connected,
         remember: device.remember,

--- a/packages/suite/src/utils/suite/metadata.ts
+++ b/packages/suite/src/utils/suite/metadata.ts
@@ -5,6 +5,7 @@ import * as base58check from 'bs58check';
 
 const CIPHER_TYPE = 'aes-256-gcm';
 const CIPHER_IVSIZE = 96 / 8;
+const AUTH_SIZE = 128 / 8;
 
 export const deriveMetadataKey = (masterKey: string, xpub: string) => {
     const hmac = crypto.createHmac('sha256', Buffer.from(masterKey, 'hex'));
@@ -83,11 +84,10 @@ export const decrypt = (input: Buffer, key: string | Buffer) => {
         key = Buffer.from(key, 'hex');
     }
 
-    const ivsize = CIPHER_IVSIZE;
-    const iv = input.slice(0, ivsize);
+    const iv = input.slice(0, CIPHER_IVSIZE);
     // tag is always 128-bits
-    const authTag = input.slice(ivsize, ivsize + 128 / 8);
-    const cText = input.slice(ivsize + 128 / 8);
+    const authTag = input.slice(CIPHER_IVSIZE, CIPHER_IVSIZE + AUTH_SIZE);
+    const cText = input.slice(CIPHER_IVSIZE + AUTH_SIZE);
     const decipher = crypto.createDecipheriv(CIPHER_TYPE, key, iv);
     const start = decipher.update(cText);
 

--- a/packages/suite/src/utils/suite/storage.ts
+++ b/packages/suite/src/utils/suite/storage.ts
@@ -17,6 +17,7 @@ export const serializeDiscovery = (discovery: Discovery) => ({ ...discovery, run
 export const serializeDevice = (device: AcquiredDevice, forceRemember?: true) => {
     const sd = {
         ...device,
+        metadata: { status: 'disabled' as const },
         path: '',
         remember: true,
         connected: false,

--- a/packages/suite/src/views/settings/general/DisconnectLabelingProvider.tsx
+++ b/packages/suite/src/views/settings/general/DisconnectLabelingProvider.tsx
@@ -7,12 +7,17 @@ import { disconnectProvider } from 'src/actions/suite/metadataActions';
 import { Translation } from 'src/components/suite';
 import { useAnchor } from 'src/hooks/suite/useAnchor';
 import { SettingsAnchor } from 'src/constants/suite/anchors';
+import { selectSelectedProviderForLabels } from 'src/reducers/suite/metadataReducer';
 
 export const DisconnectLabelingProvider = () => {
     const metadata = useSelector(state => state.metadata);
+    const selectedProvider = useSelector(selectSelectedProviderForLabels);
 
     const { anchorRef, shouldHighlight } = useAnchor(SettingsAnchor.LabelingDisconnect);
+
     const dispatch = useDispatch();
+
+    if (!metadata.enabled || !selectedProvider) return null;
 
     return (
         <SectionItem
@@ -22,12 +27,12 @@ export const DisconnectLabelingProvider = () => {
         >
             <TextColumn
                 title={
-                    metadata.provider?.isCloud ? (
+                    selectedProvider.isCloud ? (
                         <Translation
                             id="TR_CONNECTED_TO_PROVIDER"
                             values={{
-                                provider: capitalizeFirstLetter(metadata.provider.type),
-                                user: metadata.provider.user,
+                                provider: capitalizeFirstLetter(selectedProvider.type),
+                                user: selectedProvider.user,
                             }}
                         />
                     ) : (
@@ -35,7 +40,7 @@ export const DisconnectLabelingProvider = () => {
                     )
                 }
                 description={
-                    metadata.provider?.isCloud ? (
+                    selectedProvider.isCloud ? (
                         <Translation id="TR_YOUR_LABELING_IS_SYNCED" />
                     ) : (
                         <Translation id="TR_YOUR_LABELING_IS_SYNCED_LOCALLY" />
@@ -45,7 +50,9 @@ export const DisconnectLabelingProvider = () => {
             <ActionColumn>
                 <ActionButton
                     variant="secondary"
-                    onClick={() => dispatch(disconnectProvider())}
+                    onClick={() =>
+                        dispatch(disconnectProvider({ clientId: metadata.selectedProvider.labels }))
+                    }
                     data-test="@settings/metadata/disconnect-provider-button"
                 >
                     <Translation id="TR_DISCONNECT" />

--- a/packages/suite/src/views/settings/general/SettingsGeneral.tsx
+++ b/packages/suite/src/views/settings/general/SettingsGeneral.tsx
@@ -42,7 +42,7 @@ export const SettingsGeneral = () => {
 
     const isMetadataEnabled = metadata.enabled && !metadata.initiating;
     const isProviderConnected =
-        metadata.enabled && device?.metadata.status === 'enabled' && !!metadata.provider;
+        metadata.enabled && device?.metadata.status === 'enabled' && !!metadata.providers;
 
     return (
         <SettingsLayout data-test="@settings/index">

--- a/packages/suite/src/views/settings/general/SettingsGeneral.tsx
+++ b/packages/suite/src/views/settings/general/SettingsGeneral.tsx
@@ -42,7 +42,7 @@ export const SettingsGeneral = () => {
 
     const isMetadataEnabled = metadata.enabled && !metadata.initiating;
     const isProviderConnected =
-        metadata.enabled && device?.metadata.status === 'enabled' && !!metadata.providers;
+        metadata.enabled && device?.metadata.status === 'enabled' && !!metadata.providers.length;
 
     return (
         <SettingsLayout data-test="@settings/index">

--- a/packages/suite/src/views/wallet/receive/components/UsedAddresses.tsx
+++ b/packages/suite/src/views/wallet/receive/components/UsedAddresses.tsx
@@ -7,6 +7,8 @@ import { formatNetworkAmount } from '@suite-common/wallet-utils';
 import { Network } from 'src/types/wallet';
 import { AppState } from 'src/types/suite';
 import { MetadataAddPayload } from 'src/types/suite/metadata';
+import { useSelector } from 'src/hooks/suite/useSelector';
+import { selectLabelingDataForSelectedAccount } from 'src/reducers/suite/metadataReducer';
 
 const StyledCard = styled(Card)`
     flex-direction: column;
@@ -187,6 +189,7 @@ export const UsedAddresses = ({
     locked,
 }: UsedAddressesProps) => {
     const [limit, setLimit] = useState(DEFAULT_LIMIT);
+    const { addressLabels } = useSelector(selectLabelingDataForSelectedAccount);
 
     if (!account) {
         return null;
@@ -200,7 +203,6 @@ export const UsedAddresses = ({
     }
 
     const { used, unused } = account.addresses;
-    const { addressLabels } = account.metadata;
     // find revealed addresses in `unused` list
     const revealed = unused.reduce((result, addr) => {
         const r = addresses.find(u => u.path === addr.path);

--- a/packages/suite/src/views/wallet/send/index.tsx
+++ b/packages/suite/src/views/wallet/send/index.tsx
@@ -42,7 +42,7 @@ const SendLoaded = ({ children, selectedAccount }: SendLoadedProps) => {
         fees: state.wallet.fees,
         online: state.suite.online,
         sendRaw: state.wallet.send.sendRaw,
-        metadataEnabled: state.metadata.enabled && !!state.metadata.provider,
+        metadataEnabled: state.metadata.enabled && !!state.metadata.providers[0],
         targetAnonymity: selectTargetAnonymityByAccountKey(state, selectedAccount.account.key),
         prison: selectBlockedUtxosByAccountKey(state, selectedAccount.account.key),
     }));

--- a/packages/suite/src/views/wallet/transactions/components/ExportAction.tsx
+++ b/packages/suite/src/views/wallet/transactions/components/ExportAction.tsx
@@ -5,12 +5,14 @@ import { Translation } from 'src/components/suite';
 import { useActions } from 'src/hooks/suite';
 import { SETTINGS } from 'src/config/suite';
 import { useTranslation } from 'src/hooks/suite/useTranslation';
+import { useSelector } from 'src/hooks/suite/useSelector';
 import { notificationsActions } from '@suite-common/toast-notifications';
 import { exportTransactionsThunk, fetchTransactionsThunk } from '@suite-common/wallet-core';
 import { ExportFileType } from '@suite-common/wallet-types';
 import { Account } from 'src/types/wallet';
 import { isFeatureFlagEnabled } from '@suite-common/suite-utils';
 import { getTitleForNetwork, getTitleForCoinjoinAccount } from '@suite-common/wallet-utils';
+import { selectLabelingDataForSelectedAccount } from 'src/reducers/suite/metadataReducer';
 
 export interface ExportActionProps {
     account: Account;
@@ -36,6 +38,8 @@ export const ExportAction = ({ account }: ExportActionProps) => {
         });
     }, [account, translationString]);
 
+    const { accountLabel } = useSelector(selectLabelingDataForSelectedAccount);
+
     const runExport = useCallback(
         async (type: ExportFileType) => {
             if (isExportRunning) {
@@ -59,7 +63,7 @@ export const ExportAction = ({ account }: ExportActionProps) => {
                     noLoading: true,
                     recursive: true,
                 });
-                const accountName = account.metadata.accountLabel || getAccountTitle();
+                const accountName = accountLabel || getAccountTitle();
                 await exportTransactions({ account, accountName, type });
             } catch (error) {
                 console.error('Export transaction failed: ', error);
@@ -79,6 +83,7 @@ export const ExportAction = ({ account }: ExportActionProps) => {
             addToast,
             translationString,
             getAccountTitle,
+            accountLabel,
         ],
     );
 

--- a/packages/suite/src/views/wallet/transactions/components/TransactionList.tsx
+++ b/packages/suite/src/views/wallet/transactions/components/TransactionList.tsx
@@ -24,6 +24,7 @@ import { findAnchorTransactionPage } from 'src/utils/suite/anchor';
 import { fetchTransactionsThunk } from '@suite-common/wallet-core';
 import { CoinjoinBatchItem } from 'src/components/wallet/TransactionItem/components/CoinjoinBatchItem';
 import { TransactionCandidates } from './TransactionCandidates';
+import { selectLabelingDataForAccount } from 'src/reducers/suite/metadataReducer';
 
 const StyledSection = styled(Section)`
     margin-bottom: 20px;
@@ -50,7 +51,7 @@ export const TransactionList = ({
         localCurrency: state.wallet.settings.localCurrency,
         anchor: state.router.anchor,
     }));
-
+    const accountMetadata = useSelector(state => selectLabelingDataForAccount(state, account.key));
     const network = getAccountNetwork(account);
 
     // Search
@@ -66,11 +67,11 @@ export const TransactionList = ({
 
     useDebounce(
         () => {
-            const results = advancedSearchTransactions(transactions, account.metadata, search);
+            const results = advancedSearchTransactions(transactions, accountMetadata, search);
             setSearchedTransactions(results);
         },
         200,
-        [transactions, account.metadata, search],
+        [transactions, account.metadata, search, accountMetadata],
     );
 
     useEffect(() => {
@@ -151,7 +152,7 @@ export const TransactionList = ({
                                     key={item.tx.txid}
                                     transaction={item.tx}
                                     isPending={isPending}
-                                    accountMetadata={account.metadata}
+                                    accountMetadata={accountMetadata}
                                     accountKey={account.key}
                                     network={network!}
                                     index={index}
@@ -161,7 +162,7 @@ export const TransactionList = ({
                     </TransactionsGroup>
                 );
             }),
-        [transactionsByDate, account.key, account.metadata, localCurrency, symbol, network],
+        [transactionsByDate, account.key, localCurrency, symbol, network, accountMetadata],
     );
 
     // if total pages cannot be determined check current page and number of txs (XRP)

--- a/suite-common/metadata-types/src/metadataTypes.ts
+++ b/suite-common/metadata-types/src/metadataTypes.ts
@@ -1,3 +1,14 @@
+export interface LabelableEntityKeys {
+    fileName: string; // file name in data provider
+    aesKey: string; // symmetric key for file encryption
+}
+
+export type LabelableEntityKeysByVersion = {
+    [Version in MetadataEncryptionVersion]?: LabelableEntityKeys;
+} & {
+    key: string; // legacy xpub format (btc-like coins) or account descriptor (other coins)
+};
+
 export type MetadataAddPayload =
     | {
           type: 'outputLabel';
@@ -38,19 +49,6 @@ export type MetadataProviderType = 'dropbox' | 'google' | 'fileSystem' | 'sdCard
 export type Tokens = {
     accessToken?: string;
     refreshToken?: string;
-};
-
-/**
- * Representation of provider data stored in reducer
- * properties 'tokens' and 'type' are needed to recreate corresponding provider instance
- * others may be used in UI
- */
-
-export type MetadataProvider = {
-    type: MetadataProviderType;
-    user: string;
-    tokens: Tokens;
-    isCloud: boolean;
 };
 
 /**
@@ -106,7 +104,7 @@ export abstract class AbstractMetadataProvider {
     /**
      * Get details if provider that are supposed to be saved in reducer
      */
-    abstract getProviderDetails(): Result<MetadataProvider>;
+    abstract getProviderDetails(): Result<Omit<MetadataProvider, 'data'>>;
     /**
      * For given filename download metadata file from provider
      */
@@ -143,30 +141,60 @@ export abstract class AbstractMetadataProvider {
     }
 }
 
-export interface AccountMetadata {
-    key: string; // legacy xpub format (btc-like coins) or account descriptor (other coins)
-    fileName: string; // file name in dropbox
-    aesKey: string; // asymmetric key for file encryption
+export interface AccountLabels {
     accountLabel?: MetadataItem;
     outputLabels: { [txid: string]: { [index: string]: MetadataItem } };
     addressLabels: { [address: string]: MetadataItem };
 }
 
+export interface WalletLabels {
+    walletLabel?: string;
+}
+
+export type Labels = AccountLabels | WalletLabels;
+
 export type DeviceMetadata =
     | {
           status: 'disabled' | 'cancelled'; // user rejects "Enable labeling" on device
       }
-    | {
+    | ({
           status: 'enabled';
-          key: string; // master key for all values (Device and Account)
-          fileName: string; // file name in dropbox
-          aesKey: string; // asymmetric key for file encryption
-          walletLabel?: string;
-      };
+      } & LabelableEntityKeysByVersion);
+
+type Data = Record<
+    LabelableEntityKeys['fileName'], // unique "id" for mapping with labelable entitties
+    Labels
+>;
+
+/**
+ * DataType dictates shape of data.
+ * in the future, it could be
+ * 'labels' | 'passwords' | 'contacts'...
+ */
+export type DataType = 'labels';
+
+/**
+ * Representation of provider data stored in reducer
+ * properties 'tokens' and 'type' are needed to recreate corresponding provider instance
+ * others may be used in UI
+ */
+export type MetadataProvider = {
+    type: MetadataProviderType;
+    user: string;
+    tokens: Tokens;
+    isCloud: boolean;
+    // decrypted content of data per provider
+    data: Data;
+    clientId: string;
+};
 
 export interface MetadataState {
     enabled: boolean; // global for all devices
-    provider?: MetadataProvider;
+    providers: MetadataProvider[];
+    // being selected means:
+    // - see data from this provider
+    // - save data to this provider when making changes
+    selectedProvider: { [key in DataType]: MetadataProvider['clientId'] };
     // is there active inline input? only one may be active at time so we save this
     // information in reducer to make it easily accessible in UI.
     // field shall hold default value for which user may add metadata (address, txId, etc...);
@@ -175,3 +203,4 @@ export interface MetadataState {
 }
 
 export type OAuthServerEnvironment = 'production' | 'staging' | 'localhost';
+export type MetadataEncryptionVersion = 1 | 2;

--- a/suite-common/redux-utils/src/extraDependenciesType.ts
+++ b/suite-common/redux-utils/src/extraDependenciesType.ts
@@ -39,7 +39,6 @@ export type ExtraDependencies = {
     // That means you will need to convert actual action creators in packages/suite to use createAction from redux-toolkit,
     // but that shouldn't be problem.
     actions: {
-        setAccountLoadedMetadata: ActionCreatorWithPreparedPayload<[payload: Account], Account>;
         setAccountAddMetadata: ActionCreatorWithPreparedPayload<[payload: Account], Account>;
         setWalletSettingsLocalCurrency:
             | ActionCreatorWithPreparedPayload<

--- a/suite-common/test-utils/src/extraDependenciesMock.ts
+++ b/suite-common/test-utils/src/extraDependenciesMock.ts
@@ -72,7 +72,6 @@ export const extraDependenciesMock: ExtraDependencies = {
         }),
     },
     actions: {
-        setAccountLoadedMetadata: mockAction('setAccountLoadedMetadata'),
         setAccountAddMetadata: mockAction('setAccountAddMetadata'),
         setWalletSettingsLocalCurrency: mockAction('setWalletSettingsLocalCurrency'),
         changeWalletSettingsNetworks: mockAction('changeWalletSettingsNetworks'),

--- a/suite-common/wallet-core/src/accounts/accountsActions.ts
+++ b/suite-common/wallet-core/src/accounts/accountsActions.ts
@@ -80,11 +80,6 @@ const createAccount = createAction(
             history: accountInfo.history,
             metadata: {
                 key: accountInfo.legacyXpub || accountInfo.descriptor,
-                fileName: '',
-                aesKey: '',
-                accountLabel,
-                outputLabels: {},
-                addressLabels: {},
             },
             imported,
             ...getAccountSpecific(accountInfo, discoveryItem.networkType),

--- a/suite-common/wallet-core/src/accounts/accountsActions.ts
+++ b/suite-common/wallet-core/src/accounts/accountsActions.ts
@@ -1,12 +1,7 @@
 import { createAction } from '@reduxjs/toolkit';
 
 import { AccountInfo } from '@trezor/connect';
-import {
-    Account,
-    SelectedAccountStatus,
-    DiscoveryItem,
-    MetadataItem,
-} from '@suite-common/wallet-types';
+import { Account, SelectedAccountStatus, DiscoveryItem } from '@suite-common/wallet-types';
 import {
     enhanceAddresses,
     enhanceTokens,
@@ -41,7 +36,7 @@ const createAccount = createAction(
         discoveryItem: DiscoveryItem,
         accountInfo: AccountInfo,
         imported?: boolean,
-        accountLabel?: MetadataItem,
+        accountLabel?: string,
     ): { payload: Account } => ({
         payload: {
             deviceState,
@@ -81,6 +76,7 @@ const createAccount = createAction(
             metadata: {
                 key: accountInfo.legacyXpub || accountInfo.descriptor,
             },
+            accountLabel,
             imported,
             ...getAccountSpecific(accountInfo, discoveryItem.networkType),
         },

--- a/suite-common/wallet-core/src/accounts/accountsReducer.ts
+++ b/suite-common/wallet-core/src/accounts/accountsReducer.ts
@@ -83,7 +83,7 @@ export const prepareAccountsReducer = createReducerWithExtraDeps(
             .addCase(accountsActions.renameAccount, (state, action) => {
                 const { accountKey, accountLabel } = action.payload;
                 const accountByAccountKey = state.find(account => account.key === accountKey);
-                if (accountByAccountKey) accountByAccountKey.metadata.accountLabel = accountLabel;
+                if (accountByAccountKey) accountByAccountKey.accountLabel = accountLabel;
             })
             .addCase(accountsActions.changeAccountVisibility, (state, action) => {
                 update(state, action.payload);
@@ -167,7 +167,7 @@ export const selectAccountLabel = (
 
     if (!account) return null;
 
-    return account.metadata.accountLabel ?? null;
+    return account.accountLabel ?? null;
 };
 
 export const selectAccountNetworkSymbol = (

--- a/suite-common/wallet-core/src/accounts/accountsReducer.ts
+++ b/suite-common/wallet-core/src/accounts/accountsReducer.ts
@@ -102,16 +102,10 @@ export const prepareAccountsReducer = createReducerWithExtraDeps(
                 }
             })
             .addCase(extra.actionTypes.storageLoad, extra.reducers.storageLoadAccounts)
-            .addMatcher(
-                isAnyOf(
-                    extra.actions.setAccountLoadedMetadata,
-                    extra.actions.setAccountAddMetadata,
-                ),
-                (state, action) => {
-                    const { payload } = action;
-                    setMetadata(state, payload);
-                },
-            );
+            .addMatcher(isAnyOf(extra.actions.setAccountAddMetadata), (state, action) => {
+                const { payload } = action;
+                setMetadata(state, payload);
+            });
     },
 );
 

--- a/suite-common/wallet-core/src/transactions/transactionsThunks.ts
+++ b/suite-common/wallet-core/src/transactions/transactionsThunks.ts
@@ -228,26 +228,31 @@ export const exportTransactionsThunk = createThunk(
         // Get state of transactions
         const allTransactions = selectTransactions(getState());
         const localCurrency = selectors.selectLocalCurrency(getState());
-        
-        const provider = getState().metadata.providers.find(p => p.clientId === state.metadata.selectedProvider.labels);
+
+        // TODO: this is not nice (copy-paste)
+        // metadata reducer is still not part of trezor-common and I can not import it
+        // here. so either followup, or maybe when I have a moment I'll refactor it  before merging this
+        // eslint-disable-next-line no-restricted-syntax
+        const provider = getState().metadata.providers.find(
+            // @ts-expect-error
+            // eslint-disable-next-line no-restricted-syntax
+            p => p.clientId === getState().metadata.selectedProvider.labels,
+        );
         const metadataKeys = account?.metadata[1];
         let labels = {};
         if (!metadataKeys || !metadataKeys?.fileName || !provider?.data[metadataKeys.fileName]) {
-            labels={outputLabels:{}};
-        }  else {
+            labels = { outputLabels: {} };
+        } else {
             labels = provider.data[metadataKeys.fileName];
         }
 
-        const transactions = getAccountTransactions(
-            account.key,
-            allTransactions,
-        )
+        const transactions = getAccountTransactions(account.key, allTransactions)
             .filter(transaction => transaction.blockHeight !== -1)
             .map(transaction => ({
                 ...transaction,
                 targets: transaction.targets.map(target => ({
                     ...target,
-                    // @ts-ignore
+                    // @ts-expect-error
                     metadataLabel: labels.outputLabels?.[transaction.txid]?.[target.n],
                 })),
             }));

--- a/suite-common/wallet-core/src/transactions/transactionsThunks.ts
+++ b/suite-common/wallet-core/src/transactions/transactionsThunks.ts
@@ -228,17 +228,27 @@ export const exportTransactionsThunk = createThunk(
         // Get state of transactions
         const allTransactions = selectTransactions(getState());
         const localCurrency = selectors.selectLocalCurrency(getState());
+        
+        const provider = getState().metadata.providers.find(p => p.clientId === state.metadata.selectedProvider.labels);
+        const metadataKeys = account?.metadata[1];
+        let labels = {};
+        if (!metadataKeys || !metadataKeys?.fileName || !provider?.data[metadataKeys.fileName]) {
+            labels={outputLabels:{}};
+        }  else {
+            labels = provider.data[metadataKeys.fileName];
+        }
+
         const transactions = getAccountTransactions(
             account.key,
             allTransactions,
-            // add metadata directly to transactions
         )
             .filter(transaction => transaction.blockHeight !== -1)
             .map(transaction => ({
                 ...transaction,
                 targets: transaction.targets.map(target => ({
                     ...target,
-                    metadataLabel: account.metadata?.outputLabels?.[transaction.txid]?.[target.n],
+                    // @ts-ignore
+                    metadataLabel: labels.outputLabels?.[transaction.txid]?.[target.n],
                 })),
             }));
 

--- a/suite-common/wallet-types/package.json
+++ b/suite-common/wallet-types/package.json
@@ -11,6 +11,7 @@
     },
     "dependencies": {
         "@suite-common/intl-types": "workspace:*",
+        "@suite-common/metadata-types": "workspace:*",
         "@suite-common/suite-config": "workspace:*",
         "@suite-common/wallet-config": "workspace:*",
         "@suite-common/wallet-constants": "workspace:*",

--- a/suite-common/wallet-types/src/account.ts
+++ b/suite-common/wallet-types/src/account.ts
@@ -1,4 +1,5 @@
 import { Network, BackendType, NetworkSymbol } from '@suite-common/wallet-config';
+import { LabelableEntityKeysByVersion } from '@suite-common/metadata-types';
 import { AccountInfo, PROTO, TokenInfo } from '@trezor/connect';
 
 export type MetadataItem = string;
@@ -11,15 +12,6 @@ export type TokenInfoBranded = TokenInfo & {
     symbol: TokenSymbol;
     contract: TokenAddress;
 };
-
-export interface AccountMetadata {
-    key: string; // legacy xpub format (btc-like coins) or account descriptor (other coins)
-    fileName: string; // file name in dropbox
-    aesKey: string; // asymmetric key for file encryption
-    accountLabel?: MetadataItem;
-    outputLabels: { [txid: string]: { [index: string]: MetadataItem } };
-    addressLabels: { [address: string]: MetadataItem };
-}
 
 type AccountNetworkSpecific =
     | {
@@ -87,7 +79,7 @@ export type Account = {
     addresses?: AccountInfo['addresses'];
     utxo: AccountInfo['utxo'];
     history: AccountInfo['history'];
-    metadata: AccountMetadata;
+    metadata: LabelableEntityKeysByVersion;
 } & AccountBackendSpecific &
     AccountNetworkSpecific;
 

--- a/suite-common/wallet-types/src/account.ts
+++ b/suite-common/wallet-types/src/account.ts
@@ -80,6 +80,11 @@ export type Account = {
     utxo: AccountInfo['utxo'];
     history: AccountInfo['history'];
     metadata: LabelableEntityKeysByVersion;
+    /**
+     * accountLabel was introduced by mobile app. In early stage of developement, it was not possible to connect device and work with
+     * metadata/labeling feature which requires device for encryption. local accountLabel field was introduced.
+     */
+    accountLabel?: string;
 } & AccountBackendSpecific &
     AccountNetworkSpecific;
 

--- a/suite-common/wallet-types/tsconfig.json
+++ b/suite-common/wallet-types/tsconfig.json
@@ -3,6 +3,7 @@
     "compilerOptions": { "outDir": "libDev" },
     "references": [
         { "path": "../intl-types" },
+        { "path": "../metadata-types" },
         { "path": "../suite-config" },
         { "path": "../wallet-config" },
         { "path": "../wallet-constants" },

--- a/suite-common/wallet-utils/src/__fixtures__/searchTransactions.json
+++ b/suite-common/wallet-utils/src/__fixtures__/searchTransactions.json
@@ -1,8 +1,5 @@
 {
-    "metadata": {
-        "key": "tpubDCZB6sR48s4T5Cr8qHUYSZEFCQMMHRg8AoVKVmvcAP5bRw7ArDKeoNwKAJujV3xCPkBvXH5ejSgbgyN6kREmF7sMd41NdbuHa8n1DZNxSMg",
-        "fileName": "7061500d8482d422b07cbd59784db51ae60f72a5c25f47d3d344888585e0c37d",
-        "aesKey": "16994717c3c3a64fefd0725e4e4599826ea82bdc1b56c3cf664541c83ccef7d4",
+    "labels": {
         "outputLabels": {
             "62431e78bb13a4fdd9c87517db1ea70b4cb5763227327da35748c96497c6ea9a": { "0": "Potato" },
             "f5cea29dec1d4e8b83a81b61627caf36adc33085284bde2969ae5beb75bd413c": { "1": "Onions" },

--- a/suite-common/wallet-utils/src/__tests__/accountUtils.test.ts
+++ b/suite-common/wallet-utils/src/__tests__/accountUtils.test.ts
@@ -191,6 +191,7 @@ describe('account utils', () => {
                     aesKey: 'foo',
                 },
             },
+            accountLabel: 'meow',
         });
 
         expect(accountSearchFn(btcAcc, 'btc')).toBe(true);
@@ -209,6 +210,7 @@ describe('account utils', () => {
         expect(accountSearchFn(btcAcc, 'ltc')).toBe(false);
         expect(accountSearchFn(btcAcc, 'litecoin')).toBe(false);
         expect(accountSearchFn(btcAcc, 'meow')).toBe(true);
+        expect(accountSearchFn(btcAcc, 'wuff', undefined, 'wuff')).toBe(true);
         expect(accountSearchFn(btcAcc, 'meo')).toBe(true);
         expect(accountSearchFn(btcAcc, 'eow')).toBe(true);
         expect(accountSearchFn(btcAcc, 'MEOW')).toBe(true);

--- a/suite-common/wallet-utils/src/__tests__/accountUtils.test.ts
+++ b/suite-common/wallet-utils/src/__tests__/accountUtils.test.ts
@@ -186,11 +186,10 @@ describe('account utils', () => {
             accountType: 'legacy',
             metadata: {
                 key: 'xpub-foo-bar',
-                fileName: '123',
-                aesKey: 'foo',
-                accountLabel: 'meow',
-                outputLabels: {},
-                addressLabels: {},
+                1: {
+                    fileName: '123',
+                    aesKey: 'foo',
+                },
             },
         });
 

--- a/suite-common/wallet-utils/src/__tests__/transactionUtils.test.ts
+++ b/suite-common/wallet-utils/src/__tests__/transactionUtils.test.ts
@@ -1,5 +1,4 @@
 import { WalletAccountTransaction } from '@suite-common/wallet-types';
-import { AccountMetadata } from '@suite-common/metadata-types';
 import { testMocks } from '@suite-common/test-utils';
 
 import * as fixtures from '../__fixtures__/transactionUtils';
@@ -165,7 +164,7 @@ describe('transaction utils', () => {
     });
 
     const transactions = stMock.transactions as WalletAccountTransaction[];
-    const metadata = stMock.metadata as AccountMetadata;
+    const metadata = stMock.labels;
     fixtures.searchTransactions.forEach(f => {
         it(`searchTransactions - ${f.description}`, () => {
             const search = advancedSearchTransactions(transactions, metadata, f.search);

--- a/suite-common/wallet-utils/src/accountUtils.ts
+++ b/suite-common/wallet-utils/src/accountUtils.ts
@@ -684,7 +684,7 @@ export const accountSearchFn = (
     account: Account,
     rawSearchString?: string,
     coinFilter?: NetworkSymbol,
-    accountLabel?: string,
+    metadataAccountLabel?: string,
 ) => {
     // if coin filter is active and account symbol doesn't match return false and don't continue the search
     const coinFilterMatch = coinFilter ? account.symbol === coinFilter : true;
@@ -712,7 +712,8 @@ export const accountSearchFn = (
     const matchXRPAlternativeName =
         network?.networkType === 'ripple' && 'ripple'.includes(searchString);
 
-    const metadataMatch = accountLabel?.toLowerCase().includes(searchString);
+    const metadataMatch = !!metadataAccountLabel?.toLowerCase().includes(searchString);
+    const accountLabelMatch = !!account.accountLabel?.toLowerCase().includes(searchString);
 
     return (
         symbolMatch ||
@@ -721,7 +722,8 @@ export const accountSearchFn = (
         descriptorMatch ||
         addressMatch ||
         matchXRPAlternativeName ||
-        metadataMatch
+        metadataMatch ||
+        accountLabelMatch
     );
 };
 

--- a/suite-common/wallet-utils/src/accountUtils.ts
+++ b/suite-common/wallet-utils/src/accountUtils.ts
@@ -669,10 +669,6 @@ export const getFailedAccounts = (discovery: Discovery): Account[] =>
             },
             metadata: {
                 key: descriptor,
-                fileName: '',
-                aesKey: '',
-                outputLabels: {},
-                addressLabels: {},
             },
             ...getAccountSpecific({}, getNetwork(f.symbol)!.networkType),
         };
@@ -688,6 +684,7 @@ export const accountSearchFn = (
     account: Account,
     rawSearchString?: string,
     coinFilter?: NetworkSymbol,
+    accountLabel?: string,
 ) => {
     // if coin filter is active and account symbol doesn't match return false and don't continue the search
     const coinFilterMatch = coinFilter ? account.symbol === coinFilter : true;
@@ -715,7 +712,7 @@ export const accountSearchFn = (
     const matchXRPAlternativeName =
         network?.networkType === 'ripple' && 'ripple'.includes(searchString);
 
-    const metadataMatch = account.metadata.accountLabel?.toLowerCase().includes(searchString);
+    const metadataMatch = accountLabel?.toLowerCase().includes(searchString);
 
     return (
         symbolMatch ||

--- a/suite-common/wallet-utils/src/transactionUtils.ts
+++ b/suite-common/wallet-utils/src/transactionUtils.ts
@@ -7,7 +7,6 @@ import {
     RbfTransactionParams,
     WalletAccountTransaction,
 } from '@suite-common/wallet-types';
-import { AccountMetadata } from '@suite-common/metadata-types';
 import {
     AccountAddress,
     AccountTransaction,
@@ -16,6 +15,7 @@ import {
 } from '@trezor/connect';
 import { SignOperator } from '@suite-common/suite-types';
 import { arrayPartition } from '@trezor/utils';
+import { AccountLabels } from '@suite-common/metadata-types';
 
 import { formatAmount, formatNetworkAmount } from './accountUtils';
 import { toFiatCurrency } from './fiatConverterUtils';
@@ -650,7 +650,7 @@ const groupTransactionIdsByAddress = (transactions: WalletAccountTransaction[]) 
     return addresses;
 };
 
-const groupTransactionsByLabel = (accountMetadata: AccountMetadata) => {
+const groupTransactionsByLabel = (accountMetadata: AccountLabels) => {
     const labels: { [label: string]: string[] } = {};
     const { outputLabels } = accountMetadata;
 
@@ -667,7 +667,7 @@ const groupTransactionsByLabel = (accountMetadata: AccountMetadata) => {
     return labels;
 };
 
-const groupAddressesByLabel = (accountMetadata: AccountMetadata) => {
+const groupAddressesByLabel = (accountMetadata: AccountLabels) => {
     const labels: { [label: string]: string[] } = {};
     const { addressLabels } = accountMetadata;
 
@@ -727,7 +727,7 @@ const numberSearchFilter = (
 const searchDateRegex = new RegExp(/^[0-9]{4}-[0-9]{2}-[0-9]{2}$/);
 export const simpleSearchTransactions = (
     transactions: WalletAccountTransaction[],
-    accountMetadata: AccountMetadata,
+    accountMetadata: AccountLabels,
     search: string,
 ) => {
     // Trim
@@ -844,7 +844,7 @@ export const simpleSearchTransactions = (
 
 export const advancedSearchTransactions = (
     transactions: WalletAccountTransaction[],
-    accountMetadata: AccountMetadata,
+    accountMetadata: AccountLabels,
     search: string,
 ) => {
     // No AND/OR operators, just run a simple search

--- a/suite-native/accounts/src/components/AccountListItem.tsx
+++ b/suite-native/accounts/src/components/AccountListItem.tsx
@@ -45,7 +45,7 @@ export const valuesContainerStyle = prepareNativeStyle(utils => ({
 
 export const AccountListItem = ({ account, areTokensDisplayed = false }: AccountListItemProps) => {
     const { applyStyle } = useNativeStyles();
-    const { accountLabel } = account.metadata;
+    const { accountLabel } = account;
 
     const formattedAccountType = useSelector((state: AccountsRootState) =>
         selectFormattedAccountType(state, account.key),

--- a/yarn.lock
+++ b/yarn.lock
@@ -6750,6 +6750,7 @@ __metadata:
   resolution: "@suite-common/wallet-types@workspace:suite-common/wallet-types"
   dependencies:
     "@suite-common/intl-types": "workspace:*"
+    "@suite-common/metadata-types": "workspace:*"
     "@suite-common/suite-config": "workspace:*"
     "@suite-common/wallet-config": "workspace:*"
     "@suite-common/wallet-constants": "workspace:*"


### PR DESCRIPTION
based on #6579 could be helpful for #8567

### Overview

- allows connecting multiple providers. this can be useful for migration between providers, or when we decide to support multiple labeling-like features in the future where each feature historically has a different provider
- separates labeling data from labelable entities (accounts, wallets) - this could be useful for example when resolving conflicts - there may be one file in dropbox, another file for the same account in google drive. we might display their content next to each other and let user decide which he wants to keep
- adds support for multiple data formats (labels, passwords, contacts..) 
- adds support for having multiple keys associated with a labelable entity at the same time. 
- <img width="359" alt="Screenshot 2023-06-06 at 14 33 10" src="https://github.com/trezor/trezor-suite/assets/30367552/c939d39e-1200-4adb-b39d-62d73e130a8d">
- <img width="313" alt="Screenshot 2023-06-07 at 12 25 05" src="https://github.com/trezor/trezor-suite/assets/30367552/5aead30d-1f12-4ec6-8232-73b1ec8dc715">

### Commits

commits are just for easier orientation, are not self-sustaining and should be squashed

d7476945cdfaf37210a963776749cec92a6d5a36 - new data structure in types. @matejkriz 
0a7fd8d11a9ee21e011c1cd074293f992a073513 - this new structure unfortunately does not play well with mobile. mobile now saves a local label (they don't have full-fledged metadata yet) into metadata structure (account.metadata.accountLabel). I am now getting rid of this data structure but at the same time I am not able to save their label to the new data structure. Therefore I propose to create local `account.accountLabel` field that for mobile. @Nodonisko 
6ad303b8122184101871dbaadfc9540509c6621a - connected with previous commit. I suspect this might kill labelling feature in mobile and I need to use something like `selectLabelingDataForSelectedAccount(getState()) || account.accountLabel`? @Nodonisko 
89264be7262152402cd8bcde7527ab6923b9c24a - Here I suspect this was not needed. Or was it a performance optimization?
1b5c63f8dfc8839f97d50f7e8e114d45dcacbf2a - this commit is not strictly related to what I am trying to achieve here, but will be useful in the future (as seen in #6579). Just stop assuming that filenames in data providers always have .mtdt suffix.
1097e92e879594d98724722a29a360a3246c004f - with the new data structure that allows multiple providers we need a way how to reference them. we can't simply use type "dropbox | google" because we can imagine scenarios when there are multiple providers of the same type connected which is the reason why we need to expose clientId.
3b6eec01cd4020aed17ef11b98bf71c9df1cdc95 - pure refactoring of metadata utils.
8cfcd642f717ca61d2583ac5304a7ba682bd291e - bigger commit. implementation of the new data structure in reducers, actions and middlewares
d523d8a2e0de37ad93a372249668e1c63a7f4174 - fetching metadata for saved devices from inside initAction. `TODO: describe how it was handled before`
59b811ba10429d5449b1d71898dd664a2949334c - implementation of selectors in views and components
4fb5c54e716972532b8ef1afd0aa06b1668fc104 - log and analytics utils. please @tomasklim see my notes. 
58cc52f9ef6cc17cc751fdc1c1468b527d3d28c3 - some rest changes that did not fit elsewhere
9736b2d0a228124279737274b1ba496d967082d1 - tests and fixtures changes
6365c50b42663630b0129fa88f137f4358a1bee1 - migration. historically @marekrjpolak had a good statitics in spotting bugs in migrations. 

### How does it help with migrations?
1. connect data provider
2. get all files names 
3. get encryptions keys v2 from device
4. derive v2 filenames, store them with labelable entitites under '2' key
5. are all v2 filenames present in what we got in point 2 OR is result from 2 empty
a. YES, no migration needed
6. get encryptions keys v1 from devices
7. derive v1 filenames, store them with labelabel entitites under '1' key
8. do migration. the good part is that we have now all the data we need available. 
