### PR TITLE
fix(suite): set sequence to undefined for final transactions

### DIFF
--- a/packages/suite/src/actions/wallet/send/sendFormBitcoinActions.ts
+++ b/packages/suite/src/actions/wallet/send/sendFormBitcoinActions.ts
@@ -64,7 +64,7 @@ export const composeTransaction =
             });
         }
 
-        let sequence = 0;
+        let sequence; // Must be undefined for final transaction.
         if (formValues.options.includes('bitcoinRBF')) {
             // RBF is set, add sequence to inputs
             sequence = BTC_RBF_SEQUENCE;


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Transactions must have their `sequence` number set to `undefined` to be treated as final by `inputToTrezor`. The bug stems from 06a9f7a53f5e30bc0914f01d0d4e8488a3fb5315.

Resolves #9874 
