### PR TITLE
feat(connect): cancel auth method

### DIFF
--- a/.github/workflows/connect-test.yml
+++ b/.github/workflows/connect-test.yml
@@ -44,7 +44,7 @@ jobs:
     needs: [build]
     uses: ./.github/workflows/connect-test-params.yml
     with:
-      test-pattern: "init authorizeCoinjoin passphrase unlockPath setBusy override checkFirmwareAuthenticity"
+      test-pattern: "init authorizeCoinjoin cancelCoinjoinAuthorization passphrase unlockPath setBusy override checkFirmwareAuthenticity"
 
   management:
     needs: [build]

--- a/ci/test.yml
+++ b/ci/test.yml
@@ -298,7 +298,7 @@ connect-popup manual:
   parallel:
     matrix:
       - TESTS_ENVIRONMENT: ["node", "web"]
-        TESTS_PATTERN: "init authorizeCoinjoin passphrase unlockPath setBusy override"
+        TESTS_PATTERN: "init authorizeCoinjoin cancelCoinjoinAuthorization passphrase unlockPath setBusy override"
         TESTS_FIRMWARE: ["2-master", "2.2.0"]
         # todo:
         # TESTS_NODE_VERSION: ["12", "14", "16"]

--- a/docs/packages/connect/methods/cancelCoinjoinAuthorization.md
+++ b/docs/packages/connect/methods/cancelCoinjoinAuthorization.md
@@ -1,0 +1,48 @@
+## Bitcoin: cancel coinjoin authorization
+
+Clear device's authorization for coinjoin-related operations.
+
+```javascript
+const result = await TrezorConnect.cancelCoinjoinAuthorization(params);
+```
+
+> :warning: **This feature is experimental! Do not use it in production!**
+
+> :note: **Supported only by TT with Firmware 2.5.3 or higher!**
+
+### Params
+
+[Optional common params](commonParams.md)
+
+### Example:
+
+```javascript
+TrezorConnect.cancelCoinjoinAuthorization({
+    device,
+    useEmptyPassphrase: device?.useEmptyPassphrase,
+});
+```
+
+### Result
+
+[Success type](https://github.com/trezor/trezor-suite/blob/develop/packages/transport/src/types/messages.ts)
+
+```javascript
+{
+    success: true,
+    payload: {
+        message: 'Authorization cancelled'
+    }
+}
+```
+
+Error
+
+```javascript
+{
+    success: false,
+    payload: {
+        error: string // error message
+    }
+}
+```

--- a/packages/connect/e2e/tests/device/cancelCoinjoinAuthorization.test.ts
+++ b/packages/connect/e2e/tests/device/cancelCoinjoinAuthorization.test.ts
@@ -1,0 +1,73 @@
+/* eslint-disable import/no-named-as-default */
+import TrezorConnect, { Success, PROTO, Unsuccessful } from '../../../src';
+
+const { ADDRESS_N } = global.TestUtils;
+const { getController, setup, conditionalTest, initTrezorConnect } = global.Trezor;
+
+describe('TrezorConnect.cancelCoinjoinAuthorization', () => {
+    const controller = getController();
+
+    beforeAll(async () => {
+        await setup(controller, {
+            mnemonic: 'mnemonic_all',
+        });
+    });
+
+    beforeEach(async () => {
+        // restart connect for each test (working with event listeners)
+        await TrezorConnect.dispose();
+        await initTrezorConnect(controller, { debug: false });
+    });
+
+    afterAll(async () => {
+        controller.dispose();
+        await TrezorConnect.dispose();
+    });
+
+    conditionalTest(['1', '<2.5.4'], 'Cancel authorization works', async () => {
+        const auth = await TrezorConnect.authorizeCoinjoin({
+            coordinator: 'www.example.com',
+            maxRounds: 2,
+            maxCoordinatorFeeRate: 500000, // 5% => 0.005 * 10**8;
+            maxFeePerKvbyte: 3500,
+            path: ADDRESS_N("m/10025'/1'/0'/1'"),
+            coin: 'Testnet',
+            scriptType: 'SPENDTAPROOT',
+        });
+
+        expect(auth.success).toBe(true);
+        expect(auth.payload).toEqual({ message: 'Coinjoin authorized' });
+
+        const commitmentData =
+            '0f7777772e6578616d706c652e636f6d0000000000000000000000000000000000000000000000000000000000000001';
+
+        const proof = await TrezorConnect.getOwnershipProof({
+            coin: 'Testnet',
+            path: ADDRESS_N("m/10025'/1'/0'/1'/1/0"),
+            scriptType: 'SPENDTAPROOT',
+            userConfirmation: true,
+            commitmentData,
+            preauthorized: true,
+        });
+
+        expect(proof.success).toBe(true);
+
+        const cancelAuthResult = await TrezorConnect.cancelCoinjoinAuthorization({});
+        expect(cancelAuthResult.success).toBe(true);
+        expect((cancelAuthResult as Success<PROTO.Success>).payload.message).toBe(
+            'Authorization cancelled',
+        );
+
+        const proof2 = await TrezorConnect.getOwnershipProof({
+            coin: 'Testnet',
+            path: ADDRESS_N("m/10025'/1'/0'/1'/1/0"),
+            scriptType: 'SPENDTAPROOT',
+            userConfirmation: true,
+            commitmentData,
+            preauthorized: true,
+        });
+
+        expect(proof2.success).toBe(false);
+        expect((proof2 as Unsuccessful).payload.error).toBe('No preauthorized operation');
+    });
+});

--- a/packages/connect/src/api/cancelCoinjoinAuthorization.ts
+++ b/packages/connect/src/api/cancelCoinjoinAuthorization.ts
@@ -1,0 +1,31 @@
+import { AbstractMethod } from '../core/AbstractMethod';
+import { getFirmwareRange } from './common/paramsValidator';
+import { PROTO } from '../constants';
+
+export default class CancelCoinjoinAuthorization extends AbstractMethod<
+    'cancelCoinjoinAuthorization',
+    PROTO.CancelAuthorization
+> {
+    init() {
+        const { payload } = this;
+
+        this.firmwareRange = getFirmwareRange(this.name, null, this.firmwareRange);
+        this.preauthorized =
+            typeof payload.preauthorized === 'boolean' ? payload.preauthorized : true;
+        this.info = 'Cancel Coinjoin Authorization';
+    }
+
+    async run() {
+        const cmd = this.device.getCommands();
+
+        if (!this.preauthorized) {
+            if (!(await cmd.preauthorize(false))) {
+                // device is not preauthorised
+                return { message: 'Not authorized' };
+            }
+        }
+
+        const response = await cmd.typedCall('CancelAuthorization', 'Success');
+        return response.message;
+    }
+}

--- a/packages/connect/src/api/index.ts
+++ b/packages/connect/src/api/index.ts
@@ -1,6 +1,7 @@
 export { default as applyFlags } from './applyFlags';
 export { default as applySettings } from './applySettings';
 export { default as authorizeCoinjoin } from './authorizeCoinjoin';
+export { default as cancelCoinjoinAuthorization } from './cancelCoinjoinAuthorization';
 export { default as backupDevice } from './backupDevice';
 export { default as binanceGetAddress } from './binanceGetAddress';
 export { default as binanceGetPublicKey } from './binanceGetPublicKey';

--- a/packages/connect/src/data/config.ts
+++ b/packages/connect/src/data/config.ts
@@ -184,6 +184,7 @@ export const config = {
             capabilities: ['coinjoin'],
             methods: [
                 'authorizeCoinjoin',
+                'cancelCoinjoinAuthorization',
                 'getOwnershipId',
                 'getOwnershipProof',
                 'setBusy',

--- a/packages/connect/src/factory.ts
+++ b/packages/connect/src/factory.ts
@@ -219,6 +219,9 @@ export const factory = ({
 
         authorizeCoinjoin: params => call({ ...params, method: 'authorizeCoinjoin' }),
 
+        cancelCoinjoinAuthorization: params =>
+            call({ ...params, method: 'cancelCoinjoinAuthorization' }),
+
         backupDevice: params => call({ ...params, method: 'backupDevice' }),
 
         changePin: params => call({ ...params, method: 'changePin' }),

--- a/packages/connect/src/types/api/cancelCoinjoinAuthorization.ts
+++ b/packages/connect/src/types/api/cancelCoinjoinAuthorization.ts
@@ -1,0 +1,10 @@
+import type { PROTO } from '../../constants';
+import type { Params, Response } from '../params';
+
+interface CancelCoinjoinAuthorization {
+    preauthorized?: boolean;
+}
+
+export declare function cancelCoinjoinAuthorization(
+    params: Params<CancelCoinjoinAuthorization>,
+): Response<PROTO.Success>;

--- a/packages/connect/src/types/api/index.ts
+++ b/packages/connect/src/types/api/index.ts
@@ -75,6 +75,7 @@ import { unlockPath } from './unlockPath';
 import { verifyMessage } from './verifyMessage';
 import { wipeDevice } from './wipeDevice';
 import { checkFirmwareAuthenticity } from './checkFirmwareAuthenticity';
+import { cancelCoinjoinAuthorization } from './cancelCoinjoinAuthorization';
 
 export interface TrezorConnect {
     // https://github.com/trezor/trezor-suite/blob/develop/docs/packages/connect/methods/applyFlags.md
@@ -85,6 +86,9 @@ export interface TrezorConnect {
 
     // https://github.com/trezor/trezor-suite/blob/develop/docs/packages/connect/methods/authorizeCoinjoin.md
     authorizeCoinjoin: typeof authorizeCoinjoin;
+
+    // https://github.com/trezor/trezor-suite/blob/develop/docs/packages/connect/methods/cancelCoinjoinAuthorization.md
+    cancelCoinjoinAuthorization: typeof cancelCoinjoinAuthorization;
 
     // https://github.com/trezor/trezor-suite/blob/develop/docs/packages/connect/methods/backupDevice.md
     backupDevice: typeof backupDevice;

--- a/suite-common/test-utils/src/mocks.ts
+++ b/suite-common/test-utils/src/mocks.ts
@@ -287,6 +287,11 @@ const getTrezorConnect = <M>(methods?: M) => {
                 ...getFixture(),
                 _params,
             })),
+            cancelCoinjoinAuthorization: jest.fn(async _params => ({
+                success: true,
+                ...getFixture(),
+                _params,
+            })),
             blockchainSetCustomBackend: jest.fn(async _params => ({
                 success: true,
                 ...getFixture(),


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

* add the cancelCoinjoinAuthorization method
* cancel device authorization when stopping coinjoin

The "Coinjoin Authorized" banner is not disappearing because of a bug on the FW side https://github.com/trezor/trezor-firmware/issues/3111

## Related Issue
https://github.com/trezor/trezor-suite/issues/7871
