### PR TITLE
fix(suite): hide token balances in discreet mode

### DIFF
--- a/packages/suite/src/views/wallet/send/components/Outputs/components/Amount/index.tsx
+++ b/packages/suite/src/views/wallet/send/components/Outputs/components/Amount/index.tsx
@@ -3,7 +3,7 @@ import BigNumber from 'bignumber.js';
 import styled from 'styled-components';
 
 import { Icon, Switch, Warning, variables, useTheme } from '@trezor/components';
-import { FiatValue, Translation, NumberInput } from 'src/components/suite';
+import { FiatValue, Translation, NumberInput, HiddenPlaceholder } from 'src/components/suite';
 import { InputError } from 'src/components/wallet';
 import {
     amountToSatoshi,
@@ -141,7 +141,11 @@ export const Amount = ({ output, outputId }: Props) => {
     const token = findToken(tokens, tokenValue);
 
     const tokenBalance = token ? (
-        <TokenBalanceValue>{`${token.balance} ${token.symbol!.toUpperCase()}`}</TokenBalanceValue>
+        <HiddenPlaceholder>
+            <TokenBalanceValue>{`${
+                token.balance
+            } ${token.symbol!.toUpperCase()}`}</TokenBalanceValue>
+        </HiddenPlaceholder>
     ) : undefined;
 
     let decimals: number;


### PR DESCRIPTION
Added HiddenPlaceholder as a wrapper around token balance

## Description

When discreet mode is toggled token balance is blurred.

## Related Issue

Resolve #8429 

## Screenshots:
<img width="1442" alt="Screenshot 2023-06-24 at 4 22 34 PM" src="https://github.com/trezor/trezor-suite/assets/66002635/63d80f9a-cf32-4139-8976-eefb02c44d21">
