### PR TITLE
fix(suite): graph worker file logic to avoid importing connect in worker

### DIFF
--- a/packages/suite/src/actions/firmware/firmwareThunks.ts
+++ b/packages/suite/src/actions/firmware/firmwareThunks.ts
@@ -10,9 +10,9 @@ import {
     selectPrevDevice,
     selectTargetRelease,
     selectUseDevkit,
-} from '../../reducers/firmware/firmwareReducer';
-import { selectDevice } from '../../reducers/suite/suiteReducer';
-import { Dispatch, FirmwareType, GetState } from '../../types/suite';
+} from 'src/reducers/firmware/firmwareReducer';
+import { selectDevice } from 'src/reducers/suite/suiteReducer';
+import { Dispatch, FirmwareType, GetState } from 'src/types/suite';
 import { firmwareActions } from './firmwareActions';
 
 /**

--- a/packages/suite/src/actions/suite/storageActions.ts
+++ b/packages/suite/src/actions/suite/storageActions.ts
@@ -18,8 +18,8 @@ import type { PreloadStoreAction } from 'src/support/suite/preloadStore';
 import { getFormDraftKey } from '@suite-common/wallet-utils';
 import { FormDraftPrefixKeyValues } from '@suite-common/wallet-constants';
 import { STORAGE } from './constants';
-import { GraphData } from '../../types/wallet/graph';
-import { deviceGraphDataFilterFn } from '../../utils/wallet/graphUtils';
+import { GraphData } from 'src/types/wallet/graph';
+import { deviceGraphDataFilterFn } from 'src/utils/wallet/graph';
 import { selectCoinjoinAccountByKey } from 'src/reducers/wallet/coinjoinReducer';
 
 export type StorageAction = NonNullable<PreloadStoreAction>;

--- a/packages/suite/src/actions/wallet/graphActions.ts
+++ b/packages/suite/src/actions/wallet/graphActions.ts
@@ -15,14 +15,14 @@ import {
     SET_SELECTED_RANGE,
     SET_SELECTED_VIEW,
 } from './constants/graphConstants';
-import { GraphData, GraphRange, GraphScale } from '../../types/wallet/graph';
+import { GraphData, GraphRange, GraphScale } from 'src/types/wallet/graph';
 import {
     ensureHistoryRates,
     enhanceBlockchainAccountHistory,
     accountGraphDataFilterFn,
     deviceGraphDataFilterFn,
-} from '../../utils/wallet/graphUtils';
-import { selectLocalCurrency } from '../../reducers/wallet/settingsReducer';
+} from 'src/utils/wallet/graph';
+import { selectLocalCurrency } from 'src/reducers/wallet/settingsReducer';
 
 export type GraphAction =
     | {

--- a/packages/suite/src/components/suite/NumberInput.tsx
+++ b/packages/suite/src/components/suite/NumberInput.tsx
@@ -5,7 +5,7 @@ import BigNumber from 'bignumber.js';
 import { Input, InputProps } from '@trezor/components';
 import { localizeNumber } from '@suite-common/wallet-utils';
 import { Locale } from 'src/config/suite/languages';
-import { useSelector } from '../../hooks/suite';
+import { useSelector } from 'src/hooks/suite';
 import { getLocaleSeparators } from '@trezor/utils';
 
 const isValidDecimalString = (value: string) => /^([^.]*)\.[^.]+$/.test(value);

--- a/packages/suite/src/components/suite/TransactionsGraph/components/CustomTooltipAccount.tsx
+++ b/packages/suite/src/components/suite/TransactionsGraph/components/CustomTooltipAccount.tsx
@@ -9,7 +9,7 @@ import { Formatters, useFormatters } from '@suite-common/formatters';
 
 import { Props as GraphProps, CryptoGraphProps } from '../definitions';
 import { CustomTooltipBase } from './CustomTooltipBase';
-import { CommonAggregatedHistory } from '../../../../types/wallet/graph';
+import { CommonAggregatedHistory } from 'src/types/wallet/graph';
 import { SignOperator } from '@suite-common/suite-types';
 
 const StyledCryptoAmount = styled(FormattedCryptoAmount)`

--- a/packages/suite/src/components/suite/TransactionsGraph/components/CustomTooltipBase.tsx
+++ b/packages/suite/src/components/suite/TransactionsGraph/components/CustomTooltipBase.tsx
@@ -7,7 +7,7 @@ import { TooltipProps } from 'recharts';
 import { variables } from '@trezor/components';
 
 import { Props as GraphProps } from '../definitions';
-import { CommonAggregatedHistory } from '../../../../types/wallet/graph';
+import { CommonAggregatedHistory } from 'src/types/wallet/graph';
 
 // Used for triggering custom Tooltip alignment
 const OFFSET_LIMIT_HORIZONTAL = 125;

--- a/packages/suite/src/components/suite/TransactionsGraph/components/CustomTooltipDashboard.tsx
+++ b/packages/suite/src/components/suite/TransactionsGraph/components/CustomTooltipDashboard.tsx
@@ -6,7 +6,7 @@ import { useFormatters } from '@suite-common/formatters';
 
 import { Props as GraphProps, FiatGraphProps } from '../definitions';
 import { CustomTooltipBase } from './CustomTooltipBase';
-import { CommonAggregatedHistory } from '../../../../types/wallet/graph';
+import { CommonAggregatedHistory } from 'src/types/wallet/graph';
 
 interface CustomTooltipDashboardProps extends TooltipProps<number, any> {
     selectedRange: GraphProps['selectedRange'];

--- a/packages/suite/src/components/suite/TransactionsGraph/components/CustomXAxisTick.tsx
+++ b/packages/suite/src/components/suite/TransactionsGraph/components/CustomXAxisTick.tsx
@@ -4,7 +4,7 @@ import { FormattedDate } from 'react-intl';
 import { differenceInMonths } from 'date-fns';
 
 import { useTheme } from '@trezor/components';
-import { GraphRange } from '../../../../types/wallet/graph';
+import { GraphRange } from 'src/types/wallet/graph';
 
 interface CustomXAxisProps {
     selectedRange: GraphRange;

--- a/packages/suite/src/components/suite/TransactionsGraph/components/GraphScaleDropdownItem.tsx
+++ b/packages/suite/src/components/suite/TransactionsGraph/components/GraphScaleDropdownItem.tsx
@@ -4,7 +4,7 @@ import { useGraph } from 'src/hooks/suite';
 import { Translation } from 'src/components/suite';
 
 import { SelectBar, SelectBarProps } from '@trezor/components';
-import { GraphScale } from '../../../../types/wallet/graph';
+import { GraphScale } from 'src/types/wallet/graph';
 
 export const GraphScaleDropdownItem = (props: Omit<SelectBarProps<GraphScale>, 'options'>) => {
     const { selectedView, setSelectedView } = useGraph();

--- a/packages/suite/src/components/suite/TransactionsGraph/components/RangeSelector.tsx
+++ b/packages/suite/src/components/suite/TransactionsGraph/components/RangeSelector.tsx
@@ -14,7 +14,7 @@ import {
 } from 'date-fns';
 
 import { colors, variables, Dropdown, DropdownRef, Timerange } from '@trezor/components';
-import { GraphRange } from '../../../../types/wallet/graph';
+import { GraphRange } from 'src/types/wallet/graph';
 
 const Wrapper = styled.div`
     display: flex;

--- a/packages/suite/src/components/suite/TransactionsGraph/definitions.ts
+++ b/packages/suite/src/components/suite/TransactionsGraph/definitions.ts
@@ -3,7 +3,7 @@ import {
     GraphRange,
     AggregatedAccountHistory,
     AggregatedDashboardHistory,
-} from '../../../types/wallet/graph';
+} from 'src/types/wallet/graph';
 
 interface CommonProps {
     isLoading?: boolean;

--- a/packages/suite/src/components/suite/TransactionsGraph/index.tsx
+++ b/packages/suite/src/components/suite/TransactionsGraph/index.tsx
@@ -15,11 +15,7 @@ import { CustomBar } from './components/CustomBar';
 import { CustomTooltipDashboard } from './components/CustomTooltipDashboard';
 import { CustomTooltipAccount } from './components/CustomTooltipAccount';
 import { SkeletonTransactionsGraph } from './components/SkeletonTransactionsGraph';
-import {
-    calcYDomain,
-    calcFakeGraphDataForTimestamps,
-    calcXDomain,
-} from '../../../utils/wallet/graphUtils';
+import { calcYDomain, calcFakeGraphDataForTimestamps, calcXDomain } from 'src/utils/wallet/graph';
 
 const Wrapper = styled.div`
     display: flex;

--- a/packages/suite/src/components/suite/__tests__/Translation.test.tsx
+++ b/packages/suite/src/components/suite/__tests__/Translation.test.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import createComponentWithIntl from '../../../support/tests/IntlHelper';
+import createComponentWithIntl from 'src/support/tests/IntlHelper';
 import { Translation } from '../Translation';
 
 const messages = {

--- a/packages/suite/src/middlewares/firmware/firmwareMiddleware.ts
+++ b/packages/suite/src/middlewares/firmware/firmwareMiddleware.ts
@@ -4,7 +4,7 @@ import { firmwareUpdate } from 'src/actions/firmware/firmwareThunks';
 import type { MiddlewareAPI } from 'redux';
 import type { AppState, Action, Dispatch } from 'src/types/suite';
 
-import { selectFirmware } from '../../reducers/firmware/firmwareReducer';
+import { selectFirmware } from 'src/reducers/firmware/firmwareReducer';
 
 const firmwareMiddleware =
     (api: MiddlewareAPI<Dispatch, AppState>) =>

--- a/packages/suite/src/middlewares/suite/__tests__/firmwareMiddleware.test.ts
+++ b/packages/suite/src/middlewares/suite/__tests__/firmwareMiddleware.test.ts
@@ -7,7 +7,7 @@ import suiteReducer from 'src/reducers/suite/suiteReducer';
 import firmwareMiddleware from 'src/middlewares/firmware/firmwareMiddleware';
 import { firmwareActions } from 'src/actions/firmware/firmwareActions';
 
-import { extraDependencies } from '../../../support/extraDependencies';
+import { extraDependencies } from 'src/support/extraDependencies';
 
 const { getSuiteDevice } = global.JestMocks;
 

--- a/packages/suite/src/middlewares/suite/__tests__/messageSystemMiddleware.test.ts
+++ b/packages/suite/src/middlewares/suite/__tests__/messageSystemMiddleware.test.ts
@@ -8,7 +8,7 @@ import * as messageSystemUtils from '@suite-common/message-system/src/messageSys
 import { extraDependencies } from 'src/support/extraDependencies';
 import WalletReducers from 'src/reducers/wallet';
 import messageSystemMiddleware from '../messageSystemMiddleware';
-import { AppState } from '../../../reducers/store';
+import { AppState } from 'src/reducers/store';
 
 // Type annotation as workaround for typecheck error "The inferred type of 'default' cannot be named..."
 const messageSystemReducer: Reducer = prepareMessageSystemReducer(extraDependencies);

--- a/packages/suite/src/middlewares/wallet/index.ts
+++ b/packages/suite/src/middlewares/wallet/index.ts
@@ -7,7 +7,7 @@ import coinmarketMiddleware from './coinmarketMiddleware';
 import coinmarketSavingsMiddleware from './coinmarketSavingsMiddleware';
 import pollingMiddleware from './pollingMiddleware';
 import { coinjoinMiddleware } from './coinjoinMiddleware';
-import { extraDependencies } from '../../support/extraDependencies';
+import { extraDependencies } from 'src/support/extraDependencies';
 
 export default [
     prepareBlockchainMiddleware(extraDependencies),

--- a/packages/suite/src/reducers/wallet/graphReducer.ts
+++ b/packages/suite/src/reducers/wallet/graphReducer.ts
@@ -6,7 +6,7 @@ import { Action as SuiteAction } from 'src/types/suite';
 import { SETTINGS } from 'src/config/suite';
 
 import { accountsActions } from '@suite-common/wallet-core';
-import { GraphData, AccountIdentifier, GraphRange, GraphScale } from '../../types/wallet/graph';
+import { GraphData, AccountIdentifier, GraphRange, GraphScale } from 'src/types/wallet/graph';
 
 export interface State {
     data: GraphData[];

--- a/packages/suite/src/support/workers/graph.ts
+++ b/packages/suite/src/support/workers/graph.ts
@@ -1,6 +1,10 @@
 /* eslint-disable no-restricted-globals */
 
