### PR TITLE
feat(solana) display solana account details

### DIFF
--- a/packages/suite/src/actions/wallet/publicKeyActions.ts
+++ b/packages/suite/src/actions/wallet/publicKeyActions.ts
@@ -59,6 +59,9 @@ export const showXpub = () => async (dispatch: Dispatch, getState: GetState) => 
         case 'cardano':
             response = await TrezorConnect.cardanoGetPublicKey(params);
             break;
+        case 'solana':
+            response = await TrezorConnect.solanaGetPublicKey(params);
+            break;
         default:
             response = {
                 success: false,

--- a/packages/suite/src/components/wallet/AccountTopPanel/AccountNavigation.tsx
+++ b/packages/suite/src/components/wallet/AccountTopPanel/AccountNavigation.tsx
@@ -46,7 +46,7 @@ export const AccountNavigation = ({
             },
             title: <Translation id="TR_NAV_DETAILS" />,
             position: 'primary',
-            isHidden: !['cardano', 'bitcoin'].includes(networkType),
+            isHidden: !['cardano', 'bitcoin', 'solana'].includes(networkType),
         },
         {
             id: 'wallet-tokens',

--- a/packages/suite/src/support/messages.ts
+++ b/packages/suite/src/support/messages.ts
@@ -3741,6 +3741,18 @@ export default defineMessages({
         id: 'TR_ACCOUNT_TYPE_BIP44_TECH',
         defaultMessage: 'BIP44, P2PKH, Base58',
     },
+    TR_ACCOUNT_TYPE_SOLANA_BIP44_CHANGE_NAME: {
+        id: 'TR_ACCOUNT_TYPE_SOLANA_BIP44_CHANGE_NAME',
+        defaultMessage: 'Bip44Change',
+    },
+    TR_ACCOUNT_TYPE_SOLANA_BIP44_CHANGE_TECH: {
+        id: 'TR_ACCOUNT_TYPE_SOLANA_BIP44_CHANGE_TECH',
+        defaultMessage: 'BIP44, Base58',
+    },
+    TR_ACCOUNT_TYPE_SOLANA_BIP44_CHANGE_DESC: {
+        id: 'TR_ACCOUNT_TYPE_SOLANA_BIP44_CHANGE_DESC',
+        defaultMessage: 'Bip44Change account',
+    },
     TR_ACCOUNT_TYPE_SLIP25_NAME: {
         id: 'TR_ACCOUNT_TYPE_SLIP25_NAME',
         defaultMessage: 'Coinjoin',

--- a/suite-common/connect-init/src/connectInitThunks.ts
+++ b/suite-common/connect-init/src/connectInitThunks.ts
@@ -56,6 +56,7 @@ export const connectInitThunk = createThunk(
             'ethereumGetAddress',
             'rippleGetAddress',
             'cardanoGetAddress',
+            'solanaGetPublicKey',
             'applySettings',
             'changePin',
             'pushTransaction',

--- a/suite-common/wallet-config/src/networksConfig.ts
+++ b/suite-common/wallet-config/src/networksConfig.ts
@@ -420,7 +420,7 @@ export const networks = {
     sol: {
         name: 'Solana',
         networkType: 'solana',
-        bip43Path: "m/44'/501'/i'/0'", // TODO(vl): accounts and paths
+        bip43Path: "m/44'/501'/i'/0'",
         decimals: 9,
         testnet: false,
         // features: ['tokens', 'staking'],
@@ -433,9 +433,7 @@ export const networks = {
             [DeviceModelInternal.T2T1]: '2.4.3', // TODO(vl): revisit, for now just anything above 2.0.0
         },
         customBackends: ['solana'],
-        accountTypes: {
-            // TODO(vl): accounts and paths
-        },
+        accountTypes: {},
     },
 } as const;
 

--- a/suite-common/wallet-utils/src/accountUtils.ts
+++ b/suite-common/wallet-utils/src/accountUtils.ts
@@ -169,6 +169,18 @@ export const getTitleForNetwork = (symbol: NetworkSymbol) => {
     }
 };
 
+export const getAccountTypePrefix = (path: string) => {
+    if (typeof path !== 'string') return null;
+    const coinType = path.split('/')[2];
+    switch (coinType) {
+        case `501'`: {
+            return 'TR_ACCOUNT_TYPE_SOLANA_BIP44_CHANGE';
+        }
+        default:
+            return null;
+    }
+};
+
 export const getBip43Type = (path: string) => {
     if (typeof path !== 'string') return 'unknown';
     // https://github.com/bitcoin/bips/blob/master/bip-0043.mediawiki
@@ -192,6 +204,8 @@ export const getBip43Type = (path: string) => {
 };
 
 export const getAccountTypeName = (path: string) => {
+    const accountTypePrefix = getAccountTypePrefix(path);
+    if (accountTypePrefix) return `${accountTypePrefix}_NAME` as const;
     const bip43 = getBip43Type(path);
     if (bip43 === 'bip86') return 'TR_ACCOUNT_TYPE_BIP86_NAME';
     if (bip43 === 'bip84') return 'TR_ACCOUNT_TYPE_BIP84_NAME';
@@ -202,6 +216,8 @@ export const getAccountTypeName = (path: string) => {
 };
 
 export const getAccountTypeTech = (path: string) => {
+    const accountTypePrefix = getAccountTypePrefix(path);
+    if (accountTypePrefix) return `${accountTypePrefix}_TECH` as const;
     const bip43 = getBip43Type(path);
     if (bip43 === 'bip86') return 'TR_ACCOUNT_TYPE_BIP86_TECH';
     if (bip43 === 'bip84') return 'TR_ACCOUNT_TYPE_BIP84_TECH';
@@ -212,6 +228,8 @@ export const getAccountTypeTech = (path: string) => {
 };
 
 export const getAccountTypeDesc = (path: string) => {
+    const accountTypePrefix = getAccountTypePrefix(path);
+    if (accountTypePrefix) return `${accountTypePrefix}_DESC` as const;
     const bip43 = getBip43Type(path);
     if (bip43 === 'bip86') return 'TR_ACCOUNT_TYPE_BIP86_DESC';
     if (bip43 === 'bip84') return 'TR_ACCOUNT_TYPE_BIP84_DESC';


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Notes
- It works with [this branch](https://github.com/vacuumlabs/trezor-firmware/tree/solana-poc) in the Vacuumlabs’ Trezor firmware fork
- use `file obscure frog dance chunk panda honey obvious fault match unable always` mnemonic to see all kinds of accounts

## Description

This PR
 - adds a other types of solana accounts
