### PR TITLE
Use `.onion` addresses for CJ discovery with fallback to clearnet

### DIFF
--- a/packages/coinjoin/src/backend/CoinjoinWebsocketController.ts
+++ b/packages/coinjoin/src/backend/CoinjoinWebsocketController.ts
@@ -48,6 +48,7 @@ export class CoinjoinWebsocketController {
                 timeout,
                 url,
                 headers: { 'Proxy-Authorization': `Basic ${identity}` },
+                onSending: this.logMessages(socketId),
             });
             this.sockets[socketId] = socket;
         }
@@ -70,7 +71,14 @@ export class CoinjoinWebsocketController {
         return socket;
     }
 
-    getSocketId(url: string, identity = this.defaultIdentity): SocketId {
+    private logMessages(
+        socketId: string,
+    ): ConstructorParameters<typeof BlockbookAPI>[0]['onSending'] {
+        return ({ method, params }) =>
+            this.logger?.debug(`WS ${method} ${JSON.stringify(params)} ${socketId}`);
+    }
+
+    private getSocketId(url: string, identity = this.defaultIdentity): SocketId {
         return `${identity}@${url}`;
     }
 }

--- a/packages/coinjoin/src/backend/backendUtils.ts
+++ b/packages/coinjoin/src/backend/backendUtils.ts
@@ -51,8 +51,18 @@ export const deriveAddresses = (
     return prederived.slice(fromPrederived, fromPrederived + countPrederived).concat(derived);
 };
 
