### PR TITLE
chore(sentry): bump default value for max value length to see the whole errors

### DIFF
--- a/suite-common/sentry/src/index.ts
+++ b/suite-common/sentry/src/index.ts
@@ -64,9 +64,9 @@ const beforeBreadcrumb: Options['beforeBreadcrumb'] = breadcrumb => {
     // filter out analytics requests and image fetches
     const isAnalytics =
         breadcrumb.category === 'fetch' &&
-        breadcrumb.data?.url?.contains('data.trezor.io/suite/log');
+        breadcrumb.data?.url?.contains?.('data.trezor.io/suite/log');
     const isImageFetch =
-        breadcrumb.category === 'xhr' && breadcrumb.data?.url?.contains('/assets/');
+        breadcrumb.category === 'xhr' && breadcrumb.data?.url?.contains?.('/assets/');
     const isConsole = breadcrumb.category === 'console';
 
     if (isAnalytics || isImageFetch || isConsole) {
@@ -98,6 +98,7 @@ export const SENTRY_CONFIG: Options = {
     ],
     beforeSend,
     enabled: !isDevEnv,
+    maxValueLength: 500, // default 250 is not enough for some errors
     release: process.env.SENTRY_RELEASE,
     environment: process.env.SUITE_TYPE,
     normalizeDepth: 4,


### PR DESCRIPTION


<!--- Provide a general summary of your changes in the Title above -->

## Description

- Some of the coinjoin errors are cut off just before the important info.
- breadcrumb cointains not always defined on localhost
- 


## Screenshots:
![image](https://github.com/trezor/trezor-suite/assets/3729633/580dc913-1c9e-4e16-85d8-6d18b7ec1f7c)

