### PR TITLE
fix(suite): max fee copy

### DIFF
--- a/packages/suite/src/components/suite/modals/ReviewTransaction/components/Output.tsx
+++ b/packages/suite/src/components/suite/modals/ReviewTransaction/components/Output.tsx
@@ -58,6 +58,7 @@ export type Props = OutputProps & {
 const Output = (props: Props) => {
     const { type, state, label, value, symbol, token, account } = props;
     let outputLabel: React.ReactNode = label;
+    const { networkType } = account;
 
     if (type === 'locktime') {
         const isTimestamp = new BigNumber(value).gte(BTC_LOCKTIME_VALUE);
@@ -66,7 +67,7 @@ const Output = (props: Props) => {
         );
     }
     if (type === 'fee') {
-        outputLabel = <Translation id="FEE" />;
+        outputLabel = <Translation id={networkType === 'ethereum' ? 'MAX_FEE' : 'FEE'} />;
     }
     if (type === 'contract') {
         outputLabel = <Translation id="TR_CONTRACT" />;

--- a/packages/suite/src/components/wallet/Fees/index.tsx
+++ b/packages/suite/src/components/wallet/Fees/index.tsx
@@ -163,7 +163,7 @@ export const Fees = <TFieldValues extends FormState>({
     const labelComponent =
         showLabel || label ? (
             <Label rbfForm={rbfForm}>
-                <Translation id={label ?? 'FEE'} />
+                <Translation id={label || (networkType === 'ethereum' ? 'MAX_FEE' : 'FEE')} />
             </Label>
         ) : null;
 

--- a/packages/suite/src/support/messages.ts
+++ b/packages/suite/src/support/messages.ts
@@ -5654,6 +5654,11 @@ export default defineMessages({
         description: 'Label in Send form',
         id: 'FEE',
     },
+    MAX_FEE: {
+        defaultMessage: 'Maximum fee',
+        description: 'Label in Send form for Ethereum network type',
+        id: 'MAX_FEE',
+    },
     FEE_LEVEL_CUSTOM: {
         defaultMessage: 'Custom',
         id: 'FEE_LEVEL_CUSTOM',


### PR DESCRIPTION
Updating copy since fees on Ethereum are not final

## Description

Ethereum type network have now in confirm modal Maximum fee instead of Fee.

## Related Issue

Resolve #3330
