### PR TITLE
fix(suite): prevent from immediate stop coinjoin when session is in critical phase

### DIFF
--- a/packages/suite/src/actions/wallet/coinjoinAccountActions.ts
+++ b/packages/suite/src/actions/wallet/coinjoinAccountActions.ts
@@ -166,7 +166,7 @@ const coinjoinSessionStarting = (accountKey: string, isStarting: boolean) =>
         },
     } as const);
 
-const coinjoinSessionAutostop = (accountKey: string, isAutostopped: boolean) =>
+export const coinjoinSessionAutostop = (accountKey: string, isAutostopped: boolean) =>
     ({
         type: COINJOIN.SESSION_AUTOSTOP,
         payload: {

--- a/packages/suite/src/components/wallet/CoinjoinSummary/CoinjoinStatusWheel/ProgressContent.tsx
+++ b/packages/suite/src/components/wallet/CoinjoinSummary/CoinjoinStatusWheel/ProgressContent.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import styled, { css } from 'styled-components';
-import { FluidSpinner, Icon, useTheme, variables } from '@trezor/components';
+import { FluidSpinner, Icon, Tooltip, useTheme, variables } from '@trezor/components';
 import { Translation } from 'src/components/suite/Translation';
 import { CountdownTimer } from 'src/components/suite/CountdownTimer';
 import { useSelector } from 'src/hooks/suite/useSelector';
@@ -46,6 +46,12 @@ const StyledLoader = styled(FluidSpinner)`
     opacity: 0.4;
 `;
 
+const TooltipChildren = styled.div`
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+`;
+
 const TimeLeft = styled.p`
     max-width: 80%;
     color: ${({ theme }) => theme.TYPE_DARK_GREY};
@@ -72,9 +78,15 @@ interface ProgressContentProps {
 }
 
 export const ProgressContent = ({ accountKey, isWheelHovered }: ProgressContentProps) => {
-    const { isSessionActive, isLoading, isPaused, isAllPrivate, isAccountEmpty } = useSelector(
-        selectCurrentCoinjoinWheelStates,
-    );
+    const {
+        isSessionActive,
+        isLoading,
+        isPaused,
+        isAutoStopEnabled,
+        isCriticalPhase,
+        isAllPrivate,
+        isAccountEmpty,
+    } = useSelector(selectCurrentCoinjoinWheelStates);
     const { sessionDeadline } = useSelector(selectCurrentSessionDeadlineInfo);
     const roundsDurationInHours = useSelector(selectRoundsDurationInHours);
 
@@ -122,7 +134,40 @@ export const ProgressContent = ({ accountKey, isWheelHovered }: ProgressContentP
             );
         }
 
+        if (isAutoStopEnabled) {
+            if (isWheelHovered) {
+                return (
+                    <>
+                        <StyledIcon icon="PLAY" {...iconConfig} />
+                        <Translation id="TR_RESUME" />
+                    </>
+                );
+            }
+            return (
+                <>
+                    <StyledIcon icon="STOP" {...iconConfig} />
+                    <Translation id="TR_STOPPING" />
+                </>
+            );
+        }
+
         if (isRunningAndHovered) {
+            if (isCriticalPhase) {
+                return (
+                    <Tooltip
+                        interactive={false}
+                        maxWidth={160}
+                        offset={40}
+                        cursor="pointer"
+                        content={<Translation id="TR_AUTO_STOP_TOOLTIP" />}
+                    >
+                        <TooltipChildren>
+                            <StyledIcon icon="STOP" {...iconConfig} />
+                            <Translation id="TR_STOP" />
+                        </TooltipChildren>
+                    </Tooltip>
+                );
+            }
             return (
                 <>
                     <StyledIcon icon="STOP" {...iconConfig} />

--- a/packages/suite/src/components/wallet/CoinjoinSummary/CoinjoinStatusWheel/ProgressWheel.tsx
+++ b/packages/suite/src/components/wallet/CoinjoinSummary/CoinjoinStatusWheel/ProgressWheel.tsx
@@ -15,7 +15,10 @@ import { goto } from 'src/actions/suite/routerActions';
 import { Translation } from 'src/components/suite/Translation';
 import { openModal } from 'src/actions/suite/modalActions';
 import { stopCoinjoinSession } from 'src/actions/wallet/coinjoinClientActions';
-import { startCoinjoinSession } from 'src/actions/wallet/coinjoinAccountActions';
+import {
+    startCoinjoinSession,
+    coinjoinSessionAutostop,
+} from 'src/actions/wallet/coinjoinAccountActions';
 
 const getOutlineSvg = (theme: DefaultTheme) =>
     `url("data:image/svg+xml,%3csvg width='100%25' height='100%25' xmlns='http://www.w3.org/2000/svg'%3e%3crect width='100%25' height='100%25' fill='none' rx='100' ry='100' stroke='${theme.TYPE_LIGHT_GREY.replace(
@@ -146,6 +149,8 @@ export const ProgressWheel = ({ accountKey }: ProgressWheelProps) => {
         isSessionActive,
         isPaused,
         isLoading,
+        isAutoStopEnabled,
+        isCriticalPhase,
         isAllPrivate,
         isAccountEmpty,
         isResumeBlockedByLastingIssue,
@@ -172,7 +177,11 @@ export const ProgressWheel = ({ accountKey }: ProgressWheelProps) => {
         }
 
         if (isSessionActive) {
-            dispatch(stopCoinjoinSession(accountKey));
+            if (isCriticalPhase) {
+                dispatch(coinjoinSessionAutostop(accountKey, !isAutoStopEnabled));
+            } else if (!isAutoStopEnabled) {
+                dispatch(stopCoinjoinSession(accountKey));
+            }
 
             return;
         }
@@ -195,6 +204,8 @@ export const ProgressWheel = ({ accountKey }: ProgressWheelProps) => {
         isAllPrivate,
         isAccountEmpty,
         isSessionActive,
+        isCriticalPhase,
+        isAutoStopEnabled,
         dispatch,
         accountKey,
         isCoinjoinUneco,

--- a/packages/suite/src/reducers/wallet/coinjoinReducer.ts
+++ b/packages/suite/src/reducers/wallet/coinjoinReducer.ts
@@ -730,10 +730,12 @@ export const selectIsCoinjoinBlockedByTor = (state: CoinjoinRootState) => {
     return !isTorEnabled;
 };
 
+const isRoundPhaseCritical = (roundPhase?: number) => (roundPhase ?? 0) > 0;
+
 export const selectIsAnySessionInCriticalPhase = (state: CoinjoinRootState) => {
     const coinjoinAccounts = selectCoinjoinAccounts(state);
 
-    return coinjoinAccounts.some(acc => (acc.session?.roundPhase ?? 0) > 0);
+    return coinjoinAccounts.some(acc => isRoundPhaseCritical(acc.session?.roundPhase));
 };
 
 export const selectIsAccountWithSessionInCriticalPhaseByAccountKey = (
@@ -741,7 +743,7 @@ export const selectIsAccountWithSessionInCriticalPhaseByAccountKey = (
     accountKey: AccountKey,
 ) => {
     const coinjoinAccount = selectCoinjoinAccountByKey(state, accountKey);
-    return (coinjoinAccount?.session?.roundPhase ?? 0) > 0;
+    return isRoundPhaseCritical(coinjoinAccount?.session?.roundPhase);
 };
 
 export const selectIsAccountWithSessionByAccountKey = (
@@ -946,6 +948,8 @@ export const selectCurrentCoinjoinWheelStates = (state: CoinjoinRootState) => {
     const isSessionActive = !!coinjoinAccount?.session;
     const isPaused = !!paused;
     const isLoading = coinjoinSessionBlocker === 'SESSION_STARTING';
+    const isAutoStopEnabled = coinjoinAccount?.session?.isAutoStopEnabled;
+    const isCriticalPhase = isRoundPhaseCritical(coinjoinAccount?.session?.roundPhase);
 
     // account states
     const isAccountEmpty = !balance || balance === '0';
@@ -972,6 +976,8 @@ export const selectCurrentCoinjoinWheelStates = (state: CoinjoinRootState) => {
         isSessionActive,
         isPaused,
         isLoading,
+        isAutoStopEnabled,
+        isCriticalPhase,
         isAccountEmpty,
         isNonePrivate,
         isAllPrivate,

--- a/packages/suite/src/support/messages.ts
+++ b/packages/suite/src/support/messages.ts
@@ -7374,6 +7374,23 @@ export default defineMessages({
         id: 'TR_STOP',
         defaultMessage: 'Stop',
     },
+    TR_AUTO_STOP_TOOLTIP: {
+        id: 'TR_AUTO_STOP_TOOLTIP',
+        defaultMessage: 'Coinjoin is in signing phase. Click to stop it after this round.',
+        description: 'Tooltip for TR_AUTO_STOP button',
+    },
+    TR_STOPPING: {
+        id: 'TR_STOPPING',
+        defaultMessage: 'Stopping',
+        description:
+            'Button in coinjoin summary. Session is not in critical phase and auto stop is enabled',
+    },
+    TR_RESUME: {
+        id: 'TR_RESUME',
+        defaultMessage: 'Resume',
+        description:
+            'Button hover in coinjoin summary. Session is not in critical phase and auto stop is enabled',
+    },
     TR_CANCEL_COINJOIN: {
         id: 'TR_CANCEL_COINJOIN',
         defaultMessage: 'Cancel coinjoin',


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

After transaction is successfully signed and "critical phase" modal is gone it **doesn't mean** that this round has ended, it only means that device will no longer be needed.
This round is still in critical phase and can be easily broken by immediate clicking on "stop" button.

Button in `CoinjoinSummary` should reflect the behavior of "auto-stop" button displayed in "critical phase" modal
- by hovering on it should display "Stop" message with additional tooltip  (screenshot 1)
- by clicking on it should display "Stopping" message (screenshot 2)
- by hovering on button is "Stopping" state it should display "Resume" message (screenshot 3)

[design in figma](https://www.figma.com/file/PrfGpe3axW0BBgf0UCzFyO/Exploring-CoinJoin?type=design&node-id=2137%3A15354&mode=design&t=djy9Rh2R0umOsHxq-1)

Button new states are also a prerequisite for https://github.com/trezor/trezor-suite/issues/8374

## Screenshots:

![Screenshot from 2023-08-02 11-45-39](https://github.com/trezor/trezor-suite/assets/3435913/e8ac8aae-9628-43e4-af52-84fee5368533)

![Screenshot from 2023-08-01 18-49-58](https://github.com/trezor/trezor-suite/assets/3435913/6c27a46d-70be-4ddb-ab49-e0637c55a3c4)


![Screenshot from 2023-08-02 09-47-02](https://github.com/trezor/trezor-suite/assets/3435913/15917f02-9bb1-4312-830b-8468a9c57fc9)

