### PR TITLE
fix(ci): webextension with legacy npm packages

### DIFF
--- a/ci/build.yml
+++ b/ci/build.yml
@@ -262,7 +262,7 @@ connect-web build:
     # build webextension examples with latest trezor.io and latest npm package
     - node ./packages/connect-examples/update-webextensions.js --trezor-connect-src "https://suite.corp.sldev.cz/connect/${CI_COMMIT_REF_NAME}/"
     # build webextension examples with latest trezor.io and outdated npm package (current production)
-    - node ./packages/connect-examples/update-webextensions.js --trezor-connect-src "https://suite.corp.sldev.cz/connect/${CI_COMMIT_REF_NAME}/" --build-folder build-legacy --npm-src="https://connect.trezor.io/9/trezor-connect.js"
+    - node ./packages/connect-examples/update-webextensions.js --trezor-connect-src "https://suite.corp.sldev.cz/connect/${CI_COMMIT_REF_NAME}/" --build-folder build-legacy --npm-src "https://connect.trezor.io/9/trezor-connect.js"
     - yarn workspace @trezor/connect-explorer-webextension build
 
   artifacts:


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->
Fixing the command to build web extensions with legacy npm packages. It had an equal sign that was making the command not to work as expected and using npm package code from current branch instead of using old release one as it was expected.