### PR TITLE
Update cypress and cover important analytics events by e2e

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -12,7 +12,7 @@ module.exports = {
             jsx: true,
         },
     },
-    plugins: ['import', '@typescript-eslint', 'react-hooks', 'prettier', 'jest'],
+    plugins: ['import', '@typescript-eslint', 'react-hooks', 'prettier', 'jest', 'chai-friendly'],
     extends: [
         'airbnb',
         'plugin:@typescript-eslint/recommended',
@@ -183,6 +183,8 @@ module.exports = {
         'no-undefined': 'off', // disallow use of undefined variable (off by default)
         'no-undef-init': 'error', // disallow use of undefined when initializing variables
         'no-unused-vars': 'off',
+        'no-unused-expressions': 0,
+        'chai-friendly/no-unused-expressions': 2,
         '@typescript-eslint/no-unused-vars': [
             'error',
             { vars: 'all', args: 'none', ignoreRestSiblings: true, varsIgnorePattern: '^_' },

--- a/docker/docker-compose.suite-ci.yml
+++ b/docker/docker-compose.suite-ci.yml
@@ -7,7 +7,7 @@ services:
       - XDG_RUNTIME_DIR=/var/tmp
     network_mode: bridge # this makes docker reuse existing networks
   test-run:
-    image: $CI_DEPENDENCY_PROXY_DIRECT_GROUP_IMAGE_PREFIX/cypress/included:12.12.0
+    image: $CI_DEPENDENCY_PROXY_DIRECT_GROUP_IMAGE_PREFIX/cypress/included:12.14.0
     entrypoint: []
     environment:
       - CYPRESS_SNAPSHOT=$CYPRESS_SNAPSHOT

--- a/docker/test-runner/Dockerfile
+++ b/docker/test-runner/Dockerfile
@@ -1,6 +1,6 @@
 ## Use a proxy or fallback to no proxy at all (direct access to Docker Hub).
 ARG CI_DOCKER_PROXY=""
-FROM ${CI_DOCKER_PROXY}cypress/included:12.12.0
+FROM ${CI_DOCKER_PROXY}cypress/included:12.14.0
 
 RUN apt-get update && apt-get -y --no-install-recommends install \
     ca-certificates \

--- a/package.json
+++ b/package.json
@@ -111,6 +111,7 @@
         "eslint-config-airbnb": "^18.2.1",
         "eslint-config-prettier": "^8.8.0",
         "eslint-import-resolver-typescript": "^3.5.5",
+        "eslint-plugin-chai-friendly": "^0.7.2",
         "eslint-plugin-cypress": "^2.13.3",
         "eslint-plugin-import": "^2.27.5",
         "eslint-plugin-jest": "^27.2.1",

--- a/packages/suite-web/e2e/support/commands.ts
+++ b/packages/suite-web/e2e/support/commands.ts
@@ -21,9 +21,11 @@ import {
     enableRegtestAndGetCoins,
     createAccountFromMyAccounts,
     interceptDataTrezorIo,
-    Requests,
+    findAnalyticsEventByType,
 } from './utils/shortcuts';
 import { interceptInvityApi } from './utils/intercept-invity-api';
+import { SuiteAnalyticsEvent } from '@trezor/suite-analytics';
+import { EventPayload, Requests } from './types';
 
 const command = require('cypress-image-snapshot/command');
 const { skipOn, onlyOn } = require('@cypress/skip-test');
@@ -112,6 +114,10 @@ declare global {
             createAccountFromMyAccounts: (coin: string, label: string) => Chainable<Subject>;
             interceptInvityApi: () => void;
             interceptDataTrezorIo: (requests: Requests) => Cypress.Chainable<null>;
+            findAnalyticsEventByType: <T extends SuiteAnalyticsEvent>(
+                requests: Requests,
+                eventType: T['type'],
+            ) => Cypress.Chainable<NonNullable<EventPayload<T>>>;
         }
     }
 }
@@ -155,3 +161,5 @@ Cypress.Commands.add('text', { prevSubject: true }, subject => subject.text());
 Cypress.Commands.add('createAccountFromMyAccounts', createAccountFromMyAccounts);
 Cypress.Commands.add('interceptInvityApi', interceptInvityApi);
 Cypress.Commands.add('interceptDataTrezorIo', interceptDataTrezorIo);
+
+Cypress.Commands.add('findAnalyticsEventByType', findAnalyticsEventByType);

--- a/packages/suite-web/e2e/support/commands.ts
+++ b/packages/suite-web/e2e/support/commands.ts
@@ -20,6 +20,8 @@ import {
     passThroughSetPin,
     enableRegtestAndGetCoins,
     createAccountFromMyAccounts,
+    interceptDataTrezorIo,
+    Requests,
 } from './utils/shortcuts';
 import { interceptInvityApi } from './utils/intercept-invity-api';
 
@@ -109,6 +111,7 @@ declare global {
             onlyOn: (nameOrFlag: string | boolean, cb?: () => void) => Cypress.Chainable<any>;
             createAccountFromMyAccounts: (coin: string, label: string) => Chainable<Subject>;
             interceptInvityApi: () => void;
+            interceptDataTrezorIo: (requests: Requests) => Cypress.Chainable<null>;
         }
     }
 }
@@ -151,3 +154,4 @@ Cypress.Commands.add('onlyOn', onlyOn);
 Cypress.Commands.add('text', { prevSubject: true }, subject => subject.text());
 Cypress.Commands.add('createAccountFromMyAccounts', createAccountFromMyAccounts);
 Cypress.Commands.add('interceptInvityApi', interceptInvityApi);
+Cypress.Commands.add('interceptDataTrezorIo', interceptDataTrezorIo);

--- a/packages/suite-web/e2e/support/types/index.ts
+++ b/packages/suite-web/e2e/support/types/index.ts
@@ -1,0 +1,10 @@
+import { SuiteAnalyticsEvent } from '@trezor/suite-analytics';
+import { urlSearchParams } from '@trezor/suite/src/utils/suite/metadata';
+
+export type Requests = ReturnType<typeof urlSearchParams>[];
+
+export type ExtractByEventType<EventType> = Extract<SuiteAnalyticsEvent, { type: EventType }>;
+
+export type EventPayload<T extends SuiteAnalyticsEvent> = T extends { payload: infer P }
+    ? P
+    : undefined;

--- a/packages/suite-web/e2e/support/utils/shortcuts.ts
+++ b/packages/suite-web/e2e/support/utils/shortcuts.ts
@@ -1,3 +1,4 @@
+import { urlSearchParams } from '@trezor/suite/src/utils/suite/metadata';
 /**
  * Shortcut to click device menu
  */
@@ -102,3 +103,10 @@ export const createAccountFromMyAccounts = (coin: string, label: string) => {
     cy.get(`[data-test="@add-account-type/select/option/${label}"]`).click();
     cy.getTestElement('@add-account').click();
 };
+
+export type Requests = ReturnType<typeof urlSearchParams>[];
+export const interceptDataTrezorIo = (requests: Requests) =>
+    cy.intercept({ hostname: 'data.trezor.io', url: '/suite/log/**' }, req => {
+        const params = urlSearchParams(req.url);
+        requests.push(params);
+    });

