### PR TITLE
fix(suite-common): discovery types

### DIFF
--- a/packages/suite/src/middlewares/wallet/discoveryMiddleware.ts
+++ b/packages/suite/src/middlewares/wallet/discoveryMiddleware.ts
@@ -85,7 +85,7 @@ export const prepareDiscoveryMiddleware = createMiddlewareWithExtraDeps(
         // 2. selected device becomes acquired from unacquired or connected from disconnected
         let becomesConnected = false;
         if (deviceActions.updateSelectedDevice.match(action)) {
-            const prevDevice = prevState.suite.device;
+            const prevDevice = prevState.device.selectedDevice;
             const becomesAcquired = !!(
                 prevDevice &&
                 !prevDevice.features &&

--- a/suite-common/wallet-core/src/discovery/discoveryActions.ts
+++ b/suite-common/wallet-core/src/discovery/discoveryActions.ts
@@ -1,28 +1,43 @@
 import { createAction } from '@reduxjs/toolkit';
 
-import { PartialDiscovery } from '@suite-common/wallet-types';
+import { Discovery, PartialDiscovery } from '@suite-common/wallet-types';
 
 export const DISCOVERY_MODULE_PREFIX = '@common/wallet-core/discovery';
 
-export const createDiscovery = createAction(`${DISCOVERY_MODULE_PREFIX}/create`, payload => ({
-    payload,
-}));
+export const createDiscovery = createAction(
+    `${DISCOVERY_MODULE_PREFIX}/create`,
+    (payload: Discovery) => ({
+        payload,
+    }),
+);
 
-export const startDiscovery = createAction(`${DISCOVERY_MODULE_PREFIX}/start`, payload => ({
-    payload,
-}));
+export const startDiscovery = createAction(
+    `${DISCOVERY_MODULE_PREFIX}/start`,
+    (payload: Discovery) => ({
+        payload,
+    }),
+);
 
-export const interruptDiscovery = createAction(`${DISCOVERY_MODULE_PREFIX}/interrupt`, payload => ({
-    payload,
-}));
+export const interruptDiscovery = createAction(
+    `${DISCOVERY_MODULE_PREFIX}/interrupt`,
+    (payload: PartialDiscovery) => ({
+        payload,
+    }),
+);
 
-export const completeDiscovery = createAction(`${DISCOVERY_MODULE_PREFIX}/complete`, payload => ({
-    payload,
-}));
+export const completeDiscovery = createAction(
+    `${DISCOVERY_MODULE_PREFIX}/complete`,
+    (payload: PartialDiscovery) => ({
+        payload,
+    }),
+);
 
-export const stopDiscovery = createAction(`${DISCOVERY_MODULE_PREFIX}/stop`, payload => ({
-    payload,
-}));
+export const stopDiscovery = createAction(
+    `${DISCOVERY_MODULE_PREFIX}/stop`,
+    (payload: PartialDiscovery) => ({
+        payload,
+    }),
+);
 
 export const removeDiscovery = createAction(
     `${DISCOVERY_MODULE_PREFIX}/remove`,

--- a/suite-common/wallet-core/src/discovery/discoveryReducer.ts
+++ b/suite-common/wallet-core/src/discovery/discoveryReducer.ts
@@ -1,5 +1,3 @@
-import { PayloadAction } from '@reduxjs/toolkit';
-
 import { createDeferred } from '@trezor/utils';
 import { Discovery, PartialDiscovery } from '@suite-common/wallet-types';
 import { createReducerWithExtraDeps } from '@suite-common/redux-utils';
@@ -38,59 +36,38 @@ export const prepareDiscoveryReducer = createReducerWithExtraDeps(
     initialState,
     (builder, extra) => {
         builder
-            .addCase(
-                discoveryActions.createDiscovery,
-                (state, { payload }: PayloadAction<Discovery>) => {
-                    const index = state.findIndex(d => d.deviceState === payload.deviceState);
-                    if (index < 0) {
-                        state.push(payload);
-                    }
-                },
-            )
-            .addCase(
-                discoveryActions.startDiscovery,
-                (state, { payload }: PayloadAction<Discovery>) => {
-                    const index = state.findIndex(f => f.deviceState === payload.deviceState);
-                    if (index >= 0) {
-                        state[index] = {
-                            ...state[index],
-                            ...payload,
-                            running: createDeferred(),
-                        };
-                    }
-                },
-            )
-            .addCase(
-                discoveryActions.removeDiscovery,
-                (state, { payload }: PayloadAction<string>) => {
-                    const index = state.findIndex(f => f.deviceState === payload);
-                    state.splice(index, 1);
-                },
-            )
-            .addCase(
-                discoveryActions.updateDiscovery,
-                (state, { payload }: PayloadAction<PartialDiscovery>) => {
-                    update(state, payload);
-                },
-            )
-            .addCase(
-                discoveryActions.interruptDiscovery,
-                (state, { payload }: PayloadAction<PartialDiscovery>) => {
-                    update(state, payload);
-                },
-            )
-            .addCase(
-                discoveryActions.completeDiscovery,
-                (state, { payload }: PayloadAction<PartialDiscovery>) => {
-                    update(state, payload, true);
-                },
-            )
-            .addCase(
-                discoveryActions.stopDiscovery,
-                (state, { payload }: PayloadAction<PartialDiscovery>) => {
-                    update(state, payload, true);
-                },
-            )
+            .addCase(discoveryActions.createDiscovery, (state, { payload }) => {
+                const index = state.findIndex(d => d.deviceState === payload.deviceState);
+                if (index < 0) {
+                    state.push(payload);
+                }
+            })
+            .addCase(discoveryActions.startDiscovery, (state, { payload }) => {
+                const index = state.findIndex(f => f.deviceState === payload.deviceState);
+                if (index >= 0) {
+                    state[index] = {
+                        ...state[index],
+                        ...payload,
+                        running: createDeferred(),
+                    };
+                }
+            })
+            .addCase(discoveryActions.removeDiscovery, (state, { payload }) => {
+                const index = state.findIndex(f => f.deviceState === payload);
+                state.splice(index, 1);
+            })
+            .addCase(discoveryActions.updateDiscovery, (state, { payload }) => {
+                update(state, payload);
+            })
+            .addCase(discoveryActions.interruptDiscovery, (state, { payload }) => {
+                update(state, payload);
+            })
+            .addCase(discoveryActions.completeDiscovery, (state, { payload }) => {
+                update(state, payload, true);
+            })
+            .addCase(discoveryActions.stopDiscovery, (state, { payload }) => {
+                update(state, payload, true);
+            })
             .addMatcher(
                 action => action.type === extra.actionTypes.storageLoad,
                 extra.reducers.storageLoadDiscovery,


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Discovery actions were typed in reducer but the actions weren't. Reducer can infer types from actions so I moved types to actions payload so that it catches type errors and reducer infers type.

## Related Issue

Resolve <!--- link the issue here -->

## Screenshots:
