### PR TITLE
fix(suite): exclude unconfirmed transactions from exports

### DIFF
--- a/suite-common/wallet-core/src/transactions/transactionsThunks.ts
+++ b/suite-common/wallet-core/src/transactions/transactionsThunks.ts
@@ -232,13 +232,15 @@ export const exportTransactionsThunk = createThunk(
             account.key,
             allTransactions,
             // add metadata directly to transactions
-        ).map(transaction => ({
-            ...transaction,
-            targets: transaction.targets.map(target => ({
-                ...target,
-                metadataLabel: account.metadata?.outputLabels?.[transaction.txid]?.[target.n],
-            })),
-        }));
+        )
+            .filter(transaction => transaction.blockHeight !== -1)
+            .map(transaction => ({
+                ...transaction,
+                targets: transaction.targets.map(target => ({
+                    ...target,
+                    metadataLabel: account.metadata?.outputLabels?.[transaction.txid]?.[target.n],
+                })),
+            }));
 
         // Prepare data in right format
         const data = await formatData({


### PR DESCRIPTION
Unconfirmed transaction (or transactions with blockHeigh equals to -1) are not visible inside of exports.

## Description

Added filter so no unconfirmed transactions are inside of exports.

## Related Issue

Resolve #8496 
