### PR TITLE
feat(solana) add solana backend

### DIFF
--- a/packages/blockchain-link/package.json
+++ b/packages/blockchain-link/package.json
@@ -67,6 +67,7 @@
         "worker-loader": "^3.0.8"
     },
     "dependencies": {
+        "@solana/web3.js": "^1.78.4",
         "@trezor/blockchain-link-types": "workspace:*",
         "@trezor/blockchain-link-utils": "workspace:*",
         "@trezor/utils": "workspace:*",

--- a/packages/blockchain-link/src/ui/config.ts
+++ b/packages/blockchain-link/src/ui/config.ts
@@ -449,4 +449,29 @@ export default [
             tx: '83a400818258208911f640d452c3be4ff3d89db63b41ce048c056951286e2e28bbf8a51588ab44000181825839009493315cd92eb5d8c4304e67b7e16ae36d61d34502694657811a2c8e32c728d3861e164cab28cb8f006448139c8f1740ffb8e7aa9e5232dc1a10b2531f021a00029519075820cb798b0bce50604eaf2e0dc89367896b18f0a6ef6b32b57e3c9f83f8ee71e608a1008182582073fea80d424276ad0978d4fe5310e8bc2d485f5f6bb3bf87612989f112ad5a7d5840c40425229749a9434763cf01b492057fd56d7091a6372eaa777a1c9b1ca508c914e6a4ee9c0d40fc10952ed668e9ad65378a28b149de6bd4204bd9f095b0a902a11907b0a1667469636b657281a266736f757263656b736f757263655f6e616d656576616c7565736675676961742076656e69616d206d696e7573',
         },
     },
+    {
+        blockchain: {
+            name: 'Solana Mainnet',
+            // we do not use path to worker build here because its not used, we use it just to match this config to actual implementation of the worker
+            worker: 'solana',
+            server: [
+                'wiser-green-owl.solana-mainnet.discover.quiknode.pro/c218d0c9e451f6c5c0bf8b7c7d8e5a72384c9570/',
+            ],
+            debug: true,
+        },
+        data: {
+            estimateFeeOptions: {
+                // TODO(vl): revisit once we implement txs
+                blocks: [1],
+            },
+            accountInfoOptions: {
+                page: 0,
+                pageSize: 25,
+            },
+            address: 'FSJnAbqHcGm1wAijWEptDVc77VWjL7PrLw3ds8hLYgAf',
+            txid: '', // TODO(vl): once we implemented tx history
+            blockNumber: '', // TODO(vl): once we implement getBlock '212702904',
+            tx: '', // TODO(vl): once we implemented tx submission
+        },
+    },
 ];

--- a/packages/blockchain-link/src/ui/index.ui.ts
+++ b/packages/blockchain-link/src/ui/index.ui.ts
@@ -4,6 +4,7 @@ import BlockfrostWorker from '../workers/blockfrost/index';
 import CONFIG from './config';
 import BlockchainLink from '../index';
 import { getInputValue, fillValues, onClear } from './utils';
+import SolanaWorker from '../workers/solana';
 
 const instances: BlockchainLink[] = [];
 
@@ -378,6 +379,10 @@ CONFIG.forEach(i => {
 
     if (i.blockchain.worker.includes('blockfrost')) {
         worker = BlockfrostWorker;
+    }
+
+    if (i.blockchain.worker.includes('solana')) {
+        worker = SolanaWorker;
     }
 
     const b = new BlockchainLink({

--- a/packages/blockchain-link/src/workers/solana/index.ts
+++ b/packages/blockchain-link/src/workers/solana/index.ts
@@ -79,6 +79,8 @@ const getInfo = async (request: Request<MessageTypes.GetInfo>) => {
     } as const;
 };
 
+const BLOCK_SUBSCRIBE_INTERVAL_MS = 10000;
+
 const subscribeBlock = async ({ state, connect, post }: Context) => {
     if (state.getSubscription('block')) return;
     const api = await connect();
@@ -105,7 +107,7 @@ const subscribeBlock = async ({ state, connect, post }: Context) => {
                 },
             });
         }
-    }, 10000);
+    }, BLOCK_SUBSCRIBE_INTERVAL_MS);
     // we save the interval in the state so we can clear it later
     state.addSubscription('block', interval);
 };

--- a/packages/blockchain-link/src/workers/solana/index.ts
+++ b/packages/blockchain-link/src/workers/solana/index.ts
@@ -5,7 +5,7 @@ import { BaseWorker, ContextType, CONTEXT } from '../baseWorker';
 import { MESSAGES, RESPONSES } from '@trezor/blockchain-link-types/lib/constants';
 import { Connection, PublicKey } from '@solana/web3.js';
 
-type SolanaAPI = Connection;
+export type SolanaAPI = Connection;
 
 type Context = ContextType<SolanaAPI>;
 type Request<T> = T & Context;

