### PR TITLE
chore(suite): remove CoinjoinAccount.previousSessions

### DIFF
--- a/packages/suite/src/actions/wallet/__fixtures__/coinjoinClientActions.ts
+++ b/packages/suite/src/actions/wallet/__fixtures__/coinjoinClientActions.ts
@@ -141,7 +141,6 @@ export const onCoinjoinRoundChanged = [
                     {
                         key: 'a',
                         session: { signedRounds: ['1', '2'], maxRounds: 2 },
-                        previousSessions: [],
                     },
                 ],
             },
@@ -177,7 +176,6 @@ export const onCoinjoinRoundChanged = [
                     {
                         key: 'a',
                         session: { signedRounds: ['1', '2'], maxRounds: 2 },
-                        previousSessions: [],
                     },
                 ],
             },
@@ -218,7 +216,6 @@ export const onCoinjoinRoundChanged = [
                     {
                         key: 'a',
                         session: { signedRounds: ['1', '2'], maxRounds: 2 },
-                        previousSessions: [],
                     },
                 ],
             },

--- a/packages/suite/src/actions/wallet/__tests__/coinjoinClientActions.test.ts
+++ b/packages/suite/src/actions/wallet/__tests__/coinjoinClientActions.test.ts
@@ -223,7 +223,6 @@ describe('coinjoinClientActions', () => {
                             key: 'btc-account1',
                             symbol: 'btc',
                             session: { roundPhase: 1, signedRounds: [], maxRounds: 10 },
-                            previousSessions: [],
                         },
                     ],
                 } as any,

--- a/packages/suite/src/reducers/wallet/__fixtures__/coinjoinReducer.ts
+++ b/packages/suite/src/reducers/wallet/__fixtures__/coinjoinReducer.ts
@@ -6,7 +6,6 @@ const account = {
     key: 'A',
     symbol: 'test',
     targetAnonymity: 20,
-    previousSessions: [],
     session: {
         maxCoordinatorFeeRate: 0.003,
         maxFeePerKvbyte: 2000,

--- a/packages/suite/src/reducers/wallet/coinjoinReducer.ts
+++ b/packages/suite/src/reducers/wallet/coinjoinReducer.ts
@@ -104,7 +104,6 @@ const createAccount = (
         key: account.key,
         symbol: account.symbol,
         rawLiquidityClue: null, // NOTE: liquidity clue is calculated from tx history. default value is `null`
-        previousSessions: [],
     };
     const index = draft.accounts.findIndex(a => a.key === account.key);
     if (index < 0) draft.accounts.push(coinjoinAccount);
@@ -271,13 +270,7 @@ const completeSession = (
     payload: ExtractActionPayload<typeof COINJOIN.SESSION_COMPLETED>,
 ) => {
     const account = getAccount(draft, payload.accountKey);
-    if (!account) return;
-    if (account.session) {
-        account.previousSessions.push({
-            ...account.session,
-            timeEnded: Date.now(),
-            sessionPhaseQueue: [],
-        });
+    if (account?.session) {
         delete account.session;
     }
 };
@@ -287,12 +280,7 @@ const stopSession = (
     payload: ExtractActionPayload<typeof COINJOIN.ACCOUNT_UNREGISTER>,
 ) => {
     const account = getAccount(draft, payload.accountKey);
-    if (!account) return;
-    if (account.session) {
-        account.previousSessions.push({
-            ...account.session,
-            timeEnded: Date.now(),
-        });
+    if (account?.session) {
         delete account.session;
     }
 };

--- a/packages/suite/src/storage/migrations/index.ts
+++ b/packages/suite/src/storage/migrations/index.ts
@@ -568,6 +568,8 @@ export const migrate: OnUpgradeFunc<SuiteDBSchema> = async (
     if (oldVersion < 37) {
         await updateAll(transaction, 'coinjoinAccounts', account => {
             delete account.session;
+            // @ts-expect-error previousSessions field is removed
+            delete account.previousSessions;
 
             return account;
         });

--- a/packages/suite/src/types/wallet/coinjoin.ts
+++ b/packages/suite/src/types/wallet/coinjoin.ts
@@ -67,7 +67,6 @@ export interface CoinjoinAccount {
     setup?: CoinjoinSetup; // unless enabled, account uses default (recommended) values
     rawLiquidityClue: RegisterAccountParams['rawLiquidityClue'];
     session?: CoinjoinSession; // current/active authorized session
-    previousSessions: CoinjoinSession[]; // history
     checkpoints?: CoinjoinDiscoveryCheckpoint[];
     anonymityGains?: AnonymityGains;
     transactionCandidates?: CoinjoinTxCandidate[];


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

followup for https://github.com/trezor/trezor-suite/pull/8852

remove unused `previousSessions` field from `CoinjoinAccount`