### PR TITLE
feat(suite-native): discovery account labels

### DIFF
--- a/packages/suite/src/actions/wallet/coinjoinAccountActions.ts
+++ b/packages/suite/src/actions/wallet/coinjoinAccountActions.ts
@@ -592,9 +592,9 @@ export const createCoinjoinAccount =
 
         // create empty account
         const account = dispatch(
-            accountsActions.createAccount(
-                device!.state!,
-                {
+            accountsActions.createAccount({
+                deviceState: device!.state!,
+                discoveryItem: {
                     index: 0,
                     path,
                     unlockPath: unlockPath.payload,
@@ -605,12 +605,12 @@ export const createCoinjoinAccount =
                     derivationType: 0,
                     status: 'initial',
                 },
-                {
+                accountInfo: {
                     ...EMPTY_ACCOUNT_INFO,
                     descriptor: publicKey.payload.xpubSegwit || publicKey.payload.xpub,
                     legacyXpub: publicKey.payload.xpub,
                 },
-            ),
+            }),
         );
 
         log(`CoinjoinAccount created: ${getAccountProgressHandle(account.payload)}`);

--- a/suite-common/wallet-core/src/accounts/accountsActions.ts
+++ b/suite-common/wallet-core/src/accounts/accountsActions.ts
@@ -29,57 +29,93 @@ const removeAccount = createAction(
     }),
 );
 
