### PR TITLE
refactor(request-manager): simplification of RequestPool

### DIFF
--- a/packages/request-manager/src/httpPool.ts
+++ b/packages/request-manager/src/httpPool.ts
@@ -1,73 +1,38 @@
 import http from 'http';
 import { InterceptorOptions } from './types';
-import { getWeakRandomId } from '@trezor/utils';
 
-interface RequestData {
-    id: string;
-    requestTime: number;
-    host: string;
-}
+export const createRequestPool = (interceptorOptions: InterceptorOptions) => {
+    const requestTimeoutLimit = 1000 * 30;
 
-export class RequestPool {
-    requestPool: RequestData[] = [];
-    requestTimeoutLimit = 1000 * 30;
-    isNetworkMisbehaving = false;
-    interceptorOptions: InterceptorOptions;
-
-    constructor(interceptorOptions: InterceptorOptions) {
-        this.interceptorOptions = interceptorOptions;
-    }
-
-    removeRequest(id: string) {
-        this.requestPool = this.requestPool.filter(req => req.id !== id);
-    }
-
-    addRequest(request: http.ClientRequest) {
-        const id = getWeakRandomId(10);
+    return (request: http.ClientRequest) => {
         const { host } = request;
-        this.requestPool.push({
-            id,
-            requestTime: new Date().getTime(),
-            host,
-        });
-        request.on('response', (response: http.IncomingMessage) => {
-            const requestFromPool = this.requestPool.find(req => req.id === id);
-            if (requestFromPool) {
-                const timeRequestTook = new Date().getTime() - requestFromPool.requestTime;
-                const { statusCode } = response;
+        const requestTime = Date.now();
 
-                this.isNetworkMisbehaving = timeRequestTook > this.requestTimeoutLimit;
-                if (this.isNetworkMisbehaving) {
-                    this.interceptorOptions.handler({
-                        type: 'NETWORK_MISBEHAVING',
-                    });
-                }
-                this.interceptorOptions.handler({
-                    type: 'INTERCEPTED_RESPONSE',
-                    host: requestFromPool.host,
-                    time: timeRequestTook,
-                    statusCode,
+        request.on('response', response => {
+            const timeRequestTook = Date.now() - requestTime;
+            const { statusCode } = response;
+
+            const isNetworkMisbehaving = timeRequestTook > requestTimeoutLimit;
+            if (isNetworkMisbehaving) {
+                interceptorOptions.handler({
+                    type: 'NETWORK_MISBEHAVING',
                 });
-                this.removeRequest(id);
             }
+            interceptorOptions.handler({
+                type: 'INTERCEPTED_RESPONSE',
+                host,
+                time: timeRequestTook,
+                statusCode,
+            });
         });
 
         request.on('error', (error: Error) => {
-            const isProxyConnectionTimedout = error.message.includes('Proxy connection timed out');
-            const isProxyRejectedConnection = error.message.includes(
-                'Socks5 proxy rejected connection',
-            );
-            let errorType: 'ERROR' | 'ERROR_PROXY_TIMEOUT' | 'ERROR_PROXY_REJECTED' = 'ERROR';
-            if (isProxyConnectionTimedout) {
-                errorType = 'ERROR_PROXY_TIMEOUT';
-            } else if (isProxyRejectedConnection) {
-                errorType = 'ERROR_PROXY_REJECTED';
-            }
-
-            this.interceptorOptions.handler({
-                type: errorType,
+            interceptorOptions.handler({
+                type: 'ERROR',
+                error,
             });
-            this.removeRequest(id);
         });
-    }
-}
+
+        return request;
+    };
+};

--- a/packages/request-manager/src/types.ts
+++ b/packages/request-manager/src/types.ts
@@ -31,7 +31,8 @@ export type InterceptedEvent =
           type: 'NETWORK_MISBEHAVING';
       }
     | {
-          type: 'ERROR' | 'ERROR_PROXY_TIMEOUT' | 'ERROR_PROXY_REJECTED';
+          type: 'ERROR';
+          error: Error;
       };
 
 export type TorSettings = {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Prerequisite for [tor circuits timeouts](https://github.com/trezor/trezor-suite/pull/8661) 
Cherry picked to standalone PR to avoid complex changes in main PR.

1. `RequestPool` unnecessarily stores the data (RequestData) of the request in `requestPool` array. All could be done in the scope of one function.
2.  `RequestPool` doesn't have to be class (see discussion below)
3. removed unused 'ERROR_PROXY_TIMEOUT' and 'ERROR_PROXY_REJECTED' - will be done/handled differently in the main PR
4. fixed `interceptNetSocketConnect` and `interceptNetConnect` details. Occasionally it logs:
```
DEBUG(request-interceptor): net.Socket.connect - undefined
```

 because of forcetyping and ts-ignore