### PR TITLE
Fix/suite replace transaction action

### DIFF
--- a/packages/blockchain-link-utils/src/blockbook.ts
+++ b/packages/blockchain-link-utils/src/blockbook.ts
@@ -226,9 +226,10 @@ export const transformTransaction = (
 
     type = isTxFailed(tx) ? 'failed' : type;
 
-    const rbf = inputs.find(i => typeof i.sequence === 'number' && i.sequence < 0xffffffff - 1)
-        ? true
-        : undefined;
+    const rbf =
+        tx.rbf || inputs.find(i => typeof i.sequence === 'number' && i.sequence < 0xffffffff - 1)
+            ? true
+            : undefined;
 
     const fee =
         tx.ethereumSpecific && !tx.ethereumSpecific.gasUsed

--- a/packages/connect/src/api/bitcoin/createPendingTx.ts
+++ b/packages/connect/src/api/bitcoin/createPendingTx.ts
@@ -51,6 +51,7 @@ export const createPendingTransaction = (
             isAddress: true,
             addresses: findAddress(ins),
             value: ins.amount.toString(),
+            sequence: ins.sequence,
         })),
         vout: outputs.map((out, n) => {
             let transformedAddresses: string[] = [];

--- a/packages/suite/src/actions/wallet/sendFormActions.ts
+++ b/packages/suite/src/actions/wallet/sendFormActions.ts
@@ -246,7 +246,13 @@ const pushTransaction =
                 // notification from the backend may be delayed.
                 // modify affected transaction(s) in the reducer until the real account update occurs.
                 // this will update transaction details (like time, fee etc.)
-                dispatch(replaceTransactionThunk({ tx: precomposedTx, newTxid: txid }));
+                dispatch(
+                    replaceTransactionThunk({
+                        precomposedTx,
+                        newTxid: txid,
+                        signedTransaction,
+                    }),
+                );
             }
 
             // notification from the backend may be delayed.

--- a/packages/suite/src/components/wallet/TransactionTimestamp.tsx
+++ b/packages/suite/src/components/wallet/TransactionTimestamp.tsx
@@ -22,13 +22,11 @@ export const TransactionTimestamp = ({
     showDate = false,
     transaction,
 }: TransactionTimestampProps) => {
-    const { blockTime, blockHeight } = transaction;
+    const { blockTime } = transaction;
 
     return (
         <TimestampLink>
-            {blockHeight !== 0 && blockTime && blockTime > 0 && (
-                <FormattedDate value={new Date(blockTime * 1000)} time date={showDate} />
-            )}
+            {blockTime && <FormattedDate value={new Date(blockTime * 1000)} time date={showDate} />}
         </TimestampLink>
     );
 };

--- a/suite-common/wallet-core/src/transactions/transactionsReducer.ts
+++ b/suite-common/wallet-core/src/transactions/transactionsReducer.ts
@@ -124,7 +124,8 @@ export const prepareTransactionsReducer = createReducerWithExtraDeps(
                         if (
                             ((existingTx.blockHeight ?? 0) <= 0 &&
                                 (transaction.blockHeight ?? 0) > 0) ||
-                            (!existingTx.blockTime && transaction.blockTime) ||
+                            (transaction.blockTime &&
+                                (existingTx.blockTime ?? 0) < transaction.blockTime) ||
                             (existingTx.deadline && !transaction.deadline)
                         ) {
                             // pending tx got confirmed (blockHeight changed from undefined/0 to a number > 0)

--- a/suite-common/wallet-utils/src/transactionUtils.ts
+++ b/suite-common/wallet-utils/src/transactionUtils.ts
@@ -1,11 +1,12 @@
 import BigNumber from 'bignumber.js';
-import { fromWei } from 'web3-utils';
+import { fromWei, toWei } from 'web3-utils';
 import { addDays, startOfMonth } from 'date-fns';
 
 import {
     Account,
     RbfTransactionParams,
     WalletAccountTransaction,
+    PrecomposedTransactionFinal,
 } from '@suite-common/wallet-types';
 import { AccountMetadata } from '@suite-common/metadata-types';
 import {
@@ -468,6 +469,19 @@ export const getTargetAmount = (
 export const getFeeRate = (tx: AccountTransaction) =>
     // calculate fee rate, TODO: add this to blockchain-link tx details
     new BigNumber(tx.fee).div(tx.details.size).integerValue(BigNumber.ROUND_CEIL).toString();
+
+// used by replaceTransactionThunk
+export const replaceEthereumSpecific = (
+    tx: AccountTransaction,
+    precomposedTx: PrecomposedTransactionFinal,
+) => {
+    if (!tx.ethereumSpecific) return;
+    return {
+        ...tx.ethereumSpecific,
+        gasLimit: Number(precomposedTx.feeLimit),
+        gasPrice: toWei(precomposedTx.feePerByte, 'gwei'),
+    };
+};
 
 const getEthereumRbfParams = (
     tx: AccountTransaction,


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Minor adjustments here and there + fixing issues related to RBF for both bitcoin and ethereum as prerequisite of https://github.com/trezor/trezor-suite/pull/9040

## Explanation

- Timestamp of pending transaction was not always visible ([mentioned here](https://github.com/trezor/trezor-suite/issues/8719#issuecomment-1602364030)) because of invalid condition in the `TimestampLink` component. `blockHeight` could be <= 0 (usually is set to -1). IMHO blockHeight should not be taken in consideration there

- `@trezor/connect` createPendingTx didn't use `sequence` in inputs so RBF "fake pending tx" (prepending) was always shown as final

- fixed/refactored `replaceTransactionThunk` action (update data in tx detail modal)
  - for bitcoin-like use signedTransaction from `@trezor/connect` same as in addFakePendingTxThunk - this creates exact same transaction as received later from the backend
  - for ethereum-like update `ethereumSpecific` and use `getRbfParams`
  
- skip creation on "fake pending tx" if it was a replacement tx - unnecessary step, tx will be ignored anyway (already updated by replaceTransactionThunk)



## Related Issue

Resolve https://github.com/trezor/trezor-suite/issues/8724
Resolve https://github.com/trezor/trezor-suite/issues/7856
