### PR TITLE
Fix: cj cooridinator response patch

### DIFF
--- a/packages/coinjoin/src/backend/CoinjoinBackendClient.ts
+++ b/packages/coinjoin/src/backend/CoinjoinBackendClient.ts
@@ -2,7 +2,7 @@ import { scheduleAction, arrayShuffle, urlToOnion } from '@trezor/utils';
 import { TypedEmitter } from '@trezor/utils/lib/typedEventEmitter';
 import type { BlockbookAPI } from '@trezor/blockchain-link/lib/workers/blockbook/websocket';
 
-import { httpGet, RequestOptions } from '../utils/http';
+import { httpGet, patchResponse, RequestOptions } from '../utils/http';
 import type {
     BlockFilter,
     BlockbookBlock,
@@ -192,7 +192,10 @@ export class CoinjoinBackendClient {
             case 204:
                 return { status: 'up-to-date' };
             case 200: {
-                const result: { bestHeight: number; filters: string[] } = await response.json();
+                const result: { bestHeight: number; filters: string[] } = await response
+                    .json()
+                    .then(r => patchResponse(r));
+
                 const filters = result.filters.map<BlockFilter>(data => {
                     const [blockHeight, blockHash, filter, prevHash, blockTime] = data.split(':');
                     return {

--- a/packages/coinjoin/src/backend/scanAccount.ts
+++ b/packages/coinjoin/src/backend/scanAccount.ts
@@ -37,7 +37,7 @@ export const scanAccount = async (
 
     const addresses = new CoinjoinAddressController(xpub, network, checkpoints[0], params.cache);
 
-    let checkpoint = checkpoints[0];
+    let [checkpoint] = checkpoints;
     const checkpointCooldown = createCooldown(CHECKPOINT_COOLDOWN);
 
     const txs = new Set<BlockbookTransaction>();
@@ -90,8 +90,11 @@ export const scanAccount = async (
             pending = mempool.getTransactions(addresses).map(transformTx(xpub, addresses));
         }
 
-        checkpoint.receiveCount = addresses.receive.length;
-        checkpoint.changeCount = addresses.change.length;
+        checkpoint = {
+            ...checkpoint,
+            receiveCount: addresses.receive.length,
+            changeCount: addresses.change.length,
+        };
     }
 
     const cache = {

--- a/packages/coinjoin/src/client/Status.ts
+++ b/packages/coinjoin/src/client/Status.ts
@@ -2,6 +2,7 @@ import { TypedEmitter } from '@trezor/utils/lib/typedEventEmitter';
 
 import * as coordinator from './coordinator';
 import { transformStatus } from '../utils/roundUtils';
+import { patchResponse } from '../utils/http';
 import { coordinatorRequest } from './coordinatorRequest';
 import { STATUS_TIMEOUT } from '../constants';
 import { RoundPhase } from '../enums';
@@ -229,7 +230,7 @@ export class Status extends TypedEmitter<StatusEvents> {
                 identity: this.identities[0],
                 attempts: 3, // schedule 3 attempts on start
             },
-        );
+        ).then(response => patchResponse(response));
 
         return version
             ? ({

--- a/packages/coinjoin/src/client/coordinator.ts
+++ b/packages/coinjoin/src/client/coordinator.ts
@@ -1,4 +1,5 @@
-import { coordinatorRequest as request, RequestOptions } from './coordinatorRequest';
+import { coordinatorRequest, RequestOptions } from './coordinatorRequest';
+import { patchResponse } from '../utils/http';
 import {
     CoinjoinStatus,
     ZeroCredentials,
@@ -8,6 +9,9 @@ import {
     RegistrationData,
 } from '../types/coordinator';
 import { AFFILIATION_ID } from '../constants';
+
+const request = <T>(...args: Parameters<typeof coordinatorRequest>) =>
+    coordinatorRequest<T>(...args).then(result => patchResponse(result));
 
 export const getStatus = async (options: RequestOptions) => {
     const data = await request<CoinjoinStatus>(

--- a/packages/coinjoin/src/client/coordinatorRequest.ts
+++ b/packages/coinjoin/src/client/coordinatorRequest.ts
@@ -2,7 +2,7 @@ import { scheduleAction, enumUtils } from '@trezor/utils';
 
 import { HTTP_REQUEST_TIMEOUT } from '../constants';
 import { WabiSabiProtocolErrorCode } from '../enums';
-import { httpPost, httpGet, RequestOptions } from '../utils/http';
+import { httpPost, httpGet, patchResponse, RequestOptions } from '../utils/http';
 
 export type { RequestOptions } from '../utils/http';
 
@@ -114,9 +114,10 @@ export const coordinatorRequest = async <R = void>(
         return result;
     }
 
+    const protocolError = patchResponse(result);
     // catch WabiSabiProtocolException
-    if (typeof result === 'object' && 'errorCode' in result) {
-        throw new WabiSabiProtocolException(result);
+    if (typeof protocolError === 'object' && 'errorCode' in protocolError) {
+        throw new WabiSabiProtocolException(protocolError);
     }
 
     // fallback error

--- a/packages/coinjoin/src/utils/http.ts
+++ b/packages/coinjoin/src/utils/http.ts
@@ -10,6 +10,31 @@ export interface RequestOptions extends ScheduleActionParams {
     userAgent?: string;
 }
 
+const skipPascalCasePatch = ['Type', 'BackenMajordVersion', 'LegalDocumentsVersion'];
+const pascalCaseToCamelCase = (key: string) => {
+    if (skipPascalCasePatch.includes(key)) return key;
+    return key.charAt(0).toLowerCase() + key.slice(1);
+};
+
+export const patchResponse = (obj: any) => {
+    if (Array.isArray(obj)) {
+        for (let i = 0; i < obj.length; i++) {
+            patchResponse(obj[i]);
+        }
+    } else if (obj && typeof obj === 'object') {
+        Object.keys(obj).forEach(key => {
+            const newKey = pascalCaseToCamelCase(key);
+            obj[newKey] = obj[key];
+            if (key !== newKey) {
+                delete obj[key];
+            }
+            patchResponse(obj[newKey]);
+        });
+    }
+
+    return obj;
+};
+
 const createHeaders = (options: RequestOptions) => {
     const headers: HeadersInit = {
         'Content-Type': 'application/json; charset=utf-8',

--- a/packages/coinjoin/tests/client/CoinjoinClient.test.ts
+++ b/packages/coinjoin/tests/client/CoinjoinClient.test.ts
@@ -33,8 +33,9 @@ describe(`CoinjoinClient`, () => {
         const cli = new CoinjoinClient(server?.requestOptions);
 
         const status = await cli.enable();
-        expect(status?.rounds.length).toBeGreaterThan(0);
-        expect(status?.coordinationFeeRate.rate).toBeGreaterThan(0);
+        if (!status.success) throw new Error(`Client not enabled ${status.error}`);
+        expect(status.rounds.length).toBeGreaterThan(0);
+        expect(status.coordinationFeeRate.rate).toBeGreaterThan(0);
 
         cli.disable();
     });

--- a/packages/coinjoin/tests/client/coordinatorRequest.test.ts
+++ b/packages/coinjoin/tests/client/coordinatorRequest.test.ts
@@ -48,7 +48,7 @@ describe('http', () => {
         });
 
         await expect(coordinatorRequest('status', {}, { baseUrl })).rejects.toThrow(
-            'Internal Server Error: InternalErrorCodeExample',
+            'Internal Server Error (500) InternalErrorCodeExample',
         );
     });
 
@@ -62,7 +62,7 @@ describe('http', () => {
         });
 
         await expect(coordinatorRequest('status', {}, { baseUrl })).rejects.toThrow(
-            'Internal Server Error: InternalErrorCodeExample',
+            'Internal Server Error (500) InternalErrorCodeExample',
         );
     });
 

--- a/packages/suite/src/actions/wallet/__fixtures__/mockCoinjoinService.ts
+++ b/packages/suite/src/actions/wallet/__fixtures__/mockCoinjoinService.ts
@@ -9,6 +9,7 @@ export const mockCoinjoinService = () => {
             emit: jest.fn(),
             enable: jest.fn(() =>
                 Promise.resolve({
+                    success: true,
                     rounds: [{ id: '00', phase: 0 }],
                     feeRateMedian: 0,
                     coordinatorFeeRate: 0.003,

--- a/packages/suite/src/actions/wallet/coinjoinClientActions.ts
+++ b/packages/suite/src/actions/wallet/coinjoinClientActions.ts
@@ -752,8 +752,8 @@ export const initCoinjoinService =
             });
             const { client } = service;
             const status = await client.enable();
-            if (!status) {
-                throw new Error('status is missing');
+            if (!status.success) {
+                throw new Error(status.error);
             }
             // handle status change
             client.on('status', status => dispatch(clientOnStatusEvent(symbol, status)));
@@ -776,7 +776,7 @@ export const initCoinjoinService =
             dispatch(
                 notificationsActions.addToast({
                     type: 'error',
-                    error: `Coinjoin client not enabled: ${error.message}`,
+                    error: `CoinjoinClient ${error.message}`,
                 }),
             );
         }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Wasabi coordinator responses [are now returned](https://github.com/zkSNACKs/WalletWasabi/pull/11080) in `PascalCase` (testnet) while mainnet is still in cameCase.

Adding a patch to json responses to convert PascalCase to camelCase until both coordinators (testnet/mainnet) will have them unified.

