### PR TITLE
Fix/tor circuit timeouts

### DIFF
--- a/packages/blockchain-link/src/workers/blockbook/websocket.ts
+++ b/packages/blockchain-link/src/workers/blockbook/websocket.ts
@@ -87,6 +87,11 @@ export class BlockbookAPI extends TypedEmitter<BlockbookEvents> {
         );
     }
 
+    private rejectAllPending(code: string, message?: string) {
+        this.messages.forEach(m => m.reject(new CustomError(code, message)));
+        this.messages = [];
+    }
+
     onTimeout() {
         const { ws } = this;
         if (!ws) return;
@@ -98,7 +103,7 @@ export class BlockbookAPI extends TypedEmitter<BlockbookEvents> {
                 // empty
             }
         } else {
-            this.messages.forEach(m => m.reject(new CustomError('websocket_timeout')));
+            this.rejectAllPending('websocket_timeout');
             ws.close();
         }
     }
@@ -428,6 +433,8 @@ export class BlockbookAPI extends TypedEmitter<BlockbookEvents> {
             this.disconnect();
         }
         this.ws?.removeAllListeners();
+
+        this.rejectAllPending('websocket_runtime_error', 'Websocket closed unexpectedly');
     }
 
     dispose() {

--- a/packages/blockchain-link/src/workers/blockfrost/websocket.ts
+++ b/packages/blockchain-link/src/workers/blockfrost/websocket.ts
@@ -78,6 +78,11 @@ export class BlockfrostAPI extends TypedEmitter<BlockfrostEvents> {
         );
     }
 
+    private rejectAllPending(code: string, message?: string) {
+        this.messages.forEach(m => m.reject(new CustomError(code, message)));
+        this.messages = [];
+    }
+
     onTimeout() {
         const { ws } = this;
         if (!ws) return;
@@ -89,7 +94,7 @@ export class BlockfrostAPI extends TypedEmitter<BlockfrostEvents> {
                 // empty
             }
         } else {
-            this.messages.forEach(m => m.reject(new CustomError('websocket_timeout')));
+            this.rejectAllPending('websocket_timeout');
             ws.close();
         }
     }
@@ -321,6 +326,9 @@ export class BlockfrostAPI extends TypedEmitter<BlockfrostEvents> {
             this.disconnect();
         }
         this.ws?.removeAllListeners();
+
+        this.rejectAllPending('websocket_runtime_error', 'Websocket closed unexpectedly');
+
         this.removeAllListeners();
     }
 }

--- a/packages/coinjoin/src/backend/CoinjoinBackendClient.ts
+++ b/packages/coinjoin/src/backend/CoinjoinBackendClient.ts
@@ -26,7 +26,7 @@ export class CoinjoinBackendClient {
 
     protected blockbookRequestId;
 
-    private readonly identityWabisabi = 'Satoshi';
+    private readonly identityWabisabi = 'WabisabiApi';
     private readonly identitiesBlockbook = [
         'Blockbook_1',
         'Blockbook_2',

--- a/packages/coinjoin/src/backend/CoinjoinBackendClient.ts
+++ b/packages/coinjoin/src/backend/CoinjoinBackendClient.ts
@@ -9,7 +9,12 @@ import type {
     BlockbookTransaction,
 } from '../types/backend';
 import type { CoinjoinBackendSettings, Logger } from '../types';
-import { FILTERS_REQUEST_TIMEOUT, HTTP_REQUEST_GAP, HTTP_REQUEST_TIMEOUT } from '../constants';
+import {
+    FILTERS_REQUEST_TIMEOUT,
+    HTTP_REQUEST_GAP,
+    HTTP_REQUEST_TIMEOUT,
+    WS_MESSAGE_TIMEOUT,
+} from '../constants';
 import { CoinjoinWebsocketController, BlockbookWS } from './CoinjoinWebsocketController';
 
 type CoinjoinBackendClientSettings = CoinjoinBackendSettings & {
@@ -135,7 +140,7 @@ export class CoinjoinBackendClient {
                     this.logger?.error(error?.message);
                     throw error;
                 }),
-            { attempts: 3 },
+            { attempts: 3, timeout: WS_MESSAGE_TIMEOUT, gap: HTTP_REQUEST_GAP },
         );
     }
 

--- a/packages/request-manager/src/controller.ts
+++ b/packages/request-manager/src/controller.ts
@@ -195,6 +195,10 @@ export class TorController extends EventEmitter {
         });
     }
 
+    public closeActiveCircuits() {
+        return this.controlPort.closeActiveCircuits();
+    }
+
     public stop() {
         this.status = TOR_CONTROLLER_STATUS.Stopped;
     }

