### PR TITLE
feat(suite): add the getMetadataFilesList method to metadata providers

### DIFF
--- a/packages/suite-desktop-api/src/api.ts
+++ b/packages/suite-desktop-api/src/api.ts
@@ -71,6 +71,7 @@ export interface InvokeChannels {
     'handshake/load-tor-module': () => HandshakeTorModule;
     'metadata/read': (options: { file: string }) => InvokeResult<string>;
     'metadata/write': (options: { file: string; content: string }) => InvokeResult;
+    'metadata/get-files': () => InvokeResult<string[]>;
     'server/request-address': (route: string) => string | undefined;
     'tor/toggle': (shouldEnableTor: boolean) => InvokeResult;
     'bridge/toggle': () => InvokeResult;
@@ -109,6 +110,7 @@ export interface DesktopApi {
     // Metadata
     metadataWrite: DesktopApiInvoke<'metadata/write'>;
     metadataRead: DesktopApiInvoke<'metadata/read'>;
+    metadataGetFiles: DesktopApiInvoke<'metadata/get-files'>;
     // HttpReceiver
     getHttpReceiverAddress: DesktopApiInvoke<'server/request-address'>;
     // Tor

--- a/packages/suite-desktop-api/src/factory.ts
+++ b/packages/suite-desktop-api/src/factory.ts
@@ -78,6 +78,7 @@ export const factory = <R extends StrictIpcRenderer<any>>(ipcRenderer?: R): Desk
             }
             return Promise.resolve({ success: false, error: 'invalid params' });
         },
+        metadataGetFiles: () => ipcRenderer.invoke('metadata/get-files'),
 
         // HttpReceiver
         getHttpReceiverAddress: route => {

--- a/packages/suite-desktop/src/libs/user-data.ts
+++ b/packages/suite-desktop/src/libs/user-data.ts
@@ -73,6 +73,28 @@ export const read = async (directory: string, name: string): Promise<InvokeResul
     }
 };
 
+export const readDir = async (directory: string): Promise<InvokeResult<string[]>> => {
+    const dir = path.join(app.getPath('userData'), directory);
+
+    try {
+        await fs.promises.access(dir, fs.constants.R_OK);
+    } catch {
+        await fs.promises.mkdir(dir);
+
+        return { success: true, payload: [] };
+    }
+
+    try {
+        const dirFiles = await fs.promises.readdir(dir);
+        const filteredDirFiles = dirFiles.filter(file => !file.startsWith('.'));
+
+        return { success: true, payload: filteredDirFiles };
+    } catch (error) {
+        global.logger.error('user-data', `Get folder file names failed: ${error.message}`);
+        return { success: false, error: error.message, code: error.code };
+    }
+};
+
 export const clear = async (): Promise<InvokeResult> => {
     const dir = path.normalize(app.getPath('userData'));
     try {

--- a/packages/suite-desktop/src/modules/metadata.ts
+++ b/packages/suite-desktop/src/modules/metadata.ts
@@ -2,7 +2,7 @@
  * Metadata feature (save/load metadata locally)
  */
 import { ipcMain } from '../typed-electron';
-import { save, read } from '../libs/user-data';
+import { save, read, readDir } from '../libs/user-data';
 
 import type { Module } from './index';
 
@@ -20,6 +20,12 @@ export const init: Module = () => {
     ipcMain.handle('metadata/read', async (_, message) => {
         logger.info('metadata', `Reading metadata from ${DATA_DIR}/${message.file}`);
         const resp = await read(DATA_DIR, message.file);
+        return resp;
+    });
+
+    ipcMain.handle('metadata/get-files', async () => {
+        logger.info('metadata', `Retrieving metadata file names from ${DATA_DIR}`);
+        const resp = await readDir(DATA_DIR);
         return resp;
     });
 };

--- a/packages/suite/src/services/suite/metadata/DropboxProvider.ts
+++ b/packages/suite/src/services/suite/metadata/DropboxProvider.ts
@@ -172,6 +172,26 @@ class DropboxProvider extends AbstractMetadataProvider {
         }
     }
 
+    async getFilesList() {
+        try {
+            const response = await this.client.filesListFolder({ path: '' });
+
+            if (response.result) {
+                const formattedList = response.result.entries.map(({ name }) => name);
+
+                return this.ok(formattedList);
+            }
+
+            return this.ok(undefined);
+        } catch (error) {
+            if (error?.error?.code === 404) {
+                return this.ok(undefined);
+            }
+
+            return this.handleProviderError(error);
+        }
+    }
+
     async getProviderDetails() {
         const token = this.auth.getRefreshToken();
         if (!token) return this.error('AUTH_ERROR', 'token is missing');

--- a/packages/suite/src/services/suite/metadata/FileSystemProvider.ts
+++ b/packages/suite/src/services/suite/metadata/FileSystemProvider.ts
@@ -47,6 +47,16 @@ class FileSystemProvider extends AbstractMetadataProvider {
         return this.ok(undefined);
     }
 
+    async getFilesList() {
+        const response = await desktopApi.metadataGetFiles();
+
+        if (!response.success) {
+            return this.error('PROVIDER_ERROR', response.error);
+        }
+
+        return this.ok(response.payload);
+    }
+
     isConnected() {
         return true;
     }

--- a/packages/suite/src/services/suite/metadata/GoogleProvider.ts
+++ b/packages/suite/src/services/suite/metadata/GoogleProvider.ts
@@ -96,6 +96,24 @@ class GoogleProvider extends AbstractMetadataProvider {
         }
     }
 
+    async getFilesList() {
+        try {
+            const response = await GoogleClient.list({
+                query: { spaces: 'appDataFolder' },
+            });
+
+            if (response) {
+                const formattedList = response.files.map(({ name }) => name);
+
+                return this.ok(formattedList);
+            }
+
+            return this.ok(undefined);
+        } catch (error) {
+            return this.handleProviderError(error);
+        }
+    }
+
     async getProviderDetails() {
         try {
             const response = await GoogleClient.getTokenInfo();

--- a/suite-common/metadata-types/src/metadataTypes.ts
+++ b/suite-common/metadata-types/src/metadataTypes.ts
@@ -115,6 +115,10 @@ export abstract class AbstractMetadataProvider {
      * Upload metadata content in cloud provider for given filename and content
      */
     abstract setFileContent(file: string, content: any): Result<void>;
+    /**
+     * Get a list of metadata file names if any
+     */
+    abstract getFilesList(): Result<string[] | undefined>;
 
     ok(): Success<void>;
     ok<T>(payload: T): Success<T>;


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

* add a method for fetching metadata filenames to providers
* determine what encryption to use based on the file name. It should not affect anything for now since there is no way to create v2 files, it's a preparation for the follow-up changes

## Related Issue

https://github.com/trezor/trezor-suite/issues/6304

