### PR TITLE
Suppress backup warning modal when getPublicKey is not initiated by user

### DIFF
--- a/docs/packages/connect/methods/cardanoGetPublicKey.md
+++ b/docs/packages/connect/methods/cardanoGetPublicKey.md
@@ -18,6 +18,7 @@ const result = await TrezorConnect.cardanoGetPublicKey(params);
 -   `path` — _required_ `string | Array<number>` minimum length is `3`. [read more](../path.md)
 -   `showOnTrezor` — _optional_ `boolean` determines if publick key will be displayed on device. Default is set to `true`
 -   `derivationType` — _optional_ `CardanoDerivationType` enum. determines used derivation type. Default is set to ICARUS_TREZOR=2
+-   `suppressBackupWarning` - _optional_ `boolean` By default, this method will emit an event to show a warning if the wallet does not have a backup. This option suppresses the message.
 
 #### Exporting bundle of publick keys
 

--- a/docs/packages/connect/methods/getAccountInfo.md
+++ b/docs/packages/connect/methods/getAccountInfo.md
@@ -51,6 +51,7 @@ params are forwarded to [BlockBook backend](https://github.com/trezor/blockbook/
 -   `contractFilter` — `string` Ethereum-like accounts only: get ERC20 token info and balance
 -   `marker` — `{ ledger: number, seq: number }` XRP accounts only, transaction history page marker
 -   `defaultAccountType` — `'normal' | 'segwit' | 'legacy'` Bitcoin-like accounts only: specify which account group is displayed as default in popup, subject of `Using discovery`
+-   `suppressBackupWarning` - `boolean` By default, this method will emit an event to show a warning if the wallet does not have a backup. This option suppresses the message.
 
 ### Example
 

--- a/docs/packages/connect/methods/getPublicKey.md
+++ b/docs/packages/connect/methods/getPublicKey.md
@@ -20,6 +20,7 @@ const result = await TrezorConnect.getPublicKey(params);
 -   `ecdsaCurveName` — _optional_ `string` ECDSA curve name to use
 -   `crossChain` — _optional_ `boolean` Advanced feature. Use it only if you are know what you are doing. Allows to generate address between chains. For example Bitcoin path on Litecoin network will display cross chain address in Litecoin format.
 -   `unlockPath` - _optional_ [PROTO.UnlockPath](https://github.com/trezor/trezor-suite/blob/develop/packages/transport/src/types/messages.ts), the result of [TrezorConnect.unlockPath](./unlockPath.md) method.
+-   `suppressBackupWarning` - _optional_ `boolean` By default, this method will emit an event to show a warning if the wallet does not have a backup. This option suppresses the message.
 
 #### Exporting bundle of public keys
 

--- a/packages/connect/src/api/cardanoGetPublicKey.ts
+++ b/packages/connect/src/api/cardanoGetPublicKey.ts
@@ -104,7 +104,7 @@ export default class CardanoGetPublicKey extends AbstractMethod<'cardanoGetPubli
         // request confirmation view
         this.postMessage(
             createUiMessage(UI.REQUEST_CONFIRMATION, {
-                view: 'get-public-key-no-backup',
+                view: 'no-backup',
             }),
         );
 

--- a/packages/connect/src/api/getAccountInfo.ts
+++ b/packages/connect/src/api/getAccountInfo.ts
@@ -55,6 +55,7 @@ export default class GetAccountInfo extends AbstractMethod<'getAccountInfo', Req
                 { name: 'marker', type: 'object' },
                 { name: 'defaultAccountType', type: 'string' },
                 { name: 'derivationType', type: 'number' },
+                { name: 'suppressBackupWarning', type: 'boolean' },
             ]);
 
             // validate coin info
@@ -161,7 +162,10 @@ export default class GetAccountInfo extends AbstractMethod<'getAccountInfo', Req
         return uiResp.payload;
     }
 
-    async noBackupConfirmation() {
+    async noBackupConfirmation(allowSuppression?: boolean) {
+        if (allowSuppression && this.params.every(batch => batch.suppressBackupWarning)) {
+            return true;
+        }
         // wait for popup window
         await this.getPopupPromise().promise;
         // initialize user response promise

--- a/packages/connect/src/api/getPublicKey.ts
+++ b/packages/connect/src/api/getPublicKey.ts
@@ -11,6 +11,7 @@ import type { PROTO } from '../constants';
 
 type Params = PROTO.GetPublicKey & {
     coinInfo?: BitcoinNetworkInfo;
+    suppressBackupWarning?: boolean;
     unlockPath?: PROTO.UnlockPath;
 };
 
@@ -41,6 +42,7 @@ export default class GetPublicKey extends AbstractMethod<'getPublicKey', Params[
                 { name: 'ignoreXpubMagic', type: 'boolean' },
                 { name: 'ecdsaCurveName', type: 'boolean' },
                 { name: 'unlockPath', type: 'object' },
+                { name: 'suppressBackupWarning', type: 'boolean' },
             ]);
 
             if (batch.unlockPath) {
@@ -76,6 +78,7 @@ export default class GetPublicKey extends AbstractMethod<'getPublicKey', Params[
                 ecdsa_curve_name: batch.ecdsaCurveName,
                 coinInfo,
                 unlockPath: batch.unlockPath,
+                suppress_backup_warning: batch.suppressBackupWarning,
             };
         });
     }
