### PR TITLE
feat(suite-native): filterable accounts list

### DIFF
--- a/suite-common/wallet-core/src/accounts/accountsReducer.ts
+++ b/suite-common/wallet-core/src/accounts/accountsReducer.ts
@@ -1,11 +1,11 @@
 import { isAnyOf } from '@reduxjs/toolkit';
-import { A, pipe } from '@mobily/ts-belt';
+import { A, G, pipe } from '@mobily/ts-belt';
 import { memoize, memoizeWithArgs } from 'proxy-memoize';
 
 import { createReducerWithExtraDeps } from '@suite-common/redux-utils';
 import { enhanceHistory, isTestnet, isUtxoBased } from '@suite-common/wallet-utils';
 import { Account, AccountKey } from '@suite-common/wallet-types';
-import { NetworkSymbol } from '@suite-common/wallet-config';
+import { networks, NetworkSymbol } from '@suite-common/wallet-config';
 
 import { selectCoins, FiatRatesRootState } from '../fiat-rates/fiatRatesReducer';
 import { accountsActions } from './accountsActions';
@@ -141,14 +141,16 @@ export const selectHasAccountTransactions = (state: AccountsRootState, accountKe
     return !!account?.history.total;
 };
 
-export const selectAccountsByNetworkSymbols = memoizeWithArgs(
-    (state: AccountsRootState, networkSymbols: NetworkSymbol[]) => {
+export const selectAccountsByNetworkSymbol = memoizeWithArgs(
+    (state: AccountsRootState, networkSymbol: NetworkSymbol | null) => {
+        if (G.isNull(networkSymbol)) return [];
+
         const accounts = selectAccounts(state);
 
-        return accounts.filter(account => networkSymbols.includes(account.symbol));
+        return A.filter(accounts, account => account.symbol === networkSymbol);
     },
     {
-        size: 40,
+        size: Object.keys(networks).length,
     },
 );
 

--- a/suite-native/accounts/package.json
+++ b/suite-native/accounts/package.json
@@ -29,8 +29,12 @@
         "@trezor/styles": "workspace:*",
         "@trezor/theme": "workspace:*",
         "@trezor/validation": "workspace:*",
+        "proxy-memoize": "2.0.2",
         "react": "18.2.0",
         "react-native": "0.71.8",
         "react-redux": "8.0.7"
+    },
+    "devDependencies": {
+        "jest": "^26.6.3"
     }
 }

--- a/suite-native/accounts/src/components/AccountsList.tsx
+++ b/suite-native/accounts/src/components/AccountsList.tsx
@@ -1,28 +1,38 @@
 import React from 'react';
 import { useSelector } from 'react-redux';
 
-import { A } from '@mobily/ts-belt';
+import { D } from '@mobily/ts-belt';
 
 import { Text } from '@suite-native/atoms';
-import { selectAccounts, selectAccountsSymbols } from '@suite-common/wallet-core';
+import { AccountsRootState } from '@suite-common/wallet-core';
 import { AccountKey, TokenAddress } from '@suite-common/wallet-types';
 
 import { AccountsListGroup } from './AccountsListGroup';
+import { selectFilteredAccountsGroupedByNetwork } from '../selectors';
 
 type AccountsListProps = {
     onSelectAccount: (accountKey: AccountKey, tokenContract?: TokenAddress) => void;
+    filterValue?: string | null;
 };
 
