### PR TITLE
fix(suite): rework cancelCoinjoinAuthorization call

### DIFF
--- a/packages/suite/src/actions/wallet/coinjoinClientActions.ts
+++ b/packages/suite/src/actions/wallet/coinjoinClientActions.ts
@@ -301,26 +301,26 @@ export const stopCoinjoinSession =
             return;
         }
 
-        const { device } = getState().suite;
-
-        const result = await TrezorConnect.cancelCoinjoinAuthorization({
-            device,
-            useEmptyPassphrase: device?.useEmptyPassphrase,
-        });
-
-        if (!result.success) {
-            dispatch(
-                notificationsActions.addToast({
-                    type: 'error',
-                    error: `Coinjoin session not stopped: ${result.payload.error}`,
-                }),
-            );
-
-            return;
-        }
-
         // unregister account in @trezor/coinjoin
         client.unregisterAccount(account.key);
+
+        const { device } = getState().suite;
+
+        if (device?.connected) {
+            const result = await TrezorConnect.cancelCoinjoinAuthorization({
+                device,
+                useEmptyPassphrase: device?.useEmptyPassphrase,
+            });
+
+            if (!result.success) {
+                dispatch(
+                    notificationsActions.addToast({
+                        type: 'error',
+                        error: `Cancel coinjoin authorization ${result.payload.error}`,
+                    }),
+                );
+            }
+        }
 
         // dispatch data to reducer
         dispatch({

--- a/suite-common/connect-init/src/connectInitThunks.ts
+++ b/suite-common/connect-init/src/connectInitThunks.ts
@@ -67,6 +67,7 @@ export const connectInitThunk = createThunk(
             'recoveryDevice',
             'checkFirmwareAuthenticity',
             'authorizeCoinjoin',
+            'cancelCoinjoinAuthorization',
             'getOwnershipProof',
             'setBusy',
         ] as const;


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

- "stop coinjoin" button was active after first click, it is possible to perform mad-clicking and get "device call in progress" error message
- return statement might lead to unwanted behavior: if connect call ends with success=false then account will **not** be unregistered from coinjoin lib
-  order of the actions might lead to unwanted behavior: sending messages to Trezor is taking time, you might enter "critical phase" before connect response. 
see the screenshot: there is 2 seconds difference between calling connect and calling coinjoin lib

![Screenshot from 2023-07-13 17-44-25](https://github.com/trezor/trezor-suite/assets/3435913/c9143c87-1b18-4981-8d93-93564442f06d)

