### PR TITLE
Test/connect explorer webextension popup

### DIFF
--- a/ci/test.yml
+++ b/ci/test.yml
@@ -206,7 +206,6 @@ transport manual:
     TEST_FILE: $TEST_FILE
   script:
     - yarn install --immutable
-    - yarn workspace @trezor/connect-explorer-webextension build
     - docker-compose pull
     - docker-compose up -d trezor-user-env-unix
     - docker-compose run test-run
@@ -270,10 +269,38 @@ connect-popup legacy:
     <<: *run_everything_rules
   when: manual
 
-connect-popup-webextension:
-  extends: .e2e connect-popup
+.e2e connect-popup-webextension:
+  stage: integration testing
+  retry: 1
   variables:
+    COMPOSE_PROJECT_NAME: $CI_JOB_ID
+    COMPOSE_FILE: ./docker/docker-compose.connect-popup-ci.yml
+    URL: ${DEV_SERVER_URL}/connect/${CI_COMMIT_REF_NAME}/
+    TEST_FILE: $TEST_FILE
     IS_WEBEXTENSION: "true"
+  script:
+    - yarn install --immutable
+    - yarn workspace @trezor/connect-explorer-webextension build
+    - docker-compose pull
+    - docker-compose up -d trezor-user-env-unix
+    - docker-compose run test-run
+  after_script:
+    - docker-compose down
+    - docker network prune -f
+  artifacts:
+    expire_in: 7 days
+    when: always
+    paths:
+      - ./packages/connect-popup/e2e/screenshots
+      - ./packages/connect-popup/connect-popup-overview.html
+      - ./packages/connect-popup/test-results
+  interruptible: true
+  parallel:
+    matrix:
+      - TEST_FILE: ["methods.test"]
+
+connect-popup-webextension:
+  extends: .e2e connect-popup-webextension
   dependencies:
     - install
     - connect-web build
@@ -281,9 +308,7 @@ connect-popup-webextension:
     <<: *run_everything_rules
 
 connect-popup-webextension manual:
-  extends: .e2e connect-popup
-  variables:
-    IS_WEBEXTENSION: "true"
+  extends: .e2e connect-popup-webextension
   needs:
     - install
     - connect-web build

--- a/ci/test.yml
+++ b/ci/test.yml
@@ -206,6 +206,7 @@ transport manual:
     TEST_FILE: $TEST_FILE
   script:
     - yarn install --immutable
+    - yarn workspace @trezor/connect-explorer-webextension build
     - docker-compose pull
     - docker-compose up -d trezor-user-env-unix
     - docker-compose run test-run
@@ -265,6 +266,27 @@ connect-popup legacy:
     matrix:
       - CONNECT_VERSION: "9.0.11"
         TEST_FILE: ["methods.test", "browser-support.test", "popup-close-legacy.test"]
+  except:
+    <<: *run_everything_rules
+  when: manual
+
+connect-popup-webextension:
+  extends: .e2e connect-popup
+  variables:
+    IS_WEBEXTENSION: "true"
+  dependencies:
+    - install
+    - connect-web build
+  only:
+    <<: *run_everything_rules
+
+connect-popup-webextension manual:
+  extends: .e2e connect-popup
+  variables:
+    IS_WEBEXTENSION: "true"
+  needs:
+    - install
+    - connect-web build
   except:
     <<: *run_everything_rules
   when: manual

--- a/docker/docker-compose.connect-popup-ci.yml
+++ b/docker/docker-compose.connect-popup-ci.yml
@@ -21,6 +21,7 @@ services:
       - CI_COMMIT_BRANCH=$CI_COMMIT_BRANCH
       - CI_JOB_NAME=$CI_JOB_NAME
       - TEST_FILE=$TEST_FILE
+      - IS_WEBEXTENSION=$IS_WEBEXTENSION
     working_dir: /e2e
     command: bash -c "npx playwright install && yarn workspace @trezor/connect-popup test:e2e $TEST_FILE"
     volumes:

--- a/docker/docker-compose.connect-popup-test.yml
+++ b/docker/docker-compose.connect-popup-test.yml
@@ -32,6 +32,7 @@ services:
       # useful for debugging tests
       - PWDEBUG=console
       - TEST_FILE=$TEST_FILE
+      - IS_WEBEXTENSION=$IS_WEBEXTENSION
     working_dir: /trezor-suite
     command: bash -c "npx playwright install && docker/wait-for-200.sh http://localhost:8088/index.html && yarn workspace @trezor/connect-popup test:e2e $TEST_FILE"
     volumes:

--- a/packages/connect-explorer/src/data/methods/binance/signTransaction.ts
+++ b/packages/connect-explorer/src/data/methods/binance/signTransaction.ts
@@ -1,6 +1,6 @@
 const name = 'binanceSignTransaction';
 const docs = 'methods/binanceSignTransaction.md';
