### PR TITLE
fix(suite-native): use cancelAuthenticate only on Android

### DIFF
--- a/suite-native/biometrics/src/useBiometrics.tsx
+++ b/suite-native/biometrics/src/useBiometrics.tsx
@@ -1,5 +1,5 @@
 import { useCallback, useEffect, useRef, useState } from 'react';
-import { AppState } from 'react-native';
+import { AppState, Platform } from 'react-native';
 
 import * as LocalAuthentication from 'expo-local-authentication';
 
@@ -34,7 +34,7 @@ export const useBiometrics = () => {
 
     const handleAuthentication = useCallback(async () => {
         // Stop the authentication flow if the user leaves the app.
-        if (appState.current !== 'active') {
+        if (appState.current !== 'active' && Platform.OS === 'android') {
             LocalAuthentication.cancelAuthenticate();
             return;
         }


### PR DESCRIPTION
Based on [the docs](https://docs.expo.dev/versions/latest/sdk/local-authentication/#localauthenticationcancelauthenticate) cancelAuthenticate is not available for iOS devices

## Description

`LocalAuthentication.cancelAuthenticate()` is now used only on Android devices.

## Related Issue

Resolve #9308