### PR TITLE
Feat: connect explorer settings page

### DIFF
--- a/packages/connect-explorer/src/actions/index.ts
+++ b/packages/connect-explorer/src/actions/index.ts
@@ -21,5 +21,6 @@ export const ON_CUSTOM_FEE_CHANGE = 'action__on_custom_fee_change';
 
 export const ON_SELECT_DEVICE = 'action__on_select_device';
 export const ON_CHANGE_CONNECT_OPTIONS = 'action__on_change_connect_options';
+export const ON_CHANGE_CONNECT_OPTION = 'action__on_change_connect_option';
 
 export const ON_LOCATION_CHANGE = 'action__on_location_change';

--- a/packages/connect-explorer/src/components/Method.tsx
+++ b/packages/connect-explorer/src/components/Method.tsx
@@ -3,7 +3,7 @@ import styled from 'styled-components';
 
 import { Button } from '@trezor/components';
 
-import type { Field, FieldWithBundle, AppState } from '../types';
+import type { Field, FieldWithBundle } from '../types';
 
 import * as methodActions from '../actions/methodActions';
 import { useSelector, useActions } from '../hooks';
@@ -13,8 +13,6 @@ import { Row } from './fields/Row';
 import Response from './Response';
 
 interface Props {
-    method: AppState['method'];
-    docs: AppState['docs'];
     actions: any; // todo
 }
 
@@ -36,7 +34,7 @@ const getArray = (field: FieldWithBundle<any>, props: Props) => (
     </ArrayWrapper>
 );
 
