### PR TITLE
fix(suite-native): long amounts formatting

### DIFF
--- a/suite-native/assets/src/components/AssetItem.tsx
+++ b/suite-native/assets/src/components/AssetItem.tsx
@@ -118,6 +118,8 @@ export const AssetItem = React.memo(
                             <CryptoAmountFormatter
                                 value={cryptoCurrencyValue}
                                 network={cryptoCurrencySymbol}
+                                // Every asset crypto amount is rounded to 8 decimals to prevent UI overflow.
+                                decimals={8}
                             />
                         </Box>
                     </Box>

--- a/suite-native/atoms/src/Table.tsx
+++ b/suite-native/atoms/src/Table.tsx
@@ -1,6 +1,7 @@
 import React, { ReactNode } from 'react';
 
 import { Box } from './Box';
+import { HStack } from './Stack';
 import { Text } from './Text';
 
 type TableProps = {
@@ -10,11 +11,7 @@ type TdProps = {
     children?: ReactNode;
 };
 
-export const Td = ({ children }: TdProps) => (
-    <Box flex={1}>
-        <Text variant="hint">{children}</Text>
-    </Box>
-);
+export const Td = ({ children }: TdProps) => <Box flex={1}>{children}</Box>;
 
 export const Th = ({ children }: TdProps) => (
     <Box flex={1}>
@@ -24,9 +21,9 @@ export const Th = ({ children }: TdProps) => (
     </Box>
 );
 export const Tr = ({ children }: TableProps) => (
-    <Box flexDirection="row" justifyContent="space-between" marginVertical="small">
+    <HStack flexDirection="row" justifyContent="space-between" marginVertical="small">
         {children}
-    </Box>
+    </HStack>
 );
 
 export const Table = ({ children }: TableProps) => <Box>{children}</Box>;

--- a/suite-native/formatters/src/components/CryptoAmountFormatter.tsx
+++ b/suite-native/formatters/src/components/CryptoAmountFormatter.tsx
@@ -15,6 +15,7 @@ type CryptoToFiatAmountFormatterProps = FormatterProps<string | null | number> &
         network: NetworkSymbol;
         isBalance?: boolean;
         isDiscreetText?: boolean;
+        decimals?: number;
     };
 
 export const CryptoAmountFormatter = ({
@@ -24,13 +25,14 @@ export const CryptoAmountFormatter = ({
     isDiscreetText = true,
     variant = 'hint',
     color = 'textSubdued',
+    decimals,
     ...textProps
 }: CryptoToFiatAmountFormatterProps) => {
     const { CryptoAmountFormatter: formatter } = useFormatters();
 
     if (!value) return <EmptyAmountText />;
 
-    const maxDisplayedDecimals = networks[network].decimals;
+    const maxDisplayedDecimals = decimals ?? networks[network].decimals;
 
     const stringValue = G.isNumber(value) ? value.toString() : value;
     const formattedValue = formatter.format(stringValue, {

--- a/suite-native/transactions/src/components/TransactionDetail/TransactionDetailInputsSheetSection.tsx
+++ b/suite-native/transactions/src/components/TransactionDetail/TransactionDetailInputsSheetSection.tsx
@@ -41,6 +41,8 @@ const TransactionAddressAmount = ({
                     network={symbol}
                     isBalance={false}
                     variant="label"
+                    numberOfLines={1}
+                    adjustsFontSizeToFit
                 />
             ) : (
                 <EthereumTokenAmountFormatter
@@ -48,6 +50,8 @@ const TransactionAddressAmount = ({
                     symbol={symbol}
                     decimals={decimals}
                     variant="label"
+                    numberOfLines={1}
+                    adjustsFontSizeToFit
                 />
             ))}
     </Box>

--- a/suite-native/transactions/src/components/TransactionDetail/TransactionDetailValuesSheet.tsx
+++ b/suite-native/transactions/src/components/TransactionDetail/TransactionDetailValuesSheet.tsx
@@ -110,15 +110,21 @@ export const TransactionDetailValuesSheet = ({
                         <Th>Input</Th>
                         <Td>
                             <CryptoToFiatAmountFormatter
+                                variant="hint"
                                 value={transaction.details.totalInput}
                                 network={transaction.symbol}
                                 customRates={transaction.rates}
+                                numberOfLines={1}
+                                adjustsFontSizeToFit
                             />
                         </Td>
                         <Td>
                             <CryptoToFiatAmountFormatter
+                                variant="hint"
                                 value={transaction.details.totalInput}
                                 network={transaction.symbol}
+                                numberOfLines={1}
+                                adjustsFontSizeToFit
                             />
                         </Td>
                     </Tr>
@@ -126,15 +132,21 @@ export const TransactionDetailValuesSheet = ({
                         <Th>Fee</Th>
                         <Td>
                             <CryptoToFiatAmountFormatter
+                                variant="hint"
                                 value={transaction.fee}
                                 network={transaction.symbol}
                                 customRates={transaction.rates}
+                                numberOfLines={1}
+                                adjustsFontSizeToFit
                             />
                         </Td>
                         <Td>
                             <CryptoToFiatAmountFormatter
+                                variant="hint"
                                 value={transaction.fee}
                                 network={transaction.symbol}
+                                numberOfLines={1}
+                                adjustsFontSizeToFit
                             />
                         </Td>
                     </Tr>
@@ -142,15 +154,21 @@ export const TransactionDetailValuesSheet = ({
                         <Th>Total</Th>
                         <Td>
                             <CryptoToFiatAmountFormatter
+                                variant="hint"
                                 value={transaction.amount}
                                 network={transaction.symbol}
                                 customRates={transaction.rates}
+                                numberOfLines={1}
+                                adjustsFontSizeToFit
                             />
                         </Td>
                         <Td>
                             <CryptoToFiatAmountFormatter
+                                variant="hint"
                                 value={transaction.amount}
                                 network={transaction.symbol}
+                                numberOfLines={1}
+                                adjustsFontSizeToFit
                             />
                         </Td>
                     </Tr>


### PR DESCRIPTION
## Description
- home screen long crypto amounts are rounded to 8 decimals
- Other places in the app where long amounts overflow changed to use text prop `adjustFontsizeToFit`

## Related Issue

Resolve #8813 

## Screenshots:

https://github.com/trezor/trezor-suite/assets/26143964/67aa7758-8569-40e3-a472-05859df8fb79


