### PR TITLE
fix(nix): use older gcc packages for linux

### DIFF
--- a/packages/suite-build/plugins/nixos-interpreter-plugin.ts
+++ b/packages/suite-build/plugins/nixos-interpreter-plugin.ts
@@ -26,10 +26,20 @@ export class NixosInterpreterPlugin {
     }
 
     setInterpreter(interpreter: string, file: string) {
-        return spawnSync('patchelf', ['--set-interpreter', interpreter, file], {
-            stdio: 'inherit',
-            cwd: this.options.cwd,
-        });
+        return spawnSync(
+            'patchelf',
+            [
+                '--set-rpath',
+                `${process.env.NIX_PATCHELF_LIBRARY_PATH}`,
+                '--set-interpreter',
+                interpreter,
+                file,
+            ],
+            {
+                stdio: 'inherit',
+                cwd: this.options.cwd,
+            },
+        );
     }
 
     apply(compiler: webpack.Compiler) {

--- a/shell.nix
+++ b/shell.nix
@@ -8,10 +8,16 @@ with import
 
 let
   # unstable packages
-  electron = electron_26;  # use the same version as defined in packages/suite-desktop/package.json
+  electron = electron_26; # use the same version as defined in packages/suite-desktop/package.json
   nodejs = nodejs_18;
+  # use older gcc. 10.2.0 with glibc 2.32 for node_modules bindings.
+  # electron-builder is packing the app with glibc 2.32, bindings should not be compiled with newer version.
+  gccPkgs = import (builtins.fetchTarball {
+    url = "https://github.com/NixOS/nixpkgs/archive/a78ed5cbdd5427c30ca02a47ce6cccc9b7d17de4.tar.gz";
+    sha256 = "0l5b1libi46sc3ly7a5vj04098f63aj5jynxpz44sb396nncnivl";
+  }) {};
 in
-  stdenv.mkDerivation {
+  stdenvNoCC.mkDerivation {
     name = "trezor-suite-dev";
     buildInputs = [
       bash
@@ -30,16 +36,17 @@ in
       pixman cairo giflib libjpeg libpng librsvg pango            # build dependencies for node-canvas
       shellcheck
     ] ++ lib.optionals stdenv.isLinux [
-      appimagekit nsis openjpeg osslsigncode p7zip squashfsTools  # binaries used by node_module: electron-builder
+      appimagekit nsis openjpeg osslsigncode p7zip squashfsTools gccPkgs.gcc # binaries used by node_module: electron-builder
       udev  # used by node_module: usb
-      # winePackages.minimal
     ] ++ lib.optionals stdenv.isDarwin (with darwin.apple_sdk.frameworks; [
       Cocoa
       CoreServices
+      gcc
     ]);
 
-    # for WalletWasabi.WabiSabiClientLibrary
-    LD_LIBRARY_PATH = "${gcc}/lib:${openssl.out}/lib:${zlib}/lib:${stdenv.cc.cc.lib}/lib";
+    # used by patchelf for WabiSabiClientLibrary in dev mode (see webpack nixos-interpreter-plugin)
+    NIX_PATCHELF_LIBRARY_PATH = "${openssl.out}/lib:${zlib}/lib:${gcc.cc.lib}/lib";
+    NIX_CC="${gcc}";
 
     shellHook = ''
       export NODE_OPTIONS=--max_old_space_size=4096


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

after [recent changes](https://github.com/trezor/trezor-suite/commit/f2dcb78f955838e7fd3322deb61dea889962d638) in shell.nix there is a problem with `LD_LIBRARY_PATH`

local environment with older system setup (older GLIBC) fails when accessing nix-shell with:
```
/nix/store/...-glibc-2.37-45/lib/libc.so.6: version `GLIBC_2.38' not found
```

same error occurs on `suite-data build:lib` script

`suite-desktop build:linux` works but created AppImage file cannot be opened (similar error about missing GLIBC)

## Solution:
- downgrade gcc and glibc to the same version as packed by electron-builder
- remove LD_LIBRARY_PATH in favor of custom variable which is used in patchelf of WabiSabiClientLibrary binary (only in dev mode)