--- a/packages/suite-web/e2e/tests/analytics/events.test.ts
+++ b/packages/suite-web/e2e/tests/analytics/events.test.ts
@@ -1,0 +1,204 @@
+// @group:suite
+// @retry=2
+
+import { urlSearchParams } from '@trezor/suite/src/utils/suite/metadata';
+import { EventType, SuiteAnalyticsEvent } from '@trezor/suite-analytics';
+
+type Requests = ReturnType<typeof urlSearchParams>[];
+let requests: Requests;
+
+const windowWidth = 1080;
+const windowHeight = 1440;
+
+describe('Analytics Events', () => {
+    beforeEach(() => {
+        cy.viewport(windowWidth, windowHeight).resetDb();
+        requests = [];
+    });
+
+    it('reports transport-type, suite-ready and device-connect/device-disconnect events when analytics is initialized and enabled', () => {
+        cy.prefixedVisit('/');
+
+        // go to settings and enable analytics (makes analytics enabled and initialized)
+        cy.getTestElement('@suite/menu/settings').click();
+        cy.getTestElement('@analytics/toggle-switch').click({ force: true });
+        cy.getTestElement('@settings/menu/close').click();
+
+        cy.task('startEmu', { wipe: true, version: '2.6.0' });
+        cy.task('setupEmu', {
+            needs_backup: false,
+            mnemonic: 'all all all all all all all all all all all all',
+            passphrase_protection: true,
+        });
+
+        cy.task('startBridge');
+
+        // reload to activate bridge and start testing app with enabled analytics
+        cy.reload();
+        cy.intercept({ hostname: 'data.trezor.io', url: '/suite/log/**' }, req => {
+            const params = urlSearchParams(req.url);
+            requests.push(params);
+        });
+
+        // suite-ready is logged 1st, just check that it is reported when app is initialized and enabled
+        // device-connect is logged 2nd
+        // transport-type is logged 3th
+
+        // wait until loaded
+        cy.getTestElement('@onboarding/exit-app-button');
+        cy.wrap(requests).should('have.length', 3);
+        cy.wrap(requests).its(0).should('have.property', 'c_type', EventType.SuiteReady);
+        cy.wrap(requests).its(1).should('have.property', 'c_type', EventType.DeviceConnect);
+        cy.wrap(requests).its(2).should('have.property', 'c_type', EventType.TransportType);
+
+        // device-connect
+        cy.wrap(requests).then(requestsArr => {
+            const deviceConnectEvent = requestsArr.find(
+                req => req.c_type === EventType.SettingsCoins,
+            ) as unknown as Extract<
+                SuiteAnalyticsEvent,
+                { type: EventType.DeviceConnect }
+            >['payload'];
+
+            expect(deviceConnectEvent.mode).to.equal('normal'); // not in BL
+            expect(deviceConnectEvent.firmware).to.equal('2.6.0'); // 2.6.0 is hardcoded in startEmu to always match
+            expect(deviceConnectEvent.firmwareRevision).to.equal(
+                // good to check because of phishing
+                '88e1f8c7a5c7615723664c64b0a25adc0c409dee', // https://github.com/trezor/trezor-firmware/releases/tag/core%2Fv2.6.0
+            );
+            expect(deviceConnectEvent.bootloaderHash).to.equal('');
+            expect(deviceConnectEvent.backup_type).to.equal('Bip39');
+            expect(deviceConnectEvent.pin_protection).to.equal('false');
+            expect(deviceConnectEvent.passphrase_protection).to.equal('true'); // set in startEmu
+            expect(deviceConnectEvent.totalInstances).to.equal('1');
+            expect(deviceConnectEvent.isBitcoinOnly).to.equal('false');
+            expect(deviceConnectEvent.totalDevices).to.equal('1');
+            expect(deviceConnectEvent.language).to.equal('en-US');
+            expect(deviceConnectEvent.model).to.equal('T');
+        });
+
+        // transport-type
+        cy.wrap(requests).then(requestsArr => {
+            const transportTypeEvent = requestsArr.find(
+                req => req.c_type === EventType.TransportType,
+            ) as Extract<SuiteAnalyticsEvent, { type: EventType.TransportType }>['payload'];
+
+            expect(transportTypeEvent.type).to.equal('BridgeTransport');
+            expect(parseInt(transportTypeEvent.version, 10)).to.not.equal(NaN);
+        });
+
+        // device-disconnect is logged 4th
+        cy.task('stopEmu');
+        cy.wrap(requests).should('have.length', 4);
+        cy.wrap(requests).its(3).should('have.property', 'c_type', EventType.DeviceDisconnect);
+    });
+
+    it('reports suite-ready after enabling analytics on app initial run', () => {
+        cy.task('startEmu', { wipe: true });
+        cy.task('setupEmu', {
+            needs_backup: false,
+            mnemonic: 'all all all all all all all all all all all all',
+        });
+        cy.task('startBridge');
+
+        cy.intercept({ hostname: 'data.trezor.io', url: '/suite/log/**' }, req => {
+            const params = urlSearchParams(req.url);
+            requests.push(params);
+        });
+
+        cy.prefixedVisit('/');
+
+        // change few settings to see if it is different from default values in suite-ready
+        cy.getTestElement('@suite/menu/settings').click();
+
+        // change language
+        cy.getTestElement('@settings/language-select/input').click();
+        cy.getTestElement('@settings/language-select/option/cs').click();
+
+        // change fiat
+        cy.getTestElement('@settings/fiat-select/input').click();
+        cy.getTestElement('@settings/fiat-select/option/czk').click();
+
+        // change BTC units
+        cy.getTestElement('@settings/btc-units-select/input').click();
+        cy.getTestElement('@settings/btc-units-select/option/Satoshis').click(); // sat
+
+        // change dark mode
+        cy.getTestElement('@theme/color-scheme-select/input').click();
+        cy.getTestElement('@theme/color-scheme-select/option/dark').click();
+
+        // disable btc, enable ethereum and goerli
+        cy.getTestElement('@settings/menu/wallet').click();
+        cy.getTestElement('@settings/wallet/network/btc').click();
+        cy.getTestElement('@settings/wallet/network/eth').click();
+        cy.getTestElement('@settings/wallet/network/tgor').click();
+
+        // custom eth backend
+        cy.getTestElement('@settings/wallet/network/eth/advance').click();
+        cy.getTestElement('@settings/advance/select-type/input').click();
+        cy.getTestElement('@settings/advance/select-type/option/blockbook').click();
+        cy.getTestElement('@settings/advance/url').type('https://eth.marek.pl/');
+        cy.getTestElement('@settings/advance/button/save').click();
+
+        cy.getTestElement('@settings/menu/close').click();
+
+        // nothing should be reported until analytics is initialized and enabled
+        cy.wrap(requests).should('have.length', 0);
+
+        cy.getTestElement('@analytics/continue-button').click();
+        cy.getTestElement('@onboarding/exit-app-button');
+
+        // settings/analytics and suite-ready should be reported now
+        // settings/analytics is logged 1st
+        // suite-ready is logged 2nd
+        cy.wrap(requests).should('have.length', 2);
+
+        cy.wrap(requests).its(0).should('have.property', 'c_type', EventType.SettingsAnalytics);
+        cy.wrap(requests).its(1).should('have.property', 'c_type', EventType.SuiteReady);
+
+        // settings/analytics
+        cy.wrap(requests).then(requestsArr => {
+            const transportTypeEvent = requestsArr.find(
+                req => req.c_type === EventType.SettingsAnalytics,
+            ) as unknown as Extract<
+                SuiteAnalyticsEvent,
+                { type: EventType.SettingsAnalytics }
+            >['payload'];
+            expect(transportTypeEvent.value).to.equal('true');
+        });
+
+        // suite-ready
+        cy.wrap(requests).then(requestsArr => {
+            const suiteReadyEvent = requestsArr.find(
+                req => req.c_type === EventType.SuiteReady,
+            ) as unknown as Extract<SuiteAnalyticsEvent, { type: EventType.SuiteReady }>['payload'];
+
+            expect(suiteReadyEvent.language).to.equal('cs');
+            expect(suiteReadyEvent.enabledNetworks).to.equal('eth,tgor');
+            expect(suiteReadyEvent.customBackends).to.equal('eth');
+            expect(suiteReadyEvent.localCurrency).to.equal('czk');
+            expect(suiteReadyEvent.bitcoinUnit).to.equal('sat');
+            expect(suiteReadyEvent.discreetMode).to.equal('false');
+            expect(suiteReadyEvent.screenWidth).to.exist.and.not.to.be.empty;
+            expect(suiteReadyEvent.screenHeight).to.exist.and.not.to.be.empty;
+            expect(suiteReadyEvent.platformLanguages).to.exist.and.not.to.be.empty;
+            expect(suiteReadyEvent.tor).to.equal('false');
+            expect(suiteReadyEvent.labeling).to.exist;
+            expect(suiteReadyEvent.rememberedStandardWallets).to.equal('0');
+            expect(suiteReadyEvent.rememberedHiddenWallets).to.equal('0');
+            expect(suiteReadyEvent.theme).to.equal('dark');
+            expect(parseInt(suiteReadyEvent.suiteVersion, 10)).to.not.equal(NaN);
+            expect(suiteReadyEvent.earlyAccessProgram).to.equal('false');
+            expect(suiteReadyEvent.browserName).to.equal(Cypress.browser.name);
+            expect(parseInt(suiteReadyEvent.browserVersion, 10)).to.not.equal(NaN);
+            expect(suiteReadyEvent.osName).to.exist.and.not.to.be.empty;
+            expect(parseInt(suiteReadyEvent.osVersion, 10)).to.not.equal(NaN);
+            expect(suiteReadyEvent.windowWidth).to.equal(windowWidth.toString());
+            expect(suiteReadyEvent.windowHeight).to.equal(windowHeight.toString());
+            expect(suiteReadyEvent.autodetectLanguage).to.equal('false');
+            expect(suiteReadyEvent.autodetectTheme).to.equal('false');
+        });
+    });
+});
+
+export {};

--- a/packages/suite-web/e2e/tests/analytics/toggle.test.ts
+++ b/packages/suite-web/e2e/tests/analytics/toggle.test.ts
@@ -9,7 +9,7 @@ let requests: Requests;
 const instance = new RegExp(/^[A-Za-z0-9]{10,10}$/);
 const timestamp = new RegExp(/^[0-9]{13,16}$/);
 
