### PR TITLE
metadata: encryption version migration

### DIFF
--- a/packages/e2e-utils/src/mocks/google.ts
+++ b/packages/e2e-utils/src/mocks/google.ts
@@ -35,7 +35,7 @@ class File {
  * Mock implementation of Google Drive service intended to be used in e2e tests.
  */
 export class GoogleMock {
-    files: Record<string, any> = {};
+    files: Record<string, File> = {};
     nextResponse: null | Record<string, any> = null;
     // store requests for assertions in tests
     requests: string[] = [];
@@ -151,6 +151,12 @@ export class GoogleMock {
         app.get('/drive/v3/files', express.json(), (_req, res) => {
             res.json({
                 files: Object.values(this.files),
+            });
+        });
+
+        app.get('/drive/api/v3/reference/files/list', express.json(), (_req, res) => {
+            res.json({
+                files: Object.keys(this.files),
             });
         });
 

--- a/packages/suite-web/e2e/cypress.config.ts
+++ b/packages/suite-web/e2e/cypress.config.ts
@@ -78,7 +78,7 @@ export default defineConfig({
                 addMatchImageSnapshotPlugin(on, config);
             });
             on('task', {
-                metadataStartProvider: async provider => {
+                metadataStartProvider: async (provider: 'dropbox' | 'google') => {
                     switch (provider) {
                         case 'dropbox':
                             await mocked.dropbox.start();
@@ -137,6 +137,18 @@ export default defineConfig({
                             return mocked.dropbox.requests;
                         case 'google':
                             return mocked.google.requests;
+                        default:
+                            throw new Error('not a valid case');
+                    }
+                },
+                metadataGetFilesList: ({ provider }) => {
+                    switch (provider) {
+                        case 'dropbox':
+                            return Object.keys(mocked.dropbox.files).map(name =>
+                                name.replace('/apps/trezor/', ''),
+                            );
+                        case 'google':
+                            return Object.keys(mocked.google.files);
                         default:
                             throw new Error('not a valid case');
                     }

--- a/packages/suite-web/e2e/support/utils/shortcuts.ts
+++ b/packages/suite-web/e2e/support/utils/shortcuts.ts
@@ -51,8 +51,6 @@ export const passThroughBackupShamir = (shares: number, threshold: number) => {
 };
 
 export const passThroughInitMetadata = (provider: 'dropbox' | 'google') => {
-    cy.getConfirmActionOnDeviceModal();
-    cy.task('pressYes');
     cy.getTestElement(`@modal/metadata-provider/${provider}-button`).click();
     cy.getTestElement('@modal/metadata-provider').should('not.exist');
 };

--- a/packages/suite-web/e2e/tests/metadata/dropbox-api-errors.test.ts
+++ b/packages/suite-web/e2e/tests/metadata/dropbox-api-errors.test.ts
@@ -18,14 +18,14 @@ describe('Dropbox api errors', () => {
         // prepare some initial files
         cy.task('metadataSetFileContent', {
             provider: 'dropbox',
-            file: '/apps/trezor/f7acc942eeb83921892a95085e409b3e6b5325db6400ae5d8de523a305291dca.mtdt',
+            file: '/apps/trezor/b9b5e1fd2800d4dc68e2f4e775fd819f4da3fb9e1bcc2cacd7f04fa543eac8a0_2.mtdt',
             content: {
                 version: '1.0.0',
                 accountLabel: 'already existing label',
                 outputLabels: {},
                 addressLabels: {},
             },
-            aesKey: 'c785ef250807166bffc141960c525df97647fcc1bca57f6892ca3742ba86ed8d',
+            aesKey: '998daf71f3fbc486076f0ee8d5737a61b82bceacb0ec69100cbe4d45cd79676a',
         });
         cy.prefixedVisit('/', {
             onBeforeLoad: (win: Window) => {

--- a/packages/suite-web/e2e/tests/metadata/interval-fetching.test.ts
+++ b/packages/suite-web/e2e/tests/metadata/interval-fetching.test.ts
@@ -9,13 +9,13 @@ const fixtures = [
     {
         provider: 'google',
         desc: 'does NOT watch files over time',
-        file: 'f7acc942eeb83921892a95085e409b3e6b5325db6400ae5d8de523a305291dca.mtdt',
+        file: 'b9b5e1fd2800d4dc68e2f4e775fd819f4da3fb9e1bcc2cacd7f04fa543eac8a0_2.mtdt',
         content: 'already existing label',
     },
     {
         provider: 'dropbox',
         desc: 'does watch files over time',
-        file: '/apps/trezor/f7acc942eeb83921892a95085e409b3e6b5325db6400ae5d8de523a305291dca.mtdt',
+        file: '/apps/trezor/b9b5e1fd2800d4dc68e2f4e775fd819f4da3fb9e1bcc2cacd7f04fa543eac8a0_2.mtdt',
         content: 'label from another window',
     },
 ] as const;
@@ -44,7 +44,7 @@ describe('Metadata - suite is watching cloud provider and syncs periodically', (
                     outputLabels: {},
                     addressLabels: {},
                 },
-                aesKey: 'c785ef250807166bffc141960c525df97647fcc1bca57f6892ca3742ba86ed8d',
+                aesKey: '998daf71f3fbc486076f0ee8d5737a61b82bceacb0ec69100cbe4d45cd79676a',
             });
             cy.prefixedVisit('/', {
                 onBeforeLoad: win => {
@@ -81,7 +81,7 @@ describe('Metadata - suite is watching cloud provider and syncs periodically', (
                     outputLabels: {},
                     addressLabels: {},
                 },
-                aesKey: 'c785ef250807166bffc141960c525df97647fcc1bca57f6892ca3742ba86ed8d',
+                aesKey: '998daf71f3fbc486076f0ee8d5737a61b82bceacb0ec69100cbe4d45cd79676a',
             });
 
             // and this does the time travel to trigger fetch

--- a/packages/suite-web/e2e/tests/metadata/metadata-migration.test.ts
+++ b/packages/suite-web/e2e/tests/metadata/metadata-migration.test.ts
@@ -1,0 +1,87 @@
+import { rerouteMetadataToMockProvider, stubOpen } from '../../stubs/metadata';
+
+const providers = ['google', 'dropbox'] as const;
+
+const fileName = 'f7acc942eeb83921892a95085e409b3e6b5325db6400ae5d8de523a305291dca.mtdt';
+const migratedFileName = 'b9b5e1fd2800d4dc68e2f4e775fd819f4da3fb9e1bcc2cacd7f04fa543eac8a0_v2.mtdt';
+
+const fileLocation = {
+    google: fileName,
+    dropbox: `/apps/trezor/${fileName}`,
+};
+
+const checkLabel = () => {
+    cy.getTestElement('@suite/menu/wallet-index').click();
+    cy.getTestElement('@account-menu/btc/normal/0/label').should('contain', 'some account label');
+};
+
+describe('Metadata - metadata files are properly migrated from ENCRYPTION_VERSION v1 to v2', () => {
+    beforeEach(() => {
+        cy.viewport(1080, 1440).resetDb();
+        cy.task('startEmu', { wipe: true });
+        cy.task('setupEmu', {
+            mnemonic: 'all all all all all all all all all all all all',
+        });
+        cy.task('startBridge');
+        cy.prefixedVisit('/', {
+            onBeforeLoad: (win: Window) => {
+                cy.stub(win, 'open').callsFake(stubOpen(win));
+                cy.stub(win, 'fetch').callsFake(rerouteMetadataToMockProvider);
+            },
+        });
+
+        cy.passThroughInitialRun();
+        cy.discoveryShouldFinish();
+
+        cy.getTestElement('@suite/menu/settings').click();
+    });
+
+    providers.forEach(provider => {
+        it(`should migrate metadata file from v1 to v2 using ${provider}`, () => {
+            // initialize provider
+            cy.task('metadataStartProvider', provider);
+            cy.task('metadataSetFileContent', {
+                provider,
+                file: fileLocation[provider],
+                content: {
+                    version: '1.0.0',
+                    accountLabel: 'some account label',
+                    outputLabels: {},
+                    addressLabels: {},
+                },
+                aesKey: 'c785ef250807166bffc141960c525df97647fcc1bca57f6892ca3742ba86ed8d',
+            });
+
+            // enable labeling
+            cy.getTestElement('@settings/metadata-switch').click({ force: true });
+            cy.passThroughInitMetadata(provider);
+
+            // appears only when a migration is needed
+            cy.getConfirmActionOnDeviceModal();
+            cy.task('pressYes');
+
+            // wait until migration finishes
+            cy.getTestElement('@settings/metadata-switch').get('input').should('not.be.disabled');
+
+            // check if the file has been migrated
+            cy.task('metadataGetFilesList', { provider }).then(files => {
+                const isFileMigrated = (files as string[]).includes(migratedFileName);
+                expect(isFileMigrated).to.be.true;
+            });
+
+            // check if the label is there after migration
+            checkLabel();
+
+            // toggle labeling to see if the migration is not run again (no device prompt modal = no migration)
+            cy.getTestElement('@suite/menu/settings').click();
+            cy.getTestElement('@settings/metadata-switch').click({ force: false });
+            cy.getTestElement('@settings/metadata-switch').click({ force: true });
+
+            // wait until migration finishes
+            cy.getTestElement('@settings/metadata-switch').get('input').should('not.be.disabled');
+
+            // check if the label is still there
+            checkLabel();
+        });
+    });
+});

--- a/packages/suite-web/e2e/tests/metadata/remembered-device.test.ts
+++ b/packages/suite-web/e2e/tests/metadata/remembered-device.test.ts
@@ -6,11 +6,11 @@ import { rerouteMetadataToMockProvider, stubOpen } from '../../stubs/metadata';
 const providers = [
     {
         provider: 'google',
-        file: 'f7acc942eeb83921892a95085e409b3e6b5325db6400ae5d8de523a305291dca.mtdt',
+        file: 'b9b5e1fd2800d4dc68e2f4e775fd819f4da3fb9e1bcc2cacd7f04fa543eac8a0_2.mtdt',
     },
     {
         provider: 'dropbox',
-        file: '/apps/trezor/f7acc942eeb83921892a95085e409b3e6b5325db6400ae5d8de523a305291dca.mtdt',
+        file: '/apps/trezor/b9b5e1fd2800d4dc68e2f4e775fd819f4da3fb9e1bcc2cacd7f04fa543eac8a0_2.mtdt',
     },
 ] as const;
 
@@ -40,7 +40,7 @@ On disable, it throws away all metadata related records from memory.`, () => {
                     outputLabels: {},
                     addressLabels: {},
                 },
-                aesKey: 'c785ef250807166bffc141960c525df97647fcc1bca57f6892ca3742ba86ed8d',
+                aesKey: '998daf71f3fbc486076f0ee8d5737a61b82bceacb0ec69100cbe4d45cd79676a',
             });
 
             cy.prefixedVisit('/', {
@@ -105,11 +105,10 @@ On disable, it throws away all metadata related records from memory.`, () => {
             cy.getTestElement('@account-menu/btc/normal/0/label').should('not.contain', 'label');
             cy.hoverTestElement("@metadata/accountLabel/m/84'/0'/0'/hover-container");
             cy.getTestElement("@metadata/accountLabel/m/84'/0'/0'/add-label-button").click();
-            cy.log(
-                'disabling metadata removed also all keys, so metadata init flow takes all steps now expect for providers, these stay connected',
+            cy.getTestElement('@account-menu/btc/normal/0/label').should(
+                'contain',
+                'already existing label',
             );
-            cy.getConfirmActionOnDeviceModal();
-            cy.task('pressYes');
 
             // device saved, disconnect provider
             cy.getTestElement('@menu/switch-device').click();

--- a/packages/suite-web/e2e/tests/metadata/wallet-metadata.test.ts
+++ b/packages/suite-web/e2e/tests/metadata/wallet-metadata.test.ts
@@ -81,8 +81,6 @@ describe('Metadata - wallet labeling', () => {
             cy.getConfirmActionOnDeviceModal();
             cy.task('pressYes');
             cy.getTestElement('@menu/switch-device').click();
-            cy.getConfirmActionOnDeviceModal();
-            cy.task('pressYes');
             cy.getTestElement(`@metadata/walletLabel/${standardWalletState}`).should(
                 'contain',
                 'wallet for drugs',

--- a/packages/suite/src/actions/suite/__fixtures__/metadataActions.ts
+++ b/packages/suite/src/actions/suite/__fixtures__/metadataActions.ts
@@ -71,12 +71,11 @@ const setDeviceMetadataKey = [
                 payload: {
                     deviceState: 'device-state',
                     metadata: {
-                        key: '20c8bf0701213cdcf4c2f56fd0096c1772322d42fb9c4d0ddf6bb122d713d2f3',
-
-                        1: {
+                        2: {
                             fileName:
-                                'c734ff5106c4910aa3444f3672cc2c82d8cb4595f0527be672d8b100ed82908f',
+                                'c734ff5106c4910aa3444f3672cc2c82d8cb4595f0527be672d8b100ed82908f_v2.mtdt',
                             aesKey: 'bc37a9a8c6cfa6ab2f75b384df2745895d75f2c572a195ccff59ae9958aaf0e8',
+                            key: '20c8bf0701213cdcf4c2f56fd0096c1772322d42fb9c4d0ddf6bb122d713d2f3',
                         },
                         status: 'enabled',
                     },
@@ -86,12 +85,12 @@ const setDeviceMetadataKey = [
                 type: SUITE.UPDATE_SELECTED_DEVICE,
                 payload: {
                     metadata: {
-                        1: {
+                        2: {
                             aesKey: 'bc37a9a8c6cfa6ab2f75b384df2745895d75f2c572a195ccff59ae9958aaf0e8',
                             fileName:
-                                'c734ff5106c4910aa3444f3672cc2c82d8cb4595f0527be672d8b100ed82908f',
+                                'c734ff5106c4910aa3444f3672cc2c82d8cb4595f0527be672d8b100ed82908f_v2.mtdt',
+                            key: '20c8bf0701213cdcf4c2f56fd0096c1772322d42fb9c4d0ddf6bb122d713d2f3',
                         },
-                        key: '20c8bf0701213cdcf4c2f56fd0096c1772322d42fb9c4d0ddf6bb122d713d2f3',
                         status: 'enabled',
                     },
                     state: 'device-state',
@@ -116,8 +115,9 @@ const setAccountMetadataKey = [
             device: {
                 metadata: {
                     status: 'enabled',
-                    key: '20c8bf0701213cdcf4c2f56fd0096c1772322d42fb9c4d0ddf6bb122d713d2f3',
-                    providers: [],
+                    2: {
+                        key: '20c8bf0701213cdcf4c2f56fd0096c1772322d42fb9c4d0ddf6bb122d713d2f3',
+                    },
                 },
             },
         },
@@ -128,9 +128,9 @@ const setAccountMetadataKey = [
         },
         result: {
             metadata: {
-                1: {
+                2: {
                     fileName:
-                        '828652b66f2e6f919fbb7fe4c9609d4891ed531c6fac4c28441e53ebe577ac85.mtdt',
+                        '828652b66f2e6f919fbb7fe4c9609d4891ed531c6fac4c28441e53ebe577ac85_v2.mtdt',
                     aesKey: '9bc3736f0b45cd681854a724b5bba67b9da1e50bc9983fd2dd56e53e74b75480',
                 },
             },
@@ -155,7 +155,7 @@ const addDeviceMetadata = [
             device: {
                 state: 'device-state',
                 metadata: {
-                    1: {
+                    2: {
                         aesKey: 'eb0f1f0238c7fa8018c6101f4e887b871ce07b99d01d5ea57089b82f93149557',
                         fileName:
                             '039fe833cba71d84b7bf4c99d44468ee48e311e741cbfcd6daf5263f584ef9f6',
@@ -280,7 +280,7 @@ const addAccountMetadata = [
             accounts: [
                 {
                     metadata: {
-                        1: {
+                        2: {
                             aesKey: '9bc3736f0b45cd681854a724b5bba67b9da1e50bc9983fd2dd56e53e74b75480',
                             fileName: 'filename-123',
                         },
@@ -550,13 +550,13 @@ const init = [
                 payload: {
                     deviceState: 'device-state',
                     metadata: {
-                        '1': {
+                        '2': {
                             fileName:
-                                'c734ff5106c4910aa3444f3672cc2c82d8cb4595f0527be672d8b100ed82908f',
+                                'c734ff5106c4910aa3444f3672cc2c82d8cb4595f0527be672d8b100ed82908f_v2.mtdt',
                             aesKey: 'bc37a9a8c6cfa6ab2f75b384df2745895d75f2c572a195ccff59ae9958aaf0e8',
+                            key: '20c8bf0701213cdcf4c2f56fd0096c1772322d42fb9c4d0ddf6bb122d713d2f3',
                         },
                         status: 'enabled',
-                        key: '20c8bf0701213cdcf4c2f56fd0096c1772322d42fb9c4d0ddf6bb122d713d2f3',
                     },
                 },
             },
@@ -566,13 +566,13 @@ const init = [
                     state: 'device-state',
                     connected: true,
                     metadata: {
-                        '1': {
+                        '2': {
                             fileName:
-                                'c734ff5106c4910aa3444f3672cc2c82d8cb4595f0527be672d8b100ed82908f',
+                                'c734ff5106c4910aa3444f3672cc2c82d8cb4595f0527be672d8b100ed82908f_v2.mtdt',
                             aesKey: 'bc37a9a8c6cfa6ab2f75b384df2745895d75f2c572a195ccff59ae9958aaf0e8',
+                            key: '20c8bf0701213cdcf4c2f56fd0096c1772322d42fb9c4d0ddf6bb122d713d2f3',
                         },
                         status: 'enabled',
-                        key: '20c8bf0701213cdcf4c2f56fd0096c1772322d42fb9c4d0ddf6bb122d713d2f3',
                     },
                 },
             },

--- a/packages/suite/src/actions/suite/__fixtures__/metadataActions.ts
+++ b/packages/suite/src/actions/suite/__fixtures__/metadataActions.ts
@@ -29,36 +29,6 @@ const setDeviceMetadataKey = [
         },
     },
     {
-        description: `Master key cancelled`,
-        connect: {
-            success: false,
-        },
-        initialState: {
-            metadata: { enabled: true, providers: [] },
-            device: { state: 'device-state', connected: true, metadata: { status: 'disabled' } },
-        },
-        result: [
-            {
-                type: METADATA.SET_DEVICE_METADATA,
-                payload: {
-                    metadata: {
-                        status: 'cancelled',
-                    },
-                },
-            },
-            {
-                type: SUITE.UPDATE_SELECTED_DEVICE,
-                payload: {
-                    state: 'device-state',
-                    metadata: { status: 'cancelled' },
-                },
-            },
-            {
-                type: METADATA.DISABLE,
-            },
-        ],
-    },
-    {
         description: `Master key successfully generated`,
         initialState: {
             metadata: { enabled: true, providers: [] },
@@ -360,7 +330,7 @@ const fetchMetadata = [
                 },
                 providers: [],
             },
-            device: { state: 'device-state', metadata: { status: 'cancelled' } },
+            device: { state: 'device-state', metadata: { status: 'disabled' } },
             accounts: [],
         },
         params: 'device-state',
@@ -572,7 +542,6 @@ const init = [
             metadata: { enabled: false, providers: [], selectedProvider: {} },
             suite: { online: true },
         },
-        params: true,
         result: [
             { type: '@metadata/enable' },
             { type: '@metadata/set-initiating', payload: true },

--- a/packages/suite/src/actions/suite/__tests__/metadataActions.test.ts
+++ b/packages/suite/src/actions/suite/__tests__/metadataActions.test.ts
@@ -274,7 +274,7 @@ describe('Metadata Actions', () => {
             // @ts-expect-error
             const store = initStore(getInitialState(f.initialState));
             // @ts-expect-error, params
-            const result = await store.dispatch(metadataActions.init(f.params));
+            const result = await store.dispatch(metadataActions.init());
             if (!f.result) {
                 expect(store.getActions().length).toEqual(0);
             } else {

--- a/packages/suite/src/actions/suite/__tests__/metadataActions.test.ts
+++ b/packages/suite/src/actions/suite/__tests__/metadataActions.test.ts
@@ -1,5 +1,3 @@
-/* eslint-disable @typescript-eslint/no-var-requires */
-/* eslint-disable global-require */
 import fs from 'fs';
 import path from 'path';
 import { configureStore } from 'src/support/tests/configureStore';
@@ -122,8 +120,6 @@ const initStore = (state: State) => {
 describe('Metadata Actions', () => {
     fixtures.setDeviceMetadataKey.forEach(f => {
         it(`setDeviceMetadataKey - ${f.description}`, async () => {
-            // set fixtures in @trezor/connect
-            require('@trezor/connect').setTestFixtures(f.connect);
             // @ts-expect-error
             const store = initStore(getInitialState(f.initialState));
             await store.dispatch(metadataActions.setDeviceMetadataKey());

--- a/packages/suite/src/actions/suite/constants/metadataConstants.ts
+++ b/packages/suite/src/actions/suite/constants/metadataConstants.ts
@@ -1,4 +1,9 @@
-import { MetadataEncryptionVersion } from '@suite-common/metadata-types';
+import {
+    AccountLabels,
+    MetadataEncryptionVersion,
+    WalletLabels,
+} from '@suite-common/metadata-types';
+import { TrezorConnect } from '@trezor/connect';
 
 export const ENABLE = '@metadata/enable';
 export const DISABLE = '@metadata/disable';
@@ -13,8 +18,7 @@ export const SET_INITIATING = '@metadata/set-initiating';
 export const SET_DATA = '@metadata/set-data';
 export const SET_SELECTED_PROVIDER = '@metadata/set-selected-provider';
 
-// todo: use in metadataActions, currently migration is not implemented yet
-export const METADATA_VERSION = '2.0.0';
+export const METADATA_FORMAT_VERSION = '1.0.0';
 
 // @trezor/connect params
 export const ENABLE_LABELING_PATH = "m/10015'/0'";
@@ -39,4 +43,36 @@ export const GOOGLE_IMPLICIT_FLOW_CLIENT_ID =
 // dropbox allows authorization code flow for both web and desktop without client secret
 export const DROPBOX_CLIENT_ID = 'wg0yz2pbgjyhoda';
 
-export const ENCRYPTION_VERSION: MetadataEncryptionVersion = 1;
+export const ENCRYPTION_VERSION: MetadataEncryptionVersion = 2;
+
+export const ENCRYPTION_VERSION_CONFIGS: Record<
+    MetadataEncryptionVersion,
+    Parameters<TrezorConnect['cipherKeyValue']>[0]['bundle'][0]
+> = {
+    1: {
+        path: ENABLE_LABELING_PATH,
+        key: ENABLE_LABELING_KEY,
+        value: ENABLE_LABELING_VALUE,
+        encrypt: true,
+        askOnEncrypt: true,
+        askOnDecrypt: true,
+    },
+    2: {
+        path: ENABLE_LABELING_PATH,
+        key: ENABLE_LABELING_KEY,
+        value: ENABLE_LABELING_VALUE,
+        encrypt: true,
+        askOnEncrypt: false,
+        askOnDecrypt: false,
+    },
+};
+
+export const DEFAULT_ACCOUNT_METADATA: AccountLabels = {
+    accountLabel: '',
+    outputLabels: {},
+    addressLabels: {},
+};
+
+export const DEFAULT_WALLET_METADATA: WalletLabels = {
+    walletLabel: '',
+};

--- a/packages/suite/src/actions/suite/metadataActions.ts
+++ b/packages/suite/src/actions/suite/metadataActions.ts
@@ -670,7 +670,7 @@ export const addDeviceMetadata =
             data: nextMetadata,
         });
 
-        dispatch(
+        const isSaveSuccessful = dispatch(
             encryptAndSaveMetadata({
                 data: { walletLabel },
                 aesKey,
@@ -678,6 +678,8 @@ export const addDeviceMetadata =
                 provider,
             }),
         );
+
+        return isSaveSuccessful;
     };
 
 /**

--- a/packages/suite/src/actions/suite/metadataActions.ts
+++ b/packages/suite/src/actions/suite/metadataActions.ts
@@ -1,9 +1,9 @@
 import TrezorConnect from '@trezor/connect';
 import { analytics, EventType } from '@trezor/suite-analytics';
+import { createDeferred, promiseAllSequence } from '@trezor/utils';
 
-import { createDeferred } from '@trezor/utils';
 import { METADATA } from 'src/actions/suite/constants';
-import { Dispatch, GetState } from 'src/types/suite';
+import { Dispatch, GetState, TrezorDevice } from 'src/types/suite';
 import {
     MetadataProviderType,
     MetadataProvider,
@@ -15,6 +15,9 @@ import {
     ProviderErrorAction,
     Labels,
     DataType,
+    MetadataEncryptionVersion,
+    WalletLabels,
+    AccountLabels,
 } from 'src/types/suite/metadata';
 import { Account } from 'src/types/wallet';
 import * as metadataUtils from 'src/utils/suite/metadata';
@@ -26,6 +29,11 @@ import { selectSelectedProviderForLabels } from 'src/reducers/suite/metadataRedu
 
 import { createAction } from '@reduxjs/toolkit';
 import { notificationsActions } from '@suite-common/toast-notifications';
+import {
+    DEFAULT_ACCOUNT_METADATA,
+    DEFAULT_WALLET_METADATA,
+    METADATA_FORMAT_VERSION,
+} from './constants/metadataConstants';
 
 export const setAccountAdd = createAction(METADATA.ACCOUNT_ADD, (payload: Account) => ({
     payload,
@@ -105,6 +113,7 @@ export const disposeMetadata = (keys?: boolean) => (dispatch: Dispatch, getState
             provider,
             data: undefined,
         },
+        provider,
     });
 
     if (keys) {
@@ -276,10 +285,115 @@ export const initProvider = () => (dispatch: Dispatch) => {
     return decision.promise;
 };
 
+const setMetadata =
+    ({
+        provider,
+        fileName,
+        data,
+    }: {
+        provider: MetadataProvider;
+        fileName: string;
+        data: WalletLabels | AccountLabels | undefined;
+    }) =>
+    (dispatch: Dispatch) => {
+        dispatch({
+            type: METADATA.SET_DATA,
+            payload: {
+                provider,
+                data: {
+                    [fileName]: data,
+                },
+            },
+        });
+    };
+
+const getLabelableEntitities =
+    (deviceState: string) => (_dispatch: Dispatch, getState: GetState) => {
+        const { accounts } = getState().wallet;
+        const { devices } = getState();
+
+        return [
+            ...accounts
+                .filter(a => a.deviceState === deviceState)
+                .map(account => ({
+                    ...account.metadata,
+                    type: 'account' as const,
+                })),
+            ...devices
+                .filter(
+                    (device: TrezorDevice) =>
+                        device.metadata.status === 'enabled' && device.state === deviceState,
+                )
+                .map((device: TrezorDevice) => ({
+                    ...device.metadata,
+                    type: 'device' as const,
+                })),
+        ];
+    };
+
+type LabelableEntity = ReturnType<ReturnType<typeof getLabelableEntitities>>[number];
+
 export const fetchMetadata =
-    (deviceStateArg?: string) => async (dispatch: Dispatch, getState: GetState) => {
+    ({
+        provider,
+        entity,
+        encryptionVersion = METADATA.ENCRYPTION_VERSION,
+    }: {
+        deviceStateArg?: string;
+        provider: MetadataProvider;
+        entity: LabelableEntity;
+        encryptionVersion?: MetadataEncryptionVersion;
+    }) =>
+    async (dispatch: Dispatch) => {
+        const providerInstance = dispatch(
+            getProviderInstance({
+                clientId: provider.clientId,
+            }),
+        );
+
+        if (!providerInstance) {
+            throw new Error('no provider instance');
+        }
+
+        if (entity.type === 'device' && entity.status !== 'enabled') {
+            return;
+        }
+
+        const entityData = entity[encryptionVersion];
+        if (!entityData) {
+            return;
+        }
+
+        const { fileName, aesKey } = entityData;
+
+        const response = await providerInstance.getFileContent(fileName);
+
+        if (!response.success) {
+            throw new Error(response.error);
+        }
+
+        if (response.payload) {
+            // we found associated metadata file for given account, decrypt it
+            // and save its metadata into reducer;
+            const decryptedData = metadataUtils.decrypt(
+                metadataUtils.arrayBufferToBuffer(response.payload),
+                aesKey,
+            );
+
+            return {
+                fileName,
+                aesKey,
+                data: decryptedData,
+            };
+        }
+    };
+
+export const fetchAndSaveMetadata =
+    (deviceStateArg: string) => async (dispatch: Dispatch, getState: GetState) => {
         const provider = selectSelectedProviderForLabels(getState());
         if (!provider) return;
+
+        const labelabelEntities = dispatch(getLabelableEntitities(deviceStateArg));
 
         const providerInstance = dispatch(
             getProviderInstance({
@@ -298,6 +412,20 @@ export const fetchMetadata =
 
         const device = getState().devices.find(d => d.state === deviceState);
 
+        // this triggers renewal of access token if needed. Otherwise multiple requests
+        // to renew access token are issued by every provider.getFileContent
+        const response = await providerInstance.getProviderDetails();
+        if (!response.success) {
+            dispatch(
+                handleProviderError({
+                    error: response,
+                    action: ProviderErrorAction.LOAD,
+                    clientId: provider.clientId,
+                }),
+            );
+            return;
+        }
+
         // device is disconnected or something is wrong with it
         if (device?.metadata?.status !== 'enabled') {
             if (fetchIntervals[deviceState]) {
@@ -307,137 +435,19 @@ export const fetchMetadata =
             return;
         }
 
-        // this triggers renewal of access token if needed. Otherwise multiple requests
-        // to renew access token are issued by every provider.getFileContent
-        const response = await providerInstance.getProviderDetails();
-        if (!response.success) {
-            return dispatch(
-                handleProviderError({
-                    error: response,
-                    action: ProviderErrorAction.LOAD,
-                    clientId: provider.clientId,
-                }),
-            );
-        }
-
-        const deviceFileContentP = new Promise<void>((resolve, reject) => {
-            if (device?.metadata?.status !== 'enabled') {
-                return reject(new Error('metadata not enabled for this device'));
-            }
-            const { fileName, aesKey } = device.metadata[METADATA.ENCRYPTION_VERSION] || {};
-            if (!fileName || !aesKey) {
-                return reject(
-                    new Error(
-                        `filename or aesKey of version ${METADATA.ENCRYPTION_VERSION} does not exist for device ${device.path}`,
-                    ),
-                );
-            }
-            return providerInstance.getFileContent(fileName).then(result => {
-                // ts-stuff
-                if (device?.metadata?.status !== 'enabled') {
-                    // this should never happen
-                    return reject(new Error('metadata not enabled for this device'));
-                }
-
-                if (!result.success) {
-                    return reject(result);
-                }
-
-                const json = { walletLabel: '' };
-                if (result.payload) {
-                    try {
-                        const decryptedData = metadataUtils.decrypt(
-                            metadataUtils.arrayBufferToBuffer(result.payload),
-                            aesKey,
-                        );
-
-                        dispatch({
-                            type: METADATA.SET_DATA,
-                            payload: {
-                                provider,
-                                data: {
-                                    [fileName]: decryptedData,
-                                },
-                            },
-                        });
-                        Object.assign(json, decryptedData);
-                    } catch (err) {
-                        const error = providerInstance.error('OTHER_ERROR', err.message);
-                        return reject(error);
-                    }
-                }
-
-                resolve();
-            });
-        });
-
-        const accounts = getState().wallet.accounts.filter(
-            a => a.deviceState === deviceState && a.metadata[METADATA.ENCRYPTION_VERSION]?.fileName,
+        const promises = labelabelEntities.map(entity =>
+            dispatch(fetchMetadata({ deviceStateArg, provider, entity })),
         );
 
-        const accountPromises = accounts.map(async account => {
-            if (!provider) return; // ts
-            const { fileName, aesKey } = account.metadata[METADATA.ENCRYPTION_VERSION] || {};
-            if (!fileName || !aesKey) {
-                console.error(
-                    `filename or aesKey of version ${METADATA.ENCRYPTION_VERSION} does not exist for account ${account.path}`,
-                );
-                return;
-            }
-            const response = await providerInstance.getFileContent(fileName);
-
-            if (!response.success) {
-                throw new Error(response.error);
-            }
-
-            const json = { accountLabel: '', outputLabels: {}, addressLabels: {} };
-
-            if (response.payload) {
-                try {
-                    // we found associated metadata file for given account, decrypt it
-                    // and save its metadata into reducer;
-                    const decryptedData = metadataUtils.decrypt(
-                        metadataUtils.arrayBufferToBuffer(response.payload),
-                        aesKey,
-                    );
-
-                    Object.assign(json, decryptedData);
-
-                    dispatch({
-                        type: METADATA.SET_DATA,
-                        payload: {
-                            provider,
-                            data: {
-                                [fileName]: json,
-                            },
-                        },
-                    });
-                } catch (err) {
-                    console.error('error fetching labeling for account: ', account.path, err);
-                    const error = providerInstance.error('OTHER_ERROR', err.message);
-                    return dispatch(
-                        handleProviderError({
-                            error,
-                            action: ProviderErrorAction.LOAD,
-                            clientId: provider.clientId,
-                        }),
-                    );
-                }
-            }
-        });
-
-        const promises = [deviceFileContentP, ...accountPromises];
-
         try {
-            await Promise.all(promises);
-            // if interval for watching provider is not set, create it
-            if (!fetchIntervals[deviceState]) {
-                fetchIntervals[deviceState] = setInterval(() => {
-                    if (!getState().suite.online) {
-                        return;
-                    }
-                    dispatch(fetchMetadata(deviceState));
-                }, METADATA.FETCH_INTERVAL);
+            const result = await Promise.all(promises);
+
+            if (result) {
+                // todo: weird ts
+                result.forEach(record => {
+                    if (!record) return;
+                    dispatch(setMetadata({ ...record, provider }));
+                });
             }
         } catch (error) {
             // This handles cases of providers that do not support token renewal.
@@ -463,26 +473,31 @@ export const fetchMetadata =
     };
 
 export const setAccountMetadataKey =
-    (account: Account) => (dispatch: Dispatch, getState: GetState) => {
+    (account: Account, encryptionVersion = METADATA.ENCRYPTION_VERSION) =>
+    (dispatch: Dispatch, getState: GetState) => {
         const { devices } = getState();
         const device = devices.find(d => d.state === account.deviceState);
         if (!device || device.metadata.status !== 'enabled') {
             return account;
         }
 
+        const deviceMetaKey = device.metadata[encryptionVersion]?.key;
+
+        if (!deviceMetaKey) {
+            throw new Error('device meta key is missing');
+        }
         try {
-            const metaKey = metadataUtils.deriveMetadataKey(
-                device.metadata.key,
-                account.metadata.key,
-            );
-            const fileName = `${metadataUtils.deriveFilename(metaKey)}.mtdt`;
+            const metaKey = metadataUtils.deriveMetadataKey(deviceMetaKey, account.metadata.key);
+            const fileName = metadataUtils.deriveFilenameForLabeling(metaKey, encryptionVersion);
 
             const aesKey = metadataUtils.deriveAesKey(metaKey);
             return {
                 ...account,
                 metadata: {
                     ...account.metadata,
-                    [METADATA.ENCRYPTION_VERSION]: { fileName, aesKey },
+                    // I don't like that encryption version is not actually used to compute anything here directly,
+                    // its the "master key"
+                    [encryptionVersion]: { fileName, aesKey },
                 },
             };
         } catch (error) {
@@ -494,14 +509,16 @@ export const setAccountMetadataKey =
 /**
  * Fill any record in reducer that may have metadata with metadata keys (not values).
  */
-const syncMetadataKeys = () => (dispatch: Dispatch, getState: GetState) => {
-    getState().wallet.accounts.forEach(account => {
-        const accountWithMetadata = dispatch(setAccountMetadataKey(account));
-        dispatch(setAccountAdd(accountWithMetadata));
-    });
-    // note that devices are intentionally omitted here - device receives metadata
-    // keys sooner when enabling labeling on device;
-};
+const syncMetadataKeys =
+    (encryptionVersion = METADATA.ENCRYPTION_VERSION) =>
+    (dispatch: Dispatch, getState: GetState) => {
+        getState().wallet.accounts.forEach(account => {
+            const accountWithMetadata = dispatch(setAccountMetadataKey(account, encryptionVersion));
+            dispatch(setAccountAdd(accountWithMetadata));
+        });
+        // note that devices are intentionally omitted here - device receives metadata
+        // keys sooner when enabling labeling on device;
+    };
 
 export const selectProvider =
     ({ dataType, clientId }: { dataType: DataType; clientId: string }) =>
@@ -564,46 +581,19 @@ export const connectProvider =
         return true;
     };
 
-export const addDeviceMetadata =
-    (payload: Extract<MetadataAddPayload, { type: 'walletLabel' }>) =>
-    async (dispatch: Dispatch, getState: GetState) => {
-        const device = getState().devices.find(d => d.state === payload.deviceState);
-        const provider = selectSelectedProviderForLabels(getState());
-
-        if (!device || device.metadata.status !== 'enabled') return false;
-
-        if (!device || !provider) return false;
-
-        const { fileName, aesKey } = device.metadata[METADATA.ENCRYPTION_VERSION] || {};
-        if (!fileName || !aesKey) {
-            console.error('fileName or aesKey is missing for device', device.state);
-            return;
-        }
-        // todo: not danger overwrite empty?
-        const metadata = fileName ? provider.data[fileName] : undefined;
-
-        const nextMetadata = metadata
-            ? JSON.parse(JSON.stringify(metadata))
-            : {
-                  walletLabel: '',
-              };
-        const walletLabel =
-            typeof payload.value === 'string' && payload.value.length > 0
-                ? payload.value
-                : undefined;
-
-        nextMetadata.walletLabel = walletLabel;
-
-        dispatch({
-            type: METADATA.SET_DATA,
-            payload: {
-                provider,
-                data: {
-                    [fileName]: nextMetadata,
-                },
-            },
-        });
-
+const encryptAndSaveMetadata =
+    ({
+        data,
+        aesKey,
+        fileName,
+        provider,
+    }: {
+        data: AccountLabels | WalletLabels;
+        aesKey: string;
+        fileName: string;
+        provider: MetadataProvider;
+    }) =>
+    async (dispatch: Dispatch) => {
         const providerInstance = dispatch(getProviderInstance({ clientId: provider.clientId }));
 
         if (!providerInstance) {
@@ -614,11 +604,13 @@ export const addDeviceMetadata =
         try {
             const encrypted = await metadataUtils.encrypt(
                 {
-                    version: '1.0.0',
-                    walletLabel,
+                    version: METADATA_FORMAT_VERSION,
+                    ...data,
                 },
                 aesKey,
             );
+
+            // we started postfixing files
             const result = await providerInstance.setFileContent(fileName, encrypted);
             if (!result.success) {
                 dispatch(
@@ -643,6 +635,51 @@ export const addDeviceMetadata =
         }
     };
 
+export const addDeviceMetadata =
+    (payload: Extract<MetadataAddPayload, { type: 'walletLabel' }>) =>
+    (dispatch: Dispatch, getState: GetState) => {
+        const device = getState().devices.find(d => d.state === payload.deviceState);
+        const provider = selectSelectedProviderForLabels(getState());
+
+        if (!device || device.metadata.status !== 'enabled') return false;
+
+        if (!device || !provider) return false;
+
+        const { fileName, aesKey } = device.metadata[METADATA.ENCRYPTION_VERSION] || {};
+        if (!fileName || !aesKey) {
+            console.error('fileName or aesKey is missing for device', device.state);
+            return;
+        }
+
+        // todo: not danger overwrite empty?
+        const metadata = fileName ? provider.data[fileName] : undefined;
+
+        const nextMetadata = metadata
+            ? JSON.parse(JSON.stringify(metadata))
+            : DEFAULT_WALLET_METADATA;
+        const walletLabel =
+            typeof payload.value === 'string' && payload.value.length > 0
+                ? payload.value
+                : undefined;
+
+        nextMetadata.walletLabel = walletLabel;
+
+        setMetadata({
+            provider,
+            fileName,
+            data: nextMetadata,
+        });
+
+        dispatch(
+            encryptAndSaveMetadata({
+                data: { walletLabel },
+                aesKey,
+                fileName,
+                provider,
+            }),
+        );
+    };
+
 /**
  * @param payload - metadata payload
  * @param save - should metadata be saved into persistent storage? this is useful when you are updating multiple records
@@ -656,10 +693,10 @@ export const addAccountMetadata =
         if (!account || !provider) return false;
 
         // todo: not danger overwrite empty?
-        const fileName = account.metadata?.[METADATA.ENCRYPTION_VERSION]?.fileName;
+        const { fileName, aesKey } = account.metadata?.[METADATA.ENCRYPTION_VERSION] || {};
         const metadata = fileName ? provider.data[fileName] : undefined;
 
-        if (!fileName) {
+        if (!fileName || !aesKey) {
             throw new Error(
                 `filename of version ${METADATA.ENCRYPTION_VERSION} does not exist for account ${account.path}`,
             );
@@ -667,11 +704,7 @@ export const addAccountMetadata =
 
         const nextMetadata = metadata
             ? JSON.parse(JSON.stringify(metadata))
-            : {
-                  outputLabels: {},
-                  addressLabels: {},
-                  accountLabel: '',
-              };
+            : DEFAULT_ACCOUNT_METADATA;
 
         if (payload.type === 'outputLabel') {
             if (typeof payload.value !== 'string' || payload.value.length === 0) {
@@ -710,136 +743,289 @@ export const addAccountMetadata =
             }
         }
 
-        dispatch({
-            type: METADATA.SET_DATA,
-            payload: {
+        dispatch(
+            setMetadata({
+                fileName,
                 provider,
-                data: {
-                    [fileName]: nextMetadata,
-                },
-            },
-        });
+                data: nextMetadata,
+            }),
+        );
 
         // we might intentionally skip saving metadata content to persistent storage.
         if (!save) return true;
 
-        const providerInstance = await dispatch(
-            getProviderInstance({ clientId: provider.clientId }),
+        await dispatch(
+            encryptAndSaveMetadata({
+                data: {
+                    accountLabel: nextMetadata.accountLabel,
+                    outputLabels: nextMetadata.outputLabels,
+                    addressLabels: nextMetadata.addressLabels,
+                },
+                aesKey,
+                fileName,
+                provider,
+            }),
         );
-
-        if (!providerInstance) {
-            // provider should always be set here (see init)
-            return false;
-        }
-
-        // todo: can't this throw? heh?
-        const encrypted = await metadataUtils.encrypt(
-            {
-                version: '1.0.0',
-                accountLabel: nextMetadata.accountLabel,
-                outputLabels: nextMetadata.outputLabels,
-                addressLabels: nextMetadata.addressLabels,
-            },
-            account.metadata[METADATA.ENCRYPTION_VERSION]!.aesKey,
-        );
-
-        const result = await providerInstance.setFileContent(
-            account.metadata[METADATA.ENCRYPTION_VERSION]!.fileName,
-            encrypted,
-        );
-        if (!result.success) {
-            dispatch(
-                handleProviderError({
-                    error: result,
-                    action: ProviderErrorAction.SAVE,
-                    clientId: provider.clientId,
-                }),
-            );
-            return false;
-        }
         return true;
     };
 
 /**
  * Generate device master-key
  * */
-export const setDeviceMetadataKey = () => async (dispatch: Dispatch, getState: GetState) => {
-    if (!getState().metadata.enabled) return;
-    const { device } = getState().suite;
-    if (!device || !device.state || !device.connected) return;
+export const setDeviceMetadataKey =
+    (encryptionVersion = METADATA.ENCRYPTION_VERSION) =>
+    async (dispatch: Dispatch, getState: GetState) => {
+        if (!getState().metadata.enabled) return;
 
-    // master key already exists
-    if (device.metadata.status === 'enabled') return;
+        const { device } = getState().suite;
+        if (!device || !device.state || !device.connected) return;
 
-    const result = await TrezorConnect.cipherKeyValue({
-        device: {
-            path: device.path,
-            state: device.state,
-            instance: device.instance,
-        },
-        useEmptyPassphrase: device.useEmptyPassphrase,
-        path: METADATA.ENABLE_LABELING_PATH,
-        key: METADATA.ENABLE_LABELING_KEY,
-        value: METADATA.ENABLE_LABELING_VALUE,
-        encrypt: true,
-        askOnEncrypt: true,
-        askOnDecrypt: true,
-    });
+        const result = await TrezorConnect.cipherKeyValue({
+            device: {
+                path: device.path,
+                state: device.state,
+                instance: device.instance,
+            },
+            useEmptyPassphrase: device.useEmptyPassphrase,
+            ...METADATA.ENCRYPTION_VERSION_CONFIGS[encryptionVersion],
+        });
 
-    if (result.success) {
-        if (!getState().metadata.enabled) {
+        if (result.success) {
+            if (!getState().metadata.enabled) {
+                dispatch({
+                    type: METADATA.ENABLE,
+                });
+            }
+
+            const [stateAddress] = device.state.split('@'); // address@device_id:instance
+            const metaKey = metadataUtils.deriveMetadataKey(result.payload.value, stateAddress);
+            const fileName = `${metadataUtils.deriveFilenameForLabeling(
+                metaKey,
+                encryptionVersion,
+            )}`;
+            const aesKey = metadataUtils.deriveAesKey(metaKey);
+
             dispatch({
-                type: METADATA.ENABLE,
+                type: METADATA.SET_DEVICE_METADATA,
+                payload: {
+                    deviceState: device.state,
+                    metadata: {
+                        ...device.metadata,
+                        status: 'enabled',
+                        [encryptionVersion]: {
+                            fileName,
+                            aesKey,
+                            key: result.payload.value,
+                        },
+                    },
+                },
+            });
+        } else {
+            dispatch({
+                type: METADATA.SET_DEVICE_METADATA,
+                payload: {
+                    deviceState: device.state,
+                    metadata: {
+                        status: 'cancelled',
+                    },
+                },
+            });
+
+            // in effort to resolve https://github.com/trezor/trezor-suite/issues/2315
+            // also turn of global metadata.enabled setting
+            // pros:
+            // - user without saved device is not bothered with labeling when reloading page
+            // cons:
+            // - it makes concept device.metadata.status "cancelled" useless
+            // - new device will not be prompted with metadata when connected so even when there is
+            //   existing metadata for this device, user will not see it until he clicks "add label" button
+            dispatch({
+                type: METADATA.DISABLE,
             });
         }
-
-        const [stateAddress] = device.state.split('@'); // address@device_id:instance
-        const metaKey = metadataUtils.deriveMetadataKey(result.payload.value, stateAddress);
-        const fileName = metadataUtils.deriveFilename(metaKey);
-        const aesKey = metadataUtils.deriveAesKey(metaKey);
-
-        dispatch({
-            type: METADATA.SET_DEVICE_METADATA,
-            payload: {
-                deviceState: device.state,
-                metadata: {
-                    ...device.metadata,
-                    status: 'enabled',
-                    key: result.payload.value,
-                    [METADATA.ENCRYPTION_VERSION]: { fileName, aesKey },
-                },
-            },
-        });
-    } else {
-        dispatch({
-            type: METADATA.SET_DEVICE_METADATA,
-            payload: {
-                deviceState: device.state,
-                metadata: {
-                    status: 'cancelled',
-                },
-            },
-        });
-
-        // in effort to resolve https://github.com/trezor/trezor-suite/issues/2315
-        // also turn of global metadata.enabled setting
-        // pros:
-        // - user without saved device is not bothered with labeling when reloading page
-        // cons:
-        // - it makes concept device.metadata.status "cancelled" useless
-        // - new device will not be prompted with metadata when connected so even when there is
-        //   existing metadata for this device, user will not see it until he clicks "add label" button
-        dispatch({
-            type: METADATA.DISABLE,
-        });
-    }
-};
+    };
 
 export const addMetadata = (payload: MetadataAddPayload) => (dispatch: Dispatch) => {
     if (payload.type === 'walletLabel') {
         return dispatch(addDeviceMetadata(payload));
     }
     return dispatch(addAccountMetadata(payload));
+};
+
+const getEntitiesWithoutFileInProvider =
+    (deviceState: string, files: string[]) => (dispatch: Dispatch) => {
+        const allEntitites = dispatch(getLabelableEntitities(deviceState));
+        const needMigration = allEntitites.filter(
+            entity =>
+                !files.find(
+                    // @ts-expect-error. todo: maybe add some type guard
+                    file => file === entity[METADATA.ENCRYPTION_VERSION].fileName,
+                ),
+        );
+
+        return needMigration;
+    };
+
+const getFilesToMigrate =
+    () =>
+    async (dispatch: Dispatch, getState: GetState): Promise<string[] | undefined> => {
+        const provider = selectSelectedProviderForLabels(getState());
+        if (!provider) {
+            return;
+        }
+
+        const providerInstance = dispatch(
+            getProviderInstance({
+                clientId: getState().metadata.providers[0].clientId,
+            }),
+        );
+
+        // fetch list of all files saved withing currently selected provider for labeling
+        const files = await providerInstance!.getFilesList().then(response => {
+            if (!response.success) {
+                dispatch(
+                    handleProviderError({
+                        error: response,
+                        action: ProviderErrorAction.LOAD,
+                        clientId: provider.clientId,
+                    }),
+                );
+                return;
+            }
+            //   imho [] should be default return, it should not be also nullable
+            return response?.payload || [];
+        });
+
+        // no files, fresh account, no metadata encryption version migration needed
+        if (!files?.length) {
+            return;
+        }
+
+        // all files are already migrated to latest version
+        if (files.every(file => file.endsWith(`_v${METADATA.ENCRYPTION_VERSION}`))) {
+            return;
+        }
+
+        const { device } = getState().suite;
+        if (!device?.state || device.metadata.status !== 'enabled') {
+            console.error('metadata migration: device unexpected state'); // or throw, or error? i never know
+            return;
+        }
+        // gather all labelable enetitites from state
+        const needMigration = dispatch(getEntitiesWithoutFileInProvider(device.state, files));
+
+        // each labelable entitity has file created for the latest version of encryption. no migration needed
+        if (!needMigration.length) {
+            return;
+        }
+
+        return files;
+    };
+
+const migrateEntity =
+    (entity: LabelableEntity, prevEncryptionVersion: MetadataEncryptionVersion) =>
+    async (dispatch: Dispatch, getState: GetState) => {
+        const { device } = getState().suite;
+        if (!device?.state || device.metadata.status !== 'enabled') {
+            console.error('metadata migration: device unexpected state'); // or throw, or error? i never know
+            return;
+        }
+
+        try {
+            const result = await dispatch(
+                fetchMetadata({
+                    deviceStateArg: device.state,
+                    entity,
+                    encryptionVersion: prevEncryptionVersion,
+                    provider: getState().metadata.providers[0],
+                }),
+            );
+
+            if (entity.type === 'device' && entity.status !== 'enabled') {
+                console.error('meetadata migration: unexpected entity');
+                return; // ts. should not happen
+            }
+
+            const nextKeys = entity[METADATA.ENCRYPTION_VERSION];
+            if (!nextKeys) {
+                console.error('metadata migration: next keys are missing');
+                return; // should never happen
+            }
+
+            const defaultEntityData =
+                entity.type === 'account' ? DEFAULT_ACCOUNT_METADATA : DEFAULT_WALLET_METADATA;
+            const nextData = result?.data ? result.data : defaultEntityData;
+
+            dispatch(
+                setMetadata({
+                    ...nextKeys,
+                    data: nextData,
+                    provider: getState().metadata.providers[0]!,
+                }),
+            );
+
+            dispatch(
+                encryptAndSaveMetadata({
+                    ...nextKeys,
+                    data: nextData,
+                    provider: getState().metadata.providers[0]!,
+                }),
+            );
+        } catch (err) {
+            console.error('metadata migration failed');
+        }
+    };
+
+/**
+ * Check whether encryption version migration is needed and execute it
+ */
+const handleEncryptionVersionMigration = () => async (dispatch: Dispatch, getState: GetState) => {
+    const filesToMigrate = await dispatch(getFilesToMigrate());
+
+    if (!filesToMigrate?.length) {
+        return;
+    }
+
+    // migration is needed :( steps:
+    // 1. select lower encryption version
+    const prevEncryptionVersion = (METADATA.ENCRYPTION_VERSION - 1) as MetadataEncryptionVersion;
+
+    if (prevEncryptionVersion < 1) {
+        console.error(`metadata migration: can not migrate to version ${prevEncryptionVersion}!!!`);
+        return;
+    }
+
+    // 2. sync metadata keys
+    const { device } = getState().suite;
+    if (!device?.state || device.metadata.status !== 'enabled') {
+        console.error('metadata migration: device unexpected state'); // or throw, or error? i never know
+        return;
+    }
+
+    if (!device.metadata[prevEncryptionVersion]) {
+        await dispatch(setDeviceMetadataKey(prevEncryptionVersion));
+    }
+
+    dispatch(syncMetadataKeys(prevEncryptionVersion));
+
+    // 3. gather labelable entities with already updated keys
+    const needMigration = dispatch(getEntitiesWithoutFileInProvider(device.state, filesToMigrate));
+
+    // 4. for each entity
+    //   - fetch metadata associated with lower encryption version filenames
+    //   - save fetched metadata to local state using new keys
+    //   - save fetched metadata to provider using new keys
+    const migrationPromises = needMigration.map(
+        entity => () => dispatch(migrateEntity(entity, prevEncryptionVersion)),
+    );
+
+    // NOTE: I understand that this is not the right layer to rate limit access to provider API. It should be handled in provider service itself but
+    // I don't have free hands to do it now. So I am running all requests in series as a workaround now. Correct solution would be
+    // implementing provider.batchWrite and do batching if possible and if not, use single requests with some rate limiting
+
+    // NOTE2: If application exits in the process of running this, no hardship should happen. Migration will be left unfinished meaning that it will
+    // prompt user next time again for the remaining 'labelableEntitites'
+    await promiseAllSequence(migrationPromises);
 };
 
 /**
@@ -865,13 +1051,14 @@ export const init =
             return false;
         }
 
+        dispatch({ type: METADATA.SET_INITIATING, payload: true });
+
         // 2. set device metadata key (master key). Sometimes, if state is not present
         if (
             device.metadata.status === 'disabled' ||
             (device.metadata.status === 'cancelled' && force && device?.connected)
         ) {
-            dispatch({ type: METADATA.SET_INITIATING, payload: true });
-            await dispatch(setDeviceMetadataKey());
+            await dispatch(setDeviceMetadataKey(METADATA.ENCRYPTION_VERSION));
         }
 
         // did user confirm labeling on device? or maybe device was not connected
@@ -883,10 +1070,9 @@ export const init =
 
             return false;
         }
-
         // if yes, add metadata keys to accounts
         if (getState().metadata.initiating) {
-            dispatch(syncMetadataKeys());
+            dispatch(syncMetadataKeys(METADATA.ENCRYPTION_VERSION));
         }
 
         // 3. connect to provider
@@ -894,10 +1080,6 @@ export const init =
             getState().suite.device?.metadata.status === 'enabled' &&
             !getState().metadata.providers?.length
         ) {
-            if (!getState().metadata.initiating) {
-                dispatch({ type: METADATA.SET_INITIATING, payload: true });
-            }
-
             const providerResult = await dispatch(initProvider());
             if (!providerResult) {
                 dispatch({ type: METADATA.SET_INITIATING, payload: false });
@@ -907,9 +1089,23 @@ export const init =
             }
         }
 
+        // 4. migration
+        await dispatch(handleEncryptionVersionMigration());
+        // 5. fetch metadata
+        await dispatch(fetchAndSaveMetadata(device.state));
         if (getState().metadata.initiating) {
-            await dispatch(fetchMetadata(device.state));
             dispatch({ type: METADATA.SET_INITIATING, payload: false });
+        }
+
+        // 6. if interval for watching provider is not set, create it
+        if (device.state && !fetchIntervals[device.state]) {
+            fetchIntervals[device.state] = setInterval(() => {
+                const { device } = getState().suite;
+                if (!getState().suite.online || !device?.state) {
+                    return;
+                }
+                dispatch(fetchAndSaveMetadata(device.state));
+            }, METADATA.FETCH_INTERVAL);
         }
 
         return true;

--- a/packages/suite/src/actions/wallet/discoveryActions.ts
+++ b/packages/suite/src/actions/wallet/discoveryActions.ts
@@ -457,7 +457,7 @@ export const start =
             // if previous discovery status was running (typically after application start or when user added a new account)
             // trigger fetch metadata; necessary to load account labels
             if (discovery.status === DiscoveryStatus.RUNNING) {
-                dispatch(metadataActions.fetchMetadata(deviceState));
+                await dispatch(metadataActions.init());
             }
 
             dispatch(

--- a/packages/suite/src/actions/wallet/discoveryActions.ts
+++ b/packages/suite/src/actions/wallet/discoveryActions.ts
@@ -456,8 +456,8 @@ export const start =
 
             // if previous discovery status was running (typically after application start or when user added a new account)
             // trigger fetch metadata; necessary to load account labels
-            if (discovery.status === DiscoveryStatus.RUNNING) {
-                await dispatch(metadataActions.init());
+            if (discovery.status === DiscoveryStatus.RUNNING && device.state) {
+                await dispatch(metadataActions.fetchAndSaveMetadata(device.state));
             }
 
             dispatch(

--- a/packages/suite/src/components/suite/Labeling/components/Metadata/MetadataLabeling.tsx
+++ b/packages/suite/src/components/suite/Labeling/components/Metadata/MetadataLabeling.tsx
@@ -248,7 +248,7 @@ export const MetadataLabeling = (props: Props) => {
             !isLabelingAvailable
         ) {
             // provide force=true argument (user wants to enable metadata)
-            init(true);
+            init();
         }
         setEditing(props.payload.defaultValue);
     };

--- a/packages/suite/src/middlewares/suite/metadataMiddleware.ts
+++ b/packages/suite/src/middlewares/suite/metadataMiddleware.ts
@@ -22,6 +22,7 @@ const metadata =
                     api.getState().metadata.enabled &&
                     action.payload.metadata.status === 'disabled'
                 ) {
+                    console.debug('metadata init discovery middleware');
                     api.dispatch(metadataActions.init());
                 }
                 break;

--- a/packages/suite/src/reducers/suite/metadataReducer.ts
+++ b/packages/suite/src/reducers/suite/metadataReducer.ts
@@ -7,6 +7,10 @@ import { Action, TrezorDevice } from 'src/types/suite';
 import { MetadataState, WalletLabels, AccountLabels } from 'src/types/suite/metadata';
 import { selectDevice, SuiteRootState } from 'src/reducers/suite/suiteReducer';
 import { Account } from 'src/types/wallet';
+import {
+    DEFAULT_ACCOUNT_METADATA,
+    DEFAULT_WALLET_METADATA,
+} from 'src/actions/suite/constants/metadataConstants';
 
 export const initialState: MetadataState = {
     // is Suite trying to load metadata (get master key -> sync cloud)?
@@ -16,16 +20,6 @@ export const initialState: MetadataState = {
     selectedProvider: {
         labels: '',
     },
-};
-
-const initialAccountLabels: AccountLabels = {
-    addressLabels: {},
-    outputLabels: {},
-    accountLabel: '',
-};
-
-const initialWalletLabels: WalletLabels = {
-    walletLabel: '',
 };
 
 type MetadataRootState = {
@@ -99,7 +93,7 @@ export const selectLabelingDataForSelectedAccount = (state: {
 
     const metadataKeys = selectedAccount?.account?.metadata[METADATA.ENCRYPTION_VERSION];
     if (!metadataKeys || !metadataKeys.fileName || !provider?.data[metadataKeys.fileName]) {
-        return initialAccountLabels;
+        return DEFAULT_ACCOUNT_METADATA;
     }
 
     return provider.data[metadataKeys.fileName] as AccountLabels;
@@ -117,7 +111,7 @@ export const selectLabelingDataForAccount = (
     const metadataKeys = account?.metadata?.[METADATA.ENCRYPTION_VERSION];
 
     if (!metadataKeys || !metadataKeys?.fileName || !provider?.data[metadataKeys.fileName]) {
-        return initialAccountLabels;
+        return DEFAULT_ACCOUNT_METADATA;
     }
 
     return provider.data[metadataKeys.fileName] as AccountLabels;
@@ -133,14 +127,14 @@ export const selectLabelingDataForWallet = (
     const provider = selectSelectedProviderForLabels(state);
     const device = state.devices.find(d => d.state === deviceState);
     if (device?.metadata.status !== 'enabled') {
-        return initialWalletLabels;
+        return DEFAULT_WALLET_METADATA;
     }
     const metadataKeys = device?.metadata[METADATA.ENCRYPTION_VERSION];
 
     if (metadataKeys && metadataKeys.fileName && provider?.data[metadataKeys.fileName]) {
         return provider.data[metadataKeys.fileName] as WalletLabels;
     }
-    return initialWalletLabels;
+    return DEFAULT_WALLET_METADATA;
 };
 
 // is everything ready (more or less) to add label?

--- a/packages/suite/src/storage/migrations/index.ts
+++ b/packages/suite/src/storage/migrations/index.ts
@@ -605,9 +605,10 @@ export const migrate: OnUpgradeFunc<SuiteDBSchema> = async (
                 device.metadata.aesKey
             ) {
                 device.metadata = {
-                    key: device.metadata.key,
                     status: device.metadata.status,
                     1: {
+                        // @ts-expect-error
+                        key: device.metadata.key,
                         // @ts-expect-error
                         fileName: device.metadata.fileName,
                         // @ts-expect-error

--- a/packages/suite/src/utils/suite/metadata.ts
+++ b/packages/suite/src/utils/suite/metadata.ts
@@ -40,6 +40,14 @@ export const deriveFilename = (metadataKey: string) => {
     return firstHalf.toString('hex');
 };
 
+export const deriveFilenameForLabeling = (metaKey: string, encryptionVersion: number) => {
+    const name = deriveFilename(metaKey);
+    // postfixes were added with version 2
+    const postfix = encryptionVersion > 1 ? `_v${encryptionVersion}` : '';
+    const extension = '.mtdt';
+    return `${name}${postfix}${extension}`;
+};
+
 const getRandomIv = (): Promise<Buffer> =>
     new Promise((resolve, reject) => {
         try {

--- a/packages/suite/src/views/settings/general/ConnectLabelingProvider.tsx
+++ b/packages/suite/src/views/settings/general/ConnectLabelingProvider.tsx
@@ -24,7 +24,7 @@ export const ConnectLabelingProvider = () => {
             <ActionColumn>
                 <ActionButton
                     variant="secondary"
-                    onClick={() => dispatch(metadataActions.init(true))}
+                    onClick={() => dispatch(metadataActions.init())}
                     data-test="@settings/metadata/connect-provider-button"
                 >
                     <Translation id="TR_CONNECT" />

--- a/packages/suite/src/views/settings/general/Labeling.tsx
+++ b/packages/suite/src/views/settings/general/Labeling.tsx
@@ -20,7 +20,7 @@ export const Labeling = () => {
         if (metadata.enabled) {
             dispatch(metadataActions.disableMetadata());
         } else {
-            dispatch(metadataActions.init(true));
+            dispatch(metadataActions.init());
         }
 
         analytics.report({

--- a/suite-common/metadata-types/src/metadataTypes.ts
+++ b/suite-common/metadata-types/src/metadataTypes.ts
@@ -161,7 +161,7 @@ export type Labels = AccountLabels | WalletLabels;
 
 export type DeviceMetadata =
     | {
-          status: 'disabled' | 'cancelled'; // user rejects "Enable labeling" on device
+          status: 'disabled';
       }
     | ({
           status: 'enabled';

--- a/suite-common/metadata-types/src/metadataTypes.ts
+++ b/suite-common/metadata-types/src/metadataTypes.ts
@@ -3,11 +3,17 @@ export interface LabelableEntityKeys {
     aesKey: string; // symmetric key for file encryption
 }
 
-export type LabelableEntityKeysByVersion = {
+export type DeviceEntityKeys = {
+    [Version in MetadataEncryptionVersion]?: LabelableEntityKeys & { key: string };
+};
+
+export type AccountEntityKeys = {
     [Version in MetadataEncryptionVersion]?: LabelableEntityKeys;
 } & {
     key: string; // legacy xpub format (btc-like coins) or account descriptor (other coins)
 };
+
+export type LabelableEntityKeysByVersion = DeviceEntityKeys | AccountEntityKeys;
 
 export type MetadataAddPayload =
     | {
@@ -159,7 +165,7 @@ export type DeviceMetadata =
       }
     | ({
           status: 'enabled';
-      } & LabelableEntityKeysByVersion);
+      } & DeviceEntityKeys);
 
 type Data = Record<
     LabelableEntityKeys['fileName'], // unique "id" for mapping with labelable entitties

--- a/suite-common/wallet-types/src/account.ts
+++ b/suite-common/wallet-types/src/account.ts
@@ -1,5 +1,5 @@
 import { Network, BackendType, NetworkSymbol } from '@suite-common/wallet-config';
-import { LabelableEntityKeysByVersion } from '@suite-common/metadata-types';
+import { AccountEntityKeys } from '@suite-common/metadata-types';
 import { AccountInfo, PROTO, TokenInfo } from '@trezor/connect';
 
 export type MetadataItem = string;
@@ -79,7 +79,7 @@ export type Account = {
     addresses?: AccountInfo['addresses'];
     utxo: AccountInfo['utxo'];
     history: AccountInfo['history'];
-    metadata: LabelableEntityKeysByVersion;
+    metadata: AccountEntityKeys;
     /**
      * accountLabel was introduced by mobile app. In early stage of developement, it was not possible to connect device and work with
      * metadata/labeling feature which requires device for encryption. local accountLabel field was introduced.


### PR DESCRIPTION
Based on #8646  which is a PR that introduces changes to metadata data model in reducers. That PR is basically ready to be merged but as it does not bring any new features I am hesitant to do it. Also I dont want to bloat it with more changes so I decided to build on it instead. I am also stealing some ideas from https://github.com/trezor/trezor-suite/pull/8567

### Commits
- 1st commit - is basically fixup for #8646 I realized that `device.metadata.key` should also be versioned as it determines `account.metadata.aesKey` and `account.metadata.fileName`. This fixup is incomplete, there are also some changes in the second commit that should go here.
- 2nd commit -implements metadata migration and resolves #6304 
- 3rd commit does not exist yet. I would definitely add at least e2e test from here https://github.com/trezor/trezor-suite/pull/8567 and whatevere else might be useful

### Todos: 
- [ ] unit tests
- [x] e2e tests
- [x] couple of todos and areas for improvements

### How does it work
1.  user tries to add a label, initation process kicks in as usual
2. once data provider is connected and metadata keys (for the latest encryption version) are derived we fetch list of all files from data provider
3. if all labelable entities (currently discovered) have associated file in what we fetchted in 2 no further action is needed
4. else we separate labelable entities that don't have their counterpart in dataprovider and derive legacy keys for them
5. then we fetch legacy files from data provider
6. we decrypt legacy files using legacy keys, load them into application memory and encrypt them using new keys and upload them to data provider. 
7. if there was no legacy file match in 5, we create dummy files and upload them as well. this ensures that next time metadata is initiated, we are likely to be able to stop at point 3 (unless user created a new account in the meantime somewhere else)

### Testing tips
1. create an empty account on dropbox
8. go to https://suite.trezor.io/web
9. create some labels
10. open build of this branch 
11. enable labeling
12. labels should be there
13. forget device, enable labeling again. you should not be prompted on device. labels should still be there

### Drawbacks
- we can not migrate all labels at once because we simply can't be sure we know them. Labels are bound to 'labelable entities' which are now accounts and wallets. So whenever user adds a labelable entity, we must run "metadata discovery" including migration if needed. So it is very well possible that user might migrate his data on day, they might be using suite without "enable labeling prompt" for years, and then, after adding some long unused passphrase or account, user will need to confirm labeling on device again.
- possibility of mismatch between versions of suite. after this is release user opens updated version of suite, migrates data, then opens outdated version of suite and works with labeling. Under current implementation labels added in the outdated version will be lost.