### PR TITLE
chore(suite): bump supported browser versions

### DIFF
--- a/packages/suite-build/browserslist
+++ b/packages/suite-build/browserslist
@@ -1,2 +1,2 @@
-Chrome >= 84
-Firefox >= 78
+Chrome >= 92
+Firefox >= 102

--- a/packages/suite-data/src/browser-detection/index.ts
+++ b/packages/suite-data/src/browser-detection/index.ts
@@ -163,17 +163,17 @@ window.addEventListener('load', () => {
     const supportedBrowsers = [
         {
             name: 'chrome',
-            version: 84,
+            version: 92,
             mobile: true,
         },
         {
             name: 'chromium',
-            version: 84,
+            version: 92,
             mobile: true,
         },
         {
             name: 'firefox',
-            version: 78,
+            version: 102,
             mobile: false, // no webusb support
         },
     ] as const;

--- a/packages/suite-web/e2e/tests/browser/outdated-chrome.test.ts
+++ b/packages/suite-web/e2e/tests/browser/outdated-chrome.test.ts
@@ -1,6 +1,6 @@
 // @group:browser
 // @retry=2
-// @user-agent=Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/83.0.4103.61 Safari/537.36
+// @user-agent=Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/91.0.4472 Safari/537.36
 
 // note that running tests in /browser folder will not work in 'debug local setup'
 

--- a/packages/suite-web/e2e/tests/browser/outdated-firefox.test.ts
+++ b/packages/suite-web/e2e/tests/browser/outdated-firefox.test.ts
@@ -1,6 +1,6 @@
 // @group:browser
 // @retry=2
-// @user-agent=Mozilla/5.0 (Windows NT 10.0; Win64; x64; rv:109.0) Gecko/20100101 Firefox/77.0
+// @user-agent=Mozilla/5.0 (Windows NT 10.0; Win64; x64; rv:109.0) Gecko/20100101 Firefox/101.0
 
 // note that running tests in /browser folder will not work in 'debug local setup'
 


### PR DESCRIPTION
Bumped supported browser version as per discussion on Slack

## Description

Supported versions are now `Chrome >= 92` and `Firefox >= 102`.

## Related Issue

Resolve #8832 
