### PR TITLE
Recognize connected device in XPUB/address modal

### DIFF
--- a/packages/suite/src/actions/suite/modalActions.ts
+++ b/packages/suite/src/actions/suite/modalActions.ts
@@ -25,9 +25,7 @@ export type UserContextPayload =
           value: string;
           addressPath: string;
           symbol: NetworkSymbol;
-          networkType: Account['networkType'];
           isConfirmed?: boolean;
-          isCancelable?: boolean;
       }
     | {
           type: 'xpub';
@@ -36,7 +34,6 @@ export type UserContextPayload =
           symbol: NetworkSymbol;
           accountLabel: AccountLabels['accountLabel'];
           isConfirmed?: boolean;
-          isCancelable?: boolean;
       }
     | {
           type: 'passphrase-duplicate';

--- a/packages/suite/src/actions/suite/modalActions.ts
+++ b/packages/suite/src/actions/suite/modalActions.ts
@@ -22,7 +22,6 @@ export type UserContextPayload =
       }
     | {
           type: 'address';
-          device: TrezorDevice;
           value: string;
           addressPath: string;
           symbol: NetworkSymbol;
@@ -32,7 +31,6 @@ export type UserContextPayload =
       }
     | {
           type: 'xpub';
-          device: TrezorDevice;
           value: string;
           accountIndex: number;
           symbol: NetworkSymbol;

--- a/packages/suite/src/actions/suite/modalActions.ts
+++ b/packages/suite/src/actions/suite/modalActions.ts
@@ -2,8 +2,7 @@ import TrezorConnect, { UI } from '@trezor/connect';
 import { createDeferred, Deferred, DeferredResponse } from '@trezor/utils';
 import { MODAL, SUITE } from 'src/actions/suite/constants';
 import { Route, Dispatch, GetState, TrezorDevice } from 'src/types/suite';
-import { AccountLabels } from 'src/types/suite/metadata';
-import { Account, NetworkSymbol, WalletAccountTransaction } from 'src/types/wallet';
+import { Account, WalletAccountTransaction } from 'src/types/wallet';
 import { RequestEnableTorResponse } from 'src/components/suite/modals/RequestEnableTor';
 
 export type UserContextPayload =
@@ -28,10 +27,6 @@ export type UserContextPayload =
       }
     | {
           type: 'xpub';
-          value: string;
-          accountIndex: number;
-          symbol: NetworkSymbol;
-          accountLabel: AccountLabels['accountLabel'];
           isConfirmed?: boolean;
       }
     | {

--- a/packages/suite/src/actions/suite/modalActions.ts
+++ b/packages/suite/src/actions/suite/modalActions.ts
@@ -24,7 +24,6 @@ export type UserContextPayload =
           type: 'address';
           value: string;
           addressPath: string;
-          symbol: NetworkSymbol;
           isConfirmed?: boolean;
       }
     | {

--- a/packages/suite/src/actions/wallet/__fixtures__/publicKeyActions.ts
+++ b/packages/suite/src/actions/wallet/__fixtures__/publicKeyActions.ts
@@ -20,22 +20,6 @@ export default [
         },
     },
     {
-        description: 'Show unverified public key, device is undefined',
-        initialState: {
-            suite: {
-                device: undefined,
-            },
-        },
-        mocks: {},
-        action: () => publicKeyActions.openXpubModal(),
-        result: {
-            actions: [
-                { type: connectInitThunk.pending.type, payload: undefined },
-                { type: connectInitThunk.fulfilled.type, payload: undefined },
-            ],
-        },
-    },
-    {
         description: 'Show public key success (bitcoin)',
         initialState: undefined,
         mocks: {},

--- a/packages/suite/src/actions/wallet/__fixtures__/receiveActions.ts
+++ b/packages/suite/src/actions/wallet/__fixtures__/receiveActions.ts
@@ -9,8 +9,6 @@ const { getSuiteDevice } = global.JestMocks;
 const PATH = "m/49'/0'/0'/0/0";
 const ADDRESS = 'AddRe5s';
 
-const UNAVAILABLE_DEVICE = getSuiteDevice({ available: false });
-
 export default [
     {
         description: 'Show unverified address',
@@ -27,23 +25,6 @@ export default [
                     path: PATH,
                     address: ADDRESS,
                 },
-            ],
-        },
-    },
-    {
-        description: 'Show unverified address, device is undefined',
-        initialState: {
-            suite: {
-                device: undefined,
-                settings: { debug: {} },
-            },
-        },
-        mocks: {},
-        action: () => receiveActions.showUnverifiedAddress(PATH, ADDRESS),
-        result: {
-            actions: [
-                { type: connectInitThunk.pending.type, payload: undefined },
-                { type: connectInitThunk.fulfilled.type, payload: undefined },
             ],
         },
     },
