### PR TITLE
fix(suite-native): graph event normalization

### DIFF
--- a/suite-common/graph/src/hooks.ts
+++ b/suite-common/graph/src/hooks.ts
@@ -46,6 +46,8 @@ const normalizeExtremeGraphEvents = (
     startOfTimeFrameDate: Date,
     endOfTimeFrameDate: Date,
 ) => {
+    if (A.isEmpty(events)) return;
+
     const timeframeUnixLength = endOfTimeFrameDate.getTime() - startOfTimeFrameDate.getTime();
     const minimalEdgeOffset = timeframeUnixLength * EVENT_MINIMAL_PROPORTIONAL_EDGE_OFFSET;
 


### PR DESCRIPTION
If the array of graph events was empty, the normalization function threw an error. Does not happen anymore.

Closes #9158
