### PR TITLE
Fix: Standard wallet as hidden + enable passphrase warning

### DIFF
--- a/packages/connect/src/core/index.ts
+++ b/packages/connect/src/core/index.ts
@@ -525,6 +525,7 @@ export const onCall = async (message: CoreMessage) => {
             }
 
             // Make sure that device will display pin/passphrase
+            const isDeviceUnlocked = device.features.unlocked;
             try {
                 const invalidDeviceState = method.useDeviceState
                     ? await device.validateState(method.network, method.preauthorized)
@@ -573,6 +574,12 @@ export const onCall = async (message: CoreMessage) => {
                 device.setInternalState(undefined);
                 // interrupt process and go to "final" block
                 return Promise.reject(error);
+            }
+
+            // emit additional CHANGE event if device becomes unlocked after authorization
+            // features were automatically updated after PinMatrixAck in DeviceCommands
+            if (!isDeviceUnlocked && device.features.unlocked) {
+                postMessage(createDeviceMessage(DEVICE.CHANGED, device.toMessageObject()));
             }
 
             if (method.useUi) {

--- a/packages/connect/src/device/DeviceCommands.ts
+++ b/packages/connect/src/device/DeviceCommands.ts
@@ -491,7 +491,14 @@ export class DeviceCommands {
 
         if (res.type === 'PinMatrixRequest') {
             return this._promptPin(res.message.type).then(
-                pin => this._commonCall('PinMatrixAck', { pin }),
+                pin =>
+                    this._commonCall('PinMatrixAck', { pin }).then(response => {
+                        if (!this.device.features.unlocked) {
+                            // reload features to after successful PIN
+                            return this.device.getFeatures().then(() => response);
+                        }
+                        return response;
+                    }),
                 () => this._commonCall('Cancel', {}),
             );
         }

--- a/packages/suite/src/reducers/suite/__fixtures__/deviceReducer.ts
+++ b/packages/suite/src/reducers/suite/__fixtures__/deviceReducer.ts
@@ -167,6 +167,7 @@ const connect = [
         initialState: [
             getSuiteDevice(
                 {
+                    useEmptyPassphrase: false,
                     instance: 1,
                 },
                 {

--- a/packages/suite/src/reducers/suite/deviceReducer.ts
+++ b/packages/suite/src/reducers/suite/deviceReducer.ts
@@ -110,15 +110,19 @@ const connectDevice = (draft: State, device: Device) => {
     if (affectedDevices.length > 0) {
         const changedDevices = affectedDevices.map(d => {
             // change availability according to "passphrase_protection" field
-            if (d.instance && isUnlocked(device.features) && !features.passphrase_protection) {
+            if (
+                !d.useEmptyPassphrase &&
+                isUnlocked(device.features) &&
+                !features.passphrase_protection
+            ) {
                 return merge(d, { ...device, connected: true, available: false });
             }
             return merge(d, { ...device, connected: true, available: true });
         });
 
         // affected device with current "passphrase_protection" does not exists
-        // basically it means that the "base" device without "instance" was forgotten (removed from reducer)
-        // automatically create new instance
+        // basically it means that the "standard" device without "useEmptyPassphrase" was forgotten or never created (removed from reducer)
+        // automatically create new "standard" instance
         if (!changedDevices.find(d => d.available)) {
             changedDevices.push(newDevice);
         }
@@ -165,12 +169,12 @@ const changeDevice = (
         const isDeviceUnlocked = isUnlocked(device.features);
         // merge incoming device with State
         const changedDevices = affectedDevices.map(d => {
+            let { useEmptyPassphrase } = d;
             // change availability according to "passphrase_protection" field
-            if (d.instance && isDeviceUnlocked && !device.features.passphrase_protection) {
+            if (!useEmptyPassphrase && isDeviceUnlocked && !device.features.passphrase_protection) {
                 return merge(d, { ...device, ...extended, available: !d.state });
             }
             // if device without instance becomes unlocked update useEmptyPassphrase field (hidden/standard wallet)
-            let { useEmptyPassphrase } = d;
             if (!d.instance && !isUnlocked(d.features) && isDeviceUnlocked) {
                 useEmptyPassphrase = !device.features.passphrase_protection;
             }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

What was the reason for #7927?

- Connected and **locked** device[ is created](https://github.com/trezor/trezor-suite/blob/develop/packages/suite/src/reducers/suite/deviceReducer.ts#L96) with `useEmptyPassphrase` flag = true because we dont know if the passphrase is set or not at the time. Features.passphrase_protection is set to true but it's not final info until device becomes unlocked.
- After successful pin request device features were never updated (and `DEVICE.CHANGED` event was not emitted from connect)
- `DEVICE.CHANGED` handled in deviceReducer didnt cover the case when locked device becomes unlocked and didnt update `useEmptyPassphrase` flag 

What was the reason for #4933?
- deviceReducer condition was based on `d.instance` instead of `d.useEmptyPassphrase`

## Explanation
- device.useEmptyPassphrase informs if this is hidden (false) or standard (true) wallet
- device.instance informs if this is first (undefined) or n-th wallet (number)

Regarding #4933 i believe that this was a part of legacy behavior from the time of suite 0.1 - when standard wallet was **always** created as first instance (without asking a user which wallet he want to access) standard was a default back then. i dont remember when it was changed but it was long time ago :)


## QA
@bosomt issue #7927 was only on T1 right? or model R is affected as well?
@STew790 issue #4933 should be also fixed, standard wallet should not ask for enabling passphrase, hidden wallet should

Pls test all possible cases/models anything that comes to your mind even scenarios like for example:
- remember wallet with passphrase enabled and closing suite
- disabling passphrase using trezorctrl
- entering suite with remembered wallet again (but without passphrase) 

Desktop builds: https://gitlab.com/satoshilabs/trezor/trezor-suite/-/pipelines/968774801
Web build: https://suite.corp.sldev.cz/suite-web/fix/7927/web/

## Related Issue

Resolve https://github.com/trezor/trezor-suite/issues/7927
Resolve https://github.com/trezor/trezor-suite/issues/4933
