### PR TITLE
fix(suite-desktop): enable to pass apple team Id to notarization

### DIFF
--- a/packages/suite-desktop-core/scripts/notarize.ts
+++ b/packages/suite-desktop-core/scripts/notarize.ts
@@ -11,7 +11,7 @@ exports.default = context => {
         return;
     }
 
-    if (!process.env.APPLEID || !process.env.APPLEIDPASS) {
+    if (!process.env.APPLEID || !process.env.APPLEIDPASS || !process.env.APPLETEAMID) {
         return;
     }
 
@@ -26,5 +26,6 @@ exports.default = context => {
         appPath,
         appleId: process.env.APPLEID,
         appleIdPassword: process.env.APPLEIDPASS,
+        teamId: process.env.APPLETEAMID,
     });
 };


### PR DESCRIPTION

<!--- Provide a general summary of your changes in the Title above -->

## Description

- Required for new notarytool
described here: https://github.com/electron/notarize#method-notarizeopts-promisevoid

## Related Issue

Fix of https://github.com/trezor/trezor-suite/issues/8692

