### PR TITLE
connect-webextension-tests-ci

### DIFF
--- a/ci/test.yml
+++ b/ci/test.yml
@@ -398,3 +398,21 @@ connect-web:
   extends: .e2e connect-web
   only:
     <<: *run_everything_rules
+
+connect-web mv2:
+  stage: integration testing
+  variables:
+    COMPOSE_PROJECT_NAME: $CI_JOB_ID
+    COMPOSE_FILE: ./docker/docker-compose.connect-webextension-test.yml
+    URL: ${DEV_SERVER_URL}/connect/${CI_COMMIT_REF_NAME}/
+  script:
+    - yarn install --immutable
+    - node ./packages/connect-examples/update-webextensions.js --trezor-connect-src "${URL}" --npm-src "${URL}/trezor-connect.js"
+    - docker-compose pull
+    - docker-compose up -d trezor-user-env-unix
+    - docker-compose run test-run
+  after_script:
+    - docker-compose down
+    - docker network prune -f
+  only:
+    <<: *run_everything_rules


### PR DESCRIPTION
we can't comfortably run webextension tests in github yet, so lets re-enable them it in gitlab. 

I am trying to make our basic tests work, but MV2 has some problems at least for me locally. could it be this? https://bugs.chromium.org/p/chromium/issues/detail?id=1316588

cc @karliatto 