### PR TITLE
fix(coinmarket): Include destinationTag for recomposeAndSign call in sell

### DIFF
--- a/packages/suite/src/hooks/wallet/useCoinmarketSellOffers.ts
+++ b/packages/suite/src/hooks/wallet/useCoinmarketSellOffers.ts
@@ -241,10 +241,13 @@ export const useOffers = ({ selectedAccount }: UseOffersProps) => {
             const cryptoStringAmount = shouldSendInSats
                 ? amountToSatoshi(selectedQuote.cryptoStringAmount, network.decimals)
                 : selectedQuote.cryptoStringAmount;
+            const destinationPaymentExtraId =
+                selectedQuote.destinationPaymentExtraId || trade?.data?.destinationPaymentExtraId;
             const result = await recomposeAndSign(
                 selectedAccount,
                 destinationAddress,
                 cryptoStringAmount,
+                destinationPaymentExtraId,
             );
             if (result?.success) {
                 // send txid to the server as confirmation
@@ -253,9 +256,7 @@ export const useOffers = ({ selectedAccount }: UseOffersProps) => {
                     ...selectedQuote,
                     txid,
                     destinationAddress,
-                    destinationPaymentExtraId:
-                        selectedQuote?.destinationPaymentExtraId ||
-                        trade?.data?.destinationPaymentExtraId,
+                    destinationPaymentExtraId,
                 };
                 const response = await invityAPI.doSellConfirm(quote);
                 if (!response) {


### PR DESCRIPTION
## Description
When users want to sell for example XRP, one of our partners provides us a desitnation tag which the partner requires to be as a part of the XRP transaction.
