### PR TITLE
Fix: get favicon back in connect-explorer and popup

### DIFF
--- a/packages/connect-explorer/package.json
+++ b/packages/connect-explorer/package.json
@@ -12,6 +12,7 @@
         "@trezor/components": "workspace:*",
         "@trezor/connect-web": "workspace:*",
         "@trezor/protobuf": "workspace:*",
+        "copy-webpack-plugin": "^11.0.0",
         "markdown-it": "^13.0.1",
         "markdown-it-link-attributes": "^4.0.1",
         "markdown-it-replace-link": "^1.2.0",

--- a/packages/connect-explorer/webpack/prod.webpack.config.ts
+++ b/packages/connect-explorer/webpack/prod.webpack.config.ts
@@ -2,6 +2,9 @@ import webpack from 'webpack';
 import path from 'path';
 import HtmlWebpackPlugin from 'html-webpack-plugin';
 import TerserPlugin from 'terser-webpack-plugin';
+import CopyPlugin from 'copy-webpack-plugin';
+
+const DIST = path.resolve(__dirname, '../build');
 
 const config: webpack.Configuration = {
     mode: 'production',
@@ -11,7 +14,7 @@ const config: webpack.Configuration = {
     output: {
         filename: '[name].[hash].js',
         publicPath: './',
-        path: path.resolve(__dirname, '../build'),
+        path: DIST,
     },
     module: {
         rules: [
@@ -71,6 +74,14 @@ const config: webpack.Configuration = {
         new webpack.DefinePlugin({
             // eslint-disable-next-line no-underscore-dangle
             'process.env.__TREZOR_CONNECT_SRC': JSON.stringify(process.env.__TREZOR_CONNECT_SRC),
+        }),
+        new CopyPlugin({
+            patterns: [
+                {
+                    from: path.resolve(__dirname, '../src/images'),
+                    to: path.resolve(DIST, 'images'),
+                },
+            ],
         }),
     ],
     optimization: {

--- a/packages/connect-popup/src/static/popup.html
+++ b/packages/connect-popup/src/static/popup.html
@@ -16,6 +16,7 @@
         <meta name="theme-color" content="#ffffff" />
         <meta http-equiv="Pragma" content="no-cache" />
         <meta http-equiv="Expires" content="-1" />
+        <link rel="icon" type="image/png" href="images/favicon.png" />
         <link href="./popup.css" rel="stylesheet" />
 
         <!-- suite-like fonts -->

--- a/yarn.lock
+++ b/yarn.lock
@@ -9008,6 +9008,7 @@ __metadata:
     "@types/react-router-dom": ^5.1.7
     "@types/styled-components": ^5.1.26
     babel-loader: ^9.1.2
+    copy-webpack-plugin: ^11.0.0
     html-webpack-plugin: ^5.5.3
     jest: ^26.6.3
     markdown-it: ^13.0.1


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
This fix missing favicon in connect-explorer and popup. This itself is something worth fixing but my initial worry was console error in connect-web since the favicon was missing and I want to add a check that makes sure we do not have errors in console for the porpoise of making sure in the future we do not add any circular dependencies to any of the logs that could cause bigger performance and other types of issues https://github.com/trezor/trezor-suite/pull/8623


![image](https://github.com/trezor/trezor-suite/assets/5362163/35cf8079-5f5e-457c-85b5-2000fc079170)

