### PR TITLE
fix(connect): add tslib (tsconfig importHelpers)

### DIFF
--- a/packages/connect/package.json
+++ b/packages/connect/package.json
@@ -84,5 +84,8 @@
         "typescript": "4.9.5",
         "webpack": "^5.87.0",
         "ws": "7.5.9"
+    },
+    "peerDependencies": {
+        "tslib": "^2.6.2"
     }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -9537,6 +9537,8 @@ __metadata:
     typescript: 4.9.5
     webpack: ^5.87.0
     ws: 7.5.9
+  peerDependencies:
+    tslib: ^2.6.2
   languageName: unknown
   linkType: soft
 
@@ -35358,9 +35360,9 @@ __metadata:
   linkType: hard
 
 "tslib@npm:^2.0.0, tslib@npm:^2.0.1, tslib@npm:^2.0.3, tslib@npm:^2.1.0, tslib@npm:^2.3.0, tslib@npm:^2.4.0, tslib@npm:^2.5.0, tslib@npm:^2.5.3":
-  version: 2.5.3
-  resolution: "tslib@npm:2.5.3"
-  checksum: 88902b309afaf83259131c1e13da1dceb0ad1682a213143a1346a649143924d78cf3760c448b84d796938fd76127183894f8d85cbb3bf9c4fddbfcc140c0003c
+  version: 2.6.2
+  resolution: "tslib@npm:2.6.2"
+  checksum: 329ea56123005922f39642318e3d1f0f8265d1e7fcb92c633e0809521da75eeaca28d2cf96d7248229deb40e5c19adf408259f4b9640afd20d13aecc1430f3ad
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
ok, we are playing a nice game here

at some point in the past, tslib was removed from pacakges/connect
995aa7dddc83657acb845a558d9bf310821aff72 tslib was added as a fix.
3d0506c834d3b9736c8df881ac0e7b5efe287a60 @tomasklim again removed tslib 

current connect build depends on tslib. see this check https://gitlab.com/satoshilabs/trezor/trezor-suite/-/jobs/5124718038 

maybe it should be listed as a peer dependency? @Nodonisko 