### PR TITLE
chore(suite): sentry tree shaking

### DIFF
--- a/packages/suite-build/configs/base.webpack.config.ts
+++ b/packages/suite-build/configs/base.webpack.config.ts
@@ -163,31 +163,18 @@ const config: webpack.Configuration = {
     },
     plugins: [
         new webpack.ProgressPlugin(),
-        new webpack.DefinePlugin(
-            isDev
-                ? {
-                      'process.browser': true,
-                      'process.env.SUITE_TYPE': JSON.stringify(project),
-                      'process.env.VERSION': JSON.stringify(suiteVersion),
-                      'process.env.COMMITHASH': JSON.stringify(gitRevision),
-                      'process.env.ASSET_PREFIX': JSON.stringify(assetPrefix),
-                      'process.env.JWS_PUBLIC_KEY': JSON.stringify(jwsPublicKey),
-                      'process.env.CODESIGN_BUILD': isCodesignBuild,
-                      'process.env.SENTRY_RELEASE': JSON.stringify(sentryRelease),
-                  }
-                : {
-                      'process.browser': true,
-                      'process.env.SUITE_TYPE': JSON.stringify(project),
-                      'process.env.VERSION': JSON.stringify(suiteVersion),
-                      'process.env.COMMITHASH': JSON.stringify(gitRevision),
-                      'process.env.ASSET_PREFIX': JSON.stringify(assetPrefix),
-                      'process.env.JWS_PUBLIC_KEY': JSON.stringify(jwsPublicKey),
-                      'process.env.CODESIGN_BUILD': isCodesignBuild,
-                      'process.env.SENTRY_RELEASE': JSON.stringify(sentryRelease),
-                      __SENTRY_DEBUG__: false,
-                      __SENTRY_TRACING__: false, // needs to be removed when we introduce performance monitoring in trezor-suite
-                  },
-        ),
+        new webpack.DefinePlugin({
+            'process.browser': true,
+            'process.env.SUITE_TYPE': JSON.stringify(project),
+            'process.env.VERSION': JSON.stringify(suiteVersion),
+            'process.env.COMMITHASH': JSON.stringify(gitRevision),
+            'process.env.ASSET_PREFIX': JSON.stringify(assetPrefix),
+            'process.env.JWS_PUBLIC_KEY': JSON.stringify(jwsPublicKey),
+            'process.env.CODESIGN_BUILD': isCodesignBuild,
+            'process.env.SENTRY_RELEASE': JSON.stringify(sentryRelease),
+            __SENTRY_DEBUG__: isDev,
+            __SENTRY_TRACING__: false, // needs to be removed when we introduce performance monitoring in trezor-suite
+        }),
         new webpack.ProvidePlugin({
             Buffer: ['buffer', 'Buffer'],
             process: 'process',

--- a/packages/suite-build/configs/base.webpack.config.ts
+++ b/packages/suite-build/configs/base.webpack.config.ts
@@ -163,16 +163,31 @@ const config: webpack.Configuration = {
     },
     plugins: [
         new webpack.ProgressPlugin(),
-        new webpack.DefinePlugin({
-            'process.browser': true,
-            'process.env.SUITE_TYPE': JSON.stringify(project),
-            'process.env.VERSION': JSON.stringify(suiteVersion),
-            'process.env.COMMITHASH': JSON.stringify(gitRevision),
-            'process.env.ASSET_PREFIX': JSON.stringify(assetPrefix),
-            'process.env.JWS_PUBLIC_KEY': JSON.stringify(jwsPublicKey),
-            'process.env.CODESIGN_BUILD': isCodesignBuild,
-            'process.env.SENTRY_RELEASE': JSON.stringify(sentryRelease),
-        }),
+        new webpack.DefinePlugin(
+            isDev
+                ? {
+                      'process.browser': true,
+                      'process.env.SUITE_TYPE': JSON.stringify(project),
+                      'process.env.VERSION': JSON.stringify(suiteVersion),
+                      'process.env.COMMITHASH': JSON.stringify(gitRevision),
+                      'process.env.ASSET_PREFIX': JSON.stringify(assetPrefix),
+                      'process.env.JWS_PUBLIC_KEY': JSON.stringify(jwsPublicKey),
+                      'process.env.CODESIGN_BUILD': isCodesignBuild,
+                      'process.env.SENTRY_RELEASE': JSON.stringify(sentryRelease),
+                  }
+                : {
+                      'process.browser': true,
+                      'process.env.SUITE_TYPE': JSON.stringify(project),
+                      'process.env.VERSION': JSON.stringify(suiteVersion),
+                      'process.env.COMMITHASH': JSON.stringify(gitRevision),
+                      'process.env.ASSET_PREFIX': JSON.stringify(assetPrefix),
+                      'process.env.JWS_PUBLIC_KEY': JSON.stringify(jwsPublicKey),
+                      'process.env.CODESIGN_BUILD': isCodesignBuild,
+                      'process.env.SENTRY_RELEASE': JSON.stringify(sentryRelease),
+                      __SENTRY_DEBUG__: false,
+                      __SENTRY_TRACING__: false, // needs to be removed when we introduce performance monitoring in trezor-suite
+                  },
+        ),
         new webpack.ProvidePlugin({
             Buffer: ['buffer', 'Buffer'],
             process: 'process',


### PR DESCRIPTION
Minimized the bundle size of the Sentry SDK

## Description

Set 2 flags in the Sentry SDK to `false`:
1. `__SENTRY_DEBUG__` - removes code related to debug logging
2. `__SENTRY_TRACING__` - removes code related to performance monitoring (needs to be removed when this is introduced in the app)

## Related Issue

Resolve #6444 