### PR TITLE
chore(suite): copy change in container when invalid passphrase

### DIFF
--- a/packages/suite/src/components/suite/NoRatesTooltip/index.tsx
+++ b/packages/suite/src/components/suite/NoRatesTooltip/index.tsx
@@ -1,7 +1,7 @@
-import { ComponentProps } from 'react';
 import { Translation, TooltipSymbol } from 'src/components/suite';
 import styled from 'styled-components';
 import { Tooltip, variables } from '@trezor/components';
+import { TranslationKey } from '../Translation';
 
 const NoRatesMessage = styled.div`
     display: flex;
@@ -13,8 +13,8 @@ const NoRatesMessage = styled.div`
 `;
 
 interface NoRatesTooltipProps extends Partial<typeof Tooltip> {
-    customText?: ComponentProps<typeof Translation>['id'];
-    customTooltip?: ComponentProps<typeof Translation>['id'];
+    customText?: TranslationKey;
+    customTooltip?: TranslationKey;
     iconOnly?: boolean;
     className?: string;
 }

--- a/packages/suite/src/support/messages.ts
+++ b/packages/suite/src/support/messages.ts
@@ -1988,10 +1988,6 @@ export default defineMessages({
         defaultMessage: 'Wrong passphrase',
         id: 'TR_AUTH_CONFIRM_FAILED_TITLE',
     },
-    TR_AUTH_CONFIRM_FAILED_DESC: {
-        defaultMessage: 'Invalid passphrase confirmation.',
-        id: 'TR_AUTH_CONFIRM_FAILED_DESC',
-    },
     TR_BACK: {
         defaultMessage: 'Back',
         description: 'Back button',

--- a/packages/suite/src/views/dashboard/components/PortfolioCard/components/Exception.tsx
+++ b/packages/suite/src/views/dashboard/components/PortfolioCard/components/Exception.tsx
@@ -53,7 +53,7 @@ interface CTA {
 
 interface ContainerProps {
     title: ComponentProps<typeof Translation>['id'];
-    description: ComponentProps<typeof Translation>['id'] | JSX.Element;
+    description?: ComponentProps<typeof Translation>['id'] | JSX.Element;
     cta: CTA | CTA[];
     dataTestBase: string;
 }
@@ -68,9 +68,15 @@ const Container = ({ title, description, cta, dataTestBase }: ContainerProps) =>
             <Title>
                 <Translation id={title} />
             </Title>
-            <Description>
-                {typeof description === 'string' ? <Translation id={description} /> : description}
-            </Description>
+            {description && (
+                <Description>
+                    {typeof description === 'string' ? (
+                        <Translation id={description} />
+                    ) : (
+                        description
+                    )}
+                </Description>
+            )}
             <Actions>
                 {actions.map(a => (
                     <Button
@@ -129,7 +135,6 @@ export const Exception = ({ exception, discovery }: ExceptionProps) => {
             return (
                 <Container
                     title="TR_AUTH_CONFIRM_FAILED_TITLE"
-                    description="TR_AUTH_CONFIRM_FAILED_DESC"
                     cta={{ action: () => dispatch(authConfirm()) }}
                     dataTestBase={exception.type}
                 />

--- a/packages/suite/src/views/dashboard/components/PortfolioCard/components/Exception.tsx
+++ b/packages/suite/src/views/dashboard/components/PortfolioCard/components/Exception.tsx
@@ -13,6 +13,7 @@ import { applySettings } from 'src/actions/settings/deviceSettingsActions';
 import { authConfirm, authorizeDevice } from 'src/actions/suite/suiteActions';
 import { goto } from 'src/actions/suite/routerActions';
 import { DiscoveryStatusType } from 'src/types/wallet';
+import { TranslationKey } from 'src/components/suite/Translation';
 
 const Wrapper = styled.div`
     display: flex;
@@ -45,15 +46,15 @@ const Actions = styled.div`
 `;
 
 interface CTA {
-    label?: ComponentProps<typeof Translation>['id'];
+    label?: TranslationKey;
     variant?: ComponentProps<typeof Button>['variant'];
     action: () => void;
     icon?: IconProps['icon'];
 }
 
 interface ContainerProps {
-    title: ComponentProps<typeof Translation>['id'];
-    description?: ComponentProps<typeof Translation>['id'] | JSX.Element;
+    title: TranslationKey;
+    description?: TranslationKey | JSX.Element;
     cta: CTA | CTA[];
     dataTestBase: string;
 }


### PR DESCRIPTION
Dropping `TR_AUTH_CONFIRM_FAILED_DESC`

## Description

Dropped `TR_AUTH_CONFIRM_FAILED_DESC` from the dashboard portfolio card when something failed on invalid passphrase.

## Related Issue

Resolve #7557 
