### PR TITLE
feat(suite): push toast error keys to analytics

### DIFF
--- a/packages/suite-analytics/src/constants.ts
+++ b/packages/suite-analytics/src/constants.ts
@@ -80,4 +80,6 @@ export enum EventType {
 
     GetDesktopApp = 'promo/desktop',
     GetMobileApp = 'promo/mobile',
+
+    ToastError = 'toast/error',
 }

--- a/packages/suite-analytics/src/types/events.ts
+++ b/packages/suite-analytics/src/types/events.ts
@@ -379,4 +379,10 @@ export type SuiteAnalyticsEvent =
           payload: {
               platform: 'ios' | 'android';
           };
+      }
+    | {
+          type: EventType.ToastError;
+          payload: {
+              error?: string;
+          };
       };

--- a/packages/suite/src/actions/firmware/firmwareActions.ts
+++ b/packages/suite/src/actions/firmware/firmwareActions.ts
@@ -318,7 +318,7 @@ export const checkFirmwareAuthenticity = () => async (dispatch: Dispatch, getSta
         }
     } else {
         dispatch(
-            notificationsActions.addToast({
+            notificationsActions.addErrorToastWithAnalytics({
                 type: 'error',
                 error: `Unable to validate firmware: ${result.payload.error}`,
             }),

--- a/packages/suite/src/middlewares/suite/analyticsMiddleware.ts
+++ b/packages/suite/src/middlewares/suite/analyticsMiddleware.ts
@@ -17,6 +17,7 @@ import {
     isDeviceInBootloaderMode,
 } from '@trezor/device-utils';
 import { analyticsActions } from '@suite-common/analytics';
+import { notificationsActions } from '@suite-common/toast-notifications';
 import {
     selectAnonymityGainToReportByAccountKey,
     selectCoinjoinAccountByKey,
@@ -210,6 +211,14 @@ const analyticsMiddleware =
                 }
                 break;
             }
+            case notificationsActions.addErrorToastWithAnalytics.type:
+                analytics.report({
+                    type: EventType.ToastError,
+                    payload: {
+                        error: action.payload.error,
+                    },
+                });
+                break;
 
             default:
                 break;

--- a/suite-common/toast-notifications/src/notificationsActions.ts
+++ b/suite-common/toast-notifications/src/notificationsActions.ts
@@ -36,6 +36,17 @@ export const addToast = createActionWithExtraDeps(
     }),
 );
 
+export const addErrorToastWithAnalytics = createActionWithExtraDeps(
+    `${ACTION_PREFIX}/addErrorToast`,
+    (payload: ToastPayload, { getState, extra }): NotificationEntry => ({
+        context: 'toast',
+        id: new Date().getTime(),
+        device: extra.selectors.selectCurrentDevice(getState()),
+        seen: true,
+        ...payload,
+    }),
+);
+
 // Adds a Toast if there is not one of same type visible.
 export const addToastOnce = createActionWithExtraDeps(
     `${ACTION_PREFIX}/addToastOnce`,
@@ -63,6 +74,7 @@ export const notificationsActions = {
     resetUnseen,
     remove,
     addToast,
+    addErrorToastWithAnalytics,
     addEvent,
     addToastOnce,
 };


### PR DESCRIPTION
Enable pushing error keys in toasts to analytics

## Description

Created `addAnalyticsErrorToast` function that reports events in `analyticsMiddleware`. This will be used in every file that currently has error toast (example usage in `firmwareActions.ts` file, counted roughly 50 other places) with no custom analytics.

## Related Issue

Resolve #7888 
