### PR TITLE
chore(github): workaround nx cache issue with build:libs

### DIFF
--- a/.github/workflows/validation.yml
+++ b/.github/workflows/validation.yml
@@ -42,7 +42,7 @@ jobs:
         run: yarn workspace @suite-common/message-system validate-config
       - run: git status
       - name: build libs
-        run: yarn nx:build:libs
+        run: yarn build:libs
       - run: git status
       - name: type check
         run: yarn nx:type-check


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

`build:libs` skipping nx cache and run build:lib for ALL packages, not only affected - so it's much slower, but should be most reliable.

It should unblock all approved PRs and then we can revert it. 