### PR TITLE
chore: metadata refactoring 4

### DIFF
--- a/packages/e2e-utils/src/mocks/dropbox.ts
+++ b/packages/e2e-utils/src/mocks/dropbox.ts
@@ -100,7 +100,7 @@ export class DropboxMock {
         app.post('/2/files/search_v2', express.raw(), (req, res) => {
             const { query } = req.body;
 
-            const file = this.files[`/apps/trezor/${query}`];
+            const file = this.files[`/${query}`];
 
             // @ts-expect-error
             res.writeHeader(200, { 'Content-Type': 'application/json' });
@@ -144,9 +144,9 @@ export class DropboxMock {
             // @ts-expect-error
             const dropboxApiArgs = JSON.parse(req.headers['dropbox-api-arg']);
             const { path } = dropboxApiArgs;
-            const name = path.replace('/apps/trezor/', '');
+            const name = path.replace('/apps/trezor', '');
 
-            const file = this.files[path];
+            const file = this.files[name];
 
             if (file) {
                 // @ts-expect-error

--- a/packages/suite-web/e2e/tests/metadata/account-metadata.test.ts
+++ b/packages/suite-web/e2e/tests/metadata/account-metadata.test.ts
@@ -152,6 +152,17 @@ Hovering over fields that may be labeled shows "add label" button upon which is 
             //         expect(requests.length).equal(expectedNumberOfRequests[1]);
             //     }),
             // );
+
+            // test labeling of a newly added account
+            cy.getTestElement('@suite/menu/wallet-index').click();
+            cy.getTestElement('@account-menu/add-account').click();
+            cy.getTestElement('@settings/wallet/network/btc').click();
+            cy.getTestElement('@add-account').click();
+            cy.hoverTestElement("@metadata/accountLabel/m/84'/0'/2'/hover-container");
+            cy.getTestElement("@metadata/accountLabel/m/84'/0'/2'/add-label-button").click();
+            cy.getTestElement('@metadata/input').type(
+                'adding label to a newly added account. does it work?{enter}',
+            );
         });
     });
 });

