### PR TITLE
chore(ci): optimize repository fetching in gitlab CI

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -7,6 +7,7 @@ variables:
   STAGING_SUITE_SERVER_URL: "https://staging-suite.trezor.io"
   DESKTOP_APP_NAME: "Trezor-Suite"
   GIT_CLEAN_FLAGS: "-ffdx -e .yarn"
+  GIT_DEPTH: 20
 
 stages:
   - setup environment

--- a/ci/releases.yml
+++ b/ci/releases.yml
@@ -80,6 +80,8 @@ release commit messages:
     refs:
       - /^release\//
       - codesign
+  variables:
+    GIT_DEPTH: 300
   script:
     - ci/scripts/check_release_commit_messages.sh
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Default is 50. This is the reason why `release commit messages` job is usually passing locally but failing on CI 🤦‍♂️ 

- Set default GIT_DEPTH to 20,  almost no job needs any history but as we use retry and jobs queue we can't put it on 1.
- Set higher number for the only (I hope) job that needs it.


