### PR TITLE
feat(suite-native): discovery middleware

### DIFF
--- a/suite-common/wallet-core/src/device/deviceReducer.ts
+++ b/suite-common/wallet-core/src/device/deviceReducer.ts
@@ -493,6 +493,25 @@ export const selectDeviceState = (state: DeviceRootState) => {
 export const selectDiscoveryForDevice = (state: DiscoveryRootState & { device: State }) =>
     selectDiscoveryByDeviceState(state, state.device.selectedDevice?.state);
 
+export const selectIsDeviceDiscoveryActive = (state: DiscoveryRootState & DeviceRootState) => {
+    const discovery = selectDiscoveryForDevice(state);
+
+    if (!discovery) return false;
+
+    return (
+        discovery.status === DiscoveryStatus.RUNNING ||
+        discovery.status === DiscoveryStatus.STOPPING
+    );
+};
+
+export const selectIsDeviceReadyForDiscovery = (state: DiscoveryRootState & DeviceRootState) => {
+    const device = selectDevice(state);
+
+    if (!device) return false;
+
+    return device.connected && !device.authFailed && !device.authConfirm;
+};
+
 /**
  * Helper selector called from components
  * return `true` if discovery process is running/completed and `authConfirm` is required

--- a/suite-common/wallet-core/src/discovery/discoveryThunks.ts
+++ b/suite-common/wallet-core/src/discovery/discoveryThunks.ts
@@ -22,6 +22,7 @@ import {
 import { selectDiscoveryByDeviceState, selectDiscovery } from './discoveryReducer';
 import { selectAccounts } from '../accounts/accountsReducer';
 import { accountsActions } from '../accounts/accountsActions';
+import { selectDevice, selectDevices, selectDiscoveryForDevice } from '../device/deviceReducer';
 
 type ProgressEvent = BundleProgress<AccountInfo | null>['payload'];
 
@@ -145,10 +146,7 @@ const handleProgressThunk = createThunk(
 
 export const stopDiscoveryThunk = createThunk(
     `${DISCOVERY_MODULE_PREFIX}/stop`,
-    (_, { dispatch, getState, extra }) => {
-        const {
-            selectors: { selectDiscoveryForDevice },
-        } = extra;
+    (_, { dispatch, getState }) => {
         const discovery = selectDiscoveryForDevice(getState());
         if (discovery && discovery.running) {
             dispatch(
@@ -311,7 +309,7 @@ export const startDiscoveryThunk = createThunk(
     `${DISCOVERY_MODULE_PREFIX}/start`,
     async (_, { dispatch, getState, extra }): Promise<void> => {
         const {
-            selectors: { selectMetadata, selectDevice, selectDiscoveryForDevice },
+            selectors: { selectMetadata },
             thunks: { initMetadata, fetchAndSaveMetadata },
             actions: { requestAuthConfirm },
         } = extra;
@@ -611,7 +609,7 @@ export const updateNetworkSettingsThunk = createThunk(
     `${DISCOVERY_MODULE_PREFIX}/updateNetworkSettings`,
     (_, { dispatch, getState, extra }) => {
         const {
-            selectors: { selectEnabledNetworks, selectDevices },
+            selectors: { selectEnabledNetworks },
         } = extra;
         const enabledNetworks = selectEnabledNetworks(getState());
         const discovery = selectDiscovery(getState());
@@ -641,10 +639,7 @@ export const updateNetworkSettingsThunk = createThunk(
 
 export const restartDiscoveryThunk = createThunk(
     `${DISCOVERY_MODULE_PREFIX}/restart`,
-    async (_, { dispatch, getState, extra }) => {
-        const {
-            selectors: { selectDiscoveryForDevice },
-        } = extra;
+    async (_, { dispatch, getState }) => {
         const discovery = selectDiscoveryForDevice(getState());
         if (!discovery) return;
         const progress = dispatch(

--- a/suite-native/discovery/package.json
+++ b/suite-native/discovery/package.json
@@ -1,0 +1,19 @@
+{
+    "name": "@suite-native/discovery",
+    "version": "1.0.0",
+    "private": true,
+    "license": "See LICENSE.md in repo root",
+    "sideEffects": false,
+    "main": "src/index",
+    "scripts": {
+        "lint:js": "yarn g:eslint '**/*.{ts,tsx,js}'",
+        "type-check": "tsc --build"
+    },
+    "dependencies": {
+        "@reduxjs/toolkit": "1.9.5",
+        "@suite-common/redux-utils": "workspace:*",
+        "@suite-common/suite-types": "workspace:*",
+        "@suite-common/wallet-constants": "workspace:*",
+        "@suite-common/wallet-core": "workspace:*"
+    }
+}

