### PR TITLE
tests: coinjoinClientActions coverage to 100%

### DIFF
--- a/packages/suite/src/actions/wallet/__fixtures__/mockCoinjoinService.ts
+++ b/packages/suite/src/actions/wallet/__fixtures__/mockCoinjoinService.ts
@@ -1,12 +1,23 @@
+import { EventEmitter } from 'events';
+
 export const mockCoinjoinService = () => {
     const allowed = ['btc', 'test'];
     const clients: Record<string, any> = {}; // @trezor/coinjoin CoinjoinClient
+    const clientEmitter = new EventEmitter();
+    clientEmitter.setMaxListeners(Infinity);
+
     const getMockedInstance = (network: string) => {
         const client = {
             settings: { coordinatorName: '', network },
-            on: jest.fn(),
-            off: jest.fn(),
-            emit: jest.fn(),
+            on: jest.fn((...args: Parameters<typeof clientEmitter.on>) => {
+                clientEmitter.on(...args);
+            }),
+            off: jest.fn((...args: Parameters<typeof clientEmitter.off>) => {
+                clientEmitter.off(...args);
+            }),
+            emit: jest.fn((eventName: string, ...args: any[]) => {
+                clientEmitter.emit(eventName, ...args);
+            }),
             enable: jest.fn(() =>
                 Promise.resolve({
                     success: true,
@@ -19,6 +30,7 @@ export const mockCoinjoinService = () => {
             registerAccount: jest.fn(),
             unregisterAccount: jest.fn(),
             updateAccount: jest.fn(),
+            resolveRequest: jest.fn(),
             analyzeTransactions: jest.fn(() => ({ anonymityScores: {}, rawLiquidityClue: 0 })),
         };
         const backend = {

--- a/packages/suite/src/actions/wallet/constants/coinjoinConstants.ts
+++ b/packages/suite/src/actions/wallet/constants/coinjoinConstants.ts
@@ -28,7 +28,6 @@ export const SESSION_AUTOSTOP = '@coinjoin/session-autostop';
 export const SESSION_RESTORE = '@coinjoin/session-restore';
 export const SESSION_ROUND_CHANGED = '@coinjoin/session-round-changed';
 export const SESSION_COMPLETED = '@coinjoin/session-completed';
-export const SESSION_OWNERSHIP = '@coinjoin/session-ownership';
 export const SESSION_TX_SIGNED = '@coinjoin/session-tx-signed';
 export const SESSION_TX_CANDIDATE = '@coinjoin/session-tx-candidate';
 export const SESSION_TX_BROADCASTED = '@coinjoin/session-tx-broadcasted';

--- a/packages/suite/src/reducers/wallet/coinjoinReducer.ts
+++ b/packages/suite/src/reducers/wallet/coinjoinReducer.ts
@@ -810,13 +810,14 @@ export const selectWeightedAnonymityByAccountKey = (
     const anonymitySet = account?.addresses?.anonymitySet || {};
     const utxos = account?.utxo || [];
     const weightedAnonymitySum = BigNumber.sum(
+        0,
         ...utxos.map(utxo =>
             new BigNumber(utxo.amount).times(
                 Math.min(targetAnonymity, anonymitySet[utxo.address] || 1),
             ),
         ),
     );
-    const amountsSum = BigNumber.sum(...utxos.map(utxo => utxo.amount));
+    const amountsSum = BigNumber.sum(0, ...utxos.map(utxo => utxo.amount));
 
     return amountsSum.isZero() ? 1 : weightedAnonymitySum.div(amountsSum).toNumber();
 };


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

I wanted to increase coverage of coinjoinClientActions because current global coverage is almost at lowest accepted percentage.
And i did it - now it's increased to 100%

While writing test i've found 2 issues/bugs in actions:

- unused `clientSessionOwnership` (now removed)
- condition to call `cancelCoinjoinAuthorization` in `stopCoinjoinSession` action -  TrezorConnect.cancelCoinjoinAuthorization was called on **currently selected** device instead of the device related to the account which session should be stopped. Going deeper this action should not be called if there is another coinjoin account with enabled session (for example on different passphrase or different coin)