### PR TITLE
fix(suite): support unknown (custom) internal_models

### DIFF
--- a/packages/suite/src/config/onboarding/steps.ts
+++ b/packages/suite/src/config/onboarding/steps.ts
@@ -41,13 +41,13 @@ const steps: Step[] = [
     {
         id: STEP.ID_AUTHENTICATE_DEVICE_STEP,
         stepGroup: 0,
-        unsupportedModels: [DeviceModelInternal.T1B1, DeviceModelInternal.T2T1],
+        supportedModels: [DeviceModelInternal.T2B1],
         prerequisites: [...commonPrerequisites, 'device-recovery-mode', 'device-different'],
     },
     {
         id: STEP.ID_TUTORIAL_STEP,
         stepGroup: 0,
-        unsupportedModels: [DeviceModelInternal.T1B1, DeviceModelInternal.T2T1],
+        supportedModels: [DeviceModelInternal.T2B1],
         prerequisites: [...commonPrerequisites, 'device-recovery-mode', 'device-different'],
     },
     {

--- a/packages/suite/src/types/onboarding/index.ts
+++ b/packages/suite/src/types/onboarding/index.ts
@@ -7,7 +7,7 @@ export interface Step {
     stepGroup: number | undefined;
     prerequisites?: (PrerequisiteType | 'device-different')[];
     path?: AnyPath[];
-    unsupportedModels?: DeviceModelInternal[];
+    supportedModels?: DeviceModelInternal[];
 }
 
 // todo: remove, improve typing

--- a/packages/suite/src/utils/onboarding/__tests__/steps.test.ts
+++ b/packages/suite/src/utils/onboarding/__tests__/steps.test.ts
@@ -14,7 +14,7 @@ const backupStep: Step = {
     id: STEP.ID_BACKUP_STEP,
     path: [],
     stepGroup: 1,
-    unsupportedModels: [DeviceModelInternal.T1B1],
+    supportedModels: [DeviceModelInternal.T2B1],
 };
 
 const stateMock = {

--- a/packages/suite/src/utils/onboarding/steps.ts
+++ b/packages/suite/src/utils/onboarding/steps.ts
@@ -12,7 +12,11 @@ export const isStepUsed = (step: Step, getState: GetState) => {
     const deviceModelInternal = device?.features?.internal_model;
 
     // The order of IF conditions matters!
-    if (deviceModelInternal && step.unsupportedModels?.includes(deviceModelInternal)) {
+    if (
+        deviceModelInternal &&
+        Array.isArray(step.supportedModels) &&
+        !step.supportedModels.includes(deviceModelInternal)
+    ) {
         return false;
     }
     if (step.id === ID_AUTHENTICATE_DEVICE_STEP) {

--- a/packages/suite/src/views/settings/SettingsDevice/Homescreen.tsx
+++ b/packages/suite/src/views/settings/SettingsDevice/Homescreen.tsx
@@ -82,6 +82,10 @@ export const Homescreen = ({ isDeviceLocked }: HomescreenProps) => {
     }
 
     const deviceModelInternal = device.features.internal_model;
+    if (!deviceModelInformation[deviceModelInternal]) {
+        // disallow homescreen updates for unknown/custom models
+        return null;
+    }
 
     const resetUpload = () => {
         setCustomHomescreen('');


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Similar to https://github.com/trezor/trezor-suite/pull/9764
fix critical actions where suite is failing when connecting unknown/custom internal_model

There are possibly more places where suite expect defined objects by checking device.internal_model but i dint run across them
