### PR TITLE
chore(suite-native): use validation for non-eth network types

### DIFF
--- a/suite-native/module-accounts-import/src/screens/XpubScanScreen.tsx
+++ b/suite-native/module-accounts-import/src/screens/XpubScanScreen.tsx
@@ -68,9 +68,11 @@ export const XpubScanScreen = ({
     const inputLabel = networkTypeToInputLabelMap[networkType];
 
     const goToAccountImportScreen = ({ xpubAddress }: XpubFormValues) => {
-        const isCoinWithXpub = networkType === 'bitcoin';
-
-        if (xpubAddress && isCoinWithXpub && isAddressValid(xpubAddress, networkSymbol)) {
+        if (
+            xpubAddress &&
+            networkType !== 'ethereum' &&
+            isAddressValid(xpubAddress, networkSymbol)
+        ) {
             showAlert({
                 title: 'This is your receive address',
                 description: 'To check the balance of your coin, scan your public key (XPUB).',


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Condition was wrong and we need to use this for all non-ethereum network types.

## Related Issue

Resolve https://github.com/trezor/trezor-suite/issues/8746

## Screenshots:
