### PR TITLE
fix(coinjoin): CoinjoinBackend checkpoint(s) read-only

### DIFF
--- a/packages/coinjoin/src/backend/scanAccount.ts
+++ b/packages/coinjoin/src/backend/scanAccount.ts
@@ -37,7 +37,7 @@ export const scanAccount = async (
 
     const addresses = new CoinjoinAddressController(xpub, network, checkpoints[0], params.cache);
 
-    let checkpoint = checkpoints[0];
+    let [checkpoint] = checkpoints;
     const checkpointCooldown = createCooldown(CHECKPOINT_COOLDOWN);
 
     const txs = new Set<BlockbookTransaction>();
@@ -90,8 +90,11 @@ export const scanAccount = async (
             pending = mempool.getTransactions(addresses).map(transformTx(xpub, addresses));
         }
 
-        checkpoint.receiveCount = addresses.receive.length;
-        checkpoint.changeCount = addresses.change.length;
+        checkpoint = {
+            ...checkpoint,
+            receiveCount: addresses.receive.length,
+            changeCount: addresses.change.length,
+        };
     }
 
     const cache = {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

After removing [build:lib from coinjoin package](https://github.com/trezor/trezor-suite/commit/0a5d8267c4fee09a78dd7e6dd9ce366c7af63840) discovery on web build (scanAccount) start throwing errors regarding trying to write to read-only objects.
idk what kind of magic is that - it works with transpiled code from `lib` but it's not working with the code from `src` 🤷

```
TypeError: Cannot assign to read only property 'receiveCount' of object '#<Object>'
    at scanAccount (scanAccount.ts:93:32)
    at async eval (coinjoinAccountActions.ts:465:52)
```

are you aware of any other params sent to `CoinjoinBackend` which might throw similar error @marekrjpolak ?





