### PR TITLE
Remove tslib and ts-loader dependencies

### DIFF
--- a/packages/blockchain-link/webpack/dev.js
+++ b/packages/blockchain-link/webpack/dev.js
@@ -40,8 +40,10 @@ module.exports = {
                 test: /\.ts$/,
                 exclude: /node_modules/,
                 use: {
-                    loader: 'ts-loader',
-                    options: { configFile: 'tsconfig.lib.json' },
+                    loader: 'babel-loader',
+                    options: {
+                        presets: ['@babel/preset-typescript'],
+                    },
                 },
             },
         ],

--- a/packages/blockchain-link/webpack/workers.module.js
+++ b/packages/blockchain-link/webpack/workers.module.js
@@ -22,8 +22,10 @@ module.exports = {
                 exclude: /node_modules/,
                 use: [
                     {
-                        loader: 'ts-loader',
-                        options: { configFile: 'tsconfig.lib.json' },
+                        loader: 'babel-loader',
+                        options: {
+                            presets: ['@babel/preset-typescript'],
+                        },
                     },
                 ],
             },

--- a/packages/blockchain-link/webpack/workers.web.js
+++ b/packages/blockchain-link/webpack/workers.web.js
@@ -21,8 +21,10 @@ module.exports = {
                 exclude: /node_modules/,
                 use: [
                     {
-                        loader: 'ts-loader',
-                        options: { configFile: 'tsconfig.lib.json' },
+                        loader: 'babel-loader',
+                        options: {
+                            presets: ['@babel/preset-typescript'],
+                        },
                     },
                 ],
             },

