### PR TITLE
Chore/update to jest 29 in suite

### DIFF
--- a/packages/suite/jest.config.js
+++ b/packages/suite/jest.config.js
@@ -67,4 +67,9 @@ module.exports = {
     verbose: false,
     watchPlugins: ['jest-watch-typeahead/filename', 'jest-watch-typeahead/testname'],
     testEnvironment: 'jsdom',
+    fakeTimers: {
+        enableGlobally: false,
+        // https://jestjs.io/docs/28.x/upgrading-to-jest28#faketimers
+        legacyFakeTimers: true,
+    },
 };

--- a/packages/suite/jest.config.js
+++ b/packages/suite/jest.config.js
@@ -66,4 +66,5 @@ module.exports = {
     },
     verbose: false,
     watchPlugins: ['jest-watch-typeahead/filename', 'jest-watch-typeahead/testname'],
+    testEnvironment: 'jsdom',
 };

--- a/packages/suite/package.json
+++ b/packages/suite/package.json
@@ -15,7 +15,7 @@
         "translations:list-duplicates": "yarn tsx ../suite-data/src/translations/list-duplicates.ts",
         "translations:list-unused": "yarn tsx ../suite-data/src/translations/list-unused.ts",
         "type-check": "tsc --build tsconfig.json",
-        "test:unit": "jest",
+        "test:unit": "jest --version && jest",
         "test-unit:watch": "jest -o --watch"
     },
     "dependencies": {
@@ -131,8 +131,9 @@
         "@types/ua-parser-js": "^0.7.36",
         "@types/uuid": "^9.0.1",
         "@types/zxcvbn": "^4.4.1",
-        "jest": "^26.6.3",
+        "jest": "^29.5.0",
         "jest-canvas-mock": "^2.5.1",
+        "jest-environment-jsdom": "^29.5.0",
         "jest-watch-typeahead": "0.6.5",
         "prettier": "2.8.8",
         "react-test-renderer": "^18.2.0",

--- a/packages/suite/src/actions/wallet/__tests__/coinjoinClientActions.test.ts
+++ b/packages/suite/src/actions/wallet/__tests__/coinjoinClientActions.test.ts
@@ -2,6 +2,7 @@ import { combineReducers, createReducer } from '@reduxjs/toolkit';
 import { configureMockStore, testMocks } from '@suite-common/test-utils';
 import { promiseAllSequence } from '@trezor/utils';
 
+import { db } from 'src/storage';
 import { accountsReducer } from 'src/reducers/wallet';
 import { coinjoinReducer } from 'src/reducers/wallet/coinjoinReducer';
 import selectedAccountReducer from 'src/reducers/wallet/selectedAccountReducer';
@@ -86,6 +87,9 @@ const initStore = ({ accounts, coinjoin, devices, selectedAccount }: Wallet = {}
 describe('coinjoinClientActions', () => {
     afterEach(() => {
         jest.clearAllMocks();
+    });
+    beforeAll(async () => {
+        await db.getDB();
     });
 
     fixtures.onCoinjoinRoundChanged.forEach(f => {

--- a/packages/suite/src/actions/wallet/__tests__/discoveryActions.test.ts
+++ b/packages/suite/src/actions/wallet/__tests__/discoveryActions.test.ts
@@ -235,7 +235,7 @@ describe('Discovery Actions', () => {
 
     // Detailed info about this test could be found in fixtures
     interruptionFixtures.forEach(f => {
-        it(`Start/stop/change networks/start: ${f.description}`, async done => {
+        it(`Start/stop/change networks/start: ${f.description}`, async () => {
             require('@trezor/connect').setTestFixtures(f);
             const store = initStore();
             // additional action listener for triggering "discovery.stop" action
@@ -274,12 +274,12 @@ describe('Discovery Actions', () => {
             expect(complete.type).toEqual(DISCOVERY.COMPLETE);
             const discovery = store.getState().wallet.discovery[0];
             expect(discovery.loaded).toEqual(store.getState().wallet.accounts.length);
-            done(expect(discovery.total).toEqual(discovery.loaded));
+            expect(discovery.total).toEqual(discovery.loaded);
         });
     });
 
     changeNetworksFixtures.forEach(f => {
-        it(`Change network: ${f.description}`, async done => {
+        it(`Change network: ${f.description}`, async () => {
             require('@trezor/connect').setTestFixtures(f);
             const state = getInitialState();
             const store = initStore(state);
@@ -313,7 +313,7 @@ describe('Discovery Actions', () => {
             // length of accounts in reducer are equal discovery.loaded
             expect(discovery.loaded).toEqual(accounts.length);
             // 100% progress
-            done(expect(discovery.total).toEqual(discovery.loaded));
+            expect(discovery.total).toEqual(discovery.loaded);
         });
     });
 
@@ -446,7 +446,7 @@ describe('Discovery Actions', () => {
         await store.dispatch(discoveryActions.restart());
     });
 
-    it(`TrezorConnect responded with success but discovery was removed`, async done => {
+    it(`TrezorConnect responded with success but discovery was removed`, async () => {
         const f = new Promise(resolve => {
             setTimeout(() => resolve({ success: true }), 100);
         });
@@ -465,10 +465,10 @@ describe('Discovery Actions', () => {
         store.dispatch(discoveryActions.create('device-state', SUITE_DEVICE));
         await store.dispatch(discoveryActions.start());
         const action = store.getActions().pop();
-        done(expect(action.type).toEqual(DISCOVERY.REMOVE));
+        expect(action.type).toEqual(DISCOVERY.REMOVE);
     });
 
-    it(`TrezorConnect responded with success but discovery is not running`, async done => {
+    it(`TrezorConnect responded with success but discovery is not running`, async () => {
         const f = new Promise(resolve => {
             setTimeout(() => resolve({ success: true }), 100);
         });
@@ -492,7 +492,7 @@ describe('Discovery Actions', () => {
         store.dispatch(discoveryActions.create('device-state', SUITE_DEVICE));
         await store.dispatch(discoveryActions.start());
         const action = store.getActions().pop();
-        done(expect(action.type).toEqual(notificationsActions.addToast.type));
+        expect(action.type).toEqual(notificationsActions.addToast.type);
     });
 
     it('Discovery completed but device is not connected anymore', async () => {

--- a/packages/suite/src/hooks/wallet/__tests__/useRbfForm.test.tsx
+++ b/packages/suite/src/hooks/wallet/__tests__/useRbfForm.test.tsx
@@ -116,9 +116,6 @@ describe('useRbfForm hook', () => {
     afterAll(async () => {
         await TrezorConnect.dispose();
     });
-    beforeEach(() => {
-        jest.setTimeout(30000); // action sequences takes time
-    });
     afterEach(() => {
         jest.clearAllMocks();
     });

--- a/packages/suite/src/hooks/wallet/__tests__/useSendForm.test.tsx
+++ b/packages/suite/src/hooks/wallet/__tests__/useSendForm.test.tsx
@@ -214,9 +214,6 @@ const actionCallback = (
 };
 
 describe('useSendForm hook', () => {
-    beforeEach(() => {
-        jest.setTimeout(30000); // action sequences takes time
-    });
     afterEach(() => {
         jest.clearAllMocks();
     });
@@ -251,33 +248,37 @@ describe('useSendForm hook', () => {
 
             unmount();
         });
-    });
+    }, 30000);
 
     fixtures.setMax.forEach(f => {
-        it(f.description, async () => {
-            TrezorConnect.setTestFixtures(f.connect);
-            const store = initStore(getInitialState(f.store));
-            const callback: TestCallback = {};
-            const { unmount } = renderWithProviders(
-                store,
-                <SendIndex>
-                    <Component callback={callback} />
-                </SendIndex>,
-            );
+        it(
+            f.description,
+            async () => {
+                TrezorConnect.setTestFixtures(f.connect);
+                const store = initStore(getInitialState(f.store));
+                const callback: TestCallback = {};
+                const { unmount } = renderWithProviders(
+                    store,
+                    <SendIndex>
+                        <Component callback={callback} />
+                    </SendIndex>,
+                );
 
-            // wait for first render
-            await waitForLoader();
+                // wait for first render
+                await waitForLoader();
 
-            // execute user actions sequence
-            if (f.actions) {
-                await actionSequence(f.actions, a => actionCallback(callback, a));
-            }
+                // execute user actions sequence
+                if (f.actions) {
+                    await actionSequence(f.actions, a => actionCallback(callback, a));
+                }
 
-            // validate finalResult
-            actionCallback(callback, { result: f.finalResult });
+                // validate finalResult
+                actionCallback(callback, { result: f.finalResult });
 
-            unmount();
-        });
+                unmount();
+            },
+            30000,
+        );
     });
 
     fixtures.composeDebouncedTransaction.forEach(f => {
@@ -340,7 +341,7 @@ describe('useSendForm hook', () => {
     });
 
     fixtures.feeChange.forEach(f => {
-        it(f.description, async () => {
+        it(`changeFee: ${f.description}`, async () => {
             TrezorConnect.setTestFixtures(f.connect);
             const store = initStore(getInitialState(f.store));
             const callback: TestCallback = {};
@@ -361,7 +362,7 @@ describe('useSendForm hook', () => {
             actionCallback(callback, { result: f.finalResult });
 
             unmount();
-        });
+        }, 30000);
     });
 
     fixtures.amountUnitChange.forEach(f => {

--- a/packages/suite/src/middlewares/wallet/__tests__/pollingMiddleware.test.ts
+++ b/packages/suite/src/middlewares/wallet/__tests__/pollingMiddleware.test.ts
@@ -88,6 +88,11 @@ describe('pollingMiddleware', () => {
         jest.runOnlyPendingTimers();
 
         expect(store.getActions()).toEqual([{ type: POLLING.REQUEST, key: 'fake' }]);
+        // todo:
+        // this assertion fails without
+        // legacyFakeTimers: true,
+        // (see jest.config.js)
+        // https://jestjs.io/docs/28.x/upgrading-to-jest28#faketimers
         expect(setTimeout).toHaveBeenCalledTimes(1);
     });
 

--- a/packages/suite/src/support/tests/svgTransform.js
+++ b/packages/suite/src/support/tests/svgTransform.js
@@ -1,8 +1,10 @@
-// https://stackoverflow.com/questions/46791263/jest-test-fail-syntaxerror-unexpected-token
 module.exports = {
     process() {
-        return 'module.exports = {};';
+        return {
+            code: 'module.exports = {};',
+        };
     },
+
     getCacheKey() {
         // The output is always the same.
         return 'svgTransform';

--- a/yarn.lock
+++ b/yarn.lock
@@ -8333,8 +8333,9 @@ __metadata:
     history: ^4.10.1
     idb: ^7.1.1
     immer: 9.0.21
-    jest: ^26.6.3
+    jest: ^29.5.0
     jest-canvas-mock: ^2.5.1
+    jest-environment-jsdom: ^29.5.0
     jest-watch-typeahead: 0.6.5
     jws: ^4.0.0
     lottie-react: ^2.4.0


### PR DESCRIPTION
- [6e0c490](https://github.com/trezor/trezor-suite/pull/8726/commits/6e0c49088b63e0ae5b3b1819b5dbb7343f9a3f85) updates jest in packages/suite. I believe that other package should now be pretty easy to update and we can get rid of outdated jest 26 now
- [253d268](https://github.com/trezor/trezor-suite/pull/8726/commits/253d268fa3c5a38965cf22602cd9f699c500ce19) - sets config to use some legacy behaviour without this, one assertion in polling middleware test fails. I don't really have time to spent on this on, so only acking @LukasRada 
[a39b491](https://github.com/trezor/trezor-suite/pull/8726/commits/a39b491926e6ebdd798836ef3ca3937ed6839247) - this one is funny. Looks at [this run](https://github.com/trezor/trezor-suite/actions/runs/5333688514/jobs/9664487787#step:19:4189) all the tests are marked "PASSED" but unit tests in suite package still exit with non-zero code. Interestingly, it never happens on my machine [(seems to be linux related)](https://github.com/jestjs/jest/issues/9324#issuecomment-1247210154). On my machine, I am seeing those error logs but tests exit with 0. I thought myself it might be a good idea to fix it actually and the fix I am proposing is not allowing multiple calls to db before it is really migrated but I'll post the fix in another PR. Here, as a workaround, I only initiate db in the start of the test.

part of https://github.com/trezor/trezor-suite/issues/6025