### PR TITLE
feat: prepare suite-web build on github

### DIFF
--- a/.github/workflows/build-test-suite-web-e2e.yaml
+++ b/.github/workflows/build-test-suite-web-e2e.yaml
@@ -1,0 +1,151 @@
+name: '[Build/Test] suite-web'
+
+permissions:
+    id-token: write # for fetching the OIDC token
+    contents: read # for actions/checkout
+
+# run only if there are changes in suite or related libs paths
+on:
+    pull_request:
+        branches:
+            - develop
+        paths-ignore:
+            - 'suite-native/**'
+            - 'packages/connect*/**'
+            - 'packages/react-native-usb/**'
+    # TODO: after a more sophisticated system of test running is implemented, move the cron job into a separate flow that will run all tests
+    schedule:
+        - cron: '0 0 * * *' # runn all tests every day at midnight
+
+env:
+    DEV_SERVER_URL: 'https://dev.suite.sldev.cz'
+    STAGING_SUITE_SERVER_URL: 'https://staging-suite.trezor.io'
+
+jobs:
+    build-web:
+        runs-on: ubuntu-latest
+        steps:
+            - name: Checkout
+              uses: actions/checkout@v4
+              with:
+                  lfs: true
+            - name: Configure aws credentials
+              uses: aws-actions/configure-aws-credentials@v4
+              with:
+                  role-to-assume: arn:aws:iam::538326561891:role/gh_actions_trezor_suite_dev_deploy
+                  aws-region: eu-central-1
+
+            - name: Extract branch name
+              run: echo "branch=${GITHUB_HEAD_REF:-${GITHUB_REF#refs/heads/}}" >> $GITHUB_OUTPUT
+              id: extract_branch
+
+            - name: Setup node
+              uses: actions/setup-node@v4
+              with:
+                  node-version-file: '.nvmrc'
+            - name: Build suite-web
+              env:
+                  ASSET_PREFIX: /suite-web/${{ steps.extract_branch.outputs.branch }}/web
+                  CI_COMMIT_REF_NAME: ${{ steps.extract_branch.outputs.branch }}
+                  DESKTOP_APP_NAME: 'Trezor-Suite'
+              run: |
+                  yarn install
+                  yarn message-system-sign-config
+                  yarn workspace @trezor/suite-data build:lib
+                  yarn workspace @trezor/connect-iframe build:lib
+                  yarn workspace @trezor/suite-web build
+            # this step should upload build result to s3 bucket dev.suite.sldev.cz using awscli
+            - name: Upload suite-web to dev.suite.sldev.cz
+              env:
+                  DEPLOY_PATH: s3://dev.suite.sldev.cz/suite-web/${{ steps.extract_branch.outputs.branch }}
+              run: |
+                  aws s3 sync --delete ./packages/suite-web/build ${DEPLOY_PATH}/web
+
+    e2e-test-suite-web:
+        runs-on: ubuntu-latest
+        needs:
+            - build-web
+        strategy:
+            fail-fast: false
+            matrix:
+                include:
+                    - TEST_GROUP: '@group_suite'
+                      CONTAINERS: 'trezor-user-env-unix'
+                      CYPRESS_USE_TREZOR_USER_ENV_BRIDGE: '1'
+                    - TEST_GROUP: '@group_device-management'
+                      CONTAINERS: 'trezor-user-env-unix'
+                      CYPRESS_USE_TREZOR_USER_ENV_BRIDGE: '1'
+                    - TEST_GROUP: '@group_settings'
+                      CONTAINERS: 'trezor-user-env-unix'
+                      CYPRESS_USE_TREZOR_USER_ENV_BRIDGE: '1'
+                    - TEST_GROUP: '@group_metadata'
+                      CONTAINERS: 'trezor-user-env-unix'
+                      CYPRESS_USE_TREZOR_USER_ENV_BRIDGE: '1'
+                    - TEST_GROUP: '@group_passphrase'
+                      CONTAINERS: 'trezor-user-env-unix'
+                      CYPRESS_USE_TREZOR_USER_ENV_BRIDGE: '1'
+                    - TEST_GROUP: '@group_other'
+                      CONTAINERS: 'trezor-user-env-unix'
+                      CYPRESS_USE_TREZOR_USER_ENV_BRIDGE: '1'
+                    - TEST_GROUP: '@group_wallet'
+                      CONTAINERS: 'trezor-user-env-unix bitcoin-regtest'
+                      CYPRESS_USE_TREZOR_USER_ENV_BRIDGE: '1'
+                    - TEST_GROUP: '@group_firmware-update'
+                      CONTAINERS: 'trezor-user-env-unix'
+        steps:
+            - name: Checkout
+              uses: actions/checkout@v4
+              with:
+                  lfs: true
+            - name: Setup node
+              uses: actions/setup-node@v4
+              with:
+                  node-version-file: '.nvmrc'
+            - name: Extract branch name
+              run: echo "branch=${GITHUB_HEAD_REF:-${GITHUB_REF#refs/heads/}}" >> $GITHUB_OUTPUT
+              id: extract_branch
+            - name: Run e2e tests
+              env:
+                  CI_COMMIT_REF_NAME: ${{ steps.extract_branch.outputs.branch }}
+                  COMPOSE_FILE: ./docker/docker-compose.suite-ci.yml
+                  ## Tells Cypress where is the index of application
+                  CYPRESS_ASSET_PREFIX: /web
+                  CYPRESS_baseUrl: https://dev.suite.sldev.cz/suite-web/
+                  ## should tests do snapshot testing
+                  # cypress open todo. temporarily turned off (messaging system)
+                  CYPRESS_SNAPSHOT: 0
+                  ## reporter url
+                  TRACK_SUITE_URL: https://track-suite-ff9ad9f5b4f6.herokuapp.com
+                  ## when debugging or developing tests it does not make sense to have retries,
+                  ## in other cases retries are useful to avoid occasional failures due to flaky tests
+                  ALLOW_RETRY: 1
+                  TEST_GROUP: ${{ matrix.TEST_GROUP }}
+                  CYPRESS_TEST_URLS: ${{ steps.extract_branch.outputs.branch }}
+                  CYPRESS_USE_TREZOR_USER_ENV_BRIDGE: ${{ matrix.CYPRESS_USE_TREZOR_USER_ENV_BRIDGE }}
+                  CYPRESS_updateSnapshots: 0
+              run: |
+                  yarn install --immutable
+                  docker-compose pull
+                  docker-compose up -d ${{ matrix.CONTAINERS }}
+                  docker-compose run test-run
+
+            - name: Upload logs
+              run: |
+                  docker cp docker_trezor-user-env-unix_1:/trezor-user-env/logs/debugging.log trezor-user-env-debugging.log || true
+                  docker cp docker_trezor-user-env-unix_1:/trezor-user-env/logs/emulator_bridge.log tenv-emulator-bridge-debugging.log || true
+                  docker cp docker_trezor-user-env-unix_1:/trezor-user-env/docker/version.txt trezor-user-env-version.txt || true
+
+            - name: Upload artifacts
+              # this will run the upload artifacts even if the previous steps failed (e.g. tests failed). It wont run if the workflow was cancelled.
+              if: ${{ ! cancelled() }}
+              uses: actions/upload-artifact@v4
+              with:
+                  name: test-artifacts-${{ matrix.TEST_GROUP }}
+                  path: |
+                      ./packages/suite-web/e2e/snapshots
+                      ./packages/suite-web/e2e/screenshots
+                      ./packages/suite-web/e2e/videos
+                      download-snapshots.sh
+                      trezor-user-env-debugging.log
+                      tenv-emulator-bridge-debugging.log
+                      trezor-user-env-version.txt

