### PR TITLE
Fix round phase utils and refactor enums to constants

### DIFF
--- a/packages/coinjoin/src/client/CoinjoinRound.ts
+++ b/packages/coinjoin/src/client/CoinjoinRound.ts
@@ -8,7 +8,7 @@ import {
     getCoinjoinRoundDeadlines,
 } from '../utils/roundUtils';
 import { ROUND_PHASE_PROCESS_TIMEOUT, ACCOUNT_BUSY_TIMEOUT } from '../constants';
-import { RoundPhase, EndRoundState, SessionPhase } from '../enums';
+import { EndRoundState, RoundPhase, SessionPhase } from '../enums';
 import { AccountAddress, RegisterAccountParams } from '../types/account';
 import {
     SerializedCoinjoinRound,

--- a/packages/coinjoin/src/enums.ts
+++ b/packages/coinjoin/src/enums.ts
@@ -1,43 +1,47 @@
-export enum SessionPhase {
+export const SessionPhase = {
     // RoundPhase.InputRegistration
-    RoundSearch = 101,
-    CoinSelection = 102,
-    RoundPairing = 103,
-    CoinRegistration = 104,
+    RoundSearch: 101,
+    CoinSelection: 102,
+    RoundPairing: 103,
+    CoinRegistration: 104,
     // error phases
-    AccountMissingUtxos = 151,
-    SkippingRound = 152,
-    RetryingRoundPairing = 153,
-    AffiliateServerOffline = 154,
-    CriticalError = 155,
-    BlockedUtxos = 156,
+    AccountMissingUtxos: 151,
+    SkippingRound: 152,
+    RetryingRoundPairing: 153,
+    AffiliateServerOffline: 154,
+    CriticalError: 155,
+    BlockedUtxos: 156,
 
     // RoundPhase.ConnectionConfirmation
-    AwaitingConfirmation = 201,
-    AwaitingOthersConfirmation = 202,
+    AwaitingConfirmation: 201,
+    AwaitingOthersConfirmation: 202,
 
     // RoundPhase.OutputRegistration
-    RegisteringOutputs = 301,
-    AwaitingOthersOutputs = 302,
+    RegisteringOutputs: 301,
+    AwaitingOthersOutputs: 302,
     // error phase
-    OutputRegistrationFailed = 351,
+    OutputRegistrationFailed: 351,
 
     // RoundPhase.TransactionSigning
-    AwaitingCoinjoinTransaction = 401,
-    TransactionSigning = 402,
-    SendingSignature = 403,
-    AwaitingOtherSignatures = 404,
+    AwaitingCoinjoinTransaction: 401,
+    TransactionSigning: 402,
+    SendingSignature: 403,
+    AwaitingOtherSignatures: 404,
     // error phases
-    SignatureFailed = 451,
-}
+    SignatureFailed: 451,
+} as const;
 
-export enum RoundPhase {
-    InputRegistration = 0,
-    ConnectionConfirmation = 1,
-    OutputRegistration = 2,
-    TransactionSigning = 3,
-    Ended = 4,
-}
+export type SessionPhase = (typeof SessionPhase)[keyof typeof SessionPhase];
+
+export const RoundPhase = {
+    InputRegistration: 0,
+    ConnectionConfirmation: 1,
+    OutputRegistration: 2,
+    TransactionSigning: 3,
+    Ended: 4,
+} as const;
+
+export type RoundPhase = (typeof RoundPhase)[keyof typeof RoundPhase];
 
 export enum EndRoundState {
     None = 0,

--- a/packages/suite/src/actions/wallet/coinjoinClientActions.ts
+++ b/packages/suite/src/actions/wallet/coinjoinClientActions.ts
@@ -7,6 +7,7 @@ import {
     CoinjoinRequestEvent,
     CoinjoinResponseEvent,
     CoinjoinClientEvents,
+    RoundPhase,
 } from '@trezor/coinjoin';
 import { SUITE } from 'src/actions/suite/constants';
 import { arrayDistinct, arrayToDictionary, promiseAllSequence } from '@trezor/utils';
@@ -23,12 +24,7 @@ import { selectAccountByKey } from '@suite-common/wallet-core';
 import { getUtxoOutpoint } from '@suite-common/wallet-utils';
 import { Dispatch, GetState } from 'src/types/suite';
 import { Account } from '@suite-common/wallet-types';
-import {
-    RoundPhase,
-    CoinjoinAccount,
-    EndRoundState,
-    CoinjoinDebugSettings,
-} from 'src/types/wallet/coinjoin';
+import { CoinjoinAccount, EndRoundState, CoinjoinDebugSettings } from 'src/types/wallet/coinjoin';
 import { onCancel as closeModal, openModal } from 'src/actions/suite/modalActions';
 import { notificationsActions } from '@suite-common/toast-notifications';
 import {

--- a/packages/suite/src/components/suite/modals/CriticalCoinjoinPhase/PhaseProgress.tsx
+++ b/packages/suite/src/components/suite/modals/CriticalCoinjoinPhase/PhaseProgress.tsx
@@ -1,10 +1,11 @@
 import React from 'react';
 import styled from 'styled-components';
-import { CoinjoinSession, RoundPhase, SessionPhase } from 'src/types/wallet/coinjoin';
+import { CoinjoinSession, SessionPhase } from 'src/types/wallet/coinjoin';
 import { Spinner, Icon, useTheme, variables } from '@trezor/components';
 import { SESSION_PHASE_MESSAGES } from 'src/constants/suite/coinjoin';
 import { Translation } from 'src/components/suite/Translation';
 import { CountdownTimer } from 'src/components/suite/CountdownTimer';
+import { RoundPhase } from '@trezor/coinjoin';
 
 const Container = styled.div`
     padding: 32px 38px 0;

--- a/packages/suite/src/constants/suite/coinjoin.ts
+++ b/packages/suite/src/constants/suite/coinjoin.ts
@@ -1,5 +1,5 @@
 import { TranslationKey } from '@suite-common/intl-types';
-import { RoundPhase, SessionPhase } from 'src/types/wallet/coinjoin';
+import { RoundPhase, SessionPhase } from '@trezor/coinjoin';
 
 export const ROUND_PHASE_MESSAGES: Record<RoundPhase, TranslationKey> = {
     [RoundPhase.InputRegistration]: 'TR_COINJOIN_PHASE_0_MESSAGE',

--- a/packages/suite/src/middlewares/wallet/coinjoinMiddleware.ts
+++ b/packages/suite/src/middlewares/wallet/coinjoinMiddleware.ts
@@ -15,7 +15,7 @@ import {
     messageSystemActions,
 } from '@suite-common/message-system';
 import { addToast } from '@suite-common/toast-notifications';
-import { SessionPhase } from '@trezor/coinjoin';
+import { RoundPhase, SessionPhase } from '@trezor/coinjoin';
 import { UI, DEVICE } from '@trezor/connect';
 import { arrayDistinct } from '@trezor/utils';
 
@@ -31,7 +31,7 @@ import * as coinjoinClientActions from 'src/actions/wallet/coinjoinClientActions
 import * as storageActions from 'src/actions/suite/storageActions';
 import { CoinjoinService } from 'src/services/coinjoin';
 import type { AppState, Action, Dispatch } from 'src/types/suite';
-import { CoinjoinConfig, RoundPhase } from 'src/types/wallet/coinjoin';
+import { CoinjoinConfig } from 'src/types/wallet/coinjoin';
 import {
     selectCoinjoinAccountByKey,
     selectIsAnySessionInCriticalPhase,

--- a/packages/suite/src/reducers/wallet/__fixtures__/coinjoinReducer.ts
+++ b/packages/suite/src/reducers/wallet/__fixtures__/coinjoinReducer.ts
@@ -1,6 +1,6 @@
+import { SessionPhase } from '@trezor/coinjoin';
 import { COINJOIN } from 'src/actions/wallet/constants';
 import { initialState } from 'src/reducers/wallet/coinjoinReducer';
-import { SessionPhase } from 'src/types/wallet/coinjoin';
 
 const account = {
     key: 'A',

--- a/packages/suite/src/reducers/wallet/coinjoinReducer.ts
+++ b/packages/suite/src/reducers/wallet/coinjoinReducer.ts
@@ -1,13 +1,12 @@
 import produce from 'immer';
 import BigNumber from 'bignumber.js';
 
-import { getInputSize, getOutputSize } from '@trezor/coinjoin';
+import { getInputSize, getOutputSize, RoundPhase } from '@trezor/coinjoin';
 import { PartialRecord } from '@trezor/type-utils';
 import { STORAGE } from 'src/actions/suite/constants';
 import { Account, AccountKey } from '@suite-common/wallet-types';
 import {
     CoinjoinAccount,
-    RoundPhase,
     CoinjoinDebugSettings,
     CoinjoinConfig,
     CoinjoinClientInstance,

--- a/packages/suite/src/types/wallet/coinjoin.ts
+++ b/packages/suite/src/types/wallet/coinjoin.ts
@@ -16,7 +16,8 @@ import {
     WabiSabiProtocolErrorCode,
 } from '@trezor/coinjoin/src/enums';
 
-export { RoundPhase, SessionPhase, EndRoundState, WabiSabiProtocolErrorCode };
+export { EndRoundState, WabiSabiProtocolErrorCode };
+export type { RoundPhase, SessionPhase };
 
 export interface CoinjoinSetup {
     targetAnonymity: number;

--- a/packages/suite/src/utils/wallet/__fixtures__/coinjoinUtils.ts
+++ b/packages/suite/src/utils/wallet/__fixtures__/coinjoinUtils.ts
@@ -1,3 +1,4 @@
+import { RoundPhase, SessionPhase } from '@trezor/coinjoin';
 import { ANONYMITY_GAINS_HINDSIGHT_COUNT } from 'src/services/coinjoin';
 import * as coinjoinUtils from '../coinjoinUtils';
 
@@ -153,6 +154,23 @@ export const calculateProgressParams: Array<{
         },
         result: 100,
     },
+];
+
+export const getRoundPhaseFromSessionPhase: {
+    sessionPhase: SessionPhase;
+    result?: RoundPhase | 'error';
+}[] = [
+    { sessionPhase: 101, result: 0 },
+    { sessionPhase: 451, result: 3 },
+];
+
+export const getFirstSessionPhaseFromRoundPhase: {
+    roundPhase: RoundPhase;
+    result: SessionPhase | 'error';
+}[] = [
+    { roundPhase: 0, result: 101 },
+    { roundPhase: 1, result: 201 },
+    { roundPhase: 4, result: 'error' },
 ];
 
 export const cleanAnonymityGains: Array<{

--- a/packages/suite/src/utils/wallet/__tests__/coinjoinUtils.test.ts
+++ b/packages/suite/src/utils/wallet/__tests__/coinjoinUtils.test.ts
@@ -22,6 +22,35 @@ describe('calculateAnonymityProgress', () => {
     });
 });
 
+describe('getRoundPhaseFromSessionPhase', () => {
+    it('gets correct value or throws', () => {
+        fixtures.getRoundPhaseFromSessionPhase.forEach(({ sessionPhase, result }) => {
+            const getSessionPhase = () => coinjoinUtils.getRoundPhaseFromSessionPhase(sessionPhase);
+
+            if (result === 'error') {
+                expect(getSessionPhase).toThrowError();
+            } else {
+                expect(getSessionPhase()).toEqual(result);
+            }
+        });
+    });
+});
+
+describe('getFirstSessionPhaseFromRoundPhase', () => {
+    it('gets correct value or throws', () => {
+        fixtures.getFirstSessionPhaseFromRoundPhase.forEach(({ roundPhase, result }) => {
+            const getSessionPhase = () =>
+                coinjoinUtils.getFirstSessionPhaseFromRoundPhase(roundPhase);
+
+            if (result === 'error') {
+                expect(getSessionPhase).toThrowError();
+            } else {
+                expect(getSessionPhase()).toEqual(result);
+            }
+        });
+    });
+});
+
 describe('cleanAnonymityGains', () => {
     it('cleans correctly', () => {
         fixtures.cleanAnonymityGains.forEach(({ params, resultLength }) => {

--- a/packages/suite/src/utils/wallet/coinjoinUtils.ts
+++ b/packages/suite/src/utils/wallet/coinjoinUtils.ts
@@ -320,7 +320,7 @@ export const getRoundPhaseFromSessionPhase = (sessionPhase: SessionPhase): Round
     roundPhases[Number(String(sessionPhase)[0]) - 1];
 
 export const getFirstSessionPhaseFromRoundPhase = (roundPhase?: RoundPhase): SessionPhase =>
-    Number(`${(roundPhase || 0) + 1}1`);
+    Number(`${(roundPhase || 0) + 1}01`);
 
 export const getAccountProgressHandle = (account: Pick<Account, 'key'>) =>
     createHash('sha256').update(account.key).digest('hex').slice(0, 16);

--- a/packages/suite/src/utils/wallet/coinjoinUtils.ts
+++ b/packages/suite/src/utils/wallet/coinjoinUtils.ts
@@ -15,14 +15,14 @@ import {
     AnonymityGainPerRound,
     CoinjoinAccount,
     CoinjoinSessionParameters,
-    RoundPhase,
-    SessionPhase,
 } from 'src/types/wallet/coinjoin';
 import { AnonymitySet } from '@trezor/blockchain-link';
 import {
     CoinjoinStatusEvent,
     RegisterAccountParams,
     CoinjoinTransactionData,
+    SessionPhase,
+    RoundPhase,
 } from '@trezor/coinjoin';
 
 export type CoinjoinBalanceBreakdown = {
@@ -308,19 +308,31 @@ export const getIsCoinjoinOutOfSync = (selectedAccount: SelectedAccountStatus) =
     }
 };
 
-const roundPhases = [
-    RoundPhase.InputRegistration,
-    RoundPhase.ConnectionConfirmation,
-    RoundPhase.OutputRegistration,
-    RoundPhase.TransactionSigning,
-    RoundPhase.Ended,
-];
+export const getRoundPhaseFromSessionPhase = (sessionPhase: SessionPhase) => {
+    const isValidRoundPhase = (result: number): result is RoundPhase =>
+        Object.values(RoundPhase).some(value => value === result);
 
-export const getRoundPhaseFromSessionPhase = (sessionPhase: SessionPhase): RoundPhase =>
-    roundPhases[Number(String(sessionPhase)[0]) - 1];
+    const result = Number(String(sessionPhase)[0]) - 1;
 
-export const getFirstSessionPhaseFromRoundPhase = (roundPhase?: RoundPhase): SessionPhase =>
-    Number(`${(roundPhase || 0) + 1}01`);
+    if (!isValidRoundPhase(result)) {
+        throw new Error(`Invalid round phase value: ${result}`);
+    }
+
+    return result;
+};
+
+export const getFirstSessionPhaseFromRoundPhase = (roundPhase?: RoundPhase) => {
+    const isValidSessionPhase = (result: number): result is SessionPhase =>
+        Object.values(SessionPhase).some(value => value === result);
+
+    const result = Number(`${(roundPhase || 0) + 1}01`);
+
+    if (!isValidSessionPhase(result)) {
+        throw new Error(`Invalid session phase value: ${result}`);
+    }
+
+    return result;
+};
 
 export const getAccountProgressHandle = (account: Pick<Account, 'key'>) =>
     createHash('sha256').update(account.key).digest('hex').slice(0, 16);


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->
Bug reported [here](https://satoshilabs.slack.com/archives/C048XFAKL10/p1693295058278249). I haven't reproduced it, but from code inspection it seems that the culprit was the `getFirstSessionPhaseFromRoundPhase` util which expected an old, two-digit format of `SessionPhase`.

I added a check to throw an error on invalid value and some unit tests.

I also refactored the enums to constants for better type safety. The enums accepted any `number` instead of limiting it to the listed values, which could lead to more bugs. Discussed [here](https://www.notion.so/satoshilabs/Proposals-6296b830b8e94df889ba93f66f7964a5).

## Screenshots:

![image (2)](https://github.com/trezor/trezor-suite/assets/42465546/2136591d-2c2c-405f-aa4a-089e0f7afb98)
