### PR TITLE
fix(suite): fix hologram sticker tooltip not being visible

### DIFF
--- a/packages/components/src/components/Tooltip/index.tsx
+++ b/packages/components/src/components/Tooltip/index.tsx
@@ -55,7 +55,7 @@ const BoxRich = styled(motion.div)<{ $maxWidth: string | number }>`
     padding: 24px;
     background: ${props => props.theme.BG_WHITE_ALT};
     color: ${props => props.theme.TYPE_DARK_GREY};
-    border-radius: 5px;
+    border-radius: 8px;
     font-size: ${variables.FONT_SIZE.NORMAL};
     text-align: left;
     box-shadow: 0 2px 5px 0 rgba(0, 0, 0, 0.2);

--- a/packages/suite/src/components/onboarding/Hologram.tsx
+++ b/packages/suite/src/components/onboarding/Hologram.tsx
@@ -11,6 +11,7 @@ import { getPackagingUrl } from 'src/utils/suite/device';
 const Wrapper = styled.div`
     display: flex;
     flex-direction: column;
+    width: 300px;
 `;
 
 const HologramHeading = styled.span`
@@ -30,7 +31,9 @@ const AnimationWrapper = styled.div`
 `;
 
 const StyledWarning = styled(Warning)`
-    font-size: ${variables.FONT_SIZE.SMALL};
+    width: calc(100% + 16px);
+    margin: 0px -8px;
+    font-size: ${variables.FONT_SIZE.TINY};
 `;
 
 interface HologramProps {

--- a/packages/suite/src/views/onboarding/steps/Welcome/components/PreOnboardingSetup/SecurityCheck.tsx
+++ b/packages/suite/src/views/onboarding/steps/Welcome/components/PreOnboardingSetup/SecurityCheck.tsx
@@ -59,6 +59,14 @@ const Text = styled.div`
 
 const StyledTooltip = styled(Tooltip)`
     display: inline-block;
+
+    ${variables.SCREEN_QUERY.MOBILE} {
+        pointer-events: none;
+
+        span {
+            text-decoration: none;
+        }
+    }
 `;
 
 const OuterActions = styled.div`
@@ -90,7 +98,11 @@ const SecurityCheck = () => {
                     id="TR_ONBOARDING_DEVICE_CHECK_1"
                     values={{
                         strong: chunks => (
-                            <StyledTooltip rich content={<Hologram device={device} />}>
+                            <StyledTooltip
+                                placement="left"
+                                rich
+                                content={<Hologram device={device} />}
+                            >
                                 <Underline>{chunks}</Underline>
                             </StyledTooltip>
                         ),


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

* fix hologram sticker tooltip not being visible
* remove it from mobile since it was not visible anyways

## Related Issue

Resolve https://github.com/trezor/trezor-suite/issues/6263

## Screenshots:

<img width="600" alt="image" src="https://github.com/trezor/trezor-suite/assets/45338719/586bdec0-83a2-4051-aa91-07b5ecb6bbf7">

