### PR TITLE
fix(suite): account XPUB disconnected to connected Trezor

### DIFF
--- a/packages/suite-data/files/translations/cs.json
+++ b/packages/suite-data/files/translations/cs.json
@@ -254,6 +254,7 @@
   "TR_ADDRESS_FORMAT": "Správný formát adresy",
   "TR_ADDRESS_MODAL_CLIPBOARD": "Kopírovat adresu",
   "TR_ADDRESS_MODAL_TITLE": "{networkName} adresa pro příjem",
+  "TR_ADDRESS_PHISHING_WARNING": "Abyste zabránili phishingovým útokům, měli byste ověřit adresu v zařízení Trezor. {claim}",
   "TR_ADD_ACCOUNT": "Přidat účet",
   "TR_ADD_HIDDEN_WALLET": "Přidat skrytou peněženku",
   "TR_ADD_NEW_BLOCKBOOK_BACKEND": "Přidat nový",

--- a/packages/suite/src/components/suite/ModalSwitcher/UserContextModal.tsx
+++ b/packages/suite/src/components/suite/ModalSwitcher/UserContextModal.tsx
@@ -78,9 +78,15 @@ export const UserContextModal = ({
                 />
             );
         case 'address':
-            return <ConfirmAddress {...payload} onCancel={onCancel} />;
+            return (
+                <ConfirmAddress
+                    {...payload}
+                    verify={() => showAddress(payload.addressPath, payload.value)}
+                    onCancel={onCancel}
+                />
+            );
         case 'xpub':
-            return <ConfirmXpub {...payload} onCancel={onCancel} />;
+            return <ConfirmXpub {...payload} verify={showXpub} onCancel={onCancel} />;
         case 'device-background-gallery':
             return <BackgroundGallery onCancel={onCancel} />;
         case 'wipe-device':

--- a/packages/suite/src/components/suite/modals/confirm/ConfirmAddress.tsx
+++ b/packages/suite/src/components/suite/modals/confirm/ConfirmAddress.tsx
@@ -5,7 +5,7 @@ import { NetworkSymbol } from 'src/types/wallet';
 import { ConfirmValueOnDevice, ConfirmDeviceScreenProps } from './ConfirmValueOnDevice';
 
 interface ConfirmAddressProps
-    extends Pick<ConfirmDeviceScreenProps, 'device' | 'isConfirmed' | 'onCancel' | 'value'> {
+    extends Pick<ConfirmDeviceScreenProps, 'verify' | 'isConfirmed' | 'onCancel' | 'value'> {
     symbol: NetworkSymbol;
 }
 

--- a/packages/suite/src/components/suite/modals/confirm/ConfirmXpub.tsx
+++ b/packages/suite/src/components/suite/modals/confirm/ConfirmXpub.tsx
@@ -5,7 +5,7 @@ import { ConfirmValueOnDevice, ConfirmDeviceScreenProps } from './ConfirmValueOn
 import { Account, NetworkSymbol } from 'src/types/wallet/index';
 
 interface ConfirmXpubProps
-    extends Pick<ConfirmDeviceScreenProps, 'device' | 'isConfirmed' | 'onCancel' | 'value'> {
+    extends Pick<ConfirmDeviceScreenProps, 'verify' | 'isConfirmed' | 'onCancel' | 'value'> {
     accountIndex: number;
     symbol: NetworkSymbol;
     accountLabel: Account['metadata']['accountLabel'];


### PR DESCRIPTION
Device connection is detected and verification flow is continued

## Description

Used `useDevice` hook to correctly detect device connection. Also saw missing cs translation for TR_ADDRESS_PHISHING_WARNING so I added this in this PR too.

## Related Issue

Resolve #8637 

## Screenshots:

https://github.com/trezor/trezor-suite/assets/66002635/765b5683-c4ef-42be-8a58-14a0fb8508b0
