### PR TITLE
feat(coinjoin): implement DelayTransactionSigning

### DIFF
--- a/packages/coinjoin/src/constants.ts
+++ b/packages/coinjoin/src/constants.ts
@@ -25,6 +25,8 @@ export const ROUND_REGISTRATION_END_OFFSET = 2000;
 // This is a maximum cap the delay can be zero if the remaining time is less.
 export const ROUND_MAXIMUM_REQUEST_DELAY = 10000;
 
+export const TX_SIGNING_DELAY = 50000;
+
 // do not register into Round if round.inputRegistrationEnd is below offset
 export const ROUND_SELECTION_REGISTRATION_OFFSET = 30000;
 

--- a/packages/coinjoin/src/types/coordinator.ts
+++ b/packages/coinjoin/src/types/coordinator.ts
@@ -97,6 +97,7 @@ export interface CoinjoinRoundParameters {
     MaxVsizeAllocationPerAlice: number;
     MaxTransactionSize: number;
     MinRelayTxFee: number;
+    DelayTransactionSigning: boolean;
 }
 
 export interface CoinjoinRoundCreatedEvent {

--- a/packages/coinjoin/tests/fixtures/round.fixture.ts
+++ b/packages/coinjoin/tests/fixtures/round.fixture.ts
@@ -37,6 +37,7 @@ export const ROUND_CREATION_EVENT = {
         MaxVsizeAllocationPerAlice: 255,
         MaxTransactionSize: 100000,
         MinRelayTxFee: 1000,
+        DelayTransactionSigning: true,
     },
 };
 

--- a/packages/coinjoin/tests/utils/roundUtils.test.ts
+++ b/packages/coinjoin/tests/utils/roundUtils.test.ts
@@ -1,3 +1,5 @@
+import { getRandomNumberInRange } from '@trezor/utils';
+
 import {
     getCommitmentData,
     readTimeSpan,
@@ -8,6 +10,16 @@ import {
 } from '../../src/utils/roundUtils';
 import { ROUND_REGISTRATION_END_OFFSET } from '../../src/constants';
 import { DEFAULT_ROUND, STATUS_EVENT, STATUS_TRANSFORMED } from '../fixtures/round.fixture';
+
+// mock random delay function
+jest.mock('@trezor/utils', () => {
+    const originalModule = jest.requireActual('@trezor/utils');
+    return {
+        __esModule: true,
+        ...originalModule,
+        getRandomNumberInRange: jest.fn(originalModule.getRandomNumberInRange),
+    };
+});
 
 describe('roundUtils', () => {
     it('getCommitmentData', () => {
@@ -122,14 +134,45 @@ describe('roundUtils', () => {
     });
 
     it('scheduleDelay', () => {
-        const d1 = scheduleDelay(20000, 3000);
-        expect(d1).toBeGreaterThanOrEqual(3000);
-        expect(d1).toBeLessThanOrEqual(10000);
+        const resultInRange = (result: number, min: number, max: number) => {
+            expect(result).toBeGreaterThanOrEqual(min);
+            expect(result).toBeLessThanOrEqual(max);
+        };
 
-        const d2 = scheduleDelay(1000, 3000);
-        expect(d2).toEqual(3000); // deadline < min
+        // default (no min, no max) range 0-10 sec.
+        resultInRange(scheduleDelay(60000), 0, 10000);
+        expect(getRandomNumberInRange).toHaveBeenLastCalledWith(0, 10000);
 
-        const d3 = scheduleDelay(1000, 0, 5000);
-        expect(d3).toEqual(0); // deadline < max
+        // range 3-10sec.
+        resultInRange(scheduleDelay(20000, 3000), 3000, 10000);
+        expect(getRandomNumberInRange).toHaveBeenLastCalledWith(3000, 10000);
+
+        // deadlineOffset < 0, range 0-1 sec.
+        resultInRange(scheduleDelay(1000, 3000), 0, 1000);
+        expect(getRandomNumberInRange).toHaveBeenLastCalledWith(0, 1000);
+
+        // deadline < min, range 9-10 sec.
+        resultInRange(scheduleDelay(60000, 61000), 9000, 10000);
+        expect(getRandomNumberInRange).toHaveBeenLastCalledWith(9000, 10000);
+
+        // deadline < min && deadline < max, range 49-50 sec.
+        resultInRange(scheduleDelay(60000, 61000, 62000), 49000, 50000);
+        expect(getRandomNumberInRange).toHaveBeenLastCalledWith(49000, 50000);
+
+        // deadline > min && deadline < max, range 3-20 sec.
+        resultInRange(scheduleDelay(30000, 3000, 50000), 3000, 20000);
+        expect(getRandomNumberInRange).toHaveBeenLastCalledWith(3000, 20000);
+
+        // min < 0 && deadline < max && deadlineOffset > 0, range 0-2.5 sec.
+        resultInRange(scheduleDelay(12500, -3000, 50000), 0, 2500);
+        expect(getRandomNumberInRange).toHaveBeenLastCalledWith(0, 2500);
+
+        // min < 0 && max < 0 && deadlineOffset > 0, range 0-1 sec.
+        resultInRange(scheduleDelay(12500, -10000, -5000), 0, 1000);
+        expect(getRandomNumberInRange).toHaveBeenLastCalledWith(0, 1000);
+
+        // min < 0 && max < 0 && deadlineOffset < 0, range 0-1 sec.
+        resultInRange(scheduleDelay(7500, -10000, -5000), 0, 1000);
+        expect(getRandomNumberInRange).toHaveBeenLastCalledWith(0, 1000);
     });
 });


### PR DESCRIPTION
## Description

following recent changes in WalletWasabi
https://github.com/zkSNACKs/WalletWasabi/commit/336a7d876d4429dbaf76f05878ebf65fef4266ea

- signatures are sent in random time range between 0-50 sec (default)
- if RoundParameters.DelayTransactionSigning is set then signatures are sent with 50 sec. delay. Random time range remains the same

## Related Issue

Resolve https://github.com/trezor/trezor-suite/issues/9392
