### PR TITLE
Feat/connect core in popup

### DIFF
--- a/packages/connect-iframe/package.json
+++ b/packages/connect-iframe/package.json
@@ -6,7 +6,7 @@
         "lint:js": "yarn g:eslint '**/*.{ts,tsx,js}'",
         "build:iframe": "TS_NODE_PROJECT=\"tsconfig.json\" yarn webpack --config ./webpack/prod.webpack.config.ts",
         "build:core-module": "TS_NODE_PROJECT=\"tsconfig.json\" yarn webpack --config ./webpack/core.webpack.config.ts",
-        "build": "rimraf build && yarn build:iframe",
+        "build": "rimraf build && yarn build:iframe && yarn build:core-module",
         "___NOTE__": "iframe build is one of the prerequisites of suite-web. build:lib script provides it together with other libraries",
         "build:lib": "yarn build",
         "type-check": "tsc --build tsconfig.json",

--- a/packages/connect-popup/package.json
+++ b/packages/connect-popup/package.json
@@ -8,7 +8,8 @@
         "lint:styles": "npx stylelint './src/**/*{.ts,.tsx}' --cache --config ../../.stylelintrc",
         "type-check": "tsc --build",
         "dev": "rimraf build && TS_NODE_PROJECT=\"tsconfig.json\" yarn webpack --config ./webpack/dev.webpack.config.ts",
-        "build": "rimraf build && TS_NODE_PROJECT=\"tsconfig.json\" yarn webpack --config ./webpack/prod.webpack.config.ts",
+        "build:popup": "TS_NODE_PROJECT=\"tsconfig.json\" yarn webpack --config ./webpack/prod.webpack.config.ts",
+        "build": "rimraf build && yarn workspace @trezor/connect-popup build:popup",
         "test:e2e": "yarn xvfb-maybe -- playwright test --config=./e2e/playwright.config.ts",
         "test:unit": "jest"
     },
@@ -17,6 +18,7 @@
         "@trezor/connect": "workspace:*",
         "@trezor/connect-analytics": "workspace:*",
         "@trezor/connect-common": "workspace:*",
+        "@trezor/connect-iframe": "workspace:*",
         "@trezor/connect-ui": "workspace:*",
         "@trezor/crypto-utils": "workspace:*",
         "@trezor/device-utils": "workspace:*",

--- a/packages/connect-popup/src/utils/debug.ts
+++ b/packages/connect-popup/src/utils/debug.ts
@@ -1,19 +1,25 @@
-import { LogMessage, LogWriter, initLog } from '@trezor/connect/src/utils/debug';
+import { LogMessage, LogWriter } from '@trezor/connect/src/utils/debug';
+
+let worker: SharedWorker | undefined;
+
+export const logWriterFactory = (): LogWriter => ({
+    add: (message: LogMessage) => {
+        worker?.port.postMessage({ type: 'add-log', data: message });
+    },
+});
 
 export const initSharedLogger = (workerSrc: string) => {
     try {
         if (!SharedWorker) {
             throw new Error('SharedWorker is not supported');
         }
-        const worker = new SharedWorker(workerSrc);
+        worker = new SharedWorker(workerSrc);
         worker.port.start();
-        const logWriter: LogWriter = {
-            add: (message: LogMessage) =>
-                worker.port.postMessage({ type: 'add-log', data: message }),
-        };
-        return initLog('@trezor/connect-popup', false, logWriter);
+        return logWriterFactory();
     } catch (error) {
         console.warn('Failed to initialize LogWorker:', error);
-        return initLog('@trezor/connect-popup');
+        return {
+            add: (_message: LogMessage) => {},
+        };
     }
 };

