### PR TITLE
refactor(suite-native): rename text align prop

### DIFF
--- a/suite-native/atoms/src/AlertBox.tsx
+++ b/suite-native/atoms/src/AlertBox.tsx
@@ -21,10 +21,6 @@ const textWidthStyle = prepareNativeStyle(_ => ({
     flex: 1,
 }));
 
-const titleStyle = prepareNativeStyle<{ isIconVisible: boolean }>((_, { isIconVisible }) => ({
-    textAlign: isIconVisible ? 'left' : 'center',
-}));
-
 export const AlertBox = ({ title, isIconVisible = true }: AlertBoxProps) => {
     const { applyStyle } = useNativeStyles();
 
@@ -41,7 +37,7 @@ export const AlertBox = ({ title, isIconVisible = true }: AlertBoxProps) => {
                 </Box>
             )}
             <Box style={applyStyle(textWidthStyle)}>
-                <Text color="textAlertBlue" style={applyStyle(titleStyle, { isIconVisible })}>
+                <Text color="textAlertBlue" textAlign={isIconVisible ? 'left' : 'center'}>
                     {title}
                 </Text>
             </Box>

--- a/suite-native/atoms/src/Button/Button.tsx
+++ b/suite-native/atoms/src/Button/Button.tsx
@@ -205,7 +205,7 @@ export const Button = ({
                 <HStack alignItems="center">
                     {iconLeft && icon}
                     <Text
-                        align="center"
+                        textAlign="center"
                         variant={buttonToTextSizeMap[size]}
                         color={isDisabled ? disabledTextColor : textColor}
                     >

--- a/suite-native/atoms/src/Pictogram.tsx
+++ b/suite-native/atoms/src/Pictogram.tsx
@@ -102,11 +102,11 @@ export const Pictogram = ({
             {title && (
                 <VStack alignItems="center">
                     <Box>
-                        <Text variant={titleVariant} align="center">
+                        <Text variant={titleVariant} textAlign="center">
                             {title}
                         </Text>
                     </Box>
-                    <Text color="textSubdued" align="center">
+                    <Text color="textSubdued" textAlign="center">
                         {subtitle}
                     </Text>
                 </VStack>

--- a/suite-native/atoms/src/Text.tsx
+++ b/suite-native/atoms/src/Text.tsx
@@ -8,14 +8,14 @@ import { TestProps } from './types';
 export interface TextProps extends Omit<RNTextProps, 'style'>, TestProps {
     variant?: TypographyStyle;
     color?: Color;
-    align?: TextStyle['textAlign'];
+    textAlign?: TextStyle['textAlign'];
     style?: NativeStyleObject;
 }
 
 type TextStyleProps = {
     variant: TypographyStyle;
     color: Color;
-    align: TextStyle['textAlign'];
+    textAlign: TextStyle['textAlign'];
 };
 
 export const TITLE_MAX_FONT_MULTIPLIER = 1.5;
@@ -46,16 +46,16 @@ const variantToMaxFontSizeMultiplier = {
     label: TEXT_MAX_FONT_MULTIPLIER,
 } as const satisfies Record<TypographyStyle, number>;
 
-const textStyle = prepareNativeStyle<TextStyleProps>((utils, { variant, color, align }) => ({
+const textStyle = prepareNativeStyle<TextStyleProps>((utils, { variant, color, textAlign }) => ({
     ...utils.typography[variant],
     color: utils.colors[color],
-    textAlign: align,
+    textAlign,
 }));
 
 export const Text = ({
     variant = 'body',
     color = 'textDefault',
-    align = 'left',
+    textAlign = 'left',
     style,
     children,
     ...otherProps
@@ -64,7 +64,7 @@ export const Text = ({
     const maxFontSizeMultiplier = variantToMaxFontSizeMultiplier[variant];
     return (
         <RNText
-            style={[applyStyle(textStyle, { variant, color, align }), style]}
+            style={[applyStyle(textStyle, { variant, color, textAlign }), style]}
             maxFontSizeMultiplier={maxFontSizeMultiplier}
             {...otherProps}
         >

--- a/suite-native/graph/src/components/GraphError.tsx
+++ b/suite-native/graph/src/components/GraphError.tsx
@@ -7,10 +7,10 @@ type GraphErrorProps = {
 
 export const GraphError = ({ error, onTryAgain }: GraphErrorProps) => (
     <VStack spacing="small" alignItems="center">
-        <Text variant="label" color="textSubdued" align="center">
+        <Text variant="label" color="textSubdued" textAlign="center">
             There are some troubles with loading graph points: {error}
         </Text>
-        <Text variant="body" color="textSecondaryHighlight" align="center" onPress={onTryAgain}>
+        <Text variant="body" color="textSecondaryHighlight" textAlign="center" onPress={onTryAgain}>
             Try again
         </Text>
     </VStack>

--- a/suite-native/module-accounts-import/src/components/XpubHintBottomSheet.tsx
+++ b/suite-native/module-accounts-import/src/components/XpubHintBottomSheet.tsx
@@ -76,7 +76,7 @@ export const XpubHintBottomSheet = ({
             <Box paddingTop="small" justifyContent="space-between">
                 <Video name={video} aspectRatio={1} />
                 <VStack spacing="large" paddingTop="large">
-                    <Text color="textSubdued" align="center" variant="hint">
+                    <Text color="textSubdued" textAlign="center" variant="hint">
                         {text}
                     </Text>
                 </VStack>

--- a/suite-native/module-onboarding/src/components/OnboardingFooter.tsx
+++ b/suite-native/module-onboarding/src/components/OnboardingFooter.tsx
@@ -48,7 +48,7 @@ export const OnboardingFooter = ({ redirectTarget, isLastStep = false }: Onboard
     return (
         <Stack spacing="large" style={applyStyle(wrapperStyle)}>
             <Box flexDirection="row" alignItems="center" justifyContent="center">
-                <Text variant="hint" align="center">
+                <Text variant="hint" textAlign="center">
                     Don’t have a Trezor? <Link href="https://trezor.io/" label="Get one here." />
                 </Text>
             </Box>

--- a/suite-native/module-onboarding/src/screens/WelcomeScreen.tsx
+++ b/suite-native/module-onboarding/src/screens/WelcomeScreen.tsx
@@ -60,7 +60,7 @@ export const WelcomeScreen = () => {
                                 Welcome to <TrezorSuiteLiteHeader textVariant="titleMedium" />
                             </Text>
                         </Box>
-                        <Text color="textSubdued" align="center">
+                        <Text color="textSubdued" textAlign="center">
                             Simple and secure portfolio tracker
                         </Text>
                     </Box>

--- a/suite-native/module-settings/src/components/AboutUsBanners.tsx
+++ b/suite-native/module-settings/src/components/AboutUsBanners.tsx
@@ -30,7 +30,7 @@ export const AboutUsBanners = () => {
                 <VStack spacing="large" style={applyStyle(stackStyle)}>
                     <Icon color="iconOnPrimary" name="trezor" />
                     <Text
-                        align="center"
+                        textAlign="center"
                         color="textOnPrimary"
                         variant="titleSmall"
                         style={applyStyle(trezorDescriptionTextStyle)}

--- a/suite-native/navigation/src/components/TabBarItem.tsx
+++ b/suite-native/navigation/src/components/TabBarItem.tsx
@@ -55,7 +55,7 @@ export const TabBarItem = ({ isFocused, onPress, iconName, title }: TabBarItemPr
                     <Text
                         maxFontSizeMultiplier={TITLE_MAX_FONT_MULTIPLIER}
                         variant="label"
-                        align="center"
+                        textAlign="center"
                         color={isFocused ? 'textPrimaryDefault' : 'textDisabled'}
                     >
                         {title}

--- a/suite-native/qr-code/src/components/AddressQRCode.tsx
+++ b/suite-native/qr-code/src/components/AddressQRCode.tsx
@@ -40,7 +40,7 @@ export const AddressQRCode = ({ address, backgroundElevation = '0' }: AddressQRC
         <VStack spacing="large">
             <QRCode data={address} />
             <Box alignItems="center" justifyContent="center">
-                <Text variant="titleSmall" align="center">
+                <Text variant="titleSmall" textAlign="center">
                     {formattedAddress}
                 </Text>
             </Box>

--- a/suite-native/qr-code/src/components/CameraPermissionError.tsx
+++ b/suite-native/qr-code/src/components/CameraPermissionError.tsx
@@ -18,8 +18,8 @@ export const CameraPermissionError = ({ onPermissionRequest }: CameraPermissionE
 
     return (
         <Box style={applyStyle(permissionTextContainerStyle)}>
-            <Text align="center">Camera access denied.</Text>
-            <Text align="center">Please allow camera access in your device settings.</Text>
+            <Text textAlign="center">Camera access denied.</Text>
+            <Text textAlign="center">Please allow camera access in your device settings.</Text>
 
             <Button onPress={onPermissionRequest} style={applyStyle(grantPermissionButtonStyle)}>
                 Grant permission

--- a/suite-native/qr-code/src/components/XpubQRCodeCard.tsx
+++ b/suite-native/qr-code/src/components/XpubQRCodeCard.tsx
@@ -28,7 +28,7 @@ export const XpubQRCodeCard = ({
                 <>
                     <QRCode data={qrCodeData} />
                     <Box margin="small" alignItems="center" justifyContent="center">
-                        <Text align="center">{qrCodeData}</Text>
+                        <Text textAlign="center">{qrCodeData}</Text>
                     </Box>
                 </>
             ) : (


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
It doesn't make sense to have `align` instead of `textAlign`, which is more expected. I tried to use it and wasn't there and didn't realise that it's align. Same assumption is then happening on code review so let's just change it for better DX.
<img width="843" alt="image" src="https://github.com/trezor/trezor-suite/assets/36101761/1425e9fd-7b9b-47f1-8131-dc1d0b4cf3f7">


## Related Issue

Resolve <!--- link the issue here -->

## Screenshots:
