### PR TITLE
Fix: utxo-lib dustThreshold calculation

### DIFF
--- a/packages/connect/src/api/bitcoin/TransactionComposer.ts
+++ b/packages/connect/src/api/bitcoin/TransactionComposer.ts
@@ -180,6 +180,7 @@ export class TransactionComposer {
             outputs: this.outputs,
             height: this.blockHeight,
             feeRate,
+            longTermFeeRate: this.feeLevels.longTermFeeRate,
             skipPermutation: this.skipPermutation,
             basePath: account.address_n,
             network: coinInfo.network,

--- a/packages/utxo-lib/src/coinselect/index.ts
+++ b/packages/utxo-lib/src/coinselect/index.ts
@@ -11,6 +11,6 @@ export function coinselect(
     options: CoinSelectOptions,
 ) {
     const sortedInputs = options.skipPermutation ? inputs : inputs.sort(sortByScore(feeRate));
-    const algorithm = tryConfirmed(anyOf([bnb(0.5), accumulative]), options);
+    const algorithm = tryConfirmed(anyOf([bnb, accumulative]), options);
     return algorithm(sortedInputs, outputs, feeRate, options);
 }

--- a/packages/utxo-lib/src/coinselect/outputs/split.ts
+++ b/packages/utxo-lib/src/coinselect/outputs/split.ts
@@ -4,7 +4,7 @@ import {
     sumOrNaN,
     transactionBytes,
     filterCoinbase,
-    dustThreshold,
+    getDustAmount,
     getFee,
     finalize,
     ZERO,
@@ -44,10 +44,10 @@ export function split(
     }
 
     const splitValue = remaining.div(new BN(unspecified));
-    const dustAmount = dustThreshold(feeRate, options);
+    const dustAmount = getDustAmount(feeRate, options);
 
     // ensure every output is either user defined, or over the threshold
-    if (unspecified && splitValue.lte(new BN(dustAmount))) return { fee };
+    if (unspecified && splitValue.lt(new BN(dustAmount))) return { fee };
 
     // assign splitValue to outputs not user defined
     const outputsSplit = outputs.map(x => {

--- a/packages/utxo-lib/src/compose/coinselect.ts
+++ b/packages/utxo-lib/src/compose/coinselect.ts
@@ -19,6 +19,7 @@ export function coinselect(
     rOutputs: ComposeOutput[],
     height: number,
     feeRate: number,
+    longTermFeeRate: number | undefined,
     countMax: boolean,
     countMaxId: number,
     dustThreshold: number,
@@ -33,6 +34,7 @@ export function coinselect(
     const options: CoinSelectOptions = {
         txType,
         dustThreshold,
+        longTermFeeRate,
         baseFee,
         floorBaseFee,
         dustOutputFee,

--- a/packages/utxo-lib/src/compose/index.ts
+++ b/packages/utxo-lib/src/compose/index.ts
@@ -11,6 +11,7 @@ export function composeTx({
     outputs,
     height,
     feeRate,
+    longTermFeeRate,
     basePath,
     network,
     changeId,
@@ -34,6 +35,14 @@ export function composeTx({
         return { type: 'error', error: 'INCORRECT-FEE-RATE' };
     }
 
+    let longTermFeeRateNumber;
+    if (longTermFeeRate) {
+        longTermFeeRateNumber = convertFeeRate(longTermFeeRate);
+        if (!longTermFeeRateNumber) {
+            return { type: 'error', error: 'INCORRECT-FEE-RATE' };
+        }
+    }
+
     let countMax = { exists: false, id: 0 };
     try {
         countMax = request.getMax(outputs);
@@ -55,6 +64,7 @@ export function composeTx({
             outputs,
             height,
             feeRateNumber,
+            longTermFeeRateNumber,
             countMax.exists,
             countMax.id,
             dustThreshold,

--- a/packages/utxo-lib/src/types/coinselect.ts
+++ b/packages/utxo-lib/src/types/coinselect.ts
@@ -2,7 +2,8 @@ export type CoinSelectPaymentType = 'p2pkh' | 'p2sh' | 'p2tr' | 'p2wpkh' | 'p2ws
 
 export interface CoinSelectOptions {
     txType: CoinSelectPaymentType;
-    dustThreshold: number;
+    dustThreshold?: number;
+    longTermFeeRate?: number;
     own?: number;
     other?: number;
     coinbase?: number;

--- a/packages/utxo-lib/src/types/compose.ts
+++ b/packages/utxo-lib/src/types/compose.ts
@@ -55,12 +55,13 @@ export interface ComposeRequest {
     outputs: ComposeOutput[]; // all output "requests"
     height: number;
     feeRate: string | number; // in sat/byte, virtual size
+    longTermFeeRate?: string | number; // dust output feeRate multiplier in sat/byte, virtual size
     basePath: number[]; // for trezor inputs
     network: Network;
     changeId: number;
     changeAddress: string;
     dustThreshold: number; // explicit dust threshold, in satoshi
-    baseFee?: number; // DOGE base fee
+    baseFee?: number; // DOGE or RBF base fee
     floorBaseFee?: boolean; // DOGE floor base fee to the nearest integer
     dustOutputFee?: number; // DOGE fee for every output below dust limit
     skipUtxoSelection?: boolean; // use custom utxo selection, without algorithm

--- a/packages/utxo-lib/tests/__fixtures__/coinselect/accumulative.ts
+++ b/packages/utxo-lib/tests/__fixtures__/coinselect/accumulative.ts
@@ -187,7 +187,7 @@ export default [
     {
         description:
             '1 output, sub-optimal inputs (if re-ordered), direct possible, but slightly higher fee',
-        feeRate: 10,
+        feeRate: 12,
         inputs: ['10000', '40000', '40000'],
         outputs: ['6800'],
         expected: {
@@ -436,7 +436,7 @@ export default [
     },
     {
         description: '1 output, script provided, no change',
-        feeRate: 10,
+        feeRate: 12,
         inputs: ['100000'],
         outputs: [
             {
@@ -866,7 +866,7 @@ export default [
         expected: {
             fee: 100000000,
         },
-        dustThreshold: 99999999,
+        dustThreshold: 100000000,
     },
     {
         description: 'DOGE: 2 inputs, not enough to cover fee (tx size)',
@@ -887,7 +887,7 @@ export default [
         expected: {
             fee: 200000000,
         },
-        dustThreshold: 99999999,
+        dustThreshold: 100000000,
     },
     {
         description: 'DOGE: 1 input, not enough to cover fee (output-dust)',
@@ -900,7 +900,7 @@ export default [
         expected: {
             fee: 200000000,
         },
-        dustThreshold: 99999999,
+        dustThreshold: 100000000,
     },
     {
         description: 'DOGE: 1 input, 1 output, expect change',
@@ -927,7 +927,7 @@ export default [
             ],
             fee: 100000000,
         },
-        dustThreshold: 99999999,
+        dustThreshold: 100000000,
     },
     {
         description: 'DOGE: 2 outputs, no change (spend dust)',
@@ -954,7 +954,7 @@ export default [
             ],
             fee: 299999995,
         },
-        dustThreshold: 99999999,
+        dustThreshold: 100000000,
     },
     {
         description: 'DOGE: 1 output, no change (tx size)',
@@ -988,7 +988,7 @@ export default [
             ],
             fee: 200000000,
         },
-        dustThreshold: 99999999,
+        dustThreshold: 100000000,
     },
     {
         description: 'DOGE: 1 outputs, no change (increased fee rate)',
@@ -1023,6 +1023,379 @@ export default [
             ],
             fee: 200000000,
         },
-        dustThreshold: 99999999,
+        dustThreshold: 100000000,
+    },
+    {
+        description:
+            'p2pkh with high feeRate and explicit longTermFeeRate (change > dustThreshold 546)',
+        txType: 'p2pkh',
+        feeRate: 40,
+        longTermFeeRate: 4,
+        dustThreshold: 546,
+        inputs: ['100000'],
+        outputs: [{ value: '90000' }],
+        expected: {
+            inputs: [
+                {
+                    i: 0,
+                    value: '100000',
+                    script: { length: 108 },
+                },
+            ],
+            outputs: [
+                {
+                    script: { length: 25 },
+                    value: '90000',
+                },
+                {
+                    script: { length: 25 },
+                    value: '960',
+                },
+            ],
+            fee: 9040,
+        },
+    },
+    {
+        description:
+            'p2pkh with high feeRate, no explicit dustThreshold, dust amount calculated from inputSize (change > 148 * 3)',
+        txType: 'p2pkh',
+        feeRate: 42,
+        inputs: ['100000'],
+        outputs: [{ value: '90000' }],
+        expected: {
+            inputs: [
+                {
+                    i: 0,
+                    value: '100000',
+                    script: { length: 108 },
+                },
+            ],
+            outputs: [
+                {
+                    script: { length: 25 },
+                    value: '90000',
+                },
+                {
+                    script: { length: 25 },
+                    value: '508',
+                },
+            ],
+            fee: 9492,
+        },
+    },
+    {
+        description:
+            'p2pkh with high feeRate, no explicit dustThreshold, dust dropped (change < 148 * 3)',
+        txType: 'p2pkh',
+        feeRate: 43,
+        inputs: ['100000'],
+        outputs: [{ value: '90000' }],
+        expected: {
+            inputs: [
+                {
+                    i: 0,
+                    value: '100000',
+                    script: { length: 108 },
+                },
+            ],
+            outputs: [
+                {
+                    script: { length: 25 },
+                    value: '90000',
+                },
+            ],
+            fee: 10000,
+        },
+    },
+    {
+        description:
+            'p2sh with high feeRate and explicit longTermFeeRate (change > dustThreshold 546)',
+        txType: 'p2sh',
+        feeRate: 42,
+        longTermFeeRate: 4,
+        dustThreshold: 546,
+        inputs: [
+            {
+                script: { length: 107 }, // INPUT_SCRIPT_LENGTH.p2sh
+                value: '100000',
+            },
+        ],
+        outputs: [{ value: '90000' }],
+        expected: {
+            inputs: [
+                {
+                    i: 0,
+                    value: '100000',
+                    script: { length: 107 },
+                },
+            ],
+            outputs: [
+                {
+                    script: { length: 25 },
+                    value: '90000',
+                },
+                {
+                    script: { length: 23 },
+                    value: '634',
+                },
+            ],
+            fee: 9366,
+        },
+    },
+    {
+        description:
+            'p2sh with high feeRate, no explicit dustThreshold, dust amount calculated from inputSize (change > 91 * 3)',
+        txType: 'p2sh',
+        feeRate: 43,
+        inputs: [
+            {
+                script: { length: 107 }, // INPUT_SCRIPT_LENGTH.p2sh
+                value: '100000',
+            },
+        ],
+        outputs: [{ value: '90000' }],
+        expected: {
+            inputs: [
+                {
+                    i: 0,
+                    value: '100000',
+                    script: { length: 107 },
+                },
+            ],
+            outputs: [
+                {
+                    script: { length: 25 },
+                    value: '90000',
+                },
+                {
+                    script: { length: 23 },
+                    value: '411',
+                },
+            ],
+            fee: 9589,
+        },
+    },
+    {
+        description:
+            'p2sh with high feeRate, no explicit dustThreshold, dust dropped (change < 91 * 3)',
+        txType: 'p2sh',
+        feeRate: 44,
+        inputs: [
+            {
+                script: { length: 107 }, // INPUT_SCRIPT_LENGTH.p2sh
+                value: '100000',
+            },
+        ],
+        outputs: [{ value: '90000' }],
+        expected: {
+            inputs: [
+                {
+                    i: 0,
+                    value: '100000',
+                    script: { length: 107 },
+                },
+            ],
+            outputs: [
+                {
+                    script: { length: 25 },
+                    value: '90000',
+                },
+            ],
+            fee: 10000,
+        },
+    },
+    {
+        description:
+            'p2wpkh with high feeRate and explicit longTermFeeRate (change > dustThreshold 546)',
+        txType: 'p2wpkh',
+        feeRate: 42,
+        longTermFeeRate: 4,
+        dustThreshold: 546,
+        inputs: [
+            {
+                script: { length: 107 }, // INPUT_SCRIPT_LENGTH.p2wpkh
+                value: '100000',
+            },
+        ],
+        outputs: [{ value: '90000' }],
+        expected: {
+            inputs: [
+                {
+                    i: 0,
+                    value: '100000',
+                    script: { length: 107 },
+                },
+            ],
+            outputs: [
+                {
+                    script: { length: 25 },
+                    value: '90000',
+                },
+                {
+                    script: { length: 22 },
+                    value: '676',
+                },
+            ],
+            fee: 9324,
+        },
+    },
+    {
+        description:
+            'p2wpkh with high feeRate, no explicit dustThreshold, dust amount calculated from inputSize (change > 58 * 3)',
+        txType: 'p2wpkh',
+        feeRate: 43,
+        inputs: [
+            {
+                script: { length: 107 }, // INPUT_SCRIPT_LENGTH.p2wpkh
+                value: '100000',
+            },
+        ],
+        outputs: [{ value: '90000' }],
+        expected: {
+            inputs: [
+                {
+                    i: 0,
+                    value: '100000',
+                    script: { length: 107 },
+                },
+            ],
+            outputs: [
+                {
+                    script: { length: 25 },
+                    value: '90000',
+                },
+                {
+                    script: { length: 22 },
+                    value: '454',
+                },
+            ],
+            fee: 9546,
+        },
+    },
+    {
+        description:
+            'p2wpkh with high feeRate, no explicit dustThreshold, dust dropped (change < 58 * 3)',
+        txType: 'p2wpkh',
+        feeRate: 45,
+        inputs: [
+            {
+                script: { length: 107 }, // INPUT_SCRIPT_LENGTH.p2wpkh
+                value: '100000',
+            },
+        ],
+        outputs: [{ value: '90000' }],
+        expected: {
+            inputs: [
+                {
+                    i: 0,
+                    value: '100000',
+                    script: { length: 107 },
+                },
+            ],
+            outputs: [
+                {
+                    script: { length: 25 },
+                    value: '90000',
+                },
+            ],
+            fee: 10000,
+        },
+    },
+    {
+        description:
+            'p2tr with high feeRate and explicit longTermFeeRate (change > dustThreshold 546)',
+        txType: 'p2tr',
+        feeRate: 49,
+        longTermFeeRate: 4,
+        dustThreshold: 546,
+        inputs: [
+            {
+                script: { length: 65 }, // INPUT_SCRIPT_LENGTH.p2tr
+                value: '100000',
+            },
+        ],
+        outputs: [{ value: '90000' }],
+        expected: {
+            inputs: [
+                {
+                    i: 0,
+                    value: '100000',
+                    script: { length: 65 },
+                },
+            ],
+            outputs: [
+                {
+                    script: { length: 25 },
+                    value: '90000',
+                },
+                {
+                    script: { length: 34 },
+                    value: '592',
+                },
+            ],
+            fee: 9408,
+        },
+    },
+    {
+        description:
+            'p2tr with high feeRate, no explicit dustThreshold, dust amount calculated from inputSize (> 68 * 3)',
+        txType: 'p2tr',
+        feeRate: 50,
+        inputs: [
+            {
+                script: { length: 65 }, // INPUT_SCRIPT_LENGTH.p2tr
+                value: '100000',
+            },
+        ],
+        outputs: [{ value: '90000' }],
+        expected: {
+            inputs: [
+                {
+                    i: 0,
+                    value: '100000',
+                    script: { length: 65 },
+                },
+            ],
+            outputs: [
+                {
+                    script: { length: 25 },
+                    value: '90000',
+                },
+                {
+                    script: { length: 34 },
+                    value: '400',
+                },
+            ],
+            fee: 9600,
+        },
+    },
+    {
+        description:
+            'p2tr with high feeRate, no explicit dustThreshold, dust dropped (change < 68 * 3)',
+        txType: 'p2tr',
+        feeRate: 53,
+        inputs: [
+            {
+                script: { length: 65 }, // INPUT_SCRIPT_LENGTH.p2tr
+                value: '100000',
+            },
+        ],
+        outputs: [{ value: '90000' }],
+        expected: {
+            inputs: [
+                {
+                    i: 0,
+                    value: '100000',
+                    script: { length: 65 },
+                },
+            ],
+            outputs: [
+                {
+                    script: { length: 25 },
+                    value: '90000',
+                },
+            ],
+            fee: 10000,
+        },
     },
 ];

--- a/packages/utxo-lib/tests/__fixtures__/coinselect/bnb.ts
+++ b/packages/utxo-lib/tests/__fixtures__/coinselect/bnb.ts
@@ -19,7 +19,6 @@ export default [
             fee: 2001,
         },
         dustThreshold: 546,
-        factor: 0.5,
     },
     {
         description: '1 output, no change, value > 2^32',
@@ -41,7 +40,6 @@ export default [
             fee: 2001,
         },
         dustThreshold: 546,
-        factor: 0.5,
     },
     {
         description: '1 output, no change, value > Number.MAX_SAFE_INTEGER (DOGE)',
@@ -63,7 +61,81 @@ export default [
             fee: 2000,
         },
         dustThreshold: 546,
-        factor: 0.5,
+    },
+    {
+        description: '3 inputs, sub-optimal solution with higher fee',
+        feeRate: 3,
+        inputs: ['100000', '1200', '1000'], // it would be better to pick "1000" (less fee)
+        outputs: ['99980'],
+        expected: {
+            inputs: [
+                {
+                    i: 0,
+                    value: '100000',
+                },
+                {
+                    i: 1,
+                    value: '1200',
+                },
+            ],
+            outputs: [
+                {
+                    value: '99980',
+                },
+            ],
+            fee: 1220,
+        },
+        dustThreshold: 546,
+    },
+    {
+        description: '3 inputs, optimal solution',
+        feeRate: 3,
+        inputs: ['100000', '1000', '13000'],
+        outputs: ['99980'],
+        expected: {
+            inputs: [
+                {
+                    i: 0,
+                    value: '100000',
+                },
+                {
+                    i: 1,
+                    value: '1000',
+                },
+            ],
+            outputs: [
+                {
+                    value: '99980',
+                },
+            ],
+            fee: 1020,
+        },
+        dustThreshold: 546,
+    },
+    {
+        description: '3 inputs, high feeRate, optimal solution',
+        feeRate: 100,
+        inputs: ['100000', '50000', '45000'],
+        outputs: ['110000'],
+        expected: {
+            inputs: [
+                {
+                    i: 0,
+                    value: '100000',
+                },
+                {
+                    i: 2,
+                    value: '45000',
+                },
+            ],
+            outputs: [
+                {
+                    value: '110000',
+                },
+            ],
+            fee: 35000,
+        },
+        dustThreshold: 546,
     },
     {
         description: '1 output, change rejected, value > 2^32',
@@ -72,7 +144,6 @@ export default [
         outputs: ['1'],
         expected: { fee: 0 },
         dustThreshold: 546,
-        factor: 0.5,
     },
     {
         description: '1 output, only possibility with change, rejects',
@@ -81,7 +152,6 @@ export default [
         outputs: ['100000'],
         expected: { fee: 0 },
         dustThreshold: 546,
-        factor: 0.5,
     },
     {
         description: '1 output, sub-optimal inputs (if re-ordered), direct possible',
@@ -103,7 +173,6 @@ export default [
             fee: 2300,
         },
         dustThreshold: 546,
-        factor: 0.5,
     },
     {
         description:
@@ -113,7 +182,6 @@ export default [
         outputs: ['6800'],
         expected: { fee: 0 },
         dustThreshold: 546,
-        factor: 0.5,
     },
     {
         description: '1 output, passes, skipped detrimental input',
@@ -152,7 +220,6 @@ export default [
             ],
         },
         dustThreshold: 546,
-        factor: 0.5,
     },
     {
         description: '1 output, fails, skips (and finishes on) detrimental input',
@@ -168,7 +235,6 @@ export default [
         outputs: ['38000'],
         expected: { fee: 0 },
         dustThreshold: 546,
-        factor: 0.5,
     },
     {
         description: '1 output, passes, good match despite bad ordering',
@@ -207,7 +273,6 @@ export default [
             fee: 2000,
         },
         dustThreshold: 546,
-        factor: 0.5,
     },
     {
         description: '1 output, optimal inputs, no change',
@@ -229,7 +294,6 @@ export default [
             fee: 2300,
         },
         dustThreshold: 546,
-        factor: 0.5,
     },
     {
         description: '1 output, no fee, no match',
@@ -238,7 +302,6 @@ export default [
         outputs: ['28000'],
         expected: { fee: 0 },
         dustThreshold: 546,
-        factor: 0.5,
     },
     {
         description: '1 output, 2 inputs (related), no change',
@@ -270,7 +333,6 @@ export default [
             fee: 2000,
         },
         dustThreshold: 546,
-        factor: 0.5,
     },
     {
         description: 'many outputs, no change',
@@ -309,7 +371,6 @@ export default [
             fee: 6221,
         },
         dustThreshold: 546,
-        factor: 0.5,
     },
     {
         description: 'many outputs, no match',
@@ -318,7 +379,6 @@ export default [
         outputs: ['35000', '5000', '5000', '1000'],
         expected: { fee: 0 },
         dustThreshold: 546,
-        factor: 0.5,
     },
     {
         description: 'many outputs, no match',
@@ -327,7 +387,6 @@ export default [
         outputs: ['28000', '1000'],
         expected: { fee: 0 },
         dustThreshold: 546,
-        factor: 0.5,
     },
     {
         description: 'no outputs, no change',
@@ -345,7 +404,6 @@ export default [
             fee: 1900,
         },
         dustThreshold: 546,
-        factor: 0.5,
     },
     {
         description: 'no outputs, no match',
@@ -354,7 +412,6 @@ export default [
         outputs: [],
         expected: { fee: 0 },
         dustThreshold: 546,
-        factor: 0.5,
     },
     {
         description: 'not enough funds, empty result',
@@ -363,7 +420,6 @@ export default [
         outputs: ['40000'],
         expected: { fee: 0 },
         dustThreshold: 546,
-        factor: 0.5,
     },
     {
         description: 'not enough funds (w/ fee), empty result',
@@ -372,7 +428,6 @@ export default [
         outputs: ['40000'],
         expected: { fee: 0 },
         dustThreshold: 546,
-        factor: 0.5,
     },
     {
         description: 'not enough funds (no inputs), empty result',
@@ -381,7 +436,6 @@ export default [
         outputs: [],
         expected: { fee: 0 },
         dustThreshold: 546,
-        factor: 0.5,
     },
     {
         description: 'not enough funds (no inputs), empty result (>1KiB)',
@@ -420,7 +474,6 @@ export default [
         ],
         expected: { fee: 0 },
         dustThreshold: 546,
-        factor: 0.5,
     },
     {
         description: '2 outputs, some with missing value (NaN)',
@@ -429,7 +482,6 @@ export default [
         outputs: ['1000', {}],
         expected: { fee: 0 },
         dustThreshold: 546,
-        factor: 0.5,
     },
     {
         description: 'input with float values (NaN)',
@@ -438,7 +490,6 @@ export default [
         outputs: ['10000', '1200'],
         expected: { fee: 0 },
         dustThreshold: 546,
-        factor: 0.5,
     },
     {
         description: '2 outputs, with float values (NaN)',
@@ -447,7 +498,6 @@ export default [
         outputs: ['10000.25', '1200.5'],
         expected: { fee: 0 },
         dustThreshold: 546,
-        factor: 0.5,
     },
     {
         description: '2 outputs, string values (NaN)',
@@ -463,7 +513,6 @@ export default [
         ],
         expected: { fee: 0 },
         dustThreshold: 546,
-        factor: 0.5,
     },
     {
         description: 'exhausting BnB',
@@ -683,6 +732,5 @@ export default [
         outputs: ['1000000'],
         expected: { fee: 0 },
         dustThreshold: 546,
-        factor: 0.5,
     },
 ];

--- a/packages/utxo-lib/tests/__fixtures__/coinselect/split.ts
+++ b/packages/utxo-lib/tests/__fixtures__/coinselect/split.ts
@@ -323,7 +323,7 @@ export default [
             ],
             fee: 100000000,
         },
-        dustThreshold: 99999999,
+        dustThreshold: 100000000,
     },
     {
         description: 'DOGE: 1 to 3',
@@ -353,7 +353,7 @@ export default [
             ],
             fee: 100000000,
         },
-        dustThreshold: 99999999,
+        dustThreshold: 100000000,
     },
     {
         description: 'DOGE: 1 to 1 with tx size',
@@ -388,7 +388,7 @@ export default [
             ],
             fee: 200000000,
         },
-        dustThreshold: 99999999,
+        dustThreshold: 100000000,
     },
     {
         description: 'DOGE: 1 to 1 with increased feeRate',
@@ -423,7 +423,7 @@ export default [
             ],
             fee: 200000000,
         },
-        dustThreshold: 99999999,
+        dustThreshold: 100000000,
     },
     {
         description: 'DOGE: 1 to 2 with dust output',
@@ -455,7 +455,7 @@ export default [
             ],
             fee: 200000000,
         },
-        dustThreshold: 99999999,
+        dustThreshold: 100000000,
     },
     {
         description: 'DOGE: 1 to 1, not enough funds (feeRate)',
@@ -473,7 +473,7 @@ export default [
         expected: {
             fee: 200000000,
         },
-        dustThreshold: 99999999,
+        dustThreshold: 100000000,
     },
     {
         description: 'DOGE: 1 to 1, not enough funds (dust output)',
@@ -491,7 +491,7 @@ export default [
         expected: {
             fee: 100000000,
         },
-        dustThreshold: 99999999,
+        dustThreshold: 100000000,
     },
     {
         description: 'DOGE: 1 to 2, not enough funds (dust defined output)',
@@ -509,6 +509,326 @@ export default [
         expected: {
             fee: 200000000,
         },
-        dustThreshold: 99999999,
+        dustThreshold: 100000000,
+    },
+    {
+        description:
+            'p2pkh to p2pkh with high feeRate and explicit longTermFeeRate (max output > dustThreshold 546)',
+        feeRate: 49,
+        longTermFeeRate: 4,
+        dustThreshold: 546,
+        inputs: ['10000'],
+        outputs: [{}],
+        expected: {
+            inputs: [
+                {
+                    i: 0,
+                    value: '10000',
+                },
+            ],
+            outputs: [
+                {
+                    value: '592',
+                },
+            ],
+            fee: 9408,
+        },
+    },
+    {
+        description:
+            'p2pkh to p2pkh with high feeRate, no explicit dustThreshold, dust amount calculated from inputSize (max output > 148 * 3)',
+        feeRate: 49.5,
+        inputs: ['10000'],
+        outputs: [{}],
+        expected: {
+            inputs: [
+                {
+                    i: 0,
+                    value: '10000',
+                },
+            ],
+            outputs: [
+                {
+                    value: '496',
+                },
+            ],
+            fee: 9504,
+        },
+    },
+    {
+        description:
+            'p2pkh to p2pkh spending dust with lowest feeRate is not possible (no explicit dustThreshold)',
+        feeRate: 1,
+        inputs: ['546'],
+        outputs: [{}],
+        expected: {
+            // 546 - 192 < 148 * 3
+            fee: 192,
+        },
+    },
+    {
+        description:
+            'p2sh to p2sh with high feeRate and explicit longTermFeeRate (max output > dustThreshold 546)',
+        txType: 'p2sh',
+        feeRate: 50,
+        longTermFeeRate: 4,
+        dustThreshold: 546,
+        inputs: [
+            {
+                script: { length: 107 }, // INPUT_SCRIPT_LENGTH.p2sh
+                value: '10000',
+            },
+        ],
+        outputs: [{ script: { length: 23 } }], // OUTPUT_SCRIPT_LENGTH.p2sh
+        expected: {
+            inputs: [
+                {
+                    i: 0,
+                    value: '10000',
+                    script: { length: 107 },
+                },
+            ],
+            outputs: [
+                {
+                    value: '550',
+                    script: { length: 23 },
+                },
+            ],
+            fee: 9450,
+        },
+    },
+    {
+        description:
+            'p2sh to p2sh with high feeRate, no explicit dustThreshold, dust amount calculated from inputSize (max output > 91 * 3)',
+        txType: 'p2sh',
+        feeRate: 51,
+        inputs: [
+            {
+                script: { length: 107 }, // INPUT_SCRIPT_LENGTH.p2sh
+                value: '10000',
+            },
+        ],
+        outputs: [{ script: { length: 23 } }], // OUTPUT_SCRIPT_LENGTH.p2sh
+        expected: {
+            inputs: [
+                {
+                    i: 0,
+                    value: '10000',
+                    script: { length: 107 },
+                },
+            ],
+            outputs: [
+                {
+                    value: '361',
+                    script: { length: 23 },
+                },
+            ],
+            fee: 9639,
+        },
+    },
+    {
+        description: 'p2sh to p2sh spending dust with lowest feeRate (no explicit dustThreshold)',
+        txType: 'p2sh',
+        feeRate: 1,
+        inputs: [
+            {
+                script: { length: 107 }, // INPUT_SCRIPT_LENGTH.p2sh
+                value: '546',
+            },
+        ],
+        outputs: [{ script: { length: 23 } }], // OUTPUT_SCRIPT_LENGTH.p2sh
+        expected: {
+            inputs: [
+                {
+                    i: 0,
+                    value: '546',
+                    script: { length: 107 },
+                },
+            ],
+            outputs: [
+                {
+                    value: '357',
+                    script: { length: 23 },
+                },
+            ],
+            fee: 189,
+        },
+    },
+    {
+        description:
+            'p2wpkh to p2wpkh with high feeRate and explicit longTermFeeRate (max output > dustThreshold 546)',
+        txType: 'p2wpkh',
+        feeRate: 50,
+        longTermFeeRate: 4,
+        dustThreshold: 546,
+        inputs: [
+            {
+                script: { length: 107 }, // INPUT_SCRIPT_LENGTH.p2wpkh
+                value: '10000',
+            },
+        ],
+        outputs: [{ script: { length: 22 } }], // OUTPUT_SCRIPT_LENGTH.p2wpkh
+        expected: {
+            inputs: [
+                {
+                    i: 0,
+                    value: '10000',
+                    script: { length: 107 },
+                },
+            ],
+            outputs: [
+                {
+                    value: '600',
+                    script: { length: 22 },
+                },
+            ],
+            fee: 9400,
+        },
+    },
+    {
+        description:
+            'p2wpkh to p2wpkh with high feeRate, no explicit dustThreshold, dust amount calculated from inputSize (max output > 58 * 3)',
+        txType: 'p2wpkh',
+        feeRate: 51,
+        inputs: [
+            {
+                script: { length: 107 }, // INPUT_SCRIPT_LENGTH.p2wpkh
+                value: '10000',
+            },
+        ],
+        outputs: [{ script: { length: 22 } }], // OUTPUT_SCRIPT_LENGTH.p2wpkh
+        expected: {
+            inputs: [
+                {
+                    i: 0,
+                    value: '10000',
+                    script: { length: 107 },
+                },
+            ],
+            outputs: [
+                {
+                    value: '412',
+                    script: { length: 22 },
+                },
+            ],
+            fee: 9588,
+        },
+    },
+    {
+        description:
+            'p2wpkh to p2wpkh spending dust with lowest feeRate (no explicit dustThreshold)',
+        txType: 'p2wpkh',
+        feeRate: 1,
+        inputs: [
+            {
+                script: { length: 107 }, // INPUT_SCRIPT_LENGTH.p2wpkh
+                value: '546',
+            },
+        ],
+        outputs: [{ script: { length: 22 } }], // OUTPUT_SCRIPT_LENGTH.p2wpkh
+        expected: {
+            inputs: [
+                {
+                    i: 0,
+                    value: '546',
+                    script: { length: 107 },
+                },
+            ],
+            outputs: [
+                {
+                    value: '358',
+                    script: { length: 22 },
+                },
+            ],
+            fee: 188,
+        },
+    },
+    {
+        description:
+            'p2tr to p2tr with high feeRate and explicit longTermFeeRate (max output > dustThreshold 546)',
+        txType: 'p2tr',
+        feeRate: 59,
+        longTermFeeRate: 4,
+        dustThreshold: 546,
+        inputs: [
+            {
+                script: { length: 65 }, // INPUT_SCRIPT_LENGTH.p2tr
+                value: '10000',
+            },
+        ],
+        outputs: [{ script: { length: 34 } }], // OUTPUT_SCRIPT_LENGTH.p2tr
+        expected: {
+            inputs: [
+                {
+                    i: 0,
+                    value: '10000',
+                    script: { length: 65 },
+                },
+            ],
+            outputs: [
+                {
+                    value: '678',
+                    script: { length: 34 },
+                },
+            ],
+            fee: 9322,
+        },
+    },
+    {
+        description:
+            'p2tr to p2tr with high feeRate, no explicit dustThreshold, dust amount calculated from inputSize (max output > 68 * 3)',
+        txType: 'p2tr',
+        feeRate: 61,
+        inputs: [
+            {
+                script: { length: 65 }, // INPUT_SCRIPT_LENGTH.p2tr
+                value: '10000',
+            },
+        ],
+        outputs: [{ script: { length: 34 } }], // OUTPUT_SCRIPT_LENGTH.p2tr
+        expected: {
+            inputs: [
+                {
+                    i: 0,
+                    value: '10000',
+                    script: { length: 65 },
+                },
+            ],
+            outputs: [
+                {
+                    value: '362',
+                    script: { length: 34 },
+                },
+            ],
+            fee: 9638,
+        },
+    },
+    {
+        description: 'p2tr to p2tr spending dust with lowest feeRate (no explicit dustThreshold)',
+        txType: 'p2tr',
+        feeRate: 1,
+        inputs: [
+            {
+                script: { length: 65 }, // INPUT_SCRIPT_LENGTH.p2tr
+                value: '546',
+            },
+        ],
+        outputs: [{ script: { length: 34 } }], // OUTPUT_SCRIPT_LENGTH.p2tr
+        expected: {
+            inputs: [
+                {
+                    i: 0,
+                    script: { length: 65 },
+                    value: '546',
+                },
+            ],
+            outputs: [
+                {
+                    value: '388',
+                    script: { length: 34 },
+                },
+            ],
+            fee: 158,
+        },
     },
 ];

--- a/packages/utxo-lib/tests/__fixtures__/compose.crosscheck.ts
+++ b/packages/utxo-lib/tests/__fixtures__/compose.crosscheck.ts
@@ -17,7 +17,7 @@ export default [
                     own: true,
                     transactionHash: 'b4dc0ffeee',
                     tsize: 0,
-                    value: '102300',
+                    value: 'replace-me',
                     vsize: 0,
                 },
             ],

--- a/packages/utxo-lib/tests/__fixtures__/compose.ts
+++ b/packages/utxo-lib/tests/__fixtures__/compose.ts
@@ -1136,11 +1136,11 @@ export default [
         },
     },
     {
-        description: 'builds a simple tx without change (recv bech32/p2wpkh)',
+        description: 'builds bech32/p2wpkh tx without change (drop dust)',
         request: {
             txType: 'p2wpkh',
             basePath: [84, 0, 1],
-            changeAddress: '1CrwjoKxvdbAnPcGzYjpvZ4no4S71neKXT',
+            changeAddress: 'bc1qafk4yhqvj4wep57m62dgrmutldusqde8adh20d',
             changeId: 0,
             dustThreshold: 546,
             feeRate: '10',
@@ -1161,17 +1161,17 @@ export default [
                     own: true,
                     transactionHash: 'b4dc0ffeee',
                     tsize: 0,
-                    value: '102001',
+                    value: '101500',
                     vsize: 0,
                 },
             ],
         },
         result: {
             bytes: 110,
-            fee: '2001',
-            feePerByte: '18.19090909090909',
+            fee: '1500',
+            feePerByte: '13.636363636363637',
             max: undefined,
-            totalSpent: '102001',
+            totalSpent: '101500',
             transaction: {
                 PERM_outputs: {
                     permutation: [0],
@@ -1187,7 +1187,7 @@ export default [
                         REV_hash: 'b4dc0ffeee',
                         index: 0,
                         path: [84, 0, 1, 3, 4],
-                        amount: '102001',
+                        amount: '101500',
                     },
                 ],
             },
@@ -1195,17 +1195,19 @@ export default [
         },
     },
     {
-        description: 'builds a simple tx without change (recv p2sh)',
+        description:
+            'builds bech32/p2wpkh tx, no explicit dustThreshold (change above calculated dust)',
         request: {
-            basePath: [44, 1],
-            changeAddress: '1CrwjoKxvdbAnPcGzYjpvZ4no4S71neKXT',
+            txType: 'p2wpkh',
+            basePath: [84, 0, 1],
+            changeAddress: 'bc1qafk4yhqvj4wep57m62dgrmutldusqde8adh20d',
             changeId: 0,
-            dustThreshold: 546,
+            dustThreshold: 0,
             feeRate: '10',
             height: 100,
             outputs: [
                 {
-                    address: '3NukJ6fYZJ5Kk8bPjycAnruZkE5Q7UW7i8',
+                    address: 'bc1qar0srrr7xfkvy5l643lydnw9re59gtzzwf5mdq',
                     amount: '100000',
                     type: 'complete',
                 },
@@ -1219,17 +1221,80 @@ export default [
                     own: true,
                     transactionHash: 'b4dc0ffeee',
                     tsize: 0,
-                    value: '102001',
+                    value: '101900',
                     vsize: 0,
                 },
             ],
         },
         result: {
-            bytes: 190,
-            fee: '2001',
-            feePerByte: '10.531578947368422',
+            bytes: 141,
+            fee: '1410',
+            feePerByte: '10',
             max: undefined,
-            totalSpent: '102001',
+            totalSpent: '101410',
+            transaction: {
+                PERM_outputs: {
+                    permutation: [1, 0],
+                    sorted: [
+                        {
+                            path: [84, 0, 1, 1, 0],
+                            value: '490',
+                        },
+                        {
+                            address: 'bc1qar0srrr7xfkvy5l643lydnw9re59gtzzwf5mdq',
+                            value: '100000',
+                        },
+                    ],
+                },
+                inputs: [
+                    {
+                        REV_hash: 'b4dc0ffeee',
+                        index: 0,
+                        path: [84, 0, 1, 3, 4],
+                        amount: '101900',
+                    },
+                ],
+            },
+            type: 'final',
+        },
+    },
+    {
+        description: 'builds Legacy Segwit/p2sh tx without change (drop dust)',
+        request: {
+            txType: 'p2sh',
+            basePath: [49, 0, 0],
+            changeAddress: '3LRW7jeCvQCRdPF8S3yUCfRAx4eqXFmdcr',
+            changeId: 0,
+            dustThreshold: 546,
+            feeRate: '10',
+            height: 100,
+            outputs: [
+                {
+                    address: '3NukJ6fYZJ5Kk8bPjycAnruZkE5Q7UW7i8',
+                    amount: '100000',
+                    type: 'complete',
+                },
+            ],
+            utxos: [
+                {
+                    addressPath: [1, 4],
+                    coinbase: false,
+                    height: 100,
+                    index: 0,
+                    own: true,
+                    transactionHash: 'b4dc0ffeee',
+                    tsize: 0,
+                    value: '101500',
+                    vsize: 0,
+                },
+            ],
+        },
+        result: {
+            bytes: 134,
+            fee: '1500',
+            feePerByte: '11.194029850746269',
+            max: undefined,
+            totalSpent: '101500',
             transaction: {
                 PERM_outputs: {
                     permutation: [0],
@@ -1244,8 +1309,8 @@ export default [
                     {
                         REV_hash: 'b4dc0ffeee',
                         index: 0,
-                        path: [44, 1, 3, 4],
-                        amount: '102001',
+                        path: [49, 0, 0, 1, 4],
+                        amount: '101500',
                     },
                 ],
             },
@@ -1253,48 +1318,53 @@ export default [
         },
     },
     {
-        description: 'builds a simple tx without change (recv bech32/p2tr)',
+        description:
+            'builds Legacy Segwit/p2sh tx, no explicit dustThreshold (change above calculated dust)',
         request: {
-            basePath: [44, 1],
-            changeAddress: '1CrwjoKxvdbAnPcGzYjpvZ4no4S71neKXT',
+            txType: 'p2sh',
+            basePath: [49, 0, 0],
+            changeAddress: '3LRW7jeCvQCRdPF8S3yUCfRAx4eqXFmdcr',
             changeId: 0,
-            dustThreshold: 546,
+            dustThreshold: 0,
             feeRate: '10',
             height: 100,
             outputs: [
                 {
-                    address: 'bc1qc7slrfxkknqcq2jevvvkdgvrt8080852dfjewde450xdlk4ugp7szw5tk9',
+                    address: '3NukJ6fYZJ5Kk8bPjycAnruZkE5Q7UW7i8',
                     amount: '100000',
                     type: 'complete',
                 },
             ],
             utxos: [
                 {
-                    addressPath: [3, 4],
+                    addressPath: [1, 4],
                     coinbase: false,
                     height: 100,
                     index: 0,
                     own: true,
                     transactionHash: 'b4dc0ffeee',
                     tsize: 0,
-                    value: '103001',
+                    value: '102000',
                     vsize: 0,
                 },
             ],
         },
         result: {
-            bytes: 201,
-            fee: '3001',
-            feePerByte: '14.930348258706468',
+            bytes: 166,
+            fee: '1660',
+            feePerByte: '10',
             max: undefined,
-            totalSpent: '103001',
+            totalSpent: '101660',
             transaction: {
                 PERM_outputs: {
-                    permutation: [0],
+                    permutation: [1, 0],
                     sorted: [
                         {
-                            address:
-                                'bc1qc7slrfxkknqcq2jevvvkdgvrt8080852dfjewde450xdlk4ugp7szw5tk9',
+                            path: [49, 0, 0, 1, 0],
+                            value: '340',
+                        },
+                        {
+                            address: '3NukJ6fYZJ5Kk8bPjycAnruZkE5Q7UW7i8',
                             value: '100000',
                         },
                     ],
@@ -1303,8 +1373,133 @@ export default [
                     {
                         REV_hash: 'b4dc0ffeee',
                         index: 0,
-                        path: [44, 1, 3, 4],
-                        amount: '103001',
+                        path: [49, 0, 0, 1, 4],
+                        amount: '102000',
+                    },
+                ],
+            },
+            type: 'final',
+        },
+    },
+    {
+        description: 'builds taproot/p2tr tx without change (drop dust)',
+        request: {
+            txType: 'p2tr',
+            basePath: [86, 0, 0],
+            changeAddress: 'bc1pgypgja2hmcx2l6s2ssq75k6ev68ved6nujcspt47dgvkp8euc70s6uegk6',
+            changeId: 0,
+            dustThreshold: 546,
+            feeRate: '10',
+            height: 100,
+            outputs: [
+                {
+                    address: 'bc1ptxs597p3fnpd8gwut5p467ulsydae3rp9z75hd99w8k3ljr9g9rqx6ynaw',
+                    amount: '100000',
+                    type: 'complete',
+                },
+            ],
+            utxos: [
+                {
+                    addressPath: [0, 1],
+                    coinbase: false,
+                    height: 100,
+                    index: 0,
+                    own: true,
+                    transactionHash: 'b4dc0ffeee',
+                    tsize: 0,
+                    value: '101500',
+                    vsize: 0,
+                },
+            ],
+        },
+        result: {
+            bytes: 111,
+            fee: '1500',
+            feePerByte: '13.513513513513514',
+            max: undefined,
+            totalSpent: '101500',
+            transaction: {
+                PERM_outputs: {
+                    permutation: [0],
+                    sorted: [
+                        {
+                            address:
+                                'bc1ptxs597p3fnpd8gwut5p467ulsydae3rp9z75hd99w8k3ljr9g9rqx6ynaw',
+                            value: '100000',
+                        },
+                    ],
+                },
+                inputs: [
+                    {
+                        REV_hash: 'b4dc0ffeee',
+                        index: 0,
+                        path: [86, 0, 0, 0, 1],
+                        amount: '101500',
+                    },
+                ],
+            },
+            type: 'final',
+        },
+    },
+    {
+        description:
+            'builds taproot/p2tr tx, no explicit dustThreshold (change above calculated dust)',
+        request: {
+            txType: 'p2tr',
+            basePath: [86, 0, 0],
+            changeAddress: 'bc1pgypgja2hmcx2l6s2ssq75k6ev68ved6nujcspt47dgvkp8euc70s6uegk6',
+            changeId: 0,
+            dustThreshold: 0,
+            feeRate: '10',
+            height: 100,
+            outputs: [
+                {
+                    address: 'bc1ptxs597p3fnpd8gwut5p467ulsydae3rp9z75hd99w8k3ljr9g9rqx6ynaw',
+                    amount: '100000',
+                    type: 'complete',
+                },
+            ],
+            utxos: [
+                {
+                    addressPath: [0, 1],
+                    coinbase: false,
+                    height: 100,
+                    index: 0,
+                    own: true,
+                    transactionHash: 'b4dc0ffeee',
+                    tsize: 0,
+                    value: '102000',
+                    vsize: 0,
+                },
+            ],
+        },
+        result: {
+            bytes: 154,
+            fee: '1540',
+            feePerByte: '10',
+            max: undefined,
+            totalSpent: '101540',
+            transaction: {
+                PERM_outputs: {
+                    permutation: [1, 0],
+                    sorted: [
+                        {
+                            path: [86, 0, 0, 1, 0],
+                            value: '460',
+                        },
+                        {
+                            address:
+                                'bc1ptxs597p3fnpd8gwut5p467ulsydae3rp9z75hd99w8k3ljr9g9rqx6ynaw',
+                            value: '100000',
+                        },
+                    ],
+                },
+                inputs: [
+                    {
+                        REV_hash: 'b4dc0ffeee',
+                        index: 0,
+                        path: [86, 0, 0, 0, 1],
+                        amount: '102000',
                     },
                 ],
             },

--- a/packages/utxo-lib/tests/coinselect/accumulative.test.ts
+++ b/packages/utxo-lib/tests/coinselect/accumulative.test.ts
@@ -1,6 +1,7 @@
 import { accumulative } from '../../src/coinselect/inputs/accumulative';
 import fixtures from '../__fixtures__/coinselect/accumulative';
 import * as utils from './test.utils';
+import { CoinSelectOptions } from '../../src/types';
 
 describe('coinselect: accumulative', () => {
     fixtures.forEach(f => {
@@ -9,23 +10,18 @@ describe('coinselect: accumulative', () => {
             const outputs = utils.expand(f.outputs as any, false);
             const expected = utils.addScriptLengthToExpected(f.expected);
             const options = {
-                txType: 'p2pkh',
+                txType: f.txType || 'p2pkh',
                 dustThreshold: f.dustThreshold,
                 baseFee: f.baseFee,
                 floorBaseFee: f.floorBaseFee,
                 dustOutputFee: f.dustOutputFee,
-            } as const;
+            } as CoinSelectOptions;
 
-            const actual = accumulative(inputs, outputs, f.feeRate as any, options);
-
+            const actual = accumulative(inputs, outputs, f.feeRate, options);
             expect(actual).toEqual(expected);
+
             if (actual.inputs) {
-                const feedback = accumulative(
-                    actual.inputs,
-                    actual.outputs,
-                    f.feeRate as any,
-                    options,
-                );
+                const feedback = accumulative(actual.inputs, actual.outputs, f.feeRate, options);
                 expect(feedback).toEqual(expected);
             }
         });

--- a/packages/utxo-lib/tests/coinselect/bnb.test.ts
+++ b/packages/utxo-lib/tests/coinselect/bnb.test.ts
@@ -1,6 +1,7 @@
 import { bnb } from '../../src/coinselect/inputs/bnb';
 import fixtures from '../__fixtures__/coinselect/bnb';
 import * as utils from './test.utils';
+import { CoinSelectOptions } from '../../src/types';
 
 describe('coinselect: branchAndBound (bnb)', () => {
     fixtures.forEach(f => {
@@ -11,12 +12,13 @@ describe('coinselect: branchAndBound (bnb)', () => {
             const options = {
                 txType: 'p2pkh',
                 dustThreshold: f.dustThreshold,
-            } as const;
+            } as CoinSelectOptions;
 
-            const actual = bnb(f.factor)(inputs, outputs, f.feeRate, options);
+            const actual = bnb(inputs, outputs, f.feeRate, options);
             expect(actual).toEqual(expected);
+
             if (actual.inputs) {
-                const feedback = bnb(f.factor)(actual.inputs, actual.outputs, f.feeRate, options);
+                const feedback = bnb(actual.inputs, actual.outputs, f.feeRate, options);
                 expect(feedback).toEqual(expected);
             }
         });

--- a/packages/utxo-lib/tests/coinselect/split.test.ts
+++ b/packages/utxo-lib/tests/coinselect/split.test.ts
@@ -1,6 +1,7 @@
 import { split } from '../../src/coinselect/outputs/split';
 import fixtures from '../__fixtures__/coinselect/split';
 import * as utils from './test.utils';
+import { CoinSelectOptions } from '../../src/types';
 
 describe('coinselect split', () => {
     fixtures.forEach(f => {
@@ -9,16 +10,18 @@ describe('coinselect split', () => {
             const outputs = utils.expand(f.outputs as any, false);
             const expected = utils.addScriptLengthToExpected(f.expected);
             const options = {
-                txType: 'p2pkh',
+                txType: f.txType || 'p2pkh',
                 dustThreshold: f.dustThreshold,
                 baseFee: f.baseFee,
                 floorBaseFee: f.floorBaseFee,
                 dustOutputFee: f.dustOutputFee,
-            } as const;
-            const actual = split(inputs, outputs, f.feeRate as number, options);
+            } as CoinSelectOptions;
+
+            const actual = split(inputs, outputs, f.feeRate, options);
             expect(actual).toEqual(expected);
+
             if (actual.inputs) {
-                const feedback = split(actual.inputs, actual.outputs, f.feeRate as number, options);
+                const feedback = split(actual.inputs, actual.outputs, f.feeRate, options);
                 expect(feedback).toEqual(expected);
             }
         });

--- a/packages/utxo-lib/tests/compose.test.ts
+++ b/packages/utxo-lib/tests/compose.test.ts
@@ -56,6 +56,13 @@ describe('composeTx addresses cross-check', () => {
         p2wpkh: 'bc1qafk4yhqvj4wep57m62dgrmutldusqde8adh20d',
         p2wsh: 'bc1q6rgl33d3s9dugudw7n68yrryajkr3ha9q8q24j20zs62se4q9tsqdy0t2q',
     };
+    const amounts = {
+        p2pkh: '102300',
+        p2sh: '101500',
+        p2tr: '101500',
+        p2wpkh: '101500',
+        p2wsh: '101500',
+    };
     const addrKeys = Object.keys(addrTypes) as Array<keyof typeof addrTypes>;
     fixturesCrossCheck.forEach(f => {
         txTypes.forEach(txType => {
@@ -71,7 +78,10 @@ describe('composeTx addresses cross-check', () => {
                         ...f.request,
                         network: NETWORKS.bitcoin,
                         txType,
-                        changeType: 'PAYTOADDRESS',
+                        utxos: f.request.utxos.map(utxo => ({
+                            ...utxo,
+                            value: utxo.value === 'replace-me' ? amounts[txType] : utxo.value,
+                        })),
                         outputs: f.request.outputs.map(o => {
                             if (o.type === 'complete') {
                                 return {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

While working on RBF in coinjoin i have noticed unexpected behavior of @trezor/utxo-lib coinselect algorithms.
This issue affects sending small amounts (like few thousand sats) while using high fee rate.

Examples with simplified calculations:

Fee for tx sent from `p2pkh` (legacy) accounts following [transactionWeight calculation](https://github.com/trezor/trezor-suite/blob/develop/packages/utxo-lib/src/coinselect/utils.ts#L83-L94) formula
```
1 input + 1 output:
txWeight = 32 + 4 + (160 + (4 * 108)) + 4 + (4 * (8 + 1 + 25)) = 768
txBytes = Math.ceil(txWeight / 4) = 192

1 input + 1 output + 1 change:
txWeight = 32 + 4 + (160 + (4 * 108)) + 4 + ((4 * (8 + 1 + 25)) * 2) = 904
txBytes = Math.ceil(txWeight / 4) = 226
```

1. on your `p2pkh` account you have one utxo worth 8000 sats and trying to "send max" to a different account with fee rate `30`
fee calculation: 192 bytes * 20 => 5760 sats
therefore you should still be able to send 2240 sats but since dust threshold is also multiplied by 40 send from will throw "not enough funds" (2240 < 5760)

2. similar scenario but this time you want to send 5000 sats at fee rate `10`
fee calculation:192 bytes * 10 => 1920 sats
fee with change output: 226 * 10 = 2260 sats
your change output should be: 8000 - 5000 - 2260 = `740` sats which is greater than dustLimit specified in coins.json (546) but since dust threshold is also multiplied by 10 this change is dropped as fee (740 < 1920)

this math is different of each script types (account types) used in suite but the results are always the same (wrong)
```
p2sh: 1 to 1 = 134 bytes; 1 to 2 = 166 bytes
p2tr: 1 to 1 = 111 bytes; 1 to 2 = 154 bytes
p2wpkh: 1 to 1 = 110 bytes; 1 to 2 = 141 bytes
```
