### PR TITLE
feat: Solana tokens 

### DIFF
--- a/packages/blockchain-link-types/package.json
+++ b/packages/blockchain-link-types/package.json
@@ -23,5 +23,8 @@
         "socks-proxy-agent": "6.1.1",
         "tsx": "^3.12.7",
         "typescript": "4.9.5"
+    },
+    "dependencies": {
+        "@solana/web3.js": "^1.78.5"
     }
 }

--- a/packages/blockchain-link-types/src/solana.ts
+++ b/packages/blockchain-link-types/src/solana.ts
@@ -7,3 +7,5 @@ export type SolanaValidParsedTxWithMeta = ParsedTransactionWithMeta & {
 };
 
 export type { ParsedInstruction, ParsedTransactionWithMeta } from '@solana/web3.js';
+
+export type TokenDetailByMint = { [mint: string]: { name: string; symbol: string } };

--- a/packages/blockchain-link-utils/package.json
+++ b/packages/blockchain-link-utils/package.json
@@ -17,6 +17,8 @@
         "prepublish": "yarn tsx ../../scripts/prepublish.js"
     },
     "dependencies": {
+        "@mobily/ts-belt": "^3.13.1",
+        "@solana/web3.js": "^1.78.5",
         "@trezor/utils": "workspace:*",
         "bignumber.js": "^9.1.1"
     },

--- a/packages/blockchain-link-utils/src/solana.ts
+++ b/packages/blockchain-link-utils/src/solana.ts
@@ -1,6 +1,6 @@
-import BigNumber from 'bignumber.js';
-import { A, F, pipe } from '@mobily/ts-belt';
+import { A, D, F, pipe } from '@mobily/ts-belt';
 import type { AccountInfo, ParsedAccountData, PublicKey } from '@solana/web3.js';
+import BigNumber from 'bignumber.js';
 
 import { Target, Transaction } from '@trezor/blockchain-link-types/lib';
 import type {
@@ -42,7 +42,18 @@ export const transformTokenInfo = (
                     ...getTokenNameAndSymbol(info.mint, tokenDetailByMint),
                 };
             }),
-            A.uniqBy(token => token.contract),
+            A.reduce({}, (acc: { [mint: string]: TokenInfo }, token: TokenInfo) => {
+                if (acc[token.contract] != null) {
+                    acc[token.contract].balance = new BigNumber(acc[token.contract].balance || '0')
+                        .plus(token.balance || '0')
+                        .toString();
+                } else {
+                    acc[token.contract] = token;
+                }
+
+                return acc;
+            }),
+            D.values,
         ),
     );
 

--- a/packages/blockchain-link-utils/src/tests/fixtures/solana.ts
+++ b/packages/blockchain-link-utils/src/tests/fixtures/solana.ts
@@ -501,6 +501,17 @@ export const fixtures = {
                 symbol: 'AQo...',
             },
         },
+        {
+            description: 'parses whitelisted token data from mint',
+            input: {
+                mint: 'So11111111111111111111111111111111111111112',
+                map: sampleMintToDetailMap,
+            },
+            expectedOutput: {
+                name: 'Wrapped SOL',
+                symbol: 'WSOL',
+            },
+        },
     ],
     transformTokenInfo: [
         {

--- a/packages/blockchain-link-utils/src/tests/fixtures/solana.ts
+++ b/packages/blockchain-link-utils/src/tests/fixtures/solana.ts
@@ -442,4 +442,17 @@ export const fixtures = {
             },
         },
     ],
+    getTokenNameAndSymbol: [
+        {
+            description: 'parses non-whitelist token data from mint',
+            input: {
+                mint: 'AQoKYV7tYpTrFZN6P5oUufbQKAUr9mNYGe1TTJC5wajM',
+                map: {},
+            },
+            expectedOutput: {
+                name: 'AQoKYV7tYpTrFZN6P5oUufbQKAUr9mNYGe1TTJC5wajM',
+                symbol: 'AQo...',
+            },
+        },
+    ],
 };

--- a/packages/blockchain-link-utils/src/tests/fixtures/solana.ts
+++ b/packages/blockchain-link-utils/src/tests/fixtures/solana.ts
@@ -160,6 +160,65 @@ const tokenAccountInfo = [
     },
 ];
 
