### PR TITLE
Connect: accept signTransaction inputs/outputs with `address_n: string`

### DIFF
--- a/packages/connect/src/api/bitcoin/inputs.ts
+++ b/packages/connect/src/api/bitcoin/inputs.ts
@@ -6,14 +6,14 @@ import { bufferUtils } from '@trezor/utils';
 import { validatePath, isSegwitPath, getScriptType, fixPath } from '../../utils/pathUtils';
 import { convertMultisigPubKey } from '../../utils/hdnodeUtils';
 import { validateParams } from '../common/paramsValidator';
-import type { BitcoinNetworkInfo } from '../../types';
+import type { BitcoinNetworkInfo, ProtoWithDerivationPath } from '../../types';
 import type { PROTO } from '../../constants';
 
 /** *****
  * SignTx: validation
  ****** */
 export const validateTrezorInputs = (
-    inputs: PROTO.TxInputType[],
+    inputs: ProtoWithDerivationPath<PROTO.TxInputType>[],
     coinInfo: BitcoinNetworkInfo,
 ): PROTO.TxInputType[] =>
     inputs

--- a/packages/connect/src/api/bitcoin/outputs.ts
+++ b/packages/connect/src/api/bitcoin/outputs.ts
@@ -6,14 +6,14 @@ import { isValidAddress } from '../../utils/addressUtils';
 import { convertMultisigPubKey } from '../../utils/hdnodeUtils';
 import { validateParams } from '../common/paramsValidator';
 import { PROTO, ERRORS } from '../../constants';
