### PR TITLE
fix(coinjoin): ignore WitnessAlreadyProvided error when sending tx signature

### DIFF
--- a/packages/coinjoin/src/constants.ts
+++ b/packages/coinjoin/src/constants.ts
@@ -19,6 +19,12 @@ export const STATUS_TIMEOUT = {
 // we are expecting phase to change but server didn't propagate it yet
 export const ROUND_REGISTRATION_END_OFFSET = 2000;
 
+// following https://github.com/zkSNACKs/WalletWasabi/blob/913b16953a965eb922e0ae02a0f71a991a7b9bb7/WalletWasabi/WabiSabi/Client/CoinJoinClient.cs#L31-L34
+// Maximum delay when spreading the requests in time, except input registration requests which
+// timings only depends on the input-reg timeout and signing requests which timings must be larger.
+// This is a maximum cap the delay can be zero if the remaining time is less.
+export const ROUND_MAXIMUM_REQUEST_DELAY = 10000;
+
 // do not register into Round if round.inputRegistrationEnd is below offset
 export const ROUND_SELECTION_REGISTRATION_OFFSET = 30000;
 

--- a/packages/coinjoin/tests/client/transactionSigning.test.ts
+++ b/packages/coinjoin/tests/client/transactionSigning.test.ts
@@ -3,20 +3,32 @@ import { networks } from '@trezor/utxo-lib';
 import { transactionSigning } from '../../src/client/round/transactionSigning';
 import { createServer } from '../mocks/server';
 import { createInput } from '../fixtures/input.fixture';
-import { ROUND_CREATION_EVENT } from '../fixtures/round.fixture';
+import { createCoinjoinRound } from '../fixtures/round.fixture';
 
-let server: Awaited<ReturnType<typeof createServer>>;
-
-const COINJOIN_REQUEST = {
-    fee_rate: 300000,
-    min_registrable_amount: 5000,
-    no_fee_threshold: 1000000,
-    coinjoin_flags_array: [0, 0],
-    mask_public_key: '0'.repeat(33 * 2),
-    signature: '0'.repeat(64 * 2),
-};
+// mock random delay function
+jest.mock('@trezor/utils', () => {
+    const originalModule = jest.requireActual('@trezor/utils');
+    return {
+        __esModule: true,
+        ...originalModule,
+        getRandomNumberInRange: () => 0,
+    };
+});
 
 describe('transactionSigning', () => {
+    let server: Awaited<ReturnType<typeof createServer>>;
+
+    const COINJOIN_REQUEST = {
+        fee_rate: 300000,
+        min_registrable_amount: 5000,
+        no_fee_threshold: 1000000,
+        coinjoin_flags_array: [0, 0],
+        mask_public_key: '0'.repeat(33 * 2),
+        signature: '0'.repeat(64 * 2),
+    };
+
+    const affiliateRequest = Buffer.from('0'.repeat(97 * 2 + 4), 'hex').toString('base64');
+
     beforeAll(async () => {
         server = await createServer();
     });
@@ -29,7 +41,7 @@ describe('transactionSigning', () => {
         server?.close();
     });
 
-    it('affiliate-request and update-liquidity-clue', async () => {
+    it('getTransactionData: read affiliate-request and update-liquidity-clue', async () => {
         server?.addListener('test-request', ({ url, data, resolve }) => {
             if (url.endsWith('/update-liquidity-clue')) {
                 resolve({ rawLiquidityClue: data.externalAmounts[0] });
@@ -38,11 +50,8 @@ describe('transactionSigning', () => {
         });
 
         const response = await transactionSigning(
-            {
-                affiliateRequest: Buffer.from('0'.repeat(97 * 2 + 4), 'hex').toString('base64'),
-                id: '01',
-                phase: 3,
-                inputs: [
+            createCoinjoinRound(
+                [
                     createInput(
                         'account-A',
                         '1b5b1feea4dfed4253db5f639011a744a337b25a67975310439233bd8a1dc49f00000000',
@@ -52,63 +61,84 @@ describe('transactionSigning', () => {
                         '1b5b1feea4dfed4253db5f639011a744a337b25a67975310439233bd8a1dc49f00000000',
                     ),
                 ],
-                addresses: [
-                    {
-                        path: "m/10025'/1'/0'/0'/1/0",
-                        scriptPubKey:
-                            '1 b67b77a4cac9a32c463e5bbe0c6cbfbab3c86cb59518e5661766056e6a7e849c',
-                    },
-                ],
-                roundParameters: {
-                    ...ROUND_CREATION_EVENT.roundParameters,
-                },
-                coinjoinState: {
-                    // test vectors from connect signTransactionPaymentRequest
-                    events: [
-                        {
-                            Type: 'InputAdded',
-                            coin: {
-                                outpoint:
-                                    '1B5B1FEEA4DFED4253DB5F639011A744A337B25A67975310439233BD8A1DC49F00000000',
-                                txOut: {
-                                    scriptPubKey:
-                                        '1 6a6daebd9abae25cdd376b811190163eb00c58e87da1867ba8546229098231c3',
-                                    value: 12300000,
-                                },
-                            },
-                        },
-                        {
-                            Type: 'InputAdded',
-                            coin: {
-                                outpoint:
-                                    '1B5B1FEEA4DFED4253DB5F639011A744A337B25A67975310439233BD8A1DC49F00000000',
-                                txOut: {
-                                    scriptPubKey:
-                                        '1 6a6daebd9abae25cdd376b811190163eb00c58e87da1867ba8546229098231c3',
-                                    value: 12300000,
-                                },
-                            },
-                        },
-                        {
-                            Type: 'OutputAdded',
-                            output: {
-                                scriptPubKey:
-                                    '1 b899b1962f24757bf8f641d125a88944d1541272cc86da7815ff7899e368b2d4',
-                                value: 2000000,
-                            },
-                        },
-                        {
-                            Type: 'OutputAdded',
-                            output: {
+                {
+                    ...server?.requestOptions,
+                    round: {
+                        phase: 3,
+                        affiliateRequest,
+                        addresses: [
+                            {
+                                accountKey: 'account-A',
+                                path: "m/10025'/0'/0'/0'/1/0",
+                                address:
+                                    'bc1pkeah0fx2ex3jc337twlqcm9lh2eusm94j5vw2eshvczku6n7sjwqrfyfj2',
                                 scriptPubKey:
                                     '1 b67b77a4cac9a32c463e5bbe0c6cbfbab3c86cb59518e5661766056e6a7e849c',
-                                value: 12300000 - 5000000 - 2000000 - 11000,
                             },
+                        ],
+                        coinjoinState: {
+                            Type: '',
+                            events: [
+                                {
+                                    Type: 'InputAdded',
+                                    coin: {
+                                        outpoint:
+                                            '1B5B1FEEA4DFED4253DB5F639011A744A337B25A67975310439233BD8A1DC49F00000000',
+                                        txOut: {
+                                            scriptPubKey:
+                                                '1 6a6daebd9abae25cdd376b811190163eb00c58e87da1867ba8546229098231c3',
+                                            value: 12300000,
+                                        },
+                                    },
+                                    ownershipProof: 'not-relevant',
+                                },
+                                {
+                                    Type: 'InputAdded', // external input
+                                    coin: {
+                                        outpoint:
+                                            '000000000000000000000000000000000000000000000000000000000000000001000000',
+                                        txOut: {
+                                            scriptPubKey:
+                                                '1 b899b1962f24757bf8f641d125a88944d1541272cc86da7815ff7899e368b2d4',
+                                            value: 12300000,
+                                        },
+                                    },
+                                    ownershipProof: 'not-relevant',
+                                },
+                                {
+                                    Type: 'InputAdded',
+                                    coin: {
+                                        outpoint:
+                                            '1B5B1FEEA4DFED4253DB5F639011A744A337B25A67975310439233BD8A1DC49F00000000',
+                                        txOut: {
+                                            scriptPubKey:
+                                                '1 6a6daebd9abae25cdd376b811190163eb00c58e87da1867ba8546229098231c3',
+                                            value: 12300000,
+                                        },
+                                    },
+                                    ownershipProof: 'not-relevant',
+                                },
+                                {
+                                    Type: 'OutputAdded', // external output
+                                    output: {
+                                        scriptPubKey:
+                                            '1 b899b1962f24757bf8f641d125a88944d1541272cc86da7815ff7899e368b2d4',
+                                        value: 2000000,
+                                    },
+                                },
+                                {
+                                    Type: 'OutputAdded',
+                                    output: {
+                                        scriptPubKey:
+                                            '1 b67b77a4cac9a32c463e5bbe0c6cbfbab3c86cb59518e5661766056e6a7e849c',
+                                        value: 12300000 - 5000000 - 2000000 - 11000,
+                                    },
+                                },
+                            ],
                         },
-                    ],
+                    },
                 },
-                setSessionPhase: () => null,
-            } as any, // simplified CoinjoinRound
+            ),
             [
                 {
                     accountKey: 'account-A',
@@ -123,6 +153,7 @@ describe('transactionSigning', () => {
             ],
             { ...server?.requestOptions, network: networks.bitcoin },
         );
+
         expect(response).toMatchObject({
             transactionData: {
                 affiliateRequest: COINJOIN_REQUEST,
@@ -131,41 +162,317 @@ describe('transactionSigning', () => {
         });
     });
 
-    // it('try to sign input with error', async () => {
-    //     const response = await transactionSigning(
-    //         {
-    //             id: '00',
-    //             phase: 3,
-    //             accounts: {
-    //                 account1: {
-    //                     utxos: [{ outpoint: 'AA', error: 'Error from previous phase' }],
-    //                 },
-    //             },
-    //             coinjoinState: {
-    //                 events: [],
-    //             },
-    //         } as any,
-    //         server?.requestOptions,
-    //     );
-    //     expect(response).toMatchObject({
-    //         id: '00',
-    //         accounts: {
-    //             account1: {
-    //                 utxos: [{ outpoint: 'AA', error: 'Error from previous phase' }],
-    //             },
-    //         },
-    //     });
-    // });
+    it('getTransactionData: missing registered outputs', async () => {
+        const response = await transactionSigning(
+            createCoinjoinRound(
+                [
+                    createInput(
+                        'account-A',
+                        '1b5b1feea4dfed4253db5f639011a744a337b25a67975310439233bd8a1dc49f00000000',
+                    ),
+                ],
+                {
+                    ...server?.requestOptions,
+                    round: {
+                        phase: 3,
+                        affiliateRequest,
+                    },
+                },
+            ),
+            [],
+            server?.requestOptions,
+        );
 
-    // it('signed', async () => {
-    //     const response = await transactionSigning({
-    //         round: {
-    //             coinjoinState: {
-    //                 events: [],
-    //             },
-    //         },
-    //         inputs: [{ phase: 5, witness: '0102' }],
-    //     } as any);
-    //     expect(response).toMatchObject({ inputs: [{ phase: 7 }] });
-    // });
+        response.inputs.forEach(input => {
+            expect(input.error?.message).toMatch(/No registered outputs/);
+        });
+    });
+
+    it('getTransactionData: inconsistent number of registered outputs', async () => {
+        const response = await transactionSigning(
+            createCoinjoinRound(
+                [
+                    createInput(
+                        'account-A',
+                        '1b5b1feea4dfed4253db5f639011a744a337b25a67975310439233bd8a1dc49f00000000',
+                    ),
+                ],
+                {
+                    ...server?.requestOptions,
+                    round: {
+                        phase: 3,
+                        affiliateRequest,
+                        addresses: [
+                            {
+                                accountKey: 'account-A',
+                                path: "m/10025'/0'/0'/0'/1/0",
+                                address:
+                                    'bc1pkeah0fx2ex3jc337twlqcm9lh2eusm94j5vw2eshvczku6n7sjwqrfyfj2',
+                                scriptPubKey:
+                                    '1 b67b77a4cac9a32c463e5bbe0c6cbfbab3c86cb59518e5661766056e6a7e849c',
+                            },
+                        ],
+                        coinjoinState: {
+                            Type: '',
+                            events: [
+                                {
+                                    Type: 'InputAdded',
+                                    coin: {
+                                        outpoint:
+                                            '1B5B1FEEA4DFED4253DB5F639011A744A337B25A67975310439233BD8A1DC49F00000000',
+                                        txOut: {
+                                            scriptPubKey:
+                                                '1 6a6daebd9abae25cdd376b811190163eb00c58e87da1867ba8546229098231c3',
+                                            value: 12300000,
+                                        },
+                                    },
+                                    ownershipProof: 'not-relevant',
+                                },
+                            ],
+                        },
+                    },
+                },
+            ),
+            [],
+            server?.requestOptions,
+        );
+
+        response.inputs.forEach(input => {
+            expect(input.error?.message).toMatch(/Unexpected sum of registered outputs/);
+        });
+    });
+
+    it('getTransactionData: inconsistent number of registered inputs', async () => {
+        const response = await transactionSigning(
+            createCoinjoinRound(
+                [
+                    createInput(
+                        'account-A',
+                        '1b5b1feea4dfed4253db5f639011a744a337b25a67975310439233bd8a1dc49f00000000',
+                    ),
+                ],
+                {
+                    ...server?.requestOptions,
+                    round: {
+                        phase: 3,
+                        affiliateRequest,
+                        addresses: [
+                            {
+                                accountKey: 'account-A',
+                                path: "m/10025'/0'/0'/0'/1/0",
+                                address:
+                                    'bc1pkeah0fx2ex3jc337twlqcm9lh2eusm94j5vw2eshvczku6n7sjwqrfyfj2',
+                                scriptPubKey:
+                                    '1 b67b77a4cac9a32c463e5bbe0c6cbfbab3c86cb59518e5661766056e6a7e849c',
+                            },
+                        ],
+                    },
+                },
+            ),
+            [],
+            server?.requestOptions,
+        );
+
+        response.inputs.forEach(input => {
+            expect(input.error?.message).toMatch(/Unexpected sum of registered inputs/);
+        });
+    });
+
+    it('signed successfully with one WitnessAlreadyProvided error', async () => {
+        const spy = jest.fn();
+        jest.spyOn(console, 'error').mockImplementation(() => {}); // do not show error in console
+
+        let alreadyProvided = false;
+        server?.addListener('test-request', ({ url, resolve, data, reject }) => {
+            if (url.endsWith('/transaction-signature')) {
+                spy();
+                if (data.inputIndex === 1) {
+                    if (!alreadyProvided) {
+                        alreadyProvided = true;
+                        reject(403); // Simulate cloudflare error. Enforce to repeat the request
+                    } else {
+                        reject(500, { errorCode: 'WitnessAlreadyProvided' });
+                    }
+                }
+            }
+            resolve();
+        });
+
+        const response = await transactionSigning(
+            createCoinjoinRound(
+                [
+                    createInput(
+                        'account-A',
+                        'a00000000000000000000000000000000000000000000000000000000000000001000000',
+                        {
+                            witness: 'aa',
+                            witnessIndex: 0,
+                        },
+                    ),
+                    createInput(
+                        'account-A',
+                        'b00000000000000000000000000000000000000000000000000000000000000002000000',
+                        {
+                            witness: 'bb',
+                            witnessIndex: 1,
+                        },
+                    ),
+                    createInput(
+                        'account-A',
+                        'c00000000000000000000000000000000000000000000000000000000000000003000000',
+                        {
+                            witness: 'cc',
+                            witnessIndex: 2,
+                        },
+                    ),
+                ],
+                {
+                    ...server?.requestOptions,
+                    round: {
+                        phase: 3,
+                        affiliateRequest: Buffer.from('0'.repeat(97 * 2 + 4), 'hex').toString(
+                            'base64',
+                        ),
+                        phaseDeadline: Date.now() + 5000, // use shortened delays...
+                    },
+                },
+            ),
+            [], // Account is not relevant for this test
+            server?.requestOptions,
+        );
+
+        expect(spy).toBeCalledTimes(4); // called 4 times because witnessIndex 1 was repeated
+
+        response.inputs.forEach(input => {
+            expect(input.error).toBe(undefined);
+        });
+
+        expect(response.isSignedSuccessfully()).toBe(true);
+    });
+
+    it('failed to send signatures', async () => {
+        server?.addListener('test-request', ({ url, resolve, reject }) => {
+            if (url.endsWith('/transaction-signature')) {
+                reject(500, { errorCode: 'WrongPhase' });
+            }
+            resolve();
+        });
+
+        const response = await transactionSigning(
+            createCoinjoinRound(
+                [
+                    createInput(
+                        'account-A',
+                        'a00000000000000000000000000000000000000000000000000000000000000001000000',
+                        {
+                            witness: 'aa',
+                            witnessIndex: 0,
+                        },
+                    ),
+                ],
+                {
+                    ...server?.requestOptions,
+                    round: {
+                        phase: 3,
+                        affiliateRequest,
+                    },
+                },
+            ),
+            [], // Account is not relevant for this test
+            server?.requestOptions,
+        );
+
+        response.inputs.forEach(input => {
+            expect(input.error?.message).toMatch(/WrongPhase/);
+        });
+
+        expect(response.isSignedSuccessfully()).toBe(false);
+    });
+
+    it('try to sign input with error', async () => {
+        const response = await transactionSigning(
+            createCoinjoinRound(
+                [
+                    createInput(
+                        'account-A',
+                        'a00000000000000000000000000000000000000000000000000000000000000001000000',
+                        {
+                            error: new Error('Error from previous phase'),
+                        },
+                    ),
+                ],
+                {
+                    ...server?.requestOptions,
+                    round: {
+                        phase: 3,
+                    },
+                },
+            ),
+            [], // Account is not relevant for this test
+            server?.requestOptions,
+        );
+
+        response.inputs.forEach(input => {
+            expect(input.error).not.toBe(undefined);
+        });
+
+        expect(response.isSignedSuccessfully()).toBe(false);
+    });
+
+    it('try to sign input with already requested signature', async () => {
+        const response = await transactionSigning(
+            createCoinjoinRound(
+                [
+                    createInput(
+                        'account-A',
+                        'a00000000000000000000000000000000000000000000000000000000000000001000000',
+                        {
+                            requested: { type: 'signature' },
+                        },
+                    ),
+                ],
+                {
+                    ...server?.requestOptions,
+                    round: {
+                        phase: 3,
+                    },
+                },
+            ),
+            [], // Account is not relevant for this test
+            server?.requestOptions,
+        );
+
+        response.inputs.forEach(input => {
+            expect(input.error).toBe(undefined);
+        });
+
+        expect(response.isSignedSuccessfully()).toBe(false);
+    });
+
+    it('try to sign without affiliate request', async () => {
+        const response = await transactionSigning(
+            createCoinjoinRound(
+                [
+                    createInput(
+                        'account-A',
+                        'a00000000000000000000000000000000000000000000000000000000000000001000000',
+                    ),
+                ],
+                {
+                    ...server?.requestOptions,
+                    round: {
+                        phase: 3,
+                    },
+                },
+            ),
+            [], // Account is not relevant for this test
+            server?.requestOptions,
+        );
+
+        response.inputs.forEach(input => {
+            expect(input.error).toBe(undefined);
+        });
+
+        expect(response.isSignedSuccessfully()).toBe(false);
+    });
 });


### PR DESCRIPTION
## Description

should fix error [reported in sentry](https://satoshilabs.sentry.io/issues/4280883364/?rule_id=13976773)

It is possible that the `transaction-signature` request will timeout on the client side but was successfully received by coordinator.
When it happens client will try retry the request and end up with error `WitnessAlreadyProvided`

This exception **should not** break the round, client should assume that everything is alright and continue as if nothing happens.

Additional changes in `transactionSigning` module:

- added unit tests and increasing coverage to 100%
- added missing delays to `transaction-signature` request, same as WalletWasabi