### PR TITLE
tests(suite): create preloadedState from partialState

### DIFF
--- a/packages/suite/src/actions/wallet/__tests__/coinjoinAccountActions.test.ts
+++ b/packages/suite/src/actions/wallet/__tests__/coinjoinAccountActions.test.ts
@@ -1,5 +1,5 @@
 import { combineReducers, createReducer } from '@reduxjs/toolkit';
-import { configureMockStore, testMocks } from '@suite-common/test-utils';
+import { configureMockStore, initPreloadedState, testMocks } from '@suite-common/test-utils';
 
 import { accountsReducer } from 'src/reducers/wallet';
 import { coinjoinReducer } from 'src/reducers/wallet/coinjoinReducer';
@@ -45,25 +45,15 @@ const rootReducer = combineReducers({
 type State = ReturnType<typeof rootReducer>;
 type Wallet = Partial<State['wallet']> & { devices?: State['devices'] };
 
-const initStore = ({ accounts, coinjoin, devices }: Wallet = {}) => {
-    const preloadedState: State = JSON.parse(
-        JSON.stringify(rootReducer(undefined, { type: 'init' })),
-    );
-    if (devices) {
-        preloadedState.devices = devices;
-    }
-    if (accounts) {
-        preloadedState.wallet.accounts = accounts;
-    }
-    if (coinjoin) {
-        preloadedState.wallet.coinjoin = {
-            ...preloadedState.wallet.coinjoin,
-            ...coinjoin,
-        };
-    }
+const initStore = ({ accounts, coinjoin, devices }: Wallet = {}) =>
     // State != suite AppState, therefore <any>
-    return configureMockStore<any>({ reducer: rootReducer, preloadedState });
-};
+    configureMockStore<any>({
+        reducer: rootReducer,
+        preloadedState: initPreloadedState({
+            rootReducer,
+            partialState: { devices, wallet: { accounts, coinjoin } },
+        }),
+    });
 
 describe('coinjoinAccountActions', () => {
     beforeEach(() => {

--- a/suite-common/test-utils/src/configureMockStore.ts
+++ b/suite-common/test-utils/src/configureMockStore.ts
@@ -16,6 +16,14 @@ import { mergeDeepObject } from '@trezor/utils';
 
 import { extraDependenciesMock } from './extraDependenciesMock';
 
+export const initPreloadedState = ({
+    rootReducer,
+    partialState,
+}: {
+    rootReducer: Reducer<any, any>;
+    partialState: PreloadedState<CombinedState<any>>;
+}) => mergeDeepObject(partialState, rootReducer(undefined, { type: 'test-init' }));
+
 /**
  * A mock store for testing Redux async action creators and middleware.
  */


### PR DESCRIPTION
## Description

Follow up for [discussion here](https://github.com/trezor/trezor-suite/pull/6649#discussion_r1005460087)

I would like to start using `configureMockStore` in tests but for that i need to be able to create `initialState` from rootReducer + parialState from the fixtures

cc @Nodonisko 