### PR TITLE
Remove inconsistent txs from CJ mempool

### DIFF
--- a/packages/coinjoin/src/backend/backendUtils.ts
+++ b/packages/coinjoin/src/backend/backendUtils.ts
@@ -28,6 +28,14 @@ export const isTaprootTx = (tx: VinVoutAddressTx, network: Network) =>
 export const doesTxContainAddress = (address: string) => (tx: VinVoutAddressTx) =>
     doesAnyAddressFulfill(tx, addr => addr === address);
 
+export const isDoublespend = (
+    { vin: vinA }: { vin: VinVout[] },
+    { vin: vinB }: { vin: VinVout[] },
+) =>
+    vinA.some(({ txid: txidA, vout: voutA = 0 }) =>
+        vinB.some(({ txid: txidB, vout: voutB = 0 }) => txidA === txidB && voutA === voutB),
+    );
+
 export const deriveAddresses = (
     prederived: PrederivedAddress[] = [],
     ...[descriptor, type, from, count, network]: Parameters<typeof deriveNewAddresses>

--- a/packages/coinjoin/tests/backend/CoinjoinMempoolController.test.ts
+++ b/packages/coinjoin/tests/backend/CoinjoinMempoolController.test.ts
@@ -79,4 +79,22 @@ describe('CoinjoinMempoolController', () => {
         await mempool.init();
         expect(mempool.getTransactions()).toEqual([TXS[1], TXS[3], TXS[4]]);
     });
+
+    it('Replace-by-fee', async () => {
+        const outpointCollision = { txid: 'foo', vout: 3 };
+        const a1 = TXS[1];
+        a1.vin[0] = { ...a1.vin[0], ...outpointCollision };
+        const b = TXS[2];
+        const a2 = TXS[4];
+        a2.vin[1] = { ...a2.vin[1], ...outpointCollision };
+
+        client.setMempoolTxs([a1]);
+        await mempool.start();
+        await mempool.init();
+        expect(mempool.getTransactions()).toEqual([a1]);
+        client.fireTx(b);
+        expect(mempool.getTransactions()).toEqual([a1, b]);
+        client.fireTx(a2);
+        expect(mempool.getTransactions()).toEqual([b, a2]);
+    });
 });

--- a/packages/coinjoin/tests/fixtures/methods.fixture.ts
+++ b/packages/coinjoin/tests/fixtures/methods.fixture.ts
@@ -41,6 +41,7 @@ export const BLOCKS = [
                         addresses: ['mkUzYq8aQ4xzgPoCw8QVsRzkn1dceiPzmi'],
                         isAddress: true,
                         value: '1578625117',
+                        txid: 'foo',
                     },
                 ],
                 vout: [
@@ -125,6 +126,7 @@ export const BLOCKS = [
                         ],
                         isAddress: true,
                         value: '1000000000',
+                        txid: 'bar',
                     },
                 ],
                 vout: [
@@ -257,6 +259,7 @@ export const BLOCKS = [
                         ],
                         isAddress: true,
                         value: '999999311',
+                        txid: 'baz',
                     },
                 ],
                 vout: [


### PR DESCRIPTION
## Description

When CJ mempool receives tx which is RBF for some of the already known pending txs, these txs are removed first. This resolves potential duplicity of pending transactions on CJ account.

## Related issues

Prerequisite for CJ accounts RBF support.