### PR TITLE
Fix: CoinjoinClient.enable return unsuccessful error message (reason)

### DIFF
--- a/packages/coinjoin/tests/client/CoinjoinClient.test.ts
+++ b/packages/coinjoin/tests/client/CoinjoinClient.test.ts
@@ -33,8 +33,9 @@ describe(`CoinjoinClient`, () => {
         const cli = new CoinjoinClient(server?.requestOptions);
 
         const status = await cli.enable();
-        expect(status?.rounds.length).toBeGreaterThan(0);
-        expect(status?.coordinationFeeRate.rate).toBeGreaterThan(0);
+        if (!status.success) throw new Error(`Client not enabled ${status.error}`);
+        expect(status.rounds.length).toBeGreaterThan(0);
+        expect(status.coordinationFeeRate.rate).toBeGreaterThan(0);
 
         cli.disable();
     });

--- a/packages/coinjoin/tests/client/coordinatorRequest.test.ts
+++ b/packages/coinjoin/tests/client/coordinatorRequest.test.ts
@@ -48,7 +48,7 @@ describe('http', () => {
         });
 
         await expect(coordinatorRequest('status', {}, { baseUrl })).rejects.toThrow(
-            'Internal Server Error: InternalErrorCodeExample',
+            'Internal Server Error (500) InternalErrorCodeExample',
         );
     });
 
@@ -62,7 +62,7 @@ describe('http', () => {
         });
 
         await expect(coordinatorRequest('status', {}, { baseUrl })).rejects.toThrow(
-            'Internal Server Error: InternalErrorCodeExample',
+            'Internal Server Error (500) InternalErrorCodeExample',
         );
     });
 

--- a/packages/suite/src/actions/wallet/__fixtures__/mockCoinjoinService.ts
+++ b/packages/suite/src/actions/wallet/__fixtures__/mockCoinjoinService.ts
@@ -9,6 +9,7 @@ export const mockCoinjoinService = () => {
             emit: jest.fn(),
             enable: jest.fn(() =>
                 Promise.resolve({
+                    success: true,
                     rounds: [{ id: '00', phase: 0 }],
                     feeRateMedian: 0,
                     coordinatorFeeRate: 0.003,

--- a/packages/suite/src/actions/wallet/coinjoinClientActions.ts
+++ b/packages/suite/src/actions/wallet/coinjoinClientActions.ts
@@ -752,8 +752,8 @@ export const initCoinjoinService =
             });
             const { client } = service;
             const status = await client.enable();
-            if (!status) {
-                throw new Error('status is missing');
+            if (!status.success) {
+                throw new Error(status.error);
             }
             // handle status change
             client.on('status', status => dispatch(clientOnStatusEvent(symbol, status)));
@@ -776,7 +776,7 @@ export const initCoinjoinService =
             dispatch(
                 notificationsActions.addToast({
                     type: 'error',
-                    error: `Coinjoin client not enabled: ${error.message}`,
+                    error: `CoinjoinClient ${error.message}`,
                 }),
             );
         }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Return full error message including requested url and error code from `CoinjoinClient.enable` method.
For easier debugging issues like https://github.com/trezor/trezor-suite/issues/9137 (Coinjoin client not enabled: status is missing)

## Screenshots:
Network request error:
![Screenshot from 2023-08-11 14-32-12](https://github.com/trezor/trezor-suite/assets/3435913/e3698cba-e621-4aee-b437-c4880db5a383)

Change of Status data format which we are facing right now on Wasabi testnet coordinator. reason:  https://github.com/zkSNACKs/WalletWasabi/pull/11080
![Screenshot from 2023-08-11 14-36-50](https://github.com/trezor/trezor-suite/assets/3435913/a57a5c58-8f4c-4899-b963-e458d6f6e337)
