### PR TITLE
Add buy button to dashboard grid and table asset view

### DIFF
--- a/packages/suite-web/e2e/tests/dashboard/dashboard.test.ts
+++ b/packages/suite-web/e2e/tests/dashboard/dashboard.test.ts
@@ -45,6 +45,24 @@ describe('Dashboard', () => {
         // QA todo: discreet @dashboard/security-card/toggle-discreet/button
     });
 
+    it('Assets table buy button', () => {
+        cy.getTestElement('@dashboard/assets/table-icon').click();
+        cy.getTestElement('@dashboard/assets/table/btc/buy-button').click();
+        cy.getTestElement('@coinmarket/buy/crypto-currency-select/input').should(
+            'contain.text',
+            'BTC',
+        );
+    });
+
+    it('Assets grid buy button', () => {
+        cy.getTestElement('@dashboard/assets/grid-icon').click();
+        cy.getTestElement('@dashboard/assets/grid/btc/buy-button').click();
+        cy.getTestElement('@coinmarket/buy/crypto-currency-select/input').should(
+            'contain.text',
+            'BTC',
+        );
+    });
+
     // QA todo: test for graph
     // QA todo: dashboard appearance for seed with tx history vs seed without tx history
 });

--- a/packages/suite/src/components/wallet/CoinmarketBuyButton.tsx
+++ b/packages/suite/src/components/wallet/CoinmarketBuyButton.tsx
@@ -1,0 +1,35 @@
+import React from 'react';
+import * as routerActions from 'src/actions/suite/routerActions';
+import { Button } from '@trezor/components';
+import { NetworkSymbol } from 'src/types/wallet';
+import { Translation } from 'src/components/suite';
+import { useDispatch, useAccountSearch } from 'src/hooks/suite';
+
+interface BuyButtonProps {
+    symbol: NetworkSymbol;
+    dataTest: string;
+}
+
+export const CoinmarketBuyButton = ({ symbol, dataTest }: BuyButtonProps) => {
+    const dispatch = useDispatch();
+    const { setCoinFilter, setSearchString } = useAccountSearch();
+
+    const onClick = () => {
+        dispatch(
+            routerActions.goto('wallet-coinmarket-buy', {
+                params: {
+                    symbol,
+                    accountIndex: 0,
+                    accountType: 'normal',
+                },
+            }),
+        );
+        setCoinFilter(symbol);
+        setSearchString(undefined);
+    };
+    return (
+        <Button onClick={onClick} variant="secondary" data-test={dataTest}>
+            <Translation id="TR_BUY_BUY" />
+        </Button>
+    );
+};

--- a/packages/suite/src/components/wallet/index.tsx
+++ b/packages/suite/src/components/wallet/index.tsx
@@ -40,6 +40,7 @@ import type { WithCoinmarketProps, WithSelectedAccountLoadedProps } from './hocs
 import { AccountException } from './AccountException';
 import { AccountTopPanel } from './AccountTopPanel';
 import { CoinjoinExplanation } from './CoinjoinExplanation';
