### PR TITLE
deps: cypress 12.16.0

### DIFF
--- a/docker/docker-compose.suite-ci.yml
+++ b/docker/docker-compose.suite-ci.yml
@@ -7,7 +7,7 @@ services:
       - XDG_RUNTIME_DIR=/var/tmp
     network_mode: bridge # this makes docker reuse existing networks
   test-run:
-    image: $CI_DEPENDENCY_PROXY_DIRECT_GROUP_IMAGE_PREFIX/cypress/included:12.14.0
+    image: $CI_DEPENDENCY_PROXY_DIRECT_GROUP_IMAGE_PREFIX/cypress/included:12.16.0
     entrypoint: []
     environment:
       - CYPRESS_SNAPSHOT=$CYPRESS_SNAPSHOT

--- a/docker/test-runner/Dockerfile
+++ b/docker/test-runner/Dockerfile
@@ -1,6 +1,6 @@
 ## Use a proxy or fallback to no proxy at all (direct access to Docker Hub).
 ARG CI_DOCKER_PROXY=""
-FROM ${CI_DOCKER_PROXY}cypress/included:12.14.0
+FROM ${CI_DOCKER_PROXY}cypress/included:12.16.0
 
 RUN apt-get update && apt-get -y --no-install-recommends install \
     ca-certificates \

--- a/packages/suite-web/package.json
+++ b/packages/suite-web/package.json
@@ -45,7 +45,7 @@
         "@types/react-router-dom": "^5.1.7",
         "@types/styled-components": "^5.1.26",
         "chrome-remote-interface": "^0.32.2",
-        "cypress": "^12.14.0",
+        "cypress": "^12.16.0",
         "cypress-file-upload": "^5.0.8",
         "cypress-image-snapshot": "^4.0.1",
         "jest": "^26.6.3",

--- a/yarn.lock
+++ b/yarn.lock
@@ -8562,7 +8562,7 @@ __metadata:
     "@types/react-router-dom": ^5.1.7
     "@types/styled-components": ^5.1.26
     chrome-remote-interface: ^0.32.2
-    cypress: ^12.14.0
+    cypress: ^12.16.0
     cypress-file-upload: ^5.0.8
     cypress-image-snapshot: ^4.0.1
     jest: ^26.6.3
@@ -14839,9 +14839,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"cypress@npm:^12.14.0":
-  version: 12.14.0
-  resolution: "cypress@npm:12.14.0"
+"cypress@npm:^12.16.0":
+  version: 12.16.0
+  resolution: "cypress@npm:12.16.0"
   dependencies:
     "@cypress/request": ^2.88.10
     "@cypress/xvfb": ^1.2.4
@@ -14887,7 +14887,7 @@ __metadata:
     yauzl: ^2.10.0
   bin:
     cypress: bin/cypress
-  checksum: c98d33dc50f5e48a215f41e3a5139514816d2320e433d143a352a460f74941d3106a1f7485f61172f544cf125176c1225ac8edec31645d5a89cd394f72f93588
+  checksum: 551e2ec372f56a39a22526575b39bf9c6a110e5648ac1bf1c76460dfaebc3ca57d5537e7c206316284fe796ec76fa18f0493f3e040c92bd39c3720c9136fd5e4
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
i hoped it might fix one problem with outputs-labeling test (doesnt really work locally) but it did not help. we can update anyway. 