### PR TITLE
fix(suite): chevron icon in select

### DIFF
--- a/packages/components/src/components/form/Select/index.tsx
+++ b/packages/components/src/components/form/Select/index.tsx
@@ -94,6 +94,7 @@ const selectStyle = (
                     : theme.TYPE_LIGHT_GREY,
                 [`.${reactSelectClassNamePrefix}__dropdown-indicator`]: {
                     color: theme.TYPE_LIGHT_GREY,
+                    transform: menuIsOpen ? 'rotate(180deg)' : 'none',
                 },
             },
         };
@@ -111,7 +112,7 @@ const selectStyle = (
     indicatorSeparator: () => ({
         display: 'none',
     }),
-    dropdownIndicator: (base, { isDisabled, isFocused }) => ({
+    dropdownIndicator: (base, { isDisabled }) => ({
         ...base,
         display: !withDropdownIndicator || isDisabled ? 'none' : 'flex',
         alignItems: 'center',
@@ -119,7 +120,6 @@ const selectStyle = (
         cursor: 'pointer',
         path: '',
         padding: isClean ? 0 : '10px 16px',
-        transform: isFocused ? 'rotate(180deg)' : 'none',
         transition: `transform 0.2s cubic-bezier(0.68, -0.02, 0.21, 1.1)`,
     }),
     menu: base => ({


### PR DESCRIPTION
The icon points down after closing by clicking inside it

## Description

Value for `transform` is now based on `menuIsOpen` not `isFocused`. This variable is available only in `control` not `dropdownIndicator`.

## Related Issue

Resolve #9125 

## Screenshots:

https://github.com/trezor/trezor-suite/assets/66002635/6896a139-f617-4996-adb1-4a02b3803713