### PR TITLE
fix(connect-explorer): remove eval for json

### DIFF
--- a/packages/connect-explorer/src/data/methods/bitcoin/signTransaction.p2sh.ts
+++ b/packages/connect-explorer/src/data/methods/bitcoin/signTransaction.p2sh.ts
@@ -1,29 +1,42 @@
+/* eslint-disable no-bitwise */
 import { select } from './common';
 
 const name = 'signTransaction';
 const docs = 'methods/signTransaction.md';
 
 const test = {
-    inputs: `[
-    {
-        address_n: [(44 | 0x80000000) >>> 0, (1 | 0x80000000) >>> 0, (0 | 0x80000000) >>> 0, 1, 0],
-        amount: "123456789",
-        prev_index: 0,
-        prev_hash: "20912f98ea3ed849042efed0fdac8cb4fc301961c5988cba56902d8ffb61c337",
-    }
-]`,
-    outputs: `[
-    {
-        address: "1MJ2tj2ThBE62zXbBYA5ZaN3fdve5CPAz1",
-        amount: "12300000",
-        script_type: "PAYTOADDRESS"
-    },
-    {
-        address_n: [(49 | 0x80000000) >>> 0, (1 | 0x80000000) >>> 0, (0 | 0x80000000) >>> 0, 2, 0],
-        script_type: "PAYTOADDRESS",
-        amount: Number(123456789 - 11000 - 12300000).toString(),
-    }
-]`,
+    inputs: [
+        {
+            address_n: [
+                (44 | 0x80000000) >>> 0,
+                (1 | 0x80000000) >>> 0,
+                (0 | 0x80000000) >>> 0,
+                1,
+                0,
+            ],
+            amount: '123456789',
+            prev_index: 0,
+            prev_hash: '20912f98ea3ed849042efed0fdac8cb4fc301961c5988cba56902d8ffb61c337',
+        },
+    ],
+    outputs: [
+        {
+            address: '1MJ2tj2ThBE62zXbBYA5ZaN3fdve5CPAz1',
+            amount: '12300000',
+            script_type: 'PAYTOADDRESS',
+        },
+        {
+            address_n: [
+                (49 | 0x80000000) >>> 0,
+                (1 | 0x80000000) >>> 0,
+                (0 | 0x80000000) >>> 0,
+                2,
+                0,
+            ],
+            script_type: 'PAYTOADDRESS',
+            amount: Number(123456789 - 11000 - 12300000).toString(),
+        },
+    ],
 };
 
 const examples = {

--- a/packages/connect-explorer/src/data/methods/bitcoin/signTransaction.paytoaddress.ts
+++ b/packages/connect-explorer/src/data/methods/bitcoin/signTransaction.paytoaddress.ts
@@ -1,130 +1,160 @@
+/* eslint-disable no-bitwise */
 import { select } from './common';
 
 const name = 'signTransaction';
 const docs = 'methods/signTransaction.md';
 
 const btc = {
-    inputs: `[
-    {
-        address_n: [44 | 0x80000000, 0 | 0x80000000, 0 | 0x80000000, 0, 5],
-        prev_hash: '50f6f1209ca92d7359564be803cb2c932cde7d370f7cee50fd1fad6790f6206d',
-        prev_index: 1,
-    },
-]`,
-    outputs: `[
+    inputs: [
+        {
+            address_n: [44 | 0x80000000, 0 | 0x80000000, 0 | 0x80000000, 0, 5],
+            prev_hash: '50f6f1209ca92d7359564be803cb2c932cde7d370f7cee50fd1fad6790f6206d',
+            prev_index: 1,
+        },
+    ],
+    outputs: [
         {
             address: 'bc1qrp33g0q5c5txsp9arysrx4k6zdkfs4nce4xj0gdcccefvpysxf3qccfmv3',
             amount: '10000',
             script_type: 'PAYTOADDRESS',
         },
-]`,
+    ],
 };
 
 const bch = {
-    inputs: `[
-    {
-        address_n: [44 | 0x80000000, 145 | 0x80000000, 0 | 0x80000000, 0, 0],
-        amount: '1995344',
-        prev_hash: 'bc37c28dfb467d2ecb50261387bf752a3977d7e5337915071bb4151e6b711a78',
-        prev_index: 0,
-        script_type: 'SPENDADDRESS',
-    },
-]`,
-    outputs: `[
-    {
-        address_n: [44 | 0x80000000, 145 | 0x80000000, 0 | 0x80000000, 1, 0],
-        amount: '1896050',
-        script_type: 'PAYTOADDRESS',
-    },
-    {
-        address: 'bitcoincash:qr23ajjfd9wd73l87j642puf8cad20lfmqdgwvpat4',
-        amount: '73452',
-        script_type: 'PAYTOADDRESS',
-    },
-]`,
+    inputs: [
+        {
+            address_n: [44 | 0x80000000, 145 | 0x80000000, 0 | 0x80000000, 0, 0],
+            amount: '1995344',
+            prev_hash: 'bc37c28dfb467d2ecb50261387bf752a3977d7e5337915071bb4151e6b711a78',
+            prev_index: 0,
+            script_type: 'SPENDADDRESS',
+        },
+    ],
+    outputs: [
+        {
+            address_n: [44 | 0x80000000, 145 | 0x80000000, 0 | 0x80000000, 1, 0],
+            amount: '1896050',
+            script_type: 'PAYTOADDRESS',
+        },
+        {
+            address: 'bitcoincash:qr23ajjfd9wd73l87j642puf8cad20lfmqdgwvpat4',
+            amount: '73452',
+            script_type: 'PAYTOADDRESS',
+        },
+    ],
 };
 
 const test = {
-    inputs: `[
+    inputs: [
         {
-            address_n: [(44 | 0x80000000) >>> 0, (1 | 0x80000000) >>> 0, (0 | 0x80000000) >>> 0, 1, 0],
-            amount: "123456789",
+            address_n: [
+                (44 | 0x80000000) >>> 0,
+                (1 | 0x80000000) >>> 0,
+                (0 | 0x80000000) >>> 0,
+                1,
+                0,
+            ],
+            amount: '123456789',
             prev_index: 0,
-            prev_hash: "20912f98ea3ed849042efed0fdac8cb4fc301961c5988cba56902d8ffb61c337",
-        }
-    ]`,
-    outputs: `[
+            prev_hash: '20912f98ea3ed849042efed0fdac8cb4fc301961c5988cba56902d8ffb61c337',
+        },
+    ],
+    outputs: [
         {
-            address: "1MJ2tj2ThBE62zXbBYA5ZaN3fdve5CPAz1",
-            amount: "12300000",
-            script_type: "PAYTOADDRESS"
+            address: '1MJ2tj2ThBE62zXbBYA5ZaN3fdve5CPAz1',
+            amount: '12300000',
+            script_type: 'PAYTOADDRESS',
         },
         {
-            address_n: [(49 | 0x80000000) >>> 0, (1 | 0x80000000) >>> 0, (0 | 0x80000000) >>> 0, 2, 0],
-            script_type: "PAYTOADDRESS",
+            address_n: [
+                (49 | 0x80000000) >>> 0,
+                (1 | 0x80000000) >>> 0,
+                (0 | 0x80000000) >>> 0,
+                2,
+                0,
+            ],
+            script_type: 'PAYTOADDRESS',
             amount: Number(123456789 - 11000 - 12300000).toString(),
-        }
-    ]`,
+        },
+    ],
 };
 
 const dash = {
-    inputs: `[
+    inputs: [
         {
-            address_n: [(44 | 0x80000000) >>> 0, (5 | 0x80000000) >>> 0, (0 | 0x80000000) >>> 0, 1, 0],
-            amount: "167280961",
+            address_n: [
+                (44 | 0x80000000) >>> 0,
+                (5 | 0x80000000) >>> 0,
+                (0 | 0x80000000) >>> 0,
+                1,
+                0,
+            ],
+            amount: '167280961',
             prev_index: 0,
-            prev_hash: "adb43bcd8fc99d6ed353c30ca8e5bd5996cd7bcf719bd4253f103dfb7227f6ed",
-        }
-]`,
-    outputs: `[
-    {
-        address: "XkNPrBSJtrHZUvUqb3JF4g5rMB3uzaJfEL",
-        amount: "167000000",
-        script_type: "PAYTOADDRESS"
-    },
-]`,
+            prev_hash: 'adb43bcd8fc99d6ed353c30ca8e5bd5996cd7bcf719bd4253f103dfb7227f6ed',
+        },
+    ],
+    outputs: [
+        {
+            address: 'XkNPrBSJtrHZUvUqb3JF4g5rMB3uzaJfEL',
+            amount: '167000000',
+            script_type: 'PAYTOADDRESS',
+        },
+    ],
 };
 
 // version 3
 const zcash = {
-    inputs: `[
+    inputs: [
         {
             address_n: [2147483692, 2147483781, 2147483648, 0, 2],
             prev_hash: '6df53ccdc6fa17e1cd248f7ec57e86178d6f96f2736bdf978602992b5850ac79',
             prev_index: 1,
-            amount: '200000'
+            amount: '200000',
         },
-
-    ]`,
-    outputs: `[
+    ],
+    outputs: [
         {
             address: 't1N5zTV5PjJqRgSPmszHopk88Nc6mvMBSD7',
             amount: '100000',
             script_type: 'PAYTOADDRESS',
         },
-    ]`,
+    ],
 };
 
 const doge = {
-    inputs: `[
+    inputs: [
         {
-            address_n: [(44 | 0x80000000) >>> 0, (3 | 0x80000000) >>> 0, (0 | 0x80000000) >>> 0, 1, 0],
+            address_n: [
+                (44 | 0x80000000) >>> 0,
+                (3 | 0x80000000) >>> 0,
+                (0 | 0x80000000) >>> 0,
+                1,
+                0,
+            ],
             prev_index: 12,
-            prev_hash: "0a4cb7d5c27455333701f0e53812e4be56a0272ad7f168279acfed7b065ee118",
+            prev_hash: '0a4cb7d5c27455333701f0e53812e4be56a0272ad7f168279acfed7b065ee118',
         },
-]`,
-    outputs: `[
+    ],
+    outputs: [
         {
-            address: "D9vbBhmwXgRegm5kVAcx8j6H2GDM87D58T",
-            amount: "1351855234633976",
-            script_type: "PAYTOADDRESS"
+            address: 'D9vbBhmwXgRegm5kVAcx8j6H2GDM87D58T',
+            amount: '1351855234633976',
+            script_type: 'PAYTOADDRESS',
         },
         {
-            address_n: [(44 | 0x80000000) >>> 0, (3 | 0x80000000) >>> 0, (0 | 0x80000000) >>> 0, 1, 0],
-            amount: "10000000000000000",
-            script_type: "PAYTOADDRESS"
+            address_n: [
+                (44 | 0x80000000) >>> 0,
+                (3 | 0x80000000) >>> 0,
+                (0 | 0x80000000) >>> 0,
+                1,
+                0,
+            ],
+            amount: '10000000000000000',
+            script_type: 'PAYTOADDRESS',
         },
-]`,
+    ],
 };
 
 const examples = {

--- a/packages/connect-explorer/src/data/methods/bitcoin/signTransaction.zcash.ts
+++ b/packages/connect-explorer/src/data/methods/bitcoin/signTransaction.zcash.ts
@@ -1,3 +1,4 @@
+/* eslint-disable no-bitwise */
 import { select } from './common';
 
 const name = 'signTransaction';
@@ -19,21 +20,32 @@ export default [
             {
                 name: 'inputs',
                 type: 'json',
-                value: `[{
-    address_n: [(44 | 0x80000000) >>> 0, (133 | 0x80000000) >>> 0, (0 | 0x80000000) >>> 0, 0, 0],
-    prev_hash: '4264f5f339c9fd498976dabb6d7b8819e112d25a0c1770a0f3ee81de525de8f8',
-    prev_index: 0,
-    amount: '118540'
-}]`,
+                value: [
+                    {
+                        address_n: [
+                            (44 | 0x80000000) >>> 0,
+                            (133 | 0x80000000) >>> 0,
+                            (0 | 0x80000000) >>> 0,
+                            0,
+                            0,
+                        ],
+                        prev_hash:
+                            '4264f5f339c9fd498976dabb6d7b8819e112d25a0c1770a0f3ee81de525de8f8',
+                        prev_index: 0,
+                        amount: '118540',
+                    },
+                ],
             },
             {
                 name: 'outputs',
                 type: 'json',
-                value: `[{
-    address: 't1fT6Zv1LcPwSwausNAuYGdewv2Mke3nrYo',
-    amount: '118000',
-    script_type: 'PAYTOADDRESS',
-}]`,
+                value: [
+                    {
+                        address: 't1fT6Zv1LcPwSwausNAuYGdewv2Mke3nrYo',
+                        amount: '118000',
+                        script_type: 'PAYTOADDRESS',
+                    },
+                ],
             },
             {
                 name: 'overwintered',

--- a/packages/connect-explorer/src/data/methods/ethereum/signTransaction-erc20-known.ts
+++ b/packages/connect-explorer/src/data/methods/ethereum/signTransaction-erc20-known.ts
@@ -1,6 +1,6 @@
 const name = 'ethereumSignTransaction';
 const docs = 'methods/ethereumSignTransaction.md';
-const tx = `{
+const tx = {
     nonce: '0x0',
     gasPrice: '0x14',
     gasLimit: '0x14',
@@ -8,7 +8,7 @@ const tx = `{
     chainId: 1,
     value: '0x0',
     data: '0xa9059cbb000000000000000000000000D6971aabeDC7f2A8113679199FE374aE1B1Aea96000000000000000000000000000000000000000000000000000000000097f6b2',
-}`;
+};
 
 // sending erc20 known token (USDT)
 export default [

--- a/packages/connect-explorer/src/data/methods/ethereum/signTransaction-erc20-unknown.ts
+++ b/packages/connect-explorer/src/data/methods/ethereum/signTransaction-erc20-unknown.ts
@@ -1,7 +1,7 @@
 const name = 'ethereumSignTransaction';
 const docs = 'methods/ethereumSignTransaction.md';
 
-const tx = `{
+const tx = {
     nonce: '0x0',
     gasPrice: '0x14',
     gasLimit: '0x14',
@@ -9,7 +9,7 @@ const tx = `{
     chainId: 1,
     value: '0x0',
     data: '0xa9059cbb000000000000000000000000D6971aabeDC7f2A8113679199FE374aE1B1Aea96000000000000000000000000000000000000000000000000000000000097f6b2',
-}`;
+};
 
 // sending erc-20 unknown token (unknown to firmware)
 // https://etherscan.io/token/0x26fb86579e371c7aedc461b2ddef0a8628c93d3b

--- a/packages/connect-explorer/src/data/methods/ethereum/signTransaction.ts
+++ b/packages/connect-explorer/src/data/methods/ethereum/signTransaction.ts
@@ -1,14 +1,14 @@
 const name = 'ethereumSignTransaction';
 const docs = 'methods/ethereumSignTransaction.md';
 
-const tx = `{
+const tx = {
     nonce: '0x0',
     gasPrice: '0x14',
     gasLimit: '0x14',
     to: '0xd0d6d6c5fe4a677d343cc433536bb717bae167dd',
     chainId: 1,
     value: '1',
-}`;
+};
 
 export default [
     {

--- a/packages/connect-explorer/src/data/methods/ethereum/signTypedData.ts
+++ b/packages/connect-explorer/src/data/methods/ethereum/signTypedData.ts
@@ -31,7 +31,7 @@ export default [
             {
                 name: 'data',
                 type: 'json',
-                value: JSON.stringify(eip712Data),
+                value: eip712Data,
             },
             {
                 name: 'domain_separator_hash',

--- a/packages/connect-explorer/src/reducers/methodReducer.ts
+++ b/packages/connect-explorer/src/reducers/methodReducer.ts
@@ -54,7 +54,11 @@ const getParam = (field: Field<any>, $params: Record<string, any> = {}) => {
         }
     } else if (field.type === 'json') {
         try {
-            params[field.name] = field.value.length > 0 ? eval(`(${field.value});`) : '';
+            if (typeof field.value === 'string' && field.value.length > 0) {
+                params[field.name] = JSON.parse(field.value);
+            } else {
+                params[field.name] = field.value;
+            }
         } catch (error) {
             params[field.name] = `Invalid json, ${error.toString()}`;
         }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
When implementing trezor connect explorer in web extension some methods are not working because of using eval.
These changes want to change the way we store and read data for methods in connect-explorer so `eval` becomes unnecessary.

I think it is straight forward to replace it in methods with type `json` but there is one with a function and I am still not sure how to fix that https://github.com/trezor/trezor-suite/blob/develop/packages/connect-explorer/src/data/methods/other/login.ts#L31

## Related Issue
This is a requirement to have popup tests running in connect-explorer in web extension https://github.com/trezor/trezor-suite/pull/9217

