### PR TITLE
Feat/message system config 40

### DIFF
--- a/suite-common/message-system/config/config.v1.json
+++ b/suite-common/message-system/config/config.v1.json
@@ -176,7 +176,7 @@
             "conditions": [
                 {
                     "environment": {
-                        "desktop": "<23.3.2",
+                        "desktop": "<23.7.2",
                         "mobile": "!",
                         "web": "!"
                     }

--- a/suite-common/message-system/config/config.v1.json
+++ b/suite-common/message-system/config/config.v1.json
@@ -113,9 +113,9 @@
             "conditions": [
                 {
                     "environment": {
-                        "desktop": ">=23.5.1",
+                        "desktop": ">=23.8.1",
                         "mobile": "!",
-                        "web": ">=23.5.1"
+                        "web": ">=23.8.1"
                     }
                 }
             ],
@@ -148,9 +148,9 @@
             "conditions": [
                 {
                     "environment": {
-                        "desktop": "<23.5.2",
+                        "desktop": "<23.8.1",
                         "mobile": "!",
-                        "web": "<23.5.2"
+                        "web": "<23.8.1"
                     }
                 }
             ],

--- a/suite-common/message-system/config/config.v1.json
+++ b/suite-common/message-system/config/config.v1.json
@@ -1,62 +1,8 @@
 {
     "version": 1,
-    "timestamp": "2023-07-31T00:00:00+00:00",
-    "sequence": 39,
+    "timestamp": "2023-08-16T00:00:00+00:00",
+    "sequence": 40,
     "actions": [
-        {
-            "conditions": [
-                {
-                    "devices": [
-                        {
-                            "model": "1",
-                            "firmware": "*",
-                            "bootloader": "*",
-                            "variant": "*",
-                            "firmwareRevision": "*",
-                            "vendor": "*"
-                        },
-                        {
-                            "model": "T1B1",
-                            "firmware": "*",
-                            "bootloader": "*",
-                            "variant": "*",
-                            "firmwareRevision": "*",
-                            "vendor": "*"
-                        }
-                    ],
-                    "environment": {
-                        "desktop": ">=23.1.0",
-                        "mobile": "!",
-                        "web": "!"
-                    }
-                }
-            ],
-            "message": {
-                "id": "6f793f82-5e13-492f-803c-2d5Fsdcc3cd1",
-                "priority": 93,
-                "dismissible": false,
-                "variant": "warning",
-                "category": ["feature"],
-                "content": {
-                    "en-GB": "Coinjoin not publicly available on T1",
-                    "en": "Coinjoin not publicly available on T1",
-                    "es": "Coinjoin not publicly available on T1",
-                    "cs": "Coinjoin not publicly available on T1",
-                    "ru": "Coinjoin not publicly available on T1",
-                    "ja": "Coinjoin not publicly available on T1。"
-                },
-                "feature": [
-                    {
-                        "flag": true,
-                        "domain": "coinjoin",
-                        "isPublic": false,
-                        "averageAnonymityGainPerRound": 0.34,
-                        "roundsFailRateBuffer": 10,
-                        "roundsDurationInHours": 3
-                    }
-                ]
-            }
-        },
         {
             "conditions": [
                 {
@@ -72,6 +18,22 @@
                         {
                             "model": "T2T1",
                             "firmware": "<2.6.0",
+                            "bootloader": "*",
+                            "variant": "*",
+                            "firmwareRevision": "*",
+                            "vendor": "*"
+                        },
+                        {
+                            "model": "1",
+                            "firmware": "<1.12.1",
+                            "bootloader": "*",
+                            "variant": "*",
+                            "firmwareRevision": "*",
+                            "vendor": "*"
+                        },
+                        {
+                            "model": "T1B1",
+                            "firmware": "<1.12.1",
                             "bootloader": "*",
                             "variant": "*",
                             "firmwareRevision": "*",

--- a/suite-common/message-system/config/config.v1.json
+++ b/suite-common/message-system/config/config.v1.json
@@ -139,7 +139,7 @@
                         "flag": true,
                         "averageAnonymityGainPerRound": 0.34,
                         "roundsFailRateBuffer": 10,
-                        "roundsDurationInHours": 3
+                        "roundsDurationInHours": 1
                     }
                 ]
             }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

-  Enable coinjoin accounts for T1 from 23.8
-  Request at least 23.8 Suite version for coinjoin feature
- bump Suite version for deprecation warning (23.7.2)

## Related Issue

Resolve https://github.com/trezor/trezor-suite/issues/8958

## Screenshots:

T1 without debug menu
<img width="728" alt="image" src="https://github.com/trezor/trezor-suite/assets/3729633/87414b64-937e-48e0-b7a3-34da80dea1f9">

T1 1.11 (not latest FW)
<img width="579" alt="image" src="https://github.com/trezor/trezor-suite/assets/3729633/2dd654ac-8326-46dc-b7a3-16a75188cf93">

