### PR TITLE
Support IPv6 Electrum urls

### DIFF
--- a/packages/blockchain-link/src/workers/electrum/devrun.ts
+++ b/packages/blockchain-link/src/workers/electrum/devrun.ts
@@ -10,6 +10,7 @@ const TOR_ADDRESS = '127.0.0.1:9050';
 const LOCALHOST_CONFIG = 'localhost:50001:t';
 const TCP_CONFIG = 'electrum.corp.sldev.cz:50001:t';
 const TLS_CONFIG = 'bitcoin.aranguren.org:50002:s';
+const IPv6_CONFIG = '[2401:d002:3902:700:d72c:5e22:4e95:389d]:50001:t';
 const TOR_CONFIG = ''; // My personal Umbrel
 
 const ADDR_REGTEST = 'bcrt1qx4009e2mpuch20p3uwvwmplaxgnjqwjmenrcfu';

--- a/packages/suite/src/hooks/settings/backends/useBackendsForm.ts
+++ b/packages/suite/src/hooks/settings/backends/useBackendsForm.ts
@@ -62,12 +62,12 @@ const useBackendUrlInput = (
     const validate = (value: string) => {
         // Check if URL is valid
         if (!validateUrl(type, value)) {
-            return 'TR_CUSTOM_BACKEND_INVALID_URL';
+            return translationString('TR_CUSTOM_BACKEND_INVALID_URL');
         }
 
         // Check if already exists
         if (currentUrls.find(url => url === value)) {
-            return 'TR_CUSTOM_BACKEND_BACKEND_ALREADY_ADDED';
+            return translationString('TR_CUSTOM_BACKEND_BACKEND_ALREADY_ADDED');
         }
     };
 

--- a/packages/utils/src/index.ts
+++ b/packages/utils/src/index.ts
@@ -22,6 +22,7 @@ export * from './isNotUndefined';
 export * from './isUrl';
 export * from './mergeDeepObject';
 export * from './objectPartition';
+export * from './parseElectrumUrl';
 export * from './parseHostname';
 export * from './promiseAllSequence';
 export * from './redactUserPath';

--- a/packages/utils/src/parseElectrumUrl.ts
+++ b/packages/utils/src/parseElectrumUrl.ts
@@ -1,0 +1,12 @@
+// URL is in format host:port:[t|s] (t for tcp, s for ssl)
+const ELECTRUM_URL_REGEX = /^(?:([a-zA-Z0-9.-]+)|\[([a-f0-9:]+)\]):([0-9]{1,5}):([ts])$/;
+
+export const parseElectrumUrl = (url: string) => {
+    const match = url.match(ELECTRUM_URL_REGEX);
+    if (!match) return undefined;
+    return {
+        host: match[1] ?? match[2],
+        port: Number.parseInt(match[3], 10),
+        protocol: match[4] as 't' | 's',
+    };
+};

--- a/packages/utils/tests/parseElectrumUrl.test.ts
+++ b/packages/utils/tests/parseElectrumUrl.test.ts
@@ -1,0 +1,29 @@
+import { parseElectrumUrl } from '../src/parseElectrumUrl';
+
+const FIXTURE = [
+    ['electrum.example.com:50001:t', 'electrum.example.com', 50001, 't'],
+    ['electrum.example.com:50001:s', 'electrum.example.com', 50001, 's'],
+    ['electrum.example.onion:50001:t', 'electrum.example.onion', 50001, 't'],
+    ['electrum.example.com:50001:x'],
+    ['127.0.0.1:50001:t', '127.0.0.1', 50001, 't'],
+    ['2001:0db8:85a3:0000:0000:8a2e:0370:7334:50001:t'],
+    [
+        '[2001:0db8:85a3:0000:0000:8a2e:0370:7334]:50001:t',
+        '2001:0db8:85a3:0000:0000:8a2e:0370:7334',
+        50001,
+        't',
+    ],
+    ['[::1]:50001:t', '::1', 50001, 't'],
+    ['[example.com]:50001:t'],
+    ['wss://blockfrost.io'],
+    ['https://google.com'],
+    [''],
+] as const;
+
+describe('parseElectrumUrl', () => {
+    FIXTURE.forEach(([url, host, port, protocol]) =>
+        it(url, () => {
+            expect(parseElectrumUrl(url)).toStrictEqual(host && { host, port, protocol });
+        }),
+    );
+});

--- a/suite-common/wallet-utils/src/__tests__/backend.test.ts
+++ b/suite-common/wallet-utils/src/__tests__/backend.test.ts
@@ -1,4 +1,4 @@
-import { getDefaultBackendType, isElectrumUrl, isTrezorConnectBackendType } from '../backend';
+import { getDefaultBackendType, isTrezorConnectBackendType } from '../backend';
 
 describe('backend utils', () => {
     test('getDefaultBackendType', () => {
@@ -6,16 +6,6 @@ describe('backend utils', () => {
         expect(getDefaultBackendType('ltc')).toBe('blockbook');
         expect(getDefaultBackendType('ada')).toBe('blockfrost');
         expect(getDefaultBackendType('tada')).toBe('blockfrost');
-    });
-
-    test('isElectrumUrl', () => {
-        expect(isElectrumUrl('electrum.example.com:50001:t')).toBe(true);
-        expect(isElectrumUrl('electrum.example.com:50001:s')).toBe(true);
-        expect(isElectrumUrl('electrum.example.onion:50001:t')).toBe(true);
-        expect(isElectrumUrl('electrum.example.com:50001:x')).toBe(false);
-        expect(isElectrumUrl('wss://blockfrost.io')).toBe(false);
-        expect(isElectrumUrl('https://google.com')).toBe(false);
-        expect(isElectrumUrl('')).toBe(false);
     });
 
     test('isTrezorConnectBackendType', () => {

--- a/suite-common/wallet-utils/src/backend.ts
+++ b/suite-common/wallet-utils/src/backend.ts
@@ -1,3 +1,4 @@
+import { parseElectrumUrl } from '@trezor/utils';
 import type {
     CustomBackend,
     BlockchainNetworks,
@@ -37,9 +38,7 @@ export const getCustomBackends = (blockchains: BlockchainNetworks): CustomBacken
         }))
         .filter(isBackend);
 
-const electrumUrlRegex = /^([a-zA-Z0-9.-]+):[0-9]{1,5}:[ts]$/; // URL is in format host:port:[t|s] (t for tcp, s for ssl)
-
-export const isElectrumUrl = (value: string) => electrumUrlRegex.test(value);
+export const isElectrumUrl = (value: string) => !!parseElectrumUrl(value);
 
 // check if account.backendType or NETWORK.accountType.backendType is supported by TrezorConnect api (defined in TREZOR_CONNECT_BACKENDS)
 // if it's not then different (non-standard) api should be used for fetching data


### PR DESCRIPTION
## Description

Adds support for IPv6 Electrum backend urls.

- https://github.com/trezor/trezor-suite/pull/9192/commits/cf876db88666739b05bbef82a69885d8c8510011 - add `parseElectrumUrl` util to `@trezor/utils` (based on `isElectrumUrl` from wallet-utils and extended by IPv6 parsing)
- https://github.com/trezor/trezor-suite/pull/9192/commits/727b0b9471a1abbcb5ce9cc15f67c06e5e34b5bf - use `parseElectrumUrl` for supporting IPv6 in blockchain-link
- https://github.com/trezor/trezor-suite/pull/9192/commits/1da02373f135e8c918efa5bc36cac4f91fe86ecd - reuse `parseElectrumUrl` for `isElectrumUrl` logic in wallet-utils
- https://github.com/trezor/trezor-suite/pull/9192/commits/b3eaa9449cbb272d182191b8ef031e74b473507b - unrelated, fix localized error messages in custom backend form

## Related Issue

Resolve #5798

## QA

Please test that IPv6 addresses can be used for Electrum backends (I've tried e.g. `[2401:d002:3902:700:d72c:5e22:4e95:389d]:50001:t`) as well as hostnames and IPv4 (as before).
