### PR TITLE
fix(suite-native): long screen header cropped

### DIFF
--- a/suite-native/navigation/src/components/ScreenHeader.tsx
+++ b/suite-native/navigation/src/components/ScreenHeader.tsx
@@ -77,7 +77,7 @@ export const ScreenHeader = ({
                         <StepsProgressBar numberOfSteps={numberOfSteps} activeStep={activeStep} />
                     )}
                     {typeof content === 'string' ? (
-                        <Text variant={titleVariant} numberOfLines={1} ellipsizeMode="tail">
+                        <Text variant={titleVariant} adjustsFontSizeToFit numberOfLines={1}>
                             {content}
                         </Text>
                     ) : (


### PR DESCRIPTION
A long screen header is not cropped anymore.

Closes #9126

## Screenshots:

![Screenshot 2023-08-11 at 14 16 05](https://github.com/trezor/trezor-suite/assets/26143964/74f7aafb-6efa-46a9-837f-5324f3533607)
