### PR TITLE
feat(connect-popup): report error screen presence to analytics

### DIFF
--- a/packages/connect-analytics/src/constants.ts
+++ b/packages/connect-analytics/src/constants.ts
@@ -3,6 +3,7 @@ export enum EventType {
     AppInfo = 'app/info',
 
     ViewChange = 'view/change',
+    ViewChangeError = 'view/change-error',
 
     SettingsTracking = 'settings/tracking',
     SettingsPermissions = 'settings/permissions',

--- a/packages/connect-analytics/src/types/events.ts
+++ b/packages/connect-analytics/src/types/events.ts
@@ -52,6 +52,12 @@ export type ConnectAnalyticsEvent =
           };
       }
     | {
+          type: EventType.ViewChangeError;
+          payload: {
+              code: string;
+          };
+      }
+    | {
           type: EventType.WalletType;
           payload: {
               type: 'hidden' | 'standard';

--- a/packages/connect-popup/src/index.tsx
+++ b/packages/connect-popup/src/index.tsx
@@ -79,6 +79,10 @@ const handleMessage = (
                     detail: 'response-event-error',
                     message: data.payload?.error || 'Unknown error',
                 });
+                analytics.report({
+                    type: EventType.ViewChangeError,
+                    payload: { code: data.payload?.code || 'Code missing' },
+                });
                 return;
         }
     }


### PR DESCRIPTION
should resolve https://github.com/trezor/trezor-suite/issues/8744 

notes: 
- how to test, lets check data after this is merged and deployed
- do we still mix dev and production logs? 
- also I don't really like how analytics is made now for connect-popup. sending some special messages to popup only to report them to analytics feels off. Why don't we send the analytics request already from connect-iframe? 