### PR TITLE
Fix/mobile - add transports in correct order

### DIFF
--- a/packages/connect/src/device/DeviceList.ts
+++ b/packages/connect/src/device/DeviceList.ts
@@ -123,7 +123,7 @@ export class DeviceList extends TypedEmitter<DeviceListEvents> {
                         );
                 }
             } else if (transportType instanceof Transport) {
-                this.transports.unshift(transportType);
+                this.transports.push(transportType);
             } else {
                 // runtime check
                 throw ERRORS.TypedError(

--- a/suite-native/app/ios/Podfile.lock
+++ b/suite-native/app/ios/Podfile.lock
@@ -23,6 +23,8 @@ PODS:
     - ExpoModulesCore
   - ExpoClipboard (4.1.1):
     - ExpoModulesCore
+  - ExpoDevice (5.6.0):
+    - ExpoModulesCore
   - ExpoHaptics (12.4.0):
     - ExpoModulesCore
   - ExpoLinearGradient (12.5.0):
@@ -550,6 +552,7 @@ DEPENDENCIES:
   - Expo (from `../../../node_modules/expo`)
   - ExpoBrightness (from `../../../node_modules/expo-brightness/ios`)
   - ExpoClipboard (from `../../../node_modules/expo-clipboard/ios`)
+  - ExpoDevice (from `../../../node_modules/expo-device/ios`)
   - ExpoHaptics (from `../../../node_modules/expo-haptics/ios`)
   - ExpoLinearGradient (from `../../../node_modules/expo-linear-gradient/ios`)
   - ExpoLocalAuthentication (from `../../../node_modules/expo-local-authentication/ios`)
@@ -676,6 +679,8 @@ EXTERNAL SOURCES:
     :path: "../../../node_modules/expo-brightness/ios"
   ExpoClipboard:
     :path: "../../../node_modules/expo-clipboard/ios"
+  ExpoDevice:
+    :path: "../../../node_modules/expo-device/ios"
   ExpoHaptics:
     :path: "../../../node_modules/expo-haptics/ios"
   ExpoLinearGradient:
@@ -799,6 +804,7 @@ SPEC CHECKSUMS:
   Expo: 79deb55f33fab1b232232868a74713772943238d
   ExpoBrightness: 13a6108d77641ad310b7873438a0260f9eedfe5c
   ExpoClipboard: 8a36a8376ab93df9050c14577e9e0fcb805e9114
+  ExpoDevice: 4b9825263a3f996fd5a89ec26426e22e6cbc32d6
   ExpoHaptics: 360af6898407ee4e8265d30a1a8fb16491a660eb
   ExpoLinearGradient: 5d18293f89c063036121281175c4653d6a7c34a2
   ExpoLocalAuthentication: dd96886ee4c50a0ec5b73bae5e929ea082a2e53e

--- a/suite-native/state/package.json
+++ b/suite-native/state/package.json
@@ -32,6 +32,7 @@
         "@trezor/protobuf": "workspace:*",
         "@trezor/transport-native": "workspace:*",
         "@trezor/utils": "workspace:*",
+        "expo-device": "5.6.0",
         "react": "18.2.0",
         "react-native": "0.71.7",
         "react-redux": "8.0.7",

--- a/suite-native/state/src/extraDependencies.ts
+++ b/suite-native/state/src/extraDependencies.ts
@@ -1,5 +1,7 @@
 import { Platform } from 'react-native';
 
+import * as Device from 'expo-device';
+
 import { ExtraDependencies } from '@suite-common/redux-utils';
 import { extraDependenciesMock } from '@suite-common/test-utils';
 import { supportedNetworkSymbols } from '@suite-native/config';
@@ -11,16 +13,21 @@ import { NativeUsbTransport } from '@trezor/transport-native';
 
 const protobufMessages = require('@trezor/protobuf/messages.json');
 
-const transports = Platform.select({
-    ios: ['BridgeTransport', 'UdpTransport'],
-    android: [
-        'BridgeTransport',
-        'UdpTransport',
-        new NativeUsbTransport({
-            messages: protobufMessages,
-        }),
-    ],
-});
+const deviceType = Device.isDevice ? 'device' : 'emulator';
+
+const transportsPerDeviceType = {
+    device: Platform.select({
+        ios: ['BridgeTransport', 'UdpTransport'],
+        android: [
+            new NativeUsbTransport({
+                messages: protobufMessages,
+            }),
+        ],
+    }),
+    emulator: ['BridgeTransport', 'UdpTransport'],
+} as const;
+
+const transports = transportsPerDeviceType[deviceType];
 
 export const extraDependencies: ExtraDependencies = mergeDeepObject(extraDependenciesMock, {
     selectors: {

--- a/suite-native/state/src/extraDependencies.ts
+++ b/suite-native/state/src/extraDependencies.ts
@@ -12,12 +12,13 @@ import { NativeUsbTransport } from '@trezor/transport-native';
 const protobufMessages = require('@trezor/protobuf/messages.json');
 
 const transports = Platform.select({
-    ios: ['UdpTransport'],
+    ios: ['BridgeTransport', 'UdpTransport'],
     android: [
+        'BridgeTransport',
+        'UdpTransport',
         new NativeUsbTransport({
             messages: protobufMessages,
         }),
-        'UdpTransport',
     ],
 });
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -34073,14 +34073,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"ua-parser-js@npm:^0.7.30":
-  version: 0.7.31
-  resolution: "ua-parser-js@npm:0.7.31"
-  checksum: e2f8324a83d1715601576af85b2b6c03890699aaa7272950fc77ea925c70c5e4f75060ae147dc92124e49f7f0e3d6dd2b0a91e7f40d267e92df8894be967ba8b
-  languageName: node
-  linkType: hard
-
-"ua-parser-js@npm:^0.7.33":
+"ua-parser-js@npm:^0.7.30, ua-parser-js@npm:^0.7.33":
   version: 0.7.37
   resolution: "ua-parser-js@npm:0.7.37"
   checksum: 9e91a66171aa16c74680cfac84af6ed7ecdeb508ff7c90a55222f56c63172da2d98d2478763e9469c940415fe29c45a56ae51fec1c19a498e7a3b293f7b3b874

--- a/yarn.lock
+++ b/yarn.lock
@@ -8246,6 +8246,7 @@ __metadata:
     "@trezor/protobuf": "workspace:*"
     "@trezor/transport-native": "workspace:*"
     "@trezor/utils": "workspace:*"
+    expo-device: 5.6.0
     react: 18.2.0
     react-native: 0.71.7
     react-redux: 8.0.7
@@ -18674,6 +18675,17 @@ __metadata:
   peerDependencies:
     expo: "*"
   checksum: 647fda433b302780eae453a6dc58ea6da4aed42753729b04fd3ecaca277cc1979a67cfeaea2c6a60b82ca5d79f139b08b94576986264a1f13b0ef1bfc2911d01
+  languageName: node
+  linkType: hard
+
+"expo-device@npm:5.6.0":
+  version: 5.6.0
+  resolution: "expo-device@npm:5.6.0"
+  dependencies:
+    ua-parser-js: ^0.7.33
+  peerDependencies:
+    expo: "*"
+  checksum: d30bf016da78bc5f5d163e9583fb3199d273a33bce800f7b3d28212925f08be5a9dd89df3d19fe4449ebfa31c12fe3dd7b7b2270bf302abcce9e0da52f2ca639
   languageName: node
   linkType: hard
 
@@ -34065,6 +34077,13 @@ __metadata:
   version: 0.7.31
   resolution: "ua-parser-js@npm:0.7.31"
   checksum: e2f8324a83d1715601576af85b2b6c03890699aaa7272950fc77ea925c70c5e4f75060ae147dc92124e49f7f0e3d6dd2b0a91e7f40d267e92df8894be967ba8b
+  languageName: node
+  linkType: hard
+
+"ua-parser-js@npm:^0.7.33":
+  version: 0.7.37
+  resolution: "ua-parser-js@npm:0.7.37"
+  checksum: 9e91a66171aa16c74680cfac84af6ed7ecdeb508ff7c90a55222f56c63172da2d98d2478763e9469c940415fe29c45a56ae51fec1c19a498e7a3b293f7b3b874
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
For some reason emulator doesn't work if there is no BridgeTransport and also NativeTransport must be last.

## Description

<!--- Describe your changes in detail -->

## Related Issue

Resolve <!--- link the issue here -->

## Screenshots:
