### PR TITLE
Fix/cancel modals

### DIFF
--- a/packages/suite/src/components/suite/modals/ReviewTransaction/index.tsx
+++ b/packages/suite/src/components/suite/modals/ReviewTransaction/index.tsx
@@ -9,7 +9,7 @@ import OutputList from './components/OutputList';
 import Summary from './components/Summary';
 import { isCardanoTx } from 'src/utils/wallet/cardanoUtils';
 import { DeviceModel, getDeviceModel } from '@trezor/device-utils';
-import { selectDevice } from 'src/reducers/suite/suiteReducer';
+import { selectDevice, selectIsActionAbortable } from 'src/reducers/suite/suiteReducer';
 import { constructOutputs } from './constructOutputs';
 
 const StyledModal = styled(Modal)`
@@ -35,6 +35,7 @@ export const ReviewTransaction = ({ decision }: ReviewTransactionProps) => {
     const send = useSelector(state => state.wallet.send);
     const fees = useSelector(state => state.wallet.fees);
     const device = useSelector(selectDevice);
+    const isActionAbortable = useSelector(selectIsActionAbortable);
 
     const { cancelSignTx } = useActions({
         cancelSignTx: sendFormActions.cancelSignTx,
@@ -99,6 +100,14 @@ export const ReviewTransaction = ({ decision }: ReviewTransactionProps) => {
 
     const buttonRequestsCount = isCardano ? buttonRequests.length - 1 : buttonRequests.length;
 
+    const onCancel =
+        isActionAbortable || signedTx
+            ? () => {
+                  cancelSignTx();
+                  decision?.resolve(false);
+              }
+            : undefined;
+
     return (
         <StyledModal
             modalPrompt={
@@ -108,10 +117,7 @@ export const ReviewTransaction = ({ decision }: ReviewTransactionProps) => {
                     activeStep={signedTx ? outputs.length + 2 : buttonRequestsCount}
                     deviceModel={deviceModel}
                     successText={<Translation id="TR_CONFIRMED_TX" />}
-                    onCancel={() => {
-                        cancelSignTx();
-                        decision?.resolve(false);
-                    }}
+                    onCancel={onCancel}
                 />
             }
         >

--- a/packages/suite/src/components/suite/modals/confirm/ConfirmValueOnDevice.tsx
+++ b/packages/suite/src/components/suite/modals/confirm/ConfirmValueOnDevice.tsx
@@ -3,13 +3,14 @@ import styled from 'styled-components';
 
 import { Translation, Modal } from 'src/components/suite';
 import { notificationsActions } from '@suite-common/toast-notifications';
-import { useDispatch } from 'src/hooks/suite';
+import { useDispatch, useSelector } from 'src/hooks/suite';
 import { QrCode, QRCODE_PADDING, QRCODE_SIZE } from 'src/components/suite/QrCode';
 import { TrezorDevice } from 'src/types/suite/index';
 import { Button, ConfirmOnDevice, ModalProps, variables } from '@trezor/components';
 import { getDeviceModel } from '@trezor/device-utils';
 import { copyToClipboard } from '@trezor/dom-utils';
 import DeviceDisconnected from './Address/components/DeviceDisconnected';
+import { selectIsActionAbortable } from 'src/reducers/suite/suiteReducer';
 
 const Wrapper = styled.div`
     display: flex;
@@ -72,6 +73,8 @@ export const ConfirmValueOnDevice = ({
 
     const showCopyButton = isConfirmed || !device.connected;
 
+    const isActionAbortable = useSelector(selectIsActionAbortable) || showCopyButton;
+
     const copy = () => {
         const result = copyToClipboard(value);
         if (typeof result !== 'string') {
@@ -81,7 +84,7 @@ export const ConfirmValueOnDevice = ({
 
     return (
         <StyledModal
-            isCancelable
+            isCancelable={isActionAbortable}
             heading={heading}
             modalPrompt={
                 device.connected ? (


### PR DESCRIPTION
## Description

Old bridge issue
- in case of receive / xpub cancel, the `X` did nothing
- in case of review modal, it froze the app until user cancelled it on device

## Related Issue

Found during `react-hook-form` update PR
