### PR TITLE
test(connect): adapt eos fixtures to fw change

### DIFF
--- a/packages/connect/e2e/__fixtures__/eosSignTransaction.ts
+++ b/packages/connect/e2e/__fixtures__/eosSignTransaction.ts
@@ -46,9 +46,19 @@ export default {
                     ],
                 },
             },
+            legacyResults: [
+                // https://github.com/trezor/trezor-firmware/commit/c3f6e8f19fd647c73b414322e287ba23cf8a0c7c
+                {
+                    rules: ['<2.6.2'],
+                    payload: {
+                        signature:
+                            'SIG_K1_JveDuew7oyKjgLmApra3NmKArx3QH6HVmatgkLYeUYWv7aGaoQPFyjBwAdcxuo2Skq9wRgsizos92h9iq9i5JbeHh7zNuo',
+                    },
+                },
+            ],
             result: {
                 signature:
-                    'SIG_K1_JveDuew7oyKjgLmApra3NmKArx3QH6HVmatgkLYeUYWv7aGaoQPFyjBwAdcxuo2Skq9wRgsizos92h9iq9i5JbeHh7zNuo',
+                    'SIG_K1_JyuCzvv5DUT6bWo2cQ5yjtsbVD3fLbzAbSRhH4wRRfWrivbasrU17VpfK8JqiqiWrw1aqcwYghuqSpwhexRmbHgwx5xib3',
             },
         },
         {
@@ -86,9 +96,19 @@ export default {
                     ],
                 },
             },
+            legacyResults: [
+                // https://github.com/trezor/trezor-firmware/commit/c3f6e8f19fd647c73b414322e287ba23cf8a0c7c
+                {
+                    rules: ['<2.6.2'],
+                    payload: {
+                        signature:
+                            'SIG_K1_Juju8Wjzyn38nuvgS1KT3koKQLHxMMfqVHrp5jMjv4QLU2pUG6EbiJD7D1EHE6xP8DRuwFLVUNR38nTyUKC1Eiz33WocUE',
+                    },
+                },
+            ],
             result: {
                 signature:
-                    'SIG_K1_Juju8Wjzyn38nuvgS1KT3koKQLHxMMfqVHrp5jMjv4QLU2pUG6EbiJD7D1EHE6xP8DRuwFLVUNR38nTyUKC1Eiz33WocUE',
+                    'SIG_K1_KdwCsth6XmRG39LxgswkFhJShWdTkTSeg8UDUzJn6qhEES92iGy3P1aJs3HKXNrrUkYU8tJbiXczb2NUJwe4tTnry5CNNH',
             },
         },
         {
@@ -125,9 +145,19 @@ export default {
                     ],
                 },
             },
+            legacyResults: [
+                // https://github.com/trezor/trezor-firmware/commit/c3f6e8f19fd647c73b414322e287ba23cf8a0c7c
+                {
+                    rules: ['<2.6.2'],
+                    payload: {
+                        signature:
+                            'SIG_K1_K3XXUzCUkT2HEdrJTz1CdDDKZbLMShmyEjknQozGhy4F21yUetr1nEe2vUgmGebk2nyYe49R5nkA155J5yFBBaLsTcSdBL',
+                    },
+                },
+            ],
             result: {
                 signature:
-                    'SIG_K1_K3XXUzCUkT2HEdrJTz1CdDDKZbLMShmyEjknQozGhy4F21yUetr1nEe2vUgmGebk2nyYe49R5nkA155J5yFBBaLsTcSdBL',
+                    'SIG_K1_KakW1eEPediabKj8YmJq4SqDvtLsKuV1cbuwWj1iAPrG4jt2F2he7xFzgYjgzRHchh2q8Hb9LJoHPevPUWZ5U2HQZWhLXt',
             },
         },
         {
@@ -163,9 +193,19 @@ export default {
                     ],
                 },
             },
