### PR TITLE
IndexedDB migrations refactoring - part 1

### DIFF
--- a/packages/suite/src/storage/index.ts
+++ b/packages/suite/src/storage/index.ts
@@ -11,87 +11,18 @@ const VERSION = 36; // don't forget to add migration and CHANGELOG when changing
  *  Otherwise runs a migration function that transform the data to new scheme version if necessary
  */
 const onUpgrade: OnUpgradeFunc<SuiteDBSchema> = async (db, oldVersion, newVersion, transaction) => {
-    let shouldInitDB = oldVersion === 0;
     if (oldVersion > 0 && oldVersion < 13) {
         // just delete whole db as migrations from version older than 13 (internal releases) are not implemented
         try {
             await SuiteDB.removeStores(db);
-            shouldInitDB = true;
         } catch (err) {
             console.error('Storage: Error during removing all stores', err);
+            throw err;
         }
     }
 
-    if (shouldInitDB) {
-        // init db
-        // object store for wallet transactions
-        const txsStore = db.createObjectStore('txs', {
-            keyPath: ['tx.deviceState', 'tx.descriptor', 'tx.txid', 'tx.type'],
-        });
-        txsStore.createIndex('txid', 'tx.txid', { unique: false });
-        txsStore.createIndex('order', 'order', { unique: false });
-        txsStore.createIndex('blockTime', 'tx.blockTime', { unique: false });
-        txsStore.createIndex('deviceState', 'tx.deviceState', { unique: false });
-        txsStore.createIndex('accountKey', ['tx.descriptor', 'tx.symbol', 'tx.deviceState'], {
-            unique: false,
-        });
-
-        // object store for settings
-        db.createObjectStore('suiteSettings');
-        db.createObjectStore('walletSettings');
-
-        // object store for devices
-        db.createObjectStore('devices');
-        // object store for accounts
-        const accountsStore = db.createObjectStore('accounts', {
-            keyPath: ['descriptor', 'symbol', 'deviceState'],
-        });
-        accountsStore.createIndex('deviceState', 'deviceState', { unique: false });
-
-        // object store for discovery
-        db.createObjectStore('discovery', { keyPath: 'deviceState' });
-
-        // object store for send form
-        db.createObjectStore('sendFormDrafts');
-
-        db.createObjectStore('fiatRates');
-        db.createObjectStore('analytics');
-
-        // graph
-        const graphStore = db.createObjectStore('graph', {
-            keyPath: ['account.descriptor', 'account.symbol', 'account.deviceState'],
-        });
-
-        graphStore.createIndex('accountKey', [
-            'account.descriptor',
-            'account.symbol',
-            'account.deviceState',
-        ]);
-
-        graphStore.createIndex('deviceState', 'account.deviceState');
-
-        db.createObjectStore('coinmarketTrades', { keyPath: 'key' });
-
-        // metadata
-        db.createObjectStore('metadata');
-
-        db.createObjectStore('messageSystem');
-        db.createObjectStore('formDrafts');
-
-        db.createObjectStore('backendSettings');
-
-        // firmware. added in 28
-        db.createObjectStore('firmware');
-
-        // coinjoin, added in 32
-        db.createObjectStore('coinjoinAccounts');
-
-        // coinjoin settings
-        db.createObjectStore('coinjoinDebugSettings');
-    } else {
-        // migrate functions
-        await migrate(db, oldVersion, newVersion, transaction);
-    }
+    // migrate functions
+    await migrate(db, oldVersion, newVersion, transaction);
 };
 
 export const db = new SuiteDB<SuiteDBSchema>('trezor-suite', VERSION, onUpgrade, reloadApp);

--- a/packages/suite/src/storage/migrations/index.ts
+++ b/packages/suite/src/storage/migrations/index.ts
@@ -13,6 +13,7 @@ import {
     networkAmountToSatoshi,
     amountToSatoshi,
 } from '@suite-common/wallet-utils';
+import { updateAll } from '@trezor/suite/src/storage/migrations/utils';
 
 import type { SuiteDBSchema } from '../definitions';
 import { GraphData } from '../../types/wallet/graph';
