### PR TITLE
Fix/discovery improvements

### DIFF
--- a/suite-common/wallet-core/src/device/deviceThunks.ts
+++ b/suite-common/wallet-core/src/device/deviceThunks.ts
@@ -275,7 +275,7 @@ export const acquireDevice = createThunk(
 export const authorizeDevice = createThunk(
     `${MODULE_PREFIX}/authorizeDevice`,
     async (
-        // isUseEmptyPassphraseForced will be removed once the suite-native has support for passphrase authorization.
+        // TODO: isUseEmptyPassphraseForced will be removed once the suite-native has support for passphrase authorization.
         {
             isUseEmptyPassphraseForced = false,
         }: { isUseEmptyPassphraseForced?: boolean } | undefined = {},

--- a/suite-common/wallet-core/src/discovery/discoveryThunks.ts
+++ b/suite-common/wallet-core/src/discovery/discoveryThunks.ts
@@ -239,16 +239,25 @@ const getBundleThunk = createThunk(
 export const getAvailableCardanoDerivationsThunk = createThunk(
     `${DISCOVERY_MODULE_PREFIX}/getAvailableCardanoDerivations`,
     async (
-        { deviceState, device }: { deviceState: string; device: TrezorDevice },
+        {
+            deviceState,
+            device,
+            // TODO: isUseEmptyPassphraseForced will be removed once the suite-native has support for passphrase authorization.
+            isUseEmptyPassphraseForced = false,
+        }: { deviceState: string; device: TrezorDevice; isUseEmptyPassphraseForced?: boolean },
         { dispatch },
     ): Promise<('normal' | 'legacy' | 'ledger')[] | undefined> => {
+        // The suite-native does not have support for passphrase authorization, so the `useEmptyPassphrase` has to be hardcoded to `true` in that case.
+        // The thunk argument `isUseEmptyPassphraseForced` can be removed once the passphrase support is implemented in suite-native.
+        const useEmptyPassphrase = isUseEmptyPassphraseForced || device.useEmptyPassphrase;
+
         // If icarus and icarus-trezor derivations return same pub key
         // we can skip derivation of the latter as it would discover same accounts.
         // Ledger derivation will always result in different pub key except in shamir where all derivations are the same
         const commonParams = {
             device,
+            useEmptyPassphrase,
             keepSession: true,
-            useEmptyPassphrase: device.useEmptyPassphrase,
             path: "m/1852'/1815'/0'",
         };
         const icarusPubKeyResult = await TrezorConnect.cardanoGetPublicKey({

--- a/suite-native/discovery/src/discoveryMiddleware.ts
+++ b/suite-native/discovery/src/discoveryMiddleware.ts
@@ -36,16 +36,6 @@ export const prepareDiscoveryMiddleware = createMiddlewareWithExtraDeps(
             );
         }
 
-        // Update discovery for pass-phrased wallets.
-        if (deviceActions.receiveAuthConfirm.match(action) && action.payload.device.state) {
-            dispatch(
-                discoveryActions.updateDiscovery({
-                    deviceState: action.payload.device.state,
-                    authConfirm: false,
-                }),
-            );
-        }
-
         return next(action);
     },
 );

--- a/suite-native/discovery/src/discoveryThunks.ts
+++ b/suite-native/discovery/src/discoveryThunks.ts
@@ -74,6 +74,7 @@ const discoverAccountsByDescriptorThunk = createThunk(
                 coin: bundleItem.coin,
                 descriptor: bundleItem.descriptor,
                 useEmptyPassphrase: true,
+                details: 'tokenBalances',
             });
 
             if (success) {

--- a/suite-native/discovery/src/discoveryThunks.ts
+++ b/suite-native/discovery/src/discoveryThunks.ts
@@ -73,6 +73,7 @@ const discoverAccountsByDescriptorThunk = createThunk(
             const { success, payload: accountInfo } = await TrezorConnect.getAccountInfo({
                 coin: bundleItem.coin,
                 descriptor: bundleItem.descriptor,
+                useEmptyPassphrase: true,
             });
 
             if (success) {
@@ -216,13 +217,17 @@ export const createDescriptorPreloadedDiscoveryThunk = createThunk(
         const networks = areTestnetsEnabled ? supportedNetworkSymbols : supportedMainnetSymbols;
 
         const availableCardanoDerivations = await dispatch(
-            getAvailableCardanoDerivationsThunk({ deviceState, device }),
+            getAvailableCardanoDerivationsThunk({
+                deviceState,
+                device,
+                isUseEmptyPassphraseForced: true,
+            }),
         ).unwrap();
 
         dispatch(
             createDiscovery({
                 deviceState,
-                authConfirm: !device.useEmptyPassphrase,
+                authConfirm: false,
                 index: 0,
                 status: DiscoveryStatus.IDLE,
                 total: networks.length,

--- a/suite-native/discovery/src/utils.ts
+++ b/suite-native/discovery/src/utils.ts
@@ -41,6 +41,7 @@ export class DeviceAccessMutex {
 export const fetchBundleDescriptors = async (bundle: DiscoveryItem[]) => {
     const { success, payload } = await TrezorConnect.getAccountDescriptor({
         bundle,
+        useEmptyPassphrase: true,
     });
 
     if (success && payload)


### PR DESCRIPTION
## Description
There are two commits in this PR:
- 481e6f96176c27e62deeb494fb6539ff340eb567 makes sure, that native discovery never asks user to insert a passphrase
- fc597289ef80835dbd825c1a7dbc392dee6d96a7 Makes discovery find the ETH tokens if there are any
<!--- Describe your changes in detail -->