### PR TITLE
fix(suite-native): inputs polishing

### DIFF
--- a/suite-native/atoms/src/Input/SearchInput.tsx
+++ b/suite-native/atoms/src/Input/SearchInput.tsx
@@ -31,9 +31,9 @@ const inputWrapperStyle = prepareNativeStyle<InputStyleProps>((utils, { isFocuse
     alignItems: 'center',
     height: 48,
     borderWidth: utils.borders.widths.small,
-    borderColor: utils.colors.borderOnElevation0,
-    backgroundColor: utils.colors.backgroundNeutralSubtleOnElevation0,
     borderRadius: utils.borders.radii.small,
+    borderColor: utils.colors.backgroundNeutralSubtleOnElevation0,
+    backgroundColor: utils.colors.backgroundNeutralSubtleOnElevation0,
     paddingLeft: 14,
     paddingRight: 14.25,
     extend: [

--- a/suite-native/atoms/src/Sheet/BottomSheet.tsx
+++ b/suite-native/atoms/src/Sheet/BottomSheet.tsx
@@ -108,6 +108,7 @@ export const BottomSheet = ({
                                 isCloseScrollEnabled ? panGestureRef.current : scrollViewRef.current
                             }
                             onScroll={scrollEvent}
+                            keyboardShouldPersistTaps="handled"
                         >
                             <Animated.View>
                                 <Box paddingHorizontal="medium">{children}</Box>

--- a/suite-native/forms/src/fields/TextInputField.tsx
+++ b/suite-native/forms/src/fields/TextInputField.tsx
@@ -1,4 +1,6 @@
-import React from 'react';
+import React, { forwardRef } from 'react';
+
+import { TextInput } from 'react-native/types';
 
 import { Input, InputWrapper, InputProps, InputWrapperProps } from '@suite-native/atoms';
 
@@ -17,34 +19,30 @@ export interface FieldProps extends AllowedTextInputFieldProps, AllowedInputWrap
     defaultValue?: string;
 }
 
-export const TextInputField = ({
-    name,
-    label,
-    hint,
-    onBlur,
-    defaultValue = '',
-    ...otherProps
-}: FieldProps) => {
-    const field = useField({ name, label, defaultValue });
-    const { errorMessage, onBlur: hookFormOnBlur, onChange, value, hasError } = field; // prejmenovat
+export const TextInputField = forwardRef<TextInput, FieldProps>(
+    ({ name, label, hint, onBlur, defaultValue = '', ...otherProps }, ref) => {
+        const field = useField({ name, label, defaultValue });
+        const { errorMessage, onBlur: hookFormOnBlur, onChange, value, hasError } = field;
 
-    const handleOnBlur = () => {
-        hookFormOnBlur();
-        if (onBlur) {
-            onBlur();
-        }
-    };
+        const handleOnBlur = () => {
+            hookFormOnBlur();
+            if (onBlur) {
+                onBlur();
+            }
+        };
 
-    return (
-        <InputWrapper error={errorMessage} hint={hint}>
-            <Input
-                {...otherProps}
-                onBlur={handleOnBlur}
-                onChangeText={onChange}
-                value={value}
-                hasError={hasError}
-                label={label}
-            />
-        </InputWrapper>
-    );
-};
+        return (
+            <InputWrapper error={errorMessage} hint={hint}>
+                <Input
+                    {...otherProps}
+                    onBlur={handleOnBlur}
+                    onChangeText={onChange}
+                    value={value}
+                    hasError={hasError}
+                    label={label}
+                    ref={ref}
+                />
+            </InputWrapper>
+        );
+    },
+);

--- a/suite-native/module-accounts-import/src/screens/XpubScanScreen.tsx
+++ b/suite-native/module-accounts-import/src/screens/XpubScanScreen.tsx
@@ -1,5 +1,6 @@
 import React, { useCallback, useEffect, useState } from 'react';
 import { View } from 'react-native';
+import Animated, { FadeIn } from 'react-native-reanimated';
 
 import { useFocusEffect } from '@react-navigation/native';
 
@@ -32,6 +33,11 @@ const networkTypeToInputLabelMap: Record<NetworkType, string> = {
     ripple: 'Enter receive address manually',
 };
 
+const FORM_BUTTON_FADE_IN_DURATION = 200;
+
+// Extra padding needed to make multiline xpub input form visible even with the sticky footer.
+const EXTRA_KEYBOARD_AVOIDING_VIEW_HEIGHT = 350;
+
 const cameraStyle = prepareNativeStyle(utils => ({
     alignItems: 'center',
     marginTop: 20,
@@ -57,6 +63,8 @@ export const XpubScanScreen = ({
     const watchXpubAddress = watch('xpubAddress');
     const { networkSymbol } = route.params;
     const [isHintSheetVisible, setIsHintSheetVisible] = useState(false);
+
+    const isXpubFormFilled = watchXpubAddress?.length > 0;
 
     const resetToDefaultValues = useCallback(() => {
         setIsCameraRequested(false);
@@ -132,6 +140,7 @@ export const XpubScanScreen = ({
         <Screen
             header={<AccountImportHeader activeStep={2} />}
             footer={<XpubHint networkType={networkType} handleOpen={handleOpenHint} />}
+            extraKeyboardAvoidingViewHeight={EXTRA_KEYBOARD_AVOIDING_VIEW_HEIGHT}
         >
             <HeaderedCard
                 title="Coin to sync"
@@ -156,15 +165,19 @@ export const XpubScanScreen = ({
                             data-testID="@accounts-import/sync-coins/xpub-input"
                             name="xpubAddress"
                             label={inputLabel}
+                            multiline
                         />
-                        <Button
-                            data-testID="@accounts-import/sync-coins/xpub-submit"
-                            onPress={onXpubFormSubmit}
-                            size="large"
-                            isDisabled={!watchXpubAddress?.length}
-                        >
-                            Confirm
-                        </Button>
+                        {isXpubFormFilled && (
+                            <Animated.View entering={FadeIn.duration(FORM_BUTTON_FADE_IN_DURATION)}>
+                                <Button
+                                    data-testID="@accounts-import/sync-coins/xpub-submit"
+                                    onPress={onXpubFormSubmit}
+                                    size="large"
+                                >
+                                    Confirm
+                                </Button>
+                            </Animated.View>
+                        )}
                     </VStack>
                 </Form>
                 {isDevelopOrDebugEnv() && (

--- a/suite-native/module-accounts/src/components/AccountRenameForm.tsx
+++ b/suite-native/module-accounts/src/components/AccountRenameForm.tsx
@@ -1,6 +1,8 @@
-import React from 'react';
+import React, { useEffect, useRef } from 'react';
 import { useDispatch, useSelector } from 'react-redux';
 import { useWatch, Control } from 'react-hook-form';
+
+import { TextInput } from 'react-native/types';
 
 import { Box, Text, Button, VStack } from '@suite-native/atoms';
 import { TextInputField, Form } from '@suite-native/forms';
@@ -41,6 +43,7 @@ export const AccountRenameForm = ({ accountKey, onSubmit }: AccountRenameFormPro
     const account = useSelector((state: AccountsRootState) =>
         selectAccountByKey(state, accountKey),
     );
+    const inputRef = useRef<TextInput>(null);
 
     const accountLabel = useSelector((state: AccountsRootState) =>
         selectAccountLabel(state, accountKey),
@@ -52,6 +55,11 @@ export const AccountRenameForm = ({ accountKey, onSubmit }: AccountRenameFormPro
         formState: { isValid },
         control,
     } = form;
+
+    // Focus account label input field and open keyboard on the first render.
+    useEffect(() => {
+        inputRef.current?.focus();
+    }, [inputRef]);
 
     if (!account) return null;
 
@@ -65,6 +73,7 @@ export const AccountRenameForm = ({ accountKey, onSubmit }: AccountRenameFormPro
             <Form form={form}>
                 <VStack spacing="small">
                     <TextInputField
+                        ref={inputRef}
                         name="accountLabel"
                         label="Coin label"
                         maxLength={MAX_ACCOUNT_LABEL_LENGTH}

--- a/suite-native/navigation/src/components/Screen.tsx
+++ b/suite-native/navigation/src/components/Screen.tsx
@@ -24,6 +24,7 @@ type ScreenProps = {
     backgroundColor?: Color;
     customVerticalPadding?: number;
     customHorizontalPadding?: number;
+    extraKeyboardAvoidingViewHeight?: number;
 };
 
 const screenContainerStyle = prepareNativeStyle<{
@@ -85,6 +86,7 @@ export const Screen = ({
     backgroundColor = 'backgroundSurfaceElevation0',
     customVerticalPadding = nativeSpacings.small,
     customHorizontalPadding = nativeSpacings.small,
+    extraKeyboardAvoidingViewHeight = 0,
 }: ScreenProps) => {
     const {
         applyStyle,
@@ -148,6 +150,7 @@ export const Screen = ({
                 isScrollable={isScrollable}
                 customVerticalPadding={customVerticalPadding}
                 customHorizontalPadding={customHorizontalPadding}
+                extraKeyboardAvoidingViewHeight={extraKeyboardAvoidingViewHeight}
             >
                 {children}
             </ScreenContent>

--- a/suite-native/navigation/src/components/ScreenContent.tsx
+++ b/suite-native/navigation/src/components/ScreenContent.tsx
@@ -11,6 +11,7 @@ type ScreenContentProps = {
     isScrollable: boolean;
     customVerticalPadding: number;
     customHorizontalPadding: number;
+    extraKeyboardAvoidingViewHeight: number;
 };
 
 const screenContentStyle = prepareNativeStyle<{
@@ -43,6 +44,7 @@ export const ScreenContent = ({
     isScrollable,
     customHorizontalPadding,
     customVerticalPadding,
+    extraKeyboardAvoidingViewHeight,
 }: ScreenContentProps) => {
     const { applyStyle } = useNativeStyles();
     const insets = useSafeAreaInsets();
@@ -61,6 +63,7 @@ export const ScreenContent = ({
                     keyboardShouldPersistTaps="always"
                     contentInsetAdjustmentBehavior="automatic"
                     contentContainerStyle={screenStyle}
+                    extraHeight={extraKeyboardAvoidingViewHeight}
                 >
                     {children}
                 </KeyboardAwareScrollView>


### PR DESCRIPTION
- unfocused input doesn't have a border
- confirm button on xpub import screen is not displayed until the input is filled
- input on xpub import screen is always visible while focused
- input extends to multiple lines if needed
- on clicking the rename button in account detail, the label input keyboard is opened and input focused so the user can start typing immediately.

Closes #9207

## Screenshots:

https://github.com/trezor/trezor-suite/assets/26143964/cd360406-b92f-4dd3-8f9d-2c7cd667cf45