--- a/packages/suite-web/e2e/tests/metadata/dropbox-api-errors.test.ts
+++ b/packages/suite-web/e2e/tests/metadata/dropbox-api-errors.test.ts
@@ -18,7 +18,7 @@ describe('Dropbox api errors', () => {
         // prepare some initial files
         cy.task('metadataSetFileContent', {
             provider: 'dropbox',
-            file: '/apps/trezor/f7acc942eeb83921892a95085e409b3e6b5325db6400ae5d8de523a305291dca.mtdt',
+            file: '/f7acc942eeb83921892a95085e409b3e6b5325db6400ae5d8de523a305291dca.mtdt',
             content: {
                 version: '1.0.0',
                 accountLabel: 'already existing label',
@@ -80,7 +80,7 @@ describe('Dropbox api errors', () => {
         // prepare some initial files
         cy.task('metadataSetFileContent', {
             provider: 'dropbox',
-            file: '/apps/trezor/f7acc942eeb83921892a95085e409b3e6b5325db6400ae5d8de523a305291dca.mtdt',
+            file: '/f7acc942eeb83921892a95085e409b3e6b5325db6400ae5d8de523a305291dca.mtdt',
             content: {
                 version: '1.0.0',
                 accountLabel: 'already existing label',

--- a/packages/suite-web/e2e/tests/metadata/dropbox-api-errors.test.ts
+++ b/packages/suite-web/e2e/tests/metadata/dropbox-api-errors.test.ts
@@ -104,8 +104,30 @@ describe('Dropbox api errors', () => {
 
         cy.passThroughInitMetadata('dropbox');
 
-        cy.getTestElement('@suite/menu/wallet-index').click();
+        // this request is not retried
+        cy.task('metadataSetNextResponse', {
+            provider: 'dropbox',
+            status: 200,
+            body: {
+                name: {
+                    given_name: 'dog',
+                    surname: 'cat',
+                    familiar_name: 'kitty-dog',
+                    display_name: 'dog-cat',
+                    abbreviated_name: 'DC',
+                },
+                email: 'some@mail.com',
+                email_verified: true,
+                profile_photo_url: 'foo',
+                disabled: false,
+                country: 'CZ',
+                locale: 'en',
+                referral_link: 'foo',
+                is_paired: false,
+            },
+        });
 
+        // this one is -> simulate rate limitted scenario
         cy.task('metadataSetNextResponse', {
             provider: 'dropbox',
             status: 429,
@@ -114,6 +136,7 @@ describe('Dropbox api errors', () => {
                 'Content-Type': 'text/plain; charset=utf-8',
             },
         });
+        cy.getTestElement('@suite/menu/wallet-index').click();
 
         cy.getTestElement("@metadata/accountLabel/m/84'/0'/0'").click({ force: true });
         cy.getTestElement("@metadata/accountLabel/m/84'/0'/0'/edit-label-button").click({
@@ -133,7 +156,7 @@ describe('Dropbox api errors', () => {
         // prepare some initial files
         cy.task('metadataSetFileContent', {
             provider: 'dropbox',
-            file: '/apps/trezor/f7acc942eeb83921892a95085e409b3e6b5325db6400ae5d8de523a305291dca.mtdt',
+            file: '/f7acc942eeb83921892a95085e409b3e6b5325db6400ae5d8de523a305291dca.mtdt',
             content: {
                 version: '1.0.0',
                 accountLabel: 'already existing label',
@@ -160,6 +183,8 @@ describe('Dropbox api errors', () => {
 
         // just enter some label, this indicates that app did not crash
         cy.getTestElement('@suite/menu/wallet-index').click();
+
+        cy.hoverTestElement("@metadata/accountLabel/m/84'/0'/0'/hover-container");
         cy.getTestElement("@metadata/accountLabel/m/84'/0'/0'").click({ force: true });
         cy.getTestElement("@metadata/accountLabel/m/84'/0'/0'/edit-label-button").click({
             force: true,

--- a/packages/suite-web/e2e/tests/metadata/interval-fetching.test.ts
+++ b/packages/suite-web/e2e/tests/metadata/interval-fetching.test.ts
@@ -15,7 +15,7 @@ const fixtures = [
     {
         provider: 'dropbox',
         desc: 'does watch files over time',
-        file: '/apps/trezor/f7acc942eeb83921892a95085e409b3e6b5325db6400ae5d8de523a305291dca.mtdt',
+        file: '/f7acc942eeb83921892a95085e409b3e6b5325db6400ae5d8de523a305291dca.mtdt',
         content: 'label from another window',
     },
 ] as const;

--- a/packages/suite-web/e2e/tests/metadata/metadata-lifecycle.test.ts
+++ b/packages/suite-web/e2e/tests/metadata/metadata-lifecycle.test.ts
@@ -1,0 +1,94 @@
+// @group:metadata
+// @retry=2
+
+const mnemonic = 'all all all all all all all all all all all all';
+
+describe('Metadata - cancel metadata on device', () => {
+    beforeEach(() => {
+        cy.viewport(1080, 1440).resetDb();
+    });
+
+    it('user cancels metadata on device, choice is respected on subsequent runs but only for the cancelled wallet', () => {
+        // prepare test
+        cy.task('startEmu', { wipe: true });
+        cy.task('setupEmu', {
+            mnemonic,
+        });
+        cy.task('startBridge');
+        cy.task('metadataStartProvider', 'dropbox');
+
+        // first go to settings, see that metadata is disabled by default.
+        cy.prefixedVisit('/settings');
+        cy.passThroughInitialRun();
+        cy.getTestElement('@settings/metadata-switch').within(() => {
+            cy.get('input').should('not.be.checked');
+        });
+
+        // now go to accounts. application does not try to initiate metadata
+        cy.getTestElement('@suite/menu/wallet-index').click();
+        cy.discoveryShouldFinish();
+
+        // but even though metadata is disabled, on hover "add label" button appears
+        cy.hoverTestElement("@metadata/accountLabel/m/84'/0'/0'/hover-container");
+        cy.getTestElement("@metadata/accountLabel/m/84'/0'/0'/add-label-button").click();
+
+        // now user cancels dialogue on device
+        cy.getConfirmActionOnDeviceModal();
+        cy.task('pressNo');
+        cy.wait(501);
+
+        // cancelling labeling on device actually enables labeling globally so when user reloads app,
+        // metadata dialogue will be propmted. now user cancels dialogue on device again and remembers device
+        cy.reload();
+        cy.getConfirmActionOnDeviceModal();
+        cy.task('pressNo');
+        cy.getTestElement('@menu/switch-device').click();
+        cy.getTestElement('@switch-device/wallet-on-index/0/toggle-remember-switch').click({
+            force: true,
+        });
+        cy.wait(200); // wait for db write to finish :( sad
+        cy.reload();
+        cy.discoveryShouldFinish(); // no dialogue!
+
+        // but when user tries to add another wallet, there is enable labeling dialogue again
+        cy.getTestElement('@menu/switch-device').click();
+        cy.getTestElement('@switch-device/add-hidden-wallet-button').click();
+        cy.getConfirmActionOnDeviceModal();
+        cy.task('pressYes');
+        cy.getTestElement('@passphrase/input').type('abc');
+        cy.getTestElement('@passphrase/hidden/submit-button').click();
+        cy.getTestElement('@passphrase/input').should('not.exist');
+        cy.getConfirmActionOnDeviceModal();
+        cy.task('pressYes');
+        cy.getConfirmActionOnDeviceModal();
+        cy.task('pressYes');
+        cy.getTestElement('@passphrase/input').type('abc');
+        cy.getTestElement('@passphrase/confirm-checkbox', { timeout: 10000 }).click();
+        cy.getTestElement('@passphrase/hidden/submit-button').click();
+        cy.getTestElement('@passphrase/input').should('not.exist');
+        cy.getConfirmActionOnDeviceModal();
+        cy.task('pressYes');
+        cy.wait(501);
+        cy.getConfirmActionOnDeviceModal();
+        cy.task('pressYes');
+        cy.wait(501);
+        cy.getConfirmActionOnDeviceModal(); // <--- this is enable labeling dialogue
+        cy.task('pressNo');
+        cy.getTestElement('@accounts/empty-account/receive');
+
+        // unremember device and reload -> enable labeling dialogue appers
+        // explanation: metadata.error is index by device.state and we treat this field as sensitive
+        // as keeping it might beat users pluasible deniability
+        cy.getTestElement('@menu/switch-device').click();
+        cy.getTestElement('@switch-device/wallet-on-index/0/toggle-remember-switch').click({
+            force: true,
+        });
+        cy.wait(200); // wait for db write to finish :( sad
+        cy.reload();
+        cy.getTestElement('@passphrase-type/standard').click();
+        cy.getConfirmActionOnDeviceModal();
+        cy.task('pressNo');
+    });
+});
+
+export {};

--- a/packages/suite-web/e2e/tests/metadata/remembered-device.test.ts
+++ b/packages/suite-web/e2e/tests/metadata/remembered-device.test.ts
@@ -10,7 +10,7 @@ const providers = [
     },
     {
         provider: 'dropbox',
-        file: '/apps/trezor/f7acc942eeb83921892a95085e409b3e6b5325db6400ae5d8de523a305291dca.mtdt',
+        file: '/f7acc942eeb83921892a95085e409b3e6b5325db6400ae5d8de523a305291dca.mtdt',
     },
 ] as const;
 

--- a/packages/suite-web/e2e/tests/metadata/wallet-metadata.test.ts
+++ b/packages/suite-web/e2e/tests/metadata/wallet-metadata.test.ts
@@ -110,6 +110,31 @@ describe('Metadata - wallet labeling', () => {
                     );
                     return expect(errors).to.be.empty;
                 });
+
+            // remember wallet, reload app, and observe that labels were loaded
+            // https://github.com/trezor/trezor-suite/pull/9560
+            cy.getTestElement('@switch-device/wallet-on-index/0/toggle-remember-switch').click({
+                force: true,
+            });
+            cy.getTestElement('@switch-device/wallet-on-index/1/toggle-remember-switch').click({
+                force: true,
+            });
+            cy.wait(200); // wait for data to save to persistent storage. currently this is not reflected in UI
+            cy.prefixedVisit('/', {
+                onBeforeLoad: (win: Window) => {
+                    cy.stub(win, 'open').callsFake(stubOpen(win));
+                    cy.stub(win, 'fetch').callsFake(rerouteMetadataToMockProvider);
+                },
+            });
+            cy.getTestElement('@menu/switch-device').click();
+            cy.getTestElement(`@metadata/walletLabel/${standardWalletState}`).should(
+                'contain',
+                'wallet for drugs',
+            );
+            cy.getTestElement(`@metadata/walletLabel/${firstHiddenWalletState}`).should(
+                'contain',
+                'wallet not for drugs',
+            );
         });
     });
 });

--- a/packages/suite-web/e2e/tests/metadata/wallet-metadata.test.ts
+++ b/packages/suite-web/e2e/tests/metadata/wallet-metadata.test.ts
@@ -11,6 +11,8 @@ const mnemonic = 'all all all all all all all all all all all all';
 const standardWalletState = 'mvbu1Gdy8SUjTenqerxUaZyYjmveZvt33q@355C817510C0EABF2F147145:0';
 // state corresponding to "wallet for drugs"
 const firstHiddenWalletState = 'myBrmyzvN5Wa4oeYrL7t8EYU1Ch5Q6vp47@355C817510C0EABF2F147145:1';
+// state corresponding to "C"
+const secondHiddenWalletState = 'mkx2Uqi3fmLHh8AHpQvAErTM3MZpzrmFr2@355C817510C0EABF2F147145:2';
 
 describe('Metadata - wallet labeling', () => {
     beforeEach(() => {
@@ -100,17 +102,6 @@ describe('Metadata - wallet labeling', () => {
                 'wallet not for drugs',
             );
 
-            cy.window()
-                .its('store')
-                .invoke('getState')
-                .then(state => {
-                    console.log(state);
-                    const errors = state.notifications.filter(
-                        (n: { type: string }) => n.type === 'error',
-                    );
-                    return expect(errors).to.be.empty;
-                });
-
             // remember wallet, reload app, and observe that labels were loaded
             // https://github.com/trezor/trezor-suite/pull/9560
             cy.getTestElement('@switch-device/wallet-on-index/0/toggle-remember-switch').click({
@@ -135,6 +126,51 @@ describe('Metadata - wallet labeling', () => {
                 'contain',
                 'wallet not for drugs',
             );
+
+            // add another passphrase wallet C, have selected passphrase wallet A, try to enable
+            // labeling for wallet C
+            cy.getTestElement('@switch-device/add-hidden-wallet-button').click();
+            cy.getTestElement('@passphrase/input').type('C');
+            cy.getTestElement('@passphrase/hidden/submit-button').click();
+            cy.getTestElement('@passphrase/input').should('not.exist');
+            cy.getConfirmActionOnDeviceModal();
+            cy.task('pressYes');
+            cy.getConfirmActionOnDeviceModal();
+            cy.task('pressYes');
+            cy.getTestElement('@passphrase/input', { timeout: 30000 }).type('C');
+            cy.getTestElement('@passphrase/confirm-checkbox').click();
+            cy.getTestElement('@passphrase/hidden/submit-button').click();
+            cy.getTestElement('@modal').should('not.exist');
+            cy.getConfirmActionOnDeviceModal();
+            cy.task('pressYes');
+            cy.getConfirmActionOnDeviceModal();
+            cy.task('pressYes');
+            cy.getTestElement('@menu/switch-device').click();
+            cy.getConfirmActionOnDeviceModal();
+            cy.task('pressNo'); // labeling was not enabled at this moment
+            // select previous wallet
+            cy.getTestElement('@switch-device/wallet-on-index/1').click();
+            cy.getTestElement('@menu/switch-device').click();
+            cy.hoverTestElement(`@metadata/walletLabel/${secondHiddenWalletState}/hover-container`);
+            cy.getTestElement(
+                `@metadata/walletLabel/${secondHiddenWalletState}/add-label-button`,
+            ).click();
+            cy.getConfirmActionOnDeviceModal();
+            cy.task('pressYes'); // only now labeling was enabled
+            cy.getTestElement('@metadata/input').type(
+                'still works, metadata enabled for currently not selected device{enter}',
+            );
+
+            cy.window()
+                .its('store')
+                .invoke('getState')
+                .then(state => {
+                    console.log(state);
+                    const errors = state.notifications.filter(
+                        (n: { type: string }) => n.type === 'error',
+                    );
+                    return expect(errors).to.be.empty;
+                });
         });
     });
 });

--- a/packages/suite/src/actions/suite/__fixtures__/metadataActions.ts
+++ b/packages/suite/src/actions/suite/__fixtures__/metadataActions.ts
@@ -1,101 +1,53 @@
 import { deviceActions } from '@suite-common/wallet-core';
-
 import { METADATA } from 'src/actions/suite/constants';
 
-const setDeviceMetadataKey = [
+import * as metadataActions from '../metadataActions';
+
+const { getSuiteDevice } = global.JestMocks;
+
+type Fixture<T extends (...a: any) => any> = {
+    description: string;
+    params: Parameters<T>;
+    initialState: any;
+    result?: any;
+};
+
+const setDeviceMetadataKey: Fixture<(typeof metadataActions)['setDeviceMetadataKey']>[] = [
     {
         description: `Metadata not enabled`,
+        params: [getSuiteDevice({ state: 'a' }), METADATA.ENCRYPTION_VERSION],
         initialState: {
             metadata: { enabled: false, providers: [] },
         },
     },
     {
         description: `Device without state`,
+        params: [getSuiteDevice({ state: undefined }), METADATA.ENCRYPTION_VERSION],
         initialState: {
             metadata: { enabled: true, providers: [] },
-            device: { state: undefined },
         },
     },
     {
         description: `Device not connected (remembered)`,
-        initialState: {
-            metadata: { enabled: true, providers: [] },
-            device: { state: 'device-state', connected: false, metadata: { status: 'disabled' } },
-        },
-    },
-    {
-        description: `Device metadata already enabled`,
-        initialState: {
-            metadata: { enabled: true, providers: [] },
-            device: { state: 'device-state', metadata: { status: 'enabled' } },
-        },
-    },
-    {
-        description: `Master key cancelled`,
-        connect: {
-            success: false,
-        },
-        initialState: {
-            metadata: { enabled: true, providers: [] },
-            device: { state: 'device-state', connected: true, metadata: { status: 'disabled' } },
-        },
-        result: [
-            {
-                type: METADATA.SET_DEVICE_METADATA,
-                payload: {
-                    metadata: {
-                        status: 'cancelled',
-                    },
-                },
-            },
-            {
-                type: deviceActions.updateSelectedDevice.type,
-                payload: {
-                    state: 'device-state',
-                    metadata: { status: 'cancelled' },
-                },
-            },
-            {
-                type: METADATA.DISABLE,
-            },
+        params: [
+            getSuiteDevice({ state: 'device-state', connected: false, metadata: {} }),
+            METADATA.ENCRYPTION_VERSION,
         ],
+        initialState: {
+            metadata: { enabled: true, providers: [] },
+        },
     },
     {
         description: `Master key successfully generated`,
-        initialState: {
-            metadata: { enabled: true, providers: [] },
-            device: { state: 'device-state', connected: true, metadata: { status: 'disabled' } },
-        },
-        result: [
-            {
-                type: METADATA.SET_DEVICE_METADATA,
-                payload: {
-                    metadata: {
-                        status: 'enabled',
-                    },
-                },
-            },
-            {
-                type: deviceActions.updateSelectedDevice.type,
-            },
+        params: [
+            getSuiteDevice({ state: 'device-state', connected: true, metadata: {} }),
+            METADATA.ENCRYPTION_VERSION,
         ],
-    },
-    {
-        description: `Master key successfully generated, provider already connected`,
         initialState: {
             metadata: {
                 enabled: true,
-                selectedProvider: { labels: '' },
-                providers: [
-                    {
-                        type: 'dropbox',
-                        user: 'User Name',
-                        tokens: { refreshToken: 'oauth-token' },
-                        providers: [],
-                    },
-                ],
             },
-            device: { state: 'device-state', connected: true, metadata: { status: 'disabled' } },
+            device: { state: 'device-state', connected: true, metadata: {} },
         },
         result: [
             {
@@ -109,7 +61,6 @@ const setDeviceMetadataKey = [
                             aesKey: 'bc37a9a8c6cfa6ab2f75b384df2745895d75f2c572a195ccff59ae9958aaf0e8',
                             key: '20c8bf0701213cdcf4c2f56fd0096c1772322d42fb9c4d0ddf6bb122d713d2f3',
                         },
-                        status: 'enabled',
                     },
                 },
             },
@@ -123,7 +74,6 @@ const setDeviceMetadataKey = [
                                 'c734ff5106c4910aa3444f3672cc2c82d8cb4595f0527be672d8b100ed82908f.mtdt',
                             key: '20c8bf0701213cdcf4c2f56fd0096c1772322d42fb9c4d0ddf6bb122d713d2f3',
                         },
-                        status: 'enabled',
                     },
                     state: 'device-state',
                 },
@@ -134,32 +84,32 @@ const setDeviceMetadataKey = [
 
 const setAccountMetadataKey = [
     {
-        description: `Device without master key - account fileName and aesKey can't be computed`,
-        initialState: {
-            device: { metadata: { status: 'disabled', providers: [] } },
-        },
-        account: { key: 'account-key' },
-        result: { key: 'account-key' },
-    },
-    {
         description: `Account m/49'/0'/0'`,
         initialState: {
             device: {
+                state: 'a',
                 metadata: {
-                    status: 'enabled',
-                    key: '20c8bf0701213cdcf4c2f56fd0096c1772322d42fb9c4d0ddf6bb122d713d2f3',
-                    providers: [],
+                    1: {
+                        key: '20c8bf0701213cdcf4c2f56fd0096c1772322d42fb9c4d0ddf6bb122d713d2f3',
+                    },
                 },
             },
         },
-        account: {
-            metadata: {
-                key: 'xpub6CVKsQYXc9awxgV1tWbG4foDvdcnieK2JkbpPEBKB5WwAPKBZ1mstLbKVB4ov7QzxzjaxNK6EfmNY5Jsk2cG26EVcEkycGW4tchT2dyUhrx',
+        params: [
+            {
+                metadata: {
+                    key: 'xpub6CVKsQYXc9awxgV1tWbG4foDvdcnieK2JkbpPEBKB5WwAPKBZ1mstLbKVB4ov7QzxzjaxNK6EfmNY5Jsk2cG26EVcEkycGW4tchT2dyUhrx',
+                },
+                deviceState: 'a',
             },
-        },
+        ],
         result: {
             metadata: {
-                key: 'xpub6CVKsQYXc9awxgV1tWbG4foDvdcnieK2JkbpPEBKB5WwAPKBZ1mstLbKVB4ov7QzxzjaxNK6EfmNY5Jsk2cG26EVcEkycGW4tchT2dyUhrx',
+                1: {
+                    fileName:
+                        '828652b66f2e6f919fbb7fe4c9609d4891ed531c6fac4c28441e53ebe577ac85.mtdt',
+                    aesKey: '9bc3736f0b45cd681854a724b5bba67b9da1e50bc9983fd2dd56e53e74b75480',
+                },
             },
         },
     },
@@ -188,7 +138,6 @@ const addDeviceMetadata = [
                             '039fe833cba71d84b7bf4c99d44468ee48e311e741cbfcd6daf5263f584ef9f6',
                     },
                     key: 'CKValue',
-                    status: 'enabled',
                 },
             },
         },
@@ -239,9 +188,7 @@ const addAccountMetadata = [
                 ],
             },
             device: {
-                metadata: {
-                    status: 'enabled',
-                },
+                metadata: {},
             },
             accounts: [
                 {
@@ -302,7 +249,9 @@ const addAccountMetadata = [
                 ],
             },
             device: {
-                metadata: { status: 'enabled', key: 'B' },
+                metadata: {
+                    key: 'B',
+                },
             },
             accounts: [
                 {
@@ -349,10 +298,10 @@ const connectProvider = [
                 type: '@metadata/add-provider',
                 payload: {
                     type: 'dropbox',
-                    tokens: { refreshToken: 'token-haf-mnau' },
-                    user: 'haf',
+                    tokens: { refreshToken: 'token' },
+                    user: 'power-user',
                     isCloud: true,
-                    clientId: 'wg0yz2pbgjyhoda',
+                    clientId: 'meow',
                     data: {},
                 },
             },
@@ -371,31 +320,25 @@ const connectProvider = [
 
 const addMetadata = [
     {
-        description: 'device without state',
-        initialState: {
-            metadata: { enabled: true, providers: [] },
-            device: {
-                state: undefined,
-            },
-        },
-        params: {},
-        result: [],
-    },
-    {
         description: 'does not need update',
         initialState: {
             metadata: {
                 enabled: true,
                 selectedProvider: {
-                    type: 'dropbox',
-                    user: 'User Name',
-                    tokens: { refreshToken: 'oauth-token' },
+                    labels: 'clientId',
                 },
-                providers: [],
+                providers: [
+                    {
+                        clientId: 'clientId',
+                        type: 'dropbox',
+                        user: 'User Name',
+                        tokens: { refreshToken: 'oauth-token' },
+                    },
+                ],
             },
             device: {
                 state: 'mmcGdEpTPqgQNRHqf3gmB5uDsEoPo2d3tp@46CE52D1ED50A900687D6BA2:undefined',
-                metadata: { status: 'enabled' },
+                metadata: {},
             },
         },
         params: {
@@ -412,15 +355,20 @@ const addMetadata = [
             metadata: {
                 enabled: true,
                 selectedProvider: {
-                    type: 'dropbox',
-                    user: 'User Name',
-                    tokens: { refreshToken: 'oauth-token' },
+                    labels: 'clientId',
                 },
-                providers: [],
+                providers: [
+                    {
+                        client: 'clientId',
+                        type: 'dropbox',
+                        user: 'User Name',
+                        tokens: { refreshToken: 'oauth-token' },
+                    },
+                ],
             },
             device: {
                 state: 'mmcGdEpTPqgQNRHqf3gmB5uDsEoPo2d3tp@46CE52D1ED50A900687D6BA2:undefined',
-                metadata: { status: 'enabled' },
+                metadata: {},
             },
         },
         params: {
@@ -470,13 +418,28 @@ const init = [
         initialState: {
             device: { state: undefined },
         },
-        result: [{ type: '@metadata/enable' }],
+        result: [],
     },
     {
         description: 'metadata already enabled',
         initialState: {
-            device: { state: 'device-state', metadata: { status: 'enabled' } },
-            metadata: { enabled: true, selectedProvider: {}, providers: [] },
+            device: {
+                state: 'device-state',
+                connected: true,
+                metadata: {
+                    1: {
+                        fileName:
+                            'c734ff5106c4910aa3444f3672cc2c82d8cb4595f0527be672d8b100ed82908f.mtdt',
+                        aesKey: 'bc37a9a8c6cfa6ab2f75b384df2745895d75f2c572a195ccff59ae9958aaf0e8',
+                        key: '20c8bf0701213cdcf4c2f56fd0096c1772322d42fb9c4d0ddf6bb122d713d2f3',
+                    },
+                },
+            },
+            metadata: {
+                enabled: true,
+                selectedProvider: {},
+                providers: [],
+            },
         },
         result: [
             { type: '@metadata/set-initiating', payload: true },
@@ -499,32 +462,35 @@ const init = [
                 type: '@metadata/set-selected-provider',
                 payload: { dataType: 'labels', clientId: 'wg0yz2pbgjyhoda' },
             },
+
             { type: '@metadata/set-initiating', payload: false },
         ],
     },
     {
         description: 'metadata not enabled',
         initialState: {
-            device: { state: 'device-state', connected: true, metadata: { status: 'disabled' } },
-            metadata: { enabled: false, providers: [], selectedProvider: {} },
+            device: { state: 'device-state', connected: true, metadata: {} },
+            metadata: {
+                enabled: false,
+                providers: [],
+                selectedProvider: {},
+            },
             suite: { online: true },
         },
-        params: true,
         result: [
-            { type: '@metadata/enable' },
             { type: '@metadata/set-initiating', payload: true },
+            { type: '@metadata/enable' },
             {
                 type: '@metadata/set-device-metadata',
                 payload: {
                     deviceState: 'device-state',
                     metadata: {
-                        '1': {
+                        1: {
                             fileName:
                                 'c734ff5106c4910aa3444f3672cc2c82d8cb4595f0527be672d8b100ed82908f.mtdt',
                             aesKey: 'bc37a9a8c6cfa6ab2f75b384df2745895d75f2c572a195ccff59ae9958aaf0e8',
                             key: '20c8bf0701213cdcf4c2f56fd0096c1772322d42fb9c4d0ddf6bb122d713d2f3',
                         },
-                        status: 'enabled',
                     },
                 },
             },
@@ -534,13 +500,12 @@ const init = [
                     state: 'device-state',
                     connected: true,
                     metadata: {
-                        '1': {
+                        1: {
                             fileName:
                                 'c734ff5106c4910aa3444f3672cc2c82d8cb4595f0527be672d8b100ed82908f.mtdt',
                             aesKey: 'bc37a9a8c6cfa6ab2f75b384df2745895d75f2c572a195ccff59ae9958aaf0e8',
                             key: '20c8bf0701213cdcf4c2f56fd0096c1772322d42fb9c4d0ddf6bb122d713d2f3',
                         },
-                        status: 'enabled',
                     },
                 },
             },
@@ -563,8 +528,97 @@ const init = [
                 type: '@metadata/set-selected-provider',
                 payload: { dataType: 'labels', clientId: 'wg0yz2pbgjyhoda' },
             },
+
             { type: '@metadata/set-initiating', payload: false },
         ],
+    },
+];
+
+const disposeMetadata = [
+    {
+        description: '',
+        initialState: {
+            device: { state: 'device-state', metadata: {} },
+            metadata: {
+                providers: [
+                    {
+                        type: 'dropbox',
+                        data: {
+                            'filename-123': {
+                                outputLabels: {
+                                    TXID: {
+                                        0: 'Foo',
+                                    },
+                                },
+                            },
+                        },
+                        clientId: 'clientId',
+                    },
+                ],
+                selectedProvider: { labels: 'clientId' },
+            },
+        },
+        params: [],
+        result: {
+            metadata: {
+                providers: [
+                    {
+                        type: 'dropbox',
+                        data: {},
+                        clientId: 'clientId',
+                    },
+                ],
+                selectedProvider: {
+                    labels: 'clientId',
+                },
+            },
+        },
+    },
+    {
+        description: 'keys',
+        initialState: {
+            device: {
+                state: 'device-state',
+                metadata: { 1: { fileName: 'foo', aesKey: 'bar' } },
+            },
+            metadata: {
+                providers: [
+                    {
+                        type: 'dropbox',
+                        data: {
+                            'filename-123': {
+                                outputLabels: {
+                                    TXID: {
+                                        0: 'Foo',
+                                    },
+                                },
+                            },
+                        },
+                        clientId: 'clientId',
+                    },
+                ],
+                selectedProvider: { labels: 'clientId' },
+            },
+            accounts: [
+                {
+                    deviceState: 'device-state',
+                    key: 'account-key',
+                    metadata: {
+                        1: {
+                            fileName: 'foo',
+                            aesKey: 'bar',
+                        },
+                    },
+                },
+            ],
+        },
+        params: [true],
+        result: {
+            device: { selectedDevice: { state: 'device-state', metadata: {} } },
+            wallet: {
+                accounts: [{ deviceState: 'device-state', key: 'account-key', metadata: {} }],
+            },
+        },
     },
 ];
 
@@ -576,4 +630,5 @@ export {
     connectProvider,
     addMetadata,
     init,
+    disposeMetadata,
 };

--- a/packages/suite/src/actions/suite/constants/metadataConstants.ts
+++ b/packages/suite/src/actions/suite/constants/metadataConstants.ts
@@ -15,6 +15,7 @@ export const SET_EDITING = '@metadata/set-editing';
 export const SET_INITIATING = '@metadata/set-initiating';
 export const SET_DATA = '@metadata/set-data';
 export const SET_SELECTED_PROVIDER = '@metadata/set-selected-provider';
+export const SET_ERROR_FOR_DEVICE = '@metadata/set-error-for-device';
 
 export const FORMAT_VERSION = '1.0.0';
 

--- a/packages/suite/src/actions/suite/constants/metadataConstants.ts
+++ b/packages/suite/src/actions/suite/constants/metadataConstants.ts
@@ -7,8 +7,6 @@ import { TrezorConnect } from '@trezor/connect';
 
 export const ENABLE = '@metadata/enable';
 export const DISABLE = '@metadata/disable';
-export const SET_READY = '@metadata/set-ready';
-export const CANCELLED = '@metadata/cancelled';
 export const SET_DEVICE_METADATA = '@metadata/set-device-metadata';
 export const ADD_PROVIDER = '@metadata/add-provider';
 export const REMOVE_PROVIDER = '@metadata/remove-provider';

--- a/packages/suite/src/actions/suite/initAction.ts
+++ b/packages/suite/src/actions/suite/initAction.ts
@@ -60,7 +60,7 @@ export const init = () => async (dispatch: Dispatch, getState: GetState) => {
     // 8. fetch metadata. metadata is not saved together with other data in storage.
     // historically it was saved in indexedDB together with devices and accounts and we did not need to load them
     // immediately after suite start.
-    dispatch(metadataActions.fetchAndSaveMetadata());
+    dispatch(metadataActions.fetchAndSaveMetadataForAllDevices());
 
     // 9. backend connected, suite is ready to use
     dispatch({ type: SUITE.READY });

--- a/packages/suite/src/actions/suite/metadataActions.ts
+++ b/packages/suite/src/actions/suite/metadataActions.ts
@@ -32,6 +32,7 @@ import GoogleProvider from 'src/services/suite/metadata/GoogleProvider';
 import FileSystemProvider from 'src/services/suite/metadata/FileSystemProvider';
 import {
     selectLabelableEntities,
+    selectMetadata,
     selectSelectedProviderForLabels,
 } from 'src/reducers/suite/metadataReducer';
 
@@ -469,6 +470,10 @@ export const fetchAndSaveMetadata =
     };
 
 export const fetchAndSaveMetadataForAllDevices = () => (dispatch: Dispatch, getState: GetState) => {
+    const metadata = selectMetadata(getState());
+    if (!metadata.enabled) {
+        return;
+    }
     const devices = selectDevices(getState());
     devices.forEach(device => {
         if (!device.state || !device.metadata[METADATA.ENCRYPTION_VERSION]) return;

--- a/packages/suite/src/actions/suite/metadataActions.ts
+++ b/packages/suite/src/actions/suite/metadataActions.ts
@@ -331,7 +331,7 @@ export const getLabelableEntities =
 
 type LabelableEntity = ReturnType<ReturnType<typeof getLabelableEntities>>[number];
 
-export const fetchMetadata =
+const fetchMetadata =
     ({
         provider,
         entity,

--- a/packages/suite/src/actions/suite/metadataActions.ts
+++ b/packages/suite/src/actions/suite/metadataActions.ts
@@ -492,6 +492,13 @@ export const setAccountMetadataKey =
         ) {
             return account;
         }
+export const fetchAndSaveMetadataForAllDevices = () => (dispatch: Dispatch, getState: GetState) => {
+    const devices = selectDevices(getState());
+    devices.forEach(device => {
+        if (!device.state) return;
+        dispatch(fetchAndSaveMetadata(device.state));
+    });
+};
 
         const deviceMetaKey = device.metadata[encryptionVersion]?.key;
 

--- a/packages/suite/src/actions/suite/metadataActions.ts
+++ b/packages/suite/src/actions/suite/metadataActions.ts
@@ -606,7 +606,7 @@ export const addDeviceMetadata =
     (payload: Extract<MetadataAddPayload, { type: 'walletLabel' }>) =>
     (dispatch: Dispatch, getState: GetState) => {
         const devices = selectDevices(getState());
-        const device = devices.find(d => d.state === payload.deviceState);
+        const device = devices.find(d => d.state === payload.entityKey);
         const provider = selectSelectedProviderForLabels(getState());
 
         if (!device || device.metadata.status !== 'enabled') return Promise.resolve(false);
@@ -658,8 +658,8 @@ export const addDeviceMetadata =
  */
 export const addAccountMetadata =
     (payload: Exclude<MetadataAddPayload, { type: 'walletLabel' }>, save = true) =>
-    async (dispatch: Dispatch, getState: GetState) => {
-        const account = getState().wallet.accounts.find(a => a.key === payload.accountKey);
+    (dispatch: Dispatch, getState: GetState) => {
+        const account = getState().wallet.accounts.find(a => a.key === payload.entityKey);
         const provider = selectSelectedProviderForLabels(getState());
 
         if (!account || !provider) return false;

--- a/packages/suite/src/actions/suite/metadataActions.ts
+++ b/packages/suite/src/actions/suite/metadataActions.ts
@@ -30,7 +30,10 @@ import * as modalActions from 'src/actions/suite/modalActions';
 import DropboxProvider from 'src/services/suite/metadata/DropboxProvider';
 import GoogleProvider from 'src/services/suite/metadata/GoogleProvider';
 import FileSystemProvider from 'src/services/suite/metadata/FileSystemProvider';
-import { selectSelectedProviderForLabels } from 'src/reducers/suite/metadataReducer';
+import {
+    selectLabelableEntities,
+    selectSelectedProviderForLabels,
+} from 'src/reducers/suite/metadataReducer';
 
 export const setAccountAdd = createAction(METADATA.ACCOUNT_ADD, (payload: Account) => ({
     payload,
@@ -307,27 +310,8 @@ const setMetadata =
     };
 
 export const getLabelableEntities =
-    (deviceState: string) => (_dispatch: Dispatch, getState: GetState) => {
-        const { accounts } = getState().wallet;
-        const devices = selectDevices(getState());
-
-        return [
-            ...accounts
-                .filter(a => a.deviceState === deviceState)
-                .map(account => ({
-                    ...account.metadata,
-                    key: account.key,
-                    type: 'account' as const,
-                })),
-            ...devices
-                .filter((device: TrezorDevice) => device.state === deviceState)
-                .map((device: TrezorDevice) => ({
-                    ...device.metadata,
-                    state: device.state,
-                    type: 'device' as const,
-                })),
-        ];
-    };
+    (deviceState: string) => (_dispatch: Dispatch, getState: GetState) =>
+        selectLabelableEntities(getState(), deviceState);
 
 type LabelableEntity = ReturnType<ReturnType<typeof getLabelableEntities>>[number];
 

--- a/packages/suite/src/actions/suite/storageActions.ts
+++ b/packages/suite/src/actions/suite/storageActions.ts
@@ -1,5 +1,7 @@
 import { FieldValues } from 'react-hook-form';
 
+import { cloneObject } from '@trezor/utils';
+
 import { Discovery, FormDraftKeyPrefix } from '@suite-common/wallet-types';
 import { notificationsActions } from '@suite-common/toast-notifications';
 import { getFormDraftKey } from '@suite-common/wallet-utils';
@@ -22,6 +24,7 @@ import { deviceGraphDataFilterFn } from 'src/utils/wallet/graph';
 import { selectCoinjoinAccountByKey } from 'src/reducers/wallet/coinjoinReducer';
 
 import { STORAGE } from './constants';
+import { MetadataState } from '@suite-common/metadata-types';
 
 export type StorageAction = NonNullable<PreloadStoreAction>;
 export type StorageLoadAction = Extract<StorageAction, { type: typeof STORAGE.LOAD }>;
@@ -213,6 +216,8 @@ export const rememberDevice =
         if (!(await db.isAccessible())) return;
         if (!device || !device.features || !device.state) return;
         if (!remember) {
+            // eslint-disable-next-line @typescript-eslint/no-use-before-define
+            dispatch(forgetDeviceMetadataError(device));
             return dispatch(forgetDevice(device));
         }
 
@@ -244,6 +249,8 @@ export const rememberDevice =
                 saveAccounts(accounts),
                 saveGraph(graphData),
                 saveDiscovery(discovery),
+                // eslint-disable-next-line  @typescript-eslint/no-use-before-define
+                dispatch(saveDeviceMetadataError(device)),
                 ...accountPromises,
             ] as Promise<void | string | undefined>[]);
         } catch (error) {
@@ -320,24 +327,48 @@ export const saveAnalytics = () => async (_dispatch: Dispatch, getState: GetStat
     );
 };
 
+export const saveMetadata = async (metadata: MetadataState) => {
+    if (!(await db.isAccessible())) return;
+
+    await db.addItem('metadata', metadata, 'state', true);
+};
+
 /**
  * save general metadata settings
  */
-export const saveMetadata = () => async (_dispatch: Dispatch, getState: GetState) => {
+export const saveMetadataSettings = () => async (_dispatch: Dispatch, getState: GetState) => {
     if (!(await db.isAccessible())) return;
 
     const { metadata } = getState();
-    db.addItem(
-        'metadata',
-        {
-            providers: metadata.providers,
-            enabled: metadata.enabled,
-            selectedProvider: metadata.selectedProvider,
-        },
-        'state',
-        true,
-    );
+
+    saveMetadata({
+        providers: metadata.providers,
+        enabled: metadata.enabled,
+        selectedProvider: metadata.selectedProvider,
+    });
 };
+
+export const saveDeviceMetadataError =
+    (device: TrezorDevice) => async (_dispatch: Dispatch, getState: GetState) => {
+        if (!(await db.isAccessible())) return;
+
+        const { metadata } = getState();
+        if (device.state && metadata?.error?.[device.state]) {
+            await saveMetadata(metadata);
+        }
+    };
+
+export const forgetDeviceMetadataError =
+    (device: TrezorDevice) => async (_dispatch: Dispatch, getState: GetState) => {
+        if (!(await db.isAccessible())) return;
+
+        const { metadata } = getState();
+        if (device.state && metadata?.error) {
+            const next = cloneObject(metadata.error);
+            delete next[device.state];
+            saveMetadata({ ...metadata, error: next });
+        }
+    };
 
 export const saveMessageSystem = () => async (_dispatch: Dispatch, getState: GetState) => {
     if (!(await db.isAccessible())) return;

--- a/packages/suite/src/actions/wallet/sendFormActions.ts
+++ b/packages/suite/src/actions/wallet/sendFormActions.ts
@@ -323,7 +323,7 @@ const pushTransaction =
                         const outputIndex = outputsPermutation.findIndex(p => p === index);
                         const metadata: Extract<MetadataAddPayload, { type: 'outputLabel' }> = {
                             type: 'outputLabel',
-                            accountKey: account.key,
+                            entityKey: account.key,
                             txid, // txid becomes available, use it
                             outputIndex,
                             value: label,

--- a/packages/suite/src/components/suite/SwitchDevice/components/WalletInstance.tsx
+++ b/packages/suite/src/components/suite/SwitchDevice/components/WalletInstance.tsx
@@ -153,7 +153,7 @@ export const WalletInstance = ({
                                 defaultVisibleValue={<WalletLabeling device={instance} />}
                                 payload={{
                                     type: 'walletLabel',
-                                    deviceState: instance.state,
+                                    entityKey: instance.state,
                                     defaultValue: instance.state,
                                     value:
                                         instance?.metadata.status === 'enabled' ? walletLabel : '',

--- a/packages/suite/src/components/suite/SwitchDevice/components/WalletInstance.tsx
+++ b/packages/suite/src/components/suite/SwitchDevice/components/WalletInstance.tsx
@@ -19,6 +19,7 @@ import {
 import { useDispatch, useSelector } from 'src/hooks/suite';
 import { TrezorDevice, AcquiredDevice } from 'src/types/suite';
 import { selectLabelingDataForWallet } from 'src/reducers/suite/metadataReducer';
+import { METADATA } from 'src/actions/suite/constants';
 
 const InstanceType = styled.div`
     display: flex;
@@ -155,8 +156,9 @@ export const WalletInstance = ({
                                     type: 'walletLabel',
                                     entityKey: instance.state,
                                     defaultValue: instance.state,
-                                    value:
-                                        instance?.metadata.status === 'enabled' ? walletLabel : '',
+                                    value: instance?.metadata[METADATA.ENCRYPTION_VERSION]
+                                        ? walletLabel
+                                        : '',
                                 }}
                             />
                         ) : (

--- a/packages/suite/src/components/suite/labeling/WalletLabeling.tsx
+++ b/packages/suite/src/components/suite/labeling/WalletLabeling.tsx
@@ -13,7 +13,7 @@ export const WalletLabeling = ({ device, shouldUseDeviceLabel }: WalletLabelling
     const { walletLabel } = useSelector(state => selectLabelingDataForWallet(state, device.state));
 
     let label: string | undefined;
-    if (device.metadata.status === 'enabled' && walletLabel) {
+    if (walletLabel) {
         label = walletLabel;
     } else if (device.state) {
         label = device.useEmptyPassphrase

--- a/packages/suite/src/components/wallet/TransactionItem/TransactionTarget/TransactionTarget.tsx
+++ b/packages/suite/src/components/wallet/TransactionItem/TransactionTarget/TransactionTarget.tsx
@@ -169,7 +169,7 @@ export const TransactionTarget = ({
                     ]}
                     payload={{
                         type: 'outputLabel',
-                        accountKey,
+                        entityKey: accountKey,
                         txid: transaction.txid,
                         outputIndex: target.n,
                         defaultValue: `${transaction.txid}-${target.n}`,

--- a/packages/suite/src/components/wallet/WalletLayout/AccountTopPanel/AccountTopPanel.tsx
+++ b/packages/suite/src/components/wallet/WalletLayout/AccountTopPanel/AccountTopPanel.tsx
@@ -80,7 +80,7 @@ export const AccountTopPanel = () => {
                     defaultVisibleValue={<AccountLabeling account={account} />}
                     payload={{
                         type: 'accountLabel',
-                        accountKey: account.key,
+                        entityKey: account.key,
                         defaultValue: account.path,
                         value: selectedAccountLabels.accountLabel,
                     }}

--- a/packages/suite/src/middlewares/suite/metadataMiddleware.ts
+++ b/packages/suite/src/middlewares/suite/metadataMiddleware.ts
@@ -23,7 +23,7 @@ const metadata =
                 api.getState().metadata.enabled &&
                 !action.payload.device.metadata[METADATA.ENCRYPTION_VERSION]
             ) {
-                api.dispatch(metadataActions.init());
+                api.dispatch(metadataActions.init(false));
             }
         }
 

--- a/packages/suite/src/middlewares/suite/metadataMiddleware.ts
+++ b/packages/suite/src/middlewares/suite/metadataMiddleware.ts
@@ -4,7 +4,7 @@ import { accountsActions, deviceActions } from '@suite-common/wallet-core';
 
 import * as metadataActions from 'src/actions/suite/metadataActions';
 import { AppState, Action, Dispatch } from 'src/types/suite';
-import { ROUTER } from 'src/actions/suite/constants';
+import { METADATA, ROUTER } from 'src/actions/suite/constants';
 
 const metadata =
     (api: MiddlewareAPI<Dispatch, AppState>) =>
@@ -21,7 +21,7 @@ const metadata =
             if (
                 action.payload.success &&
                 api.getState().metadata.enabled &&
-                action.payload.device.metadata.status === 'disabled'
+                !action.payload.device.metadata[METADATA.ENCRYPTION_VERSION]
             ) {
                 api.dispatch(metadataActions.init());
             }

--- a/packages/suite/src/middlewares/wallet/storageMiddleware.ts
+++ b/packages/suite/src/middlewares/wallet/storageMiddleware.ts
@@ -239,6 +239,18 @@ const storageMiddleware = (api: MiddlewareAPI<Dispatch, AppState>) => {
                     }
                     break;
                 }
+                // au, this hurts, I need to call saveDevice manually. saved device should be updated automatically
+                // anytime any of its properties change
+                case METADATA.SET_DEVICE_METADATA: {
+                    const device = selectDeviceByState(api.getState(), action.payload.deviceState);
+                    if (isDeviceRemembered(device) && device) {
+                        storageActions.saveDevice({
+                            ...device,
+                            metadata: action.payload.metadata,
+                        });
+                    }
+                    break;
+                }
                 case FORM_DRAFT.STORE_DRAFT: {
                     const device = selectDevice(api.getState());
                     // save drafts for remembered device

--- a/packages/suite/src/middlewares/wallet/storageMiddleware.ts
+++ b/packages/suite/src/middlewares/wallet/storageMiddleware.ts
@@ -13,6 +13,7 @@ import {
     fiatRatesActions,
     selectAccountByKey,
     deviceActions,
+    selectDeviceByState,
 } from '@suite-common/wallet-core';
 import { isDeviceRemembered } from '@suite-common/suite-utils';
 import { messageSystemActions } from '@suite-common/message-system';
@@ -159,6 +160,7 @@ const storageMiddleware = (api: MiddlewareAPI<Dispatch, AppState>) => {
 
             if (deviceActions.forgetDevice.match(action)) {
                 api.dispatch(storageActions.forgetDevice(action.payload));
+                api.dispatch(storageActions.forgetDeviceMetadataError(action.payload));
             }
 
             if (deviceActions.updateSelectedDevice.match(action)) {
@@ -228,9 +230,15 @@ const storageMiddleware = (api: MiddlewareAPI<Dispatch, AppState>) => {
                 case METADATA.DISABLE:
                 case METADATA.ADD_PROVIDER:
                 case METADATA.REMOVE_PROVIDER:
-                    api.dispatch(storageActions.saveMetadata());
+                    api.dispatch(storageActions.saveMetadataSettings());
                     break;
-
+                case METADATA.SET_ERROR_FOR_DEVICE: {
+                    const device = selectDeviceByState(api.getState(), action.payload.deviceState);
+                    if (isDeviceRemembered(device) && device) {
+                        api.dispatch(storageActions.saveDeviceMetadataError(device));
+                    }
+                    break;
+                }
                 case FORM_DRAFT.STORE_DRAFT: {
                     const device = selectDevice(api.getState());
                     // save drafts for remembered device

--- a/packages/suite/src/reducers/suite/metadataReducer.ts
+++ b/packages/suite/src/reducers/suite/metadataReducer.ts
@@ -25,6 +25,7 @@ export const initialState: MetadataState = {
     selectedProvider: {
         labels: '',
     },
+    error: {},
 };
 
 type MetadataRootState = {
@@ -76,6 +77,14 @@ const metadataReducer = (state = initialState, action: Action): MetadataState =>
 
                 break;
             }
+            case METADATA.SET_ERROR_FOR_DEVICE:
+                if (action.payload.failed) {
+                    if (!draft.error) draft.error = {};
+                    draft.error[action.payload.deviceState] = action.payload.failed;
+                } else {
+                    delete draft.error?.[action.payload.deviceState];
+                }
+                break;
             // no default
         }
     });

--- a/packages/suite/src/reducers/suite/metadataReducer.ts
+++ b/packages/suite/src/reducers/suite/metadataReducer.ts
@@ -8,6 +8,7 @@ import {
     selectDevices,
     State,
     selectDeviceByState,
+    deviceActions,
 } from '@suite-common/wallet-core';
 
 import { STORAGE, METADATA } from 'src/actions/suite/constants';
@@ -91,6 +92,11 @@ const metadataReducer = (state = initialState, action: Action): MetadataState =>
                     delete draft.error?.[action.payload.deviceState];
                 }
                 break;
+            case deviceActions.forgetDevice.type:
+                if (action.payload.state) {
+                    delete draft.error?.[action.payload.state];
+                }
+
             // no default
         }
     });

--- a/packages/suite/src/reducers/suite/metadataReducer.ts
+++ b/packages/suite/src/reducers/suite/metadataReducer.ts
@@ -46,7 +46,9 @@ const metadataReducer = (state = initialState, action: Action): MetadataState =>
                 draft.providers.push(action.payload);
                 break;
             case METADATA.REMOVE_PROVIDER:
-                draft.providers = draft.providers.filter(p => p.type !== action.payload.type);
+                draft.providers = draft.providers.filter(
+                    p => p.clientId !== action.payload.clientId,
+                );
                 break;
             case METADATA.SET_SELECTED_PROVIDER:
                 draft.selectedProvider[action.payload.dataType] = action.payload.clientId;

--- a/packages/suite/src/reducers/suite/metadataReducer.ts
+++ b/packages/suite/src/reducers/suite/metadataReducer.ts
@@ -165,7 +165,28 @@ export const selectLabelingDataForWallet = (
     return DEFAULT_WALLET_METADATA;
 };
 
-// is everything ready (more or less) to add label?
+export const selectLabelableEntities = (state: MetadataRootState, deviceState: string) => {
+    const { wallet, device } = state;
+    const { devices } = device;
+    const { accounts } = wallet;
+    return [
+        ...accounts
+            .filter(a => a.deviceState === deviceState)
+            .map(account => ({
+                ...account.metadata,
+                key: account.key,
+                type: 'account' as const,
+            })),
+        ...devices
+            .filter((device: TrezorDevice) => device.state === deviceState)
+            .map((device: TrezorDevice) => ({
+                ...device.metadata,
+                state: device.state,
+                type: 'device' as const,
+            })),
+    ];
+};
+
 const selectLabelableEntityByKey = (
     state: MetadataRootState,
     deviceState: string,

--- a/packages/suite/src/reducers/suite/metadataReducer.ts
+++ b/packages/suite/src/reducers/suite/metadataReducer.ts
@@ -156,7 +156,7 @@ export const selectLabelingDataForWallet = (
     const provider = selectSelectedProviderForLabels(state);
     const devices = selectDevices(state);
     const device = devices.find(d => d.state === deviceState);
-    if (device?.metadata.status !== 'enabled') {
+    if (!device?.metadata[METADATA.ENCRYPTION_VERSION]) {
         return DEFAULT_WALLET_METADATA;
     }
     const metadataKeys = device?.metadata[METADATA.ENCRYPTION_VERSION];

--- a/packages/suite/src/reducers/suite/metadataReducer.ts
+++ b/packages/suite/src/reducers/suite/metadataReducer.ts
@@ -166,6 +166,21 @@ export const selectLabelingDataForWallet = (
 };
 
 // is everything ready (more or less) to add label?
+const selectLabelableEntityByKey = (
+    state: MetadataRootState,
+    deviceState: string,
+    entityKey: string,
+) =>
+    selectLabelableEntities(state, deviceState).find(e => {
+        if ('key' in e) {
+            return e.key === entityKey;
+        }
+        if ('state' in e) {
+            return e.state === entityKey;
+        }
+        return false;
+    });
+
 export const selectIsLabelingAvailable = (state: MetadataRootState) => {
     const { enabled } = selectMetadata(state);
     const provider = selectSelectedProviderForLabels(state);

--- a/packages/suite/src/storage/CHANGELOG.md
+++ b/packages/suite/src/storage/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Storage changelog
 
+## 40
+
+-   `device.metadata.status` does not exist anymore. this information is derivable from `device.metadata[key]` and `metadata.error[deviceState]`
+
 ## 39
 
 -   `metadata.provider` replaced with array of `metadata.providers`

--- a/packages/suite/src/storage/index.ts
+++ b/packages/suite/src/storage/index.ts
@@ -4,7 +4,7 @@ import { migrate } from './migrations';
 
 import type { SuiteDBSchema } from './definitions';
 
-const VERSION = 39; // don't forget to add migration and CHANGELOG when changing versions!
+const VERSION = 40; // don't forget to add migration and CHANGELOG when changing versions!
 
 /**
  *  If the object stores don't already exist then creates them.

--- a/packages/suite/src/storage/migrations/index.ts
+++ b/packages/suite/src/storage/migrations/index.ts
@@ -101,6 +101,7 @@ export const migrate: OnUpgradeFunc<SuiteDBSchema> = async (
 
         await updateAll(transaction, 'devices', device => {
             device.metadata = {
+                // @ts-expect-error
                 status: 'disabled',
             };
             return device;
@@ -618,6 +619,7 @@ export const migrate: OnUpgradeFunc<SuiteDBSchema> = async (
 
         await updateAll(transaction, 'devices', device => {
             if (
+                // @ts-expect-error
                 device.metadata.status === 'enabled' &&
                 // @ts-expect-error
                 device.metadata.fileName &&
@@ -625,6 +627,7 @@ export const migrate: OnUpgradeFunc<SuiteDBSchema> = async (
                 device.metadata.aesKey
             ) {
                 device.metadata = {
+                    // @ts-expect-error
                     status: device.metadata.status,
                     1: {
                         // @ts-expect-error

--- a/packages/suite/src/storage/migrations/index.ts
+++ b/packages/suite/src/storage/migrations/index.ts
@@ -682,4 +682,22 @@ export const migrate: OnUpgradeFunc<SuiteDBSchema> = async (
             return updatedMetadata;
         });
     }
+
+    if (oldVersion < 40) {
+        // device.metadata.status does not exist anymore. this information is derivable from
+        // device.metadata[key]
+        // and
+        // metadata.error[deviceState]
+        await updateAll(transaction, 'devices', device => {
+            if (
+                // @ts-expect-error
+                device.metadata.status
+            ) {
+                // @ts-expect-error
+                delete device.metadata.status;
+            }
+
+            return device;
+        });
+    }
 };

--- a/packages/suite/src/utils/suite/logsUtils.ts
+++ b/packages/suite/src/utils/suite/logsUtils.ts
@@ -33,6 +33,7 @@ import { getPhysicalDeviceUniqueIds } from '@suite-common/suite-utils';
 
 import { getIsTorEnabled } from 'src/utils/suite/tor';
 import { AppState, TrezorDevice } from 'src/types/suite';
+import { METADATA } from 'src/actions/suite/constants';
 import { Account } from 'src/types/wallet';
 import { selectLabelingDataForWallet } from 'src/reducers/suite/metadataReducer';
 
@@ -242,7 +243,7 @@ export const getApplicationInfo = (state: AppState, hideSensitiveInfo: boolean) 
         deviceLabel: hideSensitiveInfo ? REDACTED_REPLACEMENT : device.label,
         label:
             // eslint-disable-next-line no-nested-ternary
-            device.metadata.status === 'enabled'
+            device.metadata[METADATA.ENCRYPTION_VERSION]
                 ? hideSensitiveInfo
                     ? REDACTED_REPLACEMENT
                     : selectLabelingDataForWallet(state).walletLabel

--- a/packages/suite/src/views/settings/general/SettingsGeneral.tsx
+++ b/packages/suite/src/views/settings/general/SettingsGeneral.tsx
@@ -1,5 +1,4 @@
 import { isDesktop, isWeb } from '@trezor/env-utils';
-import { selectDevice } from '@suite-common/wallet-core';
 
 import { SettingsLayout } from 'src/components/settings';
 import { SettingsSection } from 'src/components/suite/Settings';
@@ -8,6 +7,7 @@ import { useLayoutSize, useSelector } from 'src/hooks/suite';
 import { selectTorState } from 'src/reducers/suite/suiteReducer';
 import { selectEnabledNetworks } from 'src/reducers/wallet/settingsReducer';
 import { NETWORKS } from 'src/config/wallet';
+import { selectSelectedProviderForLabels } from 'src/reducers/suite/metadataReducer';
 
 import { Language } from './Language';
 import { Fiat } from './Fiat';
@@ -31,7 +31,6 @@ export const SettingsGeneral = () => {
     const enabledNetworks = useSelector(selectEnabledNetworks);
     const desktopUpdate = useSelector(state => state.desktopUpdate);
     const metadata = useSelector(state => state.metadata);
-    const device = useSelector(selectDevice);
 
     const { isMobileLayout } = useLayoutSize();
 
@@ -41,8 +40,7 @@ export const SettingsGeneral = () => {
     );
 
     const isMetadataEnabled = metadata.enabled && !metadata.initiating;
-    const isProviderConnected =
-        metadata.enabled && device?.metadata.status === 'enabled' && !!metadata.providers.length;
+    const isProviderConnected = useSelector(selectSelectedProviderForLabels);
 
     return (
         <SettingsLayout data-test="@settings/index">

--- a/packages/suite/src/views/wallet/receive/components/UsedAddresses.tsx
+++ b/packages/suite/src/views/wallet/receive/components/UsedAddresses.tsx
@@ -248,7 +248,7 @@ export const UsedAddresses = ({
                         locked={locked}
                         metadataPayload={{
                             type: 'addressLabel',
-                            accountKey: account.key,
+                            entityKey: account.key,
                             defaultValue: addr.address,
                             value: addressLabels[addr.address],
                         }}

--- a/packages/suite/src/views/wallet/send/components/Options/BitcoinOptions/CoinControl/UtxoSelection.tsx
+++ b/packages/suite/src/views/wallet/send/components/Options/BitcoinOptions/CoinControl/UtxoSelection.tsx
@@ -249,7 +249,7 @@ export const UtxoSelection = ({ transaction, utxo }: UtxoSelectionProps) => {
                                 visible
                                 payload={{
                                     type: 'outputLabel',
-                                    accountKey: account.key,
+                                    entityKey: account.key,
                                     txid: utxo.txid,
                                     outputIndex: utxo.vout,
                                     defaultValue: `${utxo.txid}-${utxo.vout}`,

--- a/packages/suite/src/views/wallet/send/components/Options/BitcoinOptions/CoinControl/UtxoSelection.tsx
+++ b/packages/suite/src/views/wallet/send/components/Options/BitcoinOptions/CoinControl/UtxoSelection.tsx
@@ -6,7 +6,6 @@ import { darken } from 'polished';
 import { formatNetworkAmount, isSameUtxo } from '@suite-common/wallet-utils';
 import { useTheme, Checkbox, Spinner, Tooltip, variables } from '@trezor/components';
 import type { AccountUtxo } from '@trezor/connect';
-import { selectDevice } from '@suite-common/wallet-core';
 
 import { openModal } from 'src/actions/suite/modalActions';
 import {
@@ -20,8 +19,11 @@ import { TransactionTimestamp, UtxoAnonymity } from 'src/components/wallet';
 import { useSendFormContext } from 'src/hooks/wallet';
 import { useCoinjoinUnavailableUtxos } from 'src/hooks/wallet/form/useCoinjoinUnavailableUtxos';
 import { WalletAccountTransaction } from 'src/types/wallet';
-import { selectLabelingDataForSelectedAccount } from 'src/reducers/suite/metadataReducer';
 import { UtxoTag } from './UtxoTag';
+import {
+    selectIsLabelingInitPossible,
+    selectLabelingDataForSelectedAccount,
+} from 'src/reducers/suite/metadataReducer';
 
 const VisibleOnHover = styled.div<{ alwaysVisible?: boolean }>`
     display: ${({ alwaysVisible }) => (alwaysVisible ? 'contents' : 'none')};
@@ -155,8 +157,6 @@ export const UtxoSelection = ({ transaction, utxo }: UtxoSelectionProps) => {
             isCoinControlEnabled,
         },
     } = useSendFormContext();
-
-    const device = useSelector(selectDevice);
     // selecting metadata from store rather than send form context which does not update on metadata change
     const { outputLabels } = useSelector(selectLabelingDataForSelectedAccount);
 
@@ -168,7 +168,8 @@ export const UtxoSelection = ({ transaction, utxo }: UtxoSelectionProps) => {
     const isPendingTransaction = utxo.confirmations === 0;
     const isChangeAddress = utxo.path.split('/').at(-2) === '1'; // change address always has a 1 on the penultimate level of the derivation path
     const outputLabel = outputLabels?.[utxo.txid]?.[utxo.vout];
-    const isLabelingPossible = device?.metadata.status === 'enabled' || device?.connected;
+
+    const isLabelingPossible = useSelector(selectIsLabelingInitPossible);
     const anonymity = account.addresses?.anonymitySet?.[utxo.address];
 
     const isChecked = isCoinControlEnabled

--- a/packages/suite/src/views/wallet/send/components/Outputs/components/Address/index.tsx
+++ b/packages/suite/src/views/wallet/send/components/Outputs/components/Address/index.tsx
@@ -210,7 +210,7 @@ export const Address = ({ output, outputId, outputsCount }: AddressProps) => {
                         defaultVisibleValue=""
                         payload={{
                             type: 'outputLabel',
-                            accountKey: account.key,
+                            entityKey: account.key,
                             // txid is not known at this moment. metadata is only saved
                             // along with other sendForm data and processed in sendFormActions
                             txid: 'will-be-replaced',

--- a/suite-common/metadata-types/src/metadataTypes.ts
+++ b/suite-common/metadata-types/src/metadataTypes.ts
@@ -18,7 +18,7 @@ export type LabelableEntityKeysByVersion = DeviceEntityKeys | AccountEntityKeys;
 export type MetadataAddPayload =
     | {
           type: 'outputLabel';
-          accountKey: string;
+          entityKey: string;
           txid: string;
           outputIndex: number;
           defaultValue: string;
@@ -26,19 +26,19 @@ export type MetadataAddPayload =
       }
     | {
           type: 'addressLabel';
-          accountKey: string;
+          entityKey: string;
           defaultValue: string;
           value?: string;
       }
     | {
           type: 'accountLabel';
-          accountKey: string;
+          entityKey: string;
           defaultValue: string;
           value?: string;
       }
     | {
           type: 'walletLabel';
-          deviceState: string;
+          entityKey: string;
           defaultValue: string;
           value?: string;
       };

--- a/suite-common/metadata-types/src/metadataTypes.ts
+++ b/suite-common/metadata-types/src/metadataTypes.ts
@@ -187,13 +187,7 @@ export interface WalletLabels {
 
 export type Labels = AccountLabels | WalletLabels;
 
-export type DeviceMetadata =
-    | {
-          status: 'disabled' | 'cancelled'; // user rejects "Enable labeling" on device
-      }
-    | ({
-          status: 'enabled';
-      } & DeviceEntityKeys);
+export type DeviceMetadata = DeviceEntityKeys;
 
 type Data = Record<
     LabelableEntityKeys['fileName'], // unique "id" for mapping with labelable entitties

--- a/suite-common/metadata-types/src/metadataTypes.ts
+++ b/suite-common/metadata-types/src/metadataTypes.ts
@@ -228,6 +228,12 @@ export interface MetadataState {
     // field shall hold default value for which user may add metadata (address, txId, etc...);
     editing?: string;
     initiating?: boolean;
+    /**
+     * error, typical reasons:
+     * - user clicked cancel button on device when "Enable labeling" was shown.
+     * - device disconnected
+     */
+    error?: { [deviceState: string]: boolean };
 }
 
 export type OAuthServerEnvironment = 'production' | 'staging' | 'localhost';

--- a/suite-common/test-utils/src/mocks.ts
+++ b/suite-common/test-utils/src/mocks.ts
@@ -189,7 +189,7 @@ const getSuiteDevice = (dev?: Partial<TrezorDevice>, feat?: Partial<Features>): 
             instance: undefined,
             ts: 0,
             buttonRequests: [],
-            metadata: { status: 'disabled' },
+            metadata: {},
             ...dev,
             ...device,
         } as TrezorDevice;

--- a/suite-common/wallet-core/src/device/deviceConstants.ts
+++ b/suite-common/wallet-core/src/device/deviceConstants.ts
@@ -61,8 +61,6 @@ export const hiddenDevice: TrezorDevice = {
     available: true,
     ts: 0,
     buttonRequests: [],
-    metadata: {
-        status: 'disabled',
-    },
+    metadata: {},
     unavailableCapabilities: {},
 };

--- a/suite-common/wallet-core/src/device/deviceReducer.ts
+++ b/suite-common/wallet-core/src/device/deviceReducer.ts
@@ -83,7 +83,7 @@ const connectDevice = (draft: State, device: Device) => {
             available: false,
             useEmptyPassphrase: true,
             buttonRequests: [],
-            metadata: { status: 'disabled' },
+            metadata: {},
             ts: new Date().getTime(),
         });
         return;
@@ -121,7 +121,7 @@ const connectDevice = (draft: State, device: Device) => {
             ? deviceUtils.getNewInstanceNumber(draft.devices, device) || 1
             : undefined,
         buttonRequests: [],
-        metadata: { status: 'disabled' },
+        metadata: {},
         ts: new Date().getTime(),
     };
 
@@ -354,7 +354,7 @@ const createInstance = (draft: State, device: TrezorDevice) => {
         authConfirm: false,
         ts: new Date().getTime(),
         buttonRequests: [],
-        metadata: { status: 'disabled' },
+        metadata: {},
     };
     draft.devices.push(newDevice);
 };
@@ -404,7 +404,7 @@ const forget = (draft: State, device: TrezorDevice) => {
         draft.devices[index].passphraseOnDevice = false;
         // set remember to false to make it disappear after device is disconnected
         draft.devices[index].remember = false;
-        draft.devices[index].metadata = { status: 'disabled' };
+        draft.devices[index].metadata = {};
     } else {
         draft.devices.splice(index, 1);
     }

--- a/suite-common/wallet-core/src/device/deviceReducer.ts
+++ b/suite-common/wallet-core/src/device/deviceReducer.ts
@@ -564,6 +564,9 @@ export const selectIsDeviceConnectedAndAuthorized = (state: DeviceRootState) => 
     return !!deviceState && !!deviceFeatures;
 };
 
+export const selectDeviceByState = (state: DeviceRootState, deviceState: string) =>
+    selectDevices(state).find(d => d.state === deviceState);
+
 export const selectDeviceUnavailableCapabilities = (state: DeviceRootState) =>
     state.device.selectedDevice?.unavailableCapabilities;
 

--- a/suite-common/wallet-core/src/discovery/discoveryThunks.ts
+++ b/suite-common/wallet-core/src/discovery/discoveryThunks.ts
@@ -351,7 +351,7 @@ export const startDiscoveryThunk = createThunk(
         }
 
         const { deviceState, authConfirm } = discovery;
-        const metadataEnabled = metadata.enabled && device.metadata.status === 'disabled';
+        const metadataEnabled = metadata.enabled && !device.metadata[1]; // todo: can't import constant
 
         // start process
         if (


### PR DESCRIPTION
In this PR I am separating code from #9130 which is not features. so basically everything from #9130 except for confirm-less labeling and migration was moved to this PR.

While working on #9130 I noticed couple of problems which might have been around for long time or might have been introduced in one of the previous requests on the were merged along the way to the confirm-less labeling feature (#9108, #9218, #9262, #9270)

commits:
- 853ee539b85f36ac134982dfce2048bd3f8a13a9
  - labels have not been stored anymore into indexxed db for some time now and are instead loaded when provider becomes available. This commit fixes bug when labels were loaded only for selected device.
  - added e2e test to validate this
  - fixed paths of files in mocked providers in e2e tests.
- 7cc08f08d421f0b7ded7255008491273010597f5
  - unifies unique id for labelable entities. Previously there was `account.key` and `device.state` and it was necessary to use `in` operator frequently. Now we are using everywhere `entity.key` abstraction narrowing defined in a newly added selector.
- 051e504246b73792ee828fe6e400dc6d6fd07c0a
  - removes unused constants and export
- 9d88de1a016e1dbe30d1cc05b12410494a5dd945
  - moves code from metadataActions `getLabelableEntities` which was actually a selector to metadataReducer.
- 9f91aeff7232d3a708a34929168e4b4d61fb8d28
  - micro change. remove provider by clientId instead of type. type would work as well for now but we want to be ready for future.
- 298fca7e2a84a21ff5fb1d789134b0afdcb18b8f
  - removes field `device.metadata.status ('disabled' || 'cancelled' || 'enabled')`. This is mostyl types simplification. Previously, `metadata[encryptionVersion]...` was bound with `metadata.status.enabled` and it was needed to use `in` operator in my opinion superfluously. 
  - `cancelled` status is replaced by newly added `metadata.error` which is basically `metadata.failedMigration` field introduced in #9130. When error is set, suite does not try to init metadata automatically. 
- 2fc852cdd6996ad6a304cf96d3293f155c19e74d
  - updates unit tests, there were some antipatterns, for example mocking happend inside single "tests/its" meaning that running some of the tests in isolation did not work
- f59a696be5882520a552df7726bfb7a112ab6a76
   - just use selector in SettingsGeneral component.
 - cb4e79d91776602fafc0d1e19a36a031d5200a39
   - in metadataActions we need to be careful about for which device (passphrase) selected action runs. Previously, we only worked with selected device but it was not right. It was actually possible to have one device selected and trigger metadata init action for another device when trying to label another wallet in wallet modal selection. 
- 4f1951f46377a3c69bc08f9ee9dda40da3199dc9
  - revision of return types in metadataActions. in general, the more atomic the action is, the less sideefects it should have. example: `encryptAndSaveMetadata` action and `fetchMetadata` actions should never handle their errors and only return results to their caller. The reason is that caller knows whether these actions are run in batch and is in better position to handle errors. In other words - if error is handled in an atomic action we might fire dozens of notifications in case of error which we obviously don't want to do. 
- e82a6ad022364006a8d1601bc79eb6e2c7c13542
  - removing device.status `'cancelled'` actually changes behaviour of app. we need to make a note that user cancelled labeling on device so that we know that in the next run we don't want to trigger this dialogue again. Also this field will be reused in #9130 where I named it `metadata.failedMigration` but I believe that naming in this PR `metadata.error` is actually better.
  - more about it in e2e test added in later commit 8c5029cc7175132d73229aae741f64aab1c1ddb0
  - this commit does not make that field persitent yet, it is added in 8c5029cc7175132d73229aae741f64aab1c1ddb0
- 073e40edfb500fd56c7833e5a0dc466db0d21641
  - e2e test for cb4e79d91776602fafc0d1e19a36a031d5200a39
- b86a5e0304bb6fe09f82cdd698e2b16403822a78
  - e2e test to make sure that newly added account has keys added too (this is handled in metadata middleware)
- a8308936d5c6a232e7dc379b23d2a5db0f75bd0d
  - revision of selectors
- 8c5029cc7175132d73229aae741f64aab1c1ddb0
  - addition to e82a6ad022364006a8d1601bc79eb6e2c7c13542 making `metadata.error`, while not leaking info about number of used passphrases. This information follows fate of device (remember/forget)
  - I believe that decoupling this data (device.status => metadat.error) is benefitial, but our current implementation does not have any good way how to work with relational data unfortunately :( we should investigate something like https://redux-orm.github.io/redux-orm/basics/reducers. 
  - this commit also adds test that describe how suite and (un)remembered devices behave in relation to labeling
- d7f4cd5e2099447dc69fed857d12e6fe2c98781b
  - mitigation for #9545. when data is fetched from provider, check its shape and if it does not match the expected one fill in missing structure.
  - it would still be nice to find the root cause of  #9545 but I really could not spot the problem, maybe whoever is reviewing this has better eyes.

## Screamshots

Trying to enable labeling for other than currently selected device should work 

<img width="696" alt="image" src="https://github.com/trezor/trezor-suite/assets/30367552/81097cc3-aac3-40fc-bf29-89c3a8617f5d">

When there are more saved wallets, all should load their labels after app reload. not only the selected one.

<img width="590" alt="image" src="https://github.com/trezor/trezor-suite/assets/30367552/31e2d178-4338-4c99-8b55-16b2d4327fbb">

