### PR TITLE
Remove (some of the) mined txs from CJ mempool

### DIFF
--- a/packages/coinjoin/src/backend/CoinjoinMempoolController.ts
+++ b/packages/coinjoin/src/backend/CoinjoinMempoolController.ts
@@ -14,7 +14,7 @@ type MempoolStatus = 'stopped' | 'running';
 
 export type MempoolController = Pick<
     CoinjoinMempoolController,
-    'status' | 'start' | 'stop' | 'init' | 'update' | 'getTransactions'
+    'status' | 'start' | 'stop' | 'init' | 'update' | 'getTransactions' | 'removeTransactions'
 >;
 
 type CoinjoinMempoolControllerSettings = {
@@ -200,5 +200,9 @@ export class CoinjoinMempoolController {
         );
 
         return Array.from(set, txid => this.mempool.get(txid)!);
+    }
+
+    removeTransactions(txids: string[]) {
+        txids.forEach(this.onTxRemove);
     }
 }

--- a/packages/coinjoin/src/backend/scanAccount.ts
+++ b/packages/coinjoin/src/backend/scanAccount.ts
@@ -50,6 +50,9 @@ export const scanAccount = async (
 
         if (isMatch(scripts)) {
             const block = await client.fetchBlock(blockHeight, { signal: abortSignal });
+            if (mempool?.status === 'running') {
+                mempool.removeTransactions(block.txs.map(({ txid }) => txid));
+            }
             addresses.analyze(
                 ({ address }) => block.txs.filter(doesTxContainAddress(address)),
                 transactions => transactions.forEach(txs.add, txs),

--- a/packages/coinjoin/tests/backend/CoinjoinMempoolController.test.ts
+++ b/packages/coinjoin/tests/backend/CoinjoinMempoolController.test.ts
@@ -80,6 +80,15 @@ describe('CoinjoinMempoolController', () => {
         expect(mempool.getTransactions()).toEqual([TXS[1], TXS[3], TXS[4]]);
     });
 
+    it('Removing', async () => {
+        client.setMempoolTxs(TXS);
+        await mempool.init();
+        expect(mempool.getTransactions()).toEqual(TXS);
+
+        mempool.removeTransactions([TXS[0].txid, TXS[2].txid, 'unknown', TXS[4].txid]);
+        expect(mempool.getTransactions()).toEqual([TXS[1], TXS[3], TXS[5]]);
+    });
+
     it('Replace-by-fee', async () => {
         const outpointCollision = { txid: 'foo', vout: 3 };
         const a1 = TXS[1];


### PR DESCRIPTION
## Description

When tx was mined, CJ mempool still kept it as pending until purge and it was Suite's responsibility to prefer the mined one. Now mined txs are removed from CJ mempool whenever block is fetched based on filters.