### PR TITLE
Fix/unable to bump fee

### DIFF
--- a/packages/suite/src/hooks/wallet/useRbfForm.ts
+++ b/packages/suite/src/hooks/wallet/useRbfForm.ts
@@ -38,24 +38,24 @@ const getEthereumFeeInfo = (info: FeeInfo, gasPrice: string) => {
         fromWei(info.levels[0].feePerUnit, 'gwei'),
     ).integerValue(BigNumber.ROUND_FLOOR);
 
-    const getMinFee = () => {
+    const getFee = () => {
         if (minFeeFromNetwork.lte(current)) {
             return current.plus(1);
         }
         return minFeeFromNetwork;
     };
 
-    const minFee = getMinFee();
+    const fee = getFee();
 
     // increase FeeLevel only if it's lower than predefined
     const levels = getFeeLevels('ethereum', info).map(l => ({
         ...l,
-        feePerUnit: minFee.toString(),
+        feePerUnit: fee.toString(),
     }));
     return {
         ...info,
         levels,
-        minFee: minFee.toNumber(), // increase required minFee rate
+        minFee: current.plus(1).toNumber(), // increase required minFee rate
     };
 };
 


### PR DESCRIPTION
Fixed minimum gas price when replacing tx

## Description

Form error handler not accepts for replacing tx  minimum gas price `2`  (tx created with gas price `1`).

## Related Issue

Resolve #8972 

## Screenshots:

This was created with gas price 5
![Screenshot 2023-07-26 at 1 17 36 PM](https://github.com/trezor/trezor-suite/assets/66002635/728c0b59-25c2-4bf1-86f0-dde6c55b5a60)

