### PR TITLE
Test: get logs at the end

### DIFF
--- a/packages/connect-popup/e2e/support/helpers.ts
+++ b/packages/connect-popup/e2e/support/helpers.ts
@@ -107,3 +107,21 @@ export const openPopup = (
 
     return Promise.all(triggerPopup) as Promise<Page[]>;
 };
+
+export const checkHasLogs = async (logPage: Page) => {
+    const locator = await logPage.locator("button[data-test='@log-container/download-button']");
+    if (await locator.isVisible()) {
+        return true;
+    }
+    return false;
+};
+
+export const downloadLogs = async (logPage: Page, downloadLogPath: string) => {
+    const [download] = await Promise.all([
+        logPage.waitForEvent('download'), // wait for download to start
+        logPage.click("button[data-test='@log-container/download-button']"),
+    ]);
+
+    await download.saveAs(downloadLogPath);
+    return download;
+};

--- a/packages/connect-popup/src/log.tsx
+++ b/packages/connect-popup/src/log.tsx
@@ -154,6 +154,7 @@ const DebugCenter = () => {
             {logs.length > 0 ? (
                 <View
                     title="Logs"
+                    data-test="@connect-logs/logs"
                     buttons={
                         <DownloadButton
                             array={orderByTimestamp(logs)}
@@ -169,7 +170,9 @@ const DebugCenter = () => {
                 </View>
             ) : (
                 <Wrapper>
-                    <StyledP>Waiting for an app to connect</StyledP>
+                    <StyledP data-test="@connect-logs/no-logs">
+                        Waiting for an app to connect
+                    </StyledP>
                 </Wrapper>
             )}
         </>

--- a/packages/utils/src/addDashesToSpaces.ts
+++ b/packages/utils/src/addDashesToSpaces.ts
@@ -1,0 +1,3 @@
+export const addDashesToSpaces = (inputString: string): string =>
+    // Use a regular expression to replace spaces with dashes
+    inputString.replace(/\s+/g, '-');

--- a/packages/utils/src/index.ts
+++ b/packages/utils/src/index.ts
@@ -34,3 +34,4 @@ export * from './urlToOnion';
 export * as versionUtils from './versionUtils';
 export * as xssFilters from './xssFilters';
 export * from './getLocaleSeparators';
+export * from './addDashesToSpaces';


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Downloads the logs from logs collector in connect popup and store it as artifacts in /test-results/ so we can have a look at the logs in CI as well as locally.


Because it happens in `afterEach` it should not impact in the test it self.
