### PR TITLE
fix(suite): use localhost instead of [::] when starting webpack

### DIFF
--- a/packages/suite-build/configs/dev.webpack.config.ts
+++ b/packages/suite-build/configs/dev.webpack.config.ts
@@ -25,6 +25,7 @@ const config: webpack.Configuration = {
         new WebpackPluginServe({
             port: DEV_PORTS[project],
             hmr: true,
+            host: 'localhost',
             static: distPath,
             progress: true,
             historyFallback: {


### PR DESCRIPTION
Edited Webpack to write Server Listening on: http://localhost:8000 instead of http://[::]:8000 to terminal window (causing confusion because routing and WebUSB was not working for this url)

## Description

Specified `host` in `WebpackPluginServe`.

## Screenshots:

Before:

![Screenshot 2023-07-24 at 3 57 22 PM](https://github.com/trezor/trezor-suite/assets/66002635/22131fd8-ac59-4aba-8fab-490d5c87d5d3)

After:
![Screenshot 2023-07-24 at 3 58 07 PM](https://github.com/trezor/trezor-suite/assets/66002635/d2f9f9c1-e15a-4e2b-93ef-ed93d3c05826)