### PR TITLE
fix(components): prevent closing select menu when scrolling through o…

### DIFF
--- a/packages/components/src/components/form/Select/index.tsx
+++ b/packages/components/src/components/form/Select/index.tsx
@@ -218,6 +218,10 @@ const BottomText = styled.div<Pick<SelectProps, 'inputState'>>`
     min-height: 27px;
 `;
 
+// Prevent closing the menu when scrolling through options.
+const closeMenuOnScroll = (e: Event) =>
+    !(e.target as Element)?.className?.startsWith(reactSelectClassNamePrefix);
+
 type Option = any;
 
 /** Custom Type Guards to check if options are grouped or not */
@@ -449,7 +453,7 @@ export const Select = ({
                 onKeyDown={onKeyDown}
                 classNamePrefix={reactSelectClassNamePrefix}
                 openMenuOnFocus
-                closeMenuOnScroll={() => true}
+                closeMenuOnScroll={closeMenuOnScroll}
                 menuPosition="fixed" // Required for closeMenuOnScroll to work properly when near page bottom
                 menuPortalTarget={menuPortalTarget}
                 styles={selectStyle(


### PR DESCRIPTION
Follow-up fix to https://github.com/trezor/trezor-suite/pull/8917.

This code was originally there, I removed it when disabling `closeMenuOnScroll` and then forgot to add it back in https://github.com/trezor/trezor-suite/commit/b508348f336a46657a3bfed1ac52453a7d866eb7.