-import { aggregateBalanceHistory } from '../../utils/wallet/graphUtils';
+/*
+    It's crucial to import directly from the 'utilsWorker' file. 
+    Otherwise, '@trezor/connect' would end up being bundled into the worker, which will break graph on dashboard.
+*/
+import { aggregateBalanceHistory } from 'src/utils/wallet/graph/utilsWorker';
 
 const ctx: Worker = self as any;
 

--- a/packages/suite/src/utils/wallet/graph/index.ts
+++ b/packages/suite/src/utils/wallet/graph/index.ts
@@ -1,0 +1,11 @@
+/*
+    The Graph utilities are organized into three distinct files. 
+    This structure is implemented to prevent the '@trezor/connect' from being bundled into the worker file. 
+
+    When working within Suite, you can import from this file. 
+    However, it's important to note that these utilities should not be imported from the worker (graph.ts file).
+*/
+
+export * from './utils'; // Utilities specific to suite.
+export * from './utilsShared'; // Utilities that are shared between suite and worker.
+export * from './utilsWorker'; // Utilities specific to the worker process.

--- a/packages/suite/src/utils/wallet/graph/utils.ts
+++ b/packages/suite/src/utils/wallet/graph/utils.ts
@@ -1,30 +1,16 @@
 import { getFiatRatesForTimestamps, getTickerConfig } from '@suite-common/fiat-services';
 import { resetTime } from '@suite-common/suite-utils';
