### PR TITLE
coinjoin: persistent confirmation of terms and conditions

### DIFF
--- a/packages/suite/src/actions/wallet/coinjoinAccountActions.ts
+++ b/packages/suite/src/actions/wallet/coinjoinAccountActions.ts
@@ -15,6 +15,7 @@ import { Network, NetworkSymbol } from '@suite-common/wallet-config';
 import { Account } from '@suite-common/wallet-types';
 import {
     CoinjoinAccount,
+    CoinjoinConfig,
     CoinjoinDiscoveryCheckpoint,
     CoinjoinSessionParameters,
 } from 'src/types/wallet/coinjoin';
@@ -189,28 +190,10 @@ export const updateLastAnonymityReportTimestamp = (accountKey: string) =>
         payload: { accountKey },
     } as const);
 
-export const updateCoinjoinConfig = ({
-    averageAnonymityGainPerRound,
-    roundsFailRateBuffer,
-    roundsDurationInHours,
-    maxMiningFeeModifier,
-    maxFeePerVbyte,
-}: {
-    averageAnonymityGainPerRound: number;
-    roundsFailRateBuffer: number;
-    roundsDurationInHours: number;
-    maxMiningFeeModifier: number;
-    maxFeePerVbyte?: number;
-}) =>
+export const updateCoinjoinConfig = (payload: Partial<CoinjoinConfig>) =>
     ({
         type: COINJOIN.UPDATE_CONFIG,
-        payload: {
-            averageAnonymityGainPerRound,
-            roundsFailRateBuffer,
-            roundsDurationInHours,
-            maxMiningFeeModifier,
-            maxFeePerVbyte,
-        },
+        payload,
     } as const);
 
 export type CoinjoinAccountAction =

--- a/packages/suite/src/components/wallet/CoinjoinSummary/CoinjoinStatusWheel/ProgressWheel.tsx
+++ b/packages/suite/src/components/wallet/CoinjoinSummary/CoinjoinStatusWheel/ProgressWheel.tsx
@@ -7,6 +7,7 @@ import { useSelector } from 'src/hooks/suite/useSelector';
 import {
     selectCurrentCoinjoinWheelStates,
     selectSessionProgressByAccountKey,
+    selectStartCoinjoinSessionArguments,
 } from 'src/reducers/wallet/coinjoinReducer';
 import { useDispatch } from 'src/hooks/suite/useDispatch';
 import { useCoinjoinSessionBlockers } from 'src/hooks/coinjoin/useCoinjoinSessionBlockers';
@@ -14,6 +15,7 @@ import { goto } from 'src/actions/suite/routerActions';
 import { Translation } from 'src/components/suite/Translation';
 import { openModal } from 'src/actions/suite/modalActions';
 import { stopCoinjoinSession } from 'src/actions/wallet/coinjoinClientActions';
