### PR TITLE
chore(connect): change timestamp to use now() for performance

### DIFF
--- a/packages/connect/src/utils/debug.ts
+++ b/packages/connect/src/utils/debug.ts
@@ -41,7 +41,7 @@ class Log {
             level,
             prefix,
             message: args,
-            timestamp: new Date().getTime(),
+            timestamp: Date.now(),
         });
         if (this.messages.length > MAX_ENTRIES) {
             this.messages.shift();


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Just change timestamp to use `Date.now()` for performance.
