### PR TITLE
chore(connect-common): remove blockchain_link field from co…

### DIFF
--- a/packages/connect-common/files/blockchain-link.json
+++ b/packages/connect-common/files/blockchain-link.json
@@ -1,0 +1,133 @@
+{
+    "BTC": {
+        "type": "blockbook",
+        "url": [
+            "https://btc1.trezor.io",
+            "https://btc2.trezor.io",
+            "https://btc3.trezor.io",
+            "https://btc4.trezor.io",
+            "https://btc5.trezor.io"
+        ]
+    },
+    "TEST": {
+        "type": "blockbook",
+        "url": ["https://tbtc1.trezor.io", "https://tbtc2.trezor.io"]
+    },
+    "BCH": {
+        "type": "blockbook",
+        "url": [
+            "https://bch1.trezor.io",
+            "https://bch2.trezor.io",
+            "https://bch3.trezor.io",
+            "https://bch4.trezor.io",
+            "https://bch5.trezor.io"
+        ]
+    },
+    "BTG": {
+        "type": "blockbook",
+        "url": [
+            "https://btg1.trezor.io",
+            "https://btg2.trezor.io",
+            "https://btg3.trezor.io",
+            "https://btg4.trezor.io",
+            "https://btg5.trezor.io"
+        ]
+    },
+    "DASH": {
+        "type": "blockbook",
+        "url": [
+            "https://dash1.trezor.io",
+            "https://dash2.trezor.io",
+            "https://dash3.trezor.io",
+            "https://dash4.trezor.io",
+            "https://dash5.trezor.io"
+        ]
+    },
+    "DGB": {
+        "type": "blockbook",
+        "url": ["https://dgb1.trezor.io", "https://dgb2.trezor.io"]
+    },
+    "DOGE": {
+        "type": "blockbook",
+        "url": [
+            "https://doge1.trezor.io",
+            "https://doge2.trezor.io",
+            "https://doge3.trezor.io",
+            "https://doge4.trezor.io",
+            "https://doge5.trezor.io"
+        ]
+    },
+    "FJC": { "type": "blockbook", "url": ["https://explorer.fujicoin.org"] },
+    "LTC": {
+        "type": "blockbook",
+        "url": [
+            "https://ltc1.trezor.io",
+            "https://ltc2.trezor.io",
+            "https://ltc3.trezor.io",
+            "https://ltc4.trezor.io",
+            "https://ltc5.trezor.io"
+        ]
+    },
+    "MONA": { "type": "blockbook", "url": ["https://blockbook.electrum-mona.org"] },
+    "NMC": {
+        "type": "blockbook",
+        "url": ["https://nmc1.trezor.io", "https://nmc2.trezor.io"]
+    },
+    "PPC": { "type": "blockbook", "url": ["https://blockbook.peercoin.net"] },
+    "tPPC": { "type": "blockbook", "url": ["https://tblockbook.peercoin.net"] },
+    "RVN": { "type": "blockbook", "url": ["https://blockbook.ravencoin.org"] },
+    "RITO": { "type": "blockbook", "url": ["https://blockbook.ritocoin.org"] },
+    "SYS": { "type": "blockbook", "url": ["https://blockbook.elint.services"] },
+    "VTC": {
+        "type": "blockbook",
+        "url": [
+            "https://vtc1.trezor.io",
+            "https://vtc2.trezor.io",
+            "https://vtc3.trezor.io",
+            "https://vtc4.trezor.io",
+            "https://vtc5.trezor.io"
+        ]
+    },
+    "ZEC": {
+        "type": "blockbook",
+        "url": [
+            "https://zec1.trezor.io",
+            "https://zec2.trezor.io",
+            "https://zec3.trezor.io",
+            "https://zec4.trezor.io",
+            "https://zec5.trezor.io"
+        ]
+    },
+    "ADA": {
+        "type": "blockfrost",
+        "url": ["wss://trezor-cardano-mainnet.blockfrost.io"]
+    },
+    "tADA": {
+        "type": "blockfrost",
+        "url": ["wss://trezor-cardano-preview.blockfrost.io"]
+    },
+    "tXRP": {
+        "type": "ripple",
+        "url": ["wss://s.altnet.rippletest.net"]
+    },
+    "XRP": {
+        "type": "ripple",
+        "url": ["wss://s1.ripple.com", "wss://s-east.ripple.com", "wss://s-west.ripple.com"]
+    },
+    "ETH": {
+        "type": "blockbook",
+        "url": ["https://eth1.trezor.io", "https://eth2.trezor.io"]
+    },
+    "tSEP:11155111": {
+        "type": "blockbook",
+        "url": ["https://sepolia1.trezor.io"]
+    },
+    "tGOR:5": {
+        "type": "blockbook",
+        "url": ["https://goerli1.trezor.io", "https://goerli2.trezor.io"]
+    },
+    "ETC": {
+        "type": "blockbook",
+        "url": ["https://etc1.trezor.io", "https://etc2.trezor.io"]
+    }
+}

--- a/packages/connect-common/files/coins-eth.json
+++ b/packages/connect-common/files/coins-eth.json
@@ -1,9 +1,5 @@
 [
     {
-        "blockchain_link": {
-            "type": "blockbook",
-            "url": ["https://eth1.trezor.io", "https://eth2.trezor.io"]
-        },
         "chain": "eth",
         "chain_id": 1,
         "name": "Ethereum",
@@ -16,60 +12,5 @@
             "trezor2": "2.0.7"
         },
         "url": "https://ethereum.org"
-    },
-    {
-        "blockchain_link": {
-            "type": "blockbook",
-            "url": ["https://sepolia1.trezor.io"]
-        },
-        "chain": "sep",
-        "chain_id": 11155111,
-        "name": "Sepolia",
-        "rskip60": false,
-        "shortcut": "tSEP",
-        "slip44": 1,
-        "support": {
-            "connect": true,
-            "suite": false,
-            "trezor1": "1.11.2",
-            "trezor2": "2.5.2"
-        },
-        "url": "https://sepolia.otterscan.io"
-    },
-    {
-        "blockchain_link": {
-            "type": "blockbook",
-            "url": ["https://goerli1.trezor.io", "https://goerli2.trezor.io"]
-        },
-        "chain": "gor",
-        "chain_id": 5,
-        "name": "G\u00f6rli",
-        "shortcut": "tGOR",
-        "slip44": 1,
-        "support": {
-            "connect": true,
-            "suite": false,
-            "trezor1": "1.11.2",
-            "trezor2": "2.5.2"
-        },
-        "url": "https://goerli.net/#about"
-    },
-    {
-        "blockchain_link": {
-            "type": "blockbook",
-            "url": ["https://etc1.trezor.io", "https://etc2.trezor.io"]
-        },
-        "chain": "etc",
-        "chain_id": 61,
-        "name": "Ethereum Classic",
-        "shortcut": "ETC",
-        "slip44": 61,
-        "support": {
-            "connect": true,
-            "suite": true,
-            "trezor1": "1.6.2",
-            "trezor2": "2.0.7"
-        },
-        "url": "https://ethereumclassic.org"
     }
 ]

--- a/packages/connect-common/files/coins.json
+++ b/packages/connect-common/files/coins.json
@@ -4,16 +4,7 @@
             "address_type": 0,
             "address_type_p2sh": 5,
             "bech32_prefix": "bc",
-            "blockchain_link": {
-                "type": "blockbook",
-                "url": [
-                    "https://btc1.trezor.io",
-                    "https://btc2.trezor.io",
-                    "https://btc3.trezor.io",
-                    "https://btc4.trezor.io",
-                    "https://btc5.trezor.io"
-                ]
-            },
+
             "blocktime_seconds": 600,
             "cashaddr_prefix": null,
             "coin_label": "Bitcoin",
@@ -63,7 +54,7 @@
             "address_type": 111,
             "address_type_p2sh": 196,
             "bech32_prefix": "bcrt",
-            "blockchain_link": null,
+
             "blocktime_seconds": 600,
             "cashaddr_prefix": null,
             "coin_label": "Regtest",
@@ -110,10 +101,6 @@
             "address_type": 111,
             "address_type_p2sh": 196,
             "bech32_prefix": "tb",
-            "blockchain_link": {
-                "type": "blockbook",
-                "url": ["https://tbtc1.trezor.io", "https://tbtc2.trezor.io"]
-            },
             "blocktime_seconds": 600,
             "cashaddr_prefix": null,
             "coin_label": "Testnet",
@@ -160,7 +147,7 @@
             "address_type": 53,
             "address_type_p2sh": 55,
             "bech32_prefix": "acm",
-            "blockchain_link": null,
+
             "blocktime_seconds": 150,
             "cashaddr_prefix": null,
             "coin_label": "Actinium",
@@ -207,7 +194,7 @@
             "address_type": 55,
             "address_type_p2sh": 16,
             "bech32_prefix": null,
-            "blockchain_link": null,
+
             "blocktime_seconds": 150,
             "cashaddr_prefix": null,
             "coin_label": "Axe",
@@ -254,16 +241,6 @@
             "address_type": 0,
             "address_type_p2sh": 5,
             "bech32_prefix": null,
-            "blockchain_link": {
-                "type": "blockbook",
-                "url": [
-                    "https://bch1.trezor.io",
-                    "https://bch2.trezor.io",
-                    "https://bch3.trezor.io",
-                    "https://bch4.trezor.io",
-                    "https://bch5.trezor.io"
-                ]
-            },
             "blocktime_seconds": 600,
             "cashaddr_prefix": "bitcoincash",
             "coin_label": "Bitcoin Cash",
@@ -310,7 +287,7 @@
             "address_type": 111,
             "address_type_p2sh": 196,
             "bech32_prefix": null,
-            "blockchain_link": null,
+
             "blocktime_seconds": 600,
             "cashaddr_prefix": "bchtest",
             "coin_label": "Bitcoin Cash Testnet",
@@ -357,16 +334,6 @@
             "address_type": 38,
             "address_type_p2sh": 23,
             "bech32_prefix": "btg",
-            "blockchain_link": {
-                "type": "blockbook",
-                "url": [
-                    "https://btg1.trezor.io",
-                    "https://btg2.trezor.io",
-                    "https://btg3.trezor.io",
-                    "https://btg4.trezor.io",
-                    "https://btg5.trezor.io"
-                ]
-            },
             "blocktime_seconds": 600,
             "cashaddr_prefix": null,
             "coin_label": "Bitcoin Gold",
@@ -413,7 +380,7 @@
             "address_type": 111,
             "address_type_p2sh": 196,
             "bech32_prefix": "tbtg",
-            "blockchain_link": null,
+
             "blocktime_seconds": 600,
             "cashaddr_prefix": null,
             "coin_label": "Bitcoin Gold Testnet",
@@ -463,7 +430,7 @@
             "address_type": 4901,
             "address_type_p2sh": 5039,
             "bech32_prefix": null,
-            "blockchain_link": null,
+
             "blocktime_seconds": 150,
             "cashaddr_prefix": null,
             "coin_label": "Bitcoin Private",
@@ -510,7 +477,7 @@
             "address_type": 3,
             "address_type_p2sh": 125,
             "bech32_prefix": "btx",
-            "blockchain_link": null,
+
             "blocktime_seconds": 150,
             "cashaddr_prefix": null,
             "coin_label": "Bitcore",
@@ -557,16 +524,6 @@
             "address_type": 76,
             "address_type_p2sh": 16,
             "bech32_prefix": null,
-            "blockchain_link": {
-                "type": "blockbook",
-                "url": [
-                    "https://dash1.trezor.io",
-                    "https://dash2.trezor.io",
-                    "https://dash3.trezor.io",
-                    "https://dash4.trezor.io",
-                    "https://dash5.trezor.io"
-                ]
-            },
             "blocktime_seconds": 150,
             "cashaddr_prefix": null,
             "coin_label": "Dash",
