### PR TITLE
Fix: blockchain-link error handling

### DIFF
--- a/packages/blockchain-link/src/utils/ws-native.ts
+++ b/packages/blockchain-link/src/utils/ws-native.ts
@@ -13,7 +13,6 @@ class WSWrapper extends EventEmitter {
 
     constructor(url: string, _protocols: any, _websocketOptions: any) {
         super();
-        this.setMaxListeners(Infinity);
 
         // React Native WebSocket is able to accept headers compared to the native browser `WebSocket`.
         // @ts-expect-error
@@ -31,8 +30,14 @@ class WSWrapper extends EventEmitter {
             this.emit('open');
         };
 
-        this._ws.onerror = error => {
-            this.emit('error', error);
+        // WebSocket error Event does not contain any useful description.
+        // https://websockets.spec.whatwg.org//#dom-websocket-onerror
+        // If the user agent was required to fail the WebSocket connection,
+        // or if the WebSocket connection was closed after being flagged as full,
+        // fire an event named error at the WebSocket object.
+        // https://stackoverflow.com/a/31003057
+        this._ws.onerror = _event => {
+            this.emit('error', new Error(`WsWrapper error. Ready state: ${this.readyState}`));
         };
 
         this._ws.onmessage = message => {

--- a/packages/blockchain-link/src/utils/ws.ts
+++ b/packages/blockchain-link/src/utils/ws.ts
@@ -13,7 +13,6 @@ class WSWrapper extends EventEmitter {
 
     constructor(url: string, _protocols: any, _websocketOptions: any) {
         super();
-        this.setMaxListeners(Infinity);
 
         this._ws = new WebSocket(url);
 
@@ -25,8 +24,14 @@ class WSWrapper extends EventEmitter {
             this.emit('open');
         };
 
-        this._ws.onerror = error => {
-            this.emit('error', error);
+        // WebSocket error Event does not contain any useful description.
+        // https://websockets.spec.whatwg.org//#dom-websocket-onerror
+        // If the user agent was required to fail the WebSocket connection,
+        // or if the WebSocket connection was closed after being flagged as full,
+        // fire an event named error at the WebSocket object.
+        // https://stackoverflow.com/a/31003057
+        this._ws.onerror = _event => {
+            this.emit('error', new Error(`WsWrapper error. Ready state: ${this.readyState}`));
         };
 
         this._ws.onmessage = message => {

--- a/packages/blockchain-link/src/workers/blockbook/websocket.ts
+++ b/packages/blockchain-link/src/workers/blockbook/websocket.ts
@@ -109,14 +109,14 @@ export class BlockbookAPI extends TypedEmitter<BlockbookEvents> {
     async onPing() {
         // make sure that connection is alive if there are subscriptions
         if (this.ws && this.isConnected()) {
-            if (this.subscriptions.length > 0 || this.options.keepAlive) {
-                await this.getBlockHash(0);
-            } else {
-                try {
+            try {
+                if (this.subscriptions.length > 0 || this.options.keepAlive) {
+                    await this.getBlockHash(1);
+                } else {
                     this.ws.close();
-                } catch (error) {
-                    // empty
                 }
+            } catch (error) {
+                // empty
             }
         }
     }

--- a/packages/blockchain-link/src/workers/blockfrost/websocket.ts
+++ b/packages/blockchain-link/src/workers/blockfrost/websocket.ts
@@ -100,14 +100,14 @@ export class BlockfrostAPI extends TypedEmitter<BlockfrostEvents> {
     async onPing() {
         // make sure that connection is alive if there are subscriptions
         if (this.ws && this.isConnected()) {
-            if (this.subscriptions.length > 0 || this.options.keepAlive) {
-                await this.getBlockHash(1);
-            } else {
-                try {
+            try {
+                if (this.subscriptions.length > 0 || this.options.keepAlive) {
+                    await this.getBlockHash(1);
+                } else {
                     this.ws.close();
-                } catch (error) {
-                    // empty
                 }
+            } catch (error) {
+                // empty
             }
         }
     }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

While working on [tor circuits timeouts](https://github.com/trezor/trezor-suite/pull/8661) i've noticed that:

1. `onPing` method (internally using `getBlockHash` call) rejects unhandled errors
2. WebSocket.on('error') handler does not return `Error` object which ends with "Message not set" `CustomError` (only in web and probably mobile/native builds cc @Nodonisko pls verify that)
3. Websocket classes sets setMaxListeners to `Infinity` (totally unnecessary) which may lead to memory leaks
