### PR TITLE
fix(suite): dry run modal width

### DIFF
--- a/packages/suite/src/components/suite/modals/WordAdvanced.tsx
+++ b/packages/suite/src/components/suite/modals/WordAdvanced.tsx
@@ -23,10 +23,6 @@ const BottomText = styled.div`
     margin-top: 20px;
 `;
 
-const StyledModal = styled(Modal)`
-    width: 100%;
-`;
-
 interface WordAdvancedProps extends ModalProps {
     count: 6 | 9;
 }
@@ -35,7 +31,7 @@ export const WordAdvanced = ({ count, ...rest }: WordAdvancedProps) => {
     const intl = useIntl();
 
     return (
-        <StyledModal
+        <Modal
             heading={<Translation id="TR_FOLLOW_INSTRUCTIONS_ON_DEVICE" />}
             description={<Translation id="TR_ADVANCED_RECOVERY_TEXT" />}
             onCancel={() => TrezorConnect.cancel(intl.formatMessage(messages.TR_CANCELLED))}
@@ -55,6 +51,6 @@ export const WordAdvanced = ({ count, ...rest }: WordAdvancedProps) => {
                     </P>
                 </BottomText>
             </ContentWrapper>
-        </StyledModal>
+        </Modal>
     );
 };


### PR DESCRIPTION
Fixed modal width from full width to content width

## Description

Removed `width: 100%` from the modal style.

## Related Issue

Resolve #8760 

## Screenshots:

<img width="1443" alt="Screenshot 2023-06-28 at 8 08 12 PM" src="https://github.com/trezor/trezor-suite/assets/66002635/41fdcd55-f54c-4a3b-ab16-411e146ea459">