@@ -89,41 +90,23 @@ export const migrate: OnUpgradeFunc<SuiteDBSchema> = async (
     if (oldVersion < 15) {
         db.createObjectStore('metadata');
 
-        const accountsStore = transaction.objectStore('accounts');
-        await accountsStore
-            .openCursor()
-            .then(async function addMetadataKeys(cursor): Promise<void> {
-                if (!cursor) {
-                    return;
-                }
-                const account = cursor.value;
+        await updateAll(transaction, 'accounts', account => {
+            account.metadata = {
+                key: '',
+                fileName: '',
+                aesKey: '',
+                outputLabels: {},
+                addressLabels: {},
+            };
+            account.key = `${account.descriptor}-${account.symbol}-${account.deviceState}`;
+            return account;
+        });
 
-                account.metadata = {
-                    key: '',
-                    fileName: '',
-                    aesKey: '',
-                    outputLabels: {},
-                    addressLabels: {},
-                };
-                account.key = `${account.descriptor}-${account.symbol}-${account.deviceState}`;
-                await cursor.update(account);
-
-                return cursor.continue().then(addMetadataKeys);
-            });
-
-        const devicesStore = transaction.objectStore('devices');
-        await devicesStore.openCursor().then(async function addMetadataKeys(cursor): Promise<void> {
-            if (!cursor) {
-                return;
-            }
-            const device = cursor.value;
-
+        await updateAll(transaction, 'devices', device => {
             device.metadata = {
                 status: 'disabled',
             };
-            await cursor.update(device);
-
-            return cursor.continue().then(addMetadataKeys);
+            return device;
         });
     }
 
@@ -139,17 +122,9 @@ export const migrate: OnUpgradeFunc<SuiteDBSchema> = async (
     }
 
     if (oldVersion < 18) {
-        const devicesStore = transaction.objectStore('devices');
-        await devicesStore.openCursor().then(async function addWalletNumber(cursor): Promise<void> {
-            if (!cursor) {
-                return;
-            }
-            const device = cursor.value;
-
+        await updateAll(transaction, 'devices', device => {
             device.walletNumber = device.instance;
-            await cursor.update(device);
-
-            return cursor.continue().then(addWalletNumber);
+            return device;
         });
     }
 
@@ -161,9 +136,7 @@ export const migrate: OnUpgradeFunc<SuiteDBSchema> = async (
 
     if (oldVersion < 20) {
         // enhance tx.details
-        let cursor = await transaction.objectStore('txs').openCursor();
-        while (cursor) {
-            const tx = cursor.value;
+        await updateAll(transaction, 'txs', tx => {
             if (tx.tx.details) {
                 tx.tx.details = {
                     ...tx.tx.details,
@@ -179,20 +152,14 @@ export const migrate: OnUpgradeFunc<SuiteDBSchema> = async (
                     totalOutput: formatNetworkAmount(tx.tx.details.totalOutput, tx.tx.symbol),
                 };
             }
-
-            // eslint-disable-next-line no-await-in-loop
-            await cursor.update(tx);
-            // eslint-disable-next-line no-await-in-loop
-            cursor = await cursor.continue();
-        }
+            return tx;
+        });
     }
 
     if (oldVersion < 21) {
         // do the same thing as in blockchain-link's transformTransaction
-        let cursor = await transaction.objectStore('txs').openCursor();
         const symbolsToExclude = ['eth', 'etc', 'xrp', 'trop', 'txrp'];
-        while (cursor) {
-            const tx = cursor.value as DBWalletAccountTransactionCompatible;
+        await updateAll<'txs', DBWalletAccountTransactionCompatible>(transaction, 'txs', tx => {
             if (!tx.tx.totalSpent) {
                 if (!symbolsToExclude.includes(tx.tx.symbol)) {
                     // btc-like txs
@@ -221,41 +188,28 @@ export const migrate: OnUpgradeFunc<SuiteDBSchema> = async (
                     // self, recv txs
                     tx.tx.totalSpent = tx.tx.amount;
                 }
-                // eslint-disable-next-line no-await-in-loop
-                await cursor.update(tx);
+                return tx;
             }
-            // eslint-disable-next-line no-await-in-loop
-            cursor = await cursor.continue();
-        }
+        });
     }
 
     if (oldVersion < 22) {
-        let cursor = await transaction.objectStore('accounts').openCursor();
-        while (cursor) {
-            const account = cursor.value;
+        await updateAll(transaction, 'accounts', account => {
             if (account.symbol === 'ltc' && account.accountType === 'normal') {
                 // change account type from normal to segwit
                 account.accountType = 'segwit';
-                // eslint-disable-next-line no-await-in-loop
-                await cursor.update(account);
+                return account;
             }
-            // eslint-disable-next-line no-await-in-loop
-            cursor = await cursor.continue();
-        }
+        });
 
-        let discovery = await transaction.objectStore('discovery').openCursor();
-        while (discovery) {
-            const d = discovery.value;
+        await updateAll(transaction, 'discovery', d => {
             // reset discovery
             if (d.networks.includes('ltc')) {
                 d.index = 0;
                 d.loaded = 0;
-                // eslint-disable-next-line no-await-in-loop
-                await discovery.update(d);
+                return d;
             }
-            // eslint-disable-next-line no-await-in-loop
-            discovery = await discovery.continue();
-        }
+        });
     }
 
     if (oldVersion < 23) {
@@ -267,11 +221,12 @@ export const migrate: OnUpgradeFunc<SuiteDBSchema> = async (
     }
 
     if (oldVersion < 25) {
-        let cursor = await transaction.objectStore('walletSettings').openCursor();
-        while (cursor) {
-            const settings: State & {
+        await updateAll<
+            'walletSettings',
+            State & {
                 blockbookUrls?: BlockbookUrl[];
-            } & WalletWithBackends = cursor.value;
+            } & WalletWithBackends
+        >(transaction, 'walletSettings', settings => {
             if (!settings.backends && settings.blockbookUrls) {
                 settings.backends = settings.blockbookUrls.reduce<{ [key: string]: any }>(
                     (backends, { coin, url, tor }) =>
@@ -287,81 +242,59 @@ export const migrate: OnUpgradeFunc<SuiteDBSchema> = async (
                     {},
                 );
                 delete settings.blockbookUrls;
-                // eslint-disable-next-line no-await-in-loop
-                await cursor.update(settings);
+                return settings;
             }
-
-            // eslint-disable-next-line no-await-in-loop
-            cursor = await cursor.continue();
-        }
+        });
     }
 
     if (oldVersion < 26) {
-        let cursor = await transaction.objectStore('accounts').openCursor();
-        while (cursor) {
-            const account = cursor.value;
+        await updateAll(transaction, 'accounts', account => {
             if (account.symbol === 'vtc' && account.accountType === 'normal') {
                 // change account type from normal to segwit
                 account.accountType = 'segwit';
-                // eslint-disable-next-line no-await-in-loop
-                await cursor.update(account);
+                return account;
             }
-            // eslint-disable-next-line no-await-in-loop
-            cursor = await cursor.continue();
-        }
+        });
 
-        let discovery = await transaction.objectStore('discovery').openCursor();
-        while (discovery) {
-            const d = discovery.value;
+        await updateAll(transaction, 'discovery', d => {
             // reset discovery
             if (d.networks.includes('vtc')) {
                 d.index = 0;
                 d.loaded = 0;
-                // eslint-disable-next-line no-await-in-loop
-                await discovery.update(d);
+                return d;
             }
-            // eslint-disable-next-line no-await-in-loop
-            discovery = await discovery.continue();
-        }
+        });
     }
 
     if (oldVersion < 27) {
         const backendSettings = db.createObjectStore('backendSettings');
-        let cursor = await transaction.objectStore('walletSettings').openCursor();
-        while (cursor) {
-            const settings: State & WalletWithBackends = cursor.value;
-            const { backends = {}, ...rest } = settings;
-            Object.entries(backends).forEach(([coin, { type, urls }]) => {
-                const settings: BackendSettings = {
-                    selected: type,
-                    urls: {
-                        [type]: urls,
-                    },
-                };
-                backendSettings.add(settings, coin as Network['symbol']);
-            });
 
-            // eslint-disable-next-line no-await-in-loop
-            await cursor.update(rest);
-            // eslint-disable-next-line no-await-in-loop
-            cursor = await cursor.continue();
-        }
+        await updateAll<'walletSettings', State & WalletWithBackends>(
+            transaction,
+            'walletSettings',
+            settings => {
+                const { backends = {}, ...rest } = settings;
+                Object.entries(backends).forEach(([coin, { type, urls }]) => {
+                    const settings: BackendSettings = {
+                        selected: type,
+                        urls: {
+                            [type]: urls,
+                        },
+                    };
+                    backendSettings.add(settings, coin as Network['symbol']);
+                });
+
+                return rest;
+            },
+        );
     }
 
     if (oldVersion < 28) {
-        const devicesStore = transaction.objectStore('devices');
-        await devicesStore.openCursor().then(async function update(cursor): Promise<void> {
-            if (!cursor) {
-                return;
-            }
-            const device = cursor.value;
-
+        await updateAll(transaction, 'devices', device => {
             if (device.state?.includes('undefined')) {
                 device.state = device.state.replace('undefined', '0');
-                await cursor.update(device);
+                return device;
             }
-
-            return cursor.continue().then(update);
         });
 
         const accounts: Account[] = [];
@@ -503,12 +436,7 @@ export const migrate: OnUpgradeFunc<SuiteDBSchema> = async (
     if (oldVersion < 29) {
         db.createObjectStore('firmware');
 
-        const providerStore = await transaction.objectStore('metadata');
-        await providerStore.openCursor().then(async function update(cursor): Promise<void> {
-            if (!cursor) {
-                return;
-            }
-            const state = cursor.value;
+        await updateAll(transaction, 'metadata', state => {
             // @ts-expect-error (token property removed)
             if (state.provider?.token) {
                 if (isDesktop()) {
@@ -520,98 +448,77 @@ export const migrate: OnUpgradeFunc<SuiteDBSchema> = async (
                 }
                 // @ts-expect-error
                 delete state.provider.token;
-                await cursor.update(state);
+                return state;
             }
-            return cursor.continue().then(update);
         });
     }
 
     if (oldVersion < 30) {
-        const walletSettingsStore = transaction.objectStore('walletSettings');
+        await updateAll(transaction, 'walletSettings', walletSettings => {
+            if (walletSettings.bitcoinAmountUnit || !walletSettings) {
+                return;
+            }
 
-        await walletSettingsStore
-            .openCursor()
-            .then(async function addAmountUnits(cursor): Promise<void> {
-                if (!cursor) {
-                    return;
-                }
-
-                const walletSettings = cursor.value;
-
-                if (walletSettings.bitcoinAmountUnit || !walletSettings) {
-                    return;
-                }
-
-                walletSettings.bitcoinAmountUnit = 0;
-                await cursor.update(walletSettings);
-
-                return cursor.continue().then(addAmountUnits);
-            });
+            walletSettings.bitcoinAmountUnit = 0;
+            return walletSettings;
+        });
     }
 
     if (oldVersion < 31) {
-        let cursor = await transaction.objectStore('txs').openCursor();
-        while (cursor) {
-            const { order, tx: origTx } = cursor.value as DBWalletAccountTransactionCompatible;
+        await updateAll<'txs', DBWalletAccountTransactionCompatible>(
+            transaction,
+            'txs',
+            ({ order, tx: origTx }) => {
+                const unformat = (amount: string) => networkAmountToSatoshi(amount, origTx.symbol);
+                const unformatIfDefined = (amount: string | undefined) =>
+                    amount ? unformat(amount) : amount;
 
-            const unformat = (amount: string) => networkAmountToSatoshi(amount, origTx.symbol);
-            const unformatIfDefined = (amount: string | undefined) =>
-                amount ? unformat(amount) : amount;
-
-            const unenhancedTx = {
-                ...origTx,
-                amount: unformat(origTx.amount),
-                fee: unformat(origTx.fee),
-                totalSpent: unformat(origTx.totalSpent),
-                tokens: origTx.tokens.map(tok => ({
-                    ...tok,
-                    amount: amountToSatoshi(tok.amount, tok.decimals),
-                })),
-                targets: origTx.targets.map(target => ({
-                    ...target,
-                    amount: unformatIfDefined(target.amount),
-                })),
-                ethereumSpecific: origTx.ethereumSpecific
-                    ? {
-                          ...origTx.ethereumSpecific,
-                          gasPrice: toWei(origTx.ethereumSpecific.gasPrice, 'gwei'),
-                      }
-                    : undefined,
-                cardanoSpecific: origTx.cardanoSpecific
-                    ? {
-                          ...origTx.cardanoSpecific,
-                          withdrawal: unformatIfDefined(origTx.cardanoSpecific.withdrawal),
-                          deposit: unformatIfDefined(origTx.cardanoSpecific.deposit),
-                      }
-                    : undefined,
-                details: origTx.details && {
-                    ...origTx.details,
-                    vin: origTx.details.vin.map(v => ({
-                        ...v,
-                        value: unformatIfDefined(v.value),
+                const unenhancedTx = {
+                    ...origTx,
+                    amount: unformat(origTx.amount),
+                    fee: unformat(origTx.fee),
+                    totalSpent: unformat(origTx.totalSpent),
+                    tokens: origTx.tokens.map(tok => ({
+                        ...tok,
+                        amount: amountToSatoshi(tok.amount, tok.decimals),
                     })),
-                    vout: origTx.details.vout.map(v => ({
-                        ...v,
-                        value: unformatIfDefined(v.value),
+                    targets: origTx.targets.map(target => ({
+                        ...target,
+                        amount: unformatIfDefined(target.amount),
                     })),
-                    totalInput: unformat(origTx.details.totalInput),
-                    totalOutput: unformat(origTx.details.totalOutput),
-                },
-            };
+                    ethereumSpecific: origTx.ethereumSpecific
+                        ? {
+                              ...origTx.ethereumSpecific,
+                              gasPrice: toWei(origTx.ethereumSpecific.gasPrice, 'gwei'),
+                          }
+                        : undefined,
+                    cardanoSpecific: origTx.cardanoSpecific
+                        ? {
+                              ...origTx.cardanoSpecific,
+                              withdrawal: unformatIfDefined(origTx.cardanoSpecific.withdrawal),
+                              deposit: unformatIfDefined(origTx.cardanoSpecific.deposit),
+                          }
+                        : undefined,
+                    details: origTx.details && {
+                        ...origTx.details,
+                        vin: origTx.details.vin.map(v => ({
+                            ...v,
+                            value: unformatIfDefined(v.value),
+                        })),
+                        vout: origTx.details.vout.map(v => ({
+                            ...v,
+                            value: unformatIfDefined(v.value),
+                        })),
+                        totalInput: unformat(origTx.details.totalInput),
+                        totalOutput: unformat(origTx.details.totalOutput),
+                    },
+                };
 
-            // eslint-disable-next-line no-await-in-loop
-            await cursor.update({ order, tx: unenhancedTx });
-            // eslint-disable-next-line no-await-in-loop
-            cursor = await cursor.continue();
-        }
+                return { order, tx: unenhancedTx };
+            },
+        );
 
-        const devicesStore = transaction.objectStore('devices');
-        await devicesStore.openCursor().then(async function update(cursor): Promise<void> {
-            if (!cursor) {
-                return;
-            }
-            const device = cursor.value;
-
+        await updateAll(transaction, 'devices', device => {
             const { features } = device;
 
             device.firmwareType =
@@ -621,9 +528,7 @@ export const migrate: OnUpgradeFunc<SuiteDBSchema> = async (
                     ? 'bitcoin-only'
                     : 'regular';
 
-            await cursor.update(device);
-
-            return cursor.continue().then(update);
+            return device;
         });
     }
 
@@ -632,20 +537,15 @@ export const migrate: OnUpgradeFunc<SuiteDBSchema> = async (
     }
 
     if (oldVersion < 33) {
-        let cursor = await transaction.objectStore('messageSystem').openCursor();
-        while (cursor) {
-            const messageSystem = cursor.value;
+        await updateAll(transaction, 'messageSystem', messageSystem => {
             Object.values(messageSystem.dismissedMessages).forEach(dismissedMessage => {
                 if (typeof dismissedMessage.feature === 'undefined') {
                     dismissedMessage.feature = false;
                 }
             });
 
-            // eslint-disable-next-line no-await-in-loop
-            await cursor.update(messageSystem);
-            // eslint-disable-next-line no-await-in-loop
-            cursor = await cursor.continue();
-        }
+            return messageSystem;
+        });
     }
 
     if (oldVersion < 34) {
@@ -653,115 +553,68 @@ export const migrate: OnUpgradeFunc<SuiteDBSchema> = async (
     }
 
     if (oldVersion < 35) {
-        // remove ethereum network transactions
-        let txsCursor = await transaction.objectStore('txs').openCursor();
-
         const accountsToUpdate = ['eth', 'etc', 'trop', 'tgor'];
 
-        while (txsCursor) {
-            const tx = txsCursor.value as DBWalletAccountTransactionCompatible;
-
+        // remove ethereum network transactions
+        await updateAll<'txs', DBWalletAccountTransactionCompatible>(transaction, 'txs', tx => {
             if (accountsToUpdate.includes(tx.tx.symbol)) {
-                // eslint-disable-next-line no-await-in-loop
-                await txsCursor.delete();
-            } else {
-                tx.tx.internalTransfers = [];
-                // eslint-disable-next-line no-await-in-loop
-                await txsCursor.update(tx);
+                return null;
             }
-            // eslint-disable-next-line no-await-in-loop
-            txsCursor = await txsCursor.continue();
-        }
+            tx.tx.internalTransfers = [];
+            return tx;
+        });
 
         // force to fetch ethereum network transactions again
-        let accountsCursor = await transaction.objectStore('accounts').openCursor();
-
-        while (accountsCursor) {
-            const account = accountsCursor.value;
-
+        await updateAll(transaction, 'accounts', account => {
             if (accountsToUpdate.includes(account.symbol)) {
                 account.history = { total: 0, unconfirmed: 0, tokens: 0 };
-                // eslint-disable-next-line no-await-in-loop
-                await accountsCursor.update(account);
+                return account;
             }
-
-            // eslint-disable-next-line no-await-in-loop
-            accountsCursor = await accountsCursor.continue();
-        }
+        });
     }
 
     if (oldVersion < 36) {
         // remove trop network transactions, change token address to contract
-        let txsCursor = await transaction.objectStore('txs').openCursor();
-
-        while (txsCursor) {
-            const tx = txsCursor.value;
-
+        await updateAll(transaction, 'txs', tx => {
             // @ts-expect-error
             if (tx.tx.symbol === 'trop') {
-                // eslint-disable-next-line no-await-in-loop
-                await txsCursor.delete();
-            } else {
-                tx.tx.tokens.forEach(token => {
-                    // @ts-expect-error
-                    token.contract = token.address;
-                    // @ts-expect-error
-                    delete token.address;
-                });
-                // eslint-disable-next-line no-await-in-loop
-                await txsCursor.update(tx);
+                return null;
             }
-
-            // eslint-disable-next-line no-await-in-loop
-            txsCursor = await txsCursor.continue();
-        }
+            tx.tx.tokens.forEach(token => {
+                // @ts-expect-error
+                token.contract = token.address;
+                // @ts-expect-error
+                delete token.address;
+            });
+            return tx;
+        });
 
         // remove trop network accounts, change token address to contract
-        let accountsCursor = await transaction.objectStore('accounts').openCursor();
-
-        while (accountsCursor) {
-            const account = accountsCursor.value;
-
+        await updateAll(transaction, 'accounts', account => {
             // @ts-expect-error
             if (account.symbol === 'trop') {
-                // eslint-disable-next-line no-await-in-loop
-                await accountsCursor.delete();
-            } else {
-                account.tokens?.forEach(token => {
-                    // @ts-expect-error
-                    token.contract = token.address;
-                    // @ts-expect-error
-                    delete token.address;
-                });
-                // eslint-disable-next-line no-await-in-loop
-                await accountsCursor.update(account);
+                return null;
             }
-
-            // eslint-disable-next-line no-await-in-loop
-            accountsCursor = await accountsCursor.continue();
-        }
+            account.tokens?.forEach(token => {
+                // @ts-expect-error
+                token.contract = token.address;
+                // @ts-expect-error
+                delete token.address;
+            });
+            return account;
+        });
 
         // remove trop from coin settings
-        let walletSettingsCursor = await transaction.objectStore('walletSettings').openCursor();
-
-        while (walletSettingsCursor) {
-            const walletSettings: State = walletSettingsCursor.value;
-
+        await updateAll(transaction, 'walletSettings', walletSettings => {
             walletSettings.enabledNetworks = walletSettings.enabledNetworks.filter(
                 // @ts-expect-error
                 network => network !== 'trop',
             );
 
-            // eslint-disable-next-line no-await-in-loop
-            await walletSettingsCursor.update(walletSettings);
+            return walletSettings;
+        });
 
-            // eslint-disable-next-line no-await-in-loop
-            walletSettingsCursor = await walletSettingsCursor.continue();
-        }
-
-        let discoveryCursor = await transaction.objectStore('discovery').openCursor();
-        while (discoveryCursor) {
-            const discovery = discoveryCursor.value;
+        await updateAll(transaction, 'discovery', discovery => {
             // remove trop from discovery networks
             discovery.networks = discovery.networks.filter(
                 // @ts-expect-error
@@ -769,12 +622,8 @@ export const migrate: OnUpgradeFunc<SuiteDBSchema> = async (
             );
             discovery.failed = [];
 
-            // eslint-disable-next-line no-await-in-loop
-            await discoveryCursor.update(discovery);
-
-            // eslint-disable-next-line no-await-in-loop
-            discoveryCursor = await discoveryCursor.continue();
-        }
+            return discovery;
+        });
 
         // remove trop from backend settings
         const backendSettings = transaction.objectStore('backendSettings');

--- a/packages/suite/src/storage/migrations/utils.ts
+++ b/packages/suite/src/storage/migrations/utils.ts
@@ -1,0 +1,34 @@
+import type { StoreNames, StoreValue, IDBPTransaction } from 'idb';
+import type { SuiteDBSchema } from '../definitions';
+
+/**
+ * Iterates over specified object store and applies `update` function to all the entries
+ * @param update If non-null value is returned, db entry is updated with the returned value.
+ * If null is returned, entry is removed from db.
+ * If nothing (void/undefined) is returned, entry is left untouched.
+ */
+export const updateAll = async <
+    T extends StoreNames<SuiteDBSchema>,
+    OldValueType = StoreValue<SuiteDBSchema, T>,
+>(
+    transaction: IDBPTransaction<SuiteDBSchema, StoreNames<SuiteDBSchema>[], 'versionchange'>,
+    store: T,
+    update: (old: OldValueType) => StoreValue<SuiteDBSchema, T> | null | void,
+): Promise<void> => {
+    let cursor = await transaction.objectStore(store).openCursor();
+    while (cursor) {
+        const oldObj = cursor.value as OldValueType;
+        const newObj = update(oldObj);
+
+        if (newObj) {
+            // eslint-disable-next-line no-await-in-loop
+            await cursor.update(newObj);
+        } else if (newObj === null) {
+            // eslint-disable-next-line no-await-in-loop
+            await cursor.delete();
+        }
+
+        // eslint-disable-next-line no-await-in-loop
+        cursor = await cursor.continue();
+    }
+};


### PR DESCRIPTION
## Description

First part of long-sleeping migrations refactoring (previously in #6431).

Splitting the migrations into files and other possible improvements left for followups.

## Commits

- https://github.com/trezor/trezor-suite/pull/8684/commits/f7ba8f3b12e4020aa20c5c3b3f9f746ce4ad91e5 - create `updateAll` util for iterating over object stores; replace the recurring object store iteration pattern in migrations with `updateAll`
- https://github.com/trezor/trezor-suite/pull/8684/commits/cec9119e3954a9f68d0792af5f86446b155c394c - try to polish the migration to v28 a bit; it deletes and recreates `accounts`, `txs`, `graph` and `discovery` object stores; now it uses `store.getAll()` instead of reading one by one
- https://github.com/trezor/trezor-suite/pull/8684/commits/580a679aaa8edc84095b4510bb248e87fab896a1 - DB initialization is now equivalent to migrating from the oldest supported version, therefore duplicate `createObjectStore` etc. is not needed anymore.

## How to test
No idea. Have fun. :trollface: 