### PR TITLE
fix(suite): long device name PIN modal

### DIFF
--- a/packages/suite/src/components/suite/modals/Pin.tsx
+++ b/packages/suite/src/components/suite/modals/Pin.tsx
@@ -41,7 +41,7 @@ export const Pin = ({ device, ...rest }: PinProps) => {
 
     return (
         <StyledModal
-            heading={<Translation id="TR_ENTER_PIN_ON_DEVICE_LABEL" />}
+            heading={<Translation id="TR_ENTER_PIN" />}
             description={
                 <Translation
                     id="TR_THE_PIN_LAYOUT_IS_DISPLAYED"

--- a/packages/suite/src/components/suite/modals/Pin.tsx
+++ b/packages/suite/src/components/suite/modals/Pin.tsx
@@ -41,13 +41,13 @@ export const Pin = ({ device, ...rest }: PinProps) => {
 
     return (
         <StyledModal
-            heading={
+            heading={<Translation id="TR_ENTER_PIN_ON_DEVICE_LABEL" />}
+            description={
                 <Translation
-                    id="TR_ENTER_PIN_ON_DEVICE_LABEL"
-                    values={{ deviceLabel: device.label }}
+                    id="TR_THE_PIN_LAYOUT_IS_DISPLAYED"
+                    values={{ deviceLabel: device.label, b: text => <b>{text}</b> }}
                 />
             }
-            description={<Translation id="TR_THE_PIN_LAYOUT_IS_DISPLAYED" />}
             onCancel={onCancel}
             isCancelable
             data-test="@modal/pin"

--- a/packages/suite/src/support/messages.ts
+++ b/packages/suite/src/support/messages.ts
@@ -2480,12 +2480,8 @@ export default defineMessages({
     },
     TR_ENTER_PIN: {
         defaultMessage: 'Enter PIN',
-        description: 'Button. Submit PIN',
+        description: 'Text for Header and Button when submitting PIN',
         id: 'TR_ENTER_PIN',
-    },
-    TR_ENTER_PIN_ON_DEVICE_LABEL: {
-        defaultMessage: 'Enter PIN',
-        id: 'TR_ENTER_PIN_ON_DEVICE_LABEL',
     },
     TR_ENTER_SEED_WORDS_INSTRUCTION: {
         defaultMessage:

--- a/packages/suite/src/support/messages.ts
+++ b/packages/suite/src/support/messages.ts
@@ -2484,7 +2484,7 @@ export default defineMessages({
         id: 'TR_ENTER_PIN',
     },
     TR_ENTER_PIN_ON_DEVICE_LABEL: {
-        defaultMessage: 'Enter PIN on {deviceLabel}',
+        defaultMessage: 'Enter PIN',
         id: 'TR_ENTER_PIN_ON_DEVICE_LABEL',
     },
     TR_ENTER_SEED_WORDS_INSTRUCTION: {
@@ -3356,7 +3356,7 @@ export default defineMessages({
         id: 'TR_TESTNET_COINS_LABEL',
     },
     TR_THE_PIN_LAYOUT_IS_DISPLAYED: {
-        defaultMessage: 'Check your Trezor screen for the keypad layout.',
+        defaultMessage: 'Check your <b>{deviceLabel}</b> screen for the keypad layout.',
         id: 'TR_THE_PIN_LAYOUT_IS_DISPLAYED',
     },
     TR_THIS_HIDDEN_WALLET_IS_EMPTY: {


### PR DESCRIPTION
Long device name caused that the UI of modal was a bit broken.

## Description

Moved the device name from modal's heading to modal's description. Also bolded the device name (as per a discussion in #8789)

Will be updating translations in Crowdin for `TR_ENTER_PIN_ON_DEVICE_LABEL` and `TR_THE_PIN_LAYOUT_IS_DISPLAYED`. Will use almost everything that I already translated and wrote to the translations files in the old PR (#8789) just this time will focus on putting the device name at the beginning or in the middle of the sentence ([suggestion](https://github.com/trezor/trezor-suite/pull/8789#issuecomment-1609504732) from @tomasklim). 

## Related Issue

Resolve #8606 
