### PR TITLE
fix(suite): update useEmptyPassphrase only if passhprase is disabled on device [RELEASE ONLY]

### DIFF
--- a/packages/suite/src/reducers/suite/deviceReducer.ts
+++ b/packages/suite/src/reducers/suite/deviceReducer.ts
@@ -177,13 +177,18 @@ const changeDevice = (
                     : !!device.features.passphrase_protection;
                 return merge(d, { ...device, ...extended, available });
             }
-            if (!d.state && !isUnlocked(d.features) && isDeviceUnlocked) {
-                // if is not authorized (no state) and becomes unlocked update useEmptyPassphrase field (hidden/standard wallet)
+            if (
+                !d.state &&
+                !device.features.passphrase_protection &&
+                !isUnlocked(d.features) &&
+                isDeviceUnlocked
+            ) {
+                // if device with passhprase disabled is not authorized (no state) and becomes unlocked update useEmptyPassphrase field (hidden/standard wallet)
                 return merge(d, {
                     ...device,
                     ...extended,
                     available: true,
-                    useEmptyPassphrase: !device.features.passphrase_protection,
+                    useEmptyPassphrase: true,
                 });
             }
             return merge(d, { ...device, ...extended });


### PR DESCRIPTION

<!--- Provide a general summary of your changes in the Title above -->

## Description

That condition fixing only case for devices with passhprase disabled and should not be applied for devices with passhprase_protection enabled because passhprase_protection == true doesn't mean that hidden wallet is active.

followup of https://github.com/trezor/trezor-suite/pull/9180 and followup of followup https://github.com/trezor/trezor-suite/pull/9291

## Related Issue

Resolve https://github.com/trezor/trezor-suite/issues/9502