--- a/packages/connect-popup/src/view/selectDevice.ts
+++ b/packages/connect-popup/src/view/selectDevice.ts
@@ -14,9 +14,7 @@ import { SUITE_BRIDGE_URL, SUITE_UDEV_URL, TREZOR_SUPPORT_URL } from '@trezor/ur
 import { container, getState, showView, postMessage } from './common';
 
 const initWebUsbButton = (showLoader: boolean) => {
-    const { iframe } = getState();
-
-    const usb = iframe ? iframe.navigator.usb : null;
+    const { usb } = window.navigator;
     const webusbContainer = container.getElementsByClassName('webusb')[0] as HTMLElement;
     webusbContainer.style.display = 'flex';
     const button = webusbContainer.getElementsByTagName('button')[0];
@@ -32,16 +30,21 @@ const initWebUsbButton = (showLoader: boolean) => {
             await window.navigator.usb.requestDevice({
                 filters: TREZOR_USB_DESCRIPTORS,
             });
-            const { iframe } = getState();
-            if (!iframe) {
+
+            const { iframe, core } = getState();
+
+            if (iframe) {
+                iframe.postMessage({
+                    event: UI_EVENT,
+                    type: TRANSPORT.REQUEST_DEVICE,
+                });
+                if (showLoader) {
+                    showView('loader');
+                }
+            } else if (core) {
+                core.enumerate();
+            } else {
                 throw ERRORS.TypedError('Popup_ConnectionMissing');
-            }
-            iframe.postMessage({
-                event: UI_EVENT,
-                type: TRANSPORT.REQUEST_DEVICE,
-            });
-            if (showLoader) {
-                showView('loader');
             }
         } catch (error) {
             // empty, do nothing, should not happen anyway

--- a/packages/connect-popup/tsconfig.json
+++ b/packages/connect-popup/tsconfig.json
@@ -10,6 +10,7 @@
         { "path": "../connect" },
         { "path": "../connect-analytics" },
         { "path": "../connect-common" },
+        { "path": "../connect-iframe" },
         { "path": "../connect-ui" },
         { "path": "../crypto-utils" },
         { "path": "../device-utils" },

--- a/packages/connect-popup/webpack/prod.webpack.config.ts
+++ b/packages/connect-popup/webpack/prod.webpack.config.ts
@@ -113,6 +113,10 @@ const config: webpack.Configuration = {
                     from: path.join(__dirname, '../../suite-data/files/images/png/trezor-*'),
                     to: `${DIST}/images/[name][ext]`,
                 },
+                {
+                    from: path.join(__dirname, '../../connect-iframe/build'),
+                    to: `${DIST}`,
+                },
             ],
         }),
     ],
@@ -128,6 +132,9 @@ const config: webpack.Configuration = {
                 },
             }),
         ],
+    },
+    externals: {
+        'js/core': 'js/core',
     },
 };
 

--- a/packages/connect-ui/src/types.ts
+++ b/packages/connect-ui/src/types.ts
@@ -1,10 +1,12 @@
 import { PopupHandshake, PopupMethodInfo, IFrameLoaded } from '@trezor/connect';
+import type { Core } from '@trezor/connect/lib/core';
 
 export type State = Partial<PopupHandshake['payload']> &
     Partial<PopupMethodInfo['payload']> &
     Partial<IFrameLoaded['payload']> & {
         iframe?: Window;
         broadcast?: BroadcastChannel;
+        core?: Core;
         // preferred device will appear here
     };
 

--- a/packages/connect-ui/src/views/Error.tsx
+++ b/packages/connect-ui/src/views/Error.tsx
@@ -17,7 +17,9 @@ export interface ErrorViewProps {
     detail: // errors that might arise when using connect-ui with connect-popup
     | 'response-event-error' // Error coming from connect RESPONSE_EVENT
         | 'handshake-timeout' // communication was not established in a set time period
-        | 'iframe-failure'; // another (legacy) error, this is sent from popupManager (host) to popup. it means basically the same like handshake-timeout but we might be notified earlier
+        | 'iframe-failure' // another (legacy) error, this is sent from popupManager (host) to popup. it means basically the same like handshake-timeout but we might be notified earlier
+        | 'core-missing' // core was loaded correctly but became unavailable later
+        | 'core-failed-to-load'; // dynamic import of core failed
     // future errors when using connect-ui in different contexts
     message?: string;
 }
@@ -143,6 +145,16 @@ const getTroubleshootingTips = (props: ErrorViewProps) => {
             title: 'Action not completed',
             detail: {
                 steps: [<Step>{props.message}</Step>],
+            },
+        });
+    }
+
+    if (['core-missing', 'core-failed-to-load'].includes(props.detail)) {
+        tips.push({
+            icon: 'QUESTION',
+            title: 'Tried to access connect core which is not loaded yet',
+            detail: {
+                steps: [<Step>Try again or contact developers</Step>],
             },
         });
     }

--- a/packages/connect/src/core/index.ts
+++ b/packages/connect/src/core/index.ts
@@ -1021,6 +1021,13 @@ export class Core extends EventEmitter {
         }
         return _deviceList.getTransportInfo();
     }