--- a/suite-native/discovery/src/discoveryMiddleware.ts
+++ b/suite-native/discovery/src/discoveryMiddleware.ts
@@ -1,0 +1,36 @@
+import { deviceActions, selectDevice, discoveryActions } from '@suite-common/wallet-core';
+import { createMiddlewareWithExtraDeps } from '@suite-common/redux-utils';
+
+import { createAndStartDiscoveryThunk } from './discoveryThunks';
+
+export const prepareDiscoveryMiddleware = createMiddlewareWithExtraDeps(
+    (action, { dispatch, next, getState }) => {
+        if (deviceActions.forgetDevice.match(action) && action.payload.state) {
+            dispatch(discoveryActions.removeDiscovery(action.payload.state));
+        }
+
+        const device = selectDevice(getState());
+
+        // On successful authorization, create discovery instance and run.
+        if (deviceActions.authDevice.match(action) && device) {
+            dispatch(
+                createAndStartDiscoveryThunk({
+                    deviceState: action.payload.state,
+                    device,
+                }),
+            );
+        }
+
+        // Update discovery for pass-phrased wallets.
+        if (deviceActions.receiveAuthConfirm.match(action) && action.payload.device.state) {
+            dispatch(
+                discoveryActions.updateDiscovery({
+                    deviceState: action.payload.device.state,
+                    authConfirm: false,
+                }),
+            );
+        }
+
+        return next(action);
+    },
+);

--- a/suite-native/discovery/src/discoveryThunks.ts
+++ b/suite-native/discovery/src/discoveryThunks.ts
@@ -1,0 +1,24 @@
+import { createThunk } from '@suite-common/redux-utils';
+import { TrezorDevice } from '@suite-common/suite-types';
+import {
+    createDiscoveryThunk,
+    DISCOVERY_MODULE_PREFIX,
+    startDiscoveryThunk,
+} from '@suite-common/wallet-core';
+
+export const createAndStartDiscoveryThunk = createThunk(
+    `${DISCOVERY_MODULE_PREFIX}/createAndStart`,
+    async (
+        { deviceState, device }: { deviceState: string; device: TrezorDevice },
+        { dispatch },
+    ) => {
+        await dispatch(
+            createDiscoveryThunk({
+                deviceState,
+                device,
+            }),
+        );
+
+        dispatch(startDiscoveryThunk());
+    },
+);

--- a/suite-native/discovery/src/index.ts
+++ b/suite-native/discovery/src/index.ts
@@ -1,0 +1,1 @@
+export { prepareDiscoveryMiddleware } from './discoveryMiddleware';

--- a/suite-native/discovery/tsconfig.json
+++ b/suite-native/discovery/tsconfig.json
@@ -1,0 +1,18 @@
+{
+    "extends": "../../tsconfig.json",
+    "compilerOptions": { "outDir": "libDev" },
+    "references": [
+        {
+            "path": "../../suite-common/redux-utils"
+        },
+        {
+            "path": "../../suite-common/suite-types"
+        },
+        {
+            "path": "../../suite-common/wallet-constants"
+        },
+        {
+            "path": "../../suite-common/wallet-core"
+        }
+    ]
+}

--- a/suite-native/state/package.json
+++ b/suite-native/state/package.json
@@ -20,6 +20,7 @@
         "@suite-common/wallet-core": "workspace:*",
         "@suite-native/config": "workspace:*",
         "@suite-native/device": "workspace:*",
+        "@suite-native/discovery": "workspace:*",
         "@suite-native/fiat-rates": "workspace:*",
         "@suite-native/graph": "workspace:*",
         "@suite-native/logger": "workspace:*",

--- a/suite-native/state/src/reducers.ts
+++ b/suite-native/state/src/reducers.ts
@@ -4,6 +4,7 @@ import {
     prepareAccountsReducer,
     prepareBlockchainReducer,
     prepareDeviceReducer,
+    prepareDiscoveryReducer,
     prepareTransactionsReducer,
 } from '@suite-common/wallet-core';
 import { prepareFiatRatesReducer } from '@suite-native/fiat-rates';
