### PR TITLE
Feat/connect authenticate device (T2B1)

### DIFF
--- a/ci/test.yml
+++ b/ci/test.yml
@@ -365,6 +365,10 @@ connect model R:
       - schedules
   parallel:
     matrix:
+      - TESTS_ENVIRONMENT: ["node", "web"]
+        TESTS_PATTERN: "authenticateDevice"
+        TESTS_FIRMWARE: ["2-latest"]
+        TESTS_FIRMWARE_MODEL: "R"
       - TESTS_ENVIRONMENT: ["node"]
         TESTS_PATTERN: "methods"
         TESTS_FIRMWARE: ["2-latest"]

--- a/docs/packages/connect/methods/authenticateDevice.md
+++ b/docs/packages/connect/methods/authenticateDevice.md
@@ -1,0 +1,27 @@
+## authenticateDevice
+
+> :note: **Supported only by T2B1 devices**
+
+Request a signature and validate certificate issued by the Trezor company.
+Returns [DeviceAuthenticityResult type](https://github.com/trezor/trezor-suite/blob/develop/packages/connect/src/types/api/authenticateDevice.ts)
+
+### Params
+
+[Optional common params](commonParams.md)
+
+-   `config` — _optional_ [`DeviceAuthenticityConfig`](https://github.com/trezor/trezor-suite/blob/develop/packages/connect/src/types/api/authenticateDevice.ts)
+
+### Example
+
+```javascript
+TrezorConnect.authenticateDevice({ config });
+```
+
+### Result
+
+```javascript
+{
+    success: true,
+    payload: DeviceAuthenticityResult
+}
+```

--- a/packages/connect/e2e/tests/device/authenticateDevice.test.ts
+++ b/packages/connect/e2e/tests/device/authenticateDevice.test.ts
@@ -1,0 +1,79 @@
+/* eslint-disable import/no-named-as-default */
+
+import TrezorConnect from '../../../src';
+
+const { getController, setup, initTrezorConnect } = global.Trezor;
+
+const controller = getController();
+
+describe('TrezorConnect.authenticateDevice', () => {
+    beforeAll(async () => {
+        await setup(controller, {
+            mnemonic: 'mnemonic_all',
+        });
+        await initTrezorConnect(controller);
+    });
+
+    afterAll(async () => {
+        controller.dispose();
+        await TrezorConnect.dispose();
+    });
+
+    // NOTE: emulator uses different provisioning keys than production FW (different than ./data/deviceAuthenticityConfig)
+    const config = {
+        version: 1,
+        timestamp: '2023-09-07T14:00:00+00:00',
+        T2B1: {
+            rootPubKeys: [
+                '04626d58aca84f0fcb52ea63f0eb08de1067b8d406574a715d5e7928f4b67f113a00fb5c5918e74d2327311946c446b242c20fe7347482999bdc1e229b94e27d96',
+            ],
+            caPubKeys: [
+                '049bf0760cd7555efc5b01e64ce94606cdeeb48a4f9196f454bc2a0141b331882d068b4b6e637913dd220654e28fde3c442141f953b3e36ad9a57519007119d9c9',
+            ],
+        },
+    };
+
+    it('validation successful', async () => {
+        const result = await TrezorConnect.authenticateDevice({
+            config,
+        });
+
+        if (result.success) {
+            expect(result.payload.valid).toEqual(true);
+        }
+    });
+
+    it('validation unsuccessful (rootPubKey not found)', async () => {
+        const result = await TrezorConnect.authenticateDevice({
+            config: {
+                ...config,
+                T2B1: {
+                    ...config.T2B1,
+                    rootPubKeys: [],
+                },
+            },
+        });
+
+        if (result.success) {
+            expect(result.payload.valid).toEqual(false);
+            expect(result.payload.error).toEqual('ROOT_PUBKEY_NOT_FOUND');
+        }
+    });
+
+    it('sanity check unsuccessful (caPubkey not found)', async () => {
+        const result = await TrezorConnect.authenticateDevice({
+            config: {
+                ...config,
+                T2B1: {
+                    ...config.T2B1,
+                    caPubKeys: [],
+                },
+            },
+        });
+
+        if (result.success) {
+            expect(result.payload.valid).toEqual(false);
+            expect(result.payload.error).toEqual('CA_PUBKEY_NOT_FOUND');
+        }
+    });
+});

--- a/packages/connect/src/api/authenticateDevice.ts
+++ b/packages/connect/src/api/authenticateDevice.ts
@@ -1,0 +1,60 @@
+import { AbstractMethod } from '../core/AbstractMethod';
+import { UI } from '../events';
+import { validateParams } from './common/paramsValidator';
+import { deviceAuthenticityConfig } from '../data/deviceAuthenticityConfig';
+import { AuthenticateDeviceParams } from '../types/api/authenticateDevice';
+import { getRandomChallenge, verifyAuthenticityProof } from './firmware/verifyAuthenticityProof';
+
+export default class AuthenticateDevice extends AbstractMethod<
+    'authenticateDevice',
+    AuthenticateDeviceParams
+> {
+    init() {
+        this.useEmptyPassphrase = true;
+        this.allowDeviceMode = [UI.INITIALIZE, UI.SEEDLESS];
+        this.requiredPermissions = ['management'];
+        this.useDeviceState = false;
+
+        const { payload } = this;
+
+        // TODO validate firmware/model version
+
+        validateParams(payload, [
+            { name: 'config', type: 'object' },
+            { name: 'allowDebugKeys', type: 'boolean' },
+        ]);
+        if (payload.config) {
+            validateParams(payload.config, [{ name: 'timestamp', type: 'string', required: true }]);
+            validateParams(payload.config.T2B1, [
+                { name: 'rootPubKeys', type: 'array', required: true },
+                { name: 'caPubKeys', type: 'array', required: true },
+            ]);
+        }
+
+        this.params = {
+            config: payload.config,
+            allowDebugKeys: payload.allowDebugKeys,
+        };
+    }
+
+    async run() {
+        const challenge = getRandomChallenge();
+
+        const { message } = await this.device
+            .getCommands()
+            .typedCall('AuthenticateDevice', 'AuthenticityProof', {
+                challenge: challenge.toString('hex'),
+            });
+
+        const config = this.params.config || deviceAuthenticityConfig;
+        const valid = await verifyAuthenticityProof({
+            ...message,
+            challenge,
+            config,
+            allowDebugKeys: this.params.allowDebugKeys,
+            deviceModel: this.device.features.internal_model,
+        });
+
+        return valid;
+    }
+}

--- a/packages/connect/src/api/firmware/__tests__/verifyAuthenticityProof.test.ts
+++ b/packages/connect/src/api/firmware/__tests__/verifyAuthenticityProof.test.ts
@@ -1,0 +1,183 @@
+import { verifyAuthenticityProof } from '../verifyAuthenticityProof';
+
+const CA_CERT =
+    '308201df30820184a00302010202040a001ab3300a06082a8648ce3d0403023054310b300906035504061302435a311e301c060355040a0c155472657a6f7220436f6d70616e7920732e722e6f2e3125302306035504030c1c5472657a6f72204d616e75666163747572696e6720526f6f742043413020170d3233303130313030303030305a180f32303533303130313030303030305a304f310b300906035504061302435a311e301c060355040a0c155472657a6f7220436f6d70616e7920732e722e6f2e3120301e06035504030c175472657a6f72204d616e75666163747572696e672043413059301306072a8648ce3d020106082a8648ce3d030107034200041b36cc98d5e3d1a20677aaf26254ef3756f27c9d63080c93ad3e7d39d3ad23bf00497b924789bc8e3f87834994e16780ad4eae7e75db1f03835ca64363e980b4a3473045300e0603551d0f0101ff04040302020430120603551d130101ff040830060101ff020100301f0603551d2304183016801428b202f8f9c78a74e8c152bbfb433d99d0ca03ef300a06082a8648ce3d0403020349003046022100dfe2f837f3644c1f0250d37cd0f7d1e4e9b8cfc4820d7f5a623a8cb69df99f6c02210089148848c5fc597df4b8545d9b19d1cc15abe0e1252fa2938a4cf01ae835c563';
+const DEVICE_CERT =
+    '3082019e30820145a00302010202044ee2a50f300a06082a8648ce3d040302304f310b300906035504061302435a311e301c060355040a0c155472657a6f7220436f6d70616e7920732e722e6f2e3120301e06035504030c175472657a6f72204d616e75666163747572696e67204341301e170d3232303433303134313630315a170d3432303433303134313630315a301d311b301906035504030c1254324231205472657a6f72205361666520333059301306072a8648ce3d020106082a8648ce3d030107034200049bbf06dad9ab5905e05471ce16d5222c89c2caa39f26267ac0747129885fbd441bcc7fa84de120a36755daf30a6f47e8c0d4bddc15036ed2a3447dfa7a1d3e88a341303f300e0603551d0f0101ff040403020080300c0603551d130101ff04023000301f0603551d23041830168014176d8b9a403574f6a2b9ac353ef578682201a21a300a06082a8648ce3d04030203470030440220747c545e112df816173d3071f1ab25d399d8108550764ce1a3a428f1f18b506902200cda822c75b3da6e44e098014452f3fc324f29a79204c3fb4d5815afafc04b17';
+const SIGNATURE =
+    '3045022100c01793ffbe4f16d4efc84a4533d9bbfbbf1baa5349346678e07fdb6d848cca7902200df11b9d2850173d9c93993fca983c6d2a3f31ea69a0e19b69e18cc3b78424fe';
+const CHALLENGE = '29d0be0f3cb191c80d108359c64d22984a77ad8b99433814be31db0b6e9e7920';
+const CONFIG = {
+    version: 1,
+    timestamp: '2023-09-07T14:00:00+00:00',
+    T2B1: {
+        rootPubKeys: [
+            '04626d58aca84f0fcb52ea63f0eb08de1067b8d406574a715d5e7928f4b67f113a00fb5c5918e74d2327311946c446b242c20fe7347482999bdc1e229b94e27d96',
+        ],
+        caPubKeys: [
+            '041b36cc98d5e3d1a20677aaf26254ef3756f27c9d63080c93ad3e7d39d3ad23bf00497b924789bc8e3f87834994e16780ad4eae7e75db1f03835ca64363e980b4',
+        ],
+    },
+};
+
+describe('firmware/verifyAuthenticityProof', () => {
+    it('verify success (with prod keys)', async () => {
+        const verify = await verifyAuthenticityProof({
+            certificates: [DEVICE_CERT, CA_CERT],
+            signature: SIGNATURE,
+            challenge: Buffer.from(CHALLENGE, 'hex'),
+            deviceModel: 'T2B1',
+            config: CONFIG,
+        });
+
+        expect(verify.valid).toBe(true);
+        expect(verify.debugKey).toBe(undefined);
+        expect(verify.caPubKey).toEqual(expect.any(String));
+    });
+
+    it('verify success (with debug keys)', async () => {
+        const verify = await verifyAuthenticityProof({
+            certificates: [DEVICE_CERT, CA_CERT],
+            signature: SIGNATURE,
+            challenge: Buffer.from(CHALLENGE, 'hex'),
+            deviceModel: 'T2B1',
+            config: {
+                ...CONFIG,
+                T2B1: {
+                    rootPubKeys: [],
+                    caPubKeys: [],
+                    debug: {
+                        rootPubKeys: CONFIG.T2B1.rootPubKeys,
+                        caPubKeys: CONFIG.T2B1.caPubKeys,
+                    },
+                },
+            },
+            allowDebugKeys: true,
+        });
+
+        expect(verify.valid).toBe(true);
+        expect(verify.debugKey).toBe(true);
+        expect(verify.caPubKey).toEqual(expect.any(String));
+    });
+
+    it('verify failed (signature missmatch)', async () => {
+        const verify = await verifyAuthenticityProof({
+            certificates: [DEVICE_CERT, CA_CERT],
+            signature:
+                // invalid 1st byte of signature
+                '0045022100c01793ffbe4f16d4efc84a4533d9bbfbbf1baa5349346678e07fdb6d848cca7902200df11b9d2850173d9c93993fca983c6d2a3f31ea69a0e19b69e18cc3b78424fe',
+            challenge: Buffer.from(CHALLENGE, 'hex'),
+            deviceModel: 'T2B1',
+            config: CONFIG,
+        });
+
+        expect(verify.valid).toBe(false);
+        expect(verify.error).toBe('INVALID_DEVICE_SIGNATURE');
+    });
+
+    it('verify failed (missing rootPubKey)', async () => {
+        const verify = await verifyAuthenticityProof({
+            certificates: [DEVICE_CERT, CA_CERT],
+            signature: SIGNATURE,
+            challenge: Buffer.from(CHALLENGE, 'hex'),
+            deviceModel: 'T2B1',
+            config: {
+                ...CONFIG,
+                T2B1: {
+                    ...CONFIG.T2B1,
+                    rootPubKeys: [
+                        // invalid root pub key
+                        '0423a5c9ec44dfb96023838d958f6289fa611277ee7af60c3bcb54eff2310546d5ece48b1a507503142b122b53eda53fef3f3d3510f3b7ae2fd5f13614b025ede1',
+                    ],
+                },
+            },
+        });
+
+        expect(verify.valid).toBe(false);
+        expect(verify.configExpired).toBe(false);
+        expect(verify.error).toBe('ROOT_PUBKEY_NOT_FOUND');
+    });
+
+    it('verify failed (outdated config, missing rootPubKey)', async () => {
+        const verify = await verifyAuthenticityProof({
+            certificates: [DEVICE_CERT, CA_CERT],
+            signature: SIGNATURE,
+            challenge: Buffer.from(CHALLENGE, 'hex'),
+            deviceModel: 'T2B1',
+            config: {
+                ...CONFIG,
+                // old timestamp
+                timestamp: '2000-09-07T14:00:00+00:00',
+                T2B1: {
+                    ...CONFIG.T2B1,
+                    rootPubKeys: [
+                        // invalid root pub key
+                        '0423a5c9ec44dfb96023838d958f6289fa611277ee7af60c3bcb54eff2310546d5ece48b1a507503142b122b53eda53fef3f3d3510f3b7ae2fd5f13614b025ede1',
+                    ],
+                },
+            },
+        });
+
+        expect(verify.valid).toBe(false);
+        expect(verify.configExpired).toBe(true);
+        expect(verify.error).toBe('ROOT_PUBKEY_NOT_FOUND');
+    });
+
+    it('verify failed (device model mismatch)', async () => {
+        const verify = await verifyAuthenticityProof({
+            certificates: [
+                '3082019e30820145a00302010202044ee2a50f300a06082a8648ce3d040302304f310b300906035504061302435a311e301c060355040a0c155472657a6f7220436f6d70616e7920732e722e6f2e3120301e06035504030c175472657a6f72204d616e75666163747572696e67204341301e170d3232303433303134313630315a170d3432303433303134313630315a301d311b301906035504030c1254324232205472657a6f72205361666520333059301306072a8648ce3d020106082a8648ce3d030107034200049bbf06dad9ab5905e05471ce16d5222c89c2caa39f26267ac0747129885fbd441bcc7fa84de120a36755daf30a6f47e8c0d4bddc15036ed2a3447dfa7a1d3e88a341303f300e0603551d0f0101ff040403020080300c0603551d130101ff04023000301f0603551d23041830168014176d8b9a403574f6a2b9ac353ef578682201a21a300a06082a8648ce3d04030203470030440220747c545e112df816173d3071f1ab25d399d8108550764ce1a3a428f1f18b506902200cda822c75b3da6e44e098014452f3fc324f29a79204c3fb4d5815afafc04b17',
+                CA_CERT,
+            ],
+            signature: SIGNATURE,
+            challenge: Buffer.from(CHALLENGE, 'hex'),
+            deviceModel: 'T2B1',
+            config: CONFIG,
+        });
+
+        expect(verify.valid).toBe(false);
+        expect(verify.error).toBe('INVALID_DEVICE_MODEL');
+    });
+
+    it('verify failed (missing caPubKey)', async () => {
+        const verify = await verifyAuthenticityProof({
+            certificates: [DEVICE_CERT, CA_CERT],
+            signature: SIGNATURE,
+            challenge: Buffer.from(CHALLENGE, 'hex'),
+            deviceModel: 'T2B1',
+            config: {
+                ...CONFIG,
+                T2B1: {
+                    ...CONFIG.T2B1,
+                    caPubKeys: [],
+                },
+            },
+        });
+
+        expect(verify.valid).toBe(false);
+        expect(verify.configExpired).toBe(false);
+        expect(verify.error).toBe('CA_PUBKEY_NOT_FOUND');
+    });
+
+    it('verify failed (outdated config, missing caPubKey)', async () => {
+        const verify = await verifyAuthenticityProof({
+            certificates: [DEVICE_CERT, CA_CERT],
+            signature: SIGNATURE,
+            challenge: Buffer.from(CHALLENGE, 'hex'),
+            deviceModel: 'T2B1',
+            config: {
+                ...CONFIG,
+                // old timestamp
+                timestamp: '2000-09-07T14:00:00+00:00',
+                T2B1: {
+                    ...CONFIG.T2B1,
+                    caPubKeys: [],
+                },
+            },
+        });
+
+        expect(verify.valid).toBe(false);
+        expect(verify.configExpired).toBe(true);
+        expect(verify.error).toBe('CA_PUBKEY_NOT_FOUND');
+    });
+});

--- a/packages/connect/src/api/firmware/verifyAuthenticityProof.ts
+++ b/packages/connect/src/api/firmware/verifyAuthenticityProof.ts
@@ -1,0 +1,179 @@
+import * as crypto from 'crypto';
+import { bufferUtils } from '@trezor/utils';
+
+import { PROTO } from '../../constants';
+import { DeviceAuthenticityConfig } from '../../data/deviceAuthenticityConfig';
+import { AuthenticateDeviceResult } from '../../types/api/authenticateDevice';
+import { parseCertificate } from './x509certificate';
+
+// There is incomparability in results between nodejs and window SubtleCrypto api.
+// window.crypto.subtle.importKey (CryptoKey) cannot be used by `crypto-browserify`.Verify
+// The only common format of publicKey is PEM.
+const verifySignature = async (rawKey: Buffer, data: Uint8Array, signature: Uint8Array) => {
+    const signer = crypto.createVerify('sha256');
+    signer.update(Buffer.from(data));
+
+    // use native SubtleCrypto api.
+    // Unfortunately `crypto-browserify`.subtle polyfill is missing so needs to be referenced directly from window object (if exists)
+    // https://github.com/browserify/crypto-browserify/issues/221
+    const SubtleCrypto = typeof window !== 'undefined' ? window.crypto.subtle : crypto.subtle;
+    if (!SubtleCrypto) {
+        throw new Error('SubtleCrypto not supported');
+    }
+
+    // get ECDSA P-256 (secp256r1) key from RAW key
+    const ecPubKey = await SubtleCrypto.importKey(
+        'raw',
+        rawKey,
+        { name: 'ECDSA', namedCurve: 'P-256' },
+        true,
+        ['verify'],
+    );
+
+    // export ECDSA key as spki
+    const spkiPubKey = await SubtleCrypto.exportKey('spki', ecPubKey);
+
+    // create PEM from spki
+    const key = `-----BEGIN PUBLIC KEY-----\n${Buffer.from(spkiPubKey).toString(
+        'base64',
+    )}\n-----END PUBLIC KEY-----`;
+
+    // verify using PEM key
+    return signer.verify({ key }, Buffer.from(signature));
+};
+
+interface AuthenticityProofData extends PROTO.AuthenticityProof {
+    challenge: Buffer;
+    config: DeviceAuthenticityConfig;
+    allowDebugKeys?: boolean;
+    deviceModel: keyof typeof PROTO.DeviceModelInternal; // Device.features.internal_model
+}
+
+export const getRandomChallenge = () => crypto.randomBytes(32);
+
+export const verifyAuthenticityProof = async ({
+    certificates,
+    signature,
+    challenge,
+    config,
+    allowDebugKeys,
+    deviceModel,
+}: AuthenticityProofData): Promise<AuthenticateDeviceResult> => {
+    const modelConfig = config[deviceModel];
+    if (!modelConfig) {
+        throw new Error(`Pubkeys for ${deviceModel} not found in config`);
+    }
+    const { caPubKeys, debug } = modelConfig;
+
+    // 1. parse x509 CA certificate from AuthenticityProof
+    const caCert = parseCertificate(new Uint8Array(Buffer.from(certificates[1], 'hex')));
+    const caPubKey = Buffer.from(caCert.tbsCertificate.subjectPublicKeyInfo.bits.bytes).toString(
+        'hex',
+    );
+
+    // 2. parse x509 DEVICE certificate from AuthenticityProof
+    const deviceCert = parseCertificate(new Uint8Array(Buffer.from(certificates[0], 'hex')));
+
+    // 3. validate that CA certificate was created using one of rootPubkeys
+    const rootPubKeys = allowDebugKeys
+        ? modelConfig.rootPubKeys.concat(debug?.rootPubKeys || [])
+        : modelConfig.rootPubKeys;
+
+    const isCertSignedByRootPubkey = await Promise.all(
+        rootPubKeys.map(rootPubKey =>
+            verifySignature(
+                Buffer.from(rootPubKey, 'hex'),
+                caCert.tbsCertificate.asn1.raw,
+                caCert.signatureValue.bits.bytes,
+            ),
+        ),
+    );
+
+    const rootPubKeyIndex = isCertSignedByRootPubkey.findIndex(valid => !!valid);
+    const rootPubKey = rootPubKeys[rootPubKeyIndex];
+    const isDebugRootPubKey = debug?.rootPubKeys.includes(rootPubKey);
+    if (!rootPubKey) {
+        const configExpired =
+            new Date(config.timestamp).getTime() < caCert.tbsCertificate.validity.from.getTime();
+        return {
+            valid: false,
+            configExpired,
+            caPubKey,
+            error: 'ROOT_PUBKEY_NOT_FOUND',
+        };
+    }
+
+    // 4. validate DEVICE certificate subject (Trezor features internal_model)
+    const [subject] = deviceCert.tbsCertificate.subject;
+    // subject algorithm (OID) https://www.alvestrand.no/objectid/2.5.4.3.html
+    if (!subject.parameters || subject.algorithm !== '2.5.4.3') {
+        throw new Error('Missing certificate subject');
+    }
+    // slice 4 bytes from the subject (internal model)
+    const subjectValue = Buffer.from(subject.parameters.asn1.contents.subarray(0, 4)).toString();
+    if (subjectValue !== deviceModel) {
+        return {
+            valid: false,
+            caPubKey,
+            error: 'INVALID_DEVICE_MODEL',
+        };
+    }
+
+    // 5. validate that DEVICE certificate was created using pubKey from CA certificate
+    const isDeviceCertValid = await verifySignature(
+        Buffer.from(caCert.tbsCertificate.subjectPublicKeyInfo.bits.bytes),
+        deviceCert.tbsCertificate.asn1.raw,
+        deviceCert.signatureValue.bits.bytes,
+    );
+
+    // 6. validate that the signature from AuthenticityProof was created using prefixed challenge **and** DEVICE certificate pubKey
+    const challengePrefix = Buffer.from('AuthenticateDevice:');
+    const prefixedChallenge = Buffer.concat([
+        bufferUtils.getChunkSize(challengePrefix.length),
+        challengePrefix,
+        bufferUtils.getChunkSize(challenge.length),
+        challenge,
+    ]);
+    const isSignatureValid = await verifySignature(
+        Buffer.from(deviceCert.tbsCertificate.subjectPublicKeyInfo.bits.bytes),
+        prefixedChallenge,
+        Buffer.from(signature, 'hex'),
+    );
+
+    if (rootPubKey && isDeviceCertValid && isSignatureValid) {
+        if (
+            (!isDebugRootPubKey && !caPubKeys.includes(caPubKey)) ||
+            (isDebugRootPubKey && !debug?.caPubKeys.includes(caPubKey))
+        ) {
+            const configExpired =
+                new Date(config.timestamp).getTime() <
+                deviceCert.tbsCertificate.validity.from.getTime();
+            return {
+                valid: false,
+                configExpired,
+                caPubKey,
+                error: 'CA_PUBKEY_NOT_FOUND',
+            };
+        }
+
+        return {
+            valid: true,
+            caPubKey,
+            debugKey: isDebugRootPubKey,
+        };
+    }
+
+    if (!isDeviceCertValid) {
+        return {
+            valid: false,
+            caPubKey,
+            error: 'INVALID_DEVICE_CERTIFICATE',
+        };
+    }
+
+    return {
+        valid: false,
+        caPubKey,
+        error: 'INVALID_DEVICE_SIGNATURE',
+    };
+};

--- a/packages/connect/src/api/firmware/x509certificate.ts
+++ b/packages/connect/src/api/firmware/x509certificate.ts
@@ -1,0 +1,291 @@
+/**
+ * Module used by `authenticateDevice` method.
+ *
+ * Parse x509 certificate returned from Trezor (PROTO.AuthenticityProof) from DER format.
+ * inspired by https://blog.engelke.com/2014/10/21/web-crypto-and-x-509-certificates/
+ */
+
+interface Asn1 {
+    cls: number; // ASN.1 class of the object.
+    tag: number; // ASN.1 object type.
+    structured: boolean; // Structured objects are encoded ASN.1 objects. Other objects (primitive) values depends on the tag and class
+    byteLength: number; // value size
+    contents: Uint8Array; // byte array containing the object value.
+    raw: Uint8Array; // original byte array
+}
+
+const derToAsn1 = (byteArray: Uint8Array): Asn1 => {
+    let position = 0;
+
+    function getTag() {
+        let tag = byteArray[0] & 0x1f;
+        position += 1;
+        if (tag === 0x1f) {
+            tag = 0;
+            while (byteArray[position] >= 0x80) {
+                tag = tag * 128 + byteArray[position] - 0x80;
+                position += 1;
+            }
+            tag = tag * 128 + byteArray[position] - 0x80;
+            position += 1;
+        }
+        return tag;
+    }
+
+    function getLength() {
+        let length = 0;
+
+        if (byteArray[position] < 0x80) {
+            length = byteArray[position];
+            position += 1;
+        } else {
+            const numberOfDigits = byteArray[position] & 0x7f;
+            position += 1;
+            length = 0;
+            for (let i = 0; i < numberOfDigits; i++) {
+                length = length * 256 + byteArray[position];
+                position += 1;
+            }
+        }
+        return length;
+    }
+
+    const cls = (byteArray[0] & 0xc0) / 64;
+    const structured = (byteArray[0] & 0x20) === 0x20;
+    const tag = getTag();
+
+    let length = getLength(); // As encoded, which may be special value 0
+    let byteLength;
+    let contents;
+
+    if (length === 0x80) {
+        length = 0;
+        while (byteArray[position + length] !== 0 || byteArray[position + length + 1] !== 0) {
+            length += 1;
+        }
+        byteLength = position + length + 2;
+        contents = byteArray.subarray(position, position + length);
+    } else {
+        byteLength = position + length;
+        contents = byteArray.subarray(position, byteLength);
+    }
+
+    const raw = byteArray.subarray(0, byteLength); // May not be the whole input array
+
+    return {
+        cls,
+        tag,
+        structured,
+        byteLength,
+        contents,
+        raw,
+    };
+};
+
+const derToAsn1List = (byteArray: Uint8Array) => {
+    const result = [];
+    let nextPosition = 0;
+    while (nextPosition < byteArray.length) {
+        const nextPiece = derToAsn1(byteArray.subarray(nextPosition));
+        result.push(nextPiece);
+        nextPosition += nextPiece.byteLength;
+    }
+    return result;
+};
+
+const derBitStringValue = (byteArray: Uint8Array) => ({
+    unusedBits: byteArray[0],
+    bytes: byteArray.subarray(1),
+});
+
+const parseSignatureValue = (asn1: Asn1) => {
+    if (asn1.cls !== 0 || asn1.tag !== 3 || asn1.structured) {
+        throw new Error('Bad signature value. Not a BIT STRING.');
+    }
+    return {
+        asn1,
+        bits: derBitStringValue(asn1.contents),
+    };
+};
+
+const derObjectIdentifierValue = (byteArray: Uint8Array) => {
+    let oid = `${Math.floor(byteArray[0] / 40)}.${byteArray[0] % 40}`;
+    let position = 1;
+    while (position < byteArray.length) {
+        let nextInteger = 0;
+        while (byteArray[position] >= 0x80) {
+            nextInteger = nextInteger * 0x80 + (byteArray[position] & 0x7f);
+            position += 1;
+        }
+        nextInteger = nextInteger * 0x80 + byteArray[position];
+        position += 1;
+        oid += `.${nextInteger}`;
+    }
+    return oid;
+};
+
+/*
+ * AlgorithmIdentifier ::= SEQUENCE {
+ *   algorithm     OBJECT IDENTIFIER,
+ *   parameters    ANY DEFINED BY algorithm OPTIONAL
+ * }
+ */
+const parseAlgorithmIdentifier = (asn1: Asn1) => {
+    if (asn1.cls !== 0 || asn1.tag !== 16 || !asn1.structured) {
+        throw new Error('Bad algorithm identifier. Not a SEQUENCE.');
+    }
+    const pieces = derToAsn1List(asn1.contents);
+    if (pieces.length > 2) {
+        throw new Error('Bad algorithm identifier. Contains too many child objects.');
+    }
+    const encodedAlgorithm = pieces[0];
+    if (encodedAlgorithm.cls !== 0 || encodedAlgorithm.tag !== 6 || encodedAlgorithm.structured) {
+        throw new Error('Bad algorithm identifier. Does not begin with an OBJECT IDENTIFIER.');
+    }
+    const algorithm = derObjectIdentifierValue(encodedAlgorithm.contents);
+
+    return {
+        asn1,
+        algorithm,
+        parameters: pieces.length === 2 ? { asn1: pieces[1] } : null,
+    };
+};
+
+/*
+ * Name ::= SEQUENCE {
+ *   algorithm     OBJECT IDENTIFIER,
+ *   parameters    ANY DEFINED BY algorithm OPTIONAL
+ * }
+ */
+export const parseName = (asn1: Asn1) =>
+    // SEQUENCE > SET > SEQUENCE
+    derToAsn1List(asn1.contents).map(item => {
+        const attrSet = derToAsn1(item.contents);
+        return parseAlgorithmIdentifier(attrSet);
+    });
+
+/*
+ * SubjectPublicKeyInfo ::= SEQUENCE {
+ *   algorithm            AlgorithmIdentifier,
+ *   subjectPublicKey     BIT STRING
+ * }
+ */
+const parseSubjectPublicKeyInfo = (asn1: Asn1) => {
+    if (asn1.cls !== 0 || asn1.tag !== 16 || !asn1.structured) {
+        throw new Error('Bad SPKI. Not a SEQUENCE.');
+    }
+    const pieces = derToAsn1List(asn1.contents);
+    if (pieces.length !== 2) {
+        throw new Error('Bad SubjectPublicKeyInfo. Wrong number of child objects.');
+    }
+
+    return {
+        asn1,
+        algorithm: parseAlgorithmIdentifier(pieces[0]),
+        bits: derBitStringValue(pieces[1].contents),
+    };
+};
+
+/*
+ * Time ::= CHOICE {
+ *   utcTime        UTCTime,
+ *   generalTime    GeneralizedTime
+ * }
+ * NOTE: UTC and generalized times may both appear. (generalized > 2050)
+ */
+const parseUtcTime = (time: Asn1) => {
+    // tag: 23 = UTCTime (YYMMDDhhmmZ);
+    // tag: 24 = GeneralizedTime (YYYYMMDDhhmmZ)
+    let offset = 4;
+    let yearOffset = 0;
+    if (time.tag === 23) {
+        offset = 2;
+        yearOffset = 2000;
+    }
+    const utc = Buffer.from(time.contents).toString();
+    const year = yearOffset + Number(utc.substring(0, offset));
+    const month = Number(utc.substring(offset, offset + 2)) - 1;
+    const day = Number(utc.substring(offset + 2, offset + 4));
+    const hour = Number(utc.substring(offset + 4, offset + 6));
+    const minute = Number(utc.substring(offset + 6, offset + 8));
+
+    const date = new Date();
+    date.setUTCFullYear(year, month, day);
+    date.setUTCHours(hour, minute, 0);
+    return date;
+};
+
+/*
+ * Validity ::= SEQUENCE {
+ *   from    Time,
+ *   to      Time
+ * }
+ */
+const parseValidity = (asn1: Asn1) => {
+    const [from, to] = derToAsn1List(asn1.contents);
+    return {
+        from: parseUtcTime(from),
+        to: parseUtcTime(to),
+    };
+};
+
+/*
+ * TBSCertificate ::= SEQUENCE {
+ *   version         [0]  EXPLICIT Version DEFAULT v1,
+ *   serialNumber         CertificateSerialNumber,
+ *   signature            AlgorithmIdentifier,
+ *   issuer               Name[],
+ *   validity             Validity,
+ *   subject              Name[],
+ *   subjectPublicKeyInfo SubjectPublicKeyInfo,
+ *   issuerUniqueID  [1]  IMPLICIT UniqueIdentifier OPTIONAL,
+ *   subjectUniqueID [2]  IMPLICIT UniqueIdentifier OPTIONAL,
+ *   extensions      [3]  EXPLICIT Extensions OPTIONAL
+ * }
+ */
+const parseTBSCertificate = (asn1: Asn1) => {
+    if (asn1.cls !== 0 || asn1.tag !== 16 || !asn1.structured) {
+        throw new Error("This can't be a TBSCertificate. Wrong data type.");
+    }
+    const pieces = derToAsn1List(asn1.contents);
+    if (pieces.length < 7) {
+        throw new Error('Bad TBS Certificate. There are fewer than the seven required children.');
+    }
+
+    return {
+        asn1,
+        version: pieces[0],
+        serialNumber: pieces[1],
+        signature: parseAlgorithmIdentifier(pieces[2]),
+        issuer: pieces[3],
+        validity: parseValidity(pieces[4]),
+        subject: parseName(pieces[5]),
+        subjectPublicKeyInfo: parseSubjectPublicKeyInfo(pieces[6]),
+        extensions: pieces[7],
+    };
+};
+
+/*
+ * Certificate ::= SEQUENCE {
+ *   tbsCertificate       TBSCertificate,
+ *   signatureAlgorithm   AlgorithmIdentifier,
+ *   signatureValue       BIT STRING
+ * }
+ */
+export const parseCertificate = (byteArray: Uint8Array) => {
+    const asn1 = derToAsn1(byteArray);
+    if (asn1.cls !== 0 || asn1.tag !== 16 || !asn1.structured) {
+        throw new Error("This can't be an X.509 certificate. Wrong data type.");
+    }
+    const pieces = derToAsn1List(asn1.contents);
+    if (pieces.length !== 3) {
+        throw new Error('Certificate contains more than the three specified children.');
+    }
+
+    return {
+        asn1,
+        tbsCertificate: parseTBSCertificate(pieces[0]),
+        signatureAlgorithm: parseAlgorithmIdentifier(pieces[1]),
+        signatureValue: parseSignatureValue(pieces[2]),
+    };
+};

--- a/packages/connect/src/api/index.ts
+++ b/packages/connect/src/api/index.ts
@@ -1,5 +1,6 @@
 export { default as applyFlags } from './applyFlags';
 export { default as applySettings } from './applySettings';
+export { default as authenticateDevice } from './authenticateDevice';
 export { default as authorizeCoinjoin } from './authorizeCoinjoin';
 export { default as cancelCoinjoinAuthorization } from './cancelCoinjoinAuthorization';
 export { default as showDeviceTutorial } from './showDeviceTutorial';

--- a/packages/connect/src/data/deviceAuthenticityConfig.ts
+++ b/packages/connect/src/data/deviceAuthenticityConfig.ts
@@ -1,0 +1,34 @@
+import { PROTO } from '../constants';
+
+type CertPubKeys = {
+    rootPubKeys: string[];
+    caPubKeys: string[];
+};
+
+// NOTE: only T2B1 model is required in config, other models should be optional and undefined
+type ModelPubKeys = Record<PROTO.DeviceModelInternal.T2B1, CertPubKeys & { debug?: CertPubKeys }> &
+    Partial<Record<Exclude<PROTO.DeviceModelInternal, 'T2B1'>, undefined>>;
+
+export interface DeviceAuthenticityConfig extends ModelPubKeys {
+    version: number;
+    timestamp: string;
+}
+
+export const deviceAuthenticityConfig: DeviceAuthenticityConfig = {
+    version: 1,
+    timestamp: '2023-09-07T14:00:00+00:00',
+    T2B1: {
+        rootPubKeys: [],
+        caPubKeys: [],
+        debug: {
+            // debug keys are used **only** to validate emulator or dev. firmware
+            // use `allowDebugKeys: true` parameter in `authenticateDevice` method
+            rootPubKeys: [
+                '047f77368dea2d4d61e989f474a56723c3212dacf8a808d8795595ef38441427c4389bc454f02089d7f08b873005e4c28d432468997871c0bf286fd3861e21e96a',
+            ],
+            caPubKeys: [
+                '04ba6084cb9fba7c86d5d5a86108a91d55a27056da4eabbedde88a95e1cae8bce3620889167aaf7f2db166998f950984aa195e868f96e22803c3cd991be31d39e7',
+            ],
+        },
+    },
+};

--- a/packages/connect/src/factory.ts
+++ b/packages/connect/src/factory.ts
@@ -217,6 +217,8 @@ export const factory = ({
 
         applySettings: params => call({ ...params, method: 'applySettings' }),
 
+        authenticateDevice: params => call({ ...params, method: 'authenticateDevice' }),
+
         authorizeCoinjoin: params => call({ ...params, method: 'authorizeCoinjoin' }),
 
         cancelCoinjoinAuthorization: params =>

--- a/packages/connect/src/types/api/authenticateDevice.ts
+++ b/packages/connect/src/types/api/authenticateDevice.ts
@@ -1,0 +1,32 @@
+import type { DeviceAuthenticityConfig } from '../../data/deviceAuthenticityConfig';
+import type { Params, Response } from '../params';
+
+export interface AuthenticateDeviceParams {
+    config?: DeviceAuthenticityConfig;
+    allowDebugKeys?: boolean;
+}
+
+export type AuthenticateDeviceResult =
+    | {
+          valid: true;
+          caPubKey: string;
+          debugKey?: boolean;
+          configExpired?: typeof undefined;
+          error?: typeof undefined;
+      }
+    | {
+          valid: false;
+          caPubKey: string;
+          debugKey?: boolean;
+          configExpired?: boolean;
+          error:
+              | 'ROOT_PUBKEY_NOT_FOUND'
+              | 'CA_PUBKEY_NOT_FOUND'
+              | 'INVALID_DEVICE_MODEL'
+              | 'INVALID_DEVICE_CERTIFICATE'
+              | 'INVALID_DEVICE_SIGNATURE';
+      };
+
+export declare function authenticateDevice(
+    params: Params<AuthenticateDeviceParams>,
+): Response<AuthenticateDeviceResult>;

--- a/packages/connect/src/types/api/index.ts
+++ b/packages/connect/src/types/api/index.ts
@@ -1,5 +1,6 @@
 import { applyFlags } from './applyFlags';
 import { applySettings } from './applySettings';
+import { authenticateDevice } from './authenticateDevice';
 import { authorizeCoinjoin } from './authorizeCoinjoin';
 import { backupDevice } from './backupDevice';
 import { binanceGetAddress } from './binanceGetAddress';
@@ -84,6 +85,9 @@ export interface TrezorConnect {
 
     // https://github.com/trezor/trezor-suite/blob/develop/docs/packages/connect/methods/applySettings.md
     applySettings: typeof applySettings;
+
+    // https://github.com/trezor/trezor-suite/blob/develop/docs/packages/connect/methods/authenticateDevice.md
+    authenticateDevice: typeof authenticateDevice;
 
     // https://github.com/trezor/trezor-suite/blob/develop/docs/packages/connect/methods/authorizeCoinjoin.md
     authorizeCoinjoin: typeof authorizeCoinjoin;

--- a/packages/connect/src/types/index.ts
+++ b/packages/connect/src/types/index.ts
@@ -20,6 +20,7 @@ export * from './api/tezos';
 // types used in @trezor/suite. if you need a type, reexport it from ./api/<method>
 export type { ComposeOutput, PrecomposedTransaction } from './api/composeTransaction';
 export type { RecoveryDevice } from './api/recoveryDevice';
+export type { AuthenticateDeviceResult } from './api/authenticateDevice';
 export type {
     TokenInfo,
     TokenTransfer,

--- a/packages/suite/package.json
+++ b/packages/suite/package.json
@@ -28,6 +28,7 @@
         "@sentry/core": "^7.56.0",
         "@suite-common/analytics": "workspace:*",
         "@suite-common/connect-init": "workspace:*",
+        "@suite-common/device-authenticity": "workspace:*",
         "@suite-common/fiat-services": "workspace:*",
         "@suite-common/formatters": "workspace:*",
         "@suite-common/intl-types": "workspace:*",

--- a/packages/suite/src/components/suite/NotificationRenderer/index.tsx
+++ b/packages/suite/src/components/suite/NotificationRenderer/index.tsx
@@ -104,6 +104,10 @@ const NotificationRenderer = ({ notification, render }: NotificationRendererProp
             return success(render, notification, 'TR_STORAGE_CLEARED');
         case 'firmware-check-authenticity-success':
             return success(render, notification, 'TR_FIRMWARE_CHECK_AUTHENTICITY_SUCCESS');
+        case 'device-authenticity-success':
+            return success(render, notification, 'TR_DEVICE_AUTHENTICITY_SUCCESS');
+        case 'device-authenticity-error':
+            return error(render, notification, 'TR_DEVICE_AUTHENTICITY_ERROR');
         case 'bridge-dev-restart':
             return info(
                 render,

--- a/packages/suite/src/hooks/suite/useFirmware.ts
+++ b/packages/suite/src/hooks/suite/useFirmware.ts
@@ -7,6 +7,7 @@ import {
     selectFirmware,
     firmwareActions,
 } from '@suite-common/wallet-core';
+import { checkDeviceAuthenticityThunk } from '@suite-common/device-authenticity';
 import { FirmwareStatus } from '@suite-common/suite-types';
 
 import { useActions, useSelector } from 'src/hooks/suite';
@@ -27,6 +28,7 @@ export const useFirmware = () => {
         firmwareUpdate,
         firmwareCustom,
         checkFirmwareAuthenticity,
+        checkDeviceAuthenticityThunk,
     });
 
     return {

--- a/packages/suite/src/middlewares/suite/sentryMiddleware.ts
+++ b/packages/suite/src/middlewares/suite/sentryMiddleware.ts
@@ -14,6 +14,7 @@ import {
 } from '@trezor/device-utils';
 import { DEVICE, TRANSPORT } from '@trezor/connect';
 import { analyticsActions } from '@suite-common/analytics';
+import { deviceAuthenticityActions } from '@suite-common/device-authenticity';
 
 import { WALLET_SETTINGS } from 'src/actions/settings/constants';
 import * as walletSettingsActions from 'src/actions/settings/walletSettingsActions';
@@ -122,6 +123,10 @@ const sentryMiddleware =
                 });
                 break;
             }
+            case deviceAuthenticityActions.result.type:
+                if (action.payload.result.valid) return;
+                setSentryContext('device-authenticity', action.payload.result);
+                break;
             default:
                 break;
         }

--- a/packages/suite/src/support/messages.ts
+++ b/packages/suite/src/support/messages.ts
@@ -7143,6 +7143,14 @@ export default defineMessages({
         id: 'TR_FIRMWARE_CHECK_AUTHENTICITY_SUCCESS',
         defaultMessage: 'Firmware authentic',
     },
+    TR_DEVICE_AUTHENTICITY_SUCCESS: {
+        id: 'TR_DEVICE_AUTHENTICITY_SUCCESS',
+        defaultMessage: 'Device authentic',
+    },
+    TR_DEVICE_AUTHENTICITY_ERROR: {
+        id: 'TR_DEVICE_AUTHENTICITY_ERROR',
+        defaultMessage: 'Device is not authentic',
+    },
     TR_FEE_ROUNDING_WARNING: {
         id: 'TR_FEE_ROUNDING_WARNING',
         defaultMessage: 'Your Trezor may display a different rate caused by fee rounding.',

--- a/packages/suite/src/types/suite/index.ts
+++ b/packages/suite/src/types/suite/index.ts
@@ -12,6 +12,7 @@ import type { ObjectValues } from '@trezor/type-utils';
 import type { UiEvent, DeviceEvent, TransportEvent, BlockchainEvent } from '@trezor/connect';
 import { notificationsActions } from '@suite-common/toast-notifications';
 import { messageSystemActions } from '@suite-common/message-system';
+import { deviceAuthenticityActions } from '@suite-common/device-authenticity';
 import type { Route } from '@suite-common/suite-types';
 
 import type { RouterAction } from 'src/actions/suite/routerActions';
@@ -61,6 +62,9 @@ type AnalyticsAction = ReturnType<(typeof analyticsActions)[keyof typeof analyti
 type FirmwareAction = ReturnType<(typeof firmwareActions)[keyof typeof firmwareActions]>;
 type DeviceAction = ReturnType<(typeof deviceActions)[keyof typeof deviceActions]>;
 type DiscoveryAction = ReturnType<(typeof discoveryActions)[keyof typeof discoveryActions]>;
+type DeviceAuthenticityAction = ReturnType<
+    (typeof deviceAuthenticityActions)[keyof typeof deviceAuthenticityActions]
+>;
 
 // all actions from all apps used to properly type Dispatch.
 export type Action =
@@ -85,7 +89,8 @@ export type Action =
     | GuideAction
     | ProtocolAction
     | DiscoveryAction
-    | DeviceAction;
+    | DeviceAction
+    | DeviceAuthenticityAction;
 
 export type ThunkAction = TAction<any, AppState, any, Action>;
 

--- a/packages/suite/src/views/settings/debug/CheckFirmwareAuthenticity.tsx
+++ b/packages/suite/src/views/settings/debug/CheckFirmwareAuthenticity.tsx
@@ -8,7 +8,7 @@ import { setDebugMode } from 'src/actions/suite/suiteActions';
 export const CheckFirmwareAuthenticity = () => {
     const [inProgress, setInProgress] = useState(false);
 
-    const { checkFirmwareAuthenticity } = useFirmware();
+    const { checkFirmwareAuthenticity, checkDeviceAuthenticityThunk } = useFirmware();
 
     const debug = useSelector(state => state.suite.settings.debug);
     const dispatch = useDispatch();
@@ -22,8 +22,26 @@ export const CheckFirmwareAuthenticity = () => {
         setInProgress(false);
     };
 
+    const onCheckDeviceAuthenticity = async () => {
+        setInProgress(true);
+        await checkDeviceAuthenticityThunk({ allowDebugKeys: true });
+        setInProgress(false);
+    };
+
     return (
         <>
+            <SectionItem data-test="@settings/debug/check-device-authenticity">
+                <TextColumn title="Check device authenticity" description="" />
+                <ActionColumn>
+                    <Button
+                        onClick={onCheckDeviceAuthenticity}
+                        isLoading={inProgress}
+                        isDisabled={inProgress}
+                    >
+                        Check device authenticity
+                    </Button>
+                </ActionColumn>
+            </SectionItem>
             <SectionItem data-test="@settings/debug/check-firmware-authenticity">
                 <TextColumn
                     title="Check firmware authenticity"

--- a/packages/suite/tsconfig.json
+++ b/packages/suite/tsconfig.json
@@ -19,6 +19,9 @@
             "path": "../../suite-common/connect-init"
         },
         {
+            "path": "../../suite-common/device-authenticity"
+        },
+        {
             "path": "../../suite-common/fiat-services"
         },
         {

--- a/suite-common/device-authenticity/README.md
+++ b/suite-common/device-authenticity/README.md
@@ -1,0 +1,1 @@
+### Device authenticity

--- a/suite-common/device-authenticity/package.json
+++ b/suite-common/device-authenticity/package.json
@@ -1,0 +1,25 @@
+{
+    "name": "@suite-common/device-authenticity",
+    "version": "1.0.0",
+    "private": true,
+    "license": "See LICENSE.md in repo root",
+    "sideEffects": false,
+    "main": "src/index",
+    "scripts": {
+        "lint:js": "yarn g:eslint '**/*.{ts,tsx,js}'",
+        "test:unit": "jest -c ../../jest.config.base.js --passWithNoTests",
+        "type-check": "tsc --build"
+    },
+    "dependencies": {
+        "@reduxjs/toolkit": "1.9.5",
+        "@suite-common/redux-utils": "workspace:*",
+        "@suite-common/suite-types": "workspace:*",
+        "@suite-common/toast-notifications": "workspace:*",
+        "@trezor/connect": "workspace:*"
+    },
+    "devDependencies": {
+        "jest": "^26.6.3",
+        "tsx": "^3.12.7",
+        "typescript": "4.9.5"
+    }
+}

--- a/suite-common/device-authenticity/src/deviceAuthenticityActions.ts
+++ b/suite-common/device-authenticity/src/deviceAuthenticityActions.ts
@@ -1,0 +1,17 @@
+import { createAction } from '@reduxjs/toolkit';
+
+import { TrezorDevice } from '@suite-common/suite-types';
+import { AuthenticateDeviceResult } from '@trezor/connect';
+
+export const ACTION_PREFIX = '@device-authenticity';
+
+const result = createAction(
+    `${ACTION_PREFIX}/result`,
+    (payload: { device: TrezorDevice; result: AuthenticateDeviceResult }) => ({
+        payload,
+    }),
+);
+
+export const deviceAuthenticityActions = {
+    result,
+} as const;

--- a/suite-common/device-authenticity/src/deviceAuthenticityThunks.ts
+++ b/suite-common/device-authenticity/src/deviceAuthenticityThunks.ts
@@ -1,0 +1,54 @@
+import TrezorConnect from '@trezor/connect';
+import { createThunk } from '@suite-common/redux-utils';
+import { notificationsActions } from '@suite-common/toast-notifications';
+
+import { ACTION_PREFIX, deviceAuthenticityActions } from './deviceAuthenticityActions';
+
+export const checkDeviceAuthenticityThunk = createThunk<{ allowDebugKeys: boolean }>(
+    `${ACTION_PREFIX}/checkDeviceAuthenticity`,
+    async ({ allowDebugKeys }, { dispatch, getState, extra }) => {
+        const {
+            selectors: { selectDevice },
+        } = extra;
+        const device = selectDevice(getState());
+        if (!device) {
+            throw new Error('device is not connected');
+        }
+
+        const result = await TrezorConnect.authenticateDevice({
+            device: {
+                path: device.path,
+            },
+            allowDebugKeys,
+        });
+
+        if (result.success) {
+            if (result.payload.valid) {
+                dispatch(notificationsActions.addToast({ type: 'device-authenticity-success' }));
+            } else if (
+                result.payload.configExpired &&
+                result.payload.error === 'CA_PUBKEY_NOT_FOUND'
+            ) {
+                // sanity check result: CA_PUBKEY_NOT_FOUND with configExpired is temporary allowed
+                // it will be logged to sentry nevertheless (see sentryMiddleware)
+                // TODO: try fetch new config
+                // if (result.payload.configOutdated) {}
+            } else {
+                dispatch(
+                    notificationsActions.addToast({
+                        type: 'device-authenticity-error',
+                        error: `Device is not authentic: ${result.payload.error}`,
+                    }),
+                );
+            }
+            dispatch(deviceAuthenticityActions.result({ device, result: result.payload }));
+        } else {
+            dispatch(
+                notificationsActions.addToast({
+                    type: 'error',
+                    error: `Unable to validate device: ${result.payload.error}`,
+                }),
+            );
+        }
+    },
+);

--- a/suite-common/device-authenticity/src/index.ts
+++ b/suite-common/device-authenticity/src/index.ts
@@ -1,0 +1,2 @@
+export * from './deviceAuthenticityActions';
+export * from './deviceAuthenticityThunks';

--- a/suite-common/device-authenticity/tsconfig.json
+++ b/suite-common/device-authenticity/tsconfig.json
@@ -1,0 +1,10 @@
+{
+    "extends": "../../tsconfig.json",
+    "compilerOptions": { "outDir": "libDev" },
+    "references": [
+        { "path": "../redux-utils" },
+        { "path": "../suite-types" },
+        { "path": "../toast-notifications" },
+        { "path": "../../packages/connect" }
+    ]
+}

--- a/suite-common/toast-notifications/src/types.ts
+++ b/suite-common/toast-notifications/src/types.ts
@@ -46,7 +46,8 @@ export type ToastPayload = (
               | 'backup-failed'
               | 'sign-message-success'
               | 'verify-message-success'
-              | 'firmware-check-authenticity-success';
+              | 'firmware-check-authenticity-success'
+              | 'device-authenticity-success';
       }
     | SentTransactionNotification
     | {
@@ -78,7 +79,8 @@ export type ToastPayload = (
               | 'sign-tx-error'
               | 'metadata-auth-error'
               | 'metadata-not-found-error'
-              | 'metadata-unexpected-error';
+              | 'metadata-unexpected-error'
+              | 'device-authenticity-error';
           error: string;
       }
     | {

--- a/suite-common/wallet-core/package.json
+++ b/suite-common/wallet-core/package.json
@@ -13,6 +13,7 @@
     "dependencies": {
         "@mobily/ts-belt": "^3.13.1",
         "@reduxjs/toolkit": "1.9.5",
+        "@suite-common/device-authenticity": "workspace:*",
         "@suite-common/fiat-services": "workspace:*",
         "@suite-common/redux-utils": "workspace:*",
         "@suite-common/suite-config": "workspace:*",

--- a/suite-common/wallet-core/src/device/deviceReducer.ts
+++ b/suite-common/wallet-core/src/device/deviceReducer.ts
@@ -1,17 +1,22 @@
 import * as deviceUtils from '@suite-common/suite-utils';
 import { getStatus } from '@suite-common/suite-utils';
-import { Device, Features } from '@trezor/connect';
+import { Device, Features, AuthenticateDeviceResult } from '@trezor/connect';
 import { DiscoveryStatus } from '@suite-common/wallet-constants';
 import { getFirmwareVersion } from '@trezor/device-utils';
 import { Network, networks } from '@suite-common/wallet-config';
 import { versionUtils } from '@trezor/utils';
 import { createReducerWithExtraDeps } from '@suite-common/redux-utils';
 import { TrezorDevice, AcquiredDevice, ButtonRequest } from '@suite-common/suite-types';
+import { deviceAuthenticityActions } from '@suite-common/device-authenticity';
 
 import { deviceActions } from './deviceActions';
 import { DiscoveryRootState, selectDiscoveryByDeviceState } from '../discovery/discoveryReducer';
 
-export type State = { devices: TrezorDevice[]; selectedDevice?: TrezorDevice };
+export type State = {
+    devices: TrezorDevice[];
+    selectedDevice?: TrezorDevice;
+    deviceAuthenticity?: Record<string, AuthenticateDeviceResult>;
+};
 
 const initialState: State = { devices: [], selectedDevice: undefined };
 
@@ -19,6 +24,7 @@ export type DeviceRootState = {
     device: {
         devices: TrezorDevice[];
         selectedDevice?: TrezorDevice;
+        deviceAuthenticity?: State['deviceAuthenticity'];
     };
 };
 
@@ -416,6 +422,17 @@ const addButtonRequest = (
     draft.devices[index].buttonRequests.push(buttonRequest);
 };
 
+export const setDeviceAuthenticity = (
+    draft: State,
+    device: TrezorDevice,
+    result: AuthenticateDeviceResult,
+) => {
+    if (!device.id) return;
+    draft.deviceAuthenticity = {
+        [device.id]: result,
+    };
+};
+
 export const prepareDeviceReducer = createReducerWithExtraDeps(initialState, (builder, extra) => {
     builder
         .addCase(deviceActions.connectDevice, (state, { payload }) => {
@@ -465,6 +482,9 @@ export const prepareDeviceReducer = createReducerWithExtraDeps(initialState, (bu
         })
         .addCase(deviceActions.updateSelectedDevice, (state, { payload }) => {
             state.selectedDevice = payload;
+        })
+        .addCase(deviceAuthenticityActions.result, (state, { payload }) => {
+            setDeviceAuthenticity(state, payload.device, payload.result);
         })
         .addCase(extra.actionTypes.setDeviceMetadata, extra.reducers.setDeviceMetadataReducer)
         .addCase(extra.actionTypes.storageLoad, extra.reducers.storageLoadDevices);

--- a/suite-common/wallet-core/tsconfig.json
+++ b/suite-common/wallet-core/tsconfig.json
@@ -2,6 +2,7 @@
     "extends": "../../tsconfig.json",
     "compilerOptions": { "outDir": "libDev" },
     "references": [
+        { "path": "../device-authenticity" },
         { "path": "../fiat-services" },
         { "path": "../redux-utils" },
         { "path": "../suite-config" },

--- a/yarn.lock
+++ b/yarn.lock
@@ -7388,6 +7388,21 @@ __metadata:
   languageName: unknown
   linkType: soft
 
+"@suite-common/device-authenticity@workspace:suite-common/device-authenticity":
+  version: 0.0.0-use.local
+  resolution: "@suite-common/device-authenticity@workspace:suite-common/device-authenticity"
+  dependencies:
+    "@reduxjs/toolkit": 1.9.5
+    "@suite-common/redux-utils": "workspace:*"
+    "@suite-common/suite-types": "workspace:*"
+    "@suite-common/toast-notifications": "workspace:*"
+    "@trezor/connect": "workspace:*"
+    jest: ^26.6.3
+    tsx: ^3.12.7
+    typescript: 4.9.5
+  languageName: unknown
+  linkType: soft
+
 "@suite-common/fiat-services@workspace:*, @suite-common/fiat-services@workspace:suite-common/fiat-services":
   version: 0.0.0-use.local
   resolution: "@suite-common/fiat-services@workspace:suite-common/fiat-services"

--- a/yarn.lock
+++ b/yarn.lock
@@ -7388,7 +7388,7 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@suite-common/device-authenticity@workspace:suite-common/device-authenticity":
+"@suite-common/device-authenticity@workspace:*, @suite-common/device-authenticity@workspace:suite-common/device-authenticity":
   version: 0.0.0-use.local
   resolution: "@suite-common/device-authenticity@workspace:suite-common/device-authenticity"
   dependencies:
@@ -7704,6 +7704,7 @@ __metadata:
   dependencies:
     "@mobily/ts-belt": ^3.13.1
     "@reduxjs/toolkit": 1.9.5
+    "@suite-common/device-authenticity": "workspace:*"
     "@suite-common/fiat-services": "workspace:*"
     "@suite-common/redux-utils": "workspace:*"
     "@suite-common/suite-config": "workspace:*"
@@ -9763,6 +9764,7 @@ __metadata:
     "@sentry/core": ^7.56.0
     "@suite-common/analytics": "workspace:*"
     "@suite-common/connect-init": "workspace:*"
+    "@suite-common/device-authenticity": "workspace:*"
     "@suite-common/fiat-services": "workspace:*"
     "@suite-common/formatters": "workspace:*"
     "@suite-common/intl-types": "workspace:*"


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Validate `T2B1` device authenticity. implementation of https://github.com/trezor/trezor-firmware/pull/3255

I didn't find any suitable library to parse `x509` certificate and validate certificate pubKeys/signatures without adding tons of new crypto related dependencies (the missing half of the internet which we dont have here yet) so i ended up with writing our own using nodejs `crypto` polyfilled by `crypto-browserify`

It works in browser and nodejs but Im not sure if its working in react-native

## TODO:

- [x] update new protobuf messages after merge of https://github.com/trezor/trezor-firmware/pull/3255
- [x] add production rootPubKey and caPubKeys to config
- [x] serialize/prefix ECDSA P-256 pubKey to ASN format
- [x] validate current device model capabilities https://github.com/trezor/trezor-suite/issues/8952
- [x] fetch `caPubkeys` from file and pass it as parameter of `authenticateDevice` method
- [x] add unit tests for `x509` module
- [ ] add e2e tests after merge of https://github.com/trezor/trezor-firmware/pull/3255
- [x] add docs


