### PR TITLE
Fix: coinjoin registered utxo selector

### DIFF
--- a/packages/coinjoin/src/client/CoinjoinClient.ts
+++ b/packages/coinjoin/src/client/CoinjoinClient.ts
@@ -177,7 +177,7 @@ export class CoinjoinClient extends TypedEmitter<CoinjoinClientEvents> {
         rounds,
     }: Pick<CoinjoinStatusEvent, 'changed' | 'rounds'>) {
         // try to release inputs from prison
-        this.prison.release();
+        this.prison.release(rounds.map(r => r.id));
 
         // find all CoinjoinRounds changed by Status
         const roundsToProcess = await Promise.all(

--- a/packages/coinjoin/src/client/CoinjoinPrison.ts
+++ b/packages/coinjoin/src/client/CoinjoinPrison.ts
@@ -134,10 +134,18 @@ export class CoinjoinPrison extends TypedEmitter<CoinjoinPrisonEvents> {
     }
 
     // called on each status change before rounds are processed
-    release() {
+    release(rounds: string[]) {
         const now = Date.now();
         const prevLen = this.inmates.length;
-        this.inmates = this.inmates.filter(inmate => inmate.sentenceEnd > now);
+
+        this.inmates = this.inmates.filter(inmate => {
+            if (inmate.sentenceEnd !== Infinity && inmate.roundId) {
+                // release inmates assigned to Round which is no longer present in Status
+                // regardless of their sentenceEnd
+                if (!rounds.includes(inmate.roundId)) return false;
+            }
+            return inmate.sentenceEnd > now;
+        });
 
         if (prevLen !== this.inmates.length) {
             this.dispatchChange();

--- a/packages/coinjoin/tests/client/CoinjoinPrison.test.ts
+++ b/packages/coinjoin/tests/client/CoinjoinPrison.test.ts
@@ -1,0 +1,24 @@
+import { CoinjoinPrison } from '../../src/client/CoinjoinPrison';
+
+describe('CoinjoinPrison', () => {
+    it('release inmate when Round is no longer present in Status', done => {
+        const inmate = {
+            accountKey: 'account-A',
+            type: 'input',
+            sentenceStart: Date.now() - 10000,
+        } as const;
+
+        const prison = new CoinjoinPrison([
+            { ...inmate, id: '00AA', roundId: '00', sentenceEnd: Date.now() + 10000 }, // will be released - round not present)
+            { ...inmate, id: '00AB', roundId: '00', sentenceEnd: Infinity }, // will NOT be released - sentence Infinity
+            { ...inmate, id: '01AA', roundId: '01', sentenceEnd: Date.now() + 10000 }, // wil NOT be released - round IS present
+            { ...inmate, id: '01AB', roundId: '01', sentenceEnd: Date.now() - 1 }, // will be released - sentence is lower
+        ]);
+
+        prison.on('change', () => done()); // end test after change event
+
+        prison.release(['01']); // only one round is present in Status
+
+        expect(prison.inmates.map(({ id }) => id)).toEqual(['00AB', '01AA']);
+    });
+});

--- a/packages/suite/src/actions/wallet/__fixtures__/coinjoinAccountActions.ts
+++ b/packages/suite/src/actions/wallet/__fixtures__/coinjoinAccountActions.ts
@@ -253,7 +253,6 @@ export const restoreCoinjoinAccounts = [
         },
         result: {
             actions: [
-                COINJOIN.SESSION_PAUSE, // pause account-A session
                 COINJOIN.CLIENT_ENABLE,
                 COINJOIN.CLIENT_ENABLE_FAILED,
                 notificationsActions.addToast.type, // failed account 1 + 2 client init

--- a/packages/suite/src/actions/wallet/coinjoinAccountActions.ts
+++ b/packages/suite/src/actions/wallet/coinjoinAccountActions.ts
@@ -899,16 +899,9 @@ export const restoreCoinjoinAccounts = () => (dispatch: Dispatch, getState: GetS
 
     // find all networks to restore
     const coinjoinNetworks = coinjoin.accounts.reduce<NetworkSymbol[]>((res, account) => {
-        // currently it is not possible to full restore session while using passphrase.
-        // related to @trezor/connect and inner-outer state
-        if (account.session && !account.session.paused) {
-            dispatch(coinjoinClientActions.pauseCoinjoinSession(account.key));
-        }
-
         if (!res.includes(account.symbol)) {
             return res.concat(account.symbol);
         }
-
         return res;
     }, []);
 

--- a/packages/suite/src/actions/wallet/send/sendFormBitcoinActions.ts
+++ b/packages/suite/src/actions/wallet/send/sendFormBitcoinActions.ts
@@ -82,7 +82,7 @@ export const composeTransaction =
               });
 
         // certain change addresses might be temporary blocked by coinjoin process
-        // exclude addresses which exists in "prison" dataset (see coinjoinReducer/selectBlockedUtxosByAccountKey)
+        // exclude addresses which exists in "prison" dataset (see coinjoinReducer/selectRegisteredUtxosByAccountKey)
         const changeAddresses = prison
             ? account.addresses.change.filter(a => !prison[a.address])
             : account.addresses.change;

--- a/packages/suite/src/reducers/wallet/__fixtures__/coinjoinReducer.ts
+++ b/packages/suite/src/reducers/wallet/__fixtures__/coinjoinReducer.ts
@@ -21,7 +21,7 @@ const account = {
     },
 };
 
-export default [
+export const actionFixtures = [
     {
         description: 'updateSessionPhase initial',
         initialState: {
@@ -160,5 +160,64 @@ export default [
                 },
             ],
         },
+    },
+];
+
+export const selectorFixtures = [
+    {
+        description: 'missing prison object',
+        selector: 'selectRegisteredUtxosByAccountKey' as const,
+        selectorArgs: [account.key],
+        initialState: {
+            ...initialState,
+            accounts: [account],
+        },
+        result: undefined,
+    },
+    {
+        description: 'with one blocked input',
+        selector: 'selectRegisteredUtxosByAccountKey' as const,
+        selectorArgs: [account.key],
+        initialState: {
+            ...initialState,
+            accounts: [
+                {
+                    ...account,
+                    prison: { A0: { roundId: '00' }, A1: { reason: 'this will not be picked' } },
+                },
+            ],
+        },
+        result: { A0: { roundId: '00' } },
+    },
+    {
+        description: 'with two blocked inputs (no session but with tx candidate)',
+        selector: 'selectRegisteredUtxosByAccountKey' as const,
+        selectorArgs: [account.key],
+        initialState: {
+            ...initialState,
+            accounts: [
+                {
+                    ...account,
+                    prison: {
+                        A0: { roundId: '00' },
+                        A1: { roundId: '11', reason: 'this will not be picked' },
+                        A2: { roundId: '00' },
+                    },
+                    session: undefined,
+                    transactionCandidates: [{ roundId: '00' }],
+                },
+            ],
+        },
+        result: { A0: { roundId: '00' }, A2: { roundId: '00' } },
+    },
+    {
+        description: 'with blocked input ignored (no session + no tx candidate)',
+        selector: 'selectRegisteredUtxosByAccountKey' as const,
+        selectorArgs: [account.key],
+        initialState: {
+            ...initialState,
+            accounts: [{ ...account, prison: { A0: { roundId: '00' } }, session: undefined }],
+        },
+        result: {},
     },
 ];

--- a/packages/suite/src/reducers/wallet/__tests__/coinjoinReducer.test.ts
+++ b/packages/suite/src/reducers/wallet/__tests__/coinjoinReducer.test.ts
@@ -1,16 +1,44 @@
-import { coinjoinReducer, CoinjoinState } from '../coinjoinReducer';
-import fixtures from '../__fixtures__/coinjoinReducer';
+import {
+    coinjoinReducer,
+    CoinjoinState,
+    CoinjoinRootState,
+    selectRegisteredUtxosByAccountKey,
+} from '../coinjoinReducer';
+import { actionFixtures, selectorFixtures } from '../__fixtures__/coinjoinReducer';
 
 import type { Action } from 'src/types/suite';
 
-describe('Coinjoin reducer', () => {
-    fixtures.forEach(f => {
+describe('Coinjoin reducer actions', () => {
+    actionFixtures.forEach(f => {
         it(f.description, () => {
             let state = f.initialState as unknown as CoinjoinState;
             f.actions.forEach(a => {
                 state = coinjoinReducer(state, a as Action);
             });
             expect(state).toEqual(f.result);
+        });
+    });
+});
+
+describe('Coinjoin reducer selectors', () => {
+    const selectors = { selectRegisteredUtxosByAccountKey };
+
+    selectorFixtures.forEach(f => {
+        it(`${f.selector}: ${f.description}`, () => {
+            const state = {
+                suite: {},
+                wallet: {
+                    accounts: [],
+                    selectedAccount: {},
+                    coinjoin: f.initialState,
+                },
+            } as unknown as CoinjoinRootState;
+
+            const selectorFn = selectors[f.selector];
+            const args = [state, ...f.selectorArgs] as unknown as Parameters<typeof selectorFn>;
+
+            const result = selectorFn(...args);
+            expect(result).toEqual(f.result);
         });
     });
 });

--- a/packages/suite/src/views/wallet/send/index.tsx
+++ b/packages/suite/src/views/wallet/send/index.tsx
@@ -14,7 +14,7 @@ import { ReviewButton } from './components/ReviewButton';
 import Raw from './components/Raw';
 import {
     selectTargetAnonymityByAccountKey,
-    selectBlockedUtxosByAccountKey,
+    selectRegisteredUtxosByAccountKey,
 } from 'src/reducers/wallet/coinjoinReducer';
 
 const StyledCard = styled(Card)`
@@ -44,7 +44,7 @@ const SendLoaded = ({ children, selectedAccount }: SendLoadedProps) => {
         sendRaw: state.wallet.send.sendRaw,
         metadataEnabled: state.metadata.enabled && !!state.metadata.provider,
         targetAnonymity: selectTargetAnonymityByAccountKey(state, selectedAccount.account.key),
-        prison: selectBlockedUtxosByAccountKey(state, selectedAccount.account.key),
+        prison: selectRegisteredUtxosByAccountKey(state, selectedAccount.account.key),
     }));
 
     const sendContextValues = useSendForm({ ...props, selectedAccount });


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Prerequisite for https://github.com/trezor/trezor-suite/pull/9021

TLDR; selector should exclude utxos from spending **only** if session is running **or** utxo is promised to successfully signed round (round id exists in transactionCandidates)

## Explanation

utxos stored in `CoinjoinPrison` have assigned `sentenceEnd` to prevent using them too often for example:
If utxo is successfully registered in Round and this round is not yet in critical phase you can still use "stop coinjoin" button.
This action **will not** unregister utxo from the round on coordinator, it will only stop sending `connection-confirmation` and coordinator will unregister it automatically (after ~45 seconds)
By clicking again on "start coinjoin" this utxo **should not** be registered again (until sentenceEnd) to the same or different round.
But it doesnt mean that this utxo is **not spendable** (excluded by selector) it only means that it shouldnt be used in coin registration.
Currently this utxo is **not spendable** until coinjoin package release it from the prison (until sentenceEnd) - which is a bug i discovered while working on `Coin control` feature.

Additionally i've renamed the selector to something more meaningful and also added some unit tests to increase coverage (it's very low already)

## Commits

1. fix in coinjoin package: release inmate from prison before `sentenceEnd` if assigned Round is no longler present in status 
    This means that utxo can be safely registered without `AliceAlreadyRegistered` error
2. fix in suite - described above
3. code hygiene - remove dead code. cj session is no longer stored in indexeddb therfore there is noo need to pause it

