### PR TITLE
Fix: rbf decreased outputs view

### DIFF
--- a/packages/suite/src/components/suite/modals/TransactionDetail/components/ChangeFee/components/DecreasedOutputs.tsx
+++ b/packages/suite/src/components/suite/modals/TransactionDetail/components/ChangeFee/components/DecreasedOutputs.tsx
@@ -63,6 +63,7 @@ const StyledRadioButton = styled(RadioButton)`
 
 export const DecreasedOutputs = () => {
     const {
+        showDecreasedOutputs,
         formValues,
         account,
         getValues,
@@ -72,7 +73,9 @@ export const DecreasedOutputs = () => {
         shouldSendInSats,
     } = useRbfContext();
     const { selectedFee, setMaxOutputId } = getValues();
-    if (typeof setMaxOutputId !== 'number') return null; // no set-max means that no output was decreased
+
+    // no set-max means that no output was decreased
+    if (!showDecreasedOutputs || typeof setMaxOutputId !== 'number') return null;
 
     let reducedAmount: React.ReactNode = null;
     if (composedLevels) {
@@ -101,7 +104,7 @@ export const DecreasedOutputs = () => {
         <AnimatePresence initial>
             <motion.div {...motionAnimation.expand}>
                 <GreyCard>
-                    <WarnHeader>
+                    <WarnHeader data-test="@send/decreased-outputs">
                         <Translation id="TR_DECREASE_TX" />
                     </WarnHeader>
                     <OutputsWrapper>

--- a/packages/suite/src/components/suite/modals/TransactionDetail/components/ChangeFee/components/WarnHeader.tsx
+++ b/packages/suite/src/components/suite/modals/TransactionDetail/components/ChangeFee/components/WarnHeader.tsx
@@ -20,21 +20,21 @@ const Body = styled.div`
     flex: 1;
 `;
 
-interface WarnHeaderProps {
+interface WarnHeaderProps extends React.HTMLAttributes<HTMLDivElement> {
     action?: React.ReactNode;
     children?: React.ReactNode;
 }
 
-export const WarnHeader = (props: WarnHeaderProps) => {
+export const WarnHeader = ({ action, children, ...rest }: WarnHeaderProps) => {
     const theme = useTheme();
 
     return (
-        <Header>
+        <Header {...rest}>
             <IconWrapper>
                 <Icon size={16} icon="WARNING" color={theme.TYPE_ORANGE} />
             </IconWrapper>
-            <Body>{props.children}</Body>
-            {props.action && props.action}
+            <Body>{children}</Body>
+            {action}
         </Header>
     );
 };

--- a/packages/suite/src/hooks/wallet/__fixtures__/useRbfForm.ts
+++ b/packages/suite/src/hooks/wallet/__fixtures__/useRbfForm.ts
@@ -585,6 +585,7 @@ export const composeAndSign = [
             },
         },
         composeTransactionCalls: 3, // 1. normal fee, 2. custom fee, 3. send-max
+        decreasedOutputs: true,
         signedTx: {
             inputs: [{ prev_hash: DCBA }],
             outputs: [
@@ -631,6 +632,7 @@ export const composeAndSign = [
             changeAddress: undefined,
         }),
         composeTransactionCalls: 1, // 1. immediate send-max
+        decreasedOutputs: true,
         composedLevels: {
             normal: {
                 type: 'final',
@@ -692,6 +694,7 @@ export const composeAndSign = [
             },
         },
         composeTransactionCalls: 3, // 1. normal fee, 2. custom fee, 3 send-max
+        decreasedOutputs: true,
         signedTx: {
             inputs: [{ prev_hash: DCBA }],
             outputs: [

--- a/packages/suite/src/hooks/wallet/__fixtures__/useRbfForm.ts
+++ b/packages/suite/src/hooks/wallet/__fixtures__/useRbfForm.ts
@@ -138,6 +138,7 @@ export const composeAndSign = [
                 },
             },
         },
+        composeTransactionCalls: 1,
         signedTx: {
             outputs: [
                 {
@@ -180,6 +181,7 @@ export const composeAndSign = [
                 },
             },
         },
+        composeTransactionCalls: 1,
         signedTx: {
             outputs: [
                 {
@@ -234,6 +236,7 @@ export const composeAndSign = [
                 },
             },
         },
+        composeTransactionCalls: 1,
         signedTx: {
             outputs: [
                 // change-output is gone
@@ -288,6 +291,7 @@ export const composeAndSign = [
                 },
             },
         },
+        composeTransactionCalls: 2, // 1. normal fee, 2. custom fee
         signedTx: {
             outputs: [
                 // change-output is gone
@@ -361,6 +365,7 @@ export const composeAndSign = [
                 },
             },
         },
+        composeTransactionCalls: 1,
         signedTx: {
             outputs: [
                 {
@@ -432,6 +437,7 @@ export const composeAndSign = [
                 },
             },
         },
+        composeTransactionCalls: 2, // 1. normal fee, 2. custom fee
         signedTx: {
             inputs: [{ prev_hash: DCBA }, { prev_hash: ABCD }],
             outputs: [
@@ -507,6 +513,7 @@ export const composeAndSign = [
                 },
             },
         },
+        composeTransactionCalls: 2, // 1. normal fee, 2. custom fee
         signedTx: {
             inputs: [{ prev_hash: DCBA }, { prev_hash: ABCD }],
             outputs: [
@@ -577,6 +584,7 @@ export const composeAndSign = [
                 },
             },
         },
+        composeTransactionCalls: 3, // 1. normal fee, 2. custom fee, 3. send-max
         signedTx: {
             inputs: [{ prev_hash: DCBA }],
             outputs: [
@@ -622,6 +630,7 @@ export const composeAndSign = [
             ],
             changeAddress: undefined,
         }),
+        composeTransactionCalls: 1, // 1. immediate send-max
         composedLevels: {
             normal: {
                 type: 'final',
@@ -650,7 +659,7 @@ export const composeAndSign = [
         },
     },
     {
-        description: 'output decreased. there is not change or new utxo.',
+        description: 'output decreased. there is no change or new utxo.',
         store: {
             selectedAccount: {
                 ...BTC_ACCOUNT,
@@ -682,6 +691,7 @@ export const composeAndSign = [
                 },
             },
         },
+        composeTransactionCalls: 3, // 1. normal fee, 2. custom fee, 3 send-max
         signedTx: {
             inputs: [{ prev_hash: DCBA }],
             outputs: [
@@ -742,6 +752,7 @@ export const composeAndSign = [
                 },
             },
         },
+        composeTransactionCalls: 1,
         signedTx: {
             // outputs are restored
             outputs: [
@@ -803,6 +814,7 @@ export const composeAndSign = [
                 error: 'NOT-ENOUGH-FUNDS',
             },
         },
+        composeTransactionCalls: 4, // 1. normal fee, 2. custom fee, 3. send-max normal fee, 4. send-max custom fee
         // tx is not signed
     },
 ];

--- a/packages/suite/src/hooks/wallet/__tests__/useRbfForm.test.tsx
+++ b/packages/suite/src/hooks/wallet/__tests__/useRbfForm.test.tsx
@@ -10,6 +10,7 @@ import {
     waitForLoader,
     waitForRender,
     actionSequence,
+    findByTestId,
 } from 'src/support/tests/hooksHelper';
 import { ChangeFee } from 'src/components/suite/modals/TransactionDetail/components/ChangeFee';
 import { useRbfContext } from '../useRbfForm';
@@ -165,6 +166,14 @@ describe('useRbfForm hook', () => {
             // validate number of calls to '@trezor/connect'
             if (typeof f.composeTransactionCalls === 'number') {
                 expect(composeTransactionSpy).toBeCalledTimes(f.composeTransactionCalls);
+            }
+
+            if (f.decreasedOutputs) {
+                expect(() => findByTestId('@send/decreased-outputs')).not.toThrow();
+            } else {
+                expect(() => findByTestId('@send/decreased-outputs')).toThrow(
+                    'Unable to find an element',
+                );
             }
 
             const sendAction = () =>

--- a/packages/suite/src/hooks/wallet/__tests__/useRbfForm.test.tsx
+++ b/packages/suite/src/hooks/wallet/__tests__/useRbfForm.test.tsx
@@ -132,6 +132,8 @@ describe('useRbfForm hook', () => {
                 </ChangeFee>,
             );
 
+            const composeTransactionSpy = jest.spyOn(TrezorConnect, 'composeTransaction');
+
             // mock responses from 'signTransaction'.
             // response doesn't matter. parameters are tested.
             const signTransactionMock = jest
@@ -159,6 +161,11 @@ describe('useRbfForm hook', () => {
 
             // check composeTransaction result
             expect(composedLevels).toMatchObject(f.composedLevels);
+
+            // validate number of calls to '@trezor/connect'
+            if (typeof f.composeTransactionCalls === 'number') {
+                expect(composeTransactionSpy).toBeCalledTimes(f.composeTransactionCalls);
+            }
 
             const sendAction = () =>
                 actionSequence([


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Another day, another cherry-picking from [coinjoin RBF branch](https://github.com/trezor/trezor-suite/pull/9040)

EDIT: Actually there were two problems

1. `DecreasedOutputs` view was unnecessarily shown if reducing output is not possible or even blinks as described in issue https://github.com/trezor/trezor-suite/issues/8742
2. Once you start decreasing destination output there was no possibility to back to reducing change output if it was possible with at least one fee level

How to test it case 1 (recommending on regtest to have control over mined blocks)

- send yourself a small amount like 0.00008 test and **be sure that this is the only utxo you have** on that account
- send this utxo somewhere else using send-max (without change output) with high (maximum possible) feeRate, like 60+ sat/b (maybe smaller, i've tested it on RBF branch where dust limit calculation is already fixed)
- try to bump tx (this should not be possible)

Result: `DecreasedOutputs` view is not visible  
Bug on develop: `DecreasedOutputs` view will be visible and/or behave like in mentioned issue

How to test case 2 (recommending on regtest to have control over mined blocks)

- send yourself a small amount like 0.00008 test and **be sure that this is the only utxo you have** on that account
- send 0.00004 somewhere else (with change output)
- go to bump (reducing change output should be possible with "normal" fee level)
- go to custom fee level and try some higher value, like 30-40

Result: using higher value will show "Not enough funds"
Bug on develop: you will be never able to cancel decreasing output even if you change fee rate to smaller or you switch back to "normal" fee level