### PR TITLE
analytics(connect): report usage of method params

### DIFF
--- a/packages/connect-analytics/src/types/events.ts
+++ b/packages/connect-analytics/src/types/events.ts
@@ -27,6 +27,7 @@ export type ConnectAnalyticsEvent =
               referrerApp?: string;
               referrerEmail?: string;
               method?: string;
+              payload?: string[];
               transportType?: string;
               transportVersion?: string;
           };

--- a/packages/connect-iframe/package.json
+++ b/packages/connect-iframe/package.json
@@ -12,6 +12,7 @@
     },
     "dependencies": {
         "@trezor/connect": "workspace:*",
+        "@trezor/connect-analytics": "workspace:*",
         "@trezor/connect-common": "workspace:*"
     },
     "devDependencies": {

--- a/packages/connect-iframe/tsconfig.json
+++ b/packages/connect-iframe/tsconfig.json
@@ -6,6 +6,7 @@
     },
     "references": [
         { "path": "../connect" },
+        { "path": "../connect-analytics" },
         { "path": "../connect-common" },
         { "path": "../env-utils" }
     ],

--- a/packages/connect-popup/src/index.tsx
+++ b/packages/connect-popup/src/index.tsx
@@ -251,20 +251,6 @@ const handshake = (handshake: PopupHandshake) => {
 
     reactEventBus.dispatch(handshake);
 
-    analytics.report({
-        type: EventType.AppReady,
-        payload: {
-            version: payload?.settings?.version,
-            // reported in IFRAME.INIT. either origin where iframe was initiated or chrome.runtime.id for extensions
-            origin: payload?.settings?.origin,
-            referrerApp: payload?.settings?.manifest?.appUrl,
-            referrerEmail: payload?.settings?.manifest?.email,
-            method: payload?.method,
-            transportType: payload.transport?.type,
-            transportVersion: payload.transport?.version,
-        },
-    });
-
     if (isPhishingDomain(payload.settings.origin || '')) {
         reactEventBus.dispatch({ type: 'phishing-domain' });
     }

--- a/packages/connect-ui/src/components/AnalyticsConsentWrapper.tsx
+++ b/packages/connect-ui/src/components/AnalyticsConsentWrapper.tsx
@@ -10,7 +10,7 @@ const Wrapper = styled.div`
 `;
 
 type AnalyticsConsentWrapperProps = {
-    onAnalyticsConfirm: () => void;
+    onAnalyticsConfirm: (enabled: boolean) => void;
 };
 
 export const AnalyticsConsentWrapper = ({ onAnalyticsConfirm }: AnalyticsConsentWrapperProps) => {
@@ -21,7 +21,7 @@ export const AnalyticsConsentWrapper = ({ onAnalyticsConfirm }: AnalyticsConsent
             analytics.disable();
         }
 
-        onAnalyticsConfirm();
+        onAnalyticsConfirm(trackingEnabled);
     };
 
     return (

--- a/packages/connect-ui/src/components/BottomRightFloatingBar.tsx
+++ b/packages/connect-ui/src/components/BottomRightFloatingBar.tsx
@@ -28,13 +28,24 @@ const getView = () => {
     return View.Default;
 };
 
-export const BottomRightFloatingBar = () => {
+type BottomRightFloatingBarProps = {
+    onAnalyticsConfirm: (enabled: boolean) => void;
+};
+
+export const BottomRightFloatingBar = ({ onAnalyticsConfirm }: BottomRightFloatingBarProps) => {
     const [view, setView] = useState(getView());
 
     let content;
     switch (view) {
         case View.AnalyticsConsent:
-            content = <AnalyticsConsentWrapper onAnalyticsConfirm={() => setView(View.Default)} />;
+            content = (
+                <AnalyticsConsentWrapper
+                    onAnalyticsConfirm={(enabled: boolean) => {
+                        setView(View.Default);
+                        onAnalyticsConfirm(enabled);
+                    }}
+                />
+            );
             break;
         case View.Default:
         default:

--- a/packages/connect-ui/src/index.tsx
+++ b/packages/connect-ui/src/index.tsx
@@ -2,7 +2,14 @@ import React, { useCallback, useEffect, useState, useMemo } from 'react';
 
 import styled from 'styled-components';
 
-import { PostMessage, UI, PopupHandshake, UI_REQUEST } from '@trezor/connect';
+import {
+    PostMessage,
+    UI,
+    PopupHandshake,
+    UI_REQUEST,
+    POPUP,
+    createPopupMessage,
+} from '@trezor/connect';
 
 // views
 import { Transport } from './views/Transport';
@@ -147,7 +154,13 @@ export const ConnectUI = ({ postMessage, clearLegacyView }: ConnectUIProps) => {
                             </div>
                         )}
 
-                        <BottomRightFloatingBar />
+                        <BottomRightFloatingBar
+                            onAnalyticsConfirm={enabled => {
+                                postMessage(
+                                    createPopupMessage(POPUP.ANALYTICS_RESPONSE, { enabled }),
+                                );
+                            }}
+                        />
                     </Layout>
                 </IntlWrapper>
             </ThemeWrapper>

--- a/packages/connect/src/events/popup.ts
+++ b/packages/connect/src/events/popup.ts
@@ -26,6 +26,8 @@ export const POPUP = {
     CANCEL_POPUP_REQUEST: 'ui-cancel-popup-request',
     // Message called from inline element in popup.html (window.closeWindow), this is used only with webextensions to properly handle popup close event
     CLOSE_WINDOW: 'window.close',
+    // todo: shouldn't it be UI_RESPONSE?
+    ANALYTICS_RESPONSE: 'popup-analytics-response',
 } as const;
 
 export interface PopupInit {
@@ -58,6 +60,11 @@ export interface PopupClosedMessage {
     payload: { error: any } | null;
 }
 
+export interface PopupAnalyticsResponse {
+    type: typeof POPUP.ANALYTICS_RESPONSE;
+    payload: { enabled: boolean };
+}
+
 export type PopupEvent =
     | {
           type: typeof POPUP.LOADED | typeof POPUP.CANCEL_POPUP_REQUEST;
@@ -66,7 +73,8 @@ export type PopupEvent =
     | PopupInit
     | PopupHandshake
     | PopupError
-    | PopupClosedMessage;
+    | PopupClosedMessage
+    | PopupAnalyticsResponse;
 
 export type PopupEventMessage = PopupEvent & { event: typeof UI_EVENT };
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -9024,6 +9024,7 @@ __metadata:
   resolution: "@trezor/connect-iframe@workspace:packages/connect-iframe"
   dependencies:
     "@trezor/connect": "workspace:*"
+    "@trezor/connect-analytics": "workspace:*"
     "@trezor/connect-common": "workspace:*"
     "@trezor/env-utils": "workspace:*"
     copy-webpack-plugin: ^11.0.0


### PR DESCRIPTION
there are times (#9143) we would like to make a breaking changes to public APIs we believe nobody uses but we are not sure. Unfortunately, current implementation of analytics does not help us :(

changes here:
- reporting method.name instead of method.info
- reporting top-level params names
- imho it does not make sense to report everything from connect-popup. This project should be pure UI so only some UI related reports should go here. Other data should be reported as close to their source as possible - for example using this perspective iframe is beter than popup.

<img width="976" alt="image" src="https://github.com/trezor/trezor-suite/assets/30367552/b5f6ed5a-65d9-4048-879d-0eecc246e21d">
