### PR TITLE
Disable "Reveal address" buttons for used addresses during discovery

### DIFF
--- a/packages/suite/src/views/wallet/receive/components/UsedAddresses.tsx
+++ b/packages/suite/src/views/wallet/receive/components/UsedAddresses.tsx
@@ -111,12 +111,13 @@ const DEFAULT_LIMIT = 10;
 interface ItemProps {
     index: number;
     addr: AccountAddress;
+    locked: boolean;
     symbol: Network['symbol'];
     metadataPayload: MetadataAddPayload;
     onClick: () => void;
 }
 
-const Item = ({ addr, symbol, onClick, metadataPayload, index }: ItemProps) => {
+const Item = ({ addr, locked, symbol, onClick, metadataPayload, index }: ItemProps) => {
     // Currently used addresses are always partially hidden
     // The only place where full address is shown is confirm-addr modal
     const [isHovered, setIsHovered] = React.useState(false);
@@ -166,6 +167,8 @@ const Item = ({ addr, symbol, onClick, metadataPayload, index }: ItemProps) => {
                     <Button
                         data-test={`@wallet/receive/reveal-address-button/${index}`}
                         variant="tertiary"
+                        disabled={locked}
+                        isLoading={locked}
                         onClick={onClick}
                     >
                         <Translation id="TR_REVEAL_ADDRESS" />
@@ -242,15 +245,14 @@ export const UsedAddresses = ({
                         key={addr.path}
                         addr={addr}
                         symbol={account.symbol}
+                        locked={locked}
                         metadataPayload={{
                             type: 'addressLabel',
                             accountKey: account.key,
                             defaultValue: addr.address,
                             value: addressLabels[addr.address],
                         }}
-                        onClick={() =>
-                            !locked ? dispatch(showAddress(addr.path, addr.address)) : undefined
-                        }
+                        onClick={() => dispatch(showAddress(addr.path, addr.address))}
                     />
                 ))}
             </GridTable>


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->
No functional change, but the buttons are now visually disabled the same way as the "Show full address" button.

## Screenshots:
### before:

https://github.com/trezor/trezor-suite/assets/42465546/9d1601e6-0c5a-4bf3-bda4-3d10effa0ba5

### after:

https://github.com/trezor/trezor-suite/assets/42465546/32f27e81-0be4-40f3-8a96-6fed4fa6a7e7

