### PR TITLE
fix(suite): unbreakable symbol name

### DIFF
--- a/packages/suite/src/components/suite/FormattedCryptoAmount.tsx
+++ b/packages/suite/src/components/suite/FormattedCryptoAmount.tsx
@@ -23,9 +23,7 @@ const Value = styled.span`
     text-overflow: ellipsis;
 `;
 
-const Symbol = styled.span`
-    word-break: initial;
-`;
+const Symbol = styled.span``;
 
 export interface FormattedCryptoAmountProps {
     value?: string | number;


### PR DESCRIPTION
## Description

- I do not want to touch it more as it is reused everywhere. It didnt find an issue when removing word-break
- if symbol does not have space, we cannot break it and it breaks ui of whole token section
- It makes whole tokens section unusable

## Related Issue

https://satoshilabs.slack.com/archives/C03SRP8PSS2/p1698844822232859

## Screenshots:
past:
![Screenshot 2023-11-01 at 16 02 51](https://github.com/trezor/trezor-suite/assets/33235762/290fd8a5-7001-4a7c-bf2e-53c9f5c1d5f1)
now:
![Screenshot 2023-11-01 at 16 02 39](https://github.com/trezor/trezor-suite/assets/33235762/c16b698d-5d3e-4e22-a2be-d003cb6eecba)
