### PR TITLE
chore(suite): remove unused skip test commands

### DIFF
--- a/packages/suite-web/e2e/support/commands.ts
+++ b/packages/suite-web/e2e/support/commands.ts
@@ -26,7 +26,6 @@ import { SuiteAnalyticsEvent } from '@trezor/suite-analytics';
 import { EventPayload, Requests } from './types';
 
 const command = require('cypress-image-snapshot/command');
-const { skipOn, onlyOn } = require('@cypress/skip-test');
 
 const prefixedVisit = (route: string, options?: Partial<Cypress.VisitOptions>) => {
     const baseUrl = Cypress.config('baseUrl');
@@ -150,10 +149,6 @@ Cypress.Commands.add('passThroughInitMetadata', passThroughInitMetadata);
 Cypress.Commands.add('passThroughSetPin', passThroughSetPin);
 // @ts-expect-error
 Cypress.Commands.add('enableRegtestAndGetCoins', enableRegtestAndGetCoins);
-// redux
-// skip tests conditionally
-Cypress.Commands.add('skipOn', skipOn);
-Cypress.Commands.add('onlyOn', onlyOn);
 
 Cypress.Commands.add('text', { prevSubject: true }, subject => subject.text());
 Cypress.Commands.add('createAccountFromMyAccounts', createAccountFromMyAccounts);

--- a/packages/suite-web/package.json
+++ b/packages/suite-web/package.json
@@ -27,7 +27,6 @@
         "worker-loader": "^3.0.8"
     },
     "devDependencies": {
-        "@cypress/skip-test": "^2.6.1",
         "@suite-common/test-utils": "workspace:*",
         "@suite-common/wallet-config": "workspace:*",
         "@trezor/connect": "workspace:*",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2006,13 +2006,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@cypress/skip-test@npm:^2.6.1":
-  version: 2.6.1
-  resolution: "@cypress/skip-test@npm:2.6.1"
-  checksum: 48ec912f162563ca8657b6f023b701f66ddc29083ed36ae96cd861087c828046c2abb36c6fa0b316bb74941a17b046ac3b143532218e4cdc6d78d7838a64a141
-  languageName: node
-  linkType: hard
-
 "@cypress/xvfb@npm:^1.2.4":
   version: 1.2.4
   resolution: "@cypress/xvfb@npm:1.2.4"
@@ -8539,7 +8532,6 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@trezor/suite-web@workspace:packages/suite-web"
   dependencies:
-    "@cypress/skip-test": ^2.6.1
     "@sentry/browser": ^7.56.0
     "@suite-common/formatters": "workspace:*"
     "@suite-common/sentry": "workspace:*"


### PR DESCRIPTION
Removed unused skip test commands and `@cypress/skip-test` package

## Description

Removed unused commands (`skipOn` and `onlyOn`) from the `@cypress/skip-test` package and also removed `@ts-expect-error` comment since it was not needed.

## Related Issue

Resolve #8821 
