### PR TITLE
feat(suite): open testnet coins in onboarding for btc-only, add tooltip

### DIFF
--- a/packages/suite/src/views/onboarding/steps/BasicSettings/BasicSettingsStepBox.tsx
+++ b/packages/suite/src/views/onboarding/steps/BasicSettings/BasicSettingsStepBox.tsx
@@ -1,7 +1,7 @@
 import React, { useEffect } from 'react';
 import styled from 'styled-components';
 import { OnboardingStepBox, OnboardingStepBoxProps } from 'src/components/onboarding';
-import { CoinsGroup, Translation } from 'src/components/suite';
+import { CoinsGroup, TooltipSymbol, Translation } from 'src/components/suite';
 import { useEnabledNetworks } from 'src/hooks/settings/useEnabledNetworks';
 import { CollapsibleBox } from '@trezor/components';
 
@@ -47,7 +47,14 @@ export const BasicSettingsStepBox = (props: OnboardingStepBoxProps) => {
             />
             <StyledCollapsibleBox
                 noContentPadding
-                heading={<Translation id="TR_TESTNET_COINS" />}
+                heading={
+                    <>
+                        <Translation id="TR_TESTNET_COINS" />
+                        <TooltipSymbol
+                            content={<Translation id="TR_TESTNET_COINS_DESCRIPTION" />}
+                        />
+                    </>
+                }
                 variant="large"
             >
                 <StyledCoinsGroup


### PR DESCRIPTION
## Description

- explain what is testnet coin
- open it for btc-only so that it is not that empty

## Related Issue


## Screenshots:

![Screenshot 2023-08-23 at 10 07 14](https://github.com/trezor/trezor-suite/assets/33235762/0e9c15e2-5ec5-4f41-9914-2aa28e2405cd)
![Screenshot 2023-08-23 at 10 06 24](https://github.com/trezor/trezor-suite/assets/33235762/6e22f7c9-081f-4f71-b33a-28d19bbd05c9)
