### PR TITLE
fix(suite): fix tx summary details button color

### DIFF
--- a/packages/suite/src/components/suite/modals/ReviewTransaction/components/Summary.tsx
+++ b/packages/suite/src/components/suite/modals/ReviewTransaction/components/Summary.tsx
@@ -133,6 +133,13 @@ const TxDetailsButton = styled.button<{ detailsOpen: boolean }>`
         detailsOpen && darken(theme.HOVER_DARKEN_FILTER, theme.STROKE_LIGHT_GREY)};
     cursor: pointer;
 
+    ${variables.MEDIA_QUERY.DARK_THEME} {
+        background: ${({ theme, detailsOpen }) =>
+            detailsOpen
+                ? darken(theme.HOVER_DARKEN_FILTER, theme.STROKE_LIGHT_GREY)
+                : theme.BG_LIGHT_GREY};
+    }
+
     :hover {
         background: ${({ theme }) => theme.STROKE_GREY};
     }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

* fix tx summary details button color

## Screenshots:

<img width="689" alt="image" src="https://github.com/trezor/trezor-suite/assets/45338719/e035876a-f7c1-4fa7-8de7-f077f5e19253">

