### PR TITLE
refactor(suite-native): use translate hook simplified

### DIFF
--- a/suite-native/intl/src/hooks.ts
+++ b/suite-native/intl/src/hooks.ts
@@ -15,5 +15,5 @@ export const useTranslate = () => {
         [formatMessage],
     );
 
-    return { translate };
+    return translate;
 };


### PR DESCRIPTION
Since the `useTranslate` hook does return only a single value, there is no need to wrap it in the object. Then there is no need to unwrap it again while using the `translate` function. 