### PR TITLE
fix(suite): device label input

### DIFF
--- a/packages/components/src/components/form/Input/Input.tsx
+++ b/packages/components/src/components/form/Input/Input.tsx
@@ -1,7 +1,7 @@
 import React, { useCallback, useState } from 'react';
 import styled, { css } from 'styled-components';
 
-import { FONT_SIZE, SCREEN_SIZE, Z_INDEX } from '../../../config/variables';
+import { FONT_SIZE, Z_INDEX } from '../../../config/variables';
 import { InputState, InputVariant } from '../../../support/types';
 import { useTheme } from '../../../utils';
 import { Icon } from '../../assets/Icon/Icon';
@@ -16,14 +16,10 @@ import {
     LabelAddon,
 } from '../InputStyles';
 
-const Wrapper = styled.div<Pick<InputProps, 'width' | 'alignInputRight'>>`
+const Wrapper = styled.div<Pick<InputProps, 'width'>>`
     display: inline-flex;
     flex-direction: column;
     width: ${({ width }) => (width ? `${width}px` : '100%')};
-
-    @media (min-width: ${SCREEN_SIZE.SM}) {
-        align-items: ${({ alignInputRight }) => alignInputRight && 'flex-end'};
-    }
 `;
 
 interface StyledInputProps extends InputProps {
@@ -121,7 +117,6 @@ export interface InputProps extends React.InputHTMLAttributes<HTMLInputElement> 
     wrapperProps?: Record<string, any>;
     inputState?: InputState;
     addonAlign?: AddonAlignment;
-    alignInputRight?: boolean;
     errorPosition?: 'bottom' | 'right';
     noError?: boolean;
     noTopLabel?: boolean;
@@ -155,7 +150,6 @@ const Input = ({
     clearButton,
     onClear,
     addonAlign = 'right',
-    alignInputRight,
     errorPosition = 'bottom',
     noError = false,
     noTopLabel = false,
@@ -187,7 +181,6 @@ const Input = ({
     return (
         <Wrapper
             width={width}
-            alignInputRight={alignInputRight}
             data-test={dataTest}
             onMouseEnter={() => setIsHovered(true)}
             onMouseLeave={() => setIsHovered(false)}

--- a/packages/components/src/components/form/Input/Input.tsx
+++ b/packages/components/src/components/form/Input/Input.tsx
@@ -1,7 +1,7 @@
 import React, { useCallback, useState } from 'react';
 import styled, { css } from 'styled-components';
 
-import { FONT_SIZE, Z_INDEX } from '../../../config/variables';
+import { FONT_SIZE, SCREEN_SIZE, Z_INDEX } from '../../../config/variables';
 import { InputState, InputVariant } from '../../../support/types';
 import { useTheme } from '../../../utils';
 import { Icon } from '../../assets/Icon/Icon';
@@ -16,10 +16,14 @@ import {
     LabelAddon,
 } from '../InputStyles';
 
-const Wrapper = styled.div<Pick<InputProps, 'width'>>`
+const Wrapper = styled.div<Pick<InputProps, 'width' | 'alignInputRight'>>`
     display: inline-flex;
     flex-direction: column;
     width: ${({ width }) => (width ? `${width}px` : '100%')};
+
+    @media (min-width: ${SCREEN_SIZE.SM}) {
+        align-items: ${({ alignInputRight }) => alignInputRight && 'flex-end'};
+    }
 `;
 
 interface StyledInputProps extends InputProps {
@@ -117,6 +121,7 @@ export interface InputProps extends React.InputHTMLAttributes<HTMLInputElement> 
     wrapperProps?: Record<string, any>;
     inputState?: InputState;
     addonAlign?: AddonAlignment;
+    alignInputRight?: boolean;
     errorPosition?: 'bottom' | 'right';
     noError?: boolean;
     noTopLabel?: boolean;
@@ -150,6 +155,7 @@ const Input = ({
     clearButton,
     onClear,
     addonAlign = 'right',
+    alignInputRight,
     errorPosition = 'bottom',
     noError = false,
     noTopLabel = false,
@@ -181,6 +187,7 @@ const Input = ({
     return (
         <Wrapper
             width={width}
+            alignInputRight={alignInputRight}
             data-test={dataTest}
             onMouseEnter={() => setIsHovered(true)}
             onMouseLeave={() => setIsHovered(false)}

--- a/packages/suite/src/components/suite/ChangeDeviceLabel.tsx
+++ b/packages/suite/src/components/suite/ChangeDeviceLabel.tsx
@@ -4,26 +4,18 @@ import styled, { css } from 'styled-components';
 
 import { Button, INPUT_HEIGHTS, Input } from '@trezor/components';
 import { Translation } from 'src/components/suite';
-import { useDevice, useDispatch, useTranslation } from 'src/hooks/suite';
+import { useDevice, useDispatch, useTranslation, useLayoutSize } from 'src/hooks/suite';
 import { applySettings } from 'src/actions/settings/deviceSettingsActions';
 import { MAX_LABEL_LENGTH } from 'src/constants/suite/device';
-import { SCREEN_SIZE } from '@trezor/components/src/config/variables';
 import { isAscii } from '@trezor/utils';
+import { SCREEN_SIZE } from '@trezor/components/src/config/variables';
 
 const StyledInput = styled(Input)<{ isVertical?: boolean }>`
-    width: 170px;
-
     ${props =>
         props.isVertical &&
         css`
-            margin: 4px 0;
-
             &:not(:first-child) {
                 margin-left: 8px;
-            }
-
-            @media (max-width: ${SCREEN_SIZE.SM}) {
-                width: 100%;
             }
         `};
 `;
@@ -66,6 +58,7 @@ export const ChangeDeviceLabel = ({
     const { translationString } = useTranslation();
     const { device } = useDevice();
     const dispatch = useDispatch();
+    const { isMobileLayout } = useLayoutSize();
 
     const [label, setLabel] = useState(device?.label === placeholder ? '' : device?.label);
     const [error, setError] = useState<string | null>(null);
@@ -100,6 +93,7 @@ export const ChangeDeviceLabel = ({
     return (
         <>
             <StyledInput
+                width={!isMobileLayout ? 170 : undefined}
                 isVertical={isVertical}
                 noTopLabel
                 bottomText={error}
@@ -108,7 +102,6 @@ export const ChangeDeviceLabel = ({
                 inputState={error ? 'error' : undefined}
                 onChange={handleChange}
                 data-test="@settings/device/label-input"
-                alignInputRight
             />
             <StyledButton
                 isVertical={isVertical}

--- a/packages/suite/src/components/suite/ChangeDeviceLabel.tsx
+++ b/packages/suite/src/components/suite/ChangeDeviceLabel.tsx
@@ -11,20 +11,21 @@ import { SCREEN_SIZE } from '@trezor/components/src/config/variables';
 import { isAscii } from '@trezor/utils';
 
 const StyledInput = styled(Input)<{ isVertical?: boolean }>`
+    width: 170px;
+
     ${props =>
         props.isVertical &&
         css`
-            margin: 4px 0 4px 4px;
+            margin: 4px 0;
 
             &:not(:first-child) {
                 margin-left: 8px;
             }
 
             @media (max-width: ${SCREEN_SIZE.SM}) {
-                margin: 0px 0 10px;
                 width: 100%;
             }
-        `}
+        `};
 `;
 
 const StyledButton = styled(Button)<{ isVertical?: boolean; isDisabled: boolean }>`
@@ -34,7 +35,7 @@ const StyledButton = styled(Button)<{ isVertical?: boolean; isDisabled: boolean 
         props.isVertical &&
         css`
             min-width: 170px;
-            margin: 4px 0 4px 4px;
+            margin: 4px 0;
             &:not(:first-child) {
                 margin-left: 8px;
 
@@ -45,7 +46,6 @@ const StyledButton = styled(Button)<{ isVertical?: boolean; isDisabled: boolean 
 
             @media (max-width: ${SCREEN_SIZE.SM}) {
                 width: 100%;
-                margin: 0;
             }
         `}
 `;
@@ -100,7 +100,6 @@ export const ChangeDeviceLabel = ({
     return (
         <>
             <StyledInput
-                width={170}
                 isVertical={isVertical}
                 noTopLabel
                 bottomText={error}
@@ -109,6 +108,7 @@ export const ChangeDeviceLabel = ({
                 inputState={error ? 'error' : undefined}
                 onChange={handleChange}
                 data-test="@settings/device/label-input"
+                alignInputRight
             />
             <StyledButton
                 isVertical={isVertical}


### PR DESCRIPTION
Device label input tweaks

## Description

Device label input has the same width as button and also fixed mobile version.

## Screenshots:

<img width="195" alt="Screenshot 2023-08-23 at 12 26 51 PM" src="https://github.com/trezor/trezor-suite/assets/66002635/c5ef5fb1-abd5-4163-b611-36c15735946e">
<img width="508" alt="Screenshot 2023-08-23 at 12 27 00 PM" src="https://github.com/trezor/trezor-suite/assets/66002635/a9259fbf-4a15-42a2-98da-0e8f22c945d9">