### PR TITLE
fix(suite-desktop): move mainThreadEmitter to module Dependencies

### DIFF
--- a/packages/suite-desktop/src/app.ts
+++ b/packages/suite-desktop/src/app.ts
@@ -13,7 +13,7 @@ import { MIN_HEIGHT, MIN_WIDTH } from './libs/screen';
 import { getBuildInfo, getComputerInfo } from './libs/info';
 import { restartApp } from './libs/app-utils';
 import { clearAppCache, initUserData } from './libs/user-data';
-import { initModules } from './modules';
+import { initModules, mainThreadEmitter } from './modules';
 import { init as initTorModule } from './modules/tor';
 import { createInterceptor } from './libs/request-interceptor';
 import { hangDetect } from './hang-detect';
@@ -145,6 +145,7 @@ const init = async () => {
         mainWindow,
         store,
         interceptor,
+        mainThreadEmitter,
     });
 
     // create handler for handshake/load-modules
@@ -168,6 +169,7 @@ const init = async () => {
         mainWindow,
         store,
         interceptor,
+        mainThreadEmitter,
     });
 
     ipcMain.handle('handshake/load-tor-module', () => loadTorModule());

--- a/packages/suite-desktop/src/modules/coinjoin.ts
+++ b/packages/suite-desktop/src/modules/coinjoin.ts
@@ -15,7 +15,6 @@ import { InterceptedEvent } from '@trezor/request-manager';
 import { CoinjoinProcess } from '../libs/processes/CoinjoinProcess';
 import { PowerSaveBlocker } from '../libs/power-save-blocker';
 import { ThreadProxy } from '../libs/thread-proxy';
-import { mainThreadEmitter } from '../typed-electron';
 
 import type { Module } from './index';
 
@@ -23,7 +22,7 @@ const SERVICE_NAME = '@trezor/coinjoin';
 const CLIENT_CHANNEL = 'CoinjoinClient';
 const BACKEND_CHANNEL = 'CoinjoinBackend';
 
-export const init: Module = ({ mainWindow, store }) => {
+export const init: Module = ({ mainWindow, store, mainThreadEmitter }) => {
     const { logger } = global;
 
     const backends: ThreadProxy<CoinjoinBackend>[] = [];

--- a/packages/suite-desktop/src/modules/index.ts
+++ b/packages/suite-desktop/src/modules/index.ts
@@ -3,6 +3,8 @@
 import path from 'path';
 
 import { isNotUndefined } from '@trezor/utils';
+import { TypedEmitter } from '@trezor/utils/lib/typedEventEmitter';
+import { InterceptedEvent } from '@trezor/request-manager';
 import { isDevEnv } from '@suite-common/suite-utils';
 import type { HandshakeClient } from '@trezor/suite-desktop-api';
 
@@ -40,10 +42,18 @@ const MODULES = [
     ...(isDevEnv ? [] : ['csp', 'file-protocol']),
 ];
 
+// define events internally sent between modules
+interface MainThreadMessages {
+    'module/request-interceptor': InterceptedEvent;
+    'module/reset-tor-circuits': Extract<InterceptedEvent, { type: 'CIRCUIT_MISBEHAVING' }>;
+}
+export const mainThreadEmitter = new TypedEmitter<MainThreadMessages>();
+
 export type Dependencies = {
     mainWindow: StrictBrowserWindow;
     store: Store;
     interceptor: RequestInterceptor;
+    mainThreadEmitter: typeof mainThreadEmitter;
 };
 
 type ModuleLoad = (payload: HandshakeClient) => any | Promise<any>;

--- a/packages/suite-desktop/src/modules/request-interceptor.ts
+++ b/packages/suite-desktop/src/modules/request-interceptor.ts
@@ -11,11 +11,9 @@ import { createInterceptor, InterceptedEvent } from '@trezor/request-manager';
 import { isDevEnv } from '@suite-common/suite-utils';
 import { TorStatus } from '@trezor/suite-desktop-api';
 
-import { mainThreadEmitter } from '../typed-electron';
-
 import { Module } from './index';
 
-export const init: Module = ({ mainWindow, store }) => {
+export const init: Module = ({ mainWindow, store, mainThreadEmitter }) => {
     const { logger } = global;
 
     const requestInterceptorEventHandler = (event: InterceptedEvent) => {

--- a/packages/suite-desktop/src/typed-electron.ts
+++ b/packages/suite-desktop/src/typed-electron.ts
@@ -1,14 +1,6 @@
 import * as electron from 'electron';
 
-import { TypedEmitter } from '@trezor/utils/lib/typedEventEmitter';
 import * as desktopApi from '@trezor/suite-desktop-api';
-import { InterceptedEvent } from '@trezor/request-manager';
-
-// define events internally sent between src/modules
-interface MainThreadMessages {
-    'module/request-interceptor': InterceptedEvent;
-}
-export const mainThreadEmitter = new TypedEmitter<MainThreadMessages>();
 
 export type StrictIpcMain = desktopApi.StrictIpcMain<
     Omit<Electron.IpcMain, 'handle' | 'handleOnce' | 'removeHandler'>,


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

cherry-picked from https://github.com/trezor/trezor-suite/pull/8661 fix of https://github.com/trezor/trezor-suite/pull/8733

`mainThreadEmitter` was initialized in typed-electron module.
Since each suite-desktop module is dynamically loaded it means that each module holds different reference of mainThreadEmitter.

So i've moved it to common module `Dependencies`