### PR TITLE
chore(connect): update coins.json support format

### DIFF
--- a/packages/connect-common/files/coins-eth.json
+++ b/packages/connect-common/files/coins-eth.json
@@ -12,8 +12,9 @@
         "support": {
             "connect": true,
             "suite": true,
-            "trezor1": "1.6.2",
-            "trezor2": "2.0.7"
+            "T1B1": "1.6.2",
+            "T2T1": "2.0.7",
+            "T2B1": "2.6.1"
         },
         "url": "https://ethereum.org"
     },
@@ -31,8 +32,9 @@
         "support": {
             "connect": true,
             "suite": false,
-            "trezor1": "1.11.2",
-            "trezor2": "2.5.2"
+            "T1B1": "1.11.2",
+            "T2T1": "2.5.2",
+            "T2B1": "2.6.1"
         },
         "url": "https://sepolia.otterscan.io"
     },
@@ -49,8 +51,9 @@
         "support": {
             "connect": true,
             "suite": false,
-            "trezor1": "1.11.2",
-            "trezor2": "2.5.2"
+            "T1B1": "1.11.2",
+            "T2T1": "2.5.2",
+            "T2B1": "2.6.1"
         },
         "url": "https://goerli.net/#about"
     },
@@ -67,8 +70,9 @@
         "support": {
             "connect": true,
             "suite": true,
-            "trezor1": "1.6.2",
-            "trezor2": "2.0.7"
+            "T1B1": "1.6.2",
+            "T2T1": "2.0.7",
+            "T2B1": "2.6.1"
         },
         "url": "https://ethereumclassic.org"
     }

--- a/packages/connect-common/files/coins.json
+++ b/packages/connect-common/files/coins.json
@@ -45,10 +45,11 @@
             "signed_message_header": "Bitcoin Signed Message:\n",
             "slip44": 0,
             "support": {
+                "T1B1": "1.5.2",
+                "T2B1": "2.6.1",
+                "T2T1": "2.0.5",
                 "connect": true,
-                "suite": true,
-                "trezor1": "1.5.2",
-                "trezor2": "2.0.5"
+                "suite": true
             },
             "taproot": true,
             "timestamp": false,
@@ -92,10 +93,11 @@
             "signed_message_header": "Bitcoin Signed Message:\n",
             "slip44": 1,
             "support": {
+                "T1B1": "1.8.2",
+                "T2B1": "2.6.1",
+                "T2T1": "2.1.1",
                 "connect": true,
-                "suite": true,
-                "trezor1": "1.8.2",
-                "trezor2": "2.1.1"
+                "suite": true
             },
             "taproot": true,
             "timestamp": false,
@@ -142,10 +144,11 @@
             "signed_message_header": "Bitcoin Signed Message:\n",
             "slip44": 1,
             "support": {
+                "T1B1": "1.5.2",
+                "T2B1": "2.6.1",
+                "T2T1": "2.0.5",
                 "connect": true,
-                "suite": true,
-                "trezor1": "1.5.2",
-                "trezor2": "2.0.5"
+                "suite": true
             },
             "taproot": true,
             "timestamp": false,
@@ -189,10 +192,11 @@
             "signed_message_header": "Actinium Signed Message:\n",
             "slip44": 228,
             "support": {
+                "T1B1": "1.7.2",
+                "T2B1": "2.6.1",
+                "T2T1": "2.0.10",
                 "connect": true,
-                "suite": false,
-                "trezor1": "1.7.2",
-                "trezor2": "2.0.10"
+                "suite": false
             },
             "taproot": false,
             "timestamp": false,
@@ -236,10 +240,11 @@
             "signed_message_header": "DarkCoin Signed Message:\n",
             "slip44": 4242,
             "support": {
+                "T1B1": "1.7.3",
+                "T2B1": "2.6.1",
+                "T2T1": "2.0.11",
                 "connect": true,
-                "suite": false,
-                "trezor1": "1.7.3",
-                "trezor2": "2.0.11"
+                "suite": false
             },
             "taproot": false,
             "timestamp": false,
@@ -292,10 +297,11 @@
             "signed_message_header": "Bitcoin Signed Message:\n",
             "slip44": 145,
             "support": {
+                "T1B1": "1.6.2",
+                "T2B1": "2.6.1",
+                "T2T1": "2.0.7",
                 "connect": true,
-                "suite": true,
-                "trezor1": "1.6.2",
-                "trezor2": "2.0.7"
+                "suite": true
             },
             "taproot": false,
             "timestamp": false,
@@ -339,10 +345,11 @@
             "signed_message_header": "Bitcoin Signed Message:\n",
             "slip44": 1,
             "support": {
+                "T1B1": "1.6.2",
+                "T2B1": "2.6.1",
+                "T2T1": "2.0.7",
                 "connect": true,
-                "suite": false,
-                "trezor1": "1.6.2",
-                "trezor2": "2.0.7"
+                "suite": false
             },
             "taproot": false,
             "timestamp": false,
@@ -395,10 +402,11 @@
             "signed_message_header": "Bitcoin Gold Signed Message:\n",
             "slip44": 156,
             "support": {
+                "T1B1": "1.6.2",
+                "T2B1": false,
+                "T2T1": "2.0.7",
                 "connect": true,
-                "suite": true,
-                "trezor1": "1.6.2",
-                "trezor2": "2.0.7"
+                "suite": true
             },
             "taproot": false,
             "timestamp": false,
@@ -445,10 +453,11 @@
             "signed_message_header": "Bitcoin Gold Signed Message:\n",
             "slip44": 1,
             "support": {
+                "T1B1": "1.7.1",
+                "T2B1": false,
+                "T2T1": "2.0.8",
                 "connect": true,
-                "suite": false,
-                "trezor1": "1.7.1",
-                "trezor2": "2.0.8"
+                "suite": false
             },
             "taproot": false,
             "timestamp": false,
@@ -492,10 +501,11 @@
             "signed_message_header": "BitcoinPrivate Signed Message:\n",
             "slip44": 183,
             "support": {
+                "T1B1": "1.6.2",
+                "T2B1": "2.6.1",
+                "T2T1": "2.0.7",
                 "connect": true,
-                "suite": false,
-                "trezor1": "1.6.2",
-                "trezor2": "2.0.7"
+                "suite": false
             },
             "taproot": false,
             "timestamp": false,
@@ -539,10 +549,11 @@
             "signed_message_header": "BitCore Signed Message:\n",
             "slip44": 160,
             "support": {
+                "T1B1": "1.7.1",
+                "T2B1": "2.6.1",
+                "T2T1": "2.0.8",
                 "connect": true,
-                "suite": false,
-                "trezor1": "1.7.1",
-                "trezor2": "2.0.8"
+                "suite": false
             },
             "taproot": false,
             "timestamp": false,
@@ -595,10 +606,11 @@
             "signed_message_header": "DarkCoin Signed Message:\n",
             "slip44": 5,
             "support": {
+                "T1B1": "1.5.2",
+                "T2B1": false,
+                "T2T1": "2.0.5",
                 "connect": true,
-                "suite": true,
-                "trezor1": "1.5.2",
-                "trezor2": "2.0.5"
+                "suite": true
             },
             "taproot": false,
             "timestamp": false,
@@ -642,10 +654,11 @@
             "signed_message_header": "DarkCoin Signed Message:\n",
             "slip44": 1,
             "support": {
+                "T1B1": "1.6.2",
+                "T2B1": false,
+                "T2T1": "2.0.8",
                 "connect": true,
-                "suite": false,
-                "trezor1": "1.6.2",
-                "trezor2": "2.0.8"
+                "suite": false
             },
             "taproot": false,
             "timestamp": false,
@@ -689,10 +702,11 @@
             "signed_message_header": "Decred Signed Message:\n",
             "slip44": 42,
             "support": {
+                "T1B1": "1.6.2",
+                "T2B1": false,
+                "T2T1": "2.0.8",
                 "connect": true,
-                "suite": false,
-                "trezor1": "1.6.2",
-                "trezor2": "2.0.8"
+                "suite": false
             },
             "taproot": false,
             "timestamp": false,
@@ -736,10 +750,11 @@
             "signed_message_header": "Decred Signed Message:\n",
             "slip44": 1,
             "support": {
+                "T1B1": "1.6.2",
+                "T2B1": false,
+                "T2T1": "2.0.8",
                 "connect": true,
-                "suite": false,
-                "trezor1": "1.6.2",
-                "trezor2": "2.0.8"
+                "suite": false
             },
             "taproot": false,
             "timestamp": false,
@@ -786,10 +801,11 @@
             "signed_message_header": "DigiByte Signed Message:\n",
             "slip44": 20,
             "support": {
+                "T1B1": "1.6.3",
+                "T2B1": false,
+                "T2T1": "2.0.7",
                 "connect": true,
-                "suite": true,
-                "trezor1": "1.6.3",
-                "trezor2": "2.0.7"
+                "suite": true
             },
             "taproot": false,
             "timestamp": false,
@@ -842,10 +858,11 @@
             "signed_message_header": "Dogecoin Signed Message:\n",
             "slip44": 3,
             "support": {
+                "T1B1": "1.5.2",
+                "T2B1": "2.6.1",
+                "T2T1": "2.0.5",
                 "connect": true,
-                "suite": true,
-                "trezor1": "1.5.2",
-                "trezor2": "2.0.5"
+                "suite": true
             },
             "taproot": false,
             "timestamp": false,
@@ -889,10 +906,11 @@
             "signed_message_header": "Feathercoin Signed Message:\n",
             "slip44": 8,
             "support": {
+                "T1B1": "1.7.1",
+                "T2B1": "2.6.1",
+                "T2T1": "2.0.8",
                 "connect": true,
-                "suite": false,
-                "trezor1": "1.7.1",
-                "trezor2": "2.0.8"
+                "suite": false
             },
             "taproot": false,
             "timestamp": false,
