### PR TITLE
fix(connect): release init comment with changes

### DIFF
--- a/ci/scripts/connect-release-init.js
+++ b/ci/scripts/connect-release-init.js
@@ -57,8 +57,6 @@ const splitByNewlines = input => input.split('\n');
 const findIndexByCommit = (commitArr, searchString) =>
     commitArr.findIndex(commit => commit.includes(searchString));
 
-const formArrayToText = arr => arr.join('\n');
-
 const initConnectRelease = () => {
     const checkResult = checkPackageDependencies('connect');
 
@@ -179,7 +177,13 @@ const initConnectRelease = () => {
     // Creating a comment only if there are commits to add since last connect release.
     if (connectGitLogIndex !== -1) {
         connectGitLogArr.splice(connectGitLogIndex, connectGitLogArr.length - connectGitLogIndex);
-        const connectGitLogText = formArrayToText(connectGitLogArr);
+        // In array `connectGitLogArr` each item string contains " at the beginning and " at the end, let's remove those characters.
+        const cleanConnectGitLogArr = connectGitLogArr.map(line => line.slice(1, -1));
+        const connectGitLogText = cleanConnectGitLogArr.reduce(
+            (acc, line) => `${acc}\n${line}`,
+            '',
+        );
+
         comment({
             prNumber,
             body: connectGitLogText,


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
There was an issue that this last part of the release code was not working properly with the error below:

```
gh pr comment 8956 --body 
{
  status: 1,
  signal: null,
  output: [ null, '', 'GraphQL: Body cannot be blank (addComment)\n' ],
  pid: 4607,
  stdout: '',
  stderr: 'GraphQL: Body cannot be blank (addComment)\n'
}
```

https://github.com/trezor/trezor-suite/actions/runs/5601934219/jobs/10246515443

I think that the concatenated string previously provided like below was creating and issue with `gh pr comment`:
"- text", "- other text"....
Instead using multiline string the same way that `depsChecklist` is doing should work.


