### PR TITLE
chore(connect): move remembered device away from local variable

### DIFF
--- a/packages/connect-common/src/index.ts
+++ b/packages/connect-common/src/index.ts
@@ -1,5 +1,3 @@
-import * as storage from './storage';
+export * from './storage';
 
 export * from './systemInfo';
-
-export { storage };

--- a/packages/connect-common/src/test/storage.test.ts
+++ b/packages/connect-common/src/test/storage.test.ts
@@ -1,15 +1,16 @@
 import { storage } from '..';
 
+const origin = 'foo.bar';
+
 describe('storage', () => {
     beforeEach(() => {
         window.localStorage?.clear();
     });
 
     test('window.localStorage', () => {
-        expect(storage.load().permissions).toBe(undefined);
-        storage.save(state => ({ ...state, permissions: [] }));
-        expect(storage.load().permissions).toStrictEqual([]);
-
+        expect(storage.load().browser).toBe(undefined);
+        storage.save(state => ({ ...state, browser: true }));
+        expect(storage.load().browser).toStrictEqual(true);
         // @ts-expect-error
         expect(storage.load().random).toBe(undefined);
         storage.save(state => ({ ...state, random: {} }));
@@ -18,11 +19,10 @@ describe('storage', () => {
     });
 
     test('memoryStorage', () => {
-        expect(storage.load(true).permissions).toBe(undefined);
-        storage.save(state => ({ ...state, permissions: [] }), true);
-        expect(storage.load(true).permissions).toStrictEqual([]);
-        expect(storage.load().permissions).toBe(undefined);
-
+        expect(storage.load(true).browser).toBe(undefined);
+        storage.save(state => ({ ...state, browser: true }), true);
+        expect(storage.load(true).browser).toStrictEqual(true);
+        expect(storage.load().browser).toBe(undefined);
         // @ts-expect-error
         expect(storage.load(true).random).toBe(undefined);
         storage.save(state => ({ ...state, random: {} }), true);
@@ -32,18 +32,27 @@ describe('storage', () => {
         expect(storage.load().random).toBe(undefined);
     });
 
-    test('!window', () => {
-        // @ts-expect-error
-        global.window = undefined;
+    test('storage.saveForOrigin', () => {
+        storage.saveForOrigin(state => ({ ...state, permissions: [] }), origin);
+        expect(storage.load().origin[origin].permissions).toStrictEqual([]);
+        storage.saveForOrigin(
+            state => ({ ...state, permissions: [{ type: 'a', device: 'b' }] }),
+            origin,
+        );
+        expect(storage.load().origin[origin].permissions).toStrictEqual([
+            { type: 'a', device: 'b' },
+        ]);
+    });
 
-        expect(storage.load().permissions).toBe(undefined);
-        storage.save(state => ({ ...state, permissions: [] }));
-        expect(storage.load().permissions).toStrictEqual([]);
-
-        // @ts-expect-error
-        expect(storage.load().random).toBe(undefined);
-        storage.save(state => ({ ...state, random: {} }));
-        // @ts-expect-error
-        expect(storage.load().random).toStrictEqual({});
+    test('storage.loadForOrigin', () => {
+        storage.saveForOrigin(state => ({ ...state, permissions: [] }), origin);
+        expect(storage.loadForOrigin(origin).permissions).toStrictEqual([]);
+        storage.saveForOrigin(
+            state => ({ ...state, permissions: [{ type: 'a', device: 'b' }] }),
+            origin,
+        );
+        expect(storage.loadForOrigin(origin).permissions).toStrictEqual([
+            { type: 'a', device: 'b' },
+        ]);
     });
 });

--- a/packages/connect-common/tsconfig.lib.json
+++ b/packages/connect-common/tsconfig.lib.json
@@ -1,7 +1,6 @@
 {
     "extends": "../../tsconfig.lib.json",
     "compilerOptions": {
-        "target": "es5",
         "outDir": "./lib",
         "importHelpers": true,
         "esModuleInterop": false

--- a/packages/connect-iframe/src/index.ts
+++ b/packages/connect-iframe/src/index.ts
@@ -268,13 +268,16 @@ const filterDeviceEvent = (message: DeviceEvent) => {
     const features =
         'device' in message.payload ? message.payload.device.features : message.payload.features;
     if (features) {
-        const savedPermissions = storage.load().permissions || storage.load(true).permissions;
+        const origin = DataManager.getSettings('origin')!;
+
+        const savedPermissions =
+            storage.loadForOrigin(origin)?.permissions ||
+            storage.loadForOrigin(origin, true)?.permissions ||
+            [];
+
         if (savedPermissions) {
             const devicePermissions = savedPermissions.filter(
-                p =>
-                    p.origin === DataManager.getSettings('origin') &&
-                    p.type === 'read' &&
-                    p.device === features.device_id,
+                p => p.type === 'read' && p.device === features.device_id,
             );
             return devicePermissions.length > 0;
         }

--- a/packages/connect-popup/src/view/common.tsx
+++ b/packages/connect-popup/src/view/common.tsx
@@ -3,7 +3,7 @@
 import { POPUP, ERRORS, PopupInit, CoreMessage, createUiResponse } from '@trezor/connect';
 import { createRoot } from 'react-dom/client';
 
-import { ConnectUI, State } from '@trezor/connect-ui';
+import { ConnectUI, State, getDefaultState } from '@trezor/connect-ui';
 import { StyleSheetWrapper } from './react/StylesSheetWrapper';
 import { reactEventBus } from '@trezor/connect-ui/src/utils/eventBus';
 
@@ -11,7 +11,7 @@ export const header: HTMLElement = document.getElementsByTagName('header')[0];
 export const container: HTMLElement = document.getElementById('container')!;
 export const views: HTMLElement = document.getElementById('views')!;
 
-let state: State = {};
+let state: State = getDefaultState();
 
 export const setState = (newState: Partial<State>) => (state = { ...state, ...newState });
 export const getState = () => state;

--- a/packages/connect-ui/src/index.tsx
+++ b/packages/connect-ui/src/index.tsx
@@ -3,6 +3,7 @@ import { useCallback, useEffect, useState, useMemo, ReactNode } from 'react';
 import styled from 'styled-components';
 
 import { PostMessage, UI, UI_REQUEST, POPUP, createPopupMessage } from '@trezor/connect';
+import { storage, OriginBoundState } from '@trezor/connect-common';
 
 // views
 import { Transport } from './views/Transport';
@@ -67,7 +68,30 @@ export const ConnectUI = ({ postMessage, clearLegacyView }: ConnectUIProps) => {
     useEffect(() => {
         reactEventBus.dispatch({ type: 'connect-ui-rendered' });
         initAnalytics();
+
+        // subscribe to changes
+        storage.on('changed', storageNextState => {
+            setState(prevState => ({ ...prevState, ...storageNextState }));
+        });
     }, []);
+
+    useEffect(() => {
+        if (!state?.settings?.origin) return;
+
+        const data = storage.loadForOrigin(state.settings.origin);
+
+        const getNextState = (prevState: State, originBoundState: OriginBoundState) => ({
+            ...prevState,
+            ...originBoundState,
+        });
+
+        // load initial data
+        setState(prevState => getNextState(prevState, data));
+
+        return () => {
+            storage.removeAllListeners();
+        };
+    }, [state?.settings?.origin]);
 
     const [Component, Notifications] = useMemo(() => {
         let component: ReactNode | null;

--- a/packages/connect-ui/src/types.ts
+++ b/packages/connect-ui/src/types.ts
@@ -1,5 +1,6 @@
 import { PopupHandshake, PopupMethodInfo, IFrameLoaded } from '@trezor/connect';
 import type { Core } from '@trezor/connect/lib/core';
+import type { OriginBoundState } from '@trezor/connect-common';
 
 export type State = Partial<PopupHandshake['payload']> &
     Partial<PopupMethodInfo['payload']> &
@@ -7,7 +8,8 @@ export type State = Partial<PopupHandshake['payload']> &
         iframe?: Window;
         broadcast?: BroadcastChannel;
         core?: Core;
-        // preferred device will appear here
-    };
+    } & Partial<OriginBoundState>;
 
-export const getDefaultState = (): State => ({});
+export const getDefaultState = (): State => ({
+    permissions: [],
+});

--- a/packages/connect/src/core/AbstractMethod.ts
+++ b/packages/connect/src/core/AbstractMethod.ts
@@ -179,6 +179,15 @@ export abstract class AbstractMethod<Name extends CallMethodPayload['method'], P
         return false;
     }
 
+    private getOriginPermissions() {
+        const origin = DataManager.getSettings('origin');
+        if (!origin) {
+            return [];
+        }
+
+        return storage.loadForOrigin(origin)?.permissions || [];
+    }
+
     checkPermissions() {
         const savedPermissions = storage.load().permissions;
 
@@ -238,11 +247,13 @@ export abstract class AbstractMethod<Name extends CallMethodPayload['method'], P
             });
         }
 
-        storage.save(
+        const origin = DataManager.getSettings('origin')!;
+        storage.saveForOrigin(
             state => ({
                 ...state,
-                permissions: savedPermissions.concat(permissionsToSave),
+                permissions: [...(state.permissions || []), ...permissionsToSave],
             }),
+            origin,
             temporary,
         );
 

--- a/packages/connect/src/core/index.ts
+++ b/packages/connect/src/core/index.ts
@@ -210,7 +210,20 @@ const initDevice = async (method: AbstractMethod<any>) => {
     const isWebUsb = _deviceList.transportType() === 'WebUsbTransport';
     let device: Device | typeof undefined;
     let showDeviceSelection = isWebUsb;
-    if (method.devicePath) {
+    const origin = DataManager.getSettings('origin')!;
+    const { preferredDevice } = storage.load().origin[origin] || {};
+    const preferredDeviceInList = preferredDevice && _deviceList.getDevice(preferredDevice.path);
+
+    // we detected that there is a preferred device (user stored previously) but it's not in the list anymore (disconnected now)
+    // we treat this situation as implicit forget
+    if (preferredDevice && !preferredDeviceInList) {
+        storage.save(store => {
+            store.origin[origin] = { ...store.origin[origin], preferredDevice: undefined };
+            return store;
+        });
+    }
+
+    if (method.devicePath && preferredDevice && preferredDeviceInList) {
         device = _deviceList.getDevice(method.devicePath);
         showDeviceSelection = !!device?.unreadableError;
     } else {
@@ -911,10 +924,6 @@ const handleDeviceSelectionChanges = (interruptDevice?: DeviceTyped) => {
                 shouldClosePopup = true;
             }
         });
-
-        if (_preferredDevice && _preferredDevice.path === path) {
-            _preferredDevice = undefined;
-        }
 
         if (shouldClosePopup) {
             closePopup();


### PR DESCRIPTION
Make "remember" device work when core is loaded in popup.

## Description

In #9525 we are introducing loading connect core inside popup. This has 2 effects:
- to support environments that can't inject iframe. 
- to support webusb in popup

Couple of changes are needed. First of them is how "remember" device works: 
- Previously, remembered device was stored in a local variable which was ok, because iframe was actually making it persist between 2 calls. This is not the case anymore. When core is loaded in popup, everything locally stored is gone after popup is closed. This means we need to move it to storage.
- Previously, due to persistent nature ensured by iframe, when user disconnected device when popup was already closed, transport event was handled and local variable _preferedDevice was cleared. Without this behaviour we would get `Device not found` error, because connect would obviously try to target a device which is not connected at all. I had to change this behaviour in 2 ways:
  - do not rely on disconnect event
  - remove prefered device from store when device is not available in `initDevice` phase and show device selection instead. 

## Testing
- it should be just rework of internal logic, now new features, no changes
- mainly using webusb with remember on sldev should work as you would expect
- maybe try please testing with more than 1 device

## Related Issue

#9525, #9644

## Screenshots:

Connecting device for the 1st time or if there is more than 1 device connected

<img width="1256" alt="image" src="https://github.com/trezor/trezor-suite/assets/30367552/ff77c764-8c81-4df6-bce3-009b8b99de38">