-const getField = (field: Field<any> | FieldWithBundle<any>, props: Props) => {
+export const getField = (field: Field<any> | FieldWithBundle<any>, props: Props) => {
     switch (field.type) {
         case 'array':
             return getArray(field, props);
@@ -45,19 +43,12 @@ const getField = (field: Field<any> | FieldWithBundle<any>, props: Props) => {
         case 'number':
             return <Input key={field.name} field={field} onChange={props.actions.onFieldChange} />;
         case 'address':
-            return (
-                <Input
-                    key={field.name}
-                    field={field}
-                    // validation={props.method.addressValidation}
-                    onChange={props.actions.onFieldChange}
-                />
-            );
+            return <Input key={field.name} field={field} onChange={props.actions.onFieldChange} />;
 
         case 'checkbox':
             return (
                 <Checkbox
-                    data-test="@checkbox"
+                    data-test={`@checkbox/${field.name}`}
                     key={field.name}
                     field={field}
                     onChange={props.actions.onFieldChange}
@@ -134,7 +125,7 @@ const Method = () => {
 
     return (
         <MethodContent>
-            {fields.map(field => getField(field, { method, docs, actions }))}
+            {fields.map(field => getField(field, { actions }))}
             <Row>
                 <Button onClick={onSubmit} data-test="@submit-button">
                     {submitButton}

--- a/packages/connect-explorer/src/components/Settings.tsx
+++ b/packages/connect-explorer/src/components/Settings.tsx
@@ -1,0 +1,48 @@
+import styled from 'styled-components';
+
+import { Button } from '@trezor/components';
+
+import * as trezorConnectActions from '../actions/trezorConnectActions';
+import { useSelector, useActions } from '../hooks';
+
+import { Row } from './fields/Row';
+import { getField } from './Method';
+import { Field, FieldWithBundle } from '../types';
+
+const SettingsContent = styled.section`
+    flex: 1;
+    padding: 10px 20px;
+    display: flex;
+    flex-direction: column;
+`;
+
+export const Settings = () => {
+    const connectOptions = useSelector(state => ({
+        trustedHost: state.connect?.options?.trustedHost || false,
+    }));
+    const actions = useActions({
+        onSubmitInit: trezorConnectActions.onSubmitInit,
+        onFieldChange: trezorConnectActions.onConnectOptionChange,
+    });
+
+    const submitButton = 'Init Connect';
+    const fields: (Field<any> | FieldWithBundle<any>)[] = [
+        {
+            name: 'trustedHost',
+            type: 'checkbox',
+            key: 'trustedHost',
+            value: connectOptions?.trustedHost || false,
+        },
+    ];
+
+    return (
+        <SettingsContent>
+            {fields.map(field => getField(field, { actions }))}
+            <Row>
+                <Button onClick={actions.onSubmitInit} data-test="@submit-button">
+                    {submitButton}
+                </Button>
+            </Row>
+        </SettingsContent>
+    );
+};

--- a/packages/connect-explorer/src/components/fields/Checkbox.tsx
+++ b/packages/connect-explorer/src/components/fields/Checkbox.tsx
@@ -9,9 +9,13 @@ interface CheckboxProps {
     onChange: typeof onFieldChange;
 }
 
-const Checkbox = ({ field, onChange }: CheckboxProps) => (
+const Checkbox = ({ field, onChange, ...rest }: CheckboxProps) => (
     <Row>
-        <CheckboxComponent onClick={_e => onChange(field, !field.value)} isChecked={field.value}>
+        <CheckboxComponent
+            onClick={_e => onChange(field, !field.value)}
+            isChecked={field.value}
+            {...rest}
+        >
             {field.name}
         </CheckboxComponent>
     </Row>

--- a/packages/connect-explorer/src/reducers/trezorConnectReducer.ts
+++ b/packages/connect-explorer/src/reducers/trezorConnectReducer.ts
@@ -1,6 +1,6 @@
 import TrezorConnect, { DEVICE } from '@trezor/connect-web';
 import * as ACTIONS from '../actions/index';
-import { TrezorConnectDevice, Action } from '../types';
+import { TrezorConnectDevice, Action, Field } from '../types';
 
 type ConnectState = {
     devices: TrezorConnectDevice[];
@@ -46,6 +46,22 @@ const removeDevice = (state: ConnectState, device: TrezorConnectDevice): Connect
     return state;
 };
 
+const onOptionChange = <T>(state: ConnectState, field: Field<T>, value: T): ConnectState => {
+    const newState = {
+        ...state,
+    };
+    if (!newState.options) {
+        newState.options = {
+            manifest: {
+                email: 'info@trezor.io',
+                appUrl: '@trezor/suite',
+            },
+        };
+    }
+    newState.options[field.name] = value;
+    return newState;
+};
+
 export default function connect(state: ConnectState = initialState, action: Action) {
     switch (action.type) {
         case DEVICE.CONNECT:
@@ -66,6 +82,9 @@ export default function connect(state: ConnectState = initialState, action: Acti
                 ...state,
                 selectedDevice: action.path,
             };
+
+        case ACTIONS.ON_CHANGE_CONNECT_OPTION:
+            return onOptionChange(state, action.payload.option, action.payload.value);
 
         case ACTIONS.ON_CHANGE_CONNECT_OPTIONS:
             return {

--- a/packages/connect-explorer/src/router/index.tsx
+++ b/packages/connect-explorer/src/router/index.tsx
@@ -8,6 +8,7 @@ import Method from '../components/Method';
 import { About } from '../components/PageAbout';
 import { Events } from '../components/PageEvents';
 import { Changelog } from '../components/PageChangelog';
+import { Settings } from '../components/Settings';
 
 const App = () => (
     <>
@@ -20,6 +21,7 @@ const App = () => (
                         <Route exact path="/" component={About} />
                         <Route exact path="/changelog" component={Changelog} />
                         <Route exact path="/events" component={Events} />
+                        <Route exact path="/settings" component={Settings} />
                     </AppContainer>
                 </Switch>
             </Router>

--- a/packages/connect-popup/e2e/support/helpers.ts
+++ b/packages/connect-popup/e2e/support/helpers.ts
@@ -125,3 +125,9 @@ export const downloadLogs = async (logPage: Page, downloadLogPath: string) => {
     await download.saveAs(downloadLogPath);
     return download;
 };
+
+export const setTrustedHost = async (explorerPage: Page, explorerUrl: string) => {
+    await explorerPage.goto(`${explorerUrl}#/settings`);
+    await waitAndClick(explorerPage, ['@checkbox/trustedHost']);
+    await waitAndClick(explorerPage, ['@submit-button']);
+};

--- a/packages/connect-popup/e2e/tests/methods.test.ts
+++ b/packages/connect-popup/e2e/tests/methods.test.ts
@@ -9,7 +9,7 @@ import { buildOverview } from '../support/buildOverview';
 import { ensureDirectoryExists } from '@trezor/node-utils';
 import { getContexts, log, openPopup } from '../support/helpers';
 
-const url = `${process.env.URL || 'http://localhost:8088/'}?trust-issues=true`;
+const url = process.env.URL || 'http://localhost:8088/';
 
 const emuScreenshots: Record<string, string> = {};
 

--- a/packages/connect-popup/e2e/tests/passphrase.test.ts
+++ b/packages/connect-popup/e2e/tests/passphrase.test.ts
@@ -8,7 +8,7 @@ import {
     waitAndClick,
 } from '../support/helpers';
 
-const url = `${process.env.URL || 'http://localhost:8088/'}?trust-issues=true`;
+const url = process.env.URL || 'http://localhost:8088/';
 const bridgeVersion = '2.0.31';
 
 const isWebExtension = process.env.IS_WEBEXTENSION === 'true';

--- a/packages/connect-popup/e2e/tests/permissions.test.ts
+++ b/packages/connect-popup/e2e/tests/permissions.test.ts
@@ -1,6 +1,6 @@
 import { test, chromium, Page } from '@playwright/test';
 import { TrezorUserEnvLink } from '@trezor/trezor-user-env-link';
-import { waitAndClick } from '../support/helpers';
+import { setTrustedHost } from '../support/helpers';
 
 const url = process.env.URL || 'http://localhost:8088/';
 
@@ -16,22 +16,6 @@ test.beforeAll(async () => {
 });
 
 const fixtures = [
-    {
-        description: `iframe and host same origins but with trust-issues=true -> show permissions`,
-        queryString: '?trust-issues=true',
-        setTrustedHost: false,
-        expect: () => popup.waitForSelector("[data-test='@permissions/confirm-button']"),
-    },
-    {
-        description: `iframe and host same origins but with trust-issues=false -> no permissions shown`,
-        queryString: '?trust-issues=false',
-        setTrustedHost: false,
-        expect: () =>
-            popup.waitForSelector('//p[contains(., "Follow instructions on your device")]', {
-                state: 'visible',
-                strict: false,
-            }),
-    },
     {
         description:
             'iframe and host same origins but with settings to trustedHost -> no permissions shown',
@@ -57,9 +41,7 @@ fixtures.forEach(f => {
         const browserInstance = await chromium.launch();
         const page = await browserInstance.newPage();
         if (f.setTrustedHost) {
-            await page.goto(`${url}#/settings`);
-            await waitAndClick(page, ['@checkbox/trustedHost']);
-            await waitAndClick(page, ['@submit-button']);
+            await setTrustedHost(page, url);
         }
         await page.goto(`${url}${f.queryString}#/method/verifyMessage`);
 

--- a/packages/connect-popup/e2e/tests/popup-close.test.ts
+++ b/packages/connect-popup/e2e/tests/popup-close.test.ts
@@ -9,8 +9,7 @@ import {
     checkHasLogs,
 } from '../support/helpers';
 
-const host = process.env.URL || 'http://localhost:8088/';
-const url = `${host}?trust-issues=true`;
+const url = process.env.URL || 'http://localhost:8088/';
 
 const WAIT_AFTER_TEST = 3000; // how long test should wait for more potential trezord requests
 
@@ -120,7 +119,7 @@ test.beforeAll(async () => {
     // we are validating here this commit https://github.com/trezor/connect/commit/fc60c3c03d6e689f3de2d518cc51f62e649a20e2
     test.afterEach(async ({ page, context }, testInfo) => {
         const logPage = await context.newPage();
-        await logPage.goto(`${host}log.html`);
+        await logPage.goto(`${url}log.html`);
 
         const hasLogs = await checkHasLogs(logPage);
         if (hasLogs) {

--- a/packages/connect-popup/e2e/tests/popup-error-page.test.ts
+++ b/packages/connect-popup/e2e/tests/popup-error-page.test.ts
@@ -1,7 +1,7 @@
 import { test, Page } from '@playwright/test';
 import { TrezorUserEnvLink } from '@trezor/trezor-user-env-link';
 
-const url = `${process.env.URL || 'http://localhost:8088/'}?trust-issues=true`;
+const url = process.env.URL || 'http://localhost:8088/';
 
 const bridgeVersion = '2.0.31';
 

--- a/packages/connect-web/src/connectSettings.ts
+++ b/packages/connect-web/src/connectSettings.ts
@@ -56,25 +56,12 @@ export const parseConnectSettings = (input: Partial<ConnectSettings> = {}): Conn
     }
 
     if (typeof window !== 'undefined' && typeof window.location?.search === 'string') {
-        const query = processQueryString(window.location.search, [
-            'trezor-connect-src',
-            'trust-issues',
-        ]);
+        const query = processQueryString(window.location.search, ['trezor-connect-src']);
         // For debugging purposes `connectSrc` could be defined in url query of hosting page. Usage:
         // https://3rdparty-page.com/?trezor-connect-src=https://localhost:8088/
         if (query['trezor-connect-src']) {
             settings.debug = true;
             settings.connectSrc = query['trezor-connect-src'];
-        }
-
-        // Even if connect is running on trusted domain we can override it with `trust-issues=true` query param.
-        if (query['trust-issues'] === 'true') {
-            settings.trustedHost = false;
-        }
-
-        // Even if connect is running on not trusted domain we can override it with `trust-issues=false` query param.
-        if (query['trust-issues'] === 'false') {
-            settings.trustedHost = true;
         }
     }
 

--- a/packages/connect-web/src/connectSettings.ts
+++ b/packages/connect-web/src/connectSettings.ts
@@ -71,6 +71,11 @@ export const parseConnectSettings = (input: Partial<ConnectSettings> = {}): Conn
         if (query['trust-issues'] === 'true') {
             settings.trustedHost = false;
         }
+
+        // Even if connect is running on not trusted domain we can override it with `trust-issues=false` query param.
+        if (query['trust-issues'] === 'false') {
+            settings.trustedHost = true;
+        }
     }
 
     if (typeof input.env !== 'string') {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
* New page in connect-explorer to set connect options. For now only `trustedHost` but we can extend it for transport for example. This page is for now intended to be used in e2e tests.
* Extend permissions test to make sure the new feature works.