### PR TITLE
test(e2e): re-enable discovery test

### DIFF
--- a/packages/connect/src/api/common/paramsValidator.ts
+++ b/packages/connect/src/api/common/paramsValidator.ts
@@ -107,13 +107,19 @@ export const getFirmwareRange = (
     if (coinInfo) {
         if (!coinInfo.support || typeof coinInfo.support.trezor1 !== 'string') {
             current['1'].min = '0';
-        } else if (versionUtils.isNewer(coinInfo.support.trezor1, current['1'].min)) {
+        } else if (
+            current['1'].min !== '0' &&
+            versionUtils.isNewer(coinInfo.support.trezor1, current['1'].min)
+        ) {
             current['1'].min = coinInfo.support.trezor1;
         }
 
         if (!coinInfo.support || typeof coinInfo.support.trezor2 !== 'string') {
             current['2'].min = '0';
-        } else if (versionUtils.isNewer(coinInfo.support.trezor2, current['2'].min)) {
+        } else if (
+            current['2'].min !== '0' &&
+            versionUtils.isNewer(coinInfo.support.trezor2, current['2'].min)
+        ) {
             current['2'].min = coinInfo.support.trezor2;
         }
     }

--- a/packages/suite-web/e2e/tests/wallet/discovery.test.ts
+++ b/packages/suite-web/e2e/tests/wallet/discovery.test.ts
@@ -4,8 +4,22 @@
 // discovery should end within this time frame
 const DISCOVERY_LIMIT = 1000 * 60 * 2;
 
-// todo: discovery does not run to end, is it only in tests?
-describe.skip('Discovery', () => {
+const coinsToActivate = [
+    'ltc',
+    'eth',
+    'etc',
+    'dash',
+    'btg',
+    'bch',
+    'doge',
+    'vtc',
+    'ada',
+    'xrp',
+    'dgb',
+    'zec',
+    'nmc',
+];
+describe('Discovery', () => {
     beforeEach(() => {
         cy.task('startEmu', { wipe: true });
         cy.task('setupEmu');
@@ -16,11 +30,8 @@ describe.skip('Discovery', () => {
     });
 
     it('go to wallet settings page, activate all coins and see that there is equal number of records on dashboard', () => {
-        cy.getTestElement('@settings/wallet/coins-group/mainnet/activate-all').click({
-            force: true,
-        });
-        cy.getTestElement('@settings/wallet/coins-group/testnet/activate-all').click({
-            force: true,
+        coinsToActivate.forEach(symbol => {
+            cy.getTestElement(`@settings/wallet/network/${symbol}`).click();
         });
 
         cy.getTestElement('@suite/menu/suite-index').click({ force: true });
@@ -28,6 +39,9 @@ describe.skip('Discovery', () => {
 
         cy.getTestElement('@dashboard/loading', { timeout: 1000 * 10 });
         cy.getTestElement('@dashboard/loading', { timeout: DISCOVERY_LIMIT }).should('not.exist');
+        ['btc', ...coinsToActivate].forEach(symbol => {
+            cy.getTestElement(`@asset-card/${symbol}/balance`);
+        });
     });
 });
 

--- a/packages/suite/src/views/dashboard/components/AssetsCard/components/AssetTable.tsx
+++ b/packages/suite/src/views/dashboard/components/AssetsCard/components/AssetTable.tsx
@@ -161,7 +161,10 @@ export const AssetTable = memo(({ network, failed, cryptoValue, isLastRow }: Ass
             </CoinNameWrapper>
 
             {!failed ? (
-                <CryptoBalanceWrapper isLastRow={isLastRow}>
+                <CryptoBalanceWrapper
+                    isLastRow={isLastRow}
+                    data-test={`@asset-card/${symbol}/balance`}
+                >
                     <AmountUnitSwitchWrapper symbol={symbol}>
                         <CoinBalance value={cryptoValue} symbol={symbol} />
 


### PR DESCRIPTION
adding test for #9572

- when base on develop, it failed (expected) https://gitlab.com/satoshilabs/trezor/trezor-suite/-/jobs/5211158352/artifacts/file/packages/suite-web/e2e/videos/discovery.test.ts.mp4
-  based on #9572 it succeeded https://gitlab.com/satoshilabs/trezor/trezor-suite/-/jobs/5211499918/artifacts/file/packages/suite-web/e2e/videos/discovery.test.ts.mp4