### PR TITLE
feat(suite-common): add optional title to messages

### DIFF
--- a/docs/features/message-system.md
+++ b/docs/features/message-system.md
@@ -215,6 +215,12 @@ Structure of config, types and optionality of specific keys can be found in the 
                     "en": "New Trezor firmware is available!",
                     "de": "Neue Trezor Firmware ist verfügbar!"
                 },
+                // optional headline following the language structure of content
+                "headline": {
+                    "en-GB": "Update your Trezor",
+                    "en": "Update your Trezor",
+                    "de": "Neue"
+                },
                 // Call to action. Used only for banner and context.
                 "cta": {
                     /*

--- a/suite-common/message-system/schema/config.schema.v1.json
+++ b/suite-common/message-system/schema/config.schema.v1.json
@@ -253,6 +253,9 @@
                             "content": {
                                 "$ref": "#/definitions/localization"
                             },
+                            "headline": {
+                                "$ref": "#/definitions/localization"
+                            },
                             "cta": {
                                 "title": "CTA",
                                 "description": "Only used for 'banner' and 'context' categories.",

--- a/suite-common/message-system/src/messageSystemTypes.ts
+++ b/suite-common/message-system/src/messageSystemTypes.ts
@@ -18,6 +18,7 @@ export type MessageSystemRootState = {
 
 export const Feature = {
     coinjoin: 'coinjoin',
+    killswitch: 'killswitch',
 } as const;
 
 export type FeatureDomain = (typeof Feature)[keyof typeof Feature];

--- a/suite-common/suite-types/src/messageSystem.ts
+++ b/suite-common/suite-types/src/messageSystem.ts
@@ -102,6 +102,7 @@ export interface Message {
     variant: Variant;
     category: Category | Category[];
     content: Localization;
+    headline?: Localization;
     cta?: CTA;
     modal?: Modal;
     /**


### PR DESCRIPTION
Adding optional title for messages and killswitch feature domain

## Description

This will enable sending killswitch feature message to a device as discussed with @matejkriz and also adds option to send title for the message in the app, not only the content.

