### PR TITLE
Remove resetting effect from RBF form

### DIFF
--- a/packages/suite/src/hooks/wallet/useRbfForm.ts
+++ b/packages/suite/src/hooks/wallet/useRbfForm.ts
@@ -190,8 +190,8 @@ export const useRbf = (props: UseRbfProps) => {
     const [showDecreasedOutputs, setShowDecreasedOutputs] = useState(false);
 
     // react-hook-form
-    const useFormMethods = useForm<FormState>({ mode: 'onChange' });
-    const { reset, register, control, setValue, getValues, formState } = useFormMethods;
+    const useFormMethods = useForm<FormState>({ mode: 'onChange', defaultValues: formValues });
+    const { register, control, setValue, getValues, formState } = useFormMethods;
 
     // react-hook-form auto register custom form fields (without HTMLElement)
     useEffect(() => {
@@ -199,11 +199,6 @@ export const useRbf = (props: UseRbfProps) => {
         register('setMaxOutputId');
         register('options');
     }, [register]);
-
-    // react-hook-form reset, set default values
-    useEffect(() => {
-        reset(formValues);
-    }, [formValues, reset]);
 
     // sub-hook
     const { isLoading, composeRequest, composedLevels, onFeeLevelChange, signTransaction } =


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->
The bug was caused by the effect triggering on a render caused by update of the parent (probably `feeInfo`). It looks like the effect was there only to set default values which should be done by setting `defaultValues` when calling `useForm`, not by `reset`.

## Related Issue

Resolve #9416

