### PR TITLE
Fix ETH gas fees

### DIFF
--- a/packages/suite/src/actions/wallet/send/sendFormEthereumActions.ts
+++ b/packages/suite/src/actions/wallet/send/sendFormEthereumActions.ts
@@ -127,8 +127,9 @@ export const composeTransaction =
                     from: account.descriptor,
                     ...getEthereumEstimateFeeParams(
                         address || account.descriptor,
+                        // if amount is not set (set-max case) use max available balance
+                        amount || (tokenInfo ? tokenInfo.balance! : account.formattedBalance),
                         tokenInfo,
-                        amount,
                         formValues.ethereumDataHex,
                     ),
                 },

--- a/packages/suite/src/components/wallet/Fees/components/CustomFee.tsx
+++ b/packages/suite/src/components/wallet/Fees/components/CustomFee.tsx
@@ -211,23 +211,21 @@ export const CustomFee = ({
         <>
             <Wrapper>
                 {useFeeLimit ? (
-                    <>
-                        <Col>
-                            <StyledNumberInput
-                                control={control}
-                                label={<Translation id="TR_GAS_LIMIT" />}
-                                disabled={feeLimitDisabled}
-                                isMonospace
-                                variant="small"
-                                inputState={getInputState(feeLimitError, feeLimitValue)}
-                                name={FEE_LIMIT}
-                                data-test={FEE_LIMIT}
-                                onChange={changeFeeLimit}
-                                rules={feeLimitRules}
-                                bottomText={<InputError error={feeLimitError} />}
-                            />
-                        </Col>
-                    </>
+                    <Col>
+                        <StyledNumberInput
+                            control={control}
+                            label={<Translation id="TR_GAS_LIMIT" />}
+                            disabled={feeLimitDisabled}
+                            isMonospace
+                            variant="small"
+                            inputState={getInputState(feeLimitError, feeLimitValue)}
+                            name={FEE_LIMIT}
+                            data-test={FEE_LIMIT}
+                            onChange={changeFeeLimit}
+                            rules={feeLimitRules}
+                            bottomText={<InputError error={feeLimitError} />}
+                        />
+                    </Col>
                 ) : (
                     <input type="hidden" name={FEE_LIMIT} ref={register()} />
                 )}

--- a/packages/suite/src/components/wallet/Fees/components/FeeDetails.tsx
+++ b/packages/suite/src/components/wallet/Fees/components/FeeDetails.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useEffect, useState } from 'react';
 import styled from 'styled-components';
 import { FeeLevel } from '@trezor/connect';
 import { variables } from '@trezor/components';
@@ -35,6 +35,12 @@ const Label = styled.span`
     padding-right: 8px;
 `;
 
+// set min-width to prevent jumping when changing amount, width to fit 6 digits
+const FeeItem = styled.span`
+    min-width: 42px;
+    display: inline-block;
+`;
+
 interface Props {
     networkType: Network['networkType'];
     selectedLevel: FeeLevel;
@@ -69,24 +75,34 @@ const BitcoinDetails = ({ networkType, feeInfo, selectedLevel, transactionInfo }
     </Wrapper>
 );
 
-const EthereumDetails = ({ networkType, selectedLevel, transactionInfo }: Props) => (
-    <Wrapper>
-        <Item>
-            <Label>
-                <Translation id="TR_GAS_LIMIT" />
-            </Label>
-            {transactionInfo && transactionInfo.type !== 'error'
-                ? transactionInfo.feeLimit
-                : selectedLevel.feeLimit}
-        </Item>
-        <Item>
-            <Label>
-                <Translation id="TR_GAS_PRICE" />
-            </Label>
-            {`${selectedLevel.feePerUnit} ${getFeeUnits(networkType)}`}
-        </Item>
-    </Wrapper>
-);
+const EthereumDetails = ({ networkType, selectedLevel, transactionInfo }: Props) => {
+    const [fee, setFee] = useState<string | undefined>(selectedLevel.feeLimit);
+
+    const isComposedTx = transactionInfo && transactionInfo.type !== 'error';
+
+    useEffect(() => {
+        if (isComposedTx) {
+            setFee(transactionInfo.feeLimit);
+        }
+    }, [isComposedTx, transactionInfo]);
+
+    return (
+        <Wrapper>
+            <Item>
+                <Label>
+                    <Translation id="TR_GAS_LIMIT" />
+                </Label>
+                <FeeItem>{isComposedTx ? transactionInfo.feeLimit : fee}</FeeItem>
+            </Item>
+            <Item>
+                <Label>
+                    <Translation id="TR_GAS_PRICE" />
+                </Label>
+                <FeeItem>{`${selectedLevel.feePerUnit} ${getFeeUnits(networkType)}`}</FeeItem>
+            </Item>
+        </Wrapper>
+    );
+};
 
 const RippleDetails = ({ networkType, selectedLevel }: Props) => (
     <Wrapper>

--- a/packages/suite/src/components/wallet/Fees/index.tsx
+++ b/packages/suite/src/components/wallet/Fees/index.tsx
@@ -64,7 +64,7 @@ const FiatAmount = styled.div`
 const FeeInfoRow = styled.div`
     display: flex;
     width: 100%;
-    min-height: 50px; /* reserve space for fiat/crypto amounts */
+    min-height: 51px; /* reserve space for fiat/crypto amounts */
 `;
 
 const FeeAmount = styled.div`

--- a/suite-common/wallet-utils/src/sendFormUtils.ts
+++ b/suite-common/wallet-utils/src/sendFormUtils.ts
@@ -88,25 +88,28 @@ const getSerializedErc20Transfer = (token: TokenInfo, to: string, amount: string
     return `0x${ERC20_TRANSFER}${erc20recipient}${erc20amount}`;
 };
 
-// TrezorConnect.blockchainEstimateFee for ethereum
-// NOTE:
-// - amount cannot be "0" (send max calculation), use at least 1 unit.
+// TrezorConnect.blockchainEstimateFee for ETH
 export const getEthereumEstimateFeeParams = (
     to: string,
+    amount: string,
     token?: TokenInfo,
-    amount?: string,
     data?: string,
 ) => {
+    if (new BigNumber(amount).lte(0)) {
+        throw new Error('Amount has to be greater than 0');
+    }
+
     if (token) {
         return {
             to: token.contract,
             value: '0x0',
-            data: getSerializedErc20Transfer(token, to, amount || token.balance!), // if amount is not set (set-max case) use whole token balance
+            data: getSerializedErc20Transfer(token, to, amount),
         };
     }
+
     return {
         to,
-        value: amount ? getSerializedAmount(amount) : toHex('1'), // if amount is not set (set-max case) use at least 1 wei
+        value: getSerializedAmount(amount),
         data: data || '',
     };
 };


### PR DESCRIPTION
## Description

- fees bubble was jumping when fee was calculated
- in case of sending ERC-20 tokens, the value of gas limit was changing constantly between correct amount and 21000 while changing amount input
- gas limit was not calculated correctly when using send max as amount was set to 1 wei because amount is not yet calculated and is based on the result of the function `getEthereumEstimateFeeParams`
<img width="908" alt="Screenshot 2023-06-07 at 16 34 19" src="https://github.com/trezor/trezor-suite/assets/33235762/5d96b3ea-b907-4c4b-a316-9132c71ad359">
which can result into failing txs if the contract is conditional based on amount

## Related Issue

I fixed it during ETH staking. I can put it there, but probably better to separate it to make it clearer

## Screenshots:

https://github.com/trezor/trezor-suite/assets/33235762/94a922a6-28f2-45f5-ae12-070c0a8eb44b