--- a/packages/connect/e2e/karma.config.js
+++ b/packages/connect/e2e/karma.config.js
@@ -96,10 +96,9 @@ module.exports = config => {
                         exclude: /node_modules/,
                         use: [
                             {
-                                loader: 'ts-loader',
+                                loader: 'babel-loader',
                                 options: {
-                                    transpileOnly: true,
-                                    // configFile: '../../tsconfig.json',
+                                    presets: ['@babel/preset-typescript'],
                                 },
                             },
                         ],

--- a/packages/connect/package.json
+++ b/packages/connect/package.json
@@ -80,7 +80,6 @@
         "karma-sourcemap-loader": "^0.4.0",
         "karma-webpack": "^5.0.0",
         "rimraf": "^5.0.1",
-        "ts-loader": "^9.4.2",
         "ts-node": "^10.9.1",
         "tsx": "^3.12.7",
         "typescript": "4.9.5",

--- a/packages/connect/package.json
+++ b/packages/connect/package.json
@@ -63,8 +63,7 @@
         "cross-fetch": "^3.1.6",
         "events": "^3.3.0",
         "randombytes": "2.1.0",
-        "react-native": "0.71.8",
-        "tslib": "2.5.2"
+        "react-native": "0.71.8"
     },
     "devDependencies": {
         "@trezor/trezor-user-env-link": "workspace:*",

--- a/yarn.lock
+++ b/yarn.lock
@@ -7803,7 +7803,6 @@ __metadata:
     randombytes: 2.1.0
     react-native: 0.71.8
     rimraf: ^5.0.1
-    ts-loader: ^9.4.2
     ts-node: ^10.9.1
     tsx: ^3.12.7
     typescript: 4.9.5
@@ -15873,16 +15872,6 @@ __metadata:
     engine.io-parser: ~5.0.3
     ws: ~8.2.3
   checksum: 626d7a77f2f6d3e1f888c43932e2f34222201b6c0bc4bcbb0ead054cc170a1df3bf0d6f8b34432e68d7223346b7aa5ed34fbda1e706ef02b7801789465e34f40
-  languageName: node
-  linkType: hard
-
-"enhanced-resolve@npm:^5.0.0":
-  version: 5.15.0
-  resolution: "enhanced-resolve@npm:5.15.0"
-  dependencies:
-    graceful-fs: ^4.2.4
-    tapable: ^2.2.0
-  checksum: fbd8cdc9263be71cc737aa8a7d6c57b43d6aa38f6cc75dde6fcd3598a130cc465f979d2f4d01bb3bf475acb43817749c79f8eef9be048683602ca91ab52e4f11
   languageName: node
   linkType: hard
 
@@ -24768,7 +24757,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"micromatch@npm:^4.0.0, micromatch@npm:^4.0.2, micromatch@npm:^4.0.4, micromatch@npm:^4.0.5":
+"micromatch@npm:^4.0.2, micromatch@npm:^4.0.4, micromatch@npm:^4.0.5":
   version: 4.0.5
   resolution: "micromatch@npm:4.0.5"
   dependencies:
@@ -32594,21 +32583,6 @@ __metadata:
   bin:
     ts-jest: cli.js
   checksum: 6f65ad4fe67ab3f0fd4c7f9954acbee863af05b2b3f88dd0f490bbcdc58002960fac908b2cb9f009ec14da6fe13cb00a39e291260d6e555abe72448d1c0a017f
-  languageName: node
-  linkType: hard
-
-"ts-loader@npm:^9.4.2":
-  version: 9.4.3
-  resolution: "ts-loader@npm:9.4.3"
-  dependencies:
-    chalk: ^4.1.0
-    enhanced-resolve: ^5.0.0
-    micromatch: ^4.0.0
-    semver: ^7.3.4
-  peerDependencies:
-    typescript: "*"
-    webpack: ^5.0.0
-  checksum: 139ed53bc60717d0ca231cdffbdef7566b9feda11c72fecc697983113f1266ccca2e1cdf191f841a43afa6b87d6afe57a0caf4feecf02f30845aa7ac6f2411a4
   languageName: node
   linkType: hard
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -7805,7 +7805,6 @@ __metadata:
     rimraf: ^5.0.1
     ts-loader: ^9.4.2
     ts-node: ^10.9.1
-    tslib: 2.5.2
     tsx: ^3.12.7
     typescript: 4.9.5
     webpack: ^5.83.1
@@ -15877,7 +15876,17 @@ __metadata:
   languageName: node
   linkType: hard
 
-"enhanced-resolve@npm:^5.0.0, enhanced-resolve@npm:^5.12.0, enhanced-resolve@npm:^5.14.0":
+"enhanced-resolve@npm:^5.0.0":
+  version: 5.15.0
+  resolution: "enhanced-resolve@npm:5.15.0"
+  dependencies:
+    graceful-fs: ^4.2.4
+    tapable: ^2.2.0
+  checksum: fbd8cdc9263be71cc737aa8a7d6c57b43d6aa38f6cc75dde6fcd3598a130cc465f979d2f4d01bb3bf475acb43817749c79f8eef9be048683602ca91ab52e4f11
+  languageName: node
+  linkType: hard
+
+"enhanced-resolve@npm:^5.12.0, enhanced-resolve@npm:^5.14.0":
   version: 5.14.0
   resolution: "enhanced-resolve@npm:5.14.0"
   dependencies:
@@ -32589,8 +32598,8 @@ __metadata:
   linkType: hard
 
 "ts-loader@npm:^9.4.2":
-  version: 9.4.2
-  resolution: "ts-loader@npm:9.4.2"
+  version: 9.4.3
+  resolution: "ts-loader@npm:9.4.3"
   dependencies:
     chalk: ^4.1.0
     enhanced-resolve: ^5.0.0
@@ -32599,7 +32608,7 @@ __metadata:
   peerDependencies:
     typescript: "*"
     webpack: ^5.0.0
-  checksum: 6f306ee4c615c2a159fb177561e3fb86ca2cbd6c641e710d408a64b4978e1ff3f2c9733df07bff27d3f82efbfa7c287523d4306049510c7485ac2669a9c37eb0
+  checksum: 139ed53bc60717d0ca231cdffbdef7566b9feda11c72fecc697983113f1266ccca2e1cdf191f841a43afa6b87d6afe57a0caf4feecf02f30845aa7ac6f2411a4
   languageName: node
   linkType: hard
 
@@ -32681,17 +32690,17 @@ __metadata:
   languageName: node
   linkType: hard
 
-"tslib@npm:2.5.2, tslib@npm:^2.0.0, tslib@npm:^2.0.1, tslib@npm:^2.0.3, tslib@npm:^2.1.0, tslib@npm:^2.3.0, tslib@npm:^2.4.0, tslib@npm:^2.5.0":
-  version: 2.5.2
-  resolution: "tslib@npm:2.5.2"
-  checksum: 4d3c1e238b94127ed0e88aa0380db3c2ddae581dc0f4bae5a982345e9f50ee5eda90835b8bfba99b02df10a5734470be197158c36f9129ac49fdc14a6a9da222
-  languageName: node
-  linkType: hard
-
 "tslib@npm:^1.10.0, tslib@npm:^1.8.1, tslib@npm:^1.9.0, tslib@npm:^1.9.3":
   version: 1.14.1
   resolution: "tslib@npm:1.14.1"
   checksum: dbe628ef87f66691d5d2959b3e41b9ca0045c3ee3c7c7b906cc1e328b39f199bb1ad9e671c39025bd56122ac57dfbf7385a94843b1cc07c60a4db74795829acd
+  languageName: node
+  linkType: hard
+
+"tslib@npm:^2.0.0, tslib@npm:^2.0.1, tslib@npm:^2.0.3, tslib@npm:^2.1.0, tslib@npm:^2.3.0, tslib@npm:^2.4.0, tslib@npm:^2.5.0":
+  version: 2.5.2
+  resolution: "tslib@npm:2.5.2"
+  checksum: 4d3c1e238b94127ed0e88aa0380db3c2ddae581dc0f4bae5a982345e9f50ee5eda90835b8bfba99b02df10a5734470be197158c36f9129ac49fdc14a6a9da222
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Description

- `tslib` is not required, we have `tsc` from `typescript`
- we use `babel-loader` with plugin everywhere, so unify it with the rest of packages