### PR TITLE
test(e2e): making db migration test work

### DIFF
--- a/packages/suite-web/e2e/tests/suite/database-migration.test.ts
+++ b/packages/suite-web/e2e/tests/suite/database-migration.test.ts
@@ -29,7 +29,8 @@ describe('Database migration', () => {
         };
         // this test can be run only in sldev so we ignore baseUrl env variable
         const baseUrl = 'https://suite.corp.sldev.cz/suite-web';
-        const btcAddressInputSelector = 'outputs.0.address';
+        const btcAddressInputSelector = 'outputs[0].address';
+        const workaroundBtcAddressInputSelector = 'outputs.0.address';
         const hiddenWalletSelector = '[data-test^="@switch-device/wallet-on-index"]';
         cy.viewport(1080, 1440);
         cy.task('startEmu', { wipe: true });
@@ -136,7 +137,8 @@ describe('Database migration', () => {
 
         // checking the Send form
         cy.getTestElement('@wallet/menu/wallet-send').click();
-        cy.getTestElement(btcAddressInputSelector)
+        // TODO: remove this workaround after the "old" version also uses the new data-testid attribute
+        cy.getTestElement(workaroundBtcAddressInputSelector)
             .should('be.visible')
             .invoke('attr', 'value')
             .should('eq', testData.btcAddress);


### PR DESCRIPTION
Making the db migration test work by adding a workaround selector until the current version of web Suite is the "old" version and thus the selectors are again matching in both old and current version.