### PR TITLE
fix(suite): update selectedUtxos if utxo is spent

### DIFF
--- a/packages/suite/src/components/wallet/CoinControl/UtxoSelectionList.tsx
+++ b/packages/suite/src/components/wallet/CoinControl/UtxoSelectionList.tsx
@@ -3,6 +3,7 @@ import styled from 'styled-components';
 import { transparentize } from 'polished';
 
 import { selectAccountTransactionsWithNulls } from '@suite-common/wallet-core';
+import { isSameUtxo } from '@suite-common/wallet-utils';
 import { useSelector } from 'src/hooks/suite';
 import { Icon, variables, IconType } from '@trezor/components';
 import type { AccountUtxo } from '@trezor/connect';
@@ -68,7 +69,7 @@ export const UtxoSelectionList = ({
 
     const isChecked = (utxo: AccountUtxo) =>
         isCoinControlEnabled
-            ? selectedUtxos.some(u => u.txid === utxo.txid && u.vout === utxo.vout)
+            ? selectedUtxos.some(selected => isSameUtxo(selected, utxo))
             : composedInputs.some(u => u.prev_hash === utxo.txid && u.prev_index === utxo.vout);
 
     return (

--- a/packages/suite/src/hooks/wallet/form/useUtxoSelection.ts
+++ b/packages/suite/src/hooks/wallet/form/useUtxoSelection.ts
@@ -9,7 +9,7 @@ import {
     FormState,
 } from '@suite-common/wallet-types';
 import type { AccountUtxo, PROTO } from '@trezor/connect';
-import { getUtxoOutpoint } from '@suite-common/wallet-utils';
+import { getUtxoOutpoint, isSameUtxo } from '@suite-common/wallet-utils';
 
 interface UtxoSelectionContextProps
     extends UseFormReturn<FormState>,
@@ -47,10 +47,7 @@ export const useUtxoSelection = ({
     useEffect(() => {
         if (isCoinControlEnabled && selectedUtxos.length > 0) {
             const spentUtxos = selectedUtxos.filter(
-                selectedUtxo =>
-                    !account.utxo?.some(
-                        u => selectedUtxo.txid === u.txid && selectedUtxo.vout === u.vout,
-                    ),
+                selected => !account.utxo?.some(utxo => isSameUtxo(selected, utxo)),
             );
             if (spentUtxos.length > 0) {
                 setValue(
@@ -85,7 +82,7 @@ export const useUtxoSelection = ({
 
     // are all UTXOs in the top category selected?
     const allUtxosSelected = !!topCategory?.every((utxo: AccountUtxo) =>
-        selectedUtxos.some(selected => selected.txid === utxo.txid && selected.vout === utxo.vout),
+        selectedUtxos.some(selected => isSameUtxo(selected, utxo)),
     );
 
     // transaction composed for the fee level chosen by the user
@@ -110,7 +107,7 @@ export const useUtxoSelection = ({
         [account.utxo, composedInputs],
     );
 
-    // at least one of the selected UTXOs does not comply to targe anonymity
+    // at least one of the selected UTXOs does not comply to target anonymity
     const isLowAnonymityUtxoSelected =
         account.accountType === 'coinjoin' &&
         selectedUtxos.some(
@@ -132,7 +129,7 @@ export const useUtxoSelection = ({
         } else {
             // check top category and keep any already checked UTXOs from other categories
             const selectedUtxosFromLowerCategories = selectedUtxos.filter(
-                utxo => !topCategory?.find(u => u.txid === utxo.txid && u.vout === utxo.vout),
+                selected => !topCategory?.find(utxo => isSameUtxo(selected, utxo)),
             );
             setValue('selectedUtxos', topCategory.concat(selectedUtxosFromLowerCategories));
             setValue('isCoinControlEnabled', true);
@@ -149,9 +146,7 @@ export const useUtxoSelection = ({
 
     // uncheck a UTXO or check it and enable coin control
     const toggleUtxoSelection = (utxo: AccountUtxo) => {
-        const isSameUtxo = (u: AccountUtxo) => u.txid === utxo.txid && u.vout === utxo.vout;
-
-        const alreadySelectedUtxo = selectedUtxos.find(isSameUtxo);
+        const alreadySelectedUtxo = selectedUtxos.find(selected => isSameUtxo(selected, utxo));
         if (alreadySelectedUtxo) {
             // uncheck the UTXO if already selected
             setValue(
@@ -162,7 +157,7 @@ export const useUtxoSelection = ({
             // check the UTXO
             // however, in case the coin control has not been enabled and the UTXO has been preselected, do not check it
             const selectedUtxosOld = !isCoinControlEnabled ? preselectedUtxos : selectedUtxos;
-            const selectedUtxosNew = preselectedUtxos.some(isSameUtxo)
+            const selectedUtxosNew = preselectedUtxos.some(selected => isSameUtxo(selected, utxo))
                 ? preselectedUtxos
                 : [...selectedUtxosOld, utxo];
 

--- a/suite-common/wallet-utils/src/accountUtils.ts
+++ b/suite-common/wallet-utils/src/accountUtils.ts
@@ -1,6 +1,12 @@
 import BigNumber from 'bignumber.js';
 
-import { AccountInfo, AccountAddresses, AccountAddress, AccountTransaction } from '@trezor/connect';
+import {
+    AccountInfo,
+    AccountAddresses,
+    AccountAddress,
+    AccountTransaction,
+    AccountUtxo,
+} from '@trezor/connect';
 import { arrayDistinct, bufferUtils } from '@trezor/utils';
 import {
     networksCompatibility as NETWORKS,
@@ -917,3 +923,6 @@ export const readUtxoOutpoint = (outpoint: string) => {
     const vout = buffer.readUInt32LE(txid.length);
     return { txid: txid.toString('hex'), vout };
 };
+
+export const isSameUtxo = (a: AccountUtxo, b: AccountUtxo) =>
+    a.txid === b.txid && a.vout === b.vout;


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Fixing case when utxo selected in `CoinControl` was spent (for example in different window or app)

## How to test it?

The fastest way will be on Regtest

- Create an account and remember it (Tab 1)
- Send yourself two utxos
- Go to send form and select all utxos in CoinControl and click on "send max" button
- Open another tab (Tab 2), go to send form, you will see transaction draft from previous window
- Unselect one of the utxos and send it (doesnt matter where, it could be the same or different account)
- go back to original tab (Tab 1)

**Result**
- "send max" amount is recalculated
- number of "selected" utxos is valid (1) - it will show 2 on the develop branch
