### PR TITLE
fix transport e2e

### DIFF
--- a/packages/transport/e2e/tests/bridge.test.ts
+++ b/packages/transport/e2e/tests/bridge.test.ts
@@ -156,7 +156,7 @@ describe('bridge', () => {
             });
 
             test(`call(Backup) - send(Cancel) - receive`, async () => {
-                // initiate change pin procedure on device
+                // initiate backup procedure on device
                 const callResponse = await bridge.call({ session, name: 'BackupDevice', data: {} })
                     .promise;
                 expect(callResponse).toMatchObject({
@@ -166,7 +166,7 @@ describe('bridge', () => {
                     },
                 });
 
-                // cancel change pin procedure
+                // cancel backup procedure
                 const sendResponse = await bridge.send({ session, name: 'Cancel', data: {} })
                     .promise;
                 expect(sendResponse).toEqual({ success: true });

--- a/packages/transport/e2e/tests/events.test.ts
+++ b/packages/transport/e2e/tests/events.test.ts
@@ -65,9 +65,6 @@ describe('bridge', () => {
         await bridge1.init().promise;
         await bridge2.init().promise;
 
-        bridge1.listen();
-        bridge2.listen();
-
         const result = await bridge1.enumerate().promise;
         expect(result.success).toBe(true);
 
@@ -86,6 +83,12 @@ describe('bridge', () => {
                 debugSession: null,
             },
         ]);
+
+        bridge1.handleDescriptorsChange(descriptors);
+        bridge2.handleDescriptorsChange(descriptors);
+
+        bridge1.listen();
+        bridge2.listen();
     });
 
     test('2 clients. one acquires and releases, the other one is watching', async () => {
@@ -138,7 +141,7 @@ describe('bridge', () => {
             return;
         }
 
-        await bridge1.release(session1.payload).promise;
+        await bridge1.release({ path: '1', session: session1.payload }).promise;
 
         await wait();
 
@@ -190,7 +193,7 @@ describe('bridge', () => {
             return;
         }
 
-        await wait(); // fait for event to be propagated
+        await wait(); // wait for event to be propagated
 
         // bridge 2 steals session
         const session2 = await bridge2.acquire({
@@ -204,7 +207,7 @@ describe('bridge', () => {
             session: '2',
         });
 
-        await wait(); // fait for event to be propagated
+        await wait(); // wait for event to be propagated
 
         expect(bride1spy).toHaveBeenLastCalledWith('transport-update', {
             acquired: [expectedDescriptor],


### PR DESCRIPTION
Fixing failing e2e test. 
This change introduces the very same way of working with transport we use in @trezor/connect. First there is manual enumeration, manual update of descriptors and listening starts only after this initial state is setup.

passed here https://gitlab.com/satoshilabs/trezor/trezor-suite/-/jobs/4778264661