### PR TITLE
CJ discovery reentrance fix

### DIFF
--- a/packages/suite-desktop/src/modules/coinjoin.ts
+++ b/packages/suite-desktop/src/modules/coinjoin.ts
@@ -206,7 +206,7 @@ export const init: Module = ({ mainWindow, store }) => {
         mainWindow.webContents.on('did-start-loading', () => {
             dispose();
         });
-        ipcMain.on('app/restart', () => {
+        ipcMain.once('app/restart', () => {
             dispose();
         });
     };


### PR DESCRIPTION
## Description

When user created CJ account and immediately opened device selection modal, CJ discovery was started twice in parallel (once as a continuation of account creation and once as a result of `@discovery/start` event fired by device modal).

As a solution, account data are now freshly reobtained in `fetchAndUpdateAccount` so there's no gap between `account.syncing` check and `startCoinjoinAccountSync` action.

## Related Issue

Resolve #8756
Resolve also some instances of incorrectly scanned CJ account