### PR TITLE
fix(connect-ui): add missing host label to info panel

### DIFF
--- a/packages/connect-ui/src/components/InfoPanel.tsx
+++ b/packages/connect-ui/src/components/InfoPanel.tsx
@@ -67,10 +67,11 @@ const Origin = styled.p`
 interface InfoPanelProps {
     method?: string;
     origin?: string;
+    hostLabel?: string;
     topSlot?: ReactNode;
 }
 
-export const InfoPanel = ({ method, origin, topSlot }: InfoPanelProps) => (
+export const InfoPanel = ({ method, origin, hostLabel, topSlot }: InfoPanelProps) => (
     <>
         <Aside data-test="@info-panel">
             {/*  notifications appear hear */}
@@ -98,7 +99,7 @@ export const InfoPanel = ({ method, origin, topSlot }: InfoPanelProps) => (
                 </Header>
                 <Info>
                     <MethodName>{method}</MethodName>
-                    <Origin>{origin}</Origin>
+                    <Origin>{hostLabel || origin}</Origin>
                 </Info>
             </MainSlot>
         </Aside>

--- a/packages/connect-ui/src/index.tsx
+++ b/packages/connect-ui/src/index.tsx
@@ -139,6 +139,7 @@ export const ConnectUI = ({ postMessage, clearLegacyView }: ConnectUIProps) => {
                         <InfoPanel
                             method={flowInfo?.method}
                             origin={flowInfo?.settings?.origin}
+                            hostLabel={flowInfo?.settings?.hostLabel}
                             topSlot={Object.values(Notifications)}
                         />
                         {Component && (


### PR DESCRIPTION

looks like we are missing host label in the left info panel in popup

<img width="643" alt="image" src="https://github.com/trezor/trezor-suite/assets/30367552/e9539b7f-97d1-4bda-ae58-9bffd921a1f8">