### PR TITLE
Chore/project automations

### DIFF
--- a/.github/workflows/bot-pr-ready-for-review.yml
+++ b/.github/workflows/bot-pr-ready-for-review.yml
@@ -21,7 +21,7 @@ jobs:
         id: find-pr-id
         uses: actions/github-script@v6
         env:
-          GITHUB_TOKEN: ${{ secrets.TREZOR_BOT_TOKEN }}
+          GITHUB_TOKEN: ${{ steps.generate_token.outputs.token }}
         with:
           result-encoding: string
           script: |

--- a/.github/workflows/bot-pr-ready-for-review.yml
+++ b/.github/workflows/bot-pr-ready-for-review.yml
@@ -62,11 +62,15 @@ jobs:
             `;
 
 
-            await github.graphql(updateItemFieldMutation, {
-              projectId: "PVT_kwDOAD9FD84AB-s-", // Suite Pull Requests
-              itemId: process.env.PR_ID,
-              fieldId: "PVTSSF_lADOAD9FD84AB-s-zgBJWdk", // Status
-              value: {
-                  singleSelectOptionId: "49f430a3"  // To be reviewed
-                  }
-            });
+            try {
+              await github.graphql(updateItemFieldMutation, {
+                projectId: "PVT_kwDOAD9FD84AB-s-", // Suite Pull Requests
+                itemId: process.env.PR_ID,
+                fieldId: "PVTSSF_lADOAD9FD84AB-s-zgBJWdk", // Status
+                value: {
+                    singleSelectOptionId: "49f430a3"  // To be reviewed
+                    }
+              });
+            } catch (error) {
+              console.log(JSON.stringify(error, null, 2);
+            }

--- a/.github/workflows/bot-pr-ready-for-review.yml
+++ b/.github/workflows/bot-pr-ready-for-review.yml
@@ -8,6 +8,10 @@ jobs:
   pr_set_status:
     name: Move PR to To be reviewed
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: write
+      repository-projects: write
     steps:
       - name: Generate token
         id: generate_token

--- a/.github/workflows/bot-pr-ready-for-review.yml
+++ b/.github/workflows/bot-pr-ready-for-review.yml
@@ -1,0 +1,72 @@
+name: "[Bot] set PR status To be reviewed"
+
+on:
+  pull_request:
+    types:
+      - ready_for_review
+jobs:
+  pr_set_status:
+    name: Move PR to To be reviewed
+    runs-on: ubuntu-latest
+    steps:
+      - name: Generate token
+        id: generate_token
+        uses: actions/create-github-app-token@v1
+        with:
+          app-id: ${{ secrets.TSPM_APP_ID }}
+          private-key: ${{ secrets.TSPM_APP_SECRET }}
+
+      - name: Find ID of the Pull Request
+        id: find-pr-id
+        uses: actions/github-script@v6
+        env:
+          GITHUB_TOKEN: ${{ secrets.TREZOR_BOT_TOKEN }}
+        with:
+          result-encoding: string
+          script: |
+            // GraphQL query to find the project card associated with the current PR
+            const findPRQuery = `query FindProjectCard($repoOwner: String!, $repoName: String!, $prNumber: Int!) {
+                repository(owner: $repoOwner, name: $repoName) {
+                  pullRequest(number: $prNumber) {
+                      id
+                  }
+                }
+              }
+            `;
+
+            const findPRResponse = await github.graphql(findPRQuery, {
+              repoOwner: context.repo.owner,
+              repoName: context.repo.repo,
+              prNumber: context.issue.number
+            });
+
+            const itemId = findPRResponse.repository.pullRequest.id;
+
+            console.log("itemId: " + itemId)
+            return itemId;
+            
+
+      - name: Update PR status
+        uses: actions/github-script@v6
+        env:
+          GITHUB_TOKEN: ${{ steps.generate_token.outputs.token }}
+          PR_ID: ${{ steps.find-pr-id.outputs.result }}
+        with:
+          script: |
+            // GraphQL mutation to update the custom field "Status" of the project card
+            const updateItemFieldMutation = `mutation UpdateItemCustomField($projectId: ID!,$itemId: ID!, $fieldId: ID!, $value: ProjectV2FieldValue!) {
+                updateProjectV2ItemFieldValue(input: {projectId: $projectId,itemId: $itemId, fieldId: $fieldId, value: $value}) {
+                    clientMutationId
+                }
+              }
+            `;
+
+
+            await github.graphql(updateItemFieldMutation, {
+              projectId: "PVT_kwDOAD9FD84AB-s-", // Suite Pull Requests
+              itemId: process.env.PR_ID,
+              fieldId: "PVTSSF_lADOAD9FD84AB-s-zgBJWdk", // Status
+              value: {
+                  singleSelectOptionId: "49f430a3"  // To be reviewed
+                  }
+            });

--- a/.github/workflows/bot-pr-ready-for-review.yml
+++ b/.github/workflows/bot-pr-ready-for-review.yml
@@ -68,9 +68,9 @@ jobs:
                 itemId: process.env.PR_ID,
                 fieldId: "PVTSSF_lADOAD9FD84AB-s-zgBJWdk", // Status
                 value: {
-                    singleSelectOptionId: "49f430a3"  // To be reviewed
-                    }
+                  singleSelectOptionId: "49f430a3"  // To be reviewed
+                }
               });
             } catch (error) {
-              console.log(JSON.stringify(error, null, 2);
+              console.log(JSON.stringify(error, null, 2));
             }

--- a/.github/workflows/bot-pr-ready-for-review.yml
+++ b/.github/workflows/bot-pr-ready-for-review.yml
@@ -45,7 +45,6 @@ jobs:
 
             console.log("itemId: " + itemId)
             return itemId;
-            
 
       - name: Update PR status
         uses: actions/github-script@v6

--- a/.github/workflows/bot-pr-ready-for-review.yml
+++ b/.github/workflows/bot-pr-ready-for-review.yml
@@ -15,6 +15,7 @@ jobs:
         with:
           app-id: ${{ secrets.TSPM_APP_ID }}
           private-key: ${{ secrets.TSPM_APP_SECRET }}
+          owner: ${{ github.repository_owner }}
 
       - name: Find ID of the Pull Request
         id: find-pr-id


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

The goal of this action is to automate moving PR from "Draft" to "To be reviewed" state in [Suite Pull Requests](https://github.com/orgs/trezor/projects/62) project so we don't need to do it manually when PR is marked as Ready for review.


If we make this action work, we would get much more flexibility to automate github projects, because predefined workflows are very limited.

But the blocker are permission. 

To properly authorize the action for projects that are on organization level and not repository level, we need a Github App.

But that should be somewhat easy to setup in github:

Register: https://docs.github.com/en/enterprise-cloud@latest/apps/creating-github-apps/registering-a-github-app/registering-a-github-app

Install: [https://docs.github.com/en/enterprise-cloud@latest/apps/using-github-apps/installing-your-own-github-app#installing-your-priv[…]p-on-your-repository](https://docs.github.com/en/enterprise-cloud@latest/apps/using-github-apps/installing-your-own-github-app#installing-your-private-github-app-on-your-repository)

And then we can get inspiration from this example how to use the authentication via Github App:
https://docs.github.com/en/enterprise-cloud@latest/issues/planning-and-tracking-with-projects/automating-your-project/automating-projects-using-actions#example-workflow-authenticating-with-a-github-app