### PR TITLE
feat(solana) hide transaction summary for solana

### DIFF
--- a/packages/suite/src/actions/wallet/graphActions.ts
+++ b/packages/suite/src/actions/wallet/graphActions.ts
@@ -65,7 +65,7 @@ export const setSelectedView = (view: GraphScale): GraphAction => ({
 /**
  * Fetch the account history (received, sent amounts, num of txs) for the given `startDate`, `endDate`.
  * Returned data are grouped by `groupBy` seconds
- * No XRP support
+ * No XRP and SOL support
  *
  * @param {Account} account
  * @returns

--- a/packages/suite/src/views/wallet/transactions/Transactions.tsx
+++ b/packages/suite/src/views/wallet/transactions/Transactions.tsx
@@ -69,9 +69,12 @@ export const Transactions = () => {
     }
 
     if (accountTransactions.length > 0 || transactionsIsLoading) {
+        const networksWithoutTxSummary = ['ripple', 'solana'];
         return (
             <Layout selectedAccount={selectedAccount}>
-                {account.networkType !== 'ripple' && <TransactionSummary account={account} />}
+                {!networksWithoutTxSummary.includes(account.networkType) && (
+                    <TransactionSummary account={account} />
+                )}
 
                 <TransactionList
                     account={account}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Notes
- It works with [this branch](https://github.com/vacuumlabs/trezor-firmware/tree/solana-poc) in the Vacuumlabs’ Trezor firmware fork
- use `file obscure frog dance chunk panda honey obvious fault match unable always` mnemonic to see all kinds of transactions and pagination

## Description

This PR
 - removes tx summary for solana
 
 ## Explanation
  - solana does don't really have an endpoint for getting the the balance history, only way to get it, would be to fetch the whole tx history and parse it from it. Let me know what you think but IMO in that case we should avoid fetching tx history twice, and all at once and rather remove the tx summary 