### PR TITLE
test(suite-desktop): get rid of copying binaries

### DIFF
--- a/docs/tests/e2e-suite-desktop.md
+++ b/docs/tests/e2e-suite-desktop.md
@@ -1,0 +1,20 @@
+# @trezor/suite-desktop e2e tests
+
+**currently works only on Linux, volunteers to make it work on Mac needed**
+
+### Prerequisites
+
+```
+yarn workspace @trezor/suite-desktop build:ui
+yarn workspace @trezor/suite-desktop build:app:dev
+```
+
+Produces `build` and `dist` directories with javascript bundles in production mode and application assets.
+
+_Note: This step needs to be repeated on each change._
+
+### Running tests locally
+
+`yarn workspace @trezor/suite-desktop-core test:e2e`
+
+Opens an electron app controlled by the [playwright test runner](https://playwright.dev/)

--- a/packages/suite-desktop-core/e2e/support/common.ts
+++ b/packages/suite-desktop-core/e2e/support/common.ts
@@ -1,72 +1,34 @@
-import { promisify } from 'util';
+/* eslint-disable no-console */
+
 import path from 'path';
-import fs from 'fs';
 import { Page, _electron as electron } from '@playwright/test';
 
-const mkdir = promisify(fs.mkdir);
-const fileExists = promisify(fs.exists);
-const copyFile = promisify(fs.copyFile);
-const chmod = promisify(fs.chmod);
-
 export const launchSuite = async () => {
+    const appDir = path.join(__dirname, '../../../suite-desktop');
+
     const electronApp = await electron.launch({
-        cwd: path.join(__dirname, '../../../suite-desktop'),
-        args: ['./dist/app.js', '--log-level=debug', '--bridge-test'],
+        cwd: appDir,
+        args: [path.join(appDir, './dist/app.js'), '--log-level=debug', '--bridge-test'],
         // when testing electron, video needs to be setup like this. it works locally but not in docker
         // recordVideo: { dir: 'test-results' },
     });
+
+    electronApp.process().stdout?.on('data', data => console.log(data.toString()));
+    electronApp.process().stderr?.on('data', data => console.error(data.toString()));
+
+    await electronApp.evaluate(
+        (_, [resourcesPath]) => {
+            // This runs in the main Electron process.
+            // override global variable defined in app.ts
+            global.resourcesPath = resourcesPath;
+            return global.resourcesPath;
+        },
+        [path.join(appDir, 'build/static')],
+    );
+
     const window = await electronApp.firstWindow();
+
     return { electronApp, window };
-};
-
-export const patchBinaries = async () => {
-    const binResourcesPathFrom = path.join(__dirname, '../../..', 'suite-data/files/bin');
-    const binResourcesPathTo = path.join(
-        __dirname,
-        '../../../..',
-        '/node_modules/electron/dist/resources/bin',
-    );
-
-    const trezordPathFrom = path.join(binResourcesPathFrom, '/bridge/linux-x64/trezord');
-    const trezordPathTo = path.join(binResourcesPathTo, 'bridge');
-    if (!(await fileExists(trezordPathTo))) {
-        await mkdir(trezordPathTo, {
-            recursive: true,
-        });
-    }
-    await copyFile(trezordPathFrom, `${trezordPathTo}/trezord`);
-
-    const torPathFrom = path.join(binResourcesPathFrom, '/tor/linux-x64/tor');
-    const torPathTo = path.join(binResourcesPathTo, 'tor');
-    if (!(await fileExists(torPathTo))) {
-        await mkdir(torPathTo, {
-            recursive: true,
-        });
-    }
-
-    await copyFile(torPathFrom, `${torPathTo}/tor`);
-
-    const coinjoinMiddlewarePathFrom = path.join(
-        binResourcesPathFrom,
-        '/coinjoin/linux-x64/WalletWasabi.WabiSabiClientLibrary',
-    );
-    const coinjoinMiddlewarePathTo = path.join(binResourcesPathTo, 'coinjoin');
-
-    if (!(await fileExists(coinjoinMiddlewarePathTo))) {
-        await mkdir(coinjoinMiddlewarePathTo, {
-            recursive: true,
-        });
-    }
-
-    await copyFile(
-        coinjoinMiddlewarePathFrom,
-        `${coinjoinMiddlewarePathTo}/WalletWasabi.WabiSabiClientLibrary`,
-    );
-    // todo: for some reason, wabisabiclient lib needs to update permissions
-    await chmod(
-        `${coinjoinMiddlewarePathTo}/WalletWasabi.WabiSabiClientLibrary`,
-        fs.constants.S_IXOTH,
-    );
 };
 
 export const waitForDataTestSelector = (window: Page, selector: string, options = {}) =>

--- a/packages/suite-desktop-core/e2e/tests/coinjoin.test.ts
+++ b/packages/suite-desktop-core/e2e/tests/coinjoin.test.ts
@@ -4,7 +4,7 @@ import { Page, test as testPlaywright } from '@playwright/test';
 
 import { TrezorUserEnvLink } from '@trezor/trezor-user-env-link';
 
-import { patchBinaries, launchSuite } from '../support/common';
+import { launchSuite } from '../support/common';
 import { sendToAddress, generateBlock, waitForCoinjoinBackend } from '../support/regtest';
 
 /**
@@ -111,10 +111,6 @@ const passThroughInitialRun = async (window: Page) => {
 testPlaywright.describe('Coinjoin', () => {
     testPlaywright.beforeAll(async () => {
         testPlaywright.setTimeout(timeout * 10);
-        // todo: some problems with path in dev and production and tests. tldr tests are expecting
-        // binaries somewhere where they are not, so I copy them to that place. Maybe I find a
-        // better solution later
-        await patchBinaries();
 
         await TrezorUserEnvLink.api.trezorUserEnvConnect();
         await waitForCoinjoinBackend();

--- a/packages/suite-desktop-core/e2e/tests/electrum.test.ts
+++ b/packages/suite-desktop-core/e2e/tests/electrum.test.ts
@@ -2,7 +2,7 @@ import { Page, test as testPlaywright } from '@playwright/test';
 
 import { TrezorUserEnvLink } from '@trezor/trezor-user-env-link';
 
-import { patchBinaries, launchSuite, waitForDataTestSelector } from '../support/common';
+import { launchSuite, waitForDataTestSelector } from '../support/common';
 
 const clickDataTest = (window: Page, selector: string) => window.click(`[data-test="${selector}"]`);
 
@@ -16,10 +16,6 @@ const toggleDebugModeInSettings = async (window: Page) => {
 
 testPlaywright.describe.serial('Suite works with Electrum server', () => {
     testPlaywright.beforeAll(async () => {
-        // todo: some problems with path in dev and production and tests. tldr tests are expecting
-        // binaries somewhere where they are not, so I copy them to that place. Maybe I find a
-        // better solution later
-        await patchBinaries();
         await TrezorUserEnvLink.api.trezorUserEnvConnect();
         await TrezorUserEnvLink.api.startEmu({ wipe: true });
         await TrezorUserEnvLink.api.setupEmu({

--- a/packages/suite-desktop-core/e2e/tests/spawn-bridge.test.ts
+++ b/packages/suite-desktop-core/e2e/tests/spawn-bridge.test.ts
@@ -2,14 +2,10 @@ import { test as testPlaywright, expect as expectPlaywright } from '@playwright/
 
 import { TrezorUserEnvLink } from '@trezor/trezor-user-env-link';
 
-import { patchBinaries, launchSuite, waitForDataTestSelector } from '../support/common';
+import { launchSuite, waitForDataTestSelector } from '../support/common';
 
 testPlaywright.describe.serial('Bridge', () => {
     testPlaywright.beforeAll(async () => {
-        // todo: some problems with path in dev and production and tests. tldr tests are expecting
-        // binaries somewhere where they are not, so I copy them to that place. Maybe I find a
-        // better solution later
-        await patchBinaries();
         // We make sure that bridge from trezor-user-env is stopped.
         // So we properly test the electron app spawning bridge binary.
         await TrezorUserEnvLink.api.trezorUserEnvConnect();

--- a/packages/suite-desktop-core/e2e/tests/spawn-tor.test.ts
+++ b/packages/suite-desktop-core/e2e/tests/spawn-tor.test.ts
@@ -1,6 +1,6 @@
 import { Page, test as testPlaywright, expect as expectPlaywright } from '@playwright/test';
 
-import { patchBinaries, launchSuite } from '../support/common';
+import { launchSuite } from '../support/common';
 import { NetworkAnalyzer } from '../support/networkAnalyzer';
 
 const timeout = 1000 * 60 * 5; // 5 minutes because it takes a while to start tor.
@@ -32,13 +32,6 @@ const turnOnTorInSettings = async (window: Page, shouldEnableTor = true) => {
 };
 
 testPlaywright.describe('Tor loading screen', () => {
-    testPlaywright.beforeAll(async () => {
-        // todo: some problems with path in dev and production and tests. tldr tests are expecting
-        // binaries somewhere where they are not, so I copy them to that place. Maybe I find a
-        // better solution later
-        await patchBinaries();
-    });
-
     testPlaywright('Tor loading screen: happy path', async () => {
         testPlaywright.setTimeout(timeout);
 

--- a/packages/suite-desktop-core/src/libs/processes/BaseProcess.ts
+++ b/packages/suite-desktop-core/src/libs/processes/BaseProcess.ts
@@ -1,8 +1,6 @@
 import path from 'path';
 import { spawn, ChildProcess } from 'child_process';
 
-import { isDevEnv } from '@suite-common/suite-utils';
-
 import { b2t } from '../utils';
 
 export type Status = {
@@ -110,12 +108,8 @@ export abstract class BaseProcess {
         this.stopped = false;
 
         const { system, ext } = this.getPlatformInfo();
-        const processDir = path.join(
-            global.resourcesPath,
-            'bin',
-            this.resourceName,
-            isDevEnv ? system : '',
-        );
+        const processDir = path.join(global.resourcesPath, 'bin', this.resourceName, system);
+
         const processPath = path.join(processDir, `${this.processName}${ext}`);
         const processEnv = { ...process.env };
         // library search path for macOS


### PR DESCRIPTION
taking core fixes from https://github.com/trezor/trezor-suite/pull/8297

### what this pr does
this PR removes annoying copying of binaries from their location to some another location where tests in their default expect them. this is definitely somethign we want. 

### what this pr does not 
- fix spawn-tor test
- fix runnig on mac locally (problem is occupied port and I can not run processes from host and cointainer, only running from container is possible)
- fix skipped coinjoin test


its no worse than in develop
https://gitlab.com/satoshilabs/trezor/trezor-suite/-/pipelines/988895302