### PR TITLE
fix(components): device animation path - lowercase device model internal

### DIFF
--- a/packages/components/src/components/animations/DeviceAnimation.tsx
+++ b/packages/components/src/components/animations/DeviceAnimation.tsx
@@ -62,12 +62,13 @@ export const DeviceAnimation = forwardRef<HTMLVideoElement, DeviceAnimationProps
                     >
                         <source
                             src={resolveStaticPath(
-                                `videos/device/trezor_${deviceModelInternal}_${type.toLowerCase()}${theme}.webm`,
+                                `videos/device/trezor_${deviceModelInternal.toLowerCase()}_${type.toLowerCase()}${theme}.webm`,
                             )}
                             type="video/webm"
                         />
                     </StyledVideo>
                 )}
+                {/* Images available only for T1B1 */}
                 {['BOOTLOADER_TWO_BUTTONS', 'NORMAL'].includes(type) && (
                     <StyledVideo
                         loop={loop}
@@ -80,9 +81,7 @@ export const DeviceAnimation = forwardRef<HTMLVideoElement, DeviceAnimationProps
                     >
                         <source
                             src={resolveStaticPath(
-                                `videos/device/trezor_${
-                                    DeviceModelInternal.T1B1
-                                }_${type.toLowerCase()}${theme}.webm`,
+                                `videos/device/trezor_${DeviceModelInternal.T1B1.toLowerCase()}_${type.toLowerCase()}${theme}.webm`,
                             )}
                             type="video/webm"
                         />
@@ -98,7 +97,7 @@ export const DeviceAnimation = forwardRef<HTMLVideoElement, DeviceAnimationProps
                     >
                         <source
                             src={resolveStaticPath(
-                                `videos/device/trezor_${deviceModelInternal}_hologram.webm`,
+                                `videos/device/trezor_${deviceModelInternal.toLowerCase()}_hologram.webm`,
                             )}
                             type="video/webm"
                         />


### PR DESCRIPTION
## Description

- device animations did not work in prod app as the path had incorrect device internal name (uppercased and has to be lowercased)

Caused by https://github.com/trezor/trezor-suite/pull/9372