### PR TITLE
chore(ci): separate pre-relase and release jobs for connect

### DIFF
--- a/.github/workflows/connect-pre-release-init.yml
+++ b/.github/workflows/connect-pre-release-init.yml
@@ -1,21 +1,34 @@
-name: release - connect v9 - init
+name: pre-release-npm - connect v9 - init
+
+on:
+  workflow_dispatch:
+    inputs:
+      semver:
+        type: choice
+        description: semver
+        options:
+          - patch
+          - minor
 
 jobs:
-  release:
+  pre-release:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
         uses: actions/checkout@v3
+        with:
+          # Number of commits to fetch. 0 indicates all history for all branches and tags.
+          fetch-depth: 0
       - name: Setup node
         uses: actions/setup-node@v3
         with:
           node-version-file: ".nvmrc"
-      - name: Run @trezor/connect create v9 release branch
+      - name: Run @trezor/connect create npm release branch
         run: |
           npm install -g yarn && yarn install
           git config --global user.name "trezor-ci"
           git config --global user.email "${{ secrets.TREZOR_BOT_EMAIL }}"
           gh config set prompt disabled
-          node ./ci/scripts/connect-release-init-v9.js
+          node ./ci/scripts/connect-release-init-npm.js ${{ github.event.inputs.semver }}
         env:
           GITHUB_TOKEN: ${{ secrets.TREZOR_BOT_TOKEN }}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
This PR separates Connect pre-relase and release jobs in 2 different jobs.
It will allow us to:
1. Create npm pre-release branch and after checking changelogs and release npm packages merge it into develop
2. Once we want to do the connect release we can do it from the branch that was created in step 1 that allows us to use that branch as frozen so if there are after changes in `develop` we do not include it in the release.
