### PR TITLE
fix(suite): only ASCII characters in device label

### DIFF
--- a/packages/suite/src/components/suite/ChangeDeviceLabel.tsx
+++ b/packages/suite/src/components/suite/ChangeDeviceLabel.tsx
@@ -1,0 +1,123 @@
+import React, { useState } from 'react';
+import { analytics, EventType } from '@trezor/suite-analytics';
+import styled, { css } from 'styled-components';
+
+import { Button, INPUT_HEIGHTS, Input } from '@trezor/components';
+import { Translation } from 'src/components/suite';
+import { useDevice, useDispatch, useTranslation } from 'src/hooks/suite';
+import { applySettings } from 'src/actions/settings/deviceSettingsActions';
+import { MAX_LABEL_LENGTH } from 'src/constants/suite/device';
+import { SCREEN_SIZE } from '@trezor/components/src/config/variables';
+import { isAscii } from '@trezor/utils';
+
+const StyledInput = styled(Input)<{ isVertical?: boolean }>`
+    ${props =>
+        props.isVertical &&
+        css`
+            margin: 4px 0 4px 4px;
+
+            &:not(:first-child) {
+                margin-left: 8px;
+            }
+
+            @media (max-width: ${SCREEN_SIZE.SM}) {
+                margin: 0px 0 10px;
+                width: 100%;
+            }
+        `}
+`;
+
+const StyledButton = styled(Button)<{ isVertical?: boolean; isDisabled: boolean }>`
+    height: ${INPUT_HEIGHTS.large}px;
+
+    ${props =>
+        props.isVertical &&
+        css`
+            min-width: 170px;
+            margin: 4px 0 4px 4px;
+            &:not(:first-child) {
+                margin-left: 8px;
+
+                @media (max-width: ${SCREEN_SIZE.SM}) {
+                    margin-left: 0;
+                }
+            }
+
+            @media (max-width: ${SCREEN_SIZE.SM}) {
+                width: 100%;
+                margin: 0;
+            }
+        `}
+`;
+
+interface ChangeDeviceLabelProps {
+    isDeviceLocked: boolean;
+    placeholder?: string;
+    isVertical?: boolean;
+    onClick?: () => void;
+}
+
+export const ChangeDeviceLabel = ({
+    isDeviceLocked,
+    placeholder,
+    isVertical,
+    onClick,
+}: ChangeDeviceLabelProps) => {
+    const { translationString } = useTranslation();
+    const { device } = useDevice();
+    const dispatch = useDispatch();
+
+    const [label, setLabel] = useState(device?.label === placeholder ? '' : device?.label);
+    const [error, setError] = useState<string | null>(null);
+
+    const handleChange: React.ChangeEventHandler<HTMLInputElement> = ({ target: { value } }) => {
+        setLabel(value);
+
+        if (value.length > MAX_LABEL_LENGTH) {
+            setError(
+                translationString('TR_LABEL_ERROR_LENGTH', {
+                    length: 16,
+                }),
+            );
+        } else if (!isAscii(value)) {
+            setError(translationString('TR_LABEL_ERROR_CHARACTERS'));
+        } else {
+            setError(null);
+        }
+    };
+
+    const handleClick = () => {
+        dispatch(applySettings({ label }));
+        analytics.report({
+            type: EventType.SettingsDeviceChangeLabel,
+        });
+        onClick?.();
+    };
+
+    const isDisabled =
+        isDeviceLocked || (!placeholder && label === device?.label) || !!error || !label;
+
+    return (
+        <>
+            <StyledInput
+                width={170}
+                isVertical={isVertical}
+                noTopLabel
+                bottomText={error}
+                value={label}
+                placeholder={placeholder}
+                inputState={error ? 'error' : undefined}
+                onChange={handleChange}
+                data-test="@settings/device/label-input"
+            />
+            <StyledButton
+                isVertical={isVertical}
+                onClick={handleClick}
+                isDisabled={isDisabled}
+                data-test="@settings/device/label-submit"
+            >
+                <Translation id="TR_DEVICE_SETTINGS_DEVICE_EDIT_LABEL" />
+            </StyledButton>
+        </>
+    );
+};

