### PR TITLE
Feat/connect device lock

### DIFF
--- a/packages/connect/src/core/index.ts
+++ b/packages/connect/src/core/index.ts
@@ -343,6 +343,8 @@ export const onCall = async (message: CoreMessage) => {
         return Promise.resolve();
     }
 
+    postMessage(createDeviceMessage(DEVICE.LOCK, true));
+
     if (!_deviceList && !DataManager.getSettings('transportReconnect')) {
         // transport is missing try to initialize it once again
         await initTransport(DataManager.getSettings());
@@ -678,6 +680,8 @@ export const onCall = async (message: CoreMessage) => {
             }
             postMessage(response);
         }
+
+        postMessage(createDeviceMessage(DEVICE.LOCK, false));
     }
 };
 

--- a/packages/connect/src/events/device.ts
+++ b/packages/connect/src/events/device.ts
@@ -14,6 +14,7 @@ export const DEVICE = {
     ACQUIRED: 'device-acquired',
     RELEASED: 'device-released',
     USED_ELSEWHERE: 'device-used_elsewhere',
+    LOCK: 'device-lock',
 
     LOADING: 'device-loading',
 
@@ -34,6 +35,11 @@ export interface DeviceButtonRequest {
     payload: DeviceButtonRequestPayload & { device: Device };
 }
 
+export interface DeviceLockEvent {
+    type: typeof DEVICE.LOCK;
+    payload: boolean;
+}
+
 export type DeviceEvent =
     | {
           type:
@@ -43,7 +49,8 @@ export type DeviceEvent =
               | typeof DEVICE.DISCONNECT;
           payload: Device;
       }
-    | DeviceButtonRequest;
+    | DeviceButtonRequest
+    | DeviceLockEvent;
 
 export type DeviceEventMessage = DeviceEvent & { event: typeof DEVICE_EVENT };
 

--- a/packages/suite/src/reducers/suite/suiteReducer.ts
+++ b/packages/suite/src/reducers/suite/suiteReducer.ts
@@ -6,7 +6,7 @@ import { getNumberFromPixelString, versionUtils } from '@trezor/utils';
 import { isWeb, getWindowWidth } from '@trezor/env-utils';
 import { variables } from '@trezor/components';
 import { SuiteThemeVariant } from '@trezor/suite-desktop-api';
-import { TRANSPORT, TransportInfo, ConnectSettings } from '@trezor/connect';
+import { TRANSPORT, DEVICE, TransportInfo, ConnectSettings } from '@trezor/connect';
 
 import { getIsTorEnabled, getIsTorLoading } from 'src/utils/suite/tor';
 import type { OAuthServerEnvironment } from 'src/types/suite/metadata';
@@ -226,7 +226,7 @@ const suiteReducer = (state: SuiteState = initialState, action: Action): SuiteSt
                 changeLock(draft, SUITE.LOCK_TYPE.UI, action.payload);
                 break;
 
-            case SUITE.LOCK_DEVICE:
+            case DEVICE.LOCK:
                 changeLock(draft, SUITE.LOCK_TYPE.DEVICE, action.payload);
                 break;
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

WIP proof of concept, looking for volunteer to finish suite implementation :) 

emit `DEVICE.LOCK` event from connect when requested method is using the device,

this feature is here to replace suite `DEVICE_LOCK` action which is [constantly not working](https://github.com/trezor/trezor-suite/pull/9858) properly

