### PR TITLE
test(connect): adjust legacy fixtures

### DIFF
--- a/packages/connect/e2e/__fixtures__/ethereumSignTransactionEip155.ts
+++ b/packages/connect/e2e/__fixtures__/ethereumSignTransactionEip155.ts
@@ -22,6 +22,24 @@ const legacyResults: Record<string, LegacyResult[]> = {
     ],
 };
 
+// Legacy results for eth networks related fixtures
+// historically, ethereum definitions used to be part of firwmares so it was expected that certain fw would
+// not support certain eth network. With (I believe) 2.6.0, definitions are sent from host so we don't really need
+// to care about support of particular networks.
+[
+    'Unknown_chain_id_testnet_path',
+    'Ropsten',
+    'Rinkeby',
+    'max_chain_id',
+    'max_chain_plus_one',
+].forEach(fixture => {
+    legacyResults[fixture] = [
+        {
+            rules: ['2.2.0'], // I am not sure about exact fw ranges here, so just lets use 2.2.0 which is the fw version we run legacy tests with
+        },
+    ];
+});
+
 export default {
     method: 'ethereumSignTransaction',
     setup: {


### PR DESCRIPTION
struggle for green CI. 

this should fix https://gitlab.com/satoshilabs/trezor/trezor-suite/-/jobs/4909020896#L3019

imho 2.2.0 is correctly considered as unsupported fw for eth calls using for example ropsten network. such definitions are not part of that fw. since 2.6.0 on the other hand we don't need to mantain support list for this anymore since we send definition from host. 