### PR TITLE
feat(connect): update stellar-sdk and stellar-base

### DIFF
--- a/packages/connect-plugin-stellar/jest.config.js
+++ b/packages/connect-plugin-stellar/jest.config.js
@@ -1,3 +1,6 @@
 module.exports = {
     preset: '../../jest.config.base.js',
+    moduleNameMapper: {
+        axios: 'axios/dist/node/axios.cjs',
+    },
 };

--- a/packages/connect-plugin-stellar/package.json
+++ b/packages/connect-plugin-stellar/package.json
@@ -24,13 +24,13 @@
     ],
     "peerDependencies": {
         "@trezor/connect": "9.x.x",
-        "stellar-sdk": "^10.4.1"
+        "stellar-sdk": "^v11.0.0-beta.3"
     },
     "devDependencies": {
         "jest": "^26.6.3",
         "rimraf": "^5.0.1",
-        "stellar-base": "^8.2.2",
-        "stellar-sdk": "^10.4.1",
+        "stellar-base": "v10.0.0-beta.2",
+        "stellar-sdk": "^v11.0.0-beta.3",
         "typescript": "4.9.5"
     },
     "dependencies": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -9402,12 +9402,12 @@ __metadata:
     bignumber.js: ^9.1.1
     jest: ^26.6.3
     rimraf: ^5.0.1
-    stellar-base: ^8.2.2
-    stellar-sdk: ^10.4.1
+    stellar-base: v10.0.0-beta.2
+    stellar-sdk: ^v11.0.0-beta.3
     typescript: 4.9.5
   peerDependencies:
     "@trezor/connect": 9.x.x
-    stellar-sdk: ^10.4.1
+    stellar-sdk: ^v11.0.0-beta.3
   languageName: unknown
   linkType: soft
 
@@ -10757,13 +10757,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@types/eventsource@npm:^1.1.2":
-  version: 1.1.12
-  resolution: "@types/eventsource@npm:1.1.12"
-  checksum: 19039099c2dc8fb369517b248856ba30dca3c36cf58cb2d62137d7c907db40871c6c4e67b1960ebba2b6f84a6bba7add4c25dc647fefbb4a37cdb7ccfa3b3f15
-  languageName: node
-  linkType: hard
-
 "@types/express-serve-static-core@npm:*, @types/express-serve-static-core@npm:^4.17.33":
   version: 4.17.35
   resolution: "@types/express-serve-static-core@npm:4.17.35"
@@ -11354,15 +11347,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@types/randombytes@npm:^2.0.0":
-  version: 2.0.1
-  resolution: "@types/randombytes@npm:2.0.1"
-  dependencies:
-    "@types/node": "*"
-  checksum: 3ff0e1f812cabafe2957d6633f5127119224f8d7c1765ab47a1c1b2427f3375c59356ed47b59e8e08796930cca50b23a8322e9d9420fc56d9614e9a0956cb539
-  languageName: node
-  linkType: hard
-
 "@types/range-parser@npm:*":
   version: 1.2.4
   resolution: "@types/range-parser@npm:1.2.4"
@@ -11650,13 +11634,6 @@ __metadata:
   version: 2.0.6
   resolution: "@types/unist@npm:2.0.6"
   checksum: 25cb860ff10dde48b54622d58b23e66214211a61c84c0f15f88d38b61aa1b53d4d46e42b557924a93178c501c166aa37e28d7f6d994aba13d24685326272d5db
-  languageName: node
-  linkType: hard
-
-"@types/urijs@npm:^1.19.6":
-  version: 1.19.20
-  resolution: "@types/urijs@npm:1.19.20"
-  checksum: 9e2e0e5ba19a27bdb5bdd258518082e555500d7efe957f9b09d68d98d99c472d0efa7616ec6e55262514189d8e22e482175576229cbbcf539a72f1e1c20d1df1
   languageName: node
   linkType: hard
 