+
+    enumerate() {
+        if (!_deviceList) {
+            return;
+        }
+        _deviceList.enumerate();
+    }
 }
 
 /**

--- a/packages/connect/src/events/popup.ts
+++ b/packages/connect/src/events/popup.ts
@@ -8,6 +8,9 @@ export const POPUP = {
     BOOTSTRAP: 'popup-bootstrap',
     // Message from popup.js to window.opener, called after "window.onload" event. This is second message from popup to window.opener.
     LOADED: 'popup-loaded',
+    // Message from popup run in "core" mode. Connect core has been loaded, popup is ready to handle messages
+    // This is similar to IFRAME.LOADED message which signals the same but core is loaded in different context
+    CORE_LOADED: 'popup-core-loaded',
     // Message from window.opener to popup.js. Send settings to popup. This is first message from window.opener to popup.
     INIT: 'popup-init',
     // Error message from popup to window.opener. Could be thrown during popup initialization process (POPUP.INIT)
@@ -28,6 +31,8 @@ export const POPUP = {
     CLOSE_WINDOW: 'window.close',
     // todo: shouldn't it be UI_RESPONSE?
     ANALYTICS_RESPONSE: 'popup-analytics-response',
+    /** webextension injected content script and content script notified popup */
+    CONTENT_SCRIPT_LOADED: 'popup-content-script-loaded',
     /** method.info async getter result passed from core to popup */
     METHOD_INFO: 'popup-method-info',
 } as const;
@@ -38,6 +43,7 @@ export interface PopupInit {
         settings: ConnectSettings; // settings from window.opener (sent by @trezor/connect-web)
         useBroadcastChannel: boolean;
         systemInfo: SystemInfo;
+        useCore?: boolean;
     };
 }
 
@@ -71,9 +77,14 @@ export interface PopupMethodInfo {
     payload: { info: string; method: string };
 }
 
+export interface PopupContentScriptLoaded {
+    type: typeof POPUP.CONTENT_SCRIPT_LOADED;
+    payload: { id: string };
+}
+
 export type PopupEvent =
     | {
-          type: typeof POPUP.LOADED | typeof POPUP.CANCEL_POPUP_REQUEST;
+          type: typeof POPUP.LOADED | typeof POPUP.CORE_LOADED | typeof POPUP.CANCEL_POPUP_REQUEST;
           payload?: typeof undefined;
       }
     | PopupInit
@@ -81,6 +92,7 @@ export type PopupEvent =
     | PopupError
     | PopupClosedMessage
     | PopupAnalyticsResponse
+    | PopupContentScriptLoaded
     | PopupMethodInfo;
 
 export type PopupEventMessage = PopupEvent & { event: typeof UI_EVENT };

--- a/yarn.lock
+++ b/yarn.lock
@@ -8778,7 +8778,7 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@trezor/connect-iframe@workspace:packages/connect-iframe":
+"@trezor/connect-iframe@workspace:*, @trezor/connect-iframe@workspace:packages/connect-iframe":
   version: 0.0.0-use.local
   resolution: "@trezor/connect-iframe@workspace:packages/connect-iframe"
   dependencies:
@@ -8841,6 +8841,7 @@ __metadata:
     "@trezor/connect": "workspace:*"
     "@trezor/connect-analytics": "workspace:*"
     "@trezor/connect-common": "workspace:*"
+    "@trezor/connect-iframe": "workspace:*"
     "@trezor/connect-ui": "workspace:*"
     "@trezor/crypto-utils": "workspace:*"
     "@trezor/device-utils": "workspace:*"


### PR DESCRIPTION
part of #9525 

builds on top of #9896 

this PR loads connect-core in popup. this will be useful for:
- support of env where iframe can't be loaded (service worker)
- support for webusb transport

### Commits:
- [de7789f](https://github.com/trezor/trezor-suite/pull/9914/commits/de7789fd996c5ee869a392fbf0cc7bc28ddea433) Ignore, this has its own PR in #9896 
- [4578f31](https://github.com/trezor/trezor-suite/pull/9914/commits/4578f315e1bac1db9db98e232c881eb0400fdf02) - new events for connect-webextension (#9525), they are not sent yet but popup already knows them
- [7e06e91](https://github.com/trezor/trezor-suite/pull/9914/commits/7e06e91e27ad5c2081096a8cdc228fd1410dcad0) - this is basically the same thing  `TRANSPORT.REQUEST_DEVICE` message does when communication goes through popup
- [3f002e2](https://github.com/trezor/trezor-suite/pull/9914/commits/3f002e2e30dccc009fb2a74ebd0ebee3017364cd) - this commit implements connect core in popup