### PR TITLE
fix(suite-native): biometrics overlay on first launch

### DIFF
--- a/suite-native/biometrics/src/biometricsAtoms.ts
+++ b/suite-native/biometrics/src/biometricsAtoms.ts
@@ -8,7 +8,7 @@ const isBiometricsOptionEnabledAtom = atomWithUnecryptedStorage<boolean>(
 );
 
 const isUserAuthenticatedAtom = atom(false);
-const isBiometricsOverlayVisibleAtom = atom(false);
+const isBiometricsOverlayVisibleAtom = atom(true);
 
 export const useIsUserAuthenticated = () => {
     const [isUserAuthenticated, setIsUserAuthenticated] = useAtom(isUserAuthenticatedAtom);
@@ -29,13 +29,17 @@ export const useIsBiometricsEnabled = () => {
 
 export const useIsBiometricsOverlayVisible = () => {
     const isBiometricsOptionEnabled = useAtomValue(isBiometricsOptionEnabledAtom);
-    const [isBiometricsOverlayVisible, setBiometricsOverlay] = useAtom(
+    const [isBiometricsOverlayVisibleAtomValue, setBiometricsOverlayVisibleAtomValue] = useAtom(
         isBiometricsOverlayVisibleAtom,
     );
 
+    // If biometrics option is disabled, always return false.
+    const isBiometricsOverlayVisible =
+        isBiometricsOptionEnabled && isBiometricsOverlayVisibleAtomValue;
+
     const setIsBiometricsOverlayVisible = (value: boolean) => {
         // Change value only if biometrics options is turned on to prevent showing overlay without enabled biometrics.
-        if (isBiometricsOptionEnabled) setBiometricsOverlay(value);
+        if (isBiometricsOptionEnabled) setBiometricsOverlayVisibleAtomValue(value);
     };
 
     return {


### PR DESCRIPTION
On first launch of the app with enabled biometrics, hide content of the screen with overlay.