@@ -179,25 +160,8 @@ export default [
                 { type: connectInitThunk.fulfilled.type, payload: undefined },
                 {
                     type: MODAL.OPEN_USER_CONTEXT,
-                    payload: { device: UNAVAILABLE_DEVICE, addressPath: PATH },
+                    payload: { addressPath: PATH, value: ADDRESS },
                 },
-            ],
-        },
-    },
-    {
-        description: 'Show address, device is undefined',
-        initialState: {
-            suite: {
-                settings: { debug: {} },
-                device: undefined,
-            },
-        },
-        mocks: {},
-        action: () => receiveActions.showAddress(PATH, ADDRESS),
-        result: {
-            actions: [
-                { type: connectInitThunk.pending.type, payload: undefined },
-                { type: connectInitThunk.fulfilled.type, payload: undefined },
             ],
         },
     },

--- a/packages/suite/src/actions/wallet/__fixtures__/receiveActions.ts
+++ b/packages/suite/src/actions/wallet/__fixtures__/receiveActions.ts
@@ -14,7 +14,7 @@ export default [
         description: 'Show unverified address',
         initialState: undefined,
         mocks: {},
-        action: () => receiveActions.showUnverifiedAddress(PATH, ADDRESS),
+        action: () => receiveActions.openAddressModal({ addressPath: PATH, value: ADDRESS }),
         result: {
             actions: [
                 { type: connectInitThunk.pending.type, payload: undefined },

--- a/packages/suite/src/actions/wallet/__tests__/receiveActions.test.ts
+++ b/packages/suite/src/actions/wallet/__tests__/receiveActions.test.ts
@@ -165,17 +165,17 @@ describe('ReceiveActions', () => {
         const VERIFIED = [{ path: 'a', address: 'b', isVerified: true }];
         const UNVERIFIED = [{ path: 'a', address: 'b', isVerified: false }];
 
-        await store.dispatch(receiveActions.showUnverifiedAddress('a', 'b'));
+        await store.dispatch(receiveActions.openAddressModal({ addressPath: 'a', value: 'b' }));
         expect(store.getState().wallet.receive).toEqual(UNVERIFIED);
 
         await store.dispatch(receiveActions.showAddress('a', 'b'));
         expect(store.getState().wallet.receive).toEqual(VERIFIED);
 
-        await store.dispatch(receiveActions.showUnverifiedAddress('a', 'b'));
+        await store.dispatch(receiveActions.openAddressModal({ addressPath: 'a', value: 'b' }));
         expect(store.getState().wallet.receive).toEqual(UNVERIFIED);
 
         // add second
-        await store.dispatch(receiveActions.showUnverifiedAddress('c', 'd'));
+        await store.dispatch(receiveActions.openAddressModal({ addressPath: 'c', value: 'd' }));
         expect(store.getState().wallet.receive.length).toEqual(2);
 
         // clear

--- a/packages/suite/src/actions/wallet/coinmarket/coinmarketCommonActions.ts
+++ b/packages/suite/src/actions/wallet/coinmarket/coinmarketCommonActions.ts
@@ -70,23 +70,15 @@ export const verifyAddress =
         path = path ?? accountAddress.path;
         if (!path || !address) return;
 
-        const { networkType, symbol } = account;
         const { useEmptyPassphrase, connected, available } = device;
-
-        const modalPayload = {
-            device,
-            value: address,
-            networkType,
-            symbol,
-            addressPath: path,
-        };
 
         // Show warning when device is not connected
         if (!connected || !available) {
             dispatch(
                 modalActions.openModal({
                     type: 'unverified-address',
-                    ...modalPayload,
+                    value: address,
+                    addressPath: path,
                 }),
             );
             return;

--- a/packages/suite/src/actions/wallet/publicKeyActions.ts
+++ b/packages/suite/src/actions/wallet/publicKeyActions.ts
@@ -7,15 +7,13 @@ import { selectLabelingDataForSelectedAccount } from 'src/reducers/suite/metadat
 export const openXpubModal =
     (params?: Pick<Extract<modalActions.UserContextPayload, { type: 'xpub' }>, 'isConfirmed'>) =>
     (dispatch: Dispatch, getState: GetState) => {
-        const { device } = getState().suite;
         const { account } = getState().wallet.selectedAccount;
         const { accountLabel } = selectLabelingDataForSelectedAccount(getState());
-        if (!device || !account) return;
+        if (!account) return;
 
         dispatch(
             modalActions.openModal({
                 type: 'xpub',
-                device,
                 value: account.descriptor,
                 accountIndex: account.index,
                 symbol: account.symbol,

--- a/packages/suite/src/actions/wallet/publicKeyActions.ts
+++ b/packages/suite/src/actions/wallet/publicKeyActions.ts
@@ -1,26 +1,12 @@
-import * as modalActions from 'src/actions/suite/modalActions';
+import { onCancel, openModal, preserve, UserContextPayload } from 'src/actions/suite/modalActions';
 import { notificationsActions } from '@suite-common/toast-notifications';
 import { GetState, Dispatch } from 'src/types/suite';
 import TrezorConnect, { Success, Unsuccessful } from '@trezor/connect';
-import { selectLabelingDataForSelectedAccount } from 'src/reducers/suite/metadataReducer';
 
 export const openXpubModal =
-    (params?: Pick<Extract<modalActions.UserContextPayload, { type: 'xpub' }>, 'isConfirmed'>) =>
-    (dispatch: Dispatch, getState: GetState) => {
-        const { account } = getState().wallet.selectedAccount;
-        const { accountLabel } = selectLabelingDataForSelectedAccount(getState());
-        if (!account) return;
-
-        dispatch(
-            modalActions.openModal({
-                type: 'xpub',
-                value: account.descriptor,
-                accountIndex: account.index,
-                symbol: account.symbol,
-                accountLabel,
-                ...params,
-            }),
-        );
+    (params?: Pick<Extract<UserContextPayload, { type: 'xpub' }>, 'isConfirmed'>) =>
+    (dispatch: Dispatch) => {
+        dispatch(openModal({ type: 'xpub', ...params }));
     };
 
 export const showXpub = () => async (dispatch: Dispatch, getState: GetState) => {
@@ -31,16 +17,12 @@ export const showXpub = () => async (dispatch: Dispatch, getState: GetState) => 
 
     // Show warning when device is not connected.
     if (!device.connected || !device.available) {
-        dispatch(
-            modalActions.openModal({
-                type: 'unverified-xpub',
-            }),
-        );
+        dispatch(openModal({ type: 'unverified-xpub' }));
         return;
     }
 
     // Prevent flickering screen when modal changes.
-    dispatch(modalActions.preserve());
+    dispatch(preserve());
 
     const params = {
         device,
@@ -68,7 +50,7 @@ export const showXpub = () => async (dispatch: Dispatch, getState: GetState) => 
         // Show second part of the "confirm XPUB" modal.
         dispatch(openXpubModal({ isConfirmed: true }));
     } else {
-        dispatch(modalActions.onCancel());
+        dispatch(onCancel());
         // Special case: closing no-backup warning modal should not show a toast.
         if (response.payload.code === 'Method_PermissionsNotGranted') return;
         dispatch(

--- a/packages/suite/src/actions/wallet/receiveActions.ts
+++ b/packages/suite/src/actions/wallet/receiveActions.ts
@@ -23,13 +23,12 @@ export const dispose = (): ReceiveAction => ({
 
 export const showUnverifiedAddress =
     (path: string, address: string) => (dispatch: Dispatch, getState: GetState) => {
-        const { device } = getState().suite;
         const { account } = getState().wallet.selectedAccount;
-        if (!device || !account) return;
+        if (!account) return;
+
         dispatch(
             modalActions.openModal({
                 type: 'address',
-                device,
                 value: address,
                 addressPath: path,
                 networkType: account.networkType,
@@ -51,7 +50,6 @@ export const showAddress =
         if (!device || !account) return;
 
         const modalPayload = {
-            device,
             value: address,
             addressPath: path,
             networkType: account.networkType,

--- a/packages/suite/src/actions/wallet/receiveActions.ts
+++ b/packages/suite/src/actions/wallet/receiveActions.ts
@@ -31,9 +31,7 @@ export const showUnverifiedAddress =
                 type: 'address',
                 value: address,
                 addressPath: path,
-                networkType: account.networkType,
                 symbol: account.symbol,
-                isCancelable: true,
             }),
         );
         dispatch({
@@ -52,8 +50,6 @@ export const showAddress =
         const modalPayload = {
             value: address,
             addressPath: path,
-            networkType: account.networkType,
-            symbol: account.symbol,
         };
 
         // Show warning when device is not connected
@@ -116,8 +112,8 @@ export const showAddress =
                 modalActions.openModal({
                     type: 'address',
                     ...modalPayload,
+                    symbol: account.symbol,
                     isConfirmed: true,
-                    isCancelable: true,
                 }),
             );
             dispatch({

--- a/packages/suite/src/actions/wallet/receiveActions.ts
+++ b/packages/suite/src/actions/wallet/receiveActions.ts
@@ -28,14 +28,10 @@ export const openAddressModal =
             'addressPath' | 'value' | 'isConfirmed'
         >,
     ) =>
-    (dispatch: Dispatch, getState: GetState) => {
-        const { account } = getState().wallet.selectedAccount;
-        if (!account) return;
-
+    (dispatch: Dispatch) => {
         dispatch(
             modalActions.openModal({
                 type: 'address',
-                symbol: account.symbol,
                 ...params,
             }),
         );

--- a/packages/suite/src/actions/wallet/receiveActions.ts
+++ b/packages/suite/src/actions/wallet/receiveActions.ts
@@ -21,23 +21,28 @@ export const dispose = (): ReceiveAction => ({
     type: RECEIVE.DISPOSE,
 });
 
-export const showUnverifiedAddress =
-    (path: string, address: string) => (dispatch: Dispatch, getState: GetState) => {
+export const openAddressModal =
+    (
+        params: Pick<
+            Extract<modalActions.UserContextPayload, { type: 'address' }>,
+            'addressPath' | 'value' | 'isConfirmed'
+        >,
+    ) =>
+    (dispatch: Dispatch, getState: GetState) => {
         const { account } = getState().wallet.selectedAccount;
         if (!account) return;
 
         dispatch(
             modalActions.openModal({
                 type: 'address',
-                value: address,
-                addressPath: path,
                 symbol: account.symbol,
+                ...params,
             }),
         );
         dispatch({
-            type: RECEIVE.SHOW_UNVERIFIED_ADDRESS,
-            path,
-            address,
+            type: params.isConfirmed ? RECEIVE.SHOW_ADDRESS : RECEIVE.SHOW_UNVERIFIED_ADDRESS,
+            path: params.addressPath,
+            address: params.value,
         });
     };
 
@@ -108,19 +113,7 @@ export const showAddress =
 
         if (response.success) {
             // show second part of the "confirm address" modal
-            dispatch(
-                modalActions.openModal({
-                    type: 'address',
-                    ...modalPayload,
-                    symbol: account.symbol,
-                    isConfirmed: true,
-                }),
-            );
-            dispatch({
-                type: RECEIVE.SHOW_ADDRESS,
-                path,
-                address,
-            });
+            dispatch(openAddressModal({ ...modalPayload, isConfirmed: true }));
         } else {
             dispatch(modalActions.onCancel());
             // special case: device no-backup permissions not granted

--- a/packages/suite/src/components/suite/ModalSwitcher/DeviceContextModal.tsx
+++ b/packages/suite/src/components/suite/ModalSwitcher/DeviceContextModal.tsx
@@ -19,9 +19,6 @@ import {
     ConfirmAddress,
     ConfirmXpub,
 } from 'src/components/suite/modals';
-import { selectSelectedAccount } from 'src/reducers/wallet/selectedAccountReducer';
-import { selectLabelingDataForSelectedAccount } from 'src/reducers/suite/metadataReducer';
-
 import type { ReduxModalProps } from './types';
 
 /** Modals requested by Device from `trezor-connect` */
@@ -31,8 +28,6 @@ export const DeviceContextModal = ({
     data,
 }: ReduxModalProps<typeof MODAL.CONTEXT_DEVICE>) => {
     const device = useSelector(state => state.suite.device);
-    const account = useSelector(selectSelectedAccount);
-    const { accountLabel } = useSelector(selectLabelingDataForSelectedAccount);
     const intl = useIntl();
 
     if (!device) return null;
@@ -89,7 +84,7 @@ export const DeviceContextModal = ({
         case 'ButtonRequest_PinEntry':
             return <ConfirmActionModal device={device} renderer={renderer} />;
         case 'ButtonRequest_Address':
-            return account && data?.address ? (
+            return data ? (
                 <ConfirmAddress
                     value={data.address}
                     addressPath={data.serializedPath}
@@ -97,15 +92,7 @@ export const DeviceContextModal = ({
                 />
             ) : null;
         case 'ButtonRequest_PublicKey':
-            return account ? (
-                <ConfirmXpub
-                    value={account.descriptor}
-                    symbol={account.symbol}
-                    accountIndex={account.index}
-                    accountLabel={accountLabel}
-                    onCancel={abort}
-                />
-            ) : null;
+            return <ConfirmXpub onCancel={abort} />;
         default:
             return null;
     }

--- a/packages/suite/src/components/suite/ModalSwitcher/DeviceContextModal.tsx
+++ b/packages/suite/src/components/suite/ModalSwitcher/DeviceContextModal.tsx
@@ -91,8 +91,8 @@ export const DeviceContextModal = ({
         case 'ButtonRequest_Address':
             return account && data?.address ? (
                 <ConfirmAddress
-                    device={device}
                     value={data.address}
+                    addressPath={data.serializedPath}
                     symbol={account.symbol}
                     onCancel={abort}
                 />
@@ -100,7 +100,6 @@ export const DeviceContextModal = ({
         case 'ButtonRequest_PublicKey':
             return account ? (
                 <ConfirmXpub
-                    device={device}
                     value={account.descriptor}
                     symbol={account.symbol}
                     accountIndex={account.index}

--- a/packages/suite/src/components/suite/ModalSwitcher/DeviceContextModal.tsx
+++ b/packages/suite/src/components/suite/ModalSwitcher/DeviceContextModal.tsx
@@ -93,7 +93,6 @@ export const DeviceContextModal = ({
                 <ConfirmAddress
                     value={data.address}
                     addressPath={data.serializedPath}
-                    symbol={account.symbol}
                     onCancel={abort}
                 />
             ) : null;

--- a/packages/suite/src/components/suite/ModalSwitcher/UserContextModal.tsx
+++ b/packages/suite/src/components/suite/ModalSwitcher/UserContextModal.tsx
@@ -35,7 +35,7 @@ import { DisableTorStopCoinjoin } from 'src/components/suite/modals/DisableTorSt
 import { UnecoCoinjoinWarning } from 'src/components/suite/modals/UnecoCoinjoinWarning';
 import type { AcquiredDevice } from 'src/types/suite';
 import { openXpubModal, showXpub } from 'src/actions/wallet/publicKeyActions';
-import { showAddress, showUnverifiedAddress } from 'src/actions/wallet/receiveActions';
+import { showAddress, openAddressModal } from 'src/actions/wallet/receiveActions';
 import type { ReduxModalProps } from './types';
 
 /** Modals opened as a result of user action */
@@ -83,7 +83,7 @@ export const UserContextModal = ({
                     showUnverifiedButtonText="TR_SHOW_UNVERIFIED_XPUB"
                     warningText="TR_XPUB_PHISHING_WARNING"
                     verify={showXpub}
-                    showUnverified={() => openXpubModal()}
+                    showUnverified={openXpubModal}
                     onCancel={onCancel}
                 />
             );

--- a/packages/suite/src/components/suite/ModalSwitcher/UserContextModal.tsx
+++ b/packages/suite/src/components/suite/ModalSwitcher/UserContextModal.tsx
@@ -1,6 +1,6 @@
-import React from 'react';
+import React, { useCallback } from 'react';
 
-import { onCancel as onCancelAction } from 'src/actions/suite/modalActions';
+import { onCancel as onCancelAction, UserContextPayload } from 'src/actions/suite/modalActions';
 import { MODAL } from 'src/actions/suite/constants';
 import { useDispatch } from 'src/hooks/suite';
 import {
@@ -45,6 +45,14 @@ export const UserContextModal = ({
 }: ReduxModalProps<typeof MODAL.CONTEXT_USER>) => {
     const dispatch = useDispatch();
 
+    const verifyAddress = useCallback(() => {
+        const { addressPath, value } = payload as Extract<
+            UserContextPayload,
+            { type: 'unverified-address' }
+        >;
+        return showAddress(addressPath, value);
+    }, [payload]);
+
     const onCancel = () => dispatch(onCancelAction());
 
     switch (payload.type) {
@@ -62,8 +70,10 @@ export const UserContextModal = ({
                 <ConfirmUnverified
                     showUnverifiedButtonText="TR_SHOW_UNVERIFIED_ADDRESS"
                     warningText="TR_ADDRESS_PHISHING_WARNING"
-                    verify={() => showAddress(payload.addressPath, payload.value)}
-                    showUnverified={() => showUnverifiedAddress(payload.addressPath, payload.value)}
+                    verify={verifyAddress}
+                    showUnverified={() =>
+                        openAddressModal({ addressPath: payload.addressPath, value: payload.value })
+                    }
                     onCancel={onCancel}
                 />
             );

--- a/packages/suite/src/components/suite/modals/confirm/ConfirmAddress.tsx
+++ b/packages/suite/src/components/suite/modals/confirm/ConfirmAddress.tsx
@@ -2,13 +2,13 @@ import React, { useCallback } from 'react';
 
 import { showAddress } from 'src/actions/wallet/receiveActions';
 import { Translation } from 'src/components/suite';
-import { NetworkSymbol } from 'src/types/wallet';
+import { useSelector } from 'src/hooks/suite';
+import { selectSelectedAccount } from 'src/reducers/wallet/selectedAccountReducer';
 import { ConfirmValueOnDevice, ConfirmDeviceScreenProps } from './ConfirmValueOnDevice';
 
 interface ConfirmAddressProps
     extends Pick<ConfirmDeviceScreenProps, 'isConfirmed' | 'onCancel' | 'value'> {
     addressPath: string;
-    symbol: NetworkSymbol;
 }
 
 export const ConfirmAddress = ({ addressPath, value, ...props }: ConfirmAddressProps) => {

--- a/packages/suite/src/components/suite/modals/confirm/ConfirmAddress.tsx
+++ b/packages/suite/src/components/suite/modals/confirm/ConfirmAddress.tsx
@@ -1,25 +1,40 @@
-import React from 'react';
+import React, { useCallback } from 'react';
 
+import { showAddress } from 'src/actions/wallet/receiveActions';
 import { Translation } from 'src/components/suite';
 import { NetworkSymbol } from 'src/types/wallet';
 import { ConfirmValueOnDevice, ConfirmDeviceScreenProps } from './ConfirmValueOnDevice';
 
 interface ConfirmAddressProps
-    extends Pick<ConfirmDeviceScreenProps, 'device' | 'isConfirmed' | 'onCancel' | 'value'> {
+    extends Pick<ConfirmDeviceScreenProps, 'isConfirmed' | 'onCancel' | 'value'> {
+    addressPath: string;
     symbol: NetworkSymbol;
 }
 
-export const ConfirmAddress = ({ symbol, ...props }: ConfirmAddressProps) => (
-    <ConfirmValueOnDevice
-        heading={
-            <Translation
-                id="TR_ADDRESS_MODAL_TITLE"
-                values={{ networkName: symbol.toUpperCase() }}
-            />
-        }
-        copyButtonText={<Translation id="TR_ADDRESS_MODAL_CLIPBOARD" />}
-        copyButtonDataTest="@metadata/copy-address-button"
-        valueDataTest="@modal/confirm-address/address-field"
-        {...props}
-    />
-);
+export const ConfirmAddress = ({ addressPath, value, ...props }: ConfirmAddressProps) => {
+    const account = useSelector(selectSelectedAccount);
+
+    const validateAddress = useCallback(
+        () => showAddress(addressPath, value),
+        [addressPath, value],
+    );
+
+    if (!account) return null;
+
+    return (
+        <ConfirmValueOnDevice
+            heading={
+                <Translation
+                    id="TR_ADDRESS_MODAL_TITLE"
+                    values={{ networkName: account.symbol.toUpperCase() }}
+                />
+            }
+            copyButtonText={<Translation id="TR_ADDRESS_MODAL_CLIPBOARD" />}
+            validateOnDevice={validateAddress}
+            value={value}
+            copyButtonDataTest="@metadata/copy-address-button"
+            valueDataTest="@modal/confirm-address/address-field"
+            {...props}
+        />
+    );
+};

--- a/packages/suite/src/components/suite/modals/confirm/ConfirmXpub.tsx
+++ b/packages/suite/src/components/suite/modals/confirm/ConfirmXpub.tsx
@@ -2,35 +2,37 @@ import React from 'react';
 
 import { Translation } from 'src/components/suite';
 import { ConfirmValueOnDevice, ConfirmDeviceScreenProps } from './ConfirmValueOnDevice';
-import { NetworkSymbol } from 'src/types/wallet/index';
-import { AccountLabels } from 'src/types/suite/metadata';
 import { showXpub } from 'src/actions/wallet/publicKeyActions';
+import { selectSelectedAccount } from 'src/reducers/wallet/selectedAccountReducer';
+import { selectLabelingDataForSelectedAccount } from 'src/reducers/suite/metadataReducer';
+import { useSelector } from 'src/hooks/suite';
 
-interface ConfirmXpubProps
-    extends Pick<ConfirmDeviceScreenProps, 'isConfirmed' | 'onCancel' | 'value'> {
-    accountIndex: number;
-    symbol: NetworkSymbol;
-    accountLabel: AccountLabels['accountLabel'];
-}
+export const ConfirmXpub = (props: Pick<ConfirmDeviceScreenProps, 'isConfirmed' | 'onCancel'>) => {
+    const account = useSelector(selectSelectedAccount);
+    const { accountLabel } = useSelector(selectLabelingDataForSelectedAccount);
 
-export const ConfirmXpub = ({ accountIndex, symbol, accountLabel, ...props }: ConfirmXpubProps) => (
-    <ConfirmValueOnDevice
-        heading={
-            accountLabel ? (
-                <Translation id="TR_XPUB_MODAL_TITLE_METADATA" values={{ accountLabel }} />
-            ) : (
-                <Translation
-                    id="TR_XPUB_MODAL_TITLE"
-                    values={{
-                        networkName: symbol.toUpperCase(),
-                        accountIndex: `#${accountIndex + 1}`,
-                    }}
-                />
-            )
-        }
-        validateOnDevice={showXpub}
-        copyButtonText={<Translation id="TR_XPUB_MODAL_CLIPBOARD" />}
-        valueDataTest="@xpub-modal/xpub-field"
-        {...props}
-    />
-);
+    if (!account) return null;
+
+    return (
+        <ConfirmValueOnDevice
+            heading={
+                accountLabel ? (
+                    <Translation id="TR_XPUB_MODAL_TITLE_METADATA" values={{ accountLabel }} />
+                ) : (
+                    <Translation
+                        id="TR_XPUB_MODAL_TITLE"
+                        values={{
+                            networkName: account.symbol.toUpperCase(),
+                            accountIndex: `#${account.index + 1}`,
+                        }}
+                    />
+                )
+            }
+            validateOnDevice={showXpub}
+            copyButtonText={<Translation id="TR_XPUB_MODAL_CLIPBOARD" />}
+            value={account.descriptor}
+            valueDataTest="@xpub-modal/xpub-field"
+            {...props}
+        />
+    );
+};

--- a/packages/suite/src/components/suite/modals/confirm/ConfirmXpub.tsx
+++ b/packages/suite/src/components/suite/modals/confirm/ConfirmXpub.tsx
@@ -4,9 +4,10 @@ import { Translation } from 'src/components/suite';
 import { ConfirmValueOnDevice, ConfirmDeviceScreenProps } from './ConfirmValueOnDevice';
 import { NetworkSymbol } from 'src/types/wallet/index';
 import { AccountLabels } from 'src/types/suite/metadata';
+import { showXpub } from 'src/actions/wallet/publicKeyActions';
 
 interface ConfirmXpubProps
-    extends Pick<ConfirmDeviceScreenProps, 'device' | 'isConfirmed' | 'onCancel' | 'value'> {
+    extends Pick<ConfirmDeviceScreenProps, 'isConfirmed' | 'onCancel' | 'value'> {
     accountIndex: number;
     symbol: NetworkSymbol;
     accountLabel: AccountLabels['accountLabel'];
@@ -27,6 +28,7 @@ export const ConfirmXpub = ({ accountIndex, symbol, accountLabel, ...props }: Co
                 />
             )
         }
+        validateOnDevice={showXpub}
         copyButtonText={<Translation id="TR_XPUB_MODAL_CLIPBOARD" />}
         valueDataTest="@xpub-modal/xpub-field"
         {...props}

--- a/packages/suite/src/support/messages.ts
+++ b/packages/suite/src/support/messages.ts
@@ -6055,10 +6055,6 @@ export default defineMessages({
         defaultMessage:
             'Failed to sync labeling data with cloud provider {provider}. User was logged out.',
     },
-    TR_TRY_VERIFYING_ON_DEVICE_AGAIN: {
-        id: 'TR_TRY_VERIFYING_ON_DEVICE_AGAIN',
-        defaultMessage: 'Try again',
-    },
     TR_REVEAL_ADDRESS: {
         id: 'TR_REVEAL_ADDRESS',
         defaultMessage: 'Reveal address',


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

When you want to display XPUB or a receive address while the device is remembered and disconnected, you will see 1) warning modal and then 2) second modal with the requested information and another warning box.

Previously, only the first modal would react to a device connecting, and it required clicking the "Try again" button.

Now, when you connect the device while either modal is displayed, Suite reacts to it.

- I moved the `device` selector form the action to the component so that it is reactive.
- I removed some unit tests as they were not relevant anymore after this change.
- I moved other data from action to component, I find it cleaner.
- I refactored the receive and publicKey actions to work in the same way.
<!--- Describe your changes in detail -->

## Related Issue

Resolve #8637
