### PR TITLE
fix(connect): reboot to bootloader

### DIFF
--- a/packages/connect/src/core/index.ts
+++ b/packages/connect/src/core/index.ts
@@ -649,7 +649,12 @@ export const onCall = async (message: CoreMessage) => {
                 await resolveAfter(1000).promise;
                 // call Device.run with empty function to fetch new Features
                 // (acquire > Initialize > nothing > release)
-                await device.run(() => Promise.resolve(), { skipFinalReload: true });
+                try {
+                    await device.run(() => Promise.resolve(), { skipFinalReload: true });
+                } catch (err) {
+                    // ignore. on model T, this block of code is probably not needed at all. but I am keeping it here for
+                    // backwards compatibility
+                }
             }
 
             await device.cleanup();


### PR DESCRIPTION
it looks like on model T reboot to bootloader works in different manner than on model One. 

on model T device physically disconnects which means that 
```
await device.run(()
```
throws error, which is not handled here so the remaining lines below are not executed.  It also means that if you have suite locks set for rebootToBootloader method, which we added recently here https://github.com/trezor/trezor-suite/pull/9584  suite would never remove such lock becaue TrezorConnect.rebootToBootloader remains in hanged state. 

might affect #9608