### PR TITLE
transport followup (squashing 🏁 race conditions)

### DIFF
--- a/packages/connect/src/device/Device.ts
+++ b/packages/connect/src/device/Device.ts
@@ -202,7 +202,10 @@ export class Device extends TypedEmitter<DeviceEvents> {
             if (this.releasePromise) {
                 await this.releasePromise;
             }
-            this.releasePromise = this.transport.release(this.activitySessionID, false);
+            this.releasePromise = this.transport.release({
+                session: this.activitySessionID,
+                path: this.originalDescriptor.path,
+            });
 
             const releaseResponse = await this.releasePromise.promise;
             this.releasePromise = undefined;
@@ -647,7 +650,11 @@ export class Device extends TypedEmitter<DeviceEvents> {
                     this.commands.cancel();
                 }
 
-                return this.transport.release(this.activitySessionID, true);
+                return this.transport.release({
+                    session: this.activitySessionID,
+                    path: this.originalDescriptor.path,
+                    onClose: true,
+                });
             } catch (err) {
                 // empty
             }

--- a/packages/connect/src/device/DeviceCommands.ts
+++ b/packages/connect/src/device/DeviceCommands.ts
@@ -429,6 +429,9 @@ export class DeviceCommands {
 
     async _commonCall(type: MessageKey, msg?: DefaultMessageResponse['message']) {
         const resp = await this.call(type, msg);
+        if (this.disposed) {
+            throw ERRORS.TypedError('Runtime', 'typedCall: DeviceCommands already disposed');
+        }
         return this._filterCommonTypes(resp);
     }
 

--- a/packages/connect/src/device/DeviceList.ts
+++ b/packages/connect/src/device/DeviceList.ts
@@ -180,13 +180,6 @@ export class DeviceList extends TypedEmitter<DeviceListEvents> {
                     }
                 });
 
-                diff.acquired.forEach(descriptor => {
-                    const path = descriptor.path.toString();
-                    if (this.creatingDevicesDescriptors[path]) {
-                        this.creatingDevicesDescriptors[path] = descriptor;
-                    }
-                });
-
                 diff.acquiredElsewhere.forEach((descriptor: Descriptor) => {
                     const path = descriptor.path.toString();
                     const device = this.devices[path];

--- a/packages/transport/tests/abstractUsb.test.ts
+++ b/packages/transport/tests/abstractUsb.test.ts
@@ -347,7 +347,11 @@ describe('Usb', () => {
             expect(acquireRes.payload).toEqual('1');
 
             // doesn't really matter what what message we send
-            const res = await transport.release(acquireRes.payload, false).promise;
+            const res = await transport.release({
+                session: acquireRes.payload,
+                path: '123',
+                onClose: false,
+            }).promise;
             expect(res).toEqual({
                 success: true,
                 payload: undefined,


### PR DESCRIPTION
couple of changes hopefully fixing raceconditions in transports / connect. 

runs in github: 
https://github.com/trezor/trezor-suite/actions/workflows/connect-test.yml?query=branch%3Atransport-followup

runs in gitlab
https://gitlab.com/satoshilabs/trezor/trezor-suite/-/pipelines?page=1&scope=all&ref=transport-followup
unfortunately, there are some failing tests now, but these are due to [broken develop](https://satoshilabs.slack.com/archives/G019WLX2P7B/p1690791963504299)

Still sometimes you can see in logs a failed test with error from trezor-user-env containing `acquire/29/debug`.  this means that there is a similar unhandled race condtion in communication between trezor-user-env and bridge.  