### PR TITLE
Feat: coinjoin session not interrupted while accessing sendform

### DIFF
--- a/packages/suite/src/middlewares/wallet/__fixtures__/coinjoinMiddleware.ts
+++ b/packages/suite/src/middlewares/wallet/__fixtures__/coinjoinMiddleware.ts
@@ -1,4 +1,4 @@
-import { ROUTER, SUITE } from 'src/actions/suite/constants';
+import { SUITE } from 'src/actions/suite/constants';
 import { accountsActions } from '@suite-common/wallet-core';
 import { SelectedAccountLoaded } from '@suite-common/wallet-types';
 import { AnonymitySet } from '@trezor/blockchain-link';
@@ -168,48 +168,6 @@ export const fixtures = [
         action: {
             type: SUITE.TOR_STATUS,
             payload: 'Enabled',
-        },
-        expectedActions: RESTORE_SESSION_B_ACTIONS,
-    },
-    {
-        description: 'interrupt current coinjoin session when user enters send form',
-        state: DEFAULT_STATE,
-        action: {
-            type: ROUTER.LOCATION_CHANGE,
-            payload: {
-                route: {
-                    name: 'wallet-send',
-                },
-            },
-        },
-        expectedActions: [
-            {
-                type: COINJOIN.SESSION_PAUSE,
-                payload: {
-                    accountKey: 'account-B-key',
-                },
-            },
-        ],
-    },
-    {
-        description: 'restore all interrupted coinjoin sessions when user leaves send form',
-        state: STATE_WITH_INTERRUPTED_SESSION,
-        client: 'btc' as NetworkSymbol,
-        connect: [
-            {
-                success: true,
-            },
-        ],
-        action: {
-            type: ROUTER.LOCATION_CHANGE,
-            payload: {
-                route: {
-                    name: 'settings-index',
-                },
-                settingsBackRoute: {
-                    name: 'wallet-send',
-                },
-            },
         },
         expectedActions: RESTORE_SESSION_B_ACTIONS,
     },

--- a/packages/suite/src/middlewares/wallet/coinjoinMiddleware.ts
+++ b/packages/suite/src/middlewares/wallet/coinjoinMiddleware.ts
@@ -200,31 +200,6 @@ export const coinjoinMiddleware =
             }
         }
 
-        // Pause/restore coinjoin session depending on current route.
-        // Device may be locked by another connect call, so check on LOCK_DEVICE action as well.
-        if (action.type === ROUTER.LOCATION_CHANGE || action.type === SUITE.LOCK_DEVICE) {
-            const state = api.getState();
-            const { locks } = state.suite;
-            if (!locks.includes(SUITE.LOCK_TYPE.DEVICE) && !locks.includes(SUITE.LOCK_TYPE.UI)) {
-                const previousRoute = state.router.settingsBackRoute.name;
-                if (previousRoute === 'wallet-send') {
-                    api.dispatch(coinjoinAccountActions.restorePausedCoinjoinSessions());
-                } else {
-                    const accountKey = state.wallet.selectedAccount.account?.key;
-                    if (accountKey) {
-                        const session = selectCoinjoinAccountByKey(state, accountKey)?.session;
-                        if (
-                            state.router.route?.name === 'wallet-send' &&
-                            !session?.paused &&
-                            !session?.starting
-                        ) {
-                            api.dispatch(coinjoinClientActions.pauseCoinjoinSession(accountKey));
-                        }
-                    }
-                }
-            }
-        }
-
         if (action.type === messageSystemActions.updateValidMessages.type) {
             const state = api.getState();
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Base branch https://github.com/trezor/trezor-suite/pull/9021

Keep coinjoin running when accessing send form

## Related Issue

Resolve https://github.com/trezor/trezor-suite/issues/8373

## Screenshots:
