### PR TITLE
Fix Select/Modal z-index clash

### DIFF
--- a/packages/components/src/components/form/Select/index.tsx
+++ b/packages/components/src/components/form/Select/index.tsx
@@ -37,6 +37,7 @@ const selectStyle = (
     minWidth: string,
     theme: SuiteThemeColors,
     inputState?: InputState,
+    isOverlapped?: boolean,
 ): StylesConfig<Option, boolean> => ({
     singleValue: base => ({
         ...base,
@@ -131,7 +132,12 @@ const selectStyle = (
     }),
     menuPortal: base => ({
         ...base,
-        zIndex: Z_INDEX.GUIDE_BUTTON,
+        /*
+        Menu is rendered inside a portal so that it can overlap a Modal - unlike other elements that make the Modal scrollable instead.
+        Its z-index is set on par with the Modal so that the menu is visible when a Select is inside of a Modal.
+        In a special case when an open Select menu is meant to be overlapped by a Modal, the portal's z-index must be decreased.
+        */
+        zIndex: isOverlapped ? Z_INDEX.BASE : Z_INDEX.MODAL,
     }),
     menuList: base => ({
         ...base,
@@ -225,6 +231,7 @@ const isOptionGrouped = (x: OptionsOrGroups<Option, GroupBase<Option>>): x is Gr
 interface CommonProps extends Omit<ReactSelectProps<Option>, 'onChange'> {
     withDropdownIndicator?: boolean;
     isClean?: boolean;
+    isOverlapped?: boolean;
     label?: React.ReactNode;
     wrapperProps?: Record<string, any>;
     variant?: InputVariant;
@@ -251,6 +258,7 @@ export const Select = ({
     className,
     wrapperProps,
     isClean = false,
+    isOverlapped = false,
     label,
     variant = 'large',
     noError = true,
@@ -433,7 +441,7 @@ export const Select = ({
                 onKeyDown={onKeyDown}
                 classNamePrefix={reactSelectClassNamePrefix}
                 openMenuOnFocus
-                menuPortalTarget={document.body}
+                menuPortalTarget={document.getElementById('modal-window')}
                 styles={selectStyle(
                     isSearchable,
                     withDropdownIndicator,
@@ -443,6 +451,7 @@ export const Select = ({
                     minWidth,
                     theme,
                     inputState,
+                    isOverlapped,
                 )}
                 onChange={handleOnChange}
                 isSearchable={isSearchable}

--- a/packages/suite/src/views/wallet/coinmarket/exchange/offers/Offers/SelectedOffer/components/VerifyAddress/ReceiveOptions.tsx
+++ b/packages/suite/src/views/wallet/coinmarket/exchange/offers/Offers/SelectedOffer/components/VerifyAddress/ReceiveOptions.tsx
@@ -215,6 +215,7 @@ export const ReceiveOptions = (props: Props) => {
                 />
             }
             menuIsOpen={menuIsOpen}
+            isOverlapped
         />
     );
 };


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

As explained by the comment in code:

> Menu is rendered inside a portal so that it can overlap a Modal - unlike other elements that make the Modal scrollable instead. Its z-index is set on par with the Modal so that the menu is visible when a Select is inside of a Modal. In a special case when an open Select menu is meant to be overlapped by a Modal, the portal's z-index must be decreased.\

I don't think this solution is nice and I would prefer removing the `menuPortalTarget`, but it is there for a reason - to allow `Select` menu to overflow the `Modal` which has a fixed `max-height`.

The `Select` in question is special because it stays open after selecting a value, but I can imagine the problem arising for other selects - e.g. a `Select` menu in settings is open when a Critical phase coinjoin modal appears.

## Related Issue

https://github.com/trezor/trezor-suite/pull/6168
https://github.com/trezor/trezor-suite/pull/6294

## Screenshots:
The bug:
![Screenshot 2023-07-12 at 9 58 50](https://github.com/trezor/trezor-suite/assets/42465546/37f41689-c544-45ae-b297-90db76ccb249)

**How to test:** You need to have some amount of mainnet coins in your account. Go to Trade > Exchange > Compare offers > Get deal > Create a new account. Reported [here](https://satoshilabs.slack.com/archives/C031LD98L9K/p1688568630994659?thread_ts=1688480384.320529&cid=C031LD98L9K).

