### PR TITLE
Syntax cleanup 🧹: dispatching, selectors, props destructuring, renaming

### DIFF
--- a/packages/components/src/components/CollapsibleCard.tsx
+++ b/packages/components/src/components/CollapsibleCard.tsx
@@ -87,7 +87,7 @@ const CardWrapperInner = styled.div<{ expandable: boolean }>`
 `;
 
 const Text = styled.span`
-    color: ${props => props.theme.TYPE_LIGHT_GREY};
+    color: ${({ theme }) => theme.TYPE_LIGHT_GREY};
     font-size: ${variables.FONT_SIZE.SMALL};
     font-weight: ${variables.FONT_WEIGHT.MEDIUM};
 `;

--- a/packages/components/src/components/DataAnalytics.tsx
+++ b/packages/components/src/components/DataAnalytics.tsx
@@ -32,7 +32,7 @@ const Label = styled.span`
     margin-left: 20px;
     font-size: ${variables.FONT_SIZE.SMALL};
     font-weight: ${variables.FONT_WEIGHT.MEDIUM};
-    color: ${props => props.theme.TYPE_DARK_GREY};
+    color: ${({ theme }) => theme.TYPE_DARK_GREY};
     align-items: center;
     display: flex;
 `;
@@ -40,7 +40,7 @@ const Label = styled.span`
 const Heading = styled(H1)`
     font-size: ${variables.FONT_SIZE.SMALL};
     font-weight: ${variables.FONT_WEIGHT.DEMI_BOLD};
-    color: ${props => props.theme.TYPE_DARK_GREY};
+    color: ${({ theme }) => theme.TYPE_DARK_GREY};
     margin-bottom: 16px;
     text-align: left;
 `;
@@ -48,7 +48,7 @@ const Heading = styled(H1)`
 const Description = styled.span`
     font-size: ${variables.FONT_SIZE.SMALL};
     font-weight: ${variables.FONT_WEIGHT.MEDIUM};
-    color: ${props => props.theme.TYPE_LIGHT_GREY};
+    color: ${({ theme }) => theme.TYPE_LIGHT_GREY};
 
     margin-bottom: 20px;
     /* text-align: center; */

--- a/packages/components/src/components/Dropdown/index.tsx
+++ b/packages/components/src/components/Dropdown/index.tsx
@@ -29,7 +29,7 @@ const MasterLinkComponent = styled.button<{
     right: 10px;
     font-size: 11px;
     letter-spacing: 0.4px;
-    color: ${props => props.theme.TYPE_GREEN};
+    color: ${({ theme }) => theme.TYPE_GREEN};
     font-weight: ${FONT_WEIGHT.BOLD};
     text-transform: uppercase;
     display: flex;
@@ -65,8 +65,8 @@ const Menu = styled.ul<MenuProps>`
     position: absolute;
     flex: 1;
     min-width: ${props => props.minWidth}px;
-    box-shadow: 0 2px 7px 0 ${props => props.theme.BOX_SHADOW_BLACK_15},
-        0 2px 3px 0 ${props => props.theme.BOX_SHADOW_BLACK_5};
+    box-shadow: 0 2px 7px 0 ${({ theme }) => theme.BOX_SHADOW_BLACK_15},
+        0 2px 3px 0 ${({ theme }) => theme.BOX_SHADOW_BLACK_5};
     padding: ${props => props.topPadding}px ${props => props.horizontalPadding}px
         ${props => props.bottomPadding}px;
     border-radius: 10px;
@@ -85,7 +85,7 @@ const Menu = styled.ul<MenuProps>`
         props.alignMenu === 'top-left' || props.alignMenu === 'top-right'
             ? `-${props.offset}px`
             : `${props.offset}px`};
-    background: ${props => props.theme.BG_WHITE};
+    background: ${({ theme }) => theme.BG_WHITE};
     overflow: hidden;
 
     ${props =>
@@ -131,7 +131,7 @@ const Menu = styled.ul<MenuProps>`
 `;
 
 const Group = styled.li`
-    color: ${props => props.theme.TYPE_LIGHT_GREY};
+    color: ${({ theme }) => theme.TYPE_LIGHT_GREY};
     font-size: ${FONT_SIZE.TINY};
     font-weight: ${FONT_WEIGHT.MEDIUM};
     padding: 10px 16px 10px 16px;

--- a/packages/components/src/components/HoverAnimation.tsx
+++ b/packages/components/src/components/HoverAnimation.tsx
@@ -16,8 +16,8 @@ const Wrapper = styled.div<{ size?: string; isHoverable?: boolean }>`
         height: 100%;
         transform: scale(0.5);
         border-radius: 8px;
-        transition: ${props =>
-            `all ${props.theme.HOVER_TRANSITION_TIME} ${props.theme.HOVER_TRANSITION_EFFECT}`};
+        transition: ${({ theme }) =>
+            `all ${theme.HOVER_TRANSITION_TIME} ${theme.HOVER_TRANSITION_EFFECT}`};
 
         background-color: transparent;
         pointer-events: none;
@@ -32,10 +32,10 @@ const Wrapper = styled.div<{ size?: string; isHoverable?: boolean }>`
             :active {
                 :after {
                     transform: scale(1);
-                    background-color: ${props =>
+                    background-color: ${({ theme }) =>
                         transparentize(
-                            props.theme.HOVER_TRANSPARENTIZE_FILTER,
-                            props.theme.HOVER_PRIMER_COLOR,
+                            theme.HOVER_TRANSPARENTIZE_FILTER,
+                            theme.HOVER_PRIMER_COLOR,
                         )};
                 }
             }

--- a/packages/components/src/components/Icon/all.stories.tsx
+++ b/packages/components/src/components/Icon/all.stories.tsx
@@ -24,7 +24,7 @@ const IconWrapper = styled.div`
 
 const IconText = styled.div`
     padding-bottom: 10px;
-    color: ${props => props.theme.TYPE_LIGHT_GREY};
+    color: ${({ theme }) => theme.TYPE_LIGHT_GREY};
 `;
 
 storiesOf('Icons', module).add(

--- a/packages/components/src/components/Passphrase/PassphraseTypeCard.tsx
+++ b/packages/components/src/components/Passphrase/PassphraseTypeCard.tsx
@@ -37,7 +37,7 @@ const Wrapper = styled.div<Pick<PassphraseTypeCardProps, 'type' | 'singleColModa
         !props.singleColModal &&
         css`
             padding: 12px;
-            /* border: solid 1px ${props => props.theme.STROKE_GREY}; */
+            /* border: solid 1px ${({ theme }) => theme.STROKE_GREY}; */
         `}
 
     ${props =>
@@ -50,8 +50,8 @@ const Wrapper = styled.div<Pick<PassphraseTypeCardProps, 'type' | 'singleColModa
 const IconWrapper = styled.div<Pick<PassphraseTypeCardProps, 'type'>>`
     width: 38px;
     height: 38px;
-    background: ${props =>
-        props.type === 'standard' ? props.theme.BG_LIGHT_GREEN : props.theme.BG_GREY};
+    background: ${({ theme, type }) =>
+        type === 'standard' ? theme.BG_LIGHT_GREEN : theme.BG_GREY};
     border-radius: 8px;
     display: flex;
     justify-content: center;
@@ -75,7 +75,7 @@ const ArrowCol = styled(Col)`
 const WalletTitle = styled.div<{ withMargin: boolean }>`
     display: flex;
     font-size: ${variables.FONT_SIZE.NORMAL};
-    color: ${props => props.theme.TYPE_DARK_GREY};
+    color: ${({ theme }) => theme.TYPE_DARK_GREY};
     font-weight: 500;
     line-height: 1.5;
     align-items: center;
@@ -84,7 +84,7 @@ const WalletTitle = styled.div<{ withMargin: boolean }>`
 
 const Description = styled.div<Pick<PassphraseTypeCardProps, 'authConfirmation'>>`
     display: flex;
-    color: ${props => props.theme.TYPE_LIGHT_GREY};
+    color: ${({ theme }) => theme.TYPE_LIGHT_GREY};
     font-size: ${variables.FONT_SIZE.TINY};
     line-height: 1.33;
 `;
@@ -104,7 +104,7 @@ const Spacer = styled.div`
 `;
 
 const PassphraseInput = styled(Input)`
-    color: ${props => props.theme.TYPE_DARK_GREY};
+    color: ${({ theme }) => theme.TYPE_DARK_GREY};
     font-size: ${variables.FONT_SIZE.SMALL};
 `;
 
@@ -131,7 +131,7 @@ const ActionButton = styled(Button)`
 const OnDeviceActionButton = styled(ActionButton)`
     background: transparent;
     text-decoration: underline;
-    color: ${props => props.theme.TYPE_LIGHT_GREY};
+    color: ${({ theme }) => theme.TYPE_LIGHT_GREY};
 
     &:first-child {
         margin-top: 0px;
@@ -140,7 +140,7 @@ const OnDeviceActionButton = styled(ActionButton)`
     &:hover,
     &:focus,
     &:active {
-        color: ${props => props.theme.TYPE_LIGHT_GREY};
+        color: ${({ theme }) => theme.TYPE_LIGHT_GREY};
         background: transparent;
     }
 `;
@@ -149,7 +149,7 @@ const Content = styled.div`
     display: flex;
     flex: 1;
     margin: 8px 12px;
-    color: ${props => props.theme.TYPE_DARK_GREY};
+    color: ${({ theme }) => theme.TYPE_DARK_GREY};
     font-size: ${variables.FONT_SIZE.SMALL};
 `;
 

--- a/packages/components/src/components/Passphrase/PasswordStrengthIndicator.tsx
+++ b/packages/components/src/components/Passphrase/PasswordStrengthIndicator.tsx
@@ -54,11 +54,11 @@ const getPasswordScore = async (password: string) => {
     return zxcvbn.default(password).score;
 };
 
-interface Props {
+interface PasswordStrengthIndicatorProps {
     password: string;
 }
 
-const PasswordStrengthIndicator = ({ password }: Props) => {
+const PasswordStrengthIndicator = ({ password }: PasswordStrengthIndicatorProps) => {
     const [score, setScore] = useState<OptionalZXCVBNScore>();
     useEffect(() => {
         const runScoring = async () => {

--- a/packages/components/src/components/Timerange/index.tsx
+++ b/packages/components/src/components/Timerange/index.tsx
@@ -22,7 +22,7 @@ const StyledTimerange = styled.div`
     width: 345px;
     display: flex;
     flex-direction: column;
-    background: ${props => props.theme.BG_WHITE};
+    background: ${({ theme }) => theme.BG_WHITE};
     border-radius: 12px;
 
     ${variables.MEDIA_QUERY.DARK_THEME} {
@@ -44,23 +44,23 @@ const Buttons = styled.div`
 const Calendar = styled.div`
     width: 345px;
     padding: 12px 12px 0;
-    border-bottom: 1px solid ${props => props.theme.STROKE_GREY};
+    border-bottom: 1px solid ${({ theme }) => theme.STROKE_GREY};
 
     ${datepickerStyle}
 
     .rdrDayNumber span {
-        color: ${props => props.theme.TYPE_LIGHT_GREY};
+        color: ${({ theme }) => theme.TYPE_LIGHT_GREY};
     }
 
     .rdrDayDisabled .rdrDayNumber span,
     .rdrDayPassive .rdrDayNumber span {
         opacity: 0.5;
-        color: ${props => props.theme.TYPE_LIGHT_GREY};
+        color: ${({ theme }) => theme.TYPE_LIGHT_GREY};
     }
 
     .rdrCalendarWrapper {
-        background: ${props => props.theme.BG_WHITE};
-        color: ${props => props.theme.TYPE_LIGHT_GREY};
+        background: ${({ theme }) => theme.BG_WHITE};
+        color: ${({ theme }) => theme.TYPE_LIGHT_GREY};
     }
 
     .rdrDateDisplay {
@@ -74,25 +74,25 @@ const Calendar = styled.div`
     }
 
     .rdrDateDisplayItem input {
-        color: ${props => props.theme.TYPE_DARK_GREY};
+        color: ${({ theme }) => theme.TYPE_DARK_GREY};
     }
 
     .rdrDateDisplayItem + .rdrDateDisplayItem {
         &:after {
-            color: ${props => props.theme.TYPE_LIGHTER_GREY};
+            color: ${({ theme }) => theme.TYPE_LIGHTER_GREY};
         }
     }
 
     .rdrDateInput .rdrWarning {
-        color: ${props => props.theme.TYPE_ORANGE};
+        color: ${({ theme }) => theme.TYPE_ORANGE};
     }
 
     .rdrMonthAndYearPickers select {
-        color: ${props => props.theme.TYPE_LIGHT_GREY};
+        color: ${({ theme }) => theme.TYPE_LIGHT_GREY};
     }
 
     .rdrMonthAndYearPickers select:hover {
-        background-color: ${props => props.theme.BG_GREY_ALT};
+        background-color: ${({ theme }) => theme.BG_GREY_ALT};
     }
 
     .rdrNextPrevButton {
@@ -108,64 +108,64 @@ const Calendar = styled.div`
 
     .rdrPprevButton i {
         margin: 0 0 0 8px;
-        border-color: transparent ${props => props.theme.TYPE_LIGHT_GREY} transparent transparent;
+        border-color: transparent ${({ theme }) => theme.TYPE_LIGHT_GREY} transparent transparent;
     }
 
     .rdrNextButton i {
         margin: auto;
-        border-color: transparent transparent transparent ${props => props.theme.TYPE_LIGHT_GREY};
+        border-color: transparent transparent transparent ${({ theme }) => theme.TYPE_LIGHT_GREY};
     }
 
     .rdrWeekDay {
-        color: ${props => props.theme.TYPE_LIGHT_GREY};
+        color: ${({ theme }) => theme.TYPE_LIGHT_GREY};
         opacity: 0.7;
     }
 
     .rdrDay {
-        color: ${props => props.theme.TYPE_LIGHT_GREY};
+        color: ${({ theme }) => theme.TYPE_LIGHT_GREY};
     }
 
     .rdrDayToday .rdrDayNumber span:after {
-        background: ${props => props.theme.TYPE_DARK_GREY};
+        background: ${({ theme }) => theme.TYPE_DARK_GREY};
     }
 
     .rdrDayToday .rdrStartEdge .rdrDayNumber span:after,
     .rdrDayToday .rdrEndEdge .rdrDayNumber span:after {
-        background: ${props => props.theme.BG_WHITE};
+        background: ${({ theme }) => theme.BG_WHITE};
     }
 
     .rdrDayToday:not(.rdrDayPassive) .rdrInRange ~ .rdrDayNumber span:after,
     .rdrDayToday:not(.rdrDayPassive) .rdrStartEdge ~ .rdrDayNumber span:after,
     .rdrDayToday:not(.rdrDayPassive) .rdrEndEdge ~ .rdrDayNumber span:after,
     .rdrDayToday:not(.rdrDayPassive) .rdrSelected ~ .rdrDayNumber span:after {
-        background: ${props => props.theme.BG_WHITE};
+        background: ${({ theme }) => theme.BG_WHITE};
     }
 
     .rdrDay:not(.rdrDayPassive) .rdrInRange ~ .rdrDayNumber span,
     .rdrDay:not(.rdrDayPassive) .rdrSelected ~ .rdrDayNumber span {
-        color: ${props => props.theme.TYPE_LIGHT_GREY};
+        color: ${({ theme }) => theme.TYPE_LIGHT_GREY};
     }
 
     .rdrDay:not(.rdrDayPassive) .rdrStartEdge ~ .rdrDayNumber span,
     .rdrDay:not(.rdrDayPassive) .rdrEndEdge ~ .rdrDayNumber span {
-        color: ${props => props.theme.TYPE_WHITE};
+        color: ${({ theme }) => theme.TYPE_WHITE};
     }
 
     .rdrSelected,
     .rdrInRange,
     .rdrStartEdge,
     .rdrEndEdge {
-        background: ${props => props.theme.BG_LIGHT_GREEN};
+        background: ${({ theme }) => theme.BG_LIGHT_GREEN};
     }
 
     .rdrMonthName {
-        color: ${props => props.theme.TYPE_DARK_GREY};
+        color: ${({ theme }) => theme.TYPE_DARK_GREY};
     }
 
     .rdrDateDisplayWrapper {
         padding-bottom: 13px;
-        background: ${props => props.theme.BG_WHITE};
-        border-bottom: 1px solid ${props => props.theme.STROKE_GREY};
+        background: ${({ theme }) => theme.BG_WHITE};
+        border-bottom: 1px solid ${({ theme }) => theme.STROKE_GREY};
     }
 
     .rdrMonthAndYearWrapper {
@@ -175,16 +175,16 @@ const Calendar = styled.div`
 
     .rdrStartEdge,
     .rdrEndEdge {
-        background: ${props => props.theme.BG_GREEN};
-        color: ${props => props.theme.TYPE_WHITE};
-        box-shadow: ${props => props.theme.BG_GREEN} 0px 0px 0px 2px;
+        background: ${({ theme }) => theme.BG_GREEN};
+        color: ${({ theme }) => theme.TYPE_WHITE};
+        box-shadow: ${({ theme }) => theme.BG_GREEN} 0px 0px 0px 2px;
         border-radius: 4px;
         z-index: ${variables.Z_INDEX.BASE};
     }
 
     .rdrDayDisabled {
         opacity: 0.5;
-        color: ${props => props.theme.TYPE_LIGHT_GREY};
+        color: ${({ theme }) => theme.TYPE_LIGHT_GREY};
         background: transparent;
     }
 

--- a/packages/components/src/components/Tooltip/index.tsx
+++ b/packages/components/src/components/Tooltip/index.tsx
@@ -28,8 +28,8 @@ const OpenGuideInner = styled.span`
 
 const BoxDefault = styled(motion.div)<{ $maxWidth: string | number }>`
     padding: 8px;
-    background: ${props => props.theme.BG_TOOLTIP};
-    color: ${props => props.theme.TYPE_WHITE};
+    background: ${({ theme }) => theme.BG_TOOLTIP};
+    color: ${({ theme }) => theme.TYPE_WHITE};
     font-weight: ${variables.FONT_WEIGHT.MEDIUM};
     border-radius: 10px;
     font-size: ${variables.FONT_SIZE.TINY};
@@ -40,7 +40,7 @@ const BoxDefault = styled(motion.div)<{ $maxWidth: string | number }>`
     @media all and (min-width: ${variables.SCREEN_SIZE.MD}) {
         &:hover ${OpenGuideInner} {
             border-radius: 26px;
-            background-color: ${props => transparentize(0.85, props.theme.TYPE_ORANGE)};
+            background-color: ${({ theme }) => transparentize(0.85, theme.TYPE_ORANGE)};
             & > a span:first-child {
                 max-width: 100px;
             }
@@ -53,8 +53,8 @@ const BoxDefault = styled(motion.div)<{ $maxWidth: string | number }>`
 
 const BoxRich = styled(motion.div)<{ $maxWidth: string | number }>`
     padding: 24px;
-    background: ${props => props.theme.BG_WHITE_ALT};
-    color: ${props => props.theme.TYPE_DARK_GREY};
+    background: ${({ theme }) => theme.BG_WHITE_ALT};
+    color: ${({ theme }) => theme.TYPE_DARK_GREY};
     border-radius: 8px;
     font-size: ${variables.FONT_SIZE.NORMAL};
     text-align: left;
@@ -65,9 +65,8 @@ const BoxRich = styled(motion.div)<{ $maxWidth: string | number }>`
 const Content = styled.div<{ dashed?: boolean; cursor: Cursor }>`
     & > * {
         cursor: ${props => props.cursor};
-        ${props =>
-            props.dashed &&
-            `border-bottom: 1.5px dashed ${transparentize(0.66, props.theme.TYPE_LIGHT_GREY)};`}
+        ${({ dashed, theme }) =>
+            dashed && `border-bottom: 1.5px dashed ${transparentize(0.66, theme.TYPE_LIGHT_GREY)};`}
     }
 `;
 
@@ -80,7 +79,7 @@ const ReadMoreLink = styled(Link)`
 
 const StyledTooltipTitle = styled.span`
     display: inline-flex;
-    color: ${props => props.theme.TYPE_LIGHT_GREY};
+    color: ${({ theme }) => theme.TYPE_LIGHT_GREY};
     font-size: ${variables.FONT_SIZE.SMALL};
     font-weight: ${variables.FONT_WEIGHT.MEDIUM};
     margin-bottom: 8px;

--- a/packages/components/src/components/Truncate/index.tsx
+++ b/packages/components/src/components/Truncate/index.tsx
@@ -21,12 +21,12 @@ const StyledButton = styled.button`
     line-height: 1;
 `;
 
-type Props = {
+type TruncateProps = {
     children: React.ReactNode;
     lines?: number;
 };
 
-const Truncate = ({ children, lines = 1 }: Props) => {
+const Truncate = ({ children, lines = 1 }: TruncateProps) => {
     const theme = useTheme();
     const [expanded, setExpanded] = useState(false);
     const [truncated, setTruncated] = useState(false);

--- a/packages/components/src/components/buttons/Pin/index.tsx
+++ b/packages/components/src/components/buttons/Pin/index.tsx
@@ -12,8 +12,8 @@ const Button = styled.button`
     width: 100%;
 
     border-radius: 5px;
-    border: 1px solid ${props => props.theme.BG_GREY};
-    background: ${props => props.theme.BG_GREY};
+    border: 1px solid ${({ theme }) => theme.BG_GREY};
+    background: ${({ theme }) => theme.BG_GREY};
 
     &:first-child {
         margin-left: 0px;
@@ -23,7 +23,7 @@ const Button = styled.button`
     }
 
     &:hover {
-        background: ${props => props.theme.BG_LIGHT_GREEN};
+        background: ${({ theme }) => theme.BG_LIGHT_GREEN};
     }
 
     &:before {
@@ -32,13 +32,13 @@ const Button = styled.button`
         content: ' ';
         position: absolute;
         border-radius: 100%;
-        background: ${props => props.theme.TYPE_DARK_GREY};
+        background: ${({ theme }) => theme.TYPE_DARK_GREY};
         top: calc(50% - 3px);
         left: calc(50% - 3px);
     }
 
     &:hover:before {
-        background: ${props => props.theme.TYPE_GREEN};
+        background: ${({ theme }) => theme.TYPE_GREEN};
     }
 `;
 

--- a/packages/components/src/components/form/RadioButton/index.tsx
+++ b/packages/components/src/components/form/RadioButton/index.tsx
@@ -48,7 +48,7 @@ const Label = styled.div`
     padding-left: 12px;
     padding-top: 2px;
     justify-content: left;
-    color: ${props => props.theme.TYPE_LIGHT_GREY};
+    color: ${({ theme }) => theme.TYPE_LIGHT_GREY};
     font-weight: ${FONT_WEIGHT.MEDIUM};
     font-size: ${FONT_SIZE.SMALL};
     line-height: 22px;

--- a/packages/components/src/components/loaders/Loader.tsx
+++ b/packages/components/src/components/loaders/Loader.tsx
@@ -15,9 +15,9 @@ const Wrapper = styled.div<LoaderProps>`
 const StyledLoader = styled.div<{ size: number; strokeWidth: number }>`
     position: relative;
     text-indent: -9999em;
-    border-top: ${props => `${props.strokeWidth}px`} solid ${props => props.theme.TYPE_GREEN};
-    border-right: ${props => `${props.strokeWidth}px`} solid ${props => props.theme.TYPE_GREEN};
-    border-bottom: ${props => `${props.strokeWidth}px`} solid ${props => props.theme.TYPE_GREEN};
+    border-top: ${props => `${props.strokeWidth}px`} solid ${({ theme }) => theme.TYPE_GREEN};
+    border-right: ${props => `${props.strokeWidth}px`} solid ${({ theme }) => theme.TYPE_GREEN};
+    border-bottom: ${props => `${props.strokeWidth}px`} solid ${({ theme }) => theme.TYPE_GREEN};
     border-left: ${props => `${props.strokeWidth}px`} solid transparent;
     transform: translateZ(0);
     animation: ${SPIN} 1s infinite linear;

--- a/packages/components/src/components/logos/TrezorLogo/index.tsx
+++ b/packages/components/src/components/logos/TrezorLogo/index.tsx
@@ -15,7 +15,7 @@ const SvgWrapper = styled.div<Omit<TrezorLogoProps, 'type'>>`
 `;
 
 const StyledReactSVG = styled(ReactSVG)`
-    color: ${props => props.theme.TYPE_DARK_GREY};
+    color: ${({ theme }) => theme.TYPE_DARK_GREY};
 `;
 
 export interface TrezorLogoProps extends React.ImgHTMLAttributes<HTMLImageElement> {

--- a/packages/components/src/components/logos/index.stories.tsx
+++ b/packages/components/src/components/logos/index.stories.tsx
@@ -6,7 +6,7 @@ import { StoryColumn } from '../../support/Story';
 
 const CoinName = styled.div`
     margin-bottom: 0.5rem;
-    color: ${props => props.theme.TYPE_LIGHT_GREY};
+    color: ${({ theme }) => theme.TYPE_LIGHT_GREY};
 `;
 
 interface WrapperProps {

--- a/packages/components/src/components/others/Box/index.tsx
+++ b/packages/components/src/components/others/Box/index.tsx
@@ -12,15 +12,15 @@ const Wrapper = styled.div<{ state: BoxProps['state'] }>`
     flex: 1;
     border-radius: 8px;
     padding: 16px 14px;
-    border: solid 1px ${props => props.theme.STROKE_GREY};
+    border: solid 1px ${({ theme }) => theme.STROKE_GREY};
 
-    ${props =>
-        props.state &&
+    ${({ state, theme }) =>
+        state &&
         css`
-            border-left: 6px solid ${getInputStateTextColor(props.state, props.theme)};
+            border-left: 6px solid ${getInputStateTextColor(state, theme)};
         `}
-    ${props =>
-        !props.state &&
+    ${({ state }) =>
+        !state &&
         css`
             padding-left: 20px;
         `}

--- a/packages/components/src/components/others/Card.stories.tsx
+++ b/packages/components/src/components/others/Card.stories.tsx
@@ -6,7 +6,7 @@ import { variables } from '../../index';
 
 const Wrapper = styled.div`
     margin: 10px 0;
-    background: ${props => props.theme.BG_GREY};
+    background: ${({ theme }) => theme.BG_GREY};
     padding: 20px;
 `;
 

--- a/packages/components/src/components/others/Card.tsx
+++ b/packages/components/src/components/others/Card.tsx
@@ -6,7 +6,7 @@ const Wrapper = styled.div<{ paddingSize: string }>`
     flex-direction: column;
     border-radius: 12px;
     padding: ${props => props.paddingSize};
-    background: ${props => props.theme.BG_WHITE};
+    background: ${({ theme }) => theme.BG_WHITE};
 `;
 
 const getPaddingSize = (

--- a/packages/components/src/components/others/SecurityCard/index.stories.tsx
+++ b/packages/components/src/components/others/SecurityCard/index.stories.tsx
@@ -10,7 +10,7 @@ const Wrapper = styled.div`
     padding: 20px;
     grid-gap: 20px;
     grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
-    background: ${props => props.theme.BG_GREY};
+    background: ${({ theme }) => theme.BG_GREY};
 `;
 
 const StyledSecurityCard = styled(SecurityCard)`

--- a/packages/components/src/components/others/SecurityCard/index.tsx
+++ b/packages/components/src/components/others/SecurityCard/index.tsx
@@ -99,7 +99,7 @@ const Line = styled.div`
     /* border-top: 1px solid ${({ theme }) => theme.STROKE_GREY}; */
 `;
 
-interface Props extends CardProps {
+interface SecurityCardProps extends CardProps {
     variant: 'primary' | 'secondary';
     icon: IconProps['icon'];
     heading: React.ReactNode;
@@ -112,7 +112,7 @@ interface Props extends CardProps {
     };
 }
 
-const SecurityCard = ({ variant, icon, heading, description, cta, ...rest }: Props) => {
+const SecurityCard = ({ variant, icon, heading, description, cta, ...rest }: SecurityCardProps) => {
     const theme = useTheme();
     return (
         <Wrapper {...rest}>
@@ -174,5 +174,5 @@ const SecurityCard = ({ variant, icon, heading, description, cta, ...rest }: Pro
     );
 };
 
-export type { Props as SecurityCardProps };
+export type { SecurityCardProps };
 export { SecurityCard };

--- a/packages/components/src/components/others/SecurityCard/index.tsx
+++ b/packages/components/src/components/others/SecurityCard/index.tsx
@@ -29,8 +29,8 @@ const Header = styled.div`
 `;
 
 const Circle = styled.div`
-    border: 1px solid ${props => props.theme.STROKE_GREY};
-    background: ${props => props.theme.BG_WHITE};
+    border: 1px solid ${({ theme }) => theme.STROKE_GREY};
+    background: ${({ theme }) => theme.BG_WHITE};
     width: 58px;
     height: 58px;
     border-radius: 50%;
@@ -42,7 +42,7 @@ const Circle = styled.div`
 `;
 
 const Title = styled.div`
-    color: ${props => props.theme.TYPE_DARK_GREY};
+    color: ${({ theme }) => theme.TYPE_DARK_GREY};
     width: 200px;
     margin-top: 30px;
     min-height: 44px;
@@ -53,7 +53,7 @@ const Title = styled.div`
 
 const Description = styled.div`
     font-size: ${variables.FONT_SIZE.SMALL};
-    color: ${props => props.theme.TYPE_LIGHT_GREY};
+    color: ${({ theme }) => theme.TYPE_LIGHT_GREY};
     text-align: center;
     width: 200px;
     margin-top: 7px;
@@ -87,7 +87,7 @@ const CheckIconWrapper = styled.div`
     height: 16px;
     top: 10px;
     right: 8px;
-    background: ${props => props.theme.BG_GREEN};
+    background: ${({ theme }) => theme.BG_GREEN};
 `;
 
 const Line = styled.div`
@@ -95,8 +95,8 @@ const Line = styled.div`
     width: 100%;
     height: 1px;
     margin: 10px 0;
-    background: ${props => props.theme.STROKE_GREY};
-    /* border-top: 1px solid ${props => props.theme.STROKE_GREY}; */
+    background: ${({ theme }) => theme.STROKE_GREY};
+    /* border-top: 1px solid ${({ theme }) => theme.STROKE_GREY}; */
 `;
 
 interface Props extends CardProps {

--- a/packages/components/src/components/typography/Heading/index.tsx
+++ b/packages/components/src/components/typography/Heading/index.tsx
@@ -27,7 +27,7 @@ const baseStyles = css`
     line-height: normal;
     letter-spacing: normal;
     ${(props: Props) => props.fontWeight && fontWeightStyle}
-    color: ${props => props.theme.TYPE_DARK_GREY};
+    color: ${({ theme }) => theme.TYPE_DARK_GREY};
 
     ${props =>
         !props.noMargin &&

--- a/packages/components/src/components/typography/Link/index.tsx
+++ b/packages/components/src/components/typography/Link/index.tsx
@@ -11,7 +11,7 @@ const A_SIZES = {
     tiny: FONT_SIZE.TINY,
 };
 
-const A = styled.a<Props>`
+const A = styled.a<LinkProps>`
     font-size: ${props => (props.size ? A_SIZES[props.size] : 'inherit')};
     text-decoration: none;
     cursor: pointer;
@@ -48,7 +48,7 @@ const IconWrapper = styled.div`
     margin-left: 4px;
 `;
 
-interface Props {
+interface LinkProps {
     href?: string;
     to?: any;
     target?: string;
@@ -61,7 +61,7 @@ interface Props {
     iconProps?: IconProps;
 }
 
-const Link = ({ icon, iconProps, ...props }: Props) => {
+const Link = ({ icon, iconProps, ...props }: LinkProps) => {
     const theme = useTheme();
     return (
         <A
@@ -93,5 +93,5 @@ const Link = ({ icon, iconProps, ...props }: Props) => {
         </A>
     );
 };
-export type { Props as LinkProps };
+export type { LinkProps };
 export { Link };

--- a/packages/components/src/components/typography/Link/index.tsx
+++ b/packages/components/src/components/typography/Link/index.tsx
@@ -15,7 +15,7 @@ const A = styled.a<Props>`
     font-size: ${props => (props.size ? A_SIZES[props.size] : 'inherit')};
     text-decoration: none;
     cursor: pointer;
-    color: ${props => props.theme.TYPE_DARK_GREY};
+    color: ${({ theme }) => theme.TYPE_DARK_GREY};
     font-weight: 500;
     display: inline-flex;
     align-items: center;

--- a/packages/components/src/components/typography/Paragraph/index.tsx
+++ b/packages/components/src/components/typography/Paragraph/index.tsx
@@ -3,7 +3,7 @@ import styled, { css } from 'styled-components';
 import { variables } from '../../../config';
 import { ParagraphSize } from '../../../support/types';
 
-const getLineHeight = (size: Props['size']) => {
+const getLineHeight = (size: PProps['size']) => {
     switch (size) {
         case 'small':
             return '18px';
@@ -14,7 +14,7 @@ const getLineHeight = (size: Props['size']) => {
     }
 };
 
-const getWeight = (size: Props['weight']) => {
+const getWeight = (size: PProps['weight']) => {
     switch (size) {
         case 'normal':
             return variables.FONT_WEIGHT.REGULAR;
@@ -33,7 +33,7 @@ const P_SIZES: { [key: string]: string } = {
     tiny: variables.FONT_SIZE.TINY,
 };
 
-const Paragraph = styled.div<Props>`
+const Paragraph = styled.div<PProps>`
     font-size: ${props => P_SIZES[props.size || 'normal']};
     line-height: ${props => getLineHeight(props.size)};
     color: ${({ size, theme }) => (size === 'tiny' ? theme.TYPE_LIGHT_GREY : theme.TYPE_DARK_GREY)};
@@ -46,7 +46,7 @@ const Paragraph = styled.div<Props>`
         `}
 `;
 
-interface Props extends React.HTMLAttributes<HTMLDivElement> {
+interface PProps extends React.HTMLAttributes<HTMLDivElement> {
     children: React.ReactNode;
     className?: string;
     size?: ParagraphSize;
@@ -61,11 +61,11 @@ const P = ({
     weight = 'normal',
     textAlign,
     ...rest
-}: Props) => (
+}: PProps) => (
     <Paragraph className={className} size={size} textAlign={textAlign} weight={weight} {...rest}>
         {children}
     </Paragraph>
 );
 
-export type { Props as PProps };
+export type { PProps };
 export { P };

--- a/packages/components/src/components/typography/Paragraph/index.tsx
+++ b/packages/components/src/components/typography/Paragraph/index.tsx
@@ -36,8 +36,7 @@ const P_SIZES: { [key: string]: string } = {
 const Paragraph = styled.div<Props>`
     font-size: ${props => P_SIZES[props.size || 'normal']};
     line-height: ${props => getLineHeight(props.size)};
-    color: ${props =>
-        props.size === 'tiny' ? props.theme.TYPE_LIGHT_GREY : props.theme.TYPE_DARK_GREY};
+    color: ${({ size, theme }) => (size === 'tiny' ? theme.TYPE_LIGHT_GREY : theme.TYPE_DARK_GREY)};
     padding: 0;
     font-weight: ${({ weight }) => getWeight(weight)};
     ${props =>

--- a/packages/components/src/support/Story.tsx
+++ b/packages/components/src/support/Story.tsx
@@ -7,8 +7,8 @@ const Wrapper = styled.div`
     display: flex;
     height: 100%;
     flex-wrap: wrap;
-    background: ${props => props.theme.BG_WHITE};
-    color: ${props => props.theme.TYPE_DARK_GREY};
+    background: ${({ theme }) => theme.BG_WHITE};
+    color: ${({ theme }) => theme.TYPE_DARK_GREY};
 `;
 
 const StoryWrapper = (story: any) => (

--- a/packages/components/src/support/ThemeProvider.tsx
+++ b/packages/components/src/support/ThemeProvider.tsx
@@ -4,16 +4,16 @@ import { SuiteThemeColors } from './types';
 
 const ThemeContext = React.createContext<SuiteThemeColors>(THEME.light);
 
-interface Props {
+interface ThemeProviderProps {
     theme: SuiteThemeColors;
     children?: any;
 }
 
-const ThemeProvider = (props: Props) => {
-    if (!props.children) {
+const ThemeProvider = ({ children, theme }: ThemeProviderProps) => {
+    if (!children) {
         return null;
     }
-    return <ThemeContext.Provider value={props.theme}>{props.children}</ThemeContext.Provider>;
+    return <ThemeContext.Provider value={theme}>{children}</ThemeContext.Provider>;
 };
 
 export { ThemeProvider, ThemeContext };

--- a/packages/connect-ui/src/views/Passphrase.tsx
+++ b/packages/connect-ui/src/views/Passphrase.tsx
@@ -29,7 +29,7 @@ const WalletsWrapper = styled.div`
 const Divider = styled.div`
     margin: 16px 16px;
     height: 1px;
-    background: ${props => props.theme.STROKE_GREY};
+    background: ${({ theme }) => theme.STROKE_GREY};
 `;
 
 export type PassphraseEventProps = Extract<UiEvent, { type: 'ui-request_passphrase' }>;

--- a/packages/suite-desktop-ui/src/support/DesktopUpdater/Available.tsx
+++ b/packages/suite-desktop-ui/src/support/DesktopUpdater/Available.tsx
@@ -1,28 +1,28 @@
-import React, { useCallback } from 'react';
+import React from 'react';
 import ReactMarkdown from 'react-markdown';
 
 import styled from 'styled-components';
 import { Translation, Modal } from 'src/components/suite';
-import { useActions } from 'src/hooks/suite';
+import { useDispatch } from 'src/hooks/suite';
 import { getReleaseUrl } from 'src/services/github';
-import * as desktopUpdateActions from 'src/actions/suite/desktopUpdateActions';
+import { download } from 'src/actions/suite/desktopUpdateActions';
 
 import { Button, H2, variables, Link } from '@trezor/components';
 import { desktopApi, UpdateInfo } from '@trezor/suite-desktop-api';
 
 const GreenH2 = styled(H2)`
     text-align: left;
-    color: ${props => props.theme.TYPE_GREEN};
+    color: ${({ theme }) => theme.TYPE_GREEN};
 `;
 
 const ChangelogWrapper = styled.div`
     margin: 20px 0px;
-    background: ${props => props.theme.BG_GREY};
+    background: ${({ theme }) => theme.BG_GREY};
     border-radius: 8px;
     max-height: 400px;
     overflow-y: auto;
     padding: 16px 20px;
-    color: ${props => props.theme.TYPE_DARK_GREY};
+    color: ${({ theme }) => theme.TYPE_DARK_GREY};
     font-size: ${variables.FONT_SIZE.SMALL};
     font-weight: ${variables.FONT_WEIGHT.MEDIUM};
     text-align: left;
@@ -105,14 +105,12 @@ interface AvailableProps {
 }
 
 export const Available = ({ hideWindow, isCancelable, latest }: AvailableProps) => {
-    const { download } = useActions({
-        download: desktopUpdateActions.download,
-    });
+    const dispatch = useDispatch();
 
-    const downloadUpdate = useCallback(() => {
-        download();
+    const downloadUpdate = () => {
+        dispatch(download());
         desktopApi.downloadUpdate();
-    }, [download]);
+    };
 
     return (
         <StyledModal

--- a/packages/suite-desktop-ui/src/support/DesktopUpdater/Downloading.tsx
+++ b/packages/suite-desktop-ui/src/support/DesktopUpdater/Downloading.tsx
@@ -16,19 +16,19 @@ const DownloadWrapper = styled(Row)`
 const DownloadProgress = styled.span`
     font-size: 20px;
     font-weight: ${variables.FONT_WEIGHT.DEMI_BOLD};
-    color: ${props => props.theme.TYPE_LIGHT_GREY};
+    color: ${({ theme }) => theme.TYPE_LIGHT_GREY};
 `;
 
 const ReceivedData = styled.span`
-    color: ${props => props.theme.TYPE_GREEN};
+    color: ${({ theme }) => theme.TYPE_GREEN};
 `;
 
 const TotalData = styled.span`
-    color: ${props => props.theme.TYPE_LIGHT_GREY};
+    color: ${({ theme }) => theme.TYPE_LIGHT_GREY};
 `;
 
 const Text = styled(H2)`
-    color: ${props => props.theme.TYPE_DARK_GREY};
+    color: ${({ theme }) => theme.TYPE_DARK_GREY};
     font-weight: ${variables.FONT_WEIGHT.MEDIUM};
 `;
 

--- a/packages/suite-desktop-ui/src/support/DesktopUpdater/Ready.tsx
+++ b/packages/suite-desktop-ui/src/support/DesktopUpdater/Ready.tsx
@@ -1,16 +1,16 @@
 import React from 'react';
-
 import styled from 'styled-components';
+
 import { Translation, Modal } from 'src/components/suite';
-import { useActions } from 'src/hooks/suite';
-import * as desktopUpdateActions from 'src/actions/suite/desktopUpdateActions';
+import { useDispatch } from 'src/hooks/suite';
+import { installUpdate } from 'src/actions/suite/desktopUpdateActions';
 
 import { Button, H2, variables } from '@trezor/components';
 
 const Description = styled.span`
     font-size: ${variables.FONT_SIZE.SMALL};
     font-weight: ${variables.FONT_WEIGHT.MEDIUM};
-    color: ${props => props.theme.TYPE_LIGHT_GREY};
+    color: ${({ theme }) => theme.TYPE_LIGHT_GREY};
 `;
 
 const StyledModal = styled(Modal)`
@@ -27,12 +27,11 @@ interface ReadyProps {
 }
 
 export const Ready = ({ hideWindow, isCancelable }: ReadyProps) => {
-    const { installUpdate } = useActions({
-        installUpdate: desktopUpdateActions.installUpdate,
-    });
+    const dispatch = useDispatch();
 
+    const install = () => dispatch(installUpdate());
     const installOnQuit = () => {
-        installUpdate(true);
+        install();
         hideWindow();
     };
 
@@ -46,7 +45,7 @@ export const Ready = ({ hideWindow, isCancelable }: ReadyProps) => {
                     <Button onClick={installOnQuit} variant="secondary">
                         <Translation id="TR_UPDATE_MODAL_UPDATE_ON_QUIT" />
                     </Button>
-                    <Button onClick={() => installUpdate()} variant="primary">
+                    <Button onClick={install} variant="primary">
                         <Translation id="TR_UPDATE_MODAL_INSTALL_AND_RESTART" />
                     </Button>
                 </>

--- a/packages/suite-desktop-ui/src/support/DesktopUpdater/styles.ts
+++ b/packages/suite-desktop-ui/src/support/DesktopUpdater/styles.ts
@@ -24,7 +24,7 @@ export const Divider = styled.div`
     width: 100%;
     height: 1px;
     margin: 30px 0px;
-    background: ${props => props.theme.STROKE_GREY};
+    background: ${({ theme }) => theme.STROKE_GREY};
 `;
 
 export const ImageWrapper = styled.div`
@@ -48,5 +48,5 @@ export const Title = styled(H2)`
 
 export const Description = styled(P)`
     font-size: ${variables.FONT_SIZE.SMALL};
-    color: ${props => props.theme.TYPE_LIGHT_GREY};
+    color: ${({ theme }) => theme.TYPE_LIGHT_GREY};
 `;

--- a/packages/suite/src/components/dashboard/Section/index.tsx
+++ b/packages/suite/src/components/dashboard/Section/index.tsx
@@ -19,13 +19,13 @@ const Title = styled(H3)`
 
 const Actions = styled.div``;
 
-interface Props extends React.HTMLAttributes<HTMLDivElement> {
+interface SectionProps extends React.HTMLAttributes<HTMLDivElement> {
     heading: ReactElement;
     actions?: ReactElement;
 }
 
 const Section = React.forwardRef(
-    ({ heading, actions, children, ...rest }: Props, ref: React.Ref<HTMLDivElement>) => (
+    ({ heading, actions, children, ...rest }: SectionProps, ref: React.Ref<HTMLDivElement>) => (
         <Wrapper {...rest} ref={ref}>
             <Header>
                 {heading && <Title>{heading}</Title>}

--- a/packages/suite/src/components/firmware/Fingerprint.tsx
+++ b/packages/suite/src/components/firmware/Fingerprint.tsx
@@ -7,8 +7,8 @@ const Wrapper = styled.pre`
     padding: 8px;
     width: 100%;
     overflow: hidden;
-    background-color: ${props => props.theme.BG_GREY};
-    color: ${props => props.theme.TYPE_DARK_GREY};
+    background-color: ${({ theme }) => theme.BG_GREY};
+    color: ${({ theme }) => theme.TYPE_DARK_GREY};
     text-align: center;
     word-break: break-all;
     font-family: monospace;

--- a/packages/suite/src/components/firmware/FirmwareChangelog.tsx
+++ b/packages/suite/src/components/firmware/FirmwareChangelog.tsx
@@ -7,7 +7,7 @@ import { Button, variables } from '@trezor/components';
 import { AcquiredDevice } from 'src/types/suite/index';
 
 const Wrapper = styled.div`
-    color: ${props => props.theme.TYPE_DARK_GREY};
+    color: ${({ theme }) => theme.TYPE_DARK_GREY};
     max-height: 360px;
     min-width: 305px;
     overflow: auto;

--- a/packages/suite/src/components/firmware/ProgressBar.tsx
+++ b/packages/suite/src/components/firmware/ProgressBar.tsx
@@ -39,7 +39,7 @@ const Percentage = styled.div`
     height: 24px;
 `;
 
-interface Props {
+interface ProgressBarProps {
     current: number; // current progress
     total: number; // total number of increments
     label: React.ReactNode;
@@ -55,7 +55,7 @@ export const ProgressBar = ({
     maintainCompletedState,
     fakeProgressDuration,
     fakeProgressBarrier = 90,
-}: Props) => {
+}: ProgressBarProps) => {
     const theme = useTheme();
     const [storedProgress, setStoreProgress] = useState(0);
     const progress = (100 / total) * current;

--- a/packages/suite/src/components/firmware/SelectCustomFirmware.tsx
+++ b/packages/suite/src/components/firmware/SelectCustomFirmware.tsx
@@ -24,12 +24,12 @@ const InstallButton = styled(Button)`
     margin: 36px auto 0;
 `;
 
-type Props = {
+type SelectCustomFirmwareProps = {
     device?: TrezorDevice;
     onSuccess: (fw: ArrayBuffer) => void;
 };
 
-export const SelectCustomFirmware = ({ device, onSuccess }: Props) => {
+export const SelectCustomFirmware = ({ device, onSuccess }: SelectCustomFirmwareProps) => {
     const [firmwareBinary, setFirmwareBinary] = useState<ArrayBuffer>();
 
     const onFirmwareUpload = async (

--- a/packages/suite/src/components/firmware/Typography.tsx
+++ b/packages/suite/src/components/firmware/Typography.tsx
@@ -13,7 +13,7 @@ interface Props {
 }
 
 const StyledP = styled(OrigP)`
-    color: ${props => props.theme.TYPE_LIGHT_GREY};
+    color: ${({ theme }) => theme.TYPE_LIGHT_GREY};
 `;
 
 export const P = (props: Props) => (
@@ -29,7 +29,7 @@ const StyledH2 = styled(OrigH2)<{ isGreen?: boolean }>`
     ${props =>
         props.isGreen &&
         css`
-            color: ${props => props.theme.TYPE_GREEN};
+            color: ${({ theme }) => theme.TYPE_GREEN};
         `};
 `;
 

--- a/packages/suite/src/components/guide/GuideCategory.tsx
+++ b/packages/suite/src/components/guide/GuideCategory.tsx
@@ -3,9 +3,9 @@ import styled from 'styled-components';
 
 import { variables } from '@trezor/components';
 import { Header, Content, ViewWrapper, GuideNode, GuideCategories } from 'src/components/guide';
-import { useActions, useSelector } from 'src/hooks/suite';
+import { useDispatch, useSelector } from 'src/hooks/suite';
 import { Translation } from 'src/components/suite';
-import * as guideActions from 'src/actions/suite/guideActions';
+import { setView } from 'src/actions/suite/guideActions';
 import { getNodeTitle } from 'src/utils/suite/guide';
 
 const Section = styled.div`
@@ -19,7 +19,7 @@ const Section = styled.div`
 const SectionHeading = styled.h3`
     font-size: ${variables.FONT_SIZE.SMALL};
     font-weight: ${variables.FONT_WEIGHT.DEMI_BOLD};
-    color: ${props => props.theme.TYPE_LIGHT_GREY};
+    color: ${({ theme }) => theme.TYPE_LIGHT_GREY};
     padding: 8px 0 18px 0;
 `;
 
@@ -30,13 +30,9 @@ const Nodes = styled.div`
 `;
 
 export const GuideCategory = () => {
-    const { currentNode, language } = useSelector(state => ({
-        currentNode: state.guide.currentNode,
-        language: state.suite.settings.language,
-    }));
-    const { setView } = useActions({
-        setView: guideActions.setView,
-    });
+    const currentNode = useSelector(state => state.guide.currentNode);
+    const language = useSelector(state => state.suite.settings.language);
+    const dispatch = useDispatch();
 
     if (!currentNode || currentNode.type === 'page') {
         return null;
@@ -50,9 +46,11 @@ export const GuideCategory = () => {
     const pages = currentNode.children.filter(child => child.type === 'page');
     const subcategories = currentNode.children.filter(child => child.type === 'category');
 
+    const goBack = () => dispatch(setView('GUIDE_DEFAULT'));
+
     return (
         <ViewWrapper>
-            <Header back={() => setView('GUIDE_DEFAULT')} label={title} />
+            <Header back={goBack} label={title} />
             <Content>
                 {pages.length ? (
                     <Section>

--- a/packages/suite/src/components/guide/GuideDefault.tsx
+++ b/packages/suite/src/components/guide/GuideDefault.tsx
@@ -4,13 +4,13 @@ import styled from 'styled-components';
 import { analytics, EventType } from '@trezor/suite-analytics';
 
 import { Translation } from 'src/components/suite';
-import * as guideActions from 'src/actions/suite/guideActions';
-import { useActions, useSelector } from 'src/hooks/suite';
+import { setView } from 'src/actions/suite/guideActions';
+import { useDispatch, useSelector } from 'src/hooks/suite';
 import { Icon, variables, useTheme } from '@trezor/components';
 import { Header, Content, ViewWrapper, GuideCategories, GuideSearch } from 'src/components/guide';
 
 const FeedbackLinkWrapper = styled.div`
-    border-top: 1px solid ${props => props.theme.STROKE_GREY};
+    border-top: 1px solid ${({ theme }) => theme.STROKE_GREY};
     padding: 11px 14px;
 `;
 
@@ -21,19 +21,19 @@ const FeedbackButton = styled.button`
     border: 0;
     border-radius: 4px;
     cursor: pointer;
-    color: ${props => props.theme.TYPE_LIGHT_GREY};
+    color: ${({ theme }) => theme.TYPE_LIGHT_GREY};
     text-align: left;
     padding: 11px;
     background: none;
-    transition: ${props =>
-        `background ${props.theme.HOVER_TRANSITION_TIME} ${props.theme.HOVER_TRANSITION_EFFECT}`};
+    transition: ${({ theme }) =>
+        `background ${theme.HOVER_TRANSITION_TIME} ${theme.HOVER_TRANSITION_EFFECT}`};
     /* speficy position and z-index so that GuideButton does not interfere */
     position: relative;
     z-index: ${variables.Z_INDEX.GUIDE};
 
     :hover,
     :focus {
-        background: ${props => darken(props.theme.HOVER_DARKEN_FILTER, props.theme.BG_WHITE)};
+        background: ${({ theme }) => darken(theme.HOVER_DARKEN_FILTER, theme.BG_WHITE)};
     }
 
     :last-child {
@@ -56,16 +56,11 @@ const FeedbackButtonRightIcon = styled(Icon)`
 export const GuideDefault = () => {
     const theme = useTheme();
     const [searchActive, setSearchActive] = useState(false);
-
-    const { setView } = useActions({
-        setView: guideActions.setView,
-    });
-    const { indexNode } = useSelector(state => ({
-        indexNode: state.guide.indexNode,
-    }));
+    const indexNode = useSelector(state => state.guide.indexNode);
+    const dispatch = useDispatch();
 
     const handleFeedbackButtonClick = () => {
-        setView('SUPPORT_FEEDBACK_SELECTION');
+        dispatch(setView('SUPPORT_FEEDBACK_SELECTION'));
         analytics.report({
             type: EventType.GuideFeedbackNavigation,
             payload: { type: 'overview' },

--- a/packages/suite/src/components/guide/GuideNode.tsx
+++ b/packages/suite/src/components/guide/GuideNode.tsx
@@ -5,8 +5,8 @@ import { analytics, EventType } from '@trezor/suite-analytics';
 import { resolveStaticPath } from '@suite-common/suite-utils';
 
 import { Icon, variables, useTheme } from '@trezor/components';
-import { useActions, useSelector } from 'src/hooks/suite';
-import * as guideActions from 'src/actions/suite/guideActions';
+import { useDispatch, useSelector } from 'src/hooks/suite';
+import { openNode } from 'src/actions/suite/guideActions';
 import { GuideNode as GuideNodeType } from '@suite-common/suite-types';
 import { getNodeTitle } from 'src/utils/suite/guide';
 
@@ -42,7 +42,7 @@ const Label = styled.div<{ isBold: boolean }>`
     font-size: ${variables.FONT_SIZE.SMALL};
     font-weight: ${({ isBold }) =>
         isBold ? variables.FONT_WEIGHT.DEMI_BOLD : variables.FONT_WEIGHT.MEDIUM};
-    color: ${props => props.theme.TYPE_DARK_GREY};
+    color: ${({ theme }) => theme.TYPE_DARK_GREY};
     overflow: hidden;
     line-height: 16px;
     flex: 1;
@@ -71,19 +71,13 @@ type GuideNodeProps = {
 };
 
 export const GuideNode = ({ node, description }: GuideNodeProps) => {
-    const { language } = useSelector(state => ({
-        language: state.suite.settings.language,
-    }));
+    const language = useSelector(state => state.suite.settings.language);
+    const dispatch = useDispatch();
 
     const theme = useTheme();
 
-    const { openNode } = useActions({
-        setView: guideActions.setView,
-        openNode: guideActions.openNode,
-    });
-
     const navigateToNode = () => {
-        openNode(node);
+        dispatch(openNode(node));
         analytics.report({
             type: EventType.GuideNodeNavigation,
             payload: {

--- a/packages/suite/src/components/guide/GuidePage.tsx
+++ b/packages/suite/src/components/guide/GuidePage.tsx
@@ -5,10 +5,8 @@ import { Translation } from 'src/components/suite';
 import { useGuideLoadPage } from 'src/hooks/guide';
 
 export const GuidePage = () => {
-    const { currentNode, language } = useSelector(state => ({
-        currentNode: state.guide.currentNode,
-        language: state.suite.settings.language,
-    }));
+    const currentNode = useSelector(state => state.guide.currentNode);
+    const language = useSelector(state => state.suite.settings.language);
 
     const { markdown, hasError } = useGuideLoadPage(currentNode, language);
 

--- a/packages/suite/src/components/guide/GuidePanel.tsx
+++ b/packages/suite/src/components/guide/GuidePanel.tsx
@@ -60,9 +60,7 @@ const MotionGuide = styled(motion.div)`
 `;
 
 export const GuidePanel = () => {
-    const { activeView } = useSelector(state => ({
-        activeView: state.guide.view,
-    }));
+    const activeView = useSelector(state => state.guide.view);
 
     const { isGuideOpen, closeGuide } = useGuide();
 

--- a/packages/suite/src/components/guide/GuideSearch.tsx
+++ b/packages/suite/src/components/guide/GuideSearch.tsx
@@ -44,7 +44,7 @@ const StyledInput = styled(Input)`
         background-color: ${({ theme }) => theme.BG_GREY_ALT};
         border-radius: 8px;
         height: 40px;
-        border-color: ${props => props.theme.BG_GREY_ALT};
+        border-color: ${({ theme }) => theme.BG_GREY_ALT};
         transition: border-color 0.2s;
 
         :focus {

--- a/packages/suite/src/components/guide/HeaderBreadcrumb.tsx
+++ b/packages/suite/src/components/guide/HeaderBreadcrumb.tsx
@@ -3,8 +3,8 @@ import styled from 'styled-components';
 import { darken } from 'polished';
 import { analytics, EventType } from '@trezor/suite-analytics';
 
-import { useActions, useSelector } from 'src/hooks/suite';
-import * as guideActions from 'src/actions/suite/guideActions';
+import { useDispatch, useSelector } from 'src/hooks/suite';
+import { openNode, setView } from 'src/actions/suite/guideActions';
 import { variables } from '@trezor/components';
 import { Translation } from 'src/components/suite';
 import TrezorLink from 'src/components/suite/TrezorLink';
@@ -44,21 +44,17 @@ const CategoryLink = styled(TrezorLink)`
 `;
 
 export const HeaderBreadcrumb = () => {
-    const { language, indexNode, currentNode } = useSelector(state => ({
-        language: state.suite.settings.language,
-        indexNode: state.guide.indexNode,
-        currentNode: state.guide.currentNode,
-    }));
+    const language = useSelector(state => state.suite.settings.language);
+    const indexNode = useSelector(state => state.guide.indexNode);
+    const currentNode = useSelector(state => state.guide.currentNode);
+    const dispatch = useDispatch();
 
-    const { setView, openNode } = useActions({
-        setView: guideActions.setView,
-        openNode: guideActions.openNode,
-    });
+    const goToDashboard = () => dispatch(setView('GUIDE_DEFAULT'));
 
     // if no parent available, offer navigation to guide dashboard
     const FallbackBreadcrumb = (
         <BreadcrumbWrapper>
-            <CategoryLink onClick={() => setView('GUIDE_DEFAULT')}>
+            <CategoryLink onClick={goToDashboard}>
                 <Translation id="TR_GUIDE_DASHBOARD" />
             </CategoryLink>
         </BreadcrumbWrapper>
@@ -73,7 +69,7 @@ export const HeaderBreadcrumb = () => {
     if (!parentNodes.length) return FallbackBreadcrumb;
 
     const navigateToCategory = (node: GuideCategory) => {
-        openNode(node);
+        dispatch(openNode(node));
         analytics.report({
             type: EventType.GuideHeaderNavigation,
             payload: {
@@ -84,7 +80,7 @@ export const HeaderBreadcrumb = () => {
     };
 
     const navigateToGuideDashboard = () => {
-        setView('GUIDE_DEFAULT');
+        dispatch(setView('GUIDE_DEFAULT'));
         analytics.report({
             type: EventType.GuideHeaderNavigation,
             payload: {

--- a/packages/suite/src/components/guide/OpenGuideFromTooltip.tsx
+++ b/packages/suite/src/components/guide/OpenGuideFromTooltip.tsx
@@ -13,7 +13,7 @@ const OpenGuideLink = styled(TrezorLink)`
 `;
 
 const StyledText = styled.span`
-    color: ${props => props.theme.TYPE_ORANGE};
+    color: ${({ theme }) => theme.TYPE_ORANGE};
     font-weight: 500;
     overflow: hidden;
     max-width: 0;
@@ -28,7 +28,7 @@ const StyledIconWrap = styled.span`
     justify-content: center;
     transition: all 0.3s ease-in-out;
     border-radius: 50%;
-    background-color: ${props => transparentize(0.85, props.theme.TYPE_ORANGE)};
+    background-color: ${({ theme }) => transparentize(0.85, theme.TYPE_ORANGE)};
 `;
 
 type OpenGuideFromTooltipProps = {

--- a/packages/suite/src/components/guide/SupportFeedbackSelection.tsx
+++ b/packages/suite/src/components/guide/SupportFeedbackSelection.tsx
@@ -6,8 +6,8 @@ import { analytics, EventType } from '@trezor/suite-analytics';
 import { resolveStaticPath, isDevEnv } from '@suite-common/suite-utils';
 
 import { Translation } from 'src/components/suite';
-import * as guideActions from 'src/actions/suite/guideActions';
-import { useActions, useSelector } from 'src/hooks/suite';
+import { setView } from 'src/actions/suite/guideActions';
+import { useDispatch, useSelector } from 'src/hooks/suite';
 import { Icon, Link, variables } from '@trezor/components';
 import { ViewWrapper, Header, Content } from 'src/components/guide';
 import { isDesktop } from '@trezor/env-utils';
@@ -23,7 +23,7 @@ const Section = styled.div`
 const SectionHeader = styled.h3`
     font-size: ${variables.FONT_SIZE.SMALL};
     font-weight: ${variables.FONT_WEIGHT.DEMI_BOLD};
-    color: ${props => props.theme.TYPE_LIGHT_GREY};
+    color: ${({ theme }) => theme.TYPE_LIGHT_GREY};
     padding: 0 0 18px 0;
 `;
 
@@ -36,14 +36,14 @@ const SectionButton = styled.button<{ hasBackground?: boolean }>`
     display: flex;
     align-items: center;
     padding: 13px;
-    background: ${props => (props.hasBackground ? props.theme.BG_GREY_ALT : 'none')};
-    border: 2px solid ${props => props.theme.BG_GREY_ALT};
+    background: ${({ hasBackground, theme }) => (hasBackground ? theme.BG_GREY_ALT : 'none')};
+    border: 2px solid ${({ theme }) => theme.BG_GREY_ALT};
 
-    transition: ${props =>
-        `background ${props.theme.HOVER_TRANSITION_TIME} ${props.theme.HOVER_TRANSITION_EFFECT}`};
+    transition: ${({ theme }) =>
+        `background ${theme.HOVER_TRANSITION_TIME} ${theme.HOVER_TRANSITION_EFFECT}`};
 
     &:hover {
-        background: ${props => darken(props.theme.HOVER_DARKEN_FILTER, props.theme.BG_GREY_ALT)};
+        background: ${({ theme }) => darken(theme.HOVER_DARKEN_FILTER, theme.BG_GREY_ALT)};
     }
 `;
 
@@ -55,7 +55,7 @@ const Details = styled.div`
     padding: 10px 0 0 0;
     font-size: 10px;
     font-weight: ${variables.FONT_WEIGHT.MEDIUM};
-    color: ${props => props.theme.TYPE_LIGHT_GREY};
+    color: ${({ theme }) => theme.TYPE_LIGHT_GREY};
     display: flex;
     justify-content: space-around;
 `;
@@ -83,7 +83,7 @@ const Label = styled.div`
 const LabelHeadline = styled.strong`
     font-size: ${variables.FONT_SIZE.NORMAL};
     font-weight: ${variables.FONT_WEIGHT.MEDIUM};
-    color: ${props => props.theme.TYPE_DARK_GREY};
+    color: ${({ theme }) => theme.TYPE_DARK_GREY};
     display: flex;
     align-items: center;
     justify-content: space-between;
@@ -96,17 +96,13 @@ const LabelHeadline = styled.strong`
 const LabelSubheadline = styled.div`
     font-size: ${variables.FONT_SIZE.SMALL};
     font-weight: ${variables.FONT_WEIGHT.MEDIUM};
-    color: ${props => props.theme.TYPE_LIGHT_GREY};
+    color: ${({ theme }) => theme.TYPE_LIGHT_GREY};
 `;
 
 export const SupportFeedbackSelection = () => {
-    const { setView } = useActions({
-        setView: guideActions.setView,
-    });
-    const { desktopUpdate, device } = useSelector(state => ({
-        desktopUpdate: state.desktopUpdate,
-        device: state.suite.device,
-    }));
+    const desktopUpdate = useSelector(state => state.desktopUpdate);
+    const device = useSelector(state => state.suite.device);
+    const dispatch = useDispatch();
 
     const appUpToDate =
         isDesktop() &&
@@ -119,10 +115,26 @@ export const SupportFeedbackSelection = () => {
         <Translation id="TR_DEVICE_NOT_CONNECTED" />
     );
 
+    const goBack = () => dispatch(setView('GUIDE_DEFAULT'));
+    const handleBugButtonClick = () => {
+        dispatch(setView('FEEDBACK_BUG'));
+        analytics.report({
+            type: EventType.GuideFeedbackNavigation,
+            payload: { type: 'bug' },
+        });
+    };
+    const handleFeedbackButtonClick = () => {
+        dispatch(setView('FEEDBACK_SUGGESTION'));
+        analytics.report({
+            type: EventType.GuideFeedbackNavigation,
+            payload: { type: 'suggestion' },
+        });
+    };
+
     return (
         <ViewWrapper>
             <Header
-                back={() => setView('GUIDE_DEFAULT')}
+                back={goBack}
                 label={<Translation id="TR_GUIDE_VIEW_HEADLINES_SUPPORT_FEEDBACK_SELECTION" />}
             />
             <Content>
@@ -131,13 +143,7 @@ export const SupportFeedbackSelection = () => {
                         <Translation id="TR_GUIDE_VIEW_HEADLINE_HELP_US_IMPROVE" />
                     </SectionHeader>
                     <SectionButton
-                        onClick={() => {
-                            setView('FEEDBACK_BUG');
-                            analytics.report({
-                                type: EventType.GuideFeedbackNavigation,
-                                payload: { type: 'bug' },
-                            });
-                        }}
+                        onClick={handleBugButtonClick}
                         hasBackground
                         data-test="@guide/feedback/bug"
                     >
@@ -157,13 +163,7 @@ export const SupportFeedbackSelection = () => {
                         </Label>
                     </SectionButton>
                     <SectionButton
-                        onClick={() => {
-                            setView('FEEDBACK_SUGGESTION');
-                            analytics.report({
-                                type: EventType.GuideFeedbackNavigation,
-                                payload: { type: 'suggestion' },
-                            });
-                        }}
+                        onClick={handleFeedbackButtonClick}
                         hasBackground
                         data-test="@guide/feedback/suggestion"
                     >

--- a/packages/suite/src/components/onboarding/Buttons/ButtonAlt.tsx
+++ b/packages/suite/src/components/onboarding/Buttons/ButtonAlt.tsx
@@ -1,11 +1,11 @@
 import React from 'react';
 import { Button } from '@trezor/components';
 
-interface Props extends React.ButtonHTMLAttributes<HTMLButtonElement> {
+interface ButtonAltProps extends React.ButtonHTMLAttributes<HTMLButtonElement> {
     isDisabled?: boolean;
 }
 
-const ButtonAlt = (props: Props) => (
+const ButtonAlt = (props: ButtonAltProps) => (
     <Button variant="secondary" {...props}>
         {props.children}
     </Button>

--- a/packages/suite/src/components/onboarding/Buttons/ButtonSkip.tsx
+++ b/packages/suite/src/components/onboarding/Buttons/ButtonSkip.tsx
@@ -5,7 +5,7 @@ import { variables } from '@trezor/components';
 const StyledSpan = styled.span`
     cursor: pointer;
     text-decoration: underline;
-    color: ${props => props.theme.TYPE_LIGHT_GREY};
+    color: ${({ theme }) => theme.TYPE_LIGHT_GREY};
     font-weight: ${variables.FONT_WEIGHT.MEDIUM};
     font-size: ${variables.FONT_SIZE.SMALL};
 `;

--- a/packages/suite/src/components/onboarding/ConnectDevicePromptManager/index.tsx
+++ b/packages/suite/src/components/onboarding/ConnectDevicePromptManager/index.tsx
@@ -46,9 +46,8 @@ export const ConnectDevicePromptManager = ({
     className,
     children,
 }: ConnectDevicePromptManagerProps) => {
-    const { transport } = useSelector(state => ({
-        transport: state.suite.transport,
-    }));
+    const transport = useSelector(state => state.suite.transport);
+
     const deviceStatus = getConnectedDeviceStatus(device);
     const isDetectingDevice =
         (device && device.features && device.connected) || deviceStatus === 'unreadable';

--- a/packages/suite/src/components/onboarding/DeviceAnimation/index.tsx
+++ b/packages/suite/src/components/onboarding/DeviceAnimation/index.tsx
@@ -43,7 +43,7 @@ const Wrapper = styled.div<{ size?: number; shape?: Shape }>`
 const StyledLottie = styled(Lottie)`
     width: 100%;
     height: 100%;
-    background: ${props => props.theme.BG_GREY};
+    background: ${({ theme }) => theme.BG_GREY};
 `;
 
 const StyledVideo = styled.video`

--- a/packages/suite/src/components/onboarding/OnboardingLayout.tsx
+++ b/packages/suite/src/components/onboarding/OnboardingLayout.tsx
@@ -96,7 +96,7 @@ const ProgressBarRow = styled.div`
 const Content = styled.div`
     display: flex;
     flex-direction: column;
-    color: ${props => props.theme.TYPE_DARK_GREY};
+    color: ${({ theme }) => theme.TYPE_DARK_GREY};
     justify-content: center;
     align-items: center;
     max-width: ${MAX_WIDTH};

--- a/packages/suite/src/components/onboarding/Option.tsx
+++ b/packages/suite/src/components/onboarding/Option.tsx
@@ -6,15 +6,15 @@ const Wrapper = styled.div`
     display: flex;
     padding: 24px 16px 24px 24px;
     border-radius: 5px;
-    border: solid 1px ${props => props.theme.STROKE_GREY};
+    border: solid 1px ${({ theme }) => theme.STROKE_GREY};
     align-items: center;
     width: 100%;
     cursor: pointer;
     transition: all 0.3s;
 
     :hover {
-        box-shadow: 0 6px 40px 0 ${props => props.theme.BOX_SHADOW_OPTION_CARD};
-        border: 1px solid ${props => props.theme.STROKE_GREY_ALT};
+        box-shadow: 0 6px 40px 0 ${({ theme }) => theme.BOX_SHADOW_OPTION_CARD};
+        border: 1px solid ${({ theme }) => theme.STROKE_GREY_ALT};
     }
 `;
 
@@ -25,14 +25,14 @@ const Content = styled.div`
 `;
 
 const Heading = styled.span`
-    color: ${props => props.theme.TYPE_DARK_GREY};
+    color: ${({ theme }) => theme.TYPE_DARK_GREY};
     font-weight: ${variables.FONT_WEIGHT.DEMI_BOLD};
     font-size: ${variables.FONT_SIZE.NORMAL};
 `;
 
 const Description = styled.span`
     margin-top: 5px;
-    color: ${props => props.theme.TYPE_LIGHT_GREY};
+    color: ${({ theme }) => theme.TYPE_LIGHT_GREY};
     font-weight: ${variables.FONT_WEIGHT.MEDIUM};
     font-size: ${variables.FONT_SIZE.SMALL};
 `;

--- a/packages/suite/src/components/onboarding/ProgressBar.tsx
+++ b/packages/suite/src/components/onboarding/ProgressBar.tsx
@@ -18,7 +18,7 @@ const StepWrapper = styled.div<{ active: boolean }>`
     padding: 0 20px;
     align-items: center;
     align-self: center;
-    color: ${props => props.theme.TYPE_LIGHT_GREY};
+    color: ${({ theme }) => theme.TYPE_LIGHT_GREY};
     font-size: ${variables.NEUE_FONT_SIZE.NORMAL};
     font-weight: ${variables.FONT_WEIGHT.DEMI_BOLD};
 
@@ -26,10 +26,10 @@ const StepWrapper = styled.div<{ active: boolean }>`
         padding: 0;
     }
 
-    ${props =>
-        props.active &&
+    ${({ active, theme }) =>
+        active &&
         css`
-            color: ${props.theme.TYPE_GREEN};
+            color: ${theme.TYPE_GREEN};
         `}
 `;
 
@@ -37,7 +37,7 @@ const IconWrapper = styled.div<{ stepCompleted?: boolean; active?: boolean }>`
     display: flex;
     width: 32px;
     height: 32px;
-    background: ${props => props.theme.BG_GREY};
+    background: ${({ theme }) => theme.BG_GREY};
     align-items: center;
     justify-content: center;
     border-radius: 50%;
@@ -46,15 +46,15 @@ const IconWrapper = styled.div<{ stepCompleted?: boolean; active?: boolean }>`
     ${props =>
         props.stepCompleted &&
         css`
-            background: ${props => props.theme.BG_LIGHT_GREY};
+            background: ${({ theme }) => theme.BG_LIGHT_GREY};
         `}
 
-    ${props =>
-        props.active &&
+    ${({ active, theme }) =>
+        active &&
         css`
-            background: ${props.theme.BG_WHITE};
-            box-shadow: 0 2px 5px 0 ${props.theme.BOX_SHADOW_BLACK_20};
-            color: ${props.theme.TYPE_GREEN};
+            background: ${theme.BG_WHITE};
+            box-shadow: 0 2px 5px 0 ${theme.BOX_SHADOW_BLACK_20};
+            color: ${theme.TYPE_GREEN};
         `}
 `;
 
@@ -62,7 +62,7 @@ const Label = styled.div`
     text-align: center;
     margin: 10px 0 0 0;
     display: block;
-    color: ${props => props.theme.TYPE_LIGHT_GREY};
+    color: ${({ theme }) => theme.TYPE_LIGHT_GREY};
     font-size: ${variables.NEUE_FONT_SIZE.TINY};
     font-weight: ${variables.FONT_WEIGHT.MEDIUM};
 
@@ -73,7 +73,7 @@ const Label = styled.div`
 
 const Divider = styled.div`
     flex-grow: 1;
-    border-bottom: 1px solid ${props => props.theme.STROKE_GREY};
+    border-bottom: 1px solid ${({ theme }) => theme.STROKE_GREY};
     margin: 20px;
 
     @media (max-width: ${variables.SCREEN_SIZE.XL}) {

--- a/packages/suite/src/components/onboarding/ProgressBar.tsx
+++ b/packages/suite/src/components/onboarding/ProgressBar.tsx
@@ -85,7 +85,7 @@ const Divider = styled.div`
     }
 `;
 
-interface Props {
+interface ProgressBarProps {
     steps: {
         key: string;
         label?: React.ReactNode;
@@ -94,7 +94,7 @@ interface Props {
     className?: string;
 }
 
-export const ProgressBar = ({ steps, activeStep, className }: Props) => {
+export const ProgressBar = ({ steps, activeStep, className }: ProgressBarProps) => {
     const theme = useTheme();
     return (
         <ProgressBarWrapper className={className}>

--- a/packages/suite/src/components/onboarding/SkipStepConfirmation.tsx
+++ b/packages/suite/src/components/onboarding/SkipStepConfirmation.tsx
@@ -10,7 +10,7 @@ import { useOnboarding } from 'src/hooks/suite';
 const Wrapper = styled.div`
     display: flex;
     width: 100%;
-    color: ${props => props.theme.TYPE_DARK_GREY};
+    color: ${({ theme }) => theme.TYPE_DARK_GREY};
     font-size: ${variables.NEUE_FONT_SIZE.NORMAL};
     font-weight: ${variables.FONT_WEIGHT.MEDIUM};
     padding: 16px 0px;

--- a/packages/suite/src/components/suite/AccountFormCloseButton/index.tsx
+++ b/packages/suite/src/components/suite/AccountFormCloseButton/index.tsx
@@ -1,18 +1,14 @@
 import React from 'react';
-import { useActions } from 'src/hooks/suite';
-import * as routerActions from 'src/actions/suite/routerActions';
+import { useDispatch } from 'src/hooks/suite';
+import { goto } from 'src/actions/suite/routerActions';
 import { CloseButton } from 'src/components/suite';
 
 const AccountFormCloseButton = () => {
-    const { goto } = useActions({
-        goto: routerActions.goto,
-    });
-    return (
-        <CloseButton
-            onClick={() => goto('wallet-index', { preserveParams: true })}
-            data-test="@wallet/menu/close-button"
-        />
-    );
+    const dispatch = useDispatch();
+
+    const handleClick = () => dispatch(goto('wallet-index', { preserveParams: true }));
+
+    return <CloseButton onClick={handleClick} data-test="@wallet/menu/close-button" />;
 };
 
 export default AccountFormCloseButton;

--- a/packages/suite/src/components/suite/AddAccountButton/index.tsx
+++ b/packages/suite/src/components/suite/AddAccountButton/index.tsx
@@ -2,8 +2,8 @@ import React from 'react';
 
 import { Translation } from 'src/components/suite';
 import { TrezorDevice } from 'src/types/suite';
-import { useActions, useDiscovery } from 'src/hooks/suite';
-import * as modalActions from 'src/actions/suite/modalActions';
+import { useDiscovery, useDispatch } from 'src/hooks/suite';
+import { openModal } from 'src/actions/suite/modalActions';
 
 import { Button, Tooltip, ButtonProps, useTheme } from '@trezor/components';
 import { DiscoveryStatus } from '@suite-common/wallet-constants';
@@ -28,9 +28,8 @@ const getExplanationMessage = (device: TrezorDevice | undefined, discoveryIsRunn
 const AddAccountButton = ({ device, isDisabled, noButtonLabel, closeMenu, ...rest }: Props) => {
     const theme = useTheme();
     const { discovery } = useDiscovery();
-    const { openModal } = useActions({
-        openModal: modalActions.openModal,
-    });
+    const dispatch = useDispatch();
+
     const discoveryIsRunning = discovery ? discovery.status <= DiscoveryStatus.STOPPING : false;
 
     // TODO: add more cases when adding account is not possible
@@ -48,10 +47,12 @@ const AddAccountButton = ({ device, isDisabled, noButtonLabel, closeMenu, ...res
             onClick={
                 device
                     ? () => {
-                          openModal({
-                              type: 'add-account',
-                              device,
-                          });
+                          dispatch(
+                              openModal({
+                                  type: 'add-account',
+                                  device,
+                              }),
+                          );
                           if (closeMenu) closeMenu();
                       }
                     : undefined

--- a/packages/suite/src/components/suite/AddAccountButton/index.tsx
+++ b/packages/suite/src/components/suite/AddAccountButton/index.tsx
@@ -8,13 +8,6 @@ import { openModal } from 'src/actions/suite/modalActions';
 import { Button, Tooltip, ButtonProps, useTheme } from '@trezor/components';
 import { DiscoveryStatus } from '@suite-common/wallet-constants';
 
-interface Props extends ButtonProps {
-    device: TrezorDevice | undefined;
-    noButtonLabel?: boolean;
-    closeMenu?: () => void;
-    isDisabled?: boolean;
-}
-
 const getExplanationMessage = (device: TrezorDevice | undefined, discoveryIsRunning: boolean) => {
     let message;
     if (device && !device.connected) {
@@ -25,7 +18,20 @@ const getExplanationMessage = (device: TrezorDevice | undefined, discoveryIsRunn
     return message;
 };
 
-const AddAccountButton = ({ device, isDisabled, noButtonLabel, closeMenu, ...rest }: Props) => {
+interface AddAccountButtonProps extends ButtonProps {
+    device: TrezorDevice | undefined;
+    noButtonLabel?: boolean;
+    closeMenu?: () => void;
+    isDisabled?: boolean;
+}
+
+const AddAccountButton = ({
+    device,
+    isDisabled,
+    noButtonLabel,
+    closeMenu,
+    ...rest
+}: AddAccountButtonProps) => {
     const theme = useTheme();
     const { discovery } = useDiscovery();
     const dispatch = useDispatch();

--- a/packages/suite/src/components/suite/AppNavigation.tsx
+++ b/packages/suite/src/components/suite/AppNavigation.tsx
@@ -190,7 +190,7 @@ export type AppNavigationItem = {
     isHidden?: boolean;
 };
 
-interface Props {
+interface AppNavigationProps {
     items: AppNavigationItem[];
     primaryContent?: React.ReactNode;
     maxWidth?: 'small' | 'default';
@@ -214,7 +214,7 @@ const isSubsection = (routeName: Route['name']): boolean =>
 const isSecondaryMenuOverflown = ({ primary, secondary, wrapper }: MenuWidths) =>
     primary + secondary >= wrapper;
 
-export const AppNavigation = ({ items, primaryContent, maxWidth, inView }: Props) => {
+export const AppNavigation = ({ items, primaryContent, maxWidth, inView }: AppNavigationProps) => {
     const [condensedSecondaryMenuVisible, setCondensedSecondaryMenuVisible] =
         useState<boolean>(false);
     const wrapper = useRef<HTMLDivElement>(null);

--- a/packages/suite/src/components/suite/AppNavigation.tsx
+++ b/packages/suite/src/components/suite/AppNavigation.tsx
@@ -24,7 +24,7 @@ const Wrapper = styled.div<{ subRoute: boolean | undefined; inView?: boolean }>`
     width: 100%;
     z-index: ${variables.Z_INDEX.STICKY_BAR};
     display: flex;
-    background: ${props => props.theme.BG_LIGHT_GREY};
+    background: ${({ theme }) => theme.BG_LIGHT_GREY};
     justify-content: center;
     position: sticky;
     top: 0;
@@ -77,7 +77,7 @@ const KeepWidth = styled.div<{ maxWidth?: string; inView?: boolean }>`
     display: flex;
     align-items: center;
     justify-content: space-between;
-    background: ${props => props.theme.BG_LIGHT_GREY};
+    background: ${({ theme }) => theme.BG_LIGHT_GREY};
     width: 100%;
     max-width: ${props => (props.maxWidth === 'default' ? MAX_WIDTH : MAX_WIDTH_WALLET_CONTENT)};
 `;
@@ -107,16 +107,13 @@ const MenuElement = styled.div<{ isActive: boolean }>`
     position: relative;
     height: ${SECONDARY_PANEL_HEIGHT};
     font-size: ${FONT_SIZE.NORMAL};
-    color: ${props =>
-        props.isActive
-            ? props => props.theme.TYPE_DARK_GREY
-            : props => props.theme.TYPE_LIGHT_GREY};
+    color: ${({ isActive, theme }) => (isActive ? theme.TYPE_DARK_GREY : theme.TYPE_LIGHT_GREY)};
     font-weight: ${FONT_WEIGHT.MEDIUM};
     display: flex;
     align-items: center;
     white-space: nowrap;
     border-bottom: 2px solid
-        ${props => (props.isActive ? props => props.theme.TYPE_DARK_GREY : 'transparent')};
+        ${({ isActive, theme }) => (isActive ? theme.TYPE_DARK_GREY : 'transparent')};
     margin-right: 20px;
 
     :first-child {
@@ -142,8 +139,8 @@ const InnerWrap = styled.div`
     justify-content: center;
     align-content: center;
     padding: 0 16px;
-    border-bottom: 1px solid ${props => props.theme.STROKE_GREY};
-    background: ${props => props.theme.BG_LIGHT_GREY};
+    border-bottom: 1px solid ${({ theme }) => theme.STROKE_GREY};
+    background: ${({ theme }) => theme.BG_LIGHT_GREY};
 `;
 
 const IconWrapper = styled.div`

--- a/packages/suite/src/components/suite/AppNavigationPanel.tsx
+++ b/packages/suite/src/components/suite/AppNavigationPanel.tsx
@@ -7,7 +7,7 @@ const Wrapper = styled.div`
     display: flex;
     width: 100%;
     justify-content: center;
-    background: ${props => props.theme.BG_LIGHT_GREY};
+    background: ${({ theme }) => theme.BG_LIGHT_GREY};
     padding: 24px 32px 10px 32px;
     z-index: ${variables.Z_INDEX.PAGE_HEADER};
 
@@ -30,7 +30,7 @@ const BasicInfo = styled.div`
 
 const Title = styled(H1)`
     font-weight: ${variables.FONT_WEIGHT.DEMI_BOLD};
-    color: ${props => props.theme.TYPE_DARK_GREY};
+    color: ${({ theme }) => theme.TYPE_DARK_GREY};
     white-space: nowrap;
     overflow: hidden;
 `;

--- a/packages/suite/src/components/suite/Banners/Banner.tsx
+++ b/packages/suite/src/components/suite/Banners/Banner.tsx
@@ -29,8 +29,8 @@ const getIcon = (variant: BannerProps['variant'], theme: SuiteThemeColors) => {
 
 const Wrapper = styled.div<{ variant: BannerProps['variant'] }>`
     display: flex;
-    background: ${props => getBgColor(props.variant, props.theme)};
-    color: ${props => props.theme.TYPE_WHITE};
+    background: ${({ theme, variant }) => getBgColor(variant, theme)};
+    color: ${({ theme }) => theme.TYPE_WHITE};
     padding: 7px 9px;
     font-weight: 600;
     border-radius: 10px;

--- a/packages/suite/src/components/suite/Banners/FailedBackup.tsx
+++ b/packages/suite/src/components/suite/Banners/FailedBackup.tsx
@@ -1,25 +1,21 @@
 import React from 'react';
 import { Translation } from 'src/components/suite';
-import * as routerActions from 'src/actions/suite/routerActions';
-import { useActions } from 'src/hooks/suite';
+import { goto } from 'src/actions/suite/routerActions';
+import { useDispatch } from 'src/hooks/suite';
 import { Banner } from './Banner';
 import { SettingsAnchor } from 'src/constants/suite/anchors';
 
 const FailedBackup = () => {
-    const { goto } = useActions({
-        goto: routerActions.goto,
-    });
+    const dispatch = useDispatch();
+
+    const action = {
+        label: <Translation id="TR_CONTINUE" />,
+        onClick: () => dispatch(goto('settings-device', { anchor: SettingsAnchor.BackupFailed })),
+        'data-test': '@notification/failed-backup/cta',
+    };
 
     return (
-        <Banner
-            variant="critical"
-            body={<Translation id="TR_FAILED_BACKUP" />}
-            action={{
-                label: <Translation id="TR_CONTINUE" />,
-                onClick: () => goto('settings-device', { anchor: SettingsAnchor.BackupFailed }),
-                'data-test': '@notification/failed-backup/cta',
-            }}
-        />
+        <Banner variant="critical" body={<Translation id="TR_FAILED_BACKUP" />} action={action} />
     );
 };
 

--- a/packages/suite/src/components/suite/Banners/NoBackup.tsx
+++ b/packages/suite/src/components/suite/Banners/NoBackup.tsx
@@ -1,32 +1,29 @@
 import React from 'react';
-import styled from 'styled-components';
 
 import { Translation } from 'src/components/suite';
-import * as routerActions from 'src/actions/suite/routerActions';
-import { useActions } from 'src/hooks/suite';
+import { goto } from 'src/actions/suite/routerActions';
+import { useDispatch } from 'src/hooks/suite';
 import { Banner } from './Banner';
 
-const Message = styled.span``;
-
 const NoBackup = () => {
-    const { goto } = useActions({
-        goto: routerActions.goto,
-    });
+    const dispatch = useDispatch();
+
+    const action = {
+        label: <Translation id="TR_CREATE_BACKUP" />,
+        onClick: () => dispatch(goto('backup-index')),
+        'data-test': '@notification/no-backup/button',
+    };
 
     return (
         <Banner
             variant="critical"
             body={
-                <Message>
+                <>
                     <Translation id="TR_YOUR_TREZOR_IS_NOT_BACKED_UP" />{' '}
                     <Translation id="TR_IF_YOUR_DEVICE_IS_EVER_LOST" />
-                </Message>
+                </>
             }
-            action={{
-                label: <Translation id="TR_CREATE_BACKUP" />,
-                onClick: () => goto('backup-index'),
-                'data-test': '@notification/no-backup/button',
-            }}
+            action={action}
         />
     );
 };

--- a/packages/suite/src/components/suite/Banners/OnlineStatus.tsx
+++ b/packages/suite/src/components/suite/Banners/OnlineStatus.tsx
@@ -3,11 +3,11 @@ import * as React from 'react';
 import { Translation } from 'src/components/suite';
 import { Banner } from './Banner';
 
-interface Props {
+interface OnlineStatusProps {
     isOnline: boolean;
 }
 
-const OnlineStatus = ({ isOnline }: Props) => {
+const OnlineStatus = ({ isOnline }: OnlineStatusProps) => {
     if (isOnline) return null;
 
     return <Banner variant="critical" body={<Translation id="TR_YOU_WERE_DISCONNECTED_DOT" />} />;

--- a/packages/suite/src/components/suite/Banners/SafetyChecks.tsx
+++ b/packages/suite/src/components/suite/Banners/SafetyChecks.tsx
@@ -1,39 +1,42 @@
 import React from 'react';
 
 import { Translation } from 'src/components/suite';
-import { useActions } from 'src/hooks/suite';
-import * as routerActions from 'src/actions/suite/routerActions';
+import { useDispatch } from 'src/hooks/suite';
+import { goto } from 'src/actions/suite/routerActions';
 import { Banner } from './Banner';
 import { SettingsAnchor } from 'src/constants/suite/anchors';
 
-interface Props {
+interface SafetyChecksBannerProps {
     onDismiss?: () => void;
 }
 
-const SafetyChecksBanner = (props: Props) => {
-    const { goto } = useActions({
-        goto: routerActions.goto,
-    });
+const SafetyChecksBanner = ({ onDismiss }: SafetyChecksBannerProps) => {
+    const dispatch = useDispatch();
+
+    const action = {
+        label: <Translation id="TR_SAFETY_CHECKS_BANNER_CHANGE" />,
+        onClick: () =>
+            dispatch(
+                goto('settings-device', {
+                    preserveParams: true,
+                    anchor: SettingsAnchor.SafetyChecks,
+                }),
+            ),
+        'data-test': '@banner/safety-checks/button',
+    };
 
     return (
         <Banner
             variant="warning"
             body={<Translation id="TR_SAFETY_CHECKS_DISABLED_WARNING" />}
-            action={{
-                label: <Translation id="TR_SAFETY_CHECKS_BANNER_CHANGE" />,
-                onClick: () =>
-                    goto('settings-device', {
-                        preserveParams: true,
-                        anchor: SettingsAnchor.SafetyChecks,
-                    }),
-                'data-test': '@banner/safety-checks/button',
-            }}
+            action={action}
             dismissal={
-                (props.onDismiss !== undefined && {
-                    onClick: props.onDismiss,
-                    'data-test': '@banner/safety-checks/dismiss',
-                }) ||
-                undefined
+                onDismiss
+                    ? {
+                          onClick: onDismiss,
+                          'data-test': '@banner/safety-checks/dismiss',
+                      }
+                    : undefined
             }
         />
     );

--- a/packages/suite/src/components/suite/Banners/UpdateBridge.tsx
+++ b/packages/suite/src/components/suite/Banners/UpdateBridge.tsx
@@ -1,25 +1,24 @@
 import React from 'react';
 
 import { Translation } from 'src/components/suite';
-import * as routerActions from 'src/actions/suite/routerActions';
-import { useActions } from 'src/hooks/suite';
-
+import { goto } from 'src/actions/suite/routerActions';
+import { useDispatch } from 'src/hooks/suite';
 import { Banner } from './Banner';
 
 const UpdateBridge = () => {
-    const { goto } = useActions({
-        goto: routerActions.goto,
-    });
+    const dispatch = useDispatch();
+
+    const action = {
+        label: <Translation id="TR_SHOW_DETAILS" />,
+        onClick: () => dispatch(goto('suite-bridge')),
+        'data-test': '@notification/update-bridge/button',
+    };
 
     return (
         <Banner
             variant="info"
             body={<Translation id="TR_NEW_TREZOR_BRIDGE_IS_AVAILABLE" />}
-            action={{
-                label: <Translation id="TR_SHOW_DETAILS" />,
-                onClick: () => goto('suite-bridge'),
-                'data-test': '@notification/update-bridge/button',
-            }}
+            action={action}
         />
     );
 };

--- a/packages/suite/src/components/suite/Banners/UpdateFirmware.tsx
+++ b/packages/suite/src/components/suite/Banners/UpdateFirmware.tsx
@@ -1,24 +1,24 @@
-import * as React from 'react';
+import React from 'react';
 
 import { Translation } from 'src/components/suite';
-import * as routerActions from 'src/actions/suite/routerActions';
-import { useActions } from 'src/hooks/suite';
+import { goto } from 'src/actions/suite/routerActions';
+import { useDispatch } from 'src/hooks/suite';
 import { Banner } from './Banner';
 
 const UpdateFirmware = () => {
-    const { goto } = useActions({
-        goto: routerActions.goto,
-    });
+    const dispatch = useDispatch();
+
+    const action = {
+        label: <Translation id="TR_SHOW_DETAILS" />,
+        onClick: () => dispatch(goto('firmware-index')),
+        'data-test': '@notification/update-firmware/button',
+    };
 
     return (
         <Banner
             variant="info"
             body={<Translation id="TR_NEW_TREZOR_FIRMWARE_IS_AVAILABLE_DOT" />}
-            action={{
-                label: <Translation id="TR_SHOW_DETAILS" />,
-                onClick: () => goto('firmware-index'),
-                'data-test': '@notification/update-firmware/button',
-            }}
+            action={action}
         />
     );
 };

--- a/packages/suite/src/components/suite/Banners/index.tsx
+++ b/packages/suite/src/components/suite/Banners/index.tsx
@@ -16,7 +16,7 @@ import TranslationMode from './TranslationMode';
 import FirmwareHashMismatch from './FirmwareHashMismatch';
 
 const Wrapper = styled.div`
-    background: ${props => props.theme.BG_WHITE};
+    background: ${({ theme }) => theme.BG_WHITE};
 `;
 
 const Banners = () => {

--- a/packages/suite/src/components/suite/CardWithHeader.tsx
+++ b/packages/suite/src/components/suite/CardWithHeader.tsx
@@ -24,7 +24,7 @@ const Wrapper = styled.div`
 
 const Content = styled(Card)`
     flex-direction: row;
-    color: ${props => props.theme.TYPE_DARK_GREY};
+    color: ${({ theme }) => theme.TYPE_DARK_GREY};
 `;
 
 const Header = styled.div`
@@ -38,7 +38,7 @@ const Title = styled.div`
     font-size: ${variables.FONT_SIZE.TINY};
     font-weight: ${variables.FONT_WEIGHT.DEMI_BOLD};
     text-transform: uppercase;
-    color: ${props => props.theme.TYPE_DARK_GREY};
+    color: ${({ theme }) => theme.TYPE_DARK_GREY};
 `;
 
 const Description = styled.div``;

--- a/packages/suite/src/components/suite/CardWithHeader.tsx
+++ b/packages/suite/src/components/suite/CardWithHeader.tsx
@@ -43,7 +43,7 @@ const Title = styled.div`
 
 const Description = styled.div``;
 
-export interface Props {
+export interface CardWithHeaderProps {
     children?: React.ReactNode;
     customHeader?: React.ReactNode;
     title?: string | React.ReactNode;
@@ -62,7 +62,7 @@ export const CardWithHeader = ({
     noVerticalPadding,
     customHeader,
     ...rest
-}: Props) => (
+}: CardWithHeaderProps) => (
     <Wrapper>
         {title && (
             <Header>

--- a/packages/suite/src/components/suite/CharacterCount/index.tsx
+++ b/packages/suite/src/components/suite/CharacterCount/index.tsx
@@ -7,7 +7,7 @@ const Wrapper = styled.div`
     bottom: 35px;
     right: 15px;
     font-size: ${variables.FONT_SIZE.TINY};
-    color: ${props => props.theme.TYPE_LIGHT_GREY};
+    color: ${({ theme }) => theme.TYPE_LIGHT_GREY};
 `;
 
 const CharacterCount = ({

--- a/packages/suite/src/components/suite/CheckItem/index.tsx
+++ b/packages/suite/src/components/suite/CheckItem/index.tsx
@@ -24,7 +24,7 @@ const CheckboxTitle = styled.p`
 
 const CheckboxText = styled.div`
     font-size: ${FONT_SIZE.SMALL};
-    color: ${props => props.theme.TYPE_LIGHT_GREY};
+    color: ${({ theme }) => theme.TYPE_LIGHT_GREY};
 `;
 
 interface CheckItemProps {

--- a/packages/suite/src/components/suite/Coin.tsx
+++ b/packages/suite/src/components/suite/Coin.tsx
@@ -20,13 +20,13 @@ const SettingsWrapper = styled.div<{
     transition: 0.2s ease-in-out;
     position: relative;
     opacity: 0;
-    ${props =>
-        props.onClick &&
+    ${({ onClick, theme }) =>
+        onClick &&
         css`
             &:hover {
                 background-color: ${transparentize(
-                    props.theme.HOVER_TRANSPARENTIZE_FILTER,
-                    props.theme.HOVER_PRIMER_COLOR,
+                    theme.HOVER_TRANSPARENTIZE_FILTER,
+                    theme.HOVER_PRIMER_COLOR,
                 )};
             }
         `}
@@ -72,12 +72,12 @@ export const CoinWrapper = styled.button<{
     display: flex;
     justify-items: flex-start;
     align-items: center;
-    border: 1.5px solid ${props => props.theme.STROKE_GREY};
-    background: ${props => props.theme.BG_WHITE};
+    border: 1.5px solid ${({ theme }) => theme.STROKE_GREY};
+    background: ${({ theme }) => theme.BG_WHITE};
     border-radius: 9999px;
     height: 47px;
     font-weight: ${variables.FONT_WEIGHT.DEMI_BOLD};
-    color: ${props => props.theme.TYPE_DARK_GREY};
+    color: ${({ theme }) => theme.TYPE_DARK_GREY};
     cursor: pointer;
     transition: 0.2s ease-in-out;
     overflow: hidden;
@@ -85,7 +85,7 @@ export const CoinWrapper = styled.button<{
     &:disabled {
         cursor: not-allowed;
         opacity: 0.5;
-        background: ${props => props.theme.BG_GREY};
+        background: ${({ theme }) => theme.BG_GREY};
     }
 
     :hover {
@@ -94,13 +94,13 @@ export const CoinWrapper = styled.button<{
             toggled ? theme.BG_GREEN_HOVER : theme.TYPE_LIGHTER_GREY};
     }
 
-    ${props =>
-        !props.disabled &&
-        props.toggled &&
+    ${({ disabled, forceHover, hasSettings, theme, toggled }) =>
+        !disabled &&
+        toggled &&
         css`
-            border-color: ${props.theme.BG_GREEN};
-            ${props.forceHover && ShiftToSettings}
-            ${props.hasSettings &&
+            border-color: ${theme.BG_GREEN};
+            ${forceHover && ShiftToSettings}
+            ${hasSettings &&
             css`
                 @media (hover: hover) {
                     &:hover {
@@ -141,7 +141,7 @@ const Check = styled.div<{ visible: boolean }>`
     align-items: center;
     justify-content: center;
     border-radius: 50%;
-    background: ${props => props.theme.BG_GREEN};
+    background: ${({ theme }) => theme.BG_GREEN};
     width: 12px;
     height: 12px;
     position: absolute;

--- a/packages/suite/src/components/suite/CoinsGroup/CoinsGroup.tsx
+++ b/packages/suite/src/components/suite/CoinsGroup/CoinsGroup.tsx
@@ -1,7 +1,8 @@
 import React, { useState } from 'react';
 import styled from 'styled-components';
-import { useActions } from 'src/hooks/suite';
-import { openModal as openModalAction } from 'src/actions/suite/modalActions';
+
+import { useDispatch } from 'src/hooks/suite';
+import { openModal } from 'src/actions/suite/modalActions';
 import { CoinsGroupHeader } from './CoinsGroupHeader';
 import { CoinsList } from './CoinsList';
 import type { Network } from 'src/types/wallet';
@@ -23,9 +24,7 @@ export const CoinsGroup = ({
     selectedNetworks,
     className,
 }: CoinsGroupProps) => {
-    const { openModal } = useActions({
-        openModal: openModalAction,
-    });
+    const dispatch = useDispatch();
 
     const [settingsMode, setSettingsMode] = useState(false);
 
@@ -33,10 +32,12 @@ export const CoinsGroup = ({
 
     const onSettings = (symbol: Network['symbol']) => {
         setSettingsMode(false);
-        openModal({
-            type: 'advanced-coin-settings',
-            coin: symbol,
-        });
+        dispatch(
+            openModal({
+                type: 'advanced-coin-settings',
+                coin: symbol,
+            }),
+        );
     };
     const toggleSettingsMode = () => setSettingsMode(value => !value);
 

--- a/packages/suite/src/components/suite/CoinsGroup/CoinsGroupHeader.tsx
+++ b/packages/suite/src/components/suite/CoinsGroup/CoinsGroupHeader.tsx
@@ -30,11 +30,8 @@ const SettingsWrapper = styled.div<{ disabled: boolean }>`
             visibility: hidden;
         `}
     &:hover {
-        background-color: ${props =>
-            transparentize(
-                props.theme.HOVER_TRANSPARENTIZE_FILTER,
-                props.theme.HOVER_PRIMER_COLOR,
-            )};
+        background-color: ${({ theme }) =>
+            transparentize(theme.HOVER_TRANSPARENTIZE_FILTER, theme.HOVER_PRIMER_COLOR)};
     }
 `;
 

--- a/packages/suite/src/components/suite/CoinsGroup/CoinsGroupHeader.tsx
+++ b/packages/suite/src/components/suite/CoinsGroup/CoinsGroupHeader.tsx
@@ -35,7 +35,7 @@ const SettingsWrapper = styled.div<{ disabled: boolean }>`
     }
 `;
 
-interface Props {
+interface CoinsGroupHeaderProps {
     isAtLeastOneActive: boolean;
     settingsMode: boolean;
     toggleSettingsMode?: () => void;
@@ -45,7 +45,7 @@ export const CoinsGroupHeader = ({
     isAtLeastOneActive,
     settingsMode,
     toggleSettingsMode,
-}: Props) => (
+}: CoinsGroupHeaderProps) => (
     <Wrapper>
         {settingsMode && <Translation id="TR_SELECT_COIN_FOR_SETTINGS" />}
         <SettingsWrapper onClick={toggleSettingsMode} disabled={!isAtLeastOneActive}>

--- a/packages/suite/src/components/suite/ConnectDevicePrompt.tsx
+++ b/packages/suite/src/components/suite/ConnectDevicePrompt.tsx
@@ -4,8 +4,8 @@ import styled from 'styled-components';
 import { variables, Icon, Button, useTheme, motionEasing } from '@trezor/components';
 import { DeviceAnimation } from 'src/components/onboarding';
 import { Translation } from 'src/components/suite';
-import { useDevice, useActions } from 'src/hooks/suite';
-import * as routerActions from 'src/actions/suite/routerActions';
+import { useDevice, useDispatch } from 'src/hooks/suite';
+import { goto } from 'src/actions/suite/routerActions';
 import type { PrerequisiteType } from 'src/types/suite';
 import { motion } from 'framer-motion';
 
@@ -85,12 +85,12 @@ export const ConnectDevicePrompt = ({
     showWarning,
     allowSwitchDevice,
 }: ConnectDevicePromptProps) => {
-    const { goto } = useActions({
-        goto: routerActions.goto,
-    });
-
+    const dispatch = useDispatch();
     const theme = useTheme();
     const { device } = useDevice();
+
+    const handleSwitchDeviceClick = () =>
+        dispatch(goto('suite-switch-device', { params: { cancelable: true } }));
 
     return (
         <Wrapper
@@ -121,12 +121,7 @@ export const ConnectDevicePrompt = ({
                 <Translation id={getMessageId({ connected, showWarning, prerequisite })} />
 
                 {allowSwitchDevice && (
-                    <Button
-                        variant="tertiary"
-                        onClick={() =>
-                            goto('suite-switch-device', { params: { cancelable: true } })
-                        }
-                    >
+                    <Button variant="tertiary" onClick={handleSwitchDeviceClick}>
                         <Translation id="TR_SWITCH_DEVICE" />
                     </Button>
                 )}

--- a/packages/suite/src/components/suite/DeviceInvalidModeLayout/index.tsx
+++ b/packages/suite/src/components/suite/DeviceInvalidModeLayout/index.tsx
@@ -1,18 +1,17 @@
 import React from 'react';
 import styled, { css } from 'styled-components';
-import { Button, Image, ImageProps } from '@trezor/components';
+import { Button, Image, ImageType } from '@trezor/components';
 import { Translation } from 'src/components/suite';
-import { useSelector, useActions } from 'src/hooks/suite';
-import * as routerActions from 'src/actions/suite/routerActions';
+import { useDispatch, useSelector } from 'src/hooks/suite';
+import { goto } from 'src/actions/suite/routerActions';
 import { Modal } from '../Modal';
 
-const StyledImage = styled(Image)`
+const StyledImage = styled(Image)<{ image: ImageType }>`
     flex: 1;
     margin: 20px 0;
 
-    ${props =>
-        'image' in props &&
-        props.image === 'UNI_WARNING' &&
+    ${({ image }) =>
+        image === 'UNI_WARNING' &&
         css`
             max-height: 160px;
             flex: 0 0 auto;
@@ -34,37 +33,39 @@ const StyledModal = styled(Modal)`
  * like views listed in suite/views
  */
 
-type Props = {
+type DeviceInvalidModeLayoutProps = {
     title: React.ReactNode;
     text?: React.ReactNode;
-    image?: Extract<ImageProps, { image: any }>['image'];
+    image?: ImageType;
     allowSwitchDevice?: boolean;
     resolveButton?: React.ReactNode;
     ['data-test']?: string;
 };
 
-const DeviceInvalidModeLayout = (props: Props) => {
-    const { title, text, image = 'UNI_WARNING', allowSwitchDevice, resolveButton } = props;
-
+const DeviceInvalidModeLayout = ({
+    title,
+    text,
+    image = 'UNI_WARNING',
+    allowSwitchDevice,
+    resolveButton,
+    'data-test': dataTest,
+}: DeviceInvalidModeLayoutProps) => {
     const devices = useSelector(state => state.devices);
-    const { goto } = useActions({
-        goto: routerActions.goto,
-    });
+    const dispatch = useDispatch();
+
+    const handleSwitchDeviceButtonClick = () =>
+        dispatch(goto('suite-switch-device', { params: { cancelable: true } }));
 
     return (
         <StyledModal
             heading={title}
             description={text}
-            data-test={props['data-test']}
+            data-test={dataTest}
             bottomBar={
                 <>
                     {resolveButton && resolveButton}
                     {allowSwitchDevice && devices.length > 1 && (
-                        <Button
-                            onClick={() =>
-                                goto('suite-switch-device', { params: { cancelable: true } })
-                            }
-                        >
+                        <Button onClick={handleSwitchDeviceButtonClick}>
                             <Translation id="TR_SWITCH_DEVICE" />
                         </Button>
                     )}

--- a/packages/suite/src/components/suite/DeviceMatrixExplanation/index.tsx
+++ b/packages/suite/src/components/suite/DeviceMatrixExplanation/index.tsx
@@ -8,7 +8,7 @@ const Wrapper = styled.div<{ isGuideOpen?: boolean }>`
     display: flex;
     flex-direction: column;
     align-items: center;
-    background: ${props => props.theme.BG_GREY};
+    background: ${({ theme }) => theme.BG_GREY};
     padding: 20px 24px;
     margin-right: 34px;
     width: 100%;
@@ -37,7 +37,7 @@ const ItemIconWrapper = styled.div`
 
 const ItemText = styled.div`
     width: 100%;
-    color: ${props => props.theme.TYPE_DARK_GREY};
+    color: ${({ theme }) => theme.TYPE_DARK_GREY};
     font-size: ${variables.FONT_SIZE.SMALL};
     font-weight: ${variables.FONT_WEIGHT.MEDIUM};
     padding: 26px 0px;

--- a/packages/suite/src/components/suite/DropZone.tsx
+++ b/packages/suite/src/components/suite/DropZone.tsx
@@ -144,14 +144,14 @@ const Wrapper = styled.div`
     flex-direction: column;
     justify-content: center;
     align-items: center;
-    border: 2px dashed ${props => props.theme.STROKE_GREY};
+    border: 2px dashed ${({ theme }) => theme.STROKE_GREY};
     border-radius: 8px;
     cursor: pointer;
     min-height: 250px;
     transition: background-color 0.3s;
     &:hover,
     &.dragging {
-        background: ${props => props.theme.BG_GREY};
+        background: ${({ theme }) => theme.BG_GREY};
     }
     * {
         pointer-events: none;

--- a/packages/suite/src/components/suite/DropZone.tsx
+++ b/packages/suite/src/components/suite/DropZone.tsx
@@ -5,7 +5,7 @@ import { Translation } from 'src/components/suite';
 import type { ExtendedMessageDescriptor } from 'src/types/suite';
 import { IconType } from '@trezor/components/src/support/types';
 
-interface Props {
+interface DropZoneProps {
     // 'accept' attribute for underlying HTML file input
     accept?: string;
     // icon displayed inside Dropzone
@@ -15,7 +15,7 @@ interface Props {
     className?: string;
 }
 
-export const useDropZone = ({ accept, onSelect, className }: Props) => {
+export const useDropZone = ({ accept, onSelect, className }: DropZoneProps) => {
     const available = useRef(window.File && window.FileReader && window.FileList && window.Blob);
     const wrapperRef = useRef<HTMLDivElement | null>(null);
     const inputRef = useRef<HTMLInputElement | null>(null);
@@ -171,7 +171,7 @@ const Label = styled.div`
     align-items: center;
 `;
 
-export const DropZone = (props: Props) => {
+export const DropZone = (props: DropZoneProps) => {
     const { getWrapperProps, getInputProps, error, filename } = useDropZone(props);
 
     return (

--- a/packages/suite/src/components/suite/Error.tsx
+++ b/packages/suite/src/components/suite/Error.tsx
@@ -26,7 +26,7 @@ const Buttons = styled.div`
 `;
 
 const Separator = styled.div`
-    background: ${props => props.theme.STROKE_GREY};
+    background: ${({ theme }) => theme.STROKE_GREY};
     height: 1px;
     margin: 30px 0px;
     width: 80%;
@@ -51,7 +51,7 @@ const ErrorMessage = styled.span`
     max-width: 600px;
     font-family: Consolas, Menlo, Courier, monospace;
     font-size: ${variables.FONT_SIZE.TINY};
-    color: ${props => props.theme.TYPE_DARK_GREY};
+    color: ${({ theme }) => theme.TYPE_DARK_GREY};
 `;
 
 type ErrorProps = {

--- a/packages/suite/src/components/suite/FiatValue.tsx
+++ b/packages/suite/src/components/suite/FiatValue.tsx
@@ -57,7 +57,7 @@ type FiatValueProps = (DefaultSourceProps | CustomSourceProps) & { className?: s
  * The function will be called (and rendered) with 1 object param: {fiatValue, fiatRateValue, fiatRateTimestamp}.
  *
  *  In case of custom source of fiat rates returned timestamp is always null;
- * @param {Props} { amount, symbol, fiatCurrency, ...props }
+ * @param {FiatValuePropsProps} { amount, symbol, fiatCurrency, ...props }
  * @returns
  */
 export const FiatValue = ({

--- a/packages/suite/src/components/suite/FormattedDate/index.tsx
+++ b/packages/suite/src/components/suite/FormattedDate/index.tsx
@@ -5,12 +5,12 @@ import styled from 'styled-components';
 const Bullet = styled.span`
     margin-left: 0.5ch;
     margin-right: 0.5ch;
-    color: ${props => props.theme.TYPE_LIGHT_GREY};
+    color: ${({ theme }) => theme.TYPE_LIGHT_GREY};
 `;
 
 const HourWrapper = styled.div<Pick<BulletProps, 'timeLightColor'>>`
     display: inline-flex;
-    color: ${props => (props.timeLightColor ? props.theme.TYPE_LIGHT_GREY : 'inherit')};
+    color: ${({ theme, timeLightColor }) => (timeLightColor ? theme.TYPE_LIGHT_GREY : 'inherit')};
 `;
 
 const Timestamp = styled.span`

--- a/packages/suite/src/components/suite/HomescreenGallery.tsx
+++ b/packages/suite/src/components/suite/HomescreenGallery.tsx
@@ -4,9 +4,9 @@ import { analytics, EventType } from '@trezor/suite-analytics';
 import { resolveStaticPath } from '@suite-common/suite-utils';
 
 import { homescreensBW64x128, homescreensColor240x240 } from 'src/constants/suite/homescreens';
-import * as deviceSettingsActions from 'src/actions/settings/deviceSettingsActions';
+import { applySettings } from 'src/actions/settings/deviceSettingsActions';
 import { imagePathToHex } from 'src/utils/suite/homescreen';
-import { useActions, useDevice } from 'src/hooks/suite';
+import { useDevice, useDispatch } from 'src/hooks/suite';
 import { DeviceModelInternal } from '@trezor/connect';
 
 type AnyImageName = (typeof homescreensBW64x128)[number] | (typeof homescreensColor240x240)[number];
@@ -40,8 +40,9 @@ type HomescreenGalleryProps = {
 };
 
 export const HomescreenGallery = ({ onConfirm }: HomescreenGalleryProps) => {
+    const dispatch = useDispatch();
     const { device, isLocked } = useDevice();
-    const { applySettings } = useActions({ applySettings: deviceSettingsActions.applySettings });
+
     const deviceModelInternal = device?.features?.internal_model;
 
     if (!deviceModelInternal) return null;
@@ -51,7 +52,7 @@ export const HomescreenGallery = ({ onConfirm }: HomescreenGalleryProps) => {
 
         const hex = await imagePathToHex(imagePath, deviceModelInternal);
 
-        applySettings({ homescreen: hex });
+        dispatch(applySettings({ homescreen: hex }));
 
         if (onConfirm) {
             onConfirm();

--- a/packages/suite/src/components/suite/Labeling/components/AccountLabeling.tsx
+++ b/packages/suite/src/components/suite/Labeling/components/AccountLabeling.tsx
@@ -11,10 +11,9 @@ interface AccountProps {
 }
 
 export const AccountLabeling = ({ account }: AccountProps) => {
-    const { device, devices } = useSelector(state => ({
-        device: state.suite.device,
-        devices: state.devices,
-    }));
+    const device = useSelector(state => state.suite.device);
+    const devices = useSelector(state => state.devices);
+
     const accounts = !Array.isArray(account) ? [account] : account;
 
     if (accounts.length < 1) return null;

--- a/packages/suite/src/components/suite/MenuSecondary/index.tsx
+++ b/packages/suite/src/components/suite/MenuSecondary/index.tsx
@@ -9,8 +9,8 @@ interface Props {
 const AbsoluteWrapper = styled.aside`
     width: ${variables.LAYOUT_SIZE.MENU_SECONDARY_WIDTH};
     flex: 0 0 auto;
-    background: ${props => props.theme.BG_WHITE};
-    border-right: 1px solid ${props => props.theme.STROKE_GREY};
+    background: ${({ theme }) => theme.BG_WHITE};
+    border-right: 1px solid ${({ theme }) => theme.STROKE_GREY};
     height: 100%;
     overflow: auto;
 `;

--- a/packages/suite/src/components/suite/MenuSecondary/index.tsx
+++ b/packages/suite/src/components/suite/MenuSecondary/index.tsx
@@ -1,10 +1,7 @@
-import { variables } from '@trezor/components';
 import React from 'react';
 import styled from 'styled-components';
 
-interface Props {
-    children: React.ReactNode;
-}
+import { variables } from '@trezor/components';
 
 const AbsoluteWrapper = styled.aside`
     width: ${variables.LAYOUT_SIZE.MENU_SECONDARY_WIDTH};
@@ -20,7 +17,11 @@ const Wrapper = styled.div`
     display: flex;
 `;
 
-const MenuSecondary = ({ children }: Props) => (
+interface MenuSecondaryProps {
+    children: React.ReactNode;
+}
+
+const MenuSecondary = ({ children }: MenuSecondaryProps) => (
     <AbsoluteWrapper>
         <Wrapper>{children}</Wrapper>
     </AbsoluteWrapper>

--- a/packages/suite/src/components/suite/ModalSwitcher/ForegroundAppModal.tsx
+++ b/packages/suite/src/components/suite/ModalSwitcher/ForegroundAppModal.tsx
@@ -3,7 +3,7 @@ import { Firmware } from 'src/views/firmware';
 import { FirmwareCustom } from 'src/views/firmware/FirmwareCustom';
 import { Recovery } from 'src/views/recovery';
 import { Backup } from 'src/views/backup';
-import { useActions } from 'src/hooks/suite';
+import { useDispatch } from 'src/hooks/suite';
 import { closeModalApp } from 'src/actions/suite/routerActions';
 import { InstallBridge } from 'src/views/suite/bridge';
 import { UdevRules } from 'src/views/suite/udev';
@@ -46,16 +46,15 @@ type ForegroundAppModalProps = {
 
 /** Modals (foreground applications) initiated by redux state.router.route */
 export const ForegroundAppModal = ({ app, cancelable }: ForegroundAppModalProps) => {
-    const actions = useActions({
-        closeModalApp,
-    });
+    const dispatch = useDispatch();
+
+    const onCancel = () => dispatch(closeModalApp());
 
     // check if current route is a "foreground application" marked as isForegroundApp in router config
     // display it above requested physical route (route in url) or as fullscreen app
     // pass common params to "foreground application"
     // every app is dealing with "prerequisites" and other params (like action modals) on they own.
     const ForegroundApp = getForegroundApp(app);
-    return (
-        ForegroundApp && <ForegroundApp cancelable={cancelable} onCancel={actions.closeModalApp} />
-    );
+
+    return ForegroundApp && <ForegroundApp cancelable={cancelable} onCancel={onCancel} />;
 };

--- a/packages/suite/src/components/suite/NavigationBar/components/MainNavigation.tsx
+++ b/packages/suite/src/components/suite/NavigationBar/components/MainNavigation.tsx
@@ -6,8 +6,8 @@ import { findRouteByName } from 'src/utils/suite/router';
 import { variables, HoverAnimation } from '@trezor/components';
 import { Translation } from 'src/components/suite';
 import { MAIN_MENU_ITEMS } from 'src/constants/suite/menu';
-import { useActions, useSelector, useAccountSearch } from 'src/hooks/suite';
-import * as routerActions from 'src/actions/suite/routerActions';
+import { useAccountSearch, useSelector, useDispatch } from 'src/hooks/suite';
+import { goto } from 'src/actions/suite/routerActions';
 
 interface ComponentProps {
     isActive: boolean;
@@ -54,7 +54,7 @@ const MobileMenuItem = styled.div<ComponentProps>`
     cursor: ${({ isDisabled, isActive }) => (!isDisabled && !isActive ? 'pointer' : 'default')};
 
     & + & {
-        border-top: 1px solid ${props => props.theme.STROKE_GREY};
+        border-top: 1px solid ${({ theme }) => theme.STROKE_GREY};
     }
 `;
 
@@ -63,7 +63,7 @@ const ItemTitleWrapper = styled.span`
 `;
 
 const ItemTitle = styled.span<ComponentProps>`
-    color: ${props => transparentize(0.3, props.theme.TYPE_DARK_GREY)};
+    color: ${({ theme }) => transparentize(0.3, theme.TYPE_DARK_GREY)};
     font-weight: ${variables.FONT_WEIGHT.MEDIUM};
     font-size: ${variables.FONT_SIZE.NORMAL};
     line-height: 24px;
@@ -88,8 +88,8 @@ const NewBadge = styled.span`
         top: -14px;
         right: -30px;
         padding: 3px 3px 2px 3px;
-        background: ${props => props.theme.BG_LIGHT_GREEN};
-        color: ${props => props.theme.TYPE_GREEN};
+        background: ${({ theme }) => theme.BG_LIGHT_GREEN};
+        color: ${({ theme }) => theme.TYPE_GREEN};
         letter-spacing: 0.2px;
         text-transform: UPPERCASE;
         font-size: 12px;
@@ -108,9 +108,7 @@ interface MainNavigationProps {
 
 export const MainNavigation = ({ isMobileLayout, closeMainNavigation }: MainNavigationProps) => {
     const activeApp = useSelector(state => state.router.app);
-    const { goto } = useActions({
-        goto: routerActions.goto,
-    });
+    const dispatch = useDispatch();
 
     const { setCoinFilter, setSearchString } = useAccountSearch();
 
@@ -133,7 +131,7 @@ export const MainNavigation = ({ isMobileLayout, closeMainNavigation }: MainNavi
                                         setCoinFilter(undefined);
                                         setSearchString(undefined);
                                     }
-                                    goto(route);
+                                    dispatch(goto(route));
                                     closeMainNavigation?.();
                                 }
                             }}

--- a/packages/suite/src/components/suite/NavigationBar/components/NavigationActions/components/NavBackends.tsx
+++ b/packages/suite/src/components/suite/NavigationBar/components/NavigationActions/components/NavBackends.tsx
@@ -4,10 +4,9 @@ import styled from 'styled-components';
 import { Dropdown, DropdownRef, CoinLogo, variables } from '@trezor/components';
 import { Translation, StatusLight } from 'src/components/suite';
 import { ActionItem } from './ActionItem';
-import { useActions, useSelector } from 'src/hooks/suite';
-import { goto as gotoAction } from 'src/actions/suite/routerActions';
-import { openModal as openModalAction } from 'src/actions/suite/modalActions';
-
+import { useDispatch, useSelector } from 'src/hooks/suite';
+import { goto } from 'src/actions/suite/routerActions';
+import { openModal } from 'src/actions/suite/modalActions';
 import { BlockchainState } from '@suite-common/wallet-core';
 import type { CustomBackend } from 'src/types/wallet';
 
@@ -38,7 +37,7 @@ const RowWrapper = styled.div`
         > span:last-child {
             font-weight: ${variables.FONT_WEIGHT.MEDIUM};
             font-size: ${variables.FONT_SIZE.SMALL};
-            color: ${props => props.theme.TYPE_LIGHT_GREY};
+            color: ${({ theme }) => theme.TYPE_LIGHT_GREY};
             text-transform: capitalize;
         }
     }
@@ -79,13 +78,10 @@ type NavBackendsProps = {
 export const NavBackends = ({ customBackends }: NavBackendsProps) => {
     const [open, setOpen] = useState(false);
     const dropdownRef = useRef<DropdownRef>();
-    const { blockchain } = useSelector(state => ({
-        blockchain: state.wallet.blockchain,
-    }));
-    const { goto, openModal } = useActions({
-        goto: gotoAction,
-        openModal: openModalAction,
-    });
+    const blockchain = useSelector(state => state.wallet.blockchain);
+    const dispatch = useDispatch();
+
+    const goToCoinsSettings = () => dispatch(goto('settings-coins'));
 
     return (
         <Wrapper>
@@ -97,7 +93,7 @@ export const NavBackends = ({ customBackends }: NavBackendsProps) => {
                 topPadding={0}
                 minWidth={230}
                 masterLink={{
-                    callback: () => goto('settings-coins'),
+                    callback: goToCoinsSettings,
                     label: <Translation id="TR_MANAGE" />,
                     icon: 'ARROW_RIGHT_LONG',
                 }}
@@ -109,10 +105,12 @@ export const NavBackends = ({ customBackends }: NavBackendsProps) => {
                             key: backend.coin,
                             label: <BackendRow backend={backend} blockchain={blockchain} />,
                             callback: () =>
-                                openModal({
-                                    type: 'advanced-coin-settings',
-                                    coin: backend.coin,
-                                }),
+                                dispatch(
+                                    openModal({
+                                        type: 'advanced-coin-settings',
+                                        coin: backend.coin,
+                                    }),
+                                ),
                         })),
                     },
                     {

--- a/packages/suite/src/components/suite/NavigationBar/components/NavigationActions/components/NavEarlyAccess.tsx
+++ b/packages/suite/src/components/suite/NavigationBar/components/NavigationActions/components/NavEarlyAccess.tsx
@@ -3,8 +3,8 @@ import styled from 'styled-components';
 
 import { Translation } from 'src/components/suite';
 import { ActionItem } from './ActionItem';
-import { useActions } from 'src/hooks/suite';
-import * as routerActions from 'src/actions/suite/routerActions';
+import { useDispatch } from 'src/hooks/suite';
+import { goto } from 'src/actions/suite/routerActions';
 import { SettingsAnchor } from 'src/constants/suite/anchors';
 
 const Wrapper = styled.div`
@@ -18,16 +18,17 @@ interface NavEarlyAccessProps {
 }
 
 export const NavEarlyAccess = (props: NavEarlyAccessProps) => {
-    const { goto } = useActions({
-        goto: routerActions.goto,
-    });
+    const dispatch = useDispatch();
+
+    const handleClick = () =>
+        dispatch(goto('settings-index', { anchor: SettingsAnchor.EarlyAccess }));
 
     return (
         <Wrapper {...props}>
             <ActionItem
                 label={<Translation id="TR_EARLY_ACCESS_MENU" />}
                 icon="EXPERIMENTAL"
-                onClick={() => goto('settings-index', { anchor: SettingsAnchor.EarlyAccess })}
+                onClick={handleClick}
             />
         </Wrapper>
     );

--- a/packages/suite/src/components/suite/NavigationBar/components/NavigationActions/components/NavNotifications.tsx
+++ b/packages/suite/src/components/suite/NavigationBar/components/NavigationActions/components/NavNotifications.tsx
@@ -5,7 +5,7 @@ import { analytics, EventType } from '@trezor/suite-analytics';
 import { Translation, Notifications } from 'src/components/suite';
 import { Dropdown, DropdownRef, variables } from '@trezor/components';
 import { ActionItem } from './ActionItem';
-import { useActions } from 'src/hooks/suite';
+import { useDispatch } from 'src/hooks/suite';
 import { notificationsActions } from '@suite-common/toast-notifications';
 
 const Wrapper = styled.div`
@@ -35,9 +35,7 @@ export const NavNotifications = ({
     const [open, setOpen] = useState(false);
     const dropdownRef = useRef<DropdownRef>();
 
-    const { resetUnseen } = useActions({
-        resetUnseen: notificationsActions.resetUnseen,
-    });
+    const dispatch = useDispatch();
 
     const handleToggleChange = useCallback(
         (isToggled: boolean) => {
@@ -45,7 +43,7 @@ export const NavNotifications = ({
                 setOpen(true);
             } else {
                 // if the dropdown is going to be closed, mark all notifications as seen and "deactivate" ActionItem
-                resetUnseen();
+                dispatch(notificationsActions.resetUnseen());
                 setOpen(false);
             }
 
@@ -56,7 +54,7 @@ export const NavNotifications = ({
                 },
             });
         },
-        [resetUnseen],
+        [dispatch],
     );
 
     return (

--- a/packages/suite/src/components/suite/NavigationBar/components/NavigationActions/components/NavSettings.tsx
+++ b/packages/suite/src/components/suite/NavigationBar/components/NavigationActions/components/NavSettings.tsx
@@ -3,8 +3,8 @@ import styled from 'styled-components';
 
 import { Translation } from 'src/components/suite';
 import { ActionItem } from './ActionItem';
-import { useActions } from 'src/hooks/suite';
-import * as routerActions from 'src/actions/suite/routerActions';
+import { useDispatch } from 'src/hooks/suite';
+import { goto } from 'src/actions/suite/routerActions';
 
 const Wrapper = styled.div`
     margin-left: 8px;
@@ -16,9 +16,9 @@ interface NavSettingsProps {
 }
 
 export const NavSettings = ({ isActive }: NavSettingsProps) => {
-    const { goto } = useActions({
-        goto: routerActions.goto,
-    });
+    const dispatch = useDispatch();
+
+    const handleClick = () => dispatch(goto('settings-index'));
 
     return (
         <Wrapper>
@@ -27,9 +27,7 @@ export const NavSettings = ({ isActive }: NavSettingsProps) => {
                 label={<Translation id="TR_SETTINGS" />}
                 icon="SETTINGS"
                 isActive={isActive}
-                onClick={() => {
-                    goto('settings-index');
-                }}
+                onClick={handleClick}
             />
         </Wrapper>
     );

--- a/packages/suite/src/components/suite/NavigationBar/components/NavigationActions/components/NavTor.tsx
+++ b/packages/suite/src/components/suite/NavigationBar/components/NavigationActions/components/NavTor.tsx
@@ -3,8 +3,8 @@ import styled from 'styled-components';
 
 import { Translation } from 'src/components/suite';
 import { ActionItem, IndicatorStatus } from './ActionItem';
-import { useActions } from 'src/hooks/suite';
-import * as routerActions from 'src/actions/suite/routerActions';
+import { useDispatch } from 'src/hooks/suite';
+import { goto } from 'src/actions/suite/routerActions';
 import { SettingsAnchor } from 'src/constants/suite/anchors';
 
 const Wrapper = styled.div`
@@ -17,9 +17,9 @@ interface NavTorProps {
 }
 
 export const NavTor = ({ indicator }: NavTorProps) => {
-    const { goto } = useActions({
-        goto: routerActions.goto,
-    });
+    const dispatch = useDispatch();
+
+    const handleClick = () => dispatch(goto('settings-index', { anchor: SettingsAnchor.Tor }));
 
     return (
         <Wrapper>
@@ -27,7 +27,7 @@ export const NavTor = ({ indicator }: NavTorProps) => {
                 label={<Translation id="TR_TOR" />}
                 icon="TOR"
                 indicator={indicator}
-                onClick={() => goto('settings-index', { anchor: SettingsAnchor.Tor })}
+                onClick={handleClick}
             />
         </Wrapper>
     );

--- a/packages/suite/src/components/suite/NavigationBar/components/NavigationActions/index.tsx
+++ b/packages/suite/src/components/suite/NavigationBar/components/NavigationActions/index.tsx
@@ -1,11 +1,11 @@
 import React, { useMemo } from 'react';
 import styled from 'styled-components';
 
-import * as walletSettingsActions from 'src/actions/settings/walletSettingsActions';
-import * as routerActions from 'src/actions/suite/routerActions';
+import { setDiscreetMode } from 'src/actions/settings/walletSettingsActions';
+import { goto } from 'src/actions/suite/routerActions';
 import { Translation } from 'src/components/suite';
 import { findRouteByName } from 'src/utils/suite/router';
-import { useActions, useSelector } from 'src/hooks/suite';
+import { useDispatch, useSelector } from 'src/hooks/suite';
 import { useCustomBackends } from 'src/hooks/settings/backends';
 import { ActionItem } from './components/ActionItem';
 import { isDesktop } from '@trezor/env-utils';
@@ -39,7 +39,7 @@ const MobileWrapper = styled.div`
 `;
 
 const Separator = styled.div`
-    border: 1px solid ${props => props.theme.STROKE_GREY};
+    border: 1px solid ${({ theme }) => theme.STROKE_GREY};
     height: 38px;
     width: 0;
     margin: 0 10px;
@@ -66,27 +66,19 @@ export const NavigationActions = ({
     isMobileLayout,
 }: NavigationActionsProps) => {
     const { isTorEnabled, isTorLoading } = useSelector(selectTorState);
-    const { activeApp, notifications, discreetMode, allowPrerelease, enabledNetworks } =
-        useSelector(state => ({
-            activeApp: state.router.app,
-            notifications: state.notifications,
-            discreetMode: state.wallet.settings.discreetMode,
-            theme: state.suite.settings.theme,
-            allowPrerelease: state.desktopUpdate.allowPrerelease,
-            enabledNetworks: state.wallet.settings.enabledNetworks,
-        }));
-
-    const { goto, setDiscreetMode } = useActions({
-        goto: routerActions.goto,
-        setDiscreetMode: walletSettingsActions.setDiscreetMode,
-    });
+    const activeApp = useSelector(state => state.router.app);
+    const notifications = useSelector(state => state.notifications);
+    const discreetMode = useSelector(state => state.wallet.settings.discreetMode);
+    const allowPrerelease = useSelector(state => state.desktopUpdate.allowPrerelease);
+    const enabledNetworks = useSelector(state => state.wallet.settings.enabledNetworks);
+    const dispatch = useDispatch();
 
     const { openGuide } = useGuide();
 
     const WrapperComponent = isMobileLayout ? MobileWrapper : Wrapper;
 
     const action = (...gotoArgs: Parameters<typeof goto>) => {
-        goto(...gotoArgs);
+        dispatch(goto(...gotoArgs));
         if (closeMainNavigation) closeMainNavigation();
     };
 
@@ -94,7 +86,7 @@ export const NavigationActions = ({
         closeMainNavigation?.();
         openGuide();
     };
-
+    const toggleDiscreetMode = () => dispatch(setDiscreetMode(!discreetMode));
     const getIfRouteIsActive = (route: Route['name']) => {
         const routeObj = findRouteByName(route);
         return routeObj ? routeObj.app === activeApp : false;
@@ -109,7 +101,7 @@ export const NavigationActions = ({
     return (
         <WrapperComponent>
             <ActionItem
-                onClick={() => setDiscreetMode(!discreetMode)}
+                onClick={toggleDiscreetMode}
                 isActive={discreetMode}
                 label={<Translation id="TR_DISCREET" />}
                 icon={discreetMode ? 'HIDE' : 'SHOW'}

--- a/packages/suite/src/components/suite/NoRatesTooltip/index.tsx
+++ b/packages/suite/src/components/suite/NoRatesTooltip/index.tsx
@@ -6,7 +6,7 @@ import { Tooltip, variables } from '@trezor/components';
 const NoRatesMessage = styled.div`
     display: flex;
     align-items: center;
-    color: ${props => props.theme.TYPE_LIGHT_GREY};
+    color: ${({ theme }) => theme.TYPE_LIGHT_GREY};
     font-size: ${variables.FONT_SIZE.TINY};
     font-weight: ${variables.FONT_WEIGHT.REGULAR};
     text-transform: none;

--- a/packages/suite/src/components/suite/NoRatesTooltip/index.tsx
+++ b/packages/suite/src/components/suite/NoRatesTooltip/index.tsx
@@ -12,14 +12,19 @@ const NoRatesMessage = styled.div`
     text-transform: none;
 `;
 
-interface Props extends Partial<typeof Tooltip> {
+interface NoRatesTooltipProps extends Partial<typeof Tooltip> {
     customText?: React.ComponentProps<typeof Translation>['id'];
     customTooltip?: React.ComponentProps<typeof Translation>['id'];
     iconOnly?: boolean;
     className?: string;
 }
 
-const NoRatesTooltip = ({ customText, iconOnly, customTooltip, className }: Props) => (
+const NoRatesTooltip = ({
+    customText,
+    iconOnly,
+    customTooltip,
+    className,
+}: NoRatesTooltipProps) => (
     <NoRatesMessage className={className}>
         {!iconOnly && <Translation id={customText || 'TR_FIAT_RATES_NOT_AVAILABLE'} />}
         <TooltipSymbol

--- a/packages/suite/src/components/suite/NotificationCard/index.tsx
+++ b/packages/suite/src/components/suite/NotificationCard/index.tsx
@@ -62,7 +62,7 @@ const Wrapper = styled.div`
     border-radius: 8px;
     padding: 14px 18px 14px 18px;
     align-items: center;
-    background: ${props => props.theme.STROKE_GREY};
+    background: ${({ theme }) => theme.STROKE_GREY};
     margin-bottom: 8px;
 `;
 
@@ -79,7 +79,7 @@ const Body = styled.div`
     justify-content: space-between;
     align-items: center;
     width: 100%;
-    color: ${props => props.theme.TYPE_DARK_GREY};
+    color: ${({ theme }) => theme.TYPE_DARK_GREY};
     font-weight: ${variables.FONT_WEIGHT.MEDIUM};
     font-size: ${variables.FONT_SIZE.SMALL};
 `;
@@ -88,17 +88,18 @@ const NotificationButton = styled(Button)<{
     notificationVariant: NotificationCardProps['variant'];
 }>`
     margin-left: 16px;
-    color: ${props => props.theme.TYPE_WHITE};
+    color: ${({ theme }) => theme.TYPE_WHITE};
     font-weight: ${variables.FONT_WEIGHT.DEMI_BOLD};
     font-size: ${variables.FONT_SIZE.SMALL};
-    background: ${props => getMainColor(props.notificationVariant, props.theme)};
+    background: ${({ notificationVariant, theme }) => getMainColor(notificationVariant, theme)};
     height: 30px;
 
     &:hover,
     &:focus,
     &:active {
-        color: ${props => props.theme.TYPE_WHITE};
-        background: ${props => getHoverColor(props.notificationVariant, props.theme)};
+        color: ${({ theme }) => theme.TYPE_WHITE};
+        background: ${({ notificationVariant, theme }) =>
+            getHoverColor(notificationVariant, theme)};
     }
 `;
 

--- a/packages/suite/src/components/suite/NotificationRenderer/renderers/ActionRenderer.tsx
+++ b/packages/suite/src/components/suite/NotificationRenderer/renderers/ActionRenderer.tsx
@@ -1,31 +1,28 @@
 import React from 'react';
 import { DEVICE } from '@trezor/connect';
-import { useActions } from 'src/hooks/suite';
-import * as suiteActions from 'src/actions/suite/suiteActions';
+import { useDispatch } from 'src/hooks/suite';
+import { acquireDevice, selectDevice } from 'src/actions/suite/suiteActions';
 import type { NotificationViewProps, NotificationRendererProps } from '../types';
 
 type ActionRendererProps = NotificationViewProps & NotificationRendererProps;
 
 const ActionRenderer = ({ render: View, ...props }: ActionRendererProps) => {
-    const { type, seen, device } = props.notification;
+    const dispatch = useDispatch();
 
-    const { selectDevice, acquireDevice } = useActions({
-        selectDevice: suiteActions.selectDevice,
-        acquireDevice: suiteActions.acquireDevice,
-    });
+    const { type, seen, device } = props.notification;
 
     let action: NotificationViewProps['action'];
     switch (type) {
         case DEVICE.CONNECT:
             action = {
                 label: 'TR_SELECT_DEVICE',
-                onClick: () => selectDevice(device),
+                onClick: () => dispatch(selectDevice(device)),
             };
             break;
         case DEVICE.CONNECT_UNACQUIRED:
             action = {
                 label: 'TR_SOLVE_ISSUE',
-                onClick: () => acquireDevice(device),
+                onClick: () => dispatch(acquireDevice(device)),
             };
             break;
         // no default

--- a/packages/suite/src/components/suite/NotificationRenderer/renderers/ConditionalActionRenderer.tsx
+++ b/packages/suite/src/components/suite/NotificationRenderer/renderers/ConditionalActionRenderer.tsx
@@ -6,7 +6,7 @@ import type { NotificationRendererProps } from '../types';
 
 const Header = styled.div`
     font-weight: ${variables.FONT_WEIGHT.MEDIUM};
-    color: ${props => props.theme.TYPE_LIGHT_GREY};
+    color: ${({ theme }) => theme.TYPE_LIGHT_GREY};
     margin-top: 1px;
 `;
 

--- a/packages/suite/src/components/suite/NotificationRenderer/renderers/UriSchemeRenderers.tsx
+++ b/packages/suite/src/components/suite/NotificationRenderer/renderers/UriSchemeRenderers.tsx
@@ -19,10 +19,9 @@ const Row = styled.span`
 const getIcon = (symbol?: Network['symbol']) => symbol && <CoinLogo symbol={symbol} size={24} />;
 
 const useActionAllowed = (path: string, network?: Network['symbol']) => {
-    const { selectedAccount } = useSelector(state => ({
-        selectedAccount: state.wallet.selectedAccount,
-    }));
+    const selectedAccount = useSelector(state => state.wallet.selectedAccount);
     const pathMatch = useRouteMatch(`${process.env.ASSET_PREFIX || ''}${path}`);
+
     return !!pathMatch && selectedAccount?.network?.symbol === network;
 };
 

--- a/packages/suite/src/components/suite/NotificationRenderer/renderers/UriSchemeRenderers.tsx
+++ b/packages/suite/src/components/suite/NotificationRenderer/renderers/UriSchemeRenderers.tsx
@@ -1,10 +1,10 @@
 import React from 'react';
 import styled from 'styled-components';
 import { useRouteMatch } from 'react-router-dom';
-import * as protocolActions from 'src/actions/suite/protocolActions';
+import { fillSendForm, resetProtocol } from 'src/actions/suite/protocolActions';
 import { Translation } from 'src/components/suite';
 import { CoinLogo } from '@trezor/components';
-import { useActions, useSelector } from 'src/hooks/suite';
+import { useDispatch, useSelector } from 'src/hooks/suite';
 import { capitalizeFirstLetter } from '@trezor/utils';
 import { PROTOCOL_TO_NETWORK } from 'src/constants/suite/protocol';
 import ConditionalActionRenderer from './ConditionalActionRenderer';
@@ -30,11 +30,12 @@ export const CoinProtocolRenderer = ({
     render,
     notification,
 }: NotificationRendererProps<'coin-scheme-protocol'>) => {
-    const { fillSendForm, resetProtocol } = useActions({
-        fillSendForm: protocolActions.fillSendForm,
-        resetProtocol: protocolActions.resetProtocol,
-    });
+    const dispatch = useDispatch();
     const allowed = useActionAllowed('/accounts/send', PROTOCOL_TO_NETWORK[notification.scheme]);
+
+    const onAction = () => dispatch(fillSendForm(true));
+    const onCancel = () => dispatch(resetProtocol);
+
     return (
         <ConditionalActionRenderer
             render={render}
@@ -51,8 +52,8 @@ export const CoinProtocolRenderer = ({
             }
             actionLabel="TOAST_COIN_SCHEME_PROTOCOL_ACTION"
             actionAllowed={allowed}
-            onAction={() => fillSendForm(true)}
-            onCancel={resetProtocol}
+            onAction={onAction}
+            onCancel={onCancel}
             icon={getIcon(PROTOCOL_TO_NETWORK[notification.scheme])}
         />
     );

--- a/packages/suite/src/components/suite/Notifications/components/NotificationGroup/index.tsx
+++ b/packages/suite/src/components/suite/Notifications/components/NotificationGroup/index.tsx
@@ -11,7 +11,7 @@ const SectionHeadline = styled.div`
     font-size: ${variables.FONT_SIZE.TINY};
     font-weight: ${variables.FONT_WEIGHT.DEMI_BOLD};
     text-transform: uppercase;
-    color: ${props => props.theme.TYPE_LIGHT_GREY};
+    color: ${({ theme }) => theme.TYPE_LIGHT_GREY};
     height: 16px;
     line-height: 1.33;
     letter-spacing: 0.2px;

--- a/packages/suite/src/components/suite/Notifications/components/NotificationGroup/index.tsx
+++ b/packages/suite/src/components/suite/Notifications/components/NotificationGroup/index.tsx
@@ -31,10 +31,10 @@ const EmptyHeadline = styled.div`
 const EmptyDescriptionP = styled(P)`
     color: ${({ theme }) => theme.TYPE_LIGHT_GREY};
 `;
-interface Props {
+interface NotificationGroupProps {
     notifications: AppState['notifications'];
 }
-const NotificationGroup = (props: Props) => {
+const NotificationGroup = (props: NotificationGroupProps) => {
     const { seenNotifications, unseenNotifications } = getSeenAndUnseenNotifications(
         props.notifications,
     );

--- a/packages/suite/src/components/suite/Notifications/components/NotificationList/index.tsx
+++ b/packages/suite/src/components/suite/Notifications/components/NotificationList/index.tsx
@@ -11,11 +11,11 @@ const Wrapper = styled.div`
     max-width: 100%;
 `;
 
-interface Props {
+interface NotificationListProps {
     notifications: AppState['notifications'];
 }
 
-const NotificationList = ({ notifications }: Props) => (
+const NotificationList = ({ notifications }: NotificationListProps) => (
     <Wrapper>
         {notifications.map(n => (
             <NotificationRenderer key={n.id} notification={n} render={NotificationView} />

--- a/packages/suite/src/components/suite/Notifications/components/NotificationView/index.tsx
+++ b/packages/suite/src/components/suite/Notifications/components/NotificationView/index.tsx
@@ -22,7 +22,7 @@ const Item = styled.div`
     padding: 16px 0px;
 
     & + & {
-        border-top: 1px solid ${props => props.theme.STROKE_GREY};
+        border-top: 1px solid ${({ theme }) => theme.STROKE_GREY};
     }
 `;
 

--- a/packages/suite/src/components/suite/Notifications/index.tsx
+++ b/packages/suite/src/components/suite/Notifications/index.tsx
@@ -15,7 +15,7 @@ const Header = styled.div`
     margin-top: -8px;
     padding: 0 22px;
     align-items: center;
-    border-bottom: 1px solid ${props => props.theme.STROKE_GREY_ALT};
+    border-bottom: 1px solid ${({ theme }) => theme.STROKE_GREY_ALT};
 `;
 const TabSelector = styled.div`
     display: flex;
@@ -32,9 +32,9 @@ const TabButton = styled.button<{ selected: boolean }>`
     margin-right: 24px;
     cursor: pointer;
     /* change styles if the button is selected*/
-    color: ${props => (props.selected ? props.theme.TYPE_DARK_GREY : props.theme.TYPE_LIGHT_GREY)};
+    color: ${({ selected, theme }) => (selected ? theme.TYPE_DARK_GREY : theme.TYPE_LIGHT_GREY)};
     border-bottom: 2px solid;
-    border-color: ${props => (props.selected ? props.theme.TYPE_DARK_GREY : 'transparent')};
+    border-color: ${({ selected, theme }) => (selected ? theme.TYPE_DARK_GREY : 'transparent')};
     transition: border-color 0.1s;
 
     :hover {

--- a/packages/suite/src/components/suite/Notifications/index.tsx
+++ b/packages/suite/src/components/suite/Notifications/index.tsx
@@ -54,11 +54,11 @@ const Content = styled.div`
         max-height: 100%;
     }
 `;
-interface Props {
+interface NotificationsProps {
     onCancel?: () => void;
 }
 
-const Notifications = (props: Props) => {
+const Notifications = (props: NotificationsProps) => {
     const notifications = useSelector(state => state.notifications);
     const [selectedTab, setSelectedTab] = useState<'important' | 'all'>('important');
     const theme = useTheme();

--- a/packages/suite/src/components/suite/PinInput/components/InputPin/index.tsx
+++ b/packages/suite/src/components/suite/PinInput/components/InputPin/index.tsx
@@ -14,12 +14,12 @@ const StyledInput = styled(Input)`
     box-sizing: border-box;
 `;
 
-interface Props {
+interface InputPinProps {
     value: string;
     onDeleteClick: (event?: React.MouseEvent<any>) => void;
 }
 
-const InputPin = ({ value, onDeleteClick }: Props) => {
+const InputPin = ({ value, onDeleteClick }: InputPinProps) => {
     const theme = useTheme();
 
     return (

--- a/packages/suite/src/components/suite/PinInput/components/InputPin/index.tsx
+++ b/packages/suite/src/components/suite/PinInput/components/InputPin/index.tsx
@@ -9,7 +9,7 @@ const StyledInput = styled(Input)`
     font-weight: ${variables.FONT_WEIGHT.DEMI_BOLD};
     font-size: ${variables.FONT_SIZE.SMALL};
     padding: 0 32px 0 20px;
-    color: ${props => props.theme.TYPE_DARK_GREY};
+    color: ${({ theme }) => theme.TYPE_DARK_GREY};
     background: transparent;
     box-sizing: border-box;
 `;

--- a/packages/suite/src/components/suite/PinInput/index.tsx
+++ b/packages/suite/src/components/suite/PinInput/index.tsx
@@ -43,12 +43,12 @@ const StyledButtonPin = styled(ButtonPin)<{ blur?: boolean }>`
         `}
 `;
 
-interface Props {
+interface PinInputProps {
     isSubmitting: boolean;
     onPinSubmit: (pin: string) => void;
 }
 
-const PinInput = ({ isSubmitting, onPinSubmit }: Props) => {
+const PinInput = ({ isSubmitting, onPinSubmit }: PinInputProps) => {
     const [pin, setPin] = useState('');
 
     const onPinBackspace = useCallback(() => {

--- a/packages/suite/src/components/suite/PinMatrix.tsx
+++ b/packages/suite/src/components/suite/PinMatrix.tsx
@@ -4,8 +4,8 @@ import { HELP_CENTER_PIN_URL } from '@trezor/urls';
 import { variables, useTheme } from '@trezor/components';
 import { DeviceMatrixExplanation, PinInput, Translation, TrezorLink } from 'src/components/suite';
 import { TrezorDevice } from 'src/types/suite';
-import * as modalActions from 'src/actions/suite/modalActions';
-import { useActions } from 'src/hooks/suite';
+import { onPinSubmit } from 'src/actions/suite/modalActions';
+import { useDispatch } from 'src/hooks/suite';
 import { DeviceModelInternal } from '@trezor/connect';
 
 export const PIN_MATRIX_MAX_WIDTH = '316px';
@@ -41,7 +41,8 @@ interface Props {
 export const PinMatrix = ({ device, hideExplanation, invalid }: Props) => {
     const theme = useTheme();
     const [submitted, setSubmitted] = useState(false);
-    const { onPinSubmit } = useActions({ onPinSubmit: modalActions.onPinSubmit });
+    const dispatch = useDispatch();
+
     const pinRequestType = device.buttonRequests[device.buttonRequests.length - 1];
 
     useEffect(() => {
@@ -60,7 +61,7 @@ export const PinMatrix = ({ device, hideExplanation, invalid }: Props) => {
     if (!device.features) return null;
 
     const submit = (pin: string) => {
-        onPinSubmit(pin);
+        dispatch(onPinSubmit(pin));
         setSubmitted(true);
     };
 

--- a/packages/suite/src/components/suite/PinMatrix.tsx
+++ b/packages/suite/src/components/suite/PinMatrix.tsx
@@ -32,13 +32,13 @@ const Col = styled.div`
     width: 100%;
     max-width: ${PIN_MATRIX_MAX_WIDTH};
 `;
-interface Props {
+interface PinMatrixProps {
     device: TrezorDevice;
     hideExplanation?: boolean;
     invalid?: boolean;
 }
 
-export const PinMatrix = ({ device, hideExplanation, invalid }: Props) => {
+export const PinMatrix = ({ device, hideExplanation, invalid }: PinMatrixProps) => {
     const theme = useTheme();
     const [submitted, setSubmitted] = useState(false);
     const dispatch = useDispatch();

--- a/packages/suite/src/components/suite/Preloader/components/DatabaseUpgradeModal/index.tsx
+++ b/packages/suite/src/components/suite/Preloader/components/DatabaseUpgradeModal/index.tsx
@@ -13,11 +13,11 @@ const StyledModal = styled(Modal)`
     width: 600px;
 `;
 
-interface Props {
+interface DatabaseUpgradeModalProps {
     variant: 'blocking' | 'blocked';
 }
 
-const DatabaseUpgradeModal = (props: Props) => (
+const DatabaseUpgradeModal = (props: DatabaseUpgradeModalProps) => (
     <StyledModal
         heading={
             <Translation

--- a/packages/suite/src/components/suite/Preloader/components/PrerequisiteScreen/index.tsx
+++ b/packages/suite/src/components/suite/Preloader/components/PrerequisiteScreen/index.tsx
@@ -2,11 +2,11 @@ import React from 'react';
 import { WelcomeLayout, PrerequisitesGuide } from 'src/components/suite';
 import type { PrerequisiteType } from 'src/types/suite';
 
-interface Props {
+interface PrerequisiteScreenProps {
     prerequisite: PrerequisiteType;
 }
 
-const PrerequisiteScreen = ({ prerequisite }: Props) => (
+const PrerequisiteScreen = ({ prerequisite }: PrerequisiteScreenProps) => (
     <WelcomeLayout>
         <PrerequisitesGuide prerequisite={prerequisite} padded allowSwitchDevice />
     </WelcomeLayout>

--- a/packages/suite/src/components/suite/Preloader/index.tsx
+++ b/packages/suite/src/components/suite/Preloader/index.tsx
@@ -4,13 +4,12 @@ import { SuiteLayout } from 'src/components/suite';
 import InitialLoading from './components/InitialLoading';
 import DatabaseUpgradeModal from './components/DatabaseUpgradeModal';
 import PrerequisiteScreen from './components/PrerequisiteScreen';
-import { useDiscovery, useSelector, useActions } from 'src/hooks/suite';
+import { useDiscovery, useDispatch, useSelector } from 'src/hooks/suite';
 import { Onboarding } from 'src/views/onboarding';
 import { getPrerequisites } from 'src/utils/suite/prerequisites';
 import { ErrorPage } from 'src/views/suite/ErrorPage';
 import { useGuideKeyboard } from 'src/hooks/guide';
 import { init } from 'src/actions/suite/initAction';
-
 import type { AppState } from 'src/types/suite';
 
 const getFullscreenApp = (route: AppState['router']['route']) => {
@@ -29,21 +28,16 @@ interface PreloaderProps {
 // Preloader is a top level wrapper used in _app.tsx.
 // Decides which content should be displayed basing on route and prerequisites.
 const Preloader = ({ children }: PreloaderProps) => {
-    const { initSuite } = useActions({
-        initSuite: init,
-    });
-
-    const { lifecycle, router, transport } = useSelector(state => ({
-        lifecycle: state.suite.lifecycle,
-        transport: state.suite.transport,
-        router: state.router,
-    }));
+    const lifecycle = useSelector(state => state.suite.lifecycle);
+    const transport = useSelector(state => state.suite.transport);
+    const router = useSelector(state => state.router);
+    const dispatch = useDispatch();
 
     const { device } = useDiscovery();
 
     useEffect(() => {
-        initSuite();
-    }, [initSuite]);
+        dispatch(init());
+    }, [dispatch]);
 
     // Register keyboard handlers for opening/closing Guide using keyboard
     useGuideKeyboard();

--- a/packages/suite/src/components/suite/PrerequisitesGuide/components/DeviceAcquire.tsx
+++ b/packages/suite/src/components/suite/PrerequisitesGuide/components/DeviceAcquire.tsx
@@ -2,27 +2,23 @@ import React from 'react';
 import { Button } from '@trezor/components';
 
 import { Translation, TroubleshootingTips } from 'src/components/suite';
-import { useDevice, useActions } from 'src/hooks/suite';
-import * as suiteActions from 'src/actions/suite/suiteActions';
+import { useDevice, useDispatch } from 'src/hooks/suite';
+import { acquireDevice } from 'src/actions/suite/suiteActions';
 import { isDesktop } from '@trezor/env-utils';
 
 export const DeviceAcquire = () => {
     const { isLocked } = useDevice();
-    const { acquireDevice } = useActions({
-        acquireDevice: suiteActions.acquireDevice,
-    });
+    const dispatch = useDispatch();
 
     const isDeviceLocked = isLocked();
 
+    const handleClick: React.MouseEventHandler = e => {
+        e.stopPropagation();
+        dispatch(acquireDevice());
+    };
+
     const ctaButton = (
-        <Button
-            data-test="@device-acquire"
-            isLoading={isDeviceLocked}
-            onClick={e => {
-                e.stopPropagation();
-                acquireDevice();
-            }}
-        >
+        <Button data-test="@device-acquire" isLoading={isDeviceLocked} onClick={handleClick}>
             <Translation id="TR_ACQUIRE_DEVICE" />
         </Button>
     );

--- a/packages/suite/src/components/suite/PrerequisitesGuide/components/DeviceBootloader.tsx
+++ b/packages/suite/src/components/suite/PrerequisitesGuide/components/DeviceBootloader.tsx
@@ -2,8 +2,8 @@ import React from 'react';
 import styled from 'styled-components';
 import { Translation, TroubleshootingTips } from 'src/components/suite';
 import { Button } from '@trezor/components';
-import { useActions } from 'src/hooks/suite';
-import * as routerActions from 'src/actions/suite/routerActions';
+import { useDispatch } from 'src/hooks/suite';
+import { goto } from 'src/actions/suite/routerActions';
 import { TrezorDevice } from 'src/types/suite';
 import { pickByDeviceModel } from '@trezor/device-utils';
 import { DeviceModelInternal } from '@trezor/connect';
@@ -18,10 +18,11 @@ interface DeviceBootloaderProps {
 
 /* User connected the device in bootloader mode, but in order to continue it needs to be in normal mode */
 export const DeviceBootloader = ({ device }: DeviceBootloaderProps) => {
-    const { goto } = useActions({
-        goto: routerActions.goto,
-    });
+    const dispatch = useDispatch();
+
     const deviceModelInternal = device?.features?.internal_model;
+
+    const gotToDeviceSettings = () => dispatch(goto('settings-device'));
 
     const tips = [
         {
@@ -44,15 +45,7 @@ export const DeviceBootloader = ({ device }: DeviceBootloaderProps) => {
             heading: <Translation id="TR_WIPE_OR_UPDATE" />,
             description: <Translation id="TR_WIPE_OR_UPDATE_DESCRIPTION" />,
             noBullet: true,
-            action: (
-                <Button
-                    onClick={() => {
-                        goto('settings-device');
-                    }}
-                    icon="SETTINGS"
-                    size={20}
-                />
-            ),
+            action: <Button onClick={gotToDeviceSettings} icon="SETTINGS" size={20} />,
         },
     ];
 

--- a/packages/suite/src/components/suite/PrerequisitesGuide/components/DeviceInitialize.tsx
+++ b/packages/suite/src/components/suite/PrerequisitesGuide/components/DeviceInitialize.tsx
@@ -1,26 +1,21 @@
 import React from 'react';
 import { Button } from '@trezor/components';
 import { Translation, TroubleshootingTips } from 'src/components/suite';
-import { useActions } from 'src/hooks/suite';
-import * as routerActions from 'src/actions/suite/routerActions';
-import * as onboardingActions from 'src/actions/onboarding/onboardingActions';
+import { useDispatch } from 'src/hooks/suite';
+import { goto } from 'src/actions/suite/routerActions';
+import { enableOnboardingReducer, resetOnboarding } from 'src/actions/onboarding/onboardingActions';
 
 export const DeviceInitialize = () => {
-    const { goto, resetOnboarding, enableOnboardingReducer } = useActions({
-        // todo: there could be an utility action wrapping all these 3
-        goto: routerActions.goto,
-        resetOnboarding: onboardingActions.resetOnboarding,
-        enableOnboardingReducer: onboardingActions.enableOnboardingReducer,
-    });
+    const dispatch = useDispatch();
 
     const handleCtaClick = (e: React.MouseEvent) => {
         e.stopPropagation();
         // in case this prerequisite (device-initialize) is displayed inside onboarding app we need to reset onboarding state
-        resetOnboarding();
+        dispatch(resetOnboarding());
         // and resetting state disables onboarding reducer so we need to enable it again
-        enableOnboardingReducer(true);
+        dispatch(enableOnboardingReducer(true));
 
-        goto('onboarding-index');
+        dispatch(goto('onboarding-index'));
     };
 
     return (

--- a/packages/suite/src/components/suite/PrerequisitesGuide/components/DeviceNoFirmware.tsx
+++ b/packages/suite/src/components/suite/PrerequisitesGuide/components/DeviceNoFirmware.tsx
@@ -2,24 +2,22 @@ import React from 'react';
 import { Button } from '@trezor/components';
 
 import { Translation, TroubleshootingTips } from 'src/components/suite';
-import { useActions } from 'src/hooks/suite';
-import * as routerActions from 'src/actions/suite/routerActions';
+import { useDispatch } from 'src/hooks/suite';
+import { goto } from 'src/actions/suite/routerActions';
 
 export const DeviceNoFirmware = () => {
-    const { goto } = useActions({
-        goto: routerActions.goto,
-    });
+    const dispatch = useDispatch();
+
+    const handleClick: React.MouseEventHandler = e => {
+        e.stopPropagation();
+        dispatch(goto('onboarding-index'));
+    };
 
     return (
         <TroubleshootingTips
             label={<Translation id="TR_NO_FIRMWARE" />}
             cta={
-                <Button
-                    onClick={e => {
-                        e.stopPropagation();
-                        goto('onboarding-index');
-                    }}
-                >
+                <Button onClick={handleClick}>
                     <Translation id="TR_GO_TO_ONBOARDING" />
                 </Button>
             }

--- a/packages/suite/src/components/suite/PrerequisitesGuide/components/DeviceRecoveryMode.tsx
+++ b/packages/suite/src/components/suite/PrerequisitesGuide/components/DeviceRecoveryMode.tsx
@@ -1,12 +1,12 @@
 import React from 'react';
 import { Button } from '@trezor/components';
 import { Translation, TroubleshootingTips } from 'src/components/suite';
-import * as recoveryActions from 'src/actions/recovery/recoveryActions';
-import { useDevice, useSelector, useActions } from 'src/hooks/suite';
+import { rerun } from 'src/actions/recovery/recoveryActions';
+import { useDevice, useDispatch, useSelector } from 'src/hooks/suite';
 
 export const DeviceRecoveryMode = () => {
     const recovery = useSelector(state => state.recovery);
-    const { rerun } = useActions({ rerun: recoveryActions.rerun });
+    const dispatch = useDispatch();
 
     const { isLocked } = useDevice();
 
@@ -14,17 +14,16 @@ export const DeviceRecoveryMode = () => {
         return null;
     }
 
+    const handleClick: React.MouseEventHandler = e => {
+        e.stopPropagation();
+        dispatch(rerun());
+    };
+
     return (
         <TroubleshootingTips
             label={<Translation id="TR_DEVICE_IN_RECOVERY_MODE" />}
             cta={
-                <Button
-                    isDisabled={isLocked()}
-                    onClick={e => {
-                        e.stopPropagation();
-                        rerun();
-                    }}
-                >
+                <Button isDisabled={isLocked()} onClick={handleClick}>
                     <Translation id="TR_CONTINUE" />
                 </Button>
             }

--- a/packages/suite/src/components/suite/PrerequisitesGuide/components/DeviceUnreadable.tsx
+++ b/packages/suite/src/components/suite/PrerequisitesGuide/components/DeviceUnreadable.tsx
@@ -11,7 +11,7 @@ import {
     TROUBLESHOOTING_TIP_USB,
     TROUBLESHOOTING_TIP_DIFFERENT_COMPUTER,
 } from 'src/components/suite/TroubleshootingTips/tips';
-import { useActions } from 'src/hooks/suite';
+import { useDispatch } from 'src/hooks/suite';
 import { notificationsActions } from '@suite-common/toast-notifications';
 import type { TrezorDevice } from 'src/types/suite';
 
@@ -39,9 +39,7 @@ const UdevWeb = () => (
 const UdevDesktop = () => {
     const [response, setResponse] = useState(-1);
 
-    const { addToast } = useActions({
-        addToast: notificationsActions.addToast,
-    });
+    const dispatch = useDispatch();
 
     const handleCtaClick = async (event: React.MouseEvent) => {
         event.preventDefault();
@@ -52,10 +50,12 @@ const UdevDesktop = () => {
         if (resp?.success) {
             setResponse(1);
         } else {
-            addToast({
-                type: 'error',
-                error: resp?.error || 'desktopApi not available',
-            });
+            dispatch(
+                notificationsActions.addToast({
+                    type: 'error',
+                    error: resp?.error || 'desktopApi not available',
+                }),
+            );
 
             setResponse(0);
         }

--- a/packages/suite/src/components/suite/PrerequisitesGuide/components/DeviceUpdateRequired.tsx
+++ b/packages/suite/src/components/suite/PrerequisitesGuide/components/DeviceUpdateRequired.tsx
@@ -2,22 +2,22 @@ import React from 'react';
 import { Button } from '@trezor/components';
 
 import { Translation, TroubleshootingTips } from 'src/components/suite';
-import { useActions } from 'src/hooks/suite';
-import * as routerActions from 'src/actions/suite/routerActions';
+import { useDispatch } from 'src/hooks/suite';
+import { goto } from 'src/actions/suite/routerActions';
 
 export const DeviceUpdateRequired = () => {
-    const { goto } = useActions({ goto: routerActions.goto });
+    const dispatch = useDispatch();
+
+    const handleClick: React.MouseEventHandler = e => {
+        e.stopPropagation();
+        dispatch(goto('firmware-index'));
+    };
 
     return (
         <TroubleshootingTips
             label={<Translation id="FW_CAPABILITY_UPDATE_REQUIRED" />}
             cta={
-                <Button
-                    onClick={e => {
-                        e.stopPropagation();
-                        goto('firmware-index');
-                    }}
-                >
+                <Button onClick={handleClick}>
                     <Translation id="TR_SEE_DETAILS" />
                 </Button>
             }

--- a/packages/suite/src/components/suite/PrerequisitesGuide/index.tsx
+++ b/packages/suite/src/components/suite/PrerequisitesGuide/index.tsx
@@ -58,11 +58,9 @@ export const PrerequisitesGuide = ({
     padded,
     allowSwitchDevice,
 }: PrerequisitesGuideProps) => {
-    const { device, transport, devices } = useSelector(state => ({
-        device: state.suite.device,
-        devices: state.devices.length,
-        transport: state.suite.transport,
-    }));
+    const device = useSelector(state => state.suite.device);
+    const devices = useSelector(state => state.devices.length);
+    const transport = useSelector(state => state.suite.transport);
 
     const isWebUsbTransport = isWebUsb(transport);
 

--- a/packages/suite/src/components/suite/QuestionTooltip/index.tsx
+++ b/packages/suite/src/components/suite/QuestionTooltip/index.tsx
@@ -11,7 +11,7 @@ const Wrapper = styled.div`
 
 const Label = styled(H3)`
     margin-right: 4px;
-    color: ${props => props.theme.TYPE_DARK_GREY};
+    color: ${({ theme }) => theme.TYPE_DARK_GREY};
 `;
 
 // Label container to avoid jumping when tooltip appears

--- a/packages/suite/src/components/suite/Settings/components/DeviceBanner.tsx
+++ b/packages/suite/src/components/suite/Settings/components/DeviceBanner.tsx
@@ -55,7 +55,7 @@ interface DeviceBannerProps {
 export const DeviceBanner = ({ title, description }: DeviceBannerProps) => {
     const { device } = useDevice();
 
-    const transport = useSelector(state => (state.suite.transport);
+    const transport = useSelector(state => state.suite.transport);
 
     const isWebUsbTransport = isWebUsb(transport);
 

--- a/packages/suite/src/components/suite/Settings/components/DeviceBanner.tsx
+++ b/packages/suite/src/components/suite/Settings/components/DeviceBanner.tsx
@@ -55,9 +55,7 @@ interface DeviceBannerProps {
 export const DeviceBanner = ({ title, description }: DeviceBannerProps) => {
     const { device } = useDevice();
 
-    const { transport } = useSelector(state => ({
-        transport: state.suite.transport,
-    }));
+    const transport = useSelector(state => (state.suite.transport);
 
     const isWebUsbTransport = isWebUsb(transport);
 

--- a/packages/suite/src/components/suite/Settings/components/Row.tsx
+++ b/packages/suite/src/components/suite/Settings/components/Row.tsx
@@ -12,7 +12,7 @@ const Wrapper = styled.div`
     display: flex;
     flex-direction: column;
     &:not(:first-child) {
-        border-top: 1px solid ${props => props.theme.STROKE_GREY};
+        border-top: 1px solid ${({ theme }) => theme.STROKE_GREY};
     }
 `;
 

--- a/packages/suite/src/components/suite/Settings/components/SectionItem.tsx
+++ b/packages/suite/src/components/suite/Settings/components/SectionItem.tsx
@@ -42,11 +42,11 @@ const Content = styled.div`
     }
 `;
 
-interface Props extends React.HTMLAttributes<HTMLDivElement> {
+interface SectionItemProps extends React.HTMLAttributes<HTMLDivElement> {
     shouldHighlight?: boolean;
 }
 
-export const SectionItem = React.forwardRef<HTMLDivElement, Props>(
+export const SectionItem = React.forwardRef<HTMLDivElement, SectionItemProps>(
     ({ children, shouldHighlight, ...rest }, ref) => (
         <Wrapper ref={ref} shouldHighlight={shouldHighlight} {...rest}>
             <Content>{children}</Content>

--- a/packages/suite/src/components/suite/Settings/components/SectionItem.tsx
+++ b/packages/suite/src/components/suite/Settings/components/SectionItem.tsx
@@ -13,7 +13,7 @@ const Wrapper = styled.div<{ shouldHighlight?: boolean }>`
 
     &:not(:first-child) {
         > div {
-            border-top: 1px solid ${props => props.theme.STROKE_GREY};
+            border-top: 1px solid ${({ theme }) => theme.STROKE_GREY};
         }
     }
 

--- a/packages/suite/src/components/suite/Settings/components/SettingsSection.tsx
+++ b/packages/suite/src/components/suite/Settings/components/SettingsSection.tsx
@@ -15,7 +15,7 @@ const Title = styled.div`
     display: flex;
     align-items: center;
     font-size: ${variables.FONT_SIZE.TINY};
-    color: ${props => props.theme.TYPE_LIGHT_GREY};
+    color: ${({ theme }) => theme.TYPE_LIGHT_GREY};
     text-transform: uppercase;
     font-weight: ${variables.FONT_WEIGHT.DEMI_BOLD};
 `;

--- a/packages/suite/src/components/suite/Settings/components/TextColumn.tsx
+++ b/packages/suite/src/components/suite/Settings/components/TextColumn.tsx
@@ -28,7 +28,7 @@ const ButtonLink = styled(Button)`
 `;
 
 const Description = styled.div`
-    color: ${props => props.theme.TYPE_LIGHT_GREY};
+    color: ${({ theme }) => theme.TYPE_LIGHT_GREY};
     margin-bottom: 12px;
     margin-top: 12px;
     font-size: ${variables.FONT_SIZE.SMALL};

--- a/packages/suite/src/components/suite/Skeleton/index.tsx
+++ b/packages/suite/src/components/suite/Skeleton/index.tsx
@@ -47,8 +47,8 @@ export const shimmerEffect = css`
     animation: ${SHINE} 1.5s ease infinite;
     background: linear-gradient(
         90deg,
-        ${props =>
-            `${props.theme.GRADIENT_SKELETON_START}, ${props.theme.BG_GREY_ALT}, ${props.theme.GRADIENT_SKELETON_START}`}
+        ${({ theme }) =>
+            `${theme.GRADIENT_SKELETON_START}, ${theme.BG_GREY_ALT}, ${theme.GRADIENT_SKELETON_START}`}
     );
     background-size: 200%;
 `;
@@ -56,7 +56,7 @@ export const shimmerEffect = css`
 const SkeletonRectangle = styled.div<SkeletonProps>`
     width: ${props => props.width ?? '80px'};
     height: ${props => props.height ?? '20px'};
-    background: ${props => props.background ?? props.theme.BG_GREY_ALT};
+    background: ${({ background, theme }) => background ?? theme.BG_GREY_ALT};
     border-radius: ${props => props.borderRadius ?? '4px'};
     background-size: 200%;
 
@@ -71,7 +71,7 @@ const SkeletonCircle = styled.div<SkeletonProps>`
     width: ${props => props.size ?? '24px'};
     height: ${props => props.size ?? '24px'};
     border-radius: ${props => props.size ?? '24px'};
-    background: ${props => props.background ?? props.theme.BG_GREY_ALT};
+    background: ${({ background, theme }) => background ?? theme.BG_GREY_ALT};
     background-size: 200%;
 
     ${props =>

--- a/packages/suite/src/components/suite/StatusLight/index.tsx
+++ b/packages/suite/src/components/suite/StatusLight/index.tsx
@@ -30,12 +30,12 @@ const Circle = styled.div<{ status: Status }>`
     }
 `;
 
-type Props = {
+interface StatusLightProps {
     status: Status;
     className?: string;
-};
+}
 
-const StatusLight = ({ status, className }: Props) => (
+const StatusLight = ({ status, className }: StatusLightProps) => (
     <Circle status={status} className={className}>
         <div />
     </Circle>

--- a/packages/suite/src/components/suite/SuiteLayout/index.tsx
+++ b/packages/suite/src/components/suite/SuiteLayout/index.tsx
@@ -57,8 +57,8 @@ const Columns = styled.div`
 const AppWrapper = styled.div`
     display: flex;
     flex: 1;
-    color: ${props => props.theme.TYPE_DARK_GREY};
-    background: ${props => props.theme.BG_GREY};
+    color: ${({ theme }) => theme.TYPE_DARK_GREY};
+    background: ${({ theme }) => theme.BG_GREY};
     flex-direction: column;
     overflow-x: auto;
     overflow-y: scroll;
@@ -94,11 +94,9 @@ type SuiteLayoutProps = {
 };
 
 export const SuiteLayout = ({ children }: SuiteLayoutProps) => {
-    const { url, anchor, initialRun } = useSelector(state => ({
-        url: state.router.url,
-        anchor: state.router.anchor,
-        initialRun: state.suite.flags.initialRun,
-    }));
+    const url = useSelector(state => state.router.url);
+    const anchor = useSelector(state => state.router.anchor);
+    const initialRun = useSelector(state => state.suite.flags.initialRun);
 
     const { isMobileLayout, layoutSize } = useLayoutSize();
     const { isGuideOpen, isModalOpen } = useGuide();

--- a/packages/suite/src/components/suite/SuiteLayout/useAnchorRemoving.tsx
+++ b/packages/suite/src/components/suite/SuiteLayout/useAnchorRemoving.tsx
@@ -1,25 +1,23 @@
 import { useEffect, useRef } from 'react';
-import { useActions } from 'src/hooks/suite';
+import { useDispatch } from 'src/hooks/suite';
 import { onAnchorChange } from 'src/actions/suite/routerActions';
 
 export const useAnchorRemoving = (anchor: string | undefined) => {
     const ref = useRef<HTMLDivElement>(null);
 
-    const { onAnchorChangeAction } = useActions({
-        onAnchorChangeAction: onAnchorChange,
-    });
+    const dispatch = useDispatch();
 
     useEffect(() => {
         // to assure propagation of click, which removes anchor highlight, work reliably
         // click listener has to be added on react container
         const parent = ref.current?.parentElement;
-        const removeAnchor = () => anchor && onAnchorChangeAction();
+        const removeAnchor = () => anchor && dispatch(onAnchorChange());
 
         if (parent && anchor) {
             parent.addEventListener('click', removeAnchor);
             return () => parent.removeEventListener('click', removeAnchor);
         }
-    }, [anchor, onAnchorChangeAction, ref]);
+    }, [anchor, dispatch, ref]);
 
     return ref;
 };

--- a/packages/suite/src/components/suite/SwitchDevice/components/DeviceItem/components/AddWalletButton/index.tsx
+++ b/packages/suite/src/components/suite/SwitchDevice/components/DeviceItem/components/AddWalletButton/index.tsx
@@ -16,7 +16,7 @@ const AddWallet = styled.div`
 const StyledButton = styled(Button)`
     padding: 16px;
     justify-content: center;
-    border: 1px dashed ${props => props.theme.STROKE_GREY};
+    border: 1px dashed ${({ theme }) => theme.STROKE_GREY};
     border-radius: 8px;
     background: transparent;
 

--- a/packages/suite/src/components/suite/SwitchDevice/components/DeviceItem/components/AddWalletButton/index.tsx
+++ b/packages/suite/src/components/suite/SwitchDevice/components/DeviceItem/components/AddWalletButton/index.tsx
@@ -31,14 +31,19 @@ const StyledTooltip = styled(Tooltip)`
     width: 100%;
 `;
 
-interface Props {
+interface AddWalletButtonProps {
     device: TrezorDevice;
     instances: AcquiredDevice[];
     addDeviceInstance: (instance: TrezorDevice) => Promise<void>;
     selectDeviceInstance: (instance: TrezorDevice) => void;
 }
 
-const AddWalletButton = ({ device, instances, addDeviceInstance, selectDeviceInstance }: Props) => {
+const AddWalletButton = ({
+    device,
+    instances,
+    addDeviceInstance,
+    selectDeviceInstance,
+}: AddWalletButtonProps) => {
     const hasAtLeastOneWallet = instances.find(d => d.state);
     // Find a "standard wallet" among user's wallet instances. If no such wallet is found, the variable is undefined.
     const emptyPassphraseWalletExists = instances.find(d => d.useEmptyPassphrase && d.state);

--- a/packages/suite/src/components/suite/SwitchDevice/components/DeviceItem/components/ColHeader/index.tsx
+++ b/packages/suite/src/components/suite/SwitchDevice/components/DeviceItem/components/ColHeader/index.tsx
@@ -4,7 +4,7 @@ import { Tooltip, TooltipProps, variables } from '@trezor/components';
 
 const Wrapper = styled.div`
     display: flex;
-    color: ${props => props.theme.TYPE_LIGHT_GREY};
+    color: ${({ theme }) => theme.TYPE_LIGHT_GREY};
     align-items: center;
     justify-content: center;
 `;

--- a/packages/suite/src/components/suite/SwitchDevice/components/DeviceItem/components/ColHeader/index.tsx
+++ b/packages/suite/src/components/suite/SwitchDevice/components/DeviceItem/components/ColHeader/index.tsx
@@ -16,13 +16,13 @@ const Text = styled.span`
     text-transform: uppercase;
 `;
 
-interface Props {
+interface ColHeaderProps {
     children?: React.ReactNode;
     tooltipContent?: TooltipProps['content'];
     tooltipOpenGuide?: TooltipProps['guideAnchor'];
 }
 
-const ColHeader = ({ children, tooltipContent, tooltipOpenGuide, ...rest }: Props) => (
+const ColHeader = ({ children, tooltipContent, tooltipOpenGuide, ...rest }: ColHeaderProps) => (
     <Wrapper {...rest}>
         {tooltipContent ? (
             <Tooltip maxWidth={285} content={tooltipContent} guideAnchor={tooltipOpenGuide} dashed>

--- a/packages/suite/src/components/suite/SwitchDevice/components/DeviceItem/components/DeviceHeaderButton/index.tsx
+++ b/packages/suite/src/components/suite/SwitchDevice/components/DeviceItem/components/DeviceHeaderButton/index.tsx
@@ -7,7 +7,7 @@ import * as deviceUtils from 'src/utils/suite/device';
 import { TrezorDevice } from 'src/types/suite';
 
 const GrayNotificationCard = styled(NotificationCard)`
-    background: ${props => props.theme.BG_GREY};
+    background: ${({ theme }) => theme.BG_GREY};
     margin-bottom: 0px;
 `;
 interface Props {

--- a/packages/suite/src/components/suite/SwitchDevice/components/DeviceItem/components/DeviceHeaderButton/index.tsx
+++ b/packages/suite/src/components/suite/SwitchDevice/components/DeviceItem/components/DeviceHeaderButton/index.tsx
@@ -10,14 +10,14 @@ const GrayNotificationCard = styled(NotificationCard)`
     background: ${({ theme }) => theme.BG_GREY};
     margin-bottom: 0px;
 `;
-interface Props {
+interface DeviceHeaderButtonProps {
     needsAttention: boolean;
     device: TrezorDevice;
     onSolveIssueClick: () => void;
     onDeviceSettingsClick: () => void;
 }
 
-const DeviceHeaderButton = (props: Props) => {
+const DeviceHeaderButton = (props: DeviceHeaderButtonProps) => {
     const { device } = props;
     const theme = useTheme();
     const deviceStatus = deviceUtils.getStatus(device);

--- a/packages/suite/src/components/suite/SwitchDevice/index.tsx
+++ b/packages/suite/src/components/suite/SwitchDevice/index.tsx
@@ -19,7 +19,6 @@ const DeviceItemsWrapper = styled.div`
 `;
 
 export const SwitchDevice = ({ cancelable, onCancel }: ForegroundAppProps) => {
-    const router = useSelector(state => state.router);
     const selectedDevice = useSelector(state => state.suite.device);
     const devices = useSelector(state => state.devices);
     const transport = useSelector(state => state.suite.transport);

--- a/packages/suite/src/components/suite/SwitchDevice/index.tsx
+++ b/packages/suite/src/components/suite/SwitchDevice/index.tsx
@@ -19,12 +19,10 @@ const DeviceItemsWrapper = styled.div`
 `;
 
 export const SwitchDevice = ({ cancelable, onCancel }: ForegroundAppProps) => {
-    const { selectedDevice, devices, transport } = useSelector(state => ({
-        router: state.router,
-        selectedDevice: state.suite.device,
-        devices: state.devices,
-        transport: state.suite.transport,
-    }));
+    const router = useSelector(state => state.router);
+    const selectedDevice = useSelector(state => state.suite.device);
+    const devices = useSelector(state => state.devices);
+    const transport = useSelector(state => state.suite.transport);
 
     const isWebUsbTransport = isWebUsb(transport);
 

--- a/packages/suite/src/components/suite/Ticker/index.tsx
+++ b/packages/suite/src/components/suite/Ticker/index.tsx
@@ -9,7 +9,7 @@ import { useSelector } from 'src/hooks/suite';
 const FiatRateWrapper = styled.span`
     display: flex;
     align-items: center;
-    color: ${props => props.theme.TYPE_DARK_GREY};
+    color: ${({ theme }) => theme.TYPE_DARK_GREY};
     font-size: ${variables.NEUE_FONT_SIZE.SMALL};
     font-weight: ${variables.FONT_WEIGHT.DEMI_BOLD};
 `;
@@ -18,21 +18,21 @@ const LastUpdate = styled.div`
     text-transform: none;
 `;
 
-interface Props {
+interface TickerProps {
     symbol: string;
     tooltipPos?: 'top' | 'bottom';
 }
-const Ticker = ({ symbol, tooltipPos = 'top' }: Props) => {
+const Ticker = ({ symbol, tooltipPos = 'top' }: TickerProps) => {
+    const rates = useSelector(state => state.wallet.fiat.coins.find(r => r.symbol === symbol));
+    const localCurrency = useSelector(state => state.wallet.settings.localCurrency);
     const theme = useTheme();
-    const rateAge = (timestamp: number) => differenceInMinutes(new Date(timestamp), new Date());
-    const { rates, localCurrency } = useSelector(state => ({
-        rates: state.wallet.fiat.coins.find(r => r.symbol === symbol),
-        localCurrency: state.wallet.settings.localCurrency,
-    }));
+
     const lastWeekRates = rates?.lastWeek?.tickers ?? [];
     const currentRate = rates?.current?.rates?.[localCurrency];
     const lastWeekRate = lastWeekRates[0]?.rates?.[localCurrency];
     const rateGoingUp = currentRate && lastWeekRate ? currentRate >= lastWeekRate : false;
+
+    const rateAge = (timestamp: number) => differenceInMinutes(new Date(timestamp), new Date());
 
     return (
         <FiatValue amount="1" symbol={symbol}>

--- a/packages/suite/src/components/suite/ToastContainer.tsx
+++ b/packages/suite/src/components/suite/ToastContainer.tsx
@@ -33,8 +33,8 @@ const StyledContainer = styled(BaseToastContainer)`
     .Toastify__toast {
         border-radius: 8px;
         box-shadow: 0 2px 5px 0 rgba(0, 0, 0, 0.19);
-        color: ${props => props.theme.TYPE_DARK_GREY};
-        background: ${props => props.theme.BG_WHITE};
+        color: ${({ theme }) => theme.TYPE_DARK_GREY};
+        background: ${({ theme }) => theme.BG_WHITE};
         padding: 0px;
         font-family: 'TT Hoves', -apple-system, BlinkMacSystemFont, 'Segoe UI', 'Helvetica Neue',
             Arial, sans-serif;

--- a/packages/suite/src/components/suite/ToastNotification.tsx
+++ b/packages/suite/src/components/suite/ToastNotification.tsx
@@ -3,7 +3,7 @@ import styled, { css } from 'styled-components';
 import { Button, Icon, useTheme, variables } from '@trezor/components';
 import { Translation } from 'src/components/suite';
 import { notificationsActions, NotificationEntry } from '@suite-common/toast-notifications';
-import { useActions } from 'src/hooks/suite';
+import { useDispatch } from 'src/hooks/suite';
 import { getNotificationIcon, getVariantColor } from 'src/utils/suite//notification';
 import NotificationRenderer, {
     NotificationViewProps,
@@ -61,12 +61,8 @@ const ToastNotification = ({
     notification: { type, id },
 }: NotificationViewProps) => {
     const [isTall, setIsTall] = useState(false);
-
-    const { closeNotification } = useActions({
-        closeNotification: notificationsActions.close,
-    });
-
     const theme = useTheme();
+    const dispatch = useDispatch();
     const wrapperRef = useRef<HTMLDivElement>(null);
 
     useLayoutEffect(() => {
@@ -82,7 +78,7 @@ const ToastNotification = ({
     const defaultIcon = icon ?? getNotificationIcon(variant);
 
     const handleCancelClick = () => {
-        closeNotification(id);
+        dispatch(notificationsActions.close(id));
         onCancel?.();
     };
 

--- a/packages/suite/src/components/suite/TransactionsGraph/components/RangeSelector.tsx
+++ b/packages/suite/src/components/suite/TransactionsGraph/components/RangeSelector.tsx
@@ -100,13 +100,13 @@ const getFormattedLabel = (rangeLabel: GraphRange['label']) => {
     }
 };
 
-interface Props {
+interface RangeSelectorProps {
     onSelectedRange?: (range: GraphRange) => void;
     className?: string;
     align?: 'left' | 'right';
 }
 
-export const RangeSelector = ({ onSelectedRange, className, align }: Props) => {
+export const RangeSelector = ({ onSelectedRange, className, align }: RangeSelectorProps) => {
     const [customTimerangeStart, setCustomTimerangeStart] = useState<Date>();
     const [customTimerangeEnd, setCustomTimerangeEnd] = useState<Date>();
 

--- a/packages/suite/src/components/suite/Translation/components/HelperTooltip/index.tsx
+++ b/packages/suite/src/components/suite/Translation/components/HelperTooltip/index.tsx
@@ -14,7 +14,7 @@ const MessageWrapper = styled.span`
     text-decoration: underline solid red;
 `;
 
-export interface Props {
+export interface HelperTooltipProps {
     messageId?: string;
     isNested?: boolean;
     language?: string;
@@ -25,7 +25,13 @@ export interface Props {
 /**
  * When translationMode is enabled wraps a message with a Tooltip and adds styling to provide visual hint for translators
  */
-const HelperTooltip = ({ messageId, isNested, language, translationMode, children }: Props) => {
+const HelperTooltip = ({
+    messageId,
+    isNested,
+    language,
+    translationMode,
+    children,
+}: HelperTooltipProps) => {
     const locale = language?.replace('-', '') || 'en';
     // don't wrap with tooltip for messages that are nested in another message
     // fixes https://github.com/trezor/trezor-suite/issues/1509

--- a/packages/suite/src/components/suite/TroubleshootingTips/tips.tsx
+++ b/packages/suite/src/components/suite/TroubleshootingTips/tips.tsx
@@ -2,26 +2,22 @@ import React from 'react';
 import TrezorLink from 'src/components/suite/TrezorLink';
 import { Translation } from 'src/components/suite/Translation';
 import { isWeb, isLinux, isAndroid } from '@trezor/env-utils';
-import { useActions } from 'src/hooks/suite';
-import * as routerActions from 'src/actions/suite/routerActions';
+import { useDispatch } from 'src/hooks/suite';
+import { goto } from 'src/actions/suite/routerActions';
 
 // TODO: move it to separated components?
 
 const UdevDescription = () => {
-    const { goto } = useActions({
-        goto: routerActions.goto,
-    });
+    const dispatch = useDispatch();
+
+    const handleClick = () => dispatch(goto('suite-udev'));
 
     return (
         <Translation
             id="TR_TROUBLESHOOTING_TIP_UDEV_INSTALL_DESCRIPTION"
             values={{
                 a: chunks => (
-                    <TrezorLink
-                        variant="underline"
-                        onClick={() => goto('suite-udev')}
-                        data-test="@goto/udev"
-                    >
+                    <TrezorLink variant="underline" onClick={handleClick} data-test="@goto/udev">
                         {chunks}
                     </TrezorLink>
                 ),
@@ -44,16 +40,16 @@ const BridgeStatus = () => (
 );
 
 const BridgeInstall = () => {
-    const { goto } = useActions({
-        goto: routerActions.goto,
-    });
+    const dispatch = useDispatch();
+
+    const handleClick = () => dispatch(goto('suite-bridge'));
 
     return (
         <Translation
             id="TR_TROUBLESHOOTING_TIP_BRIDGE_INSTALL_DESCRIPTION"
             values={{
                 a: chunks => (
-                    <TrezorLink variant="underline" onClick={() => goto('suite-bridge')}>
+                    <TrezorLink variant="underline" onClick={handleClick}>
                         {chunks}
                     </TrezorLink>
                 ),
@@ -63,16 +59,16 @@ const BridgeInstall = () => {
 };
 
 const BridgeUse = () => {
-    const { goto } = useActions({
-        goto: routerActions.goto,
-    });
+    const dispatch = useDispatch();
+
+    const handleClick = () => dispatch(goto('suite-bridge'));
 
     return (
         <Translation
             id="TR_TROUBLESHOOTING_TIP_BRIDGE_USE_DESCRIPTION"
             values={{
                 a: chunks => (
-                    <TrezorLink variant="underline" onClick={() => goto('suite-bridge')}>
+                    <TrezorLink variant="underline" onClick={handleClick}>
                         {chunks}
                     </TrezorLink>
                 ),

--- a/packages/suite/src/components/suite/UdevDownload/index.tsx
+++ b/packages/suite/src/components/suite/UdevDownload/index.tsx
@@ -33,7 +33,7 @@ const LoaderWrapper = styled.div`
 const Manual = styled(Download)`
     margin-top: 24px;
     padding-top: 24px;
-    border-top: 1px solid ${props => props.theme.STROKE_GREY};
+    border-top: 1px solid ${({ theme }) => theme.STROKE_GREY};
 `;
 
 const StyledButton = styled(Button)`

--- a/packages/suite/src/components/suite/VersionWithGithubTooltip.tsx
+++ b/packages/suite/src/components/suite/VersionWithGithubTooltip.tsx
@@ -17,13 +17,13 @@ const VersionButton = styled(Button)<{ isDev?: boolean }>`
     ${({ isDev }) =>
         isDev &&
         css`
-            color: ${props => props.theme.TYPE_WHITE};
-            background: ${props => props.theme.BUTTON_RED};
+            color: ${({ theme }) => theme.TYPE_WHITE};
+            background: ${({ theme }) => theme.BUTTON_RED};
 
             :hover,
             :active,
             :focus {
-                background: ${props => props.theme.BUTTON_RED_HOVER};
+                background: ${({ theme }) => theme.BUTTON_RED_HOVER};
             }
         `};
 `;

--- a/packages/suite/src/components/suite/WelcomeLayout.tsx
+++ b/packages/suite/src/components/suite/WelcomeLayout.tsx
@@ -47,7 +47,7 @@ const MotionWelcome = styled(motion.div)`
     flex-direction: column;
     justify-content: center;
     align-items: center;
-    background: ${props => props.theme.BG_LIGHT_GREY};
+    background: ${({ theme }) => theme.BG_LIGHT_GREY};
     display: flex;
     height: 100%;
     overflow: hidden;
@@ -72,13 +72,13 @@ const Content = styled.div`
     flex-direction: column;
     flex: 3;
     padding: 20px;
-    background-color: ${props => props.theme.BG_GREY};
+    background-color: ${({ theme }) => theme.BG_GREY};
     background-image: url(${resolveStaticPath(`images/svg/${SVG_IMAGES.ONBOARDING_WELCOME_BG}`)});
     background-repeat: no-repeat;
     background-position: center;
     background-attachment: local;
     background-size: 570px 570px;
-    color: ${props => props.theme.TYPE_DARK_GREY};
+    color: ${({ theme }) => theme.TYPE_DARK_GREY};
     align-items: center;
     overflow-y: auto;
 

--- a/packages/suite/src/components/suite/modals/AddAccount/components/AccountTypeDescription.tsx
+++ b/packages/suite/src/components/suite/modals/AddAccount/components/AccountTypeDescription.tsx
@@ -9,7 +9,7 @@ const Info = styled(P).attrs(() => ({
     size: 'small',
     textAlign: 'left',
 }))`
-    color: ${props => props.theme.TYPE_LIGHT_GREY};
+    color: ${({ theme }) => theme.TYPE_LIGHT_GREY};
     margin: 20px 0;
 `;
 

--- a/packages/suite/src/components/suite/modals/AddAccount/components/AccountTypeSelect.tsx
+++ b/packages/suite/src/components/suite/modals/AddAccount/components/AccountTypeSelect.tsx
@@ -17,7 +17,7 @@ const TypeInfo = styled.div`
     padding-top: 2px;
     align-items: center;
     font-size: ${variables.FONT_SIZE.TINY};
-    color: ${props => props.theme.TYPE_LIGHT_GREY};
+    color: ${({ theme }) => theme.TYPE_LIGHT_GREY};
     margin-left: 1ch;
 `;
 

--- a/packages/suite/src/components/suite/modals/AddAccount/components/MoreCoins.tsx
+++ b/packages/suite/src/components/suite/modals/AddAccount/components/MoreCoins.tsx
@@ -158,10 +158,6 @@ const Content = ({ children }: Props) => (
     </motion.div>
 );
 
-interface Props {
-    children: React.ReactNode;
-}
-
 export const MoreCoins = ({ children }: Props) => {
     const [isExpanded, setExpanded] = useState(false);
     return (

--- a/packages/suite/src/components/suite/modals/AddAccount/components/SelectNetwork.tsx
+++ b/packages/suite/src/components/suite/modals/AddAccount/components/SelectNetwork.tsx
@@ -32,7 +32,7 @@ const IconAnimated = styled(Icon)`
     }
 `;
 
-type Props = {
+type SelectNetworkProps = {
     networks: Network[];
     networkCanChange: boolean;
     selectedNetworks: Network['symbol'][];
@@ -44,7 +44,7 @@ export const SelectNetwork = ({
     networkCanChange,
     selectedNetworks,
     handleNetworkSelection,
-}: Props) => {
+}: SelectNetworkProps) => {
     const resetNetworkSelection = () => {
         if (networkCanChange) {
             handleNetworkSelection();

--- a/packages/suite/src/components/suite/modals/AdvancedCoinSettings/components/ConnectionInfo.tsx
+++ b/packages/suite/src/components/suite/modals/AdvancedCoinSettings/components/ConnectionInfo.tsx
@@ -11,14 +11,13 @@ const Wrapper = styled(P)`
     text-align: left;
 `;
 
-interface Props {
+interface ConnectionInfoProps {
     coin: Network['symbol'];
 }
 
-const ConnectionInfo = ({ coin }: Props) => {
-    const { blockchain } = useSelector(state => ({
-        blockchain: state.wallet.blockchain,
-    }));
+const ConnectionInfo = ({ coin }: ConnectionInfoProps) => {
+    const blockchain = useSelector(state => state.wallet.blockchain);
+
     const { connected, url, blockHash: hash, blockHeight: height, version } = blockchain[coin];
     return (
         <Wrapper size="small">

--- a/packages/suite/src/components/suite/modals/AdvancedCoinSettings/components/CustomBackends.tsx
+++ b/packages/suite/src/components/suite/modals/AdvancedCoinSettings/components/CustomBackends.tsx
@@ -3,8 +3,8 @@ import styled from 'styled-components';
 
 import { Input, Button, H3, CollapsibleBox } from '@trezor/components';
 import { Translation, TooltipSymbol } from 'src/components/suite';
-import { useSelector, useActions } from 'src/hooks/suite';
-import { toggleTor as toggleTorAction } from 'src/actions/suite/suiteActions';
+import { useDispatch, useSelector } from 'src/hooks/suite';
+import { toggleTor } from 'src/actions/suite/suiteActions';
 import { useDefaultUrls, useBackendsForm } from 'src/hooks/settings/backends';
 import ConnectionInfo from './ConnectionInfo';
 import { BackendInput } from './BackendInput';
@@ -69,11 +69,8 @@ interface CustomBackendsProps {
 export const CustomBackends = ({ network, onCancel }: CustomBackendsProps) => {
     const { isTorEnabled } = useSelector(selectTorState);
     const blockchain = useSelector(state => state.wallet.blockchain);
+    const dispatch = useDispatch();
     const [torModalOpen, setTorModalOpen] = useState(false);
-
-    const { toggleTor } = useActions({
-        toggleTor: toggleTorAction,
-    });
 
     const { symbol: coin } = network;
 
@@ -100,7 +97,7 @@ export const CustomBackends = ({ network, onCancel }: CustomBackendsProps) => {
     const onTorResult = async (result: TorResult) => {
         switch (result) {
             case 'enable-tor':
-                await toggleTor(true);
+                await dispatch(toggleTor(true));
 
                 setTorModalOpen(false);
                 save();

--- a/packages/suite/src/components/suite/modals/ApplicationLog.tsx
+++ b/packages/suite/src/components/suite/modals/ApplicationLog.tsx
@@ -14,8 +14,8 @@ const LogWrapper = styled.pre`
     height: 380px;
     width: 100%;
     overflow: auto;
-    background-color: ${props => props.theme.BG_LIGHT_GREY};
-    color: ${props => props.theme.TYPE_DARK_GREY};
+    background-color: ${({ theme }) => theme.BG_LIGHT_GREY};
+    color: ${({ theme }) => theme.TYPE_DARK_GREY};
     font-size: ${variables.FONT_SIZE.TINY};
     text-align: left;
     word-break: break-all;
@@ -46,9 +46,7 @@ export const ApplicationLog = ({ onCancel }: ApplicationLogProps) => {
     const [hideSensitiveInfo, setHideSensitiveInfo] = useState(false);
     const logs = useSelector(selectLogs);
 
-    const { state } = useSelector(state => ({
-        state,
-    }));
+    const state = useSelector(state => state);
 
     const actionLog = getApplicationLog(logs, hideSensitiveInfo);
     const applicationInfo = getApplicationInfo(state, hideSensitiveInfo);

--- a/packages/suite/src/components/suite/modals/DisableTor.tsx
+++ b/packages/suite/src/components/suite/modals/DisableTor.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 import styled from 'styled-components';
 import { Button, H3, P, CoinLogo, variables } from '@trezor/components';
 import { Modal, Translation } from 'src/components/suite';
-import { useActions } from 'src/hooks/suite';
+import { useDispatch } from 'src/hooks/suite';
 import { isOnionUrl } from 'src/utils/suite/tor';
 import { useCustomBackends } from 'src/hooks/settings/backends';
 import { getTitleForNetwork } from '@suite-common/wallet-utils';
@@ -17,7 +17,7 @@ const BackendRowWrapper = styled.div`
     align-items: center;
     padding: 12px 0;
     & + & {
-        border-top: 1px solid ${props => props.theme.STROKE_GREY};
+        border-top: 1px solid ${({ theme }) => theme.STROKE_GREY};
     }
 `;
 
@@ -38,7 +38,7 @@ const CoinTitle = styled.span`
 const CoinUrls = styled.span`
     font-weight: ${variables.FONT_WEIGHT.MEDIUM};
     font-size: ${variables.FONT_SIZE.SMALL};
-    color: ${props => props.theme.TYPE_LIGHT_GREY};
+    color: ${({ theme }) => theme.TYPE_LIGHT_GREY};
     white-space: nowrap;
     overflow: hidden;
     width: 100%;
@@ -46,15 +46,13 @@ const CoinUrls = styled.span`
     text-align: start;
 `;
 
-const BackendRow = ({
-    coin,
-    urls,
-    onSettings,
-}: {
+interface BackendRowProps {
     coin: Network['symbol'];
     urls: string[];
     onSettings: () => void;
-}) => (
+}
+
+const BackendRow = ({ coin, urls, onSettings }: BackendRowProps) => (
     <BackendRowWrapper>
         <CoinLogo symbol={coin} />
         <CoinDescription>
@@ -84,19 +82,19 @@ type DisableTorProps = Omit<Extract<UserContextPayload, { type: 'disable-tor' }>
 };
 
 export const DisableTor = ({ onCancel, decision }: DisableTorProps) => {
-    const actions = useActions({
-        setBackend: blockchainActions.setBackend,
-    });
+    const dispatch = useDispatch();
     const [coin, setCoin] = React.useState<Network['symbol']>();
     const onionBackends = useCustomBackends().filter(({ urls }) => urls.every(isOnionUrl));
 
     const onDisableTor = () => {
         onionBackends.forEach(({ coin, type, urls }) =>
-            actions.setBackend({
-                coin,
-                type,
-                urls: urls.filter(url => !isOnionUrl(url)),
-            }),
+            dispatch(
+                blockchainActions.setBackend({
+                    coin,
+                    type,
+                    urls: urls.filter(url => !isOnionUrl(url)),
+                }),
+            ),
         );
         decision.resolve(true);
         onCancel();

--- a/packages/suite/src/components/suite/modals/ImportTransaction/components/DelimiterForm.tsx
+++ b/packages/suite/src/components/suite/modals/ImportTransaction/components/DelimiterForm.tsx
@@ -17,12 +17,12 @@ const Label = styled.span`
     font-weight: ${variables.FONT_WEIGHT.MEDIUM};
 `;
 
-interface Props {
+interface DelimiterFormProps {
     value?: string;
     onChange: (value?: string) => void;
 }
 
-export const DelimiterForm = ({ value, onChange }: Props) => {
+export const DelimiterForm = ({ value, onChange }: DelimiterFormProps) => {
     const [custom, setCustom] = useState(false);
     const inputRef = useRef<HTMLInputElement | null>(null);
 

--- a/packages/suite/src/components/suite/modals/ImportTransaction/components/ExampleCSV.tsx
+++ b/packages/suite/src/components/suite/modals/ImportTransaction/components/ExampleCSV.tsx
@@ -15,7 +15,7 @@ const Wrapper = styled.div`
 
 const ExpandWrapper = styled(motion.div)`
     width: 100%;
-    background: ${props => props.theme.BG_GREY};
+    background: ${({ theme }) => theme.BG_GREY};
     border-radius: 8px;
     overflow: hidden;
     margin-top: 8px;
@@ -26,7 +26,7 @@ const ExpandWrapper = styled(motion.div)`
 const ExpandButton = styled.div`
     display: flex;
     cursor: pointer;
-    color: ${props => props.theme.TYPE_LIGHT_GREY};
+    color: ${({ theme }) => theme.TYPE_LIGHT_GREY};
     font-size: ${variables.FONT_SIZE.SMALL};
     font-weight: 500;
     justify-content: space-between;

--- a/packages/suite/src/components/suite/modals/ImportTransaction/index.tsx
+++ b/packages/suite/src/components/suite/modals/ImportTransaction/index.tsx
@@ -12,12 +12,12 @@ const StyledModal = styled(Modal)`
     width: 600px;
 `;
 
-type Props = {
+type ImportTransactionProps = {
     onCancel: () => any;
     decision: Extract<UserContextPayload, { type: 'import-transaction' }>['decision'];
 };
 
-export const ImportTransaction = ({ onCancel, decision }: Props) => {
+export const ImportTransaction = ({ onCancel, decision }: ImportTransactionProps) => {
     // const [mode, setMode] = useState<'upload' | 'form'>('upload'); // TODO: upload or textarea form? (fallback for upload)
     const [delimiter, setDelimiter] = useState<string | undefined>(undefined);
 

--- a/packages/suite/src/components/suite/modals/Passphrase/index.tsx
+++ b/packages/suite/src/components/suite/modals/Passphrase/index.tsx
@@ -44,11 +44,11 @@ const SmallModal = styled(Modal)`
     width: 600px;
 `;
 
-type Props = {
+interface PassphraseProps {
     device: TrezorDevice;
-};
+}
 
-export const Passphrase = ({ device }: Props) => {
+export const Passphrase = ({ device }: PassphraseProps) => {
     const [submitted, setSubmitted] = useState(false);
     const devices = useSelector(state => state.devices);
     const authConfirmation =

--- a/packages/suite/src/components/suite/modals/Passphrase/index.tsx
+++ b/packages/suite/src/components/suite/modals/Passphrase/index.tsx
@@ -33,7 +33,7 @@ const WalletsWrapper = styled.div`
 const Divider = styled.div`
     margin: 16px 16px;
     height: 1px;
-    background: ${props => props.theme.STROKE_GREY};
+    background: ${({ theme }) => theme.STROKE_GREY};
 `;
 
 const TinyModal = styled(Modal)`

--- a/packages/suite/src/components/suite/modals/PassphraseDuplicate/index.tsx
+++ b/packages/suite/src/components/suite/modals/PassphraseDuplicate/index.tsx
@@ -2,14 +2,9 @@ import React from 'react';
 import styled from 'styled-components';
 import { Button, Image } from '@trezor/components';
 import { Translation, Modal } from 'src/components/suite';
-import * as suiteActions from 'src/actions/suite/suiteActions';
-import { useDevice, useActions } from 'src/hooks/suite';
+import { authorizeDevice, switchDuplicatedDevice } from 'src/actions/suite/suiteActions';
+import { useDevice, useDispatch } from 'src/hooks/suite';
 import { TrezorDevice } from 'src/types/suite';
-
-type Props = {
-    device: TrezorDevice;
-    duplicate: TrezorDevice;
-};
 
 const StyledImage = styled(Image)`
     margin: 14px 0px;
@@ -28,13 +23,20 @@ const StyledModal = styled(Modal)`
     }
 `;
 
-export const PassphraseDuplicate = ({ device, duplicate }: Props) => {
+type PassphraseDuplicateProps = {
+    device: TrezorDevice;
+    duplicate: TrezorDevice;
+};
+
+export const PassphraseDuplicate = ({ device, duplicate }: PassphraseDuplicateProps) => {
+    const dispatch = useDispatch();
     const { isLocked } = useDevice();
+
     const isDeviceLocked = isLocked();
-    const { switchDuplicatedDevice, authorizeDevice } = useActions({
-        switchDuplicatedDevice: suiteActions.switchDuplicatedDevice,
-        authorizeDevice: suiteActions.authorizeDevice,
-    });
+
+    const handleSwitchDevice = () => dispatch(switchDuplicatedDevice(device, duplicate));
+    const handleAuthorizeDevice = () => dispatch(authorizeDevice());
+
     return (
         <StyledModal
             heading={<Translation id="TR_WALLET_DUPLICATE_TITLE" />}
@@ -44,14 +46,14 @@ export const PassphraseDuplicate = ({ device, duplicate }: Props) => {
                 <>
                     <Button
                         variant="primary"
-                        onClick={() => switchDuplicatedDevice(device, duplicate)}
+                        onClick={handleSwitchDevice}
                         isDisabled={isDeviceLocked}
                     >
                         <Translation id="TR_WALLET_DUPLICATE_SWITCH" />
                     </Button>
                     <Button
                         variant="secondary"
-                        onClick={authorizeDevice}
+                        onClick={handleAuthorizeDevice}
                         isDisabled={isDeviceLocked}
                     >
                         <Translation id="TR_WALLET_DUPLICATE_RETRY" />

--- a/packages/suite/src/components/suite/modals/PinMismatch/index.tsx
+++ b/packages/suite/src/components/suite/modals/PinMismatch/index.tsx
@@ -2,8 +2,8 @@ import React from 'react';
 import styled from 'styled-components';
 import { Button, Image } from '@trezor/components';
 import { Translation, Modal, ModalProps } from 'src/components/suite';
-import * as deviceSettingsActions from 'src/actions/settings/deviceSettingsActions';
-import { useActions } from 'src/hooks/suite';
+import { changePin } from 'src/actions/settings/deviceSettingsActions';
+import { useDispatch } from 'src/hooks/suite';
 
 const StyledImage = styled(Image)`
     margin: 48px auto;
@@ -14,9 +14,10 @@ const StyledModal = styled(Modal)`
 `;
 
 export const PinMismatch = (props: ModalProps) => {
-    const { changePin } = useActions({ changePin: deviceSettingsActions.changePin });
+    const dispatch = useDispatch();
+
     const onTryAgain = () => {
-        changePin({});
+        dispatch(changePin({}));
     };
 
     return (

--- a/packages/suite/src/components/suite/modals/QrScanner/index.tsx
+++ b/packages/suite/src/components/suite/modals/QrScanner/index.tsx
@@ -42,7 +42,7 @@ const CameraPlaceholder = styled.div`
     padding: 40px;
     height: 100%;
     border-radius: 16px;
-    background: ${props => props.theme.BG_GREY};
+    background: ${({ theme }) => theme.BG_GREY};
 `;
 
 const Error = styled.div`
@@ -58,7 +58,7 @@ const ErrorTitle = styled(P)`
 `;
 const ErrorMessage = styled.span`
     text-align: center;
-    color: ${props => props.theme.TYPE_DARK_GREY};
+    color: ${({ theme }) => theme.TYPE_DARK_GREY};
 `;
 
 const IconWrapper = styled.div`

--- a/packages/suite/src/components/suite/modals/QrScanner/index.tsx
+++ b/packages/suite/src/components/suite/modals/QrScanner/index.tsx
@@ -95,16 +95,16 @@ const StyledModal = styled(Modal)`
     }
 `;
 
-type Props = Omit<Extract<UserContextPayload, { type: 'qr-reader' }>, 'type'> & {
+interface QrScannerProps extends Omit<Extract<UserContextPayload, { type: 'qr-reader' }>, 'type'> {
     onCancel: () => void;
-};
+}
 
 export interface State {
     readerLoaded: boolean;
     error: JSX.Element | null;
 }
 
-export const QrScanner = ({ onCancel, decision, allowPaste }: Props) => {
+export const QrScanner = ({ onCancel, decision, allowPaste }: QrScannerProps) => {
     const [readerLoaded, setReaderLoaded] = useState<State['readerLoaded']>(false);
     const [error, setError] = useState<State['error']>(null);
     const [isPasteMode, setPasteMode] = useState(false);

--- a/packages/suite/src/components/suite/modals/ReviewTransaction/components/Indicator.tsx
+++ b/packages/suite/src/components/suite/modals/ReviewTransaction/components/Indicator.tsx
@@ -18,12 +18,12 @@ const Dot = styled.div<{ color: string }>`
     background: ${props => props.color};
 `;
 
-export interface Props {
+export interface IndicatorProps {
     state?: 'success' | 'active';
     size?: number;
 }
 
-const Indicator = ({ state, size = 24 }: Props) => {
+const Indicator = ({ state, size = 24 }: IndicatorProps) => {
     const theme = useTheme();
 
     return (

--- a/packages/suite/src/components/suite/modals/ReviewTransaction/components/Output.tsx
+++ b/packages/suite/src/components/suite/modals/ReviewTransaction/components/Output.tsx
@@ -5,7 +5,7 @@ import { formatNetworkAmount, formatAmount, isTestnet } from '@suite-common/wall
 import { BTC_LOCKTIME_VALUE } from '@suite-common/wallet-constants';
 import { Network, NetworkSymbol } from 'src/types/wallet';
 import { TokenInfo } from '@trezor/connect';
-import Indicator, { Props as IndicatorProps } from './Indicator';
+import Indicator, { IndicatorProps } from './Indicator';
 import OutputElement, { OutputElementLine } from './OutputElement';
 import type { Account } from 'src/types/wallet';
 

--- a/packages/suite/src/components/suite/modals/ReviewTransaction/components/Success.tsx
+++ b/packages/suite/src/components/suite/modals/ReviewTransaction/components/Success.tsx
@@ -22,7 +22,7 @@ const IconWrapper = styled.div`
     flex-direction: column;
     align-items: center;
     justify-content: center;
-    border: 2px solid ${props => props.theme.STROKE_LIGHT_GREY};
+    border: 2px solid ${({ theme }) => theme.STROKE_LIGHT_GREY};
     border-radius: 75px;
     padding: 2px 0 0px 2px;
 `;

--- a/packages/suite/src/components/suite/modals/ReviewTransaction/components/Summary.tsx
+++ b/packages/suite/src/components/suite/modals/ReviewTransaction/components/Summary.tsx
@@ -15,7 +15,7 @@ const Wrapper = styled.div`
     display: flex;
     flex-direction: column;
     border-radius: 8px;
-    background: ${props => props.theme.BG_GREY};
+    background: ${({ theme }) => theme.BG_GREY};
     min-width: 190px;
     width: 225px;
     justify-content: flex-start;
@@ -35,7 +35,7 @@ const SummaryHead = styled.div`
 `;
 
 const IconWrapper = styled.div`
-    background-color: ${props => props.theme.BG_WHITE};
+    background-color: ${({ theme }) => theme.BG_WHITE};
     padding: 4px;
     border-radius: 100px;
     position: relative;
@@ -70,7 +70,7 @@ const Headline = styled.div`
 
 const AccountWrapper = styled.div`
     font-size: 12px;
-    color: ${props => props.theme.TYPE_LIGHT_GREY};
+    color: ${({ theme }) => theme.TYPE_LIGHT_GREY};
     display: flex;
     margin-top: 5px;
     word-break: normal;
@@ -82,7 +82,7 @@ const AccountWrapper = styled.div`
 `;
 
 const Separator = styled.div`
-    border-top: 1px solid ${props => props.theme.STROKE_GREY};
+    border-top: 1px solid ${({ theme }) => theme.STROKE_GREY};
     margin: 10px 0 0;
     padding: 0 0 10px;
     width: 100%;
@@ -127,7 +127,7 @@ const TxDetailsButton = styled.button<{ detailsOpen: boolean }>`
     align-items: center;
     justify-content: space-between;
     font-size: 10px;
-    color: ${props => props.theme.TYPE_LIGHT_GREY};
+    color: ${({ theme }) => theme.TYPE_LIGHT_GREY};
     transition: background 0.1s;
     background: ${({ theme, detailsOpen }) =>
         detailsOpen && darken(theme.HOVER_DARKEN_FILTER, theme.STROKE_LIGHT_GREY)};
@@ -169,7 +169,7 @@ const ReviewRbfLeftDetailsLineLeft = styled.div`
     display: flex;
     margin: 0 5% 0 0;
     width: 50%;
-    color: ${props => props.theme.TYPE_LIGHT_GREY};
+    color: ${({ theme }) => theme.TYPE_LIGHT_GREY};
 
     & > div:first-child {
         margin: 1px 5px 0 0;

--- a/packages/suite/src/components/suite/modals/ReviewTransaction/components/Summary.tsx
+++ b/packages/suite/src/components/suite/modals/ReviewTransaction/components/Summary.tsx
@@ -189,7 +189,7 @@ const ReviewRbfLeftDetailsLineRight = styled.div<{ color: string; uppercase?: bo
   `};
 `;
 
-interface Props {
+interface SummaryProps {
     estimateTime?: number;
     tx: PrecomposedTransactionFinal | TxFinalCardano;
     account: Account;
@@ -209,7 +209,7 @@ const Summary = ({
     detailsOpen,
     isRbfAction,
     onDetailsClick,
-}: Props) => {
+}: SummaryProps) => {
     const drafts = useSelector(state => state.wallet.send.drafts);
     const currentAccountKey = useSelector(
         state => state.wallet.selectedAccount.account?.key,

--- a/packages/suite/src/components/suite/modals/ReviewTransaction/index.tsx
+++ b/packages/suite/src/components/suite/modals/ReviewTransaction/index.tsx
@@ -2,9 +2,9 @@ import React, { useState } from 'react';
 import styled from 'styled-components';
 import { ConfirmOnDevice, variables } from '@trezor/components';
 import { Translation, Modal } from 'src/components/suite';
-import { useActions, useSelector } from 'src/hooks/suite';
+import { useDispatch, useSelector } from 'src/hooks/suite';
 import { UserContextPayload } from 'src/actions/suite/modalActions';
-import * as sendFormActions from 'src/actions/wallet/sendFormActions';
+import { cancelSignTx } from 'src/actions/wallet/sendFormActions';
 import OutputList from './components/OutputList';
 import Summary from './components/Summary';
 import { isCardanoTx } from 'src/utils/wallet/cardanoUtils';
@@ -36,10 +36,7 @@ export const ReviewTransaction = ({ decision }: ReviewTransactionProps) => {
     const fees = useSelector(state => state.wallet.fees);
     const device = useSelector(selectDevice);
     const isActionAbortable = useSelector(selectIsActionAbortable);
-
-    const { cancelSignTx } = useActions({
-        cancelSignTx: sendFormActions.cancelSignTx,
-    });
+    const dispatch = useDispatch();
 
     const [detailsOpen, setDetailsOpen] = useState(false);
 
@@ -103,7 +100,7 @@ export const ReviewTransaction = ({ decision }: ReviewTransactionProps) => {
     const onCancel =
         isActionAbortable || signedTx
             ? () => {
-                  cancelSignTx();
+                  dispatch(cancelSignTx());
                   decision?.resolve(false);
               }
             : undefined;

--- a/packages/suite/src/components/suite/modals/SafetyChecks/index.tsx
+++ b/packages/suite/src/components/suite/modals/SafetyChecks/index.tsx
@@ -1,9 +1,9 @@
 import React, { useState } from 'react';
 import styled from 'styled-components';
-import { useActions, useDevice } from 'src/hooks/suite';
+import { useDevice, useDispatch } from 'src/hooks/suite';
 import { RadioButton, Button, H3, P, Warning } from '@trezor/components';
 import { Translation, Modal, ModalProps } from 'src/components/suite';
-import * as deviceSettingsActions from 'src/actions/settings/deviceSettingsActions';
+import { applySettings } from 'src/actions/settings/deviceSettingsActions';
 
 const StyledButton = styled(Button)`
     min-width: 230px;
@@ -36,8 +36,10 @@ const StyledWarning = styled(Warning)`
  */
 export const SafetyChecks = ({ onCancel }: ModalProps) => {
     const { device, isLocked } = useDevice();
-    const { applySettings } = useActions({ applySettings: deviceSettingsActions.applySettings });
     const [level, setLevel] = useState(device?.features?.safety_checks || undefined);
+    const dispatch = useDispatch();
+
+    const confirm = () => dispatch(applySettings({ safety_checks: level }));
 
     return (
         <Modal
@@ -46,9 +48,7 @@ export const SafetyChecks = ({ onCancel }: ModalProps) => {
             heading={<Translation id="TR_SAFETY_CHECKS_MODAL_TITLE" />}
             bottomBar={
                 <StyledButton
-                    onClick={() => {
-                        applySettings({ safety_checks: level });
-                    }}
+                    onClick={confirm}
                     // Only allow confirming when the value will be changed.
                     isDisabled={isLocked() || level === device?.features?.safety_checks}
                     data-test="@safety-checks-apply"

--- a/packages/suite/src/components/suite/modals/TransactionDetail/components/ChainedTxs.tsx
+++ b/packages/suite/src/components/suite/modals/TransactionDetail/components/ChainedTxs.tsx
@@ -19,7 +19,7 @@ const ChainedTransactionItem = styled(TransactionItem)`
     padding: 0px 40px;
     cursor: pointer;
     &:hover {
-        background: ${props => props.theme.BG_GREY};
+        background: ${({ theme }) => theme.BG_GREY};
     }
 `;
 

--- a/packages/suite/src/components/suite/modals/TransactionDetail/components/ChangeFee/components/AffectedTransactions.tsx
+++ b/packages/suite/src/components/suite/modals/TransactionDetail/components/ChangeFee/components/AffectedTransactions.tsx
@@ -15,7 +15,7 @@ const ChainedTxs = styled.div`
     flex-direction: column;
     padding-top: 24px;
     margin-top: 24px;
-    border-top: 1px solid ${props => props.theme.STROKE_GREY};
+    border-top: 1px solid ${({ theme }) => theme.STROKE_GREY};
 `;
 
 const TxRow = styled.div`
@@ -29,7 +29,7 @@ const IconWrapper = styled.div`
 `;
 
 const Text = styled.span`
-    color: ${props => props.theme.TYPE_LIGHT_GREY};
+    color: ${({ theme }) => theme.TYPE_LIGHT_GREY};
     font-weight: ${variables.FONT_WEIGHT.MEDIUM};
     font-size: ${variables.FONT_SIZE.SMALL};
     font-variant-numeric: tabular-nums;
@@ -55,7 +55,7 @@ const Amount = styled(Text)`
 const Bullet = styled.div`
     margin-left: 8px;
     margin-right: 8px;
-    color: ${props => props.theme.TYPE_LIGHT_GREY};
+    color: ${({ theme }) => theme.TYPE_LIGHT_GREY};
 `;
 
 export const AffectedTransactions = ({ showChained }: { showChained: () => void }) => {

--- a/packages/suite/src/components/suite/modals/TransactionDetail/components/ChangeFee/components/DecreasedOutputs.tsx
+++ b/packages/suite/src/components/suite/modals/TransactionDetail/components/ChangeFee/components/DecreasedOutputs.tsx
@@ -13,7 +13,7 @@ const OutputsWrapper = styled.div`
     flex-direction: column;
     padding-top: 12px;
     margin-top: 24px;
-    border-top: 1px solid ${props => props.theme.STROKE_GREY};
+    border-top: 1px solid ${({ theme }) => theme.STROKE_GREY};
 `;
 
 const Output = styled.div`
@@ -34,14 +34,14 @@ const OutputLabel = styled.div<{ isChecked: boolean }>`
     line-height: 24px; /* icon height */
     font-weight: ${$props =>
         $props.isChecked ? variables.FONT_WEIGHT.DEMI_BOLD : variables.FONT_WEIGHT.MEDIUM};
-    color: ${$props => ($props.isChecked ? $props.theme.TYPE_GREEN : 'inherit')};
+    color: ${({ isChecked, theme }) => (isChecked ? theme.TYPE_GREEN : 'inherit')};
 `;
 
 const OutputAddress = styled.div<{ isChecked: boolean }>`
     font-size: ${variables.FONT_SIZE.TINY};
     font-weight: ${$props =>
         $props.isChecked ? variables.FONT_WEIGHT.DEMI_BOLD : variables.FONT_WEIGHT.MEDIUM};
-    color: ${$props => ($props.isChecked ? $props.theme.TYPE_DARK_GREY : 'inherit')};
+    color: ${({ isChecked, theme }) => (isChecked ? theme.TYPE_DARK_GREY : 'inherit')};
     padding-top: 2px;
 `;
 
@@ -53,7 +53,7 @@ const ReducedAmount = styled.span`
 const ArrowIcon = styled(Icon)`
     margin: 0px 8px;
     & svg {
-        fill: ${$props => $props.theme.TYPE_GREEN};
+        fill: ${({ theme }) => theme.TYPE_GREEN};
     }
 `;
 

--- a/packages/suite/src/components/suite/modals/TransactionDetail/components/ChangeFee/components/GreyCard.tsx
+++ b/packages/suite/src/components/suite/modals/TransactionDetail/components/ChangeFee/components/GreyCard.tsx
@@ -6,7 +6,7 @@ const Wrapper = styled(Card)`
     display: flex;
     flex-direction: column;
     text-align: left;
-    background-color: ${props => props.theme.BG_GREY};
+    background-color: ${({ theme }) => theme.BG_GREY};
     margin-left: -10px;
     margin-right: -10px;
     margin-top: 12px;

--- a/packages/suite/src/components/suite/modals/TransactionDetail/components/ChangeFee/components/WarnHeader.tsx
+++ b/packages/suite/src/components/suite/modals/TransactionDetail/components/ChangeFee/components/WarnHeader.tsx
@@ -5,7 +5,7 @@ import { Icon, useTheme, variables } from '@trezor/components';
 const Header = styled.div`
     display: flex;
     margin-top: 4px;
-    color: ${props => props.theme.TYPE_ORANGE};
+    color: ${({ theme }) => theme.TYPE_ORANGE};
     font-weight: ${variables.FONT_WEIGHT.DEMI_BOLD};
     font-size: ${variables.FONT_SIZE.TINY};
     align-items: center;

--- a/packages/suite/src/components/suite/modals/TransactionDetail/components/ChangeFee/components/WarnHeader.tsx
+++ b/packages/suite/src/components/suite/modals/TransactionDetail/components/ChangeFee/components/WarnHeader.tsx
@@ -20,12 +20,12 @@ const Body = styled.div`
     flex: 1;
 `;
 
-interface Props {
+interface WarnHeaderProps {
     action?: React.ReactNode;
     children?: React.ReactNode;
 }
 
-export const WarnHeader = (props: Props) => {
+export const WarnHeader = (props: WarnHeaderProps) => {
     const theme = useTheme();
 
     return (

--- a/packages/suite/src/components/suite/modals/TransactionDetail/components/ChangeFee/index.tsx
+++ b/packages/suite/src/components/suite/modals/TransactionDetail/components/ChangeFee/index.tsx
@@ -17,14 +17,14 @@ const Box = styled.div`
     display: flex;
     flex-direction: column;
     padding: 18px 26px;
-    border: 1px solid ${props => props.theme.STROKE_GREY};
+    border: 1px solid ${({ theme }) => theme.STROKE_GREY};
     border-radius: 8px;
 `;
 
 const Inner = styled.div`
     display: flex;
     & + & {
-        border-top: 1px solid ${props => props.theme.STROKE_GREY};
+        border-top: 1px solid ${({ theme }) => theme.STROKE_GREY};
         margin-top: 28px;
         padding-top: 22px;
     }
@@ -51,7 +51,7 @@ const RateWrapper = styled.div`
 const Rate = styled.div`
     margin: 1px 20px 0 0;
     font-size: ${variables.NEUE_FONT_SIZE.SMALL};
-    color: ${props => props.theme.TYPE_LIGHT_GREY};
+    color: ${({ theme }) => theme.TYPE_LIGHT_GREY};
 `;
 
 const Amount = styled.div`
@@ -71,7 +71,7 @@ const StyledCryptoAmount = styled.div`
 
 const StyledFiatValue = styled.div`
     font-size: ${variables.NEUE_FONT_SIZE.SMALL};
-    color: ${props => props.theme.TYPE_LIGHT_GREY};
+    color: ${({ theme }) => theme.TYPE_LIGHT_GREY};
 `;
 
 const FinalizeWarning = styled(Card)`
@@ -83,8 +83,8 @@ const FinalizeWarning = styled(Card)`
     text-align: center;
     align-items: center;
     justify-content: center;
-    color: ${props => props.theme.TYPE_DARK_GREY};
-    background: ${props => props.theme.BG_GREY};
+    color: ${({ theme }) => theme.TYPE_DARK_GREY};
+    background: ${({ theme }) => theme.BG_GREY};
     font-size: ${variables.NEUE_FONT_SIZE.SMALL};
     font-weight: ${variables.FONT_WEIGHT.MEDIUM};
 `;
@@ -95,7 +95,7 @@ const InfoIcon = styled(Icon)`
 
 const Red = styled.span`
     margin-left: 2px;
-    color: ${props => props.theme.TYPE_RED};
+    color: ${({ theme }) => theme.TYPE_RED};
     font-weight: ${variables.FONT_WEIGHT.BOLD};
 `;
 

--- a/packages/suite/src/components/suite/modals/TransactionDetail/index.tsx
+++ b/packages/suite/src/components/suite/modals/TransactionDetail/index.tsx
@@ -77,10 +77,8 @@ type TransactionDetailProps = {
 };
 
 export const TransactionDetail = ({ tx, rbfForm, onCancel }: TransactionDetailProps) => {
-    const { blockchain, transactions } = useSelector(state => ({
-        blockchain: state.wallet.blockchain[tx.symbol],
-        transactions: state.wallet.transactions.transactions,
-    }));
+    const blockchain = useSelector(state => state.wallet.blockchain[tx.symbol]);
+    const transactions = useSelector(state => state.wallet.transactions.transactions);
 
     const [section, setSection] = useState<'CHANGE_FEE' | 'DETAILS'>(
         rbfForm ? 'CHANGE_FEE' : 'DETAILS',

--- a/packages/suite/src/components/suite/modals/WipeDevice/index.tsx
+++ b/packages/suite/src/components/suite/modals/WipeDevice/index.tsx
@@ -2,8 +2,8 @@ import React, { useState } from 'react';
 import styled from 'styled-components';
 import { Button, Image } from '@trezor/components';
 import { Translation, CheckItem, Modal } from 'src/components/suite';
-import * as deviceSettingsActions from 'src/actions/settings/deviceSettingsActions';
-import { useDevice, useActions } from 'src/hooks/suite';
+import { wipeDevice } from 'src/actions/settings/deviceSettingsActions';
+import { useDevice, useDispatch } from 'src/hooks/suite';
 
 const Row = styled.div`
     display: flex;
@@ -41,9 +41,12 @@ type WipeDeviceProps = {
 export const WipeDevice = ({ onCancel }: WipeDeviceProps) => {
     const [checkbox1, setCheckbox1] = useState(false);
     const [checkbox2, setCheckbox2] = useState(false);
-    const { wipeDevice } = useActions({ wipeDevice: deviceSettingsActions.wipeDevice });
+
+    const dispatch = useDispatch();
 
     const { isLocked } = useDevice();
+
+    const handleWipeDevice = () => dispatch(wipeDevice());
 
     return (
         <StyledModal
@@ -54,7 +57,7 @@ export const WipeDevice = ({ onCancel }: WipeDeviceProps) => {
             bottomBar={
                 <Button
                     variant="danger"
-                    onClick={wipeDevice}
+                    onClick={handleWipeDevice}
                     isDisabled={isLocked() || !checkbox1 || !checkbox2}
                     data-test="@wipe/wipe-button"
                 >

--- a/packages/suite/src/components/suite/modals/confirm/Address/components/DeviceDisconnected.tsx
+++ b/packages/suite/src/components/suite/modals/confirm/Address/components/DeviceDisconnected.tsx
@@ -7,7 +7,7 @@ import { Translation } from 'src/components/suite';
 const Wrapper = styled.div`
     display: flex;
     text-align: left;
-    background: ${props => props.theme.BG_GREY};
+    background: ${({ theme }) => theme.BG_GREY};
     align-items: center;
     border-radius: 8px;
     width: 100%;

--- a/packages/suite/src/components/suite/modals/confirm/CoinmarketLeaveSpend/index.tsx
+++ b/packages/suite/src/components/suite/modals/confirm/CoinmarketLeaveSpend/index.tsx
@@ -1,10 +1,10 @@
 import { Button, H3 } from '@trezor/components';
 import React from 'react';
-import * as routerActions from 'src/actions/suite/routerActions';
-import { useActions } from 'src/hooks/suite';
+import { goto } from 'src/actions/suite/routerActions';
+import { useDispatch } from 'src/hooks/suite';
 import { Translation, Modal } from 'src/components/suite';
 import styled from 'styled-components';
-import * as coinmarketSellActions from 'src/actions/wallet/coinmarketSellActions';
+import { setShowLeaveModal } from 'src/actions/wallet/coinmarketSellActions';
 
 const Text = styled(H3)`
     display: flex;
@@ -12,18 +12,24 @@ const Text = styled(H3)`
     padding: 10px 0;
     align-items: center;
     justify-content: center;
-    color: ${props => props.theme.TYPE_DARK_GREY};
+    color: ${({ theme }) => theme.TYPE_DARK_GREY};
 `;
 
-export type Props = {
+export type CoinmarketLeaveSpendProps = {
     onCancel: () => void;
 };
 
-export const CoinmarketLeaveSpend = ({ onCancel }: Props) => {
-    const { goto, setShowLeaveModal } = useActions({
-        goto: routerActions.goto,
-        setShowLeaveModal: coinmarketSellActions.setShowLeaveModal,
-    });
+export const CoinmarketLeaveSpend = ({ onCancel }: CoinmarketLeaveSpendProps) => {
+    const dispatch = useDispatch();
+
+    const leave = () => {
+        onCancel();
+        dispatch(setShowLeaveModal(false));
+    };
+    const stay = () => {
+        onCancel();
+        dispatch(goto('wallet-coinmarket-spend'));
+    };
 
     return (
         <Modal
@@ -31,20 +37,10 @@ export const CoinmarketLeaveSpend = ({ onCancel }: Props) => {
             onCancel={onCancel}
             bottomBar={
                 <>
-                    <Button
-                        onClick={() => {
-                            onCancel();
-                            setShowLeaveModal(false);
-                        }}
-                    >
+                    <Button onClick={leave}>
                         <Translation id="TR_SPEND_LEAVE" />
                     </Button>
-                    <Button
-                        onClick={() => {
-                            onCancel();
-                            goto('wallet-coinmarket-spend');
-                        }}
-                    >
+                    <Button onClick={stay}>
                         <Translation id="TR_SPEND_STAY" />
                     </Button>
                 </>

--- a/packages/suite/src/components/suite/modals/confirm/CoinmarketTermsModal/index.tsx
+++ b/packages/suite/src/components/suite/modals/confirm/CoinmarketTermsModal/index.tsx
@@ -60,7 +60,7 @@ const FooterContent = styled.div`
     place-content: center;
 `;
 
-export type Props = {
+export type CoinmarketTermsModalProps = {
     decision: Deferred<boolean>;
     onCancel: () => void;
     type: 'BUY' | 'SELL' | 'EXCHANGE' | 'EXCHANGE_DEX' | 'SAVINGS' | 'P2P';
@@ -77,7 +77,7 @@ export const CoinmarketTermsModal = ({
     cryptoCurrency,
     toCryptoCurrency,
     fromCryptoCurrency,
-}: Props) => {
+}: CoinmarketTermsModalProps) => {
     const providerName = provider || 'unknown provider';
     const lowercaseType = type.toLowerCase();
     return (

--- a/packages/suite/src/components/suite/modals/metadata/MetadataProvider/index.tsx
+++ b/packages/suite/src/components/suite/modals/metadata/MetadataProvider/index.tsx
@@ -3,8 +3,8 @@ import styled from 'styled-components';
 import { P, Button, variables } from '@trezor/components';
 
 import { Translation, Modal } from 'src/components/suite';
-import { useActions } from 'src/hooks/suite';
-import * as metadataActions from 'src/actions/suite/metadataActions';
+import { useDispatch } from 'src/hooks/suite';
+import { connectProvider } from 'src/actions/suite/metadataActions';
 import type { Deferred } from '@trezor/utils';
 import { MetadataProviderType } from 'src/types/suite/metadata';
 import { isFeatureFlagEnabled } from '@suite-common/suite-utils';
@@ -14,7 +14,7 @@ const { FONT_SIZE, FONT_WEIGHT, SCREEN_SIZE } = variables;
 const Error = styled.div`
     margin-top: 8px;
     font-size: ${FONT_SIZE.TINY};
-    color: ${props => props.theme.TYPE_RED};
+    color: ${({ theme }) => theme.TYPE_RED};
 `;
 
 // todo: can't use button from @trezor/components directly, probably inconsistent design again
@@ -23,7 +23,7 @@ const StyledButton = styled(Button)`
     padding: 10px;
     margin: 0 16px;
     font-size: ${FONT_SIZE.NORMAL};
-    background-color: ${props => props.theme.BG_GREY};
+    background-color: ${({ theme }) => theme.BG_GREY};
     font-weight: ${FONT_WEIGHT.DEMI_BOLD};
     height: 42px;
 
@@ -34,7 +34,7 @@ const StyledButton = styled(Button)`
 
 // todo: typography shall be unified and these ad hoc styles removed..
 const StyledP = styled(P)`
-    color: ${props => props.theme.TYPE_DARK_GREY};
+    color: ${({ theme }) => theme.TYPE_DARK_GREY};
     margin-bottom: 25px;
     font-size: ${FONT_SIZE.SMALL};
     font-weight: ${FONT_WEIGHT.REGULAR};
@@ -53,7 +53,8 @@ export const MetadataProvider = ({ onCancel, decision }: MetadataProviderProps) 
     const [isLoading, setIsLoading] = useState('');
     // error from authorization popup
     const [error, setError] = useState('');
-    const { connectProvider } = useActions({ connectProvider: metadataActions.connectProvider });
+
+    const dispatch = useDispatch();
 
     const onModalCancel = () => {
         decision.resolve(false);
@@ -62,7 +63,7 @@ export const MetadataProvider = ({ onCancel, decision }: MetadataProviderProps) 
 
     const connect = async (type: MetadataProviderType) => {
         setIsLoading(type);
-        const result = await connectProvider(type);
+        const result = await dispatch(connectProvider(type));
         // window close indicates user action, user knows what happened, no need to show an error message
         if (result === 'window closed') {
             setIsLoading('');

--- a/packages/suite/src/components/wallet/AccountAnnouncement/TorDisconnected.tsx
+++ b/packages/suite/src/components/wallet/AccountAnnouncement/TorDisconnected.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { NotificationCard, Translation } from 'src/components/suite';
-import { useActions, useSelector } from 'src/hooks/suite';
-import * as suiteActions from 'src/actions/suite/suiteActions';
+import { useDispatch, useSelector } from 'src/hooks/suite';
+import { toggleTor } from 'src/actions/suite/suiteActions';
 import { selectTorState } from 'src/reducers/suite/suiteReducer';
 import { selectIsCoinjoinBlockedByTor } from 'src/reducers/wallet/coinjoinReducer';
 import { selectSelectedAccount } from 'src/reducers/wallet/selectedAccountReducer';
@@ -10,17 +10,17 @@ export const TorDisconnected = () => {
     const account = useSelector(selectSelectedAccount);
     const { isTorLoading } = useSelector(selectTorState);
     const isCoinjoinBlockedByTor = useSelector(selectIsCoinjoinBlockedByTor);
-    const { toggleTor } = useActions({
-        toggleTor: suiteActions.toggleTor,
-    });
+    const dispatch = useDispatch();
 
     if (account?.accountType !== 'coinjoin' || !isCoinjoinBlockedByTor) return null;
+
+    const handleButtonClick = () => dispatch(toggleTor(true));
 
     return (
         <NotificationCard
             variant="warning"
             button={{
-                onClick: () => toggleTor(true),
+                onClick: handleButtonClick,
                 isLoading: isTorLoading,
                 children: isTorLoading ? (
                     <Translation id="TR_ENABLING_TOR" />

--- a/packages/suite/src/components/wallet/AccountException/AccountNotEnabled.tsx
+++ b/packages/suite/src/components/wallet/AccountException/AccountNotEnabled.tsx
@@ -1,11 +1,11 @@
 import React from 'react';
-import * as walletSettingsActions from 'src/actions/settings/walletSettingsActions';
-import { useDevice, useActions } from 'src/hooks/suite';
+import { changeCoinVisibility } from 'src/actions/settings/walletSettingsActions';
+import { useDevice, useDispatch } from 'src/hooks/suite';
 import { Network } from 'src/types/wallet';
 import { Translation } from 'src/components/suite';
 import { AccountExceptionLayout } from 'src/components/wallet';
 
-interface Props {
+interface AccountNotEnabledProps {
     network: Network;
 }
 
@@ -13,12 +13,11 @@ interface Props {
  * Handler for invalid router params, coin is not enabled in settings
  * see: @wallet-actions/selectedAccountActions
  */
-const AccountNotEnabled = (props: Props) => {
-    const { network } = props;
+const AccountNotEnabled = ({ network }: AccountNotEnabledProps) => {
+    const dispatch = useDispatch();
     const { isLocked } = useDevice();
-    const { changeCoinVisibility } = useActions({
-        changeCoinVisibility: walletSettingsActions.changeCoinVisibility,
-    });
+
+    const handleClick = () => dispatch(changeCoinVisibility(network.symbol, true));
 
     return (
         <AccountExceptionLayout
@@ -34,7 +33,7 @@ const AccountNotEnabled = (props: Props) => {
                     icon: 'PLUS',
                     key: '1',
                     isLoading: isLocked(),
-                    onClick: () => changeCoinVisibility(network.symbol, true),
+                    onClick: handleClick,
                     children: (
                         <Translation
                             id="TR_ENABLE_NETWORK_BUTTON"

--- a/packages/suite/src/components/wallet/AccountException/AccountNotLoaded.tsx
+++ b/packages/suite/src/components/wallet/AccountException/AccountNotLoaded.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
-import * as discoveryActions from 'src/actions/wallet/discoveryActions';
-import { useDevice, useActions } from 'src/hooks/suite';
+import { restart } from 'src/actions/wallet/discoveryActions';
+import { useDevice, useDispatch } from 'src/hooks/suite';
 import { Translation } from 'src/components/suite';
 import { AccountExceptionLayout } from 'src/components/wallet';
 
@@ -11,10 +11,10 @@ import { AccountExceptionLayout } from 'src/components/wallet';
  * - Other @trezor/connect runtime error
  */
 const AccountNotLoaded = () => {
+    const dispatch = useDispatch();
     const { isLocked } = useDevice();
-    const { restart } = useActions({
-        restart: discoveryActions.restart,
-    });
+
+    const handleClick = () => dispatch(restart());
 
     return (
         <AccountExceptionLayout
@@ -26,7 +26,7 @@ const AccountNotLoaded = () => {
                     key: '1',
                     icon: 'REFRESH',
                     isLoading: isLocked(),
-                    onClick: restart,
+                    onClick: handleClick,
                     children: <Translation id="TR_RETRY" />,
                 },
             ]}

--- a/packages/suite/src/components/wallet/AccountException/AuthFailed.tsx
+++ b/packages/suite/src/components/wallet/AccountException/AuthFailed.tsx
@@ -1,14 +1,15 @@
 import React from 'react';
-import * as suiteActions from 'src/actions/suite/suiteActions';
-import { useDevice, useActions } from 'src/hooks/suite';
+import { authorizeDevice } from 'src/actions/suite/suiteActions';
+import { useDevice, useDispatch } from 'src/hooks/suite';
 import { Translation } from 'src/components/suite';
 import { AccountExceptionLayout } from 'src/components/wallet';
 
 const AuthFailed = () => {
+    const dispatch = useDispatch();
     const { isLocked } = useDevice();
-    const { authDevice } = useActions({
-        authDevice: suiteActions.authorizeDevice,
-    });
+
+    const handleClick = () => dispatch(authorizeDevice());
+
     return (
         <AccountExceptionLayout
             title={<Translation id="TR_ACCOUNT_EXCEPTION_AUTH_ERROR" />}
@@ -19,7 +20,7 @@ const AuthFailed = () => {
                     key: '1',
                     icon: 'REFRESH',
                     isLoading: isLocked(),
-                    onClick: authDevice,
+                    onClick: handleClick,
                     children: <Translation id="TR_RETRY" />,
                 },
             ]}

--- a/packages/suite/src/components/wallet/AccountException/DiscoveryEmpty.tsx
+++ b/packages/suite/src/components/wallet/AccountException/DiscoveryEmpty.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
-import * as modalActions from 'src/actions/suite/modalActions';
-import * as routerActions from 'src/actions/suite/routerActions';
-import { useDevice, useActions } from 'src/hooks/suite';
+import { openModal } from 'src/actions/suite/modalActions';
+import { goto } from 'src/actions/suite/routerActions';
+import { useDevice, useDispatch } from 'src/hooks/suite';
 import { Translation } from 'src/components/suite';
 import { AccountExceptionLayout } from 'src/components/wallet';
 
@@ -10,14 +10,19 @@ import { AccountExceptionLayout } from 'src/components/wallet';
  * see: @wallet-actions/selectedAccountActions
  */
 const DiscoveryEmpty = () => {
+    const dispatch = useDispatch();
     const { device, isLocked } = useDevice();
-    const { openModal, goto } = useActions({
-        openModal: modalActions.openModal,
-        goto: routerActions.goto,
-    });
 
     const isDeviceLocked = isLocked();
     const isDisabled = !device || !device.connected || device.authFailed || device.authConfirm;
+
+    const goToCoinsSettings = () => dispatch(goto('settings-coins'));
+    const addAccount = () =>
+        openModal({
+            type: 'add-account',
+            device: device!,
+        });
+
     return (
         <AccountExceptionLayout
             title={<Translation id="TR_ACCOUNT_EXCEPTION_DISCOVERY_EMPTY" />}
@@ -29,18 +34,14 @@ const DiscoveryEmpty = () => {
                     variant: 'secondary',
                     isLoading: isDeviceLocked,
                     isDisabled,
-                    onClick: () => goto('settings-coins'),
+                    onClick: goToCoinsSettings,
                     children: <Translation id="TR_COIN_SETTINGS" />,
                 },
                 {
                     key: '2',
                     isLoading: isDeviceLocked,
                     isDisabled,
-                    onClick: () =>
-                        openModal({
-                            type: 'add-account',
-                            device: device!,
-                        }),
+                    onClick: addAccount,
                     children: <Translation id="TR_ADD_ACCOUNT" />,
                 },
             ]}

--- a/packages/suite/src/components/wallet/AccountException/DiscoveryFailed.tsx
+++ b/packages/suite/src/components/wallet/AccountException/DiscoveryFailed.tsx
@@ -1,18 +1,18 @@
 import React from 'react';
 import { Translation } from 'src/components/suite';
 import { AccountExceptionLayout } from 'src/components/wallet';
-import { useDiscovery, useActions } from 'src/hooks/suite';
-import * as discoveryActions from 'src/actions/wallet/discoveryActions';
+import { useDiscovery, useDispatch } from 'src/hooks/suite';
+import { restart } from 'src/actions/wallet/discoveryActions';
 
 /**
  * Handler for discovery "hard" error (other than bundle-error)
  * see: @wallet-actions/selectedAccountActions
  */
 const DiscoveryFailed = () => {
+    const dispatch = useDispatch();
     const { discovery } = useDiscovery();
-    const { restart } = useActions({
-        restart: discoveryActions.restart,
-    });
+
+    const handleClick = () => dispatch(restart());
 
     return (
         <AccountExceptionLayout
@@ -23,7 +23,7 @@ const DiscoveryFailed = () => {
                 {
                     key: '1',
                     icon: 'REFRESH',
-                    onClick: restart,
+                    onClick: handleClick,
                     children: <Translation id="TR_RETRY" />,
                 },
             ]}

--- a/packages/suite/src/components/wallet/AccountException/index.tsx
+++ b/packages/suite/src/components/wallet/AccountException/index.tsx
@@ -20,7 +20,7 @@ const Wrapper = styled.div`
 const Title = styled(H2)`
     display: flex;
     text-align: center;
-    color: ${props => props.theme.TYPE_DARK_GREY};
+    color: ${({ theme }) => theme.TYPE_DARK_GREY};
 `;
 
 const getExceptionPage = (

--- a/packages/suite/src/components/wallet/AccountExceptionLayout/index.tsx
+++ b/packages/suite/src/components/wallet/AccountExceptionLayout/index.tsx
@@ -49,7 +49,7 @@ const Divider = styled.div`
     margin: 30px 0px 36px 0px;
 `;
 
-interface Props {
+interface AccountExceptionLayoutProps {
     title: JSX.Element | string;
     description?: JSX.Element | string;
     image?: Extract<ImageProps, { image: any }>['image'];
@@ -58,7 +58,7 @@ interface Props {
     actionComponent?: JSX.Element;
 }
 
-const AccountExceptionLayout = (props: Props) => (
+const AccountExceptionLayout = (props: AccountExceptionLayoutProps) => (
     <StyledCard>
         {props.image && <StyledImage image={props.image} />}
         {props.imageComponent && props.imageComponent}

--- a/packages/suite/src/components/wallet/AccountExceptionLayout/index.tsx
+++ b/packages/suite/src/components/wallet/AccountExceptionLayout/index.tsx
@@ -17,7 +17,7 @@ const Description = styled.span`
     font-size: ${variables.FONT_SIZE.NORMAL};
     font-weight: 500;
     text-align: center;
-    color: ${props => props.theme.TYPE_LIGHT_GREY};
+    color: ${({ theme }) => theme.TYPE_LIGHT_GREY};
 `;
 
 const StyledImage = styled(props => <Image {...props} />)`
@@ -45,7 +45,7 @@ const ActionButton = styled(Button)`
 const Divider = styled.div`
     width: 100%;
     height: 1px;
-    background: ${props => props.theme.STROKE_GREY};
+    background: ${({ theme }) => theme.STROKE_GREY};
     margin: 30px 0px 36px 0px;
 `;
 

--- a/packages/suite/src/components/wallet/AccountMode/AuthConfirmFailed.tsx
+++ b/packages/suite/src/components/wallet/AccountMode/AuthConfirmFailed.tsx
@@ -1,21 +1,21 @@
 import React from 'react';
 import { NotificationCard, Translation } from 'src/components/suite';
-import * as suiteActions from 'src/actions/suite/suiteActions';
-import { useDevice, useActions } from 'src/hooks/suite';
+import { authConfirm } from 'src/actions/suite/suiteActions';
+import { useDevice, useDispatch } from 'src/hooks/suite';
 
 const AuthConfirmFailed = () => {
+    const dispatch = useDispatch();
     const { device, isLocked } = useDevice();
-    const { authConfirm } = useActions({
-        authConfirm: suiteActions.authConfirm,
-    });
 
     if (!device?.connected || !device.authConfirm) return null;
+
+    const handleClick = () => dispatch(authConfirm());
 
     return (
         <NotificationCard
             variant="warning"
             button={{
-                onClick: authConfirm,
+                onClick: handleClick,
                 isLoading: isLocked(),
                 icon: 'REFRESH',
                 'data-test': '@passphrase-mismatch/retry-button',

--- a/packages/suite/src/components/wallet/AccountMode/BackendDisconnected.tsx
+++ b/packages/suite/src/components/wallet/AccountMode/BackendDisconnected.tsx
@@ -57,11 +57,9 @@ const DisconnectedNotification = ({
 };
 
 const Disconnected = () => {
-    const { blockchain, selectedAccount, online } = useSelector(state => ({
-        blockchain: state.wallet.blockchain,
-        selectedAccount: state.wallet.selectedAccount,
-        online: state.suite.online,
-    }));
+    const blockchain = useSelector(state => state.wallet.blockchain);
+    const selectedAccount = useSelector(state => state.wallet.selectedAccount);
+    const online = useSelector(state => state.suite.online);
 
     if (!online) return null;
 

--- a/packages/suite/src/components/wallet/AccountMode/BackendDisconnected.tsx
+++ b/packages/suite/src/components/wallet/AccountMode/BackendDisconnected.tsx
@@ -1,6 +1,6 @@
 import React, { useState, useEffect } from 'react';
 import { NotificationCard, Translation } from 'src/components/suite';
-import { useSelector, useActions } from 'src/hooks/suite';
+import { useDispatch, useSelector } from 'src/hooks/suite';
 import { reconnectBlockchainThunk } from '@suite-common/wallet-core';
 import { isTrezorConnectBackendType } from '@suite-common/wallet-utils';
 import type { NetworkSymbol } from '@suite-common/wallet-config';
@@ -15,9 +15,7 @@ const DisconnectedNotification = ({
     const [progress, setProgress] = useState(false);
     const [time, setTime] = useState<number>();
 
-    const { reconnect } = useActions({
-        reconnect: reconnectBlockchainThunk,
-    });
+    const dispatch = useDispatch();
 
     useEffect(() => {
         const interval = setInterval(() => {
@@ -31,7 +29,7 @@ const DisconnectedNotification = ({
 
     const click = async () => {
         setProgress(true);
-        const r: any = await reconnect(symbol);
+        const r: any = await dispatch(reconnectBlockchainThunk(symbol));
         if (!r.success) {
             setProgress(false);
         }

--- a/packages/suite/src/components/wallet/AccountMode/DeviceUnavailable.tsx
+++ b/packages/suite/src/components/wallet/AccountMode/DeviceUnavailable.tsx
@@ -1,15 +1,15 @@
 import React from 'react';
-import { useDevice, useActions } from 'src/hooks/suite';
-import * as deviceSettingsActions from 'src/actions/settings/deviceSettingsActions';
+import { useDevice, useDispatch } from 'src/hooks/suite';
+import { applySettings } from 'src/actions/settings/deviceSettingsActions';
 import { NotificationCard, Translation } from 'src/components/suite';
 
 const DeviceUnavailable = () => {
+    const dispatch = useDispatch();
     const { device, isLocked } = useDevice();
-    const { applySettings } = useActions({
-        applySettings: deviceSettingsActions.applySettings,
-    });
 
     if (!device?.connected || device.available) return null;
+
+    const handleButtonClick = () => dispatch(applySettings({ use_passphrase: true }));
 
     return (
         <NotificationCard
@@ -17,7 +17,7 @@ const DeviceUnavailable = () => {
             button={{
                 children: <Translation id="TR_ACCOUNT_ENABLE_PASSPHRASE" />,
                 isLoading: isLocked(),
-                onClick: () => applySettings({ use_passphrase: true }),
+                onClick: handleButtonClick,
             }}
         >
             <Translation id="TR_ACCOUNT_PASSPHRASE_DISABLED" />

--- a/packages/suite/src/components/wallet/AccountTopPanel/AccountNavigation.tsx
+++ b/packages/suite/src/components/wallet/AccountTopPanel/AccountNavigation.tsx
@@ -2,10 +2,11 @@ import React from 'react';
 import { WalletParams } from 'src/types/wallet';
 import { AppNavigation, AppNavigationItem } from 'src/components/suite/AppNavigation';
 import { Translation } from 'src/components/suite/Translation';
-import { useActions, useSelector } from 'src/hooks/suite';
+import { useDispatch, useSelector } from 'src/hooks/suite';
 import { getNetwork, hasNetworkFeatures } from '@suite-common/wallet-utils';
-import * as routerActions from 'src/actions/suite/routerActions';
-import * as modalActions from 'src/actions/suite/modalActions';
+import { goto } from 'src/actions/suite/routerActions';
+import { openModal } from 'src/actions/suite/modalActions';
+import { selectSelectedAccount } from 'src/reducers/wallet/selectedAccountReducer';
 
 interface AccountNavigationProps {
     filterPosition?: 'primary' | 'secondary';
@@ -20,14 +21,10 @@ export const AccountNavigation = ({
     primaryContent,
     inView,
 }: AccountNavigationProps) => {
-    const { goto, openModal } = useActions({
-        goto: routerActions.goto,
-        openModal: modalActions.openModal,
-    });
-
-    const selectedAccount = useSelector(state => state.wallet.selectedAccount);
-    const { account } = selectedAccount;
+    const account = useSelector(selectSelectedAccount);
     const routerParams = useSelector(state => state.router.params) as WalletParams;
+    const dispatch = useDispatch();
+
     const network = getNetwork(routerParams?.symbol || '');
     const networkType = account?.networkType || network?.networkType || '';
     const accountType = account?.accountType || routerParams?.accountType || '';
@@ -36,7 +33,7 @@ export const AccountNavigation = ({
         {
             id: 'wallet-index',
             callback: () => {
-                goto('wallet-index', { preserveParams: true });
+                dispatch(goto('wallet-index', { preserveParams: true }));
             },
             title: <Translation id="TR_NAV_TRANSACTIONS" />,
             position: 'primary',
@@ -45,7 +42,7 @@ export const AccountNavigation = ({
         {
             id: 'wallet-details',
             callback: () => {
-                goto('wallet-details', { preserveParams: true });
+                dispatch(goto('wallet-details', { preserveParams: true }));
             },
             title: <Translation id="TR_NAV_DETAILS" />,
             position: 'primary',
@@ -54,7 +51,7 @@ export const AccountNavigation = ({
         {
             id: 'wallet-tokens',
             callback: () => {
-                goto('wallet-tokens', { preserveParams: true });
+                dispatch(goto('wallet-tokens', { preserveParams: true }));
             },
             title: <Translation id="TR_NAV_TOKENS" />,
             position: 'primary',
@@ -63,7 +60,7 @@ export const AccountNavigation = ({
         {
             id: 'wallet-staking',
             callback: () => {
-                goto('wallet-staking', { preserveParams: true });
+                dispatch(goto('wallet-staking', { preserveParams: true }));
             },
             title: <Translation id="TR_NAV_STAKING" />,
             position: 'primary',
@@ -72,7 +69,7 @@ export const AccountNavigation = ({
         {
             id: 'wallet-send',
             callback: () => {
-                goto('wallet-send', { preserveParams: true });
+                dispatch(goto('wallet-send', { preserveParams: true }));
             },
             title: <Translation id="TR_NAV_SEND" />,
             position: 'secondary',
@@ -81,7 +78,7 @@ export const AccountNavigation = ({
         {
             id: 'wallet-receive',
             callback: () => {
-                goto('wallet-receive', { preserveParams: true });
+                dispatch(goto('wallet-receive', { preserveParams: true }));
             },
             title: <Translation id="TR_NAV_RECEIVE" />,
             position: 'secondary',
@@ -90,7 +87,7 @@ export const AccountNavigation = ({
         {
             id: 'wallet-coinmarket-buy',
             callback: () => {
-                goto('wallet-coinmarket-buy', { preserveParams: true });
+                dispatch(goto('wallet-coinmarket-buy', { preserveParams: true }));
             },
             title: <Translation id="TR_NAV_TRADE" />,
             position: 'secondary',
@@ -99,7 +96,7 @@ export const AccountNavigation = ({
         {
             id: 'wallet-add-token',
             callback: () => {
-                openModal({ type: 'add-token' });
+                dispatch(openModal({ type: 'add-token' }));
             },
             title: <Translation id="TR_TOKENS_ADD" />,
             position: 'secondary',
@@ -109,7 +106,7 @@ export const AccountNavigation = ({
         {
             id: 'wallet-sign-verify',
             callback: () => {
-                goto('wallet-sign-verify', { preserveParams: true });
+                dispatch(goto('wallet-sign-verify', { preserveParams: true }));
             },
             title: <Translation id="TR_NAV_SIGN_AND_VERIFY" />,
             icon: 'SIGNATURE',

--- a/packages/suite/src/components/wallet/AccountsMenu/AccountGroup.tsx
+++ b/packages/suite/src/components/wallet/AccountsMenu/AccountGroup.tsx
@@ -6,13 +6,13 @@ import { Account } from 'src/types/wallet';
 import { AnimationWrapper } from './AnimationWrapper';
 
 const Wrapper = styled.div`
-    background: ${props => props.theme.BG_WHITE};
+    background: ${({ theme }) => theme.BG_WHITE};
 `;
 
 const HeaderWrapper = styled.div`
     position: sticky;
     top: 0;
-    background: ${props => props.theme.BG_WHITE};
+    background: ${({ theme }) => theme.BG_WHITE};
 `;
 
 const ChevronIcon = styled(Icon)`
@@ -32,8 +32,8 @@ const Header = styled.header<{ isOpen: boolean; onClick?: () => void }>`
     text-transform: uppercase;
     font-size: ${variables.FONT_SIZE.TINY};
     font-weight: ${variables.FONT_WEIGHT.MEDIUM};
-    color: ${props => props.theme.TYPE_DARK_GREY};
-    border-top: 1px solid ${props => props.theme.STROKE_GREY};
+    color: ${({ theme }) => theme.TYPE_DARK_GREY};
+    border-top: 1px solid ${({ theme }) => theme.STROKE_GREY};
 
     :hover {
         ${ChevronIcon} {

--- a/packages/suite/src/components/wallet/AccountsMenu/AccountSearchBox.tsx
+++ b/packages/suite/src/components/wallet/AccountsMenu/AccountSearchBox.tsx
@@ -4,7 +4,7 @@ import { useTheme, Icon, Input, CoinLogo } from '@trezor/components';
 import { useSelector, useAccountSearch, useTranslation } from 'src/hooks/suite';
 
 const Wrapper = styled.div`
-    background: ${props => props.theme.BG_WHITE};
+    background: ${({ theme }) => theme.BG_WHITE};
     width: 100%;
     margin-top: 16px;
 `;
@@ -20,9 +20,9 @@ const OuterCircle = styled.div<{ isSelected?: boolean; isMobile?: boolean }>`
     justify-content: center;
     align-items: center;
     padding: 3px;
-    background: ${props => props.theme.BG_WHITE};
+    background: ${({ theme }) => theme.BG_WHITE};
     border-radius: 50%;
-    border: 2px solid ${props => (props.isSelected ? props.theme.BG_GREEN : 'transparent')};
+    border: 2px solid ${({ isSelected, theme }) => (isSelected ? theme.BG_GREEN : 'transparent')};
     transition: all 0.3;
     cursor: pointer;
 
@@ -43,8 +43,8 @@ const InputWrapper = styled.div<{ showCoinFilter: boolean }>`
 
 const StyledInput = styled(Input)`
     && {
-        background-color: ${props => props.theme.BG_GREY_ALT};
-        border-color: ${props => props.theme.BG_GREY_ALT};
+        background-color: ${({ theme }) => theme.BG_GREY_ALT};
+        border-color: ${({ theme }) => theme.BG_GREY_ALT};
         transition: border-color 0.2s;
 
         :focus {

--- a/packages/suite/src/components/wallet/AccountsMenu/AccountSearchBox.tsx
+++ b/packages/suite/src/components/wallet/AccountsMenu/AccountSearchBox.tsx
@@ -74,10 +74,8 @@ export const AccountSearchBox = (props: AccountSearchBoxProps) => {
     const theme = useTheme();
     const { translationString } = useTranslation();
     const { coinFilter, setCoinFilter, searchString, setSearchString } = useAccountSearch();
-    const { enabledNetworks, device } = useSelector(state => ({
-        enabledNetworks: state.wallet.settings.enabledNetworks,
-        device: state.suite.device,
-    }));
+    const enabledNetworks = useSelector(state => state.wallet.settings.enabledNetworks);
+    const device = useSelector(state => state.suite.device);
 
     const unavailableCapabilities = device?.unavailableCapabilities ?? {};
     const supportedNetworks = enabledNetworks.filter(symbol => !unavailableCapabilities[symbol]);

--- a/packages/suite/src/components/wallet/AccountsMenu/TokensCount.tsx
+++ b/packages/suite/src/components/wallet/AccountsMenu/TokensCount.tsx
@@ -9,8 +9,8 @@ const ButtonBadge = styled(Button)`
     font-size: 10px;
     line-height: 1;
     font-weight: ${variables.FONT_WEIGHT.DEMI_BOLD};
-    background: ${props => props.theme.STROKE_GREY_ALT};
-    color: ${props => props.theme.TYPE_LIGHT_GREY};
+    background: ${({ theme }) => theme.STROKE_GREY_ALT};
+    color: ${({ theme }) => theme.TYPE_LIGHT_GREY};
 `;
 
 interface TokensCountProps {

--- a/packages/suite/src/components/wallet/AccountsMenu/index.tsx
+++ b/packages/suite/src/components/wallet/AccountsMenu/index.tsx
@@ -29,7 +29,7 @@ const MenuHeader = styled.div<{ isInline?: boolean }>`
     display: flex;
     flex-direction: column;
     /* justify-content: center; */
-    background: ${props => props.theme.BG_WHITE};
+    background: ${({ theme }) => theme.BG_WHITE};
 
     ${props =>
         props.isInline &&
@@ -62,12 +62,12 @@ const Search = styled.div`
     justify-content: space-between;
     padding: 8px 0px;
 
-    background: ${props => props.theme.BG_WHITE};
+    background: ${({ theme }) => theme.BG_WHITE};
 `;
 
 const Heading = styled(H2)<{ isInline?: boolean }>`
     font-weight: ${variables.FONT_WEIGHT.MEDIUM};
-    color: ${props => props.theme.TYPE_DARK_GREY};
+    color: ${({ theme }) => theme.TYPE_DARK_GREY};
     ${props =>
         props.isInline &&
         css`
@@ -84,12 +84,12 @@ const ExpandedMobileWrapper = styled.div`
     display: flex;
     position: absolute;
     flex-direction: column;
-    background: ${props => props.theme.BG_WHITE};
+    background: ${({ theme }) => theme.BG_WHITE};
     z-index: ${variables.Z_INDEX.EXPANDABLE_NAVIGATION};
     width: 100%;
     max-height: 80vh;
     overflow-y: auto;
-    box-shadow: 0 4px 10px 0 ${props => props.theme.BOX_SHADOW_BLACK_20};
+    box-shadow: 0 4px 10px 0 ${({ theme }) => theme.BOX_SHADOW_BLACK_20};
     border-bottom-left-radius: 4px;
     border-bottom-right-radius: 4px;
     padding: 0px 16px;
@@ -111,7 +111,7 @@ const NoResults = styled.div`
     display: flex;
     font-size: ${variables.FONT_SIZE.SMALL};
     font-weight: ${variables.FONT_WEIGHT.MEDIUM};
-    color: ${props => props.theme.TYPE_LIGHT_GREY};
+    color: ${({ theme }) => theme.TYPE_LIGHT_GREY};
     justify-content: center;
     text-align: center;
     margin: 36px 0px;

--- a/packages/suite/src/components/wallet/CoinControl/UtxoSelection.tsx
+++ b/packages/suite/src/components/wallet/CoinControl/UtxoSelection.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 import styled, { css } from 'styled-components';
 import { darken } from 'polished';
 
-import * as modalActions from 'src/actions/suite/modalActions';
+import { openModal } from 'src/actions/suite/modalActions';
 import {
     FiatValue,
     FormattedCryptoAmount,
@@ -10,7 +10,7 @@ import {
     Translation,
 } from 'src/components/suite';
 import { formatNetworkAmount, isSameUtxo } from '@suite-common/wallet-utils';
-import { useActions, useSelector } from 'src/hooks/suite';
+import { useDispatch, useSelector } from 'src/hooks/suite';
 import { useTheme, Checkbox, FluidSpinner, Tooltip, variables } from '@trezor/components';
 import type { AccountUtxo } from '@trezor/connect';
 import { TransactionTimestamp, UtxoAnonymity } from 'src/components/wallet';
@@ -89,7 +89,7 @@ const BottomRow = styled(Row)`
 
 const Dot = styled.div`
     border-radius: 50%;
-    background: ${props => props.theme.TYPE_LIGHT_GREY};
+    background: ${({ theme }) => theme.TYPE_LIGHT_GREY};
     height: 3px;
     width: 3px;
 `;
@@ -157,9 +157,7 @@ export const UtxoSelection = ({ transaction, utxo }: UtxoSelectionProps) => {
     const outputLabels = useSelector(
         state => state.wallet.selectedAccount.account?.metadata.outputLabels,
     );
-    const { openModal } = useActions({
-        openModal: modalActions.openModal,
-    });
+    const dispatch = useDispatch();
 
     const theme = useTheme();
 
@@ -180,7 +178,7 @@ export const UtxoSelection = ({ transaction, utxo }: UtxoSelectionProps) => {
     const showTransactionDetail: React.MouseEventHandler = e => {
         e.stopPropagation(); // do not trigger the checkbox
         if (transaction) {
-            openModal({ type: 'transaction-detail', tx: transaction });
+            dispatch(openModal({ type: 'transaction-detail', tx: transaction }));
         }
     };
 

--- a/packages/suite/src/components/wallet/CoinMarketFractionButtons.tsx
+++ b/packages/suite/src/components/wallet/CoinMarketFractionButtons.tsx
@@ -22,13 +22,17 @@ const SmallButton = styled(Button).attrs(props => ({
     margin-right: 10px;
 `;
 
-interface Props {
+interface FractionButtonsProps {
     onFractionClick: (divisor: number) => void;
     onAllClick: () => void;
     disabled?: boolean;
 }
 
-export const FractionButtons = ({ disabled, onFractionClick, onAllClick }: Props) => (
+export const FractionButtons = ({
+    disabled,
+    onFractionClick,
+    onAllClick,
+}: FractionButtonsProps) => (
     <Wrapper>
         <Left>
             <SmallButton isDisabled={disabled} onClick={() => onFractionClick(4)}>

--- a/packages/suite/src/components/wallet/CoinmarketBuyOfferInfo/index.tsx
+++ b/packages/suite/src/components/wallet/CoinmarketBuyOfferInfo/index.tsx
@@ -12,15 +12,6 @@ import { Translation, AccountLabeling } from 'src/components/suite';
 import { CoinmarketCryptoAmount } from 'src/views/wallet/coinmarket/common/CoinmarketCryptoAmount';
 import { CoinmarketFiatAmount } from 'src/views/wallet/coinmarket/common/CoinmarketFiatAmount';
 
-interface Props {
-    selectedQuote: BuyTrade;
-    transactionId?: string;
-    providers?: {
-        [name: string]: BuyProviderInfo;
-    };
-    account: Account;
-}
-
 const Wrapper = styled.div`
     display: flex;
     flex-direction: column;
@@ -101,7 +92,21 @@ const TransactionIdWrapper = styled.div`
     max-width: 350px;
 `;
 
-const CoinmarketBuyOfferInfo = ({ selectedQuote, transactionId, providers, account }: Props) => {
+interface CoinmarketBuyOfferInfoProps {
+    selectedQuote: BuyTrade;
+    transactionId?: string;
+    providers?: {
+        [name: string]: BuyProviderInfo;
+    };
+    account: Account;
+}
+
+const CoinmarketBuyOfferInfo = ({
+    selectedQuote,
+    transactionId,
+    providers,
+    account,
+}: CoinmarketBuyOfferInfoProps) => {
     const {
         receiveStringAmount,
         receiveCurrency,

--- a/packages/suite/src/components/wallet/CoinmarketBuyOfferInfo/index.tsx
+++ b/packages/suite/src/components/wallet/CoinmarketBuyOfferInfo/index.tsx
@@ -34,7 +34,7 @@ const Wrapper = styled.div`
 const Header = styled.div`
     display: flex;
     align-items: center;
-    border-bottom: 1px solid ${props => props.theme.STROKE_GREY};
+    border-bottom: 1px solid ${({ theme }) => theme.STROKE_GREY};
     margin-bottom: 5px;
     padding: 15px 24px;
     max-width: 340px;
@@ -42,7 +42,7 @@ const Header = styled.div`
 
 const AccountText = styled.div`
     font-weight: ${variables.FONT_WEIGHT.MEDIUM};
-    color: ${props => props.theme.TYPE_DARK_GREY};
+    color: ${({ theme }) => theme.TYPE_DARK_GREY};
     padding-left: 7px;
 `;
 
@@ -52,7 +52,7 @@ const Info = styled.div`
     min-width: 350px;
     margin: 0 0 10px 30px;
     min-height: 200px;
-    border: 1px solid ${props => props.theme.STROKE_GREY};
+    border: 1px solid ${({ theme }) => theme.STROKE_GREY};
     border-radius: 4px;
 
     @media screen and (max-width: ${variables.SCREEN_SIZE.LG}) {
@@ -67,7 +67,7 @@ const LeftColumn = styled.div`
     flex: 1;
     text-transform: uppercase;
     font-weight: ${variables.FONT_WEIGHT.MEDIUM};
-    color: ${props => props.theme.TYPE_LIGHT_GREY};
+    color: ${({ theme }) => theme.TYPE_LIGHT_GREY};
     align-self: center;
 `;
 
@@ -87,11 +87,11 @@ const Dark = styled.div`
     justify-content: flex-end;
     flex: 1;
     font-weight: ${variables.FONT_WEIGHT.DEMI_BOLD};
-    color: ${props => props.theme.TYPE_DARK_GREY};
+    color: ${({ theme }) => theme.TYPE_DARK_GREY};
 `;
 
 const RowWithBorder = styled(Row)`
-    border-bottom: 1px solid ${props => props.theme.STROKE_GREY};
+    border-bottom: 1px solid ${({ theme }) => theme.STROKE_GREY};
     margin-bottom: 10px;
     padding-bottom: 10px;
 `;

--- a/packages/suite/src/components/wallet/CoinmarketExchangeOfferInfo/index.tsx
+++ b/packages/suite/src/components/wallet/CoinmarketExchangeOfferInfo/index.tsx
@@ -10,14 +10,6 @@ import QuestionTooltip from 'src/components/suite/QuestionTooltip';
 import { ExchangeInfo } from 'src/actions/wallet/coinmarketExchangeActions';
 import invityAPI from 'src/services/suite/invityAPI';
 
-interface Props {
-    selectedQuote: ExchangeTrade;
-    transactionId?: string;
-    exchangeInfo?: ExchangeInfo;
-    account: Account;
-    receiveAccount?: Account;
-}
-
 const Wrapper = styled.div`
     margin: 0 0 0 30px;
 
@@ -124,13 +116,21 @@ const AccountType = styled.span`
     font-weight: ${variables.FONT_WEIGHT.MEDIUM};
 `;
 
+interface CoinmarketExchangeOfferInfoProps {
+    selectedQuote: ExchangeTrade;
+    transactionId?: string;
+    exchangeInfo?: ExchangeInfo;
+    account: Account;
+    receiveAccount?: Account;
+}
+
 const CoinmarketExchangeOfferInfo = ({
     selectedQuote,
     transactionId,
     exchangeInfo,
     account,
     receiveAccount,
-}: Props) => {
+}: CoinmarketExchangeOfferInfoProps) => {
     const { exchange, receiveStringAmount, receive, sendStringAmount, send } = selectedQuote;
     const provider =
         exchangeInfo?.providerInfos && exchange ? exchangeInfo?.providerInfos[exchange] : undefined;

--- a/packages/suite/src/components/wallet/CoinmarketExchangeOfferInfo/index.tsx
+++ b/packages/suite/src/components/wallet/CoinmarketExchangeOfferInfo/index.tsx
@@ -27,7 +27,7 @@ const Wrapper = styled.div`
 `;
 
 const AccountText = styled.div`
-    color: ${props => props.theme.TYPE_LIGHT_GREY};
+    color: ${({ theme }) => theme.TYPE_LIGHT_GREY};
     padding-left: 7px;
     font-weight: ${variables.FONT_WEIGHT.MEDIUM};
 `;
@@ -39,7 +39,7 @@ const Info = styled.div`
 
     padding-top: 10px;
     min-height: 200px;
-    border: 1px solid ${props => props.theme.STROKE_GREY};
+    border: 1px solid ${({ theme }) => theme.STROKE_GREY};
     border-radius: 4px;
 
     @media screen and (max-width: ${variables.SCREEN_SIZE.LG}) {
@@ -55,7 +55,7 @@ const LeftColumn = styled.div`
     font-size: ${variables.FONT_SIZE.SMALL};
     text-transform: uppercase;
     font-weight: ${variables.FONT_WEIGHT.MEDIUM};
-    color: ${props => props.theme.TYPE_LIGHT_GREY};
+    color: ${({ theme }) => theme.TYPE_LIGHT_GREY};
 `;
 
 const RightColumn = styled.div`
@@ -63,7 +63,7 @@ const RightColumn = styled.div`
     justify-content: flex-end;
     flex: 1;
     font-size: ${variables.FONT_SIZE.TINY};
-    color: ${props => props.theme.TYPE_LIGHT_GREY};
+    color: ${({ theme }) => theme.TYPE_LIGHT_GREY};
 `;
 
 const Row = styled.div`
@@ -85,12 +85,12 @@ const Dark = styled.div`
     justify-content: flex-end;
     flex: 1;
     font-weight: ${variables.FONT_WEIGHT.DEMI_BOLD};
-    color: ${props => props.theme.TYPE_DARK_GREY};
+    color: ${({ theme }) => theme.TYPE_DARK_GREY};
 `;
 
 const RowWithBorder = styled(Row)`
-    border-top: 1px solid ${props => props.theme.STROKE_GREY};
-    border-bottom: 1px solid ${props => props.theme.STROKE_GREY};
+    border-top: 1px solid ${({ theme }) => theme.STROKE_GREY};
+    border-bottom: 1px solid ${({ theme }) => theme.STROKE_GREY};
     margin-bottom: 0px;
     margin-top: 10px;
     padding-bottom: 10px;
@@ -102,7 +102,7 @@ const Middle = styled.div`
     justify-content: center;
     align-items: center;
     flex: 1;
-    color: ${props => props.theme.TYPE_LIGHT_GREY};
+    color: ${({ theme }) => theme.TYPE_LIGHT_GREY};
     font-weight: ${variables.FONT_WEIGHT.MEDIUM};
 `;
 
@@ -119,7 +119,7 @@ const InvityCoinLogo = styled.img`
 `;
 
 const AccountType = styled.span`
-    color: ${props => props.theme.TYPE_LIGHT_GREY};
+    color: ${({ theme }) => theme.TYPE_LIGHT_GREY};
     padding-left: 5px;
     font-weight: ${variables.FONT_WEIGHT.MEDIUM};
 `;

--- a/packages/suite/src/components/wallet/CoinmarketFooter/index.tsx
+++ b/packages/suite/src/components/wallet/CoinmarketFooter/index.tsx
@@ -13,14 +13,14 @@ const Wrapper = styled.div`
     justify-content: center;
     padding-top: 20px;
     margin-top: auto;
-    border-top: 1px solid ${props => props.theme.STROKE_GREY};
+    border-top: 1px solid ${({ theme }) => theme.STROKE_GREY};
 `;
 
 const Left = styled.div`
     display: flex;
     flex: 1;
     align-items: center;
-    color: ${props => props.theme.TYPE_LIGHT_GREY};
+    color: ${({ theme }) => theme.TYPE_LIGHT_GREY};
     font-weight: ${variables.FONT_WEIGHT.DEMI_BOLD};
 `;
 
@@ -40,10 +40,10 @@ const FooterBox = styled.div`
     flex: 1;
     min-width: 345px;
     bottom: 30px;
-    box-shadow: 0 1px 2px 0 ${props => props.theme.BOX_SHADOW_BLACK_20};
+    box-shadow: 0 1px 2px 0 ${({ theme }) => theme.BOX_SHADOW_BLACK_20};
     z-index: ${variables.Z_INDEX.TOOLTIP};
 
-    background: ${props => props.theme.BG_WHITE};
+    background: ${({ theme }) => theme.BG_WHITE};
     overflow: hidden;
 `;
 
@@ -52,7 +52,7 @@ const Header = styled.div`
     justify-content: space-between;
     padding-bottom: 10px;
     margin-bottom: 10px;
-    border-bottom: 1px solid ${props => props.theme.STROKE_GREY};
+    border-bottom: 1px solid ${({ theme }) => theme.STROKE_GREY};
 `;
 
 const BoxLeft = styled.div``;
@@ -75,7 +75,7 @@ const IconWrapper = styled.div`
 
 const Text = styled.div`
     padding-left: 10px;
-    color: ${props => props.theme.TYPE_LIGHT_GREY};
+    color: ${({ theme }) => theme.TYPE_LIGHT_GREY};
     font-weight: ${variables.FONT_WEIGHT.MEDIUM};
     margin-bottom: 15px;
 `;
@@ -100,7 +100,7 @@ const LearnMoreToggle = styled.div`
 
 const VerticalDivider = styled.div`
     height: 12px;
-    border-left: 1px solid ${props => props.theme.TYPE_LIGHTER_GREY};
+    border-left: 1px solid ${({ theme }) => theme.TYPE_LIGHTER_GREY};
     margin: 0 8px;
 `;
 

--- a/packages/suite/src/components/wallet/CoinmarketLayout/components/AccountTransactions/components/ExchangeTransaction/index.tsx
+++ b/packages/suite/src/components/wallet/CoinmarketLayout/components/AccountTransactions/components/ExchangeTransaction/index.tsx
@@ -4,35 +4,27 @@ import { ExchangeProviderInfo } from 'invity-api';
 import { Button, Icon, variables, useTheme } from '@trezor/components';
 import { CoinmarketProviderInfo } from 'src/components/wallet';
 import { TradeExchange } from 'src/types/wallet/coinmarketCommonTypes';
-import * as routerActions from 'src/actions/suite/routerActions';
-import * as coinmarketExchangeActions from 'src/actions/wallet/coinmarketExchangeActions';
+import { goto } from 'src/actions/suite/routerActions';
+import { saveTransactionId } from 'src/actions/wallet/coinmarketExchangeActions';
 import { Account } from 'src/types/wallet';
 import { useWatchExchangeTrade } from 'src/hooks/wallet/useCoinmarket';
 import Status from '../Status';
 import { Translation, FormattedDate, FormattedCryptoAmount } from 'src/components/suite';
-import { useActions } from 'src/hooks/suite';
-
-interface Props {
-    trade: TradeExchange;
-    account: Account;
-    providers?: {
-        [name: string]: ExchangeProviderInfo;
-    };
-}
+import { useDispatch } from 'src/hooks/suite';
 
 const Wrapper = styled.div`
     display: flex;
     flex: 1;
     align-items: center;
     margin-bottom: 20px;
-    border: 1px solid ${props => props.theme.STROKE_GREY};
+    border: 1px solid ${({ theme }) => theme.STROKE_GREY};
     border-radius: 4px;
     padding: 12px 0;
 
     &:hover {
-        background: ${props => props.theme.BG_WHITE};
-        border: 1px solid ${props => props.theme.TYPE_WHITE};
-        box-shadow: 0 1px 2px 0 ${props => props.theme.BOX_SHADOW_BLACK_20};
+        background: ${({ theme }) => theme.BG_WHITE};
+        border: 1px solid ${({ theme }) => theme.TYPE_WHITE};
+        box-shadow: 0 1px 2px 0 ${({ theme }) => theme.BOX_SHADOW_BLACK_20};
     }
 
     @media screen and (max-width: ${variables.SCREEN_SIZE.SM}) {
@@ -72,7 +64,7 @@ const ProviderColumn = styled(Column)`
 
 const TradeID = styled.span`
     padding-left: 5px;
-    color: ${props => props.theme.TYPE_LIGHT_GREY};
+    color: ${({ theme }) => theme.TYPE_LIGHT_GREY};
     font-weight: ${variables.FONT_WEIGHT.DEMI_BOLD};
     overflow: hidden;
     text-overflow: ellipsis;
@@ -81,14 +73,14 @@ const TradeID = styled.span`
 const Row = styled.div`
     display: flex;
     align-items: center;
-    color: ${props => props.theme.TYPE_DARK_GREY};
+    color: ${({ theme }) => theme.TYPE_DARK_GREY};
     font-weight: ${variables.FONT_WEIGHT.MEDIUM};
 `;
 
 const SmallRow = styled.div`
     padding-top: 8px;
     display: flex;
-    color: ${props => props.theme.TYPE_LIGHT_GREY};
+    color: ${({ theme }) => theme.TYPE_LIGHT_GREY};
     font-weight: ${variables.FONT_WEIGHT.MEDIUM};
     font-size: ${variables.FONT_SIZE.TINY};
     white-space: nowrap;
@@ -106,26 +98,33 @@ const Arrow = styled.div`
     padding: 0 11px;
 `;
 
-const ExchangeTransaction = ({ trade, providers, account }: Props) => {
+interface ExchangeTransactionProps {
+    trade: TradeExchange;
+    account: Account;
+    providers?: {
+        [name: string]: ExchangeProviderInfo;
+    };
+}
+
+const ExchangeTransaction = ({ trade, providers, account }: ExchangeTransactionProps) => {
+    const dispatch = useDispatch();
     const theme = useTheme();
-    const { goto, saveTransactionId } = useActions({
-        goto: routerActions.goto,
-        saveTransactionId: coinmarketExchangeActions.saveTransactionId,
-    });
     useWatchExchangeTrade(account, trade);
 
     const { date, data } = trade;
     const { send, sendStringAmount, receive, receiveStringAmount, exchange } = data;
 
     const viewDetail = async () => {
-        await saveTransactionId(trade.key || '');
-        goto('wallet-coinmarket-exchange-detail', {
-            params: {
-                symbol: account.symbol,
-                accountIndex: account.index,
-                accountType: account.accountType,
-            },
-        });
+        await dispatch(saveTransactionId(trade.key || ''));
+        dispatch(
+            goto('wallet-coinmarket-exchange-detail', {
+                params: {
+                    symbol: account.symbol,
+                    accountIndex: account.index,
+                    accountType: account.accountType,
+                },
+            }),
+        );
     };
 
     return (

--- a/packages/suite/src/components/wallet/CoinmarketLayout/components/AccountTransactions/components/ExchangeTransaction/index.tsx
+++ b/packages/suite/src/components/wallet/CoinmarketLayout/components/AccountTransactions/components/ExchangeTransaction/index.tsx
@@ -55,7 +55,7 @@ const BuyColumn = styled(Column)`
         border-left: 0;
     }
 
-    border-left: 1px solid ${props => props.theme.STROKE_GREY};
+    border-left: 1px solid ${({ theme }) => theme.STROKE_GREY};
 `;
 
 const ProviderColumn = styled(Column)`

--- a/packages/suite/src/components/wallet/CoinmarketLayout/components/AccountTransactions/components/SavingsTransaction/index.tsx
+++ b/packages/suite/src/components/wallet/CoinmarketLayout/components/AccountTransactions/components/SavingsTransaction/index.tsx
@@ -14,14 +14,6 @@ import { CoinmarketProviderInfo, CoinmarketPaymentType } from 'src/components/wa
 import { useWatchSavingsTrade } from 'src/hooks/wallet/useCoinmarket';
 import type { Account } from 'src/types/wallet';
 
-interface Props {
-    trade: TradeSavings;
-    account: Account;
-    providers?: {
-        [name: string]: SavingsProviderInfo;
-    };
-}
-
 const Wrapper = styled.div`
     display: flex;
     flex: 1;
@@ -102,7 +94,15 @@ const Arrow = styled.div`
     padding: 0 11px;
 `;
 
-const SavingsTransaction = ({ trade, providers, account }: Props) => {
+interface SavingsTransactionProps {
+    trade: TradeSavings;
+    account: Account;
+    providers?: {
+        [name: string]: SavingsProviderInfo;
+    };
+}
+
+const SavingsTransaction = ({ trade, providers, account }: SavingsTransactionProps) => {
     const theme = useTheme();
 
     useWatchSavingsTrade(account, trade);

--- a/packages/suite/src/components/wallet/CoinmarketLayout/components/AccountTransactions/components/SavingsTransaction/index.tsx
+++ b/packages/suite/src/components/wallet/CoinmarketLayout/components/AccountTransactions/components/SavingsTransaction/index.tsx
@@ -27,14 +27,14 @@ const Wrapper = styled.div`
     flex: 1;
     align-items: center;
     margin-bottom: 20px;
-    border: 1px solid ${props => props.theme.STROKE_GREY};
+    border: 1px solid ${({ theme }) => theme.STROKE_GREY};
     border-radius: 4px;
     padding: 12px 0;
 
     &:hover {
-        background: ${props => props.theme.BG_WHITE};
-        border: 1px solid ${props => props.theme.TYPE_WHITE};
-        box-shadow: 0 1px 2px 0 ${props => props.theme.BOX_SHADOW_BLACK_20};
+        background: ${({ theme }) => theme.BG_WHITE};
+        border: 1px solid ${({ theme }) => theme.TYPE_WHITE};
+        box-shadow: 0 1px 2px 0 ${({ theme }) => theme.BOX_SHADOW_BLACK_20};
     }
 
     @media screen and (max-width: ${variables.SCREEN_SIZE.SM}) {
@@ -60,7 +60,7 @@ const ProviderColumn = styled(Column)`
 
 const TradeID = styled.span`
     padding-left: 5px;
-    color: ${props => props.theme.TYPE_LIGHT_GREY};
+    color: ${({ theme }) => theme.TYPE_LIGHT_GREY};
     font-weight: ${variables.FONT_WEIGHT.DEMI_BOLD};
     overflow: hidden;
     text-overflow: ellipsis;
@@ -69,7 +69,7 @@ const TradeID = styled.span`
 const Row = styled.div`
     display: flex;
     align-items: center;
-    color: ${props => props.theme.TYPE_DARK_GREY};
+    color: ${({ theme }) => theme.TYPE_DARK_GREY};
     font-weight: ${variables.FONT_WEIGHT.MEDIUM};
 `;
 
@@ -85,7 +85,7 @@ const RowSecond = styled(Row)`
 const SmallRow = styled.div`
     padding-top: 8px;
     display: flex;
-    color: ${props => props.theme.TYPE_LIGHT_GREY};
+    color: ${({ theme }) => theme.TYPE_LIGHT_GREY};
     font-weight: ${variables.FONT_WEIGHT.MEDIUM};
     font-size: ${variables.FONT_SIZE.TINY};
 `;

--- a/packages/suite/src/components/wallet/CoinmarketLayout/components/AccountTransactions/components/SpendTransaction/index.tsx
+++ b/packages/suite/src/components/wallet/CoinmarketLayout/components/AccountTransactions/components/SpendTransaction/index.tsx
@@ -19,14 +19,14 @@ const Wrapper = styled.div`
     flex: 1;
     align-items: center;
     margin-bottom: 20px;
-    border: 1px solid ${props => props.theme.STROKE_GREY};
+    border: 1px solid ${({ theme }) => theme.STROKE_GREY};
     border-radius: 4px;
     padding: 12px 0;
 
     &:hover {
-        background: ${props => props.theme.BG_WHITE};
-        border: 1px solid ${props => props.theme.TYPE_WHITE};
-        box-shadow: 0 1px 2px 0 ${props => props.theme.BOX_SHADOW_BLACK_20};
+        background: ${({ theme }) => theme.BG_WHITE};
+        border: 1px solid ${({ theme }) => theme.TYPE_WHITE};
+        box-shadow: 0 1px 2px 0 ${({ theme }) => theme.BOX_SHADOW_BLACK_20};
     }
 
     @media screen and (max-width: ${variables.SCREEN_SIZE.SM}) {
@@ -37,7 +37,7 @@ const Wrapper = styled.div`
 const Row = styled.div`
     display: flex;
     align-items: center;
-    color: ${props => props.theme.TYPE_DARK_GREY};
+    color: ${({ theme }) => theme.TYPE_DARK_GREY};
     font-weight: ${variables.FONT_WEIGHT.MEDIUM};
 `;
 
@@ -54,7 +54,7 @@ const Amount = styled.div``;
 const SmallRow = styled.div`
     padding-top: 8px;
     display: flex;
-    color: ${props => props.theme.TYPE_LIGHT_GREY};
+    color: ${({ theme }) => theme.TYPE_LIGHT_GREY};
     font-weight: ${variables.FONT_WEIGHT.MEDIUM};
     font-size: ${variables.FONT_SIZE.TINY};
 `;
@@ -69,7 +69,7 @@ const StyledStatus = styled(Status)`
 
 const TradeID = styled.span`
     padding-left: 5px;
-    color: ${props => props.theme.TYPE_LIGHT_GREY};
+    color: ${({ theme }) => theme.TYPE_LIGHT_GREY};
     font-weight: ${variables.FONT_WEIGHT.DEMI_BOLD};
     overflow: hidden;
     text-overflow: ellipsis;

--- a/packages/suite/src/components/wallet/CoinmarketLayout/components/AccountTransactions/components/SpendTransaction/index.tsx
+++ b/packages/suite/src/components/wallet/CoinmarketLayout/components/AccountTransactions/components/SpendTransaction/index.tsx
@@ -7,13 +7,6 @@ import { CoinmarketProviderInfo } from 'src/components/wallet';
 import { SellProviderInfo } from 'invity-api';
 import { TradeSpend } from 'src/types/wallet/coinmarketCommonTypes';
 
-interface Props {
-    trade: TradeSpend;
-    providers?: {
-        [name: string]: SellProviderInfo;
-    };
-}
-
 const Wrapper = styled.div`
     display: flex;
     flex: 1;
@@ -79,7 +72,14 @@ const ProviderColumn = styled(Column)`
     max-width: 330px;
 `;
 
-const SpendTransaction = ({ trade, providers }: Props) => {
+interface SpendTransactionProps {
+    trade: TradeSpend;
+    providers?: {
+        [name: string]: SellProviderInfo;
+    };
+}
+
+const SpendTransaction = ({ trade, providers }: SpendTransactionProps) => {
     const { date, data, tradeType } = trade;
     const { exchange } = data;
     const { cryptoAmount, cryptoCurrency, paymentId } = data;

--- a/packages/suite/src/components/wallet/CoinmarketLayout/components/AccountTransactions/components/Status/index.tsx
+++ b/packages/suite/src/components/wallet/CoinmarketLayout/components/AccountTransactions/components/Status/index.tsx
@@ -14,12 +14,6 @@ import {
     SavingsTradeItemStatus,
 } from 'invity-api';
 
-interface Props {
-    trade: Trade['data'];
-    tradeType: Trade['tradeType'];
-    className?: string;
-}
-
 const Wrapper = styled.div<{ color: string }>`
     display: flex;
     color: ${props => props.color};
@@ -163,7 +157,13 @@ type StatusData =
     | ReturnType<typeof getSpendTradeData>
     | ReturnType<typeof getSavingsTradeData>;
 
-const Status = ({ trade, className, tradeType }: Props) => {
+interface StatusProps {
+    trade: Trade['data'];
+    tradeType: Trade['tradeType'];
+    className?: string;
+}
+
+const Status = ({ trade, className, tradeType }: StatusProps) => {
     const theme = useTheme();
     let data: StatusData;
     switch (tradeType) {

--- a/packages/suite/src/components/wallet/CoinmarketLayout/components/AccountTransactions/index.tsx
+++ b/packages/suite/src/components/wallet/CoinmarketLayout/components/AccountTransactions/index.tsx
@@ -26,7 +26,7 @@ const NoTransactions = styled.div`
     display: flex;
     justify-content: center;
     font-weight: ${variables.FONT_WEIGHT.MEDIUM};
-    color: ${props => props.theme.TYPE_LIGHT_GREY};
+    color: ${({ theme }) => theme.TYPE_LIGHT_GREY};
 `;
 
 const StyledH2 = styled(H2)`
@@ -39,25 +39,22 @@ const TransactionCount = styled.div`
     margin-top: 6px;
     font-weight: ${variables.FONT_WEIGHT.MEDIUM};
     font-size: ${variables.FONT_SIZE.SMALL};
-    color: ${props => props.theme.TYPE_LIGHT_GREY};
+    color: ${({ theme }) => theme.TYPE_LIGHT_GREY};
 `;
 
 const AccountTransactions = () => {
-    const {
-        selectedAccount,
-        allTransactions,
-        buyProviders,
-        exchangeProviders,
-        sellProviders,
-        savingsProviders,
-    } = useSelector(state => ({
-        selectedAccount: state.wallet.selectedAccount,
-        allTransactions: state.wallet.coinmarket.trades,
-        buyProviders: state.wallet.coinmarket.buy.buyInfo?.providerInfos,
-        exchangeProviders: state.wallet.coinmarket.exchange.exchangeInfo?.providerInfos,
-        sellProviders: state.wallet.coinmarket.sell.sellInfo?.providerInfos,
-        savingsProviders: state.wallet.coinmarket.savings.savingsInfo?.providerInfos,
-    }));
+    const selectedAccount = useSelector(state => state.wallet.selectedAccount);
+    const allTransactions = useSelector(state => state.wallet.coinmarket.trades);
+    const buyProviders = useSelector(state => state.wallet.coinmarket.buy.buyInfo?.providerInfos);
+    const exchangeProviders = useSelector(
+        state => state.wallet.coinmarket.exchange.exchangeInfo?.providerInfos,
+    );
+    const sellProviders = useSelector(
+        state => state.wallet.coinmarket.sell.sellInfo?.providerInfos,
+    );
+    const savingsProviders = useSelector(
+        state => state.wallet.coinmarket.savings.savingsInfo?.providerInfos,
+    );
 
     if (selectedAccount.status !== 'loaded') {
         return null;

--- a/packages/suite/src/components/wallet/CoinmarketLayout/components/Navigation/index.tsx
+++ b/packages/suite/src/components/wallet/CoinmarketLayout/components/Navigation/index.tsx
@@ -1,10 +1,11 @@
 import React from 'react';
 import styled from 'styled-components';
-import * as routerActions from 'src/actions/suite/routerActions';
-import { useSelector, useActions } from 'src/hooks/suite';
+import { goto } from 'src/actions/suite/routerActions';
+import { useDispatch, useSelector } from 'src/hooks/suite';
 import { WalletLayoutNavigation, WalletLayoutNavLink } from 'src/components/wallet';
 import { getTitleForNetwork } from '@suite-common/wallet-utils';
 import { Translation } from 'src/components/suite';
+import { selectSelectedAccount } from 'src/reducers/wallet/selectedAccountReducer';
 
 const SavingsWalletLayoutNavLinkWrapper = styled.div`
     display: flex;
@@ -12,23 +13,24 @@ const SavingsWalletLayoutNavLinkWrapper = styled.div`
     padding-left: 42px;
 `;
 
-const Navigation = () => {
-    const items = [
-        { route: 'wallet-coinmarket-buy', title: 'TR_NAV_BUY' },
-        { route: 'wallet-coinmarket-sell', title: 'TR_NAV_SELL' },
-        { route: 'wallet-coinmarket-exchange', title: 'TR_NAV_EXCHANGE' },
-        { route: 'wallet-coinmarket-spend', title: 'TR_NAV_SPEND' },
-    ] as const;
+const items = [
+    { route: 'wallet-coinmarket-buy', title: 'TR_NAV_BUY' },
+    { route: 'wallet-coinmarket-sell', title: 'TR_NAV_SELL' },
+    { route: 'wallet-coinmarket-exchange', title: 'TR_NAV_EXCHANGE' },
+    { route: 'wallet-coinmarket-spend', title: 'TR_NAV_SPEND' },
+] as const;
+const p2pRoute = 'wallet-coinmarket-p2p';
 
-    const { routeName, account, p2pSupportedCoins, savingsProviders } = useSelector(state => ({
-        routeName: state.router.route?.name,
-        account: state.wallet.selectedAccount?.account,
-        p2pSupportedCoins: state.wallet.coinmarket.p2p.p2pInfo?.supportedCoins,
-        savingsProviders: state.wallet.coinmarket.savings.savingsInfo?.savingsList?.providers,
-    }));
-    const { goto } = useActions({
-        goto: routerActions.goto,
-    });
+const Navigation = () => {
+    const routeName = useSelector(state => state.router.route?.name);
+    const account = useSelector(selectSelectedAccount);
+    const p2pSupportedCoins = useSelector(
+        state => state.wallet.coinmarket.p2p.p2pInfo?.supportedCoins,
+    );
+    const savingsProviders = useSelector(
+        state => state.wallet.coinmarket.savings.savingsInfo?.savingsList?.providers,
+    );
+    const dispatch = useDispatch();
 
     const showP2pTab = account && p2pSupportedCoins && p2pSupportedCoins.has(account.symbol);
     const showSavingsTab =
@@ -40,7 +42,13 @@ const Navigation = () => {
                 savingsProvider.tradedCoins.includes(account.symbol.toUpperCase()),
         );
 
-    const p2pRoute = 'wallet-coinmarket-p2p';
+    const goToP2p = () => dispatch(goto(p2pRoute, { preserveParams: true }));
+    const goToSavingsSetup = () =>
+        dispatch(
+            goto('wallet-coinmarket-savings-setup', {
+                preserveParams: true,
+            }),
+        );
 
     return (
         <WalletLayoutNavigation>
@@ -51,7 +59,7 @@ const Navigation = () => {
                         key={route}
                         title={title}
                         active={routeName === route}
-                        onClick={() => goto(route, { preserveParams: true })}
+                        onClick={() => dispatch(goto(route, { preserveParams: true }))}
                     />
                 ))}
                 {showP2pTab && (
@@ -59,7 +67,7 @@ const Navigation = () => {
                         key={p2pRoute}
                         title="TR_NAV_P2P"
                         active={routeName === p2pRoute}
-                        onClick={() => goto(p2pRoute, { preserveParams: true })}
+                        onClick={goToP2p}
                     />
                 )}
                 {showSavingsTab && (
@@ -74,9 +82,7 @@ const Navigation = () => {
                             }}
                             badge="TR_NAV_SAVINGS_BADGE"
                             active={!!routeName?.startsWith('wallet-coinmarket-savings')}
-                            onClick={() =>
-                                goto('wallet-coinmarket-savings-setup', { preserveParams: true })
-                            }
+                            onClick={goToSavingsSetup}
                         />
                     </SavingsWalletLayoutNavLinkWrapper>
                 )}

--- a/packages/suite/src/components/wallet/CoinmarketLayout/index.tsx
+++ b/packages/suite/src/components/wallet/CoinmarketLayout/index.tsx
@@ -21,13 +21,17 @@ const BottomContent = styled.div`
     flex-direction: column;
 `;
 
-interface Props {
+interface CoinmarketLayoutProps {
     children: ReactNode;
     selectedAccount: SelectedAccountLoaded;
     onClearFormButtonClick?: () => void;
 }
 
-const CoinmarketLayout = ({ children, selectedAccount, onClearFormButtonClick }: Props) => (
+const CoinmarketLayout = ({
+    children,
+    selectedAccount,
+    onClearFormButtonClick,
+}: CoinmarketLayoutProps) => (
     <WalletLayout title="TR_NAV_TRADE" account={selectedAccount}>
         <WalletLayoutHeader title="TR_NAV_TRADE">
             {onClearFormButtonClick && (

--- a/packages/suite/src/components/wallet/CoinmarketPaymentType/index.tsx
+++ b/packages/suite/src/components/wallet/CoinmarketPaymentType/index.tsx
@@ -11,7 +11,7 @@ const Wrapper = styled.div`
 `;
 
 const Bg = styled.div`
-    background: ${props => props.theme.BG_ICON};
+    background: ${({ theme }) => theme.BG_ICON};
     display: flex;
     align-items: center;
     border-radius: 4px;
@@ -29,7 +29,7 @@ const Text = styled.div`
     display: flex;
     align-items: center;
     font-size: ${variables.FONT_SIZE.NORMAL};
-    color: ${props => props.theme.TYPE_DARK_GREY};
+    color: ${({ theme }) => theme.TYPE_DARK_GREY};
     font-weight: ${variables.FONT_WEIGHT.MEDIUM};
 `;
 

--- a/packages/suite/src/components/wallet/CoinmarketProvidedByInvity/index.tsx
+++ b/packages/suite/src/components/wallet/CoinmarketProvidedByInvity/index.tsx
@@ -8,7 +8,7 @@ const Wrapper = styled.div`
     display: flex;
     align-items: center;
     font-weight: ${variables.FONT_WEIGHT.MEDIUM};
-    color: ${props => props.theme.TYPE_LIGHT_GREY};
+    color: ${({ theme }) => theme.TYPE_LIGHT_GREY};
 `;
 
 const StyledLink = styled(Link)`

--- a/packages/suite/src/components/wallet/CoinmarketProviderInfo/index.tsx
+++ b/packages/suite/src/components/wallet/CoinmarketProviderInfo/index.tsx
@@ -34,7 +34,7 @@ const Text = styled.div`
     font-weight: ${variables.FONT_WEIGHT.MEDIUM};
 `;
 
-interface Props {
+interface CoinmarketProviderInfoProps {
     exchange?: string;
     providers?: {
         [name: string]: {
@@ -44,7 +44,7 @@ interface Props {
     };
 }
 
-const CoinmarketProviderInfo = ({ exchange, providers }: Props) => {
+const CoinmarketProviderInfo = ({ exchange, providers }: CoinmarketProviderInfoProps) => {
     const provider = providers && exchange ? providers[exchange] : null;
     return (
         <Wrapper>

--- a/packages/suite/src/components/wallet/CoinmarketProviderInfo/index.tsx
+++ b/packages/suite/src/components/wallet/CoinmarketProviderInfo/index.tsx
@@ -9,7 +9,7 @@ const Wrapper = styled.div`
 `;
 
 const Bg = styled.div`
-    background: ${props => props.theme.BG_ICON};
+    background: ${({ theme }) => theme.BG_ICON};
     display: flex;
     align-items: center;
     border-radius: 4px;
@@ -30,7 +30,7 @@ const Text = styled.div`
     padding-left: 5px;
     align-items: center;
     font-size: ${variables.FONT_SIZE.NORMAL};
-    color: ${props => props.theme.TYPE_DARK_GREY};
+    color: ${({ theme }) => theme.TYPE_DARK_GREY};
     font-weight: ${variables.FONT_WEIGHT.MEDIUM};
 `;
 

--- a/packages/suite/src/components/wallet/CoinmarketRefreshTime/index.tsx
+++ b/packages/suite/src/components/wallet/CoinmarketRefreshTime/index.tsx
@@ -25,14 +25,19 @@ const RefreshTime = styled.div`
     font-weight: ${variables.FONT_WEIGHT.DEMI_BOLD};
 `;
 
-interface Props {
+interface CoinmarketRefreshTimeProps {
     isLoading: boolean;
     seconds: number;
     refetchInterval: number;
     label: ReactElement;
 }
 
-const CoinmarketRefreshTime = ({ isLoading, seconds, refetchInterval, label }: Props) => (
+const CoinmarketRefreshTime = ({
+    isLoading,
+    seconds,
+    refetchInterval,
+    label,
+}: CoinmarketRefreshTimeProps) => (
     <Wrapper>
         {!isLoading && <RefreshLabel>{label}</RefreshLabel>}
         <RefreshTime>

--- a/packages/suite/src/components/wallet/CoinmarketRefreshTime/index.tsx
+++ b/packages/suite/src/components/wallet/CoinmarketRefreshTime/index.tsx
@@ -11,7 +11,7 @@ const Wrapper = styled.div`
 `;
 
 const RefreshLabel = styled.div`
-    color: ${props => props.theme.TYPE_LIGHT_GREY};
+    color: ${({ theme }) => theme.TYPE_LIGHT_GREY};
     font-size: ${variables.FONT_SIZE.SMALL};
     font-weight: ${variables.FONT_WEIGHT.MEDIUM};
 `;
@@ -20,7 +20,7 @@ const RefreshTime = styled.div`
     margin-left: 4px;
     font-variant-numeric: tabular-nums;
     text-align: right;
-    color: ${props => props.theme.TYPE_DARK_GREY};
+    color: ${({ theme }) => theme.TYPE_DARK_GREY};
     font-size: ${variables.FONT_SIZE.SMALL};
     font-weight: ${variables.FONT_WEIGHT.DEMI_BOLD};
 `;

--- a/packages/suite/src/components/wallet/CoinmarketSellOfferInfo/index.tsx
+++ b/packages/suite/src/components/wallet/CoinmarketSellOfferInfo/index.tsx
@@ -34,7 +34,7 @@ const Wrapper = styled.div`
 const Header = styled.div`
     display: flex;
     align-items: center;
-    border-bottom: 1px solid ${props => props.theme.STROKE_GREY};
+    border-bottom: 1px solid ${({ theme }) => theme.STROKE_GREY};
     margin-bottom: 5px;
     padding: 15px 24px;
     max-width: 340px;
@@ -42,7 +42,7 @@ const Header = styled.div`
 
 const AccountText = styled.div`
     font-weight: ${variables.FONT_WEIGHT.MEDIUM};
-    color: ${props => props.theme.TYPE_DARK_GREY};
+    color: ${({ theme }) => theme.TYPE_DARK_GREY};
     padding-left: 7px;
 `;
 
@@ -52,7 +52,7 @@ const Info = styled.div`
     min-width: 350px;
     margin: 0 0 10px 30px;
     min-height: 200px;
-    border: 1px solid ${props => props.theme.STROKE_GREY};
+    border: 1px solid ${({ theme }) => theme.STROKE_GREY};
     border-radius: 4px;
 
     @media screen and (max-width: ${variables.SCREEN_SIZE.LG}) {
@@ -67,7 +67,7 @@ const LeftColumn = styled.div`
     flex: 1;
     text-transform: uppercase;
     font-weight: ${variables.FONT_WEIGHT.MEDIUM};
-    color: ${props => props.theme.TYPE_LIGHT_GREY};
+    color: ${({ theme }) => theme.TYPE_LIGHT_GREY};
     align-self: center;
 `;
 
@@ -87,11 +87,11 @@ const Dark = styled.div`
     justify-content: flex-end;
     flex: 1;
     font-weight: ${variables.FONT_WEIGHT.DEMI_BOLD};
-    color: ${props => props.theme.TYPE_DARK_GREY};
+    color: ${({ theme }) => theme.TYPE_DARK_GREY};
 `;
 
 const RowWithBorder = styled(Row)`
-    border-bottom: 1px solid ${props => props.theme.STROKE_GREY};
+    border-bottom: 1px solid ${({ theme }) => theme.STROKE_GREY};
     margin-bottom: 10px;
     padding-bottom: 10px;
 `;

--- a/packages/suite/src/components/wallet/CoinmarketSellOfferInfo/index.tsx
+++ b/packages/suite/src/components/wallet/CoinmarketSellOfferInfo/index.tsx
@@ -12,15 +12,6 @@ import { Translation, AccountLabeling } from 'src/components/suite';
 import { CoinmarketCryptoAmount } from 'src/views/wallet/coinmarket/common/CoinmarketCryptoAmount';
 import { CoinmarketFiatAmount } from 'src/views/wallet/coinmarket/common/CoinmarketFiatAmount';
 
-interface Props {
-    selectedQuote: SellFiatTrade;
-    transactionId?: string;
-    providers?: {
-        [name: string]: SellProviderInfo;
-    };
-    account: Account;
-}
-
 const Wrapper = styled.div`
     display: flex;
     flex-direction: column;
@@ -101,7 +92,21 @@ const TransactionIdWrapper = styled.div`
     max-width: 350px;
 `;
 
-const CoinmarketSellOfferInfo = ({ selectedQuote, transactionId, providers, account }: Props) => {
+interface CoinmarketSellOfferInfoProps {
+    selectedQuote: SellFiatTrade;
+    transactionId?: string;
+    providers?: {
+        [name: string]: SellProviderInfo;
+    };
+    account: Account;
+}
+
+const CoinmarketSellOfferInfo = ({
+    selectedQuote,
+    transactionId,
+    providers,
+    account,
+}: CoinmarketSellOfferInfoProps) => {
     const {
         cryptoStringAmount,
         cryptoCurrency,

--- a/packages/suite/src/components/wallet/CoinmarketTag/index.tsx
+++ b/packages/suite/src/components/wallet/CoinmarketTag/index.tsx
@@ -10,8 +10,8 @@ const Tag = styled.div`
     margin: 0 16px 2px 16px;
     padding: 3px 8px 0 8px;
     border-radius: 8px;
-    background: ${props => props.theme.TYPE_ORANGE};
-    color: ${props => props.theme.TYPE_WHITE};
+    background: ${({ theme }) => theme.TYPE_ORANGE};
+    color: ${({ theme }) => theme.TYPE_WHITE};
     font-size: ${variables.FONT_SIZE.TINY};
     line-height: 21px;
     text-transform: uppercase;

--- a/packages/suite/src/components/wallet/CoinmarketTopPanel/index.tsx
+++ b/packages/suite/src/components/wallet/CoinmarketTopPanel/index.tsx
@@ -1,6 +1,6 @@
-import * as routerActions from 'src/actions/suite/routerActions';
+import { goto } from 'src/actions/suite/routerActions';
 import { MAX_WIDTH } from 'src/constants/suite/layout';
-import { useActions, useSelector } from 'src/hooks/suite';
+import { useDispatch, useSelector } from 'src/hooks/suite';
 import { AccountLabeling } from 'src/components/suite';
 import { Icon, variables } from '@trezor/components';
 import React from 'react';
@@ -11,8 +11,8 @@ const Wrapper = styled.div`
     display: flex;
     width: 100%;
     justify-content: center;
-    background: ${props => props.theme.BG_LIGHT_GREY};
-    border-bottom: 1px solid ${props => props.theme.STROKE_GREY};
+    background: ${({ theme }) => theme.BG_LIGHT_GREY};
+    border-bottom: 1px solid ${({ theme }) => theme.STROKE_GREY};
 `;
 
 const Content = styled.div`
@@ -33,7 +33,7 @@ const Left = styled.div`
     display: flex;
     flex: 1;
     align-items: center;
-    color: ${props => props.theme.TYPE_LIGHT_GREY};
+    color: ${({ theme }) => theme.TYPE_LIGHT_GREY};
     font-weight: ${variables.FONT_WEIGHT.DEMI_BOLD};
 `;
 
@@ -55,27 +55,24 @@ const StyledIcon = styled(Icon)`
     margin-right: 12px;
 `;
 
-interface Props {
+interface CoinmarketTopPanelProps {
     backRoute: Route['name'];
 }
 
-const CoinmarketTopPanel = ({ backRoute }: Props) => {
-    const { goto } = useActions({
-        goto: routerActions.goto,
-    });
-
+const CoinmarketTopPanel = ({ backRoute }: CoinmarketTopPanelProps) => {
     const selectedAccount = useSelector(state => state.wallet.selectedAccount);
+    const dispatch = useDispatch();
+
     if (selectedAccount.status !== 'loaded') return null;
     const { account } = selectedAccount;
+
+    const goBack = () => dispatch(goto(backRoute, { params: selectedAccount.params }));
 
     return (
         <Wrapper>
             <Content>
                 <Left>
-                    <Back
-                        onClick={() => goto(backRoute, { params: selectedAccount.params })}
-                        data-test="@coinmarket/back"
-                    >
+                    <Back onClick={goBack} data-test="@coinmarket/back">
                         <StyledIcon icon="ARROW_LEFT" />
                         <AccountLabeling account={account} />
                     </Back>

--- a/packages/suite/src/components/wallet/CoinmarketTransactionId/index.tsx
+++ b/packages/suite/src/components/wallet/CoinmarketTransactionId/index.tsx
@@ -2,14 +2,9 @@ import React from 'react';
 import styled from 'styled-components';
 import { variables, Button } from '@trezor/components';
 import { copyToClipboard } from '@trezor/dom-utils';
-import { useActions } from 'src/hooks/suite';
+import { useDispatch } from 'src/hooks/suite';
 import { Translation } from 'src/components/suite';
 import { notificationsActions } from '@suite-common/toast-notifications';
-
-interface Props {
-    transactionId: string;
-    className?: string;
-}
 
 const Wrapper = styled.div`
     display: flex;
@@ -18,7 +13,7 @@ const Wrapper = styled.div`
     align-items: center;
     justify-content: space-between;
     font-size: ${variables.FONT_SIZE.TINY};
-    color: ${props => props.theme.TYPE_LIGHT_GREY};
+    color: ${({ theme }) => theme.TYPE_LIGHT_GREY};
     font-weight: ${variables.FONT_WEIGHT.MEDIUM};
 `;
 
@@ -42,12 +37,17 @@ const Value = styled.div`
     text-overflow: ellipsis;
 `;
 
-const TransactionId = ({ transactionId, className }: Props) => {
-    const { addNotification } = useActions({ addNotification: notificationsActions.addToast });
+interface TransactionIdProps {
+    transactionId: string;
+    className?: string;
+}
+
+const TransactionId = ({ transactionId, className }: TransactionIdProps) => {
+    const dispatch = useDispatch();
     const copy = () => {
         const result = copyToClipboard(transactionId);
         if (typeof result !== 'string') {
-            addNotification({ type: 'copy-to-clipboard' });
+            dispatch(notificationsActions.addToast({ type: 'copy-to-clipboard' }));
         }
     };
 
@@ -60,7 +60,7 @@ const TransactionId = ({ transactionId, className }: Props) => {
                 <Value>{transactionId}</Value>
             </Left>
             <Right>
-                <Button variant="tertiary" onClick={() => copy()}>
+                <Button variant="tertiary" onClick={copy}>
                     <Translation id="TR_COPY_TO_CLIPBOARD_TX_ID" />
                 </Button>
             </Right>

--- a/packages/suite/src/components/wallet/Fees/components/FeeDetails.tsx
+++ b/packages/suite/src/components/wallet/Fees/components/FeeDetails.tsx
@@ -25,12 +25,12 @@ const Wrapper = styled.div`
 
 const Item = styled.span`
     font-size: ${variables.FONT_SIZE.TINY};
-    color: ${props => props.theme.TYPE_LIGHT_GREY};
+    color: ${({ theme }) => theme.TYPE_LIGHT_GREY};
     font-weight: ${variables.FONT_WEIGHT.MEDIUM};
 `;
 
 const Label = styled.span`
-    color: ${props => props.theme.TYPE_DARK_GREY};
+    color: ${({ theme }) => theme.TYPE_DARK_GREY};
     font-weight: ${variables.FONT_WEIGHT.DEMI_BOLD};
     padding-right: 8px;
 `;

--- a/packages/suite/src/components/wallet/KYCError/index.tsx
+++ b/packages/suite/src/components/wallet/KYCError/index.tsx
@@ -6,7 +6,7 @@ import { Image } from '@trezor/components';
 
 const StyledCard = styled(SavingsKYCCard)`
     background: rgba(239, 65, 65, 0.1);
-    color: ${props => props.theme.BG_RED};
+    color: ${({ theme }) => theme.BG_RED};
 `;
 const Icon = styled.div`
     margin-right: 14px;

--- a/packages/suite/src/components/wallet/KYCFailed/index.tsx
+++ b/packages/suite/src/components/wallet/KYCFailed/index.tsx
@@ -6,7 +6,7 @@ import { Image } from '@trezor/components';
 
 const StyledCard = styled(SavingsKYCCard)`
     background: rgba(239, 65, 65, 0.1);
-    color: ${props => props.theme.BG_RED};
+    color: ${({ theme }) => theme.BG_RED};
 `;
 
 const Icon = styled.div`

--- a/packages/suite/src/components/wallet/KYCFailed/index.tsx
+++ b/packages/suite/src/components/wallet/KYCFailed/index.tsx
@@ -24,11 +24,11 @@ const Description = styled.div`
     line-height: 18px;
 `;
 
-interface Props {
+interface KYCFailedProps {
     providerName?: string;
 }
 
-const KYCFailed = ({ providerName }: Props) => (
+const KYCFailed = ({ providerName }: KYCFailedProps) => (
     <StyledCard>
         <Icon>
             <Image image="WARNING" />

--- a/packages/suite/src/components/wallet/KYCInProgress/index.tsx
+++ b/packages/suite/src/components/wallet/KYCInProgress/index.tsx
@@ -20,7 +20,7 @@ const Header = styled.div`
     line-height: 28px;
 `;
 const Description = styled.div`
-    color: ${props => props.theme.TYPE_LIGHT_GREY};
+    color: ${({ theme }) => theme.TYPE_LIGHT_GREY};
     font-size: 14px;
     line-height: 18px;
 `;

--- a/packages/suite/src/components/wallet/OnOffSwitcher/index.tsx
+++ b/packages/suite/src/components/wallet/OnOffSwitcher/index.tsx
@@ -22,12 +22,12 @@ const EqualSign = styled.div`
     padding: 0 4px;
 `;
 
-interface Props {
+interface OnOffSwitcherProps {
     isOn: boolean;
     hasEqualSign?: boolean;
 }
 
-const OnOffSwitcher = ({ isOn = true, hasEqualSign = true }: Props) => (
+const OnOffSwitcher = ({ isOn = true, hasEqualSign = true }: OnOffSwitcherProps) => (
     <Wrapper>
         {hasEqualSign && <EqualSign> = </EqualSign>}
         {isOn ? (

--- a/packages/suite/src/components/wallet/OnOffSwitcher/index.tsx
+++ b/packages/suite/src/components/wallet/OnOffSwitcher/index.tsx
@@ -11,11 +11,11 @@ const Option = styled.div`
 `;
 
 const On = styled(Option)`
-    color: ${props => props.theme.BG_GREEN};
+    color: ${({ theme }) => theme.BG_GREEN};
 `;
 
 const Off = styled(Option)`
-    color: ${props => props.theme.TYPE_RED};
+    color: ${({ theme }) => theme.TYPE_RED};
 `;
 
 const EqualSign = styled.div`

--- a/packages/suite/src/components/wallet/Pagination.tsx
+++ b/packages/suite/src/components/wallet/Pagination.tsx
@@ -12,8 +12,8 @@ const Wrapper = styled.div`
 const PageItem = styled.div<{ isActive?: boolean }>`
     cursor: pointer;
     font-size: ${variables.FONT_SIZE.SMALL};
-    background: ${props => (props.isActive ? props.theme.BG_GREEN : 'transparent')};
-    color: ${props => (props.isActive ? props.theme.TYPE_WHITE : props.theme.TYPE_GREEN)};
+    background: ${({ isActive, theme }) => (isActive ? theme.BG_GREEN : 'transparent')};
+    color: ${({ isActive, theme }) => (isActive ? theme.TYPE_WHITE : theme.TYPE_GREEN)};
     padding: 4px 8px;
     border-radius: 2px;
 `;

--- a/packages/suite/src/components/wallet/Pagination.tsx
+++ b/packages/suite/src/components/wallet/Pagination.tsx
@@ -24,7 +24,7 @@ const Actions = styled.div<{ isActive: boolean }>`
     font-weight: ${variables.FONT_WEIGHT.MEDIUM};
 `;
 
-interface Props {
+interface PaginationProps {
     currentPage: number;
     isLastPage?: boolean;
     hasPages?: boolean;
@@ -41,7 +41,7 @@ export const Pagination = ({
     perPage,
     totalItems,
     ...rest
-}: Props) => {
+}: PaginationProps) => {
     const totalPages = Math.ceil(totalItems / perPage);
     const showPrevious = currentPage > 1;
     // array of int used for creating all page buttons

--- a/packages/suite/src/components/wallet/TransactionItem/components/BaseTargetLayout.tsx
+++ b/packages/suite/src/components/wallet/TransactionItem/components/BaseTargetLayout.tsx
@@ -7,7 +7,7 @@ import { variables, motionAnimation } from '@trezor/components';
 export const MIN_ROW_HEIGHT = '23px';
 
 const FiatAmount = styled.span`
-    color: ${props => props.theme.TYPE_LIGHT_GREY};
+    color: ${({ theme }) => theme.TYPE_LIGHT_GREY};
     font-size: ${variables.FONT_SIZE.SMALL};
     font-weight: ${variables.FONT_WEIGHT.MEDIUM};
     line-height: 1.57;
@@ -45,7 +45,7 @@ const StyledHiddenPlaceholder = styled(props => <HiddenPlaceholder {...props} />
 const TargetAddress = styled(motion.div)`
     display: flex;
     flex: 1;
-    color: ${props => props.theme.TYPE_LIGHT_GREY};
+    color: ${({ theme }) => theme.TYPE_LIGHT_GREY};
     font-size: ${variables.FONT_SIZE.SMALL};
     font-weight: ${variables.FONT_WEIGHT.MEDIUM};
     overflow: hidden;
@@ -75,7 +75,7 @@ const TimelineDot = styled.div`
     width: 3px;
     height: 3px;
     border-radius: 50%;
-    background: ${props => props.theme.TYPE_LIGHT_GREY};
+    background: ${({ theme }) => theme.TYPE_LIGHT_GREY};
 `;
 
 const TimelineLine = styled.div<{ show: boolean; top?: boolean }>`

--- a/packages/suite/src/components/wallet/TransactionItem/components/CoinjoinBatchItem.tsx
+++ b/packages/suite/src/components/wallet/TransactionItem/components/CoinjoinBatchItem.tsx
@@ -11,8 +11,8 @@ import {
 import { useFormatters } from '@suite-common/formatters';
 import { variables, CollapsibleBox } from '@trezor/components';
 
-import { useActions } from 'src/hooks/suite/useActions';
-import * as modalActions from 'src/actions/suite/modalActions';
+import { useDispatch } from 'src/hooks/suite';
+import { openModal } from 'src/actions/suite/modalActions';
 import { WalletAccountTransaction } from 'src/types/wallet/index';
 import { HiddenPlaceholder, Translation } from 'src/components/suite';
 import { TransactionTimestamp } from 'src/components/wallet/TransactionTimestamp';
@@ -50,19 +50,20 @@ const RoundRow = styled.div`
 `;
 
 const Round = ({ transaction }: { transaction: WalletAccountTransaction }) => {
-    const { openModal } = useActions({ openModal: modalActions.openModal });
+    const dispatch = useDispatch();
 
     const transactionAmount = new BigNumber(transaction.amount);
 
+    const openTransactionDetail = () =>
+        dispatch(
+            openModal({
+                type: 'transaction-detail',
+                tx: transaction,
+            }),
+        );
+
     return (
-        <RoundRow
-            onClick={() =>
-                openModal({
-                    type: 'transaction-detail',
-                    tx: transaction,
-                })
-            }
-        >
+        <RoundRow onClick={openTransactionDetail}>
             <TransactionTypeIcon type="joint" isPending={false} size={20} />
             <TransactionTimestamp transaction={transaction} />
             <BaseTargetLayout
@@ -95,7 +96,7 @@ const Round = ({ transaction }: { transaction: WalletAccountTransaction }) => {
 };
 
 const StyledCollapsibleBox = styled(CollapsibleBox)<{ isPending: boolean }>`
-    background-color: ${props => props.theme.BG_WHITE};
+    background-color: ${({ theme }) => theme.BG_WHITE};
     box-shadow: none;
     border-radius: 12px;
     margin-bottom: 0;

--- a/packages/suite/src/components/wallet/TransactionItem/components/CommonComponents.tsx
+++ b/packages/suite/src/components/wallet/TransactionItem/components/CommonComponents.tsx
@@ -37,7 +37,7 @@ export const Content = styled.div`
 `;
 
 export const Description = styled(props => <HiddenPlaceholder {...props} />)`
-    color: ${props => props.theme.TYPE_DARK_GREY};
+    color: ${({ theme }) => theme.TYPE_DARK_GREY};
     font-size: ${variables.FONT_SIZE.NORMAL};
     font-weight: ${variables.FONT_WEIGHT.MEDIUM};
     line-height: 1.5;

--- a/packages/suite/src/components/wallet/WalletLayout/components/WalletLayoutHeader.tsx
+++ b/packages/suite/src/components/wallet/WalletLayout/components/WalletLayoutHeader.tsx
@@ -30,7 +30,7 @@ const HeaderRight = styled.div`
 
 const StyledTitle = styled(H2)`
     font-weight: ${variables.FONT_WEIGHT.DEMI_BOLD};
-    color: ${props => props.theme.TYPE_DARK_GREY};
+    color: ${({ theme }) => theme.TYPE_DARK_GREY};
 `;
 
 type WalletLayoutHeaderProps = {

--- a/packages/suite/src/components/wallet/WalletLayout/components/WalletLayoutNavigation.tsx
+++ b/packages/suite/src/components/wallet/WalletLayout/components/WalletLayoutNavigation.tsx
@@ -9,13 +9,13 @@ const { FONT_WEIGHT, FONT_SIZE } = variables;
 const NavLink = styled.div<{ active?: boolean }>`
     cursor: pointer;
     font-size: ${FONT_SIZE.NORMAL};
-    color: ${props => (props.active ? props.theme.TYPE_GREEN : props.theme.TYPE_LIGHT_GREY)};
+    color: ${({ active, theme }) => (active ? theme.TYPE_GREEN : theme.TYPE_LIGHT_GREY)};
     font-weight: ${FONT_WEIGHT.MEDIUM};
     display: flex;
     align-items: center;
     padding: 14px 6px 12px 6px;
     white-space: nowrap;
-    border-bottom: 2px solid ${props => (props.active ? props.theme.BG_GREEN : 'transparent')};
+    border-bottom: 2px solid ${({ active, theme }) => (active ? theme.BG_GREEN : 'transparent')};
     transition: border-color 0.1s;
 
     :hover {
@@ -92,7 +92,7 @@ const Navigation = styled.div`
         height: 0;
     }
 
-    border-bottom: 1px solid ${props => props.theme.STROKE_GREY};
+    border-bottom: 1px solid ${({ theme }) => theme.STROKE_GREY};
 `;
 
 type WalletLayoutNavigationProps = {

--- a/packages/suite/src/components/wallet/hocs/withCoinmarket.tsx
+++ b/packages/suite/src/components/wallet/hocs/withCoinmarket.tsx
@@ -1,8 +1,8 @@
 import React, { useEffect } from 'react';
 import { CoinmarketLayout, withSelectedAccountLoaded } from 'src/components/wallet';
 import type { AppState, ExtendedMessageDescriptor } from 'src/types/suite';
-import { useActions } from 'src/hooks/suite';
-import * as coinmarketCommonActions from 'src/actions/wallet/coinmarket/coinmarketCommonActions';
+import { useDispatch } from 'src/hooks/suite';
+import { loadInvityData } from 'src/actions/wallet/coinmarket/coinmarketCommonActions';
 
 interface ComponentProps {
     selectedAccount: AppState['wallet']['selectedAccount'];
@@ -22,13 +22,11 @@ export const withCoinmarket = (
 ) => {
     const displayName = WrappedComponent.displayName || WrappedComponent.name || 'Component';
     const Component = withSelectedAccountLoaded(({ selectedAccount }) => {
-        const { loadInvityData } = useActions({
-            loadInvityData: coinmarketCommonActions.loadInvityData,
-        });
+        const dispatch = useDispatch();
 
         useEffect(() => {
-            loadInvityData();
-        }, [loadInvityData]);
+            dispatch(loadInvityData());
+        }, [dispatch]);
 
         return (
             <CoinmarketLayout selectedAccount={selectedAccount}>

--- a/packages/suite/src/components/wallet/hocs/withSelectedAccountLoaded.tsx
+++ b/packages/suite/src/components/wallet/hocs/withSelectedAccountLoaded.tsx
@@ -19,9 +19,7 @@ export const withSelectedAccountLoaded = (
     const { title } = options;
     const displayName = WrappedComponent.displayName || WrappedComponent.name || 'Component';
     const Component = () => {
-        const { selectedAccount } = useSelector(state => ({
-            selectedAccount: state.wallet.selectedAccount,
-        }));
+        const selectedAccount = useSelector(state => state.wallet.selectedAccount);
 
         if (selectedAccount.status !== 'loaded') {
             return <WalletLayout title={title} account={selectedAccount} />;

--- a/packages/suite/src/components/wallet/tooltips/VerifyAddressTooltip/index.tsx
+++ b/packages/suite/src/components/wallet/tooltips/VerifyAddressTooltip/index.tsx
@@ -5,13 +5,17 @@ import { Translation } from 'src/components/suite/Translation';
 const Wrapper = styled.div``;
 const Content = styled.div``;
 
-interface Props {
+interface VerifyAddressTooltipProps {
     isConnected: boolean;
     isAvailable: boolean;
     addressUnverified: boolean;
 }
 
-const VerifyAddressTooltip = ({ isConnected, isAvailable, addressUnverified }: Props) => (
+const VerifyAddressTooltip = ({
+    isConnected,
+    isAvailable,
+    addressUnverified,
+}: VerifyAddressTooltipProps) => (
     <Wrapper>
         {addressUnverified && (
             <Content>

--- a/packages/suite/src/hooks/firmware/useRebootRequest.ts
+++ b/packages/suite/src/hooks/firmware/useRebootRequest.ts
@@ -2,8 +2,8 @@ import { useState, useEffect } from 'react';
 import { valid, satisfies } from 'semver';
 import { getFirmwareVersion } from '@trezor/device-utils';
 import type { TrezorDevice } from 'src/types/suite';
-import { useActions } from 'src/hooks/suite';
-import * as firmwareActions from 'src/actions/firmware/firmwareActions';
+import { useDispatch } from 'src/hooks/suite';
+import { rebootToBootloader } from 'src/actions/firmware/firmwareActions';
 
 export type RebootRequestedMode = 'bootloader' | 'normal';
 export type RebootPhase = 'initial' | 'wait-for-confirm' | 'disconnected' | 'done';
@@ -32,9 +32,7 @@ export const useRebootRequest = (
             : 'manual';
     });
 
-    const { rebootToBootloader } = useActions({
-        rebootToBootloader: firmwareActions.rebootToBootloader,
-    });
+    const dispatch = useDispatch();
 
     // Sets current reboot phase based on previous phase, requested mode
     // and current device state.
@@ -53,7 +51,7 @@ export const useRebootRequest = (
             // else do nothing and wait for manual disconnection
             if (method === 'automatic') {
                 setPhase('wait-for-confirm');
-                rebootToBootloader().then(res => {
+                dispatch(rebootToBootloader()).then(res => {
                     if (!res?.success) {
                         // If automatic reboot wasn't successful, fallback to 'manual' and return to 'initial'
                         setMethod('manual');
@@ -62,7 +60,7 @@ export const useRebootRequest = (
                 });
             }
         }
-    }, [device, phase, method, requestedMode, rebootToBootloader]);
+    }, [device, dispatch, phase, method, requestedMode]);
 
     return {
         rebootMethod: method,

--- a/packages/suite/src/hooks/guide/useGuide.ts
+++ b/packages/suite/src/hooks/guide/useGuide.ts
@@ -1,19 +1,15 @@
 import { useMemo } from 'react';
-import { useSelector, useActions, useLayoutSize } from 'src/hooks/suite';
-import * as guideActions from 'src/actions/suite/guideActions';
+import { useDispatch, useSelector, useLayoutSize } from 'src/hooks/suite';
+import { close, open } from 'src/actions/suite/guideActions';
 import { usePreferredModal } from '../suite/usePreferredModal';
 
 export const GUIDE_ANIMATION_DURATION_MS = 300;
 
 export const useGuide = () => {
     const isGuideOpen = useSelector(state => state.guide.open);
+    const dispatch = useDispatch();
 
     const { layoutSize } = useLayoutSize();
-
-    const { openGuide, closeGuide } = useActions({
-        openGuide: guideActions.open,
-        closeGuide: guideActions.close,
-    });
 
     const isGuideOnTop = useMemo(
         () => ['NORMAL', 'SMALL', 'TINY'].includes(layoutSize),
@@ -26,7 +22,7 @@ export const useGuide = () => {
         isGuideOpen,
         isGuideOnTop,
         isModalOpen,
-        openGuide,
-        closeGuide,
+        openGuide: () => dispatch(open()),
+        closeGuide: () => dispatch(close()),
     };
 };

--- a/packages/suite/src/hooks/guide/useGuideOpenNode.ts
+++ b/packages/suite/src/hooks/guide/useGuideOpenNode.ts
@@ -1,20 +1,15 @@
 import { analytics, EventType } from '@trezor/suite-analytics';
 
-import { useActions, useSelector } from 'src/hooks/suite';
-import * as guideActions from 'src/actions/suite/guideActions';
+import { useDispatch, useSelector } from 'src/hooks/suite';
+import { openNode } from 'src/actions/suite/guideActions';
 import { getNodeById } from 'src/utils/suite/guide';
 import { useGuide } from 'src/hooks/guide';
 
 export const useGuideOpenNode = () => {
     const { isGuideOpen, openGuide } = useGuide();
 
-    const { openNode } = useActions({
-        openNode: guideActions.openNode,
-    });
-
-    const { indexNode } = useSelector(state => ({
-        indexNode: state.guide.indexNode,
-    }));
+    const indexNode = useSelector(state => state.guide.indexNode);
+    const dispatch = useDispatch();
 
     const openNodeById = (id: string) => {
         if (!indexNode) {
@@ -27,7 +22,7 @@ export const useGuideOpenNode = () => {
             return;
         }
 
-        openNode(node);
+        dispatch(openNode(node));
 
         if (!isGuideOpen) {
             openGuide();

--- a/packages/suite/src/hooks/settings/backends/useBackendsForm.ts
+++ b/packages/suite/src/hooks/settings/backends/useBackendsForm.ts
@@ -2,7 +2,7 @@ import { useState } from 'react';
 import { useForm } from 'react-hook-form';
 import { analytics, EventType } from '@trezor/suite-analytics';
 
-import { useActions, useSelector, useTranslation } from 'src/hooks/suite';
+import { useDispatch, useSelector, useTranslation } from 'src/hooks/suite';
 import { isUrl } from '@trezor/utils';
 import { isOnionUrl } from 'src/utils/suite/tor';
 import { blockchainActions } from '@suite-common/wallet-core';
@@ -97,11 +97,9 @@ const getStoredState = (
 
 export const useBackendsForm = (coin: Network['symbol']) => {
     const backends = useSelector(state => state.wallet.blockchain[coin].backends);
+    const dispatch = useDispatch();
     const initial = getStoredState(coin, backends.selected, backends.urls);
     const [currentValues, setCurrentValues] = useState(initial);
-    const actions = useActions({
-        setBackend: blockchainActions.setBackend,
-    });
 
     const changeType = (type: BackendOption) => {
         setCurrentValues(getStoredState(coin, type, backends.urls));
@@ -136,7 +134,7 @@ export const useBackendsForm = (coin: Network['symbol']) => {
     const save = () => {
         const { type } = currentValues;
         const urls = type === 'default' ? [] : getUrls();
-        actions.setBackend({ coin, type, urls });
+        dispatch(blockchainActions.setBackend({ coin, type, urls }));
         const totalOnion = urls.filter(isOnionUrl).length;
 
         analytics.report({

--- a/packages/suite/src/hooks/settings/useEnabledNetworks.ts
+++ b/packages/suite/src/hooks/settings/useEnabledNetworks.ts
@@ -12,14 +12,12 @@ type EnabledNetworks = {
 };
 
 export const useEnabledNetworks = (): EnabledNetworks => {
-    const { enabledNetworks, debug } = useSelector(state => ({
-        enabledNetworks: state.wallet.settings.enabledNetworks,
-        debug: state.suite.settings.debug.showDebugMenu,
-    }));
+    const enabledNetworks = useSelector(state => state.wallet.settings.enabledNetworks);
+    const isDebug = useSelector(state => state.suite.settings.debug.showDebugMenu);
 
-    const mainnets: Network[] = getMainnets();
+    const mainnets = getMainnets();
 
-    const testnets: Network[] = getTestnets(debug);
+    const testnets = getTestnets(isDebug);
 
     const { setEnabled } = useActions({
         setEnabled: changeCoinVisibility,

--- a/packages/suite/src/hooks/suite/useDevice.ts
+++ b/packages/suite/src/hooks/suite/useDevice.ts
@@ -3,10 +3,9 @@ import { useSelector } from './useSelector';
 import { SUITE } from 'src/actions/suite/constants';
 
 export const useDevice = () => {
-    const { device, locks } = useSelector(state => ({
-        device: state.suite.device,
-        locks: state.suite.locks,
-    }));
+    const device = useSelector(state => state.suite.device);
+    const locks = useSelector(state => state.suite.locks);
+
     const isLocked = useCallback(
         (ignoreDisconnectedDevice = false) => {
             if (!device?.connected && !ignoreDisconnectedDevice) return true;

--- a/packages/suite/src/hooks/suite/useFirmware.ts
+++ b/packages/suite/src/hooks/suite/useFirmware.ts
@@ -10,10 +10,8 @@ import { FirmwareStatus, selectFirmware } from 'src/reducers/firmware/firmwareRe
 export const useFirmware = () => {
     const dispatch = useDispatch();
     const firmware = useSelector(selectFirmware);
-    const { transport, modal } = useSelector(state => ({
-        modal: state.modal,
-        transport: state.suite.transport,
-    }));
+    const transport = useSelector(state => state.suite.transport);
+    const modal = useSelector(state => state.modal);
 
     const showFingerprintCheck =
         modal.context === MODAL.CONTEXT_DEVICE &&

--- a/packages/suite/src/hooks/suite/useGraph.ts
+++ b/packages/suite/src/hooks/suite/useGraph.ts
@@ -2,10 +2,8 @@ import { useSelector, useActions } from 'src/hooks/suite';
 import * as graphActions from 'src/actions/wallet/graphActions';
 
 export const useGraph = () => {
-    const { selectedRange, selectedView } = useSelector(state => ({
-        selectedRange: state.wallet.graph.selectedRange,
-        selectedView: state.wallet.graph.selectedView,
-    }));
+    const selectedRange = useSelector(state => state.wallet.graph.selectedRange);
+    const selectedView = useSelector(state => state.wallet.graph.selectedView);
 
     const actions = useActions({
         setSelectedRange: graphActions.setSelectedRange,

--- a/packages/suite/src/hooks/suite/useLocales.ts
+++ b/packages/suite/src/hooks/suite/useLocales.ts
@@ -6,9 +6,7 @@ import { useSelector } from 'src/hooks/suite';
 
 export const useLocales = () => {
     const [locale, setLocale] = useState<Locale>();
-    const { language } = useSelector(state => ({
-        language: state.suite.settings.language,
-    }));
+    const language = useSelector(state => state.suite.settings.language);
 
     useEffect(() => {
         let active = true;

--- a/packages/suite/src/hooks/suite/usePreferredModal.ts
+++ b/packages/suite/src/hooks/suite/usePreferredModal.ts
@@ -36,11 +36,9 @@ const getForegroundAppAction = (route: ForegroundAppRoute, params: Partial<Modal
 
 export const usePreferredModal = () => {
     const { getDiscoveryStatus } = useDiscovery();
-    const { route, params, modal } = useSelector(state => ({
-        route: state.router.route,
-        params: state.router.params as Partial<ModalAppParams>,
-        modal: state.modal,
-    }));
+    const route = useSelector(state => state.router.route);
+    const params = useSelector(state => state.router.params as Partial<ModalAppParams>);
+    const modal = useSelector(state => state.modal);
 
     if (route && isForegroundApp(route) && hasPriority(route)) {
         return getForegroundAppAction(route, params);

--- a/packages/suite/src/hooks/wallet/form/useFees.ts
+++ b/packages/suite/src/hooks/wallet/form/useFees.ts
@@ -1,8 +1,8 @@
 import { useEffect, useRef } from 'react';
 import { FieldPath, UseFormReturn } from 'react-hook-form';
 import { FeeLevel } from '@trezor/connect';
-import * as walletSettingsActions from 'src/actions/settings/walletSettingsActions';
-import { useActions } from 'src/hooks/suite';
+import { setLastUsedFeeLevel } from 'src/actions/settings/walletSettingsActions';
+import { useDispatch } from 'src/hooks/suite';
 import {
     FeeInfo,
     FormState,
@@ -32,16 +32,14 @@ export const useFees = <TFieldValues extends FormState>({
     formState: { errors },
     ...props
 }: Props<TFieldValues>) => {
+    const dispatch = useDispatch();
+
     // local references
     const selectedFeeRef = useRef(defaultValue);
     const feePerUnitRef = useRef<string | undefined>('');
     const feeLimitRef = useRef<string | undefined>('');
     const estimatedFeeLimitRef = useRef<string | undefined>('');
     const saveLastUsedFeeRef = useRef(saveLastUsedFee);
-
-    const { setLastUsedFeeLevel } = useActions({
-        setLastUsedFeeLevel: walletSettingsActions.setLastUsedFeeLevel,
-    });
 
     // Type assertion allowing to make the component reusable, see https://stackoverflow.com/a/73624072.
     const { clearErrors, getValues, register, setValue, watch } =
@@ -92,17 +90,12 @@ export const useFees = <TFieldValues extends FormState>({
                 !errors.feePerUnit &&
                 !errors.feeLimit
             ) {
-                setLastUsedFeeLevel({ label: 'custom', feePerUnit, feeLimit, blocks: -1 });
+                dispatch(
+                    setLastUsedFeeLevel({ label: 'custom', feePerUnit, feeLimit, blocks: -1 }),
+                );
             }
         }
-    }, [
-        feePerUnit,
-        feeLimit,
-        errors.feePerUnit,
-        errors.feeLimit,
-        composeRequest,
-        setLastUsedFeeLevel,
-    ]);
+    }, [dispatch, feePerUnit, feeLimit, errors.feePerUnit, errors.feeLimit, composeRequest]);
 
     // watch estimatedFee change
     const estimatedFeeLimit = watch('estimatedFeeLimit');
@@ -163,7 +156,7 @@ export const useFees = <TFieldValues extends FormState>({
         // save last used fee
         if (level !== 'custom' && saveLastUsedFeeRef.current) {
             const nextLevel = feeInfo.levels.find(l => l.label === (level || 'normal'))!;
-            setLastUsedFeeLevel(nextLevel);
+            dispatch(setLastUsedFeeLevel(nextLevel));
         }
 
         selectedFeeRef.current = selectedFee;

--- a/packages/suite/src/hooks/wallet/sign-verify/useCopySignedMessage.ts
+++ b/packages/suite/src/hooks/wallet/sign-verify/useCopySignedMessage.ts
@@ -1,5 +1,5 @@
 import { copyToClipboard } from '@trezor/dom-utils';
-import { useActions } from 'src/hooks/suite';
+import { useDispatch } from 'src/hooks/suite';
 import { notificationsActions } from '@suite-common/toast-notifications';
 
 type SignedMessageData = {
@@ -22,7 +22,7 @@ export const useCopySignedMessage = <T extends SignedMessageData>(
     { message, address, signature }: T,
     network?: string,
 ) => {
-    const { addNotification } = useActions({ addNotification: notificationsActions.addToast });
+    const dispatch = useDispatch();
 
     const canCopy = address && signature;
 
@@ -35,7 +35,7 @@ export const useCopySignedMessage = <T extends SignedMessageData>(
         const result = copyToClipboard(formatted);
 
         if (typeof result !== 'string') {
-            addNotification({ type: 'copy-to-clipboard' });
+            dispatch(notificationsActions.addToast({ type: 'copy-to-clipboard' }));
         }
     };
 

--- a/packages/suite/src/hooks/wallet/useAccounts.ts
+++ b/packages/suite/src/hooks/wallet/useAccounts.ts
@@ -7,10 +7,8 @@ import type { Account, Discovery } from 'src/types/wallet';
 export const useAccounts = (discovery?: Discovery) => {
     const [accounts, setAccounts] = useState<Account[]>([]);
 
-    const { device, accountsState } = useSelector(state => ({
-        device: state.suite.device,
-        accountsState: state.wallet.accounts,
-    }));
+    const device = useSelector(state => state.suite.device);
+    const accountsState = useSelector(state => state.wallet.accounts);
 
     useEffect(() => {
         if (device) {
@@ -27,10 +25,9 @@ export const useAccounts = (discovery?: Discovery) => {
 };
 
 export const useFastAccounts = () => {
-    const { device, accounts } = useSelector(state => ({
-        device: state.suite.device,
-        accounts: state.wallet.accounts,
-    }));
+    const device = useSelector(state => state.suite.device);
+    const accounts = useSelector(state => state.wallet.accounts);
+
     const deviceAccounts = useMemo(
         () => (device ? accountUtils.getAllAccounts(device.state, accounts) : []),
         [accounts, device],

--- a/packages/suite/src/hooks/wallet/useCoinmarket.ts
+++ b/packages/suite/src/hooks/wallet/useCoinmarket.ts
@@ -7,12 +7,12 @@ import {
 } from 'invity-api';
 import useUnmount from 'react-use/lib/useUnmount';
 import useTimeoutFn from 'react-use/lib/useTimeoutFn';
-import { useActions } from 'src/hooks/suite';
+import { useDispatch } from 'src/hooks/suite';
 import invityAPI from 'src/services/suite/invityAPI';
-import * as coinmarketBuyActions from 'src/actions/wallet/coinmarketBuyActions';
-import * as coinmarketExchangeActions from 'src/actions/wallet/coinmarketExchangeActions';
-import * as coinmarketSellActions from 'src/actions/wallet/coinmarketSellActions';
-import * as coinmarketSavingsActions from 'src/actions/wallet/coinmarketSavingsActions';
+import { saveTrade as saveBuyTrade } from 'src/actions/wallet/coinmarketBuyActions';
+import { saveTrade as saveExchangeTrade } from 'src/actions/wallet/coinmarketExchangeActions';
+import { saveTrade as saveSellTrade } from 'src/actions/wallet/coinmarketSellActions';
+import { saveTrade as saveSavingsTrade } from 'src/actions/wallet/coinmarketSavingsActions';
 import { Account } from 'src/types/wallet';
 import type {
     TradeBuy,
@@ -29,7 +29,7 @@ const shouldRefreshBuyTrade = (trade?: TradeBuy) =>
 
 export const useWatchBuyTrade = (account: Account, trade: TradeBuy) => {
     const REFRESH_SECONDS = 30;
-    const { saveTrade } = useActions({ saveTrade: coinmarketBuyActions.saveTrade });
+    const dispatch = useDispatch();
     const [refreshCount, setRefreshCount] = useState(0);
     const invokeRefresh = () => {
         if (shouldRefreshBuyTrade(trade)) {
@@ -56,7 +56,7 @@ export const useWatchBuyTrade = (account: Account, trade: TradeBuy) => {
                         status: response.status,
                         error: response.error,
                     };
-                    saveTrade(tradeData, account, newDate);
+                    dispatch(saveBuyTrade(tradeData, account, newDate));
                 }
                 if (response.status && BuyTradeFinalStatuses.includes(response.status)) {
                     removeDraft(account.key);
@@ -64,7 +64,7 @@ export const useWatchBuyTrade = (account: Account, trade: TradeBuy) => {
             });
             resetRefresh();
         }
-    }, [account, cancelRefresh, refreshCount, removeDraft, resetRefresh, saveTrade, trade]);
+    }, [account, cancelRefresh, dispatch, refreshCount, removeDraft, resetRefresh, trade]);
 };
 
 export const ExchangeTradeFinalStatuses: ExchangeTradeStatus[] = ['SUCCESS', 'ERROR', 'KYC'];
@@ -74,7 +74,7 @@ const shouldRefreshExchangeTrade = (trade?: TradeExchange) =>
 
 export const useWatchExchangeTrade = (account: Account, trade: TradeExchange) => {
     const REFRESH_SECONDS = 30;
-    const { saveTrade } = useActions({ saveTrade: coinmarketExchangeActions.saveTrade });
+    const dispatch = useDispatch();
     const [refreshCount, setRefreshCount] = useState(0);
     const invokeRefresh = () => {
         if (shouldRefreshExchangeTrade(trade)) {
@@ -101,7 +101,7 @@ export const useWatchExchangeTrade = (account: Account, trade: TradeExchange) =>
                         status: response.status,
                         error: response.error,
                     };
-                    saveTrade(tradeData, account, newDate);
+                    dispatch(saveExchangeTrade(tradeData, account, newDate));
                 }
                 if (response.status && ExchangeTradeFinalStatuses.includes(response.status)) {
                     removeDraft(account.key);
@@ -109,7 +109,7 @@ export const useWatchExchangeTrade = (account: Account, trade: TradeExchange) =>
             });
             resetRefresh();
         }
-    }, [account, cancelRefresh, refreshCount, removeDraft, resetRefresh, saveTrade, trade]);
+    }, [account, cancelRefresh, dispatch, refreshCount, removeDraft, resetRefresh, trade]);
 };
 
 export const SellFiatTradeFinalStatuses: SellTradeStatus[] = [
@@ -125,7 +125,7 @@ const shouldRefreshSellTrade = (trade?: TradeSell) =>
 
 export const useWatchSellTrade = (account: Account, trade?: TradeSell) => {
     const REFRESH_SECONDS = 30;
-    const { saveTrade } = useActions({ saveTrade: coinmarketSellActions.saveTrade });
+    const dispatch = useDispatch();
     const [refreshCount, setRefreshCount] = useState(0);
     const invokeRefresh = () => {
         if (shouldRefreshSellTrade(trade)) {
@@ -156,7 +156,7 @@ export const useWatchSellTrade = (account: Account, trade?: TradeSell) => {
                         tradeData.destinationAddress = response.destinationAddress;
                         tradeData.destinationPaymentExtraId = response.destinationPaymentExtraId;
                     }
-                    saveTrade(tradeData, account, newDate);
+                    dispatch(saveSellTrade(tradeData, account, newDate));
                     if (response.status && SellFiatTradeFinalStatuses.includes(response.status)) {
                         removeDraft(account.key);
                     }
@@ -164,7 +164,7 @@ export const useWatchSellTrade = (account: Account, trade?: TradeSell) => {
             });
             resetRefresh();
         }
-    }, [account, cancelRefresh, refreshCount, removeDraft, resetRefresh, saveTrade, trade]);
+    }, [account, cancelRefresh, dispatch, refreshCount, removeDraft, resetRefresh, trade]);
 };
 
 export const SavingsTradeFinalStatuses: SavingsTradeItemStatus[] = [
@@ -180,7 +180,7 @@ const shouldRefreshSavingsTrade = (trade?: TradeSavings) =>
 
 export const useWatchSavingsTrade = (account: Account, trade: TradeSavings) => {
     const REFRESH_SECONDS = 30;
-    const { saveTrade } = useActions({ saveTrade: coinmarketSavingsActions.saveTrade });
+    const dispatch = useDispatch();
     const [refreshCount, setRefreshCount] = useState(0);
     const invokeRefresh = () => {
         if (shouldRefreshSavingsTrade(trade)) {
@@ -208,10 +208,10 @@ export const useWatchSavingsTrade = (account: Account, trade: TradeSavings) => {
                         status: response.savingsTradeItem?.status || 'Error',
                         error: response.error,
                     };
-                    saveTrade(tradeData, account, newDate);
+                    dispatch(saveSavingsTrade(tradeData, account, newDate));
                 }
             });
             resetRefresh();
         }
-    }, [account, cancelRefresh, refreshCount, resetRefresh, saveTrade, trade]);
+    }, [account, cancelRefresh, dispatch, refreshCount, resetRefresh, trade]);
 };

--- a/packages/suite/src/hooks/wallet/useCoinmarketBuyDetail.ts
+++ b/packages/suite/src/hooks/wallet/useCoinmarketBuyDetail.ts
@@ -6,13 +6,15 @@ import invityAPI from 'src/services/suite/invityAPI';
 import type { TradeBuy } from 'src/types/wallet/coinmarketCommonTypes';
 
 export const useCoinmarketBuyDetail = ({ selectedAccount }: UseCoinmarketBuyDetailProps) => {
+    const invityServerEnvironment = useSelector(
+        state => state.suite.settings.debug.invityServerEnvironment,
+    );
+    const buyInfo = useSelector(state => state.wallet.coinmarket.buy.buyInfo);
+    const trades = useSelector(state => state.wallet.coinmarket.trades);
+    const transactionId = useSelector(state => state.wallet.coinmarket.buy.transactionId);
+
     const { account } = selectedAccount;
-    const { invityServerEnvironment, buyInfo, trades, transactionId } = useSelector(state => ({
-        invityServerEnvironment: state.suite.settings.debug.invityServerEnvironment,
-        buyInfo: state.wallet.coinmarket.buy.buyInfo,
-        trades: state.wallet.coinmarket.trades,
-        transactionId: state.wallet.coinmarket.buy.transactionId,
-    }));
+
     const buyTrade = trades.find(
         trade =>
             trade.tradeType === 'buy' &&

--- a/packages/suite/src/hooks/wallet/useCoinmarketBuyForm.ts
+++ b/packages/suite/src/hooks/wallet/useCoinmarketBuyForm.ts
@@ -33,6 +33,10 @@ BuyFormContext.displayName = 'CoinmarketBuyContext';
 export const useCoinmarketBuyForm = ({
     selectedAccount,
 }: UseCoinmarketBuyFormProps): BuyFormContextValues => {
+    const buyInfo = useSelector(state => state.wallet.coinmarket.buy.buyInfo);
+    const exchangeCoinInfo = useSelector(
+        state => state.wallet.coinmarket.exchange.exchangeCoinInfo,
+    );
     const dispatch = useDispatch();
 
     useEffect(() => {
@@ -45,11 +49,6 @@ export const useCoinmarketBuyForm = ({
     const { saveDraft, getDraft, removeDraft } = useFormDraft<FormState>('coinmarket-buy');
     const draft = getDraft(account.key);
     const isDraft = !!draft;
-
-    const { buyInfo, exchangeCoinInfo } = useSelector(state => ({
-        buyInfo: state.wallet.coinmarket.buy.buyInfo,
-        exchangeCoinInfo: state.wallet.coinmarket.exchange.exchangeCoinInfo,
-    }));
 
     const { shouldSendInSats } = useBitcoinAmountUnit(account.symbol);
     const { defaultValues, defaultCountry, defaultCurrency } = useCoinmarketBuyFormDefaultValues(

--- a/packages/suite/src/hooks/wallet/useCoinmarketBuyOffers.ts
+++ b/packages/suite/src/hooks/wallet/useCoinmarketBuyOffers.ts
@@ -41,25 +41,13 @@ export const useOffers = ({ selectedAccount }: UseOffersProps) => {
         goto: routerActions.goto,
     });
 
-    const {
-        invityServerEnvironment,
-        device,
-        quotes,
-        alternativeQuotes,
-        quotesRequest,
-        isFromRedirect,
-        addressVerified,
-        providersInfo,
-    } = useSelector(state => ({
-        invityServerEnvironment: state.suite.settings.debug.invityServerEnvironment,
-        device: state.suite.device,
-        quotes: state.wallet.coinmarket.buy.quotes,
-        alternativeQuotes: state.wallet.coinmarket.buy.alternativeQuotes,
-        quotesRequest: state.wallet.coinmarket.buy.quotesRequest,
-        isFromRedirect: state.wallet.coinmarket.buy.isFromRedirect,
-        addressVerified: state.wallet.coinmarket.buy.addressVerified,
-        providersInfo: state.wallet.coinmarket.buy.buyInfo?.providerInfos,
-    }));
+    const invityServerEnvironment = useSelector(
+        state => state.suite.settings.debug.invityServerEnvironment,
+    );
+    const device = useSelector(state => state.suite.device);
+    const { addressVerified, alternativeQuotes, buyInfo, isFromRedirect, quotes, quotesRequest } =
+        useSelector(state => state.wallet.coinmarket.buy);
+
     const [innerQuotes, setInnerQuotes] = useState<BuyTrade[] | undefined>(quotes);
     const [innerAlternativeQuotes, setInnerAlternativeQuotes] = useState<BuyTrade[] | undefined>(
         alternativeQuotes,
@@ -112,7 +100,7 @@ export const useOffers = ({ selectedAccount }: UseOffersProps) => {
     });
 
     const selectQuote = async (quote: BuyTrade) => {
-        const provider = providersInfo && quote.exchange ? providersInfo[quote.exchange] : null;
+        const provider = buyInfo && quote.exchange ? buyInfo.providerInfos[quote.exchange] : null;
         if (quotesRequest) {
             const result = await openCoinmarketBuyConfirmModal(
                 provider?.companyName,
@@ -186,7 +174,7 @@ export const useOffers = ({ selectedAccount }: UseOffersProps) => {
         selectedQuote,
         verifyAddress,
         device,
-        providersInfo,
+        providersInfo: buyInfo?.providerInfos,
         quotesRequest,
         addressVerified,
         quotes: innerQuotes,

--- a/packages/suite/src/hooks/wallet/useCoinmarketBuyOffers.ts
+++ b/packages/suite/src/hooks/wallet/useCoinmarketBuyOffers.ts
@@ -187,7 +187,6 @@ export const useOffers = ({ selectedAccount }: UseOffersProps) => {
         verifyAddress,
         device,
         providersInfo,
-        saveTrade,
         quotesRequest,
         addressVerified,
         quotes: innerQuotes,

--- a/packages/suite/src/hooks/wallet/useCoinmarketExchangeDetail.ts
+++ b/packages/suite/src/hooks/wallet/useCoinmarketExchangeDetail.ts
@@ -11,12 +11,14 @@ import invityAPI from 'src/services/suite/invityAPI';
 export const useCoinmarketExchangeDetail = ({
     selectedAccount,
 }: UseCoinmarketExchangeDetailProps) => {
+    const invityServerEnvironment = useSelector(
+        state => state.suite.settings.debug.invityServerEnvironment,
+    );
+    const trades = useSelector(state => state.wallet.coinmarket.trades);
+    const transactionId = useSelector(state => state.wallet.coinmarket.exchange.transactionId);
+
     const { account } = selectedAccount;
-    const { invityServerEnvironment, trades, transactionId } = useSelector(state => ({
-        invityServerEnvironment: state.suite.settings.debug.invityServerEnvironment,
-        trades: state.wallet.coinmarket.trades,
-        transactionId: state.wallet.coinmarket.exchange.transactionId,
-    }));
+
     const exchangeTrade = trades.find(
         trade => trade.tradeType === 'exchange' && trade.key === transactionId,
     ) as TradeExchange;

--- a/packages/suite/src/hooks/wallet/useCoinmarketExchangeOffers.ts
+++ b/packages/suite/src/hooks/wallet/useCoinmarketExchangeOffers.ts
@@ -340,7 +340,6 @@ export const useOffers = ({ selectedAccount }: UseCoinmarketExchangeFormProps) =
         exchangeInfo,
         exchangeStep,
         setExchangeStep,
-        saveTrade,
         quotesRequest,
         addressVerified,
         fixedQuotes: innerFixedQuotes,

--- a/packages/suite/src/hooks/wallet/useCoinmarketExchangeOffers.ts
+++ b/packages/suite/src/hooks/wallet/useCoinmarketExchangeOffers.ts
@@ -64,29 +64,21 @@ export const useOffers = ({ selectedAccount }: UseCoinmarketExchangeFormProps) =
         verifyAddress: coinmarketExchangeActions.verifyAddress,
     });
 
+    const invityServerEnvironment = useSelector(
+        state => state.suite.settings.debug.invityServerEnvironment,
+    );
+    const accounts = useSelector(state => state.wallet.accounts);
+    const device = useSelector(state => state.suite.device);
     const {
-        invityServerEnvironment,
+        addressVerified,
+        dexQuotes,
         exchangeCoinInfo,
-        accounts,
-        device,
+        exchangeInfo,
         fixedQuotes,
         floatQuotes,
-        dexQuotes,
         quotesRequest,
-        addressVerified,
-        exchangeInfo,
-    } = useSelector(state => ({
-        invityServerEnvironment: state.suite.settings.debug.invityServerEnvironment,
-        exchangeCoinInfo: state.wallet.coinmarket.exchange.exchangeCoinInfo,
-        accounts: state.wallet.accounts,
-        device: state.suite.device,
-        fixedQuotes: state.wallet.coinmarket.exchange.fixedQuotes,
-        floatQuotes: state.wallet.coinmarket.exchange.floatQuotes,
-        dexQuotes: state.wallet.coinmarket.exchange.dexQuotes,
-        quotesRequest: state.wallet.coinmarket.exchange.quotesRequest,
-        addressVerified: state.wallet.coinmarket.exchange.addressVerified,
-        exchangeInfo: state.wallet.coinmarket.exchange.exchangeInfo,
-    }));
+    } = useSelector(state => state.wallet.coinmarket.exchange);
+
     const [innerFixedQuotes, setInnerFixedQuotes] = useState<ExchangeTrade[] | undefined>(
         fixedQuotes,
     );

--- a/packages/suite/src/hooks/wallet/useCoinmarketNavigation.ts
+++ b/packages/suite/src/hooks/wallet/useCoinmarketNavigation.ts
@@ -1,12 +1,10 @@
 import { useCallback } from 'react';
 import { Account } from 'src/types/wallet';
-import * as routerActions from 'src/actions/suite/routerActions';
-import { useActions } from 'src/hooks/suite';
+import { goto } from 'src/actions/suite/routerActions';
+import { useDispatch } from 'src/hooks/suite';
 
 export const useCoinmarketNavigation = (account: Account) => {
-    const { goto } = useActions({
-        goto: routerActions.goto,
-    });
+    const dispatch = useDispatch();
 
     type WalletCoinmarketRouteNameType = Extract<
         Parameters<typeof goto>[0],
@@ -14,13 +12,15 @@ export const useCoinmarketNavigation = (account: Account) => {
     >;
     const useNavigateToRouteName = (routeName: WalletCoinmarketRouteNameType) =>
         useCallback(() => {
-            goto(routeName, {
-                params: {
-                    symbol: account.symbol,
-                    accountIndex: account.index,
-                    accountType: account.accountType,
-                },
-            });
+            dispatch(
+                goto(routeName, {
+                    params: {
+                        symbol: account.symbol,
+                        accountIndex: account.index,
+                        accountType: account.accountType,
+                    },
+                }),
+            );
         }, [routeName]);
 
     return {

--- a/packages/suite/src/hooks/wallet/useCoinmarketP2pForm.ts
+++ b/packages/suite/src/hooks/wallet/useCoinmarketP2pForm.ts
@@ -4,9 +4,9 @@ import {
     P2pFormContextValues,
     UseCoinmarketP2pFormProps,
 } from 'src/types/wallet/coinmarketP2pForm';
-import { useActions, useSelector } from 'src/hooks/suite';
-import * as coinmarketP2pActions from 'src/actions/wallet/coinmarketP2pActions';
-import * as coinmarketCommonActions from 'src/actions/wallet/coinmarket/coinmarketCommonActions';
+import { useDispatch, useSelector } from 'src/hooks/suite';
+import { saveQuotes, saveQuotesRequest } from 'src/actions/wallet/coinmarketP2pActions';
+import { loadInvityData } from 'src/actions/wallet/coinmarket/coinmarketCommonActions';
 import { useCoinmarketP2pFormDefaultValues } from 'src/hooks/wallet/useCoinmarketP2pFormDefaultValues';
 import { useForm, useWatch } from 'react-hook-form';
 import { useFormDraft } from 'src/hooks/wallet/useFormDraft';
@@ -18,27 +18,22 @@ import invityAPI from 'src/services/suite/invityAPI';
 export const P2pFormContext = createContext<P2pFormContextValues | null>(null);
 P2pFormContext.displayName = 'CoinmarketP2pContext';
 
-export const useCoinmarketP2pForm = (props: UseCoinmarketP2pFormProps): P2pFormContextValues => {
-    const { loadInvityData, saveQuotesRequest, saveQuotes } = useActions({
-        loadInvityData: coinmarketCommonActions.loadInvityData,
-        saveQuotesRequest: coinmarketP2pActions.saveQuotesRequest,
-        saveQuotes: coinmarketP2pActions.saveQuotes,
-    });
+export const useCoinmarketP2pForm = ({
+    selectedAccount,
+}: UseCoinmarketP2pFormProps): P2pFormContextValues => {
+    const p2pInfo = useSelector(state => state.wallet.coinmarket.p2p.p2pInfo);
+    const dispatch = useDispatch();
 
     useEffect(() => {
-        loadInvityData();
-    }, [loadInvityData]);
+        dispatch(loadInvityData());
+    }, [dispatch]);
 
-    const { selectedAccount } = props;
     const { account } = selectedAccount;
     const { navigateToP2pOffers } = useCoinmarketNavigation(account);
     const { getDraft, saveDraft, removeDraft } = useFormDraft<FormState>('coinmarket-p2p');
     const draft = getDraft(account.key);
     const isDraft = !!draft;
 
-    const { p2pInfo } = useSelector(state => ({
-        p2pInfo: state.wallet.coinmarket.p2p.p2pInfo,
-    }));
     const { defaultValues, defaultCountry, defaultCurrency } =
         useCoinmarketP2pFormDefaultValues(p2pInfo);
     const methods = useForm<FormState>({

--- a/packages/suite/src/hooks/wallet/useCoinmarketP2pFormDefaultValues.ts
+++ b/packages/suite/src/hooks/wallet/useCoinmarketP2pFormDefaultValues.ts
@@ -4,9 +4,7 @@ import { buildOption, getDefaultCountry } from 'src/utils/wallet/coinmarket/coin
 import { P2pInfo } from 'src/actions/wallet/coinmarketP2pActions';
 
 export const useCoinmarketP2pFormDefaultValues = (p2pInfo?: P2pInfo) => {
-    const { localCurrency } = useSelector(state => ({
-        localCurrency: state.wallet.settings.localCurrency,
-    }));
+    const localCurrency = useSelector(state => state.wallet.settings.localCurrency);
 
     const country = p2pInfo?.country;
     const suggestedFiatCurrency = p2pInfo?.suggestedFiatCurrency || localCurrency;

--- a/packages/suite/src/hooks/wallet/useCoinmarketP2pOffers.ts
+++ b/packages/suite/src/hooks/wallet/useCoinmarketP2pOffers.ts
@@ -1,30 +1,26 @@
 import { createContext, useCallback, useContext, useEffect, useState } from 'react';
 import { ContextValues, P2pStep, UseOffersProps } from 'src/types/wallet/coinmarketP2pOffers';
-import { useActions, useSelector } from 'src/hooks/suite';
+import { useDispatch, useSelector } from 'src/hooks/suite';
 import { useTimer } from '@trezor/react-utils';
 import { InvityAPIReloadQuotesAfterSeconds } from 'src/constants/wallet/coinmarket/metadata';
-import * as coinmarketP2pActions from 'src/actions/wallet/coinmarketP2pActions';
+import { openCoinmarketP2pConfirmModal } from 'src/actions/wallet/coinmarketP2pActions';
 import invityAPI from 'src/services/suite/invityAPI';
 import { P2pQuote } from 'invity-api';
 import { useCoinmarketNavigation } from 'src/hooks/wallet/useCoinmarketNavigation';
-import * as coinmarketCommonActions from 'src/actions/wallet/coinmarket/coinmarketCommonActions';
+import { submitRequestForm } from 'src/actions/wallet/coinmarket/coinmarketCommonActions';
 
 export const useOffers = ({ selectedAccount }: UseOffersProps): ContextValues => {
     const timer = useTimer();
 
+    const device = useSelector(state => state.suite.device);
+    const providers = useSelector(state => state.wallet.coinmarket.p2p.p2pInfo?.providers);
+    const quotesRequest = useSelector(state => state.wallet.coinmarket.p2p.quotesRequest);
+    const quotes = useSelector(state => state.wallet.coinmarket.p2p.quotes);
+    const dispatch = useDispatch();
+
     const { account } = selectedAccount;
     const [selectedQuote, setSelectedQuote] = useState<P2pQuote>();
     const { navigateToP2pForm } = useCoinmarketNavigation(account);
-    const { openCoinmarketP2pConfirmModal, submitRequestForm } = useActions({
-        openCoinmarketP2pConfirmModal: coinmarketP2pActions.openCoinmarketP2pConfirmModal,
-        submitRequestForm: coinmarketCommonActions.submitRequestForm,
-    });
-    const { device, providers, quotesRequest, quotes } = useSelector(state => ({
-        device: state.suite.device,
-        providers: state.wallet.coinmarket.p2p.p2pInfo?.providers,
-        quotesRequest: state.wallet.coinmarket.p2p.quotesRequest,
-        quotes: state.wallet.coinmarket.p2p.quotes,
-    }));
     const [innerQuotes, setInnerQuotes] = useState(quotes);
     const [callInProgress, setCallInProgress] = useState(false);
     const [providerVisited, setProviderVisited] = useState(false);
@@ -64,7 +60,7 @@ export const useOffers = ({ selectedAccount }: UseOffersProps): ContextValues =>
 
     const selectQuote = async (quote: P2pQuote) => {
         const provider = providers ? providers[quote.provider] : null;
-        if (await openCoinmarketP2pConfirmModal(provider?.companyName, quote.assetCode)) {
+        if (await dispatch(openCoinmarketP2pConfirmModal(provider?.companyName, quote.assetCode))) {
             setSelectedQuote(quote);
             timer.stop();
         }
@@ -85,7 +81,7 @@ export const useOffers = ({ selectedAccount }: UseOffersProps): ContextValues =>
         setCallInProgress(false);
 
         if (response && response.tradeForm) {
-            submitRequestForm(response.tradeForm.form);
+            dispatch(submitRequestForm(response.tradeForm.form));
             setProviderVisited(true);
         }
     };

--- a/packages/suite/src/hooks/wallet/useCoinmarketRecomposeAndSign .ts
+++ b/packages/suite/src/hooks/wallet/useCoinmarketRecomposeAndSign .ts
@@ -1,6 +1,6 @@
 import { useCallback } from 'react';
-import { useActions, useSelector, useTranslation } from 'src/hooks/suite';
-import * as sendFormActions from 'src/actions/wallet/sendFormActions';
+import { useDispatch, useSelector, useTranslation } from 'src/hooks/suite';
+import { composeTransaction, signTransaction } from 'src/actions/wallet/sendFormActions';
 import { notificationsActions } from '@suite-common/toast-notifications';
 import { DEFAULT_VALUES, DEFAULT_PAYMENT } from '@suite-common/wallet-constants';
 import { FormState, UseSendFormState } from 'src/types/wallet/sendForm';
@@ -9,17 +9,11 @@ import type { SelectedAccountLoaded } from '@suite-common/wallet-types';
 
 export const useCoinmarketRecomposeAndSign = () => {
     const { translationString } = useTranslation();
-    const { addNotification, composeAction, signAction } = useActions({
-        addNotification: notificationsActions.addToast,
-        composeAction: sendFormActions.composeTransaction,
-        signAction: sendFormActions.signTransaction,
-    });
-
-    const { composed, selectedFee, fees } = useSelector(state => ({
-        composed: state.wallet.coinmarket.composedTransactionInfo.composed,
-        selectedFee: state.wallet.coinmarket.composedTransactionInfo.selectedFee,
-        fees: state.wallet.fees,
-    }));
+    const { composed, selectedFee } = useSelector(
+        state => state.wallet.coinmarket.composedTransactionInfo,
+    );
+    const fees = useSelector(state => state.wallet.fees);
+    const dispatch = useDispatch();
 
     const recomposeAndSign = useCallback(
         async (
@@ -34,10 +28,12 @@ export const useCoinmarketRecomposeAndSign = () => {
             const { account, network } = selectedAccount;
 
             if (!composed) {
-                addNotification({
-                    type: 'sign-tx-error',
-                    error: 'Missing composed data',
-                });
+                dispatch(
+                    notificationsActions.addToast({
+                        type: 'sign-tx-error',
+                        error: 'Missing composed data',
+                    }),
+                );
                 return;
             }
             // prepare the fee levels, set custom values from composed
@@ -72,9 +68,11 @@ export const useCoinmarketRecomposeAndSign = () => {
             // recalcCustomLimit is used in case of custom fee level, when we want to keep the feePerUnit defined by the user
             // but recompute the feeLimit based on a different transaction data (for example from ethereumDataHex)
             if (recalcCustomLimit && selectedFee === 'custom') {
-                const normalLevels = await composeAction(
-                    { ...formValues, selectedFee: 'normal' },
-                    formState as UseSendFormState,
+                const normalLevels = await dispatch(
+                    composeTransaction(
+                        { ...formValues, selectedFee: 'normal' },
+                        formState as UseSendFormState,
+                    ),
                 );
                 if (
                     !normalLevels ||
@@ -95,22 +93,28 @@ export const useCoinmarketRecomposeAndSign = () => {
                     if (!errorMessage) {
                         errorMessage = 'Missing fee level';
                     }
-                    addNotification({
-                        type: 'sign-tx-error',
-                        error: errorMessage,
-                    });
+                    dispatch(
+                        notificationsActions.addToast({
+                            type: 'sign-tx-error',
+                            error: errorMessage,
+                        }),
+                    );
                     return;
                 }
                 formValues.feeLimit = normalLevels.normal.feeLimit;
             }
 
             // compose transaction again to recalculate fees based on real account values
-            const composedLevels = await composeAction(formValues, formState as UseSendFormState);
+            const composedLevels = await dispatch(
+                composeTransaction(formValues, formState as UseSendFormState),
+            );
             if (!selectedFee || !composedLevels) {
-                addNotification({
-                    type: 'sign-tx-error',
-                    error: 'Missing fee level',
-                });
+                dispatch(
+                    notificationsActions.addToast({
+                        type: 'sign-tx-error',
+                        error: 'Missing fee level',
+                    }),
+                );
                 return;
             }
             const composedToSign = composedLevels[selectedFee];
@@ -126,24 +130,18 @@ export const useCoinmarketRecomposeAndSign = () => {
                 if (!errorMessage) {
                     errorMessage = 'Cannot create transaction';
                 }
-                addNotification({
-                    type: 'sign-tx-error',
-                    error: errorMessage,
-                });
+                dispatch(
+                    notificationsActions.addToast({
+                        type: 'sign-tx-error',
+                        error: errorMessage,
+                    }),
+                );
                 return;
             }
 
-            return signAction(formValues, composedToSign);
+            return dispatch(signTransaction(formValues, composedToSign));
         },
-        [
-            addNotification,
-            composeAction,
-            composed,
-            fees,
-            selectedFee,
-            signAction,
-            translationString,
-        ],
+        [composed, dispatch, fees, selectedFee, translationString],
     );
     return { selectedFee, composed, recomposeAndSign };
 };

--- a/packages/suite/src/hooks/wallet/useCoinmarketRedirect.ts
+++ b/packages/suite/src/hooks/wallet/useCoinmarketRedirect.ts
@@ -1,10 +1,10 @@
 import { Account } from 'src/types/wallet';
 import { BuyTradeQuoteRequest, SellFiatTradeQuoteRequest } from 'invity-api';
-import { useActions } from 'src/hooks/suite';
-import * as routerActions from 'src/actions/suite/routerActions';
+import { useDispatch } from 'src/hooks/suite';
+import { goto } from 'src/actions/suite/routerActions';
 import * as coinmarketBuyActions from 'src/actions/wallet/coinmarketBuyActions';
 import * as coinmarketSellActions from 'src/actions/wallet/coinmarketSellActions';
-import * as coinmarketCommonActions from 'src/actions/wallet/coinmarket/coinmarketCommonActions';
+import { saveComposedTransactionInfo } from 'src/actions/wallet/coinmarket/coinmarketCommonActions';
 import { FeeLevel } from '@trezor/connect';
 
 export interface OfferRedirectParams {
@@ -41,25 +41,7 @@ export interface DetailRedirectParams {
 }
 
 export const useCoinmarketRedirect = () => {
-    const {
-        saveBuyQuoteRequest,
-        setBuyIsFromRedirect,
-        saveBuyTransactionDetailId,
-        saveSellQuoteRequest,
-        setSellIsFromRedirect,
-        saveSellTransactionDetailId,
-        saveComposedTransactionInfo,
-        goto,
-    } = useActions({
-        saveBuyQuoteRequest: coinmarketBuyActions.saveQuoteRequest,
-        setBuyIsFromRedirect: coinmarketBuyActions.setIsFromRedirect,
-        saveBuyTransactionDetailId: coinmarketBuyActions.saveTransactionDetailId,
-        saveSellQuoteRequest: coinmarketSellActions.saveQuoteRequest,
-        setSellIsFromRedirect: coinmarketSellActions.setIsFromRedirect,
-        saveSellTransactionDetailId: coinmarketSellActions.saveTransactionId,
-        saveComposedTransactionInfo: coinmarketCommonActions.saveComposedTransactionInfo,
-        goto: routerActions.goto,
-    });
+    const dispatch = useDispatch();
 
     const redirectToOffers = (params: OfferRedirectParams) => {
         const {
@@ -88,11 +70,13 @@ export const useCoinmarketRedirect = () => {
                 fiatStringAmount: amount,
             };
         }
-        saveBuyQuoteRequest(request);
-        setBuyIsFromRedirect(true);
-        goto('wallet-coinmarket-buy-offers', {
-            params: { symbol, accountIndex: index, accountType },
-        });
+        dispatch(coinmarketBuyActions.saveQuoteRequest(request));
+        dispatch(coinmarketBuyActions.setIsFromRedirect(true));
+        dispatch(
+            goto('wallet-coinmarket-buy-offers', {
+                params: { symbol, accountIndex: index, accountType },
+            }),
+        );
     };
 
     const redirectToSellOffers = (params: SellOfferRedirectParams) => {
@@ -126,31 +110,35 @@ export const useCoinmarketRedirect = () => {
                 fiatStringAmount: amount,
             };
         }
-        saveSellQuoteRequest(request);
-        setSellIsFromRedirect(true);
+        dispatch(coinmarketSellActions.saveQuoteRequest(request));
+        dispatch(coinmarketSellActions.setIsFromRedirect(true));
         const composed = {
             feeLimit,
             feePerByte: feePerByte || '',
             fee: '', // fee is not passed by redirect, will be recalculated
         };
-        saveComposedTransactionInfo({ selectedFee: selectedFee || 'normal', composed });
-        saveSellTransactionDetailId(orderId);
-        goto('wallet-coinmarket-sell-offers', {
-            params: { symbol, accountIndex: index, accountType },
-        });
+        dispatch(saveComposedTransactionInfo({ selectedFee: selectedFee || 'normal', composed }));
+        dispatch(coinmarketSellActions.saveTransactionId(orderId));
+        dispatch(
+            goto('wallet-coinmarket-sell-offers', {
+                params: { symbol, accountIndex: index, accountType },
+            }),
+        );
     };
 
     const redirectToDetail = (params: DetailRedirectParams) => {
         const { transactionId } = params;
 
-        saveBuyTransactionDetailId(transactionId);
-        goto('wallet-coinmarket-buy-detail', {
-            params: {
-                symbol: params.symbol,
-                accountIndex: params.index,
-                accountType: params.accountType,
-            },
-        });
+        dispatch(coinmarketBuyActions.saveTransactionDetailId(transactionId));
+        dispatch(
+            goto('wallet-coinmarket-buy-detail', {
+                params: {
+                    symbol: params.symbol,
+                    accountIndex: params.index,
+                    accountType: params.accountType,
+                },
+            }),
+        );
     };
 
     return {

--- a/packages/suite/src/hooks/wallet/useCoinmarketSavingsOverview.ts
+++ b/packages/suite/src/hooks/wallet/useCoinmarketSavingsOverview.ts
@@ -15,27 +15,19 @@ export const useSavingsOverview = ({
     selectedAccount,
 }: UseSavingsOverviewProps): SavingsOverviewContextValues => {
     const { account } = selectedAccount;
+
     const { navigateToSavingsSetupContinue } = useCoinmarketNavigation(account);
 
+    const trades = useSelector(state => state.wallet.coinmarket.trades);
+    const fiat = useSelector(state => state.wallet.fiat);
     const {
+        isSavingsTradeLoading,
         isWatchingKYCStatus,
         kycFinalStatus,
         savingsTrade,
-        selectedProvider,
         savingsTradePayments,
-        isSavingsTradeLoading,
-        trades,
-        fiat,
-    } = useSelector(state => ({
-        isWatchingKYCStatus: state.wallet.coinmarket.savings.isWatchingKYCStatus,
-        kycFinalStatus: state.wallet.coinmarket.savings.kycFinalStatus,
-        savingsTrade: state.wallet.coinmarket.savings.savingsTrade,
-        selectedProvider: state.wallet.coinmarket.savings.selectedProvider,
-        savingsTradePayments: state.wallet.coinmarket.savings.savingsTradePayments,
-        isSavingsTradeLoading: state.wallet.coinmarket.savings.isSavingsTradeLoading,
-        trades: state.wallet.coinmarket.trades,
-        fiat: state.wallet.fiat,
-    }));
+        selectedProvider,
+    } = useSelector(state => state.wallet.coinmarket.savings);
 
     const savingsCryptoSum = trades.reduce((previous: BigNumber, current: Trade) => {
         if (

--- a/packages/suite/src/hooks/wallet/useCoinmarketSavingsPaymentInfo.ts
+++ b/packages/suite/src/hooks/wallet/useCoinmarketSavingsPaymentInfo.ts
@@ -1,11 +1,11 @@
 import { useCallback, useState } from 'react';
 import { useCoinmarketNavigation } from 'src/hooks/wallet/useCoinmarketNavigation';
-import * as coinmarketSavingsActions from 'src/actions/wallet/coinmarketSavingsActions';
+import { saveSavingsTradeResponse } from 'src/actions/wallet/coinmarketSavingsActions';
 import type {
     SavingsPaymentInfoContextValues,
     UseSavingsPaymentInfoProps,
 } from 'src/types/wallet/coinmarketSavingsPaymentInfo';
-import { useActions, useSelector } from 'src/hooks/suite';
+import { useDispatch, useSelector } from 'src/hooks/suite';
 import invityAPI from 'src/services/suite/invityAPI';
 import { useCoinmarketSavingsPaymentInfoCopy } from 'src/hooks/wallet/useCoinmarketSavingsPaymentInfoCopy';
 
@@ -16,24 +16,18 @@ export const useSavingsPaymentInfo = ({
         selectedAccount.account,
     );
 
-    const { isWatchingKYCStatus, kycFinalStatus } = useSelector(state => ({
-        isWatchingKYCStatus: state.wallet.coinmarket.savings.isWatchingKYCStatus,
-        kycFinalStatus: state.wallet.coinmarket.savings.kycFinalStatus,
-    }));
+    const {
+        savingsTrade,
+        selectedProvider,
+        isSavingsTradeLoading,
+        isWatchingKYCStatus,
+        kycFinalStatus,
+    } = useSelector(state => state.wallet.coinmarket.savings);
+    const dispatch = useDispatch();
 
     const handleEditButtonClick = useCallback(() => {
         navigateToSavingsSetupContinue();
     }, [navigateToSavingsSetupContinue]);
-
-    const { savingsTrade, selectedProvider, isSavingsTradeLoading } = useSelector(state => ({
-        savingsTrade: state.wallet.coinmarket.savings.savingsTrade,
-        selectedProvider: state.wallet.coinmarket.savings.selectedProvider,
-        isSavingsTradeLoading: state.wallet.coinmarket.savings.isSavingsTradeLoading,
-    }));
-
-    const { saveSavingsTradeResponse } = useActions({
-        saveSavingsTradeResponse: coinmarketSavingsActions.saveSavingsTradeResponse,
-    });
 
     const [isSubmitting, setIsSubmitting] = useState(false);
     const handleSubmit = useCallback(async () => {
@@ -41,12 +35,12 @@ export const useSavingsPaymentInfo = ({
         if (savingsTrade) {
             const response = await invityAPI.doSavingsTrade({ trade: savingsTrade });
             if (response) {
-                saveSavingsTradeResponse(response);
+                dispatch(saveSavingsTradeResponse(response));
                 navigateToSavingsOverview();
             }
         }
         setIsSubmitting(false);
-    }, [navigateToSavingsOverview, saveSavingsTradeResponse, savingsTrade]);
+    }, [dispatch, navigateToSavingsOverview, savingsTrade]);
 
     const { copyPaymentInfo } = useCoinmarketSavingsPaymentInfoCopy(savingsTrade?.paymentInfo);
 

--- a/packages/suite/src/hooks/wallet/useCoinmarketSavingsPaymentInfoCopy.ts
+++ b/packages/suite/src/hooks/wallet/useCoinmarketSavingsPaymentInfoCopy.ts
@@ -1,19 +1,21 @@
 import type { SavingsPaymentInfo } from 'invity-api';
 import { copyToClipboard } from '@trezor/dom-utils';
-import { useActions } from 'src/hooks/suite';
+import { useDispatch } from 'src/hooks/suite';
 import { notificationsActions } from '@suite-common/toast-notifications';
 
 export const useCoinmarketSavingsPaymentInfoCopy = (paymentInfo?: SavingsPaymentInfo) => {
-    const { addNotification } = useActions({ addNotification: notificationsActions.addToast });
+    const dispatch = useDispatch();
+
     const copyPaymentInfo = (paymentInfoKey: keyof SavingsPaymentInfo) => {
         if (paymentInfo) {
             const paymentInfoValue = paymentInfo[paymentInfoKey];
             const result = paymentInfoValue && copyToClipboard(paymentInfoValue);
             if (typeof result !== 'string') {
-                addNotification({ type: 'copy-to-clipboard' });
+                dispatch(notificationsActions.addToast({ type: 'copy-to-clipboard' }));
             }
         }
     };
+
     return {
         copyPaymentInfo,
     };

--- a/packages/suite/src/hooks/wallet/useCoinmarketSavingsSetup.ts
+++ b/packages/suite/src/hooks/wallet/useCoinmarketSavingsSetup.ts
@@ -7,12 +7,18 @@ import type {
 import { useForm, useWatch } from 'react-hook-form';
 import { InitSavingsTradeRequest } from 'invity-api';
 import invityAPI, { SavingsTradeKYCFinalStatuses } from 'src/services/suite/invityAPI';
-import { useActions, useSelector } from 'src/hooks/suite';
+import { useDispatch, useSelector } from 'src/hooks/suite';
 import type { CountryOption } from 'src/types/wallet/coinmarketCommonTypes';
 import { CustomPaymentAmountKey } from 'src/constants/wallet/coinmarket/savings';
-import * as coinmarketSavingsActions from 'src/actions/wallet/coinmarketSavingsActions';
-import * as coinmarketCommonActions from 'src/actions/wallet/coinmarket/coinmarketCommonActions';
-import * as pollingActions from 'src/actions/wallet/pollingActions';
+import {
+    openCoinmarketSavingsConfirmModal,
+    setSelectedProvider,
+} from 'src/actions/wallet/coinmarketSavingsActions';
+import {
+    loadInvityData,
+    submitRequestForm,
+} from 'src/actions/wallet/coinmarket/coinmarketCommonActions';
+import { isPolling } from 'src/actions/wallet/pollingActions';
 import { useCoinmarketNavigation } from 'src/hooks/wallet/useCoinmarketNavigation';
 import regional from 'src/constants/wallet/coinmarket/regional';
 import {
@@ -27,45 +33,29 @@ export const useSavingsSetup = ({
     selectedAccount,
 }: UseSavingsSetupProps): SavingsSetupContextValues => {
     const { account } = selectedAccount;
-    const {
-        fiat,
-        selectedProvider,
-        providers,
-        supportedCountries,
-        userCountry,
-        savingsTrade,
-        isSavingsTradeLoading,
-        formDrafts,
-    } = useSelector(state => ({
-        fiat: state.wallet.fiat,
-        selectedProvider: state.wallet.coinmarket.savings.selectedProvider,
-        supportedCountries: state.wallet.coinmarket.savings.savingsInfo?.supportedCountries,
-        providers: state.wallet.coinmarket.savings.savingsInfo?.savingsList?.providers,
-        userCountry: state.wallet.coinmarket.savings.savingsInfo?.country?.toUpperCase(),
-        savingsTrade: state.wallet.coinmarket.savings.savingsTrade,
-        isSavingsTradeLoading: state.wallet.coinmarket.savings.isSavingsTradeLoading,
-        formDrafts: state.wallet.formDrafts,
-    }));
+    const fiat = useSelector(state => state.wallet.fiat);
+    const selectedProvider = useSelector(state => state.wallet.coinmarket.savings.selectedProvider);
+    const supportedCountries = useSelector(
+        state => state.wallet.coinmarket.savings.savingsInfo?.supportedCountries,
+    );
+    const providers = useSelector(
+        state => state.wallet.coinmarket.savings.savingsInfo?.savingsList?.providers,
+    );
+    const userCountry = useSelector(state =>
+        state.wallet.coinmarket.savings.savingsInfo?.country?.toUpperCase(),
+    );
+    const savingsTrade = useSelector(state => state.wallet.coinmarket.savings.savingsTrade);
+    const isSavingsTradeLoading = useSelector(
+        state => state.wallet.coinmarket.savings.isSavingsTradeLoading,
+    );
+    const formDrafts = useSelector(state => state.wallet.formDrafts);
+    const dispatch = useDispatch();
 
     const noProviders = !providers || providers.length === 0;
 
-    const {
-        submitRequestForm,
-        setSelectedProvider,
-        loadInvityData,
-        openCoinmarketSavingsConfirmModal,
-        isPolling,
-    } = useActions({
-        submitRequestForm: coinmarketCommonActions.submitRequestForm,
-        loadInvityData: coinmarketCommonActions.loadInvityData,
-        setSelectedProvider: coinmarketSavingsActions.setSelectedProvider,
-        openCoinmarketSavingsConfirmModal:
-            coinmarketSavingsActions.openCoinmarketSavingsConfirmModal,
-        isPolling: pollingActions.isPolling,
-    });
     const pollingKey = `coinmarket-savings-trade/${account.descriptor}` as const;
     const isSavingsTradeLoadingEffective =
-        (!providers || isSavingsTradeLoading) && !isPolling(pollingKey);
+        (!providers || isSavingsTradeLoading) && !dispatch(isPolling(pollingKey));
     const {
         navigateToSavingsSetupContinue,
         navigateToSavingsOverview,
@@ -74,8 +64,8 @@ export const useSavingsSetup = ({
     } = useCoinmarketNavigation(account);
 
     useEffect(() => {
-        loadInvityData();
-    }, [loadInvityData]);
+        dispatch(loadInvityData());
+    }, [dispatch]);
 
     useEffect(() => {
         if (!isSavingsTradeLoadingEffective && savingsTrade) {
@@ -149,7 +139,7 @@ export const useSavingsSetup = ({
                 provider &&
                 (!fiatAmount || !paymentFrequency || provider.name !== selectedProvider?.name)
             ) {
-                setSelectedProvider(provider);
+                dispatch(setSelectedProvider(provider));
                 if (!fiatAmount || !provider.setupPaymentAmounts.includes(fiatAmount)) {
                     setValue('fiatAmount', provider.defaultPaymentAmount.toString());
                 }
@@ -163,12 +153,12 @@ export const useSavingsSetup = ({
         }
     }, [
         countryEffective,
+        dispatch,
         fiatAmount,
         paymentFrequency,
         providers,
         savingsTrade,
         selectedProvider,
-        setSelectedProvider,
         setValue,
     ]);
 
@@ -177,12 +167,12 @@ export const useSavingsSetup = ({
     useEffect(() => {
         const requestForm = getDraft(account.descriptor) as Parameters<typeof submitRequestForm>[0];
         if (isDesktop() && requestForm && isSubmitted) {
-            submitRequestForm(requestForm);
+            dispatch(submitRequestForm(requestForm));
             navigateToSavingsSetupWaiting();
         }
     }, [
         account.descriptor,
-        submitRequestForm,
+        dispatch,
         navigateToSavingsSetupWaiting,
         formDrafts,
         getDraft,
@@ -201,7 +191,9 @@ export const useSavingsSetup = ({
         async (formValues: SavingsSetupFormState) => {
             const { customFiatAmount, fiatAmount, paymentFrequency, country } = formValues;
             if (selectedProvider && country) {
-                if (await openCoinmarketSavingsConfirmModal(selectedProvider.companyName)) {
+                if (
+                    await dispatch(openCoinmarketSavingsConfirmModal(selectedProvider.companyName))
+                ) {
                     const savingsParameters: InitSavingsTradeRequest = {
                         amount: customFiatAmount || fiatAmount,
                         exchange: selectedProvider.name,
@@ -219,7 +211,7 @@ export const useSavingsSetup = ({
                         // closed Invity web page before the savings flow was finished.
                         saveDraft(account.descriptor, formResponse.form);
                         if (!isDesktop()) {
-                            submitRequestForm(formResponse?.form);
+                            dispatch(submitRequestForm(formResponse?.form));
                         }
                     }
                 } else {
@@ -227,15 +219,7 @@ export const useSavingsSetup = ({
                 }
             }
         },
-        [
-            account.descriptor,
-            account.symbol,
-            openCoinmarketSavingsConfirmModal,
-            removeDraft,
-            saveDraft,
-            selectedProvider,
-            submitRequestForm,
-        ],
+        [account.descriptor, account.symbol, dispatch, removeDraft, saveDraft, selectedProvider],
     );
 
     const canConfirmSetup =

--- a/packages/suite/src/hooks/wallet/useCoinmarketSellDetail.ts
+++ b/packages/suite/src/hooks/wallet/useCoinmarketSellDetail.ts
@@ -9,12 +9,14 @@ import type { TradeSell } from 'src/types/wallet/coinmarketCommonTypes';
 import invityAPI from 'src/services/suite/invityAPI';
 
 export const useCoinmarketSellDetail = ({ selectedAccount }: UseCoinmarketSellDetailProps) => {
+    const invityServerEnvironment = useSelector(
+        state => state.suite.settings.debug.invityServerEnvironment,
+    );
+    const trades = useSelector(state => state.wallet.coinmarket.trades);
+    const transactionId = useSelector(state => state.wallet.coinmarket.sell.transactionId);
+
     const { account } = selectedAccount;
-    const { invityServerEnvironment, trades, transactionId } = useSelector(state => ({
-        invityServerEnvironment: state.suite.settings.debug.invityServerEnvironment,
-        trades: state.wallet.coinmarket.trades,
-        transactionId: state.wallet.coinmarket.sell.transactionId,
-    }));
+
     const sellTrade = trades.find(
         trade => trade.tradeType === 'sell' && trade.key === transactionId,
     ) as TradeSell;

--- a/packages/suite/src/hooks/wallet/useCoinmarketSpend.ts
+++ b/packages/suite/src/hooks/wallet/useCoinmarketSpend.ts
@@ -68,11 +68,10 @@ export const useCoinmarketSpend = ({
 
     const { account, network } = selectedAccount;
     const { shouldSendInSats } = useBitcoinAmountUnit(account.symbol);
-    const { sellInfo, language, fees } = useSelector(state => ({
-        sellInfo: state.wallet.coinmarket.sell.sellInfo,
-        language: state.suite.settings.language,
-        fees: state.wallet.fees,
-    }));
+    const sellInfo = useSelector(state => state.wallet.coinmarket.sell.sellInfo);
+    const language = useSelector(state => state.suite.settings.language);
+    const fees = useSelector(state => state.wallet.fees);
+
     const country = sellInfo?.sellList?.country;
     const isLoading = !sellInfo || !voucherSiteUrl;
     const provider = sellInfo?.sellList?.providers.filter(p => p.type === 'Voucher')[0];

--- a/packages/suite/src/hooks/wallet/useFiatValue.ts
+++ b/packages/suite/src/hooks/wallet/useFiatValue.ts
@@ -2,10 +2,9 @@ import { useSelector } from 'src/hooks/suite';
 
 // TODO: do the calculation here
 export const useFiatValue = () => {
-    const { fiat, localCurrency } = useSelector(state => ({
-        fiat: state.wallet.fiat,
-        localCurrency: state.wallet.settings.localCurrency,
-    }));
+    const fiat = useSelector(state => state.wallet.fiat);
+    const localCurrency = useSelector(state => state.wallet.settings.localCurrency);
+
     return {
         fiat,
         localCurrency,

--- a/packages/suite/src/hooks/wallet/useSendFormImport.ts
+++ b/packages/suite/src/hooks/wallet/useSendFormImport.ts
@@ -1,7 +1,7 @@
-import * as sendFormActions from 'src/actions/wallet/sendFormActions';
-import { useActions } from 'src/hooks/suite';
+import { importRequest } from 'src/actions/wallet/sendFormActions';
+import { useDispatch } from 'src/hooks/suite';
 import { DEFAULT_PAYMENT } from '@suite-common/wallet-constants';
-import { FIAT } from 'src/config/suite';
+import { fiatCurrencies } from '@suite-common/suite-config';
 import { fromFiatCurrency, toFiatCurrency } from '@suite-common/wallet-utils';
 import { UseSendFormState, Output } from 'src/types/wallet/sendForm';
 
@@ -15,13 +15,11 @@ type Props = {
 // This hook should be used only as a sub-hook of `useSendForm`
 
 export const useSendFormImport = ({ network, tokens, localCurrencyOption, fiatRates }: Props) => {
-    const { importRequest } = useActions({
-        importRequest: sendFormActions.importRequest,
-    });
+    const dispatch = useDispatch();
 
     const importTransaction = async () => {
         // open ImportTransaction modal and get parsed csv
-        const result = await importRequest();
+        const result = await dispatch(importRequest());
         if (!result) return; // cancelled
 
         const outputs = result.map(item => {
@@ -54,7 +52,7 @@ export const useSendFormImport = ({ network, tokens, localCurrencyOption, fiatRa
                             ) || '';
                     }
                 } else if (
-                    FIAT.currencies.find(c => c === currency) &&
+                    Object.keys(fiatCurrencies).find(c => c === currency) &&
                     fiatRates &&
                     fiatRates.current &&
                     Object.keys(fiatRates.current.rates).includes(currency)

--- a/packages/suite/src/support/messages.ts
+++ b/packages/suite/src/support/messages.ts
@@ -1850,10 +1850,6 @@ export default defineMessages({
         defaultMessage: 'Go to payment gateway',
         id: 'TR_BUY_DETAIL_SUBMITTED_GATE',
     },
-    TR_BUY_DETAIL_SUBMITTED_CANCEL: {
-        defaultMessage: 'Cancel transaction',
-        id: 'TR_BUY_DETAIL_SUBMITTED_CANCEL',
-    },
     TR_BUY_DETAIL_WAITING_FOR_USER_TITLE: {
         defaultMessage: 'Complete your transaction',
         id: 'TR_BUY_DETAIL_WAITING_FOR_USER_TITLE',

--- a/packages/suite/src/support/suite/Autodetect.tsx
+++ b/packages/suite/src/support/suite/Autodetect.tsx
@@ -6,14 +6,11 @@ import { setTheme as setThemeAction } from 'src/actions/suite/suiteActions';
 import * as languageActions from 'src/actions/settings/languageActions';
 
 const Autodetect = () => {
-    const { autodetectTheme, autodetectLanguage, currentTheme, currentLanguage } = useSelector(
-        state => ({
-            autodetectTheme: state.suite.settings.autodetect.theme,
-            autodetectLanguage: state.suite.settings.autodetect.language,
-            currentTheme: state.suite.settings.theme.variant,
-            currentLanguage: state.suite.settings.language,
-        }),
-    );
+    const autodetectTheme = useSelector(state => state.suite.settings.autodetect.theme);
+    const autodetectLanguage = useSelector(state => state.suite.settings.autodetect.language);
+    const currentTheme = useSelector(state => state.suite.settings.theme.variant);
+    const currentLanguage = useSelector(state => state.suite.settings.language);
+
     const { setTheme, setLanguage } = useActions({
         setTheme: setThemeAction,
         setLanguage: languageActions.setLanguage,

--- a/packages/suite/src/support/suite/OnlineStatus.tsx
+++ b/packages/suite/src/support/suite/OnlineStatus.tsx
@@ -1,5 +1,5 @@
 import { useEffect } from 'react';
-import { useActions } from 'src/hooks/suite/useActions';
+import { useDispatch } from 'src/hooks/suite';
 import { updateOnlineStatus } from 'src/actions/suite/suiteActions';
 
 /**
@@ -9,10 +9,11 @@ import { updateOnlineStatus } from 'src/actions/suite/suiteActions';
  */
 
 const OnlineStatus = () => {
-    const actions = useActions({ updateOnlineStatus });
+    const dispatch = useDispatch();
+
     useEffect(() => {
         const statusHandler = () => {
-            actions.updateOnlineStatus(navigator.onLine);
+            dispatch(updateOnlineStatus(navigator.onLine));
         };
 
         // handle browser back button
@@ -25,7 +26,7 @@ const OnlineStatus = () => {
             window.removeEventListener('online', statusHandler, false);
             window.removeEventListener('offline', statusHandler, false);
         };
-    }, [actions]);
+    }, [dispatch]);
 
     return null;
 };

--- a/packages/suite/src/support/suite/Resize.tsx
+++ b/packages/suite/src/support/suite/Resize.tsx
@@ -1,6 +1,6 @@
 import { useEffect, useState } from 'react';
 import useDebounce from 'react-use/lib/useDebounce';
-import { useActions } from 'src/hooks/suite/useActions';
+import { useDispatch } from 'src/hooks/suite';
 import { updateWindowSize } from 'src/actions/suite/resizeActions';
 
 /**
@@ -10,10 +10,12 @@ import { updateWindowSize } from 'src/actions/suite/resizeActions';
  */
 
 const Resize = () => {
-    const actions = useActions({ updateWindowSize });
     // useDebounce is triggered on every change of size value
     const [size, setSize] = useState({ width: 0, height: 0 });
-    useDebounce(() => actions.updateWindowSize(size.width, size.height), 300, [size]);
+
+    const dispatch = useDispatch();
+
+    useDebounce(() => dispatch(updateWindowSize(size.width, size.height)), 300, [size]);
 
     useEffect(() => {
         const handleResize = () => {
@@ -26,7 +28,7 @@ const Resize = () => {
         return () => {
             window.removeEventListener('resize', handleResize);
         };
-    }, [actions]);
+    }, []);
 
     return null;
 };

--- a/packages/suite/src/support/suite/Router.tsx
+++ b/packages/suite/src/support/suite/Router.tsx
@@ -1,35 +1,29 @@
 import { useEffect } from 'react';
-
 import { useLocation } from 'react-router-dom';
+
 import { useDidUpdate } from '@trezor/react-utils';
-import { useActions } from 'src/hooks/suite/useActions';
-import * as routerActions from 'src/actions/suite/routerActions';
+import { useDispatch, useSelector } from 'src/hooks/suite';
+import { onBeforePopState, onLocationChange } from 'src/actions/suite/routerActions';
 import history from 'src/support/history';
-import { useSelector } from 'src/hooks/suite';
 
 const RouterComponent = () => {
-    const { routerLoaded } = useSelector(state => ({
-        routerLoaded: state.router.loaded,
-    }));
+    const routerLoaded = useSelector(state => state.router.loaded);
+    const dispatch = useDispatch();
 
     const location = useLocation();
-    const { onLocationChange, onBeforePopState } = useActions({
-        onLocationChange: routerActions.onLocationChange,
-        onBeforePopState: routerActions.onBeforePopState,
-    });
 
     useDidUpdate(() => {
         // Let router to be initialized properly
         if (routerLoaded) {
             // Handle browser navigation (back button)
             const url = location.pathname + location.hash;
-            onLocationChange(url);
+            dispatch(onLocationChange(url));
         }
-    }, [location.pathname, location.hash, onLocationChange]);
+    }, [dispatch, location.pathname, location.hash]);
 
     useEffect(() => {
         const onPopState = () => {
-            const canGoBack = onBeforePopState();
+            const canGoBack = dispatch(onBeforePopState());
             if (!canGoBack) {
                 history.go(1);
             }
@@ -37,7 +31,7 @@ const RouterComponent = () => {
 
         window.addEventListener('popstate', onPopState);
         return () => window.removeEventListener('popstate', onPopState);
-    }, [onBeforePopState]);
+    }, [dispatch]);
 
     return null;
 };

--- a/packages/suite/src/support/suite/styles/GlobalStyle.tsx
+++ b/packages/suite/src/support/suite/styles/GlobalStyle.tsx
@@ -16,7 +16,7 @@ const GlobalStyle = createGlobalStyle<{ theme: SuiteThemeColors }>`
     }
 
     body, html {
-        background: ${props => props.theme.BG_GREY};
+        background: ${({ theme }) => theme.BG_GREY};
         font-size: ${variables.FONT_SIZE.NORMAL};
         -webkit-font-smoothing: antialiased;
         -moz-osx-font-smoothing: grayscale;
@@ -46,7 +46,7 @@ const GlobalStyle = createGlobalStyle<{ theme: SuiteThemeColors }>`
     }
 
     :root {
-        color-scheme: ${props => (props.theme.THEME === 'light' ? 'light' : 'dark')};
+        color-scheme: ${({ theme }) => (theme.THEME === 'light' ? 'light' : 'dark')};
     }
 
     ${animations}

--- a/packages/suite/src/support/suite/useTor.tsx
+++ b/packages/suite/src/support/suite/useTor.tsx
@@ -1,41 +1,42 @@
 import { useEffect } from 'react';
+
 import { desktopApi, BootstrapTorEvent, TorStatusEvent } from '@trezor/suite-desktop-api';
 import { TorStatus } from 'src/types/suite';
-
-import { useActions, useSelector } from 'src/hooks/suite';
+import { useDispatch, useSelector } from 'src/hooks/suite';
 import { getIsTorDomain } from 'src/utils/suite/tor';
-import * as suiteActions from 'src/actions/suite/suiteActions';
+import {
+    setTorBootstrap,
+    setTorBootstrapSlow,
+    updateTorStatus,
+} from 'src/actions/suite/suiteActions';
 import { isWeb, isDesktop, getLocationHostname } from '@trezor/env-utils';
 import { selectTorState } from 'src/reducers/suite/suiteReducer';
 import { notificationsActions } from '@suite-common/toast-notifications';
 
 export const useTor = () => {
-    const { updateTorStatus, setTorBootstrap, setTorBootstrapSlow, addToastOnce } = useActions({
-        updateTorStatus: suiteActions.updateTorStatus,
-        setTorBootstrap: suiteActions.setTorBootstrap,
-        setTorBootstrapSlow: suiteActions.setTorBootstrapSlow,
-        addToastOnce: notificationsActions.addToastOnce,
-    });
     const { torBootstrap, isTorEnabling } = useSelector(selectTorState);
+    const dispatch = useDispatch();
 
     useEffect(() => {
         if (isWeb()) {
             const isTorDomain = getIsTorDomain(getLocationHostname());
             const newTorStatus = isTorDomain ? TorStatus.Enabled : TorStatus.Disabled;
 
-            updateTorStatus(newTorStatus);
+            dispatch(updateTorStatus(newTorStatus));
         }
 
         if (isDesktop()) {
             desktopApi.on('tor/status', (newStatus: TorStatusEvent) => {
                 const { type } = newStatus;
-                updateTorStatus(type);
+                dispatch(updateTorStatus(type));
                 if (type === TorStatus.Misbehaving) {
                     // When network is slow for some reason but still working we display toast message
                     // to let the user know that it is going to take some time but it's working.
-                    addToastOnce({
-                        type: 'tor-is-slow',
-                    });
+                    dispatch(
+                        notificationsActions.addToastOnce({
+                            type: 'tor-is-slow',
+                        }),
+                    );
                 }
             });
             if (!isTorEnabling) {
@@ -43,30 +44,32 @@ export const useTor = () => {
             }
             return () => desktopApi.removeAllListeners('tor/status');
         }
-    }, [updateTorStatus, torBootstrap, addToastOnce, isTorEnabling]);
+    }, [dispatch, torBootstrap, isTorEnabling]);
 
     useEffect(() => {
         if (isDesktop()) {
             desktopApi.on('tor/bootstrap', (bootstrapEvent: BootstrapTorEvent) => {
                 if (bootstrapEvent.type === 'slow') {
-                    setTorBootstrapSlow(true);
+                    dispatch(setTorBootstrapSlow(true));
                 }
 
                 if (bootstrapEvent.type === 'progress') {
-                    setTorBootstrap({
-                        current: bootstrapEvent.progress.current,
-                        total: bootstrapEvent.progress.total,
-                    });
+                    dispatch(
+                        setTorBootstrap({
+                            current: bootstrapEvent.progress.current,
+                            total: bootstrapEvent.progress.total,
+                        }),
+                    );
 
                     if (bootstrapEvent.progress.current === bootstrapEvent.progress.total) {
-                        updateTorStatus(TorStatus.Enabled);
+                        dispatch(updateTorStatus(TorStatus.Enabled));
                     } else if (!isTorEnabling) {
-                        updateTorStatus(TorStatus.Enabling);
+                        dispatch(updateTorStatus(TorStatus.Enabling));
                     }
                 }
             });
 
             return () => desktopApi.removeAllListeners('tor/bootstrap');
         }
-    }, [updateTorStatus, setTorBootstrap, torBootstrap, setTorBootstrapSlow, isTorEnabling]);
+    }, [dispatch, torBootstrap, isTorEnabling]);
 };

--- a/packages/suite/src/types/wallet/coinmarketBuyForm.ts
+++ b/packages/suite/src/types/wallet/coinmarketBuyForm.ts
@@ -1,6 +1,6 @@
 import type { Account, Network } from 'src/types/wallet';
-import type { BuyInfo, saveQuotes, saveTrade } from 'src/actions/wallet/coinmarketBuyActions';
-import type { FormState as ReactHookFormState, UseFormReturn } from 'react-hook-form';
+import type { BuyInfo } from 'src/actions/wallet/coinmarketBuyActions';
+import type { UseFormReturn, FormState as ReactHookFormState } from 'react-hook-form';
 import type { AmountLimits, DefaultCountryOption, Option } from './coinmarketCommonTypes';
 import type { ExchangeCoinInfo } from 'invity-api';
 import type { WithSelectedAccountLoadedProps } from 'src/components/wallet';
@@ -24,8 +24,6 @@ export type BuyFormContextValues = UseFormReturn<FormState> & {
     defaultCurrency: Option;
     buyInfo?: BuyInfo;
     exchangeCoinInfo?: ExchangeCoinInfo[];
-    saveQuotes: typeof saveQuotes;
-    saveTrade: typeof saveTrade;
     amountLimits?: AmountLimits;
     setAmountLimits: (limits?: AmountLimits) => void;
     isLoading: boolean;

--- a/packages/suite/src/types/wallet/coinmarketExchangeForm.ts
+++ b/packages/suite/src/types/wallet/coinmarketExchangeForm.ts
@@ -2,18 +2,15 @@ import type { AppState } from 'src/types/suite';
 import type { FormState as ReactHookFormState, UseFormReturn } from 'react-hook-form';
 import type { Account, Network, CoinFiatRates } from 'src/types/wallet';
 import type { FeeLevel } from '@trezor/connect';
-import type { ExchangeTrade, ExchangeTradeQuoteRequest, ExchangeCoinInfo } from 'invity-api';
-import type {
-    ExchangeInfo,
-    CoinmarketExchangeAction,
-} from 'src/actions/wallet/coinmarketExchangeActions';
+import type { ExchangeCoinInfo } from 'invity-api';
+import type { ExchangeInfo } from 'src/actions/wallet/coinmarketExchangeActions';
 import type {
     FeeInfo,
     FormState,
     PrecomposedLevels,
     PrecomposedLevelsCardano,
 } from 'src/types/wallet/sendForm';
-import type { CryptoAmountLimits, Option } from './coinmarketCommonTypes';
+import type { AmountLimits, CryptoAmountLimits, Option } from './coinmarketCommonTypes';
 import type { WithSelectedAccountLoadedProps } from 'src/components/wallet';
 import { SendContextValues } from '@suite-common/wallet-types';
 
@@ -41,18 +38,7 @@ export interface ExchangeFormContextValues extends UseFormReturn<ExchangeFormSta
     composeRequest: SendContextValues['composeTransaction'];
     updateFiatCurrency: (selectedCurrency: { value: string; label: string }) => void;
     updateSendCryptoValue: (fiatValue: string, decimals: number) => void;
-    saveQuoteRequest: (request: ExchangeTradeQuoteRequest) => CoinmarketExchangeAction;
-    saveQuotes: (
-        fixedQuotes: ExchangeTrade[],
-        floatQuotes: ExchangeTrade[],
-        dexQuotes: ExchangeTrade[],
-    ) => CoinmarketExchangeAction;
-    saveTrade: (
-        exchangeTrade: ExchangeTrade,
-        account: Account,
-        date: string,
-    ) => CoinmarketExchangeAction;
-    amountLimits?: CryptoAmountLimits;
+    amountLimits?: AmountLimits;
     composedLevels?: PrecomposedLevels | PrecomposedLevelsCardano;
     fiatRates?: CoinFiatRates;
     setAmountLimits: (limits?: CryptoAmountLimits) => void;

--- a/packages/suite/src/types/wallet/coinmarketExchangeOffers.ts
+++ b/packages/suite/src/types/wallet/coinmarketExchangeOffers.ts
@@ -2,10 +2,7 @@ import type { AppState } from 'src/types/suite';
 import type { Account } from 'src/types/wallet';
 import type { ExchangeTrade } from 'invity-api';
 import type { Timer } from '@trezor/react-utils';
-import type {
-    CoinmarketExchangeAction,
-    ExchangeInfo,
-} from 'src/actions/wallet/coinmarketExchangeActions';
+import type { ExchangeInfo } from 'src/actions/wallet/coinmarketExchangeActions';
 import type { WithSelectedAccountLoadedProps } from 'src/components/wallet';
 
 export type UseCoinmarketExchangeFormProps = WithSelectedAccountLoadedProps;
@@ -32,11 +29,6 @@ export type ContextValues = {
     receiveSymbol?: string;
     receiveAccount?: Account;
     setReceiveAccount: (account?: Account) => void;
-    saveTrade: (
-        exchangeTrade: ExchangeTrade,
-        account: Account,
-        date: string,
-    ) => CoinmarketExchangeAction;
     confirmTrade: (address: string, extraField?: string) => Promise<boolean>;
     sendTransaction: () => void;
     timer: Timer;

--- a/packages/suite/src/types/wallet/coinmarketSellForm.ts
+++ b/packages/suite/src/types/wallet/coinmarketSellForm.ts
@@ -2,8 +2,8 @@ import type { AppState } from 'src/types/suite';
 import type { FormState as ReactHookFormState, UseFormReturn } from 'react-hook-form';
 import type { Account, Network, CoinFiatRates } from 'src/types/wallet';
 import type { FeeLevel } from '@trezor/connect';
-import type { SellFiatTrade, SellFiatTradeQuoteRequest, ExchangeCoinInfo } from 'invity-api';
-import type { CoinmarketSellAction, SellInfo } from 'src/actions/wallet/coinmarketSellActions';
+import type { ExchangeCoinInfo } from 'invity-api';
+import type { SellInfo } from 'src/actions/wallet/coinmarketSellActions';
 import type {
     FeeInfo,
     FormState,
@@ -44,12 +44,6 @@ export type SellFormContextValues = UseFormReturn<SellFormState> & {
     exchangeCoinInfo?: ExchangeCoinInfo[];
     localCurrencyOption: { label: string; value: string };
     composeRequest: SendContextValues<SellFormState>['composeTransaction'];
-    saveQuoteRequest: (request: SellFiatTradeQuoteRequest) => CoinmarketSellAction;
-    saveQuotes: (
-        fixedQuotes: SellFiatTrade[],
-        floatQuotes: SellFiatTrade[],
-    ) => CoinmarketSellAction;
-    saveTrade: (sellTrade: SellFiatTrade, account: Account, date: string) => CoinmarketSellAction;
     amountLimits?: AmountLimits;
     composedLevels?: PrecomposedLevels | PrecomposedLevelsCardano;
     fiatRates?: CoinFiatRates;

--- a/packages/suite/src/types/wallet/coinmarketSellOffers.ts
+++ b/packages/suite/src/types/wallet/coinmarketSellOffers.ts
@@ -2,7 +2,7 @@ import type { AppState } from 'src/types/suite';
 import type { Account } from 'src/types/wallet';
 import type { BankAccount, SellFiatTrade } from 'invity-api';
 import type { Timer } from '@trezor/react-utils';
-import type { CoinmarketSellAction, SellInfo } from 'src/actions/wallet/coinmarketSellActions';
+import type { SellInfo } from 'src/actions/wallet/coinmarketSellActions';
 import type { WithSelectedAccountLoadedProps } from 'src/components/wallet';
 import { TradeSell } from './coinmarketCommonTypes';
 
@@ -24,7 +24,6 @@ export type ContextValues = {
     sellStep: SellStep;
     setSellStep: (step: SellStep) => void;
     selectQuote: (quote: SellFiatTrade) => void;
-    saveTrade: (sellTrade: SellFiatTrade, account: Account, date: string) => CoinmarketSellAction;
     addBankAccount: () => void;
     confirmTrade: (bankAccount: BankAccount) => void;
     sendTransaction: () => void;

--- a/packages/suite/src/utils/suite/anchor.ts
+++ b/packages/suite/src/utils/suite/anchor.ts
@@ -33,7 +33,7 @@ export const anchorOutlineStyles = css<{ shouldHighlight?: boolean }>`
     ${props =>
         props.shouldHighlight &&
         css`
-            outline: solid 3px ${props => props.theme.TYPE_ORANGE};
-            background: ${props => props.theme.TYPE_LIGHT_ORANGE};
+            outline: solid 3px ${({ theme }) => theme.TYPE_ORANGE};
+            background: ${({ theme }) => theme.TYPE_LIGHT_ORANGE};
         `}
 `;

--- a/packages/suite/src/views/backup/index.tsx
+++ b/packages/suite/src/views/backup/index.tsx
@@ -18,7 +18,7 @@ const StyledButton = styled(Button)`
 `;
 
 const StyledP = styled(P)`
-    color: ${props => props.theme.TYPE_LIGHT_GREY};
+    color: ${({ theme }) => theme.TYPE_LIGHT_GREY};
 `;
 
 const StyledImage = styled(Image)`

--- a/packages/suite/src/views/dashboard/components/AssetsCard/components/AssetGrid.tsx
+++ b/packages/suite/src/views/dashboard/components/AssetsCard/components/AssetGrid.tsx
@@ -12,8 +12,8 @@ import {
 } from 'src/components/suite';
 import { CoinBalance, CoinmarketBuyButton } from 'src/components/wallet';
 import { isTestnet } from '@suite-common/wallet-utils';
-import * as routerActions from 'src/actions/suite/routerActions';
-import { useActions, useAccountSearch, useLoadingSkeleton } from 'src/hooks/suite';
+import { goto } from 'src/actions/suite/routerActions';
+import { useAccountSearch, useDispatch, useLoadingSkeleton } from 'src/hooks/suite';
 
 const Col = styled.div`
     display: flex;
@@ -95,28 +95,29 @@ interface AssetGridProps {
 
 export const AssetGrid = React.memo(({ network, failed, cryptoValue }: AssetGridProps) => {
     const { symbol, name } = network;
+    const dispatch = useDispatch();
     const theme = useTheme();
     const { setCoinFilter, setSearchString } = useAccountSearch();
 
-    const { goto } = useActions({ goto: routerActions.goto });
+    const handleLogoClick = () => {
+        dispatch(
+            goto('wallet-index', {
+                params: {
+                    symbol,
+                    accountIndex: 0,
+                    accountType: 'normal',
+                },
+            }),
+        );
+        // activate coin filter and reset account search string
+        setCoinFilter(symbol);
+        setSearchString(undefined);
+    };
 
     return (
         <CoinGridWrapper>
             <UpperRowWrapper>
-                <CoinNameWrapper
-                    onClick={() => {
-                        goto('wallet-index', {
-                            params: {
-                                symbol,
-                                accountIndex: 0,
-                                accountType: 'normal',
-                            },
-                        });
-                        // activate coin filter and reset account search string
-                        setCoinFilter(symbol);
-                        setSearchString(undefined);
-                    }}
-                >
+                <CoinNameWrapper onClick={handleLogoClick}>
                     <LogoWrapper>
                         <CoinLogo symbol={symbol} size={24} />
                     </LogoWrapper>

--- a/packages/suite/src/views/dashboard/components/AssetsCard/components/AssetTable.tsx
+++ b/packages/suite/src/views/dashboard/components/AssetsCard/components/AssetTable.tsx
@@ -12,8 +12,8 @@ import {
 } from 'src/components/suite';
 import { CoinBalance, CoinmarketBuyButton } from 'src/components/wallet';
 import { isTestnet } from '@suite-common/wallet-utils';
-import * as routerActions from 'src/actions/suite/routerActions';
-import { useActions, useAccountSearch, useLoadingSkeleton } from 'src/hooks/suite';
+import { goto } from 'src/actions/suite/routerActions';
+import { useAccountSearch, useDispatch, useLoadingSkeleton } from 'src/hooks/suite';
 import { motion } from 'framer-motion';
 
 const LogoWrapper = styled.div`
@@ -129,28 +129,28 @@ interface AssetTableProps {
 export const AssetTable = React.memo(
     ({ network, failed, cryptoValue, isLastRow }: AssetTableProps) => {
         const { symbol, name } = network;
+        const dispatch = useDispatch();
         const theme = useTheme();
         const { setCoinFilter, setSearchString } = useAccountSearch();
 
-        const { goto } = useActions({ goto: routerActions.goto });
+        const handleLogoClick = () => {
+            dispatch(
+                goto('wallet-index', {
+                    params: {
+                        symbol,
+                        accountIndex: 0,
+                        accountType: 'normal',
+                    },
+                }),
+            );
+            // activate coin filter and reset account search string
+            setCoinFilter(symbol);
+            setSearchString(undefined);
+        };
 
         return (
             <>
-                <CoinNameWrapper
-                    isLastRow={isLastRow}
-                    onClick={() => {
-                        goto('wallet-index', {
-                            params: {
-                                symbol,
-                                accountIndex: 0,
-                                accountType: 'normal',
-                            },
-                        });
-                        // activate coin filter and reset account search string
-                        setCoinFilter(symbol);
-                        setSearchString(undefined);
-                    }}
-                >
+                <CoinNameWrapper isLastRow={isLastRow} onClick={handleLogoClick}>
                     <LogoWrapper>
                         <CoinLogo symbol={symbol} size={24} />
                     </LogoWrapper>

--- a/packages/suite/src/views/dashboard/components/AssetsCard/index.tsx
+++ b/packages/suite/src/views/dashboard/components/AssetsCard/index.tsx
@@ -8,10 +8,10 @@ import { AssetGrid, AssetGridSkeleton } from './components/AssetGrid';
 import { Account, Network } from 'src/types/wallet';
 import { variables, Icon, Button, colors, LoadingContent } from '@trezor/components';
 import { Card, Translation } from 'src/components/suite';
-import { useDiscovery, useActions, useSelector } from 'src/hooks/suite';
+import { useDiscovery, useDispatch, useSelector } from 'src/hooks/suite';
 import { useAccounts } from 'src/hooks/wallet';
-import * as suiteActions from 'src/actions/suite/suiteActions';
-import * as routerActions from 'src/actions/suite/routerActions';
+import { setFlag } from 'src/actions/suite/suiteActions';
+import { goto } from 'src/actions/suite/routerActions';
 import { AnimatePresence } from 'framer-motion';
 
 const StyledCard = styled(Card)`
@@ -22,7 +22,7 @@ const StyledCard = styled(Card)`
 const InfoMessage = styled.div`
     padding: 16px 25px;
     display: flex;
-    color: ${props => props.theme.TYPE_RED};
+    color: ${({ theme }) => theme.TYPE_RED};
     font-size: ${variables.FONT_SIZE.TINY};
     font-weight: ${variables.FONT_WEIGHT.REGULAR};
 `;
@@ -35,12 +35,12 @@ const ActionsWrapper = styled.div`
 const Header = styled.div`
     display: flex;
     font-size: ${variables.FONT_SIZE.SMALL};
-    color: ${props => props.theme.TYPE_LIGHT_GREY};
+    color: ${({ theme }) => theme.TYPE_LIGHT_GREY};
     font-weight: 500;
     line-height: 1.57;
     align-items: center;
     padding: 12px 0px;
-    border-bottom: 1px solid ${props => props.theme.STROKE_GREY};
+    border-bottom: 1px solid ${({ theme }) => theme.STROKE_GREY};
 
     &:first-child {
         padding-left: 18px;
@@ -82,10 +82,7 @@ const AssetsCard = () => {
     const { discovery, getDiscoveryStatus, isDiscoveryRunning } = useDiscovery();
     const { accounts } = useAccounts(discovery);
     const { dashboardAssetsGridMode } = useSelector(s => s.suite.flags);
-    const { goto, setFlag } = useActions({
-        goto: routerActions.goto,
-        setFlag: suiteActions.setFlag,
-    });
+    const dispatch = useDispatch();
 
     const assets: { [key: string]: Account[] } = {};
     accounts.forEach(a => {
@@ -118,6 +115,10 @@ const AssetsCard = () => {
     const discoveryInProgress = discoveryStatus && discoveryStatus.status === 'loading';
     const isError = discoveryStatus && discoveryStatus.status === 'exception' && !networks.length;
 
+    const goToCoinsSettings = () => dispatch(goto('settings-coins'));
+    const setTable = () => dispatch(setFlag('dashboardAssetsGridMode', false));
+    const setGrid = () => dispatch(setFlag('dashboardAssetsGridMode', true));
+
     return (
         <Section
             heading={
@@ -129,7 +130,7 @@ const AssetsCard = () => {
                     <StyledAddAccountButton
                         variant="tertiary"
                         icon="PLUS"
-                        onClick={() => goto('settings-coins')}
+                        onClick={goToCoinsSettings}
                     >
                         <Translation id="TR_ENABLE_MORE_COINS" />
                     </StyledAddAccountButton>
@@ -140,13 +141,13 @@ const AssetsCard = () => {
                     <Icon
                         icon="TABLE"
                         data-test="@dashboard/assets/table-icon"
-                        onClick={() => setFlag('dashboardAssetsGridMode', false)}
+                        onClick={setTable}
                         color={!dashboardAssetsGridMode ? colors.BG_GREEN : colors.TYPE_LIGHT_GREY}
                     />
                     <Icon
                         icon="GRID"
                         data-test="@dashboard/assets/grid-icon"
-                        onClick={() => setFlag('dashboardAssetsGridMode', true)}
+                        onClick={setGrid}
                         color={dashboardAssetsGridMode ? colors.BG_GREEN : colors.TYPE_LIGHT_GREY}
                     />
                 </ActionsWrapper>

--- a/packages/suite/src/views/dashboard/components/Header/index.tsx
+++ b/packages/suite/src/views/dashboard/components/Header/index.tsx
@@ -8,7 +8,7 @@ const Wrapper = styled.div`
 `;
 
 const Left = styled.div`
-    color: ${props => props.theme.TYPE_DARK_GREY};
+    color: ${({ theme }) => theme.TYPE_DARK_GREY};
 `;
 
 const Right = styled.div``;

--- a/packages/suite/src/views/dashboard/components/Header/index.tsx
+++ b/packages/suite/src/views/dashboard/components/Header/index.tsx
@@ -13,12 +13,12 @@ const Left = styled.div`
 
 const Right = styled.div``;
 
-interface Props {
+interface HeaderProps {
     left: ReactElement;
     right?: ReactElement;
 }
 
-const Header = ({ left, right }: Props) => (
+const Header = ({ left, right }: HeaderProps) => (
     <Wrapper>
         {left && <Left>{left}</Left>}
         {right && <Right>{right}</Right>}

--- a/packages/suite/src/views/dashboard/components/PortfolioCard/components/DashboardGraph.tsx
+++ b/packages/suite/src/views/dashboard/components/PortfolioCard/components/DashboardGraph.tsx
@@ -1,13 +1,13 @@
 import React, { memo, useState, useEffect, useCallback } from 'react';
-
-import { TransactionsGraph, Translation, HiddenPlaceholder } from 'src/components/suite';
 import { getUnixTime } from 'date-fns';
 import styled from 'styled-components';
+
 import { CARD_PADDING_SIZE } from 'src/constants/suite/layout';
 import GraphWorker from 'src/support/workers/graph';
-import * as graphActions from 'src/actions/wallet/graphActions';
-import { useActions, useSelector } from 'src/hooks/suite';
+import { getGraphDataForInterval, updateGraphData } from 'src/actions/wallet/graphActions';
+import { useDispatch, useSelector } from 'src/hooks/suite';
 import { Account } from 'src/types/wallet';
+import { TransactionsGraph, Translation, HiddenPlaceholder } from 'src/components/suite';
 
 import { variables, Button } from '@trezor/components';
 import { calcTicks, calcTicksFromData } from '@suite-common/suite-utils';
@@ -34,7 +34,7 @@ const ErrorMessage = styled.div`
     padding: 20px;
     align-items: center;
     justify-content: center;
-    color: ${props => props.theme.TYPE_LIGHT_GREY};
+    color: ${({ theme }) => theme.TYPE_LIGHT_GREY};
     font-size: ${variables.FONT_SIZE.SMALL};
     text-align: center;
 `;
@@ -45,30 +45,22 @@ interface DashboardGraphProps {
 
 // DashboardGraph.whyDidYouRender = true;
 export const DashboardGraph = memo(({ accounts }: DashboardGraphProps) => {
-    const { updateGraphData, getGraphDataForInterval } = useActions({
-        updateGraphData: graphActions.updateGraphData,
-        getGraphDataForInterval: graphActions.getGraphDataForInterval,
-    });
-    const { graph, selectedDevice, localCurrency } = useSelector(state => ({
-        graph: state.wallet.graph,
-        selectedDevice: state.suite.device,
-        localCurrency: state.wallet.settings.localCurrency,
-    }));
-
-    const { selectedRange } = graph;
+    const { error, isLoading, selectedRange } = useSelector(state => state.wallet.graph);
+    const selectedDevice = useSelector(state => state.suite.device);
+    const localCurrency = useSelector(state => state.wallet.settings.localCurrency);
+    const dispatch = useDispatch();
 
     const [data, setData] = useState<AggregatedDashboardHistory[]>([]);
     const [isProcessing, setIsProcessing] = useState(false);
     const [xTicks, setXticks] = useState<number[]>([]);
 
     const selectedDeviceState = selectedDevice?.state;
-    const { isLoading } = graph;
-    const failedAccounts = graph.error?.filter(a => a.deviceState === selectedDeviceState);
+    const failedAccounts = error?.filter(a => a.deviceState === selectedDeviceState);
     const allFailed = failedAccounts && failedAccounts.length === accounts.length;
 
     const onRefresh = useCallback(() => {
-        updateGraphData(accounts);
-    }, [updateGraphData, accounts]);
+        dispatch(updateGraphData(accounts));
+    }, [accounts, dispatch]);
 
     const receivedValueFn = useCallback(
         (sourceData: AggregatedDashboardHistory) => sourceData.receivedFiat[localCurrency],
@@ -97,7 +89,7 @@ export const DashboardGraph = memo(({ accounts }: DashboardGraphProps) => {
         if (!isLoading) {
             const worker = new GraphWorker();
             setIsProcessing(true);
-            const rawData = getGraphDataForInterval({ deviceState: selectedDeviceState });
+            const rawData = dispatch(getGraphDataForInterval({ deviceState: selectedDeviceState }));
 
             worker.postMessage({
                 history: rawData,
@@ -125,7 +117,7 @@ export const DashboardGraph = memo(({ accounts }: DashboardGraphProps) => {
                 worker.terminate();
             };
         }
-    }, [isLoading, getGraphDataForInterval, selectedDeviceState, selectedRange]);
+    }, [dispatch, isLoading, selectedDeviceState, selectedRange]);
 
     return (
         <Wrapper data-test="@dashboard/graph">

--- a/packages/suite/src/views/dashboard/components/PortfolioCard/components/EmptyWallet.tsx
+++ b/packages/suite/src/views/dashboard/components/PortfolioCard/components/EmptyWallet.tsx
@@ -22,7 +22,7 @@ const Content = styled.div`
 `;
 
 const Title = styled(H3)`
-    color: ${props => props.theme.TYPE_DARK_GREY};
+    color: ${({ theme }) => theme.TYPE_DARK_GREY};
     margin-bottom: 30px;
 
     @media (max-width: ${variables.SCREEN_SIZE.MD}) {
@@ -36,7 +36,7 @@ const StyledImage = styled(props => <Image {...props} />)`
 `;
 
 const SecurityItem = styled.div`
-    color: ${props => props.theme.TYPE_LIGHT_GREY};
+    color: ${({ theme }) => theme.TYPE_LIGHT_GREY};
     font-size: ${variables.FONT_SIZE.SMALL};
 
     & + & {

--- a/packages/suite/src/views/dashboard/components/PortfolioCard/components/Header.tsx
+++ b/packages/suite/src/views/dashboard/components/PortfolioCard/components/Header.tsx
@@ -18,12 +18,12 @@ const Wrapper = styled.div<{ hideBorder: boolean }>`
     ${props =>
         !props.hideBorder &&
         css`
-            border-bottom: solid 1px ${props => props.theme.STROKE_GREY};
+            border-bottom: solid 1px ${({ theme }) => theme.STROKE_GREY};
         `}
 `;
 
 const ValueWrapper = styled(H2)`
-    color: ${props => props.theme.TYPE_DARK_GREY};
+    color: ${({ theme }) => theme.TYPE_DARK_GREY};
     font-variant-numeric: tabular-nums;
 `;
 

--- a/packages/suite/src/views/dashboard/components/PortfolioCard/index.tsx
+++ b/packages/suite/src/views/dashboard/components/PortfolioCard/index.tsx
@@ -3,11 +3,11 @@ import styled from 'styled-components';
 import { Dropdown } from '@trezor/components';
 import { Card, QuestionTooltip, Translation } from 'src/components/suite';
 import { Section } from 'src/components/dashboard';
-import { useDiscovery, useSelector, useActions } from 'src/hooks/suite';
+import { useDiscovery, useDispatch, useSelector } from 'src/hooks/suite';
 import { useFastAccounts, useFiatValue } from 'src/hooks/wallet';
 import { SkeletonTransactionsGraph } from 'src/components/suite/TransactionsGraph';
-import * as routerActions from 'src/actions/suite/routerActions';
-import * as suiteActions from 'src/actions/suite/suiteActions';
+import { goto } from 'src/actions/suite/routerActions';
+import { setFlag } from 'src/actions/suite/suiteActions';
 import * as accountUtils from '@suite-common/wallet-utils';
 
 import { Header } from './components/Header';
@@ -44,10 +44,7 @@ const PortfolioCard = React.memo(() => {
     const { discovery, getDiscoveryStatus, isDiscoveryRunning } = useDiscovery();
     const accounts = useFastAccounts();
     const { dashboardGraphHidden } = useSelector(s => s.suite.flags);
-    const { setFlag, goto } = useActions({
-        setFlag: suiteActions.setFlag,
-        goto: routerActions.goto,
-    });
+    const dispatch = useDispatch();
 
     const isDeviceEmpty = useMemo(() => accounts.every(a => a.empty), [accounts]);
     const portfolioValue = accountUtils
@@ -88,6 +85,9 @@ const PortfolioCard = React.memo(() => {
         showGraphControls &&
         !!accounts.find(a => a.networkType === 'ethereum' || a.networkType === 'ripple');
 
+    const goToReceive = () => dispatch(goto('wallet-receive'));
+    const goToBuy = () => dispatch(goto('wallet-coinmarket-buy'));
+
     return (
         <Section
             heading={
@@ -120,7 +120,12 @@ const PortfolioCard = React.memo(() => {
                                             <Translation id="TR_HIDE_GRAPH" />
                                         ),
                                         callback: () => {
-                                            setFlag('dashboardGraphHidden', !dashboardGraphHidden);
+                                            dispatch(
+                                                setFlag(
+                                                    'dashboardGraphHidden',
+                                                    !dashboardGraphHidden,
+                                                ),
+                                            );
                                             return true;
                                         },
                                     },
@@ -141,8 +146,8 @@ const PortfolioCard = React.memo(() => {
                     isWalletLoading={isWalletLoading}
                     isWalletError={isWalletError}
                     isDiscoveryRunning={isDiscoveryRunning}
-                    receiveClickHandler={() => goto('wallet-receive')}
-                    buyClickHandler={() => goto('wallet-coinmarket-buy')}
+                    receiveClickHandler={goToReceive}
+                    buyClickHandler={goToBuy}
                 />
 
                 {body && <Body>{body}</Body>}

--- a/packages/suite/src/views/dashboard/components/SecurityFeatures/index.tsx
+++ b/packages/suite/src/views/dashboard/components/SecurityFeatures/index.tsx
@@ -5,11 +5,11 @@ import { Button, SecurityCard, SecurityCardProps, variables } from '@trezor/comp
 import { Translation } from 'src/components/suite';
 import { Section } from 'src/components/dashboard';
 import { AcquiredDevice } from 'src/types/suite';
-import { useDevice, useDiscovery, useActions, useSelector } from 'src/hooks/suite';
-import * as walletSettingsActions from 'src/actions/settings/walletSettingsActions';
-import * as suiteActions from 'src/actions/suite/suiteActions';
-import * as deviceSettingsActions from 'src/actions/settings/deviceSettingsActions';
-import * as routerActions from 'src/actions/suite/routerActions';
+import { useDevice, useDiscovery, useDispatch, useSelector } from 'src/hooks/suite';
+import { setDiscreetMode } from 'src/actions/settings/walletSettingsActions';
+import { createDeviceInstance, setFlag } from 'src/actions/suite/suiteActions';
+import { applySettings, changePin } from 'src/actions/settings/deviceSettingsActions';
+import { goto } from 'src/actions/suite/routerActions';
 import { SettingsAnchor } from 'src/constants/suite/anchors';
 
 const Content = styled.div`
@@ -26,20 +26,10 @@ const Content = styled.div`
 `;
 
 const SecurityFeatures = () => {
-    const { setDiscreetMode, createDeviceInstance, changePin, applySettings, goto, setFlag } =
-        useActions({
-            setDiscreetMode: walletSettingsActions.setDiscreetMode,
-            createDeviceInstance: suiteActions.createDeviceInstance,
-            changePin: deviceSettingsActions.changePin,
-            applySettings: deviceSettingsActions.applySettings,
-            goto: routerActions.goto,
-            setFlag: suiteActions.setFlag,
-        });
-    const { discreetMode, device, flags } = useSelector(state => ({
-        discreetMode: state.wallet.settings.discreetMode,
-        device: state.suite.device,
-        flags: state.suite.flags,
-    }));
+    const discreetMode = useSelector(state => state.wallet.settings.discreetMode);
+    const device = useSelector(state => state.suite.device);
+    const flags = useSelector(state => state.suite.flags);
+    const dispatch = useDispatch();
 
     const { isLocked } = useDevice();
     const isDeviceLocked = isLocked();
@@ -77,7 +67,7 @@ const SecurityFeatures = () => {
               cta: {
                   label: <Translation id="TR_BACKUP_NOW" />,
                   dataTest: 'backup',
-                  action: () => goto('backup-index'),
+                  action: () => dispatch(goto('backup-index')),
                   isDisabled: !!backupFailed,
               },
           }
@@ -89,7 +79,9 @@ const SecurityFeatures = () => {
                   label: <Translation id="TR_CHECK_SEED_IN_SETTINGS" />,
                   dataTest: 'seed-link',
                   action: () =>
-                      goto('settings-device', { anchor: SettingsAnchor.CheckRecoverySeed }),
+                      dispatch(
+                          goto('settings-device', { anchor: SettingsAnchor.CheckRecoverySeed }),
+                      ),
               },
           };
 
@@ -102,7 +94,7 @@ const SecurityFeatures = () => {
               cta: {
                   label: <Translation id="TR_ENABLE_PIN" />,
                   dataTest: 'pin',
-                  action: () => changePin({}),
+                  action: () => dispatch(changePin({})),
                   isDisabled: isDeviceLocked,
               },
           }
@@ -113,7 +105,8 @@ const SecurityFeatures = () => {
               cta: {
                   label: <Translation id="TR_CHANGE_PIN_IN_SETTINGS" />,
                   dataTest: 'pin-link',
-                  action: () => goto('settings-device', { anchor: SettingsAnchor.ChangePin }),
+                  action: () =>
+                      dispatch(goto('settings-device', { anchor: SettingsAnchor.ChangePin })),
               },
           };
 
@@ -126,9 +119,11 @@ const SecurityFeatures = () => {
               cta: {
                   label: <Translation id="TR_ENABLE_PASSPHRASE" />,
                   action: () =>
-                      applySettings({
-                          use_passphrase: true,
-                      }),
+                      dispatch(
+                          applySettings({
+                              use_passphrase: true,
+                          }),
+                      ),
                   dataTest: 'hidden-wallet',
                   isDisabled: isDeviceLocked,
               },
@@ -139,7 +134,7 @@ const SecurityFeatures = () => {
               heading: <Translation id="TR_PASSPHRASE_PROTECTION_ENABLED" />,
               cta: {
                   label: <Translation id="TR_CREATE_HIDDEN_WALLET" />,
-                  action: () => createDeviceInstance(device as AcquiredDevice),
+                  action: () => dispatch(createDeviceInstance(device as AcquiredDevice)),
                   dataTest: 'create-hidden-wallet',
                   isDisabled: isDeviceLocked,
               },
@@ -153,7 +148,7 @@ const SecurityFeatures = () => {
               description: <Translation id="TR_TRY_TO_TEMPORARILY_HIDE" />,
               cta: {
                   label: <Translation id="TR_TRY_DISCREET_MODE" />,
-                  action: () => setDiscreetMode(true),
+                  action: () => dispatch(setDiscreetMode(true)),
                   dataTest: 'discreet',
               },
           }
@@ -167,7 +162,7 @@ const SecurityFeatures = () => {
                   ) : (
                       <Translation id="TR_ENABLE_DISCREET_MODE" />
                   ),
-                  action: () => setDiscreetMode(!discreetMode),
+                  action: () => dispatch(setDiscreetMode(!discreetMode)),
                   dataTest: 'toggle-discreet',
               },
           };
@@ -186,7 +181,7 @@ const SecurityFeatures = () => {
                 <Button
                     variant="tertiary"
                     icon={securityStepsHidden ? 'ARROW_DOWN' : 'ARROW_UP'}
-                    onClick={() => setFlag('securityStepsHidden', !securityStepsHidden)}
+                    onClick={() => dispatch(setFlag('securityStepsHidden', !securityStepsHidden))}
                 >
                     {securityStepsHidden ? (
                         <Translation id="TR_SHOW_BUTTON" />

--- a/packages/suite/src/views/firmware/FirmwareCustom.tsx
+++ b/packages/suite/src/views/firmware/FirmwareCustom.tsx
@@ -1,12 +1,12 @@
 import React, { useState, useMemo, useCallback } from 'react';
 import styled from 'styled-components';
 import { ConfirmOnDevice } from '@trezor/components';
-import { useActions, useDevice, useFirmware } from 'src/hooks/suite';
+import { useDevice, useDispatch, useFirmware } from 'src/hooks/suite';
 import { Translation, Modal } from 'src/components/suite';
 import { DeviceAcquire } from 'src/views/suite/device-acquire';
 import { DeviceUnknown } from 'src/views/suite/device-unknown';
 import { DeviceUnreadable } from 'src/views/suite/device-unreadable';
-import * as routerActions from 'src/actions/suite/routerActions';
+import { closeModalApp } from 'src/actions/suite/routerActions';
 import type { TrezorDevice } from 'src/types/suite';
 import { ConnectDevicePromptManager, OnboardingStepBox } from 'src/components/onboarding';
 import { useCachedDevice } from 'src/hooks/firmware/useCachedDevice';
@@ -17,7 +17,7 @@ import {
     ReconnectDevicePrompt,
     SelectCustomFirmware,
 } from 'src/components/firmware';
-import * as suiteActions from 'src/actions/suite/suiteActions';
+import { acquireDevice } from 'src/actions/suite/suiteActions';
 
 const StyledModal = styled(Modal)<{ isNarrow: boolean }>`
     width: ${({ isNarrow }) => (isNarrow ? '450px' : '620px')};
@@ -33,10 +33,8 @@ const ModalContent = styled.div<{ isNarrow: boolean }>`
 
 export const FirmwareCustom = () => {
     const [firmwareBinary, setFirmwareBinary] = useState<ArrayBuffer>();
-    const { closeModalApp, acquireDevice } = useActions({
-        closeModalApp: routerActions.closeModalApp,
-        acquireDevice: suiteActions.acquireDevice,
-    });
+
+    const dispatch = useDispatch();
 
     const { setStatus, firmwareCustom, resetReducer, status, error } = useFirmware();
     const { device: liveDevice } = useDevice();
@@ -68,11 +66,11 @@ export const FirmwareCustom = () => {
 
     const onClose = useCallback(() => {
         if (liveDevice?.status !== 'available') {
-            acquireDevice(liveDevice);
+            dispatch(acquireDevice(liveDevice));
         }
-        closeModalApp();
+        dispatch(closeModalApp());
         resetReducer();
-    }, [liveDevice, acquireDevice, closeModalApp, resetReducer]);
+    }, [dispatch, liveDevice, resetReducer]);
 
     const shouldDisplayConnectPrompt = (device?: TrezorDevice) =>
         !device?.connected || !device?.features;

--- a/packages/suite/src/views/firmware/index.tsx
+++ b/packages/suite/src/views/firmware/index.tsx
@@ -1,6 +1,6 @@
 import React, { useState } from 'react';
 import styled from 'styled-components';
-import * as routerActions from 'src/actions/suite/routerActions';
+import { closeModalApp } from 'src/actions/suite/routerActions';
 import { TrezorDevice } from 'src/types/suite';
 import {
     CheckSeedStep,
@@ -13,9 +13,9 @@ import { DeviceUnknown } from 'src/views/suite/device-unknown';
 import { DeviceUnreadable } from 'src/views/suite/device-unreadable';
 import { Translation, Modal } from 'src/components/suite';
 import { OnboardingStepBox } from 'src/components/onboarding';
-import { useActions, useFirmware, useSelector } from 'src/hooks/suite';
+import { useDispatch, useFirmware, useSelector } from 'src/hooks/suite';
 import { ConfirmOnDevice, variables } from '@trezor/components';
-import * as suiteActions from 'src/actions/suite/suiteActions';
+import { acquireDevice } from 'src/actions/suite/suiteActions';
 
 const Wrapper = styled.div<{ isWithTopPadding: boolean }>`
     display: flex;
@@ -44,17 +44,15 @@ export const Firmware = ({ shouldSwitchFirmwareType }: FirmwareProps) => {
     const { resetReducer, status, setStatus, error, firmwareUpdate, firmwareHashInvalid } =
         useFirmware();
     const device = useSelector(state => state.suite.device);
-    const { closeModalApp, acquireDevice } = useActions({
-        closeModalApp: routerActions.closeModalApp,
-        acquireDevice: suiteActions.acquireDevice,
-    });
+    const dispatch = useDispatch();
+
     const deviceModelInternal = device?.features?.internal_model;
 
     const onClose = () => {
         if (device?.status !== 'available') {
-            acquireDevice(device);
+            dispatch(acquireDevice(device));
         }
-        closeModalApp();
+        dispatch(closeModalApp());
         resetReducer();
     };
 

--- a/packages/suite/src/views/onboarding/UnexpectedState/index.tsx
+++ b/packages/suite/src/views/onboarding/UnexpectedState/index.tsx
@@ -15,7 +15,7 @@ const Wrapper = styled.div`
     flex-direction: column;
 `;
 
-interface Props {
+interface UnexpectedStateProps {
     children: JSX.Element;
     prerequisite?: PrerequisiteType;
     prerequisitesGuidePadded?: boolean;
@@ -24,7 +24,11 @@ interface Props {
 /**
  * This component handles unexpected device states across various steps in the onboarding.
  */
-const UnexpectedState = ({ children, prerequisite, prerequisitesGuidePadded }: Props) => {
+const UnexpectedState = ({
+    children,
+    prerequisite,
+    prerequisitesGuidePadded,
+}: UnexpectedStateProps) => {
     const { device } = useSelector(s => s.suite);
     const { prevDevice, activeStepId, showPinMatrix } = useOnboarding();
     const activeStep = steps.find(s => s.id === activeStepId);

--- a/packages/suite/src/views/onboarding/steps/Backup.tsx
+++ b/packages/suite/src/views/onboarding/steps/Backup.tsx
@@ -12,10 +12,10 @@ import {
 import { Translation } from 'src/components/suite';
 import { BackupSeedCards } from 'src/components/backup';
 import { canContinue } from 'src/utils/backup';
-import { useSelector, useActions } from 'src/hooks/suite';
-import * as onboardingActions from 'src/actions/onboarding/onboardingActions';
-import * as backupActions from 'src/actions/backup/backupActions';
-import * as routerActions from 'src/actions/suite/routerActions';
+import { useDispatch, useSelector } from 'src/hooks/suite';
+import { goToNextStep, updateAnalytics } from 'src/actions/onboarding/onboardingActions';
+import { backupDevice } from 'src/actions/backup/backupActions';
+import { goto } from 'src/actions/suite/routerActions';
 import { SettingsAnchor } from 'src/constants/suite/anchors';
 import { selectIsActionAbortable } from 'src/reducers/suite/suiteReducer';
 
@@ -25,19 +25,13 @@ const StyledImage = styled(Image)`
 
 export const BackupStep = () => {
     const [showSkipConfirmation, setShowSkipConfirmation] = useState(false);
-    const { goToNextStep, backupDevice, goto, updateAnalytics } = useActions({
-        goToNextStep: onboardingActions.goToNextStep,
-        backupDevice: backupActions.backupDevice,
-        goto: routerActions.goto,
-        updateAnalytics: onboardingActions.updateAnalytics,
-    });
-    const { backup, locks, device } = useSelector(state => ({
-        backup: state.backup,
-        locks: state.suite.locks,
-        device: state.suite.device,
-    }));
-    const deviceModelInternal = device?.features?.internal_model;
+    const backup = useSelector(state => state.backup);
+    const device = useSelector(state => state.suite.device);
+    const locks = useSelector(state => state.suite.locks);
     const isActionAbortable = useSelector(selectIsActionAbortable);
+    const dispatch = useDispatch();
+
+    const deviceModelInternal = device?.features?.internal_model;
 
     if (!deviceModelInternal) {
         return null;
@@ -58,8 +52,8 @@ export const BackupStep = () => {
                         <OnboardingButtonCta
                             data-test="@backup/start-button"
                             onClick={() => {
-                                updateAnalytics({ backup: 'create' });
-                                backupDevice();
+                                dispatch(updateAnalytics({ backup: 'create' }));
+                                dispatch(backupDevice());
                             }}
                             isDisabled={!canContinue(backup.userConfirmed, locks)}
                         >
@@ -70,7 +64,7 @@ export const BackupStep = () => {
                         <OnboardingButtonSkip
                             data-test="@onboarding/exit-app-button"
                             onClick={() => {
-                                updateAnalytics({ backup: 'skip' });
+                                dispatch(updateAnalytics({ backup: 'skip' }));
                                 setShowSkipConfirmation(true);
                             }}
                         >
@@ -103,7 +97,7 @@ export const BackupStep = () => {
                     innerActions={
                         <OnboardingButtonCta
                             data-test="@backup/close-button"
-                            onClick={() => goToNextStep()}
+                            onClick={() => dispatch(goToNextStep())}
                             isDisabled={!canContinue(backup.userConfirmed)}
                         >
                             <Translation id="TR_BACKUP_FINISHED_BUTTON" />
@@ -122,7 +116,9 @@ export const BackupStep = () => {
                     innerActions={
                         <OnboardingButtonCta
                             onClick={() => {
-                                goto('settings-device', { anchor: SettingsAnchor.WipeDevice });
+                                dispatch(
+                                    goto('settings-device', { anchor: SettingsAnchor.WipeDevice }),
+                                );
                             }}
                         >
                             <Translation id="TR_GO_TO_SETTINGS" />

--- a/packages/suite/src/views/onboarding/steps/BasicSettings/BasicSettingsStepBox.tsx
+++ b/packages/suite/src/views/onboarding/steps/BasicSettings/BasicSettingsStepBox.tsx
@@ -10,7 +10,7 @@ const Separator = styled.hr`
     width: 100%;
     background: none;
     border: 0;
-    border-top: 1px solid ${props => props.theme.STROKE_GREY};
+    border-top: 1px solid ${({ theme }) => theme.STROKE_GREY};
     margin-bottom: 30px;
 `;
 

--- a/packages/suite/src/views/onboarding/steps/BasicSettings/TorSection.tsx
+++ b/packages/suite/src/views/onboarding/steps/BasicSettings/TorSection.tsx
@@ -2,8 +2,8 @@ import React from 'react';
 import styled from 'styled-components';
 import { variables, Switch } from '@trezor/components';
 import { Translation } from 'src/components/suite';
-import { useActions } from 'src/hooks/suite';
-import { toggleTor as toggleTorAction } from 'src/actions/suite/suiteActions';
+import { useDispatch } from 'src/hooks/suite';
+import { toggleTor } from 'src/actions/suite/suiteActions';
 import { getIsTorEnabled, getIsTorLoading } from 'src/utils/suite/tor';
 import { TorStatus } from 'src/types/suite';
 
@@ -33,12 +33,13 @@ interface TorSectionProps {
 }
 
 export const TorSection = ({ torStatus }: TorSectionProps) => {
-    const { toggleTor } = useActions({
-        toggleTor: toggleTorAction,
-    });
+    const dispatch = useDispatch();
 
     const isTorEnabled = getIsTorEnabled(torStatus);
     const isTorLoading = getIsTorLoading(torStatus);
+    const isChecked = isTorEnabled || torStatus === TorStatus.Enabling;
+
+    const handleChange = () => dispatch(toggleTor(!isTorEnabled));
 
     return (
         <TorWrapper>
@@ -48,11 +49,9 @@ export const TorSection = ({ torStatus }: TorSectionProps) => {
             <SwitchWrapper>
                 <Switch
                     dataTest="@onboarding/tor-switch"
-                    isChecked={isTorEnabled || torStatus === TorStatus.Enabling}
+                    isChecked={isChecked}
                     isDisabled={isTorLoading}
-                    onChange={() => {
-                        toggleTor(!isTorEnabled);
-                    }}
+                    onChange={handleChange}
                 />
             </SwitchWrapper>
         </TorWrapper>

--- a/packages/suite/src/views/onboarding/steps/BasicSettings/index.tsx
+++ b/packages/suite/src/views/onboarding/steps/BasicSettings/index.tsx
@@ -7,12 +7,13 @@ import { AdvancedSetup } from './AdvancedSetup';
 import { getIsTorLoading } from 'src/utils/suite/tor';
 
 const BasicSettings = () => {
-    const { noNetworkEnabled, isTorLoading } = useSelector(state => ({
-        noNetworkEnabled: !state.wallet.settings.enabledNetworks.length,
-        isTorLoading: getIsTorLoading(state.suite.torStatus),
-    }));
+    const enabledNetworks = useSelector(state => state.wallet.settings.enabledNetworks);
+    const torStatus = useSelector(state => state.suite.torStatus);
 
     const { goToNextStep } = useOnboarding();
+
+    const noNetworkEnabled = !enabledNetworks.length;
+    const isTorLoading = getIsTorLoading(torStatus);
 
     return (
         <BasicSettingsStepBox

--- a/packages/suite/src/views/onboarding/steps/Final.tsx
+++ b/packages/suite/src/views/onboarding/steps/Final.tsx
@@ -6,8 +6,8 @@ import { analytics, EventType } from '@trezor/suite-analytics';
 import { Button, Icon, variables, Input, Dropdown, DropdownRef, Tooltip } from '@trezor/components';
 import { Translation, HomescreenGallery } from 'src/components/suite';
 import { DeviceAnimation, OnboardingStepBox } from 'src/components/onboarding';
-import { useActions, useDevice, useOnboarding, useSelector } from 'src/hooks/suite';
-import * as deviceSettingsActions from 'src/actions/settings/deviceSettingsActions';
+import { useDevice, useDispatch, useOnboarding, useSelector } from 'src/hooks/suite';
+import { applySettings } from 'src/actions/settings/deviceSettingsActions';
 import { DEFAULT_LABEL, MAX_LABEL_LENGTH } from 'src/constants/suite/device';
 import { isHomescreenSupportedOnDevice } from 'src/utils/suite/homescreen';
 import { selectIsActionAbortable } from 'src/reducers/suite/suiteReducer';
@@ -84,7 +84,7 @@ const SetupActions = styled.div`
     display: flex;
     margin-bottom: 32px;
     padding-bottom: 32px;
-    border-bottom: 1px solid ${props => props.theme.STROKE_GREY};
+    border-bottom: 1px solid ${({ theme }) => theme.STROKE_GREY};
     width: fit-content;
     gap: 16px;
 `;
@@ -134,26 +134,24 @@ export const FinalStep = () => {
     const { goToSuite } = useOnboarding();
 
     const dropdownRef = useRef<DropdownRef>();
-    const { applySettings } = useActions({
-        applySettings: deviceSettingsActions.applySettings,
-    });
 
     const { isLocked, device } = useDevice();
     const isDeviceLocked = isLocked();
-    const { modal, onboardingAnalytics } = useSelector(state => ({
-        modal: state.modal,
-        onboardingAnalytics: state.onboarding.onboardingAnalytics,
-    }));
-    const deviceModelInternal = device?.features?.internal_model;
+
+    const modalContext = useSelector(state => state.modal.context);
+    const onboardingAnalytics = useSelector(state => state.onboarding.onboardingAnalytics);
     const isActionAbortable = useSelector(selectIsActionAbortable);
+    const dispatch = useDispatch();
+
+    const deviceModelInternal = device?.features?.internal_model;
 
     const [state, setState] = useState<'rename' | 'homescreen' | null>(null);
     const [label, setLabel] = useState('');
 
-    const isWaitingForConfirm = modal.context === '@modal/context-device';
+    const isWaitingForConfirm = modalContext === '@modal/context-device';
 
     const onRename = async () => {
-        await applySettings({ label });
+        await dispatch(applySettings({ label }));
         setState(null);
     };
 

--- a/packages/suite/src/views/onboarding/steps/Firmware.tsx
+++ b/packages/suite/src/views/onboarding/steps/Firmware.tsx
@@ -15,9 +15,7 @@ import { DeviceTutorial } from 'src/components/firmware/DeviceTutorial';
 import { selectOnboardingTutorialStatus } from 'src/reducers/onboarding/onboardingReducer';
 
 const FirmwareStep = () => {
-    const { device } = useSelector(state => ({
-        device: state.suite.device,
-    }));
+    const device = useSelector(state => state.suite.device);
     const isTutorialOffered = useSelector(selectOnboardingTutorialStatus);
     const { goToNextStep, updateAnalytics } = useOnboarding();
     const {

--- a/packages/suite/src/views/onboarding/steps/Recovery/RecoveryStepBox.tsx
+++ b/packages/suite/src/views/onboarding/steps/Recovery/RecoveryStepBox.tsx
@@ -1,22 +1,19 @@
 import React from 'react';
+
+import { DeviceModelInternal } from '@trezor/connect';
 import {
     OnboardingButtonBack,
     OnboardingStepBox,
     OnboardingStepBoxProps,
 } from 'src/components/onboarding';
 import { Translation } from 'src/components/suite';
-import * as onboardingActions from 'src/actions/onboarding/onboardingActions';
-import * as recoveryActions from 'src/actions/recovery/recoveryActions';
-import { useActions, useDevice, useSelector } from 'src/hooks/suite';
-import { DeviceModelInternal } from '@trezor/connect';
+import { goToPreviousStep } from 'src/actions/onboarding/onboardingActions';
+import { setStatus } from 'src/actions/recovery/recoveryActions';
+import { useDevice, useDispatch, useSelector } from 'src/hooks/suite';
 
 const RecoveryStepBox = (props: OnboardingStepBoxProps) => {
-    const { goToPreviousStep, setStatus } = useActions({
-        goToPreviousStep: onboardingActions.goToPreviousStep,
-        setStatus: recoveryActions.setStatus,
-    });
-
     const recovery = useSelector(state => state.recovery);
+    const dispatch = useDispatch();
 
     const { device } = useDevice();
 
@@ -28,7 +25,7 @@ const RecoveryStepBox = (props: OnboardingStepBoxProps) => {
 
     const handleBack = () => {
         if (recovery.status === 'select-recovery-type') {
-            return setStatus('initial');
+            return dispatch(setStatus('initial'));
         }
         // allow to change recovery settings for T1 in case of error
         if (
@@ -36,9 +33,9 @@ const RecoveryStepBox = (props: OnboardingStepBoxProps) => {
             recovery.error &&
             deviceModelInternal === DeviceModelInternal.T1B1
         ) {
-            return setStatus('initial');
+            return dispatch(setStatus('initial'));
         }
-        return goToPreviousStep();
+        return dispatch(goToPreviousStep());
     };
 
     const isBackButtonVisible = () => {

--- a/packages/suite/src/views/onboarding/steps/ResetDevice.tsx
+++ b/packages/suite/src/views/onboarding/steps/ResetDevice.tsx
@@ -9,20 +9,20 @@ import {
     OnboardingStepBox,
 } from 'src/components/onboarding';
 import { Translation } from 'src/components/suite';
-import { useActions, useSelector, useOnboarding } from 'src/hooks/suite';
-import * as deviceSettingsActions from 'src/actions/settings/deviceSettingsActions';
+import { useDispatch, useSelector, useOnboarding } from 'src/hooks/suite';
+import { resetDevice } from 'src/actions/settings/deviceSettingsActions';
 import { selectIsActionAbortable } from 'src/reducers/suite/suiteReducer';
 
 export const ResetDeviceStep = () => {
     const [submitted, setSubmitted] = useState(false);
-    const { resetDevice } = useActions({
-        resetDevice: deviceSettingsActions.resetDevice,
-    });
+
     const { goToPreviousStep, goToNextStep, updateAnalytics } = useOnboarding();
 
     const device = useSelector(state => state.suite.device);
-    const deviceModelInternal = device?.features?.internal_model;
     const isActionAbortable = useSelector(selectIsActionAbortable);
+    const dispatch = useDispatch();
+
+    const deviceModelInternal = device?.features?.internal_model;
 
     // this step expects device
     if (!device || !device.features) {
@@ -38,7 +38,7 @@ export const ResetDeviceStep = () => {
     const onResetDevice = async (params?: { backup_type?: 0 | 1 | undefined }) => {
         setSubmitted(false);
 
-        const result = await resetDevice(params);
+        const result = await dispatch(resetDevice(params));
 
         setSubmitted(true);
 

--- a/packages/suite/src/views/onboarding/steps/Welcome/components/PreOnboardingSetup/SecurityCheck.tsx
+++ b/packages/suite/src/views/onboarding/steps/Welcome/components/PreOnboardingSetup/SecurityCheck.tsx
@@ -28,7 +28,7 @@ const Underline = styled.span`
 `;
 
 const HowLong = styled.div`
-    color: ${props => props.theme.TYPE_LIGHT_GREY};
+    color: ${({ theme }) => theme.TYPE_LIGHT_GREY};
     font-size: ${variables.FONT_SIZE.TINY};
     font-weight: ${variables.FONT_WEIGHT.MEDIUM};
     display: flex;
@@ -47,11 +47,11 @@ const Buttons = styled.div`
     justify-content: center;
     margin-top: 24px;
     padding-top: 24px;
-    border-top: 1px solid ${props => props.theme.STROKE_GREY};
+    border-top: 1px solid ${({ theme }) => theme.STROKE_GREY};
 `;
 
 const Text = styled.div`
-    color: ${props => props.theme.TYPE_LIGHT_GREY};
+    color: ${({ theme }) => theme.TYPE_LIGHT_GREY};
     font-size: ${variables.FONT_SIZE.SMALL};
     font-weight: ${variables.FONT_WEIGHT.MEDIUM};
     margin-left: 24px;

--- a/packages/suite/src/views/onboarding/steps/Welcome/components/PreOnboardingSetup/index.tsx
+++ b/packages/suite/src/views/onboarding/steps/Welcome/components/PreOnboardingSetup/index.tsx
@@ -13,13 +13,10 @@ const StyledTrezorLink = styled(TrezorLink)`
 `;
 
 const PreOnboardingSetup = () => {
-    const { activeSubStep } = useOnboarding();
-    const { confirmed } = useSelector(state => ({
-        confirmed: state.analytics.confirmed,
-    }));
-
-    const { goToSubStep, rerun } = useOnboarding();
+    const confirmed = useSelector(state => state.analytics.confirmed);
     const recovery = useSelector(state => state.recovery);
+
+    const { activeSubStep, goToSubStep, rerun } = useOnboarding();
 
     const onConfirm = (trackingEnabled: boolean) => {
         if (trackingEnabled) {

--- a/packages/suite/src/views/onboarding/steps/Welcome/components/PreOnboardingSetup/index.tsx
+++ b/packages/suite/src/views/onboarding/steps/Welcome/components/PreOnboardingSetup/index.tsx
@@ -9,7 +9,7 @@ import TrezorLink from 'src/components/suite/TrezorLink';
 import styled from 'styled-components';
 
 const StyledTrezorLink = styled(TrezorLink)`
-    color: ${props => props.theme.TYPE_LIGHT_GREY};
+    color: ${({ theme }) => theme.TYPE_LIGHT_GREY};
 `;
 
 const PreOnboardingSetup = () => {

--- a/packages/suite/src/views/recovery/index.tsx
+++ b/packages/suite/src/views/recovery/index.tsx
@@ -4,8 +4,13 @@ import { Button, H2, P, Image, variables } from '@trezor/components';
 import { SelectWordCount, SelectRecoveryType } from 'src/components/recovery';
 import { Loading, Translation, CheckItem, TrezorLink, Modal } from 'src/components/suite';
 import { ReduxModal } from 'src/components/suite/ModalSwitcher/ReduxModal';
-import * as recoveryActions from 'src/actions/recovery/recoveryActions';
-import { useDevice, useSelector, useActions } from 'src/hooks/suite';
+import {
+    checkSeed,
+    setAdvancedRecovery,
+    setStatus,
+    setWordsCount,
+} from 'src/actions/recovery/recoveryActions';
+import { useDevice, useDispatch, useSelector } from 'src/hooks/suite';
 import type { ForegroundAppProps } from 'src/types/suite';
 import type { WordCount } from 'src/types/recovery';
 import { InstructionStep } from 'src/components/suite/InstructionStep';
@@ -59,29 +64,22 @@ const VerticalCenter = styled.div`
 `;
 
 export const Recovery = ({ onCancel }: ForegroundAppProps) => {
-    const { recovery, modal } = useSelector(state => ({
-        recovery: state.recovery,
-        modal: state.modal,
-    }));
-    const actions = useActions({
-        checkSeed: recoveryActions.checkSeed,
-        setStatus: recoveryActions.setStatus,
-        setWordsCount: recoveryActions.setWordsCount,
-        setAdvancedRecovery: recoveryActions.setAdvancedRecovery,
-    });
+    const recovery = useSelector(state => state.recovery);
+    const modal = useSelector(state => state.modal);
+    const dispatch = useDispatch();
     const { device, isLocked } = useDevice();
     const [understood, setUnderstood] = useState(false);
 
     const intl = useIntl();
 
     const onSetWordsCount = (count: WordCount) => {
-        actions.setWordsCount(count);
-        actions.setStatus('select-recovery-type');
+        dispatch(setWordsCount(count));
+        dispatch(setStatus('select-recovery-type'));
     };
 
     const onSetRecoveryType = (type: 'standard' | 'advanced') => {
-        actions.setAdvancedRecovery(type === 'advanced');
-        actions.checkSeed();
+        dispatch(setAdvancedRecovery(type === 'advanced'));
+        dispatch(checkSeed());
     };
 
     const deviceModelInternal = device?.features?.internal_model;
@@ -117,8 +115,8 @@ export const Recovery = ({ onCancel }: ForegroundAppProps) => {
                 <StyledButton
                     onClick={() =>
                         deviceModelInternal === DeviceModelInternal.T1B1
-                            ? actions.setStatus('select-word-count')
-                            : actions.checkSeed()
+                            ? dispatch(setStatus('select-word-count'))
+                            : dispatch(checkSeed())
                     }
                     isDisabled={!understood || isLocked()}
                     data-test="@recovery/start-button"

--- a/packages/suite/src/views/settings/coins/FirmwareTypeSuggestion.tsx
+++ b/packages/suite/src/views/settings/coins/FirmwareTypeSuggestion.tsx
@@ -1,18 +1,18 @@
 import React from 'react';
 import styled from 'styled-components';
 
-import * as suiteActions from 'src/actions/suite/suiteActions';
-import * as routerActions from 'src/actions/suite/routerActions';
+import { setFlag } from 'src/actions/suite/suiteActions';
+import { goto } from 'src/actions/suite/routerActions';
 import { Translation } from 'src/components/suite';
 import { TextColumn } from 'src/components/suite/Settings';
 import { SettingsAnchor } from 'src/constants/suite/anchors';
-import { useActions, useDevice } from 'src/hooks/suite';
+import { useDevice, useDispatch } from 'src/hooks/suite';
 import { Button, Card } from '@trezor/components';
 
 const StyledCard = styled(Card)`
     align-items: flex-start;
-    border-left: 10px solid ${props => props.theme.TYPE_GREEN};
-    box-shadow: 0 2px 5px 0 ${props => props.theme.BOX_SHADOW_BLACK_20};
+    border-left: 10px solid ${({ theme }) => theme.TYPE_GREEN};
+    box-shadow: 0 2px 5px 0 ${({ theme }) => theme.BOX_SHADOW_BLACK_20};
     flex-direction: row;
     justify-content: space-between;
 `;
@@ -22,10 +22,7 @@ const StyledButton = styled(Button)`
 `;
 
 export const FirmwareTypeSuggestion = () => {
-    const { goto, setFlag } = useActions({
-        goto: routerActions.goto,
-        setFlag: suiteActions.setFlag,
-    });
+    const dispatch = useDispatch();
     const { device } = useDevice();
 
     const bitcoinOnlyFirmware = device?.firmwareType === 'bitcoin-only';
@@ -33,11 +30,9 @@ export const FirmwareTypeSuggestion = () => {
         ? 'TR_SETTINGS_COINS_UNIVERSAL_FIRMWARE_SUGGESTION'
         : 'TR_SETTINGS_COINS_BITCOIN_FIRMWARE_SUGGESTION';
 
-    const handleClose = () => setFlag('firmwareTypeBannerClosed', true);
+    const handleClose = () => dispatch(setFlag('firmwareTypeBannerClosed', true));
     const goToFirmwareType = () =>
-        goto('settings-device', {
-            anchor: SettingsAnchor.FirmwareType,
-        });
+        dispatch(goto('settings-device', { anchor: SettingsAnchor.FirmwareType }));
 
     return (
         <StyledCard>

--- a/packages/suite/src/views/settings/debug/CheckFirmwareAuthenticity.tsx
+++ b/packages/suite/src/views/settings/debug/CheckFirmwareAuthenticity.tsx
@@ -2,25 +2,19 @@ import React, { useState } from 'react';
 
 import { Button, Switch } from '@trezor/components';
 import { ActionColumn, SectionItem, TextColumn } from 'src/components/suite/Settings';
-import { useFirmware, useActions, useSelector } from 'src/hooks/suite';
-import * as suiteActions from 'src/actions/suite/suiteActions';
+import { useDispatch, useFirmware, useSelector } from 'src/hooks/suite';
+import { setDebugMode } from 'src/actions/suite/suiteActions';
 
 export const CheckFirmwareAuthenticity = () => {
     const [inProgress, setInProgress] = useState(false);
 
     const { checkFirmwareAuthenticity } = useFirmware();
-    const { setDebugMode } = useActions({
-        setDebugMode: suiteActions.setDebugMode,
-    });
-    const { debug } = useSelector(state => ({
-        debug: state.suite.settings.debug,
-    }));
 
-    const onChangeRegularCheck = (state?: boolean) => {
-        setDebugMode({
-            checkFirmwareAuthenticity: state,
-        });
-    };
+    const debug = useSelector(state => state.suite.settings.debug);
+    const dispatch = useDispatch();
+
+    const onChangeRegularCheck = (state?: boolean) =>
+        dispatch(setDebugMode({ checkFirmwareAuthenticity: state }));
 
     const onCheckFirmwareAuthenticity = async () => {
         setInProgress(true);

--- a/packages/suite/src/views/settings/debug/CoinjoinApi.tsx
+++ b/packages/suite/src/views/settings/debug/CoinjoinApi.tsx
@@ -4,8 +4,8 @@ import styled from 'styled-components';
 import { Switch, Button, Link } from '@trezor/components';
 import { COINJOIN_NETWORKS } from 'src/services/coinjoin';
 import { ActionColumn, ActionSelect, SectionItem, TextColumn } from 'src/components/suite/Settings';
-import * as coinjoinClientActions from 'src/actions/wallet/coinjoinClientActions';
-import { useSelector, useActions } from 'src/hooks/suite';
+import { setDebugSettings } from 'src/actions/wallet/coinjoinClientActions';
+import { useDispatch, useSelector } from 'src/hooks/suite';
 import { CoinjoinServerEnvironment, CoinjoinClientInstance } from 'src/types/wallet/coinjoin';
 import { NetworkSymbol, networks } from '@suite-common/wallet-config';
 import { reloadApp } from 'src/utils/suite/reload';
@@ -87,27 +87,24 @@ const CoordinatorServer = ({
 };
 
 export const CoinjoinApi = () => {
-    const { setDebugSettings } = useActions({
-        setDebugSettings: coinjoinClientActions.setDebugSettings,
-    });
     const debug = useSelector(state => state.wallet.coinjoin.debug);
     const clients = useSelector(state => state.wallet.coinjoin.clients);
+    const dispatch = useDispatch();
 
     const handleServerChange: CoordinatorServerProps['onChange'] = (network, value) => {
-        setDebugSettings({
-            coinjoinServerEnvironment: {
-                [network]: value,
-            },
-        });
+        dispatch(
+            setDebugSettings({
+                coinjoinServerEnvironment: {
+                    [network]: value,
+                },
+            }),
+        );
         // reload the Suite to reinitialize everything, with a slight delay to let the browser save the settings
         reloadApp(100);
     };
 
-    const handleTorChange = () => {
-        setDebugSettings({
-            coinjoinAllowNoTor: !debug?.coinjoinAllowNoTor,
-        });
-    };
+    const handleTorChange = () =>
+        dispatch(setDebugSettings({ coinjoinAllowNoTor: !debug?.coinjoinAllowNoTor }));
 
     return (
         <>

--- a/packages/suite/src/views/settings/debug/OAuthApi.tsx
+++ b/packages/suite/src/views/settings/debug/OAuthApi.tsx
@@ -3,8 +3,8 @@ import styled from 'styled-components';
 
 import GoogleClient from 'src/services/google';
 import { ActionColumn, ActionSelect, SectionItem, TextColumn } from 'src/components/suite/Settings';
-import * as suiteActions from 'src/actions/suite/suiteActions';
-import { useSelector, useActions } from 'src/hooks/suite';
+import { setDebugMode } from 'src/actions/suite/suiteActions';
+import { useDispatch, useSelector } from 'src/hooks/suite';
 import type { OAuthServerEnvironment } from 'src/types/suite/metadata';
 import { useAnchor } from 'src/hooks/suite/useAnchor';
 import { SettingsAnchor } from 'src/constants/suite/anchors';
@@ -14,12 +14,8 @@ const StyledActionSelect = styled(ActionSelect)`
 `;
 
 export const OAuthApi = () => {
-    const { setDebugMode } = useActions({
-        setDebugMode: suiteActions.setDebugMode,
-    });
-    const { debug } = useSelector(state => ({
-        debug: state.suite.settings.debug,
-    }));
+    const debug = useSelector(state => state.suite.settings.debug);
+    const dispatch = useDispatch();
     const { anchorRef, shouldHighlight } = useAnchor(SettingsAnchor.OAuthApi);
 
     const options = Object.entries(GoogleClient.servers).map(([environment, server]) => ({
@@ -30,9 +26,7 @@ export const OAuthApi = () => {
         options.find(option => option.value === debug.oauthServerEnvironment) || options[0];
 
     const handleChange = (item: { value: OAuthServerEnvironment }) => {
-        setDebugMode({
-            oauthServerEnvironment: item.value,
-        });
+        dispatch(setDebugMode({ oauthServerEnvironment: item.value }));
         GoogleClient.setEnvironment(item.value);
     };
 

--- a/packages/suite/src/views/settings/debug/Transport.tsx
+++ b/packages/suite/src/views/settings/debug/Transport.tsx
@@ -2,8 +2,8 @@ import React, { useMemo } from 'react';
 
 import { Checkbox } from '@trezor/components';
 import { isDesktop } from '@trezor/env-utils';
-import { useSelector, useActions } from 'src/hooks/suite';
-import * as suiteActions from 'src/actions/suite/suiteActions';
+import { useDispatch, useSelector } from 'src/hooks/suite';
+import { setDebugMode } from 'src/actions/suite/suiteActions';
 import { DebugModeOptions } from 'src/reducers/suite/suiteReducer';
 import { ArrayElement } from '@trezor/type-utils';
 
@@ -17,10 +17,9 @@ type TransportMenuItem = {
 };
 
 export const Transport = () => {
-    const { debug, transport } = useSelector(state => ({
-        debug: state.suite.settings.debug,
-        transport: state.suite.transport,
-    }));
+    const debug = useSelector(state => state.suite.settings.debug);
+    const transport = useSelector(state => state.suite.transport);
+    const dispatch = useDispatch();
 
     // fallback [] to avoid need of migration.
     const debugTransports = useMemo(() => debug.transports || [], [debug.transports]);
@@ -39,10 +38,6 @@ export const Transport = () => {
             name: t,
         }));
     }, [transport]);
-
-    const { setDebugMode } = useActions({
-        setDebugMode: suiteActions.setDebugMode,
-    });
 
     return (
         <>
@@ -67,9 +62,7 @@ export const Transport = () => {
                                     ? debugTransports.filter(t => t !== transport.name)
                                     : [...debugTransports, transport.name];
 
-                                setDebugMode({
-                                    transports: nextTransports,
-                                });
+                                dispatch(setDebugMode({ transports: nextTransports }));
                             }}
                         />
                     </ActionColumn>

--- a/packages/suite/src/views/settings/debug/WipeData.tsx
+++ b/packages/suite/src/views/settings/debug/WipeData.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 import styled from 'styled-components';
 import { desktopApi } from '@trezor/suite-desktop-api';
 import { ActionButton, ActionColumn, SectionItem, TextColumn } from 'src/components/suite/Settings';
-import { useSelector, useActions } from 'src/hooks/suite';
+import { useDispatch, useSelector } from 'src/hooks/suite';
 import { useAnchor } from 'src/hooks/suite/useAnchor';
 import { notificationsActions } from '@suite-common/toast-notifications';
 import { SettingsAnchor } from 'src/constants/suite/anchors';
@@ -16,10 +16,8 @@ const UserDataLink = styled.span`
 
 export const WipeData = () => {
     const userDataDir = useSelector(state => state.desktop?.paths.userDir);
+    const dispatch = useDispatch();
     const { anchorRef, shouldHighlight } = useAnchor(SettingsAnchor.WipeData);
-    const { addToast } = useActions({
-        addToast: notificationsActions.addToast,
-    });
 
     return (
         <SectionItem
@@ -38,10 +36,12 @@ export const WipeData = () => {
                                 const result = await desktopApi.openUserDataDirectory();
 
                                 if (!result.success) {
-                                    addToast({
-                                        type: 'error',
-                                        error: result.error,
-                                    });
+                                    dispatch(
+                                        notificationsActions.addToast({
+                                            type: 'error',
+                                            error: result.error,
+                                        }),
+                                    );
                                 }
                             }}
                         >

--- a/packages/suite/src/views/settings/device/BackupRecoverySeed.tsx
+++ b/packages/suite/src/views/settings/device/BackupRecoverySeed.tsx
@@ -3,8 +3,8 @@ import { HELP_CENTER_RECOVERY_SEED_URL } from '@trezor/urls';
 
 import { Translation } from 'src/components/suite';
 import { ActionButton, ActionColumn, SectionItem, TextColumn } from 'src/components/suite/Settings';
-import { useDevice, useActions } from 'src/hooks/suite';
-import * as routerActions from 'src/actions/suite/routerActions';
+import { useDevice, useDispatch } from 'src/hooks/suite';
+import { goto } from 'src/actions/suite/routerActions';
 import { useAnchor } from 'src/hooks/suite/useAnchor';
 import { SettingsAnchor } from 'src/constants/suite/anchors';
 
@@ -13,13 +13,14 @@ interface BackupRecoverySeedProps {
 }
 
 export const BackupRecoverySeed = ({ isDeviceLocked }: BackupRecoverySeedProps) => {
+    const dispatch = useDispatch();
     const { device } = useDevice();
-    const { goto } = useActions({
-        goto: routerActions.goto,
-    });
     const { anchorRef, shouldHighlight } = useAnchor(SettingsAnchor.BackupRecoverySeed);
 
     const needsBackup = !!device?.features?.needs_backup;
+
+    const handleClick = () => dispatch(goto('backup-index', { params: { cancelable: true } }));
+
     return (
         <SectionItem
             data-test="@settings/device/backup-recovery-seed"
@@ -34,7 +35,7 @@ export const BackupRecoverySeed = ({ isDeviceLocked }: BackupRecoverySeedProps) 
             <ActionColumn>
                 <ActionButton
                     data-test="@settings/device/create-backup-button"
-                    onClick={() => goto('backup-index', { params: { cancelable: true } })}
+                    onClick={handleClick}
                     isDisabled={isDeviceLocked || !needsBackup}
                 >
                     {needsBackup ? (

--- a/packages/suite/src/views/settings/device/ChangePin.tsx
+++ b/packages/suite/src/views/settings/device/ChangePin.tsx
@@ -3,8 +3,8 @@ import { analytics, EventType } from '@trezor/suite-analytics';
 
 import { Translation } from 'src/components/suite';
 import { ActionButton, ActionColumn, SectionItem, TextColumn } from 'src/components/suite/Settings';
-import { useActions } from 'src/hooks/suite';
-import * as deviceSettingsActions from 'src/actions/settings/deviceSettingsActions';
+import { useDispatch } from 'src/hooks/suite';
+import { changePin } from 'src/actions/settings/deviceSettingsActions';
 import { useAnchor } from 'src/hooks/suite/useAnchor';
 import { SettingsAnchor } from 'src/constants/suite/anchors';
 
@@ -13,11 +13,15 @@ interface ChangePinProps {
 }
 
 export const ChangePin = ({ isDeviceLocked }: ChangePinProps) => {
+    const dispatch = useDispatch();
     const { anchorRef, shouldHighlight } = useAnchor(SettingsAnchor.ChangePin);
 
-    const { changePin } = useActions({
-        changePin: deviceSettingsActions.changePin,
-    });
+    const handleClick = () => {
+        dispatch(changePin({ remove: false }));
+        analytics.report({
+            type: EventType.SettingsDeviceChangePin,
+        });
+    };
 
     return (
         <SectionItem
@@ -30,16 +34,7 @@ export const ChangePin = ({ isDeviceLocked }: ChangePinProps) => {
                 description={<Translation id="TR_DEVICE_SETTINGS_CHANGE_PIN_DESC" />}
             />
             <ActionColumn>
-                <ActionButton
-                    onClick={() => {
-                        changePin({ remove: false });
-                        analytics.report({
-                            type: EventType.SettingsDeviceChangePin,
-                        });
-                    }}
-                    isDisabled={isDeviceLocked}
-                    variant="secondary"
-                >
+                <ActionButton onClick={handleClick} isDisabled={isDeviceLocked} variant="secondary">
                     <Translation id="TR_CHANGE_PIN" />
                 </ActionButton>
             </ActionColumn>

--- a/packages/suite/src/views/settings/device/CheckRecoverySeed.tsx
+++ b/packages/suite/src/views/settings/device/CheckRecoverySeed.tsx
@@ -2,8 +2,8 @@ import React from 'react';
 
 import { Translation } from 'src/components/suite';
 import { ActionButton, ActionColumn, SectionItem, TextColumn } from 'src/components/suite/Settings';
-import { useDevice, useActions } from 'src/hooks/suite';
-import * as routerActions from 'src/actions/suite/routerActions';
+import { useDevice, useDispatch } from 'src/hooks/suite';
+import { goto } from 'src/actions/suite/routerActions';
 import { useAnchor } from 'src/hooks/suite/useAnchor';
 import { SettingsAnchor } from 'src/constants/suite/anchors';
 import { getCheckBackupUrl } from 'src/utils/suite/device';
@@ -13,14 +13,14 @@ interface CheckRecoverySeedProps {
 }
 
 export const CheckRecoverySeed = ({ isDeviceLocked }: CheckRecoverySeedProps) => {
+    const dispatch = useDispatch();
     const { device } = useDevice();
-    const { goto } = useActions({
-        goto: routerActions.goto,
-    });
     const { anchorRef, shouldHighlight } = useAnchor(SettingsAnchor.CheckRecoverySeed);
 
     const needsBackup = !!device?.features?.needs_backup;
     const learnMoreUrl = getCheckBackupUrl(device);
+
+    const handleClick = () => dispatch(goto('recovery-index', { params: { cancelable: true } }));
 
     return (
         <SectionItem
@@ -36,7 +36,7 @@ export const CheckRecoverySeed = ({ isDeviceLocked }: CheckRecoverySeedProps) =>
             <ActionColumn>
                 <ActionButton
                     data-test="@settings/device/check-seed-button"
-                    onClick={() => goto('recovery-index', { params: { cancelable: true } })}
+                    onClick={handleClick}
                     isDisabled={isDeviceLocked || needsBackup}
                     variant="secondary"
                 >

--- a/packages/suite/src/views/settings/device/CustomFirmware.tsx
+++ b/packages/suite/src/views/settings/device/CustomFirmware.tsx
@@ -2,23 +2,21 @@ import React from 'react';
 
 import { Translation } from 'src/components/suite';
 import { ActionButton, ActionColumn, SectionItem, TextColumn } from 'src/components/suite/Settings';
-import { useActions, useDevice } from 'src/hooks/suite';
-import * as routerActions from 'src/actions/suite/routerActions';
+import { useDevice, useDispatch } from 'src/hooks/suite';
+import { goto } from 'src/actions/suite/routerActions';
 import { useAnchor } from 'src/hooks/suite/useAnchor';
 import { SettingsAnchor } from 'src/constants/suite/anchors';
 import { getFirmwareDowngradeUrl } from 'src/utils/suite/device';
 
 export const CustomFirmware = () => {
-    const { goto } = useActions({
-        goto: routerActions.goto,
-    });
+    const dispatch = useDispatch();
     const { anchorRef, shouldHighlight } = useAnchor(SettingsAnchor.CustomFirmware);
     const { device, isLocked } = useDevice();
 
     const isDeviceLocked = isLocked();
     const firmwareDowngradeUrl = getFirmwareDowngradeUrl(device);
 
-    const openModal = () => goto('firmware-custom', { params: { cancelable: true } });
+    const openModal = () => dispatch(goto('firmware-custom', { params: { cancelable: true } }));
 
     return (
         <SectionItem

--- a/packages/suite/src/views/settings/device/DeviceLabel.tsx
+++ b/packages/suite/src/views/settings/device/DeviceLabel.tsx
@@ -9,8 +9,8 @@ import {
     SectionItem,
     TextColumn,
 } from 'src/components/suite/Settings';
-import { useDevice, useActions } from 'src/hooks/suite';
-import * as deviceSettingsActions from 'src/actions/settings/deviceSettingsActions';
+import { useDevice, useDispatch } from 'src/hooks/suite';
+import { applySettings } from 'src/actions/settings/deviceSettingsActions';
 import { MAX_LABEL_LENGTH } from 'src/constants/suite/device';
 import { useAnchor } from 'src/hooks/suite/useAnchor';
 import { SettingsAnchor } from 'src/constants/suite/anchors';
@@ -20,13 +20,18 @@ interface DeviceLabelProps {
 }
 
 export const DeviceLabel = ({ isDeviceLocked }: DeviceLabelProps) => {
+    const [label, setLabel] = useState('');
+    const dispatch = useDispatch();
     const { device } = useDevice();
-    const { applySettings } = useActions({
-        applySettings: deviceSettingsActions.applySettings,
-    });
     const { anchorRef, shouldHighlight } = useAnchor(SettingsAnchor.DeviceLabel);
 
-    const [label, setLabel] = useState('');
+    const handleButtonClick = () => {
+        dispatch(applySettings({ label }));
+        analytics.report({
+            type: EventType.SettingsDeviceChangeLabel,
+        });
+    };
+
     useEffect(() => {
         if (device) {
             setLabel(device.label);
@@ -61,12 +66,7 @@ export const DeviceLabel = ({ isDeviceLocked }: DeviceLabelProps) => {
                     isDisabled={isDeviceLocked}
                 />
                 <ActionButton
-                    onClick={() => {
-                        applySettings({ label });
-                        analytics.report({
-                            type: EventType.SettingsDeviceChangeLabel,
-                        });
-                    }}
+                    onClick={handleButtonClick}
                     isDisabled={
                         isDeviceLocked || label.length > MAX_LABEL_LENGTH || label === device?.label
                     }

--- a/packages/suite/src/views/settings/device/DisplayRotation.tsx
+++ b/packages/suite/src/views/settings/device/DisplayRotation.tsx
@@ -5,8 +5,8 @@ import { analytics, EventType } from '@trezor/suite-analytics';
 import { Translation } from 'src/components/suite';
 import { ActionButton, ActionColumn, SectionItem, TextColumn } from 'src/components/suite/Settings';
 import { variables } from '@trezor/components';
-import { useActions } from 'src/hooks/suite';
-import * as deviceSettingsActions from 'src/actions/settings/deviceSettingsActions';
+import { useDispatch } from 'src/hooks/suite';
+import { applySettings } from 'src/actions/settings/deviceSettingsActions';
 import { useAnchor } from 'src/hooks/suite/useAnchor';
 import { SettingsAnchor } from 'src/constants/suite/anchors';
 
@@ -33,9 +33,7 @@ interface DisplayRotationProps {
 }
 
 export const DisplayRotation = ({ isDeviceLocked }: DisplayRotationProps) => {
-    const { applySettings } = useActions({
-        applySettings: deviceSettingsActions.applySettings,
-    });
+    const dispatch = useDispatch();
     const { anchorRef, shouldHighlight } = useAnchor(SettingsAnchor.DisplayRotation);
 
     return (
@@ -51,9 +49,7 @@ export const DisplayRotation = ({ isDeviceLocked }: DisplayRotationProps) => {
                         key={variant.value}
                         variant="secondary"
                         onClick={() => {
-                            applySettings({
-                                display_rotation: variant.value,
-                            });
+                            dispatch(applySettings({ display_rotation: variant.value }));
                             analytics.report({
                                 type: EventType.SettingsDeviceChangeOrientation,
                                 payload: {

--- a/packages/suite/src/views/settings/device/FirmwareTypeChange.tsx
+++ b/packages/suite/src/views/settings/device/FirmwareTypeChange.tsx
@@ -3,8 +3,8 @@ import styled from 'styled-components';
 
 import { Translation, TrezorLink } from 'src/components/suite';
 import { ActionButton, ActionColumn, SectionItem, TextColumn } from 'src/components/suite/Settings';
-import { useDevice, useActions } from 'src/hooks/suite';
-import * as routerActions from 'src/actions/suite/routerActions';
+import { useDevice, useDispatch } from 'src/hooks/suite';
+import { goto } from 'src/actions/suite/routerActions';
 import { Button } from '@trezor/components';
 import { useAnchor } from 'src/hooks/suite/useAnchor';
 import { SettingsAnchor } from 'src/constants/suite/anchors';
@@ -27,11 +27,8 @@ interface FirmwareTypeProps {
 }
 
 export const FirmwareTypeChange = ({ isDeviceLocked }: FirmwareTypeProps) => {
+    const dispatch = useDispatch();
     const { device } = useDevice();
-    const { goto } = useActions({
-        goto: routerActions.goto,
-    });
-
     const { anchorRef, shouldHighlight } = useAnchor(SettingsAnchor.FirmwareType);
 
     if (!device?.features) {
@@ -43,11 +40,7 @@ export const FirmwareTypeChange = ({ isDeviceLocked }: FirmwareTypeProps) => {
     const actionButtonId =
         device.firmwareType === 'bitcoin-only' ? 'TR_SWITCH_TO_UNIVERSAL' : 'TR_SWITCH_TO_BITCOIN';
 
-    const handleAction = () => {
-        goto('firmware-type', {
-            params: { cancelable: true },
-        });
-    };
+    const handleAction = () => dispatch(goto('firmware-type', { params: { cancelable: true } }));
 
     return (
         <SectionItem

--- a/packages/suite/src/views/settings/device/FirmwareVersion.tsx
+++ b/packages/suite/src/views/settings/device/FirmwareVersion.tsx
@@ -4,8 +4,8 @@ import { getFirmwareVersion } from '@trezor/device-utils';
 
 import { Translation, TrezorLink } from 'src/components/suite';
 import { ActionButton, ActionColumn, SectionItem, TextColumn } from 'src/components/suite/Settings';
-import { useDevice, useActions } from 'src/hooks/suite';
-import * as routerActions from 'src/actions/suite/routerActions';
+import { useDevice, useDispatch } from 'src/hooks/suite';
+import { goto } from 'src/actions/suite/routerActions';
 import { getChangelogUrl, getFwUpdateVersion } from 'src/utils/suite/device';
 import { Button, Tooltip } from '@trezor/components';
 import { AcquiredDevice } from 'src/types/suite';
@@ -56,10 +56,8 @@ interface FirmwareVersionProps {
 }
 
 export const FirmwareVersion = ({ isDeviceLocked }: FirmwareVersionProps) => {
+    const dispatch = useDispatch();
     const { device } = useDevice();
-    const { goto } = useActions({
-        goto: routerActions.goto,
-    });
     const { anchorRef, shouldHighlight } = useAnchor(SettingsAnchor.FirmwareVersion);
 
     if (!device?.features) {
@@ -72,7 +70,7 @@ export const FirmwareVersion = ({ isDeviceLocked }: FirmwareVersionProps) => {
     const changelogUrl = getChangelogUrl(device, revision);
     const githubButtonIcon = revision ? 'EXTERNAL_LINK' : undefined;
 
-    const handleUpdate = () => goto('firmware-index', { params: { cancelable: true } });
+    const handleUpdate = () => dispatch(goto('firmware-index', { params: { cancelable: true } }));
 
     const GithubButton = () => (
         <Button variant="tertiary" icon={githubButtonIcon} alignIcon="right" disabled={!revision}>

--- a/packages/suite/src/views/settings/device/Passphrase.tsx
+++ b/packages/suite/src/views/settings/device/Passphrase.tsx
@@ -5,8 +5,8 @@ import { analytics, EventType } from '@trezor/suite-analytics';
 import { Translation } from 'src/components/suite';
 import { ActionColumn, SectionItem, TextColumn } from 'src/components/suite/Settings';
 import { Switch } from '@trezor/components';
-import { useDevice, useActions } from 'src/hooks/suite';
-import * as deviceSettingsActions from 'src/actions/settings/deviceSettingsActions';
+import { useDevice, useDispatch } from 'src/hooks/suite';
+import { applySettings } from 'src/actions/settings/deviceSettingsActions';
 import { useAnchor } from 'src/hooks/suite/useAnchor';
 import { SettingsAnchor } from 'src/constants/suite/anchors';
 
@@ -15,13 +15,22 @@ interface PassphraseProps {
 }
 
 export const Passphrase = ({ isDeviceLocked }: PassphraseProps) => {
+    const dispatch = useDispatch();
     const { device } = useDevice();
-    const { applySettings } = useActions({
-        applySettings: deviceSettingsActions.applySettings,
-    });
     const { anchorRef, shouldHighlight } = useAnchor(SettingsAnchor.Passphrase);
 
     const passphraseProtection = !!device?.features?.passphrase_protection;
+
+    const handleChange = () => {
+        dispatch(applySettings({ use_passphrase: !passphraseProtection }));
+        analytics.report({
+            type: EventType.SettingsDeviceChangePassphraseProtection,
+            payload: {
+                use_passphrase: !passphraseProtection,
+            },
+        });
+    };
+
     return (
         <SectionItem
             data-test="@settings/device/passphrase"
@@ -36,17 +45,7 @@ export const Passphrase = ({ isDeviceLocked }: PassphraseProps) => {
             <ActionColumn>
                 <Switch
                     isChecked={passphraseProtection}
-                    onChange={() => {
-                        applySettings({
-                            use_passphrase: !passphraseProtection,
-                        });
-                        analytics.report({
-                            type: EventType.SettingsDeviceChangePassphraseProtection,
-                            payload: {
-                                use_passphrase: !passphraseProtection,
-                            },
-                        });
-                    }}
+                    onChange={handleChange}
                     dataTest="@settings/device/passphrase-switch"
                     isDisabled={isDeviceLocked}
                 />

--- a/packages/suite/src/views/settings/device/PinProtection.tsx
+++ b/packages/suite/src/views/settings/device/PinProtection.tsx
@@ -4,8 +4,8 @@ import { analytics, EventType } from '@trezor/suite-analytics';
 import { Translation } from 'src/components/suite';
 import { ActionColumn, SectionItem, TextColumn } from 'src/components/suite/Settings';
 import { Switch } from '@trezor/components';
-import { useDevice, useActions } from 'src/hooks/suite';
-import * as deviceSettingsActions from 'src/actions/settings/deviceSettingsActions';
+import { useDevice, useDispatch } from 'src/hooks/suite';
+import { changePin } from 'src/actions/settings/deviceSettingsActions';
 import { useAnchor } from 'src/hooks/suite/useAnchor';
 import { SettingsAnchor } from 'src/constants/suite/anchors';
 
@@ -14,13 +14,22 @@ interface PinProtectionProps {
 }
 
 export const PinProtection = ({ isDeviceLocked }: PinProtectionProps) => {
+    const dispatch = useDispatch();
     const { device } = useDevice();
-    const { changePin } = useActions({
-        changePin: deviceSettingsActions.changePin,
-    });
     const { anchorRef, shouldHighlight } = useAnchor(SettingsAnchor.PinProtection);
 
     const pinProtection = device?.features?.pin_protection ?? null;
+
+    const handleChange = () => {
+        dispatch(changePin({ remove: !!pinProtection }));
+        analytics.report({
+            type: EventType.SettingsDeviceChangePinProtection,
+            payload: {
+                remove: pinProtection,
+            },
+        });
+    };
+
     return (
         <SectionItem
             data-test="@settings/device/pin-protection"
@@ -34,15 +43,7 @@ export const PinProtection = ({ isDeviceLocked }: PinProtectionProps) => {
             <ActionColumn>
                 <Switch
                     isChecked={!!pinProtection}
-                    onChange={() => {
-                        changePin({ remove: !!pinProtection });
-                        analytics.report({
-                            type: EventType.SettingsDeviceChangePinProtection,
-                            payload: {
-                                remove: pinProtection,
-                            },
-                        });
-                    }}
+                    onChange={handleChange}
                     isDisabled={isDeviceLocked}
                     dataTest="@settings/device/pin-switch"
                 />

--- a/packages/suite/src/views/settings/device/SafetyChecks.tsx
+++ b/packages/suite/src/views/settings/device/SafetyChecks.tsx
@@ -1,8 +1,8 @@
 import React from 'react';
 import { Translation } from 'src/components/suite';
 import { ActionButton, ActionColumn, SectionItem, TextColumn } from 'src/components/suite/Settings';
-import { useActions } from 'src/hooks/suite';
-import * as modalActions from 'src/actions/suite/modalActions';
+import { useDispatch } from 'src/hooks/suite';
+import { openModal } from 'src/actions/suite/modalActions';
 import { useAnchor } from 'src/hooks/suite/useAnchor';
 import { SettingsAnchor } from 'src/constants/suite/anchors';
 
@@ -11,10 +11,11 @@ interface SafetyChecksProps {
 }
 
 export const SafetyChecks = ({ isDeviceLocked }: SafetyChecksProps) => {
-    const { openModal } = useActions({
-        openModal: modalActions.openModal,
-    });
+    const dispatch = useDispatch();
+
     const { anchorRef, shouldHighlight } = useAnchor(SettingsAnchor.SafetyChecks);
+
+    const handleClick = () => dispatch(openModal({ type: 'safety-checks' }));
 
     return (
         <SectionItem
@@ -29,9 +30,7 @@ export const SafetyChecks = ({ isDeviceLocked }: SafetyChecksProps) => {
             <ActionColumn>
                 <ActionButton
                     variant="secondary"
-                    onClick={() => {
-                        openModal({ type: 'safety-checks' });
-                    }}
+                    onClick={handleClick}
                     data-test="@settings/device/safety-checks-button"
                     isDisabled={isDeviceLocked}
                 >

--- a/packages/suite/src/views/settings/device/SettingsDevice.tsx
+++ b/packages/suite/src/views/settings/device/SettingsDevice.tsx
@@ -40,9 +40,8 @@ const deviceSettingsUnavailable = (device?: TrezorDevice, transport?: Partial<Tr
 
 export const SettingsDevice = () => {
     const { device, isLocked } = useDevice();
-    const { transport } = useSelector(state => ({
-        transport: state.suite.transport,
-    }));
+    const transport = useSelector(state => state.suite.transport);
+
     const deviceUnavailable = !device?.features;
     const isDeviceLocked = isLocked();
     const bootloaderMode = device?.mode === 'bootloader';

--- a/packages/suite/src/views/settings/device/WipeDevice.tsx
+++ b/packages/suite/src/views/settings/device/WipeDevice.tsx
@@ -2,8 +2,8 @@ import React from 'react';
 
 import { Translation } from 'src/components/suite';
 import { ActionButton, ActionColumn, SectionItem, TextColumn } from 'src/components/suite/Settings';
-import { useActions } from 'src/hooks/suite';
-import * as modalActions from 'src/actions/suite/modalActions';
+import { useDispatch } from 'src/hooks/suite';
+import { openModal } from 'src/actions/suite/modalActions';
 import { useAnchor } from 'src/hooks/suite/useAnchor';
 import { SettingsAnchor } from 'src/constants/suite/anchors';
 
@@ -12,10 +12,11 @@ interface WipeDeviceProps {
 }
 
 export const WipeDevice = ({ isDeviceLocked }: WipeDeviceProps) => {
-    const { openModal } = useActions({
-        openModal: modalActions.openModal,
-    });
+    const dispatch = useDispatch();
+
     const { anchorRef, shouldHighlight } = useAnchor(SettingsAnchor.WipeDevice);
+
+    const handleClick = () => dispatch(openModal({ type: 'wipe-device' }));
 
     return (
         <SectionItem
@@ -29,11 +30,7 @@ export const WipeDevice = ({ isDeviceLocked }: WipeDeviceProps) => {
             />
             <ActionColumn>
                 <ActionButton
-                    onClick={() =>
-                        openModal({
-                            type: 'wipe-device',
-                        })
-                    }
+                    onClick={handleClick}
                     variant="danger"
                     isDisabled={isDeviceLocked}
                     data-test="@settings/device/open-wipe-modal-button"

--- a/packages/suite/src/views/settings/general/ClearStorage.tsx
+++ b/packages/suite/src/views/settings/general/ClearStorage.tsx
@@ -2,19 +2,30 @@ import React from 'react';
 import { desktopApi } from '@trezor/suite-desktop-api';
 import { ActionButton, ActionColumn, SectionItem, TextColumn } from 'src/components/suite/Settings';
 import { Translation } from 'src/components/suite';
-import * as storageActions from 'src/actions/suite/storageActions';
-import * as routerActions from 'src/actions/suite/routerActions';
-import { useActions } from 'src/hooks/suite';
+import { removeDatabase } from 'src/actions/suite/storageActions';
+import { goto } from 'src/actions/suite/routerActions';
+import { useDispatch } from 'src/hooks/suite';
 import { useAnchor } from 'src/hooks/suite/useAnchor';
 import { SettingsAnchor } from 'src/constants/suite/anchors';
 import { reloadApp } from 'src/utils/suite/reload';
 
 export const ClearStorage = () => {
-    const { removeDatabase, goto } = useActions({
-        removeDatabase: storageActions.removeDatabase,
-        goto: routerActions.goto,
-    });
+    const dispatch = useDispatch();
+
     const { anchorRef, shouldHighlight } = useAnchor(SettingsAnchor.ClearStorage);
+
+    const hanldeClick = async () => {
+        localStorage.clear();
+        dispatch(removeDatabase());
+        if (desktopApi.available) {
+            // Reset the desktop-specific store.
+            desktopApi.clearStore();
+        } else {
+            // redirect to / and reload the web
+            await dispatch(goto('suite-index'));
+        }
+        reloadApp();
+    };
 
     return (
         <SectionItem
@@ -28,18 +39,7 @@ export const ClearStorage = () => {
             />
             <ActionColumn>
                 <ActionButton
-                    onClick={async () => {
-                        localStorage.clear();
-                        removeDatabase();
-                        if (desktopApi.available) {
-                            // Reset the desktop-specific store.
-                            desktopApi.clearStore();
-                        } else {
-                            // redirect to / and reload the web
-                            await goto('suite-index');
-                        }
-                        reloadApp();
-                    }}
+                    onClick={hanldeClick}
                     variant="secondary"
                     data-test="@settings/reset-app-button"
                 >

--- a/packages/suite/src/views/settings/general/EarlyAccess.tsx
+++ b/packages/suite/src/views/settings/general/EarlyAccess.tsx
@@ -1,11 +1,11 @@
-import React, { useCallback } from 'react';
+import React from 'react';
 import styled from 'styled-components';
 
 import { desktopApi } from '@trezor/suite-desktop-api';
 import { Translation } from 'src/components/suite';
 import { ActionButton, ActionColumn, SectionItem, TextColumn } from 'src/components/suite/Settings';
-import { useSelector, useActions } from 'src/hooks/suite';
-import * as desktopUpdateActions from 'src/actions/suite/desktopUpdateActions';
+import { useDispatch, useSelector } from 'src/hooks/suite';
+import { openEarlyAccessSetup } from 'src/actions/suite/desktopUpdateActions';
 import { useAnchor } from 'src/hooks/suite/useAnchor';
 import { SettingsAnchor } from 'src/constants/suite/anchors';
 
@@ -17,18 +17,14 @@ const Version = styled.div`
 `;
 
 export const EarlyAccess = () => {
+    const desktopUpdate = useSelector(state => state.desktopUpdate);
+    const dispatch = useDispatch();
     const { anchorRef, shouldHighlight } = useAnchor(SettingsAnchor.EarlyAccess);
 
-    const desktopUpdate = useSelector(state => state.desktopUpdate);
-
-    const { openEarlyAccessSetup } = useActions({
-        openEarlyAccessSetup: desktopUpdateActions.openEarlyAccessSetup,
-    });
-
-    const setupEarlyAccess = useCallback(() => {
-        openEarlyAccessSetup(desktopUpdate.allowPrerelease);
+    const setupEarlyAccess = () => {
+        dispatch(openEarlyAccessSetup(desktopUpdate.allowPrerelease));
         desktopApi.cancelUpdate(); // stop downloading the update if it is in progress to prevent confusing state switching
-    }, [openEarlyAccessSetup, desktopUpdate.allowPrerelease]);
+    };
 
     return (
         <SectionItem

--- a/packages/suite/src/views/settings/general/Language.tsx
+++ b/packages/suite/src/views/settings/general/Language.tsx
@@ -3,10 +3,10 @@ import { analytics, EventType } from '@trezor/suite-analytics';
 
 import { Translation } from 'src/components/suite';
 import { isTranslationMode, getOsLocale } from 'src/utils/suite/l10n';
-import { useActions, useSelector, useTranslation } from 'src/hooks/suite';
+import { useDispatch, useSelector, useTranslation } from 'src/hooks/suite';
 import LANGUAGES, { Locale, LocaleInfo } from 'src/config/suite/languages';
-import * as suiteActions from 'src/actions/suite/suiteActions';
-import * as languageActions from 'src/actions/settings/languageActions';
+import { setAutodetect } from 'src/actions/suite/suiteActions';
+import { setLanguage } from 'src/actions/settings/languageActions';
 import { ActionColumn, ActionSelect, SectionItem, TextColumn } from 'src/components/suite/Settings';
 import { useAnchor } from 'src/hooks/suite/useAnchor';
 import { SettingsAnchor } from 'src/constants/suite/anchors';
@@ -44,14 +44,9 @@ const useLanguageOptions = () => {
 };
 
 export const Language = () => {
-    const { language, autodetectLanguage } = useSelector(state => ({
-        language: state.suite.settings.language,
-        autodetectLanguage: state.suite.settings.autodetect.language,
-    }));
-    const { setLanguage, setAutodetect } = useActions({
-        setLanguage: languageActions.setLanguage,
-        setAutodetect: suiteActions.setAutodetect,
-    });
+    const language = useSelector(state => state.suite.settings.language);
+    const autodetectLanguage = useSelector(state => state.suite.settings.autodetect.language);
+    const dispatch = useDispatch();
     const { anchorRef, shouldHighlight } = useAnchor(SettingsAnchor.Language);
 
     const { options, systemOption } = useLanguageOptions();
@@ -76,10 +71,10 @@ export const Language = () => {
             },
         });
         if ((value === 'system') !== autodetectLanguage) {
-            setAutodetect({ language: !autodetectLanguage });
+            dispatch(setAutodetect({ language: !autodetectLanguage }));
         }
         if (value !== 'system') {
-            setLanguage(value);
+            dispatch(setLanguage(value));
         }
     };
 

--- a/packages/suite/src/views/settings/general/ShowApplicationLog.tsx
+++ b/packages/suite/src/views/settings/general/ShowApplicationLog.tsx
@@ -1,17 +1,17 @@
 import React from 'react';
 
-import * as modalActions from 'src/actions/suite/modalActions';
-import { useActions } from 'src/hooks/suite';
+import { openModal } from 'src/actions/suite/modalActions';
+import { useDispatch } from 'src/hooks/suite';
 import { ActionButton, ActionColumn, SectionItem, TextColumn } from 'src/components/suite/Settings';
 import { Translation } from 'src/components/suite';
 import { useAnchor } from 'src/hooks/suite/useAnchor';
 import { SettingsAnchor } from 'src/constants/suite/anchors';
 
 export const ShowApplicationLog = () => {
-    const { openModal } = useActions({
-        openModal: modalActions.openModal,
-    });
+    const dispatch = useDispatch();
     const { anchorRef, shouldHighlight } = useAnchor(SettingsAnchor.ShowLog);
+
+    const handleClick = () => dispatch(openModal({ type: 'application-log' }));
 
     return (
         <SectionItem
@@ -25,7 +25,7 @@ export const ShowApplicationLog = () => {
             />
             <ActionColumn>
                 <ActionButton
-                    onClick={() => openModal({ type: 'application-log' })}
+                    onClick={handleClick}
                     variant="secondary"
                     data-test="@settings/show-log-button"
                 >

--- a/packages/suite/src/views/settings/general/Theme.tsx
+++ b/packages/suite/src/views/settings/general/Theme.tsx
@@ -2,10 +2,10 @@ import React, { useMemo } from 'react';
 import { analytics, EventType } from '@trezor/suite-analytics';
 
 import { desktopApi, SuiteThemeVariant } from '@trezor/suite-desktop-api';
-import * as suiteActions from 'src/actions/suite/suiteActions';
+import { setAutodetect, setTheme } from 'src/actions/suite/suiteActions';
 import { Translation } from 'src/components/suite/Translation';
 import { SectionItem, ActionColumn, ActionSelect, TextColumn } from 'src/components/suite/Settings';
-import { useActions, useSelector, useTranslation } from 'src/hooks/suite';
+import { useDispatch, useSelector, useTranslation } from 'src/hooks/suite';
 import { useAnchor } from 'src/hooks/suite/useAnchor';
 import { SettingsAnchor } from 'src/constants/suite/anchors';
 import { getOsTheme } from 'src/utils/suite/env';
@@ -46,16 +46,10 @@ const useThemeOptions = () => {
 };
 
 export const Theme = () => {
-    const { theme, autodetectTheme } = useSelector(state => ({
-        theme: state.suite.settings.theme,
-        autodetectTheme: state.suite.settings.autodetect.theme,
-    }));
-    const { setTheme, setAutodetect } = useActions({
-        setTheme: suiteActions.setTheme,
-        setAutodetect: suiteActions.setAutodetect,
-    });
+    const theme = useSelector(state => state.suite.settings.theme);
+    const autodetectTheme = useSelector(state => state.suite.settings.autodetect.theme);
+    const dispatch = useDispatch();
     const { anchorRef, shouldHighlight } = useAnchor(SettingsAnchor.Theme);
-
     const { options, getOption } = useThemeOptions();
 
     const selectedValue = getOption(autodetectTheme ? 'system' : theme.variant);
@@ -73,10 +67,10 @@ export const Theme = () => {
             },
         });
         if ((value === 'system') !== autodetectTheme) {
-            setAutodetect({ theme: !autodetectTheme });
+            dispatch(setAutodetect({ theme: !autodetectTheme }));
         }
         if (value !== 'system') {
-            setTheme(value);
+            dispatch(setTheme(value));
         }
         if (desktopApi.available) {
             desktopApi.themeChange(value);

--- a/packages/suite/src/views/settings/general/Tor.tsx
+++ b/packages/suite/src/views/settings/general/Tor.tsx
@@ -1,37 +1,23 @@
 import React, { useEffect, useState } from 'react';
 import { LoadingContent, Switch } from '@trezor/components';
 import { TOR_PROJECT_URL } from '@trezor/urls';
-import { useSelector, useActions } from 'src/hooks/suite';
+import { useDispatch, useSelector } from 'src/hooks/suite';
 import { ActionColumn, SectionItem, TextColumn } from 'src/components/suite/Settings';
-import * as suiteActions from 'src/actions/suite/suiteActions';
+import { toggleTor } from 'src/actions/suite/suiteActions';
 import { Translation } from 'src/components/suite';
 import { useAnchor } from 'src/hooks/suite/useAnchor';
 import { SettingsAnchor } from 'src/constants/suite/anchors';
 import { getIsTorEnabled, getIsTorLoading } from 'src/utils/suite/tor';
-import { Dispatch, TorStatus } from 'src/types/suite';
-
-import * as modalActions from 'src/actions/suite/modalActions';
+import { TorStatus } from 'src/types/suite';
+import { openDeferredModal } from 'src/actions/suite/modalActions';
 import { selectCoinjoinAccounts } from 'src/reducers/wallet/coinjoinReducer';
 
-const disableTorStopCoinjoinAction = () => (dispatch: Dispatch) =>
-    dispatch(
-        modalActions.openDeferredModal({
-            type: 'disable-tor-stop-coinjoin',
-        }),
-    );
-
 export const Tor = () => {
+    const [hasTorError, setHasTorError] = useState(false);
     const coinjoinAccounts = useSelector((state: any) => selectCoinjoinAccounts(state));
     const isCoinjoinAccount = coinjoinAccounts.length > 0;
     const torStatus = useSelector(state => state.suite.torStatus);
-
-    const [hasTorError, setHasTorError] = useState(false);
-
-    const { toggleTor, disableTorStopCoinjoin } = useActions({
-        toggleTor: suiteActions.toggleTor,
-        disableTorStopCoinjoin: disableTorStopCoinjoinAction,
-    });
-
+    const dispatch = useDispatch();
     const { anchorRef, shouldHighlight } = useAnchor(SettingsAnchor.Tor);
 
     useEffect(() => {
@@ -50,13 +36,17 @@ export const Tor = () => {
     const handleTorSwitch = async () => {
         if (isTorEnabled && isCoinjoinAccount) {
             // Let the user know that stopping Tor will stop coinjoin.
-            const isKeepRunningTor = await disableTorStopCoinjoin();
+            const isKeepRunningTor = await dispatch(
+                openDeferredModal({
+                    type: 'disable-tor-stop-coinjoin',
+                }),
+            );
             if (isKeepRunningTor) {
                 return;
             }
         }
         try {
-            await toggleTor(!isTorEnabled);
+            await dispatch(toggleTor(!isTorEnabled));
         } catch {
             setHasTorError(true);
         }

--- a/packages/suite/src/views/settings/general/TorOnionLinks.tsx
+++ b/packages/suite/src/views/settings/general/TorOnionLinks.tsx
@@ -1,8 +1,8 @@
 import React from 'react';
 import { analytics, EventType } from '@trezor/suite-analytics';
 
-import * as suiteActions from 'src/actions/suite/suiteActions';
-import { useSelector, useActions } from 'src/hooks/suite';
+import { setOnionLinks } from 'src/actions/suite/suiteActions';
+import { useDispatch, useSelector } from 'src/hooks/suite';
 import { ActionColumn, SectionItem, TextColumn } from 'src/components/suite/Settings';
 import { Switch } from '@trezor/components';
 import { Translation } from 'src/components/suite';
@@ -12,15 +12,19 @@ import { SettingsAnchor } from 'src/constants/suite/anchors';
 /* keep torOnionLinks value as it is but hide this section when tor is off.
    when tor is off this value has no effect anyway (handled by ExternalLink hook) */
 export const TorOnionLinks = () => {
+    const torOnionLinks = useSelector(state => state.suite.settings.torOnionLinks);
+    const dispatch = useDispatch();
     const { anchorRef, shouldHighlight } = useAnchor(SettingsAnchor.TorOnionLinks);
 
-    const { torOnionLinks } = useSelector(state => ({
-        torOnionLinks: state.suite.settings.torOnionLinks,
-    }));
-
-    const { setOnionLinks } = useActions({
-        setOnionLinks: suiteActions.setOnionLinks,
-    });
+    const handleChange = () => {
+        dispatch(setOnionLinks(!torOnionLinks));
+        analytics.report({
+            type: EventType.SettingsTorOnionLinks,
+            payload: {
+                value: !torOnionLinks,
+            },
+        });
+    };
 
     return (
         <SectionItem
@@ -36,15 +40,7 @@ export const TorOnionLinks = () => {
                 <Switch
                     dataTest="@settings/general/onion-links-switch"
                     isChecked={torOnionLinks}
-                    onChange={() => {
-                        analytics.report({
-                            type: EventType.SettingsTorOnionLinks,
-                            payload: {
-                                value: !torOnionLinks,
-                            },
-                        });
-                        setOnionLinks(!torOnionLinks);
-                    }}
+                    onChange={handleChange}
                 />
             </ActionColumn>
         </SectionItem>

--- a/packages/suite/src/views/settings/general/VersionWithUpdate.tsx
+++ b/packages/suite/src/views/settings/general/VersionWithUpdate.tsx
@@ -1,12 +1,12 @@
-import React, { useCallback } from 'react';
+import React from 'react';
 import styled from 'styled-components';
 import { desktopApi } from '@trezor/suite-desktop-api';
 
-import * as desktopUpdateActions from 'src/actions/suite/desktopUpdateActions';
+import { installUpdate, setUpdateWindow } from 'src/actions/suite/desktopUpdateActions';
 import { VersionWithGithubTooltip } from 'src/components/suite/VersionWithGithubTooltip';
 import { Translation } from 'src/components/suite';
 import { ActionButton, ActionColumn, SectionItem, TextColumn } from 'src/components/suite/Settings';
-import { useSelector, useActions } from 'src/hooks/suite';
+import { useDispatch, useSelector } from 'src/hooks/suite';
 import { UpdateState } from 'src/reducers/suite/desktopUpdateReducer';
 import { isDevEnv } from '@suite-common/suite-utils';
 import { useAnchor } from 'src/hooks/suite/useAnchor';
@@ -32,16 +32,13 @@ const Version = styled.div`
 `;
 
 export const VersionWithUpdate = () => {
-    const { setUpdateWindow, installUpdate } = useActions({
-        setUpdateWindow: desktopUpdateActions.setUpdateWindow,
-        installUpdate: desktopUpdateActions.installUpdate,
-    });
+    const desktopUpdate = useSelector(state => state.desktopUpdate);
+    const dispatch = useDispatch();
     const { anchorRef, shouldHighlight } = useAnchor(SettingsAnchor.VersionWithUpdate);
 
-    const desktopUpdate = useSelector(state => state.desktopUpdate);
-
-    const checkForUpdates = useCallback(() => desktopApi.checkForUpdates(true), []);
-    const maximizeUpdater = useCallback(() => setUpdateWindow('maximized'), [setUpdateWindow]);
+    const checkForUpdates = () => desktopApi.checkForUpdates(true);
+    const maximizeUpdater = () => dispatch(setUpdateWindow('maximized'));
+    const install = () => dispatch(installUpdate());
 
     return (
         <SectionItem
@@ -114,7 +111,7 @@ export const VersionWithUpdate = () => {
                         </ActionButton>
                     )}
                     {desktopUpdate.state === UpdateState.Ready && (
-                        <ActionButton onClick={() => installUpdate()} variant="secondary">
+                        <ActionButton onClick={install} variant="secondary">
                             <Translation id="SETTINGS_UPDATE_READY" />
                         </ActionButton>
                     )}

--- a/packages/suite/src/views/suite/bridge/index.tsx
+++ b/packages/suite/src/views/suite/bridge/index.tsx
@@ -3,9 +3,9 @@ import styled from 'styled-components';
 import { DATA_URL, HELP_CENTER_TOR_URL, GITHUB_BRIDGE_CHANGELOG_URL } from '@trezor/urls';
 import { Translation, TrezorLink, Modal, Metadata } from 'src/components/suite';
 import { Button, P, Link, Select, Image, useTheme, variables, Loader } from '@trezor/components';
-import * as routerActions from 'src/actions/suite/routerActions';
+import { goto } from 'src/actions/suite/routerActions';
 import { isDesktop, isWeb } from '@trezor/env-utils';
-import { useSelector, useActions } from 'src/hooks/suite';
+import { useDispatch, useSelector } from 'src/hooks/suite';
 import { selectTorState } from 'src/reducers/suite/suiteReducer';
 import { DeviceModelInternal } from '@trezor/connect';
 
@@ -66,7 +66,7 @@ const LoaderWrapper = styled.div`
 `;
 
 const Version = styled.div<{ show: boolean }>`
-    visibility: ${props => (props.show ? 'visible' : 'hidden')};
+    visibility: ${({ show }) => (show ? 'visible' : 'hidden')};
     margin-top: 10px;
     font-size: ${variables.FONT_SIZE.SMALL};
 `;
@@ -86,7 +86,7 @@ const StyledImage = styled(Image)`
 const Col = styled.div<{ justify?: string }>`
     display: flex;
     flex: 1;
-    justify-content: ${props => props.justify};
+    justify-content: ${({ justify }) => justify};
 `;
 
 interface Installer {
@@ -97,14 +97,11 @@ interface Installer {
 }
 
 export const InstallBridge = () => {
+    const [selectedTarget, setSelectedTarget] = useState<Installer | null>(null);
     const { isTorEnabled } = useSelector(selectTorState);
     const transport = useSelector(state => state.suite.transport);
-    const [selectedTarget, setSelectedTarget] = useState<Installer | null>(null);
-
+    const dispatch = useDispatch();
     const theme = useTheme();
-    const actions = useActions({
-        goto: routerActions.goto,
-    });
 
     const installers: Installer[] =
         transport && transport.bridge
@@ -128,6 +125,8 @@ export const InstallBridge = () => {
     const target = selectedTarget || data.target;
     const isLoading = !transport;
     const transportAvailable = transport && transport.type;
+
+    const goToWallet = () => dispatch(goto('wallet-index'));
 
     return (
         <Modal
@@ -194,7 +193,7 @@ export const InstallBridge = () => {
                             icon="ARROW_LEFT"
                             variant="tertiary"
                             color={theme.TYPE_LIGHT_GREY}
-                            onClick={() => actions.goto('wallet-index')}
+                            onClick={goToWallet}
                             data-test="@bridge/goto/wallet-index"
                         >
                             <Translation id="TR_TAKE_ME_BACK_TO_WALLET" />
@@ -205,12 +204,7 @@ export const InstallBridge = () => {
                     <>
                         <Col justify="center">
                             <Link variant="nostyle" href={GITHUB_BRIDGE_CHANGELOG_URL}>
-                                <Button
-                                    icon="LOG"
-                                    color={theme.TYPE_LIGHT_GREY}
-                                    variant="tertiary"
-                                    onClick={() => {}}
-                                >
+                                <Button icon="LOG" color={theme.TYPE_LIGHT_GREY} variant="tertiary">
                                     <Translation id="TR_CHANGELOG" />
                                 </Button>
                             </Link>
@@ -222,7 +216,6 @@ export const InstallBridge = () => {
                                         color={theme.TYPE_LIGHT_GREY}
                                         icon="SIGNATURE"
                                         variant="tertiary"
-                                        onClick={() => {}}
                                     >
                                         <Translation id="TR_CHECK_PGP_SIGNATURE" />
                                     </Button>

--- a/packages/suite/src/views/suite/device-acquire/index.tsx
+++ b/packages/suite/src/views/suite/device-acquire/index.tsx
@@ -1,25 +1,26 @@
 // TODO: remove whole file, replaced by @suite-components/PrerequisitesGuide/components/DeviceAcquire
 
 import React from 'react';
-import { useDevice, useActions } from 'src/hooks/suite';
-import * as suiteActions from 'src/actions/suite/suiteActions';
+import { useDevice, useDispatch } from 'src/hooks/suite';
+import { acquireDevice } from 'src/actions/suite/suiteActions';
 import { Button } from '@trezor/components';
 import { Translation, DeviceInvalidModeLayout } from 'src/components/suite';
 
 export const DeviceAcquire = () => {
+    const dispatch = useDispatch();
     const { device, isLocked } = useDevice();
-    const { acquireDevice } = useActions({
-        acquireDevice: suiteActions.acquireDevice,
-    });
 
     if (!device) return null;
+
+    const handleClick = () => dispatch(acquireDevice());
+
     return (
         <DeviceInvalidModeLayout
             title={<Translation id="TR_ACQUIRE_DEVICE_TITLE" />}
             text={<Translation id="TR_ACQUIRE_DEVICE_DESCRIPTION" />}
             image="DEVICE_ANOTHER_SESSION"
             resolveButton={
-                <Button isLoading={isLocked()} onClick={() => acquireDevice()}>
+                <Button isLoading={isLocked()} onClick={handleClick}>
                     <Translation id="TR_ACQUIRE_DEVICE" />
                 </Button>
             }

--- a/packages/suite/src/views/suite/device-unreadable/index.tsx
+++ b/packages/suite/src/views/suite/device-unreadable/index.tsx
@@ -1,20 +1,23 @@
 // TODO: remove whole file, replaced by @suite-components/PrerequisitesGuide/components/DeviceUnreadable
 
 import React from 'react';
-import * as routerActions from 'src/actions/suite/routerActions';
+import { goto } from 'src/actions/suite/routerActions';
 import { Button } from '@trezor/components';
 import { DeviceInvalidModeLayout, Translation } from 'src/components/suite';
-import { useActions } from 'src/hooks/suite';
+import { useDispatch } from 'src/hooks/suite';
 
 export const DeviceUnreadable = () => {
-    const { goto } = useActions({ goto: routerActions.goto });
+    const dispatch = useDispatch();
+
+    const handleClick = () => dispatch(goto('suite-bridge'));
+
     return (
         <DeviceInvalidModeLayout
             data-test="@device-invalid-mode/unreadable"
             title={<Translation id="TR_UNREADABLE" />}
             text={<Translation id="TR_UNREADABLE_EXPLAINED" />}
             resolveButton={
-                <Button onClick={() => goto('suite-bridge')}>
+                <Button onClick={handleClick}>
                     <Translation id="TR_SEE_DETAILS" />
                 </Button>
             }

--- a/packages/suite/src/views/wallet/coinmarket/buy/components/BuyForm/Footer/index.tsx
+++ b/packages/suite/src/views/wallet/coinmarket/buy/components/BuyForm/Footer/index.tsx
@@ -21,7 +21,7 @@ const FlagWrapper = styled.div`
 const LabelText = styled.div`
     font-size: ${variables.FONT_SIZE.SMALL};
     font-weight: ${variables.FONT_WEIGHT.MEDIUM};
-    color: ${props => props.theme.TYPE_DARK_GREY};
+    color: ${({ theme }) => theme.TYPE_DARK_GREY};
 `;
 
 const StyledRight = styled(Right)`
@@ -35,7 +35,7 @@ const Label = styled.div`
     align-items: center;
     white-space: nowrap;
     padding-top: 1px;
-    color: ${props => props.theme.TYPE_LIGHT_GREY};
+    color: ${({ theme }) => theme.TYPE_LIGHT_GREY};
     font-weight: ${variables.FONT_WEIGHT.MEDIUM};
 `;
 

--- a/packages/suite/src/views/wallet/coinmarket/buy/detail/Detail/index.tsx
+++ b/packages/suite/src/views/wallet/coinmarket/buy/detail/Detail/index.tsx
@@ -3,8 +3,8 @@ import styled from 'styled-components';
 import { Card, variables } from '@trezor/components';
 import { CoinmarketBuyOfferInfo, CoinmarketBuyTopPanel } from 'src/components/wallet';
 import { useCoinmarketBuyDetailContext } from 'src/hooks/wallet/useCoinmarketBuyDetail';
-import * as routerActions from 'src/actions/suite/routerActions';
-import { useActions, useLayout } from 'src/hooks/suite';
+import { goto } from 'src/actions/suite/routerActions';
+import { useDispatch, useLayout } from 'src/hooks/suite';
 
 import PaymentFailed from '../components/PaymentFailed';
 import PaymentProcessing from '../components/PaymentProcessing';
@@ -29,18 +29,20 @@ const CoinmarketDetail = () => {
     useLayout('Trezor Suite | Trade', CoinmarketBuyTopPanel);
 
     const { account, trade, buyInfo } = useCoinmarketBuyDetailContext();
-    const { goto } = useActions({ goto: routerActions.goto });
+    const dispatch = useDispatch();
 
     // if trade not found, it is because user refreshed the page and stored transactionId got removed
     // go to the default coinmarket page, the trade is shown there in the previous trades
     if (!trade) {
-        goto('wallet-coinmarket-buy', {
-            params: {
-                symbol: account.symbol,
-                accountIndex: account.index,
-                accountType: account.accountType,
-            },
-        });
+        dispatch(
+            goto('wallet-coinmarket-buy', {
+                params: {
+                    symbol: account.symbol,
+                    accountIndex: account.index,
+                    accountType: account.accountType,
+                },
+            }),
+        );
         return null;
     }
 

--- a/packages/suite/src/views/wallet/coinmarket/buy/detail/components/PaymentFailed/index.tsx
+++ b/packages/suite/src/views/wallet/coinmarket/buy/detail/components/PaymentFailed/index.tsx
@@ -1,10 +1,10 @@
-import * as routerActions from 'src/actions/suite/routerActions';
 import React from 'react';
 import styled from 'styled-components';
 import { Button, variables, Link, Image } from '@trezor/components';
-import { useActions } from 'src/hooks/suite/useActions';
+import { useDispatch } from 'src/hooks/suite';
 import { Account } from 'src/types/wallet';
 import { Translation } from 'src/components/suite/Translation';
+import { goto } from 'src/actions/suite/routerActions';
 
 const Wrapper = styled.div`
     display: flex;
@@ -23,7 +23,7 @@ const Description = styled.div`
     display: flex;
     align-items: center;
     justify-content: center;
-    color: ${props => props.theme.TYPE_LIGHT_GREY};
+    color: ${({ theme }) => theme.TYPE_LIGHT_GREY};
     font-weight: ${variables.FONT_WEIGHT.MEDIUM};
     margin: 17px 0 10px 0;
     max-width: 310px;
@@ -38,15 +38,25 @@ const StyledButton = styled(Button)`
     margin-top: 30px;
 `;
 
-interface Props {
+interface PaymentFailedProps {
     supportUrl?: string;
     account: Account;
 }
 
-const PaymentFailed = ({ supportUrl, account }: Props) => {
-    const { goto } = useActions({
-        goto: routerActions.goto,
-    });
+const PaymentFailed = ({ supportUrl, account }: PaymentFailedProps) => {
+    const dispatch = useDispatch();
+
+    const goToBuy = () =>
+        dispatch(
+            goto('wallet-coinmarket-buy', {
+                params: {
+                    symbol: account.symbol,
+                    accountIndex: account.index,
+                    accountType: account.accountType,
+                },
+            }),
+        );
+
     return (
         <Wrapper>
             <Image image="UNI_ERROR" />
@@ -63,17 +73,7 @@ const PaymentFailed = ({ supportUrl, account }: Props) => {
                     </Button>
                 </StyledLink>
             )}
-            <StyledButton
-                onClick={() =>
-                    goto('wallet-coinmarket-buy', {
-                        params: {
-                            symbol: account.symbol,
-                            accountIndex: account.index,
-                            accountType: account.accountType,
-                        },
-                    })
-                }
-            >
+            <StyledButton onClick={goToBuy}>
                 <Translation id="TR_BUY_DETAIL_ERROR_BUTTON" />
             </StyledButton>
         </Wrapper>

--- a/packages/suite/src/views/wallet/coinmarket/buy/detail/components/PaymentProcessing/index.tsx
+++ b/packages/suite/src/views/wallet/coinmarket/buy/detail/components/PaymentProcessing/index.tsx
@@ -20,11 +20,11 @@ const StyledLink = styled(Link)`
     margin-top: 50px;
 `;
 
-interface Props {
+interface PaymentProcessingProps {
     supportUrl?: string;
 }
 
-const PaymentProcessing = ({ supportUrl }: Props) => (
+const PaymentProcessing = ({ supportUrl }: PaymentProcessingProps) => (
     <Wrapper>
         <Loader />
         <Title>

--- a/packages/suite/src/views/wallet/coinmarket/buy/detail/components/PaymentSuccessful/index.tsx
+++ b/packages/suite/src/views/wallet/coinmarket/buy/detail/components/PaymentSuccessful/index.tsx
@@ -1,10 +1,10 @@
-import * as routerActions from 'src/actions/suite/routerActions';
 import React from 'react';
 import styled from 'styled-components';
 import { Button, variables, Image } from '@trezor/components';
 import { Translation } from 'src/components/suite';
-import { useActions } from 'src/hooks/suite';
+import { useDispatch } from 'src/hooks/suite';
 import { Account } from 'src/types/wallet';
+import { goto } from 'src/actions/suite/routerActions';
 
 const Wrapper = styled.div`
     display: flex;
@@ -23,21 +23,31 @@ const Description = styled.div`
     display: flex;
     align-items: center;
     justify-content: center;
-    color: ${props => props.theme.TYPE_LIGHT_GREY};
+    color: ${({ theme }) => theme.TYPE_LIGHT_GREY};
     font-weight: ${variables.FONT_WEIGHT.MEDIUM};
     margin: 17px 0 30px 0;
     max-width: 310px;
     text-align: center;
 `;
 
-interface Props {
+interface PaymentSuccessfulProps {
     account: Account;
 }
 
-const PaymentSuccessful = ({ account }: Props) => {
-    const { goto } = useActions({
-        goto: routerActions.goto,
-    });
+const PaymentSuccessful = ({ account }: PaymentSuccessfulProps) => {
+    const dispatch = useDispatch();
+
+    const handleClick = () =>
+        dispatch(
+            goto('wallet-coinmarket-buy', {
+                params: {
+                    symbol: account.symbol,
+                    accountIndex: account.index,
+                    accountType: account.accountType,
+                },
+            }),
+        );
+
     return (
         <Wrapper>
             <Image image="COINMARKET_SUCCESS" />
@@ -47,17 +57,7 @@ const PaymentSuccessful = ({ account }: Props) => {
             <Description>
                 <Translation id="TR_BUY_DETAIL_SUCCESS_TEXT" />
             </Description>
-            <Button
-                onClick={() =>
-                    goto('wallet-coinmarket-buy', {
-                        params: {
-                            symbol: account.symbol,
-                            accountIndex: account.index,
-                            accountType: account.accountType,
-                        },
-                    })
-                }
-            >
+            <Button onClick={handleClick}>
                 <Translation id="TR_BUY_DETAIL_SUCCESS_BUTTON" />
             </Button>
         </Wrapper>

--- a/packages/suite/src/views/wallet/coinmarket/buy/detail/components/WaitingForUser/index.tsx
+++ b/packages/suite/src/views/wallet/coinmarket/buy/detail/components/WaitingForUser/index.tsx
@@ -37,12 +37,6 @@ const PaymentButton = styled(Button)`
     margin-top: 30px;
 `;
 
-interface Props {
-    trade: BuyTrade;
-    account: Account;
-    providerName?: string;
-}
-
 const getTranslations = (tradeStatus: BuyTradeStatus | undefined) => {
     if (tradeStatus === 'WAITING_FOR_USER') {
         return {
@@ -58,7 +52,13 @@ const getTranslations = (tradeStatus: BuyTradeStatus | undefined) => {
     } as const;
 };
 
-const WaitingForUser = ({ trade, account, providerName }: Props) => {
+interface WaitingForUserProps {
+    trade: BuyTrade;
+    account: Account;
+    providerName?: string;
+}
+
+const WaitingForUser = ({ trade, account, providerName }: WaitingForUserProps) => {
     const [isWorking, setIsWorking] = useState(false);
     const dispatch = useDispatch();
 

--- a/packages/suite/src/views/wallet/coinmarket/buy/detail/components/WaitingForUser/index.tsx
+++ b/packages/suite/src/views/wallet/coinmarket/buy/detail/components/WaitingForUser/index.tsx
@@ -6,8 +6,8 @@ import { BuyTrade, BuyTradeStatus } from 'invity-api';
 import { Account } from 'src/types/wallet';
 import invityAPI from 'src/services/suite/invityAPI';
 import { createTxLink } from 'src/utils/wallet/coinmarket/buyUtils';
-import * as coinmarketCommonActions from 'src/actions/wallet/coinmarket/coinmarketCommonActions';
-import { useActions } from 'src/hooks/suite';
+import { submitRequestForm } from 'src/actions/wallet/coinmarket/coinmarketCommonActions';
+import { useDispatch } from 'src/hooks/suite';
 
 const Wrapper = styled.div`
     display: flex;
@@ -26,16 +26,12 @@ const Description = styled.div`
     display: flex;
     align-items: center;
     justify-content: center;
-    color: ${props => props.theme.TYPE_LIGHT_GREY};
+    color: ${({ theme }) => theme.TYPE_LIGHT_GREY};
     font-weight: ${variables.FONT_WEIGHT.MEDIUM};
     margin: 17px 0 10px 0;
     max-width: 200px;
     text-align: center;
 `;
-
-// const CancelButton = styled(Button)`
-//     margin-top: 15px;
-// `;
 
 const PaymentButton = styled(Button)`
     margin-top: 30px;
@@ -64,19 +60,16 @@ const getTranslations = (tradeStatus: BuyTradeStatus | undefined) => {
 
 const WaitingForUser = ({ trade, account, providerName }: Props) => {
     const [isWorking, setIsWorking] = useState(false);
-    const { submitRequestForm } = useActions({
-        submitRequestForm: coinmarketCommonActions.submitRequestForm,
-    });
+    const dispatch = useDispatch();
 
     const goToPayment = async () => {
         setIsWorking(true);
         const returnUrl = await createTxLink(trade, account);
         const response = await invityAPI.getBuyTradeForm({ trade, returnUrl });
         if (response) {
-            submitRequestForm(response.form);
+            dispatch(submitRequestForm(response.form));
         }
     };
-    // const cancelTrade = () => {};
 
     const translations = getTranslations(trade.status);
 
@@ -92,10 +85,7 @@ const WaitingForUser = ({ trade, account, providerName }: Props) => {
             <PaymentButton onClick={goToPayment} isLoading={isWorking} isDisabled={isWorking}>
                 <Translation id={translations.buttonTextTranslationId} />
             </PaymentButton>
-            {/* TODO add a possibility in the future to cancel the transaction by the user
-            <CancelButton isWhite variant="tertiary" onClick={cancelTrade}>
-                <Translation id="TR_BUY_DETAIL_SUBMITTED_CANCEL" />
-            </CancelButton> */}
+            {/* TODO add a possibility in the future to cancel the transaction by the user */}
         </Wrapper>
     );
 };

--- a/packages/suite/src/views/wallet/coinmarket/buy/offers/Offers/List/Quote/index.tsx
+++ b/packages/suite/src/views/wallet/coinmarket/buy/offers/Offers/List/Quote/index.tsx
@@ -27,7 +27,7 @@ const Wrapper = styled.div`
     width: 100%;
     min-height: 150px;
     padding-bottom: 16px;
-    background: ${props => props.theme.BG_WHITE};
+    background: ${({ theme }) => theme.BG_WHITE};
 `;
 
 const Main = styled.div`
@@ -35,7 +35,7 @@ const Main = styled.div`
     margin: 0 30px;
     justify-content: space-between;
     padding: 20px 0;
-    border-bottom: 1px solid ${props => props.theme.STROKE_GREY};
+    border-bottom: 1px solid ${({ theme }) => theme.STROKE_GREY};
 
     @media (max-width: ${variables.SCREEN_SIZE.SM}) {
         flex-direction: column;
@@ -82,7 +82,7 @@ const Column = styled.div`
 const Heading = styled.div`
     display: flex;
     text-transform: uppercase;
-    color: ${props => props.theme.TYPE_LIGHT_GREY};
+    color: ${({ theme }) => theme.TYPE_LIGHT_GREY};
     font-weight: ${variables.FONT_WEIGHT.DEMI_BOLD};
     padding-bottom: 9px;
 `;
@@ -98,7 +98,7 @@ const StyledButton = styled(Button)`
 const Value = styled.div`
     display: flex;
     align-items: center;
-    color: ${props => props.theme.TYPE_DARK_GREY};
+    color: ${({ theme }) => theme.TYPE_DARK_GREY};
     font-weight: ${variables.FONT_WEIGHT.MEDIUM};
 `;
 
@@ -106,8 +106,8 @@ const Footer = styled.div`
     margin: 0 30px;
     padding: 10px 0;
     padding-top: 23px;
-    color: ${props => props.theme.TYPE_LIGHT_GREY};
-    border-top: 1px solid ${props => props.theme.STROKE_GREY};
+    color: ${({ theme }) => theme.TYPE_LIGHT_GREY};
+    border-top: 1px solid ${({ theme }) => theme.STROKE_GREY};
     font-weight: ${variables.FONT_WEIGHT.MEDIUM};
     font-size: ${variables.FONT_SIZE.SMALL};
 
@@ -120,8 +120,8 @@ const ErrorFooter = styled.div`
     display: flex;
     margin: 0 30px;
     padding: 10px 0;
-    border-top: 1px solid ${props => props.theme.STROKE_GREY};
-    color: ${props => props.theme.TYPE_RED};
+    border-top: 1px solid ${({ theme }) => theme.STROKE_GREY};
+    color: ${({ theme }) => theme.TYPE_RED};
 
     @media (max-width: ${variables.SCREEN_SIZE.SM}) {
         margin: 0 20px;
@@ -140,7 +140,7 @@ const ErrorText = styled.div``;
 
 const StyledQuestionTooltip = styled(QuestionTooltip)`
     padding-left: 4px;
-    color: ${props => props.theme.TYPE_LIGHT_GREY};
+    color: ${({ theme }) => theme.TYPE_LIGHT_GREY};
 `;
 
 export function getQuoteError(quote: BuyTrade, wantCrypto: boolean) {

--- a/packages/suite/src/views/wallet/coinmarket/buy/offers/Offers/List/Quote/index.tsx
+++ b/packages/suite/src/views/wallet/coinmarket/buy/offers/Offers/List/Quote/index.tsx
@@ -13,12 +13,6 @@ import { getTagAndInfoNote } from 'src/utils/wallet/coinmarket/coinmarketUtils';
 import { CoinmarketCryptoAmount } from 'src/views/wallet/coinmarket/common/CoinmarketCryptoAmount';
 import { CoinmarketFiatAmount } from 'src/views/wallet/coinmarket/common/CoinmarketFiatAmount';
 
-interface Props {
-    className?: string;
-    quote: BuyTrade;
-    wantCrypto: boolean;
-}
-
 const Wrapper = styled.div`
     display: flex;
     flex-direction: column;
@@ -143,6 +137,12 @@ const StyledQuestionTooltip = styled(QuestionTooltip)`
     color: ${({ theme }) => theme.TYPE_LIGHT_GREY};
 `;
 
+interface QuoteProps {
+    className?: string;
+    quote: BuyTrade;
+    wantCrypto: boolean;
+}
+
 export function getQuoteError(quote: BuyTrade, wantCrypto: boolean) {
     if (quote.error) {
         if (wantCrypto) {
@@ -228,7 +228,7 @@ export function getQuoteError(quote: BuyTrade, wantCrypto: boolean) {
     return '';
 }
 
-const Quote = ({ className, quote, wantCrypto }: Props) => {
+const Quote = ({ className, quote, wantCrypto }: QuoteProps) => {
     const theme = useTheme();
     const { selectQuote, providersInfo } = useCoinmarketBuyOffersContext();
     const { tag, infoNote } = getTagAndInfoNote(quote);

--- a/packages/suite/src/views/wallet/coinmarket/buy/offers/Offers/List/index.tsx
+++ b/packages/suite/src/views/wallet/coinmarket/buy/offers/Offers/List/index.tsx
@@ -51,7 +51,7 @@ const SummaryRow = styled.div`
 `;
 
 const OrigAmount = styled.div`
-    color: ${props => props.theme.TYPE_LIGHT_GREY};
+    color: ${({ theme }) => theme.TYPE_LIGHT_GREY};
     font-size: ${variables.FONT_SIZE.SMALL};
 `;
 

--- a/packages/suite/src/views/wallet/coinmarket/buy/offers/Offers/List/index.tsx
+++ b/packages/suite/src/views/wallet/coinmarket/buy/offers/Offers/List/index.tsx
@@ -10,11 +10,6 @@ import { InvityAPIReloadQuotesAfterSeconds } from 'src/constants/wallet/coinmark
 import { CoinmarketCryptoAmount } from 'src/views/wallet/coinmarket/common/CoinmarketCryptoAmount';
 import { CoinmarketFiatAmount } from 'src/views/wallet/coinmarket/common/CoinmarketFiatAmount';
 
-interface Props {
-    isAlternative?: boolean;
-    quotes: BuyTrade[];
-}
-
 const Wrapper = styled.div``;
 const Quotes = styled.div``;
 
@@ -79,7 +74,12 @@ const NoQuotes = styled.div`
     flex: 1;
 `;
 
-const List = ({ isAlternative, quotes }: Props) => {
+interface ListProps {
+    isAlternative?: boolean;
+    quotes: BuyTrade[];
+}
+
+const List = ({ isAlternative, quotes }: ListProps) => {
     const { account, quotesRequest, timer } = useCoinmarketBuyOffersContext();
 
     if (!quotesRequest) return null;

--- a/packages/suite/src/views/wallet/coinmarket/buy/offers/Offers/SelectedOffer/components/VerifyAddress/index.tsx
+++ b/packages/suite/src/views/wallet/coinmarket/buy/offers/Offers/SelectedOffer/components/VerifyAddress/index.tsx
@@ -73,7 +73,7 @@ const StyledImage = styled(Image)`
 const Amount = styled.div`
     display: flex;
     font-size: ${variables.FONT_SIZE.TINY};
-    color: ${props => props.theme.TYPE_LIGHT_GREY};
+    color: ${({ theme }) => theme.TYPE_LIGHT_GREY};
     font-weight: ${variables.FONT_WEIGHT.MEDIUM};
 `;
 
@@ -89,8 +89,8 @@ const FakeInput = styled.div`
     min-height: 61px;
     align-items: center;
     border-radius: 4px;
-    border: solid 2px ${props => props.theme.STROKE_GREY};
-    background: ${props => props.theme.BG_WHITE};
+    border: solid 2px ${({ theme }) => theme.STROKE_GREY};
+    background: ${({ theme }) => theme.BG_WHITE};
 `;
 
 const ButtonWrapper = styled.div`
@@ -98,7 +98,7 @@ const ButtonWrapper = styled.div`
     align-items: center;
     justify-content: center;
     padding-top: 20px;
-    border-top: 1px solid ${props => props.theme.STROKE_GREY};
+    border-top: 1px solid ${({ theme }) => theme.STROKE_GREY};
     margin: 20px 0;
 `;
 
@@ -107,7 +107,7 @@ const Confirmed = styled.div`
     height: 60px;
     font-size: ${variables.FONT_SIZE.BIG};
     font-weight: ${variables.FONT_WEIGHT.MEDIUM};
-    background: ${props => props.theme.BG_GREY};
+    background: ${({ theme }) => theme.BG_GREY};
     align-items: center;
     justify-content: center;
     margin-top: 27px;

--- a/packages/suite/src/views/wallet/coinmarket/buy/offers/Offers/index.tsx
+++ b/packages/suite/src/views/wallet/coinmarket/buy/offers/Offers/index.tsx
@@ -33,14 +33,14 @@ const Divider = styled.div`
 const DividerLine = styled.div`
     height: 1px;
     flex: 1;
-    background: ${props => props.theme.STROKE_GREY};
+    background: ${({ theme }) => theme.STROKE_GREY};
 `;
 
 const DividerLeft = styled(DividerLine)``;
 const DividerRight = styled(DividerLine)``;
 
 const Currency = styled.div`
-    color: ${props => props.theme.TYPE_DARK_GREY};
+    color: ${({ theme }) => theme.TYPE_DARK_GREY};
     text-transform: uppercase;
     padding-left: 3px;
 `;
@@ -49,12 +49,12 @@ const DividerMiddle = styled.div`
     display: flex;
     align-items: center;
     padding: 5px 20px;
-    color: ${props => props.theme.TYPE_LIGHT_GREY};
+    color: ${({ theme }) => theme.TYPE_LIGHT_GREY};
     font-weight: ${variables.FONT_WEIGHT.MEDIUM};
     font-size: ${variables.FONT_SIZE.SMALL};
     border-radius: 25px;
-    border: 1px solid ${props => props.theme.STROKE_GREY};
-    background: ${props => props.theme.BG_WHITE};
+    border: 1px solid ${({ theme }) => theme.STROKE_GREY};
+    background: ${({ theme }) => theme.BG_WHITE};
     text-align: center;
 `;
 

--- a/packages/suite/src/views/wallet/coinmarket/common/no-offers/index.tsx
+++ b/packages/suite/src/views/wallet/coinmarket/common/no-offers/index.tsx
@@ -5,14 +5,6 @@ import { CoinmarketRefreshTime } from 'src/components/wallet';
 import { Button, Image } from '@trezor/components';
 import { InvityAPIReloadQuotesAfterSeconds } from 'src/constants/wallet/coinmarket/metadata';
 
-interface Props {
-    coinmarketRefreshTimeIsLoading: boolean;
-    coinmarketRefreshTimeSeconds: number;
-    onBackButtonClick: () => void;
-    onReloadOffersButtonClick: () => void;
-    hasLoadingFailed: boolean;
-}
-
 const NoOffersWrapper = styled.div`
     display: flex;
     justify-content: center;
@@ -44,13 +36,21 @@ const ButtonsWrapper = styled.div`
     }
 `;
 
+interface NoOffersProps {
+    coinmarketRefreshTimeIsLoading: boolean;
+    coinmarketRefreshTimeSeconds: number;
+    onBackButtonClick: () => void;
+    onReloadOffersButtonClick: () => void;
+    hasLoadingFailed: boolean;
+}
+
 const NoOffers = ({
     coinmarketRefreshTimeIsLoading,
     coinmarketRefreshTimeSeconds,
     onBackButtonClick,
     onReloadOffersButtonClick,
     hasLoadingFailed,
-}: Props) => (
+}: NoOffersProps) => (
     <NoOffersWrapper>
         <NoOffersImage>
             <Image image="CLOUDY" />

--- a/packages/suite/src/views/wallet/coinmarket/exchange/components/ExchangeForm/Inputs/ReceiveCryptoSelect/index.tsx
+++ b/packages/suite/src/views/wallet/coinmarket/exchange/components/ExchangeForm/Inputs/ReceiveCryptoSelect/index.tsx
@@ -35,7 +35,7 @@ const Option = styled.div`
 
 const OptionName = styled.div`
     display: flex;
-    color: ${props => props.theme.TYPE_LIGHT_GREY};
+    color: ${({ theme }) => theme.TYPE_LIGHT_GREY};
     font-size: ${variables.FONT_SIZE.TINY};
     max-width: 150px;
 `;

--- a/packages/suite/src/views/wallet/coinmarket/exchange/detail/Detail/index.tsx
+++ b/packages/suite/src/views/wallet/coinmarket/exchange/detail/Detail/index.tsx
@@ -4,8 +4,8 @@ import { Card, variables } from '@trezor/components';
 import { CoinmarketExchangeOfferInfo, CoinmarketExchangeTopPanel } from 'src/components/wallet';
 import { useCoinmarketExchangeDetailContext } from 'src/hooks/wallet/useCoinmarketExchangeDetail';
 import { ExchangeTradeFinalStatuses } from 'src/hooks/wallet/useCoinmarket';
-import * as routerActions from 'src/actions/suite/routerActions';
-import { useActions, useLayout } from 'src/hooks/suite';
+import { goto } from 'src/actions/suite/routerActions';
+import { useDispatch, useLayout } from 'src/hooks/suite';
 
 import PaymentFailed from '../components/PaymentFailed';
 import PaymentSuccessful from '../components/PaymentSuccessful';
@@ -31,18 +31,20 @@ const CoinmarketDetail = () => {
     useLayout('Trezor Suite | Trade', CoinmarketExchangeTopPanel);
 
     const { account, trade, exchangeInfo } = useCoinmarketExchangeDetailContext();
-    const { goto } = useActions({ goto: routerActions.goto });
+    const dispatch = useDispatch();
 
     // if trade not found, it is because user refreshed the page and stored transactionId got removed
     // go to the default coinmarket page, the trade is shown there in the previous trades
     if (!trade) {
-        goto('wallet-coinmarket-exchange', {
-            params: {
-                symbol: account.symbol,
-                accountIndex: account.index,
-                accountType: account.accountType,
-            },
-        });
+        dispatch(
+            goto('wallet-coinmarket-exchange', {
+                params: {
+                    symbol: account.symbol,
+                    accountIndex: account.index,
+                    accountType: account.accountType,
+                },
+            }),
+        );
         return null;
     }
 

--- a/packages/suite/src/views/wallet/coinmarket/exchange/detail/components/PaymentConverting/index.tsx
+++ b/packages/suite/src/views/wallet/coinmarket/exchange/detail/components/PaymentConverting/index.tsx
@@ -20,11 +20,11 @@ const StyledLink = styled(Link)`
     margin-top: 50px;
 `;
 
-interface Props {
+interface PaymentConvertingProps {
     supportUrl?: string;
 }
 
-const PaymentConverting = ({ supportUrl }: Props) => (
+const PaymentConverting = ({ supportUrl }: PaymentConvertingProps) => (
     <Wrapper>
         <Loader />
         <Title>

--- a/packages/suite/src/views/wallet/coinmarket/exchange/detail/components/PaymentFailed/index.tsx
+++ b/packages/suite/src/views/wallet/coinmarket/exchange/detail/components/PaymentFailed/index.tsx
@@ -1,11 +1,11 @@
-import * as routerActions from 'src/actions/suite/routerActions';
 import React from 'react';
 import styled from 'styled-components';
 import { Button, variables, Link, Image } from '@trezor/components';
 import { CoinmarketTransactionId } from 'src/components/wallet';
-import { useActions } from 'src/hooks/suite/useActions';
+import { useDispatch } from 'src/hooks/suite';
 import { Account } from 'src/types/wallet';
 import { Translation } from 'src/components/suite/Translation';
+import { goto } from 'src/actions/suite/routerActions';
 
 const Wrapper = styled.div`
     display: flex;
@@ -24,7 +24,7 @@ const Description = styled.div`
     display: flex;
     align-items: center;
     justify-content: center;
-    color: ${props => props.theme.TYPE_LIGHT_GREY};
+    color: ${({ theme }) => theme.TYPE_LIGHT_GREY};
     font-weight: ${variables.FONT_WEIGHT.MEDIUM};
     margin: 17px 0 10px 0;
     max-width: 310px;
@@ -36,16 +36,26 @@ const StyledLink = styled(Link)`
     margin-bottom: 30px;
 `;
 
-interface Props {
+interface PaymentFailedProps {
     transactionId?: string;
     supportUrl?: string;
     account: Account;
 }
 
-const PaymentFailed = ({ transactionId, supportUrl, account }: Props) => {
-    const { goto } = useActions({
-        goto: routerActions.goto,
-    });
+const PaymentFailed = ({ transactionId, supportUrl, account }: PaymentFailedProps) => {
+    const dispatch = useDispatch();
+
+    const goToExchange = () =>
+        dispatch(
+            goto('wallet-coinmarket-exchange', {
+                params: {
+                    symbol: account.symbol,
+                    accountIndex: account.index,
+                    accountType: account.accountType,
+                },
+            }),
+        );
+
     return (
         <Wrapper>
             <Image image="UNI_ERROR" />
@@ -63,17 +73,7 @@ const PaymentFailed = ({ transactionId, supportUrl, account }: Props) => {
                     </Button>
                 </StyledLink>
             )}
-            <Button
-                onClick={() =>
-                    goto('wallet-coinmarket-exchange', {
-                        params: {
-                            symbol: account.symbol,
-                            accountIndex: account.index,
-                            accountType: account.accountType,
-                        },
-                    })
-                }
-            >
+            <Button onClick={goToExchange}>
                 <Translation id="TR_EXCHANGE_DETAIL_ERROR_BUTTON" />
             </Button>
         </Wrapper>

--- a/packages/suite/src/views/wallet/coinmarket/exchange/detail/components/PaymentKYC/index.tsx
+++ b/packages/suite/src/views/wallet/coinmarket/exchange/detail/components/PaymentKYC/index.tsx
@@ -1,12 +1,12 @@
-import * as routerActions from 'src/actions/suite/routerActions';
 import React from 'react';
 import styled from 'styled-components';
 import { Button, variables, Link, Image } from '@trezor/components';
 import { CoinmarketTransactionId } from 'src/components/wallet';
-import { useActions } from 'src/hooks/suite/useActions';
+import { useDispatch } from 'src/hooks/suite';
 import { Account } from 'src/types/wallet';
 import { Translation } from 'src/components/suite/Translation';
 import { ExchangeProviderInfo } from 'invity-api';
+import { goto } from 'src/actions/suite/routerActions';
 
 const Wrapper = styled.div`
     display: flex;
@@ -25,7 +25,7 @@ const Description = styled.div`
     display: flex;
     align-items: center;
     justify-content: center;
-    color: ${props => props.theme.TYPE_LIGHT_GREY};
+    color: ${({ theme }) => theme.TYPE_LIGHT_GREY};
     font-weight: ${variables.FONT_WEIGHT.MEDIUM};
     margin: 17px 0 10px 0;
     max-width: 310px;
@@ -37,17 +37,27 @@ const StyledLink = styled(Link)`
     margin-bottom: 20px;
 `;
 
-interface Props {
+interface PaymentKYCProps {
     transactionId?: string;
     supportUrl?: string;
     provider?: ExchangeProviderInfo;
     account: Account;
 }
 
-const PaymentKYC = ({ transactionId, supportUrl, provider, account }: Props) => {
-    const { goto } = useActions({
-        goto: routerActions.goto,
-    });
+const PaymentKYC = ({ transactionId, supportUrl, provider, account }: PaymentKYCProps) => {
+    const dispatch = useDispatch();
+
+    const goToExchange = () =>
+        dispatch(
+            goto('wallet-coinmarket-exchange', {
+                params: {
+                    symbol: account.symbol,
+                    accountIndex: account.index,
+                    accountType: account.accountType,
+                },
+            }),
+        );
+
     return (
         <Wrapper>
             <Image image="UNI_WARNING" />
@@ -72,17 +82,7 @@ const PaymentKYC = ({ transactionId, supportUrl, provider, account }: Props) => 
                     </Button>
                 </Link>
             )}
-            <Button
-                onClick={() =>
-                    goto('wallet-coinmarket-exchange', {
-                        params: {
-                            symbol: account.symbol,
-                            accountIndex: account.index,
-                            accountType: account.accountType,
-                        },
-                    })
-                }
-            >
+            <Button onClick={goToExchange}>
                 <Translation id="TR_EXCHANGE_DETAIL_KYC_BUTTON" />
             </Button>
         </Wrapper>

--- a/packages/suite/src/views/wallet/coinmarket/exchange/detail/components/PaymentSending/index.tsx
+++ b/packages/suite/src/views/wallet/coinmarket/exchange/detail/components/PaymentSending/index.tsx
@@ -20,11 +20,11 @@ const StyledLink = styled(Link)`
     margin-top: 50px;
 `;
 
-interface Props {
+interface PaymentSendingProps {
     supportUrl?: string;
 }
 
-const PaymentSending = ({ supportUrl }: Props) => (
+const PaymentSending = ({ supportUrl }: PaymentSendingProps) => (
     <Wrapper>
         <Loader />
         <Title>

--- a/packages/suite/src/views/wallet/coinmarket/exchange/detail/components/PaymentSuccessful/index.tsx
+++ b/packages/suite/src/views/wallet/coinmarket/exchange/detail/components/PaymentSuccessful/index.tsx
@@ -1,10 +1,10 @@
-import * as routerActions from 'src/actions/suite/routerActions';
 import React from 'react';
 import styled from 'styled-components';
 import { Button, variables, Image } from '@trezor/components';
 import { Translation } from 'src/components/suite';
-import { useActions } from 'src/hooks/suite';
+import { useDispatch } from 'src/hooks/suite';
 import { Account } from 'src/types/wallet';
+import { goto } from 'src/actions/suite/routerActions';
 
 const Wrapper = styled.div`
     display: flex;
@@ -23,21 +23,31 @@ const Description = styled.div`
     display: flex;
     align-items: center;
     justify-content: center;
-    color: ${props => props.theme.TYPE_LIGHT_GREY};
+    color: ${({ theme }) => theme.TYPE_LIGHT_GREY};
     font-weight: ${variables.FONT_WEIGHT.MEDIUM};
     margin: 17px 0 30px 0;
     max-width: 310px;
     text-align: center;
 `;
 
-interface Props {
+interface PaymentSuccessfulProps {
     account: Account;
 }
 
-const PaymentSuccessful = ({ account }: Props) => {
-    const { goto } = useActions({
-        goto: routerActions.goto,
-    });
+const PaymentSuccessful = ({ account }: PaymentSuccessfulProps) => {
+    const dispatch = useDispatch();
+
+    const handleClick = () =>
+        dispatch(
+            goto('wallet-coinmarket-exchange', {
+                params: {
+                    symbol: account.symbol,
+                    accountIndex: account.index,
+                    accountType: account.accountType,
+                },
+            }),
+        );
+
     return (
         <Wrapper>
             <Image image="COINMARKET_SUCCESS" />
@@ -47,18 +57,7 @@ const PaymentSuccessful = ({ account }: Props) => {
             <Description>
                 <Translation id="TR_EXCHANGE_DETAIL_SUCCESS_TEXT" />
             </Description>
-            <Button
-                data-test="@coinmarket/exchange/payment/back-to-account"
-                onClick={() =>
-                    goto('wallet-coinmarket-exchange', {
-                        params: {
-                            symbol: account.symbol,
-                            accountIndex: account.index,
-                            accountType: account.accountType,
-                        },
-                    })
-                }
-            >
+            <Button data-test="@coinmarket/exchange/payment/back-to-account" onClick={handleClick}>
                 <Translation id="TR_EXCHANGE_DETAIL_SUCCESS_BUTTON" />
             </Button>
         </Wrapper>

--- a/packages/suite/src/views/wallet/coinmarket/exchange/offers/Offers/List/Quote/index.tsx
+++ b/packages/suite/src/views/wallet/coinmarket/exchange/offers/Offers/List/Quote/index.tsx
@@ -20,7 +20,7 @@ const Wrapper = styled.div`
     flex: 1;
     width: 100%;
     min-height: 150px;
-    background: ${props => props.theme.BG_WHITE};
+    background: ${({ theme }) => theme.BG_WHITE};
 `;
 
 const Main = styled.div`
@@ -28,7 +28,7 @@ const Main = styled.div`
     margin: 0 30px;
     justify-content: space-between;
     padding: 20px 0;
-    border-bottom: 1px solid ${props => props.theme.STROKE_GREY};
+    border-bottom: 1px solid ${({ theme }) => theme.STROKE_GREY};
 
     @media (max-width: ${variables.SCREEN_SIZE.SM}) {
         flex-direction: column;
@@ -74,14 +74,14 @@ const Column = styled.div<ColumnProps>`
     flex: 1;
     flex-direction: column;
     justify-content: flex-start;
-    max-width: ${props => (props.maxWidth ? props.maxWidth : '100%')};
+    max-width: ${({ maxWidth }) => maxWidth ?? '100%'};
 `;
 
 const Heading = styled.div`
     display: flex;
     text-transform: uppercase;
     align-items: center;
-    color: ${props => props.theme.TYPE_LIGHT_GREY};
+    color: ${({ theme }) => theme.TYPE_LIGHT_GREY};
     font-weight: ${variables.FONT_WEIGHT.DEMI_BOLD};
     padding-bottom: 9px;
 `;
@@ -97,7 +97,7 @@ const StyledButton = styled(Button)`
 const Value = styled.div`
     display: flex;
     align-items: center;
-    color: ${props => props.theme.TYPE_DARK_GREY};
+    color: ${({ theme }) => theme.TYPE_DARK_GREY};
     font-weight: ${variables.FONT_WEIGHT.MEDIUM};
 `;
 
@@ -105,8 +105,8 @@ const Footer = styled.div`
     margin: 0 30px;
     padding: 10px 0;
     padding-top: 23px;
-    color: ${props => props.theme.TYPE_LIGHT_GREY};
-    border-top: 1px solid ${props => props.theme.STROKE_GREY};
+    color: ${({ theme }) => theme.TYPE_LIGHT_GREY};
+    border-top: 1px solid ${({ theme }) => theme.STROKE_GREY};
     font-weight: ${variables.FONT_WEIGHT.MEDIUM};
     font-size: ${variables.FONT_SIZE.SMALL};
 
@@ -119,8 +119,8 @@ const ErrorFooter = styled.div`
     display: flex;
     margin: 0 30px;
     padding: 20px 0;
-    border-top: 1px solid ${props => props.theme.STROKE_GREY};
-    color: ${props => props.theme.TYPE_RED};
+    border-top: 1px solid ${({ theme }) => theme.STROKE_GREY};
+    color: ${({ theme }) => theme.TYPE_RED};
 
     @media (max-width: ${variables.SCREEN_SIZE.SM}) {
         margin: 0 20px;
@@ -135,26 +135,17 @@ const IconWrapper = styled.div`
     padding-right: 3px;
 `;
 
-const ErrorText = styled.div``;
-
 const StyledQuestionTooltip = styled(QuestionTooltip)`
     padding-left: 4px;
-    color: ${props => props.theme.TYPE_LIGHT_GREY};
+    color: ${({ theme }) => theme.TYPE_LIGHT_GREY};
 `;
 
 const DexFooter = styled.div`
     display: flex;
     margin: 0 30px;
     padding: 20px 0;
-    border-top: 1px solid ${props => props.theme.STROKE_GREY};
+    border-top: 1px solid ${({ theme }) => theme.STROKE_GREY};
 `;
-
-const DexText = styled.div``;
-
-interface Props {
-    className?: string;
-    quote: ExchangeTrade;
-}
 
 function getQuoteError(quote: ExchangeTrade) {
     const cryptoAmount = Number(quote.sendStringAmount);
@@ -184,7 +175,12 @@ function getQuoteError(quote: ExchangeTrade) {
     return quote.error;
 }
 
-const Quote = ({ className, quote }: Props) => {
+interface QuoteProps {
+    className?: string;
+    quote: ExchangeTrade;
+}
+
+const Quote = ({ className, quote }: QuoteProps) => {
     const { FiatAmountFormatter } = useFormatters();
 
     const theme = useTheme();
@@ -192,11 +188,12 @@ const Quote = ({ className, quote }: Props) => {
 
     const { account, selectQuote, exchangeInfo, callInProgress } =
         useCoinmarketExchangeOffersContext();
-    const { feePerByte, fiat, localCurrency } = useSelector(state => ({
-        feePerByte: state.wallet.coinmarket.composedTransactionInfo.composed?.feePerByte,
-        fiat: state.wallet.fiat,
-        localCurrency: state.wallet.settings.localCurrency,
-    }));
+
+    const feePerByte = useSelector(
+        state => state.wallet.coinmarket.composedTransactionInfo.composed?.feePerByte,
+    );
+    const fiat = useSelector(state => state.wallet.fiat);
+    const localCurrency = useSelector(state => state.wallet.settings.localCurrency);
 
     const { tag, infoNote } = getTagAndInfoNote(quote);
     const { exchange, receive, receiveStringAmount } = quote;
@@ -277,7 +274,7 @@ const Quote = ({ className, quote }: Props) => {
             </Details>
             {approvalFee && swapFee && localCurrency && (
                 <DexFooter>
-                    <DexText>
+                    <div>
                         <Translation
                             id="TR_EXCHANGE_DEX_OFFER_FEE_INFO"
                             values={{
@@ -311,7 +308,7 @@ const Quote = ({ className, quote }: Props) => {
                                 ),
                             }}
                         />
-                    </DexText>
+                    </div>
                 </DexFooter>
             )}
             {errorQuote && (
@@ -319,7 +316,7 @@ const Quote = ({ className, quote }: Props) => {
                     <IconWrapper>
                         <StyledIcon icon="CROSS" size={12} color={theme.TYPE_RED} />
                     </IconWrapper>
-                    <ErrorText>{noFundsForFeesError || getQuoteError(quote)}</ErrorText>
+                    <div>{noFundsForFeesError || getQuoteError(quote)}</div>
                 </ErrorFooter>
             )}
 

--- a/packages/suite/src/views/wallet/coinmarket/exchange/offers/Offers/List/index.tsx
+++ b/packages/suite/src/views/wallet/coinmarket/exchange/offers/Offers/List/index.tsx
@@ -76,9 +76,8 @@ const List = ({ quotes, type }: Props) => {
         quotesRequest,
         account: { symbol },
     } = useCoinmarketExchangeOffersContext();
-    const { fee } = useSelector(state => ({
-        fee: state.wallet.coinmarket.composedTransactionInfo.composed?.fee,
-    }));
+    const fee = useSelector(state => state.wallet.coinmarket.composedTransactionInfo.composed?.fee);
+
     if (!quotesRequest || !quotes) return null;
 
     return (

--- a/packages/suite/src/views/wallet/coinmarket/exchange/offers/Offers/List/index.tsx
+++ b/packages/suite/src/views/wallet/coinmarket/exchange/offers/Offers/List/index.tsx
@@ -66,12 +66,12 @@ const RatesRow = styled.div`
     align-items: center;
 `;
 
-interface Props {
+interface ListProps {
     quotes?: ExchangeTrade[];
     type: 'float' | 'fixed' | 'dex';
 }
 
-const List = ({ quotes, type }: Props) => {
+const List = ({ quotes, type }: ListProps) => {
     const {
         quotesRequest,
         account: { symbol },

--- a/packages/suite/src/views/wallet/coinmarket/exchange/offers/Offers/List/index.tsx
+++ b/packages/suite/src/views/wallet/coinmarket/exchange/offers/Offers/List/index.tsx
@@ -24,7 +24,7 @@ const SummaryRow = styled.div`
     display: flex;
     align-items: center;
     justify-content: space-between;
-    color: ${props => props.theme.TYPE_DARK_GREY};
+    color: ${({ theme }) => theme.TYPE_DARK_GREY};
     font-size: ${variables.FONT_SIZE.NORMAL};
     font-weight: ${variables.FONT_WEIGHT.DEMI_BOLD};
     padding: 10px 0;
@@ -41,7 +41,7 @@ const Divider = styled.div`
 const DividerLine = styled.div`
     height: 1px;
     flex: 1;
-    background: ${props => props.theme.STROKE_GREY};
+    background: ${({ theme }) => theme.STROKE_GREY};
 `;
 
 const Left = styled.div`
@@ -57,7 +57,7 @@ const Right = styled.div`
 const StyledQuestionTooltip = styled(QuestionTooltip)`
     padding-left: 4px;
     padding-top: 1px;
-    color: ${props => props.theme.TYPE_LIGHT_GREY};
+    color: ${({ theme }) => theme.TYPE_LIGHT_GREY};
 `;
 
 const RatesRow = styled.div`

--- a/packages/suite/src/views/wallet/coinmarket/exchange/offers/Offers/SelectedOffer/components/SendApprovalTransaction/index.tsx
+++ b/packages/suite/src/views/wallet/coinmarket/exchange/offers/Offers/SelectedOffer/components/SendApprovalTransaction/index.tsx
@@ -20,13 +20,13 @@ const Wrapper = styled.div`
 
 const LabelText = styled.div`
     font-size: ${variables.FONT_SIZE.TINY};
-    color: ${props => props.theme.TYPE_LIGHT_GREY};
+    color: ${({ theme }) => theme.TYPE_LIGHT_GREY};
 `;
 
 const Value = styled.div`
     padding-top: 6px;
     font-size: ${variables.FONT_SIZE.SMALL};
-    color: ${props => props.theme.TYPE_DARK_GREY};
+    color: ${({ theme }) => theme.TYPE_DARK_GREY};
     font-weight: ${variables.FONT_WEIGHT.MEDIUM};
 `;
 
@@ -39,7 +39,7 @@ const ButtonWrapper = styled.div`
     align-items: center;
     justify-content: center;
     padding-top: 20px;
-    border-top: 1px solid ${props => props.theme.STROKE_GREY};
+    border-top: 1px solid ${({ theme }) => theme.STROKE_GREY};
     margin: 20px 0;
 `;
 
@@ -70,7 +70,7 @@ const LoaderWrapper = styled.div`
 `;
 
 const ErrorWrapper = styled(LoaderWrapper)`
-    color: ${props => props.theme.TYPE_RED};
+    color: ${({ theme }) => theme.TYPE_RED};
 `;
 
 const REFRESH_SECONDS = 15;

--- a/packages/suite/src/views/wallet/coinmarket/exchange/offers/Offers/SelectedOffer/components/SendSwapTransaction/index.tsx
+++ b/packages/suite/src/views/wallet/coinmarket/exchange/offers/Offers/SelectedOffer/components/SendSwapTransaction/index.tsx
@@ -25,13 +25,13 @@ const Wrapper = styled.div`
 
 const LabelText = styled.div`
     font-size: ${variables.FONT_SIZE.TINY};
-    color: ${props => props.theme.TYPE_LIGHT_GREY};
+    color: ${({ theme }) => theme.TYPE_LIGHT_GREY};
 `;
 
 const Value = styled.div`
     padding-top: 6px;
     font-size: ${variables.FONT_SIZE.SMALL};
-    color: ${props => props.theme.TYPE_DARK_GREY};
+    color: ${({ theme }) => theme.TYPE_DARK_GREY};
     font-weight: ${variables.FONT_WEIGHT.MEDIUM};
 `;
 
@@ -48,7 +48,7 @@ const ButtonWrapper = styled.div`
     align-items: center;
     justify-content: center;
     padding-top: 20px;
-    border-top: 1px solid ${props => props.theme.STROKE_GREY};
+    border-top: 1px solid ${({ theme }) => theme.STROKE_GREY};
     margin: 20px 0;
 `;
 
@@ -79,7 +79,7 @@ const RightColumn = styled.div`
 `;
 
 const Slippage = styled.div`
-    color: ${props => props.theme.TYPE_DARK_GREY};
+    color: ${({ theme }) => theme.TYPE_DARK_GREY};
     font-weight: ${variables.FONT_WEIGHT.MEDIUM};
 `;
 

--- a/packages/suite/src/views/wallet/coinmarket/exchange/offers/Offers/SelectedOffer/components/SendTransaction/index.tsx
+++ b/packages/suite/src/views/wallet/coinmarket/exchange/offers/Offers/SelectedOffer/components/SendTransaction/index.tsx
@@ -12,13 +12,13 @@ const Wrapper = styled.div`
 
 const LabelText = styled.div`
     font-size: ${variables.FONT_SIZE.TINY};
-    color: ${props => props.theme.TYPE_LIGHT_GREY};
+    color: ${({ theme }) => theme.TYPE_LIGHT_GREY};
 `;
 
 const Value = styled.div`
     padding-top: 6px;
     font-size: ${variables.FONT_SIZE.SMALL};
-    color: ${props => props.theme.TYPE_DARK_GREY};
+    color: ${({ theme }) => theme.TYPE_DARK_GREY};
     font-weight: ${variables.FONT_WEIGHT.MEDIUM};
 `;
 
@@ -27,7 +27,7 @@ const ButtonWrapper = styled.div`
     align-items: center;
     justify-content: center;
     padding-top: 20px;
-    border-top: 1px solid ${props => props.theme.STROKE_GREY};
+    border-top: 1px solid ${({ theme }) => theme.STROKE_GREY};
     margin: 20px 0;
 `;
 

--- a/packages/suite/src/views/wallet/coinmarket/exchange/offers/Offers/SelectedOffer/components/VerifyAddress/ReceiveOptions.tsx
+++ b/packages/suite/src/views/wallet/coinmarket/exchange/offers/Offers/SelectedOffer/components/VerifyAddress/ReceiveOptions.tsx
@@ -8,8 +8,8 @@ import {
     AccountLabeling,
     FormattedCryptoAmount,
 } from 'src/components/suite';
-import { useActions } from 'src/hooks/suite';
-import * as modalActions from 'src/actions/suite/modalActions';
+import { useDispatch } from 'src/hooks/suite';
+import { openModal } from 'src/actions/suite/modalActions';
 import { useCoinmarketExchangeOffersContext } from 'src/hooks/wallet/useCoinmarketExchangeOffers';
 import { getUnusedAddressFromAccount } from 'src/utils/wallet/coinmarket/coinmarketUtils';
 import type { UseFormReturn } from 'react-hook-form';
@@ -38,7 +38,7 @@ const FiatWrapper = styled.div`
 const Amount = styled.div`
     display: flex;
     font-size: ${variables.FONT_SIZE.TINY};
-    color: ${props => props.theme.TYPE_LIGHT_GREY};
+    color: ${({ theme }) => theme.TYPE_LIGHT_GREY};
     font-weight: ${variables.FONT_WEIGHT.MEDIUM};
 `;
 
@@ -53,7 +53,7 @@ const Option = styled.div`
 `;
 
 const AccountType = styled.span`
-    color: ${props => props.theme.TYPE_LIGHT_GREY};
+    color: ${({ theme }) => theme.TYPE_LIGHT_GREY};
     padding-left: 5px;
 `;
 
@@ -66,16 +66,14 @@ type FormState = {
     address?: string;
 };
 
-type Props = Pick<UseFormReturn<FormState>, 'setValue'> & {
+type ReceiveOptionsProps = Pick<UseFormReturn<FormState>, 'setValue'> & {
     selectedAccountOption?: AccountSelectOption;
     setSelectedAccountOption: (o: AccountSelectOption) => void;
 };
 
-export const ReceiveOptions = (props: Props) => {
+export const ReceiveOptions = (props: ReceiveOptionsProps) => {
     const theme = useTheme();
-    const { openModal } = useActions({
-        openModal: modalActions.openModal,
-    });
+    const dispatch = useDispatch();
     const { device, suiteReceiveAccounts, receiveSymbol, setReceiveAccount } =
         useCoinmarketExchangeOffersContext();
     const [menuIsOpen, setMenuIsOpen] = useState<boolean | undefined>(undefined);
@@ -107,12 +105,14 @@ export const ReceiveOptions = (props: Props) => {
         if (account.type === 'ADD_SUITE') {
             if (device) {
                 setMenuIsOpen(true);
-                openModal({
-                    type: 'add-account',
-                    device: device!,
-                    symbol: receiveSymbol as Account['symbol'],
-                    noRedirect: true,
-                });
+                dispatch(
+                    openModal({
+                        type: 'add-account',
+                        device: device!,
+                        symbol: receiveSymbol as Account['symbol'],
+                        noRedirect: true,
+                    }),
+                );
             }
         } else {
             selectAccountOption(account);
@@ -129,9 +129,7 @@ export const ReceiveOptions = (props: Props) => {
 
     return (
         <Select
-            onChange={(selected: any) => {
-                onChangeAccount(selected);
-            }}
+            onChange={(selected: any) => onChangeAccount(selected)}
             value={selectedAccountOption}
             isClearable={false}
             options={selectAccountOptions}

--- a/packages/suite/src/views/wallet/coinmarket/exchange/offers/Offers/SelectedOffer/components/VerifyAddress/index.tsx
+++ b/packages/suite/src/views/wallet/coinmarket/exchange/offers/Offers/SelectedOffer/components/VerifyAddress/index.tsx
@@ -18,7 +18,7 @@ const Wrapper = styled.div`
 `;
 
 const Heading = styled.div`
-    color: ${props => props.theme.TYPE_LIGHT_GREY};
+    color: ${({ theme }) => theme.TYPE_LIGHT_GREY};
     padding: 16px 24px 0 24px;
     font-weight: ${variables.FONT_WEIGHT.MEDIUM};
     font-size: ${variables.FONT_SIZE.SMALL};
@@ -54,7 +54,7 @@ const ButtonWrapper = styled.div`
     align-items: center;
     justify-content: center;
     padding-top: 20px;
-    border-top: 1px solid ${props => props.theme.STROKE_GREY};
+    border-top: 1px solid ${({ theme }) => theme.STROKE_GREY};
     margin: 20px 0;
 `;
 
@@ -63,7 +63,7 @@ const Confirmed = styled.div`
     height: 60px;
     font-size: ${variables.FONT_SIZE.BIG};
     font-weight: ${variables.FONT_WEIGHT.MEDIUM};
-    background: ${props => props.theme.BG_GREY};
+    background: ${({ theme }) => theme.BG_GREY};
     align-items: center;
     justify-content: center;
     margin-top: 27px;

--- a/packages/suite/src/views/wallet/coinmarket/exchange/offers/Offers/SelectedOffer/index.tsx
+++ b/packages/suite/src/views/wallet/coinmarket/exchange/offers/Offers/SelectedOffer/index.tsx
@@ -28,7 +28,7 @@ const Header = styled.div`
     align-items: center;
     justify-content: center;
     padding: 10px 25px;
-    border-bottom: 1px solid ${props => props.theme.STROKE_GREY};
+    border-bottom: 1px solid ${({ theme }) => theme.STROKE_GREY};
 `;
 
 interface ActiveProps {
@@ -36,10 +36,9 @@ interface ActiveProps {
 }
 
 const Step = styled.div<ActiveProps>`
-    font-weight: ${props =>
-        props.active ? variables.FONT_WEIGHT.DEMI_BOLD : variables.FONT_WEIGHT.MEDIUM};
-    color: ${props =>
-        props.active ? props => props.theme.TYPE_GREEN : props.theme.TYPE_LIGHT_GREY};
+    font-weight: ${({ active }) =>
+        active ? variables.FONT_WEIGHT.DEMI_BOLD : variables.FONT_WEIGHT.MEDIUM};
+    color: ${({ active, theme }) => (active ? theme.TYPE_GREEN : theme.TYPE_LIGHT_GREY)};
     display: flex;
     font-size: ${variables.FONT_SIZE.SMALL};
     flex: 1;
@@ -63,7 +62,7 @@ const Middle = styled.div`
     height: 48px;
     align-items: center;
     justify-content: center;
-    color: ${props => props.theme.STROKE_GREY};
+    color: ${({ theme }) => theme.STROKE_GREY};
 `;
 
 const MiddleNarrow = styled.div`
@@ -71,7 +70,7 @@ const MiddleNarrow = styled.div`
     height: 48px;
     align-items: center;
     justify-content: center;
-    color: ${props => props.theme.STROKE_GREY};
+    color: ${({ theme }) => theme.STROKE_GREY};
 `;
 
 const SelectedOffer = () => {

--- a/packages/suite/src/views/wallet/coinmarket/index.tsx
+++ b/packages/suite/src/views/wallet/coinmarket/index.tsx
@@ -53,7 +53,7 @@ export const StyledIcon = styled(Icon)<ResponsiveSize>`
 
 export const FeesWrapper = styled.div`
     margin: 25px 0;
-    border-top: 1px solid ${props => props.theme.STROKE_GREY};
+    border-top: 1px solid ${({ theme }) => theme.STROKE_GREY};
 `;
 
 export const NoProviders = styled.div`
@@ -65,7 +65,7 @@ export const FooterWrapper = styled.div`
     display: flex;
     align-items: center;
     padding-top: 30px;
-    border-top: 1px solid ${props => props.theme.STROKE_GREY};
+    border-top: 1px solid ${({ theme }) => theme.STROKE_GREY};
 
     @media screen and (max-width: ${variables.SCREEN_SIZE.MD}) {
         flex-direction: column;

--- a/packages/suite/src/views/wallet/coinmarket/p2p/offers/SelectedOffer/OfferDetails.tsx
+++ b/packages/suite/src/views/wallet/coinmarket/p2p/offers/SelectedOffer/OfferDetails.tsx
@@ -8,13 +8,6 @@ import { CoinmarketProviderInfo } from 'src/components/wallet';
 import { P2pProviderInfo, P2pQuote, P2pQuotesRequest } from 'invity-api';
 import { Avatar } from '../Avatar';
 
-interface Props {
-    account: Account;
-    providers?: { [name: string]: P2pProviderInfo };
-    quotesRequest: P2pQuotesRequest;
-    selectedQuote: P2pQuote;
-}
-
 const Wrapper = styled.div`
     display: flex;
     flex-direction: column;
@@ -91,7 +84,19 @@ const Dark = styled.div`
     color: ${({ theme }) => theme.TYPE_DARK_GREY};
 `;
 
-export const OfferDetails = ({ account, providers, quotesRequest, selectedQuote }: Props) => {
+interface OfferDetailsProps {
+    account: Account;
+    providers?: { [name: string]: P2pProviderInfo };
+    quotesRequest: P2pQuotesRequest;
+    selectedQuote: P2pQuote;
+}
+
+export const OfferDetails = ({
+    account,
+    providers,
+    quotesRequest,
+    selectedQuote,
+}: OfferDetailsProps) => {
     const { FiatAmountFormatter } = useFormatters();
     const { amount, currency } = quotesRequest;
     const { provider, trader, paymentWindowMinutes, confirmations } = selectedQuote;

--- a/packages/suite/src/views/wallet/coinmarket/p2p/offers/SelectedOffer/ReceivingAddressStep.tsx
+++ b/packages/suite/src/views/wallet/coinmarket/p2p/offers/SelectedOffer/ReceivingAddressStep.tsx
@@ -1,11 +1,11 @@
 import React from 'react';
 import styled from 'styled-components';
-import { useActions, useDevice } from 'src/hooks/suite';
+import { useDevice, useDispatch } from 'src/hooks/suite';
 import { Translation } from 'src/components/suite';
-import * as routerActions from 'src/actions/suite/routerActions';
+import { goto } from 'src/actions/suite/routerActions';
 import { Button, variables } from '@trezor/components';
 import { useCoinmarketP2pOffersContext } from 'src/hooks/wallet/useCoinmarketP2pOffers';
-import * as receiveActions from 'src/actions/wallet/receiveActions';
+import { showAddress } from 'src/actions/wallet/receiveActions';
 import { getUnusedAddressFromAccount } from 'src/utils/wallet/coinmarket/coinmarketUtils';
 
 const Wrapper = styled.div`
@@ -54,7 +54,7 @@ const Overlay = styled.div`
     background-image: linear-gradient(
         to right,
         rgba(0, 0, 0, 0) 0%,
-        ${props => props.theme.BG_WHITE} 120px
+        ${({ theme }) => theme.BG_WHITE} 120px
     );
 `;
 
@@ -80,18 +80,18 @@ export const ReceivingAddressStep = () => {
     const { isLocked } = useDevice();
     const { providers, account, selectedQuote, callInProgress, goToProvider, providerVisited } =
         useCoinmarketP2pOffersContext();
-    const { address: unusedAddress, path } = getUnusedAddressFromAccount(account);
+    const dispatch = useDispatch();
 
-    const { goto, showAddress } = useActions({
-        goto: routerActions.goto,
-        showAddress: receiveActions.showAddress,
-    });
+    const { address: unusedAddress, path } = getUnusedAddressFromAccount(account);
 
     if (!providers || !selectedQuote || !unusedAddress) {
         return null;
     }
 
     const providerName = providers[selectedQuote.provider].companyName;
+
+    const handleAddressReveal = () => dispatch(showAddress(path, unusedAddress));
+    const goToP2p = () => dispatch(goto('wallet-coinmarket-p2p', { preserveParams: true }));
 
     return (
         <Wrapper>
@@ -110,7 +110,7 @@ export const ReceivingAddressStep = () => {
                             icon="TREZOR_LOGO"
                             isDisabled={isLocked()}
                             isLoading={isLocked()}
-                            onClick={() => showAddress(path, unusedAddress)}
+                            onClick={handleAddressReveal}
                         >
                             <Translation id="TR_P2P_REVEAL_ADDRESS" />
                         </StyledButton>
@@ -136,9 +136,7 @@ export const ReceivingAddressStep = () => {
                     <Translation id="TR_P2P_GO_TO_PROVIDER" values={{ providerName }} />
                 </StyledButton>
                 {providerVisited && (
-                    <StyledButton
-                        onClick={() => goto('wallet-coinmarket-p2p', { preserveParams: true })}
-                    >
+                    <StyledButton onClick={goToP2p}>
                         <Translation id="TR_P2P_BACK_TO_ACCOUNT" />
                     </StyledButton>
                 )}

--- a/packages/suite/src/views/wallet/coinmarket/savings/overview/components/PaymentDetail/index.tsx
+++ b/packages/suite/src/views/wallet/coinmarket/savings/overview/components/PaymentDetail/index.tsx
@@ -29,7 +29,7 @@ const IconWrapper = styled.div`
 `;
 
 const PaymentItem = styled.div`
-    border: 1px solid ${props => props.theme.STROKE_GREY};
+    border: 1px solid ${({ theme }) => theme.STROKE_GREY};
     border-radius: 8px;
     display: flex;
     flex-direction: column;
@@ -42,13 +42,13 @@ const PaymentItem = styled.div`
 const PaymentItemDate = styled.div`
     margin: 4px 0;
     padding: 9px 38px;
-    border-right: 1px solid ${props => props.theme.STROKE_GREY};
+    border-right: 1px solid ${({ theme }) => theme.STROKE_GREY};
     width: 25%;
 `;
 
 const PaymentItemStatus = styled.div<{ isNextUp: boolean; isPaymentInfoAvailable: boolean }>`
-    margin: ${props => (props.isPaymentInfoAvailable ? '13px 38px' : '0 auto')};
-    color: ${props => (props.isNextUp ? props.theme.TYPE_ORANGE : props.theme.TYPE_LIGHT_GREY)};
+    margin: ${({ isPaymentInfoAvailable }) => (isPaymentInfoAvailable ? '13px 38px' : '0 auto')};
+    color: ${({ isNextUp, theme }) => (isNextUp ? theme.TYPE_ORANGE : theme.TYPE_LIGHT_GREY)};
     display: flex;
     flex-direction: row;
     align-items: center;
@@ -70,7 +70,7 @@ const PaymentItemStatusIconReactSVG = styled(Image)<{ isNextUp: boolean }>`
         display: flex;
     }
     & path {
-        fill: ${props => (props.isNextUp ? props.theme.TYPE_ORANGE : props.theme.TYPE_LIGHT_GREY)};
+        fill: ${({ isNextUp, theme }) => (isNextUp ? theme.TYPE_ORANGE : theme.TYPE_LIGHT_GREY)};
     }
 `;
 
@@ -84,7 +84,7 @@ const PaymentInfoItemLabel = styled.div`
     font-weight: 600;
     font-size: 12px;
     line-height: 24px;
-    color: ${props => props.theme.TYPE_LIGHT_GREY};
+    color: ${({ theme }) => theme.TYPE_LIGHT_GREY};
 `;
 const PaymentInfoItemValue = styled.div`
     display: flex;
@@ -101,7 +101,7 @@ const Row = styled.div`
     justify-content: space-between;
     text-align: center;
     ${PaymentItem} &:nth-child(2) {
-        border-top: 1px solid ${props => props.theme.STROKE_GREY};
+        border-top: 1px solid ${({ theme }) => theme.STROKE_GREY};
     }
 `;
 

--- a/packages/suite/src/views/wallet/coinmarket/savings/overview/components/WaitingForFirstPayment/index.tsx
+++ b/packages/suite/src/views/wallet/coinmarket/savings/overview/components/WaitingForFirstPayment/index.tsx
@@ -20,7 +20,7 @@ const Header = styled.div`
     line-height: 28px;
 `;
 const Description = styled.div`
-    color: ${props => props.theme.TYPE_LIGHT_GREY};
+    color: ${({ theme }) => theme.TYPE_LIGHT_GREY};
     font-size: 14px;
     line-height: 18px;
 `;

--- a/packages/suite/src/views/wallet/coinmarket/savings/overview/index.tsx
+++ b/packages/suite/src/views/wallet/coinmarket/savings/overview/index.tsx
@@ -57,7 +57,7 @@ const HeaderBlock = styled.div`
     height: 120px;
 `;
 const Setup = styled(HeaderBlock)`
-    background-color: ${props => props.theme.BG_GREY};
+    background-color: ${({ theme }) => theme.BG_GREY};
     padding: 21px;
     border-radius: 8px;
     margin-right: 12px;
@@ -74,14 +74,14 @@ const StyledFiatValue = styled(FiatValue)`
 const Period = styled.div`
     font-size: 16px;
     line-height: 24px;
-    color: ${props => props.theme.TYPE_LIGHT_GREY};
+    color: ${({ theme }) => theme.TYPE_LIGHT_GREY};
 `;
 
 const SoFarSaved = styled.div`
     display: flex;
     flex-direction: column;
     align-items: flex-end;
-    background-color: ${props => props.theme.BG_WHITE};
+    background-color: ${({ theme }) => theme.BG_WHITE};
     padding: 21px 0 0 21px;
     width: 100%;
 `;
@@ -89,14 +89,14 @@ const SoFarSaved = styled.div`
 const Crypto = styled.div`
     font-size: 20px;
     line-height: 28px;
-    color: ${props => props.theme.TYPE_GREEN};
+    color: ${({ theme }) => theme.TYPE_GREEN};
     display: flex;
 `;
 
 const Fiat = styled(HiddenPlaceholder)`
     font-size: 20px;
     line-height: 28px;
-    color: ${props => props.theme.TYPE_LIGHT_GREY};
+    color: ${({ theme }) => theme.TYPE_LIGHT_GREY};
     display: flex;
 `;
 
@@ -113,7 +113,7 @@ const StyledIcon = styled(Icon)`
         width: 26px;
         height: 26px;
         border-radius: 50%;
-        background: ${props => darken(0.1)(props.theme.BG_GREY)};
+        background: ${({ theme }) => darken(0.1)(theme.BG_GREY)};
     }
 `;
 

--- a/packages/suite/src/views/wallet/coinmarket/savings/payment-info/index.tsx
+++ b/packages/suite/src/views/wallet/coinmarket/savings/payment-info/index.tsx
@@ -21,14 +21,14 @@ const Header = styled.div`
 const Description = styled.div`
     font-size: 14px;
     line-height: 24px;
-    color: ${props => props.theme.TYPE_LIGHT_GREY};
+    color: ${({ theme }) => theme.TYPE_LIGHT_GREY};
     margin-bottom: 13px;
 `;
 
 const Divider = styled.div`
     height: 1px;
     width: 100%;
-    border: 1px solid ${props => props.theme.BG_GREY};
+    border: 1px solid ${({ theme }) => theme.BG_GREY};
 `;
 
 const Setup = styled.div`
@@ -43,7 +43,7 @@ const Setup = styled.div`
 const Values = styled.div`
     font-size: 16px;
     line-height: 24px;
-    color: ${props => props.theme.TYPE_GREEN};
+    color: ${({ theme }) => theme.TYPE_GREEN};
 `;
 
 const PaymentInfoOverview = styled.div`
@@ -63,7 +63,7 @@ const PaymentInfoItemLabel = styled.div`
     font-weight: 600;
     font-size: 12px;
     line-height: 24px;
-    color: ${props => props.theme.TYPE_LIGHT_GREY};
+    color: ${({ theme }) => theme.TYPE_LIGHT_GREY};
 `;
 const PaymentInfoItemValue = styled.div`
     display: flex;

--- a/packages/suite/src/views/wallet/coinmarket/savings/setup/components/Summary/index.tsx
+++ b/packages/suite/src/views/wallet/coinmarket/savings/setup/components/Summary/index.tsx
@@ -42,7 +42,7 @@ const Crypto = styled.div`
     display: flex;
 `;
 
-interface Props {
+interface SummaryProps {
     fiatCurrency?: string;
     annualSavingsFiatAmount: number;
     annualSavingsCryptoAmount: string;
@@ -54,7 +54,7 @@ const Summary = ({
     annualSavingsCryptoAmount,
     annualSavingsFiatAmount,
     fiatCurrency,
-}: Props) => (
+}: SummaryProps) => (
     <SummaryWrapper>
         <Left>
             <Translation id="TR_SAVINGS_SETUP_SUMMARY_LABEL" />

--- a/packages/suite/src/views/wallet/coinmarket/savings/setup/components/Summary/index.tsx
+++ b/packages/suite/src/views/wallet/coinmarket/savings/setup/components/Summary/index.tsx
@@ -7,8 +7,8 @@ import { NetworkSymbol } from 'src/types/wallet';
 const SummaryWrapper = styled.div`
     display: flex;
     justify-content: space-between;
-    border-top: 1px solid ${props => props.theme.BG_GREY};
-    border-bottom: 1px solid ${props => props.theme.BG_GREY};
+    border-top: 1px solid ${({ theme }) => theme.BG_GREY};
+    border-bottom: 1px solid ${({ theme }) => theme.BG_GREY};
     margin: 34px 0;
     padding: 14px 0;
     font-weight: ${variables.FONT_WEIGHT.MEDIUM};
@@ -29,7 +29,7 @@ const Right = styled.div`
 const StyledFiatValue = styled(FiatValue)`
     font-size: 20px;
     line-height: 28px;
-    color: ${props => props.theme.TYPE_GREEN};
+    color: ${({ theme }) => theme.TYPE_GREEN};
     justify-content: end;
     display: flex;
 `;
@@ -37,7 +37,7 @@ const StyledFiatValue = styled(FiatValue)`
 const Crypto = styled.div`
     font-size: 20px;
     line-height: 28px;
-    color: ${props => props.theme.TYPE_LIGHT_GREY};
+    color: ${({ theme }) => theme.TYPE_LIGHT_GREY};
     justify-content: end;
     display: flex;
 `;

--- a/packages/suite/src/views/wallet/coinmarket/savings/setup/continue/index.tsx
+++ b/packages/suite/src/views/wallet/coinmarket/savings/setup/continue/index.tsx
@@ -32,7 +32,7 @@ const Label = styled.div`
     font-weight: ${variables.FONT_WEIGHT.MEDIUM};
     text-transform: capitalize;
     font-size: ${variables.FONT_SIZE.NORMAL};
-    color: ${props => props.theme.TYPE_DARK_GREY};
+    color: ${({ theme }) => theme.TYPE_DARK_GREY};
     margin-bottom: 11px;
 `;
 

--- a/packages/suite/src/views/wallet/coinmarket/sell/components/SellForm/Footer/index.tsx
+++ b/packages/suite/src/views/wallet/coinmarket/sell/components/SellForm/Footer/index.tsx
@@ -25,7 +25,7 @@ const FlagWrapper = styled.div`
 const LabelText = styled.div`
     font-size: ${variables.FONT_SIZE.SMALL};
     font-weight: ${variables.FONT_WEIGHT.MEDIUM};
-    color: ${props => props.theme.TYPE_DARK_GREY};
+    color: ${({ theme }) => theme.TYPE_DARK_GREY};
 `;
 
 const StyledRight = styled(Right)`
@@ -39,7 +39,7 @@ const Label = styled.div`
     align-items: center;
     white-space: nowrap;
     padding-top: 1px;
-    color: ${props => props.theme.TYPE_LIGHT_GREY};
+    color: ${({ theme }) => theme.TYPE_LIGHT_GREY};
     font-weight: ${variables.FONT_WEIGHT.MEDIUM};
 `;
 

--- a/packages/suite/src/views/wallet/coinmarket/sell/detail/Detail/index.tsx
+++ b/packages/suite/src/views/wallet/coinmarket/sell/detail/Detail/index.tsx
@@ -4,8 +4,8 @@ import { Card, variables } from '@trezor/components';
 import { CoinmarketSellOfferInfo, CoinmarketSellTopPanel } from 'src/components/wallet';
 import { useCoinmarketSellDetailContext } from 'src/hooks/wallet/useCoinmarketSellDetail';
 import { SellFiatTradeFinalStatuses } from 'src/hooks/wallet/useCoinmarket';
-import * as routerActions from 'src/actions/suite/routerActions';
-import { useActions, useLayout } from 'src/hooks/suite';
+import { goto } from 'src/actions/suite/routerActions';
+import { useDispatch, useLayout } from 'src/hooks/suite';
 
 import PaymentPending from '../components/PaymentPending';
 import PaymentSuccessful from '../components/PaymentSuccessful';
@@ -29,18 +29,20 @@ const CoinmarketDetail = () => {
     useLayout('Trezor Suite | Trade', CoinmarketSellTopPanel);
 
     const { account, trade, sellInfo } = useCoinmarketSellDetailContext();
-    const { goto } = useActions({ goto: routerActions.goto });
+    const dispatch = useDispatch();
 
     // if trade not found, it is because user refreshed the page and stored transactionId got removed
     // go to the default coinmarket page, the trade is shown there in the previous trades
     if (!trade) {
-        goto('wallet-coinmarket-sell', {
-            params: {
-                symbol: account.symbol,
-                accountIndex: account.index,
-                accountType: account.accountType,
-            },
-        });
+        dispatch(
+            goto('wallet-coinmarket-sell', {
+                params: {
+                    symbol: account.symbol,
+                    accountIndex: account.index,
+                    accountType: account.accountType,
+                },
+            }),
+        );
         return null;
     }
 

--- a/packages/suite/src/views/wallet/coinmarket/sell/detail/components/PaymentFailed/index.tsx
+++ b/packages/suite/src/views/wallet/coinmarket/sell/detail/components/PaymentFailed/index.tsx
@@ -36,13 +36,13 @@ const StyledLink = styled(Link)`
     margin-bottom: 30px;
 `;
 
-interface Props {
+interface PaymentFailedProps {
     transactionId?: string;
     supportUrl?: string;
     account: Account;
 }
 
-const PaymentFailed = ({ transactionId, supportUrl, account }: Props) => {
+const PaymentFailed = ({ transactionId, supportUrl, account }: PaymentFailedProps) => {
     const dispatch = useDispatch();
 
     const goToSell = () =>

--- a/packages/suite/src/views/wallet/coinmarket/sell/detail/components/PaymentFailed/index.tsx
+++ b/packages/suite/src/views/wallet/coinmarket/sell/detail/components/PaymentFailed/index.tsx
@@ -1,11 +1,11 @@
-import * as routerActions from 'src/actions/suite/routerActions';
 import React from 'react';
 import styled from 'styled-components';
 import { Button, variables, Link, Image } from '@trezor/components';
 import { CoinmarketTransactionId } from 'src/components/wallet';
-import { useActions } from 'src/hooks/suite/useActions';
+import { useDispatch } from 'src/hooks/suite';
 import { Account } from 'src/types/wallet';
 import { Translation } from 'src/components/suite/Translation';
+import { goto } from 'src/actions/suite/routerActions';
 
 const Wrapper = styled.div`
     display: flex;
@@ -24,7 +24,7 @@ const Description = styled.div`
     display: flex;
     align-items: center;
     justify-content: center;
-    color: ${props => props.theme.TYPE_LIGHT_GREY};
+    color: ${({ theme }) => theme.TYPE_LIGHT_GREY};
     font-weight: ${variables.FONT_WEIGHT.MEDIUM};
     margin: 17px 0 10px 0;
     max-width: 310px;
@@ -43,9 +43,19 @@ interface Props {
 }
 
 const PaymentFailed = ({ transactionId, supportUrl, account }: Props) => {
-    const { goto } = useActions({
-        goto: routerActions.goto,
-    });
+    const dispatch = useDispatch();
+
+    const goToSell = () =>
+        dispatch(
+            goto('wallet-coinmarket-sell', {
+                params: {
+                    symbol: account.symbol,
+                    accountIndex: account.index,
+                    accountType: account.accountType,
+                },
+            }),
+        );
+
     return (
         <Wrapper>
             <Image image="UNI_ERROR" />
@@ -63,17 +73,7 @@ const PaymentFailed = ({ transactionId, supportUrl, account }: Props) => {
                     </Button>
                 </StyledLink>
             )}
-            <Button
-                onClick={() =>
-                    goto('wallet-coinmarket-sell', {
-                        params: {
-                            symbol: account.symbol,
-                            accountIndex: account.index,
-                            accountType: account.accountType,
-                        },
-                    })
-                }
-            >
+            <Button onClick={goToSell}>
                 <Translation id="TR_SELL_DETAIL_ERROR_BUTTON" />
             </Button>
         </Wrapper>

--- a/packages/suite/src/views/wallet/coinmarket/sell/detail/components/PaymentPending/index.tsx
+++ b/packages/suite/src/views/wallet/coinmarket/sell/detail/components/PaymentPending/index.tsx
@@ -20,11 +20,11 @@ const StyledLink = styled(Link)`
     margin-top: 50px;
 `;
 
-interface Props {
+interface PaymentConvertingProps {
     supportUrl?: string;
 }
 
-const PaymentConverting = ({ supportUrl }: Props) => (
+const PaymentConverting = ({ supportUrl }: PaymentConvertingProps) => (
     <Wrapper>
         <Loader />
         <Title>

--- a/packages/suite/src/views/wallet/coinmarket/sell/detail/components/PaymentSuccessful/index.tsx
+++ b/packages/suite/src/views/wallet/coinmarket/sell/detail/components/PaymentSuccessful/index.tsx
@@ -1,10 +1,10 @@
-import * as routerActions from 'src/actions/suite/routerActions';
 import React from 'react';
 import styled from 'styled-components';
 import { Button, variables, Image } from '@trezor/components';
 import { Translation } from 'src/components/suite';
-import { useActions } from 'src/hooks/suite';
+import { useDispatch } from 'src/hooks/suite';
 import { Account } from 'src/types/wallet';
+import { goto } from 'src/actions/suite/routerActions';
 
 const Wrapper = styled.div`
     display: flex;
@@ -23,7 +23,7 @@ const Description = styled.div`
     display: flex;
     align-items: center;
     justify-content: center;
-    color: ${props => props.theme.TYPE_LIGHT_GREY};
+    color: ${({ theme }) => theme.TYPE_LIGHT_GREY};
     font-weight: ${variables.FONT_WEIGHT.MEDIUM};
     margin: 17px 0 30px 0;
     max-width: 310px;
@@ -33,7 +33,7 @@ const Description = styled.div`
 const FixedRate = styled.div`
     display: flex;
     flex-direction: column;
-    background-color: ${props => props.theme.BG_GREY};
+    background-color: ${({ theme }) => theme.BG_GREY};
     padding: 14px 18px;
     border-radius: 8px;
     margin-bottom: 30px;
@@ -43,16 +43,26 @@ const FixedRateHeader = styled.div`
     font-size: ${variables.FONT_SIZE.SMALL};
 `;
 const FixedRateMessage = styled.div`
-    color: ${props => props.theme.TYPE_LIGHT_GREY};
+    color: ${({ theme }) => theme.TYPE_LIGHT_GREY};
 `;
-interface Props {
+interface PaymentSuccessfulProps {
     account: Account;
 }
 
-const PaymentSuccessful = ({ account }: Props) => {
-    const { goto } = useActions({
-        goto: routerActions.goto,
-    });
+const PaymentSuccessful = ({ account }: PaymentSuccessfulProps) => {
+    const dispatch = useDispatch();
+
+    const goToSell = () =>
+        dispatch(
+            goto('wallet-coinmarket-sell', {
+                params: {
+                    symbol: account.symbol,
+                    accountIndex: account.index,
+                    accountType: account.accountType,
+                },
+            }),
+        );
+
     return (
         <Wrapper>
             <Image image="COINMARKET_SUCCESS" />
@@ -70,17 +80,7 @@ const PaymentSuccessful = ({ account }: Props) => {
                     <Translation id="TR_SELL_DETAIL_SUCCESS_FIXED_RATE_MESSAGE" />
                 </FixedRateMessage>
             </FixedRate>
-            <Button
-                onClick={() =>
-                    goto('wallet-coinmarket-sell', {
-                        params: {
-                            symbol: account.symbol,
-                            accountIndex: account.index,
-                            accountType: account.accountType,
-                        },
-                    })
-                }
-            >
+            <Button onClick={goToSell}>
                 <Translation id="TR_SELL_DETAIL_SUCCESS_BUTTON" />
             </Button>
         </Wrapper>

--- a/packages/suite/src/views/wallet/coinmarket/sell/offers/Offers/List/Quote/index.tsx
+++ b/packages/suite/src/views/wallet/coinmarket/sell/offers/Offers/List/Quote/index.tsx
@@ -13,12 +13,6 @@ import { getTagAndInfoNote } from 'src/utils/wallet/coinmarket/coinmarketUtils';
 import { CoinmarketCryptoAmount } from 'src/views/wallet/coinmarket/common/CoinmarketCryptoAmount';
 import { CoinmarketFiatAmount } from 'src/views/wallet/coinmarket/common/CoinmarketFiatAmount';
 
-interface Props {
-    className?: string;
-    quote: SellFiatTrade;
-    amountInCrypto: boolean;
-}
-
 const Wrapper = styled.div`
     display: flex;
     flex-direction: column;
@@ -232,7 +226,13 @@ export function getQuoteError(quote: SellFiatTrade, amountInCrypto: boolean) {
     return '';
 }
 
-const Quote = ({ className, quote, amountInCrypto }: Props) => {
+interface QuoteProps {
+    className?: string;
+    quote: SellFiatTrade;
+    amountInCrypto: boolean;
+}
+
+const Quote = ({ className, quote, amountInCrypto }: QuoteProps) => {
     const theme = useTheme();
     const { selectQuote, sellInfo, needToRegisterOrVerifyBankAccount } =
         useCoinmarketSellOffersContext();

--- a/packages/suite/src/views/wallet/coinmarket/sell/offers/Offers/List/Quote/index.tsx
+++ b/packages/suite/src/views/wallet/coinmarket/sell/offers/Offers/List/Quote/index.tsx
@@ -27,7 +27,7 @@ const Wrapper = styled.div`
     width: 100%;
     min-height: 150px;
     padding-bottom: 16px;
-    background: ${props => props.theme.BG_WHITE};
+    background: ${({ theme }) => theme.BG_WHITE};
 `;
 
 const Main = styled.div`
@@ -35,7 +35,7 @@ const Main = styled.div`
     margin: 0 30px;
     justify-content: space-between;
     padding: 20px 0;
-    border-bottom: 1px solid ${props => props.theme.STROKE_GREY};
+    border-bottom: 1px solid ${({ theme }) => theme.STROKE_GREY};
 
     @media (max-width: ${variables.SCREEN_SIZE.SM}) {
         flex-direction: column;
@@ -82,7 +82,7 @@ const Column = styled.div`
 const Heading = styled.div`
     display: flex;
     text-transform: uppercase;
-    color: ${props => props.theme.TYPE_LIGHT_GREY};
+    color: ${({ theme }) => theme.TYPE_LIGHT_GREY};
     font-weight: ${variables.FONT_WEIGHT.DEMI_BOLD};
     padding-bottom: 9px;
 `;
@@ -98,7 +98,7 @@ const StyledButton = styled(Button)`
 const Value = styled.div`
     display: flex;
     align-items: center;
-    color: ${props => props.theme.TYPE_DARK_GREY};
+    color: ${({ theme }) => theme.TYPE_DARK_GREY};
     font-weight: ${variables.FONT_WEIGHT.MEDIUM};
 `;
 
@@ -106,8 +106,8 @@ const Footer = styled.div`
     margin: 0 30px;
     padding: 10px 0;
     padding-top: 23px;
-    color: ${props => props.theme.TYPE_LIGHT_GREY};
-    border-top: 1px solid ${props => props.theme.STROKE_GREY};
+    color: ${({ theme }) => theme.TYPE_LIGHT_GREY};
+    border-top: 1px solid ${({ theme }) => theme.STROKE_GREY};
     font-weight: ${variables.FONT_WEIGHT.MEDIUM};
     font-size: ${variables.FONT_SIZE.SMALL};
 
@@ -120,8 +120,8 @@ const ErrorFooter = styled.div`
     display: flex;
     margin: 0 30px;
     padding: 10px 0;
-    border-top: 1px solid ${props => props.theme.STROKE_GREY};
-    color: ${props => props.theme.TYPE_RED};
+    border-top: 1px solid ${({ theme }) => theme.STROKE_GREY};
+    color: ${({ theme }) => theme.TYPE_RED};
 
     @media (max-width: ${variables.SCREEN_SIZE.SM}) {
         margin: 0 20px;
@@ -139,12 +139,12 @@ const IconWrapper = styled.div`
 const ErrorText = styled.div``;
 
 const VerificationInfo = styled.div`
-    color: ${props => props.theme.TYPE_BLUE};
+    color: ${({ theme }) => theme.TYPE_BLUE};
 `;
 
 const StyledQuestionTooltip = styled(QuestionTooltip)`
     padding-left: 4px;
-    color: ${props => props.theme.TYPE_LIGHT_GREY};
+    color: ${({ theme }) => theme.TYPE_LIGHT_GREY};
 `;
 
 export function getQuoteError(quote: SellFiatTrade, amountInCrypto: boolean) {

--- a/packages/suite/src/views/wallet/coinmarket/sell/offers/Offers/List/index.tsx
+++ b/packages/suite/src/views/wallet/coinmarket/sell/offers/Offers/List/index.tsx
@@ -52,7 +52,7 @@ const SummaryRow = styled(H2)`
 `;
 
 const OrigAmount = styled.div`
-    color: ${props => props.theme.TYPE_LIGHT_GREY};
+    color: ${({ theme }) => theme.TYPE_LIGHT_GREY};
     font-size: ${variables.FONT_SIZE.SMALL};
 `;
 

--- a/packages/suite/src/views/wallet/coinmarket/sell/offers/Offers/List/index.tsx
+++ b/packages/suite/src/views/wallet/coinmarket/sell/offers/Offers/List/index.tsx
@@ -10,11 +10,6 @@ import { InvityAPIReloadQuotesAfterSeconds } from 'src/constants/wallet/coinmark
 import { CoinmarketCryptoAmount } from 'src/views/wallet/coinmarket/common/CoinmarketCryptoAmount';
 import { CoinmarketFiatAmount } from 'src/views/wallet/coinmarket/common/CoinmarketFiatAmount';
 
-interface Props {
-    isAlternative?: boolean;
-    quotes: SellFiatTrade[];
-}
-
 const Wrapper = styled.div``;
 const Quotes = styled.div``;
 
@@ -81,7 +76,12 @@ const NoQuotes = styled.div`
     flex: 1;
 `;
 
-const List = ({ isAlternative, quotes }: Props) => {
+interface ListProps {
+    isAlternative?: boolean;
+    quotes: SellFiatTrade[];
+}
+
+const List = ({ isAlternative, quotes }: ListProps) => {
     const { account, quotesRequest, timer } = useCoinmarketSellOffersContext();
 
     if (!quotesRequest) return null;

--- a/packages/suite/src/views/wallet/coinmarket/sell/offers/Offers/SelectedOffer/components/SelectBankAccount.tsx
+++ b/packages/suite/src/views/wallet/coinmarket/sell/offers/Offers/SelectedOffer/components/SelectBankAccount.tsx
@@ -30,7 +30,7 @@ const StyledQuestionTooltip = styled(QuestionTooltip)`
 
 const CustomLabel = styled(Label)`
     padding: 12px 0;
-    color: ${props => props.theme.TYPE_LIGHT_GREY};
+    color: ${({ theme }) => theme.TYPE_LIGHT_GREY};
 `;
 
 const LabelText = styled.div``;
@@ -51,7 +51,7 @@ const AccountInfo = styled.div`
 
 const AccountName = styled.div`
     display: flex;
-    color: ${props => props.theme.TYPE_LIGHT_GREY};
+    color: ${({ theme }) => theme.TYPE_LIGHT_GREY};
 `;
 
 const AccountNumber = styled.div`
@@ -63,11 +63,11 @@ const AccountVerified = styled.div`
     display: flex;
     justify-content: flex-end;
     font-size: ${variables.FONT_SIZE.TINY};
-    color: ${props => props.theme.TYPE_GREEN};
+    color: ${({ theme }) => theme.TYPE_GREEN};
 `;
 
 const AccountNotVerified = styled(AccountVerified)`
-    color: ${props => props.theme.TYPE_LIGHT_GREY};
+    color: ${({ theme }) => theme.TYPE_LIGHT_GREY};
 `;
 
 const ButtonWrapper = styled.div`
@@ -75,7 +75,7 @@ const ButtonWrapper = styled.div`
     align-items: center;
     justify-content: center;
     padding-top: 20px;
-    border-top: 1px solid ${props => props.theme.STROKE_GREY};
+    border-top: 1px solid ${({ theme }) => theme.STROKE_GREY};
     margin: 20px 0;
 `;
 

--- a/packages/suite/src/views/wallet/coinmarket/sell/offers/Offers/SelectedOffer/components/SendTransaction.tsx
+++ b/packages/suite/src/views/wallet/coinmarket/sell/offers/Offers/SelectedOffer/components/SendTransaction.tsx
@@ -21,13 +21,13 @@ const WaitingWrapper = styled.div`
 
 const LabelText = styled.div`
     font-size: ${variables.FONT_SIZE.TINY};
-    color: ${props => props.theme.TYPE_LIGHT_GREY};
+    color: ${({ theme }) => theme.TYPE_LIGHT_GREY};
 `;
 
 const Value = styled.div`
     padding-top: 6px;
     font-size: ${variables.FONT_SIZE.SMALL};
-    color: ${props => props.theme.TYPE_DARK_GREY};
+    color: ${({ theme }) => theme.TYPE_DARK_GREY};
     font-weight: ${variables.FONT_WEIGHT.MEDIUM};
 `;
 
@@ -36,7 +36,7 @@ const ButtonWrapper = styled.div`
     align-items: center;
     justify-content: center;
     padding-top: 20px;
-    border-top: 1px solid ${props => props.theme.STROKE_GREY};
+    border-top: 1px solid ${({ theme }) => theme.STROKE_GREY};
     margin: 20px 0;
 `;
 

--- a/packages/suite/src/views/wallet/coinmarket/sell/offers/Offers/SelectedOffer/index.tsx
+++ b/packages/suite/src/views/wallet/coinmarket/sell/offers/Offers/SelectedOffer/index.tsx
@@ -26,7 +26,7 @@ const Header = styled.div`
     align-items: center;
     justify-content: center;
     padding: 10px 25px;
-    border-bottom: 1px solid ${props => props.theme.STROKE_GREY};
+    border-bottom: 1px solid ${({ theme }) => theme.STROKE_GREY};
 `;
 
 interface ActiveProps {
@@ -34,10 +34,9 @@ interface ActiveProps {
 }
 
 const Step = styled.div<ActiveProps>`
-    font-weight: ${props =>
-        props.active ? variables.FONT_WEIGHT.DEMI_BOLD : variables.FONT_WEIGHT.MEDIUM};
-    color: ${props =>
-        props.active ? props => props.theme.TYPE_GREEN : props.theme.TYPE_LIGHT_GREY};
+    font-weight: ${({ active }) =>
+        active ? variables.FONT_WEIGHT.DEMI_BOLD : variables.FONT_WEIGHT.MEDIUM};
+    color: ${({ active, theme }) => (active ? theme.TYPE_GREEN : theme.TYPE_LIGHT_GREY)};
     display: flex;
     font-size: ${variables.FONT_SIZE.SMALL};
     flex: 1;
@@ -61,7 +60,7 @@ const Middle = styled.div`
     height: 48px;
     align-items: center;
     justify-content: center;
-    color: ${props => props.theme.STROKE_GREY};
+    color: ${({ theme }) => theme.STROKE_GREY};
 `;
 
 export const SelectedOffer = () => {

--- a/packages/suite/src/views/wallet/coinmarket/sell/offers/Offers/index.tsx
+++ b/packages/suite/src/views/wallet/coinmarket/sell/offers/Offers/index.tsx
@@ -33,14 +33,14 @@ const Divider = styled.div`
 const DividerLine = styled.div`
     height: 1px;
     flex: 1;
-    background: ${props => props.theme.STROKE_GREY};
+    background: ${({ theme }) => theme.STROKE_GREY};
 `;
 
 const DividerLeft = styled(DividerLine)``;
 const DividerRight = styled(DividerLine)``;
 
 const Currency = styled.div`
-    color: ${props => props.theme.TYPE_DARK_GREY};
+    color: ${({ theme }) => theme.TYPE_DARK_GREY};
     text-transform: uppercase;
     padding-left: 3px;
 `;
@@ -49,12 +49,12 @@ const DividerMiddle = styled.div`
     display: flex;
     align-items: center;
     padding: 5px 20px;
-    color: ${props => props.theme.TYPE_LIGHT_GREY};
+    color: ${({ theme }) => theme.TYPE_LIGHT_GREY};
     font-weight: ${variables.FONT_WEIGHT.MEDIUM};
     font-size: ${variables.FONT_SIZE.SMALL};
     border-radius: 25px;
-    border: 1px solid ${props => props.theme.STROKE_GREY};
-    background: ${props => props.theme.BG_WHITE};
+    border: 1px solid ${({ theme }) => theme.STROKE_GREY};
+    background: ${({ theme }) => theme.BG_WHITE};
     text-align: center;
 `;
 

--- a/packages/suite/src/views/wallet/coinmarket/skeleton/index.tsx
+++ b/packages/suite/src/views/wallet/coinmarket/skeleton/index.tsx
@@ -27,7 +27,7 @@ const FooterSkeletonWrapper = styled(FooterWrapper)`
 
 const Divider = styled(Wrapper)`
     display: flex;
-    border-top: 1px solid ${props => props.theme.STROKE_GREY};
+    border-top: 1px solid ${({ theme }) => theme.STROKE_GREY};
     padding: 0;
 `;
 

--- a/packages/suite/src/views/wallet/coinmarket/spend/components/Spend/index.tsx
+++ b/packages/suite/src/views/wallet/coinmarket/spend/components/Spend/index.tsx
@@ -16,7 +16,7 @@ const ProviderInfo = styled.div`
     display: flex;
     align-items: center;
     margin-bottom: 15px;
-    color: ${props => props.theme.TYPE_LIGHT_GREY};
+    color: ${({ theme }) => theme.TYPE_LIGHT_GREY};
 `;
 
 const IframeWrapper = styled.div`
@@ -24,7 +24,7 @@ const IframeWrapper = styled.div`
     display: flex;
     align-items: center;
     justify-content: center;
-    border: 1px solid ${props => props.theme.STROKE_GREY};
+    border: 1px solid ${({ theme }) => theme.STROKE_GREY};
 `;
 
 const WebContent = styled.div`

--- a/packages/suite/src/views/wallet/receive/components/FreshAddress.tsx
+++ b/packages/suite/src/views/wallet/receive/components/FreshAddress.tsx
@@ -1,9 +1,10 @@
 import React, { useMemo } from 'react';
-import { useSelector } from 'react-redux';
 
 import styled from 'styled-components';
 import { Translation, QuestionTooltip, ReadMoreLink } from 'src/components/suite';
 import { AppState } from 'src/types/suite';
+import { showAddress } from 'src/actions/wallet/receiveActions';
+import { useDispatch, useSelector } from 'src/hooks/suite/';
 
 import { Button, Card, variables, H2, Tooltip } from '@trezor/components';
 import { getFirstFreshAddress } from '@suite-common/wallet-utils';
@@ -48,12 +49,12 @@ const FreshAddressWrapper = styled.div`
 `;
 
 const StyledFreshAddress = styled(H2)`
-    color: ${props => props.theme.TYPE_DARK_GREY};
+    color: ${({ theme }) => theme.TYPE_DARK_GREY};
     font-weight: ${variables.FONT_WEIGHT.REGULAR};
 `;
 const AddressLabel = styled.span`
     font-weight: 600;
-    color: ${props => props.theme.TYPE_LIGHT_GREY};
+    color: ${({ theme }) => theme.TYPE_LIGHT_GREY};
     font-size: ${variables.FONT_SIZE.TINY};
     letter-spacing: 0.2px;
     text-transform: uppercase;
@@ -69,7 +70,7 @@ const Overlay = styled.div`
     background-image: linear-gradient(
         to right,
         rgba(0, 0, 0, 0) 0%,
-        ${props => props.theme.BG_WHITE} 220px
+        ${({ theme }) => theme.BG_WHITE} 220px
     );
 `;
 
@@ -114,7 +115,6 @@ const TooltipLabel = ({
 interface FreshAddressProps {
     account: AppState['wallet']['selectedAccount']['account'];
     addresses: AppState['wallet']['receive'];
-    showAddress: (path: string, address: string) => void;
     disabled: boolean;
     locked: boolean;
     pendingAddresses: string[];
@@ -123,7 +123,6 @@ interface FreshAddressProps {
 export const FreshAddress = ({
     account,
     addresses,
-    showAddress,
     disabled,
     pendingAddresses,
     locked,
@@ -131,6 +130,7 @@ export const FreshAddress = ({
     const isAccountUtxoBased = useSelector((state: AccountsRootState) =>
         selectIsAccountUtxoBased(state, account?.key ?? ''),
     );
+    const dispatch = useDispatch();
 
     const firstFreshAddress = useMemo(() => {
         if (account) {
@@ -148,6 +148,9 @@ export const FreshAddress = ({
         account.accountType === 'coinjoin' &&
         !account.addresses?.used.length &&
         firstFreshAddress.address !== account.addresses?.unused[0]?.address;
+
+    const handleAddressReveal = () =>
+        dispatch(showAddress(firstFreshAddress.path, firstFreshAddress.address));
 
     return (
         <StyledCard>
@@ -170,7 +173,7 @@ export const FreshAddress = ({
                 <StyledButton
                     data-test="@wallet/receive/reveal-address-button"
                     icon="TREZOR_LOGO"
-                    onClick={() => showAddress(firstFreshAddress.path, firstFreshAddress.address)}
+                    onClick={handleAddressReveal}
                     isDisabled={disabled || locked || coinjoinDisallowReveal}
                     isLoading={locked}
                 >

--- a/packages/suite/src/views/wallet/receive/components/UsedAddresses.tsx
+++ b/packages/suite/src/views/wallet/receive/components/UsedAddresses.tsx
@@ -1,5 +1,6 @@
 import React, { useState } from 'react';
 import styled from 'styled-components';
+
 import { AccountAddress } from '@trezor/connect';
 import { variables, Button } from '@trezor/components';
 import { Card, Translation, MetadataLabeling, FormattedCryptoAmount } from 'src/components/suite';
@@ -7,6 +8,8 @@ import { formatNetworkAmount } from '@suite-common/wallet-utils';
 import { Network } from 'src/types/wallet';
 import { AppState } from 'src/types/suite';
 import { MetadataAddPayload } from 'src/types/suite/metadata';
+import { showAddress } from 'src/actions/wallet/receiveActions';
+import { useDispatch } from 'src/hooks/suite/';
 
 const StyledCard = styled(Card)`
     flex-direction: column;
@@ -174,7 +177,6 @@ const Item = ({ addr, symbol, onClick, metadataPayload, index }: ItemProps) => {
 interface UsedAddressesProps {
     account: AppState['wallet']['selectedAccount']['account'];
     addresses: AppState['wallet']['receive'];
-    showAddress: (path: string, address: string) => void;
     locked: boolean;
     pendingAddresses: string[];
 }
@@ -183,10 +185,10 @@ export const UsedAddresses = ({
     account,
     addresses,
     pendingAddresses,
-    showAddress,
     locked,
 }: UsedAddressesProps) => {
     const [limit, setLimit] = useState(DEFAULT_LIMIT);
+    const dispatch = useDispatch();
 
     if (!account) {
         return null;
@@ -244,7 +246,9 @@ export const UsedAddresses = ({
                             defaultValue: addr.address,
                             value: addressLabels[addr.address],
                         }}
-                        onClick={() => (!locked ? showAddress(addr.path, addr.address) : undefined)}
+                        onClick={() =>
+                            !locked ? dispatch(showAddress(addr.path, addr.address)) : undefined
+                        }
                     />
                 ))}
             </GridTable>

--- a/packages/suite/src/views/wallet/receive/index.tsx
+++ b/packages/suite/src/views/wallet/receive/index.tsx
@@ -1,8 +1,7 @@
 import React from 'react';
 
 import { WalletLayout, WalletLayoutHeader } from 'src/components/wallet';
-import { useDevice, useSelector, useActions } from 'src/hooks/suite';
-import * as receiveActions from 'src/actions/wallet/receiveActions';
+import { useDevice, useSelector } from 'src/hooks/suite';
 
 import { selectPendingAccountAddresses } from '@suite-common/wallet-core';
 import { selectDevice } from 'src/reducers/suite/suiteReducer';
@@ -18,10 +17,6 @@ const Receive = () => {
     const selectedAccount = useSelector(state => state.wallet.selectedAccount);
     const receive = useSelector(state => state.wallet.receive);
     const device = useSelector(selectDevice);
-
-    const { showAddress } = useActions({
-        showAddress: receiveActions.showAddress,
-    });
 
     const { account } = selectedAccount;
 
@@ -49,7 +44,6 @@ const Receive = () => {
             <FreshAddress
                 account={account}
                 addresses={receive}
-                showAddress={showAddress}
                 disabled={disabled}
                 locked={isDeviceLocked}
                 pendingAddresses={pendingAddresses}
@@ -58,7 +52,6 @@ const Receive = () => {
             <UsedAddresses
                 account={account}
                 addresses={receive}
-                showAddress={showAddress}
                 locked={isDeviceLocked}
                 pendingAddresses={pendingAddresses}
             />

--- a/packages/suite/src/views/wallet/send/components/Header/components/Clear.tsx
+++ b/packages/suite/src/views/wallet/send/components/Header/components/Clear.tsx
@@ -15,7 +15,7 @@ const In = styled.div`
     display: flex;
     align-items: center;
     padding-right: 10px;
-    color: ${props => props.theme.TYPE_LIGHT_GREY};
+    color: ${({ theme }) => theme.TYPE_LIGHT_GREY};
 `;
 
 export const Clear = () => {

--- a/packages/suite/src/views/wallet/send/components/Header/index.tsx
+++ b/packages/suite/src/views/wallet/send/components/Header/index.tsx
@@ -1,23 +1,20 @@
 import React from 'react';
 import { Dropdown } from '@trezor/components';
 import { Translation } from 'src/components/suite';
-import { useActions } from 'src/hooks/suite';
+import { useDispatch } from 'src/hooks/suite';
 import { useSendFormContext } from 'src/hooks/wallet';
-import * as sendFormActions from 'src/actions/wallet/sendFormActions';
+import { sendRaw } from 'src/actions/wallet/sendFormActions';
 import { Clear } from './components/Clear';
 import { WalletLayoutHeader } from 'src/components/wallet';
 
 export const Header = () => {
+    const dispatch = useDispatch();
     const {
         outputs,
         account: { networkType },
         addOpReturn,
         loadTransaction,
     } = useSendFormContext();
-
-    const { sendRaw } = useActions({
-        sendRaw: sendFormActions.sendRaw,
-    });
 
     const opreturnOutput = (outputs || []).find(o => o.type === 'opreturn');
     const options = [
@@ -41,7 +38,7 @@ export const Header = () => {
         {
             key: 'raw',
             callback: () => {
-                sendRaw(true);
+                dispatch(sendRaw(true));
                 return true;
             },
             label: <Translation id="SEND_RAW" />,

--- a/packages/suite/src/views/wallet/send/components/Options/components/BitcoinOptions/components/CoinControl.tsx
+++ b/packages/suite/src/views/wallet/send/components/Options/components/BitcoinOptions/components/CoinControl.tsx
@@ -5,7 +5,7 @@ import { fetchTransactionsThunk } from '@suite-common/wallet-core';
 import { amountToSatoshi, formatNetworkAmount } from '@suite-common/wallet-utils';
 import { FormattedCryptoAmount, Translation } from 'src/components/suite';
 import { SETTINGS } from 'src/config/suite';
-import { useActions, useSelector } from 'src/hooks/suite';
+import { useDispatch, useSelector } from 'src/hooks/suite';
 import { Pagination } from 'src/components/wallet';
 import { useTheme, Checkbox, Icon, Switch, variables } from '@trezor/components';
 import { UtxoSelectionList } from 'src/components/wallet/CoinControl/UtxoSelectionList';
@@ -65,10 +65,7 @@ export const CoinControl = ({ close }: CoinControlProps) => {
     const [currentPage, setSelectedPage] = useState(1);
 
     const targetAnonymity = useSelector(selectCurrentTargetAnonymity);
-
-    const { fetchTransactions } = useActions({
-        fetchTransactions: fetchTransactionsThunk,
-    });
+    const dispatch = useDispatch();
 
     const {
         account,
@@ -150,17 +147,19 @@ export const CoinControl = ({ close }: CoinControlProps) => {
 
     // fetch all transactions so that we can show a transaction timestamp for each UTXO
     useEffect(() => {
-        const promise = fetchTransactions({
-            accountKey: account.key,
-            page: 2,
-            perPage: SETTINGS.TXS_PER_PAGE,
-            noLoading: true,
-            recursive: true,
-        });
+        const promise = dispatch(
+            fetchTransactionsThunk({
+                accountKey: account.key,
+                page: 2,
+                perPage: SETTINGS.TXS_PER_PAGE,
+                noLoading: true,
+                recursive: true,
+            }),
+        );
         return () => {
             promise.abort();
         };
-    }, [account, fetchTransactions]);
+    }, [account, dispatch]);
 
     const missingToInputValues = {
         amount: <FormattedCryptoAmount value={formattedMissing} symbol={account.symbol} />,

--- a/packages/suite/src/views/wallet/send/components/Options/components/BitcoinOptions/components/Locktime.tsx
+++ b/packages/suite/src/views/wallet/send/components/Options/components/BitcoinOptions/components/Locktime.tsx
@@ -58,11 +58,11 @@ const Description = styled.div`
     color: ${({ theme }) => theme.TYPE_LIGHT_GREY};
 `;
 
-interface Props {
+interface LocktimeProps {
     close: () => void;
 }
 
-export const Locktime = ({ close }: Props) => {
+export const Locktime = ({ close }: LocktimeProps) => {
     const {
         network,
         register,

--- a/packages/suite/src/views/wallet/send/components/Options/components/BitcoinOptions/components/Locktime.tsx
+++ b/packages/suite/src/views/wallet/send/components/Options/components/BitcoinOptions/components/Locktime.tsx
@@ -49,13 +49,13 @@ const Right = styled.div`
 const Title = styled.div`
     font-weight: ${variables.FONT_WEIGHT.MEDIUM};
     font-size: ${variables.FONT_SIZE.NORMAL};
-    color: ${props => props.theme.TYPE_DARK_GREY};
+    color: ${({ theme }) => theme.TYPE_DARK_GREY};
 `;
 
 const Description = styled.div`
     font-weight: ${variables.FONT_WEIGHT.MEDIUM};
     font-size: ${variables.FONT_SIZE.SMALL};
-    color: ${props => props.theme.TYPE_LIGHT_GREY};
+    color: ${({ theme }) => theme.TYPE_LIGHT_GREY};
 `;
 
 interface Props {

--- a/packages/suite/src/views/wallet/send/components/Options/index.tsx
+++ b/packages/suite/src/views/wallet/send/components/Options/index.tsx
@@ -24,7 +24,7 @@ const Content = styled.div`
 const Line = styled.div`
     width: 100%;
     height: 1px;
-    border-top: 1px solid ${props => props.theme.STROKE_GREY};
+    border-top: 1px solid ${({ theme }) => theme.STROKE_GREY};
     margin-top: 10px;
 `;
 

--- a/packages/suite/src/views/wallet/send/components/Outputs/components/Amount/index.tsx
+++ b/packages/suite/src/views/wallet/send/components/Outputs/components/Amount/index.tsx
@@ -107,11 +107,11 @@ const StyledWarning = styled(Warning)`
     margin-bottom: 8px;
 `;
 
-interface Props {
+interface AmountProps {
     output: Partial<Output>;
     outputId: number;
 }
-export const Amount = ({ output, outputId }: Props) => {
+export const Amount = ({ output, outputId }: AmountProps) => {
     const { translationString } = useTranslation();
     const {
         account,

--- a/packages/suite/src/views/wallet/send/components/Outputs/index.tsx
+++ b/packages/suite/src/views/wallet/send/components/Outputs/index.tsx
@@ -28,7 +28,7 @@ const OutputWrapper = styled.div<{ index: number }>`
         css`
             margin: 0 42px;
             padding-top: 32px;
-            border-top: 1px solid ${props => props.theme.STROKE_GREY};
+            border-top: 1px solid ${({ theme }) => theme.STROKE_GREY};
         `}
 `;
 

--- a/packages/suite/src/views/wallet/send/components/Outputs/index.tsx
+++ b/packages/suite/src/views/wallet/send/components/Outputs/index.tsx
@@ -40,11 +40,11 @@ const Row = styled.div`
     }
 `;
 
-interface Props {
+interface OutputsProps {
     disableAnim?: boolean; // used in tests, with animations enabled react-testing-library can't find output fields
 }
 
-const Outputs = ({ disableAnim }: Props) => {
+const Outputs = ({ disableAnim }: OutputsProps) => {
     const { outputs } = useSendFormContext();
     const [renderedOutputs, setRenderedOutputs] = useState(1);
     const lastOutputRef = useRef<HTMLDivElement | null>(null);

--- a/packages/suite/src/views/wallet/send/components/TotalSent.tsx
+++ b/packages/suite/src/views/wallet/send/components/TotalSent.tsx
@@ -28,13 +28,13 @@ const Label = styled.div`
     padding-right: 10px;
     text-transform: capitalize;
     font-size: ${variables.FONT_SIZE.NORMAL};
-    color: ${props => props.theme.TYPE_DARK_GREY};
+    color: ${({ theme }) => theme.TYPE_DARK_GREY};
 `;
 
 const SecondaryLabel = styled.div`
     padding-top: 2px;
     font-size: ${variables.FONT_SIZE.SMALL};
-    color: ${props => props.theme.TYPE_LIGHT_GREY};
+    color: ${({ theme }) => theme.TYPE_LIGHT_GREY};
 `;
 
 const Right = styled.div`
@@ -49,7 +49,7 @@ const TotalSentCoin = styled.div`
     display: flex;
     font-weight: ${variables.FONT_WEIGHT.MEDIUM};
     font-size: ${variables.FONT_SIZE.NORMAL};
-    color: ${props => props.theme.TYPE_DARK_GREY};
+    color: ${({ theme }) => theme.TYPE_DARK_GREY};
     padding-bottom: 6px;
 `;
 
@@ -57,7 +57,7 @@ const TotalSentFiat = styled.div`
     display: flex;
     font-weight: ${variables.FONT_WEIGHT.MEDIUM};
     font-size: ${variables.FONT_SIZE.NORMAL};
-    color: ${props => props.theme.TYPE_LIGHT_GREY};
+    color: ${({ theme }) => theme.TYPE_LIGHT_GREY};
 `;
 
 export const TotalSent = () => {

--- a/packages/suite/src/views/wallet/sign-verify/components/VerifyAddressButton.tsx
+++ b/packages/suite/src/views/wallet/sign-verify/components/VerifyAddressButton.tsx
@@ -1,8 +1,8 @@
 import React from 'react';
 import styled from 'styled-components';
 import { Icon, variables } from '@trezor/components';
-import { showAddress as showAddressAction } from 'src/actions/wallet/signVerifyActions';
-import { useActions } from 'src/hooks/suite';
+import { showAddress } from 'src/actions/wallet/signVerifyActions';
+import { useDispatch } from 'src/hooks/suite';
 import { Translation } from 'src/components/suite';
 
 const RevealText = styled.div`
@@ -44,14 +44,11 @@ interface VerifyAddressButtonProps {
 }
 
 export const VerifyAddressButton = ({ item: { label, value } }: VerifyAddressButtonProps) => {
-    const { showAddress } = useActions({
-        showAddress: showAddressAction,
-    });
+    const dispatch = useDispatch();
 
     const reveal = (e: React.MouseEvent<HTMLElement>) => {
         e.stopPropagation();
-
-        showAddress(label, value);
+        dispatch(showAddress(label, value));
     };
 
     return (

--- a/packages/suite/src/views/wallet/sign-verify/components/VerifyAddressButton.tsx
+++ b/packages/suite/src/views/wallet/sign-verify/components/VerifyAddressButton.tsx
@@ -31,7 +31,7 @@ const ButtonWrapper = styled.button`
     cursor: pointer;
 
     :hover {
-        background-color: ${props => props.theme.BG_WHITE_ALT_HOVER};
+        background-color: ${({ theme }) => theme.BG_WHITE_ALT_HOVER};
 
         > div {
             max-width: 100px;

--- a/packages/suite/src/views/wallet/staking/components/CardanoPrimitives.ts
+++ b/packages/suite/src/views/wallet/staking/components/CardanoPrimitives.ts
@@ -27,7 +27,7 @@ export const Column = styled.div`
 
 export const Title = styled.div`
     display: flex;
-    color: ${props => props.theme.TYPE_DARK_GREY};
+    color: ${({ theme }) => theme.TYPE_DARK_GREY};
     font-size: ${variables.FONT_SIZE.NORMAL};
     font-weight: ${variables.FONT_WEIGHT.DEMI_BOLD};
     align-items: center;
@@ -43,7 +43,7 @@ export const Actions = styled.div`
 `;
 
 export const Text = styled.div`
-    color: ${props => props.theme.TYPE_LIGHT_GREY};
+    color: ${({ theme }) => theme.TYPE_LIGHT_GREY};
     margin-bottom: 8px;
     margin-top: 8px;
     font-size: ${variables.FONT_SIZE.SMALL};
@@ -60,12 +60,12 @@ export const Content = styled.div`
 
 export const Value = styled.div`
     font-size: ${variables.FONT_SIZE.NORMAL};
-    color: ${props => props.theme.TYPE_DARK_GREY};
+    color: ${({ theme }) => theme.TYPE_DARK_GREY};
     font-weight: ${variables.FONT_WEIGHT.MEDIUM};
     font-variant-numeric: tabular-nums slashed-zero;
     width: fit-content;
-    background: ${props => props.theme.BG_LIGHT_GREY};
-    border: 1px solid ${props => props.theme.STROKE_GREY};
+    background: ${({ theme }) => theme.BG_LIGHT_GREY};
+    border: 1px solid ${({ theme }) => theme.STROKE_GREY};
     border-radius: 8px;
     word-break: break-all;
     padding: 10px;

--- a/packages/suite/src/views/wallet/tokens/components/NoTokens.tsx
+++ b/packages/suite/src/views/wallet/tokens/components/NoTokens.tsx
@@ -2,37 +2,30 @@ import React from 'react';
 import { Button } from '@trezor/components';
 import { AccountExceptionLayout } from 'src/components/wallet';
 import { Translation } from 'src/components/suite';
-import * as modalActions from 'src/actions/suite/modalActions';
-import { useActions, useSelector } from 'src/hooks/suite';
+import { openModal } from 'src/actions/suite/modalActions';
+import { useDispatch, useSelector } from 'src/hooks/suite';
 
 export const NoTokens = () => {
-    const { selectedAccount } = useSelector(state => ({
-        selectedAccount: state.wallet.selectedAccount,
-    }));
+    const selectedAccount = useSelector(state => state.wallet.selectedAccount);
+    const dispatch = useDispatch();
 
-    const { openModal } = useActions({
-        openModal: modalActions.openModal,
-    });
     if (selectedAccount.status !== 'loaded') return null;
 
     const { account } = selectedAccount;
 
-    const addButton = (
-        <Button
-            variant="primary"
-            onClick={() => {
-                openModal({ type: 'add-token' });
-            }}
-        >
-            <Translation id="TR_TOKENS_ADD" />
-        </Button>
-    );
+    const handleButtonClick = () => dispatch(openModal({ type: 'add-token' }));
 
     return (
         <AccountExceptionLayout
             title={<Translation id="TR_TOKENS_EMPTY" />}
             image="CLOUDY"
-            actionComponent={account.networkType !== 'cardano' ? addButton : undefined}
+            actionComponent={
+                account.networkType !== 'cardano' ? (
+                    <Button variant="primary" onClick={handleButtonClick}>
+                        <Translation id="TR_TOKENS_ADD" />
+                    </Button>
+                ) : undefined
+            }
         />
     );
 };

--- a/packages/suite/src/views/wallet/transactions/components/AccountEmpty.tsx
+++ b/packages/suite/src/views/wallet/transactions/components/AccountEmpty.tsx
@@ -4,10 +4,10 @@ import { analytics, EventType } from '@trezor/suite-analytics';
 
 import { variables, H2, Button, Card, Image } from '@trezor/components';
 import { Translation } from 'src/components/suite';
-import { useActions, useSelector } from 'src/hooks/suite';
+import { useDispatch, useSelector } from 'src/hooks/suite';
 import { Account } from 'src/types/wallet';
-import * as suiteActions from 'src/actions/suite/suiteActions';
-import * as routerActions from 'src/actions/suite/routerActions';
+import { setFlag } from 'src/actions/suite/suiteActions';
+import { goto } from 'src/actions/suite/routerActions';
 import { TaprootBanner } from './TaprootBanner';
 import { getBip43Type } from '@suite-common/wallet-utils';
 
@@ -70,17 +70,13 @@ interface AccountEmptyProps {
 
 export const AccountEmpty = ({ account }: AccountEmptyProps) => {
     const { taprootBannerClosed } = useSelector(state => state.suite.flags);
-
-    const { goto, setFlag } = useActions({
-        goto: routerActions.goto,
-        setFlag: suiteActions.setFlag,
-    });
+    const dispatch = useDispatch();
 
     const bip43 = getBip43Type(account.path);
     const networkSymbol = account.symbol.toUpperCase();
 
     const handleNavigateToReceivePage = () => {
-        goto('wallet-receive', { preserveParams: true });
+        dispatch(goto('wallet-receive', { preserveParams: true }));
         analytics.report({
             type: EventType.AccountsEmptyAccountReceive,
             payload: {
@@ -88,9 +84,8 @@ export const AccountEmpty = ({ account }: AccountEmptyProps) => {
             },
         });
     };
-
     const handleNavigateToBuyPage = () => {
-        goto('wallet-coinmarket-buy', { preserveParams: true });
+        dispatch(goto('wallet-coinmarket-buy', { preserveParams: true }));
 
         analytics.report({
             type: EventType.AccountsEmptyAccountBuy,
@@ -99,12 +94,11 @@ export const AccountEmpty = ({ account }: AccountEmptyProps) => {
             },
         });
     };
+    const closeBanner = () => dispatch(setFlag('taprootBannerClosed', true));
 
     return (
         <Wrapper>
-            {bip43 === 'bip86' && !taprootBannerClosed && (
-                <TaprootBanner onClose={() => setFlag('taprootBannerClosed', true)} />
-            )}
+            {bip43 === 'bip86' && !taprootBannerClosed && <TaprootBanner onClose={closeBanner} />}
 
             <StyledCard>
                 <StyledImage image="CLOUDY" />

--- a/packages/suite/src/views/wallet/transactions/components/NoSearchResults.tsx
+++ b/packages/suite/src/views/wallet/transactions/components/NoSearchResults.tsx
@@ -7,7 +7,7 @@ import { getRandomNumberInRange } from '@trezor/utils';
 const NoResults = styled(Card)`
     display: flex;
     text-align: center;
-    color: ${props => props.theme.TYPE_DARK_GREY};
+    color: ${({ theme }) => theme.TYPE_DARK_GREY};
     font-size: ${variables.FONT_SIZE.NORMAL};
     font-weight: ${variables.FONT_WEIGHT.MEDIUM};
 `;
@@ -16,7 +16,7 @@ const Examples = styled.div`
     display: flex;
     flex-direction: column;
     margin-top: 12px;
-    color: ${props => props.theme.TYPE_LIGHT_GREY};
+    color: ${({ theme }) => theme.TYPE_LIGHT_GREY};
     font-size: ${variables.FONT_SIZE.SMALL};
     font-style: italic;
 `;

--- a/packages/suite/src/views/wallet/transactions/components/TaprootBanner.tsx
+++ b/packages/suite/src/views/wallet/transactions/components/TaprootBanner.tsx
@@ -7,8 +7,8 @@ const StyledCard = styled(Card)`
     width: 100%;
     margin-bottom: 48px;
     padding: 24px 28px 24px 18px;
-    border-left: 10px solid ${props => props.theme.TYPE_GREEN};
-    box-shadow: 0 2px 5px 0 ${props => props.theme.BOX_SHADOW_BLACK_20};
+    border-left: 10px solid ${({ theme }) => theme.TYPE_GREEN};
+    box-shadow: 0 2px 5px 0 ${({ theme }) => theme.BOX_SHADOW_BLACK_20};
 `;
 
 const Heading = styled.div`
@@ -27,7 +27,7 @@ const Point = styled.div`
     font-size: ${variables.FONT_SIZE.SMALL};
     font-weight: 500;
     text-align: center;
-    color: ${props => props.theme.TYPE_LIGHT_GREY};
+    color: ${({ theme }) => theme.TYPE_LIGHT_GREY};
 
     & + & {
         margin-top: 10px;
@@ -35,7 +35,7 @@ const Point = styled.div`
 `;
 
 const Dark = styled.span`
-    color: ${props => props.theme.TYPE_DARK_GREY};
+    color: ${({ theme }) => theme.TYPE_DARK_GREY};
 `;
 
 const StyledIcon = styled(Icon)`
@@ -45,7 +45,7 @@ const StyledIcon = styled(Icon)`
 const Divider = styled.div`
     width: 100%;
     height: 1px;
-    background: ${props => props.theme.STROKE_GREY};
+    background: ${({ theme }) => theme.STROKE_GREY};
     margin: 16px 0px 20px 0px;
 `;
 

--- a/packages/suite/src/views/wallet/transactions/components/TransactionCandidates.tsx
+++ b/packages/suite/src/views/wallet/transactions/components/TransactionCandidates.tsx
@@ -47,7 +47,7 @@ const Wrapper = styled(Card)`
 `;
 
 const Text = styled.div`
-    color: ${props => props.theme.TYPE_DARK_GREY};
+    color: ${({ theme }) => theme.TYPE_DARK_GREY};
     font-size: ${variables.FONT_SIZE.NORMAL};
     font-weight: ${variables.FONT_WEIGHT.MEDIUM};
 `;

--- a/packages/suite/src/views/wallet/transactions/components/TransactionList.tsx
+++ b/packages/suite/src/views/wallet/transactions/components/TransactionList.tsx
@@ -5,7 +5,7 @@ import useDebounce from 'react-use/lib/useDebounce';
 import { Stack } from 'src/components/suite/Skeleton';
 import { Translation } from 'src/components/suite';
 import { Section } from 'src/components/dashboard';
-import { useSelector, useActions } from 'src/hooks/suite';
+import { useDispatch, useSelector } from 'src/hooks/suite';
 import {
     groupTransactionsByDate,
     advancedSearchTransactions,
@@ -46,10 +46,9 @@ export const TransactionList = ({
     account,
     symbol,
 }: TransactionListProps) => {
-    const { anchor, localCurrency } = useSelector(state => ({
-        localCurrency: state.wallet.settings.localCurrency,
-        anchor: state.router.anchor,
-    }));
+    const localCurrency = useSelector(state => state.wallet.settings.localCurrency);
+    const anchor = useSelector(state => state.router.anchor);
+    const dispatch = useDispatch();
 
     const network = getAccountNetwork(account);
 
@@ -57,10 +56,6 @@ export const TransactionList = ({
     const [search, setSearch] = useState('');
     const [searchedTransactions, setSearchedTransactions] = useState(transactions);
     const [hasFetchedAll, setHasFetchedAll] = useState(false);
-
-    const { fetchTransactions } = useActions({
-        fetchTransactions: fetchTransactionsThunk,
-    });
 
     const sectionRef = useRef<HTMLDivElement>(null);
 
@@ -75,16 +70,18 @@ export const TransactionList = ({
 
     useEffect(() => {
         if (anchor && !hasFetchedAll) {
-            fetchTransactions({
-                accountKey: account.key,
-                page: 2,
-                perPage: SETTINGS.TXS_PER_PAGE,
-                noLoading: true,
-                recursive: true,
-            });
+            dispatch(
+                fetchTransactionsThunk({
+                    accountKey: account.key,
+                    page: 2,
+                    perPage: SETTINGS.TXS_PER_PAGE,
+                    noLoading: true,
+                    recursive: true,
+                }),
+            );
             setHasFetchedAll(true);
         }
-    }, [anchor, fetchTransactions, account, hasFetchedAll]);
+    }, [anchor, account, dispatch, hasFetchedAll]);
 
     // Pagination
     const perPage = SETTINGS.TXS_PER_PAGE;
@@ -103,7 +100,7 @@ export const TransactionList = ({
         setSelectedPage(page);
 
         if (!isSearching) {
-            fetchTransactions({ accountKey: account.key, page, perPage });
+            dispatch(fetchTransactionsThunk({ accountKey: account.key, page, perPage }));
         }
 
         if (sectionRef.current) {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

I have been working on some refactoring on and off. It should make the code style feel more unified and less misleading for new contributors.

- replacing `useActions` with `useDispatch` as recommended by [Code Style Guide](https://www.notion.so/satoshilabs/Redux-b0a4c3b7e71b499a8d592fb44cd794fe?pvs=4#12231761e4c242b2a446c15e51ce22fa)
- removing some unnecessary memoization
- moving logic from JSX to component body for improved readability
- simplifying `useSelector` syntax as recommended by [Code Style Guide](https://www.notion.so/satoshilabs/Redux-b0a4c3b7e71b499a8d592fb44cd794fe?pvs=4#e72125b6582f40688c7eb794ae85811b)
- renaming `Props` to `<component name>Props` as in the majority of components
- destructuring props in `styled-components` declarations as in the majority of components

The first commit includes all of the above, sorry, others are better structured.

The original plan was to remove `useActions` altogether, but it is useful when an action is returned from a hook or passed as a callback. I kept it in the files where it is used this way.