### PR TITLE
fix(suite): error message padding

### DIFF
--- a/packages/components/src/components/form/Select/index.tsx
+++ b/packages/components/src/components/form/Select/index.tsx
@@ -214,7 +214,7 @@ const BottomText = styled.div<Pick<SelectProps, 'inputState'>>`
     display: flex;
     font-size: ${FONT_SIZE.TINY};
     color: ${({ inputState, theme }) => getInputStateTextColor(inputState, theme)};
-    padding: 10px 10px 0 10px;
+    padding: 6px 10px 0 10px;
     min-height: 27px;
 `;
 

--- a/packages/components/src/components/form/Textarea/index.tsx
+++ b/packages/components/src/components/form/Textarea/index.tsx
@@ -1,4 +1,4 @@
-import styled, { css } from 'styled-components';
+import styled from 'styled-components';
 import React, { useState } from 'react';
 
 import { FONT_SIZE } from '../../../config/variables';
@@ -12,7 +12,6 @@ import {
     getInputStateTextColor,
     LabelAddon,
 } from '../InputStyles';
-import { darken } from 'polished';
 
 const Wrapper = styled.div`
     width: 100%;
@@ -32,7 +31,7 @@ const StyledTextarea = styled.textarea<Pick<TextareaProps, 'inputState' | 'width
 `;
 
 const BottomText = styled.span<Pick<TextareaProps, 'inputState'>>`
-    padding: 10px 10px 0 10px;
+    padding: 6px 10px 0 10px;
     min-height: 27px;
     font-size: ${FONT_SIZE.TINY};
     color: ${({ inputState, theme }) => getInputStateTextColor(inputState, theme)};


### PR DESCRIPTION
Fixes padding for `Select` and `Textarea` error messages

## Description

Error message in `Select` (not even used) and `Textarea` components has same padding like the bottom version in `Input` component.

Also removed some unused imports.

Also maybe there is a question whether not to also change `min-height` or bottom padding (or something else) to increase space between error message and the button under it (with new design changes probably not important).

## Related Issue

#9063 (4.)

## Screenshots:

Before:

<img width="722" alt="Screenshot 2023-08-07 at 5 26 20 PM" src="https://github.com/trezor/trezor-suite/assets/66002635/709db31c-630e-47e3-82ad-8474cc65de1f">

After:

<img width="732" alt="Screenshot 2023-08-07 at 5 25 56 PM" src="https://github.com/trezor/trezor-suite/assets/66002635/d2c3d8fc-dadf-4fec-98f2-14545edcb86e">