### PR TITLE
Change Note text element type to allow nesting divs

### DIFF
--- a/packages/components/src/components/Note/Note.tsx
+++ b/packages/components/src/components/Note/Note.tsx
@@ -13,7 +13,7 @@ const InfoIcon = styled(Icon)`
     margin-top: 1px;
 `;
 
-const P = styled.p<{ $color?: string }>`
+const Text = styled.div<{ $color?: string }>`
     color: ${({ $color }) => $color};
     font-size: ${FONT_SIZE.SMALL};
     font-weight: ${FONT_WEIGHT.MEDIUM};
@@ -33,7 +33,7 @@ export const Note = ({ children, className, color }: NoteProps) => {
     return (
         <Row className={className}>
             <InfoIcon icon="INFO" size={14} color={noteColor} />
-            <P $color={noteColor}>{children}</P>
+            <Text $color={noteColor}>{children}</Text>
         </Row>
     );
 };


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->
Just a quick change from `p` to `div` to get rid of console warning about invalid DOM nesting in `P2pInfo` component where `Tooltip` (`div`) component is nested inside `Note`.

## Screenshots:
![Screenshot 2023-06-20 at 11 32 06](https://github.com/trezor/trezor-suite/assets/42465546/b67f9da8-1497-4591-8390-a2a2ef0b1bb6)

**QA**: No UI change, only markup change to remove console warning from Trade/Buy P2P page.
