### PR TITLE
ci: connect staging

### DIFF
--- a/ci/build.yml
+++ b/ci/build.yml
@@ -266,7 +266,7 @@ connect-web build:
     - yarn workspace @trezor/connect-explorer-webextension build
 
   artifacts:
-    expire_in: 1 week
+    expire_in: 14 days
     paths:
       - packages/connect-iframe/build
       - packages/connect-web/build

--- a/ci/releases.yml
+++ b/ci/releases.yml
@@ -105,7 +105,7 @@ msg-system codesign deploy:
 
 # connect v9 deploy to production jobs
 
-# Create rollback copy of connect.trezo.io
+# Create rollback copy of connect.trezor.io
 connect v9 rollback production:
   stage: deploy to production
   only:
@@ -116,19 +116,15 @@ connect v9 rollback production:
   needs:
     - connect-web build
     - connect-explorer build
+    - connect v9 deploy production
   script:
     - source ${CONNECT_DEPLOY_KEYFILE}
-    - aws s3 sync s3://connect.trezor.io s3://rollback-connect.trezor.io
+    - aws s3 sync --delete s3://rollback-connect.trezor.io/9/ s3://connect.trezor.io/9/
   tags:
     - connect_deploy
 
-# Deploy connect v9 to connect.trezor.io
-connect v9 deploy production:
+.connect v9 deploy:
   stage: deploy to production
-  only:
-    refs:
-      - release/connect-v9
-  when: manual
   dependencies:
     - connect-web build
     - connect-explorer build
@@ -136,9 +132,24 @@ connect v9 deploy production:
     - release commit messages
     - connect-web build
     - connect-explorer build
-  before_script: []
-  script:
+  before_script:
     - source ${CONNECT_DEPLOY_KEYFILE}
-    - ./ci/scripts/connect-release.sh 9
   tags:
     - connect_deploy
+  only:
+    refs:
+      - release/connect-v9
+
+connect v9 deploy staging:
+  extends: .connect v9 deploy
+  script:
+    - ./ci/scripts/connect-release-staging.sh 9
+
+# Deploy connect v9 to connect.trezor.io from staging-conntect.trezor.io
+connect v9 deploy production:
+  extends: .connect v9 deploy
+  when: manual
+  script:
+    - ./ci/scripts/connect-release-production.sh 9
+# todo: copy from old-production to production
+# connect v9 revert production

--- a/ci/scripts/connect-release-production.sh
+++ b/ci/scripts/connect-release-production.sh
@@ -1,0 +1,36 @@
+#!/usr/bin/env bash
+
+set -e -o pipefail
+
+# Usage:
+# ./connect-release-production.sh DESTINATION
+# @DESTINATION: required, destination directory (connect major version)
+
+# Validate params
+while [[ "$#" -gt 0 ]]; do case $1 in
+    9)
+        latest_version="9"
+        current_version=$(jq -r .version packages/connect/package.json)
+        shift
+        ;;
+    *)
+        echo "Invalid version parameter passed: $1
+Used only for version 9"
+        exit 1
+        shift
+        ;;
+    esac done
+
+echo "Backing up current production version $latest_version to rollback bucket"
+
+# sync the files to rollback bucket
+aws s3 sync "s3://connect.trezor.io/$latest_version/" "s3://rollback-connect.trezor.io/$latest_version/"
+
+echo "Uploading to s3://connect.trezor.io/$latest_version/ and s3://connect.trezor.io/$current_version/"
+
+# sync the files to aws
+aws s3 sync --delete --cache-control 'public, max-age=3600' "s3://staging-connect.trezor.io/$latest_version/" "s3://connect.trezor.io/$latest_version/"
+aws s3 sync --delete --cache-control 'public, max-age=3600' "s3://staging-connect.trezor.io/$current_version/" "s3://connect.trezor.io/$current_version/"
+aws cloudfront create-invalidation --distribution-id E3LVNAOGT94E37 --paths '/*'
+
+echo "DONE"

--- a/ci/scripts/connect-release-staging.sh
+++ b/ci/scripts/connect-release-staging.sh
@@ -3,7 +3,7 @@
 set -e -o pipefail
 
 # Usage:
-# ./connect-release.sh DESTINATION
+# ./connect-release-staging.sh DESTINATION
 # @DESTINATION: required, destination directory (connect major version)
 
 # Validate params
@@ -21,7 +21,7 @@ Used only for version 9"
         ;;
     esac done
 
-echo "Uploading to s3://connect.trezor.io/$latest_version/ and s3://connect.trezor.io/$current_version/"
+echo "Uploading to s3://staging-connect.trezor.io/$latest_version/ and s3://staging-connect.trezor.io/$current_version/"
 
 # organize the files in one directory
 tmp_folder="tmp-connect-release"
@@ -33,9 +33,9 @@ cp -r packages/connect-web/build/* $tmp_folder/.
 cp -r packages/connect-explorer/build/* $tmp_folder/.
 
 # sync the files to aws
-aws s3 sync --delete --cache-control 'public, max-age=3600' "$tmp_folder/" "s3://connect.trezor.io/$latest_version/"
-aws s3 sync --delete --cache-control 'public, max-age=3600' "$tmp_folder/" "s3://connect.trezor.io/$current_version/"
-aws cloudfront create-invalidation --distribution-id E3LVNAOGT94E37 --paths '/*'
+aws s3 sync --delete --cache-control 'public, max-age=3600' "$tmp_folder/" "s3://staging-connect.trezor.io/$latest_version/"
+aws s3 sync --delete --cache-control 'public, max-age=3600' "$tmp_folder/" "s3://staging-connect.trezor.io/$current_version/"
+aws cloudfront create-invalidation --distribution-id E55GK1B3RPIPX --paths '/*'
 
 # cleaning up
 echo "Cleaning up"


### PR DESCRIPTION
there is staging env we might use https://staging-connect.trezor.io/


## Plan

as discussed with @hynek-jina today

- have connect.trezor.io for production
- have staging-connect trezor.io for staging.
- release to staging-connect.trezor.io/9 and staging-connect.trezor.io/9.x.y at the same time
- do testing on staging-connect.trezor.io/9
- copy staging-connect.trezor.io/9 to connect.trezor.io/9 and staging-connect.trezor.io/9.x.y to connect.trezor.io/9.x.y. ⚠️ it means the release script will need to be aware of what 9.x.y is.
- future plans: maybe start using 9.x.y folder for canary / nightly builds
