### PR TITLE
fix(connect-iframe): device event not propagating to host

### DIFF
--- a/packages/connect-iframe/src/index.ts
+++ b/packages/connect-iframe/src/index.ts
@@ -12,6 +12,7 @@ import {
     POPUP,
     IFRAME,
     UI,
+    DEVICE,
     parseMessage,
     createResponseMessage,
     createIFrameMessage,
@@ -237,6 +238,11 @@ const shouldUiEventBeSentToHost = (message: CoreMessage) => {
         UI.BUNDLE_PROGRESS,
         UI.ADDRESS_VALIDATION,
         RESPONSE_EVENT,
+        DEVICE.CONNECT,
+        DEVICE.CONNECT_UNACQUIRED,
+        DEVICE.CHANGED,
+        DEVICE.DISCONNECT,
+        DEVICE.BUTTON,
     ];
     return whitelistedMessages.includes(message.type);
 };


### PR DESCRIPTION
we broke propagating device events probably here #8447 or somewhere around. 
this is a quick fix.

I am planning to add tests too here https://github.com/trezor/trezor-suite/pull/8886/files#r1315737960

fix #9344 