### PR TITLE
Chore/dependencies small fixes

### DIFF
--- a/package.json
+++ b/package.json
@@ -127,7 +127,6 @@
         "nx": "^16.3.2",
         "nx-cloud": "16.0.5",
         "patch-package": "7.0.0",
-        "postinstall-postinstall": "^2.1.0",
         "prettier": "2.8.8",
         "prettier-eslint": "^15.0.1",
         "rimraf": "^5.0.1",

--- a/packages/env-utils/package.json
+++ b/packages/env-utils/package.json
@@ -25,6 +25,8 @@
         "prepublish": "yarn tsx ../../scripts/prepublish.js"
     },
     "dependencies": {
+        "expo-localization": "^14.1.1",
+        "react-native": "0.71.8",
         "react-native-config": "^1.5.0",
         "ua-parser-js": "^1.0.35"
     },

--- a/packages/env-utils/src/envUtils.native.ts
+++ b/packages/env-utils/src/envUtils.native.ts
@@ -1,5 +1,3 @@
-/* eslint-disable import/no-extraneous-dependencies -- react-native and expo-localization have been excluded from the package.json file as a workaround, ensuring that they are not bundled with the suite-desktop app  */
-
 import { Dimensions, Platform } from 'react-native';
 import Config from 'react-native-config';
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -27766,13 +27766,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"postinstall-postinstall@npm:^2.1.0":
-  version: 2.1.0
-  resolution: "postinstall-postinstall@npm:2.1.0"
-  checksum: e1d34252cf8d2c5641c7d2db7426ec96e3d7a975f01c174c68f09ef5b8327bc8d5a9aa2001a45e693db2cdbf69577094d3fe6597b564ad2d2202b65fba76134b
-  languageName: node
-  linkType: hard
-
 "prelude-ls@npm:^1.2.1":
   version: 1.2.1
   resolution: "prelude-ls@npm:1.2.1"
@@ -32915,7 +32908,6 @@ __metadata:
     nx: ^16.3.2
     nx-cloud: 16.0.5
     patch-package: 7.0.0
-    postinstall-postinstall: ^2.1.0
     prettier: 2.8.8
     prettier-eslint: ^15.0.1
     rimraf: ^5.0.1

--- a/yarn.lock
+++ b/yarn.lock
@@ -8187,6 +8187,8 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@trezor/env-utils@workspace:packages/env-utils"
   dependencies:
+    expo-localization: ^14.1.1
+    react-native: 0.71.8
     react-native-config: ^1.5.0
     rimraf: ^5.0.1
     tsx: ^3.12.7


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

- remove unnecessary `postinstall-postinstall` dependency  we don't need to call postinstall (patch) on package removal
-  remove unnecessary exception for no-extraneous-dependencies because react native dependencies are currently bundled in suite destkop anyway, we have to fix it in some other way

