### PR TITLE
feat(suite): label translations

### DIFF
--- a/packages/components/src/components/form/Select/index.tsx
+++ b/packages/components/src/components/form/Select/index.tsx
@@ -153,7 +153,6 @@ const selectStyle = (
         ...base,
         padding: 0,
         '& + &': {
-            borderTop: `1px solid ${theme.BG_WHITE_ALT_HOVER}`,
             paddingTop: 4,
             marginTop: 4,
         },

--- a/packages/suite/src/config/suite/languages.ts
+++ b/packages/suite/src/config/suite/languages.ts
@@ -1,12 +1,12 @@
 export const TRANSLATION_PSEUDOLANGUAGE = 'lol' as const;
 
 const LANGUAGES = {
-    en: { name: 'English', en: 'English', complete: true },
-    es: { name: 'Español', en: 'Spanish', complete: true },
+    en: { name: 'English', en: 'English', type: 'official' },
+    es: { name: 'Español', en: 'Spanish', type: 'community' },
     af: { name: 'Afrikaans', en: 'Afrikaans' },
     ar: { name: 'العربية‬', en: 'Arabic' },
     ca: { name: 'Català', en: 'Catalan' },
-    cs: { name: 'Čeština', en: 'Czech', complete: true },
+    cs: { name: 'Čeština', en: 'Czech', type: 'official' },
     da: { name: 'Dansk', en: 'Danish' },
     de: { name: 'Deutsch', en: 'German' },
     el: { name: 'Ελληνικά', en: 'Greek' },
@@ -17,7 +17,7 @@ const LANGUAGES = {
     hu: { name: 'Magyar', en: 'Hungarian' },
     id: { name: 'Bahasa Indonesia', en: 'Indonesian' },
     it: { name: 'Italiano', en: 'Italian' },
-    ja: { name: '日本語（ベータ版）', en: 'Japanese (BETA)', complete: true },
+    ja: { name: '日本語（ベータ版）', en: 'Japanese (BETA)', type: 'community' },
     jv: { name: 'Basa Jawa', en: 'Javanese' },
     ko: { name: '한국어', en: 'Korean' },
     nl: { name: 'Nederlands', en: 'Dutch' },
@@ -25,7 +25,7 @@ const LANGUAGES = {
     pl: { name: 'Polski', en: 'Polish' },
     pt: { name: 'Português', en: 'Portuguese' },
     ro: { name: 'Română', en: 'Romanian' },
-    ru: { name: 'Русский', en: 'Russian', complete: true },
+    ru: { name: 'Русский', en: 'Russian', type: 'community' },
     sk: { name: 'Slovenčina', en: 'Slovak' },
     sr: { name: 'Српски', en: 'Serbian' },
     sv: { name: 'Svenska', en: 'Swedish' },
@@ -41,7 +41,7 @@ export type Locale = keyof typeof LANGUAGES;
 export type LocaleInfo = {
     name: string;
     en: string;
-    complete?: boolean;
+    type?: 'official' | 'community';
 };
 
 export default LANGUAGES as { [code in Locale]: LocaleInfo };

--- a/packages/suite/src/support/messages.ts
+++ b/packages/suite/src/support/messages.ts
@@ -2695,6 +2695,23 @@ export default defineMessages({
         defaultMessage: 'Language',
         id: 'TR_LANGUAGE',
     },
+    TR_LANGUAGE_DESCRIPTION: {
+        defaultMessage:
+            'The Trezor community translated Czech, and we are thankful for their contributions. Ensure language consistency by referring to our official languages for verification.',
+        id: 'TR_LANGUAGE_DESCRIPTION',
+    },
+    TR_LANGUAGE_CREDITS: {
+        defaultMessage: 'See credits',
+        id: 'TR_LANGUAGE_CREDITS',
+    },
+    TR_OFFICIAL_LANGUAGES: {
+        defaultMessage: 'Official',
+        id: 'TR_OFFICIAL_LANGUAGES',
+    },
+    TR_COMMUNITY_LANGUAGES: {
+        defaultMessage: 'Community',
+        id: 'TR_COMMUNITY_LANGUAGES',
+    },
     TR_LEARN: {
         defaultMessage: 'Learn',
         description: 'Link to Suite Guide.',

--- a/packages/suite/src/utils/suite/l10n.ts
+++ b/packages/suite/src/utils/suite/l10n.ts
@@ -17,7 +17,7 @@ export const setTranslationMode = (value: boolean) => {
 export const isLocale = (lang: string): lang is Locale => lang in LANGUAGES;
 
 export const isCompletedLocale = (lang: string): lang is Locale =>
-    isLocale(lang) && !!LANGUAGES[lang].complete;
+    isLocale(lang) && !!LANGUAGES[lang].type;
 
 /**
  * Finds and returns first of languages preferred by user's environment

--- a/packages/suite/src/views/settings/general/Language.tsx
+++ b/packages/suite/src/views/settings/general/Language.tsx
@@ -11,9 +11,13 @@ import { ActionColumn, ActionSelect, SectionItem, TextColumn } from 'src/compone
 import { useAnchor } from 'src/hooks/suite/useAnchor';
 import { SettingsAnchor } from 'src/constants/suite/anchors';
 import { getPlatformLanguages } from '@trezor/env-utils';
+import { CROWDIN_URL } from '@trezor/urls';
 
-const onlyComplete = (locale: [string, LocaleInfo]): locale is [Locale, LocaleInfo] =>
-    !!locale[1].complete;
+const onlyOfficial = (locale: [string, LocaleInfo]): locale is [Locale, LocaleInfo] =>
+    locale[1].type === 'official';
+
+const onlyCommunity = (locale: [string, LocaleInfo]): locale is [Locale, LocaleInfo] =>
+    locale[1].type === 'community';
 
 const useLanguageOptions = () => {
     const { translationString } = useTranslation();
@@ -30,12 +34,19 @@ const useLanguageOptions = () => {
                 options: [systemOption],
             },
             {
+                label: translationString('TR_OFFICIAL_LANGUAGES'),
                 options: Object.entries(LANGUAGES)
-                    .filter(onlyComplete)
+                    .filter(onlyOfficial)
+                    .map(([value, { name }]) => ({ value, label: name })),
+            },
+            {
+                label: translationString('TR_COMMUNITY_LANGUAGES'),
+                options: Object.entries(LANGUAGES)
+                    .filter(onlyCommunity)
                     .map(([value, { name }]) => ({ value, label: name })),
             },
         ],
-        [systemOption],
+        [systemOption, translationString],
     );
     return {
         options,
@@ -84,7 +95,12 @@ export const Language = () => {
             ref={anchorRef}
             shouldHighlight={shouldHighlight}
         >
-            <TextColumn title={<Translation id="TR_LANGUAGE" />} />
+            <TextColumn
+                title={<Translation id="TR_LANGUAGE" />}
+                description={<Translation id="TR_LANGUAGE_DESCRIPTION" />}
+                buttonTitle={<Translation id="TR_LANGUAGE_CREDITS" />}
+                buttonLink={CROWDIN_URL}
+            />
             <ActionColumn>
                 <ActionSelect
                     hideTextCursor

--- a/packages/urls/src/urls.ts
+++ b/packages/urls/src/urls.ts
@@ -80,3 +80,4 @@ export const FIREFOX_UPDATE_URL =
 export const TOR_PROJECT_URL = 'https://www.torproject.org/';
 export const ZKSNACKS_TERMS_URL =
     'https://github.com/zkSNACKs/WalletWasabi/blob/master/WalletWasabi/Legal/Assets/LegalDocumentsWw2.txt';
+export const CROWDIN_URL = 'https://crowdin.com/project/trezor-suite';


### PR DESCRIPTION
Translations are divided into groups.

## Description

Translations are divided into official and community group (grouping checked with @Hermez-cz). Removed group divider.

Added translation keys:
- `TR_LANGUAGE_DESCRIPTION`
- `TR_LANGUAGE_CREDITS`
- `TR_OFFICIAL_LANGUAGES`
- `TR_COMMUNITY_LANGUAGES`

## Related Issue

Resolve #7624 

## Screenshots:

![Screenshot 2023-08-11 at 12 45 41 PM](https://github.com/trezor/trezor-suite/assets/66002635/403128fe-1555-47ef-8d8c-1a9ded5971ee)