### PR TITLE
fix(connect): show webusb selection in popup

### DIFF
--- a/packages/connect/src/core/index.ts
+++ b/packages/connect/src/core/index.ts
@@ -202,6 +202,11 @@ const initDevice = async (method: AbstractMethod) => {
         throw ERRORS.TypedError('Transport_Missing');
     }
 
+    // see initTransport.
+    // if transportReconnect: true, initTransport does not wait to be finished. if there are multiple requested transports
+    // in TrezorConnect.init, this method may emit UI.SELECT_DEVICE with wrong parameters (for example it thinks that it does not use weubsb although it should)
+    await _deviceList.transportFirstEventPromise;
+
     const isWebUsb = _deviceList.transportType() === 'WebUsbTransport';
     let device: Device | typeof undefined;
     let showDeviceSelection = isWebUsb;

--- a/packages/connect/src/device/DeviceList.ts
+++ b/packages/connect/src/device/DeviceList.ts
@@ -61,6 +61,8 @@ export class DeviceList extends TypedEmitter<DeviceListEvents> {
 
     penalizedDevices: { [deviceID: string]: number } = {};
 
+    transportFirstEventPromise: Promise<void> | undefined;
+
     constructor() {
         super();
 
@@ -319,7 +321,7 @@ export class DeviceList extends TypedEmitter<DeviceListEvents> {
     }
 
     async waitForTransportFirstEvent() {
-        await new Promise<void>(resolve => {
+        this.transportFirstEventPromise = new Promise<void>(resolve => {
             const handler = () => {
                 this.removeListener(TRANSPORT.START, handler);
                 this.removeListener(TRANSPORT.ERROR, handler);
@@ -328,6 +330,7 @@ export class DeviceList extends TypedEmitter<DeviceListEvents> {
             this.on(TRANSPORT.START, handler);
             this.on(TRANSPORT.ERROR, handler);
         });
+        await this.transportFirstEventPromise;
     }
 
     private async _createAndSaveDevice(descriptor: Descriptor) {


### PR DESCRIPTION
followup for https://github.com/trezor/trezor-suite/pull/8886

I noticed, that if you initiated connect with transports: ['BridgeTransport', 'WebusbTransport'], it did not send proper intstructions to pupup (when bridge was not running) and did not render select device button. 


