### PR TITLE
feat(suite-native): blurred overlays reintroduced

### DIFF
--- a/suite-native/alerts/src/components/AlertSheet.tsx
+++ b/suite-native/alerts/src/components/AlertSheet.tsx
@@ -3,7 +3,8 @@ import { Modal, Pressable } from 'react-native';
 import Animated from 'react-native-reanimated';
 
 import { prepareNativeStyle, useNativeStyles } from '@trezor/styles';
-import { Button, Card, VStack, useBottomSheetAnimation, Pictogram } from '@suite-native/atoms';
+import { Button, Card, VStack, useBottomSheetAnimation, Pictogram, Box } from '@suite-native/atoms';
+import { BlurredScreenOverlay } from '@suite-native/screen-overlay';
 
 import { useShakeAnimation } from '../useShakeAnimation';
 import { Alert } from '../alertsAtoms';
@@ -43,12 +44,8 @@ export const AlertSheet = ({ alert }: AlertSheetProps) => {
     const { applyStyle } = useNativeStyles();
     const { runShakeAnimation, shakeAnimatedStyle } = useShakeAnimation();
 
-    const {
-        animatedSheetWithOverlayStyle,
-        animatedSheetWrapperStyle,
-        closeSheetAnimated,
-        openSheetAnimated,
-    } = useBottomSheetAnimation({ onClose: hideAlert, isVisible: true });
+    const { animatedSheetWrapperStyle, closeSheetAnimated, openSheetAnimated } =
+        useBottomSheetAnimation({ onClose: hideAlert, isVisible: true });
 
     useEffect(() => {
         openSheetAnimated();
@@ -78,7 +75,8 @@ export const AlertSheet = ({ alert }: AlertSheetProps) => {
 
     return (
         <Modal transparent visible={!!alert}>
-            <Animated.View style={[animatedSheetWithOverlayStyle, applyStyle(sheetOverlayStyle)]}>
+            <BlurredScreenOverlay />
+            <Box style={applyStyle(sheetOverlayStyle)}>
                 <Pressable onPress={runShakeAnimation} style={applyStyle(shakeTriggerStyle)}>
                     <Animated.View
                         style={[animatedSheetWrapperStyle, shakeAnimatedStyle]}
@@ -115,7 +113,7 @@ export const AlertSheet = ({ alert }: AlertSheetProps) => {
                         </Card>
                     </Animated.View>
                 </Pressable>
-            </Animated.View>
+            </Box>
         </Modal>
     );
 };

--- a/suite-native/app/package.json
+++ b/suite-native/app/package.json
@@ -68,6 +68,7 @@
         "@suite-native/navigation": "workspace:*",
         "@suite-native/notifications": "workspace:*",
         "@suite-native/receive": "workspace:*",
+        "@suite-native/screen-overlay": "workspace:*",
         "@suite-native/state": "workspace:*",
         "@suite-native/storage": "workspace:*",
         "@suite-native/theme": "workspace:*",

--- a/suite-native/app/src/App.tsx
+++ b/suite-native/app/src/App.tsx
@@ -15,6 +15,7 @@ import { NavigationContainerWithAnalytics } from '@suite-native/navigation';
 import { AuthenticatorProvider } from '@suite-native/biometrics';
 import { MessageSystemRenderer } from '@suite-native/message-system';
 import { IntlProvider } from '@suite-native/intl';
+import { ScreenshotProvider, ScreenshotCapturer } from '@suite-native/screen-overlay';
 
 import { RootStackNavigator } from './navigation/RootStackNavigator';
 import { StylesProvider } from './StylesProvider';
@@ -55,18 +56,22 @@ const AppComponent = () => {
 
     return (
         <FormatterProvider config={formattersConfig}>
-            <AuthenticatorProvider>
-                <AlertRenderer>
-                    <MessageSystemRenderer />
-                    {/* Notifications are disabled until the problem with after-import notifications flooding is solved. */}
-                    {/* More here: https://github.com/trezor/trezor-suite/issues/7721  */}
-                    {/* <NotificationRenderer> */}
-                    <ToastRenderer>
-                        <RootStackNavigator />
-                    </ToastRenderer>
-                    {/* </NotificationRenderer> */}
-                </AlertRenderer>
-            </AuthenticatorProvider>
+            <ScreenshotProvider>
+                <AuthenticatorProvider>
+                    <AlertRenderer>
+                        <MessageSystemRenderer />
+                        {/* Notifications are disabled until the problem with after-import notifications flooding is solved. */}
+                        {/* More here: https://github.com/trezor/trezor-suite/issues/7721  */}
+                        {/* <NotificationRenderer> */}
+                        <ToastRenderer>
+                            <ScreenshotCapturer>
+                                <RootStackNavigator />
+                            </ScreenshotCapturer>
+                        </ToastRenderer>
+                        {/* </NotificationRenderer> */}
+                    </AlertRenderer>
+                </AuthenticatorProvider>
+            </ScreenshotProvider>
         </FormatterProvider>
     );
 };

--- a/suite-native/app/src/navigation/RootStackNavigator.tsx
+++ b/suite-native/app/src/navigation/RootStackNavigator.tsx
@@ -39,7 +39,6 @@ export const RootStackNavigator = () => {
         }
         return RootStackRoutes.Onboarding;
     };
-
     return (
         <RootStack.Navigator
             initialRouteName={getInitialRouteName()}

--- a/suite-native/app/tsconfig.json
+++ b/suite-native/app/tsconfig.json
@@ -47,6 +47,7 @@
         { "path": "../navigation" },
         { "path": "../notifications" },
         { "path": "../receive" },
+        { "path": "../screen-overlay" },
         { "path": "../state" },
         { "path": "../storage" },
         { "path": "../theme" },

--- a/suite-native/atoms/package.json
+++ b/suite-native/atoms/package.json
@@ -16,6 +16,7 @@
         "@suite-common/wallet-config": "workspace:*",
         "@suite-common/wallet-types": "workspace:*",
         "@suite-native/intl": "workspace:^",
+        "@suite-native/screen-overlay": "workspace:*",
         "@suite-native/storage": "workspace:*",
         "@trezor/env-utils": "workspace:*",
         "@trezor/styles": "workspace:*",

--- a/suite-native/atoms/src/Sheet/BottomSheet.tsx
+++ b/suite-native/atoms/src/Sheet/BottomSheet.tsx
@@ -4,6 +4,7 @@ import Animated from 'react-native-reanimated';
 import { ScrollView, PanGestureHandler } from 'react-native-gesture-handler';
 
 import { prepareNativeStyle, useNativeStyles } from '@trezor/styles';
+import { BlurredScreenOverlay } from '@suite-native/screen-overlay';
 
 import { Box } from '../Box';
 import { BottomSheetContainer } from './BottomSheetContainer';
@@ -50,7 +51,6 @@ export const BottomSheet = ({
     const insets = useSafeAreaInsets();
     const [isCloseScrollEnabled, setIsCloseScrollEnabled] = useState(true);
     const {
-        animatedSheetWithOverlayStyle,
         animatedSheetWrapperStyle,
         closeSheetAnimated,
         openSheetAnimated,
@@ -81,9 +81,8 @@ export const BottomSheet = ({
 
     return (
         <BottomSheetContainer isVisible={isVisible} onClose={handleCloseSheet}>
-            <Animated.View
-                style={[animatedSheetWithOverlayStyle, applyStyle(sheetWithOverlayStyle)]}
-            >
+            <BlurredScreenOverlay />
+            <Box style={applyStyle(sheetWithOverlayStyle)}>
                 <PanGestureHandler
                     enabled={isCloseScrollEnabled}
                     ref={panGestureRef.current}
@@ -119,7 +118,7 @@ export const BottomSheet = ({
                         </ScrollView>
                     </Animated.View>
                 </PanGestureHandler>
-            </Animated.View>
+            </Box>
         </BottomSheetContainer>
     );
 };

--- a/suite-native/atoms/src/Sheet/useBottomSheetAnimation.ts
+++ b/suite-native/atoms/src/Sheet/useBottomSheetAnimation.ts
@@ -1,6 +1,5 @@
 import {
     Easing,
-    interpolateColor,
     runOnJS,
     useAnimatedGestureHandler,
     useAnimatedStyle,
@@ -11,7 +10,6 @@ import { useCallback, useEffect } from 'react';
 import { PanGestureHandlerGestureEvent } from 'react-native-gesture-handler';
 import { NativeScrollEvent } from 'react-native';
 
-import { useNativeStyles } from '@trezor/styles';
 import { getScreenHeight } from '@trezor/env-utils';
 
 type GestureHandlerContext = {
@@ -32,9 +30,7 @@ export const useBottomSheetAnimation = ({
     setIsCloseScrollEnabled?: (isCloseScrollEnabled: boolean) => void;
     isCloseScrollEnabled?: boolean;
 }) => {
-    const { utils } = useNativeStyles();
     const transparency = isVisible ? 1 : 0;
-    const colorOverlay = utils.transparentize(0.3, utils.colors.backgroundNeutralBold);
     const translatePanY = useSharedValue(SCREEN_HEIGHT);
     const animatedTransparency = useSharedValue(transparency);
 
@@ -44,17 +40,6 @@ export const useBottomSheetAnimation = ({
             easing: Easing.out(Easing.cubic),
         });
     }, [transparency, animatedTransparency]);
-
-    const animatedSheetWithOverlayStyle = useAnimatedStyle(
-        () => ({
-            backgroundColor: interpolateColor(
-                animatedTransparency.value,
-                [0, 1],
-                ['transparent', colorOverlay],
-            ),
-        }),
-        [transparency, animatedTransparency],
-    );
 
     const animatedSheetWrapperStyle = useAnimatedStyle(() => ({
         transform: [
@@ -130,7 +115,6 @@ export const useBottomSheetAnimation = ({
     });
 
     return {
-        animatedSheetWithOverlayStyle,
         animatedSheetWrapperStyle,
         closeSheetAnimated,
         openSheetAnimated,

--- a/suite-native/atoms/tsconfig.json
+++ b/suite-native/atoms/tsconfig.json
@@ -10,6 +10,7 @@
             "path": "../../suite-common/wallet-types"
         },
         { "path": "../intl" },
+        { "path": "../screen-overlay" },
         { "path": "../storage" },
         { "path": "../../packages/env-utils" },
         { "path": "../../packages/styles" },

--- a/suite-native/biometrics/package.json
+++ b/suite-native/biometrics/package.json
@@ -15,6 +15,7 @@
         "@suite-native/alerts": "workspace:*",
         "@suite-native/analytics": "workspace:*",
         "@suite-native/atoms": "workspace:*",
+        "@suite-native/screen-overlay": "workspace:*",
         "@suite-native/storage": "workspace:*",
         "@trezor/styles": "workspace:*",
         "expo-local-authentication": "13.7.0",

--- a/suite-native/biometrics/src/components/AuthenticatorProvider.tsx
+++ b/suite-native/biometrics/src/components/AuthenticatorProvider.tsx
@@ -15,7 +15,7 @@ export const AuthenticatorProvider = ({ children }: AuthenticatorProviderProps) 
     return (
         <>
             {children}
-            {isBiometricsOverlayVisible && <BiometricOverlay />}
+            <BiometricOverlay isDisplayed={isBiometricsOverlayVisible} />
         </>
     );
 };

--- a/suite-native/biometrics/src/components/BiometricOverlay.tsx
+++ b/suite-native/biometrics/src/components/BiometricOverlay.tsx
@@ -3,20 +3,36 @@ import { StyleSheet } from 'react-native';
 import { Box } from '@suite-native/atoms';
 import { prepareNativeStyle, useNativeStyles } from '@trezor/styles';
 import { Icon } from '@suite-common/icons';
+import { BlurredScreenOverlay } from '@suite-native/screen-overlay';
 
-const overlayWrapperStyle = prepareNativeStyle(utils => ({
+const overlayWrapperStyle = prepareNativeStyle((_, { isDisplayed }) => ({
     ...StyleSheet.absoluteFillObject,
     justifyContent: 'center',
     alignItems: 'center',
-    backgroundColor: utils.colors.backgroundTertiaryDefaultOnElevation0,
+
+    /* To ensure that the overlay is displayed correctly when the app goes to the `background` state, 
+    it is important to pre-render the content and set its visibility using the `display` style when necessary. 
+    This ensures that the content has enough time to render before the app transitions to the `background` state. 
+    Failing to do so would may result in a blank screen being displayed. */
+    extend: {
+        condition: !isDisplayed,
+        style: {
+            display: 'none',
+        },
+    },
 }));
 
-export const BiometricOverlay = () => {
+type BiometricsOverlayProps = {
+    isDisplayed: boolean;
+};
+
+export const BiometricOverlay = ({ isDisplayed }: BiometricsOverlayProps) => {
     const { applyStyle } = useNativeStyles();
 
     return (
-        <Box style={applyStyle(overlayWrapperStyle)}>
-            <Icon name="trezor" size="extraLarge" color="iconOnPrimary" />
+        <Box style={applyStyle(overlayWrapperStyle, { isDisplayed })}>
+            <BlurredScreenOverlay isDimmed={false} blurValue={15} />
+            <Icon name="trezor" customSize={70} color="iconDefault" />
         </Box>
     );
 };

--- a/suite-native/biometrics/tsconfig.json
+++ b/suite-native/biometrics/tsconfig.json
@@ -6,6 +6,7 @@
         { "path": "../alerts" },
         { "path": "../analytics" },
         { "path": "../atoms" },
+        { "path": "../screen-overlay" },
         { "path": "../storage" },
         { "path": "../../packages/styles" }
     ]

--- a/suite-native/screen-overlay/package.json
+++ b/suite-native/screen-overlay/package.json
@@ -1,5 +1,5 @@
 {
-    "name": "@suite-native/alerts",
+    "name": "@suite-native/screen-overlay",
     "version": "1.0.0",
     "private": true,
     "license": "See LICENSE.md in repo root",
@@ -7,16 +7,14 @@
     "main": "src/index",
     "scripts": {
         "lint:js": "yarn g:eslint '**/*.{ts,tsx,js}'",
+        "test:unit": "jest -c ../../jest.config.base.js --passWithNoTests",
         "type-check": "tsc --build"
     },
     "dependencies": {
-        "@suite-common/icons": "workspace:*",
-        "@suite-native/atoms": "workspace:*",
-        "@suite-native/screen-overlay": "workspace:*",
+        "@react-navigation/native": "^6.1.3",
+        "@shopify/react-native-skia": "0.1.214",
         "@trezor/styles": "workspace:*",
-        "jotai": "1.9.1",
         "react": "18.2.0",
-        "react-native": "0.71.3",
-        "react-native-reanimated": "3.5.4"
+        "react-native": "0.71.8"
     }
 }

--- a/suite-native/screen-overlay/src/components/BlurredScreenOverlay.tsx
+++ b/suite-native/screen-overlay/src/components/BlurredScreenOverlay.tsx
@@ -1,0 +1,78 @@
+import React, { useContext } from 'react';
+import { Dimensions, View, StyleSheet, StatusBar } from 'react-native';
+
+import { BackdropBlur, Canvas, Fill, Image } from '@shopify/react-native-skia';
+
+import { prepareNativeStyle, useNativeStyles } from '@trezor/styles';
+
+import { ScreenshotContext } from './ScreenshotProvider';
+
+const SCREEN_HEIGHT = Dimensions.get('window').height;
+const SCREEN_WIDTH = Dimensions.get('window').width;
+const STATUS_BAR_HEIGHT = StatusBar.currentHeight ?? 0;
+
+type BlurredScreenOverlayProps = {
+    isDimmed?: boolean;
+    blurValue?: number;
+};
+
+const canvasStyle = prepareNativeStyle(_ => ({
+    flex: 1,
+}));
+
+const overlayWrapperStyle = prepareNativeStyle(utils => ({
+    ...StyleSheet.absoluteFillObject,
+    justifyContent: 'center',
+    alignItems: 'center',
+    backgroundColor: utils.colors.backgroundTertiaryDefaultOnElevation0,
+}));
+
+const BlankScreenPlaceholder = () => {
+    const { applyStyle } = useNativeStyles();
+
+    return <View style={applyStyle(overlayWrapperStyle)} />;
+};
+
+export const BlurredScreenOverlay = ({
+    isDimmed = true,
+    blurValue = 4,
+}: BlurredScreenOverlayProps) => {
+    const {
+        applyStyle,
+        utils: { colors },
+    } = useNativeStyles();
+
+    const { screenshot } = useContext(ScreenshotContext);
+
+    /* If the screenshot is not ready yet (typically right after starting the app), display
+     a blank screen to prevent unauthorized user from seeing the content of the screen. */
+    if (!screenshot) return <BlankScreenPlaceholder />;
+
+    const overlayHeight = SCREEN_HEIGHT - STATUS_BAR_HEIGHT;
+
+    return (
+        <View style={StyleSheet.absoluteFillObject}>
+            <Canvas style={applyStyle(canvasStyle)}>
+                <Image
+                    image={screenshot}
+                    x={0}
+                    y={0}
+                    height={overlayHeight}
+                    width={SCREEN_WIDTH}
+                    fit="fill"
+                />
+                <BackdropBlur
+                    blur={blurValue}
+                    clip={{
+                        x: 0,
+                        y: 0,
+                        height: SCREEN_HEIGHT,
+                        width: SCREEN_WIDTH,
+                    }}
+                >
+                    {isDimmed && <Fill color={colors.backgroundNeutralBold} opacity={0.1} />}
+                </BackdropBlur>
+            </Canvas>
+        </View>
+    );
+};

--- a/suite-native/screen-overlay/src/components/ScreenshotCapturer.tsx
+++ b/suite-native/screen-overlay/src/components/ScreenshotCapturer.tsx
@@ -1,0 +1,28 @@
+import { useRef, useEffect, useContext } from 'react';
+import { View, StyleSheet } from 'react-native';
+
+import { useNavigation } from '@react-navigation/native';
+
+import { ScreenshotContext } from './ScreenshotProvider';
+
+export const ScreenshotCapturer = ({ children }: { children: React.ReactNode }) => {
+    const navigation = useNavigation();
+    const screenshotViewRef = useRef<View | null>(null);
+
+    const { takeScreenshot } = useContext(ScreenshotContext);
+
+    // Take screenshot on every navigation state change so it can be used for biometrics and other overlays later.
+    useEffect(() => {
+        const removeStateSubscription = navigation.addListener('state', () => {
+            takeScreenshot(screenshotViewRef);
+        });
+
+        return removeStateSubscription;
+    }, [navigation, takeScreenshot]);
+
+    return (
+        <View style={StyleSheet.absoluteFillObject} ref={screenshotViewRef}>
+            {children}
+        </View>
+    );
+};

--- a/suite-native/screen-overlay/src/components/ScreenshotProvider.tsx
+++ b/suite-native/screen-overlay/src/components/ScreenshotProvider.tsx
@@ -1,0 +1,37 @@
+import React, { createContext, MutableRefObject, useCallback, useMemo, useState } from 'react';
+import { View } from 'react-native';
+
+import { makeImageFromView, SkImage } from '@shopify/react-native-skia';
+
+const SNAPSHOT_TIMEOUT = 1000;
+
+export const ScreenshotContext = createContext<{
+    screenshot: SkImage | null;
+    takeScreenshot: (screenViewRef: MutableRefObject<View | null>) => void;
+}>({ screenshot: null, takeScreenshot: () => {} });
+
+export const ScreenshotProvider = ({ children }: { children: React.ReactNode }) => {
+    const [screenshot, setScreenshot] = useState<SkImage | null>(null);
+
+    const takeScreenshot = useCallback((screenViewRef: MutableRefObject<View | null>) => {
+        if (!screenViewRef) return;
+
+        // The timeout is needed because sometimes happens that the target view of the snapshot is already defined
+        // but the UI is not rendered yet. If you try to take snapshot in such situation, the Skia crashes the app.
+        // see more: https://github.com/Shopify/react-native-skia/discussions/1648
+        setTimeout(async () => {
+            const freshSnapshot = await makeImageFromView(screenViewRef);
+            setScreenshot(freshSnapshot);
+        }, SNAPSHOT_TIMEOUT);
+    }, []);
+
+    const contextValue = useMemo(
+        () => ({
+            screenshot,
+            takeScreenshot,
+        }),
+        [screenshot, takeScreenshot],
+    );
+
+    return <ScreenshotContext.Provider value={contextValue}>{children}</ScreenshotContext.Provider>;
+};

--- a/suite-native/screen-overlay/src/index.ts
+++ b/suite-native/screen-overlay/src/index.ts
@@ -1,0 +1,3 @@
+export { BlurredScreenOverlay } from './components/BlurredScreenOverlay';
+export { ScreenshotProvider } from './components/ScreenshotProvider';
+export { ScreenshotCapturer } from './components/ScreenshotCapturer';

--- a/suite-native/screen-overlay/tsconfig.json
+++ b/suite-native/screen-overlay/tsconfig.json
@@ -2,9 +2,6 @@
     "extends": "../../tsconfig.json",
     "compilerOptions": { "outDir": "libDev" },
     "references": [
-        { "path": "../../suite-common/icons" },
-        { "path": "../atoms" },
-        { "path": "../screen-overlay" },
         { "path": "../../packages/styles" }
     ]
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -8088,6 +8088,7 @@ __metadata:
   dependencies:
     "@suite-common/icons": "workspace:*"
     "@suite-native/atoms": "workspace:*"
+    "@suite-native/screen-overlay": "workspace:*"
     "@trezor/styles": "workspace:*"
     jotai: 1.9.1
     react: 18.2.0
@@ -8152,6 +8153,7 @@ __metadata:
     "@suite-common/wallet-config": "workspace:*"
     "@suite-common/wallet-types": "workspace:*"
     "@suite-native/intl": "workspace:^"
+    "@suite-native/screen-overlay": "workspace:*"
     "@suite-native/storage": "workspace:*"
     "@trezor/env-utils": "workspace:*"
     "@trezor/styles": "workspace:*"
@@ -8177,6 +8179,7 @@ __metadata:
     "@suite-native/alerts": "workspace:*"
     "@suite-native/analytics": "workspace:*"
     "@suite-native/atoms": "workspace:*"
+    "@suite-native/screen-overlay": "workspace:*"
     "@suite-native/storage": "workspace:*"
     "@trezor/styles": "workspace:*"
     expo-local-authentication: 13.7.0
@@ -8802,6 +8805,18 @@ __metadata:
     react: 18.2.0
     react-native: 0.71.8
     react-redux: 8.0.7
+  languageName: unknown
+  linkType: soft
+
+"@suite-native/screen-overlay@workspace:*, @suite-native/screen-overlay@workspace:suite-native/screen-overlay":
+  version: 0.0.0-use.local
+  resolution: "@suite-native/screen-overlay@workspace:suite-native/screen-overlay"
+  dependencies:
+    "@react-navigation/native": ^6.1.3
+    "@shopify/react-native-skia": 0.1.214
+    "@trezor/styles": "workspace:*"
+    react: 18.2.0
+    react-native: 0.71.8
   languageName: unknown
   linkType: soft
 
@@ -9988,6 +10003,7 @@ __metadata:
     "@suite-native/navigation": "workspace:*"
     "@suite-native/notifications": "workspace:*"
     "@suite-native/receive": "workspace:*"
+    "@suite-native/screen-overlay": "workspace:*"
     "@suite-native/state": "workspace:*"
     "@suite-native/storage": "workspace:*"
     "@suite-native/theme": "workspace:*"


### PR DESCRIPTION
Enabling the blurred overlays again after the recent upgrade of `react-native-skia` (0.1.207 --> 0.1.214).

(This is just a reapply of a previously reverted commit, so no thorough review is needed. It was already approved before)

Resolves #8576
Resolves #9235
Resolves #9338