-// https://github.com/websockets/ws/blob/0b235e0f9b650b1bdcbdb974cbeaaaa6a0797855/lib/websocket.js#L891
-export const isWsError403 = (error: Error) => error?.message === 'Unexpected server response: 403';
+export const identifyWsError = (error: Error) => {
+    switch (error?.message) {
+        // https://github.com/websockets/ws/blob/0b235e0f9b650b1bdcbdb974cbeaaaa6a0797855/lib/websocket.js#L891
+        case 'Unexpected server response: 403':
+            return 'ERROR_FORBIDDEN';
+        // file://./../../../blockchain-link-types/src/constants/errors.ts
+        case 'Websocket timeout':
+            return 'ERROR_TIMEOUT';
+        default:
+            return 'ERROR_OTHER';
+    }
+};
 
 // Randomize identity password to reset TOR circuit for this identity
 export const resetIdentityCircuit = (identity: string) => {

--- a/packages/coinjoin/src/constants.ts
+++ b/packages/coinjoin/src/constants.ts
@@ -31,6 +31,9 @@ export const ROUND_SELECTION_REGISTRATION_OFFSET = 30000;
 // max output count
 export const ROUND_SELECTION_MAX_OUTPUTS = 20;
 
+// custom timeout for websocket opening
+export const WS_CONNECT_TIMEOUT = 15000;
+
 // custom timeout for http requests (default is 50000 ms)
 export const HTTP_REQUEST_TIMEOUT = 35000;
 

--- a/packages/coinjoin/src/types/index.ts
+++ b/packages/coinjoin/src/types/index.ts
@@ -3,6 +3,7 @@ import { CoinjoinPrisonInmate } from './client';
 interface BaseSettings {
     network: 'btc' | 'test' | 'regtest';
     wabisabiBackendUrl: string;
+    onionDomains?: { [clearnet: string]: string };
 }
 
 export interface CoinjoinBackendSettings extends BaseSettings {

--- a/packages/coinjoin/tests/backend/CoinjoinBackendClient.test.ts
+++ b/packages/coinjoin/tests/backend/CoinjoinBackendClient.test.ts
@@ -1,15 +1,9 @@
+import * as http from '../../src/utils/http';
 import { CoinjoinBackendClient } from '../../src/backend/CoinjoinBackendClient';
 import { COINJOIN_BACKEND_SETTINGS } from '../fixtures/config.fixture';
 
-const ZERO_HASH = '0f9188f13cb7b2c71f2a335e3a4fc328bf5beb436012afca590b1a11466e2206';
-const TIP_HASH = '66a8baf3fe7e759f4682a2c9780efcbb78a9bd938c95d0114737b3fcef709b82';
-const NONEXISTENT_HASH = 'deadbeef3cb7b2c71f2a335e3a4fc328bf5beb436012afca590b1a11466e2206';
-const MALFORMED_HASH = 'deadbeef';
-
-const VALID_TX = 'd20a1e1f3b98f82dc7aa0fa0538b75be357ab53f2d1c6f68c0be4e7537122f5d';
-const INVALID_TX = 'deadbeef';
-
 const BLOCKBOOKS = ['bb_A', 'bb_B', 'bb_C', 'bb_D', 'bb_E', 'bb_F', 'bb_G'];
+const WS_ERROR_403 = 'Unexpected server response: 403';
 
 describe('CoinjoinBackendClient', () => {
     let client: CoinjoinBackendClient;
@@ -21,15 +15,12 @@ describe('CoinjoinBackendClient', () => {
         });
     });
 
-    it.only('blockbook backends rotation', async () => {
+    it('Blockbook backends rotation', async () => {
         let lastBackend = '';
-        (client as any).websockets = {
-            getOrCreate: ({ url }: { url: string }) => {
-                [lastBackend] = (url as string).split('/');
-                return new Proxy({}, { get: (_, b, c) => b !== 'then' && (() => c) });
-            },
-            getSocketId: () => undefined,
-        };
+        jest.spyOn((client as any).websockets, 'getOrCreate').mockImplementation(args => {
+            [lastBackend] = (args as any).url.split('/');
+            return new Proxy({}, { get: (_, b, c) => b !== 'then' && (() => c) });
+        });
 
         const shuffledBackends = (client as any).blockbookUrls as string[];
         expect(shuffledBackends.slice().sort()).toEqual(BLOCKBOOKS.slice().sort());
@@ -47,50 +38,63 @@ describe('CoinjoinBackendClient', () => {
         }
     });
 
-    it('fetchFilters success', async () => {
-        const response = await client.fetchFilters(ZERO_HASH, 10);
-        expect(response.status).toBe('ok');
-        expect((response as any).filters.length).toBe(10);
+    it('Blockbook switch identities on 403', async () => {
+        const identities: string[] = [];
+        jest.spyOn((client as any).websockets, 'getOrCreate').mockImplementation(args => {
+            const { identity } = args as any;
+            identities.push(identity);
+            return Promise.reject(new Error(identity === 'is' ? 'unknown' : WS_ERROR_403));
+        });
+
+        await expect(() =>
+            client.fetchBlock(123456, { identity: 'taxation', /* default attempts: 3 */ gap: 0 }),
+        ).rejects.toThrow(WS_ERROR_403);
+        await expect(() =>
+            client.fetchTransaction('txid', { identity: 'is', attempts: 4, gap: 0 }),
+        ).rejects.toThrow('unknown');
+        await expect(() =>
+            client.fetchNetworkInfo({ identity: 'theft', attempts: 2, gap: 0 }),
+        ).rejects.toThrow(WS_ERROR_403);
+
+        expect(identities.length).toBe(9);
+
+        expect(identities[0]).toBe('taxation');
+        identities.slice(1, 3).forEach((id, i, arr) => {
+            expect(id).toMatch(/taxation:[a-z0-9]+/);
+            expect(arr.indexOf(id)).toBe(i);
+        });
+
+        identities.slice(3, 7).forEach(id => expect(id).toBe('is'));
+
+        expect(identities[7]).toBe('theft');
+        identities.slice(8, 9).forEach((id, i, arr) => {
+            expect(id).toMatch(/theft:[a-z0-9]+/);
+            expect(arr.indexOf(id)).toBe(i);
+        });
     });
 
-    it('fetchFilters tip', async () => {
-        const { status } = await client.fetchFilters(TIP_HASH, 10);
-        expect(status).toBe('up-to-date');
-    });
+    it('Wabisabi switch identities on 403', async () => {
+        const identities: string[] = [];
+        jest.spyOn(http, 'httpGet').mockImplementation((_, __, { identity } = {}) => {
+            identities.push(identity!);
+            return Promise.resolve({ status: identity === 'bar' ? 404 : 403 } as Response);
+        });
 
-    it('fetchFilters not found', async () => {
-        const { status } = await client.fetchFilters(NONEXISTENT_HASH, 10);
-        expect(status).toBe('not-found');
-    });
+        await expect(() =>
+            client.fetchFilters('abc', 123, { identity: 'foo', attempts: 4, gap: 0 }),
+        ).rejects.toThrow();
+        await expect(() =>
+            client.fetchMempoolTxids({ identity: 'bar', /* default attempts: 3 */ gap: 0 }),
+        ).rejects.toThrow();
 
-    it('fetchFilters bad params', async () => {
-        await expect(client.fetchFilters(TIP_HASH, -1)).rejects.toThrow(/^400:/);
-    });
+        expect(identities.length).toBe(7);
 
-    it('fetchFilters malformed', async () => {
-        await expect(client.fetchFilters(MALFORMED_HASH, 10)).rejects.toThrow(/^500:/);
-    });
+        expect(identities[0]).toBe('foo');
+        identities.slice(1, 4).forEach((id, i, arr) => {
+            expect(id).toMatch(/foo:[a-z0-9]+/);
+            expect(arr.indexOf(id)).toBe(i);
+        });
 
-    it('fetchMempoolTxids', async () => {
-        const res = await client.fetchMempoolTxids();
-        expect(Array.isArray(res)).toBe(true);
-    });
-
-    it('fetchBlock success', async () => {
-        const block = await client.fetchBlock(3);
-        expect(block).toMatchObject({ height: 3 });
-    });
-
-    it('fetchBlock not found', async () => {
-        await expect(client.fetchBlock(999)).rejects.toThrow(/^400:/);
-    });
-
-    it('fetchTransaction success', async () => {
-        const tx = await client.fetchTransaction(VALID_TX);
-        expect(tx).toMatchObject({ txid: VALID_TX, blockHeight: 1 });
-    });
-
-    it('fetchTransaction not found', async () => {
-        await expect(client.fetchTransaction(INVALID_TX)).rejects.toThrow(/^400:/);
+        identities.slice(4, 7).forEach(id => expect(id).toBe('bar'));
     });
 });

--- a/packages/connect/src/utils/urlUtils.ts
+++ b/packages/connect/src/utils/urlUtils.ts
@@ -1,5 +1,7 @@
 // origin: https://github.com/trezor/connect/blob/develop/src/js/utils/urlUtils.js
 
+import { urlToOnion } from '@trezor/utils';
+
 export const getOrigin = (url: unknown) => {
     if (typeof url !== 'string') return 'unknown';
     if (url.indexOf('file://') === 0) return 'file://';
@@ -19,24 +21,13 @@ export const getHost = (url: unknown) => {
     }
 };
 
-export const getOnionDomain = <T extends string | string[]>(
-    url: T,
-    dict: { [domain: string]: string },
-): T => {
-    if (Array.isArray(url)) {
-        return url.map(u => getOnionDomain(u, dict)) as T;
-    }
-    if (typeof url === 'string') {
-        const [, protocol, subdomain, domain, rest] =
-            url.match(/^(http|ws)s?:\/\/([^:/]+\.)?([^/.]+\.[^/.]+)(\/.*)?$/i) ?? [];
-        // ^(http|ws)s?:\/\/ - required http(s)/ws(s) protocol
-        // ([^:/]+\.)? - optional subdomains, e.g. 'blog.'
-        // ([^/.]+\.[^/.]+) - required two-part domain name, e.g. 'trezor.io'
-        // (\/.*)?$ - optional path and/or query, e.g. '/api/data?id=1234'
+interface GetOnionDomain {
+    (url: string, dict: { [domain: string]: string }): string;
+    (url: string[], dict: { [domain: string]: string }): string[];
+}
 
-        if (!domain || !dict[domain]) return url;
-
-        return `${protocol}://${subdomain || ''}${dict[domain]}${rest || ''}` as T;
-    }
+export const getOnionDomain: GetOnionDomain = (url, dict): any => {
+    if (Array.isArray(url)) return url.map(u => urlToOnion(u, dict) ?? u);
+    if (typeof url === 'string') return urlToOnion(url, dict) ?? url;
     return url;
 };

--- a/packages/suite/src/services/coinjoin/config.ts
+++ b/packages/suite/src/services/coinjoin/config.ts
@@ -28,6 +28,10 @@ export const COINJOIN_NETWORKS: PartialRecord<NetworkSymbol, ServerEnvironment> 
                 'https://btc4.trezor.io',
                 'https://btc5.trezor.io',
             ],
+            onionDomains: {
+                'trezor.io': 'trezoriovpjcahpzkrewelclulmszwbqpzmzgub37gbcjlvluxtruqad.onion',
+                'wasabiwallet.io': 'wasabiukrxmkdgve5kynjztuovbg43uxcbcxn6y2okcrsg7gb6jdmbad.onion',
+            },
             /* 28.02.2023 */
             baseBlockHeight: 778666,
             baseBlockHash: '000000000000000000054d1ca4a160dd37541d776ccc34af955dbfcd3b2405f6',
@@ -54,6 +58,10 @@ export const COINJOIN_NETWORKS: PartialRecord<NetworkSymbol, ServerEnvironment> 
             // backend settings
             wabisabiBackendUrl: 'https://wasabiwallet.co/',
             blockbookUrls: ['https://tbtc1.trezor.io', 'https://tbtc2.trezor.io'],
+            onionDomains: {
+                'trezor.io': 'trezoriovpjcahpzkrewelclulmszwbqpzmzgub37gbcjlvluxtruqad.onion',
+                'wasabiwallet.co': 'testwnp3fugjln6vh5vpj7mvq3lkqqwjj3c2aafyu7laxz42kgwh2rad.onion',
+            },
             /* */
             /* onion addresses *
             coordinatorUrl:

--- a/packages/suite/src/utils/suite/tor.ts
+++ b/packages/suite/src/utils/suite/tor.ts
@@ -1,26 +1,11 @@
-import { parseHostname } from '@trezor/utils';
+import { parseHostname, urlToOnion } from '@trezor/utils';
 import { TOR_URLS } from '@trezor/urls';
 import { TorStatus } from 'src/types/suite';
 
 /**
  * returns tor url if tor url is request and tor url is available for given domain
  */
-export const getTorUrlIfAvailable = (url: string) => {
-    const [, subdomain, domain, rest] =
-        url.match(/^https?:\/\/([^:/]+\.)?([^/.]+\.[^/.]+)(\/.*)?$/i) ?? [];
-    // ^https?:\/\/ - required http(s) protocol
-    // ([^:/]+\.)? - optional subdomains, e.g. 'blog.'
-    // ([^/.]+\.[^/.]+) - required two-part domain name, e.g. 'trezor.io'
-    // (\/.*)?$ - optional path and/or query, e.g. '/api/data?id=1234'
-
-    if (!domain) return;
-
-    // TOR_URL contains a map of open:onion domains
-    const onionDomain = TOR_URLS[domain];
-    if (!onionDomain) return;
-
-    return `http://${subdomain ?? ''}${onionDomain}${rest ?? ''}`;
-};
+export const getTorUrlIfAvailable = (url: string) => urlToOnion(url, TOR_URLS);
 
 export const getIsTorDomain = (domain: string) => domain.endsWith('.onion');
 

--- a/packages/utils/src/index.ts
+++ b/packages/utils/src/index.ts
@@ -29,6 +29,7 @@ export * from './scheduleAction';
 export * from './throwError';
 export * from './truncateMiddle';
 export * from './topologicalSort';
+export * from './urlToOnion';
 export * as versionUtils from './versionUtils';
 export * as xssFilters from './xssFilters';
 export * from './getLocaleSeparators';

--- a/packages/utils/src/urlToOnion.ts
+++ b/packages/utils/src/urlToOnion.ts
@@ -1,0 +1,16 @@
+/**
+ * Tries to replace clearnet domain name in given `url` by any of the onion domain names in
+ * `onionDomains` map and return it. When no onion replacement is found, returns `undefined`.
+ */
+export const urlToOnion = (url: string, onionDomains: { [domain: string]: string }) => {
+    const [, protocol, subdomain, domain, rest] =
+        url.match(/^(http|ws)s?:\/\/([^:/]+\.)?([^/.]+\.[^/.]+)(\/.*)?$/i) ?? [];
+    // ^(http|ws)s?:\/\/ - required http(s)/ws(s) protocol
+    // ([^:/]+\.)? - optional subdomains, e.g. 'blog.'
+    // ([^/.]+\.[^/.]+) - required two-part domain name, e.g. 'trezor.io'
+    // (\/.*)?$ - optional path and/or query, e.g. '/api/data?id=1234'
+
+    if (!domain || !onionDomains[domain]) return;
+
+    return `${protocol}://${subdomain ?? ''}${onionDomains[domain]}${rest ?? ''}`;
+};

--- a/packages/utils/tests/urlToOnion.test.ts
+++ b/packages/utils/tests/urlToOnion.test.ts
@@ -1,0 +1,28 @@
+import { urlToOnion } from '../src/urlToOnion';
+
+const DICT = {
+    'trezor.io': 'trezorioabcd.onion',
+    'coingecko.com': 'coingeckoabcd.onion',
+};
+
+const FIXTURE = [
+    ['invalid domain', 'aaaa', undefined],
+    ['unknown domain', 'http://www.something.test', undefined],
+    ['missing protocol', 'trezor.io', undefined],
+    ['simple domain http', 'https://trezor.io/', `http://trezorioabcd.onion/`],
+    ['simple domain https', 'https://trezor.io/', `http://trezorioabcd.onion/`],
+    ['subdomain', 'https://cdn.trezor.io/x/1*ab.png', `http://cdn.trezorioabcd.onion/x/1*ab.png`],
+    ['subsubdomain', 'http://alpha.beta.trezor.io', `http://alpha.beta.trezorioabcd.onion`],
+    ['blockbook', 'https://btc1.trezor.io/api?t=13#a', `http://btc1.trezorioabcd.onion/api?t=13#a`],
+    ['coingecko', 'https://coingecko.com/?dt=5-1-2021', `http://coingeckoabcd.onion/?dt=5-1-2021`],
+    ['websocket wss', 'wss://trezor.io', 'ws://trezorioabcd.onion'],
+    ['websocket ws', 'ws://foo.bar.trezor.io/?foo=bar', 'ws://foo.bar.trezorioabcd.onion/?foo=bar'],
+    ['duplicate match', 'http://trezor.io/trezor.io', 'http://trezorioabcd.onion/trezor.io'],
+    ['false match', 'http://a.test/b?url=trezor.io', undefined],
+] as [string, string, string | undefined][];
+
+describe('urlToOnion', () => {
+    FIXTURE.forEach(([desc, clear, onion]) =>
+        it(desc, () => expect(urlToOnion(clear, DICT)).toBe(onion)),
+    );
+});


### PR DESCRIPTION
## Description

As the Tor DDoS is hopefully over, we could try to use onion addresses again for CJ discovery, with fallback to clearnet urls in case of any issues.

- https://github.com/trezor/trezor-suite/pull/9101/commits/7a1f87db33928c2c4800d9cc0adffb926677103d
  - repeated logic for translating clearnet urls to .onion moved to `@trezor/utils`
  - unit tests added
- https://github.com/trezor/trezor-suite/pull/9101/commits/aef08ed830ac383a30f24ec087f6e69c011f1f2e
  - util from previous commit used in `suite` and `connect` packages
- https://github.com/trezor/trezor-suite/pull/9101/commits/0854d5a7b162ef26f8b7bbb99bedefcea1d20185
  - base websocket options from `@trezor/blockchain-link` extended by `connectionTimeout` (so timeout for ws opening can be different than for regular responses) and `onSend` (so outgoing messages can be logged)
  - both used in subsequent commits
- https://github.com/trezor/trezor-suite/pull/9101/commits/3f290e750f3e903e7744fa20d2f904538cbb86cb
  - pure refactoring
  - wabisabi request handling simplified in `CoinjoinBackendClient`
- https://github.com/trezor/trezor-suite/pull/9101/commits/a077295138883f19e86d7b2a518db34a88532dab
  - pure refactoring
  - blockbook request handling simplified in `CoinjoinBackendClient`
- https://github.com/trezor/trezor-suite/pull/9101/commits/80c140bf15f5c34f27a7dc83949b9c237c657fa4
  - mempool subscription reworked in `CoinjoinBackendClient` so `scheduleAction` mechanism with multiple trials and fallbacks is used for them as well
  - websocket used for mempool is now explicitly stored in `CoinjoinBackendClient`
  - **potentially risky as it changes the logic of persistently opened mempool ws**
- https://github.com/trezor/trezor-suite/pull/9101/commits/5e10e91c56ea346d99da09937aa66ae6118ce1f8
  - unit tests adjusted to the previous three commits
- https://github.com/trezor/trezor-suite/pull/9101/commits/9d71f50ff052f2a8ef9fa5bb2bc127a3b447ef75
  - **main part**
  - logic for starting ws communication via onion address (if available) with fallback to clearnet on timeout and later changing identity on 403
- https://github.com/trezor/trezor-suite/pull/9101/commits/fa7548167a35be5a92faa1c9ca441eafb6e1fdd5
  - new unit test for previous commit

## Related Issue

Part of #8960 

## QA

Nothing changes from user's perspective, except CJ discovery should be more stable now. Please test especially CJ mempool stability.