-const transfer = `{
+const transfer = {
     chain_id: 'Binance-Chain-Nile',
     account_number: 34,
     memo: 'test',
@@ -10,23 +10,19 @@ const transfer = `{
         inputs: [
             {
                 address: 'tbnb1hgm0p7khfk85zpz5v0j8wnej3a90w709zzlffd',
-                coins: [
-                    { amount: 1000000000, denom: 'BNB' },
-                ],
+                coins: [{ amount: 1000000000, denom: 'BNB' }],
             },
         ],
         outputs: [
             {
                 address: 'tbnb1ss57e8sa7xnwq030k2ctr775uac9gjzglqhvpy',
-                coins: [
-                    { amount: 1000000000, denom: 'BNB' },
-                ],
+                coins: [{ amount: 1000000000, denom: 'BNB' }],
             },
         ],
     },
-}`;
+};
 
-const placeOrder = `{
+const placeOrder = {
     chain_id: 'Binance-Chain-Nile',
     account_number: 34,
     memo: '',
@@ -42,9 +38,9 @@ const placeOrder = `{
         symbol: 'ADA.B-B63_BNB',
         timeinforce: 1,
     },
-}`;
+};
 
-const cancelOrder = `{
+const cancelOrder = {
     chain_id: 'Binance-Chain-Nile',
     account_number: 34,
     memo: '',
@@ -55,7 +51,7 @@ const cancelOrder = `{
         sender: 'tbnb1hgm0p7khfk85zpz5v0j8wnej3a90w709zzlffd',
         symbol: 'BCHSV.B-10F_BNB',
     },
-}`;
+};
 
 export default [
     {

--- a/packages/connect-explorer/src/data/methods/bitcoin/composeTransaction.ts
+++ b/packages/connect-explorer/src/data/methods/bitcoin/composeTransaction.ts
@@ -1,56 +1,72 @@
 import { select } from './common';
 
 const examples = {
-    btc: `[
-    {
-        amount: '498066',
-        address: '3L6TyTisPBmrDAj6RoKmDzNnj4eQi54gD2',
-    }
-]`,
-    test: `[
-    {
-        amount: '2000',
-        address: '2N4Q5FhU2497BryFfUgbqkAJE87aKHUhXMp',
-    }
-]`,
-    bch: `[
-    {
-        amount: '20000',
-        address: 'bitcoincash:qrjgzvp26w92hgg06h69zxuarxtlsryzwg7wecq0mn',
-    }
-]`,
-    btg: `[{
-    amount: '20000',
-    address: 'AXibjT5r96ZaVA8Lu4BQZocdTx7p5Ud8ZP',
-}]`,
-    ltc: `[{
-    amount: '20000',
-    address: 'MUbHn23ZL733kCUbvQ88ZhVSWMdFQMEoV8',
-}]`,
-    dash: `[{
-    amount: '20000',
-    address: 'XdTw4G5AWW4cogGd7ayybyBNDbuB45UpgH',
-}]`,
-    zcash: `[{
-    amount: '20000',
-    address: 't1Lv2EguMkaZwvtFQW5pmbUsBw59KfTEhf4',
-}]`,
-    doge: `[{
-    amount: '20000',
-    address: 'DUCd1B3YBiXL5By15yXgSLZtEkvwsgEdqS',
-}]`,
-    nmc: `[{
-    amount: '20000',
-    address: 'N4n9hyYH5EDfhmCRS3qqzh7crLbuXrku6d',
-}]`,
-    vtc: `[{
-    amount: '20000',
-    address: '33GN5Aq3tqBbF3f2HBfCRZi6fyS3baEQWH',
-}]`,
-    cpc: `[{
-    amount: '20000',
-    address: 'CMSgH7wq4kV9ogmSPB5rBmPceQJy3oA9Bu',
-}]`,
+    btc: [
+        {
+            amount: '498066',
+            address: '3L6TyTisPBmrDAj6RoKmDzNnj4eQi54gD2',
+        },
+    ],
+    test: [
+        {
+            amount: '2000',
+            address: '2N4Q5FhU2497BryFfUgbqkAJE87aKHUhXMp',
+        },
+    ],
+    bch: [
+        {
+            amount: '20000',
+            address: 'bitcoincash:qrjgzvp26w92hgg06h69zxuarxtlsryzwg7wecq0mn',
+        },
+    ],
+    btg: [
+        {
+            amount: '20000',
+            address: 'AXibjT5r96ZaVA8Lu4BQZocdTx7p5Ud8ZP',
+        },
+    ],
+    ltc: [
+        {
+            amount: '20000',
+            address: 'MUbHn23ZL733kCUbvQ88ZhVSWMdFQMEoV8',
+        },
+    ],
+    dash: [
+        {
+            amount: '20000',
+            address: 'XdTw4G5AWW4cogGd7ayybyBNDbuB45UpgH',
+        },
+    ],
+    zcash: [
+        {
+            amount: '20000',
+            address: 't1Lv2EguMkaZwvtFQW5pmbUsBw59KfTEhf4',
+        },
+    ],
+    doge: [
+        {
+            amount: '20000',
+            address: 'DUCd1B3YBiXL5By15yXgSLZtEkvwsgEdqS',
+        },
+    ],
+    nmc: [
+        {
+            amount: '20000',
+            address: 'N4n9hyYH5EDfhmCRS3qqzh7crLbuXrku6d',
+        },
+    ],
+    vtc: [
+        {
+            amount: '20000',
+            address: '33GN5Aq3tqBbF3f2HBfCRZi6fyS3baEQWH',
+        },
+    ],
+    cpc: [
+        {
+            amount: '20000',
+            address: 'CMSgH7wq4kV9ogmSPB5rBmPceQJy3oA9Bu',
+        },
+    ],
 };
 
 export default [

--- a/packages/connect-explorer/src/data/methods/bitcoin/signTransaction.p2sh.ts
+++ b/packages/connect-explorer/src/data/methods/bitcoin/signTransaction.p2sh.ts
@@ -1,29 +1,42 @@
+/* eslint-disable no-bitwise */
 import { select } from './common';
 
 const name = 'signTransaction';
 const docs = 'methods/signTransaction.md';
 
 const test = {
-    inputs: `[
-    {
-        address_n: [(44 | 0x80000000) >>> 0, (1 | 0x80000000) >>> 0, (0 | 0x80000000) >>> 0, 1, 0],
-        amount: "123456789",
-        prev_index: 0,
-        prev_hash: "20912f98ea3ed849042efed0fdac8cb4fc301961c5988cba56902d8ffb61c337",
-    }
-]`,
-    outputs: `[
-    {
-        address: "1MJ2tj2ThBE62zXbBYA5ZaN3fdve5CPAz1",
-        amount: "12300000",
-        script_type: "PAYTOADDRESS"
-    },
-    {
-        address_n: [(49 | 0x80000000) >>> 0, (1 | 0x80000000) >>> 0, (0 | 0x80000000) >>> 0, 2, 0],
-        script_type: "PAYTOADDRESS",
-        amount: Number(123456789 - 11000 - 12300000).toString(),
-    }
-]`,
+    inputs: [
+        {
+            address_n: [
+                (44 | 0x80000000) >>> 0,
+                (1 | 0x80000000) >>> 0,
+                (0 | 0x80000000) >>> 0,
+                1,
+                0,
+            ],
+            amount: '123456789',
+            prev_index: 0,
+            prev_hash: '20912f98ea3ed849042efed0fdac8cb4fc301961c5988cba56902d8ffb61c337',
+        },
+    ],
+    outputs: [
+        {
+            address: '1MJ2tj2ThBE62zXbBYA5ZaN3fdve5CPAz1',
+            amount: '12300000',
+            script_type: 'PAYTOADDRESS',
+        },
+        {
+            address_n: [
+                (49 | 0x80000000) >>> 0,
+                (1 | 0x80000000) >>> 0,
+                (0 | 0x80000000) >>> 0,
+                2,
+                0,
+            ],
+            script_type: 'PAYTOADDRESS',
+            amount: Number(123456789 - 11000 - 12300000).toString(),
+        },
+    ],
 };
 
 const examples = {

--- a/packages/connect-explorer/src/data/methods/bitcoin/signTransaction.paytoaddress.ts
+++ b/packages/connect-explorer/src/data/methods/bitcoin/signTransaction.paytoaddress.ts
@@ -1,130 +1,160 @@
+/* eslint-disable no-bitwise */
 import { select } from './common';
 
 const name = 'signTransaction';
 const docs = 'methods/signTransaction.md';
 
 const btc = {
-    inputs: `[
-    {
-        address_n: [44 | 0x80000000, 0 | 0x80000000, 0 | 0x80000000, 0, 5],
-        prev_hash: '50f6f1209ca92d7359564be803cb2c932cde7d370f7cee50fd1fad6790f6206d',
-        prev_index: 1,
-    },
-]`,
-    outputs: `[
+    inputs: [
+        {
+            address_n: [44 | 0x80000000, 0 | 0x80000000, 0 | 0x80000000, 0, 5],
+            prev_hash: '50f6f1209ca92d7359564be803cb2c932cde7d370f7cee50fd1fad6790f6206d',
+            prev_index: 1,
+        },
+    ],
+    outputs: [
         {
             address: 'bc1qrp33g0q5c5txsp9arysrx4k6zdkfs4nce4xj0gdcccefvpysxf3qccfmv3',
             amount: '10000',
             script_type: 'PAYTOADDRESS',
         },
-]`,
+    ],
 };
 
 const bch = {
-    inputs: `[
-    {
-        address_n: [44 | 0x80000000, 145 | 0x80000000, 0 | 0x80000000, 0, 0],
-        amount: '1995344',
-        prev_hash: 'bc37c28dfb467d2ecb50261387bf752a3977d7e5337915071bb4151e6b711a78',
-        prev_index: 0,
-        script_type: 'SPENDADDRESS',
-    },
-]`,
-    outputs: `[
-    {
-        address_n: [44 | 0x80000000, 145 | 0x80000000, 0 | 0x80000000, 1, 0],
-        amount: '1896050',
-        script_type: 'PAYTOADDRESS',
-    },
-    {
-        address: 'bitcoincash:qr23ajjfd9wd73l87j642puf8cad20lfmqdgwvpat4',
-        amount: '73452',
-        script_type: 'PAYTOADDRESS',
-    },
-]`,
+    inputs: [
+        {
+            address_n: [44 | 0x80000000, 145 | 0x80000000, 0 | 0x80000000, 0, 0],
+            amount: '1995344',
+            prev_hash: 'bc37c28dfb467d2ecb50261387bf752a3977d7e5337915071bb4151e6b711a78',
+            prev_index: 0,
+            script_type: 'SPENDADDRESS',
+        },
+    ],
+    outputs: [
+        {
+            address_n: [44 | 0x80000000, 145 | 0x80000000, 0 | 0x80000000, 1, 0],
+            amount: '1896050',
+            script_type: 'PAYTOADDRESS',
+        },
+        {
+            address: 'bitcoincash:qr23ajjfd9wd73l87j642puf8cad20lfmqdgwvpat4',
+            amount: '73452',
+            script_type: 'PAYTOADDRESS',
+        },
+    ],
 };
 
 const test = {
-    inputs: `[
+    inputs: [
         {
-            address_n: [(44 | 0x80000000) >>> 0, (1 | 0x80000000) >>> 0, (0 | 0x80000000) >>> 0, 1, 0],
-            amount: "123456789",
+            address_n: [
+                (44 | 0x80000000) >>> 0,
+                (1 | 0x80000000) >>> 0,
+                (0 | 0x80000000) >>> 0,
+                1,
+                0,
+            ],
+            amount: '123456789',
             prev_index: 0,
-            prev_hash: "20912f98ea3ed849042efed0fdac8cb4fc301961c5988cba56902d8ffb61c337",
-        }
-    ]`,
-    outputs: `[
+            prev_hash: '20912f98ea3ed849042efed0fdac8cb4fc301961c5988cba56902d8ffb61c337',
+        },
+    ],
+    outputs: [
         {
-            address: "1MJ2tj2ThBE62zXbBYA5ZaN3fdve5CPAz1",
-            amount: "12300000",
-            script_type: "PAYTOADDRESS"
+            address: '1MJ2tj2ThBE62zXbBYA5ZaN3fdve5CPAz1',
+            amount: '12300000',
+            script_type: 'PAYTOADDRESS',
         },
         {
-            address_n: [(49 | 0x80000000) >>> 0, (1 | 0x80000000) >>> 0, (0 | 0x80000000) >>> 0, 2, 0],
-            script_type: "PAYTOADDRESS",
+            address_n: [
+                (49 | 0x80000000) >>> 0,
+                (1 | 0x80000000) >>> 0,
+                (0 | 0x80000000) >>> 0,
+                2,
+                0,
+            ],
+            script_type: 'PAYTOADDRESS',
             amount: Number(123456789 - 11000 - 12300000).toString(),
-        }
-    ]`,
+        },
+    ],
 };
 
 const dash = {
-    inputs: `[
+    inputs: [
         {
-            address_n: [(44 | 0x80000000) >>> 0, (5 | 0x80000000) >>> 0, (0 | 0x80000000) >>> 0, 1, 0],
-            amount: "167280961",
+            address_n: [
+                (44 | 0x80000000) >>> 0,
+                (5 | 0x80000000) >>> 0,
+                (0 | 0x80000000) >>> 0,
+                1,
+                0,
+            ],
+            amount: '167280961',
             prev_index: 0,
-            prev_hash: "adb43bcd8fc99d6ed353c30ca8e5bd5996cd7bcf719bd4253f103dfb7227f6ed",
-        }
-]`,
-    outputs: `[
-    {
-        address: "XkNPrBSJtrHZUvUqb3JF4g5rMB3uzaJfEL",
-        amount: "167000000",
-        script_type: "PAYTOADDRESS"
-    },
-]`,
+            prev_hash: 'adb43bcd8fc99d6ed353c30ca8e5bd5996cd7bcf719bd4253f103dfb7227f6ed',
+        },
+    ],
+    outputs: [
+        {
+            address: 'XkNPrBSJtrHZUvUqb3JF4g5rMB3uzaJfEL',
+            amount: '167000000',
+            script_type: 'PAYTOADDRESS',
+        },
+    ],
 };
 
 // version 3
 const zcash = {
-    inputs: `[
+    inputs: [
         {
             address_n: [2147483692, 2147483781, 2147483648, 0, 2],
             prev_hash: '6df53ccdc6fa17e1cd248f7ec57e86178d6f96f2736bdf978602992b5850ac79',
             prev_index: 1,
-            amount: '200000'
+            amount: '200000',
         },
-
-    ]`,
-    outputs: `[
+    ],
+    outputs: [
         {
             address: 't1N5zTV5PjJqRgSPmszHopk88Nc6mvMBSD7',
             amount: '100000',
             script_type: 'PAYTOADDRESS',
         },
-    ]`,
+    ],
 };
 
 const doge = {
-    inputs: `[
+    inputs: [
         {
-            address_n: [(44 | 0x80000000) >>> 0, (3 | 0x80000000) >>> 0, (0 | 0x80000000) >>> 0, 1, 0],
+            address_n: [
+                (44 | 0x80000000) >>> 0,
+                (3 | 0x80000000) >>> 0,
+                (0 | 0x80000000) >>> 0,
+                1,
+                0,
+            ],
             prev_index: 12,
-            prev_hash: "0a4cb7d5c27455333701f0e53812e4be56a0272ad7f168279acfed7b065ee118",
+            prev_hash: '0a4cb7d5c27455333701f0e53812e4be56a0272ad7f168279acfed7b065ee118',
         },
-]`,
-    outputs: `[
+    ],
+    outputs: [
         {
-            address: "D9vbBhmwXgRegm5kVAcx8j6H2GDM87D58T",
-            amount: "1351855234633976",
-            script_type: "PAYTOADDRESS"
+            address: 'D9vbBhmwXgRegm5kVAcx8j6H2GDM87D58T',
+            amount: '1351855234633976',
+            script_type: 'PAYTOADDRESS',
         },
         {
-            address_n: [(44 | 0x80000000) >>> 0, (3 | 0x80000000) >>> 0, (0 | 0x80000000) >>> 0, 1, 0],
-            amount: "10000000000000000",
-            script_type: "PAYTOADDRESS"
+            address_n: [
+                (44 | 0x80000000) >>> 0,
+                (3 | 0x80000000) >>> 0,
+                (0 | 0x80000000) >>> 0,
+                1,
+                0,
+            ],
+            amount: '10000000000000000',
+            script_type: 'PAYTOADDRESS',
         },
-]`,
+    ],
 };
 
 const examples = {

--- a/packages/connect-explorer/src/data/methods/bitcoin/signTransaction.zcash.ts
+++ b/packages/connect-explorer/src/data/methods/bitcoin/signTransaction.zcash.ts
@@ -1,3 +1,4 @@
+/* eslint-disable no-bitwise */
 import { select } from './common';
 
 const name = 'signTransaction';
@@ -19,21 +20,32 @@ export default [
             {
                 name: 'inputs',
                 type: 'json',
-                value: `[{
-    address_n: [(44 | 0x80000000) >>> 0, (133 | 0x80000000) >>> 0, (0 | 0x80000000) >>> 0, 0, 0],
-    prev_hash: '4264f5f339c9fd498976dabb6d7b8819e112d25a0c1770a0f3ee81de525de8f8',
-    prev_index: 0,
-    amount: '118540'
-}]`,
+                value: [
+                    {
+                        address_n: [
+                            (44 | 0x80000000) >>> 0,
+                            (133 | 0x80000000) >>> 0,
+                            (0 | 0x80000000) >>> 0,
+                            0,
+                            0,
+                        ],
+                        prev_hash:
+                            '4264f5f339c9fd498976dabb6d7b8819e112d25a0c1770a0f3ee81de525de8f8',
+                        prev_index: 0,
+                        amount: '118540',
+                    },
+                ],
             },
             {
                 name: 'outputs',
                 type: 'json',
-                value: `[{
-    address: 't1fT6Zv1LcPwSwausNAuYGdewv2Mke3nrYo',
-    amount: '118000',
-    script_type: 'PAYTOADDRESS',
-}]`,
+                value: [
+                    {
+                        address: 't1fT6Zv1LcPwSwausNAuYGdewv2Mke3nrYo',
+                        amount: '118000',
+                        script_type: 'PAYTOADDRESS',
+                    },
+                ],
             },
             {
                 name: 'overwintered',

--- a/packages/connect-explorer/src/data/methods/cardano/getAddress.ts
+++ b/packages/connect-explorer/src/data/methods/cardano/getAddress.ts
@@ -9,7 +9,11 @@ const batch = [
     {
         name: 'addressParameters',
         type: 'json',
-        value: `{'path': "m/1852'/1815'/0'/0/0", 'stakingPath': "m/1852'/1815'/0'/2/0", 'addressType': ${CardanoAddressType.BASE} }`,
+        value: {
+            path: "m/1852'/1815'/0'/0/0",
+            stakingPath: "m/1852'/1815'/0'/2/0",
+            addressType: CardanoAddressType.BASE,
+        },
     },
     {
         name: 'networkId',

--- a/packages/connect-explorer/src/data/methods/cardano/getNativeScriptHash.ts
+++ b/packages/connect-explorer/src/data/methods/cardano/getNativeScriptHash.ts
@@ -16,7 +16,10 @@ export default [
             {
                 name: 'script',
                 type: 'json',
-                value: `{'type': ${CardanoNativeScriptType.PUB_KEY}, 'keyHash': "c4b9265645fde9536c0795adbcc5291767a0c61fd62448341d7e0386" }`,
+                value: {
+                    type: CardanoNativeScriptType.PUB_KEY,
+                    keyHash: 'c4b9265645fde9536c0795adbcc5291767a0c61fd62448341d7e0386',
+                },
             },
             cardanoNativeScriptHashDisplayFormat,
             cardanoDerivationType,

--- a/packages/connect-explorer/src/data/methods/eos/signTransaction.ts
+++ b/packages/connect-explorer/src/data/methods/eos/signTransaction.ts
@@ -2,25 +2,26 @@ const name = 'eosSignTransaction';
 const docs = 'methods/eosSignTransaction.md';
 
 const tx = {
-    inputs: `[
-    {
-        path: "m/44'/1815'/0'/0/0",
-        prev_hash: "2effff328b76a8113e32a218f7af99e77768289c9201e8d26a9cda0edaf59bfd",
-        prev_index: 0,
-        type: 0
-    }
-]`,
-    outputs: `[
-    {
-        address: "2w1sdSJu3GVeNrv8NVHmWNBqK6ssW84An4pExajjdFgXx6k4gksoo6CP1qTwbE34qjKEHZtUKGxY1GMkApUnNEMwGPTgLc7Yghs",
-        amount: "1000000"
-    },
-    {
-        path: "m/44'/1815'/0'/0/1",
-        amount: "7120787"
-    }
-]`,
-    transactions: `{
+    inputs: [
+        {
+            path: "m/44'/1815'/0'/0/0",
+            prev_hash: '2effff328b76a8113e32a218f7af99e77768289c9201e8d26a9cda0edaf59bfd',
+            prev_index: 0,
+            type: 0,
+        },
+    ],
+    outputs: [
+        {
+            address:
+                '2w1sdSJu3GVeNrv8NVHmWNBqK6ssW84An4pExajjdFgXx6k4gksoo6CP1qTwbE34qjKEHZtUKGxY1GMkApUnNEMwGPTgLc7Yghs',
+            amount: '1000000',
+        },
+        {
+            path: "m/44'/1815'/0'/0/1",
+            amount: '7120787',
+        },
+    ],
+    transactions: {
         chainId: 'cf057bbfb72640471fd910bcb67639c22df9f92470936cddc1ade0e2f2e7dc4f',
         header: {
             expiration: '2018-07-14T10:43:28',
@@ -32,15 +33,13 @@ const tx = {
         },
         actions: [
             {
-                "account": "foocontract",
-                "name": "baraction",
-                "authorization": [
-                    {"actor": "miniminimini", "permission": "active"}
-                ],
-                "data": "deadbeef",
+                account: 'foocontract',
+                name: 'baraction',
+                authorization: [{ actor: 'miniminimini', permission: 'active' }],
+                data: 'deadbeef',
             },
-        ]
-    }`,
+        ],
+    },
 };
 
 export default [

--- a/packages/connect-explorer/src/data/methods/ethereum/signTransaction-erc20-known.ts
+++ b/packages/connect-explorer/src/data/methods/ethereum/signTransaction-erc20-known.ts
@@ -1,6 +1,6 @@
 const name = 'ethereumSignTransaction';
 const docs = 'methods/ethereumSignTransaction.md';
-const tx = `{
+const tx = {
     nonce: '0x0',
     gasPrice: '0x14',
     gasLimit: '0x14',
@@ -8,7 +8,7 @@ const tx = `{
     chainId: 1,
     value: '0x0',
     data: '0xa9059cbb000000000000000000000000D6971aabeDC7f2A8113679199FE374aE1B1Aea96000000000000000000000000000000000000000000000000000000000097f6b2',
-}`;
+};
 
 // sending erc20 known token (USDT)
 export default [

--- a/packages/connect-explorer/src/data/methods/ethereum/signTransaction-erc20-unknown.ts
+++ b/packages/connect-explorer/src/data/methods/ethereum/signTransaction-erc20-unknown.ts
@@ -1,7 +1,7 @@
 const name = 'ethereumSignTransaction';
 const docs = 'methods/ethereumSignTransaction.md';
 
-const tx = `{
+const tx = {
     nonce: '0x0',
     gasPrice: '0x14',
     gasLimit: '0x14',
@@ -9,7 +9,7 @@ const tx = `{
     chainId: 1,
     value: '0x0',
     data: '0xa9059cbb000000000000000000000000D6971aabeDC7f2A8113679199FE374aE1B1Aea96000000000000000000000000000000000000000000000000000000000097f6b2',
-}`;
+};
 
 // sending erc-20 unknown token (unknown to firmware)
 // https://etherscan.io/token/0x26fb86579e371c7aedc461b2ddef0a8628c93d3b

--- a/packages/connect-explorer/src/data/methods/ethereum/signTransaction.ts
+++ b/packages/connect-explorer/src/data/methods/ethereum/signTransaction.ts
@@ -1,14 +1,14 @@
 const name = 'ethereumSignTransaction';
 const docs = 'methods/ethereumSignTransaction.md';
 
-const tx = `{
+const tx = {
     nonce: '0x0',
     gasPrice: '0x14',
     gasLimit: '0x14',
     to: '0xd0d6d6c5fe4a677d343cc433536bb717bae167dd',
     chainId: 1,
     value: '1',
-}`;
+};
 
 export default [
     {

--- a/packages/connect-explorer/src/data/methods/ethereum/signTypedData.ts
+++ b/packages/connect-explorer/src/data/methods/ethereum/signTypedData.ts
@@ -31,7 +31,7 @@ export default [
             {
                 name: 'data',
                 type: 'json',
-                value: JSON.stringify(eip712Data),
+                value: eip712Data,
             },
             {
                 name: 'domain_separator_hash',

--- a/packages/connect-explorer/src/data/methods/nem/signTransaction.ts
+++ b/packages/connect-explorer/src/data/methods/nem/signTransaction.ts
@@ -1,19 +1,19 @@
 const name = 'nemSignTransaction';
 const docs = 'methods/nemSignTransaction.md';
 
-const example = `{
+const example = {
     timeStamp: 74649215,
     amount: 2000000,
     fee: 2000000,
-    recipient: "TALICE2GMA34CXHD7XLJQ536NM5UNKQHTORNNT2J",
+    recipient: 'TALICE2GMA34CXHD7XLJQ536NM5UNKQHTORNNT2J',
     type: 257,
     deadline: 74735615,
     version: (0x98 << 24) >> 0,
     message: {
-        payload: "746573745f6e656d5f7472616e73616374696f6e5f7472616e73666572",
+        payload: '746573745f6e656d5f7472616e73616374696f6e5f7472616e73666572',
         type: 1,
     },
-}`;
+};
 
 export default [
     {

--- a/packages/connect-explorer/src/data/methods/nem/signTransaction.ts
+++ b/packages/connect-explorer/src/data/methods/nem/signTransaction.ts
@@ -8,6 +8,7 @@ const example = {
     recipient: 'TALICE2GMA34CXHD7XLJQ536NM5UNKQHTORNNT2J',
     type: 257,
     deadline: 74735615,
+    // eslint-disable-next-line no-bitwise
     version: (0x98 << 24) >> 0,
     message: {
         payload: '746573745f6e656d5f7472616e73616374696f6e5f7472616e73666572',

--- a/packages/connect-explorer/src/data/methods/other/login.ts
+++ b/packages/connect-explorer/src/data/methods/other/login.ts
@@ -29,17 +29,17 @@ export default [
             {
                 name: 'callback',
                 type: 'function',
-                value: `function() {
-    return new Promise(function(resolve) {
-        // wait 3 sec. and resolve
-        setTimeout(function() {
-            resolve({
-                challengeHidden: '0123456789abcdef',
-                challengeVisual: 'Login to',
-            })
-        }, 3000)
-    });
-}`,
+                value() {
+                    return new Promise(resolve => {
+                        // wait 3 sec. and resolve
+                        setTimeout(() => {
+                            resolve({
+                                challengeHidden: '0123456789abcdef',
+                                challengeVisual: 'Login to',
+                            });
+                        }, 3000);
+                    });
+                },
             },
         ],
     },

--- a/packages/connect-explorer/src/data/methods/ripple/signTransaction.ts
+++ b/packages/connect-explorer/src/data/methods/ripple/signTransaction.ts
@@ -1,15 +1,15 @@
 const name = 'rippleSignTransaction';
 const docs = 'methods/rippleSignTransaction.md';
 
-const example = `{
+const example = {
     fee: '12',
     flags: 0x80000000,
     sequence: 25,
     payment: {
         amount: '1000000',
         destination: 'rBKz5MC2iXdoS3XgnNSYmF69K1Yo4NS3Ws',
-    }
-}`;
+    },
+};
 
 export default [
     {

--- a/packages/connect-explorer/src/data/methods/tezos/signTransaction.ts
+++ b/packages/connect-explorer/src/data/methods/tezos/signTransaction.ts
@@ -1,16 +1,16 @@
 const name = 'tezosSignTransaction';
 const docs = 'methods/tezosSignTransaction.md';
-const example = `{
+const example = {
     transaction: {
-        source: "tz1ckrgqGGGBt4jGDmwFhtXc1LNpZJUnA9F2",
-        destination: "tz1cTfmc5uuBr2DmHDgkXTAoEcufvXLwq5TP",
+        source: 'tz1ckrgqGGGBt4jGDmwFhtXc1LNpZJUnA9F2',
+        destination: 'tz1cTfmc5uuBr2DmHDgkXTAoEcufvXLwq5TP',
         counter: 20449,
         amount: 1000000000,
         fee: 10000,
         gas_limit: 11000,
-        storage_limit: 277
-    }
-}`;
+        storage_limit: 277,
+    },
+};
 
 export default [
     {

--- a/packages/connect-explorer/src/reducers/methodReducer.ts
+++ b/packages/connect-explorer/src/reducers/methodReducer.ts
@@ -150,6 +150,9 @@ const setAffectedValues = (state: MethodState, field: any) => {
             const affectedField = root.find(f => f.name === af);
             if (affectedField) {
                 affectedField.value = values[index];
+                if (state.name === 'composeTransaction') {
+                    affectedField.value = values;
+                }
             }
         });
     } else if (field.affect && typeof field.affect === 'string' && field.value) {

--- a/packages/connect-explorer/src/reducers/methodReducer.ts
+++ b/packages/connect-explorer/src/reducers/methodReducer.ts
@@ -1,5 +1,3 @@
-/* eslint-disable no-eval */
-
 import {
     TAB_CHANGE,
     FIELD_CHANGE,

--- a/packages/connect-explorer/src/reducers/methodReducer.ts
+++ b/packages/connect-explorer/src/reducers/methodReducer.ts
@@ -54,13 +54,20 @@ const getParam = (field: Field<any>, $params: Record<string, any> = {}) => {
         }
     } else if (field.type === 'json') {
         try {
-            params[field.name] = field.value.length > 0 ? eval(`(${field.value});`) : '';
+            if (typeof field.value === 'string' && field.value.length > 0) {
+                params[field.name] = JSON.parse(field.value);
+            } else {
+                params[field.name] = field.value;
+            }
         } catch (error) {
             params[field.name] = `Invalid json, ${error.toString()}`;
         }
     } else if (field.type === 'function') {
         try {
-            params[field.name] = field.value.length > 0 ? eval(`(${field.value});`) : '';
+            if (typeof field.value !== 'function') {
+                throw new Error('Invalid function');
+            }
+            params[field.name] = field.value;
         } catch (error) {
             params[field.name] = `Invalid function, ${error.toString()}`;
         }

--- a/packages/connect-popup/e2e/support/helpers.ts
+++ b/packages/connect-popup/e2e/support/helpers.ts
@@ -1,6 +1,7 @@
 /* eslint-disable no-await-in-loop */
 
-import { Page } from '@playwright/test';
+import path from 'path';
+import { chromium, Page } from '@playwright/test';
 
 // Waits and clicks for an array on buttons in serial order.
 export const waitAndClick = async (page: Page, buttons: string[]) => {
@@ -19,4 +20,51 @@ export const findElementByDataTest = async (page: Page, dataTest: string, timeou
 
 export const log = (...val: string[]) => {
     console.log(`[===]`, ...val);
+};
+
+export const getExtensionPage = async () => {
+    const pathToExtension = path.join(
+        __dirname,
+        '..',
+        '..',
+        '..',
+        'connect-explorer-webextension',
+        'build',
+    );
+
+    const userDataDir = `/tmp/test-user-data-dir/${new Date().getTime()}`;
+    const browserContext = await chromium.launchPersistentContext(userDataDir, {
+        // https://playwright.dev/docs/chrome-extensions#headless-mode
+        // By default, Chrome's headless mode in Playwright does not support Chrome extensions.
+        // To overcome this limitation, you can run Chrome's persistent context with a new headless mode.
+        // using `--headless=new`
+        headless: false,
+        args: [
+            process.env.HEADLESS === 'true' ? `--headless=new` : '', // the new headless arg for chrome v109+. Use '--headless=chrome' as arg for browsers v94-108.
+            `--disable-extensions-except=${pathToExtension}`,
+            `--load-extension=${pathToExtension}`,
+        ],
+    });
+
+    await browserContext.clearCookies();
+
+    const page = await browserContext.newPage();
+
+    // https://playwright.dev/docs/chrome-extensions#testing
+    // It looks like the only way to get extension ID from a MV3 web extension in playwright is having serviceworker loaded.
+    let [background] = browserContext.serviceWorkers();
+    if (!background) background = await browserContext.waitForEvent('serviceworker');
+
+    // https://github.com/microsoft/playwright/issues/5593#issuecomment-949813218
+    await page.goto('chrome://inspect/#extensions');
+
+    const extensionId = background.url().split('/')[2];
+
+    const url = `chrome-extension://${extensionId}/connect-explorer.html`;
+
+    return {
+        page,
+        url,
+        browserContext,
+    };
 };


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
This PR makes current popup tests with connect-explorer to run also in connect-explorer in a webextension.
This allows us to use the testing framework we already have to test in webextension environment.

It required to change to stop using eval in connect-explorer to load the method data.

Related to https://github.com/trezor/trezor-suite/issues/8883