### PR TITLE
Remove old unused files from suite package

### DIFF
--- a/packages/suite/src/config/onboarding/index.ts
+++ b/packages/suite/src/config/onboarding/index.ts
@@ -1,7 +1,5 @@
-import * as MAILCHIMP from './mailchimp';
 import * as STEPS from './steps';
 
 export default {
-    MAILCHIMP,
     STEPS,
 };

--- a/packages/suite/src/config/onboarding/mailchimp.ts
+++ b/packages/suite/src/config/onboarding/mailchimp.ts
@@ -1,3 +1,0 @@
-export const MAILCHIMP_U = 'a87eb6070c965ef1be1b02854';
-export const MAILCHIMP_ID = '0ac8b24e69';
-export const MAILCHIMP_BASE = 'https://trezor.us7.list-manage.com';

--- a/packages/suite/src/support/workers/graph.ts
+++ b/packages/suite/src/support/workers/graph.ts
@@ -1,6 +1,6 @@
 /* eslint-disable no-restricted-globals */
 
-import { aggregateBalanceHistory } from '../utils/wallet/graphUtils';
+import { aggregateBalanceHistory } from '../../utils/wallet/graphUtils';
 
 const ctx: Worker = self as any;
 

--- a/packages/suite/src/views/dashboard/components/PortfolioCard/components/DashboardGraph.tsx
+++ b/packages/suite/src/views/dashboard/components/PortfolioCard/components/DashboardGraph.tsx
@@ -4,7 +4,7 @@ import { TransactionsGraph, Translation, HiddenPlaceholder } from 'src/component
 import { getUnixTime } from 'date-fns';
 import styled from 'styled-components';
 import { CARD_PADDING_SIZE } from 'src/constants/suite/layout';
-import GraphWorker from 'src/workers/graph';
+import GraphWorker from 'src/support/workers/graph';
 import * as graphActions from 'src/actions/wallet/graphActions';
 import { useActions, useSelector } from 'src/hooks/suite';
 import { Account } from 'src/types/wallet';


### PR DESCRIPTION
## Description

- remove old forgotten onboarding files
- move graph worker to support folder as there was just one file in `src/worker` in `suite` package
