### PR TITLE
chore: protobuf update

### DIFF
--- a/packages/protobuf/messages.json
+++ b/packages/protobuf/messages.json
@@ -2495,6 +2495,11 @@
             },
             "nested": {
                 "ButtonRequestType": {
+                    "valuesOptions": {
+                        "_Deprecated_ButtonRequest_PassphraseType": {
+                            "deprecated": true
+                        }
+                    },
                     "values": {
                         "ButtonRequest_Other": 1,
                         "ButtonRequest_FeeOverThreshold": 2,
@@ -4456,6 +4461,26 @@
                 "Capability": {
                     "options": {
                         "(has_bitcoin_only_values)": true
+                    },
+                    "valuesOptions": {
+                        "Capability_Bitcoin": {
+                            "(bitcoin_only)": true
+                        },
+                        "Capability_Crypto": {
+                            "(bitcoin_only)": true
+                        },
+                        "Capability_Lisk": {
+                            "deprecated": true
+                        },
+                        "Capability_Shamir": {
+                            "(bitcoin_only)": true
+                        },
+                        "Capability_ShamirGroups": {
+                            "(bitcoin_only)": true
+                        },
+                        "Capability_PassphraseEntry": {
+                            "(bitcoin_only)": true
+                        }
                     },
                     "values": {
                         "Capability_Bitcoin": 1,
@@ -7423,6 +7448,802 @@
         "MessageType": {
             "options": {
                 "(has_bitcoin_only_values)": true
+            },
+            "valuesOptions": {
+                "MessageType_Initialize": {
+                    "(bitcoin_only)": true,
+                    "(wire_in)": true,
+                    "(wire_tiny)": true
+                },
+                "MessageType_Ping": {
+                    "(bitcoin_only)": true,
+                    "(wire_in)": true
+                },
+                "MessageType_Success": {
+                    "(bitcoin_only)": true,
+                    "(wire_out)": true,
+                    "(wire_debug_out)": true
+                },
+                "MessageType_Failure": {
+                    "(bitcoin_only)": true,
+                    "(wire_out)": true,
+                    "(wire_debug_out)": true
+                },
+                "MessageType_ChangePin": {
+                    "(bitcoin_only)": true,
+                    "(wire_in)": true
+                },
+                "MessageType_WipeDevice": {
+                    "(bitcoin_only)": true,
+                    "(wire_in)": true
+                },
+                "MessageType_GetEntropy": {
+                    "(bitcoin_only)": true,
+                    "(wire_in)": true
+                },
+                "MessageType_Entropy": {
+                    "(bitcoin_only)": true,
+                    "(wire_out)": true
+                },
+                "MessageType_LoadDevice": {
+                    "(bitcoin_only)": true,
+                    "(wire_in)": true
+                },
+                "MessageType_ResetDevice": {
+                    "(bitcoin_only)": true,
+                    "(wire_in)": true
+                },
+                "MessageType_SetBusy": {
+                    "(bitcoin_only)": true,
+                    "(wire_in)": true
+                },
+                "MessageType_Features": {
+                    "(bitcoin_only)": true,
+                    "(wire_out)": true
+                },
+                "MessageType_PinMatrixRequest": {
+                    "(bitcoin_only)": true,
+                    "(wire_out)": true
+                },
+                "MessageType_PinMatrixAck": {
+                    "(bitcoin_only)": true,
+                    "(wire_in)": true,
+                    "(wire_tiny)": true,
+                    "(wire_no_fsm)": true
+                },
+                "MessageType_Cancel": {
+                    "(bitcoin_only)": true,
+                    "(wire_in)": true,
+                    "(wire_tiny)": true
+                },
+                "MessageType_LockDevice": {
+                    "(bitcoin_only)": true,
+                    "(wire_in)": true
+                },
+                "MessageType_ApplySettings": {
+                    "(bitcoin_only)": true,
+                    "(wire_in)": true
+                },
+                "MessageType_ButtonRequest": {
+                    "(bitcoin_only)": true,
+                    "(wire_out)": true
+                },
+                "MessageType_ButtonAck": {
+                    "(bitcoin_only)": true,
+                    "(wire_in)": true,
+                    "(wire_tiny)": true,
+                    "(wire_no_fsm)": true
+                },
+                "MessageType_ApplyFlags": {
+                    "(bitcoin_only)": true,
+                    "(wire_in)": true
+                },
+                "MessageType_GetNonce": {
+                    "(bitcoin_only)": true,
+                    "(wire_in)": true
+                },
+                "MessageType_Nonce": {
+                    "(bitcoin_only)": true,
+                    "(wire_out)": true
+                },
+                "MessageType_BackupDevice": {
+                    "(bitcoin_only)": true,
+                    "(wire_in)": true
+                },
+                "MessageType_EntropyRequest": {
+                    "(bitcoin_only)": true,
+                    "(wire_out)": true
+                },
+                "MessageType_EntropyAck": {
+                    "(bitcoin_only)": true,
+                    "(wire_in)": true
+                },
+                "MessageType_PassphraseRequest": {
+                    "(bitcoin_only)": true,
+                    "(wire_out)": true
+                },
+                "MessageType_PassphraseAck": {
+                    "(bitcoin_only)": true,
+                    "(wire_in)": true,
+                    "(wire_tiny)": true,
+                    "(wire_no_fsm)": true
+                },
+                "MessageType_RecoveryDevice": {
+                    "(bitcoin_only)": true,
+                    "(wire_in)": true
+                },
+                "MessageType_WordRequest": {
+                    "(bitcoin_only)": true,
+                    "(wire_out)": true
+                },
+                "MessageType_WordAck": {
+                    "(bitcoin_only)": true,
+                    "(wire_in)": true
+                },
+                "MessageType_GetFeatures": {
+                    "(bitcoin_only)": true,
+                    "(wire_in)": true
+                },
+                "MessageType_SdProtect": {
+                    "(bitcoin_only)": true,
+                    "(wire_in)": true
+                },
+                "MessageType_ChangeWipeCode": {
+                    "(bitcoin_only)": true,
+                    "(wire_in)": true
+                },
+                "MessageType_EndSession": {
+                    "(bitcoin_only)": true,
+                    "(wire_in)": true
+                },
+                "MessageType_DoPreauthorized": {
+                    "(bitcoin_only)": true,
+                    "(wire_in)": true
+                },
+                "MessageType_PreauthorizedRequest": {
+                    "(bitcoin_only)": true,
+                    "(wire_out)": true
+                },
+                "MessageType_CancelAuthorization": {
+                    "(bitcoin_only)": true,
+                    "(wire_in)": true
+                },
+                "MessageType_RebootToBootloader": {
+                    "(bitcoin_only)": true,
+                    "(wire_in)": true
+                },
+                "MessageType_GetFirmwareHash": {
+                    "(bitcoin_only)": true,
+                    "(wire_in)": true
+                },
+                "MessageType_FirmwareHash": {
+                    "(bitcoin_only)": true,
+                    "(wire_out)": true
+                },
+                "MessageType_UnlockPath": {
+                    "(bitcoin_only)": true,
+                    "(wire_in)": true
+                },
+                "MessageType_UnlockedPathRequest": {
+                    "(bitcoin_only)": true,
+                    "(wire_out)": true
+                },
+                "MessageType_ShowDeviceTutorial": {
+                    "(bitcoin_only)": true,
+                    "(wire_in)": true
+                },
+                "MessageType_SetU2FCounter": {
+                    "(wire_in)": true
+                },
+                "MessageType_GetNextU2FCounter": {
+                    "(wire_in)": true
+                },
+                "MessageType_NextU2FCounter": {
+                    "(wire_out)": true
+                },
+                "MessageType_Deprecated_PassphraseStateRequest": {
+                    "deprecated": true
+                },
+                "MessageType_Deprecated_PassphraseStateAck": {
+                    "deprecated": true
+                },
+                "MessageType_FirmwareErase": {
+                    "(bitcoin_only)": true,
+                    "(wire_in)": true,
+                    "(wire_bootloader)": true
+                },
+                "MessageType_FirmwareUpload": {
+                    "(bitcoin_only)": true,
+                    "(wire_in)": true,
+                    "(wire_bootloader)": true
+                },
+                "MessageType_FirmwareRequest": {
+                    "(bitcoin_only)": true,
+                    "(wire_out)": true,
+                    "(wire_bootloader)": true
+                },
+                "MessageType_SelfTest": {
+                    "(bitcoin_only)": true,
+                    "(wire_in)": true,
+                    "(wire_bootloader)": true
+                },
+                "MessageType_GetPublicKey": {
+                    "(bitcoin_only)": true,
+                    "(wire_in)": true
+                },
+                "MessageType_PublicKey": {
+                    "(bitcoin_only)": true,
+                    "(wire_out)": true
+                },
+                "MessageType_SignTx": {
+                    "(bitcoin_only)": true,
+                    "(wire_in)": true
+                },
+                "MessageType_TxRequest": {
+                    "(bitcoin_only)": true,
+                    "(wire_out)": true
+                },
+                "MessageType_TxAck": {
+                    "(bitcoin_only)": true,
+                    "(wire_in)": true
+                },
+                "MessageType_GetAddress": {
+                    "(bitcoin_only)": true,
+                    "(wire_in)": true
+                },
+                "MessageType_Address": {
+                    "(bitcoin_only)": true,
+                    "(wire_out)": true
+                },
+                "MessageType_TxAckPaymentRequest": {
+                    "(wire_in)": true
+                },
+                "MessageType_SignMessage": {
+                    "(bitcoin_only)": true,
+                    "(wire_in)": true
+                },
+                "MessageType_VerifyMessage": {
+                    "(bitcoin_only)": true,
+                    "(wire_in)": true
+                },
+                "MessageType_MessageSignature": {
+                    "(bitcoin_only)": true,
+                    "(wire_out)": true
+                },
+                "MessageType_GetOwnershipId": {
+                    "(bitcoin_only)": true,
+                    "(wire_in)": true
+                },
+                "MessageType_OwnershipId": {
+                    "(bitcoin_only)": true,
+                    "(wire_out)": true
+                },
+                "MessageType_GetOwnershipProof": {
+                    "(bitcoin_only)": true,
+                    "(wire_in)": true
+                },
+                "MessageType_OwnershipProof": {
+                    "(bitcoin_only)": true,
+                    "(wire_out)": true
+                },
+                "MessageType_AuthorizeCoinJoin": {
+                    "(bitcoin_only)": true,
+                    "(wire_in)": true
+                },
+                "MessageType_CipherKeyValue": {
+                    "(bitcoin_only)": true,
+                    "(wire_in)": true
+                },
+                "MessageType_CipheredKeyValue": {
+                    "(bitcoin_only)": true,
+                    "(wire_out)": true
+                },
+                "MessageType_SignIdentity": {
+                    "(bitcoin_only)": true,
+                    "(wire_in)": true
+                },
+                "MessageType_SignedIdentity": {
+                    "(bitcoin_only)": true,
+                    "(wire_out)": true
+                },
+                "MessageType_GetECDHSessionKey": {
+                    "(bitcoin_only)": true,
+                    "(wire_in)": true
+                },
+                "MessageType_ECDHSessionKey": {
+                    "(bitcoin_only)": true,
+                    "(wire_out)": true
+                },
+                "MessageType_CosiCommit": {
+                    "(bitcoin_only)": true,
+                    "(wire_in)": true
+                },
+                "MessageType_CosiCommitment": {
+                    "(bitcoin_only)": true,
+                    "(wire_out)": true
+                },
+                "MessageType_CosiSign": {
+                    "(bitcoin_only)": true,
+                    "(wire_in)": true
+                },
+                "MessageType_CosiSignature": {
+                    "(bitcoin_only)": true,
+                    "(wire_out)": true
+                },
+                "MessageType_DebugLinkDecision": {
+                    "(bitcoin_only)": true,
+                    "(wire_debug_in)": true,
+                    "(wire_tiny)": true,
+                    "(wire_no_fsm)": true
+                },
+                "MessageType_DebugLinkGetState": {
+                    "(bitcoin_only)": true,
+                    "(wire_debug_in)": true,
+                    "(wire_tiny)": true
+                },
+                "MessageType_DebugLinkState": {
+                    "(bitcoin_only)": true,
+                    "(wire_debug_out)": true
+                },
+                "MessageType_DebugLinkStop": {
+                    "(bitcoin_only)": true,
+                    "(wire_debug_in)": true
+                },
+                "MessageType_DebugLinkLog": {
+                    "(bitcoin_only)": true,
+                    "(wire_debug_out)": true
+                },
+                "MessageType_DebugLinkMemoryRead": {
+                    "(bitcoin_only)": true,
+                    "(wire_debug_in)": true
+                },
+                "MessageType_DebugLinkMemory": {
+                    "(bitcoin_only)": true,
+                    "(wire_debug_out)": true
+                },
+                "MessageType_DebugLinkMemoryWrite": {
+                    "(bitcoin_only)": true,
+                    "(wire_debug_in)": true
+                },
+                "MessageType_DebugLinkFlashErase": {
+                    "(bitcoin_only)": true,
+                    "(wire_debug_in)": true
+                },
+                "MessageType_DebugLinkLayout": {
+                    "(bitcoin_only)": true,
+                    "(wire_debug_out)": true
+                },
+                "MessageType_DebugLinkReseedRandom": {
+                    "(bitcoin_only)": true,
+                    "(wire_debug_in)": true
+                },
+                "MessageType_DebugLinkRecordScreen": {
+                    "(bitcoin_only)": true,
+                    "(wire_debug_in)": true
+                },
+                "MessageType_DebugLinkEraseSdCard": {
+                    "(bitcoin_only)": true,
+                    "(wire_debug_in)": true
+                },
+                "MessageType_DebugLinkWatchLayout": {
+                    "(bitcoin_only)": true,
+                    "(wire_debug_in)": true
+                },
+                "MessageType_DebugLinkResetDebugEvents": {
+                    "(bitcoin_only)": true,
+                    "(wire_debug_in)": true
+                },
+                "MessageType_EthereumGetPublicKey": {
+                    "(wire_in)": true
+                },
+                "MessageType_EthereumPublicKey": {
+                    "(wire_out)": true
+                },
+                "MessageType_EthereumGetAddress": {
+                    "(wire_in)": true
+                },
+                "MessageType_EthereumAddress": {
+                    "(wire_out)": true
+                },
+                "MessageType_EthereumSignTx": {
+                    "(wire_in)": true
+                },
+                "MessageType_EthereumSignTxEIP1559": {
+                    "(wire_in)": true
+                },
+                "MessageType_EthereumTxRequest": {
+                    "(wire_out)": true
+                },
+                "MessageType_EthereumTxAck": {
+                    "(wire_in)": true
+                },
+                "MessageType_EthereumSignMessage": {
+                    "(wire_in)": true
+                },
+                "MessageType_EthereumVerifyMessage": {
+                    "(wire_in)": true
+                },
+                "MessageType_EthereumMessageSignature": {
+                    "(wire_out)": true
+                },
+                "MessageType_EthereumSignTypedData": {
+                    "(wire_in)": true
+                },
+                "MessageType_EthereumTypedDataStructRequest": {
+                    "(wire_out)": true
+                },
+                "MessageType_EthereumTypedDataStructAck": {
+                    "(wire_in)": true
+                },
+                "MessageType_EthereumTypedDataValueRequest": {
+                    "(wire_out)": true
+                },
+                "MessageType_EthereumTypedDataValueAck": {
+                    "(wire_in)": true
+                },
+                "MessageType_EthereumTypedDataSignature": {
+                    "(wire_out)": true
+                },
+                "MessageType_EthereumSignTypedHash": {
+                    "(wire_in)": true
+                },
+                "MessageType_NEMGetAddress": {
+                    "(wire_in)": true
+                },
+                "MessageType_NEMAddress": {
+                    "(wire_out)": true
+                },
+                "MessageType_NEMSignTx": {
+                    "(wire_in)": true
+                },
+                "MessageType_NEMSignedTx": {
+                    "(wire_out)": true
+                },
+                "MessageType_NEMDecryptMessage": {
+                    "(wire_in)": true
+                },
+                "MessageType_NEMDecryptedMessage": {
+                    "(wire_out)": true
+                },
+                "MessageType_TezosGetAddress": {
+                    "(wire_in)": true
+                },
+                "MessageType_TezosAddress": {
+                    "(wire_out)": true
+                },
+                "MessageType_TezosSignTx": {
+                    "(wire_in)": true
+                },
+                "MessageType_TezosSignedTx": {
+                    "(wire_out)": true
+                },
+                "MessageType_TezosGetPublicKey": {
+                    "(wire_in)": true
+                },
+                "MessageType_TezosPublicKey": {
+                    "(wire_out)": true
+                },
+                "MessageType_StellarSignTx": {
+                    "(wire_in)": true
+                },
+                "MessageType_StellarTxOpRequest": {
+                    "(wire_out)": true
+                },
+                "MessageType_StellarGetAddress": {
+                    "(wire_in)": true
+                },
+                "MessageType_StellarAddress": {
+                    "(wire_out)": true
+                },
+                "MessageType_StellarCreateAccountOp": {
+                    "(wire_in)": true
+                },
+                "MessageType_StellarPaymentOp": {
+                    "(wire_in)": true
+                },
+                "MessageType_StellarPathPaymentStrictReceiveOp": {
+                    "(wire_in)": true
+                },
+                "MessageType_StellarManageSellOfferOp": {
+                    "(wire_in)": true
+                },
+                "MessageType_StellarCreatePassiveSellOfferOp": {
+                    "(wire_in)": true
+                },
+                "MessageType_StellarSetOptionsOp": {
+                    "(wire_in)": true
+                },
+                "MessageType_StellarChangeTrustOp": {
+                    "(wire_in)": true
+                },
+                "MessageType_StellarAllowTrustOp": {
+                    "(wire_in)": true
+                },
+                "MessageType_StellarAccountMergeOp": {
+                    "(wire_in)": true
+                },
+                "MessageType_StellarManageDataOp": {
+                    "(wire_in)": true
+                },
+                "MessageType_StellarBumpSequenceOp": {
+                    "(wire_in)": true
+                },
+                "MessageType_StellarManageBuyOfferOp": {
+                    "(wire_in)": true
+                },
+                "MessageType_StellarPathPaymentStrictSendOp": {
+                    "(wire_in)": true
+                },
+                "MessageType_StellarSignedTx": {
+                    "(wire_out)": true
+                },
+                "MessageType_CardanoGetPublicKey": {
+                    "(wire_in)": true
+                },
+                "MessageType_CardanoPublicKey": {
+                    "(wire_out)": true
+                },
+                "MessageType_CardanoGetAddress": {
+                    "(wire_in)": true
+                },
+                "MessageType_CardanoAddress": {
+                    "(wire_out)": true
+                },
+                "MessageType_CardanoTxItemAck": {
+                    "(wire_out)": true
+                },
+                "MessageType_CardanoTxAuxiliaryDataSupplement": {
+                    "(wire_out)": true
+                },
+                "MessageType_CardanoTxWitnessRequest": {
+                    "(wire_in)": true
+                },
+                "MessageType_CardanoTxWitnessResponse": {
+                    "(wire_out)": true
+                },
+                "MessageType_CardanoTxHostAck": {
+                    "(wire_in)": true
+                },
+                "MessageType_CardanoTxBodyHash": {
+                    "(wire_out)": true
+                },
+                "MessageType_CardanoSignTxFinished": {
+                    "(wire_out)": true
+                },
+                "MessageType_CardanoSignTxInit": {
+                    "(wire_in)": true
+                },
+                "MessageType_CardanoTxInput": {
+                    "(wire_in)": true
+                },
+                "MessageType_CardanoTxOutput": {
+                    "(wire_in)": true
+                },
+                "MessageType_CardanoAssetGroup": {
+                    "(wire_in)": true
+                },
+                "MessageType_CardanoToken": {
+                    "(wire_in)": true
+                },
+                "MessageType_CardanoTxCertificate": {
+                    "(wire_in)": true
+                },
+                "MessageType_CardanoTxWithdrawal": {
+                    "(wire_in)": true
+                },
+                "MessageType_CardanoTxAuxiliaryData": {
+                    "(wire_in)": true
+                },
+                "MessageType_CardanoPoolOwner": {
+                    "(wire_in)": true
+                },
+                "MessageType_CardanoPoolRelayParameters": {
+                    "(wire_in)": true
+                },
+                "MessageType_CardanoGetNativeScriptHash": {
+                    "(wire_in)": true
+                },
+                "MessageType_CardanoNativeScriptHash": {
+                    "(wire_out)": true
+                },
+                "MessageType_CardanoTxMint": {
+                    "(wire_in)": true
+                },
+                "MessageType_CardanoTxCollateralInput": {
+                    "(wire_in)": true
+                },
+                "MessageType_CardanoTxRequiredSigner": {
+                    "(wire_in)": true
+                },
+                "MessageType_CardanoTxInlineDatumChunk": {
+                    "(wire_in)": true
+                },
+                "MessageType_CardanoTxReferenceScriptChunk": {
+                    "(wire_in)": true
+                },
+                "MessageType_CardanoTxReferenceInput": {
+                    "(wire_in)": true
+                },
+                "MessageType_RippleGetAddress": {
+                    "(wire_in)": true
+                },
+                "MessageType_RippleAddress": {
+                    "(wire_out)": true
+                },
+                "MessageType_RippleSignTx": {
+                    "(wire_in)": true
+                },
+                "MessageType_RippleSignedTx": {
+                    "(wire_in)": true
+                },
+                "MessageType_MoneroTransactionInitRequest": {
+                    "(wire_out)": true
+                },
+                "MessageType_MoneroTransactionInitAck": {
+                    "(wire_out)": true
+                },
+                "MessageType_MoneroTransactionSetInputRequest": {
+                    "(wire_out)": true
+                },
+                "MessageType_MoneroTransactionSetInputAck": {
+                    "(wire_out)": true
+                },
+                "MessageType_MoneroTransactionInputViniRequest": {
+                    "(wire_out)": true
+                },
+                "MessageType_MoneroTransactionInputViniAck": {
+                    "(wire_out)": true
+                },
+                "MessageType_MoneroTransactionAllInputsSetRequest": {
+                    "(wire_out)": true
+                },
+                "MessageType_MoneroTransactionAllInputsSetAck": {
+                    "(wire_out)": true
+                },
+                "MessageType_MoneroTransactionSetOutputRequest": {
+                    "(wire_out)": true
+                },
+                "MessageType_MoneroTransactionSetOutputAck": {
+                    "(wire_out)": true
+                },
+                "MessageType_MoneroTransactionAllOutSetRequest": {
+                    "(wire_out)": true
+                },
+                "MessageType_MoneroTransactionAllOutSetAck": {
+                    "(wire_out)": true
+                },
+                "MessageType_MoneroTransactionSignInputRequest": {
+                    "(wire_out)": true
+                },
+                "MessageType_MoneroTransactionSignInputAck": {
+                    "(wire_out)": true
+                },
+                "MessageType_MoneroTransactionFinalRequest": {
+                    "(wire_out)": true
+                },
+                "MessageType_MoneroTransactionFinalAck": {
+                    "(wire_out)": true
+                },
+                "MessageType_MoneroKeyImageExportInitRequest": {
+                    "(wire_out)": true
+                },
+                "MessageType_MoneroKeyImageExportInitAck": {
+                    "(wire_out)": true
+                },
+                "MessageType_MoneroKeyImageSyncStepRequest": {
+                    "(wire_out)": true
+                },
+                "MessageType_MoneroKeyImageSyncStepAck": {
+                    "(wire_out)": true
+                },
+                "MessageType_MoneroKeyImageSyncFinalRequest": {
+                    "(wire_out)": true
+                },
+                "MessageType_MoneroKeyImageSyncFinalAck": {
+                    "(wire_out)": true
+                },
+                "MessageType_MoneroGetAddress": {
+                    "(wire_in)": true
+                },
+                "MessageType_MoneroAddress": {
+                    "(wire_out)": true
+                },
+                "MessageType_MoneroGetWatchKey": {
+                    "(wire_in)": true
+                },
+                "MessageType_MoneroWatchKey": {
+                    "(wire_out)": true
+                },
+                "MessageType_DebugMoneroDiagRequest": {
+                    "(wire_in)": true
+                },
+                "MessageType_DebugMoneroDiagAck": {
+                    "(wire_out)": true
+                },
+                "MessageType_MoneroGetTxKeyRequest": {
+                    "(wire_in)": true
+                },
+                "MessageType_MoneroGetTxKeyAck": {
+                    "(wire_out)": true
+                },
+                "MessageType_MoneroLiveRefreshStartRequest": {
+                    "(wire_in)": true
+                },
+                "MessageType_MoneroLiveRefreshStartAck": {
+                    "(wire_out)": true
+                },
+                "MessageType_MoneroLiveRefreshStepRequest": {
+                    "(wire_in)": true
+                },
+                "MessageType_MoneroLiveRefreshStepAck": {
+                    "(wire_out)": true
+                },
+                "MessageType_MoneroLiveRefreshFinalRequest": {
+                    "(wire_in)": true
+                },
+                "MessageType_MoneroLiveRefreshFinalAck": {
+                    "(wire_out)": true
+                },
+                "MessageType_EosGetPublicKey": {
+                    "(wire_in)": true
+                },
+                "MessageType_EosPublicKey": {
+                    "(wire_out)": true
+                },
+                "MessageType_EosSignTx": {
+                    "(wire_in)": true
+                },
+                "MessageType_EosTxActionRequest": {
+                    "(wire_out)": true
+                },
+                "MessageType_EosTxActionAck": {
+                    "(wire_in)": true
+                },
+                "MessageType_EosSignedTx": {
+                    "(wire_out)": true
+                },
+                "MessageType_BinanceGetAddress": {
+                    "(wire_in)": true
+                },
+                "MessageType_BinanceAddress": {
+                    "(wire_out)": true
+                },
+                "MessageType_BinanceGetPublicKey": {
+                    "(wire_in)": true
+                },
+                "MessageType_BinancePublicKey": {
+                    "(wire_out)": true
+                },
+                "MessageType_BinanceSignTx": {
+                    "(wire_in)": true
+                },
+                "MessageType_BinanceTxRequest": {
+                    "(wire_out)": true
+                },
+                "MessageType_BinanceTransferMsg": {
+                    "(wire_in)": true
+                },
+                "MessageType_BinanceOrderMsg": {
+                    "(wire_in)": true
+                },
+                "MessageType_BinanceCancelMsg": {
+                    "(wire_in)": true
+                },
+                "MessageType_BinanceSignedTx": {
+                    "(wire_out)": true
+                },
+                "MessageType_WebAuthnListResidentCredentials": {
+                    "(wire_in)": true
+                },
+                "MessageType_WebAuthnCredentials": {
+                    "(wire_out)": true
+                },
+                "MessageType_WebAuthnAddResidentCredential": {
+                    "(wire_in)": true
+                },
+                "MessageType_WebAuthnRemoveResidentCredential": {
+                    "(wire_in)": true
+                }
             },
             "values": {
                 "MessageType_Initialize": 0,

--- a/packages/protobuf/package.json
+++ b/packages/protobuf/package.json
@@ -28,6 +28,7 @@
     },
     "devDependencies": {
         "jest": "^29.5.0",
+        "protobufjs-cli": "^1.1.1",
         "rimraf": "^5.0.1",
         "tsx": "^3.12.7",
         "typescript": "4.9.5"

--- a/packages/protobuf/scripts/protobuf-build.sh
+++ b/packages/protobuf/scripts/protobuf-build.sh
@@ -36,7 +36,8 @@ grep -hv -e '^import ' -e '^syntax' -e '^package' -e 'option java_' "$SRC"/messa
 | grep -v '    reserved '>> "$DIST"/messages.proto
 
 # BUILD messages.json from message.proto
-npx pbjs -t json -p "$DIST" -o "$DIST"/messages.json --keep-case messages.proto
+# pbjs command is added by protobufjs-cli package
+yarn pbjs -t json -p "$DIST" -o "$DIST"/messages.json --keep-case messages.proto
 rm "$DIST"/messages.proto
 
 cd "$PARENT_PATH"

--- a/yarn.lock
+++ b/yarn.lock
@@ -443,12 +443,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@babel/parser@npm:^7.1.0, @babel/parser@npm:^7.12.11, @babel/parser@npm:^7.12.7, @babel/parser@npm:^7.13.16, @babel/parser@npm:^7.14.0, @babel/parser@npm:^7.14.7, @babel/parser@npm:^7.20.0, @babel/parser@npm:^7.20.7, @babel/parser@npm:^7.22.5, @babel/parser@npm:^7.8.3":
-  version: 7.22.5
-  resolution: "@babel/parser@npm:7.22.5"
+"@babel/parser@npm:^7.1.0, @babel/parser@npm:^7.12.11, @babel/parser@npm:^7.12.7, @babel/parser@npm:^7.13.16, @babel/parser@npm:^7.14.0, @babel/parser@npm:^7.14.7, @babel/parser@npm:^7.20.0, @babel/parser@npm:^7.20.15, @babel/parser@npm:^7.20.7, @babel/parser@npm:^7.22.5, @babel/parser@npm:^7.8.3":
+  version: 7.22.7
+  resolution: "@babel/parser@npm:7.22.7"
   bin:
     parser: ./bin/babel-parser.js
-  checksum: 470ebba516417ce8683b36e2eddd56dcfecb32c54b9bb507e28eb76b30d1c3e618fd0cfeee1f64d8357c2254514e1a19e32885cfb4e73149f4ae875436a6d59c
+  checksum: 02209ddbd445831ee8bf966fdf7c29d189ed4b14343a68eb2479d940e7e3846340d7cc6bd654a5f3d87d19dc84f49f50a58cf9363bee249dc5409ff3ba3dab54
   languageName: node
   linkType: hard
 
@@ -3986,6 +3986,15 @@ __metadata:
   bin:
     bump: bin/bump.js
   checksum: 9fc12d25881e9d959c93aed42c71dc339943d33b6731e6983c84b53e30fb5e72a26a65a723799711dc2b8c6b21abbf3a7eb89cb1ea4db634a6a4b18c44b00730
+  languageName: node
+  linkType: hard
+
+"@jsdoc/salty@npm:^0.2.1":
+  version: 0.2.5
+  resolution: "@jsdoc/salty@npm:0.2.5"
+  dependencies:
+    lodash: ^4.17.21
+  checksum: 16c65d48c340d8f1b892797bdd6ace4f90d916d16bed5023f2a5421240ead20e828031dfb1d07b8eb0e172a62f532c3c005287e723e30ee9a0c8a0d7d2e98953
   languageName: node
   linkType: hard
 
@@ -8184,6 +8193,7 @@ __metadata:
     jest: ^29.5.0
     long: ^4.0.0
     protobufjs: 7.2.4
+    protobufjs-cli: ^1.1.1
     rimraf: ^5.0.1
     tsx: ^3.12.7
     typescript: 4.9.5
@@ -13361,6 +13371,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"catharsis@npm:^0.9.0":
+  version: 0.9.0
+  resolution: "catharsis@npm:0.9.0"
+  dependencies:
+    lodash: ^4.17.15
+  checksum: da867df1fd01823ea5a7283886ba382f6eb5b1fe5af356e00fd944a02d9b867f4ea2fc7f61416c53427f62760fdbd41614f6e8ae37686d2c3a4696871526df20
+  languageName: node
+  linkType: hard
+
 "cbor-js@npm:^0.1.0":
   version: 0.1.0
   resolution: "cbor-js@npm:0.1.0"
@@ -16257,6 +16276,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"entities@npm:~2.1.0":
+  version: 2.1.0
+  resolution: "entities@npm:2.1.0"
+  checksum: a10a877e489586a3f6a691fe49bf3fc4e58f06c8e80522f08214a5150ba457e7017b447d4913a3fa041bda06ee4c92517baa4d8d75373eaa79369e9639225ffd
+  languageName: node
+  linkType: hard
+
 "entities@npm:~3.0.1":
   version: 3.0.1
   resolution: "entities@npm:3.0.1"
@@ -16859,7 +16885,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"escodegen@npm:^1.11.1":
+"escodegen@npm:^1.11.1, escodegen@npm:^1.13.0":
   version: 1.14.3
   resolution: "escodegen@npm:1.14.3"
   dependencies:
@@ -19330,7 +19356,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"glob@npm:^8.0.1":
+"glob@npm:^8.0.0, glob@npm:^8.0.1":
   version: 8.1.0
   resolution: "glob@npm:8.1.0"
   dependencies:
@@ -19548,10 +19574,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"graceful-fs@npm:^4.1.11, graceful-fs@npm:^4.1.2, graceful-fs@npm:^4.1.3, graceful-fs@npm:^4.1.6, graceful-fs@npm:^4.2.0, graceful-fs@npm:^4.2.10, graceful-fs@npm:^4.2.4, graceful-fs@npm:^4.2.6, graceful-fs@npm:^4.2.9":
-  version: 4.2.10
-  resolution: "graceful-fs@npm:4.2.10"
-  checksum: 3f109d70ae123951905d85032ebeae3c2a5a7a997430df00ea30df0e3a6c60cf6689b109654d6fdacd28810a053348c4d14642da1d075049e6be1ba5216218da
+"graceful-fs@npm:^4.1.11, graceful-fs@npm:^4.1.2, graceful-fs@npm:^4.1.3, graceful-fs@npm:^4.1.6, graceful-fs@npm:^4.1.9, graceful-fs@npm:^4.2.0, graceful-fs@npm:^4.2.10, graceful-fs@npm:^4.2.4, graceful-fs@npm:^4.2.6, graceful-fs@npm:^4.2.9":
+  version: 4.2.11
+  resolution: "graceful-fs@npm:4.2.11"
+  checksum: ac85f94da92d8eb6b7f5a8b20ce65e43d66761c55ce85ac96df6865308390da45a8d3f0296dd3a663de65d30ba497bd46c696cc1e248c72b13d6d567138a4fc7
   languageName: node
   linkType: hard
 
@@ -22702,6 +22728,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"js2xmlparser@npm:^4.0.2":
+  version: 4.0.2
+  resolution: "js2xmlparser@npm:4.0.2"
+  dependencies:
+    xmlcreate: ^2.0.4
+  checksum: 55e3af71dc0104941dfc3e85452230db42ff3870a5777d1ea26bc0c68743f49113a517a7b305421a932b29f10058a012a7da8f5ba07860a05a1dce9fe5b62962
+  languageName: node
+  linkType: hard
+
 "jsbn@npm:~0.1.0":
   version: 0.1.1
   resolution: "jsbn@npm:0.1.1"
@@ -22744,6 +22779,31 @@ __metadata:
   bin:
     jscodeshift: bin/jscodeshift.js
   checksum: 1c35938de5fc29cafec80e2c37d5c3411f85cd5d40e0243b52f2da0c1ab4b659daddfd62de558eca5d562303616f7838097727b651f4ad8e32b1e96f169cdd76
+  languageName: node
+  linkType: hard
+
+"jsdoc@npm:^4.0.0":
+  version: 4.0.2
+  resolution: "jsdoc@npm:4.0.2"
+  dependencies:
+    "@babel/parser": ^7.20.15
+    "@jsdoc/salty": ^0.2.1
+    "@types/markdown-it": ^12.2.3
+    bluebird: ^3.7.2
+    catharsis: ^0.9.0
+    escape-string-regexp: ^2.0.0
+    js2xmlparser: ^4.0.2
+    klaw: ^3.0.0
+    markdown-it: ^12.3.2
+    markdown-it-anchor: ^8.4.1
+    marked: ^4.0.10
+    mkdirp: ^1.0.4
+    requizzle: ^0.2.3
+    strip-json-comments: ^3.1.0
+    underscore: ~1.13.2
+  bin:
+    jsdoc: jsdoc.js
+  checksum: 04bf5ab005349b7581bd0e72ed99933eb71a41dcb47235b486b7d9146fbdf212a53e0cc044abe48ccf46012bd812dc1dfc007c6d679660ebdd053cd000242515
   languageName: node
   linkType: hard
 
@@ -23281,6 +23341,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"klaw@npm:^3.0.0":
+  version: 3.0.0
+  resolution: "klaw@npm:3.0.0"
+  dependencies:
+    graceful-fs: ^4.1.9
+  checksum: 1bf9de22392c80d28de8a2babd6f0de29fa52fcdc1654838fd35174b3641c168ec32b8b03022191e3c190efd535c31fce23f85e29cb260245571da7263ef418e
+  languageName: node
+  linkType: hard
+
 "kleur@npm:^3.0.3":
   version: 3.0.3
   resolution: "kleur@npm:3.0.3"
@@ -23523,6 +23592,15 @@ __metadata:
   version: 2.0.3
   resolution: "lines-and-columns@npm:2.0.3"
   checksum: 5955363dfd7d3d7c476d002eb47944dbe0310d57959e2112dce004c0dc76cecfd479cf8c098fd479ff344acdf04ee0e82b455462a26492231ac152f6c48d17a1
+  languageName: node
+  linkType: hard
+
+"linkify-it@npm:^3.0.1":
+  version: 3.0.3
+  resolution: "linkify-it@npm:3.0.3"
+  dependencies:
+    uc.micro: ^1.0.1
+  checksum: 31367a4bb70c5bbc9703246236b504b0a8e049bcd4e0de4291fa50f0ebdebf235b5eb54db6493cb0b1319357c6eeafc4324c9f4aa34b0b943d9f2e11a1268fbc
   languageName: node
   linkType: hard
 
@@ -24111,6 +24189,16 @@ __metadata:
   languageName: node
   linkType: hard
 
+"markdown-it-anchor@npm:^8.4.1":
+  version: 8.6.7
+  resolution: "markdown-it-anchor@npm:8.6.7"
+  peerDependencies:
+    "@types/markdown-it": "*"
+    markdown-it: "*"
+  checksum: 828236768ac7f61ed5591393c1b1bfc5dbf2b6d0c58a3deec606c61dddaa12658a34450cbef37ab50a04453e618ce1efd47d86e4e52595024334898fd306225b
+  languageName: node
+  linkType: hard
+
 "markdown-it-link-attributes@npm:^4.0.1":
   version: 4.0.1
   resolution: "markdown-it-link-attributes@npm:4.0.1"
@@ -24133,6 +24221,21 @@ __metadata:
   languageName: node
   linkType: hard
 
+"markdown-it@npm:^12.3.2":
+  version: 12.3.2
+  resolution: "markdown-it@npm:12.3.2"
+  dependencies:
+    argparse: ^2.0.1
+    entities: ~2.1.0
+    linkify-it: ^3.0.1
+    mdurl: ^1.0.1
+    uc.micro: ^1.0.5
+  bin:
+    markdown-it: bin/markdown-it.js
+  checksum: 890555711c1c00fa03b936ca2b213001a3b9b37dea140d8445ae4130ce16628392aad24b12e2a0a9935336ca5951f2957a38f4e5309a2e38eab44e25ff32a41e
+  languageName: node
+  linkType: hard
+
 "markdown-it@npm:^13.0.1":
   version: 13.0.1
   resolution: "markdown-it@npm:13.0.1"
@@ -24145,6 +24248,15 @@ __metadata:
   bin:
     markdown-it: bin/markdown-it.js
   checksum: faf5891d389dc433bcf21d3fbff2009beb044b42b117c92f4848899780ca1a2282a209e3ff4672db4afed726a7248304ec473e6e242a7d6498af7113d31974e7
+  languageName: node
+  linkType: hard
+
+"marked@npm:^4.0.10":
+  version: 4.3.0
+  resolution: "marked@npm:4.3.0"
+  bin:
+    marked: bin/marked.js
+  checksum: 0db6817893952c3ec710eb9ceafb8468bf5ae38cb0f92b7b083baa13d70b19774674be04db5b817681fa7c5c6a088f61300815e4dd75a59696f4716ad69f6260
   languageName: node
   linkType: hard
 
@@ -27993,6 +28105,29 @@ __metadata:
   languageName: node
   linkType: hard
 
+"protobufjs-cli@npm:^1.1.1":
+  version: 1.1.1
+  resolution: "protobufjs-cli@npm:1.1.1"
+  dependencies:
+    chalk: ^4.0.0
+    escodegen: ^1.13.0
+    espree: ^9.0.0
+    estraverse: ^5.1.0
+    glob: ^8.0.0
+    jsdoc: ^4.0.0
+    minimist: ^1.2.0
+    semver: ^7.1.2
+    tmp: ^0.2.1
+    uglify-js: ^3.7.7
+  peerDependencies:
+    protobufjs: ^7.0.0
+  bin:
+    pbjs: bin/pbjs
+    pbts: bin/pbts
+  checksum: 124a2cb10d6fccdd6e8f2984b0f7d9a351d9c1efd17f237acd4a9e7c4b82d63265364b1c86bfa5c6a6fa17d7119182c4c323a8972c0078e1ac5c5f653d096f9b
+  languageName: node
+  linkType: hard
+
 "protobufjs@npm:7.2.4":
   version: 7.2.4
   resolution: "protobufjs@npm:7.2.4"
@@ -29803,6 +29938,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"requizzle@npm:^0.2.3":
+  version: 0.2.4
+  resolution: "requizzle@npm:0.2.4"
+  dependencies:
+    lodash: ^4.17.21
+  checksum: fceaa448b235f9ed111aa58360129225a3cec1a897a23293dc08d2a00f001756c042a62df0a9d4d1e2669ace52dec960aea73437f407b30c51bfba2e9da208b7
+  languageName: node
+  linkType: hard
+
 "reselect@npm:^4.0.0, reselect@npm:^4.1.8":
   version: 4.1.8
   resolution: "reselect@npm:4.1.8"
@@ -30544,7 +30688,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"semver@npm:7.x, semver@npm:^7.3.2, semver@npm:^7.3.4, semver@npm:^7.3.5, semver@npm:^7.3.7, semver@npm:^7.3.8, semver@npm:^7.5.3":
+"semver@npm:7.x, semver@npm:^7.1.2, semver@npm:^7.3.2, semver@npm:^7.3.4, semver@npm:^7.3.5, semver@npm:^7.3.7, semver@npm:^7.3.8, semver@npm:^7.5.3":
   version: 7.5.4
   resolution: "semver@npm:7.5.4"
   dependencies:
@@ -33375,12 +33519,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"uglify-js@npm:^3.1.4":
-  version: 3.17.3
-  resolution: "uglify-js@npm:3.17.3"
+"uglify-js@npm:^3.1.4, uglify-js@npm:^3.7.7":
+  version: 3.17.4
+  resolution: "uglify-js@npm:3.17.4"
   bin:
     uglifyjs: bin/uglifyjs
-  checksum: 2650b2e0385fe6bf68bc0b7746028fd004bbe839447c28a59f8a9e458187e897a5057900cb715b3be4cf7cf3f1d10217198210c5c23c0bffcb20feca2de5bb17
+  checksum: 7b3897df38b6fc7d7d9f4dcd658599d81aa2b1fb0d074829dd4e5290f7318dbca1f4af2f45acb833b95b1fe0ed4698662ab61b87e94328eb4c0a0d3435baf924
   languageName: node
   linkType: hard
 
@@ -33393,6 +33537,13 @@ __metadata:
     has-symbols: ^1.0.3
     which-boxed-primitive: ^1.0.2
   checksum: b7a1cf5862b5e4b5deb091672ffa579aa274f648410009c81cca63fed3b62b610c4f3b773f912ce545bb4e31edc3138975b5bc777fc6e4817dca51affb6380e9
+  languageName: node
+  linkType: hard
+
+"underscore@npm:~1.13.2":
+  version: 1.13.6
+  resolution: "underscore@npm:1.13.6"
+  checksum: d5cedd14a9d0d91dd38c1ce6169e4455bb931f0aaf354108e47bd46d3f2da7464d49b2171a5cf786d61963204a42d01ea1332a903b7342ad428deaafaf70ec36
   languageName: node
   linkType: hard
 
@@ -35286,6 +35437,13 @@ __metadata:
   version: 2.2.0
   resolution: "xmlchars@npm:2.2.0"
   checksum: 8c70ac94070ccca03f47a81fcce3b271bd1f37a591bf5424e787ae313fcb9c212f5f6786e1fa82076a2c632c0141552babcd85698c437506dfa6ae2d58723062
+  languageName: node
+  linkType: hard
+
+"xmlcreate@npm:^2.0.4":
+  version: 2.0.4
+  resolution: "xmlcreate@npm:2.0.4"
+  checksum: b8dd52668b9aea77cd1408fa85538c14bb8dcc98b4e7bb51e76696c9c115d59eba7240298d0c4fd2caf8f1a8e283ab4e5c7b9a6bcfcf23a8b48f5068b677b748
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
recently, we updated to a new major version of protobufjs lib. the latest version no longer bundles protobufjs-cli project, which in node_modules appears as pbjs which on the other hand is completely different package -> this means that update protobuf script tries to install this different package.

also updating messages.json

closes #7213