### PR TITLE
fix(connect): content type header applied for native

### DIFF
--- a/packages/transport/package.json
+++ b/packages/transport/package.json
@@ -24,6 +24,10 @@
         "./src/transports/udp": "./src/transports/udp.browser",
         "./src/transports/webusb": "./src/transports/webusb.browser"
     },
+    "react-native": {
+        "__comment__": "Fixes commutation between android device and bridge by always applying content-type header.",
+        "./lib/utils/applyContentTypeHeader": "./lib/utils/applyContentTypeHeader.native.js"
+    },
     "files": [
         "lib/",
         "!**/*.map"

--- a/packages/transport/src/transports/bridge.ts
+++ b/packages/transport/src/transports/bridge.ts
@@ -363,6 +363,7 @@ export class BridgeTransport extends AbstractTransport {
             ...restOptions,
             method: 'POST',
             url: `${this.url + endpoint}${options?.params ? `/${options.params}` : ''}`,
+            skipContentTypeHeader: true,
         });
 
         if (!response.success) {

--- a/packages/transport/src/utils/applyContentTypeHeader.native.ts
+++ b/packages/transport/src/utils/applyContentTypeHeader.native.ts
@@ -1,0 +1,17 @@
+export function applyContentTypeHeader({
+    headers,
+    contentType,
+    // @ts-expect-error : On native we never want to omit the content type header,
+    // because otherwise is the Android OS unable to communicate with the bridge.
+    // In other words the `skipContentTypeHeader` is always ignored.
+    skipContentTypeHeader,
+}: {
+    headers: object;
+    contentType: string;
+    skipContentTypeHeader?: boolean;
+}) {
+    return {
+        ...headers,
+        'Content-Type': contentType,
+    };
+}

--- a/packages/transport/src/utils/applyContentTypeHeader.ts
+++ b/packages/transport/src/utils/applyContentTypeHeader.ts
@@ -1,0 +1,16 @@
+export function applyContentTypeHeader({
+    headers,
+    contentType,
+    skipContentTypeHeader,
+}: {
+    headers: object;
+    contentType: string;
+    skipContentTypeHeader?: boolean;
+}) {
+    if (skipContentTypeHeader) return headers;
+
+    return {
+        ...headers,
+        'Content-Type': contentType,
+    };
+}

--- a/packages/transport/src/utils/bridgeApiCall.ts
+++ b/packages/transport/src/utils/bridgeApiCall.ts
@@ -5,6 +5,7 @@ import { success, error, unknownError } from './result';
 import * as ERRORS from '../errors';
 
 import { PROTOCOL_MALFORMED } from '@trezor/protocol';
+import { applyContentTypeHeader } from './applyContentTypeHeader';
 
 export type HttpRequestOptions = {
     body?: Array<any> | Record<string, unknown> | string;
@@ -52,12 +53,11 @@ export async function bridgeApiCall(options: HttpRequestOptions) {
         timeout: options.timeout,
     };
 
-    if (options.skipContentTypeHeader == null || options.skipContentTypeHeader === false) {
-        fetchOptions.headers = {
-            ...fetchOptions.headers,
-            'Content-Type': contentType(options.body == null ? '' : options.body),
-        };
-    }
+    fetchOptions.headers = applyContentTypeHeader({
+        headers: fetchOptions.headers,
+        contentType: contentType(options.body == null ? '' : options.body),
+        skipContentTypeHeader: options.skipContentTypeHeader,
+    });
 
     // Node applications must spoof origin for bridge CORS
     if (_isNode) {


### PR DESCRIPTION
The `Content-type` header is now applied for native requests.