### PR TITLE
Reset Tor circuit on 403 from Blockbook websocket

### DIFF
--- a/packages/coinjoin/src/backend/backendUtils.ts
+++ b/packages/coinjoin/src/backend/backendUtils.ts
@@ -42,3 +42,12 @@ export const deriveAddresses = (
         : [];
     return prederived.slice(fromPrederived, fromPrederived + countPrederived).concat(derived);
 };
+
+// https://github.com/websockets/ws/blob/0b235e0f9b650b1bdcbdb974cbeaaaa6a0797855/lib/websocket.js#L891
+export const isWsError403 = (error: Error) => error?.message === 'Unexpected server response: 403';
+
+// Randomize identity password to reset TOR circuit for this identity
+export const resetIdentityCircuit = (identity: string) => {
+    const [user] = identity.split(':');
+    return `${user}:${Math.random().toString(36).slice(2)}`;
+};

--- a/packages/coinjoin/tests/backend/CoinjoinBackendClient.test.ts
+++ b/packages/coinjoin/tests/backend/CoinjoinBackendClient.test.ts
@@ -26,7 +26,7 @@ describe('CoinjoinBackendClient', () => {
         (client as any).websockets = {
             getOrCreate: ({ url }: { url: string }) => {
                 [lastBackend] = (url as string).split('/');
-                return new Proxy({}, { get: (_, b) => b !== 'then' && (() => undefined) });
+                return new Proxy({}, { get: (_, b, c) => b !== 'then' && (() => c) });
             },
             getSocketId: () => undefined,
         };

--- a/packages/request-manager/src/torIdentities.ts
+++ b/packages/request-manager/src/torIdentities.ts
@@ -4,10 +4,12 @@ import type { TorSettings } from './types';
 export class TorIdentities {
     private readonly getTorSettings: () => TorSettings;
     private readonly identities: { [key: string]: SocksProxyAgent };
+    private readonly passwords: { [key: string]: string };
 
     constructor(getTorSettings: () => TorSettings) {
         this.getTorSettings = getTorSettings;
         this.identities = {};
+        this.passwords = {};
     }
 
     public getIdentity(
@@ -17,8 +19,11 @@ export class TorIdentities {
     ): SocksProxyAgent {
         const [user, password] = identity.split(':');
 
-        if (this.identities[user] && password) {
-            this.removeIdentity(user);
+        if (password && this.passwords[user] !== password) {
+            if (this.identities[user]) {
+                this.removeIdentity(user);
+            }
+            this.passwords[user] = password;
         }
 
         const { host, port } = this.getTorSettings();
@@ -48,5 +53,6 @@ export class TorIdentities {
         // looks like destroy does nothing, but just in case
         this.identities[user].destroy();
         delete this.identities[user];
+        delete this.passwords[user];
     }
 }


### PR DESCRIPTION
## Description

Catch `403 Forbidden` when opening Blockbook websockets during CJ discovery and reset the corresponding Tor circuit (in the same way as for HTTP requests).

Wasn't tested _in the wild_ as I'm currently unable to get 403's :upside_down_face: .

## Related Issue

One part of #8960
