### PR TITLE
Test: 3rd party is reloaded with passphrase

### DIFF
--- a/packages/connect-popup/e2e/support/helpers.ts
+++ b/packages/connect-popup/e2e/support/helpers.ts
@@ -1,0 +1,18 @@
+/* eslint-disable no-await-in-loop */
+
+import { Page } from '@playwright/test';
+
+// Waits and clicks for an array on buttons in serial order.
+export const waitAndClick = async (page: Page, buttons: string[]) => {
+    // eslint-disable-next-line no-restricted-syntax
+    for (const button of buttons) {
+        await page.waitForSelector(`[data-test='${button}']`, { state: 'visible' });
+        await page.click(`[data-test='${button}']`);
+    }
+};
+
+// Helper to use data-test attributes to find elements.
+export const findElementByDataTest = async (page: Page, dataTest: string, timeout?: number) => {
+    await page.waitForSelector(`[data-test='${dataTest}']`, { state: 'visible', timeout });
+    return page.$(`[data-test='${dataTest}']`);
+};

--- a/packages/connect-popup/src/static/popup.html
+++ b/packages/connect-popup/src/static/popup.html
@@ -274,7 +274,7 @@
             <!-- Passphrase: END -->
 
             <!-- invalid passphrase -->
-            <div class="invalid-passphrase">
+            <div data-test="@invalid-passphrase" class="invalid-passphrase">
                 <div>
                     <h3>Passphrase doesn't match</h3>
                     <p>Looks like You have set a different passphrase</p>
@@ -474,8 +474,16 @@
                 </div>
 
                 <div class="buttons">
-                    <button class="confirm retry">No, Try again</button>
-                    <button class="cancel useCurrent" tabindex="4">Yes, use this passphrase</button>
+                    <button data-test="@invalid-passphrase/try-again" class="confirm retry">
+                        No, Try again
+                    </button>
+                    <button
+                        data-test="@invalid-passphrase/use-this-passphrase"
+                        class="cancel useCurrent"
+                        tabindex="4"
+                    >
+                        Yes, use this passphrase
+                    </button>
                 </div>
             </div>
             <!-- invalid passphrase: END -->
@@ -3144,7 +3152,7 @@
             <!-- Export address: END -->
 
             <!-- Check address on device -->
-            <div class="check-address">
+            <div data-test="@check-address-on-device" class="check-address">
                 <svg width="12px" height="35px" viewBox="0 0 20 57">
                     <g stroke="none" stroke-width="1" fill="none" transform="translate(1, 1)">
                         <path


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Extend e2e tests for passphrase to address some of the situation mentioned https://github.com/trezor/trezor-suite/issues/8739  where 3rd party is reloaded and when it is not.

It also adds some helper function to make tests easier to write.

## Related Issue

Related https://github.com/trezor/trezor-suite/issues/8739 
Closes https://github.com/trezor/trezor-suite/issues/8775