+import { CoinmarketBuyButton } from './CoinmarketBuyButton';
 
 export {
     Title,
@@ -79,6 +80,7 @@ export {
     AccountException,
     AccountTopPanel,
     CoinjoinExplanation,
+    CoinmarketBuyButton,
 };
 
 export type { WithCoinmarketProps, WithSelectedAccountLoadedProps };

--- a/packages/suite/src/views/dashboard/components/AssetsCard/components/AssetGrid.tsx
+++ b/packages/suite/src/views/dashboard/components/AssetsCard/components/AssetGrid.tsx
@@ -10,7 +10,7 @@ import {
     Ticker,
     Translation,
 } from 'src/components/suite';
-import { CoinBalance } from 'src/components/wallet';
+import { CoinBalance, CoinmarketBuyButton } from 'src/components/wallet';
 import { isTestnet } from '@suite-common/wallet-utils';
 import * as routerActions from 'src/actions/suite/routerActions';
 import { useActions, useAccountSearch, useLoadingSkeleton } from 'src/hooks/suite';
@@ -35,7 +35,7 @@ const CoinNameWrapper = styled.div`
 const UpperRowWrapper = styled.div`
     display: flex;
     justify-content: space-between;
-    padding: 0px 15px 15px 15px;
+    padding: 15px 0;
     border-bottom: 1px solid ${({ theme }) => theme.STROKE_GREY};
 `;
 
@@ -83,6 +83,10 @@ const FiatBalanceWrapper = styled.span`
     margin-left: 0.5ch;
 `;
 
+const TickerWrapper = styled.div`
+    align-self: center;
+`;
+
 interface AssetGridProps {
     network: Network;
     failed: boolean;
@@ -119,8 +123,17 @@ export const AssetGrid = React.memo(({ network, failed, cryptoValue }: AssetGrid
 
                     <Coin>{name}</Coin>
                 </CoinNameWrapper>
-
-                {!isTestnet(symbol) && <Ticker symbol={symbol} />}
+                {!isTestnet(symbol) && (
+                    <>
+                        <TickerWrapper>
+                            <Ticker symbol={symbol} />
+                        </TickerWrapper>
+                        <CoinmarketBuyButton
+                            symbol={symbol}
+                            dataTest={`@dashboard/assets/grid/${symbol}/buy-button`}
+                        />
+                    </>
+                )}
             </UpperRowWrapper>
 
             {!failed ? (
@@ -163,9 +176,11 @@ export const AssetGridSkeleton = (props: { animate?: boolean }) => {
                     <LogoWrapper>
                         <SkeletonCircle />
                     </LogoWrapper>
-
                     <SkeletonRectangle animate={animate} />
                 </CoinNameWrapper>
+
+                <SkeletonRectangle animate={animate} />
+                <SkeletonRectangle animate={animate} />
             </UpperRowWrapper>
 
             <CryptoBalanceWrapper>

--- a/packages/suite/src/views/dashboard/components/AssetsCard/components/AssetTable.tsx
+++ b/packages/suite/src/views/dashboard/components/AssetsCard/components/AssetTable.tsx
@@ -10,7 +10,7 @@ import {
     Ticker,
     Translation,
 } from 'src/components/suite';
-import { CoinBalance } from 'src/components/wallet';
+import { CoinBalance, CoinmarketBuyButton } from 'src/components/wallet';
 import { isTestnet } from '@suite-common/wallet-utils';
 import * as routerActions from 'src/actions/suite/routerActions';
 import { useActions, useAccountSearch, useLoadingSkeleton } from 'src/hooks/suite';
@@ -110,8 +110,13 @@ const FiatBalanceWrapper = styled.span`
 
 const ExchangeRateWrapper = styled(Col)`
     font-variant-numeric: tabular-nums;
-    margin-right: 25px;
     padding-right: 0px;
+`;
+
+const BuyButtonWrapper = styled(Col)`
+    justify-content: right;
+    margin-right: 25px;
+    padding-right: 0;
 `;
 
 interface AssetTableProps {
@@ -184,6 +189,14 @@ export const AssetTable = React.memo(
                 <ExchangeRateWrapper isLastRow={isLastRow}>
                     {!isTestnet(symbol) && <Ticker symbol={symbol} />}
                 </ExchangeRateWrapper>
+                <BuyButtonWrapper isLastRow={isLastRow}>
+                    {!isTestnet(symbol) && (
+                        <CoinmarketBuyButton
+                            symbol={symbol}
+                            dataTest={`@dashboard/assets/table/${symbol}/buy-button`}
+                        />
+                    )}
+                </BuyButtonWrapper>
             </>
         );
     },
@@ -211,6 +224,9 @@ export const AssetTableSkeleton = (props: { animate?: boolean }) => {
             <ExchangeRateWrapper isLastRow>
                 <SkeletonRectangle animate={animate} />
             </ExchangeRateWrapper>
+            <BuyButtonWrapper isLastRow>
+                <SkeletonRectangle animate={animate} />
+            </BuyButtonWrapper>
         </>
     );
 };

--- a/packages/suite/src/views/dashboard/components/AssetsCard/index.tsx
+++ b/packages/suite/src/views/dashboard/components/AssetsCard/index.tsx
@@ -53,7 +53,7 @@ const Header = styled.div`
 const Grid = styled.div`
     display: grid;
     overflow: hidden;
-    grid-template-columns: 2fr 2fr 1fr;
+    grid-template-columns: 2fr 2fr 1fr 1fr;
 `;
 
 const GridWrapper = styled.div`
@@ -139,11 +139,13 @@ const AssetsCard = () => {
                 <ActionsWrapper>
                     <Icon
                         icon="TABLE"
+                        data-test="@dashboard/assets/table-icon"
                         onClick={() => setFlag('dashboardAssetsGridMode', false)}
                         color={!dashboardAssetsGridMode ? colors.BG_GREEN : colors.TYPE_LIGHT_GREY}
                     />
                     <Icon
                         icon="GRID"
+                        data-test="@dashboard/assets/grid-icon"
                         onClick={() => setFlag('dashboardAssetsGridMode', true)}
                         color={dashboardAssetsGridMode ? colors.BG_GREEN : colors.TYPE_LIGHT_GREY}
                     />
@@ -176,6 +178,8 @@ const AssetsCard = () => {
                             <Header>
                                 <Translation id="TR_EXCHANGE_RATE" />
                             </Header>
+                            {/* empty column */}
+                            <Header />
                             {assetsData.map((asset, i) => (
                                 <AssetTable
                                     key={asset.symbol}
@@ -188,7 +192,6 @@ const AssetsCard = () => {
                             {discoveryInProgress && <AssetTableSkeleton />}
                         </Grid>
                     </AnimatePresence>
-
                     {isError && (
                         <InfoMessage>
                             <StyledIcon icon="WARNING" color={theme.TYPE_RED} size={14} />


### PR DESCRIPTION
Add buy button to asset grid/table in dashboard according to its cryptocurrency.

## Screenshots:
<img width="864" alt="Screenshot 2023-07-03 at 13 00 24" src="https://github.com/trezor/trezor-suite/assets/41970479/64a570da-b501-4a6d-b55b-716a80460174">
<img width="864" alt="Screenshot 2023-07-03 at 13 00 14" src="https://github.com/trezor/trezor-suite/assets/41970479/012660c3-cd87-4100-ae26-c871a4bb3e4e">
