### PR TITLE
fix(connect-iframe): define plugin in build to support analytics

### DIFF
--- a/packages/connect-iframe/tsconfig.json
+++ b/packages/connect-iframe/tsconfig.json
@@ -4,6 +4,7 @@
         "outDir": "./libDev",
         "types": ["web", "w3c-web-usb", "jest"]
     },
+    "include": [".", "**/*.json"],
     "references": [
         { "path": "../connect" },
         { "path": "../connect-analytics" },

--- a/packages/connect-iframe/webpack/prod.webpack.config.ts
+++ b/packages/connect-iframe/webpack/prod.webpack.config.ts
@@ -1,13 +1,17 @@
 import path from 'path';
+import { execSync } from 'child_process';
 import webpack from 'webpack';
 import HtmlWebpackPlugin from 'html-webpack-plugin';
 import CopyWebpackPlugin from 'copy-webpack-plugin';
 import TerserPlugin from 'terser-webpack-plugin';
+import { version } from '../package.json';
 
 const COMMON_DATA_SRC = '../../packages/connect-common/files';
 const MESSAGES_SRC = '../../packages/protobuf/messages.json';
 
 const DIST = path.resolve(__dirname, '../build');
+
+const commitHash = execSync('git rev-parse HEAD').toString().trim();
 
 const config: webpack.Configuration = {
     target: 'web',
@@ -116,6 +120,14 @@ const config: webpack.Configuration = {
             template: path.resolve(__dirname, '../src/static/iframe.html'),
             minify: false,
             inject: false,
+        }),
+        new webpack.DefinePlugin({
+            process: {
+                env: {
+                    VERSION: JSON.stringify(version),
+                    COMMIT_HASH: JSON.stringify(commitHash),
+                },
+            },
         }),
     ],
 


### PR DESCRIPTION
Just a copy of branch https://github.com/trezor/trezor-suite/pull/9322 to make GitLab pipelines work.

> fixing "Unable to report app/ready. Analytics is not initialized! Missing: commitId, version, " 
> should resolve https://github.com/trezor/trezor-suite/pull/9231#issuecomment-1700403411