### PR TITLE
Revert "chore: replace deprecated Buffer.slice with Buffer.subarray"

### DIFF
--- a/packages/blockchain-link-utils/src/tests/blockbook.test.ts
+++ b/packages/blockchain-link-utils/src/tests/blockbook.test.ts
@@ -13,6 +13,7 @@ describe('blockbook/utils', () => {
     });
 
     describe('transformTransaction', () => {
+        // fixtures.transformTransaction = fixtures.transformTransaction.slice(3, 6);
         fixtures.transformTransaction.forEach(f => {
             it(f.description, () => {
                 // @ts-expect-error incorrect params

--- a/packages/coinjoin/src/backend/filters.ts
+++ b/packages/coinjoin/src/backend/filters.ts
@@ -33,13 +33,13 @@ export const getAddressScript = (address: string, network: Network) =>
 export const getFilter = (filterHex: string, { P, M, key }: FilterParams = {}) => {
     if (!filterHex) return () => false;
     const filter = createFilter(Buffer.from(filterHex, 'hex'), { P, M });
-    const keyBuffer = key ? Buffer.from(key, 'hex').subarray(0, KEY_SIZE) : ZERO_KEY;
+    const keyBuffer = key ? Buffer.from(key, 'hex').slice(0, KEY_SIZE) : ZERO_KEY;
     return (script: Buffer) => filter.match(keyBuffer, script);
 };
 
 export const getMultiFilter = (filterHex: string, { P, M, key }: FilterParams = {}) => {
     if (!filterHex) return () => false;
     const filter = createFilter(Buffer.from(filterHex, 'hex'), { P, M });
-    const keyBuffer = key ? Buffer.from(key, 'hex').subarray(0, KEY_SIZE) : ZERO_KEY;
+    const keyBuffer = key ? Buffer.from(key, 'hex').slice(0, KEY_SIZE) : ZERO_KEY;
     return (scripts: Buffer[]) => !!scripts.length && filter.matchAny(keyBuffer, scripts);
 };

--- a/packages/connect/src/api/eos/eosSignTx.ts
+++ b/packages/connect/src/api/eos/eosSignTx.ts
@@ -134,10 +134,11 @@ const parseAuth = (a: $EosAuthorization): PROTO.EosAuthorization => {
     const keyToBuffer = (pk: string) => {
         const len = pk.indexOf('EOS') === 0 ? 3 : 7;
         const key = Buffer.from(bs58.decode(pk.substring(len)));
+        // key.slice(0, key.length - 4);
 
         return {
             type: 0,
-            key: key.subarray(0, key.length - 4).toString('hex'),
+            key: key.slice(0, key.length - 4).toString('hex'),
         };
     };
     return {

--- a/packages/suite/src/actions/wallet/__tests__/publicKeyActions.test.ts
+++ b/packages/suite/src/actions/wallet/__tests__/publicKeyActions.test.ts
@@ -111,6 +111,7 @@ const initStore = (stateOverrides?: StateOverrides) => {
 };
 
 describe('PublicKeyActions', () => {
+    // fixtures.slice(3, 4).forEach(f => {
     fixtures.forEach(f => {
         it(f.description, async () => {
             // eslint-disable-next-line @typescript-eslint/no-var-requires

--- a/packages/suite/src/actions/wallet/__tests__/receiveActions.test.ts
+++ b/packages/suite/src/actions/wallet/__tests__/receiveActions.test.ts
@@ -146,6 +146,7 @@ const initStore = (state: State) => {
 };
 
 describe('ReceiveActions', () => {
+    // fixtures.slice(3, 4).forEach(f => {
     fixtures.forEach(f => {
         it(f.description, async () => {
             // eslint-disable-next-line @typescript-eslint/no-var-requires

--- a/packages/suite/src/utils/suite/metadata.ts
+++ b/packages/suite/src/utils/suite/metadata.ts
@@ -30,13 +30,13 @@ export const deriveAesKey = (metadataKey: string) => {
             )}`,
         );
     }
-    const secondHalf = hash.subarray(32, 64);
+    const secondHalf = hash.slice(32, 64);
     return secondHalf.toString('hex');
 };
 
 export const deriveFilename = (metadataKey: string) => {
     const hash = deriveHmac(metadataKey);
-    const firstHalf = hash.subarray(0, 32);
+    const firstHalf = hash.slice(0, 32);
     return firstHalf.toString('hex');
 };
 
@@ -92,10 +92,10 @@ export const decrypt = (input: Buffer, key: string | Buffer) => {
         key = Buffer.from(key, 'hex');
     }
 
-    const iv = input.subarray(0, CIPHER_IVSIZE);
+    const iv = input.slice(0, CIPHER_IVSIZE);
     // tag is always 128-bits
-    const authTag = input.subarray(CIPHER_IVSIZE, CIPHER_IVSIZE + AUTH_SIZE);
-    const cText = input.subarray(CIPHER_IVSIZE + AUTH_SIZE);
+    const authTag = input.slice(CIPHER_IVSIZE, CIPHER_IVSIZE + AUTH_SIZE);
+    const cText = input.slice(CIPHER_IVSIZE + AUTH_SIZE);
     const decipher = crypto.createDecipheriv(CIPHER_TYPE, key, iv);
     const start = decipher.update(cText);
 

--- a/packages/utxo-lib/src/address.ts
+++ b/packages/utxo-lib/src/address.ts
@@ -73,7 +73,7 @@ const FUTURE_SEGWIT_MIN_VERSION = 1;
 const FUTURE_SEGWIT_VERSION_DIFF = 0x50;
 
 function toFutureSegwitAddress(output: Buffer, network = BITCOIN_NETWORK) {
-    const data = output.subarray(2);
+    const data = output.slice(2);
 
     if (data.length < FUTURE_SEGWIT_MIN_SIZE || data.length > FUTURE_SEGWIT_MAX_SIZE)
         throw new TypeError('Invalid program length for segwit address');

--- a/packages/utxo-lib/src/bip32.ts
+++ b/packages/utxo-lib/src/bip32.ts
@@ -143,7 +143,7 @@ class BIP32 implements BIP32Interface {
     }
 
     get fingerprint(): Buffer {
-        return this.identifier.subarray(0, 4);
+        return this.identifier.slice(0, 4);
     }
 
     get compressed(): boolean {
@@ -234,8 +234,8 @@ class BIP32 implements BIP32Interface {
         }
 
         const I = crypto.hmacSHA512(this.chainCode, data);
-        const IL = I.subarray(0, 32);
-        const IR = I.subarray(32);
+        const IL = I.slice(0, 32);
+        const IR = I.slice(32);
 
         // if parse256(IL) >= n, proceed with the next value for i
         if (!ecc.isPrivate(IL)) return this.derive(index + 1);
@@ -361,19 +361,19 @@ export function fromBase58(inString: string, network?: Network): BIP32Interface 
     if (depth === 0 && index !== 0) throw new TypeError('Invalid index');
 
     // 32 bytes: the chain code
-    const chainCode = buffer.subarray(13, 45);
+    const chainCode = buffer.slice(13, 45);
     let hd: BIP32Interface;
 
     // 33 bytes: private key data (0x00 + k)
     if (version === network.bip32.private) {
         if (buffer.readUInt8(45) !== 0x00) throw new TypeError('Invalid private key');
-        const k = buffer.subarray(46, 78);
+        const k = buffer.slice(46, 78);
 
         hd = fromPrivateKeyLocal(k, chainCode, network, depth, index, parentFingerprint);
 
         // 33 bytes: public key data (0x02 + X or 0x03 + X)
     } else {
-        const X = buffer.subarray(45, 78);
+        const X = buffer.slice(45, 78);
 
         hd = fromPublicKeyLocal(X, chainCode, network, depth, index, parentFingerprint);
     }
@@ -404,8 +404,8 @@ export function fromSeed(seed: Buffer, network?: Network): BIP32Interface {
     network = network || BITCOIN;
 
     const I = crypto.hmacSHA512(Buffer.from('Bitcoin seed', 'utf8'), seed);
-    const IL = I.subarray(0, 32);
-    const IR = I.subarray(32);
+    const IL = I.slice(0, 32);
+    const IR = I.slice(32);
 
     return fromPrivateKey(IL, IR, network);
 }

--- a/packages/utxo-lib/src/bs58check.ts
+++ b/packages/utxo-lib/src/bs58check.ts
@@ -5,9 +5,9 @@ import * as bs58check from 'bs58check';
 import { blake256 } from './crypto';
 
 export function decodeBlake(buffer: Buffer) {
-    const want = buffer.subarray(-4);
-    const payload = buffer.subarray(0, -4);
-    const got = blake256(blake256(payload)).subarray(0, 4);
+    const want = buffer.slice(-4);
+    const payload = buffer.slice(0, -4);
+    const got = blake256(blake256(payload)).slice(0, 4);
 
     if ((want[0] ^ got[0]) | (want[1] ^ got[1]) | (want[2] ^ got[2]) | (want[3] ^ got[3]))
         throw new Error('invalid checksum');
@@ -38,7 +38,7 @@ export function decodeBlake256(address: string) {
 }
 
 export function encodeBlake256(payload: Buffer) {
-    const checksum = blake256(blake256(payload)).subarray(0, 4);
+    const checksum = blake256(blake256(payload)).slice(0, 4);
     return bs58.encode(Buffer.concat([payload, checksum]));
 }
 
@@ -69,7 +69,7 @@ export function decodeAddress(address: string, network = BITCOIN_NETWORK) {
     const offset = multibyte ? 2 : 1;
 
     const version = multibyte ? payload.readUInt16BE(0) : payload[0];
-    const hash = payload.subarray(offset);
+    const hash = payload.slice(offset);
 
     return { version, hash };
 }

--- a/packages/utxo-lib/src/bufferutils.ts
+++ b/packages/utxo-lib/src/bufferutils.ts
@@ -238,7 +238,7 @@ export class BufferReader {
         if (this.buffer.length < this.offset + n) {
             throw new Error('Cannot read slice out of bounds');
         }
-        const result = this.buffer.subarray(this.offset, this.offset + n);
+        const result = this.buffer.slice(this.offset, this.offset + n);
         this.offset += n;
         return result;
     }

--- a/packages/utxo-lib/src/payments/p2pk.ts
+++ b/packages/utxo-lib/src/payments/p2pk.ts
@@ -40,7 +40,7 @@ export function p2pk(a: Payment, opts?: PaymentOpts): Payment {
     });
     lazy.prop(o, 'pubkey', () => {
         if (!a.output) return;
-        return a.output.subarray(1, -1);
+        return a.output.slice(1, -1);
     });
     lazy.prop(o, 'signature', () => {
         if (!a.input) return;

--- a/packages/utxo-lib/src/payments/p2pkh.ts
+++ b/packages/utxo-lib/src/payments/p2pkh.ts
@@ -48,7 +48,7 @@ export function p2pkh(a: Payment, opts?: PaymentOpts): Payment {
         return bs58check.encodeAddress(o.hash, network.pubKeyHash, network);
     });
     lazy.prop(o, 'hash', () => {
-        if (a.output) return a.output.subarray(3, 23);
+        if (a.output) return a.output.slice(3, 23);
         if (a.address) return _address().hash;
         if (a.pubkey || o.pubkey) return bcrypto.hash160(a.pubkey! || o.pubkey!);
     });
@@ -107,7 +107,7 @@ export function p2pkh(a: Payment, opts?: PaymentOpts): Payment {
             )
                 throw new TypeError('Output is invalid');
 
-            const hash2 = a.output.subarray(3, 23);
+            const hash2 = a.output.slice(3, 23);
             if (hash.length > 0 && !hash.equals(hash2)) throw new TypeError('Hash mismatch');
             else hash = hash2;
         }

--- a/packages/utxo-lib/src/payments/p2sh.ts
+++ b/packages/utxo-lib/src/payments/p2sh.ts
@@ -76,7 +76,7 @@ export function p2sh(a: Payment, opts?: PaymentOpts): Payment {
     });
     lazy.prop(o, 'hash', () => {
         // in order of least effort
-        if (a.output) return a.output.subarray(2, 22);
+        if (a.output) return a.output.slice(2, 22);
         if (a.address) return _address().hash;
         if (o.redeem && o.redeem.output) return bcrypto.hash160(o.redeem.output);
     });
@@ -130,7 +130,7 @@ export function p2sh(a: Payment, opts?: PaymentOpts): Payment {
             )
                 throw new TypeError('Output is invalid');
 
-            const hash2 = a.output.subarray(2, 22);
+            const hash2 = a.output.slice(2, 22);
             if (hash.length > 0 && !hash.equals(hash2)) throw new TypeError('Hash mismatch');
             else hash = hash2;
         }

--- a/packages/utxo-lib/src/payments/p2tr.ts
+++ b/packages/utxo-lib/src/payments/p2tr.ts
@@ -53,7 +53,7 @@ function tapTweakPubkey(pubkey: Buffer, tapTreeRoot?: Buffer) {
 const liftX = (pubkey: Buffer) => {
     // bip32.derive returns one additional byte in publicKey
     const offset = pubkey.length === 33 ? 1 : 0;
-    return pubkey.subarray(offset);
+    return pubkey.slice(offset);
 };
 
 // output: OP_1 {witnessProgram}
@@ -94,7 +94,7 @@ export function p2tr(a: Payment, opts?: PaymentOpts): Payment {
         return bech32m.encode(network.bech32, words);
     });
     lazy.prop(o, 'hash', () => {
-        if (a.output) return a.output.subarray(2);
+        if (a.output) return a.output.slice(2);
         if (a.address) return _address().data;
         if (a.pubkey) {
             return tapTweakPubkey(liftX(a.pubkey)).pubkey;
@@ -123,7 +123,7 @@ export function p2tr(a: Payment, opts?: PaymentOpts): Payment {
         if (a.output) {
             if (a.output[0] !== OPS.OP_1 || a.output[1] !== 0x20)
                 throw new TypeError('p2tr output is invalid');
-            const hash2 = a.output.subarray(2);
+            const hash2 = a.output.slice(2);
             if (hash.length > 0 && !hash.equals(hash2)) throw new TypeError('Hash mismatch');
             else hash = hash2;
         }

--- a/packages/utxo-lib/src/payments/p2wpkh.ts
+++ b/packages/utxo-lib/src/payments/p2wpkh.ts
@@ -58,7 +58,7 @@ export function p2wpkh(a: Payment, opts?: PaymentOpts): Payment {
         return bech32.encode(network.bech32, words);
     });
     lazy.prop(o, 'hash', () => {
-        if (a.output) return a.output.subarray(2, 22);
+        if (a.output) return a.output.slice(2, 22);
         if (a.address) return _address().data;
         if (a.pubkey || o.pubkey) return bcrypto.hash160(a.pubkey! || o.pubkey!);
     });
@@ -105,9 +105,9 @@ export function p2wpkh(a: Payment, opts?: PaymentOpts): Payment {
         if (a.output) {
             if (a.output.length !== 22 || a.output[0] !== OPS.OP_0 || a.output[1] !== 0x14)
                 throw new TypeError('Output is invalid');
-            if (hash.length > 0 && !hash.equals(a.output.subarray(2)))
+            if (hash.length > 0 && !hash.equals(a.output.slice(2)))
                 throw new TypeError('Hash mismatch');
-            else hash = a.output.subarray(2);
+            else hash = a.output.slice(2);
         }
 
         if (a.pubkey) {

--- a/packages/utxo-lib/src/payments/p2wsh.ts
+++ b/packages/utxo-lib/src/payments/p2wsh.ts
@@ -82,7 +82,7 @@ export function p2wsh(a: Payment, opts?: PaymentOpts): Payment {
         return bech32.encode(network!.bech32, words);
     });
     lazy.prop(o, 'hash', () => {
-        if (a.output) return a.output.subarray(2);
+        if (a.output) return a.output.slice(2);
         if (a.address) return _address().data;
         if (o.redeem && o.redeem.output) return bcrypto.sha256(o.redeem.output);
     });
@@ -150,7 +150,7 @@ export function p2wsh(a: Payment, opts?: PaymentOpts): Payment {
         if (a.output) {
             if (a.output.length !== 34 || a.output[0] !== OPS.OP_0 || a.output[1] !== 0x20)
                 throw new TypeError('Output is invalid');
-            const hash2 = a.output.subarray(2);
+            const hash2 = a.output.slice(2);
             if (hash.length > 0 && !hash.equals(hash2)) throw new TypeError('Hash mismatch');
             else hash = hash2;
         }

--- a/packages/utxo-lib/src/payments/sstxchange.ts
+++ b/packages/utxo-lib/src/payments/sstxchange.ts
@@ -35,7 +35,7 @@ export function sstxchange(a: Payment, opts?: PaymentOpts): Payment {
         return bs58check.encodeAddress(o.hash, network.pubKeyHash, network);
     });
     lazy.prop(o, 'hash', () => {
-        if (a.output) return a.output.subarray(4, 24);
+        if (a.output) return a.output.slice(4, 24);
         if (a.address) return _address().hash;
     });
     lazy.prop(o, 'output', () => {
@@ -76,7 +76,7 @@ export function sstxchange(a: Payment, opts?: PaymentOpts): Payment {
             )
                 throw new TypeError('sstxchange output is invalid');
 
-            const hash2 = a.output.subarray(4, 24);
+            const hash2 = a.output.slice(4, 24);
             if (hash.length > 0 && !hash.equals(hash2)) throw new TypeError('Hash mismatch');
         }
     }

--- a/packages/utxo-lib/src/payments/sstxcommitment.ts
+++ b/packages/utxo-lib/src/payments/sstxcommitment.ts
@@ -38,7 +38,7 @@ export function sstxcommitment(a: Payment, opts?: PaymentOpts): Payment {
     });
 
     lazy.prop(o, 'hash', () => {
-        if (a.output) return a.output.subarray(2, 22);
+        if (a.output) return a.output.slice(2, 22);
         if (a.address) return _address().hash;
     });
 
@@ -72,7 +72,7 @@ export function sstxcommitment(a: Payment, opts?: PaymentOpts): Payment {
             if (a.output.length !== 32 || a.output[0] !== OPS.OP_RETURN)
                 throw new TypeError('sstxcommitment output is invalid');
 
-            const hash2 = a.output.subarray(2, 22);
+            const hash2 = a.output.slice(2, 22);
             if (hash.length > 0 && !hash.equals(hash2)) throw new TypeError('Hash mismatch');
         }
     }

--- a/packages/utxo-lib/src/payments/sstxpkh.ts
+++ b/packages/utxo-lib/src/payments/sstxpkh.ts
@@ -35,7 +35,7 @@ export function sstxpkh(a: Payment, opts?: PaymentOpts): Payment {
         return bs58check.encodeAddress(o.hash, network.pubKeyHash, network);
     });
     lazy.prop(o, 'hash', () => {
-        if (a.output) return a.output.subarray(4, 24);
+        if (a.output) return a.output.slice(4, 24);
         if (a.address) return _address().hash;
     });
     lazy.prop(o, 'output', () => {
@@ -76,7 +76,7 @@ export function sstxpkh(a: Payment, opts?: PaymentOpts): Payment {
             )
                 throw new TypeError('sstxpkh output is invalid');
 
-            const hash2 = a.output.subarray(4, 24);
+            const hash2 = a.output.slice(4, 24);
             if (hash.length > 0 && !hash.equals(hash2)) throw new TypeError('Hash mismatch');
         }
     }

--- a/packages/utxo-lib/src/payments/sstxsh.ts
+++ b/packages/utxo-lib/src/payments/sstxsh.ts
@@ -34,7 +34,7 @@ export function sstxsh(a: Payment, opts?: PaymentOpts): Payment {
         return bs58check.encodeAddress(o.hash, network.scriptHash, network);
     });
     lazy.prop(o, 'hash', () => {
-        if (a.output) return a.output.subarray(3, 23);
+        if (a.output) return a.output.slice(3, 23);
         if (a.address) return _address().hash;
     });
     lazy.prop(o, 'output', () => {
@@ -66,7 +66,7 @@ export function sstxsh(a: Payment, opts?: PaymentOpts): Payment {
             )
                 throw new TypeError('sstxsh output is invalid');
 
-            const hash2 = a.output.subarray(3, 23);
+            const hash2 = a.output.slice(3, 23);
             if (hash.length > 0 && !hash.equals(hash2)) throw new TypeError('Hash mismatch');
         }
     }

--- a/packages/utxo-lib/src/script/index.ts
+++ b/packages/utxo-lib/src/script/index.ts
@@ -111,7 +111,7 @@ export function decompile(buffer: Buffer | Stack) {
             // attempt to read too much data? empty script
             if (i + d.number > buffer.length) return [];
 
-            const data = buffer.subarray(i, i + d.number);
+            const data = buffer.slice(i, i + d.number);
             i += d.number;
 
             // decompile minimally
@@ -193,7 +193,7 @@ export function isCanonicalScriptSignature(buffer: Buffer) {
     if (!types.Buffer(buffer)) return false;
     if (!isDefinedHashType(buffer[buffer.length - 1])) return false;
 
-    return bip66.check(buffer.subarray(0, -1));
+    return bip66.check(buffer.slice(0, -1));
 }
 
 export const number = scriptNumber;

--- a/packages/utxo-lib/src/script/scriptSignature.ts
+++ b/packages/utxo-lib/src/script/scriptSignature.ts
@@ -10,13 +10,13 @@ export function toDER(x: Buffer) {
     let i = 0;
     while (x[i] === 0) ++i;
     if (i === x.length) return ZERO;
-    x = x.subarray(i);
+    x = x.slice(i);
     if (x[0] & 0x80) return Buffer.concat([ZERO, x], 1 + x.length);
     return x;
 }
 
 export function fromDER(x: Buffer) {
-    if (x[0] === 0x00) x = x.subarray(1);
+    if (x[0] === 0x00) x = x.slice(1);
     const buffer = Buffer.alloc(32, 0);
     const bstart = Math.max(0, 32 - x.length);
     x.copy(buffer, bstart);
@@ -29,7 +29,7 @@ export function decode(buffer: Buffer) {
     const hashTypeMod = hashType & ~0x80;
     if (hashTypeMod <= 0 || hashTypeMod >= 4) throw new Error(`Invalid hashType ${hashType}`);
 
-    const decoded = bip66.decode(buffer.subarray(0, -1));
+    const decoded = bip66.decode(buffer.slice(0, -1));
     const r = fromDER(decoded.r);
     const s = fromDER(decoded.s);
     const signature = Buffer.concat([r, s], 64);
@@ -52,8 +52,8 @@ export function encode(signature: Buffer, hashType: number) {
     const hashTypeBuffer = Buffer.allocUnsafe(1);
     hashTypeBuffer.writeUInt8(hashType, 0);
 
-    const r = toDER(signature.subarray(0, 32));
-    const s = toDER(signature.subarray(32, 64));
+    const r = toDER(signature.slice(0, 32));
+    const s = toDER(signature.slice(32, 64));
 
     return Buffer.concat([bip66.encode(r, s), hashTypeBuffer]);
 }

--- a/packages/utxo-lib/src/transaction/bitcoin.ts
+++ b/packages/utxo-lib/src/transaction/bitcoin.ts
@@ -58,7 +58,7 @@ function toBuffer<S>(
     bufferWriter.writeUInt32(tx.locktime);
 
     // avoid slicing unless necessary
-    if (initialOffset !== undefined) return buffer.subarray(initialOffset, bufferWriter.offset);
+    if (initialOffset !== undefined) return buffer.slice(initialOffset, bufferWriter.offset);
     return buffer;
 }
 

--- a/packages/utxo-lib/src/transaction/dash.ts
+++ b/packages/utxo-lib/src/transaction/dash.ts
@@ -61,7 +61,7 @@ function toBuffer(
     if (tx.specific?.extraPayload) bufferWriter.writeVarSlice(tx.specific.extraPayload);
 
     // avoid slicing unless necessary
-    if (initialOffset !== undefined) return buffer.subarray(initialOffset, bufferWriter.offset);
+    if (initialOffset !== undefined) return buffer.slice(initialOffset, bufferWriter.offset);
     return buffer;
 }
 

--- a/packages/utxo-lib/src/transaction/decred.ts
+++ b/packages/utxo-lib/src/transaction/decred.ts
@@ -82,7 +82,7 @@ function toBuffer(
     }
 
     // avoid slicing unless necessary
-    if (initialOffset !== undefined) return buffer.subarray(initialOffset, bufferWriter.offset);
+    if (initialOffset !== undefined) return buffer.slice(initialOffset, bufferWriter.offset);
     return buffer;
 }
 

--- a/packages/utxo-lib/src/transaction/peercoin.ts
+++ b/packages/utxo-lib/src/transaction/peercoin.ts
@@ -26,7 +26,7 @@ function toBuffer(tx: TransactionBase, buffer?: Buffer, initialOffset?: number) 
     bufferWriter.writeUInt32(tx.locktime);
 
     // avoid slicing unless necessary
-    if (initialOffset !== undefined) return buffer.subarray(initialOffset, bufferWriter.offset);
+    if (initialOffset !== undefined) return buffer.slice(initialOffset, bufferWriter.offset);
     return buffer;
 }
 

--- a/packages/utxo-lib/src/transaction/zcash.ts
+++ b/packages/utxo-lib/src/transaction/zcash.ts
@@ -287,7 +287,7 @@ function toBuffer(tx: TransactionBase<ZcashSpecific>, buffer?: Buffer, initialOf
     }
 
     // avoid slicing unless necessary
-    if (initialOffset !== undefined) return buffer.subarray(initialOffset, bufferWriter.offset);
+    if (initialOffset !== undefined) return buffer.slice(initialOffset, bufferWriter.offset);
     return buffer;
 }
 
@@ -302,7 +302,7 @@ function getExtraData(tx: TransactionBase<ZcashSpecific>) {
         tx.ins.reduce((sum, input) => sum + 40 + varSliceSize(input.script), 0) + // inputs
         tx.outs.reduce((sum, output) => sum + 8 + varSliceSize(output.script), 0) + // outputs
         4; // locktime
-    return tx.toBuffer().subarray(offset);
+    return tx.toBuffer().slice(offset);
 }
 
 function getBlake2bDigestHash(buffer: Buffer, personalization: string | Buffer) {

--- a/packages/utxo-lib/tests/bufferutils.test.ts
+++ b/packages/utxo-lib/tests/bufferutils.test.ts
@@ -124,7 +124,7 @@ describe('bufferutils', () => {
                 const buffer = Buffer.alloc(5, 0);
 
                 const n = bufferutils.writePushDataInt(buffer, f.dec, 0);
-                expect(buffer.subarray(0, n).toString('hex')).toEqual(f.hexPD);
+                expect(buffer.slice(0, n).toString('hex')).toEqual(f.hexPD);
             });
         });
     });
@@ -156,7 +156,7 @@ describe('bufferutils', () => {
                 const buffer = Buffer.alloc(9, 0);
 
                 const n = bufferutils.writeVarInt(buffer, f.dec, 0);
-                expect(buffer.subarray(0, n).toString('hex')).toEqual(f.hexVI);
+                expect(buffer.slice(0, n).toString('hex')).toEqual(f.hexVI);
             });
         });
 

--- a/packages/utxo-lib/tests/scriptSignature.test.ts
+++ b/packages/utxo-lib/tests/scriptSignature.test.ts
@@ -14,8 +14,8 @@ describe('Script Signatures', () => {
         s: string;
     } {
         return {
-            r: signature.subarray(0, 32).toString('hex'),
-            s: signature.subarray(32, 64).toString('hex'),
+            r: signature.slice(0, 32).toString('hex'),
+            s: signature.slice(32, 64).toString('hex'),
         };
     }
 

--- a/suite-common/wallet-utils/src/accountUtils.ts
+++ b/suite-common/wallet-utils/src/accountUtils.ts
@@ -920,7 +920,7 @@ export const getUtxoOutpoint = (utxo: { txid: string; vout: number }) => {
 // https://developer.bitcoin.org/reference/transactions.html#outpoint-the-specific-part-of-a-specific-output
 export const readUtxoOutpoint = (outpoint: string) => {
     const buffer = Buffer.from(outpoint, 'hex');
-    const txid = bufferUtils.reverseBuffer(buffer.subarray(0, 32));
+    const txid = bufferUtils.reverseBuffer(buffer.slice(0, 32));
     const vout = buffer.readUInt32LE(txid.length);
     return { txid: txid.toString('hex'), vout };
 };


### PR DESCRIPTION
This reverts commit 814caeaa91fa4985ddecd9a9a727dfd2294f647b.

# Conflicts:
#	packages/coinjoin/src/backend/filters.ts

<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->

## Related Issue

Resolve #9413

## Screenshots:

https://github.com/trezor/trezor-suite/assets/36101761/ee86094b-cc6b-46cc-b832-31855d0a125c

