### PR TITLE
fix(suite): app crash on decimal gwei on new TT fw

### DIFF
--- a/packages/suite/src/components/suite/modals/ReviewTransaction/constructOutputs.ts
+++ b/packages/suite/src/components/suite/modals/ReviewTransaction/constructOutputs.ts
@@ -4,7 +4,7 @@ import { FormState, PrecomposedTransactionFinal, TxFinalCardano } from 'src/type
 import { Account } from 'src/types/wallet/index';
 import { getShortFingerprint, isCardanoTx } from 'src/utils/wallet/cardanoUtils';
 import { OutputProps } from './components/Output';
-import { fromWei } from 'web3-utils';
+import { fromWei, toWei } from 'web3-utils';
 import { getIsUpdatedSendFlow } from './components/getIsUpdatedSendFlow';
 
 const getCardanoTokenBundle = (account: Account, output: CardanoOutput) => {
@@ -234,10 +234,13 @@ const constructNewFlow = ({
     }
 
     if (networkType === 'ethereum') {
-        // formatted to be alligned with the device, feePerByte is stired in Gwei
+        // device shows ether, precomposedTx.feePerByte is in gwei
+        const wei = toWei(precomposedTx.feePerByte, 'gwei'); // from gwei to wei
+        const ether = fromWei(wei, 'ether'); // from wei to ether
+
         outputs.push({
             type: 'gas',
-            value: fromWei(precomposedTx.feePerByte, 'Gwei'),
+            value: ether,
         });
     }
 


### PR DESCRIPTION
## Description

- TT with new UI crashed on decimal gas price because of new flow
- The conversion was incorrect. We wanted `gwei` to `ether`. However, we hacked it as `wei` to `gwei` 
- However, `fromWei` does not take decimals of course as `wei` cant be decimal.. 

https://web3js.readthedocs.io/en/v1.2.11/web3-utils.html#fromwei
https://web3js.readthedocs.io/en/v1.2.11/web3-utils.html#towei

## Related Issue

Resolve #8919

## Screenshots:
Gas price in `ether` is weird but I think change is planned on fw side 
![Screenshot 2023-07-18 at 11 40 54](https://github.com/trezor/trezor-suite/assets/33235762/22082a5d-9595-43ac-9a31-928c705120f8)
![IMG_6286](https://github.com/trezor/trezor-suite/assets/33235762/4175cc0d-c292-447b-b1ca-f07245ec4b21)
