### PR TITLE
Chore/connect popup/refactor 1

### DIFF
--- a/packages/connect-popup/src/index.tsx
+++ b/packages/connect-popup/src/index.tsx
@@ -19,6 +19,7 @@ import { getSystemInfo } from '@trezor/connect-common';
 
 import * as view from './view';
 import {
+    getState,
     setState,
     showView,
     initMessageChannel,
@@ -253,9 +254,9 @@ const handshake = (handshake: PopupHandshake) => {
     clearTimeout(handshakeTimeout);
 
     // use trusted settings from iframe
-    setState({ settings: payload.settings });
+    setState({ ...getState(), ...payload.settings });
 
-    reactEventBus.dispatch(handshake);
+    reactEventBus.dispatch({ type: 'state-update', payload: getState() });
 
     if (isPhishingDomain(payload.settings.origin || '')) {
         reactEventBus.dispatch({ type: 'phishing-domain' });

--- a/packages/connect-popup/src/view/common.tsx
+++ b/packages/connect-popup/src/view/common.tsx
@@ -1,17 +1,9 @@
 // origin: https://github.com/trezor/connect/blob/develop/src/js/popup/view/common.js
 
-import {
-    POPUP,
-    ERRORS,
-    PopupInit,
-    CoreMessage,
-    ConnectSettings,
-    SystemInfo,
-    createUiResponse,
-} from '@trezor/connect';
+import { POPUP, ERRORS, PopupInit, CoreMessage, createUiResponse } from '@trezor/connect';
 import { createRoot } from 'react-dom/client';
 
-import { ConnectUI } from '@trezor/connect-ui';
+import { ConnectUI, State } from '@trezor/connect-ui';
 import { StyleSheetWrapper } from './react/StylesSheetWrapper';
 import { reactEventBus } from '@trezor/connect-ui/src/utils/eventBus';
 
@@ -19,16 +11,9 @@ export const header: HTMLElement = document.getElementsByTagName('header')[0];
 export const container: HTMLElement = document.getElementById('container')!;
 export const views: HTMLElement = document.getElementById('views')!;
 
-type State = {
-    settings?: ConnectSettings;
-    iframe?: Window;
-    broadcast?: BroadcastChannel;
-    systemInfo?: SystemInfo;
-};
-
 let state: State = {};
 
-export const setState = (newState: State) => (state = { ...state, ...newState });
+export const setState = (newState: Partial<State>) => (state = { ...state, ...newState });
 export const getState = () => state;
 
 export const createTooltip = (text: string) => {

--- a/packages/connect-ui/src/types.ts
+++ b/packages/connect-ui/src/types.ts
@@ -1,0 +1,10 @@
+import { PopupHandshake, IFrameLoaded } from '@trezor/connect';
+
+export type State = Partial<PopupHandshake['payload']> &
+    Partial<IFrameLoaded['payload']> & {
+        iframe?: Window;
+        broadcast?: BroadcastChannel;
+        // preferred device will appear here
+    };
+
+export const getDefaultState = (): State => ({});

--- a/packages/connect-ui/src/types.ts
+++ b/packages/connect-ui/src/types.ts
@@ -1,6 +1,7 @@
-import { PopupHandshake, IFrameLoaded } from '@trezor/connect';
+import { PopupHandshake, PopupMethodInfo, IFrameLoaded } from '@trezor/connect';
 
 export type State = Partial<PopupHandshake['payload']> &
+    Partial<PopupMethodInfo['payload']> &
     Partial<IFrameLoaded['payload']> & {
         iframe?: Window;
         broadcast?: BroadcastChannel;

--- a/packages/connect-ui/src/utils/eventBus.ts
+++ b/packages/connect-ui/src/utils/eventBus.ts
@@ -1,23 +1,23 @@
-import { PopupHandshake, UI_REQUEST, Device, PopupMethodInfo } from '@trezor/connect';
+import { UI_REQUEST, Device } from '@trezor/connect';
 
 import { TransportEventProps } from '../views/Transport';
 import { PassphraseEventProps } from '../views/Passphrase';
 import { ErrorViewProps } from '../views/Error';
+import { State } from '../types';
 
 export type ConnectUIEventProps =
     // connect-core events
     | TransportEventProps
     | PassphraseEventProps
     | ErrorViewProps
-    | PopupHandshake
-    | PopupMethodInfo
     | { type: typeof UI_REQUEST.DEVICE_NEEDS_BACKUP; device: Device }
     | { type: typeof UI_REQUEST.FIRMWARE_OUTDATED; device: Device }
     // connect-popup events
     | { type: 'phishing-domain' }
     | { type: 'connect-ui-rendered' }
     | { type: 'waiting-for-iframe-handshake' }
-    | { type: 'waiting-for-iframe-init' };
+    | { type: 'waiting-for-iframe-init' }
+    | { type: 'state-update'; payload: State };
 
 const reactChannel = 'react';
 


### PR DESCRIPTION
cherry-picking imho uncontroversial commits from #9790

these will be useful also for #9525

[177246c](https://github.com/trezor/trezor-suite/pull/9879/commits/177246c7608f53c45b957860a96433b919f6dd74) - moves state definition from connect-popup to connect-ui. connect-popup depends on connect-ui and not the other way round. another option would be to move this to some connect-common package but I wasn't sure about that. 
[385efbf](https://github.com/trezor/trezor-suite/pull/9879/commits/385efbf2dfdc59194d757f6516088569ba831428) - now react state and connect-popup state should be more or less mirrored (the serializable part). before this we were building connect-ui state separately for no good reason.
[24bfb42](https://github.com/trezor/trezor-suite/pull/9879/commits/24bfb42d4899d73d17eb7baa2729c9269c294e3e) - temporary. run all tests