@@ -613,7 +570,7 @@
             "address_type": 140,
             "address_type_p2sh": 19,
             "bech32_prefix": null,
-            "blockchain_link": null,
+
             "blocktime_seconds": 150,
             "cashaddr_prefix": null,
             "coin_label": "Dash Testnet",
@@ -660,7 +617,7 @@
             "address_type": 1855,
             "address_type_p2sh": 1818,
             "bech32_prefix": null,
-            "blockchain_link": null,
+
             "blocktime_seconds": 300,
             "cashaddr_prefix": null,
             "coin_label": "Decred",
@@ -707,7 +664,7 @@
             "address_type": 3873,
             "address_type_p2sh": 3836,
             "bech32_prefix": null,
-            "blockchain_link": null,
+
             "blocktime_seconds": 120,
             "cashaddr_prefix": null,
             "coin_label": "Decred Testnet",
@@ -754,10 +711,6 @@
             "address_type": 30,
             "address_type_p2sh": 63,
             "bech32_prefix": "dgb",
-            "blockchain_link": {
-                "type": "blockbook",
-                "url": ["https://dgb1.trezor.io", "https://dgb2.trezor.io"]
-            },
             "blocktime_seconds": 15,
             "cashaddr_prefix": null,
             "coin_label": "DigiByte",
@@ -804,16 +757,6 @@
             "address_type": 30,
             "address_type_p2sh": 22,
             "bech32_prefix": null,
-            "blockchain_link": {
-                "type": "blockbook",
-                "url": [
-                    "https://doge1.trezor.io",
-                    "https://doge2.trezor.io",
-                    "https://doge3.trezor.io",
-                    "https://doge4.trezor.io",
-                    "https://doge5.trezor.io"
-                ]
-            },
             "blocktime_seconds": 60,
             "cashaddr_prefix": null,
             "coin_label": "Dogecoin",
@@ -860,7 +803,7 @@
             "address_type": 14,
             "address_type_p2sh": 5,
             "bech32_prefix": "fc",
-            "blockchain_link": null,
+
             "blocktime_seconds": 60,
             "cashaddr_prefix": null,
             "coin_label": "Feathercoin",
@@ -907,7 +850,7 @@
             "address_type": 82,
             "address_type_p2sh": 7,
             "bech32_prefix": null,
-            "blockchain_link": null,
+
             "blocktime_seconds": 600,
             "cashaddr_prefix": null,
             "coin_label": "Firo",
@@ -957,7 +900,7 @@
             "address_type": 65,
             "address_type_p2sh": 178,
             "bech32_prefix": null,
-            "blockchain_link": null,
+
             "blocktime_seconds": 600,
             "cashaddr_prefix": null,
             "coin_label": "Firo Testnet",
@@ -1007,7 +950,7 @@
             "address_type": 35,
             "address_type_p2sh": 94,
             "bech32_prefix": "flo",
-            "blockchain_link": null,
+
             "blocktime_seconds": 40,
             "cashaddr_prefix": null,
             "coin_label": "Flo",
@@ -1054,10 +997,6 @@
             "address_type": 36,
             "address_type_p2sh": 16,
             "bech32_prefix": "fc",
-            "blockchain_link": {
-                "type": "blockbook",
-                "url": ["https://explorer.fujicoin.org"]
-            },
             "blocktime_seconds": 60,
             "cashaddr_prefix": null,
             "coin_label": "Fujicoin",
@@ -1107,7 +1046,7 @@
             "address_type": 60,
             "address_type_p2sh": 85,
             "bech32_prefix": null,
-            "blockchain_link": null,
+
             "blocktime_seconds": 60,
             "cashaddr_prefix": null,
             "coin_label": "Komodo",
@@ -1154,7 +1093,7 @@
             "address_type": 6198,
             "address_type_p2sh": 6203,
             "bech32_prefix": null,
-            "blockchain_link": null,
+
             "blocktime_seconds": 60,
             "cashaddr_prefix": null,
             "coin_label": "Koto",
@@ -1201,16 +1140,6 @@
             "address_type": 48,
             "address_type_p2sh": 50,
             "bech32_prefix": "ltc",
-            "blockchain_link": {
-                "type": "blockbook",
-                "url": [
-                    "https://ltc1.trezor.io",
-                    "https://ltc2.trezor.io",
-                    "https://ltc3.trezor.io",
-                    "https://ltc4.trezor.io",
-                    "https://ltc5.trezor.io"
-                ]
-            },
             "blocktime_seconds": 150,
             "cashaddr_prefix": null,
             "coin_label": "Litecoin",
@@ -1257,7 +1186,7 @@
             "address_type": 111,
             "address_type_p2sh": 58,
             "bech32_prefix": "tltc",
-            "blockchain_link": null,
+
             "blocktime_seconds": 150,
             "cashaddr_prefix": null,
             "coin_label": "Litecoin Testnet",
@@ -1304,10 +1233,6 @@
             "address_type": 50,
             "address_type_p2sh": 55,
             "bech32_prefix": "mona",
-            "blockchain_link": {
-                "type": "blockbook",
-                "url": ["https://blockbook.electrum-mona.org"]
-            },
             "blocktime_seconds": 90,
             "cashaddr_prefix": null,
             "coin_label": "Monacoin",
@@ -1354,10 +1279,6 @@
             "address_type": 52,
             "address_type_p2sh": 5,
             "bech32_prefix": null,
-            "blockchain_link": {
-                "type": "blockbook",
-                "url": ["https://nmc1.trezor.io", "https://nmc2.trezor.io"]
-            },
             "blocktime_seconds": 600,
             "cashaddr_prefix": null,
             "coin_label": "Namecoin",
@@ -1404,10 +1325,6 @@
             "address_type": 55,
             "address_type_p2sh": 117,
             "bech32_prefix": "pc",
-            "blockchain_link": {
-                "type": "blockbook",
-                "url": ["https://blockbook.peercoin.net"]
-            },
             "blocktime_seconds": 600,
             "cashaddr_prefix": null,
             "coin_label": "Peercoin",
@@ -1454,10 +1371,6 @@
             "address_type": 111,
             "address_type_p2sh": 196,
             "bech32_prefix": "tpc",
-            "blockchain_link": {
-                "type": "blockbook",
-                "url": ["https://tblockbook.peercoin.net"]
-            },
             "blocktime_seconds": 600,
             "cashaddr_prefix": null,
             "coin_label": "Peercoin Testnet",
@@ -1504,7 +1417,7 @@
             "address_type": 23,
             "address_type_p2sh": 83,
             "bech32_prefix": null,
-            "blockchain_link": null,
+
             "blocktime_seconds": 60,
             "cashaddr_prefix": null,
             "coin_label": "Primecoin",
@@ -1551,10 +1464,6 @@
             "address_type": 60,
             "address_type_p2sh": 122,
             "bech32_prefix": null,
-            "blockchain_link": {
-                "type": "blockbook",
-                "url": ["https://blockbook.ravencoin.org"]
-            },
             "blocktime_seconds": 60,
             "cashaddr_prefix": null,
             "coin_label": "Ravencoin",
@@ -1601,10 +1510,6 @@
             "address_type": 25,
             "address_type_p2sh": 105,
             "bech32_prefix": null,
-            "blockchain_link": {
-                "type": "blockbook",
-                "url": ["https://blockbook.ritocoin.org"]
-            },
             "blocktime_seconds": 60,
             "cashaddr_prefix": null,
             "coin_label": "Ritocoin",
@@ -1651,7 +1556,7 @@
             "address_type": 76,
             "address_type_p2sh": 16,
             "bech32_prefix": "xc",
-            "blockchain_link": null,
+
             "blocktime_seconds": 60,
             "cashaddr_prefix": null,
             "coin_label": "Stakenet",
@@ -1701,10 +1606,6 @@
             "address_type": 63,
             "address_type_p2sh": 5,
             "bech32_prefix": "sys",
-            "blockchain_link": {
-                "type": "blockbook",
-                "url": ["https://blockbook.elint.services"]
-            },
             "blocktime_seconds": 60,
             "cashaddr_prefix": null,
             "coin_label": "Syscoin",
@@ -1754,7 +1655,7 @@
             "address_type": 130,
             "address_type_p2sh": 30,
             "bech32_prefix": null,
-            "blockchain_link": null,
+
             "blocktime_seconds": 30,
             "cashaddr_prefix": null,
             "coin_label": "Unobtanium",
@@ -1804,7 +1705,7 @@
             "address_type": 30,
             "address_type_p2sh": 33,
             "bech32_prefix": null,
-            "blockchain_link": null,
+
             "blocktime_seconds": 30,
             "cashaddr_prefix": null,
             "coin_label": "Verge",
@@ -1851,16 +1752,6 @@
             "address_type": 71,
             "address_type_p2sh": 5,
             "bech32_prefix": "vtc",
-            "blockchain_link": {
-                "type": "blockbook",
-                "url": [
-                    "https://vtc1.trezor.io",
-                    "https://vtc2.trezor.io",
-                    "https://vtc3.trezor.io",
-                    "https://vtc4.trezor.io",
-                    "https://vtc5.trezor.io"
-                ]
-            },
             "blocktime_seconds": 150,
             "cashaddr_prefix": null,
             "coin_label": "Vertcoin",
@@ -1907,7 +1798,7 @@
             "address_type": 71,
             "address_type_p2sh": 33,
             "bech32_prefix": "via",
-            "blockchain_link": null,
+
             "blocktime_seconds": 24,
             "cashaddr_prefix": null,
             "coin_label": "Viacoin",
@@ -1957,7 +1848,7 @@
             "address_type": 142,
             "address_type_p2sh": 145,
             "bech32_prefix": null,
-            "blockchain_link": null,
+
             "blocktime_seconds": 120,
             "cashaddr_prefix": null,
             "coin_label": "ZCore",
@@ -2004,16 +1895,6 @@
             "address_type": 7352,
             "address_type_p2sh": 7357,
             "bech32_prefix": null,
-            "blockchain_link": {
-                "type": "blockbook",
-                "url": [
-                    "https://zec1.trezor.io",
-                    "https://zec2.trezor.io",
-                    "https://zec3.trezor.io",
-                    "https://zec4.trezor.io",
-                    "https://zec5.trezor.io"
-                ]
-            },
             "blocktime_seconds": 150,
             "cashaddr_prefix": null,
             "coin_label": "Zcash",
@@ -2060,7 +1941,7 @@
             "address_type": 7461,
             "address_type_p2sh": 7354,
             "bech32_prefix": null,
-            "blockchain_link": null,
+
             "blocktime_seconds": 150,
             "cashaddr_prefix": null,
             "coin_label": "Zcash Testnet",
@@ -2107,7 +1988,7 @@
             "address_type": 61,
             "address_type_p2sh": 123,
             "bech32_prefix": null,
-            "blockchain_link": null,
+
             "blocktime_seconds": 600,
             "cashaddr_prefix": null,
             "coin_label": "xRhodium",
