### PR TITLE
fix(suite-native): internal notifications disabled

### DIFF
--- a/suite-native/app/src/App.tsx
+++ b/suite-native/app/src/App.tsx
@@ -10,7 +10,7 @@ import * as Sentry from '@sentry/react-native';
 // FIXME this is only temporary until Intl refactor will be finished
 import enMessages from '@trezor/suite-data/files/translations/en.json';
 import { selectIsAppReady, selectIsConnectInitialized, StoreProvider } from '@suite-native/state';
-import { NotificationRenderer } from '@suite-native/notifications';
+// import { NotificationRenderer } from '@suite-native/notifications';
 import { ToastRenderer } from '@suite-native/toasts';
 import { FormatterProvider } from '@suite-common/formatters';
 import { AlertRenderer } from '@suite-native/alerts';
@@ -60,11 +60,13 @@ const AppComponent = () => {
             <AuthenticatorProvider>
                 <AlertRenderer>
                     <MessageSystemRenderer />
-                    <NotificationRenderer>
-                        <ToastRenderer>
-                            <RootStackNavigator />
-                        </ToastRenderer>
-                    </NotificationRenderer>
+                    {/* Notifications are disabled until the problem with after-import notifications flooding is solved. */}
+                    {/* More here: https://github.com/trezor/trezor-suite/issues/7721  */}
+                    {/* <NotificationRenderer> */}
+                    <ToastRenderer>
+                        <RootStackNavigator />
+                    </ToastRenderer>
+                    {/* </NotificationRenderer> */}
                 </AlertRenderer>
             </AuthenticatorProvider>
         </FormatterProvider>


### PR DESCRIPTION
Since the problem with flooding notifications is still not resolved, we need to disable this functionality before release.