@@ -939,10 +957,11 @@
             "signed_message_header": "Zcoin Signed Message:\n",
             "slip44": 136,
             "support": {
+                "T1B1": "1.6.2",
+                "T2B1": "2.6.1",
+                "T2T1": "2.0.7",
                 "connect": true,
-                "suite": false,
-                "trezor1": "1.6.2",
-                "trezor2": "2.0.7"
+                "suite": false
             },
             "taproot": false,
             "timestamp": false,
@@ -989,10 +1008,11 @@
             "signed_message_header": "Zcoin Signed Message:\n",
             "slip44": 1,
             "support": {
+                "T1B1": "1.6.2",
+                "T2B1": "2.6.1",
+                "T2T1": "2.0.7",
                 "connect": true,
-                "suite": false,
-                "trezor1": "1.6.2",
-                "trezor2": "2.0.7"
+                "suite": false
             },
             "taproot": false,
             "timestamp": false,
@@ -1036,10 +1056,11 @@
             "signed_message_header": "Florincoin Signed Message:\n",
             "slip44": 216,
             "support": {
+                "T1B1": "1.7.2",
+                "T2B1": "2.6.1",
+                "T2T1": "2.0.11",
                 "connect": true,
-                "suite": false,
-                "trezor1": "1.7.2",
-                "trezor2": "2.0.11"
+                "suite": false
             },
             "taproot": false,
             "timestamp": false,
@@ -1089,10 +1110,11 @@
             "signed_message_header": "FujiCoin Signed Message:\n",
             "slip44": 75,
             "support": {
+                "T1B1": "1.6.1",
+                "T2B1": "2.6.1",
+                "T2T1": "2.0.5",
                 "connect": true,
-                "suite": false,
-                "trezor1": "1.6.1",
-                "trezor2": "2.0.5"
+                "suite": false
             },
             "taproot": true,
             "timestamp": false,
@@ -1136,10 +1158,11 @@
             "signed_message_header": "Komodo Signed Message:\n",
             "slip44": 141,
             "support": {
+                "T1B1": "1.8.0",
+                "T2B1": "2.6.1",
+                "T2T1": "2.0.11",
                 "connect": true,
-                "suite": false,
-                "trezor1": "1.8.0",
-                "trezor2": "2.0.11"
+                "suite": false
             },
             "taproot": false,
             "timestamp": false,
@@ -1183,10 +1206,11 @@
             "signed_message_header": "Koto Signed Message:\n",
             "slip44": 510,
             "support": {
+                "T1B1": "1.7.1",
+                "T2B1": "2.6.1",
+                "T2T1": "2.0.8",
                 "connect": true,
-                "suite": false,
-                "trezor1": "1.7.1",
-                "trezor2": "2.0.8"
+                "suite": false
             },
             "taproot": false,
             "timestamp": false,
@@ -1239,10 +1263,11 @@
             "signed_message_header": "Litecoin Signed Message:\n",
             "slip44": 2,
             "support": {
+                "T1B1": "1.5.2",
+                "T2B1": "2.6.1",
+                "T2T1": "2.0.5",
                 "connect": true,
-                "suite": true,
-                "trezor1": "1.5.2",
-                "trezor2": "2.0.5"
+                "suite": true
             },
             "taproot": false,
             "timestamp": false,
@@ -1286,10 +1311,11 @@
             "signed_message_header": "Litecoin Signed Message:\n",
             "slip44": 1,
             "support": {
+                "T1B1": "1.6.2",
+                "T2B1": "2.6.1",
+                "T2T1": "2.0.7",
                 "connect": true,
-                "suite": false,
-                "trezor1": "1.6.2",
-                "trezor2": "2.0.7"
+                "suite": false
             },
             "taproot": false,
             "timestamp": false,
@@ -1336,10 +1362,11 @@
             "signed_message_header": "Monacoin Signed Message:\n",
             "slip44": 22,
             "support": {
+                "T1B1": "1.6.0",
+                "T2B1": "2.6.1",
+                "T2T1": "2.0.5",
                 "connect": true,
-                "suite": false,
-                "trezor1": "1.6.0",
-                "trezor2": "2.0.5"
+                "suite": false
             },
             "taproot": false,
             "timestamp": false,
@@ -1386,10 +1413,11 @@
             "signed_message_header": "Namecoin Signed Message:\n",
             "slip44": 7,
             "support": {
+                "T1B1": "1.5.2",
+                "T2B1": false,
+                "T2T1": "2.0.5",
                 "connect": true,
-                "suite": true,
-                "trezor1": "1.5.2",
-                "trezor2": "2.0.5"
+                "suite": true
             },
             "taproot": false,
             "timestamp": false,
@@ -1436,10 +1464,11 @@
             "signed_message_header": "Peercoin Signed Message:\n",
             "slip44": 6,
             "support": {
+                "T1B1": "1.8.4",
+                "T2B1": "2.6.1",
+                "T2T1": "2.1.9",
                 "connect": true,
-                "suite": false,
-                "trezor1": "1.8.4",
-                "trezor2": "2.1.9"
+                "suite": false
             },
             "taproot": false,
             "timestamp": true,
@@ -1486,10 +1515,11 @@
             "signed_message_header": "Peercoin Signed Message:\n",
             "slip44": 1,
             "support": {
+                "T1B1": "1.8.4",
+                "T2B1": "2.6.1",
+                "T2T1": "2.1.9",
                 "connect": true,
-                "suite": false,
-                "trezor1": "1.8.4",
-                "trezor2": "2.1.9"
+                "suite": false
             },
             "taproot": false,
             "timestamp": true,
@@ -1533,10 +1563,11 @@
             "signed_message_header": "Primecoin Signed Message:\n",
             "slip44": 24,
             "support": {
+                "T1B1": "1.8.0",
+                "T2B1": "2.6.1",
+                "T2T1": "2.0.11",
                 "connect": true,
-                "suite": false,
-                "trezor1": "1.8.0",
-                "trezor2": "2.0.11"
+                "suite": false
             },
             "taproot": false,
             "timestamp": false,
@@ -1583,10 +1614,11 @@
             "signed_message_header": "Raven Signed Message:\n",
             "slip44": 175,
             "support": {
+                "T1B1": "1.7.2",
+                "T2B1": "2.6.1",
+                "T2T1": "2.0.10",
                 "connect": true,
-                "suite": false,
-                "trezor1": "1.7.2",
-                "trezor2": "2.0.10"
+                "suite": false
             },
             "taproot": false,
             "timestamp": false,
@@ -1633,10 +1665,11 @@
             "signed_message_header": "Rito Signed Message:\n",
             "slip44": 19169,
             "support": {
+                "T1B1": "1.8.2",
+                "T2B1": "2.6.1",
+                "T2T1": "2.1.1",
                 "connect": true,
-                "suite": false,
-                "trezor1": "1.8.2",
-                "trezor2": "2.1.1"
+                "suite": false
             },
             "taproot": false,
             "timestamp": false,
@@ -1683,10 +1716,11 @@
             "signed_message_header": "DarkCoin Signed Message:\n",
             "slip44": 199,
             "support": {
+                "T1B1": "1.8.0",
+                "T2B1": "2.6.1",
+                "T2T1": "2.0.11",
                 "connect": true,
-                "suite": false,
-                "trezor1": "1.8.0",
-                "trezor2": "2.0.11"
+                "suite": false
             },
             "taproot": false,
             "timestamp": false,
@@ -1736,10 +1770,11 @@
             "signed_message_header": "Syscoin Signed Message:\n",
             "slip44": 57,
             "support": {
+                "T1B1": "1.8.4",
+                "T2B1": "2.6.1",
+                "T2T1": "2.1.8",
                 "connect": true,
-                "suite": false,
-                "trezor1": "1.8.4",
-                "trezor2": "2.1.8"
+                "suite": false
             },
             "taproot": false,
             "timestamp": false,
@@ -1786,10 +1821,11 @@
             "signed_message_header": "Unobtanium Signed Message:\n",
             "slip44": 92,
             "support": {
+                "T1B1": "1.8.4",
+                "T2B1": "2.6.1",
+                "T2T1": "2.1.6",
                 "connect": true,
-                "suite": false,
-                "trezor1": "1.8.4",
-                "trezor2": "2.1.6"
+                "suite": false
             },
             "taproot": false,
             "timestamp": false,
@@ -1833,10 +1869,11 @@
             "signed_message_header": "Name: Dogecoin Dark\n",
             "slip44": 77,
             "support": {
+                "T1B1": "1.9.3",
+                "T2B1": "2.6.1",
+                "T2T1": "2.3.3",
                 "connect": true,
-                "suite": false,
-                "trezor1": "1.9.3",
-                "trezor2": "2.3.3"
+                "suite": false
             },
             "taproot": false,
             "timestamp": true,
@@ -1889,10 +1926,11 @@
             "signed_message_header": "Vertcoin Signed Message:\n",
             "slip44": 28,
             "support": {
+                "T1B1": "1.6.1",
+                "T2B1": false,
+                "T2T1": "2.0.5",
                 "connect": true,
-                "suite": true,
-                "trezor1": "1.6.1",
-                "trezor2": "2.0.5"
+                "suite": true
             },
             "taproot": false,
             "timestamp": false,
@@ -1939,10 +1977,11 @@
             "signed_message_header": "Viacoin Signed Message:\n",
             "slip44": 14,
             "support": {
+                "T1B1": "1.6.2",
+                "T2B1": "2.6.1",
+                "T2T1": "2.0.7",
                 "connect": true,
-                "suite": false,
-                "trezor1": "1.6.2",
-                "trezor2": "2.0.7"
+                "suite": false
             },
             "taproot": false,
             "timestamp": false,
@@ -1986,10 +2025,11 @@
             "signed_message_header": "DarkNet Signed Message:\n",
             "slip44": 428,
             "support": {
+                "T1B1": "1.8.4",
+                "T2B1": "2.6.1",
+                "T2T1": "2.1.7",
                 "connect": true,
-                "suite": false,
-                "trezor1": "1.8.4",
-                "trezor2": "2.1.7"
+                "suite": false
             },
             "taproot": false,
             "timestamp": false,