-export const AccountsList = ({ onSelectAccount }: AccountsListProps) => {
-    const accountsSymbols = useSelector(selectAccountsSymbols);
-    const accounts = useSelector(selectAccounts);
+export const AccountsList = ({ onSelectAccount, filterValue }: AccountsListProps) => {
+    const accounts = useSelector((state: AccountsRootState) =>
+        selectFilteredAccountsGroupedByNetwork(state, filterValue),
+    );
 
-    if (A.isEmpty(accounts)) return <Text>No accounts found.</Text>;
+    // FIXME: In case the filter does not match any account, this ugly message is displayed.
+    //        Let's create a proper component for this.
+    //        See issue: https://github.com/trezor/trezor-suite/issues/9092
+    if (D.isEmpty(accounts)) return <Text>No accounts found.</Text>;
 
     return (
         <>
-            {accountsSymbols.map(symbol => (
-                <AccountsListGroup key={symbol} symbol={symbol} onSelectAccount={onSelectAccount} />
+            {Object.entries(accounts).map(([networkSymbol, networkAccounts]) => (
+                <AccountsListGroup
+                    key={networkSymbol}
+                    accounts={networkAccounts}
+                    onSelectAccount={onSelectAccount}
+                />
             ))}
         </>
     );

--- a/suite-native/accounts/src/components/AccountsListGroup.tsx
+++ b/suite-native/accounts/src/components/AccountsListGroup.tsx
@@ -1,16 +1,15 @@
-import React, { useMemo } from 'react';
-import { useSelector } from 'react-redux';
+import React from 'react';
+
+import { G } from '@mobily/ts-belt';
 
 import { Box } from '@suite-native/atoms';
 import { prepareNativeStyle, useNativeStyles } from '@trezor/styles';
-import { AccountsRootState, selectAccountsByNetworkSymbols } from '@suite-common/wallet-core';
-import { NetworkSymbol } from '@suite-common/wallet-config';
-import { AccountKey, TokenAddress } from '@suite-common/wallet-types';
+import { Account, AccountKey, TokenAddress } from '@suite-common/wallet-types';
 
 import { AccountListItemInteractive } from './AccountListItemInteractive';
 
 type AccountsListGroupProps = {
-    symbol: NetworkSymbol;
+    accounts: readonly Account[] | null;
     onSelectAccount: (accountKey: AccountKey, tokenContract?: TokenAddress) => void;
 };
 
@@ -20,13 +19,9 @@ const accountListGroupStyle = prepareNativeStyle(utils => ({
     marginBottom: utils.spacings.small,
 }));
 
-export const AccountsListGroup = ({ symbol, onSelectAccount }: AccountsListGroupProps) => {
+export const AccountsListGroup = ({ accounts, onSelectAccount }: AccountsListGroupProps) => {
     const { applyStyle } = useNativeStyles();
-    const symbols = useMemo(() => [symbol], [symbol]);
-    const accounts = useSelector((state: AccountsRootState) =>
-        // we need to memoize [symbol] array to prevent re-renders with every state change
-        selectAccountsByNetworkSymbols(state, symbols),
-    );
+    if (G.isNull(accounts)) return null;
 
     return (
         <Box style={applyStyle(accountListGroupStyle)}>

--- a/suite-native/accounts/src/selectors.ts
+++ b/suite-native/accounts/src/selectors.ts
@@ -1,0 +1,54 @@
+import { A, pipe } from '@mobily/ts-belt';
+import { memoizeWithArgs } from 'proxy-memoize';
+
+import { AccountsRootState, selectAccounts } from '@suite-common/wallet-core';
+import { Account } from '@suite-common/wallet-types';
+import { getNetwork } from '@suite-common/wallet-utils';
+
+/**
+ * Returns true if account label, network name or account included token contains filter value as a substring.
+ */
+export const isFilterValueMatchingAccount = (account: Account, filterValue: string) => {
+    const lowerCaseFilterValue = filterValue?.trim().toLowerCase();
+
+    const isMatchingLabel = account.metadata.accountLabel
+        ?.toLowerCase()
+        .includes(lowerCaseFilterValue);
+
+    if (isMatchingLabel) return true;
+
+    const accountNetwork = getNetwork(account.symbol);
+    const isMatchingNetworkName = accountNetwork?.name.toLowerCase().includes(lowerCaseFilterValue);
+
+    if (isMatchingNetworkName) return true;
+
+    const isMatchingTokenName =
+        account.tokens?.some(token => token.name?.toLowerCase().includes(lowerCaseFilterValue)) ??
+        false;
+
+    if (isMatchingTokenName) return true;
+
+    return false;
+};
+
+/**
+ * Filter accounts by labels, network names and included token names.
+ */
+const filterAccountsByLabelAndNetworkNames = (accounts: Account[], filterValue?: string | null) => {
+    if (!filterValue) return accounts;
+
+    return A.filter(accounts, account => isFilterValueMatchingAccount(account, filterValue));
+};
+
+export const selectFilteredAccountsGroupedByNetwork = memoizeWithArgs(
+    (state: AccountsRootState, filterValue?: string | null) => {
+        const accounts = selectAccounts(state);
+
+        return pipe(
+            filterAccountsByLabelAndNetworkNames(accounts, filterValue),
+            A.groupBy(account => account.symbol),
+        );
+    },
+    // This selector is used only in one search component, so cache size equal to 1 is enough.
+    { size: 1 },
+);

--- a/suite-native/accounts/src/tests/selectors.test.ts
+++ b/suite-native/accounts/src/tests/selectors.test.ts
@@ -1,0 +1,41 @@
+import { Account } from '@suite-common/wallet-types';
+
+import { isFilterValueMatchingAccount } from '../selectors';
+
+describe('isFilterValueMatchingAccountLabelOrNetworkName', () => {
+    const account = {
+        metadata: { accountLabel: 'Original account name' },
+        symbol: 'eth',
+        tokens: [{ name: 'Tether USD' }],
+    } as Account;
+
+    test('should return false if the filter value does not match the account label nor network name.', () => {
+        const filterValue = 'not match';
+
+        expect(isFilterValueMatchingAccount(account, filterValue)).toBe(false);
+    });
+
+    test('should return false if the filter value does not match the network name.', () => {
+        const filterValue = 'bitcoin';
+
+        expect(isFilterValueMatchingAccount(account, filterValue)).toBe(false);
+    });
+
+    test('should return true if filter value matches the network name', () => {
+        const filterValue = 'ethereum';
+
+        expect(isFilterValueMatchingAccount(account, filterValue)).toBe(true);
+    });
+
+    test('should return true if filter value matches the included token name', () => {
+        const filterValue = 'tether';
+
+        expect(isFilterValueMatchingAccount(account, filterValue)).toBe(true);
+    });
+
+    test('should return true if filter value does match the account label', () => {
+        const filterValue = 'Original account';
+
+        expect(isFilterValueMatchingAccount(account, filterValue)).toBe(true);
+    });
+});

--- a/suite-native/assets/package.json
+++ b/suite-native/assets/package.json
@@ -11,6 +11,7 @@
         "type-check": "tsc --build"
     },
     "dependencies": {
+        "@mobily/ts-belt": "^3.13.1",
         "@react-navigation/native": "^6.1.3",
         "@suite-common/icons": "workspace:*",
         "@suite-common/suite-config": "workspace:*",

--- a/suite-native/assets/src/components/Assets.tsx
+++ b/suite-native/assets/src/components/Assets.tsx
@@ -3,7 +3,7 @@ import { useSelector } from 'react-redux';
 
 import { useNavigation } from '@react-navigation/native';
 
-import { BottomSheet, Card, VStack } from '@suite-native/atoms';
+import { Card, VStack } from '@suite-native/atoms';
 import {
     AppTabsParamList,
     AppTabsRoutes,
@@ -12,12 +12,12 @@ import {
     TabToStackCompositeNavigationProp,
 } from '@suite-native/navigation';
 import { networks, NetworkSymbol } from '@suite-common/wallet-config';
-import { AccountsListGroup } from '@suite-native/accounts';
 import { AccountKey, TokenAddress } from '@suite-common/wallet-types';
 
 import { AssetItem } from './AssetItem';
 import { selectAssetsWithBalances } from '../assetsSelectors';
 import { calculateAssetsPercentage } from '../utils';
+import { NetworkAssetsBottomSheet } from './NetworkAssetsBottomSheet';
 
 export const Assets = () => {
     const navigation =
@@ -47,7 +47,7 @@ export const Assets = () => {
         [navigation],
     );
 
-    const handleSelectAccountClose = useCallback(() => {
+    const handleCloseBottomSheet = useCallback(() => {
         setSelectedAssetSymbol(null);
     }, []);
 
@@ -70,18 +70,11 @@ export const Assets = () => {
                     ))}
                 </VStack>
             </Card>
-            <BottomSheet
-                title="Select Account"
-                isVisible={!!selectedAssetSymbol}
-                onClose={handleSelectAccountClose}
-            >
-                {selectedAssetSymbol && (
-                    <AccountsListGroup
-                        symbol={selectedAssetSymbol}
-                        onSelectAccount={handleSelectAssetsAccount}
-                    />
-                )}
-            </BottomSheet>
+            <NetworkAssetsBottomSheet
+                networkSymbol={selectedAssetSymbol}
+                onSelectAccount={handleSelectAssetsAccount}
+                onClose={handleCloseBottomSheet}
+            />
         </>
     );
 };

--- a/suite-native/assets/src/components/NetworkAssetsBottomSheet.tsx
+++ b/suite-native/assets/src/components/NetworkAssetsBottomSheet.tsx
@@ -1,0 +1,36 @@
+import React from 'react';
+import { useSelector } from 'react-redux';
+
+import { G } from '@mobily/ts-belt';
+
+import { BottomSheet } from '@suite-native/atoms';
+import { AccountsListGroup } from '@suite-native/accounts';
+import { NetworkSymbol } from '@suite-common/wallet-config';
+import { AccountKey, TokenAddress } from '@suite-common/wallet-types';
+import { selectAccountsByNetworkSymbol } from '@suite-common/wallet-core';
+
+type NetworkAssetsBottomSheetProps = {
+    networkSymbol: NetworkSymbol | null;
+    onSelectAccount: (accountKey: AccountKey, tokenContract?: TokenAddress) => void;
+    onClose: () => void;
+};
+
+export const NetworkAssetsBottomSheet = ({
+    networkSymbol,
+    onSelectAccount,
+    onClose,
+}: NetworkAssetsBottomSheetProps) => {
+    const selectedAccounts = useSelector((state: any) =>
+        selectAccountsByNetworkSymbol(state, networkSymbol),
+    );
+
+    if (G.isNull(networkSymbol)) return null;
+
+    return (
+        <BottomSheet title="Select Account" isVisible onClose={onClose}>
+            {networkSymbol && (
+                <AccountsListGroup accounts={selectedAccounts} onSelectAccount={onSelectAccount} />
+            )}
+        </BottomSheet>
+    );
+};

--- a/suite-native/atoms/src/Input/Input.tsx
+++ b/suite-native/atoms/src/Input/Input.tsx
@@ -43,6 +43,15 @@ type InputWrapperStyleProps = {
     isLabelMinimized: boolean;
 };
 
+type InputLabelStyleProps = {
+    isLabelMinimized: boolean;
+    isIconDisplayed: boolean;
+};
+
+type InputStyleProps = {
+    isIconDisplayed: boolean;
+};
+
 const inputWrapperStyle = prepareNativeStyle<InputWrapperStyleProps>(
     (utils, { hasError, hasWarning }) => ({
         borderWidth: utils.borders.widths.small,
@@ -72,12 +81,13 @@ const inputWrapperStyle = prepareNativeStyle<InputWrapperStyleProps>(
     }),
 );
 
-const inputStyle = prepareNativeStyle(utils => ({
+const inputStyle = prepareNativeStyle<InputStyleProps>((utils, { isIconDisplayed }) => ({
     ...utils.typography.body,
     alignItems: 'center',
     justifyContent: 'center',
     height: INPUT_TEXT_HEIGHT,
     color: utils.colors.textDefault,
+    left: isIconDisplayed ? utils.spacings.large : 0,
     borderWidth: 0,
     flex: 1,
     // Make the text input uniform on both platforms (https://stackoverflow.com/a/68458803/1281305)
@@ -93,11 +103,11 @@ const inputHitSlop = {
 };
 
 const inputLabelStyle = prepareNativeStyle(
-    (utils, { isLabelMinimized }: Pick<InputWrapperStyleProps, 'isLabelMinimized'>) => ({
+    (utils, { isLabelMinimized, isIconDisplayed }: InputLabelStyleProps) => ({
         ...D.deleteKey(utils.typography.body, 'fontSize'),
         color: utils.colors.textSubdued,
         position: 'absolute',
-        left: INPUT_WRAPPER_PADDING_HORIZONTAL,
+        left: INPUT_WRAPPER_PADDING_HORIZONTAL + (isIconDisplayed ? utils.spacings.large : 0),
         extend: {
             condition: isLabelMinimized,
             style: {
@@ -107,10 +117,13 @@ const inputLabelStyle = prepareNativeStyle(
     }),
 );
 
-const leftIconStyle = prepareNativeStyle(() => ({
+const leftIconStyle = prepareNativeStyle(utils => ({
+    position: 'absolute',
     justifyContent: 'center',
     alignItems: 'center',
     marginRight: 3,
+    top: 15,
+    left: utils.spacings.small,
 }));
 
 const useInputLabelAnimationStyles = ({
@@ -169,6 +182,7 @@ export const Input = React.forwardRef<TextInput, InputProps>(
     ) => {
         const [isFocused, setIsFocused] = useState<boolean>(false);
         const isLabelMinimized = isFocused || !!value?.length;
+        const isIconDisplayed = !!leftIcon;
 
         const { applyStyle } = useNativeStyles();
         const { animatedInputLabelStyle } = useInputLabelAnimationStyles({
@@ -193,6 +207,7 @@ export const Input = React.forwardRef<TextInput, InputProps>(
                     isLabelMinimized,
                 })}
             >
+                {leftIcon && <Box style={applyStyle(leftIconStyle)}>{leftIcon}</Box>}
                 <Animated.Text
                     style={[
                         /*
@@ -201,17 +216,16 @@ export const Input = React.forwardRef<TextInput, InputProps>(
                             in both places (native and animated style).
                             */
                         animatedInputLabelStyle,
-                        applyStyle(inputLabelStyle, { isLabelMinimized }),
+                        applyStyle(inputLabelStyle, { isLabelMinimized, isIconDisplayed }),
                     ]}
                     numberOfLines={1}
                 >
                     {label}
                 </Animated.Text>
                 <Box flexDirection="row" alignItems="center">
-                    {leftIcon && <Box style={applyStyle(leftIconStyle)}>{leftIcon}</Box>}
                     <TextInput
                         ref={ref}
-                        style={applyStyle(inputStyle)}
+                        style={applyStyle(inputStyle, { isIconDisplayed })}
                         onFocus={handleOnFocus}
                         onBlur={handleOnBlur}
                         hitSlop={inputHitSlop}

--- a/suite-native/module-accounts-import/src/components/XpubHint.tsx
+++ b/suite-native/module-accounts-import/src/components/XpubHint.tsx
@@ -31,7 +31,8 @@ export const XpubHint = ({ networkType, handleOpen }: XpubScanHintSheet) => {
 
     return (
         <KeyboardAvoidingView behavior={Platform.OS === 'ios' ? 'padding' : 'height'}>
-            {/*  TODO : Replace with a TextButton atom component when ready. */}
+            {/*  TODO : Replace with a TextButton atom component when ready.
+                 issue: https://github.com/trezor/trezor-suite/issues/9084 */}
             <TouchableOpacity onPress={handleOpen} style={applyStyle(sheetTriggerStyle)}>
                 <Box marginRight="small">
                     <Icon name="question" size="medium" color="iconPrimaryDefault" />

--- a/suite-native/module-accounts/src/components/AccountsScreenHeader.tsx
+++ b/suite-native/module-accounts/src/components/AccountsScreenHeader.tsx
@@ -1,4 +1,11 @@
-import React from 'react';
+import React, { useState } from 'react';
+import Animated, {
+    EntryExitAnimationFunction,
+    FadeOut,
+    useSharedValue,
+    withDelay,
+    withTiming,
+} from 'react-native-reanimated';
 
 import { useNavigation } from '@react-navigation/native';
 
@@ -12,6 +19,17 @@ import {
     TabToStackCompositeNavigationProp,
 } from '@suite-native/navigation';
 import { IconButton } from '@suite-native/atoms';
+import { prepareNativeStyle, useNativeStyles } from '@trezor/styles';
+
+import {
+    AccountsSearchForm,
+    SEARCH_FORM_HEIGHT,
+    SEARCH_INPUT_ANIMATION_DURATION,
+} from './AccountsSearchForm';
+
+type AccountsScreenHeaderProps = {
+    onSearchInputChange: (value: string) => void;
+};
 
 type NavigationProp = TabToStackCompositeNavigationProp<
     AppTabsParamList,
@@ -19,8 +37,20 @@ type NavigationProp = TabToStackCompositeNavigationProp<
     RootStackParamList
 >;
 
-export const AccountsScreenHeader = () => {
+const headerContainerStyle = prepareNativeStyle(() => ({
+    // The height of this container has to be same as the height of the AccountsSearchForm to prevent
+    // the AccountsList from jumping when the header content is switched to the search form and vice versa.
+    height: SEARCH_FORM_HEIGHT,
+}));
+
+const HEADER_ANIMATION_DURATION = 100;
+
+export const AccountsScreenHeader = ({ onSearchInputChange }: AccountsScreenHeaderProps) => {
     const navigation = useNavigation<NavigationProp>();
+    const { applyStyle } = useNativeStyles();
+    const isFirstRender = useSharedValue(true);
+
+    const [isSearchActive, setIsSearchActive] = useState(false);
 
     const handleImportAsset = () => {
         navigation.navigate(RootStackRoutes.AccountsImport, {
@@ -28,17 +58,60 @@ export const AccountsScreenHeader = () => {
         });
     };
 
-    return (
-        <ScreenHeader
-            content="My assets"
-            leftIcon={
-                <IconButton
-                    iconName="plus"
-                    onPress={handleImportAsset}
-                    colorScheme="tertiaryElevation0"
-                    size="medium"
-                />
-            }
-        />
+    const handleHideFilter = () => {
+        setIsSearchActive(false);
+        onSearchInputChange('');
+    };
+
+    const enteringFadeInAnimation: EntryExitAnimationFunction = () => {
+        'worklet';
+
+        // This fade in animation is not triggered on the first render of AccountsScreenHeader. Triggered only on
+        // subsequent renders while the user is switching between the header and AccountsSearchForm.
+        const initialValues = {
+            opacity: isFirstRender.value ? 1 : 0,
+        };
+        isFirstRender.value = false;
+
+        return {
+            initialValues,
+            animations: {
+                opacity: withDelay(
+                    // Delayed to start right after the AccountsSearchForm exit animation finishes.
+                    SEARCH_INPUT_ANIMATION_DURATION,
+                    withTiming(1, { duration: HEADER_ANIMATION_DURATION }),
+                ),
+            },
+        };
+    };
+
+    return isSearchActive ? (
+        <AccountsSearchForm onPressCancel={handleHideFilter} onInputChange={onSearchInputChange} />
+    ) : (
+        <Animated.View
+            entering={enteringFadeInAnimation}
+            exiting={FadeOut.duration(HEADER_ANIMATION_DURATION)}
+            style={applyStyle(headerContainerStyle)}
+        >
+            <ScreenHeader
+                content="My assets"
+                leftIcon={
+                    <IconButton
+                        iconName="search"
+                        onPress={() => setIsSearchActive(true)}
+                        colorScheme="tertiaryElevation0"
+                        size="medium"
+                    />
+                }
+                rightIcon={
+                    <IconButton
+                        iconName="plus"
+                        onPress={handleImportAsset}
+                        colorScheme="tertiaryElevation0"
+                        size="medium"
+                    />
+                }
+            />
+        </Animated.View>
     );
 };

--- a/suite-native/module-accounts/src/components/AccountsSearchForm.tsx
+++ b/suite-native/module-accounts/src/components/AccountsSearchForm.tsx
@@ -1,0 +1,106 @@
+import React, { useEffect } from 'react';
+import Animated, { FadeIn, FadeOut, SlideInLeft, SlideOutLeft } from 'react-native-reanimated';
+import { useWatch } from 'react-hook-form';
+import { TouchableOpacity } from 'react-native';
+
+import { Icon } from '@suite-common/icons';
+import { Form, TextInputField, useForm } from '@suite-native/forms';
+import { prepareNativeStyle, useNativeStyles } from '@trezor/styles';
+import { yup } from '@trezor/validation';
+import { Box, HStack, Text } from '@suite-native/atoms';
+
+type AccountsSearchFormProps = {
+    onPressCancel: () => void;
+    onInputChange: (value: string) => void;
+};
+
+export const SEARCH_FORM_HEIGHT = 58;
+export const SEARCH_INPUT_ANIMATION_DURATION = 100;
+export const SEARCH_INPUT_ANIMATION_DELAY = 100;
+const MAX_SEARCH_VALUE_LENGTH = 30;
+const KEYBOARD_INACTIVITY_TIMEOUT = 200;
+
+const searchFormContainerStyle = prepareNativeStyle(() => ({
+    height: SEARCH_FORM_HEIGHT,
+}));
+
+const searchFormInputStyle = prepareNativeStyle(() => ({
+    flex: 1,
+}));
+
+const cancelButtonStyle = prepareNativeStyle(() => ({
+    justifyContent: 'center',
+    alignItems: 'center',
+}));
+
+const accountSearchFormValidationSchema = yup.object({
+    searchValue: yup.string().max(MAX_SEARCH_VALUE_LENGTH),
+});
+
+type AccountSearchFormValues = yup.InferType<typeof accountSearchFormValidationSchema>;
+
+const useAccountsSearchForm = () =>
+    useForm<AccountSearchFormValues>({
+        validation: accountSearchFormValidationSchema,
+        reValidateMode: 'onChange',
+    });
+
+export const AccountsSearchForm = ({ onPressCancel, onInputChange }: AccountsSearchFormProps) => {
+    const { applyStyle } = useNativeStyles();
+
+    const form = useAccountsSearchForm();
+    const { searchValue } = useWatch({ control: form.control });
+
+    // Change input value after short time of inactivity to prevent unnecessary re-renders while the user types.
+    useEffect(() => {
+        const timeoutId = setTimeout(() => {
+            onInputChange(searchValue ?? '');
+        }, KEYBOARD_INACTIVITY_TIMEOUT);
+
+        return () => {
+            clearTimeout(timeoutId);
+        };
+    }, [searchValue, onInputChange]);
+
+    return (
+        <Animated.View
+            entering={FadeIn.duration(SEARCH_INPUT_ANIMATION_DURATION).delay(
+                SEARCH_INPUT_ANIMATION_DELAY,
+            )}
+            exiting={FadeOut.duration(SEARCH_INPUT_ANIMATION_DURATION)}
+            style={applyStyle(searchFormContainerStyle)}
+        >
+            <Box marginHorizontal="medium">
+                <Form form={form}>
+                    <HStack spacing="medium" justifyContent="space-between">
+                        <Animated.View
+                            entering={SlideInLeft.duration(SEARCH_INPUT_ANIMATION_DURATION).delay(
+                                SEARCH_INPUT_ANIMATION_DELAY,
+                            )}
+                            exiting={SlideOutLeft.duration(SEARCH_INPUT_ANIMATION_DURATION)}
+                            style={applyStyle(searchFormInputStyle)}
+                        >
+                            <TextInputField
+                                leftIcon={
+                                    <Icon name="search" color="iconOnTertiary" size="large" />
+                                }
+                                name="searchValue"
+                                label="Search assets"
+                                maxLength={MAX_SEARCH_VALUE_LENGTH}
+                            />
+                        </Animated.View>
+
+                        {/*  TODO : Replace with a TextButton atom component when the design is ready.
+                                 issue: https://github.com/trezor/trezor-suite/issues/9084 */}
+                        <TouchableOpacity
+                            onPress={onPressCancel}
+                            style={applyStyle(cancelButtonStyle)}
+                        >
+                            <Text color="textPrimaryDefault">Cancel</Text>
+                        </TouchableOpacity>
+                    </HStack>
+                </Form>
+            </Box>
+        </Animated.View>
+    );
+};

--- a/suite-native/module-accounts/src/screens/AccountsScreen.tsx
+++ b/suite-native/module-accounts/src/screens/AccountsScreen.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useState } from 'react';
 
 import { useNavigation } from '@react-navigation/native';
 
@@ -17,6 +17,8 @@ export const AccountsScreen = () => {
     const navigation =
         useNavigation<StackNavigationProps<RootStackParamList, RootStackRoutes.AccountDetail>>();
 
+    const [accountsFilterValue, setAccountsFilterValue] = useState<string>('');
+
     const handleSelectAccount = (accountKey: AccountKey, tokenContract?: TokenAddress) => {
         navigation.navigate(RootStackRoutes.AccountDetail, {
             accountKey,
@@ -24,9 +26,13 @@ export const AccountsScreen = () => {
         });
     };
 
+    const handleFilterChange = (value: string) => {
+        setAccountsFilterValue(value);
+    };
+
     return (
-        <Screen header={<AccountsScreenHeader />}>
-            <AccountsList onSelectAccount={handleSelectAccount} />
+        <Screen header={<AccountsScreenHeader onSearchInputChange={handleFilterChange} />}>
+            <AccountsList onSelectAccount={handleSelectAccount} filterValue={accountsFilterValue} />
         </Screen>
     );
 };

--- a/suite-native/navigation/src/components/ScreenHeader.tsx
+++ b/suite-native/navigation/src/components/ScreenHeader.tsx
@@ -27,7 +27,7 @@ const screenHeaderStyle = prepareNativeStyle(utils => ({
     alignItems: 'center',
     justifyContent: 'space-between',
     height: ICON_SIZE,
-    marginHorizontal: utils.spacings.small,
+    marginHorizontal: utils.spacings.medium,
 }));
 
 const iconWrapperStyle = prepareNativeStyle(() => ({

--- a/suite-native/receive/src/components/ReceiveTextHint.tsx
+++ b/suite-native/receive/src/components/ReceiveTextHint.tsx
@@ -41,6 +41,8 @@ export const ReceiveTextHint = ({ onShowAddress }: ReceiveTextHintProps) => {
                 </Box>
             </Card>
 
+            {/*  TODO : Replace with a TextButton atom component when ready.
+                 issue: https://github.com/trezor/trezor-suite/issues/9084 */}
             <TouchableOpacity
                 onPress={() =>
                     openLink('https://trezor.io/learn/a/verifying-trezor-suite-lite-addresses')

--- a/yarn.lock
+++ b/yarn.lock
@@ -6818,6 +6818,8 @@ __metadata:
     "@trezor/styles": "workspace:*"
     "@trezor/theme": "workspace:*"
     "@trezor/validation": "workspace:*"
+    jest: ^26.6.3
+    proxy-memoize: 2.0.2
     react: 18.2.0
     react-native: 0.71.8
     react-redux: 8.0.7
@@ -6858,6 +6860,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@suite-native/assets@workspace:suite-native/assets"
   dependencies:
+    "@mobily/ts-belt": ^3.13.1
     "@react-navigation/native": ^6.1.3
     "@suite-common/icons": "workspace:*"
     "@suite-common/suite-config": "workspace:*"


### PR DESCRIPTION
The accounts list is filterable by the string value. If value matches substring of account label, network name or included token name, account is displayed in the list.

Closes #6988

## Screenshots:

https://github.com/trezor/trezor-suite/assets/26143964/66ec0a59-227d-432e-bcb5-6179b76dc219

