### PR TITLE
fix(suite): recv sign in tx modal

### DIFF
--- a/packages/suite/src/components/suite/modals/TransactionDetail/components/AmountDetails.tsx
+++ b/packages/suite/src/components/suite/modals/TransactionDetail/components/AmountDetails.tsx
@@ -87,7 +87,6 @@ export const AmountDetails = ({ tx, isTestnet }: AmountDetailsProps) => {
                         }
                     />
                 )}
-
                 {/* AMOUNT */}
                 {(tx.targets.length || tx.type === 'joint') && (
                     <AmountRow
@@ -97,9 +96,8 @@ export const AmountDetails = ({ tx, isTestnet }: AmountDetailsProps) => {
                                 value={amount.abs().toString()}
                                 symbol={tx.symbol}
                                 signValue={
-                                    getTxOperation(tx.type, true) || amount.isLessThan(0)
-                                        ? 'negative'
-                                        : 'positive'
+                                    getTxOperation(tx.type, true) ||
+                                    (amount.isLessThan(0) ? 'negative' : 'positive')
                                 }
                             />
                         }
@@ -116,7 +114,6 @@ export const AmountDetails = ({ tx, isTestnet }: AmountDetailsProps) => {
                         }
                     />
                 )}
-
                 {cardanoWithdrawal && (
                     <AmountRow
                         firstColumn={<Translation id="TR_TX_WITHDRAWAL" />}
@@ -138,7 +135,6 @@ export const AmountDetails = ({ tx, isTestnet }: AmountDetailsProps) => {
                         fourthColumn={<FiatValue amount={cardanoWithdrawal} symbol={tx.symbol} />}
                     />
                 )}
-
                 {cardanoDeposit && (
                     <AmountRow
                         firstColumn={<Translation id="TR_TX_DEPOSIT" />}
@@ -160,7 +156,6 @@ export const AmountDetails = ({ tx, isTestnet }: AmountDetailsProps) => {
                         fourthColumn={<FiatValue amount={cardanoDeposit} symbol={tx.symbol} />}
                     />
                 )}
-
                 {tx.internalTransfers.map((transfer, i) => (
                     <AmountRow
                         // eslint-disable-next-line react/no-array-index-key
@@ -191,7 +186,6 @@ export const AmountDetails = ({ tx, isTestnet }: AmountDetailsProps) => {
                         }
                     />
                 ))}
-
                 {tx.tokens.map((transfer, i) => (
                     <AmountRow
                         // eslint-disable-next-line react/no-array-index-key
@@ -227,7 +221,6 @@ export const AmountDetails = ({ tx, isTestnet }: AmountDetailsProps) => {
                         }
                     />
                 ))}
-
                 {/* TX FEE */}
                 {isTxFeePaid(tx) && (
                     <AmountRow


### PR DESCRIPTION
## Description

- missing parenthesis
- every `recv` tx, no matter `ETH`, `BTC`, had incorrect sign in tx modal

## Related Issue

Closes #8913
We nees to solve this #8342 and then the condition can be removed

## Screenshots:
![Screenshot 2023-07-17 at 14 44 21](https://github.com/trezor/trezor-suite/assets/33235762/1f3a3133-f905-476c-b5c4-7c198e56ce85)
![Screenshot 2023-07-17 at 14 44 13](https://github.com/trezor/trezor-suite/assets/33235762/32fa73c8-0ba9-4bf1-bc4a-3de934505701)
