### PR TITLE
fix(suite): button in translations

### DIFF
--- a/packages/suite/src/support/messages.ts
+++ b/packages/suite/src/support/messages.ts
@@ -5655,7 +5655,7 @@ export default defineMessages({
         id: 'CUSTOM_FEE_NOT_IN_RANGE',
     },
     CUSTOM_FEE_LIMIT_BELOW_RECOMMENDED: {
-        defaultMessage: 'Gas limit too low {button}',
+        defaultMessage: 'Gas limit too low',
         id: 'CUSTOM_FEE_LIMIT_BELOW_RECOMMENDED',
     },
     CUSTOM_FEE_LIMIT_USE_RECOMMENDED: {


### PR DESCRIPTION
There was unused variable `button` in `CUSTOM_FEE_LIMIT_BELOW_RECOMMENDED` translation string.

## Description

There was unused variable `button` in `CUSTOM_FEE_LIMIT_BELOW_RECOMMENDED` translation string.

Updated defaultMessage of this string and translations values in Crowdin.

## Screenshots:

Before:

![Screenshot 2023-08-08 at 5 43 40 PM](https://github.com/trezor/trezor-suite/assets/66002635/1a61ed9e-26ee-4db8-9484-6453c098a55b)

After:

![Screenshot 2023-08-08 at 5 46 55 PM](https://github.com/trezor/trezor-suite/assets/66002635/8f6ae0a6-1ebc-4260-b7f2-e145e613417d)
