### PR TITLE
Handle error when WS is trying to reconnect in CJ

### DIFF
--- a/packages/coinjoin/src/backend/CoinjoinMempoolController.ts
+++ b/packages/coinjoin/src/backend/CoinjoinMempoolController.ts
@@ -36,6 +36,7 @@ export class CoinjoinMempoolController implements MempoolController {
     private readonly filter;
     private readonly onTxAdd;
     private readonly onTxRemove;
+    private readonly onDisconnect;
     private lastPurge;
     private _status: MempoolStatus;
 
@@ -52,6 +53,9 @@ export class CoinjoinMempoolController implements MempoolController {
         this.filter = filter;
         this.onTxAdd = this.onTransactionAdd.bind(this);
         this.onTxRemove = this.onTransactionRemove.bind(this);
+        this.onDisconnect = () => {
+            this._status = 'stopped';
+        };
         this.lastPurge = new Date().getTime();
         this._status = 'stopped';
     }
@@ -131,13 +135,13 @@ export class CoinjoinMempoolController implements MempoolController {
 
     async start() {
         if (this._status === 'running') return;
-        await this.client.subscribeMempoolTxs(this.onTxAdd);
+        await this.client.subscribeMempoolTxs(this.onTxAdd, this.onDisconnect);
         this._status = 'running';
     }
 
     async stop() {
         if (this._status === 'stopped') return;
-        await this.client.unsubscribeMempoolTxs(this.onTxAdd);
+        await this.client.unsubscribeMempoolTxs(this.onTxAdd, this.onDisconnect);
         this._status = 'stopped';
     }
 

--- a/packages/coinjoin/src/backend/CoinjoinWebsocketController.ts
+++ b/packages/coinjoin/src/backend/CoinjoinWebsocketController.ts
@@ -41,7 +41,13 @@ export class CoinjoinWebsocketController {
             this.sockets[socketId] = socket;
         }
         if (!socket.isConnected()) {
-            await socket.connect();
+            try {
+                await socket.connect();
+            } catch (err) {
+                delete this.sockets[socketId];
+                socket.dispose();
+                throw err;
+            }
             this.logger?.debug(`WS OPENED ${socketId}`);
             socket.once('disconnected', () => {
                 this.logger?.debug(`WS CLOSED ${socketId}`);


### PR DESCRIPTION
## Description
- `CoinjoinWebsocketController` - when unconnected websocket fails to connect, it's immediately disposed and thrown away, so new websocket is created next time instead of recycling
- `CoinjoinBackendClient` - new emitter is added, so `onDisconnect` function (passed from outside) is fired whenever disconnected websocket cannot be reconnected in `reconnect` (instead of throwing unhandled error)
- `CoinjoinMempoolController` - when websocket disconnects and cannot reconnect while subscribed to mempool, status is set to `stopped` and has to be started again next time