### PR TITLE
Use reboot to bootloader feature for T2 >=2.6.0

### DIFF
--- a/packages/connect/src/api/rebootToBootloader.ts
+++ b/packages/connect/src/api/rebootToBootloader.ts
@@ -16,7 +16,7 @@ export default class RebootToBootloader extends AbstractMethod<'rebootToBootload
         this.useDeviceState = false;
         this.firmwareRange = getFirmwareRange(this.name, null, {
             1: { min: '1.10.0', max: '0' },
-            2: { min: '0', max: '0' },
+            2: { min: '2.6.0', max: '0' },
         });
     }
 

--- a/packages/suite/src/hooks/firmware/useRebootRequest.ts
+++ b/packages/suite/src/hooks/firmware/useRebootRequest.ts
@@ -20,14 +20,14 @@ export const useRebootRequest = (
     const [phase, setPhase] = useState<RebootPhase>('initial');
 
     // Default reboot method is 'manual'. If the device is connected when
-    // the hook is first called and it is T1 with sufficient fw version,
+    // the hook is first called and fw version is sufficient,
     // then the 'automatic' method is enabled.
     const [method, setMethod] = useState<RebootMethod>(() => {
         if (!device?.connected || !device?.features) return 'manual';
         const deviceFwVersion = getFirmwareVersion(device);
         return requestedMode === 'bootloader' &&
             valid(deviceFwVersion) &&
-            satisfies(deviceFwVersion, '>=1.10.0 <2.0.0')
+            satisfies(deviceFwVersion, '>=1.10.0 <2.0.0 || >=2.6.0')
             ? 'automatic'
             : 'manual';
     });


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

It was available on T1 only since 1.10.0 and now it's available on T2 without experimental features too.

The flow is not ideal because of an extra step to click INSTALL FIRMWARE/FW, [see comment here](https://github.com/trezor/trezor-suite/issues/7961#issuecomment-1651251886). But it's not worse than it was so let's address that in other issue/PR.

## Related Issue

Resolve https://github.com/trezor/trezor-suite/issues/7961

## Screenshots:
<img width="647" alt="image" src="https://github.com/trezor/trezor-suite/assets/3729633/2d5de52f-e03d-4dc1-aad8-9360c2c98f81">


# Notes for QA:
Please test all FW installation flows 
- onboarding
- settings
- FW upgrade vs FW installation (with no FW on the device)

both bridge (desktop app) and webusb (chrome) 🙏 
