### PR TITLE
Block filters from Blockbook instead of Wasabi

### DIFF
--- a/packages/blockchain-link-types/src/blockbook-api.ts
+++ b/packages/blockchain-link-types/src/blockbook-api.ts
@@ -309,7 +309,8 @@ export interface WsReq {
         | 'ping'
         | 'getCurrentFiatRates'
         | 'getFiatRatesForTimestamps'
-        | 'getFiatRatesTickersList';
+        | 'getFiatRatesTickersList'
+        | 'getMempoolFilters';
     params: any;
 }
 export interface WsRes {
@@ -355,6 +356,13 @@ export interface WsBlockReq {
     id: string;
     pageSize?: number;
     page?: number;
+}
+export interface WsBlockFilterReq {
+    blockHash: string;
+}
+export interface WsBlockFiltersBatchReq {
+    bestKnownBlockHash: string;
+    pageSize?: number;
 }
 export interface WsAccountUtxoReq {
     descriptor: string;
@@ -411,4 +419,11 @@ export interface WsFiatRatesForTimestampsReq {
 export interface WsFiatRatesTickersListReq {
     timestamp?: number;
     token?: string;
+}
+export interface WsMempoolFiltersReq {
+    scriptType: string;
+    fromTimestamp: number;
+}
+export interface MempoolTxidFilterEntries {
+    entries?: { [key: string]: string };
 }

--- a/packages/blockchain-link-types/src/blockbook.ts
+++ b/packages/blockchain-link-types/src/blockbook.ts
@@ -13,6 +13,9 @@ import type {
     Utxo as BlockbookUtxo,
     WsInfoRes,
     WsBlockHashRes,
+    WsBlockFilterReq,
+    WsBlockFiltersBatchReq,
+    MempoolTxidFilterEntries,
     Token as BlockbookToken,
     EthereumParsedInputData as BlockbookEthereumParsedInputData,
     EthereumSpecific as BlockbookEthereumSpecific,
@@ -43,14 +46,22 @@ export interface Block {
     txs: Transaction[];
 }
 
-export interface MempoolFiltersParams {
-    scriptType: 'taproot';
+export interface FilterRequestParams {
+    scriptType: 'taproot' | 'taproot-noordinals';
+    M?: number;
+}
+
+export interface MempoolFiltersParams extends FilterRequestParams {
     fromTimestamp?: number;
 }
 
-export interface MempoolFilters {
-    entries?: { [txid: string]: string };
+export interface FilterResponse {
+    P: number;
+    M: number;
+    zeroedKey: boolean;
 }
+
+type BlockFiltersBatch = `${string}:${string}:${string}`[];
 
 // XPUBAddress, ERC20, ERC721, ERC1155 - blockbook generated type (Token) is not strict enough
 export type XPUBAddress = {
@@ -191,9 +202,17 @@ declare function FSend(method: 'getInfo'): Promise<ServerInfo>;
 declare function FSend(method: 'getBlockHash', params: { height: number }): Promise<BlockHash>;
 declare function FSend(method: 'getBlock', params: { id: string }): Promise<Block>;
 declare function FSend(
+    method: 'getBlockFilter',
+    params: WsBlockFilterReq & FilterRequestParams,
+): Promise<FilterResponse & { blockFilter: string }>;
+declare function FSend(
+    method: 'getBlockFiltersBatch',
+    params: WsBlockFiltersBatchReq & FilterRequestParams,
+): Promise<FilterResponse & { blockFiltersBatch: BlockFiltersBatch }>;
+declare function FSend(
     method: 'getMempoolFilters',
     params: MempoolFiltersParams,
-): Promise<MempoolFilters>;
+): Promise<FilterResponse & MempoolTxidFilterEntries>;
 declare function FSend(method: 'getAccountInfo', params: AccountInfoParams): Promise<AccountInfo>;
 declare function FSend(method: 'getAccountUtxo', params: AccountUtxoParams): Promise<AccountUtxo>;
 declare function FSend(method: 'getTransaction', params: { txid: string }): Promise<Transaction>;

--- a/packages/blockchain-link/src/workers/blockbook/websocket.ts
+++ b/packages/blockchain-link/src/workers/blockbook/websocket.ts
@@ -7,6 +7,7 @@ import type {
     AddressNotification,
     Send,
     FiatRatesNotification,
+    FilterRequestParams,
 } from '@trezor/blockchain-link-types/lib/blockbook';
 import type {
     GetFiatRatesForTimestamps,
@@ -75,8 +76,33 @@ export class BlockbookAPI extends BaseWebsocket<BlockbookEvents> {
         return this.send('getBlock', { id: `${block}` });
     }
 
-    getMempoolFilters(fromTimestamp?: number) {
-        return this.send('getMempoolFilters', { fromTimestamp, scriptType: 'taproot' });
+    getBlockFilter(blockHash: string, filterParams?: FilterRequestParams) {
+        return this.send('getBlockFilter', {
+            blockHash,
+            scriptType: 'taproot-noordinals',
+            ...filterParams,
+        });
+    }
+
+    getBlockFiltersBatch(
+        bestKnownBlockHash: string,
+        pageSize?: number,
+        filterParams?: FilterRequestParams,
+    ) {
+        return this.send('getBlockFiltersBatch', {
+            bestKnownBlockHash,
+            pageSize,
+            scriptType: 'taproot-noordinals',
+            ...filterParams,
+        });
+    }
+
+    getMempoolFilters(fromTimestamp?: number, filterParams?: FilterRequestParams) {
+        return this.send('getMempoolFilters', {
+            fromTimestamp,
+            scriptType: 'taproot-noordinals',
+            ...filterParams,
+        });
     }
 
     getAccountInfo(payload: AccountInfoParams) {

--- a/packages/coinjoin/package.json
+++ b/packages/coinjoin/package.json
@@ -20,6 +20,7 @@
         "test:unit": "jest --version && jest",
         "test:discovery": "tsx ./tests/tools/discovery-test.ts",
         "test:anonymity": "tsx ./tests/tools/anonymity-test.ts",
+        "test:benchmark": "tsx ./tests/tools/benchmark-test.ts",
         "type-check": "tsc --build"
     },
     "dependencies": {

--- a/packages/coinjoin/src/backend/CoinjoinAddressController.ts
+++ b/packages/coinjoin/src/backend/CoinjoinAddressController.ts
@@ -3,7 +3,7 @@
 import type { Network } from '@trezor/utxo-lib';
 
 import { deriveAddresses } from './backendUtils';
-import { getBlockAddressScript } from './filters';
+import { getAddressScript } from './filters';
 import type { AccountAddress, ScanAccountCheckpoint, AccountCache } from '../types/backend';
 import { DISCOVERY_LOOKOUT, DISCOVERY_LOOKOUT_EXTENDED } from '../constants';
 
@@ -50,7 +50,7 @@ export class CoinjoinAddressController {
             ({ address, path }) => ({
                 address,
                 path,
-                script: getBlockAddressScript(address, this.network),
+                script: getAddressScript(address, this.network),
             }),
         );
     }

--- a/packages/coinjoin/src/backend/CoinjoinMempoolController.ts
+++ b/packages/coinjoin/src/backend/CoinjoinMempoolController.ts
@@ -98,8 +98,8 @@ export class CoinjoinMempoolController {
 
         const filters = await this.client
             .fetchMempoolFilters()
-            .then(res =>
-                Object.entries(res).map(
+            .then(({ entries }) =>
+                Object.entries(entries).map(
                     ([txid, filter]) => [txid, getMempoolMultiFilter(filter, txid)] as const,
                 ),
             );
@@ -179,7 +179,7 @@ export class CoinjoinMempoolController {
 
         const mempoolTxids = await this.client
             .fetchMempoolFilters()
-            .then(filters => Object.keys(filters));
+            .then(({ entries }) => Object.keys(entries));
         const keepTxids = mempoolTxids.filter(txid => this.mempool.has(txid));
         const removeTxids = Array.from(this.mempool.keys()).filter(
             txid => !keepTxids.includes(txid),

--- a/packages/coinjoin/src/backend/backendUtils.ts
+++ b/packages/coinjoin/src/backend/backendUtils.ts
@@ -61,6 +61,8 @@ export const identifyWsError = (error: Error) => {
             return 'ERROR_TIMEOUT';
         case 'Block not found':
             return 'ERROR_BLOCK_NOT_FOUND';
+        case 'Unsupported script filter taproot-noordinals':
+            return 'ERROR_UNSUPPORTED_NOORDINALS';
         default:
             return 'ERROR_OTHER';
     }

--- a/packages/coinjoin/src/backend/backendUtils.ts
+++ b/packages/coinjoin/src/backend/backendUtils.ts
@@ -59,6 +59,8 @@ export const identifyWsError = (error: Error) => {
         // file://./../../../blockchain-link-types/src/constants/errors.ts
         case 'Websocket timeout':
             return 'ERROR_TIMEOUT';
+        case 'Block not found':
+            return 'ERROR_BLOCK_NOT_FOUND';
         default:
             return 'ERROR_OTHER';
     }

--- a/packages/coinjoin/src/backend/scanAccount.ts
+++ b/packages/coinjoin/src/backend/scanAccount.ts
@@ -1,7 +1,7 @@
 import { createCooldown } from '@trezor/utils';
 import { transformTransaction } from '@trezor/blockchain-link-utils/lib/blockbook';
 
-import { getBlockMultiFilter } from './filters';
+import { getMultiFilter } from './filters';
 import { doesTxContainAddress } from './backendUtils';
 import { CoinjoinAddressController } from './CoinjoinAddressController';
 import type {
@@ -44,8 +44,8 @@ export const scanAccount = async (
 
     const everyFilter = filters.getFilterIterator({ checkpoints }, { abortSignal, onProgressInfo });
     // eslint-disable-next-line no-restricted-syntax
-    for await (const { filter, blockHash, blockHeight } of everyFilter) {
-        const isMatch = getBlockMultiFilter(filter, blockHash);
+    for await (const { blockHash, blockHeight, filter, filterParams } of everyFilter) {
+        const isMatch = getMultiFilter(filter, filterParams);
         const scripts = addresses.receive.concat(addresses.change).map(({ script }) => script);
 
         if (isMatch(scripts)) {

--- a/packages/coinjoin/src/types/backend.ts
+++ b/packages/coinjoin/src/types/backend.ts
@@ -10,6 +10,7 @@ import type {
 import type {
     Transaction as BlockbookTransaction,
     VinVout,
+    FilterResponse,
 } from '@trezor/blockchain-link-types/lib/blockbook';
 
 import type { CoinjoinBackendClient } from '../backend/CoinjoinBackendClient';
@@ -31,18 +32,16 @@ export type BlockFilter = {
     blockHeight: number;
     blockHash: string;
     filter: string;
-    prevHash: string;
-    blockTime: number;
 };
 
 export type BlockFilterResponse =
     | { status: 'up-to-date' }
     | { status: 'not-found' }
-    | {
-          status: 'ok';
-          bestHeight: number;
-          filters: BlockFilter[];
-      };
+    | ({ status: 'ok'; filters: BlockFilter[] } & Partial<FilterResponse>);
+
+export type MempoolFilterResponse = Partial<FilterResponse> & {
+    entries: { [txid: string]: string };
+};
 
 export type ScanAccountContext = {
     client: CoinjoinBackendClient;
@@ -109,7 +108,7 @@ export type FilterControllerContext = {
     onProgressInfo?: OnProgressInfo;
 };
 
-export type FilterClient = Pick<CoinjoinBackendClient, 'fetchFilters'>;
+export type FilterClient = Pick<CoinjoinBackendClient, 'fetchNetworkInfo' | 'fetchBlockFilters'>;
 
 export type MempoolClient = Pick<
     CoinjoinBackendClient,

--- a/packages/coinjoin/tests/backend/CoinjoinBackendClient.test.ts
+++ b/packages/coinjoin/tests/backend/CoinjoinBackendClient.test.ts
@@ -1,4 +1,3 @@
-import * as http from '../../src/utils/http';
 import { CoinjoinBackendClient } from '../../src/backend/CoinjoinBackendClient';
 import { COINJOIN_BACKEND_SETTINGS } from '../fixtures/config.fixture';
 
@@ -72,31 +71,6 @@ describe('CoinjoinBackendClient', () => {
             expect(id).toMatch(/theft:[a-z0-9]+/);
             expect(arr.indexOf(id)).toBe(i);
         });
-    });
-
-    it('Wabisabi switch identities on 403', async () => {
-        const identities: string[] = [];
-        jest.spyOn(http, 'httpGet').mockImplementation((_, __, { identity } = {}) => {
-            identities.push(identity!);
-            return Promise.resolve({ status: identity === 'bar' ? 404 : 403 } as Response);
-        });
-
-        await expect(() =>
-            client.fetchFilters('abc', 123, { identity: 'foo', attempts: 4, gap: 0 }),
-        ).rejects.toThrow();
-        await expect(() =>
-            client.fetchMempoolTxids({ identity: 'bar', /* default attempts: 3 */ gap: 0 }),
-        ).rejects.toThrow();
-
-        expect(identities.length).toBe(7);
-
-        expect(identities[0]).toBe('foo');
-        identities.slice(1, 4).forEach((id, i, arr) => {
-            expect(id).toMatch(/foo:[a-z0-9]+/);
-            expect(arr.indexOf(id)).toBe(i);
-        });
-
-        identities.slice(4, 7).forEach(id => expect(id).toBe('bar'));
     });
 
     it('Blockbook onion with fallback', async () => {

--- a/packages/coinjoin/tests/backend/CoinjoinFilterController.test.ts
+++ b/packages/coinjoin/tests/backend/CoinjoinFilterController.test.ts
@@ -1,24 +1,23 @@
 import { CoinjoinFilterController } from '../../src/backend/CoinjoinFilterController';
-import { BlockFilter } from '../../src/types/backend';
-import { mockFilterSequence } from '../fixtures/filters.fixture';
+import { MockBlockFilter, mockFilterSequence } from '../fixtures/filters.fixture';
 import { COINJOIN_BACKEND_SETTINGS } from '../fixtures/config.fixture';
 import { MockFilterClient } from '../mocks/MockFilterClient';
 
 const FILTER_COUNT = 16;
 const FILTER_MIDDLE = 8;
 
-const FILTERS: BlockFilter[] = mockFilterSequence(
+const FILTERS: MockBlockFilter[] = mockFilterSequence(
     FILTER_COUNT,
     COINJOIN_BACKEND_SETTINGS.baseBlockHeight,
     COINJOIN_BACKEND_SETTINGS.baseBlockHash,
 );
 
-const REORG_FILTER: BlockFilter = {
+const REORG_FILTER: MockBlockFilter = {
     blockHeight: 9,
-    blockTime: 90,
     blockHash: 'nope',
     filter: 'nope',
     prevHash: FILTERS[FILTER_MIDDLE - 1].blockHash,
+    filterParams: { key: 'nope' },
 };
 
 const REORG_FILTERS = FILTERS.slice(0, FILTER_MIDDLE).concat(REORG_FILTER);

--- a/packages/coinjoin/tests/backend/filters.test.ts
+++ b/packages/coinjoin/tests/backend/filters.test.ts
@@ -1,84 +1,9 @@
 import { networks } from '@trezor/utxo-lib';
 
-import {
-    getBlockAddressScript,
-    getBlockFilter,
-    getBlockMultiFilter,
-    getMempoolAddressScript,
-    getMempoolFilter,
-} from '../../src/backend/filters';
-
-const NETWORK = networks.regtest;
-
-const COINJOIN_RECEIVE_0 = 'bcrt1pksw3pwfgueqmnxvyesjxj24q2wek77lsq4jan745j2z9wr9csf3qpgmdpz'; // OUT 106, IN 108
-const COINJOIN_CHANGE_0 = 'bcrt1pc3488glntqgqel3jjtwujl8g50xrvx04ewpt799ns77dg756km5qa66ca8'; // OUT 108, IN 109
-const BECH32_RECEIVE_0 = 'bcrt1qkvwu9g3k2pdxewfqr7syz89r3gj557l374sg5v'; // OUT 157, IN 158
-const BECH32_CHANGE_0 = 'bcrt1qejqxwzfld7zr6mf7ygqy5s5se5xq7vmt8ntmj0'; // OUT 159, IN 160
-const TAPROOT_RECEIVE_0 = 'bcrt1pswrqtykue8r89t9u4rprjs0gt4qzkdfuursfnvqaa3f2yql07zmq2fdmpx'; // OUT 161, IN 162
-const TAPROOT_CHANGE_0 = 'bcrt1pn2d0yjeedavnkd8z8lhm566p0f2utm3lgvxrsdehnl94y34txmtsef5dqz'; // OUT 162, IN 163
-
-const BLOCK_106 = {
-    height: 106,
-    filter: '0135dff8',
-    hash: '2c94e940c0584944bfdf0137936e6a6fc8ad4416a96b3663b09961574568331c',
-};
-
-const BLOCK_108 = {
-    height: 108,
-    filter: '0662a3ec50c3e5524c8b25ceaa9c061aef80',
-    hash: '4bf55f6337c2e921fe2bf87bb121ded31988ea99d9edf2dc5498f605fd1d966e',
-};
-
-const BLOCK_109 = {
-    height: 109,
-    filter: '0704ac18e1c3e5f4f22fd21e20233627d8927624',
-    hash: '35fbbceea020bc388dcb1b7afcba60e27da0889bd3d0689d2a786e9a8bd12746',
-};
-
-const BLOCK_157 = {
-    height: 157,
-    filter: '01656c90',
-    hash: '09f69854a4572575e2a8af0dea70ff5efd46957e2cb60e81c0d760098ab48b44',
-};
-
-const BLOCK_158 = {
-    height: 158,
-    filter: '0298ad7857d0c0',
-    hash: '5513d63651bbb32985b54fa9e0e530553e3e9cebdd10feae7f019c04edb80f61',
-};
-
-const BLOCK_159 = {
-    height: 159,
-    filter: '03a69058941e6f5fc1',
-    hash: '5021a2185f27ad04d45f1b53c873b2231311aea99e0f1d7a6252167540b9db4c',
-};
-
-const BLOCK_160 = {
-    height: 160,
-    filter: '023eee59053e40',
-    hash: '01d37c4490e9ddaf6b5c886eaa215b8d0b658c93ea42cfd871b226f606672c0b',
-};
-
-const BLOCK_161 = {
-    height: 161,
-    filter: '012d70f8',
-    hash: '01c8add70f124c8d220d8f82e759ad3d1d0fa8f174dab9a9363a4c36de4e4b44',
-};
-
-const BLOCK_162 = {
-    height: 162,
-    filter: '03018bfa4d4731ee2480',
-    hash: '12de06b8ae4bbc660e3f565c876c606f5a1bd3463364c6abfc882b5ff6dd86e3',
-};
-
-const BLOCK_163 = {
-    height: 163,
-    filter: '02782a5165c980',
-    hash: '36d01c975372c363d94f0e9e22e8a61a6a52e3408c98920ef1587b024ec487e3',
-};
+import { getAddressScript, getFilter, getMultiFilter } from '../../src/backend/filters';
 
 // from blockbook repo
-const MEMPOOL_FILTERS = [
+const FIXTURES = [
     [
         'taproot',
         '86336c62a63f509a278624e3f400cdd50838d035a44e0af8a7d6d133c04cc2d2',
@@ -114,9 +39,20 @@ const MEMPOOL_FILTERS = [
         '011aeee8',
         ['bc1pgeqrcq5capal83ypxczmypjdhk4d9wwcea4k66c7ghe07p2qt97sqh8sy5'],
     ],
+    [
+        'all',
+        '86336c62a63f509a278624e3f400cdd50838d035a44e0af8a7d6d133c04cc2d2',
+        '0350ccc61ac611976c80',
+        [
+            'bc1pgeqrcq5capal83ypxczmypjdhk4d9wwcea4k66c7ghe07p2qt97sqh8sy5',
+            'bc1p7en40zu9hmf9d3luh8evmfyg655pu5k2gtna6j7zr623f9tz7z0stfnwav',
+            '39ECUF8YaFRX7XfttfAiLa5ir43bsrQUZJ',
+        ],
+    ],
+    ['empty', '86336c62a63f509a278624e3f400cdd50838d035a44e0af8a7d6d133c04cc2d2', '', []],
 ] as const;
 
-const MEMPOOL_ADDRS_MISS = [
+const ADDRS_MISS = [
     'bc1ptxs597p3fnpd8gwut5p467ulsydae3rp9z75hd99w8k3ljr9g9rqx6ynaw',
     'bc1plca7n9vs7d906nwlqyvk0d0jxnxss6x7w3x2y879quuvj8xn3p3s7vrrl2',
     'bc1pks4em3l8vg4zyk5xpcmgygh7elkhu03z3fqj48a2a2lv948cn4hsyltl3h',
@@ -125,124 +61,36 @@ const MEMPOOL_ADDRS_MISS = [
 ];
 
 describe('Golomb filtering', () => {
-    describe('Block filters', () => {
-        it('Receive address as input', () => {
-            const script = getBlockAddressScript(COINJOIN_RECEIVE_0, NETWORK);
-            const filter = getBlockFilter(BLOCK_108.filter, BLOCK_108.hash);
-            expect(filter(script)).toBe(true);
-        });
+    const missScripts = ADDRS_MISS.map(miss => getAddressScript(miss, networks.bitcoin));
 
-        it('Receive address as output', () => {
-            const script = getBlockAddressScript(COINJOIN_RECEIVE_0, NETWORK);
-            const filter = getBlockFilter(BLOCK_106.filter, BLOCK_106.hash);
-            expect(filter(script)).toBe(true);
-        });
-
-        it('Receive address nowhere', () => {
-            const script = getBlockAddressScript(COINJOIN_RECEIVE_0, NETWORK);
-            const filter = getBlockFilter(BLOCK_109.filter, BLOCK_109.hash);
-            expect(filter(script)).toBe(false);
-        });
-
-        it('Change address as input', () => {
-            const script = getBlockAddressScript(COINJOIN_CHANGE_0, NETWORK);
-            const filter = getBlockFilter(BLOCK_109.filter, BLOCK_109.hash);
-            expect(filter(script)).toBe(true);
-        });
-
-        it('Change address as output', () => {
-            const script = getBlockAddressScript(COINJOIN_CHANGE_0, NETWORK);
-            const filter = getBlockFilter(BLOCK_108.filter, BLOCK_108.hash);
-            expect(filter(script)).toBe(true);
-        });
-
-        it('Change address nowhere', () => {
-            const script = getBlockAddressScript(COINJOIN_CHANGE_0, NETWORK);
-            const filter = getBlockFilter(BLOCK_106.filter, BLOCK_106.hash);
-            expect(filter(script)).toBe(false);
-        });
-
-        it('Bech32 receive address as input', () => {
-            const script = getBlockAddressScript(BECH32_RECEIVE_0, NETWORK);
-            const filter = getBlockFilter(BLOCK_158.filter, BLOCK_158.hash);
-            expect(filter(script)).toBe(true);
-        });
-
-        it('Bech32 receive address as output', () => {
-            const script = getBlockAddressScript(BECH32_RECEIVE_0, NETWORK);
-            const filter = getBlockFilter(BLOCK_157.filter, BLOCK_157.hash);
-            expect(filter(script)).toBe(true);
-        });
-
-        it('Bech32 change address as input', () => {
-            const script = getBlockAddressScript(BECH32_CHANGE_0, NETWORK);
-            const filter = getBlockFilter(BLOCK_160.filter, BLOCK_160.hash);
-            expect(filter(script)).toBe(true);
-        });
-
-        it('Bech32 change address as output', () => {
-            const script = getBlockAddressScript(BECH32_CHANGE_0, NETWORK);
-            const filter = getBlockFilter(BLOCK_159.filter, BLOCK_159.hash);
-            expect(filter(script)).toBe(true);
-        });
-
-        it('Taproot receive address as input', () => {
-            const script = getBlockAddressScript(TAPROOT_RECEIVE_0, NETWORK);
-            const filter = getBlockFilter(BLOCK_162.filter, BLOCK_162.hash);
-            expect(filter(script)).toBe(true);
-        });
-
-        it('Taproot receive address as output', () => {
-            const script = getBlockAddressScript(TAPROOT_RECEIVE_0, NETWORK);
-            const filter = getBlockFilter(BLOCK_161.filter, BLOCK_161.hash);
-            expect(filter(script)).toBe(true);
-        });
-
-        it('Taproot change address as input', () => {
-            const script = getBlockAddressScript(TAPROOT_CHANGE_0, NETWORK);
-            const filter = getBlockFilter(BLOCK_163.filter, BLOCK_163.hash);
-            expect(filter(script)).toBe(true);
-        });
-
-        it('Taproot change address as output', () => {
-            const script = getBlockAddressScript(TAPROOT_CHANGE_0, NETWORK);
-            const filter = getBlockFilter(BLOCK_162.filter, BLOCK_162.hash);
-            expect(filter(script)).toBe(true);
-        });
-
-        it('Multifilter hit', () => {
-            const filter = getBlockMultiFilter(BLOCK_108.filter, BLOCK_108.hash);
-            const scripts = [
-                getBlockAddressScript(TAPROOT_RECEIVE_0, NETWORK),
-                getBlockAddressScript(COINJOIN_CHANGE_0, NETWORK),
-                getBlockAddressScript(TAPROOT_CHANGE_0, NETWORK),
-            ];
-            expect(filter(scripts)).toBe(true);
-        });
-
-        it('Multifilter miss', () => {
-            const filter = getBlockMultiFilter(BLOCK_106.filter, BLOCK_106.hash);
-            const scripts = [
-                getBlockAddressScript(TAPROOT_RECEIVE_0, NETWORK),
-                getBlockAddressScript(COINJOIN_CHANGE_0, NETWORK),
-                getBlockAddressScript(TAPROOT_CHANGE_0, NETWORK),
-            ];
-            expect(filter(scripts)).toBe(false);
+    describe('match', () => {
+        FIXTURES.forEach(([desc, key, filterHex, hits]) => {
+            it(desc, () => {
+                const filter = getFilter(filterHex, { key });
+                hits.forEach(hit => {
+                    const script = getAddressScript(hit, networks.bitcoin);
+                    expect(filter(script)).toBe(true);
+                });
+                missScripts.forEach(script => {
+                    expect(filter(script)).toBe(false);
+                });
+            });
         });
     });
 
-    describe('Mempool filters', () => {
-        MEMPOOL_FILTERS.forEach(([desc, txid, filterHex, hits]) => {
+    describe('matchAny', () => {
+        FIXTURES.forEach(([desc, key, filterHex, hits]) => {
             it(desc, () => {
-                const filter = getMempoolFilter(filterHex, txid);
-                hits.forEach(hit => {
-                    const script = getMempoolAddressScript(hit, networks.bitcoin);
-                    expect(filter(script)).toBe(true);
-                });
-                MEMPOOL_ADDRS_MISS.forEach(miss => {
-                    const script = getMempoolAddressScript(miss, networks.bitcoin);
-                    expect(filter(script)).toBe(false);
-                });
+                const filter = getMultiFilter(filterHex, { key });
+                const hitScripts = hits.map(hit => getAddressScript(hit, networks.bitcoin));
+
+                expect(filter([])).toBe(false);
+                expect(filter(missScripts)).toBe(false);
+                if (hitScripts.length) {
+                    expect(filter(hitScripts)).toBe(true);
+                    expect(filter([...missScripts, hitScripts[0]])).toBe(true);
+                    expect(filter([...hitScripts, ...missScripts])).toBe(true);
+                }
             });
         });
     });

--- a/packages/coinjoin/tests/backend/methods.test.ts
+++ b/packages/coinjoin/tests/backend/methods.test.ts
@@ -27,7 +27,7 @@ const hasFilters = (r: BlockFilterResponse): r is Extract<BlockFilterResponse, {
 
 describe(`CoinjoinBackend methods`, () => {
     const client = new MockBackendClient();
-    const fetchFiltersMock = jest.spyOn(client, 'fetchFilters');
+    const fetchFiltersMock = jest.spyOn(client, 'fetchBlockFilters');
     const fetchBlockMock = jest.spyOn(client, 'fetchBlock');
 
     const getRequestedFilters = () =>

--- a/packages/coinjoin/tests/fixtures/filters.fixture.ts
+++ b/packages/coinjoin/tests/fixtures/filters.fixture.ts
@@ -1,5 +1,10 @@
 import { BlockFilter } from '../../src/types/backend';
 
+export type MockBlockFilter = BlockFilter & {
+    prevHash: string;
+    filterParams: { key: string };
+};
+
 /**
  * example: 3 => {
  *  blockHeight: 3,
@@ -9,20 +14,20 @@ import { BlockFilter } from '../../src/types/backend';
  *  filter: 'filter_3',
  * }
  */
-export const mockFilter = (height: number): BlockFilter => ({
+export const mockFilter = (height: number): MockBlockFilter => ({
     blockHeight: height,
-    blockTime: height * 10,
     blockHash: `hash_${height}`,
     prevHash: `hash_${height - 1}`,
     filter: `filter_${height}`,
+    filterParams: { key: `hash_${height}` },
 });
 
 export const mockFilterSequence = (
     count: number,
     baseHeight = 0,
     baseHash = 'hash_0',
-): BlockFilter[] => {
-    const filters: BlockFilter[] = [];
+): MockBlockFilter[] => {
+    const filters: MockBlockFilter[] = [];
     for (let i = 0; i < count; ++i) {
         filters.push({
             ...mockFilter(baseHeight + i + 1),

--- a/packages/coinjoin/tests/fixtures/methods.fixture.ts
+++ b/packages/coinjoin/tests/fixtures/methods.fixture.ts
@@ -25,7 +25,7 @@ export const BLOCKS = [
     {
         height: 1,
         hash: '09f69854a4572575e2a8af0dea70ff5efd46957e2cb60e81c0d760098ab48b44',
-        filter: '01656c90', // receive 1 out
+        filter: '03a282604dcbe72d0e', // receive 1 out
         previousBlockHash: BASE_HASH,
         txs: [
             {
@@ -66,7 +66,7 @@ export const BLOCKS = [
     {
         height: 2,
         hash: '5513d63651bbb32985b54fa9e0e530553e3e9cebdd10feae7f019c04edb80f61',
-        filter: '0298ad7857d0c0', // receive 1 in, receive 2 out
+        filter: '02044071f773c0', // receive 1 in, receive 2 out
         previousBlockHash: '09f69854a4572575e2a8af0dea70ff5efd46957e2cb60e81c0d760098ab48b44',
         txs: [
             {
@@ -101,14 +101,14 @@ export const BLOCKS = [
     {
         height: 3,
         hash: '295578a3c8eb87736a5e657b06a0933f7ec5f82c43f8418fdb38f74c0fc066c7',
-        filter: '0802a1103e91e638632d0f148d8c4618cc6118aeaad3d0', // nothing
+        filter: '', // empty
         previousBlockHash: '5513d63651bbb32985b54fa9e0e530553e3e9cebdd10feae7f019c04edb80f61',
         txs: [],
     },
     {
         height: 4,
         hash: '12de06b8ae4bbc660e3f565c876c606f5a1bd3463364c6abfc882b5ff6dd86e3',
-        filter: '03018bfa4d4731ee2480', // receive 1 out
+        filter: '030361ceb3dfc1c1e600', // receive 1 out
         previousBlockHash: '295578a3c8eb87736a5e657b06a0933f7ec5f82c43f8418fdb38f74c0fc066c7',
         txs: [
             {
@@ -152,14 +152,14 @@ export const BLOCKS = [
     {
         height: 5,
         hash: '2c2c65aad93eebe235955e170913fd6558453dd999a4ded6249bbdc9d54da1f7',
-        filter: '08a4afd740dddb6185ca00666d22a55fc9252008f9cda0', // nothing
+        filter: '03c1e18a1589b6051780', // no match
         previousBlockHash: '12de06b8ae4bbc660e3f565c876c606f5a1bd3463364c6abfc882b5ff6dd86e3',
         txs: [],
     },
     {
         height: 6,
         hash: '5021a2185f27ad04d45f1b53c873b2231311aea99e0f1d7a6252167540b9db4c',
-        filter: '03a69058941e6f5fc1', // receive 2 in, receive 1 out, change 1 out'
+        filter: '036e6e302da2ce028c', // receive 2 in, receive 1 out, change 1 out'
         previousBlockHash: '2c2c65aad93eebe235955e170913fd6558453dd999a4ded6249bbdc9d54da1f7',
         txs: [
             {
@@ -200,7 +200,7 @@ export const BLOCKS = [
     {
         height: 7,
         hash: '01d37c4490e9ddaf6b5c886eaa215b8d0b658c93ea42cfd871b226f606672c0b',
-        filter: '023eee59053e40', // receive 1 in, change 1 in, receive 1 out'
+        filter: '02020f2a9a0ac0', // receive 1 in, change 1 in, receive 1 out'
         previousBlockHash: '5021a2185f27ad04d45f1b53c873b2231311aea99e0f1d7a6252167540b9db4c',
         txs: [
             {
@@ -241,7 +241,7 @@ export const BLOCKS = [
     {
         height: 8,
         hash: '36d01c975372c363d94f0e9e22e8a61a6a52e3408c98920ef1587b024ec487e3',
-        filter: '02782a5165c980', // receive 1 out
+        filter: '023e09f4f752a0', // receive 1 out
         previousBlockHash: '01d37c4490e9ddaf6b5c886eaa215b8d0b658c93ea42cfd871b226f606672c0b',
         txs: [
             {

--- a/packages/coinjoin/tests/mocks/MockBackendClient.ts
+++ b/packages/coinjoin/tests/mocks/MockBackendClient.ts
@@ -90,6 +90,9 @@ export class MockBackendClient extends CoinjoinBackendClient {
 
     private getBlockbookProxyHandler(method: string | symbol, ...params: any[]) {
         switch (method) {
+            case 'getServerInfo': {
+                return Promise.resolve({ bestHeight: this.blocks[this.blocks.length - 1].height });
+            }
             case 'getTransaction': {
                 const tx = this.transactions.find(t => t.txid === params[0]);
                 if (tx) return Promise.resolve(tx as any);
@@ -106,6 +109,23 @@ export class MockBackendClient extends CoinjoinBackendClient {
                         this.mempool.map(({ txid, filter }) => [txid, filter]),
                     ),
                 });
+            }
+            case 'getBlockFiltersBatch': {
+                const bestKnownBlockHash = params[0];
+                const count = params[1];
+
+                if (this.blocks[this.blocks.length - 1].hash === bestKnownBlockHash)
+                    return Promise.resolve({ blockFiltersBatch: [] });
+                const from = this.blocks.findIndex(
+                    ({ previousBlockHash }) => previousBlockHash === bestKnownBlockHash,
+                );
+                if (from >= 0)
+                    return Promise.resolve({
+                        blockFiltersBatch: this.blocks
+                            .slice(from, from + count)
+                            .map(({ height, hash, filter }) => `${height}:${hash}:${filter}`),
+                    });
+                return Promise.reject(new Error('Block not found'));
             }
             // no default
         }

--- a/packages/coinjoin/tests/mocks/MockFilterClient.ts
+++ b/packages/coinjoin/tests/mocks/MockFilterClient.ts
@@ -1,13 +1,22 @@
-import type { BlockFilter, FilterClient } from '../../src/types/backend';
+import type { FilterClient } from '../../src/types/backend';
+import type { MockBlockFilter } from '../fixtures/filters.fixture';
 
 export class MockFilterClient implements FilterClient {
-    private filters: BlockFilter[] = [];
+    private filters: MockBlockFilter[] = [];
 
-    setFixture(filters: BlockFilter[]) {
+    setFixture(filters: MockBlockFilter[]) {
         this.filters = filters;
     }
 
-    fetchFilters(knownHash: string, count: number): ReturnType<FilterClient['fetchFilters']> {
+    fetchNetworkInfo(): ReturnType<FilterClient['fetchNetworkInfo']> {
+        const tip = this.filters[this.filters.length - 1];
+        return Promise.resolve({ bestHeight: tip.blockHeight } as any);
+    }
+
+    fetchBlockFilters(
+        knownHash: string,
+        count: number,
+    ): ReturnType<FilterClient['fetchBlockFilters']> {
         const tip = this.filters[this.filters.length - 1];
         if (knownHash === tip.blockHash) {
             return Promise.resolve({ status: 'up-to-date' });
@@ -17,7 +26,6 @@ export class MockFilterClient implements FilterClient {
             ? Promise.resolve({ status: 'not-found' })
             : Promise.resolve({
                   status: 'ok',
-                  bestHeight: tip.blockHeight,
                   filters: this.filters.slice(from, from + count),
               });
     }

--- a/packages/coinjoin/tests/mocks/MockMempoolClient.ts
+++ b/packages/coinjoin/tests/mocks/MockMempoolClient.ts
@@ -19,9 +19,9 @@ export class MockMempoolClient implements MempoolClient {
     }
 
     fetchMempoolFilters() {
-        return Promise.resolve(
-            Object.fromEntries(this.mempoolTxs.map(({ txid, filter }) => [txid, filter])),
-        );
+        return Promise.resolve({
+            entries: Object.fromEntries(this.mempoolTxs.map(({ txid, filter }) => [txid, filter])),
+        });
     }
 
     fetchTransaction(txid: string) {

--- a/packages/coinjoin/tests/tools/benchmark-test.ts
+++ b/packages/coinjoin/tests/tools/benchmark-test.ts
@@ -1,0 +1,197 @@
+/* eslint-disable import/no-extraneous-dependencies */
+/* eslint-disable no-console */
+
+import net from 'net';
+import http from 'http';
+import https from 'https';
+import fetch from 'node-fetch';
+import { SocksProxyAgent } from 'socks-proxy-agent';
+import WebSocket from 'ws';
+
+const WASABI_URL = 'https://wasabiwallet.io';
+const BLOCKBOOK_URL = 'wss://staging-btc.trezor.io/websocket';
+const TIMEOUT = 20000;
+
+const [bestKnownHash, batchSizeString = '500', torSocket = ''] = process.argv.slice(2);
+const batchSize = Number(batchSizeString);
+const [host, port] = torSocket.split(':');
+const agent = host && port ? new SocksProxyAgent({ host, port }) : undefined;
+
+// Copied from request-manager to remove disallowed headers because of Wasabi
+const stripHeaders = () => {
+    const originalSocketWrite = net.Socket.prototype.write;
+    net.Socket.prototype.write = function (data, ...args) {
+        const overloadedHeaders: string[] = [];
+        if (typeof data === 'string' && /Allowed-Headers/gi.test(data)) {
+            const headers = data.split('\r\n');
+            const allowedHeaders = headers
+                .find(line => /^Allowed-Headers/i.test(line))
+                ?.split(': ');
+
+            if (allowedHeaders) {
+                const allowedKeys = allowedHeaders[1].split(';');
+
+                headers.forEach(line => {
+                    const [key, value] = line.split(': ');
+                    if (key && value) {
+                        if (allowedKeys.some(allowed => new RegExp(`^${allowed}`, 'i').test(key))) {
+                            overloadedHeaders.push(line);
+                        }
+                    } else {
+                        overloadedHeaders.push(line);
+                    }
+                });
+            }
+        }
+
+        return originalSocketWrite.apply(this, [
+            overloadedHeaders.length > 0 ? overloadedHeaders.join('\r\n') : data,
+            ...args,
+        ] as unknown as Parameters<typeof originalSocketWrite>);
+    };
+};
+
+let bytes = 0;
+
+const origHttpsRequest = https.request;
+https.request = (...args) => {
+    const response = origHttpsRequest(...(args as Parameters<typeof origHttpsRequest>));
+    response.on('response', res => {
+        res.on('data', (data: Buffer) => (bytes += data.byteLength));
+    });
+    return response;
+};
+
+const origHttpRequest = http.request;
+http.request = (...args) => {
+    const response = origHttpRequest(...(args as Parameters<typeof origHttpRequest>));
+    response.on('response', res => {
+        res.on('data', (data: Buffer) => (bytes += data.byteLength));
+    });
+    return response;
+};
+
+const log = (hash: string, compressed: number, uncompressed: number) => {
+    console.log(`${hash}\t${compressed}\t${uncompressed}`);
+};
+
+const filtersFromWasabi = async (hash: string) => {
+    bytes = 0;
+    const response = await fetch(
+        `${WASABI_URL}/api/v4/btc/Blockchain/filters?bestKnownBlockHash=${hash}&count=${batchSize}`,
+        {
+            agent,
+            method: 'GET',
+            headers: {
+                'Content-Type': 'application/json; charset=utf-8',
+                'Accept-Encoding': 'br',
+                'Allowed-Headers': 'Accept-Encoding;Content-Type;Content-Length;Host',
+            },
+        },
+    );
+
+    if (response.status === 204) return [];
+    if (response.status === 200) {
+        const buffer = await response.buffer();
+        const { filters }: { filters: string[] } = JSON.parse(buffer.toString());
+        log(hash, bytes, buffer.byteLength);
+        return filters.map(data => {
+            const [_blockHeight, blockHash, _filter, _prevHash, _blockTime] = data.split(':');
+            return blockHash;
+        });
+    }
+    throw new Error(`${response.status} ${response.statusText}`);
+};
+
+const getWebsocket = async () => {
+    const ws = new WebSocket(BLOCKBOOK_URL, {
+        agent,
+        perMessageDeflate: true,
+        headers: {
+            Origin: 'https://node.trezor.io',
+            'User-Agent': 'Trezor Suite',
+        },
+    });
+
+    await new Promise<void>((resolve, reject) => {
+        const timeout = setTimeout(() => reject(new Error('timeout')), TIMEOUT);
+        ws.once('error', error => reject(error));
+        ws.once('open', () => {
+            clearTimeout(timeout);
+            ws.removeAllListeners();
+            resolve();
+        });
+    });
+
+    let compressed = 0;
+
+    // eslint-disable-next-line no-underscore-dangle
+    (ws as any)._socket.on('data', (chunk: Buffer) => (compressed += chunk.byteLength));
+
+    let messageID = 0;
+
+    return (bestKnownBlockHash: string) => {
+        compressed = 0;
+        const reqID = (messageID++).toString();
+        return new Promise<string[]>((resolve, reject) => {
+            const timeout = setTimeout(() => reject(new Error('timeout')), TIMEOUT);
+            ws.once('message', (message: string) => {
+                log(bestKnownBlockHash, compressed, message.length);
+                clearTimeout(timeout);
+                const resp = JSON.parse(message);
+                const {
+                    id,
+                    data: { error, blockFiltersBatch },
+                } = resp;
+                if (reqID !== id || error) {
+                    reject(new Error(`Error ${id} ${reqID} ${error.message}`));
+                } else {
+                    resolve(blockFiltersBatch.map((row: string) => row.split(':')[1]));
+                }
+            });
+            ws.send(
+                JSON.stringify({
+                    id: reqID,
+                    method: 'getBlockFiltersBatch',
+                    params: {
+                        bestKnownBlockHash,
+                        pageSize: batchSize,
+                        scriptType: 'taproot-noordinals',
+                    },
+                }),
+            );
+        });
+    };
+};
+
+(async () => {
+    stripHeaders();
+
+    console.log('✅', 'Start Wasabi benchmark');
+
+    console.time('Wasabi filters');
+
+    let batch = await filtersFromWasabi(bestKnownHash);
+    while (batch.length === batchSize) {
+        // eslint-disable-next-line no-await-in-loop
+        batch = await filtersFromWasabi(batch[batchSize - 1]);
+    }
+
+    console.timeEnd('Wasabi filters');
+
+    console.log('\n', '✅', 'Start Blockbook benchmark');
+
+    console.time('Blockbook filters');
+
+    const filtersFromBlockbook = await getWebsocket();
+
+    batch = await filtersFromBlockbook(bestKnownHash);
+    while (batch.length === batchSize) {
+        // eslint-disable-next-line no-await-in-loop
+        batch = await filtersFromBlockbook(batch[batchSize - 1]);
+    }
+
+    console.timeEnd('Blockbook filters');
+
+    console.log('✅', 'End');
+})();


### PR DESCRIPTION
## Description

Block filters needed for Coinjoin account discovery are now fetched from Blockbook instead of Wasabi backend, so 1) we aren't dependent on 3rd party for using CJ account (except mixing itself) and 2) the filters are much smaller (-> faster discovery) because 2a) block filters from Blockbook are taproot-only and 2b) don't include Ordinals transactions.

## Commits

- https://github.com/trezor/trezor-suite/pull/9266/commits/2c0e9bf5c184139ebdfd7ab21f6153b3f16424bf - types related to block filters are added to `@trezor/blockchain-link-types` **(must be updated after corresponding PR is merged in Blockbook repo)**
- https://github.com/trezor/trezor-suite/pull/9266/commits/5cc745d00b9363fe320c09a7f8b9a6cda52d662c - `getBlockFilter` and `getBlockFiltersBatch` methods added to `BlockbookAPI` in `@trezor/blockchain-link`
- https://github.com/trezor/trezor-suite/pull/9266/commits/ab43cb5e636e4d96bf4f880661a8a4a5992a2ce0 - adjust CJ discovery process to fetch filters from Blockbook instead of Wasabi
- https://github.com/trezor/trezor-suite/pull/9266/commits/090ae1b0adc3ba999c900c93f9e63952d3cde436 - unit tests adjusted to the previous commit
- https://github.com/trezor/trezor-suite/pull/9266/commits/cc76e0e16dbd75e2d7fd5f6f98e3573b9322ad31 - stop distinguishing between block filters and mempool filters as they're now used in the same way
- https://github.com/trezor/trezor-suite/pull/9266/commits/cbc1b739c5ce1e5f70b3f1e8e7d13f2781456cf8 - unit tests adjusted to the previous commit
- https://github.com/trezor/trezor-suite/pull/9266/commits/42a04a80059eed164194ba27dfffa9828ba3d986 - remove code related to fetching filters from Wasabi as it's irrelevant now
- https://github.com/trezor/trezor-suite/pull/9266/commits/5ce53579c0cb33232b5eac3b9a9506ca0e018e25 -  benchmarking utility.

Resolves https://github.com/trezor/trezor-suite/issues/8473