### PR TITLE
fix(suite): fix OverfloItems component cycle in e2e tests

### DIFF
--- a/packages/suite/src/components/suite/OverflowItems.tsx
+++ b/packages/suite/src/components/suite/OverflowItems.tsx
@@ -1,4 +1,4 @@
-import { ReactNode, useCallback, useEffect, useRef, useState } from 'react';
+import { ReactNode, useCallback, useLayoutEffect, useRef, useState } from 'react';
 import { usePrevious } from 'react-use';
 import { useSelector } from 'src/hooks/suite';
 import styled from 'styled-components';
@@ -95,8 +95,8 @@ export function OverflowItems<T extends OverflowItem>({
         }
     }, [minVisibleItems]);
 
-    useEffect(() => {
-        if (!previousWidth || screenWidth > previousWidth) {
+    useLayoutEffect(() => {
+        if (screenWidth && (!previousWidth || screenWidth > previousWidth)) {
             showAllItems();
             return;
         }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Fix is the extra `screenWidth &&` condition that prevents showAllItems() from being called if screenWidth is 0. 

I'm not sure about useLayoutEffect, but I believe it can prevent flickering during rendering, but I didn't personally observe it (nor did I try to)


## Screenshots:
fix 
<img width="542" alt="image" src="https://github.com/trezor/trezor-suite/assets/3729633/b60c4447-7a9b-4c18-b14f-8b662e0b7936">

