### PR TITLE
fix(suite): list cardanoGetPublicKey in connect wrapped methods

### DIFF
--- a/packages/suite/src/actions/wallet/__fixtures__/publicKeyActions.ts
+++ b/packages/suite/src/actions/wallet/__fixtures__/publicKeyActions.ts
@@ -7,6 +7,8 @@ import { MODAL } from 'src/actions/suite/constants';
 
 const { getSuiteDevice } = testMocks;
 
+const LOCK_DEVICE = '@mocked/extraDependency/action/notImplemented/lockDevice';
+
 export default [
     {
         description: 'Show unverified public key',
@@ -31,6 +33,8 @@ export default [
                 { type: connectInitThunk.pending.type, payload: undefined },
                 { type: connectInitThunk.fulfilled.type, payload: undefined },
                 { type: MODAL.PRESERVE },
+                { type: LOCK_DEVICE },
+                { type: LOCK_DEVICE },
                 { type: MODAL.OPEN_USER_CONTEXT },
             ],
         },
@@ -47,6 +51,8 @@ export default [
                 { type: connectInitThunk.pending.type, payload: undefined },
                 { type: connectInitThunk.fulfilled.type, payload: undefined },
                 { type: MODAL.PRESERVE },
+                { type: LOCK_DEVICE },
+                { type: LOCK_DEVICE },
                 { type: MODAL.OPEN_USER_CONTEXT },
             ],
         },
@@ -121,6 +127,8 @@ export default [
                 { type: connectInitThunk.pending.type, payload: undefined },
                 { type: connectInitThunk.fulfilled.type, payload: undefined },
                 { type: MODAL.PRESERVE },
+                { type: LOCK_DEVICE },
+                { type: LOCK_DEVICE },
                 { type: MODAL.CLOSE },
                 {
                     type: notificationsActions.addToast.type,
@@ -144,6 +152,8 @@ export default [
                 { type: connectInitThunk.pending.type, payload: undefined },
                 { type: connectInitThunk.fulfilled.type, payload: undefined },
                 { type: MODAL.PRESERVE },
+                { type: LOCK_DEVICE },
+                { type: LOCK_DEVICE },
                 { type: MODAL.CLOSE },
             ],
         },

--- a/suite-common/connect-init/src/connectInitThunks.ts
+++ b/suite-common/connect-init/src/connectInitThunks.ts
@@ -54,10 +54,12 @@ export const connectInitThunk = createThunk(
 
         const wrappedMethods: Array<keyof typeof TrezorConnect> = [
             'applySettings',
+            'authenticateDevice',
             'authorizeCoinjoin',
             'backupDevice',
             'cancelCoinjoinAuthorization',
             'cardanoGetAddress',
+            'cardanoGetPublicKey',
             'cardanoSignTransaction',
             'changePin',
             'checkFirmwareAuthenticity',
@@ -68,6 +70,7 @@ export const connectInitThunk = createThunk(
             'getDeviceState',
             'getFeatures',
             'getOwnershipProof',
+            'getPublicKey',
             'pushTransaction',
             'rebootToBootloader',
             'recoveryDevice',
@@ -75,9 +78,12 @@ export const connectInitThunk = createThunk(
             'rippleGetAddress',
             'rippleSignTransaction',
             'setBusy',
+            'showDeviceTutorial',
             'signTransaction',
             'solanaGetAddress',
             'solanaSignTransaction',
+            'unlockPath',
+            'wipeDevice',
         ] as const;
 
         wrappedMethods.forEach(key => {


### PR DESCRIPTION
micro fix for mad clickcing on cardno show public key

1st commit - list cardanoGetPublicKey method in wrapped methods so that locks apply.
2nd commit - yet to be delivered - implement correctly disabling button based on device lock. It looks like it doesnt work even for bitcoin now.  Looking for somebody to finish this 🙏 cc @matejkriz 

<img width="1004" alt="image" src="https://github.com/trezor/trezor-suite/assets/30367552/cf52eba9-f15e-4c53-9a55-7d19db3b7b0f">
