### PR TITLE
Reset  button requests in device authenticity check

### DIFF
--- a/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/AuthenticateDeviceModal.tsx
+++ b/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/AuthenticateDeviceModal.tsx
@@ -18,24 +18,14 @@ export const AuthenticateDeviceModal = () => {
     const handleClick = async () => {
         setIsLoading(true);
 
-        try {
-            const result = await dispatch(
-                checkDeviceAuthenticityThunk({
-                    allowDebugKeys: isDebugModeActive,
-                }),
-            ).unwrap();
+        const result = await dispatch(
+            checkDeviceAuthenticityThunk({ allowDebugKeys: isDebugModeActive }),
+        ).unwrap();
 
-            setIsLoading(false);
+        setIsLoading(false);
 
-            if (
-                typeof result !== 'string' &&
-                result.valid === false &&
-                (result.error !== 'CA_PUBKEY_NOT_FOUND' || !result.configExpired)
-            ) {
-                dispatch(openModal({ type: 'authenticate-device-fail' }));
-            }
-        } catch (error) {
-            console.warn(error);
+        if (result.resolved && !result.valid) {
+            dispatch(openModal({ type: 'authenticate-device-fail' }));
         }
     };
 

--- a/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/AuthenticateDeviceModal.tsx
+++ b/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/AuthenticateDeviceModal.tsx
@@ -1,30 +1,28 @@
 import { useState } from 'react';
-// useDispatch used directly from react-redux instead of src/hooks/suite because we need unwrap() method
-import { useDispatch } from 'react-redux';
 
 import { checkDeviceAuthenticityThunk } from '@suite-common/device-authenticity';
 import { Button } from '@trezor/components';
 
 import { onCancel, openModal } from 'src/actions/suite/modalActions';
 import { DeviceAuthenticationExplainer, Modal, Translation } from 'src/components/suite';
-import { useSelector } from 'src/hooks/suite';
+import { useDispatch, useSelector } from 'src/hooks/suite';
 import { selectIsDebugModeActive } from 'src/reducers/suite/suiteReducer';
+import { selectDeviceAuthenticity } from '@suite-common/wallet-core';
 
 export const AuthenticateDeviceModal = () => {
     const [isLoading, setIsLoading] = useState(false);
     const dispatch = useDispatch();
     const isDebugModeActive = useSelector(selectIsDebugModeActive);
+    const deviceAuthenticity = useSelector(selectDeviceAuthenticity);
 
     const handleClick = async () => {
         setIsLoading(true);
 
-        const result = await dispatch(
-            checkDeviceAuthenticityThunk({ allowDebugKeys: isDebugModeActive }),
-        ).unwrap();
+        await dispatch(checkDeviceAuthenticityThunk({ allowDebugKeys: isDebugModeActive }));
 
         setIsLoading(false);
 
-        if (result.resolved && !result.valid) {
+        if (deviceAuthenticity?.valid === false) {
             dispatch(openModal({ type: 'authenticate-device-fail' }));
         }
     };

--- a/packages/suite/src/middlewares/suite/buttonRequestMiddleware.ts
+++ b/packages/suite/src/middlewares/suite/buttonRequestMiddleware.ts
@@ -6,6 +6,7 @@ import TrezorConnect, { UI } from '@trezor/connect';
 import { SUITE } from 'src/actions/suite/constants';
 import { AppState, Action, Dispatch } from 'src/types/suite';
 import { ONBOARDING } from 'src/actions/onboarding/constants';
+import { checkDeviceAuthenticityThunk } from '@suite-common/device-authenticity';
 
 const buttonRequest =
     (api: MiddlewareAPI<Dispatch, AppState>) =>
@@ -92,7 +93,8 @@ const buttonRequest =
                 }
                 break;
             case ONBOARDING.SET_STEP_ACTIVE:
-                // clear all device's button requests in each step of the onboarding
+            case checkDeviceAuthenticityThunk.fulfilled.type:
+                // clear all device's button requests in each step of the onboarding and after device authenticity check
                 api.dispatch(
                     deviceActions.removeButtonRequests({
                         device: selectDevice(api.getState()) ?? null,

--- a/packages/suite/src/middlewares/suite/sentryMiddleware.ts
+++ b/packages/suite/src/middlewares/suite/sentryMiddleware.ts
@@ -130,11 +130,11 @@ const sentryMiddleware =
                 break;
             }
             case deviceAuthenticityActions.result.type: {
-                if (action.payload.result.valid) return;
+                if (!action.payload.result?.error) return;
 
                 withSentryScope(scope => {
                     scope.setLevel('error');
-                    scope.setTag('deviceAuthenticityError', action.payload.result.error);
+                    scope.setTag('deviceAuthenticityError', action.payload.result?.error);
                     captureSentryMessage(
                         `Device authenticity invalid!
                         ${JSON.stringify(action.payload.result, null, 2)}`,

--- a/packages/suite/src/views/onboarding/steps/SecurityCheck/DeviceAuthenticity.tsx
+++ b/packages/suite/src/views/onboarding/steps/SecurityCheck/DeviceAuthenticity.tsx
@@ -39,6 +39,8 @@ export const DeviceAuthenticity = () => {
     // Tracking request cancellation because it is the only error that does not trigger the fail screen.
     const [isAborted, setIsAborted] = useState(false);
 
+    if (!device) return null;
+
     const isWaitingForConfirmation =
         !!device?.buttonRequests.some(request => request.code === 'ButtonRequest_Other') &&
         !isSubmitted;

--- a/suite-common/device-authenticity/package.json
+++ b/suite-common/device-authenticity/package.json
@@ -14,6 +14,7 @@
         "@reduxjs/toolkit": "1.9.5",
         "@suite-common/redux-utils": "workspace:*",
         "@suite-common/suite-types": "workspace:*",
+        "@suite-common/test-utils": "workspace:*",
         "@suite-common/toast-notifications": "workspace:*",
         "@trezor/connect": "workspace:*"
     },

--- a/suite-common/device-authenticity/src/deviceAuthenticityActions.ts
+++ b/suite-common/device-authenticity/src/deviceAuthenticityActions.ts
@@ -5,9 +5,15 @@ import { AuthenticateDeviceResult } from '@trezor/connect';
 
 export const ACTION_PREFIX = '@device-authenticity';
 
+export type StoredAuthenticateDeviceResult =
+    | (Omit<Partial<AuthenticateDeviceResult>, 'error'> & {
+          error?: string;
+      })
+    | undefined;
+
 const result = createAction(
     `${ACTION_PREFIX}/result`,
-    (payload: { device: TrezorDevice; result: AuthenticateDeviceResult }) => ({
+    (payload: { device: TrezorDevice; result: StoredAuthenticateDeviceResult }) => ({
         payload,
     }),
 );

--- a/suite-common/device-authenticity/src/deviceAuthenticityThunks.ts
+++ b/suite-common/device-authenticity/src/deviceAuthenticityThunks.ts
@@ -1,16 +1,13 @@
-import TrezorConnect from '@trezor/connect';
+import TrezorConnect, { AuthenticateDeviceResult } from '@trezor/connect';
 import { createThunk } from '@suite-common/redux-utils';
-import { notificationsActions } from '@suite-common/toast-notifications';
+import { notificationsActions, ToastPayload } from '@suite-common/toast-notifications';
 
 import { ACTION_PREFIX, deviceAuthenticityActions } from './deviceAuthenticityActions';
 
-export const checkDeviceAuthenticityThunk = createThunk<
-    {
-        allowDebugKeys: boolean;
-        skipSuccessToast?: boolean;
-    },
-    { resolved: boolean; error?: string; valid?: boolean }
->(
+export const checkDeviceAuthenticityThunk = createThunk<{
+    allowDebugKeys: boolean;
+    skipSuccessToast?: boolean;
+}>(
     `${ACTION_PREFIX}/checkDeviceAuthenticity`,
     async ({ allowDebugKeys, skipSuccessToast }, { dispatch, getState, extra }) => {
         const {
@@ -28,45 +25,44 @@ export const checkDeviceAuthenticityThunk = createThunk<
             allowDebugKeys,
         });
 
+        let storedResult:
+            | AuthenticateDeviceResult
+            | { error: string; valid?: boolean }
+            | undefined = result.payload;
+        let toastPayload: ToastPayload | undefined;
+
         if (!result.success) {
-            dispatch(
-                notificationsActions.addToast({
-                    type: 'error',
-                    error: `Unable to validate device: ${result.payload.error}`,
-                }),
-            );
-            if (!device.features?.bootloader_locked) {
-                return {
-                    resolved: true,
-                    valid: false,
-                    error: result.payload.error,
-                };
-            }
-            return { resolved: false };
+            toastPayload = {
+                type: 'error',
+                error: `Unable to validate device: ${result.payload.error}`,
+            };
+            storedResult = device.features?.bootloader_locked
+                ? undefined
+                : {
+                      valid: false,
+                      error: result.payload.error,
+                  };
+        } else if (result.payload.error === 'CA_PUBKEY_NOT_FOUND' && result.payload.configExpired) {
+            // CA_PUBKEY_NOT_FOUND with configExpired is temporarily allowed and just logged to Sentry
+            storedResult = {
+                ...result.payload,
+                valid: true,
+            };
+        } else if (!result.payload.valid) {
+            toastPayload = {
+                type: 'device-authenticity-error',
+                error: `Device is not authentic: ${result.payload.error}`,
+            };
         }
 
-        dispatch(deviceAuthenticityActions.result({ device, result: result.payload }));
-
-        // CA_PUBKEY_NOT_FOUND with configExpired is temporarily allowed and just logged to Sentry
-        const caPubKeyNotFoundInExpiredConfig =
-            result.payload.error === 'CA_PUBKEY_NOT_FOUND' && result.payload.configExpired;
-
-        if (!result.payload.valid && !caPubKeyNotFoundInExpiredConfig) {
-            dispatch(
-                notificationsActions.addToast({
-                    type: 'device-authenticity-error',
-                    error: `Device is not authentic: ${result.payload.error}`,
-                }),
-            );
-            console.warn(result.payload.error);
-        } else if (!skipSuccessToast) {
-            dispatch(notificationsActions.addToast({ type: 'device-authenticity-success' }));
+        if (!skipSuccessToast && storedResult?.valid) {
+            toastPayload = { type: 'device-authenticity-success' };
         }
 
-        return {
-            resolved: true,
-            valid: caPubKeyNotFoundInExpiredConfig ? true : result.payload.valid,
-            error: result.payload.error,
-        };
+        if (toastPayload) {
+            dispatch(notificationsActions.addToast(toastPayload));
+        }
+
+        dispatch(deviceAuthenticityActions.result({ device, result: storedResult }));
     },
 );

--- a/suite-common/device-authenticity/tests/deviceAuthenticityThunks.test.ts
+++ b/suite-common/device-authenticity/tests/deviceAuthenticityThunks.test.ts
@@ -1,0 +1,132 @@
+import { TrezorDevice } from '@suite-common/suite-types';
+import { notificationsActions } from '@suite-common/toast-notifications';
+import { configureMockStore, testMocks } from '@suite-common/test-utils';
+import { AuthenticateDeviceResult, Response as ConnectResponse } from '@trezor/connect';
+
+import { deviceAuthenticityActions } from '../src/deviceAuthenticityActions';
+import { checkDeviceAuthenticityThunk } from '../src/deviceAuthenticityThunks';
+
+jest.mock('@trezor/connect', () => {
+    let fixture: ConnectResponse<AuthenticateDeviceResult>;
+    return {
+        ...jest.requireActual('@trezor/connect'),
+        __esModule: true,
+        default: {
+            authenticateDevice: () => fixture,
+        },
+        setTestFixtures: (f: ConnectResponse<AuthenticateDeviceResult>) => {
+            fixture = f;
+        },
+    };
+});
+
+const initStore = (device?: TrezorDevice) =>
+    configureMockStore({
+        extra: {
+            selectors: {
+                selectDevice: () => device,
+            },
+        },
+    });
+
+const getDevice = (isLocked: boolean) => ({
+    ...testMocks.getSuiteDevice(undefined, { bootloader_locked: isLocked }),
+});
+
+const successResponse = {
+    success: true,
+    payload: {
+        valid: true,
+    },
+};
+const failResponse = {
+    success: false,
+    payload: { error: 'error' },
+};
+const failResult = { valid: false, error: 'error' };
+const deviceWithLockedBootloader = getDevice(true);
+
+const fixtures = [
+    {
+        description: 'Success',
+        device: deviceWithLockedBootloader,
+        connectResponse: successResponse,
+        expectedToastType: 'device-authenticity-success',
+        expectedResult: { valid: true },
+    },
+    {
+        description: 'Success - skip toast',
+        device: deviceWithLockedBootloader,
+        connectResponse: successResponse,
+        expectedResult: { valid: true },
+    },
+    {
+        description: 'Success - despite expired config',
+        device: deviceWithLockedBootloader,
+        connectResponse: {
+            success: true,
+            payload: { valid: false, error: 'CA_PUBKEY_NOT_FOUND', configExpired: true },
+        },
+        expectedToastType: 'device-authenticity-success',
+        expectedResult: { valid: true, error: 'CA_PUBKEY_NOT_FOUND', configExpired: true },
+    },
+    {
+        description: 'Exception - missing device',
+        device: undefined,
+    },
+    {
+        description: 'No result - aborted on device or some other error',
+        device: deviceWithLockedBootloader,
+        connectResponse: failResponse,
+        expectedToastType: 'error',
+        expectedResult: undefined,
+    },
+    {
+        description: 'Fail - bootloader unlocked',
+        device: getDevice(false),
+        connectResponse: failResponse,
+        expectedToastType: 'error',
+        expectedResult: failResult,
+    },
+    {
+        description: 'Fail',
+        device: deviceWithLockedBootloader,
+        connectResponse: {
+            success: true,
+            payload: failResult,
+        },
+        expectedToastType: 'device-authenticity-error',
+        expectedResult: failResult,
+    },
+];
+
+describe('Check device authenticity', () => {
+    fixtures.forEach(f => {
+        it(f.description, async () => {
+            const store = initStore(f.device);
+            // eslint-disable-next-line
+            require('@trezor/connect').setTestFixtures(f.connectResponse);
+            await store.dispatch(
+                checkDeviceAuthenticityThunk({
+                    allowDebugKeys: false,
+                    skipSuccessToast: !f.expectedToastType,
+                }),
+            );
+
+            const actions = store.getActions();
+            const expectedActions = [checkDeviceAuthenticityThunk.pending.type];
+            if (f.expectedToastType) {
+                expectedActions.splice(1, 0, notificationsActions.addToast.type);
+                expect(actions[1].payload.type).toBe(f.expectedToastType);
+            }
+            if (f.device) {
+                expectedActions.push(deviceAuthenticityActions.result.type);
+                expectedActions.push(checkDeviceAuthenticityThunk.fulfilled.type);
+                expect(actions[actions.length - 2].payload.result).toEqual(f.expectedResult);
+            } else {
+                expectedActions.push(checkDeviceAuthenticityThunk.rejected.type);
+            }
+            expect(actions.map(action => action.type)).toEqual(expectedActions);
+        });
+    });
+});

--- a/suite-common/device-authenticity/tsconfig.json
+++ b/suite-common/device-authenticity/tsconfig.json
@@ -4,6 +4,7 @@
     "references": [
         { "path": "../redux-utils" },
         { "path": "../suite-types" },
+        { "path": "../test-utils" },
         { "path": "../toast-notifications" },
         { "path": "../../packages/connect" }
     ]

--- a/suite-common/wallet-core/src/device/deviceReducer.ts
+++ b/suite-common/wallet-core/src/device/deviceReducer.ts
@@ -657,26 +657,6 @@ export const selectSupportedNetworks = (state: DeviceRootState) => {
 export const selectDeviceById = (state: DeviceRootState, deviceId: TrezorDevice['id']) =>
     state.device.devices.find(device => device.id === deviceId);
 
-export const selectDeviceAuthenticity = (state: DeviceRootState, deviceId?: TrezorDevice['id']) =>
-    deviceId ? state.device.deviceAuthenticity?.[deviceId] : undefined;
-
-// Return true if device passed the authenticity check successfully even if CA pubKey was not found but config is expired.
-export const selectIsDeviceAuthenticityFulfilled = (
-    state: DeviceRootState,
-    deviceId?: TrezorDevice['id'],
-) => {
-    const deviceAuthenticity = selectDeviceAuthenticity(state, deviceId);
-
-    if (!deviceAuthenticity) {
-        return undefined;
-    }
-
-    return (
-        deviceAuthenticity.valid ||
-        (deviceAuthenticity.error === 'CA_PUBKEY_NOT_FOUND' && deviceAuthenticity.configExpired) // CA_PUBKEY_NOT_FOUND with configExpired is temporary allowed and just logged to Sentry
-    );
-};
-
 export const selectIsSelectedDeviceImported = (state: DeviceRootState) => {
     const device = selectDevice(state);
     return device?.id === PORTFOLIO_TRACKER_DEVICE_ID;

--- a/suite-common/wallet-core/src/device/deviceReducer.ts
+++ b/suite-common/wallet-core/src/device/deviceReducer.ts
@@ -2,14 +2,17 @@ import { memoize } from 'proxy-memoize';
 
 import * as deviceUtils from '@suite-common/suite-utils';
 import { getStatus } from '@suite-common/suite-utils';
-import { Device, Features, AuthenticateDeviceResult } from '@trezor/connect';
+import { Device, Features } from '@trezor/connect';
 import { DiscoveryStatus } from '@suite-common/wallet-constants';
 import { getFirmwareVersion, getFirmwareVersionArray } from '@trezor/device-utils';
 import { Network, networks } from '@suite-common/wallet-config';
 import { versionUtils } from '@trezor/utils';
 import { createReducerWithExtraDeps } from '@suite-common/redux-utils';
 import { TrezorDevice, AcquiredDevice, ButtonRequest } from '@suite-common/suite-types';
-import { deviceAuthenticityActions } from '@suite-common/device-authenticity';
+import {
+    deviceAuthenticityActions,
+    StoredAuthenticateDeviceResult,
+} from '@suite-common/device-authenticity';
 
 import { deviceActions } from './deviceActions';
 import { DiscoveryRootState, selectDiscoveryByDeviceState } from '../discovery/discoveryReducer';
@@ -18,7 +21,7 @@ import { PORTFOLIO_TRACKER_DEVICE_ID } from './deviceConstants';
 export type State = {
     devices: TrezorDevice[];
     selectedDevice?: TrezorDevice;
-    deviceAuthenticity?: Record<string, AuthenticateDeviceResult>;
+    deviceAuthenticity?: Record<string, StoredAuthenticateDeviceResult>;
 };
 
 const initialState: State = { devices: [], selectedDevice: undefined };
@@ -443,7 +446,7 @@ const addButtonRequest = (
 export const setDeviceAuthenticity = (
     draft: State,
     device: TrezorDevice,
-    result: AuthenticateDeviceResult,
+    result?: StoredAuthenticateDeviceResult,
 ) => {
     if (!device.id) return;
     draft.deviceAuthenticity = {
@@ -656,6 +659,11 @@ export const selectSupportedNetworks = (state: DeviceRootState) => {
 
 export const selectDeviceById = (state: DeviceRootState, deviceId: TrezorDevice['id']) =>
     state.device.devices.find(device => device.id === deviceId);
+
+export const selectDeviceAuthenticity = (state: DeviceRootState) => {
+    const device = selectDevice(state);
+    return device?.id ? state.device.deviceAuthenticity?.[device.id] : undefined;
+};
 
 export const selectIsSelectedDeviceImported = (state: DeviceRootState) => {
     const device = selectDevice(state);

--- a/yarn.lock
+++ b/yarn.lock
@@ -6809,6 +6809,7 @@ __metadata:
     "@reduxjs/toolkit": "npm:1.9.5"
     "@suite-common/redux-utils": "workspace:*"
     "@suite-common/suite-types": "workspace:*"
+    "@suite-common/test-utils": "workspace:*"
     "@suite-common/toast-notifications": "workspace:*"
     "@trezor/connect": "workspace:*"
     jest: "npm:29.5.0"


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->
Without resetting the button requests, one could get to a state where Suite incorrectly expected confirmation on Trezor, see attached videos 1 and 2.

While fixing this, I encountered some other issues such as unnecessary complexity in the components, missing loading state (video 3) and this condition never triggering:

```ts
if (typeof result === 'string' || result.valid === undefined) {
    dispatch(reportToSentry(new Error(`Device authenticity failed: ${result}`)));
    setIsAborted(true);
}
```



## Related Issue

Resolve <!--- link the issue here -->

## Screenshots:
1)
https://github.com/trezor/trezor-suite/assets/42465546/845034c2-95a1-42c1-afa9-bbd06dee46ed

2)
https://github.com/trezor/trezor-suite/assets/42465546/ecd58b2b-72c8-486f-bef8-a1405c75bd33

3)
https://github.com/trezor/trezor-suite/assets/42465546/1c7b645e-cc5b-41b5-b8ca-8d93bf4fc486


I initially refactored `checkDeviceAuthenticityThunk` to always return a value, but changed my mind in the last two commits -  `StoredAuthenticateDeviceResult` is sent to the reducer and the thunk has no return value. This allowed unifying Sentry reporting in one place and removing the need for the `unwrap` method.