### PR TITLE
fix(suite-desktop): show stack trace for nodejs warnings

### DIFF
--- a/packages/suite-desktop/src/modules/event-logging/process.ts
+++ b/packages/suite-desktop/src/modules/event-logging/process.ts
@@ -12,4 +12,13 @@ export const init: Module = () => {
             logger.warn('rejection', `Unhandled Rejection: ${e?.toString()}`);
         }
     });
+
+    // Workaround for misleading message: Use `electron --trace-warnings ...` to show where the warning was created
+    // but actually this flag is not working...
+    // https://nodejs.org/api/process.html#process_event_warning
+    process.on('warning', error => {
+        if (error) {
+            logger.warn('warning', `Stack: ${error.stack}`);
+        }
+    });
 };


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Fix for missing stack trace of nodejs warnings in electron main process.
Message printed in console is misleading:
```
Use `electron --trace-warnings ...` to show where the warning was created
```

adding this flag to package.json script didnt work `yarn electron --trace-warnings .`
is there any other way how to add flags to electron process? idk...


However this workaround prints error stracktrace using the logger:

```
(node:291265) MaxListenersExceededWarning: Possible EventTarget memory leak detected. 11 abort listeners added to [AbortSignal]. Use events.setMaxListeners() to increase limit
(Use `electron --trace-warnings ...` to show where the warning was created)
2023-06-22T12:41:54.651Z - WARN(warning): Stack: MaxListenersExceededWarning: Possible EventTarget memory leak detected. 11 abort listeners added to [AbortSignal]. Use events.setMaxListeners() to increase limit
    at [kNewListener] (node:internal/event_target:514:17)
    at [kNewListener] (node:internal/abort_controller:183:24)
    at EventTarget.addEventListener (node:internal/event_target:623:23)
    at request (/Workspace/suite/packages/coinjoin/lib/client/coordinatorRequest.js:43:21)
    at /Workspace/suite/packages/utils/lib/scheduleAction.js:62:53
    at new Promise (<anonymous>)
    at /Workspace/suite/packages/utils/lib/scheduleAction.js:62:22
    at Generator.next (<anonymous>)
    at /Workspace/suite/packages/utils/lib/scheduleAction.js:8:71
    at new Promise (<anonymous>)
```