### PR TITLE
@trezor/env-utils build:lib (connect dep)

### DIFF
--- a/packages/connect/e2e/test-npm-install.sh
+++ b/packages/connect/e2e/test-npm-install.sh
@@ -15,4 +15,7 @@ npm init -y
 npm install @trezor/connect
 npm install @trezor/connect-web
 
+echo "import TrezorConnect from '@trezor/connect'" > ./index.js
+node index.js
+
 cat package.json

--- a/packages/env-utils/package.json
+++ b/packages/env-utils/package.json
@@ -12,10 +12,15 @@
         "url": "https://github.com/trezor/trezor-suite/issues"
     },
     "sideEffects": false,
-    "main": "src/index.ts",
+    "main": "lib/index",
+    "files": [
+        "lib/",
+        "!**/*.map"
+    ],
     "scripts": {
         "lint:js": "yarn g:eslint '**/*.{ts,tsx,js}'",
         "type-check": "tsc --build",
+        "build:lib": "rimraf ./lib && yarn tsc --build tsconfig.lib.json",
         "prepublishOnly": "yarn tsx ../../scripts/prepublishNPM.js",
         "prepublish": "yarn tsx ../../scripts/prepublish.js"
     },

--- a/packages/env-utils/tsconfig.lib.json
+++ b/packages/env-utils/tsconfig.lib.json
@@ -1,0 +1,7 @@
+{
+    "extends": "../../tsconfig.lib.json",
+    "compilerOptions": {
+        "outDir": "lib"
+    },
+    "include": ["./src"]
+}


### PR DESCRIPTION
imho all the "@trezor" @trezor/connect deps should be released in the same way. this was not the case for @trezor/env-utils where we released only src package. 

in the first commit I am also adding a test that should catch this situation earlier.

should resolve #9389