### PR TITLE
Npm bump versions for connect-release

### DIFF
--- a/packages/analytics/CHANGELOG.md
+++ b/packages/analytics/CHANGELOG.md
@@ -1,3 +1,8 @@
+# 1.0.7
+
+-   fix(analytics): adding missing fields package.json (8f1626c49)
+-   fix(analytics): re-adding missing tsconfig.lib (d3bc367b2)
+
 # 1.0.6
 
 -   chore(analytics): report also analytics event type to sentry to see what we miss (27563c630)

--- a/packages/analytics/package.json
+++ b/packages/analytics/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@trezor/analytics",
-    "version": "1.0.6",
+    "version": "1.0.7",
     "license": "See LICENSE.md in repo root",
     "sideEffects": false,
     "main": "src/index",

--- a/packages/connect-analytics/package.json
+++ b/packages/connect-analytics/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@trezor/connect-analytics",
-    "version": "1.0.5",
+    "version": "1.0.6",
     "license": "See LICENSE.md in repo root",
     "sideEffects": false,
     "main": "lib/index",

--- a/packages/connect-common/package.json
+++ b/packages/connect-common/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@trezor/connect-common",
-    "version": "0.0.19",
+    "version": "0.0.20",
     "author": "Trezor <info@trezor.io>",
     "homepage": "https://github.com/trezor/trezor-suite/tree/develop/packages/connect-common",
     "keywords": [


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

We have released those 3 packages into NPM isolated from the rest of the packages to provide a hotfix because of transpile code not included in last version of @trezor/env-utils https://github.com/trezor/trezor-suite/issues/9389


https://github.com/trezor/trezor-suite/pull/9442/commits