@@ -13266,15 +13243,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"axios@npm:0.25.0":
-  version: 0.25.0
-  resolution: "axios@npm:0.25.0"
-  dependencies:
-    follow-redirects: ^1.14.7
-  checksum: 2a8a3787c05f2a0c9c3878f49782357e2a9f38945b93018fb0c4fd788171c43dceefbb577988628e09fea53952744d1ecebde234b561f1e703aa43e0a598a3ad
-  languageName: node
-  linkType: hard
-
 "axios@npm:1.1.3":
   version: 1.1.3
   resolution: "axios@npm:1.1.3"
@@ -13286,14 +13254,14 @@ __metadata:
   languageName: node
   linkType: hard
 
-"axios@npm:^1.0.0":
-  version: 1.3.2
-  resolution: "axios@npm:1.3.2"
+"axios@npm:^1.0.0, axios@npm:^1.5.1":
+  version: 1.5.1
+  resolution: "axios@npm:1.5.1"
   dependencies:
     follow-redirects: ^1.15.0
     form-data: ^4.0.0
     proxy-from-env: ^1.1.0
-  checksum: 9791af75a6df137b15ef45d13ad11eb357b3860d2496347ee18778db9d0abc2320362a4452f1e070e3160f1dbcc518fcefdc9e005be097e7db39acb22cf608e5
+  checksum: 4444f06601f4ede154183767863d2b8e472b4a6bfc5253597ed6d21899887e1fd0ee2b3de792ac4f8459fe2e359d2aa07c216e45fd8b9e4e0688a6ebf48a5a8d
   languageName: node
   linkType: hard
 
@@ -13885,17 +13853,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"bignumber.js@npm:^4.0.0":
-  version: 4.1.0
-  resolution: "bignumber.js@npm:4.1.0"
-  checksum: d6356def9af39048e4ce87ee6518e85a69e297c9a055df1e44633d8e3a6c2b4cf2d333462e1ab8a7c487c851adc45fb44bb5748d545d2416ac0f751bccd811c8
-  languageName: node
-  linkType: hard
-
-"bignumber.js@npm:^9.0.0, bignumber.js@npm:^9.1.1":
-  version: 9.1.1
-  resolution: "bignumber.js@npm:9.1.1"
-  checksum: ad243b7e2f9120b112d670bb3d674128f0bd2ca1745b0a6c9df0433bd2c0252c43e6315d944c2ac07b4c639e7496b425e46842773cf89c6a2dcd4f31e5c4b11e
+"bignumber.js@npm:^9.0.0, bignumber.js@npm:^9.1.1, bignumber.js@npm:^9.1.2":
+  version: 9.1.2
+  resolution: "bignumber.js@npm:9.1.2"
+  checksum: 582c03af77ec9cb0ebd682a373ee6c66475db94a4325f92299621d544aa4bd45cb45fd60001610e94aef8ae98a0905fa538241d9638d4422d57abbeeac6fadaf
   languageName: node
   linkType: hard
 
@@ -15958,7 +15919,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"crc@npm:^3.5.0, crc@npm:^3.8.0":
+"crc@npm:^3.8.0":
   version: 3.8.0
   resolution: "crc@npm:3.8.0"
   dependencies:
@@ -18066,7 +18027,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"es6-promise@npm:^4.2.4, es6-promise@npm:^4.2.8":
+"es6-promise@npm:^4.2.8":
   version: 4.2.8
   resolution: "es6-promise@npm:4.2.8"
   checksum: 95614a88873611cb9165a85d36afa7268af5c03a378b35ca7bda9508e1d4f1f6f19a788d4bc755b3fd37c8ebba40782018e02034564ff24c9d6fa37e959ad57d
