### PR TITLE
Derivation path added in account details

### DIFF
--- a/packages/suite/src/support/messages.ts
+++ b/packages/suite/src/support/messages.ts
@@ -3662,6 +3662,15 @@ export default defineMessages({
         id: 'TR_ACCOUNT_DETAILS_TYPE_HEADER',
         defaultMessage: 'Account type',
     },
+    TR_ACCOUNT_DETAILS_PATH_HEADER: {
+        id: 'TR_ACCOUNT_DETAILS_PATH_HEADER',
+        defaultMessage: 'Derivation path',
+    },
+    TR_ACCOUNT_DETAILS_PATH_DESC: {
+        id: 'TR_ACCOUNT_DETAILS_PATH_DESC',
+        defaultMessage:
+            'Derivation path is a parameter according to which the Hierarchical Deterministic (HD) wallet derives individual keys within the tree of keys.',
+    },
     TR_ACCOUNT_TYPE_BIP84_DESC: {
         id: 'TR_ACCOUNT_TYPE_BIP84_DESC',
         defaultMessage:

--- a/packages/suite/src/views/wallet/details/index.tsx
+++ b/packages/suite/src/views/wallet/details/index.tsx
@@ -1,21 +1,22 @@
 import styled from 'styled-components';
 
 import {
+    getAccountTypeDesc,
     getAccountTypeName,
     getAccountTypeTech,
     getAccountTypeUrl,
     getAccountTypeDesc,
 } from '@suite-common/wallet-utils';
 import { P, variables } from '@trezor/components';
-import { HELP_CENTER_XPUB_URL } from '@trezor/urls';
 
-import { WalletLayout } from 'src/components/wallet';
-import { useDevice, useDispatch, useSelector } from 'src/hooks/suite';
 import { ActionButton, ActionColumn, Card, TextColumn, Translation } from 'src/components/suite';
 
-import { CARD_PADDING_SIZE } from 'src/constants/suite/layout';
+import { HELP_CENTER_BIP32_URL, HELP_CENTER_XPUB_URL } from '@trezor/urls';
 import { showXpub } from 'src/actions/wallet/publicKeyActions';
+import { WalletLayout } from 'src/components/wallet';
 import { NETWORKS } from 'src/config/wallet';
+import { CARD_PADDING_SIZE } from 'src/constants/suite/layout';
+import { useDevice, useDispatch, useSelector } from 'src/hooks/suite';
 import { CoinjoinLogs } from './CoinjoinLogs';
 import { CoinjoinSetup } from './CoinjoinSetup/CoinjoinSetup';
 import { RescanAccount } from './RescanAccount';
@@ -129,6 +130,18 @@ const Details = () => {
                             )}
                             <P size="tiny">
                                 (<Translation id={accountTypeTech} />)
+                            </P>
+                        </AccountTypeLabel>
+                    </Row>
+                    <Row>
+                        <TextColumn
+                            title={<Translation id="TR_ACCOUNT_DETAILS_PATH_HEADER" />}
+                            description={<Translation id="TR_ACCOUNT_DETAILS_PATH_DESC" />}
+                            buttonLink={HELP_CENTER_BIP32_URL}
+                        />
+                        <AccountTypeLabel>
+                            <P size="small" weight="medium">
+                                {account.path}
                             </P>
                         </AccountTypeLabel>
                     </Row>

--- a/packages/suite/src/views/wallet/details/index.tsx
+++ b/packages/suite/src/views/wallet/details/index.tsx
@@ -1,7 +1,6 @@
 import styled from 'styled-components';
 
 import {
-    getAccountTypeDesc,
     getAccountTypeName,
     getAccountTypeTech,
     getAccountTypeUrl,
@@ -44,10 +43,7 @@ const AccountTypeLabel = styled.div`
     line-height: 20px;
     text-align: center;
     min-width: 170px;
-
-    div:first-child {
-        margin-bottom: 8px;
-    }
+    gap: 8px;
 `;
 
 const StyledCard = styled(Card)`

--- a/packages/urls/src/urls.ts
+++ b/packages/urls/src/urls.ts
@@ -52,6 +52,7 @@ export const HELP_CENTER_FAILED_BACKUP_URL = 'https://trezor.io/support/a/trezor
 export const HELP_CENTER_ADVANCED_RECOVERY_URL =
     'https://trezor.io/learn/a/advanced-recovery-on-trezor-model-one';
 export const HELP_CENTER_XPUB_URL = 'https://trezor.io/learn/a/trezor-suite-app-public-keys-xpub';
+export const HELP_CENTER_BIP32_URL = 'https://trezor.io/learn/a/what-is-bip32';
 export const HELP_FIRMWARE_TYPE = 'https://trezor.io/learn/a/bitcoin-only-firmware-on-trezor';
 export const HELP_CENTER_ZERO_VALUE_ATTACKS =
     'https://trezor.io/support/a/address-poisoning-attacks';


### PR DESCRIPTION
Resolves: https://github.com/trezor/trezor-suite/issues/6781
- [x] Add Derivation path field between Account type and Public key (XPUB) fields.

Was already done:
- [x] Change the Account tab to Details tab

Missing part:
- [ ] ~Where Account tab is not present, create one. (e.g. ETH account)~
→ Not requested anymore
