### PR TITLE
Message system config for FW header change and fixed welcome layout

### DIFF
--- a/packages/suite/src/components/suite/Preloader/PrerequisiteScreen.tsx
+++ b/packages/suite/src/components/suite/Preloader/PrerequisiteScreen.tsx
@@ -7,6 +7,6 @@ interface PrerequisiteScreenProps {
 
 export const PrerequisiteScreen = ({ prerequisite }: PrerequisiteScreenProps) => (
     <WelcomeLayout>
-        <PrerequisitesGuide prerequisite={prerequisite} padded allowSwitchDevice />
+        <PrerequisitesGuide prerequisite={prerequisite} allowSwitchDevice />
     </WelcomeLayout>
 );

--- a/packages/suite/src/components/suite/PrerequisitesGuide/index.tsx
+++ b/packages/suite/src/components/suite/PrerequisitesGuide/index.tsx
@@ -1,10 +1,10 @@
 import { useMemo } from 'react';
 
-import styled, { css } from 'styled-components';
+import styled from 'styled-components';
 import { motion } from 'framer-motion';
 
 import { getStatus, deviceNeedsAttention } from '@suite-common/suite-utils';
-import { variables, motionEasing } from '@trezor/components';
+import { motionEasing } from '@trezor/components';
 import { selectDevicesCount, selectDevice } from '@suite-common/wallet-core';
 
 import { ConnectDevicePrompt } from 'src/components/suite';
@@ -27,23 +27,12 @@ import { DeviceDisconnectRequired } from './components/DeviceDisconnectRequired'
 
 const Wrapper = styled.div<{ padded?: boolean }>`
     display: flex;
+    flex: 1;
     flex-direction: column;
     align-items: center;
+    justify-content: center;
     max-width: 700px;
-
-    ${({ padded }) =>
-        padded &&
-        css`
-            margin-top: 20vh;
-
-            @media all and (max-height: ${variables.SCREEN_SIZE.MD}) {
-                margin-top: 5vh;
-            }
-
-            @media all and (max-height: ${variables.SCREEN_SIZE.SM}) {
-                margin-top: 0vh;
-            }
-        `}
+    margin-bottom: 66px;
 `;
 
 const TipsContainer = styled(motion.div)`
@@ -52,14 +41,12 @@ const TipsContainer = styled(motion.div)`
 
 interface PrerequisitesGuideProps {
     prerequisite: PrerequisiteType;
-    padded?: boolean;
     allowSwitchDevice?: boolean;
 }
 
 // PrerequisitesGuide is a shared component used in Preloader and Onboarding
 export const PrerequisitesGuide = ({
     prerequisite,
-    padded,
     allowSwitchDevice,
 }: PrerequisitesGuideProps) => {
     const device = useSelector(selectDevice);
@@ -106,7 +93,7 @@ export const PrerequisitesGuide = ({
     );
 
     return (
-        <Wrapper padded={padded}>
+        <Wrapper>
             <ConnectDevicePrompt
                 connected={!!device}
                 showWarning={!!(device && deviceNeedsAttention(getStatus(device)))}

--- a/packages/suite/src/views/onboarding/UnexpectedState/index.tsx
+++ b/packages/suite/src/views/onboarding/UnexpectedState/index.tsx
@@ -14,24 +14,19 @@ import IsSameDevice from './components/IsSameDevice';
 
 const Wrapper = styled.div`
     display: flex;
-    align-items: center;
+    flex: 1;
     flex-direction: column;
 `;
 
 interface UnexpectedStateProps {
     children: JSX.Element;
     prerequisite?: PrerequisiteType;
-    prerequisitesGuidePadded?: boolean;
 }
 
 /**
  * This component handles unexpected device states across various steps in the onboarding.
  */
-const UnexpectedState = ({
-    children,
-    prerequisite,
-    prerequisitesGuidePadded,
-}: UnexpectedStateProps) => {
+const UnexpectedState = ({ children, prerequisite }: UnexpectedStateProps) => {
     const device = useSelector(selectDevice);
     const { prevDevice, activeStepId, showPinMatrix } = useOnboarding();
     const activeStep = steps.find(s => s.id === activeStepId);
@@ -61,11 +56,9 @@ const UnexpectedState = ({
 
         // otherwise handle common prerequisite which are determined and passed as prop from Preloader component
         if (prerequisite && activeStep?.prerequisites?.includes(prerequisite)) {
-            return (
-                <PrerequisitesGuide prerequisite={prerequisite} padded={prerequisitesGuidePadded} />
-            );
+            return <PrerequisitesGuide prerequisite={prerequisite} />;
         }
-    }, [activeStep, prerequisite, isNotSameDevice, prerequisitesGuidePadded]);
+    }, [activeStep, prerequisite, isNotSameDevice]);
 
     const getPinComponent = () => {
         // After the PIN is set it may happen that it takes too long for an user to finish the onboarding process.

--- a/packages/suite/src/views/onboarding/index.tsx
+++ b/packages/suite/src/views/onboarding/index.tsx
@@ -27,11 +27,11 @@ type OnboardingProps = {
 export const Onboarding = ({ prerequisite }: OnboardingProps) => {
     const { activeStepId } = useOnboarding();
 
-    const [StepComponent, LayoutComponent, prerequisitesGuidePadded] = useMemo(() => {
+    const [StepComponent, LayoutComponent] = useMemo(() => {
         switch (activeStepId) {
             case STEP.ID_WELCOME_STEP:
                 // Welcome Layout with Connect device prompt and Analytics toggle
-                return [WelcomeStep, WelcomeLayout, true];
+                return [WelcomeStep, WelcomeLayout];
             case STEP.ID_FIRMWARE_STEP:
                 // Firmware installation
                 return [FirmwareStep, OnboardingLayout];
@@ -78,10 +78,7 @@ export const Onboarding = ({ prerequisite }: OnboardingProps) => {
     return (
         <LayoutComponent>
             {allowedModal && <ReduxModal {...allowedModal} />}
-            <UnexpectedState
-                prerequisite={prerequisite}
-                prerequisitesGuidePadded={prerequisitesGuidePadded}
-            >
+            <UnexpectedState prerequisite={prerequisite}>
                 <StepComponent />
             </UnexpectedState>
         </LayoutComponent>

--- a/packages/suite/src/views/onboarding/steps/SecurityCheck/SecurityCheck.tsx
+++ b/packages/suite/src/views/onboarding/steps/SecurityCheck/SecurityCheck.tsx
@@ -20,22 +20,6 @@ import { DeviceAuthenticity } from './DeviceAuthenticity';
 const StyledCard = styled(CollapsibleOnboardingCard)`
     max-width: ${MAX_WIDTH};
     padding: 16px;
-
-    /* compensate top margin from WelcomeStep wrapper only for this card, because it has lot of content */
-    @media all and (max-width: ${variables.SCREEN_SIZE.LG}) {
-        margin-top: -15vh;
-    }
-
-    @media all and (max-width: ${variables.SCREEN_SIZE.MD}) {
-        margin-top: -20vh;
-    }
-
-    @media all and (max-height: ${variables.SCREEN_SIZE.MD}) {
-        margin-top: -5vh;
-    }
-    @media all and (max-height: ${variables.SCREEN_SIZE.SM}) {
-        margin-top: 0vh;
-    }
 `;
 
 const Content = styled.div`

--- a/packages/suite/src/views/onboarding/steps/Welcome/index.tsx
+++ b/packages/suite/src/views/onboarding/steps/Welcome/index.tsx
@@ -1,24 +1,17 @@
 import styled from 'styled-components';
 
-import { variables } from '@trezor/components';
-
 import { MAX_WIDTH } from 'src/constants/suite/layout';
 import PreOnboardingSetup from './components/PreOnboardingSetup';
 
 const Wrapper = styled.div`
     display: flex;
+    flex: 1;
     flex-direction: column;
     align-items: center;
-    margin-top: 20vh;
+    justify-content: center;
     max-width: ${MAX_WIDTH};
     width: 100%;
-
-    @media all and (max-height: ${variables.SCREEN_SIZE.MD}) {
-        margin-top: 5vh;
-    }
-    @media all and (max-height: ${variables.SCREEN_SIZE.SM}) {
-        margin-top: 0vh;
-    }
+    margin-bottom: 66px;
 `;
 
 const WelcomeStep = () => (

--- a/suite-common/message-system/config/config.v1.json
+++ b/suite-common/message-system/config/config.v1.json
@@ -1,8 +1,159 @@
 {
     "version": 1,
-    "timestamp": "2023-10-13T00:00:00+00:00",
-    "sequence": 43,
+    "timestamp": "2023-10-25T00:00:00+00:00",
+    "sequence": 44,
     "actions": [
+        {
+            "conditions": [
+                {
+                    "duration": {
+                        "from": "2023-10-24T00:00:00+00:00",
+                        "to": "2023-11-15T12:00:00+00:00"
+                    },
+                    "environment": {
+                        "desktop": "23.10.1",
+                        "mobile": "!",
+                        "web": "23.10.1"
+                    },
+                    "devices": [
+                        {
+                            "model": "T2B1",
+                            "firmware": "*",
+                            "bootloader": "*",
+                            "variant": "*",
+                            "firmwareRevision": "*",
+                            "vendor": "*"
+                        }
+                    ]
+                }
+            ],
+            "message": {
+                "id": "e96a586f-f2d7-4c7b-7dd9-d8e56d1c90ad",
+                "priority": 92,
+                "dismissible": true,
+                "variant": "warning",
+                "category": "banner",
+                "content": {
+                    "en-GB": "When the next Trezor device update rolls out, make sure you've got your recovery seed ready. You’ll need it to regain access to your coins.",
+                    "en": "When the next Trezor device update rolls out, make sure you've got your recovery seed ready. You’ll need it to regain access to your coins.",
+                    "es": "Cuando salga la próxima actualización del dispositivo Trezor, asegúrate de tener preparada tu semilla de recuperación. La necesitarás para recuperar el acceso a tus monedas.",
+                    "cs": "Až se objeví další aktualizace zařízení Trezor, nezapomeňte si připravit sadu pro obnovení. Budete ho potřebovat k obnovení přístupu k mincím.",
+                    "ru": "Когда выйдет следующее обновление устройства Trezor, убедитесь, что у вас наготове семя восстановления. Она понадобится для восстановления доступа к монетам.",
+                    "ja": "次のTrezorデバイスのアップデートがリリースされたら、リカバリーシードを準備しておいてください。コインへのアクセスを回復するために必要です。",
+                    "hu": "Amikor a következő Trezor készülékfrissítés megjelenik, győződjön meg róla, hogy készen áll a helyreállítási mag. Szükséged lesz rá, hogy újra hozzáférj az érméidhez.",
+                    "it": "Quando uscirà il prossimo aggiornamento del dispositivo Trezor, assicuratevi di avere pronto il seme di ripristino. Ne avrete bisogno per riavere accesso alle vostre monete."
+                }
+            }
+        },
+        {
+            "conditions": [
+                {
+                    "duration": {
+                        "from": "2023-11-15T12:00:00+00:00",
+                        "to": "2024-11-15T12:00:00+00:00"
+                    },
+                    "environment": {
+                        "desktop": "23.10.1",
+                        "mobile": "!",
+                        "web": "23.10.1"
+                    },
+                    "devices": [
+                        {
+                            "model": "T2B1",
+                            "firmware": "*",
+                            "bootloader": "*",
+                            "variant": "*",
+                            "firmwareRevision": "*",
+                            "vendor": "*"
+                        }
+                    ]
+                }
+            ],
+            "message": {
+                "id": "e16a586f-f2d7-4c7b-7dd9-d8e56d1c90ae",
+                "priority": 93,
+                "dismissible": false,
+                "variant": "critical",
+                "category": "banner",
+                "content": {
+                    "en-GB": "Essential update of Trezor Suite is required for your new Trezor Safe 3.",
+                    "en": "Essential update of Trezor Suite is required for your new Trezor Safe 3.",
+                    "es": "Se requiere una actualización esencial de Trezor Suite para su nuevo Trezor Safe 3.",
+                    "cs": "Pro nový Trezor Safe 3 je nutná aktualizace Trezor Suite.",
+                    "ru": "Для нового Trezor Safe 3 требуется обновление Trezor Suite.",
+                    "ja": "新しいTrezor Safe 3を使用するには、Trezor Suiteの必須アップデートが必要です。",
+                    "hu": "A Trezor Suite alapvető frissítése szükséges az új Trezor Safe 3 készülékhez.",
+                    "it": "Per il nuovo Trezor Safe 3 è necessario un aggiornamento essenziale di Trezor Suite."
+                },
+                "cta": {
+                    "action": "internal-link",
+                    "link": "settings-index",
+                    "anchor": "@general-settings/version-with-update",
+                    "label": {
+                        "en-GB": "Update Suite",
+                        "en": "Update Suite",
+                        "es": "Actualizar Suite",
+                        "cs": "Aktualizovat Suite",
+                        "ru": "Обновить Suite",
+                        "ja": "Suiteのアップデート",
+                        "hu": "Frissítés Suite",
+                        "it": "Suite di aggiornamento"
+                    }
+                }
+            }
+        },
+        {
+            "conditions": [
+                {
+                    "environment": {
+                        "desktop": ">23.10.1",
+                        "mobile": "!",
+                        "web": ">23.10.1"
+                    },
+                    "devices": [
+                        {
+                            "model": "T2B1",
+                            "firmware": "<2.6.3",
+                            "bootloader": "*",
+                            "variant": "*",
+                            "firmwareRevision": "*",
+                            "vendor": "*"
+                        }
+                    ]
+                }
+            ],
+            "message": {
+                "id": "e11a586f-f2d7-4c7b-7dd9-d8f56d1c90ad",
+                "priority": 92,
+                "dismissible": false,
+                "variant": "critical",
+                "category": "banner",
+                "content": {
+                    "en-GB": "An update is available for your Trezor device. Make sure you’ve got your recovery seed ready as you’ll need it to regain access to your coins.",
+                    "en": "An update is available for your Trezor device. Make sure you’ve got your recovery seed ready as you’ll need it to regain access to your coins.",
+                    "es": "Hay una actualización disponible para tu dispositivo Trezor. Asegúrate de tener preparada tu semilla de recuperación, ya que la necesitarás para recuperar el acceso a tus monedas.",
+                    "cs": "Pro zařízení Trezor je k dispozici aktualizace. Ujistěte se, že máte připravený recovery seed, protože jej budete potřebovat k obnovení přístupu k mincím.",
+                    "ru": "Для устройства Trezor доступно обновление. Убедитесь, что у вас наготове семена восстановления, поскольку они понадобятся для восстановления доступа к монетам.",
+                    "ja": "お使いのTrezorデバイスにアップデートが提供されています。コインへのアクセスを回復するにはリカバリーのシードが必要です。",
+                    "hu": "Frissítés érhető el a Trezor készülékéhez. Győződjön meg róla, hogy készenlétben tartja a helyreállítási magot, mivel szüksége lesz rá, hogy újra hozzáférjen az érméihez.",
+                    "it": "È disponibile un aggiornamento per il vostro dispositivo Trezor. Assicuratevi di avere pronto il seme di ripristino, che vi servirà per riavere accesso alle monete."
+                },
+                "cta": {
+                    "action": "internal-link",
+                    "link": "firmware-index",
+                    "label": {
+                        "en-GB": "Update now",
+                        "en": "Update now",
+                        "es": "Actualizar ahora",
+                        "cs": "Aktualizovat teď",
+                        "ru": "Обновить сейчас",
+                        "ja": "今すぐアップデート",
+                        "hu": "Frissítés most",
+                        "it": "Aggiorna ora"
+                    }
+                }
+            }
+        },
         {
             "conditions": [
                 {

--- a/suite-common/message-system/config/config.v1.json
+++ b/suite-common/message-system/config/config.v1.json
@@ -343,7 +343,7 @@
                 }
             ],
             "message": {
-                "id": "a99d0ad4-3bab-4660-9352-fh1d6518153f",
+                "id": "a99d0ad4-3bab-4660-9352-fh1d6518154a",
                 "priority": 91,
                 "dismissible": true,
                 "variant": "warning",
@@ -359,17 +359,18 @@
                     "it": "Aggiornate Trezor Suite per ottenere una maggiore sicurezza, tutte le funzioni più recenti e per far funzionare tutto nel modo più fluido possibile."
                 },
                 "cta": {
-                    "action": "external-link",
-                    "link": "https://trezor.io/trezor-suite",
+                    "action": "internal-link",
+                    "link": "settings-index",
+                    "anchor": "@general-settings/version-with-update",
                     "label": {
-                        "en-GB": "Go to trezor.io/trezor-suite",
-                        "en": "Go to trezor.io/trezor-suite",
-                        "es": "Ir a trezor.io/trezor-suite",
-                        "cs": "Přejít na trezor.io/trezor-suite",
-                        "ru": "Перейти на trezor.io/trezor-suite",
-                        "ja": "trezor.io/trezor-suite に移動",
-                        "hu": "Tovább a trezor.io/trezor-suite oldalra",
-                        "it": "Vai a trezor.io/trezor-suite"
+                        "en-GB": "Update Suite",
+                        "en": "Update Suite",
+                        "es": "Actualizar Suite",
+                        "cs": "Aktualizovat Suite",
+                        "ru": "Обновить Suite",
+                        "ja": "Suiteのアップデート",
+                        "hu": "Frissítés Suite",
+                        "it": "Suite di aggiornamento"
                     }
                 }
             }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Updating the T2B1 FW from 2.6.2 to 2.6.3 will wipe any previously stored seed.

<details>
  <summary>3 new messages:</summary>
  
1. **Suite ≤ 23.10 w/ and w/o TS3 2.6.2 FW ~ pre November 15** 
yellow, dismissable
- When the next Trezor device update rolls out, make sure you've got your recovery seed ready. You’ll need it to regain access to your coins.
- CS: Až se objeví další aktualizace zařízení Trezor, nezapomeňte si připravit sadu pro obnovení. Budete ho potřebovat k obnovení přístupu k mincím.
- ES: Cuando salga la próxima actualización del dispositivo Trezor, asegúrate de tener preparada tu semilla de recuperación. La necesitarás para recuperar el acceso a tus monedas.
- JA: 次のTrezorデバイスのアップデートがリリースされたら、リカバリーシードを準備しておいてください。コインへのアクセスを回復するために必要です。
- IT: Quando uscirà il prossimo aggiornamento del dispositivo Trezor, assicuratevi di avere pronto il seme di ripristino. Ne avrete bisogno per riavere accesso alle vostre monete.
- HU: Amikor a következő Trezor készülékfrissítés megjelenik, győződjön meg róla, hogy készen áll a helyreállítási mag. Szükséged lesz rá, hogy újra hozzáférj az érméidhez.
- RU: Когда выйдет следующее обновление устройства Trezor, убедитесь, что у вас наготове семя восстановления. Она понадобится для восстановления доступа к монетам.

2. **Suite ≤ 23.10 w/ and w/o TS3 2.6.2 FW ~ after November 15**
red, non-dismissable
- Essential update of Trezor Suite is required for your new Trezor Safe 3.
- CS: Pro nový Trezor Safe 3 je nutná základní aktualizace sady Trezor Suite.
- ES: Se requiere una actualización esencial de Trezor Suite para su nuevo Trezor Safe 3.
- JA: 新しいTrezor Safe 3を使用するには、Trezor Suiteの必須アップデートが必要です。
- IT: Per il nuovo Trezor Safe 3 è necessario un aggiornamento essenziale di Trezor Suite.
- HU: A Trezor Suite alapvető frissítése szükséges az új Trezor Safe 3 készülékhez.
- RU: Для нового Trezor Safe 3 требуется обновление Trezor Suite.

3. **Suite ≥ 23.11 w/ TS3 2.6.2 FW**
red, non-dismissable
-  An update is available for your Trezor device. Make sure you’ve got your recovery seed ready as you’ll need it to regain access to your coins.
- CS: Pro zařízení Trezor je k dispozici aktualizace. Ujistěte se, že máte připravený recovery seed, protože jej budete potřebovat k obnovení přístupu k mincím.
- ES: Hay una actualización disponible para tu dispositivo Trezor. Asegúrate de tener preparada tu semilla de recuperación, ya que la necesitarás para recuperar el acceso a tus monedas.
- JA: お使いのTrezorデバイスにアップデートが提供されています。コインへのアクセスを回復するにはリカバリーのシードが必要です。
- IT: È disponibile un aggiornamento per il vostro dispositivo Trezor. Assicuratevi di avere pronto il seme di ripristino, che vi servirà per riavere accesso alle monete.
- HU: Frissítés érhető el a Trezor készülékéhez. Győződjön meg róla, hogy készenlétben tartja a helyreállítási magot, mivel szüksége lesz rá, hogy újra hozzáférjen az érméihez.
- RU: Для устройства Trezor доступно обновление. Убедитесь, что у вас наготове семена восстановления, поскольку они понадобятся для восстановления доступа к монетам.
</details>

 \+ Fix vertical alignment on welcome screen to work with banner.
 I found out during testing, that security check and other welcome screen components can't scroll to the very bottom on smaller screen heights when there is banner shown on top. I removed top 20vh top-margin completely because it had to have lot of workarounds and align everything on center instead.

## Related Issue

Notion description
https://www.notion.so/satoshilabs/Copy-TS3-FW-wiping-update-d1937c3b0f39476286f043065727bdf0?pvs=4

message system requests overview:
https://www.notion.so/satoshilabs/Secure-message-system-5ade512cbd38481f9d5f65f03dbfd9a8?pvs=4

## Screenshots:
1. Suite ≤ 23.10 w/ and w/o TS3 2.6.2 FW ~ pre November 15:
<img width="815" alt="image" src="https://github.com/trezor/trezor-suite/assets/3729633/9029494c-77f1-48c3-bbda-c76f1f6bbd98">
<img width="1473" alt="image" src="https://github.com/trezor/trezor-suite/assets/3729633/56403996-7178-4b9a-97be-9fdb27c6fff6">

2. Suite ≤ 23.10 w/ and w/o TS3 2.6.2 FW ~ after November 15:
<img width="1477" alt="image" src="https://github.com/trezor/trezor-suite/assets/3729633/f7ad6f9d-b7b0-4d7e-80b9-3cef84472621">


3. Suite ≥ 23.11 w/ TS3 2.6.2 FW:
<img width="1210" alt="image" src="https://github.com/trezor/trezor-suite/assets/3729633/900a0f50-85b0-4e07-a67c-dc025be9ad2b">

