### PR TITLE
fix(coinjoin): do not ban inputs locally after unsuccessful round

### DIFF
--- a/packages/coinjoin/tests/client/endedRound.test.ts
+++ b/packages/coinjoin/tests/client/endedRound.test.ts
@@ -123,7 +123,7 @@ describe('ended', () => {
 
         expect(logger.error).toBeCalledTimes(1);
         expect(logger.error).toBeCalledWith(expect.stringMatching(/Missing affiliate request/));
-        expect(round.prison.inmates.length).toEqual(1);
+        expect(round.prison.inmates.length).toEqual(2); // input + output are detained
     });
 
     it('NotAllAlicesSign by this instance (missing witnesses)', () => {
@@ -164,7 +164,7 @@ describe('ended', () => {
 
         expect(logger.error).toBeCalledTimes(1);
         expect(logger.error).toBeCalledWith(expect.stringMatching(/Missing signed inputs/));
-        expect(round.prison.inmates.length).toEqual(1);
+        expect(round.prison.inmates.length).toEqual(2); // input + output are detained
     });
 
     it('NotAllAlicesSign by this instance (other)', () => {
@@ -205,7 +205,7 @@ describe('ended', () => {
 
         expect(logger.error).toBeCalledTimes(1);
         expect(logger.error).toBeCalledWith(expect.stringMatching(/This should never happen/));
-        expect(round.prison.inmates.length).toEqual(1);
+        expect(round.prison.inmates.length).toEqual(2); // input + output are detained
     });
 
     it('AbortedNotEnoughAlicesSigned by other instance (no blame round)', () => {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

solve https://www.notion.so/satoshilabs/Coinjoin-55b6fb9efaa540e98a01473d62ef8337?p=89ed3a4a3ba34d52937dfe1d85ebb3ad&pm=s

Distinguish noted and banned inputs, do not ban inputs locally after unsuccessful round, try again after randomized time and detain (ban) input if coordinator say so

Related issue https://github.com/trezor/trezor-suite/issues/8307
