### PR TITLE
chore(connect): fix local storage check

### DIFF
--- a/packages/connect-common/src/storage.ts
+++ b/packages/connect-common/src/storage.ts
@@ -37,7 +37,7 @@ export const save = (getNewState: GetNewStateCallback, temporary = false) => {
 };
 
 export const load = (temporary = false): Store => {
-    if (temporary || !global.window) {
+    if (temporary || !global?.window?.localStorage) {
         return memoryStorage;
     }
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
This check needs to be updated so the `getDeviceState` method doesn't fail on mobile app.

## Related Issue

Resolve <!--- link the issue here -->

## Screenshots:
