### PR TITLE
fix(suite-native): navigation receive icon

### DIFF
--- a/suite-common/icons/assets/icons/arrowDownLight.svg
+++ b/suite-common/icons/assets/icons/arrowDownLight.svg
@@ -1,0 +1,3 @@
+<svg fill="none" viewBox="0 0 25 24">
+  <path stroke="#999" stroke-linecap="round" stroke-linejoin="round" stroke-width="1.5" d="M12.75 3.75v16.5M6 13.5l6.75 6.75 6.75-6.75"/>
+</svg>

--- a/suite-common/icons/src/icons.ts
+++ b/suite-common/icons/src/icons.ts
@@ -8,6 +8,7 @@ export const icons = {
     action: require('../assets/icons/action.svg'),
     actionHorizontal: require('../assets/icons/actionHorizontal.svg'),
     arrowDown: require('../assets/icons/arrowDown.svg'),
+    arrowDownLight: require('../assets/icons/arrowDownLight.svg'),
     arrowURightDown: require('../assets/icons/arrowURightDown.svg'),
     arrowUp: require('../assets/icons/arrowUp.svg'),
     arrowUpRight: require('../assets/icons/arrowUpRight.svg'),

--- a/suite-native/app/src/navigation/routes.ts
+++ b/suite-native/app/src/navigation/routes.ts
@@ -20,7 +20,7 @@ const accountsStack = enhanceTabOption({
 const receiveStack = enhanceTabOption({
     routeName: AppTabsRoutes.ReceiveStack,
     label: 'Receive',
-    iconName: 'receive',
+    iconName: 'arrowDownLight',
 });
 
 const settingsStack = enhanceTabOption({


### PR DESCRIPTION
Replaces navigation receive tab icon to use light cut.

Closes #8584

Other icons were already fixed in PR #9213
