### PR TITLE
Console warning fixes

### DIFF
--- a/packages/components/src/components/Modal/Modal.tsx
+++ b/packages/components/src/components/Modal/Modal.tsx
@@ -185,7 +185,7 @@ interface ModalProps {
     onClick?: (e: MouseEvent<HTMLDivElement>) => void;
     totalProgressBarSteps?: number;
     currentProgressBarStep?: number;
-    headerComponents?: Array<ReactNode>;
+    headerComponent?: ReactNode;
     className?: string;
     'data-test'?: string;
 }
@@ -205,7 +205,7 @@ const Modal = ({
     onCancel,
     totalProgressBarSteps,
     currentProgressBarStep,
-    headerComponents,
+    headerComponent,
     className,
     'data-test': dataTest = '@modal',
 }: ModalProps) => {
@@ -223,7 +223,7 @@ const Modal = ({
     const showProgressBar =
         totalProgressBarSteps !== undefined && currentProgressBarStep !== undefined;
 
-    const showHeaderActions = !!headerComponents?.length || isCancelable;
+    const showHeaderActions = !!headerComponent || isCancelable;
 
     if (isCancelable && escPressed) {
         onCancel?.();
@@ -282,7 +282,7 @@ const Modal = ({
 
                         {showHeaderActions && (
                             <HeaderComponentsContainer ref={measureComponentsRef}>
-                                {headerComponents}
+                                {headerComponent}
 
                                 {isCancelable && (
                                     <CloseIcon

--- a/packages/suite-desktop-ui/src/support/DesktopUpdater/Downloading.tsx
+++ b/packages/suite-desktop-ui/src/support/DesktopUpdater/Downloading.tsx
@@ -54,7 +54,7 @@ export const Downloading = ({ hideWindow, progress }: DownloadingProps) => {
 
     return (
         <Modal
-            headerComponents={[
+            headerComponent={
                 <StyledButton
                     variant="secondary"
                     icon="CROSS"
@@ -62,8 +62,8 @@ export const Downloading = ({ hideWindow, progress }: DownloadingProps) => {
                     onClick={hideWindow}
                 >
                     <Translation id="TR_BACKGROUND_DOWNLOAD" />
-                </StyledButton>,
-            ]}
+                </StyledButton>
+            }
             currentProgressBarStep={progress?.percent || 0}
             totalProgressBarSteps={100}
             onCancel={hideWindow}

--- a/packages/suite/src/components/suite/CheckItem.tsx
+++ b/packages/suite/src/components/suite/CheckItem.tsx
@@ -18,7 +18,7 @@ const CheckboxRight = styled.div`
     text-align: left;
 `;
 
-const CheckboxTitle = styled.p`
+const CheckboxTitle = styled.div`
     font-weight: ${variables.FONT_WEIGHT.MEDIUM};
 `;
 

--- a/packages/suite/src/components/suite/SwitchDevice/index.tsx
+++ b/packages/suite/src/components/suite/SwitchDevice/index.tsx
@@ -45,11 +45,7 @@ export const SwitchDevice = ({ cancelable, onCancel }: ForegroundAppProps) => {
             isCancelable={cancelable}
             onCancel={onCancel}
             heading={<Translation id="TR_CHOOSE_WALLET" />}
-            headerComponents={
-                isWebUsbTransport
-                    ? [<WebUsbButton variant="tertiary" key="webusb-button" />]
-                    : undefined
-            }
+            headerComponent={isWebUsbTransport ? <WebUsbButton variant="tertiary" /> : undefined}
         >
             <DeviceItemsWrapper>
                 {sortedDevices.map(device => (

--- a/packages/suite/src/components/suite/modals/Modal/DefaultRenderer.tsx
+++ b/packages/suite/src/components/suite/modals/Modal/DefaultRenderer.tsx
@@ -1,4 +1,4 @@
-import { useMemo, ReactPortal } from 'react';
+import { ReactPortal } from 'react';
 import { createPortal } from 'react-dom';
 import { Modal, ModalProps, Icon, colors } from '@trezor/components';
 import { useGuide } from 'src/hooks/guide';
@@ -7,7 +7,7 @@ import { useModalTarget } from 'src/support/suite/ModalContext';
 import { ModalEnvironment } from '../ModalEnvironment';
 
 export const DefaultRenderer = ({
-    headerComponents = [],
+    headerComponent,
     isCancelable,
     onCancel,
     ...rest
@@ -16,19 +16,6 @@ export const DefaultRenderer = ({
     const { isMobileLayout } = useLayoutSize();
     const modalTarget = useModalTarget();
 
-    const GuideButton = useMemo(
-        () => (
-            <Icon
-                key="guide-button"
-                icon="LIGHTBULB"
-                size={20}
-                hoverColor={colors.TYPE_ORANGE}
-                onClick={openGuide}
-            />
-        ),
-        [openGuide],
-    );
-
     if (!modalTarget) return null;
 
     const modal = (
@@ -36,7 +23,19 @@ export const DefaultRenderer = ({
             <Modal
                 isCancelable={isCancelable}
                 onCancel={onCancel}
-                headerComponents={[...(isMobileLayout ? [GuideButton] : []), ...headerComponents]}
+                headerComponent={
+                    <>
+                        {isMobileLayout && (
+                            <Icon
+                                icon="LIGHTBULB"
+                                size={20}
+                                hoverColor={colors.TYPE_ORANGE}
+                                onClick={openGuide}
+                            />
+                        )}
+                        {headerComponent}
+                    </>
+                }
                 {...rest}
             />
         </ModalEnvironment>

--- a/packages/suite/src/components/suite/modals/ReduxModal/DeviceContextModal/DevicePromptModal.tsx
+++ b/packages/suite/src/components/suite/modals/ReduxModal/DeviceContextModal/DevicePromptModal.tsx
@@ -25,7 +25,7 @@ const StyledTrezorModal = styled(TrezorModal)`
     }
 
     ${Modal.Body} {
-        margin-top: ${({ headerComponents }) => !headerComponents?.length && '60px'};
+        margin-top: ${({ headerComponent }) => !headerComponent && '60px'};
         padding: 24px;
     }
 `;
@@ -53,7 +53,7 @@ const DevicePromptModalRenderer = ({
     const { device } = useDevice();
     const modalTarget = useModalTarget();
 
-    // duplicated because headerComponents should receive undefined if isAbortable === false
+    // duplicated because headerComponent should receive undefined if isAbortable === false
     const isActionAbortable = useSelector(selectIsActionAbortable) || isAbortable;
 
     const intl = useIntl();
@@ -79,11 +79,7 @@ const DevicePromptModalRenderer = ({
                         />
                     )
                 }
-                headerComponents={
-                    isActionAbortable
-                        ? [<AbortButton key="abort-button" onAbort={onAbort} />]
-                        : undefined
-                }
+                headerComponent={isActionAbortable ? <AbortButton onAbort={onAbort} /> : undefined}
                 {...rest}
             />
         </ModalEnvironment>


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->
Resolving some console warnings.

`headerComponents` in `Modal` was an array and React sometimes complained because its members didn't have a `key` prop. This can be observed in the `Downloading` component when updating Suite. I would like to know why it is triggered there and not in other modals, e.g. when `GuideButton` is rendered.

`CheckboxTitle` was a `p` which triggers a warning whenever a `div` is nested inside. This was the case whenever the EarlyAccessEnable modal was opened.

