### PR TITLE
New Zcash fee calculation (ZIP-317)

### DIFF
--- a/packages/connect/e2e/__fixtures__/composeTransaction.ts
+++ b/packages/connect/e2e/__fixtures__/composeTransaction.ts
@@ -363,9 +363,9 @@ export default {
                 {
                     type: 'final',
                     bytes: 226,
-                    fee: '1000000', // NOTE: +0.01 DOGE per dust limit output
+                    fee: '1226000', // NOTE: +0.01 DOGE per dust limit output
                     max: undefined,
-                    totalSpent: '1100000',
+                    totalSpent: '1326000',
                     transaction: {
                         inputs: [{ script_type: 'SPENDADDRESS' }],
                         outputs: [
@@ -374,7 +374,7 @@ export default {
                                 amount: '100000',
                                 script_type: 'PAYTOADDRESS',
                             },
-                            { amount: '498900000', script_type: 'PAYTOADDRESS' },
+                            { amount: '498674000', script_type: 'PAYTOADDRESS' },
                         ],
                     },
                 },

--- a/packages/connect/src/api/bitcoin/TransactionComposer.ts
+++ b/packages/connect/src/api/bitcoin/TransactionComposer.ts
@@ -163,17 +163,6 @@ export class TransactionComposer {
         const changeId = getHDPath(changeAddress.path).slice(-1)[0]; // get address id from the path
         // const inputAmounts = coinInfo.segwit || coinInfo.forkid !== null || coinInfo.network.consensusBranchId !== null;
 
-        const enhancement = {
-            baseFee,
-            floorBaseFee: false,
-            dustOutputFee: 0,
-        };
-
-        // DOGE changed fee policy and requires:
-        if (coinInfo.shortcut === 'DOGE') {
-            enhancement.dustOutputFee = 1000000; // 0.01 DOGE for every output lower than dust (dust = 0.01 DOGE)
-        }
-
         return composeTx({
             txType: account.type,
             utxos: this.utxos,
@@ -187,7 +176,7 @@ export class TransactionComposer {
             changeId,
             changeAddress: changeAddress.address,
             dustThreshold: coinInfo.dustLimit,
-            ...enhancement,
+            baseFee,
         });
     }
 

--- a/packages/utxo-lib/src/coinselect/outputs/split.ts
+++ b/packages/utxo-lib/src/coinselect/outputs/split.ts
@@ -2,7 +2,6 @@ import * as BN from 'bn.js';
 import {
     bignumberOrNaN,
     sumOrNaN,
-    transactionBytes,
     filterCoinbase,
     getDustAmount,
     getFee,
@@ -26,8 +25,7 @@ export function split(
     const coinbase = options.coinbase || 100;
     const utxos = filterCoinbase(utxosOrig, coinbase);
 
-    const bytesAccum = transactionBytes(utxos, outputs);
-    const fee = getFee(feeRate, bytesAccum, options, outputs);
+    const fee = getFee(utxos, outputs, feeRate, options);
     if (outputs.length === 0) return { fee };
 
     const inAccum = sumOrNaN(utxos);

--- a/packages/utxo-lib/src/compose/coinselect.ts
+++ b/packages/utxo-lib/src/compose/coinselect.ts
@@ -1,7 +1,7 @@
 import * as BN from 'bn.js';
 import { split as bitcoinJsSplit } from '../coinselect/outputs/split';
 import { coinselect as bitcoinJsCoinselect } from '../coinselect';
-import { transactionBytes } from '../coinselect/coinselectUtils';
+import { getFeePolicy, transactionBytes } from '../coinselect/coinselectUtils';
 import { convertInputs, convertOutputs } from './composeUtils';
 import {
     ComposeInput,
@@ -26,19 +26,19 @@ export function coinselect(
     network: Network,
     baseFee?: number,
     floorBaseFee?: boolean,
-    dustOutputFee?: number,
     skipPermutation?: boolean,
 ): CoinSelectSuccess | CoinSelectFailure {
     const inputs0 = convertInputs(utxos, height, txType);
     const outputs0 = convertOutputs(rOutputs, network, txType);
+    const feePolicy = getFeePolicy(network);
     const options: CoinSelectOptions = {
         txType,
         dustThreshold,
         longTermFeeRate,
         baseFee,
         floorBaseFee,
-        dustOutputFee,
         skipPermutation,
+        feePolicy,
     };
 
     const algorithm = countMax ? bitcoinJsSplit : bitcoinJsCoinselect;

--- a/packages/utxo-lib/src/compose/index.ts
+++ b/packages/utxo-lib/src/compose/index.ts
@@ -19,7 +19,6 @@ export function composeTx({
     dustThreshold,
     baseFee,
     floorBaseFee,
-    dustOutputFee,
     skipPermutation,
 }: ComposeRequest): ComposeResult {
     if (outputs.length === 0) {
@@ -71,7 +70,6 @@ export function composeTx({
             network,
             baseFee,
             floorBaseFee,
-            dustOutputFee,
             skipPermutation,
         );
     } catch (e) {

--- a/packages/utxo-lib/src/networks.ts
+++ b/packages/utxo-lib/src/networks.ts
@@ -240,7 +240,7 @@ export const decredSim: Network = {
     wif: 0x2307,
 };
 
-export const doge = {
+export const doge: Network = {
     messagePrefix: '\x19Dogecoin Signed Message:\n',
     bech32: '',
     bip32: {
@@ -259,6 +259,7 @@ const NETWORK_TYPES = {
     peercoin: [peercoin, peercoinTest],
     zcash: [zcash, zcashTest, komodo],
     litecoin: [litecoin, litecoinTest],
+    doge: [doge],
 };
 
 export type NetworkTypes = keyof typeof NETWORK_TYPES;

--- a/packages/utxo-lib/src/types/coinselect.ts
+++ b/packages/utxo-lib/src/types/coinselect.ts
@@ -9,8 +9,8 @@ export interface CoinSelectOptions {
     coinbase?: number;
     baseFee?: number;
     floorBaseFee?: boolean;
-    dustOutputFee?: number;
     skipPermutation?: boolean;
+    feePolicy?: 'bitcoin' | 'doge';
 }
 
 export interface CoinSelectInput {

--- a/packages/utxo-lib/src/types/coinselect.ts
+++ b/packages/utxo-lib/src/types/coinselect.ts
@@ -10,7 +10,7 @@ export interface CoinSelectOptions {
     baseFee?: number;
     floorBaseFee?: boolean;
     skipPermutation?: boolean;
-    feePolicy?: 'bitcoin' | 'doge';
+    feePolicy?: 'bitcoin' | 'doge' | 'zcash';
 }
 
 export interface CoinSelectInput {

--- a/packages/utxo-lib/src/types/compose.ts
+++ b/packages/utxo-lib/src/types/compose.ts
@@ -63,7 +63,6 @@ export interface ComposeRequest {
     dustThreshold: number; // explicit dust threshold, in satoshi
     baseFee?: number; // DOGE or RBF base fee
     floorBaseFee?: boolean; // DOGE floor base fee to the nearest integer
-    dustOutputFee?: number; // DOGE fee for every output below dust limit
     skipUtxoSelection?: boolean; // use custom utxo selection, without algorithm
     skipPermutation?: boolean; // Do not sort inputs/outputs and preserve the given order. Handy for RBF.
 }

--- a/packages/utxo-lib/tests/__fixtures__/coinselect/accumulative.ts
+++ b/packages/utxo-lib/tests/__fixtures__/coinselect/accumulative.ts
@@ -860,7 +860,7 @@ export default [
         feeRate: 100000,
         baseFee: 100000000,
         floorBaseFee: true,
-        dustOutputFee: 100000000,
+        feePolicy: 'doge',
         inputs: ['200000000', '20000000'],
         outputs: ['120000001'],
         expected: {
@@ -873,7 +873,7 @@ export default [
         feeRate: 100000,
         baseFee: 100000000,
         floorBaseFee: true,
-        dustOutputFee: 100000000,
+        feePolicy: 'doge',
         inputs: [
             '200000000',
             {
@@ -894,7 +894,7 @@ export default [
         feeRate: 100000,
         baseFee: 100000000,
         floorBaseFee: true,
-        dustOutputFee: 100000000,
+        feePolicy: 'doge',
         inputs: ['200000000'],
         outputs: ['10000000'],
         expected: {
@@ -907,7 +907,7 @@ export default [
         feeRate: 100000,
         baseFee: 100000000,
         floorBaseFee: true,
-        dustOutputFee: 100000000,
+        feePolicy: 'doge',
         inputs: ['500000111'],
         outputs: ['100000000'],
         expected: {
@@ -934,7 +934,7 @@ export default [
         feeRate: 100000,
         baseFee: 100000000,
         floorBaseFee: true,
-        dustOutputFee: 100000000,
+        feePolicy: 'doge',
         inputs: ['400000000'],
         outputs: ['100000000', '5'],
         expected: {
@@ -961,7 +961,7 @@ export default [
         feeRate: 100000,
         baseFee: 100000000,
         floorBaseFee: true,
-        dustOutputFee: 100000000,
+        feePolicy: 'doge',
         inputs: [
             {
                 script: {
@@ -995,7 +995,7 @@ export default [
         feeRate: 150000,
         baseFee: 100000000,
         floorBaseFee: true,
-        dustOutputFee: 100000000,
+        feePolicy: 'doge',
         inputs: [
             {
                 i: 0,

--- a/packages/utxo-lib/tests/__fixtures__/coinselect/split.ts
+++ b/packages/utxo-lib/tests/__fixtures__/coinselect/split.ts
@@ -306,7 +306,7 @@ export default [
         feeRate: 100000,
         baseFee: 100000000,
         floorBaseFee: true,
-        dustOutputFee: 100000000,
+        feePolicy: 'doge',
         inputs: ['200000011'],
         outputs: [{}],
         expected: {
@@ -330,7 +330,7 @@ export default [
         feeRate: 100000,
         baseFee: 100000000,
         floorBaseFee: true,
-        dustOutputFee: 100000000,
+        feePolicy: 'doge',
         inputs: ['400000000'],
         outputs: [{}, {}, {}],
         expected: {
@@ -360,7 +360,7 @@ export default [
         feeRate: 100000,
         baseFee: 100000000,
         floorBaseFee: true,
-        dustOutputFee: 100000000,
+        feePolicy: 'doge',
         inputs: [
             {
                 i: 0,
@@ -395,7 +395,7 @@ export default [
         feeRate: 150000,
         baseFee: 100000000,
         floorBaseFee: true,
-        dustOutputFee: 100000000,
+        feePolicy: 'doge',
         inputs: [
             {
                 i: 0,
@@ -430,7 +430,7 @@ export default [
         feeRate: 100000,
         baseFee: 100000000,
         floorBaseFee: true,
-        dustOutputFee: 100000000,
+        feePolicy: 'doge',
         inputs: [
             {
                 i: 0,
@@ -462,7 +462,7 @@ export default [
         feeRate: 700000,
         baseFee: 100000000,
         floorBaseFee: true,
-        dustOutputFee: 100000000,
+        feePolicy: 'doge',
         inputs: [
             {
                 i: 0,
@@ -480,7 +480,7 @@ export default [
         feeRate: 100000,
         baseFee: 100000000,
         floorBaseFee: true,
-        dustOutputFee: 100000000,
+        feePolicy: 'doge',
         inputs: [
             {
                 i: 0,
@@ -498,7 +498,7 @@ export default [
         feeRate: 100000,
         baseFee: 100000000,
         floorBaseFee: true,
-        dustOutputFee: 100000000,
+        feePolicy: 'doge',
         inputs: [
             {
                 i: 0,

--- a/packages/utxo-lib/tests/coinselect/accumulative.test.ts
+++ b/packages/utxo-lib/tests/coinselect/accumulative.test.ts
@@ -14,7 +14,7 @@ describe('coinselect: accumulative', () => {
                 dustThreshold: f.dustThreshold,
                 baseFee: f.baseFee,
                 floorBaseFee: f.floorBaseFee,
-                dustOutputFee: f.dustOutputFee,
+                feePolicy: f.feePolicy,
             } as CoinSelectOptions;
 
             const actual = accumulative(inputs, outputs, f.feeRate, options);

--- a/packages/utxo-lib/tests/coinselect/coinselectUtils.test.ts
+++ b/packages/utxo-lib/tests/coinselect/coinselectUtils.test.ts
@@ -27,43 +27,44 @@ describe('coinselectUtils', () => {
     });
 
     it('getBaseFee', () => {
-        expect(getFee(1.33, 56, {}, [])).toEqual(75);
-        expect(getFee(1, 100, {}, [])).toEqual(100);
-        expect(getFee(1, 200, {}, [])).toEqual(200);
+        expect(getFee([], [{ script: { length: 37 } }], 1.33)).toEqual(75);
+        expect(getFee([], [{ script: { length: 81 } }], 1)).toEqual(100);
+        expect(getFee([], [{ script: { length: 181 } }], 1)).toEqual(200);
         // without floor
-        expect(getFee(1, 200, { baseFee: 1000 }, [])).toEqual(1200);
+        expect(getFee([], [{ script: { length: 181 } }], 1, { baseFee: 1000 })).toEqual(1200);
         expect(
             getFee(
+                [],
+                [
+                    { value: '8', script: { length: 49 } },
+                    { value: '7', script: { length: 50 } },
+                ],
                 2,
-                127,
                 {
                     baseFee: 1000,
                     dustOutputFee: 1000,
                     dustThreshold: 9,
                 },
-                [
-                    { value: '8', script: { length: 0 } },
-                    { value: '7', script: { length: 0 } },
-                ],
             ),
         ).toEqual(3254);
-
         // with floor
-        expect(getFee(1, 200, { baseFee: 1000, floorBaseFee: true }, [])).toEqual(1000);
+        expect(
+            getFee([], [{ script: { length: 181 } }], 1, { baseFee: 1000, floorBaseFee: true }),
+        ).toEqual(1000);
         expect(
             getFee(
+                [],
+                [
+                    { value: '8', script: { length: 500 } },
+                    { value: '7', script: { length: 472 } },
+                ],
                 2,
-                1000,
                 {
                     baseFee: 1000,
                     dustOutputFee: 1000,
                     dustThreshold: 9,
                     floorBaseFee: true,
                 },
-                [
-                    { value: '8', script: { length: 0 } },
-                    { value: '7', script: { length: 0 } },
-                ],
             ),
         ).toEqual(5000);
     });

--- a/packages/utxo-lib/tests/coinselect/coinselectUtils.test.ts
+++ b/packages/utxo-lib/tests/coinselect/coinselectUtils.test.ts
@@ -32,6 +32,13 @@ describe('coinselectUtils', () => {
         expect(getFee([], [{ script: { length: 181 } }], 1)).toEqual(200);
         // without floor
         expect(getFee([], [{ script: { length: 181 } }], 1, { baseFee: 1000 })).toEqual(1200);
+        // with floor
+        expect(
+            getFee([], [{ script: { length: 181 } }], 1, { baseFee: 1000, floorBaseFee: true }),
+        ).toEqual(1000);
+    });
+
+    it('getDogeFee', () => {
         expect(
             getFee(
                 [],
@@ -40,17 +47,9 @@ describe('coinselectUtils', () => {
                     { value: '7', script: { length: 50 } },
                 ],
                 2,
-                {
-                    baseFee: 1000,
-                    dustOutputFee: 1000,
-                    dustThreshold: 9,
-                },
+                { feePolicy: 'doge', baseFee: 1000, dustThreshold: 1000 },
             ),
         ).toEqual(3254);
-        // with floor
-        expect(
-            getFee([], [{ script: { length: 181 } }], 1, { baseFee: 1000, floorBaseFee: true }),
-        ).toEqual(1000);
         expect(
             getFee(
                 [],
@@ -59,12 +58,7 @@ describe('coinselectUtils', () => {
                     { value: '7', script: { length: 472 } },
                 ],
                 2,
-                {
-                    baseFee: 1000,
-                    dustOutputFee: 1000,
-                    dustThreshold: 9,
-                    floorBaseFee: true,
-                },
+                { feePolicy: 'doge', baseFee: 1000, dustThreshold: 1000, floorBaseFee: true },
             ),
         ).toEqual(5000);
     });

--- a/packages/utxo-lib/tests/coinselect/coinselectUtils.test.ts
+++ b/packages/utxo-lib/tests/coinselect/coinselectUtils.test.ts
@@ -63,6 +63,23 @@ describe('coinselectUtils', () => {
         ).toEqual(5000);
     });
 
+    it('getZcashFee', () => {
+        const IN = {
+            type: 'p2pkh',
+            i: 0,
+            value: '0',
+            confirmations: 0,
+            script: { length: 108 },
+        } as const;
+        const OUT = { script: { length: 25 } };
+
+        expect(getFee([], [], 10, { feePolicy: 'zcash' })).toBe(10000);
+        expect(getFee([IN], [OUT], 10, { feePolicy: 'zcash' })).toBe(10000);
+        expect(getFee([IN, IN], [OUT], 10, { feePolicy: 'zcash' })).toBe(10000);
+        expect(getFee([IN], [OUT, OUT, OUT], 10, { feePolicy: 'zcash' })).toBe(15000);
+        expect(getFee([IN], [OUT], 60, { feePolicy: 'zcash' })).toBe(11520); // fee per byte is higher
+    });
+
     it('getDustAmount', () => {
         // NOTE: p2wsh case in intentionally not tested as INPUT_SCRIPT_LENGTH.p2wsh is not quite accurate and waits for the implementation of multisig
 

--- a/packages/utxo-lib/tests/coinselect/split.test.ts
+++ b/packages/utxo-lib/tests/coinselect/split.test.ts
@@ -14,7 +14,7 @@ describe('coinselect split', () => {
                 dustThreshold: f.dustThreshold,
                 baseFee: f.baseFee,
                 floorBaseFee: f.floorBaseFee,
-                dustOutputFee: f.dustOutputFee,
+                feePolicy: f.feePolicy,
             } as CoinSelectOptions;
 
             const actual = split(inputs, outputs, f.feeRate, options);


### PR DESCRIPTION
## Description

Implements [ZIP-317](https://github.com/zcash/zips/blob/main/zip-0317.rst) which changes the fee calculation mechanism for Zcash. Now the (minimum) fee is calculated as 5000 zat per every input or output (whichever there's more of, but at least 2).

Given that all the other bitcoin-like coins in Suite calculate their fee for bytes, the newly calculated fee is used only as a floor value which can be increased by increasing the fee per byte.

**Known issue** is that this change kind of breaks the coin selection algorithms, as it's now impossible to tell the proportional fee for isolated inputs and outputs.

- https://github.com/trezor/trezor-suite/pull/9419/commits/6dbf91e8c528e7d5a3ced351f21e9c8f0a1bf15f
  - `getFee` function now accepts all inputs and outputs instead of byte count, so it can be more flexible
- https://github.com/trezor/trezor-suite/pull/9419/commits/f2a47a58f211a3906d0845c550961c949a16370c
  - newly added `feePolicy` is now detected in `coinselect` and used in `getFee` to choose specific algorithm
  - `dustOutputFee` removed as it's used only for doge and should always be the same as `dustThreshold`
- https://github.com/trezor/trezor-suite/pull/9419/commits/c791f85b7cdcc67a744fb203166aea825ff47d2f
  - unit tests adjusted to reflect `feePolicy`
- https://github.com/trezor/trezor-suite/pull/9419/commits/e6e5384a198e3d970e99cbdc24b751402eca08b3
  - doge specifics removed from Connect's `TransactionComposer` as they're now handled in utxo-lib
- https://github.com/trezor/trezor-suite/pull/9419/commits/f66518f05c62da60c6b57e0cbad3cf0529ab0afe
  - Connect e2e doge tx test fixed (previously it ignored default fee when dust output penalty was present)
- https://github.com/trezor/trezor-suite/pull/9419/commits/20e6d7ce3a108b84d3fcd7a8cb129e28228b79e6
  - implemented `zcash` fee policy (yes, this commit alone was a reason for this PR)
- https://github.com/trezor/trezor-suite/pull/9419/commits/82cddbe28f4728f91424d6c86b87905e8269a9b9
  - unit tests added for `zcash` fee policy

## Related Issue

Could resolve #9375