### PR TITLE
fix(suite): migration of devices without internal model

### DIFF
--- a/packages/suite/src/storage/CHANGELOG.md
+++ b/packages/suite/src/storage/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Storage changelog
 
+## 38
+
+-   add internal model to saved devices
+
 ## 37
 
 -   remove persisted coinjoin sessions

--- a/packages/suite/src/storage/index.ts
+++ b/packages/suite/src/storage/index.ts
@@ -4,7 +4,7 @@ import { migrate } from './migrations';
 
 import type { SuiteDBSchema } from './definitions';
 
-const VERSION = 37; // don't forget to add migration and CHANGELOG when changing versions!
+const VERSION = 38; // don't forget to add migration and CHANGELOG when changing versions!
 
 /**
  *  If the object stores don't already exist then creates them.


### PR DESCRIPTION
## Description

- add migration of remembered devices
- 1:1 with `_updateFeatures`

## Related Issue

https://satoshilabs.slack.com/archives/G019WLX2P7B/p1690958737370039

