### PR TITLE
Fix/finalize solana backend urls

### DIFF
--- a/packages/blockchain-link/src/workers/solana/index.ts
+++ b/packages/blockchain-link/src/workers/solana/index.ts
@@ -171,7 +171,7 @@ const getAccountInfo = async (request: Request<MessageTypes.GetAccountInfo>) => 
 
     const pageNumber = payload.page ? payload.page - 1 : 0;
     // for the first page of txs, payload.page is undefined, for the second page is 2
-    const pageSize = payload.pageSize || 2;
+    const pageSize = payload.pageSize || 25;
 
     const pageStartIndex = pageNumber * pageSize;
     const pageEndIndex = Math.min(pageStartIndex + pageSize, allTxIds.length);

--- a/packages/connect-common/files/coins.json
+++ b/packages/connect-common/files/coins.json
@@ -2201,9 +2201,7 @@
         {
             "blockchain_link": {
                 "type": "solana",
-                "url": [
-                    "wiser-green-owl.solana-mainnet.quiknode.pro/c218d0c9e451f6c5c0bf8b7c7d8e5a72384c9570/"
-                ]
+                "url": ["solana.trezor.io"]
             },
             "curve": "ed25519",
             "decimals": 9,
@@ -2362,9 +2360,7 @@
         {
             "blockchain_link": {
                 "type": "solana",
-                "url": [
-                    "billowing-orbital-model.solana-devnet.quiknode.pro/3fee3e6bd1d751aca4afa5f494925c8643c88f42/"
-                ]
+                "url": ["solana-dev.trezor.io"]
             },
             "curve": "ed25519",
             "decimals": 9,

--- a/suite-common/suite-config/src/settings.ts
+++ b/suite-common/suite-config/src/settings.ts
@@ -1,5 +1,5 @@
 export const settingsCommonConfig = {
     MAX_ACCOUNTS: 10,
     FRESH_ADDRESS_LIMIT: 20,
-    TXS_PER_PAGE: 2,
+    TXS_PER_PAGE: 25,
 } as const;


### PR DESCRIPTION
Put final solana backend urls into coins.json. Revert previous changes that made the page size smaller so free quicknode plan could handle it