### PR TITLE
Transaction types revamp #1

### DIFF
--- a/packages/blockchain-link-types/src/blockbook.ts
+++ b/packages/blockchain-link-types/src/blockbook.ts
@@ -8,6 +8,7 @@ import type {
 } from './params';
 import type { AccountBalanceHistory, FiatRates, TokenStandard } from './common';
 import type {
+    Tx as BlockbookTx,
     Vin,
     Vout,
     Utxo as BlockbookUtxo,
@@ -17,10 +18,7 @@ import type {
     WsBlockFiltersBatchReq,
     MempoolTxidFilterEntries,
     Token as BlockbookToken,
-    EthereumParsedInputData as BlockbookEthereumParsedInputData,
-    EthereumSpecific as BlockbookEthereumSpecific,
     TokenTransfer as BlockbookTokenTransfer,
-    AddressAlias,
 } from './blockbook-api';
 
 type OptionalKey<M, K extends keyof M> = Omit<M, K> & Partial<Pick<M, K>>;
@@ -112,9 +110,6 @@ export interface AccountUtxoParams {
 
 export type VinVout = OptionalKey<Vin & Vout, 'addresses'>;
 
-type EthereumParsedData = BlockbookEthereumParsedInputData &
-    Partial<Pick<BlockbookEthereumParsedInputData, 'name'>>;
-
 export interface EthereumInternalTransfer {
     type: number;
     from: string;
@@ -122,37 +117,11 @@ export interface EthereumInternalTransfer {
     value?: string;
 }
 
-type EthereumSpecific = BlockbookEthereumSpecific & {
-    parsedData?: EthereumParsedData;
-};
-
-type TokenTransfer = BlockbookTokenTransfer & {
-    type: TokenStandard;
-};
-
-export interface Transaction {
-    txid: string;
-    version?: number;
-    vin: VinVout[];
-    vout: VinVout[];
-    blockHeight: number;
-    blockHash?: string;
-    confirmations: number;
-    blockTime: number;
-    value: string; // optional
-    valueIn: string; // optional
-    fees: string; // optional
-    hex?: string;
-    lockTime?: number;
-    vsize?: number;
-    size?: number;
-    ethereumSpecific?: EthereumSpecific;
-    tokenTransfers?: TokenTransfer[];
-    confirmationETABlocks?: number;
-    confirmationETASeconds?: number;
-    rbf?: boolean;
-    coinSpecificData?: any;
-    addressAliases?: { [key: string]: AddressAlias };
+export interface Transaction extends BlockbookTx {
+    fees: string; // optional in Tx, seems to always be there
+    tokenTransfers?: (BlockbookTokenTransfer & {
+        type: TokenStandard; // string in Tx, seems to always be ERC20 | ERC721 | ERC1155
+    })[];
 }
 
 export interface Push {

--- a/packages/blockchain-link-types/src/blockfrost.ts
+++ b/packages/blockchain-link-types/src/blockfrost.ts
@@ -266,10 +266,7 @@ declare function FSend(
     method: 'GET_ACCOUNT_UTXO',
     params: AccountUtxoParams,
 ): Promise<BlockfrostUtxos[]>;
-declare function FSend(
-    method: 'GET_TRANSACTION',
-    params: { txId: string },
-): Promise<BlockfrostTransaction>;
+declare function FSend(method: 'GET_TRANSACTION', params: { txId: string }): Promise<TxContent>;
 declare function FSend(method: 'PUSH_TRANSACTION', params: { txData: string }): Promise<string>;
 declare function FSend(method: 'SUBSCRIBE_BLOCK'): Promise<Subscribe>;
 declare function FSend(method: 'UNSUBSCRIBE_BLOCK'): Promise<Subscribe>;

--- a/packages/blockchain-link-types/src/common.ts
+++ b/packages/blockchain-link-types/src/common.ts
@@ -1,8 +1,6 @@
 import type { SocksProxyAgentOptions } from 'socks-proxy-agent';
-import type { FormattedTransactionType as RippleTransaction } from 'ripple-lib';
 
 import type { Transaction as BlockbookTransaction, VinVout } from './blockbook';
-import type { BlockfrostTransaction } from './blockfrost';
 import type { TokenTransfer as BlockbookTokenTransfer } from './blockbook-api';
 
 /* Common types used in both params and responses */
@@ -57,20 +55,6 @@ export interface Target {
     coinbase?: string;
     isAccountTarget?: boolean;
 }
-
-export type TypedRawTransaction =
-    | {
-          type: 'blockbook';
-          tx: BlockbookTransaction;
-      }
-    | {
-          type: 'ripple';
-          tx: RippleTransaction;
-      }
-    | {
-          type: 'blockfrost';
-          tx: BlockfrostTransaction;
-      };
 
 export type EnhancedVinVout = VinVout & {
     isAccountOwned?: boolean;

--- a/packages/blockchain-link-types/src/common.ts
+++ b/packages/blockchain-link-types/src/common.ts
@@ -115,12 +115,7 @@ export interface Transaction {
     ethereumSpecific?: BlockbookTransaction['ethereumSpecific'];
     internalTransfers: InternalTransfer[];
     cardanoSpecific?: {
-        subtype:
-            | 'withdrawal'
-            | 'stake_delegation'
-            | 'stake_registration'
-            | 'stake_deregistration'
-            | null;
+        subtype?: 'withdrawal' | 'stake_delegation' | 'stake_registration' | 'stake_deregistration';
         withdrawal?: string;
         deposit?: string;
     };

--- a/packages/blockchain-link-types/src/constants/messages.ts
+++ b/packages/blockchain-link-types/src/constants/messages.ts
@@ -12,6 +12,7 @@ export const GET_BLOCK = 'm_get_block';
 export const GET_ACCOUNT_INFO = 'm_get_account_info';
 export const GET_ACCOUNT_UTXO = 'm_get_account_utxo';
 export const GET_TRANSACTION = 'm_get_transaction';
+export const GET_TRANSACTION_HEX = 'm_get_transaction_hex';
 export const ESTIMATE_FEE = 'm_estimate_fee';
 export const SUBSCRIBE = 'm_subscribe';
 export const UNSUBSCRIBE = 'm_unsubscribe';

--- a/packages/blockchain-link-types/src/constants/responses.ts
+++ b/packages/blockchain-link-types/src/constants/responses.ts
@@ -11,6 +11,7 @@ export const GET_ACCOUNT_INFO = 'r_account_info';
 export const GET_ACCOUNT_UTXO = 'r_get_account_utxo';
 export const GET_ACCOUNT_BALANCE_HISTORY = 'r_get_account_balance_history';
 export const GET_TRANSACTION = 'r_get_transaction';
+export const GET_TRANSACTION_HEX = 'r_get_transaction_hex';
 export const ESTIMATE_FEE = 'r_estimate_fee';
 export const SUBSCRIBE = 'r_subscribe';
 export const UNSUBSCRIBE = 'r_unsubscribe';

--- a/packages/blockchain-link-types/src/messages.ts
+++ b/packages/blockchain-link-types/src/messages.ts
@@ -47,6 +47,11 @@ export interface GetTransaction {
     payload: string;
 }
 
+export interface GetTransactionHex {
+    type: typeof MESSAGES.GET_TRANSACTION_HEX;
+    payload: string;
+}
+
 export interface GetFiatRatesTickersList {
     type: typeof MESSAGES.GET_FIAT_RATES_TICKERS_LIST;
     payload: GetFiatRatesTickersListParams;
@@ -133,6 +138,7 @@ export type Message =
     | ChannelMessage<GetAccountInfo>
     | ChannelMessage<GetAccountUtxo>
     | ChannelMessage<GetTransaction>
+    | ChannelMessage<GetTransactionHex>
     | ChannelMessage<GetCurrentFiatRates>
     | ChannelMessage<GetFiatRatesForTimestamps>
     | ChannelMessage<GetAccountBalanceHistory>

--- a/packages/blockchain-link-types/src/responses.ts
+++ b/packages/blockchain-link-types/src/responses.ts
@@ -57,6 +57,11 @@ export interface GetTransaction {
     payload: TypedRawTransaction;
 }
 
+export interface GetTransactionHex {
+    type: typeof RESPONSES.GET_TRANSACTION_HEX;
+    payload: string;
+}
+
 export interface GetAccountBalanceHistory {
     type: typeof RESPONSES.GET_ACCOUNT_BALANCE_HISTORY;
     payload: AccountBalanceHistory[];
@@ -163,6 +168,7 @@ export type Response =
     | ChannelMessage<GetAccountInfo>
     | ChannelMessage<GetAccountUtxo>
     | ChannelMessage<GetTransaction>
+    | ChannelMessage<GetTransactionHex>
     | ChannelMessage<GetAccountBalanceHistory>
     | ChannelMessage<GetCurrentFiatRates>
     | ChannelMessage<GetFiatRatesForTimestamps>

--- a/packages/blockchain-link-types/src/responses.ts
+++ b/packages/blockchain-link-types/src/responses.ts
@@ -6,7 +6,6 @@ import type {
     Utxo,
     FiatRates,
     Transaction,
-    TypedRawTransaction,
     AccountBalanceHistory,
     ChannelMessage,
 } from './common';
@@ -54,7 +53,7 @@ export interface GetAccountUtxo {
 
 export interface GetTransaction {
     type: typeof RESPONSES.GET_TRANSACTION;
-    payload: TypedRawTransaction;
+    payload: Transaction;
 }
 
 export interface GetTransactionHex {

--- a/packages/blockchain-link-utils/src/blockfrost.ts
+++ b/packages/blockchain-link-utils/src/blockfrost.ts
@@ -174,15 +174,20 @@ export const filterTokenTransfers = (
 };
 
 export const transformTransaction = (
-    descriptor: string,
-    accountAddress: AccountAddresses | undefined,
     blockfrostTxData: BlockfrostTransaction,
+    // TODO does 'descriptor' branch make sense for Cardano or was it just copypaste from blockbook?
+    addressesOrDescriptor?: AccountAddresses | string,
 ): Transaction => {
+    const [accountAddress, descriptor] =
+        typeof addressesOrDescriptor === 'object'
+            ? [addressesOrDescriptor, undefined]
+            : [undefined, addressesOrDescriptor];
+
     const myAddresses = accountAddress
         ? accountAddress.change
               .concat(accountAddress.used, accountAddress.unused)
               .map(a => a.address)
-        : [descriptor];
+        : (descriptor && [descriptor]) || [];
 
     let type: Transaction['type'];
     let targets: VinVout[] = [];
@@ -298,7 +303,7 @@ export const transformAccountInfo = (info: BlockfrostAccountInfo): AccountInfo =
             transactions: !blockfrostTxs
                 ? []
                 : blockfrostTxs?.map(tx =>
-                      transformTransaction(info.descriptor, info.addresses, tx),
+                      transformTransaction(tx, info.addresses ?? info.descriptor),
                   ),
         },
     };

--- a/packages/blockchain-link-utils/src/blockfrost.ts
+++ b/packages/blockchain-link-utils/src/blockfrost.ts
@@ -49,7 +49,7 @@ const hexToString = (input: string): string => {
     return str;
 };
 
-export const getSubtype = (tx: BlockfrostTransaction) => {
+const getSubtype = (tx: Pick<BlockfrostTransaction, 'txData'>) => {
     const withdrawal = tx.txData.withdrawal_count > 0;
     if (withdrawal) {
         return 'withdrawal';
@@ -57,7 +57,7 @@ export const getSubtype = (tx: BlockfrostTransaction) => {
 
     const registrations = tx.txData.stake_cert_count;
     const delegations = tx.txData.delegation_count;
-    if (registrations === 0 && delegations === 0) return null;
+    if (registrations === 0 && delegations === 0) return;
 
     if (registrations > 0) {
         if (new BigNumber(tx.txData.deposit).gt(0)) {
@@ -70,7 +70,6 @@ export const getSubtype = (tx: BlockfrostTransaction) => {
     if (delegations > 0) {
         return 'stake_delegation';
     }
-    return null;
 };
 
 export const parseAsset = (hex: string): ParseAssetResult => {

--- a/packages/blockchain-link-utils/src/ripple.ts
+++ b/packages/blockchain-link-utils/src/ripple.ts
@@ -23,7 +23,7 @@ export const transformServerInfo = (payload: any) => ({
 // https://bitcoin.stackexchange.com/questions/23061/ripple-ledger-time-format/23065#23065
 const BLOCKTIME_OFFSET = 946684800;
 
-export const transformTransaction = (descriptor: string, tx: any): Transaction => {
+export const transformTransaction = (tx: any, descriptor?: string): Transaction => {
     const blockTime =
         typeof tx.date === 'number' && tx.date > 0 ? tx.date + BLOCKTIME_OFFSET : tx.date;
 

--- a/packages/blockchain-link-utils/src/ripple.ts
+++ b/packages/blockchain-link-utils/src/ripple.ts
@@ -11,68 +11,40 @@ export const transformServerInfo = (payload: any) => ({
     blockHash: payload.validatedLedger.hash,
 });
 
-// export const concatTransactions = (
-//     txs: Array<Transaction>,
-//     newTxs: Array<Transaction>
-// ): Array<Transaction> => {
-//     if (newTxs.length < 1) return txs;
-//     const unique = newTxs.filter(tx => txs.indexOf(tx) < 0);
-//     return txs.concat(unique);
-// };
-
 // https://bitcoin.stackexchange.com/questions/23061/ripple-ledger-time-format/23065#23065
 const BLOCKTIME_OFFSET = 946684800;
 
 export const transformTransaction = (tx: any, descriptor?: string): Transaction => {
     const blockTime =
         typeof tx.date === 'number' && tx.date > 0 ? tx.date + BLOCKTIME_OFFSET : tx.date;
-
-    if (tx.TransactionType !== 'Payment') {
-        // TODO: https://github.com/ripple/ripple-lib/blob/develop/docs/index.md#transaction-types
-        return {
-            type: 'unknown',
-            txid: tx.hash,
-            amount: '0',
-            fee: '0',
-            blockTime,
-            blockHeight: tx.ledger_index,
-            blockHash: tx.hash,
-            targets: [],
-            tokens: [],
-            internalTransfers: [],
-            feeRate: undefined,
-            details: {
-                vin: [],
-                vout: [],
-                size: 0,
-                totalInput: '0',
-                totalOutput: '0',
-            },
-        };
-    }
-    const type = tx.Account === descriptor ? 'sent' : 'recv';
+    const type =
+        tx.TransactionType !== 'Payment' || !descriptor
+            ? 'unknown'
+            : (tx.Account === descriptor && 'sent') || 'recv';
     const addresses = [tx.Destination];
     const amount = tx.Amount;
     const fee = tx.Fee;
 
+    // TODO: https://github.com/ripple/ripple-lib/blob/develop/docs/index.md#transaction-types
     return {
         type,
-
         txid: tx.hash,
+        amount,
+        fee,
         blockTime,
         blockHeight: tx.ledger_index,
         blockHash: tx.hash,
-
-        amount,
-        fee,
-        targets: [
-            {
-                addresses,
-                isAddress: true,
-                amount,
-                n: 0, // no multi-targets in ripple
-            },
-        ],
+        targets:
+            type === 'unknown'
+                ? []
+                : [
+                      {
+                          addresses,
+                          isAddress: true,
+                          amount,
+                          n: 0, // no multi-targets in ripple
+                      },
+                  ],
         tokens: [],
         internalTransfers: [],
         feeRate: undefined,

--- a/packages/blockchain-link-utils/src/tests/blockbook.test.ts
+++ b/packages/blockchain-link-utils/src/tests/blockbook.test.ts
@@ -16,7 +16,7 @@ describe('blockbook/utils', () => {
         fixtures.transformTransaction.forEach(f => {
             it(f.description, () => {
                 // @ts-expect-error incorrect params
-                const tx = transformTransaction(f.descriptor, f.addresses, f.tx);
+                const tx = transformTransaction(f.tx, f.addresses ?? f.descriptor);
                 expect(tx).toMatchObject(f.parsed);
             });
         });

--- a/packages/blockchain-link-utils/src/tests/blockfrost.test.ts
+++ b/packages/blockchain-link-utils/src/tests/blockfrost.test.ts
@@ -46,10 +46,10 @@ describe('blockfrost/utils', () => {
     describe('transformTransaction', () => {
         fixtures.transformTransaction.forEach(f => {
             it(f.description, () => {
-                // @ts-expect-error incorrect params
-                expect(transformTransaction(f.descriptor, f.accountAddress, f.data)).toMatchObject(
-                    f.result,
-                );
+                expect(
+                    // @ts-expect-error incorrect params
+                    transformTransaction(f.data, f.accountAddress ?? f.descriptor),
+                ).toMatchObject(f.result);
             });
         });
     });

--- a/packages/blockchain-link/src/index.ts
+++ b/packages/blockchain-link/src/index.ts
@@ -390,6 +390,5 @@ export type {
     InternalTransfer,
     Transaction,
     TransactionDetail,
-    TypedRawTransaction,
     Utxo,
 } from '@trezor/blockchain-link-types/lib/common';

--- a/packages/blockchain-link/src/index.ts
+++ b/packages/blockchain-link/src/index.ts
@@ -174,6 +174,15 @@ class BlockchainLink extends TypedEmitter<Events> {
         });
     }
 
+    getTransactionHex(
+        payload: MessageTypes.GetTransactionHex['payload'],
+    ): Promise<ResponseTypes.GetTransactionHex['payload']> {
+        return this.sendMessage({
+            type: MESSAGES.GET_TRANSACTION_HEX,
+            payload,
+        });
+    }
+
     /**
      * Get historical progression of given account's balance
      * Used for rendering a graph in Suite's dashboard.

--- a/packages/blockchain-link/src/workers/blockbook/index.ts
+++ b/packages/blockchain-link/src/workers/blockbook/index.ts
@@ -114,13 +114,11 @@ const getFiatRatesTickersList = async (request: Request<MessageTypes.GetFiatRate
 
 const getTransaction = async (request: Request<MessageTypes.GetTransaction>) => {
     const api = await request.connect();
-    const tx = await api.getTransaction(request.payload);
+    const rawtx = await api.getTransaction(request.payload);
+    const tx = utils.transformTransaction(rawtx);
     return {
         type: RESPONSES.GET_TRANSACTION,
-        payload: {
-            type: 'blockbook',
-            tx,
-        },
+        payload: tx,
     } as const;
 };
 

--- a/packages/blockchain-link/src/workers/blockbook/index.ts
+++ b/packages/blockchain-link/src/workers/blockbook/index.ts
@@ -124,6 +124,16 @@ const getTransaction = async (request: Request<MessageTypes.GetTransaction>) => 
     } as const;
 };
 
+const getTransactionHex = async (request: Request<MessageTypes.GetTransactionHex>) => {
+    const api = await request.connect();
+    const { hex } = await api.getTransaction(request.payload);
+    if (!hex) throw new CustomError(`Missing hex of ${request.payload}`);
+    return {
+        type: RESPONSES.GET_TRANSACTION_HEX,
+        payload: hex,
+    } as const;
+};
+
 const pushTransaction = async (request: Request<MessageTypes.PushTransaction>) => {
     const api = await request.connect();
     const resp = await api.pushTransaction(request.payload);
@@ -372,6 +382,8 @@ const onRequest = (request: Request<MessageTypes.Message>) => {
             return getAccountUtxo(request);
         case MESSAGES.GET_TRANSACTION:
             return getTransaction(request);
+        case MESSAGES.GET_TRANSACTION_HEX:
+            return getTransactionHex(request);
         case MESSAGES.GET_ACCOUNT_BALANCE_HISTORY:
             return getAccountBalanceHistory(request);
         case MESSAGES.GET_CURRENT_FIAT_RATES:

--- a/packages/blockchain-link/src/workers/blockbook/index.ts
+++ b/packages/blockchain-link/src/workers/blockbook/index.ts
@@ -180,8 +180,8 @@ const onTransaction = ({ state, post }: Context, event: AddressNotification) => 
             payload: {
                 descriptor: account ? account.descriptor : descriptor,
                 tx: account
-                    ? utils.transformTransaction(account.descriptor, account.addresses, event.tx)
-                    : utils.transformTransaction(descriptor, undefined, event.tx),
+                    ? utils.transformTransaction(event.tx, account.addresses ?? account.descriptor)
+                    : utils.transformTransaction(event.tx, descriptor),
             },
         },
     });

--- a/packages/blockchain-link/src/workers/blockfrost/index.ts
+++ b/packages/blockchain-link/src/workers/blockfrost/index.ts
@@ -128,8 +128,8 @@ const onTransaction = ({ state, post }: Context, event: BlockfrostTransaction) =
             payload: {
                 descriptor: account ? account.descriptor : descriptor,
                 tx: account
-                    ? transformTransaction(account.descriptor, account.addresses, event)
-                    : transformTransaction(descriptor, undefined, event),
+                    ? transformTransaction(event, account.addresses ?? account.descriptor)
+                    : transformTransaction(event, descriptor),
             },
         },
     });

--- a/packages/blockchain-link/src/workers/blockfrost/index.ts
+++ b/packages/blockchain-link/src/workers/blockfrost/index.ts
@@ -52,13 +52,11 @@ const getAccountBalanceHistory = async (
 
 const getTransaction = async (request: Request<MessageTypes.GetTransaction>) => {
     const api = await request.connect();
-    const tx = await api.getTransaction(request.payload);
+    const txData = await api.getTransaction(request.payload);
+    const tx = transformTransaction({ txData });
     return {
         type: RESPONSES.GET_TRANSACTION,
-        payload: {
-            type: 'blockfrost',
-            tx,
-        },
+        payload: tx,
     } as const;
 };
 

--- a/packages/blockchain-link/src/workers/electrum/index.ts
+++ b/packages/blockchain-link/src/workers/electrum/index.ts
@@ -29,6 +29,8 @@ type ResponseType<T extends MessageType> = T extends typeof MESSAGES.GET_INFO
     ? typeof RESPONSES.GET_ACCOUNT_UTXO
     : T extends typeof MESSAGES.GET_TRANSACTION
     ? typeof RESPONSES.GET_TRANSACTION
+    : T extends typeof MESSAGES.GET_TRANSACTION_HEX
+    ? typeof RESPONSES.GET_TRANSACTION_HEX
     : T extends typeof MESSAGES.GET_ACCOUNT_BALANCE_HISTORY
     ? typeof RESPONSES.GET_ACCOUNT_BALANCE_HISTORY
     : T extends typeof MESSAGES.ESTIMATE_FEE
@@ -71,6 +73,11 @@ const onRequest = async <T extends Message>(
             return {
                 type: RESPONSES.GET_TRANSACTION,
                 payload: await M.getTransaction(client, request.payload),
+            };
+        case MESSAGES.GET_TRANSACTION_HEX:
+            return {
+                type: RESPONSES.GET_TRANSACTION_HEX,
+                payload: await client.request('blockchain.transaction.get', request.payload, false),
             };
         case MESSAGES.GET_ACCOUNT_BALANCE_HISTORY:
             return {

--- a/packages/blockchain-link/src/workers/electrum/listeners/txListener.ts
+++ b/packages/blockchain-link/src/workers/electrum/listeners/txListener.ts
@@ -48,7 +48,7 @@ export const txListener = (worker: BaseWorker<ElectrumAPI>) => {
                 type: 'notification',
                 payload: {
                     descriptor,
-                    tx: transformTransaction(descriptor, addresses, tx),
+                    tx: transformTransaction(tx, addresses ?? descriptor),
                 },
             },
         });

--- a/packages/blockchain-link/src/workers/electrum/methods/getAccountBalanceHistory.ts
+++ b/packages/blockchain-link/src/workers/electrum/methods/getAccountBalanceHistory.ts
@@ -97,7 +97,7 @@ const getAccountBalanceHistory: Api<Req, Res> = async (
                     (from || 0) <= blockTime && blockTime <= (to || Number.MAX_SAFE_INTEGER),
             )
             .sort((a, b) => a.blockTime - b.blockTime)
-            .map(tx => ({ blockTime: -1, ...transformTransaction(descriptor, addresses, tx) })),
+            .map(tx => ({ blockTime: -1, ...transformTransaction(tx, addresses ?? descriptor) })),
     );
 
     return aggregateTransactions(txs, groupBy);

--- a/packages/blockchain-link/src/workers/electrum/methods/getAccountInfo.ts
+++ b/packages/blockchain-link/src/workers/electrum/methods/getAccountInfo.ts
@@ -77,7 +77,7 @@ const getAccountInfo: Api<Req, Res> = async (client, payload) => {
         const transactions =
             details === 'txs'
                 ? await getTransactions(client, history)
-                      .then(txs => txs.map(tx => transformTransaction(descriptor, undefined, tx)))
+                      .then(txs => txs.map(tx => transformTransaction(tx, descriptor)))
                       .then(sortTxsFromLatest)
                 : undefined;
 
@@ -124,7 +124,7 @@ const getAccountInfo: Api<Req, Res> = async (client, payload) => {
 
     const transactions = ['tokenBalances', 'txids', 'txs'].includes(details)
         ? await getTransactions(client, history)
-              .then(txs => txs.map(tx => transformTransaction(descriptor, addresses, tx)))
+              .then(txs => txs.map(tx => transformTransaction(tx, addresses)))
               .then(sortTxsFromLatest)
         : [];
 

--- a/packages/blockchain-link/src/workers/electrum/methods/getTransaction.ts
+++ b/packages/blockchain-link/src/workers/electrum/methods/getTransaction.ts
@@ -1,13 +1,11 @@
 import { Api, getTransactions } from '../utils';
+import { transformTransaction } from '@trezor/blockchain-link-utils/lib/blockbook';
 import type { GetTransaction as Req } from '@trezor/blockchain-link-types/lib/messages';
 import type { GetTransaction as Res } from '@trezor/blockchain-link-types/lib/responses';
 
 const getTransaction: Api<Req, Res> = async (client, payload) => {
     const [tx] = await getTransactions(client, [{ tx_hash: payload, height: -1 }]);
-    return {
-        type: 'blockbook',
-        tx,
-    };
+    return transformTransaction(tx);
 };
 
 export default getTransaction;

--- a/packages/blockchain-link/src/workers/ripple/index.ts
+++ b/packages/blockchain-link/src/workers/ripple/index.ts
@@ -160,7 +160,7 @@ const getAccountInfo = async (request: Request<MessageTypes.GetAccountInfo>) => 
     const api = await request.connect();
     const transactionsData: RawTxData = await api.request('account_tx', requestOptions);
     account.history.transactions = transactionsData.transactions.map(raw =>
-        utils.transformTransaction(payload.descriptor, raw.tx),
+        utils.transformTransaction(raw.tx, payload.descriptor),
     );
 
     return {
@@ -247,7 +247,7 @@ const onTransaction = ({ state, post }: Context, event: any) => {
                 type: 'notification',
                 payload: {
                     descriptor,
-                    tx: utils.transformTransaction(descriptor, { ...event, ...tx }),
+                    tx: utils.transformTransaction({ ...event, ...tx }, descriptor),
                 },
             },
         });

--- a/packages/blockchain-link/src/workers/ripple/index.ts
+++ b/packages/blockchain-link/src/workers/ripple/index.ts
@@ -174,13 +174,11 @@ const getAccountInfo = async (request: Request<MessageTypes.GetAccountInfo>) => 
 
 const getTransaction = async ({ connect, payload }: Request<MessageTypes.GetTransaction>) => {
     const api = await connect();
-    const tx = await api.getTransaction(payload);
+    const rawtx = await api.request('tx', { transaction: payload, binary: false });
+    const tx = utils.transformTransaction(rawtx);
     return {
         type: RESPONSES.GET_TRANSACTION,
-        payload: {
-            type: 'ripple',
-            tx,
-        },
+        payload: tx,
     } as const;
 };
 

--- a/packages/blockchain-link/tests/unit/connection.test.ts
+++ b/packages/blockchain-link/tests/unit/connection.test.ts
@@ -42,7 +42,7 @@ workers.forEach(instance => {
         it('Handle connection timeout', async () => {
             try {
                 blockchain.settings.server = ['wss://google.com:11111', 'wss://google.com:22222'];
-                blockchain.settings.timeout = 4000;
+                blockchain.settings.timeout = 200;
                 await blockchain.connect();
                 fail('Did not throw');
             } catch (error) {
@@ -60,11 +60,11 @@ workers.forEach(instance => {
                         ripple: 'server_info',
                     }[instance.name],
                     response: undefined,
-                    delay: 8000, // wait 8 sec. to send response
+                    delay: 400, // wait 0.4 sec. to send response
                 },
             ]);
             try {
-                blockchain.settings.timeout = 4000;
+                blockchain.settings.timeout = 200;
                 await blockchain.getInfo();
                 fail('Did not throw');
             } catch (error) {
@@ -81,9 +81,9 @@ workers.forEach(instance => {
                 { method, response: undefined },
                 { method, response: undefined },
             ]);
-            blockchain.settings.pingTimeout = 2500; // ping message will be called 3 sec. after subscription
+            blockchain.settings.pingTimeout = 200; // ping message will be called 0.2 sec. after subscription
             await blockchain.subscribe({ type: 'block' });
-            await new Promise(resolve => setTimeout(resolve, 6000));
+            await new Promise(resolve => setTimeout(resolve, 500));
             expect(server.fixtures).toEqual([]);
         }, 7000);
 
@@ -95,12 +95,12 @@ workers.forEach(instance => {
                 { method, response: undefined },
             ]);
 
-            blockchain.settings.pingTimeout = 2500; // ping message will be called 3 sec. after subscription
+            blockchain.settings.pingTimeout = 200; // ping message will be called 0.2 sec. after subscription
             blockchain.settings.keepAlive = true;
             await blockchain.subscribe({ type: 'block' });
             await blockchain.unsubscribe({ type: 'block' });
 
-            await new Promise(resolve => setTimeout(resolve, 6000));
+            await new Promise(resolve => setTimeout(resolve, 500));
             expect(server.fixtures).toEqual([]);
         }, 7000);
 
@@ -117,11 +117,11 @@ workers.forEach(instance => {
             const callback = jest.fn();
             blockchain.on('disconnected', callback);
 
-            blockchain.settings.pingTimeout = 2500; // ping message will be called 3 sec. after subscription
+            blockchain.settings.pingTimeout = 200; // ping message will be called 0.2 sec. after subscription
             await blockchain.subscribe({ type: 'block' });
             await blockchain.unsubscribe({ type: 'block' });
 
-            await new Promise(resolve => setTimeout(resolve, 4000));
+            await new Promise(resolve => setTimeout(resolve, 500));
 
             expect(callback).toHaveBeenCalled();
             expect(server.getFixtures()!.length).toEqual(2);
@@ -142,7 +142,7 @@ workers.forEach(instance => {
                 // Error [ERR_UNHANDLED_ERROR]: Unhandled error. (websocket)
                 // at Connection.RippleAPI.connection.on (../../node_modules/ripple-lib/src/api.ts:133:14)
                 if (instance.name === 'ripple') {
-                    setTimeout(() => blockchain.disconnect(), 1000);
+                    setTimeout(() => blockchain.disconnect(), 100);
                 } else {
                     blockchain.disconnect();
                 }
@@ -216,7 +216,7 @@ workers.forEach(instance => {
         });
 
         it('Connect error (server field with invalid values)', async () => {
-            blockchain.settings.timeout = 4000;
+            blockchain.settings.timeout = 200;
             blockchain.settings.server = [
                 'gibberish',
                 'ws://gibberish',

--- a/packages/blockchain-link/tests/unit/connection.test.ts
+++ b/packages/blockchain-link/tests/unit/connection.test.ts
@@ -44,6 +44,7 @@ workers.forEach(instance => {
                 blockchain.settings.server = ['wss://google.com:11111', 'wss://google.com:22222'];
                 blockchain.settings.timeout = 4000;
                 await blockchain.connect();
+                fail('Did not throw');
             } catch (error) {
                 expect(error.code).toEqual('blockchain_link/connect');
                 expect(error.message).toEqual('All backends are down');
@@ -53,7 +54,11 @@ workers.forEach(instance => {
         it('Handle message timeout', async () => {
             server.setFixtures([
                 {
-                    method: instance.name === 'ripple' ? 'server_info' : 'getInfo',
+                    method: {
+                        blockbook: 'getInfo',
+                        blockfrost: 'GET_SERVER_INFO',
+                        ripple: 'server_info',
+                    }[instance.name],
                     response: undefined,
                     delay: 8000, // wait 8 sec. to send response
                 },
@@ -61,6 +66,7 @@ workers.forEach(instance => {
             try {
                 blockchain.settings.timeout = 4000;
                 await blockchain.getInfo();
+                fail('Did not throw');
             } catch (error) {
                 expect(error.code).toEqual('blockchain_link/websocket_timeout');
             }
@@ -163,6 +169,7 @@ workers.forEach(instance => {
             blockchain.settings.server = null;
             try {
                 await blockchain.connect();
+                fail('Did not throw');
             } catch (error) {
                 expect(error.code).toEqual('blockchain_link/connect');
             }
@@ -172,6 +179,7 @@ workers.forEach(instance => {
             blockchain.settings.server = [];
             try {
                 await blockchain.connect();
+                fail('Did not throw');
             } catch (error) {
                 expect(error.code).toEqual('blockchain_link/connect');
             }
@@ -182,6 +190,7 @@ workers.forEach(instance => {
             blockchain.settings.server = 1;
             try {
                 await blockchain.connect();
+                fail('Did not throw');
             } catch (error) {
                 expect(error.code).toEqual('blockchain_link/connect');
             }
@@ -193,12 +202,14 @@ workers.forEach(instance => {
         });
 
         it('Websocket connection closed without error before connection.open event', async () => {
+            if (instance.name !== 'ripple') return;
             // auto reconnect RippleApi issue: https://github.com/ripple/ripple-lib/issues/1068
             server.removeAllListeners('connection');
             server.on('connection', (ws: any) => ws.close());
 
             try {
                 await blockchain.connect();
+                fail('Did not throw');
             } catch (error) {
                 expect(error.code).toEqual('blockchain_link/connect');
             }
@@ -220,6 +231,7 @@ workers.forEach(instance => {
             ];
             try {
                 await blockchain.connect();
+                fail('Did not throw');
             } catch (error) {
                 expect(error.message).toEqual('All backends are down');
             }

--- a/packages/blockchain-link/tests/unit/estimateFee.test.ts
+++ b/packages/blockchain-link/tests/unit/estimateFee.test.ts
@@ -29,12 +29,12 @@ workers.forEach(instance => {
         fixtures[instance.name].forEach(f => {
             it(f.description, async () => {
                 server.setFixtures(f.serverFixtures);
-                try {
-                    // @ts-expect-error
-                    const response = await blockchain.estimateFee(f.params);
-                    expect(response).toEqual(f.response);
-                } catch (error) {
-                    expect(error.message).toEqual(f.error);
+                // @ts-expect-error
+                const promise = blockchain.estimateFee(f.params);
+                if (!f.error) {
+                    expect(await promise).toEqual(f.response);
+                } else {
+                    await expect(promise).rejects.toThrow(f.error);
                 }
             });
         });

--- a/packages/blockchain-link/tests/unit/fixtures/getAccountInfo-ripple.ts
+++ b/packages/blockchain-link/tests/unit/fixtures/getAccountInfo-ripple.ts
@@ -96,8 +96,6 @@ export default [
                 transactions: [
                     {
                         type: 'unknown',
-                        amount: '0',
-                        fee: '0',
                         targets: [],
                         internalTransfers: [],
                         tokens: [],

--- a/packages/blockchain-link/tests/unit/fixtures/getTransaction.ts
+++ b/packages/blockchain-link/tests/unit/fixtures/getTransaction.ts
@@ -1,4 +1,4 @@
-const blockbookTx = {
+const blockbookFixture = {
     txid: '28451eff296d05f25cdb08c8bb7956d4f18d0c1e09fe4a1d337f347afdf9a7a1',
     version: 2,
     vin: [
@@ -23,10 +23,36 @@ const blockbookTx = {
     value: '39165971',
     valueIn: '0',
     fees: '0',
+    size: 122,
+    vsize: 122,
     hex: '02000000010000000000000000000000000000000000000000000000000000000000000000ffffffff2503a4f617041fba365d2f4d696e65642042792048454c4c4f2fffffffffafcb4c0000000000ffffffff0113a05502000000001976a91431938090e8a00edb2a42a8fbcf1a56d99de43bc988ac00000000',
 };
 
-const blockfrostTx = {
+const blockbookTx = {
+    type: 'unknown',
+    txid: blockbookFixture.txid,
+    details: {
+        vin: blockbookFixture.vin,
+        vout: blockbookFixture.vout,
+        size: blockbookFixture.size,
+        totalInput: blockbookFixture.valueIn,
+        totalOutput: blockbookFixture.value,
+    },
+    amount: blockbookFixture.value,
+    blockHash: blockbookFixture.blockHash,
+    blockHeight: blockbookFixture.blockHeight,
+    blockTime: blockbookFixture.blockTime,
+    fee: blockbookFixture.fees,
+    feeRate: '0',
+    vsize: blockbookFixture.vsize,
+    hex: blockbookFixture.hex,
+    internalTransfers: [],
+    targets: [],
+    tokens: [],
+};
+
+const blockfrostFixture = {
+    hash: 'deadbeef',
     block: 'e6369fee087d31192016b1659f1c381e9fc4925339278a4eef6f340c96c1947f',
     block_height: 5040611,
     slot: 15650536,
@@ -50,24 +76,53 @@ const blockfrostTx = {
     pool_retire_count: 0,
 };
 
+const blockfrostTx = {
+    type: 'unknown',
+    txid: 'deadbeef',
+    amount: blockfrostFixture.output_amount[0].quantity,
+    blockHash: blockfrostFixture.block,
+    blockHeight: blockfrostFixture.block_height,
+    fee: blockfrostFixture.fees,
+    details: { vin: [], vout: [], size: blockfrostFixture.size, totalInput: '0', totalOutput: '0' },
+    targets: [],
+    tokens: [],
+    internalTransfers: [],
+    cardanoSpecific: {},
+};
+
+const xrpFixture = {
+    Account: 'rB8Ai21NLgz85T9js2fKAVTVEDZnbTn8Eu',
+    Amount: '10000000',
+    Destination: 'rHb9CJAWyB4rj91VRWn96DkukG4bwdtyTh',
+    DestinationTag: 1000000999,
+    Fee: '12',
+    Flags: 2147483648,
+    LastLedgerSequence: 21230993,
+    Sequence: 176,
+    SigningPubKey: '02EEFCFCDC10B7ADAD61C9DF80AEF746A7D2439B52AA5155E6D21B4008CDB6AC43',
+    TransactionType: 'Payment',
+    TxnSignature:
+        '3045022100EE2DC777F71513EEAEC9E6F61F8A83FB0ED4C1278D634B71937142F6934C7BCE02200C33939DA39B5654D67B659265ED3616C9C7B66BE864FDED523FA47B336DF539',
+    date: 617181871,
+    hash: '34E5B5A710421589B868FDFB5BF9AAD2C08352ED0886E17800867A89FBD317D3',
+    inLedger: 21230990,
+    ledger_index: 21230990,
+    validated: true,
+};
+
 const xrpTx = {
-    type: 'payment',
-    address: 'rB8Ai21NLgz85T9js2fKAVTVEDZnbTn8Eu',
-    sequence: 176,
-    id: '34E5B5A710421589B868FDFB5BF9AAD2C08352ED0886E17800867A89FBD317D3',
-    specification: {
-        source: {
-            address: 'rB8Ai21NLgz85T9js2fKAVTVEDZnbTn8Eu',
-            maxAmount: {
-                currency: 'XRP',
-                value: '10',
-            },
-        },
-        destination: {
-            address: 'rHb9CJAWyB4rj91VRWn96DkukG4bwdtyTh',
-            tag: 1000000999,
-        },
-    },
+    txid: xrpFixture.hash,
+    type: 'unknown',
+    blockHeight: xrpFixture.ledger_index,
+    blockHash: xrpFixture.hash,
+    blockTime: xrpFixture.date + 946684800,
+    amount: xrpFixture.Amount,
+    fee: xrpFixture.Fee,
+
+    targets: [],
+    tokens: [],
+    internalTransfers: [],
+    details: { size: 0, totalInput: '0', totalOutput: '0', vin: [], vout: [] },
 };
 
 export default {
@@ -79,14 +134,11 @@ export default {
                 {
                     method: 'getTransaction',
                     response: {
-                        data: blockbookTx,
+                        data: blockbookFixture,
                     },
                 },
             ],
-            response: {
-                type: 'blockbook',
-                tx: blockbookTx,
-            },
+            response: blockbookTx,
         },
         {
             description: 'Not found',
@@ -104,48 +156,24 @@ export default {
                     response: {
                         type: 'response',
                         status: 'success',
-                        result: {
-                            Account: 'rB8Ai21NLgz85T9js2fKAVTVEDZnbTn8Eu',
-                            Amount: '10000000',
-                            Destination: 'rHb9CJAWyB4rj91VRWn96DkukG4bwdtyTh',
-                            DestinationTag: 1000000999,
-                            Fee: '12',
-                            Flags: 2147483648,
-                            LastLedgerSequence: 21230993,
-                            Sequence: 176,
-                            SigningPubKey:
-                                '02EEFCFCDC10B7ADAD61C9DF80AEF746A7D2439B52AA5155E6D21B4008CDB6AC43',
-                            TransactionType: 'Payment',
-                            TxnSignature:
-                                '3045022100EE2DC777F71513EEAEC9E6F61F8A83FB0ED4C1278D634B71937142F6934C7BCE02200C33939DA39B5654D67B659265ED3616C9C7B66BE864FDED523FA47B336DF539',
-                            date: 617181871,
-                            hash: '34E5B5A710421589B868FDFB5BF9AAD2C08352ED0886E17800867A89FBD317D3',
-                            inLedger: 21230990,
-                            ledger_index: 21230990,
-                            validated: true,
-                        },
+                        result: xrpFixture,
                     },
                 },
             ],
-            response: {
-                type: 'ripple',
-                tx: xrpTx,
-            },
+            response: xrpTx,
         },
         {
             description: 'Not found',
             params: '6390FE5EE3B22239B2CA403C32DAFCA613B7FEEE55473A50CB8602CE0FE3EB3F',
-            error: '[NotFoundError(Transaction not found)]',
+            error: 'Transaction not found',
         },
     ],
     blockfrost: [
         {
             description: 'Successful',
             params: '28172ea876c3d1e691284e5179fae2feb3e69d7d41e43f8023dc380115741026',
-            response: {
-                type: 'blockfrost',
-                tx: blockfrostTx,
-            },
+            serverFixtures: [{ method: 'GET_TRANSACTION', response: { data: blockfrostFixture } }],
+            response: blockfrostTx,
         },
         {
             description: 'Not found',

--- a/packages/blockchain-link/tests/unit/fixtures/notifications-blockfrost.ts
+++ b/packages/blockchain-link/tests/unit/fixtures/notifications-blockfrost.ts
@@ -114,9 +114,7 @@ const notifyAddresses = [
                 amount: '0',
                 type: 'sent',
                 targets: [{ addresses: ['B'], n: 0, amount: '0', isAddress: true }],
-                cardanoSpecific: {
-                    subtype: null,
-                },
+                cardanoSpecific: {},
                 details: {
                     vin: [{ addresses: ['A'], isAddress: true, value: '0', isAccountOwned: true }],
                     vout: [{ addresses: ['B'], isAddress: true, value: '0' }],
@@ -175,9 +173,7 @@ const notifyAddresses = [
                         isAddress: true,
                     },
                 ],
-                cardanoSpecific: {
-                    subtype: null,
-                },
+                cardanoSpecific: {},
                 details: {
                     vin: [{ addresses: ['B'], value: '100', isAddress: true }],
                     vout: [
@@ -218,9 +214,7 @@ const notifyAddresses = [
             tx: {
                 ...tx,
                 type: 'self',
-                cardanoSpecific: {
-                    subtype: null,
-                },
+                cardanoSpecific: {},
                 targets: [
                     { addresses: ['A'], isAccountTarget: true, n: 0, amount: '0', isAddress: true },
                 ],
@@ -270,9 +264,7 @@ const notifyAddresses = [
                 amount: '60',
                 type: 'sent',
                 targets: [{ addresses: ['A'], amount: '40', n: 0, isAddress: true }],
-                cardanoSpecific: {
-                    subtype: null,
-                },
+                cardanoSpecific: {},
                 details: {
                     vin: [
                         { addresses: ['B'], value: '100', isAddress: true, isAccountOwned: true },
@@ -330,9 +322,7 @@ const notifyAddresses = [
                         isAddress: true,
                     },
                 ],
-                cardanoSpecific: {
-                    subtype: null,
-                },
+                cardanoSpecific: {},
                 details: {
                     vin: [{ addresses: ['A'], value: '100', isAddress: true }],
                     vout: [
@@ -369,9 +359,7 @@ const notifyAddresses = [
                 ...tx,
                 type: 'sent',
                 amount: '0',
-                cardanoSpecific: {
-                    subtype: null,
-                },
+                cardanoSpecific: {},
                 targets: [{ addresses: ['0x1'], n: 0, isAddress: true, amount: '0' }],
                 details: {
                     vin: [
@@ -450,7 +438,7 @@ const notifyAddresses = [
             tx: {
                 ...tx,
                 type: 'self',
-                cardanoSpecific: { subtype: null },
+                cardanoSpecific: {},
                 details: {
                     vin: [
                         { addresses: ['B'], isAddress: true, value: '0', isAccountOwned: true },
@@ -487,9 +475,7 @@ const notifyAddresses = [
                 ...tx,
                 type: 'unknown',
                 amount: '0',
-                cardanoSpecific: {
-                    subtype: null,
-                },
+                cardanoSpecific: {},
                 details: {
                     vin: [{ addresses: ['B'], isAddress: true, value: '0' }],
                     vout: [{ addresses: ['D'], isAddress: true, value: '0' }],

--- a/packages/blockchain-link/tests/unit/getAccountInfo.test.ts
+++ b/packages/blockchain-link/tests/unit/getAccountInfo.test.ts
@@ -28,12 +28,12 @@ workers.forEach(instance => {
         fixtures[instance.name].forEach(f => {
             it(f.description, async () => {
                 server.setFixtures(f.serverFixtures);
-                try {
-                    // @ts-expect-error incorrect params
-                    const response = await blockchain.getAccountInfo(f.params);
-                    expect(response).toEqual(f.response);
-                } catch (error) {
-                    expect(error.message).toEqual(f.error);
+                // @ts-expect-error incorrect params
+                const promise = blockchain.getAccountInfo(f.params);
+                if (!f.error) {
+                    expect(await promise).toEqual(f.response);
+                } else {
+                    await expect(promise).rejects.toThrow(f.error);
                 }
             });
         });

--- a/packages/blockchain-link/tests/unit/getAccountUtxo.test.ts
+++ b/packages/blockchain-link/tests/unit/getAccountUtxo.test.ts
@@ -28,12 +28,12 @@ workers.forEach(instance => {
         fixtures[instance.name].forEach(f => {
             it(f.description, async () => {
                 server.setFixtures(f.serverFixtures);
-                try {
-                    // @ts-expect-error incorrect params
-                    const response = await blockchain.getAccountUtxo(f.params);
-                    expect(response).toEqual(f.response);
-                } catch (error) {
-                    expect(error.message).toEqual(f.error);
+                // @ts-expect-error incorrect params
+                const promise = blockchain.getAccountUtxo(f.params);
+                if (!f.error) {
+                    expect(await promise).toEqual(f.response);
+                } else {
+                    await expect(promise).rejects.toThrow(f.error);
                 }
             });
         });

--- a/packages/blockchain-link/tests/unit/getBlockHash.test.ts
+++ b/packages/blockchain-link/tests/unit/getBlockHash.test.ts
@@ -28,11 +28,11 @@ workers.forEach(instance => {
         fixtures[instance.name].forEach(f => {
             it(f.description, async () => {
                 server.setFixtures(f.serverFixtures);
-                try {
-                    const response = await blockchain.getBlockHash(f.params);
-                    expect(response).toEqual(f.response);
-                } catch (error) {
-                    expect(error.message).toEqual(f.error);
+                const promise = blockchain.getBlockHash(f.params);
+                if (!f.error) {
+                    expect(await promise).toEqual(f.response);
+                } else {
+                    await expect(promise).rejects.toThrow(f.error);
                 }
             });
         });

--- a/packages/blockchain-link/tests/unit/getInfo.test.ts
+++ b/packages/blockchain-link/tests/unit/getInfo.test.ts
@@ -28,14 +28,14 @@ workers.forEach(instance => {
         fixtures[instance.name].forEach(f => {
             it(f.description, async () => {
                 server.setFixtures(f.serverFixtures);
-                try {
-                    const response = await blockchain.getInfo();
-                    expect(response).toEqual({
+                const promise = blockchain.getInfo();
+                if (!f.error) {
+                    expect(await promise).toEqual({
                         ...f.response,
                         url: `ws://localhost:${server.options.port}`,
                     });
-                } catch (error) {
-                    expect(error.message).toEqual(f.error);
+                } else {
+                    await expect(promise).rejects.toThrow(f.error);
                 }
             });
         });

--- a/packages/blockchain-link/tests/unit/getTransaction.test.ts
+++ b/packages/blockchain-link/tests/unit/getTransaction.test.ts
@@ -29,11 +29,11 @@ workers.forEach(instance => {
         fixtures[instance.name].forEach(f => {
             it(f.description, async () => {
                 server.setFixtures(f.serverFixtures);
-                try {
-                    const response = await blockchain.getTransaction(f.params);
-                    expect(response).toEqual(f.response);
-                } catch (error) {
-                    expect(error.message).toEqual(f.error);
+                const promise = blockchain.getTransaction(f.params);
+                if (!f.error) {
+                    expect(await promise).toEqual(f.response);
+                } else {
+                    await expect(promise).rejects.toThrow(f.error);
                 }
             });
         });

--- a/packages/blockchain-link/tests/unit/pushTransaction.test.ts
+++ b/packages/blockchain-link/tests/unit/pushTransaction.test.ts
@@ -29,11 +29,11 @@ workers.forEach(instance => {
         fixtures[instance.name].forEach(f => {
             it(f.description, async () => {
                 server.setFixtures(f.serverFixtures);
-                try {
-                    const response = await blockchain.pushTransaction(f.params);
-                    expect(response).toEqual(f.response);
-                } catch (error) {
-                    expect(error.message).toEqual(f.error);
+                const promise = blockchain.pushTransaction(f.params);
+                if (!f.error) {
+                    expect(await promise).toEqual(f.response);
+                } else {
+                    await expect(promise).rejects.toThrow(f.error);
                 }
             });
         });

--- a/packages/blockchain-link/tests/unit/state.test.ts
+++ b/packages/blockchain-link/tests/unit/state.test.ts
@@ -6,26 +6,28 @@ const state = new WorkerState();
 describe('Add and remove address in sequence', () => {
     fixtures.addAddresses.forEach(f => {
         it('add address', () => {
-            try {
+            if (!f.error) {
                 // @ts-expect-error invalid param
                 const unique = state.addAddresses(f.input);
                 expect(unique).toEqual(f.unique);
                 expect(state.getAddresses()).toEqual(f.subscribed);
-            } catch (error) {
-                expect(error.message).toEqual(f.error);
+            } else {
+                // @ts-expect-error invalid param
+                expect(() => state.addAddresses(f.input)).toThrow(f.error);
             }
         });
     });
 
     fixtures.removeAddresses.forEach(f => {
         it('remove address', () => {
-            try {
+            if (!f.error) {
                 // @ts-expect-error invalid param
                 const unique = state.removeAddresses(f.input);
                 expect(unique).toEqual(f.subscribed);
                 expect(state.getAddresses()).toEqual(f.subscribed);
-            } catch (error) {
-                expect(error.message).toEqual(f.error);
+            } else {
+                // @ts-expect-error invalid param
+                expect(() => state.removeAddresses(f.input)).toThrow(f.error);
             }
         });
     });

--- a/packages/blockchain-link/tests/unit/workers.test.ts
+++ b/packages/blockchain-link/tests/unit/workers.test.ts
@@ -62,8 +62,8 @@ describe('Worker', () => {
     it('Worker error (invalid worker path)', async () => {
         try {
             blockchain.settings.worker = 'foo.bar';
-            const result = await blockchain.connect();
-            expect(result).toBe(true);
+            await blockchain.connect();
+            fail('Did not throw');
         } catch (error) {
             expect(error.code).toBe('blockchain_link/worker_not_found');
             expect(error.message).toBe('Worker not found');
@@ -74,6 +74,7 @@ describe('Worker', () => {
         try {
             blockchain.settings.worker = () => 1;
             await blockchain.connect();
+            fail('Did not throw');
         } catch (error) {
             expect(error.code).toBe('blockchain_link/worker_invalid');
             expect(error.message).toBe('Invalid worker object');
@@ -84,6 +85,7 @@ describe('Worker', () => {
         try {
             blockchain.settings.worker = () => {};
             await blockchain.connect();
+            fail('Did not throw');
         } catch (error) {
             expect(error.code).toBe('blockchain_link/worker_invalid');
             expect(error.message).toBe('Invalid worker object');
@@ -93,10 +95,9 @@ describe('Worker', () => {
     it('Worker error (handshake timeout)', async () => {
         try {
             blockchain.settings.timeout = 2500;
-            blockchain.settings.worker = () => ({
-                postMessage: () => {},
-            });
+            blockchain.settings.worker = () => ({ postMessage: () => {} });
             await blockchain.connect();
+            fail('Did not throw');
         } catch (error) {
             expect(error.code).toBe('blockchain_link/worker_timeout');
             expect(error.message).toBe('Worker timeout');
@@ -123,6 +124,7 @@ describe('Worker', () => {
                 });
             };
             await blockchain.connect();
+            fail('Did not throw');
         } catch (error) {
             expect(error.code).toBe('blockchain_link/worker_runtime');
         }
@@ -140,6 +142,7 @@ describe('Worker', () => {
         try {
             blockchain.settings.worker = 'foo.bar';
             await blockchain.connect();
+            fail('Did not throw');
         } catch (error) {
             expect(error.code).toBe('blockchain_link/worker_runtime');
         }
@@ -167,6 +170,7 @@ describe('Worker', () => {
                 });
             };
             await blockchain.connect();
+            fail('Did not throw');
         } catch (error) {
             expect(error.code).toBe('blockchain_link/worker_runtime');
         }
@@ -187,6 +191,7 @@ describe('Worker', () => {
         try {
             blockchain.settings.worker = 'foo.bar';
             await blockchain.connect();
+            fail('Did not throw');
         } catch (error) {
             expect(error.code).toBe('blockchain_link/worker_runtime');
         }

--- a/packages/blockchain-link/tests/unit/workers.test.ts
+++ b/packages/blockchain-link/tests/unit/workers.test.ts
@@ -94,7 +94,7 @@ describe('Worker', () => {
 
     it('Worker error (handshake timeout)', async () => {
         try {
-            blockchain.settings.timeout = 2500;
+            blockchain.settings.timeout = 200;
             blockchain.settings.worker = () => ({ postMessage: () => {} });
             await blockchain.connect();
             fail('Did not throw');
@@ -120,7 +120,7 @@ describe('Worker', () => {
                         // @ts-expect-error self is not typed
                         // eslint-disable-next-line no-restricted-globals
                         self.onerror(new Error('runtime error'));
-                    }, 1000);
+                    }, 100);
                 });
             };
             await blockchain.connect();

--- a/packages/coinjoin/src/backend/createPendingTx.ts
+++ b/packages/coinjoin/src/backend/createPendingTx.ts
@@ -38,5 +38,5 @@ export const createPendingTransaction = (
         })),
     };
 
-    return transformTransaction(descriptor, addresses, blockbookTx);
+    return transformTransaction(blockbookTx, addresses ?? descriptor);
 };

--- a/packages/coinjoin/src/backend/scanAccount.ts
+++ b/packages/coinjoin/src/backend/scanAccount.ts
@@ -15,10 +15,10 @@ import type {
 import { CHECKPOINT_COOLDOWN } from '../constants';
 
 const transformTx =
-    (xpub: string, { receive, change }: CoinjoinAddressController) =>
+    ({ receive, change }: CoinjoinAddressController) =>
     (tx: BlockbookTransaction) =>
         // It doesn't matter for transformTransaction which receive addrs are used and which are unused
-        transformTransaction(xpub, { used: receive, unused: [], change }, tx);
+        transformTransaction(tx, { used: receive, unused: [], change });
 
 export const scanAccount = async (
     params: ScanAccountParams & { checkpoints: ScanAccountCheckpoint[] },
@@ -59,7 +59,7 @@ export const scanAccount = async (
             );
         }
 
-        const transactions = Array.from(txs, transformTx(xpub, addresses));
+        const transactions = Array.from(txs, transformTx(addresses));
         checkpoint = {
             blockHash,
             blockHeight,
@@ -80,14 +80,14 @@ export const scanAccount = async (
             await mempool.start();
             pending = await mempool
                 .init(addresses, onProgressInfo)
-                .then(transactions => transactions.map(transformTx(xpub, addresses)))
+                .then(transactions => transactions.map(transformTx(addresses)))
                 .catch(err => {
                     mempool.stop();
                     throw err;
                 });
         } else {
             await mempool.update();
-            pending = mempool.getTransactions(addresses).map(transformTx(xpub, addresses));
+            pending = mempool.getTransactions(addresses).map(transformTx(addresses));
         }
 
         checkpoint = {

--- a/packages/connect-explorer/src/data/methods/blockchain/index.ts
+++ b/packages/connect-explorer/src/data/methods/blockchain/index.ts
@@ -21,6 +21,8 @@ const select = [
     { value: 'thol', label: 'Holesky' },
     { value: 'sol', label: 'Solana' },
     { value: 'dsol', label: 'Solana devnet' },
+    { value: 'ada', label: 'Cardano' },
+    { value: 'tada', label: 'Cardano Testnet' },
 ];
 
 const json = `[

--- a/packages/connect-explorer/src/data/methods/cardano/getAccountInfo.ts
+++ b/packages/connect-explorer/src/data/methods/cardano/getAccountInfo.ts
@@ -26,6 +26,16 @@ export default [
                 value: true,
             },
             cardanoDerivationType,
+            {
+                name: 'details',
+                placeholder: 'Select details',
+                type: 'select',
+                optional: true,
+                data: [
+                    { value: 'basic', label: 'Basic' },
+                    { value: 'txs', label: 'Transactions' },
+                ],
+            },
         ],
     },
 ];

--- a/packages/connect/src/api/bitcoin/__fixtures__/refTx.ts
+++ b/packages/connect/src/api/bitcoin/__fixtures__/refTx.ts
@@ -1,4 +1,5 @@
 /* eslint-disable @typescript-eslint/prefer-ts-expect-error */
+import { networks } from '@trezor/utxo-lib';
 // @ts-ignore
 import tx43d273 from '../../../../e2e/__txcache__/testnet/43d273d3caf41759ad843474f960fbf80ff2ec961135d018b61e9fab3ad1fc06.json';
 // @ts-ignore
@@ -13,6 +14,8 @@ const tx70f987blockbook = {
             {
                 addresses: ['tb1q9l0rk0gkgn73d0gc57qn3t3cwvucaj3h8wtrlu'],
                 value: '20000000',
+                txid: '43d273d3caf41759ad843474f960fbf80ff2ec961135d018b61e9fab3ad1fc06',
+                vout: 1,
             },
         ],
         vout: [
@@ -77,7 +80,7 @@ export const validateReferencedTransactions = [
             ],
             outputs: [], // irrelevant
             addresses: {}, // irrelevant
-            coinInfo: {}, // irrelevant
+            coinInfo: { network: networks.testnet },
         },
         result: [
             {
@@ -102,7 +105,7 @@ export const validateReferencedTransactions = [
             ],
             addresses: ADDRESSES,
             outputs: [], // irrelevant
-            coinInfo: {}, // irrelevant
+            coinInfo: { network: networks.testnet },
         },
         result: [
             {
@@ -142,6 +145,8 @@ export const validateReferencedTransactions = [
                     prev_index: 1,
                     orig_hash: '70f9871eb03a38405cfd7a01e0e1448678132d815e2c9f552ad83ae23969509e',
                     orig_index: 0,
+                    address_n: [2147483734, 2147483649, 2147483648, 0, 0],
+                    amount: '20000000',
                 },
             ],
             addresses: {
@@ -160,7 +165,7 @@ export const validateReferencedTransactions = [
                 ],
             },
             outputs: [], // irrelevant
-            coinInfo: {}, // irrelevant
+            coinInfo: { network: networks.testnet },
         },
         result: [
             {
@@ -231,6 +236,8 @@ export const validateReferencedTransactions = [
                     prev_index: 1,
                     orig_hash: 'ba917a2b563966e324ab37ed7de5f5cd7503b970b0f0bb9a5208f5835557e99c',
                     orig_index: 0,
+                    address_n: [2147483732, 2147483649, 2147483649, 0, 14],
+                    amount: '1000000',
                 },
             ],
             addresses: {
@@ -249,7 +256,7 @@ export const validateReferencedTransactions = [
                 ],
             },
             outputs: [], // irrelevant
-            coinInfo: {}, // irrelevant
+            coinInfo: { network: networks.testnet },
         },
         result: [
             {
@@ -292,7 +299,7 @@ export const validateReferencedTransactions = [
                 },
             ],
             outputs: [], // irrelevant
-            coinInfo: {}, // irrelevant
+            coinInfo: { network: networks.testnet },
         },
         error: '43d273d3caf41759ad843474f960fbf80ff2ec961135d018b61e9fab3ad1fc06 not provided',
     },
@@ -320,35 +327,9 @@ export const validateReferencedTransactions = [
             ],
             addresses: ADDRESSES,
             outputs: [], // irrelevant
-            coinInfo: {}, // irrelevant
+            coinInfo: { network: networks.testnet },
         },
         error: 'invalid input at 70f9871eb03a38405cfd7a01e0e1448678132d815e2c9f552ad83ae23969509e [0]',
-    },
-    {
-        description: 'AccountTransaction to OrigTransaction throws missing outputs data',
-        params: {
-            transactions: [
-                {
-                    ...tx70f987blockbook,
-                    details: {
-                        ...tx70f987blockbook.details,
-                        vout: [{ isAddress: true }], // missing "addresses" field
-                    },
-                },
-            ],
-            inputs: [
-                {
-                    prev_hash: '43d273d3caf41759ad843474f960fbf80ff2ec961135d018b61e9fab3ad1fc06',
-                    prev_index: 1,
-                    orig_hash: '70f9871eb03a38405cfd7a01e0e1448678132d815e2c9f552ad83ae23969509e',
-                    orig_index: 0,
-                },
-            ],
-            addresses: ADDRESSES,
-            outputs: [], // irrelevant
-            coinInfo: {}, // irrelevant
-        },
-        error: 'invalid output at 70f9871eb03a38405cfd7a01e0e1448678132d815e2c9f552ad83ae23969509e [0]',
     },
     {
         description: 'AccountTransaction to OrigTransaction throws missing hex',
@@ -369,7 +350,7 @@ export const validateReferencedTransactions = [
             ],
             outputs: [], // irrelevant
             addresses: {}, // irrelevant
-            coinInfo: {}, // irrelevant
+            coinInfo: { network: networks.testnet },
         },
         error: 'hex for 70f9871eb03a38405cfd7a01e0e1448678132d815e2c9f552ad83ae23969509e not provided',
     },
@@ -390,7 +371,7 @@ export const validateReferencedTransactions = [
             ],
             outputs: [], // irrelevant
             addresses: {}, // irrelevant
-            coinInfo: {}, // irrelevant
+            coinInfo: { network: networks.testnet },
         },
         error: 'hex for 70f9871eb03a38405cfd7a01e0e1448678132d815e2c9f552ad83ae23969509e not provided',
     },
@@ -408,7 +389,7 @@ export const validateReferencedTransactions = [
             ],
             addresses: undefined,
             outputs: [], // irrelevant
-            coinInfo: {}, // irrelevant
+            coinInfo: { network: networks.testnet },
         },
         error: 'addresses for 70f9871eb03a38405cfd7a01e0e1448678132d815e2c9f552ad83ae23969509e not provided',
     },
@@ -418,7 +399,7 @@ export const validateReferencedTransactions = [
             transactions: [],
             inputs: [], // irrelevant
             outputs: [], // irrelevant
-            coinInfo: {}, // irrelevant
+            coinInfo: { network: networks.testnet },
         },
         result: undefined,
     },
@@ -428,7 +409,7 @@ export const validateReferencedTransactions = [
             transactions: {},
             inputs: [], // irrelevant
             outputs: [], // irrelevant
-            coinInfo: {}, // irrelevant
+            coinInfo: { network: networks.testnet },
         },
         result: undefined,
     },

--- a/packages/connect/src/api/bitcoin/inputs.ts
+++ b/packages/connect/src/api/bitcoin/inputs.ts
@@ -1,6 +1,6 @@
 // origin: https://github.com/trezor/connect/blob/develop/src/js/core/methods/tx/inputs.js
 
-import type { TypedRawTransaction } from '@trezor/blockchain-link';
+import { Transaction as BitcoinJsTransaction } from '@trezor/utxo-lib';
 import {
     validatePath,
     isSegwitPath,
@@ -55,13 +55,16 @@ export const validateTrezorInputs = (
 
 // this method exist as a workaround for breaking change described in validateTrezorInputs
 // TODO: it could be removed after another major version release.
-export const enhanceTrezorInputs = (inputs: PROTO.TxInputType[], rawTxs: TypedRawTransaction[]) => {
+export const enhanceTrezorInputs = (
+    inputs: PROTO.TxInputType[],
+    rawTxs: BitcoinJsTransaction[],
+) => {
     inputs.forEach(input => {
         if (!input.amount) {
             console.warn('TrezorConnect.singTransaction deprecation: missing input amount.');
-            const refTx = rawTxs.find(t => 'txid' in t.tx && t.tx.txid === input.prev_hash);
-            if (refTx && refTx.type === 'blockbook' && refTx.tx.vout[input.prev_index]) {
-                input.amount = refTx.tx.vout[input.prev_index].value!;
+            const refTx = rawTxs.find(t => t.getId() === input.prev_hash);
+            if (refTx && refTx.outs[input.prev_index]) {
+                input.amount = refTx.outs[input.prev_index].value;
             }
         }
     });

--- a/packages/connect/src/backend/Blockchain.ts
+++ b/packages/connect/src/backend/Blockchain.ts
@@ -141,6 +141,10 @@ export class Blockchain {
         return Promise.all(txs.map(id => this.link.getTransaction(id)));
     }
 
+    getTransactionHexes(txids: string[]) {
+        return Promise.all(txids.map(id => this.link.getTransactionHex(id)));
+    }
+
     getCurrentFiatRates(params: { currencies?: string[]; token?: string }) {
         return this.link.getCurrentFiatRates(params);
     }

--- a/packages/connect/src/types/api/__tests__/blockchain.ts
+++ b/packages/connect/src/types/api/__tests__/blockchain.ts
@@ -73,15 +73,9 @@ export const blockchainGetTransactions = async (api: TrezorConnect) => {
     const txs = await api.blockchainGetTransactions({ coin: 'btc', txs: ['txid'] });
     if (txs.success) {
         txs.payload.forEach(raw => {
-            if (raw.type === 'blockbook') {
-                raw.tx.blockHash?.toLowerCase();
-            }
-            if (raw.type === 'ripple') {
-                raw.tx.outcome.fee.toLowerCase();
-            }
-            if (raw.type === 'blockfrost') {
-                raw.tx.txHash.toLowerCase();
-            }
+            raw.txid.toLowerCase();
+            raw.amount.toLowerCase();
+            raw.blockHash?.toLowerCase();
         });
     }
 };

--- a/packages/connect/src/types/api/blockchainGetTransactions.ts
+++ b/packages/connect/src/types/api/blockchainGetTransactions.ts
@@ -1,4 +1,4 @@
-import type { TypedRawTransaction } from '@trezor/blockchain-link';
+import type { Transaction } from '@trezor/blockchain-link';
 import type { CommonParamsWithCoin, Response } from '../params';
 
 export type BlockchainGetTransactions = CommonParamsWithCoin & {
@@ -7,4 +7,4 @@ export type BlockchainGetTransactions = CommonParamsWithCoin & {
 
 export declare function blockchainGetTransactions(
     params: BlockchainGetTransactions,
-): Response<TypedRawTransaction[]>;
+): Response<Transaction[]>;

--- a/suite-common/wallet-core/src/transactions/transactionsThunks.ts
+++ b/suite-common/wallet-core/src/transactions/transactionsThunks.ts
@@ -60,9 +60,8 @@ export const replaceTransactionThunk = createThunk<ReplaceTransactionThunkParams
                 // bitcoin-like: profile transaction for affected account
                 newTx = enhanceTransaction(
                     blockbookUtils.transformTransaction(
-                        affectedAccount.descriptor,
-                        affectedAccount.addresses,
                         signedTransaction,
+                        affectedAccount.addresses,
                     ),
                     affectedAccount,
                 );
@@ -141,9 +140,8 @@ export const addFakePendingTxThunk = createThunk<AddFakePendingTransactionParams
             if (!precomposedTx.prevTxid) {
                 // create and profile pending transaction for affected account if it's not a replacement tx
                 const affectedAccountTransaction = blockbookUtils.transformTransaction(
-                    affectedAccount.descriptor,
-                    affectedAccount.addresses,
                     transaction,
+                    affectedAccount.addresses ?? affectedAccount.descriptor,
                 );
                 const prependingTx = { ...affectedAccountTransaction, deadline: blockHeight + 2 };
                 dispatch(

--- a/suite-common/wallet-core/src/transactions/transactionsThunks.ts
+++ b/suite-common/wallet-core/src/transactions/transactionsThunks.ts
@@ -204,9 +204,7 @@ export const addFakePendingCardanoTxThunk = createThunk(
             targets: [],
             tokens: [],
             internalTransfers: [],
-            cardanoSpecific: {
-                subtype: null,
-            },
+            cardanoSpecific: {},
             details: {
                 vin: [],
                 vout: [],


### PR DESCRIPTION
## Description
I've tried to make Connect's API a bit more usable by unifying the transaction types, specifically removing `TypedRawTransaction`. While doing it, I've descended deeper and deeper and created multiple sections of commits which are somehow independent (I can create multiple PRs if you want).

## Commits
- Blockchain-link unit test improvements
  - https://github.com/trezor/trezor-suite/pull/8711/commits/457ff59148ffd9f95caf5c4e25ac4b025d8b80fd - fixing a lot of unit tests where we expected errors but haven't failed when we didn't receive them (the whole `try { foo(); } catch (err) { expect(error)... }` construction was wrong).
  - https://github.com/trezor/trezor-suite/pull/8711/commits/7e6b24758235ac8c087da446084390214625f051 - significantly smaller timeouts in unit tests in order to make them faster (I've tried to mock the timers but it was more complicated than I've thought)
- Cardano improvements
  - https://github.com/trezor/trezor-suite/pull/8711/commits/fe1c0692eed703ce1e5a5bd898f1e48d83376bec - add some params to `connect-explorer`, specifically `ADA` and `tADA` networks to blockchain methods and `details` param to `getAccountInfo`
  - https://github.com/trezor/trezor-suite/pull/8711/commits/cb2fb538b1bc8e293d1a4caa1145ab40f087669a - fixed unmatching return type of Cardano's `GET_TRANSACTION` message (empirically tested)
  - https://github.com/trezor/trezor-suite/pull/8711/commits/61c014de5fc94eb360e28c87d377c2dfc8ef76a6 - remove `null` subtype of Cardano txs in favour of `undefined`
- Changing order of `transformTransaction` parameters
  - https://github.com/trezor/trezor-suite/pull/8711/commits/de244ae7ddb05168c4dd6a75bd722e4e104d572a - make the `tx` param of `transformTransaction` first (so the following can be optional) in `blockchain-link-utils` and unify the `addresses` and `descriptor` params (as only one of them is always relevant)
  - https://github.com/trezor/trezor-suite/pull/8711/commits/24fcb3b26dedc33cb233e7469357c5054e48ffdf - adjust `blockchain-link` to this change
  - https://github.com/trezor/trezor-suite/pull/8711/commits/f7b9376a4bdeeb0ad21a0ca4372da2c1ce3b25ae - adjust `coinjoin` to this change
  - https://github.com/trezor/trezor-suite/pull/8711/commits/1b479faf6ac381807b1a13f4d01321eebba5094a - adjust `suite` to this change
- Unify return type of Connect's blockchainGetTransactions method
  - https://github.com/trezor/trezor-suite/pull/8711/commits/b036d38b41e541059f71cf481dc3054089b89d22 - added `getTransactionHex` method to `blockchain-link` and implemented for blockbook and electrum, will be needed in the last commit
  - https://github.com/trezor/trezor-suite/pull/8711/commits/655b93cd8edf95ce63ffae8bb011033b9d92fa42 - remove `TypedRawTransaction` type and transform the transactions returned from `blockchain-link` to the shared format instead; transformation of 'accountless' ripple and blockfrost txs had to change a bit
  - https://github.com/trezor/trezor-suite/pull/8711/commits/1b60216abd45bd78bc1ec4d87e67ab4e1499cd96 - tests adjusted to the previous commit
  - https://github.com/trezor/trezor-suite/pull/8711/commits/53e0f55d4cbfc6076c00377945d5923c2f359d10 - Connect adjusted to the changes
- Improved refTxs/origTxs fetching in Connect
  - https://github.com/trezor/trezor-suite/pull/8711/commits/678a498a805e962b12c849624c6147fa78331b65 - `composeTransaction` and `signTransaction` now works only with transaction hexes when fetching `refTxs` or `origTxs`, which should be a bit more robust

## Potential breaking changes for 3rd parties
- subtype of unrecognized Cardano txs is `undefined` instead of `null` in txs from `getAccountInfo` or from `notification` event
- `TrezorConnect.blockchainGetTransactions` is now returning txs in Suite's format instead of `TypedRawTransaction`