### PR TITLE
test(connect-popup): micro fix composeTransaction fixture

### DIFF
--- a/packages/connect-popup/e2e/tests/__fixtures__/methods.ts
+++ b/packages/connect-popup/e2e/tests/__fixtures__/methods.ts
@@ -184,7 +184,7 @@ const composeTransaction = [
                 screenshot: {
                     name: 'select-fee-default-screen',
                 },
-                next: 'text=Custom >> visible=true',
+                next: '.custom-fee >> visible=true',
             },
             {
                 selector: '.send-button >> visible=true',


### PR DESCRIPTION
noticed connet-popup e2e test for composeTransaction failed with this error in CI
<img width="1223" alt="image" src="https://github.com/trezor/trezor-suite/assets/30367552/f979546b-6be2-4899-8b49-3f4a905597d1">

this particular error means that playwright didn't like two strings "Custom" when he was looking for selector containing string "custom". 

I was unable to reproduce locally, could be that it depends on current fees and exact balance of account use for tx compose. Also @trezor/qa as you may see in the screenshot, there is apparently something wrong with the submit button. Could you please retest if you have a while? It might be useful to compare test trace from failed and successful test.