@@ -2042,10 +2082,11 @@
             "signed_message_header": "Zcash Signed Message:\n",
             "slip44": 133,
             "support": {
+                "T1B1": "1.8.1",
+                "T2B1": "2.6.1",
+                "T2T1": "2.1.1",
                 "connect": true,
-                "suite": true,
-                "trezor1": "1.8.1",
-                "trezor2": "2.1.1"
+                "suite": true
             },
             "taproot": false,
             "timestamp": false,
@@ -2089,10 +2130,11 @@
             "signed_message_header": "Zcash Signed Message:\n",
             "slip44": 1,
             "support": {
+                "T1B1": "1.8.1",
+                "T2B1": "2.6.1",
+                "T2T1": "2.1.1",
                 "connect": true,
-                "suite": false,
-                "trezor1": "1.8.1",
-                "trezor2": "2.1.1"
+                "suite": false
             },
             "taproot": false,
             "timestamp": false,
@@ -2139,10 +2181,11 @@
             "signed_message_header": "BitCoin Rhodium Signed Message:\n",
             "slip44": 10291,
             "support": {
+                "T1B1": "1.8.2",
+                "T2B1": "2.6.1",
+                "T2T1": "2.1.1",
                 "connect": true,
-                "suite": false,
-                "trezor1": "1.8.2",
-                "trezor2": "2.1.1"
+                "suite": false
             },
             "taproot": false,
             "timestamp": false,
@@ -2167,10 +2210,11 @@
             "shortcut": "ADA",
             "slip44": 1815,
             "support": {
+                "T1B1": false,
+                "T2B1": "2.6.1",
+                "T2T1": "2.0.8",
                 "connect": true,
-                "suite": false,
-                "trezor1": false,
-                "trezor2": "2.0.8"
+                "suite": false
             }
         },
         {
@@ -2182,10 +2226,11 @@
             "shortcut": "BNB",
             "slip44": 714,
             "support": {
+                "T1B1": false,
+                "T2B1": "2.6.1",
+                "T2T1": "2.1.5",
                 "connect": true,
-                "suite": false,
-                "trezor1": false,
-                "trezor2": "2.1.5"
+                "suite": false
             }
         },
         {
@@ -2197,10 +2242,11 @@
             "shortcut": "EOS",
             "slip44": 194,
             "support": {
+                "T1B1": false,
+                "T2B1": false,
+                "T2T1": "2.1.1",
                 "connect": true,
-                "suite": false,
-                "trezor1": false,
-                "trezor2": "2.1.1"
+                "suite": false
             }
         },
         {
@@ -2215,10 +2261,11 @@
             "shortcut": "tADA",
             "slip44": 1815,
             "support": {
+                "T1B1": false,
+                "T2B1": "2.6.1",
+                "T2T1": "2.0.8",
                 "connect": true,
-                "suite": false,
-                "trezor1": false,
-                "trezor2": "2.0.8"
+                "suite": false
             }
         },
         {
@@ -2233,10 +2280,11 @@
             "shortcut": "tXRP",
             "slip44": 1,
             "support": {
+                "T1B1": false,
+                "T2B1": "2.6.1",
+                "T2T1": "2.0.8",
                 "connect": true,
-                "suite": true,
-                "trezor1": false,
-                "trezor2": "2.0.8"
+                "suite": true
             }
         },
         {
@@ -2248,10 +2296,11 @@
             "shortcut": "XLM",
             "slip44": 148,
             "support": {
+                "T1B1": "1.7.1",
+                "T2B1": "2.6.1",
+                "T2T1": "2.0.8",
                 "connect": true,
-                "suite": false,
-                "trezor1": "1.7.1",
-                "trezor2": "2.0.8"
+                "suite": false
             }
         },
         {
@@ -2266,10 +2315,11 @@
             "shortcut": "XRP",
             "slip44": 144,
             "support": {
+                "T1B1": false,
+                "T2B1": "2.6.1",
+                "T2T1": "2.0.8",
                 "connect": true,
-                "suite": true,
-                "trezor1": false,
-                "trezor2": "2.0.8"
+                "suite": true
             }
         },
         {
@@ -2281,10 +2331,11 @@
             "shortcut": "XTZ",
             "slip44": 1729,
             "support": {
+                "T1B1": false,
+                "T2B1": "2.6.1",
+                "T2T1": "2.0.8",
                 "connect": true,
-                "suite": false,
-                "trezor1": false,
-                "trezor2": "2.0.8"
+                "suite": false
             }
         }
     ],
@@ -2298,10 +2349,11 @@
             "namespace": "nem",
             "shortcut": "XEM",
             "support": {
+                "T1B1": "1.6.2",
+                "T2B1": false,
+                "T2T1": "2.0.7",
                 "connect": true,
-                "suite": false,
-                "trezor1": "1.6.2",
-                "trezor2": "2.0.7"
+                "suite": false
             },
             "ticker": "XEM"
         },
@@ -2319,10 +2371,11 @@
             "networks": [104],
             "shortcut": "DIM",
             "support": {
+                "T1B1": "1.6.2",
+                "T2B1": "2.6.1",
+                "T2T1": "2.0.7",
                 "connect": true,
-                "suite": false,
-                "trezor1": "1.6.2",
-                "trezor2": "2.0.7"
+                "suite": false
             },
             "ticker": "DIM"
         },
@@ -2336,10 +2389,11 @@
             "networks": [104],
             "shortcut": "DIMTOK",
             "support": {
+                "T1B1": "1.6.2",
+                "T2B1": "2.6.1",
+                "T2T1": "2.0.7",
                 "connect": true,
-                "suite": false,
-                "trezor1": "1.6.2",
-                "trezor2": "2.0.7"
+                "suite": false
             },
             "ticker": "DIMTOK"
         },
@@ -2353,10 +2407,11 @@
             "networks": [104],
             "shortcut": "BREEZE",
             "support": {
+                "T1B1": "1.6.2",
+                "T2B1": "2.6.1",
+                "T2T1": "2.0.7",
                 "connect": true,
-                "suite": false,
-                "trezor1": "1.6.2",
-                "trezor2": "2.0.7"
+                "suite": false
             },
             "ticker": "BREEZE"
         },
@@ -2370,10 +2425,11 @@
             "networks": [104],
             "shortcut": "PAC:HRT",
             "support": {
+                "T1B1": "1.6.2",
+                "T2B1": "2.6.1",
+                "T2T1": "2.0.7",
                 "connect": true,
-                "suite": false,
-                "trezor1": "1.6.2",
-                "trezor2": "2.0.7"
+                "suite": false
             },
             "ticker": "PAC:HRT"
         },
@@ -2391,10 +2447,11 @@
             "networks": [104],
             "shortcut": "PAC:CHS",
             "support": {
+                "T1B1": "1.6.2",
+                "T2B1": "2.6.1",
+                "T2T1": "2.0.7",
                 "connect": true,
-                "suite": false,
-                "trezor1": "1.6.2",
-                "trezor2": "2.0.7"
+                "suite": false
             },
             "ticker": "PAC:CHS"
         }

--- a/packages/connect/src/api/authenticateDevice.ts
+++ b/packages/connect/src/api/authenticateDevice.ts
@@ -1,6 +1,6 @@
 import { AbstractMethod } from '../core/AbstractMethod';
 import { UI } from '../events';
-import { validateParams } from './common/paramsValidator';
+import { validateParams, getFirmwareRange } from './common/paramsValidator';
 import { deviceAuthenticityConfig } from '../data/deviceAuthenticityConfig';
 import { AuthenticateDeviceParams } from '../types/api/authenticateDevice';
 import { getRandomChallenge, verifyAuthenticityProof } from './firmware/verifyAuthenticityProof';
@@ -14,10 +14,9 @@ export default class AuthenticateDevice extends AbstractMethod<
         this.allowDeviceMode = [UI.INITIALIZE, UI.SEEDLESS];
         this.requiredPermissions = ['management'];
         this.useDeviceState = false;
+        this.firmwareRange = getFirmwareRange(this.name, null, this.firmwareRange);
 
         const { payload } = this;
-
-        // TODO validate firmware/model version
 
         validateParams(payload, [
             { name: 'config', type: 'object' },

--- a/packages/connect/src/api/common/__fixtures__/paramsValidator.ts
+++ b/packages/connect/src/api/common/__fixtures__/paramsValidator.ts
@@ -463,4 +463,13 @@ export const getFirmwareRange = [
             T2B1: { min: '2.6.1', max: '0' },
         },
     },
+    {
+        description: 'method available only for T2B1, defined by config',
+        params: ['authenticateDevice', undefined, DEFAULT_RANGE],
+        result: {
+            T1B1: { min: '0', max: '0' },
+            T2T1: { min: '0', max: '0' },
+            T2B1: { min: '2.6.1', max: '0' },
+        },
+    },
 ];

--- a/packages/connect/src/api/common/__fixtures__/paramsValidator.ts
+++ b/packages/connect/src/api/common/__fixtures__/paramsValidator.ts
@@ -169,12 +169,13 @@ export const validateParams = [
 ];
 
 const DEFAULT_RANGE = {
-    1: { min: '1.0.0', max: '0' },
-    2: { min: '2.0.0', max: '0' },
+    T1B1: { min: '1.0.0', max: '0' },
+    T2T1: { min: '2.0.0', max: '0' },
+    T2B1: { min: '2.6.1', max: '0' },
 };
 
 const DEFAULT_COIN_INFO = {
-    support: { trezor1: '1.6.2', trezor2: '2.1.0' },
+    support: { T1B1: '1.6.2', T2T1: '2.1.0', T2B1: '2.6.1' },
     shortcut: 'btc',
     type: 'bitcoin',
 };
