### PR TITLE
fix(connect): wrong version format in discovery

### DIFF
--- a/packages/connect/src/api/common/paramsValidator.ts
+++ b/packages/connect/src/api/common/paramsValidator.ts
@@ -107,13 +107,19 @@ export const getFirmwareRange = (
     if (coinInfo) {
         if (!coinInfo.support || typeof coinInfo.support.trezor1 !== 'string') {
             current['1'].min = '0';
-        } else if (versionUtils.isNewer(coinInfo.support.trezor1, current['1'].min)) {
+        } else if (
+            current['1'].min !== '0' &&
+            versionUtils.isNewer(coinInfo.support.trezor1, current['1'].min)
+        ) {
             current['1'].min = coinInfo.support.trezor1;
         }
 
         if (!coinInfo.support || typeof coinInfo.support.trezor2 !== 'string') {
             current['2'].min = '0';
-        } else if (versionUtils.isNewer(coinInfo.support.trezor2, current['2'].min)) {
+        } else if (
+            current['2'].min !== '0' &&
+            versionUtils.isNewer(coinInfo.support.trezor2, current['2'].min)
+        ) {
             current['2'].min = coinInfo.support.trezor2;
         }
     }


### PR DESCRIPTION
fixing a bug introduced in https://github.com/trezor/trezor-suite/pull/9366 that manifests as this issue https://github.com/trezor/trezor-suite-private/issues/57

TrezorConnect.getAccountInfo receives batch of parameters describing networks it is supposed to discover. Than it iterates over the batch and sets information about firmware range (=firmware requriement for this method). So typically it works like that it either gradually increases min required firmware version as it iterates over networks, or it sets min version to 0, meaning this network is not support. The newly introduced comparison function in #9366 does not accept 0 argument 

fixes https://github.com/trezor/trezor-suite-private/issues/57