### PR TITLE
@trezor/connect in webextension serviceworker

### DIFF
--- a/ci/build.yml
+++ b/ci/build.yml
@@ -259,11 +259,14 @@ connect-web build:
     - ./packages/connect-web/scripts/check-inline-build-size.sh
     - yarn workspace @trezor/connect-iframe build
     - yarn workspace @trezor/connect-popup build
+    - yarn workspace @trezor/connect-explorer-webextension build
     # build webextension examples with latest trezor.io and latest npm package
     - node ./packages/connect-examples/update-webextensions.js --trezor-connect-src "https://suite.corp.sldev.cz/connect/${CI_COMMIT_REF_NAME}/"
     # build webextension examples with latest trezor.io and outdated npm package (current production)
     - node ./packages/connect-examples/update-webextensions.js --trezor-connect-src "https://suite.corp.sldev.cz/connect/${CI_COMMIT_REF_NAME}/" --build-folder build-legacy --npm-src "https://connect.trezor.io/9/trezor-connect.js"
-    - yarn workspace @trezor/connect-explorer-webextension build
+    # build webextension example using @trezor/connect-webextension package
+    - yarn workspace @trezor/connect-webextension build
+    - node ./packages/connect-examples/update-webextensions-sw.js
 
   artifacts:
     expire_in: 14 days
@@ -275,6 +278,7 @@ connect-web build:
       - packages/connect-examples/webextension-mv2/build-legacy
       - packages/connect-examples/webextension-mv3/build
       - packages/connect-examples/webextension-mv3/build-legacy
+      - packages/connect-examples/webextension-mv3-sw/build
       - packages/connect-explorer-webextension/build
 
 # Build components

--- a/ci/test.yml
+++ b/ci/test.yml
@@ -237,8 +237,8 @@ connect-popup:
   dependencies:
     - install
     - connect-web build
-  only:
-    <<: *run_everything_rules
+  # only:
+  #   <<: *run_everything_rules
 
 connect-popup manual:
   extends: .e2e connect-popup

--- a/packages/connect-common/package.json
+++ b/packages/connect-common/package.json
@@ -36,7 +36,8 @@
         "prepublish": "yarn tsx ../../scripts/prepublish.js"
     },
     "dependencies": {
-        "@trezor/env-utils": "workspace:*"
+        "@trezor/env-utils": "workspace:*",
+        "@trezor/utils": "workspace:*"
     },
     "devDependencies": {
         "jest": "^26.6.3",

--- a/packages/connect-common/src/messageChannel/abstract.ts
+++ b/packages/connect-common/src/messageChannel/abstract.ts
@@ -1,0 +1,183 @@
+/**
+ * IMPORTS WARNING
+ * this file is bundled into content script so be careful what you are importing not to bloat the bundle
+ */
+
+import { Deferred, createDeferred } from '@trezor/utils/lib/createDeferred';
+import { TypedEmitter } from '@trezor/utils/lib/typedEventEmitter';
+
+// todo: I can't import Log from connect to connect-common (connect imports from connect-common).
+// so logger should be probably moved to connect common, or this file should be moved to connect
+// import type { Log } from '@trezor/connect/lib/utils/debug';
+type Log = any;
+
+export interface AbstractMessageChannelConstructorParams {
+    sendFn: (message: any) => void;
+    channel: {
+        here: string;
+        peer: string[];
+    };
+    logger?: Log;
+}
+
+export type Message<IncomingMessages extends { type: string }> = {
+    channel: AbstractMessageChannelConstructorParams['channel'];
+    id: number;
+    type: IncomingMessages['type'];
+    payload: IncomingMessages;
+    success: boolean;
+};
+
+/**
+ * concepts:
+ * - it handshakes automatically with the other side of the channel
+ * - it queues messages fired before handshake and sends them after handshake is done
+ */
+export abstract class AbstractMessageChannel<
+    IncomingMessages extends { type: string },
+> extends TypedEmitter<{
+    message: Message<IncomingMessages>;
+}> {
+    protected messagePromises: Record<number, Deferred<any>> = {};
+    /** queue of messages that were scheduled before handshake */
+    protected messagesQueue: any[] = [];
+    protected messageID = 0;
+
+    abstract disconnect(): void;
+
+    private handshakeCurrentRetry = 0;
+    private handshakeMaxRetries = 5;
+    private handshakeRetryInterval = 2000;
+    private handshakeFinished: Deferred<void> | undefined;
+
+    protected logger?: Log;
+
+    /**
+     * function that passes data to the other side of the channel
+     */
+    sendFn: AbstractMessageChannelConstructorParams['sendFn'];
+    /**
+     * channel identifiers that pairs AbstractMessageChannel instances on sending and receiving end together
+     */
+    channel: AbstractMessageChannelConstructorParams['channel'];
+
+    constructor({ sendFn, channel, logger }: AbstractMessageChannelConstructorParams) {
+        super();
+        this.channel = channel;
+        this.sendFn = (message: any) => {
+            try {
+                message.channel = this.channel;
+                sendFn(message);
+            } catch (err) {
+                this.messagesQueue.push(message);
+            }
+        };
+        this.logger = logger;
+    }
+
+    /**
+     * initiates handshake sequence with peer. resolves after communication with peer is established
+     */
+    public async init() {
+        if (this.handshakeFinished?.promise) {
+            await this.handshakeFinished.promise;
+        } else {
+            await this.handshakeWithPeer();
+        }
+    }
+
+    /**
+     * handshake between both parties of the channel.
+     * both parties initiate handshake procedure and keep asking over time in a loop until they time out or receive confirmation from peer
+     */
+    protected handshakeWithPeer(): Promise<void> {
+        this.logger?.log(this.channel.here, 'handshake, retry: ', this.handshakeCurrentRetry);
+        this.handshakeFinished = createDeferred();
+
+        this.sendFn({
+            type: 'channel-handshake-request',
+            channel: this.channel,
+            data: { success: true, payload: undefined },
+        });
+
+        return Promise.race([
+            this.handshakeFinished.promise,
+            new Promise((_resolve, reject) => {
+                setTimeout(() => {
+                    reject(new Error('handshake timeout'));
+                }, this.handshakeRetryInterval);
+            }),
+        ])
+            .then(() => {
+                this.logger?.log(this.channel.here, 'handshake confirmed');
+                this.messagesQueue.forEach(message => this.sendFn(message));
+                this.messagesQueue = [];
+
+                this.handshakeFinished!.resolve();
+            })
+            .catch(() => {
+                this.handshakeCurrentRetry++;
+                if (this.handshakeCurrentRetry < this.handshakeMaxRetries) {
+                    return this.handshakeWithPeer();
+                }
+                throw new Error('handshake failed');
+            });
+    }
+
+    /**
+     * message received from communication channel in descendants of this class
+     * should be handled by this common onMessage method
+     */
+    protected onMessage(message: Message<IncomingMessages>) {
+        const { channel, id, type, payload, success } = message;
+
+        if (!channel?.peer || !channel.peer.includes(this.channel.here)) {
+            return;
+        }
+        if (!channel?.here || !this.channel.peer.includes(channel.here)) {
+            return;
+        }
+
+        if (type === 'channel-handshake-request') {
+            this.sendFn({
+                type: 'channel-handshake-confirm',
+                channel: this.channel,
+                data: { success: true, payload: undefined },
+            });
+            return;
+        }
+        if (type === 'channel-handshake-confirm') {
+            this.handshakeFinished?.resolve(undefined);
+            return;
+        }
+
+        if (this.messagePromises[id]) {
+            this.messagePromises[id].resolve({ id, payload, success });
+            delete this.messagePromises[id];
+        }
+        const messagePromisesLength = Object.keys(this.messagePromises).length;
+        if (messagePromisesLength > 5) {
+            this.logger.warn(
+                `too many message promises (${messagePromisesLength}). this feels unexpected!`,
+            );
+        }
+
+        this.emit('message', message);
+    }
+
+    // todo: outgoing messages should be typed
+    postMessage(message: any, usePromise = true) {
+        if (!usePromise) {
+            this.sendFn(message);
+            return;
+        }
+
+        this.messageID++;
+        message.id = this.messageID;
+        this.messagePromises[message.id] = createDeferred();
+
+        this.sendFn(message);
+
+        return this.messagePromises[message.id].promise;
+    }
+}

--- a/packages/connect-common/tsconfig.json
+++ b/packages/connect-common/tsconfig.json
@@ -2,5 +2,8 @@
     "extends": "../../tsconfig.json",
     "compilerOptions": { "outDir": "./libDev" },
     "include": ["."],
-    "references": [{ "path": "../env-utils" }]
+    "references": [
+        { "path": "../env-utils" },
+        { "path": "../utils" }
+    ]
 }

