### PR TITLE
feat(connect-popup): add metamask extension id

### DIFF
--- a/packages/connect/src/data/config.ts
+++ b/packages/connect/src/data/config.ts
@@ -37,6 +37,11 @@ export const config = {
             label: 'MetaMask',
             icon: '',
         },
+        {
+            origin: 'nkbihfbeogaeaoehlefnkodbefgpgknn',
+            label: 'MetaMask',
+            icon: '',
+        },
         { origin: 'file://', label: ' ', icon: '' },
     ],
     onionDomains: {


### PR DESCRIPTION
this should help a bit with https://reddit.com/r/TREZOR/s/LUaU7qmG2M

@karliatto  Could you please review and test it with @trezor/connect-explorer-webextension? I wonder, if this webextension (developed locally) has stable extensionId? If yes, maybe it would make sense to add some mapping for it too.

Followup 
it might make sense to mantain  list of 3rd parties (domains) that enjoy some kind of elevated privilege. Maybe not being on this list would result in popup showing something like "unverified 3rd party", or whatever. this is a product question, I am just mentioning it because we already have something like this (extensionids mapping to extension names in config) and maybe we could approach this more systematically. cc @Hannsek 