### PR TITLE
Feat(connect-popup): success screen (on debug mode)

### DIFF
--- a/packages/connect-popup/src/index.tsx
+++ b/packages/connect-popup/src/index.tsx
@@ -51,11 +51,14 @@ const handleMessage = (
 ) => {
     const { data } = event;
     if (!data) return;
-
     // This is message from the window.opener
     if (data.type === POPUP.INIT) {
         init(escapeHtml(data.payload)); // eslint-disable-line @typescript-eslint/no-use-before-define
         return;
+    }
+
+    if (data.type === RESPONSE_EVENT && data.success) {
+        reactEventBus.dispatch({ type: 'success' });
     }
 
     if (

--- a/packages/connect-ui/src/index.tsx
+++ b/packages/connect-ui/src/index.tsx
@@ -23,6 +23,7 @@ import {
     BridgeUpdateNotification,
     SuspiciousOriginNotification,
 } from './components/Notification';
+import { SuccessView } from './views/Success';
 
 const Layout = styled.div`
     display: flex;
@@ -86,6 +87,9 @@ export const ConnectUI = ({ postMessage, clearLegacyView }: ConnectUIProps) => {
                     break;
                 case UI.REQUEST_PASSPHRASE:
                     component = <Passphrase {...messages[0]} postMessage={postMessage} />;
+                    break;
+                case 'success':
+                    component = <SuccessView />;
                     break;
                 case 'error':
                     component = <ErrorView {...messages[0]} />;

--- a/packages/connect-ui/src/utils/eventBus.ts
+++ b/packages/connect-ui/src/utils/eventBus.ts
@@ -3,12 +3,14 @@ import { PopupHandshake, UI_REQUEST, Device } from '@trezor/connect';
 import { TransportEventProps } from '../views/Transport';
 import { PassphraseEventProps } from '../views/Passphrase';
 import { ErrorViewProps } from '../views/Error';
+import { SuccessViewProps } from '../views/Success';
 
 export type ConnectUIEventProps =
     // connect-core events
     | TransportEventProps
     | PassphraseEventProps
     | ErrorViewProps
+    | SuccessViewProps
     | PopupHandshake
     | { type: typeof UI_REQUEST.DEVICE_NEEDS_BACKUP; device: Device }
     | { type: typeof UI_REQUEST.FIRMWARE_OUTDATED; device: Device }

--- a/packages/connect-ui/src/views/Success.tsx
+++ b/packages/connect-ui/src/views/Success.tsx
@@ -1,0 +1,51 @@
+import React from 'react';
+
+import styled from 'styled-components';
+
+import { Button, colors, variables } from '@trezor/components';
+
+export interface SuccessViewProps {
+    type: 'success';
+}
+
+const View = styled.div`
+    display: flex;
+    flex-direction: column;
+    justify-content: center;
+    align-items: center;
+    min-height: 100vh;
+`;
+
+const InnerWrapper = styled.div`
+    display: flex;
+    flex-direction: column;
+    justify-content: center;
+`;
+
+const H = styled.h1`
+    color: ${colors.TYPE_RED};
+    font-size: 28px;
+    font-weight: ${variables.FONT_WEIGHT.DEMI_BOLD};
+`;
+
+const Text = styled.div`
+    color: ${colors.TYPE_LIGHT_GREY};
+    font-size: ${variables.FONT_SIZE.NORMAL};
+`;
+
+export const SuccessView = () => (
+    <View data-test="@connect-ui/success">
+        <InnerWrapper>
+            <H>Success</H>
+            <Text>Your request to Trezor device has been successful.</Text>
+
+            <Button
+                data-test="@connect-ui/success-close-button"
+                variant="primary"
+                onClick={() => window.close()}
+            >
+                Close
+            </Button>
+        </InnerWrapper>
+    </View>
+);


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Provide a success screen in popup when the action with device is successful when in debug mode for now it does not close. 

## Related Issue

Related to https://github.com/trezor/trezor-suite/issues/8739

## Screenshots:

Probably improbably but it is a success screen :heavy_check_mark: Looking forward for feedback for copy and designs.

![image](https://github.com/trezor/trezor-suite/assets/5362163/7b633cce-374e-406c-8900-8b244fc7dbc2)

