### PR TITLE
Fix/allow sending amount equal to dustLimit

### DIFF
--- a/packages/connect/src/api/bitcoin/TransactionComposer.ts
+++ b/packages/connect/src/api/bitcoin/TransactionComposer.ts
@@ -55,7 +55,7 @@ export class TransactionComposer {
                   .map(a => a.address);
         this.utxos = options.utxo.flatMap(u => {
             // exclude amounts lower than dust limit if they are NOT required
-            if (!u.required && new BigNumber(u.amount).lte(this.coinInfo.dustLimit)) return [];
+            if (!u.required && new BigNumber(u.amount).lt(this.coinInfo.dustLimit)) return [];
             const addressPath = getHDPath(u.path);
             const [chain, index] = addressPath.slice(addressPath.length - 2);
 

--- a/packages/connect/src/api/composeTransaction.ts
+++ b/packages/connect/src/api/composeTransaction.ts
@@ -94,7 +94,7 @@ export default class ComposeTransaction extends AbstractMethod<'composeTransacti
 
         // if outputs contains regular items
         // check if total amount is not lower than dust limit
-        // if (outputs.find(o => o.type === 'complete') !== undefined && total.lte(coinInfo.dustLimit)) {
+        // if (outputs.find(o => o.type === 'complete') !== undefined && total.lt(coinInfo.dustLimit)) {
         //     throw error 'Total amount is too low';
         // }
 

--- a/packages/connect/src/api/signTransaction.ts
+++ b/packages/connect/src/api/signTransaction.ts
@@ -112,7 +112,7 @@ export default class SignTransaction extends AbstractMethod<'signTransaction', P
                 (bn, output) => bn.plus(typeof output.amount === 'string' ? output.amount : '0'),
                 new BigNumber(0),
             );
-            if (total.lte(coinInfo.dustLimit)) {
+            if (total.lt(coinInfo.dustLimit)) {
                 throw ERRORS.TypedError(
                     'Method_InvalidParameter',
                     'Total amount is below dust limit.',

--- a/packages/suite/src/support/messages.ts
+++ b/packages/suite/src/support/messages.ts
@@ -5443,7 +5443,7 @@ export default defineMessages({
         id: 'AMOUNT_IS_TOO_LOW',
     },
     AMOUNT_IS_BELOW_DUST: {
-        defaultMessage: 'Amount must be greater than the dust limit ({dust})',
+        defaultMessage: 'Amount must be greater than or equal the dust limit ({dust})',
         id: 'AMOUNT_IS_BELOW_DUST',
     },
     AMOUNT_IS_MORE_THAN_RESERVE: {

--- a/packages/suite/src/views/wallet/send/components/Outputs/components/Amount/index.tsx
+++ b/packages/suite/src/views/wallet/send/components/Outputs/components/Amount/index.tsx
@@ -197,7 +197,7 @@ export const Amount = ({ output, outputId }: AmountProps) => {
                 let dust =
                     rawDust && (shouldSendInSats ? rawDust : formatNetworkAmount(rawDust, symbol));
 
-                if (dust && amountBig.lte(dust)) {
+                if (dust && amountBig.lt(dust)) {
                     if (shouldSendInSats) {
                         dust = amountToSatoshi(dust, decimals);
                     }

--- a/suite-common/wallet-utils/src/__tests__/sendFormUtils.test.ts
+++ b/suite-common/wallet-utils/src/__tests__/sendFormUtils.test.ts
@@ -386,17 +386,17 @@ describe('sendForm utils', () => {
         });
         const lowAnonymityDustUtxo = getUtxo({
             address: 'one',
-            amount: '1',
+            amount: '100',
             vout: 2,
         });
         const lowAnonymityUtxo = getUtxo({
             address: 'one',
-            amount: '2',
+            amount: '1000',
             vout: 3,
         });
         const spendableUtxo = getUtxo({
             address: 'two',
-            amount: '2',
+            amount: '546',
             vout: 4,
         });
 
@@ -404,7 +404,7 @@ describe('sendForm utils', () => {
             utxos: [dustUtxo, lowAnonymityDustUtxo, lowAnonymityUtxo, spendableUtxo],
             anonymitySet: { one: 1, two: 2 },
             targetAnonymity: 2,
-            dustLimit: 1,
+            dustLimit: 546,
         });
 
         expect(excludedUtxos[getUtxoOutpoint(dustUtxo)]).toBe('dust');

--- a/suite-common/wallet-utils/src/sendFormUtils.ts
+++ b/suite-common/wallet-utils/src/sendFormUtils.ts
@@ -464,7 +464,7 @@ export const getExcludedUtxos = ({
     utxos?.forEach(utxo => {
         const outpoint = getUtxoOutpoint(utxo);
         const anonymity = (anonymitySet && anonymitySet[utxo.address]) || 1;
-        if (new BigNumber(utxo.amount).lte(Number(dustLimit))) {
+        if (new BigNumber(utxo.amount).lt(Number(dustLimit))) {
             // is lower than dust limit
             excludedUtxos[outpoint] = 'dust';
         } else if (anonymity < (targetAnonymity || 1)) {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

cherry picked from [dust threshold calculation fix](https://github.com/trezor/trezor-suite/pull/9109)

Allowed amount to send should be greater **or equal** specified dust limit
