### PR TITLE
Fix/memoization

### DIFF
--- a/packages/suite/package.json
+++ b/packages/suite/package.json
@@ -81,7 +81,6 @@
         "lottie-react": "^2.4.0",
         "pdfmake": "^0.2.7",
         "polished": "^4.2.2",
-        "proxy-memoize": "2.0.2",
         "qrcode.react": "^3.1.0",
         "react": "18.2.0",
         "react-dom": "18.2.0",

--- a/packages/suite/src/reducers/suite/metadataReducer.ts
+++ b/packages/suite/src/reducers/suite/metadataReducer.ts
@@ -1,16 +1,19 @@
 import produce from 'immer';
-import { createSelector } from '@reduxjs/toolkit';
 
 import { STORAGE, METADATA } from 'src/actions/suite/constants';
 import { Action } from 'src/types/suite';
 import { MetadataState } from 'src/types/suite/metadata';
-import { selectDevice } from 'src/reducers/suite/suiteReducer';
+import { selectDevice, SuiteRootState } from 'src/reducers/suite/suiteReducer';
 
 export const initialState: MetadataState = {
     // is Suite trying to load metadata (get master key -> sync cloud)?
     enabled: false,
     initiating: false,
 };
+
+type MetadataRootState = {
+    metadata: MetadataState;
+} & SuiteRootState;
 
 const metadataReducer = (state = initialState, action: Action): MetadataState =>
     produce(state, draft => {
@@ -36,13 +39,12 @@ const metadataReducer = (state = initialState, action: Action): MetadataState =>
         }
     });
 
-const selectMetadata = (state: { metadata: MetadataState }) => state.metadata;
-
 // is everything ready (more or less) to add label?
-export const selectIsLabelingAvailable = createSelector(
-    [selectDevice, selectMetadata],
-    (device, metadata) =>
-        !!(metadata.enabled && device?.metadata?.status === 'enabled' && metadata.provider),
-);
+export const selectIsLabelingAvailable = (state: MetadataRootState) => {
+    const { enabled, provider } = state.metadata;
+    const device = selectDevice(state);
+
+    return !!(enabled && device?.metadata?.status === 'enabled' && provider);
+};
 
 export default metadataReducer;

--- a/packages/suite/src/reducers/suite/suiteReducer.ts
+++ b/packages/suite/src/reducers/suite/suiteReducer.ts
@@ -1,5 +1,4 @@
 import produce from 'immer';
-import { memoizeWithArgs, memoize } from 'proxy-memoize';
 import { TRANSPORT, TransportInfo, ConnectSettings } from '@trezor/connect';
 import { SuiteThemeVariant } from '@trezor/suite-desktop-api';
 import { Action, TrezorDevice, Lock, TorBootstrap, TorStatus } from 'src/types/suite';
@@ -254,7 +253,7 @@ const suiteReducer = (state: SuiteState = initialState, action: Action): SuiteSt
         }
     });
 
