### PR TITLE
fix(connect): use type header with the bridge API

### DIFF
--- a/packages/transport/src/transports/bridge.ts
+++ b/packages/transport/src/transports/bridge.ts
@@ -363,7 +363,6 @@ export class BridgeTransport extends AbstractTransport {
             ...restOptions,
             method: 'POST',
             url: `${this.url + endpoint}${options?.params ? `/${options.params}` : ''}`,
-            skipContentTypeHeader: true,
         });
 
         if (!response.success) {


### PR DESCRIPTION
The Bridge API calls now use the type header to specify the type of the request body. Fixes Android native suite communication with the bridge.