--- a/packages/blockchain-link/src/workers/solana/index.ts
+++ b/packages/blockchain-link/src/workers/solana/index.ts
@@ -1,0 +1,139 @@
+import type { Response, AccountInfo } from '@trezor/blockchain-link-types';
+import type * as MessageTypes from '@trezor/blockchain-link-types/lib/messages';
+import { CustomError } from '@trezor/blockchain-link-types/lib/constants/errors';
+import { BaseWorker, ContextType, CONTEXT } from '../baseWorker';
+import { MESSAGES, RESPONSES } from '@trezor/blockchain-link-types/lib/constants';
+import { Connection, PublicKey } from '@solana/web3.js';
+
+type SolanaAPI = Connection;
+
+type Context = ContextType<SolanaAPI>;
+type Request<T> = T & Context;
+
+const getAccountInfo = async (request: Request<MessageTypes.GetAccountInfo>) => {
+    const { payload } = request;
+    const api = await request.connect();
+
+    const accountInfo = await api.getAccountInfo(new PublicKey(payload.descriptor));
+
+    if (!accountInfo) {
+        // return empty account
+        const account: AccountInfo = {
+            descriptor: payload.descriptor,
+            balance: '0', // default balance
+            availableBalance: '0', // default balance
+            empty: true,
+            history: {
+                total: -1,
+                unconfirmed: 0,
+                transactions: undefined,
+            },
+        };
+        return Promise.resolve({
+            type: RESPONSES.GET_ACCOUNT_INFO,
+            payload: account,
+        } as const);
+    }
+
+    const account: AccountInfo = {
+        descriptor: payload.descriptor,
+        balance: accountInfo.lamports.toString(), // TODO(vl): check if this should also include staking balances
+        availableBalance: accountInfo.lamports.toString(), // TODO(vl): revisit to make sure that what getAccountInfo returns is actually available balance
+        empty: accountInfo.lamports === 0, // TODO(vl): this is not correct, it should depend on the length of transaction history
+        // TODO(vl): transaction history
+        history: {
+            total: -1,
+            unconfirmed: 0,
+            transactions: undefined,
+        },
+    };
+    return Promise.resolve({
+        type: RESPONSES.GET_ACCOUNT_INFO,
+        payload: account,
+    } as const);
+};
+
+const getInfo = async (request: Request<MessageTypes.GetInfo>) => {
+    const api = await request.connect();
+    const blockHeight = await api.getBlockHeight('finalized');
+
+    // more info for the parsedBlock endpoint here https://www.quicknode.com/docs/solana/getParsedBlock
+    // the maxSupportedTransactionVersion might need to get updated if solana introduces a new version of transactions
+    const { blockhash: blockHash } = await api.getParsedBlock(blockHeight, {
+        maxSupportedTransactionVersion: 0,
+    });
+    const serverInfo = {
+        // genesisHash is reliable identifier of the network, for mainnet the genesis hash is 5eykt4UsFv8P8NJdTREpY1vzqKqZKvdpKuc147dw2N9d
+        testnet: (await api.getGenesisHash()) !== '5eykt4UsFv8P8NJdTREpY1vzqKqZKvdpKuc147dw2N9d',
+        blockHeight,
+        blockHash,
+        shortcut: 'sol',
+        url: api.rpcEndpoint,
+        name: 'Solana',
+        version: (await api.getVersion())['solana-core'],
+        decimals: 9,
+    };
+    return {
+        type: RESPONSES.GET_INFO,
+        payload: { ...serverInfo },
+    } as const;
+};
+
+const onRequest = (request: Request<MessageTypes.Message>) => {
+    switch (request.type) {
+        case MESSAGES.GET_ACCOUNT_INFO:
+            return getAccountInfo(request);
+        case MESSAGES.GET_INFO:
+            return getInfo(request);
+        default:
+            throw new CustomError('worker_unknown_request', `+${request.type}`);
+    }
+};
+
+class SolanaWorker extends BaseWorker<SolanaAPI> {
+    protected isConnected(api: SolanaAPI | undefined): api is SolanaAPI {
+        return !!api;
+    }
+
+    tryConnect(url: string): Promise<SolanaAPI> {
+        const api = new Connection(`https://${url}`, { wsEndpoint: `wss://${url}` });
+        this.post({ id: -1, type: RESPONSES.CONNECTED });
+        return Promise.resolve(api);
+    }
+
+    async messageHandler(event: { data: MessageTypes.Message }) {
+        try {
+            // skip processed messages
+            if (await super.messageHandler(event)) return true;
+
+            const request: Request<MessageTypes.Message> = {
+                ...event.data,
+                connect: () => this.connect(),
+                post: (data: Response) => this.post(data),
+                state: this.state,
+            };
+
+            const response = await onRequest(request);
+            this.post({ id: event.data.id, ...response });
+        } catch (error) {
+            this.errorResponse(event.data.id, error);
+        }
+    }
+
+    disconnect(): void {
+        if (this.api) {
+            // TODO(vl): revisit, seems there is no way to disconnect, but we can remove all created listeners
+        }
+    }
+}
+
+// export worker factory used in src/index
+export default function Solana() {
+    return new SolanaWorker();
+}
+
+if (CONTEXT === 'worker') {
+    // Initialize module if script is running in worker context
+    const module = new SolanaWorker();
+    onmessage = module.messageHandler.bind(module);
+}

