### PR TITLE
Fix Guide button z-index conflict

### DIFF
--- a/packages/suite/src/components/guide/GuideDefault.tsx
+++ b/packages/suite/src/components/guide/GuideDefault.tsx
@@ -27,6 +27,9 @@ const FeedbackButton = styled.button`
     background: none;
     transition: ${props =>
         `background ${props.theme.HOVER_TRANSITION_TIME} ${props.theme.HOVER_TRANSITION_EFFECT}`};
+    /* speficy position and z-index so that GuideButton does not interfere */
+    position: relative;
+    z-index: ${variables.Z_INDEX.GUIDE};
 
     :hover,
     :focus {
@@ -61,6 +64,14 @@ export const GuideDefault = () => {
         indexNode: state.guide.indexNode,
     }));
 
+    const handleFeedbackButtonClick = () => {
+        setView('SUPPORT_FEEDBACK_SELECTION');
+        analytics.report({
+            type: EventType.GuideFeedbackNavigation,
+            payload: { type: 'overview' },
+        });
+    };
+
     return (
         <ViewWrapper>
             <Header label={<Translation id="TR_GUIDE_VIEW_HEADLINE_LEARN_AND_DISCOVER" />} />
@@ -73,16 +84,11 @@ export const GuideDefault = () => {
                     />
                 )}
             </Content>
-            <FeedbackLinkWrapper
-                onClick={() => {
-                    setView('SUPPORT_FEEDBACK_SELECTION');
-                    analytics.report({
-                        type: EventType.GuideFeedbackNavigation,
-                        payload: { type: 'overview' },
-                    });
-                }}
-            >
-                <FeedbackButton data-test="@guide/button-feedback">
+            <FeedbackLinkWrapper>
+                <FeedbackButton
+                    data-test="@guide/button-feedback"
+                    onClick={handleFeedbackButtonClick}
+                >
                     <Icon icon="FEEDBACK" size={16} color={theme.TYPE_LIGHT_GREY} />
                     <FeedbackButtonLabel>
                         <Translation id="TR_GUIDE_SUPPORT_AND_FEEDBACK" />


### PR DESCRIPTION
`GuideButton` (lightbulb) intereferes with the Feedback button, making the right part of the button not interactive:


https://github.com/trezor/trezor-suite/assets/42465546/bd45e8e7-dfae-4b03-8020-6f40606f2943

Another problem is that clicking outside of the button (on the wrapper) can trigger the click handler:

https://github.com/trezor/trezor-suite/assets/42465546/9c358ecd-5a9d-4b0b-a76e-b4d82bdc17c3

Fixed:

https://github.com/trezor/trezor-suite/assets/42465546/0b3d0ad4-d455-43cc-85ef-076a5da74c56