--- a/packages/connect-examples/update-webextensions-sw.js
+++ b/packages/connect-examples/update-webextensions-sw.js
@@ -1,0 +1,92 @@
+/**
+ * Utility script. Not part of example itself. It only helps put the example together.
+ */
+
+const fs = require('fs');
+const path = require('path');
+const fetch = require('node-fetch');
+
+const rootPaths = ['webextension-mv3-sw'];
+
+const trezorConnectSrcIndex = process.argv.indexOf('--trezor-connect-src');
+const buildFolderIndex = process.argv.indexOf('--build-folder');
+const npmSrcIndex = process.argv.indexOf('--npm-src');
+
+const DEFAULT_SRC = 'https://connect.trezor.io/9/';
+let trezorConnectSrc = DEFAULT_SRC;
+
+if (trezorConnectSrcIndex > -1) {
+    trezorConnectSrc = process.argv[trezorConnectSrcIndex + 1];
+    console.log('trezorConnectSrc: ', trezorConnectSrc);
+}
+
+let buildFolder = 'build';
+if (buildFolderIndex > -1) {
+    buildFolder = process.argv[buildFolderIndex + 1];
+    console.log('buildFolder: ', buildFolder);
+}
+
+let npmSrc = '';
+if (npmSrcIndex > -1) {
+    npmSrc = process.argv[npmSrcIndex + 1];
+    console.log('npmSrc: ', npmSrc);
+}
+
+rootPaths.forEach(dir => {
+    const rootPath = path.join(__dirname, dir);
+    const buildPath = path.join(rootPath, buildFolder);
+    const vendorPath = path.join(buildPath, 'vendor');
+
+    const contentScriptPath = path.join(vendorPath, 'trezor-content-script.js');
+    const backgroundScriptPath = path.join(rootPath, 'background.js');
+
+    fs.rmSync(buildPath, { recursive: true, force: true });
+    if (!fs.existsSync(buildPath)) {
+        fs.mkdirSync(buildPath);
+    }
+    if (!fs.existsSync(vendorPath)) {
+        fs.mkdirSync(vendorPath);
+    }
+
+    const srcPath = path.join(__dirname, '../connect-web');
+
+    if (npmSrc) {
+        fetch(npmSrc).then(res => {
+            const dest = fs.createWriteStream(
+                path.join(rootPath, buildFolder, 'vendor', 'trezor-connect-webextension.js'),
+            );
+            res.body.pipe(dest);
+        });
+    } else {
+        ['trezor-connect-webextension.js'].forEach(p => {
+            fs.copyFileSync(
+                path.join(__dirname, '../connect-webextension', 'build', p),
+                path.join(rootPath, buildFolder, 'vendor', p),
+            );
+        });
+    }
+
+    fs.readdirSync(path.join(rootPath, 'src')).forEach(p => {
+        // Some files like binary `.png` we just want to copy.
+        const isJustCopied = ['.png'].some(ext => p.endsWith(ext));
+        if (isJustCopied) {
+            fs.copyFileSync(path.join(rootPath, 'src', p), path.join(rootPath, buildFolder, p));
+            return;
+        }
+        fs.readFile(path.join(rootPath, 'src', p), 'utf-8', (err, contents) => {
+            if (err) {
+                console.log(err);
+                return;
+            }
+
+            const replaced = contents.replace(DEFAULT_SRC, trezorConnectSrc);
+
+            fs.writeFile(path.join(rootPath, buildFolder, p), replaced, 'utf-8', err => {
+                if (err) {
+                    console.log(err);
+                    return;
+                }
+            });
+        });
+    });
+});

--- a/packages/connect-examples/webextension-mv3-sw/README.md
+++ b/packages/connect-examples/webextension-mv3-sw/README.md
@@ -1,0 +1,25 @@
+# Web extension manifest V3 example using service worker
+
+`@trezor/connect-webextension` running in a `service worker` and communicating with `@trezor/popup` (which loads core logic) through `chrome.runtime` messages.
+
+Tested in Chrome
+
+## Install
+
+Run the commands below in order to get the webextension ready to be loaded in the browser.
+
+-   `yarn`
+-   `yarn build:libs`
+-   `yarn workspace @trezor/connect-webextension build`
+-   `node packages/connect-examples/update-webextensions-sw.js`
+-   `yarn workspace @trezor/connect-popup dev`
+
+This extension is super simple and only reacts to "reload" button.
+
+## Browsers
+
+### Chrome
+
+-   Go to chrome://extensions
+-   Enable developer mode and load unpacked
+-   Choose `packages/connect-examples/webextension-mv3-sw` directory

--- a/packages/connect-examples/webextension-mv3-sw/src/manifest.json
+++ b/packages/connect-examples/webextension-mv3-sw/src/manifest.json
@@ -1,0 +1,10 @@
+{
+    "name": "@trezor/connect web extension mv3 example",
+    "version": "1.0.0",
+    "manifest_version": 3,
+    "background": {
+        "service_worker": "serviceWorker.js"
+    },
+    "permissions": ["tabs", "notifications", "scripting", "activeTab"],
+    "host_permissions": ["http://*/*", "https://*/*"]
+}

--- a/packages/connect-examples/webextension-mv3-sw/src/serviceWorker.js
+++ b/packages/connect-examples/webextension-mv3-sw/src/serviceWorker.js
@@ -1,0 +1,24 @@
+// import connect
+importScripts('vendor/trezor-connect-webextension.js');
+
+// call connect once extension is started. and thats all
+chrome.runtime.onInstalled.addListener(details => {
+    TrezorConnect.init({
+        manifest: {
+            email: 'meow',
+            appUrl: 'http://localhost:8088',
+        },
+        transports: ['BridgeTransport', 'WebUsbTransport'],
+        connectSrc: 'http://localhost:8088/',
+    });
+
+    TrezorConnect.on('DEVICE_EVENT', event => {
+        console.log('EVENT in service worker', event);
+    });
+    TrezorConnect.ethereumGetAddress({
+        path: "m/44'/60'/0'/0/0",
+        showOnTrezor: true,
+    }).then(res => {
+        console.log('RESULT in service worker', res);
+    });
+});

--- a/packages/connect-iframe/package.json
+++ b/packages/connect-iframe/package.json
@@ -6,7 +6,7 @@
         "lint:js": "yarn g:eslint '**/*.{ts,tsx,js}'",
         "build:iframe": "TS_NODE_PROJECT=\"tsconfig.json\" yarn webpack --config ./webpack/prod.webpack.config.ts",
         "build:core-module": "TS_NODE_PROJECT=\"tsconfig.json\" yarn webpack --config ./webpack/core.webpack.config.ts",
-        "build": "rimraf build && yarn build:iframe",
+        "build": "rimraf build && yarn build:iframe && yarn build:core-module",
         "___NOTE__": "iframe build is one of the prerequisites of suite-web. build:lib script provides it together with other libraries",
         "build:lib": "yarn build",
         "type-check": "tsc --build tsconfig.json",

--- a/packages/connect-iframe/src/index.ts
+++ b/packages/connect-iframe/src/index.ts
@@ -1,7 +1,6 @@
 /* eslint-disable no-underscore-dangle, @typescript-eslint/no-use-before-define */
 
 // origin: https://github.com/trezor/connect/blob/develop/src/js/iframe/iframe.js
