### PR TITLE
feat(coinmarket): RBF in exchange

### DIFF
--- a/packages/suite/src/hooks/suite/__fixtures__/useCountdownTimer.ts
+++ b/packages/suite/src/hooks/suite/__fixtures__/useCountdownTimer.ts
@@ -1,0 +1,32 @@
+export const fixtures = [
+    {
+        desc: 'last second finished',
+        duration: 1000,
+        expected: {
+            isPastDeadline: true,
+            duration: {
+                years: 0,
+                months: 0,
+                days: 0,
+                hours: 0,
+                minutes: 0,
+                seconds: 0,
+            },
+        },
+    },
+    {
+        desc: '90 seconds unfinished',
+        duration: 1000 * 90,
+        expected: {
+            isPastDeadline: false,
+            duration: {
+                years: 0,
+                months: 0,
+                days: 0,
+                hours: 0,
+                minutes: 1,
+                seconds: 29,
+            },
+        },
+    },
+];

--- a/packages/suite/src/hooks/suite/__tests__/useCountdownTimer.test.tsx
+++ b/packages/suite/src/hooks/suite/__tests__/useCountdownTimer.test.tsx
@@ -1,0 +1,41 @@
+import { act, render } from '@testing-library/react';
+import { fixtures } from 'src/hooks/suite/__fixtures__/useCountdownTimer';
+import { useCountdownTimer } from 'src/hooks/suite/useCountdownTimer';
+
+type Result = ReturnType<typeof useCountdownTimer>;
+
+const Component = ({
+    params,
+    callback,
+}: {
+    params: Parameters<typeof useCountdownTimer>;
+    callback: (res: Result) => void;
+}) => {
+    const result = useCountdownTimer(...params);
+    callback(result);
+    return null;
+};
+
+describe('useCountdownTimer', () => {
+    fixtures.forEach(({ desc, duration, expected }) => {
+        it(desc, () => {
+            jest.useFakeTimers();
+
+            let result: Result = {
+                duration: {},
+                isPastDeadline: false,
+            };
+
+            const { unmount } = render(
+                <Component params={[Date.now() + duration]} callback={res => (result = res)} />,
+            );
+
+            act(() => {
+                jest.advanceTimersToNextTimer(1000); // wait 1 second
+            });
+
+            expect(result).toEqual(expected);
+            unmount();
+        });
+    });
+});

--- a/packages/suite/src/hooks/wallet/useCoinmarketExchangeOffers.ts
+++ b/packages/suite/src/hooks/wallet/useCoinmarketExchangeOffers.ts
@@ -23,7 +23,7 @@ import { useCoinmarketNavigation } from 'src/hooks/wallet/useCoinmarketNavigatio
 import { InvityAPIReloadQuotesAfterSeconds } from 'src/constants/wallet/coinmarket/metadata';
 import { useBitcoinAmountUnit } from 'src/hooks/wallet/useBitcoinAmountUnit';
 
-import { useCoinmarketRecomposeAndSign } from './useCoinmarketRecomposeAndSign ';
+import { useCoinmarketRecomposeAndSign } from './useCoinmarketRecomposeAndSign';
 
 const getReceiveAccountSymbol = (
     symbol?: string,
@@ -309,6 +309,10 @@ export const useOffers = ({ selectedAccount }: UseCoinmarketExchangeFormProps) =
                 selectedQuote.sendAddress,
                 sendStringAmount,
                 selectedQuote.partnerPaymentExtraId,
+                undefined,
+                undefined,
+                undefined,
+                ['broadcast', 'bitcoinRBF'],
             );
             // in case of not success, recomposeAndSign shows notification
             if (result?.success) {

--- a/packages/suite/src/hooks/wallet/useCoinmarketRecomposeAndSign.ts
+++ b/packages/suite/src/hooks/wallet/useCoinmarketRecomposeAndSign.ts
@@ -5,7 +5,7 @@ import { notificationsActions } from '@suite-common/toast-notifications';
 import { DEFAULT_VALUES, DEFAULT_PAYMENT } from '@suite-common/wallet-constants';
 import { FormState, UseSendFormState } from 'src/types/wallet/sendForm';
 import { getFeeLevels } from '@suite-common/wallet-utils';
-import type { SelectedAccountLoaded } from '@suite-common/wallet-types';
+import type { FormOptions, SelectedAccountLoaded } from '@suite-common/wallet-types';
 
 export const useCoinmarketRecomposeAndSign = () => {
     const { translationString } = useTranslation();
@@ -24,6 +24,7 @@ export const useCoinmarketRecomposeAndSign = () => {
             ethereumDataHex?: string,
             recalcCustomLimit?: boolean,
             ethereumAdjustGasLimit?: string,
+            options: FormOptions[] = ['broadcast'],
         ) => {
             const { account, network } = selectedAccount;
 
@@ -52,7 +53,7 @@ export const useCoinmarketRecomposeAndSign = () => {
                 feePerUnit: composed.feePerByte,
                 feeLimit: composed.feeLimit || '',
                 estimatedFeeLimit: composed.estimatedFeeLimit,
-                options: ['broadcast'],
+                options,
                 rippleDestinationTag: destinationTag,
                 ethereumDataHex,
                 ethereumAdjustGasLimit,

--- a/packages/suite/src/hooks/wallet/useCoinmarketSellOffers.ts
+++ b/packages/suite/src/hooks/wallet/useCoinmarketSellOffers.ts
@@ -28,7 +28,7 @@ import { getUnusedAddressFromAccount } from 'src/utils/wallet/coinmarket/coinmar
 import type { TradeSell } from 'src/types/wallet/coinmarketCommonTypes';
 import { useBitcoinAmountUnit } from 'src/hooks/wallet/useBitcoinAmountUnit';
 
-import { useCoinmarketRecomposeAndSign } from './useCoinmarketRecomposeAndSign ';
+import { useCoinmarketRecomposeAndSign } from './useCoinmarketRecomposeAndSign';
 
 export const useOffers = ({ selectedAccount }: UseOffersProps) => {
     const timer = useTimer();


### PR DESCRIPTION
## Description

Let’s send all Exchange transactions with RBF on. User will be able to bump the tx fee in Suite account.
(For sell we’re unable to allow this since the Sell providers require txid which changes after the fees are updated)

## Related Issue

Resolve #9938

## Screenshots:
![image](https://github.com/trezor/trezor-suite/assets/12121074/1fee93f0-4dd8-4337-b6e0-ad5e21619bdb)

