### PR TITLE
fix(request-manager): handle control port sendCommand errors

### DIFF
--- a/packages/request-manager/src/torControlPort.ts
+++ b/packages/request-manager/src/torControlPort.ts
@@ -135,7 +135,12 @@ export class TorControlPort {
                     resolve({ success: false, payload });
                 }
             });
-            this.write(command);
+
+            try {
+                this.write(command);
+            } catch (error) {
+                return { success: false, payload: error };
+            }
         });
     }
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

handle `TorControlPort.sendCommand` errors recently reported in [sentry](https://satoshilabs.sentry.io/share/issue/8394f6e30a8b480889486d90aa94b53a/)