### PR TITLE
CJ Golomb filtering optimization

### DIFF
--- a/packages/coinjoin/src/backend/CoinjoinAddressController.ts
+++ b/packages/coinjoin/src/backend/CoinjoinAddressController.ts
@@ -10,10 +10,6 @@ type BareAddress = {
 
 export interface AddressController {
     addresses: BareAddress[];
-    analyze<T>(
-        getTxs: (address: BareAddress) => Promise<T[]>,
-        onTxs?: (txs: T[]) => void,
-    ): Promise<void>;
     analyze<T>(getTxs: (address: BareAddress) => T[], onTxs?: (txs: T[]) => void): void;
 }
 
@@ -46,14 +42,9 @@ export class CoinjoinAddressController implements AddressController {
         this.derived = this.deriveMore(0, initialCount);
     }
 
-    async analyze<T>(
-        getTxs: (address: AccountAddress) => T[] | Promise<T[]>,
-        onTxs?: (txs: T[]) => void,
-    ) {
+    analyze<T>(getTxs: (address: AccountAddress) => T[], onTxs?: (txs: T[]) => void) {
         for (let i = 0; i < this.derived.length; ++i) {
-            const maybePromise = getTxs(this.derived[i]);
-            // eslint-disable-next-line no-await-in-loop
-            const txs = 'then' in maybePromise ? await maybePromise : maybePromise;
+            const txs = getTxs(this.derived[i]);
             if (txs.length) {
                 onTxs?.(txs);
                 const missing = this.lookout + i + 1 - this.derived.length;

--- a/packages/coinjoin/src/backend/filters.ts
+++ b/packages/coinjoin/src/backend/filters.ts
@@ -38,3 +38,15 @@ export const getBlockFilter = (filterHex: string, blockHash: string) =>
 
 export const getMempoolFilter = (filterHex: string, txid: string) =>
     getFilter(filterHex, Buffer.from(txid, 'hex'));
+
+const getMultiFilter = (filterHex: string, keyBuffer: Buffer) => {
+    const filter = createFilter(Buffer.from(filterHex, 'hex'));
+    const key = keyBuffer.slice(0, KEY_SIZE);
+    return (scripts: Buffer[]) => filter.matchAny(key, scripts);
+};
+
+export const getBlockMultiFilter = (filterHex: string, blockHash: string) =>
+    getMultiFilter(filterHex, Buffer.from(blockHash, 'hex').reverse());
+
+export const getMempoolMultiFilter = (filterHex: string, txid: string) =>
+    getMultiFilter(filterHex, Buffer.from(txid, 'hex'));

--- a/packages/coinjoin/src/backend/scanAccount.ts
+++ b/packages/coinjoin/src/backend/scanAccount.ts
@@ -61,8 +61,8 @@ export const scanAccount = async (
                 block.txs.filter(doesTxContainAddress(address));
             const onTxs = (transactions: BlockbookTransaction[]) =>
                 transactions.forEach(txs.add, txs);
-            await receive.analyze(findTxs, onTxs);
-            await change.analyze(findTxs, onTxs);
+            receive.analyze(findTxs, onTxs);
+            change.analyze(findTxs, onTxs);
         }
 
         const transactions = Array.from(

--- a/packages/coinjoin/src/global.d.ts
+++ b/packages/coinjoin/src/global.d.ts
@@ -9,6 +9,7 @@ declare module 'golomb' {
         m: Number;
         data: Buffer;
         match(key: Buffer, script: Buffer): boolean;
+        matchAny(key: Buffer, items: Buffer[]): boolean;
         static fromItems(P: Number, key: Buffer, items: Buffer[]): Golomb;
         static fromBytes(N: Number, P: Number, data: Buffer): Golomb;
         static fromNBytes(P: Number, data: Buffer): Golomb;

--- a/packages/coinjoin/tests/backend/CoinjoinAddressController.test.ts
+++ b/packages/coinjoin/tests/backend/CoinjoinAddressController.test.ts
@@ -41,15 +41,6 @@ describe('CoinjoinAddressController', () => {
         expect(controller.addresses.map(getAddress)).toStrictEqual(SEGWIT_RECEIVE_ADDRESSES);
     });
 
-    it('derive more async', async () => {
-        await controller.analyze(({ address }) =>
-            new Promise(resolve => setTimeout(resolve, 1)).then(() =>
-                address === SEGWIT_RECEIVE_ADDRESSES[1] ? [true] : [],
-            ),
-        );
-        expect(controller.addresses.map(getAddress)).toStrictEqual(SEGWIT_RECEIVE_ADDRESSES);
-    });
-
     it('collect txs', () => {
         const result: number[] = [];
         controller.analyze(

--- a/packages/coinjoin/tests/backend/filters.test.ts
+++ b/packages/coinjoin/tests/backend/filters.test.ts
@@ -3,6 +3,7 @@ import { networks } from '@trezor/utxo-lib';
 import {
     getBlockAddressScript,
     getBlockFilter,
+    getBlockMultiFilter,
     getMempoolAddressScript,
     getMempoolFilter,
 } from '../../src/backend/filters';
@@ -207,6 +208,26 @@ describe('Golomb filtering', () => {
             const script = getBlockAddressScript(TAPROOT_CHANGE_0, NETWORK);
             const filter = getBlockFilter(BLOCK_162.filter, BLOCK_162.hash);
             expect(filter(script)).toBe(true);
+        });
+
+        it('Multifilter hit', () => {
+            const filter = getBlockMultiFilter(BLOCK_108.filter, BLOCK_108.hash);
+            const scripts = [
+                getBlockAddressScript(TAPROOT_RECEIVE_0, NETWORK),
+                getBlockAddressScript(COINJOIN_CHANGE_0, NETWORK),
+                getBlockAddressScript(TAPROOT_CHANGE_0, NETWORK),
+            ];
+            expect(filter(scripts)).toBe(true);
+        });
+
+        it('Multifilter miss', () => {
+            const filter = getBlockMultiFilter(BLOCK_106.filter, BLOCK_106.hash);
+            const scripts = [
+                getBlockAddressScript(TAPROOT_RECEIVE_0, NETWORK),
+                getBlockAddressScript(COINJOIN_CHANGE_0, NETWORK),
+                getBlockAddressScript(TAPROOT_CHANGE_0, NETWORK),
+            ];
+            expect(filter(scripts)).toBe(false);
         });
     });
 


### PR DESCRIPTION
## Description

Now `filter.matchAny()` is used instead of `filter.match()`, which speeds up the CJ discovery process by a lot.

## Commits

- https://github.com/trezor/trezor-suite/pull/8869/commits/de9f8076e7c41ab9d76a8a3c382f925bee56404f
  - adds helper methods equivalent to the existing ones but using `matchAny` instead of `match`
  - `scanAccount` now checks all the derived addresses at once and when there's a match, fetches the block and continues as before
  - `CoinjoinMempoolController` checks receive/change addresses separately, but always all derived & yet unchecked at once, until new addresses are derived, based on already found mempool txs
- https://github.com/trezor/trezor-suite/pull/8869/commits/0fc41f5a7cad75b83111fcaec5ecfc5947f10a3a
  - add unit test for multifiltering
- https://github.com/trezor/trezor-suite/pull/8869/commits/8ba99710c56be773f410836a1b5a5dbb9901230c
  - `CoinjoinAddressController.analyze` doesn't have to support async callbacks anymore as block is now potentially fetched before the analysis, based on all the already derived address scripts

## Related issues
Prerequisite for #8881
Prerequisite for #8826

## QA
Please just test that CJ discovery is returning the same results (incl. pending transactions) as before, but hopefully faster.