### PR TITLE
Replace confetti emoji with an icon

### DIFF
--- a/packages/suite/src/components/onboarding/ProgressBar.tsx
+++ b/packages/suite/src/components/onboarding/ProgressBar.tsx
@@ -85,6 +85,10 @@ const Divider = styled.div`
     }
 `;
 
+const ConfettiIcon = styled(Icon)`
+    margin-left: 1px;
+`;
+
 interface ProgressBarProps {
     steps: {
         key: string;
@@ -108,8 +112,17 @@ export const ProgressBar = ({ steps, activeStep, className }: ProgressBarProps) 
                                 {stepCompleted ? (
                                     <Icon icon="CHECK" color={theme.TYPE_GREEN} />
                                 ) : (
-                                    // TODO: Proper icon instead of emoji for last step
-                                    <>{index === steps.length - 1 ? <>🎉</> : index + 1}</>
+                                    <>
+                                        {index === steps.length - 1 ? (
+                                            <ConfettiIcon
+                                                icon="CONFETTI_SUCCESS"
+                                                size={20}
+                                                color={stepActive ? theme.TYPE_GREEN : undefined}
+                                            />
+                                        ) : (
+                                            index + 1
+                                        )}
+                                    </>
                                 )}
                             </IconWrapper>
                             <Label>{step.label}</Label>


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->
An old TODO. We now have our own confetti icon so I replaced the emoji in onboarding. It turns green on the last step.

## Screenshots:
![Screenshot 2023-09-05 at 14 01 17](https://github.com/trezor/trezor-suite/assets/42465546/488fd6f4-2f8a-49aa-bcf9-862dba5d4d6d)
![Screenshot 2023-09-05 at 14 01 03](https://github.com/trezor/trezor-suite/assets/42465546/b6b2651f-3214-4d09-8c50-e12a627c151b)