+            legacyResults: [
+                // https://github.com/trezor/trezor-firmware/commit/c3f6e8f19fd647c73b414322e287ba23cf8a0c7c
+                {
+                    rules: ['<2.6.2'],
+                    payload: {
+                        signature:
+                            'SIG_K1_K4gU5S9g7rS6MojaPwWppEBCBbPrJm1pyJtVR9mts1sBq5xyN7nJv3FGnrBR7ByjanboCtK4ogY35sNPFX1F5qoZW7BkF9',
+                    },
+                },
+            ],
             result: {
                 signature:
-                    'SIG_K1_K4gU5S9g7rS6MojaPwWppEBCBbPrJm1pyJtVR9mts1sBq5xyN7nJv3FGnrBR7ByjanboCtK4ogY35sNPFX1F5qoZW7BkF9',
+                    'SIG_K1_K86DReCevfV5sfwfM1AYzsT98ZVSYrymsnYz47rXyBBpUSWA8QdkFnQhJQdwJJqJT4vcqYUcoWM2ECUAGJLdKXUn55RymR',
             },
         },
         {
@@ -201,9 +241,19 @@ export default {
                     ],
                 },
             },
+            legacyResults: [
+                // https://github.com/trezor/trezor-firmware/commit/c3f6e8f19fd647c73b414322e287ba23cf8a0c7c
+                {
+                    rules: ['<2.6.2'],
+                    payload: {
+                        signature:
+                            'SIG_K1_K618wK9f27YxHoPG9hoUCsazZXzxumBj3V9MqcTUh9yCocvP1uFZQAmGmZLhsAtuC2TRR4gtqbeQj57FniYd5i4faQCb6t',
+                    },
+                },
+            ],
             result: {
                 signature:
-                    'SIG_K1_K618wK9f27YxHoPG9hoUCsazZXzxumBj3V9MqcTUh9yCocvP1uFZQAmGmZLhsAtuC2TRR4gtqbeQj57FniYd5i4faQCb6t',
+                    'SIG_K1_Kh4JmjHFQ4HkUP4wMwjoUYuUj3dQYc41P6HXT1YkLD8MSQQjqeCZJXXXAYFeu4xzTyqvowyPpW1N8VsfVw16jt3o1j57pG',
             },
         },
         {
@@ -238,9 +288,19 @@ export default {
                     ],
                 },
             },
+            legacyResults: [
+                // https://github.com/trezor/trezor-firmware/commit/c3f6e8f19fd647c73b414322e287ba23cf8a0c7c
+                {
+                    rules: ['<2.6.2'],
+                    payload: {
+                        signature:
+                            'SIG_K1_JusrCS7H5DR53qke7edoWvJuLiQS2VQ84CsN5NWmWYVa7wmJVjh3Hcg5hH42zF8KjAmmvHtaJZ3wkortTW9eds1eoiKsrj',
+                    },
+                },
+            ],
             result: {
                 signature:
-                    'SIG_K1_JusrCS7H5DR53qke7edoWvJuLiQS2VQ84CsN5NWmWYVa7wmJVjh3Hcg5hH42zF8KjAmmvHtaJZ3wkortTW9eds1eoiKsrj',
+                    'SIG_K1_Jxcs3V5FNDf7oR8yGCJekVPGR2Bf7LVk3kpr4RFbAg76Y3tSR8DJnDXQRE3j49VjXJSokXBHmGytdtK7V2ycJ64DPZ6LgR',
             },
         },
         {
@@ -445,9 +505,19 @@ export default {
                     ],
                 },
             },
+            legacyResults: [
+                // https://github.com/trezor/trezor-firmware/commit/c3f6e8f19fd647c73b414322e287ba23cf8a0c7c
+                {
+                    rules: ['<2.6.2'],
+                    payload: {
+                        signature:
+                            'SIG_K1_KjPTp8jCtgBKQWqsndhrH4pdCGiks76Q1qBt9e8MtexW6FQg3FzfVFKDU4SvyVDyFs3worn6RyW6WYavw76ACNqcqkCYjf',
+                    },
+                },
+            ],
             result: {
                 signature:
-                    'SIG_K1_KjPTp8jCtgBKQWqsndhrH4pdCGiks76Q1qBt9e8MtexW6FQg3FzfVFKDU4SvyVDyFs3worn6RyW6WYavw76ACNqcqkCYjf',
+                    'SIG_K1_JyDbrnQhvBKx6ZHvrya57ajWtMzWWjy1F2U9NL7cUPer6NJjNFZ6E98qGoyBkQ67VBWKQVW2fWwuG3AeGz7vZ1KkSqRnZb',
             },
         },
         {
@@ -484,9 +554,19 @@ export default {
                     ],
                 },
             },
