### PR TITLE
feat(suite-native): biometrics authetication required after timeout

### DIFF
--- a/suite-native/biometrics/src/biometricsAtoms.ts
+++ b/suite-native/biometrics/src/biometricsAtoms.ts
@@ -8,6 +8,7 @@ const isBiometricsOptionEnabledAtom = atomWithUnecryptedStorage<boolean>(
 );
 
 const isUserAuthenticatedAtom = atom(false);
+const isBiometricsOverlayVisibleAtom = atom(false);
 
 export const useIsUserAuthenticated = () => {
     const [isUserAuthenticated, setIsUserAuthenticated] = useAtom(isUserAuthenticatedAtom);
@@ -26,12 +27,13 @@ export const useIsBiometricsEnabled = () => {
     };
 };
 
-export const isBiometricsOverlayVisibleAtom = atom(get => {
-    const isUserAuthenticated = get(isUserAuthenticatedAtom);
-    const isBiometricsOptionEnabled = get(isBiometricsOptionEnabledAtom);
+export const useIsBiometricsOverlayVisible = () => {
+    const [isBiometricsOverlayVisible, setIsBiometricsOverlayVisible] = useAtom(
+        isBiometricsOverlayVisibleAtom,
+    );
 
-    if (isBiometricsOptionEnabled) {
-        return !isUserAuthenticated;
-    }
-    return false;
-});
+    return {
+        isBiometricsOverlayVisible,
+        setIsBiometricsOverlayVisible,
+    };
+};

--- a/suite-native/biometrics/src/components/AuthenticatorProvider.tsx
+++ b/suite-native/biometrics/src/components/AuthenticatorProvider.tsx
@@ -1,9 +1,7 @@
 import React, { ReactNode } from 'react';
 
-import { useAtomValue } from 'jotai';
-
 import { useBiometrics } from '../useBiometrics';
-import { isBiometricsOverlayVisibleAtom } from '../biometricsAtoms';
+import { useIsBiometricsOverlayVisible } from '../biometricsAtoms';
 import { BiometricOverlay } from './BiometricOverlay';
 
 type AuthenticatorProviderProps = {
@@ -12,7 +10,7 @@ type AuthenticatorProviderProps = {
 
 export const AuthenticatorProvider = ({ children }: AuthenticatorProviderProps) => {
     useBiometrics();
-    const isBiometricsOverlayVisible = useAtomValue(isBiometricsOverlayVisibleAtom);
+    const { isBiometricsOverlayVisible } = useIsBiometricsOverlayVisible();
 
     return (
         <>

--- a/suite-native/module-settings/src/screens/SettingsPrivacyAndSecurity.tsx
+++ b/suite-native/module-settings/src/screens/SettingsPrivacyAndSecurity.tsx
@@ -123,8 +123,8 @@ const BiometricsSwitchRow = () => {
             setIsBiometricsOptionEnabled(false);
             setIsUserAuthenticated(false);
         } else {
-            setIsBiometricsOptionEnabled(true);
             setIsUserAuthenticated(true);
+            setIsBiometricsOptionEnabled(true);
         }
     };
 


### PR DESCRIPTION
The biometrics authentication is asked only if the 30s timeout already run out. If the user returns to the app sooner than 30s after he left, authentication is not needed.