### PR TITLE
fix(ci): make test file name more clear

### DIFF
--- a/ci/test.yml
+++ b/ci/test.yml
@@ -222,13 +222,13 @@ transport manual:
   interruptible: true
   parallel:
     matrix:
-      - TEST_FILE: ["methods"]
-      - TEST_FILE: ["popup-close"]
-      - TEST_FILE: ["popup-error-page"]
-      - TEST_FILE: ["passphrase"]
-      - TEST_FILE: ["unchained"]
-      - TEST_FILE: ["browser-support"]
-      - TEST_FILE: ["install-bridge"]
+      - TEST_FILE: ["methods.test"]
+      - TEST_FILE: ["popup-close.test"]
+      - TEST_FILE: ["popup-error-page.test"]
+      - TEST_FILE: ["passphrase.test"]
+      - TEST_FILE: ["unchained.test"]
+      - TEST_FILE: ["browser-support.test"]
+      - TEST_FILE: ["install-bridge.test"]
 
 connect-popup:
   extends: .e2e connect-popup

--- a/ci/test.yml
+++ b/ci/test.yml
@@ -262,7 +262,7 @@ connect-popup legacy:
   parallel:
     matrix:
       - CONNECT_VERSION: "9.0.11"
-        TEST_FILE: ["methods", "browser-support", "popup-close-legacy"]
+        TEST_FILE: ["methods.test", "browser-support.test", "popup-close-legacy.test"]
   except:
     <<: *run_everything_rules
   when: manual


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Playwright CLI was confusing test `popup-close` with test `popup-close-legacy` and running it when it does not have to run. It probably uses some match like "what-ever-file-name*" but that is just my assumption.
Adding the end of the file `.test` to the tests makes it more clear so there is not error.