+import { startCoinjoinSession } from 'src/actions/wallet/coinjoinAccountActions';
 
 const getOutlineSvg = (theme: DefaultTheme) =>
     `url("data:image/svg+xml,%3csvg width='100%25' height='100%25' xmlns='http://www.w3.org/2000/svg'%3e%3crect width='100%25' height='100%25' fill='none' rx='100' ry='100' stroke='${theme.TYPE_LIGHT_GREY.replace(
@@ -149,9 +151,13 @@ export const ProgressWheel = ({ accountKey }: ProgressWheelProps) => {
         isResumeBlockedByLastingIssue,
         isNonePrivate,
         isCoinjoinUneco,
+        isLegalDocumentConfirmed,
     } = useSelector(selectCurrentCoinjoinWheelStates);
     const sessionProgress = useSelector(state =>
         selectSessionProgressByAccountKey(state, accountKey),
+    );
+    const startCoinjoinArgs = useSelector(state =>
+        selectStartCoinjoinSessionArguments(state, accountKey),
     );
 
     const [isWheelHovered, setIsWheelHovered] = useState(false);
@@ -177,6 +183,12 @@ export const ProgressWheel = ({ accountKey }: ProgressWheelProps) => {
             return;
         }
 
+        if (isLegalDocumentConfirmed && startCoinjoinArgs) {
+            dispatch(startCoinjoinSession(...startCoinjoinArgs));
+
+            return;
+        }
+
         dispatch(goto('wallet-anonymize', { preserveParams: true }));
     }, [
         isCoinjoinSessionBlocked,
@@ -186,6 +198,8 @@ export const ProgressWheel = ({ accountKey }: ProgressWheelProps) => {
         dispatch,
         accountKey,
         isCoinjoinUneco,
+        isLegalDocumentConfirmed,
+        startCoinjoinArgs,
     ]);
 
     const getTooltipMessage = () => {

--- a/packages/suite/src/components/wallet/PrivacyAccount/MaxMiningFeeSetup.tsx
+++ b/packages/suite/src/components/wallet/PrivacyAccount/MaxMiningFeeSetup.tsx
@@ -7,7 +7,7 @@ import { coinjoinAccountUpdateMaxMiningFee } from 'src/actions/wallet/coinjoinAc
 import { SetupSlider } from './SetupSlider';
 import {
     selectDefaultMaxMiningFeeByAccountKey,
-    selectfeeRateMedianByAccountKey,
+    selectFeeRateMedianByAccountKey,
 } from 'src/reducers/wallet/coinjoinReducer';
 
 const min = 1;
@@ -25,7 +25,7 @@ interface MaxMiningFeeSetupProps {
 }
 
 export const MaxMiningFeeSetup = ({ accountKey, maxMiningFee }: MaxMiningFeeSetupProps) => {
-    const feeRateMedian = useSelector(state => selectfeeRateMedianByAccountKey(state, accountKey));
+    const feeRateMedian = useSelector(state => selectFeeRateMedianByAccountKey(state, accountKey));
     const defaultMaxMiningFee = useSelector(state =>
         selectDefaultMaxMiningFeeByAccountKey(state, accountKey),
     );

--- a/packages/suite/src/middlewares/wallet/coinjoinMiddleware.ts
+++ b/packages/suite/src/middlewares/wallet/coinjoinMiddleware.ts
@@ -231,22 +231,25 @@ export const coinjoinMiddleware =
             const incomingConfig = selectFeatureConfig(state, Feature.coinjoin);
 
             if (incomingConfig) {
-                const config = {
-                    ...state.wallet.coinjoin.config,
-                };
+                const { config } = state.wallet.coinjoin;
+                const updatedConfig: Partial<typeof config> = {};
 
                 // Iterate over existing config and replace the value from remote config only if it's valid number.
-                (Object.keys(config) as Array<keyof CoinjoinConfig>).forEach(
-                    (key: keyof CoinjoinConfig) => {
-                        const value = Number(incomingConfig[key]);
+                (Object.keys(config) as Array<keyof CoinjoinConfig>).forEach(key => {
+                    const value = incomingConfig[key];
 
-                        if (!Number.isNaN(value)) {
-                            config[key] = value;
-                        }
-                    },
-                );
+                    if (
+                        config[key] !== value &&
+                        ((typeof config[key] === 'string' && typeof value === 'string') ||
+                            (typeof config[key] !== 'string' && typeof value === 'number'))
+                    ) {
+                        Object.assign(updatedConfig, { [key]: value });
+                    }
+                });
 
-                api.dispatch(coinjoinAccountActions.updateCoinjoinConfig(config));
+                if (Object.keys(updatedConfig).length > 0) {
+                    api.dispatch(coinjoinAccountActions.updateCoinjoinConfig(updatedConfig));
+                }
             }
         }
 

--- a/packages/suite/src/services/coinjoin/config.ts
+++ b/packages/suite/src/services/coinjoin/config.ts
@@ -147,6 +147,8 @@ export const CLIENT_STATUS_FALLBACK = {
         max: MAX_ALLOWED_AMOUNT_FALLBACK,
     },
 };
+export const ZKSNACKS_LEGAL_DOCUMENTS_VERSION = '1.0';
+export const TREZOR_LEGAL_DOCUMENTS_VERSION = '1.0';
 
 // Estimating anonymity gain per round:
 // How many previous coinjoin transactions are taken into account

--- a/packages/suite/src/types/wallet/coinjoin.ts
+++ b/packages/suite/src/types/wallet/coinjoin.ts
@@ -76,6 +76,11 @@ export interface CoinjoinTxCandidate {
     roundId: string;
 }
 
+export interface CoinjoinLegalDocuments {
+    zkSNACKs: string;
+    trezor: string;
+}
+
 export interface CoinjoinAccount {
     key: string; // reference to wallet Account.key
     symbol: NetworkSymbol;
@@ -86,6 +91,7 @@ export interface CoinjoinAccount {
     anonymityGains?: AnonymityGains;
     transactionCandidates?: CoinjoinTxCandidate[];
     prison?: Record<string, Omit<CoinjoinPrisonInmate, 'id' | 'accountKey'>>;
+    agreedToLegalDocumentVersions?: CoinjoinLegalDocuments;
 }
 
 export type CoinjoinServerEnvironment = 'public' | 'staging' | 'localhost';
@@ -101,4 +107,5 @@ export interface CoinjoinConfig {
     roundsDurationInHours: number;
     maxMiningFeeModifier: number;
     maxFeePerVbyte?: number;
+    legalDocumentsVersion: string;
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Confirm terms and conditions only once per (remembered) account

- create common selector for `startCoinjoinSession` action [0c320b5](https://github.com/trezor/trezor-suite/pull/8957/commits/0c320b5b0d3f161dd63aedd62ee9ac3e4bc8fde8)
  action is called from `CoinjoinConfirmation` component (as before) and from `ProgressWheel` component (newly)
  additional cleanup in coinjoinReducer:
  - proper fallback of default traget anonymity
  - renamend selector to keep CamelCase syntax
  
- create new condition `isLegalDocumentConfirmed` [c33694d](https://github.com/trezor/trezor-suite/pull/8957/commits/c33694d03de64c054355facd9d875e14bdc0fa12)
  legalDocuments versions  could be overriden by:
  - trezor T&C version via messagingSystem (same as other values of coinjoinReducer.config)
  - zkSNACKs version via coinjoinClient.version returned by coordinator


## Related Issue

Resolve https://github.com/trezor/trezor-suite/issues/7456
