### PR TITLE
docs(connect-explorer): update index readme

### DIFF
--- a/packages/connect-explorer/README.md
+++ b/packages/connect-explorer/README.md
@@ -9,8 +9,12 @@ To run the explorer locally:
 
 `yarn workspace @trezor/connect-explorer dev` - runs dev server on port 8088
 
-When `connect-exporer` is run locally, WebUSB is disabled because [@trezor/connect-popup](../connect-popup) runs on a different domain and Chrome does not allow `navigator.usb.requestDevice` calls between cross-site elements since v72. Further investigation needed to see if we can fix that. Until then, run [Bridge](https://suite.trezor.io/web/bridge/) to connect to Trezor.
+## Examples
 
-Alternatively, use the [online explorer](https://trezor.github.io/trezor-suite/connect-explorer), which is pointing to the latest stable version of [@trezor/connect](../connect).
+-   [production](https://connect.trezor.io/9/). This build allows working with restricted methods (management) since it is hosted on a whitelisted domain.
+-   [non-whitelisted domain](https://trezor.github.io/trezor-suite/connect-explorer), which is pointing to the latest stable version of [@trezor/connect](../connect). This build effectively simulates 3rd party integration.
+-   [develop](https://suite.corp.sldev.cz/connect-explorer/develop) Branches builds available for here for internal use.
 
-For internal use, a build from the develop branch is available at [SLDEV](https://suite.corp.sldev.cz/connect-explorer/develop).
+## Webusb
+
+When `connect-explorer` is run locally, WebUSB is disabled because [@trezor/connect-popup](../connect-popup) runs on a different domain and Chrome does not allow `navigator.usb.requestDevice` calls between cross-site elements since v72. Further investigation needed to see if we can fix that. Until then, run [Bridge](https://suite.trezor.io/web/bridge/) to connect to Trezor.


### PR DESCRIPTION
When reviewing https://github.com/trezor/trezor-suite/pull/8929  I got and idea that `connect-explorer` readme and the newly added `connect-explorer-webextension` readme should be similar and possibly link to each other. I mean:
- in connect-explorer "for implementation in a webextension refer to [connect-explorer-webextension package](link)
- in connect-explorer-webextension "for implementation in a web app refer to [connect-explorer package](link)
