### PR TITLE
fix(suite): eth send flow

### DIFF
--- a/packages/suite/src/components/suite/modals/ReduxModal/TransactionReviewModal/TransactionReviewOutputList/TransactionReviewOutputElement.tsx
+++ b/packages/suite/src/components/suite/modals/ReduxModal/TransactionReviewModal/TransactionReviewOutputList/TransactionReviewOutputElement.tsx
@@ -187,11 +187,17 @@ export const TransactionReviewOutputElement = forwardRef<
                                             <FormattedCryptoAmount
                                                 disableHiddenPlaceholder
                                                 value={line.value}
-                                                symbol={cryptoSymbol}
+                                                symbol={
+                                                    // TX fee is so far always paid in network native coin
+                                                    line.id !== 'fee' && token
+                                                        ? token.symbol
+                                                        : cryptoSymbol
+                                                }
                                             />
                                         )}
                                     </OutputValueWrapper>
-                                    {fiatVisible && (
+                                    {/* temporary solution until fiat value for ERC20 tokens will be fixed  */}
+                                    {fiatVisible && !(line.id !== 'fee' && token) && (
                                         <>
                                             <DotSeparatorWrapper>
                                                 <DotSeparator />

--- a/packages/suite/src/components/suite/modals/ReduxModal/TransactionReviewModal/TransactionReviewOutputList/TransactionReviewOutputList.tsx
+++ b/packages/suite/src/components/suite/modals/ReduxModal/TransactionReviewModal/TransactionReviewOutputList/TransactionReviewOutputList.tsx
@@ -185,16 +185,14 @@ export const TransactionReviewOutputList = ({
                             );
                         })}
 
-                        {!precomposedTx.token && (
-                            <TransactionReviewTotalOutput
-                                ref={totalRef}
-                                account={account}
-                                signedTx={signedTx}
-                                outputs={outputs}
-                                buttonRequestsCount={buttonRequestsCount}
-                                precomposedTx={precomposedTx}
-                            />
-                        )}
+                        <TransactionReviewTotalOutput
+                            ref={totalRef}
+                            account={account}
+                            signedTx={signedTx}
+                            outputs={outputs}
+                            buttonRequestsCount={buttonRequestsCount}
+                            precomposedTx={precomposedTx}
+                        />
                     </RightTopInner>
                 </RightTop>
                 <RightBottom>

--- a/suite-common/wallet-types/src/transaction.ts
+++ b/suite-common/wallet-types/src/transaction.ts
@@ -136,12 +136,14 @@ export type PrecomposedTransactionFinal =
           feeDifference?: typeof undefined;
           useNativeRbf?: typeof undefined;
           useDecreaseOutput?: typeof undefined;
+          isTokenKnown?: typeof undefined;
       })
     | (TxFinal & {
           prevTxid: string;
           feeDifference: string;
           useNativeRbf: boolean;
           useDecreaseOutput: boolean;
+          isTokenKnown?: boolean;
       });
 
 export type PrecomposedTransaction =


### PR DESCRIPTION
## Description

Align steps in send flow for Ethereum in Suite with steps on the actual device.

Also fixed that for ERC-20 we display only token address if there are no definitions for the particular token.

## Related Issue

Resolve #9567

# Notes for @trezor/qa 

- Please check send flow for all coins, not only ETH!
- Check it on all models T2T1/T2B1/T1B1
- Check latest FW first, but please verify that 2.6.0 and 2.5.3 are not more broken after those changes than on the production
- Cardano send flow is broken, but should not be broken more than on production. @AdamSchinzel promised an issue for that