### PR TITLE
Resolve `MaxListenersExceededWarning` in CJ electron module

### DIFF
--- a/packages/suite-desktop-core/src/app.ts
+++ b/packages/suite-desktop-core/src/app.ts
@@ -135,7 +135,7 @@ const init = async () => {
 
     // init modules
     const interceptor = createInterceptor();
-    const loadModules = await initModules({
+    const loadModules = initModules({
         mainWindow,
         store,
         interceptor,


### PR DESCRIPTION
## Description

When electron app was reloaded by Ctrl+R, `dispose` func was repeatedly subscribed to `before-quit` and `did-start-loading` events. Now it's subscribed only once.

## Related Issue

Resolve #8839