-export const selectTorState = memoize((state: SuiteRootState) => {
+export const selectTorState = (state: SuiteRootState) => {
     const { torStatus, torBootstrap } = state.suite;
     return {
         isTorEnabled: getIsTorEnabled(torStatus),
@@ -265,33 +264,29 @@ export const selectTorState = memoize((state: SuiteRootState) => {
         isTorEnabling: torStatus === TorStatus.Enabling,
         torBootstrap,
     };
-});
+};
 
-export const selectDeviceState = memoize((state: SuiteRootState) => {
+export const selectDeviceState = (state: SuiteRootState) => {
     const { device } = state.suite;
     return device && getStatus(device);
-});
+};
 
 export const selectDebug = (state: SuiteRootState) => state.suite.settings.debug;
 
 export const selectDevice = (state: SuiteRootState) => state.suite.device;
 
-export const selectDeviceModel = memoizeWithArgs(
-    (state: SuiteRootState, overrideDevice?: TrezorDevice) => {
-        const device = selectDevice(state);
-        return getDeviceModel(overrideDevice || device);
-    },
-);
+export const selectDeviceModel = (state: SuiteRootState, overrideDevice?: TrezorDevice) => {
+    const device = selectDevice(state);
+    return getDeviceModel(overrideDevice || device);
+};
 
 export const selectLanguage = (state: SuiteRootState) => state.suite.settings.language;
 
 export const selectLocks = (state: SuiteRootState) => state.suite.locks;
 
-export const selectIsDeviceLocked = memoize(
-    (state: SuiteRootState) =>
-        state.suite.locks.includes(SUITE.LOCK_TYPE.DEVICE) ||
-        state.suite.locks.includes(SUITE.LOCK_TYPE.UI),
-);
+export const selectIsDeviceLocked = (state: SuiteRootState) =>
+    state.suite.locks.includes(SUITE.LOCK_TYPE.DEVICE) ||
+    state.suite.locks.includes(SUITE.LOCK_TYPE.UI);
 
 export const selectIsActionAbortable = (state: SuiteRootState) =>
     state.suite.transport?.type === 'BridgeTransport'

--- a/packages/suite/src/reducers/wallet/coinjoinReducer.ts
+++ b/packages/suite/src/reducers/wallet/coinjoinReducer.ts
@@ -1,5 +1,4 @@
 import produce from 'immer';
-import { memoizeWithArgs, memoize } from 'proxy-memoize';
 import BigNumber from 'bignumber.js';
 
 import { CoinjoinStatusEvent, getInputSize, getOutputSize } from '@trezor/coinjoin';
@@ -620,27 +619,21 @@ export const selectMaxMiningFeeModifier = (state: CoinjoinRootState) =>
 export const selectMaxMiningFeeConfig = (state: CoinjoinRootState) =>
     state.wallet.coinjoin.config.maxFeePerVbyte;
 
-export const selectCoinjoinAccountByKey = memoizeWithArgs(
-    (state: CoinjoinRootState, accountKey: AccountKey) => {
-        const coinjoinAccounts = selectCoinjoinAccounts(state);
-        return coinjoinAccounts.find(account => account.key === accountKey);
-    },
-);
+export const selectCoinjoinAccountByKey = (state: CoinjoinRootState, accountKey: AccountKey) => {
+    const coinjoinAccounts = selectCoinjoinAccounts(state);
+    return coinjoinAccounts.find(account => account.key === accountKey);
+};
 
-export const selectCoinjoinClient = memoizeWithArgs(
-    (state: CoinjoinRootState, accountKey: AccountKey) => {
-        const coinjoinAccount = selectCoinjoinAccountByKey(state, accountKey);
-        const clients = selectCoinjoinClients(state);
-        return coinjoinAccount?.symbol && clients[coinjoinAccount?.symbol];
-    },
-);
+export const selectCoinjoinClient = (state: CoinjoinRootState, accountKey: AccountKey) => {
+    const coinjoinAccount = selectCoinjoinAccountByKey(state, accountKey);
+    const clients = selectCoinjoinClients(state);
+    return coinjoinAccount?.symbol && clients[coinjoinAccount?.symbol];
+};
 
-export const selectSessionByAccountKey = memoizeWithArgs(
-    (state: CoinjoinRootState, accountKey: AccountKey) => {
-        const coinjoinAccounts = selectCoinjoinAccounts(state);
-        return coinjoinAccounts.find(account => account.key === accountKey)?.session;
-    },
-);
+export const selectSessionByAccountKey = (state: CoinjoinRootState, accountKey: AccountKey) => {
+    const coinjoinAccounts = selectCoinjoinAccounts(state);
+    return coinjoinAccounts.find(account => account.key === accountKey)?.session;
+};
 
 export const selectTargetAnonymityByAccountKey = (
     state: CoinjoinRootState,
@@ -651,7 +644,6 @@ export const selectTargetAnonymityByAccountKey = (
     return coinjoinAccount.setup?.targetAnonymity ?? DEFAULT_TARGET_ANONYMITY;
 };
 
-// memoization was causing incorrect return from the selector
 export const selectCurrentCoinjoinBalanceBreakdown = (state: CoinjoinRootState) => {
     const selectedAccount = selectSelectedAccount(state);
     const targetAnonymity = selectedAccount
@@ -713,7 +705,7 @@ export const selectSessionProgressByAccountKey = (
     return progress;
 };
 
-export const selectCurrentCoinjoinSession = memoize((state: CoinjoinRootState) => {
+export const selectCurrentCoinjoinSession = (state: CoinjoinRootState) => {
     const selectedAccount = selectSelectedAccount(state);
     const coinjoinAccounts = selectCoinjoinAccounts(state);
 
@@ -724,7 +716,7 @@ export const selectCurrentCoinjoinSession = memoize((state: CoinjoinRootState) =
     const { session } = currentCoinjoinAccount || {};
 
     return session;
-});
+};
 
 export const selectCurrentTargetAnonymity = (state: CoinjoinRootState) => {
     const selectedAccount = selectSelectedAccount(state);
@@ -735,7 +727,7 @@ export const selectCurrentTargetAnonymity = (state: CoinjoinRootState) => {
     return targetAnonymity;
 };
 
-export const selectIsCoinjoinBlockedByTor = memoize((state: CoinjoinRootState) => {
+export const selectIsCoinjoinBlockedByTor = (state: CoinjoinRootState) => {
     const { isTorEnabled } = selectTorState(state);
 
     if (state.wallet.coinjoin.debug?.coinjoinAllowNoTor) {
@@ -743,27 +735,29 @@ export const selectIsCoinjoinBlockedByTor = memoize((state: CoinjoinRootState) =
     }
 
     return !isTorEnabled;
-});
+};
 
-export const selectIsAnySessionInCriticalPhase = memoize((state: CoinjoinRootState) => {
+export const selectIsAnySessionInCriticalPhase = (state: CoinjoinRootState) => {
     const coinjoinAccounts = selectCoinjoinAccounts(state);
 
     return coinjoinAccounts.some(acc => (acc.session?.roundPhase ?? 0) > 0);
-});
+};
 
-export const selectIsAccountWithSessionInCriticalPhaseByAccountKey = memoizeWithArgs(
-    (state: CoinjoinRootState, accountKey: AccountKey) => {
-        const coinjoinAccount = selectCoinjoinAccountByKey(state, accountKey);
-        return (coinjoinAccount?.session?.roundPhase ?? 0) > 0;
-    },
-);
+export const selectIsAccountWithSessionInCriticalPhaseByAccountKey = (
+    state: CoinjoinRootState,
+    accountKey: AccountKey,
+) => {
+    const coinjoinAccount = selectCoinjoinAccountByKey(state, accountKey);
+    return (coinjoinAccount?.session?.roundPhase ?? 0) > 0;
+};
 
-export const selectIsAccountWithSessionByAccountKey = memoizeWithArgs(
-    (state: CoinjoinRootState, accountKey: AccountKey) => {
-        const coinjoinAccounts = selectCoinjoinAccounts(state);
-        return coinjoinAccounts.find(a => a.key === accountKey && a.session && !a.session.paused);
-    },
-);
+export const selectIsAccountWithSessionByAccountKey = (
+    state: CoinjoinRootState,
+    accountKey: AccountKey,
+) => {
+    const coinjoinAccounts = selectCoinjoinAccounts(state);
+    return coinjoinAccounts.find(a => a.key === accountKey && a.session && !a.session.paused);
+};
 
 export const selectfeeRateMedianByAccountKey = (
     state: CoinjoinRootState,
@@ -792,21 +786,22 @@ export const selectMinAllowedInputWithFee = (state: CoinjoinRootState, accountKe
     return minAllowedInput + txSize * status.feeRateMedian;
 };
 
-export const selectIsNothingToAnonymizeByAccountKey = memoizeWithArgs(
-    (state: CoinjoinRootState, accountKey: AccountKey) => {
-        const minAllowedInputWithFee = selectMinAllowedInputWithFee(state, accountKey);
-        const account = selectAccountByKey(state, accountKey);
-        const targetAnonymity = selectTargetAnonymityByAccountKey(state, accountKey) ?? 1;
+export const selectIsNothingToAnonymizeByAccountKey = (
+    state: CoinjoinRootState,
+    accountKey: AccountKey,
+) => {
+    const minAllowedInputWithFee = selectMinAllowedInputWithFee(state, accountKey);
+    const account = selectAccountByKey(state, accountKey);
+    const targetAnonymity = selectTargetAnonymityByAccountKey(state, accountKey) ?? 1;
 
-        const anonymitySet = account?.addresses?.anonymitySet || {};
-        const utxos = account?.utxo || [];
+    const anonymitySet = account?.addresses?.anonymitySet || {};
+    const utxos = account?.utxo || [];
 
-        // Return true if all non-private funds are too small.
-        return utxos
-            .filter(utxo => (anonymitySet[utxo.address] ?? 1) < targetAnonymity)
-            .every(utxo => new BigNumber(utxo.amount).lt(minAllowedInputWithFee));
-    },
-);
+    // Return true if all non-private funds are too small.
+    return utxos
+        .filter(utxo => (anonymitySet[utxo.address] ?? 1) < targetAnonymity)
+        .every(utxo => new BigNumber(utxo.amount).lt(minAllowedInputWithFee));
+};
 
 export const selectWeightedAnonymityByAccountKey = (
     state: CoinjoinRootState,
@@ -890,7 +885,7 @@ export const selectRoundsLeftByAccountKey = (state: CoinjoinRootState, accountKe
     return maxRounds - signedRounds.length;
 };
 
-export const selectHasAnonymitySetError = memoize((state: CoinjoinRootState) => {
+export const selectHasAnonymitySetError = (state: CoinjoinRootState) => {
     const selectedAccount = selectSelectedAccount(state);
 
     if (!selectedAccount) {
@@ -904,7 +899,7 @@ export const selectHasAnonymitySetError = memoize((state: CoinjoinRootState) => 
     );
 
     return hasFaultyAnonymitySet;
-});
+};
 
 export const selectCoinjoinSessionBlockerByAccountKey = (
     state: CoinjoinRootState,
@@ -940,7 +935,6 @@ export const selectCoinjoinSessionBlockerByAccountKey = (
     }
 };
 
-// memoization was causing incorrect return from the selector
 export const selectCurrentCoinjoinWheelStates = (state: CoinjoinRootState) => {
     const { notAnonymized } = selectCurrentCoinjoinBalanceBreakdown(state);
     const session = selectCurrentCoinjoinSession(state);
@@ -979,7 +973,7 @@ export const selectCurrentCoinjoinWheelStates = (state: CoinjoinRootState) => {
     };
 };
 
-export const selectCurrentSessionDeadlineInfo = memoize((state: CoinjoinRootState) => {
+export const selectCurrentSessionDeadlineInfo = (state: CoinjoinRootState) => {
     const session = selectCurrentCoinjoinSession(state);
 
     const { roundPhase, roundPhaseDeadline, sessionDeadline } = session || {};
@@ -989,17 +983,14 @@ export const selectCurrentSessionDeadlineInfo = memoize((state: CoinjoinRootStat
         roundPhaseDeadline,
         sessionDeadline,
     };
-});
+};
 
 // Return true if it's not explicitly set to false in the message-system config.
-export const selectIsPublic = memoize(
-    (state: CoinjoinRootState) => selectFeatureConfig(state, Feature.coinjoin)?.isPublic !== false,
-);
+export const selectIsPublic = (state: CoinjoinRootState) =>
+    selectFeatureConfig(state, Feature.coinjoin)?.isPublic !== false;
 
-export const selectIsSessionAutopaused = memoizeWithArgs(
-    (state: CoinjoinRootState, accountKey: string) => {
-        const currentState = selectSessionByAccountKey(state, accountKey);
+export const selectIsSessionAutopaused = (state: CoinjoinRootState, accountKey: string) => {
+    const currentState = selectSessionByAccountKey(state, accountKey);
 
-        return !!currentState?.isAutoPauseEnabled;
-    },
-);
+    return !!currentState?.isAutoPauseEnabled;
+};

--- a/packages/suite/src/reducers/wallet/discoveryReducer.ts
+++ b/packages/suite/src/reducers/wallet/discoveryReducer.ts
@@ -1,5 +1,4 @@
 import produce from 'immer';
-import { memoize } from 'proxy-memoize';
 import { DISCOVERY } from 'src/actions/wallet/constants';
 import { STORAGE } from 'src/actions/suite/constants';
 import { createDeferred } from '@trezor/utils';
@@ -96,12 +95,13 @@ export const selectDiscoveryForDevice = (state: RootState) =>
  * Helper selector called from components
  * return `true` if discovery process is running/completed and `authConfirm` is required
  */
-export const selectIsDiscoveryAuthConfirmationRequired = memoize((state: RootState) => {
+export const selectIsDiscoveryAuthConfirmationRequired = (state: RootState) => {
     const discovery = selectDiscoveryForDevice(state);
+
     return (
         discovery &&
         discovery.authConfirm &&
         (discovery.status < DISCOVERY.STATUS.STOPPING ||
             discovery.status === DISCOVERY.STATUS.COMPLETED)
     );
-});
+};

--- a/suite-common/message-system/src/messageSystemSelectors.ts
+++ b/suite-common/message-system/src/messageSystemSelectors.ts
@@ -88,16 +88,20 @@ export const selectFeatureConfig = memoizeWithArgs(
     },
 );
 
-export const selectIsFeatureEnabled = memoizeWithArgs(
-    (state: MessageSystemRootState, domain: FeatureDomain, defaultValue?: boolean) => {
-        const featureFlag = selectFeatureConfig(state, domain)?.flag;
-        return featureFlag ?? defaultValue ?? true;
-    },
-);
+export const selectIsFeatureEnabled = (
+    state: MessageSystemRootState,
+    domain: FeatureDomain,
+    defaultValue?: boolean,
+) => {
+    const featureFlag = selectFeatureConfig(state, domain)?.flag;
+    return featureFlag ?? defaultValue ?? true;
+};
 
-export const selectIsFeatureDisabled = memoizeWithArgs(
-    (state: MessageSystemRootState, domain: FeatureDomain, defaultValue?: boolean) => {
-        const featureFlag = selectFeatureConfig(state, domain)?.flag;
-        return typeof featureFlag === 'boolean' ? !featureFlag : defaultValue ?? false;
-    },
-);
+export const selectIsFeatureDisabled = (
+    state: MessageSystemRootState,
+    domain: FeatureDomain,
+    defaultValue?: boolean,
+) => {
+    const featureFlag = selectFeatureConfig(state, domain)?.flag;
+    return typeof featureFlag === 'boolean' ? !featureFlag : defaultValue ?? false;
+};

--- a/suite-common/toast-notifications/package.json
+++ b/suite-common/toast-notifications/package.json
@@ -19,7 +19,7 @@
         "@suite-common/test-utils": "workspace:*",
         "@suite-common/wallet-config": "workspace:*",
         "@trezor/connect": "workspace:*",
-        "proxy-memoize": "2.0.2"
+        "proxy-memoize": "^2.0.4"
     },
     "devDependencies": {
         "jest": "^26.6.3",

--- a/suite-common/toast-notifications/src/notificationsSelectors.ts
+++ b/suite-common/toast-notifications/src/notificationsSelectors.ts
@@ -1,27 +1,24 @@
-import { createSelector } from '@reduxjs/toolkit';
 import { memoizeWithArgs } from 'proxy-memoize';
 
 import {
     NotificationId,
     NotificationsRootState,
-    NotificationsState,
     ToastPayload,
     TransactionNotification,
 } from './types';
 
 export const selectNotifications = (state: NotificationsRootState) => state.notifications;
 
-export const selectVisibleNotificationsByType = createSelector(
-    [
-        selectNotifications,
-        (_state: NotificationsRootState, notificationType: ToastPayload[keyof ToastPayload]) =>
-            notificationType,
-    ],
-    (notifications: NotificationsState, notificationType) =>
-        notifications.filter(
-            notification => notification.type === notificationType && !notification.closed,
-        ),
-);
+export const selectVisibleNotificationsByType = (
+    state: NotificationsRootState,
+    notificationType: ToastPayload[keyof ToastPayload],
+) => {
+    const notifications = selectNotifications(state);
+
+    return notifications.filter(
+        notification => notification.type === notificationType && !notification.closed,
+    );
+};
 
 export const selectTransactionNotificationById = memoizeWithArgs(
     (

--- a/suite-common/wallet-core/package.json
+++ b/suite-common/wallet-core/package.json
@@ -29,7 +29,7 @@
         "@trezor/type-utils": "workspace:*",
         "@trezor/utils": "workspace:*",
         "date-fns": "^2.30.0",
-        "proxy-memoize": "2.0.2"
+        "proxy-memoize": "^2.0.4"
     },
     "devDependencies": {
         "jest": "^26.6.3",

--- a/suite-native/assets/package.json
+++ b/suite-native/assets/package.json
@@ -28,7 +28,7 @@
         "@suite-native/navigation": "workspace:*",
         "@trezor/styles": "workspace:*",
         "bignumber.js": "^9.1.1",
-        "proxy-memoize": "2.0.2",
+        "proxy-memoize": "^2.0.4",
         "react": "^18.2.0",
         "react-native": "0.71.8",
         "react-redux": "8.0.7"

--- a/suite-native/ethereum-tokens/package.json
+++ b/suite-native/ethereum-tokens/package.json
@@ -20,7 +20,7 @@
         "@suite-native/fiat-rates": "workspace:*",
         "@suite-native/module-settings": "workspace:*",
         "@trezor/blockchain-link": "workspace:*",
-        "proxy-memoize": "2.0.2",
+        "proxy-memoize": "^2.0.4",
         "react": "18.2.0"
     }
 }

--- a/suite-native/fiat-rates/package.json
+++ b/suite-native/fiat-rates/package.json
@@ -22,6 +22,6 @@
         "@suite-common/wallet-utils": "workspace:*",
         "@trezor/connect": "workspace:*",
         "date-fns": "^2.30.0",
-        "proxy-memoize": "2.0.2"
+        "proxy-memoize": "^2.0.4"
     }
 }

--- a/suite-native/transactions/package.json
+++ b/suite-native/transactions/package.json
@@ -35,7 +35,7 @@
         "@trezor/styles": "workspace:*",
         "@trezor/theme": "workspace:*",
         "jotai": "1.9.1",
-        "proxy-memoize": "2.0.2",
+        "proxy-memoize": "^2.0.4",
         "react": "18.2.0",
         "react-native": "0.71.8",
         "react-native-gesture-handler": "^2.9.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -8628,7 +8628,6 @@ __metadata:
     pdfmake: ^0.2.7
     polished: ^4.2.2
     prettier: 2.8.8
-    proxy-memoize: 2.0.2
     qrcode.react: ^3.1.0
     react: 18.2.0
     react-dom: 18.2.0

--- a/yarn.lock
+++ b/yarn.lock
@@ -6698,7 +6698,7 @@ __metadata:
     "@suite-common/wallet-config": "workspace:*"
     "@trezor/connect": "workspace:*"
     jest: ^26.6.3
-    proxy-memoize: 2.0.2
+    proxy-memoize: ^2.0.4
     typescript: 4.9.5
   languageName: unknown
   linkType: soft
@@ -6747,7 +6747,7 @@ __metadata:
     "@trezor/utils": "workspace:*"
     date-fns: ^2.30.0
     jest: ^26.6.3
-    proxy-memoize: 2.0.2
+    proxy-memoize: ^2.0.4
     typescript: 4.9.5
   languageName: unknown
   linkType: soft
@@ -6883,7 +6883,7 @@ __metadata:
     "@trezor/styles": "workspace:*"
     bignumber.js: ^9.1.1
     jest: ^26.6.3
-    proxy-memoize: 2.0.2
+    proxy-memoize: ^2.0.4
     react: ^18.2.0
     react-native: 0.71.8
     react-redux: 8.0.7
@@ -6957,7 +6957,7 @@ __metadata:
     "@suite-native/fiat-rates": "workspace:*"
     "@suite-native/module-settings": "workspace:*"
     "@trezor/blockchain-link": "workspace:*"
-    proxy-memoize: 2.0.2
+    proxy-memoize: ^2.0.4
     react: 18.2.0
   languageName: unknown
   linkType: soft
@@ -6977,7 +6977,7 @@ __metadata:
     "@suite-common/wallet-utils": "workspace:*"
     "@trezor/connect": "workspace:*"
     date-fns: ^2.30.0
-    proxy-memoize: 2.0.2
+    proxy-memoize: ^2.0.4
   languageName: unknown
   linkType: soft
 
@@ -7568,7 +7568,7 @@ __metadata:
     "@trezor/theme": "workspace:*"
     jest: ^26.6.3
     jotai: 1.9.1
-    proxy-memoize: 2.0.2
+    proxy-memoize: ^2.0.4
     react: 18.2.0
     react-native: 0.71.8
     react-native-gesture-handler: ^2.9.0
@@ -27967,6 +27967,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"proxy-compare@npm:2.5.1":
+  version: 2.5.1
+  resolution: "proxy-compare@npm:2.5.1"
+  checksum: c7cc151ac255150bcb24becde6495b3e399416c31991af377ce082255b51f07eaeb5d861bf8bf482703e92f88b90a5892ad57d3153ea29450d03ef921683d9fa
+  languageName: node
+  linkType: hard
+
 "proxy-from-env@npm:1.0.0":
   version: 1.0.0
   resolution: "proxy-from-env@npm:1.0.0"
@@ -27987,6 +27994,15 @@ __metadata:
   dependencies:
     proxy-compare: 2.4.0
   checksum: 3cfb54fdd3032959de0c4da7bb7c85713bfa92d442841a6882a5ed20bd2dab0c629194615988e9b7dfdb8885183b8ab28817ed7205e912e7e285f031efdb8443
+  languageName: node
+  linkType: hard
+
+"proxy-memoize@npm:^2.0.4":
+  version: 2.0.4
+  resolution: "proxy-memoize@npm:2.0.4"
+  dependencies:
+    proxy-compare: 2.5.1
+  checksum: d97b5cf6c50ebe050c5ff7ecd0bb040423d0ba41deb5795d421a34159deb12fbd9d99792fb9108ffe03e6ada225d863b2d31f51f2230bf4fcb2761f30987c7d7
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Removing lot of unnecessary memoization from selectors. 

- It makes no sense to memoize selectors returning primitive values and not doing any costly calculations.
- Even if selector returns object, it doesn't mean that memoization is necessary. Performance should be measured in that case to verify if unnecessary rerenders costs more than the memoization. Check https://github.com/dai-shi/proxy-memoize/issues/81 and https://github.com/dai-shi/proxy-memoize/issues/80.

 In suite-desktop/web we use shallow equality check to prevent unnecessary rerenders. In suite-native there is just strict equality check used in useSelector.



I also verified, that using memoized selector inside other memoized selector is fine (I suspected if changes in the affected properties of the nested selector correctly invalidate the cache and yes.)

<details>
  <summary>How did I debug it?</summary>
  
  
  `settingsReducer.ts`:
  ```js
let counterSomething = 1;
const selectSomething = memoizeWithArgs((state: AppState) => {
    console.log('selectSomethingSettings called', ++counterSomething, state.resize?.screenWidth);
    return (state.resize?.screenWidth || 0) > 1000;
});

let counter = 1;
export const selectEnabledNetworksMemoized = memoizeWithArgs((state: AppState) => {
    console.log('selectEnabledNetworks called', ++counter);
    const something = selectSomething(state);
    return {
        enabledNetworks: state.wallet.settings.enabledNetworks,
        something,
    };
});
  ```
  
  `SettingsGeneral.tsx`:
  ```js
  console.time('selectEnabledNetworks');
  const { enabledNetworks, something } = useSelector(selectEnabledNetworksMemoized);
  console.timeEnd('selectEnabledNetworks');
  console.log('SettingsGeneral', something);
  
  
  {something && <h1>something</h1>}
  ```
</details>
