### PR TITLE
fix(native): buffer polyfill

### DIFF
--- a/suite-native/app/globalPolyfills.js
+++ b/suite-native/app/globalPolyfills.js
@@ -1,3 +1,4 @@
+/* eslint-disable no-bitwise */
 /**
  * Inject global objects to react-native app
  */
@@ -13,6 +14,37 @@ import '@formatjs/intl-datetimeformat/add-all-tz';
 
 global.Buffer = require('buffer').Buffer;
 global.process = require('process');
+
+// There is bug in buffer polyfill that when you call subarray it returns Uint8Array instead of Buffer, this fixes it
+// It's basically copy pasted slice method from buffer polyfill with one change in line `const newBuf...`
+Buffer.prototype.subarray = function subarray(start, end) {
+    const len = this.length;
+    start = ~~start;
+    end = end === undefined ? len : ~~end;
+
+    if (start < 0) {
+        start += len;
+        if (start < 0) start = 0;
+    } else if (start > len) {
+        start = len;
+    }
+
+    if (end < 0) {
+        end += len;
+        if (end < 0) end = 0;
+    } else if (end > len) {
+        end = len;
+    }
+
+    if (end < start) end = start;
+
+    const newBuf = Uint8Array.prototype.subarray.call(this, start, end);
+
+    // Return an augmented `Uint8Array` instance
+    Object.setPrototypeOf(newBuf, Buffer.prototype);
+
+    return newBuf;
+};
 
 // global.IntlLocales = require('intl/locale-data/jsonp/en');
 

--- a/suite-native/app/package.json
+++ b/suite-native/app/package.json
@@ -76,6 +76,7 @@
         "@trezor/theme": "workspace:*",
         "babel-plugin-transform-remove-console": "^6.9.4",
         "basil-ws-flipper": "^0.2.8",
+        "buffer": "^6.0.3",
         "expo": "48.0.1",
         "expo-barcode-scanner": "^12.3.1",
         "expo-brightness": "^11.2.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -9638,6 +9638,7 @@ __metadata:
     babel-jest: ^26.6.3
     babel-plugin-transform-remove-console: ^6.9.4
     basil-ws-flipper: ^0.2.8
+    buffer: ^6.0.3
     expo: 48.0.1
     expo-barcode-scanner: ^12.3.1
     expo-brightness: ^11.2.1


### PR DESCRIPTION
This PR fixes issues where buffer polyfill method `subarray` returns `Uint8Array` instance instead of `Buffer`.