--- a/packages/suite/src/components/suite/Settings/components/ActionColumn.ts
+++ b/packages/suite/src/components/suite/Settings/components/ActionColumn.ts
@@ -1,6 +1,5 @@
-import React from 'react';
 import styled, { css } from 'styled-components';
-import { Input, InputProps, Select, variables, Button } from '@trezor/components';
+import { Select, variables, Button } from '@trezor/components';
 
 const { SCREEN_SIZE } = variables;
 
@@ -16,26 +15,6 @@ export const ActionColumn = styled.div`
         margin-top: 10px;
     }
 `;
-
-const InputWrapper = styled.div`
-    margin: 4px 0 4px 4px;
-    width: 210px;
-
-    &:not(:first-child) {
-        margin-left: 8px;
-    }
-
-    @media (max-width: ${SCREEN_SIZE.SM}) {
-        margin: 0px 0 10px;
-        width: 100%;
-    }
-`;
-
-export const ActionInput = (props: InputProps) => (
-    <InputWrapper>
-        <Input {...props} />
-    </InputWrapper>
-);
 
 export const ActionSelect = styled(Select)`
     width: 170px;

--- a/packages/suite/src/components/suite/Settings/components/ActionColumn.tsx
+++ b/packages/suite/src/components/suite/Settings/components/ActionColumn.tsx
@@ -19,7 +19,7 @@ export const ActionColumn = styled.div`
 
 const InputWrapper = styled.div`
     margin: 4px 0 4px 4px;
-    width: 170px;
+    width: 210px;
 
     &:not(:first-child) {
         margin-left: 8px;

--- a/packages/suite/src/components/suite/Settings/index.ts
+++ b/packages/suite/src/components/suite/Settings/index.ts
@@ -1,7 +1,7 @@
 import { SettingsSection } from './components/SettingsSection';
 import { SectionItem } from './components/SectionItem';
 import { TextColumn } from './components/TextColumn';
-import { ActionColumn, ActionButton, ActionInput, ActionSelect } from './components/ActionColumn';
+import { ActionColumn, ActionButton, ActionSelect } from './components/ActionColumn';
 import { Row } from './components/Row';
 import { DeviceBanner } from './components/DeviceBanner';
 
@@ -12,7 +12,6 @@ export {
     ActionColumn,
     Row,
     ActionButton,
-    ActionInput,
     ActionSelect,
     DeviceBanner,
 };

--- a/packages/suite/src/support/messages.ts
+++ b/packages/suite/src/support/messages.ts
@@ -4851,10 +4851,20 @@ export default defineMessages({
         defaultMessage: 'Application',
         description: 'Computer program.',
     },
-    TR_MAX_LABEL_LENGTH_IS: {
-        id: 'TR_MAX_LABEL_LENGTH_IS',
-        defaultMessage: 'Names can be up to {length} characters.',
-        description: 'How many characters may be in device label.',
+    TR_LABEL_REQUIREMENTS: {
+        id: 'TR_LABEL_REQUIREMENTS',
+        defaultMessage:
+            'Names can be up to {length} characters and only characters of the English alphabet are allowed.',
+        description: 'How many characters may be in device label and of what type.',
+    },
+    TR_LABEL_ERROR_LENGTH: {
+        id: 'TR_LABEL_ERROR_LENGTH',
+        defaultMessage: 'Name must be {length} characters or less',
+    },
+    TR_LABEL_ERROR_CHARACTERS: {
+        id: 'TR_LABEL_ERROR_CHARACTERS',
+        defaultMessage: 'Unsupported characters',
+        description: 'Device name can only use standard ASCII characters',
     },
     TR_I_HAVE_ENOUGH_TIME_TO_DO: {
         id: 'TR_I_HAVE_ENOUGH_TIME_TO_DO',

--- a/packages/suite/src/views/settings/device/DeviceLabel.tsx
+++ b/packages/suite/src/views/settings/device/DeviceLabel.tsx
@@ -1,61 +1,18 @@
-import React, { useState, useEffect } from 'react';
-import { analytics, EventType } from '@trezor/suite-analytics';
+import React from 'react';
 
 import { Translation } from 'src/components/suite';
-import {
-    ActionButton,
-    ActionInput,
-    ActionColumn,
-    SectionItem,
-    TextColumn,
-} from 'src/components/suite/Settings';
-import { useDevice, useDispatch, useTranslation } from 'src/hooks/suite';
-import { applySettings } from 'src/actions/settings/deviceSettingsActions';
+import { ActionColumn, SectionItem, TextColumn } from 'src/components/suite/Settings';
 import { MAX_LABEL_LENGTH } from 'src/constants/suite/device';
 import { useAnchor } from 'src/hooks/suite/useAnchor';
 import { SettingsAnchor } from 'src/constants/suite/anchors';
-import { isAscii } from '@trezor/utils';
+import { ChangeDeviceLabel } from 'src/components/suite/ChangeDeviceLabel';
 
 interface DeviceLabelProps {
     isDeviceLocked: boolean;
 }
 
 export const DeviceLabel = ({ isDeviceLocked }: DeviceLabelProps) => {
-    const [label, setLabel] = useState('');
-    const dispatch = useDispatch();
-    const { device } = useDevice();
     const { anchorRef, shouldHighlight } = useAnchor(SettingsAnchor.DeviceLabel);
-    const { translationString } = useTranslation();
-
-    const handleButtonClick = () => {
-        dispatch(applySettings({ label }));
-        analytics.report({
-            type: EventType.SettingsDeviceChangeLabel,
-        });
-    };
-    const [error, setError] = useState<string | null>(null);
-
-    useEffect(() => {
-        if (device) {
-            setLabel(device.label);
-        }
-    }, [device]);
-
-    const handleChange: React.ChangeEventHandler<HTMLInputElement> = ({ target: { value } }) => {
-        setLabel(value);
-
-        if (value.length > MAX_LABEL_LENGTH) {
-            setError(
-                translationString('TR_LABEL_ERROR_LENGTH', {
-                    length: 16,
-                }),
-            );
-        } else if (!isAscii(value)) {
-            setError(translationString('TR_LABEL_ERROR_CHARACTERS'));
-        } else {
-            setError(null);
-        }
-    };
 
     return (
         <SectionItem
@@ -70,24 +27,7 @@ export const DeviceLabel = ({ isDeviceLocked }: DeviceLabelProps) => {
                 }
             />
             <ActionColumn>
-                <ActionInput
-                    noTopLabel
-                    bottomText={error}
-                    value={label}
-                    inputState={error ? 'error' : undefined}
-                    onChange={handleChange}
-                    data-test="@settings/device/label-input"
-                    isDisabled={isDeviceLocked}
-                />
-                <ActionButton
-                    onClick={handleButtonClick}
-                    isDisabled={
-                        isDeviceLocked || label.length > MAX_LABEL_LENGTH || label === device?.label
-                    }
-                    data-test="@settings/device/label-submit"
-                >
-                    <Translation id="TR_DEVICE_SETTINGS_DEVICE_EDIT_LABEL" />
-                </ActionButton>
+                <ChangeDeviceLabel isVertical isDeviceLocked={isDeviceLocked} />
             </ActionColumn>
         </SectionItem>
     );


### PR DESCRIPTION
Added check so that label can only have ASCIII characters.

## Description

Used `isAscii` to check if label has only ASCII characters.

Translations changed: `TR_LABEL_REQUIREMENTS`
Translations added: `TR_LABEL_ERROR_LENGHT`, `TR_LABEL_ERROR_CHARACTERS`

## Related Issue

Resolve #8604 

## Screenshots:

Device settings:
<img width="752" alt="Screenshot 2023-07-27 at 11 20 15 AM" src="https://github.com/trezor/trezor-suite/assets/66002635/e3b280f4-be26-41a7-83e3-cf11aa8ba88b">

Onboarding:
<img width="767" alt="Screenshot 2023-07-27 at 11 22 52 AM" src="https://github.com/trezor/trezor-suite/assets/66002635/c1dd4adf-6f5a-4df0-ab68-e0943580f16c">