### PR TITLE
Restrict Select menu to use portal in modals only

### DIFF
--- a/packages/components/src/components/Modal/index.tsx
+++ b/packages/components/src/components/Modal/index.tsx
@@ -12,6 +12,7 @@ import { Progress } from '../loaders/Progress';
 
 const CLOSE_ICON_SIDE = 26;
 const CLOSE_ICON_PADDING = 16;
+const MODAL_CONTENT_ID = 'modal-content';
 
 const ModalPromptContainer = styled.div`
     margin-bottom: 25px;
@@ -303,7 +304,7 @@ const Modal = ({
 
                 <Body>
                     {description && <Description>{description}</Description>}
-                    <Content>{children}</Content>
+                    <Content id="modal-content">{children}</Content>
                 </Body>
 
                 {bottomBar && <BottomBar>{bottomBar}</BottomBar>}
@@ -319,5 +320,5 @@ Modal.Content = Content;
 Modal.BottomBar = BottomBar;
 Modal.closeIconWidth = CLOSE_ICON_SIDE + CLOSE_ICON_PADDING;
 
-export { Modal };
+export { Modal, MODAL_CONTENT_ID };
 export type { ModalProps };


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Probably better solution than #8901, plus it also fixes #8909. There is some small performance impact due to the loop, however an extra render only happens for a `Select` inside a `Modal`. Using a `RefCallback` instead of `useEffect` would also work, but it causes an extra render, so I opted for the effect.

I also removed the `closeMenuOnScroll` because it was immediately closing the menu in case the `Select` was on the bottom of the page, as demonstrated in #8909.

I changed portal `z-index` from `GUIDE_BUTTON` to `MODAL` for clarity.

## Related Issue

Resolve #8909
Resolve #8907