+            legacyResults: [
+                // https://github.com/trezor/trezor-firmware/commit/c3f6e8f19fd647c73b414322e287ba23cf8a0c7c
+                {
+                    rules: ['<2.6.2'],
+                    payload: {
+                        signature:
+                            'SIG_K1_Kgs3JdLNqTyGz7uyNiuYLK8sy5qhVQWozrBY7bJWKsjrWAxNyDQUKqHsHmTom5rGY21vYdXmCpi4msU6XeMgWvi4bsBxTx',
+                    },
+                },
+            ],
             result: {
                 signature:
-                    'SIG_K1_Kgs3JdLNqTyGz7uyNiuYLK8sy5qhVQWozrBY7bJWKsjrWAxNyDQUKqHsHmTom5rGY21vYdXmCpi4msU6XeMgWvi4bsBxTx',
+                    'SIG_K1_KVSS3vmu3quh63t2PADN9Fa7tAgEpC8Cg5y1JVQ8MbYUuh5EX4qdCNzgZpjHMBENjbyUiyTNwRDfvA6gM6vWfivTdQHXUd',
             },
         },
         {
@@ -603,9 +683,19 @@ export default {
                     ],
                 },
             },
+            legacyResults: [
+                // https://github.com/trezor/trezor-firmware/commit/c3f6e8f19fd647c73b414322e287ba23cf8a0c7c
+                {
+                    rules: ['<2.6.2'],
+                    payload: {
+                        signature:
+                            'SIG_K1_KhjdS1gKUHR4jKbN3YSdNbPbEqnUVM1Nt6ybdzEAwsUtfbCRJDwpQwPRuEau48CyvhYC5fKo5BiWMPQJbQPrg5ErHThieU',
+                    },
+                },
+            ],
             result: {
                 signature:
-                    'SIG_K1_KhjdS1gKUHR4jKbN3YSdNbPbEqnUVM1Nt6ybdzEAwsUtfbCRJDwpQwPRuEau48CyvhYC5fKo5BiWMPQJbQPrg5ErHThieU',
+                    'SIG_K1_JxgTbQsTKAfrJG2LnSAmfUG57MrLshJEeF3BZTPo7FrA1KARGA5gGX4kYctSvpxgb669JC3WfuNQzT8Gm4FkKznTE3sYjb',
             },
         },
         {
@@ -638,9 +728,19 @@ export default {
                     ],
                 },
             },
+            legacyResults: [
+                // https://github.com/trezor/trezor-firmware/commit/c3f6e8f19fd647c73b414322e287ba23cf8a0c7c
+                {
+                    rules: ['<2.6.2'],
+                    payload: {
+                        signature:
+                            'SIG_K1_KiG8c8t2SQkSfrEbD9BwJoYT133BPFLx3gu8sAzJadXyFk1EXKYAsgx4tkjt79G6ofuaQzJPAfDqy1FSpgLRbhbeFH9omd',
+                    },
+                },
+            ],
             result: {
                 signature:
-                    'SIG_K1_KiG8c8t2SQkSfrEbD9BwJoYT133BPFLx3gu8sAzJadXyFk1EXKYAsgx4tkjt79G6ofuaQzJPAfDqy1FSpgLRbhbeFH9omd',
+                    'SIG_K1_KkRowmmQgKvUxaCWFLUqwP16hPrh7vULMpsFvz5e7ufaGgArKyAWtueWBpdGmy9Ji761UTSA8KfSEJUnccwzh2orPukbgE',
             },
         },
         {
@@ -672,5 +772,8 @@ export default {
                     'SIG_K1_JvoJtrHpQJjHAZzEBhiQm75iimYabcAVNDvz8mkempLh6avSJgnXm5JzCCUEBjDtW3syByfXknmgr93Sw3P9RNLnwySmv6',
             },
         },
-    ].map(fixture => ({ ...fixture, legacyResults })),
+    ].map(fixture => ({
+        ...fixture,
+        legacyResults: [...legacyResults, ...(fixture.legacyResults || [])],
+    })),
 };


### PR DESCRIPTION
should be safu 
https://satoshilabs.slack.com/archives/CL1D61PQF/p1687763327039379

current latest released fw is 2.6.1. in master however, fw is also marked as 2.6.1 but it already has this incompatible change.  Our tests setup does not allow setting legacy results using commit hashesh for example. This all means that boundary I could use for legacy results fixtures does not exist yet.

So this change will take effect only after 2.6.2 is released. Until then, eos nightly 2-master jobs will be failing.