### PR TITLE
fix(suite-native): include tokens transactions list

### DIFF
--- a/suite-native/transactions/src/components/TransactionsList/TransactionList.tsx
+++ b/suite-native/transactions/src/components/TransactionsList/TransactionList.tsx
@@ -153,26 +153,11 @@ export const TransactionList = ({
             ]);
         }
 
-        if (areTokensIncluded) {
-            return transactionMonthKeys.flatMap(monthKey => [
-                monthKey,
-                ...accountTransactionsByMonth[monthKey].flatMap(transaction =>
-                    transaction.tokens.map(
-                        tokenTransfer =>
-                            ({
-                                ...tokenTransfer,
-                                originalTransaction: transaction,
-                            } as EthereumTokenTransferWithTx),
-                    ),
-                ),
-            ]);
-        }
-
         return transactionMonthKeys.flatMap(monthKey => [
             monthKey,
             ...accountTransactionsByMonth[monthKey],
         ]) as TransactionListItem[];
-    }, [transactions, tokenContract, areTokensIncluded]);
+    }, [transactions, tokenContract]);
 
     const renderItem = useCallback(
         ({ item, index }: { item: TransactionListItem; index: number }) => {


### PR DESCRIPTION
Transaction list of ETH with toggled "Include tokens" shows all the normal transactions + tokens transactions as it should be.

The token filtering was removed from `TransactionList`, because rendering a sub-token transaction is handled separately inside of the `TransactionItem` component.

Fixes #8985

## Screenshot

https://github.com/trezor/trezor-suite/assets/26143964/08f7d5b3-7a80-4e12-bf80-ef8c789ae71c

