### PR TITLE
Fix 'Cannot read properties of undefined (reading 'amount')'

### DIFF
--- a/packages/suite/src/views/wallet/send/components/Options/components/EthereumOptions/Data.tsx
+++ b/packages/suite/src/views/wallet/send/components/Options/components/EthereumOptions/Data.tsx
@@ -24,11 +24,11 @@ const Space = styled.div`
     min-width: 65px;
 `;
 
-interface Props {
+interface DataProps {
     close: () => void;
 }
 
-export const Data = ({ close }: Props) => {
+export const Data = ({ close }: DataProps) => {
     const {
         register,
         formState: { errors },
@@ -120,5 +120,3 @@ export const Data = ({ close }: Props) => {
         </Wrapper>
     );
 };
-
-export default Data;

--- a/packages/suite/src/views/wallet/send/components/Options/components/EthereumOptions/components/Data/index.tsx
+++ b/packages/suite/src/views/wallet/send/components/Options/components/EthereumOptions/components/Data/index.tsx
@@ -42,7 +42,7 @@ const Data = ({ close }: Props) => {
 
     const asciiValue = getDefaultValue(inputAsciiName);
     const hexValue = getDefaultValue(inputHexName);
-    const amount = getDefaultValue('outputs.0.amount', outputs[0].amount);
+    const amount = getDefaultValue('outputs.0.amount', '');
 
     const asciiError = errors.ethereumDataAscii;
     const hexError = errors.ethereumDataHex;

--- a/packages/suite/src/views/wallet/send/components/Options/components/EthereumOptions/components/Data/index.tsx
+++ b/packages/suite/src/views/wallet/send/components/Options/components/EthereumOptions/components/Data/index.tsx
@@ -7,6 +7,10 @@ import { getInputState, isHexValid } from '@suite-common/wallet-utils';
 import { MAX_LENGTH } from 'src/constants/suite/inputs';
 import { useTranslation } from 'src/hooks/suite';
 
+const inputAsciiName = 'ethereumDataAscii';
+const inputHexName = 'ethereumDataHex';
+const inputAmountName = 'outputs.0.amount';
+
 const Wrapper = styled.div`
     display: flex;
     width: 100%;
@@ -24,25 +28,18 @@ interface Props {
     close: () => void;
 }
 
-const Data = ({ close }: Props) => {
+export const Data = ({ close }: Props) => {
     const {
         register,
-        outputs,
         formState: { errors },
-        getDefaultValue,
         setValue,
         setAmount,
         composeTransaction,
+        watch,
     } = useSendFormContext();
-
     const { translationString } = useTranslation();
 
-    const inputAsciiName = 'ethereumDataAscii';
-    const inputHexName = 'ethereumDataHex';
-
-    const asciiValue = getDefaultValue(inputAsciiName);
-    const hexValue = getDefaultValue(inputHexName);
-    const amount = getDefaultValue('outputs.0.amount', '');
+    const [asciiValue, hexValue, amount] = watch([inputAsciiName, inputHexName, inputAmountName]);
 
     const asciiError = errors.ethereumDataAscii;
     const hexError = errors.ethereumDataHex;
@@ -69,10 +66,10 @@ const Data = ({ close }: Props) => {
                 !hexError ? Buffer.from(event.target.value, 'hex').toString('ascii') : '',
             );
             if (!amount) {
-                setValue('outputs.0.amount', '0');
+                setValue(inputAmountName, '0');
             }
             if ((event.target.value === '' || hexError) && amount === '0') {
-                setValue('outputs.0.amount', '');
+                setValue(inputAmountName, '');
             }
             composeTransaction(inputHexName);
         },

--- a/packages/suite/src/views/wallet/send/components/Options/components/EthereumOptions/index.tsx
+++ b/packages/suite/src/views/wallet/send/components/Options/components/EthereumOptions/index.tsx
@@ -4,7 +4,7 @@ import { Button, Tooltip } from '@trezor/components';
 import { Translation } from 'src/components/suite';
 import { OnOffSwitcher } from 'src/components/wallet';
 import { useSendFormContext } from 'src/hooks/wallet';
-import Data from './components/Data';
+import { Data } from './Data';
 
 const Wrapper = styled.div`
     display: flex;


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->
The error was caused by accessing `outputs[0].amount` before outputs registered. I don't think it was even necessary to set the fallback value, so I removed it. I also refactored it from `getDefaultValue` to `watch` -  I believe it works the same in this case and it is much simpler.

How to reproduce the bug:
- open devtools
- open send form on an ETH account
- click "Add Data"
- close the form
- open send form again
- see the error in devtools console (it has no impact on the app, though)

## Related Issue

Resolve #8840