+type CreateAccountActionProps = {
+    deviceState: string;
+    discoveryItem: DiscoveryItem;
+    accountInfo: AccountInfo;
+    imported?: boolean;
+    accountLabel?: string;
+};
+
+type CreateIndexLabeledAccountActionProps = Omit<
+    CreateAccountActionProps,
+    'imported' | 'accountLabel'
+>;
+
+const composeCreateAccountActionPayload = ({
+    deviceState,
+    discoveryItem,
+    accountInfo,
+    imported,
+    accountLabel,
+}: CreateAccountActionProps): Account => ({
+    deviceState,
+    accountLabel,
+    imported,
+    index: discoveryItem.index,
+    path: discoveryItem.path,
+    unlockPath: discoveryItem.unlockPath,
+    descriptor: accountInfo.descriptor,
+    key: getAccountKey(accountInfo.descriptor, discoveryItem.coin, deviceState),
+    accountType: discoveryItem.accountType,
+    symbol: discoveryItem.coin,
+    empty: accountInfo.empty,
+    ...(discoveryItem.backendType === 'coinjoin'
+        ? {
+              backendType: 'coinjoin',
+              status: discoveryItem.status,
+          }
+        : {
+              backendType: discoveryItem.backendType,
+          }),
+    visible:
+        !accountInfo.empty ||
+        discoveryItem.accountType === 'coinjoin' ||
+        (discoveryItem.accountType === 'normal' && discoveryItem.index === 0),
+    balance: accountInfo.balance,
+    availableBalance: accountInfo.availableBalance,
+    formattedBalance: formatNetworkAmount(
+        // xrp `availableBalance` is reduced by reserve, use regular balance
+        discoveryItem.networkType === 'ripple' ? accountInfo.balance : accountInfo.availableBalance,
+        discoveryItem.coin,
+    ),
+    tokens: enhanceTokens(accountInfo.tokens),
+    addresses: enhanceAddresses(accountInfo, discoveryItem),
+    utxo: enhanceUtxo(accountInfo.utxo, discoveryItem.networkType, discoveryItem.index),
+    history: accountInfo.history,
+    metadata: {
+        key: accountInfo.legacyXpub || accountInfo.descriptor,
+    },
+    ...getAccountSpecific(accountInfo, discoveryItem.networkType),
+});
+
+const createIndexLabeledAccount = createAction(
+    `${actionPrefix}/createIndexLabeledAccount`,
+    ({
+        deviceState,
+        discoveryItem,
+        accountInfo,
+    }: CreateIndexLabeledAccountActionProps): { payload: Account } => ({
+        payload: composeCreateAccountActionPayload({ deviceState, discoveryItem, accountInfo }),
+    }),
+);
+
 const createAccount = createAction(
     `${actionPrefix}/createAccount`,
-    (
-        deviceState: string,
-        discoveryItem: DiscoveryItem,
-        accountInfo: AccountInfo,
-        imported?: boolean,
-        accountLabel?: string,
-    ): { payload: Account } => ({
-        payload: {
+    ({
+        deviceState,
+        discoveryItem,
+        accountInfo,
+        imported,
+        accountLabel,
+    }: CreateAccountActionProps): { payload: Account } => ({
+        payload: composeCreateAccountActionPayload({
             deviceState,
-            index: discoveryItem.index,
-            path: discoveryItem.path,
-            unlockPath: discoveryItem.unlockPath,
-            descriptor: accountInfo.descriptor,
-            key: getAccountKey(accountInfo.descriptor, discoveryItem.coin, deviceState),
-            accountType: discoveryItem.accountType,
-            symbol: discoveryItem.coin,
-            empty: accountInfo.empty,
-            ...(discoveryItem.backendType === 'coinjoin'
-                ? {
-                      backendType: 'coinjoin',
-                      status: discoveryItem.status,
-                  }
-                : {
-                      backendType: discoveryItem.backendType,
-                  }),
-            visible:
-                !accountInfo.empty ||
-                discoveryItem.accountType === 'coinjoin' ||
-                (discoveryItem.accountType === 'normal' && discoveryItem.index === 0),
-            balance: accountInfo.balance,
-            availableBalance: accountInfo.availableBalance,
-            formattedBalance: formatNetworkAmount(
-                // xrp `availableBalance` is reduced by reserve, use regular balance
-                discoveryItem.networkType === 'ripple'
-                    ? accountInfo.balance
-                    : accountInfo.availableBalance,
-                discoveryItem.coin,
-            ),
-            tokens: enhanceTokens(accountInfo.tokens),
-            addresses: enhanceAddresses(accountInfo, discoveryItem),
-            utxo: enhanceUtxo(accountInfo.utxo, discoveryItem.networkType, discoveryItem.index),
-            history: accountInfo.history,
-            metadata: {
-                key: accountInfo.legacyXpub || accountInfo.descriptor,
-            },
-            accountLabel,
+            discoveryItem,
+            accountInfo,
             imported,
-            ...getAccountSpecific(accountInfo, discoveryItem.networkType),
-        },
+            accountLabel,
+        }),
     }),
 );
 
@@ -160,6 +196,7 @@ export const accountsActions = {
     disposeAccount,
     removeAccount,
     createAccount,
+    createIndexLabeledAccount,
     updateAccount,
     renameAccount,
     updateSelectedAccount,

--- a/suite-common/wallet-core/src/accounts/accountsReducer.ts
+++ b/suite-common/wallet-core/src/accounts/accountsReducer.ts
@@ -77,6 +77,23 @@ export const prepareAccountsReducer = createReducerWithExtraDeps(
                 };
                 state.push(account);
             })
+            .addCase(accountsActions.createIndexLabeledAccount, (state, action) => {
+                const { deviceState, symbol } = action.payload;
+                const deviceNetworkAccounts = state.filter(
+                    account => account.deviceState === deviceState && account.symbol === symbol,
+                );
+
+                const indexOfLastAccount = deviceNetworkAccounts.length;
+                const networkName = networks[symbol].name;
+                const accountLabel = `${networkName} #${indexOfLastAccount + 1}`;
+
+                const account = {
+                    ...action.payload,
+                    accountLabel,
+                    history: enhanceHistory(action.payload.history),
+                };
+                state.push(account);
+            })
             .addCase(accountsActions.updateAccount, (state, action) => {
                 update(state, action.payload);
             })

--- a/suite-common/wallet-core/src/accounts/tests/accountsReducer.test.ts
+++ b/suite-common/wallet-core/src/accounts/tests/accountsReducer.test.ts
@@ -36,16 +36,16 @@ describe('Account Reducer', () => {
     it('Create account', () => {
         const store = initStore();
         store.dispatch(
-            accountsActions.createAccount(
-                'device-state',
-                {
+            accountsActions.createAccount({
+                deviceState: 'device-state',
+                discoveryItem: {
                     index: 0,
                     path: "m/84'/0'/0'",
                     accountType: 'normal',
                     networkType: 'bitcoin',
                     coin: 'btc',
                 },
-                {
+                accountInfo: {
                     descriptor: 'XPUB',
                     path: "m/84'/0'/0'",
                     empty: false,
@@ -58,7 +58,7 @@ describe('Account Reducer', () => {
                         unconfirmed: 0,
                     },
                 },
-            ),
+            }),
         );
         expect(store.getState().wallet.accounts.length).toEqual(1);
     });

--- a/suite-common/wallet-core/src/discovery/discoveryThunks.ts
+++ b/suite-common/wallet-core/src/discovery/discoveryThunks.ts
@@ -118,7 +118,13 @@ const handleProgressThunk = createThunk(
                 },
             ]);
         } else {
-            dispatch(accountsActions.createAccount(deviceState, item, response));
+            dispatch(
+                accountsActions.createAccount({
+                    deviceState,
+                    discoveryItem: item,
+                    accountInfo: response,
+                }),
+            );
         }
         // calculate progress
         const progress = dispatch(

--- a/suite-native/discovery/src/discoveryThunks.ts
+++ b/suite-native/discovery/src/discoveryThunks.ts
@@ -81,15 +81,11 @@ const discoverAccountsByDescriptorThunk = createThunk(
                 }
 
                 dispatch(
-                    accountsActions.createAccount(
+                    accountsActions.createIndexLabeledAccount({
+                        discoveryItem: bundleItem,
                         deviceState,
-                        bundleItem,
                         accountInfo,
-                        false,
-                        // TODO: name of newly created account will be handled in follow-up issue:
-                        // see more: https://github.com/trezor/trezor-suite/issues/9501
-                        bundleItem.descriptor,
-                    ),
+                    }),
                 );
             }
         }

--- a/suite-native/module-accounts-import/src/accountsImportThunks.ts
+++ b/suite-native/module-accounts-import/src/accountsImportThunks.ts
@@ -58,19 +58,19 @@ export const importAccountThunk = createThunk(
             const accountType = getAccountTypeFromDescriptor(accountInfo.descriptor, coin);
             const imported = true;
             dispatch(
-                accountsActions.createAccount(
+                accountsActions.createAccount({
                     deviceState,
-                    {
+                    discoveryItem: {
                         index: deviceNetworkAccounts.length, // indexed from 0
                         path: accountInfo?.path ?? '',
                         accountType,
                         networkType: networks[coin].networkType,
                         coin,
                     },
-                    { ...accountInfo },
+                    accountInfo,
                     imported,
                     accountLabel,
-                ),
+                }),
             );
         }
     },


### PR DESCRIPTION
Mobile app discovered accounts are labeled by name of the network and index.

Closes #9501
