### PR TITLE
chore(suite): migrate notarization from altool to notarytool

### DIFF
--- a/packages/suite-desktop-core/scripts/notarize.ts
+++ b/packages/suite-desktop-core/scripts/notarize.ts
@@ -21,6 +21,7 @@ exports.default = context => {
     console.log(`notarizing ${appPath} ...`);
 
     return notarize({
+        tool: 'notarytool',
         appBundleId: 'io.trezor.TrezorSuite',
         appPath,
         appleId: process.env.APPLEID,


### PR DESCRIPTION
Switched to the notarytool system

## Description

The altool system (currently used) will be disabled on November 1, 2023 and it the new notarizing tool is much faster and more reliable than the altool system.

## Related Issue

Resolve #8692 