### PR TITLE
fix(coinmarket): Fix address label not showing in dropdown

### DIFF
--- a/packages/suite/src/views/wallet/coinmarket/common/AddressOptions.tsx
+++ b/packages/suite/src/views/wallet/coinmarket/common/AddressOptions.tsx
@@ -10,6 +10,8 @@ import { formatNetworkAmount } from '@suite-common/wallet-utils';
 import type { Account } from 'src/types/wallet';
 import { useAccountAddressDictionary } from 'src/hooks/wallet/useAccounts';
 import { AddressOptionsFormState } from 'src/types/wallet/coinmarketBuyOffers';
+import { selectLabelingDataForAccount } from 'src/reducers/suite/metadataReducer';
+import { useSelector } from 'src/hooks/suite';
 
 const AddressWrapper = styled.div`
     display: flex;
@@ -87,6 +89,9 @@ export const AddressOptions = <TFieldValues extends AddressOptionsFormState>({
     const addresses = account?.addresses;
     const addressDictionary = useAccountAddressDictionary(account);
     const value = address ? addressDictionary[address] : undefined;
+    const accountMetadata = useSelector(
+        state => account && selectLabelingDataForAccount(state, account.key),
+    );
 
     useEffect(() => {
         if (!address && addresses) {
@@ -115,7 +120,10 @@ export const AddressOptions = <TFieldValues extends AddressOptionsFormState>({
                         return (
                             <Option>
                                 <AddressWrapper>
-                                    <Address>{accountAddress.address}</Address>
+                                    <Address>
+                                        {accountMetadata?.addressLabels[accountAddress.address] ||
+                                            accountAddress.address}
+                                    </Address>
                                     <Amount>
                                         <CryptoWrapper>
                                             <FormattedCryptoAmount

--- a/packages/suite/src/views/wallet/coinmarket/common/AddressOptions.tsx
+++ b/packages/suite/src/views/wallet/coinmarket/common/AddressOptions.tsx
@@ -89,8 +89,8 @@ export const AddressOptions = <TFieldValues extends AddressOptionsFormState>({
     const addresses = account?.addresses;
     const addressDictionary = useAccountAddressDictionary(account);
     const value = address ? addressDictionary[address] : undefined;
-    const accountMetadata = useSelector(
-        state => account && selectLabelingDataForAccount(state, account.key),
+    const accountMetadata = useSelector(state =>
+        selectLabelingDataForAccount(state, account?.key || ''),
     );
 
     useEffect(() => {
@@ -121,7 +121,7 @@ export const AddressOptions = <TFieldValues extends AddressOptionsFormState>({
                             <Option>
                                 <AddressWrapper>
                                     <Address>
-                                        {accountMetadata?.addressLabels[accountAddress.address] ||
+                                        {accountMetadata.addressLabels[accountAddress.address] ||
                                             accountAddress.address}
                                     </Address>
                                     <Amount>


### PR DESCRIPTION
Fix address label not showing in dropdown.

## Description

When user sets a label for any bitcoin or bitcoin-like receiving address, the label is then not showing in the exchange flow.

## Related Issue

Resolve #9532 

## Screenshots:
![image](https://github.com/trezor/trezor-suite/assets/12121074/55cd31c3-4482-4294-9222-765b1c3db177)

