### PR TITLE
Test: refactor mv2 webextension

### DIFF
--- a/packages/connect-examples/webextension-mv2/src/background.js
+++ b/packages/connect-examples/webextension-mv2/src/background.js
@@ -1,34 +1,49 @@
 /**
-When the button's clicked:
+TrezorConnect is loaded in background script but it is triggered from content script.
 - call for TrezorConnect action
 - show a notification with response
 */
 
 const DEFAULT_SRC = 'https://connect.trezor.io/9/';
 
-TrezorConnect.init({
-    manifest: {
-        email: 'email@developer.com',
-        appUrl: 'webextension-app-boilerplate',
-    },
-    connectSrc: DEFAULT_SRC,
-});
-
-function onClick() {
-    TrezorConnect.getAddress({
-        path: "m/49'/0'/0'/0/0",
-    }).then(response => {
-        const message = response.success
-            ? `BTC Address: ${response.payload.address}`
-            : `Error: ${response.payload.error}`;
-
-        chrome.notifications.create(new Date().getTime().toString(), {
-            type: 'basic',
-            iconUrl: 'icon48.png',
-            title: 'TrezorConnect',
-            message,
-        });
+function loadTrezorConnect() {
+    return TrezorConnect.init({
+        manifest: {
+            email: 'email@developer.com',
+            appUrl: 'webextension-app-boilerplate',
+        },
+        connectSrc: DEFAULT_SRC,
     });
 }
 
-chrome.browserAction.onClicked.addListener(onClick);
+function getAddress() {
+    return TrezorConnect.getAddress({
+        path: "m/49'/0'/0'/0/0",
+    });
+}
+
+async function sendMessageToContentScript(tabID, type, data = null) {
+    try {
+        const response = await chrome.tabs.sendMessage(tabID, { type, data });
+        return response;
+    } catch (error) {
+        return null;
+    }
+}
+
+chrome.runtime.onMessage.addListener((message, sender) => {
+    const { tab } = sender;
+    const { type, data } = message;
+    if (type === 'getAddress') {
+        getAddress().then(response => {
+            const message = response.success
+                ? `BTC Address: ${response.payload.address}`
+                : `Error: ${response.payload.error}`;
+            sendMessageToContentScript(tab.id, 'getAddress', message);
+        });
+    } else if (type === 'pageLoaded') {
+        loadTrezorConnect().then(() => {
+            sendMessageToContentScript(tab.id, 'connectLoaded');
+        });
+    }
+});

--- a/packages/connect-examples/webextension-mv2/src/connect-manager.html
+++ b/packages/connect-examples/webextension-mv2/src/connect-manager.html
@@ -1,0 +1,13 @@
+<!DOCTYPE html>
+<html lang="en">
+    <head>
+        <meta charset="UTF-8" />
+        <meta http-equiv="X-UA-Compatible" content="IE=edge" />
+        <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    </head>
+    <body>
+        <button id="get-address" data-test="get-address">Get Address</button>
+        <div id="result"></div>
+        <script src="./connect-manager.js" type="module"></script>
+    </body>
+</html>

--- a/packages/connect-examples/webextension-mv2/src/connect-manager.js
+++ b/packages/connect-examples/webextension-mv2/src/connect-manager.js
@@ -1,0 +1,31 @@
+async function sendMessageToBackground(type, data = null) {
+    try {
+        const response = await chrome.runtime.sendMessage({ type, data });
+        return response;
+    } catch (error) {
+        console.error('sendMessageToBackground error: ', error);
+        return null;
+    }
+}
+
+const button = document.getElementById('get-address');
+button.addEventListener('click', () => {
+    sendMessageToBackground('getAddress');
+});
+
+chrome.runtime.onMessage.addListener((message, sender) => {
+    const { type, data } = message;
+    if (type === 'getAddress') {
+        document.getElementById('result').innerText = JSON.stringify(data);
+    } else if (type === 'connectLoaded') {
+        const connectLoaded = document.createElement('div');
+        connectLoaded.setAttribute('data-test', 'connect-loaded');
+        connectLoaded.innerText = 'TrezorConnect is loaded';
+        connectLoaded.style.display = 'block';
+        document.body.appendChild(connectLoaded);
+    }
+});
+
+// When page is loaded send message to background script to get reference so when
+// TrezorConnect is loaded we know it and can call it.
+sendMessageToBackground('pageLoaded');

--- a/packages/connect-examples/webextension-mv2/src/manifest.json
+++ b/packages/connect-examples/webextension-mv2/src/manifest.json
@@ -6,9 +6,7 @@
         "48": "icon48.png"
     },
     "browser_action": {
-        "browser_style": true,
-        "default_icon": "icon48.png",
-        "default_title": "Get address"
+        "default_popup": "popup.html"
     },
     "permissions": [
         "tabs",

--- a/packages/connect-examples/webextension-mv2/src/popup.html
+++ b/packages/connect-examples/webextension-mv2/src/popup.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<html lang="en">
+    <head>
+        <meta charset="UTF-8" />
+        <meta http-equiv="X-UA-Compatible" content="IE=edge" />
+        <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    </head>
+    <body>
+        <button id="tab">Connect manager</button>
+        <script src="./popup.js" type="module"></script>
+    </body>
+</html>

--- a/packages/connect-examples/webextension-mv2/src/popup.js
+++ b/packages/connect-examples/webextension-mv2/src/popup.js
@@ -1,0 +1,4 @@
+const newTabButton = document.getElementById('tab');
+newTabButton.addEventListener('click', () => {
+    chrome.tabs.create({ url: 'connect-manager.html' });
+});

--- a/packages/connect-webextension/e2e/webextension.test.ts
+++ b/packages/connect-webextension/e2e/webextension.test.ts
@@ -72,13 +72,13 @@ test('Basic web extension MV2', async () => {
 
     expect(extensionId).toBeTruthy();
 
-    await page.goto(url);
+    await page.goto(`chrome-extension://${extensionId}/connect-manager.html`);
 
-    await page.evaluate(() => {
-        chrome.tabs.query({ active: true }, tabs => {
-            chrome.browserAction.onClicked.dispatch(tabs[0]);
-        });
-    });
+    // Wait for connect to be ready.
+    await page.waitForSelector("div[data-test='connect-loaded']");
+
+    await page.waitForSelector("button[data-test='get-address']");
+    await page.click("button[data-test='get-address']");
 
     const popup = await browserContext.waitForEvent('page');
     await popup.waitForLoadState('load');
@@ -100,6 +100,8 @@ test('Basic web extension MV2', async () => {
         popup.waitForEvent('close'),
         TrezorUserEnvLink.send({ type: 'emulator-press-yes' }),
     ]);
+
+    await page.waitForSelector('text=3AnYTd2FGxJLNKL1AzxfW3FJMntp9D2KKX');
 
     await browserContext.close();
 });


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Making a page `connect-manager` for MV2 webextension example so we can test it better.
I wanted to keep the important bit where TrezorConnect is loaded in background script and the request comes fromthe content script because it is the normal situation in MV2 extensions. To achieve that I had to make some little changes.

The tests are updated and should now work.
