### PR TITLE
Feat: transport with default messages

### DIFF
--- a/packages/connect/src/device/DeviceList.ts
+++ b/packages/connect/src/device/DeviceList.ts
@@ -123,6 +123,10 @@ export class DeviceList extends TypedEmitter<DeviceListEvents> {
                         );
                 }
             } else if (transportType instanceof Transport) {
+                // custom Transport might be initialized without messages, update them if so
+                if (!transportType.getMessage()) {
+                    transportType.updateMessages(this.messages);
+                }
                 this.transports.push(transportType);
             } else {
                 // runtime check

--- a/packages/transport-native/src/nativeUsb.ts
+++ b/packages/transport-native/src/nativeUsb.ts
@@ -11,7 +11,8 @@ export class NativeUsbTransport extends AbstractUsbTransport {
     // TODO: Not sure how to solve this type correctly.
     public name = 'NativeUsbTransport' as any;
 
-    constructor({ messages, logger }: ConstructorParameters<typeof AbstractTransport>[0]) {
+    constructor(params?: ConstructorParameters<typeof AbstractTransport>[0]) {
+        const { messages, logger } = params || {};
         const sessionsBackground = new SessionsBackground();
 
         const sessionsClient = new SessionsClient({

--- a/packages/transport/src/transports/abstractUsb.ts
+++ b/packages/transport/src/transports/abstractUsb.ts
@@ -1,13 +1,13 @@
 import { createDeferred, Deferred } from '@trezor/utils';
 
-import { AbstractTransport, AcquireInput, ReleaseInput } from './abstract';
+import { AbstractTransport, AbstractTransportParams, AcquireInput, ReleaseInput } from './abstract';
 import { buildAndSend } from '../utils/send';
 import { receiveAndParse } from '../utils/receive';
 import { SessionsClient } from '../sessions/client';
 import * as ERRORS from '../errors';
 import type { UsbInterface } from '../interfaces/usb';
 
-export type UsbTransportConstructorParams = ConstructorParameters<typeof AbstractTransport>[0] & {
+export type UsbTransportConstructorParams = AbstractTransportParams & {
     usbInterface: UsbInterface;
     sessionsClient: (typeof SessionsClient)['prototype'];
 };

--- a/packages/transport/src/transports/bridge.ts
+++ b/packages/transport/src/transports/bridge.ts
@@ -4,7 +4,7 @@ import { bridgeApiCall } from '../utils/bridgeApiCall';
 import * as bridgeApiResult from '../utils/bridgeApiResult';
 import { buildOne } from '../utils/send';
 import { receiveOne } from '../utils/receive';
-import { AbstractTransport, AcquireInput, ReleaseInput } from './abstract';
+import { AbstractTransport, AbstractTransportParams, AcquireInput, ReleaseInput } from './abstract';
 
 import * as ERRORS from '../errors';
 import { AnyError, AsyncResultWithTypedError, Descriptor } from '../types';
@@ -44,7 +44,7 @@ type IncompleteRequestOptions = {
     signal?: AbortController['signal'];
 };
 
-type BridgeConstructorParameters = ConstructorParameters<typeof AbstractTransport>[0] & {
+type BridgeConstructorParameters = AbstractTransportParams & {
     // bridge url
     url?: string;
     latestVersion?: string;
@@ -68,7 +68,8 @@ export class BridgeTransport extends AbstractTransport {
 
     public name = 'BridgeTransport' as const;
 
-    constructor({ url = DEFAULT_URL, latestVersion, ...args }: BridgeConstructorParameters) {
+    constructor(params?: BridgeConstructorParameters) {
+        const { url = DEFAULT_URL, latestVersion, ...args } = params || {};
         super(args);
         this.url = url;
         this.latestVersion = latestVersion;

--- a/packages/transport/src/transports/nodeusb.browser.ts
+++ b/packages/transport/src/transports/nodeusb.browser.ts
@@ -1,4 +1,4 @@
-import { AbstractTransport } from './abstract';
+import { AbstractTransport, AbstractTransportParams } from './abstract';
 
 import { WRONG_ENVIRONMENT } from '../errors';
 import { empty, emptyAbortable, emptySync } from '../utils/resultEmpty';
@@ -8,7 +8,7 @@ import { empty, emptyAbortable, emptySync } from '../utils/resultEmpty';
 export class NodeUsbTransport extends AbstractTransport {
     public name = 'NodeUsbTransport' as const;
 
-    constructor(params: ConstructorParameters<typeof AbstractTransport>[0]) {
+    constructor(params?: AbstractTransportParams) {
         super(params);
         console.error(WRONG_ENVIRONMENT);
     }

--- a/packages/transport/src/transports/nodeusb.ts
+++ b/packages/transport/src/transports/nodeusb.ts
@@ -1,5 +1,5 @@
 import { WebUSB } from 'usb';
-import { AbstractTransport } from './abstract';
+import { AbstractTransportParams } from './abstract';
 import { AbstractUsbTransport } from './abstractUsb';
 import { SessionsClient } from '../sessions/client';
 import { SessionsBackground } from '../sessions/background';
@@ -12,7 +12,8 @@ import { UsbInterface } from '../interfaces/usb';
 export class NodeUsbTransport extends AbstractUsbTransport {
     public name = 'NodeUsbTransport' as const;
 
-    constructor({ messages, logger }: ConstructorParameters<typeof AbstractTransport>[0]) {
+    constructor(params?: AbstractTransportParams) {
+        const { messages, logger } = params || {};
         const sessionsBackground = new SessionsBackground();
 
         // in nodeusb there is no synchronization yet. this is a followup and needs to be decided

--- a/packages/transport/src/transports/udp.ts
+++ b/packages/transport/src/transports/udp.ts
@@ -1,4 +1,4 @@
-import { AbstractTransport } from './abstract';
+import { AbstractTransportParams } from './abstract';
 
 import { UdpInterface } from '../interfaces/udp';
 import { AbstractUsbTransport } from './abstractUsb';
@@ -6,11 +6,11 @@ import { AbstractUsbTransport } from './abstractUsb';
 import { SessionsClient } from '../sessions/client';
 import { SessionsBackground } from '../sessions/background';
 
-type UdpConstructorParameters = ConstructorParameters<typeof AbstractTransport>[0] & {};
 export class UdpTransport extends AbstractUsbTransport {
     public name = 'UdpTransport' as const;
 
-    constructor({ messages, logger }: UdpConstructorParameters) {
+    constructor(params?: AbstractTransportParams) {
+        const { messages, logger } = params || {};
         const sessionsBackground = new SessionsBackground();
 
         // in udp there is no synchronization yet. it depends where this transport runs (node or browser)

--- a/packages/transport/src/transports/webusb.browser.ts
+++ b/packages/transport/src/transports/webusb.browser.ts
@@ -1,11 +1,9 @@
-import { AbstractTransport } from './abstract';
+import { AbstractTransportParams } from './abstract';
 import { AbstractUsbTransport } from './abstractUsb';
 import { SessionsClient } from '../sessions/client';
 import { UsbInterface } from '../interfaces/usb';
 
 import { initBackgroundInBrowser } from '../sessions/background-browser';
-
-type UsbTransportConstructorParams = ConstructorParameters<typeof AbstractTransport>[0];
 
 /**
  * WebUsbTransport
@@ -15,7 +13,8 @@ type UsbTransportConstructorParams = ConstructorParameters<typeof AbstractTransp
 export class WebUsbTransport extends AbstractUsbTransport {
     public name = 'WebUsbTransport' as const;
 
-    constructor({ messages, logger }: UsbTransportConstructorParams) {
+    constructor(params?: AbstractTransportParams) {
+        const { messages, logger } = params || {};
         const { requestFn, registerBackgroundCallbacks } = initBackgroundInBrowser();
 
         super({

--- a/packages/transport/src/transports/webusb.ts
+++ b/packages/transport/src/transports/webusb.ts
@@ -1,4 +1,4 @@
-import { AbstractTransport } from './abstract';
+import { AbstractTransport, AbstractTransportParams } from './abstract';
 
 import { WRONG_ENVIRONMENT } from '../errors';
 import { empty, emptyAbortable, emptySync } from '../utils/resultEmpty';
@@ -7,7 +7,7 @@ import { empty, emptyAbortable, emptySync } from '../utils/resultEmpty';
 export class WebUsbTransport extends AbstractTransport {
     public name = 'WebUsbTransport' as const;
 
-    constructor(params: ConstructorParameters<typeof AbstractTransport>[0]) {
+    constructor(params?: AbstractTransportParams) {
         super(params);
         console.error(WRONG_ENVIRONMENT);
     }

--- a/packages/transport/tests/abstractUsb.test.ts
+++ b/packages/transport/tests/abstractUsb.test.ts
@@ -77,8 +77,10 @@ describe('Usb', () => {
             const transport = new TestUsbTransport({
                 usbInterface: testUsbInterface,
                 sessionsClient,
-                messages,
             });
+
+            // there are no loaded messages
+            expect(transport.getMessage()).toEqual(false);
 
             const res = await transport.init().promise;
             expect(res).toMatchObject({
@@ -107,7 +109,6 @@ describe('Usb', () => {
             const transport = new TestUsbTransport({
                 usbInterface: testUsbInterface,
                 sessionsClient,
-                messages,
             });
 
             await transport.init().promise;
@@ -285,6 +286,8 @@ describe('Usb', () => {
             if (!acquireRes.success) return;
 
             expect(acquireRes.payload).toEqual('1');
+
+            expect(transport.getMessage('GetAddress')).toEqual(true);
 
             // doesn't really matter what what message we send
             const res = await transport.call({

--- a/suite-native/state/package.json
+++ b/suite-native/state/package.json
@@ -30,7 +30,6 @@
         "@suite-native/storage": "workspace:*",
         "@suite-native/toasts": "workspace:*",
         "@trezor/connect": "workspace:*",
-        "@trezor/protobuf": "workspace:*",
         "@trezor/transport-native": "workspace:*",
         "@trezor/utils": "workspace:*",
         "expo-device": "5.6.0",

--- a/suite-native/state/src/extraDependencies.ts
+++ b/suite-native/state/src/extraDependencies.ts
@@ -11,18 +11,12 @@ import { PROTO } from '@trezor/connect';
 import { mergeDeepObject } from '@trezor/utils';
 import { NativeUsbTransport } from '@trezor/transport-native';
 
-const protobufMessages = require('@trezor/protobuf/messages.json');
-
 const deviceType = Device.isDevice ? 'device' : 'emulator';
 
 const transportsPerDeviceType = {
     device: Platform.select({
         ios: ['BridgeTransport', 'UdpTransport'],
-        android: [
-            new NativeUsbTransport({
-                messages: protobufMessages,
-            }),
-        ],
+        android: [new NativeUsbTransport()],
     }),
     emulator: ['BridgeTransport', 'UdpTransport'],
 } as const;

--- a/suite-native/state/tsconfig.json
+++ b/suite-native/state/tsconfig.json
@@ -33,7 +33,6 @@
         { "path": "../storage" },
         { "path": "../toasts" },
         { "path": "../../packages/connect" },
-        { "path": "../../packages/protobuf" },
         {
             "path": "../../packages/transport-native"
         },

--- a/yarn.lock
+++ b/yarn.lock
@@ -8270,7 +8270,6 @@ __metadata:
     "@suite-native/storage": "workspace:*"
     "@suite-native/toasts": "workspace:*"
     "@trezor/connect": "workspace:*"
-    "@trezor/protobuf": "workspace:*"
     "@trezor/transport-native": "workspace:*"
     "@trezor/utils": "workspace:*"
     expo-device: 5.6.0


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

~`@trezor/transport` package already have a reference to `@trezor/protobuf` package therefore there is no need to require protobuf messages (json) by the `AbstractTransport` constructor~

~if messages are not provided then default messages are used~

i've changed the concept, custom transports might be initialized without protobuf messages, and their presence is checked by `@trezor/connect`

not need to explicitly import messages.json is useful when custom Transport interface is used (for example NativeUsbTransport)
