### PR TITLE
Fix/app start blockchain init

### DIFF
--- a/suite-native/app/src/initActions.ts
+++ b/suite-native/app/src/initActions.ts
@@ -26,7 +26,7 @@ export const applicationInit = createThunk(
 
             dispatch(setIsConnectInitialized(true));
 
-            dispatch(initBlockchainThunk()).unwrap();
+            await dispatch(initBlockchainThunk()).unwrap();
 
             dispatch(
                 periodicFetchFiatRatesThunk({

--- a/suite-native/app/src/initActions.ts
+++ b/suite-native/app/src/initActions.ts
@@ -22,11 +22,11 @@ export const applicationInit = createThunk(
             // TODO: uncomment or revert commit when UI is ready for message system
             // dispatch(initMessageSystemThunk({ jwsPublicKey: getJWSPublicKey() }));
 
-            await dispatch(connectInitThunk()).unwrap();
+            await dispatch(connectInitThunk());
 
             dispatch(setIsConnectInitialized(true));
 
-            await dispatch(initBlockchainThunk()).unwrap();
+            await dispatch(initBlockchainThunk());
 
             dispatch(
                 periodicFetchFiatRatesThunk({


### PR DESCRIPTION
Await the initialization thunk of the blockchains to ensure they are ready to be used when the logic utilizing them is executed.

Closes #9646 