### PR TITLE
fix(ci): using nix-shell to have npm available

### DIFF
--- a/ci/npm-deploy.yml
+++ b/ci/npm-deploy.yml
@@ -85,5 +85,5 @@ deploy npm connect:
   <<: *packages_matrix_connect
   script:
     - nix-shell --run "cd ./packages/${PACKAGE} && yarn npm publish --access public"
-    - ./packages/connect/e2e/test-npm-install.sh
-    - ./packages/connect/e2e/test-yarn-install.sh
+    - nix-shell --run "./packages/connect/e2e/test-npm-install.sh"
+    - nix-shell --run "./packages/connect/e2e/test-yarn-install.sh"


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
In our latest connect release there was a script that we use to test that the deployment has been successful failing because of missing `npm`. With this PR those scripts will use `nix-shell` in order to have `npm` available.

https://gitlab.com/satoshilabs/trezor/trezor-suite/-/jobs/5202989027
