### PR TITLE
fix(suite-native): tokens without fiat rates glitch

### DIFF
--- a/suite-native/accounts/src/components/AccountListItemInteractive.tsx
+++ b/suite-native/accounts/src/components/AccountListItemInteractive.tsx
@@ -1,12 +1,15 @@
 import React from 'react';
 import { TouchableOpacity } from 'react-native';
+import { useSelector } from 'react-redux';
 
 import { Box } from '@suite-native/atoms';
 import { AccountKey, TokenAddress } from '@suite-common/wallet-types';
-import { isEthereumAccountSymbol } from '@suite-common/wallet-utils';
+import { selectIsEthereumAccountWithTokensWithFiatRates } from '@suite-native/ethereum-tokens';
+import { SettingsSliceRootState } from '@suite-native/module-settings';
+import { FiatRatesRootState } from '@suite-native/fiat-rates';
 
-import { AccountListItem, AccountListItemProps } from './AccountListItem';
 import { TokenList } from './TokenList';
+import { AccountListItem, AccountListItemProps } from './AccountListItem';
 
 interface AccountListItemInteractiveProps extends AccountListItemProps {
     onSelectAccount: (accountKey: AccountKey, tokenContract?: TokenAddress) => void;
@@ -15,13 +18,23 @@ interface AccountListItemInteractiveProps extends AccountListItemProps {
 export const AccountListItemInteractive = ({
     account,
     onSelectAccount,
-}: AccountListItemInteractiveProps) => (
-    <Box>
-        <TouchableOpacity onPress={() => onSelectAccount(account.key)}>
-            <AccountListItem key={account.key} account={account} areTokensDisplayed />
-        </TouchableOpacity>
-        {isEthereumAccountSymbol(account.symbol) && (
-            <TokenList accountKey={account.key} onSelectAccount={onSelectAccount} />
-        )}
-    </Box>
-);
+}: AccountListItemInteractiveProps) => {
+    const areTokensDisplayed = useSelector((state: SettingsSliceRootState & FiatRatesRootState) =>
+        selectIsEthereumAccountWithTokensWithFiatRates(state, account.key),
+    );
+
+    return (
+        <Box>
+            <TouchableOpacity onPress={() => onSelectAccount(account.key)}>
+                <AccountListItem
+                    key={account.key}
+                    account={account}
+                    areTokensDisplayed={areTokensDisplayed}
+                />
+            </TouchableOpacity>
+            {areTokensDisplayed && (
+                <TokenList accountKey={account.key} onSelectAccount={onSelectAccount} />
+            )}
+        </Box>
+    );
+};

--- a/suite-native/ethereum-tokens/src/ethereumTokensSelectors.ts
+++ b/suite-native/ethereum-tokens/src/ethereumTokensSelectors.ts
@@ -97,6 +97,11 @@ export const selectEthereumTokenHasFiatRates = (
     return !!rates?.rate;
 };
 
+export const selectAnyOfTokensHasFiatRates = (
+    state: FiatRatesRootState & SettingsSliceRootState,
+    tokens: TokenInfoBranded[],
+) => A.any(tokens, token => selectEthereumTokenHasFiatRates(state, token.contract, token.symbol));
+
 const isNotZeroAmountTranfer = (tokenTranfer: TokenTransfer) =>
     tokenTranfer.amount !== '' && tokenTranfer.amount !== '0';
 
@@ -178,8 +183,6 @@ export const selectEthereumAccountsTokensWithFiatRates = memoizeWithArgs(
     { size: 50 },
 );
 
-// If account item is ethereum which has tokens with fiat rates,
-// we want to adjust styling to display token items.
 export const selectIsEthereumAccountWithTokensWithFiatRates = (
     state: FiatRatesRootState & SettingsSliceRootState,
     ethereumAccountKey: AccountKey,
@@ -187,13 +190,15 @@ export const selectIsEthereumAccountWithTokensWithFiatRates = (
     const account = selectAccountByKey(state, ethereumAccountKey);
     if (!account || G.isNullable(account.tokens) || !isEthereumAccountSymbol(account.symbol))
         return false;
-    return A.isNotEmpty(
-        A.filterMap(account.tokens, token =>
+
+    return (
+        account.tokens,
+        A.any(account.tokens, token =>
             selectEthereumTokenHasFiatRates(
                 state,
                 token.contract as TokenAddress,
                 token.symbol as TokenSymbol,
             ),
-        ),
+        )
     );
 };

--- a/suite-native/module-accounts-import/src/components/AccountImportEthereumTokens.tsx
+++ b/suite-native/module-accounts-import/src/components/AccountImportEthereumTokens.tsx
@@ -17,8 +17,8 @@ export const AccountImportEthereumTokens = ({ tokens }: AccountImportEthereumTok
 
     return (
         <Box marginTop="medium">
-            <Text variant="titleSmall">Tokens: </Text>
             <VStack spacing="small" marginBottom="small">
+                <Text variant="titleSmall">Tokens: </Text>
                 {tokens.map(({ symbol, contract, balance, name, decimals }) => (
                     <EthereumTokenInfo
                         key={contract}

--- a/suite-native/module-accounts-import/src/components/AccountImportSummaryForm.tsx
+++ b/suite-native/module-accounts-import/src/components/AccountImportSummaryForm.tsx
@@ -1,7 +1,6 @@
 import React from 'react';
 import { useDispatch, useSelector } from 'react-redux';
 
-import { A } from '@mobily/ts-belt';
 import { CommonActions, useNavigation } from '@react-navigation/core';
 
 import { networks, NetworkSymbol } from '@suite-common/wallet-config';
@@ -21,8 +20,10 @@ import {
 import { AccountInfo } from '@trezor/connect';
 import { prepareNativeStyle, useNativeStyles } from '@trezor/styles';
 import { analytics, EventType } from '@suite-native/analytics';
-import { TokenSymbol } from '@suite-common/wallet-types';
-import { isEthereumAccountSymbol } from '@suite-common/wallet-utils';
+import { TokenInfoBranded, TokenSymbol } from '@suite-common/wallet-types';
+import { selectAnyOfTokensHasFiatRates } from '@suite-native/ethereum-tokens';
+import { FiatRatesRootState } from '@suite-native/fiat-rates';
+import { SettingsSliceRootState } from '@suite-native/module-settings';
 
 import { importAccountThunk } from '../accountsImportThunks';
 import { AccountImportOverview } from './AccountImportOverview';
@@ -103,16 +104,16 @@ export const AccountImportSummaryForm = ({
         }
     });
 
-    const shouldDisplayEthereumAccountTokens =
-        isEthereumAccountSymbol(networkSymbol) && A.isNotEmpty(accountInfo.tokens ?? []);
-
+    const areTokensDisplayed = useSelector((state: SettingsSliceRootState & FiatRatesRootState) =>
+        selectAnyOfTokensHasFiatRates(state, (accountInfo?.tokens as TokenInfoBranded[]) ?? []),
+    );
     return (
         <Form form={form}>
             <AccountImportOverview
                 balance={accountInfo.availableBalance}
                 networkSymbol={networkSymbol}
             />
-            {shouldDisplayEthereumAccountTokens && (
+            {areTokensDisplayed && (
                 <AccountImportEthereumTokens tokens={accountInfo.tokens ?? []} />
             )}
             <Divider marginBottom="small" />


### PR DESCRIPTION
UI fixed for imported Ethereum accounts that contain only tokens without fiat rates.

Closes #9144
