### PR TITLE
Fix: sendform compose transaction callback

### DIFF
--- a/packages/suite/src/actions/wallet/sendFormActions.ts
+++ b/packages/suite/src/actions/wallet/sendFormActions.ts
@@ -170,6 +170,7 @@ export const composeTransaction =
         if (account.networkType === 'cardano') {
             return dispatch(sendFormCardanoActions.composeTransaction(formValues, formState));
         }
+        return Promise.resolve(undefined);
     };
 
 // this is only a wrapper for `openDeferredModal` since it doesn't work with `bindActionCreators`

--- a/packages/suite/src/hooks/wallet/__fixtures__/useSendForm.ts
+++ b/packages/suite/src/hooks/wallet/__fixtures__/useSendForm.ts
@@ -300,15 +300,6 @@ export const addingOutputs = [
                     },
                 },
             },
-            {
-                type: 'click',
-                element: 'clear-form',
-                result: {
-                    formValues: {
-                        outputs: [{ address: '' }],
-                    },
-                },
-            },
         ],
     },
     {

--- a/packages/suite/src/hooks/wallet/useSendForm.ts
+++ b/packages/suite/src/hooks/wallet/useSendForm.ts
@@ -62,7 +62,6 @@ const getStateFromProps = (props: UseSendFormProps) => {
         network,
         coinFees,
         feeInfo,
-        feeOutdated: false,
         fiatRates,
         localCurrencyOption,
         online: props.online,

--- a/packages/suite/src/hooks/wallet/useSendForm.ts
+++ b/packages/suite/src/hooks/wallet/useSendForm.ts
@@ -65,7 +65,6 @@ const getStateFromProps = (props: UseSendFormProps) => {
         feeOutdated: false,
         fiatRates,
         localCurrencyOption,
-        isDirty: false,
         online: props.online,
         metadataEnabled: props.metadataEnabled,
     };
@@ -235,8 +234,8 @@ export const useSendForm = (props: UseSendFormProps): SendContextValues => {
         if (!outputs) return; // ignore empty result (cancelled or error)
         setComposedLevels(undefined);
         const values = getLoadedValues({ outputs });
-        reset(values);
-        updateContext({ isDirty: true });
+        // keepDefaultValues will set `isDirty` flag to true
+        reset(values, { keepDefaultValues: true });
         setLoading(false);
         const valid = await trigger();
         if (valid) {
@@ -316,7 +315,8 @@ export const useSendForm = (props: UseSendFormProps): SendContextValues => {
     useEffect(() => {
         const storedState = getDraft();
         const values = getLoadedValues(storedState);
-        reset(values);
+        // keepDefaultValues will set `isDirty` flag to true
+        reset(values, { keepDefaultValues: !!storedState });
 
         if (storedState) {
             draft.current = storedState;

--- a/packages/suite/src/hooks/wallet/useSendFormCompose.ts
+++ b/packages/suite/src/hooks/wallet/useSendFormCompose.ts
@@ -34,7 +34,7 @@ export const useSendFormCompose = ({
     getValues,
     setValue,
     setError,
-    formState: { errors },
+    formState: { errors, isDirty },
     clearErrors,
     state,
     account,
@@ -63,7 +63,6 @@ export const useSendFormCompose = ({
         async (values: FormState) => {
             // start composing without debounce
             setLoading(true);
-            updateContext({ isDirty: true });
             setComposedLevels(undefined);
 
             const result = await composeTransaction(values, {
@@ -76,7 +75,6 @@ export const useSendFormCompose = ({
 
             setComposedLevels(result);
             setLoading(false);
-            updateContext({ isDirty: true }); // isDirty needs to be set again, "state" is cached in updateContext callback
         },
         [
             account,
@@ -85,7 +83,6 @@ export const useSendFormCompose = ({
             state.network,
             state.feeInfo,
             composeTransaction,
-            updateContext,
             setLoading,
         ],
     );
@@ -160,7 +157,6 @@ export const useSendFormCompose = ({
         setComposeField(field);
         // start composing
         setLoading(true);
-        updateContext({ isDirty: true });
     };
 
     // Handle composeRequest
@@ -298,10 +294,9 @@ export const useSendFormCompose = ({
                 const currentLevel = composedLevels[current || 'normal'];
                 updateComposedValues(currentLevel);
             }
-            updateContext({ isDirty: true });
             setDraftSaveRequest(true);
         },
-        [composedLevels, updateComposedValues, updateContext],
+        [composedLevels, updateComposedValues],
     );
 
     // handle props.account change:
@@ -317,7 +312,7 @@ export const useSendFormCompose = ({
         ) {
             return; // account didn't change
         }
-        if (!state.isDirty) {
+        if (!isDirty) {
             // there was no interaction with the form, just update state.account
             updateContext({ account });
             return;
@@ -340,7 +335,7 @@ export const useSendFormCompose = ({
     }, [
         state.account,
         state.feeInfo.dustLimit,
-        state.isDirty,
+        isDirty,
         account,
         clearErrors,
         errors,

--- a/packages/suite/src/hooks/wallet/useSendFormCompose.ts
+++ b/packages/suite/src/hooks/wallet/useSendFormCompose.ts
@@ -54,7 +54,6 @@ export const useSendFormCompose = ({
     });
     const { translationString } = useTranslation();
 
-    const composeRequestRef = useRef<string | undefined>(undefined); // input name, caller of compose request
     const composeRequestID = useRef(0); // compose ID, incremented with every compose request
 
     const debounce = useAsyncDebounce();
@@ -87,86 +86,72 @@ export const useSendFormCompose = ({
         ],
     );
 
-    // called from composeRequest useEffect
-    const processComposeRequest = useCallback(async () => {
-        // eslint-disable-next-line require-await
-        const composeInner = async () => {
-            if (Object.keys(errors).length > 0) {
-                return;
+    // Create a compose request
+    const composeRequest = useCallback(
+        async (field: FieldPath<FormState> | undefined = 'outputs.0.amount') => {
+            // reset current precomposed transactions
+            setComposedLevels(undefined);
+            // update request id
+            composeRequestID.current++;
+            // clear errors from previous compose process
+            const composeErrors = findComposeErrors(errors);
+            if (composeErrors.length > 0) {
+                clearErrors(composeErrors);
             }
+            // set state value for later use in updateComposedValues function
+            setComposeField(field);
+            // start composing
+            setLoading(true);
 
-            const values = getValues();
-            // save draft (it could be changed later, after composing)
-            setDraftSaveRequest(true);
+            // store current request ID before async debounced process and compare it later. see explanation below
+            const resultID = composeRequestID.current;
+            const result = await debounce(() => {
+                if (Object.keys(errors).length > 0) {
+                    return Promise.resolve(undefined);
+                }
 
-            return composeTransaction(values, {
-                account,
-                network: state.network,
-                feeInfo: state.feeInfo,
-                excludedUtxos,
-                prison,
+                const values = getValues();
+                // save draft (it could be changed later, after composing)
+                setDraftSaveRequest(true);
+
+                return composeTransaction(values, {
+                    account,
+                    network: state.network,
+                    feeInfo: state.feeInfo,
+                    excludedUtxos,
+                    prison,
+                });
             });
-        };
 
-        // store current request ID before async debounced process and compare it later. see explanation below
-        const resultID = composeRequestID.current;
-        const result = await debounce(composeInner);
-        // RACE-CONDITION NOTE:
-        // resultID could be outdated when composeRequestID was updated by another upcoming/pending composeRequest and render tick didn't process it yet,
-        // therefore another debounce process was not called yet to interrupt current one
-        // unexpected result: `updateComposedValues` is trying to work with updated/newer FormState
-        if (resultID === composeRequestID.current) {
-            if (result) {
-                // set new composed transactions
-                setComposedLevels(result);
+            // RACE-CONDITION NOTE:
+            // resultID could be outdated when composeRequestID was updated by another upcoming/pending composeRequest and render tick didn't process it yet,
+            // therefore another debounce process was not called yet to interrupt current one
+            // unexpected result: `updateComposedValues` is trying to work with updated/newer FormState
+            if (resultID === composeRequestID.current) {
+                if (result) {
+                    // set new composed transactions
+                    setComposedLevels(result);
+                } else {
+                    // result undefined: (FormState got errors or sendFormActions got errors)
+                    // undefined result will not be processed by useEffect below, reset loader
+                    setLoading(false);
+                }
             }
-            // result undefined: (FormState got errors or sendFormActions got errors)
-            setLoading(false);
-        }
-    }, [
-        account,
-        excludedUtxos,
-        prison,
-        state.network,
-        state.feeInfo,
-        setLoading,
-        debounce,
-        errors,
-        getValues,
-        composeTransaction,
-    ]);
-
-    // Create a compose request which should be processed in useEffect below
-    // This function should be called from the UI (input.onChange, button.click etc...)
-    // react-hook-form doesn't propagate values immediately. New calculated FormState is available until render tick
-    // IMPORTANT NOTE: Processing request without useEffect will use outdated FormState values (FormState before input.onChange)
-    // NOTE: this function doesn't have to be wrapped in useCallback since no component is using it as a hook dependency and it will be cleared by garbage collector (useCallback are not)
-    const composeRequest = (field: FieldPath<FormState> | undefined = 'outputs.0.amount') => {
-        // reset precomposed transactions
-        setComposedLevels(undefined);
-        // set ref for later use in useEffect which handle composedLevels change
-        composeRequestRef.current = field;
-        // set ref for later use in processComposeRequest function
-        composeRequestID.current++;
-        // clear errors from compose process
-        const composeErrors = findComposeErrors(errors);
-        if (composeErrors.length > 0) {
-            clearErrors(composeErrors);
-        }
-        // set state value for later use in updateComposedValues function
-        setComposeField(field);
-        // start composing
-        setLoading(true);
-    };
-
-    // Handle composeRequest
-    useEffect(() => {
-        // compose request is not set, do nothing
-        if (!composeRequestRef.current) return;
-        processComposeRequest();
-        // reset compose request
-        composeRequestRef.current = undefined;
-    }, [composeRequestRef, processComposeRequest]);
+        },
+        [
+            debounce,
+            composeTransaction,
+            setLoading,
+            errors,
+            clearErrors,
+            getValues,
+            account,
+            state.network,
+            state.feeInfo,
+            excludedUtxos,
+            prison,
+        ],
+    );
 
     // update fields AFTER composedLevels change or selectedFee change (below)
     const updateComposedValues = useCallback(
@@ -320,8 +305,6 @@ export const useSendFormCompose = ({
 
         // reset precomposed transactions
         setComposedLevels(undefined);
-        // set ref for later use in useEffect which handle composedLevels change
-        composeRequestRef.current = 'outputs.0.amount';
         // set ref for later use in processComposeRequest function
         composeRequestID.current++;
         // clear errors from compose process

--- a/packages/suite/src/hooks/wallet/useSendFormCompose.ts
+++ b/packages/suite/src/hooks/wallet/useSendFormCompose.ts
@@ -23,6 +23,7 @@ type Props = UseFormReturn<FormState> & {
     excludedUtxos: ExcludedUtxos;
     account: UseSendFormState['account']; // account from the component props !== state.account
     updateContext: SendContextValues['updateContext'];
+    setLoading: React.Dispatch<React.SetStateAction<boolean>>;
     setAmount: (index: number, amount: string) => void;
     targetAnonymity?: number;
     prison?: Record<string, unknown>;
@@ -39,6 +40,7 @@ export const useSendFormCompose = ({
     account,
     excludedUtxos,
     updateContext,
+    setLoading,
     setAmount,
     prison,
 }: Props) => {
@@ -60,7 +62,8 @@ export const useSendFormCompose = ({
     const composeDraft = useCallback(
         async (values: FormState) => {
             // start composing without debounce
-            updateContext({ isLoading: true, isDirty: true });
+            setLoading(true);
+            updateContext({ isDirty: true });
             setComposedLevels(undefined);
 
             const result = await composeTransaction(values, {
@@ -72,7 +75,8 @@ export const useSendFormCompose = ({
             });
 
             setComposedLevels(result);
-            updateContext({ isLoading: false, isDirty: true }); // isDirty needs to be set again, "state" is cached in updateContext callback
+            setLoading(false);
+            updateContext({ isDirty: true }); // isDirty needs to be set again, "state" is cached in updateContext callback
         },
         [
             account,
@@ -82,6 +86,7 @@ export const useSendFormCompose = ({
             state.feeInfo,
             composeTransaction,
             updateContext,
+            setLoading,
         ],
     );
 
@@ -119,7 +124,7 @@ export const useSendFormCompose = ({
                 setComposedLevels(result);
             }
             // result undefined: (FormState got errors or sendFormActions got errors)
-            updateContext({ isLoading: false });
+            setLoading(false);
         }
     }, [
         account,
@@ -127,7 +132,7 @@ export const useSendFormCompose = ({
         prison,
         state.network,
         state.feeInfo,
-        updateContext,
+        setLoading,
         debounce,
         errors,
         getValues,
@@ -154,7 +159,8 @@ export const useSendFormCompose = ({
         // set state value for later use in updateComposedValues function
         setComposeField(field);
         // start composing
-        updateContext({ isLoading: true, isDirty: true });
+        setLoading(true);
+        updateContext({ isDirty: true });
     };
 
     // Handle composeRequest
@@ -329,7 +335,8 @@ export const useSendFormCompose = ({
             clearErrors(composeErrors);
         }
         // start composing
-        updateContext({ account, isLoading: true });
+        setLoading(true);
+        updateContext({ account });
     }, [
         state.account,
         state.feeInfo.dustLimit,
@@ -338,6 +345,7 @@ export const useSendFormCompose = ({
         clearErrors,
         errors,
         updateContext,
+        setLoading,
     ]);
 
     return {

--- a/packages/suite/src/hooks/wallet/useSendFormCompose.ts
+++ b/packages/suite/src/hooks/wallet/useSendFormCompose.ts
@@ -72,8 +72,12 @@ export const useSendFormCompose = ({
                 prison,
             });
 
-            setComposedLevels(result);
-            setLoading(false);
+            if (result) {
+                setComposedLevels(result);
+            } else {
+                // undefined result will not be processed by useEffect below, reset loader
+                setLoading(false);
+            }
         },
         [
             account,
@@ -163,6 +167,7 @@ export const useSendFormCompose = ({
                     // composed tx doesn't have an errorMessage (Translation props)
                     // this error is unexpected and should be handled in sendFormActions
                     console.warn('Compose unexpected error', error);
+                    setLoading(false);
                     return;
                 }
 
@@ -189,6 +194,7 @@ export const useSendFormCompose = ({
                     // setError to the all `Amount` fields, composeField not specified (load draft case)
                     values.outputs.forEach((_, i) => setError(`outputs.${i}.amount`, formError));
                 }
+                setLoading(false);
                 return;
             }
 
@@ -206,6 +212,7 @@ export const useSendFormCompose = ({
                 setAmount(setMaxOutputId, composed.max);
                 setDraftSaveRequest(true);
             }
+            setLoading(false);
         },
         [
             composeField,
@@ -215,6 +222,7 @@ export const useSendFormCompose = ({
             setError,
             clearErrors,
             setValue,
+            setLoading,
             translationString,
         ],
     );

--- a/packages/suite/src/views/wallet/send/components/Header/components/Clear.tsx
+++ b/packages/suite/src/views/wallet/send/components/Header/components/Clear.tsx
@@ -19,7 +19,10 @@ const In = styled.div`
 `;
 
 export const Clear = () => {
-    const { resetContext, isDirty } = useSendFormContext();
+    const {
+        resetContext,
+        formState: { isDirty },
+    } = useSendFormContext();
 
     if (!isDirty) return null;
     return (

--- a/packages/suite/src/views/wallet/send/components/Options/components/BitcoinOptions/components/CoinControl.tsx
+++ b/packages/suite/src/views/wallet/send/components/Options/components/BitcoinOptions/components/CoinControl.tsx
@@ -75,6 +75,7 @@ export const CoinControl = ({ close }: CoinControlProps) => {
         getDefaultValue,
         network,
         outputs,
+        isLoading,
         utxoSelection: {
             allUtxosSelected,
             composedInputs,
@@ -115,6 +116,7 @@ export const CoinControl = ({ close }: CoinControlProps) => {
     );
     const isMissingVisible =
         isCoinControlEnabled &&
+        !isLoading &&
         !missingAmountTooBig &&
         !(amountHasError && !notEnoughFundsSelectedError) &&
         (isMissingToAmount || notEnoughFundsSelectedError);

--- a/suite-common/wallet-types/src/sendForm.ts
+++ b/suite-common/wallet-types/src/sendForm.ts
@@ -56,7 +56,6 @@ export type UseSendFormState = {
     feeOutdated: boolean;
     fiatRates: CoinFiatRates | undefined;
     localCurrencyOption: CurrencyOption;
-    isDirty: boolean;
     composedLevels?: PrecomposedLevels | PrecomposedLevelsCardano;
     online: boolean;
     metadataEnabled: boolean;

--- a/suite-common/wallet-types/src/sendForm.ts
+++ b/suite-common/wallet-types/src/sendForm.ts
@@ -53,7 +53,6 @@ export type UseSendFormState = {
     network: Network;
     coinFees: FeeInfo;
     feeInfo: FeeInfo;
-    feeOutdated: boolean;
     fiatRates: CoinFiatRates | undefined;
     localCurrencyOption: CurrencyOption;
     composedLevels?: PrecomposedLevels | PrecomposedLevelsCardano;

--- a/suite-common/wallet-types/src/sendForm.ts
+++ b/suite-common/wallet-types/src/sendForm.ts
@@ -56,7 +56,6 @@ export type UseSendFormState = {
     feeOutdated: boolean;
     fiatRates: CoinFiatRates | undefined;
     localCurrencyOption: CurrencyOption;
-    isLoading: boolean;
     isDirty: boolean;
     composedLevels?: PrecomposedLevels | PrecomposedLevelsCardano;
     online: boolean;
@@ -100,6 +99,7 @@ export interface GetDefaultValue {
 export type SendContextValues<TFormValues extends FormState = FormState> =
     UseFormReturn<TFormValues> &
         UseSendFormState & {
+            isLoading: boolean;
             // additional fields
             outputs: Partial<Output & { id: string }>[]; // useFieldArray fields
             updateContext: (value: Partial<UseSendFormState>) => void;


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Related to https://github.com/trezor/trezor-suite/issues/9045

There is few things left to resolve issue completely but currently i want to resolve at least the biggest problem: unnecessary calling `useEffect` which has `composeRequest` in listed dependency

- Remove flags used by useSendFrom hook and underlying sub-hooks from `UseSendFormState`
- Create composeRequestCallback and use it as dependency of useEffect
- Fix displaying message about missing amount to input when form has `isLoading` flag enabled