@@ -194,33 +195,49 @@ export const getFirmwareRange = [
         description: 'range from coinInfo',
         config: EMPTY_CONFIG,
         params: ['signTransaction', DEFAULT_COIN_INFO, DEFAULT_RANGE],
-        result: { 1: { min: '1.6.2', max: '0' }, 2: { min: '2.1.0', max: '0' } },
+        result: {
+            T1B1: { min: '1.6.2', max: '0' },
+            T2T1: { min: '2.1.0', max: '0' },
+            T2B1: { min: '2.6.1', max: '0' },
+        },
     },
     {
         description: 'coinInfo without support',
         config: EMPTY_CONFIG,
         params: ['signTransaction', { shortcut: 'btc', type: 'bitcoin' }, DEFAULT_RANGE],
-        result: { 1: { min: '0', max: '0' }, 2: { min: '0', max: '0' } },
+        result: {
+            T1B1: { min: '0', max: '0' },
+            T2T1: { min: '0', max: '0' },
+            T2B1: { min: '2.6.1', max: '0' },
+        },
     },
     {
         description: 'coinInfo without T1B1 support',
         config: EMPTY_CONFIG,
         params: [
             'signTransaction',
-            { support: { trezor1: null, trezor2: '2.1.0' }, shortcut: 'btc', type: 'bitcoin' },
+            { support: { T1B1: null, T2T1: '2.1.0' }, shortcut: 'btc', type: 'bitcoin' },
             DEFAULT_RANGE,
         ],
-        result: { 1: { min: '0', max: '0' }, 2: { min: '2.1.0', max: '0' } },
+        result: {
+            T1B1: { min: '0', max: '0' },
+            T2T1: { min: '2.1.0', max: '0' },
+            T2B1: { min: '2.6.1', max: '0' },
+        },
     },
     {
         description: 'coinInfo without T2 support',
         config: EMPTY_CONFIG,
         params: [
             'signTransaction',
-            { support: { trezor1: '1.6.2', trezor2: null }, shortcut: 'btc', type: 'bitcoin' },
+            { support: { T1B1: '1.6.2', T2B1: null }, shortcut: 'btc', type: 'bitcoin' },
             DEFAULT_RANGE,
         ],
-        result: { 1: { min: '1.6.2', max: '0' }, 2: { min: '0', max: '0' } },
+        result: {
+            T1B1: { min: '1.6.2', max: '0' },
+            T2T1: { min: '0', max: '0' },
+            T2B1: { min: '2.6.1', max: '0' },
+        },
     },
     {
         description: 'coinInfo support is lower than default',
@@ -228,128 +245,189 @@ export const getFirmwareRange = [
         params: [
             'signTransaction',
             DEFAULT_COIN_INFO,
-            { 1: { min: '1.10.0', max: '0' }, 2: { min: '2.4.0', max: '0' } },
+            { T1B1: { min: '1.10.0', max: '0' }, T2T1: { min: '2.4.0', max: '0' } },
         ],
-        result: { 1: { min: '1.10.0', max: '0' }, 2: { min: '2.4.0', max: '0' } },
+        result: {
+            T1B1: { min: '1.10.0', max: '0' },
+            T2T1: { min: '2.4.0', max: '0' },
+        },
     },
     {
         description: 'range from config.json (by coinType and coin as string)',
         config: {
             supportedFirmware: [
                 // this one is ignored, different excludedMethod
-                { coinType: 'bitcoin', methods: ['showAddress'], min: ['1.12.0', '2.6.0'] },
+                {
+                    coinType: 'bitcoin',
+                    methods: ['showAddress'],
+                    min: { T1B1: '1.12.0', T2T1: '2.6.0' },
+                },
                 // should merge both of these ranges together, since they both match
-                { coinType: 'bitcoin', min: ['1.10.0', '2.5.0'] },
-                { coin: 'btc', min: ['1.11.0', '2.4.0'] },
+                { coinType: 'bitcoin', min: { T1B1: '1.10.0', T2T1: '2.5.0' } },
+                { coin: 'btc', min: { T1B1: '1.11.0', T2T1: '2.4.0' } },
             ],
         },
         params: ['signTransaction', DEFAULT_COIN_INFO, DEFAULT_RANGE],
-        result: { 1: { min: '1.11.0', max: '0' }, 2: { min: '2.5.0', max: '0' } },
+        result: {
+            T1B1: { min: '1.11.0', max: '0' },
+            T2T1: { min: '2.5.0', max: '0' },
+            T2B1: { min: '2.6.1', max: '0' },
+        },
     },
     {
         description: 'range from config.json (by coin as string)',
         config: {
             supportedFirmware: [
                 // this one is ignored, different excludedMethod
-                { coin: 'btc', methods: ['showAddress'], min: ['1.11.0', '2.5.0'] },
-                { coin: 'btc', min: ['1.10.0', '2.4.0'] },
+                { coin: 'btc', methods: ['showAddress'], min: { T1B1: '1.11.0', T2T1: '2.5.0' } },
+                { coin: 'btc', min: { T1B1: '1.10.0', T2T1: '2.4.0' } },
             ],
         },
         params: ['signTransaction', DEFAULT_COIN_INFO, DEFAULT_RANGE],
-        result: { 1: { min: '1.10.0', max: '0' }, 2: { min: '2.4.0', max: '0' } },
+        result: {
+            T1B1: { min: '1.10.0', max: '0' },
+            T2T1: { min: '2.4.0', max: '0' },
+            T2B1: { min: '2.6.1', max: '0' },
+        },
     },
     {
         description: 'range from config.json (by coin as array)',
         config: {
             supportedFirmware: [
                 // this one is ignored, different excludedMethod
-                { coin: ['btc'], methods: ['showAddress'], min: ['1.11.0', '2.5.0'] },
-                { coin: ['btc'], min: ['1.10.0', '2.4.0'] },
+                { coin: ['btc'], methods: ['showAddress'], min: { T1B1: '1.11.0', T2T1: '2.5.0' } },
+                { coin: ['btc'], min: { T1B1: '1.10.0', T2T1: '2.4.0' } },
             ],
         },
         params: ['signTransaction', DEFAULT_COIN_INFO, DEFAULT_RANGE],
-        result: { 1: { min: '1.10.0', max: '0' }, 2: { min: '2.4.0', max: '0' } },
+        result: {
+            T1B1: { min: '1.10.0', max: '0' },
+            T2T1: { min: '2.4.0', max: '0' },
+            T2B1: { min: '2.6.1', max: '0' },
+        },
     },
     {
         description: 'range from config.json (by methods)',
         config: {
             supportedFirmware: [
                 // this one is ignored, no data
-                { min: ['1.11.0', '2.5.0'] },
+                { min: { T1B1: '1.11.0', T2T1: '2.5.0' } },
                 // this one is ignored, different excludedMethod
-                { coin: ['btc'], methods: ['showAddress'], min: ['1.11.0', '2.5.0'] },
+                { coin: ['btc'], methods: ['showAddress'], min: { T1B1: '1.11.0', T2T1: '2.5.0' } },
                 // this one is ignored because of coin (not btc)
-                { coin: ['ltc'], methods: ['signTransaction'], min: ['1.11.0', '2.5.0'] },
+                {
+                    coin: ['ltc'],
+                    methods: ['signTransaction'],
+                    min: { T1B1: '1.11.0', T2T1: '2.5.0' },
+                },
                 // this one is ignored, different excludedMethod
-                { coinType: 'bitcoin', methods: ['showAddress'], min: ['1.11.0', '2.5.0'] },
-                { methods: ['signTransaction'], min: ['1.10.0', '2.4.0'] },
+                {
+                    coinType: 'bitcoin',
+                    methods: ['showAddress'],
+                    min: { T1B1: '1.11.0', T2T1: '2.5.0' },
+                },
+                { methods: ['signTransaction'], min: { T1B1: '1.10.0', T2T1: '2.4.0' } },
             ],
         },
         params: ['signTransaction', DEFAULT_COIN_INFO, DEFAULT_RANGE],
-        result: { 1: { min: '1.10.0', max: '0' }, 2: { min: '2.4.0', max: '0' } },
+        result: {
+            T1B1: { min: '1.10.0', max: '0' },
+            T2T1: { min: '2.4.0', max: '0' },
+            T2B1: { min: '2.6.1', max: '0' },
+        },
     },
     {
         description: 'range from config.json (by capabilities)',
         config: {
             supportedFirmware: [
                 // this one is ignored, no data
-                { min: ['1.11.0', '2.5.0'] },
+                { min: { T1B1: '1.11.0', T2T1: '2.5.0' } },
                 // this one is ignored, different excludedMethod
-                { coin: ['btc'], methods: ['showAddress'], min: ['1.11.0', '2.5.0'] },
+                { coin: ['btc'], methods: ['showAddress'], min: { T1B1: '1.11.0', T2T1: '2.5.0' } },
                 // this one is ignored because of coin (not btc)
-                { coin: ['ltc'], methods: ['signTransaction'], min: ['1.11.0', '2.5.0'] },
+                {
+                    coin: ['ltc'],
+                    methods: ['signTransaction'],
+                    min: { T1B1: '1.11.0', T2T1: '2.5.0' },
+                },
                 // this one is ignored, different excludedMethod
-                { coinType: 'bitcoin', methods: ['showAddress'], min: ['1.11.0', '2.5.0'] },
-                { capabilities: ['decreaseOutput'], min: ['1.10.0', '2.4.0'] },
+                {
+                    coinType: 'bitcoin',
+                    methods: ['showAddress'],
+                    min: { T1B1: '1.11.0', T2T1: '2.5.0' },
+                },
+                { capabilities: ['decreaseOutput'], min: { T1B1: '1.10.0', T2T1: '2.4.0' } },
             ],
         },
         params: ['decreaseOutput', DEFAULT_COIN_INFO, DEFAULT_RANGE],
-        result: { 1: { min: '1.10.0', max: '0' }, 2: { min: '2.4.0', max: '0' } },
+        result: {
+            T1B1: { min: '1.10.0', max: '0' },
+            T2T1: { min: '2.4.0', max: '0' },
+            T2B1: { min: '2.6.1', max: '0' },
+        },
     },
     {
         description: 'range from config.json is lower than coinInfo',
         config: {
-            supportedFirmware: [{ methods: ['signTransaction'], min: ['1.6.2', '2.1.0'] }],
+            supportedFirmware: [
+                { methods: ['signTransaction'], min: { T1B1: '1.6.2', T2T1: '2.1.0' } },
+            ],
         },
         params: [
             'signTransaction',
-            { support: { trezor1: '1.10.0', trezor2: '2.4.0' }, shortcut: 'btc', type: 'bitcoin' },
+            { support: { T1B1: '1.10.0', T2T1: '2.4.0' }, shortcut: 'btc', type: 'bitcoin' },
             DEFAULT_RANGE,
         ],
-        result: { 1: { min: '1.10.0', max: '0' }, 2: { min: '2.4.0', max: '0' } },
+        result: {
+            T1B1: { min: '1.10.0', max: '0' },
+            T2T1: { min: '2.4.0', max: '0' },
+            T2B1: { min: '2.6.1', max: '0' },
+        },
     },
     {
         description: 'range from config.json using max',
         config: {
-            supportedFirmware: [{ methods: ['signTransaction'], max: ['1.10.0', '2.4.0'] }],
+            supportedFirmware: [
+                { methods: ['signTransaction'], max: { T1B1: '1.10.0', T2T1: '2.4.0' } },
+            ],
         },
         params: ['signTransaction', DEFAULT_COIN_INFO, DEFAULT_RANGE],
-        result: { 1: { min: '1.6.2', max: '1.10.0' }, 2: { min: '2.1.0', max: '2.4.0' } },
+        result: {
+            T1B1: { min: '1.6.2', max: '1.10.0' },
+            T2T1: { min: '2.1.0', max: '2.4.0' },
+            T2B1: { min: '2.6.1', max: '0' },
+        },
     },
     {
         description: 'range from config.json using max (values lower than default)',
         config: {
-            supportedFirmware: [{ methods: ['signTransaction'], max: ['1.0.1', '2.0.1'] }],
+            supportedFirmware: [
+                { methods: ['signTransaction'], max: { T1B1: '1.0.1', T2T1: '2.0.1' } },
+            ],
         },
         params: [
             'signTransaction',
             DEFAULT_COIN_INFO,
             {
-                1: { min: '1.0.0', max: '1.10.0' },
-                2: { min: '1.0.0', max: '2.10.0' },
+                T1B1: { min: '1.0.0', max: '1.10.0' },
+                T2T1: { min: '1.0.0', max: '2.10.0' },
             },
         ],
-        result: { 1: { min: '1.6.2', max: '1.10.0' }, 2: { min: '2.1.0', max: '2.10.0' } },
+        result: { T1B1: { min: '1.6.2', max: '1.10.0' }, T2T1: { min: '2.1.0', max: '2.10.0' } },
     },
     // real config.json data
     {
         description: 'xrp + getAccountInfo: coinInfo range IS replaced by config.json range',
         params: [
             'getAccountInfo',
-            { support: { trezor1: '1.0.1', trezor2: '2.0.1' }, shortcut: 'xrp', type: 'ripple' },
+            { support: { T1B1: '1.0.1', T2T1: '2.0.1' }, shortcut: 'xrp', type: 'ripple' },
             DEFAULT_RANGE,
         ],
-        result: { 1: { min: '0', max: '0' }, 2: { min: '2.1.0', max: '0' } },
+        result: {
+            T1B1: { min: '0', max: '0' },
+            T2T1: { min: '2.1.0', max: '0' },
+            T2B1: { min: '2.6.1', max: '0' },
+        },
     },
     {
         description: 'btc + getAccountInfo: coinInfo range IS NOT replaced by config.json range',
@@ -360,9 +438,13 @@ export const getFirmwareRange = [
         description: 'eip1559: coinInfo range is replaced by config.json range',
         params: [
             'eip1559',
-            { support: { trezor1: '1.6.2', trezor2: '2.1.0' }, shortcut: 'eth', type: 'ethereum' },
+            { support: { T1B1: '1.6.2', T2T1: '2.1.0' }, shortcut: 'eth', type: 'ethereum' },
             DEFAULT_RANGE,
         ],
-        result: { 1: { min: '1.10.4', max: '0' }, 2: { min: '2.4.2', max: '0' } },
+        result: {
+            T1B1: { min: '1.10.4', max: '0' },
+            T2T1: { min: '2.4.2', max: '0' },
+            T2B1: { min: '2.6.1', max: '0' },
+        },
     },
 ];

--- a/packages/connect/src/api/common/__fixtures__/paramsValidator.ts
+++ b/packages/connect/src/api/common/__fixtures__/paramsValidator.ts
@@ -208,7 +208,7 @@ export const getFirmwareRange = [
         result: {
             T1B1: { min: '0', max: '0' },
             T2T1: { min: '0', max: '0' },
-            T2B1: { min: '2.6.1', max: '0' },
+            T2B1: { min: '0', max: '0' },
         },
     },
     {
@@ -216,7 +216,11 @@ export const getFirmwareRange = [
         config: EMPTY_CONFIG,
         params: [
             'signTransaction',
-            { support: { T1B1: null, T2T1: '2.1.0' }, shortcut: 'btc', type: 'bitcoin' },
+            {
+                support: { T1B1: null, T2T1: '2.1.0', T2B1: '2.6.1' },
+                shortcut: 'btc',
+                type: 'bitcoin',
+            },
             DEFAULT_RANGE,
         ],
         result: {
@@ -230,13 +234,13 @@ export const getFirmwareRange = [
         config: EMPTY_CONFIG,
         params: [
             'signTransaction',
-            { support: { T1B1: '1.6.2', T2B1: null }, shortcut: 'btc', type: 'bitcoin' },
+            { support: { T1B1: '1.6.2' }, shortcut: 'btc', type: 'bitcoin' },
             DEFAULT_RANGE,
         ],
         result: {
             T1B1: { min: '1.6.2', max: '0' },
             T2T1: { min: '0', max: '0' },
-            T2B1: { min: '2.6.1', max: '0' },
+            T2B1: { min: '0', max: '0' },
         },
     },
     {
@@ -375,7 +379,11 @@ export const getFirmwareRange = [
         },
         params: [
             'signTransaction',
-            { support: { T1B1: '1.10.0', T2T1: '2.4.0' }, shortcut: 'btc', type: 'bitcoin' },
+            {
+                support: { T1B1: '1.10.0', T2T1: '2.4.0', T2B1: '2.6.1' },
+                shortcut: 'btc',
+                type: 'bitcoin',
+            },
             DEFAULT_RANGE,
         ],
         result: {
@@ -420,7 +428,11 @@ export const getFirmwareRange = [
         description: 'xrp + getAccountInfo: coinInfo range IS replaced by config.json range',
         params: [
             'getAccountInfo',
-            { support: { T1B1: '1.0.1', T2T1: '2.0.1' }, shortcut: 'xrp', type: 'ripple' },
+            {
+                support: { T1B1: '1.0.1', T2T1: '2.0.1', T2B1: '2.6.1' },
+                shortcut: 'xrp',
+                type: 'ripple',
+            },
             DEFAULT_RANGE,
         ],
         result: {
@@ -438,7 +450,11 @@ export const getFirmwareRange = [
         description: 'eip1559: coinInfo range is replaced by config.json range',
         params: [
             'eip1559',
-            { support: { T1B1: '1.6.2', T2T1: '2.1.0' }, shortcut: 'eth', type: 'ethereum' },
+            {
+                support: { T1B1: '1.6.2', T2T1: '2.1.0', T2B1: '2.6.1' },
+                shortcut: 'eth',
+                type: 'ethereum',
+            },
             DEFAULT_RANGE,
         ],
         result: {

--- a/packages/connect/src/api/common/paramsValidator.ts
+++ b/packages/connect/src/api/common/paramsValidator.ts
@@ -4,7 +4,7 @@ import { versionUtils } from '@trezor/utils';
 import { ERRORS } from '../../constants';
 import { fromHardened } from '../../utils/pathUtils';
 import { config } from '../../data/config';
-import type { CoinInfo, FirmwareRange } from '../../types';
+import type { CoinInfo, FirmwareRange, DeviceModelInternal } from '../../types';
 
 type ParamType = 'string' | 'number' | 'array' | 'array-buffer' | 'boolean' | 'uint' | 'object';
 
@@ -102,32 +102,26 @@ export const getFirmwareRange = (
     coinInfo: CoinInfo | null | undefined,
     currentRange: FirmwareRange,
 ) => {
-    const current: FirmwareRange = JSON.parse(JSON.stringify(currentRange));
+    const range = JSON.parse(JSON.stringify(currentRange)) as FirmwareRange;
+    const models = Object.keys(range) as DeviceModelInternal[];
     // set minimum required firmware from coins.json (coinInfo)
     if (coinInfo) {
-        if (!coinInfo.support || typeof coinInfo.support.T1B1 !== 'string') {
-            current.T1B1.min = '0';
-        } else if (
-            current.T1B1.min !== '0' &&
-            versionUtils.isNewer(coinInfo.support.T1B1, current.T1B1.min)
-        ) {
-            current.T1B1.min = coinInfo.support.T1B1;
-        }
-
-        if (!coinInfo.support || typeof coinInfo.support.T2T1 !== 'string') {
-            current.T2T1.min = '0';
-        } else if (
-            current.T2T1.min !== '0' &&
-            versionUtils.isNewer(coinInfo.support.T2T1, current.T2T1.min)
-        ) {
-            current.T2T1.min = coinInfo.support.T2T1;
-        }
+        models.forEach(model => {
+            if (!coinInfo.support || typeof coinInfo.support[model] !== 'string') {
+                range[model].min = '0';
+            } else if (
+                range[model].min !== '0' &&
+                versionUtils.isNewer(coinInfo.support[model], range[model].min)
+            ) {
+                range[model].min = coinInfo.support[model];
+            }
+        });
     }
 
-    const coinType = coinInfo ? coinInfo.type : null;
-    const shortcut = coinInfo ? coinInfo.shortcut.toLowerCase() : null;
+    const coinType = coinInfo?.type;
+    const shortcut = coinInfo?.shortcut.toLowerCase();
     // find firmware range in config.json
-    const ranges = config.supportedFirmware
+    const configRules = config.supportedFirmware
         .filter(rule => {
             // check if rule applies to requested method
             if (rule.methods) {
@@ -141,64 +135,58 @@ export const getFirmwareRange = (
             // it may be a global rule for coin or coinType
             return true;
         })
-        .filter(c => {
+        .filter(rule => {
             // REF_TODO: there is no coinType in config. possibly obsolete code?
             // probably still useful, we just need to define type for config and not infer it.
             // @ts-expect-error
-            if (c.coinType) {
+            if (rule.coinType) {
                 // rule for coin type
                 // @ts-expect-error
-                return c.coinType === coinType;
+                return rule.coinType === coinType;
             }
-            if (c.coin) {
+            if (rule.coin) {
                 // rule for coin shortcut
                 // @ts-expect-error
-                return (typeof c.coin === 'string' ? [c.coin] : c.coin).includes(shortcut!);
+                return (typeof rule.coin === 'string' ? [rule.coin] : rule.coin).includes(shortcut);
             }
             // rule for method
-            return c.methods || c.capabilities;
+            return rule.methods || rule.capabilities;
         });
 
-    ranges.forEach(range => {
-        const { min, max } = range;
+    configRules.forEach(rule => {
         // override defaults
         // NOTE:
         // 0 may be confusing. means: no-support for "min" and unlimited support for "max"
-        if (min) {
-            const { T1B1, T2T1 } = min;
-            if (
-                T1B1 === '0' ||
-                current.T1B1.min === '0' ||
-                !versionUtils.isNewerOrEqual(current.T1B1.min, T1B1)
-            ) {
-                current.T1B1.min = T1B1;
-            }
-            if (
-                T2T1 === '0' ||
-                current.T2T1.min === '0' ||
-                !versionUtils.isNewerOrEqual(current.T2T1.min, T2T1)
-            ) {
-                current.T2T1.min = T2T1;
-            }
+        if (rule.min) {
+            models.forEach(model => {
+                const modelMin = rule.min[model];
+                if (modelMin) {
+                    if (
+                        modelMin === '0' ||
+                        range[model].min === '0' ||
+                        !versionUtils.isNewerOrEqual(range[model].min, modelMin)
+                    ) {
+                        range[model].min = modelMin;
+                    }
+                }
+            });
         }
-        if (max) {
-            const { T1B1, T2T1 } = max;
-            if (
-                T1B1 === '0' ||
-                current.T1B1.max === '0' ||
-                !versionUtils.isNewerOrEqual(current.T1B1.max, T1B1)
-            ) {
-                current.T1B1.max = T1B1;
-            }
-            if (
-                T2T1 === '0' ||
-                current.T2T1.max === '0' ||
-                !versionUtils.isNewerOrEqual(current.T2T1.max, T2T1)
-            ) {
-                current.T2T1.max = T2T1;
-            }
+        if (rule.max) {
+            models.forEach(model => {
+                // @ts-expect-error same issue as in coinType above, config needs to be typed not inferred.
+                const modelMax = rule.max[model];
+                if (modelMax) {
+                    if (
+                        modelMax === '0' ||
+                        range[model].max === '0' ||
+                        !versionUtils.isNewerOrEqual(range[model].max, modelMax)
+                    ) {
+                        range[model].max = modelMax;
+                    }
+                }
+            });
         }
     });
 
-    return current;
+    return range;
 };

--- a/packages/connect/src/api/common/paramsValidator.ts
+++ b/packages/connect/src/api/common/paramsValidator.ts
@@ -105,30 +105,29 @@ export const getFirmwareRange = (
     const current: FirmwareRange = JSON.parse(JSON.stringify(currentRange));
     // set minimum required firmware from coins.json (coinInfo)
     if (coinInfo) {
-        if (!coinInfo.support || typeof coinInfo.support.trezor1 !== 'string') {
-            current['1'].min = '0';
+        if (!coinInfo.support || typeof coinInfo.support.T1B1 !== 'string') {
+            current.T1B1.min = '0';
         } else if (
-            current['1'].min !== '0' &&
-            versionUtils.isNewer(coinInfo.support.trezor1, current['1'].min)
+            current.T1B1.min !== '0' &&
+            versionUtils.isNewer(coinInfo.support.T1B1, current.T1B1.min)
         ) {
-            current['1'].min = coinInfo.support.trezor1;
+            current.T1B1.min = coinInfo.support.T1B1;
         }
 
-        if (!coinInfo.support || typeof coinInfo.support.trezor2 !== 'string') {
-            current['2'].min = '0';
+        if (!coinInfo.support || typeof coinInfo.support.T2T1 !== 'string') {
+            current.T2T1.min = '0';
         } else if (
-            current['2'].min !== '0' &&
-            versionUtils.isNewer(coinInfo.support.trezor2, current['2'].min)
+            current.T2T1.min !== '0' &&
+            versionUtils.isNewer(coinInfo.support.T2T1, current.T2T1.min)
         ) {
-            current['2'].min = coinInfo.support.trezor2;
+            current.T2T1.min = coinInfo.support.T2T1;
         }
     }
 
     const coinType = coinInfo ? coinInfo.type : null;
     const shortcut = coinInfo ? coinInfo.shortcut.toLowerCase() : null;
     // find firmware range in config.json
-    const { supportedFirmware } = config;
-    const ranges = supportedFirmware
+    const ranges = config.supportedFirmware
         .filter(rule => {
             // check if rule applies to requested method
             if (rule.methods) {
@@ -166,37 +165,37 @@ export const getFirmwareRange = (
         // NOTE:
         // 0 may be confusing. means: no-support for "min" and unlimited support for "max"
         if (min) {
-            const [t1, t2] = min;
+            const { T1B1, T2T1 } = min;
             if (
-                t1 === '0' ||
-                current['1'].min === '0' ||
-                !versionUtils.isNewerOrEqual(current['1'].min, t1)
+                T1B1 === '0' ||
+                current.T1B1.min === '0' ||
+                !versionUtils.isNewerOrEqual(current.T1B1.min, T1B1)
             ) {
-                current['1'].min = t1;
+                current.T1B1.min = T1B1;
             }
             if (
-                t2 === '0' ||
-                current['2'].min === '0' ||
-                !versionUtils.isNewerOrEqual(current['2'].min, t2)
+                T2T1 === '0' ||
+                current.T2T1.min === '0' ||
+                !versionUtils.isNewerOrEqual(current.T2T1.min, T2T1)
             ) {
-                current['2'].min = t2;
+                current.T2T1.min = T2T1;
             }
         }
         if (max) {
-            const [t1, t2] = max as [string, string];
+            const { T1B1, T2T1 } = max;
             if (
-                t1 === '0' ||
-                current['1'].max === '0' ||
-                !versionUtils.isNewerOrEqual(current['1'].max, t1)
+                T1B1 === '0' ||
+                current.T1B1.max === '0' ||
+                !versionUtils.isNewerOrEqual(current.T1B1.max, T1B1)
             ) {
-                current['1'].max = t1;
+                current.T1B1.max = T1B1;
             }
             if (
-                t2 === '0' ||
-                current['2'].max === '0' ||
-                !versionUtils.isNewerOrEqual(current['2'].max, t2)
+                T2T1 === '0' ||
+                current.T2T1.max === '0' ||
+                !versionUtils.isNewerOrEqual(current.T2T1.max, T2T1)
             ) {
-                current['2'].max = t2;
+                current.T2T1.max = T2T1;
             }
         }
     });

--- a/packages/connect/src/api/ethereum/ethereumDefinitions.ts
+++ b/packages/connect/src/api/ethereum/ethereumDefinitions.ts
@@ -160,8 +160,9 @@ export const ethereumNetworkInfoFromDefinition = (
     shortcut: definition.symbol,
     support: {
         connect: true,
-        trezor1: '1.6.2',
-        trezor2: '2.0.7',
+        T1B1: '1.6.2',
+        T2T1: '2.0.7',
+        T2B1: '2.6.1',
     },
     blockchainLink: undefined,
 });

--- a/packages/connect/src/api/getAccountInfo.ts
+++ b/packages/connect/src/api/getAccountInfo.ts
@@ -1,6 +1,6 @@
 // origin: https://github.com/trezor/connect/blob/develop/src/js/core/methods/GetAccountInfo.js
 
-import { AbstractMethod, MethodReturnType } from '../core/AbstractMethod';
+import { AbstractMethod, MethodReturnType, DEFAULT_FIRMWARE_RANGE } from '../core/AbstractMethod';
 import { Discovery } from './common/Discovery';
 import { validateParams, getFirmwareRange } from './common/paramsValidator';
 import { validatePath, getSerializedPath } from '../utils/pathUtils';
@@ -192,15 +192,15 @@ export default class GetAccountInfo extends AbstractMethod<'getAccountInfo', Req
             return super.checkFirmwareRange(isUsingPopup);
         }
         // for trusted mode check each batch and return error with invalid bundle indexes
-        const defaultRange = {
-            1: { min: '1.0.0', max: '0' },
-            2: { min: '2.0.0', max: '0' },
-        };
         // find invalid ranges
         const invalid = [];
         for (let i = 0; i < this.params.length; i++) {
             // set FW range for current batch
-            this.firmwareRange = getFirmwareRange(this.name, this.params[i].coinInfo, defaultRange);
+            this.firmwareRange = getFirmwareRange(
+                this.name,
+                this.params[i].coinInfo,
+                DEFAULT_FIRMWARE_RANGE,
+            );
             const exception = await super.checkFirmwareRange(false);
             if (exception) {
                 invalid.push({

--- a/packages/connect/src/api/getFirmwareHash.ts
+++ b/packages/connect/src/api/getFirmwareHash.ts
@@ -18,8 +18,9 @@ export default class GetFirmwareHash extends AbstractMethod<
         validateParams(payload, [{ name: 'challenge', type: 'string' }]);
 
         this.firmwareRange = getFirmwareRange(this.name, null, {
-            1: { min: '1.11.1', max: '0' },
-            2: { min: '2.5.1', max: '0' },
+            T1B1: { min: '1.11.1', max: '0' },
+            T2T1: { min: '2.5.1', max: '0' },
+            T2B1: { min: '2.6.1', max: '0' },
         });
 
         this.params = {

--- a/packages/connect/src/api/getFirmwareHash.ts
+++ b/packages/connect/src/api/getFirmwareHash.ts
@@ -17,11 +17,7 @@ export default class GetFirmwareHash extends AbstractMethod<
 
         validateParams(payload, [{ name: 'challenge', type: 'string' }]);
 
-        this.firmwareRange = getFirmwareRange(this.name, null, {
-            T1B1: { min: '1.11.1', max: '0' },
-            T2T1: { min: '2.5.1', max: '0' },
-            T2B1: { min: '2.6.1', max: '0' },
-        });
+        this.firmwareRange = getFirmwareRange(this.name, null, this.firmwareRange);
 
         this.params = {
             challenge: payload.challenge,

--- a/packages/connect/src/api/rebootToBootloader.ts
+++ b/packages/connect/src/api/rebootToBootloader.ts
@@ -13,11 +13,7 @@ export default class RebootToBootloader extends AbstractMethod<'rebootToBootload
         this.keepSession = false;
         this.requiredPermissions = ['management'];
         this.useDeviceState = false;
-        this.firmwareRange = getFirmwareRange(this.name, null, {
-            T1B1: { min: '1.10.0', max: '0' },
-            T2T1: { min: '2.6.0', max: '0' },
-            T2B1: { min: '2.6.1', max: '0' },
-        });
+        this.firmwareRange = getFirmwareRange(this.name, null, this.firmwareRange);
     }
 
     get info() {

--- a/packages/connect/src/api/rebootToBootloader.ts
+++ b/packages/connect/src/api/rebootToBootloader.ts
@@ -14,8 +14,9 @@ export default class RebootToBootloader extends AbstractMethod<'rebootToBootload
         this.requiredPermissions = ['management'];
         this.useDeviceState = false;
         this.firmwareRange = getFirmwareRange(this.name, null, {
-            1: { min: '1.10.0', max: '0' },
-            2: { min: '2.6.0', max: '0' },
+            T1B1: { min: '1.10.0', max: '0' },
+            T2T1: { min: '2.6.0', max: '0' },
+            T2B1: { min: '2.6.1', max: '0' },
         });
     }
 

--- a/packages/connect/src/data/config.ts
+++ b/packages/connect/src/data/config.ts
@@ -200,7 +200,7 @@ export const config = {
             min: { T1B1: '1.12.1', T2T1: '2.5.3' },
         },
         {
-            methods: ['showDeviceTutorial'],
+            methods: ['showDeviceTutorial', 'authenticateDevice'],
             min: { T1B1: '0', T2T1: '0', T2B1: '2.6.1' },
             comment: ['Only on T2B1'],
         },

--- a/packages/connect/src/data/config.ts
+++ b/packages/connect/src/data/config.ts
@@ -94,7 +94,7 @@ export const config = {
         {
             coin: ['xrp', 'txrp'],
             methods: ['getAccountInfo'],
-            min: ['0', '2.1.0'],
+            min: { T1B1: '0', T2T1: '2.1.0' },
             max: undefined, // NOTE: max field is not used anywhere at the moment, it is here for type compatibility
             comment: [
                 "Since firmware 2.1.0 there is a new protobuf field 'destination_tag' in RippleSignTx",
@@ -102,70 +102,70 @@ export const config = {
         },
         {
             coin: ['bnb'],
-            min: ['1.9.0', '2.3.0'],
+            min: { T1B1: '1.9.0', T2T1: '2.3.0' },
             comment: [
                 'There were protobuf backwards incompatible changes with introduction of 1.9.0/2.3.0 firmwares',
             ],
         },
         {
             coin: ['eth', 'tsep', 'tgor'],
-            min: ['1.8.0', '2.1.0'],
+            min: { T1B1: '1.8.0', T2T1: '2.1.0' },
             comment: ['There were protobuf backwards incompatible changes.'],
         },
         {
             methods: ['rippleGetAddress', 'rippleSignTransaction'],
-            min: ['0', '2.1.0'],
+            min: { T1B1: '0', T2T1: '2.1.0' },
             comment: [
                 "Since firmware 2.1.0 there is a new protobuf field 'destination_tag' in RippleSignTx",
             ],
         },
         {
             methods: ['cardanoGetAddress', 'cardanoGetPublicKey'],
-            min: ['0', '2.3.2'],
+            min: { T1B1: '0', T2T1: '2.3.2' },
             comment: ['Shelley fork support since firmware 2.3.2'],
         },
         {
             methods: ['cardanoSignTransaction'],
-            min: ['0', '2.4.2'],
+            min: { T1B1: '0', T2T1: '2.4.2' },
             comment: ['Non-streamed signing no longer supported'],
         },
         {
             methods: ['cardanoGetNativeScriptHash'],
-            min: ['0', '2.4.3'],
+            min: { T1B1: '0', T2T1: '2.4.3' },
             comment: ['Cardano GetNativeScriptHash call added in 2.4.3'],
         },
         {
             methods: ['tezosSignTransaction'],
-            min: ['0', '2.1.8'],
+            min: { T1B1: '0', T2T1: '2.1.8' },
             comment: [
                 'Since 2.1.8 there are new protobuf fields in tezos transaction (Babylon fork)',
             ],
         },
         {
             methods: ['stellarSignTransaction'],
-            min: ['1.9.0', '2.3.0'],
+            min: { T1B1: '1.9.0', T2T1: '2.3.0' },
             comment: [
                 'There were protobuf backwards incompatible changes with introduction of 1.9.0/2.3.0 firmwares',
             ],
         },
         {
             capabilities: ['replaceTransaction', 'amountUnit'],
-            min: ['1.9.4', '2.3.5'],
+            min: { T1B1: '1.9.4', T2T1: '2.3.5' },
             comment: ['new sign tx process since 1.9.4/2.3.5'],
         },
         {
             capabilities: ['decreaseOutput'],
-            min: ['1.10.0', '2.4.0'],
+            min: { T1B1: '1.10.0', T2T1: '2.4.0' },
             comment: ['allow reduce output in RBF transaction since 1.10.0/2.4.0'],
         },
         {
             capabilities: ['eip1559'],
-            min: ['1.10.4', '2.4.2'],
+            min: { T1B1: '1.10.4', T2T1: '2.4.2' },
             comment: ['new eth transaction pricing mechanism (EIP1559) since 1.10.4/2.4.2'],
         },
         {
             capabilities: ['taproot', 'signMessageNoScriptType'],
-            min: ['1.10.4', '2.4.3'],
+            min: { T1B1: '1.10.4', T2T1: '2.4.3' },
             comment: [
                 'new btc accounts taproot since 1.10.4/2.4.3 (BTC + TEST only)',
                 'SignMessage with no_script_type support',
@@ -174,17 +174,17 @@ export const config = {
         {
             coin: ['dcr', 'tdcr'],
             methods: ['signTransaction'],
-            min: ['1.10.1', '2.4.0'],
+            min: { T1B1: '1.10.1', T2T1: '2.4.0' },
             comment: [''],
         },
         {
             methods: ['ethereumSignTypedData'],
-            min: ['1.10.5', '2.4.3'],
+            min: { T1B1: '1.10.5', T2T1: '2.4.3' },
             comment: ['EIP-712 typed signing support added in 1.10.5/2.4.3'],
         },
         {
             capabilities: ['eip712-domain-only'],
-            min: ['1.10.6', '2.4.4'],
+            min: { T1B1: '1.10.6', T2T1: '2.4.4' },
             comment: ['EIP-712 domain-only signing, when primaryType=EIP712Domain'],
         },
         {
@@ -197,11 +197,11 @@ export const config = {
                 'setBusy',
                 'unlockPath',
             ],
-            min: ['1.12.1', '2.5.3'],
+            min: { T1B1: '1.12.1', T2T1: '2.5.3' },
         },
         {
             methods: ['showDeviceTutorial'],
-            min: ['0', '2.6.1'],
+            min: { T1B1: '0', T2T1: '0', T2B1: '2.6.1' },
             comment: ['Only on T2B1'],
         },
     ],

--- a/packages/connect/src/data/config.ts
+++ b/packages/connect/src/data/config.ts
@@ -204,5 +204,13 @@ export const config = {
             min: { T1B1: '0', T2T1: '0', T2B1: '2.6.1' },
             comment: ['Only on T2B1'],
         },
+        {
+            methods: ['rebootToBootloader'],
+            min: { T1B1: '1.11.0', T2T1: '2.6.0' },
+        },
+        {
+            methods: ['getFirmwareHash'],
+            min: { T1B1: '1.11.1', T2T1: '2.5.1' },
+        },
     ],
 };

--- a/packages/connect/src/types/coinInfo.ts
+++ b/packages/connect/src/types/coinInfo.ts
@@ -2,8 +2,9 @@ import { FeeLevel } from './fees';
 
 export interface CoinSupport {
     connect: boolean;
-    trezor1: string;
-    trezor2: string;
+    T1B1: string;
+    T2T1: string;
+    T2B1: string;
 }
 
 // copy-paste from '@trezor/utxo-lib' module

--- a/packages/connect/src/types/firmware.ts
+++ b/packages/connect/src/types/firmware.ts
@@ -1,9 +1,13 @@
 export interface FirmwareRange {
-    '1': {
+    T1B1: {
         min: string;
         max: string;
     };
-    '2': {
+    T2T1: {
+        min: string;
+        max: string;
+    };
+    T2B1: {
         min: string;
         max: string;
     };

--- a/packages/connect/src/utils/__tests__/deviceFeaturesUtils.test.ts
+++ b/packages/connect/src/utils/__tests__/deviceFeaturesUtils.test.ts
@@ -8,7 +8,7 @@ import {
     parseCapabilities,
     parseRevision,
 } from '../deviceFeaturesUtils';
-import { DeviceModelInternal } from '../../types';
+import { Features, DeviceModelInternal } from '../../types';
 
 describe('utils/deviceFeaturesUtils', () => {
     beforeEach(() => {
@@ -29,8 +29,7 @@ describe('utils/deviceFeaturesUtils', () => {
             major_version: 2,
         };
         // default T1B1
-        // @ts-expect-error - incomplete features
-        expect(parseCapabilities(featT1B1)).toEqual([
+        expect(parseCapabilities(featT1B1 as Features)).toEqual([
             'Capability_Bitcoin',
             'Capability_Bitcoin_like',
             'Capability_Crypto',
@@ -40,9 +39,8 @@ describe('utils/deviceFeaturesUtils', () => {
             'Capability_U2F',
         ]);
 
-        // default T2
-        // @ts-expect-error - incomplete features
-        expect(parseCapabilities(featT2T1)).toEqual([
+        // default T2T1
+        expect(parseCapabilities(featT2T1 as Features)).toEqual([
             'Capability_Bitcoin',
             'Capability_Bitcoin_like',
             'Capability_Binance',
@@ -82,11 +80,10 @@ describe('utils/deviceFeaturesUtils', () => {
 
         // bitcoin only
         expect(
-            // @ts-expect-error incomplete features
             parseCapabilities({
                 major_version: 1,
                 capabilities: ['Capability_Bitcoin'],
-            }),
+            } as Features),
         ).toEqual(['Capability_Bitcoin']);
 
         // no features
@@ -96,6 +93,9 @@ describe('utils/deviceFeaturesUtils', () => {
 
     describe('getUnavailableCapabilities', () => {
         const coins = getAllNetworks();
+        beforeEach(() => {
+            jest.resetModules();
+        });
 
         const featT2T1 = {
             major_version: 2,
@@ -103,9 +103,7 @@ describe('utils/deviceFeaturesUtils', () => {
             patch_version: 3,
             capabilities: undefined,
             internal_model: DeviceModelInternal.T2T1,
-        };
-
-        // @ts-expect-error incomplete features
+        } as unknown as Features;
         featT2T1.capabilities = parseCapabilities(featT2T1);
 
         const featT1B1 = {
@@ -114,16 +112,20 @@ describe('utils/deviceFeaturesUtils', () => {
             patch_version: 3,
             capabilities: undefined,
             internal_model: DeviceModelInternal.T1B1,
-        };
-        // @ts-expect-error incomplete features
+        } as unknown as Features;
         featT1B1.capabilities = parseCapabilities(featT1B1);
 
-        it('getUnavailableCapabilities capabilities 3', () => {
-            jest.resetModules();
-            const coins = getAllNetworks();
+        const featT2B1 = {
+            major_version: 2,
+            minor_version: 6,
+            patch_version: 1,
+            capabilities: undefined,
+            internal_model: DeviceModelInternal.T2B1,
+        } as unknown as Features;
+        featT2B1.capabilities = parseCapabilities(featT2B1);
 
-            // default Capabilities T1B1
-            // @ts-expect-error incomplete features
+        it('default T1B1', () => {
+            const coins = getAllNetworks();
 
             expect(getUnavailableCapabilities(featT1B1, coins)).toEqual({
                 ada: 'no-support',
@@ -150,9 +152,11 @@ describe('utils/deviceFeaturesUtils', () => {
                 coinjoin: 'update-required',
                 signMessageNoScriptType: 'update-required',
             });
+        });
 
-            // default Capabilities T2T1
-            // @ts-expect-error incomplete features
+        it('default T2T1', () => {
+            const coins = getAllNetworks();
+
             expect(getUnavailableCapabilities(featT2T1, coins)).toEqual({
                 replaceTransaction: 'update-required',
                 amountUnit: 'update-required',
@@ -167,7 +171,25 @@ describe('utils/deviceFeaturesUtils', () => {
             });
         });
 
-        it('getUnavailable 1', done => {
+        it('default T2B1', () => {
+            const coins = getAllNetworks();
+
+            expect(getUnavailableCapabilities(featT2B1, coins)).toEqual({
+                btg: 'no-support',
+                tbtg: 'no-support',
+                dash: 'no-support',
+                tdash: 'no-support',
+                dcr: 'no-support',
+                tdcr: 'no-support',
+                dgb: 'no-support',
+                eos: 'no-support',
+                nmc: 'no-support',
+                vtc: 'no-support',
+                xem: 'no-support',
+            });
+        });
+
+        it('T2T1 update-required', done => {
             jest.resetModules();
 
             jest.mock('../../data/config', () => ({
@@ -184,7 +206,6 @@ describe('utils/deviceFeaturesUtils', () => {
 
             import('../deviceFeaturesUtils').then(({ getUnavailableCapabilities }) => {
                 // added new capability
-                // @ts-expect-error incomplete features
                 expect(getUnavailableCapabilities(featT2T1, coins)).toEqual({
                     newCapabilityOrFeature: 'update-required',
                 });
@@ -192,8 +213,9 @@ describe('utils/deviceFeaturesUtils', () => {
             });
         });
 
-        it('getUnavailable 2', done => {
+        it('T2T1 no-support', done => {
             jest.resetModules();
+
             jest.mock('../../data/config', () => ({
                 __esModule: true,
                 config: {
@@ -208,7 +230,6 @@ describe('utils/deviceFeaturesUtils', () => {
 
             import('../deviceFeaturesUtils').then(({ getUnavailableCapabilities }) => {
                 // added new capability
-                // @ts-expect-error incomplete features
                 expect(getUnavailableCapabilities(featT2T1, coins)).toEqual({
                     newCapabilityOrFeature: 'no-support',
                 });

--- a/packages/connect/src/utils/__tests__/deviceFeaturesUtils.test.ts
+++ b/packages/connect/src/utils/__tests__/deviceFeaturesUtils.test.ts
@@ -166,6 +166,7 @@ describe('utils/deviceFeaturesUtils', () => {
                 signMessageNoScriptType: 'update-required',
             });
         });
+
         it('getUnavailable 1', done => {
             jest.resetModules();
 
@@ -174,7 +175,7 @@ describe('utils/deviceFeaturesUtils', () => {
                 config: {
                     supportedFirmware: [
                         {
-                            min: ['0', '2.99.99'],
+                            min: { T1B1: '0', T2T1: '2.99.99' },
                             capabilities: ['newCapabilityOrFeature'],
                         },
                     ],
@@ -198,7 +199,7 @@ describe('utils/deviceFeaturesUtils', () => {
                 config: {
                     supportedFirmware: [
                         {
-                            min: ['0', '0'],
+                            min: { T1B1: '0', T2T1: '0' },
                             capabilities: ['newCapabilityOrFeature'],
                         },
                     ],

--- a/packages/connect/src/utils/deviceFeaturesUtils.ts
+++ b/packages/connect/src/utils/deviceFeaturesUtils.ts
@@ -110,14 +110,6 @@ export const getUnavailableCapabilities = (features: Features, coins: CoinInfo[]
         }
     });
 
-    // Bitcoin Gold, Dash, DigiByte, NameCoin, Vertcoin support dropped for new devices
-    if (![DeviceModelInternal.T1B1, DeviceModelInternal.T2T1].includes(features.internal_model)) {
-        const unsupportedCoins = ['btg', 'dash', 'dgb', 'nmc', 'vtc'];
-        unsupportedCoins.forEach(coin => {
-            list[coin] = 'no-support';
-        });
-    }
-
     return list;
 };
 

--- a/packages/connect/src/utils/deviceFeaturesUtils.ts
+++ b/packages/connect/src/utils/deviceFeaturesUtils.ts
@@ -38,13 +38,12 @@ export const parseCapabilities = (features?: Features): PROTO.Capability[] => {
     return features.capabilities;
 };
 
-// TODO: support type
 export const getUnavailableCapabilities = (features: Features, coins: CoinInfo[]) => {
     const { capabilities } = features;
     const list: UnavailableCapabilities = {};
     if (!capabilities) return list;
     const fw = [features.major_version, features.minor_version, features.patch_version];
-    const key = `trezor${features.major_version}` as 'trezor1' | 'trezor2';
+    const key = features.internal_model;
 
     // 1. check if firmware version is supported by CoinInfo.support
     const supported = coins.filter(info => {
@@ -96,8 +95,8 @@ export const getUnavailableCapabilities = (features: Features, coins: CoinInfo[]
     // 4. check if firmware version is in range of capabilities in "config.supportedFirmware"
     config.supportedFirmware.forEach(s => {
         if (!s.capabilities) return;
-        const min = s.min ? s.min[fw[0] - 1] : null;
-        const max = s.max ? s.max[fw[0] - 1] : null;
+        const min = s.min ? s.min[key] : null;
+        const max = s.max ? s.max[key] : null;
         if (min && (min === '0' || versionUtils.isNewer(min, fw.join('.')))) {
             const value = min === '0' ? 'no-support' : 'update-required';
             s.capabilities.forEach(m => {


### PR DESCRIPTION


<!--- Provide a general summary of your changes in the Title above -->

## Description

following changes in [trezor-common](https://github.com/trezor/trezor-common/commit/159a35070c9fef162197e8f50de4aabbf7bd91b4)

- `trezor1` renamed to `T1B1`
- `trezor2` renamed to `T2T1`
- added `T2B1`

using the same format in `AbstractMethod:FirmwareRange` interface:
- array [1: { min: 'version', max: 'version' }, 2: { min: 'version', max: 'version' }] becomes object 
```
{ 
  T1B1: { min: 'version', max: 'version' },
  T2T1: { min: 'version', max: 'version' },
  T2B1: { min: 'version', max: 'version' } 
}
```

## Related Issue

Resolve https://github.com/trezor/trezor-suite/issues/8952
