### PR TITLE
fix(coinmarket): Confirm on Trezor button does nothing after address change

### DIFF
--- a/packages/suite/src/views/wallet/coinmarket/common/AddressOptions.tsx
+++ b/packages/suite/src/views/wallet/coinmarket/common/AddressOptions.tsx
@@ -102,7 +102,7 @@ export const AddressOptions = <TFieldValues extends AddressOptionsFormState>({
             name="address"
             render={({ field: { onChange } }) => (
                 <Select
-                    onChange={onChange}
+                    onChange={({ address }) => onChange(address)}
                     isClearable={false}
                     value={value}
                     options={buildOptions(addresses)}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
User reported that he is not able to “Confirm on Trezor” during the buy process in Trezor Suite.
I was able to replicate the issue after I changed the Receive address from drop-down.

Both desktop&web app
- Bitcoin addresses/accounts only
- change of receiving address (sometimes even without it)
- button Confirm on Trezor seems enabled but on click nothing happens
<!--- Describe your changes in detail -->

## Screenshots:
![image](https://github.com/trezor/trezor-suite/assets/7394177/6ba2451a-e931-40c4-916d-bd620389c4e2)
