### PR TITLE
chore(connect): remove outdated knownhost

### DIFF
--- a/packages/connect/src/data/config.ts
+++ b/packages/connect/src/data/config.ts
@@ -21,12 +21,6 @@ export const config = {
             icon: '',
         },
         { origin: 'niebkpllfhmpfbffbfifagfgoamhpflf', label: 'Trezor Password Manager', icon: '' },
-        { origin: 'trezor-connect@trezor.io', label: 'Trezor Connect FF Extension', icon: '' },
-        {
-            origin: 'efbfhenfhihgdcmnfdkhaphjdnopihlf',
-            label: 'Trezor Connect Chrome Extension',
-            icon: '',
-        },
         {
             origin: 'mnpfhpndmjholfdlhpkjfmjkgppmodaf',
             label: 'MetaMask',


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
It looks there was a Trezor Connect web extension deployed in the stores but it is not anymore so maybe it is better to remove those hosts from the knownhosts list.

* Link to old blog post announcing it - https://blog.trezor.io/new-trezor-chrome-extension-re-enable-when-prompted-in-your-browser-5559d993a337
* Not found anymore in the Google extension store - https://chrome.google.com/webstore/detail/trezor-chrome-extension/jcjjhjgimijdkoamemaghajlhegmoclj?hl=en