### PR TITLE
Downgrade `proxy-memoize` to 2.0.2

### DIFF
--- a/packages/suite/package.json
+++ b/packages/suite/package.json
@@ -74,7 +74,7 @@
         "jws": "^4.0.0",
         "pdfmake": "^0.2.7",
         "polished": "^4.2.2",
-        "proxy-memoize": "^2.0.4",
+        "proxy-memoize": "2.0.2",
         "qrcode.react": "^3.1.0",
         "react": "18.2.0",
         "react-dom": "18.2.0",

--- a/suite-common/toast-notifications/package.json
+++ b/suite-common/toast-notifications/package.json
@@ -19,7 +19,7 @@
         "@suite-common/test-utils": "workspace:*",
         "@suite-common/wallet-config": "workspace:*",
         "@trezor/connect": "workspace:*",
-        "proxy-memoize": "^2.0.4"
+        "proxy-memoize": "2.0.2"
     },
     "devDependencies": {
         "jest": "^26.6.3",

--- a/suite-common/wallet-core/package.json
+++ b/suite-common/wallet-core/package.json
@@ -29,7 +29,7 @@
         "@trezor/type-utils": "workspace:*",
         "@trezor/utils": "workspace:*",
         "date-fns": "^2.30.0",
-        "proxy-memoize": "^2.0.4"
+        "proxy-memoize": "2.0.2"
     },
     "devDependencies": {
         "jest": "^26.6.3",

--- a/suite-native/assets/package.json
+++ b/suite-native/assets/package.json
@@ -28,7 +28,7 @@
         "@suite-native/navigation": "workspace:*",
         "@trezor/styles": "workspace:*",
         "bignumber.js": "^9.1.1",
-        "proxy-memoize": "^2.0.4",
+        "proxy-memoize": "2.0.2",
         "react": "^18.2.0",
         "react-native": "0.71.8",
         "react-redux": "8.0.5"

--- a/suite-native/ethereum-tokens/package.json
+++ b/suite-native/ethereum-tokens/package.json
@@ -20,7 +20,7 @@
         "@suite-native/fiat-rates": "workspace:*",
         "@suite-native/module-settings": "workspace:*",
         "@trezor/blockchain-link": "workspace:*",
-        "proxy-memoize": "^2.0.4",
+        "proxy-memoize": "2.0.2",
         "react": "18.2.0"
     }
 }

--- a/suite-native/fiat-rates/package.json
+++ b/suite-native/fiat-rates/package.json
@@ -22,6 +22,6 @@
         "@suite-common/wallet-utils": "workspace:*",
         "@trezor/connect": "workspace:*",
         "date-fns": "^2.30.0",
-        "proxy-memoize": "^2.0.4"
+        "proxy-memoize": "2.0.2"
     }
 }

--- a/suite-native/transactions/package.json
+++ b/suite-native/transactions/package.json
@@ -34,7 +34,7 @@
         "@trezor/styles": "workspace:*",
         "@trezor/theme": "workspace:*",
         "jotai": "1.9.1",
-        "proxy-memoize": "^2.0.4",
+        "proxy-memoize": "2.0.2",
         "react": "18.2.0",
         "react-native": "0.71.8",
         "react-native-gesture-handler": "^2.9.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -6386,7 +6386,7 @@ __metadata:
     "@suite-common/wallet-config": "workspace:*"
     "@trezor/connect": "workspace:*"
     jest: ^26.6.3
-    proxy-memoize: ^2.0.4
+    proxy-memoize: 2.0.2
     typescript: 4.9.5
   languageName: unknown
   linkType: soft
@@ -6435,7 +6435,7 @@ __metadata:
     "@trezor/utils": "workspace:*"
     date-fns: ^2.30.0
     jest: ^26.6.3
-    proxy-memoize: ^2.0.4
+    proxy-memoize: 2.0.2
     typescript: 4.9.5
   languageName: unknown
   linkType: soft
