### PR TITLE
feat(suite-desktop): strongly typed ipcMain emitter

### DIFF
--- a/packages/suite-desktop/src/typed-electron.ts
+++ b/packages/suite-desktop/src/typed-electron.ts
@@ -1,6 +1,14 @@
 import * as electron from 'electron';
 
+import { TypedEmitter } from '@trezor/utils/lib/typedEventEmitter';
 import * as desktopApi from '@trezor/suite-desktop-api';
+import { InterceptedEvent } from '@trezor/request-manager';
+
+// define events internally sent between src/modules
+interface MainThreadMessages {
+    'module/request-interceptor': InterceptedEvent;
+}
+export const mainThreadEmitter = new TypedEmitter<MainThreadMessages>();
 
 export type StrictIpcMain = desktopApi.StrictIpcMain<
     Omit<Electron.IpcMain, 'handle' | 'handleOnce' | 'removeHandler'>,


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

I wanted to continue in https://github.com/trezor/trezor-suite/pull/8731 but it's already merged :)

- adding possibility to send messages between electron main process modules (main <-> main)
- share requestInterceptorEventHandler between main and background thread