@@ -19134,10 +19095,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"eventsource@npm:^1.1.1":
-  version: 1.1.2
-  resolution: "eventsource@npm:1.1.2"
-  checksum: fe8f2ac3c70b1b63ee3cef5c0a28680cb00b5747bfda1d9835695fab3ed602be41c5c799b1fc997b34b02633573fead25b12b036bdf5212f23a6aa9f59212e9b
+"eventsource@npm:^2.0.2":
+  version: 2.0.2
+  resolution: "eventsource@npm:2.0.2"
+  checksum: c0072d972753e10c705d9b2285b559184bf29d011bc208973dde9c8b6b8b7b6fdad4ef0846cecb249f7b1585e860fdf324cbd2ac854a76bc53649e797496e99a
   languageName: node
   linkType: hard
 
@@ -20372,7 +20333,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"follow-redirects@npm:^1.0.0, follow-redirects@npm:^1.14.7, follow-redirects@npm:^1.15.0":
+"follow-redirects@npm:^1.0.0, follow-redirects@npm:^1.15.0":
   version: 1.15.3
   resolution: "follow-redirects@npm:1.15.3"
   peerDependenciesMeta:
@@ -24522,13 +24483,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"js-xdr@npm:^1.1.3":
-  version: 1.3.0
-  resolution: "js-xdr@npm:1.3.0"
-  dependencies:
-    lodash: ^4.17.5
-    long: ^2.2.3
-  checksum: c9d2e340840b510b7de3d8d07da610a9feb65ece25195847737ddcd88f929490ee868354957e8d615be983ff524a2863fa9b3341d2f3b3fc950a6660e7dad6a0
+"js-xdr@npm:^3.0.0":
+  version: 3.0.0
+  resolution: "js-xdr@npm:3.0.0"
+  checksum: 74eb5c67fe6e04a2d03e2295dba33219805cb8dc9fa4e664487e930b7f0e3977d6d794ef0ddde320505b9a8e403439d46a0bb646352961f9c1ca0bf6d3a227f2
   languageName: node
   linkType: hard
 
@@ -25690,7 +25648,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"lodash@npm:4.x, lodash@npm:^4.17.13, lodash@npm:^4.17.15, lodash@npm:^4.17.19, lodash@npm:^4.17.20, lodash@npm:^4.17.21, lodash@npm:^4.17.4, lodash@npm:^4.17.5, lodash@npm:^4.7.0":
+"lodash@npm:4.x, lodash@npm:^4.17.13, lodash@npm:^4.17.15, lodash@npm:^4.17.19, lodash@npm:^4.17.20, lodash@npm:^4.17.21, lodash@npm:^4.17.4, lodash@npm:^4.7.0":
   version: 4.17.21
   resolution: "lodash@npm:4.17.21"
   checksum: eb835a2e51d381e561e508ce932ea50a8e5a68f4ebdd771ea240d3048244a8d13658acbd502cd4829768c56f2e16bdd4340b9ea141297d472517b83868e677f7
@@ -25775,13 +25733,6 @@ __metadata:
   version: 4.0.1
   resolution: "loglevelnext@npm:4.0.1"
   checksum: 1464d9b0dd34c3f765424c8eda6a00a40aa9ab834f03ee9723dd600858b5fdb92fe856967e1f40c98ffbc241e4ce68b10fd0aa49f5de749ab7e854454b251542
-  languageName: node
-  linkType: hard
-
-"long@npm:^2.2.3":
-  version: 2.4.0
-  resolution: "long@npm:2.4.0"
-  checksum: e24fd5e14be90ba6ec3faa43b3b0f1c4ac88bfdc52471d90f63e173572f6db27c45873e847f8af58283ca3140eb42d7ba11708102f3cc0956793b03305c737e0
   languageName: node
   linkType: hard
 
@@ -27822,14 +27773,14 @@ __metadata:
   languageName: node
   linkType: hard
 