-describe('Analytics', () => {
+describe('Analytics Toggle - Enablement and Disablement', () => {
     beforeEach(() => {
         cy.task('startEmu', { wipe: true });
         cy.task('setupEmu');

--- a/packages/suite-web/e2e/tests/analytics/toggle.test.ts
+++ b/packages/suite-web/e2e/tests/analytics/toggle.test.ts
@@ -1,8 +1,8 @@
 // @group:suite
 // @retry=2
 
-import { urlSearchParams } from '@trezor/suite/src/utils/suite/metadata';
 import { EventType } from '@trezor/suite-analytics';
+import { urlSearchParams } from '@trezor/suite/src/utils/suite/metadata';
 
 type Requests = ReturnType<typeof urlSearchParams>[];
 let requests: Requests;
@@ -37,7 +37,8 @@ describe('Analytics Toggle - Enablement and Disablement', () => {
         cy.wait('@data-fetch');
         cy.wrap(requests).its(0).should('have.property', 'c_type', EventType.SettingsAnalytics);
         cy.wrap(requests).its(0).should('have.property', 'value', 'false');
-        cy.wrap(requests).its(0).its('c_session_id').as('request0');
+        cy.wrap(requests).its(0).its('c_session_id').as('sessionId0');
+        cy.wrap(requests).its(0).its('c_instance_id').as('instanceId0');
         cy.wrap(requests)
             .its(0)
             .should('have.property', 'c_timestamp')
@@ -64,7 +65,8 @@ describe('Analytics Toggle - Enablement and Disablement', () => {
         cy.getTestElement('@analytics/toggle-switch').find('input').should('be.checked');
         cy.wait('@data-fetch');
         cy.wrap(requests).its(1).should('have.property', 'c_type', EventType.SettingsAnalytics);
-        cy.wrap(requests).its(1).its('c_session_id').as('request1');
+        cy.wrap(requests).its(1).its('c_session_id').as('sessionId1');
+        cy.wrap(requests).its(1).its('c_instance_id').as('instanceId1');
         cy.wrap(requests)
             .its(1)
             .should('have.property', 'c_timestamp')
@@ -73,16 +75,23 @@ describe('Analytics Toggle - Enablement and Disablement', () => {
         cy.wrap(requests).should('have.length', 2);
 
         // check that timestamp changes between requests
-        cy.get('@timestamp0').then(t0 => {
-            cy.get('@timestamp1').then(t1 => {
-                expect(t1).not.to.equal(t0);
+        cy.get('@timestamp0').then(timestamp0 => {
+            cy.get('@timestamp1').then(timestamp1 => {
+                expect(timestamp0).not.to.equal(timestamp1);
             });
         });
 
         // check that session ids changed after reload;
-        cy.get('@request0').then(r0 => {
-            cy.get('@request1').then(r1 => {
-                expect(r1).not.to.equal(r0);
+        cy.get('@sessionId0').then(sessionId0 => {
+            cy.get('@sessionId1').then(sessionId1 => {
+                expect(sessionId0).not.to.equal(sessionId1);
+            });
+        });
+
+        // check that instnace ids are same after reload;
+        cy.get('@instanceId0').then(instanceId0 => {
+            cy.get('@instanceId1').then(instanceId1 => {
+                expect(instanceId0).to.equal(instanceId1);
             });
         });
 

--- a/packages/suite-web/e2e/tests/analytics/toggle.test.ts
+++ b/packages/suite-web/e2e/tests/analytics/toggle.test.ts
@@ -20,10 +20,7 @@ describe('Analytics Toggle - Enablement and Disablement', () => {
     });
 
     it('should respect disabled analytics in onboarding with following enabling in settings', () => {
-        cy.intercept({ hostname: 'data.trezor.io', url: '/suite/log/**' }, req => {
-            const params = urlSearchParams(req.url);
-            requests.push(params);
-        }).as('data-fetch');
+        cy.interceptDataTrezorIo(requests).as('data-fetch');
 
         cy.prefixedVisit('/');
 
@@ -114,10 +111,7 @@ describe('Analytics Toggle - Enablement and Disablement', () => {
     });
 
     it('should respect enabled analytics in onboarding with following disabling in settings', () => {
-        cy.intercept({ hostname: 'data.trezor.io', url: '/suite/log/**' }, req => {
-            const params = urlSearchParams(req.url);
-            requests.push(params);
-        }).as('data-fetch');
+        cy.interceptDataTrezorIo(requests).as('data-fetch');
 
         cy.prefixedVisit('/');
 

--- a/packages/suite-web/e2e/tests/backup/tt-fail.test.ts
+++ b/packages/suite-web/e2e/tests/backup/tt-fail.test.ts
@@ -1,10 +1,9 @@
-import { urlSearchParams } from '@trezor/suite/src/utils/suite/metadata';
 import { EventType, SuiteAnalyticsEvent } from '@trezor/suite-analytics';
+import { Requests } from '../../support/utils/shortcuts';
 
 // @group:device-management
 // @retry=2
 
-type Requests = ReturnType<typeof urlSearchParams>[];
 let requests: Requests;
 
 describe('Backup fail', () => {
@@ -16,11 +15,8 @@ describe('Backup fail', () => {
         cy.prefixedVisit('/');
         cy.passThroughInitialRun();
 
-        cy.intercept({ hostname: 'data.trezor.io', url: '/suite/log/**' }, req => {
-            const params = urlSearchParams(req.url);
-            requests.push(params);
-        });
         requests = [];
+        cy.interceptDataTrezorIo(requests);
     });
 
     it('Backup failed - device disconnected during action', () => {

--- a/packages/suite-web/e2e/tests/backup/tt-fail.test.ts
+++ b/packages/suite-web/e2e/tests/backup/tt-fail.test.ts
@@ -1,5 +1,5 @@
-import { EventType, SuiteAnalyticsEvent } from '@trezor/suite-analytics';
-import { Requests } from '../../support/utils/shortcuts';
+import { EventType } from '@trezor/suite-analytics';
+import { ExtractByEventType, Requests } from '../../support/types';
 
 // @group:device-management
 // @retry=2
@@ -43,11 +43,10 @@ describe('Backup fail', () => {
             'be.disabled',
         );
 
-        cy.wrap(requests).then(requestsArr => {
-            const createBackupEvent = requestsArr.find(
-                req => req.c_type === EventType.CreateBackup,
-            ) as Extract<SuiteAnalyticsEvent, { type: EventType.CreateBackup }>['payload'];
-
+        cy.findAnalyticsEventByType<ExtractByEventType<EventType.CreateBackup>>(
+            requests,
+            EventType.CreateBackup,
+        ).then(createBackupEvent => {
             expect(createBackupEvent.status).to.equal('error');
             expect(createBackupEvent.error).to.be.oneOf([
                 'device+disconnected+during+action',

--- a/packages/suite-web/e2e/tests/backup/tt-fail.test.ts
+++ b/packages/suite-web/e2e/tests/backup/tt-fail.test.ts
@@ -1,9 +1,12 @@
-/* eslint-disable @typescript-eslint/prefer-ts-expect-error */
+import { urlSearchParams } from '@trezor/suite/src/utils/suite/metadata';
+import { EventType, SuiteAnalyticsEvent } from '@trezor/suite-analytics';
 
 // @group:device-management
 // @retry=2
 
-// @ts-ignore
+type Requests = ReturnType<typeof urlSearchParams>[];
+let requests: Requests;
+
 describe('Backup fail', () => {
     beforeEach(() => {
         cy.task('startEmu', { wipe: true });
@@ -12,6 +15,12 @@ describe('Backup fail', () => {
         cy.viewport(1080, 1440).resetDb();
         cy.prefixedVisit('/');
         cy.passThroughInitialRun();
+
+        cy.intercept({ hostname: 'data.trezor.io', url: '/suite/log/**' }, req => {
+            const params = urlSearchParams(req.url);
+            requests.push(params);
+        });
+        requests = [];
     });
 
     it('Backup failed - device disconnected during action', () => {
@@ -37,6 +46,19 @@ describe('Backup fail', () => {
         cy.getTestElement('@dashboard/security-card/backup/button', { timeout: 30000 }).should(
             'be.disabled',
         );
+
+        cy.wrap(requests).then(requestsArr => {
+            const createBackupEvent = requestsArr.find(
+                req => req.c_type === EventType.CreateBackup,
+            ) as Extract<SuiteAnalyticsEvent, { type: EventType.CreateBackup }>['payload'];
+
+            expect(createBackupEvent.status).to.equal('error');
+            expect(createBackupEvent.error).to.be.oneOf([
+                'device+disconnected+during+action',
+                'Device+disconnected',
+                'session+not+found',
+            ]);
+        });
     });
 });
 

--- a/packages/suite-web/e2e/tests/backup/tt-misc.test.ts
+++ b/packages/suite-web/e2e/tests/backup/tt-misc.test.ts
@@ -1,9 +1,6 @@
-/* eslint-disable @typescript-eslint/prefer-ts-expect-error */
-
 // @group:device-management
 // @retry=2
 
-// @ts-ignore
 describe('Backup misc', () => {
     beforeEach(() => {
         cy.task('startEmu', { wipe: true });

--- a/packages/suite-web/e2e/tests/backup/tt-success.test.ts
+++ b/packages/suite-web/e2e/tests/backup/tt-success.test.ts
@@ -1,10 +1,9 @@
-import { urlSearchParams } from '@trezor/suite/src/utils/suite/metadata';
 import { EventType, SuiteAnalyticsEvent } from '@trezor/suite-analytics';
+import { Requests } from '../../support/utils/shortcuts';
 
 // @group:device-management
 // @retry=2
 
-type Requests = ReturnType<typeof urlSearchParams>[];
 let requests: Requests;
 
 describe('Backup success', () => {
@@ -20,11 +19,8 @@ describe('Backup success', () => {
         cy.prefixedVisit('/');
         cy.passThroughInitialRun();
 
-        cy.intercept({ hostname: 'data.trezor.io', url: '/suite/log/**' }, req => {
-            const params = urlSearchParams(req.url);
-            requests.push(params);
-        });
         requests = [];
+        cy.interceptDataTrezorIo(requests);
     });
 
     it('Successful backup happy path', () => {

--- a/packages/suite-web/e2e/tests/backup/tt-success.test.ts
+++ b/packages/suite-web/e2e/tests/backup/tt-success.test.ts
@@ -1,5 +1,5 @@
-import { EventType, SuiteAnalyticsEvent } from '@trezor/suite-analytics';
-import { Requests } from '../../support/utils/shortcuts';
+import { EventType } from '@trezor/suite-analytics';
+import { ExtractByEventType, Requests } from '../../support/types';
 
 // @group:device-management
 // @retry=2
@@ -54,11 +54,10 @@ describe('Backup success', () => {
         cy.getTestElement('@backup/check-item/will-hide-seed').click();
         cy.getTestElement('@backup/continue-to-pin-button').should('not.be.disabled');
 
-        cy.wrap(requests).then(requestsArr => {
-            const createBackupEvent = requestsArr.find(
-                req => req.c_type === EventType.CreateBackup,
-            ) as Extract<SuiteAnalyticsEvent, { type: EventType.CreateBackup }>['payload'];
-
+        cy.findAnalyticsEventByType<ExtractByEventType<EventType.CreateBackup>>(
+            requests,
+            EventType.CreateBackup,
+        ).then(createBackupEvent => {
             expect(createBackupEvent.status).to.equal('finished');
             expect(createBackupEvent.error).to.equal('');
         });

--- a/packages/suite-web/e2e/tests/browser/android.test.ts
+++ b/packages/suite-web/e2e/tests/browser/android.test.ts
@@ -1,6 +1,6 @@
 // @group:browser
 // @retry=2
-// @user-agent=Mozilla/5.0 (Linux; U; Android 2.3.6; en-us; Nexus S Build/GRK39F) AppleWebKit/533.1 (KHTML, like Gecko) Version/4.0 Mobile Safari/533.1
+// @user-agent=Mozilla/5.0 (Android 13; Mobile; LG-M255; rv:114.0) Gecko/114.0 Firefox/114.0
 
 // note that running tests in /browser folder will not work in 'debug local setup'
 

--- a/packages/suite-web/e2e/tests/browser/edge.test.ts
+++ b/packages/suite-web/e2e/tests/browser/edge.test.ts
@@ -1,6 +1,6 @@
 // @group:browser
 // @retry=2
-// @user-agent=Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/42.0.2311.135 Safari/537.36 Edge/12.246
+// @user-agent=Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/114.0.0.0 Safari/537.36 Edg/114.0.1823.43
 
 // note that running tests in /browser folder will not work in 'debug local setup'
 

--- a/packages/suite-web/e2e/tests/browser/ios.test.ts
+++ b/packages/suite-web/e2e/tests/browser/ios.test.ts
@@ -1,6 +1,6 @@
 // @group:browser
 // @retry=2
-// @user-agent=Mozilla/5.0 (iPhone; CPU iPhone OS 10_3_1 like Mac OS X) AppleWebKit/603.1.30 (KHTML, like Gecko) Version/10.0 Mobile/14E304 Safari/602.1
+// @user-agent=Mozilla/5.0 (iPhone; CPU iPhone OS 16_5 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/16.5 Mobile/15E148 Safari/604.1
 
 // note that running tests in /browser folder will not work in 'debug local setup'
 

--- a/packages/suite-web/e2e/tests/browser/outdated-chrome.test.ts
+++ b/packages/suite-web/e2e/tests/browser/outdated-chrome.test.ts
@@ -1,6 +1,6 @@
 // @group:browser
 // @retry=2
-// @user-agent=Mozilla/5.0 (Windows NT 6.1; WOW64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/47.0.2526.111 Safari/537.36
+// @user-agent=Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/83.0.4103.61 Safari/537.36
 
 // note that running tests in /browser folder will not work in 'debug local setup'
 

--- a/packages/suite-web/e2e/tests/browser/outdated-firefox.test.ts
+++ b/packages/suite-web/e2e/tests/browser/outdated-firefox.test.ts
@@ -1,6 +1,6 @@
 // @group:browser
 // @retry=2
-// @user-agent=Mozilla/5.0 (X11; Ubuntu; Linux x86_64; rv:15.0) Gecko/20100101 Firefox/15.0.1
+// @user-agent=Mozilla/5.0 (Windows NT 10.0; Win64; x64; rv:109.0) Gecko/20100101 Firefox/77.0
 
 // note that running tests in /browser folder will not work in 'debug local setup'
 

--- a/packages/suite-web/e2e/tests/dashboard/assets.test.ts
+++ b/packages/suite-web/e2e/tests/dashboard/assets.test.ts
@@ -1,8 +1,8 @@
 // @group:suite
 // @retry=2
 
-import { EventType, SuiteAnalyticsEvent } from '@trezor/suite-analytics';
-import { Requests } from '../../support/utils/shortcuts';
+import { EventType } from '@trezor/suite-analytics';
+import { ExtractByEventType, Requests } from '../../support/types';
 
 let requests: Requests;
 
@@ -39,22 +39,17 @@ describe('Assets', () => {
         cy.contains('Bitcoin').should('be.visible');
         cy.contains('Ethereum').should('be.visible').click();
 
-        cy.wrap(requests).then(requestsArr => {
-            const selectWalletTypeEvent = requestsArr.find(
-                req => req.c_type === EventType.SelectWalletType,
-            ) as Extract<SuiteAnalyticsEvent, { type: EventType.SelectWalletType }>['payload'];
-
+        cy.findAnalyticsEventByType<ExtractByEventType<EventType.SelectWalletType>>(
+            requests,
+            EventType.SelectWalletType,
+        ).then(selectWalletTypeEvent => {
             expect(selectWalletTypeEvent.type).to.equal('standard');
         });
 
-        cy.wrap(requests).then(requestsArr => {
-            const accountsStatusEvent = requestsArr.find(
-                req => req.c_type === EventType.AccountsStatus,
-            ) as unknown as Extract<
-                SuiteAnalyticsEvent,
-                { type: EventType.AccountsStatus }
-            >['payload'];
-
+        cy.findAnalyticsEventByType<ExtractByEventType<EventType.AccountsStatus>>(
+            requests,
+            EventType.AccountsStatus,
+        ).then(accountsStatusEvent => {
             expect(parseInt(accountsStatusEvent.btc_normal.toString(), 10)).to.not.equal(NaN);
             expect(parseInt(accountsStatusEvent.btc_taproot.toString(), 10)).to.not.equal(NaN);
             expect(parseInt(accountsStatusEvent.btc_segwit.toString(), 10)).to.not.equal(NaN);
@@ -62,42 +57,20 @@ describe('Assets', () => {
             expect(parseInt(accountsStatusEvent.eth_normal.toString(), 10)).to.not.equal(NaN);
         });
 
-        cy.wrap(requests).then(requestsArr => {
-            const AccountsNonZeroBalanceEvent = requestsArr.find(
-                req => req.c_type === EventType.AccountsNonZeroBalance,
-            ) as unknown as Extract<
-                SuiteAnalyticsEvent,
-                { type: EventType.AccountsNonZeroBalance }
-            >['payload'];
-
-            // 0x73d0385F4d8E00C5e6504C6030F47BF6212736A8 has token and nobody will be able to move it without ETH
-            expect(parseInt(AccountsNonZeroBalanceEvent.eth_normal.toString(), 10)).to.not.equal(
-                NaN,
-            );
-        });
-
-        cy.wrap(requests).then(requestsArr => {
-            const accountsNonZeroBalanceEvent = requestsArr.find(
-                req => req.c_type === EventType.AccountsNonZeroBalance,
-            ) as unknown as Extract<
-                SuiteAnalyticsEvent,
-                { type: EventType.AccountsNonZeroBalance }
-            >['payload'];
-
+        cy.findAnalyticsEventByType<ExtractByEventType<EventType.AccountsNonZeroBalance>>(
+            requests,
+            EventType.AccountsNonZeroBalance,
+        ).then(accountsNonZeroBalanceEvent => {
             // 0x73d0385F4d8E00C5e6504C6030F47BF6212736A8 has token and nobody will be able to move it without ETH
             expect(parseInt(accountsNonZeroBalanceEvent.eth_normal.toString(), 10)).to.not.equal(
                 NaN,
             );
         });
 
-        cy.wrap(requests).then(requestsArr => {
-            const accountsTokensStatusEvent = requestsArr.find(
-                req => req.c_type === EventType.AccountsTokensStatus,
-            ) as unknown as Extract<
-                SuiteAnalyticsEvent,
-                { type: EventType.AccountsTokensStatus }
-            >['payload'];
-
+        cy.findAnalyticsEventByType<ExtractByEventType<EventType.AccountsTokensStatus>>(
+            requests,
+            EventType.AccountsTokensStatus,
+        ).then(accountsTokensStatusEvent => {
             // 0x73d0385F4d8E00C5e6504C6030F47BF6212736A8 has token and nobody will be able to move it without ETH
             expect(parseInt(accountsTokensStatusEvent.eth.toString(), 10)).to.not.equal(NaN);
         });

--- a/packages/suite-web/e2e/tests/dashboard/assets.test.ts
+++ b/packages/suite-web/e2e/tests/dashboard/assets.test.ts
@@ -1,6 +1,12 @@
 // @group:suite
 // @retry=2
 
+import { urlSearchParams } from '@trezor/suite/src/utils/suite/metadata';
+import { EventType, SuiteAnalyticsEvent } from '@trezor/suite-analytics';
+
+type Requests = ReturnType<typeof urlSearchParams>[];
+let requests: Requests;
+
 describe('Assets', () => {
     beforeEach(() => {
         cy.task('startEmu', { wipe: true });
@@ -11,23 +17,94 @@ describe('Assets', () => {
         cy.task('startBridge');
 
         cy.viewport(1080, 1440).resetDb();
-        cy.prefixedVisit('/');
-        cy.passThroughInitialRun();
+
+        requests = [];
+        cy.intercept({ hostname: 'data.trezor.io', url: '/suite/log/**' }, req => {
+            const params = urlSearchParams(req.url);
+            requests.push(params);
+        });
     });
 
-    /*
-     * 1. navigate to the `Dashboard` page
-     * 2. check the `Assets` part of the page
-     * 3. the modal is rendered correctly and shows 1-n coins
-     * 4. click on a coin name (e.g. `Bitcoin`)
-     * 5. user is transferred to a bitcoin account
-     */
-    it('Assets', () => {
-        //
-        // Test execution && assert
-        //
+    it('checks that BTC and ETH accounts are available', () => {
+        cy.prefixedVisit('/');
+
+        // enable ethereum
+        cy.getTestElement('@suite/menu/settings').click();
+        cy.getTestElement('@settings/menu/wallet').click();
+        cy.getTestElement('@settings/wallet/network/eth').click();
+        cy.getTestElement('@settings/menu/close').click();
+
+        cy.passThroughInitialRun();
+
+        // ugly bug which takes user to settings after initial run in case he was there before and had initialized device
+        cy.getTestElement('@settings/menu/close').click();
+
         cy.discoveryShouldFinish();
-        cy.contains('Bitcoin').should('be.visible').click();
+        cy.contains('Bitcoin').should('be.visible');
+        cy.contains('Ethereum').should('be.visible').click();
+
+        cy.wrap(requests).then(requestsArr => {
+            const selectWalletTypeEvent = requestsArr.find(
+                req => req.c_type === EventType.SelectWalletType,
+            ) as Extract<SuiteAnalyticsEvent, { type: EventType.SelectWalletType }>['payload'];
+
+            expect(selectWalletTypeEvent.type).to.equal('standard');
+        });
+
+        cy.wrap(requests).then(requestsArr => {
+            const accountsStatusEvent = requestsArr.find(
+                req => req.c_type === EventType.AccountsStatus,
+            ) as unknown as Extract<
+                SuiteAnalyticsEvent,
+                { type: EventType.AccountsStatus }
+            >['payload'];
+
+            expect(parseInt(accountsStatusEvent.btc_normal.toString(), 10)).to.not.equal(NaN);
+            expect(parseInt(accountsStatusEvent.btc_taproot.toString(), 10)).to.not.equal(NaN);
+            expect(parseInt(accountsStatusEvent.btc_segwit.toString(), 10)).to.not.equal(NaN);
+            expect(parseInt(accountsStatusEvent.btc_legacy.toString(), 10)).to.not.equal(NaN);
+            expect(parseInt(accountsStatusEvent.eth_normal.toString(), 10)).to.not.equal(NaN);
+        });
+
+        cy.wrap(requests).then(requestsArr => {
+            const AccountsNonZeroBalanceEvent = requestsArr.find(
+                req => req.c_type === EventType.AccountsNonZeroBalance,
+            ) as unknown as Extract<
+                SuiteAnalyticsEvent,
+                { type: EventType.AccountsNonZeroBalance }
+            >['payload'];
+
+            // 0x73d0385F4d8E00C5e6504C6030F47BF6212736A8 has token and nobody will be able to move it without ETH
+            expect(parseInt(AccountsNonZeroBalanceEvent.eth_normal.toString(), 10)).to.not.equal(
+                NaN,
+            );
+        });
+
+        cy.wrap(requests).then(requestsArr => {
+            const accountsNonZeroBalanceEvent = requestsArr.find(
+                req => req.c_type === EventType.AccountsNonZeroBalance,
+            ) as unknown as Extract<
+                SuiteAnalyticsEvent,
+                { type: EventType.AccountsNonZeroBalance }
+            >['payload'];
+
+            // 0x73d0385F4d8E00C5e6504C6030F47BF6212736A8 has token and nobody will be able to move it without ETH
+            expect(parseInt(accountsNonZeroBalanceEvent.eth_normal.toString(), 10)).to.not.equal(
+                NaN,
+            );
+        });
+
+        cy.wrap(requests).then(requestsArr => {
+            const accountsTokensStatusEvent = requestsArr.find(
+                req => req.c_type === EventType.AccountsTokensStatus,
+            ) as unknown as Extract<
+                SuiteAnalyticsEvent,
+                { type: EventType.AccountsTokensStatus }
+            >['payload'];
+
+            // 0x73d0385F4d8E00C5e6504C6030F47BF6212736A8 has token and nobody will be able to move it without ETH
+            expect(parseInt(accountsTokensStatusEvent.eth.toString(), 10)).to.not.equal(NaN);
+        });
     });
 });
 

--- a/packages/suite-web/e2e/tests/dashboard/assets.test.ts
+++ b/packages/suite-web/e2e/tests/dashboard/assets.test.ts
@@ -1,10 +1,9 @@
 // @group:suite
 // @retry=2
 
-import { urlSearchParams } from '@trezor/suite/src/utils/suite/metadata';
 import { EventType, SuiteAnalyticsEvent } from '@trezor/suite-analytics';
+import { Requests } from '../../support/utils/shortcuts';
 
-type Requests = ReturnType<typeof urlSearchParams>[];
 let requests: Requests;
 
 describe('Assets', () => {
@@ -19,10 +18,7 @@ describe('Assets', () => {
         cy.viewport(1080, 1440).resetDb();
 
         requests = [];
-        cy.intercept({ hostname: 'data.trezor.io', url: '/suite/log/**' }, req => {
-            const params = urlSearchParams(req.url);
-            requests.push(params);
-        });
+        cy.interceptDataTrezorIo(requests);
     });
 
     it('checks that BTC and ETH accounts are available', () => {

--- a/packages/suite-web/e2e/tests/dashboard/discreet-mode.test.ts
+++ b/packages/suite-web/e2e/tests/dashboard/discreet-mode.test.ts
@@ -1,10 +1,9 @@
 // @group:suite
 // @retry=2
 
-import { urlSearchParams } from '@trezor/suite/src/utils/suite/metadata';
 import { EventType, SuiteAnalyticsEvent } from '@trezor/suite-analytics';
+import { Requests } from '../../support/utils/shortcuts';
 
-type Requests = ReturnType<typeof urlSearchParams>[];
 let requests: Requests;
 
 describe('Dashboard', () => {
@@ -21,10 +20,7 @@ describe('Dashboard', () => {
         cy.passThroughInitialRun();
 
         requests = [];
-        cy.intercept({ hostname: 'data.trezor.io', url: '/suite/log/**' }, req => {
-            const params = urlSearchParams(req.url);
-            requests.push(params);
-        });
+        cy.interceptDataTrezorIo(requests);
     });
 
     /*

--- a/packages/suite-web/e2e/tests/dashboard/discreet-mode.test.ts
+++ b/packages/suite-web/e2e/tests/dashboard/discreet-mode.test.ts
@@ -1,8 +1,8 @@
 // @group:suite
 // @retry=2
 
-import { EventType, SuiteAnalyticsEvent } from '@trezor/suite-analytics';
-import { Requests } from '../../support/utils/shortcuts';
+import { EventType } from '@trezor/suite-analytics';
+import { ExtractByEventType, Requests } from '../../support/types';
 
 let requests: Requests;
 
@@ -43,15 +43,11 @@ describe('Dashboard', () => {
                 expect(className).to.contain(discreetPartialClass);
             });
 
-        cy.wrap(requests).then(requestsArr => {
-            const MenuToggleDiscreetEvent = requestsArr.find(
-                req => req.c_type === EventType.MenuToggleDiscreet,
-            ) as unknown as Extract<
-                SuiteAnalyticsEvent,
-                { type: EventType.MenuToggleDiscreet }
-            >['payload'];
-
-            expect(MenuToggleDiscreetEvent.value).to.equal('true');
+        cy.findAnalyticsEventByType<ExtractByEventType<EventType.MenuToggleDiscreet>>(
+            requests,
+            EventType.MenuToggleDiscreet,
+        ).then(menuToggleDiscreetEvent => {
+            expect(menuToggleDiscreetEvent.value).to.equal('true');
         });
     });
 });

--- a/packages/suite-web/e2e/tests/metadata/interval-fetching.test.ts
+++ b/packages/suite-web/e2e/tests/metadata/interval-fetching.test.ts
@@ -1,7 +1,7 @@
 // @group:metadata
 // @retry=2
 
-import * as METADATA from '../../../../suite/src/actions/suite/constants/metadataConstants';
+import * as METADATA from '@trezor/suite/src/actions/suite/constants/metadataConstants';
 
 import { rerouteMetadataToMockProvider, stubOpen } from '../../stubs/metadata';
 

--- a/packages/suite-web/e2e/tests/settings/coins.test.ts
+++ b/packages/suite-web/e2e/tests/settings/coins.test.ts
@@ -1,8 +1,8 @@
 // @group:settings
 // @retry=2
 
-import { EventType, SuiteAnalyticsEvent } from '@trezor/suite-analytics';
-import { Requests } from '../../support/utils/shortcuts';
+import { EventType } from '@trezor/suite-analytics';
+import { ExtractByEventType, Requests } from '../../support/types';
 
 let requests: Requests;
 
@@ -91,14 +91,10 @@ describe('Coin Settings', () => {
             );
         });
 
-        cy.wrap(requests).then(requestsArr => {
-            const settingsCoinsEvent = requestsArr.find(
-                req => req.c_type === EventType.SettingsCoins,
-            ) as unknown as Extract<
-                SuiteAnalyticsEvent,
-                { type: EventType.SettingsCoins }
-            >['payload'];
-
+        cy.findAnalyticsEventByType<ExtractByEventType<EventType.SettingsCoins>>(
+            requests,
+            EventType.SettingsCoins,
+        ).then(settingsCoinsEvent => {
             expect(settingsCoinsEvent.symbol).to.be.oneOf(['btc', ...defaultUnchecked]);
             expect(settingsCoinsEvent.value).to.be.oneOf(['true', 'false']);
         });
@@ -110,14 +106,10 @@ describe('Coin Settings', () => {
         cy.getTestElement('@settings/advance/url').type('https://eth.marek.pl/');
         cy.getTestElement('@settings/advance/button/save').click();
 
-        cy.wrap(requests).then(requestsArr => {
-            const settingsCoinsBackendEvent = requestsArr.find(
-                req => req.c_type === EventType.SettingsCoinsBackend,
-            ) as unknown as Extract<
-                SuiteAnalyticsEvent,
-                { type: EventType.SettingsCoinsBackend }
-            >['payload'];
-
+        cy.findAnalyticsEventByType<ExtractByEventType<EventType.SettingsCoinsBackend>>(
+            requests,
+            EventType.SettingsCoinsBackend,
+        ).then(settingsCoinsBackendEvent => {
             expect(settingsCoinsBackendEvent.symbol).to.equal('eth');
             expect(settingsCoinsBackendEvent.type).to.equal('blockbook');
             expect(settingsCoinsBackendEvent.totalRegular).to.equal('1');

--- a/packages/suite-web/e2e/tests/settings/coins.test.ts
+++ b/packages/suite-web/e2e/tests/settings/coins.test.ts
@@ -1,6 +1,12 @@
 // @group:settings
 // @retry=2
 
+import { urlSearchParams } from '@trezor/suite/src/utils/suite/metadata';
+import { EventType, SuiteAnalyticsEvent } from '@trezor/suite-analytics';
+
+type Requests = ReturnType<typeof urlSearchParams>[];
+let requests: Requests;
+
 describe('Coin Settings', () => {
     beforeEach(() => {
         cy.task('startEmu', { wipe: true });
@@ -9,9 +15,15 @@ describe('Coin Settings', () => {
         cy.viewport(1080, 1440).resetDb();
         cy.prefixedVisit('/settings/coins');
         cy.passThroughInitialRun();
+
+        requests = [];
+        cy.intercept({ hostname: 'data.trezor.io', url: '/suite/log/**' }, req => {
+            const params = urlSearchParams(req.url);
+            requests.push(params);
+        });
     });
 
-    it('go to wallet settings page, check BTC, activate all coins, deactivate all coins and check dashboard', () => {
+    it('go to wallet settings page, check BTC, activate all coins, deactivate all coins, set custom backend', () => {
         const defaultUnchecked = [
             'ltc',
             'eth',
@@ -81,6 +93,39 @@ describe('Coin Settings', () => {
                 'data-active',
                 'true',
             );
+        });
+
+        cy.wrap(requests).then(requestsArr => {
+            const settingsCoinsEvent = requestsArr.find(
+                req => req.c_type === EventType.SettingsCoins,
+            ) as unknown as Extract<
+                SuiteAnalyticsEvent,
+                { type: EventType.SettingsCoins }
+            >['payload'];
+
+            expect(settingsCoinsEvent.symbol).to.be.oneOf(['btc', ...defaultUnchecked]);
+            expect(settingsCoinsEvent.value).to.be.oneOf(['true', 'false']);
+        });
+
+        // custom eth backend
+        cy.getTestElement('@settings/wallet/network/eth/advance').click();
+        cy.getTestElement('@settings/advance/select-type/input').click();
+        cy.getTestElement('@settings/advance/select-type/option/blockbook').click();
+        cy.getTestElement('@settings/advance/url').type('https://eth.marek.pl/');
+        cy.getTestElement('@settings/advance/button/save').click();
+
+        cy.wrap(requests).then(requestsArr => {
+            const settingsCoinsBackendEvent = requestsArr.find(
+                req => req.c_type === EventType.SettingsCoinsBackend,
+            ) as unknown as Extract<
+                SuiteAnalyticsEvent,
+                { type: EventType.SettingsCoinsBackend }
+            >['payload'];
+
+            expect(settingsCoinsBackendEvent.symbol).to.equal('eth');
+            expect(settingsCoinsBackendEvent.type).to.equal('blockbook');
+            expect(settingsCoinsBackendEvent.totalRegular).to.equal('1');
+            expect(settingsCoinsBackendEvent.totalOnion).to.equal('0');
         });
     });
 });

--- a/packages/suite-web/e2e/tests/settings/coins.test.ts
+++ b/packages/suite-web/e2e/tests/settings/coins.test.ts
@@ -1,10 +1,9 @@
 // @group:settings
 // @retry=2
 
-import { urlSearchParams } from '@trezor/suite/src/utils/suite/metadata';
 import { EventType, SuiteAnalyticsEvent } from '@trezor/suite-analytics';
+import { Requests } from '../../support/utils/shortcuts';
 
-type Requests = ReturnType<typeof urlSearchParams>[];
 let requests: Requests;
 
 describe('Coin Settings', () => {
@@ -17,10 +16,7 @@ describe('Coin Settings', () => {
         cy.passThroughInitialRun();
 
         requests = [];
-        cy.intercept({ hostname: 'data.trezor.io', url: '/suite/log/**' }, req => {
-            const params = urlSearchParams(req.url);
-            requests.push(params);
-        });
+        cy.interceptDataTrezorIo(requests);
     });
 
     it('go to wallet settings page, check BTC, activate all coins, deactivate all coins, set custom backend', () => {

--- a/packages/suite-web/e2e/tests/settings/general.test.ts
+++ b/packages/suite-web/e2e/tests/settings/general.test.ts
@@ -1,10 +1,9 @@
 // @group:settings
 // @retry=2
 
-import { urlSearchParams } from '@trezor/suite/src/utils/suite/metadata';
 import { EventType, SuiteAnalyticsEvent } from '@trezor/suite-analytics';
+import { Requests } from '../../support/utils/shortcuts';
 
-type Requests = ReturnType<typeof urlSearchParams>[];
 let requests: Requests;
 
 describe('General settings', () => {
@@ -19,10 +18,7 @@ describe('General settings', () => {
         cy.discoveryShouldFinish();
 
         requests = [];
-        cy.intercept({ hostname: 'data.trezor.io', url: '/suite/log/**' }, req => {
-            const params = urlSearchParams(req.url);
-            requests.push(params);
-        });
+        cy.interceptDataTrezorIo(requests);
     });
 
     it('Change settings on "general settings" page', () => {

--- a/packages/suite-web/e2e/tests/settings/general.test.ts
+++ b/packages/suite-web/e2e/tests/settings/general.test.ts
@@ -1,6 +1,12 @@
 // @group:settings
 // @retry=2
 
+import { urlSearchParams } from '@trezor/suite/src/utils/suite/metadata';
+import { EventType, SuiteAnalyticsEvent } from '@trezor/suite-analytics';
+
+type Requests = ReturnType<typeof urlSearchParams>[];
+let requests: Requests;
+
 describe('General settings', () => {
     beforeEach(() => {
         cy.task('startEmu', { wipe: true });
@@ -11,6 +17,12 @@ describe('General settings', () => {
         cy.prefixedVisit('/');
         cy.passThroughInitialRun();
         cy.discoveryShouldFinish();
+
+        requests = [];
+        cy.intercept({ hostname: 'data.trezor.io', url: '/suite/log/**' }, req => {
+            const params = urlSearchParams(req.url);
+            requests.push(params);
+        });
     });
 
     it('Change settings on "general settings" page', () => {
@@ -24,6 +36,17 @@ describe('General settings', () => {
         cy.getTestElement('@settings/fiat-select/input').click();
         cy.getTestElement('@settings/fiat-select/option/eur').click();
 
+        cy.wrap(requests).then(requestsArr => {
+            const settingsGeneralChangeFiatEvent = requestsArr.find(
+                req => req.c_type === EventType.SettingsGeneralChangeFiat,
+            ) as Extract<
+                SuiteAnalyticsEvent,
+                { type: EventType.SettingsGeneralChangeFiat }
+            >['payload'];
+
+            expect(settingsGeneralChangeFiatEvent.fiat).to.equal('eur');
+        });
+
         // go to dashboard and check currency
         cy.getTestElement('@suite/menu/suite-index').click();
         cy.getTestElement('@dashboard/index').should('contain', '€0.00');
@@ -31,24 +54,65 @@ describe('General settings', () => {
         // go to settings
         cy.getTestElement('@suite/menu/settings').click();
 
-        // change language
-        cy.getTestElement('@settings/language-select/input').click();
-        cy.getTestElement('@settings/language-select/option/en').click();
-        cy.getTestElement('@settings/language-select/input').should('contain', 'English');
-
         // change dark mode
         cy.getTestElement('@theme/color-scheme-select/input').click();
         cy.getTestElement('@theme/color-scheme-select/option/dark').click();
         cy.getTestElement('@theme/color-scheme-select/input').should('contain', 'Dark');
+
+        cy.wrap(requests).then(requestsArr => {
+            const settingsGeneralChangeThemeEvent = requestsArr.find(
+                req => req.c_type === EventType.SettingsGeneralChangeTheme,
+            ) as unknown as Extract<
+                SuiteAnalyticsEvent,
+                { type: EventType.SettingsGeneralChangeTheme }
+            >['payload'];
+
+            expect(settingsGeneralChangeThemeEvent.platformTheme).to.not.be.undefined;
+            expect(settingsGeneralChangeThemeEvent.previousTheme).to.not.be.undefined;
+            expect(settingsGeneralChangeThemeEvent.previousAutodetectTheme).to.equal('true');
+            expect(settingsGeneralChangeThemeEvent.autodetectTheme).to.equal('false');
+            expect(settingsGeneralChangeThemeEvent.theme).to.equal('dark');
+        });
+
+        // there is suite version also listed
+        cy.contains('Suite version');
+        cy.contains('You are currently running version');
+
+        // change language
+        cy.getTestElement('@settings/language-select/input').click();
+        cy.getTestElement('@settings/language-select/option/es').click();
+        cy.getTestElement('@settings/language-select/input').should('contain', 'Español');
+
+        cy.wrap(requests).then(requestsArr => {
+            const settingsGeneralChangeLanguageEvent = requestsArr.find(
+                req => req.c_type === EventType.SettingsGeneralChangeLanguage,
+            ) as unknown as Extract<
+                SuiteAnalyticsEvent,
+                { type: EventType.SettingsGeneralChangeLanguage }
+            >['payload'];
+
+            expect(settingsGeneralChangeLanguageEvent.language).to.equal('es');
+            expect(settingsGeneralChangeLanguageEvent.previousLanguage).to.equal('en');
+            expect(settingsGeneralChangeLanguageEvent.autodetectLanguage).to.equal('false');
+            expect(settingsGeneralChangeLanguageEvent.previousAutodetectLanguage).to.equal('true');
+            expect(settingsGeneralChangeLanguageEvent.platformLanguages).to.not.be.undefined;
+        });
 
         // toggle analytics
         cy.getTestElement('@analytics/toggle-switch').find('input').should('be.checked');
         cy.getTestElement('@analytics/toggle-switch').click({ force: true });
         cy.getTestElement('@analytics/toggle-switch').find('input').should('not.be.checked');
 
-        // there is suite version also listed
-        cy.contains('Suite version');
-        cy.contains('You are currently running version');
+        cy.wrap(requests).then(requestsArr => {
+            const settingsAnalyticsEvent = requestsArr.find(
+                req => req.c_type === EventType.SettingsAnalytics,
+            ) as unknown as Extract<
+                SuiteAnalyticsEvent,
+                { type: EventType.SettingsAnalytics }
+            >['payload'];
+
+            expect(settingsAnalyticsEvent.value).to.equal('false');
+        });
 
         // and reset app button - wipes db, reloads app, shows onboarding again
         cy.getTestElement('@settings/reset-app-button').click();

--- a/packages/suite-web/e2e/tests/settings/general.test.ts
+++ b/packages/suite-web/e2e/tests/settings/general.test.ts
@@ -1,8 +1,8 @@
 // @group:settings
 // @retry=2
 
-import { EventType, SuiteAnalyticsEvent } from '@trezor/suite-analytics';
-import { Requests } from '../../support/utils/shortcuts';
+import { EventType } from '@trezor/suite-analytics';
+import { ExtractByEventType, Requests } from '../../support/types';
 
 let requests: Requests;
 
@@ -32,14 +32,10 @@ describe('General settings', () => {
         cy.getTestElement('@settings/fiat-select/input').click();
         cy.getTestElement('@settings/fiat-select/option/eur').click();
 
-        cy.wrap(requests).then(requestsArr => {
-            const settingsGeneralChangeFiatEvent = requestsArr.find(
-                req => req.c_type === EventType.SettingsGeneralChangeFiat,
-            ) as Extract<
-                SuiteAnalyticsEvent,
-                { type: EventType.SettingsGeneralChangeFiat }
-            >['payload'];
-
+        cy.findAnalyticsEventByType<ExtractByEventType<EventType.SettingsGeneralChangeFiat>>(
+            requests,
+            EventType.SettingsGeneralChangeFiat,
+        ).then(settingsGeneralChangeFiatEvent => {
             expect(settingsGeneralChangeFiatEvent.fiat).to.equal('eur');
         });
 
@@ -55,14 +51,10 @@ describe('General settings', () => {
         cy.getTestElement('@theme/color-scheme-select/option/dark').click();
         cy.getTestElement('@theme/color-scheme-select/input').should('contain', 'Dark');
 
-        cy.wrap(requests).then(requestsArr => {
-            const settingsGeneralChangeThemeEvent = requestsArr.find(
-                req => req.c_type === EventType.SettingsGeneralChangeTheme,
-            ) as unknown as Extract<
-                SuiteAnalyticsEvent,
-                { type: EventType.SettingsGeneralChangeTheme }
-            >['payload'];
-
+        cy.findAnalyticsEventByType<ExtractByEventType<EventType.SettingsGeneralChangeTheme>>(
+            requests,
+            EventType.SettingsGeneralChangeTheme,
+        ).then(settingsGeneralChangeThemeEvent => {
             expect(settingsGeneralChangeThemeEvent.platformTheme).to.not.be.undefined;
             expect(settingsGeneralChangeThemeEvent.previousTheme).to.not.be.undefined;
             expect(settingsGeneralChangeThemeEvent.previousAutodetectTheme).to.equal('true');
@@ -79,14 +71,10 @@ describe('General settings', () => {
         cy.getTestElement('@settings/language-select/option/es').click();
         cy.getTestElement('@settings/language-select/input').should('contain', 'Español');
 
-        cy.wrap(requests).then(requestsArr => {
-            const settingsGeneralChangeLanguageEvent = requestsArr.find(
-                req => req.c_type === EventType.SettingsGeneralChangeLanguage,
-            ) as unknown as Extract<
-                SuiteAnalyticsEvent,
-                { type: EventType.SettingsGeneralChangeLanguage }
-            >['payload'];
-
+        cy.findAnalyticsEventByType<ExtractByEventType<EventType.SettingsGeneralChangeLanguage>>(
+            requests,
+            EventType.SettingsGeneralChangeLanguage,
+        ).then(settingsGeneralChangeLanguageEvent => {
             expect(settingsGeneralChangeLanguageEvent.language).to.equal('es');
             expect(settingsGeneralChangeLanguageEvent.previousLanguage).to.equal('en');
             expect(settingsGeneralChangeLanguageEvent.autodetectLanguage).to.equal('false');
@@ -99,14 +87,10 @@ describe('General settings', () => {
         cy.getTestElement('@analytics/toggle-switch').click({ force: true });
         cy.getTestElement('@analytics/toggle-switch').find('input').should('not.be.checked');
 
-        cy.wrap(requests).then(requestsArr => {
-            const settingsAnalyticsEvent = requestsArr.find(
-                req => req.c_type === EventType.SettingsAnalytics,
-            ) as unknown as Extract<
-                SuiteAnalyticsEvent,
-                { type: EventType.SettingsAnalytics }
-            >['payload'];
-
+        cy.findAnalyticsEventByType<ExtractByEventType<EventType.SettingsAnalytics>>(
+            requests,
+            EventType.SettingsAnalytics,
+        ).then(settingsAnalyticsEvent => {
             expect(settingsAnalyticsEvent.value).to.equal('false');
         });
 

--- a/packages/suite-web/e2e/tests/suite/passphrase.test.ts
+++ b/packages/suite-web/e2e/tests/suite/passphrase.test.ts
@@ -1,9 +1,8 @@
 // @group:passphrase
 // @retry=2
-import { urlSearchParams } from '@trezor/suite/src/utils/suite/metadata';
 import { EventType, SuiteAnalyticsEvent } from '@trezor/suite-analytics';
+import { Requests } from '../../support/utils/shortcuts';
 
-type Requests = ReturnType<typeof urlSearchParams>[];
 let requests: Requests;
 
 const abcAddr = 'bc1qpyfvfvm52zx7gek86ajj5pkkne3h385ada8r2y';
@@ -110,10 +109,7 @@ describe('Passphrase', () => {
         cy.task('pressYes');
         cy.task('pressYes');
 
-        cy.intercept({ hostname: 'data.trezor.io', url: '/suite/log/**' }, req => {
-            const params = urlSearchParams(req.url);
-            requests.push(params);
-        });
+        cy.interceptDataTrezorIo(requests);
 
         cy.getTestElement('@dashboard/wallet-ready');
         // go to wallet

--- a/packages/suite-web/e2e/tests/suite/passphrase.test.ts
+++ b/packages/suite-web/e2e/tests/suite/passphrase.test.ts
@@ -1,7 +1,7 @@
 // @group:passphrase
 // @retry=2
-import { EventType, SuiteAnalyticsEvent } from '@trezor/suite-analytics';
-import { Requests } from '../../support/utils/shortcuts';
+import { EventType } from '@trezor/suite-analytics';
+import { ExtractByEventType, Requests } from '../../support/types';
 
 let requests: Requests;
 
@@ -144,11 +144,10 @@ describe('Passphrase', () => {
         cy.getTestElement('@passphrase/hidden/submit-button').click();
         cy.getTestElement('@modal').should('not.exist');
 
-        cy.wrap(requests).then(requestsArr => {
-            const selectWalletTypeEvent = requestsArr.find(
-                req => req.c_type === EventType.SelectWalletType,
-            ) as Extract<SuiteAnalyticsEvent, { type: EventType.SelectWalletType }>['payload'];
-
+        cy.findAnalyticsEventByType<ExtractByEventType<EventType.SelectWalletType>>(
+            requests,
+            EventType.SelectWalletType,
+        ).then(selectWalletTypeEvent => {
             expect(selectWalletTypeEvent.type).to.equal('hidden');
         });
 

--- a/packages/suite-web/e2e/tests/suite/version-page.test.ts
+++ b/packages/suite-web/e2e/tests/suite/version-page.test.ts
@@ -1,6 +1,6 @@
 // @group:suite
 // @retry=2
-import { suiteVersion } from '../../../../suite/package.json';
+import { getSuiteVersion } from '@trezor/env-utils';
 
 describe('There is a hidden route (not accessible in UI)', () => {
     beforeEach(() => {
@@ -8,6 +8,8 @@ describe('There is a hidden route (not accessible in UI)', () => {
     });
 
     it('/version', () => {
+        const suiteVersion = getSuiteVersion();
+
         cy.prefixedVisit('/version');
         cy.getTestElement('@version/number').should('contain', suiteVersion);
         cy.getTestElement('@modal/version').screenshot('version-modal');

--- a/packages/suite-web/e2e/tests/wallet/add-account-types.test.ts
+++ b/packages/suite-web/e2e/tests/wallet/add-account-types.test.ts
@@ -5,10 +5,9 @@ import { onAccountsPage } from '../../support/pageObjects/accountsObject';
 import { onSettingsCryptoPage } from '../../support/pageObjects/settingsCryptoObject';
 import { onTopBar } from '../../support/pageObjects/topBarObject';
 import { NetworkSymbol } from '@suite-common/wallet-config';
-import { urlSearchParams } from '@trezor/suite/src/utils/suite/metadata';
 import { EventType, SuiteAnalyticsEvent } from '@trezor/suite-analytics';
+import { Requests } from '../../support/utils/shortcuts';
 
-type Requests = ReturnType<typeof urlSearchParams>[];
 let requests: Requests;
 
 describe('Account types suite', () => {
@@ -25,10 +24,7 @@ describe('Account types suite', () => {
         cy.discoveryShouldFinish();
 
         requests = [];
-        cy.intercept({ hostname: 'data.trezor.io', url: '/suite/log/**' }, req => {
-            const params = urlSearchParams(req.url);
-            requests.push(params);
-        });
+        cy.interceptDataTrezorIo(requests);
     });
 
     afterEach(() => {

--- a/packages/suite-web/e2e/tests/wallet/add-account-types.test.ts
+++ b/packages/suite-web/e2e/tests/wallet/add-account-types.test.ts
@@ -5,8 +5,8 @@ import { onAccountsPage } from '../../support/pageObjects/accountsObject';
 import { onSettingsCryptoPage } from '../../support/pageObjects/settingsCryptoObject';
 import { onTopBar } from '../../support/pageObjects/topBarObject';
 import { NetworkSymbol } from '@suite-common/wallet-config';
-import { EventType, SuiteAnalyticsEvent } from '@trezor/suite-analytics';
-import { Requests } from '../../support/utils/shortcuts';
+import { EventType } from '@trezor/suite-analytics';
+import { ExtractByEventType, Requests } from '../../support/types';
 
 let requests: Requests;
 
@@ -84,11 +84,10 @@ describe('Account types suite', () => {
         //     const numberOfAccounts1 = newAccounts.length;
         //     expect(numberOfAccounts1).to.be.equal(currentAccounts.length);
 
-        cy.wrap(requests).then(requestsArr => {
-            const accountsNewAccountEvent = requestsArr.find(
-                req => req.c_type === EventType.AccountsNewAccount,
-            ) as Extract<SuiteAnalyticsEvent, { type: EventType.AccountsNewAccount }>['payload'];
-
+        cy.findAnalyticsEventByType<ExtractByEventType<EventType.AccountsNewAccount>>(
+            requests,
+            EventType.AccountsNewAccount,
+        ).then(accountsNewAccountEvent => {
             expect(accountsNewAccountEvent.symbol).to.equal('btc');
             expect(accountsNewAccountEvent.path).to.equal(`m/84'/0'/1'`);
             expect(accountsNewAccountEvent.type).to.equal('normal'); // normal is first
@@ -147,11 +146,10 @@ describe('Account types suite', () => {
         //     expect(numberOfAccounts1).to.be.equal(1);
         // });
 
-        cy.wrap(requests).then(requestsArr => {
-            const accountsNewAccountEvent = requestsArr.find(
-                req => req.c_type === EventType.AccountsNewAccount,
-            ) as Extract<SuiteAnalyticsEvent, { type: EventType.AccountsNewAccount }>['payload'];
-
+        cy.findAnalyticsEventByType<ExtractByEventType<EventType.AccountsNewAccount>>(
+            requests,
+            EventType.AccountsNewAccount,
+        ).then(accountsNewAccountEvent => {
             expect(accountsNewAccountEvent.symbol).to.equal('ltc');
             expect(accountsNewAccountEvent.path).to.equal(`m/84'/2'/1'`);
             expect(accountsNewAccountEvent.type).to.equal('normal'); // normal is first
@@ -210,11 +208,10 @@ describe('Account types suite', () => {
             );
         });
 
-        cy.wrap(requests).then(requestsArr => {
-            const accountsNewAccountEvent = requestsArr.find(
-                req => req.c_type === EventType.AccountsNewAccount,
-            ) as Extract<SuiteAnalyticsEvent, { type: EventType.AccountsNewAccount }>['payload'];
-
+        cy.findAnalyticsEventByType<ExtractByEventType<EventType.AccountsNewAccount>>(
+            requests,
+            EventType.AccountsNewAccount,
+        ).then(accountsNewAccountEvent => {
             expect(accountsNewAccountEvent.symbol).to.equal('ada'); // ada is first
             expect(accountsNewAccountEvent.path).to.equal(`m/1852'/1815'/1'`);
             expect(accountsNewAccountEvent.type).to.equal('normal'); // normal is first

--- a/packages/suite-web/package.json
+++ b/packages/suite-web/package.json
@@ -27,6 +27,7 @@
         "@cypress/skip-test": "^2.6.1",
         "@suite-common/test-utils": "workspace:*",
         "@trezor/e2e-utils": "workspace:*",
+        "@trezor/env-utils": "workspace:*",
         "@trezor/suite-analytics": "workspace:*",
         "@trezor/trezor-user-env-link": "workspace:*",
         "@trezor/utils": "workspace:*",

--- a/packages/suite-web/package.json
+++ b/packages/suite-web/package.json
@@ -27,6 +27,7 @@
         "@cypress/skip-test": "^2.6.1",
         "@suite-common/test-utils": "workspace:*",
         "@trezor/e2e-utils": "workspace:*",
+        "@trezor/suite-analytics": "workspace:*",
         "@trezor/trezor-user-env-link": "workspace:*",
         "@trezor/utils": "workspace:*",
         "@types/chrome-remote-interface": "^0.31.9",

--- a/packages/suite-web/package.json
+++ b/packages/suite-web/package.json
@@ -38,7 +38,7 @@
         "@types/react-router-dom": "^5.1.7",
         "@types/styled-components": "^5.1.26",
         "chrome-remote-interface": "^0.32.2",
-        "cypress": "^12.12.0",
+        "cypress": "^12.14.0",
         "cypress-file-upload": "^5.0.8",
         "cypress-image-snapshot": "^4.0.1",
         "cypress-wait-until": "^1.7.2",

--- a/packages/suite-web/tsconfig.json
+++ b/packages/suite-web/tsconfig.json
@@ -16,6 +16,8 @@
             "path": "../../suite-common/test-utils"
         },
         { "path": "../e2e-utils" },
+        { "path": "../env-utils" },
+        { "path": "../suite-analytics" },
         { "path": "../trezor-user-env-link" },
         { "path": "../utils" }
     ]

--- a/suite-native/app/index.js
+++ b/suite-native/app/index.js
@@ -8,7 +8,7 @@ import { App } from './src/App';
 if (__DEV__) {
     // Flipper plugin for debugging websocket traffic.
     // more: https://github.com/Matju-M/flipper-plugin-basil-ws
-    // eslint-disable-next-line no-unused-expressions, global-require
+    // eslint-disable-next-line global-require, chai-friendly/no-unused-expressions
     require('basil-ws-flipper').wsDebugPlugin;
 }
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -16620,6 +16620,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"eslint-plugin-chai-friendly@npm:^0.7.2":
+  version: 0.7.2
+  resolution: "eslint-plugin-chai-friendly@npm:0.7.2"
+  peerDependencies:
+    eslint: ">=3.0.0"
+  checksum: a9c70da37361b54d9cdd4f7c26a3d83caed106a239d21268b8fdaa6b30c0a097dab6ff76a320e40325fd6d27f395eb5cf914c56f5aaf5215d5614f515bbfc975
+  languageName: node
+  linkType: hard
+
 "eslint-plugin-cypress@npm:^2.13.3":
   version: 2.13.3
   resolution: "eslint-plugin-cypress@npm:2.13.3"
@@ -32405,6 +32414,7 @@ __metadata:
     eslint-config-airbnb: ^18.2.1
     eslint-config-prettier: ^8.8.0
     eslint-import-resolver-typescript: ^3.5.5
+    eslint-plugin-chai-friendly: ^0.7.2
     eslint-plugin-cypress: ^2.13.3
     eslint-plugin-import: ^2.27.5
     eslint-plugin-jest: ^27.2.1

--- a/yarn.lock
+++ b/yarn.lock
@@ -8188,6 +8188,7 @@ __metadata:
     "@trezor/device-utils": "workspace:*"
     "@trezor/e2e-utils": "workspace:*"
     "@trezor/suite": "workspace:*"
+    "@trezor/suite-analytics": "workspace:*"
     "@trezor/trezor-user-env-link": "workspace:*"
     "@trezor/utils": "workspace:*"
     "@types/chrome-remote-interface": ^0.31.9

--- a/yarn.lock
+++ b/yarn.lock
@@ -8199,7 +8199,7 @@ __metadata:
     "@types/react-router-dom": ^5.1.7
     "@types/styled-components": ^5.1.26
     chrome-remote-interface: ^0.32.2
-    cypress: ^12.12.0
+    cypress: ^12.14.0
     cypress-file-upload: ^5.0.8
     cypress-image-snapshot: ^4.0.1
     cypress-wait-until: ^1.7.2
@@ -14481,9 +14481,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"cypress@npm:^12.12.0":
-  version: 12.12.0
-  resolution: "cypress@npm:12.12.0"
+"cypress@npm:^12.14.0":
+  version: 12.14.0
+  resolution: "cypress@npm:12.14.0"
   dependencies:
     "@cypress/request": ^2.88.10
     "@cypress/xvfb": ^1.2.4
@@ -14529,7 +14529,7 @@ __metadata:
     yauzl: ^2.10.0
   bin:
     cypress: bin/cypress
-  checksum: 5ab0a8bc58c8af90cdb5fea93692422e6e74436ffdaeb41853e91a3fcfcdb7a39ad6ae512537bf0edf25cc3bc3732248a32e8ad3bec3440d5f527f3a3b4650b7
+  checksum: c98d33dc50f5e48a215f41e3a5139514816d2320e433d143a352a460f74941d3106a1f7485f61172f544cf125176c1225ac8edec31645d5a89cd394f72f93588
   languageName: node
   linkType: hard
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -8187,6 +8187,7 @@ __metadata:
     "@suite-common/test-utils": "workspace:*"
     "@trezor/device-utils": "workspace:*"
     "@trezor/e2e-utils": "workspace:*"
+    "@trezor/env-utils": "workspace:*"
     "@trezor/suite": "workspace:*"
     "@trezor/suite-analytics": "workspace:*"
     "@trezor/trezor-user-env-link": "workspace:*"


### PR DESCRIPTION
## Description

- check that `transport-type`, `suite-ready`, `device-connect`, `device-disconnect` events are reported with correct values in separate file
- update user agent strings for unsupported browsers to be more up-to-date
- add checks of other analytics events to existing tests
- add eslint plugin lib to do not say that code like this is incorrect 
`expect(suiteReadyEvent.screenWidth).to.exist.and.not.to.be.empty;`
- last commit creates `cy.task` from shared logic

## Related Issue

closes #8698

## Screenshots:

![Screenshot 2023-06-14 at 14 39 48](https://github.com/trezor/trezor-suite/assets/33235762/cdfda6eb-3830-437e-81a8-27676a6d33c0)
