### PR TITLE
Fix FW update flow for BTC-only devices

### DIFF
--- a/packages/connect/src/device/Device.ts
+++ b/packages/connect/src/device/Device.ts
@@ -544,8 +544,13 @@ export class Device extends TypedEmitter<DeviceEvents> {
         this.features = feat;
         this.featuresNeedsReload = false;
 
-        // Firmware type is unknown in bootloader mode
-        if (this.getMode() !== 'bootloader') {
+        // Vendor headers have been changed in 2.6.3.
+        if (feat.fw_vendor === 'Trezor Bitcoin-only') {
+            this.firmwareType = FirmwareType.BitcoinOnly;
+        } else if (feat.fw_vendor === 'Trezor') {
+            this.firmwareType = FirmwareType.Regular;
+        } else if (this.getMode() !== 'bootloader') {
+            // Relevant for T1B1, T2T1 and custom firmware with a different vendor header. Capabilities do not work in bootloader mode.
             this.firmwareType =
                 feat.capabilities &&
                 feat.capabilities.length > 0 &&

--- a/packages/device-utils/src/firmwareUtils.ts
+++ b/packages/device-utils/src/firmwareUtils.ts
@@ -19,7 +19,10 @@ export const getFirmwareVersion = (device?: Device) => {
     return `${features.major_version}.${features.minor_version}.${features.patch_version}`;
 };
 
+// This can give a false negative in bootloader mode for T1B1 and T2T1.
 export const hasBitcoinOnlyFirmware = (device?: Device) =>
     device?.firmwareType === FirmwareType.BitcoinOnly;
 
-export const isBitcoinOnlyDevice = (device?: Device) => device?.features?.unit_btconly;
+// Bitcoin-only device with Universal firmware is treated as a regular device.
+export const isBitcoinOnlyDevice = (device?: Device) =>
+    !!device?.features?.unit_btconly && device?.firmwareType !== FirmwareType.Regular;

--- a/packages/suite/src/components/firmware/FirmwareInitial.tsx
+++ b/packages/suite/src/components/firmware/FirmwareInitial.tsx
@@ -159,17 +159,16 @@ export const FirmwareInitial = ({
         currentFwVersion &&
         availableFwVersion === currentFwVersion
     );
-    const bitcoinOnlyDevice = isBitcoinOnlyDevice(device);
-    const isCurrentlyBitcoinOnly = hasBitcoinOnlyFirmware(device) || bitcoinOnlyDevice;
+    const isCurrentlyBitcoinOnly = hasBitcoinOnlyFirmware(device);
     const targetFirmwareType =
-        // switching to Regular
-        (isCurrentlyBitcoinOnly && shouldSwitchFirmwareType) ||
-        // updating Regular
-        (!isCurrentlyBitcoinOnly && !shouldSwitchFirmwareType) ||
-        // attempting to switch to Bitcoin-only from old firmware
-        (!isCurrentlyBitcoinOnly && shouldSwitchFirmwareType && !isBitcoinOnlyAvailable)
-            ? FirmwareType.Regular
-            : FirmwareType.BitcoinOnly;
+        // updating Bitcoin-only
+        (isCurrentlyBitcoinOnly && !shouldSwitchFirmwareType) ||
+        // switching to Bitcoin-only
+        (!isCurrentlyBitcoinOnly && shouldSwitchFirmwareType && isBitcoinOnlyAvailable) ||
+        // Bitcoin-only device
+        isBitcoinOnlyDevice(device)
+            ? FirmwareType.BitcoinOnly
+            : FirmwareType.Regular;
 
     const installFirmware = (type: FirmwareType) => {
         onInstall(type);
@@ -196,7 +195,10 @@ export const FirmwareInitial = ({
                 </Description>
             ),
             body: cachedDevice?.firmwareRelease ? (
-                <FirmwareOffer device={cachedDevice} />
+                <FirmwareOffer
+                    device={cachedDevice}
+                    targetFirmwareType={FirmwareType.BitcoinOnly}
+                />
             ) : undefined,
             innerActions: (
                 <ButtonRow>

--- a/packages/suite/src/components/firmware/FirmwareOffer.tsx
+++ b/packages/suite/src/components/firmware/FirmwareOffer.tsx
@@ -2,7 +2,7 @@ import styled from 'styled-components';
 
 import { getFwUpdateVersion, parseFirmwareChangelog } from '@suite-common/suite-utils';
 import { Icon, Tooltip, variables } from '@trezor/components';
-import { getFirmwareVersion, isBitcoinOnlyDevice } from '@trezor/device-utils';
+import { getFirmwareVersion } from '@trezor/device-utils';
 import { AcquiredDevice } from '@suite-common/suite-types';
 import { FirmwareType } from '@trezor/connect';
 
@@ -63,20 +63,12 @@ export const FirmwareOffer = ({
         ? null
         : parseFirmwareChangelog(device.firmwareRelease?.release);
 
-    const firmwareType =
-        device.firmwareType ||
-        (isBitcoinOnlyDevice(device) ? FirmwareType.BitcoinOnly : FirmwareType.Regular);
-
-    const currentFirmwareType = getSuiteFirmwareTypeString(firmwareType);
-
-    // firmware type is undefined in bootloader on non-btc-only devices, regular type will be installed by default
-    const futureFirmwareType = getSuiteFirmwareTypeString(
-        targetFirmwareType || targetType || FirmwareType.Regular,
-    );
+    const currentFirmwareType = getSuiteFirmwareTypeString(device.firmwareType);
+    const futureFirmwareType = getSuiteFirmwareTypeString(targetFirmwareType || targetType);
 
     const nextVersionElement = (
         <Version isNew data-test="@firmware/offer-version/new">
-            <Translation id={futureFirmwareType!} />
+            {futureFirmwareType ? translationString(futureFirmwareType) : ''}
             {nextVersion ? ` ${nextVersion}` : ''}
             {useDevkit ? ' DEVKIT' : ''}
         </Version>

--- a/packages/suite/src/views/settings/device/FirmwareTypeChange.tsx
+++ b/packages/suite/src/views/settings/device/FirmwareTypeChange.tsx
@@ -14,7 +14,6 @@ import {
 } from '@trezor/device-utils';
 import { HELP_FIRMWARE_TYPE } from '@trezor/urls';
 import { getSuiteFirmwareTypeString } from 'src/utils/firmware';
-import { FirmwareType } from '@trezor/connect';
 
 const Version = styled.div`
     span {
@@ -42,9 +41,7 @@ export const FirmwareTypeChange = ({ isDeviceLocked }: FirmwareTypeProps) => {
 
     const bitcoinOnlyDevice = isBitcoinOnlyDevice(device);
     const currentFwVersion = getFirmwareVersion(device);
-    const currentFwType = getSuiteFirmwareTypeString(
-        device.firmwareType || (bitcoinOnlyDevice ? FirmwareType.BitcoinOnly : undefined),
-    );
+    const currentFwType = getSuiteFirmwareTypeString(device.firmwareType);
     const actionButtonId = hasBitcoinOnlyFirmware(device)
         ? 'TR_SWITCH_TO_REGULAR'
         : 'TR_SWITCH_TO_BITCOIN_ONLY';


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->
Bitcoin-only device with Universal firmware should offer updates for Universal firmware, not Bitcoin-only, and it should behave the same as a regular device in every way.

Suite (connect) should always recognize current firmware type except in the following cases:
- T1, TT or custom firmware in bootloader mode (in that case, Universal firmware is offered for update)
- TS3 with FW <2.6.3 in bootloader mode (in that case, firmware is offered based on device type (BTC-only or regular)

**QA**: Please test FW install, update and switch on a BTC-only TS3 with 2.6.3 fw (Universal firmware can be installed via custom firmware installation). Would be nice to test with other devices as well.

## Screenshots
Also a minor fix in `FirmwareOffer`, it previously said `Universal` when the user was about to install Bitcoin-only firmware in onboarding.
![Screenshot 2023-10-26 at 15 53 32](https://github.com/trezor/trezor-suite/assets/42465546/78f32f84-2bea-4512-9443-19fc0d948517)

![Screenshot 2023-10-26 at 16 20 50](https://github.com/trezor/trezor-suite/assets/42465546/7005da15-17fb-4ee4-9656-4bace4fc9222)