--- a/packages/blockchain-link/src/workers/state.ts
+++ b/packages/blockchain-link/src/workers/state.ts
@@ -4,7 +4,7 @@ import type { SubscriptionAccountInfo } from '@trezor/blockchain-link-types';
 export class WorkerState {
     addresses: string[];
     accounts: SubscriptionAccountInfo[];
-    subscription: { [key: string]: boolean };
+    subscription: { [key: string]: unknown };
     constructor() {
         this.addresses = [];
         this.accounts = [];
@@ -102,8 +102,8 @@ export class WorkerState {
         return this.accounts;
     }
 
-    addSubscription(type: string) {
-        this.subscription[type] = true;
+    addSubscription(type: string, id: unknown = true) {
+        this.subscription[type] = id;
     }
 
     getSubscription(type: string) {

--- a/packages/blockchain-link/tests/integration/solana.ts
+++ b/packages/blockchain-link/tests/integration/solana.ts
@@ -1,0 +1,53 @@
+import BlockchainLink from '../../lib';
+import SolanaWorker, { SolanaAPI } from '../../lib/workers/solana';
+
+export const solanaApi = {
+    getGenesisHash: () => '5eykt4UsFv8P8NJdTREpY1vzqKqZKvdpKuc147dw2N9d',
+    getVersion: () => ({ 'feature-set': 1879391783, 'solana-core': '1.14.22' }),
+    getParsedBlock: () => ({
+        blockHeight: 195138557,
+        blockTime: 1684668753,
+        blockhash: '9Grw2oA6XBQ499EmBKJfyjhwATojKGupGhjWQiCWhpxB',
+        parentSlot: 195138556,
+        previousBlockhash: '2K6J2Nw3z4P9SsGTq2n33YvqByrn826zjMsLqXz3f3Yh',
+        rewards: [],
+        transactions: [],
+    }),
+    getBlockHeight: () => 195138557,
+    rpcEndpoint: 'dummyUrl',
+} as unknown as SolanaAPI;
+
+describe(`Solana`, () => {
+    let blockchain: BlockchainLink;
+
+    const worker = SolanaWorker();
+
+    worker.tryConnect = () => Promise.resolve(solanaApi);
+
+    beforeEach(() => {
+        blockchain = new BlockchainLink({
+            name: 'Solana',
+            worker: () => worker,
+            server: ['dummyUrl'],
+            debug: false,
+        });
+    });
+
+    afterEach(() => {
+        blockchain.dispose();
+    });
+
+    it('Get info', async () => {
+        const result = await blockchain.getInfo();
+        expect(result).toEqual({
+            testnet: false,
+            blockHeight: 195138557,
+            blockHash: '9Grw2oA6XBQ499EmBKJfyjhwATojKGupGhjWQiCWhpxB',
+            shortcut: 'sol',
+            url: expect.any(String),
+            name: 'Solana',
+            version: '1.14.22',
+            decimals: 9,
+        });
+    });
+});

--- a/packages/connect-common/files/coins.json
+++ b/packages/connect-common/files/coins.json
@@ -2230,6 +2230,26 @@
     "misc": [
         {
             "blockchain_link": {
+                "type": "solana",
+                "url": [
+                    "wiser-green-owl.solana-mainnet.discover.quiknode.pro/c218d0c9e451f6c5c0bf8b7c7d8e5a72384c9570/"
+                ]
+            },
+            "curve": "ed25519",
+            "decimals": 9,
+            "is_testnet": false,
+            "name": "Solana",
+            "shortcut": "SOL",
+            "slip44": 501,
+            "support": {
+                "connect": true,
+                "suite": true,
+                "trezor1": false,
+                "trezor2": "2.4.3"
+            }
+        },
+        {
+            "blockchain_link": {
                 "type": "blockfrost",
                 "url": ["wss://trezor-cardano-mainnet.blockfrost.io"]
             },

--- a/packages/connect/src/backend/Blockchain.ts
+++ b/packages/connect/src/backend/Blockchain.ts
@@ -11,6 +11,7 @@ import {
     RippleWorker,
     BlockfrostWorker,
     ElectrumWorker,
+    SolanaWorker,
 } from '../workers/workers';
 
 import type { CoinInfo, Proxy } from '../types';
@@ -25,6 +26,8 @@ const getWorker = (type: string) => {
             return BlockfrostWorker;
         case 'electrum':
             return ElectrumWorker;
+        case 'solana':
+            return SolanaWorker;
         default:
             return null;
     }

--- a/packages/connect/src/device/DeviceCommands.ts
+++ b/packages/connect/src/device/DeviceCommands.ts
@@ -693,6 +693,16 @@ export class DeviceCommands {
             };
         }
 
+        if (coinInfo.shortcut === 'SOL') {
+            const { message } = await this.typedCall('SolanaGetAddress', 'SolanaAddress', {
+                address_n,
+            });
+            return {
+                descriptor: message.address,
+                address_n,
+            };
+        }
+
         throw ERRORS.TypedError(
             'Runtime',
             'DeviceCommands.getAccountDescriptor: unsupported coinInfo.type',

--- a/packages/connect/src/utils/__tests__/deviceFeaturesUtils.test.ts
+++ b/packages/connect/src/utils/__tests__/deviceFeaturesUtils.test.ts
@@ -55,6 +55,7 @@ describe('utils/deviceFeaturesUtils', () => {
             'Capability_Stellar',
             'Capability_Tezos',
             'Capability_U2F',
+            'Capability_Solana',
         ]);
 
         expect(
@@ -77,6 +78,7 @@ describe('utils/deviceFeaturesUtils', () => {
             'Capability_Stellar',
             'Capability_Tezos',
             'Capability_U2F',
+            'Capability_Solana',
         ]);
 
         // bitcoin only
@@ -117,7 +119,6 @@ describe('utils/deviceFeaturesUtils', () => {
         it('getUnavailableCapabilities capabilities 3', () => {
             jest.resetModules();
             const coins = getAllNetworks();
-
             // default Capabilities T1B1
             // @ts-expect-error incomplete features
 
@@ -135,6 +136,7 @@ describe('utils/deviceFeaturesUtils', () => {
                 xtz: 'no-support',
                 xvg: 'update-required',
                 zcr: 'update-required',
+                sol: 'no-support',
                 replaceTransaction: 'update-required',
                 amountUnit: 'update-required',
                 decreaseOutput: 'update-required',
@@ -158,6 +160,7 @@ describe('utils/deviceFeaturesUtils', () => {
                 taproot: 'update-required',
                 tsep: 'update-required',
                 tgor: 'update-required',
+                sol: 'update-required',
                 coinjoin: 'update-required',
                 signMessageNoScriptType: 'update-required',
             });

--- a/packages/connect/src/utils/deviceFeaturesUtils.ts
+++ b/packages/connect/src/utils/deviceFeaturesUtils.ts
@@ -27,6 +27,7 @@ const DEFAULT_CAPABILITIES_TT: PROTO.Capability[] = [
     'Capability_Stellar',
     'Capability_Tezos',
     'Capability_U2F',
+    'Capability_Solana',
 ];
 
 export const parseCapabilities = (features?: Features): PROTO.Capability[] => {

--- a/packages/connect/src/workers/workers-browser.ts
+++ b/packages/connect/src/workers/workers-browser.ts
@@ -1,7 +1,8 @@
 import BlockbookWorker from '@trezor/blockchain-link/lib/workers/blockbook';
 import RippleWorker from '@trezor/blockchain-link/lib/workers/ripple';
 import BlockfrostWorker from '@trezor/blockchain-link/lib/workers/blockfrost';
+import SolanaWorker from '@trezor/blockchain-link/lib/workers/solana';
 
 const ElectrumWorker = undefined;
 
-export { BlockbookWorker, RippleWorker, BlockfrostWorker, ElectrumWorker };
+export { BlockbookWorker, RippleWorker, BlockfrostWorker, ElectrumWorker, SolanaWorker };

--- a/packages/connect/src/workers/workers-react-native.ts
+++ b/packages/connect/src/workers/workers-react-native.ts
@@ -1,7 +1,8 @@
 import BlockbookWorker from '@trezor/blockchain-link/lib/workers/blockbook';
 import RippleWorker from '@trezor/blockchain-link/lib/workers/ripple';
 import BlockfrostWorker from '@trezor/blockchain-link/lib/workers/blockfrost';
+import SolanaWorker from '@trezor/blockchain-link/lib/workers/solana';
 
 const ElectrumWorker = undefined;
 
-export { BlockbookWorker, RippleWorker, BlockfrostWorker, ElectrumWorker };
+export { BlockbookWorker, RippleWorker, BlockfrostWorker, ElectrumWorker, SolanaWorker };

--- a/packages/connect/src/workers/workers.ts
+++ b/packages/connect/src/workers/workers.ts
@@ -2,5 +2,6 @@ import BlockbookWorker from '@trezor/blockchain-link/lib/workers/blockbook';
 import RippleWorker from '@trezor/blockchain-link/lib/workers/ripple';
 import BlockfrostWorker from '@trezor/blockchain-link/lib/workers/blockfrost';
 import ElectrumWorker from '@trezor/blockchain-link/lib/workers/electrum';
+import SolanaWorker from '@trezor/blockchain-link/lib/workers/solana';
 
-export { BlockbookWorker, RippleWorker, BlockfrostWorker, ElectrumWorker };
+export { BlockbookWorker, RippleWorker, BlockfrostWorker, ElectrumWorker, SolanaWorker };

--- a/packages/suite-analytics/src/types/events.ts
+++ b/packages/suite-analytics/src/types/events.ts
@@ -335,7 +335,14 @@ export type SuiteAnalyticsEvent =
           type: EventType.SettingsCoinsBackend;
           payload: {
               symbol: string;
-              type: 'blockbook' | 'electrum' | 'ripple' | 'blockfrost' | 'coinjoin' | 'default';
+              type:
+                  | 'blockbook'
+                  | 'electrum'
+                  | 'ripple'
+                  | 'blockfrost'
+                  | 'coinjoin'
+                  | 'default'
+                  | 'solana';
               totalRegular: number;
               totalOnion: number;
           };

--- a/packages/suite/jest.config.js
+++ b/packages/suite/jest.config.js
@@ -21,6 +21,7 @@ module.exports = {
         '^@trezor/(.+)': '<rootDir>/../$1',
         '^src/(.+)': '<rootDir>/src/$1',
         '\\.(mp4)$': '<rootDir>/__mocks__/file.js',
+        uuid: require.resolve('uuid'), // https://stackoverflow.com/questions/73203367/jest-syntaxerror-unexpected-token-export-with-uuid-library
     },
     moduleFileExtensions: ['js', 'ts', 'tsx'],
     coverageDirectory: './coverage',

--- a/packages/suite/src/hooks/settings/backends/useBackendsForm.ts
+++ b/packages/suite/src/hooks/settings/backends/useBackendsForm.ts
@@ -25,6 +25,7 @@ const validateUrl = (type: BackendOption, value: string) => {
             return isUrl(value);
         case 'electrum':
             return isElectrumUrl(value);
+        // TODO(vl): solana backend
         default:
             return false;
     }
@@ -38,6 +39,7 @@ const getUrlPlaceholder = (coin: Network['symbol'], type: BackendOption) => {
             return `wss://blockfrost.io`;
         case 'electrum':
             return `electrum.example.com:50001:t`;
+        // TODO(vl): solana backend
         default:
             return '';
     }

--- a/suite-common/wallet-config/src/networksConfig.ts
+++ b/suite-common/wallet-config/src/networksConfig.ts
@@ -432,14 +432,20 @@ export const networks = {
         support: {
             [DeviceModelInternal.T2T1]: '0.0.0', // TODO(vl): always support, update this once we have version
         },
-        customBackends: [''], // TODO(vl): investigate what this affects
+        customBackends: ['solana'],
         accountTypes: {
             // TODO(vl): accounts and paths
         },
     },
 } as const;
 
-export const TREZOR_CONNECT_BACKENDS = ['blockbook', 'electrum', 'ripple', 'blockfrost'] as const;
+export const TREZOR_CONNECT_BACKENDS = [
+    'blockbook',
+    'electrum',
+    'ripple',
+    'blockfrost',
+    'solana',
+] as const;
 export const NON_STANDARD_BACKENDS = ['coinjoin'] as const;
 
 export type BackendType =

--- a/suite-common/wallet-config/src/networksConfig.ts
+++ b/suite-common/wallet-config/src/networksConfig.ts
@@ -420,7 +420,7 @@ export const networks = {
     sol: {
         name: 'Solana',
         networkType: 'solana',
-        bip43Path: "m/44'/501'/i'", // TODO(vl): accounts and paths
+        bip43Path: "m/44'/501'/i'/0'", // TODO(vl): accounts and paths
         decimals: 9,
         testnet: false,
         // features: ['tokens', 'staking'],
@@ -430,7 +430,7 @@ export const networks = {
             address: '',
         },
         support: {
-            [DeviceModelInternal.T2T1]: '0.0.0', // TODO(vl): always support, update this once we have version
+            [DeviceModelInternal.T2T1]: '2.4.3', // TODO(vl): revisit, for now just anything above 2.0.0
         },
         customBackends: ['solana'],
         accountTypes: {

--- a/suite-common/wallet-core/src/discovery/discoveryThunks.ts
+++ b/suite-common/wallet-core/src/discovery/discoveryThunks.ts
@@ -396,47 +396,13 @@ export const startDiscoveryThunk = createThunk(
             });
         }
 
-        // SOLANA MOCK START (this block will be reverted once solana is supported by @trezor/connect and trezor-firmware)
-
         // prepare bundle of accounts to discover, exclude unsupported account types
-        const bundleWithSol = await dispatch(
+        const bundle = await dispatch(
             getBundleThunk({
                 discovery: { ...discovery, availableCardanoDerivations },
                 device,
             }),
         ).unwrap();
-
-        const solanaDiscoveryItem = bundleWithSol.find(
-            ({ networkType }) => networkType === 'solana',
-        );
-
-        const solanaAccountInfo: AccountInfo = {
-            descriptor:
-                'zpub6qy39U3XHtW4hyk3JXs5UjThu1JAuJjAStCm8nPr9Bb13yX8nJNfX8hiQr56NC4CGnHfvzkiaaFZ7NRsoaUqYZRhkeCyjJM2qRz7ibDiRGh',
-            balance: '0',
-            availableBalance: '0',
-            empty: false,
-            history: {
-                total: 0, // total transactions (unknown in ripple)
-                tokens: 0, // tokens transactions
-                unconfirmed: 0, // unconfirmed transactions
-                transactions: [], // list of transactions
-                txids: [], // not implemented
-            },
-        };
-
-        if (
-            solanaDiscoveryItem &&
-            !selectAccounts(getState()).some(a => a.networkType === 'solana')
-        ) {
-            dispatch(
-                accountsActions.createAccount(deviceState, solanaDiscoveryItem, solanaAccountInfo),
-            );
-        }
-
-        const bundle = bundleWithSol.filter(({ networkType }) => networkType !== 'solana');
-
-        // SOLANA MOCK END
 
         // discovery process complete
         if (bundle.length === 0) {

--- a/suite-common/wallet-types/src/backend.ts
+++ b/suite-common/wallet-types/src/backend.ts
@@ -10,7 +10,7 @@ export type BlockbookUrl = {
     tor?: boolean; // Added by TOR
 };
 
-export type BackendType = 'blockbook' | 'electrum' | 'ripple' | 'blockfrost';
+export type BackendType = 'blockbook' | 'electrum' | 'ripple' | 'blockfrost' | 'solana';
 
 export type CustomBackend = {
     coin: (typeof networksCompatibility)[number]['symbol'];

--- a/suite-common/wallet-utils/src/backend.ts
+++ b/suite-common/wallet-utils/src/backend.ts
@@ -9,6 +9,9 @@ export const getDefaultBackendType = (coin: NetworkSymbol) => {
     if (coin === 'ada' || coin === 'tada') {
         return 'blockfrost';
     }
+    if (coin === 'sol') {
+        return 'solana';
+    }
     return 'blockbook';
 };
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -1834,16 +1834,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@babel/runtime@npm:^7.0.0, @babel/runtime@npm:^7.1.2, @babel/runtime@npm:^7.12.0, @babel/runtime@npm:^7.12.1, @babel/runtime@npm:^7.12.13, @babel/runtime@npm:^7.12.5, @babel/runtime@npm:^7.13.10, @babel/runtime@npm:^7.15.4, @babel/runtime@npm:^7.17.8, @babel/runtime@npm:^7.18.0, @babel/runtime@npm:^7.18.3, @babel/runtime@npm:^7.20.0, @babel/runtime@npm:^7.20.7, @babel/runtime@npm:^7.21.0, @babel/runtime@npm:^7.22.5, @babel/runtime@npm:^7.5.0, @babel/runtime@npm:^7.5.5, @babel/runtime@npm:^7.7.6, @babel/runtime@npm:^7.8.4, @babel/runtime@npm:^7.8.7, @babel/runtime@npm:^7.9.2":
-  version: 7.22.6
-  resolution: "@babel/runtime@npm:7.22.6"
-  dependencies:
-    regenerator-runtime: ^0.13.11
-  checksum: e585338287c4514a713babf4fdb8fc2a67adcebab3e7723a739fc62c79cfda875b314c90fd25f827afb150d781af97bc16c85bfdbfa2889f06053879a1ddb597
-  languageName: node
-  linkType: hard
-
-"@babel/runtime@npm:^7.17.2, @babel/runtime@npm:^7.22.6":
+"@babel/runtime@npm:^7.0.0, @babel/runtime@npm:^7.1.2, @babel/runtime@npm:^7.12.0, @babel/runtime@npm:^7.12.1, @babel/runtime@npm:^7.12.13, @babel/runtime@npm:^7.12.5, @babel/runtime@npm:^7.13.10, @babel/runtime@npm:^7.15.4, @babel/runtime@npm:^7.17.2, @babel/runtime@npm:^7.17.8, @babel/runtime@npm:^7.18.0, @babel/runtime@npm:^7.18.3, @babel/runtime@npm:^7.20.0, @babel/runtime@npm:^7.20.7, @babel/runtime@npm:^7.21.0, @babel/runtime@npm:^7.22.5, @babel/runtime@npm:^7.22.6, @babel/runtime@npm:^7.5.0, @babel/runtime@npm:^7.5.5, @babel/runtime@npm:^7.7.6, @babel/runtime@npm:^7.8.4, @babel/runtime@npm:^7.8.7, @babel/runtime@npm:^7.9.2":
   version: 7.22.10
   resolution: "@babel/runtime@npm:7.22.10"
   dependencies:
@@ -4166,14 +4157,14 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@noble/hashes@npm:1.3.0, @noble/hashes@npm:^1.2.0, @noble/hashes@npm:^1.3.0, @noble/hashes@npm:~1.3.0":
+"@noble/hashes@npm:1.3.0":
   version: 1.3.0
   resolution: "@noble/hashes@npm:1.3.0"
   checksum: d7ddb6d7c60f1ce1f87facbbef5b724cdea536fc9e7f59ae96e0fc9de96c8f1a2ae2bdedbce10f7dcc621338dfef8533daa73c873f2b5c87fa1a4e05a95c2e2e
   languageName: node
   linkType: hard
 
-"@noble/hashes@npm:1.3.1, @noble/hashes@npm:^1.3.1":
+"@noble/hashes@npm:1.3.1, @noble/hashes@npm:^1.2.0, @noble/hashes@npm:^1.3.0, @noble/hashes@npm:^1.3.1, @noble/hashes@npm:~1.3.0":
   version: 1.3.1
   resolution: "@noble/hashes@npm:1.3.1"
   checksum: 7fdefc0f7a0c1ec27acc6ff88841793e3f93ec4ce6b8a6a12bfc0dd70ae6b7c4c82fe305fdfeda1735d5ad4a9eebe761e6693b3d355689c559e91242f4bc95b1
@@ -12113,18 +12104,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"agentkeepalive@npm:^4.2.1":
-  version: 4.2.1
-  resolution: "agentkeepalive@npm:4.2.1"
-  dependencies:
-    debug: ^4.1.0
-    depd: ^1.1.2
-    humanize-ms: ^1.2.1
-  checksum: 39cb49ed8cf217fd6da058a92828a0a84e0b74c35550f82ee0a10e1ee403c4b78ade7948be2279b188b7a7303f5d396ea2738b134731e464bf28de00a4f72a18
-  languageName: node
-  linkType: hard
-
-"agentkeepalive@npm:^4.3.0":
+"agentkeepalive@npm:^4.2.1, agentkeepalive@npm:^4.3.0":
   version: 4.5.0
   resolution: "agentkeepalive@npm:4.5.0"
   dependencies:
@@ -16795,7 +16775,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"depd@npm:^1.1.2, depd@npm:~1.1.2":
+"depd@npm:~1.1.2":
   version: 1.1.2
   resolution: "depd@npm:1.1.2"
   checksum: 6b406620d269619852885ce15965272b829df6f409724415e0002c8632ab6a8c0a08ec1f0bd2add05dc7bd7507606f7e2cc034fa24224ab829580040b835ecd9

--- a/yarn.lock
+++ b/yarn.lock
@@ -1843,6 +1843,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@babel/runtime@npm:^7.17.2, @babel/runtime@npm:^7.22.6":
+  version: 7.22.10
+  resolution: "@babel/runtime@npm:7.22.10"
+  dependencies:
+    regenerator-runtime: ^0.14.0
+  checksum: 524d41517e68953dbc73a4f3616b8475e5813f64e28ba89ff5fca2c044d535c2ea1a3f310df1e5bb06162e1f0b401b5c4af73fe6e2519ca2450d9d8c44cf268d
+  languageName: node
+  linkType: hard
+
 "@babel/template@npm:^7.0.0, @babel/template@npm:^7.12.7, @babel/template@npm:^7.22.5, @babel/template@npm:^7.3.3":
   version: 7.22.5
   resolution: "@babel/template@npm:7.22.5"
@@ -4148,10 +4157,26 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@noble/curves@npm:^1.0.0":
+  version: 1.1.0
+  resolution: "@noble/curves@npm:1.1.0"
+  dependencies:
+    "@noble/hashes": 1.3.1
+  checksum: 2658cdd3f84f71079b4e3516c47559d22cf4b55c23ac8ee9d2b1f8e5b72916d9689e59820e0f9d9cb4a46a8423af5b56dc6bb7782405c88be06a015180508db5
+  languageName: node
+  linkType: hard
+
 "@noble/hashes@npm:1.3.0, @noble/hashes@npm:^1.2.0, @noble/hashes@npm:^1.3.0, @noble/hashes@npm:~1.3.0":
   version: 1.3.0
   resolution: "@noble/hashes@npm:1.3.0"
   checksum: d7ddb6d7c60f1ce1f87facbbef5b724cdea536fc9e7f59ae96e0fc9de96c8f1a2ae2bdedbce10f7dcc621338dfef8533daa73c873f2b5c87fa1a4e05a95c2e2e
+  languageName: node
+  linkType: hard
+
+"@noble/hashes@npm:1.3.1, @noble/hashes@npm:^1.3.1":
+  version: 1.3.1
+  resolution: "@noble/hashes@npm:1.3.1"
+  checksum: 7fdefc0f7a0c1ec27acc6ff88841793e3f93ec4ce6b8a6a12bfc0dd70ae6b7c4c82fe305fdfeda1735d5ad4a9eebe761e6693b3d355689c559e91242f4bc95b1
   languageName: node
   linkType: hard
 
@@ -5873,6 +5898,38 @@ __metadata:
   version: 3.1.0
   resolution: "@socket.io/component-emitter@npm:3.1.0"
   checksum: db069d95425b419de1514dffe945cc439795f6a8ef5b9465715acf5b8b50798e2c91b8719cbf5434b3fe7de179d6cdcd503c277b7871cb3dd03febb69bdd50fa
+  languageName: node
+  linkType: hard
+
+"@solana/buffer-layout@npm:^4.0.0":
+  version: 4.0.1
+  resolution: "@solana/buffer-layout@npm:4.0.1"
+  dependencies:
+    buffer: ~6.0.3
+  checksum: bf846888e813187243d4008a7a9f58b49d16cbd995b9d7f1b72898aa510ed77b1ce5e8468e7b2fd26dd81e557a4e74a666e21fccb95f123c1f740d41138bbacd
+  languageName: node
+  linkType: hard
+
+"@solana/web3.js@npm:^1.78.4":
+  version: 1.78.4
+  resolution: "@solana/web3.js@npm:1.78.4"
+  dependencies:
+    "@babel/runtime": ^7.22.6
+    "@noble/curves": ^1.0.0
+    "@noble/hashes": ^1.3.1
+    "@solana/buffer-layout": ^4.0.0
+    agentkeepalive: ^4.3.0
+    bigint-buffer: ^1.1.5
+    bn.js: ^5.2.1
+    borsh: ^0.7.0
+    bs58: ^4.0.1
+    buffer: 6.0.3
+    fast-stable-stringify: ^1.0.0
+    jayson: ^4.1.0
+    node-fetch: ^2.6.12
+    rpc-websockets: ^7.5.1
+    superstruct: ^0.14.2
+  checksum: e1c44c6cbec87cdfd4d6d23b4241b746e14ed3a9ca73d596693758d91ac825cecf579345da3b0b7bb5e54b6794791bc0eac02cadf11f1ec79e859b6536f26f11
   languageName: node
   linkType: hard
 
@@ -8843,6 +8900,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@trezor/blockchain-link@workspace:packages/blockchain-link"
   dependencies:
+    "@solana/web3.js": ^1.78.4
     "@trezor/blockchain-link-types": "workspace:*"
     "@trezor/blockchain-link-utils": "workspace:*"
     "@trezor/e2e-utils": "workspace:*"
@@ -10144,7 +10202,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@types/connect@npm:*":
+"@types/connect@npm:*, @types/connect@npm:^3.4.33":
   version: 3.4.35
   resolution: "@types/connect@npm:3.4.35"
   dependencies:
@@ -11403,7 +11461,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@types/ws@npm:^7.2.0":
+"@types/ws@npm:^7.2.0, @types/ws@npm:^7.4.4":
   version: 7.4.7
   resolution: "@types/ws@npm:7.4.7"
   dependencies:
@@ -11899,6 +11957,18 @@ __metadata:
   languageName: node
   linkType: hard
 
+"JSONStream@npm:^1.3.5":
+  version: 1.3.5
+  resolution: "JSONStream@npm:1.3.5"
+  dependencies:
+    jsonparse: ^1.2.0
+    through: ">=2.2.7 <3"
+  bin:
+    JSONStream: ./bin.js
+  checksum: 2605fa124260c61bad38bb65eba30d2f72216a78e94d0ab19b11b4e0327d572b8d530c0c9cc3b0764f727ad26d39e00bf7ebad57781ca6368394d73169c59e46
+  languageName: node
+  linkType: hard
+
 "abab@npm:^2.0.3, abab@npm:^2.0.5, abab@npm:^2.0.6":
   version: 2.0.6
   resolution: "abab@npm:2.0.6"
@@ -12051,6 +12121,15 @@ __metadata:
     depd: ^1.1.2
     humanize-ms: ^1.2.1
   checksum: 39cb49ed8cf217fd6da058a92828a0a84e0b74c35550f82ee0a10e1ee403c4b78ade7948be2279b188b7a7303f5d396ea2738b134731e464bf28de00a4f72a18
+  languageName: node
+  linkType: hard
+
+"agentkeepalive@npm:^4.3.0":
+  version: 4.5.0
+  resolution: "agentkeepalive@npm:4.5.0"
+  dependencies:
+    humanize-ms: ^1.2.1
+  checksum: 13278cd5b125e51eddd5079f04d6fe0914ac1b8b91c1f3db2c1822f99ac1a7457869068997784342fe455d59daaff22e14fb7b8c3da4e741896e7e31faf92481
   languageName: node
   linkType: hard
 
@@ -13551,6 +13630,16 @@ __metadata:
   languageName: node
   linkType: hard
 
+"bigint-buffer@npm:^1.1.5":
+  version: 1.1.5
+  resolution: "bigint-buffer@npm:1.1.5"
+  dependencies:
+    bindings: ^1.3.0
+    node-gyp: latest
+  checksum: d010c9f57758bcdaccb435d88b483ffcc95fe8bbc6e7fb3a44fb5221f29c894ffaf4a3c5a4a530e0e7d6608203c2cde9b79ee4f2386cd6d4462d1070bc8c9f4e
+  languageName: node
+  linkType: hard
+
 "bignumber.js@npm:^4.0.0":
   version: 4.1.0
   resolution: "bignumber.js@npm:4.1.0"
@@ -13721,6 +13810,17 @@ __metadata:
   version: 3.2.0
   resolution: "boolean@npm:3.2.0"
   checksum: fb29535b8bf710ef45279677a86d14f5185d604557204abd2ca5fa3fb2a5c80e04d695c8dbf13ab269991977a79bb6c04b048220a6b2a3849853faa94f4a7d77
+  languageName: node
+  linkType: hard
+
+"borsh@npm:^0.7.0":
+  version: 0.7.0
+  resolution: "borsh@npm:0.7.0"
+  dependencies:
+    bn.js: ^5.2.0
+    bs58: ^4.0.0
+    text-encoding-utf-8: ^1.0.2
+  checksum: e98bfb5f7cfb820819c2870b884dac58dd4b4ce6a86c286c8fbf5c9ca582e73a8c6094df67e81a28c418ff07a309c6b118b2e27fdfea83fd92b8100c741da0b5
   languageName: node
   linkType: hard
 
@@ -14029,7 +14129,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"bs58@npm:^4.0.0":
+"bs58@npm:^4.0.0, bs58@npm:^4.0.1":
   version: 4.0.1
   resolution: "bs58@npm:4.0.1"
   dependencies:
@@ -14160,6 +14260,16 @@ __metadata:
   languageName: node
   linkType: hard
 
+"buffer@npm:6.0.3, buffer@npm:^6.0.3, buffer@npm:~6.0.3":
+  version: 6.0.3
+  resolution: "buffer@npm:6.0.3"
+  dependencies:
+    base64-js: ^1.3.1
+    ieee754: ^1.2.1
+  checksum: 5ad23293d9a731e4318e420025800b42bf0d264004c0286c8cc010af7a270c7a0f6522e84f54b9ad65cbd6db20b8badbfd8d2ebf4f80fa03dab093b89e68c3f9
+  languageName: node
+  linkType: hard
+
 "buffer@npm:^4.3.0":
   version: 4.9.2
   resolution: "buffer@npm:4.9.2"
@@ -14181,13 +14291,13 @@ __metadata:
   languageName: node
   linkType: hard
 
-"buffer@npm:^6.0.3":
-  version: 6.0.3
-  resolution: "buffer@npm:6.0.3"
+"bufferutil@npm:^4.0.1":
+  version: 4.0.7
+  resolution: "bufferutil@npm:4.0.7"
   dependencies:
-    base64-js: ^1.3.1
-    ieee754: ^1.2.1
-  checksum: 5ad23293d9a731e4318e420025800b42bf0d264004c0286c8cc010af7a270c7a0f6522e84f54b9ad65cbd6db20b8badbfd8d2ebf4f80fa03dab093b89e68c3f9
+    node-gyp: latest
+    node-gyp-build: ^4.3.0
+  checksum: f75aa87e3d1b99b87a95f60a855e63f70af07b57fb8443e75a2ddfef2e47788d130fdd46e3a78fd7e0c10176082b26dfbed970c5b8632e1cc299cafa0e93ce45
   languageName: node
   linkType: hard
 
@@ -15193,7 +15303,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"commander@npm:^2.19.0, commander@npm:^2.20.0":
+"commander@npm:^2.19.0, commander@npm:^2.20.0, commander@npm:^2.20.3":
   version: 2.20.3
   resolution: "commander@npm:2.20.3"
   checksum: ab8c07884e42c3a8dbc5dd9592c606176c7eb5c1ca5ff274bcf907039b2c41de3626f684ea75ccf4d361ba004bbaff1f577d5384c155f3871e456bdf27becf9e
@@ -16650,6 +16760,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"delay@npm:^5.0.0":
+  version: 5.0.0
+  resolution: "delay@npm:5.0.0"
+  checksum: 62f151151ecfde0d9afbb8a6be37a6d103c4cb24f35a20ef3fe56f920b0d0d0bb02bc9c0a3084d0179ef669ca332b91155f2ee4d9854622cd2cdba5fc95285f9
+  languageName: node
+  linkType: hard
+
 "delayed-stream@npm:~1.0.0":
   version: 1.0.0
   resolution: "delayed-stream@npm:1.0.0"
@@ -17771,10 +17888,19 @@ __metadata:
   languageName: node
   linkType: hard
 
-"es6-promise@npm:^4.2.4":
+"es6-promise@npm:^4.0.3, es6-promise@npm:^4.2.4":
   version: 4.2.8
   resolution: "es6-promise@npm:4.2.8"
   checksum: 95614a88873611cb9165a85d36afa7268af5c03a378b35ca7bda9508e1d4f1f6f19a788d4bc755b3fd37c8ebba40782018e02034564ff24c9d6fa37e959ad57d
+  languageName: node
+  linkType: hard
+
+"es6-promisify@npm:^5.0.0":
+  version: 5.0.0
+  resolution: "es6-promisify@npm:5.0.0"
+  dependencies:
+    es6-promise: ^4.0.3
+  checksum: fbed9d791598831413be84a5374eca8c24800ec71a16c1c528c43a98e2dadfb99331483d83ae6094ddb9b87e6f799a15d1553cebf756047e0865c753bc346b92
   languageName: node
   linkType: hard
 
@@ -18748,7 +18874,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"eventemitter3@npm:^4.0.0, eventemitter3@npm:^4.0.1, eventemitter3@npm:^4.0.4":
+"eventemitter3@npm:^4.0.0, eventemitter3@npm:^4.0.1, eventemitter3@npm:^4.0.4, eventemitter3@npm:^4.0.7":
   version: 4.0.7
   resolution: "eventemitter3@npm:4.0.7"
   checksum: 1875311c42fcfe9c707b2712c32664a245629b42bb0a5a84439762dd0fd637fc54d078155ea83c2af9e0323c9ac13687e03cfba79b03af9f40c89b4960099374
@@ -19328,6 +19454,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"eyes@npm:^0.1.8":
+  version: 0.1.8
+  resolution: "eyes@npm:0.1.8"
+  checksum: c31703a92bf36ba75ee8d379ee7985c24ee6149f3a6175f44cec7a05b178c38bce9836d3ca48c9acb0329a960ac2c4b2ead4e60cdd4fe6e8c92cad7cd6913687
+  languageName: node
+  linkType: hard
+
 "fake-indexeddb@npm:^4.0.1":
   version: 4.0.1
   resolution: "fake-indexeddb@npm:4.0.1"
@@ -19430,6 +19563,13 @@ __metadata:
   version: 1.0.0
   resolution: "fast-shallow-equal@npm:1.0.0"
   checksum: ae89318ce43c0c46410d9511ac31520d59cfe675bad3d0b1cb5f900b2d635943d788b8370437178e91ae0d0412decc394229c03e69925ade929a8c02da241610
+  languageName: node
+  linkType: hard
+
+"fast-stable-stringify@npm:^1.0.0":
+  version: 1.0.0
+  resolution: "fast-stable-stringify@npm:1.0.0"
+  checksum: ef1203d246a7e8ac15e2bfbda0a89fa375947bccf9f7910be0ea759856dbe8ea5024a0d8cc2cceabe18a9cb67e95927b78bb6173a3ae37ec55a518cf36e5244b
   languageName: node
   linkType: hard
 
@@ -22851,6 +22991,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"isomorphic-ws@npm:^4.0.1":
+  version: 4.0.1
+  resolution: "isomorphic-ws@npm:4.0.1"
+  peerDependencies:
+    ws: "*"
+  checksum: d7190eadefdc28bdb93d67b5f0c603385aaf87724fa2974abb382ac1ec9756ed2cfb27065cbe76122879c2d452e2982bc4314317f3d6c737ddda6c047328771a
+  languageName: node
+  linkType: hard
+
 "isstream@npm:~0.1.2":
   version: 0.1.2
   resolution: "isstream@npm:0.1.2"
@@ -22980,6 +23129,28 @@ __metadata:
   version: 4.5.0
   resolution: "jasmine-core@npm:4.5.0"
   checksum: e7adda527d544097ddb8aeec7bbbed19c59ca70ef57e1b740189eecf5cde3e0e20fba74d15c511b169105cface4fa2a775a6088c2220bf97f482b51b3c5d1fa1
+  languageName: node
+  linkType: hard
+
+"jayson@npm:^4.1.0":
+  version: 4.1.0
+  resolution: "jayson@npm:4.1.0"
+  dependencies:
+    "@types/connect": ^3.4.33
+    "@types/node": ^12.12.54
+    "@types/ws": ^7.4.4
+    JSONStream: ^1.3.5
+    commander: ^2.20.3
+    delay: ^5.0.0
+    es6-promisify: ^5.0.0
+    eyes: ^0.1.8
+    isomorphic-ws: ^4.0.1
+    json-stringify-safe: ^5.0.1
+    uuid: ^8.3.2
+    ws: ^7.4.5
+  bin:
+    jayson: bin/jayson.js
+  checksum: 86464322fbdc6db65d2bb4fc278cb6c86fad5c2a506065490d39459f09ba0d30f2b4fb740b33828a1424791419b6c8bd295dc54d361a4ad959bf70cc62b1ca7e
   languageName: node
   linkType: hard
 
@@ -24571,6 +24742,13 @@ __metadata:
   version: 0.0.1
   resolution: "jsonify@npm:0.0.1"
   checksum: 027287e1c0294fce15f18c0ff990cfc2318e7f01fb76515f784d5cd0784abfec6fc5c2355c3a2f2cb0ad7f4aa2f5b74ebbfe4e80476c35b2d13cabdb572e1134
+  languageName: node
+  linkType: hard
+
+"jsonparse@npm:^1.2.0":
+  version: 1.3.1
+  resolution: "jsonparse@npm:1.3.1"
+  checksum: 6514a7be4674ebf407afca0eda3ba284b69b07f9958a8d3113ef1005f7ec610860c312be067e450c569aab8b89635e332cee3696789c750692bb60daba627f4d
   languageName: node
   linkType: hard
 
@@ -27435,7 +27613,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"node-fetch@npm:^2.0.0, node-fetch@npm:^2.2.0, node-fetch@npm:^2.6.0, node-fetch@npm:^2.6.1, node-fetch@npm:^2.6.11, node-fetch@npm:^2.6.7":
+"node-fetch@npm:^2.0.0, node-fetch@npm:^2.2.0, node-fetch@npm:^2.6.0, node-fetch@npm:^2.6.1, node-fetch@npm:^2.6.11, node-fetch@npm:^2.6.12, node-fetch@npm:^2.6.7":
   version: 2.6.12
   resolution: "node-fetch@npm:2.6.12"
   dependencies:
@@ -31347,6 +31525,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"regenerator-runtime@npm:^0.14.0":
+  version: 0.14.0
+  resolution: "regenerator-runtime@npm:0.14.0"
+  checksum: 1c977ad82a82a4412e4f639d65d22be376d3ebdd30da2c003eeafdaaacd03fc00c2320f18120007ee700900979284fc78a9f00da7fb593f6e6eeebc673fba9a3
+  languageName: node
+  linkType: hard
+
 "regenerator-transform@npm:^0.15.1":
   version: 0.15.1
   resolution: "regenerator-transform@npm:0.15.1"
@@ -31994,6 +32179,25 @@ __metadata:
     semver-compare: ^1.0.0
     sprintf-js: ^1.1.2
   checksum: 682e28d5491e3ae99728a35ba188f4f0ccb6347dbd492f95dc9f4bfdfe8ee63d8203ad234766ee2db88c8d7a300714304976eb095ce5c9366fe586c03a21586c
+  languageName: node
+  linkType: hard
+
+"rpc-websockets@npm:^7.5.1":
+  version: 7.6.0
+  resolution: "rpc-websockets@npm:7.6.0"
+  dependencies:
+    "@babel/runtime": ^7.17.2
+    bufferutil: ^4.0.1
+    eventemitter3: ^4.0.7
+    utf-8-validate: ^5.0.2
+    uuid: ^8.3.2
+    ws: ^8.5.0
+  dependenciesMeta:
+    bufferutil:
+      optional: true
+    utf-8-validate:
+      optional: true
+  checksum: af2b254f65985610bd354e8e13de07b5a36010b94672b0b5a9d226b9bb1b8b17d01c63221cad97263845888f3610e55867a32e4c0017dfb92fddf89417c4cb6c
   languageName: node
   linkType: hard
 
@@ -33982,6 +34186,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"superstruct@npm:^0.14.2":
+  version: 0.14.2
+  resolution: "superstruct@npm:0.14.2"
+  checksum: c5c4840f432da82125b923ec45faca5113217e83ae416e314d80eae012b8bb603d2e745025d173450758d116348820bc7028157f8c9a72b6beae879f94b837c0
+  languageName: node
+  linkType: hard
+
 "supports-color@npm:^2.0.0":
   version: 2.0.0
   resolution: "supports-color@npm:2.0.0"
@@ -34398,6 +34609,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"text-encoding-utf-8@npm:^1.0.2":
+  version: 1.0.2
+  resolution: "text-encoding-utf-8@npm:1.0.2"
+  checksum: ec4c15d50e738c5dba7327ad432ebf0725ec75d4d69c0bd55609254c5a3bc5341272d7003691084a0a73d60d981c8eb0e87603676fdb6f3fed60f4c9192309f9
+  languageName: node
+  linkType: hard
+
 "text-table@npm:^0.2.0":
   version: 0.2.0
   resolution: "text-table@npm:0.2.0"
@@ -34454,7 +34672,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"through@npm:2, through@npm:^2.3.4, through@npm:^2.3.6, through@npm:^2.3.8, through@npm:~2.3.4":
+"through@npm:2, through@npm:>=2.2.7 <3, through@npm:^2.3.4, through@npm:^2.3.6, through@npm:^2.3.8, through@npm:~2.3.4":
   version: 2.3.8
   resolution: "through@npm:2.3.8"
   checksum: a38c3e059853c494af95d50c072b83f8b676a9ba2818dcc5b108ef252230735c54e0185437618596c790bbba8fcdaef5b290405981ffa09dce67b1f1bf190cbd
@@ -35850,6 +36068,16 @@ __metadata:
   languageName: node
   linkType: hard
 
+"utf-8-validate@npm:^5.0.2":
+  version: 5.0.10
+  resolution: "utf-8-validate@npm:5.0.10"
+  dependencies:
+    node-gyp: latest
+    node-gyp-build: ^4.3.0
+  checksum: 5579350a023c66a2326752b6c8804cc7b39dcd251bb088241da38db994b8d78352e388dcc24ad398ab98385ba3c5ffcadb6b5b14b2637e43f767869055e46ba6
+  languageName: node
+  linkType: hard
+
 "utf8-byte-length@npm:^1.0.1":
   version: 1.0.4
   resolution: "utf8-byte-length@npm:1.0.4"
@@ -37050,7 +37278,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"ws@npm:7.5.9, ws@npm:^7, ws@npm:^7.2.0, ws@npm:^7.3.1, ws@npm:^7.4.6, ws@npm:^7.5.1, ws@npm:^7.5.3":
+"ws@npm:7.5.9, ws@npm:^7, ws@npm:^7.2.0, ws@npm:^7.3.1, ws@npm:^7.4.5, ws@npm:^7.4.6, ws@npm:^7.5.1, ws@npm:^7.5.3":
   version: 7.5.9
   resolution: "ws@npm:7.5.9"
   peerDependencies:
@@ -37074,7 +37302,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"ws@npm:^8.11.0, ws@npm:^8.13.0, ws@npm:^8.2.3":
+"ws@npm:^8.11.0, ws@npm:^8.13.0, ws@npm:^8.2.3, ws@npm:^8.5.0":
   version: 8.13.0
   resolution: "ws@npm:8.13.0"
   peerDependencies:


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Notes

- first 5 commits are from previous PRs, so pls ignore
- It works with [this branch](https://github.com/vacuumlabs/trezor-firmware/tree/solana-poc) in the Vacuumlabs’ Trezor firmware fork

## Description

This PR tries to achieve the following
 - add minimal implementation of solana backend so we can remove mock for account info and work with real data
 - demonstrate how the backend will look, from now on we expect only to add new methods/tests as we implement more UI features such as tx history or tx sending
 