### PR TITLE
fix(coinjoin): use blameInputRegistrationTimeout for blaming rounds

### DIFF
--- a/packages/coinjoin/src/utils/roundUtils.ts
+++ b/packages/coinjoin/src/utils/roundUtils.ts
@@ -71,6 +71,7 @@ export const readTimeSpan = (ts: string) => {
 // accept CoinjoinRound or modified coordinator Round (see estimatePhaseDeadline below)
 type PartialCoinjoinRound = {
     phase: RoundPhase;
+    blameOf: string;
     inputRegistrationEnd: string;
     roundParameters: CoinjoinRoundParameters;
 };
@@ -79,8 +80,10 @@ export const getCoinjoinRoundDeadlines = (round: PartialCoinjoinRound) => {
     const now = Date.now();
     switch (round.phase) {
         case RoundPhase.InputRegistration: {
-            const deadline =
-                new Date(round.inputRegistrationEnd).getTime() + ROUND_REGISTRATION_END_OFFSET;
+            const isBlamingRound = round.blameOf !== '0'.repeat(64);
+            const deadline = isBlamingRound
+                ? now + readTimeSpan(round.roundParameters.blameInputRegistrationTimeout)
+                : new Date(round.inputRegistrationEnd).getTime() + ROUND_REGISTRATION_END_OFFSET;
             return {
                 phaseDeadline: deadline,
                 roundDeadline:

--- a/packages/coinjoin/tests/utils/roundUtils.test.ts
+++ b/packages/coinjoin/tests/utils/roundUtils.test.ts
@@ -34,6 +34,7 @@ describe('roundUtils', () => {
                             connectionConfirmationTimeout: '0d 0h 1m 0s',
                             outputRegistrationTimeout: '0d 0h 2m 0s',
                             transactionSigningTimeout: '0d 0h 3m 0s',
+                            blameInputRegistrationTimeout: '0d 0h 1m 30s',
                         },
                     },
                 ],
@@ -80,6 +81,11 @@ describe('roundUtils', () => {
                 phase: 4,
             }),
             Date.now() + timeouts * 3,
+        );
+
+        expectInRange(
+            estimatePhaseDeadline({ ...round, blameOf: '1'.repeat(64) }),
+            Date.now() + timeouts * 1.5,
         );
     });
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
from [mainnet status](https://wasabiwallet.io/swagger/index.html):


`blameInputRegistrationTimeout: "0d 0h 5m 0s"` !== `inputRegistrationTimeout: "0d 0h 10m 0s"`