### PR TITLE
fix(suite-native): event tooltip zero sum values

### DIFF
--- a/suite-native/formatters/src/components/CryptoAmountFormatter.tsx
+++ b/suite-native/formatters/src/components/CryptoAmountFormatter.tsx
@@ -28,7 +28,7 @@ export const CryptoAmountFormatter = ({
 }: CryptoToFiatAmountFormatterProps) => {
     const { CryptoAmountFormatter: formatter } = useFormatters();
 
-    if (!value) return <EmptyAmountText />;
+    if (G.isNullable(value)) return <EmptyAmountText />;
 
     const maxDisplayedDecimals = networks[network].decimals;
 

--- a/suite-native/graph/src/components/TransactionEventTooltip.tsx
+++ b/suite-native/graph/src/components/TransactionEventTooltip.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 import Animated, { FadeIn, FadeOut } from 'react-native-reanimated';
 import { Dimensions } from 'react-native';
 
-import { N } from '@mobily/ts-belt';
+import { G, N } from '@mobily/ts-belt';
 
 import { Card, Text } from '@suite-native/atoms';
 import { CryptoAmountFormatter, SignValueFormatter } from '@suite-native/formatters';
@@ -104,7 +104,7 @@ export const TransactionEventTooltip = ({
                         networkSymbol={networkSymbol}
                     />
                 )}
-                {totalAmount && (
+                {G.isNotNullable(totalAmount) && (
                     <EventTooltipRow
                         title="In total"
                         signValue={totalAmount}


### PR DESCRIPTION
Zero-sum values of the event tooltip do not crash the app anymore.

## Related Issue

related to #8857 
