### PR TITLE
test(e2e): enable some of the passphrase tests in suite

### DIFF
--- a/packages/suite-web/e2e/tests/suite/passphrase-disabled.test.ts
+++ b/packages/suite-web/e2e/tests/suite/passphrase-disabled.test.ts
@@ -4,7 +4,7 @@
 const DEFAULT_STANDARD_WALLET_LABEL = 'Standard wallet';
 const DEFAULT_HIDDEN_WALLET_LABEL = 'Hidden wallet #';
 
-describe.skip('Suite switch wallet modal', () => {
+describe('Suite switch wallet modal', () => {
     beforeEach(() => {
         cy.viewport(1080, 1440).resetDb();
         cy.task('startBridge');
@@ -40,8 +40,9 @@ describe.skip('Suite switch wallet modal', () => {
         cy.getTestElement('@suite/modal/confirm-action-on-device');
         cy.task('pressYes');
 
-        const passphaseToType = 'taxation is theft{enter}';
+        const passphaseToType = 'taxation is theft';
         cy.getTestElement('@passphrase/input').type(passphaseToType);
+        cy.getTestElement('@passphrase/hidden/submit-button').click();
 
         cy.task('pressYes');
         cy.task('pressYes');

--- a/packages/suite-web/e2e/tests/suite/passphrase-duplicate.test.ts
+++ b/packages/suite-web/e2e/tests/suite/passphrase-duplicate.test.ts
@@ -1,7 +1,7 @@
 // @group:passphrase
 // @retry=2
 
-describe.skip('Passphrase', () => {
+describe('Passphrase', () => {
     beforeEach(() => {
         cy.task('startEmu', { wipe: true });
         cy.task('setupEmu', { passphrase_protection: true });
@@ -15,7 +15,7 @@ describe.skip('Passphrase', () => {
     });
 
     it('passphrase duplicate', () => {
-        const passphraseToType = 'taxation is theft{enter}';
+        const passphraseToType = 'taxation is theft';
 
         // cy.getTestElement('@menu/switch-device').click();
         cy.getTestElement('@passphrase-type/standard').click();
@@ -26,6 +26,7 @@ describe.skip('Passphrase', () => {
         cy.getTestElement('@menu/switch-device').click();
         cy.getTestElement('@switch-device/add-hidden-wallet-button').click();
         cy.getTestElement('@passphrase/input').type(passphraseToType);
+        cy.getTestElement('@passphrase/hidden/submit-button').click();
 
         cy.task('pressYes');
         cy.task('pressYes');
@@ -47,6 +48,7 @@ describe.skip('Passphrase', () => {
         cy.task('pressYes');
 
         cy.getTestElement('@passphrase/input', { timeout: 10000 }).type(passphraseToType);
+        cy.getTestElement('@passphrase/hidden/submit-button').click();
 
         // duplicate passphrase modal appears;
         cy.getTestElement('@passphrase-duplicate');

--- a/packages/suite-web/e2e/tests/suite/passphrase-numbering.test.ts
+++ b/packages/suite-web/e2e/tests/suite/passphrase-numbering.test.ts
@@ -1,7 +1,7 @@
 // @group:passphrase
 // @retry=2
 
-describe.skip('Passphrase', () => {
+describe('Passphrase numbering', () => {
     beforeEach(() => {
         cy.task('startEmu', { wipe: true });
         cy.task('setupEmu', { passphrase_protection: true });
@@ -26,6 +26,7 @@ describe.skip('Passphrase', () => {
         cy.getTestElement('@menu/switch-device').click();
         cy.getTestElement('@switch-device/add-hidden-wallet-button').click();
         cy.getTestElement('@passphrase/input').type(passphraseOne);
+        cy.getTestElement('@passphrase/hidden/submit-button').click();
 
         cy.task('pressYes');
         cy.task('pressYes');
@@ -41,12 +42,14 @@ describe.skip('Passphrase', () => {
         cy.getTestElement('@menu/switch-device').click();
         cy.getTestElement('@switch-device/add-hidden-wallet-button').click();
         cy.getTestElement('@passphrase/input').type(passphraseTwo);
+        cy.getTestElement('@passphrase/hidden/submit-button').click();
 
         cy.task('pressYes');
         cy.task('pressYes');
 
         cy.getTestElement('@passphrase/confirm-checkbox').click();
         cy.getTestElement('@passphrase/input').type(passphraseTwo);
+        cy.getTestElement('@passphrase/hidden/submit-button').click();
 
         cy.task('pressYes');
         cy.task('pressYes');
@@ -71,12 +74,14 @@ describe.skip('Passphrase', () => {
         cy.getTestElement('@menu/switch-device').click();
         cy.getTestElement('@switch-device/add-hidden-wallet-button').click();
         cy.getTestElement('@passphrase/input').type(passphraseThree);
+        cy.getTestElement('@passphrase/hidden/submit-button').click();
 
         cy.task('pressYes');
         cy.task('pressYes');
 
         cy.getTestElement('@passphrase/confirm-checkbox', { timeout: 10000 }).click();
         cy.getTestElement('@passphrase/input').type(passphraseThree);
+        cy.getTestElement('@passphrase/hidden/submit-button').click();
 
         cy.task('pressYes');
         cy.task('pressYes');
@@ -96,6 +101,7 @@ describe.skip('Passphrase', () => {
 
         cy.getTestElement('@passphrase-type/hidden').click();
         cy.getTestElement('@passphrase/input').type(passphrase);
+        cy.getTestElement('@passphrase/hidden/submit-button').click();
 
         cy.task('pressYes');
         cy.task('pressYes');


### PR DESCRIPTION
couple of passphrase tests were disabled (and some of them still are). the problem was that with update of react, pressing keys in cy.type using syntax such as {enter} {backspace} stop working for passphrase input but there is easy workaround for that. 