### PR TITLE
chore(ci): in prerelease branch exists throw error

### DIFF
--- a/ci/scripts/connect-release-init-npm.js
+++ b/ci/scripts/connect-release-init-npm.js
@@ -104,8 +104,7 @@ const initConnectRelease = () => {
     // Check if branch exists and if so, delete it.
     const branchExists = exec('git', ['branch', '--list', branchName]).toString().trim();
     if (branchExists) {
-        console.log(`Deleting branch ${branchName} to create a fresh one.`);
-        exec('git', ['branch', '-D', branchName]);
+        throw new Error(`Branch ${branchName} already exists, delete it and call script again.`);
     }
 
     exec('git', ['checkout', '-b', branchName]);


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
It seams to me that throwing an Error in case of branch existing is better than deleting it automatically. Once you know the branch exists you can manually delete it and call the job again. Otherwise it could be deleting something you do not want to delete.