### PR TITLE
chore(sentry): reduct device session_id because it is not useful

### DIFF
--- a/docs/analytics/sentry.md
+++ b/docs/analytics/sentry.md
@@ -99,7 +99,7 @@ Browser (User Agent), System and HW specifications, Suite version, instance id s
       safety_checks: Strict,
       sd_card_present: False,
       sd_protection: False,
-      session_id: None,
+      session_id: [redacted],
       unfinished_backup: False,
       unlocked: True,
       vendor: trezor.io,

--- a/packages/suite/src/utils/suite/__tests__/logsUtils.test.ts
+++ b/packages/suite/src/utils/suite/__tests__/logsUtils.test.ts
@@ -52,6 +52,7 @@ describe('logsUtils', () => {
                 features: {
                     ...device.features,
                     device_id: REDACTED_REPLACEMENT,
+                    session_id: REDACTED_REPLACEMENT,
                     label: REDACTED_REPLACEMENT,
                 },
             });

--- a/packages/suite/src/utils/suite/logsUtils.ts
+++ b/packages/suite/src/utils/suite/logsUtils.ts
@@ -98,6 +98,7 @@ export const redactDevice = (device: DeepPartial<TrezorDevice> | undefined) => {
             ? {
                   ...device.features,
                   device_id: REDACTED_REPLACEMENT,
+                  session_id: device.features.session_id ? REDACTED_REPLACEMENT : undefined,
                   label: device.features.label ? REDACTED_REPLACEMENT : undefined,
               }
             : undefined,


### PR DESCRIPTION


## Description

It's not sensitive, but at the same time it's not useful so let's reduct it from the sentry reports.


