### PR TITLE
Make allUtxosSelected return false if there are no UTXOs

### DIFF
--- a/packages/suite/src/hooks/wallet/form/useUtxoSelection.ts
+++ b/packages/suite/src/hooks/wallet/form/useUtxoSelection.ts
@@ -80,10 +80,12 @@ export const useUtxoSelection = ({
         [spendableUtxos, lowAnonymityUtxos, dustUtxos].find(utxoCategory => utxoCategory.length) ||
         [];
 
-    // are all UTXOs in the top category selected?
-    const allUtxosSelected = !!topCategory?.every((utxo: AccountUtxo) =>
-        selectedUtxos.some(selected => isSameUtxo(selected, utxo)),
-    );
+    // is there at least one UTXO and are all UTXOs in the top category selected?
+    const allUtxosSelected =
+        !!topCategory.length &&
+        !!topCategory?.every((utxo: AccountUtxo) =>
+            selectedUtxos.some(selected => isSameUtxo(selected, utxo)),
+        );
 
     // transaction composed for the fee level chosen by the user
     const composedLevel = composedLevels?.[selectedFee || 'normal'];


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Cosmetic change. The checkbox should not be checked when there are no UTXOs to choose from.

## Screenshots:
### before:
![Screenshot 2023-07-26 at 10 08 30](https://github.com/trezor/trezor-suite/assets/42465546/a1249667-7338-482b-9199-57e64c05d490)
### after:
![Screenshot 2023-07-26 at 10 08 02](https://github.com/trezor/trezor-suite/assets/42465546/5a663ad9-b8b0-48a0-89cf-b432d52f40f1)

