### PR TITLE
Feat/cj request headers

### DIFF
--- a/packages/coinjoin/src/utils/http.ts
+++ b/packages/coinjoin/src/utils/http.ts
@@ -12,13 +12,16 @@ export interface RequestOptions extends ScheduleActionParams {
 
 const createHeaders = (options: RequestOptions) => {
     const headers: HeadersInit = {
-        'Content-Type': 'application/json',
+        'Content-Type': 'application/json; charset=utf-8',
+        'Accept-Encoding': 'gzip',
     };
-    // add custom header to define TOR identity.
-    // request is intercepted by @trezor/request-manager and requested identity is used to create TOR circuit
-    // header works only in nodejs environment (suite-desktop). browser throws: Refused to set unsafe header "proxy-authorization" error
+    // add custom headers to requests which are intercepted by @trezor/request-manager package.
+    // - Proxy-Authorization: used to create/use TOR circuit
+    // - Allowed-Headers: used to restrict headers sent to wabisabi api
+    // custom headers works only in nodejs environment (suite-desktop). browser throws: Refused to set unsafe header "proxy-authorization" error
     if (options.identity) {
         headers['Proxy-Authorization'] = `Basic ${options.identity}`;
+        headers['Allowed-Headers'] = 'Accept-Encoding;Content-Type;Content-Length;Host';
     }
     // blockbook api requires 'User-Agent' to be set
     // same as in @trezor/blockchain-link/src/workers/blockbook/websocket

--- a/packages/request-manager/src/interceptor.ts
+++ b/packages/request-manager/src/interceptor.ts
@@ -39,6 +39,49 @@ const isWhitelistedHost = (hostname: unknown, whitelist: string[] = ['127.0.0.1'
     whitelist.some(url => url === hostname || hostname.endsWith(url));
 
 const interceptNetSocketConnect = (context: InterceptorContext) => {
+    // To avoid disclosure that the request was sent by trezor-suite
+    // remove headers added by underlying libs before they are sent to the server.
+    // 1. nodejs http always(!) adds "Connection: close" header
+    //    https://github.com/nodejs/node/blob/e48763840625c037282681456ecd1e1cb034f636/lib/_http_outgoing.js#L508-L510
+    // 2. node-fetch always(!) adds "User-Agent", "Accept", "Connection"...
+    //    https://github.com/node-fetch/node-fetch/blob/7b86e946b02dfdd28f4f8fca3d73a022cbb5ca1e/src/request.js#L226
+    const originalSocketWrite = net.Socket.prototype.write;
+    net.Socket.prototype.write = function (data, ...args) {
+        const overloadedHeaders: string[] = [];
+        if (typeof data === 'string' && /Allowed-Headers/gi.test(data)) {
+            const headers = data.split('\r\n');
+            const allowedHeaders = headers
+                .find(line => /^Allowed-Headers/i.test(line))
+                ?.split(': ');
+
+            if (allowedHeaders) {
+                const allowedKeys = allowedHeaders[1].split(';');
+
+                headers.forEach(line => {
+                    const [key, value] = line.split(': ');
+                    if (key && value) {
+                        if (allowedKeys.some(allowed => new RegExp(`^${allowed}`, 'i').test(key))) {
+                            overloadedHeaders.push(line);
+                        }
+                    } else {
+                        overloadedHeaders.push(line);
+                    }
+                });
+
+                context.handler({
+                    type: 'INTERCEPTED_HEADERS',
+                    method: 'net.Socket.write',
+                    details: overloadedHeaders.join(' '),
+                });
+            }
+        }
+
+        return originalSocketWrite.apply(this, [
+            overloadedHeaders.length > 0 ? overloadedHeaders.join('\r\n') : data,
+            ...args,
+        ] as unknown as Parameters<typeof originalSocketWrite>);
+    };
+
     const originalSocketConnect = net.Socket.prototype.connect;
 
     net.Socket.prototype.connect = function (...args) {

--- a/packages/request-manager/src/types.ts
+++ b/packages/request-manager/src/types.ts
@@ -32,6 +32,11 @@ export type InterceptedEvent =
           details: string;
       }
     | {
+          type: 'INTERCEPTED_HEADERS';
+          method: string;
+          details: string;
+      }
+    | {
           type: 'INTERCEPTED_RESPONSE';
           host: string;
           time: number;


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

To avoid disclosure that the request was sent by trezor-suite
remove headers added by underlying libs before they are sent to the server.
1. nodejs http always(!) adds "Connection: close" header
    https://github.com/nodejs/node/blob/e48763840625c037282681456ecd1e1cb034f636/lib/_http_outgoing.js#L508-L510
2. node-fetch always(!) adds "User-Agent", "Accept", "Connection"...
   https://github.com/node-fetch/node-fetch/blob/7b86e946b02dfdd28f4f8fca3d73a022cbb5ca1e/src/request.js#L226

## Related Issue

Resolve https://github.com/trezor/trezor-suite/issues/7182
