### PR TITLE
fix(connect): support unknown (custom) internal_models

### DIFF
--- a/packages/connect/src/api/common/__fixtures__/paramsValidator.ts
+++ b/packages/connect/src/api/common/__fixtures__/paramsValidator.ts
@@ -217,7 +217,7 @@ export const getFirmwareRange = [
         params: [
             'signTransaction',
             {
-                support: { T1B1: null, T2T1: '2.1.0', T2B1: '2.6.1' },
+                support: { T1B1: false, T2T1: '2.1.0', T2B1: '2.6.1' },
                 shortcut: 'btc',
                 type: 'bitcoin',
             },
@@ -234,7 +234,11 @@ export const getFirmwareRange = [
         config: EMPTY_CONFIG,
         params: [
             'signTransaction',
-            { support: { T1B1: '1.6.2' }, shortcut: 'btc', type: 'bitcoin' },
+            {
+                support: { T1B1: '1.6.2', T2T1: false, T2B1: false },
+                shortcut: 'btc',
+                type: 'bitcoin',
+            },
             DEFAULT_RANGE,
         ],
         result: {

--- a/packages/connect/src/api/common/paramsValidator.ts
+++ b/packages/connect/src/api/common/paramsValidator.ts
@@ -108,13 +108,15 @@ export const getFirmwareRange = (
     // set minimum required firmware from coins.json (coinInfo)
     if (coinInfo) {
         models.forEach(model => {
-            if (!coinInfo.support || typeof coinInfo.support[model] !== 'string') {
+            const supportVersion = coinInfo.support ? coinInfo.support[model] : false;
+            if (supportVersion === false) {
                 range[model].min = '0';
             } else if (
                 range[model].min !== '0' &&
-                versionUtils.isNewer(coinInfo.support[model], range[model].min)
+                typeof supportVersion === 'string' &&
+                versionUtils.isNewer(supportVersion, range[model].min)
             ) {
-                range[model].min = coinInfo.support[model];
+                range[model].min = supportVersion;
             }
         });
     }

--- a/packages/connect/src/core/AbstractMethod.ts
+++ b/packages/connect/src/core/AbstractMethod.ts
@@ -261,6 +261,10 @@ export abstract class AbstractMethod<Name extends CallMethodPayload['method'], P
         if (device.firmwareStatus === 'none') {
             return UI.FIRMWARE_NOT_INSTALLED;
         }
+        if (!range) {
+            // range not known only for custom (unknown) models
+            return;
+        }
         if (range.min === '0') {
             return UI.FIRMWARE_NOT_SUPPORTED;
         }

--- a/packages/connect/src/data/firmwareInfo.ts
+++ b/packages/connect/src/data/firmwareInfo.ts
@@ -188,6 +188,10 @@ const getSafeReleases = ({ features, releases }: GetInfoProps) => {
  * @param releases
  */
 export const getInfo = ({ features, releases }: GetInfoProps): ReleaseInfo | null => {
+    if (!Array.isArray(releases)) {
+        // no available releases - should never happen for official firmware, only custom
+        return null;
+    }
     if (!isStrictFeatures(features)) {
         throw new Error('Features of unexpected shape provided.');
     }
@@ -245,8 +249,8 @@ export const getFirmwareStatus = (features: Features) => {
         releases: releases[features?.internal_model],
     });
 
-    // should not happen, possibly if releases list contains inconsistent data or so
-    if (!info) return 'unknown';
+    // should never happen for official firmware, see getInfo
+    if (!info) return 'custom';
 
     if (info.isRequired) return 'required';
 

--- a/packages/connect/src/device/Device.ts
+++ b/packages/connect/src/device/Device.ts
@@ -562,7 +562,10 @@ export class Device extends TypedEmitter<DeviceEvents> {
                     : FirmwareType.Regular;
         }
 
-        const deviceInfo = models[feat.internal_model];
+        const deviceInfo = models[feat.internal_model] ?? {
+            name: `Unknown ${feat.internal_model}`,
+            colors: {},
+        };
 
         this.name = deviceInfo.name;
 

--- a/packages/connect/src/types/coinInfo.ts
+++ b/packages/connect/src/types/coinInfo.ts
@@ -5,9 +5,9 @@ export type { Network } from '@trezor/utxo-lib';
 
 export interface CoinSupport {
     connect: boolean;
-    T1B1: string;
-    T2T1: string;
-    T2B1: string;
+    T1B1: string | false;
+    T2T1: string | false;
+    T2B1: string | false;
 }
 
 export interface BlockchainLink {

--- a/packages/connect/src/types/device.ts
+++ b/packages/connect/src/types/device.ts
@@ -5,7 +5,13 @@ export type DeviceStatus = 'available' | 'occupied' | 'used';
 
 export type DeviceMode = 'normal' | 'bootloader' | 'initialize' | 'seedless';
 
-export type DeviceFirmwareStatus = 'valid' | 'outdated' | 'required' | 'unknown' | 'none';
+export type DeviceFirmwareStatus =
+    | 'valid'
+    | 'outdated'
+    | 'required'
+    | 'unknown'
+    | 'custom'
+    | 'none';
 
 export type UnavailableCapability =
     | 'no-capability'


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Connecting unknown (custom or new) model fails on multiple places:
- firmwareRelease check
- deviceInfo (device name)
- getUnavailableCapabilities check
- AbstractMethod/checkFirmwareRange check
- paramsValidator/getFirmwareRange check

