### PR TITLE
feat(connect-common): add T2T1 & T2B1 firmware binaries 2.6.3 bootloader 2.1.4

### DIFF
--- a/packages/connect-common/files/devkit/firmware/t2b1/trezor-t2b1-2.6.2-bitcoinonly.bin
+++ b/packages/connect-common/files/devkit/firmware/t2b1/trezor-t2b1-2.6.2-bitcoinonly.bin
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:be5ddceac9e8078407a8d11be42e217b1fb7540369da9c9cfc75bee2ebf81a0f
-size 1188352

--- a/packages/connect-common/files/devkit/firmware/t2b1/trezor-t2b1-2.6.2.bin
+++ b/packages/connect-common/files/devkit/firmware/t2b1/trezor-t2b1-2.6.2.bin
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:8468a9892a9479d4bbe47f68b39e36fab3ffaf2b89c41bc988ec333f9bdd56fb
-size 1433088

--- a/packages/connect-common/files/firmware/t2b1/releases.json
+++ b/packages/connect-common/files/firmware/t2b1/releases.json
@@ -1,5 +1,18 @@
 [
     {
+        "required": false,
+        "version": [2, 6, 3],
+        "min_bridge_version": [2, 0, 7],
+        "min_firmware_version": [2, 6, 1],
+        "min_bootloader_version": [2, 1, 1],
+        "bootloader_version": [2, 1, 4],
+        "url": "firmware/t2b1/trezor-t2b1-2.6.3.bin",
+        "url_bitcoinonly": "firmware/t2b1/trezor-t2b1-2.6.3-bitcoinonly.bin",
+        "fingerprint": "1aea81cf4a823951540a041ae52d1950efade73531f7640c85805f8950f11a38",
+        "fingerprint_bitcoinonly": "6aecc9d9fd137a661f38ce36713aa0889b77ec4d35d91c68e01bda225cda2850",
+        "changelog": "* QR Code for Extended Public Keys (XPUBs). \n* The new bootloader version 2.1.4 is now included for enhanced system performance and security. \n* The screen will now automatically turn off when the device is locked, helping to extend the life of the OLED display and save energy."
+    },
+    {
         "required": true,
         "version": [2, 6, 2],
         "min_bridge_version": [2, 0, 7],

--- a/packages/connect-common/files/firmware/t2b1/trezor-t2b1-2.6.2-bitcoinonly.bin
+++ b/packages/connect-common/files/firmware/t2b1/trezor-t2b1-2.6.2-bitcoinonly.bin
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:dc8adffac16c9d5cd62f82f4b133b6946788be7db3127a6d665d6c0bde2c6f0f
-size 1188352

--- a/packages/connect-common/files/firmware/t2b1/trezor-t2b1-2.6.2.bin
+++ b/packages/connect-common/files/firmware/t2b1/trezor-t2b1-2.6.2.bin
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:36eb6c2f20bb0d3104fff2bbb20563c93eedcbf88dcea617b92bf94665fd8865
-size 1433088

--- a/packages/connect-common/files/firmware/t2b1/trezor-t2b1-2.6.3-bitcoinonly.bin
+++ b/packages/connect-common/files/firmware/t2b1/trezor-t2b1-2.6.3-bitcoinonly.bin
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:8e90563437bbed9e7ae36aa77ff2f3e0ff24f02987f473e5eb23fce3b97ccea4
+size 1195008

--- a/packages/connect-common/files/firmware/t2b1/trezor-t2b1-2.6.3.bin
+++ b/packages/connect-common/files/firmware/t2b1/trezor-t2b1-2.6.3.bin
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:27fe498bd394b5a1efeb9531db93c80019295d520818cbade52a81d24d97f43f
+size 1440768

--- a/packages/connect-common/files/firmware/t2t1/releases.json
+++ b/packages/connect-common/files/firmware/t2t1/releases.json
@@ -1,6 +1,19 @@
 [
     {
         "required": false,
+        "version": [2, 6, 3],
+        "min_bridge_version": [2, 0, 7],
+        "min_firmware_version": [2, 0, 8],
+        "min_bootloader_version": [2, 0, 0],
+        "bootloader_version": [2, 1, 4],
+        "url": "firmware/t2t1/trezor-t2t1-2.6.3.bin",
+        "url_bitcoinonly": "firmware/t2t1/trezor-t2t1-2.6.3-bitcoinonly.bin",
+        "fingerprint": "9ff0874f2ce3579a7502747578cef65c824097d906e7150b0142f6b9aa395a43",
+        "fingerprint_bitcoinonly": "1765518ca4025d4d46362d07128bb38413831511a2aff0dee1b05e6e58ff5317",
+        "changelog": "* QR Code for Extended Public Keys (XPUBs). \n* Adjusted buttons for multipage content scrolling, providing a more intuitive and user-friendly experience. \n* The new bootloader version 2.1.4 is now included for enhanced system performance and security."
+    },
+    {
+        "required": false,
         "version": [2, 6, 0],
         "min_bridge_version": [2, 0, 7],
         "min_firmware_version": [2, 0, 8],

--- a/packages/connect-common/files/firmware/t2t1/trezor-t2t1-2.6.0-bitcoinonly.bin
+++ b/packages/connect-common/files/firmware/t2t1/trezor-t2t1-2.6.0-bitcoinonly.bin
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:c6fe574b2348beb45abb62d38bbf09b032a5082900667b6892218903aadf856f
-size 1275904

--- a/packages/connect-common/files/firmware/t2t1/trezor-t2t1-2.6.0.bin
+++ b/packages/connect-common/files/firmware/t2t1/trezor-t2t1-2.6.0.bin
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:e5560b40a9fc470fc9f9552baed65241cb0496c5896c6336e2422b50ddf7cada
-size 1577472

--- a/packages/connect-common/files/firmware/t2t1/trezor-t2t1-2.6.3-bitcoinonly.bin
+++ b/packages/connect-common/files/firmware/t2t1/trezor-t2t1-2.6.3-bitcoinonly.bin
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:f0d2b0b583adf6f4f005fc3dc799945ba45641ca72ce88b771e31d3b6256fcfe
+size 1259008

--- a/packages/connect-common/files/firmware/t2t1/trezor-t2t1-2.6.3.bin
+++ b/packages/connect-common/files/firmware/t2t1/trezor-t2t1-2.6.3.bin
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:9d8043928a1c2ea514c5e2804953da978847eeed5acfd5133f18d755147939a6
+size 1538560


### PR DESCRIPTION

<!--- Provide a general summary of your changes in the Title above -->

## Description

New firmwares 2.6.3  including new bootloader 2.1.4 for both T2T1 and T2B1.

devkit binaries removed for now, we can add them later if we need them.

## Related Issue

Resolve https://github.com/trezor/trezor-suite/issues/9656

## Screenshots:
T2T1:
<img width="859" alt="image" src="https://github.com/trezor/trezor-suite/assets/3729633/a46a6429-9af1-412f-95fe-537bfce39d2a">

T2B1:
<img width="713" alt="image" src="https://github.com/trezor/trezor-suite/assets/3729633/08e5acdd-180c-4852-ac40-d1692fb93633">

