### PR TITLE
fix(ci): make container for local test to be latest

### DIFF
--- a/docker/docker-compose.connect-popup-test.yml
+++ b/docker/docker-compose.connect-popup-test.yml
@@ -18,7 +18,7 @@ services:
     network_mode: service:trezor-user-env-unix
 
   test-run:
-    image: mcr.microsoft.com/playwright:v1.35.1-focal
+    image: mcr.microsoft.com/playwright:latest
     container_name: explorer-test-runner
     depends_on:
       - trezor-user-env-unix


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Make local container for connect-popup tests use `latest` playwright, otherwise with a fix version it gives error when there is an update.
Still it is better than fetching playwright every-time we run a test locally with `npx playwright....` since we only need to locally update the container when there is a new version.