### PR TITLE
Fix/connect CoinInfo with FeeLevels

### DIFF
--- a/packages/blockchain-link/src/utils/ws.ts
+++ b/packages/blockchain-link/src/utils/ws.ts
@@ -54,4 +54,4 @@ class WSWrapper extends EventEmitter {
     }
 }
 
-export = WSWrapper;
+export default WSWrapper;

--- a/packages/connect/src/api/bitcoin/TransactionComposer.ts
+++ b/packages/connect/src/api/bitcoin/TransactionComposer.ts
@@ -5,8 +5,7 @@ import { composeTx, ComposeInput, ComposeOutput, ComposeResult } from '@trezor/u
 import { FeeLevels } from './Fees';
 import { Blockchain } from '../../backend/BlockchainLink';
 import { getHDPath } from '../../utils/pathUtils';
-import type { BitcoinNetworkInfo } from '../../types';
-import type { DiscoveryAccount, SelectFeeLevel } from '../../types/account';
+import type { BitcoinNetworkInfo, DiscoveryAccount, SelectFeeLevel } from '../../types';
 import type { PrecomposeParams } from '../../types/api/composeTransaction';
 
 type Options = {
@@ -139,7 +138,7 @@ export class TransactionComposer {
                     name: level.label,
                     fee: tx.fee,
                     feePerByte: level.feePerUnit,
-                    minutes: level.blocks * this.coinInfo.blocktime,
+                    minutes: level.blocks * this.coinInfo.blockTime,
                     total: tx.totalSpent,
                 });
             } else {

--- a/packages/connect/src/api/blockchainEstimateFee.ts
+++ b/packages/connect/src/api/blockchainEstimateFee.ts
@@ -61,7 +61,7 @@ export default class BlockchainEstimateFee extends AbstractMethod<'blockchainEst
     async run() {
         const { coinInfo, request } = this.params;
         const feeInfo: MethodReturnType<typeof this.name> = {
-            blockTime: coinInfo.blocktime,
+            blockTime: coinInfo.blockTime,
             minFee: coinInfo.minFee,
             maxFee: coinInfo.maxFee,
             dustLimit: coinInfo.type === 'bitcoin' ? coinInfo.dustLimit : undefined,

--- a/packages/connect/src/data/__tests__/coinInfo.test.ts
+++ b/packages/connect/src/data/__tests__/coinInfo.test.ts
@@ -21,7 +21,7 @@ describe('data/coinInfo', () => {
     it('bitcoin network blocktime', () => {
         const bitcoinNetworks = getAllNetworks().filter(({ type }) => type === 'bitcoin');
         bitcoinNetworks.forEach(network => {
-            expect(network.blocktime).toBeGreaterThan(0);
+            expect(network.blockTime).toBeGreaterThan(0);
         });
     });
 });

--- a/packages/connect/src/data/__tests__/coinInfo.test.ts
+++ b/packages/connect/src/data/__tests__/coinInfo.test.ts
@@ -1,5 +1,5 @@
 import coinsJSON from '@trezor/connect-common/files/coins.json';
-import { parseCoinsJson, getCoinInfo, getUniqueNetworks } from '../coinInfo';
+import { parseCoinsJson, getCoinInfo, getUniqueNetworks, getAllNetworks } from '../coinInfo';
 
 describe('data/coinInfo', () => {
     beforeAll(() => {
@@ -16,5 +16,12 @@ describe('data/coinInfo', () => {
         ];
         const result = [getCoinInfo('btc'), getCoinInfo('ltc')];
         expect(getUniqueNetworks(inputs)).toEqual(result);
+    });
+
+    it('bitcoin network blocktime', () => {
+        const bitcoinNetworks = getAllNetworks().filter(({ type }) => type === 'bitcoin');
+        bitcoinNetworks.forEach(network => {
+            expect(network.blocktime).toBeGreaterThan(0);
+        });
     });
 });

--- a/packages/connect/src/data/coinInfo.ts
+++ b/packages/connect/src/data/coinInfo.ts
@@ -189,7 +189,7 @@ const parseBitcoinNetworksJson = (json: any) => {
             // bitcore: not used,
             // blockbook: not used,
             blockchainLink: coin.blockchain_link,
-            blocktime: Math.round(coin.blocktime_seconds / 60),
+            blocktime: Math.max(1, Math.round(coin.blocktime_seconds / 60)),
             cashAddrPrefix: coin.cashaddr_prefix,
             label: coin.coin_label,
             name: coin.coin_name,

--- a/packages/connect/src/data/coinInfo.ts
+++ b/packages/connect/src/data/coinInfo.ts
@@ -1,5 +1,6 @@
 // origin: https://github.com/trezor/connect/blob/develop/src/js/data/CoinInfo.js
 
+import { getBitcoinFeeLevels, getEthereumFeeLevels, getMiscFeeLevels } from './defaultFeeLevels';
 import { ERRORS } from '../constants';
 import { toHardened, fromHardened } from '../utils/pathUtils';
 import type {
@@ -189,7 +190,6 @@ const parseBitcoinNetworksJson = (json: any) => {
             // bitcore: not used,
             // blockbook: not used,
             blockchainLink: coin.blockchain_link,
-            blocktime: Math.max(1, Math.round(coin.blocktime_seconds / 60)),
             cashAddrPrefix: coin.cashaddr_prefix,
             label: coin.coin_label,
             name: coin.coin_name,
@@ -197,8 +197,6 @@ const parseBitcoinNetworksJson = (json: any) => {
             // cooldown not used
             curveName: coin.curve_name,
             // decred not used
-            defaultFees: coin.default_fee_b,
-            dustLimit: coin.dust_limit,
             forceBip143: coin.force_bip143,
             // forkid in Network
             // github not used
@@ -226,29 +224,17 @@ const parseBitcoinNetworksJson = (json: any) => {
             // custom
             network, // bitcoinjs network
             isBitcoin,
-            maxFee: Math.round(coin.maxfee_kb / 1000),
-            minFee: Math.round(coin.minfee_kb / 1000),
 
             decimals: coin.decimals,
+            ...getBitcoinFeeLevels(coin),
         });
     });
 };
 
 export const ethereumNetworkInfoBase = {
     type: 'ethereum' as const,
-    blocktime: -1, // unknown
-    // key not used
-    defaultFees: [
-        {
-            label: 'normal' as const,
-            feePerUnit: '5000000000',
-            feeLimit: '21000',
-        },
-    ],
-    minFee: 1,
-    maxFee: 10000,
-    network: undefined,
     decimals: 16,
+    ...getEthereumFeeLevels(),
 };
 
 const parseEthereumNetworksJson = (json: any) => {
@@ -271,38 +257,17 @@ const parseEthereumNetworksJson = (json: any) => {
 const parseMiscNetworksJSON = (json: any, type?: 'misc' | 'nem') => {
     Object.keys(json).forEach(key => {
         const network = json[key];
-        let minFee = -1; // unknown
-        let maxFee = -1; // unknown
-        let defaultFees = { Normal: -1 }; // unknown
-        const shortcut = network.shortcut.toLowerCase();
-        if (shortcut === 'xrp' || shortcut === 'txrp') {
-            minFee = 10;
-            maxFee = 10000;
-            defaultFees = { Normal: 12 };
-        }
-        if (shortcut === 'ada' || shortcut === 'tada') {
-            minFee = 44;
-            // max tx size * lovelace per byte + base fee
-            maxFee = 16384 * 44 + 155381;
-            defaultFees = { Normal: 44 };
-        }
         miscNetworks.push({
             type: type || 'misc',
             blockchainLink: network.blockchain_link,
-            blocktime: -1,
             curve: network.curve,
-            // TODO: https://github.com/trezor/trezor-suite/issues/5340
-            // @ts-expect-error
-            defaultFees,
-            minFee,
-            maxFee,
             label: network.name,
             name: network.name,
             shortcut: network.shortcut,
             slip44: network.slip44,
             support: network.support,
-            network: undefined,
             decimals: network.decimals,
+            ...getMiscFeeLevels(network),
         });
     });
 };

--- a/packages/connect/src/data/coinInfo.ts
+++ b/packages/connect/src/data/coinInfo.ts
@@ -229,8 +229,6 @@ const parseBitcoinNetworksJson = (json: any) => {
             maxFee: Math.round(coin.maxfee_kb / 1000),
             minFee: Math.round(coin.minfee_kb / 1000),
 
-            // used in backend ?
-            blocks: Math.round(coin.blocktime_seconds / 60),
             decimals: coin.decimals,
         });
     });

--- a/packages/connect/src/data/defaultFeeLevels.ts
+++ b/packages/connect/src/data/defaultFeeLevels.ts
@@ -1,0 +1,130 @@
+import { FeeLevel, FeeInfo } from '../types';
+
+// this is workaround for the lack of information from 'trezor-common'
+// we need to declare what does "high/normal/low" mean in block time (eg: normal BTC = 6 blocks = ~1 hour)
+// coins other than BTC usually got 2 levels maximum (high/low) and we should consider to remove other levels from 'trezor-common'
+const BLOCKS_FOR_FEE_LEVEL: Record<string, Record<string, number>> = {
+    btc: {
+        // blocktime ~ 600sec.
+        high: 1,
+        normal: 6,
+        economy: 36,
+        low: 144,
+    },
+    bch: {
+        // blocktime ~ 600sec.
+        high: 1,
+        normal: 5,
+        economy: 10,
+        low: 10,
+    },
+    btg: {
+        // blocktime ~ 600sec.
+        high: 1,
+        normal: 5,
+        economy: 10,
+        low: 10,
+    },
+    dgb: {
+        // blocktime ~ 20sec.
+        high: 1,
+        normal: 15,
+        economy: 30,
+        low: 60,
+    },
+};
+
+const getDefaultBlocksForFeeLevel = (shortcut: string, label: string) =>
+    BLOCKS_FOR_FEE_LEVEL[shortcut] && BLOCKS_FOR_FEE_LEVEL[shortcut][label]
+        ? BLOCKS_FOR_FEE_LEVEL[shortcut][label]
+        : -1; // -1 for unknown
+
+// partial data from coins.jon
+interface CoinsJsonData {
+    shortcut: string; // uppercase shortcut
+    // data below are defined and relevant only for bitcoin-like coins
+    blocktime_seconds: number;
+    default_fee_b: Record<'High' | 'Normal' | 'Economy' | 'Low', number>;
+    maxfee_kb: number;
+    minfee_kb: number;
+    dust_limit: number;
+}
+
+export type FeeInfoWithLevels = FeeInfo & { defaultFees: FeeLevel[] };
+
+export const getBitcoinFeeLevels = (coin: CoinsJsonData): FeeInfoWithLevels => {
+    // sort fee levels from coinInfo
+    // and transform in to FeeLevel object
+    const defaultFees = coin.default_fee_b;
+    const shortcut = coin.shortcut.toLowerCase();
+    const keys = Object.keys(defaultFees) as unknown as (keyof CoinsJsonData['default_fee_b'])[];
+    const levels = keys
+        .sort((levelA, levelB) => defaultFees[levelB] - defaultFees[levelA])
+        .map(level => {
+            const label = level.toLowerCase() as FeeLevel['label']; // string !== 'high' | 'normal'....
+            return {
+                label,
+                feePerUnit: defaultFees[level].toString(),
+                blocks: getDefaultBlocksForFeeLevel(shortcut, label),
+            };
+        });
+
+    return {
+        blockTime: Math.max(1, Math.round(coin.blocktime_seconds / 60)),
+        dustLimit: coin.dust_limit,
+        maxFee: Math.round(coin.maxfee_kb / 1000),
+        minFee: Math.round(coin.minfee_kb / 1000),
+        defaultFees: levels,
+    };
+};
+
+export const getEthereumFeeLevels = (): FeeInfoWithLevels => ({
+    blockTime: -1, // unknown
+    defaultFees: [
+        {
+            label: 'normal' as const,
+            feePerUnit: '5000000000',
+            feeLimit: '21000', // unlike the other networks ethereum have additional value "feeLimit" (Gas limit)
+            blocks: -1, // unknown
+        },
+    ],
+    minFee: 1,
+    maxFee: 10000,
+    dustLimit: -1, // unknown/unused
+});
+
+const RIPPLE_FEE_INFO: FeeInfoWithLevels = {
+    blockTime: -1, // unknown
+    defaultFees: [{ label: 'normal', feePerUnit: '12', blocks: -1 }],
+    minFee: 10,
+    maxFee: 10000,
+    dustLimit: -1, // unknown/unused
+};
+
+const CARDANO_FEE_INFO: FeeInfoWithLevels = {
+    blockTime: -1, // unknown
+    defaultFees: [{ label: 'normal', feePerUnit: '44', blocks: -1 }],
+    minFee: 44,
+    maxFee: 16384 * 44 + 155381,
+    dustLimit: -1, // unknown/unused
+};
+
+const MISC_FEE_LEVELS: Record<string, FeeInfoWithLevels> = {
+    xrp: RIPPLE_FEE_INFO,
+    txrp: RIPPLE_FEE_INFO,
+    ada: CARDANO_FEE_INFO,
+    tada: CARDANO_FEE_INFO,
+};
+
+export const getMiscFeeLevels = (data: CoinsJsonData): FeeInfoWithLevels => {
+    const shortcut = data.shortcut.toLowerCase();
+    return (
+        MISC_FEE_LEVELS[shortcut] || {
+            blockTime: -1,
+            minFee: -1,
+            maxFee: -1,
+            defaultFees: [{ label: 'normal', feePerUnit: '-1', blocks: -1 }],
+            dustLimit: -1,
+        }
+    );
+};

--- a/packages/connect/src/events/ui-request.ts
+++ b/packages/connect/src/events/ui-request.ts
@@ -5,8 +5,8 @@ import type { EventTypeDeviceSelected } from '@trezor/connect-analytics';
 
 import type { PROTO } from '../constants';
 import type { TransportDisableWebUSB, TransportRequestWebUSBDevice } from './transport';
-import type { Device, CoinInfo, BitcoinNetworkInfo } from '../types';
-import type { DiscoveryAccountType, DiscoveryAccount, SelectFeeLevel } from '../types/account';
+import type { Device, CoinInfo, BitcoinNetworkInfo, SelectFeeLevel } from '../types';
+import type { DiscoveryAccountType, DiscoveryAccount } from '../types/account';
 import type { MessageFactoryFn } from '../types/utils';
 import type { DeviceButtonRequest } from './device';
 

--- a/packages/connect/src/types/account.ts
+++ b/packages/connect/src/types/account.ts
@@ -27,25 +27,3 @@ export interface DiscoveryAccount {
     balance?: string;
     addresses?: AccountAddresses;
 }
-export interface FeeLevel {
-    label: 'high' | 'normal' | 'economy' | 'low' | 'custom';
-    feePerUnit: string;
-    blocks: number;
-    feeLimit?: string; // eth gas limit
-    feePerTx?: string; // fee for BlockchainEstimateFeeParams.request.specific
-}
-
-export type SelectFeeLevel =
-    | {
-          name: string;
-          fee: '0';
-          feePerByte?: undefined;
-          disabled: true;
-      }
-    | {
-          name: string;
-          fee: string;
-          feePerByte: string;
-          minutes: number;
-          total: string;
-      };

--- a/packages/connect/src/types/api/__tests__/blockchain.ts
+++ b/packages/connect/src/types/api/__tests__/blockchain.ts
@@ -7,6 +7,10 @@ export const blockchainEstimateFee = async (api: TrezorConnect) => {
         payload.blockTime.toFixed();
         payload.minFee.toFixed();
         payload.maxFee.toFixed();
+        // @ts-expect-error dustLimit may be undefined
+        payload.dustLimit.toFixed();
+        payload.dustLimit?.toFixed();
+
         payload.levels.forEach(level => {
             // @ts-expect-error label not present
             if (level.label === 'custom') {

--- a/packages/connect/src/types/api/blockchainEstimateFee.ts
+++ b/packages/connect/src/types/api/blockchainEstimateFee.ts
@@ -1,5 +1,5 @@
 import type { BlockchainLinkParams, BlockchainLinkResponse } from '@trezor/blockchain-link';
-import type { FeeLevel } from '../account';
+import type { FeeLevel, FeeInfo } from '../fees';
 import type { CommonParamsWithCoin, Response } from '../params';
 
 export interface BlockchainEstimateFee {
@@ -14,12 +14,10 @@ export interface BlockchainEstimateFeeLevel {
     };
 }
 
-interface EstimatedFee {
-    blockTime: number;
-    minFee: number;
-    maxFee: number;
-    dustLimit?: number;
+interface EstimatedFee extends Omit<FeeInfo, 'dustLimit'> {
+    dustLimit?: number; // dustLimit is set only for bitcoin-like coins
 }
+
 export interface BlockchainEstimatedFee extends EstimatedFee {
     levels: BlockchainLinkResponse<'estimateFee'>;
 }

--- a/packages/connect/src/types/coinInfo.ts
+++ b/packages/connect/src/types/coinInfo.ts
@@ -61,8 +61,6 @@ export interface BitcoinNetworkInfo extends Common {
     // custom
     network: Network;
     isBitcoin: boolean;
-    // used in backend
-    blocks?: number;
 }
 
 export interface EthereumNetworkInfo extends Common {

--- a/packages/connect/src/types/coinInfo.ts
+++ b/packages/connect/src/types/coinInfo.ts
@@ -1,3 +1,5 @@
+import { FeeLevel } from './fees';
+
 export interface CoinSupport {
     connect: boolean;
     trezor1: string;
@@ -23,9 +25,6 @@ export interface BlockchainLink {
     url: string[];
 }
 
-export type BitcoinDefaultFeesKeys = 'High' | 'Normal' | 'Economy' | 'Low';
-export type BitcoinDefaultFees = { [key in BitcoinDefaultFeesKeys]: number };
-
 interface Common {
     label: string; // Human readable format, label != name
     name: string; // Trezor readable format
@@ -34,9 +33,10 @@ interface Common {
     support: CoinSupport;
     decimals: number;
     blockchainLink?: BlockchainLink;
-    blocktime: number;
+    blockTime: number;
     minFee: number;
     maxFee: number;
+    defaultFees: FeeLevel[];
 }
 
 export interface BitcoinNetworkInfo extends Common {
@@ -50,7 +50,6 @@ export interface BitcoinNetworkInfo extends Common {
     maxFeeSatoshiKb: number;
     minAddressLength: number;
     minFeeSatoshiKb: number;
-    defaultFees: BitcoinDefaultFees;
     segwit: boolean;
 
     xPubMagic: number;
@@ -66,19 +65,13 @@ export interface BitcoinNetworkInfo extends Common {
 export interface EthereumNetworkInfo extends Common {
     type: 'ethereum';
     chainId: number;
-    defaultFees: Array<{
-        label: 'high' | 'normal' | 'low';
-        feePerUnit: string;
-        feeLimit: string;
-    }>;
-    network: typeof undefined;
+    network?: typeof undefined;
 }
 
 export interface MiscNetworkInfo extends Common {
     type: 'misc' | 'nem';
     curve: string;
-    defaultFees: BitcoinDefaultFees;
-    network: typeof undefined; // compatibility
+    network?: typeof undefined; // compatibility
 }
 
 export type CoinInfo = BitcoinNetworkInfo | EthereumNetworkInfo | MiscNetworkInfo;

--- a/packages/connect/src/types/fees.ts
+++ b/packages/connect/src/types/fees.ts
@@ -1,0 +1,29 @@
+export interface FeeInfo {
+    blockTime: number;
+    minFee: number;
+    maxFee: number;
+    dustLimit: number;
+}
+
+export interface FeeLevel {
+    label: 'high' | 'normal' | 'economy' | 'low' | 'custom';
+    feePerUnit: string;
+    blocks: number;
+    feeLimit?: string; // eth gas limit
+    feePerTx?: string; // fee for BlockchainEstimateFeeParams.request.specific
+}
+
+export type SelectFeeLevel =
+    | {
+          name: string;
+          fee: '0';
+          feePerByte?: undefined;
+          disabled: true;
+      }
+    | {
+          name: string;
+          fee: string;
+          feePerByte: string;
+          minutes: number;
+          total: string;
+      };

--- a/packages/connect/src/types/index.ts
+++ b/packages/connect/src/types/index.ts
@@ -2,6 +2,7 @@ export * from './api';
 export * from './account';
 export * from './coinInfo';
 export * from './device';
+export * from './fees';
 export * from './firmware';
 export * from './params';
 export * from './settings';


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

As usual i would like to do something else but i'm ending up with something unrelated (only at first glance) 🤯

I wanted to write missing test for [Fee estimation](https://github.com/trezor/trezor-suite/blob/develop/packages/connect/src/api/bitcoin/Fees.ts) to be able to properly calculate [new feature](https://github.com/trezor/trezor-suite/pull/9109/commits/46cc3e2faaf8920135e48829832601e87afa9d0d) called `longTermFeeRate` which will be used to [estimate dustThreshold](https://github.com/trezor/trezor-suite/pull/9109) but i noticed some issues, TODOs and forgotten chores regarding CoinInfo + FeeLevels so i firstly want to resolve them as prerequisite.

First commit (blockchain-link) is here because dev mode of blockchain-link is failing
`yarn workspace @trezor/blockchain-link dev`

## Related Issue

Resolve https://github.com/trezor/trezor-suite/issues/5340
