### PR TITLE
Feat/auth copy

### DIFF
--- a/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/AuthenticateDeviceFailModal.tsx
+++ b/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/AuthenticateDeviceFailModal.tsx
@@ -2,7 +2,6 @@ import styled from 'styled-components';
 
 import { Modal } from 'src/components/suite';
 import { SecurityCheckFail } from 'src/views/onboarding/steps/SecurityCheck/SecurityCheckFail';
-import { SecurityCheckLayout } from 'src/views/onboarding/steps/SecurityCheck/SecurityCheckLayout';
 
 const StyledModal = styled(Modal)`
     text-align: left;
@@ -10,8 +9,6 @@ const StyledModal = styled(Modal)`
 
 export const AuthenticateDeviceFailModal = () => (
     <StyledModal>
-        <SecurityCheckLayout isFailed>
-            <SecurityCheckFail />
-        </SecurityCheckLayout>
+        <SecurityCheckFail />
     </StyledModal>
 );

--- a/packages/suite/src/support/messages.ts
+++ b/packages/suite/src/support/messages.ts
@@ -6711,6 +6711,15 @@ export default defineMessages({
         defaultMessage:
             "Contact Trezor Support to figure out what's going on with your device and what to do next.",
     },
+    TR_DEVICE_COMPROMISED_HEADING_SOFT: {
+        id: 'TR_PLAY_IT_SAFE',
+        defaultMessage: "Let's play it safe",
+    },
+    TR_DEVICE_COMPROMISED_TEXT_SOFT: {
+        id: 'TR_DEVICE_COMPROMISED_TEXT_SOFT',
+        defaultMessage:
+            'We want to be sure that your device is in tip-top shape before you start using it. Reach out to Trezor Support to find out what to do next.',
+    },
     TR_DISCONNECT_DEVICE: {
         id: 'TR_DISCONNECT_DEVICE',
         defaultMessage: 'Disconnect your device from your laptop or computer.',

--- a/packages/suite/src/support/messages.ts
+++ b/packages/suite/src/support/messages.ts
@@ -6732,6 +6732,18 @@ export default defineMessages({
         id: 'TR_USE_CHAT',
         defaultMessage: 'Click below and use the <b>Chat</b> option on the next page.',
     },
+    TR_DISCONNECT_DEVICE_SOFT: {
+        id: 'TR_DISCONNECT_DEVICE_SOFT',
+        defaultMessage: 'Disconnect your device from your laptop or computer.',
+    },
+    TR_AVOID_USING_DEVICE_SOFT: {
+        id: 'TR_AVOID_USING_DEVICE_SOFT',
+        defaultMessage: 'Avoid using this device or sending any funds to it.',
+    },
+    TR_USE_CHAT_SOFT: {
+        id: 'TR_USE_CHAT_SOFT',
+        defaultMessage: 'Click below and use the <b>Chat</b> option on the next page.',
+    },
     TR_CONTACT_TREZOR_SUPPORT: {
         id: 'TR_CONTACT_TREZOR_SUPPORT',
         defaultMessage: 'Contact Trezor Support',

--- a/packages/suite/src/views/onboarding/steps/SecurityCheck/DeviceAuthenticity.tsx
+++ b/packages/suite/src/views/onboarding/steps/SecurityCheck/DeviceAuthenticity.tsx
@@ -13,7 +13,6 @@ import { CollapsibleOnboardingCard } from 'src/components/onboarding/Collapsible
 import { DeviceAuthenticationExplainer, Translation } from 'src/components/suite';
 import { useOnboarding, useSelector } from 'src/hooks/suite';
 import { selectIsDebugModeActive } from 'src/reducers/suite/suiteReducer';
-import { SecurityCheckLayout } from './SecurityCheckLayout';
 import { SecurityCheckFail } from './SecurityCheckFail';
 
 const StyledCard = styled(CollapsibleOnboardingCard)`
@@ -115,9 +114,7 @@ export const DeviceAuthenticity = () => {
     if (isCheckFailed) {
         return (
             <StyledCard>
-                <SecurityCheckLayout isFailed>
-                    <SecurityCheckFail />
-                </SecurityCheckLayout>
+                <SecurityCheckFail />
             </StyledCard>
         );
     }

--- a/packages/suite/src/views/onboarding/steps/SecurityCheck/SecurityCheck.tsx
+++ b/packages/suite/src/views/onboarding/steps/SecurityCheck/SecurityCheck.tsx
@@ -203,59 +203,57 @@ export const SecurityCheck = () => {
 
     return (
         <StyledCard>
-            <SecurityCheckLayout isFailed={isFailed}>
-                {isFailed ? (
-                    <SecurityCheckFail goBack={toggleView} />
-                ) : (
-                    <>
-                        <Content>
-                            <DeviceNameSection>
-                                <Text>
-                                    <Translation id="TR_YOU_HAVE_CONNECTED" />
-                                </Text>
-                                <DeviceName>{device?.name}</DeviceName>
-                                <OnboardingButtonSkip onClick={toggleView}>
-                                    <Translation id="TR_CONNECTED_DIFFERENT_DEVICE" />
-                                </OnboardingButtonSkip>
-                            </DeviceNameSection>
-                            <StyledH1>
-                                <Translation id={headingText} />
-                            </StyledH1>
-                            <SecurityChecklist items={checklistItems} />
-                        </Content>
-                        <Buttons>
-                            <StyledSecurityCheckButton variant="secondary" onClick={toggleView}>
-                                <Translation id={secondaryButtonText} />
+            {isFailed ? (
+                <SecurityCheckFail goBack={toggleView} />
+            ) : (
+                <SecurityCheckLayout>
+                    <Content>
+                        <DeviceNameSection>
+                            <Text>
+                                <Translation id="TR_YOU_HAVE_CONNECTED" />
+                            </Text>
+                            <DeviceName>{device?.name}</DeviceName>
+                            <OnboardingButtonSkip onClick={toggleView}>
+                                <Translation id="TR_CONNECTED_DIFFERENT_DEVICE" />
+                            </OnboardingButtonSkip>
+                        </DeviceNameSection>
+                        <StyledH1>
+                            <Translation id={headingText} />
+                        </StyledH1>
+                        <SecurityChecklist items={checklistItems} />
+                    </Content>
+                    <Buttons>
+                        <StyledSecurityCheckButton variant="secondary" onClick={toggleView}>
+                            <Translation id={secondaryButtonText} />
+                        </StyledSecurityCheckButton>
+                        {initialized ? (
+                            <StyledSecurityCheckButton
+                                data-test="@onboarding/exit-app-button"
+                                onClick={handleContinueButtonClick}
+                            >
+                                <Translation id="TR_YES_CONTINUE" />
                             </StyledSecurityCheckButton>
-                            {initialized ? (
-                                <StyledSecurityCheckButton
-                                    data-test="@onboarding/exit-app-button"
-                                    onClick={handleContinueButtonClick}
-                                >
-                                    <Translation id="TR_YES_CONTINUE" />
-                                </StyledSecurityCheckButton>
-                            ) : (
-                                <SecurityCheckButtonWithSecondLine
-                                    onClick={handleSetupButtonClick}
-                                    data-test="@analytics/continue-button"
-                                >
-                                    <Translation id={primaryButtonTopText} />
-                                    <TimeEstimateWrapper>
-                                        <IconWrapper>
-                                            <Icon
-                                                size={12}
-                                                icon="CLOCK_ACTIVE"
-                                                color={theme.TYPE_WHITE}
-                                            />
-                                        </IconWrapper>
-                                        <Translation id="TR_TAKES_N_MINUTES" values={{ n: '5' }} />
-                                    </TimeEstimateWrapper>
-                                </SecurityCheckButtonWithSecondLine>
-                            )}
-                        </Buttons>
-                    </>
-                )}
-            </SecurityCheckLayout>
+                        ) : (
+                            <SecurityCheckButtonWithSecondLine
+                                onClick={handleSetupButtonClick}
+                                data-test="@analytics/continue-button"
+                            >
+                                <Translation id={primaryButtonTopText} />
+                                <TimeEstimateWrapper>
+                                    <IconWrapper>
+                                        <Icon
+                                            size={12}
+                                            icon="CLOCK_ACTIVE"
+                                            color={theme.TYPE_WHITE}
+                                        />
+                                    </IconWrapper>
+                                    <Translation id="TR_TAKES_N_MINUTES" values={{ n: '5' }} />
+                                </TimeEstimateWrapper>
+                            </SecurityCheckButtonWithSecondLine>
+                        )}
+                    </Buttons>
+                </SecurityCheckLayout>
+            )}
         </StyledCard>
     );
 };

--- a/packages/suite/src/views/onboarding/steps/SecurityCheck/SecurityCheckFail.tsx
+++ b/packages/suite/src/views/onboarding/steps/SecurityCheck/SecurityCheckFail.tsx
@@ -6,6 +6,7 @@ import { TREZOR_SUPPORT_URL } from '@trezor/urls';
 import { Translation, TrezorLink } from 'src/components/suite';
 import { SecurityChecklist } from './SecurityChecklist';
 import { SecurityCheckButton } from './SecurityCheckButton';
+import { SecurityCheckLayout } from './SecurityCheckLayout';
 
 const TopSection = styled.div`
     border-bottom: 1px solid ${({ theme }) => theme.STROKE_GREY};
@@ -64,7 +65,7 @@ interface SecurityCheckFailProps {
 }
 
 export const SecurityCheckFail = ({ goBack }: SecurityCheckFailProps) => (
-    <>
+    <SecurityCheckLayout isFailed>
         <TopSection>
             <StyledH1>
                 <Translation id="TR_DEVICE_COMPROMISED_HEADING" />
@@ -86,5 +87,5 @@ export const SecurityCheckFail = ({ goBack }: SecurityCheckFailProps) => (
                 </StyledSecurityCheckButton>
             </StyledTrezorLink>
         </Buttons>
-    </>
+    </SecurityCheckLayout>
 );

--- a/packages/suite/src/views/onboarding/steps/SecurityCheck/SecurityCheckFail.tsx
+++ b/packages/suite/src/views/onboarding/steps/SecurityCheck/SecurityCheckFail.tsx
@@ -58,6 +58,21 @@ const checklistItems = [
     },
 ] as const;
 
+const softChecklistItems = [
+    {
+        icon: 'PLUGS',
+        content: <Translation id="TR_DISCONNECT_DEVICE_SOFT" />,
+    },
+    {
+        icon: 'HAND',
+        content: <Translation id="TR_AVOID_USING_DEVICE_SOFT" />,
+    },
+    {
+        icon: 'CHAT',
+        content: <Translation id="TR_USE_CHAT_SOFT" values={{ b: chunks => <b>{chunks}</b> }} />,
+    },
+] as const;
+
 const supportChatUrl = `${TREZOR_SUPPORT_URL}#open-chat`;
 
 interface SecurityCheckFailProps {
@@ -67,6 +82,7 @@ interface SecurityCheckFailProps {
 export const SecurityCheckFail = ({ goBack }: SecurityCheckFailProps) => {
     const heading = goBack ? 'TR_DEVICE_COMPROMISED_HEADING_SOFT' : 'TR_DEVICE_COMPROMISED_HEADING';
     const text = goBack ? 'TR_DEVICE_COMPROMISED_TEXT_SOFT' : 'TR_DEVICE_COMPROMISED_TEXT';
+    const items = goBack ? softChecklistItems : checklistItems;
 
     return (
         <SecurityCheckLayout isFailed>
@@ -78,7 +94,7 @@ export const SecurityCheckFail = ({ goBack }: SecurityCheckFailProps) => {
                     <Translation id={text} />
                 </Text>
             </TopSection>
-            <SecurityChecklist items={checklistItems} />
+            <SecurityChecklist items={items} />
             <Buttons>
                 {goBack && (
                     <SecurityCheckButton variant="secondary" onClick={goBack}>

--- a/packages/suite/src/views/onboarding/steps/SecurityCheck/SecurityCheckFail.tsx
+++ b/packages/suite/src/views/onboarding/steps/SecurityCheck/SecurityCheckFail.tsx
@@ -64,28 +64,33 @@ interface SecurityCheckFailProps {
     goBack?: () => void;
 }
 
-export const SecurityCheckFail = ({ goBack }: SecurityCheckFailProps) => (
-    <SecurityCheckLayout isFailed>
-        <TopSection>
-            <StyledH1>
-                <Translation id="TR_DEVICE_COMPROMISED_HEADING" />
-            </StyledH1>
-            <Text>
-                <Translation id="TR_DEVICE_COMPROMISED_TEXT" />
-            </Text>
-        </TopSection>
-        <SecurityChecklist items={checklistItems} />
-        <Buttons>
-            {goBack && (
-                <SecurityCheckButton variant="secondary" onClick={goBack}>
-                    <Translation id="TR_BACK" />
-                </SecurityCheckButton>
-            )}
-            <StyledTrezorLink variant="nostyle" href={supportChatUrl}>
-                <StyledSecurityCheckButton>
-                    <Translation id="TR_CONTACT_TREZOR_SUPPORT" />
-                </StyledSecurityCheckButton>
-            </StyledTrezorLink>
-        </Buttons>
-    </SecurityCheckLayout>
-);
+export const SecurityCheckFail = ({ goBack }: SecurityCheckFailProps) => {
+    const heading = goBack ? 'TR_DEVICE_COMPROMISED_HEADING_SOFT' : 'TR_DEVICE_COMPROMISED_HEADING';
+    const text = goBack ? 'TR_DEVICE_COMPROMISED_TEXT_SOFT' : 'TR_DEVICE_COMPROMISED_TEXT';
+
+    return (
+        <SecurityCheckLayout isFailed>
+            <TopSection>
+                <StyledH1>
+                    <Translation id={heading} />
+                </StyledH1>
+                <Text>
+                    <Translation id={text} />
+                </Text>
+            </TopSection>
+            <SecurityChecklist items={checklistItems} />
+            <Buttons>
+                {goBack && (
+                    <SecurityCheckButton variant="secondary" onClick={goBack}>
+                        <Translation id="TR_BACK" />
+                    </SecurityCheckButton>
+                )}
+                <StyledTrezorLink variant="nostyle" href={supportChatUrl}>
+                    <StyledSecurityCheckButton>
+                        <Translation id="TR_CONTACT_TREZOR_SUPPORT" />
+                    </StyledSecurityCheckButton>
+                </StyledTrezorLink>
+            </Buttons>
+        </SecurityCheckLayout>
+    );
+};

--- a/packages/suite/src/views/onboarding/steps/SecurityCheck/SecurityCheckLayout.tsx
+++ b/packages/suite/src/views/onboarding/steps/SecurityCheck/SecurityCheckLayout.tsx
@@ -40,7 +40,7 @@ const Content = styled.div`
 `;
 
 interface SecurityCheckLayoutProps {
-    isFailed: boolean;
+    isFailed?: boolean;
     children: React.ReactNode;
 }
 

--- a/packages/suite/src/views/onboarding/steps/SecurityCheck/SecurityCheckLayout.tsx
+++ b/packages/suite/src/views/onboarding/steps/SecurityCheck/SecurityCheckLayout.tsx
@@ -34,6 +34,9 @@ const StyledImage = styled(Image)`
 
 const Content = styled.div`
     flex-grow: 1;
+    display: flex;
+    flex-direction: column;
+    justify-content: space-between;
 `;
 
 interface SecurityCheckLayoutProps {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->
e7328cd72a5b911d7e08c0c63856b9e1ff6793fa - this is to make sure the buttons are always vertically aligned with the bottom of the image and that buttons don't jump vertically when switching to and from the fail screen.
be39c1295a360a88e9e08c10cb0428697b43d057 - the layout component was initially  rendered separately to avoid image flickering in the security check  when switching to and from the fail screen; there was the same image for both states originally. Now that the image is different, it must rerender anyway, so we can simplify code by including `SecurityCheckLayout` in `SecurityCheckFail` component.
875469c23c88f03e31b3a4a65724fbfc577be7ac - resolves the issue.

## Related Issue

Resolve <!--- link the issue here -->#9674

## Screenshots:
![Screenshot 2023-10-18 at 17 22 22](https://github.com/trezor/trezor-suite/assets/42465546/55fec92f-0acb-401d-a19e-9a74f79ff900)

Before the changes (notice how the buttons move upwards):

https://github.com/trezor/trezor-suite/assets/42465546/61873cd9-c37f-4f58-a8d2-fb6d045f0604

