### PR TITLE
Feat(coinmarket): edit quote payment methods to accept even not speci…

### DIFF
--- a/packages/suite/package.json
+++ b/packages/suite/package.json
@@ -114,7 +114,7 @@
         "@testing-library/react": "14.0.0",
         "@testing-library/user-event": "14.4.3",
         "@types/file-saver": "^2.0.5",
-        "@types/invity-api": "^1.0.11",
+        "@types/invity-api": "^1.0.13",
         "@types/jws": "^3.2.5",
         "@types/pdfmake": "^0.2.2",
         "@types/qrcode.react": "^1.0.2",

--- a/packages/suite/src/components/wallet/CoinmarketBuyOfferInfo/index.tsx
+++ b/packages/suite/src/components/wallet/CoinmarketBuyOfferInfo/index.tsx
@@ -112,6 +112,7 @@ const CoinmarketBuyOfferInfo = ({
         receiveCurrency,
         exchange,
         paymentMethod,
+        paymentMethodName,
         fiatCurrency,
         fiatStringAmount,
     } = selectedQuote;
@@ -164,7 +165,10 @@ const CoinmarketBuyOfferInfo = ({
                         <Translation id="TR_BUY_PAID_BY" />
                     </LeftColumn>
                     <RightColumn>
-                        <CoinmarketPaymentType method={paymentMethod} />
+                        <CoinmarketPaymentType
+                            method={paymentMethod}
+                            methodName={paymentMethodName}
+                        />
                     </RightColumn>
                 </Row>
             </Info>

--- a/packages/suite/src/components/wallet/CoinmarketLayout/components/AccountTransactions/components/BuyTransaction/index.tsx
+++ b/packages/suite/src/components/wallet/CoinmarketLayout/components/AccountTransactions/components/BuyTransaction/index.tsx
@@ -143,6 +143,7 @@ const BuyTransaction = ({ trade, providers, account }: BuyTransactionProps) => {
         receiveStringAmount,
         exchange,
         paymentMethod,
+        paymentMethodName,
         receiveCurrency,
     } = data;
 
@@ -204,7 +205,7 @@ const BuyTransaction = ({ trade, providers, account }: BuyTransactionProps) => {
                     <CoinmarketProviderInfo exchange={exchange} providers={providers} />
                 </Row>
                 <RowSecond>
-                    <CoinmarketPaymentType method={paymentMethod} />
+                    <CoinmarketPaymentType method={paymentMethod} methodName={paymentMethodName} />
                 </RowSecond>
             </ProviderColumn>
             <BuyColumn>

--- a/packages/suite/src/components/wallet/CoinmarketLayout/components/AccountTransactions/components/SavingsTransaction/index.tsx
+++ b/packages/suite/src/components/wallet/CoinmarketLayout/components/AccountTransactions/components/SavingsTransaction/index.tsx
@@ -115,6 +115,7 @@ const SavingsTransaction = ({ trade, providers, account }: SavingsTransactionPro
         receiveCurrency,
         exchange,
         paymentMethod,
+        paymentMethodName,
     } = data;
 
     return (
@@ -145,7 +146,7 @@ const SavingsTransaction = ({ trade, providers, account }: SavingsTransactionPro
                     <CoinmarketProviderInfo exchange={exchange} providers={providers} />
                 </Row>
                 <RowSecond>
-                    <CoinmarketPaymentType method={paymentMethod} />
+                    <CoinmarketPaymentType method={paymentMethod} methodName={paymentMethodName} />
                 </RowSecond>
             </ProviderColumn>
         </Wrapper>

--- a/packages/suite/src/components/wallet/CoinmarketLayout/components/AccountTransactions/components/SellTransaction/index.tsx
+++ b/packages/suite/src/components/wallet/CoinmarketLayout/components/AccountTransactions/components/SellTransaction/index.tsx
@@ -138,6 +138,7 @@ const SellTransaction = ({ trade, providers, account }: SellTransactionProps) =>
         cryptoStringAmount,
         exchange,
         paymentMethod,
+        paymentMethodName,
         cryptoCurrency,
     } = data;
 
@@ -213,7 +214,7 @@ const SellTransaction = ({ trade, providers, account }: SellTransactionProps) =>
                     <CoinmarketProviderInfo exchange={exchange} providers={providers} />
                 </Row>
                 <RowSecond>
-                    <CoinmarketPaymentType method={paymentMethod} />
+                    <CoinmarketPaymentType method={paymentMethod} methodName={paymentMethodName} />
                 </RowSecond>
             </ProviderColumn>
             <SellColumn>

--- a/packages/suite/src/components/wallet/CoinmarketPaymentType/index.tsx
+++ b/packages/suite/src/components/wallet/CoinmarketPaymentType/index.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 import styled from 'styled-components';
 import { variables } from '@trezor/components';
 import invityApi from 'src/services/suite/invityAPI';
-import { BuyCryptoPaymentMethod, SavingsPaymentMethod } from 'invity-api';
+import { BuyCryptoPaymentMethod, SavingsPaymentMethod, SellCryptoPaymentMethod } from 'invity-api';
 import { Translation } from 'src/components/suite';
 
 const Wrapper = styled.div`
@@ -35,34 +35,49 @@ const Text = styled.div`
 
 interface CoinmarketPaymentTypeProps {
     children?: React.ReactNode;
-    method?: BuyCryptoPaymentMethod | SavingsPaymentMethod;
+    method?: BuyCryptoPaymentMethod | SellCryptoPaymentMethod | SavingsPaymentMethod;
+    methodName?: string;
 }
+type TranslatedPaymentMethod = 'bankTransfer' | 'creditCard';
 
-export const CoinmarketPaymentType = ({ children, method }: CoinmarketPaymentTypeProps) => (
+type PaymentMethodId = `TR_PAYMENT_METHOD_${Uppercase<TranslatedPaymentMethod>}`;
+
+const getPaymentMethod = (method: TranslatedPaymentMethod): PaymentMethodId =>
+    `TR_PAYMENT_METHOD_${method.toUpperCase() as Uppercase<TranslatedPaymentMethod>}`;
+
+export const CoinmarketPaymentType = ({
+    children,
+    method,
+    methodName,
+}: CoinmarketPaymentTypeProps) => (
     <Wrapper>
-        {!method && (
-            <Text>
-                <Translation id="TR_PAYMENT_METHOD_UNKNOWN" />
-            </Text>
-        )}
-        {method && (
-            <>
-                <IconWrapper>
-                    <Bg>
-                        <Icon
-                            width="24px"
-                            src={`${invityApi.getApiServerUrl()}/images/paymentMethods/suite/${method}.svg`}
-                        />
-                    </Bg>
-                </IconWrapper>
-                <div>
-                    {/* temporary solution - payment method name will be returned by API server to be independent on translations */}
-                    <Text>
-                        <Translation id={`TR_PAYMENT_METHOD_${method.toUpperCase()}` as any} />
-                    </Text>
-                    {children}
-                </div>
-            </>
-        )}
+        <>
+            <IconWrapper>
+                <Bg>
+                    <Icon
+                        width="24px"
+                        src={`${invityApi.getApiServerUrl()}/images/paymentMethods/suite/${method}.svg`}
+                    />
+                </Bg>
+            </IconWrapper>
+            <div>
+                <Text>
+                    {method ? (
+                        <>
+                            {method === 'bankTransfer' || method === 'creditCard' ? (
+                                <Translation id={getPaymentMethod(method)} />
+                            ) : (
+                                <Text>{methodName || method}</Text>
+                            )}
+                        </>
+                    ) : (
+                        <Text>
+                            <Translation id="TR_PAYMENT_METHOD_UNKNOWN" />
+                        </Text>
+                    )}
+                </Text>
+                {children}
+            </div>
+        </>
     </Wrapper>
 );

--- a/packages/suite/src/components/wallet/CoinmarketSellOfferInfo/index.tsx
+++ b/packages/suite/src/components/wallet/CoinmarketSellOfferInfo/index.tsx
@@ -112,6 +112,7 @@ const CoinmarketSellOfferInfo = ({
         cryptoCurrency,
         exchange,
         paymentMethod,
+        paymentMethodName,
         fiatCurrency,
         fiatStringAmount,
     } = selectedQuote;
@@ -164,7 +165,10 @@ const CoinmarketSellOfferInfo = ({
                         <Translation id="TR_SELL_PAID_BY" />
                     </LeftColumn>
                     <RightColumn>
-                        <CoinmarketPaymentType method={paymentMethod} />
+                        <CoinmarketPaymentType
+                            method={paymentMethod}
+                            methodName={paymentMethodName}
+                        />
                     </RightColumn>
                 </Row>
             </Info>

--- a/packages/suite/src/support/messages.ts
+++ b/packages/suite/src/support/messages.ts
@@ -4531,68 +4531,9 @@ export default defineMessages({
         defaultMessage: 'Bank Transfer',
         dynamic: true,
     },
-    TR_PAYMENT_METHOD_BANCONTACT: {
-        id: 'TR_PAYMENT_METHOD_BANCONTACT',
-        defaultMessage: 'Bancontact',
-        dynamic: true,
-    },
-    TR_PAYMENT_METHOD_SOFORT: {
-        id: 'TR_PAYMENT_METHOD_SOFORT',
-        defaultMessage: 'Sofort',
-        dynamic: true,
-    },
-    TR_PAYMENT_METHOD_IDEAL: {
-        id: 'TR_PAYMENT_METHOD_IDEAL',
-        defaultMessage: 'iDEAL',
-        dynamic: true,
-    },
-    TR_PAYMENT_METHOD_SEPA: {
-        id: 'TR_PAYMENT_METHOD_SEPA',
-        defaultMessage: 'SEPA',
-        dynamic: true,
-    },
-    TR_PAYMENT_METHOD_GIROPAY: {
-        id: 'TR_PAYMENT_METHOD_GIROPAY',
-        defaultMessage: 'Giropay',
-        dynamic: true,
-    },
-    TR_PAYMENT_METHOD_EPS: {
-        id: 'TR_PAYMENT_METHOD_EPS',
-        defaultMessage: 'EPS',
-        dynamic: true,
-    },
-    TR_PAYMENT_METHOD_APPLEPAY: {
-        id: 'TR_PAYMENT_METHOD_APPLEPAY',
-        defaultMessage: 'Apple Pay',
-        dynamic: true,
-    },
-    TR_PAYMENT_METHOD_UNKNOWN: {
-        id: 'TR_PAYMENT_METHOD_UNKNOWN',
-        defaultMessage: 'Unknown',
-    },
-    TR_PAYMENT_METHOD_POLI: {
-        id: 'TR_PAYMENT_METHOD_POLI',
-        defaultMessage: 'POLi',
-        dynamic: true,
-    },
-    TR_PAYMENT_METHOD_AUSPOST: {
-        id: 'TR_PAYMENT_METHOD_AUSPOST',
-        defaultMessage: 'Australia Post',
-        dynamic: true,
-    },
     TR_PAYMENT_METHOD_WORLDPAYCREDIT: {
         id: 'TR_PAYMENT_METHOD_WORLDPAYCREDIT',
         defaultMessage: 'Worldpay Credit',
-        dynamic: true,
-    },
-    TR_PAYMENT_METHOD_BPAY: {
-        id: 'TR_PAYMENT_METHOD_BPAY',
-        defaultMessage: 'BPAY',
-        dynamic: true,
-    },
-    TR_PAYMENT_METHOD_DCINTERAC: {
-        id: 'TR_PAYMENT_METHOD_DCINTERAC',
-        defaultMessage: 'DC Interac',
         dynamic: true,
     },
     TR_PAYMENT_METHOD_TEN31SEPA: {
@@ -4603,51 +4544,6 @@ export default defineMessages({
     TR_PAYMENT_METHOD_ACH: {
         id: 'TR_PAYMENT_METHOD_ACH',
         defaultMessage: 'ACH',
-        dynamic: true,
-    },
-    TR_PAYMENT_METHOD_PAYNOW: {
-        id: 'TR_PAYMENT_METHOD_PAYNOW',
-        defaultMessage: 'PayNow',
-        dynamic: true,
-    },
-    TR_PAYMENT_METHOD_FPS: {
-        id: 'TR_PAYMENT_METHOD_FPS',
-        defaultMessage: 'FPS',
-        dynamic: true,
-    },
-    TR_PAYMENT_METHOD_PROMPTPAY: {
-        id: 'TR_PAYMENT_METHOD_PROMPTPAY',
-        defaultMessage: 'PromptPay',
-        dynamic: true,
-    },
-    TR_PAYMENT_METHOD_INSTAPAY: {
-        id: 'TR_PAYMENT_METHOD_INSTAPAY',
-        defaultMessage: 'InstaPay',
-        dynamic: true,
-    },
-    TR_PAYMENT_METHOD_UPI: {
-        id: 'TR_PAYMENT_METHOD_UPI',
-        defaultMessage: 'UPI',
-        dynamic: true,
-    },
-    TR_PAYMENT_METHOD_GOJEKID: {
-        id: 'TR_PAYMENT_METHOD_GOJEKID',
-        defaultMessage: 'GoJek',
-        dynamic: true,
-    },
-    TR_PAYMENT_METHOD_VIETTELPAY: {
-        id: 'TR_PAYMENT_METHOD_VIETTELPAY',
-        defaultMessage: 'ViettelPay',
-        dynamic: true,
-    },
-    TR_PAYMENT_METHOD_DUITNOW: {
-        id: 'TR_PAYMENT_METHOD_DUITNOW',
-        defaultMessage: 'DuitNow',
-        dynamic: true,
-    },
-    TR_PAYMENT_METHOD_PAYID: {
-        id: 'TR_PAYMENT_METHOD_PAYID',
-        defaultMessage: 'PayID',
         dynamic: true,
     },
     TR_PAYMENT_METHOD_NZBANKTRANSFER: {
@@ -4664,6 +4560,10 @@ export default defineMessages({
         id: 'TR_PAYMENT_METHOD_PAY4FUN',
         defaultMessage: 'Pay4Fun',
         dynamic: true,
+    },
+    TR_PAYMENT_METHOD_UNKNOWN: {
+        id: 'TR_PAYMENT_METHOD_UNKNOWN',
+        defaultMessage: 'Unknown',
     },
     TR_OFFER_FEE_INFO: {
         id: 'TR_OFFER_FEE_INFO',

--- a/packages/suite/src/views/wallet/coinmarket/buy/offers/Offers/List/Quote/index.tsx
+++ b/packages/suite/src/views/wallet/coinmarket/buy/offers/Offers/List/Quote/index.tsx
@@ -232,7 +232,7 @@ const Quote = ({ className, quote, wantCrypto }: QuoteProps) => {
     const theme = useTheme();
     const { selectQuote, providersInfo } = useCoinmarketBuyOffersContext();
     const { tag, infoNote } = getTagAndInfoNote(quote);
-    const { paymentMethod, exchange, error } = quote;
+    const { paymentMethod, paymentMethodName, exchange, error } = quote;
 
     return (
         <Wrapper className={className}>
@@ -284,7 +284,10 @@ const Quote = ({ className, quote, wantCrypto }: QuoteProps) => {
                         <Translation id="TR_BUY_PAID_BY" />
                     </Heading>
                     <Value>
-                        <CoinmarketPaymentType method={paymentMethod} />
+                        <CoinmarketPaymentType
+                            method={paymentMethod}
+                            methodName={paymentMethodName}
+                        />
                     </Value>
                 </Column>
                 <Column>

--- a/packages/suite/src/views/wallet/coinmarket/sell/offers/Offers/List/Quote/index.tsx
+++ b/packages/suite/src/views/wallet/coinmarket/sell/offers/Offers/List/Quote/index.tsx
@@ -237,7 +237,7 @@ const Quote = ({ className, quote, amountInCrypto }: QuoteProps) => {
     const { selectQuote, sellInfo, needToRegisterOrVerifyBankAccount } =
         useCoinmarketSellOffersContext();
     const { tag, infoNote } = getTagAndInfoNote(quote);
-    const { paymentMethod, exchange, error, bankAccounts } = quote;
+    const { paymentMethod, paymentMethodName, exchange, error, bankAccounts } = quote;
     if (!exchange || !sellInfo) return null;
 
     // show bank account verification info if no verified account and no error and BANK_ACCOUNT flow
@@ -301,7 +301,10 @@ const Quote = ({ className, quote, amountInCrypto }: QuoteProps) => {
                         <Translation id="TR_SELL_PAID_BY" />
                     </Heading>
                     <Value>
-                        <CoinmarketPaymentType method={paymentMethod}>
+                        <CoinmarketPaymentType
+                            method={paymentMethod}
+                            methodName={paymentMethodName}
+                        >
                             {verificationInfo && (
                                 <VerificationInfo>
                                     <Translation id="TR_SELL_BANK_ACCOUNT_VERIFICATION_INFO" />

--- a/yarn.lock
+++ b/yarn.lock
@@ -9770,7 +9770,7 @@ __metadata:
     "@trezor/utils": "workspace:*"
     "@trezor/validation": "workspace:*"
     "@types/file-saver": ^2.0.5
-    "@types/invity-api": ^1.0.11
+    "@types/invity-api": ^1.0.13
     "@types/jws": ^3.2.5
     "@types/pdfmake": ^0.2.2
     "@types/qrcode.react": ^1.0.2
@@ -10610,10 +10610,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@types/invity-api@npm:^1.0.11":
-  version: 1.0.11
-  resolution: "@types/invity-api@npm:1.0.11"
-  checksum: c84646f4d072f4dd970cc8a55fc9ee1706d3fae162589f9044f6b6ac76dffb6f69074b15dfe4ed5686b06857ebb9261b4e4dfa0a825269a314c3f08bc74283c1
+"@types/invity-api@npm:^1.0.13":
+  version: 1.0.13
+  resolution: "@types/invity-api@npm:1.0.13"
+  checksum: bc30850cdc5f3faf8180427e3314e5b18661ae293a98f127ef491a44ea51da0de15075319370ce70df467ea5c594f633736438777bbeaca3eff0d1600080a17a
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Description
The goal is to be able add even not yet specified payments methods for sell, buy and savings.

## Related Issue

Resolve #9228 

## Screenshots:
<img width="738" alt="Screenshot 2023-08-11 at 13 00 43" src="https://github.com/trezor/trezor-suite/assets/41970479/a6cab4ee-27fb-4b0e-a6c1-43dd7c9a9942">
 - Example of new payment. The payment method icon is not visible because I add non existing payment method - with no image.
 - 
