### PR TITLE
Chore/metadata refactoring 2

### DIFF
--- a/packages/suite-web/e2e/tests/metadata/output-labeling.test.ts
+++ b/packages/suite-web/e2e/tests/metadata/output-labeling.test.ts
@@ -9,6 +9,7 @@ const providers = ['google'] as const;
 describe('Metadata - Output labeling', () => {
     beforeEach(() => {
         cy.viewport(1080, 1440).resetDb();
+        cy.task('rmDir', { dir: Cypress.config('downloadsFolder'), recursive: true, force: true });
     });
 
     providers.forEach(provider => {

--- a/packages/suite/src/actions/suite/constants/metadataConstants.ts
+++ b/packages/suite/src/actions/suite/constants/metadataConstants.ts
@@ -1,4 +1,8 @@
-import { MetadataEncryptionVersion } from '@suite-common/metadata-types';
+import {
+    MetadataEncryptionVersion,
+    AccountLabels,
+    WalletLabels,
+} from '@suite-common/metadata-types';
 
 export const ENABLE = '@metadata/enable';
 export const DISABLE = '@metadata/disable';
@@ -39,3 +43,12 @@ export const GOOGLE_IMPLICIT_FLOW_CLIENT_ID =
 export const DROPBOX_CLIENT_ID = 'wg0yz2pbgjyhoda';
 
 export const ENCRYPTION_VERSION: MetadataEncryptionVersion = 1;
+export const DEFAULT_ACCOUNT_METADATA: AccountLabels = {
+    accountLabel: '',
+    outputLabels: {},
+    addressLabels: {},
+};
+
+export const DEFAULT_WALLET_METADATA: WalletLabels = {
+    walletLabel: '',
+};

--- a/packages/suite/src/actions/suite/metadataActions.ts
+++ b/packages/suite/src/actions/suite/metadataActions.ts
@@ -496,14 +496,20 @@ export const setAccountMetadataKey =
 /**
  * Fill any record in reducer that may have metadata with metadata keys (not values).
  */
-const syncMetadataKeys = () => (dispatch: Dispatch, getState: GetState) => {
-    getState().wallet.accounts.forEach(account => {
-        const accountWithMetadata = dispatch(setAccountMetadataKey(account));
-        dispatch(setAccountAdd(accountWithMetadata));
-    });
-    // note that devices are intentionally omitted here - device receives metadata
-    // keys sooner when enabling labeling on device;
-};
+const syncMetadataKeys =
+    (encryptionVersion = METADATA.ENCRYPTION_VERSION) =>
+    (dispatch: Dispatch, getState: GetState) => {
+        const accountsWithoutKeys = getState().wallet.accounts.filter(
+            acc => !acc.metadata[encryptionVersion]?.fileName,
+        );
+
+        accountsWithoutKeys.forEach(account => {
+            const accountWithMetadata = dispatch(setAccountMetadataKey(account));
+            dispatch(setAccountAdd(accountWithMetadata));
+        });
+        // note that devices are intentionally omitted here - device receives metadata
+        // keys sooner when enabling labeling on device;
+    };
 
 export const selectProvider =
     ({ dataType, clientId }: { dataType: DataType; clientId: string }) =>

--- a/packages/suite/src/reducers/suite/metadataReducer.ts
+++ b/packages/suite/src/reducers/suite/metadataReducer.ts
@@ -7,6 +7,10 @@ import { Action, TrezorDevice } from 'src/types/suite';
 import { MetadataState, WalletLabels, AccountLabels } from 'src/types/suite/metadata';
 import { selectDevice, SuiteRootState } from 'src/reducers/suite/suiteReducer';
 import { Account } from 'src/types/wallet';
+import {
+    DEFAULT_ACCOUNT_METADATA,
+    DEFAULT_WALLET_METADATA,
+} from 'src/actions/suite/constants/metadataConstants';
 
 export const initialState: MetadataState = {
     // is Suite trying to load metadata (get master key -> sync cloud)?
@@ -16,16 +20,6 @@ export const initialState: MetadataState = {
     selectedProvider: {
         labels: '',
     },
-};
-
-const initialAccountLabels: AccountLabels = {
-    addressLabels: {},
-    outputLabels: {},
-    accountLabel: '',
-};
-
-const initialWalletLabels: WalletLabels = {
-    walletLabel: '',
 };
 
 type MetadataRootState = {
@@ -99,7 +93,7 @@ export const selectLabelingDataForSelectedAccount = (state: {
 
     const metadataKeys = selectedAccount?.account?.metadata[METADATA.ENCRYPTION_VERSION];
     if (!metadataKeys || !metadataKeys.fileName || !provider?.data[metadataKeys.fileName]) {
-        return initialAccountLabels;
+        return DEFAULT_ACCOUNT_METADATA;
     }
 
     return provider.data[metadataKeys.fileName] as AccountLabels;
@@ -117,7 +111,7 @@ export const selectLabelingDataForAccount = (
     const metadataKeys = account?.metadata?.[METADATA.ENCRYPTION_VERSION];
 
     if (!metadataKeys || !metadataKeys?.fileName || !provider?.data[metadataKeys.fileName]) {
-        return initialAccountLabels;
+        return DEFAULT_ACCOUNT_METADATA;
     }
 
     return provider.data[metadataKeys.fileName] as AccountLabels;
@@ -155,14 +149,14 @@ export const selectLabelingDataForWallet = (
     const provider = selectSelectedProviderForLabels(state);
     const device = state.devices.find(d => d.state === deviceState);
     if (device?.metadata.status !== 'enabled') {
-        return initialWalletLabels;
+        return DEFAULT_WALLET_METADATA;
     }
     const metadataKeys = device?.metadata[METADATA.ENCRYPTION_VERSION];
 
     if (metadataKeys && metadataKeys.fileName && provider?.data[metadataKeys.fileName]) {
         return provider.data[metadataKeys.fileName] as WalletLabels;
     }
-    return initialWalletLabels;
+    return DEFAULT_WALLET_METADATA;
 };
 
 // is everything ready (more or less) to add label?


### PR DESCRIPTION
## Description

here I continue (#9218) adding changes to make review of #9130 feasible

## Commits

[1c188b0](https://github.com/trezor/trezor-suite/pull/9262/commits/1c188b0631414a6c503a9fad90106a2dc725d2a9) -  it is not needed to sync all the keys every time. once keys are there, they never change. when migrations come to play we call these syncs relatively more often.
[c351707](https://github.com/trezor/trezor-suite/pull/9262/commits/c351707d8e443bcb85246c2dcbbe9741fcd892bf) - moving constatns to constants. they are going to be reused in metadataActions
[3049739](https://github.com/trezor/trezor-suite/pull/9262/commits/3049739f2af1048879d9f2572482505de8043932) - add actions refactor
[3507789](https://github.com/trezor/trezor-suite/pull/9262/commits/3507789de7c5593208e1832fe5244cd450355a41) - unreleated, when runnign this test locally, it wouldn't clear defaults and fail on subsequent runs.
