### PR TITLE
removing .only from tests

### DIFF
--- a/packages/suite-web/e2e/tests/coinmarket/buy.test.ts
+++ b/packages/suite-web/e2e/tests/coinmarket/buy.test.ts
@@ -44,7 +44,7 @@ describe('Coinmarket buy', () => {
      * 13. Verifies that the buy trade was approved
      * * 14. Goes back to the Buy tab and verifies the transaction is listed under "Trade transactions"
      */
-    it.only('Should buy crypto successfully', () => {
+    it('Should buy crypto successfully', () => {
         const testData = {
             fiatInput: '500',
             quoteBtcValue: '0.02073954',

--- a/packages/suite-web/e2e/tests/settings/tt-device-settings.test.ts
+++ b/packages/suite-web/e2e/tests/settings/tt-device-settings.test.ts
@@ -89,7 +89,7 @@ describe('TT - Device settings', () => {
         cy.getTestElement('@settings/device/homescreen-upload').should('be.disabled');
     });
 
-    it.only('able to change homescreen in firmware >= 2.5.4', () => {
+    it('able to change homescreen in firmware >= 2.5.4', () => {
         cy.task('startEmu', { wipe: true, version: '2-master' });
         cy.task('setupEmu');
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

While optimizing group tags for our cypress tests, I've noticed that by a mistake, `.only` has been left in the code resulting in a skip of other 4 tests.

