### PR TITLE
Remove redundant success toasts from onboarding

### DIFF
--- a/packages/suite/src/actions/backup/backupActions.ts
+++ b/packages/suite/src/actions/backup/backupActions.ts
@@ -41,7 +41,7 @@ export const resetReducer = (): BackupAction => ({
 });
 
 export const backupDevice =
-    (params: CommonParams = {}) =>
+    (params: CommonParams = {}, skipSuccessToast?: boolean) =>
     async (dispatch: Dispatch, getState: GetState) => {
         const device = selectDevice(getState());
         if (!device) {
@@ -78,7 +78,9 @@ export const backupDevice =
                 },
             });
         } else {
-            dispatch(notificationsActions.addToast({ type: 'backup-success' }));
+            if (!skipSuccessToast) {
+                dispatch(notificationsActions.addToast({ type: 'backup-success' }));
+            }
             dispatch({
                 type: BACKUP.SET_STATUS,
                 payload: 'finished',

--- a/packages/suite/src/actions/settings/deviceSettingsActions.ts
+++ b/packages/suite/src/actions/settings/deviceSettingsActions.ts
@@ -30,7 +30,7 @@ export const applySettings =
     };
 
 export const changePin =
-    (params: Parameters<typeof TrezorConnect.changePin>[0] = {}) =>
+    (params: Parameters<typeof TrezorConnect.changePin>[0] = {}, skipSuccessToast?: boolean) =>
     async (dispatch: Dispatch, getState: GetState) => {
         const device = selectDevice(getState());
 
@@ -43,7 +43,9 @@ export const changePin =
             ...params,
         });
         if (result.success) {
-            dispatch(notificationsActions.addToast({ type: 'pin-changed' }));
+            if (!skipSuccessToast) {
+                dispatch(notificationsActions.addToast({ type: 'pin-changed' }));
+            }
         } else if (result.payload.code === 'Failure_PinMismatch') {
             dispatch(modalActions.openModal({ type: 'pin-mismatch' }));
         } else if (result.payload.error.includes('string overflow')) {

--- a/packages/suite/src/views/onboarding/steps/Backup.tsx
+++ b/packages/suite/src/views/onboarding/steps/Backup.tsx
@@ -50,7 +50,7 @@ export const BackupStep = () => {
                             data-test="@backup/start-button"
                             onClick={() => {
                                 dispatch(updateAnalytics({ backup: 'create' }));
-                                dispatch(backupDevice());
+                                dispatch(backupDevice({}, true));
                             }}
                             isDisabled={!canContinue(backup.userConfirmed, locks)}
                         >

--- a/packages/suite/src/views/onboarding/steps/Pin.tsx
+++ b/packages/suite/src/views/onboarding/steps/Pin.tsx
@@ -25,12 +25,13 @@ const SetPinStep = () => {
 
     const { goToNextStep, showPinMatrix, updateAnalytics } = useOnboarding();
 
+    const setPinAndSkipSuccessToast = () => dispatch(changePin({}, true));
     const onTryAgain = () => {
         setStatus('initial');
-        dispatch(changePin({}));
+        setPinAndSkipSuccessToast();
     };
     const setPin = () => {
-        dispatch(changePin());
+        setPinAndSkipSuccessToast();
         updateAnalytics({ pin: 'create' });
     };
     const skipPin = () => {

--- a/packages/suite/src/views/onboarding/steps/SecurityCheck/DeviceAuthenticity.tsx
+++ b/packages/suite/src/views/onboarding/steps/SecurityCheck/DeviceAuthenticity.tsx
@@ -77,6 +77,7 @@ export const DeviceAuthenticity = () => {
                 const result = await dispatch(
                     checkDeviceAuthenticityThunk({
                         allowDebugKeys: isDebugModeActive,
+                        skipSuccessToast: true,
                     }),
                 ).unwrap();
 

--- a/suite-common/device-authenticity/src/deviceAuthenticityThunks.ts
+++ b/suite-common/device-authenticity/src/deviceAuthenticityThunks.ts
@@ -5,12 +5,12 @@ import { notificationsActions } from '@suite-common/toast-notifications';
 import { ACTION_PREFIX, deviceAuthenticityActions } from './deviceAuthenticityActions';
 
 export const checkDeviceAuthenticityThunk = createThunk<
-    { allowDebugKeys: boolean },
+    { allowDebugKeys: boolean; skipSuccessToast?: boolean },
     string | AuthenticateDeviceResult
 >(
     `${ACTION_PREFIX}/checkDeviceAuthenticity`,
     async (
-        { allowDebugKeys },
+        { allowDebugKeys, skipSuccessToast },
         { dispatch, getState, extra, rejectWithValue, fulfillWithValue },
     ) => {
         const {
@@ -52,7 +52,7 @@ export const checkDeviceAuthenticityThunk = createThunk<
                 }),
             );
             console.warn(result.payload.error);
-        } else {
+        } else if (!skipSuccessToast) {
             dispatch(notificationsActions.addToast({ type: 'device-authenticity-success' }));
         }
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

`backupDevice`
`changePin`
`checkDeviceAuthenticityThunk`

These action creators are shared between settings and onboarding. Toasts are necessary in settings to indicate result of the user's action, but redundant in the onboarding where the next screen always gives you the result. Keeping error modals because they can provide some error info not found on the screens. 

I was hoping to come up with some  shared logic, but since onboarding is not yet part of `@suite-common`, I just used params.
<!--- Describe your changes in detail -->

## Related Issue

Resolve #9669