-"node-gyp-build@npm:^4.2.0, node-gyp-build@npm:^4.2.2, node-gyp-build@npm:^4.3.0, node-gyp-build@npm:^4.5.0":
-  version: 4.6.0
-  resolution: "node-gyp-build@npm:4.6.0"
+"node-gyp-build@npm:^4.2.0, node-gyp-build@npm:^4.2.2, node-gyp-build@npm:^4.3.0, node-gyp-build@npm:^4.5.0, node-gyp-build@npm:^4.6.0":
+  version: 4.6.1
+  resolution: "node-gyp-build@npm:4.6.1"
   bin:
     node-gyp-build: bin.js
     node-gyp-build-optional: optional.js
     node-gyp-build-test: build-test.js
-  checksum: 25d78c5ef1f8c24291f4a370c47ba52fcea14f39272041a90a7894cd50d766f7c8cb8fb06c0f42bf6f69b204b49d9be3c8fc344aac09714d5bdb95965499eb15
+  checksum: c3676d337b36803bc7792e35bf7fdcda7cdcb7e289b8f9855a5535702a82498eb976842fefcf487258c58005ca32ce3d537fbed91280b04409161dcd7232a882
   languageName: node
   linkType: hard
 
@@ -33279,13 +33230,13 @@ __metadata:
   languageName: node
   linkType: hard
 
-"sodium-native@npm:^3.3.0":
-  version: 3.4.1
-  resolution: "sodium-native@npm:3.4.1"
+"sodium-native@npm:^4.0.1":
+  version: 4.0.4
+  resolution: "sodium-native@npm:4.0.4"
   dependencies:
     node-gyp: latest
-    node-gyp-build: ^4.3.0
-  checksum: 88f2f8c9ecb3c7952098b667ee3803f24253d72a3b3874b126e0e36b2ac20432e12ad44bde3664024e6d0ae1bc6d24fdebc81273af161e735f2eec22f10d26dd
+    node-gyp-build: ^4.6.0
+  checksum: 5697e7d8fa49b0ccde9b15beda2664c09ccc55450304b78287a6522e3e5db02c7fc3de415df5b2273bbc45e3f5e17966bf487c8a8bff7a84c8cbbee8fcd5e7b2
   languageName: node
   linkType: hard
 
@@ -33708,46 +33659,36 @@ __metadata:
   languageName: node
   linkType: hard
 
-"stellar-base@npm:^8.2.2":
-  version: 8.2.2
-  resolution: "stellar-base@npm:8.2.2"
+"stellar-base@npm:10.0.0-beta.2, stellar-base@npm:v10.0.0-beta.2":
+  version: 10.0.0-beta.2
+  resolution: "stellar-base@npm:10.0.0-beta.2"
   dependencies:
     base32.js: ^0.1.0
-    bignumber.js: ^4.0.0
-    crc: ^3.5.0
-    js-xdr: ^1.1.3
-    lodash: ^4.17.21
+    bignumber.js: ^9.1.2
+    buffer: ^6.0.3
+    js-xdr: ^3.0.0
     sha.js: ^2.3.6
-    sodium-native: ^3.3.0
+    sodium-native: ^4.0.1
     tweetnacl: ^1.0.3
   dependenciesMeta:
     sodium-native:
       optional: true
-  checksum: 9dfbbeb048b359d819c080f18993c919b0f6717f14a24c68a1da07efea47b065d762c75f24def3c868a8b4914c15d34a044c7cb00d609d04fdbe98441a841f6e
+  checksum: 0412cca65beb688a88322203af847ffb8df6d22a1a579158b4b7d59d34c33e39c67c6007161f351cfef4b8fc28d3381de0ff1c1d6c682456d69314e18d9b4974
   languageName: node
   linkType: hard
 
-"stellar-sdk@npm:^10.4.1":
-  version: 10.4.1
-  resolution: "stellar-sdk@npm:10.4.1"
+"stellar-sdk@npm:^v11.0.0-beta.3":
+  version: 11.0.0-beta.4
+  resolution: "stellar-sdk@npm:11.0.0-beta.4"
   dependencies:
-    "@types/eventsource": ^1.1.2
-    "@types/node": ">= 8"
-    "@types/randombytes": ^2.0.0
-    "@types/urijs": ^1.19.6
-    axios: 0.25.0
-    bignumber.js: ^4.0.0
-    detect-node: ^2.0.4
-    es6-promise: ^4.2.4
-    eventsource: ^1.1.1
-    lodash: ^4.17.21
+    axios: ^1.5.1
+    bignumber.js: ^9.1.2
+    eventsource: ^2.0.2
     randombytes: ^2.1.0
-    stellar-base: ^8.2.2
-    toml: ^2.3.0
-    tslib: ^1.10.0
+    stellar-base: 10.0.0-beta.2
+    toml: ^3.0.0
     urijs: ^1.19.1
-    utility-types: ^3.7.0
-  checksum: 2e407709ed56ace1514dcd32cc099be0946435021d92e9fdd3d97695f7670266264a5881b7d4086427e22915ca4fc319ea90d874f997842420dcda51dd6bc712
+  checksum: 1a42e545760704e3d2789cb319ad41c47fa78f9c01fd7f3221cb701fe669c771ea7a54f0e027817fd7f11c98322a6536dff23734107d4036a6d18f6b526f8f97
   languageName: node
   linkType: hard
 
@@ -35022,10 +34963,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"toml@npm:^2.3.0":
-  version: 2.3.6
-  resolution: "toml@npm:2.3.6"
-  checksum: e1be1ec9dad3049459d0c81e5b7b40ce8356ca5fc27d23cab101551447e22af7fe6d903d19162389ffd50cb3ff4e986374992d4c293da84166fa6307c7c1b5cf
+"toml@npm:^3.0.0":
+  version: 3.0.0
+  resolution: "toml@npm:3.0.0"
+  checksum: 5d7f1d8413ad7780e9bdecce8ea4c3f5130dd53b0a4f2e90b93340979a137739879d7b9ce2ce05c938b8cc828897fe9e95085197342a1377dd8850bf5125f15f
   languageName: node
   linkType: hard
 
@@ -35358,7 +35299,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"tslib@npm:^1.10.0, tslib@npm:^1.13.0, tslib@npm:^1.8.1, tslib@npm:^1.9.0, tslib@npm:^1.9.3":
+"tslib@npm:^1.13.0, tslib@npm:^1.8.1, tslib@npm:^1.9.0, tslib@npm:^1.9.3":
   version: 1.14.1
   resolution: "tslib@npm:1.14.1"
   checksum: dbe628ef87f66691d5d2959b3e41b9ca0045c3ee3c7c7b906cc1e328b39f199bb1ad9e671c39025bd56122ac57dfbf7385a94843b1cc07c60a4db74795829acd
@@ -36257,13 +36198,6 @@ __metadata:
   version: 0.4.0
   resolution: "utila@npm:0.4.0"
   checksum: 97ffd3bd2bb80c773429d3fb8396469115cd190dded1e733f190d8b602bd0a1bcd6216b7ce3c4395ee3c79e3c879c19d268dbaae3093564cb169ad1212d436f4
-  languageName: node
-  linkType: hard
-
-"utility-types@npm:^3.7.0":
-  version: 3.10.0
-  resolution: "utility-types@npm:3.10.0"
-  checksum: 8f274415c6196ab62883b8bd98c9d2f8829b58016e4269aaa1ebd84184ac5dda7dc2ca45800c0d5e0e0650966ba063bf9a412aaeaea6850ca4440a391283d5c8
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Updating `stellar-sdk` and `stellar-base` to the latest version to address breaking changes. `stellar-sdk` is exported as ESM instead of CJS now.

Initial PR: https://github.com/trezor/trezor-suite/pull/9543. Rebasing `yarn.lock` was messy, so I'm re-adding our updates again. 