### PR TITLE
feat(suite-desktop,tor): ensure that sentry issues wait in queue till Tor is Enabled

### DIFF
--- a/packages/suite-desktop-core/src/app.ts
+++ b/packages/suite-desktop-core/src/app.ts
@@ -1,8 +1,6 @@
 import path from 'path';
-import { app, BrowserWindow, session } from 'electron';
-import { init as initSentry, ElectronOptions, IPCMode } from '@sentry/electron';
+import { app, BrowserWindow } from 'electron';
 
-import { SENTRY_CONFIG } from '@suite-common/sentry';
 import { isDevEnv } from '@suite-common/suite-utils';
 import type { HandshakeClient } from '@trezor/suite-desktop-api';
 
@@ -13,6 +11,7 @@ import { MIN_HEIGHT, MIN_WIDTH } from './libs/screen';
 import { getBuildInfo, getComputerInfo } from './libs/info';
 import { restartApp } from './libs/app-utils';
 import { clearAppCache, initUserData } from './libs/user-data';
+import { initSentry } from './libs/sentry';
 import { initModules, mainThreadEmitter } from './modules';
 import { init as initTorModule } from './modules/tor';
 import { createInterceptor } from './libs/request-interceptor';
@@ -86,15 +85,10 @@ const init = async () => {
 
     const store = Store.getStore();
 
-    const sentryConfig: ElectronOptions = {
-        ...SENTRY_CONFIG,
-        ipcMode: IPCMode.Classic,
-        getSessions: () => [session.defaultSession],
-    };
-
-    // Sentry still ignore userPath change so in local build it uses @trezor/suite-desktop/sentry folder.
-    // I believe it is not a problem.
-    initSentry(sentryConfig);
+    initSentry({
+        store,
+        mainThreadEmitter,
+    });
 
     app.name = APP_NAME; // overrides @trezor/suite-desktop app name in menu
 

--- a/packages/suite-desktop-core/src/libs/sentry.ts
+++ b/packages/suite-desktop-core/src/libs/sentry.ts
@@ -1,0 +1,42 @@
+import { init, ElectronOptions, IPCMode } from '@sentry/electron';
+import { session } from 'electron';
+
+import { TorStatus } from '@trezor/suite-desktop-api';
+import { SENTRY_CONFIG } from '@suite-common/sentry';
+
+import type { Store } from './store';
+import type { MainThreadEmitter } from '../modules';
+
+interface InitSentryParams {
+    mainThreadEmitter: MainThreadEmitter;
+    store: Store;
+}
+
+export const initSentry = ({ mainThreadEmitter, store }: InitSentryParams) => {
+    let torStatus = TorStatus.Enabling;
+
+    mainThreadEmitter.on('module/tor-status-update', (newStatus: TorStatus) => {
+        torStatus = newStatus;
+    });
+
+    const transportOptions = {
+        beforeSend: () => {
+            if (store.getTorSettings().running && torStatus !== TorStatus.Enabled) {
+                // If Tor is enabled but not running, don't send the event but put it in a queue.
+                // Queue can be inspected in @trezor/suite-desktop/sentry/queue folder.
+                return 'queue';
+            }
+            return 'send';
+        },
+    };
+
+    const sentryConfig: ElectronOptions = {
+        ...SENTRY_CONFIG,
+        ipcMode: IPCMode.Classic,
+        getSessions: () => [session.defaultSession],
+        transportOptions,
+    };
+
+    // Sentry ignore userPath change by environment so even in local build it uses @trezor/suite-desktop/sentry folder.
+    init(sentryConfig);
+};

--- a/packages/suite-desktop-core/src/modules/index.ts
+++ b/packages/suite-desktop-core/src/modules/index.ts
@@ -4,7 +4,7 @@ import { isNotUndefined } from '@trezor/utils';
 import { TypedEmitter } from '@trezor/utils/lib/typedEventEmitter';
 import { InterceptedEvent } from '@trezor/request-manager';
 import { isDevEnv } from '@suite-common/suite-utils';
-import type { HandshakeClient } from '@trezor/suite-desktop-api';
+import type { HandshakeClient, TorStatus } from '@trezor/suite-desktop-api';
 
 import { StrictBrowserWindow } from '../typed-electron';
 import type { Store } from '../libs/store';
@@ -69,14 +69,16 @@ const MODULES = [
 interface MainThreadMessages {
     'module/request-interceptor': InterceptedEvent;
     'module/reset-tor-circuits': Extract<InterceptedEvent, { type: 'CIRCUIT_MISBEHAVING' }>;
+    'module/tor-status-update': TorStatus;
 }
 export const mainThreadEmitter = new TypedEmitter<MainThreadMessages>();
+export type MainThreadEmitter = typeof mainThreadEmitter;
 
 export type Dependencies = {
     mainWindow: StrictBrowserWindow;
     store: Store;
     interceptor: RequestInterceptor;
-    mainThreadEmitter: typeof mainThreadEmitter;
+    mainThreadEmitter: MainThreadEmitter;
 };
 
 type ModuleLoad = (payload: HandshakeClient) => any | Promise<any>;

--- a/packages/suite-desktop-core/src/modules/tor.ts
+++ b/packages/suite-desktop-core/src/modules/tor.ts
@@ -55,6 +55,7 @@ const load = async ({ mainWindow, store, mainThreadEmitter }: Dependencies) => {
         } else {
             type = TorStatus.Disabled;
         }
+        mainThreadEmitter.emit('module/tor-status-update', type);
         mainWindow.webContents.send('tor/status', {
             type,
         });


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Only after merging changed electron bundling https://github.com/trezor/trezor-suite/pull/8842 I found out, that some sentry issue can go via clearnet during app start before Tor is loaded (if enabled in previous run of Suite).

This is a working solution, that keep all issues in queue if Tor is supposed to run but not active yet.

What is wrong in this solution that I use `ipcMain` for sending the event... But what can I use? Should I create custom EventEmitter just for that? 
 

