### PR TITLE
Fix/popup lazyload

### DIFF
--- a/packages/connect-popup/src/index.tsx
+++ b/packages/connect-popup/src/index.tsx
@@ -222,9 +222,6 @@ const init = async (payload: PopupInit['payload']) => {
         payload.systemInfo = getSystemInfo(config.supportedBrowsers);
     }
 
-    // reset loading hash
-    window.location.hash = '';
-
     const isBrowserSupported = await view.initBrowserView(payload.systemInfo);
     if (!isBrowserSupported) {
         return;

--- a/packages/connect-web/src/index.ts
+++ b/packages/connect-web/src/index.ts
@@ -183,7 +183,7 @@ const call: CallMethod = async params => {
         if (!_popupManager) {
             _popupManager = initPopupManager();
         }
-        _popupManager.request(true);
+        _popupManager.request();
 
         // auto init with default settings
         try {

--- a/packages/connect-web/src/popup/index.ts
+++ b/packages/connect-web/src/popup/index.ts
@@ -112,6 +112,8 @@ export class PopupManager extends EventEmitter {
             if (this.settings.env === 'webextension') {
                 chrome.tabs.get(this.popupWindow.id, tab => {
                     if (!tab) {
+                        // If no reference to popup window, it was closed by user or by this.close() method.
+                        this.emit(POPUP.CLOSED);
                         this.clear();
                     }
                 });

--- a/packages/connect-web/src/popup/index.ts
+++ b/packages/connect-web/src/popup/index.ts
@@ -64,7 +64,7 @@ export class PopupManager extends EventEmitter {
         window.addEventListener('message', this.handleMessage, false);
     }
 
-    request(lazyLoad = false) {
+    request() {
         // popup request
         // TODO: ie - open immediately and hide it but post handshake after timeout
 
@@ -84,17 +84,16 @@ export class PopupManager extends EventEmitter {
         // we close it so we can open a new one.
         // This is necessary when popup window is in error state and we want to open a new one.
         if (this.popupWindow && !this.locked) {
-            this.popupWindow.close();
+            this.close();
         }
 
         const openFn = this.open.bind(this);
         this.locked = true;
 
-        const timeout =
-            lazyLoad || this.settings.env === 'webextension' ? 1 : POPUP_REQUEST_TIMEOUT;
+        const timeout = this.settings.env === 'webextension' ? 1 : POPUP_REQUEST_TIMEOUT;
         this.requestTimeout = window.setTimeout(() => {
             this.requestTimeout = 0;
-            openFn(lazyLoad);
+            openFn();
         }, timeout);
     }
 
@@ -102,11 +101,11 @@ export class PopupManager extends EventEmitter {
         this.locked = false;
     }
 
-    open(lazyLoad?: boolean) {
+    open() {
         const src = this.settings.popupSrc;
 
         this.popupPromise = createDeferred(POPUP.LOADED);
-        this.openWrapper(lazyLoad ? `${src}#loading` : src);
+        this.openWrapper(src);
 
         this.closeInterval = window.setInterval(() => {
             if (!this.popupWindow) return;


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Removing lazyload from PopupManager since it was not doing anything and get rid of resetting loading hash in Popup since it is not necessary anymore.

It was creating an issue with web extension closing because removing `#loading` from url was making it not a single history entry which is a requirement for `window.close()` to work as described in https://developer.mozilla.org/en-US/docs/Web/API/Window/close