@@ -6570,7 +6570,7 @@ __metadata:
     "@trezor/styles": "workspace:*"
     bignumber.js: ^9.1.1
     jest: ^26.6.3
-    proxy-memoize: ^2.0.4
+    proxy-memoize: 2.0.2
     react: ^18.2.0
     react-native: 0.71.8
     react-redux: 8.0.5
@@ -6644,7 +6644,7 @@ __metadata:
     "@suite-native/fiat-rates": "workspace:*"
     "@suite-native/module-settings": "workspace:*"
     "@trezor/blockchain-link": "workspace:*"
-    proxy-memoize: ^2.0.4
+    proxy-memoize: 2.0.2
     react: 18.2.0
   languageName: unknown
   linkType: soft
@@ -6664,7 +6664,7 @@ __metadata:
     "@suite-common/wallet-utils": "workspace:*"
     "@trezor/connect": "workspace:*"
     date-fns: ^2.30.0
-    proxy-memoize: ^2.0.4
+    proxy-memoize: 2.0.2
   languageName: unknown
   linkType: soft
 
@@ -7239,7 +7239,7 @@ __metadata:
     "@trezor/theme": "workspace:*"
     jest: ^26.6.3
     jotai: 1.9.1
-    proxy-memoize: ^2.0.4
+    proxy-memoize: 2.0.2
     react: 18.2.0
     react-native: 0.71.8
     react-native-gesture-handler: ^2.9.0
@@ -8262,7 +8262,7 @@ __metadata:
     pdfmake: ^0.2.7
     polished: ^4.2.2
     prettier: 2.8.8
-    proxy-memoize: ^2.0.4
+    proxy-memoize: 2.0.2
     qrcode.react: ^3.1.0
     react: 18.2.0
     react-dom: 18.2.0
@@ -27513,10 +27513,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"proxy-compare@npm:2.5.1":
-  version: 2.5.1
-  resolution: "proxy-compare@npm:2.5.1"
-  checksum: c7cc151ac255150bcb24becde6495b3e399416c31991af377ce082255b51f07eaeb5d861bf8bf482703e92f88b90a5892ad57d3153ea29450d03ef921683d9fa
+"proxy-compare@npm:2.4.0":
+  version: 2.4.0
+  resolution: "proxy-compare@npm:2.4.0"
+  checksum: ff8952db96980ad7123a1368aa6fed6b1eb390c22758152805bb5e1d4511fb50e798c19deb93feaa3b22f103a758c38d265ae34e4769d4e1748ee59795dfa6b2
   languageName: node
   linkType: hard
 
@@ -27534,12 +27534,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"proxy-memoize@npm:^2.0.4":
-  version: 2.0.4
-  resolution: "proxy-memoize@npm:2.0.4"
+"proxy-memoize@npm:2.0.2":
+  version: 2.0.2
+  resolution: "proxy-memoize@npm:2.0.2"
   dependencies:
-    proxy-compare: 2.5.1
-  checksum: d97b5cf6c50ebe050c5ff7ecd0bb040423d0ba41deb5795d421a34159deb12fbd9d99792fb9108ffe03e6ada225d863b2d31f51f2230bf4fcb2761f30987c7d7
+    proxy-compare: 2.4.0
+  checksum: 3cfb54fdd3032959de0c4da7bb7c85713bfa92d442841a6882a5ed20bd2dab0c629194615988e9b7dfdb8885183b8ab28817ed7205e912e7e285f031efdb8443
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Description

Upgrade of `proxy-memoize` to 2.0.4 (in https://github.com/trezor/trezor-suite/commit/eb588a8c4d2237f67a3d0bc49232639e2139208c) caused some issues with selector memoization. Therefore it was downgraded back to 2.0.2 until we fix the memoized selectors themselves.

## Related Issue

Could resolve #8658, could resolve #8660 and other various issues.
