### PR TITLE
Fix `getSynchronize` util

### DIFF
--- a/packages/utils/src/getSynchronize.ts
+++ b/packages/utils/src/getSynchronize.ts
@@ -14,12 +14,15 @@ export const getSynchronize = () => {
     let lock: Promise<any> | undefined;
 
     return <T>(action: () => T | Promise<T>): Promise<T> => {
-        lock = (lock ?? Promise.resolve())
+        const newLock = (lock ?? Promise.resolve())
             .catch(() => {})
             .then(action)
             .finally(() => {
-                lock = undefined;
+                if (lock === newLock) {
+                    lock = undefined;
+                }
             });
+        lock = newLock;
         return lock;
     };
 };

--- a/packages/utils/tests/getSynchronize.test.ts
+++ b/packages/utils/tests/getSynchronize.test.ts
@@ -52,4 +52,14 @@ describe('getSynchronize', () => {
             synchronize(() => sequence(['c', 7])),
         ]);
     });
+
+    it('nested', done => {
+        synchronize(() =>
+            sequence(['a', 3]).then(() => {
+                // 'c' registers after 'a' ended and while 'b' is running
+                delay(2).then(() => synchronize(() => sequence(['c', 3])));
+            }),
+        );
+        synchronize(() => sequence(['b', 8]).then(done));
+    });
 });


### PR DESCRIPTION
## Description

When new action was registered to `synchronize` while some of the previous ones already ended, undesirable concurrency emerged. Now the currently running promise is cleaned only by the last registered action, which should resolve this issue.
