### PR TITLE
fix(suite): do not provide ownership if session is paused

### DIFF
--- a/packages/suite/src/actions/wallet/coinjoinClientActions.ts
+++ b/packages/suite/src/actions/wallet/coinjoinClientActions.ts
@@ -404,7 +404,7 @@ export const getOwnershipProof =
             }
             const { session } = coinjoinAccount;
             // do not provide ownership if requested account is no longer authorized
-            if (!session || session.signedRounds.length >= session.maxRounds) {
+            if (!session || session.paused || session.signedRounds.length >= session.maxRounds) {
                 response.inputs.push(...coinjoinResponseError(utxos, 'Account without session'));
                 return [];
             }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Fix for a race condition when coinjoin session should be auto-paused:

1. coinjoin package handles round phase change (end) and emit event to suite. in the same time it tries to pick utxos for another round
2. suite receives the event and calls `unregisterAccount`
3. parallelly `select-utxo-for-round` (async process) returns the result from step 1. and creates new `Round`.
4. account is now unregistered (coinjoin package) and session is paused (suite)
5. newly created Round request for ownership proofs
6. suite provides them because coinjoin account still have the session (paused) **this is the condition where the bug was**
7. Round is processed further on by coinjoin package but suite ignores everything (like for example critical phase modal) because it thinks that the session is paused

![Screenshot from 2023-06-07 16-54-53](https://github.com/trezor/trezor-suite/assets/3435913/502b6a06-d05e-48ef-8257-040c2330bc05)


