### PR TITLE
ci(connect): run npm install check post npm release

### DIFF
--- a/ci/npm-deploy.yml
+++ b/ci/npm-deploy.yml
@@ -85,3 +85,5 @@ deploy npm connect:
   <<: *packages_matrix_connect
   script:
     - nix-shell --run "cd ./packages/${PACKAGE} && yarn npm publish --access public"
+    - ./packages/connect/e2e/test-npm-install.sh
+    - ./packages/connect/e2e/test-yarn-install.sh

--- a/packages/connect/e2e/test-npm-install.sh
+++ b/packages/connect/e2e/test-npm-install.sh
@@ -12,10 +12,11 @@ node --version
 mkdir connect-implementation
 cd connect-implementation
 npm init -y
-npm install @trezor/connect
-npm install @trezor/connect-web
-
-echo "import TrezorConnect from '@trezor/connect'" > ./index.js
-node index.js
+npm install @trezor/connect --save
+npm install @trezor/connect-web --save
 
 cat package.json
+
+echo "const TrezorConnect = require('@trezor/connect')" > ./index.js
+node index.js
+


### PR DESCRIPTION
in order to prevent [this situation](https://satoshilabs.slack.com/archives/G019WLX2P7B/p1694769384137829) from happening in the future, lets run npm install check immediately after release. Still not bulletproof, would be nice to simulate this before actually releasing but it mitigates impact of future problem and is quick to do for now.