### PR TITLE
Fix/blurred overlay on physical iphone

### DIFF
--- a/suite-common/icons/package.json
+++ b/suite-common/icons/package.json
@@ -11,7 +11,7 @@
         "generate-icons": "yarn tsx generateIcons.js"
     },
     "dependencies": {
-        "@shopify/react-native-skia": "0.1.188",
+        "@shopify/react-native-skia": "0.1.203",
         "@suite-common/wallet-config": "workspace:*",
         "@suite-common/wallet-types": "workspace:*",
         "@trezor/styles": "workspace:*",

--- a/suite-native/app/ios/Podfile.lock
+++ b/suite-native/app/ios/Podfile.lock
@@ -393,7 +393,7 @@ PODS:
     - RCTTypeSafety
     - React-Core
     - ReactCommon/turbomodule/core
-  - react-native-skia (0.1.188):
+  - react-native-skia (0.1.203):
     - React
     - React-callinvoker
     - React-Core
@@ -836,7 +836,7 @@ SPEC CHECKSUMS:
   react-native-mmkv: a2a40a0458bdbc9d43c4e7752ecfc5e3a87b66dd
   react-native-restart: 7595693413fe3ca15893702f2c8306c62a708162
   react-native-safe-area-context: 39c2d8be3328df5d437ac1700f4f3a4f75716acc
-  react-native-skia: 8c68c437707fd47b25420ca4c8563fe3cfc52ada
+  react-native-skia: 1231c321c7b816b04f949d18222d9260c4ecd923
   React-perflogger: d21f182895de9d1b077f8a3cd00011095c8c9100
   React-RCTActionSheet: 0151f83ef92d2a7139bba7dfdbc8066632a6d47b
   React-RCTAnimation: 5ec9c0705bb2297549c120fe6473aa3e4a01e215
@@ -865,4 +865,4 @@ SPEC CHECKSUMS:
 
 PODFILE CHECKSUM: d37876aaf00e7f8309b694188119b139b8452ca1
 
-COCOAPODS: 1.11.3
+COCOAPODS: 1.12.1

--- a/suite-native/app/package.json
+++ b/suite-native/app/package.json
@@ -38,7 +38,7 @@
         "@rnx-kit/metro-config": "^1.3.6",
         "@sentry/react-native": "5.5.0",
         "@shopify/flash-list": "^1.4.3",
-        "@shopify/react-native-skia": "0.1.188",
+        "@shopify/react-native-skia": "0.1.203",
         "@suite-common/analytics": "workspace:*",
         "@suite-common/connect-init": "workspace:*",
         "@suite-common/formatters": "workspace:*",

--- a/suite-native/atoms/package.json
+++ b/suite-native/atoms/package.json
@@ -11,7 +11,7 @@
     },
     "dependencies": {
         "@mobily/ts-belt": "^3.13.1",
-        "@shopify/react-native-skia": "0.1.188",
+        "@shopify/react-native-skia": "0.1.203",
         "@suite-common/icons": "workspace:*",
         "@suite-common/wallet-config": "workspace:*",
         "@suite-common/wallet-types": "workspace:*",

--- a/suite-native/graph/package.json
+++ b/suite-native/graph/package.json
@@ -13,7 +13,7 @@
     "dependencies": {
         "@mobily/ts-belt": "^3.13.1",
         "@reduxjs/toolkit": "1.9.5",
-        "@shopify/react-native-skia": "0.1.188",
+        "@shopify/react-native-skia": "0.1.203",
         "@suite-common/formatters": "workspace:*",
         "@suite-common/graph": "workspace:*",
         "@suite-common/icons": "workspace:*",

--- a/suite-native/module-accounts-import/package.json
+++ b/suite-native/module-accounts-import/package.json
@@ -17,7 +17,7 @@
         "@react-navigation/native": "^6.1.3",
         "@react-navigation/native-stack": "^6.9.11",
         "@reduxjs/toolkit": "1.9.5",
-        "@shopify/react-native-skia": "0.1.188",
+        "@shopify/react-native-skia": "0.1.203",
         "@suite-common/formatters": "workspace:*",
         "@suite-common/icons": "workspace:*",
         "@suite-common/redux-utils": "workspace:*",

--- a/suite-native/react-native-graph/package.json
+++ b/suite-native/react-native-graph/package.json
@@ -11,7 +11,7 @@
         "type-check": "tsc --build"
     },
     "dependencies": {
-        "@shopify/react-native-skia": "0.1.188",
+        "@shopify/react-native-skia": "0.1.203",
         "@types/react": "18.0.32",
         "react": "18.2.0",
         "react-native": "0.71.8",

--- a/suite-native/screen-overlay/package.json
+++ b/suite-native/screen-overlay/package.json
@@ -12,7 +12,7 @@
     },
     "dependencies": {
         "@react-navigation/native": "^6.1.3",
-        "@shopify/react-native-skia": "0.1.188",
+        "@shopify/react-native-skia": "0.1.203",
         "@trezor/styles": "workspace:*",
         "react": "18.2.0",
         "react-native": "0.71.8"

--- a/suite-native/screen-overlay/src/components/BlurredScreenOverlay.tsx
+++ b/suite-native/screen-overlay/src/components/BlurredScreenOverlay.tsx
@@ -20,6 +20,19 @@ const canvasStyle = prepareNativeStyle(_ => ({
     flex: 1,
 }));
 
+const overlayWrapperStyle = prepareNativeStyle(utils => ({
+    ...StyleSheet.absoluteFillObject,
+    justifyContent: 'center',
+    alignItems: 'center',
+    backgroundColor: utils.colors.backgroundTertiaryDefaultOnElevation0,
+}));
+
+const BlankScreenPlaceholder = () => {
+    const { applyStyle } = useNativeStyles();
+
+    return <View style={applyStyle(overlayWrapperStyle)} />;
+};
+
 export const BlurredScreenOverlay = ({
     isDimmed = true,
     blurValue = 4,
@@ -31,7 +44,9 @@ export const BlurredScreenOverlay = ({
 
     const { screenshot } = useContext(ScreenshotContext);
 
-    if (!screenshot) return null;
+    /* If the screenshot is not ready yet (typically right after starting the app), display
+     a blank screen to prevent unauthorized user from seeing the content of the screen. */
+    if (!screenshot) return <BlankScreenPlaceholder />;
 
     const overlayHeight = SCREEN_HEIGHT - STATUS_BAR_HEIGHT;
 

--- a/suite-native/transactions/package.json
+++ b/suite-native/transactions/package.json
@@ -14,7 +14,7 @@
         "@mobily/ts-belt": "^3.13.1",
         "@react-navigation/native": "^6.1.3",
         "@shopify/flash-list": "^1.4.3",
-        "@shopify/react-native-skia": "0.1.188",
+        "@shopify/react-native-skia": "0.1.203",
         "@suite-common/formatters": "workspace:*",
         "@suite-common/icons": "workspace:*",
         "@suite-common/suite-config": "workspace:*",

--- a/yarn.lock
+++ b/yarn.lock
@@ -5771,28 +5771,24 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@shopify/react-native-skia@npm:0.1.188":
-  version: 0.1.188
-  resolution: "@shopify/react-native-skia@npm:0.1.188"
+"@shopify/react-native-skia@npm:0.1.203":
+  version: 0.1.203
+  resolution: "@shopify/react-native-skia@npm:0.1.203"
   dependencies:
-    "@types/pixelmatch": ^5.2.4
-    "@types/pngjs": ^6.0.1
-    "@types/ws": ^8.5.3
     canvaskit-wasm: 0.38.0
-    pixelmatch: ^5.3.0
-    pngjs: ^6.0.0
     react-reconciler: ^0.27.0
-    ws: ^8.11.0
   peerDependencies:
     react: ">=18.0"
     react-native: ">=0.64"
     react-native-reanimated: ">=2.0.0"
   peerDependenciesMeta:
+    react-native:
+      optional: true
     react-native-reanimated:
       optional: true
   bin:
     setup-skia-web: scripts/setup-canvaskit.js
-  checksum: daec5f5f906684eed5bce20c5ea6f2e7da413bb94c80ebd29d02937d795f7046f8abed581920260dac571c7613e8f0e431eafa485ddfbb8ba0dc0f589a915400
+  checksum: 77132737e45e76935ac13c9b221c69d6bc602b1f163c1558a2af8cab763bc46955732314c280ac28263b9c985c10f5e3edde53f70c1de1178ab02db6f99d1dbc
   languageName: node
   linkType: hard
 
@@ -7454,7 +7450,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@suite-common/icons@workspace:suite-common/icons"
   dependencies:
-    "@shopify/react-native-skia": 0.1.188
+    "@shopify/react-native-skia": 0.1.203
     "@suite-common/wallet-config": "workspace:*"
     "@suite-common/wallet-types": "workspace:*"
     "@trezor/styles": "workspace:*"
@@ -7861,7 +7857,7 @@ __metadata:
   resolution: "@suite-native/atoms@workspace:suite-native/atoms"
   dependencies:
     "@mobily/ts-belt": ^3.13.1
-    "@shopify/react-native-skia": 0.1.188
+    "@shopify/react-native-skia": 0.1.203
     "@suite-common/icons": "workspace:*"
     "@suite-common/wallet-config": "workspace:*"
     "@suite-common/wallet-types": "workspace:*"
@@ -7993,7 +7989,7 @@ __metadata:
   dependencies:
     "@mobily/ts-belt": ^3.13.1
     "@reduxjs/toolkit": 1.9.5
-    "@shopify/react-native-skia": 0.1.188
+    "@shopify/react-native-skia": 0.1.203
     "@suite-common/formatters": "workspace:*"
     "@suite-common/graph": "workspace:*"
     "@suite-common/icons": "workspace:*"
@@ -8093,7 +8089,7 @@ __metadata:
     "@react-navigation/native": ^6.1.3
     "@react-navigation/native-stack": ^6.9.11
     "@reduxjs/toolkit": 1.9.5
-    "@shopify/react-native-skia": 0.1.188
+    "@shopify/react-native-skia": 0.1.203
     "@suite-common/formatters": "workspace:*"
     "@suite-common/icons": "workspace:*"
     "@suite-common/redux-utils": "workspace:*"
@@ -8403,7 +8399,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@suite-native/react-native-graph@workspace:suite-native/react-native-graph"
   dependencies:
-    "@shopify/react-native-skia": 0.1.188
+    "@shopify/react-native-skia": 0.1.203
     "@types/react": 18.0.32
     react: 18.2.0
     react-native: 0.71.8
@@ -8443,7 +8439,7 @@ __metadata:
   resolution: "@suite-native/screen-overlay@workspace:suite-native/screen-overlay"
   dependencies:
     "@react-navigation/native": ^6.1.3
-    "@shopify/react-native-skia": 0.1.188
+    "@shopify/react-native-skia": 0.1.203
     "@trezor/styles": "workspace:*"
     react: 18.2.0
     react-native: 0.71.8
@@ -8556,7 +8552,7 @@ __metadata:
     "@mobily/ts-belt": ^3.13.1
     "@react-navigation/native": ^6.1.3
     "@shopify/flash-list": ^1.4.3
-    "@shopify/react-native-skia": 0.1.188
+    "@shopify/react-native-skia": 0.1.203
     "@suite-common/formatters": "workspace:*"
     "@suite-common/icons": "workspace:*"
     "@suite-common/suite-config": "workspace:*"
@@ -9596,7 +9592,7 @@ __metadata:
     "@rnx-kit/metro-config": ^1.3.6
     "@sentry/react-native": 5.5.0
     "@shopify/flash-list": ^1.4.3
-    "@shopify/react-native-skia": 0.1.188
+    "@shopify/react-native-skia": 0.1.203
     "@suite-common/analytics": "workspace:*"
     "@suite-common/connect-init": "workspace:*"
     "@suite-common/formatters": "workspace:*"
@@ -10983,15 +10979,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@types/pixelmatch@npm:^5.2.4":
-  version: 5.2.4
-  resolution: "@types/pixelmatch@npm:5.2.4"
-  dependencies:
-    "@types/node": "*"
-  checksum: 8920c3b7df22851ad69192fb7637206cb8f7dc73520f602202e36dd6f6b7701a4b56746175e7d7391ed9dc2c636d4d9bc5d7bd26fc3f1b11df1a63fb86418b91
-  languageName: node
-  linkType: hard
-
 "@types/plist@npm:^3.0.1":
   version: 3.0.2
   resolution: "@types/plist@npm:3.0.2"
@@ -10999,15 +10986,6 @@ __metadata:
     "@types/node": "*"
     xmlbuilder: ">=11.0.1"
   checksum: b8f9e6b21fb41a7e8ea5250717da972cde40b120109d5d2ed79e0a25406a9f6793abcba048d9b8ecc3df4b25735d9e4223b4d8a56dff893665c4a8c8573b77ad
-  languageName: node
-  linkType: hard
-
-"@types/pngjs@npm:^6.0.1":
-  version: 6.0.1
-  resolution: "@types/pngjs@npm:6.0.1"
-  dependencies:
-    "@types/node": "*"
-  checksum: 5673a301c81edc6cfcf5c969d743c2e4f79c28e85d24c261be36273d557b131a98b35d9c79a00dc968f206cc7f73b603e261c6a6f7066c99ed98874299f369b9
   languageName: node
   linkType: hard
 
@@ -11465,7 +11443,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@types/ws@npm:^8.5.3, @types/ws@npm:^8.5.5":
+"@types/ws@npm:^8.5.5":
   version: 8.5.5
   resolution: "@types/ws@npm:8.5.5"
   dependencies:
@@ -28878,7 +28856,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"pixelmatch@npm:^5.1.0, pixelmatch@npm:^5.3.0":
+"pixelmatch@npm:^5.1.0":
   version: 5.3.0
   resolution: "pixelmatch@npm:5.3.0"
   dependencies:


### PR DESCRIPTION
## Description
- react-native-skia upgraded to 0.1.203 to make snapshot api work on physical iPhones ([related skia issue](https://github.com/Shopify/react-native-skia/issues/1558))
- blank screen placeholder added to biometrics overlay to prevent unauthorized user to see the screen content when the screenshot is not ready yet

## Related Issue

Fixes #9235 