@@ -112,7 +115,13 @@ export default class GetPublicKey extends AbstractMethod<'getPublicKey', Params[
         return this.confirmed;
     }
 
-    async noBackupConfirmation() {
+    async noBackupConfirmation(allowSuppression?: boolean) {
+        if (
+            allowSuppression &&
+            this.params.every(batch => batch.suppressBackupWarning || !batch.show_display)
+        ) {
+            return true;
+        }
         // wait for popup window
         await this.getPopupPromise().promise;
         // initialize user response promise

--- a/packages/connect/src/api/getPublicKey.ts
+++ b/packages/connect/src/api/getPublicKey.ts
@@ -130,7 +130,7 @@ export default class GetPublicKey extends AbstractMethod<'getPublicKey', Params[
         // request confirmation view
         this.postMessage(
             createUiMessage(UI.REQUEST_CONFIRMATION, {
-                view: 'get-public-key-no-backup',
+                view: 'no-backup',
             }),
         );
 

--- a/packages/connect/src/core/AbstractMethod.ts
+++ b/packages/connect/src/core/AbstractMethod.ts
@@ -80,7 +80,7 @@ export abstract class AbstractMethod<Name extends CallMethodPayload['method'], P
 
     confirmation?(): Promise<boolean | undefined>;
 
-    noBackupConfirmation?(): Promise<boolean>;
+    noBackupConfirmation?(allowSuppression?: boolean): Promise<boolean>;
 
     getButtonRequestData?(code: string): UiRequestButtonData | undefined;
 

--- a/packages/connect/src/core/index.ts
+++ b/packages/connect/src/core/index.ts
@@ -493,7 +493,7 @@ export const onCall = async (message: CoreMessage) => {
 
             const deviceNeedsBackup = device.features.needs_backup;
             if (deviceNeedsBackup && typeof method.noBackupConfirmation === 'function') {
-                const permitted = await method.noBackupConfirmation();
+                const permitted = await method.noBackupConfirmation(!isUsingPopup);
                 if (!permitted) {
                     // interrupt process and go to "final" block
                     return Promise.reject(ERRORS.TypedError('Method_PermissionsNotGranted'));

--- a/packages/connect/src/types/api/getAccountInfo.ts
+++ b/packages/connect/src/types/api/getAccountInfo.ts
@@ -9,6 +9,7 @@ export interface GetAccountInfo extends Omit<BlockchainLinkParams<'getAccountInf
     descriptor?: string;
     defaultAccountType?: DiscoveryAccountType;
     derivationType?: PROTO.CardanoDerivationType;
+    suppressBackupWarning?: boolean;
 }
 
 export declare function getAccountInfo(params: Params<GetAccountInfo>): Response<AccountInfo>;

--- a/packages/connect/src/types/params.ts
+++ b/packages/connect/src/types/params.ts
@@ -56,6 +56,7 @@ export interface Address {
 export interface GetPublicKey {
     path: string | number[];
     showOnTrezor?: boolean;
+    suppressBackupWarning?: boolean;
 }
 
 export interface PublicKey {

--- a/packages/suite/src/actions/wallet/coinjoinAccountActions.ts
+++ b/packages/suite/src/actions/wallet/coinjoinAccountActions.ts
@@ -577,6 +577,7 @@ export const createCoinjoinAccount =
             device,
             useEmptyPassphrase: device?.useEmptyPassphrase,
             coin: network.symbol,
+            suppressBackupWarning: true,
         });
         if (!publicKey.success) {
             dispatch(handleError(publicKey.payload.error));

--- a/packages/suite/src/actions/wallet/send/sendFormRippleActions.ts
+++ b/packages/suite/src/actions/wallet/send/sendFormRippleActions.ts
@@ -110,6 +110,7 @@ export const composeTransaction =
             const accountResponse = await TrezorConnect.getAccountInfo({
                 descriptor: address,
                 coin: account.symbol,
+                suppressBackupWarning: true,
             });
             if (accountResponse.success && accountResponse.payload.empty) {
                 requiredAmount = new BigNumber(accountResponse.payload.misc!.reserve!);

--- a/packages/suite/src/components/suite/ModalSwitcher/DeviceConfirmationModal.tsx
+++ b/packages/suite/src/components/suite/ModalSwitcher/DeviceConfirmationModal.tsx
@@ -7,13 +7,10 @@ import type { ReduxModalProps } from './types';
 /** Modals requested from `trezor-connect` */
 export const DeviceConfirmationModal = ({
     windowType,
-    renderer,
 }: ReduxModalProps<typeof MODAL.CONTEXT_DEVICE_CONFIRMATION>) => {
     switch (windowType) {
         case 'no-backup':
-            return <ConfirmNoBackup buttonText="TR_SHOW_ADDRESS_ANYWAY" renderer={renderer} />;
-        case 'get-public-key-no-backup':
-            return <ConfirmNoBackup buttonText="TR_SHOW_XPUB_ANYWAY" renderer={renderer} />;
+            return <ConfirmNoBackup />;
         default:
             return null;
     }

--- a/packages/suite/src/components/suite/modals/AddToken/index.tsx
+++ b/packages/suite/src/components/suite/modals/AddToken/index.tsx
@@ -40,6 +40,7 @@ export const AddToken = ({ onCancel }: AddTokenProps) => {
                 descriptor: acc.descriptor,
                 details: 'tokenBalances',
                 contractFilter: contractAddress,
+                suppressBackupWarning: true,
             });
 
             if (response.success) {

--- a/packages/suite/src/components/suite/modals/confirm/ConfirmNoBackup.tsx
+++ b/packages/suite/src/components/suite/modals/confirm/ConfirmNoBackup.tsx
@@ -6,8 +6,6 @@ import { goto } from 'src/actions/suite/routerActions';
 import { Translation, Modal } from 'src/components/suite';
 import { useDispatch } from 'src/hooks/suite/useDispatch';
 import { Button, Image } from '@trezor/components';
-import { ReduxModalProps } from 'src/components/suite/ModalSwitcher/types';
-import { TranslationKey } from 'src/components/suite/Translation';
 import { SettingsAnchor } from 'src/constants/suite/anchors';
 
 const ImageWrapper = styled.div`
@@ -18,11 +16,7 @@ const StyledModal = styled(Modal)`
     width: 600px;
 `;
 
-interface ConfirmNoBackupProps extends Pick<ReduxModalProps, 'renderer'> {
-    buttonText: TranslationKey;
-}
-
-export const ConfirmNoBackup = ({ buttonText }: ConfirmNoBackupProps) => {
+export const ConfirmNoBackup = () => {
     const dispatch = useDispatch();
 
     const confirm = () => dispatch(onReceiveConfirmation(true));
@@ -45,7 +39,7 @@ export const ConfirmNoBackup = ({ buttonText }: ConfirmNoBackupProps) => {
                         onClick={confirm}
                         data-test="@no-backup/take-risk-button"
                     >
-                        <Translation id={buttonText} />
+                        <Translation id="TR_CONTINUE_ANYWAY" />
                     </Button>
                     <Button onClick={goToSettings}>
                         <Translation id="TR_CREATE_BACKUP" />

--- a/packages/suite/src/middlewares/wallet/discoveryMiddleware.ts
+++ b/packages/suite/src/middlewares/wallet/discoveryMiddleware.ts
@@ -7,7 +7,7 @@ import {
     stopDiscoveryThunk,
     updateNetworkSettingsThunk,
 } from '@suite-common/wallet-core';
-import TrezorConnect, { UI } from '@trezor/connect';
+import { UI } from '@trezor/connect';
 import { DiscoveryStatus } from '@suite-common/wallet-constants';
 import { createMiddlewareWithExtraDeps } from '@suite-common/redux-utils';
 
@@ -28,22 +28,6 @@ export const prepareDiscoveryMiddleware = createMiddlewareWithExtraDeps(
 
         if (action.type === SUITE.FORGET_DEVICE && action.payload.state) {
             dispatch(discoveryActions.removeDiscovery(action.payload.state));
-        }
-
-        // temporary workaround, needs to be changed in @trezor/connect
-        // BLOCK action propagation (via next() function) and respond to @trezor/connect
-        // otherwise devices without backup will receive several "confirmation" modals during discovery process
-        const isCoinmarketExchange = prevState.router.route?.name === 'wallet-coinmarket-exchange';
-
-        if (
-            action.type === UI.REQUEST_CONFIRMATION &&
-            (discoveryIsRunning || isCoinmarketExchange)
-        ) {
-            TrezorConnect.uiResponse({
-                type: UI.RECEIVE_CONFIRMATION,
-                payload: true,
-            });
-            return action;
         }
 
         // do not close user context modals during discovery

--- a/packages/suite/src/support/messages.ts
+++ b/packages/suite/src/support/messages.ts
@@ -3268,13 +3268,9 @@ export default defineMessages({
             'If you only need Bitcoin wallet operations, you can install <button>{bitcoinOnly}</button> firmware.',
         id: 'TR_SETTINGS_COINS_BITCOIN_ONLY_FIRMWARE_SUGGESTION',
     },
-    TR_SHOW_ADDRESS_ANYWAY: {
-        defaultMessage: 'Show address anyway',
-        id: 'TR_SHOW_ADDRESS_ANYWAY',
-    },
-    TR_SHOW_XPUB_ANYWAY: {
-        defaultMessage: 'Show public key anyway',
-        id: 'TR_SHOW_XPUB_ANYWAY',
+    TR_CONTINUE_ANYWAY: {
+        defaultMessage: 'Continue anyway',
+        id: 'TR_CONTINUE_ANYWAY',
     },
     TR_SHOW_DETAILS: {
         defaultMessage: 'Update now',

--- a/suite-common/graph/src/graphDataFetching.ts
+++ b/suite-common/graph/src/graphDataFetching.ts
@@ -76,7 +76,7 @@ export const getAccountBalanceHistory = async ({
             // issue: https://github.com/trezor/trezor-suite/issues/8888
             currencies: ['usd'],
         }),
-        TrezorConnect.getAccountInfo({ coin, descriptor }),
+        TrezorConnect.getAccountInfo({ coin, descriptor, suppressBackupWarning: true }),
     ]);
 
     if (!accountMovementHistory?.success) {

--- a/suite-common/wallet-core/src/accounts/accountsThunks.ts
+++ b/suite-common/wallet-core/src/accounts/accountsThunks.ts
@@ -56,6 +56,7 @@ const fetchAccountTokens = async (account: Account, payloadTokens: AccountInfo['
             descriptor: account.descriptor,
             details: 'tokenBalances',
             contractFilter: t.contract,
+            suppressBackupWarning: true,
         }),
     );
 
@@ -86,6 +87,7 @@ export const fetchAndUpdateAccountThunk = createThunk(
             coin: account.symbol,
             descriptor: account.descriptor,
             details: 'basic',
+            suppressBackupWarning: true,
         });
         if (!basic.success) return;
 
@@ -107,6 +109,7 @@ export const fetchAndUpdateAccountThunk = createThunk(
             details: 'txs',
             page: 1, // useful for every network except ripple
             pageSize,
+            suppressBackupWarning: true,
         });
 
         if (response.success) {

--- a/suite-common/wallet-core/src/discovery/discoveryThunks.ts
+++ b/suite-common/wallet-core/src/discovery/discoveryThunks.ts
@@ -221,6 +221,7 @@ const getBundleThunk = createThunk(
                     accountType,
                     networkType: configNetwork.networkType,
                     derivationType: getDerivationType(accountType),
+                    suppressBackupWarning: true,
                 });
             }
         });

--- a/suite-common/wallet-core/src/transactions/transactionsThunks.ts
+++ b/suite-common/wallet-core/src/transactions/transactionsThunks.ts
@@ -347,6 +347,7 @@ export const fetchTransactionsThunk = createThunk(
             page, // useful for every network except ripple
             pageSize: perPage,
             ...(marker ? { marker } : {}), // set marker only if it is not undefined (ripple), otherwise it fails on marker validation
+            suppressBackupWarning: true,
         });
 
         if (signal.aborted) return;

--- a/suite-common/wallet-types/src/discovery.ts
+++ b/suite-common/wallet-types/src/discovery.ts
@@ -39,6 +39,7 @@ export type DiscoveryItem = {
     coin: Account['symbol'];
     details?: 'basic' | 'tokens' | 'tokenBalances' | 'txids' | 'txs';
     pageSize?: number;
+    suppressBackupWarning?: boolean;
     // wallet
     index: number;
     accountType: Account['accountType'];

--- a/suite-native/module-accounts-import/src/screens/AccountImportLoadingScreen.tsx
+++ b/suite-native/module-accounts-import/src/screens/AccountImportLoadingScreen.tsx
@@ -69,6 +69,7 @@ export const AccountImportLoadingScreen = ({
                     coin: networkSymbol,
                     descriptor: xpubAddress,
                     details: 'tokenBalances',
+                    suppressBackupWarning: true,
                 }),
                 dispatch(
                     updateFiatRatesThunk({


### PR DESCRIPTION
## Description

When device is not backed up, we want to show a warning when user displays a receive address or public key. We also want to show the warning when a third-party implementation calls `getAccountInfo`. However, there are cases in Suite, when `getPublicKey` or `getAccountInfo` is called, but we do not want to show the warning. The new `suppressBackupWarning` param handles that. It also allows us to remove the workaround from `discoveryMiddleware` and probably fixes #5280, although I have not tested that.

Adding the param to every call of `getPublicKey` is a bit annoying, maybe there is a better way... @mroz22
I have not added it to the address method because there is a lot of them and they would not use it anyway.

## Related Issue

Resolve #9059
Resolve #5280
