### PR TITLE
chore(coinjoin): use the same function to switch TOR circuit

### DIFF
--- a/packages/coinjoin/src/backend/CoinjoinBackendClient.ts
+++ b/packages/coinjoin/src/backend/CoinjoinBackendClient.ts
@@ -2,7 +2,7 @@ import { scheduleAction, arrayShuffle, urlToOnion } from '@trezor/utils';
 import { TypedEmitter } from '@trezor/utils/lib/typedEventEmitter';
 import type { BlockbookAPI } from '@trezor/blockchain-link/lib/workers/blockbook/websocket';
 
-import { RequestOptions } from '../utils/http';
+import { RequestOptions, resetIdentityCircuit } from '../utils/http';
 import type {
     BlockbookBlock,
     BlockFilterResponse,
@@ -12,7 +12,7 @@ import type {
 import type { CoinjoinBackendSettings, Logger } from '../types';
 import { FILTERS_REQUEST_TIMEOUT, HTTP_REQUEST_GAP, HTTP_REQUEST_TIMEOUT } from '../constants';
 import { CoinjoinWebsocketController } from './CoinjoinWebsocketController';
-import { identifyWsError, resetIdentityCircuit } from './backendUtils';
+import { identifyWsError } from './backendUtils';
 
 type CoinjoinBackendClientSettings = CoinjoinBackendSettings & {
     timeout?: number;

--- a/packages/coinjoin/src/backend/CoinjoinWebsocketController.ts
+++ b/packages/coinjoin/src/backend/CoinjoinWebsocketController.ts
@@ -1,8 +1,9 @@
 import { BlockbookAPI } from '@trezor/blockchain-link/lib/workers/blockbook/websocket';
 
 import { HTTP_REQUEST_TIMEOUT, WS_CONNECT_TIMEOUT } from '../constants';
+import { resetIdentityCircuit } from '../utils/http';
 import type { Logger } from '../types';
-import { identifyWsError, resetIdentityCircuit } from './backendUtils';
+import { identifyWsError } from './backendUtils';
 
 export type BlockbookWS = Pick<
     BlockbookAPI,

--- a/packages/coinjoin/src/backend/backendUtils.ts
+++ b/packages/coinjoin/src/backend/backendUtils.ts
@@ -67,9 +67,3 @@ export const identifyWsError = (error: Error) => {
             return 'ERROR_OTHER';
     }
 };
-
-// Randomize identity password to reset TOR circuit for this identity
-export const resetIdentityCircuit = (identity: string) => {
-    const [user] = identity.split(':');
-    return `${user}:${Math.random().toString(36).slice(2)}`;
-};

--- a/packages/coinjoin/src/client/coordinatorRequest.ts
+++ b/packages/coinjoin/src/client/coordinatorRequest.ts
@@ -2,7 +2,13 @@ import { scheduleAction, enumUtils } from '@trezor/utils';
 
 import { HTTP_REQUEST_TIMEOUT } from '../constants';
 import { WabiSabiProtocolErrorCode } from '../enums';
-import { httpPost, httpGet, patchResponse, RequestOptions } from '../utils/http';
+import {
+    httpPost,
+    httpGet,
+    patchResponse,
+    RequestOptions,
+    resetIdentityCircuit,
+} from '../utils/http';
 
 export type { RequestOptions } from '../utils/http';
 
@@ -52,9 +58,7 @@ export const coordinatorRequest = async <R = void>(
 
     const switchIdentity = () => {
         if (options.identity) {
-            // set random password to reset TOR circuit for this identity and then try again
-            const [user] = options.identity.split(':');
-            options.identity = `${user}:${Math.random()}`;
+            options.identity = resetIdentityCircuit(options.identity);
         }
     };
 

--- a/packages/coinjoin/src/utils/http.ts
+++ b/packages/coinjoin/src/utils/http.ts
@@ -1,6 +1,6 @@
 import fetch from 'cross-fetch';
 
-import { ScheduleActionParams } from '@trezor/utils';
+import { ScheduleActionParams, getWeakRandomId } from '@trezor/utils';
 
 export interface RequestOptions extends ScheduleActionParams {
     method?: 'POST' | 'GET';
@@ -73,3 +73,9 @@ export const httpPost = (url: string, body?: Record<string, any>, options: Reque
         signal: options.signal,
         headers: createHeaders(options),
     });
+
+// Randomize identity password to reset TOR circuit for this identity
+export const resetIdentityCircuit = (identity: string) => {
+    const [user] = identity.split(':');
+    return `${user}:${getWeakRandomId(16)}`;
+};

--- a/packages/coinjoin/tests/backend/CoinjoinBackendClient.test.ts
+++ b/packages/coinjoin/tests/backend/CoinjoinBackendClient.test.ts
@@ -60,7 +60,7 @@ describe('CoinjoinBackendClient', () => {
 
         expect(identities[0]).toBe('taxation');
         identities.slice(1, 3).forEach((id, i, arr) => {
-            expect(id).toMatch(/taxation:[a-z0-9]+/);
+            expect(id).toMatch(/taxation:[a-zA-Z0-9]+/);
             expect(arr.indexOf(id)).toBe(i);
         });
 
@@ -68,7 +68,7 @@ describe('CoinjoinBackendClient', () => {
 
         expect(identities[7]).toBe('theft');
         identities.slice(8, 9).forEach((id, i, arr) => {
-            expect(id).toMatch(/theft:[a-z0-9]+/);
+            expect(id).toMatch(/theft:[a-zA-Z0-9]+/);
             expect(arr.indexOf(id)).toBe(i);
         });
     });
@@ -104,8 +104,8 @@ describe('CoinjoinBackendClient', () => {
 
         const [idA, idB, idC, idD] = identities;
         expect([idA, idB]).toStrictEqual(['id', 'id']);
-        expect(idC).toMatch(/id:[a-z0-9]+/);
-        expect(idD).toMatch(/id:[a-z0-9]+/);
+        expect(idC).toMatch(/id:[a-zA-Z0-9]+/);
+        expect(idD).toMatch(/id:[a-zA-Z0-9]+/);
         expect(idC).not.toBe(idD);
     });
 });

--- a/packages/coinjoin/tests/utils/http.test.ts
+++ b/packages/coinjoin/tests/utils/http.test.ts
@@ -1,0 +1,16 @@
+import { resetIdentityCircuit } from '../../src/utils/http';
+
+describe('resetIdentityCircuit', () => {
+    it('identity without password', () => {
+        const id = resetIdentityCircuit('username');
+        expect(id).toMatch(/username:[a-zA-Z0-9]+/);
+    });
+    it('identity with new password', () => {
+        const oldPass = 'abcd';
+        const id = resetIdentityCircuit(`username:${oldPass}`);
+        expect(id).toMatch(/username:[a-zA-Z0-9]+/);
+        const [, pass] = id.split(':');
+        expect(pass).not.toEqual(oldPass);
+        expect(pass.length).toEqual(16);
+    });
+});


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

just for code hygiene, using the same utility for switching TOR circuits (in backend and client code)

