### PR TITLE
fix(suite): desktopApi usage in coinmarket spend form

### DIFF
--- a/packages/suite/src/hooks/wallet/useCoinmarketSpend.ts
+++ b/packages/suite/src/hooks/wallet/useCoinmarketSpend.ts
@@ -234,7 +234,9 @@ export const useCoinmarketSpend = ({
                         });
                         composeRequest();
                         setTrade(trade);
-                        desktopApi.appFocus();
+                        if (desktopApi.available) {
+                            desktopApi.appFocus();
+                        }
                     }
                 }
             };


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

The only usage of desktopApi.appFocus i've found

## Related Issue

Resolve https://github.com/trezor/trezor-suite/issues/9054
