### PR TITLE
fix(suite): remove imprisoned utxos from the set of ExcludedUtxos

### DIFF
--- a/packages/suite/src/actions/wallet/send/sendFormBitcoinActions.ts
+++ b/packages/suite/src/actions/wallet/send/sendFormBitcoinActions.ts
@@ -76,7 +76,10 @@ export const composeTransaction =
         // unspendable utxos are defined in `useSendForm` hook
         const utxo = formValues.isCoinControlEnabled
             ? formValues.selectedUtxos?.map(u => ({ ...u, required: true }))
-            : account.utxo.filter(u => (u as any).required || !excludedUtxos?.[getUtxoOutpoint(u)]);
+            : account.utxo.filter(u => {
+                  const outpoint = getUtxoOutpoint(u);
+                  return (u as any).required || (!excludedUtxos?.[outpoint] && !prison?.[outpoint]);
+              });
 
         // certain change addresses might be temporary blocked by coinjoin process
         // exclude addresses which exists in "prison" dataset (see coinjoinReducer/selectBlockedUtxosByAccountKey)

--- a/packages/suite/src/hooks/wallet/form/useExcludedUtxos.ts
+++ b/packages/suite/src/hooks/wallet/form/useExcludedUtxos.ts
@@ -12,12 +12,7 @@ interface UseExcludedUtxosProps extends GetExcludedUtxosProps {
  * Returns utxos which should be automatically excluded while composingTransaction.
  * Response format: { utxo_outpoint: exclusion_reason }
  */
-export const useExcludedUtxos = ({
-    account,
-    dustLimit,
-    targetAnonymity,
-    prison,
-}: UseExcludedUtxosProps) =>
+export const useExcludedUtxos = ({ account, dustLimit, targetAnonymity }: UseExcludedUtxosProps) =>
     useMemo(
         () =>
             getExcludedUtxos({
@@ -25,7 +20,6 @@ export const useExcludedUtxos = ({
                 anonymitySet: account.addresses?.anonymitySet,
                 dustLimit,
                 targetAnonymity,
-                prison,
             }),
-        [account.utxo, account.addresses?.anonymitySet, dustLimit, targetAnonymity, prison],
+        [account.utxo, account.addresses?.anonymitySet, dustLimit, targetAnonymity],
     );

--- a/packages/suite/src/hooks/wallet/useSendForm.ts
+++ b/packages/suite/src/hooks/wallet/useSendForm.ts
@@ -156,7 +156,6 @@ export const useSendForm = (props: UseSendFormProps): SendContextValues => {
         account: state.account,
         dustLimit: state.coinFees.dustLimit,
         targetAnonymity: props.targetAnonymity,
-        prison: props.prison,
     });
 
     // declare sendFormUtils, sub-hook of useSendForm

--- a/packages/suite/src/hooks/wallet/useSendFormCompose.ts
+++ b/packages/suite/src/hooks/wallet/useSendFormCompose.ts
@@ -102,6 +102,7 @@ export const useSendFormCompose = ({
                 network: state.network,
                 feeInfo: state.feeInfo,
                 excludedUtxos,
+                prison,
             });
         };
 
@@ -123,6 +124,7 @@ export const useSendFormCompose = ({
     }, [
         account,
         excludedUtxos,
+        prison,
         state.network,
         state.feeInfo,
         updateContext,

--- a/suite-common/wallet-types/src/sendForm.ts
+++ b/suite-common/wallet-types/src/sendForm.ts
@@ -45,7 +45,7 @@ export interface FormState {
     selectedUtxos: AccountUtxo[];
 }
 
-export type ExcludedUtxos = Record<string, 'low-anonymity' | 'dust' | 'prison' | undefined>;
+export type ExcludedUtxos = Record<string, 'low-anonymity' | 'dust' | undefined>;
 
 // local state of @wallet-hooks/useSendForm
 export type UseSendFormState = {

--- a/suite-common/wallet-utils/src/sendFormUtils.ts
+++ b/suite-common/wallet-utils/src/sendFormUtils.ts
@@ -446,7 +446,6 @@ export interface GetExcludedUtxosProps {
     anonymitySet?: NonNullable<Account['addresses']>['anonymitySet'];
     dustLimit?: number;
     targetAnonymity?: number;
-    prison?: Record<string, unknown>;
 }
 
 export const getExcludedUtxos = ({
@@ -454,7 +453,6 @@ export const getExcludedUtxos = ({
     anonymitySet,
     dustLimit,
     targetAnonymity,
-    prison,
 }: GetExcludedUtxosProps) => {
     // exclude utxos from default composeTransaction process (see sendFormBitcoinActions)
     // utxos are stored as dictionary where:
@@ -465,9 +463,7 @@ export const getExcludedUtxos = ({
     utxos?.forEach(utxo => {
         const outpoint = getUtxoOutpoint(utxo);
         const anonymity = (anonymitySet && anonymitySet[utxo.address]) || 1;
-        if (prison && prison[outpoint]) {
-            excludedUtxos[outpoint] = 'prison';
-        } else if (new BigNumber(utxo.amount).lte(Number(dustLimit))) {
+        if (new BigNumber(utxo.amount).lte(Number(dustLimit))) {
             // is lower than dust limit
             excludedUtxos[outpoint] = 'dust';
         } else if (anonymity < (targetAnonymity || 1)) {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Imprisoned utxos were stored in the set of `ExcludedUtxos` but there is no dedicated group for them in the UI therefore `useUtxoSelection` hook picks them as default case (as private, see code snipped below) 

```
account?.utxo?.forEach(utxo => {
        switch (excludedUtxos[getUtxoOutpoint(utxo)]) {
            case 'low-anonymity':
                lowAnonymityUtxos.push(utxo);
                return;
            case 'dust':
                dustUtxos.push(utxo);
                return;
            default:
                spendableUtxos.push(utxo);
        }
    });
```

Since im working on [displaying banned/blocked utxos in send form](https://github.com/trezor/trezor-suite/issues/8372) it will be resolved differently.

Currently imprisoned utxos (and change addresses) will be excluded only in `sendFormBitcoinActions`

## Related Issue

Resolve https://github.com/trezor/trezor-suite/issues/8870

## How to test it

The fastest way will be on the regtest.

- run regtest, and send yourself some coins
- start coinjoin process
- follow the logs, an wait untril once at least one utxo is successfully registered on coordinator (message like `Registration 9696ae60...00000000 to 9d9756d0...5631d029 successful. aliceId: 56c1b686-a0a7-5306-368c-e250dbf019a1`)
- stop coinjoin
- go to send form and open `Coin control`

**Result**: all utxos are marked as non private (on develop imprisoned/registered utxos are marked as private - described in the issue)

Then:

- go to detail and set coinjoin setup to "custom" -> Desired privacy level 1
- go to send form and click "send max"

**Result**: the amount is not equal to account balance (not all utxos were selected)







