### PR TITLE
feat(suite-native): device supported networks discovery

### DIFF
--- a/suite-native/config/src/supportedNetworks.ts
+++ b/suite-native/config/src/supportedNetworks.ts
@@ -22,20 +22,20 @@ export const mainnetsOrder: NetworkSymbol[] = [
 
 export const testnetsOrder: NetworkSymbol[] = ['test', 'regtest', 'tsep', 'tgor', 'tada', 'txrp'];
 
+export const supportedNetworkSymbols = Object.keys(networks) as NetworkSymbol[];
+export const supportedMainnetSymbols = getMainnets().map(network => network.symbol);
+
 // Currently not supported in suite native. When it needs to be supported, just remove this filter.
 const filterOutRipple = (network: NetworkSymbol) => network !== 'xrp' && network !== 'txrp';
 
-const networkSymbols = Object.keys(networks) as NetworkSymbol[];
-
-export const supportedNetworkSymbols = networkSymbols
+// These networks are enabled for xpub/address import in portfolio tracker.
+export const importEnabledNetworkSymbols = supportedNetworkSymbols
     .filter(network => !deprecatedNetworks.includes(network))
     .filter(filterOutRipple);
 
-export const supportedMainnets = getMainnets().filter(network =>
-    supportedNetworkSymbols.includes(network.symbol),
+export const importEnabledMainnets = getMainnets().filter(network =>
+    importEnabledNetworkSymbols.includes(network.symbol),
 );
-export const supportedTestnets = getTestnets().filter(network =>
-    supportedNetworkSymbols.includes(network.symbol),
+export const importEnabledTestnets = getTestnets().filter(network =>
+    importEnabledNetworkSymbols.includes(network.symbol),
 );
-
-export const supportedMainnetSymbols = supportedMainnets.map(network => network.symbol);

--- a/suite-native/module-accounts-import/src/components/SelectableNetworkList.tsx
+++ b/suite-native/module-accounts-import/src/components/SelectableNetworkList.tsx
@@ -5,8 +5,8 @@ import { Network, NetworkSymbol } from '@suite-common/wallet-config';
 import {
     mainnetsOrder,
     testnetsOrder,
-    supportedMainnets,
-    supportedTestnets,
+    importEnabledMainnets,
+    importEnabledTestnets,
 } from '@suite-native/config';
 
 import { SelectableNetworkItem } from './SelectableNetworkItem';
@@ -22,8 +22,8 @@ const sortNetworkItems = (networkItems: Network[], networkOrder: NetworkSymbol[]
         return aOrder - bOrder;
     }) as Network[];
 
-const sortedMainnetsNetworks = sortNetworkItems(supportedMainnets, mainnetsOrder);
-const sortedTestnetNetworks = sortNetworkItems(supportedTestnets, testnetsOrder);
+const sortedMainnetsNetworks = sortNetworkItems(importEnabledMainnets, mainnetsOrder);
+const sortedTestnetNetworks = sortNetworkItems(importEnabledTestnets, testnetsOrder);
 
 const NetworkItemSection = ({
     title,


### PR DESCRIPTION
Discovery now discovers even the network accounts that were previously not supported in suite mobile.

- all the old "deprecated" networks were tested, the account detail correctly display transactions and the graph works. 

Closes #9727 