### PR TITLE
feat(analytics): requests outlive the app session

### DIFF
--- a/packages/analytics/src/analytics.ts
+++ b/packages/analytics/src/analytics.ts
@@ -93,6 +93,7 @@ export class Analytics<T extends AnalyticsEvent> {
             url: `${this.url}?${qs}`,
             options: {
                 method: 'GET',
+                keepalive: true,
             },
             retry: true,
         });

--- a/packages/analytics/src/tests/analytics.test.ts
+++ b/packages/analytics/src/tests/analytics.test.ts
@@ -48,7 +48,7 @@ describe('analytics', () => {
         expect(global.fetch).toHaveBeenNthCalledWith(
             1,
             `https://data.trezor.io/${app}/log/${environment}/develop.log?c_v=1.18&c_type=${actionType}&c_commit=${commitId}&c_instance_id=${instanceId}&c_session_id=${sessionId}&c_timestamp=${timestamp}&c_message_id=random`,
-            { method: 'GET' },
+            { method: 'GET', keepalive: true },
         );
         expect(global.fetch).toHaveBeenCalledTimes(1);
 
@@ -92,7 +92,7 @@ describe('analytics', () => {
         expect(global.fetch).toHaveBeenNthCalledWith(
             1,
             `https://data.trezor.io/${app}/log/stable.log?c_v=1.18&c_type=${actionType}&c_commit=${commitId}&c_instance_id=${instanceId}&c_session_id=${sessionId}&c_timestamp=${timestamp}&c_message_id=random`,
-            { method: 'GET' },
+            { method: 'GET', keepalive: true },
         );
         expect(global.fetch).toHaveBeenCalledTimes(1);
     });


### PR DESCRIPTION
## Description

- few years ago, I was considering `Navigator.sendBeacon` for sending analytics data. However, the data were send using `POST` which is not possible in case of our analytics solution. 
- `keepalive` should do the same but also for other requests methods
- not available for Firefox

https://developer.mozilla.org/en-US/docs/Web/API/Navigator/sendBeacon (first note)
https://javascript.info/fetch-api#keepalive
https://caniuse.com/?search=keepalive

## Related Issue

https://github.com/trezor/trezor-suite/issues/3717#issuecomment-841168548
we do not have `session-end` anymore but let's add it