@@ -25,6 +26,7 @@ const blockchainReducer = prepareBlockchainReducer(extraDependencies);
 const analyticsReducer = prepareAnalyticsReducer(extraDependencies);
 const messageSystem = prepareMessageSystemReducer(extraDependencies);
 const deviceReducer = prepareDeviceReducer(extraDependencies);
+const discoveryReducer = prepareDiscoveryReducer(extraDependencies);
 
 export const prepareRootReducers = async () => {
     const appSettingsPersistedReducer = await preparePersistReducer({
@@ -39,6 +41,7 @@ export const prepareRootReducers = async () => {
         blockchain: blockchainReducer,
         fiat: fiatRatesReducer,
         transactions: transactionsReducer,
+        discovery: discoveryReducer,
     });
 
     const walletPersistedReducer = await preparePersistReducer({

--- a/suite-native/state/src/store.ts
+++ b/suite-native/state/src/store.ts
@@ -7,6 +7,7 @@ import { logsMiddleware as nativeLogsMiddleware } from '@suite-native/logger';
 import { messageSystemMiddleware } from '@suite-native/message-system';
 import { prepareBlockchainMiddleware } from '@suite-common/wallet-core';
 import { prepareButtonRequestMiddleware, prepareDeviceMiddleware } from '@suite-native/device';
+import { prepareDiscoveryMiddleware } from '@suite-native/discovery';
 
 import { extraDependencies } from './extraDependencies';
 import { prepareRootReducers } from './reducers';
@@ -19,6 +20,7 @@ const middlewares: Middleware[] = [
     logsMiddleware,
     prepareDeviceMiddleware(extraDependencies),
     prepareButtonRequestMiddleware(extraDependencies),
+    prepareDiscoveryMiddleware(extraDependencies),
 ];
 
 if (__DEV__) {

--- a/suite-native/state/tsconfig.json
+++ b/suite-native/state/tsconfig.json
@@ -23,6 +23,7 @@
         },
         { "path": "../config" },
         { "path": "../device" },
+        { "path": "../discovery" },
         { "path": "../fiat-rates" },
         { "path": "../graph" },
         { "path": "../logger" },

--- a/yarn.lock
+++ b/yarn.lock
@@ -8190,6 +8190,18 @@ __metadata:
   languageName: unknown
   linkType: soft
 
+"@suite-native/discovery@workspace:*, @suite-native/discovery@workspace:suite-native/discovery":
+  version: 0.0.0-use.local
+  resolution: "@suite-native/discovery@workspace:suite-native/discovery"
+  dependencies:
+    "@reduxjs/toolkit": 1.9.5
+    "@suite-common/redux-utils": "workspace:*"
+    "@suite-common/suite-types": "workspace:*"
+    "@suite-common/wallet-constants": "workspace:*"
+    "@suite-common/wallet-core": "workspace:*"
+  languageName: unknown
+  linkType: soft
+
 "@suite-native/ethereum-tokens@workspace:*, @suite-native/ethereum-tokens@workspace:suite-native/ethereum-tokens":
   version: 0.0.0-use.local
   resolution: "@suite-native/ethereum-tokens@workspace:suite-native/ethereum-tokens"
@@ -8755,6 +8767,7 @@ __metadata:
     "@suite-common/wallet-core": "workspace:*"
     "@suite-native/config": "workspace:*"
     "@suite-native/device": "workspace:*"
+    "@suite-native/discovery": "workspace:*"
     "@suite-native/fiat-rates": "workspace:*"
     "@suite-native/graph": "workspace:*"
     "@suite-native/logger": "workspace:*"


### PR DESCRIPTION
## Description

- `@suite-native/discovery` package created
- native `discoveryMiddleware` that observes device actions and when the device is ready, it automatically initializes and starts discovery

> ❗️Caution! If you would like to try this branch yourself, it won't work. I had to change some device-related files to make it running. These changes are not pushed as part of this PR since they are just some ugly workarounds. The epic issue #9181 is responsible for the proper implementation of the new device-related logic. If you wanna try this branch yourself, let me know and I will show you how. 

## Related Issue

Closes #9462

## Screenshots:

https://github.com/trezor/trezor-suite/assets/26143964/1028aaf5-4654-4dc5-859c-f623c54c99bf