-import { NetworkSymbol } from '@suite-common/wallet-config';
+import type { NetworkSymbol } from '@suite-common/wallet-config';
 import { Account } from '@suite-common/wallet-types';
-import { formatNetworkAmount, toFiatCurrency } from '@suite-common/wallet-utils';
+import { formatNetworkAmount } from '@suite-common/wallet-utils';
 import BigNumber from 'bignumber.js';
-import { differenceInMonths, fromUnixTime, getUnixTime, startOfMonth } from 'date-fns';
+import { differenceInMonths } from 'date-fns';
 
-import {
-    AggregatedAccountHistory,
-    AggregatedDashboardHistory,
-    CommonAggregatedHistory,
-    GraphData,
-    GraphRange,
-    GraphScale,
-} from '../../types/wallet/graph';
+import { CommonAggregatedHistory, GraphData, GraphRange, GraphScale } from 'src/types/wallet/graph';
 
-import type { BlockchainAccountBalanceHistory, FiatRates } from '@trezor/connect';
+import type { BlockchainAccountBalanceHistory } from '@trezor/connect';
 import { FiatCurrencyCode } from '@suite-common/suite-config';
-
-type ObjectType<T> = T extends 'account'
-    ? AggregatedAccountHistory
-    : T extends 'dashboard'
-    ? AggregatedDashboardHistory
-    : never;
-
-type TypeName = 'account' | 'dashboard';
+import { ObjectType, TypeName, sumFiatValueMapInPlace } from './utilsShared';
 
 export const deviceGraphDataFilterFn = (d: GraphData, deviceState: string | undefined) => {
     if (!deviceState) return false;
@@ -147,133 +133,6 @@ export const getMinMaxValueFromData = <TType extends TypeName>(
         .map(m => m!.toNumber());
     const minValue = Math.min(...minsToCompare);
     return [minValue, maxValue];
-};
-
-export const calcFiatValueMap = (
-    amount: string,
-    rates: FiatRates,
-): { [k: string]: string | undefined } => {
-    const fiatValueMap: { [k: string]: string | undefined } = {};
-    Object.keys(rates).forEach(fiatSymbol => {
-        fiatValueMap[fiatSymbol] = toFiatCurrency(amount, fiatSymbol, rates) ?? '0';
-    });
-    return fiatValueMap;
-};
-
-/**
- * Mutates the first object param and adds values from second object.
- *
- * @param {{ string: string | undefined }} valueMap
- * @param {{ string: string | undefined }} obj
- * @returns
- */
-export const sumFiatValueMapInPlace = (
-    valueMap: { [k: string]: string | undefined },
-    obj: { [k: string]: string | undefined },
-) => {
-    Object.entries(obj).forEach(keyVal => {
-        const [key, val] = keyVal;
-        const previousValue = valueMap[key] ?? '0';
-        valueMap[key] = new BigNumber(previousValue).plus(val ?? 0).toFixed();
-    });
-};
-
-export const isAccountAggregatedHistory = (
-    history: AggregatedAccountHistory | AggregatedDashboardHistory,
-    type: 'account' | 'dashboard',
-): history is AggregatedAccountHistory =>
-    (history as AggregatedAccountHistory).sent !== undefined && type === 'account';
-
-export const aggregateBalanceHistory = <TType extends TypeName>(
-    graphData: GraphData[],
-    groupBy: 'day' | 'month',
-    type: TType,
-): ObjectType<TType>[] => {
-    const groupedByTimestamp: { [key: string]: ObjectType<TType> } = {};
-
-    for (let i = 0; i < graphData.length; i++) {
-        // graph data for one account
-        const accountHistory = graphData[i].data;
-
-        if (accountHistory && accountHistory.length > 0) {
-            accountHistory.forEach(h => {
-                // calc sent/received amounts in fiat
-                const dataPoint = {
-                    ...h,
-                    receivedFiat: calcFiatValueMap(h.received, h.rates || {}),
-                    sentFiat: calcFiatValueMap(h.sent, h.rates || {}),
-                    balanceFiat: calcFiatValueMap(h.balance, h.rates || {}),
-                };
-
-                const d = fromUnixTime(dataPoint.time);
-                // build string used as a key to index daily/monthly bins
-                const key =
-                    groupBy === 'day'
-                        ? `${d.getFullYear()}-${d.getMonth() + 1}-${d.getDate()}`
-                        : `${d.getFullYear()}-${d.getMonth() + 1}`;
-                // current working bin
-                const bin = groupedByTimestamp[key];
-
-                // Calculate aggregated values for the bin
-                if (!bin) {
-                    // bin is empty, set initial values
-                    const baseProps: AggregatedDashboardHistory = {
-                        time:
-                            groupBy === 'day'
-                                ? dataPoint.time
-                                : getUnixTime(startOfMonth(fromUnixTime(dataPoint.time))), // set timestamp to first day of the month
-                        txs: dataPoint.txs,
-                        balanceFiat: dataPoint.balanceFiat,
-                        sentFiat: dataPoint.sentFiat,
-                        receivedFiat: dataPoint.receivedFiat,
-                        balance: undefined,
-                        sent: undefined,
-                        received: undefined,
-                    };
-
-                    const accountProps: AggregatedAccountHistory = {
-                        ...baseProps,
-                        balance: dataPoint.balance,
-                        sent: dataPoint.sent,
-                        received: dataPoint.received,
-                    };
-
-                    groupedByTimestamp[key] = (
-                        type === 'account' ? accountProps : baseProps
-                    ) as ObjectType<TType>;
-                } else {
-                    // add to existing bin
-                    bin.txs += dataPoint.txs;
-                    sumFiatValueMapInPlace(bin.sentFiat, dataPoint.sentFiat);
-                    sumFiatValueMapInPlace(bin.receivedFiat, dataPoint.receivedFiat);
-                    sumFiatValueMapInPlace(bin.balanceFiat, dataPoint.balanceFiat);
-
-                    // sumFiatValueMap(
-                    //     subFiatValueMap(bin.balanceFiat, dataPoint.sentFiat),
-                    //     dataPoint.sentFiat,
-                    // );
-
-                    if (isAccountAggregatedHistory(bin, type)) {
-                        // adding sent/received values
-                        bin.balance = new BigNumber(bin.balance)
-                            .plus(dataPoint.received)
-                            .minus(dataPoint.sent)
-                            .toFixed();
-                        bin.sent = new BigNumber(bin.sent).plus(dataPoint.sent).toFixed();
-                        bin.received = new BigNumber(bin.received)
-                            .plus(dataPoint.received)
-                            .toFixed();
-                    }
-                }
-            });
-        }
-    }
-
-    // convert bins from an object indexed by timestamp to an array of bins
-    const aggregatedData = Object.keys(groupedByTimestamp)
-        .map(timestamp => groupedByTimestamp[timestamp])
-        .sort((a, b) => Number(a.time) - Number(b.time)); // sort from older to newer;;
-    return aggregatedData;
 };
 
 export const sumFiatValueMap = (

--- a/packages/suite/src/utils/wallet/graph/utilsShared.ts
+++ b/packages/suite/src/utils/wallet/graph/utilsShared.ts
@@ -1,0 +1,28 @@
+import BigNumber from 'bignumber.js';
+import { AggregatedAccountHistory, AggregatedDashboardHistory } from 'src/types/wallet/graph';
+
+export type ObjectType<T> = T extends 'account'
+    ? AggregatedAccountHistory
+    : T extends 'dashboard'
+    ? AggregatedDashboardHistory
+    : never;
+
+export type TypeName = 'account' | 'dashboard';
+
+/**
+ * Mutates the first object param and adds values from second object.
+ *
+ * @param {{ string: string | undefined }} valueMap
+ * @param {{ string: string | undefined }} obj
+ * @returns
+ */
+export const sumFiatValueMapInPlace = (
+    valueMap: { [k: string]: string | undefined },
+    obj: { [k: string]: string | undefined },
+) => {
+    Object.entries(obj).forEach(keyVal => {
+        const [key, val] = keyVal;
+        const previousValue = valueMap[key] ?? '0';
+        valueMap[key] = new BigNumber(previousValue).plus(val ?? 0).toFixed();
+    });
+};

--- a/packages/suite/src/utils/wallet/graph/utilsWorker.ts
+++ b/packages/suite/src/utils/wallet/graph/utilsWorker.ts
@@ -1,0 +1,120 @@
+import BigNumber from 'bignumber.js';
+import { fromUnixTime, getUnixTime, startOfMonth } from 'date-fns';
+
+import {
+    AggregatedAccountHistory,
+    AggregatedDashboardHistory,
+    GraphData,
+} from 'src/types/wallet/graph';
+import { ObjectType, TypeName, sumFiatValueMapInPlace } from './utilsShared';
+import type { FiatRates } from '@trezor/connect';
+import { toFiatCurrency } from '@suite-common/wallet-utils';
+
+const calcFiatValueMap = (
+    amount: string,
+    rates: FiatRates,
+): { [k: string]: string | undefined } => {
+    const fiatValueMap: { [k: string]: string | undefined } = {};
+    Object.keys(rates).forEach(fiatSymbol => {
+        fiatValueMap[fiatSymbol] = toFiatCurrency(amount, fiatSymbol, rates) ?? '0';
+    });
+    return fiatValueMap;
+};
+
+const isAccountAggregatedHistory = (
+    history: AggregatedAccountHistory | AggregatedDashboardHistory,
+    type: 'account' | 'dashboard',
+): history is AggregatedAccountHistory =>
+    (history as AggregatedAccountHistory).sent !== undefined && type === 'account';
+
+export const aggregateBalanceHistory = <TType extends TypeName>(
+    graphData: GraphData[],
+    groupBy: 'day' | 'month',
+    type: TType,
+): ObjectType<TType>[] => {
+    const groupedByTimestamp: { [key: string]: ObjectType<TType> } = {};
+
+    for (let i = 0; i < graphData.length; i++) {
+        // graph data for one account
+        const accountHistory = graphData[i].data;
+
+        if (accountHistory && accountHistory.length > 0) {
+            accountHistory.forEach(h => {
+                // calc sent/received amounts in fiat
+                const dataPoint = {
+                    ...h,
+                    receivedFiat: calcFiatValueMap(h.received, h.rates || {}),
+                    sentFiat: calcFiatValueMap(h.sent, h.rates || {}),
+                    balanceFiat: calcFiatValueMap(h.balance, h.rates || {}),
+                };
+
+                const d = fromUnixTime(dataPoint.time);
+                // build string used as a key to index daily/monthly bins
+                const key =
+                    groupBy === 'day'
+                        ? `${d.getFullYear()}-${d.getMonth() + 1}-${d.getDate()}`
+                        : `${d.getFullYear()}-${d.getMonth() + 1}`;
+                // current working bin
+                const bin = groupedByTimestamp[key];
+
+                // Calculate aggregated values for the bin
+                if (!bin) {
+                    // bin is empty, set initial values
+                    const baseProps: AggregatedDashboardHistory = {
+                        time:
+                            groupBy === 'day'
+                                ? dataPoint.time
+                                : getUnixTime(startOfMonth(fromUnixTime(dataPoint.time))), // set timestamp to first day of the month
+                        txs: dataPoint.txs,
+                        balanceFiat: dataPoint.balanceFiat,
+                        sentFiat: dataPoint.sentFiat,
+                        receivedFiat: dataPoint.receivedFiat,
+                        balance: undefined,
+                        sent: undefined,
+                        received: undefined,
+                    };
+
+                    const accountProps: AggregatedAccountHistory = {
+                        ...baseProps,
+                        balance: dataPoint.balance,
+                        sent: dataPoint.sent,
+                        received: dataPoint.received,
+                    };
+
+                    groupedByTimestamp[key] = (
+                        type === 'account' ? accountProps : baseProps
+                    ) as ObjectType<TType>;
+                } else {
+                    // add to existing bin
+                    bin.txs += dataPoint.txs;
+                    sumFiatValueMapInPlace(bin.sentFiat, dataPoint.sentFiat);
+                    sumFiatValueMapInPlace(bin.receivedFiat, dataPoint.receivedFiat);
+                    sumFiatValueMapInPlace(bin.balanceFiat, dataPoint.balanceFiat);
+
+                    // sumFiatValueMap(
+                    //     subFiatValueMap(bin.balanceFiat, dataPoint.sentFiat),
+                    //     dataPoint.sentFiat,
+                    // );
+
+                    if (isAccountAggregatedHistory(bin, type)) {
+                        // adding sent/received values
+                        bin.balance = new BigNumber(bin.balance)
+                            .plus(dataPoint.received)
+                            .minus(dataPoint.sent)
+                            .toFixed();
+                        bin.sent = new BigNumber(bin.sent).plus(dataPoint.sent).toFixed();
+                        bin.received = new BigNumber(bin.received)
+                            .plus(dataPoint.received)
+                            .toFixed();
+                    }
+                }
+            });
+        }
+    }
+
+    // convert bins from an object indexed by timestamp to an array of bins
+    const aggregatedData = Object.keys(groupedByTimestamp)
+        .map(timestamp => groupedByTimestamp[timestamp])
+        .sort((a, b) => Number(a.time) - Number(b.time)); // sort from older to newer;;
+    return aggregatedData;
+};

--- a/packages/suite/src/views/dashboard/components/PortfolioCard/components/DashboardGraph.tsx
+++ b/packages/suite/src/views/dashboard/components/PortfolioCard/components/DashboardGraph.tsx
@@ -11,8 +11,8 @@ import { TransactionsGraph, Translation, HiddenPlaceholder } from 'src/component
 
 import { variables, Button } from '@trezor/components';
 import { calcTicks, calcTicksFromData } from '@suite-common/suite-utils';
-import { AggregatedDashboardHistory } from '../../../../../types/wallet/graph';
-import { getMinMaxValueFromData } from '../../../../../utils/wallet/graphUtils';
+import { AggregatedDashboardHistory } from 'src/types/wallet/graph';
+import { getMinMaxValueFromData } from 'src/utils/wallet/graph';
 
 const Wrapper = styled.div`
     display: flex;

--- a/packages/suite/src/views/dashboard/components/PortfolioCard/components/Header.tsx
+++ b/packages/suite/src/views/dashboard/components/PortfolioCard/components/Header.tsx
@@ -8,7 +8,7 @@ import { useFastAccounts } from 'src/hooks/wallet';
 
 import { useFormatters } from '@suite-common/formatters';
 import { H2, Button, LoadingContent } from '@trezor/components';
-import { GraphRange } from '../../../../../types/wallet/graph';
+import { GraphRange } from 'src/types/wallet/graph';
 
 const Wrapper = styled.div<{ hideBorder: boolean }>`
     display: flex;

--- a/packages/suite/src/views/wallet/transactions/components/SummaryCards.tsx
+++ b/packages/suite/src/views/wallet/transactions/components/SummaryCards.tsx
@@ -10,7 +10,7 @@ import { variables } from '@trezor/components';
 
 import { InfoCard } from './InfoCard';
 import { AggregatedAccountHistory, GraphRange } from 'src/types/wallet/graph';
-import { sumFiatValueMap } from 'src/utils/wallet/graphUtils';
+import { sumFiatValueMap } from 'src/utils/wallet/graph';
 
 const InfoCardsWrapper = styled.div`
     display: grid;

--- a/packages/suite/src/views/wallet/transactions/components/TransactionSummary.tsx
+++ b/packages/suite/src/views/wallet/transactions/components/TransactionSummary.tsx
@@ -13,10 +13,7 @@ import { variables, Button, Card } from '@trezor/components';
 
 import { TransactionSummaryDropdown } from './TransactionSummaryDropdown';
 import { SummaryCards } from './SummaryCards';
-import {
-    aggregateBalanceHistory,
-    getMinMaxValueFromData,
-} from '../../../../utils/wallet/graphUtils';
+import { aggregateBalanceHistory, getMinMaxValueFromData } from 'src/utils/wallet/graph';
 
 const Wrapper = styled.div`
     display: flex;


### PR DESCRIPTION
## Description

- This PR addresses the `register` error observed in the development (localhost) console on the dashboard.
- The issue arose due to the addition of `@trezor/connect` into `@suite-common/wallet-config`. 
- The problem stems from `@trezor/connect` being bundled into the worker, which is problematic in itself. Although this issue should not break the app, it did so because:
  - Webpack added HMR code to one of the `@trezor/connect` files (`constants/errors`) - `__webpack_require__.$Refresh$.register(_c, "TypedError");`.
  - This addition is due to `...(isDev ? ['react-refresh/babel'] : []),` in `base.webpack.config.ts`.
  - If the `constants/errors` file of `@trezor/connect` is excluded in the rules, everything functions properly, because the HMR line was added just to one file in case of worker bundle.
  `exclude: [/node_modules/, /connect\/lib\/constants\/errors/]`
  - While a solution could involve separating webpack for the app and workers, we prefer not to maintain another config.
  - Connect is not required in the graph worker, but it was imported due to probably incorrect tree shaking.

I've resolved this by splitting the graph utils into multiple files. I'm aware that we generally avoid using index files, but in this case, I believe it makes sense to do so because of the possibility to add comments.

The graph logic was moved into a worker via this issue: https://github.com/trezor/trezor-suite/issues/1613. It's unclear whether it would still cause the app to freeze currently. 🤷‍♂️
By the way, there's an interesting screenshot of `Suite 0.0`, worth checking out. 

## Request for Ideas

- If you have any ideas on how to modify `webpack` to work even without splitting files, please share.

## Related Issue

Slack Discussion: https://satoshilabs.slack.com/archives/G019WLX2P7B/p1690821148119369

## Screenshots:

**Now:**

![Screenshot 2023-08-01 at 19 39 16](https://github.com/trezor/trezor-suite/assets/33235762/9896a527-0591-4749-8b1e-78f11bd98e6f)

**Before**:
![Screenshot 2023-08-01 at 19 58 37](https://github.com/trezor/trezor-suite/assets/33235762/5abdcebc-864b-47fa-950a-0fe38e74374c)
![Screenshot 2023-08-01 at 19 58 45](https://github.com/trezor/trezor-suite/assets/33235762/f9646b82-cb9c-47c4-bcd7-a888d4334e98)


`connect` is bundled into worker and, for some reason, HMR is included. To be able to see this error like this, you have to change `devtool: 'eval-source-map'` in `dev.webpack.config.ts` to `devtool: false`


![Screenshot 2023-08-01 at 20 00 39](https://github.com/trezor/trezor-suite/assets/33235762/b84abb24-a977-4466-b136-6deb6b5bbaa8)
