### PR TITLE
Fix: handle when sharedworker is not available

### DIFF
--- a/packages/connect-iframe/src/index.ts
+++ b/packages/connect-iframe/src/index.ts
@@ -62,7 +62,9 @@ const handleMessage = (event: PostMessageEvent) => {
     };
 
     if (data.type === IFRAME.LOG && data.payload.prefix === '@trezor/connect-web') {
-        logWriterProxy.add(data.payload);
+        if (logWriterProxy) {
+            logWriterProxy.add(data.payload);
+        }
         return;
     }
 

--- a/packages/connect-iframe/src/logWriter.ts
+++ b/packages/connect-iframe/src/logWriter.ts
@@ -2,9 +2,30 @@
 import LogWorker from './sharedLoggerWorker';
 import { LogMessage, LogWriter } from '@trezor/connect/src/utils/debug';
 
-const logWorker = new LogWorker();
-logWorker.port.start();
+let logWorker: SharedWorker | undefined;
 
-export const logWriterFactory = (): LogWriter => ({
-    add: (message: LogMessage) => logWorker.port.postMessage({ type: 'add-log', data: message }),
-});
+// Check for SharedWorker support
+if (SharedWorker) {
+    try {
+        // Initialize LogWorker
+        logWorker = new LogWorker();
+        logWorker?.port?.start();
+    } catch (error) {
+        console.warn('Failed to initialize LogWorker:', error);
+    }
+} else {
+    console.warn('SharedWorker is not supported');
+}
+
+const logWriterFactory = (): LogWriter | undefined => {
+    if (logWorker) {
+        return {
+            add: (message: LogMessage) => {
+                logWorker?.port.postMessage({ type: 'add-log', data: message });
+            },
+        };
+    }
+    console.warn('Failed to initialize LogWorker');
+};
+
+export { logWriterFactory };

--- a/packages/connect-popup/src/utils/debug.ts
+++ b/packages/connect-popup/src/utils/debug.ts
@@ -1,10 +1,19 @@
 import { LogMessage, LogWriter, initLog } from '@trezor/connect/src/utils/debug';
 
 export const initSharedLogger = (workerSrc: string) => {
-    const worker = new SharedWorker(workerSrc);
-    worker.port.start();
-    const logWriter: LogWriter = {
-        add: (message: LogMessage) => worker.port.postMessage({ type: 'add-log', data: message }),
-    };
-    return initLog('@trezor/connect-popup', false, logWriter);
+    try {
+        if (!SharedWorker) {
+            throw new Error('SharedWorker is not supported');
+        }
+        const worker = new SharedWorker(workerSrc);
+        worker.port.start();
+        const logWriter: LogWriter = {
+            add: (message: LogMessage) =>
+                worker.port.postMessage({ type: 'add-log', data: message }),
+        };
+        return initLog('@trezor/connect-popup', false, logWriter);
+    } catch (error) {
+        console.warn('Failed to initialize LogWorker:', error);
+        return initLog('@trezor/connect-popup');
+    }
 };

--- a/packages/connect/src/core/index.ts
+++ b/packages/connect/src/core/index.ts
@@ -1025,7 +1025,10 @@ export class Core extends EventEmitter {
  * @returns {Promise<Core>}
  * @memberof Core
  */
-export const initCore = async (settings: ConnectSettings, logWriterFactory?: () => LogWriter) => {
+export const initCore = async (
+    settings: ConnectSettings,
+    logWriterFactory?: () => LogWriter | undefined,
+) => {
     if (logWriterFactory) {
         setLogWriter(logWriterFactory);
     }

--- a/packages/connect/src/utils/debug.ts
+++ b/packages/connect/src/utils/debug.ts
@@ -125,10 +125,12 @@ export const initLog = (prefix: string, enabled?: boolean, logWriter?: LogWriter
     return instance;
 };
 
-export const setLogWriter = (logWriterFactory: () => LogWriter) => {
+export const setLogWriter = (logWriterFactory: () => LogWriter | undefined) => {
     Object.keys(_logs).forEach(key => {
         writer = logWriterFactory();
-        _logs[key].setWriter(writer);
+        if (writer) {
+            _logs[key].setWriter(writer);
+        }
     });
 };
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Handling when shareworker is not available or for some reason it does not initialize properly.

I was not able to reproduce an environment where shareworker was not available and the rest of the connect/iframe/popup was working properly, those environment either disable `postMessages` making communication with iframe not work at all, or they fail (like in the case of disabling cookies in chromium) because `window.localstorage` was not available in popup.