### PR TITLE
fix(suite-native): infinite discovery loop

### DIFF
--- a/suite-native/discovery/src/discoveryThunks.ts
+++ b/suite-native/discovery/src/discoveryThunks.ts
@@ -62,7 +62,7 @@ const discoverAccountsByDescriptorThunk = createThunk(
     ) => {
         let isFinalRound = false;
 
-        if (!descriptorsBundle) {
+        if (A.isEmpty(descriptorsBundle)) {
             isFinalRound = true;
         }
 
@@ -161,7 +161,7 @@ const discoverNetworkBatchThunk = createThunk(
         });
 
         // All accounts of the batch were already discovered, skip it.
-        if (!chunkBundle) {
+        if (A.isEmpty(chunkBundle)) {
             dispatch(
                 discoverNetworkBatchThunk({
                     deviceState,


### PR DESCRIPTION
Because of a wrong conditional check, the discovery loop was infinite. Fixed by this commit.
