### PR TITLE
fix(coinjoin): add random delays to outputRegistration phase

### DIFF
--- a/packages/coinjoin/src/client/round/outputDecomposition.ts
+++ b/packages/coinjoin/src/client/round/outputDecomposition.ts
@@ -245,7 +245,7 @@ const findCredentialsForTarget = (
     return candidate ? [candidate[0], candidate[1]] : undefined;
 };
 
-interface Bob {
+export interface Bob {
     accountKey: string;
     amount: number;
     amountCredentials: middleware.Credentials[];

--- a/packages/coinjoin/src/client/round/outputRegistration.ts
+++ b/packages/coinjoin/src/client/round/outputRegistration.ts
@@ -1,12 +1,13 @@
-import { getWeakRandomId } from '@trezor/utils';
+import { getWeakRandomId, arrayShuffle } from '@trezor/utils';
 
 import * as coordinator from '../coordinator';
 import * as middleware from '../middleware';
-import { outputDecomposition } from './outputDecomposition';
+import { outputDecomposition, Bob } from './outputDecomposition';
 import type { Account } from '../Account';
 import type { Alice } from '../Alice';
 import type { CoinjoinRound, CoinjoinRoundOptions } from '../CoinjoinRound';
 import { AccountAddress } from '../../types';
+import { scheduleDelay } from '../../utils/roundUtils';
 import { SessionPhase, WabiSabiProtocolErrorCode } from '../../enums';
 
 /**
@@ -21,14 +22,16 @@ import { SessionPhase, WabiSabiProtocolErrorCode } from '../../enums';
 
 const registerOutput = async (
     round: CoinjoinRound,
-    accountKey: string,
-    outputAddress: AccountAddress[],
-    amountCredentials: middleware.Credentials[],
-    vsizeCredentials: middleware.Credentials[],
+    { accountKey, changeAddresses }: Account,
+    { amountCredentials, vsizeCredentials }: Bob,
+    assignedAddresses: AccountAddress[],
     options: CoinjoinRoundOptions,
 ) => {
-    const { roundParameters } = round;
+    const { roundParameters, phaseDeadline } = round;
     const { signal, coordinatorUrl, middlewareUrl, logger } = options;
+
+    const remainingTime = phaseDeadline - Date.now();
+    const delay = scheduleDelay(Math.floor(remainingTime * 0.8));
 
     const outputAmountCredentials = await middleware.getRealCredentials(
         [0, 0],
@@ -48,14 +51,19 @@ const registerOutput = async (
     // TODO: tricky, if for some reason AlreadyRegisteredScript is called then we have 2 options:
     // - try again with different address and link my new address with old address (privacy loss against coordinator?)
     // - intentionally stop output registrations for all other credentials. Question: which input will be banned if i call readyToSign on each anyway? is it better to break here and not to proceed to signing?
-    const tryToRegisterOutput = (): Promise<AccountAddress> => {
-        const address = outputAddress.find(a => !round.prison.isDetained(a.address));
+    const tryToRegisterOutput = (useDelay = true): Promise<AccountAddress> => {
+        const address = changeAddresses.find(
+            a => !round.prison.isDetained(a.address) && !assignedAddresses.includes(a),
+        );
         if (!address) {
+            const detained = changeAddresses.filter(a => round.prison.isDetained(a.address));
             logger.error(
-                `No change address available. Used: ${round.addresses.length}. Total: ${outputAddress.length}`,
+                `No change address available. Assigned in round: ${assignedAddresses.length}. Detained: ${detained.length}. Total: ${changeAddresses.length}`,
             );
             throw new Error('No change address available');
         }
+
+        assignedAddresses.push(address);
 
         return coordinator
             .outputRegistration(
@@ -67,6 +75,7 @@ const registerOutput = async (
                     signal,
                     baseUrl: coordinatorUrl,
                     identity: getWeakRandomId(10),
+                    delay: useDelay ? delay : 0, // do not use delay if registration is repeated
                     deadline: round.phaseDeadline,
                 },
             )
@@ -82,7 +91,7 @@ const registerOutput = async (
                                 sentenceEnd: Infinity, // this address should never be recycled
                             },
                         );
-                        return tryToRegisterOutput();
+                        return tryToRegisterOutput(false);
                     }
                     if (error.errorCode === WabiSabiProtocolErrorCode.NotEnoughFunds) {
                         logger.error(
@@ -104,23 +113,20 @@ const registerOutput = async (
         },
     );
 
-    return {
-        address,
-    };
+    round.addresses.push({ ...address, accountKey });
 };
 
-// TODO: delay
 const readyToSign = (
-    round: CoinjoinRound,
+    { id, phaseDeadline }: CoinjoinRound,
     input: Alice,
     { signal, coordinatorUrl }: CoinjoinRoundOptions,
 ) =>
-    coordinator.readyToSign(round.id, input.registrationData!.aliceId, !!input.affiliationFlag, {
+    coordinator.readyToSign(id, input.registrationData!.aliceId, !!input.affiliationFlag, {
         signal,
         baseUrl: coordinatorUrl,
         identity: input.outpoint, // NOTE: recycle input identity
-        delay: 0,
-        deadline: round.phaseDeadline,
+        delay: scheduleDelay(phaseDeadline - Date.now()),
+        deadline: phaseDeadline,
     });
 
 export const outputRegistration = async (
@@ -139,31 +145,25 @@ export const outputRegistration = async (
         // decompose output amounts for all registered inputs grouped by Account
         const decomposedGroup = await outputDecomposition(round, accounts, options);
 
-        // collect all used addresses
-        // try to register outputs for each account (each input in account group)
-        for (let group = 0; group < decomposedGroup.length; group++) {
-            const { accountKey, outputs } = decomposedGroup[group];
-            const account = accounts.find(a => a.accountKey === accountKey);
-            if (!account) throw new Error(`Unknown account ~~${accountKey}~~`);
-            const { changeAddresses } = account;
-            for (let index = 0; index < outputs.length; index++) {
-                // TODO: no not proceed if one of output fails (do not sign!!)
-                // eslint-disable-next-line no-await-in-loop
-                const result = await registerOutput(
-                    round,
-                    accountKey,
-                    changeAddresses,
-                    outputs[index].amountCredentials,
-                    outputs[index].vsizeCredentials,
-                    options,
+        await Promise.all(
+            decomposedGroup.map(({ accountKey, outputs }) => {
+                const account = accounts.find(a => a.accountKey === accountKey);
+                if (!account) throw new Error(`Unknown account ~~${accountKey}~~`);
+
+                const assignedAddresses: AccountAddress[] = [];
+                return Promise.all(
+                    arrayShuffle(outputs).map(output =>
+                        registerOutput(round, account, output, assignedAddresses, options),
+                    ),
                 );
-                round.addresses.push({ ...result.address, accountKey });
-            }
-        }
+            }),
+        );
 
         round.setSessionPhase(SessionPhase.AwaitingOthersOutputs);
         // inform coordinator that each registered input is ready to sign
-        await Promise.all(round.inputs.map(input => readyToSign(round, input, options)));
+        await Promise.all(
+            arrayShuffle(round.inputs).map(input => readyToSign(round, input, options)),
+        );
         logger.info(`Ready to sign ~~${round.id}~~`);
     } catch (error) {
         // NOTE: if anything goes wrong in this process this Round will be corrupted for all the users

--- a/packages/coinjoin/src/utils/roundUtils.ts
+++ b/packages/coinjoin/src/utils/roundUtils.ts
@@ -1,4 +1,5 @@
 import { bufferutils, Transaction, Network } from '@trezor/utxo-lib';
+import { getRandomNumberInRange } from '@trezor/utils';
 
 import {
     COORDINATOR_FEE_RATE_FALLBACK,
@@ -6,6 +7,7 @@ import {
     MIN_ALLOWED_AMOUNT_FALLBACK,
     PLEBS_DONT_PAY_THRESHOLD_FALLBACK,
     ROUND_REGISTRATION_END_OFFSET,
+    ROUND_MAXIMUM_REQUEST_DELAY,
 } from '../constants';
 import { RoundPhase } from '../enums';
 import { CoinjoinTransactionData } from '../types';
@@ -66,6 +68,15 @@ export const readTimeSpan = (ts: string) => {
 
     return date.getTime() - now;
 };
+
+export const scheduleDelay = (
+    deadline: number,
+    minimumDelay = 0,
+    maximumDelay = ROUND_MAXIMUM_REQUEST_DELAY,
+) =>
+    deadline > minimumDelay && deadline > maximumDelay
+        ? getRandomNumberInRange(minimumDelay, maximumDelay)
+        : minimumDelay;
 
 // NOTE: deadlines are not accurate. phase may change earlier
 // accept CoinjoinRound or modified coordinator Round (see estimatePhaseDeadline below)

--- a/packages/coinjoin/tests/client/outputRegistration.test.ts
+++ b/packages/coinjoin/tests/client/outputRegistration.test.ts
@@ -1,21 +1,33 @@
 import { outputRegistration } from '../../src/client/round/outputRegistration';
+import * as decomposition from '../../src/client/round/outputDecomposition';
 import { createServer } from '../mocks/server';
 import { createInput } from '../fixtures/input.fixture';
 import { createCoinjoinRound } from '../fixtures/round.fixture';
 
-let server: Awaited<ReturnType<typeof createServer>>;
+// mock random delay function
+jest.mock('@trezor/utils', () => {
+    const originalModule = jest.requireActual('@trezor/utils');
+    return {
+        __esModule: true,
+        ...originalModule,
+        getRandomNumberInRange: () => 0,
+    };
+});
 
 describe('outputRegistration', () => {
+    let server: Awaited<ReturnType<typeof createServer>>;
+
     beforeAll(async () => {
         server = await createServer();
     });
 
     beforeEach(() => {
+        jest.clearAllMocks();
         server?.removeAllListeners('test-request');
     });
 
     afterAll(() => {
-        if (server) server.close();
+        server?.close();
     });
 
     it('fails on joining credentials (missing data in input)', async () => {
@@ -32,15 +44,69 @@ describe('outputRegistration', () => {
         expect(response.inputs[0].error?.message).toMatch(/Missing confirmed credentials/);
     });
 
-    // it('joinInputsCredentials', async () => {
-    //     const cli = await joinInputsCredentials({
-    //         round: {},
-    //         inputs: [
-    //             { aliceId: '1', newAmountCredentials: { value: 1 } },
-    //             { aliceId: '2', newAmountCredentials: { value: 2 } },
-    //             { aliceId: '3', newAmountCredentials: { value: 3 } },
-    //             { aliceId: '4', newAmountCredentials: { value: 4 } },
-    //         ],
-    //     });
-    // });
+    it('fails on insufficient amount of available change addresses', async () => {
+        server?.addListener('test-request', ({ url, resolve, reject }) => {
+            if (url.endsWith('/output-registration')) {
+                // do not accept **any** output
+                reject(500, { errorCode: 'AlreadyRegisteredScript' });
+            }
+            resolve();
+        });
+
+        // Mock outputDecomposition module responses
+        jest.spyOn(decomposition, 'outputDecomposition').mockImplementation(() =>
+            Promise.resolve([
+                {
+                    accountKey: 'account-A',
+                    outputs: [
+                        {
+                            accountKey: 'account-A',
+                            amount: 2000,
+                            amountCredentials: [],
+                            vsizeCredentials: [],
+                        },
+                    ],
+                },
+            ]),
+        );
+
+        const round = createCoinjoinRound([createInput('account-A', 'A1')], {
+            ...server?.requestOptions,
+            round: {
+                phase: 3,
+            },
+        });
+
+        // Detain first address **before** processing other addresses will not be accepted by coordinator
+        round.prison.detain({
+            accountKey: 'account-A',
+            address: 'tb1ppll2u0aaprp92gfkntamd476emye7weykcgnctlyj7lduprjx7ys9jn7w3',
+        });
+
+        const response = await outputRegistration(
+            round,
+            [
+                {
+                    accountKey: 'account-A',
+                    changeAddresses: [
+                        {
+                            address:
+                                'tb1ppll2u0aaprp92gfkntamd476emye7weykcgnctlyj7lduprjx7ys9jn7w3',
+                        },
+                        {
+                            address:
+                                'tb1p55k3nua65qqqsq7j9zn8xp6rn3ntht9gj2ww3zfstczytd07htts3txmh9',
+                        },
+                        {
+                            address:
+                                'tb1p4jf9crt5gh57h2spvfht4zwjtnre700uvs4u63l2g2huchrk2dms4lm6kv',
+                        },
+                    ],
+                } as any, // partial Account
+            ],
+            server?.requestOptions,
+        );
+
+        expect(response.inputs[0].error?.message).toMatch(/No change address available/);
+    });
 });

--- a/packages/coinjoin/tests/utils/roundUtils.test.ts
+++ b/packages/coinjoin/tests/utils/roundUtils.test.ts
@@ -4,6 +4,7 @@ import {
     estimatePhaseDeadline,
     transformStatus,
     getAffiliateRequest,
+    scheduleDelay,
 } from '../../src/utils/roundUtils';
 import { ROUND_REGISTRATION_END_OFFSET } from '../../src/constants';
 import { DEFAULT_ROUND, STATUS_EVENT, STATUS_TRANSFORMED } from '../fixtures/round.fixture';
@@ -118,5 +119,17 @@ describe('roundUtils', () => {
                 '106bf94e6c325e3f9a8627ac6a8ebe71f322edcde26b43add515d81fc306a309a914ff0e7cfc75b05fc1cddbb60f0f5594642991a23f19b4a4794000d4169db2',
             coinjoin_flags_array: [1, 1],
         });
+    });
+
+    it('scheduleDelay', () => {
+        const d1 = scheduleDelay(20000, 3000);
+        expect(d1).toBeGreaterThanOrEqual(3000);
+        expect(d1).toBeLessThanOrEqual(10000);
+
+        const d2 = scheduleDelay(1000, 3000);
+        expect(d2).toEqual(3000); // deadline < min
+
+        const d3 = scheduleDelay(1000, 0, 5000);
+        expect(d3).toEqual(0); // deadline < max
     });
 });


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Last missing piece regarding request randomization

https://www.notion.so/satoshilabs/Specify-random-timing-in-coinjoin-69fbf0f637134b15a2c9f03fe53a4182

- `/output-registration` request is called in randomized time-frame (10 sec) 
- `/ready-to-sign` request is also called in  randomized time-frame (10 sec) 

