### PR TITLE
feat(coinmarket): USDT20 to USDT rename backward compatibility

### DIFF
--- a/packages/suite/src/utils/wallet/coinmarket/__tests__/buyUtils.test.ts
+++ b/packages/suite/src/utils/wallet/coinmarket/__tests__/buyUtils.test.ts
@@ -102,10 +102,11 @@ describe('coinmarket/buy utils', () => {
             getCryptoOptions(
                 'eth',
                 'ethereum',
-                new Set(['eth', 'usdt20', 'usdc', 'dai', 'gusd', 'other']),
+                new Set(['eth', 'usdt20', 'usdt', 'usdc', 'dai', 'gusd', 'other']),
                 [
                     { ticker: 'ETH', category: 'Popular', name: 'Ethereum' },
                     { ticker: 'USDT20', category: 'Ethereum ERC20 tokens', name: 'Tether' },
+                    { ticker: 'USDT', category: 'Ethereum ERC20 tokens', name: 'Tether' },
                     { ticker: 'USDC', category: 'Ethereum ERC20 tokens', name: 'Usdc' },
                     { ticker: 'DAI', category: 'Ethereum ERC20 tokens', name: 'Dai' },
                     { ticker: 'GUSD', category: 'Ethereum ERC20 tokens', name: 'GUsd' },
@@ -118,7 +119,7 @@ describe('coinmarket/buy utils', () => {
                 label: 'ETH',
             },
             {
-                value: 'USDT20',
+                value: 'USDT',
                 label: 'USDT',
             },
             {

--- a/packages/suite/src/utils/wallet/coinmarket/__tests__/coinmarketUtils.test.ts
+++ b/packages/suite/src/utils/wallet/coinmarket/__tests__/coinmarketUtils.test.ts
@@ -17,7 +17,7 @@ describe('coinmarket utils', () => {
 
     it('symbolToInvityApiSymbol', () => {
         expect(symbolToInvityApiSymbol('btc')).toStrictEqual('btc');
-        expect(symbolToInvityApiSymbol('usdt')).toStrictEqual('usdt20');
+        expect(symbolToInvityApiSymbol('usdt')).toStrictEqual('usdt');
     });
 
     it('getUnusedAddressFromAccount', () => {
@@ -58,15 +58,18 @@ describe('coinmarket utils', () => {
             },
         ]);
         expect(
-            getSendCryptoOptions(accountEth as Account, new Set(['eth', 'usdt20', 'usdc', 'dai'])),
+            getSendCryptoOptions(
+                accountEth as Account,
+                new Set(['eth', 'usdt20', 'usdt', 'usdc', 'dai']),
+            ),
         ).toStrictEqual([
             {
                 value: 'ETH',
                 label: 'ETH',
             },
             {
-                value: 'USDT20',
-                label: 'USDT20',
+                value: 'USDT',
+                label: 'USDT',
                 token: {
                     type: 'ERC20',
                     contract: '0x1234123412341234123412341234123412341234',

--- a/packages/suite/src/utils/wallet/coinmarket/buyUtils.ts
+++ b/packages/suite/src/utils/wallet/coinmarket/buyUtils.ts
@@ -137,6 +137,10 @@ export const getCryptoOptions = (
         coinInfo?.forEach(coin => {
             if (coin.category === 'Ethereum ERC20 tokens') {
                 const ticker = coin.ticker.toLowerCase();
+                if (ticker.toLowerCase() === 'usdt20') {
+                    // temporary solution; invity-api renamed USDT20 => USDT and sends both codes (USDT and USDT20) to maintain backward compatibility with old versions of suite
+                    return;
+                }
                 if (supportedCoins.has(ticker)) {
                     options.push({
                         label: invityApiSymbolToSymbol(ticker).toUpperCase(),

--- a/packages/suite/src/utils/wallet/coinmarket/coinmarketUtils.ts
+++ b/packages/suite/src/utils/wallet/coinmarket/coinmarketUtils.ts
@@ -4,12 +4,10 @@ import TrezorConnect, { TokenInfo } from '@trezor/connect';
 import regional from 'src/constants/wallet/coinmarket/regional';
 import { TrezorDevice } from 'src/types/suite';
 
-const suiteToInvitySymbols = [
-    {
-        suiteSymbol: 'usdt',
-        invitySymbol: 'usdt20',
-    },
-];
+const suiteToInvitySymbols: {
+    suiteSymbol: string;
+    invitySymbol: string;
+}[] = [];
 
 export const buildOption = (currency: string) => ({
     value: currency,

--- a/packages/suite/src/views/wallet/coinmarket/exchange/components/ExchangeForm/Inputs/ReceiveCryptoSelect/index.tsx
+++ b/packages/suite/src/views/wallet/coinmarket/exchange/components/ExchangeForm/Inputs/ReceiveCryptoSelect/index.tsx
@@ -65,6 +65,7 @@ const buildOptions = (
                 coin.name &&
                 coin.category &&
                 coin.ticker.toLowerCase() !== symbolToFilter &&
+                coin.ticker.toLowerCase() !== 'usdt20' && // temporary solution; invity-api renamed USDT20 => USDT and sends both codes (USDT and USDT20) to maintain backward compatibility with old versions of suite
                 exchangeInfo.buySymbols.has(coin.ticker.toLowerCase()),
         )
         .reduce((options, coin) => {


### PR DESCRIPTION
## Description

USDT20 to USDT rename backward compatibility

## Related Issue

Resolve #9680 