-import type { BitcoinNetworkInfo } from '../../types';
+import type { BitcoinNetworkInfo, ProtoWithDerivationPath } from '../../types';
 import type { ComposeOutput } from '../../types/api/composeTransaction';
 
 /** *****
  * SignTransaction: validation
  ****** */
 export const validateTrezorOutputs = (
-    outputs: PROTO.TxOutputType[],
+    outputs: ProtoWithDerivationPath<PROTO.TxOutputType>[],
     coinInfo: BitcoinNetworkInfo,
 ): PROTO.TxOutputType[] => {
     const trezorOutputs = outputs

--- a/packages/connect/src/api/getAccountInfo.ts
+++ b/packages/connect/src/api/getAccountInfo.ts
@@ -10,7 +10,7 @@ import { getCoinInfo } from '../data/coinInfo';
 import { PROTO, ERRORS } from '../constants';
 import { UI, createUiMessage } from '../events';
 import { isBackendSupported, initBlockchain } from '../backend/BlockchainLink';
-import type { CoinInfo, AccountInfo, AccountUtxo } from '../types';
+import type { CoinInfo, AccountInfo, AccountUtxo, DerivationPath } from '../types';
 import type { GetAccountInfo as GetAccountInfoParams } from '../types/api/getAccountInfo';
 
 type Request = GetAccountInfoParams & { address_n: number[]; coinInfo: CoinInfo };
@@ -118,7 +118,7 @@ export default class GetAccountInfo extends AbstractMethod<'getAccountInfo', Req
             );
         } else {
             const keys: {
-                [coin: string]: { coinInfo: CoinInfo; values: Array<string | number[]> };
+                [coin: string]: { coinInfo: CoinInfo; values: DerivationPath[] };
             } = {};
             this.params.forEach(b => {
                 if (!keys[b.coinInfo.label]) {

--- a/packages/connect/src/api/signTransaction.ts
+++ b/packages/connect/src/api/signTransaction.ts
@@ -122,7 +122,7 @@ export default class SignTransaction extends AbstractMethod<'signTransaction', P
 
         this.params = {
             inputs,
-            outputs: payload.outputs,
+            outputs,
             paymentRequests: payload.paymentRequests || [],
             refTxs,
             addresses: payload.account ? payload.account.addresses : undefined,

--- a/packages/connect/src/data/coinInfo.ts
+++ b/packages/connect/src/data/coinInfo.ts
@@ -1,5 +1,5 @@
 // origin: https://github.com/trezor/connect/blob/develop/src/js/data/CoinInfo.js
-
+import { cloneObject } from '@trezor/utils';
 import { getBitcoinFeeLevels, getEthereumFeeLevels, getMiscFeeLevels } from './defaultFeeLevels';
 import { ERRORS } from '../constants';
 import { toHardened, fromHardened } from '../utils/pathUtils';
@@ -8,14 +8,14 @@ import type {
     BitcoinNetworkInfo,
     EthereumNetworkInfo,
     MiscNetworkInfo,
-} from '../types/coinInfo';
-import { cloneObject } from '@trezor/utils';
+    DerivationPath,
+} from '../types';
 
 const bitcoinNetworks: BitcoinNetworkInfo[] = [];
 const ethereumNetworks: EthereumNetworkInfo[] = [];
 const miscNetworks: MiscNetworkInfo[] = [];
 
-export const getBitcoinNetwork = (pathOrName: number[] | string) => {
+export const getBitcoinNetwork = (pathOrName: DerivationPath) => {
     const networks = cloneObject(bitcoinNetworks);
     if (typeof pathOrName === 'string') {
         const name = pathOrName.toLowerCase();
@@ -30,7 +30,7 @@ export const getBitcoinNetwork = (pathOrName: number[] | string) => {
     return networks.find(n => n.slip44 === slip44);
 };
 
-export const getEthereumNetwork = (pathOrName: number[] | string) => {
+export const getEthereumNetwork = (pathOrName: DerivationPath) => {
     const networks = cloneObject(ethereumNetworks);
     if (typeof pathOrName === 'string') {
         const name = pathOrName.toLowerCase();
@@ -42,7 +42,7 @@ export const getEthereumNetwork = (pathOrName: number[] | string) => {
     return networks.find(n => n.slip44 === slip44);
 };
 
-export const getMiscNetwork = (pathOrName: number[] | string) => {
+export const getMiscNetwork = (pathOrName: DerivationPath) => {
     const networks = cloneObject(miscNetworks);
     if (typeof pathOrName === 'string') {
         const name = pathOrName.toLowerCase();

--- a/packages/connect/src/types/api/__tests__/bitcoin.ts
+++ b/packages/connect/src/types/api/__tests__/bitcoin.ts
@@ -113,6 +113,13 @@ export const signTransaction = async (api: TrezorConnect) => {
                 script_type: 'SPENDADDRESS',
             },
             {
+                address_n: "m/44'/0'/0'/0/0",
+                prev_index: 0,
+                prev_hash: 'txhash',
+                amount: '1',
+                script_type: 'SPENDADDRESS',
+            },
+            {
                 address_n: [0],
                 prev_index: 0,
                 prev_hash: 'txhash',
@@ -197,6 +204,11 @@ export const signTransaction = async (api: TrezorConnect) => {
                 },
             },
             // change outputs
+            {
+                address_n: "m/44'/0'/0'/1/0",
+                amount: '100',
+                script_type: 'PAYTOADDRESS',
+            },
             {
                 address_n: [0],
                 amount: '100',

--- a/packages/connect/src/types/api/authorizeCoinjoin.ts
+++ b/packages/connect/src/types/api/authorizeCoinjoin.ts
@@ -1,8 +1,8 @@
 import type { PROTO } from '../../constants';
-import type { Params, Response } from '../params';
+import type { Params, Response, DerivationPath } from '../params';
 
 export interface AuthorizeCoinjoin {
-    path: string | number[];
+    path: DerivationPath;
     coordinator: string;
     maxRounds: number;
     maxCoordinatorFeeRate: number;

--- a/packages/connect/src/types/api/binance/index.ts
+++ b/packages/connect/src/types/api/binance/index.ts
@@ -1,4 +1,5 @@
 import type { PROTO } from '../../../constants';
+import type { DerivationPath } from '../../params';
 
 // BinanceSDKTransaction from https://github.com/binance-chain/javascript-sdk/blob/master/src/tx/index.js
 
@@ -33,6 +34,6 @@ export interface BinancePreparedTransaction extends BinanceSDKTransaction {
 }
 
 export interface BinanceSignTransaction {
-    path: string | number[];
+    path: DerivationPath;
     transaction: BinanceSDKTransaction;
 }

--- a/packages/connect/src/types/api/bitcoin/index.ts
+++ b/packages/connect/src/types/api/bitcoin/index.ts
@@ -2,7 +2,7 @@ import type { AccountAddresses } from '@trezor/blockchain-link';
 import type { Transaction as BlockbookTransaction } from '@trezor/blockchain-link-types/lib/blockbook';
 import type { PROTO } from '../../../constants';
 import type { AccountTransaction } from '../../account';
-import type { DerivationPath } from '../../params';
+import type { DerivationPath, ProtoWithDerivationPath } from '../../params';
 
 // signMessage
 
@@ -63,8 +63,8 @@ export interface TransactionOptions {
 }
 
 export interface SignTransaction {
-    inputs: PROTO.TxInputType[];
-    outputs: PROTO.TxOutputType[];
+    inputs: ProtoWithDerivationPath<PROTO.TxInputType>[];
+    outputs: ProtoWithDerivationPath<PROTO.TxOutputType>[];
     paymentRequests?: PROTO.TxAckPaymentRequest[];
     refTxs?: RefTransaction[];
     account?: {

--- a/packages/connect/src/types/api/bitcoin/index.ts
+++ b/packages/connect/src/types/api/bitcoin/index.ts
@@ -1,13 +1,13 @@
-import type { PROTO } from '../../../constants';
 import type { AccountAddresses } from '@trezor/blockchain-link';
 import type { Transaction as BlockbookTransaction } from '@trezor/blockchain-link-types/lib/blockbook';
-
-import { AccountTransaction } from '../../account';
+import type { PROTO } from '../../../constants';
+import type { AccountTransaction } from '../../account';
+import type { DerivationPath } from '../../params';
 
 // signMessage
 
 export interface SignMessage {
-    path: string | number[];
+    path: DerivationPath;
     coin: string;
     message: string;
     hex?: boolean;

--- a/packages/connect/src/types/api/cardano/index.ts
+++ b/packages/connect/src/types/api/cardano/index.ts
@@ -1,5 +1,5 @@
 import type { PROTO } from '../../../constants';
-import type { GetPublicKey, PublicKey } from '../../params';
+import type { GetPublicKey, PublicKey, DerivationPath } from '../../params';
 
 // cardanoGetAddress
 
@@ -11,8 +11,8 @@ export interface CardanoCertificatePointer {
 
 export interface CardanoAddressParameters {
     addressType: PROTO.CardanoAddressType;
-    path?: string | number[];
-    stakingPath?: string | number[];
+    path?: DerivationPath;
+    stakingPath?: DerivationPath;
     stakingKeyHash?: string;
     certificatePointer?: CardanoCertificatePointer;
     paymentScriptHash?: string;
@@ -43,7 +43,7 @@ export interface CardanoNativeScript {
     type: PROTO.CardanoNativeScriptType;
     scripts?: CardanoNativeScript[];
     keyHash?: string;
-    keyPath?: string | number[];
+    keyPath?: DerivationPath;
     requiredSignaturesCount?: number;
     invalidBefore?: string;
     invalidHereafter?: string;
@@ -72,7 +72,7 @@ export interface CardanoPublicKey extends PublicKey {
 // cardanoSignTransaction
 
 export interface CardanoInput {
-    path?: string | number[];
+    path?: DerivationPath;
     prev_hash: string;
     prev_index: number;
 }
@@ -105,7 +105,7 @@ export type CardanoOutput = (
 };
 
 export interface CardanoPoolOwner {
-    stakingKeyPath?: string | number[];
+    stakingKeyPath?: DerivationPath;
     stakingKeyHash?: string;
 }
 
@@ -141,7 +141,7 @@ export interface CardanoPoolParameters {
 
 export interface CardanoCertificate {
     type: PROTO.CardanoCertificateType;
-    path?: string | number[];
+    path?: DerivationPath;
     pool?: string;
     poolParameters?: CardanoPoolParameters;
     scriptHash?: string;
@@ -149,7 +149,7 @@ export interface CardanoCertificate {
 }
 
 export interface CardanoWithdrawal {
-    path?: string | number[];
+    path?: DerivationPath;
     amount: string;
     scriptHash?: string;
     keyHash?: string;
@@ -158,13 +158,13 @@ export interface CardanoWithdrawal {
 export type CardanoMint = CardanoAssetGroup[];
 
 export interface CardanoCollateralInput {
-    path?: string | number[];
+    path?: DerivationPath;
     prev_hash: string;
     prev_index: number;
 }
 
 export interface CardanoRequiredSigner {
-    keyPath?: string | number[];
+    keyPath?: DerivationPath;
     keyHash?: string;
 }
 
@@ -180,7 +180,7 @@ export interface CardanoCVoteRegistrationDelegation {
 
 export interface CardanoCVoteRegistrationParameters {
     votePublicKey?: string;
-    stakingPath: string | number[];
+    stakingPath: DerivationPath;
     paymentAddressParameters?: CardanoAddressParameters;
     nonce: string;
     format?: PROTO.CardanoCVoteRegistrationFormat;
@@ -210,7 +210,7 @@ export interface CardanoSignTransaction {
     collateralReturn?: CardanoOutput;
     totalCollateral?: string;
     referenceInputs?: CardanoReferenceInput[];
-    additionalWitnessRequests?: (string | number[])[];
+    additionalWitnessRequests?: DerivationPath[];
     protocolMagic: number;
     networkId: number;
     signingMode: PROTO.CardanoTxSigningMode;

--- a/packages/connect/src/types/api/cipherKeyValue.ts
+++ b/packages/connect/src/types/api/cipherKeyValue.ts
@@ -1,7 +1,7 @@
-import type { Params, BundledParams, Response } from '../params';
+import type { Params, BundledParams, Response, DerivationPath } from '../params';
 
 export interface CipherKeyValue {
-    path: string | number[];
+    path: DerivationPath;
     key: string;
     value: string | Buffer;
     encrypt?: boolean;

--- a/packages/connect/src/types/api/eos/index.ts
+++ b/packages/connect/src/types/api/eos/index.ts
@@ -1,5 +1,5 @@
-// todo: should extend PROTO respective types maybe?
-import { PROTO } from '../../../constants';
+import type { PROTO } from '../../../constants';
+import type { DerivationPath } from '../../params';
 
 // eosGetPublicKey
 
@@ -137,6 +137,6 @@ export interface EosSDKTransaction {
 }
 
 export interface EosSignTransaction {
-    path: string | number[];
+    path: DerivationPath;
     transaction: EosSDKTransaction;
 }

--- a/packages/connect/src/types/api/ethereum/index.ts
+++ b/packages/connect/src/types/api/ethereum/index.ts
@@ -1,7 +1,9 @@
+import type { DerivationPath } from '../../params';
+
 // ethereumSignMessage
 
 export interface EthereumSignMessage {
-    path: string | number[];
+    path: DerivationPath;
     message: string;
     hex?: boolean;
 }
@@ -40,7 +42,7 @@ export interface EthereumTransactionEIP1559 {
 }
 
 export interface EthereumSignTransaction {
-    path: string | number[];
+    path: DerivationPath;
     transaction: EthereumTransaction | EthereumTransactionEIP1559;
 }
 
@@ -76,7 +78,7 @@ export interface EthereumSignTypedDataMessage<T extends EthereumSignTypedDataTyp
 }
 
 export interface EthereumSignTypedData<T extends EthereumSignTypedDataTypes> {
-    path: string | number[];
+    path: DerivationPath;
     data: EthereumSignTypedDataMessage<T>;
     metamask_v4_compat: boolean;
     domain_separator_hash?: undefined;
@@ -90,7 +92,7 @@ export interface EthereumSignTypedData<T extends EthereumSignTypedDataTypes> {
  * Supports both T2T1 and T1B1.
  */
 export interface EthereumSignTypedHash<T extends EthereumSignTypedDataTypes> {
-    path: string | number[];
+    path: DerivationPath;
     data: EthereumSignTypedDataMessage<T>;
     metamask_v4_compat: boolean;
     domain_separator_hash: string;

--- a/packages/connect/src/types/api/getOwnershipId.ts
+++ b/packages/connect/src/types/api/getOwnershipId.ts
@@ -1,8 +1,8 @@
 import type { PROTO } from '../../constants';
-import type { Params, BundledParams, Response } from '../params';
+import type { Params, BundledParams, Response, DerivationPath } from '../params';
 
 export interface GetOwnershipId {
-    path: string | number[];
+    path: DerivationPath;
     coin?: string;
     multisig?: PROTO.MultisigRedeemScriptType;
     scriptType?: PROTO.InternalInputScriptType;

--- a/packages/connect/src/types/api/getOwnershipProof.ts
+++ b/packages/connect/src/types/api/getOwnershipProof.ts
@@ -1,8 +1,8 @@
 import type { PROTO } from '../../constants';
-import type { Params, BundledParams, Response } from '../params';
+import type { Params, BundledParams, Response, DerivationPath } from '../params';
 
 export interface GetOwnershipProof {
-    path: string | number[];
+    path: DerivationPath;
     coin?: string;
     multisig?: PROTO.MultisigRedeemScriptType;
     scriptType?: PROTO.InternalInputScriptType;

--- a/packages/connect/src/types/api/nem/index.ts
+++ b/packages/connect/src/types/api/nem/index.ts
@@ -1,4 +1,5 @@
 import type { PROTO, NEM } from '../../../constants';
+import type { DerivationPath } from '../../params';
 
 // NEM types from nem-sdk
 // https://nemproject.github.io/#transferTransaction
@@ -109,6 +110,6 @@ export type NEMMultisigTransaction = TransactionCommon & {
 export type NEMTransaction = NEMRegularTransaction | NEMMultisigTransaction;
 
 export interface NEMSignTransaction {
-    path: string | number[];
+    path: DerivationPath;
     transaction: NEMTransaction;
 }

--- a/packages/connect/src/types/api/ripple/index.ts
+++ b/packages/connect/src/types/api/ripple/index.ts
@@ -1,3 +1,5 @@
+import type { DerivationPath } from '../../params';
+
 export interface RipplePayment {
     amount: string;
     destination: string;
@@ -13,7 +15,7 @@ export interface RippleTransaction {
 }
 
 export interface RippleSignTransaction {
-    path: string | number[];
+    path: DerivationPath;
     transaction: RippleTransaction;
 }
 

--- a/packages/connect/src/types/api/stellar/index.ts
+++ b/packages/connect/src/types/api/stellar/index.ts
@@ -2,6 +2,7 @@
 // https://github.com/stellar/js-stellar-base
 
 import type { PROTO } from '../../../constants';
+import type { DerivationPath } from '../../params';
 
 export interface StellarAsset {
     type: PROTO.StellarAssetType;
@@ -169,7 +170,7 @@ export interface StellarTransaction {
 }
 
 export interface StellarSignTransaction {
-    path: string | number[];
+    path: DerivationPath;
     networkPassphrase: string;
     transaction: StellarTransaction;
 }

--- a/packages/connect/src/types/api/tezos/index.ts
+++ b/packages/connect/src/types/api/tezos/index.ts
@@ -1,3 +1,5 @@
+import type { DerivationPath } from '../../params';
+
 export interface TezosRevealOperation {
     source: string;
     fee: number;
@@ -34,7 +36,7 @@ export interface TezosOriginationOperation {
     source: string;
     balance: number;
     delegate?: string;
-    script: string | number[];
+    script: DerivationPath;
     fee: number;
     counter: number;
     gas_limit: number;
@@ -58,7 +60,7 @@ export interface TezosOperation {
 }
 
 export interface TezosSignTransaction {
-    path: string | number[];
+    path: DerivationPath;
     branch: string;
     operation: TezosOperation;
 }

--- a/packages/connect/src/types/api/unlockPath.ts
+++ b/packages/connect/src/types/api/unlockPath.ts
@@ -1,8 +1,8 @@
 import type { PROTO } from '../../constants';
-import type { Params, Response } from '../params';
+import type { Params, Response, DerivationPath } from '../params';
 
 export interface UnlockPathParams {
-    path: string | number[];
+    path: DerivationPath;
     mac?: string;
 }
 

--- a/packages/connect/src/types/params.ts
+++ b/packages/connect/src/types/params.ts
@@ -39,9 +39,11 @@ export interface Success<T> {
 
 export type Response<T> = Promise<Success<T> | Unsuccessful>;
 
+export type DerivationPath = string | number[];
+
 // Common fields for all *.getAddress methods
 export interface GetAddress {
-    path: string | number[];
+    path: DerivationPath;
     address?: string;
     showOnTrezor?: boolean;
 }
@@ -54,7 +56,7 @@ export interface Address {
 
 // Common fields for all *.getPublicKey methods
 export interface GetPublicKey {
-    path: string | number[];
+    path: DerivationPath;
     showOnTrezor?: boolean;
     suppressBackupWarning?: boolean;
 }

--- a/packages/connect/src/types/params.ts
+++ b/packages/connect/src/types/params.ts
@@ -41,6 +41,21 @@ export type Response<T> = Promise<Success<T> | Unsuccessful>;
 
 export type DerivationPath = string | number[];
 
+// replace type `T` address_n field type `A` with address_n type `R`
+type ProtoWithExtendedAddressN<T, A, R> = Omit<Extract<T, { address_n: A }>, 'address_n'> & {
+    address_n: R;
+};
+type ProtoWithoutAddressN<T, A> = Exclude<T, { address_n: A }>;
+
+// replace address_n: number[] with address_n: DerivationPath
+export type ProtoWithDerivationPath<T> =
+    | ProtoWithoutAddressN<T, number[]>
+    | ProtoWithExtendedAddressN<T, number[], DerivationPath>;
+
+// unwrap original generic PROTO type from the replacement
+export type ProtoWithAddressN<P extends ProtoWithDerivationPath<any>> =
+    P extends ProtoWithDerivationPath<infer T> ? T : unknown;
+
 // Common fields for all *.getAddress methods
 export interface GetAddress {
     path: DerivationPath;

--- a/packages/connect/src/utils/pathUtils.ts
+++ b/packages/connect/src/utils/pathUtils.ts
@@ -1,7 +1,7 @@
 // origin: https://github.com/trezor/connect/blob/develop/src/js/utils/pathUtils.js
 
 import { PROTO, ERRORS } from '../constants';
-import type { CoinInfo } from '../types';
+import type { CoinInfo, DerivationPath } from '../types';
 
 export const HD_HARDENED = 0x80000000;
 export const toHardened = (n: number) => (n | HD_HARDENED) >>> 0;
@@ -141,7 +141,7 @@ export const getOutputScriptType = (path?: number[]): PROTO.ChangeOutputScriptTy
     }
 };
 
-export const validatePath = (path: string | number[], length = 0, base = false): number[] => {
+export const validatePath = (path: DerivationPath, length = 0, base = false): number[] => {
     let valid: number[] | undefined;
     if (typeof path === 'string') {
         valid = getHDPath(path);

--- a/packages/connect/src/utils/pathUtils.ts
+++ b/packages/connect/src/utils/pathUtils.ts
@@ -1,7 +1,12 @@
 // origin: https://github.com/trezor/connect/blob/develop/src/js/utils/pathUtils.js
 
 import { PROTO, ERRORS } from '../constants';
-import type { CoinInfo, DerivationPath } from '../types';
+import type {
+    CoinInfo,
+    DerivationPath,
+    ProtoWithDerivationPath,
+    ProtoWithAddressN,
+} from '../types';
 
 export const HD_HARDENED = 0x80000000;
 export const toHardened = (n: number) => (n | HD_HARDENED) >>> 0;
@@ -188,18 +193,22 @@ export const getIndexFromPath = (path: number[]) => {
     return fromHardened(path[2]);
 };
 
-export const fixPath = <T extends PROTO.TxInputType | PROTO.TxOutputType>(utxo: T): T => {
+export const fixPath = <
+    T extends
+        | ProtoWithDerivationPath<PROTO.TxInputType>
+        | ProtoWithDerivationPath<PROTO.TxOutputType>,
+>(
+    utxo: T,
+): ProtoWithAddressN<T> => {
     // make sure bip32 indices are unsigned
     if (utxo.address_n && Array.isArray(utxo.address_n)) {
         utxo.address_n = utxo.address_n.map(i => i >>> 0);
     }
-    // This is only a part of API wide issue: https://github.com/trezor/trezor-suite/issues/4875
-    // it works only in runtime. type T needs to have address_n as string, but currently we are using Protobuf declaration
+    // make sure that address_n is an array
     if (utxo.address_n && typeof utxo.address_n === 'string') {
-        // @ts-expect-error Related to previous comment
         utxo.address_n = getHDPath(utxo.address_n);
     }
-    return utxo;
+    return utxo as ProtoWithAddressN<T>;
 };
 
 export const getLabel = (label: string, coinInfo?: CoinInfo) => {

--- a/packages/suite/src/actions/wallet/coinjoinClientActions.ts
+++ b/packages/suite/src/actions/wallet/coinjoinClientActions.ts
@@ -624,9 +624,7 @@ const signCoinjoinTx =
                         const signTx = await TrezorConnect.signTransaction({
                             device,
                             useEmptyPassphrase: device?.useEmptyPassphrase,
-                            // @ts-expect-error TODO: tx.inputs/outputs path is a string
                             inputs: tx.inputs,
-                            // @ts-expect-error TODO: tx.inputs/outputs path is a string
                             outputs: tx.outputs,
                             coinjoinRequest: tx.coinjoinRequest,
                             coin: network,

--- a/packages/suite/src/utils/wallet/coinjoinUtils.ts
+++ b/packages/suite/src/utils/wallet/coinjoinUtils.ts
@@ -257,12 +257,12 @@ export const prepareCoinjoinTransaction = (
                     prev_index: input.index,
                     amount: input.amount,
                     coinjoin_flags: flags,
-                };
+                } as const;
             }
 
             return {
                 address_n: undefined,
-                script_type: 'EXTERNAL' as const,
+                script_type: 'EXTERNAL',
                 prev_hash: input.hash,
                 prev_index: input.index,
                 amount: input.amount,
@@ -270,21 +270,21 @@ export const prepareCoinjoinTransaction = (
                 ownership_proof: input.ownershipProof,
                 commitment_data: input.commitmentData,
                 coinjoin_flags: flags,
-            };
+            } as const;
         }),
         outputs: transaction.outputs.map(output => {
             if (isInternalOutput(output)) {
                 return {
-                    address_n: output.path! as any,
+                    address_n: output.path!,
                     amount: output.amount,
                     script_type: outputScriptType,
-                };
+                } as const;
             }
             return {
                 address: output.address,
                 amount: output.amount,
-                script_type: 'PAYTOADDRESS' as const,
-            };
+                script_type: 'PAYTOADDRESS',
+            } as const;
         }),
     };
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
This was already [been implemented](https://github.com/trezor/connect/commit/a3e052bc9f84499c941547bee33e1b9e4ac003ed) a while ago, but not on types level.

It is also a prerequisite for https://github.com/trezor/trezor-suite/pull/9143 where composedTx inputs/outputs are generic and derivation path could be anything (string or array of numbers)

## Related Issue

Resolve https://github.com/trezor/trezor-suite/issues/4875

