### PR TITLE
fix(suite): update on quit

### DIFF
--- a/packages/suite-desktop-ui/src/support/DesktopUpdater/Ready.tsx
+++ b/packages/suite-desktop-ui/src/support/DesktopUpdater/Ready.tsx
@@ -30,7 +30,7 @@ export const Ready = ({ hideWindow, isCancelable }: ReadyProps) => {
 
     const install = () => dispatch(installUpdate());
     const installOnQuit = () => {
-        install();
+        dispatch(installUpdate(true));
         hideWindow();
     };
 


### PR DESCRIPTION
In recent refactor we lost a prop in `installUpdate` function so there was no difference between `Update on quit` and `Restart & update`

## Description

Update on quit does what should.

## Related Issue

Resolve #9376 
