### PR TITLE
test(e2e): fixing eth account click

### DIFF
--- a/packages/suite-web/e2e/support/pageObjects/accountsObject.ts
+++ b/packages/suite-web/e2e/support/pageObjects/accountsObject.ts
@@ -84,7 +84,7 @@ class AccountsPage {
 
     clickOnDesiredAccount(coinName: NetworkSymbol) {
         cy.getTestElement(`@account-menu/${coinName}/normal/0`)
-            .click()
+            .click('left')
             .parent()
             .should('have.class', 'selected');
     }


### PR DESCRIPTION
Fixing a bug where eth accounts with tokens display the token page instead of overview.