@@ -2156,10 +2037,6 @@
     ],
     "misc": [
         {
-            "blockchain_link": {
-                "type": "blockfrost",
-                "url": ["wss://trezor-cardano-mainnet.blockfrost.io"]
-            },
             "curve": "ed25519",
             "decimals": 6,
             "is_testnet": false,
@@ -2174,7 +2051,6 @@
             }
         },
         {
-            "blockchain_link": null,
             "curve": "secp256k1",
             "decimals": 8,
             "is_testnet": false,
@@ -2189,7 +2065,6 @@
             }
         },
         {
-            "blockchain_link": null,
             "curve": "secp256k1",
             "decimals": 4,
             "is_testnet": false,
@@ -2204,10 +2079,6 @@
             }
         },
         {
-            "blockchain_link": {
-                "type": "blockfrost",
-                "url": ["wss://trezor-cardano-preview.blockfrost.io"]
-            },
             "curve": "ed25519",
             "decimals": 6,
             "is_testnet": false,
@@ -2222,10 +2093,6 @@
             }
         },
         {
-            "blockchain_link": {
-                "type": "ripple",
-                "url": ["wss://s.altnet.rippletest.net"]
-            },
             "curve": "secp256k1",
             "decimals": 6,
             "is_testnet": false,
@@ -2240,7 +2107,6 @@
             }
         },
         {
-            "blockchain_link": null,
             "curve": "ed25519",
             "decimals": 7,
             "is_testnet": false,
@@ -2255,10 +2121,6 @@
             }
         },
         {
-            "blockchain_link": {
-                "type": "ripple",
-                "url": ["wss://s1.ripple.com", "wss://s-east.ripple.com", "wss://s-west.ripple.com"]
-            },
             "curve": "secp256k1",
             "decimals": 6,
             "is_testnet": false,
@@ -2273,7 +2135,6 @@
             }
         },
         {
-            "blockchain_link": null,
             "curve": "ed25519",
             "decimals": 6,
             "is_testnet": false,
@@ -2290,7 +2151,6 @@
     ],
     "nem": [
         {
-            "blockchain_link": null,
             "divisibility": 6,
             "is_testnet": false,
             "mosaic": "xem",
@@ -2306,7 +2166,6 @@
             "ticker": "XEM"
         },
         {
-            "blockchain_link": null,
             "divisibility": 6,
             "fee": 10,
             "is_testnet": false,
@@ -2327,7 +2186,6 @@
             "ticker": "DIM"
         },
         {
-            "blockchain_link": null,
             "divisibility": 6,
             "is_testnet": false,
             "mosaic": "token",
@@ -2344,7 +2202,6 @@
             "ticker": "DIMTOK"
         },
         {
-            "blockchain_link": null,
             "divisibility": 0,
             "is_testnet": false,
             "mosaic": "breeze-token",
@@ -2361,7 +2218,6 @@
             "ticker": "BREEZE"
         },
         {
-            "blockchain_link": null,
             "divisibility": 0,
             "is_testnet": false,
             "mosaic": "heart",
@@ -2378,7 +2234,6 @@
             "ticker": "PAC:HRT"
         },
         {
-            "blockchain_link": null,
             "divisibility": 6,
             "fee": 100,
             "is_testnet": false,

--- a/packages/connect-iframe/src/index.ts
+++ b/packages/connect-iframe/src/index.ts
@@ -87,7 +87,7 @@ const handleMessage = (event: PostMessageEvent) => {
         }
 
         const method = _core.getCurrentMethod()[0];
-        (method.initAsync ? method?.initAsync() : Promise.resolve()).finally(() => {
+        method.init().finally(() => {
             const transport = _core!.getTransportInfo();
             const settings = DataManager.getSettings();
 
@@ -95,7 +95,7 @@ const handleMessage = (event: PostMessageEvent) => {
                 createPopupMessage(POPUP.HANDSHAKE, {
                     settings: DataManager.getSettings(),
                     transport,
-                    method: method ? method.info : undefined, // method.info might change based on initAsync
+                    method: method ? method.info : undefined, // method.info might change based on method.init
                 }),
             );
 

--- a/packages/connect/src/api/applyFlags.ts
+++ b/packages/connect/src/api/applyFlags.ts
@@ -6,7 +6,7 @@ import { UI, createUiMessage } from '../events';
 import type { PROTO } from '../constants';
 
 export default class ApplyFlags extends AbstractMethod<'applyFlags', PROTO.ApplyFlags> {
-    init() {
+    async init() {
         this.requiredPermissions = ['management'];
         this.useDeviceState = false;
 

--- a/packages/connect/src/api/applySettings.ts
+++ b/packages/connect/src/api/applySettings.ts
@@ -6,7 +6,7 @@ import { validateParams } from './common/paramsValidator';
 import type { PROTO } from '../constants';
 
 export default class ApplySettings extends AbstractMethod<'applySettings', PROTO.ApplySettings> {
-    init() {
+    async init() {
         this.requiredPermissions = ['management'];
         this.useDeviceState = false;
         const { payload } = this;

--- a/packages/connect/src/api/authorizeCoinjoin.ts
+++ b/packages/connect/src/api/authorizeCoinjoin.ts
@@ -8,7 +8,7 @@ export default class AuthorizeCoinjoin extends AbstractMethod<
     'authorizeCoinjoin',
     PROTO.AuthorizeCoinJoin
 > {
-    init() {
+    async init() {
         const { payload } = this;
 
         validateParams(payload, [

--- a/packages/connect/src/api/backupDevice.ts
+++ b/packages/connect/src/api/backupDevice.ts
@@ -4,7 +4,7 @@ import { AbstractMethod } from '../core/AbstractMethod';
 import { UI, createUiMessage } from '../events';
 
 export default class BackupDevice extends AbstractMethod<'backupDevice'> {
-    init() {
+    async init() {
         this.requiredPermissions = ['management'];
         this.useDeviceState = false;
     }

--- a/packages/connect/src/api/binanceGetAddress.ts
+++ b/packages/connect/src/api/binanceGetAddress.ts
@@ -16,7 +16,7 @@ export default class BinanceGetAddress extends AbstractMethod<'binanceGetAddress
     progress = 0;
     confirmed?: boolean;
 
-    init() {
+    async init() {
         this.requiredPermissions = ['read'];
         this.firmwareRange = getFirmwareRange(this.name, getMiscNetwork('BNB'), this.firmwareRange);
 

--- a/packages/connect/src/api/binanceGetPublicKey.ts
+++ b/packages/connect/src/api/binanceGetPublicKey.ts
@@ -14,7 +14,7 @@ export default class BinanceGetPublicKey extends AbstractMethod<
     hasBundle?: boolean;
     confirmed?: boolean;
 
-    init() {
+    async init() {
         this.requiredPermissions = ['read'];
         this.firmwareRange = getFirmwareRange(this.name, getMiscNetwork('BNB'), this.firmwareRange);
 

--- a/packages/connect/src/api/binanceSignTransaction.ts
+++ b/packages/connect/src/api/binanceSignTransaction.ts
@@ -17,7 +17,7 @@ export default class BinanceSignTransaction extends AbstractMethod<
     'binanceSignTransaction',
     Params
 > {
-    init() {
+    async init() {
         this.requiredPermissions = ['read', 'write'];
         this.firmwareRange = getFirmwareRange(this.name, getMiscNetwork('BNB'), this.firmwareRange);
 

--- a/packages/connect/src/api/bitcoin/__tests__/Fees.test.ts
+++ b/packages/connect/src/api/bitcoin/__tests__/Fees.test.ts
@@ -1,5 +1,6 @@
 import coinsJSON from '@trezor/connect-common/files/coins.json';
 import ethereumCoinsJSON from '@trezor/connect-common/files/coins-eth.json';
+import blockchainLinkJSON from '@trezor/connect-common/files/blockchain-link.json';
 import BlockchainLink from '@trezor/blockchain-link';
 import { parseCoinsJson, getBitcoinNetwork } from '../../../data/coinInfo';
 import { initBlockchain } from '../../../backend/BlockchainLink';
@@ -39,7 +40,7 @@ jest.mock('@trezor/blockchain-link', () => ({
 
 describe('api/bitcoin/Fees', () => {
     // load coin definitions
-    parseCoinsJson({ ...coinsJSON, eth: ethereumCoinsJSON });
+    parseCoinsJson({ ...coinsJSON, eth: ethereumCoinsJSON }, blockchainLinkJSON);
 
     it('Bitcoin smart FeeLevels exact match', async () => {
         const coinInfo = getBitcoinNetwork('Bitcoin');

--- a/packages/connect/src/api/blockchainDisconnect.ts
+++ b/packages/connect/src/api/blockchainDisconnect.ts
@@ -12,7 +12,7 @@ type Params = {
 };
 
 export default class BlockchainDisconnect extends AbstractMethod<'blockchainDisconnect', Params> {
-    init() {
+    async init() {
         this.requiredPermissions = [];
         this.useDevice = false;
         this.useUi = false;

--- a/packages/connect/src/api/blockchainDisconnect.ts
+++ b/packages/connect/src/api/blockchainDisconnect.ts
@@ -22,7 +22,7 @@ export default class BlockchainDisconnect extends AbstractMethod<'blockchainDisc
         // validate incoming parameters
         validateParams(payload, [{ name: 'coin', type: 'string', required: true }]);
 
-        const coinInfo = getCoinInfo(payload.coin);
+        const coinInfo = await getCoinInfo(payload.coin);
         if (!coinInfo) {
             throw ERRORS.TypedError('Method_UnknownCoin');
         }

--- a/packages/connect/src/api/blockchainEstimateFee.ts
+++ b/packages/connect/src/api/blockchainEstimateFee.ts
@@ -44,7 +44,7 @@ export default class BlockchainEstimateFee extends AbstractMethod<'blockchainEst
                 ]);
             }
         }
-        const coinInfo = getCoinInfo(payload.coin);
+        const coinInfo = await getCoinInfo(payload.coin);
 
         if (!coinInfo) {
             throw ERRORS.TypedError('Method_UnknownCoin');

--- a/packages/connect/src/api/blockchainEstimateFee.ts
+++ b/packages/connect/src/api/blockchainEstimateFee.ts
@@ -14,7 +14,7 @@ type Params = {
 };
 
 export default class BlockchainEstimateFee extends AbstractMethod<'blockchainEstimateFee', Params> {
-    init() {
+    async init() {
         this.useDevice = false;
         this.useUi = false;
 

--- a/packages/connect/src/api/blockchainGetAccountBalanceHistory.ts
+++ b/packages/connect/src/api/blockchainGetAccountBalanceHistory.ts
@@ -31,7 +31,7 @@ export default class BlockchainGetAccountBalanceHistory extends AbstractMethod<
             { name: 'groupBy', type: 'number' },
         ]);
 
-        const coinInfo = getCoinInfo(payload.coin);
+        const coinInfo = await getCoinInfo(payload.coin);
         if (!coinInfo) {
             throw ERRORS.TypedError('Method_UnknownCoin');
         }

--- a/packages/connect/src/api/blockchainGetAccountBalanceHistory.ts
+++ b/packages/connect/src/api/blockchainGetAccountBalanceHistory.ts
@@ -16,7 +16,7 @@ export default class BlockchainGetAccountBalanceHistory extends AbstractMethod<
     'blockchainGetAccountBalanceHistory',
     Params
 > {
-    init() {
+    async init() {
         this.useDevice = false;
         this.useUi = false;
 

--- a/packages/connect/src/api/blockchainGetCurrentFiatRates.ts
+++ b/packages/connect/src/api/blockchainGetCurrentFiatRates.ts
@@ -30,7 +30,7 @@ export default class BlockchainGetCurrentFiatRates extends AbstractMethod<
             { name: 'coin', type: 'string', required: true },
         ]);
 
-        const coinInfo = getCoinInfo(payload.coin);
+        const coinInfo = await getCoinInfo(payload.coin);
         if (!coinInfo) {
             throw ERRORS.TypedError('Method_UnknownCoin');
         }

--- a/packages/connect/src/api/blockchainGetCurrentFiatRates.ts
+++ b/packages/connect/src/api/blockchainGetCurrentFiatRates.ts
@@ -17,7 +17,7 @@ export default class BlockchainGetCurrentFiatRates extends AbstractMethod<
     'blockchainGetCurrentFiatRates',
     Params
 > {
-    init() {
+    async init() {
         this.useDevice = false;
         this.useUi = false;
 

--- a/packages/connect/src/api/blockchainGetFiatRatesForTimestamps.ts
+++ b/packages/connect/src/api/blockchainGetFiatRatesForTimestamps.ts
@@ -32,7 +32,7 @@ export default class BlockchainGetFiatRatesForTimestamps extends AbstractMethod<
             { name: 'coin', type: 'string', required: true },
         ]);
 
-        const coinInfo = getCoinInfo(payload.coin);
+        const coinInfo = await getCoinInfo(payload.coin);
         if (!coinInfo) {
             throw ERRORS.TypedError('Method_UnknownCoin');
         }

--- a/packages/connect/src/api/blockchainGetFiatRatesForTimestamps.ts
+++ b/packages/connect/src/api/blockchainGetFiatRatesForTimestamps.ts
@@ -18,7 +18,7 @@ export default class BlockchainGetFiatRatesForTimestamps extends AbstractMethod<
     'blockchainGetFiatRatesForTimestamps',
     Params
 > {
-    init() {
+    async init() {
         this.useDevice = false;
         this.useUi = false;
 

--- a/packages/connect/src/api/blockchainGetTransactions.ts
+++ b/packages/connect/src/api/blockchainGetTransactions.ts
@@ -28,7 +28,7 @@ export default class BlockchainGetTransactions extends AbstractMethod<
             { name: 'coin', type: 'string', required: true },
         ]);
 
-        const coinInfo = getCoinInfo(payload.coin);
+        const coinInfo = await getCoinInfo(payload.coin);
         if (!coinInfo) {
             throw ERRORS.TypedError('Method_UnknownCoin');
         }

--- a/packages/connect/src/api/blockchainGetTransactions.ts
+++ b/packages/connect/src/api/blockchainGetTransactions.ts
@@ -16,7 +16,7 @@ export default class BlockchainGetTransactions extends AbstractMethod<
     'blockchainGetTransactions',
     Params
 > {
-    init() {
+    async init() {
         this.useDevice = false;
         this.useUi = false;
 

--- a/packages/connect/src/api/blockchainSetCustomBackend.ts
+++ b/packages/connect/src/api/blockchainSetCustomBackend.ts
@@ -28,7 +28,7 @@ export default class BlockchainSetCustomBackend extends AbstractMethod<
             { name: 'blockchainLink', type: 'object' },
         ]);
 
-        const coinInfo = getCoinInfo(payload.coin);
+        const coinInfo = await getCoinInfo(payload.coin);
         if (!coinInfo) {
             throw ERRORS.TypedError('Method_UnknownCoin');
         }

--- a/packages/connect/src/api/blockchainSetCustomBackend.ts
+++ b/packages/connect/src/api/blockchainSetCustomBackend.ts
@@ -15,7 +15,7 @@ export default class BlockchainSetCustomBackend extends AbstractMethod<
     'blockchainSetCustomBackend',
     Params
 > {
-    init() {
+    async init() {
         this.requiredPermissions = [];
         this.useDevice = false;
         this.useUi = false;

--- a/packages/connect/src/api/blockchainSubscribe.ts
+++ b/packages/connect/src/api/blockchainSubscribe.ts
@@ -13,7 +13,7 @@ type Params = {
 };
 
 export default class BlockchainSubscribe extends AbstractMethod<'blockchainSubscribe', Params> {
-    init() {
+    async init() {
         this.useDevice = false;
         this.useUi = false;
 

--- a/packages/connect/src/api/blockchainSubscribe.ts
+++ b/packages/connect/src/api/blockchainSubscribe.ts
@@ -31,7 +31,7 @@ export default class BlockchainSubscribe extends AbstractMethod<'blockchainSubsc
             });
         }
 
-        const coinInfo = getCoinInfo(payload.coin);
+        const coinInfo = await getCoinInfo(payload.coin);
         if (!coinInfo) {
             throw ERRORS.TypedError('Method_UnknownCoin');
         }

--- a/packages/connect/src/api/blockchainSubscribeFiatRates.ts
+++ b/packages/connect/src/api/blockchainSubscribeFiatRates.ts
@@ -16,7 +16,7 @@ export default class BlockchainSubscribeFiatRates extends AbstractMethod<
     'blockchainSubscribeFiatRates',
     Params
 > {
-    init() {
+    async init() {
         this.useDevice = false;
         this.useUi = false;
 

--- a/packages/connect/src/api/blockchainSubscribeFiatRates.ts
+++ b/packages/connect/src/api/blockchainSubscribeFiatRates.ts
@@ -28,7 +28,7 @@ export default class BlockchainSubscribeFiatRates extends AbstractMethod<
             { name: 'coin', type: 'string', required: true },
         ]);
 
-        const coinInfo = getCoinInfo(payload.coin);
+        const coinInfo = await getCoinInfo(payload.coin);
         if (!coinInfo) {
             throw ERRORS.TypedError('Method_UnknownCoin');
         }

--- a/packages/connect/src/api/blockchainUnsubscribe.ts
+++ b/packages/connect/src/api/blockchainUnsubscribe.ts
@@ -31,7 +31,7 @@ export default class BlockchainUnsubscribe extends AbstractMethod<'blockchainUns
             });
         }
 
-        const coinInfo = getCoinInfo(payload.coin);
+        const coinInfo = await getCoinInfo(payload.coin);
         if (!coinInfo) {
             throw ERRORS.TypedError('Method_UnknownCoin');
         }

--- a/packages/connect/src/api/blockchainUnsubscribe.ts
+++ b/packages/connect/src/api/blockchainUnsubscribe.ts
@@ -13,7 +13,7 @@ type Params = {
 };
 
 export default class BlockchainUnsubscribe extends AbstractMethod<'blockchainUnsubscribe', Params> {
-    init() {
+    async init() {
         this.useDevice = false;
         this.useUi = false;
 

--- a/packages/connect/src/api/blockchainUnsubscribeFiatRates.ts
+++ b/packages/connect/src/api/blockchainUnsubscribeFiatRates.ts
@@ -15,7 +15,7 @@ export default class BlockchainUnsubscribeFiatRates extends AbstractMethod<
     'blockchainUnsubscribeFiatRates',
     Params
 > {
-    init() {
+    async init() {
         this.useDevice = false;
         this.useUi = false;
 

--- a/packages/connect/src/api/blockchainUnsubscribeFiatRates.ts
+++ b/packages/connect/src/api/blockchainUnsubscribeFiatRates.ts
@@ -24,7 +24,7 @@ export default class BlockchainUnsubscribeFiatRates extends AbstractMethod<
         // validate incoming parameters
         validateParams(payload, [{ name: 'coin', type: 'string', required: true }]);
 
-        const coinInfo = getCoinInfo(payload.coin);
+        const coinInfo = await getCoinInfo(payload.coin);
         if (!coinInfo) {
             throw ERRORS.TypedError('Method_UnknownCoin');
         }

--- a/packages/connect/src/api/cancelCoinjoinAuthorization.ts
+++ b/packages/connect/src/api/cancelCoinjoinAuthorization.ts
@@ -6,7 +6,7 @@ export default class CancelCoinjoinAuthorization extends AbstractMethod<
     'cancelCoinjoinAuthorization',
     PROTO.CancelAuthorization
 > {
-    init() {
+    async init() {
         const { payload } = this;
 
         this.firmwareRange = getFirmwareRange(this.name, null, this.firmwareRange);

--- a/packages/connect/src/api/cardanoGetAddress.ts
+++ b/packages/connect/src/api/cardanoGetAddress.ts
@@ -22,7 +22,7 @@ export default class CardanoGetAddress extends AbstractMethod<'cardanoGetAddress
     progress = 0;
     confirmed?: boolean;
 
-    init() {
+    async init() {
         this.requiredPermissions = ['read'];
         this.firmwareRange = getFirmwareRange(
             this.name,

--- a/packages/connect/src/api/cardanoGetNativeScriptHash.ts
+++ b/packages/connect/src/api/cardanoGetNativeScriptHash.ts
@@ -11,7 +11,7 @@ export default class CardanoGetNativeScriptHash extends AbstractMethod<
     'cardanoGetNativeScriptHash',
     PROTO.CardanoGetNativeScriptHash
 > {
-    init() {
+    async init() {
         this.requiredPermissions = ['read'];
         this.firmwareRange = getFirmwareRange(
             this.name,

--- a/packages/connect/src/api/cardanoGetPublicKey.ts
+++ b/packages/connect/src/api/cardanoGetPublicKey.ts
@@ -14,7 +14,7 @@ export default class CardanoGetPublicKey extends AbstractMethod<
     hasBundle?: boolean;
     confirmed?: boolean;
 
-    init() {
+    async init() {
         this.requiredPermissions = ['read'];
         this.firmwareRange = getFirmwareRange(
             this.name,

--- a/packages/connect/src/api/cardanoSignTransaction.ts
+++ b/packages/connect/src/api/cardanoSignTransaction.ts
@@ -77,7 +77,7 @@ export default class CardanoSignTransaction extends AbstractMethod<
     'cardanoSignTransaction',
     CardanoSignTransactionParams
 > {
-    init() {
+    async init() {
         this.requiredPermissions = ['read', 'write'];
         this.firmwareRange = getFirmwareRange(
             this.name,

--- a/packages/connect/src/api/changePin.ts
+++ b/packages/connect/src/api/changePin.ts
@@ -5,7 +5,7 @@ import { validateParams } from './common/paramsValidator';
 import type { PROTO } from '../constants';
 
 export default class ChangePin extends AbstractMethod<'changePin', PROTO.ChangePin> {
-    init() {
+    async init() {
         this.requiredPermissions = ['management'];
         this.useDeviceState = false;
 

--- a/packages/connect/src/api/checkFirmwareAuthenticity.ts
+++ b/packages/connect/src/api/checkFirmwareAuthenticity.ts
@@ -7,7 +7,7 @@ import { httpRequest } from '../utils/assets';
 import { FirmwareType } from '../types';
 
 export default class CheckFirmwareAuthenticity extends AbstractMethod<'checkFirmwareAuthenticity'> {
-    init() {
+    async init() {
         this.useEmptyPassphrase = true;
         this.requiredPermissions = ['management'];
         this.useDeviceState = false;

--- a/packages/connect/src/api/cipherKeyValue.ts
+++ b/packages/connect/src/api/cipherKeyValue.ts
@@ -12,7 +12,7 @@ export default class CipherKeyValue extends AbstractMethod<
 > {
     hasBundle?: boolean;
 
-    init() {
+    async init() {
         this.requiredPermissions = ['read', 'write'];
         this.firmwareRange = getFirmwareRange(this.name, null, this.firmwareRange);
 

--- a/packages/connect/src/api/composeTransaction.ts
+++ b/packages/connect/src/api/composeTransaction.ts
@@ -49,7 +49,7 @@ type Params = {
 export default class ComposeTransaction extends AbstractMethod<'composeTransaction', Params> {
     discovery?: Discovery;
 
-    init() {
+    async init() {
         this.requiredPermissions = ['read', 'write'];
 
         const { payload } = this;

--- a/packages/connect/src/api/eosGetPublicKey.ts
+++ b/packages/connect/src/api/eosGetPublicKey.ts
@@ -14,7 +14,7 @@ export default class EosGetPublicKey extends AbstractMethod<
     hasBundle?: boolean;
     confirmed?: boolean;
 
-    init() {
+    async init() {
         this.requiredPermissions = ['read'];
         this.firmwareRange = getFirmwareRange(this.name, getMiscNetwork('EOS'), this.firmwareRange);
 

--- a/packages/connect/src/api/eosSignTransaction.ts
+++ b/packages/connect/src/api/eosSignTransaction.ts
@@ -15,7 +15,7 @@ type Params = {
 };
 
 export default class EosSignTransaction extends AbstractMethod<'eosSignTransaction', Params> {
-    init() {
+    async init() {
         this.requiredPermissions = ['read', 'write'];
         this.firmwareRange = getFirmwareRange(this.name, getMiscNetwork('EOS'), this.firmwareRange);
 

--- a/packages/connect/src/api/ethereumGetAddress.ts
+++ b/packages/connect/src/api/ethereumGetAddress.ts
@@ -26,7 +26,7 @@ export default class EthereumGetAddress extends AbstractMethod<'ethereumGetAddre
     progress = 0;
     confirmed?: boolean;
 
-    init() {
+    async init() {
         this.requiredPermissions = ['read'];
 
         // create a bundle with only one batch if bundle doesn't exists

--- a/packages/connect/src/api/ethereumGetPublicKey.ts
+++ b/packages/connect/src/api/ethereumGetPublicKey.ts
@@ -17,7 +17,7 @@ export default class EthereumGetPublicKey extends AbstractMethod<'ethereumGetPub
     hasBundle?: boolean;
     confirmed?: boolean;
 
-    init() {
+    async init() {
         this.requiredPermissions = ['read'];
 
         // create a bundle with only one batch if bundle doesn't exists

--- a/packages/connect/src/api/ethereumGetPublicKey.ts
+++ b/packages/connect/src/api/ethereumGetPublicKey.ts
@@ -29,22 +29,25 @@ export default class EthereumGetPublicKey extends AbstractMethod<'ethereumGetPub
         // validate bundle type
         validateParams(payload, [{ name: 'bundle', type: 'array' }]);
 
-        this.params = payload.bundle.map(batch => {
-            // validate incoming parameters for each batch
-            validateParams(batch, [
-                { name: 'path', required: true },
-                { name: 'showOnTrezor', type: 'boolean' },
-            ]);
+        this.params = await Promise.all(
+            payload.bundle.map(async batch => {
+                // validate incoming parameters for each batch
+                validateParams(batch, [
+                    { name: 'path', required: true },
+                    { name: 'showOnTrezor', type: 'boolean' },
+                ]);
 
-            const path = validatePath(batch.path, 3);
-            const network = getEthereumNetwork(path);
-            this.firmwareRange = getFirmwareRange(this.name, network, this.firmwareRange);
-            return {
-                address_n: path,
-                show_display: typeof batch.showOnTrezor === 'boolean' ? batch.showOnTrezor : false,
-                network,
-            };
-        });
+                const path = validatePath(batch.path, 3);
+                const network = await getEthereumNetwork(path);
+                this.firmwareRange = getFirmwareRange(this.name, network!, this.firmwareRange);
+                return {
+                    address_n: path,
+                    show_display:
+                        typeof batch.showOnTrezor === 'boolean' ? batch.showOnTrezor : false,
+                    network,
+                };
+            }),
+        );
     }
 
     get info() {

--- a/packages/connect/src/api/ethereumSignMessage.ts
+++ b/packages/connect/src/api/ethereumSignMessage.ts
@@ -7,7 +7,7 @@ import { getEthereumNetwork } from '../data/coinInfo';
 import { getNetworkLabel } from '../utils/ethereumUtils';
 import { messageToHex } from '../utils/formatUtils';
 import type { PROTO } from '../constants';
-import { getEthereumDefinitions } from './ethereum/ethereumDefinitions';
+import { getEthereumDefinitions } from '../data/ethereumDefinitions';
 import type { EthereumNetworkInfo } from '../types';
 import type { EthereumDefinitions } from '@trezor/protobuf/lib/messages';
 
@@ -30,7 +30,7 @@ export default class EthereumSignMessage extends AbstractMethod<'ethereumSignMes
         ]);
 
         const path = validatePath(payload.path, 3);
-        const network = getEthereumNetwork(path);
+        const network = await getEthereumNetwork(path);
         this.firmwareRange = getFirmwareRange(this.name, network, this.firmwareRange);
 
         const messageHex = payload.hex
@@ -39,10 +39,9 @@ export default class EthereumSignMessage extends AbstractMethod<'ethereumSignMes
         this.params = {
             address_n: path,
             message: messageHex,
+            network,
         };
-    }
 
-    async initAsync() {
         if (this.params.network) return;
 
         const { address_n } = this.params;
@@ -53,7 +52,7 @@ export default class EthereumSignMessage extends AbstractMethod<'ethereumSignMes
     }
 
     get info() {
-        return getNetworkLabel('Sign #NETWORK message', getEthereumNetwork(this.params.address_n));
+        return getNetworkLabel('Sign #NETWORK message', this.params.network);
     }
 
     async run() {

--- a/packages/connect/src/api/ethereumSignMessage.ts
+++ b/packages/connect/src/api/ethereumSignMessage.ts
@@ -17,7 +17,7 @@ type Params = PROTO.EthereumSignMessage & {
 };
 
 export default class EthereumSignMessage extends AbstractMethod<'ethereumSignMessage', Params> {
-    init() {
+    async init() {
         this.requiredPermissions = ['read', 'write'];
 
         const { payload } = this;

--- a/packages/connect/src/api/ethereumSignTransaction.ts
+++ b/packages/connect/src/api/ethereumSignTransaction.ts
@@ -48,7 +48,7 @@ export default class EthereumSignTransaction extends AbstractMethod<
     'ethereumSignTransaction',
     Params
 > {
-    init() {
+    async init() {
         this.requiredPermissions = ['read', 'write'];
 
         const { payload } = this;

--- a/packages/connect/src/api/ethereumSignTransaction.ts
+++ b/packages/connect/src/api/ethereumSignTransaction.ts
@@ -11,7 +11,7 @@ import {
     getEthereumDefinitions,
     decodeEthereumDefinition,
     ethereumNetworkInfoFromDefinition,
-} from './ethereum/ethereumDefinitions';
+} from '../data/ethereumDefinitions';
 import type { EthereumTransaction, EthereumTransactionEIP1559 } from '../types/api/ethereum';
 import type { EthereumNetworkInfo } from '../types';
 import type { EthereumDefinitions } from '@trezor/protobuf/lib/messages';
@@ -59,7 +59,7 @@ export default class EthereumSignTransaction extends AbstractMethod<
         ]);
 
         const path = validatePath(payload.path, 3);
-        const network = getEthereumNetwork(path);
+        const network = await getEthereumNetwork(path);
 
         // incoming transaction should be in EthereumTx format
         // https://github.com/ethereumjs/ethereumjs-tx
@@ -113,9 +113,7 @@ export default class EthereumSignTransaction extends AbstractMethod<
             },
             network,
         };
-    }
 
-    async initAsync(): Promise<void> {
         // eth && token => yes
         // evm && token => yes
         // eth && !token => no

--- a/packages/connect/src/api/ethereumSignTypedData.ts
+++ b/packages/connect/src/api/ethereumSignTypedData.ts
@@ -15,7 +15,7 @@ import type {
 } from '../types/api/ethereum';
 import { getFieldType, parseArrayType, encodeData } from './ethereum/ethereumSignTypedData';
 import { messageToHex } from '../utils/formatUtils';
-import { getEthereumDefinitions } from './ethereum/ethereumDefinitions';
+import { getEthereumDefinitions } from '../data/ethereumDefinitions';
 import type { EthereumNetworkInfo } from '../types';
 import type { EthereumDefinitions } from '@trezor/protobuf/lib/messages';
 import { DeviceModelInternal } from '../types';
@@ -46,7 +46,7 @@ export default class EthereumSignTypedData extends AbstractMethod<'ethereumSignT
         ]);
 
         const path = validatePath(payload.path, 3);
-        const network = getEthereumNetwork(path);
+        const network = await getEthereumNetwork(path);
         this.firmwareRange = getFirmwareRange(this.name, network, this.firmwareRange);
 
         this.params = {
@@ -93,9 +93,7 @@ export default class EthereumSignTypedData extends AbstractMethod<'ethereumSignT
                 );
             }
         }
-    }
 
-    async initAsync() {
         if (this.params.network) return;
 
         const { address_n } = this.params;
@@ -106,10 +104,7 @@ export default class EthereumSignTypedData extends AbstractMethod<'ethereumSignT
     }
 
     get info() {
-        return getNetworkLabel(
-            'Sign #NETWORK typed data',
-            getEthereumNetwork(this.params.address_n),
-        );
+        return getNetworkLabel('Sign #NETWORK typed data', this.params.network);
     }
 
     async run() {

--- a/packages/connect/src/api/ethereumSignTypedData.ts
+++ b/packages/connect/src/api/ethereumSignTypedData.ts
@@ -29,7 +29,7 @@ type Params = (
     definitions?: EthereumDefinitions;
 };
 export default class EthereumSignTypedData extends AbstractMethod<'ethereumSignTypedData', Params> {
-    init() {
+    async init() {
         this.requiredPermissions = ['read', 'write'];
 
         const { payload } = this;

--- a/packages/connect/src/api/ethereumVerifyMessage.ts
+++ b/packages/connect/src/api/ethereumVerifyMessage.ts
@@ -9,7 +9,7 @@ export default class EthereumVerifyMessage extends AbstractMethod<
     'ethereumVerifyMessage',
     PROTO.EthereumVerifyMessage
 > {
-    init() {
+    async init() {
         this.requiredPermissions = ['read', 'write'];
         this.firmwareRange = getFirmwareRange(this.name, null, this.firmwareRange);
 

--- a/packages/connect/src/api/firmwareUpdate.ts
+++ b/packages/connect/src/api/firmwareUpdate.ts
@@ -24,7 +24,7 @@ type Params = {
 };
 
 export default class FirmwareUpdate extends AbstractMethod<'firmwareUpdate', Params> {
-    init() {
+    async init() {
         this.useEmptyPassphrase = true;
         this.requiredPermissions = ['management'];
         this.allowDeviceMode = [UI.BOOTLOADER, UI.INITIALIZE];

--- a/packages/connect/src/api/getAccountInfo.ts
+++ b/packages/connect/src/api/getAccountInfo.ts
@@ -20,7 +20,7 @@ export default class GetAccountInfo extends AbstractMethod<'getAccountInfo', Req
     hasBundle?: boolean;
     discovery?: Discovery;
 
-    init() {
+    async init() {
         this.requiredPermissions = ['read'];
         this.useDevice = true;
         this.useUi = true;

--- a/packages/connect/src/api/getAddress.ts
+++ b/packages/connect/src/api/getAddress.ts
@@ -19,7 +19,7 @@ export default class GetAddress extends AbstractMethod<'getAddress', Params[]> {
     progress = 0;
     confirmed?: boolean;
 
-    init() {
+    async init() {
         this.requiredPermissions = ['read'];
 
         // create a bundle with only one batch if bundle doesn't exists

--- a/packages/connect/src/api/getCoinInfo.ts
+++ b/packages/connect/src/api/getCoinInfo.ts
@@ -11,7 +11,7 @@ type Params = {
 };
 
 export default class GetCoinInfo extends AbstractMethod<'getCoinInfo', Params> {
-    init() {
+    async init() {
         this.requiredPermissions = [];
         this.useDevice = false;
         this.useUi = false;

--- a/packages/connect/src/api/getCoinInfo.ts
+++ b/packages/connect/src/api/getCoinInfo.ts
@@ -20,7 +20,7 @@ export default class GetCoinInfo extends AbstractMethod<'getCoinInfo', Params> {
 
         validateParams(payload, [{ name: 'coin', type: 'string', required: true }]);
 
-        const coinInfo = getCoinInfo(payload.coin);
+        const coinInfo = await getCoinInfo(payload.coin);
         if (!coinInfo) {
             throw ERRORS.TypedError('Method_UnknownCoin');
         }

--- a/packages/connect/src/api/getDeviceState.ts
+++ b/packages/connect/src/api/getDeviceState.ts
@@ -3,7 +3,7 @@
 import { AbstractMethod } from '../core/AbstractMethod';
 
 export default class GetDeviceState extends AbstractMethod<'getDeviceState'> {
-    init() {
+    async init() {
         this.requiredPermissions = [];
     }
 

--- a/packages/connect/src/api/getFeatures.ts
+++ b/packages/connect/src/api/getFeatures.ts
@@ -4,7 +4,7 @@ import { AbstractMethod } from '../core/AbstractMethod';
 import { UI } from '../events';
 
 export default class GetFeatures extends AbstractMethod<'getFeatures'> {
-    init() {
+    async init() {
         this.requiredPermissions = [];
         this.useUi = false;
         this.allowDeviceMode = [...this.allowDeviceMode, UI.INITIALIZE, UI.BOOTLOADER];

--- a/packages/connect/src/api/getFirmwareHash.ts
+++ b/packages/connect/src/api/getFirmwareHash.ts
@@ -7,7 +7,7 @@ export default class GetFirmwareHash extends AbstractMethod<
     'getFirmwareHash',
     PROTO.GetFirmwareHash
 > {
-    init() {
+    async init() {
         this.requiredPermissions = ['management'];
         this.useEmptyPassphrase = true;
         this.useDeviceState = false;

--- a/packages/connect/src/api/getOwnershipId.ts
+++ b/packages/connect/src/api/getOwnershipId.ts
@@ -12,7 +12,7 @@ export default class GetOwnershipId extends AbstractMethod<
     hasBundle?: boolean;
     confirmed?: boolean;
 
-    init() {
+    async init() {
         this.requiredPermissions = ['read'];
 
         // create a bundle with only one batch if bundle doesn't exists

--- a/packages/connect/src/api/getOwnershipProof.ts
+++ b/packages/connect/src/api/getOwnershipProof.ts
@@ -12,7 +12,7 @@ export default class GetOwnershipProof extends AbstractMethod<
     hasBundle?: boolean;
     confirmed?: boolean;
 
-    init() {
+    async init() {
         this.requiredPermissions = ['read'];
 
         // create a bundle with only one batch if bundle doesn't exists

--- a/packages/connect/src/api/getPublicKey.ts
+++ b/packages/connect/src/api/getPublicKey.ts
@@ -18,7 +18,7 @@ export default class GetPublicKey extends AbstractMethod<'getPublicKey', Params[
     hasBundle?: boolean;
     confirmed?: boolean;
 
-    init() {
+    async init() {
         this.requiredPermissions = ['read'];
 
         // create a bundle with only one batch if bundle doesn't exists

--- a/packages/connect/src/api/getSettings.ts
+++ b/packages/connect/src/api/getSettings.ts
@@ -4,7 +4,7 @@ import { AbstractMethod } from '../core/AbstractMethod';
 import { DataManager } from '../data/DataManager';
 
 export default class GetSettings extends AbstractMethod<'getSettings'> {
-    init() {
+    async init() {
         this.requiredPermissions = [];
         this.useDevice = false;
         this.useUi = false;

--- a/packages/connect/src/api/nemGetAddress.ts
+++ b/packages/connect/src/api/nemGetAddress.ts
@@ -20,7 +20,7 @@ export default class NEMGetAddress extends AbstractMethod<'nemGetAddress', Param
     progress = 0;
     confirmed?: boolean;
 
-    init() {
+    async init() {
         this.requiredPermissions = ['read'];
         this.firmwareRange = getFirmwareRange(this.name, getMiscNetwork('NEM'), this.firmwareRange);
 

--- a/packages/connect/src/api/nemSignTransaction.ts
+++ b/packages/connect/src/api/nemSignTransaction.ts
@@ -11,7 +11,7 @@ export default class NEMSignTransaction extends AbstractMethod<
     'nemSignTransaction',
     PROTO.NEMSignTx
 > {
-    init() {
+    async init() {
         this.requiredPermissions = ['read', 'write'];
         this.firmwareRange = getFirmwareRange(this.name, getMiscNetwork('NEM'), this.firmwareRange);
 

--- a/packages/connect/src/api/pushTransaction.ts
+++ b/packages/connect/src/api/pushTransaction.ts
@@ -26,7 +26,7 @@ export default class PushTransaction extends AbstractMethod<'pushTransaction', P
             { name: 'coin', type: 'string', required: true },
         ]);
 
-        const coinInfo = getCoinInfo(payload.coin);
+        const coinInfo = await getCoinInfo(payload.coin);
         if (!coinInfo) {
             throw ERRORS.TypedError('Method_UnknownCoin');
         }

--- a/packages/connect/src/api/pushTransaction.ts
+++ b/packages/connect/src/api/pushTransaction.ts
@@ -13,7 +13,7 @@ type Params = {
 };
 
 export default class PushTransaction extends AbstractMethod<'pushTransaction', Params> {
-    init() {
+    async init() {
         this.requiredPermissions = [];
         this.useUi = false;
         this.useDevice = false;

--- a/packages/connect/src/api/rebootToBootloader.ts
+++ b/packages/connect/src/api/rebootToBootloader.ts
@@ -7,7 +7,7 @@ import { UI, createUiMessage } from '../events';
 export default class RebootToBootloader extends AbstractMethod<'rebootToBootloader'> {
     confirmed?: boolean;
 
-    init() {
+    async init() {
         this.allowDeviceMode = [UI.INITIALIZE, UI.SEEDLESS];
         this.skipFinalReload = true;
         this.keepSession = false;

--- a/packages/connect/src/api/recoveryDevice.ts
+++ b/packages/connect/src/api/recoveryDevice.ts
@@ -6,7 +6,7 @@ import { validateParams } from './common/paramsValidator';
 import type { PROTO } from '../constants';
 
 export default class RecoveryDevice extends AbstractMethod<'recoveryDevice', PROTO.RecoveryDevice> {
-    init() {
+    async init() {
         this.requiredPermissions = ['management'];
         this.useEmptyPassphrase = true;
 

--- a/packages/connect/src/api/requestLogin.ts
+++ b/packages/connect/src/api/requestLogin.ts
@@ -11,7 +11,7 @@ import type { PROTO } from '../constants';
 export default class RequestLogin extends AbstractMethod<'requestLogin', PROTO.SignIdentity> {
     asyncChallenge?: boolean;
 
-    init() {
+    async init() {
         this.requiredPermissions = ['read', 'write'];
         this.firmwareRange = getFirmwareRange(this.name, null, this.firmwareRange);
         this.useEmptyPassphrase = true;

--- a/packages/connect/src/api/resetDevice.ts
+++ b/packages/connect/src/api/resetDevice.ts
@@ -8,7 +8,7 @@ import type { PROTO } from '../constants';
 export default class ResetDevice extends AbstractMethod<'resetDevice', PROTO.ResetDevice> {
     confirmed?: boolean;
 
-    init() {
+    async init() {
         this.allowDeviceMode = [UI.INITIALIZE, UI.SEEDLESS];
         this.useDeviceState = false;
         this.requiredPermissions = ['management'];

--- a/packages/connect/src/api/rippleGetAddress.ts
+++ b/packages/connect/src/api/rippleGetAddress.ts
@@ -16,7 +16,7 @@ export default class RippleGetAddress extends AbstractMethod<'rippleGetAddress',
     progress = 0;
     confirmed?: boolean;
 
-    init() {
+    async init() {
         this.requiredPermissions = ['read'];
         this.firmwareRange = getFirmwareRange(
             this.name,

--- a/packages/connect/src/api/rippleSignTransaction.ts
+++ b/packages/connect/src/api/rippleSignTransaction.ts
@@ -10,7 +10,7 @@ export default class RippleSignTransaction extends AbstractMethod<
     'rippleSignTransaction',
     PROTO.RippleSignTx
 > {
-    init() {
+    async init() {
         this.requiredPermissions = ['read', 'write'];
         this.firmwareRange = getFirmwareRange(
             this.name,

--- a/packages/connect/src/api/setBusy.ts
+++ b/packages/connect/src/api/setBusy.ts
@@ -4,7 +4,7 @@ import { PROTO } from '../constants';
 import { getFirmwareRange, validateParams } from './common/paramsValidator';
 
 export default class SetBusy extends AbstractMethod<'setBusy', PROTO.SetBusy> {
-    init() {
+    async init() {
         this.useDeviceState = false;
         this.requiredPermissions = ['management'];
 

--- a/packages/connect/src/api/setProxy.ts
+++ b/packages/connect/src/api/setProxy.ts
@@ -6,7 +6,7 @@ import { DataManager } from '../data/DataManager';
 import { reconnectAllBackends } from '../backend/BlockchainLink';
 
 export default class SetProxy extends AbstractMethod<'setProxy'> {
-    init() {
+    async init() {
         this.requiredPermissions = [];
         this.useDevice = false;
         this.useUi = false;

--- a/packages/connect/src/api/showDeviceTutorial.ts
+++ b/packages/connect/src/api/showDeviceTutorial.ts
@@ -7,7 +7,7 @@ export default class ShowDeviceTutorial extends AbstractMethod<
     'showDeviceTutorial',
     PROTO.ShowDeviceTutorial
 > {
-    init() {
+    async init() {
         this.firmwareRange = getFirmwareRange(this.name, null, this.firmwareRange);
         this.useEmptyPassphrase = true;
         this.useDeviceState = false;

--- a/packages/connect/src/api/signMessage.ts
+++ b/packages/connect/src/api/signMessage.ts
@@ -9,7 +9,7 @@ import type { BitcoinNetworkInfo } from '../types';
 import type { PROTO } from '../constants';
 
 export default class SignMessage extends AbstractMethod<'signMessage', PROTO.SignMessage> {
-    init() {
+    async init() {
         this.requiredPermissions = ['read', 'write'];
 
         const { payload } = this;

--- a/packages/connect/src/api/signTransaction.ts
+++ b/packages/connect/src/api/signTransaction.ts
@@ -42,7 +42,7 @@ type Params = {
 };
 
 export default class SignTransaction extends AbstractMethod<'signTransaction', Params> {
-    init() {
+    async init() {
         this.requiredPermissions = ['read', 'write'];
 
         const { payload } = this;

--- a/packages/connect/src/api/stellarGetAddress.ts
+++ b/packages/connect/src/api/stellarGetAddress.ts
@@ -16,7 +16,7 @@ export default class StellarGetAddress extends AbstractMethod<'stellarGetAddress
     progress = 0;
     confirmed?: boolean;
 
-    init() {
+    async init() {
         this.requiredPermissions = ['read'];
         this.firmwareRange = getFirmwareRange(
             this.name,

--- a/packages/connect/src/api/stellarSignTransaction.ts
+++ b/packages/connect/src/api/stellarSignTransaction.ts
@@ -23,7 +23,7 @@ export default class StellarSignTransaction extends AbstractMethod<
     'stellarSignTransaction',
     Params
 > {
-    init() {
+    async init() {
         this.requiredPermissions = ['read', 'write'];
         this.firmwareRange = getFirmwareRange(
             this.name,

--- a/packages/connect/src/api/tezosGetAddress.ts
+++ b/packages/connect/src/api/tezosGetAddress.ts
@@ -16,7 +16,7 @@ export default class TezosGetAddress extends AbstractMethod<'tezosGetAddress', P
     progress = 0;
     confirmed?: boolean;
 
-    init() {
+    async init() {
         this.requiredPermissions = ['read'];
         this.firmwareRange = getFirmwareRange(
             this.name,

--- a/packages/connect/src/api/tezosGetPublicKey.ts
+++ b/packages/connect/src/api/tezosGetPublicKey.ts
@@ -14,7 +14,7 @@ export default class TezosGetPublicKey extends AbstractMethod<
     hasBundle?: boolean;
     confirmed?: boolean;
 
-    init() {
+    async init() {
         this.requiredPermissions = ['read'];
         this.firmwareRange = getFirmwareRange(
             this.name,

--- a/packages/connect/src/api/tezosSignTransaction.ts
+++ b/packages/connect/src/api/tezosSignTransaction.ts
@@ -11,7 +11,7 @@ export default class TezosSignTransaction extends AbstractMethod<
     'tezosSignTransaction',
     PROTO.TezosSignTx
 > {
-    init() {
+    async init() {
         this.requiredPermissions = ['read', 'write'];
         this.firmwareRange = getFirmwareRange(
             this.name,

--- a/packages/connect/src/api/unlockPath.ts
+++ b/packages/connect/src/api/unlockPath.ts
@@ -4,7 +4,7 @@ import { validatePath } from '../utils/pathUtils';
 import { getFirmwareRange, validateParams } from './common/paramsValidator';
 
 export default class UnlockPath extends AbstractMethod<'unlockPath', PROTO.UnlockPath> {
-    init() {
+    async init() {
         this.requiredPermissions = ['read'];
         this.skipFinalReload = true;
         this.firmwareRange = getFirmwareRange(this.name, undefined, this.firmwareRange);

--- a/packages/connect/src/api/verifyMessage.ts
+++ b/packages/connect/src/api/verifyMessage.ts
@@ -8,7 +8,7 @@ import { messageToHex } from '../utils/formatUtils';
 import { PROTO, ERRORS } from '../constants';
 
 export default class VerifyMessage extends AbstractMethod<'verifyMessage', PROTO.VerifyMessage> {
-    init() {
+    async init() {
         this.requiredPermissions = ['read', 'write'];
 
         const { payload } = this;

--- a/packages/connect/src/api/wipeDevice.ts
+++ b/packages/connect/src/api/wipeDevice.ts
@@ -7,7 +7,7 @@ import { getFirmwareRange } from './common/paramsValidator';
 export default class WipeDevice extends AbstractMethod<'wipeDevice'> {
     confirmed?: boolean;
 
-    init() {
+    async init() {
         this.allowDeviceMode = [UI.INITIALIZE, UI.SEEDLESS, UI.BOOTLOADER];
         this.useDeviceState = false;
         this.requiredPermissions = ['management'];

--- a/packages/connect/src/backend/__tests__/Blockchain.test.ts
+++ b/packages/connect/src/backend/__tests__/Blockchain.test.ts
@@ -1,5 +1,6 @@
 import coinsJSON from '@trezor/connect-common/files/coins.json';
 import ethereumCoinsJSON from '@trezor/connect-common/files/coins-eth.json';
+import blockchainLinkJSON from '@trezor/connect-common/files/blockchain-link.json';
 import BlockchainLink from '@trezor/blockchain-link';
 import { parseCoinsJson, getBitcoinNetwork, getEthereumNetwork } from '../../data/coinInfo';
 import { initBlockchain } from '../BlockchainLink';
@@ -35,7 +36,7 @@ jest.mock('@trezor/blockchain-link', () => ({
 
 describe('backend/Blockchain', () => {
     // load coin definitions
-    parseCoinsJson({ ...coinsJSON, eth: ethereumCoinsJSON });
+    parseCoinsJson({ ...coinsJSON, eth: ethereumCoinsJSON }, blockchainLinkJSON);
 
     it('cache estimated fees (bitcoin-like)', async () => {
         jest.useFakeTimers();

--- a/packages/connect/src/backend/__tests__/Blockchain.test.ts
+++ b/packages/connect/src/backend/__tests__/Blockchain.test.ts
@@ -71,7 +71,7 @@ describe('backend/Blockchain', () => {
     });
 
     it('cache estimated fees (ethereum-like)', async () => {
-        const coinInfo = getEthereumNetwork('Ethereum');
+        const coinInfo = await getEthereumNetwork('Ethereum');
         if (!coinInfo) throw new Error('coinInfo is missing');
 
         const spy = jest.spyOn(BlockchainLink.prototype, 'estimateFee');

--- a/packages/connect/src/constants/errors.ts
+++ b/packages/connect/src/constants/errors.ts
@@ -25,7 +25,7 @@ export const ERROR_CODES = {
     Method_Override: 'override', // inner "error", it's more like a interruption
     Method_NoResponse: 'Call resolved without response', // thrown by npm index(es), call to Core resolved without response, should not happen
 
-    Backend_NotSupported: 'BlockchainLink settings not found in coins.json', // thrown by methods which using backends, blockchainLink not defined for this coin
+    Backend_NotSupported: 'BlockchainLink settings not found in blockchain-link.json', // thrown by methods which using backends, blockchainLink not defined for this coin
     Backend_WorkerMissing: '', // thrown by BlockchainLink class, worker not specified
     Backend_Disconnected: 'Backend disconnected', // thrown by BlockchainLink class
     Backend_Invalid: 'Invalid backend', // thrown by BlockchainLink class, invalid backend (ie: backend for wrong coin set)

--- a/packages/connect/src/core/AbstractMethod.ts
+++ b/packages/connect/src/core/AbstractMethod.ts
@@ -97,8 +97,6 @@ export abstract class AbstractMethod<Name extends CallMethodPayload['method'], P
     // @ts-expect-error: strictPropertyInitialization
     removeUiPromise: (promise: Deferred<any>) => void;
 
-    initAsync?(): Promise<void>;
-
     constructor(message: { id?: number; payload: Payload<Name> }) {
         const { payload } = message;
         this.name = payload.method;
@@ -304,7 +302,7 @@ export abstract class AbstractMethod<Name extends CallMethodPayload['method'], P
         }
     }
 
-    abstract init(): void;
+    abstract init(): Promise<void>;
 
     abstract run(): Promise<MethodReturnType<Name>>;
 

--- a/packages/connect/src/core/index.ts
+++ b/packages/connect/src/core/index.ts
@@ -300,14 +300,11 @@ export const onCall = async (message: CoreMessage) => {
         method.postMessage = postMessage;
         method.getPopupPromise = getPopupPromise;
         method.createUiPromise = createUiPromise;
-        // start validation process
-        method.init();
 
         _callMethods.push(method);
 
-        if (method.initAsync) {
-            await method.initAsync();
-        }
+        // start validation process
+        await method.init();
     } catch (error) {
         postMessage(createPopupMessage(POPUP.CANCEL_POPUP_REQUEST));
         postMessage(createResponseMessage(responseID, false, { error }));

--- a/packages/connect/src/data/DataManager.ts
+++ b/packages/connect/src/data/DataManager.ts
@@ -34,10 +34,13 @@ export class DataManager {
         parseBridgeJSON(this.assets.bridge);
 
         // parse coins definitions
-        parseCoinsJson({
-            ...this.assets.coins,
-            eth: this.assets.coinsEth,
-        });
+        parseCoinsJson(
+            {
+                ...this.assets.coins,
+                eth: this.assets.coinsEth,
+            },
+            this.assets.blockchainLink,
+        );
 
         // parse firmware definitions
         parseFirmware(this.assets['firmware-t1'], 1);

--- a/packages/connect/src/data/__tests__/coinInfo.test.ts
+++ b/packages/connect/src/data/__tests__/coinInfo.test.ts
@@ -1,9 +1,10 @@
 import coinsJSON from '@trezor/connect-common/files/coins.json';
+import blockchainLinkJSON from '@trezor/connect-common/files/blockchain-link.json';
 import { parseCoinsJson, getCoinInfo, getUniqueNetworks, getAllNetworks } from '../coinInfo';
 
 describe('data/coinInfo', () => {
     beforeAll(() => {
-        parseCoinsJson(coinsJSON);
+        parseCoinsJson(coinsJSON, blockchainLinkJSON);
     });
 
     it('getUniqueNetworks', () => {

--- a/packages/connect/src/data/__tests__/coinInfo.test.ts
+++ b/packages/connect/src/data/__tests__/coinInfo.test.ts
@@ -7,15 +7,15 @@ describe('data/coinInfo', () => {
         parseCoinsJson(coinsJSON, blockchainLinkJSON);
     });
 
-    it('getUniqueNetworks', () => {
+    it('getUniqueNetworks', async () => {
         const inputs = [
-            getCoinInfo('btc'),
-            getCoinInfo('ltc'),
-            getCoinInfo('btc'),
-            getCoinInfo('ltc'),
-            getCoinInfo('ltc'),
+            await getCoinInfo('btc'),
+            await getCoinInfo('ltc'),
+            await getCoinInfo('btc'),
+            await getCoinInfo('ltc'),
+            await getCoinInfo('ltc'),
         ];
-        const result = [getCoinInfo('btc'), getCoinInfo('ltc')];
+        const result = [await getCoinInfo('btc'), await getCoinInfo('ltc')];
         expect(getUniqueNetworks(inputs)).toEqual(result);
     });
 

--- a/packages/connect/src/data/coinInfo.ts
+++ b/packages/connect/src/data/coinInfo.ts
@@ -161,7 +161,7 @@ export const getCoinName = (path: number[]) => {
     return network ? network.name : 'Unknown coin';
 };
 
-const parseBitcoinNetworksJson = (json: any) => {
+const parseBitcoinNetworksJson = (json: any, blockchainLink?: any) => {
     Object.keys(json).forEach(key => {
         const coin = json[key];
         const shortcut = coin.coin_shortcut;
@@ -189,7 +189,6 @@ const parseBitcoinNetworksJson = (json: any) => {
             // bip115: not used
             // bitcore: not used,
             // blockbook: not used,
-            blockchainLink: coin.blockchain_link,
             cashAddrPrefix: coin.cashaddr_prefix,
             label: coin.coin_label,
             name: coin.coin_name,
@@ -227,6 +226,7 @@ const parseBitcoinNetworksJson = (json: any) => {
 
             decimals: coin.decimals,
             ...getBitcoinFeeLevels(coin),
+            blockchainLink: blockchainLink?.[shortcut],
         });
     });
 };
@@ -237,29 +237,28 @@ export const ethereumNetworkInfoBase = {
     ...getEthereumFeeLevels(),
 };
 
-const parseEthereumNetworksJson = (json: any) => {
+const parseEthereumNetworksJson = (json: any, blockchainLink?: any) => {
     Object.keys(json).forEach(key => {
         const network = json[key];
 
         ethereumNetworks.push({
             ...ethereumNetworkInfoBase,
-            blockchainLink: network.blockchain_link,
             chainId: network.chain_id,
             label: network.name,
             name: network.name,
             shortcut: network.shortcut,
             slip44: network.slip44,
             support: network.support,
+            blockchainLink: blockchainLink?.[network.shortcut],
         });
     });
 };
 
-const parseMiscNetworksJSON = (json: any, type?: 'misc' | 'nem') => {
+const parseMiscNetworksJSON = (json: any, type: 'misc' | 'nem', blockchainLink: any) => {
     Object.keys(json).forEach(key => {
         const network = json[key];
         miscNetworks.push({
             type: type || 'misc',
-            blockchainLink: network.blockchain_link,
             curve: network.curve,
             label: network.name,
             name: network.name,
@@ -268,21 +267,22 @@ const parseMiscNetworksJSON = (json: any, type?: 'misc' | 'nem') => {
             support: network.support,
             decimals: network.decimals,
             ...getMiscFeeLevels(network),
+            blockchainLink: blockchainLink?.[network.shortcut],
         });
     });
 };
 
-export const parseCoinsJson = (json: any) => {
+export const parseCoinsJson = (json: any, blockchainLink: any) => {
     Object.keys(json).forEach(key => {
         switch (key) {
             case 'bitcoin':
-                return parseBitcoinNetworksJson(json[key]);
+                return parseBitcoinNetworksJson(json[key], blockchainLink);
             case 'eth':
-                return parseEthereumNetworksJson(json[key]);
+                return parseEthereumNetworksJson(json[key], blockchainLink);
             case 'misc':
-                return parseMiscNetworksJSON(json[key]);
+                return parseMiscNetworksJSON(json[key], 'misc', blockchainLink);
             case 'nem':
-                return parseMiscNetworksJSON(json[key], 'nem');
+                return parseMiscNetworksJSON(json[key], 'nem', blockchainLink);
             // no default
         }
     });

--- a/packages/connect/src/data/config.ts
+++ b/packages/connect/src/data/config.ts
@@ -52,6 +52,10 @@ export const config = {
             url: './data/coins-eth.json',
         },
         {
+            name: 'blockchainLink',
+            url: './data/blockchain-link.json',
+        },
+        {
             name: 'bridge',
             url: './data/bridge/releases.json',
         },
@@ -105,9 +109,13 @@ export const config = {
             ],
         },
         {
-            coin: ['eth', 'tsep', 'tgor'],
+            coin: ['eth'],
             min: ['1.8.0', '2.1.0'],
             comment: ['There were protobuf backwards incompatible changes.'],
+        },
+        {
+            coin: ['tsep', 'tgor'],
+            min: ['1.11.2', '2.5.2'],
         },
         {
             methods: ['rippleGetAddress', 'rippleSignTransaction'],

--- a/packages/connect/src/data/ethereumDefinitions.ts
+++ b/packages/connect/src/data/ethereumDefinitions.ts
@@ -3,10 +3,11 @@ import fetch from 'cross-fetch';
 import { EthereumDefinitions } from '@trezor/protobuf/lib/messages';
 import { trzd } from '@trezor/protocol';
 import { parseConfigure, decode as decodeProtobuf } from '@trezor/protobuf';
-import { DataManager } from '../../data/DataManager';
-import { validateParams } from '../common/paramsValidator';
-import { EthereumNetworkInfo } from '../../types';
-import { ethereumNetworkInfoBase } from '../../data/coinInfo';
+import { DataManager } from './DataManager';
+import { validateParams } from '../api/common/paramsValidator';
+import { EthereumNetworkInfo } from '../types';
+import { ethereumNetworkInfoBase } from './coinInfo';
+import blockchainLinkJSON from '@trezor/connect-common/files/blockchain-link.json';
 
 interface GetEthereumDefinitions {
     chainId?: number;
@@ -150,18 +151,23 @@ export const decodeEthereumDefinition = (
  */
 export const ethereumNetworkInfoFromDefinition = (
     definition: EthereumNetworkDefinitionDecoded,
-): EthereumNetworkInfo => ({
-    ...ethereumNetworkInfoBase,
+): EthereumNetworkInfo => {
+    const [shortcut, chainId] = definition.symbol.split(':');
 
-    chainId: definition.chain_id,
-    label: definition.name,
-    name: definition.name,
-    slip44: definition.slip44,
-    shortcut: definition.symbol,
-    support: {
-        connect: true,
-        trezor1: '1.6.2',
-        trezor2: '2.0.7',
-    },
-    blockchainLink: undefined,
-});
+    return {
+        ...ethereumNetworkInfoBase,
+
+        chainId: definition.chain_id,
+        label: definition.name,
+        name: definition.name,
+        slip44: definition.slip44,
+        shortcut: definition.symbol,
+        support: {
+            connect: true,
+            trezor1: '1.6.2',
+            trezor2: '2.0.7',
+        },
+        // @ts-expect-error
+        blockchainLink: blockchainLinkJSON[chainId || shortcut],
+    };
+};

--- a/packages/connect/src/types/coinInfo.ts
+++ b/packages/connect/src/types/coinInfo.ts
@@ -66,6 +66,7 @@ export interface EthereumNetworkInfo extends Common {
     type: 'ethereum';
     chainId: number;
     network?: typeof undefined;
+    encoded_network?: ArrayBuffer;
 }
 
 export interface MiscNetworkInfo extends Common {

--- a/packages/connect/src/utils/__fixtures__/accountUtils.ts
+++ b/packages/connect/src/utils/__fixtures__/accountUtils.ts
@@ -40,7 +40,7 @@ export const isUtxoBasedFixtures: TestFixtures<typeof isUtxoBased> = [
     },
     {
         description: 'eth',
-        input: [getEthereumNetwork('eth')!],
+        input: [getEthereumNetworkFromCoinsJSON('eth')!],
         output: false,
     },
 ];

--- a/packages/connect/src/utils/__fixtures__/accountUtils.ts
+++ b/packages/connect/src/utils/__fixtures__/accountUtils.ts
@@ -1,19 +1,23 @@
 import coinsJSON from '@trezor/connect-common/files/coins.json';
 import coinsJSONEth from '@trezor/connect-common/files/coins-eth.json';
+import blockchainLinkJSON from '@trezor/connect-common/files/blockchain-link.json';
 
 import { getAccountLabel, isUtxoBased } from '../accountUtils';
 
 import {
     parseCoinsJson,
     getBitcoinNetwork,
-    getEthereumNetwork,
+    getEthereumNetworkFromCoinsJSON,
     getMiscNetwork,
 } from '../../data/coinInfo';
 
-parseCoinsJson({
-    ...coinsJSON,
-    eth: coinsJSONEth,
-});
+parseCoinsJson(
+    {
+        ...coinsJSON,
+        eth: coinsJSONEth,
+    },
+    blockchainLinkJSON,
+);
 
 export const getAccountLabelFixtures: TestFixtures<typeof getAccountLabel> = [
     {

--- a/packages/connect/src/utils/__fixtures__/ethereumUtils.ts
+++ b/packages/connect/src/utils/__fixtures__/ethereumUtils.ts
@@ -17,7 +17,8 @@ parseCoinsJson(
 export const getNetworkLabelFixtures: TestFixtures<typeof getNetworkLabel> = [
     {
         description: 'eth',
-        input: ['Export #NETWORK address', getEthereumNetwork('eth')],
+        // @ts-expect-error
+        input: ['Export #NETWORK address', coinsJSONEth[0]],
         output: 'Export Ethereum address',
     },
 ];

--- a/packages/connect/src/utils/__fixtures__/ethereumUtils.ts
+++ b/packages/connect/src/utils/__fixtures__/ethereumUtils.ts
@@ -1,14 +1,18 @@
 import coinsJSON from '@trezor/connect-common/files/coins.json';
 import coinsJSONEth from '@trezor/connect-common/files/coins-eth.json';
+import blockchainLinkJSON from '@trezor/connect-common/files/blockchain-link.json';
 
 import { getNetworkLabel } from '../ethereumUtils';
 
-import { parseCoinsJson, getEthereumNetwork } from '../../data/coinInfo';
+import { parseCoinsJson } from '../../data/coinInfo';
 
-parseCoinsJson({
-    ...coinsJSON,
-    eth: coinsJSONEth,
-});
+parseCoinsJson(
+    {
+        ...coinsJSON,
+        eth: coinsJSONEth,
+    },
+    blockchainLinkJSON,
+);
 
 export const getNetworkLabelFixtures: TestFixtures<typeof getNetworkLabel> = [
     {

--- a/packages/connect/src/utils/__fixtures__/formatUtils.ts
+++ b/packages/connect/src/utils/__fixtures__/formatUtils.ts
@@ -1,10 +1,11 @@
 import coinsJSON from '@trezor/connect-common/files/coins.json';
+import blockchainLinkJSON from '@trezor/connect-common/files/blockchain-link.json';
 
 import { formatAmount } from '../formatUtils';
 
 import { parseCoinsJson, getBitcoinNetwork } from '../../data/coinInfo';
 
-parseCoinsJson(coinsJSON);
+parseCoinsJson(coinsJSON, blockchainLinkJSON);
 
 export const formatAmountFixtures: TestFixtures<typeof formatAmount> = [
     {

--- a/packages/connect/src/utils/__tests__/addressUtils.test.ts
+++ b/packages/connect/src/utils/__tests__/addressUtils.test.ts
@@ -1,4 +1,6 @@
 import coinsJSON from '@trezor/connect-common/files/coins.json';
+import blockchainLinkJSON from '@trezor/connect-common/files/blockchain-link.json';
+
 import { parseCoinsJson, getBitcoinNetwork } from '../../data/coinInfo';
 import * as utils from '../addressUtils';
 import * as fixtures from '../__fixtures__/addressUtils';
@@ -6,7 +8,7 @@ import * as fixtures from '../__fixtures__/addressUtils';
 describe('utils/addressUtils', () => {
     beforeAll(() => {
         // load coin definitions
-        parseCoinsJson(coinsJSON);
+        parseCoinsJson(coinsJSON, blockchainLinkJSON);
     });
 
     describe('isValidAddress', () => {

--- a/packages/connect/src/utils/__tests__/deviceFeaturesUtils.test.ts
+++ b/packages/connect/src/utils/__tests__/deviceFeaturesUtils.test.ts
@@ -1,5 +1,6 @@
 import coinsJSON from '@trezor/connect-common/files/coins.json';
 import coinsJSONEth from '@trezor/connect-common/files/coins-eth.json';
+import blockchainLinkJSON from '@trezor/connect-common/files/blockchain-link.json';
 
 import { parseCoinsJson, getAllNetworks } from '../../data/coinInfo';
 
@@ -14,10 +15,13 @@ describe('utils/deviceFeaturesUtils', () => {
         jest.clearAllMocks();
     });
     beforeAll(() => {
-        parseCoinsJson({
-            ...coinsJSON,
-            eth: coinsJSONEth,
-        });
+        parseCoinsJson(
+            {
+                ...coinsJSON,
+                eth: coinsJSONEth,
+            },
+            blockchainLinkJSON,
+        );
     });
 
     it('parseCapabilities', () => {

--- a/packages/connect/src/utils/__tests__/deviceFeaturesUtils.test.ts
+++ b/packages/connect/src/utils/__tests__/deviceFeaturesUtils.test.ts
@@ -145,8 +145,6 @@ describe('utils/deviceFeaturesUtils', () => {
                 eip1559: 'update-required',
                 'eip712-domain-only': 'update-required',
                 taproot: 'update-required',
-                tsep: 'update-required',
-                tgor: 'update-required',
                 coinjoin: 'update-required',
                 signMessageNoScriptType: 'update-required',
             });
@@ -160,8 +158,6 @@ describe('utils/deviceFeaturesUtils', () => {
                 eip1559: 'update-required',
                 'eip712-domain-only': 'update-required',
                 taproot: 'update-required',
-                tsep: 'update-required',
-                tgor: 'update-required',
                 coinjoin: 'update-required',
                 signMessageNoScriptType: 'update-required',
             });

--- a/packages/connect/src/utils/assetUtils.ts
+++ b/packages/connect/src/utils/assetUtils.ts
@@ -7,6 +7,8 @@ export const getAssetByUrl = (url: string) => {
             return require('@trezor/connect-common/files/coins.json');
         case './data/coins-eth.json':
             return require('@trezor/connect-common/files/coins-eth.json');
+        case './data/blockchain-link.json':
+            return require('@trezor/connect-common/files/blockchain-link.json');
         case './data/bridge/releases.json':
             return require('@trezor/connect-common/files/bridge/releases.json');
         case './data/firmware/1/releases.json':


### PR DESCRIPTION
Help me brainstorm this 🙏 

Having blockchain_link record defined [in trezor-firmware](https://github.com/trezor/trezor-firmware/blob/master/common/defs/blockchain_link.json) repo does not make much sense. My first suggestion is to take it and mantain it in this repo. 

I wonder what keys should look like. similary to what they have in firmware repo because shortcut is not unique enough?

### steps, does it make sense?
 - make method.init async
 - remove method.initAsync
 - make coinInfo.getCoinInfo async 
 - remove blockchain-link field fromr coins.json and coins-eth.json
 - create standalone blockchain-link.json
 - remove eth classic, testnets from coins-eth.json -> thanks to this connect will start trying downloading eth definitions from data.trezor.io too.
 - coinInfo.getCoinfo -> returns either static definition or decoded def from trezor.io. if something was found, it adds blockchain-link field to it from blockchain-link.json. caching of download ethereum definitions can be done here too

### related
- https://github.com/trezor/trezor-suite/pull/8597 introduced eth definitions decoding. and probably also solved #8213 but it broke suite.
-  https://github.com/trezor/trezor-suite/pull/9113 hotfixed by putting eth records back. the logic right now is that whenever we find a definition in eth-json, it means that we don't try to download it from data.trezor.io. unfortunatelly, under current architecture we need to have all suite supported eth chains there because of blockchain-link records. 
- when we manage to decouple this we should be finally able to resolve this https://github.com/trezor/trezor-suite/issues/8213