### PR TITLE
Chore/metadata refactoring 6

### DIFF
--- a/suite-common/connect-init/src/connectInitThunks.ts
+++ b/suite-common/connect-init/src/connectInitThunks.ts
@@ -71,6 +71,7 @@ export const connectInitThunk = createThunk(
             'getOwnershipProof',
             'setBusy',
             'rebootToBootloader',
+            'cipherKeyValue',
         ] as const;
 
         wrappedMethods.forEach(key => {


### PR DESCRIPTION
cherry-picks from #9130 

- 659e69881d85c52f0d7d61823d672b4dd0992258 saving to long-term storage is now incorrect - it saves entire metadat object, which is not expected of course.
- 90589577a61a17c1a78c2c222737d29eccddef8d - just some related typo
- ab3659ef18606ecfa468268f2b4da2787a9be54e - cipherKeyValue should add lock. it has dialogue on device so it makes sense to block UI and buttons in this case too.   
 