+const tokenAccountInfoWithDuplicateTokenAccount = [
+    {
+        account: {
+            data: {
+                parsed: {
+                    info: {
+                        isNative: false,
+                        mint: '4k3Dyjzvzp8eMZWUXbBCjEvwSkkk59S5iCNLY3QrkX6R',
+                        owner: 'ETxHeBBcuw9Yu4dGuP3oXrD12V5RECvmi8ogQ9PkjyVF',
+                        state: 'initialized',
+                        tokenAmount: {
+                            amount: '2000000',
+                            decimals: 6,
+                            uiAmount: 2,
+                            uiAmountString: '2',
+                        },
+                    },
+                    type: 'account',
+                },
+                program: 'spl-token',
+                space: 165,
+            },
+            executable: false,
+            lamports: 2039280,
+            owner: new PublicKey('TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA'),
+            rentEpoch: 0,
+        },
+        pubkey: new PublicKey('ETxHeBBcuw9Yu4dGuP3oXrD12V5RECvmi8ogQ9PkjyVF'),
+    },
+    {
+        account: {
+            data: {
+                parsed: {
+                    info: {
+                        isNative: false,
+                        mint: '4k3Dyjzvzp8eMZWUXbBCjEvwSkkk59S5iCNLY3QrkX6R',
+                        owner: 'ETxHeBBcuw9Yu4dGuP3oXrD12V5RECvmi8ogQ9PkjyVF',
+                        state: 'initialized',
+                        tokenAmount: {
+                            amount: '1000000',
+                            decimals: 6,
+                            uiAmount: 2,
+                            uiAmountString: '1',
+                        },
+                    },
+                    type: 'account',
+                },
+                program: 'spl-token',
+                space: 165,
+            },
+            executable: false,
+            lamports: 2039280,
+            owner: new PublicKey('TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA'),
+            rentEpoch: 0,
+        },
+        pubkey: new PublicKey('ETxHeBBcuw9Yu4dGuP3oXrD12V5RECvmi8ogQ9PkjyVF'),
+    },
+];
+
 export const fixtures = {
     extractAccountBalanceDiff: [
         {
@@ -525,6 +584,24 @@ export const fixtures = {
                     type: 'SPL',
                     contract: '4k3Dyjzvzp8eMZWUXbBCjEvwSkkk59S5iCNLY3QrkX6R',
                     balance: '2000000',
+                    decimals: 6,
+                    name: 'Raydium',
+                    symbol: 'RAY',
+                },
+            ],
+        },
+        {
+            description:
+                'parses token info for multiple token accounts with the same token from api response',
+            input: {
+                accountInfo: tokenAccountInfoWithDuplicateTokenAccount,
+                map: sampleMintToDetailMap,
+            },
+            expectedOutput: [
+                {
+                    type: 'SPL',
+                    contract: '4k3Dyjzvzp8eMZWUXbBCjEvwSkkk59S5iCNLY3QrkX6R',
+                    balance: '3000000',
                     decimals: 6,
                     name: 'Raydium',
                     symbol: 'RAY',

--- a/packages/blockchain-link-utils/src/tests/fixtures/solana.ts
+++ b/packages/blockchain-link-utils/src/tests/fixtures/solana.ts
@@ -115,11 +115,11 @@ const effects = {
 };
 
 const sampleMintToDetailMap = {
-    'So11111111111111111111111111111111111111112': {
+    So11111111111111111111111111111111111111112: {
         name: 'Wrapped SOL',
         symbol: 'WSOL',
     },
-    'Es9vMFrzaCERmJfrF4H2FYD4KCoNkY11McCe8BenwNYB': {
+    Es9vMFrzaCERmJfrF4H2FYD4KCoNkY11McCe8BenwNYB: {
         name: 'Tether',
         symbol: 'USDT',
     },

--- a/packages/blockchain-link-utils/src/tests/fixtures/solana.ts
+++ b/packages/blockchain-link-utils/src/tests/fixtures/solana.ts
@@ -1,4 +1,5 @@
 import BigNumber from 'bignumber.js';
+import { PublicKey } from '@solana/web3.js';
 
 const instructions = {
     transfer: {
@@ -112,6 +113,52 @@ const effects = {
         amount: new BigNumber(10),
     },
 };
+
+const sampleMintToDetailMap = {
+    'So11111111111111111111111111111111111111112': {
+        name: 'Wrapped SOL',
+        symbol: 'WSOL',
+    },
+    'Es9vMFrzaCERmJfrF4H2FYD4KCoNkY11McCe8BenwNYB': {
+        name: 'Tether',
+        symbol: 'USDT',
+    },
+    '4k3Dyjzvzp8eMZWUXbBCjEvwSkkk59S5iCNLY3QrkX6R': {
+        name: 'Raydium',
+        symbol: 'RAY',
+    },
+};
+
+const tokenAccountInfo = [
+    {
+        account: {
+            data: {
+                parsed: {
+                    info: {
+                        isNative: false,
+                        mint: '4k3Dyjzvzp8eMZWUXbBCjEvwSkkk59S5iCNLY3QrkX6R',
+                        owner: 'ETxHeBBcuw9Yu4dGuP3oXrD12V5RECvmi8ogQ9PkjyVF',
+                        state: 'initialized',
+                        tokenAmount: {
+                            amount: '2000000',
+                            decimals: 6,
+                            uiAmount: 2,
+                            uiAmountString: '2',
+                        },
+                    },
+                    type: 'account',
+                },
+                program: 'spl-token',
+                space: 165,
+            },
+            executable: false,
+            lamports: 2039280,
+            owner: new PublicKey('TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA'),
+            rentEpoch: 0,
+        },
+        pubkey: new PublicKey('ETxHeBBcuw9Yu4dGuP3oXrD12V5RECvmi8ogQ9PkjyVF'),
+    },
+];
 
 export const fixtures = {
     extractAccountBalanceDiff: [
@@ -447,12 +494,31 @@ export const fixtures = {
             description: 'parses non-whitelist token data from mint',
             input: {
                 mint: 'AQoKYV7tYpTrFZN6P5oUufbQKAUr9mNYGe1TTJC5wajM',
-                map: {},
+                map: sampleMintToDetailMap,
             },
             expectedOutput: {
                 name: 'AQoKYV7tYpTrFZN6P5oUufbQKAUr9mNYGe1TTJC5wajM',
                 symbol: 'AQo...',
             },
+        },
+    ],
+    transformTokenInfo: [
+        {
+            description: 'parses token info from token accounts api response',
+            input: {
+                accountInfo: tokenAccountInfo,
+                map: sampleMintToDetailMap,
+            },
+            expectedOutput: [
+                {
+                    type: 'SPL',
+                    contract: '4k3Dyjzvzp8eMZWUXbBCjEvwSkkk59S5iCNLY3QrkX6R',
+                    balance: '2000000',
+                    decimals: 6,
+                    name: 'Raydium',
+                    symbol: 'RAY',
+                },
+            ],
         },
     ],
 };

--- a/packages/blockchain-link-utils/src/tests/solana.test.ts
+++ b/packages/blockchain-link-utils/src/tests/solana.test.ts
@@ -9,10 +9,20 @@ import {
     getTransactionEffects,
     getTxType,
     transformTransaction,
+    getTokenNameAndSymbol,
 } from '../solana';
 import { fixtures } from './fixtures/solana';
 
 describe('solana/utils', () => {
+    // Token Utils
+    describe('getTokenNameAndSymbol', () => {
+        fixtures.getTokenNameAndSymbol.forEach(({ description, input, expectedOutput }) => {
+            it(description, () => {
+                expect(getTokenNameAndSymbol(input.mint, input.map)).toEqual(expectedOutput);
+            });
+        });
+    });
+
     describe('extractAccountBalanceDiff', () => {
         fixtures.extractAccountBalanceDiff.forEach(({ description, input, expectedOutput }) => {
             it(description, () => {

--- a/packages/blockchain-link-utils/src/tests/solana.test.ts
+++ b/packages/blockchain-link-utils/src/tests/solana.test.ts
@@ -10,6 +10,7 @@ import {
     getTxType,
     transformTransaction,
     getTokenNameAndSymbol,
+    transformTokenInfo,
 } from '../solana';
 import { fixtures } from './fixtures/solana';
 
@@ -103,6 +104,14 @@ describe('solana/utils', () => {
                     input.slotToBlockHeightMapping as Record<number, number>,
                 );
                 expect(result).toEqual(expectedOutput);
+            });
+        });
+    });
+
+    describe('transformTokenInfo', () => {
+        fixtures.transformTokenInfo.forEach(({ description, input, expectedOutput }) => {
+            it(description, () => {
+                expect(transformTokenInfo(input.accountInfo, input.map)).toEqual(expectedOutput);
             });
         });
     });

--- a/packages/blockchain-link/src/workers/solana/index.ts
+++ b/packages/blockchain-link/src/workers/solana/index.ts
@@ -3,6 +3,7 @@ import type {
     AccountInfo,
     Transaction,
     SubscriptionAccountInfo,
+    TokenInfo,
 } from '@trezor/blockchain-link-types';
 import type {
     SolanaValidParsedTxWithMeta,
@@ -12,13 +13,17 @@ import type * as MessageTypes from '@trezor/blockchain-link-types/lib/messages';
 import { CustomError } from '@trezor/blockchain-link-types/lib/constants/errors';
 import { BaseWorker, ContextType, CONTEXT } from '../baseWorker';
 import { MESSAGES, RESPONSES } from '@trezor/blockchain-link-types/lib/constants';
+import { transformTokenInfo } from '@trezor/blockchain-link-utils/lib/solana';
 import { Connection, PublicKey } from '@solana/web3.js';
 import { solanaUtils } from '@trezor/blockchain-link-utils';
+import { getTokenMetadata } from './tokenUtils';
 
 export type SolanaAPI = Connection;
 
 type Context = ContextType<SolanaAPI>;
 type Request<T> = T & Context;
+
+const TOKEN_PROGRAM_PUBLIC_KEY = new PublicKey('TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA');
 
 const getAllSignatures = async (
     api: SolanaAPI,
@@ -79,7 +84,9 @@ const getAccountInfo = async (request: Request<MessageTypes.GetAccountInfo>) => 
     const { details = 'basic' } = payload;
     const api = await request.connect();
 
-    const accountInfo = await api.getAccountInfo(new PublicKey(payload.descriptor));
+    const publicKey = new PublicKey(payload.descriptor);
+
+    const accountInfo = await api.getAccountInfo(publicKey);
 
     if (!accountInfo) {
         // return empty account
@@ -141,6 +148,18 @@ const getAccountInfo = async (request: Request<MessageTypes.GetAccountInfo>) => 
 
     const transactionPage = details === 'txs' ? await getTransactionPage(txIdPage) : undefined;
 
+    const tokenInfo = await api.getParsedTokenAccountsByOwner(publicKey, {
+        programId: TOKEN_PROGRAM_PUBLIC_KEY,
+    });
+
+    // Fetch token info only if the account owns tokens
+    let tokens: TokenInfo[] = [];
+    if (tokenInfo.value.length > 0) {
+        const tokenMetadata = await getTokenMetadata();
+
+        tokens = transformTokenInfo(tokenInfo.value, tokenMetadata);
+    }
+
     const account: AccountInfo = {
         descriptor: payload.descriptor,
         balance: accountInfo.lamports.toString(), // TODO(vl): check if this should also include staking balances
@@ -159,12 +178,12 @@ const getAccountInfo = async (request: Request<MessageTypes.GetAccountInfo>) => 
                   size: transactionPage.length,
               }
             : undefined,
+        tokens,
     };
-
-    return Promise.resolve({
+    return {
         type: RESPONSES.GET_ACCOUNT_INFO,
         payload: account,
-    } as const);
+    } as const;
 };
 
 const getInfo = async (request: Request<MessageTypes.GetInfo>) => {

--- a/packages/blockchain-link/src/workers/solana/tokenUtils.ts
+++ b/packages/blockchain-link/src/workers/solana/tokenUtils.ts
@@ -1,0 +1,3 @@
+import { TokenDetailByMint } from '@trezor/blockchain-link-types/lib/solana';
+
+export const getTokenMetadata = async (): Promise<TokenDetailByMint> => Promise.resolve({});

--- a/packages/blockchain-link/src/workers/solana/tokenUtils.ts
+++ b/packages/blockchain-link/src/workers/solana/tokenUtils.ts
@@ -1,19 +1,25 @@
 import { TokenDetailByMint } from '@trezor/blockchain-link-types/lib/solana';
 
-const TOKEN_WHITELIST = {
-    So11111111111111111111111111111111111111112: {
-        name: 'Wrapped SOL',
-        symbol: 'WSOL',
-    },
-    Es9vMFrzaCERmJfrF4H2FYD4KCoNkY11McCe8BenwNYB: {
-        name: 'Tether',
-        symbol: 'USDT',
-    },
-    '4k3Dyjzvzp8eMZWUXbBCjEvwSkkk59S5iCNLY3QrkX6R': {
-        name: 'Raydium',
-        symbol: 'RAY',
-    },
-};
+// https://github.com/viaprotocol/tokenlists
+// Aggregated token list with tokens listed on multiple exchanges
+const solanaTokenListUrl =
+    'https://cdn.jsdelivr.net/gh/viaprotocol/tokenlists/all_tokens/solana.json';
 
-export const getTokenMetadata = async (): Promise<TokenDetailByMint> =>
-    Promise.resolve(TOKEN_WHITELIST);
+export const getTokenMetadata = async (): Promise<TokenDetailByMint> => {
+    const tokenListResult: { address: string; name: string; symbol: string }[] = await (
+        await fetch(solanaTokenListUrl)
+    ).json();
+
+    const tokenMap = tokenListResult.reduce(
+        (acc, token) => ({
+            [token.address]: {
+                name: token.name,
+                symbol: token.symbol,
+            },
+            ...acc,
+        }),
+        {} as TokenDetailByMint,
+    );
+
+    return tokenMap;
+};

--- a/packages/blockchain-link/src/workers/solana/tokenUtils.ts
+++ b/packages/blockchain-link/src/workers/solana/tokenUtils.ts
@@ -1,3 +1,19 @@
 import { TokenDetailByMint } from '@trezor/blockchain-link-types/lib/solana';
 
-export const getTokenMetadata = async (): Promise<TokenDetailByMint> => Promise.resolve({});
+const TOKEN_WHITELIST = {
+    So11111111111111111111111111111111111111112: {
+        name: 'Wrapped SOL',
+        symbol: 'WSOL',
+    },
+    Es9vMFrzaCERmJfrF4H2FYD4KCoNkY11McCe8BenwNYB: {
+        name: 'Tether',
+        symbol: 'USDT',
+    },
+    '4k3Dyjzvzp8eMZWUXbBCjEvwSkkk59S5iCNLY3QrkX6R': {
+        name: 'Raydium',
+        symbol: 'RAY',
+    },
+};
+
+export const getTokenMetadata = async (): Promise<TokenDetailByMint> =>
+    Promise.resolve(TOKEN_WHITELIST);

--- a/packages/blockchain-link/src/workers/solana/tokenUtils.ts
+++ b/packages/blockchain-link/src/workers/solana/tokenUtils.ts
@@ -1,5 +1,7 @@
 import { TokenDetailByMint } from '@trezor/blockchain-link-types/lib/solana';
 
+const WSOL_MINT = 'So11111111111111111111111111111111111111112';
+
 // https://github.com/viaprotocol/tokenlists
 // Aggregated token list with tokens listed on multiple exchanges
 const solanaTokenListUrl =
@@ -20,6 +22,9 @@ export const getTokenMetadata = async (): Promise<TokenDetailByMint> => {
         }),
         {} as TokenDetailByMint,
     );
+
+    // Explicitly set Wrapped SOL symbol to WSOL instead of the official 'SOL' which leads to confusion in UI
+    tokenMap[WSOL_MINT].symbol = 'WSOL';
 
     return tokenMap;
 };

--- a/packages/suite/src/components/wallet/AccountTopPanel/AccountNavigation.tsx
+++ b/packages/suite/src/components/wallet/AccountTopPanel/AccountNavigation.tsx
@@ -55,7 +55,7 @@ export const AccountNavigation = ({
             },
             title: <Translation id="TR_NAV_TOKENS" />,
             position: 'primary',
-            isHidden: !['cardano', 'ethereum'].includes(networkType),
+            isHidden: !['cardano', 'ethereum', 'solana'].includes(networkType),
         },
         {
             id: 'wallet-staking',

--- a/suite-common/wallet-config/src/networksConfig.ts
+++ b/suite-common/wallet-config/src/networksConfig.ts
@@ -423,7 +423,7 @@ export const networks = {
         bip43Path: "m/44'/501'/i'/0'",
         decimals: 9,
         testnet: false,
-        // features: ['tokens', 'staking'],
+        features: ['tokens' /* , 'staking' */],
         explorer: {
             tx: 'https://explorer.solana.com/tx/',
             account: 'https://explorer.solana.com/address/',

--- a/yarn.lock
+++ b/yarn.lock
@@ -5924,6 +5924,29 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@solana/web3.js@npm:^1.78.5":
+  version: 1.78.5
+  resolution: "@solana/web3.js@npm:1.78.5"
+  dependencies:
+    "@babel/runtime": ^7.22.6
+    "@noble/curves": ^1.0.0
+    "@noble/hashes": ^1.3.1
+    "@solana/buffer-layout": ^4.0.0
+    agentkeepalive: ^4.3.0
+    bigint-buffer: ^1.1.5
+    bn.js: ^5.2.1
+    borsh: ^0.7.0
+    bs58: ^4.0.1
+    buffer: 6.0.3
+    fast-stable-stringify: ^1.0.0
+    jayson: ^4.1.0
+    node-fetch: ^2.6.12
+    rpc-websockets: ^7.5.1
+    superstruct: ^0.14.2
+  checksum: 66fe4ddcc073d0c539e23a2aae3ba23c081a11f5ebc8216dd18e0c6770f20e419c635a50529faa59baeec9722cd521a3502abc7cdf3b3d5f31b32066e0415c24
+  languageName: node
+  linkType: hard
+
 "@storybook/addon-actions@npm:^7.2.3":
   version: 7.2.3
   resolution: "@storybook/addon-actions@npm:7.2.3"
@@ -8877,6 +8900,8 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@trezor/blockchain-link-utils@workspace:packages/blockchain-link-utils"
   dependencies:
+    "@mobily/ts-belt": ^3.13.1
+    "@solana/web3.js": ^1.78.5
     "@trezor/blockchain-link-types": "workspace:*"
     "@trezor/type-utils": "workspace:*"
     "@trezor/utils": "workspace:*"


### PR DESCRIPTION
## Description

This PR is the first in the Solana tokens feature planned for phase 2: it displays tokens in the wallet and adds them to account info.

**Note:** the last two commits are meant as alternatives to one another. We can either choose to maintain a local "whitelist" of tokens, or fetch a list of tokens from someplace online, such as [this repo](https://github.com/viaprotocol/tokenlists/blob/main/tokenlists/solana.json).

We are *not* going to implement adding tokens ("importing tokens") in Solana, as the mechanism is very different from ETH and requires a transaction in order to create a new account on chain to hold the token. The majority of wallets in the Solana ecosystem do not allow the user to explicitly manage token accounts and the transfers of tokens to and from token accounts are handled automatically by the wallet. 

#### How token accounts work on Solana
The user's system program address (= main wallet address) is used to derived new accounts, one for each token. The new account's address can be used to receive that token and no other token.  
How most wallets handle this and how we plan to handle this in suite is that when a user wants to send tokens to another user, they simply use the recipient's system program address (= main wallet address) and while constructing the transaction the wallet checks if the recipient already has a token account for the given token or not.  
If the recipient has a token account, the wallet constructs a transaction sending the token to that address, whereas if there is not token address for that token an instruction to create one for the recipient is added to the transaction and is [funded by the sender](https://spl.solana.com/token#example-transferring-tokens-to-another-user-with-sender-funding).

## Screenshots:

![obrázok](https://github.com/vacuumlabs/trezor-suite/assets/71935095/a6b58148-4a22-4374-ae6b-2b03b1e6ce80)