--- a/.prettierrc
+++ b/.prettierrc
@@ -16,6 +16,15 @@
             }
         },
         {
+            "files": [
+                "[*.yaml]"
+            ],
+            "options": {
+                "tabWidth": 2,
+                "singleQuote": false
+            }
+        },
+        {
             "files": ["packages/suite-data/files/translations/*.json"],
             "options": {
                 "tabWidth": 2

--- a/ci/test.yml
+++ b/ci/test.yml
@@ -275,6 +275,9 @@ connect-popup manual:
 .connect-popup legacy npm package base:
   extends: .e2e connect-popup
   stage: legacy testing
+  needs:
+    - install
+    - connect-web build
   retry: 0
   variables:
     COMPOSE_PROJECT_NAME: $CI_JOB_ID
@@ -294,9 +297,6 @@ connect-popup manual:
 
 connect-popup legacy npm package manual:
   extends: .connect-popup legacy npm package base
-  needs:
-    - install
-    - connect-web build
   except:
     <<: *run_everything_rules
   when: manual
@@ -445,9 +445,6 @@ connect legacy fws manual:
 .connect canary fws base:
   extends: .connect matrix
   stage: canary testing
-  needs:
-    - install
-    - connect-web build
   variables:
     TESTS_FIRMWARE: "2-main"
 

--- a/docker/docker-compose.suite-ci.yml
+++ b/docker/docker-compose.suite-ci.yml
@@ -7,7 +7,7 @@ services:
       - XDG_RUNTIME_DIR=/var/tmp
     network_mode: bridge # this makes docker reuse existing networks
   test-run:
-    image: $CI_DEPENDENCY_PROXY_DIRECT_GROUP_IMAGE_PREFIX/cypress/included:13.6.4
+    image: cypress/included:13.6.4
     entrypoint: []
     environment:
       - CYPRESS_SNAPSHOT=$CYPRESS_SNAPSHOT

--- a/packages/suite-web/e2e/support/commands.ts
+++ b/packages/suite-web/e2e/support/commands.ts
@@ -5,6 +5,7 @@ import {
     onboardingShouldLoad,
     dashboardShouldLoad,
     discoveryShouldFinish,
+    discoveryMightAppearAndShouldFinish,
 } from './utils/assertions';
 import { getTestElement, getConfirmActionOnDeviceModal, hoverTestElement } from './utils/selectors';
 import { resetDb } from './utils/test-env';
@@ -107,6 +108,7 @@ declare global {
             onboardingShouldLoad: () => Chainable<Subject>;
             dashboardShouldLoad: () => Chainable<Subject>;
             discoveryShouldFinish: () => Chainable<Subject>;
+            discoveryMightAppearAndShouldFinish: () => Chainable<Subject>;
             toggleDeviceMenu: () => Chainable<Subject>;
             enableDebugMode: () => Chainable<Subject>;
             toggleDebugModeInSettings: () => Chainable<Subject>;
@@ -153,6 +155,8 @@ Cypress.Commands.add('resetDb', { prevSubject: false }, resetDb);
 Cypress.Commands.add('onboardingShouldLoad', onboardingShouldLoad);
 Cypress.Commands.add('dashboardShouldLoad', dashboardShouldLoad);
 Cypress.Commands.add('discoveryShouldFinish', discoveryShouldFinish);
+Cypress.Commands.add('discoveryMightAppearAndShouldFinish', discoveryMightAppearAndShouldFinish);
+
 // selector helpers
 Cypress.Commands.add('getTestElement', getTestElement);
 Cypress.Commands.add('getConfirmActionOnDeviceModal', getConfirmActionOnDeviceModal);

--- a/packages/suite-web/e2e/support/utils/assertions.ts
+++ b/packages/suite-web/e2e/support/utils/assertions.ts
@@ -12,3 +12,15 @@ export const discoveryShouldFinish = () => {
     cy.getTestElement('@wallet/discovery-progress-bar', { timeout: 30000 });
     cy.getTestElement('@wallet/discovery-progress-bar', { timeout: 30000 }).should('not.exist');
 };
+
+/**
+ * This function is to be used when a discovery might appear (eg. when enabling some networks) and we need to wait for its finish
+ */
+export const discoveryMightAppearAndShouldFinish = () => {
+    cy.wait(1000); // after one second, discovery would have started if it was supposed to.
+    cy.get('body').then($body => {
+        if ($body.find('[data-test="@wallet/discovery-progress-bar"]').length > 0) {
+            discoveryShouldFinish();
+        }
+    });
+};

--- a/packages/suite-web/e2e/tests/analytics/events.test.ts
+++ b/packages/suite-web/e2e/tests/analytics/events.test.ts
@@ -1,4 +1,4 @@
-// @group:suite
+// @group_suite
 // @retry=2
 
 import { EventType } from '@trezor/suite-analytics';

--- a/packages/suite-web/e2e/tests/analytics/toggle.test.ts
+++ b/packages/suite-web/e2e/tests/analytics/toggle.test.ts
@@ -1,4 +1,4 @@
-// @group:other
+// @group_other
 // @retry=2
 
 import { EventType } from '@trezor/suite-analytics';

--- a/packages/suite-web/e2e/tests/backup/t2t1-fail.test.ts
+++ b/packages/suite-web/e2e/tests/backup/t2t1-fail.test.ts
@@ -1,7 +1,7 @@
 import { EventType } from '@trezor/suite-analytics';
 import { ExtractByEventType, Requests } from '../../support/types';
 
-// @group:device-management
+// @group_device-management
 // @retry=2
 
 let requests: Requests;

--- a/packages/suite-web/e2e/tests/backup/t2t1-misc.test.ts
+++ b/packages/suite-web/e2e/tests/backup/t2t1-misc.test.ts
@@ -1,4 +1,4 @@
-// @group:device-management
+// @group_device-management
 // @retry=2
 
 describe('Backup misc', () => {

--- a/packages/suite-web/e2e/tests/backup/t2t1-success.test.ts
+++ b/packages/suite-web/e2e/tests/backup/t2t1-success.test.ts
@@ -1,7 +1,7 @@
 import { EventType } from '@trezor/suite-analytics';
 import { ExtractByEventType, Requests } from '../../support/types';
 
-// @group:device-management
+// @group_device-management
 // @retry=2
 
 let requests: Requests;

--- a/packages/suite-web/e2e/tests/browser/android.test.ts
+++ b/packages/suite-web/e2e/tests/browser/android.test.ts
@@ -1,4 +1,4 @@
-// @group:other
+// @group_other
 // @retry=2
 // @user-agent=Mozilla/5.0 (Android 13; Mobile; LG-M255; rv:114.0) Gecko/114.0 Firefox/114.0
 

--- a/packages/suite-web/e2e/tests/browser/edge.test.ts
+++ b/packages/suite-web/e2e/tests/browser/edge.test.ts
@@ -1,4 +1,4 @@
-// @group:other
+// @group_other
 // @retry=2
 // @user-agent=Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/114.0.0.0 Safari/537.36 Edg/114.0.1823.43
 

--- a/packages/suite-web/e2e/tests/browser/ios.test.ts
+++ b/packages/suite-web/e2e/tests/browser/ios.test.ts
@@ -1,4 +1,4 @@
-// @group:other
+// @group_other
 // @retry=2
 // @user-agent=Mozilla/5.0 (iPhone; CPU iPhone OS 16_5 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/16.5 Mobile/15E148 Safari/604.1
 

--- a/packages/suite-web/e2e/tests/browser/outdated-chrome.test.ts
+++ b/packages/suite-web/e2e/tests/browser/outdated-chrome.test.ts
@@ -1,4 +1,4 @@
-// @group:other
+// @group_other
 // @retry=2
 // @user-agent=Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/91.0.4472 Safari/537.36
 

--- a/packages/suite-web/e2e/tests/browser/outdated-firefox.test.ts
+++ b/packages/suite-web/e2e/tests/browser/outdated-firefox.test.ts
@@ -1,4 +1,4 @@
-// @group:other
+// @group_other
 // @retry=2
 // @user-agent=Mozilla/5.0 (Windows NT 10.0; Win64; x64; rv:109.0) Gecko/20100101 Firefox/101.0
 

--- a/packages/suite-web/e2e/tests/coinmarket/buy.test.ts
+++ b/packages/suite-web/e2e/tests/coinmarket/buy.test.ts
@@ -1,4 +1,4 @@
-// @group:other
+// @group_other
 
 describe('Coinmarket buy', () => {
     beforeEach(() => {

--- a/packages/suite-web/e2e/tests/coinmarket/exchange.test.ts
+++ b/packages/suite-web/e2e/tests/coinmarket/exchange.test.ts
@@ -1,4 +1,4 @@
-// @group:coinmarket
+// @group_coinmarket
 
 describe.skip('Coinmarket exchange', () => {
     beforeEach(() => {

--- a/packages/suite-web/e2e/tests/dashboard/assets.test.ts
+++ b/packages/suite-web/e2e/tests/dashboard/assets.test.ts
@@ -1,4 +1,4 @@
-// @group:suite
+// @group_suite
 // @retry=2
 
 import { EventType } from '@trezor/suite-analytics';

--- a/packages/suite-web/e2e/tests/dashboard/dashboard.test.ts
+++ b/packages/suite-web/e2e/tests/dashboard/dashboard.test.ts
@@ -1,4 +1,4 @@
-// @group:suite
+// @group_suite
 // @retry=2
 
 describe('Dashboard', () => {

--- a/packages/suite-web/e2e/tests/dashboard/discreet-mode.test.ts
+++ b/packages/suite-web/e2e/tests/dashboard/discreet-mode.test.ts
@@ -1,4 +1,4 @@
-// @group:suite
+// @group_suite
 // @retry=2
 
 import { EventType } from '@trezor/suite-analytics';

--- a/packages/suite-web/e2e/tests/firmware/firmware.test.ts
+++ b/packages/suite-web/e2e/tests/firmware/firmware.test.ts
@@ -1,4 +1,4 @@
-// @group:device-management
+// @group_device-management
 // @retry=2
 
 describe('Firmware', () => {

--- a/packages/suite-web/e2e/tests/metadata/account-metadata.test.ts
+++ b/packages/suite-web/e2e/tests/metadata/account-metadata.test.ts
@@ -1,4 +1,4 @@
-// @group:metadata
+// @group_metadata
 // @retry=2
 
 import { rerouteMetadataToMockProvider, stubOpen } from '../../stubs/metadata';

--- a/packages/suite-web/e2e/tests/metadata/address-metadata.test.ts
+++ b/packages/suite-web/e2e/tests/metadata/address-metadata.test.ts
@@ -1,4 +1,4 @@
-// @group:metadata
+// @group_metadata
 // @retry=2
 
 import { rerouteMetadataToMockProvider, stubOpen } from '../../stubs/metadata';

--- a/packages/suite-web/e2e/tests/metadata/dropbox-api-errors.test.ts
+++ b/packages/suite-web/e2e/tests/metadata/dropbox-api-errors.test.ts
@@ -1,4 +1,4 @@
-// @group:metadata
+// @group_metadata
 // @retry=2
 
 import { rerouteMetadataToMockProvider, stubOpen } from '../../stubs/metadata';

--- a/packages/suite-web/e2e/tests/metadata/google-api-errors.test.ts
+++ b/packages/suite-web/e2e/tests/metadata/google-api-errors.test.ts
@@ -1,4 +1,4 @@
-// @group:metadata
+// @group_metadata
 // @retry=2
 
 import { rerouteMetadataToMockProvider, stubOpen } from '../../stubs/metadata';

--- a/packages/suite-web/e2e/tests/metadata/interval-fetching.test.ts
+++ b/packages/suite-web/e2e/tests/metadata/interval-fetching.test.ts
@@ -1,4 +1,4 @@
-// @group:metadata
+// @group_metadata
 // @retry=2
 
 import * as METADATA_LABELING from '@trezor/suite/src/actions/suite/constants/metadataLabelingConstants';

--- a/packages/suite-web/e2e/tests/metadata/metadata-lifecycle.test.ts
+++ b/packages/suite-web/e2e/tests/metadata/metadata-lifecycle.test.ts
@@ -1,4 +1,4 @@
-// @group:metadata
+// @group_metadata
 // @retry=2
 
 const mnemonic = 'all all all all all all all all all all all all';

--- a/packages/suite-web/e2e/tests/metadata/output-labeling.test.ts
+++ b/packages/suite-web/e2e/tests/metadata/output-labeling.test.ts
@@ -1,4 +1,4 @@
-// @group:metadata
+// @group_metadata
 // @retry=2
 
 import { rerouteMetadataToMockProvider, stubOpen } from '../../stubs/metadata';

--- a/packages/suite-web/e2e/tests/metadata/remembered-device.test.ts
+++ b/packages/suite-web/e2e/tests/metadata/remembered-device.test.ts
@@ -1,4 +1,4 @@
-// @group:metadata
+// @group_metadata
 // @retry=2
 
 import { rerouteMetadataToMockProvider, stubOpen } from '../../stubs/metadata';

--- a/packages/suite-web/e2e/tests/metadata/switching-providers.test.ts
+++ b/packages/suite-web/e2e/tests/metadata/switching-providers.test.ts
@@ -1,4 +1,4 @@
-// @group:metadata
+// @group_metadata
 // @retry=2
 
 import { rerouteMetadataToMockProvider, stubOpen } from '../../stubs/metadata';

--- a/packages/suite-web/e2e/tests/metadata/wallet-metadata.test.ts
+++ b/packages/suite-web/e2e/tests/metadata/wallet-metadata.test.ts
@@ -1,4 +1,4 @@
-// @group:metadata
+// @group_metadata
 // @retry=2
 
 import { rerouteMetadataToMockProvider, stubOpen } from '../../stubs/metadata';

--- a/packages/suite-web/e2e/tests/onboarding/analytics-consent.test.ts
+++ b/packages/suite-web/e2e/tests/onboarding/analytics-consent.test.ts
@@ -1,4 +1,4 @@
-// @group:device-management
+// @group_device-management
 // @retry=2
 
 const navigateToSettingsAndBack = () => {

--- a/packages/suite-web/e2e/tests/onboarding/firmware-update.test.ts
+++ b/packages/suite-web/e2e/tests/onboarding/firmware-update.test.ts
@@ -1,4 +1,4 @@
-// @group:firmware-update
+// @group_firmware-update
 // @retry=2
 
 import har from '../../fixtures/fw-update-on-bl-2.0.3-to-fw-2.5.1';

--- a/packages/suite-web/e2e/tests/onboarding/t1b1-create-wallet.test.ts
+++ b/packages/suite-web/e2e/tests/onboarding/t1b1-create-wallet.test.ts
@@ -1,4 +1,4 @@
-// @group:device-management
+// @group_device-management
 // @retry=2
 
 describe('Onboarding - create wallet', () => {

--- a/packages/suite-web/e2e/tests/onboarding/t1b1-recovery-advanced.test.ts
+++ b/packages/suite-web/e2e/tests/onboarding/t1b1-recovery-advanced.test.ts
@@ -1,4 +1,4 @@
-// @group:bounty
+// @group_bounty
 // @retry=2
 
 describe('Onboarding - recover wallet T1B1', () => {

--- a/packages/suite-web/e2e/tests/onboarding/t1b1-recovery-basic.test.ts
+++ b/packages/suite-web/e2e/tests/onboarding/t1b1-recovery-basic.test.ts
@@ -1,4 +1,4 @@
-// @group:device-management
+// @group_device-management
 // @retry=2
 
 // todo: this started to fail mysteriously after merging new base image. Skipping it for now and will investigate.

--- a/packages/suite-web/e2e/tests/onboarding/t2t1-create-wallet.test.ts
+++ b/packages/suite-web/e2e/tests/onboarding/t2t1-create-wallet.test.ts
@@ -1,4 +1,4 @@
-// @group:device-management
+// @group_device-management
 // @retry=2
 
 describe('Onboarding - create wallet', () => {

--- a/packages/suite-web/e2e/tests/onboarding/t2t1-recovery-fail.test.ts
+++ b/packages/suite-web/e2e/tests/onboarding/t2t1-recovery-fail.test.ts
@@ -1,4 +1,4 @@
-// @group:device-management
+// @group_device-management
 // @retry=2
 
 describe('Onboarding - recover wallet T2T1', () => {

--- a/packages/suite-web/e2e/tests/onboarding/t2t1-recovery-persistence.test.ts
+++ b/packages/suite-web/e2e/tests/onboarding/t2t1-recovery-persistence.test.ts
@@ -1,4 +1,4 @@
-// @group:device-management
+// @group_device-management
 // @retry=2
 
 const shareOneOfThree = [

--- a/packages/suite-web/e2e/tests/onboarding/t2t1-recovery-success.test.ts
+++ b/packages/suite-web/e2e/tests/onboarding/t2t1-recovery-success.test.ts
@@ -1,4 +1,4 @@
-// @group:device-management
+// @group_device-management
 // @retry=2
 
 describe('Onboarding - recover wallet T2T1', () => {

--- a/packages/suite-web/e2e/tests/onboarding/transport.test.ts
+++ b/packages/suite-web/e2e/tests/onboarding/transport.test.ts
@@ -1,4 +1,4 @@
-// @group:device-management
+// @group_device-management
 // @retry=2
 
 describe('Onboarding - transport webusb/bridge', () => {

--- a/packages/suite-web/e2e/tests/recovery/t1b1-dry-run.test.ts
+++ b/packages/suite-web/e2e/tests/recovery/t1b1-dry-run.test.ts
@@ -1,4 +1,4 @@
-// @group:device-management
+// @group_device-management
 
 describe.skip('Recovery - dry run', () => {
     beforeEach(() => {

--- a/packages/suite-web/e2e/tests/recovery/t2t1-dry-run-persistence.test.ts
+++ b/packages/suite-web/e2e/tests/recovery/t2t1-dry-run-persistence.test.ts
@@ -1,4 +1,4 @@
-// @group:device-management
+// @group_device-management
 // @retry=2
 
 describe('Recovery - dry run', () => {

--- a/packages/suite-web/e2e/tests/settings/application-log.test.ts
+++ b/packages/suite-web/e2e/tests/settings/application-log.test.ts
@@ -1,4 +1,4 @@
-// @group:settings
+// @group_settings
 // @retry=2
 
 describe('ApplicationLog', () => {

--- a/packages/suite-web/e2e/tests/settings/autodetect.test.ts
+++ b/packages/suite-web/e2e/tests/settings/autodetect.test.ts
@@ -1,4 +1,4 @@
-// @group:settings
+// @group_settings
 // @retry=2
 
 describe('Language and theme detection', () => {

--- a/packages/suite-web/e2e/tests/settings/coins.test.ts
+++ b/packages/suite-web/e2e/tests/settings/coins.test.ts
@@ -1,4 +1,4 @@
-// @group:settings
+// @group_settings
 // @retry=2
 
 import { EventType } from '@trezor/suite-analytics';

--- a/packages/suite-web/e2e/tests/settings/custom-firmware.test.ts
+++ b/packages/suite-web/e2e/tests/settings/custom-firmware.test.ts
@@ -1,4 +1,4 @@
-// @group:settings
+// @group_settings
 // @retry=2
 describe('Install custom firmware', () => {
     beforeEach(() => {

--- a/packages/suite-web/e2e/tests/settings/general.test.ts
+++ b/packages/suite-web/e2e/tests/settings/general.test.ts
@@ -1,4 +1,4 @@
-// @group:settings
+// @group_settings
 // @retry=2
 
 import { EventType } from '@trezor/suite-analytics';

--- a/packages/suite-web/e2e/tests/settings/notification-toast.test.ts
+++ b/packages/suite-web/e2e/tests/settings/notification-toast.test.ts
@@ -1,4 +1,4 @@
-// @group:suite
+// @group_suite
 // @retry=2
 
 describe('Check notification toast', () => {

--- a/packages/suite-web/e2e/tests/settings/safety-checks.test.ts
+++ b/packages/suite-web/e2e/tests/settings/safety-checks.test.ts
@@ -1,4 +1,4 @@
-// @group:settings
+// @group_settings
 // @retry=2
 
 describe('Safety Checks Settings', () => {

--- a/packages/suite-web/e2e/tests/settings/t1b1-device-settings.test.ts
+++ b/packages/suite-web/e2e/tests/settings/t1b1-device-settings.test.ts
@@ -1,4 +1,4 @@
-// @group:settings
+// @group_settings
 // @retry=2
 
 // TODO: t1 tests are flaky in CI. I suspect it is something in bridge/udp layer. So next step is implementing

--- a/packages/suite-web/e2e/tests/settings/t2b1-device-settings.test.ts
+++ b/packages/suite-web/e2e/tests/settings/t2b1-device-settings.test.ts
@@ -1,4 +1,4 @@
-// @group:settings
+// @group_settings
 // @retry=2
 
 // TODOS:

--- a/packages/suite-web/e2e/tests/settings/t2t1-device-settings.test.ts
+++ b/packages/suite-web/e2e/tests/settings/t2t1-device-settings.test.ts
@@ -1,4 +1,4 @@
-// @group:settings
+// @group_settings
 // @retry=2
 
 describe('T2T1 - Device settings', () => {

--- a/packages/suite-web/e2e/tests/settings/without-device.test.ts
+++ b/packages/suite-web/e2e/tests/settings/without-device.test.ts
@@ -1,4 +1,4 @@
-// @group:settings
+// @group_settings
 // @retry=2
 
 describe('Settings changes persist when device disconnected', () => {

--- a/packages/suite-web/e2e/tests/suite/bridge.test.ts
+++ b/packages/suite-web/e2e/tests/suite/bridge.test.ts
@@ -1,4 +1,4 @@
-// @group:suite
+// @group_suite
 // @retry=2
 
 const systems = [

--- a/packages/suite-web/e2e/tests/suite/bug-report-form.test.ts
+++ b/packages/suite-web/e2e/tests/suite/bug-report-form.test.ts
@@ -1,4 +1,4 @@
-// @group:suite
+// @group_suite
 // @retry=2
 
 import { onSuiteGuide } from '../../support/pageObjects/suiteGuideObject';

--- a/packages/suite-web/e2e/tests/suite/database-migration.test.ts
+++ b/packages/suite-web/e2e/tests/suite/database-migration.test.ts
@@ -1,4 +1,4 @@
-// @group:migrations
+// @group_migrations
 // @retry=2
 
 const from = '/release/22.7/web';

--- a/packages/suite-web/e2e/tests/suite/guide.test.ts
+++ b/packages/suite-web/e2e/tests/suite/guide.test.ts
@@ -1,4 +1,4 @@
-// @group:suite
+// @group_suite
 // @retry=2
 
 describe('Test Guide', () => {

--- a/packages/suite-web/e2e/tests/suite/initial-run.test.ts
+++ b/packages/suite-web/e2e/tests/suite/initial-run.test.ts
@@ -1,4 +1,4 @@
-// @group:suite
+// @group_suite
 // @retry=2
 
 describe('Suite initial run', () => {

--- a/packages/suite-web/e2e/tests/suite/passphrase-cancel.test.ts
+++ b/packages/suite-web/e2e/tests/suite/passphrase-cancel.test.ts
@@ -1,4 +1,4 @@
-// @group:passphrase
+// @group_passphrase
 // @retry=2
 
 const testedVersions = ['2-latest', '1-latest'];

--- a/packages/suite-web/e2e/tests/suite/passphrase-cardano.test.ts
+++ b/packages/suite-web/e2e/tests/suite/passphrase-cardano.test.ts
@@ -1,4 +1,4 @@
-// @group:passphrase
+// @group_passphrase
 // @retry=2
 
 const correctPassphraseAddr =

--- a/packages/suite-web/e2e/tests/suite/passphrase-disabled.test.ts
+++ b/packages/suite-web/e2e/tests/suite/passphrase-disabled.test.ts
@@ -1,4 +1,4 @@
-// @group:passphrase
+// @group_passphrase
 // @retry=2
 
 const DEFAULT_STANDARD_WALLET_LABEL = 'Standard wallet';

--- a/packages/suite-web/e2e/tests/suite/passphrase-duplicate.test.ts
+++ b/packages/suite-web/e2e/tests/suite/passphrase-duplicate.test.ts
@@ -1,4 +1,4 @@
-// @group:passphrase
+// @group_passphrase
 // @retry=2
 
 describe('Passphrase', () => {

--- a/packages/suite-web/e2e/tests/suite/passphrase-input.test.ts
+++ b/packages/suite-web/e2e/tests/suite/passphrase-input.test.ts
@@ -1,4 +1,4 @@
-// @group:passphrase
+// @group_passphrase
 // @retry=2
 
 describe('Passphrase', () => {

--- a/packages/suite-web/e2e/tests/suite/passphrase-legacy.test.ts
+++ b/packages/suite-web/e2e/tests/suite/passphrase-legacy.test.ts
@@ -1,4 +1,4 @@
-// @group:passphrase
+// @group_passphrase
 // @retry=2
 
 // todo: this test is skipped because it does not work and it can't be debugged on MacArm

--- a/packages/suite-web/e2e/tests/suite/passphrase-numbering.test.ts
+++ b/packages/suite-web/e2e/tests/suite/passphrase-numbering.test.ts
@@ -1,4 +1,4 @@
-// @group:passphrase
+// @group_passphrase
 // @retry=2
 
 describe('Passphrase numbering', () => {

--- a/packages/suite-web/e2e/tests/suite/passphrase.test.ts
+++ b/packages/suite-web/e2e/tests/suite/passphrase.test.ts
@@ -1,4 +1,4 @@
-// @group:passphrase
+// @group_passphrase
 // @retry=2
 import { EventType } from '@trezor/suite-analytics';
 import { ExtractByEventType, Requests } from '../../support/types';

--- a/packages/suite-web/e2e/tests/suite/safety-checks-warning.test.ts
+++ b/packages/suite-web/e2e/tests/suite/safety-checks-warning.test.ts
@@ -1,4 +1,5 @@
-// @group:suite
+// group:ghatest
+
 // @retry=2
 
 // TODO: enable this test once https://github.com/trezor/trezor-user-env/issues/54

--- a/packages/suite-web/e2e/tests/suite/tooltip.test.ts
+++ b/packages/suite-web/e2e/tests/suite/tooltip.test.ts
@@ -1,4 +1,4 @@
-// @group:suite
+// @group_suite
 // @retry=2
 
 describe('Test tooltip links', () => {

--- a/packages/suite-web/e2e/tests/suite/unacquired-device.test.ts
+++ b/packages/suite-web/e2e/tests/suite/unacquired-device.test.ts
@@ -1,4 +1,4 @@
-// @group:suite
+// @group_suite
 // @retry=2
 
 describe('unacquired device', () => {

--- a/packages/suite-web/e2e/tests/suite/version-page.test.ts
+++ b/packages/suite-web/e2e/tests/suite/version-page.test.ts
@@ -1,4 +1,4 @@
-// @group:suite
+// @group_suite
 // @retry=2
 import { getSuiteVersion } from '@trezor/env-utils';
 

--- a/packages/suite-web/e2e/tests/wallet/add-account-types.test.ts
+++ b/packages/suite-web/e2e/tests/wallet/add-account-types.test.ts
@@ -1,4 +1,4 @@
-// @group:wallet
+// @group_wallet
 // @retry=2
 
 import { onAccountsPage } from '../../support/pageObjects/accountsObject';

--- a/packages/suite-web/e2e/tests/wallet/cardano.test.ts
+++ b/packages/suite-web/e2e/tests/wallet/cardano.test.ts
@@ -1,4 +1,4 @@
-// @group:wallet
+// @group_wallet
 // @retry=2
 
 describe('Cardano', () => {

--- a/packages/suite-web/e2e/tests/wallet/check-coins-xpub.test.ts
+++ b/packages/suite-web/e2e/tests/wallet/check-coins-xpub.test.ts
@@ -1,4 +1,4 @@
-// @group:wallet
+// @group_wallet
 // @retry=2
 
 import { NetworkSymbol } from '@suite-common/wallet-config';

--- a/packages/suite-web/e2e/tests/wallet/coin-balance.test.ts
+++ b/packages/suite-web/e2e/tests/wallet/coin-balance.test.ts
@@ -1,4 +1,4 @@
-// @group:wallet
+// @group_wallet
 // @retry=2
 
 describe('Dashboard with regtest', () => {

--- a/packages/suite-web/e2e/tests/wallet/custom-blockbook-discovery.test.ts
+++ b/packages/suite-web/e2e/tests/wallet/custom-blockbook-discovery.test.ts
@@ -1,4 +1,4 @@
-// @group:wallet
+// @group_wallet
 // @retry=2
 
 describe('Custom-blockbook-discovery', () => {

--- a/packages/suite-web/e2e/tests/wallet/discovery.test.ts
+++ b/packages/suite-web/e2e/tests/wallet/discovery.test.ts
@@ -1,4 +1,4 @@
-// @group:wallet
+// @group_wallet
 // @retry=2
 
 // discovery should end within this time frame

--- a/packages/suite-web/e2e/tests/wallet/export-transactions.test.ts
+++ b/packages/suite-web/e2e/tests/wallet/export-transactions.test.ts
@@ -1,4 +1,4 @@
-// @group:wallet
+// @group_wallet
 // @retry=2
 
 import { NetworkSymbol } from '@suite-common/wallet-config';

--- a/packages/suite-web/e2e/tests/wallet/import-btc-csv.test.ts
+++ b/packages/suite-web/e2e/tests/wallet/import-btc-csv.test.ts
@@ -1,4 +1,4 @@
-// @group:wallet
+// @group_wallet
 // @retry=2
 
 import { rerouteMetadataToMockProvider, stubOpen } from '../../stubs/metadata';

--- a/packages/suite-web/e2e/tests/wallet/look-up-an-account.test.ts
+++ b/packages/suite-web/e2e/tests/wallet/look-up-an-account.test.ts
@@ -1,4 +1,4 @@
-// @group:wallet
+// @group_wallet
 // @retry=2
 
 describe('Look up a BTC account', () => {

--- a/packages/suite-web/e2e/tests/wallet/overview-and-transactions.test.ts
+++ b/packages/suite-web/e2e/tests/wallet/overview-and-transactions.test.ts
@@ -1,4 +1,4 @@
-// @group:wallet
+// @group_wallet
 // @retry=2
 
 import { onAccountsPage } from '../../support/pageObjects/accountsObject';

--- a/packages/suite-web/e2e/tests/wallet/pending-transactions.test.ts
+++ b/packages/suite-web/e2e/tests/wallet/pending-transactions.test.ts
@@ -1,4 +1,4 @@
-// @group:wallet
+// @group_wallet
 // @retry=2
 
 describe('Use regtest to test pending transactions', () => {

--- a/packages/suite-web/e2e/tests/wallet/send-form-doge.test.ts
+++ b/packages/suite-web/e2e/tests/wallet/send-form-doge.test.ts
@@ -1,4 +1,4 @@
-// @group:wallet
+// @group_wallet
 // @retry=2
 
 describe('Doge send form with mocked blockbook', () => {

--- a/packages/suite-web/e2e/tests/wallet/send-form-ltc.test.ts
+++ b/packages/suite-web/e2e/tests/wallet/send-form-ltc.test.ts
@@ -1,4 +1,4 @@
-// @group:wallet
+// @group_wallet
 // @retry=2
 
 describe('LTC send form with mocked blockbook', () => {

--- a/packages/suite-web/e2e/tests/wallet/send-form-regtest.test.ts
+++ b/packages/suite-web/e2e/tests/wallet/send-form-regtest.test.ts
@@ -1,4 +1,4 @@
-// @group:wallet
+// @group_wallet
 // @retry=2
 
 describe('Send form for bitcoin', () => {
@@ -62,6 +62,7 @@ describe('Send form for bitcoin', () => {
     });
 
     it('switch display units to satoshis, fill a form in satoshis and send', () => {
+        cy.discoveryMightAppearAndShouldFinish();
         cy.getTestElement('amount-unit-switch/regtest').click();
 
         // test adding and removing outputs

--- a/packages/suite-web/e2e/tests/wallet/sign-and-verify-eth.test.ts
+++ b/packages/suite-web/e2e/tests/wallet/sign-and-verify-eth.test.ts
@@ -1,4 +1,4 @@
-// @group:wallet
+// @group_wallet
 // @retry=2
 
 const SEED_SIGN = 'all all all all all all all all all all all all';

--- a/packages/suite-web/e2e/tests/wallet/sign-and-verify.test.ts
+++ b/packages/suite-web/e2e/tests/wallet/sign-and-verify.test.ts
@@ -1,4 +1,4 @@
-// @group:wallet
+// @group_wallet
 // @retry=2
 
 const SEED = 'all all all all all all all all all all all all';


### PR DESCRIPTION
Edit by @ondracja:

This PR adds the first part of the `test.yaml` rewrite; task with further info is [here](https://www.notion.so/satoshilabs/Refactor-test-yaml-from-gl-to-gh-406e99f44a3d4bb9938f59b665e20c56)

- adding a new cypress utility function `discoveryMightAppearAndShouldFinish()` for situations where discovery sometimes appear
- changing the test group naming from `@group:groupName` to `@group_groupName` in order to better grep it for gha purposes