### PR TITLE
Show unverified + disabled passphrase

### DIFF
--- a/packages/suite/src/components/suite/ModalSwitcher/UserContextModal.tsx
+++ b/packages/suite/src/components/suite/ModalSwitcher/UserContextModal.tsx
@@ -1,6 +1,6 @@
-import React, { useCallback } from 'react';
+import React from 'react';
 
-import { onCancel as onCancelAction, UserContextPayload } from 'src/actions/suite/modalActions';
+import { onCancel as onCancelAction } from 'src/actions/suite/modalActions';
 import { MODAL } from 'src/actions/suite/constants';
 import { useDispatch } from 'src/hooks/suite';
 import {
@@ -30,12 +30,12 @@ import {
     CoinjoinSuccess,
     MoreRoundsNeeded,
     ConfirmUnverified,
+    ConfirmUnverifiedAddress,
 } from 'src/components/suite/modals';
 import { DisableTorStopCoinjoin } from 'src/components/suite/modals/DisableTorStopCoinjoin';
 import { UnecoCoinjoinWarning } from 'src/components/suite/modals/UnecoCoinjoinWarning';
 import type { AcquiredDevice } from 'src/types/suite';
 import { openXpubModal, showXpub } from 'src/actions/wallet/publicKeyActions';
-import { showAddress, openAddressModal } from 'src/actions/wallet/receiveActions';
 import type { ReduxModalProps } from './types';
 
 /** Modals opened as a result of user action */
@@ -44,14 +44,6 @@ export const UserContextModal = ({
     renderer,
 }: ReduxModalProps<typeof MODAL.CONTEXT_USER>) => {
     const dispatch = useDispatch();
-
-    const verifyAddress = useCallback(() => {
-        const { addressPath, value } = payload as Extract<
-            UserContextPayload,
-            { type: 'unverified-address' }
-        >;
-        return showAddress(addressPath, value);
-    }, [payload]);
 
     const onCancel = () => dispatch(onCancelAction());
 
@@ -67,13 +59,9 @@ export const UserContextModal = ({
             );
         case 'unverified-address':
             return (
-                <ConfirmUnverified
-                    showUnverifiedButtonText="TR_SHOW_UNVERIFIED_ADDRESS"
-                    warningText="TR_ADDRESS_PHISHING_WARNING"
-                    verify={verifyAddress}
-                    showUnverified={() =>
-                        openAddressModal({ addressPath: payload.addressPath, value: payload.value })
-                    }
+                <ConfirmUnverifiedAddress
+                    addressPath={payload.addressPath}
+                    value={payload.value}
                     onCancel={onCancel}
                 />
             );
@@ -84,7 +72,6 @@ export const UserContextModal = ({
                     warningText="TR_XPUB_PHISHING_WARNING"
                     verify={showXpub}
                     showUnverified={openXpubModal}
-                    onCancel={onCancel}
                 />
             );
         case 'address':

--- a/packages/suite/src/components/suite/modals/confirm/ConfirmUnverified.tsx
+++ b/packages/suite/src/components/suite/modals/confirm/ConfirmUnverified.tsx
@@ -6,7 +6,8 @@ import { Translation, Modal } from 'src/components/suite';
 import { TranslationKey } from 'src/components/suite/Translation';
 import { useDevice, useDispatch } from 'src/hooks/suite';
 import { ThunkAction } from 'src/types/suite';
-import { Button, Image, ModalProps } from '@trezor/components';
+import { Button, Image } from '@trezor/components';
+import { onCancel } from 'src/actions/suite/modalActions';
 
 const StyledImage = styled(Image)`
     align-self: center;
@@ -21,7 +22,7 @@ const StyledButton = styled(Button)`
     flex-grow: 1;
 `;
 
-interface ConfirmUnverifiedProps extends Required<Pick<ModalProps, 'onCancel'>> {
+interface ConfirmUnverifiedProps {
     showUnverifiedButtonText: TranslationKey;
     showUnverified: () => ThunkAction;
     verify: () => ThunkAction;
@@ -30,7 +31,6 @@ interface ConfirmUnverifiedProps extends Required<Pick<ModalProps, 'onCancel'>> 
 
 export const ConfirmUnverified = ({
     showUnverifiedButtonText,
-    onCancel,
     showUnverified,
     verify,
     warningText,
@@ -65,12 +65,13 @@ export const ConfirmUnverified = ({
         dispatch(verify());
     };
     const continueUnverified = () => dispatch(showUnverified());
+    const close = () => dispatch(onCancel());
 
     return (
         <StyledModal
             heading={<Translation id={deviceStatus} values={{ deviceLabel: device.label }} />}
             isCancelable
-            onCancel={onCancel}
+            onCancel={close}
             description={
                 <Translation
                     id={warningText}

--- a/packages/suite/src/components/suite/modals/confirm/ConfirmUnverifiedAddress.tsx
+++ b/packages/suite/src/components/suite/modals/confirm/ConfirmUnverifiedAddress.tsx
@@ -1,0 +1,24 @@
+import React, { useCallback } from 'react';
+
+import { ModalProps } from '@trezor/components';
+import { openAddressModal, showAddress } from 'src/actions/wallet/receiveActions';
+import { ConfirmUnverified } from './ConfirmUnverified';
+
+interface ConfirmUnverifiedAddressProps extends Required<Pick<ModalProps, 'onCancel'>> {
+    addressPath: string;
+    value: string;
+}
+
+export const ConfirmUnverifiedAddress = ({ addressPath, value }: ConfirmUnverifiedAddressProps) => {
+    const verifyAddress = useCallback(() => showAddress(addressPath, value), [addressPath, value]);
+    const showUnverifiedAddress = () => openAddressModal({ addressPath, value });
+
+    return (
+        <ConfirmUnverified
+            showUnverifiedButtonText="TR_SHOW_UNVERIFIED_ADDRESS"
+            warningText="TR_ADDRESS_PHISHING_WARNING"
+            verify={verifyAddress}
+            showUnverified={showUnverifiedAddress}
+        />
+    );
+};

--- a/packages/suite/src/components/suite/modals/confirm/ConfirmValueOnDevice.tsx
+++ b/packages/suite/src/components/suite/modals/confirm/ConfirmValueOnDevice.tsx
@@ -8,7 +8,7 @@ import { QrCode, QRCODE_PADDING, QRCODE_SIZE } from 'src/components/suite/QrCode
 import { Button, ConfirmOnDevice, ModalProps, variables } from '@trezor/components';
 import { copyToClipboard } from '@trezor/dom-utils';
 import DeviceDisconnected from './Address/components/DeviceDisconnected';
-import { selectIsActionAbortable } from 'src/reducers/suite/suiteReducer';
+import { selectDevice, selectIsActionAbortable } from 'src/reducers/suite/suiteReducer';
 import { MODAL } from 'src/actions/suite/constants';
 import { ThunkAction } from 'src/types/suite';
 
@@ -69,7 +69,7 @@ export const ConfirmValueOnDevice = ({
     value,
     valueDataTest,
 }: ConfirmDeviceScreenProps) => {
-    const device = useSelector(state => state.suite.device);
+    const device = useSelector(selectDevice);
     const modalContext = useSelector(state => state.modal.context);
     const dispatch = useDispatch();
     const showCopyButton = isConfirmed || !device?.connected;
@@ -84,10 +84,22 @@ export const ConfirmValueOnDevice = ({
 
     // Device connected while the modal is open -> validate on device.
     useEffect(() => {
-        if (device?.connected && modalContext === MODAL.CONTEXT_USER && !isConfirmed) {
+        if (
+            device?.connected &&
+            device?.available &&
+            modalContext === MODAL.CONTEXT_USER &&
+            !isConfirmed
+        ) {
             dispatch(validateOnDevice());
         }
-    }, [device?.connected, dispatch, isConfirmed, modalContext, validateOnDevice]);
+    }, [
+        device?.available,
+        device?.connected,
+        dispatch,
+        isConfirmed,
+        modalContext,
+        validateOnDevice,
+    ]);
 
     return (
         <StyledModal

--- a/packages/suite/src/components/suite/modals/index.tsx
+++ b/packages/suite/src/components/suite/modals/index.tsx
@@ -17,6 +17,7 @@ export { ConfirmNoBackup } from './confirm/ConfirmNoBackup';
 export { ReviewTransaction } from './ReviewTransaction';
 export { ImportTransaction } from './ImportTransaction';
 export { ConfirmUnverified } from './confirm/ConfirmUnverified';
+export { ConfirmUnverifiedAddress } from './confirm/ConfirmUnverifiedAddress';
 export { AddAccount } from './AddAccount';
 export { QrScanner } from './QrScanner';
 export { BackgroundGallery } from './BackgroundGallery';


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->
Fixes multiple bugs related to displaying address/XPUB with disabled passphrase.

To reproduce:
- open hidden wallet
- disable passphrase in settings
- display XPUB/address

The fixes:
1. The first bug is that the app will loop and throw a `Maximum update depth exceeded` error
  - this is because `payload` (object) was used as a `useCallback` dependency in `UserContextModal`
  - I made this error in #9260
2. Once the first one was fixed, I noticed that "Show public key anyway" button did nothing
  - caused by incomplete condition in `useEffect` in `ConfirmValueOnDevice` which caused the warning modal to open again and again
  - also originates from #9260
3. When I fixed the second bug, I noticed that the second modal shows `ConfirmOnDevice` prompt despite Trezor not showing anything because it is not `available`. The copy button was also missing.
  - I fixed the condition there
  - it must have been like this since forever

## Screenshots

https://github.com/trezor/trezor-suite/assets/42465546/2cb05a7f-e1c6-4caf-85e0-c0b3206d00a6

