### PR TITLE
fix race condition in transport listen

### DIFF
--- a/packages/transport/src/transports/abstractUsb.ts
+++ b/packages/transport/src/transports/abstractUsb.ts
@@ -85,56 +85,52 @@ export abstract class AbstractUsbTransport extends AbstractTransport {
     }
 
     public acquire({ input }: { input: AcquireInput }) {
-        return this.scheduleAction(async () => {
-            const { path } = input;
+        return this.scheduleAction(
+            async () => {
+                const { path } = input;
 
-            if (this.listening) {
-                this.listenPromise[path] = createDeferred<string>();
-            }
+                if (this.listening) {
+                    this.listenPromise[path] = createDeferred();
+                }
 
-            const acquireIntentResponse = await this.sessionsClient.acquireIntent(input);
-            if (!acquireIntentResponse.success) {
+                const acquireIntentResponse = await this.sessionsClient.acquireIntent(input);
+
+                if (!acquireIntentResponse.success) {
+                    if (this.acquirePromise) {
+                        this.acquirePromise.resolve(undefined);
+                    }
+                    return this.error({ error: acquireIntentResponse.error });
+                }
+
+                this.acquiredUnconfirmed[path] = acquireIntentResponse.payload.session;
+
+                const reset = !!input.previous;
+                const openDeviceResult = await this.transportInterface.openDevice(path, reset);
+
+                if (!openDeviceResult.success) {
+                    if (this.listenPromise) {
+                        this.listenPromise[path].resolve(openDeviceResult);
+                    }
+                    return openDeviceResult;
+                }
+
+                this.sessionsClient.acquireDone({ path });
+
                 if (this.acquirePromise) {
                     this.acquirePromise.resolve(undefined);
                 }
-                return this.error({ error: acquireIntentResponse.error });
-            }
-            this.acquiredUnconfirmed[path] = acquireIntentResponse.payload.session;
 
-            const reset = !!input.previous;
-            const openDeviceResult = await this.transportInterface.openDevice(path, reset);
-            if (!openDeviceResult.success) {
-                if (this.listenPromise) {
-                    this.listenPromise[path].reject(new Error(openDeviceResult.error));
+                if (!this.listenPromise[path]) {
+                    return this.success(acquireIntentResponse.payload.session);
                 }
-                return openDeviceResult;
-            }
 
-            this.sessionsClient.acquireDone({ path });
-
-            if (this.acquirePromise) {
-                this.acquirePromise.resolve(undefined);
-            }
-
-            if (!this.listenPromise[path]) {
-                return this.success(acquireIntentResponse.payload.session);
-            }
-
-            return this.listenPromise[path].promise
-                .then(sessionId => {
+                return this.listenPromise[path].promise.finally(() => {
                     delete this.listenPromise[path];
-                    return this.success(sessionId);
-                })
-                .catch(err => {
-                    delete this.listenPromise[path];
-                    return this.unknownError(err, [
-                        ERRORS.DEVICE_DISCONNECTED_DURING_ACTION,
-                        ERRORS.SESSION_WRONG_PREVIOUS,
-                        ERRORS.DEVICE_NOT_FOUND,
-                        ERRORS.INTERFACE_UNABLE_TO_OPEN_DEVICE,
-                    ]);
                 });
-        });
+            },
+            undefined,
+            [ERRORS.DEVICE_DISCONNECTED_DURING_ACTION, ERRORS.SESSION_WRONG_PREVIOUS],
+        );
     }
 
     public release(session: string) {


### PR DESCRIPTION
catch handler was not not registered in time which in node.js manifests as 
```
This error originated either by throwing inside of an async function without a catch block, or by rejecting a promise which was not handled with .catch(). The promise rejected with the reason:
Error: device disconnected during action
    at /home/.../.cache/appimage-run/4f7babe4b70e86e60ee41f323b93431c213ba747240441906780a9fd0b737efc/resources/app.asar/node_modules/@trezor/transport/lib/transports/abstract.js:131:60
    at Array.forEach (<anonymous>)
...
```

