### PR TITLE
feat(connect-explorer): add rebootToBootloader method

### DIFF
--- a/packages/connect-explorer/src/data/menu.ts
+++ b/packages/connect-explorer/src/data/menu.ts
@@ -488,6 +488,10 @@ export default [
                 url: '/method/changePin',
             },
             {
+                name: 'Reboot to bootloader',
+                url: '/method/rebootToBootloader',
+            },
+            {
                 name: 'Firmware update',
                 url: '/method/firmwareUpdate',
             },

--- a/packages/connect-explorer/src/data/methods/management/index.ts
+++ b/packages/connect-explorer/src/data/methods/management/index.ts
@@ -7,6 +7,7 @@ import backupDevice from './backupDevice';
 import changePin from './changePin';
 import recoverDevice from './recoverDevice';
 import firmwareUpdate from './firmwareUpdate';
+import rebootToBootloader from './rebootToBootloader';
 
 export default [
     ...getFeatures,
@@ -18,4 +19,5 @@ export default [
     ...changePin,
     ...recoverDevice,
     ...firmwareUpdate,
+    ...rebootToBootloader,
 ];

--- a/packages/connect-explorer/src/data/methods/management/rebootToBootloader.ts
+++ b/packages/connect-explorer/src/data/methods/management/rebootToBootloader.ts
@@ -1,0 +1,10 @@
+const name = 'rebootToBootloader';
+
+export default [
+    {
+        url: `/method/rebootToBootloader`,
+        name,
+        submitButton: 'Reboot to bootloader',
+        fields: [],
+    },
+];


### PR DESCRIPTION
side product of debugging https://github.com/trezor/trezor-suite/issues/9577

at the moment, it seems that rebootToBootloader works in popup mode without any further changes to connect code.

<img width="684" alt="image" src="https://github.com/trezor/trezor-suite/assets/30367552/c1d3ceda-da36-4295-8828-d6ff42aa3f0c">
