### PR TITLE
Change `device.run` promise behavior

### DIFF
--- a/packages/connect/src/device/Device.ts
+++ b/packages/connect/src/device/Device.ts
@@ -240,8 +240,11 @@ export class Device extends TypedEmitter<DeviceEvents> {
         const runPromise = createDeferred();
         this.runPromise = runPromise;
 
-        // either finish with result or reject runPromise
-        return Promise.race([this._runInner(fn, options), runPromise.promise]);
+        this._runInner(fn, options).catch(err => {
+            runPromise.reject(err);
+        });
+
+        return runPromise.promise;
     }
 
     async override(error: Error) {


### PR DESCRIPTION
## Description

One of multiple solutions to `Authorization error: _promptPassphrase: Passphrase callback not configured` error, which are issued in parallel.

This PR preserves changes from https://github.com/trezor/trezor-suite/commit/b2678a4836944f95e29d77e88cdf65562f3a2bc5#diff-ca03cc83fb0e3d98908b763de7901b240e15b59ba046942b514f98801f3a8afaL240-R244 while it reverts the reordering of awaited promises.

The idea is following:
- if `_runInner` ends by resolving `runPromise`, new variant should be equivalent, as it returns the promise
- if `_runInner` ends by rejecting `runPromise`, new variant should be equivalent, as it returns the promise again
- if `_runInner` ends by throwing anything else (which was probably the reason for `Promise.race`), `runPromise` is still unresolved and can be rejected, therefore new variant should be equivalent