### PR TITLE
feat(coinmarket): Add tracking event on buy buttons on Dashboard

### DIFF
--- a/packages/suite-analytics/src/constants.ts
+++ b/packages/suite-analytics/src/constants.ts
@@ -35,6 +35,7 @@ export enum EventType {
     AccountsEmptyAccountBuy = 'accounts/empty-account/buy',
     AccountsEmptyAccountReceive = 'accounts/empty-account/receive',
     AccountsTransactionsExport = 'accounts/transactions-export',
+    AccountsDashboardBuy = 'accounts/dashboard/buy',
     TransactionCreated = 'transaction-created',
     SendRawTransaction = 'send-raw-transaction',
 

--- a/packages/suite-analytics/src/types/events.ts
+++ b/packages/suite-analytics/src/types/events.ts
@@ -157,6 +157,12 @@ export type SuiteAnalyticsEvent =
           };
       }
     | {
+          type: EventType.AccountsDashboardBuy;
+          payload: {
+              symbol: string;
+          };
+      }
+    | {
           type: EventType.TransactionCreated;
           payload: {
               action: 'sent' | 'copied' | 'downloaded' | 'replaced';

--- a/packages/suite/src/components/wallet/CoinmarketBuyButton.tsx
+++ b/packages/suite/src/components/wallet/CoinmarketBuyButton.tsx
@@ -4,6 +4,7 @@ import { Button } from '@trezor/components';
 import { NetworkSymbol } from 'src/types/wallet';
 import { Translation } from 'src/components/suite';
 import { useDispatch, useAccountSearch } from 'src/hooks/suite';
+import { EventType, analytics } from '@trezor/suite-analytics';
 
 interface BuyButtonProps {
     symbol: NetworkSymbol;
@@ -15,6 +16,13 @@ export const CoinmarketBuyButton = ({ symbol, dataTest }: BuyButtonProps) => {
     const { setCoinFilter, setSearchString } = useAccountSearch();
 
     const onClick = () => {
+        analytics.report({
+            type: EventType.AccountsDashboardBuy,
+            payload: {
+                symbol,
+            },
+        });
+
         dispatch(
             routerActions.goto('wallet-coinmarket-buy', {
                 params: {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

At Invity we need to know when users click on buy button shown in dashboard. So we need to send the data to analytics storage.

<!--- Describe your changes in detail -->

## Related Issue

Resolve https://github.com/trezor/trezor-suite/issues/9100
