### PR TITLE
feat(metadata): basic retries if requests fail

### DIFF
--- a/packages/e2e-utils/src/mocks/dropbox.ts
+++ b/packages/e2e-utils/src/mocks/dropbox.ts
@@ -9,7 +9,7 @@ const port = 30002;
  */
 export class DropboxMock {
     files: Record<string, any> = {};
-    nextResponse: null | Record<string, any> = null;
+    nextResponse: Record<string, any>[] = [];
     // store requests for assertions in tests
     requests: string[] = [];
     app?: Express;
@@ -24,13 +24,13 @@ export class DropboxMock {
         app.use((req, res, next) => {
             this.requests.push(req.url);
 
-            if (this.nextResponse) {
-                console.log('[dropboxMock]', this.nextResponse);
+            if (this.nextResponse.length) {
+                const response = this.nextResponse.shift();
+                console.log('[dropboxMock]', response);
                 // @ts-expect-error
-                res.writeHeader(this.nextResponse.status, this.nextResponse.headers);
-                res.write(JSON.stringify(this.nextResponse.body));
+                res.writeHeader(response.status, response.headers);
+                res.write(JSON.stringify(response!.body));
                 res.end();
-                this.nextResponse = null;
                 return;
             }
             next();
@@ -208,7 +208,7 @@ export class DropboxMock {
     reset() {
         console.log('[mockDropbox]: reset');
         this.files = {};
-        this.nextResponse = null;
+        this.nextResponse = [];
         this.requests = [];
     }
 }

--- a/packages/e2e-utils/src/mocks/google.ts
+++ b/packages/e2e-utils/src/mocks/google.ts
@@ -36,7 +36,7 @@ class File {
  */
 export class GoogleMock {
     files: Record<string, any> = {};
-    nextResponse: null | Record<string, any> = null;
+    nextResponse: Record<string, any>[] = [];
     // store requests for assertions in tests
     requests: string[] = [];
     app?: Express;
@@ -52,13 +52,13 @@ export class GoogleMock {
         app.use((req, res, next) => {
             this.requests.push(req.url);
 
-            if (this.nextResponse) {
-                console.log('[mockGoogleDrive]', this.nextResponse);
+            if (this.nextResponse.length) {
+                const response = this.nextResponse.shift();
+                console.log('[mockGoogleDrive]', response);
                 //    @ts-expect-error
-                res.writeHeader(this.nextResponse.status, this.nextResponse.headers);
-                res.write(JSON.stringify(this.nextResponse.body));
+                res.writeHeader(response.status, response.headers);
+                res.write(JSON.stringify(response!.body));
                 res.end();
-                this.nextResponse = null;
                 return;
             }
             next();
@@ -197,7 +197,7 @@ export class GoogleMock {
             kind: 'drive#user',
             displayName: 'Kryptonit',
         };
-        this.nextResponse = null;
+        this.nextResponse = [];
         this.requests = [];
     }
 

--- a/packages/suite-web/e2e/cypress.config.ts
+++ b/packages/suite-web/e2e/cypress.config.ts
@@ -121,10 +121,10 @@ export default defineConfig({
                 metadataSetNextResponse: ({ provider, status, body }) => {
                     switch (provider) {
                         case 'dropbox':
-                            mocked.dropbox.nextResponse = { status, body };
+                            mocked.dropbox.nextResponse.push({ status, body });
                             break;
                         case 'google':
-                            mocked.google.nextResponse = { status, body };
+                            mocked.google.nextResponse.push({ status, body });
                             break;
                         default:
                             throw new Error('not a valid case');

--- a/packages/suite-web/e2e/tests/metadata/dropbox-api-errors.test.ts
+++ b/packages/suite-web/e2e/tests/metadata/dropbox-api-errors.test.ts
@@ -51,21 +51,76 @@ describe('Dropbox api errors', () => {
 
         cy.log('at this moment, we send wrong token in request');
 
-        cy.task('metadataSetNextResponse', {
-            provider: 'dropbox',
-            status: 400,
-            body: 'Error in call to API function "files/upload": The given OAuth 2 access token is malformed.',
-            headers: {
-                'Content-Type': 'text/plain; charset=utf-8',
-            },
-        });
-
+        // there are 3 retries in metadata provider. this test simulates that no retry has succeeded
+        for (let i = 0; i < 4; i++) {
+            cy.task('metadataSetNextResponse', {
+                provider: 'dropbox',
+                status: 400,
+                body: 'Error in call to API function "files/upload": The given OAuth 2 access token is malformed.',
+                headers: {
+                    'Content-Type': 'text/plain; charset=utf-8',
+                },
+            });
+        }
         cy.getTestElement('@metadata/input').type('Kvooo{enter}');
 
         cy.getTestElement('@toast/error').should(
             'contain',
             'Error in call to API function "files/upload": The given OAuth 2 access token is malformed.',
         );
+    });
+
+    it('Success after retrying GET request', () => {
+        cy.task('startEmu', { wipe: true });
+        cy.task('setupEmu', {
+            mnemonic: 'all all all all all all all all all all all all',
+        });
+        cy.task('startBridge');
+        cy.task('metadataStartProvider', 'dropbox');
+        // prepare some initial files
+        cy.task('metadataSetFileContent', {
+            provider: 'dropbox',
+            file: '/apps/trezor/f7acc942eeb83921892a95085e409b3e6b5325db6400ae5d8de523a305291dca.mtdt',
+            content: {
+                version: '1.0.0',
+                accountLabel: 'already existing label',
+                outputLabels: {},
+                addressLabels: {},
+            },
+            aesKey: 'c785ef250807166bffc141960c525df97647fcc1bca57f6892ca3742ba86ed8d',
+        });
+        cy.prefixedVisit('/', {
+            onBeforeLoad: (win: Window) => {
+                cy.stub(win, 'open').callsFake(stubOpen(win));
+                cy.stub(win, 'fetch').callsFake(rerouteMetadataToMockProvider);
+            },
+        });
+
+        cy.passThroughInitialRun();
+        cy.discoveryShouldFinish();
+
+        cy.getTestElement('@suite/menu/settings').click();
+        cy.getTestElement('@settings/metadata-switch').click({ force: true });
+
+        cy.passThroughInitMetadata('dropbox');
+
+        cy.getTestElement('@suite/menu/wallet-index').click();
+
+        cy.task('metadataSetNextResponse', {
+            provider: 'dropbox',
+            status: 429,
+            body: 'Rate limited!',
+            headers: {
+                'Content-Type': 'text/plain; charset=utf-8',
+            },
+        });
+
+        cy.getTestElement("@metadata/accountLabel/m/84'/0'/0'").click({ force: true });
+        cy.getTestElement("@metadata/accountLabel/m/84'/0'/0'/edit-label-button").click({
+            force: true,
+        });
+
+        cy.getTestElement('@metadata/input').type('Kvooo{enter}');
     });
 
     // todo: add more possible errors

--- a/packages/suite-web/e2e/tests/metadata/google-api-errors.test.ts
+++ b/packages/suite-web/e2e/tests/metadata/google-api-errors.test.ts
@@ -32,29 +32,33 @@ describe('Google api errors', () => {
 
         cy.passThroughInitMetadata(provider);
 
-        // imitate response after sending request with malformed access token
-        cy.task('metadataSetNextResponse', {
-            provider,
-            status: 401,
-            body: {
-                error: {
-                    errors: [
-                        {
-                            domain: 'global',
-                            reason: 'authError',
-                            message: 'Invalid Credentials',
-                            locationType: 'header',
-                            location: 'Authorization',
-                        },
-                    ],
-                    code: 401,
-                    message: 'Invalid Credentials',
+        // there are 3 retries in metadata provider. this test simulates that no retry has succeeded
+        for (let i = 0; i < 4; i++) {
+            // imitate response after sending request with malformed access token
+
+            cy.task('metadataSetNextResponse', {
+                provider,
+                status: 401,
+                body: {
+                    error: {
+                        errors: [
+                            {
+                                domain: 'global',
+                                reason: 'authError',
+                                message: 'Invalid Credentials',
+                                locationType: 'header',
+                                location: 'Authorization',
+                            },
+                        ],
+                        code: 401,
+                        message: 'Invalid Credentials',
+                    },
                 },
-            },
-            headers: {
-                'Content-Type': 'application/json; charset=UTF-8',
-            },
-        });
+                headers: {
+                    'Content-Type': 'application/json; charset=UTF-8',
+                },
+            });
+        }
 
         cy.getTestElement('@toast/error').should(
             'contain',

--- a/packages/suite/src/services/suite/metadata/DropboxProvider.ts
+++ b/packages/suite/src/services/suite/metadata/DropboxProvider.ts
@@ -1,3 +1,5 @@
+/* eslint-disable no-underscore-dangle */
+
 import { Dropbox, DropboxAuth } from 'dropbox';
 import type { users } from 'dropbox';
 import { AbstractMetadataProvider } from 'src/types/suite/metadata';
@@ -105,7 +107,7 @@ class DropboxProvider extends AbstractMetadataProvider {
         }
     }
 
-    async getFileContent(file: string) {
+    private async _getFileContent(file: string) {
         try {
             const { result } = await this.client.filesSearchV2({
                 query: file,
@@ -156,7 +158,11 @@ class DropboxProvider extends AbstractMetadataProvider {
         }
     }
 
-    async setFileContent(file: string, content: Buffer) {
+    getFileContent(file: string) {
+        return this.scheduleApiRequest(() => this._getFileContent(file));
+    }
+
+    private async _setFileContent(file: string, content: Buffer) {
         try {
             const blob = new Blob([content], { type: 'text/plain;charset=UTF-8' });
             await this.client.filesUpload({
@@ -170,6 +176,10 @@ class DropboxProvider extends AbstractMetadataProvider {
         } catch (err) {
             return this.handleProviderError(err);
         }
+    }
+
+    setFileContent(file: string, content: Buffer) {
+        return this.scheduleApiRequest(() => this._setFileContent(file, content));
     }
 
     async getFilesList() {

--- a/packages/suite/src/services/suite/metadata/GoogleProvider.ts
+++ b/packages/suite/src/services/suite/metadata/GoogleProvider.ts
@@ -1,3 +1,5 @@
+/* eslint-disable no-underscore-dangle */
+
 import { AbstractMetadataProvider, OAuthServerEnvironment, Tokens } from 'src/types/suite/metadata';
 import GoogleClient from 'src/services/google';
 
@@ -38,7 +40,7 @@ class GoogleProvider extends AbstractMetadataProvider {
         }
     }
 
-    async getFileContent(file: string) {
+    private async _getFileContent(file: string) {
         try {
             const id = await GoogleClient.getIdByName(file);
             if (!id) {
@@ -66,7 +68,11 @@ class GoogleProvider extends AbstractMetadataProvider {
         }
     }
 
-    async setFileContent(file: string, content: Buffer) {
+    getFileContent(file: string) {
+        return this.scheduleApiRequest(() => this._getFileContent(file));
+    }
+
+    private async _setFileContent(file: string, content: Buffer) {
         try {
             // search for file by name with forceReload=true parameter to make sure that we do not save
             // two files with the same name but different ids
@@ -98,6 +104,10 @@ class GoogleProvider extends AbstractMetadataProvider {
         } catch (err) {
             return this.handleProviderError(err);
         }
+    }
+
+    setFileContent(file: string, content: Buffer) {
+        return this.scheduleApiRequest(() => this._setFileContent(file, content));
     }
 
     async getFilesList() {


### PR DESCRIPTION
while working on #9130 I noticed that already in current implementation, when all coins are active, we might be getting rate limitted sometimes which under current implementation results into metadata provider disconnecting. 

This itself feels okeyish  - when a lower layer (metadata provider) is not able to satisfy needs of a higher layer (metadata actions), it makes sense to stop trying after some time, flush everthing and let user try again. However, when this pattern is used, the lower layer should try hard to satisfy requests and only return error when it admits that it can't really get over troubles such as flaky internet connection or so. 

bf4a4edbb28606e6ead7abb50a86e5c9f93ad0ca - implements poor man mechanism which retries request 3 times with 1 second pause before returning error.

followups:
- each provider should implement its own, more precise implementation. for example dropbox returns something like "retryAfter" in rate limited failed requests.