### PR TITLE
Recognise more compose error types

### DIFF
--- a/packages/suite/src/hooks/wallet/form/useCompose.ts
+++ b/packages/suite/src/hooks/wallet/form/useCompose.ts
@@ -16,6 +16,7 @@ import {
     PrecomposedLevels,
     PrecomposedLevelsCardano,
 } from '@suite-common/wallet-types';
+import { COMPOSE_ERROR_TYPES } from '@suite-common/wallet-constants';
 
 const DEFAULT_FIELD = 'outputs.0.amount';
 
@@ -113,7 +114,7 @@ export const useCompose = <TFieldValues extends FormState>({
                 }
 
                 const formError = {
-                    type: 'compose',
+                    type: COMPOSE_ERROR_TYPES.COMPOSE,
                     message: translationString(errorMessage.id, errorMessage.values),
                 };
 

--- a/packages/suite/src/hooks/wallet/useCoinmarketExchangeForm.ts
+++ b/packages/suite/src/hooks/wallet/useCoinmarketExchangeForm.ts
@@ -33,6 +33,7 @@ import type { AppState } from 'src/types/suite';
 import { useBitcoinAmountUnit } from 'src/hooks/wallet/useBitcoinAmountUnit';
 import { useDidUpdate } from '@trezor/react-utils';
 import { CryptoAmountLimits } from 'src/types/wallet/coinmarketCommonTypes';
+import { COMPOSE_ERROR_TYPES } from '@suite-common/wallet-constants';
 
 export const ExchangeFormContext = createContext<ExchangeFormContextValues | null>(null);
 ExchangeFormContext.displayName = 'CoinmarketExchangeContext';
@@ -274,7 +275,7 @@ export const useCoinmarketExchangeForm = ({
 
         if (composed.type === 'error' && composed.errorMessage) {
             setError(CRYPTO_INPUT, {
-                type: 'compose',
+                type: COMPOSE_ERROR_TYPES.COMPOSE,
                 message: translationString(composed.errorMessage.id, composed.errorMessage.values),
             });
         }

--- a/packages/suite/src/hooks/wallet/useSendFormCompose.ts
+++ b/packages/suite/src/hooks/wallet/useSendFormCompose.ts
@@ -17,6 +17,7 @@ import * as sendFormActions from 'src/actions/wallet/sendFormActions';
 import { findComposeErrors } from '@suite-common/wallet-utils';
 import { FeeLevel } from '@trezor/connect';
 import { TranslationKey } from 'src/components/suite/Translation';
+import { COMPOSE_ERROR_TYPES } from '@suite-common/wallet-constants';
 
 type Props = UseFormReturn<FormState> & {
     state: UseSendFormState;
@@ -182,11 +183,11 @@ export const useSendFormCompose = ({
                 const getErrorType = (translationKey: TranslationKey) => {
                     switch (translationKey) {
                         case 'TR_NOT_ENOUGH_ANONYMIZED_FUNDS_WARNING':
-                            return 'anonymity';
+                            return COMPOSE_ERROR_TYPES.ANONYMITY;
                         case 'TR_NOT_ENOUGH_SELECTED':
-                            return 'coinControl';
+                            return COMPOSE_ERROR_TYPES.COIN_CONTROL;
                         default:
-                            return 'compose';
+                            return COMPOSE_ERROR_TYPES.COMPOSE;
                     }
                 };
 

--- a/packages/suite/src/views/wallet/send/components/Options/components/BitcoinOptions/components/CoinControl.tsx
+++ b/packages/suite/src/views/wallet/send/components/Options/components/BitcoinOptions/components/CoinControl.tsx
@@ -12,6 +12,7 @@ import { UtxoSelectionList } from 'src/components/wallet/CoinControl/UtxoSelecti
 import { useSendFormContext } from 'src/hooks/wallet';
 import { useBitcoinAmountUnit } from 'src/hooks/wallet/useBitcoinAmountUnit';
 import { selectCurrentTargetAnonymity } from 'src/reducers/wallet/coinjoinReducer';
+import { COMPOSE_ERROR_TYPES } from '@suite-common/wallet-constants';
 
 const Row = styled.div`
     align-items: center;
@@ -111,7 +112,7 @@ export const CoinControl = ({ close }: CoinControlProps) => {
     const missingAmountTooBig = missingToInput > Number.MAX_SAFE_INTEGER;
     const amountHasError = errors.outputs?.some?.(error => error?.amount); // relevant when input is a number, but there is an error, e.g. decimals in sats
     const notEnoughFundsSelectedError = !!errors.outputs?.some?.(
-        error => error?.amount?.type === 'coinControl',
+        error => error?.amount?.type === COMPOSE_ERROR_TYPES.COIN_CONTROL,
     );
     const isMissingVisible =
         isCoinControlEnabled &&

--- a/suite-common/wallet-constants/src/sendForm.ts
+++ b/suite-common/wallet-constants/src/sendForm.ts
@@ -52,3 +52,9 @@ export const DEFAULT_VALUES = {
 // By setting offset to 7200s transaction sent from Suite will be valid for 2h.
 // If it is not included in a block until then it will be rejected by the network.
 export const CARDANO_DEFAULT_TTL_OFFSET = 7200;
+
+export const COMPOSE_ERROR_TYPES = {
+    COMPOSE: 'compose',
+    COIN_CONTROL: 'coinControl',
+    ANONYMITY: 'anonymity',
+};

--- a/suite-common/wallet-utils/src/sendFormUtils.ts
+++ b/suite-common/wallet-utils/src/sendFormUtils.ts
@@ -16,7 +16,12 @@ import { fiatCurrencies } from '@suite-common/suite-config';
 import { isFeatureFlagEnabled } from '@suite-common/suite-utils';
 import { Network, NetworkType } from '@suite-common/wallet-config';
 import { EthereumTransaction, TokenInfo, ComposeOutput, PROTO } from '@trezor/connect';
-import { DEFAULT_PAYMENT, DEFAULT_VALUES, ERC20_TRANSFER } from '@suite-common/wallet-constants';
+import {
+    COMPOSE_ERROR_TYPES,
+    DEFAULT_PAYMENT,
+    DEFAULT_VALUES,
+    ERC20_TRANSFER,
+} from '@suite-common/wallet-constants';
 import type {
     FormState,
     FeeInfo,
@@ -212,7 +217,7 @@ export const getInputState = (
 };
 
 export const isLowAnonymityWarning = (error?: Merge<FieldError, FieldErrorsImpl<Output>>) =>
-    error?.amount?.type === 'anonymity';
+    error?.amount?.type === COMPOSE_ERROR_TYPES.ANONYMITY;
 
 export const getFiatRate = (fiatRates: CoinFiatRates | undefined, currency: string) => {
     if (!fiatRates || !fiatRates.current || !fiatRates.current.rates) return;
@@ -226,7 +231,7 @@ export const getFeeUnits = (networkType: NetworkType) => {
     return 'sat/B';
 };
 
-// Find all errors with type='compose' in FormState errors
+// Find all validation errors set while composing a transaction
 export const findComposeErrors = <T extends FieldValues>(
     errors: FieldErrors<T>,
     prefix?: string,
@@ -246,7 +251,7 @@ export const findComposeErrors = <T extends FieldValues>(
             } else if (
                 typeof val === 'object' &&
                 Object.prototype.hasOwnProperty.call(val, 'type') &&
-                val.type === 'compose'
+                Object.values(COMPOSE_ERROR_TYPES).includes(val.type as string)
             ) {
                 // regular top level field
                 composeErrors.push((prefix ? `${prefix}.${key}` : key) as FieldPath<T>);


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

I made this error during [hook-form upgrade](https://github.com/trezor/trezor-suite/pull/7018) when I changed validation messages from translation keys to translation strings. Since then, messages are identified bytheir `type`. The `type` property became more granular, but I forgot to reflect this in `findComposeErrors` where it only checked for `type === 'compose'`

## Related Issue

Resolve [#9062](https://github.com/trezor/trezor-suite/issues/9062#event-9962733507)
