### PR TITLE
tests(suite-desktop): get rid of copying binaries

### DIFF
--- a/docs/tests/e2e-suite-desktop.md
+++ b/docs/tests/e2e-suite-desktop.md
@@ -1,0 +1,25 @@
+# @trezor/suite-desktop e2e tests
+
+### Prerequisites
+
+```
+yarn workspace @trezor/suite-desktop build:ui
+```
+
+Produces `suite-desktop/build` directory with javascript bundles in production mode.
+
+_Note: This step needs to be repeated on each change in suite-desktop-ui package._
+
+```
+yarn workspace @trezor/suite-desktop build:app
+```
+
+Produces `suite-desktop/dist` directory with javascript bundles in production mode and application assets.
+
+_Note: This step needs to be repeated on each change in suite-desktop-core package._
+
+### Running tests locally
+
+`yarn workspace @trezor/suite-desktop-core test:e2e`
+
+Opens an electron app controlled by the [playwright test runner](https://playwright.dev/)

--- a/packages/suite-desktop-core/e2e/support/common.ts
+++ b/packages/suite-desktop-core/e2e/support/common.ts
@@ -1,72 +1,34 @@
-import { promisify } from 'util';
+/* eslint-disable no-console */
+
 import path from 'path';
-import fs from 'fs';
 import { Page, _electron as electron } from '@playwright/test';
 
-const mkdir = promisify(fs.mkdir);
-const fileExists = promisify(fs.exists);
-const copyFile = promisify(fs.copyFile);
-const chmod = promisify(fs.chmod);
-
 export const launchSuite = async () => {
+    const appDir = path.join(__dirname, '../../../suite-desktop');
+
     const electronApp = await electron.launch({
-        cwd: path.join(__dirname, '../../../suite-desktop'),
-        args: ['./dist/app.js', '--log-level=debug', '--bridge-test'],
+        cwd: appDir,
+        args: [path.join(appDir, './dist/app.js'), '--log-level=debug', '--bridge-test'],
         // when testing electron, video needs to be setup like this. it works locally but not in docker
         // recordVideo: { dir: 'test-results' },
     });
+
+    electronApp.process().stdout?.on('data', data => console.log(data.toString()));
+    electronApp.process().stderr?.on('data', data => console.error(data.toString()));
+
+    await electronApp.evaluate(
+        (_, [resourcesPath]) => {
+            // This runs in the main Electron process.
+            // override global variable defined in app.ts
+            global.resourcesPath = resourcesPath;
+            return global.resourcesPath;
+        },
+        [path.join(appDir, 'build/static')],
+    );
+
     const window = await electronApp.firstWindow();
+
     return { electronApp, window };
-};
-
-export const patchBinaries = async () => {
-    const binResourcesPathFrom = path.join(__dirname, '../../..', 'suite-data/files/bin');
-    const binResourcesPathTo = path.join(
-        __dirname,
-        '../../../..',
-        '/node_modules/electron/dist/resources/bin',
-    );
-
-    const trezordPathFrom = path.join(binResourcesPathFrom, '/bridge/linux-x64/trezord');
-    const trezordPathTo = path.join(binResourcesPathTo, 'bridge');
-    if (!(await fileExists(trezordPathTo))) {
-        await mkdir(trezordPathTo, {
-            recursive: true,
-        });
-    }
-    await copyFile(trezordPathFrom, `${trezordPathTo}/trezord`);
-
-    const torPathFrom = path.join(binResourcesPathFrom, '/tor/linux-x64/tor');
-    const torPathTo = path.join(binResourcesPathTo, 'tor');
-    if (!(await fileExists(torPathTo))) {
-        await mkdir(torPathTo, {
-            recursive: true,
-        });
-    }
-
-    await copyFile(torPathFrom, `${torPathTo}/tor`);
-
-    const coinjoinMiddlewarePathFrom = path.join(
-        binResourcesPathFrom,
-        '/coinjoin/linux-x64/WalletWasabi.WabiSabiClientLibrary',
-    );
-    const coinjoinMiddlewarePathTo = path.join(binResourcesPathTo, 'coinjoin');
-
-    if (!(await fileExists(coinjoinMiddlewarePathTo))) {
-        await mkdir(coinjoinMiddlewarePathTo, {
-            recursive: true,
-        });
-    }
-
-    await copyFile(
-        coinjoinMiddlewarePathFrom,
-        `${coinjoinMiddlewarePathTo}/WalletWasabi.WabiSabiClientLibrary`,
-    );
-    // todo: for some reason, wabisabiclient lib needs to update permissions
-    await chmod(
-        `${coinjoinMiddlewarePathTo}/WalletWasabi.WabiSabiClientLibrary`,
-        fs.constants.S_IXOTH,
-    );
 };
 
 export const waitForDataTestSelector = (window: Page, selector: string, options = {}) =>

--- a/packages/suite-desktop-core/e2e/tests/coinjoin.test.ts
+++ b/packages/suite-desktop-core/e2e/tests/coinjoin.test.ts
@@ -4,7 +4,7 @@ import { Page, test as testPlaywright } from '@playwright/test';
 
 import { TrezorUserEnvLink } from '@trezor/trezor-user-env-link';
 
-import { patchBinaries, launchSuite } from '../support/common';
+import { launchSuite } from '../support/common';
 import { sendToAddress, generateBlock, waitForCoinjoinBackend } from '../support/regtest';
 
 /**
@@ -111,10 +111,6 @@ const passThroughInitialRun = async (window: Page) => {
 testPlaywright.describe('Coinjoin', () => {
     testPlaywright.beforeAll(async () => {
         testPlaywright.setTimeout(timeout * 10);
-        // todo: some problems with path in dev and production and tests. tldr tests are expecting
-        // binaries somewhere where they are not, so I copy them to that place. Maybe I find a
-        // better solution later
-        await patchBinaries();
 
         await TrezorUserEnvLink.api.trezorUserEnvConnect();
         await waitForCoinjoinBackend();

--- a/packages/suite-desktop-core/e2e/tests/electrum.test.ts
+++ b/packages/suite-desktop-core/e2e/tests/electrum.test.ts
@@ -2,7 +2,7 @@ import { Page, test as testPlaywright } from '@playwright/test';
 
 import { TrezorUserEnvLink } from '@trezor/trezor-user-env-link';
 
-import { patchBinaries, launchSuite, waitForDataTestSelector } from '../support/common';
+import { launchSuite, waitForDataTestSelector } from '../support/common';
 
 const clickDataTest = (window: Page, selector: string) => window.click(`[data-test="${selector}"]`);
 
@@ -16,10 +16,6 @@ const toggleDebugModeInSettings = async (window: Page) => {
 
 testPlaywright.describe.serial('Suite works with Electrum server', () => {
     testPlaywright.beforeAll(async () => {
-        // todo: some problems with path in dev and production and tests. tldr tests are expecting
-        // binaries somewhere where they are not, so I copy them to that place. Maybe I find a
-        // better solution later
-        await patchBinaries();
         await TrezorUserEnvLink.api.trezorUserEnvConnect();
         await TrezorUserEnvLink.api.startEmu({ wipe: true });
         await TrezorUserEnvLink.api.setupEmu({

--- a/packages/suite-desktop-core/e2e/tests/spawn-bridge.test.ts
+++ b/packages/suite-desktop-core/e2e/tests/spawn-bridge.test.ts
@@ -2,14 +2,10 @@ import { test as testPlaywright, expect as expectPlaywright } from '@playwright/
 
 import { TrezorUserEnvLink } from '@trezor/trezor-user-env-link';
 
-import { patchBinaries, launchSuite, waitForDataTestSelector } from '../support/common';
+import { launchSuite, waitForDataTestSelector } from '../support/common';
 
 testPlaywright.describe.serial('Bridge', () => {
     testPlaywright.beforeAll(async () => {
-        // todo: some problems with path in dev and production and tests. tldr tests are expecting
-        // binaries somewhere where they are not, so I copy them to that place. Maybe I find a
-        // better solution later
-        await patchBinaries();
         // We make sure that bridge from trezor-user-env is stopped.
         // So we properly test the electron app spawning bridge binary.
         await TrezorUserEnvLink.api.trezorUserEnvConnect();

--- a/packages/suite-desktop-core/e2e/tests/spawn-tor.test.ts
+++ b/packages/suite-desktop-core/e2e/tests/spawn-tor.test.ts
@@ -1,6 +1,6 @@
 import { Page, test as testPlaywright, expect as expectPlaywright } from '@playwright/test';
 
-import { patchBinaries, launchSuite } from '../support/common';
+import { launchSuite } from '../support/common';
 import { NetworkAnalyzer } from '../support/networkAnalyzer';
 
 const timeout = 1000 * 60 * 5; // 5 minutes because it takes a while to start tor.
@@ -32,13 +32,6 @@ const turnOnTorInSettings = async (window: Page, shouldEnableTor = true) => {
 };
 
 testPlaywright.describe('Tor loading screen', () => {
-    testPlaywright.beforeAll(async () => {
-        // todo: some problems with path in dev and production and tests. tldr tests are expecting
-        // binaries somewhere where they are not, so I copy them to that place. Maybe I find a
-        // better solution later
-        await patchBinaries();
-    });
-
     testPlaywright('Tor loading screen: happy path', async () => {
         testPlaywright.setTimeout(timeout);
 

--- a/packages/suite-desktop-core/src/libs/processes/BaseProcess.ts
+++ b/packages/suite-desktop-core/src/libs/processes/BaseProcess.ts
@@ -1,7 +1,6 @@
+import { app } from 'electron';
 import path from 'path';
 import { spawn, ChildProcess } from 'child_process';
-
-import { isDevEnv } from '@suite-common/suite-utils';
 
 import { b2t } from '../utils';
 
@@ -110,11 +109,16 @@ export abstract class BaseProcess {
         this.stopped = false;
 
         const { system, ext } = this.getPlatformInfo();
+        // NOTE:
+        // - unpacked app (dev || e2e-test)
+        //   binaries are stored in suite-desktop/build/static/bin/{this.resourceName}/{system}/{this.processName} - see desktop.webpack.config.ts
+        // - packed app (.dmg || .AppImage || .exe)
+        //   binaries are stored in {app.resourcesPath}/bin/{this.resourceName}/{this.processName} - see electron-builder-config.js
         const processDir = path.join(
             global.resourcesPath,
             'bin',
             this.resourceName,
-            isDevEnv ? system : '',
+            !app.isPackaged ? system : '',
         );
         const processPath = path.join(processDir, `${this.processName}${ext}`);
         const processEnv = { ...process.env };

--- a/packages/suite-desktop/package.json
+++ b/packages/suite-desktop/package.json
@@ -14,12 +14,12 @@
         "clean": "rimraf ./build-electron && yarn rimraf ./build && yarn rimraf ./dist",
         "build:ui": "yarn workspace @trezor/suite-build run build:desktop",
         "build:core": "yarn workspace @trezor/suite-desktop-core run build:core",
-        "build:app": "NODE_ENV=production yarn build:core && yarn build:app:electron",
+        "build:app": "NODE_ENV=production yarn build:core",
         "build:app:dev": "NODE_ENV=development yarn build:core",
         "build:app:electron": "yarn electron-builder --config electron-builder-config.js",
-        "build:linux": "yarn clean && yarn build:ui && yarn build:app --publish never --linux --x64 --arm64",
-        "build:mac": "yarn clean && yarn build:ui && yarn build:app --publish never --mac --x64 --arm64",
-        "build:win": "yarn clean && yarn build:ui && yarn build:app --publish never --win --x64",
+        "build:linux": "yarn clean && yarn build:ui && yarn build:app && yarn build:app:electron --publish never --linux --x64 --arm64",
+        "build:mac": "yarn clean && yarn build:ui && yarn build:app && yarn build:app:electron --publish never --mac --x64 --arm64",
+        "build:win": "yarn clean && yarn build:ui && yarn build:app && yarn build:app:electron --publish never --win --x64",
         "lint:js": "yarn g:eslint '**/*.{ts,tsx,js}'"
     },
     "dependencies": {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

fix for reverted commit https://github.com/trezor/trezor-suite/commit/3b8296c3d57ba85ee98309ecdb8e7d2478bf9d49

reason for breaking builds was invalid condition when to use system suffix (BaseProcess file)
we dont need it in packed build but its required in unpacked builds (dev mode or e2e-playwright tests)