--- a/packages/request-manager/src/httpPool.ts
+++ b/packages/request-manager/src/httpPool.ts
@@ -4,7 +4,7 @@ import { InterceptorOptions } from './types';
 export const createRequestPool = (interceptorOptions: InterceptorOptions) => {
     const requestTimeoutLimit = 1000 * 30;
 
-    return (request: http.ClientRequest) => {
+    return (request: http.ClientRequest, identity?: string) => {
         const { host } = request;
         const requestTime = Date.now();
 
@@ -27,10 +27,23 @@ export const createRequestPool = (interceptorOptions: InterceptorOptions) => {
         });
 
         request.on('error', (error: Error) => {
-            interceptorOptions.handler({
-                type: 'ERROR',
-                error,
-            });
+            // catch network errors from:
+            // - nodejs http module (using error.code field) examples: "socket hang up" or "socket disconnected before secure TLS connection was established"
+            //   see ./node_modules/@types/node/*/http.d.ts
+            // - SocksClientError (using error.options field) thrown by 'socks' package (dependency of socks-proxy-agent)
+            //   see https://github.com/JoshGlazebrook/socks/blob/76d013e4c9a2d956f07868477d8f12ec0b96edfc/src/common/util.ts
+            //   see https://github.com/JoshGlazebrook/socks/blob/76d013e4c9a2d956f07868477d8f12ec0b96edfc/src/common/constants.ts
+            if (('code' in error && error.code === 'ECONNRESET') || 'options' in error) {
+                interceptorOptions.handler({
+                    type: 'CIRCUIT_MISBEHAVING',
+                    identity: identity?.split(':')[0],
+                });
+            } else {
+                interceptorOptions.handler({
+                    type: 'ERROR',
+                    error,
+                });
+            }
         });
 
         return request;

--- a/packages/request-manager/src/torControlPort.ts
+++ b/packages/request-manager/src/torControlPort.ts
@@ -3,7 +3,8 @@ import fs from 'fs';
 import crypto from 'crypto';
 import util from 'util';
 import path from 'path';
-import { TorConnectionOptions } from './types';
+import { promiseAllSequence } from '@trezor/utils';
+import { TorConnectionOptions, TorCommandResponse } from './types';
 
 const readFile = util.promisify(fs.readFile);
 const randomBytes = util.promisify(crypto.randomBytes);
@@ -121,6 +122,83 @@ export class TorControlPort {
 
     write(command: string): boolean {
         return this.socket.write(`${command}\r\n`);
+    }
+
+    // https://gitweb.torproject.org/torspec.git/tree/control-spec.txt
+    sendCommand(command: string) {
+        return new Promise<TorCommandResponse>(resolve => {
+            this.socket.once('data', data => {
+                const payload = data.toString();
+                if (/250 OK\r?\n/.test(payload)) {
+                    resolve({ success: true, payload });
+                } else {
+                    resolve({ success: false, payload });
+                }
+            });
+            this.write(command);
+        });
+    }
+
+    getInfo(command: string) {
+        return this.sendCommand(`GETINFO ${command}`);
+    }
+
+    /* Tor circuit-status response format
+     * - ${id:number} BUILT ${path: string[]} BUILD_FLAGS=${flags: string[]} PURPOSE={flag: string} TIME_CREATED=${utc_timestamp: string}\r\n
+     * - ${id:number} EXTENDED BUILD_FLAGS=${flags: string[]} PURPOSE={flag: string} TIME_CREATED=${utc_timestamp: string} SOCKS_USERNAME=${user: string} SOCKS_PASSWORD=${user: string}\r\n
+     *
+     * Clients SHOULD NOT depend on the order of keyword=value arguments (...)
+     * Read more: https://github.com/torproject/torspec/blob/8961bb4d83fccb2b987f9899ca83aa430f84ab0c/control-spec.txt#L2252
+     */
+    async getCircuits() {
+        const status = await this.getInfo('circuit-status');
+        if (status.success) {
+            // helper fn to read values
+            const getValue = (key: string, values: string[], quoted = false) => {
+                const value = values.find(v => v.startsWith(key));
+                if (!value) return;
+                const resp = quoted ? value.match(/"(.*?)"/) : value.split('=');
+                return resp ? resp[1] : undefined;
+            };
+
+            return status.payload
+                .split('\r\n')
+                .filter(line =>
+                    /^[0-9]+ (LAUNCHED|BUILT|GUARD_WAIT|EXTENDED|FAILED|CLOSED)/.test(line),
+                )
+                .map(line => {
+                    const [id, status, ...values] = line.split(' ');
+                    return {
+                        id,
+                        status,
+                        // not used for now, left as example:
+                        // buildFlags: getValue('BUILD_FLAGS', values),
+                        // purpose: getValue('PURPOSE', values),
+                        // time: getValue('TIME_CREATED', values),
+                        username: getValue('SOCKS_USERNAME', values, true),
+                        password: getValue('SOCKS_PASSWORD', values, true),
+                    };
+                });
+        }
+        return [];
+    }
+
+    async closeActiveCircuits() {
+        const circuits = await this.getCircuits();
+        return promiseAllSequence(
+            circuits.map(circuit => () => this.sendCommand(`closecircuit ${circuit.id}`)),
+        );
+    }
+
+    async closeCircuit(identity?: string) {
+        const circuits = await this.getCircuits();
+        const circuitsToClose = identity
+            ? circuits.filter(circuit => circuit.username === identity)
+            : circuits.filter(circuit => !circuit.username || circuit.username === 'Default');
+
+        return promiseAllSequence(
+            circuitsToClose.map(circuit => () => this.sendCommand(`closecircuit ${circuit.id}`)),
+        );
     }
 
     subscribeEvents() {

--- a/packages/request-manager/src/torIdentities.ts
+++ b/packages/request-manager/src/torIdentities.ts
@@ -18,9 +18,7 @@ export class TorIdentities {
         const [user, password] = identity.split(':');
 
         if (this.identities[user] && password) {
-            // looks like destroy does nothing, but just in case
-            this.identities[user].destroy();
-            delete this.identities[user];
+            this.removeIdentity(user);
         }
 
         const { host, port } = this.getTorSettings();
@@ -44,5 +42,11 @@ export class TorIdentities {
         if (protocol) agent.protocol = `${protocol}:`;
 
         return agent;
+    }
+
+    public removeIdentity(user: string) {
+        // looks like destroy does nothing, but just in case
+        this.identities[user].destroy();
+        delete this.identities[user];
     }
 }

--- a/packages/request-manager/src/types.ts
+++ b/packages/request-manager/src/types.ts
@@ -41,6 +41,10 @@ export type InterceptedEvent =
           type: 'NETWORK_MISBEHAVING';
       }
     | {
+          type: 'CIRCUIT_MISBEHAVING';
+          identity?: string;
+      }
+    | {
           type: 'ERROR';
           error: Error;
       };

--- a/packages/request-manager/src/types.ts
+++ b/packages/request-manager/src/types.ts
@@ -5,6 +5,16 @@ export interface TorConnectionOptions {
     torDataDir: string;
 }
 
+export type TorCommandResponse =
+    | {
+          success: true;
+          payload: string;
+      }
+    | {
+          success: false;
+          payload: string;
+      };
+
 export type BootstrapEvent =
     | {
           type: 'slow';

--- a/packages/suite-desktop/src/modules/request-interceptor.ts
+++ b/packages/suite-desktop/src/modules/request-interceptor.ts
@@ -32,6 +32,10 @@ export const init: Module = ({ mainWindow, store, mainThreadEmitter }) => {
                 type: TorStatus.Misbehaving,
             });
         }
+
+        if (event.type === 'CIRCUIT_MISBEHAVING') {
+            mainThreadEmitter.emit('module/reset-tor-circuits', event);
+        }
     };
 
     // handle event sent from modules/coinjoin (background thread)


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
## Description:

When internet connection is not stable enough/disabled (see testing scenario) TOR proxy throws errors like:
`Socks5 proxy rejected connection - Failure` or `Proxy connection timed out`

This state remains for **10 minutes** even if internet connection is back - this applies for all requests not only coinjoin related

Docs:
```
[[MaxCircuitDirtiness]] **MaxCircuitDirtiness** __NUM__::
    Feel free to reuse a circuit that was first used at most NUM seconds ago,
    but never attach a new stream to a circuit that is too old.  For hidden
    services, this applies to the __last__ time a circuit was used, not the
    first. Circuits with streams constructed with SOCKS authentication via
    SocksPorts that have **KeepAliveIsolateSOCKSAuth** also remain alive
    for MaxCircuitDirtiness seconds after carrying the last such stream.
    (Default: 10 minutes)
```

## Testing scenario:

- connect your computer to mobile hotspot (aifak this will work only with android, mac + iphone will not work)
- launch suite, go to CJ account
- disable internet transfer in mobile (but not the hotspot itself)
- wait ~30 seconds and enable internet transfer back
- watch logs

## Alternative scenarios:

- switch between networks: in the office between sl-private and sl-guest **or** between home wifi and (any) mobile hotspot

## Related issue

https://github.com/trezor/trezor-suite/issues/8307

prerequisite for https://github.com/trezor/trezor-suite/issues/7062
