### PR TITLE
fix(ci): connect-release check branch name

### DIFF
--- a/ci/scripts/connect-release-init-npm.js
+++ b/ci/scripts/connect-release-init-npm.js
@@ -102,7 +102,7 @@ const initConnectRelease = () => {
     const branchName = `npm-release/connect-${version}`;
 
     // Check if branch exists and if so, delete it.
-    const branchExists = exec('git', ['branch', '--list', branchName]).toString().trim();
+    const branchExists = exec('git', ['branch', '--list', branchName]).stdout;
     if (branchExists) {
         throw new Error(`Branch ${branchName} already exists, delete it and call script again.`);
     }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
There is little mistake in the script for creating branch for npm-release in ci/scripts/connect-release-init-npm.js
`exec` always returns an object that executed as truthy, so it requires using stdout.