-
 import {
     CORE_EVENT,
     RESPONSE_EVENT,
@@ -56,6 +55,10 @@ const handleMessage = async (event: PostMessageEvent) => {
     const { data } = event;
     const id = typeof data.id === 'number' ? data.id : 0;
 
+    console.log('==== data.type', data);
+    // novy RESPONSE_ENVET z popupu -> preposle nahore
+    // novy message z popupu prepsni se do zombie modu
+
     const fail = (error: string) => {
         postMessage(createResponseMessage(id, false, { error }));
         postMessage(createPopupMessage(POPUP.CANCEL_POPUP_REQUEST));
@@ -80,6 +83,8 @@ const handleMessage = async (event: PostMessageEvent) => {
         init(data.payload, event.origin);
         return;
     }
+
+    // todo: tady v hanshaku se budou muset poslat vsechny parametry metody + pripadne informace o tom ze iframe je v zombie modu
 
     // popup handshake initialization process, get reference to message channel
     if (data.type === POPUP.HANDSHAKE && event.origin === window.location.origin) {
@@ -318,6 +323,8 @@ const init = async (payload: IFrameInit['payload'], origin: string) => {
         // initialize transport and wait for the first transport event (start or error)
         await initTransport(parsedSettings);
         postMessage(
+            // todo: consider reneming IFRAME.LOADED to CORE.LOADED. now we have multiple modes describing where
+            // core may live.
             createIFrameMessage(IFRAME.LOADED, {
                 useBroadcastChannel: !!_popupMessagePort,
                 systemInfo: getSystemInfo(config.supportedBrowsers),

--- a/packages/connect-popup/package.json
+++ b/packages/connect-popup/package.json
@@ -8,7 +8,8 @@
         "lint:styles": "npx stylelint './src/**/*{.ts,.tsx}' --cache --config ../../.stylelintrc",
         "type-check": "tsc --build",
         "dev": "rimraf build && TS_NODE_PROJECT=\"tsconfig.json\" yarn webpack --config ./webpack/dev.webpack.config.ts",
-        "build": "rimraf build && TS_NODE_PROJECT=\"tsconfig.json\" yarn webpack --config ./webpack/prod.webpack.config.ts",
+        "build:popup": "TS_NODE_PROJECT=\"tsconfig.json\" yarn webpack --config ./webpack/prod.webpack.config.ts",
+        "build": "rimraf build && yarn workspace @trezor/connect-popup build:popup",
         "test:e2e": "yarn xvfb-maybe -- playwright test --config=./e2e/playwright.config.ts",
         "test:unit": "jest"
     },
@@ -17,6 +18,7 @@
         "@trezor/connect": "workspace:*",
         "@trezor/connect-analytics": "workspace:*",
         "@trezor/connect-common": "workspace:*",
+        "@trezor/connect-iframe": "workspace:*",
         "@trezor/connect-ui": "workspace:*",
         "@trezor/crypto-utils": "workspace:*",
         "@trezor/device-utils": "workspace:*",

--- a/packages/connect-popup/src/index.tsx
+++ b/packages/connect-popup/src/index.tsx
@@ -300,8 +300,7 @@ const handleMessageInCoreMode = (
             ...data,
             transport,
         });
-        reactEventBus.dispatch(getState());
-
+        reactEventBus.dispatch({ type: 'state-update', payload: getState() });
         return;
     }
 

--- a/packages/connect-popup/src/index.tsx
+++ b/packages/connect-popup/src/index.tsx
@@ -13,10 +13,15 @@ import {
     PopupInit,
     PopupHandshake,
     MethodResponseMessage,
+    CORE_EVENT,
+    IFrameCallMessage,
     IFrameLogRequest,
     CoreMessage,
 } from '@trezor/connect/lib/exports';
+import { initLog } from '@trezor/connect/lib/utils/debug';
+import type { Core } from '@trezor/connect/lib/core';
 import { config } from '@trezor/connect/lib/data/config';
+import { parseConnectSettings } from '@trezor/connect-iframe/src/connectSettings';
 
 import { reactEventBus } from '@trezor/connect-ui/src/utils/eventBus';
 import { ErrorViewProps } from '@trezor/connect-ui/src/views/Error';
@@ -33,9 +38,11 @@ import {
     showView,
 } from './view/common';
 import { isPhishingDomain } from './utils/isPhishingDomain';
-import { initSharedLogger } from './utils/debug';
+import { initSharedLogger, logWriterFactory } from './utils/debug';
 
-const log = initSharedLogger('./workers/shared-logger-worker.js');
+const logWriter = initSharedLogger('./workers/shared-logger-worker.js');
+
+const log = initLog('@trezor/connect-popup', true, logWriter);
 
 let handshakeTimeout: ReturnType<typeof setTimeout>;
 let renderConnectUIPromise: Promise<void> | undefined;
@@ -186,8 +193,21 @@ const handleInitMessage = (event: MessageEvent<PopupEvent | IFrameLogRequest>) =
     const { data } = event;
     if (!data) return;
 
+    // case of webextension which uses cross origin communication via content script
+    if (data.type === POPUP.CONTENT_SCRIPT_LOADED) {
+        log.debug('content-script loaded', data.payload);
+        setState({
+            settings: {
+                ...getState().settings!,
+                origin: data.payload.id,
+            },
+        });
+        reactEventBus.dispatch({ type: 'state-update', payload: getState() });
+        return;
+    }
+
     if (data.type === IFRAME.LOG) {
-        log.debug(data.payload);
+        logWriter.add(data.payload);
         return;
     }
 
@@ -252,14 +272,68 @@ const handleMessageInIframeMode = (
     handleUIAffectingMessage(message);
 };
 
+const handleMessageInCoreMode = (
+    event: MessageEvent<
+        | PopupEvent
+        | UiEvent
+        | IFrameLogRequest
+        | IFrameCallMessage
+        | (Omit<MethodResponseMessage, 'payload'> & { payload?: { error: string; code?: string } })
+    >,
+) => {
+    const { data } = event;
+
+    if (!data) return;
+
+    if (disposed) return;
+
+    if (data.type === IFRAME.LOG) {
+        logWriter.add(data.payload);
+        return;
+    }
+
+    if (data.type === POPUP.HANDSHAKE) {
+        handshake(data, getState().settings?.origin || '');
+        const core = ensureCore();
+        const transport = core.getTransportInfo();
+        setState({
+            ...data,
+            transport,
+        });
+        reactEventBus.dispatch(getState());
+
+        return;
+    }
+
+    if (data.type === IFRAME.CALL) {
+        const core = ensureCore();
+        core.handleMessage(data);
+
+        core.getCurrentMethod().then(method => {
+            log.debug('handling method in popup', method.name);
+            (method.initAsyncPromise ? method.initAsyncPromise : Promise.resolve()).finally(() => {
+                setState({
+                    method: method.name,
+                    info: method.info,
+                });
+                reactEventBus.dispatch({ type: 'state-update', payload: getState() });
+            });
+        });
+    }
+
+    const message = parseMessage(data);
+
+    handleUIAffectingMessage(message);
+};
+
 // handle POPUP.INIT message from window.opener
 const init = async (payload: PopupInit['payload']) => {
     log.debug('popup init', payload);
 
-    if (!payload) return;
-
     // try to establish connection with iframe
     try {
+        if (!payload) return;
+
         if (!payload.systemInfo) {
             payload.systemInfo = getSystemInfo(config.supportedBrowsers);
         }
@@ -275,11 +349,70 @@ const init = async (payload: PopupInit['payload']) => {
         await renderConnectUIPromise;
         log.debug('connect-ui rendered');
 
-        addWindowEventListener('message', handleMessageInIframeMode, false);
-        await initCoreInIframe(payload);
+        if (payload.useCore) {
+            addWindowEventListener('message', handleMessageInCoreMode, false);
+            await initCoreInPopup(payload);
+        } else {
+            addWindowEventListener('message', handleMessageInIframeMode, false);
+            await initCoreInIframe(payload);
+        }
     } catch (error) {
         postMessageToParent(createPopupMessage(POPUP.ERROR, { error: error.message }));
     }
+};
+
+const initCoreInPopup = async (payload: PopupInit['payload']) => {
+    // dynamically load core module
+    reactEventBus.dispatch({ type: 'loading', message: 'loading core' });
+
+    // core is built in a separate build step.
+    const { initCore, initTransport } = await import(
+        // @ts-expect-error
+        // eslint-disable-next-line import/extensions
+        /* webpackIgnore: true */ './js/core.js'
+    ).catch(_err => {
+        fail({
+            type: 'error',
+            detail: 'core-failed-to-load',
+        });
+    });
+
+    if (!initCore || !initTransport) {
+        return;
+    }
+    if (disposed) return;
+
+    // init core
+    log.debug('initiating core with settings: ', payload.settings);
+    reactEventBus.dispatch({ type: 'loading', message: 'initiating core' });
+    const core: Core = await initCore(
+        { ...payload.settings, trustedHost: false },
+        logWriterFactory,
+    );
+    if (disposed) return;
+    core.on(CORE_EVENT, event => {
+        const message = parseMessage(event);
+        handleUIAffectingMessage(message);
+
+        handleResponseEvent(message);
+    });
+    setState({ core });
+    log.debug('initiated core');
+
+    // init transport
+    log.debug('initiating transport with settings: ', payload.settings);
+    reactEventBus.dispatch({ type: 'loading', message: 'initiating transport' });
+    await initTransport(payload.settings);
+    if (disposed) return;
+    log.debug('initiated transport');
+
+    // done, in popup, we are ready to handle incoming messages
+    // todo: would it make sense to unify this with IFRAME.LOADED?
+    postMessageToParent(createPopupMessage(POPUP.CORE_LOADED));
+    reactEventBus.dispatch({
+        type: 'loading',
+        message: `waiting for handshake from from a 3rd party application`,
+    });
 };
 
 const initCoreInIframe = async (payload: PopupInit['payload']) => {
@@ -288,7 +421,7 @@ const initCoreInIframe = async (payload: PopupInit['payload']) => {
     // done, popup is ready to handle incoming messages, waiting for handshake from iframe
 };
 
-// handle POPUP.HANDSHAKE message from iframe
+// handle POPUP.HANDSHAKE message from iframe or npm-client
 const handshake = (handshake: PopupHandshake, origin: string) => {
     const { payload } = handshake;
     log.debug('handshake with origin: ', origin, 'payload: ', payload);
@@ -298,16 +431,34 @@ const handshake = (handshake: PopupHandshake, origin: string) => {
     clearTimeout(handshakeTimeout);
 
     // when this message comes from iframe, settings is already validated.
-    const trustedSettings = payload.settings;
+    // when there is no iframe, we must validate it here
+    const trustedSettings = parseConnectSettings(payload.settings, origin);
     setState({ settings: trustedSettings });
 
     if (isPhishingDomain(trustedSettings.origin || '')) {
         reactEventBus.dispatch({ type: 'phishing-domain' });
     }
 
-    reactEventBus.dispatch({ type: 'state-update', payload: getState() });
+    if (getState().core) {
+        const core = ensureCore();
+        core.handleMessage(handshake);
+    }
+    reactEventBus.dispatch({ type: 'state-update', payload: handshake.payload });
 
     log.debug('handshake done');
+};
+
+const ensureCore = () => {
+    const { core } = getState();
+    if (!core) {
+        fail({
+            type: 'error',
+            detail: 'core-missing',
+        });
+        throw new Error('connect core is missing');
+    }
+
+    return core;
 };
 
 // register onLoad event

--- a/packages/connect-popup/src/log.tsx
+++ b/packages/connect-popup/src/log.tsx
@@ -7,7 +7,7 @@ import { GlobalStyle } from '@trezor/connect-ui/src/support/GlobalStyle';
 import { InfoPanel } from '@trezor/connect-ui/src/components/InfoPanel';
 import { View } from '@trezor/connect-ui/src/components/View';
 import { Button, P, THEME, variables } from '@trezor/components';
-import { LogMessage } from '@trezor/connect/src/utils/debug';
+import { LogMessage, colors } from '@trezor/connect/src/utils/debug';
 
 interface ReactWrapperProps {
     children: React.ReactNode;
@@ -92,7 +92,11 @@ const logInConsole = (logs: any[]) => {
     logDebounceTimeout = setTimeout(() => {
         logDebounceCache.forEach(log => {
             const { prefix, css, message } = log;
-            console.log(`%c${prefix}`, css, ...message);
+            // todo carlos: it is not necessary to use logger module as a proxy in places that don't have
+            // access shared worker. if it is done like this, timestamp is overriden in the proxy place
+            // so we don't have corrent timestamp here in logger.
+            // disadvantage is that you don't get css for free, but it is possible to provide a fallback here - in logger
+            console.log(`%c${prefix}`, css || colors[prefix], ...message);
         });
         logDebounceCache = [];
     }, LOG_DEBOUNCE_TIME);

--- a/packages/connect-popup/src/utils/debug.ts
+++ b/packages/connect-popup/src/utils/debug.ts
@@ -1,19 +1,25 @@
-import { LogMessage, LogWriter, initLog } from '@trezor/connect/src/utils/debug';
+import { LogMessage, LogWriter } from '@trezor/connect/src/utils/debug';
+
+let worker: SharedWorker | undefined;
+
+export const logWriterFactory = (): LogWriter => ({
+    add: (message: LogMessage) => {
+        worker?.port.postMessage({ type: 'add-log', data: message });
+    },
+});
 
 export const initSharedLogger = (workerSrc: string) => {
     try {
         if (!SharedWorker) {
             throw new Error('SharedWorker is not supported');
         }
-        const worker = new SharedWorker(workerSrc);
+        worker = new SharedWorker(workerSrc);
         worker.port.start();
-        const logWriter: LogWriter = {
-            add: (message: LogMessage) =>
-                worker.port.postMessage({ type: 'add-log', data: message }),
-        };
-        return initLog('@trezor/connect-popup', false, logWriter);
+        return logWriterFactory();
     } catch (error) {
         console.warn('Failed to initialize LogWorker:', error);
-        return initLog('@trezor/connect-popup');
+        return {
+            add: (_message: LogMessage) => {},
+        };
     }
 };

--- a/packages/connect-popup/src/view/selectDevice.ts
+++ b/packages/connect-popup/src/view/selectDevice.ts
@@ -14,9 +14,7 @@ import { SUITE_BRIDGE_URL, SUITE_UDEV_URL, TREZOR_SUPPORT_URL } from '@trezor/ur
 import { container, getState, showView, postMessage } from './common';
 
 const initWebUsbButton = (showLoader: boolean) => {
-    const { iframe } = getState();
-
-    const usb = iframe ? iframe.navigator.usb : null;
+    const { usb } = window.navigator;
     const webusbContainer = container.getElementsByClassName('webusb')[0] as HTMLElement;
     webusbContainer.style.display = 'flex';
     const button = webusbContainer.getElementsByTagName('button')[0];
@@ -32,16 +30,19 @@ const initWebUsbButton = (showLoader: boolean) => {
             await window.navigator.usb.requestDevice({
                 filters: TREZOR_USB_DESCRIPTORS,
             });
-            const { iframe } = getState();
-            if (!iframe) {
-                throw ERRORS.TypedError('Popup_ConnectionMissing');
-            }
-            iframe.postMessage({
-                event: UI_EVENT,
-                type: TRANSPORT.REQUEST_DEVICE,
-            });
-            if (showLoader) {
-                showView('loader');
+
+            const { iframe, core } = getState();
+
+            if (iframe) {
+                iframe.postMessage({
+                    event: UI_EVENT,
+                    type: TRANSPORT.REQUEST_DEVICE,
+                });
+                if (showLoader) {
+                    showView('loader');
+                }
+            } else if (core) {
+                core.enumerate();
             }
         } catch (error) {
             // empty, do nothing, should not happen anyway

--- a/packages/connect-popup/tsconfig.json
+++ b/packages/connect-popup/tsconfig.json
@@ -10,6 +10,7 @@
         { "path": "../connect" },
         { "path": "../connect-analytics" },
         { "path": "../connect-common" },
+        { "path": "../connect-iframe" },
         { "path": "../connect-ui" },
         { "path": "../crypto-utils" },
         { "path": "../device-utils" },

--- a/packages/connect-popup/webpack/prod.webpack.config.ts
+++ b/packages/connect-popup/webpack/prod.webpack.config.ts
@@ -1,7 +1,7 @@
 import path from 'path';
 import webpack, { DefinePlugin } from 'webpack';
 import HtmlWebpackPlugin from 'html-webpack-plugin';
-import TerserPlugin from 'terser-webpack-plugin';
+// import TerserPlugin from 'terser-webpack-plugin';
 import CopyPlugin from 'copy-webpack-plugin';
 import * as URLS from '@trezor/urls';
 import { version } from '../package.json';
@@ -113,21 +113,18 @@ const config: webpack.Configuration = {
                     from: path.join(__dirname, '../../suite-data/files/images/png/trezor-*'),
                     to: `${DIST}/images/[name][ext]`,
                 },
+                {
+                    from: path.join(__dirname, '../../connect-iframe/build'),
+                    to: `${DIST}`,
+                },
             ],
         }),
     ],
     optimization: {
-        minimize: true,
-        minimizer: [
-            new TerserPlugin({
-                extractComments: false,
-                terserOptions: {
-                    format: {
-                        comments: false,
-                    },
-                },
-            }),
-        ],
+        minimize: false,
+    },
+    externals: {
+        'js/core': 'js/core',
     },
 };
 

--- a/packages/connect-ui/src/types.ts
+++ b/packages/connect-ui/src/types.ts
@@ -1,10 +1,12 @@
 import { PopupHandshake, PopupMethodInfo, IFrameLoaded } from '@trezor/connect';
+import type { Core } from '@trezor/connect/lib/core';
 
 export type State = Partial<PopupHandshake['payload']> &
     Partial<PopupMethodInfo['payload']> &
     Partial<IFrameLoaded['payload']> & {
         iframe?: Window;
         broadcast?: BroadcastChannel;
+        core?: Core;
         // preferred device will appear here
     };
 

--- a/packages/connect-ui/src/views/Error.tsx
+++ b/packages/connect-ui/src/views/Error.tsx
@@ -17,7 +17,9 @@ export interface ErrorViewProps {
     detail: // errors that might arise when using connect-ui with connect-popup
     | 'response-event-error' // Error coming from connect RESPONSE_EVENT
         | 'handshake-timeout' // communication was not established in a set time period
-        | 'iframe-failure'; // another (legacy) error, this is sent from popupManager (host) to popup. it means basically the same like handshake-timeout but we might be notified earlier
+        | 'iframe-failure' // another (legacy) error, this is sent from popupManager (host) to popup. it means basically the same like handshake-timeout but we might be notified earlier
+        | 'core-missing' // core was loaded correctly but became unavailable later
+        | 'core-failed-to-load'; // dynamic import of core failed
     // future errors when using connect-ui in different contexts
     message?: string;
 }
@@ -143,6 +145,16 @@ const getTroubleshootingTips = (props: ErrorViewProps) => {
             title: 'Action not completed',
             detail: {
                 steps: [<Step>{props.message}</Step>],
+            },
+        });
+    }
+
+    if (['core-missing', 'core-failed-to-load'].includes(props.detail)) {
+        tips.push({
+            icon: 'QUESTION',
+            title: 'Tried to access connect core which is not loaded yet',
+            detail: {
+                steps: [<Step>Try again or contact developers</Step>],
             },
         });
     }

--- a/packages/connect-webextension/.eslintrc.js
+++ b/packages/connect-webextension/.eslintrc.js
@@ -1,8 +1,5 @@
 module.exports = {
     rules: {
-        'import/no-extraneous-dependencies': [
-            'error',
-            { devDependencies: ['**/*.test.ts', '**/*config.ts'] },
-        ],
+        'no-underscore-dangle': 'off', // underscore is used
     },
 };

--- a/packages/connect-webextension/README.md
+++ b/packages/connect-webextension/README.md
@@ -1,3 +1,32 @@
-# @trezor/webextension
+# @trezor/webextension BETA
 
-This package will contain Trezor Connect Web Extension. For now it only has e2e tests.
+[![Build Status](https://github.com/trezor/trezor-suite/actions/workflows/connect-test.yml/badge.svg)](https://github.com/trezor/trezor-suite/actions/workflows/connect-test.yml)
+[![NPM](https://img.shields.io/npm/v/@trezor/connect-webextension.svg)](https://www.npmjs.org/package/@trezor/connect-webextension)
+[![Known Vulnerabilities](https://snyk.io/test/github/trezor/connect-webextension/badge.svg?targetFile=package.json)](https://snyk.io/test/github/trezor/trezor-suite?targetFile=packages/connect-webextension/package.json)
+
+This package contains @trezor/connect implementation suitable for webextensions. In short it:
+
+-   works in service worker
+-   provides access to TrezorConnect api
+-   handles opening of popup page on trezor.io domain when user is expected to approve some operations
+-   returns result to the caller.
+
+## Roadmap
+
+-   [ ] preliminary review (architecture, new package, same popup)
+-   [ ] internal testing
+    -   [ ] build connect-explorer-webextension using this package
+    -   [ ] make it available to QA and test it
+-   [ ] beta testing
+    -   [ ] release npm package in beta
+    -   [ ] release changes to connect popup to trezor.io, make sure standard flow using iframe is unaffected
+    -   [ ] gather feedback from 3rd parties bulding extensions
+-   [ ] public release
+
+## Development
+
+-   `yarn`
+-   `yarn build:libs`
+-   `yarn workspace @trezor/connect-webextension build`
+-   `yarn workspace @trezor/connect-iframe build:core-module`
+-   `yarn workspace @trezor/connect-popup dev`

--- a/packages/connect-webextension/package.json
+++ b/packages/connect-webextension/package.json
@@ -4,7 +4,18 @@
     "private": true,
     "scripts": {
         "lint:js": "yarn g:eslint '**/*.{ts,tsx,js}'",
-        "test:e2e": "yarn xvfb-maybe -- playwright test --config=./e2e/playwright.config.ts"
+        "test:e2e": "yarn xvfb-maybe -- playwright test --config=./e2e/playwright.config.ts",
+        "build:lib": "rimraf ./lib && yarn tsc --build tsconfig.lib.json",
+        "build:content-script": "TS_NODE_PROJECT=\"tsconfig.lib.json\" webpack --config ./webpack/content-script.webpack.config.ts",
+        "build:inline": "TS_NODE_PROJECT=\"tsconfig.lib.json\" webpack --config ./webpack/inline.webpack.config.ts",
+        "build:webextension": "TS_NODE_PROJECT=\"tsconfig.lib.json\" yarn webpack --config ./webpack/prod.webpack.config.ts",
+        "build": "rimraf build && yarn build:content-script &&  yarn build:webextension && yarn build:inline && node ./webpack/inline-content-script.js"
+    },
+    "dependencies": {
+        "@trezor/connect": "workspace:*",
+        "@trezor/connect-common": "workspace:*",
+        "@trezor/utils": "workspace:*",
+        "events": "^3.3.0"
     },
     "devDependencies": {
         "@playwright/browser-chromium": "^1.39.0",
@@ -13,7 +24,16 @@
         "@playwright/test": "^1.39.0",
         "@trezor/node-utils": "workspace:*",
         "@trezor/trezor-user-env-link": "workspace:*",
+        "@types/chrome": "latest",
+        "jest": "^26.6.3",
+        "rimraf": "^5.0.1",
+        "terser-webpack-plugin": "^5.3.9",
+        "tsx": "^3.12.7",
         "typescript": "^4.9.5",
+        "webpack": "^5.87.0",
+        "webpack-cli": "^5.1.4",
+        "webpack-merge": "^5.9.0",
+        "webpack-plugin-serve": "^1.6.0",
         "xvfb-maybe": "^0.2.1"
     }
 }

--- a/packages/connect-webextension/src/channels/serviceworker-window.ts
+++ b/packages/connect-webextension/src/channels/serviceworker-window.ts
@@ -1,0 +1,80 @@
+import {
+    AbstractMessageChannel,
+    AbstractMessageChannelConstructorParams,
+    Message,
+} from '@trezor/connect-common/src/messageChannel/abstract';
+
+/**
+ * Communication channel between:
+ * - here: chrome message port (in service worker)
+ * - peer: window.onMessage in trezor-content-script
+ */
+export class ServiceWorkerWindowChannel<
+    IncomingMessages extends { type: string },
+> extends AbstractMessageChannel<IncomingMessages> {
+    private port: chrome.runtime.Port | undefined;
+
+    constructor({
+        name,
+        channel,
+        logger,
+    }: Pick<AbstractMessageChannelConstructorParams, 'channel' | 'logger'> & { name: string }) {
+        super({
+            channel,
+            sendFn: (message: any) => {
+                if (!this.port) throw new Error('port not assigned');
+                this.port.postMessage(message);
+            },
+            logger,
+        });
+
+        chrome.runtime.onConnect.addListener(port => {
+            if (port.name !== name) return;
+            this.port = port;
+
+            this.port.onMessage.addListener((message: Message<IncomingMessages>, { sender }) => {
+                if (!sender) {
+                    this.logger?.error('service-worker-window', 'no sender');
+                    return;
+                }
+
+                const { origin } = sender;
+
+                const whitelist = [
+                    'https://connect.trezor.io',
+                    'https://staging-connect.trezor.io',
+                    'https://suite.corp.sldev.cz',
+                    'http://localhost:8088',
+                ];
+
+                if (!origin) {
+                    this.logger?.error(
+                        'connect-webextension/messageChannel/extensionPort/onMessage',
+                        'no origin',
+                    );
+
+                    return;
+                }
+                if (!whitelist.includes(origin)) {
+                    this.logger?.error(
+                        'connect-webextension/messageChannel/extensionPort/onMessage',
+                        'origin not whitelisted',
+                        origin,
+                    );
+                    return;
+                }
+
+                // eslint-disable-next-line no-restricted-globals
+                if (origin === self.origin) {
+                    return;
+                }
+
+                this.onMessage(message);
+            });
+        });
+    }
+
+    disconnect() {
+        this.port?.disconnect();
+    }
+}

--- a/packages/connect-webextension/src/channels/window-serviceworker.ts
+++ b/packages/connect-webextension/src/channels/window-serviceworker.ts
@@ -1,0 +1,47 @@
+import {
+    AbstractMessageChannel,
+    AbstractMessageChannelConstructorParams,
+    Message,
+} from '@trezor/connect-common/src/messageChannel/abstract';
+
+/**
+ * Communication channel between:
+ * - here: chrome message port (in service worker)
+ * - peer: window.onMessage in trezor-content-script
+ */
+
+export class WindowServiceWorkerChannel<
+    IncomingMessages extends { type: string },
+> extends AbstractMessageChannel<IncomingMessages> {
+    private port: chrome.runtime.Port | undefined;
+
+    constructor({
+        name,
+        channel,
+    }: Pick<AbstractMessageChannelConstructorParams, 'channel'> & { name: string }) {
+        super({
+            channel,
+            sendFn: (message: any) => {
+                if (!this.port) throw new Error('port not assigned');
+                this.port.postMessage(message);
+            },
+        });
+
+        const port = chrome.runtime.connect({ name });
+        this.port = port;
+
+        this.port.onMessage.addListener(
+            (
+                // note: portMessageEvent has message typed as any
+                message: Message<IncomingMessages>,
+            ) => {
+                if (message.channel.here === this.channel.here) return;
+                this.onMessage(message);
+            },
+        );
+    }
+
+    disconnect() {
+        this.port?.disconnect();
+    }
+}

--- a/packages/connect-webextension/src/connectSettings.ts
+++ b/packages/connect-webextension/src/connectSettings.ts
@@ -1,0 +1,20 @@
+import {
+    parseConnectSettings as parseSettings,
+    ConnectSettings,
+} from '@trezor/connect/lib/exports';
+
+export const getEnv = () => 'webextension' as const;
+
+/**
+ * Settings from host
+ * @param input Partial<ConnectSettings>
+ */
+export const parseConnectSettings = (input: Partial<ConnectSettings> = {}): ConnectSettings => {
+    const settings = { popup: true, ...input };
+
+    if (typeof input.env !== 'string') {
+        settings.env = getEnv();
+    }
+
+    return parseSettings(settings);
+};

--- a/packages/connect-webextension/src/contentScript.ts
+++ b/packages/connect-webextension/src/contentScript.ts
@@ -1,0 +1,45 @@
+import { WindowServiceWorkerChannel } from './channels/window-serviceworker';
+
+/**
+ * communication between service worker and both webextension and popup manager
+ */
+const channel = new WindowServiceWorkerChannel({
+    name: 'trezor-connect',
+    channel: {
+        here: '@trezor/connect-content-script',
+        peer: ['@trezor/connect-webextension', '@trezor/connect-popup-manager'],
+    },
+});
+
+channel.init().then(() => {
+    // once script is loaded. send information about the webextension that injected it into the popup
+    window.postMessage(
+        {
+            type: 'popup-content-script-loaded',
+            payload: { ...chrome.runtime.getManifest(), id: chrome.runtime.id },
+        },
+        window.location.origin,
+    );
+
+    /**
+     * Passing messages from service worker to popup
+     */
+    channel.on('message', message => {
+        window.postMessage(message, window.location.origin);
+    });
+
+    /*
+     * Passing messages from popup to service worker
+     */
+    window.addEventListener('message', event => {
+        if (
+            event.data?.channel?.here === '@trezor/connect-webextension' ||
+            event.data?.type === 'content-script-loaded'
+        ) {
+            return;
+        }
+        if (event.source === window && event.data) {
+            channel.sendFn(event.data);
+        }
+    });
+});

--- a/packages/connect-webextension/src/index.ts
+++ b/packages/connect-webextension/src/index.ts
@@ -1,0 +1,207 @@
+import EventEmitter from 'events';
+
+// NOTE: @trezor/connect part is intentionally not imported from the index due to NormalReplacementPlugin
+// in packages/suite-build/configs/web.webpack.config.ts
+import {
+    POPUP,
+    IFRAME,
+    ERRORS,
+    UI_EVENT,
+    createErrorMessage,
+    ConnectSettings,
+    Manifest,
+    UiResponseEvent,
+    CallMethod,
+    PopupEventMessage,
+} from '@trezor/connect/lib/exports';
+import { factory } from '@trezor/connect/lib/factory';
+import { initLog, setLogWriter, LogMessage, LogWriter } from '@trezor/connect/lib/utils/debug';
+import { createDeferred } from '@trezor/utils/lib';
+
+import * as popup from './popup';
+import { parseConnectSettings } from './connectSettings';
+import { ServiceWorkerWindowChannel } from './channels/serviceworker-window';
+
+const eventEmitter = new EventEmitter();
+let _settings = parseConnectSettings();
+let _popupManager: popup.PopupManager | undefined;
+
+/**
+ * setup logger.
+ * service worker cant communicate directly with sharedworker logger so the communication is as follows:
+ * - service worker -> content script -> popup -> sharedworker
+ * todo: this could be simplified by injecting additional content script into log.html
+ */
+const logger = initLog('@trezor/connect-webextension');
+const channelLogger = initLog('@trezor/connect-webextension/serviceWorkerWindowChannel');
+const popupManagerLogger = initLog('@trezor/connect-webextension/popupManager');
+
+/**
+ * communication channel between service worker and contentScript
+ */
+const serviceWorkerWindowChannel = new ServiceWorkerWindowChannel<PopupEventMessage>({
+    name: 'trezor-connect',
+    channel: {
+        here: '@trezor/connect-webextension',
+        peer: ['@trezor/connect-content-script'],
+    },
+    logger: channelLogger,
+});
+
+const logWriterFactory = (): LogWriter => ({
+    add: (message: LogMessage) => {
+        serviceWorkerWindowChannel.sendFn({
+            event: UI_EVENT,
+            type: IFRAME.LOG,
+            payload: message,
+        });
+    },
+});
+
+setLogWriter(logWriterFactory);
+
+const manifest = (data: Manifest) => {
+    _settings = parseConnectSettings({
+        ..._settings,
+        manifest: data,
+    });
+};
+
+const dispose = () => {
+    eventEmitter.removeAllListeners();
+    _settings = parseConnectSettings();
+    if (_popupManager) {
+        _popupManager.close();
+    }
+    return Promise.resolve(undefined);
+};
+
+const cancel = (error?: string) => {
+    if (_popupManager) {
+        _popupManager.emit(POPUP.CLOSED, error);
+    }
+};
+
+const handshakePromise = createDeferred();
+
+const init = (settings: Partial<ConnectSettings> = {}): Promise<void> => {
+    logger.debug('initiating');
+    _settings = parseConnectSettings({ ..._settings, ...settings });
+
+    if (!_popupManager) {
+        _popupManager = new popup.PopupManager(_settings, { logger: popupManagerLogger });
+    }
+
+    logger.enabled = !!settings.debug;
+
+    if (!_settings.manifest) {
+        throw ERRORS.TypedError('Init_ManifestMissing');
+    }
+
+    // defaults for connect-webextension
+    if (!_settings.transports?.length) {
+        _settings.transports = ['BridgeTransport', 'WebUsbTransport'];
+    }
+
+    serviceWorkerWindowChannel.on('message', message => {
+        if (message.type === POPUP.CORE_LOADED) {
+            serviceWorkerWindowChannel.postMessage({
+                type: POPUP.HANDSHAKE,
+                // in this case, settings will be validated in popup
+                payload: { settings: _settings },
+            });
+            handshakePromise.resolve();
+        }
+    });
+
+    logger.debug('initiated');
+
+    return Promise.resolve();
+};
+
+/**
+ * 1. opens popup
+ * 2. sends request to popup where the request is handled by core
+ * 3. returns response
+ */
+const call: CallMethod = async params => {
+    logger.debug('call', params);
+
+    // request popup window it might be used in the future
+    if (_settings.popup && _popupManager) {
+        _popupManager.request();
+    }
+
+    await serviceWorkerWindowChannel.init();
+    serviceWorkerWindowChannel.postMessage({
+        type: POPUP.INIT,
+        payload: {
+            settings: _settings,
+            useCore: true,
+        },
+    });
+
+    await handshakePromise.promise;
+
+    // post message to core in popup
+    try {
+        const response = await serviceWorkerWindowChannel.postMessage({
+            type: IFRAME.CALL,
+            payload: params,
+        });
+
+        logger.debug('call: response: ', response);
+
+        if (response) {
+            return response;
+        }
+
+        return createErrorMessage(ERRORS.TypedError('Method_NoResponse'));
+    } catch (error) {
+        logger.error('call: error', error);
+        if (_popupManager) {
+            _popupManager.clear();
+        }
+        return createErrorMessage(error);
+    }
+};
+
+const uiResponse = (response: UiResponseEvent) => {
+    const { type, payload } = response;
+    serviceWorkerWindowChannel.postMessage({ event: UI_EVENT, type, payload });
+};
+
+const renderWebUSBButton = () => {};
+
+const requestLogin = () => {
+    // todo: not supported yet
+    throw ERRORS.TypedError('Method_InvalidPackage');
+};
+
+const disableWebUSB = () => {
+    // todo: not supported yet, probably not needed
+    throw ERRORS.TypedError('Method_InvalidPackage');
+};
+
+const requestWebUSBDevice = () => {
+    // not needed - webusb pairing happens in popup
+    throw ERRORS.TypedError('Method_InvalidPackage');
+};
+
+const TrezorConnect = factory({
+    eventEmitter,
+    manifest,
+    init,
+    call,
+    requestLogin,
+    uiResponse,
+    renderWebUSBButton,
+    disableWebUSB,
+    requestWebUSBDevice,
+    cancel,
+    dispose,
+});
+
+// eslint-disable-next-line import/no-default-export
+export default TrezorConnect;
+export * from '@trezor/connect/lib/exports';

--- a/packages/connect-webextension/src/popup.ts
+++ b/packages/connect-webextension/src/popup.ts
@@ -1,0 +1,162 @@
+// origin: https://github.com/trezor/connect/blob/develop/src/js/popup/PopupManager.js
+import EventEmitter from 'events';
+import { PopupEventMessage } from 'packages/connect/lib';
+
+import {
+    // POPUP,
+    ConnectSettings,
+} from '@trezor/connect/lib/exports';
+import { getOrigin } from '@trezor/connect/lib/utils/urlUtils';
+import { Log } from '@trezor/connect/lib/utils/debug';
+
+import { ServiceWorkerWindowChannel } from './channels/serviceworker-window';
+
+export class PopupManager extends EventEmitter {
+    popupWindow: chrome.tabs.Tab | undefined;
+
+    settings: ConnectSettings;
+
+    origin: string;
+
+    locked = false;
+
+    channel = new ServiceWorkerWindowChannel<PopupEventMessage>({
+        name: 'trezor-connect',
+        channel: {
+            here: '@trezor/connect-popup-manager',
+            peer: ['@trezor/connect-content-script'],
+        },
+    });
+
+    extensionTabId = 0;
+
+    logger: Log;
+
+    constructor(settings: ConnectSettings, { logger }: { logger: Log }) {
+        super();
+        this.settings = settings;
+        this.origin = getOrigin(settings.popupSrc);
+        this.logger = logger;
+
+        this.channel.init();
+    }
+
+    request() {
+        // popup request
+        // bring popup window to front
+        if (this.locked) {
+            if (this.popupWindow?.id) {
+                chrome.tabs.update(this.popupWindow.id, { active: true });
+            }
+            return;
+        }
+
+        // When requesting a popup window and there is a reference to popup window and it is not locked
+        // we close it so we can open a new one.
+        // This is necessary when popup window is in error state and we want to open a new one.
+        if (this.popupWindow && !this.locked) {
+            this.close();
+        }
+
+        const openFn = this.open.bind(this);
+        this.locked = true;
+
+        openFn();
+    }
+
+    unlock() {
+        this.locked = false;
+    }
+
+    // create a special content script to be injected into log.html and stop sending logs over popup
+    open() {
+        const url = `${this.settings.popupSrc}`;
+        chrome.windows.getCurrent(currentWindow => {
+            this.logger.debug('opening popup. currentWindow: ', currentWindow);
+
+            // Request coming from extension popup,
+            // create new window above instead of opening new tab
+            if (currentWindow.type !== 'normal') {
+                // todo: when is this actually used?
+                chrome.windows.create({ url }, newWindow => {
+                    chrome.tabs.query(
+                        {
+                            windowId: newWindow?.id,
+                            active: true,
+                        },
+                        tabs => {
+                            // eslint-disable-next-line prefer-destructuring
+                            this.popupWindow = tabs[0];
+                            this.injectContentScript(this.popupWindow.id!);
+                        },
+                    );
+                });
+            } else {
+                chrome.tabs.query(
+                    {
+                        currentWindow: true,
+                        active: true,
+                    },
+                    tabs => {
+                        this.extensionTabId = tabs[0].id as number;
+
+                        chrome.tabs.create(
+                            {
+                                url,
+                                index: tabs[0].index + 1,
+                            },
+                            tab => {
+                                this.popupWindow = tab;
+                                this.injectContentScript(tab.id!);
+                            },
+                        );
+                    },
+                );
+            }
+        });
+    }
+
+    private injectContentScript = (tabId: number) => {
+        chrome.scripting
+            .executeScript({
+                target: { tabId },
+                // content script is injected into body of func in build time.
+                func: () => {
+                    // <!--content-script-->
+                },
+            })
+            .then(() => this.logger.debug('content script injected'))
+            .catch(error => this.logger.error('content script injection error', error));
+    };
+
+    clear(focus = true) {
+        this.locked = false;
+
+        if (this.channel) {
+            this.channel.disconnect();
+        }
+
+        // switch to previously focused tab
+
+        if (focus && this.extensionTabId) {
+            chrome.tabs.update(this.extensionTabId, { active: true });
+            this.extensionTabId = 0;
+        }
+    }
+
+    close() {
+        if (!this.popupWindow?.id) return;
+
+        this.logger.debug('closing popup', this.popupWindow.id);
+
+        let e = chrome.runtime.lastError;
+
+        chrome.tabs.remove(this.popupWindow.id, () => {
+            e = chrome.runtime.lastError;
+
+            if (e) {
+                this.logger.error('closed with error', e);
+            }
+        });
+    }
+}

--- a/packages/connect-webextension/tsconfig.json
+++ b/packages/connect-webextension/tsconfig.json
@@ -2,10 +2,14 @@
     "extends": "../../tsconfig.json",
     "compilerOptions": {
         "isolatedModules": false,
-        "noEmit": true
+        "noEmit": true,
+        "types": ["chrome", "w3c-web-usb"]
     },
     "include": ["**/*.ts", "**/*.js"],
     "references": [
+        { "path": "../connect" },
+        { "path": "../connect-common" },
+        { "path": "../utils" },
         { "path": "../node-utils" },
         { "path": "../trezor-user-env-link" }
     ]

--- a/packages/connect-webextension/tsconfig.lib.json
+++ b/packages/connect-webextension/tsconfig.lib.json
@@ -1,0 +1,10 @@
+{
+    "extends": "../../tsconfig.lib.json",
+    "compilerOptions": {
+        "outDir": "lib",
+        "target": "es2017",
+        "types": ["chrome", "w3c-web-usb"],
+        "importHelpers": true
+    },
+    "include": ["./src"]
+}

--- a/packages/connect-webextension/webpack/content-script.webpack.config.ts
+++ b/packages/connect-webextension/webpack/content-script.webpack.config.ts
@@ -1,0 +1,24 @@
+import webpack from 'webpack';
+import path from 'path';
+
+import prod from './prod.webpack.config';
+
+const config: webpack.Configuration = {
+    target: 'web',
+    mode: 'production',
+    entry: {
+        'content-script': path.resolve(__dirname, '../src/contentScript.ts'),
+    },
+
+    module: prod.module,
+    resolve: prod.resolve,
+    performance: prod.performance,
+
+    optimization: {
+        // [beta version]: keep not minimized
+        minimize: false,
+    },
+};
+
+// eslint-disable-next-line import/no-default-export
+export default config;

--- a/packages/connect-webextension/webpack/inline-content-script.js
+++ b/packages/connect-webextension/webpack/inline-content-script.js
@@ -1,0 +1,14 @@
+const fs = require('fs');
+const path = require('path');
+
+const contentScript = fs.readFileSync(path.join(__dirname, '../dist/content-script.js'), 'utf8');
+
+const buildResultPath = path.join(__dirname, '../build/trezor-connect-webextension.js');
+const buildResult = fs.readFileSync(buildResultPath, 'utf8');
+
+const replaceToken = '// <!--content-script-->';
+const updated = buildResult.replace(replaceToken, contentScript);
+
+fs.writeFileSync(buildResultPath, updated, 'utf8');
+
+console.log('replace done');

--- a/packages/connect-webextension/webpack/inline.webpack.config.ts
+++ b/packages/connect-webextension/webpack/inline.webpack.config.ts
@@ -1,0 +1,32 @@
+import webpack from 'webpack';
+import path from 'path';
+
+import prod from './prod.webpack.config';
+
+// Generate inline script hosted on https://connect.trezor.io/X/trezor-connect-webextension.js
+// This is compiled and polyfilled npm package without Core logic
+
+const config: webpack.Configuration = {
+    target: 'web',
+    mode: 'production',
+    entry: {
+        'trezor-connect-webextension': path.resolve(__dirname, '../src/index.ts'),
+        'trezor-connect-webextension.min': path.resolve(__dirname, '../src/index.ts'),
+    },
+    output: {
+        filename: '[name].js',
+        path: path.resolve(__dirname, '../build'),
+        publicPath: './',
+        library: 'TrezorConnect',
+        libraryTarget: 'umd',
+        libraryExport: 'default',
+    },
+
+    module: prod.module,
+    resolve: prod.resolve,
+    performance: prod.performance,
+    optimization: prod.optimization,
+};
+
+// eslint-disable-next-line import/no-default-export
+export default config;

--- a/packages/connect-webextension/webpack/prod.webpack.config.ts
+++ b/packages/connect-webextension/webpack/prod.webpack.config.ts
@@ -1,0 +1,62 @@
+import webpack from 'webpack';
+import path from 'path';
+import TerserPlugin from 'terser-webpack-plugin';
+
+// Generate single entry javascript bundle in build/js folder
+
+const DIST = path.resolve(__dirname, '../build');
+
+const config: webpack.Configuration = {
+    target: 'web',
+    mode: 'production',
+
+    output: {
+        filename: 'js/[name].[contenthash].js',
+        path: DIST,
+        publicPath: './',
+    },
+    module: {
+        rules: [
+            {
+                test: /\.js$/,
+                exclude: /node_modules/,
+                use: ['babel-loader'],
+            },
+            {
+                test: /\.ts$/,
+                exclude: /node_modules/,
+                use: {
+                    loader: 'babel-loader',
+                    options: {
+                        presets: ['@babel/preset-typescript'],
+                    },
+                },
+            },
+        ],
+    },
+    resolve: {
+        modules: ['node_modules'],
+        mainFields: ['browser', 'module', 'main'],
+        extensions: ['.ts', '.js'],
+    },
+    performance: {
+        hints: false,
+    },
+    optimization: {
+        // [beta version]: keep not minimized
+        minimize: false,
+        minimizer: [
+            new TerserPlugin({
+                extractComments: false,
+                terserOptions: {
+                    format: {
+                        comments: false,
+                    },
+                },
+            }),
+        ],
+    },
+};
+
+// eslint-disable-next-line import/no-default-export
+export default config;

--- a/packages/connect/src/core/index.ts
+++ b/packages/connect/src/core/index.ts
@@ -1021,6 +1021,13 @@ export class Core extends EventEmitter {
         }
         return _deviceList.getTransportInfo();
     }
+
+    enumerate() {
+        if (!_deviceList) {
+            return;
+        }
+        _deviceList.enumerate();
+    }
 }
 
 /**

--- a/packages/connect/src/data/config.ts
+++ b/packages/connect/src/data/config.ts
@@ -36,6 +36,12 @@ export const config = {
             label: 'MetaMask',
             icon: '',
         },
+        {
+            // temporary record. something to test that handing over this information from content script works
+            origin: 'mhindfjbfdlgedfmkkdgfdhkfkakifed',
+            label: 'Testing webextension',
+            icon: '',
+        },
         { origin: 'file://', label: ' ', icon: '' },
     ],
     onionDomains: {

--- a/packages/connect/src/events/popup.ts
+++ b/packages/connect/src/events/popup.ts
@@ -8,6 +8,9 @@ export const POPUP = {
     BOOTSTRAP: 'popup-bootstrap',
     // Message from popup.js to window.opener, called after "window.onload" event. This is second message from popup to window.opener.
     LOADED: 'popup-loaded',
+    // Message from popup run in "core" mode. Connect core has been loaded, popup is ready to handle messages
+    // This is similar to IFRAME.LOADED message which signals the same but core is loaded in different context
+    CORE_LOADED: 'popup-core-loaded',
     // Message from window.opener to popup.js. Send settings to popup. This is first message from window.opener to popup.
     INIT: 'popup-init',
     // Error message from popup to window.opener. Could be thrown during popup initialization process (POPUP.INIT)
@@ -28,6 +31,8 @@ export const POPUP = {
     CLOSE_WINDOW: 'window.close',
     // todo: shouldn't it be UI_RESPONSE?
     ANALYTICS_RESPONSE: 'popup-analytics-response',
+    /** webextension injected content script and content script notified popup */
+    CONTENT_SCRIPT_LOADED: 'popup-content-script-loaded',
     /** method.info async getter result passed from core to popup */
     METHOD_INFO: 'popup-method-info',
 } as const;
@@ -38,6 +43,7 @@ export interface PopupInit {
         settings: ConnectSettings; // settings from window.opener (sent by @trezor/connect-web)
         useBroadcastChannel: boolean;
         systemInfo: SystemInfo;
+        useCore?: boolean;
     };
 }
 
@@ -71,9 +77,14 @@ export interface PopupMethodInfo {
     payload: { info: string; method: string };
 }
 
+export interface PopupContentScriptLoaded {
+    type: typeof POPUP.CONTENT_SCRIPT_LOADED;
+    payload: { id: string };
+}
+
 export type PopupEvent =
     | {
-          type: typeof POPUP.LOADED | typeof POPUP.CANCEL_POPUP_REQUEST;
+          type: typeof POPUP.LOADED | typeof POPUP.CORE_LOADED | typeof POPUP.CANCEL_POPUP_REQUEST;
           payload?: typeof undefined;
       }
     | PopupInit
@@ -81,6 +92,7 @@ export type PopupEvent =
     | PopupError
     | PopupClosedMessage
     | PopupAnalyticsResponse
+    | PopupContentScriptLoaded
     | PopupMethodInfo;
 
 export type PopupEventMessage = PopupEvent & { event: typeof UI_EVENT };

--- a/packages/connect/src/utils/debug.ts
+++ b/packages/connect/src/utils/debug.ts
@@ -6,10 +6,13 @@ const blue = '#20abd8';
 const orange = '#f4a744';
 const yellow = '#fbd948';
 
-const colors: Record<string, string> = {
+export const colors: Record<string, string> = {
     // blue, npm package related
     '@trezor/connect': `color: ${blue}; background: #000;`,
     '@trezor/connect-web': `color: ${blue}; background: #000;`,
+    '@trezor/connect-webextension': `color: ${blue}; background: #000;`,
+    '@trezor/connect-webextension/serviceWorkerWindowChannel': `color: ${blue}; background: #000;`,
+    '@trezor/connect-webextension/popupManager': `color: ${blue}; background: #000;`,
     // orange, api related
     IFrame: `color: ${orange}; background: #000;`,
     Core: `color: ${orange}; background: #000;`,
@@ -36,7 +39,7 @@ export type LogWriter = {
 
 const MAX_ENTRIES = 100;
 
-class Log {
+export class Log {
     prefix: string;
     enabled: boolean;
     css: string;

--- a/yarn.lock
+++ b/yarn.lock
@@ -8709,6 +8709,7 @@ __metadata:
   resolution: "@trezor/connect-common@workspace:packages/connect-common"
   dependencies:
     "@trezor/env-utils": "workspace:*"
+    "@trezor/utils": "workspace:*"
     jest: "npm:^26.6.3"
     rimraf: "npm:^5.0.5"
     tsx: "npm:^3.14.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -8932,9 +8932,22 @@ __metadata:
     "@playwright/browser-firefox": "npm:^1.39.0"
     "@playwright/browser-webkit": "npm:^1.39.0"
     "@playwright/test": "npm:^1.39.0"
+    "@trezor/connect": "workspace:*"
+    "@trezor/connect-common": "workspace:*"
     "@trezor/node-utils": "workspace:*"
     "@trezor/trezor-user-env-link": "workspace:*"
+    "@trezor/utils": "workspace:*"
+    "@types/chrome": "npm:latest"
+    events: "npm:^3.3.0"
+    jest: "npm:^26.6.3"
+    rimraf: "npm:^5.0.1"
+    terser-webpack-plugin: "npm:^5.3.9"
+    tsx: "npm:^3.12.7"
     typescript: "npm:^4.9.5"
+    webpack: "npm:^5.87.0"
+    webpack-cli: "npm:^5.1.4"
+    webpack-merge: "npm:^5.9.0"
+    webpack-plugin-serve: "npm:^1.6.0"
     xvfb-maybe: "npm:^0.2.1"
   languageName: unknown
   linkType: soft
@@ -9962,6 +9975,16 @@ __metadata:
     "@types/filesystem": "npm:*"
     "@types/har-format": "npm:*"
   checksum: 2f18deecc75101283993a6f08258a8ea98bfc166469fce9074959e8deb8d78f771f01578cdb66ffb6b87e8f50c55e1b516cf024b6ddaefbbd30d97d07d3dac3b
+  languageName: node
+  linkType: hard
+
+"@types/chrome@npm:latest":
+  version: 0.0.251
+  resolution: "@types/chrome@npm:0.0.251"
+  dependencies:
+    "@types/filesystem": "npm:*"
+    "@types/har-format": "npm:*"
+  checksum: a775f6ce867d8edd3d18950851b6a6670510cbed4b80ada79d45952d0baacf5e898c5453f44d4a012b1a906b58cf44b191272cb9970e3589b2f4c06fcb97a28e
   languageName: node
   linkType: hard
 
@@ -30743,7 +30766,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"rimraf@npm:^5.0.5":
+"rimraf@npm:^5.0.1, rimraf@npm:^5.0.5":
   version: 5.0.5
   resolution: "rimraf@npm:5.0.5"
   dependencies:
@@ -33743,7 +33766,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"tsx@npm:^3.14.0":
+"tsx@npm:^3.12.7, tsx@npm:^3.14.0":
   version: 3.14.0
   resolution: "tsx@npm:3.14.0"
   dependencies:
@@ -35120,7 +35143,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"webpack-merge@npm:^5.10.0, webpack-merge@npm:^5.7.3":
+"webpack-merge@npm:^5.10.0, webpack-merge@npm:^5.7.3, webpack-merge@npm:^5.9.0":
   version: 5.10.0
   resolution: "webpack-merge@npm:5.10.0"
   dependencies:

--- a/yarn.lock
+++ b/yarn.lock
@@ -8779,7 +8779,7 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@trezor/connect-iframe@workspace:packages/connect-iframe":
+"@trezor/connect-iframe@workspace:*, @trezor/connect-iframe@workspace:packages/connect-iframe":
   version: 0.0.0-use.local
   resolution: "@trezor/connect-iframe@workspace:packages/connect-iframe"
   dependencies:
@@ -8842,6 +8842,7 @@ __metadata:
     "@trezor/connect": "workspace:*"
     "@trezor/connect-analytics": "workspace:*"
     "@trezor/connect-common": "workspace:*"
+    "@trezor/connect-iframe": "workspace:*"
     "@trezor/connect-ui": "workspace:*"
     "@trezor/crypto-utils": "workspace:*"
     "@trezor/device-utils": "workspace:*"


### PR DESCRIPTION
# @trezor/connect - better manifest v3 support

this PR makes it possible to use TrezorConnect from service worker. The motivation driving this effort is that with advent of manifest version 3, background script is no longer typical DOM based environment which means we can't inject iframe. 

- For service workers we are still going to provide TrezorConnect API as implementators are used to. Messages that were formerly handled by iframe will now be sent into popup. 
- Popup will (probably based on query string param) dynamically import and init connect core. 
- Popup listens to messages from service worker (through content-script, is there a better way?) and passes messages to connect core. 
- Popup listens to connect core events and renders appropriate UI based on them.

## Connect "modes":
I assume, we are going to make connect available in 4 modes. By "mode" here I describe what is the relationship between public facing connect API and its access to connect core and how user input is handled.
- iframe on host mode, popup in new tab
  - before this PR, the only mode that can be used in "web based" environments. No need to describe any further
- popup-core mode
  - introduced by this PR. core is loaded into popup, all the logic and user input happens in popup.
  - pros: works from service worker
  - cons: no persitent connection, no events
- iframe on host, popup in iframe on host
  - this would enable webusb for 3rd parties web apps
  - some experiments/POC can be found here https://github.com/trezor/trezor-suite/tree/connect-popup-iframe 
  - we should probably allow this only for whitelisted trusted apps, since users would not see trezor.io ssl certificate 
- module mode
  - no intermediary between core logic and connect api
  - currently this is what @trezor/connect package does for node.js applications 

## Roadmap: 

### Phase 1: @trezor/connect-webextension package
- connect-popup is able to work in 2 alternative regimes.
- new package @trezor/connect-webextension is created. This package works solely in "popup-core" mode.
- @trezor/connect-web still supports webextensions, especially manifest version 2 webextensions, or even mv3 workaround with injected iframe into webextension UI.

### Phase 2: implementator can chose mode
- TrezorConnect.init({ mode }) option is generally made available to implementators discretion. Implementing this requires changes to npm packages however nature of this changes might only be additions so this would possibly not require creating the next major version.

### Phase ?: future plans
- @trezor/connect-web package stops supporting webextension. The question to be decided is whether we want to support "iframe in extension UI" mode for webextensions.
- For more features, such as events, persitent connection, etc: we might implement 
  - "TrezorConnect in suite" available over websocket. or maybe over native messaging?
  - we might implement "TrezorConnect in webextension"

## Tests
- we are going to reuse connect-popup end-to-end testing via connect-explorer and its fixtures also for testing of @trezor/connect-web in webextension #9217
- lets followup with using similar setup also for testing of @trezor/connect-webextension. @karliatto 
- lets build connect-explorer-webextension and upload it to sldev similary to what we do for connect-explorer @karliatto 

## Depends on PRs: 
- #8886
- #9833
- #9879 
- #9884
- #9896
- #9790 (this can be followup, we are good for some beta, but should resolved to go to production)

## Rollout plan
- there will be a new package `@trezor/connect-webextension`. so `@trezor/connect` and `@trezor/connect-web` packages are not affected
- there are major changes in `popup.html`. These changes should not be breaking but we still should be cautious
- what about introducing something like connect.trezor.io/next where we would be gathering either breaking changes or changes we don't want to go to production directly?
- `@trezor/connect-webextension` should first be released as beta package.

## TODOS: 
- [ ] pretty much everything