### PR TITLE
Add official and community label to languages

### DIFF
--- a/packages/suite/src/config/suite/languages.ts
+++ b/packages/suite/src/config/suite/languages.ts
@@ -1,12 +1,12 @@
 export const TRANSLATION_PSEUDOLANGUAGE = 'lol' as const;
 
 const LANGUAGES = {
-    en: { name: 'English', en: 'English', complete: true },
-    es: { name: 'Español', en: 'Spanish', complete: true },
+    en: { name: 'English', en: 'English', complete: true, official: true },
+    es: { name: 'Español', en: 'Spanish', complete: true, official: false  },
     af: { name: 'Afrikaans', en: 'Afrikaans' },
     ar: { name: 'العربية‬', en: 'Arabic' },
     ca: { name: 'Català', en: 'Catalan' },
-    cs: { name: 'Čeština', en: 'Czech', complete: true },
+    cs: { name: 'Česky', en: 'Czech', complete: true, official: true },
     da: { name: 'Dansk', en: 'Danish' },
     de: { name: 'Deutsch', en: 'German' },
     el: { name: 'Ελληνικά', en: 'Greek' },
@@ -14,10 +14,10 @@ const LANGUAGES = {
     fr: { name: 'Français', en: 'French' },
     he: { name: 'עברית‬', en: 'Hebrew' },
     hi: { name: 'हिन्दी', en: 'Hindi' },
-    hu: { name: 'Magyar', en: 'Hungarian' },
+    hu: { name: 'Magyar', en: 'Hungarian', complete: true, official: false },
     id: { name: 'Bahasa Indonesia', en: 'Indonesian' },
-    it: { name: 'Italiano', en: 'Italian' },
-    ja: { name: '日本語（ベータ版）', en: 'Japanese (BETA)', complete: true },
+    it: { name: 'Italiano', en: 'Italian', official: false },
+    ja: { name: '日本語（ベータ版）', en: 'Japanese (BETA)', complete: true, official: false },
     jv: { name: 'Basa Jawa', en: 'Javanese' },
     ko: { name: '한국어', en: 'Korean' },
     nl: { name: 'Nederlands', en: 'Dutch' },
@@ -25,14 +25,14 @@ const LANGUAGES = {
     pl: { name: 'Polski', en: 'Polish' },
     pt: { name: 'Português', en: 'Portuguese' },
     ro: { name: 'Română', en: 'Romanian' },
-    ru: { name: 'Русский', en: 'Russian', complete: true },
+    ru: { name: 'Русский', en: 'Russian', complete: true, official: false  },
     sk: { name: 'Slovenčina', en: 'Slovak' },
     sr: { name: 'Српски', en: 'Serbian' },
     sv: { name: 'Svenska', en: 'Swedish' },
     tr: { name: 'Türkçe', en: 'Turkish' },
     uk: { name: 'Українська', en: 'Ukrainian' },
     vi: { name: 'Tiếng Việt', en: 'Vietnamese' },
-    'zh-CN': { name: '中文(简体)', en: 'Chinese Simplified' },
+    'zh-CN': { name: '中文(简体)', en: 'Chinese Simplified', official: false  },
     [TRANSLATION_PSEUDOLANGUAGE]: { name: 'TRANSLATION', en: 'TRANSLATION' },
 } as const;
 
@@ -42,6 +42,7 @@ export type LocaleInfo = {
     name: string;
     en: string;
     complete?: boolean;
+    official?: boolean;
 };
 
 export default LANGUAGES as { [code in Locale]: LocaleInfo };

--- a/packages/suite/src/config/suite/languages.ts
+++ b/packages/suite/src/config/suite/languages.ts
@@ -6,7 +6,7 @@ const LANGUAGES = {
     af: { name: 'Afrikaans', en: 'Afrikaans' },
     ar: { name: 'العربية‬', en: 'Arabic' },
     ca: { name: 'Català', en: 'Catalan' },
-    cs: { name: 'Česky', en: 'Czech', complete: true, official: true },
+    cs: { name: 'Čeština', en: 'Czech', complete: true, official: true },
     da: { name: 'Dansk', en: 'Danish' },
     de: { name: 'Deutsch', en: 'German' },
     el: { name: 'Ελληνικά', en: 'Greek' },

--- a/packages/suite/src/support/messages.ts
+++ b/packages/suite/src/support/messages.ts
@@ -2703,6 +2703,16 @@ export default defineMessages({
         defaultMessage: 'Language',
         id: 'TR_LANGUAGE',
     },
+    TR_LANGUAGE_COMMUNITY: {
+        id: 'TR_LANGUAGE_COMMUNITY',
+        defaultMessage: 'Community translation',
+        description: 'The translation is maintained by the community',
+    },
+    TR_LANGUAGE_OFFICIAL: {
+        id: 'TR_LANGUAGE_OFFICIAL',
+        defaultMessage: 'Official language',
+        description: 'Officially supported language',
+    },
     TR_LEARN: {
         defaultMessage: 'Learn',
         description: 'Link to Suite Guide.',

--- a/packages/suite/src/views/settings/general/Language.tsx
+++ b/packages/suite/src/views/settings/general/Language.tsx
@@ -12,8 +12,11 @@ import { useAnchor } from 'src/hooks/suite/useAnchor';
 import { SettingsAnchor } from 'src/constants/suite/anchors';
 import { getPlatformLanguages } from '@trezor/env-utils';
 
-const onlyComplete = (locale: [string, LocaleInfo]): locale is [Locale, LocaleInfo] =>
-    !!locale[1].complete;
+const officialLanguage = (locale: [string, LocaleInfo]): locale is [Locale, LocaleInfo] =>
+    !!locale[1].complete && !!locale[1].official;
+
+const communityLanguage = (locale: [string, LocaleInfo]): locale is [Locale, LocaleInfo] =>
+    !!locale[1].complete && !locale[1].official;
 
 const useLanguageOptions = () => {
     const { translationString } = useTranslation();
@@ -31,9 +34,14 @@ const useLanguageOptions = () => {
             },
             {
                 options: Object.entries(LANGUAGES)
-                    .filter(onlyComplete)
-                    .map(([value, { name }]) => ({ value, label: name })),
+                    .filter(officialLanguage)
+                    .map(([value, { name }]) => ({ value, label: `${name} (${translationString('TR_LANGUAGE_OFFICIAL')})` }))
             },
+            {
+                options: Object.entries(LANGUAGES)
+                .filter(communityLanguage)
+                .map(([value, { name }]) => ({ value, label: `${name} (${translationString('TR_LANGUAGE_COMMUNITY')})` })),
+            }
         ],
         [systemOption],
     );


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

The languages appear under Settings - Application - Language. I've added labels (inline text) for the languages.

In languages.ts besides the optional "complete" key, I've added another optional key "official" and marked official languages as true, complete unofficial ones as false (could be optional) to be able to differentiate between languages.

These keys are used in Languages.tsx where the options are gathered instead of "onlyComplete", into "officialLanguage" and "communityLanguage". These are then passed into the options of the dropdown menu - first the official ones, then the community translations.
They also get a description in brackets "(Official language)" for official ones, "(Community translation)" for the others. These descriptions use localization / translationString. For these I've added two new values TR_LANGUAGE_OFFICIAL and TR_LANGUAGE_COMMUNITY.

## Related Issue

Resolve https://github.com/trezor/trezor-suite/issues/7624

## Screenshots:

![image](https://github.com/trezor/trezor-suite/assets/79017980/dee6d25d-f215-44f9-949d-249a4f75fd3a)