### PR TITLE
fix: disable metadata enable for empty/bootloader devices

### DIFF
--- a/packages/suite/src/views/settings/general/Labeling.tsx
+++ b/packages/suite/src/views/settings/general/Labeling.tsx
@@ -40,7 +40,7 @@ export const Labeling = () => {
     // - Labeling enabled without any device connected
     // - Labeling enabled with the device connected inside Settings
     // The initialization of Labeling then start when user select a Wallet.
-    const isDisabled = !!device && !metadata.enabled && isLocked();
+    const isDisabled = (!!device && !metadata.enabled && isLocked()) || device?.mode !== 'normal';
 
     return (
         <SectionItem


### PR DESCRIPTION
When doing #9130 I accidentally discovered a little bug. When you get into application settings with device which is not initialized, it is still possible to click "enable labeling". This feature however requires call to device which is not possible for such device. As a quick fix I suggest disabling this button as this action would fail anyway. 