### PR TITLE
fix(connect-web): close popup when 3rd party page is closed

### DIFF
--- a/packages/connect-popup/src/index.tsx
+++ b/packages/connect-popup/src/index.tsx
@@ -65,6 +65,10 @@ const handleMessage = (
 
     if (data.type === RESPONSE_EVENT && !data.success) {
         switch (data.payload?.code) {
+            case 'Device_CallInProgress':
+                // Ignoring when device call is in progress.
+                // User triggers new call but device call is in progress PopupManager will focus popup.
+                break;
             case 'Transport_Missing':
                 // Ignore this error. It is handled after.
                 break;

--- a/packages/connect-web/src/index.ts
+++ b/packages/connect-web/src/index.ts
@@ -194,7 +194,7 @@ const call: CallMethod = async params => {
                 if (['Init_IframeBlocked', 'Init_IframeTimeout'].includes(error.code)) {
                     _popupManager.postMessage(createUiMessage(UI.IFRAME_FAILURE));
                 } else {
-                    _popupManager.close();
+                    _popupManager.clear();
                 }
             }
             return createErrorMessage(error);
@@ -235,7 +235,7 @@ const call: CallMethod = async params => {
     } catch (error) {
         _log.error('__call error', error);
         if (_popupManager) {
-            _popupManager.close();
+            _popupManager.clear();
         }
         return createErrorMessage(error);
     }

--- a/packages/connect-web/src/popup/index.ts
+++ b/packages/connect-web/src/popup/index.ts
@@ -80,6 +80,13 @@ export class PopupManager extends EventEmitter {
             return;
         }
 
+        // When requesting a popup window and there is a reference to popup window and it is not locked
+        // we close it so we can open a new one.
+        // This is necessary when popup window is in error state and we want to open a new one.
+        if (this.popupWindow && !this.locked) {
+            this.popupWindow.close();
+        }
+
         const openFn = this.open.bind(this);
         this.locked = true;
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Separates the way we are closing popup from 3rd party with clearing it. So we explicitly close it. For now only when 3rd party page is closed. But this should be reviewed by product team. In my opinion when 3rd party closes and popup is open we should display an error in popup instead of closing it. Maybe @Hannsek can help with this.


## Related issues

closes https://github.com/trezor/trezor-suite/issues/8882
Related https://github.com/trezor/trezor-suite/issues/8082
