### PR TITLE
transport: udp support

### DIFF
--- a/packages/connect/src/device/DeviceList.ts
+++ b/packages/connect/src/device/DeviceList.ts
@@ -7,6 +7,7 @@ import {
     BridgeTransport,
     WebUsbTransport,
     NodeUsbTransport,
+    UdpTransport,
     Transport,
     TRANSPORT,
     Descriptor,
@@ -102,6 +103,14 @@ export class DeviceList extends TypedEmitter<DeviceListEvents> {
                                 latestVersion: getBridgeInfo().version.join('.'),
                                 messages: this.messages,
                                 logger: transportLogger,
+                            }),
+                        );
+                        break;
+                    case 'UdpTransport':
+                        this.transports.push(
+                            new UdpTransport({
+                                logger: transportLogger,
+                                messages: this.messages,
                             }),
                         );
                         break;

--- a/packages/suite/src/views/settings/debug/Transport.tsx
+++ b/packages/suite/src/views/settings/debug/Transport.tsx
@@ -29,6 +29,7 @@ export const Transport = () => {
 
         if (isDesktop()) {
             transports.push('NodeUsbTransport');
+            transports.push('UdpTransport');
         } else {
             transports.push('WebUsbTransport');
         }

--- a/packages/transport/package.json
+++ b/packages/transport/package.json
@@ -18,8 +18,10 @@
     "main": "./lib/index.js",
     "browser": {
         "./lib/transports/nodeusb": "./lib/transports/nodeusb.browser",
+        "./lib/transports/udp": "./lib/transports/udp.browser",
         "./lib/transports/webusb": "./lib/transports/webusb.browser",
         "./src/transports/nodeusb": "./src/transports/nodeusb.browser",
+        "./src/transports/udp": "./src/transports/udp.browser",
         "./src/transports/webusb": "./src/transports/webusb.browser"
     },
     "files": [

--- a/packages/transport/src/index.ts
+++ b/packages/transport/src/index.ts
@@ -28,3 +28,7 @@ export { WebUsbTransport } from './transports/webusb';
 
 // node only
 export { NodeUsbTransport } from './transports/nodeusb';
+export { SessionsBackground } from './sessions/background';
+export { SessionsClient } from './sessions/client';
+
+export { UdpTransport } from './transports/udp';

--- a/packages/transport/src/interfaces/udp.ts
+++ b/packages/transport/src/interfaces/udp.ts
@@ -1,0 +1,136 @@
+import UDP from 'dgram';
+import { isNotUndefined } from '@trezor/utils';
+
+import { AbstractInterface } from './abstract';
+import { AsyncResultWithTypedError, ResultWithTypedError } from '../types';
+
+import * as ERRORS from '../errors';
+
+type ConstructorParams = ConstructorParameters<typeof AbstractInterface>[0];
+
+export class UdpInterface extends AbstractInterface {
+    interface = UDP.createSocket('udp4');
+    protected communicating = false;
+
+    constructor({ logger }: ConstructorParams) {
+        super({ logger });
+    }
+
+    public write(path: string, buffer: Buffer) {
+        const [hostname, port] = path.split(':');
+
+        return new Promise<
+            ResultWithTypedError<
+                undefined,
+                typeof ERRORS.INTERFACE_DATA_TRANSFER | typeof ERRORS.UNEXPECTED_ERROR
+            >
+        >(resolve => {
+            this.interface.send(buffer, Number.parseInt(port, 10), hostname, err => {
+                if (err) {
+                    this.logger.error(err.message);
+
+                    return resolve(
+                        this.error({
+                            error: ERRORS.INTERFACE_DATA_TRANSFER,
+                            message: err.message,
+                        }),
+                    );
+                }
+                return resolve(this.success(undefined));
+            });
+        });
+    }
+
+    public read(
+        _path: string,
+    ): AsyncResultWithTypedError<
+        ArrayBuffer,
+        | typeof ERRORS.DEVICE_NOT_FOUND
+        | typeof ERRORS.INTERFACE_UNABLE_TO_OPEN_DEVICE
+        | typeof ERRORS.INTERFACE_DATA_TRANSFER
+        | typeof ERRORS.DEVICE_DISCONNECTED_DURING_ACTION
+        | typeof ERRORS.UNEXPECTED_ERROR
+        | typeof ERRORS.ABORTED_BY_TIMEOUT
+    > {
+        this.communicating = true;
+
+        return new Promise<
+            ResultWithTypedError<
+                ArrayBuffer,
+                typeof ERRORS.INTERFACE_DATA_TRANSFER | typeof ERRORS.ABORTED_BY_TIMEOUT
+            >
+        >(resolve => {
+            const onError = (err: Error) => {
+                this.logger.error(err.message);
+
+                resolve(
+                    this.error({
+                        error: ERRORS.INTERFACE_DATA_TRANSFER,
+                        message: err.message,
+                    }),
+                );
+                this.interface.removeListener('error', onError);
+                // eslint-disable-next-line @typescript-eslint/no-use-before-define
+                this.interface.removeListener('message', onMessage);
+            };
+            const onMessage = (message: Buffer, _info: UDP.RemoteInfo) => {
+                if (message.toString() === 'PONGPONG') {
+                    return;
+                }
+                this.interface.removeListener('error', onError);
+                this.interface.removeListener('message', onMessage);
+                resolve(this.success(message));
+            };
+            this.interface.addListener('error', onError);
+            this.interface.addListener('message', onMessage);
+        }).finally(() => {
+            this.communicating = false;
+        });
+    }
+
+    private async ping(path: string) {
+        await this.write(path, Buffer.from('PINGPING'));
+
+        const pinged = new Promise<boolean>(resolve => {
+            const onMessage = (message: Buffer, _info: UDP.RemoteInfo) => {
+                if (message.toString() === 'PONGPONG') {
+                    resolve(true);
+                    this.interface.removeListener('message', onMessage);
+                    // eslint-disable-next-line @typescript-eslint/no-use-before-define
+                    clearTimeout(timeout);
+                }
+            };
+            this.interface.addListener('message', onMessage);
+
+            const timeout = setTimeout(
+                () => {
+                    this.interface.removeListener('message', onMessage);
+                    resolve(false);
+                },
+                this.communicating ? 10000 : 500,
+            );
+        });
+
+        return pinged;
+    }
+
+    public async enumerate() {
+        // in theory we could support multiple devices, but we don't yet
+        const paths = ['127.0.0.1:21324'];
+
+        const enumerateResult = await Promise.all(
+            paths.map(path => this.ping(path).then(pinged => (pinged ? path : undefined))),
+        ).then(res => res.filter(isNotUndefined));
+
+        return this.success(enumerateResult);
+    }
+
+    public openDevice(_path: string, _first: boolean) {
+        // todo: maybe ping?
+        return Promise.resolve(this.success(undefined));
+    }
+
+    public closeDevice(_path: string) {
+        return Promise.resolve(this.success(undefined));
+    }
+}

--- a/packages/transport/src/transports/abstract.ts
+++ b/packages/transport/src/transports/abstract.ts
@@ -58,7 +58,11 @@ export abstract class AbstractTransport extends TypedEmitter<{
         | typeof ERRORS.WRONG_RESULT_TYPE
         | typeof ERRORS.UNEXPECTED_ERROR;
 }> {
-    public abstract name: 'BridgeTransport' | 'NodeUsbTransport' | 'WebUsbTransport';
+    public abstract name:
+        | 'BridgeTransport'
+        | 'NodeUsbTransport'
+        | 'WebUsbTransport'
+        | 'UdpTransport';
     /**
      * transports with "external element" such as bridge can be outdated.
      */

--- a/packages/transport/src/transports/udp.browser.ts
+++ b/packages/transport/src/transports/udp.browser.ts
@@ -1,0 +1,28 @@
+import { AbstractTransport } from './abstract';
+
+import { error } from '../utils/result';
+import { WRONG_ENVIRONMENT } from '../errors';
+
+const emptyAbortable = () => ({
+    promise: Promise.resolve(error({ error: WRONG_ENVIRONMENT })),
+    abort: () => {},
+});
+
+const empty = () => Promise.resolve(error({ error: WRONG_ENVIRONMENT }));
+
+const emptySync = () => error({ error: WRONG_ENVIRONMENT });
+
+export class UdpTransport extends AbstractTransport {
+    public name = 'UdpTransport' as const;
+
+    init = emptyAbortable;
+    acquire = emptyAbortable;
+    enumerate = emptyAbortable;
+    call = emptyAbortable;
+    receive = emptyAbortable;
+    send = emptyAbortable;
+    release = emptyAbortable;
+    stop = empty;
+    releaseDevice = empty;
+    listen = emptySync;
+}

--- a/packages/transport/src/transports/udp.ts
+++ b/packages/transport/src/transports/udp.ts
@@ -1,0 +1,42 @@
+import { AbstractTransport } from './abstract';
+
+import { UdpInterface } from '../interfaces/udp';
+import { AbstractUsbTransport } from './abstractUsb';
+
+import { SessionsClient } from '../sessions/client';
+import { SessionsBackground } from '../sessions/background';
+
+type UdpConstructorParameters = ConstructorParameters<typeof AbstractTransport>[0] & {};
+export class UdpTransport extends AbstractUsbTransport {
+    public name = 'UdpTransport' as const;
+
+    constructor({ messages, logger }: UdpConstructorParameters) {
+        const sessionsBackground = new SessionsBackground();
+
+        // in udp there is no synchronization yet. it depends where this transport runs (node or browser)
+        const sessionsClient = new SessionsClient({
+            requestFn: args => sessionsBackground.handleMessage(args),
+            registerBackgroundCallbacks: () => {},
+        });
+
+        sessionsBackground.on('descriptors', descriptors => {
+            sessionsClient.emit('descriptors', descriptors);
+        });
+
+        super({
+            messages,
+            // @ts-expect-error
+            usbInterface: new UdpInterface({ logger }),
+            logger,
+
+            sessionsClient,
+        });
+
+        const enumerateRecursive = () => {
+            setTimeout(() => {
+                this.enumerate().promise.finally(enumerateRecursive);
+            }, 500);
+        };
+        enumerateRecursive();
+    }
+}


### PR DESCRIPTION

Commits:
~~1st commit - there was one remnant of protocol related logic (first byte of chunk is "?") incorrectly placed in interface related logic. Since we are starting to add new interfaces, this time its udp, it needed to go where it belongs.~~ cherry picked in https://github.com/trezor/trezor-suite/pull/9117
~~2nd commit - just a small change in interface typings. previously it did accept type parameter for device as I believed it might be useful to distinguish between nodeusb device and webusb device but this assumption turned false. it makes perfect sense to remove this type argument.~~ cherry picked in https://github.com/trezor/trezor-suite/pull/9111
3rd commit - implements udp transport. it is basically the same transport just like webusb/nodesub the only difference is that it uses udp interface to communicate with emulator under the hood. 

Followups:
- I am tempted to rename "abstractUsbTransport" to something like "abstractLocalTransport". There are basically 2 types of tranports - local ones - meaning those with direct access to the actual interface api. And remote ones that are bridging the gap between where the transport needs to be used and where it acutally runs.
- In trezor-user-env, open up udp port to host so it is possible to use UDP transport with emulator from trezor-user-env. Now it can be tested only with emulator started on host directly
- Use udp transport in tests, especially in connect. This will effectively test good part of webusb/nodesub transport as well which is a nice sideeffect